### PR TITLE
Fixes to make TRD and TPC QA tasks compatible with embedded MC

### DIFF
--- a/PWGPP/TPC/AliPerformanceDCA.cxx
+++ b/PWGPP/TPC/AliPerformanceDCA.cxx
@@ -48,7 +48,6 @@
 #include "AliMathBase.h"
 #include "AliRecInfoCuts.h" 
 #include "AliMCInfoCuts.h" 
-#include "AliStack.h" 
 #include "AliMCEvent.h" 
 #include "AliTracker.h"   
 #include "AliHeader.h"   
@@ -140,7 +139,7 @@ void AliPerformanceDCA::Init()
 }
 
 //_____________________________________________________________________________
-void AliPerformanceDCA::ProcessTPC(AliStack* const stack, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent)
+void AliPerformanceDCA::ProcessTPC(AliMCEvent* const mcev, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent)
 {
   // Fill DCA comparison information
   if(!esdEvent) return;
@@ -179,12 +178,12 @@ void AliPerformanceDCA::ProcessTPC(AliStack* const stack, AliESDtrack *const esd
   //
   // Fill rec vs MC information
   //
-  if(!stack) return;
+  return;
 
 }
 
 //_____________________________________________________________________________
-void AliPerformanceDCA::ProcessTPCITS(AliStack* const stack, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent)
+void AliPerformanceDCA::ProcessTPCITS(AliMCEvent* const mcev, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent)
 {
   // Fill DCA comparison information
   if(!esdTrack) return;
@@ -220,11 +219,11 @@ void AliPerformanceDCA::ProcessTPCITS(AliStack* const stack, AliESDtrack *const 
   //
   // Fill rec vs MC information
   //
-  if(!stack) return;
+  return;
 
 }
 
-void AliPerformanceDCA::ProcessConstrained(AliStack* const /*stack*/, AliESDtrack *const /*esdTrack*/)
+void AliPerformanceDCA::ProcessConstrained(AliMCEvent* const /*mcev*/, AliESDtrack *const /*esdTrack*/)
 {
   // Fill DCA comparison information
   
@@ -271,7 +270,6 @@ void AliPerformanceDCA::Exec(AliMCEvent* const mcEvent, AliESDEvent *const esdEv
   }
   AliHeader* header = 0;
   AliGenEventHeader* genHeader = 0;
-  AliStack* stack = 0;
   TArrayF vtxMC(3);
   
   if(bUseMC)
@@ -284,12 +282,6 @@ void AliPerformanceDCA::Exec(AliMCEvent* const mcEvent, AliESDEvent *const esdEv
     header = mcEvent->Header();
     if (!header) {
       Error("Exec","Header not available");
-      return;
-    }
-    // MC particle stack
-    stack = mcEvent->Stack();
-    if (!stack) {
-      Error("Exec","Stack not available");
       return;
     }
     // get MC vertex
@@ -334,9 +326,9 @@ void AliPerformanceDCA::Exec(AliMCEvent* const mcEvent, AliESDEvent *const esdEv
     AliESDtrack *track = esdEvent->GetTrack(iTrack);
     if(!track) continue;
 
-    if(GetAnalysisMode() == 0) ProcessTPC(stack,track,esdEvent);
-    else if(GetAnalysisMode() == 1) ProcessTPCITS(stack,track,esdEvent);
-    else if(GetAnalysisMode() == 2) ProcessConstrained(stack,track);
+    if(GetAnalysisMode() == 0) ProcessTPC(mcEvent,track,esdEvent);
+    else if(GetAnalysisMode() == 1) ProcessTPCITS(mcEvent,track,esdEvent);
+    else if(GetAnalysisMode() == 2) ProcessConstrained(mcEvent,track);
     else {
       printf("ERROR: AnalysisMode %d \n",fAnalysisMode);
       return;

--- a/PWGPP/TPC/AliPerformanceDCA.h
+++ b/PWGPP/TPC/AliPerformanceDCA.h
@@ -11,7 +11,6 @@
 
 class AliESDEvent; 
 class AliESDfriend; 
-class AliStack; 
 class AliRecInfoCuts;
 class AliMCInfoCuts;
 class AliESDVertex;
@@ -52,9 +51,9 @@ public :
   // Export objects to folder
   TFolder *ExportToFolder(TObjArray * array=0);
 
-  void ProcessConstrained(AliStack* const stack, AliESDtrack *const esdTrack);
-  void ProcessTPC(AliStack* const stack, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent);
-  void ProcessTPCITS(AliStack* const stack, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent);
+  void ProcessConstrained(AliMCEvent* const mcev, AliESDtrack *const esdTrack);
+  void ProcessTPC(AliMCEvent* const mcev, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent);
+  void ProcessTPCITS(AliMCEvent* const mcev, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent);
 
   // Selection cuts
   void SetAliRecInfoCuts(AliRecInfoCuts* const cuts=0) {fCutsRC = cuts;}

--- a/PWGPP/TPC/AliPerformanceDEdx.cxx
+++ b/PWGPP/TPC/AliPerformanceDEdx.cxx
@@ -52,7 +52,6 @@
 #include "AliTracker.h"
 #include "AliMCEvent.h"
 #include "AliESDtrack.h"
-#include "AliStack.h"
 #include "AliLog.h" 
 #include "AliMCInfoCuts.h" 
 #include "AliMathBase.h"
@@ -168,14 +167,14 @@ void AliPerformanceDEdx::Init()
 }
 
 //_____________________________________________________________________________
-void AliPerformanceDEdx::ProcessTPC(AliStack* const /*stack*/, AliESDtrack *const /*esdTrack*/)
+void AliPerformanceDEdx::ProcessTPC(AliMCEvent* const /*mcev*/, AliESDtrack *const /*esdTrack*/)
 {
   // Fill dE/dx  comparison information
   AliDebug(AliLog::kWarning, "Warning: Not implemented");
 }
 
 //_____________________________________________________________________________
-void AliPerformanceDEdx::ProcessInnerTPC(AliStack* const stack, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent)
+void AliPerformanceDEdx::ProcessInnerTPC(AliMCEvent* const mcev, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent)
 {
  //
  // Fill TPC track information at inner TPC wall
@@ -251,11 +250,11 @@ void AliPerformanceDEdx::ProcessInnerTPC(AliStack* const stack, AliESDtrack *con
   Double_t vDeDxHisto[10] = {dedx,phi,y,z,snp,tgl,Double_t(ncls),p,Double_t(TPCSignalN),nClsF};
   fDeDxHisto->Fill(vDeDxHisto); 
 
-  if(!stack) return;
+  if(!mcev) return;
 }
 
 //_____________________________________________________________________________
-void AliPerformanceDEdx::ProcessTPCITS(AliStack* const /*stack*/, AliESDtrack *const /*esdTrack*/)
+void AliPerformanceDEdx::ProcessTPCITS(AliMCEvent* const /*mcev*/, AliESDtrack *const /*esdTrack*/)
 {
   // Fill dE/dx  comparison information
   
@@ -263,7 +262,7 @@ void AliPerformanceDEdx::ProcessTPCITS(AliStack* const /*stack*/, AliESDtrack *c
 }
 
 //_____________________________________________________________________________
-void AliPerformanceDEdx::ProcessConstrained(AliStack* const /*stack*/, AliESDtrack *const /*esdTrack*/)
+void AliPerformanceDEdx::ProcessConstrained(AliMCEvent* const /*mcev*/, AliESDtrack *const /*esdTrack*/)
 {
   // Fill dE/dx  comparison information
   
@@ -323,7 +322,6 @@ void AliPerformanceDEdx::Exec(AliMCEvent* const mcEvent, AliESDEvent *const esdE
   }
   AliHeader* header = 0;
   AliGenEventHeader* genHeader = 0;
-  AliStack* stack = 0;
   TArrayF vtxMC(3);
   
   if(bUseMC)
@@ -337,12 +335,6 @@ void AliPerformanceDEdx::Exec(AliMCEvent* const mcEvent, AliESDEvent *const esdE
     header = mcEvent->Header();
     if (!header) {
       AliDebug(AliLog::kError, "Header not available");
-      return;
-    }
-    // MC particle stack
-    stack = mcEvent->Stack();
-    if (!stack) {
-      AliDebug(AliLog::kError, "Stack not available");
       return;
     }
 
@@ -389,10 +381,10 @@ void AliPerformanceDEdx::Exec(AliMCEvent* const mcEvent, AliESDEvent *const esdE
     AliESDtrack *track = esdEvent->GetTrack(iTrack);
     if(!track) continue;
 
-    if(GetAnalysisMode() == 0) ProcessTPC(stack,track);
-    else if(GetAnalysisMode() == 1) ProcessTPCITS(stack,track);
-    else if(GetAnalysisMode() == 2) ProcessConstrained(stack,track);
-    else if(GetAnalysisMode() == 3) ProcessInnerTPC(stack,track,esdEvent);
+    if(GetAnalysisMode() == 0) ProcessTPC(mcEvent,track);
+    else if(GetAnalysisMode() == 1) ProcessTPCITS(mcEvent,track);
+    else if(GetAnalysisMode() == 2) ProcessConstrained(mcEvent,track);
+    else if(GetAnalysisMode() == 3) ProcessInnerTPC(mcEvent,track,esdEvent);
     else {
       printf("ERROR: AnalysisMode %d \n",fAnalysisMode);
       return;

--- a/PWGPP/TPC/AliPerformanceDEdx.h
+++ b/PWGPP/TPC/AliPerformanceDEdx.h
@@ -19,7 +19,6 @@ class AliESDEvent;
 class AliESDfriend; 
 class AliMCEvent;
 class AliESDtrack;
-class AliStack; 
 class AliRecInfoCuts;
 class AliMCInfoCuts;
 
@@ -57,10 +56,10 @@ public :
   TFolder *ExportToFolder(TObjArray * array=0);
 
   // Process events
-  void  ProcessTPC(AliStack* const stack, AliESDtrack *const esdTrack); // not implemented
-  void  ProcessInnerTPC(AliStack* const stack, AliESDtrack *const esdTrack, AliESDEvent *const esdEvent);
-  void  ProcessTPCITS(AliStack* const stack, AliESDtrack *const esdTrack);      // not implemented
-  void  ProcessConstrained(AliStack* const stack, AliESDtrack *const esdTrack); // not implemented
+  void  ProcessTPC(AliMCEvent* const mcev, AliESDtrack *const esdTrack); // not implemented
+  void  ProcessInnerTPC(AliMCEvent* const mcev, AliESDtrack *const esdTrack, AliESDEvent *const esdEvent);
+  void  ProcessTPCITS(AliMCEvent* const mcev, AliESDtrack *const esdTrack);      // not implemented
+  void  ProcessConstrained(AliMCEvent* const mcev, AliESDtrack *const esdTrack); // not implemented
 
   
   // produce summary (currently not used)

--- a/PWGPP/TPC/AliPerformanceMC.cxx
+++ b/PWGPP/TPC/AliPerformanceMC.cxx
@@ -50,7 +50,6 @@
 #include "AliMCParticle.h" 
 #include "AliHeader.h" 
 #include "AliGenEventHeader.h" 
-#include "AliStack.h" 
 #include "AliMCInfoCuts.h" 
 #include "AliRecInfoCuts.h" 
 #include "AliTracker.h" 
@@ -174,7 +173,6 @@ void AliPerformanceMC::Exec(AliMCEvent* const mcEvent, AliESDEvent *const /*esdE
   //
   AliHeader* header = 0;
   AliGenEventHeader* genHeader = 0;
-  AliStack* stack = 0;
   TArrayF vtxMC(3);
   
   if(bUseMC)
@@ -187,12 +185,6 @@ void AliPerformanceMC::Exec(AliMCEvent* const mcEvent, AliESDEvent *const /*esdE
     header = mcEvent->Header();
     if (!header) {
       Error("Exec","Header not available");
-      return;
-    }
-    // MC particle stack
-    stack = mcEvent->Stack();
-    if (!stack) {
-      Error("Exec","Stack not available");
       return;
     }
     // get MC vertex
@@ -230,7 +222,7 @@ void AliPerformanceMC::Exec(AliMCEvent* const mcEvent, AliESDEvent *const /*esdE
     TParticle *particle = mcParticle->Particle();
     if(!particle) continue;
 
-    Bool_t prim = stack->IsPhysicalPrimary(iPart);
+    Bool_t prim = mcEvent->IsPhysicalPrimary(iPart);
 
     // Only 5 charged particle species (e,mu,pi,K,p)
     if (fCutsMC->IsPdgParticle(TMath::Abs(particle->GetPdgCode())) == kFALSE) break;

--- a/PWGPP/TPC/AliPerformanceMC.h
+++ b/PWGPP/TPC/AliPerformanceMC.h
@@ -19,7 +19,6 @@ class TClonesArray;
 class AliESDVertex;
 class AliESDtrack;
 class AliMCEvent;
-class AliStack;
 class AliTrackReference;
 class AliESDEvent; 
 class AliESDfriend; 

--- a/PWGPP/TPC/AliPerformanceMatch.cxx
+++ b/PWGPP/TPC/AliPerformanceMatch.cxx
@@ -54,7 +54,6 @@
 #include "AliMCParticle.h" 
 #include "AliHeader.h" 
 #include "AliGenEventHeader.h" 
-#include "AliStack.h" 
 #include "AliMCInfoCuts.h" 
 #include "AliRecInfoCuts.h" 
 #include "AliTracker.h" 
@@ -227,7 +226,7 @@ void AliPerformanceMatch::Init(){
 }
 
 //_____________________________________________________________________________
-void AliPerformanceMatch::ProcessITSTPC(Int_t iTrack, AliESDEvent *const esdEvent, AliStack* /*const stack*/, AliESDtrack *const esdTrack)
+void AliPerformanceMatch::ProcessITSTPC(Int_t iTrack, AliESDEvent *const esdEvent, AliMCEvent* /*const mcev*/, AliESDtrack *const esdTrack)
 {
   //
   // addition to standard analysis - check if ITS stand-alone tracks have a match in the TPC
@@ -276,7 +275,7 @@ void AliPerformanceMatch::ProcessITSTPC(Int_t iTrack, AliESDEvent *const esdEven
 }
 
 //_____________________________________________________________________________
-void AliPerformanceMatch::ProcessTPCITS(AliStack* /*const stack*/, AliESDtrack *const esdTrack)
+void AliPerformanceMatch::ProcessTPCITS(AliMCEvent* /*const mcev*/, AliESDtrack *const esdTrack)
 {
   //
   // Match TPC and ITS min-bias tracks
@@ -307,12 +306,12 @@ void AliPerformanceMatch::ProcessTPCITS(AliStack* /*const stack*/, AliESDtrack *
 }
 
 //_____________________________________________________________________________
-/*void AliPerformanceMatch::ProcessTPCTRD(AliStack* , AliESDtrack *const esdTrack, AliESDfriendTrack *const esdFriendTrack)
+/*void AliPerformanceMatch::ProcessTPCTRD(AliMCEvent* , AliESDtrack *const esdTrack, AliESDfriendTrack *const esdFriendTrack)
 {
   return;
 }*/
 
-void AliPerformanceMatch::ProcessTPCConstrain(AliStack* /*const stack*/, AliESDEvent *const esdEvent, AliESDtrack *const esdTrack){
+void AliPerformanceMatch::ProcessTPCConstrain(AliMCEvent* /*const mcev*/, AliESDEvent *const esdEvent, AliESDtrack *const esdTrack){
   //
   // Contrain TPC inner track to the vertex
   // then compare to the global tracks
@@ -423,7 +422,6 @@ void AliPerformanceMatch::Exec(AliMCEvent* const mcEvent, AliESDEvent *const esd
   }
   AliHeader* header = 0;
   AliGenEventHeader* genHeader = 0;
-  AliStack* stack = 0;
   TArrayF vtxMC(3);
   
   if(bUseMC)
@@ -436,12 +434,6 @@ void AliPerformanceMatch::Exec(AliMCEvent* const mcEvent, AliESDEvent *const esd
     header = mcEvent->Header();
     if (!header) {
       Error("Exec","Header not available");
-      return;
-    }
-    // MC particle stack
-    stack = mcEvent->Stack();
-    if (!stack) {
-      Error("Exec","Stack not available");
       return;
     }
     // get MC vertex
@@ -485,22 +477,22 @@ void AliPerformanceMatch::Exec(AliMCEvent* const mcEvent, AliESDEvent *const esd
 
     if(GetAnalysisMode() == 0){
       if(!IsUseTOFBunchCrossing()){
-	ProcessTPCITS(stack,track);
+	ProcessTPCITS(mcEvent,track);
       }
       else
 	if( track->GetTOFBunchCrossing(esdEvent->GetMagneticField())==0) {
-	  ProcessTPCITS(stack,track);
+	  ProcessTPCITS(mcEvent,track);
 	}
     }
-    /* else if(GetAnalysisMode() == 2) ProcessTPCTRD(stack,track,friendTrack);*/
-    else if(GetAnalysisMode() == 1) {ProcessITSTPC(iTrack,esdEvent,stack,track);}
+    /* else if(GetAnalysisMode() == 2) ProcessTPCTRD(mcev,track,friendTrack);*/
+    else if(GetAnalysisMode() == 1) {ProcessITSTPC(iTrack,esdEvent,mcEvent,track);}
     else if(GetAnalysisMode() == 2){
       if(!IsUseTOFBunchCrossing()){
-	ProcessTPCConstrain(stack,esdEvent,track);
+	ProcessTPCConstrain(mcEvent,esdEvent,track);
       }
       else
 	if( track->GetTOFBunchCrossing(esdEvent->GetMagneticField())==0) {
-	  ProcessTPCConstrain(stack,esdEvent,track);
+	  ProcessTPCConstrain(mcEvent,esdEvent,track);
 	}
     }
     else {

--- a/PWGPP/TPC/AliPerformanceMatch.h
+++ b/PWGPP/TPC/AliPerformanceMatch.h
@@ -18,7 +18,6 @@ class TH2F;
 class AliESDVertex;
 class AliESDtrack;
 class AliMCEvent;
-class AliStack;
 class AliTrackReference;
 class AliESDEvent; 
 class AliESDfriend; 
@@ -56,10 +55,10 @@ public :
   virtual TFolder* GetAnalysisFolder() const {return fAnalysisFolder;}
 
   // Process matching
-  void ProcessTPCITS(AliStack* const stack, AliESDtrack *const esdTrack);
+  void ProcessTPCITS(AliMCEvent* const mcev, AliESDtrack *const esdTrack);
   //  void ProcessTPCTRD(AliStack* const stack, AliESDtrack *const esdTrack, AliESDfriendTrack *const friendTrack);
-  void ProcessITSTPC(Int_t trackIdx, AliESDEvent* const esdEvent, AliStack* const stack, AliESDtrack *const esdTrack);
-  void ProcessTPCConstrain(AliStack* const stack, AliESDEvent *const esdEvent, AliESDtrack *const esdTrack); // - 01.11.2011
+  void ProcessITSTPC(Int_t trackIdx, AliESDEvent* const esdEvent, AliMCEvent* const mcev, AliESDtrack *const esdTrack);
+  void ProcessTPCConstrain(AliMCEvent* const mcev, AliESDEvent *const esdEvent, AliESDtrack *const esdTrack); // - 01.11.2011
 
   // Fill histogrrams
   void FillHistograms(AliESDtrack *const refParam, AliESDtrack *const param, Bool_t isRec);

--- a/PWGPP/TPC/AliPerformancePtCalib.h
+++ b/PWGPP/TPC/AliPerformancePtCalib.h
@@ -25,7 +25,6 @@ class TList;
 class AliESDVertex;
 class AliESDtrack;
 class AliMCEvent;
-class AliStack;
 class AliTrackReference;
 class AliESDEvent; 
 class AliESDfriend; 

--- a/PWGPP/TPC/AliPerformancePtCalibMC.cxx
+++ b/PWGPP/TPC/AliPerformancePtCalibMC.cxx
@@ -66,7 +66,6 @@ fout.Close();
 #include "AliESDtrack.h"
 #include "AliESDtrackCuts.h"
 #include "AliMCEvent.h"
-#include "AliStack.h"
 #include "AliESDfriendTrack.h"
 #include "AliESDfriend.h"
 
@@ -337,9 +336,7 @@ void AliPerformancePtCalibMC::SetPtShift(const Double_t shiftVal ) {
 void AliPerformancePtCalibMC::Exec(AliMCEvent* const mcEvent, AliESDEvent *const esdEvent, AliESDfriend *const /*esdFriend*/, const Bool_t /*bUseMC*/, const Bool_t /*bUseESDfriend*/)
 {
    //exec: read MC and esd or tpc tracks
-   
-   AliStack* stack = NULL;
- 
+    
    if (!esdEvent) {
       Printf("ERROR: Event not available");
       return;
@@ -352,12 +349,6 @@ void AliPerformancePtCalibMC::Exec(AliMCEvent* const mcEvent, AliESDEvent *const
       Printf("ERROR: Could not retrieve MC event");
       return;
    }    
-   stack = mcEvent->Stack();
-   if (!stack) {
-      Printf("ERROR: Could not retrieve stack");
-      return;
-   }
-
    
    //vertex info for cut
    //const AliESDVertex *vtx = esdEvent->GetPrimaryVertex();
@@ -394,7 +385,7 @@ void AliPerformancePtCalibMC::Exec(AliMCEvent* const mcEvent, AliESDEvent *const
       // get MC info 
       Int_t esdLabel = esdTrack->GetLabel();
       if(esdLabel<0) continue;	
-      TParticle *  partMC = stack->Particle(esdLabel);
+      TParticle *  partMC = ((AliMCParticle*)mcEvent->GetTrack(esdLabel))->Particle();
       if (!partMC) continue;
   
       // fill correlation histos MC ESD

--- a/PWGPP/TPC/AliPerformancePtCalibMC.h
+++ b/PWGPP/TPC/AliPerformancePtCalibMC.h
@@ -1,3 +1,4 @@
+
 #ifndef ALIPERFORMANCEPTCALIBMC_H
 #define ALIPERFORMANCEPTCALIBMC_H
 //----------------------------------------------------------------------------------------------------
@@ -24,7 +25,6 @@ class TList;
 class AliESDVertex;
 class AliESDtrack;
 class AliMCEvent;
-class AliStack;
 class AliTrackReference;
 class AliESDEvent; 
 class AliESDfriend; 

--- a/PWGPP/TPC/AliPerformanceRes.cxx
+++ b/PWGPP/TPC/AliPerformanceRes.cxx
@@ -50,7 +50,6 @@
 #include "AliMCParticle.h" 
 #include "AliHeader.h" 
 #include "AliGenEventHeader.h" 
-#include "AliStack.h" 
 #include "AliMCInfoCuts.h" 
 #include "AliRecInfoCuts.h" 
 #include "AliTracker.h" 
@@ -195,7 +194,7 @@ void AliPerformanceRes::Init(){
 }
 
 //_____________________________________________________________________________
-void AliPerformanceRes::ProcessTPC(AliStack* const stack, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent)
+void AliPerformanceRes::ProcessTPC(AliMCEvent* const mcev, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent)
 {
   if(!esdEvent) return;
   if(!esdTrack) return;
@@ -229,10 +228,10 @@ void AliPerformanceRes::ProcessTPC(AliStack* const stack, AliESDtrack *const esd
   //
   // Fill rec vs MC information
   //
-  if(!stack) return;
+  if(!mcev) return;
   Int_t label = esdTrack->GetTPCLabel(); //Use TPC-only label for TPC-only resolution analysis
   if (label <= 0) return;
-  TParticle* particle = stack->Particle(label);
+  TParticle* particle = ((AliMCParticle*)mcev->GetTrack(label))->Particle();
   if(!particle) return;
   if(!particle->GetPDG()) return;
   if(particle->GetPDG()->Charge()==0) return;
@@ -309,7 +308,7 @@ void AliPerformanceRes::ProcessTPC(AliStack* const stack, AliESDtrack *const esd
 }
 
 //_____________________________________________________________________________
-void AliPerformanceRes::ProcessTPCITS(AliStack* const stack, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent)
+void AliPerformanceRes::ProcessTPCITS(AliMCEvent* const mcev, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent)
 {
   // Fill resolution comparison information (TPC+ITS)
   if(!esdEvent) return;
@@ -338,10 +337,10 @@ void AliPerformanceRes::ProcessTPCITS(AliStack* const stack, AliESDtrack *const 
   //
   // Fill rec vs MC information
   //
-  if(!stack) return;
+  if(!mcev) return;
 
   Int_t label = TMath::Abs(esdTrack->GetLabel()); //Use global label for combined resolution analysis
-  TParticle* particle = stack->Particle(label);
+  TParticle* particle = ((AliMCParticle*)mcev->GetTrack(label))->Particle();
   if(!particle) return;
   if(!particle->GetPDG()) return;
   if(particle->GetPDG()->Charge()==0) return;
@@ -430,7 +429,7 @@ void AliPerformanceRes::ProcessTPCITS(AliStack* const stack, AliESDtrack *const 
 }
 
 //_____________________________________________________________________________
-void AliPerformanceRes::ProcessConstrained(AliStack* const stack, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent)
+void AliPerformanceRes::ProcessConstrained(AliMCEvent* const mcev, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent)
 {
   // Fill resolution comparison information (constarained parameters) 
   //
@@ -464,10 +463,10 @@ void AliPerformanceRes::ProcessConstrained(AliStack* const stack, AliESDtrack *c
   //
   // Fill rec vs MC information
   //
-  if(!stack) return;
+  if(!mcev) return;
 
   Int_t label = TMath::Abs(esdTrack->GetLabel()); 
-  TParticle* particle = stack->Particle(label);
+  TParticle* particle = ((AliMCParticle*)mcev->GetTrack(label))->Particle();
   if(!particle) return;
   if(!particle->GetPDG()) return;
   if(particle->GetPDG()->Charge()==0) return;
@@ -661,7 +660,7 @@ void AliPerformanceRes::ProcessInnerTPC(AliMCEvent *const mcEvent, AliESDtrack *
   else
   {
 	  //If Track vertex is not used the above check does not work, hence we use the MC reference track
-	  isPrimary = label < mcEvent->Stack()->GetNprimary();
+    isPrimary = mcEvent->IsPhysicalPrimary(label);
   }
   if(isPrimary) 
   { 
@@ -880,7 +879,6 @@ void AliPerformanceRes::Exec(AliMCEvent* const mcEvent, AliESDEvent *const esdEv
   }
   AliHeader* header = 0;
   AliGenEventHeader* genHeader = 0;
-  AliStack* stack = 0;
   TArrayF vtxMC(3);
   
   if(bUseMC)
@@ -893,12 +891,6 @@ void AliPerformanceRes::Exec(AliMCEvent* const mcEvent, AliESDEvent *const esdEv
     header = mcEvent->Header();
     if (!header) {
       Error("Exec","Header not available");
-      return;
-    }
-    // MC particle stack
-    stack = mcEvent->Stack();
-    if (!stack) {
-      Error("Exec","Stack not available");
       return;
     }
     // get MC vertex
@@ -949,33 +941,32 @@ void AliPerformanceRes::Exec(AliMCEvent* const mcEvent, AliESDEvent *const esdEv
 
 
     Int_t label = TMath::Abs(track->GetLabel()); 
-    if ( label > stack->GetNtrack() ) 
+    /* // RS this check is not needed
+    if ( label > mcEvent->GetNumberOfTracks() ) 
     {
       ULong_t status = track->GetStatus();
       printf ("Error : ESD MCLabel %d - StackSize %d - Status %lu \n",
 	       track->GetLabel(), stack->GetNtrack(), status );
       printf(" NCluster %d \n", track->GetTPCclusters(0) );
-      /*
-      if ((status&AliESDtrack::kTPCrefit)== 0 ) printf("   kTPCrefit \n");
-      if ((status&AliESDtrack::kTPCin)== 0 )    printf("   kTPCin \n");
-      if ((status&AliESDtrack::kTPCout)== 0 )   printf("   kTPCout \n");
-      if ((status&AliESDtrack::kTRDrefit)== 0 ) printf("   kTRDrefit \n");
-      if ((status&AliESDtrack::kTRDin)== 0 )    printf("   kTRDin \n");
-      if ((status&AliESDtrack::kTRDout)== 0 )   printf("   kTRDout \n");
-      if ((status&AliESDtrack::kITSrefit)== 0 ) printf("   kITSrefit \n");
-      if ((status&AliESDtrack::kITSin)== 0 )    printf("   kITSin \n");
-      if ((status&AliESDtrack::kITSout)== 0 )   printf("   kITSout \n");
-      */
+//      if ((status&AliESDtrack::kTPCrefit)== 0 ) printf("   kTPCrefit \n");
+//      if ((status&AliESDtrack::kTPCin)== 0 )    printf("   kTPCin \n");
+//      if ((status&AliESDtrack::kTPCout)== 0 )   printf("   kTPCout \n");
+//      if ((status&AliESDtrack::kTRDrefit)== 0 ) printf("   kTRDrefit \n");
+//      if ((status&AliESDtrack::kTRDin)== 0 )    printf("   kTRDin \n");
+//      if ((status&AliESDtrack::kTRDout)== 0 )   printf("   kTRDout \n");
+//      if ((status&AliESDtrack::kITSrefit)== 0 ) printf("   kITSrefit \n");
+//      if ((status&AliESDtrack::kITSin)== 0 )    printf("   kITSin \n");
+//      if ((status&AliESDtrack::kITSout)== 0 )   printf("   kITSout \n");
 
       continue;
     }
-
+*/
 	if (label == 0) continue;		//Cannot distinguish between track or fake track
 	if (track->GetLabel() < 0) continue; //Do not consider fake tracks
 
-    if(GetAnalysisMode() == 0) ProcessTPC(stack,track,esdEvent);
-    else if(GetAnalysisMode() == 1) ProcessTPCITS(stack,track,esdEvent);
-    else if(GetAnalysisMode() == 2) ProcessConstrained(stack,track,esdEvent);
+    if(GetAnalysisMode() == 0) ProcessTPC(mcEvent,track,esdEvent);
+    else if(GetAnalysisMode() == 1) ProcessTPCITS(mcEvent,track,esdEvent);
+    else if(GetAnalysisMode() == 2) ProcessConstrained(mcEvent,track,esdEvent);
     else if(GetAnalysisMode() == 3) ProcessInnerTPC(mcEvent,track,esdEvent);
     else if(GetAnalysisMode() == 4) {
 

--- a/PWGPP/TPC/AliPerformanceRes.h
+++ b/PWGPP/TPC/AliPerformanceRes.h
@@ -17,7 +17,6 @@ class TH2F;
 class AliESDVertex;
 class AliESDtrack;
 class AliMCEvent;
-class AliStack;
 class AliTrackReference;
 class AliESDEvent; 
 class AliESDfriend; 
@@ -51,9 +50,9 @@ public :
   virtual TFolder* GetAnalysisFolder() const {return fAnalysisFolder;}
 
   // Process events
-  void ProcessConstrained(AliStack* const stack, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent );
-  void ProcessTPC(AliStack* const stack, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent);
-  void ProcessTPCITS(AliStack* const stack, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent);
+  void ProcessConstrained(AliMCEvent* const mcev, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent );
+  void ProcessTPC(AliMCEvent* const mcev, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent);
+  void ProcessTPCITS(AliMCEvent* const mcev, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent);
   void ProcessInnerTPC(AliMCEvent *const mcEvent, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent);
   void ProcessOuterTPC(AliMCEvent *const mcEvent, AliESDtrack *const esdTrack, AliESDfriendTrack *const friendTrack, AliESDEvent* const esdEvent);
 

--- a/PWGPP/TPC/AliPerformanceTPC.cxx
+++ b/PWGPP/TPC/AliPerformanceTPC.cxx
@@ -55,7 +55,6 @@
 #include "AliMCEvent.h" 
 #include "AliHeader.h" 
 #include "AliGenEventHeader.h" 
-#include "AliStack.h" 
 #include "AliMCInfoCuts.h" 
 #include "AliRecInfoCuts.h" 
 #include "AliTracker.h" 
@@ -277,7 +276,7 @@ void AliPerformanceTPC::Init()
 
 
 //_____________________________________________________________________________
-void AliPerformanceTPC::ProcessTPC(AliStack* const stack, AliESDtrack *const esdTrack, AliESDEvent *const esdEvent, Bool_t vertStatus)
+void AliPerformanceTPC::ProcessTPC(AliMCEvent* const mcev, AliESDtrack *const esdTrack, AliESDEvent *const esdEvent, Bool_t vertStatus)
 {
 //
 // fill TPC QA info
@@ -354,13 +353,13 @@ void AliPerformanceTPC::ProcessTPC(AliStack* const stack, AliESDtrack *const esd
   //
   // Fill rec vs MC information
   //
-  if(!stack) return;
+  if(!mcev) return;
 
 }
 
 
 //_____________________________________________________________________________
-void AliPerformanceTPC::ProcessTPCITS(AliStack* const stack, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent, Bool_t vertStatus)
+void AliPerformanceTPC::ProcessTPCITS(AliMCEvent* const mcev, AliESDtrack *const esdTrack, AliESDEvent* const esdEvent, Bool_t vertStatus)
 {
   // Fill comparison information (TPC+ITS) 
   if(!esdTrack) return;
@@ -425,12 +424,12 @@ void AliPerformanceTPC::ProcessTPCITS(AliStack* const stack, AliESDtrack *const 
   //
   // Fill rec vs MC information
   //
-  if(!stack) return;
+  if(!mcev) return;
 }
 
 
 //_____________________________________________________________________________
-void AliPerformanceTPC::ProcessConstrained(AliStack* const /*stack*/, AliESDtrack *const /*esdTrack*/, AliESDEvent* const /*esdEvent*/)
+void AliPerformanceTPC::ProcessConstrained(AliMCEvent* const /*mcev*/, AliESDtrack *const /*esdTrack*/, AliESDEvent* const /*esdEvent*/)
 {
   // Fill comparison information (constarained parameters) 
   AliDebug(AliLog::kWarning, "Warning: Not implemented");
@@ -450,7 +449,6 @@ void AliPerformanceTPC::Exec(AliMCEvent* const mcEvent, AliESDEvent *const esdEv
   }
   AliHeader* header = 0;
   AliGenEventHeader* genHeader = 0;
-  AliStack* stack = 0;
   TArrayF vtxMC(3);
   
   if(bUseMC)
@@ -463,12 +461,6 @@ void AliPerformanceTPC::Exec(AliMCEvent* const mcEvent, AliESDEvent *const esdEv
     header = mcEvent->Header();
     if (!header) {
       Error("Exec","Header not available");
-      return;
-    }
-    // MC particle stack
-    stack = mcEvent->Stack();
-    if (!stack) {
-      Error("Exec","Stack not available");
       return;
     }
     // get MC vertex
@@ -563,9 +555,9 @@ void AliPerformanceTPC::Exec(AliMCEvent* const mcEvent, AliESDEvent *const esdEv
       }
     }
 
-    if(GetAnalysisMode() == 0) ProcessTPC(stack,track,esdEvent,vertStatus);
-    else if(GetAnalysisMode() == 1) ProcessTPCITS(stack,track,esdEvent,vertStatus);
-    else if(GetAnalysisMode() == 2) ProcessConstrained(stack,track,esdEvent);
+    if(GetAnalysisMode() == 0) ProcessTPC(mcEvent,track,esdEvent,vertStatus);
+    else if(GetAnalysisMode() == 1) ProcessTPCITS(mcEvent,track,esdEvent,vertStatus);
+    else if(GetAnalysisMode() == 2) ProcessConstrained(mcEvent,track,esdEvent);
     else {
       printf("ERROR: AnalysisMode %d \n",fAnalysisMode);
       return;

--- a/PWGPP/TPC/AliPerformanceTPC.h
+++ b/PWGPP/TPC/AliPerformanceTPC.h
@@ -19,7 +19,6 @@ class TH3;
 class AliESDVertex;
 class AliESDtrack;
 class AliMCEvent;
-class AliStack;
 class AliESDEvent; 
 class AliESDfriend; 
 class AliMCInfoCuts;
@@ -53,9 +52,9 @@ public :
   virtual TTree* CreateSummary();
 
   // Process events
-  void ProcessConstrained(AliStack* const stack, AliESDtrack *const esdTrack, AliESDEvent *const esdEvent);
-  void ProcessTPC(AliStack* const stack, AliESDtrack *const esdTrack, AliESDEvent *const esdEvent, Bool_t vertStatus);
-  void ProcessTPCITS(AliStack* const stack, AliESDtrack *const esdTrack, AliESDEvent *const esdEvent, Bool_t vertStatus);
+  void ProcessConstrained(AliMCEvent* const mcev, AliESDtrack *const esdTrack, AliESDEvent *const esdEvent);
+  void ProcessTPC(AliMCEvent* const mcev, AliESDtrack *const esdTrack, AliESDEvent *const esdEvent, Bool_t vertStatus);
+  void ProcessTPCITS(AliMCEvent* const mcev, AliESDtrack *const esdTrack, AliESDEvent *const esdEvent, Bool_t vertStatus);
 
   // Create folder for analysed histograms
   TFolder *CreateFolder(TString folder = "folderTPC",TString title = "Analysed TPC performance histograms");

--- a/PWGPP/TRD/AliTRDinfoGen.cxx
+++ b/PWGPP/TRD/AliTRDinfoGen.cxx
@@ -74,7 +74,6 @@
 #include <AliMultiplicity.h>
 #include <AliCentrality.h>
 #include <AliPID.h>
-#include <AliStack.h>
 #include <AliTrackReference.h>
 #include <TTreeStream.h>
 
@@ -550,14 +549,8 @@ void AliTRDinfoGen::UserExec(Option_t *){
   fV0Identifier->SetEvent(fESDev);
 
   Bool_t *trackMap(NULL);
-  AliStack * mStack(NULL);
   Int_t nTracksMC = HasMCdata() ? fMCev->GetNumberOfTracks() : 0, nTracksESD = fESDev->GetNumberOfTracks();
   if(HasMCdata()){
-    mStack = fMCev->Stack();
-    if(!mStack){
-      AliError("Failed retrieving MC Stack");
-      return;
-    }
     trackMap = new Bool_t[nTracksMC];
     memset(trackMap, 0, sizeof(Bool_t) * nTracksMC);
   }
@@ -652,12 +645,13 @@ void AliTRDinfoGen::UserExec(Option_t *){
       label = esdTrack->GetLabel(); 
       alab = TMath::Abs(label);
       // register the track
-      if(alab < UInt_t(nTracksMC)){ 
-        trackMap[alab] = kTRUE; 
-      } else { 
-        AliError(Form("MC label[%d] outside scope for Ev[%d] Trk[%d].", label, (Int_t)AliAnalysisManager::GetAnalysisManager()->GetCurrentEntry(), itrk));
-        continue; 
-      }
+      // RS: this check makes no sense for events with embedding
+      //      if(alab < UInt_t(nTracksMC)){ 
+      trackMap[alab] = kTRUE; 
+      //    } else { 
+      //  AliError(Form("MC label[%d] outside scope for Ev[%d] Trk[%d].", label, (Int_t)AliAnalysisManager::GetAnalysisManager()->GetCurrentEntry(), itrk));
+      //  continue; 
+      // }
       AliMCParticle *mcParticle(NULL);
       if(!(mcParticle = (AliMCParticle*) fMCev->GetTrack(alab))){
         AliError(Form("MC particle label[%d] missing for Ev[%d] Trk[%d].", label, (Int_t)AliAnalysisManager::GetAnalysisManager()->GetCurrentEntry(), itrk));

--- a/PWGPP/global/AliAnalysisTaskVertexESD.cxx
+++ b/PWGPP/global/AliAnalysisTaskVertexESD.cxx
@@ -406,7 +406,7 @@ void AliAnalysisTaskVertexESD::UserExec(Option_t *)
 
 
   const AliESDVertex *spdv=esdE->GetPrimaryVertexSPD();
-  const AliESDVertex *spdvp=esdE->GetPileupVertexSPD(0);
+  const AliESDVertex *spdvp = esdE->GetNumberOfPileupVerticesSPD()>0 ? esdE->GetPileupVertexSPD(0):0;
   const AliESDVertex *tpcv=esdE->GetPrimaryVertexTPC();
   const AliESDVertex *trkv=esdE->GetPrimaryVertexTracks();
   


### PR DESCRIPTION
1) Make sure tasks are using full AliMCEvent to query MC info and not the AliStack of signal event only (ignoring underlying event).

2) Cosmetic fix to avoid querying TClonesArray of SPD pile-up vertices w/o making sure that there are entries.