### PR TITLE
EMCal CorrFW: Small improvements and fixes

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalContainerUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalContainerUtils.h
@@ -42,10 +42,10 @@ class AliEmcalContainerUtils {
    * @brief %Type of input object to be created
    */
   enum InputObject_t {
-    kNoDefinedInputObject = -1,    //!< Not initialized type
-    kCaloCells = 0,                //!< Calo cells
-    kCluster = 1,                  //!< Cluster container
-    kTrack = 2,                    //!< Track container
+    kNoDefinedInputObject = -1,    //!<! Not initialized type
+    kCaloCells = 0,                //!<! Calo cells
+    kCluster = 1,                  //!<! Cluster container
+    kTrack = 2,                    //!<! Track container
   };
 
   // Utility functions

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.h
@@ -5,6 +5,8 @@
 
 #include "AliEMCALRecParam.h"
 
+class TStopwatch;
+
 /**
  * @class AliEmcalCorrectionClusterizer
  * @ingroup EMCALCOREFW
@@ -68,6 +70,10 @@ protected:
   void           SetClustersMCLabelFromOriginalClusters();
   void           ClearEMCalClusters();
   
+  TH1F* fHistCPUTime;                                     //!<! CPU time for the Run() function (event loop)
+  TH1F* fHistRealTime;                                    //!<! Real time for the Run() function (event loop)
+  TStopwatch * fTimer;                                    //!<! Timer for the Run() function (event loop)
+
   TClonesArray          *fDigitsArr;                      //!<!digits array
   TObjArray             *fClusterArr;                     //!<!recpoints array
   AliEMCALRecParam      *fRecParam;                       ///< reconstruction parameters container
@@ -122,7 +128,7 @@ protected:
   static RegisterCorrectionComponent<AliEmcalCorrectionClusterizer> reg;
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionClusterizer, 2); // EMCal correction clusterizer component
+  ClassDef(AliEmcalCorrectionClusterizer, 3); // EMCal correction clusterizer component
   /// \endcond
 };
 

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
@@ -721,7 +721,7 @@ void AliEmcalCorrectionTask::AddContainersToComponent(AliEmcalCorrectionComponen
       }
 
       if (checkObjectExists && !(cellCont->GetCells())) {
-        AliFatal(TString::Format("%s: Unable to retrieve input object \"%s\" because it is null. Please check your configuration!", GetName(), str.c_str()));
+        AliFatal(TString::Format("%s: Unable to retrieve cells \"%s\" in input object \"%s\" because the cells are null. Please check your configuration!", GetName(), cellCont->GetBranchName().c_str(), str.c_str()));
       }
 
       // Set the calo cells (may be null)

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
@@ -96,9 +96,10 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
   std::string toString(bool includeYAMLConfigurationInfo = false) const;
   // Set
   void                        SetForceBeamType(BeamType f)                          { fForceBeamType     = f                              ; }
-  void                        SetNeedEmcalGeometry(Bool_t b)                        { fNeedEmcalGeom = b; }
+  void                        SetNeedEmcalGeometry(Bool_t b)                        { fNeedEmcalGeom     = b                              ; }
   // Centrality options
   void                        SetUseNewCentralityEstimation(Bool_t b)               { fUseNewCentralityEstimation = b                     ; }
+  void                        SetCentralityEstimator(const char * c)                { fCentEst           = c                              ; }
   virtual void                SetNCentBins(Int_t n)                                 { fNcentBins         = n                              ; }
   void                        SetCentRange(Double_t min, Double_t max)              { fMinCent           = min  ; fMaxCent = max          ; }
 

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -73,8 +73,8 @@ Clusterizer:                                        # Clusterizer component
     enabled: false                                  # Whether to enable the task
     createHistos: false                             # Whether the task should create output histograms
     clusterizer: kClusterizerv2                     # Type of clusterizer to use. Possible options are defined in the header of the clusterizer
-    cellE: 0.05                                     # Minimum cell energy
-    seedE: 0.1                                      # Seed energy threshold
+    cellE: 0.05                                     # Minimum cell energy (GeV)
+    seedE: 0.1                                      # Seed energy threshold (GeV)
     cellTimeMin: -1                                 # Min cell time (s)
     cellTimeMax: +1                                 # Max cell time (s)
     clusterTimeLength: 1                            # Maximum time difference between the digits inside EMC cluster (s)


### PR DESCRIPTION
Changes include:
- Adding timing information to the clusterizer (Note: You need to enable
  histogram creation for the timer to run!)
- Clarify error when cells are missing
- Set the centrality estimator in the correction task
- Comment on the units of the clusterizer min cell and seed energies