### PR TITLE
Added branches to store FMD and V0 info for OOB pileup studies

### DIFF
--- a/PWGLF/STRANGENESS/CMakeLists.txt
+++ b/PWGLF/STRANGENESS/CMakeLists.txt
@@ -27,6 +27,7 @@ include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/OADB
                     ${AliPhysics_SOURCE_DIR}/OADB/COMMON/MULTIPLICITY
                     ${AliPhysics_SOURCE_DIR}/PWGCF/Correlations/Base
+		    ${AliPhysics_SOURCE_DIR}/PWGLF/FORWARD/analysis2
                     ${AliPhysics_SOURCE_DIR}/PWGLF/STRANGENESS/Cascades/lightvertexers
                     ${AliPhysics_SOURCE_DIR}/PWGLF/STRANGENESS/Cascades/Run2
                     ${AliPhysics_SOURCE_DIR}/PWGUD/base

--- a/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrangenessVsMultiplicityMCRun2.h
+++ b/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrangenessVsMultiplicityMCRun2.h
@@ -38,6 +38,7 @@ class AliESDtrackCuts;
 class AliAnalysisUtils;
 class AliESDEvent;
 class AliPhysicsSelection;
+class AliESDFMD;
 class AliCFContainer;
 class AliV0Result; 
 class AliCascadeResult;
@@ -201,6 +202,25 @@ public:
     Float_t GetCosPA(AliESDtrack *lPosTrack, AliESDtrack *lNegTrack, AliESDEvent *lEvent);
     //---------------------------------------------------------------------------------------
 
+//---------------------------------------------------------------------------------------
+    // A simple struct to handle FMD hits information
+    // Nothe: this struct is based on what is implemented in AliAnalysisTaskValidation
+    //        defined as 'Track' (thanks to C. Bourjau). It was slightly changed here and
+    //        renamed to 'FMDhit' in order to avoid any confusion.
+    struct FMDhit {     
+        Float_t eta;     
+        Float_t phi;     
+        Float_t weight;     
+        //Constructor     
+        FMDhit(Float_t _eta, Float_t _phi, Float_t _weight)       
+            :eta(_eta), phi(_phi), weight(_weight) {};   
+    };   
+    typedef std::vector<AliAnalysisTaskStrangenessVsMultiplicityMCRun2::FMDhit> FMDhits;
+//---------------------------------------------------------------------------------------
+   AliAnalysisTaskStrangenessVsMultiplicityMCRun2::FMDhits GetFMDhits(AliAODEvent* aodEvent) const;
+//---------------------------------------------------------------------------------------
+
+
 private:
     // Note : In ROOT, "//!" means "do not stream the data from Master node to Worker node" ...
     // your data member object is created on the worker nodes and streaming is not needed.
@@ -273,6 +293,15 @@ private:
     Int_t  fNTracksGlobal2015; //!
     Int_t  fNTracksGlobal2015TriggerPP; //!
 
+    //V0 info for OOB pileup study
+    Float_t fAmplitudeV0A; //!
+    Float_t fAmplitudeV0C; //!
+
+    //FMD info for OOB pileup study
+    Float_t fNHitsFMDA; //!
+    Float_t fNHitsFMDC; //!
+
+
 
 //===========================================================================================
 //   Variables for V0 Tree
@@ -331,6 +360,10 @@ private:
     //Int_t  fTreeVariableNTracksITSsa2010; //!
     //Int_t  fTreeVariableNTracksGlobal2015; //!
     //Int_t  fTreeVariableNTracksGlobal2015TriggerPP; //!
+    Float_t fTreeVariableAmplitudeV0A; //!
+    Float_t fTreeVariableAmplitudeV0C; //!
+    Float_t fTreeVariableNHitsFMDA; //!
+    Float_t fTreeVariableNHitsFMDC; //!
 
     //Event Multiplicity Variables
     Float_t fTreeVariableCentrality; //!

--- a/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrangenessVsMultiplicityRun2.cxx
+++ b/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrangenessVsMultiplicityRun2.cxx
@@ -62,6 +62,8 @@ class AliAODVertex;
 class AliESDv0;
 class AliAODv0;
 
+#include <numeric>
+
 #include <Riostream.h>
 #include "TList.h"
 #include "TH1.h"
