### PR TITLE
Unique event ID correctly evaluated and propagated to tracks

### DIFF
--- a/PWG/Tools/AliBasicParticle.h
+++ b/PWG/Tools/AliBasicParticle.h
@@ -47,21 +47,21 @@ class AliBasicParticle : public AliVParticle
     virtual Int_t   PdgCode()     const { AliFatal("Not implemented"); return 0; }
     virtual const Double_t *PID() const { AliFatal("Not implemented"); return 0; }
 
-    virtual UInt_t GetEventIndex()const { return fEventIndex; }
+    virtual Long64_t GetEventIndex()const { return fEventIndex; }
     virtual Bool_t IsEqual(const TObject* obj) const { return (obj->GetUniqueID() == GetUniqueID()); }
     virtual Bool_t IsInSameEvent(const AliBasicParticle* obj) const { return (obj->GetEventIndex() == GetEventIndex()); }
 
     virtual void SetPhi(Double_t phi) { fPhi = phi; }
-    virtual void SetEventIndex(UInt_t val) { fEventIndex = val; }
+    virtual void SetEventIndex(Long64_t val) { fEventIndex = val; }
 
   private:
     Float_t fEta;      // eta
     Float_t fPhi;      // phi
     Float_t fpT;       // pT
     Short_t fCharge;   // charge
-    UInt_t  fEventIndex;// event index
+    Long64_t fEventIndex;// event index
 
-    ClassDef( AliBasicParticle, 2); // very basic particle class used for correlation analyses
+    ClassDef( AliBasicParticle, 3); // very basic particle class used for correlation analyses
 };
 
 #endif

--- a/PWGCF/Correlations/Base/AliUEHistograms.cxx
+++ b/PWGCF/Correlations/Base/AliUEHistograms.cxx
@@ -649,8 +649,6 @@ void AliUEHistograms::FillCorrelations(Double_t centrality, Float_t zVtx, AliUEH
 	    particle = (AliVParticle*) mixed->UncheckedAt(j);
 	  
 	  // check if both particles point to the same element (does not occur for mixed events, but if subsets are mixed within the same event)
-	  if (mixed && triggerParticle->IsEqual(particle))
-	    continue;
 	  if (fCheckEventNumberInCorrelation)
 	  {
 	    AliBasicParticle* triggerParticleBasic = dynamic_cast<AliBasicParticle*>(triggerParticle);
@@ -664,6 +662,8 @@ void AliUEHistograms::FillCorrelations(Double_t centrality, Float_t zVtx, AliUEH
 	    if(triggerParticleBasic->IsInSameEvent(particleBasic))
 	      continue;
 	  }
+	  else if (mixed && triggerParticle->IsEqual(particle))
+	    continue;
 	  
 	  if (triggerParticle->Charge() * particle->Charge() > 0)
 	    continue;
@@ -725,8 +725,6 @@ void AliUEHistograms::FillCorrelations(Double_t centrality, Float_t zVtx, AliUEH
           particle = (AliVParticle*) mixed->UncheckedAt(j);
         
         // check if both particles point to the same element (does not occur for mixed events, but if subsets are mixed within the same event)
-        if (mixed && triggerParticle->IsEqual(particle))
-          continue;
         if (fCheckEventNumberInCorrelation)
         {
           AliBasicParticle* triggerParticleBasic = dynamic_cast<AliBasicParticle*>(triggerParticle);
@@ -737,6 +735,8 @@ void AliUEHistograms::FillCorrelations(Double_t centrality, Float_t zVtx, AliUEH
           if(triggerParticleBasic->IsInSameEvent(particleBasic))
             continue;
         }
+        else if (mixed && triggerParticle->IsEqual(particle))
+          continue;
         
         if (fPtOrder)
 	  if (particle->Pt() >= triggerParticle->Pt())

--- a/PWGCF/Correlations/DPhi/AliAnalysisTaskPhiCorrelations.cxx
+++ b/PWGCF/Correlations/DPhi/AliAnalysisTaskPhiCorrelations.cxx
@@ -1610,6 +1610,12 @@ TObjArray* AliAnalysisTaskPhiCorrelations::CloneAndReduceTrackList(TObjArray* tr
     else
       copy = new AliBasicParticle(particle->Eta(), particle->Phi(), particle->Pt(), particle->Charge());
     copy->SetUniqueID(particle->GetUniqueID());
+
+    // Set unique event index if input tracks are AliBasicParticles
+    AliBasicParticle* particleBasic = dynamic_cast<AliBasicParticle*>(particle);
+    if(particleBasic)
+      copy->SetEventIndex(particleBasic->GetEventIndex());
+
     tracksClone->Add(copy);
   }
   

--- a/PWGCF/Correlations/DPhi/AliAnalysisTaskPhiCorrelations.cxx
+++ b/PWGCF/Correlations/DPhi/AliAnalysisTaskPhiCorrelations.cxx
@@ -56,6 +56,7 @@
 
 #include "AliEventPoolManager.h"
 #include "AliBasicParticle.h"
+#include "AliVHeader.h"
 
 #include "AliESDZDC.h"
 #include "AliESDtrackCuts.h"
@@ -1827,7 +1828,7 @@ TObjArray* AliAnalysisTaskPhiCorrelations::GetParticlesFromDetector(AliVEvent* i
 	  {
 	    AliBasicParticle* particle = new AliBasicParticle((AliVVZERO::GetVZEROEtaMax(i) + AliVVZERO::GetVZEROEtaMin(i)) / 2, AliVVZERO::GetVZEROAvgPhi(i), 1.1, 0); // fix pT = 1.1 and charge = 0
 	    particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + j + i * 1000) * 10 + idet);
-	    particle->SetEventIndex(fAnalyseUE->GetEventCounter());
+	    particle->SetEventIndex(GetUniqueEventID(inputEvent));
 	    
 	    obj->Add(particle);
 	  }
@@ -1855,7 +1856,7 @@ TObjArray* AliAnalysisTaskPhiCorrelations::GetParticlesFromDetector(AliVEvent* i
 	  
 	  AliBasicParticle* particle = new AliBasicParticle(eta,phi, pT, 0); // pT = TMath::Abs(trklets->GetDeltaPhi(itrklets)) in mrad and charge = 0
 	  particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + itrklets) * 10 + idet);
-	  particle->SetEventIndex(fAnalyseUE->GetEventCounter());
+	  particle->SetEventIndex(GetUniqueEventID(inputEvent));
 	  
 	  obj->Add(particle);
        	}      
@@ -1879,7 +1880,7 @@ TObjArray* AliAnalysisTaskPhiCorrelations::GetParticlesFromDetector(AliVEvent* i
 	
 	AliBasicParticle* particle = new AliBasicParticle(eta,track->Phi(), track->Pt(), track->Charge()); 
 	particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + iTrack) * 10 + idet);
