### PR TITLE
Implement event counter in AliBasicParticle to allow using of all-event pool for mixed event

### DIFF
--- a/PWG/Tools/AliBasicParticle.cxx
+++ b/PWG/Tools/AliBasicParticle.cxx
@@ -3,7 +3,7 @@
 ClassImp(AliBasicParticle)
 
 //________________________________________________________________________
-AliBasicParticle::AliBasicParticle() : fEta(0), fPhi(0), fpT(0), fCharge(0) 
+AliBasicParticle::AliBasicParticle() : fEta(0), fPhi(0), fpT(0), fCharge(0), fEventIndex(0)
 {
   // constructor
 }

--- a/PWG/Tools/AliBasicParticle.h
+++ b/PWG/Tools/AliBasicParticle.h
@@ -47,17 +47,21 @@ class AliBasicParticle : public AliVParticle
     virtual Int_t   PdgCode()     const { AliFatal("Not implemented"); return 0; }
     virtual const Double_t *PID() const { AliFatal("Not implemented"); return 0; }
 
+    virtual UInt_t GetEventIndex()const { return fEventIndex; }
     virtual Bool_t IsEqual(const TObject* obj) const { return (obj->GetUniqueID() == GetUniqueID()); }
+    virtual Bool_t IsInSameEvent(const AliBasicParticle* obj) const { return (obj->GetEventIndex() == GetEventIndex()); }
 
     virtual void SetPhi(Double_t phi) { fPhi = phi; }
+    virtual void SetEventIndex(UInt_t val) { fEventIndex = val; }
 
   private:
     Float_t fEta;      // eta
     Float_t fPhi;      // phi
     Float_t fpT;       // pT
     Short_t fCharge;   // charge
+    UInt_t  fEventIndex;// event index
 
-    ClassDef( AliBasicParticle, 1); // very basic particle class used for correlation analyses
+    ClassDef( AliBasicParticle, 2); // very basic particle class used for correlation analyses
 };
 
 #endif

