### PR TITLE
PWGCF: Train/LambdaKaonFemto/ConfigFemtoAnalysis... altered config files

### DIFF
--- a/PWGCF/FEMTOSCOPY/macros/Train/LambdaKaonFemto/ConfigFemtoAnalysis.C
+++ b/PWGCF/FEMTOSCOPY/macros/Train/LambdaKaonFemto/ConfigFemtoAnalysis.C
@@ -120,7 +120,8 @@ AliFemtoManager* ConfigFemtoAnalysis(const TString& aParamString="")
   //Setup the event reader for ALICE AOD
   AliFemtoEventReaderAODChain *rdr = new AliFemtoEventReaderAODChain();
     rdr->SetUseMultiplicity(tMacroConfig.multiplicity);  //Sets the type of the event multiplicity estimator
-    rdr->SetFilterBit(tMacroConfig.filter_bit);
+    if(tAnalysisConfig.analysisType!=AFALK::kProtPiM && tAnalysisConfig.analysisType!=AFALK::kAProtPiP &&
+       tAnalysisConfig.analysisType!=AFALK::kPiPPiM) rdr->SetFilterBit(tMacroConfig.filter_bit);
     //rdr->SetCentralityPreSelection(0, 900);
     if(tAnalysisConfig.analysisType==AFALK::kXiKchP || tAnalysisConfig.analysisType==AFALK::kAXiKchP ||
        tAnalysisConfig.analysisType==AFALK::kXiKchM || tAnalysisConfig.analysisType==AFALK::kAXiKchM) rdr->SetReadCascade(1);

--- a/PWGCF/FEMTOSCOPY/macros/Train/LambdaKaonFemto/ConfigFemtoAnalysisSystematics.C
+++ b/PWGCF/FEMTOSCOPY/macros/Train/LambdaKaonFemto/ConfigFemtoAnalysisSystematics.C
@@ -132,7 +132,8 @@ AliFemtoManager* ConfigFemtoAnalysis(const TString& aParamString="")
   //Setup the event reader for ALICE AOD
   AliFemtoEventReaderAODChain *rdr = new AliFemtoEventReaderAODChain();
     rdr->SetUseMultiplicity(tMacroConfig.multiplicity);  //Sets the type of the event multiplicity estimator
-    rdr->SetFilterBit(tMacroConfig.filter_bit);
+    if(tAnalysisConfig.analysisType!=AFALK::kProtPiM && tAnalysisConfig.analysisType!=AFALK::kAProtPiP &&
+       tAnalysisConfig.analysisType!=AFALK::kPiPPiM) rdr->SetFilterBit(tMacroConfig.filter_bit);
     //rdr->SetCentralityPreSelection(0, 900);
     if(tAnalysisConfig.analysisType==AFALK::kXiKchP || tAnalysisConfig.analysisType==AFALK::kAXiKchP ||
        tAnalysisConfig.analysisType==AFALK::kXiKchM || tAnalysisConfig.analysisType==AFALK::kAXiKchM) rdr->SetReadCascade(1);

--- a/PWGCF/FEMTOSCOPY/macros/Train/LambdaKaonFemto/ConfigFemtoAnalysisSystematics2.C
+++ b/PWGCF/FEMTOSCOPY/macros/Train/LambdaKaonFemto/ConfigFemtoAnalysisSystematics2.C
@@ -137,7 +137,8 @@ AliFemtoManager* ConfigFemtoAnalysis(const TString& aParamString="")
   //Setup the event reader for ALICE AOD
   AliFemtoEventReaderAODChain *rdr = new AliFemtoEventReaderAODChain();
     rdr->SetUseMultiplicity(tMacroConfig.multiplicity);  //Sets the type of the event multiplicity estimator
-    rdr->SetFilterBit(tMacroConfig.filter_bit);
+    if(tAnalysisConfig.analysisType!=AFALK::kProtPiM && tAnalysisConfig.analysisType!=AFALK::kAProtPiP &&
+       tAnalysisConfig.analysisType!=AFALK::kPiPPiM) rdr->SetFilterBit(tMacroConfig.filter_bit);
     //rdr->SetCentralityPreSelection(0, 900);
     rdr->SetReadV0(1);  //Read V0 information from the AOD and put it into V0Collection
     if(tAnalysisConfig.analysisType==AFALK::kXiKchP || tAnalysisConfig.analysisType==AFALK::kAXiKchP ||


### PR DESCRIPTION
PWGCF: Train/LambdaKaonFemto/ConfigFemtoAnalysis... altered config files so no filter bit set for kProtPiM, kAProtPiP, and kPiPPiM analyses