### PR TITLE
Added AOD filterbit information to AliReducedBaseTrack

### DIFF
--- a/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
+++ b/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
@@ -1060,6 +1060,7 @@ void AliAnalysisTaskReducedTreeMaker::FillTrackInfo()
    if(isAOD) {
       for(Int_t idx=0; idx<3; ++idx) if(aodTrack->GetKinkIndex(idx)>0) reducedParticle->fQualityFlags |= (ULong_t(1)<<(5+idx));
       for(Int_t idx=0; idx<3; ++idx) if(aodTrack->GetKinkIndex(idx)<0) reducedParticle->fQualityFlags |= (ULong_t(1)<<(12+idx));
+      for(Int_t idx=0; idx<11; ++idx) if(aodTrack->TestFilterBit(BIT(idx))) reducedParticle->SetQualityFlag(15+idx);
    }
    
    // If we want to write only AliReducedBaseTrack objects, then we stop here

--- a/PWGDQ/reducedTree/AliReducedBaseTrack.h
+++ b/PWGDQ/reducedTree/AliReducedBaseTrack.h
@@ -87,6 +87,8 @@ class AliReducedBaseTrack : public TObject {
                                                    // BIT12 toggled if the track has kink0 index < 0
                                                    // BIT13 toggled if the track has kink1 index < 0
                                                    // BIT14 toggled if the track has kink2 index < 0
+                                                   // AOD
+                                                   // BIT(15+i) toggled if track has filter bit 0+i , 0 <= i <= 10
                                                    // BAYES TPC(||TOF)
                                                    // BIT15 toggled if electron (prob>0.5)
                                                    // BIT16 toggled if pion (prob>0.5)


### PR DESCRIPTION
Added AOD filterbit information to `AliReducedBaseTrack::fQualityFlags` starting at BIT(15).
AOD filter bit 0 corresponds to 15
AOD filter bit 10 corresponds to 25