--- a/PWGCF/Correlations/Base/AliUEHistograms.cxx
+++ b/PWGCF/Correlations/Base/AliUEHistograms.cxx
@@ -657,7 +657,7 @@ void AliUEHistograms::FillCorrelations(Double_t centrality, Float_t zVtx, AliUEH
 	    AliBasicParticle* particleBasic        = dynamic_cast<AliBasicParticle*>(particle);
 	    if(!triggerParticleBasic || !particleBasic)
 	    {
-	      AliError("If fCheckEventNumberInCorrelation is set, particle must be derived from AliBasicParticle");
+	      AliFatal("If fCheckEventNumberInCorrelation is set, particle must be derived from AliBasicParticle");
 	      continue;
 	    }
 	
@@ -732,7 +732,7 @@ void AliUEHistograms::FillCorrelations(Double_t centrality, Float_t zVtx, AliUEH
           AliBasicParticle* triggerParticleBasic = dynamic_cast<AliBasicParticle*>(triggerParticle);
           AliBasicParticle* particleBasic        = dynamic_cast<AliBasicParticle*>(particle);
           if(!triggerParticleBasic || !particleBasic)
-            AliError("If fCheckEventNumberInCorrelation is set, particle must be derived from AliBasicParticle");
+            AliFatal("If fCheckEventNumberInCorrelation is set, particle must be derived from AliBasicParticle");
       
           if(triggerParticleBasic->IsInSameEvent(particleBasic))
             continue;

--- a/PWGCF/Correlations/Base/AliUEHistograms.cxx
+++ b/PWGCF/Correlations/Base/AliUEHistograms.cxx
@@ -25,6 +25,7 @@
 #include "AliUEHistograms.h"
 
 #include "AliCFContainer.h"
+#include "AliBasicParticle.h"
 #include "AliVParticle.h"
 #include "AliAODTrack.h"
 
@@ -74,6 +75,7 @@ AliUEHistograms::AliUEHistograms(const char* name, const char* histograms, const
   fWeightPerEvent(kFALSE),
   fPtOrder(kTRUE),
   fTwoTrackCutMinRadius(0.8),
+  fCheckEventNumberInCorrelation(kFALSE),
   fRunNumber(0),
   fMergeCount(1)
 {
@@ -244,6 +246,7 @@ AliUEHistograms::AliUEHistograms(const AliUEHistograms &c) :
   fWeightPerEvent(kFALSE),
   fPtOrder(kTRUE),
   fTwoTrackCutMinRadius(0.8),
+  fCheckEventNumberInCorrelation(kFALSE),
   fRunNumber(0),
   fMergeCount(1)
 {
@@ -648,7 +651,20 @@ void AliUEHistograms::FillCorrelations(Double_t centrality, Float_t zVtx, AliUEH
 	  // check if both particles point to the same element (does not occur for mixed events, but if subsets are mixed within the same event)
 	  if (mixed && triggerParticle->IsEqual(particle))
 	    continue;
-	 
+	  if (fCheckEventNumberInCorrelation)
+	  {
+	    AliBasicParticle* triggerParticleBasic = dynamic_cast<AliBasicParticle*>(triggerParticle);
+	    AliBasicParticle* particleBasic        = dynamic_cast<AliBasicParticle*>(particle);
+	    if(!triggerParticleBasic || !particleBasic)
+	    {
+	      AliError("If fCheckEventNumberInCorrelation is set, particle must be derived from AliBasicParticle");
+	      continue;
+	    }
+	
+	    if(triggerParticleBasic->IsInSameEvent(particleBasic))
+	      continue;
+	  }
+	  
 	  if (triggerParticle->Charge() * particle->Charge() > 0)
 	    continue;
       
@@ -711,6 +727,16 @@ void AliUEHistograms::FillCorrelations(Double_t centrality, Float_t zVtx, AliUEH
         // check if both particles point to the same element (does not occur for mixed events, but if subsets are mixed within the same event)
         if (mixed && triggerParticle->IsEqual(particle))
           continue;
+        if (fCheckEventNumberInCorrelation)
+        {
+          AliBasicParticle* triggerParticleBasic = dynamic_cast<AliBasicParticle*>(triggerParticle);
+          AliBasicParticle* particleBasic        = dynamic_cast<AliBasicParticle*>(particle);
+          if(!triggerParticleBasic || !particleBasic)
+            AliError("If fCheckEventNumberInCorrelation is set, particle must be derived from AliBasicParticle");
+      
+          if(triggerParticleBasic->IsInSameEvent(particleBasic))
+            continue;
+        }
         
         if (fPtOrder)
 	  if (particle->Pt() >= triggerParticle->Pt())
@@ -1254,6 +1280,7 @@ void AliUEHistograms::Copy(TObject& c) const
   target.fWeightPerEvent = fWeightPerEvent;
   target.fPtOrder = fPtOrder;
   target.fTwoTrackCutMinRadius = fTwoTrackCutMinRadius;
+  target.fCheckEventNumberInCorrelation = fCheckEventNumberInCorrelation;
 }
 
 //____________________________________________________________________

--- a/PWGCF/Correlations/Base/AliUEHistograms.h
+++ b/PWGCF/Correlations/Base/AliUEHistograms.h
@@ -94,7 +94,8 @@ class AliUEHistograms : public TNamed
   void SetOnlyOneEtaSide(Int_t flag)    { fOnlyOneEtaSide = flag; }
   void SetPtOrder(Bool_t flag) { fPtOrder = flag; }
   void SetTwoTrackCutMinRadius(Float_t min) { fTwoTrackCutMinRadius = min; }
-  
+
+  void SetCheckEventNumberInCorrelation(Bool_t val) { fCheckEventNumberInCorrelation = val; }
   void ExtendTrackingEfficiency(Bool_t verbose = kFALSE);
   void Reset();
 
@@ -155,12 +156,14 @@ protected:
   Bool_t fWeightPerEvent;	// weight with the number of trigger particles per event
   Bool_t fPtOrder;		// apply pT,a < pT,t condition
   Float_t fTwoTrackCutMinRadius; // min radius for TTR cut
-  
+
+  Bool_t fCheckEventNumberInCorrelation; // do not correlate two particles from the same event (only works for AliBasicParticles)
+
   Long64_t fRunNumber;           // run number that has been processed
   
   Int_t fMergeCount;		// counts how many objects have been merged together
   
-  ClassDef(AliUEHistograms, 30)  // underlying event histogram container
+  ClassDef(AliUEHistograms, 31)  // underlying event histogram container
 };
 
 Float_t AliUEHistograms::GetDPhiStar(Float_t phi1, Float_t pt1, Float_t charge1, Float_t phi2, Float_t pt2, Float_t charge2, Float_t radius, Float_t bSign)

--- a/PWGCF/Correlations/DPhi/AliAnalysisTaskPhiCorrelations.cxx
+++ b/PWGCF/Correlations/DPhi/AliAnalysisTaskPhiCorrelations.cxx
@@ -191,7 +191,8 @@ fExclusionRadius(-1.),
 fCustomParticlesA(""),
 fCustomParticlesB(""),
 fEventPoolOutputList(),
-fUsePtBinnedEventPool(0)
+fUsePtBinnedEventPool(0),
+fCheckEventNumberInMixedEvent(kFALSE)
 {
   // Default constructor
   // Define input and output slots here
@@ -300,7 +301,11 @@ void  AliAnalysisTaskPhiCorrelations::CreateOutputObjects()
     histType += "D";
   fHistos = new AliUEHistograms("AliUEHistogramsSame", histType, fCustomBinning);
   fHistosMixed = new AliUEHistograms("AliUEHistogramsMixed", histType, fCustomBinning);
-  
+
+  // On demand, check event number before correlating tracks in mixed events
+  // To avoid same event contributions in mixed event when importing event pool
+  fHistosMixed->SetCheckEventNumberInCorrelation(fCheckEventNumberInMixedEvent);
+
   fHistos->SetSelectCharge(fSelectCharge);
   fHistosMixed->SetSelectCharge(fSelectCharge);
   
@@ -1822,6 +1827,7 @@ TObjArray* AliAnalysisTaskPhiCorrelations::GetParticlesFromDetector(AliVEvent* i
 	  {
 	    AliBasicParticle* particle = new AliBasicParticle((AliVVZERO::GetVZEROEtaMax(i) + AliVVZERO::GetVZEROEtaMin(i)) / 2, AliVVZERO::GetVZEROAvgPhi(i), 1.1, 0); // fix pT = 1.1 and charge = 0
 	    particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + j + i * 1000) * 10 + idet);
+	    particle->SetEventIndex(fAnalyseUE->GetEventCounter());
 	    
 	    obj->Add(particle);
 	  }
@@ -1849,6 +1855,7 @@ TObjArray* AliAnalysisTaskPhiCorrelations::GetParticlesFromDetector(AliVEvent* i
 	  
 	  AliBasicParticle* particle = new AliBasicParticle(eta,phi, pT, 0); // pT = TMath::Abs(trklets->GetDeltaPhi(itrklets)) in mrad and charge = 0
 	  particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + itrklets) * 10 + idet);
+	  particle->SetEventIndex(fAnalyseUE->GetEventCounter());
 	  
 	  obj->Add(particle);
        	}      
@@ -1872,6 +1879,7 @@ TObjArray* AliAnalysisTaskPhiCorrelations::GetParticlesFromDetector(AliVEvent* i
 	
 	AliBasicParticle* particle = new AliBasicParticle(eta,track->Phi(), track->Pt(), track->Charge()); 
 	particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + iTrack) * 10 + idet);
+	particle->SetEventIndex(fAnalyseUE->GetEventCounter());
 	
 	obj->Add(particle);
       }
@@ -1943,6 +1951,7 @@ TObjArray* AliAnalysisTaskPhiCorrelations::GetParticlesFromDetector(AliVEvent* i
           new AliBasicParticle(track->Eta(), track->Phi(), track->Pt(), track->Charge());
         // NOTE "+ idet" is missing here on purpose as the tracks are the same as in the case of idet == 0
         particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + iTrack) * 10);
