### PR TITLE
Updates for the HF multi-trial class and the D-tagged jet raw yield uncertainty

### DIFF
--- a/PWGHF/jetsHF/AliDJetRawYieldUncertainty.h
+++ b/PWGHF/jetsHF/AliDJetRawYieldUncertainty.h
@@ -17,10 +17,13 @@
  * See cxx source for full Copyright notice                               */
 
 #include <TObject.h>
+#include <vector>
 
 class TH1D;
 class TH2D;
 class TH1F;
+class TCanvas;
+class AliHFMultiTrials;
 
 class AliDJetVReader;
 
@@ -91,7 +94,7 @@ public:
 
   static void FitReflDistr(Int_t nPtBins, TString inputfile, TString fitType = "DoubleGaus");
 
-  Bool_t RunMultiTrial();
+  AliHFMultiTrials* RunMultiTrial();
   Bool_t CombineMultiTrialOutcomes();
 
   Bool_t ExtractInputMassPlot();
@@ -99,6 +102,8 @@ public:
   Bool_t EvaluateUncertainty();
   Bool_t EvaluateUncertaintyEffScale();
   Bool_t EvaluateUncertaintySideband();
+
+  Bool_t Success() const { return fSuccess; }
 
   Bool_t GenerateJetPtSpectrum(TH2* hInvMassJetPt, Double_t mean, Double_t sigma, Double_t bkg, Int_t iDbin, TH1* hjetpt, TH1* hjetpt_s, TH1* hjetpt_s1, TH1* hjetpt_s2);
 
@@ -168,6 +173,11 @@ protected:
   TH1F             **fJetSpectrSBVars            ; //!<!Array of jet spectrum histograms, one per variation (sideband approach)
   TH1F              *fJetSpectrSBDef             ; //!<!Array of jet spectrum histograms, default trial (sideband approach)
   TH1F             **fJetPtBinYieldDistribution  ; //!<!Array of histograms with yield distributions from the trials for each pT(jet)
+
+  Bool_t             fSuccess                    ; //!<!Status of the last run
+
+  std::vector<TCanvas*>
+                     fCanvases                   ; //!<!Canvases created by this class
 
 private:
   ClassDef(AliDJetRawYieldUncertainty,1);

--- a/PWGHF/jetsHF/macros/ExtractDJetRawYieldUncertainty.C
+++ b/PWGHF/jetsHF/macros/ExtractDJetRawYieldUncertainty.C
@@ -46,9 +46,11 @@ void EvaluateBinPerBinUncertainty(
     return;
   }
 
