### PR TITLE
Option to use the generated pt,eta,phi for the reconstructed tracks

### DIFF
--- a/PWGPP/EvTrkSelection/AliCFSingleTrackEfficiencyTask.cxx
+++ b/PWGPP/EvTrkSelection/AliCFSingleTrackEfficiencyTask.cxx
@@ -48,6 +48,7 @@ AliCFSingleTrackEfficiencyTask::AliCFSingleTrackEfficiencyTask() :
   fbit(0),
   fRemoveNegativeLabelTracks(kTRUE),
   fMatchToKinematicTrack(kTRUE),
+  fUseGeneratedKine(kFALSE),
   fEvalCentrality(kFALSE),
   fCentralityEstimator("V0M"),
   fConfiguration(kFast), // default  use the minimal configuration
@@ -71,6 +72,7 @@ AliCFSingleTrackEfficiencyTask::AliCFSingleTrackEfficiencyTask(const Char_t* nam
   fbit(0),
   fRemoveNegativeLabelTracks(kTRUE),
   fMatchToKinematicTrack(kTRUE),
+  fUseGeneratedKine(kFALSE),
   fEvalCentrality(kFALSE),
   fCentralityEstimator("V0M"),
   fConfiguration(kFast), // default  use the minimal configuration
@@ -114,6 +116,7 @@ AliCFSingleTrackEfficiencyTask& AliCFSingleTrackEfficiencyTask::operator=(const 
     fbit = c.fbit;
     fRemoveNegativeLabelTracks = c.fRemoveNegativeLabelTracks;
     fMatchToKinematicTrack = c.fMatchToKinematicTrack;
+    fUseGeneratedKine = c.fUseGeneratedKine;
 
     fEvalCentrality = c.fEvalCentrality;
     fCentralityEstimator = c.fCentralityEstimator;
@@ -138,6 +141,7 @@ AliCFSingleTrackEfficiencyTask::AliCFSingleTrackEfficiencyTask(const AliCFSingle
   fbit(c.fbit),
   fRemoveNegativeLabelTracks(c.fRemoveNegativeLabelTracks),
   fMatchToKinematicTrack(c.fMatchToKinematicTrack),
+  fUseGeneratedKine(c.fUseGeneratedKine),
   fEvalCentrality(c.fEvalCentrality),
   fCentralityEstimator(c.fCentralityEstimator),
   fConfiguration(c.fConfiguration),
@@ -623,6 +627,9 @@ void AliCFSingleTrackEfficiencyTask::CheckReconstructedParticles()
 
         if (!fMCCuts->IsMCParticleGenerated(mcPart)) continue;
         //    cout<< "MC matching did work"<<endl;
+	if(fUseGeneratedKine){
+	  for(Int_t ivar=0; ivar<=3; ivar++) containerInput[ivar] = containerInputMC[ivar];
+	}
     }
 
     // for filter bit selection

--- a/PWGPP/EvTrkSelection/AliCFSingleTrackEfficiencyTask.h
+++ b/PWGPP/EvTrkSelection/AliCFSingleTrackEfficiencyTask.h
@@ -64,7 +64,8 @@ class AliCFSingleTrackEfficiencyTask : public AliAnalysisTaskSE {
   void SetRemoveNegativeLabelTracks(Bool_t flag) { fRemoveNegativeLabelTracks=flag; }
   // flag to match or skip the matching of reconstructed to kinematic tracks
   void SetMatchToKinematicTrack(Bool_t flag) { fMatchToKinematicTrack=flag; }
-    
+  void SetUseGeneratedKine(Bool_t flag) {fUseGeneratedKine=flag;}
+
   // select trigger event mask
   void SetTriggerMask(ULong64_t mask=0) { fTriggerMask=mask; }
   // set whether to evaluate centrality
@@ -120,6 +121,7 @@ class AliCFSingleTrackEfficiencyTask : public AliAnalysisTaskSE {
   Int_t  fbit;          // filter-bit selection to tracks
   Bool_t fRemoveNegativeLabelTracks; // flag to remove fake tracks (reconstructed tracks with negative label)
   Bool_t fMatchToKinematicTrack;  // flag to check if the reconstructed track matches to a kinematic one in the good acceptance
+  Bool_t fUseGeneratedKine;      // flag to use the generated pt, eta phi
 
   Bool_t fEvalCentrality;        // flag to enable centrality determination
   TString fCentralityEstimator;  // centrality estimator
@@ -128,7 +130,7 @@ class AliCFSingleTrackEfficiencyTask : public AliAnalysisTaskSE {
 
   TH1I  *fHistEventsProcessed;   //! histo for monitoring the number of events processed slot 1
 
-  ClassDef(AliCFSingleTrackEfficiencyTask,5)
+  ClassDef(AliCFSingleTrackEfficiencyTask,6)
 };
 
 #endif

--- a/PWGPP/EvTrkSelection/macros/AddSingleTrackEfficiencyTaskPbPb.C
+++ b/PWGPP/EvTrkSelection/macros/AddSingleTrackEfficiencyTaskPbPb.C
@@ -24,11 +24,12 @@ AliCFSingleTrackEfficiencyTask *AddSingleTrackEfficiencyTaskPbPb(const Bool_t re
 								 TString suffix="default", // suffix for the output directory
 								 AliPID::EParticleType specie=AliPID::kPion, 
 								 Int_t pdgcode=0, //particle specie
+								 Bool_t useMCtruthForKine=kFALSE,
 								 ULong64_t triggerMask=AliVEvent::kAnyINT,
 								 TString centralityEstimator = "V0M",
 								 Int_t fBit=0,
 								 Bool_t TPCRefit = kTRUE,
-								 Int_t minclustersTPC = 70,
+								 Int_t minclustersTPC = 0,
 								 Bool_t ITSRefit = kTRUE,
 								 Int_t spdHits=AliESDtrackCuts::kAny,
 								 Int_t minclustersITS = 0,
@@ -212,6 +213,7 @@ AliCFSingleTrackEfficiencyTask *AddSingleTrackEfficiencyTaskPbPb(const Bool_t re
   //  task->SelectCollisionCandidates(triggerMask);//AliVEvent::kMB);
   if(centralityEstimator != "") task->SetUseCentrality(kTRUE,centralityEstimator);
   task->SetConfiguration(configuration);
+  task->SetUseGeneratedKine(useMCtruthForKine);
   task->SetCFManager(man); //here is set the CF manager
 
   //

--- a/PWGPP/EvTrkSelection/macros/AddSingleTrackEfficiencyTaskpp.C
+++ b/PWGPP/EvTrkSelection/macros/AddSingleTrackEfficiencyTaskpp.C
@@ -25,6 +25,7 @@ AliCFSingleTrackEfficiencyTask *AddSingleTrackEfficiencyTaskpp(const Bool_t read
 							       TString suffix="default", // suffix for the output directory
 							       AliPID::EParticleType specie=AliPID::kPion, 
 							       Int_t pdgcode=0, //particle specie
+							       Bool_t useMCtruthForKine=kFALSE,
 							       ULong64_t triggerMask=AliVEvent::kAnyINT,
 							       TString centralityEstimator = "V0M",
 							       Int_t fBit=0,
@@ -214,6 +215,7 @@ AliCFSingleTrackEfficiencyTask *AddSingleTrackEfficiencyTaskpp(const Bool_t read
   //  task->SelectCollisionCandidates(triggerMask);//AliVEvent::kMB);
   if(centralityEstimator != "") task->SetUseCentrality(kTRUE,centralityEstimator);
   task->SetConfiguration(configuration);
+  task->SetUseGeneratedKine(useMCtruthForKine);
   task->SetCFManager(man); //here is set the CF manager
 
   //


### PR DESCRIPTION
New option in the single track efficiency task