### PR TITLE
Adjusting branches with TOF info for pileup studies in pp.

### DIFF
--- a/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrangenessVsMultiplicityMCRun2.h
+++ b/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrangenessVsMultiplicityMCRun2.h
@@ -195,6 +195,8 @@ private:
 
     AliPIDResponse *fPIDResponse;     // PID response object
     AliESDtrackCuts *fESDtrackCuts;   // ESD track cuts used for primary track definition
+    AliESDtrackCuts *fESDtrackCutsITSsa2010;  // ESD track cuts used for ITSsa track definition
+    AliESDtrackCuts *fESDtrackCutsGlobal2015; // ESD track cuts used for global track definition
     AliAnalysisUtils *fUtils;         // analysis utils (for MV pileup selection)
     
     //Implementation of event selection utility
@@ -212,6 +214,7 @@ private:
     Bool_t fkUseOnTheFlyV0Cascading; 
     Bool_t fkDebugWrongPIDForTracking; //if true, add extra information to TTrees for debugging
     Bool_t fkDebugBump; //if true, add extra information to TTrees for debugging
+    Bool_t fkDebugOOBPileup; // if true, add extra information to TTrees for pileup study
     Bool_t fkDoExtraEvSels; //use AliEventCuts for event selection
     
     Bool_t fkSaveCascadeTree;         //if true, save TTree
@@ -237,6 +240,14 @@ private:
 //===========================================================================================
     Float_t fCentrality; //!
     Bool_t fMVPileupFlag; //!
+
+    //TOF info for OOB pileuo study
+    Int_t  fNTOFClusters;  //!
+    Int_t  fNTOFMatches;   //!
+    Int_t  fNTracksITSsa2010; //!
+    Int_t  fNTracksGlobal2015; //!
+    Int_t  fNTracksGlobal2015TriggerPP; //!
+
 
 //===========================================================================================
 //   Variables for V0 Tree
@@ -285,7 +296,17 @@ private:
     ULong64_t fTreeVariablePosTrackStatus; //!
     Float_t fTreeVariableNegDCAz; //!
     Float_t fTreeVariablePosDCAz; //!
-    
+
+    //Variables for OOB pileup study (high-multiplicity triggers pp 13 TeV - 2016 data)
+    Float_t fTreeVariableNegTOFExpTDiff;      //!
+    Float_t fTreeVariablePosTOFExpTDiff;      //!
+    ////Event info
+    //Int_t  fTreeVariableNTOFClusters;  //!
+    //Int_t  fTreeVariableNTOFMatches;   //!
+    //Int_t  fTreeVariableNTracksITSsa2010; //!
+    //Int_t  fTreeVariableNTracksGlobal2015; //!
+    //Int_t  fTreeVariableNTracksGlobal2015TriggerPP; //!
+
     //Event Multiplicity Variables
     Float_t fTreeVariableCentrality; //!
     Bool_t fTreeVariableMVPileupFlag;         //!

--- a/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrangenessVsMultiplicityRun2.cxx
+++ b/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrangenessVsMultiplicityRun2.cxx
@@ -205,15 +205,11 @@ fTreeVariableLeastRatioCrossedRowsOverFindable(0),
 
 fTreeVariableNegTOFExpTDiff(99999),
 fTreeVariablePosTOFExpTDiff(99999),
-fTreeVariableNegTOFSignal(99999),
-fTreeVariablePosTOFSignal(99999),
-fTreeVariableNegTOFBunchCrossing(99999),
-fTreeVariablePosTOFBunchCrossing(99999),
-fTreeVariableNTOFClusters(-1),
-fTreeVariableNTOFMatches(-1),
-fTreeVariableNTracksITSsa2010(-1),
-fTreeVariableNTracksGlobal2015(-1),
-fTreeVariableNTracksGlobal2015TriggerPP(-1),
+//fTreeVariableNTOFClusters(-1),
+//fTreeVariableNTOFMatches(-1),
+//fTreeVariableNTracksITSsa2010(-1),
+//fTreeVariableNTracksGlobal2015(-1),
+//fTreeVariableNTracksGlobal2015TriggerPP(-1),
 
 fTreeVariableCentrality(0),
 fTreeVariableMVPileupFlag(kFALSE),