-  Bool_t multitrial = interface->RunMultiTrial();
-  if (!multitrial) {
+  AliHFMultiTrials* multitrial = interface->RunMultiTrial();
+  if (!multitrial || !interface->Success()) {
     printf("Error in running the MultiTrial code! Exiting...\n");
+    delete multitrial;
+    delete interface;
     return;
   }
 

--- a/PWGHF/vertexingHF/AliHFMassFitter.cxx
+++ b/PWGHF/vertexingHF/AliHFMassFitter.cxx
@@ -50,7 +50,7 @@ using std::endl;
 ClassImp(AliHFMassFitter);
 /// \endcond
 
- //************** constructors
+//************** constructors
 AliHFMassFitter::AliHFMassFitter() : 
   TNamed(),
   fhistoInvMass(0),
@@ -83,7 +83,7 @@ AliHFMassFitter::AliHFMassFitter() :
   fContourGraph(0)
 {
   // default constructor
- 
+
   cout<<"Default constructor:"<<endl;
   cout<<"Remember to set the Histo, the Type, the FixPar"<<endl;
 
@@ -181,7 +181,7 @@ AliHFMassFitter::AliHFMassFitter(const AliHFMassFitter &mfit):
   fContourGraph(mfit.fContourGraph)
 {
   //copy constructor
-  
+
   if(mfit.fParsSize > 0){
     fFitPars=new Float_t[fParsSize];
     fFixPar=new Bool_t[fNFinalPars];
@@ -204,9 +204,9 @@ AliHFMassFitter::~AliHFMassFitter() {
   delete fntuParam;
 
   delete[] fFitPars;
-  
+
   delete[] fFixPar;
-  
+
 }
 
 //_________________________________________________________________________
@@ -242,12 +242,12 @@ AliHFMassFitter& AliHFMassFitter::operator=(const AliHFMassFitter &mfit){
 
   if(mfit.fParsSize > 0){
     delete[] fFitPars;
-    
+
     fFitPars=new Float_t[fParsSize];
     memcpy(fFitPars,mfit.fFitPars,mfit.fParsSize*sizeof(Float_t));
 
     delete[] fFixPar;
-    
+
     fFixPar=new Bool_t[fNFinalPars];
     memcpy(fFixPar,mfit.fFixPar,mfit.fNFinalPars*sizeof(Float_t));
   }
@@ -378,7 +378,7 @@ Bool_t AliHFMassFitter::GetFixThisParam(Int_t thispar)const{
 
   }
   return fFixPar[thispar];
- 
+
 }
 
 //___________________________________________________________________________
@@ -392,15 +392,15 @@ void AliHFMassFitter::SetHisto(const TH1F *histoToFit){
 //___________________________________________________________________________
 
 void AliHFMassFitter::SetType(Int_t fittypeb, Int_t fittypes) {
-  
+
   //set the type of fit to perform for signal and background
-  
+
   ftypeOfFit4Bkg = fittypeb; 
   ftypeOfFit4Sgn = fittypes; 
-  
+
   ComputeParSize();
   fFitPars = new Float_t[fParsSize];
-  
+
   SetDefaultFixParam();
 }
 
@@ -425,7 +425,7 @@ void AliHFMassFitter::InitNtuParam(TString ntuname) {
 
   fntuParam=0;
   fntuParam=new TNtuple(ntuname.Data(),"Contains fit parameters","intbkg1:slope1:conc1:intGB:meanGB:sigmaGB:intbkg2:slope2:conc2:inttot:slope3:conc3:intsgn:meansgn:sigmasgn:intbkg1Err:slope1Err:conc1Err:intGBErr:meanGBErr:sigmaGBErr:intbkg2Err:slope2Err:conc2Err:inttotErr:slope3Err:conc3Err:intsgnErr:meansgnErr:sigmasgnErr");
-  
+
 }
 
 //_________________________________________________________________________
@@ -436,40 +436,40 @@ void AliHFMassFitter::FillNtuParam() {
   Float_t nothing=0.;
 
   if (ftypeOfFit4Bkg==2) {
-      fntuParam->SetBranchAddress("intbkg1",&fFitPars[0]);
-      fntuParam->SetBranchAddress("slope1",&fFitPars[1]);
-      fntuParam->SetBranchAddress("conc1",&fFitPars[2]);
-      fntuParam->SetBranchAddress("intGB",&fFitPars[3]);
-      fntuParam->SetBranchAddress("meanGB",&fFitPars[4]);
-      fntuParam->SetBranchAddress("sigmaGB",&fFitPars[5]);
-      fntuParam->SetBranchAddress("intbkg2",&fFitPars[6]);
-      fntuParam->SetBranchAddress("slope2",&fFitPars[7]);
-      fntuParam->SetBranchAddress("conc2",&fFitPars[8]);
-      fntuParam->SetBranchAddress("inttot",&fFitPars[9]);
-      fntuParam->SetBranchAddress("slope3",&fFitPars[10]);
-      fntuParam->SetBranchAddress("conc3",&fFitPars[11]);
-      fntuParam->SetBranchAddress("intsgn",&fFitPars[12]);
-      fntuParam->SetBranchAddress("meansgn",&fFitPars[13]);
-      fntuParam->SetBranchAddress("sigmasgn",&fFitPars[14]);
+    fntuParam->SetBranchAddress("intbkg1",&fFitPars[0]);
+    fntuParam->SetBranchAddress("slope1",&fFitPars[1]);
+    fntuParam->SetBranchAddress("conc1",&fFitPars[2]);
+    fntuParam->SetBranchAddress("intGB",&fFitPars[3]);
+    fntuParam->SetBranchAddress("meanGB",&fFitPars[4]);
+    fntuParam->SetBranchAddress("sigmaGB",&fFitPars[5]);
+    fntuParam->SetBranchAddress("intbkg2",&fFitPars[6]);
+    fntuParam->SetBranchAddress("slope2",&fFitPars[7]);
+    fntuParam->SetBranchAddress("conc2",&fFitPars[8]);
+    fntuParam->SetBranchAddress("inttot",&fFitPars[9]);
+    fntuParam->SetBranchAddress("slope3",&fFitPars[10]);
+    fntuParam->SetBranchAddress("conc3",&fFitPars[11]);
+    fntuParam->SetBranchAddress("intsgn",&fFitPars[12]);
+    fntuParam->SetBranchAddress("meansgn",&fFitPars[13]);
+    fntuParam->SetBranchAddress("sigmasgn",&fFitPars[14]);
 
-      fntuParam->SetBranchAddress("intbkg1Err",&fFitPars[15]);
-      fntuParam->SetBranchAddress("slope1Err",&fFitPars[16]);
-      fntuParam->SetBranchAddress("conc1Err",&fFitPars[17]);
-      fntuParam->SetBranchAddress("intGBErr",&fFitPars[18]);
-      fntuParam->SetBranchAddress("meanGBErr",&fFitPars[19]);
-      fntuParam->SetBranchAddress("sigmaGBErr",&fFitPars[20]);
-      fntuParam->SetBranchAddress("intbkg2Err",&fFitPars[21]);
-      fntuParam->SetBranchAddress("slope2Err",&fFitPars[22]);
-      fntuParam->SetBranchAddress("conc2Err",&fFitPars[23]);
-      fntuParam->SetBranchAddress("inttotErr",&fFitPars[24]);
-      fntuParam->SetBranchAddress("slope3Err",&fFitPars[25]);
-      fntuParam->SetBranchAddress("conc3Err",&fFitPars[26]);
-      fntuParam->SetBranchAddress("intsgnErr",&fFitPars[27]);
-      fntuParam->SetBranchAddress("meansgnErr",&fFitPars[28]);
-      fntuParam->SetBranchAddress("sigmasgnErr",&fFitPars[29]);
-    
+    fntuParam->SetBranchAddress("intbkg1Err",&fFitPars[15]);
+    fntuParam->SetBranchAddress("slope1Err",&fFitPars[16]);
+    fntuParam->SetBranchAddress("conc1Err",&fFitPars[17]);
+    fntuParam->SetBranchAddress("intGBErr",&fFitPars[18]);
+    fntuParam->SetBranchAddress("meanGBErr",&fFitPars[19]);
+    fntuParam->SetBranchAddress("sigmaGBErr",&fFitPars[20]);
+    fntuParam->SetBranchAddress("intbkg2Err",&fFitPars[21]);
+    fntuParam->SetBranchAddress("slope2Err",&fFitPars[22]);
+    fntuParam->SetBranchAddress("conc2Err",&fFitPars[23]);
+    fntuParam->SetBranchAddress("inttotErr",&fFitPars[24]);
+    fntuParam->SetBranchAddress("slope3Err",&fFitPars[25]);
+    fntuParam->SetBranchAddress("conc3Err",&fFitPars[26]);
+    fntuParam->SetBranchAddress("intsgnErr",&fFitPars[27]);
+    fntuParam->SetBranchAddress("meansgnErr",&fFitPars[28]);
+    fntuParam->SetBranchAddress("sigmasgnErr",&fFitPars[29]);
+
   } else {
-    
+
     if(ftypeOfFit4Bkg==3){
       fntuParam->SetBranchAddress("intbkg1",&fFitPars[0]);
       fntuParam->SetBranchAddress("slope1",&nothing);
@@ -537,7 +537,7 @@ void AliHFMassFitter::FillNtuParam() {
       fntuParam->SetBranchAddress("meansgnErr",&fFitPars[22]);
       fntuParam->SetBranchAddress("sigmasgnErr",&fFitPars[23]);
     }
-     
+
   }
   fntuParam->TTree::Fill();
 }
@@ -566,7 +566,7 @@ void AliHFMassFitter::RebinMass(Int_t bingroup){
     fNbin=nbinshisto;
     cout<<"Kept original number of bins: "<<fNbin<<endl;
   } else{
-   
+
     while(nbinshisto%bingroup != 0) {
       bingroup--;
     }
@@ -575,7 +575,7 @@ void AliHFMassFitter::RebinMass(Int_t bingroup){
     fNbin = fhistoInvMass->GetNbinsX();
     cout<<"New number of bins: "<<fNbin<<endl;
   } 
-       
+
 }
 
 //************* fit
@@ -593,9 +593,9 @@ Double_t AliHFMassFitter::FitFunction4MassDistr (Double_t *x, Double_t *par){
   // par[2] = gaussian integral
   // par[3] = gaussian mean
   // par[4] = gaussian sigma
-  
+
   Double_t total,bkg=0,sgn=0;
-  
+
   if (ftypeOfFit4Bkg==0 || ftypeOfFit4Bkg==1) {
     if(ftypeOfFit4Sgn == 0) {
 
@@ -613,34 +613,34 @@ Double_t AliHFMassFitter::FitFunction4MassDistr (Double_t *x, Double_t *par){
 
   //polynomial fit
 
-    // par[0] = tot integral
-    // par[1] = coef1
-    // par[2] = coef2
-    // par[3] = gaussian integral
-    // par[4] = gaussian mean
-    // par[5] = gaussian sigma
+  // par[0] = tot integral
+  // par[1] = coef1
+  // par[2] = coef2
+  // par[3] = gaussian integral
+  // par[4] = gaussian mean
+  // par[5] = gaussian sigma
 
   if (ftypeOfFit4Bkg==2) {
-    
+
     if(ftypeOfFit4Sgn == 0) {
-      
+
       Double_t parbkg[3] = {par[0]-par[3], par[1], par[2]};
       bkg = FitFunction4Bkg(x,parbkg);
     }
     if(ftypeOfFit4Sgn == 1) {
-      
+
       Double_t parbkg[6] = {par[3],par[4],ffactor*par[5],par[0]-2*par[3], par[1], par[2]};
-     bkg = FitFunction4Bkg(x,parbkg);
+      bkg = FitFunction4Bkg(x,parbkg);
     }
-    
+
     sgn = FitFunction4Sgn(x,&par[3]);
   }
 
   if (ftypeOfFit4Bkg==3) {
-   
+
     if(ftypeOfFit4Sgn == 0) {
-	bkg=FitFunction4Bkg(x,par);
-	sgn=FitFunction4Sgn(x,&par[1]);
+      bkg=FitFunction4Bkg(x,par);
+      sgn=FitFunction4Sgn(x,&par[1]);
     }
     if(ftypeOfFit4Sgn == 1) {
       Double_t parbkg[4]={par[1],par[2],ffactor*par[3],par[0]};
@@ -651,21 +651,21 @@ Double_t AliHFMassFitter::FitFunction4MassDistr (Double_t *x, Double_t *par){
 
   //Power fit
 
-    // par[0] = tot integral
-    // par[1] = coef1
-    // par[2] = gaussian integral
-    // par[3] = gaussian mean
-    // par[4] = gaussian sigma
+  // par[0] = tot integral
+  // par[1] = coef1
+  // par[2] = gaussian integral
+  // par[3] = gaussian mean
+  // par[4] = gaussian sigma
 
   if (ftypeOfFit4Bkg==4) {
-    
+
     if(ftypeOfFit4Sgn == 0) {
-      
+
       Double_t parbkg[2] = {par[0]-par[2], par[1]}; 
       bkg = FitFunction4Bkg(x,parbkg);
     }
     if(ftypeOfFit4Sgn == 1) {
-      
+
       Double_t parbkg[5] = {par[2],par[3],ffactor*par[4],par[0]-par[2], par[1]}; 
       bkg = FitFunction4Bkg(x,parbkg);
     }
@@ -675,28 +675,28 @@ Double_t AliHFMassFitter::FitFunction4MassDistr (Double_t *x, Double_t *par){
 
   //Power and exponential fit
 
-    // par[0] = tot integral
-    // par[1] = coef1
-    // par[2] = coef2
-    // par[3] = gaussian integral
-    // par[4] = gaussian mean
-    // par[5] = gaussian sigma
+  // par[0] = tot integral
+  // par[1] = coef1
+  // par[2] = coef2
+  // par[3] = gaussian integral
+  // par[4] = gaussian mean
+  // par[5] = gaussian sigma
 
   if (ftypeOfFit4Bkg==5) {      
-   
+
     if(ftypeOfFit4Sgn == 0) {
-	Double_t parbkg[3] = {par[0]-par[3],par[1],par[2]}; 
-	bkg = FitFunction4Bkg(x,parbkg); 
+      Double_t parbkg[3] = {par[0]-par[3],par[1],par[2]};
+      bkg = FitFunction4Bkg(x,parbkg);
     }
     if(ftypeOfFit4Sgn == 1) {
-     Double_t parbkg[6] = {par[3],par[4],ffactor*par[5],par[0]-par[3], par[1], par[2]}; 
-     bkg = FitFunction4Bkg(x,parbkg);
+      Double_t parbkg[6] = {par[3],par[4],ffactor*par[5],par[0]-par[3], par[1], par[2]};
+      bkg = FitFunction4Bkg(x,parbkg);
     }
     sgn = FitFunction4Sgn(x,&par[3]);
   }                            
 
   total = bkg + sgn;
-  
+
   return  total;
 }
 
@@ -782,31 +782,31 @@ Double_t AliHFMassFitter::FitFunction4Bkg (Double_t *x, Double_t *par){
     // * [0] = integralBkg;
     // * [1] = b;
     // a(power function) = [0]*([1]+1)/((max-m_pi)^([1]+1)-(min-m_pi)^([1]+1))*(x-m_pi)^[1]
-    {
+  {
     Double_t mpi = TDatabasePDG::Instance()->GetParticle(211)->Mass();
 
     total = par[0+firstPar]*(par[1+firstPar]+1.)/(TMath::Power(fmaxMass-mpi,par[1+firstPar]+1.)-TMath::Power(fminMass-mpi,par[1+firstPar]+1.))*TMath::Power(x[0]-mpi,par[1+firstPar]);
     //    AliInfo("Background function set to: powerlaw");
-    }
-    break;
+  }
+  break;
   case 5:
-   //power function wit exponential
+    //power function wit exponential
     //y=a*Sqrt(x-m_pi)*exp(-b*(x-m_pi))  
-    { 
+  {
     Double_t mpi = TDatabasePDG::Instance()->GetParticle(211)->Mass();
 
     total = par[1+firstPar]*TMath::Sqrt(x[0] - mpi)*TMath::Exp(-1.*par[2+firstPar]*(x[0]-mpi));
     //    AliInfo("Background function set to: wit exponential");
-    } 
-    break;
-//   default:
-//     Types of Fit Functions for Background:
-//     * 0 = exponential;
-//     * 1 = linear;
-//     * 2 = polynomial 2nd order
-//     * 3 = no background"<<endl;
-//     * 4 = Power function 
-//     * 5 = Power function with exponential 
+  }
+  break;
+  //   default:
+  //     Types of Fit Functions for Background:
+  //     * 0 = exponential;
+  //     * 1 = linear;
+  //     * 2 = polynomial 2nd order
+  //     * 3 = no background"<<endl;
+  //     * 4 = Power function
+  //     * 5 = Power function with exponential
 
   }
   return total+gaus2;
@@ -827,7 +827,7 @@ Bool_t AliHFMassFitter::SideBandsBounds(){
     AliError("Left limit of range > mean or right limit of range < mean: change left/right limit or initial mean value");
     return kFALSE;
   } 
-  
+
   //histo limit = fit function limit
   if((TMath::Abs(fminMass-minHisto) < 1e-6 || TMath::Abs(fmaxMass - maxHisto) < 1e-6) && (fMass-4.*fSigmaSgn-fminMass) < 1e-6){
     Double_t coeff = (fMass-fminMass)/fSigmaSgn;
@@ -855,7 +855,7 @@ Bool_t AliHFMassFitter::SideBandsBounds(){
   fSideBandl=fhistoInvMass->FindBin(sidebandldouble);
   if (sidebandldouble >= fhistoInvMass->GetBinCenter(fSideBandl)) fSideBandl++;
   sidebandldouble=fhistoInvMass->GetBinLowEdge(fSideBandl);
-  
+
   if(TMath::Abs(tmp-sidebandldouble) > 1e-6){
     cout<<tmp<<" is not allowed, changing it to the nearest value allowed: ";
   }
@@ -882,7 +882,7 @@ Bool_t AliHFMassFitter::SideBandsBounds(){
 //__________________________________________________________________________
 
 void AliHFMassFitter::GetSideBandsBounds(Int_t &left, Int_t &right) const{
-  
+
   // get the range of the side bands
 
   if (fSideBandl==0 && fSideBandr==0){
@@ -926,7 +926,7 @@ Bool_t AliHFMassFitter::CheckRangeFit(){
     cout<<"Left bound "<<tmp<<" is not allowed, changing it to the nearest value allowed: "<<fminMass<<endl;
     leftok=kTRUE;
   }
- 
+
   tmp=fmaxMass;
   //calculate bin corresponding to fmaxMass
   fmaxBinMass=fhistoInvMass->FindBin(fmaxMass);
@@ -938,14 +938,14 @@ Bool_t AliHFMassFitter::CheckRangeFit(){
   }
 
   return (leftok && rightok);
- 
+
 }
 
 //__________________________________________________________________________
 
 Bool_t AliHFMassFitter::MassFitter(Bool_t draw){  
   // Main method of the class: performs the fit of the histogram
-  
+
   //Set default fitter Minuit in order to use gMinuit in the contour plots    
   TVirtualFitter::SetDefaultFitter("Minuit");
 
@@ -1012,7 +1012,7 @@ Bool_t AliHFMassFitter::MassFitter(Bool_t draw){
 
   Bool_t ok=SideBandsBounds();
   if(!ok) return kFALSE;
-  
+
   //sidebands integral - first approx (from histo)
   Double_t sideBandsInt=(Double_t)fhistoInvMass->Integral(fminBinMass,fSideBandl,"width") + (Double_t)fhistoInvMass->Integral(fSideBandr,fmaxBinMass,"width");
   cout<<"------nbin = "<<fNbin<<"\twidth = "<<width<<"\tbinleft = "<<fSideBandl<<"\tbinright = "<<fSideBandr<<endl;
@@ -1021,7 +1021,7 @@ Bool_t AliHFMassFitter::MassFitter(Bool_t draw){
     cout<<"! sideBandsInt <=0. There's a problem, cannot start the fit"<<endl;
     return kFALSE;
   }
-  
+
   /*Fit Bkg*/
 
 
@@ -1031,7 +1031,7 @@ Bool_t AliHFMassFitter::MassFitter(Bool_t draw){
   funcbkg->SetLineColor(2); //red
 
   //first fit for bkg: approx bkgint
- 
+
   switch (ftypeOfFit4Bkg) {
   case 0: //gaus+expo
     funcbkg->SetParNames("BkgInt","Slope"); 
@@ -1056,7 +1056,7 @@ Bool_t AliHFMassFitter::MassFitter(Bool_t draw){
     funcbkg->SetParNames("BkgInt","Coef2");  
     funcbkg->SetParameters(sideBandsInt,0.5);
     break;
- case 5:
+  case 5:
     funcbkg->SetParNames("BkgInt","Coef1","Coef2");
     funcbkg->SetParameters(sideBandsInt, -10., 5.);
     break;
@@ -1067,13 +1067,13 @@ Bool_t AliHFMassFitter::MassFitter(Bool_t draw){
   }
   cout<<"\nBACKGROUND FIT - only combinatorial"<<endl;
   Int_t ftypeOfFit4SgnBkp=ftypeOfFit4Sgn;
-  
+
   Double_t intbkg1=0,slope1=0,conc1=0;
   //if only signal and reflection: skip
   if (!(ftypeOfFit4Bkg==3 && ftypeOfFit4Sgn==1)) {
     ftypeOfFit4Sgn=0;
     fhistoInvMass->Fit(bkgname.Data(),Form("R,%s,0",fFitOption.Data()));
-   
+
     for(Int_t i=0;i<bkgPar;i++){
       fFitPars[i]=funcbkg->GetParameter(i);
       //cout<<i<<"\t"<<funcbkg->GetParameter(i)<<"\t";
@@ -1087,18 +1087,18 @@ Bool_t AliHFMassFitter::MassFitter(Bool_t draw){
     if(ftypeOfFit4Bkg!=3) slope1 = funcbkg->GetParameter(1);
     if(ftypeOfFit4Bkg==2) conc1 = funcbkg->GetParameter(2);
     if(ftypeOfFit4Bkg==5) conc1 = funcbkg->GetParameter(2); 
- 
+
 
     //cout<<"First fit: \nintbkg1 = "<<intbkg1<<"\t(Compare with par0 = "<<funcbkg->GetParameter(0)<<")\nslope1= "<<slope1<<"\nconc1 = "<<conc1<<endl;
   } 
   else cout<<"\t\t//"<<endl;
-  
+
   ftypeOfFit4Sgn=ftypeOfFit4SgnBkp;
   TF1 *funcbkg1=0;
   if (ftypeOfFit4Sgn == 1) {
     cout<<"\nBACKGROUND FIT WITH REFLECTION"<<endl;
     bkgPar+=3;
-    
+
     //cout<<"fNFinalPars = "<<fNFinalPars<<"\tbkgPar = "<<bkgPar<<endl;
 
     funcbkg1 = new TF1(bkg1name.Data(),this,&AliHFMassFitter::FitFunction4Bkg,fminMass,fmaxMass,bkgPar,"AliHFMassFitter","FitFunction4Bkg");
@@ -1108,49 +1108,49 @@ Bool_t AliHFMassFitter::MassFitter(Bool_t draw){
 
     switch (ftypeOfFit4Bkg) {
     case 0:
-	{
-        cout<<"*** Exponential Fit ***"<<endl;
-        funcbkg1->SetParNames("IntGB","MeanGB","SigmaGB","BkgInt","Slope");
-	funcbkg1->SetParameters(0.5*(totInt-intbkg1),fMass,ffactor*fSigmaSgn,intbkg1,slope1);
-	}
-        break;
-     case 1: 
-	{
-	cout<<"*** Linear Fit ***"<<endl;
-        funcbkg1->SetParNames("IntGB","MeanGB","SigmaGB","BkgInt","Slope");
-	funcbkg1->SetParameters(0.5*(totInt-intbkg1),fMass,ffactor*fSigmaSgn,intbkg1,slope1);
-	}
-        break;    
-     case 2:
-        {
-        cout<<"*** Polynomial Fit ***"<<endl;
-        funcbkg1->SetParNames("IntGB","MeanGB","SigmaGB","BkgInt","Coef1","Coef2");
-        funcbkg1->SetParameters(0.5*(totInt-intbkg1),fMass,ffactor*fSigmaSgn,intbkg1,slope1,conc1);
-        }
-        break;
+    {
+      cout<<"*** Exponential Fit ***"<<endl;
+      funcbkg1->SetParNames("IntGB","MeanGB","SigmaGB","BkgInt","Slope");
+      funcbkg1->SetParameters(0.5*(totInt-intbkg1),fMass,ffactor*fSigmaSgn,intbkg1,slope1);
+    }
+    break;
+    case 1:
+    {
+      cout<<"*** Linear Fit ***"<<endl;
+      funcbkg1->SetParNames("IntGB","MeanGB","SigmaGB","BkgInt","Slope");
+      funcbkg1->SetParameters(0.5*(totInt-intbkg1),fMass,ffactor*fSigmaSgn,intbkg1,slope1);
+    }
+    break;
+    case 2:
+    {
+      cout<<"*** Polynomial Fit ***"<<endl;
+      funcbkg1->SetParNames("IntGB","MeanGB","SigmaGB","BkgInt","Coef1","Coef2");
+      funcbkg1->SetParameters(0.5*(totInt-intbkg1),fMass,ffactor*fSigmaSgn,intbkg1,slope1,conc1);
+    }
+    break;
     case 3:
-       //no background: gaus sign+ gaus broadened
-	{
-	cout<<"*** No background Fit ***"<<endl;
-	funcbkg1->SetParNames("IntGB","MeanGB","SigmaGB","Const");
-	funcbkg1->SetParameters(0.5*totInt,fMass,ffactor*fSigmaSgn,0.); 
-	funcbkg1->FixParameter(3,0.);
-	} 
-        break;
-     case 4:
-	{	
- 	cout<<"*** Power function Fit ***"<<endl;
-	funcbkg1->SetParNames("IntGB","MeanGB","SigmaGB","BkgInt","Coef2");
-        funcbkg1->SetParameters(0.5*(totInt-intbkg1),fMass,ffactor*fSigmaSgn,intbkg1,slope1);
-       	}
-        break;
-      case 5:
-	{ 
-	cout<<"*** Power function conv. with exponential Fit ***"<<endl;
-        funcbkg1->SetParNames("IntGB","MeanGB","SigmaGB","BkgInt","Coef1","Coef2");
-        funcbkg1->SetParameters(0.5*(totInt-intbkg1),fMass,ffactor*fSigmaSgn,intbkg1,slope1,conc1);
-	}
-        break;
+      //no background: gaus sign+ gaus broadened
+    {
+      cout<<"*** No background Fit ***"<<endl;
+      funcbkg1->SetParNames("IntGB","MeanGB","SigmaGB","Const");
+      funcbkg1->SetParameters(0.5*totInt,fMass,ffactor*fSigmaSgn,0.);
+      funcbkg1->FixParameter(3,0.);
+    }
+    break;
+    case 4:
+    {
+      cout<<"*** Power function Fit ***"<<endl;
+      funcbkg1->SetParNames("IntGB","MeanGB","SigmaGB","BkgInt","Coef2");
+      funcbkg1->SetParameters(0.5*(totInt-intbkg1),fMass,ffactor*fSigmaSgn,intbkg1,slope1);
+    }
+    break;
+    case 5:
+    {
+      cout<<"*** Power function conv. with exponential Fit ***"<<endl;
+      funcbkg1->SetParNames("IntGB","MeanGB","SigmaGB","BkgInt","Coef1","Coef2");
+      funcbkg1->SetParameters(0.5*(totInt-intbkg1),fMass,ffactor*fSigmaSgn,intbkg1,slope1,conc1);
+    }
+    break;
     }
     //cout<<"Parameters set to: "<<0.5*(totInt-intbkg1)<<"\t"<<fMass<<"\t"<<ffactor*fSigmaSgn<<"\t"<<intbkg1<<"\t"<<slope1<<"\t"<<conc1<<"\t"<<endl;
     //cout<<"Limits: ("<<fminMass<<","<<fmaxMass<<")\tnPar = "<<bkgPar<<"\tgsidebands = "<<fSideBands<<endl;
@@ -1183,7 +1183,7 @@ Bool_t AliHFMassFitter::MassFitter(Bool_t draw){
       fFitPars[fNFinalPars+3*bkgPar-6+i]= 0.;
       cout<<fNFinalPars+3*bkgPar-6+i<<"\t"<<0.<<endl;
     }
-  
+
     for(Int_t i=0;i<bkgPar-3;i++){
       fFitPars[bkgPar+i]=funcbkg->GetParameter(i);
       cout<<bkgPar+i<<"\t"<<funcbkg->GetParameter(i)<<"\t";
@@ -1191,7 +1191,7 @@ Bool_t AliHFMassFitter::MassFitter(Bool_t draw){
       cout<<fNFinalPars+3*bkgPar-3+i<<"\t"<< funcbkg->GetParError(i)<<endl;
     }
 
-   
+
   }
 
   //sidebands integral - second approx (from fit)
@@ -1243,7 +1243,7 @@ Bool_t AliHFMassFitter::MassFitter(Bool_t draw){
   if (fNFinalPars==6){
     funcmass->SetParNames("TotInt","Coef1","Coef2","SgnInt","Mean","Sigma");
     funcmass->SetParameters(totInt,slope1,conc1,sgnInt,fMass,fSigmaSgn);
- 
+
     //cout<<"Parameters set to: "<<totInt<<"\t"<<slope1<<"\t"<<conc1<<"\t"<<sgnInt<<"\t"<<fMass<<"\t"<<fSigmaSgn<<"\t"<<endl;
     //cout<<"Limits: ("<<fminMass<<","<<fmaxMass<<")\tnPar = "<<fNFinalPars<<"\tgsidebands = "<<fSideBands<<endl;
     if(fFixPar[0])funcmass->FixParameter(0,totInt);
@@ -1263,7 +1263,7 @@ Bool_t AliHFMassFitter::MassFitter(Bool_t draw){
     if(fFixPar[1])funcmass->FixParameter(1,sgnInt);
     if(fFixPar[2])funcmass->FixParameter(2,fMass);
     if(fFixPar[3])funcmass->FixParameter(3,fSigmaSgn);
-   //cout<<"Parameters set to: "<<0.5*totInt<<"\t"<<fMass<<"\t"<<fSigmaSgn<<"\t"<<endl;
+    //cout<<"Parameters set to: "<<0.5*totInt<<"\t"<<fMass<<"\t"<<fSigmaSgn<<"\t"<<endl;
     //cout<<"Limits: ("<<fminMass<<","<<fmaxMass<<")\tnPar = "<<fNFinalPars<<"\tgsidebands = "<<fSideBands<<endl;
 
   }
@@ -1295,8 +1295,8 @@ Bool_t AliHFMassFitter::MassFitter(Bool_t draw){
   for(Int_t i=0;i<2*(fNFinalPars+2*bkgPar-3);i++){
     cout<<i<<"\t"<<fFitPars[i]<<endl;
     }
-  */
-  
+   */
+
   if(funcmass->GetParameter(fNFinalPars-1) <0 || funcmass->GetParameter(fNFinalPars-2) <0 || funcmass->GetParameter(fNFinalPars-3) <0 ) {
     cout<<"IntS or mean or sigma negative. You may tray to SetInitialGaussianSigma(..) and SetInitialGaussianMean(..)"<<endl;
     return kFALSE;
@@ -1311,51 +1311,51 @@ Bool_t AliHFMassFitter::MassFitter(Bool_t draw){
     for (Int_t kpar=1; kpar<fNFinalPars;kpar++){
 
       for(Int_t jpar=kpar+1;jpar<fNFinalPars;jpar++){
-	cout<<"Par "<<kpar<<" and "<<jpar<<endl;
-	
-	// produce 2 contours per couple of parameters
-	TGraph* cont[2] = {0x0, 0x0};
-	const Double_t errDef[2] = {1., 4.}; 
-	for (Int_t i=0; i<2; i++) {
-	  gMinuit->SetErrorDef(errDef[i]);
-	  cont[i] = (TGraph*)gMinuit->Contour(80,kpar,jpar);
-	  cout<<"Minuit Status = "<<gMinuit->GetStatus()<<endl;
-	}
-	
-	if(!cont[0] || !cont[1]){
-	  cout<<"Skipping par "<<kpar<<" vs par "<<jpar<<endl;
-	  continue;
-	}
-	  
-	// set graph titles and add them to the list
-	TString title = "Contour plot";
-	TString titleX = funcmass->GetParName(kpar);
-	TString titleY = funcmass->GetParName(jpar);
-	for (Int_t i=0; i<2; i++) {
-	  cont[i]->SetName( Form("cperr%d_%d%d", i, kpar, jpar) );
-	  cont[i]->SetTitle(title);
-	  cont[i]->GetXaxis()->SetTitle(titleX);
-	  cont[i]->GetYaxis()->SetTitle(titleY);
-	  cont[i]->GetYaxis()->SetLabelSize(0.033);
-	  cont[i]->GetYaxis()->SetTitleSize(0.033);
-	  cont[i]->GetYaxis()->SetTitleOffset(1.67);
-	  
-	  fContourGraph->Add(cont[i]);
-	}
-	
-	// plot them
-	TString cvname = Form("c%d%d", kpar, jpar);
-	TCanvas *c4=new TCanvas(cvname,cvname,600,600);
-	c4->cd();
-	cont[1]->SetFillColor(38);
-	cont[1]->Draw("alf");
-	cont[0]->SetFillColor(9);
-	cont[0]->Draw("lf");
-        
+        cout<<"Par "<<kpar<<" and "<<jpar<<endl;
+
+        // produce 2 contours per couple of parameters
+        TGraph* cont[2] = {0x0, 0x0};
+        const Double_t errDef[2] = {1., 4.};
+        for (Int_t i=0; i<2; i++) {
+          gMinuit->SetErrorDef(errDef[i]);
+          cont[i] = (TGraph*)gMinuit->Contour(80,kpar,jpar);
+          cout<<"Minuit Status = "<<gMinuit->GetStatus()<<endl;
+        }
+
+        if(!cont[0] || !cont[1]){
+          cout<<"Skipping par "<<kpar<<" vs par "<<jpar<<endl;
+          continue;
+        }
+
+        // set graph titles and add them to the list
+        TString title = "Contour plot";
+        TString titleX = funcmass->GetParName(kpar);
+        TString titleY = funcmass->GetParName(jpar);
+        for (Int_t i=0; i<2; i++) {
+          cont[i]->SetName( Form("cperr%d_%d%d", i, kpar, jpar) );
+          cont[i]->SetTitle(title);
+          cont[i]->GetXaxis()->SetTitle(titleX);
+          cont[i]->GetYaxis()->SetTitle(titleY);
+          cont[i]->GetYaxis()->SetLabelSize(0.033);
+          cont[i]->GetYaxis()->SetTitleSize(0.033);
+          cont[i]->GetYaxis()->SetTitleOffset(1.67);
+
+          fContourGraph->Add(cont[i]);
+        }
+
+        // plot them
+        TString cvname = Form("c%d%d", kpar, jpar);
+        TCanvas *c4=new TCanvas(cvname,cvname,600,600);
+        c4->cd();
+        cont[1]->SetFillColor(38);
+        cont[1]->Draw("alf");
+        cont[0]->SetFillColor(9);
+        cont[0]->Draw("lf");
+
       }
-      
+
     }
-    
+
   }
 
   if (ftypeOfFit4Sgn == 1) {
@@ -1363,10 +1363,10 @@ Bool_t AliHFMassFitter::MassFitter(Bool_t draw){
   }
   delete funcbkg;
   delete funcmass;
-  
+
   AddFunctionsToHisto();
   if (draw) DrawFit();
- 
+
 
   return kTRUE;
 }
@@ -1471,19 +1471,19 @@ Double_t AliHFMassFitter::GetBkgChiSquare() {
   Int_t binmin, binmax, binl, binr;
   Double_t mean  = GetMean();
   Double_t sigma = GetSigma();
-  
+
   fNpfits = 0;
-  
+
   xmin = bkgfunc->GetXmin();
   xmax = bkgfunc->GetXmax();
   xl   = mean-3*sigma;
   xr   = mean+3*sigma;
-  
+
   binmin = fhistoInvMass->FindBin(xmin);
   binmax = fhistoInvMass->FindBin(xmax);
   binl   = fhistoInvMass->FindBin(xl);
   binr   = fhistoInvMass->FindBin(xr);
-  
+
   for (Int_t ib=binmin; ib<=binmax; ib++) {
     if (!(ib>=binl && ib<=binr)) {
       Float_t yobs = fhistoInvMass->GetBinContent(ib);
@@ -1505,11 +1505,11 @@ Double_t AliHFMassFitter::GetBkgReducedChiSquare() {
     cout<<"Bkg function not found"<<endl;
     return -1;
   }
- 
+
   Double_t chi2 = GetBkgChiSquare();
   Int_t npar    = bkgfunc->GetNpar();
   Int_t ndf     = fNpfits - npar;
- 
+
   return chi2/ndf;
 }
 
@@ -1529,7 +1529,7 @@ Double_t AliHFMassFitter::GetFitProbability() const{
 //_________________________________________________________________________
 void  AliHFMassFitter::GetFitPars(Float_t *vector) const {
   // Return fit parameters
-  
+
   for(Int_t i=0;i<fParsSize;i++){
     vector[i]=fFitPars[i];
   }
@@ -1644,10 +1644,10 @@ void AliHFMassFitter::AddFunctionsToHisto(){
     hlist->Add((TF1*)bfullrange->Clone());
     hlist->Add((TF1*)blastpar->Clone());
     hlist->ls();
-  
+
     delete bfullrange;
     delete blastpar;
-    
+
   }
 
 
@@ -1674,7 +1674,7 @@ void AliHFMassFitter::WriteHisto(TString path) const {
 
   path += "HFMassFitterOutput.root";
   TFile *output;
- 
+
   if (fcounter == 1) output = new TFile(path.Data(),"recreate");
   else output = new TFile(path.Data(),"update");
   output->cd();
@@ -1687,7 +1687,7 @@ void AliHFMassFitter::WriteHisto(TString path) const {
   cout<<fcounter<<" "<<hget->GetName()<<" written in "<<path<<endl;
 
   delete output;
-  
+
 }
 
 //_________________________________________________________________________
@@ -1707,7 +1707,7 @@ void AliHFMassFitter::WriteNtuple(TString path) const{
     //delete nget;
     nget=NULL;
   }
-  */
+   */
 
   delete output;
 }
@@ -1715,7 +1715,7 @@ void AliHFMassFitter::WriteNtuple(TString path) const{
 //_________________________________________________________________________
 void AliHFMassFitter::WriteCanvas(TString userIDstring,TString path,Double_t nsigma,Int_t writeFitInfo,Bool_t draw) const{
 
- //write the canvas in a root file
+  //write the canvas in a root file
 
   gStyle->SetOptStat(0);
   gStyle->SetCanvasColor(0);
@@ -1784,12 +1784,12 @@ void AliHFMassFitter::PlotFit(TVirtualPad* pd,Double_t nsigma,Int_t writeFitInfo
   cout<<"Verbosity = "<<writeFitInfo<<endl;
 
   TH1F* hdraw=GetHistoClone();
-  
+
   if(!hdraw->GetFunction("funcmass") && !hdraw->GetFunction("funcbkgFullRange") && !hdraw->GetFunction("funcbkgRecalc")&& !hdraw->GetFunction("funcbkgonly")){
     cout<<"Probably fit failed and you didn't try to refit with background only, there's no function to be drawn"<<endl;
     return;
   }
- 
+
   if(hdraw->GetFunction("funcbkgonly")){ //Warning! if this function is present, no chance to draw the other!
     cout<<"Drawing background fit only"<<endl;
     hdraw->SetMinimum(0);
@@ -1805,28 +1805,28 @@ void AliHFMassFitter::PlotFit(TVirtualPad* pd,Double_t nsigma,Int_t writeFitInfo
       pinfo->SetFillStyle(0);
       TF1* f=hdraw->GetFunction("funcbkgonly");
       for (Int_t i=0;i<fNFinalPars-3;i++){
-	pinfo->SetTextColor(kBlue+3);
-	TString str=Form("%s = %.3f #pm %.3f",f->GetParName(i),f->GetParameter(i),f->GetParError(i));
-	pinfo->AddText(str);
+        pinfo->SetTextColor(kBlue+3);
+        TString str=Form("%s = %.3f #pm %.3f",f->GetParName(i),f->GetParameter(i),f->GetParError(i));
+        pinfo->AddText(str);
       }
 
       pinfo->AddText(Form("Reduced #chi^{2} = %.3f",f->GetChisquare()/f->GetNDF()));
       pd->cd();
       pinfo->DrawClone();
 
- 
+
     }
 
     return;
   }
-  
+
   hdraw->SetMinimum(0);
   hdraw->GetXaxis()->SetRangeUser(fminMass,fmaxMass);
   pd->cd();
   hdraw->SetMarkerStyle(20);
   hdraw->DrawClone("PE");
-//   if(hdraw->GetFunction("funcbkgFullRange")) hdraw->GetFunction("funcbkgFullRange")->DrawClone("same");
-//   if(hdraw->GetFunction("funcbkgRecalc")) hdraw->GetFunction("funcbkgRecalc")->DrawClone("same");
+  //   if(hdraw->GetFunction("funcbkgFullRange")) hdraw->GetFunction("funcbkgFullRange")->DrawClone("same");
+  //   if(hdraw->GetFunction("funcbkgRecalc")) hdraw->GetFunction("funcbkgRecalc")->DrawClone("same");
   if(hdraw->GetFunction("funcmass")) hdraw->GetFunction("funcmass")->DrawClone("same");
 
   if(writeFitInfo > 0){
@@ -1859,7 +1859,7 @@ void AliHFMassFitter::PlotFit(TVirtualPad* pd,Double_t nsigma,Int_t writeFitInfo
       Significance(1.828,1.892,signif,errsignif);
       Signal(1.828,1.892,signal,errsignal);
       Background(1.828,1.892,bkg, errbkg);
-    */
+     */
     TString str=Form("Significance (%.0f#sigma) %.1f #pm %.1f ",nsigma,signif,errsignif);
     pinfo2->AddText(str);
     str=Form("S (%.0f#sigma) %.0f #pm %.0f ",nsigma,signal,errsignal);
@@ -1874,9 +1874,9 @@ void AliHFMassFitter::PlotFit(TVirtualPad* pd,Double_t nsigma,Int_t writeFitInfo
 
     if(writeFitInfo > 1){
       for (Int_t i=0;i<fNFinalPars-3;i++){
-	pinfob->SetTextColor(kRed);
-	str=Form("%s = %f #pm %f",ff->GetParName(i),ff->GetParameter(i),ff->GetParError(i));
-	pinfob->AddText(str);
+        pinfob->SetTextColor(kRed);
+        str=Form("%s = %f #pm %f",ff->GetParName(i),ff->GetParameter(i),ff->GetParError(i));
+        pinfob->AddText(str);
       }
       pd->cd();
       pinfob->DrawClone();
@@ -1894,7 +1894,7 @@ void AliHFMassFitter::DrawHere(TVirtualPad* pd,Double_t nsigma,Int_t writeFitInf
   PlotFit(pd,nsigma,writeFitInfo);
 
   pd->Draw();
- 
+
 }
 //_________________________________________________________________________
 void AliHFMassFitter::DrawFit(Double_t nsigma) const{
@@ -1907,7 +1907,7 @@ void AliHFMassFitter::DrawFit(Double_t nsigma) const{
 
   TCanvas* c=(TCanvas*)GetPad(nsigma,1);
   c->Draw();
-  
+
 }
 
 
@@ -1958,7 +1958,7 @@ void AliHFMassFitter::Signal(Double_t nOfSigma,Double_t &signal,Double_t &errsig
 void AliHFMassFitter::Signal(Double_t min, Double_t max, Double_t &signal,Double_t &errsignal) const {
 
   // Return signal integral in a range
-  
+
   if(fcounter==0) {
     cout<<"Use MassFitter method before Signal"<<endl;
     return;
@@ -1989,7 +1989,7 @@ void AliHFMassFitter::Signal(Double_t min, Double_t max, Double_t &signal,Double
 
   Double_t intS,intSerr;
 
- //relative error evaluation
+  //relative error evaluation
   intS=funcmass->GetParameter(np);
   intSerr=funcmass->GetParError(np);
 
@@ -2020,7 +2020,7 @@ void AliHFMassFitter::Background(Double_t nOfSigma,Double_t &background,Double_t
   Background(min,max,background,errbackground);
 
   return;
-  
+
 }
 //___________________________________________________________________________
 
@@ -2056,7 +2056,7 @@ void AliHFMassFitter::Background(Double_t min, Double_t max, Double_t &backgroun
   }
 
   //relative error evaluation: from histo
-   
+
   intB=fhistoInvMass->Integral(1,fSideBandl)+fhistoInvMass->Integral(fSideBandr,fNbin);
   Double_t sum2=0;
   for(Int_t i=1;i<=fSideBandl;i++){
@@ -2068,7 +2068,7 @@ void AliHFMassFitter::Background(Double_t min, Double_t max, Double_t &backgroun
 
   intBerr=TMath::Sqrt(sum2);
   cout<<"Bkg relative error evaluation: from histo: "<<intBerr/intB<<endl;
-  
+
   cout<<"Last estimation of bkg error is used"<<endl;
 
   //backround +/- error in the range
@@ -2090,7 +2090,7 @@ void AliHFMassFitter::Background(Double_t min, Double_t max, Double_t &backgroun
 
 void AliHFMassFitter::Significance(Double_t nOfSigma,Double_t &significance,Double_t &errsignificance) const  {
   // Return significance in mean+- n sigma
- 
+
   Double_t min=fMass-nOfSigma*fSigmaSgn;
   Double_t max=fMass+nOfSigma*fSigmaSgn;
   Significance(min, max, significance, errsignificance);
@@ -2120,7 +2120,7 @@ void AliHFMassFitter::Significance(Double_t min, Double_t max, Double_t &signifi
   }
 
   AliVertexingHFUtils::ComputeSignificance(signal,errsignal,background,errbackground,significance,errsignificance);
-  
+
   return;
 }
 
@@ -2159,7 +2159,7 @@ TH1F* AliHFMassFitter::GetResidualsAndPulls(TH1 *h,TF1 *f,Double_t minrange,Doub
   Double_t res=-1.e-6,min=1.e+12,max=-1.e+12;
   TArrayD *arval=new TArrayD(binma-binmi+1);
   for(Int_t jst=1;jst<=h->GetNbinsX();jst++){      
-    
+
     res=h->GetBinContent(jst)-f->Integral(h->GetBinLowEdge(jst),h->GetBinLowEdge(jst)+h->GetBinWidth(jst))/h->GetBinWidth(jst);
     if(jst>=binmi&&jst<=binma){
       arval->AddAt(res,jst-binmi);
@@ -2204,13 +2204,13 @@ TH1F* AliHFMassFitter::GetResidualsAndPulls(TH1 *h,TF1 *f,Double_t minrange,Doub
 
 
 TH1F* AliHFMassFitter::GetOverBackgroundResidualsAndPulls(Double_t minrange,Double_t maxrange,TH1 *hPulls,TH1 *hResidualTrend,TH1 *hPullsTrend){
-  
+
 
   if(!fhistoInvMass){
     Printf("AliHFMassFitter::GetOverBackgroundResidualsAndPulls, invariant mass histogram not avaialble!");
     return 0x0;
   }
-  
+
   TF1 *fback=fhistoInvMass->GetFunction("funcbkgRecalc"); 
   if(!fback){
     Printf("AliHFMassFitter::GetOverBackgroundResidualsAndPulls, funcbkgRecalc not available!");
@@ -2233,7 +2233,7 @@ TH1F* AliHFMassFitter::GetOverBackgroundResidualsAndPulls(Double_t minrange,Doub
 
   TH1F *h=GetResidualsAndPulls(fhistoInvMass,fbackCp,minrange,maxrange,hPulls,hResidualTrend,hPullsTrend);
   delete fbackCp;
-  
+
   if(fSigmaSgn<0){
     Printf("AliHFMassFitter::GetOverBackgroundResidualsAndPulls, negative sigma: fit not performed or something went wrong, cannto draw gaussian term on top of residuals");    
     return h;
@@ -2252,25 +2252,25 @@ TH1F* AliHFMassFitter::GetOverBackgroundResidualsAndPulls(Double_t minrange,Doub
 
 
 TH1F* AliHFMassFitter::GetAllRangeResidualsAndPulls(Double_t minrange,Double_t maxrange,TH1 *hPulls,TH1 *hResidualTrend,TH1 *hPullsTrend){
-  
+
 
   if(!fhistoInvMass){
     Printf("AliHFMassFitter::GetAllRangeResidualsAndPulls, invariant mass histogram not avaialble!");
     return 0x0;
   }
-  
+
   TF1 *f=fhistoInvMass->GetFunction("funcmass"); 
   if(!f){
     Printf("AliHFMassFitter::GetAllRangeResidualsAndPulls, funcmass not available!");
     return 0x0;
   }
-  
+
   // THIS LONG WAY TO CP THE FUNC IS NEEDED ONLY TO EXTEND THE RANGE OF THE FUNCTION: NOT POSSIBLE OTHERWISE (WHY??? REALLY UNCOMFORTABLE)
   TF1 *fmassCp=new TF1("fmassCp",this,&AliHFMassFitter::FitFunction4MassDistr,fhistoInvMass->GetBinLowEdge(1),fhistoInvMass->GetBinLowEdge(fhistoInvMass->GetNbinsX()+1), fNFinalPars,"AliHFMassFitter","FitFunction4MassDistr");
   for(Int_t i=0;i< fNFinalPars;i++){
     fmassCp->SetParameter(i,f->GetParameter(i));
   }
-  
+
   TH1F *h=GetResidualsAndPulls(fhistoInvMass,fmassCp,minrange,maxrange,hPulls,hResidualTrend,hPullsTrend);
   delete fmassCp;
   return h;
@@ -2278,19 +2278,19 @@ TH1F* AliHFMassFitter::GetAllRangeResidualsAndPulls(Double_t minrange,Double_t m
 }
 
 TPaveText* AliHFMassFitter::GetFitParametersBox(Double_t nsigma,Int_t mode){
-  
+
   TPaveText *pinfom=new TPaveText(0.6,0.7,1.,.87,"NDC");
   pinfom->SetBorderSize(0);
   pinfom->SetFillStyle(0);
   TF1* ff=fhistoInvMass->GetFunction("funcmass");
-  
+
   for (Int_t i=fNFinalPars-3;i<fNFinalPars;i++){
     pinfom->SetTextColor(kBlue);
     TString str=Form("%s = %.3f #pm %.3f",ff->GetParName(i),ff->GetParameter(i),ff->GetParError(i));
     if(!(mode==1 && i==fNFinalPars-3)) pinfom->AddText(str);
   }  
-  
-  
+
+
   if(mode>1){
     pinfom->SetTextColor(kBlue+5);
     for (Int_t i=0;i<fNFinalPars-3;i++){      
@@ -2304,26 +2304,26 @@ TPaveText* AliHFMassFitter::GetFitParametersBox(Double_t nsigma,Int_t mode){
 
 
 TPaveText* AliHFMassFitter::GetYieldBox(Double_t nsigma){
-    TPaveText *pinfo2=new TPaveText(0.1,0.1,0.6,0.4,"NDC");
-    pinfo2->SetBorderSize(0);
-    pinfo2->SetFillStyle(0);
+  TPaveText *pinfo2=new TPaveText(0.1,0.1,0.6,0.4,"NDC");
+  pinfo2->SetBorderSize(0);
+  pinfo2->SetFillStyle(0);
 
-    Double_t signif, signal, bkg, errsignif, errsignal, errbkg;
+  Double_t signif, signal, bkg, errsignif, errsignal, errbkg;
 
-    Signal(nsigma,signal,errsignal);
-    Background(nsigma,bkg, errbkg);
-    AliVertexingHFUtils::ComputeSignificance(signal,errsignal,bkg,errbkg,signif,errsignif);
+  Signal(nsigma,signal,errsignal);
+  Background(nsigma,bkg, errbkg);
+  AliVertexingHFUtils::ComputeSignificance(signal,errsignal,bkg,errbkg,signif,errsignif);
 
 
-    TString str=Form("Significance (%.0f#sigma) %.1f #pm %.1f ",nsigma,signif,errsignif);
-    pinfo2->AddText(str);
-    str=Form("S (%.0f#sigma) %.0f #pm %.0f ",nsigma,signal,errsignal);
-    pinfo2->AddText(str);
-    str=Form("B (%.0f#sigma) %.0f #pm %.0f",nsigma,bkg,errbkg);
-    pinfo2->AddText(str);
-    if(bkg>0) str=Form("S/B (%.0f#sigma) %.4f ",nsigma,signal/bkg); 
-    pinfo2->AddText(str);
-    
-    return pinfo2;
+  TString str=Form("Significance (%.0f#sigma) %.1f #pm %.1f ",nsigma,signif,errsignif);
+  pinfo2->AddText(str);
+  str=Form("S (%.0f#sigma) %.0f #pm %.0f ",nsigma,signal,errsignal);
+  pinfo2->AddText(str);
+  str=Form("B (%.0f#sigma) %.0f #pm %.0f",nsigma,bkg,errbkg);
+  pinfo2->AddText(str);
+  if(bkg>0) str=Form("S/B (%.0f#sigma) %.4f ",nsigma,signal/bkg);
+  pinfo2->AddText(str);
+
+  return pinfo2;
 
 }

--- a/PWGHF/vertexingHF/AliHFMassFitter.cxx
+++ b/PWGHF/vertexingHF/AliHFMassFitter.cxx
@@ -1748,19 +1748,19 @@ void AliHFMassFitter::WriteCanvas(TString userIDstring,TString path,Double_t nsi
   filename.Prepend(userIDstring);
   path.Append(filename);
 
-  TFile* outputcv=new TFile(path.Data(),"update");
-
-  TCanvas* c=(TCanvas*)GetPad(nsigma,writeFitInfo);
+  TCanvas* c = static_cast<TCanvas*>(GetPad(nsigma,writeFitInfo));
   c->SetName(Form("%s%s%s",c->GetName(),userIDstring.Data(),type.Data()));
-  if(draw)c->DrawClone();
-  outputcv->cd();
+  if (draw) c->DrawClone();
+
+  TFile outputcv(path.Data(),"update");
+  outputcv.cd();
   c->Write();
-  outputcv->Close();
+  outputcv.Close();
 }
 
 //_________________________________________________________________________
-
-TVirtualPad* AliHFMassFitter::GetPad(Double_t nsigma,Int_t writeFitInfo)const{
+TVirtualPad* AliHFMassFitter::GetPad(Double_t nsigma,Int_t writeFitInfo) const
+{
   //return a TVirtualPad with the fitted histograms and info
 
   TString cvtitle="fit of ";
@@ -1768,13 +1768,14 @@ TVirtualPad* AliHFMassFitter::GetPad(Double_t nsigma,Int_t writeFitInfo)const{
   TString cvname="c";
   cvname+=fcounter;
 
-  TCanvas *c=new TCanvas(cvname,cvtitle);
-  PlotFit(c->cd(),nsigma,writeFitInfo);
-  return c->cd();
+  TCanvas* c = new TCanvas(cvname,cvtitle);
+  PlotFit(c, nsigma, writeFitInfo);
+  return c;
 }
 //_________________________________________________________________________
 
-void AliHFMassFitter::PlotFit(TVirtualPad* pd,Double_t nsigma,Int_t writeFitInfo)const{
+void AliHFMassFitter::PlotFit(TVirtualPad* pd,Double_t nsigma,Int_t writeFitInfo) const
+{
   //plot histogram, fit functions and write parameters according to verbosity level (0,1,>1)
   gStyle->SetOptStat(0);
   gStyle->SetCanvasColor(0);
@@ -1812,9 +1813,7 @@ void AliHFMassFitter::PlotFit(TVirtualPad* pd,Double_t nsigma,Int_t writeFitInfo
 
       pinfo->AddText(Form("Reduced #chi^{2} = %.3f",f->GetChisquare()/f->GetNDF()));
       pd->cd();
-      pinfo->DrawClone();
-
-
+      pinfo->Draw();
     }
 
     return;
@@ -1844,7 +1843,7 @@ void AliHFMassFitter::PlotFit(TVirtualPad* pd,Double_t nsigma,Int_t writeFitInfo
       if(!(writeFitInfo==1 && i==fNFinalPars-3)) pinfom->AddText(str);
     }
     pd->cd();
-    pinfom->DrawClone();
+    pinfom->Draw();
 
     TPaveText *pinfo2=new TPaveText(0.1,0.1,0.6,0.4,"NDC");
     pinfo2->SetBorderSize(0);
@@ -1879,10 +1878,8 @@ void AliHFMassFitter::PlotFit(TVirtualPad* pd,Double_t nsigma,Int_t writeFitInfo
         pinfob->AddText(str);
       }
       pd->cd();
-      pinfob->DrawClone();
+      pinfob->Draw();
     }
-
-
   }
   return;
 }

--- a/PWGHF/vertexingHF/AliHFMassFitterVAR.cxx
+++ b/PWGHF/vertexingHF/AliHFMassFitterVAR.cxx
@@ -334,7 +334,7 @@ void AliHFMassFitterVAR::SetBackHighPolDegree(Int_t deg){
 }
 
 
-TH1F*  AliHFMassFitterVAR::SetTemplateReflections(const TH1 *h, TString opt,Double_t minRange,Double_t maxRange){
+TH1F*  AliHFMassFitterVAR::SetTemplateReflections(const TH1F *h, TString opt,Double_t minRange,Double_t maxRange){
   fhTemplRefl=(TH1F*)h->Clone("hTemplRefl");  
 
   if(opt.EqualTo("templ")||opt.EqualTo("Templ")||opt.EqualTo("TEMPL")||opt.EqualTo("template")||opt.EqualTo("Template")||opt.EqualTo("TEMPLATE")){

--- a/PWGHF/vertexingHF/AliHFMassFitterVAR.cxx
+++ b/PWGHF/vertexingHF/AliHFMassFitterVAR.cxx
@@ -55,7 +55,7 @@ using std::endl;
 ClassImp(AliHFMassFitterVAR);
 /// \endcond
 
- //************** constructors
+//************** constructors
 AliHFMassFitterVAR::AliHFMassFitterVAR() : 
 AliHFMassFitter(),
   fNparSignal(3),
@@ -82,7 +82,7 @@ AliHFMassFitter(),
   fMassParticle(1.864)
 {
   // default constructor
- 
+
   cout<<"Default constructor:"<<endl;
   cout<<"Remember to set the Histo, the Type, the FixPar"<<endl;
 
@@ -183,15 +183,14 @@ AliHFMassFitterVAR::AliHFMassFitterVAR(const AliHFMassFitterVAR &mfit):
     fReflParNames[j]=mfit.fReflParNames[j];
   }
 
-
   fFixParSign=new Bool_t[fNparSignal];
   fFixParSignExternalValue=new Bool_t[fNparSignal];
   fparSignFixExt=new Double_t[fNparSignal];
-  
+
   fFixParBack=new Bool_t[fNparBack];
   fFixParBackExternalValue=new Bool_t[fNparBack];
   fparBackFixExt=new Double_t[fNparBack];
-  
+
   fFixParRefl=new Bool_t[fNparRefl];
   fFixParReflExternalValue=new Bool_t[fNparRefl];
   fparReflFixExt=new Double_t[fNparRefl];
@@ -199,21 +198,19 @@ AliHFMassFitterVAR::AliHFMassFitterVAR(const AliHFMassFitterVAR &mfit):
   memcpy(fFixParSign,mfit.fFixParSign,mfit.fNparSignal*sizeof(Bool_t));
   memcpy(fFixParBack,mfit.fFixParBack,mfit.fNparBack*sizeof(Bool_t));
   memcpy(fFixParRefl,mfit.fFixParRefl,mfit.fNparRefl*sizeof(Double_t));
-  
+
   memcpy(fFixParSignExternalValue,mfit.fFixParSignExternalValue,mfit.fNparSignal*sizeof(Bool_t));
   memcpy(fFixParBackExternalValue,mfit.fFixParBackExternalValue,mfit.fNparBack*sizeof(Bool_t));
   memcpy(fFixParReflExternalValue,mfit.fFixParReflExternalValue,mfit.fNparRefl*sizeof(Double_t));
-  
+
   memcpy(fparSignFixExt,mfit.fparSignFixExt,mfit.fNparSignal*sizeof(Bool_t));
   memcpy(fparBackFixExt,mfit.fparBackFixExt,mfit.fNparBack*sizeof(Bool_t));
   memcpy(fparReflFixExt,mfit.fparReflFixExt,mfit.fNparRefl*sizeof(Double_t));
-  
-
 }
 
 //_________________________________________________________________________
-
-AliHFMassFitterVAR::~AliHFMassFitterVAR() {
+AliHFMassFitterVAR::~AliHFMassFitterVAR()
+{
   //destructor
 
   if(fhTemplRefl) delete fhTemplRefl;
@@ -233,8 +230,6 @@ AliHFMassFitterVAR::~AliHFMassFitterVAR() {
   delete [] fparSignFixExt;
   delete [] fparBackFixExt;
   delete [] fparReflFixExt;
-
-
 }
 
 //_________________________________________________________________________
@@ -261,7 +256,7 @@ AliHFMassFitterVAR& AliHFMassFitterVAR::operator=(const AliHFMassFitterVAR &mfit
   delete [] fSignParNames;
   delete [] fBackParNames;
   delete [] fReflParNames;
-  
+
   fSignParNames=new TString[fNparSignal];
   fBackParNames=new TString[fNparBack];
   fReflParNames=new TString[fNparRefl];
@@ -273,27 +268,27 @@ AliHFMassFitterVAR& AliHFMassFitterVAR::operator=(const AliHFMassFitterVAR &mfit
   fparSignFixExt=new Double_t[fNparSignal];
   fparBackFixExt=new Double_t[fNparBack];
   fparReflFixExt=new Double_t[fNparRefl];
-  
+
 
   delete [] fFixParSign;
   delete [] fFixParBack;
   delete [] fFixParRefl;
-  
+
   fFixParSign=new Bool_t[fNparSignal];
   fFixParBack=new Bool_t[fNparBack];
- fFixParRefl=new Bool_t[fNparRefl];
+  fFixParRefl=new Bool_t[fNparRefl];
 
 
   delete [] fFixParSignExternalValue;
   delete [] fFixParBackExternalValue;
   delete [] fFixParReflExternalValue;
-  
+
   fFixParSignExternalValue=new Bool_t[fNparSignal];
   fFixParBackExternalValue=new Bool_t[fNparBack];
- fFixParReflExternalValue=new Bool_t[fNparRefl];
+  fFixParReflExternalValue=new Bool_t[fNparRefl];
 
 
- fSignParNames=new TString[fNparSignal];
+  fSignParNames=new TString[fNparSignal];
   for(Int_t j=0;j<fNparSignal;j++){
     fSignParNames[j]=mfit.fSignParNames[j];
   }
@@ -314,17 +309,17 @@ AliHFMassFitterVAR& AliHFMassFitterVAR::operator=(const AliHFMassFitterVAR &mfit
   memcpy(fFixParSign,mfit.fFixParSign,mfit.fNparSignal*sizeof(Bool_t));
   memcpy(fFixParBack,mfit.fFixParBack,mfit.fNparBack*sizeof(Bool_t));
   memcpy(fFixParRefl,mfit.fFixParRefl,mfit.fNparRefl*sizeof(Bool_t));
-  
+
   memcpy(fFixParSignExternalValue,mfit.fFixParSignExternalValue,mfit.fNparSignal*sizeof(Bool_t));
   memcpy(fFixParBackExternalValue,mfit.fFixParBackExternalValue,mfit.fNparBack*sizeof(Bool_t));
   memcpy(fFixParReflExternalValue,mfit.fFixParReflExternalValue,mfit.fNparRefl*sizeof(Bool_t));
 
-  
+
   memcpy(fparSignFixExt,mfit.fparSignFixExt,mfit.fNparSignal*sizeof(Double_t));
   memcpy(fparBackFixExt,mfit.fparBackFixExt,mfit.fNparBack*sizeof(Double_t));
   memcpy(fparReflFixExt,mfit.fparReflFixExt,mfit.fNparRefl*sizeof(Double_t));
 
-  
+
   return *this;
 }
 
@@ -341,7 +336,7 @@ void AliHFMassFitterVAR::SetBackHighPolDegree(Int_t deg){
 
 TH1F*  AliHFMassFitterVAR::SetTemplateReflections(const TH1 *h, TString opt,Double_t minRange,Double_t maxRange){
   fhTemplRefl=(TH1F*)h->Clone("hTemplRefl");  
-  
+
   if(opt.EqualTo("templ")||opt.EqualTo("Templ")||opt.EqualTo("TEMPL")||opt.EqualTo("template")||opt.EqualTo("Template")||opt.EqualTo("TEMPLATE")){
     return fhTemplRefl;
   }
@@ -364,7 +359,7 @@ TH1F*  AliHFMassFitterVAR::SetTemplateReflections(const TH1 *h, TString opt,Doub
     }
     for(Int_t j=1;j<=fhTemplRefl->GetNbinsX();j++){
       if(isPoissErr){
-	fhTemplRefl->SetBinError(j,TMath::Sqrt(fhTemplRefl->GetBinContent(j)));
+        fhTemplRefl->SetBinError(j,TMath::Sqrt(fhTemplRefl->GetBinContent(j)));
       }
       else fhTemplRefl->SetBinError(j,0.001*fhTemplRefl->GetBinContent(j));
     }
@@ -372,11 +367,11 @@ TH1F*  AliHFMassFitterVAR::SetTemplateReflections(const TH1 *h, TString opt,Doub
   }
 
 
- if(opt.EqualTo("2gaus")||opt.EqualTo("doublegaus")){
-   if(minRange>=0&&maxRange>=0){
-     f=new TF1("my2gaus","[0]*([3]/( TMath::Sqrt(2.*TMath::Pi())*[2])*TMath::Exp(-(x-[1])*(x-[1])/(2.*[2]*[2]))+(1.-[3])/( TMath::Sqrt(2.*TMath::Pi())*[5])*TMath::Exp(-(x-[4])*(x-[4])/(2.*[5]*[5])))",TMath::Max(minRange,h->GetBinLowEdge(1)),TMath::Min(maxRange,h->GetXaxis()->GetBinUpEdge(h->GetNbinsX())));
-   }
-   else f=new TF1("my2gaus","[0]*([3]/( TMath::Sqrt(2.*TMath::Pi())*[2])*TMath::Exp(-(x-[1])*(x-[1])/(2.*[2]*[2]))+(1.-[3])/( TMath::Sqrt(2.*TMath::Pi())*[5])*TMath::Exp(-(x-[4])*(x-[4])/(2.*[5]*[5])))",h->GetBinLowEdge(1),h->GetXaxis()->GetBinUpEdge(h->GetNbinsX()));
+  if(opt.EqualTo("2gaus")||opt.EqualTo("doublegaus")){
+    if(minRange>=0&&maxRange>=0){
+      f=new TF1("my2gaus","[0]*([3]/( TMath::Sqrt(2.*TMath::Pi())*[2])*TMath::Exp(-(x-[1])*(x-[1])/(2.*[2]*[2]))+(1.-[3])/( TMath::Sqrt(2.*TMath::Pi())*[5])*TMath::Exp(-(x-[4])*(x-[4])/(2.*[5]*[5])))",TMath::Max(minRange,h->GetBinLowEdge(1)),TMath::Min(maxRange,h->GetXaxis()->GetBinUpEdge(h->GetNbinsX())));
+    }
+    else f=new TF1("my2gaus","[0]*([3]/( TMath::Sqrt(2.*TMath::Pi())*[2])*TMath::Exp(-(x-[1])*(x-[1])/(2.*[2]*[2]))+(1.-[3])/( TMath::Sqrt(2.*TMath::Pi())*[5])*TMath::Exp(-(x-[4])*(x-[4])/(2.*[5]*[5])))",h->GetBinLowEdge(1),h->GetXaxis()->GetBinUpEdge(h->GetNbinsX()));
 
     f->SetParameter(0,h->GetMaximum());
     //    f->SetParLimits(0,0,100.*h->Integral());
@@ -396,7 +391,7 @@ TH1F*  AliHFMassFitterVAR::SetTemplateReflections(const TH1 *h, TString opt,Doub
     }
     for(Int_t j=1;j<=fhTemplRefl->GetNbinsX();j++){
       if(isPoissErr){
-	fhTemplRefl->SetBinError(j,TMath::Sqrt(fhTemplRefl->GetBinContent(j)));
+        fhTemplRefl->SetBinError(j,TMath::Sqrt(fhTemplRefl->GetBinContent(j)));
       }
       else fhTemplRefl->SetBinError(j,0.001*fhTemplRefl->GetBinContent(j));
     }
@@ -410,7 +405,7 @@ TH1F*  AliHFMassFitterVAR::SetTemplateReflections(const TH1 *h, TString opt,Doub
     }
     else f=new TF1("mypol3","pol3",h->GetBinLowEdge(1),h->GetXaxis()->GetBinUpEdge(h->GetNbinsX()));
     f->SetParameter(0,h->GetMaximum());
-    
+
     //    f->SetParLimits(0,0,100.*h->Integral());
     // Hard to initialize the other parameters...
     for(Int_t nf=0;nf<10;nf++){
@@ -424,7 +419,7 @@ TH1F*  AliHFMassFitterVAR::SetTemplateReflections(const TH1 *h, TString opt,Doub
     }
     for(Int_t j=1;j<=fhTemplRefl->GetNbinsX();j++){
       if(isPoissErr){
-	fhTemplRefl->SetBinError(j,TMath::Sqrt(fhTemplRefl->GetBinContent(j)));
+        fhTemplRefl->SetBinError(j,TMath::Sqrt(fhTemplRefl->GetBinContent(j)));
       }
       else fhTemplRefl->SetBinError(j,0.001*fhTemplRefl->GetBinContent(j));
     }
@@ -443,15 +438,15 @@ TH1F*  AliHFMassFitterVAR::SetTemplateReflections(const TH1 *h, TString opt,Doub
     // Hard to initialize the other parameters...
 
     fhTemplRefl->Fit(f,"RLEMI","");//,h->GetBinLowEdge(1),h->GetXaxis()->GetBinUpEdge(h->GetNbinsX()));
-    
-   
+
+
     for(Int_t j=1;j<=fhTemplRefl->GetNbinsX();j++){
       fhTemplRefl->SetBinContent(j,f->Integral(fhTemplRefl->GetBinLowEdge(j),fhTemplRefl->GetXaxis()->GetBinUpEdge(j))/fhTemplRefl->GetBinWidth(j));
       if(fhTemplRefl->GetBinContent(j)>=0.&&TMath::Abs(h->GetBinError(j)*h->GetBinError(j)-h->GetBinContent(j))>0.1*h->GetBinContent(j))isPoissErr=kFALSE;
     }
     for(Int_t j=1;j<=fhTemplRefl->GetNbinsX();j++){
       if(isPoissErr){
-	fhTemplRefl->SetBinError(j,TMath::Sqrt(fhTemplRefl->GetBinContent(j)));
+        fhTemplRefl->SetBinError(j,TMath::Sqrt(fhTemplRefl->GetBinContent(j)));
       }
       else fhTemplRefl->SetBinError(j,0.001*fhTemplRefl->GetBinContent(j));
     }
@@ -478,7 +473,7 @@ Double_t AliHFMassFitterVAR::FitFunction4MassDistr (Double_t *x, Double_t *par){
   // par[2] = gaussian integral
   // par[3] = gaussian mean
   // par[4] = gaussian sigma
-  
+
   Double_t bkg=0,sgn=0,refl=0.;
   Double_t parbkg[fNparBack];
   sgn = FitFunction4Sgn(x,&par[fNparBack]);  
@@ -499,9 +494,9 @@ Double_t AliHFMassFitterVAR::FitFunction4MassDistr (Double_t *x, Double_t *par){
   }  
   bkg = FitFunction4Bkg(x,parbkg);
 
-  
+
   if(ftypeOfFit4Sgn==2)refl=FitFunction4Refl(x,&par[fNparBack+fNparSignal]);
-  
+
   return sgn+bkg+refl;
 
 
@@ -538,7 +533,7 @@ Double_t AliHFMassFitterVAR::FitFunction4BkgAndReflDraw(Double_t *x, Double_t *p
 }
 /////_______________________________________________________________________
 Double_t AliHFMassFitterVAR::FitFunction4Refl(Double_t *x,Double_t *par){
-  
+
   Int_t bin =fhTemplRefl->FindBin(x[0]);
   Double_t value=fhTemplRefl->GetBinContent(bin);
   Int_t binmin=fhTemplRefl->FindBin(fminMass*1.00001);
@@ -549,7 +544,7 @@ Double_t AliHFMassFitterVAR::FitFunction4Refl(Double_t *x,Double_t *par){
     value/=3.;
   }
   return par[0]*value/norm*fRawYieldHelp*fhistoInvMass->GetBinWidth(1);
-  
+
 }
 
 /// _______________________________________________________________________
@@ -559,7 +554,7 @@ Double_t AliHFMassFitterVAR::BackFitFuncPolHelper(Double_t *x,Double_t *par){
     back+=par[it]*TMath::Power(x[0]-fMassParticle,it)/TMath::Factorial(it);
   }
   return back;
-  
+
 
 }
 
@@ -627,21 +622,21 @@ Double_t AliHFMassFitterVAR::FitFunction4Bkg(Double_t *x, Double_t *par){
     // * [0] = integralBkg;
     // * [1] = b;
     // a(power function) = [0]*([1]+1)/((max-m_pi)^([1]+1)-(min-m_pi)^([1]+1))*(x-m_pi)^[1]
-    {
+  {
     Double_t mpi = TDatabasePDG::Instance()->GetParticle(211)->Mass();
 
     total = par[0+firstPar]*(par[1+firstPar]+1.)/(TMath::Power(fmaxMass-mpi,par[1+firstPar]+1.)-TMath::Power(fminMass-mpi,par[1+firstPar]+1.))*TMath::Power(x[0]-mpi,par[1+firstPar]);
-    }
-    break;
+  }
+  break;
   case 5:
-   //power function wit exponential
+    //power function wit exponential
     //y=a*Sqrt(x-m_pi)*exp(-b*(x-m_pi))  
-    { 
+  {
     Double_t mpi = TDatabasePDG::Instance()->GetParticle(211)->Mass();
 
     total = par[1+firstPar]*TMath::Sqrt(x[0] - mpi)*TMath::Exp(-1.*par[2+firstPar]*(x[0]-mpi));
-    } 
-    break;
+  }
+  break;
   case 6:
     // the following comment must be removed
     //     // pol 3, following convention for pol 2
@@ -652,22 +647,22 @@ Double_t AliHFMassFitterVAR::FitFunction4Bkg(Double_t *x, Double_t *par){
     //     // * [1] = b;
     //     // * [2] = c;
     //     // * [3] = d;
-    {
-      total=par[0+firstPar];
-      for(Int_t it=1;it<=fpolbackdegreeTay;it++){
-	total+=par[it+firstPar]*TMath::Power(x[0]-fMassParticle,it)/TMath::Factorial(it);
-      }
-      
+  {
+    total=par[0+firstPar];
+    for(Int_t it=1;it<=fpolbackdegreeTay;it++){
+      total+=par[it+firstPar]*TMath::Power(x[0]-fMassParticle,it)/TMath::Factorial(it);
     }
-    break;
-//   default:
-//     Types of Fit Functions for Background:
-//     * 0 = exponential;
-//     * 1 = linear;
-//     * 2 = polynomial 2nd order
-//     * 3 = no background"<<endl;
-//     * 4 = Power function 
-//     * 5 = Power function with exponential 
+
+  }
+  break;
+  //   default:
+  //     Types of Fit Functions for Background:
+  //     * 0 = exponential;
+  //     * 1 = linear;
+  //     * 2 = polynomial 2nd order
+  //     * 3 = no background"<<endl;
+  //     * 4 = Power function
+  //     * 5 = Power function with exponential
 
   }
   return total+gaus2;
@@ -689,7 +684,7 @@ Bool_t AliHFMassFitterVAR::SideBandsBounds(){
     cout<<"Left limit of range > mean or right limit of range < mean: change left/right limit or initial mean value"<<endl;
     return kFALSE;
   } 
-  
+
   //histo limit = fit function limit
   if((TMath::Abs(fminMass-minHisto) < 1e6 || TMath::Abs(fmaxMass - maxHisto) < 1e6) && (fMass-4.*fSigmaSgn-fminMass) < 1e6){
     Double_t coeff = (fMass-fminMass)/fSigmaSgn;
@@ -717,7 +712,7 @@ Bool_t AliHFMassFitterVAR::SideBandsBounds(){
   fSideBandl=fhistoInvMass->FindBin(sidebandldouble);
   if (sidebandldouble >= fhistoInvMass->GetBinCenter(fSideBandl)) fSideBandl++;
   sidebandldouble=fhistoInvMass->GetBinLowEdge(fSideBandl);
-  
+
   if(TMath::Abs(tmp-sidebandldouble) > 1e-6){
     cout<<tmp<<" is not allowed, changing it to the nearest value allowed: ";
     leftok=kTRUE;
@@ -776,7 +771,7 @@ Bool_t AliHFMassFitterVAR::CheckRangeFit(){
     cout<<"Left bound "<<tmp<<" is not allowed, changing it to the nearest value allowed: "<<fminMass<<endl;
     leftok=kTRUE;
   }
- 
+
   tmp=fmaxMass;
   //calculate bin corresponding to fmaxMass
   fmaxBinMass=fhistoInvMass->FindBin(fmaxMass);
@@ -788,7 +783,7 @@ Bool_t AliHFMassFitterVAR::CheckRangeFit(){
   }
 
   return (leftok && rightok);
- 
+
 }
 
 
@@ -796,7 +791,7 @@ Bool_t AliHFMassFitterVAR::CheckRangeFit(){
 
 Bool_t AliHFMassFitterVAR::MassFitter(Bool_t draw){  
   // Main method of the class: performs the fit of the histogram
-  
+
   //Set default fitter Minuit in order to use gMinuit in the contour plots    
   TVirtualFitter::SetDefaultFitter("Minuit");
 
@@ -850,7 +845,7 @@ Bool_t AliHFMassFitterVAR::MassFitter(Bool_t draw){
 
   Bool_t ok=SideBandsBounds();
   if(!ok) return kFALSE;
-  
+
   //sidebands integral - first approx (from histo)
   Double_t sideBandsInt=(Double_t)fhistoInvMass->Integral(fminBinMass,fSideBandl,"width") + (Double_t)fhistoInvMass->Integral(fSideBandr,fmaxBinMass,"width");
   cout<<"------nbin = "<<fNbin<<"\twidth = "<<width<<"\tbinleft = "<<fSideBandl<<"\tbinright = "<<fSideBandr<<endl;
@@ -859,14 +854,14 @@ Bool_t AliHFMassFitterVAR::MassFitter(Bool_t draw){
     cout<<"! sideBandsInt <=0. There's a problem, cannot start the fit"<<endl;
     return kFALSE;
   }
-  
+
   /*Fit Bkg*/
   TF1 *funcbkg = new TF1(bkgname.Data(),this,&AliHFMassFitterVAR::FitFunction4Bkg,fminMass,fmaxMass,fNparBack,"AliHFMassFitterVAR","FitFunction4Bkg");
   //   TF1 *funcbkg = GetBackgroundFunc();
   cout<<"Function name = "<<funcbkg->GetName()<<endl<<endl;
-  
+
   funcbkg->SetLineColor(2); //red
-  
+
   //   cout<<"\nBACKGROUND FIT - only combinatorial"<<endl;
   Int_t ftypeOfFit4SgnBkp=ftypeOfFit4Sgn;
   Double_t *parBackInit=new Double_t[fNparBack];
@@ -885,7 +880,7 @@ Bool_t AliHFMassFitterVAR::MassFitter(Bool_t draw){
   if(ftypeOfFit4Bkg!=6){// THIS IS LIKELY UNNECESSARY
     parBackInit[0]=totInt;// this and the following 2 lines are from previous AliHFMassFitter version... can be removed 
   }
-  
+
   for(Int_t j=0;j<fNparBack;j++){
     //    Printf(" HERE back %d",j);
     funcbkg->SetParName(j,fBackParNames[j]);
@@ -900,12 +895,12 @@ Bool_t AliHFMassFitterVAR::MassFitter(Bool_t draw){
 
 
 
-   Double_t intbkg1=0,conc1=0;
-   //if only signal and reflection: skip
+  Double_t intbkg1=0,conc1=0;
+  //if only signal and reflection: skip
   if (!(ftypeOfFit4Bkg==3 && ftypeOfFit4Sgn==1)) {
     //    ftypeOfFit4Sgn=0;
     fhistoInvMass->Fit(funcbkg,"R,E,0");
-   
+
     fSideBands = kFALSE;
     //intbkg1 = funcbkg->GetParameter(0);
 
@@ -913,19 +908,19 @@ Bool_t AliHFMassFitterVAR::MassFitter(Bool_t draw){
     if(ftypeOfFit4Bkg!=3) slope1 = funcbkg->GetParameter(1);
     if(ftypeOfFit4Bkg==2) conc1 = funcbkg->GetParameter(2);
     if(ftypeOfFit4Bkg==5) conc1 = funcbkg->GetParameter(2); 
- 
+
 
     //cout<<"First fit: \nintbkg1 = "<<intbkg1<<"\t(Compare with par0 = "<<funcbkg->GetParameter(0)<<")\nslope1= "<<slope1<<"\nconc1 = "<<conc1<<endl;
   }
   else cout<<"\t\t//"<<endl;
   if(ftypeOfFit4Bkg==6){
-     // THE FOLLOWING LINES ARE NEEDED FOR THE FOLLOWING REASON:
-     // when a histogram is fitted with the function TF1 *f, the function that is added to the list of function is a clone of f,
-     // so the pointers are different
-     // Conversely, if the function is added to the list as f, of course the pointers remain the same
-     TF1 *fh=fhistoInvMass->GetFunction(bkgname.Data());
-     PrepareHighPolFit(fh);
-   } 
+    // THE FOLLOWING LINES ARE NEEDED FOR THE FOLLOWING REASON:
+    // when a histogram is fitted with the function TF1 *f, the function that is added to the list of function is a clone of f,
+    // so the pointers are different
+    // Conversely, if the function is added to the list as f, of course the pointers remain the same
+    TF1 *fh=fhistoInvMass->GetFunction(bkgname.Data());
+    PrepareHighPolFit(fh);
+  }
 
 
 
@@ -946,7 +941,7 @@ Bool_t AliHFMassFitterVAR::MassFitter(Bool_t draw){
   Printf("Estimates: bkgInt: %f, totInt: %f, diffUndBan:%f",bkgInt,totInt,diffUnderBands);
   //cout<<"------TotInt = "<<totInt<<"\tsgnInt = "<<sgnInt<<endl;
   /*Fit All Mass distribution with exponential + gaussian (+gaussian braodened) */
-  
+
   //  Double_t sgnInt=diffUnderBands;
   if(sgnInt<0)sgnInt=0.1*totInt;
   TF1 *funcmass = new TF1(massname.Data(),this,&AliHFMassFitterVAR::FitFunction4MassDistr,fminMass,fmaxMass,fNFinalPars,"AliHFMassFitterVAR","FitFunction4MassDistr");
@@ -1030,7 +1025,7 @@ Bool_t AliHFMassFitterVAR::MassFitter(Bool_t draw){
   //     cout<<i<<"\t"<<fFitPars[i]<<endl;
   //     }
   //   */
-  
+
   if(funcmass->GetParameter(fNparBack+2) <0 || funcmass->GetParameter(fNparBack+1) <0 || funcmass->GetParameter(fNparBack) <0 ) {
     cout<<"IntS or mean or sigma negative. You may tray to SetInitialGaussianSigma(..) and SetInitialGaussianMean(..)"<<endl;
     delete funcbkg;
@@ -1038,21 +1033,21 @@ Bool_t AliHFMassFitterVAR::MassFitter(Bool_t draw){
     delete funcmass;
     return kFALSE;
   }
-  
+
   //increase counter of number of fits done
   fcounter++;
 
-  
+
   delete[] parBackInit;
   delete funcbkg;
   delete funcmass;
-  
+
   //  Printf("Now calling add functions to hist in MassFitter");
   AddFunctionsToHisto();
   //  Printf("After calling add functions to hist in MassFitter");
   if (draw) DrawFit();
   //  Printf("After Draw Fit");
-  
+
   return kTRUE;
 }
 //________________________________________________________________________
@@ -1061,7 +1056,7 @@ Bool_t AliHFMassFitterVAR::PrepareHighPolFit(TF1 *fback){
   TH1F *hCp=(TH1F*)fhistoInvMass->Clone("htemp");
   Double_t estimatecent=0.5*(hCp->GetBinContent(hCp->FindBin(fMass-3.5*fSigmaSgn))+hCp->GetBinContent(hCp->FindBin(fMass+3.5*fSigmaSgn)));// just a first rough estimate
   Double_t estimateslope=(hCp->GetBinContent(hCp->FindBin(fMass+3.5*fSigmaSgn))-hCp->GetBinContent(hCp->FindBin(fMass-3.5*fSigmaSgn)))/(7*fSigmaSgn);// first rough estimate
-  
+
   for(Int_t j=1;j<=hCp->GetNbinsX();j++){
     //    h->SetBinContent(j,f->Eval(h->GetBinCenter(j))+fSignal->Integral(h->GetBinLowEdge(j),h->GetBinLowEdge(j+1)));
     //    h->SetBinError(j,TMath::Sqrt(h->GetBinContent(j)));
@@ -1071,28 +1066,28 @@ Bool_t AliHFMassFitterVAR::PrepareHighPolFit(TF1 *fback){
       hCp->SetBinError(j,0);
     }
   }
-  
+
   fpolbackdegreeTayHelp=2;
   TF1 *funcbkg,*funcPrev=0x0;  
   while(fpolbackdegreeTayHelp<=fpolbackdegreeTay){        
     funcbkg = new TF1(Form("temp%d",fpolbackdegreeTayHelp),this,&AliHFMassFitterVAR::BackFitFuncPolHelper,fminMass,fmaxMass,fpolbackdegreeTayHelp+1,"AliHFMassFitterVAR","BackFitFuncPolHelper");
     if(funcPrev){
       for(Int_t j=0;j<fpolbackdegreeTayHelp;j++){// now is +1 degree w.r.t. previous fit funct
-	funcbkg->SetParameter(j,funcPrev->GetParameter(j));
+        funcbkg->SetParameter(j,funcPrev->GetParameter(j));
       }
       delete funcPrev;
     }
     else{
       funcbkg->SetParameter(0,estimatecent);
       funcbkg->SetParameter(1,estimateslope);
-      
+
     }
     hCp->Fit(funcbkg,"REMN","");
     funcPrev=(TF1*)funcbkg->Clone("ftemp");
     delete funcbkg;
     fpolbackdegreeTayHelp++;
   }
-  
+
   //  TString name=fback->GetName();
   //  funcbkg->Copy(*fback);
   //  fback->SetName(name.Data());
@@ -1178,7 +1173,7 @@ Bool_t AliHFMassFitterVAR::RefitWithBkgOnly(Bool_t draw){
   Int_t status=0;
   if(ftypeOfFit4Bkg==6){
     if(PrepareHighPolFit(funcbkg)){
-      
+
       fhistoInvMass->GetListOfFunctions()->Add(funcbkg);
       fhistoInvMass->GetFunction(funcbkg->GetName())->SetBit(1<<9,kTRUE);
     }
@@ -1266,7 +1261,7 @@ void AliHFMassFitterVAR::AddFunctionsToHisto(){
       cout<<bkgname<<" not found, cannot produce "<<bkgname<<"FullRange and "<<bkgname<<"Recalc"<<endl;
       return;
     }
-  
+
     bkgname += "FullRange";
     TF1 *bfullrange=new TF1(bkgname.Data(),this,&AliHFMassFitterVAR::FitFunction4Bkg,fminMass,fmaxMass,fNparBack,"AliHFMassFitterVAR","FitFunction4Bkg");
     //cout<<bfullrange->GetName()<<endl;
@@ -1277,14 +1272,14 @@ void AliHFMassFitterVAR::AddFunctionsToHisto(){
     }
     bfullrange->SetLineStyle(4);
     bfullrange->SetLineColor(14);
-    
-    
+
+
     bkgnamesave += "Recalc";
-    
+
     TF1 *blastpar;
     if(ftypeOfFit4Sgn<2)blastpar=new TF1(bkgnamesave.Data(),this,&AliHFMassFitterVAR::FitFunction4Bkg,fminMass,fmaxMass,fNparBack,"AliHFMassFitterVAR","FitFunction4Bkg");
     else blastpar=new TF1(bkgnamesave.Data(),this,&AliHFMassFitterVAR::FitFunction4BkgAndReflDraw,fminMass,fmaxMass,fNparBack+fNparRefl,"AliHFMassFitterVAR","FitFunction4BkgAndReflDraw");
-  
+
     TF1 *mass=fhistoInvMass->GetFunction("funcmass");
 
     if (!mass){
@@ -1294,7 +1289,7 @@ void AliHFMassFitterVAR::AddFunctionsToHisto(){
       return;
     }
 
-  
+
 
     //intBkg=intTot-intS
     if(ftypeOfFit4Bkg==6){
@@ -1302,8 +1297,8 @@ void AliHFMassFitterVAR::AddFunctionsToHisto(){
       blastpar->SetParError(0,mass->GetParError(0));
     }
     else{
-    blastpar->SetParameter(0,mass->GetParameter(0)-mass->GetParameter(fNparBack));
-    blastpar->SetParError(0,mass->GetParError(fNparBack));
+      blastpar->SetParameter(0,mass->GetParameter(0)-mass->GetParameter(fNparBack));
+      blastpar->SetParError(0,mass->GetParError(fNparBack));
     }
     for(Int_t jb=1;jb<fNparBack;jb++){
       blastpar->SetParameter(jb,mass->GetParameter(jb));
@@ -1311,13 +1306,13 @@ void AliHFMassFitterVAR::AddFunctionsToHisto(){
     }
     if(ftypeOfFit4Sgn==2){
       if(ftypeOfFit4Bkg!=6){
-	blastpar->SetParameter(0,mass->GetParameter(0)-mass->GetParameter(fNparBack)-mass->GetParameter(fNparBack+fNparSignal)*mass->GetParameter(fNparBack));
-	blastpar->SetParError(0,mass->GetParError(fNparBack));
+        blastpar->SetParameter(0,mass->GetParameter(0)-mass->GetParameter(fNparBack)-mass->GetParameter(fNparBack+fNparSignal)*mass->GetParameter(fNparBack));
+        blastpar->SetParError(0,mass->GetParError(fNparBack));
       }
       blastpar->SetParameter(fNparBack,mass->GetParameter(fNparBack+fNparSignal));
       for(Int_t jr=1;jr<fNparRefl;jr++){
-	blastpar->SetParameter(jr+fNparBack,mass->GetParameter(fNparBack+fNparSignal+jr));
-	blastpar->SetParError(jr+fNparBack,mass->GetParError(fNparBack+fNparSignal+jr));
+        blastpar->SetParameter(jr+fNparBack,mass->GetParameter(fNparBack+fNparSignal+jr));
+        blastpar->SetParError(jr+fNparBack,mass->GetParError(fNparBack+fNparSignal+jr));
       }
     }
     else for(Int_t jr=0;jr<fNparRefl;jr++){
@@ -1331,10 +1326,10 @@ void AliHFMassFitterVAR::AddFunctionsToHisto(){
     hlist->Add((TF1*)bfullrange->Clone());
     hlist->Add((TF1*)blastpar->Clone());
     hlist->ls();
-  
+
     delete bfullrange;
     delete blastpar;
-    
+
   }
 
 
@@ -1342,7 +1337,7 @@ void AliHFMassFitterVAR::AddFunctionsToHisto(){
 //_________________________________________________________________________
 void AliHFMassFitterVAR::WriteCanvas(TString userIDstring,TString path,Double_t nsigma,Int_t writeFitInfo,Bool_t draw) const{
 
- //write the canvas in a root file
+  //write the canvas in a root file
 
   gStyle->SetOptStat(0);
   gStyle->SetCanvasColor(0);
@@ -1393,7 +1388,7 @@ void AliHFMassFitterVAR::DrawHere(TVirtualPad* pd,Double_t nsigma,Int_t writeFit
   PlotFitVAR(pd,nsigma,writeFitInfo);
 
   pd->Draw();
- 
+
 }
 //_________________________________________________________________________
 void AliHFMassFitterVAR::PlotFitVAR(TVirtualPad* pd,Double_t nsigma,Int_t writeFitInfo){
@@ -1406,12 +1401,12 @@ void AliHFMassFitterVAR::PlotFitVAR(TVirtualPad* pd,Double_t nsigma,Int_t writeF
   cout<<"Verbosity = "<<writeFitInfo<<endl;
 
   TH1F* hdraw=GetHistoClone();
-  
+
   if(!hdraw->GetFunction("funcmass") && !hdraw->GetFunction("funcbkgFullRange") && !hdraw->GetFunction("funcbkgRecalc")&& !hdraw->GetFunction("funcbkgonly")){
     cout<<"Probably fit failed and you didn't try to refit with background only, there's no function to be drawn"<<endl;
     return;
   }
- 
+
   if(hdraw->GetFunction("funcbkgonly")){ //Warning! if this function is present, no chance to draw the other!
     cout<<"Drawing background fit only"<<endl;
     hdraw->SetMinimum(0);
@@ -1427,33 +1422,33 @@ void AliHFMassFitterVAR::PlotFitVAR(TVirtualPad* pd,Double_t nsigma,Int_t writeF
       pinfo->SetFillStyle(0);
       TF1* f=hdraw->GetFunction("funcbkgonly");
       for (Int_t i=0;i<fNparBack;i++){
-	pinfo->SetTextColor(kBlue+3);
-	TString str=Form("%s = %.3f #pm %.3f",f->GetParName(i),f->GetParameter(i),f->GetParError(i));
-	pinfo->AddText(str);
+        pinfo->SetTextColor(kBlue+3);
+        TString str=Form("%s = %.3f #pm %.3f",f->GetParName(i),f->GetParameter(i),f->GetParError(i));
+        pinfo->AddText(str);
       }
 
       for (Int_t i=fNparBack;i<fNparBack+fNparSignal;i++){
-	pinfo->SetTextColor(kBlue+3);
-	TString str=Form("%s = %.3f #pm %.3f",f->GetParName(i),f->GetParameter(i),f->GetParError(i));
-	pinfo->AddText(str);
+        pinfo->SetTextColor(kBlue+3);
+        TString str=Form("%s = %.3f #pm %.3f",f->GetParName(i),f->GetParameter(i),f->GetParError(i));
+        pinfo->AddText(str);
       }
 
       for (Int_t i=fNparBack+fNparSignal;i<fNparBack+fNparSignal+fNparRefl;i++){
-	pinfo->SetTextColor(kBlue+3);
-	TString str=Form("%s = %.3f #pm %.3f",f->GetParName(i),f->GetParameter(i),f->GetParError(i));
-	pinfo->AddText(str);
+        pinfo->SetTextColor(kBlue+3);
+        TString str=Form("%s = %.3f #pm %.3f",f->GetParName(i),f->GetParameter(i),f->GetParError(i));
+        pinfo->AddText(str);
       }
 
       pinfo->AddText(Form("Reduced #chi^{2} = %.3f",f->GetChisquare()/f->GetNDF()));
       pd->cd();
       pinfo->DrawClone();
-      
-      
+
+
     }
 
     return;
   }
-  
+
   hdraw->SetMinimum(0);
   hdraw->GetXaxis()->SetRangeUser(fminMass,fmaxMass);
   pd->cd();
@@ -1489,7 +1484,7 @@ void AliHFMassFitterVAR::PlotFitVAR(TVirtualPad* pd,Double_t nsigma,Int_t writeF
       TString str=Form("%s = %.3f #pm %.3f",ff->GetParName(i),ff->GetParameter(i),ff->GetParError(i));
       pinfom->AddText(str);
     }
-  
+
     pd->cd();
     pinfom->DrawClone();
 
@@ -1522,26 +1517,26 @@ void AliHFMassFitterVAR::PlotFitVAR(TVirtualPad* pd,Double_t nsigma,Int_t writeF
 
       TF1 *fitCp;
       if(ftypeOfFit4Sgn==2){// drawing background function w/o reflection contribution
-	fitCp= new TF1("fbackcpfordrawing",this,&AliHFMassFitterVAR::FitFunction4BkgAndReflDraw,fminMass,fmaxMass,fNparBack+fNparRefl,"AliHFMassFitterVAR","FitFunction4BkgAndReflDraw");
-	fitCp->SetParameter(fNparBack,0);// set to 0 reflection normalization
-	
-	for(Int_t ibk=0;ibk<fNparBack;ibk++){
-	  fitCp->SetParameter(ibk,fitBkgRec->GetParameter(ibk));
-	}
-	fitCp->SetLineColor(kMagenta);
-	fitCp->SetLineStyle(7);
-	fitCp->SetLineWidth(2);
-	fitCp->DrawCopy("Lsame");
-	//Printf("WHERE I SHOULD BE: npars func=%d; par 0=%f, par1=%f,par2=%f",fitCp->GetNpar(),fitCp->GetParameter(0),fitCp->GetParameter(1),fitCp->GetParameter(2));
-	delete fitCp;
+        fitCp= new TF1("fbackcpfordrawing",this,&AliHFMassFitterVAR::FitFunction4BkgAndReflDraw,fminMass,fmaxMass,fNparBack+fNparRefl,"AliHFMassFitterVAR","FitFunction4BkgAndReflDraw");
+        fitCp->SetParameter(fNparBack,0);// set to 0 reflection normalization
+
+        for(Int_t ibk=0;ibk<fNparBack;ibk++){
+          fitCp->SetParameter(ibk,fitBkgRec->GetParameter(ibk));
+        }
+        fitCp->SetLineColor(kMagenta);
+        fitCp->SetLineStyle(7);
+        fitCp->SetLineWidth(2);
+        fitCp->DrawCopy("Lsame");
+        //Printf("WHERE I SHOULD BE: npars func=%d; par 0=%f, par1=%f,par2=%f",fitCp->GetNpar(),fitCp->GetParameter(0),fitCp->GetParameter(1),fitCp->GetParameter(2));
+        delete fitCp;
       }
     }
-    
+
     if(writeFitInfo > 1){
       for (Int_t i=0;i<fNparBack+fNparSignal;i++){
-	pinfob->SetTextColor(kRed);
-	str=Form("%s = %f #pm %f",ff->GetParName(i),ff->GetParameter(i),ff->GetParError(i));
-	pinfob->AddText(str);
+        pinfob->SetTextColor(kRed);
+        str=Form("%s = %f #pm %f",ff->GetParName(i),ff->GetParameter(i),ff->GetParError(i));
+        pinfob->AddText(str);
       }
       pd->cd();
       pinfob->DrawClone();
@@ -1588,14 +1583,14 @@ Double_t AliHFMassFitterVAR::GetReflOverSignal(Double_t &err)const{
   }
   err=funcmass->GetParError(fNparBack+fNparSignal);
   return funcmass->GetParameter(fNparBack+fNparSignal);
-  
+
 }
 //_________________________________________________________________________
 
 void AliHFMassFitterVAR::Signal(Double_t min, Double_t max, Double_t &signal,Double_t &errsignal) const {
 
   // Return signal integral in a range
-  
+
   if(fcounter==0) {
     cout<<"Use MassFitter method before Signal"<<endl;
     return;
@@ -1657,7 +1652,7 @@ void AliHFMassFitterVAR::Background(Double_t nOfSigma,Double_t &background,Doubl
   Background(min,max,background,errbackground);
 
   return;
-  
+
 }
 //___________________________________________________________________________
 
@@ -1693,7 +1688,7 @@ void AliHFMassFitterVAR::Background(Double_t min, Double_t max, Double_t &backgr
   }
 
   //relative error evaluation: from histo
-   
+
   intB=fhistoInvMass->Integral(1,fSideBandl)+fhistoInvMass->Integral(fSideBandr,fNbin);
   Double_t sum2=0;
   for(Int_t i=1;i<=fSideBandl;i++){
@@ -1705,7 +1700,7 @@ void AliHFMassFitterVAR::Background(Double_t min, Double_t max, Double_t &backgr
 
   intBerr=TMath::Sqrt(sum2);
   cout<<"Bkg relative error evaluation: from histo: "<<intBerr/intB<<endl;
-  
+
   cout<<"Last estimation of bkg error is used"<<endl;
 
   //backround +/- error in the range
@@ -1727,7 +1722,7 @@ void AliHFMassFitterVAR::Background(Double_t min, Double_t max, Double_t &backgr
 
 void AliHFMassFitterVAR::Significance(Double_t nOfSigma,Double_t &significance,Double_t &errsignificance) const  {
   // Return significance in mean+- n sigma
- 
+
   Double_t min=fMass-nOfSigma*fSigmaSgn;
   Double_t max=fMass+nOfSigma*fSigmaSgn;
   Significance(min, max, significance, errsignificance);
@@ -1752,7 +1747,7 @@ void AliHFMassFitterVAR::Significance(Double_t min, Double_t max, Double_t &sign
   }
 
   AliVertexingHFUtils::ComputeSignificance(signal,errsignal,background,errbackground,significance,errsignificance);
-  
+
   return;
 }
 
@@ -1865,7 +1860,7 @@ void AliHFMassFitterVAR::ComputeNFinalPars() {
     cout<<"AliHFMassFitterVAR, Error in computing fNparBack: check ftypeOfFit4Bkg"<<endl;
     break;
   }
-  
+
   fFixParBack=new Bool_t[fNparBack];
   fFixParBackExternalValue=new Bool_t[fNparBack];
   fparBackFixExt=new Double_t[fNparBack];
@@ -1875,13 +1870,13 @@ void AliHFMassFitterVAR::ComputeNFinalPars() {
     fFixParBackExternalValue[ib]=kFALSE;
     fparBackFixExt[ib]=0.;
   }
-  
+
   fNparSignal=3;
   fSignParNames=new TString[3];
   fSignParNames[0]="Signal";
   fSignParNames[1]="Mean";
   fSignParNames[2]="Sigma";
-  
+
   fFixParSign=new Bool_t[fNparSignal];
   fFixParSignExternalValue=new Bool_t[fNparSignal];
   fparSignFixExt=new Double_t[fNparSignal];
@@ -1911,7 +1906,7 @@ void AliHFMassFitterVAR::ComputeNFinalPars() {
     fparReflFixExt=0x0;
     fparReflFixExt=0x0;
   }
-  
+
 
   for(Int_t ib=0;ib<fNparRefl;ib++){
     fFixParRefl[ib]=kFALSE;
@@ -1932,7 +1927,7 @@ TPaveText* AliHFMassFitterVAR::GetFitParametersBox(Double_t nsigma,Int_t mode){
   pinfom->SetBorderSize(0);
   pinfom->SetFillStyle(0);
   TF1* ff=fhistoInvMass->GetFunction("funcmass");
-  
+
 
   for (Int_t i=fNparBack;i<fNparBack+fNparSignal;i++){
     pinfom->SetTextColor(kBlue);
@@ -1944,7 +1939,7 @@ TPaveText* AliHFMassFitterVAR::GetFitParametersBox(Double_t nsigma,Int_t mode){
     TString str=Form("%s = %.3f #pm %.3f",ff->GetParName(i),ff->GetParameter(i),ff->GetParError(i));
     pinfom->AddText(str);
   }
-  
+
   if(mode>1){
     pinfom->SetTextColor(kBlue+5);
     for (Int_t i=0;i<fNparBack;i++){      
@@ -1959,40 +1954,40 @@ TPaveText* AliHFMassFitterVAR::GetFitParametersBox(Double_t nsigma,Int_t mode){
 
 
 TPaveText* AliHFMassFitterVAR::GetYieldBox(Double_t nsigma){
-    TPaveText *pinfo2=new TPaveText(0.1,0.1,0.6,0.4,"NDC");
-    pinfo2->SetBorderSize(0);
-    pinfo2->SetFillStyle(0);
+  TPaveText *pinfo2=new TPaveText(0.1,0.1,0.6,0.4,"NDC");
+  pinfo2->SetBorderSize(0);
+  pinfo2->SetFillStyle(0);
 
-    Double_t signif, signal, bkg, errsignif, errsignal, errbkg;
+  Double_t signif, signal, bkg, errsignif, errsignal, errbkg;
 
-    Signal(nsigma,signal,errsignal);
-    Background(nsigma,bkg, errbkg);
-    AliVertexingHFUtils::ComputeSignificance(signal,errsignal,bkg,errbkg,signif,errsignif);
+  Signal(nsigma,signal,errsignal);
+  Background(nsigma,bkg, errbkg);
+  AliVertexingHFUtils::ComputeSignificance(signal,errsignal,bkg,errbkg,signif,errsignif);
 
 
-    TString str=Form("Significance (%.0f#sigma) %.1f #pm %.1f ",nsigma,signif,errsignif);
-    pinfo2->AddText(str);
-    str=Form("S (%.0f#sigma) %.0f #pm %.0f ",nsigma,signal,errsignal);
-    pinfo2->AddText(str);
-    str=Form("B (%.0f#sigma) %.0f #pm %.0f",nsigma,bkg,errbkg);
-    pinfo2->AddText(str);
-    if(bkg>0) str=Form("S/B (%.0f#sigma) %.4f ",nsigma,signal/bkg); 
-    pinfo2->AddText(str);
-    
-    return pinfo2;
+  TString str=Form("Significance (%.0f#sigma) %.1f #pm %.1f ",nsigma,signif,errsignif);
+  pinfo2->AddText(str);
+  str=Form("S (%.0f#sigma) %.0f #pm %.0f ",nsigma,signal,errsignal);
+  pinfo2->AddText(str);
+  str=Form("B (%.0f#sigma) %.0f #pm %.0f",nsigma,bkg,errbkg);
+  pinfo2->AddText(str);
+  if(bkg>0) str=Form("S/B (%.0f#sigma) %.4f ",nsigma,signal/bkg);
+  pinfo2->AddText(str);
+
+  return pinfo2;
 
 }
 
 
 
 TH1F* AliHFMassFitterVAR::GetOverBackgroundResidualsAndPulls(Double_t minrange,Double_t maxrange,TH1 *hPulls,TH1 *hResidualTrend,TH1 *hPullsTrend){
-  
+
 
   if(!fhistoInvMass){
     Printf("AliHFMassFitter::GetOverBackgroundResidualsAndPulls, invariant mass histogram not avaialble!");
     return 0x0;
   }
-  
+
   TF1 *fback=fhistoInvMass->GetFunction("funcbkgRecalc"); 
   if(!fback){
     Printf("AliHFMassFitter::GetOverBackgroundResidualsAndPulls, funcbkgRecalc not available!");
@@ -2003,7 +1998,7 @@ TH1F* AliHFMassFitterVAR::GetOverBackgroundResidualsAndPulls(Double_t minrange,D
   TF1 *fbackCp;
   if(ftypeOfFit4Sgn<2)fbackCp=new TF1("ftmpback",this,&AliHFMassFitterVAR::FitFunction4Bkg,fhistoInvMass->GetBinLowEdge(1),fhistoInvMass->GetBinLowEdge(fhistoInvMass->GetNbinsX()+1), fNparBack,"AliHFMassFitterVAR","FitFunction4Bkg");
   else fbackCp=new TF1("ftmpback",this,&AliHFMassFitterVAR::FitFunction4BkgAndReflDraw,fhistoInvMass->GetBinLowEdge(1),fhistoInvMass->GetBinLowEdge(fhistoInvMass->GetNbinsX()+1),fNparBack+fNparRefl,"AliHFMassFitterVAR","FitFunction4BkgAndReflDraw");
-  
+
   for(Int_t i=0;i<fback->GetNpar();i++){
     fbackCp->SetParameter(i,fback->GetParameter(i));
   }
@@ -2011,7 +2006,7 @@ TH1F* AliHFMassFitterVAR::GetOverBackgroundResidualsAndPulls(Double_t minrange,D
 
   TH1F *h=GetResidualsAndPulls(fhistoInvMass,fbackCp,minrange,maxrange,hPulls,hResidualTrend,hPullsTrend);
   delete fbackCp;
-  
+
   if(fSigmaSgn<0){
     Printf("AliHFMassFitter::GetOverBackgroundResidualsAndPulls, negative sigma: fit not performed or something went wrong, cannto draw gaussian term on top of residuals");    
     return h;
@@ -2030,13 +2025,13 @@ TH1F* AliHFMassFitterVAR::GetOverBackgroundResidualsAndPulls(Double_t minrange,D
 
 
 TH1F* AliHFMassFitterVAR::GetAllRangeResidualsAndPulls(Double_t minrange,Double_t maxrange,TH1 *hPulls,TH1 *hResidualTrend,TH1 *hPullsTrend){
-  
+
 
   if(!fhistoInvMass){
     Printf("AliHFMassFitter::GetAllRangeResidualsAndPulls, invariant mass histogram not avaialble!");
     return 0x0;
   }
-  
+
   TF1 *f=fhistoInvMass->GetFunction("funcmass"); 
   if(!f){
     Printf("AliHFMassFitter::GetAllRangeResidualsAndPulls, funcmass not available!");

--- a/PWGHF/vertexingHF/AliHFMassFitterVAR.cxx
+++ b/PWGHF/vertexingHF/AliHFMassFitterVAR.cxx
@@ -1375,14 +1375,14 @@ void AliHFMassFitterVAR::WriteCanvas(TString userIDstring,TString path,Double_t 
   filename.Prepend(userIDstring);
   path.Append(filename);
 
-  TFile* outputcv=new TFile(path.Data(),"update");
-
-  TCanvas* c=(TCanvas*)GetPad(nsigma,writeFitInfo);
+  TCanvas* c = static_cast<TCanvas*>(GetPad(nsigma,writeFitInfo));
   c->SetName(Form("%s%s%s",c->GetName(),userIDstring.Data(),type.Data()));
-  if(draw)c->DrawClone();
-  outputcv->cd();
+  if (draw) c->DrawClone();
+
+  TFile outputcv(path.Data(),"update");
+  outputcv.cd();
   c->Write();
-  outputcv->Close();
+  outputcv.Close();
 }
 
 

--- a/PWGHF/vertexingHF/AliHFMassFitterVAR.h
+++ b/PWGHF/vertexingHF/AliHFMassFitterVAR.h
@@ -95,7 +95,7 @@ class AliHFMassFitterVAR : public AliHFMassFitter {
   void     Significance(Double_t nOfSigma,Double_t &significance,Double_t &errsignificance) const; /// significance in nsigma with error
   void     Significance(Double_t min,Double_t max,Double_t &significance,Double_t &errsignificance) const; /// significance in (min, max) with error
   Double_t GetReflOverSignal(Double_t &err)const;
-  TH1F*    SetTemplateReflections(const TH1 *h,TString option="templ",Double_t minRange=1.72,Double_t maxRange=2.05);
+  TH1F*    SetTemplateReflections(const TH1F *h,TString option="templ",Double_t minRange=1.72,Double_t maxRange=2.05);
   void     SetFixReflOverS(Double_t val,Bool_t fixpar=kTRUE){fReflInit=val;
     if(ftypeOfFit4Sgn!=2)Printf("Set or Fixing Refl/Signal but fit with template not foreseen");
     fFixParReflExternalValue[0]=fixpar;

--- a/PWGHF/vertexingHF/AliHFMultiTrials.cxx
+++ b/PWGHF/vertexingHF/AliHFMultiTrials.cxx
@@ -119,9 +119,9 @@ Bool_t AliHFMultiTrials::CreateHistos(){
 
   TString funcBkg[kNBkgFuncCases]={"Expo","Lin","Pol2","Pol3","Pol4","Pol5","PowLaw","PowLawExpo"};
   TString gausSig[kNFitConfCases]={"FixedS","FixedSp20","FixedSm20","FreeS","FixedMeanFixedS","FixedMeanFreeS"};
-  
+
   Int_t totTrials=fNumOfRebinSteps*fNumOfFirstBinSteps*fNumOfLowLimFitSteps*fNumOfUpLimFitSteps;
-  
+
   fHistoRawYieldDistAll = new TH1F(Form("hRawYieldDistAll%s",fSuffix.Data()),"  ; Raw Yield",5000,0.,50000.);
   fHistoRawYieldTrialAll = new TH1F(Form("hRawYieldTrialAll%s",fSuffix.Data())," ; Trial # ; Raw Yield",nCases*totTrials,-0.5,nCases*totTrials-0.5);
   fHistoSigmaTrialAll = new TH1F(Form("hSigmaTrialAll%s",fSuffix.Data())," ; Trial # ; Sigma (GeV/c^{2})",nCases*totTrials,-0.5,nCases*totTrials-0.5);
@@ -175,7 +175,7 @@ Bool_t AliHFMultiTrials::CreateHistos(){
         fHistoBkgTrial[theCase]->SetMarkerStyle(7);
         fHistoBkgInBinEdgesTrial[theCase]->SetMarkerStyle(7);
       }
-      
+
     }
   }
   fNtupleMultiTrials = new TNtuple(Form("ntuMultiTrial%s",fSuffix.Data()),Form("ntuMultiTrial%s",fSuffix.Data()),"rebin:firstb:minfit:maxfit:bkgfunc:confsig:confmean:chi2:signif:mean:emean:sigma:esigma:rawy:erawy",128000);
@@ -190,7 +190,7 @@ Bool_t AliHFMultiTrials::DoMultiTrials(TH1D* hInvMassHisto, TPad* thePad){
 
   Bool_t hOK=CreateHistos();
   if(!hOK) return kFALSE;
-  
+
   Int_t itrial=0;
   Int_t types=0;
   Int_t itrialBC=0;
@@ -207,219 +207,219 @@ Bool_t AliHFMultiTrials::DoMultiTrials(TH1D* hInvMassHisto, TPad* thePad){
       if(fNumOfFirstBinSteps==1) hRebinned=RebinHisto(hInvMassHisto,rebin,-1);
       else hRebinned=RebinHisto(hInvMassHisto,rebin,iFirstBin);
       for(Int_t iMinMass=0; iMinMass<fNumOfLowLimFitSteps; iMinMass++){
-	Double_t minMassForFit=fLowLimFitSteps[iMinMass];
-	Double_t hmin=TMath::Max(minMassForFit,hRebinned->GetBinLowEdge(2));
-	for(Int_t iMaxMass=0; iMaxMass<fNumOfUpLimFitSteps; iMaxMass++){
-	  Double_t maxMassForFit=fUpLimFitSteps[iMaxMass];
-	  Double_t hmax=TMath::Min(maxMassForFit,hRebinned->GetBinLowEdge(hRebinned->GetNbinsX()));
-	  ++itrial;
-	  for(Int_t typeb=0; typeb<kNBkgFuncCases; typeb++){
-	    if(typeb==kExpoBkg && !fUseExpoBkg) continue;
-	    if(typeb==kLinBkg && !fUseLinBkg) continue;
-	    if(typeb==kPol2Bkg && !fUsePol2Bkg) continue;
-	    if(typeb==kPol3Bkg && !fUsePol3Bkg) continue;
-	    if(typeb==kPol4Bkg && !fUsePol4Bkg) continue;
-	    if(typeb==kPol5Bkg && !fUsePol5Bkg) continue;
-	    if(typeb==kPowBkg && !fUsePowLawBkg) continue;
-	    if(typeb==kPowTimesExpoBkg && !fUsePowLawTimesExpoBkg) continue;
-	    for(Int_t igs=0; igs<kNFitConfCases; igs++){
-	      if (igs==kFixSigUpFreeMean && !fUseFixSigUpFreeMean) continue;
-	      if (igs==kFixSigDownFreeMean && !fUseFixSigDownFreeMean) continue;
-	      if (igs==kFreeSigFixMean  && !fUseFixedMeanFreeS) continue;
-	      if (igs==kFreeSigFreeMean  && !fUseFreeS) continue;
-	      if (igs==kFixSigFreeMean  && !fUseFixSigFreeMean) continue;
-	      if (igs==kFixSigFixMean   && !fUseFixSigFixMean) continue;
-	      Int_t theCase=igs*kNBkgFuncCases+typeb;
-	      Int_t globBin=itrial+theCase*totTrials;
-	      for(Int_t j=0; j<15; j++) xnt[j]=0.;
-	      
-	      AliHFMassFitterVAR*  fitter=0x0;
-	      if(typeb<=kPol2Bkg){
-		fitter=new AliHFMassFitterVAR(hRebinned,hmin, hmax,1,typeb,types);
-	      }else if(typeb==kPowBkg){
-		fitter=new AliHFMassFitterVAR(hRebinned,hmin, hmax,1,4,types);		
-	      }else if(typeb==kPowTimesExpoBkg){
-		fitter=new AliHFMassFitterVAR(hRebinned,hmin, hmax,1,5,types);
-	      }else{
-		fitter=new AliHFMassFitterVAR(hRebinned,hmin, hmax,1,6,types);
-		if(typeb==kPol3Bkg) fitter->SetBackHighPolDegree(3);
-		if(typeb==kPol4Bkg) fitter->SetBackHighPolDegree(4);
-		if(typeb==kPol5Bkg) fitter->SetBackHighPolDegree(5);
-	      }
-	      fitter->SetReflectionSigmaFactor(0);
-	      //if D0 Reflection
-	      if(fhTemplRefl){
-		fitter=new AliHFMassFitterVAR(hRebinned,hmin,hmax,1,typeb,2);
-		fitter->SetTemplateReflections(fhTemplRefl);
-		fitter->SetFixReflOverS(fFixRefloS,kTRUE);
-	      }
-	      if(fFitOption==1) fitter->SetUseChi2Fit();
-	      fitter->SetInitialGaussianMean(fMassD);
-	      fitter->SetInitialGaussianSigma(fSigmaGausMC);
-	      xnt[0]=rebin;
-	      xnt[1]=iFirstBin;
-	      xnt[2]=minMassForFit;
-	      xnt[3]=maxMassForFit;
-	      xnt[4]=typeb;
-	      xnt[6]=0;
-	      if(igs==kFixSigFreeMean){
-		fitter->SetFixGaussianSigma(fSigmaGausMC,kTRUE);
-		xnt[5]=1;
-	      }else if(igs==kFixSigUpFreeMean){
-		fitter->SetFixGaussianSigma(fSigmaGausMC*(1.+fSigmaMCVariation),kTRUE);
-		xnt[5]=2;
-	      }else if(igs==kFixSigDownFreeMean){
-		fitter->SetFixGaussianSigma(fSigmaGausMC*(1.-fSigmaMCVariation),kTRUE);
-		xnt[5]=3;
-	      }else if(igs==kFreeSigFreeMean){
-		xnt[5]=0;
-	      }else if(igs==kFixSigFixMean){
-		fitter->SetFixGaussianSigma(fSigmaGausMC,kTRUE);
-		fitter->SetFixGaussianMean(fMassD,kTRUE);
-		xnt[5]=1;
-		xnt[6]=1;
-	      }else if(igs==kFreeSigFixMean){
-		fitter->SetFixGaussianMean(fMassD,kTRUE);	      
-		xnt[5]=0;
-		xnt[6]=1;
-	      }
-	      Bool_t out=kFALSE;
-	      Double_t chisq=-1.;
-	      Double_t sigma=0.;
-	      Double_t esigma=0.;
-	      Double_t pos=.0;
-	      Double_t epos=.0;
-	      Double_t ry=.0;
-	      Double_t ery=.0;
-	      Double_t significance=0.;
-	      Double_t erSignif=0.;
-	      Double_t bkg=0.;
-	      Double_t erbkg=0.;
-	      Double_t bkgBEdge=0;
-	      Double_t erbkgBEdge=0;
-	      TF1* fB1=0x0;
-	      if(typeb<kNBkgFuncCases){
-		printf("****** START FIT OF HISTO %s WITH REBIN %d FIRST BIN %d MASS RANGE %f-%f BACKGROUND FIT FUNCTION=%d CONFIG SIGMA/MEAN=%d\n",hInvMassHisto->GetName(),rebin,iFirstBin,minMassForFit,maxMassForFit,typeb,igs);
-		out=fitter->MassFitter(0);
-		chisq=fitter->GetReducedChiSquare();
-		fitter->Significance(3,significance,erSignif);
-		sigma=fitter->GetSigma();
-		pos=fitter->GetMean();
-		esigma=fitter->GetSigmaUncertainty();
-		if(esigma<0.00001) esigma=0.0001;
-		epos=fitter->GetMeanUncertainty();
-		if(epos<0.00001) epos=0.0001;
-		ry=fitter->GetRawYield(); 
-		ery=fitter->GetRawYieldError(); 
-		fB1=fitter->GetBackgroundFullRangeFunc();
-	        fitter->Background(fnSigmaForBkgEval,bkg,erbkg);
-		Double_t minval = hInvMassHisto->GetXaxis()->GetBinLowEdge(hInvMassHisto->FindBin(pos-fnSigmaForBkgEval*sigma));
-		Double_t maxval = hInvMassHisto->GetXaxis()->GetBinUpEdge(hInvMassHisto->FindBin(pos+fnSigmaForBkgEval*sigma));
-	  	fitter->Background(minval,maxval,bkgBEdge,erbkgBEdge);
-		if(out && fDrawIndividualFits && thePad){
-		  thePad->Clear();
-		  fitter->DrawHere(thePad);
-		  for (auto format : fInvMassFitSaveAsFormats) {
-		    thePad->SaveAs(Form("FitOutput_%s_Trial%d.%s",hInvMassHisto->GetName(),globBin, format.c_str()));
-		  }
-		}
-	      }
-	      // else{
-	      //   out=DoFitWithPol3Bkg(hRebinned,hmin,hmax,igs);
-	      //   if(out && thePad){
-	      // 	thePad->Clear();
-	      // 	hRebinned->Draw();
-	      // 	TF1* fSB=(TF1*)hRebinned->GetListOfFunctions()->FindObject("fSB");
-	      // 	fB1=new TF1("fB1","[0]+[1]*x+[2]*x*x+[3]*x*x*x",hmin,hmax);
-	      // 	for(Int_t j=0; j<4; j++) fB1->SetParameter(j,fSB->GetParameter(3+j));
-	      // 	fB1->SetLineColor(2);
-	      // 	fB1->Draw("same");
-	      // 	fSB->SetLineColor(4);
-	      // 	fSB->Draw("same");
-	      // 	thePad->Update();
-	      // 	chisq=fSB->GetChisquare()/fSB->GetNDF();;
-	      // 	sigma=fSB->GetParameter(2);
-	      // 	esigma=fSB->GetParError(2);
-	      // 	if(esigma<0.00001) esigma=0.0001;
-	      // 	pos=fSB->GetParameter(1);
-	      // 	epos=fSB->GetParError(1);
-	      // 	if(epos<0.00001) epos=0.0001;
-	      // 	ry=fSB->GetParameter(0)/hRebinned->GetBinWidth(1);
-	      // 	ery=fSB->GetParError(0)/hRebinned->GetBinWidth(1);
-	      //   }
-	      // }
-	      xnt[7]=chisq;
-	      if(out && chisq>0. && sigma>0.5*fSigmaGausMC && sigma<2.0*fSigmaGausMC){
-		xnt[8]=significance;
-		xnt[9]=pos;
-		xnt[10]=epos;
-		xnt[11]=sigma;
-		xnt[12]=esigma;
-		xnt[13]=ry;
-		xnt[14]=ery;
-		fHistoRawYieldDistAll->Fill(ry);
-		fHistoRawYieldTrialAll->SetBinContent(globBin,ry);
-		fHistoRawYieldTrialAll->SetBinError(globBin,ery);
-		fHistoSigmaTrialAll->SetBinContent(globBin,sigma);
-		fHistoSigmaTrialAll->SetBinError(globBin,esigma);
-		fHistoMeanTrialAll->SetBinContent(globBin,pos);
-		fHistoMeanTrialAll->SetBinError(globBin,epos);
-		fHistoChi2TrialAll->SetBinContent(globBin,chisq);
-		fHistoChi2TrialAll->SetBinError(globBin,0.00001);
-		fHistoSignifTrialAll->SetBinContent(globBin,significance);
-		fHistoSignifTrialAll->SetBinError(globBin,erSignif);
-	        if(fSaveBkgVal) {
-	  	  fHistoBkgTrialAll->SetBinContent(globBin,bkg);
-		  fHistoBkgTrialAll->SetBinError(globBin,erbkg);
-		  fHistoBkgInBinEdgesTrialAll->SetBinContent(globBin,bkgBEdge);
-		  fHistoBkgInBinEdgesTrialAll->SetBinError(globBin,erbkgBEdge);
-		}
+        Double_t minMassForFit=fLowLimFitSteps[iMinMass];
+        Double_t hmin=TMath::Max(minMassForFit,hRebinned->GetBinLowEdge(2));
+        for(Int_t iMaxMass=0; iMaxMass<fNumOfUpLimFitSteps; iMaxMass++){
+          Double_t maxMassForFit=fUpLimFitSteps[iMaxMass];
+          Double_t hmax=TMath::Min(maxMassForFit,hRebinned->GetBinLowEdge(hRebinned->GetNbinsX()));
+          ++itrial;
+          for(Int_t typeb=0; typeb<kNBkgFuncCases; typeb++){
+            if(typeb==kExpoBkg && !fUseExpoBkg) continue;
+            if(typeb==kLinBkg && !fUseLinBkg) continue;
+            if(typeb==kPol2Bkg && !fUsePol2Bkg) continue;
+            if(typeb==kPol3Bkg && !fUsePol3Bkg) continue;
+            if(typeb==kPol4Bkg && !fUsePol4Bkg) continue;
+            if(typeb==kPol5Bkg && !fUsePol5Bkg) continue;
+            if(typeb==kPowBkg && !fUsePowLawBkg) continue;
+            if(typeb==kPowTimesExpoBkg && !fUsePowLawTimesExpoBkg) continue;
+            for(Int_t igs=0; igs<kNFitConfCases; igs++){
+              if (igs==kFixSigUpFreeMean && !fUseFixSigUpFreeMean) continue;
+              if (igs==kFixSigDownFreeMean && !fUseFixSigDownFreeMean) continue;
+              if (igs==kFreeSigFixMean  && !fUseFixedMeanFreeS) continue;
+              if (igs==kFreeSigFreeMean  && !fUseFreeS) continue;
+              if (igs==kFixSigFreeMean  && !fUseFixSigFreeMean) continue;
+              if (igs==kFixSigFixMean   && !fUseFixSigFixMean) continue;
+              Int_t theCase=igs*kNBkgFuncCases+typeb;
+              Int_t globBin=itrial+theCase*totTrials;
+              for(Int_t j=0; j<15; j++) xnt[j]=0.;
 
-		if(ry<fMinYieldGlob) fMinYieldGlob=ry;
-		if(ry>fMaxYieldGlob) fMaxYieldGlob=ry;
-		fHistoRawYieldDist[theCase]->Fill(ry);
-		fHistoRawYieldTrial[theCase]->SetBinContent(itrial,ry);
-		fHistoRawYieldTrial[theCase]->SetBinError(itrial,ery);
-		fHistoSigmaTrial[theCase]->SetBinContent(itrial,sigma);
-		fHistoSigmaTrial[theCase]->SetBinError(itrial,esigma);
-		fHistoMeanTrial[theCase]->SetBinContent(itrial,pos);
-		fHistoMeanTrial[theCase]->SetBinError(itrial,epos);
-		fHistoChi2Trial[theCase]->SetBinContent(itrial,chisq);
-		fHistoChi2Trial[theCase]->SetBinError(itrial,0.00001);
-		fHistoSignifTrial[theCase]->SetBinContent(itrial,significance);
-		fHistoSignifTrial[theCase]->SetBinError(itrial,erSignif);
-	        if(fSaveBkgVal) {
-	  	  fHistoBkgTrial[theCase]->SetBinContent(itrial,bkg);
-		  fHistoBkgTrial[theCase]->SetBinError(itrial,erbkg);
-		  fHistoBkgInBinEdgesTrial[theCase]->SetBinContent(itrial,bkgBEdge);
-		  fHistoBkgInBinEdgesTrial[theCase]->SetBinError(itrial,erbkgBEdge);
-		}
+              AliHFMassFitterVAR*  fitter=0x0;
+              if(typeb<=kPol2Bkg){
+                fitter=new AliHFMassFitterVAR(hRebinned,hmin, hmax,1,typeb,types);
+              }else if(typeb==kPowBkg){
+                fitter=new AliHFMassFitterVAR(hRebinned,hmin, hmax,1,4,types);
+              }else if(typeb==kPowTimesExpoBkg){
+                fitter=new AliHFMassFitterVAR(hRebinned,hmin, hmax,1,5,types);
+              }else{
+                fitter=new AliHFMassFitterVAR(hRebinned,hmin, hmax,1,6,types);
+                if(typeb==kPol3Bkg) fitter->SetBackHighPolDegree(3);
+                if(typeb==kPol4Bkg) fitter->SetBackHighPolDegree(4);
+                if(typeb==kPol5Bkg) fitter->SetBackHighPolDegree(5);
+              }
+              fitter->SetReflectionSigmaFactor(0);
+              //if D0 Reflection
+              if(fhTemplRefl){
+                fitter=new AliHFMassFitterVAR(hRebinned,hmin,hmax,1,typeb,2);
+                fitter->SetTemplateReflections(fhTemplRefl);
+                fitter->SetFixReflOverS(fFixRefloS,kTRUE);
+              }
+              if(fFitOption==1) fitter->SetUseChi2Fit();
+              fitter->SetInitialGaussianMean(fMassD);
+              fitter->SetInitialGaussianSigma(fSigmaGausMC);
+              xnt[0]=rebin;
+              xnt[1]=iFirstBin;
+              xnt[2]=minMassForFit;
+              xnt[3]=maxMassForFit;
+              xnt[4]=typeb;
+              xnt[6]=0;
+              if(igs==kFixSigFreeMean){
+                fitter->SetFixGaussianSigma(fSigmaGausMC,kTRUE);
+                xnt[5]=1;
+              }else if(igs==kFixSigUpFreeMean){
+                fitter->SetFixGaussianSigma(fSigmaGausMC*(1.+fSigmaMCVariation),kTRUE);
+                xnt[5]=2;
+              }else if(igs==kFixSigDownFreeMean){
+                fitter->SetFixGaussianSigma(fSigmaGausMC*(1.-fSigmaMCVariation),kTRUE);
+                xnt[5]=3;
+              }else if(igs==kFreeSigFreeMean){
+                xnt[5]=0;
+              }else if(igs==kFixSigFixMean){
+                fitter->SetFixGaussianSigma(fSigmaGausMC,kTRUE);
+                fitter->SetFixGaussianMean(fMassD,kTRUE);
+                xnt[5]=1;
+                xnt[6]=1;
+              }else if(igs==kFreeSigFixMean){
+                fitter->SetFixGaussianMean(fMassD,kTRUE);
+                xnt[5]=0;
+                xnt[6]=1;
+              }
+              Bool_t out=kFALSE;
+              Double_t chisq=-1.;
+              Double_t sigma=0.;
+              Double_t esigma=0.;
+              Double_t pos=.0;
+              Double_t epos=.0;
+              Double_t ry=.0;
+              Double_t ery=.0;
+              Double_t significance=0.;
+              Double_t erSignif=0.;
+              Double_t bkg=0.;
+              Double_t erbkg=0.;
+              Double_t bkgBEdge=0;
+              Double_t erbkgBEdge=0;
+              TF1* fB1=0x0;
+              if(typeb<kNBkgFuncCases){
+                printf("****** START FIT OF HISTO %s WITH REBIN %d FIRST BIN %d MASS RANGE %f-%f BACKGROUND FIT FUNCTION=%d CONFIG SIGMA/MEAN=%d\n",hInvMassHisto->GetName(),rebin,iFirstBin,minMassForFit,maxMassForFit,typeb,igs);
+                out=fitter->MassFitter(0);
+                chisq=fitter->GetReducedChiSquare();
+                fitter->Significance(3,significance,erSignif);
+                sigma=fitter->GetSigma();
+                pos=fitter->GetMean();
+                esigma=fitter->GetSigmaUncertainty();
+                if(esigma<0.00001) esigma=0.0001;
+                epos=fitter->GetMeanUncertainty();
+                if(epos<0.00001) epos=0.0001;
+                ry=fitter->GetRawYield();
+                ery=fitter->GetRawYieldError();
+                fB1=fitter->GetBackgroundFullRangeFunc();
+                fitter->Background(fnSigmaForBkgEval,bkg,erbkg);
+                Double_t minval = hInvMassHisto->GetXaxis()->GetBinLowEdge(hInvMassHisto->FindBin(pos-fnSigmaForBkgEval*sigma));
+                Double_t maxval = hInvMassHisto->GetXaxis()->GetBinUpEdge(hInvMassHisto->FindBin(pos+fnSigmaForBkgEval*sigma));
+                fitter->Background(minval,maxval,bkgBEdge,erbkgBEdge);
+                if(out && fDrawIndividualFits && thePad){
+                  thePad->Clear();
+                  fitter->DrawHere(thePad);
+                  for (auto format : fInvMassFitSaveAsFormats) {
+                    thePad->SaveAs(Form("FitOutput_%s_Trial%d.%s",hInvMassHisto->GetName(),globBin, format.c_str()));
+                  }
+                }
+              }
+              // else{
+              //   out=DoFitWithPol3Bkg(hRebinned,hmin,hmax,igs);
+              //   if(out && thePad){
+              // 	thePad->Clear();
+              // 	hRebinned->Draw();
+              // 	TF1* fSB=(TF1*)hRebinned->GetListOfFunctions()->FindObject("fSB");
+              // 	fB1=new TF1("fB1","[0]+[1]*x+[2]*x*x+[3]*x*x*x",hmin,hmax);
+              // 	for(Int_t j=0; j<4; j++) fB1->SetParameter(j,fSB->GetParameter(3+j));
+              // 	fB1->SetLineColor(2);
+              // 	fB1->Draw("same");
+              // 	fSB->SetLineColor(4);
+              // 	fSB->Draw("same");
+              // 	thePad->Update();
+              // 	chisq=fSB->GetChisquare()/fSB->GetNDF();;
+              // 	sigma=fSB->GetParameter(2);
+              // 	esigma=fSB->GetParError(2);
+              // 	if(esigma<0.00001) esigma=0.0001;
+              // 	pos=fSB->GetParameter(1);
+              // 	epos=fSB->GetParError(1);
+              // 	if(epos<0.00001) epos=0.0001;
+              // 	ry=fSB->GetParameter(0)/hRebinned->GetBinWidth(1);
+              // 	ery=fSB->GetParError(0)/hRebinned->GetBinWidth(1);
+              //   }
+              // }
+              xnt[7]=chisq;
+              if(out && chisq>0. && sigma>0.5*fSigmaGausMC && sigma<2.0*fSigmaGausMC){
+                xnt[8]=significance;
+                xnt[9]=pos;
+                xnt[10]=epos;
+                xnt[11]=sigma;
+                xnt[12]=esigma;
+                xnt[13]=ry;
+                xnt[14]=ery;
+                fHistoRawYieldDistAll->Fill(ry);
+                fHistoRawYieldTrialAll->SetBinContent(globBin,ry);
+                fHistoRawYieldTrialAll->SetBinError(globBin,ery);
+                fHistoSigmaTrialAll->SetBinContent(globBin,sigma);
+                fHistoSigmaTrialAll->SetBinError(globBin,esigma);
+                fHistoMeanTrialAll->SetBinContent(globBin,pos);
+                fHistoMeanTrialAll->SetBinError(globBin,epos);
+                fHistoChi2TrialAll->SetBinContent(globBin,chisq);
+                fHistoChi2TrialAll->SetBinError(globBin,0.00001);
+                fHistoSignifTrialAll->SetBinContent(globBin,significance);
+                fHistoSignifTrialAll->SetBinError(globBin,erSignif);
+                if(fSaveBkgVal) {
+                  fHistoBkgTrialAll->SetBinContent(globBin,bkg);
+                  fHistoBkgTrialAll->SetBinError(globBin,erbkg);
+                  fHistoBkgInBinEdgesTrialAll->SetBinContent(globBin,bkgBEdge);
+                  fHistoBkgInBinEdgesTrialAll->SetBinError(globBin,erbkgBEdge);
+                }
 
-		for(Int_t iStepBC=0; iStepBC<fNumOfnSigmaBinCSteps; iStepBC++){
-		  Double_t minMassBC=fMassD-fnSigmaBinCSteps[iStepBC]*sigma;
-		  Double_t maxMassBC=fMassD+fnSigmaBinCSteps[iStepBC]*sigma;
-		  if(minMassBC>minMassForFit && 
-		     maxMassBC<maxMassForFit && 
-			       minMassBC>(hRebinned->GetXaxis()->GetXmin()) &&
-		     maxMassBC<(hRebinned->GetXaxis()->GetXmax())){
-		    Double_t cnts,ecnts;
-		    BinCount(hRebinned,fB1,1,minMassBC,maxMassBC,cnts,ecnts);
-		    ++itrialBC;
-		    fHistoRawYieldDistBinCAll->Fill(cnts);
-		    fHistoRawYieldTrialBinCAll->SetBinContent(globBin,iStepBC+1,cnts);
-		    fHistoRawYieldTrialBinCAll->SetBinError(globBin,iStepBC+1,ecnts);
-		    fHistoRawYieldTrialBinC[theCase]->SetBinContent(itrial,iStepBC+1,cnts);
-		    fHistoRawYieldTrialBinC[theCase]->SetBinError(itrial,iStepBC+1,ecnts);		    
-		    fHistoRawYieldDistBinC[theCase]->Fill(cnts);
-		  }
-		}
-	      }
-	      delete fitter;
-	      //	    if(typeb>4) delete fB1;
-	      fNtupleMultiTrials->Fill(xnt);
-	    }
-	  }
-	}
+                if(ry<fMinYieldGlob) fMinYieldGlob=ry;
+                if(ry>fMaxYieldGlob) fMaxYieldGlob=ry;
+                fHistoRawYieldDist[theCase]->Fill(ry);
+                fHistoRawYieldTrial[theCase]->SetBinContent(itrial,ry);
+                fHistoRawYieldTrial[theCase]->SetBinError(itrial,ery);
+                fHistoSigmaTrial[theCase]->SetBinContent(itrial,sigma);
+                fHistoSigmaTrial[theCase]->SetBinError(itrial,esigma);
+                fHistoMeanTrial[theCase]->SetBinContent(itrial,pos);
+                fHistoMeanTrial[theCase]->SetBinError(itrial,epos);
+                fHistoChi2Trial[theCase]->SetBinContent(itrial,chisq);
+                fHistoChi2Trial[theCase]->SetBinError(itrial,0.00001);
+                fHistoSignifTrial[theCase]->SetBinContent(itrial,significance);
+                fHistoSignifTrial[theCase]->SetBinError(itrial,erSignif);
+                if(fSaveBkgVal) {
+                  fHistoBkgTrial[theCase]->SetBinContent(itrial,bkg);
+                  fHistoBkgTrial[theCase]->SetBinError(itrial,erbkg);
+                  fHistoBkgInBinEdgesTrial[theCase]->SetBinContent(itrial,bkgBEdge);
+                  fHistoBkgInBinEdgesTrial[theCase]->SetBinError(itrial,erbkgBEdge);
+                }
+
+                for(Int_t iStepBC=0; iStepBC<fNumOfnSigmaBinCSteps; iStepBC++){
+                  Double_t minMassBC=fMassD-fnSigmaBinCSteps[iStepBC]*sigma;
+                  Double_t maxMassBC=fMassD+fnSigmaBinCSteps[iStepBC]*sigma;
+                  if(minMassBC>minMassForFit &&
+                      maxMassBC<maxMassForFit &&
+                      minMassBC>(hRebinned->GetXaxis()->GetXmin()) &&
+                      maxMassBC<(hRebinned->GetXaxis()->GetXmax())){
+                    Double_t cnts,ecnts;
+                    BinCount(hRebinned,fB1,1,minMassBC,maxMassBC,cnts,ecnts);
+                    ++itrialBC;
+                    fHistoRawYieldDistBinCAll->Fill(cnts);
+                    fHistoRawYieldTrialBinCAll->SetBinContent(globBin,iStepBC+1,cnts);
+                    fHistoRawYieldTrialBinCAll->SetBinError(globBin,iStepBC+1,ecnts);
+                    fHistoRawYieldTrialBinC[theCase]->SetBinContent(itrial,iStepBC+1,cnts);
+                    fHistoRawYieldTrialBinC[theCase]->SetBinError(itrial,iStepBC+1,ecnts);
+                    fHistoRawYieldDistBinC[theCase]->Fill(cnts);
+                  }
+                }
+              }
+              delete fitter;
+              //	    if(typeb>4) delete fB1;
+              fNtupleMultiTrials->Fill(xnt);
+            }
+          }
+        }
       }
       delete hRebinned;
     }
@@ -497,7 +497,7 @@ void AliHFMultiTrials::DrawHistos(TCanvas* cry) const{
 }
 //________________________________________________________________________
 TH1F* AliHFMultiTrials::RebinHisto(TH1D* hOrig, Int_t reb, Int_t firstUse) const{
-    // Rebin histogram, from bin firstUse to lastUse
+  // Rebin histogram, from bin firstUse to lastUse
   // Use all bins if firstUse=-1
 
   Int_t nBinOrig=hOrig->GetNbinsX();
@@ -555,7 +555,7 @@ void AliHFMultiTrials::BinCount(TH1F* h, TF1* fB, Int_t rebin, Double_t minMass,
 }
 //________________________________________________________________________
 Bool_t AliHFMultiTrials::DoFitWithPol3Bkg(TH1F* histoToFit, Double_t  hmin, Double_t  hmax, 
-					  Int_t iCase){
+    Int_t iCase){
   //
 
   TH1F *hCutTmp=(TH1F*)histoToFit->Clone("hCutTmp");

--- a/PWGHF/vertexingHF/AliHFMultiTrials.cxx
+++ b/PWGHF/vertexingHF/AliHFMultiTrials.cxx
@@ -179,6 +179,7 @@ Bool_t AliHFMultiTrials::CreateHistos(){
     }
   }
   fNtupleMultiTrials = new TNtuple(Form("ntuMultiTrial%s",fSuffix.Data()),Form("ntuMultiTrial%s",fSuffix.Data()),"rebin:firstb:minfit:maxfit:bkgfunc:confsig:confmean:chi2:signif:mean:emean:sigma:esigma:rawy:erawy",128000);
+  fNtupleMultiTrials->SetDirectory(nullptr);
   return kTRUE;
 
 }
@@ -249,7 +250,7 @@ Bool_t AliHFMultiTrials::DoMultiTrials(TH1D* hInvMassHisto, TPad* thePad){
 	      //if D0 Reflection
 	      if(fhTemplRefl){
 		fitter=new AliHFMassFitterVAR(hRebinned,hmin,hmax,1,typeb,2);
-		fitter->SetTemplateReflections((TH1*)fhTemplRefl);
+		fitter->SetTemplateReflections(fhTemplRefl);
 		fitter->SetFixReflOverS(fFixRefloS,kTRUE);
 	      }
 	      if(fFitOption==1) fitter->SetUseChi2Fit();
@@ -430,7 +431,12 @@ Bool_t AliHFMultiTrials::DoMultiTrials(TH1D* hInvMassHisto, TPad* thePad){
 void AliHFMultiTrials::SaveToRoot(TString fileName, TString option) const{
   // save histos in a root file for further analysis
   const Int_t nCases=kNBkgFuncCases*kNFitConfCases;
-  TFile* outHistos=new TFile(fileName.Data(),option.Data());
+  TFile outHistos(fileName.Data(),option.Data());
+  if (outHistos.IsZombie()) {
+    Printf("Could not open file '%s'!", fileName.Data());
+    return;
+  }
+  outHistos.cd();
   fHistoRawYieldTrialAll->Write();
   fHistoSigmaTrialAll->Write();
   fHistoMeanTrialAll->Write();
@@ -455,10 +461,9 @@ void AliHFMultiTrials::SaveToRoot(TString fileName, TString option) const{
     fHistoRawYieldTrialBinC[ic]->Write();
     fHistoRawYieldDistBinC[ic]->Write();
   }
-  fNtupleMultiTrials->SetDirectory(outHistos);
+  fNtupleMultiTrials->SetDirectory(&outHistos);
   fNtupleMultiTrials->Write();
-  outHistos->Close();
-  delete outHistos;
+  outHistos.Close();
 }
 
 //________________________________________________________________________

--- a/PWGHF/vertexingHF/AliHFMultiTrials.h
+++ b/PWGHF/vertexingHF/AliHFMultiTrials.h
@@ -7,8 +7,10 @@
 #include <TString.h>
 #include <TPad.h>
 #include <set>
+#include <vector>
 
 class TNtuple;
+class AliHFMassFitterVAR;
 
 /// \class AliHFMultiTrials
 
@@ -174,6 +176,8 @@ class AliHFMultiTrials : public TNamed {
 
   Double_t fMinYieldGlob;   /// minimum yield
   Double_t fMaxYieldGlob;   /// maximum yield
+
+  std::vector<AliHFMassFitterVAR*> fMassFitters; //!<! Mass fitters
 
   /// \cond CLASSIMP
   ClassDef(AliHFMultiTrials,5); /// class for multiple trials of invariant mass fit


### PR DESCRIPTION
These PR contains a number of commits:

- Fix an issue with invalid memory access when the results of the mass fit are drawn in the canvas and the mass fitter is deleted
- Fix various potential (and actual) memory leaks
- Fix indentation
