### PR TITLE
Modifications for doxygen of AliAnalysisTaskEmcal

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
@@ -62,9 +62,6 @@ Double_t AliAnalysisTaskEmcal::fgkEMCalDCalPhiDivide = 4.;
 ClassImp(AliAnalysisTaskEmcal);
 /// \endcond
 
-/**
- * Default constructor.
- */
 AliAnalysisTaskEmcal::AliAnalysisTaskEmcal() : 
   AliAnalysisTaskSE("AliAnalysisTaskEmcal"),
   fPythiaInfoName(""),
@@ -176,16 +173,6 @@ AliAnalysisTaskEmcal::AliAnalysisTaskEmcal() :
   fClusterCollArray.SetOwner(kTRUE);
 }
 
-/**
- * Standard constructor. Should be used by the user.
- *
- * Note: This constructor also handles the general histograms. In
- * case the second parameter is true, then general histograms (see
- * UserCreateOutputObjects and FillHistograms) are created and filled
- * by the task, and a container is provided handling the user histograms.
- * @param[in] name Name of the task
- * @param[in] histo If true then general histograms are filled by the task
- */
 AliAnalysisTaskEmcal::AliAnalysisTaskEmcal(const char *name, Bool_t histo) : 
   AliAnalysisTaskSE(name),
   fPythiaInfoName(""),
@@ -300,19 +287,10 @@ AliAnalysisTaskEmcal::AliAnalysisTaskEmcal(const char *name, Bool_t histo) :
   }
 }
 
-/**
- * Destructor
- */
 AliAnalysisTaskEmcal::~AliAnalysisTaskEmcal()
 {
 }
 
-/**
- * Apply cut on \f$ p_{t} \f$ for all clusters in container with
- * index c
- * @param[in] cut \f$ p_{t} \f$-cut to be applied
- * @param[in] c Index of the cluster container affected by the cut
- */
 void AliAnalysisTaskEmcal::SetClusPtCut(Double_t cut, Int_t c)
 {
   AliClusterContainer *cont = GetClusterContainer(c);
@@ -320,13 +298,6 @@ void AliAnalysisTaskEmcal::SetClusPtCut(Double_t cut, Int_t c)
   else AliError(Form("%s in SetClusPtCut(...): container %d not found",GetName(),c));
 }
 
-/**
- * Apply cut on cluster time for clusters in container with
- * index c
- * @param[in] min Min. cluster time
- * @param[in] max Max. cluster time
- * @param[in] c Index of the cluster container affected by the cut
- */
 void AliAnalysisTaskEmcal::SetClusTimeCut(Double_t min, Double_t max, Int_t c)
 {
   AliClusterContainer *cont = GetClusterContainer(c);
@@ -334,12 +305,6 @@ void AliAnalysisTaskEmcal::SetClusTimeCut(Double_t min, Double_t max, Int_t c)
   else AliError(Form("%s in SetClusTimeCut(...): container %d not found",GetName(),c));
 }
 
-/**
- * Apply cut on the transverse momentum \f$ p_{t} \f$ of all tracks in
- * the track container with index c.
- * @param[in] cut \f$ p_{t} \f$-cut to be applied
- * @param[in] c Index of the particle container affected by the cut
- */
 void AliAnalysisTaskEmcal::SetTrackPtCut(Double_t cut, Int_t c)
 {
   AliParticleContainer *cont = GetParticleContainer(c);
@@ -349,13 +314,6 @@ void AliAnalysisTaskEmcal::SetTrackPtCut(Double_t cut, Int_t c)
   fTrackPtCut = cut;
 }
 