@@ -394,15 +390,11 @@ fTreeVariableLeastRatioCrossedRowsOverFindable(0),
 
 fTreeVariableNegTOFExpTDiff(99999),
 fTreeVariablePosTOFExpTDiff(99999),
-fTreeVariableNegTOFSignal(99999),
-fTreeVariablePosTOFSignal(99999),
-fTreeVariableNegTOFBunchCrossing(99999),
-fTreeVariablePosTOFBunchCrossing(99999),
-fTreeVariableNTOFClusters(-1),
-fTreeVariableNTOFMatches(-1),
-fTreeVariableNTracksITSsa2010(-1),
-fTreeVariableNTracksGlobal2015(-1),
-fTreeVariableNTracksGlobal2015TriggerPP(-1),
+//fTreeVariableNTOFClusters(-1),
+//fTreeVariableNTOFMatches(-1),
+//fTreeVariableNTracksITSsa2010(-1),
+//fTreeVariableNTracksGlobal2015(-1),
+//fTreeVariableNTracksGlobal2015TriggerPP(-1),
 
 fTreeVariableCentrality(0),
 fTreeVariableMVPileupFlag(kFALSE),
@@ -652,15 +644,11 @@ void AliAnalysisTaskStrangenessVsMultiplicityRun2::UserCreateOutputObjects()
         if ( fkDebugOOBPileup ) {
             fTreeV0->Branch("fTreeVariableNegTOFExpTDiff",&fTreeVariableNegTOFExpTDiff,"fTreeVariableNegTOFExpTDiff/F");
             fTreeV0->Branch("fTreeVariablePosTOFExpTDiff",&fTreeVariablePosTOFExpTDiff,"fTreeVariablePosTOFExpTDiff/F");
-            fTreeV0->Branch("fTreeVariableNegTOFSignal",&fTreeVariableNegTOFSignal,"fTreeVariableNegTOFSignal/F");
-            fTreeV0->Branch("fTreeVariablePosTOFSignal",&fTreeVariablePosTOFSignal,"fTreeVariablePosTOFSignal/F");
-            fTreeV0->Branch("fTreeVariableNegTOFBunchCrossing",&fTreeVariableNegTOFBunchCrossing,"fTreeVariableNegTOFBunchCrossing/I");
-            fTreeV0->Branch("fTreeVariablePosTOFBunchCrossing",&fTreeVariablePosTOFBunchCrossing,"fTreeVariablePosTOFBunchCrossing/I");
-            fTreeV0->Branch("fTreeVariableNTOFClusters",&fTreeVariableNTOFClusters,"fTreeVariableNTOFClusters/I");
-            fTreeV0->Branch("fTreeVariableNTOFMatches",&fTreeVariableNTOFMatches,"fTreeVariableNTOFMatches/I");
-            fTreeV0->Branch("fTreeVariableNTracksITSsa2010",&fTreeVariableNTracksITSsa2010,"fTreeVariableNTracksITSsa2010/I");
-            fTreeV0->Branch("fTreeVariableNTracksGlobal2015",&fTreeVariableNTracksGlobal2015,"fTreeVariableNTracksGlobal2015/I");
-            fTreeV0->Branch("fTreeVariableNTracksGlobal2015TriggerPP",&fTreeVariableNTracksGlobal2015TriggerPP,"fTreeVariableNTracksGlobal2015TriggerPP/I");
+            //fTreeV0->Branch("fTreeVariableNTOFClusters",&fTreeVariableNTOFClusters,"fTreeVariableNTOFClusters/I");
+            //fTreeV0->Branch("fTreeVariableNTOFMatches",&fTreeVariableNTOFMatches,"fTreeVariableNTOFMatches/I");
+            //fTreeV0->Branch("fTreeVariableNTracksITSsa2010",&fTreeVariableNTracksITSsa2010,"fTreeVariableNTracksITSsa2010/I");
+            //fTreeV0->Branch("fTreeVariableNTracksGlobal2015",&fTreeVariableNTracksGlobal2015,"fTreeVariableNTracksGlobal2015/I");
+            //fTreeV0->Branch("fTreeVariableNTracksGlobal2015TriggerPP",&fTreeVariableNTracksGlobal2015TriggerPP,"fTreeVariableNTracksGlobal2015TriggerPP/I");
         }
         //------------------------------------------------
     }
