### PR TITLE
PWGCF: AliFemtoXi, AliFemtoXiTrackCut, AliFemtoEventReaderAOD

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventReaderAOD.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventReaderAOD.cxx
@@ -1397,6 +1397,7 @@ AliFemtoXi *AliFemtoEventReaderAOD::CopyAODtoFemtoXi(AliAODcascade *tAODxi)
   tFemtoXi->SetPhiXi(tPhiXi);
 
   tFemtoXi->SetCosPointingAngleXi(tAODxi->CosPointingAngleXi(fV1[0],fV1[1],fV1[2]));
+  tFemtoXi->SetCosPointingAngleV0toXi(tAODxi->CosPointingAngle(tAODxi->GetDecayVertexXi()));
 
   tFemtoXi->SetChargeXi(tAODxi->ChargeXi());
   tFemtoXi->SetptXi(std::sqrt(tAODxi->Pt2Xi()));

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXi.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXi.cxx
@@ -24,7 +24,7 @@ AliFemtoXi::AliFemtoXi():
   fMassXi(0), fMassOmega(0), fRapXi(0), fRapOmega(0),
   fCTauXi(0), fCTauOmega(0),
   fPtXi(0), fPtotXi(0), fPtBac(0), fPtotBac(0),
-  fKeyBac(0), fCosPointingAngleXi(0), fPhiXi(0),
+  fKeyBac(0), fCosPointingAngleXi(0), fCosPointingAngleV0toXi(0), fPhiXi(0),
   fEtaXi(0), fTPCNclsBac(0), fNdofBac(0), fStatusBac(0),
   fEtaBac(0), fIdBac(0), fBacNSigmaTPCK(-999),fBacNSigmaTPCPi(-999),
   fBacNSigmaTPCP(-999), fBacNSigmaTOFK(-999), fBacNSigmaTOFPi(-999),
@@ -49,7 +49,7 @@ AliFemtoXi::AliFemtoXi(const AliFemtoV0* aV0):
   fMassXi(0), fMassOmega(0), fRapXi(0), fRapOmega(0),
   fCTauXi(0), fCTauOmega(0),
   fPtXi(0), fPtotXi(0), fPtBac(0), fPtotBac(0),
-  fKeyBac(0), fCosPointingAngleXi(0), fPhiXi(0),
+  fKeyBac(0), fCosPointingAngleXi(0), fCosPointingAngleV0toXi(0), fPhiXi(0),
   fEtaXi(0), fTPCNclsBac(0), fNdofBac(0), fStatusBac(0),
   fEtaBac(0), fIdBac(0), fBacNSigmaTPCK(-999),fBacNSigmaTPCPi(-999),
   fBacNSigmaTPCP(-999), fBacNSigmaTOFK(-999), fBacNSigmaTOFPi(-999),
@@ -71,7 +71,7 @@ AliFemtoXi::AliFemtoXi(const AliFemtoXi& aXi) :
   fMomXi(0), fAlphaXi(0), fPtArmXi(0), fEXi(0), fEOmega(0), fEBacPion(0), 
   fEBacKaon(0), fMassXi(0), fMassOmega(0), fRapXi(0), fRapOmega(0), 
   fCTauXi(0), fCTauOmega(0), fPtXi(0), fPtotXi(0), fPtBac(0), fPtotBac(0), 
-  fKeyBac(aXi.fKeyBac), fCosPointingAngleXi(aXi.fCosPointingAngleXi), fPhiXi(aXi.fPhiXi), fEtaXi(aXi.fEtaXi), 
+  fKeyBac(aXi.fKeyBac), fCosPointingAngleXi(aXi.fCosPointingAngleXi), fCosPointingAngleV0toXi(aXi.fCosPointingAngleV0toXi), fPhiXi(aXi.fPhiXi), fEtaXi(aXi.fEtaXi), 
   fTPCNclsBac(aXi.fTPCNclsBac), fNdofBac(aXi.fNdofBac), fStatusBac(aXi.fStatusBac), fEtaBac(aXi.fEtaBac), fIdBac(aXi.fIdBac), 
   fBacNSigmaTPCK(aXi.fBacNSigmaTPCK), fBacNSigmaTPCPi(aXi.fBacNSigmaTPCPi), fBacNSigmaTPCP(aXi.fBacNSigmaTPCP),
   fBacNSigmaTOFK(aXi.fBacNSigmaTOFK), fBacNSigmaTOFPi(aXi.fBacNSigmaTOFPi), fBacNSigmaTOFP(aXi.fBacNSigmaTOFP), fTPCMomentumBac(aXi.fTPCMomentumBac),