-/**
- * Apply cut on the pseudorapidity \f$ \eta \f$ of the all tracks in the
- * track container with index c
- * @param[in] min Minimum of the allowed track \f$ \eta \f$ range
- * @param[in] max Maximum of the allowed track \f$ \eta \f$ range
- * @param[in] c Index of the particle container affected by the cut
- */
 void AliAnalysisTaskEmcal::SetTrackEtaLimits(Double_t min, Double_t max, Int_t c)
 {
   AliParticleContainer *cont = GetParticleContainer(c);
@@ -363,13 +321,6 @@ void AliAnalysisTaskEmcal::SetTrackEtaLimits(Double_t min, Double_t max, Int_t c
   else AliError(Form("%s in SetTrackPtCut(...): container %d not found",GetName(),c));
 }
 
-/**
- * Apply cut on the pseudorapidity \f$ \phi \f$ of the all tracks in the
- * track container with index c
- * @param[in] min Minimum of the allowed track \f$ \phi \f$ range
- * @param[in] max Maximum of the allowed track \f$ \phi \f$ range
- * @param[in] c Index of the particle container affected by the cut
- */
 void AliAnalysisTaskEmcal::SetTrackPhiLimits(Double_t min, Double_t max, Int_t c)
 {
   AliParticleContainer *cont = GetParticleContainer(c);
@@ -377,25 +328,6 @@ void AliAnalysisTaskEmcal::SetTrackPhiLimits(Double_t min, Double_t max, Int_t c
   else AliError(Form("%s in SetTrackPhiLimits(...): container %d not found",GetName(),c));
 }
 
-/**
- * Performing run-independent initialization. This consists of
- * - Determining data type (ESD/AOD)
- * - Creating general QA histograms
- *
- * Attention: Histograms are only created in case the task is
- * configured for this (second argument in the named constructor).
- * In this case the container fOuput is created which can be used
- * by the users to handle and store their histograms. In this case
- * the users must overwrite this function in their tasks and call
- * this function right at the beginning of their function.
- *
- * The general QA histograms monitor event related observables like
- * the z-position of the primary vertex before and after event selection,
- * the trigger classes selecting the event and the event rejection
- * reason, but also Monte-Carlo related observables like the cross
- * section, the number of trials and the \f$ p_{t} \f$-hard bin in
- * case of a corresponding production.
- */
 void AliAnalysisTaskEmcal::UserCreateOutputObjects()
 {
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
@@ -585,19 +517,6 @@ void AliAnalysisTaskEmcal::UserCreateOutputObjects()
   PostData(1, fOutput);
 }
 
-/**
- * Filling general histrograms. Among the general histograms
- * that are filled only in case of running over MC productions
- * are
- * - \f$ p_{t} \f$-hard bin
- * - Cross section after event selection
- * - Number of trials after event selection
- * - Number of events after event selection
- * In any case the vertex distribution is filled as general
- * histograms. For heavy ion collisions also the centrality
- * distribution and the event plane distribution are filled.
- * @return Always true
- */
 Bool_t AliAnalysisTaskEmcal::FillGeneralHistograms()
 {
   if (fIsPythia || fIsHerwig) {
@@ -709,14 +628,6 @@ void AliAnalysisTaskEmcal::UserExec(Option_t *option)
   }
 }
 
-/**
- * Check whether cluster is accepted under the cluster
- * selection specified in the cluster container stored
- * under index c
- * @param[in] clus EMCAL cluster to be accepted
- * @param[in] c Index of the cluster container
- * @return true if cluster is accepted
- */
 Bool_t AliAnalysisTaskEmcal::AcceptCluster(AliVCluster *clus, Int_t c) const
 {
   AliWarning("AliAnalysisTaskEmcal::AcceptCluster method is deprecated. Please use GetCusterContainer(c)->AcceptCluster(clus).");
@@ -732,14 +643,6 @@ Bool_t AliAnalysisTaskEmcal::AcceptCluster(AliVCluster *clus, Int_t c) const
   return cont->AcceptCluster(clus, rejectionReason);
 }
 
-/**
- * Check whether track is accepted under the track
- * selection specified in the track container stored
- * under index c
- * @param[in] track Track to be checked
- * @param[in] c Index of the track container
- * @return true if track is accepted
- */
 Bool_t AliAnalysisTaskEmcal::AcceptTrack(AliVParticle *track, Int_t c) const
 {
   AliWarning("AliAnalysisTaskEmcal::AcceptTrack method is deprecated. Please use GetParticleContainer(c)->AcceptParticle(clus).");
@@ -961,10 +864,6 @@ Bool_t AliAnalysisTaskEmcal::FileChanged(){
   return kTRUE;
 }
 
-/**
- * Load parton info
- * @param event
- */
 void AliAnalysisTaskEmcal::LoadPythiaInfo(AliVEvent *event)
 {
   if (!fPythiaInfoName.IsNull() && !fPythiaInfo) {
@@ -1060,11 +959,6 @@ void AliAnalysisTaskEmcal::ExecOnce()
   fLocalInitialized = kTRUE;
 }
 
-/**
- * Get beam type : pp-AA-pA
- * ESDs have it directly, AODs get it from hardcoded run number ranges
- * @return Beam type of the run.
- */
 AliAnalysisTaskEmcal::BeamType AliAnalysisTaskEmcal::GetBeamType() const
 {
   if (fForceBeamType != kNA)
@@ -1099,12 +993,6 @@ AliAnalysisTaskEmcal::BeamType AliAnalysisTaskEmcal::GetBeamType() const
   }  
 }
 
-/**
- * Get list of selected triggers of the given event.
- * The trigger selection is performed using EMCAL
- * patches found for the given event
- * @return A bitmap encoding the trigger found for the event
- */
 ULong_t AliAnalysisTaskEmcal::GetTriggerList()
 {
   if (!fTriggerPatchInfo)
@@ -1143,12 +1031,6 @@ ULong_t AliAnalysisTaskEmcal::GetTriggerList()
   return triggers;
 }
 
-/**
- * Check if event has a given trigger type
- * @param trigger
- * @return True fo the trigger type is found in the event,
- * false otherwise.
- */
 Bool_t AliAnalysisTaskEmcal::HasTriggerType(TriggerType trigger)
 {
   //
@@ -1163,27 +1045,6 @@ Bool_t AliAnalysisTaskEmcal::HasTriggerType(TriggerType trigger)
   return TESTBIT(fTriggers, trigger);
 }
 
-/**
- * Performing event selection. This contains
- * - Selection of the trigger class
- * - Selection according to the centrality class
- * - Selection of event with good vertex quality
- * - Selection of the event plane orientation
- * - Selection of the multiplicity (including
- *   above minimum \f$ p_{t} \f$ and tracks in the
- *   EMCAL acceptance
- *
- * Note that for the vertex selection both the usage
- * of the analysis util and the range of the z-position
- * of the primary vertex need to be specified.
- *
- * In case the event is rejected, a histogram
- * monitoring the rejeciton reason is filled with
- * the bin corresponding to the source of the rejection
- * of the current event.
- *
- * @return True if the event is selected.
- */
 Bool_t AliAnalysisTaskEmcal::IsEventSelected()
 {
   if (fOffTrigger != AliVEvent::kAny) {
@@ -1393,11 +1254,6 @@ Bool_t AliAnalysisTaskEmcal::IsEventSelected()
   return kTRUE;
 }
 
-/**
- * Filter the mc tails in pt-hard distributions
- * See https://twiki.cern.ch/twiki/bin/view/ALICE/JetMCProductionsCrossSections#How_to_reject_tails_in_the_pT_ha
- * @return kTRUE if it is not a MC outlier
- */
 Bool_t AliAnalysisTaskEmcal::CheckMCOutliers()
 {
   if (!fPythiaHeader || !fMCRejectFilter) return kTRUE;
@@ -1461,14 +1317,6 @@ Bool_t AliAnalysisTaskEmcal::CheckMCOutliers()
   return kTRUE;
 }
 
-/**
- * Read a TClonesArray from event. Attention: Both the
- * name of the array and the name of the object stored inside
- * must match.
- * @param[in] name Name of the array to be read in
- * @param[in] clname Name of the type of the objects stored in the array
- * @return Pointer to the TClonesArray (NULL if not found)
- */
 TClonesArray *AliAnalysisTaskEmcal::GetArrayFromEvent(const char *name, const char *clname)
 {
   TClonesArray *arr = 0;
@@ -1496,10 +1344,6 @@ TClonesArray *AliAnalysisTaskEmcal::GetArrayFromEvent(const char *name, const ch
   return arr;
 }
 
-/**
- * Retrieve objects from event.
- * @return
- */
 Bool_t AliAnalysisTaskEmcal::RetrieveEventObjects()
 {
   fVertex[0] = 0;
@@ -1690,13 +1534,6 @@ Bool_t AliAnalysisTaskEmcal::RetrieveEventObjects()
   return kTRUE;
 }
 
-/**
- * Create new container for MC particles and attach it to the task. The name
- * provided to this function must match the name of the array attached
- * to the new container inside the input event.
- * @param[in] n Name of the container and the array the container points to
- * @return Pointer to the new container for MC particles
- */
 AliMCParticleContainer* AliAnalysisTaskEmcal::AddMCParticleContainer(const char *n)
 {
   if (TString(n).IsNull()) return 0;
@@ -1708,13 +1545,6 @@ AliMCParticleContainer* AliAnalysisTaskEmcal::AddMCParticleContainer(const char 
   return cont;
 }
 
-/**
- * Create new track container and attach it to the task. The name
- * provided to this function must match the name of the array attached
- * to the new container inside the input event.
- * @param[in] n Name of the container and the array the container points to
- * @return Pointer to the new track container
- */
 AliTrackContainer* AliAnalysisTaskEmcal::AddTrackContainer(const char *n)
 {
   if (TString(n).IsNull()) return 0;
@@ -1726,13 +1556,6 @@ AliTrackContainer* AliAnalysisTaskEmcal::AddTrackContainer(const char *n)
   return cont;
 }
 
-/**
- * Create new particle container and attach it to the task. The name
- * provided to this function must match the name of the array attached
- * to the new container inside the input event.
- * @param[in] n Name of the container and the array the container points to
- * @return Pointer to the new particle container
- */
 AliParticleContainer* AliAnalysisTaskEmcal::AddParticleContainer(const char *n) 
 {
   if (TString(n).IsNull()) return 0;
@@ -1744,13 +1567,6 @@ AliParticleContainer* AliAnalysisTaskEmcal::AddParticleContainer(const char *n)
   return cont;
 }
 
-/**
- * Create new cluster container and attach it to the task. The name
- * provided to this function must match the name of the array attached
- * to the new container inside the input event.
- * @param[in] n Name of the container and the array the container points to
- * @return Pointer to the new cluster container
- */
 AliClusterContainer* AliAnalysisTaskEmcal::AddClusterContainer(const char *n) 
 {
   if (TString(n).IsNull()) return 0;
@@ -1762,11 +1578,6 @@ AliClusterContainer* AliAnalysisTaskEmcal::AddClusterContainer(const char *n)
   return cont;
 }
 
-/**
- * Get \f$ i^{th} \f$ particle container attached to this task
- * @param[in] i Index of the particle container
- * @return Particle container found for the given index (NULL if no particle container exists for that index)
- */
 AliParticleContainer* AliAnalysisTaskEmcal::GetParticleContainer(Int_t i) const 
 {
   if (i<0 || i>fParticleCollArray.GetEntriesFast()) return 0;
@@ -1774,11 +1585,6 @@ AliParticleContainer* AliAnalysisTaskEmcal::GetParticleContainer(Int_t i) const
   return cont;
 }
 
-/**
- * Get \f$ i^{th} \f$ cluster container attached to this task
- * @param[in] i Index of the cluster container
- * @return Cluster container found for the given index (NULL if no cluster container exists for that index)
- */
 AliClusterContainer* AliAnalysisTaskEmcal::GetClusterContainer(Int_t i) const 
 {
   if (i<0 || i>fClusterCollArray.GetEntriesFast()) return 0;
@@ -1786,33 +1592,18 @@ AliClusterContainer* AliAnalysisTaskEmcal::GetClusterContainer(Int_t i) const
   return cont;
 }
 
-/**
- * Find particle container attached to this task according to its name
- * @param[in] name Name of the particle container
- * @return Particle container found under the given name
- */
 AliParticleContainer* AliAnalysisTaskEmcal::GetParticleContainer(const char *name) const 
 {
   AliParticleContainer *cont = static_cast<AliParticleContainer*>(fParticleCollArray.FindObject(name));
   return cont;
 }
 
-/**
- * Find cluster container attached to this task according to its name
- * @param[in] name Name of the cluster container
- * @return Cluster container found under the given name
- */
 AliClusterContainer* AliAnalysisTaskEmcal::GetClusterContainer(const char *name) const 
 {
   AliClusterContainer *cont = static_cast<AliClusterContainer*>(fClusterCollArray.FindObject(name));
   return cont;
 }
 
-/**
- * Get \f$ $i^{th} \f$ TClonesArray with particles
- * @param[in] i Index of the particle container inside the task
- * @return TClonesArray connected to the container (NULL if not found)
- */
 TClonesArray* AliAnalysisTaskEmcal::GetParticleArray(Int_t i) const 
 {
   AliParticleContainer *cont = GetParticleContainer(i);
@@ -1824,11 +1615,6 @@ TClonesArray* AliAnalysisTaskEmcal::GetParticleArray(Int_t i) const
   return cont->GetArray();
 }
 
-/**
- * Get \f$ i^{th} \f$ TClonesArray with EMCAL clusters
- * @param[in] i Index of the cluster container inside the task
- * @return TClonesArray connected to the container (NULL if not found)
- */
 TClonesArray* AliAnalysisTaskEmcal::GetClusterArray(Int_t i) const 
 {
   AliClusterContainer *cont = GetClusterContainer(i);
@@ -1839,13 +1625,6 @@ TClonesArray* AliAnalysisTaskEmcal::GetClusterArray(Int_t i) const
   return cont->GetArray();
 }
 
-/**
- * Get particle p if accepted from  container with index c
- * If particle not accepted return 0
- * @param[in] p Index of the particle inside the Particle container
- * @param[in] c Index of the particle container
- * @return Accepted particle (NULL if no accepted particle with the index is found inside the container)
- */
 AliVParticle* AliAnalysisTaskEmcal::GetAcceptParticleFromArray(Int_t p, Int_t c) const 
 {
 
@@ -1859,13 +1638,6 @@ AliVParticle* AliAnalysisTaskEmcal::GetAcceptParticleFromArray(Int_t p, Int_t c)
   return vp;
 }
 
-/**
- * Get particle p if accepted from  container c
- * If particle not accepted return 0
- * @param[in] cl Index of the cluster inside the container
- * @param[in] c Indexd of the cluster container
- * @return Accepted cluster (NULL if no accepted cluster with index is found)
- */
 AliVCluster* AliAnalysisTaskEmcal::GetAcceptClusterFromArray(Int_t cl, Int_t c) const 
 {
   AliClusterContainer *cont = GetClusterContainer(c);
@@ -1878,11 +1650,6 @@ AliVCluster* AliAnalysisTaskEmcal::GetAcceptClusterFromArray(Int_t cl, Int_t c) 
   return vc;
 }
 
-/**
- * Get number of particles in container attached to this task with index i
- * @param[in] i Index of then particle container
- * @return Number of particles in container
- */
 Int_t AliAnalysisTaskEmcal::GetNParticles(Int_t i) const 
 {
   AliParticleContainer *cont = GetParticleContainer(i);
@@ -1893,12 +1660,6 @@ Int_t AliAnalysisTaskEmcal::GetNParticles(Int_t i) const
   return cont->GetNEntries();
 }
 
-/**
- * Get number of clusters in the cluster container attached to this task with
- * index i
- * @param[in] i Index of the container
- * @return Number of clusters inside the container
- */
 Int_t AliAnalysisTaskEmcal::GetNClusters(Int_t i) const 
 {
   AliClusterContainer *cont = GetClusterContainer(i);
@@ -1909,17 +1670,6 @@ Int_t AliAnalysisTaskEmcal::GetNClusters(Int_t i) const
   return cont->GetNEntries();
 }
 
-/**
- * Get main trigger match
- *
- * For the selection of the main trigger patch, high and low threshold triggers of a given category are grouped
- * If there are more than 1 main patch of a given trigger category (i.e. different high and low threshold patches),
- * the highest one according to the ADC value is taken. In case doSimpleOffline is true, then only the patches from
- * the simple offline trigger are used.
- * @param[in] trigger Type of the EMCAL Level0/Level1 trigger
- * @param[in] doSimpleOffline If true simple offline patches are used
- * @return Main trigger patch for the trigger category (defined as highest energy patch)
- */
 AliEMCALTriggerPatchInfo* AliAnalysisTaskEmcal::GetMainTriggerPatch(TriggerCategory trigger, Bool_t doSimpleOffline)
 {
 
@@ -2001,11 +1751,6 @@ AliEMCALTriggerPatchInfo* AliAnalysisTaskEmcal::GetMainTriggerPatch(TriggerCateg
   return selected;
 }
 
-/**
- * Add object to event
- * @param[in] obj Object to be added
- * @param[in] attempt If true don't handle error
- */
 void AliAnalysisTaskEmcal::AddObjectToEvent(TObject *obj, Bool_t attempt)
 {
   if (!(InputEvent()->FindListObject(obj->GetName()))) {
@@ -2018,13 +1763,6 @@ void AliAnalysisTaskEmcal::AddObjectToEvent(TObject *obj, Bool_t attempt)
   }
 }
 
-/**
- * Determines if a track is inside the EMCal acceptance, using \f$\eta\f$/\f$\phi\f$ at the vertex (no propagation).
- * Includes +/- edges. Useful to determine whether track propagation should be attempted.
- * @param[in] part Particle to check
- * @param[in] edges Size of the edges in \f$\phi\f$ excluded from the EMCAL acceptance
- * @return True if a particle is inside the EMCAL acceptance, false otherwise
- */
 Bool_t AliAnalysisTaskEmcal::IsTrackInEmcalAcceptance(AliVParticle* part, Double_t edges) const
 {
 
@@ -2080,12 +1818,6 @@ void AliAnalysisTaskEmcal::SetRejectionReasonLabels(TAxis* axis)
   axis->SetBinLabel(32, "Bit31");
 }
 
-/**
- * Calculates the fraction of momentum z of part 1 w.r.t. part 2 in the direction of part 2.
- * @param[in] part1 Momentum vector for which the relative fraction is calculated
- * @param[in] part2 Reference momentum vector for the calculation
- * @return Relative fraction of momentum of particle 1 with respect to particle 2
- */
 Double_t AliAnalysisTaskEmcal::GetParallelFraction(AliVParticle* part1, AliVParticle* part2)
 {
   TVector3 vect1(part1->Px(), part1->Py(), part1->Pz());
@@ -2094,12 +1826,6 @@ Double_t AliAnalysisTaskEmcal::GetParallelFraction(AliVParticle* part1, AliVPart
   return z;
 }
 
-/**
- * Calculates the fraction of momentum z of vect 1 w.r.t. part 2 in the direction of part 2.
- * @param[in] vect1 Momentum vector for which the relative fraction is calculated
- * @param[in] part2 Reference momentum vector for the calculation
- * @return Relative fraction of momentum of particle 1 with respect to particle 2
- */
 Double_t AliAnalysisTaskEmcal::GetParallelFraction(const TVector3& vect1, AliVParticle* part2)
 {
   TVector3 vect2(part2->Px(), part2->Py(), part2->Pz());
@@ -2107,14 +1833,6 @@ Double_t AliAnalysisTaskEmcal::GetParallelFraction(const TVector3& vect1, AliVPa
   return z;
 }
 
-/**
- * Calculate \f$\phi\f$ and \f$\eta\f$ difference between a track (t) and a cluster (c). The
- * position of the track is obtained on the EMCAL surface
- * @param[in] t Track to check
- * @param[in] v Cluster to check
- * @param[out] phidiff Distance in \f$\phi\f$ between cluster and track
- * @param[out] etadiff Distance in \f$\eta\f$ between cluster and track
- */
 void AliAnalysisTaskEmcal::GetEtaPhiDiff(const AliVTrack *t, const AliVCluster *v, Double_t &phidiff, Double_t &etadiff)
 {
   phidiff = 999;
@@ -2134,11 +1852,6 @@ void AliAnalysisTaskEmcal::GetEtaPhiDiff(const AliVTrack *t, const AliVCluster *
   phidiff=TVector2::Phi_mpi_pi(vphi-cphi);
 }
 
-/**
- * Get track type encoded from bits 20 and 21.
- * @param[in] t Track to check
- * @return
- */
 Byte_t AliAnalysisTaskEmcal::GetTrackType(const AliVTrack *t)
 {
   Byte_t ret = 0;
@@ -2151,15 +1864,6 @@ Byte_t AliAnalysisTaskEmcal::GetTrackType(const AliVTrack *t)
   return ret;
 }
 
-/**
- * Return track type: 0 = filterBit1, 1 = filterBit2 && ITS, 2 = filterBit2 && !ITS.
- * Returns 3 if filterBit1 and filterBit2 do not test.
- * WARNING: only works with AOD tracks and AOD filter bits must be provided. Otherwise will always return 0.
- * @param aodTrack
- * @param filterBit1
- * @param filterBit2
- * @return
- */
 Byte_t AliAnalysisTaskEmcal::GetTrackType(const AliAODTrack *aodTrack, UInt_t filterBit1, UInt_t filterBit2)
 {
 
@@ -2183,10 +1887,6 @@ Byte_t AliAnalysisTaskEmcal::GetTrackType(const AliAODTrack *aodTrack, UInt_t fi
   return res;
 }
 
-/**
- * Copy some information about the Pythia event in a PythaInfo object
- * @param[in] mcEvent Monte Carlo event from which the information is obtained
- */
 void AliAnalysisTaskEmcal::GeneratePythiaInfoObject(AliMCEvent* mcEvent)
 {
   if (!fPythiaInfo) {
@@ -2214,10 +1914,6 @@ void AliAnalysisTaskEmcal::GeneratePythiaInfoObject(AliMCEvent* mcEvent)
     fPythiaInfo->SetPythiaEventWeight(ptWeight);}
 }
 
-/**
- * Add an AOD handler to the analysis manager
- * @return pointer to the new AOD handler
- */
 AliAODInputHandler* AliAnalysisTaskEmcal::AddAODHandler()
 {
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
@@ -2246,10 +1942,6 @@ AliAODInputHandler* AliAnalysisTaskEmcal::AddAODHandler()
   return aodHandler;
 }
 
-/**
- * Add a ESD handler to the analysis manager
- * @return pointer to the new ESD handler
- */
 AliESDInputHandler* AliAnalysisTaskEmcal::AddESDHandler()
 {
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
@@ -124,21 +124,99 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
     kOverlapWithLowThreshold   //!< The overlap between low and high threshold trigger is assigned to the lower threshold only
   };
 
+  /**
+   * @brief Default constructor.
+   */
   AliAnalysisTaskEmcal();
+
+  /**
+   * @brief Standard constructor. Should be used by the user.
+   *
+   * Note: This constructor also handles the general histograms. In
+   * case the second parameter is true, then general histograms (see
+   * UserCreateOutputObjects and FillHistograms) are created and filled
+   * by the task, and a container is provided handling the user histograms.
+   * @param[in] name Name of the task
+   * @param[in] histo If true then general histograms are filled by the task
+   */
   AliAnalysisTaskEmcal(const char *name, Bool_t histo=kFALSE);
+
+  /**
+   * @brief Destructor
+   */
   virtual ~AliAnalysisTaskEmcal();
 
+  /**
+   * @brief Create new particle container and attach it to the task.
+   *
+   * The name provided to this function must match the name of the array attached
+   * to the new container inside the input event.
+   * @param[in] n Name of the container and the array the container points to
+   * @return Pointer to the new particle container
+   */
   AliParticleContainer       *AddParticleContainer(const char *n);
+
+  /**
+   * @brief Create new track container and attach it to the task.
+   *
+   * The name provided to this function must match the name of the array
+   * attached to the new container inside the input event.
+   * @param[in] n Name of the container and the array the container points to
+   * @return Pointer to the new track container
+   */
   AliTrackContainer          *AddTrackContainer(const char *n);
+
+  /**
+   * @brief Create new container for MC particles and attach it to the task.
+   *
+   * The name provided to this function must match the name of the array attached
+   * to the new container inside the input event.
+   * @param[in] n Name of the container and the array the container points to
+   * @return Pointer to the new container for MC particles
+   */
   AliMCParticleContainer     *AddMCParticleContainer(const char *n);
+
+  /**
+   * @brief Create new cluster container and attach it to the task.
+   *
+   * The name provided to this function must match the name of the array
+   * attached to the new container inside the input event.
+   * @param[in] n Name of the container and the array the container points to
+   * @return Pointer to the new cluster container
+   */
   AliClusterContainer        *AddClusterContainer(const char *n);
+
   void                        AdoptParticleContainer(AliParticleContainer* cont)    { fParticleCollArray.Add(cont)                        ; }
   void                        AdoptTrackContainer(AliTrackContainer* cont)          { AdoptParticleContainer(cont)                        ; }
   void                        AdoptMCParticleContainer(AliMCParticleContainer* cont){ AdoptParticleContainer(cont)                        ; }
   void                        AdoptClusterContainer(AliClusterContainer* cont)      { fClusterCollArray.Add(cont)                         ; }
+
+  /**
+   * @brief Get \f$ i^{th} \f$ particle container attached to this task
+   * @param[in] i Index of the particle container
+   * @return Particle container found for the given index (NULL if no particle container exists for that index)
+   */
   AliParticleContainer       *GetParticleContainer(Int_t i=0)         const;
+
+  /**
+   * @brief Find particle container attached to this task according to its name
+   * @param[in] name Name of the particle container
+   * @return Particle container found under the given name
+   */
   AliParticleContainer       *GetParticleContainer(const char* name)  const;
+
+  /**
+   * @brief Get \f$ i^{th} \f$ cluster container attached to this task
+   * @param[in] i Index of the cluster container
+   * @return Cluster container found for the given index (NULL if no cluster container exists for that index)
+   */
   AliClusterContainer        *GetClusterContainer(Int_t i=0)          const;
+
+  /**
+   * @brief Find cluster container attached to this task according to its name
+   * @param[in] name Name of the cluster container
+   * @return Cluster container found under the given name
+   */
   AliClusterContainer        *GetClusterContainer(const char* name)   const;
   AliMCParticleContainer     *GetMCParticleContainer(Int_t i=0)               const { return dynamic_cast<AliMCParticleContainer*>(GetParticleContainer(i))   ; }
   AliMCParticleContainer     *GetMCParticleContainer(const char* name)        const { return dynamic_cast<AliMCParticleContainer*>(GetParticleContainer(name)); }
@@ -151,8 +229,24 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   void                        SetCaloTriggersName(const char *n)                    { fCaloTriggersName  = n                              ; }
   void                        SetCentRange(Double_t min, Double_t max)              { fMinCent           = min  ; fMaxCent = max          ; }
   void                        SetCentralityEstimator(const char *c)                 { fCentEst           = c                              ; }
+
+  /**
+   * @brief Apply cut on \f$ p_{t} \f$ for all clusters in container with
+   * index c
+   * @param[in] cut \f$ p_{t} \f$-cut to be applied
+   * @param[in] c Index of the cluster container affected by the cut
+   */
   void                        SetClusPtCut(Double_t cut, Int_t c=0);
+
+  /**
+   * @brief Apply cut on cluster time for clusters in container with
+   * index c
+   * @param[in] min Min. cluster time
+   * @param[in] max Max. cluster time
+   * @param[in] c Index of the cluster container affected by the cut
+   */
   void                        SetClusTimeCut(Double_t min, Double_t max, Int_t c=0);
+
   void                        SetEventPlaneVsEmcal(Double_t ep)                     { fEventPlaneVsEmcal = ep                             ; }
   void                        SetForceBeamType(BeamType f)                          { fForceBeamType     = f                              ; }
   void                        SetHistoBins(Int_t nbins, Double_t min, Double_t max) { fNbins = nbins; fMinBinPt = min; fMaxBinPt = max    ; }
@@ -162,16 +256,16 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   void                        SetMakeGeneralHistograms(Bool_t g)                    { fGeneralHistograms = g                              ; }
 
   /**
-   * @brief Set the number of \f$ p_{t}\$-hard bins
-   * @param[in] nbins Number of \f$ p_{t}\$-hard bins
+   * @brief Set the number of \f$ p_{t}\f$-hard bins
+   * @param[in] nbins Number of \f$ p_{t}\f$-hard bins
    */
   void                        SetNumberOfPtHardBins(Int_t nbins)                    { fNPtHardBins = nbins; }
 
   /**
-   * @brief Set a non-standard \f$ p_{t}\$-hard binning
+   * @brief Set a non-standard \f$ p_{t}\f$-hard binning
    *
    * The array reflects the bin limits, therefore the size must
-   * match the number of \f$ p_{t}\$-hard bins + 1, otherwise
+   * match the number of \f$ p_{t}\f$-hard bins + 1, otherwise
    * the binning is not used in order to create the bin labels
    *
    * @param[in] binning Non-standard binning to be applied
@@ -187,9 +281,33 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   void                        SetNeedEmcalGeom(Bool_t n)                            { fNeedEmcalGeom     = n                              ; }
   void                        SetCountDownscaleCorrectedEvents(Bool_t d)            { fCountDownscaleCorrectedEvents =  d                 ; }
   void                        SetOffTrigger(UInt_t t)                               { fOffTrigger        = t                              ; }
+
+  /**
+   * @brief Apply cut on the pseudorapidity \f$ \eta \f$ of the all tracks in the
+   * track container with index c
+   * @param[in] min Minimum of the allowed track \f$ \eta \f$ range
+   * @param[in] max Maximum of the allowed track \f$ \eta \f$ range
+   * @param[in] c Index of the particle container affected by the cut
+   */
   void                        SetTrackEtaLimits(Double_t min, Double_t max, Int_t c=0);
+
+  /**
+   * @brief Apply cut on azimuthal angle \f$ \phi \f$ of the all tracks in the
+   * track container with index c
+   * @param[in] min Minimum of the allowed track \f$ \phi \f$ range
+   * @param[in] max Maximum of the allowed track \f$ \phi \f$ range
+   * @param[in] c Index of the particle container affected by the cut
+   */
   void                        SetTrackPhiLimits(Double_t min, Double_t max, Int_t c=0);
+
+  /**
+   * @brief Apply cut on the transverse momentum \f$ p_{t} \f$ of all tracks in
+   * the track container with index c.
+   * @param[in] cut \f$ p_{t} \f$-cut to be applied
+   * @param[in] c Index of the particle container affected by the cut
+   */
   void                        SetTrackPtCut(Double_t cut, Int_t c=0);
+
   void                        SetTrigClass(const char *n)                           { fTrigClass         = n                              ; }
   void                        SetMinBiasTriggerClassName(const char *n)             { fMinBiasRefTrigger = n                              ; }
   void                        SetTriggerTypeSel(TriggerType t)                      { fTriggerTypeSel    = t                              ; } 
@@ -213,25 +331,156 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   Float_t                     TrackPtFactor()                                       { return fPtHardAndTrackPtFactor                      ; }
 
   // Static Utilities
+  /**
+   * @brief Add an AOD handler to the analysis manager
+   * @return pointer to the new AOD handler
+   */
   static AliAODInputHandler*  AddAODHandler();
+
+  /**
+   * @brief Add a ESD handler to the analysis manager
+   * @return pointer to the new ESD handler
+   */
   static AliESDInputHandler*  AddESDHandler();
 
  protected:
+  /**
+   * @brief Load parton info
+   * @param event
+   */
   void                        LoadPythiaInfo(AliVEvent *event);
+
   void                        SetRejectionReasonLabels(TAxis* axis);
+
+  /**
+   * @brief Cluster selection
+   *
+   * Check whether cluster is accepted under the cluster
+   * selection specified in the cluster container stored
+   * under index c
+   * @param[in] clus EMCAL cluster to be accepted
+   * @param[in] c Index of the cluster container
+   * @return true if cluster is accepted
+   * @deprecated Use GetClusterContainer(c)->AcceptCluster(clust) instead
+   */
   Bool_t                      AcceptCluster(AliVCluster *clus, Int_t c = 0)      const;
+
+  /**
+   * Check whether track is accepted under the track
+   * selection specified in the track container stored
+   * under index c
+   * @param[in] track Track to be checked
+   * @param[in] c Index of the track container
+   * @return true if track is accepted
+   * @deprecated Use GetParticleContainer(c)->AcceptParticle(track) instead
+   */
   Bool_t                      AcceptTrack(AliVParticle *track, Int_t c = 0)      const;
+
+  /**
+   * @brief Add object to event
+   * @param[in] obj Object to be added
+   * @param[in] attempt If true don't handle error
+   */
   void                        AddObjectToEvent(TObject *obj, Bool_t attempt = kFALSE);
+
+  /**
+   * @brief Get particle p if accepted from  container with index c
+   * If particle not accepted return 0
+   * @param[in] p Index of the particle inside the Particle container
+   * @param[in] c Index of the particle container
+   * @return Accepted particle (NULL if no accepted particle with the index is found inside the container)
+   */
   AliVParticle               *GetAcceptParticleFromArray(Int_t p, Int_t c=0)     const;
+
+  /**
+   * @brief Get cluster cl if accepted from  container c
+   * If particle not accepted return 0
+   * @param[in] cl Index of the cluster inside the container
+   * @param[in] c Indexd of the cluster container
+   * @return Accepted cluster (NULL if no accepted cluster with index is found)
+   */
   AliVCluster                *GetAcceptClusterFromArray(Int_t cl, Int_t c=0)     const;
+
+
+  /**
+   * @brief Read a TClonesArray from event.
+   *
+   * Attention: Both the name of the array and the name of the object
+   * stored inside must match.
+   * @param[in] name Name of the array to be read in
+   * @param[in] clname Name of the type of the objects stored in the array
+   * @return Pointer to the TClonesArray (NULL if not found)
+   */
   TClonesArray               *GetArrayFromEvent(const char *name, const char *clname=0);
+
+  /**
+   * @brief Get beam type
+   *
+   * Possible beam types defined in @ref BeamType
+   * ESDs have it directly, AODs get it from hardcoded run number ranges
+   * @return Beam type of the run.
+   */
   BeamType                    GetBeamType()                                      const;
+
+  /**
+   * @brief Get \f$ i^{th} \f$ TClonesArray with particles
+   * @param[in] i Index of the particle container inside the task
+   * @return TClonesArray connected to the container (NULL if not found)
+   */
   TClonesArray               *GetParticleArray(Int_t i=0)                        const;
+
+  /**
+   * @brief Get \f$ i^{th} \f$ TClonesArray with EMCAL clusters
+   * @param[in] i Index of the cluster container inside the task
+   * @return TClonesArray connected to the container (NULL if not found)
+   */
   TClonesArray               *GetClusterArray(Int_t i=0)                         const;
+
+  /**
+   * @brief Get number of particles in container attached to this task with index i
+   * @param[in] i Index of then particle container
+   * @return Number of particles in container
+   */
   Int_t                       GetNParticles(Int_t i=0)                           const;
+
+  /**
+   * @brief Get number of clusters in the cluster container attached to this task with
+   * index i
+   * @param[in] i Index of the container
+   * @return Number of clusters inside the container
+   */
   Int_t                       GetNClusters(Int_t i=0)                            const;
+
+  /**
+   * @brief Get main trigger match
+   *
+   * For the selection of the main trigger patch, high and low threshold triggers of a given category are grouped
+   * If there are more than 1 main patch of a given trigger category (i.e. different high and low threshold patches),
+   * the highest one according to the ADC value is taken. In case doSimpleOffline is true, then only the patches from
+   * the simple offline trigger are used.
+   * @param[in] trigger Type of the EMCAL Level0/Level1 trigger
+   * @param[in] doSimpleOffline If true simple offline patches are used
+   * @return Main trigger patch for the trigger category (defined as highest energy patch)
+   */
   AliEMCALTriggerPatchInfo   *GetMainTriggerPatch(TriggerCategory triggersel = kTriggerLevel1Jet, Bool_t doOfflinSimple = kFALSE);
+
+  /**
+   * @brief Check if event has a given trigger type
+   *
+   * Trigger types defined in @ref
+   * @param trigger Trigger type to check
+   * @return True fo the trigger type is found in the event,
+   * false otherwise.
+   */
   Bool_t		                  HasTriggerType(TriggerType triggersel);
+
+  /**
+   * @brief Get list of selected triggers of the given event.
+   *
+   * The trigger selection is performed using EMCAL
+   * patches found for the given event
+   * @return A bitmap encoding the trigger found for the event
+   */
   ULong_t 		                GetTriggerList();
 
   /**
@@ -248,13 +497,70 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
    * @return True if parameters were obtained successfully, false otherwise
    */
   Bool_t                      PythiaInfoFromFile(const char* currFile, Float_t &fXsec, Float_t &fTrials, Int_t &pthard);
-
+  /**
+   * @brief Determines if a track is inside the EMCal acceptance.
+   *
+   * Selection is done using \f$\eta\f$/\f$\phi\f$ at the vertex (no propagation).
+   * Includes +/- edges. Useful to determine whether track propagation should be attempted.
+   * @param[in] part Particle to check
+   * @param[in] edges Size of the edges in \f$\phi\f$ excluded from the EMCAL acceptance
+   * @return True if a particle is inside the EMCAL acceptance, false otherwise
+   */
   Bool_t                      IsTrackInEmcalAcceptance(AliVParticle* part, Double_t edges=0.9) const;
 
+  /**
+   * @brief Copy some information about the Pythia event in a PythaInfo object
+   * @param[in] mcEvent Monte Carlo event from which the information is obtained
+   */
   void                        GeneratePythiaInfoObject(AliMCEvent* mcEvent);
+
+  /**
+   * @brief Filter the mc tails in pt-hard distributions
+   *
+   * See https://twiki.cern.ch/twiki/bin/view/ALICE/JetMCProductionsCrossSections#How_to_reject_tails_in_the_pT_ha
+   * @return kTRUE if it is not a MC outlier
+   */
   Bool_t                      CheckMCOutliers();
 
-  // Overloaded AliAnalysisTaskSE methods
+  /**
+   * @brief Main initialization function on the worker
+   *
+   * Performing run-independent initialization. This consists of
+   * - Determining data type (ESD/AOD)
+   * - Creating general QA histograms
+   *
+   * Attention: Histograms are only created in case the task is
+   * configured for this (second argument in the named constructor).
+   * In this case the container fOuput is created which can be used
+   * by the users to handle and store their histograms. In this case
+   * the users must overwrite this function in their tasks and call
+   * this function right at the beginning of their function.
+   *
+   * The general QA histograms monitor event related observables like
+   * the z-position of the primary vertex before and after event selection,
+   * the trigger classes selecting the event and the event rejection
+   * reason, but also Monte-Carlo related observables like the cross
+   * section, the number of trials and the \f$ p_{t} \f$-hard bin in
+   * case of a corresponding production.
+   *
+   * Important for user tasks: User tasks need to implement the function
+   * UserCreateOutputObjects themselves. In case the output objects uses
+   * the common output container fOutput, the function UserCreateOutputOjects
+   * from AliAnalysisTaskEmcal needs to be called at the beginning. A
+   * typical function in the user task could look like this:
+   *
+   * ~~~{.cxx}
+   * void AliAnalysisTaskInheritingFromEmcal::UserCreateOutputObjects() {
+   *   // Call UserCreateOutputObjects from AliAnalysisTaskEmcal in
+   *   // order to initialize the common output container and the
+   *   // general histograms
+   *   AliAnalysisTaskEmcal::UserCreateOutputObjects();
+   *
+   *   fTestHisto = new TH1F("fTestHisto", "Test Histogram", 100, 0., 100);
+   *   fOutput->Add(fTestHisto);
+   * }
+   * ~~~
+   */
   void                        UserCreateOutputObjects();
 
   /**
@@ -319,7 +625,6 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
    */
   Bool_t					            FileChanged();
 
-  // Virtual functions, to be overloaded in derived classes
   /**
    * @brief Perform steps needed to initialize the analysis.
    *
@@ -333,11 +638,81 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
    */
   virtual void                ExecOnce();
 
+  /**
+   * @brief Filling general histograms.
+   *
+   * Among the general histograms that are filled only in case of
+   * running over MC productions are
+   * - \f$ p_{t} \f$-hard bin
+   * - Cross section after event selection
+   * - Number of trials after event selection
+   * - Number of events after event selection
+   * In any case the vertex distribution is filled as general
+   * histograms. For heavy ion collisions also the centrality
+   * distribution and the event plane distribution are filled.
+   * @return Always true
+   */
   virtual Bool_t              FillGeneralHistograms();
+
+  /**
+   * @brief Performing event selection.
+   *
+   * This contains
+   * - Selection of the trigger class
+   * - Selection according to the centrality class
+   * - Selection of event with good vertex quality
+   * - Selection of the event plane orientation
+   * - Selection of the multiplicity (including
+   *   above minimum \f$ p_{t} \f$ and tracks in the
+   *   EMCAL acceptance
+   *
+   * Note that for the vertex selection both the usage
+   * of the analysis util and the range of the z-position
+   * of the primary vertex need to be specified.
+   *
+   * In case the event is rejected, a histogram
+   * monitoring the rejection reason is filled with
+   * the bin corresponding to the source of the rejection
+   * of the current event.
+   *
+   * The Run function is only called in case the event
+   * is selected by this function, providing a default
+   * event selection. In case the user wants to apply
+   * a different event selection, the function should
+   * be implemented by the user.
+   *
+   * @return True if the event is selected.
+   */
   virtual Bool_t              IsEventSelected();
+
+  /**
+   * @brief Retrieve common objects from event.
+   *
+   * Several object used for the analysis are handled by the
+   * AliAnalysisTaskEmcal, and provided as member variables to
+   * the task itself and to derived task. Among them are
+   * event global objects
+   * - beam type
+   * - EMCAL cells
+   * - centrality percentile
+   * - event plane angle
+   * - triggers
+   * - vertex position (both from global tracks and from SPD tracklets)
+   *
+   * as well as the arrays for
+   * - EMCAL clusters
+   * - particles
+   *
+   * In case of MC simulation the MC headers are loaded as well and in
+   * case the task is flagged to run over a pythia or herwig production
+   *
+   * @return Always true
+   */
   virtual Bool_t              RetrieveEventObjects();
 
   /**
+   * @brief Process tasks relevant when a file with a different run number is processed
+   *
    * Method exclusively called when the run is changed (new run number differing
    * from old run number). Can be used for run-dependent initializations (i.e.
    * setting parameters from the OADB)
@@ -345,6 +720,8 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   virtual void                RunChanged(Int_t /*newrun*/)          {}
 
   /**
+   * @brief Task initializations handled in user tasks
+   *
    * Interface for user code executed when the first event is called.
    * At this step we know run number and data type and can therefore
    * do proper initializations.
@@ -356,9 +733,11 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
    *
    * The event is expected to be fully configured at that stage
    */
-  virtual void				  UserFileChanged()					{}
+  virtual void				        UserFileChanged()					{}
 
   /**
+   * @brief Function filling histograms
+   *
    * This function optionally fills histograms created by the users. Can
    * access data previously handled by the user Run function.
    * @return
@@ -366,7 +745,7 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   virtual Bool_t              FillHistograms()                  { return kTRUE                 ; }
 
   /**
-   * Run function. This is the core function of the analysis and
+   * @brief Run function. This is the core function of the analysis and
    * contains the user code. Therefore users have to implement this
    * function.
    *
@@ -375,13 +754,55 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   virtual Bool_t              Run()                             { return kTRUE                 ; }
     
   // Static utilities
+  /**
+   * @brief Calculate \f$\phi\f$ and \f$\eta\f$ difference between a track (t) and a cluster (c).
+   *
+   * The position of the track is obtained on the EMCAL surface
+   * @param[in] t Track to check
+   * @param[in] v Cluster to check
+   * @param[out] phidiff Distance in \f$\phi\f$ between cluster and track
+   * @param[out] etadiff Distance in \f$\eta\f$ between cluster and track
+   */
   static void                 GetEtaPhiDiff(const AliVTrack *t, const AliVCluster *v, Double_t &phidiff, Double_t &etadiff);
+
+  /**
+   * @brief Get track type encoded from bits 20 and 21.
+   * @param[in] t Track to check
+   * @return
+   */
   static Byte_t               GetTrackType(const AliVTrack *t);
+
+  /**
+   * @brief Decode track type
+   *
+   * Return track type: 0 = filterBit1, 1 = filterBit2 && ITS, 2 = filterBit2 && !ITS.
+   * Returns 3 if filterBit1 and filterBit2 do not test.
+   * WARNING: only works with AOD tracks and AOD filter bits must be provided. Otherwise will always return 0.
+   * @param[in] aodTrack Track to check
+   * @param filterBit1 First filter bit
+   * @param filterBit2 Second filter bit
+   * @return See explanation
+   */
   static Byte_t               GetTrackType(const AliAODTrack *aodTrack, UInt_t filterBit1, UInt_t filterBit2);
+
   static Double_t             DeltaPhi(Double_t phia, Double_t phib, Double_t rMin = -TMath::Pi()/2, Double_t rMax = 3*TMath::Pi()/2);
   static Double_t*            GenerateFixedBinArray(Int_t n, Double_t min, Double_t max);
   static void                 GenerateFixedBinArray(Int_t n, Double_t min, Double_t max, Double_t* array);
+
+  /**
+   * @brief Calculates the fraction of momentum z of part 1 w.r.t. part 2 in the direction of part 2.
+   * @param[in] part1 Momentum vector for which the relative fraction is calculated
+   * @param[in] part2 Reference momentum vector for the calculation
+   * @return Relative fraction of momentum of particle 1 with respect to particle 2
+   */
   static Double_t             GetParallelFraction(AliVParticle* part1, AliVParticle* part2);
+
+  /**
+   * @brief Calculates the fraction of momentum z of vect 1 w.r.t. part 2 in the direction of part 2.
+   * @param[in] vect1 Momentum vector for which the relative fraction is calculated
+   * @param[in] part2 Reference momentum vector for the calculation
+   * @return Relative fraction of momentum of particle 1 with respect to particle 2
+   */
   static Double_t             GetParallelFraction(const TVector3& vect1, AliVParticle* part2);
 
   static Double_t             fgkEMCalDCalPhiDivide;       ///<  phi value used to distinguish between DCal and EMCal
@@ -391,7 +812,7 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   BeamType                    fForceBeamType;              ///< forced beam type
   Bool_t                      fGeneralHistograms;          ///< whether or not it should fill some general histograms
   Bool_t                      fLocalInitialized;           ///< whether or not the task has been already initialized
-  Bool_t					  fFileChanged;				   //!<! Signal triggered when the file has changed
+  Bool_t					            fFileChanged;				   //!<! Signal triggered when the file has changed
   Bool_t                      fCreateHisto;                ///< whether or not create histograms
   TString                     fCaloCellsName;              ///< name of calo cell collection
   TString                     fCaloTriggersName;           ///< name of calo triggers collection


### PR DESCRIPTION
- Consistently move documentation to the HEADER file
- Add brief descriptor for functions as well
- Replace manual description of enum types as function arguments by ref
- Mark deprecated functions as deprecated
- Improve and exdend description of some of the core framework functions