@@ -99,6 +101,8 @@ class AliAODv0;
 #include "AliMultInput.h"
 #include "AliMultSelection.h"
 
+#include "AliAODForwardMult.h"
+#include "AliForwardUtil.h"
 #include "AliCFContainer.h"
 #include "AliMultiplicity.h"
 #include "AliAODMCParticle.h"
@@ -161,6 +165,10 @@ fNTOFMatches(-1),
 fNTracksITSsa2010(-1),
 fNTracksGlobal2015(-1),
 fNTracksGlobal2015TriggerPP(-1),
+fAmplitudeV0A(-1.),
+fAmplitudeV0C(-1.),
+fNHitsFMDA(-1.),
+fNHitsFMDC(-1.),
 
 //---> Variables for fTreeV0
 fTreeVariableChi2V0(0),
@@ -210,6 +218,10 @@ fTreeVariablePosTOFExpTDiff(99999),
 //fTreeVariableNTracksITSsa2010(-1),
 //fTreeVariableNTracksGlobal2015(-1),
 //fTreeVariableNTracksGlobal2015TriggerPP(-1),
+fTreeVariableAmplitudeV0A(-1.),
+fTreeVariableAmplitudeV0C(-1.),
+fTreeVariableNHitsFMDA(-1.),
+fTreeVariableNHitsFMDC(-1.),
 
 fTreeVariableCentrality(0),
 fTreeVariableMVPileupFlag(kFALSE),
@@ -346,6 +358,10 @@ fNTOFMatches(-1),
 fNTracksITSsa2010(-1),
 fNTracksGlobal2015(-1),
 fNTracksGlobal2015TriggerPP(-1),
+fAmplitudeV0A(-1.),
+fAmplitudeV0C(-1.),
+fNHitsFMDA(-1.),
+fNHitsFMDC(-1.),
 
 //---> Variables for fTreeV0
 fTreeVariableChi2V0(0),
@@ -395,6 +411,10 @@ fTreeVariablePosTOFExpTDiff(99999),
 //fTreeVariableNTracksITSsa2010(-1),
 //fTreeVariableNTracksGlobal2015(-1),
 //fTreeVariableNTracksGlobal2015TriggerPP(-1),
+fTreeVariableAmplitudeV0A(-1.),
+fTreeVariableAmplitudeV0C(-1.),
+fTreeVariableNHitsFMDA(-1.),
+fTreeVariableNHitsFMDC(-1.),
 
 fTreeVariableCentrality(0),
 fTreeVariableMVPileupFlag(kFALSE),
@@ -602,6 +622,10 @@ void AliAnalysisTaskStrangenessVsMultiplicityRun2::UserCreateOutputObjects()
             fTreeEvent->Branch("fNTracksITSsa2010",&fNTracksITSsa2010,"fNTracksITSsa2010/I");
             fTreeEvent->Branch("fNTracksGlobal2015",&fNTracksGlobal2015,"fNTracksGlobal2015/I");
             fTreeEvent->Branch("fNTracksGlobal2015TriggerPP",&fNTracksGlobal2015TriggerPP,"fNTracksGlobal2015TriggerPP/I");
+            fTreeEvent->Branch("fAmplitudeV0A",&fAmplitudeV0A,"fAmplitudeV0A/F");
+            fTreeEvent->Branch("fAmplitudeV0C",&fAmplitudeV0C,"fAmplitudeV0C/F");
+            fTreeEvent->Branch("fNHitsFMDA",&fNHitsFMDA,"fNHitsFMDA/F");
+            fTreeEvent->Branch("fNHitsFMDC",&fNHitsFMDC,"fNHitsFMDC/F");
         }
     }
 
@@ -662,6 +686,10 @@ void AliAnalysisTaskStrangenessVsMultiplicityRun2::UserCreateOutputObjects()
             //fTreeV0->Branch("fTreeVariableNTracksITSsa2010",&fTreeVariableNTracksITSsa2010,"fTreeVariableNTracksITSsa2010/I");
             //fTreeV0->Branch("fTreeVariableNTracksGlobal2015",&fTreeVariableNTracksGlobal2015,"fTreeVariableNTracksGlobal2015/I");
             //fTreeV0->Branch("fTreeVariableNTracksGlobal2015TriggerPP",&fTreeVariableNTracksGlobal2015TriggerPP,"fTreeVariableNTracksGlobal2015TriggerPP/I");
