### PR TITLE
Fix pointer deletion in class destructor

### DIFF
--- a/PWGHF/vertexingHF/AliHFInvMassFitter.cxx
+++ b/PWGHF/vertexingHF/AliHFInvMassFitter.cxx
@@ -152,11 +152,11 @@ AliHFInvMassFitter::~AliHFInvMassFitter() {
 
   ///destructor
 
-  delete fHistoInvMass;
   delete fSigFunc;
   delete fBkgFunc;
   delete fBkgFuncSb;
   delete fBkgFuncRefit;
+  delete fHistoInvMass;
   delete fRflFunc;
   delete fBkRFunc;
   delete fSecFunc;


### PR DESCRIPTION
Fix crash of class deletion when using >3rd order polynomials ('fBkgFuncSb' has to be deleted before 'fHistoInvMass')