### PR TITLE
Fix for memory usage for Rsn analysis task + new Rsn QA config

### DIFF
--- a/PWGLF/RESONANCES/AliRsnMiniEvent.h
+++ b/PWGLF/RESONANCES/AliRsnMiniEvent.h
@@ -57,10 +57,10 @@ private:
 
    Int_t         fLeading;    // index of leading particle
    TClonesArray  fParticles;  // list of selected particles
-   AliVEvent    *fRef;      //  pointer to input event
-   AliVEvent    *fRefMC;    //  pointer to reference MC event (if any)
+   AliVEvent    *fRef;        //!  pointer to input event
+   AliVEvent    *fRefMC;      //!  pointer to reference MC event (if any)
 
-   ClassDef(AliRsnMiniEvent, 7)
+   ClassDef(AliRsnMiniEvent, 8)
 };
 
 #endif

--- a/PWGLF/RESONANCES/macros/mini/qa/AddTaskRsnQA.C
+++ b/PWGLF/RESONANCES/macros/mini/qa/AddTaskRsnQA.C
@@ -1,0 +1,171 @@
+/***************************************************************************
+// Created on 22.03.2017 by
+// Francesca Bellini f(bellini@cern.ch) - Sourav Kundu (sourav.kundu@cern.ch)
+//
+//Lauches Phi analysis with rsn mini package for QA
+//Allows basic configuration of pile-up check and event cuts
+//
+****************************************************************************/
+enum pairYCutSet { kYcentral = 0, 
+		   kYpPb5TeV,
+		   // kYpPb8TeV,
+		   // kYPbp5TeV,
+		   // kYPbp8TeV,
+		   kYcentralTight
+                 };
+
+enum eventCutSet { kEvtDefault = 0,
+		   kMCEvtDefault,
+		   kPileUpCut
+                 };
+
+AliRsnMiniAnalysisTask * AddTaskRsnQA
+(
+ Bool_t      isMC = kFALSE,
+ Bool_t      isPP = kFALSE,
+ UInt_t      triggerMask = AliVEvent::kINT7,
+ TString     outNameSuffix = "phiQA",
+ Int_t       evtCutSetID = 0,  //0 for data, 1 for MC, 2 for data with pile-up rejection
+ Int_t       pairCutSetID = 0, //selects on pair rapidity: 0 for symmetric system, 1 for p-Pb 5 TeV, 2 for p-Pb 8 TeV
+ Int_t       aodFilterBit = 5, //filter bit 5 corresponds to StdITSTPCtrackCuts2011 with TPC crossed rows
+ Bool_t      enableMonitor = kTRUE,
+ TString     monitorOpt = "NoSIGN")
+{  
+  //-------------------------------------------
+  // event cuts
+  //-------------------------------------------
+  if (evtCutSetID == eventCutSet::kPileUpCut)
+    rejectPileUp = kTRUE;
+  else
+    rejectPileUp = kFALSE;
+  
+  //-------------------------------------------
+  //pair cuts
+  //-------------------------------------------
+  Double_t    minYlab =  -0.5;
+  Double_t    maxYlab =  0.5;
+
+  if (pairCutSetID==pairYCutSet::kYpPb5TeV) {
+    //-0.5 < y_cm < 0.0
+    minYlab = -0.465;    maxYlab = 0.035;
+  }
+  
+  // if (pairCutSetID==pairYCutSet::kYpPb8TeV) {
+  //   //to be calculated
+  //   minYlab = -0.9;    maxYlab = 0.9;
+  // }
+  
+  // if (pairCutSetID==pairYCutSet::kYPbp5TeV) { 
+  //   //to be calculated
+  //   minYlab = -0.9;    maxYlab = 0.9;
+  // }
+
+  // if (pairCutSetID==pairYCutSet::kYPbp5TeV) { 
+  //   //to be calculated
+  //   minYlab = -0.765;    maxYlab = -0.165;
+  // }
+  
+  if (pairCutSetID==pairYCutSet::kYcentralTight) {
+    //|y_cm| < 0.3
+    minYlab = -0.3;    maxYlab = 0.3;
+  }
+
+  //-------------------------------------------
+  //mixing settings
+  //-------------------------------------------
+  Int_t       nmix = 5;
+  Float_t     maxDiffVzMix = 1.0;
+  Float_t     maxDiffMultMix = 5.0;
+
+  //
+  // -- INITIALIZATION ----------------------------------------------------------------------------
+  // retrieve analysis manager
+  //
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+   if (!mgr) {
+      ::Error("AddAnalysisTaskTOFKStar", "No analysis manager to connect to.");
+      return NULL;
+   } 
+
+   // create the task and configure 
+   TString taskName = Form("taskRsnQA");
+   AliRsnMiniAnalysisTask *task = new AliRsnMiniAnalysisTask(taskName.Data(), kTRUE);
+
+   //Set trigger selection
+   task->UseESDTriggerMask(triggerMask);
+   //task->SelectCollisionCandidate(triggerMask);
+
+   //Set multiplicity/centrality estimator
+   if (isPP) 
+     task->UseMultiplicity("AliMultSelection_V0M");
+   else
+     task->UseCentrality("V0M");
+   
+   //Set event mixing options
+   task->UseContinuousMix();
+   task->SetNMix(nmix);
+   task->SetMaxDiffVz(maxDiffVzMix);
+   task->SetMaxDiffMult(maxDiffMultMix);
+   ::Info("AddTaskRsnQA", Form("Event mixing configuration: \n events to mix = %i \n max diff. vtxZ = cm %5.3f \n max diff multi = %5.3f", nmix, maxDiffVzMix, maxDiffMultMix));
+
+   //Add task
+   mgr->AddTask(task);
+   
+   //
+   // -- EVENT CUTS (same for all configs) ---------------------------------------------------------
+   //
+   AliRsnCutPrimaryVertex *cutVertex = new AliRsnCutPrimaryVertex("cutVertex", 10.0, 0, kFALSE); //cut on z_vtx < 10 cm
+   AliRsnCutEventUtils* cutEventUtils=new AliRsnCutEventUtils("cutEventUtils", kTRUE, rejectPileUp);
+   cutEventUtils->SetCheckAcceptedMultSelection();
+   AliRsnCutSet *eventCuts = new AliRsnCutSet("eventCuts", AliRsnTarget::kEvent);
+   eventCuts->AddCut(cutEventUtils);
+   eventCuts->AddCut(cutVertex);
+   eventCuts->SetCutScheme(Form("%s&%s", cutEventUtils->GetName(), cutVertex->GetName()));
+   task->SetEventCuts(eventCuts);
+   
+   //
+   // -- EVENT-ONLY COMPUTATIONS -------------------------------------------------------------------
+   //   
+   //vertex
+   Int_t vtxID = task->CreateValue(AliRsnMiniValue::kVz, kFALSE);
+   //multiplicity or centrality
+   Int_t multID = task->CreateValue(AliRsnMiniValue::kMult, kFALSE);
+
+   AliRsnMiniOutput *outVtx = task->CreateOutput("eventVtx", "HIST", "EVENT");
+   outVtx->AddAxis(vtxID, 220, -11.0, 11.0);
+
+   AliRsnMiniOutput *outMult = task->CreateOutput("eventMult", "HIST", "EVENT");
+   outMult->AddAxis(multID, 101, 0.0, 101.0); //also in pp, p-Pb the percentile is returned
+   
+   TH2F* hvz = new TH2F("hVzVsCent",Form("Vertex position vs centrality"), 101, 0., 101., 220, -11.0, 11.0);
+   hvz->GetXaxis()->SetTitle("multiplicity %");
+   hvz->GetYaxis()->SetTitle("z_{vtx} (cm)");
+   task->SetEventQAHist("vz", hvz);
+
+   // -- PAIR CUTS (common to all resonances) ------------------------------------------------------
+   AliRsnCutMiniPair *cutY = new AliRsnCutMiniPair("cutRapidity", AliRsnCutMiniPair::kRapidityRange);
+   cutY->SetRangeD(minYlab, maxYlab);
+   
+   AliRsnCutSet *cutsPair = new AliRsnCutSet("pairCuts", AliRsnTarget::kMother);
+   cutsPair->AddCut(cutY);
+   cutsPair->SetCutScheme(cutY->GetName());
+   
+   //
+   // -- CONFIG ANALYSIS --------------------------------------------------------------------------
+   //
+   gROOT->LoadMacro("$ALICE_PHYSICS/PWGLF/RESONANCES/macros/mini/qa/ConfigRsnQA.C");
+   if (!ConfigRsnQA(task, isMC, isPP, cutsPair, aodFilterBit, enableMonitor, "NoSIGN") ) return 0x0;
+   
+   // -- CONTAINERS --------------------------------------------------------------------------------
+   TString outputFileName = AliAnalysisManager::GetCommonFileName();
+   Printf("AddTaskRsnQA - Set OutputFileName : \n %s\n", outputFileName.Data() );
+   AliAnalysisDataContainer *output = mgr->CreateContainer(Form("RsnQA_%s",outNameSuffix.Data()), 
+							   TList::Class(), 
+							   AliAnalysisManager::kOutputContainer, 
+							   outputFileName);
+   mgr->ConnectInput(task, 0, mgr->GetCommonInputContainer());
+   mgr->ConnectOutput(task, 1, output);
+   
+   return task;
+}
+

