### PR TITLE
Use AliDataFile for large files

### DIFF
--- a/PWGLF/FORWARD/analysis2/AliCentralCorrectionManager.cxx
+++ b/PWGLF/FORWARD/analysis2/AliCentralCorrectionManager.cxx
@@ -6,6 +6,7 @@
 #include "AliCentralCorrAcceptance.h"
 #include "AliForwardUtil.h"
 #include "AliOADBForward.h"
+#include "AliDataFile.h"
 #include <TString.h>
 #include <AliLog.h>
 #include <TFile.h>
@@ -21,7 +22,6 @@ AliCentralCorrectionManager* AliCentralCorrectionManager::fgInstance= 0;
 const char* AliCentralCorrectionManager::fgkSecondaryMapSkel = "secondary";
 const char* AliCentralCorrectionManager::fgkAcceptanceSkel   = "acceptance";
 
-#define PREFIX  "$(ALICE_PHYSICS)/OADB/PWGLF/FORWARD/CORRECTIONS/data/"
 #define DB_NAME "spd_corrections.root"
 
 //____________________________________________________________________
@@ -55,10 +55,10 @@ AliCentralCorrectionManager::AliCentralCorrectionManager(Bool_t d)
   //    Not used
   //
   RegisterCorrection(kIdSecondaryMap, fgkSecondaryMapSkel, 
-		     PREFIX DB_NAME, AliCentralCorrSecondaryMap::Class(), 
+		     AliDataFile::GetFileNameOADB("PWGLF/FORWARD/CORRECTIONS/data/" DB_NAME).c_str(), AliCentralCorrSecondaryMap::Class(), 
 		     kStandard|kSatellite);
   RegisterCorrection(kIdAcceptance, fgkAcceptanceSkel, 
-		     PREFIX DB_NAME, AliCentralCorrAcceptance::Class(),
+		     AliDataFile::GetFileNameOADB("PWGLF/FORWARD/CORRECTIONS/data/" DB_NAME).c_str(), AliCentralCorrAcceptance::Class(),
 		     kStandard|kSatellite);
 }
 //____________________________________________________________________
@@ -133,7 +133,7 @@ AliCentralCorrectionManager::Append(const TString& addition,
 {
   TString dest(destination);
   if (dest.IsNull()) 
-    dest = PREFIX DB_NAME;
+    dest = AliDataFile::GetFileNameOADB("PWGLF/FORWARD/CORRECTIONS/data/" DB_NAME).c_str();
   return AliCorrectionManagerBase::Append(addition, dest);
 }
 

--- a/PWGLF/FORWARD/analysis2/AliForwardCorrectionManager.cxx
+++ b/PWGLF/FORWARD/analysis2/AliForwardCorrectionManager.cxx
@@ -11,6 +11,7 @@
 #include "AliFMDCorrNoiseGain.h"
 #include "AliForwardUtil.h"
 #include "AliOADBForward.h"
+#include "AliDataFile.h"
 #include <TString.h>
 #include <AliLog.h>
 #include <TFile.h>
@@ -31,7 +32,6 @@ const char* AliForwardCorrectionManager::fgkMergingEffSkel   = "merging";
 const char* AliForwardCorrectionManager::fgkAcceptanceSkel   = "acceptance";
 const char* AliForwardCorrectionManager::fgkNoiseGainSkel    = "noisegain";
 
-#define PREFIX  "$(ALICE_PHYSICS)/OADB/PWGLF/FORWARD/CORRECTIONS/data/"
 #define DB_NAME "fmd_corrections.root"
 
 //____________________________________________________________________
@@ -65,25 +65,25 @@ AliForwardCorrectionManager::AliForwardCorrectionManager(Bool_t d)
   //    Not used
   //
   RegisterCorrection(kIdSecondaryMap, fgkSecondaryMapSkel, 
-		     PREFIX DB_NAME, AliFMDCorrSecondaryMap::Class(), 
+		     AliDataFile::GetFileNameOADB("PWGLF/FORWARD/CORRECTIONS/data/" DB_NAME).c_str(), AliFMDCorrSecondaryMap::Class(), 
 		     kStandard|kSatellite);
   RegisterCorrection(kIdELossFits, fgkELossFitsSkel, 
-		     PREFIX DB_NAME, AliFMDCorrELossFit::Class(), 
+		     AliDataFile::GetFileNameOADB("PWGLF/FORWARD/CORRECTIONS/data/" DB_NAME).c_str(), AliFMDCorrELossFit::Class(), 
 		     kRun|kSys|kSNN|kSatellite|kMC /*kFull*/);
   RegisterCorrection(kIdVertexBias, fgkVertexBiasSkel, 
-		     PREFIX DB_NAME, AliFMDCorrVertexBias::Class(), 
+		     AliDataFile::GetFileNameOADB("PWGLF/FORWARD/CORRECTIONS/data/" DB_NAME).c_str(), AliFMDCorrVertexBias::Class(), 
 		     kStandard|kSatellite);
   RegisterCorrection(kIdMergingEfficiency, fgkMergingEffSkel, 
-		     PREFIX DB_NAME, AliFMDCorrMergingEfficiency::Class(), 
+		     AliDataFile::GetFileNameOADB("PWGLF/FORWARD/CORRECTIONS/data/" DB_NAME).c_str(), AliFMDCorrMergingEfficiency::Class(), 
 		     kStandard|kSatellite);
   RegisterCorrection(kIdDoubleHit, fgkDoubleHitSkel, 
-		     PREFIX DB_NAME, AliFMDCorrDoubleHit::Class(),
+		     AliDataFile::GetFileNameOADB("PWGLF/FORWARD/CORRECTIONS/data/" DB_NAME).c_str(), AliFMDCorrDoubleHit::Class(),
 		     kStandard|kMC);
   RegisterCorrection(kIdAcceptance, fgkAcceptanceSkel, 
-		     PREFIX DB_NAME, AliFMDCorrAcceptance::Class(),
+		     AliDataFile::GetFileNameOADB("PWGLF/FORWARD/CORRECTIONS/data/" DB_NAME).c_str(), AliFMDCorrAcceptance::Class(),
 		     kRun|kSys|kSNN|kSatellite);
   RegisterCorrection(kIdNoiseGain, fgkNoiseGainSkel,
-		     PREFIX DB_NAME, AliFMDCorrNoiseGain::Class(), kRun);
+		     AliDataFile::GetFileNameOADB("PWGLF/FORWARD/CORRECTIONS/data/" DB_NAME).c_str(), AliFMDCorrNoiseGain::Class(), kRun);
 }
 //____________________________________________________________________
 Bool_t
