### PR TITLE
EMCal Embed: Improve finding files and init

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
@@ -71,10 +71,14 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
 
   AliVEvent* GetExternalEvent()                             const { return fExternalEvent   ; }
 
+
   /**
    * @{
    * @name Properties of the embedding helper
    */
+  bool Initialize();
+
+  // Get
   Int_t GetPtHardBin()                                      const { return fPtHardBin; }
   Int_t GetAnchorRun()                                      const { return fAnchorRun; }
   TString GetTreeName()                                     const { return fTreeName; }
@@ -85,6 +89,7 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   Int_t GetStartingFileIndex()                              const { return fFilenameIndex; }
   TString GetFileListFilename()                             const { return fFileListFilename; }
 
+  // Set
   /// Set the pt hard bin which will be added into the file pattern. Can also be omitted and set directly in the pattern.
   void SetPtHardBin(Int_t r)                                      { fPtHardBin           = r; }
   /// Sets the anchor run which will be added into the file pattern. Can also be omitted and set directly in the pattern.
@@ -131,6 +136,7 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
  protected:
   bool            GetFilenames()        ;
   std::string     GenerateUniqueFileListFilename();
+  void            DetermineFirstFileToEmbed();
   void            SetupEmbedding()      ;
   Bool_t          SetupInputFiles()     ;
   Bool_t          GetNextEntry()        ;
@@ -142,6 +148,7 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   Double_t                                      fZVertexCut;        ///<  Z vertex cut on embedded event
   Double_t                                      fMaxVertexDist;     ///<  Max distance between Z vertex of internal and embedded event
 
+  bool                                          fInitializedConfiguration; ///< Notes if the configuration has been initialized
   bool                                          fInitializedNewFile; //!<! Notes where the entry indices have been initialized for a new tree in the chain
   bool                                          fInitializedEmbedding; //!<! Notes where the TChain has been initialized for embedding
   bool                                          fWrappedAroundTree; //!<! Notes whether we have wrapped around the tree, which is important if the offset into the tree is non-zero
@@ -156,7 +163,7 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   TString                                       fInputFilename    ; ///<  Filename of input root files
   TString                                       fFileListFilename ; ///<  Name of the file list containing paths to files to embed
   Int_t                                         fFilenameIndex    ; ///<  Index of vector containing paths to files to embed
-  std::vector <std::string>                     fFilenames        ; //!<! Paths to the files to embed
+  std::vector <std::string>                     fFilenames        ; ///< Paths to the files to embed
   TFile                                        *fExternalFile     ; //!<! External file used for embedding
   TChain                                       *fChain            ; //!<! External TChain (tree) containing the events available for embedding
   Int_t                                         fCurrentEntry     ; //!<! Current entry in the current tree

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
@@ -21,6 +21,10 @@ class TChain;
 class TFile;
 class AliVEvent;
 
+#include <iosfwd>
+#include <vector>
+#include <string>
+
 #include <AliAnalysisTaskSE.h>
 
 /**
@@ -70,7 +74,6 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   static const AliAnalysisTaskEmcalEmbeddingHelper* GetInstance() { return fgInstance       ; }
 
   AliVEvent* GetExternalEvent()                             const { return fExternalEvent   ; }
-
 
   /**
    * @{
@@ -131,7 +134,19 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   void SetMaxVertexDistance(Double_t distance)                    { fMaxVertexDist = distance; }
   /* @} */
 
+  /**
+   * @{
+   * @name Utility functions
+   */
+  // AddTask
   static AliAnalysisTaskEmcalEmbeddingHelper * AddTaskEmcalEmbeddingHelper();
+
+  // Printing
+  friend std::ostream & operator<<(std::ostream &in, const AliAnalysisTaskEmcalEmbeddingHelper &myTask);
+  void Print(Option_t* opt = "") const;
+  std::ostream & Print(std::ostream &in) const;
+  std::string toString(bool includeFileList = false) const;
+  /* @} */
 
  protected:
   bool            GetFilenames()        ;

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
@@ -129,7 +129,7 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   static AliAnalysisTaskEmcalEmbeddingHelper * AddTaskEmcalEmbeddingHelper();
 
  protected:
-  void            GetFilenames()        ;
+  bool            GetFilenames()        ;
   std::string     GenerateUniqueFileListFilename();
   void            SetupEmbedding()      ;
   Bool_t          SetupInputFiles()     ;


### PR DESCRIPTION
Includes:
- Moving initialization to the run macro or wagon (like the EMCal Correction Task)
- Improved methods to find files in AliEn to embed
- Print methods for the Embedding Helper