### PR TITLE
Implememt functions setting track cuts variation

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliEmcalAnalysisFactory.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliEmcalAnalysisFactory.cxx
@@ -12,6 +12,7 @@
  * about the suitability of this software for any purpose. It is          *
  * provided "as is" without express or implied warranty.                  *
  **************************************************************************/
+#include <cstring>
 #include <functional>
 #include <iostream>
 #include <vector>
@@ -37,6 +38,12 @@ AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cut, B
   if(!aod){
     std::vector<AliVCuts *> trackcuts;
     if(cut.Contains("standard")){
+      AliESDtrackCuts *esdcuts = GenerateDefaultCutsESD();
+      esdcuts->SetName("standardRAA");
+      esdcuts->SetTitle("Standard Track cuts");
+      trackcuts.push_back(esdcuts);
+    }
+    if(cut.Contains("standardcrossedrows")){
       AliESDtrackCuts *esdcuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(true, 1);
       esdcuts->DefineHistograms(kRed);
       esdcuts->SetName("standardRAA");
@@ -46,80 +53,141 @@ AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cut, B
       trackcuts.push_back(esdcuts);
     }
     if(cut.Contains("hybrid")){
-      AliESDtrackCuts *esdcuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(kFALSE);
+      AliESDtrackCuts *esdcuts = GenerateLooseDCACutsESD();
       esdcuts->SetTitle("hybridglobal");
       esdcuts->SetTitle("Global Hybrid tracks, loose DCA");
-      esdcuts->SetMaxDCAToVertexXY(2.4);
-      esdcuts->SetMaxDCAToVertexZ(3.2);
-      esdcuts->SetDCAToVertex2D(kTRUE);
-      esdcuts->SetMaxChi2TPCConstrainedGlobal(36);
-      esdcuts->SetMaxFractionSharedTPCClusters(0.4);
       trackcuts.push_back(esdcuts);
     }
-    if(cut.Contains("ITSchi2")){
-      // Definition: ITSchi2XXXX
-      // - 3 Digits before . (to be filled with 0)
-      // - 1 Digit after .
-      int strmin = cut.Index("ITSchi2") + 7;
-      int cutvalue = TString(cut(strmin , strmin+4)).Atoi();
-      float itscut = static_cast<float>(cutvalue)/10.;
-
+    ////////////////////////////////////////////////////////////////
+    /// Systematics cuts                                         ///
+    ///   These cuts are based on the default cuts varying       ///
+    ///   each time one cut separately                           ///
+    ////////////////////////////////////////////////////////////////
+    if(cut.Contains("VarITSchi2")){
+      double cutvalue = ValueDecoder(cut, "VarITSchi2");
+      AliESDtrackCuts *esdcuts = GenerateDefaultCutsESD();
+      esdcuts->SetName(TString::Format("VarITSchi2Cut%04d", static_cast<int>(cutvalue * 10.)));
+      esdcuts->SetTitle(TString::Format("Default cuts - variation ITS chi2 cut at %f", cutvalue));
+      esdcuts->SetMaxChi2PerClusterITS(cutvalue);
+      trackcuts.push_back(esdcuts);
+    }
+    if(cut.Contains("VarTPCchi2")){
+      double cutvalue = ValueDecoder(cut, "VarTPCchi2");
+      AliESDtrackCuts *esdcuts = GenerateDefaultCutsESD();
+      esdcuts->SetName(TString::Format("VarTPCchi2Cut%04d", static_cast<int>(cutvalue * 10.)));
+      esdcuts->SetTitle(TString::Format("Default cuts - variation TPC chi2 cut at %f", cutvalue));
+      esdcuts->SetMaxChi2PerClusterTPC(cutvalue);
+      trackcuts.push_back(esdcuts);
+    }
+    if(cut.Contains("VarTPCchi2Constrained")){
+      double cutvalue = ValueDecoder(cut, "VarTPCchi2Constrained"); // in number of sigmas
+      AliESDtrackCuts *esdcuts = GenerateDefaultCutsESD();
+      esdcuts->SetName(TString::Format("VarTPCchi2ConstrainedCut%04d", static_cast<int>(cutvalue * 10.)));
+      esdcuts->SetTitle(TString::Format("Default cuts - variation TPC chi2 constrained cut at %f", cutvalue));
+      esdcuts->SetMaxChi2TPCConstrainedGlobal(cutvalue);
+      trackcuts.push_back(esdcuts);
+    }
+    if(cut.Contains("VarDCAz")){
+      double cutvalue = ValueDecoder(cut, "VarDCAz");
+      AliESDtrackCuts *esdcuts = GenerateDefaultCutsESD();
+      esdcuts->SetName(TString::Format("VarDCAzCut%04d", static_cast<int>(cutvalue * 10.)));
+      esdcuts->SetTitle(TString::Format("Default cuts - variation DCAz cut at %f", cutvalue));
+      esdcuts->SetMaxDCAToVertexZ(cutvalue);
+      trackcuts.push_back(esdcuts);
+    }
+    if(cut.Contains("VarDCAr")){
+      double cutvalue = ValueDecoder(cut, "VarDCAr");
+      double p1 = cutvalue * 0.0026, p2 = cutvalue * 0.005;
+      AliESDtrackCuts *esdcuts = GenerateDefaultCutsESD();
+      esdcuts->SetName(TString::Format("VarDCArCut%04d", static_cast<int>(cutvalue * 10.)));
+      esdcuts->SetTitle(TString::Format("Default cuts - variation DCAr cut at %f sigma", cutvalue));
+      esdcuts->SetMaxDCAToVertexXYPtDep(TString::Format("%f + %f/pt^1.01", p1, p2));
+      trackcuts.push_back(esdcuts);
+    }
+    if(cut.Contains("VarRatioCrossedRowsFindable")){
+      double cutvalue = ValueDecoder(cut, "VarRatioCrossedRowsFindable");
+      AliESDtrackCuts *esdcuts = GenerateDefaultCutsESD();
+      esdcuts->SetName(TString::Format("VarRatioCRFindableCut%04d", static_cast<int>(cutvalue * 10.)));
+      esdcuts->SetTitle(TString::Format("Default cuts - variation ratio crossed rows over findable cut at %f", cutvalue));
+      esdcuts->SetMinRatioCrossedRowsOverFindableClustersTPC(cutvalue);
+      trackcuts.push_back(esdcuts);
+    }
+    if(cut.Contains("VarFractionTPCshared")){
+      double cutvalue = ValueDecoder(cut, "VarFractionTPCshared");
+      AliESDtrackCuts *esdcuts = GenerateDefaultCutsESD();
+      esdcuts->SetName(TString::Format("VarFractionTPCShared%04d", static_cast<int>(cutvalue * 10.)));
+      esdcuts->SetTitle(TString::Format("Default cuts - variation fraction TPC shared clusters %f", cutvalue));
+      esdcuts->SetMaxFractionSharedTPCClusters(cutvalue);
+      trackcuts.push_back(esdcuts);
+    }
+    if(cut.Contains("VarTrackLengthDeadArea")){
+      double cutvalue = ValueDecoder(cut, "VarTrackLengthDeadArea");
+      AliESDtrackCuts *esdcuts = GenerateDefaultCutsESD();
+      esdcuts->SetName(TString::Format("VarTLDeadAreaCut%04d", static_cast<int>(cutvalue * 10.)));
+      esdcuts->SetTitle(TString::Format("Default cuts - variation track length dead area cut at %f", cutvalue));
+      esdcuts->SetCutGeoNcrNcl(cutvalue, 130., 1.5, 0.0, 0.0);
+      trackcuts.push_back(esdcuts);
+    }
+    if(cut.Contains("VarTrackLengthTPCLength")){
+      double cutvalue = ValueDecoder(cut, "VarTrackLengthTPCLength");
+      AliESDtrackCuts *esdcuts = GenerateDefaultCutsESD();
+      esdcuts->SetName(TString::Format("VarTLTPCLengthCut%04d", static_cast<int>(cutvalue * 10.)));
+      esdcuts->SetTitle(TString::Format("Default cuts - variation track length TPC length cut at %f", cutvalue));
+      esdcuts->SetCutGeoNcrNcl(3., cutvalue, 1.5, 0.0, 0.0);
+      trackcuts.push_back(esdcuts);
+    }
+    if(cut.Contains("VarSPDhit")){
+      double cutvalue = ValueDecoder(cut, "VarSPDhit");
+      AliESDtrackCuts *esdcuts = GenerateDefaultCutsESD();
+      if(cutvalue > 0){
+        esdcuts->SetName("VarSPDhitOn");
+        esdcuts->SetTitle("Default cuts - variation SPD hit requirement on");
+      } else {
+        esdcuts->SetName("VarSPDhitOff");
+        esdcuts->SetTitle("Default cuts - variation SPD hit requirement off");
+        esdcuts->SetClusterRequirementITS(AliESDtrackCuts::kSPD, AliESDtrackCuts::kOff);
+      }
+      trackcuts.push_back(esdcuts);
+    }
+    ////////////////////////////////////////////////////////////////
+    /// Test cuts - for tracking studies                         ///
+    ///   Cuts are based on loose cuts. Those which are entangled///
+    ///   are loosened furthermore                               ///
+    ////////////////////////////////////////////////////////////////
+    if(cut.Contains("TestITSchi2")){
+      double itscut = ValueDecoder(cut, "TestITSchi2");
       std::cout << "Using ITS chi2 cut variation: " << itscut << std::endl;
 
-      AliESDtrackCuts *esdcuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(false, 1);
-      esdcuts->DefineHistograms(kRed);
-      esdcuts->SetName(Form("VarITSchi2%d", int(itscut*10.)));
+      AliESDtrackCuts *esdcuts = GenerateLooseDCACutsESD();
+      esdcuts->SetName(Form("TestITSchi2%d", int(itscut*10.)));
       esdcuts->SetTitle(Form("Loose track cuts, ITS chi2 var %.1f", itscut));
-      esdcuts->SetMinNCrossedRowsTPC(120);
-      esdcuts->SetMaxDCAToVertexXY(2.4);
-      esdcuts->SetMaxDCAToVertexZ(3.2);
-      esdcuts->SetDCAToVertex2D(kTRUE);
+
       // Do the variation
       esdcuts->SetMaxChi2PerClusterITS(itscut);
       // Set cut on the TPC global constrained chi2 to very loose
       esdcuts->SetMaxChi2TPCConstrainedGlobal(100);
       trackcuts.push_back(esdcuts);
     }
-    if(cut.Contains("TPCchi2")){
-      // Definition: ITSchi2XXXX
-      // - 3 Digits before . (to be filled with 0)
-      // - 1 Digit after .
-      int strmin = cut.Index("TPCchi2") + 7;
-      int cutvalue = TString(cut(strmin , strmin+4)).Atoi();
-      float tpccut = static_cast<float>(cutvalue)/10.;
-
+    if(cut.Contains("TestTPCchi2")){
+      double tpccut = ValueDecoder(cut,"TestTPCchi2");
       std::cout << "Using TPC chi2 cut variation: " << tpccut << std::endl;
 
       AliESDtrackCuts *esdcuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(false, 1);
-      esdcuts->DefineHistograms(kRed);
       esdcuts->SetName(Form("VarTPCchi2%d", int(tpccut * 10.)));
       esdcuts->SetTitle(Form("Loose track cuts, TPC chi2 var %.1f", tpccut));
-      esdcuts->SetMinNCrossedRowsTPC(120);
-      esdcuts->SetMaxDCAToVertexXY(2.4);
-      esdcuts->SetMaxDCAToVertexZ(3.2);
-      esdcuts->SetDCAToVertex2D(kTRUE);
+
       // Do the variation
       esdcuts->SetMaxChi2PerClusterTPC(tpccut);
       trackcuts.push_back(esdcuts);
     }
-    if(cut.Contains("TPCchi2Constrained")){
-      // Definition: TPCchi2ConstrainedXXXX
-      // - 3 Digits before . (to be filled with 0)
-      // - 1 Digit after .
-      int strmin = cut.Index("TPCchi2Constrained") + 18;
-      int cutvalue = TString(cut(strmin , strmin+4)).Atoi();
-      float tpcconstrainedcut = static_cast<float>(cutvalue) / 10.;
-
+    if(cut.Contains("TestTPCchi2Constrained")){
+      double tpcconstrainedcut = ValueDecoder(cut, "TestTPCchi2Constrained");
       std::cout << "Using TPC chi2 constrained cut variation: " << tpcconstrainedcut << std::endl;
 
-      AliESDtrackCuts *esdcuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(false, 1);
-      esdcuts->DefineHistograms(kRed);
+      AliESDtrackCuts *esdcuts = GenerateLooseDCACutsESD();
       esdcuts->SetName(Form("VarTPCchi2constrained%d", int(tpcconstrainedcut * 10.)));
       esdcuts->SetTitle(Form("Loose track cuts, TPC constrained chi2 variation %f", tpcconstrainedcut));
-      esdcuts->SetMinNCrossedRowsTPC(120);
-      esdcuts->SetMaxDCAToVertexXY(2.4);
-      esdcuts->SetMaxDCAToVertexZ(3.2);
-      esdcuts->SetDCAToVertex2D(kTRUE);
+
       // Do the variation
       esdcuts->SetMaxChi2TPCConstrainedGlobal(tpcconstrainedcut);
       // Set ITS chi2 cut to very loose
@@ -193,6 +261,33 @@ AliEmcalTriggerOfflineSelection *AliEmcalAnalysisFactory::TriggerSelectionFactor
 
 TString AliEmcalAnalysisFactory::ClusterContainerNameFactory(Bool_t isAOD){
   return isAOD ? "caloClusters" : "CaloClusters";
+}
+
+AliESDtrackCuts *AliEmcalAnalysisFactory::GenerateDefaultCutsESD() {
+  AliESDtrackCuts *esdcuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(true, 1);
+  esdcuts->DefineHistograms(kRed);
+  esdcuts->SetCutGeoNcrNcl(3., 130., 1.5, 0.0, 0.0);
+  esdcuts->SetMaxDCAToVertexXYPtDep("0.0182+0.0350/pt^1.01");
+  return esdcuts;
+
+}
+
+AliESDtrackCuts *AliEmcalAnalysisFactory::GenerateLooseDCACutsESD(){
+  AliESDtrackCuts *esdcuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(kFALSE);
+  esdcuts->SetMaxDCAToVertexXY(2.4);
+  esdcuts->SetMaxDCAToVertexZ(3.2);
+  esdcuts->SetDCAToVertex2D(kTRUE);
+  esdcuts->SetMaxChi2TPCConstrainedGlobal(36);
+  esdcuts->SetMaxFractionSharedTPCClusters(0.4);
+  return esdcuts;
+}
+
+double AliEmcalAnalysisFactory::ValueDecoder(const char *cutstring, const char *tag) {
+  TString cuttstring(cutstring);
+  Int_t position(cuttstring.Index(tag) + strlen(tag));
+  TString valuestring = cuttstring(position, 4);
+  Int_t value = valuestring.Atoi();
+  return static_cast<double>(value) / 10.;
 }
 
 } /* namespace EMCalTriggerPtAnalysis */

--- a/PWGJE/EMCALJetTasks/Tracks/AliEmcalAnalysisFactory.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliEmcalAnalysisFactory.h
@@ -7,6 +7,7 @@
 #include <TString.h>
 #include "AliEmcalTriggerOfflineSelection.h"
 
+class AliESDtrackCuts;
 class AliEmcalTrackSelection;
 
 namespace EMCalTriggerPtAnalysis {
@@ -73,6 +74,25 @@ public:
    * @return Fully configured EMCAL trigger offline selection
    */
   static AliEmcalTriggerOfflineSelection *TriggerSelectionFactory(Double_t el0, Double_t eg1, Double_t eg2, Double_t ej1, Double_t ej2, AliEmcalTriggerOfflineSelection::EmcalEnergyDefinition_t endef = AliEmcalTriggerOfflineSelection::kFEEEnergy);
+
+  /**
+   * Generate default cut settings for the analysis
+   * @return Default cut settings for the analysis
+   */
+  static AliESDtrackCuts *GenerateDefaultCutsESD();
+
+  /**
+   * Generate cut settings with loose DCA (used for the hybrid cuts)
+   * @return Cut settings with loose DCA cuts
+   */
+  static AliESDtrackCuts *GenerateLooseDCACutsESD();
+
+  /**
+   * Definition: ITSchi2XXXX
+   * - 3 Digits before . (to be filled with 0)
+   * - 1 Digit after .
+   */
+  static double ValueDecoder(const char *string, const char *tag);
 
   /// \cond CLASSIMP
   ClassDef(AliEmcalAnalysisFactory, 1);


### PR DESCRIPTION
Functions generating ESD track cuts objects for
the track cuts variation are added. Cuts are
based on the default cut settings, each varying
only one cut at the time. Cut string always
consist of a certain tag for the cut and a
4-digit cut value where then last digit represents
the first decimal digit.