@@ -199,7 +199,7 @@ AliForwardCorrectionManager::Append(const TString& addition,
 {
   TString dest(destination);
   if (dest.IsNull()) 
-    dest = PREFIX DB_NAME;
+    dest = AliDataFile::GetFileNameOADB("OADB/PWGLF/FORWARD/CORRECTIONS/data/" DB_NAME).c_str();
   return AliCorrectionManagerBase::Append(addition, dest);
 }
 

--- a/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrectionsInterface/AliAnalysisTaskFlowVectorCorrections.cxx
+++ b/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrectionsInterface/AliAnalysisTaskFlowVectorCorrections.cxx
@@ -24,6 +24,7 @@ Instructions in AddTask_EPcorrectionsExample.C
 #include "AliQnCorrectionsManager.h"
 #include "AliQnCorrectionsHistos.h"
 #include "AliLog.h"
+#include "AliDataFile.h"
 
 #include "AliAnalysisTaskFlowVectorCorrections.h"
 
@@ -203,7 +204,7 @@ void AliAnalysisTaskFlowVectorCorrections::UserCreateOutputObjects()
     break;
   case CALIBSRC_OADBsingle:
     if (fCalibrationFile.Length() != 0) {
-      calibfile = TFile::Open(Form("%s/COMMON/EVENTPLANE/framework_v2_data/%s", AliAnalysisManager::GetOADBPath(),fCalibrationFile.Data()));
+      calibfile = AliDataFile::OpenOADB(TString::Format("COMMON/EVENTPLANE/framework_v2_data/%s", fCalibrationFile.Data()).Data());
     }
     if (calibfile != NULL && calibfile->IsOpen()) {
       AliInfo(Form("\t Calibration file %s open", fCalibrationFile.Data()));


### PR DESCRIPTION
use for the following large files:
- spd_corrections.root
  used in PWGLF/FORWARD/analysis2/AliCentralCorrectionManager.cxx
- fmd_corrections.root
  used in PWGLF/FORWARD/analysis2/AliForwardCorrectionManager.cxx
- event plane calibration (framework_v2)
  used in PWGPP/EVCHAR/FlowVectorCorrections/QnCorrectionsInterface/AliAnalysisTaskFlowVectorCorrections.cxx