### PR TITLE
preparing analysis deuteron pA for publication validation train run

### DIFF
--- a/PWGLF/NUCLEX/Nuclei/DeuteronpA/AddTaskTPCTOFpA.C
+++ b/PWGLF/NUCLEX/Nuclei/DeuteronpA/AddTaskTPCTOFpA.C
@@ -21,7 +21,7 @@ AliAnalysisTask *AddTaskDeuteronpA(){
 
   //normal tracks
   AliAnalysisDeuteronpA *task = new AliAnalysisDeuteronpA("janielskTaskDeuteronpA");
-
+  task->SelectCollisionCandidates(AliVEvent::kINT7);
 
   //initialize task
   task->Initialize();


### PR DESCRIPTION
This is to run the deuteron pA analysis a last time on the LEGO train before publishing it. Previously the physicsSelection was disabled for testing purposes.