@@ -133,6 +133,7 @@ AliFemtoXi& AliFemtoXi::operator=(const AliFemtoXi& aXi)
   fPtotBac = 0; 
   fKeyBac = aXi.fKeyBac;
   fCosPointingAngleXi = aXi.fCosPointingAngleXi;
+  fCosPointingAngleV0toXi = aXi.fCosPointingAngleV0toXi;
   fPhiXi = aXi.fPhiXi;
   fEtaXi = aXi.fEtaXi; 
   fTPCNclsBac = aXi.fTPCNclsBac;

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXi.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXi.h
@@ -106,6 +106,7 @@ public:
 
   //!!!!!!!!!!! new below 1.09.2015
   void SetCosPointingAngleXi(double x);
+  void SetCosPointingAngleV0toXi(double x);
   void SetPhiXi(double x);
   void SetEtaXi(double x);
 
@@ -133,6 +134,7 @@ public:
 
 
   double CosPointingAngleXi() const;
+  double CosPointingAngleV0toXi() const;
   double EtaXi() const;
   double PhiXi() const;
 
@@ -201,6 +203,9 @@ protected:
 
   //!!!!!!!!! new below 1.09.2015
   double fCosPointingAngleXi; // Cosine of Xi pointing angle
+  double fCosPointingAngleV0toXi; //Cosing of V0 pointing angle to Xi decay vertex 
+    //AliFemtoV0 has fCosPointingAngle, but this is the pointing angle to the primary vertex.
+    //What is more important here is the V0 pointing angle to the Xi decay vertex
   double fPhiXi;  //Phi angle of Xi
   double fEtaXi;
 
@@ -308,6 +313,7 @@ inline void AliFemtoXi::SetdedxBac(float x){fDedxBachelor=x;}
 
 //!!!!!!!!! new below 1.09.2015
 inline void AliFemtoXi::SetCosPointingAngleXi(double x) {fCosPointingAngleXi = x;}
+inline void AliFemtoXi::SetCosPointingAngleV0toXi(double x) {fCosPointingAngleV0toXi = x;}
 inline void AliFemtoXi::SetPhiXi(double x) {fPhiXi = x;}
 inline void AliFemtoXi::SetEtaXi(double x) {fEtaXi = x;}
 
@@ -333,6 +339,7 @@ inline void AliFemtoXi::SetTOFKaonTimeBac(double x) {fTOFKaonTimeBac = x;}
 inline void AliFemtoXi::SetChargeXi(int x) {fCharge = x;}
 
 inline double AliFemtoXi::CosPointingAngleXi() const {return fCosPointingAngleXi;}
+inline double AliFemtoXi::CosPointingAngleV0toXi() const {return fCosPointingAngleV0toXi;}
 inline double AliFemtoXi::EtaXi() const {return fEtaXi;}
 inline double AliFemtoXi::PhiXi() const {return fPhiXi;}
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXiTrackCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXiTrackCut.cxx
@@ -10,7 +10,7 @@
 
 
 //------------------------------
-AliFemtoXiTrackCut::AliFemtoXiTrackCut() : AliFemtoV0TrackCut(), fMaxEtaXi(100), fMinPtXi(0), fMaxPtXi(100), fChargeXi(1.0), fMaxEtaBac(100), fMinPtBac(0), fMaxPtBac(100), fTPCNclsBac(0), fNdofBac(100), fStatusBac(0), fMaxDcaXi(0), fMinDcaXiBac(0), fMaxDcaXiDaughters(0), fMinCosPointingAngleXi(0), fMaxDecayLengthXi(100.0), fInvMassXiMin(0), fInvMassXiMax(1000), fBuildPurityAidXi(false), fMinvPurityAidHistoXi(0)
+AliFemtoXiTrackCut::AliFemtoXiTrackCut() : AliFemtoV0TrackCut(), fMaxEtaXi(100), fMinPtXi(0), fMaxPtXi(100), fChargeXi(1.0), fMaxEtaBac(100), fMinPtBac(0), fMaxPtBac(100), fTPCNclsBac(0), fNdofBac(100), fStatusBac(0), fMaxDcaXi(0), fMinDcaXiBac(0), fMaxDcaXiDaughters(0), fMinCosPointingAngleXi(0), fMinCosPointingAngleV0toXi(0), fMaxDecayLengthXi(100.0), fInvMassXiMin(0), fInvMassXiMax(1000), fBuildPurityAidXi(false), fMinvPurityAidHistoXi(0)
 {
   // Default constructor
 }