@@ -1238,18 +1226,14 @@ void AliAnalysisTaskStrangenessVsMultiplicityRun2::UserExec(Option_t *)
 
         //TOF info for pileup studies
         if( fkDebugOOBPileup ) {
-            fTreeVariableNegTOFSignal        = nTrack->GetTOFsignal();
-            fTreeVariablePosTOFSignal        = pTrack->GetTOFsignal();
             fTreeVariableNegTOFExpTDiff      = nTrack->GetTOFExpTDiff(lESDevent->GetMagneticField());
             fTreeVariablePosTOFExpTDiff      = pTrack->GetTOFExpTDiff(lESDevent->GetMagneticField());
-            fTreeVariableNegTOFBunchCrossing = nTrack->GetTOFBunchCrossing(lESDevent->GetMagneticField());
-            fTreeVariablePosTOFBunchCrossing = pTrack->GetTOFBunchCrossing(lESDevent->GetMagneticField());
-            //Copy TOF information for this event
-            fTreeVariableNTOFClusters               = fNTOFClusters;
-            fTreeVariableNTOFMatches                = fNTOFMatches;
-            fTreeVariableNTracksITSsa2010           = fNTracksITSsa2010;
-            fTreeVariableNTracksGlobal2015          = fNTracksGlobal2015;
-            fTreeVariableNTracksGlobal2015TriggerPP = fNTracksGlobal2015TriggerPP;
+            ////Copy TOF information for this event
+            //fTreeVariableNTOFClusters               = fNTOFClusters;
+            //fTreeVariableNTOFMatches                = fNTOFMatches;
+            //fTreeVariableNTracksITSsa2010           = fNTracksITSsa2010;
+            //fTreeVariableNTracksGlobal2015          = fNTracksGlobal2015;
+            //fTreeVariableNTracksGlobal2015TriggerPP = fNTracksGlobal2015TriggerPP;
         }
 
 

--- a/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrangenessVsMultiplicityRun2.h
+++ b/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrangenessVsMultiplicityRun2.h
@@ -296,16 +296,12 @@ private:
     //Variables for OOB pileup study (high-multiplicity triggers pp 13 TeV - 2016 data)
     Float_t fTreeVariableNegTOFExpTDiff;      //!
     Float_t fTreeVariablePosTOFExpTDiff;      //!
-    Float_t fTreeVariableNegTOFSignal;        //!
-    Float_t fTreeVariablePosTOFSignal;        //!
-    Int_t   fTreeVariableNegTOFBunchCrossing; //!
-    Int_t   fTreeVariablePosTOFBunchCrossing; //!
-    //Event info
-    Int_t  fTreeVariableNTOFClusters;  //!
-    Int_t  fTreeVariableNTOFMatches;   //!
-    Int_t  fTreeVariableNTracksITSsa2010; //!
-    Int_t  fTreeVariableNTracksGlobal2015; //!
-    Int_t  fTreeVariableNTracksGlobal2015TriggerPP; //!
+    ////Event info
+    //Int_t  fTreeVariableNTOFClusters;  //!
+    //Int_t  fTreeVariableNTOFMatches;   //!
+    //Int_t  fTreeVariableNTracksITSsa2010; //!
+    //Int_t  fTreeVariableNTracksGlobal2015; //!
+    //Int_t  fTreeVariableNTracksGlobal2015TriggerPP; //!
 
     //Event Multiplicity Variables
     Float_t fTreeVariableCentrality; //!


### PR DESCRIPTION
Removed redundant branches added previously with TOF info for pileup studies in pp collisions.
Matching the branches added for Data and MC analysis codes.