### PR TITLE
Custom unique particle ID based on label property

### DIFF
--- a/PWGCF/Correlations/DPhi/AliAnalysisTaskPhiCorrelations.cxx
+++ b/PWGCF/Correlations/DPhi/AliAnalysisTaskPhiCorrelations.cxx
@@ -1992,8 +1992,11 @@ TObjArray* AliAnalysisTaskPhiCorrelations::GetParticlesFromDetector(AliVEvent* i
       // Set custom ID. Should be the same if custom particle A and B are the same
       if(fCustomParticlesA == fCustomParticlesB)
         particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + iParticle) * 10 + 6);
-      else
-        particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + iParticle) * 10 + idet);
+      else  // Set custom ID based on event counter & custom particle label
+      {
+        // Setting the label of the custom particle allows a user-defined labeling
+        particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + customParticle->GetLabel()) * 10 + 6);
+      }
 
       obj->Add(particle);
     }


### PR DESCRIPTION
This commit allows the user to forbid/allow certain correlations when giving custom particles A/B. Before, the mixing is done wrong in certain situations (self correlations could occur).