@@ -26,7 +26,7 @@ AliFemtoXiTrackCut::AliFemtoXiTrackCut(const AliFemtoXiTrackCut& aCut) :
   fMaxEtaXi(aCut.fMaxEtaXi),fMinPtXi(aCut.fMinPtXi),fMaxPtXi(aCut.fMaxPtXi),fChargeXi(aCut.fChargeXi),
   fMaxEtaBac(aCut.fMaxEtaBac),fMinPtBac(aCut.fMinPtBac),fMaxPtBac(aCut.fMaxPtBac),fTPCNclsBac(aCut.fTPCNclsBac),
   fNdofBac(aCut.fNdofBac),fStatusBac(aCut.fStatusBac),fMaxDcaXi(aCut.fMaxDcaXi),fMinDcaXiBac(aCut.fMinDcaXiBac),
-  fMaxDcaXiDaughters(aCut.fMaxDcaXiDaughters),fMinCosPointingAngleXi(aCut.fMinCosPointingAngleXi),
+  fMaxDcaXiDaughters(aCut.fMaxDcaXiDaughters),fMinCosPointingAngleXi(aCut.fMinCosPointingAngleXi), fMinCosPointingAngleV0toXi(aCut.fMinCosPointingAngleV0toXi),
   fMaxDecayLengthXi(aCut.fMaxDecayLengthXi),fInvMassXiMin(aCut.fInvMassXiMin),fInvMassXiMax(aCut.fInvMassXiMax),
   fParticleTypeXi(aCut.fParticleTypeXi),fBuildPurityAidXi(aCut.fBuildPurityAidXi)
 {
@@ -57,6 +57,7 @@ AliFemtoXiTrackCut& AliFemtoXiTrackCut::operator=(const AliFemtoXiTrackCut& aCut
   fMinDcaXiBac = aCut.fMinDcaXiBac;
   fMaxDcaXiDaughters = aCut.fMaxDcaXiDaughters;
   fMinCosPointingAngleXi = aCut.fMinCosPointingAngleXi;
+  fMinCosPointingAngleV0toXi = aCut.fMinCosPointingAngleV0toXi;
   fMaxDecayLengthXi = aCut.fMaxDecayLengthXi;
   fInvMassXiMin = aCut.fInvMassXiMin;
   fInvMassXiMax = aCut.fInvMassXiMax;
@@ -140,6 +141,10 @@ bool AliFemtoXiTrackCut::Pass(const AliFemtoXi* aXi)
     
     //cos pointing angle
     if(aXi->CosPointingAngleXi()<fMinCosPointingAngleXi)
+      return false; 
+
+    //cos pointing angle of V0 to Xi
+    if(aXi->CosPointingAngleV0toXi()<fMinCosPointingAngleV0toXi)
       return false; 
     
     //decay length
@@ -270,10 +275,16 @@ void AliFemtoXiTrackCut::SetMaxDcaXiDaughters(double x)
   fMaxDcaXiDaughters = x;
 }
 
-void AliFemtoXiTrackCut::SetMinCosPointingAngleXi(double max)
+void AliFemtoXiTrackCut::SetMinCosPointingAngleXi(double min)
 {
-  fMinCosPointingAngleXi = max;
+  fMinCosPointingAngleXi = min;
 }
+
+void AliFemtoXiTrackCut::SetMinCosPointingAngleV0toXi(double min)
+{
+  fMinCosPointingAngleV0toXi = min;
+}
+
 
 void AliFemtoXiTrackCut::SetParticleTypeXi(short x)
 {

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXiTrackCut.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXiTrackCut.h
@@ -50,7 +50,8 @@ class AliFemtoXiTrackCut : public AliFemtoV0TrackCut
   void SetMaxDcaXi(double x);
   void SetMinDcaXiBac(double x);
   void SetMaxDcaXiDaughters(double x);
-  void SetMinCosPointingAngleXi(double max);
+  void SetMinCosPointingAngleXi(double min);
+  void SetMinCosPointingAngleV0toXi(double min);
   void SetParticleTypeXi(short x);
 
   //-----The fMinvPurityAidHistoXi is built immediately before the (final) invariant mass cut, and thus may be used to calculate the purity of the Xi collection
@@ -79,6 +80,7 @@ class AliFemtoXiTrackCut : public AliFemtoV0TrackCut
   double fMinDcaXiBac;
   double fMaxDcaXiDaughters;
   double fMinCosPointingAngleXi;
+  double fMinCosPointingAngleV0toXi;
   double fMaxDecayLengthXi;
   double fInvMassXiMin;
   double fInvMassXiMax;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.cxx
@@ -989,6 +989,7 @@ AliFemtoXiTrackCutNSigmaFilter* AliFemtoAnalysisLambdaKaon::CreateXiCut(XiCutPar
   tXiCut->SetInvariantMassXi(aCutParams.minInvariantMass,aCutParams.maxInvariantMass);
   tXiCut->SetMaxDecayLengthXi(aCutParams.maxDecayLengthXi);
   tXiCut->SetMinCosPointingAngleXi(aCutParams.minCosPointingAngleXi);
+  tXiCut->SetMinCosPointingAngleV0toXi(aCutParams.minCosPointingAngleV0toXi);
   tXiCut->SetMaxDcaXi(aCutParams.maxDcaXi);
     //XiDaughters
     tXiCut->SetMaxDcaXiDaughters(aCutParams.maxDcaXiDaughters);
@@ -1825,6 +1826,7 @@ AliFemtoAnalysisLambdaKaon::DefaultXiCutParams()
 
   tReturnParams.maxDecayLengthXi = 100.;
   tReturnParams.minCosPointingAngleXi = 0.9992;
+  tReturnParams.minCosPointingAngleV0toXi = 0.9993;
   tReturnParams.maxDcaXi = 100.;
   tReturnParams.maxDcaXiDaughters = 0.3;
 
@@ -1838,7 +1840,8 @@ AliFemtoAnalysisLambdaKaon::DefaultXiCutParams()
   tReturnParams.minDcaV0 = 0.1;
   tReturnParams.minInvMassV0 = LambdaMass-0.005;
   tReturnParams.maxInvMassV0 = LambdaMass+0.005;
-  tReturnParams.minCosPointingAngleV0 = 0.998;
+  tReturnParams.minCosPointingAngleV0 = 0.;  //TODO was 0.998, might need to revert back
+                                             //changed because of new minCosPointingAngleV0toXi
   tReturnParams.etaV0 = 0.8;
   tReturnParams.minPtV0 = 0.4;
   tReturnParams.maxPtV0 = 100.;
@@ -1880,6 +1883,7 @@ AliFemtoAnalysisLambdaKaon::DefaultAXiCutParams()
 
   tReturnParams.maxDecayLengthXi = 100.;
   tReturnParams.minCosPointingAngleXi = 0.9992;
+  tReturnParams.minCosPointingAngleV0toXi = 0.9993;
   tReturnParams.maxDcaXi = 100.;
   tReturnParams.maxDcaXiDaughters = 0.3;
 
@@ -1893,7 +1897,8 @@ AliFemtoAnalysisLambdaKaon::DefaultAXiCutParams()
   tReturnParams.minDcaV0 = 0.1;
   tReturnParams.minInvMassV0 = LambdaMass-0.005;
   tReturnParams.maxInvMassV0 = LambdaMass+0.005;
-  tReturnParams.minCosPointingAngleV0 = 0.998;
+  tReturnParams.minCosPointingAngleV0 = 0.;  //TODO was 0.998, might need to revert back
+                                             //changed because of new minCosPointingAngleV0toXi
   tReturnParams.etaV0 = 0.8;
   tReturnParams.minPtV0 = 0.4;
   tReturnParams.maxPtV0 = 100.;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.h
@@ -219,6 +219,7 @@ struct XiCutParams
 
   double maxDecayLengthXi;
   double minCosPointingAngleXi;
+  double minCosPointingAngleV0toXi;
   double maxDcaXi;
   double maxDcaXiDaughters;
 
@@ -232,7 +233,7 @@ struct XiCutParams
   double minDcaV0;
   double minInvMassV0,
          maxInvMassV0;
-  double minCosPointingAngleV0;
+  double minCosPointingAngleV0;  //this is V0 to primary vertex, not terribly useful for Xi analysis
   double etaV0;
   double minPtV0,
          maxPtV0;


### PR DESCRIPTION
PWGCF: AliFemtoXi, AliFemtoXiTrackCut, AliFemtoEventReaderAOD: Added new attribute fCosPointingAngleV0toXi, i.e. the V0's pointing angle to the Xi's decay vertex.  In a Xi analysis, this is more useful than the V0s pointing angle to the primary vertex.