+        particle->SetEventIndex(fAnalyseUE->GetEventCounter());
         obj->Add(particle);
       }
     }
@@ -1992,11 +2001,10 @@ TObjArray* AliAnalysisTaskPhiCorrelations::GetParticlesFromDetector(AliVEvent* i
       // Set custom ID. Should be the same if custom particle A and B are the same
       if(fCustomParticlesA == fCustomParticlesB)
         particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + iParticle) * 10 + 6);
-      else  // Set custom ID based on event counter & custom particle label
-      {
-        // Setting the label of the custom particle allows a user-defined labeling
-        particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + customParticle->GetLabel()) * 10 + 6);
-      }
+      else
+        particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + iParticle) * 10 + idet);
+
+      particle->SetEventIndex(fAnalyseUE->GetEventCounter());
 
       obj->Add(particle);
     }

--- a/PWGCF/Correlations/DPhi/AliAnalysisTaskPhiCorrelations.h
+++ b/PWGCF/Correlations/DPhi/AliAnalysisTaskPhiCorrelations.h
@@ -172,6 +172,7 @@ public:
   void SetExternalEventPoolManager(AliEventPoolManager* mgr) {fPoolMgr = mgr;}
   AliEventPoolManager* GetEventPoolManager() {return fPoolMgr;}
   void SetUsePtBinnedEventPool(Bool_t val) {fUsePtBinnedEventPool = val;}
+  void SetCheckEventNumberInMixedEvent(Bool_t val) {fCheckEventNumberInMixedEvent = val;}
 
   // Set which pools will be saved
   void AddEventPoolsToOutput(Double_t minCent, Double_t maxCent,  Double_t minZvtx, Double_t maxZvtx, Double_t minPt, Double_t maxPt);
@@ -313,8 +314,9 @@ private:
   // Event pool variables
   vector<vector<Double_t> >   fEventPoolOutputList; // vector representing a list of pools (given by value range) that will be saved
   Bool_t                      fUsePtBinnedEventPool; // uses event pool in pt bins
+  Bool_t                      fCheckEventNumberInMixedEvent; // check event number before correlation in mixed event
 
-  ClassDef(AliAnalysisTaskPhiCorrelations, 61); // Analysis task for delta phi correlations
+  ClassDef(AliAnalysisTaskPhiCorrelations, 62); // Analysis task for delta phi correlations
 };
 
 #endif


### PR DESCRIPTION
This commit only (directly) affects the usage of custom particles in AliAnalysisTaskPhiCorrelations.
It is to allow the task to use an imported event pool correctly. Without, the tracks from an imported pool are mixed with tracks from the same events.