### PR TITLE
TPC PID studies and Mult Update

### DIFF
--- a/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.cxx
@@ -2008,15 +2008,15 @@ void AliAnalysisTaskHFEpACorrelation::ElectronHadronCorrelation(AliVTrack *track
     fNonHFE->SetHistDCABack(fDCABack);
     fNonHFE->SetHistDCA(fDCA);
     
-    //"SetHistMassBack" sets the ULS histogram in the invariant mass
-    //"SetHistMassk" sets the LS histogram in the invariant mass
+    //"SetHistMassBack" sets the LS histogram in the invariant mass
+    //"SetHistMass" sets the ULS histogram in the invariant mass
     
     for (Int_t pTbin = 0; pTbin < fpTBins.GetSize()-1; pTbin++ )
     {
         if(fPtE>=fpTBins.At(pTbin) && fPtE<fpTBins.At(pTbin+1))
         {
-            fNonHFE->SetHistMassBack(fInvMassULS[pTbin]);
-            fNonHFE->SetHistMass(fInvMassLS[pTbin]);
+            fNonHFE->SetHistMass(fInvMassULS[pTbin]);
+            fNonHFE->SetHistMassBack(fInvMassLS[pTbin]);
         }
     }
     

--- a/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.cxx
@@ -916,7 +916,7 @@ void AliAnalysisTaskHFEpACorrelation::UserCreateOutputObjects()
     
     //Inv Mass in pT Bins
     fInvMassULS = new TH1F *[fpTBins.GetSize()];
-    fInvMssLS = new TH1F *[fpTBins.GetSize()];
+    fInvMassLS = new TH1F *[fpTBins.GetSize()];
     
     for (Int_t i = 0 ; i < fpTBins.GetSize()-1 ; i++)
     {
@@ -1946,7 +1946,24 @@ void AliAnalysisTaskHFEpACorrelation::ElectronHadronCorrelation(AliVTrack *track
     Bool_t lIsNHFe = kFALSE;
     Bool_t lIsHFe = kFALSE;
     Bool_t lIsOther = kFALSE;
-    Bool_t lHasMother = kFALSE;;
+    Bool_t lHasMother = kFALSE;
+    
+    //Electron Information
+    Double_t fPhiE = -999;
+    Double_t fEtaE = -999;
+    Double_t fPhiH = -999;
+    Double_t fEtaH = -999;
+    Double_t fDphi = -999;
+    Double_t fDeta = -999;
+    Double_t fPtE = -999;
+    Double_t fPtH = -999;
+    
+    Double_t pi = TMath::Pi();
+    
+    fPhiE = track->Phi();
+    fEtaE = track->Eta();
+    fPtE = track->Pt();
+    
     
     ///_________________________________________________________________
     
@@ -2012,21 +2029,7 @@ void AliAnalysisTaskHFEpACorrelation::ElectronHadronCorrelation(AliVTrack *track
     ///#################################################################
     
     
-    //Electron Information
-    Double_t fPhiE = -999;
-    Double_t fEtaE = -999;
-    Double_t fPhiH = -999;
-    Double_t fEtaH = -999;
-    Double_t fDphi = -999;
-    Double_t fDeta = -999;
-    Double_t fPtE = -999;
-    Double_t fPtH = -999;
-    
-    Double_t pi = TMath::Pi();
-    
-    fPhiE = track->Phi();
-    fEtaE = track->Eta();
-    fPtE = track->Pt();
+
     
     
     if(fIsMC)

--- a/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.cxx
@@ -734,7 +734,7 @@ void AliAnalysisTaskHFEpACorrelation::UserCreateOutputObjects()
     
     for(Int_t i = 0; i < 3; i++)
     {
-        fTPC_p[i] = new TH2F(Form("fTPC_p%d",i),";pt (GeV/c);TPC dE/dx (a. u.)",1000,0.3,15,1000,-20,200);
+        fTPC_p[i] = new TH2F(Form("fTPC_p%d",i),";p (GeV/c);TPC dE/dx (a. u.)",1000,0.3,15,1000,-20,200);
         fTPCnsigma_p[i] = new TH2F(Form("fTPCnsigma_p%d",i),";p (GeV/c);TPC Electron N#sigma",1000,0.3,15,1000,-15,10);
         
         fOutputList->Add(fTPC_p[i]);
@@ -1684,7 +1684,7 @@ void AliAnalysisTaskHFEpACorrelation::UserExec(Option_t *)
         fTPC_momentum->Fill(fP,fTPCsignal);
         fTPC_eta->Fill(EtaTrig,fTPCsignal);
         
-        fTPC_p[0]->Fill(fPt,fTPCsignal);
+        fTPC_p[0]->Fill(fP,fTPCsignal);
         fTPCnsigma_p[0]->Fill(fP,fTPCnSigma);
         Float_t TPCNcls = track->GetTPCNcls();
         //TPC Ncls for pid
@@ -1772,7 +1772,7 @@ void AliAnalysisTaskHFEpACorrelation::UserExec(Option_t *)
         if(!ProcessCutStep(AliHFEcuts::kStepHFEcutsTPC, track)) continue;
         
         fEtad[1]->Fill(EtaTrig);
-        fTPC_p[1]->Fill(fPt,fTPCsignal);
+        fTPC_p[1]->Fill(fP,fTPCsignal);
         fTPCnsigma_p[1]->Fill(fP,fTPCnSigma);
         TPCNcls = track->GetTPCNcls();
         
@@ -1810,6 +1810,13 @@ void AliAnalysisTaskHFEpACorrelation::UserExec(Option_t *)
             DiHadronCorrelation(track, iTracks);
         }
         
+        //Add TOF-Only PID cuts to study contamination as function of p
+        if (TMath::Abs(fTOFnSigma) <= 3)
+        {
+            fTPC_p[2]->Fill(fP,fTPCsignal);
+            fTPCnsigma_p[2]->Fill(fP,fTPCnSigma);
+        }
+            
         
         ///________________________________________________________________________
         ///PID
@@ -1860,8 +1867,6 @@ void AliAnalysisTaskHFEpACorrelation::UserExec(Option_t *)
         fDCAElectronZ[0]->Fill(DCAz);
         
         fEtad[2]->Fill(EtaTrig);
-        fTPC_p[2]->Fill(fPt,fTPCsignal);
-        fTPCnsigma_p[2]->Fill(fP,fTPCnSigma);
         
         if(track->Pt()< fMinpTElec || track->Pt() > fMaxpTElec) continue;
         

--- a/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.cxx
@@ -1401,7 +1401,7 @@ void AliAnalysisTaskHFEpACorrelation::UserExec(Option_t *)
                 }
                 else
                 {
-                    if (fEstimator==1)
+                    if (fEstimator==0)
                     {
                         fCentralityValue =  MultSelection->GetMultiplicityPercentile("ZNA");
                     }
@@ -1416,7 +1416,7 @@ void AliAnalysisTaskHFEpACorrelation::UserExec(Option_t *)
             {
                 //Run 1 centrality
                 fCentrality = ((AliAODHeader*)fAOD->GetHeader())->GetCentralityP();
-                if(fEstimator==1)
+                if(fEstimator==0)
                     fCentralityValue = fCentrality->GetCentralityPercentile("ZNA");
                 else
                     fCentralityValue = fCentrality->GetCentralityPercentile("V0A");

--- a/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.h
+++ b/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.h
@@ -258,8 +258,8 @@ private:
     TH2F				**fCEtaPhi_ULS_NoP_Weight; //!
     TH2F				**fCEtaPhi_LS_NoP_Weight; //!
     
-    TH1F				*fInvMass; //!
-    TH1F				*fInvMassBack; //!
+    TH1F				**fInvMassULS; //!
+    TH1F				**fInvMassLS; //!
     TH1F				*fDCA; //!
     TH1F				*fDCABack; //!
     TH1F				*fOpAngle; //!

--- a/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.h
+++ b/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.h
@@ -434,7 +434,7 @@ private:
     AliAnalysisTaskHFEpACorrelation(const AliAnalysisTaskHFEpACorrelation&); 			// not implemented
     AliAnalysisTaskHFEpACorrelation& operator=(const AliAnalysisTaskHFEpACorrelation&); 		// not implemented
     
-    ClassDef(AliAnalysisTaskHFEpACorrelation, 1); 								// example of analysis
+    ClassDef(AliAnalysisTaskHFEpACorrelation, 2); 								// example of analysis
     //______________________________________________________________________
 };
 

--- a/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.h
+++ b/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.h
@@ -114,7 +114,7 @@ public:
     
     void SetUseAlternativeBinning() {fUseAlternativeBinnig = kTRUE;};
     
-    void SetCentralityEstimator(Int_t Estimator) { fEstimator=Estimator; }; //0 = V0A, 1 = Other
+    void SetCentralityEstimator(Int_t Estimator) { fEstimator=Estimator; }; //0 = ZNA, 1 = V0A
     void SetAdditionalCuts(Double_t PtMinAsso, Int_t TpcNclsAsso) {fPtMinAsso = PtMinAsso; fTpcNclsAsso = TpcNclsAsso;};
     void SetSPDCutForHadrons() {fAssocWithSPD = kTRUE;};
     

--- a/PWGHF/hfe/macros/AddTaskHFEpACorrelation.C
+++ b/PWGHF/hfe/macros/AddTaskHFEpACorrelation.C
@@ -24,6 +24,7 @@ AliAnalysisTaskHFEpACorrelation *AddTaskHFEpACorrelation(
                                                          Int_t TPCNClusterPartner = 60,
                                                          Int_t TPCNClusterPID = 80,
                                                          Bool_t UseGlobalTracksForHadrons = kTRUE,
+                                                         Int_t CentralityEstimator = 0,
                                                          TString HadronEfficiencyFile = "alien:///alice/cern.ch/user/h/hzanoli/Efficiency/Hadron_Tracking.root"
                                                          )
 {
@@ -44,9 +45,9 @@ AliAnalysisTaskHFEpACorrelation *AddTaskHFEpACorrelation(
     
     gROOT->LoadMacro("$ALICE_PHYSICS/PWGHF/hfe/macros/configs/pPb/ConfigHFEpACorrelation.C");
     TString taskName = "HFe_h";
-    taskName.Append(Form("%d_%d_%d_%d_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%d_%d_%d_%d_%d_%d",pTBin, Correlation, ispp, isMC,   ElectronDCAxy,ElectronDCAz,HadronDCAxy,HadronDCAz,TPCPIDLow,TPCPIDUp,InvariantMassCut,pTCutPartner, MultiplicityLow, MultiplicityUp, HadronPtCutLow, HadronPtCutUp, EtaCutLow, EtaCutUp, NonHFEangleCut, NHitsITS, SPDLayers, TPCNCluster, TPCNClusterPartner, TPCNClusterPID,UseGlobalTracksForHadrons));
+    taskName.Append(Form("%d_%d_%d_%d_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%1.2f_%d_%d_%d_%d_%d_%d_%d",pTBin, Correlation, ispp, isMC,   ElectronDCAxy,ElectronDCAz,HadronDCAxy,HadronDCAz,TPCPIDLow,TPCPIDUp,InvariantMassCut,pTCutPartner, MultiplicityLow, MultiplicityUp, HadronPtCutLow, HadronPtCutUp, EtaCutLow, EtaCutUp, NonHFEangleCut, NHitsITS, SPDLayers, TPCNCluster, TPCNClusterPartner, TPCNClusterPID,UseGlobalTracksForHadrons,CentralityEstimator));
     
-    AliAnalysisTaskHFEpACorrelation *task = ConfigHFEpACorrelation(taskName, Correlation, ispp, isMC,   ElectronDCAxy,ElectronDCAz,HadronDCAxy,HadronDCAz,TPCPIDLow,TPCPIDUp,InvariantMassCut,pTCutPartner, MultiplicityLow, MultiplicityUp, HadronPtCutLow, HadronPtCutUp, EtaCutLow, EtaCutUp, NonHFEangleCut, NHitsITS, SPDLayers, TPCNCluster, TPCNClusterPartner, TPCNClusterPID,UseGlobalTracksForHadrons);
+    AliAnalysisTaskHFEpACorrelation *task = ConfigHFEpACorrelation(taskName, Correlation, ispp, isMC,   ElectronDCAxy,ElectronDCAz,HadronDCAxy,HadronDCAz,TPCPIDLow,TPCPIDUp,InvariantMassCut,pTCutPartner, MultiplicityLow, MultiplicityUp, HadronPtCutLow, HadronPtCutUp, EtaCutLow, EtaCutUp, NonHFEangleCut, NHitsITS, SPDLayers, TPCNCluster, TPCNClusterPartner, TPCNClusterPID,UseGlobalTracksForHadrons,CentralityEstimator);
     
     //_______________________
     //Trigger

--- a/PWGHF/hfe/macros/configs/pPb/ConfigHFEpACorrelation.C
+++ b/PWGHF/hfe/macros/configs/pPb/ConfigHFEpACorrelation.C
@@ -15,6 +15,10 @@
  TPC PID Cluster = TPCNClusterPID (obvius)
  TPCNSigma = TPCNClusterPID (obvius)
  
+CentralityEstimator 
+0 = ZNA (Standard)
+1 = VOA (used before)
+
  
  */
 
@@ -42,7 +46,8 @@ AliAnalysisTaskHFEpACorrelation* ConfigHFEpACorrelation(TString taskName = "HFe_
                                                         Int_t TPCNCluster = 100,
                                                         Int_t TPCNClusterPartner = 60,
                                                         Int_t TPCNClusterPID = 80,
-                                                        Bool_t UseGlobalTracksForHadrons = kTRUE)
+                                                        Bool_t UseGlobalTracksForHadrons = kTRUE,
+                                                        Int_t CentralityEstimator = 0)
 {
     
     
@@ -147,6 +152,9 @@ AliAnalysisTaskHFEpACorrelation* ConfigHFEpACorrelation(TString taskName = "HFe_
     
     task->SetCentrality(MultiplicityLow,MultiplicityUp);
     printf("MinMultiplicity = %1.2f MaxMultiplicy = %1.2f\n", MultiplicityLow,MultiplicityUp);
+    
+    task->SetCentralityEstimator(CentralityEstimator);
+    printf("Centrality estimator = %d",CentralityEstimator);
     
     
     ///_______________________________________________________________________________________________________________


### PR DESCRIPTION
Hi,

I added the histograms to check the TPC Splines as function of momentum (p), the invariant mass plots as function of pT bins and changed the default multiplicity to use the ZNA. It is still possible to use V0A in case it is needed. 