-	particle->SetEventIndex(fAnalyseUE->GetEventCounter());
+	particle->SetEventIndex(GetUniqueEventID(inputEvent));
 	
 	obj->Add(particle);
       }
@@ -1951,7 +1952,7 @@ TObjArray* AliAnalysisTaskPhiCorrelations::GetParticlesFromDetector(AliVEvent* i
           new AliBasicParticle(track->Eta(), track->Phi(), track->Pt(), track->Charge());
         // NOTE "+ idet" is missing here on purpose as the tracks are the same as in the case of idet == 0
         particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + iTrack) * 10);
-        particle->SetEventIndex(fAnalyseUE->GetEventCounter());
+        particle->SetEventIndex(GetUniqueEventID(inputEvent));
         obj->Add(particle);
       }
     }
@@ -2004,7 +2005,7 @@ TObjArray* AliAnalysisTaskPhiCorrelations::GetParticlesFromDetector(AliVEvent* i
       else
         particle->SetUniqueID((fAnalyseUE->GetEventCounter() * 50000 + iParticle) * 10 + idet);
 
-      particle->SetEventIndex(fAnalyseUE->GetEventCounter());
+      particle->SetEventIndex(GetUniqueEventID(inputEvent));
 
       obj->Add(particle);
     }
@@ -2046,6 +2047,17 @@ Bool_t AliAnalysisTaskPhiCorrelations::InitiateEventPlane(Double_t& evtPlanePhi,
     evtPlanePhi = evtPlane->CalculateVZEROEventPlane(inputEvent, 10, 2, qx, qy);
     return 1;
   }
+  else
+    return 0;
+}
+
+//____________________________________________________________________
+Long64_t AliAnalysisTaskPhiCorrelations::GetUniqueEventID(AliVEvent* inputEvent)
+{
+  // Get event ID from header
+  AliVHeader* eventIDHeader = inputEvent->GetHeader();
+  if(eventIDHeader)
+    return eventIDHeader->GetEventIdAsLong();
   else
     return 0;
 }

--- a/PWGCF/Correlations/DPhi/AliAnalysisTaskPhiCorrelations.h
+++ b/PWGCF/Correlations/DPhi/AliAnalysisTaskPhiCorrelations.h
@@ -197,6 +197,7 @@ private:
   TObjArray* GetParticlesFromDetector(AliVEvent* inputEvent, Int_t idet);
   Bool_t IsMuEvent();
   Bool_t InitiateEventPlane(Double_t& evtPlanePhi, AliVEvent* inputEvent);
+  Long64_t GetUniqueEventID(AliVEvent* inputEvent);
 
   // General configuration
   Int_t               fDebug;           //  Debug flag


### PR DESCRIPTION
This is a bug fix. Before, the unique event ID was only unique on a per-task level.
With this commit, the event ID is taken from the header. In addition, the ID is now correctly set for cloned tracks.