+            fTreeV0->Branch("fTreeVariableAmplitudeV0A",&fTreeVariableAmplitudeV0A,"fTreeVariableAmplitudeV0A/F");
+            fTreeV0->Branch("fTreeVariableAmplitudeV0C",&fTreeVariableAmplitudeV0C,"fTreeVariableAmplitudeV0C/F");
+            fTreeV0->Branch("fTreeVariableNHitsFMDA",&fTreeVariableNHitsFMDA,"fTreeVariableNHitsFMDA/F");
+            fTreeV0->Branch("fTreeVariableNHitsFMDC",&fTreeVariableNHitsFMDC,"fTreeVariableNHitsFMDC/F");
         }
         //------------------------------------------------
     }
@@ -975,6 +1003,24 @@ void AliAnalysisTaskStrangenessVsMultiplicityRun2::UserExec(Option_t *)
             //Warning: 12.5 is appropriate for pp (for Pb-Pb use 30)
             if( TMath::Abs( track->GetTOFExpTDiff() ) < 12.5 ) fNTracksGlobal2015TriggerPP++;
         }
+
+        //VZERO info
+        fAmplitudeV0A = ((AliMultEstimator*)MultSelection->GetEstimator("V0A"))->GetValue();
+        fAmplitudeV0C = ((AliMultEstimator*)MultSelection->GetEstimator("V0C"))->GetValue();
+
+        //FMD info
+        AliAODEvent* aodEvent = AliForwardUtil::GetAODEvent(this);
+        if (!aodEvent) return;
+        FMDhits fmdhits = GetFMDhits(aodEvent);
+        fNHitsFMDA = std::accumulate(fmdhits.begin(), fmdhits.end(), 0, 
+                [](Float_t a, AliAnalysisTaskStrangenessVsMultiplicityRun2::FMDhit t) {
+                return a + ((2.8 < t.eta && t.eta < 5.03) ? t.weight : 0.0f);
+                });
+        fNHitsFMDC = std::accumulate(fmdhits.begin(), fmdhits.end(), 0,
+                [](Float_t a, AliAnalysisTaskStrangenessVsMultiplicityRun2::FMDhit t) {
+                return a + ((-3.4 < t.eta && t.eta < 2.01) ? t.weight : 0.0f);
+                });
+
     }
 
     //Fill centrality histogram
@@ -1256,6 +1302,12 @@ void AliAnalysisTaskStrangenessVsMultiplicityRun2::UserExec(Option_t *)
             //fTreeVariableNTracksITSsa2010           = fNTracksITSsa2010;
             //fTreeVariableNTracksGlobal2015          = fNTracksGlobal2015;
             //fTreeVariableNTracksGlobal2015TriggerPP = fNTracksGlobal2015TriggerPP;
+            //Copy VZERO information for this event
+            fTreeVariableAmplitudeV0A = fAmplitudeV0A;
+            fTreeVariableAmplitudeV0C = fAmplitudeV0C;
+            //Copy FMD information for this event
+            fTreeVariableNHitsFMDA = fNHitsFMDA;
+            fTreeVariableNHitsFMDC = fNHitsFMDC;
         }
 
 
@@ -3605,4 +3657,33 @@ void AliAnalysisTaskStrangenessVsMultiplicityRun2::CheckChargeV0(AliESDv0 *v0)
         //Printf("Ah, nice. Charges are already ordered...");
     }
     return;
