### PR TITLE
Debugging issue with incorrect pt-hard bins

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
@@ -367,8 +367,9 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   BeamType                    fBeamType;                   //!<!event beam type
   AliGenPythiaEventHeader    *fPythiaHeader;               //!<!event Pythia header
   AliGenHerwigEventHeader    *fHerwigHeader;               //!<!event Herwig header
-  Double_t                    fPtHard;                     //!<!event \f$ p_{t}\f$-hard
+  Float_t                     fPtHard;                     //!<!event \f$ p_{t}\f$-hard
   Int_t                       fPtHardBin;                  //!<!event \f$ p_{t}\f$-hard bin
+  Int_t                       fPtHardBinGlobal;            //!<!event \f$ p_{t}\f$-hard bin, detected from filename
   Int_t                       fNPtHardBins;                ///< Number of \f$ p_{t}\f$-hard bins in the dataset
   TArrayI                     fPtHardBinning;              ///< \f$ p_{t}\f$-hard binning
   Int_t                       fNTrials;                    //!<!event trials
@@ -384,7 +385,10 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   TH1                        *fHistTrials;                 //!<!trials from pyxsec.root
   TH1                        *fHistEvents;                 //!<!total number of events per pt hard bin
   TProfile                   *fHistXsection;               //!<!x section from pyxsec.root
-  TH1                        *fHistPtHard;                 //!<!pt hard distribution
+  TH1                        *fHistPtHard;                 //!<!\f$ p_{t}\f$-hard distribution
+  TH2                        *fHistPtHardCorr;             //!<!Correlation between \f$ p_{t}\f$-hard value and bin
+  TH2                        *fHistPtHardCorrGlobal;       //!<!Correlation between \f$ p_{t}\f$-hard value and global bin
+  TH2                        *fHistPtHardBinCorr;          //!<!Correlation between global and local (per-event) \f$ p_{t}\f$-hard bin
   TH1                        *fHistCentrality;             //!<!event centrality distribution
   TH1                        *fHistZVertex;                //!<!z vertex position
   TH1                        *fHistEventPlane;             //!<!event plane distribution

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskChargedParticlesRefMC.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskChargedParticlesRefMC.cxx
@@ -176,6 +176,8 @@ bool AliAnalysisTaskChargedParticlesRefMC::IsEventSelected(){
     if(!CheckMCOutliers()) return false;
   }
 
+  fHistos->FillTH1("hPtHard", fPtHard);
+
 
   // select trigger
   bool isMinBias;


### PR DESCRIPTION
Currenly in rare cases incorrect pt-hard bins are
filled when running on the grid. The incorrect pt-hard
bins are neighboring bins (in case of determination
by the pt-hard value) or bin number 0 (in case of
determination using the absolute file path.
- Storing globally defined (from file path) pt-hard
  bin in addition to locally defined (from pt-hard
  value in the header)
- Adding histograms sensitive to the pt-hard binning
  - Correlation between pt-hard value and local bin
  - Correlation between pt-hard value and global bin
  - Correlation between global and local bin
- Change type of pt-hard variable from double to float
  (implicit conversion from lower precision to high
  precision floating point number enforcing comparison
  using double precision) as pt-hard value is stored
  only with single precision in the header.
- Fixing handling obtaining cross section from header