### PR TITLE
added histograms with AD and VZero BBFlag information

### DIFF
--- a/PWGPP/AD/AliAnalysisTaskADQA.cxx
+++ b/PWGPP/AD/AliAnalysisTaskADQA.cxx
@@ -605,7 +605,7 @@ void AliAnalysisTaskADQA::UserExec(Option_t *)
 	
 	//Aging monitoring
 	Bool_t localPF = kTRUE;
-	for(Int_t iClock=0; iClock<10; iClock++) if(esdAD->GetPFBBFlag(i,iClock) || esdAD->GetPFBGFlag(i,iClock))localPF = kFALSE;
+	for(Int_t iClock=0; iClock<10; iClock++)  if(esdAD->GetPFBBFlag(i,iClock) || esdAD->GetPFBGFlag(i,iClock))localPF = kFALSE;
 	for(Int_t iClock=11; iClock<21; iClock++) if(esdAD->GetPFBBFlag(i,iClock) || esdAD->GetPFBGFlag(i,iClock))localPF = kFALSE;
 	
 	if(esdAD->GetTime(i)> -1024 + 1e-6 && !isPileUp && !isBackground){

--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliAnalysisTaskCEP.cxx
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliAnalysisTaskCEP.cxx
@@ -222,6 +222,10 @@ AliAnalysisTaskCEP::~AliAnalysisTaskCEP()
     delete flQArnum;
     flQArnum = 0x0;
   }
+  if (flBBFlag) {
+    delete flBBFlag;
+    flBBFlag = 0x0;
+  }
   if (flSPDpileup) {
     delete flSPDpileup;
     flSPDpileup = 0x0;
@@ -377,6 +381,19 @@ void AliAnalysisTaskCEP::UserCreateOutputObjects()
       fHist->Add((TObject*)flQArnum->At(ii));
   }
   