+}
+
+//______________________________________________________________________
+AliAnalysisTaskStrangenessVsMultiplicityRun2::FMDhits AliAnalysisTaskStrangenessVsMultiplicityRun2::GetFMDhits(AliAODEvent* aodEvent) const  
+// Relies on the event being vaild (no extra checks if object exists done here)   
+{
+    AliAODForwardMult* aodForward = static_cast<AliAODForwardMult*>(aodEvent->FindListObject("Forward"));   
+    // Shape of d2Ndetadphi: 200, -4, 6, 20, 0, 2pi   
+    const TH2D& d2Ndetadphi = aodForward->GetHistogram();   
+    Int_t nEta = d2Ndetadphi.GetXaxis()->GetNbins();   
+    Int_t nPhi = d2Ndetadphi.GetYaxis()->GetNbins();   
+    FMDhits ret_vector;   
+    for (Int_t iEta = 1; iEta <= nEta; iEta++) {     
+        Int_t valid = Int_t(d2Ndetadphi.GetBinContent(iEta, 0));     
+        if (!valid) {        
+            // No data expected for this eta       
+            continue;     
+        }     
+        Float_t eta = d2Ndetadphi.GetXaxis()->GetBinCenter(iEta);     
+        for (Int_t iPhi = 1; iPhi <= nPhi; iPhi++) {       
+            // Bin content is most likely number of particles!       
+            Float_t mostProbableN = d2Ndetadphi.GetBinContent(iEta, iPhi);       
+            if (mostProbableN > 0) { 	
+                Float_t phi = d2Ndetadphi.GetYaxis()->GetBinCenter(iPhi); 	
+                ret_vector.push_back(AliAnalysisTaskStrangenessVsMultiplicityRun2::FMDhit(eta, phi, mostProbableN));       
+            }     
+        }   
+    }   
+    return ret_vector; 
 }

--- a/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrangenessVsMultiplicityRun2.h
+++ b/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrangenessVsMultiplicityRun2.h
@@ -38,6 +38,7 @@ class AliESDtrackCuts;
 class AliAnalysisUtils;
 class AliESDEvent;
 class AliPhysicsSelection;
+class AliESDFMD;
 class AliCFContainer;
 class AliV0Result;
 class AliCascadeResult;
@@ -198,6 +199,24 @@ public:
     Float_t GetCosPA(AliESDtrack *lPosTrack, AliESDtrack *lNegTrack, AliESDEvent *lEvent);
 //---------------------------------------------------------------------------------------
 
+//---------------------------------------------------------------------------------------
+    // A simple struct to handle FMD hits information
+    // Nothe: this struct is based on what is implemented in AliAnalysisTaskValidation
+    //        defined as 'Track' (thanks to C. Bourjau). It was slightly changed here and
+    //        renamed to 'FMDhit' in order to avoid any confusion.
+    struct FMDhit {     
+        Float_t eta;     
+        Float_t phi;     
+        Float_t weight;     
+        //Constructor     
+        FMDhit(Float_t _eta, Float_t _phi, Float_t _weight)       
+            :eta(_eta), phi(_phi), weight(_weight) {};   
+    };   
+    typedef std::vector<AliAnalysisTaskStrangenessVsMultiplicityRun2::FMDhit> FMDhits;
+//---------------------------------------------------------------------------------------
+   AliAnalysisTaskStrangenessVsMultiplicityRun2::FMDhits GetFMDhits(AliAODEvent* aodEvent) const;
+//---------------------------------------------------------------------------------------
+
 
 private:
     // Note : In ROOT, "//!" means "do not stream the data from Master node to Worker node" ...
@@ -270,6 +289,15 @@ private:
     Int_t  fNTracksGlobal2015; //!
     Int_t  fNTracksGlobal2015TriggerPP; //!
 
+    //V0 info for OOB pileup study
+    Float_t fAmplitudeV0A; //!
+    Float_t fAmplitudeV0C; //!
+
+    //FMD info for OOB pileup study
+    Float_t fNHitsFMDA; //!
+    Float_t fNHitsFMDC; //!
+
+
 
 //===========================================================================================
 //   Variables for V0 Tree
@@ -327,6 +355,10 @@ private:
     //Int_t  fTreeVariableNTracksITSsa2010; //!
     //Int_t  fTreeVariableNTracksGlobal2015; //!
     //Int_t  fTreeVariableNTracksGlobal2015TriggerPP; //!
+    Float_t fTreeVariableAmplitudeV0A; //!
+    Float_t fTreeVariableAmplitudeV0C; //!
+    Float_t fTreeVariableNHitsFMDA; //!
+    Float_t fTreeVariableNHitsFMDC; //!
 
     //Event Multiplicity Variables
     Float_t fTreeVariableCentrality; //!


### PR DESCRIPTION
New branches added to store V0A and V0C amplitudes and FMD hits in the overlap regions with V0.