--- a/PWGLF/RESONANCES/macros/mini/qa/ConfigRsnQA.C
+++ b/PWGLF/RESONANCES/macros/mini/qa/ConfigRsnQA.C
@@ -1,0 +1,124 @@
+/***************************************************************************
+// Created on 22.03.2017 by
+// Francesca Bellini f(bellini@cern.ch)
+// Sourav Kundu (sourav.kundu@cern.ch)
+//
+// Configures Phi analysis with rsn mini package for QA
+// Allows basic configuration of pile-up check and event cuts
+//
+****************************************************************************/
+
+Bool_t ConfigRsnQA(AliRsnMiniAnalysisTask *task, 
+		   Bool_t                 isMC, 
+		   Bool_t                 isPP,
+		   AliRsnCutSet           *cutsPair,
+		   Int_t                  aodFilterBit = 5,
+		   Bool_t                 enableMonitor = kTRUE,
+		   TString                monitorOpt = "NoSIGN")
+{
+  //Configure phi
+  TString    partname = "kPhi";
+  Int_t      pdgCode  = 333;
+  Float_t    mass     = 1.019461;
+  Float_t    masslow  = 0.980;
+  Float_t    massup   = 1.200;
+  Int_t      nbins    = 220;
+  RSNPID     d1 = AliRsnDaughter::kKaon;
+  RSNPID     d2 = AliRsnDaughter::kKaon;
+
+  // -- Values ------------------------------------------------------------------------------------
+  AliRsnMiniValue::EType yaxisVar = AliRsnMiniValue::kPt;
+  /* invariant mass   */ Int_t imID   = task->CreateValue(AliRsnMiniValue::kInvMass, kFALSE);
+  /* IM resolution    */ Int_t resID  = task->CreateValue(AliRsnMiniValue::kInvMassRes, kTRUE);
+  /* transv. momentum */ Int_t ptID   = task->CreateValue(AliRsnMiniValue::kPt, kFALSE);
+  /* centrality       */ Int_t centID = task->CreateValue(AliRsnMiniValue::kMult, kFALSE);
+  /* pseudorapidity   */ Int_t etaID  = task->CreateValue(AliRsnMiniValue::kEta, kFALSE);
+  /* rapidity         */ Int_t yID    = task->CreateValue(AliRsnMiniValue::kY, kFALSE);
+
+  // set daughter cuts
+  //use default quality cuts std 2011 with crossed rows TPC  
+  Bool_t useCrossedRows = 1; Float_t nsigma = 3.0;
+  AliRsnCutSetDaughterParticle * cutSetKa = new AliRsnCutSetDaughterParticle("cutKa", AliRsnCutSetDaughterParticle::kFastTPCpidNsigma, AliPID::kKaon, nsigma, aodFilterBit, useCrossedRows);
+  cutSetKa->SetUse2011StdQualityCuts(kTRUE);
+  
+  if (enableMonitor){
+    Printf("======== Cut monitoring enabled");
+    gROOT->LoadMacro("$ALICE_PHYSICS/PWGLF/RESONANCES/macros/mini/AddMonitorOutput.C");
+    AddMonitorOutput(isMC, cutSetKa->GetMonitorOutput()), monitorOpt.Data();
+  }
+  
+  Int_t iCutKa = task->AddTrackCuts(cutSetKa);
+
+ // -- Create all needed outputs -----------------------------------------------------------------
+  // use an array for more compact writing, which are different on mixing and charges
+  // [0] = unlike
+  // [1] = mixing
+
+  Bool_t  use    [6] = { 1      , 1      , 1      , 1      , isMC   , isMC};
+  Bool_t  useIM  [6] = { 1      , 1      , 1      , 1      , 1      , 0};
+  TString name   [6] = {"Unlike","Mixing","LikePP","LikeMM","Trues" ,"Res"};
+  TString comp   [6] = {"PAIR"  , "MIX"  ,"PAIR"  ,"PAIR"  ,"TRUE"  ,"TRUE"};
+  Char_t  charge1[6] = {'+'     , '+'    ,'+'     ,'-'     , '+'    , '+'};
+  Char_t  charge2[6] = {'-'     , '-'    ,'+'     ,'-'     , '-'    , '-'};
+  TString output = "SPARSE";
+
+  for(Int_t i=0;i<6;i++){
+    if(!use[i]) continue;
+
+    AliRsnMiniOutput* out = task->CreateOutput(Form("phi_%s",name[i].Data()),output.Data(),comp[i].Data());
+    out->SetCutID(0,iCutKa);
+    out->SetCutID(1,iCutKa);
+    out->SetDaughter(0, d1);
+    out->SetDaughter(1, d2);
+    out->SetCharge(0,charge1[i]);
+    out->SetCharge(1,charge2[i]);
+    out->SetMotherPDG(pdgCode);
+    out->SetMotherMass(mass);
+    out->SetPairCuts(cutsPair);
+    //axis X: invmass (or resolution)
+    if(useIM[i]) out->AddAxis(imID,nbins, masslow, massup);
+    else out->AddAxis(resID, 200, -0.02, 0.02);
+    //axis Y: transverse momentum of pair as default 
+    out->AddAxis(ptID, 200, 0., 20.);
+    // axis Z: centrality-multiplicity
+    out->AddAxis(centID, 100, 0., 100.);
+  }
+
+  //GENERATED PAIRS
+  AliRsnMiniOutput * outm = task->CreateOutput("phi_mother", output.Data(),"MOTHER");
+  outm->SetDaughter(0, d1);
+  outm->SetDaughter(1, d2);
+  outm->SetMotherPDG(pdgCode);
+  outm->SetMotherMass(mass);
+  outm->SetPairCuts(cutsPair);
+  outm->AddAxis(imID, nbins, masslow, massup);
+  outm->AddAxis(ptID, 200, 0.0, 20.0);
+  outm->AddAxis(centID, 100, 0.0, 100.0);
+
+  return kTRUE;
+
+}
+
+  // if (enableMonitor){
+  //   Printf("======== Cut monitoring enabled");
+  //   gROOT->LoadMacro("$ALICE_PHYSICS/PWGLF/RESONANCES/macros/mini/AddMonitorOutput.C");
+  //   AddMonitorOutput(isMC, cutSetKa->GetMonitorOutput()), monitorOpt.Data();
+  //   AddMonitorOutput(isMC, cutSetPi->GetMonitorOutput(), monitorOpt.Data());
+  //   AddMonitorOutput(isMC, cutSetPro->GetMonitorOutput()), monitorOpt.Data();
+  //}  
+
+   /* Aditional cuts for pion and proton candidates
+     AliRsnCutSetDaughterParticle * cutSetPi = new AliRsnCutSetDaughterParticle("cutPi", AliRsnCutSetDaughterParticle::kQualityStd2011, AliPID::kPion, nsigma, aodFilterBit, useCrossedRows);
+     Int_t icutPi = task->AddTrackCuts(cutSetPi);
+    
+     AliRsnCutSetDaughterParticle * cutSetPro = new AliRsnCutSetDaughterParticle("cutPro", AliRsnCutSetDaughterParticle::kQualityStd2011, AliPID::kProton, nsigma, aodFilterBit, useCrossedRows);
+     Int_t icutPro = task->AddTrackCuts(cutSetPro);
+
+     if (d1==AliRsnDaughter::kProton) icut2 = icutPro;
+     else if (d1==AliRsnDaughter::kKaon) icut2 = icutKa;
+     else icut1 = icutPi;
+
+     if (d2==AliRsnDaughter::kProton) icut2 = icutPro;
+     else if (d2==AliRsnDaughter::kKaon) icut2 = icutKa;
+     else icut2 = icutPi;
+   */


### PR DESCRIPTION
Two changes for the Resonance package:
1) make pointers to event object transient members by using "//!", which should fix runtime memory problems in LEGO trains of the Resonances analysis task;
2) a new config and AddTask are created for the new Rsn analysisQA.
