### PR TITLE
Fixed issue of DCA in AOD analysis.

### DIFF
--- a/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
+++ b/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
@@ -380,7 +380,8 @@ void AliAnalysisTaskReducedTreeMaker::FillEventInfo()
   }
   
   Double_t values[AliDielectronVarManager::kNMaxValues];
-  AliDielectronVarManager::Fill(event, values);
+  AliDielectronVarManager::SetEventData(values);
+  AliDielectronVarManager::SetEvent(event);
   
   if(fUseAnalysisUtils) {
     if(fAnalysisUtils->IsVertexSelected2013pA(event))  // 2013 p-Pb event selection    


### PR DESCRIPTION
fgEvent in `AliDielectronVarManager` was not set.
Therefore DCA wasn't calculated for all AOD filter bits in the ReducedTreemaker.
Fixed by adding `AliDielectronVarManager::SetEvent(event)`.