+  // histograms BBFlag study
+  if (fCEPUtil->checkstatus(fAnalysisStatus,
+    AliCEPBase::kBitBBFlagStudy,AliCEPBase::kBitBBFlagStudy)) {
+    
+    // get list of histograms
+    flBBFlag = new TList();
+    flBBFlag = fCEPUtil->GetBBFlagQAHists();
+    
+    // add histograms to the output list
+    for (Int_t ii=0; ii<flBBFlag->GetEntries(); ii++)
+      fHist->Add((TObject*)flBBFlag->At(ii));
+  }
+  
   // histograms for SPD pile-up study
   if (fCEPUtil->checkstatus(fAnalysisStatus,
     AliCEPBase::kBitSPDPileupStudy,AliCEPBase::kBitSPDPileupStudy)) {
@@ -515,6 +532,10 @@ void AliAnalysisTaskCEP::UserExec(Option_t *)
   
   if (flSPDpileup) {
     fCEPUtil->SPDVtxAnalysis(fEvent,3,0.8,3.,2.,5.,flSPDpileup);
+  }
+  
+  if (flBBFlag) {
+    fCEPUtil->BBFlagAnalysis(fEvent,flBBFlag);
   }
   
   //fAnalysisUtils.SetBSPDCvsTCut(4);

--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliAnalysisTaskCEP.h
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliAnalysisTaskCEP.h
@@ -116,6 +116,7 @@ private:
   AliCEPUtils *fCEPUtil;                  //! object of type AliCEPUtils
 
   TList *flQArnum;      //! list of QA histograms for QA vs rnum study
+  TList *flBBFlag;      //! list of QA histograms for BBFlag study
   TList *flSPDpileup;   //! list of QA histograms for SPD pile-up study
   TList *flnClunTra;    //! list of QA histograms for nClunTra BG rejection
   TList *flVtx     ;    //! list of QA histograms for vertex selection

--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPBase.h
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPBase.h
@@ -138,7 +138,8 @@ class AliCEPBase : public TObject {
     kBitnClunTraStudy         = (1<< 6), // cluster vs tracklet study
     kBitVtxStudy              = (1<< 7), // Vtx study
     kBitTrackCutStudy         = (1<< 8), // track cut study
-		kBitConfigurationVersion  = (1<< 9)  // always set, last bit
+    kBitBBFlagStudy           = (1<< 9), // BBFlag study
+		kBitConfigurationVersion  = (1<<10)  // always set, last bit
 	
   };
 

--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx
@@ -59,7 +59,6 @@ AliCEPUtils::~AliCEPUtils()
 TH1F* AliCEPUtils::GetHistStatsFlow()
 {
 	// setup the stats flow histogram
-
 	TH1F *hist = new TH1F("statsFlow","",
     AliCEPBase::kBinLastValue,0,AliCEPBase::kBinLastValue);
 	TAxis* axis = hist->GetXaxis();
@@ -113,6 +112,40 @@ TList* AliCEPUtils::GetQArnumHists(Int_t rnummin, Int_t rnummax)
   lhh->Add(fhh04);
   TH1F* fhh05 = new TH1F("nV0DG","nV0DG",nch,rnummin,rnummax);
   lhh->Add(fhh05);
+  
+  return lhh;
+  
+}
+
+//------------------------------------------------------------------------------
+// definition of QA histograms used in AliCEPUtils::BBFlagAnalysis
+TList* AliCEPUtils::GetBBFlagQAHists()
+{
+
+  // initialisations
+  TList *lhh = new TList();
+  lhh->SetOwner();
+  
+  // define the histograms and and add them to the list lhh
+  printf("Preparing QABBFlag histograms\n");
+  // number of input events
+  TH2F* fhh01 = new TH2F("V0ABBFlag","V0ABBFlag",32,0,31,21,0,20);
+  lhh->Add(fhh01);
+  TH2F* fhh02 = new TH2F("V0CBBFlag","V0CBBFlag",32,0,31,21,0,20);
+  lhh->Add(fhh02);
+  TH2F* fhh03 = new TH2F("ADABBFlag","ADABBFlag",8,0,7,21,0,20);
+  lhh->Add(fhh03);
+  TH2F* fhh04 = new TH2F("ADCBBFlag","ADCBBFlag",8,0,7,21,0,20);
+  lhh->Add(fhh04);
+
+  TH2F* fhh05 = new TH2F("V0ABGFlag","V0ABGFlag",32,0,31,21,0,20);
+  lhh->Add(fhh05);
+  TH2F* fhh06 = new TH2F("V0CBGFlag","V0CBGFlag",32,0,31,21,0,20);
+  lhh->Add(fhh06);
+  TH2F* fhh07 = new TH2F("ADABGFlag","ADABGFlag",8,0,7,21,0,20);
+  lhh->Add(fhh07);
+  TH2F* fhh08 = new TH2F("ADCBGFlag","ADCBGFlag",8,0,7,21,0,20);
+  lhh->Add(fhh08);
   
   return lhh;
   
@@ -325,6 +358,57 @@ UInt_t AliCEPUtils::GetVtxPos(AliVEvent *Event, TVector3 *fVtxPos)
   
 }
 
+//------------------------------------------------------------------------------
+void AliCEPUtils::BBFlagAnalysis (
+  AliVEvent *Event,
+  TList *lhh)
+{
+  
+  if (!lhh) return;
+
+  // V0
+  // there are 32 channels and 21 bc
+  AliVVZERO* esdV0 = Event->GetVZEROData();
+  if (esdV0) {
+    // side A
+    for (Int_t ch=0; ch<32; ch++) {
+      for (Int_t bc=0; bc<21; bc++) {
+        if (esdV0->GetPFBBFlag(ch+32,bc)>0) ((TH2F*)lhh->At(0))->Fill(ch,bc);
+        if (esdV0->GetPFBGFlag(ch+32,bc)>0) ((TH2F*)lhh->At(4))->Fill(ch,bc);
+      }
+    }
+    
+    // side C
+    for (Int_t ch=0; ch<32; ch++) {
+      for (Int_t bc=0; bc<21; bc++) {
+        if (esdV0->GetPFBBFlag(ch,bc)>0)    ((TH2F*)lhh->At(1))->Fill(ch,bc);
+        if (esdV0->GetPFBGFlag(ch,bc)>0)    ((TH2F*)lhh->At(5))->Fill(ch,bc);
+      }
+    }
+  }
+  
+  // AD
+  // there are 16 channels - 8 channels per side (A, C) - and 21 bc values
+  AliESDAD* esdAD = (AliESDAD*)Event->GetADData();
+  if (esdAD) {
+    // side A
+    for (Int_t ch=0; ch<8; ch++) {
+      for (Int_t bc=0; bc<21; bc++) {
+        if (esdAD->GetPFBBFlag(ch+8,bc)>0) ((TH2F*)lhh->At(2))->Fill(ch,bc);
+        if (esdAD->GetPFBGFlag(ch+8,bc)>0) ((TH2F*)lhh->At(6))->Fill(ch,bc);
+      }
+    }
+
+    // side C
+    for (Int_t ch=0; ch<8; ch++){
+      for (Int_t bc=0; bc<21; bc++) {
+        if (esdAD->GetPFBBFlag(ch,bc)>0)   ((TH2F*)lhh->At(3))->Fill(ch,bc);
+        if (esdAD->GetPFBGFlag(ch,bc)>0)   ((TH2F*)lhh->At(7))->Fill(ch,bc);
+      }
+    }
+  }
+
+}
 //------------------------------------------------------------------------------
 // This function compiles parameters which are relevant in SPD pile-up
 // rejection, see AliESDEvent::IsPileupFromSPD

--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.h
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.h
@@ -42,6 +42,9 @@
 #include "AliESDtrackCuts.h"
 #include "AliESDVertex.h"
 #include "AliESDv0.h"
+#include "AliESDAD.h"
+#include "AliVVZERO.h"
+
 #include "AliCEPBase.h"
 
 class AliCEPUtils : public TObject {
@@ -86,6 +89,10 @@ class AliCEPUtils : public TObject {
     // QA studies
     static TList* GetQArnumHists(Int_t rnummin, Int_t rnummax);
     
+    static TList* GetBBFlagQAHists();
+    void BBFlagAnalysis(
+      AliVEvent *Event,
+      TList *lhh );
     static TList* GetSPDPileupQAHists();
     void SPDVtxAnalysis (
       AliVEvent *Event,


### PR DESCRIPTION
Histograms are added to the output of AliAnalysisTaskCEP containing the B[B,G]Flag information of the AD and V0 detectors