### PR TITLE
fix cluster id assignment

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.cxx
@@ -513,7 +513,7 @@ void AliEmcalCorrectionClusterizer::RecPoints2Clusters(TClonesArray *clus)
     c->SetNCells(ncellsTrue);
     c->SetCellsAbsId(absIds);
     c->SetCellsAmplitudeFraction(ratios);
-    c->SetID(recpoint->GetUniqueID());
+    c->SetID(nout-1);
     c->SetDispersion(recpoint->GetDispersion());
     c->SetEmcCpvDistance(-1);
     c->SetChi2(-1);


### PR DESCRIPTION
A difference was identified between "tender" clusterizer and new correction framework clusterizer (based on ClusterizeFast): the centralized clusterizer seems to set cluster ID always to 0 -- this commit fixes it, setting the ID as done in the tender.