### PR TITLE
PWG/Cocktail and PWGGA/GammaConv: updates for EM cocktail generation

### DIFF
--- a/PWG/Cocktail/AliGenEMCocktailV2.cxx
+++ b/PWG/Cocktail/AliGenEMCocktailV2.cxx
@@ -188,6 +188,9 @@ void AliGenEMCocktailV2::CreateCocktail()
   AliGenEMlibV2::SetPtParametrizations(fParametrizationFile, fParametrizationDir);
   SetPtParametrizations();
 
+  if (fDynPtRange)
+    AliInfo("Dynamical adaption of pT range was chosen, the number of generated particles will also be adapted");
+
   if (fUseYWeighting) {
     AliInfo("Rapidity weighting will be used");
     AliGenEMlibV2::SetPtYDistributions(fParametrizationFile, fParametrizationDir);

--- a/PWG/Cocktail/AliGenEMCocktailV2.cxx
+++ b/PWG/Cocktail/AliGenEMCocktailV2.cxx
@@ -68,6 +68,7 @@ AliGenEMCocktailV2::AliGenEMCocktailV2():AliGenCocktail(),
   fCollisionSystem(AliGenEMlibV2::kpp7TeV),
   fCentrality(AliGenEMlibV2::kpp),
   fV2Systematic(AliGenEMlibV2::kNoV2Sys),
+  fUseYWeighting(kFALSE),
   fDynPtRange(kFALSE),
   fForceConv(kFALSE),
   fSelectedParticles(kGenHadrons)
@@ -79,6 +80,7 @@ AliGenEMCocktailV2::AliGenEMCocktailV2():AliGenCocktail(),
 TF1*  AliGenEMCocktailV2::fPtParametrization[]    = {0x0};
 TF1*  AliGenEMCocktailV2::fParametrizationProton  = NULL;
 TH1D* AliGenEMCocktailV2::fMtScalingFactorHisto   = NULL;
+TH2F* AliGenEMCocktailV2::fPtYDistribution[]      = {0x0};
 
 //_________________________________________________________________________
 AliGenEMCocktailV2::~AliGenEMCocktailV2()
@@ -113,6 +115,15 @@ TH1D* AliGenEMCocktailV2::GetMtScalingFactors() {
 }
 
 //_________________________________________________________________________
+TH2F* AliGenEMCocktailV2::GetPtYDistribution(Int_t np) {
+
+  if (np<18)
+    return fPtYDistribution[np];
+  else
+    return NULL;
+}
+
+//_________________________________________________________________________
 void AliGenEMCocktailV2::GetPtRange(Double_t &ptMin, Double_t &ptMax) {
   ptMin = fPtMin;
   ptMax = fPtMax;
@@ -128,6 +139,28 @@ Double_t AliGenEMCocktailV2::GetMaxPtStretchFactor(Int_t pdgCode) {
   if (factor*fPtMax > 200) factor = 200./fPtMax; // so far the input pt parametrizations are defined up to pt = 200 GeV/c
 
   return factor;
+}
+
+//-------------------------------------------------------------------
+Double_t AliGenEMCocktailV2::GetYWeight(Int_t np, TParticle* part) {
+
+  if (!fUseYWeighting) return 1.;
+
+  Double_t weight = 0.;
+  if (fPtYDistribution[np]) {
+    if (part->Pt() > fPtYDistribution[np]->GetXaxis()->GetXmin() && part->Pt() < fPtYDistribution[np]->GetXaxis()->GetXmin()) {
+      if (part->Y() > fPtYDistribution[np]->GetYaxis()->GetXmin() && part->Y() < fPtYDistribution[np]->GetYaxis()->GetXmin()) {
+        weight = fPtYDistribution[np]->GetBinContent(fPtYDistribution[np]->GetXaxis()->FindBin(part->Pt()), fPtYDistribution[np]->GetYaxis()->FindBin(part->Y()));
+        if (weight)
+          return weight;
+        else
+          return 1.;
+      } else
+        return 1.;
+    } else
+      return 1.;
+  } else
+    return 1.;
 }
 
 //_________________________________________________________________________
@@ -154,6 +187,12 @@ void AliGenEMCocktailV2::CreateCocktail()
   SetMtScalingFactors();
   AliGenEMlibV2::SetPtParametrizations(fParametrizationFile, fParametrizationDir);
   SetPtParametrizations();
+
+  if (fUseYWeighting) {
+    AliInfo("Rapidity weighting will be used");
+    AliGenEMlibV2::SetPtYDistributions(fParametrizationFile, fParametrizationDir);
+    SetPtYDistributions();
+  }
 
   // Create and add electron sources to the generator
   // pizero
@@ -629,6 +668,21 @@ void AliGenEMCocktailV2::SetMtScalingFactors() {
 }
 
 //_________________________________________________________________________
+Bool_t AliGenEMCocktailV2::SetPtYDistributions() {
+
+  TH2F* tempPtY = NULL;
+  for(Int_t i=0; i<18; i++) {
+    tempPtY = AliGenEMlibV2::GetPtYDistribution(i);
+    if (tempPtY)
+      fPtYDistribution[i] = new TH2F(*tempPtY);
+    else
+      fPtYDistribution[i] = NULL;
+  }
+
+  return kTRUE;
+}
+
+//_________________________________________________________________________
 void AliGenEMCocktailV2::Generate()
 {
   // Generate event
@@ -676,6 +730,7 @@ void AliGenEMCocktailV2::Generate()
   Int_t pdgGrandMother = 0;
   Double_t weight = 0.;
   Double_t dNdy = 0.;
+  Double_t yWeight = 0.;
   Int_t maxPart = partArray->GetEntriesFast();
   for(iPart=0; iPart<maxPart; iPart++){
     TParticle *part = gAlice->GetMCApp()->Particle(iPart);
@@ -706,75 +761,98 @@ void AliGenEMCocktailV2::Generate()
     switch (pdgMother){
       case 111:
         dNdy = fYieldArray[kPizero];
+        yWeight = GetYWeight(kPizero, part);
         break;
       case 221:
         dNdy = fYieldArray[kEta];
+        yWeight = GetYWeight(kEta, part);
         break;
       case 113:
         dNdy = fYieldArray[kRho0];
+        yWeight = GetYWeight(kRho0, part);
         break;
       case 223:
         dNdy = fYieldArray[kOmega];
+        yWeight = GetYWeight(kOmega, part);
         break;
       case 331:
         dNdy = fYieldArray[kEtaprime];
+        yWeight = GetYWeight(kEtaprime, part);
         break;
       case 333:
         dNdy = fYieldArray[kPhi];
+        yWeight = GetYWeight(kPhi, part);
         break;
       case 443:
         dNdy = fYieldArray[kJpsi];
+        yWeight = GetYWeight(kJpsi, part);
         break;
       case 220000:
         dNdy = fYieldArray[kDirectRealGamma];
+        yWeight = 0.;
         break;
       case 220001:
         dNdy = fYieldArray[kDirectVirtGamma];
+        yWeight = 0.;
         break;
       case 3212:
         dNdy = fYieldArray[kSigma0];
+        yWeight = GetYWeight(kSigma0, part);
         break;
       case 310:
         dNdy = fYieldArray[kK0s];
+        yWeight = GetYWeight(kK0s, part);
         break;
       case 130:
         dNdy = fYieldArray[kK0l];
+        yWeight = GetYWeight(kK0l, part);
         break;
       case 3122:
         dNdy = fYieldArray[kLambda];
+        yWeight = GetYWeight(kLambda, part);
         break;
       case 2224:
         dNdy = fYieldArray[kDeltaPlPl];
+        yWeight = GetYWeight(kDeltaPlPl, part);
         break;
       case 2214:
         dNdy = fYieldArray[kDeltaPl];
+        yWeight = GetYWeight(kDeltaPl, part);
         break;
       case 1114:
         dNdy = fYieldArray[kDeltaMi];
+        yWeight = GetYWeight(kDeltaMi, part);
         break;
       case 2114:
         dNdy = fYieldArray[kDeltaZero];
+        yWeight = GetYWeight(kDeltaZero, part);
         break;
       case 213:
         dNdy = fYieldArray[kRhoPl];
+        yWeight = GetYWeight(kRhoPl, part);
         break;
       case -213:
         dNdy = fYieldArray[kRhoMi];
+        yWeight = GetYWeight(kRhoMi, part);
         break;
       case 313:
         dNdy = fYieldArray[kK0star];
+        yWeight = GetYWeight(kK0star, part);
         break;
       default:
         dNdy = 0.;
+        yWeight = 0.;
     }
     
-    weight = dNdy*part->GetWeight();
+    if (fUseYWeighting && yWeight)
+      weight = yWeight*dNdy*part->GetWeight();
+    else
+      weight = dNdy*part->GetWeight();
     part->SetWeight(weight);
   }	
   
   fHeader->SetNProduced(maxPart);
-  
-  
+
   TArrayF eventVertex;
   eventVertex.Set(3);
   for (Int_t j=0; j < 3; j++) eventVertex[j] = fVertex[j];

--- a/PWG/Cocktail/AliGenEMCocktailV2.h
+++ b/PWG/Cocktail/AliGenEMCocktailV2.h
@@ -24,6 +24,7 @@
 #include "AliGenParam.h"
 #include "TF1.h"
 #include "TH1D.h"
+#include "TH2F.h"
 
 class AliGenCocktailEntry;
 
@@ -48,6 +49,7 @@ public:
   virtual void Generate();
   
   // setters
+  void    SetUseYWeighting(Bool_t useYWeighting)                      { fUseYWeighting = useYWeighting;   }
   void    SetDynamicalPtRange(Bool_t dynamicalPtRange)                { fDynPtRange = dynamicalPtRange;   }
   void    SetParametrizationFile(TString paramFile)                   { fParametrizationFile = paramFile; }
   void    SetParametrizationFileDirectory(TString paramDir)           { fParametrizationDir = paramDir;   }
@@ -62,8 +64,11 @@ public:
   void    SetHeaviestHadron(ParticleGenerator_t part);
   static  Bool_t  SetPtParametrizations();
   static  void    SetMtScalingFactors();
+  static  Bool_t  SetPtYDistributions();
  
   // getters
+  Bool_t    GetDynamicalPtRangeOption()       const                   { return fDynPtRange;               }
+  Bool_t    GetYWeightOption()                const                   { return fUseYWeighting;            }
   Float_t   GetDecayMode()                    const                   { return fDecayMode;                }
   Float_t   GetWeightingMode()                const                   { return fWeightingMode;            }
   AliGenEMlibV2::CollisionSystem_t  GetCollisionSystem()  const       { return fCollisionSystem;          }
@@ -73,9 +78,11 @@ public:
   TString   GetParametrizationFileDirectory() const                   { return fParametrizationDir;       }
   Int_t     GetNumberOfParticles()            const                   { return fNPart;                    }
   Double_t  GetMaxPtStretchFactor(Int_t pdgCode);
+  Double_t  GetYWeight(Int_t pdgCode, TParticle* part);
   void      GetPtRange(Double_t &ptMin, Double_t &ptMax);
-  static    TF1*   GetPtParametrization(Int_t np);
-  static    TH1D*  GetMtScalingFactors();
+  static    TF1*    GetPtParametrization(Int_t np);
+  static    TH1D*   GetMtScalingFactors();
+  static    TH2F*   GetPtYDistribution(Int_t np);
   
   //***********************************************************************************************
   // This function allows to select the particle which should be procude based on 1 Integer value
@@ -113,16 +120,18 @@ private:
   static TF1*     fPtParametrization[18];               // pt paramtrizations
   static TF1*     fParametrizationProton;               //
   static TH1D*    fMtScalingFactorHisto;                // mt scaling factors
+  static TH2F*    fPtYDistribution[18];                 // pt-y distribution
   
   AliGenEMlibV2::CollisionSystem_t  fCollisionSystem;   // selected collision system
   AliGenEMlibV2::Centrality_t       fCentrality;        // selected centrality
   AliGenEMlibV2::v2Sys_t            fV2Systematic;      // selected systematic error for v2 parameters
   
+  Bool_t        fUseYWeighting;                         // select if input pt-y distributions should be used for weighting in generation
   Bool_t        fDynPtRange;                            // select if the pt range for the generation should be adapted to different mother particle weights dynamically
   Bool_t        fForceConv;                             // select whether you want to force all gammas to convert imidediately
   UInt_t        fSelectedParticles;                     // which particles to simulate, allows to switch on and off 32 different particles
   
-  ClassDef(AliGenEMCocktailV2,6)                        // cocktail for EM physics
+  ClassDef(AliGenEMCocktailV2,7)                        // cocktail for EM physics
 };
 
 #endif

--- a/PWG/Cocktail/AliGenEMlibV2.cxx
+++ b/PWG/Cocktail/AliGenEMlibV2.cxx
@@ -43,6 +43,7 @@ ClassImp(AliGenEMlibV2)
 TF1*  AliGenEMlibV2::fPtParametrization[]       = {0x0};
 TF1*  AliGenEMlibV2::fPtParametrizationProton   = NULL;
 TH1D* AliGenEMlibV2::fMtFactorHisto             = NULL;
+TH2F* AliGenEMlibV2::fPtYDistribution[]         = {0x0};
 Int_t AliGenEMlibV2::fgSelectedCollisionsSystem = AliGenEMlibV2::kpp7TeV;
 Int_t AliGenEMlibV2::fgSelectedCentrality       = AliGenEMlibV2::kpp;
 Int_t AliGenEMlibV2::fgSelectedV2Systematic     = AliGenEMlibV2::kNoV2Sys;
@@ -1134,6 +1135,57 @@ void AliGenEMlibV2::SetMtScalingFactors(TString fileName, TString dirName) {
 //--------------------------------------------------------------------------
 TH1D* AliGenEMlibV2::GetMtScalingFactors() {
   return fMtFactorHisto;
+}
+
+
+//--------------------------------------------------------------------------
+//
+//                        set pt-y distributions
+//
+//--------------------------------------------------------------------------
+Bool_t AliGenEMlibV2::SetPtYDistributions(TString fileName, TString dirName) {
+
+  // open parametrizations file
+  TFile* fPtYDistributionFile = TFile::Open(fileName.Data());
+  if (!fPtYDistributionFile) AliFatalClass(Form("File %s not found",fileName.Data()));
+  TDirectory* fPtYDistributionDir = (TDirectory*)fPtYDistributionFile->Get(dirName.Data());
+  if (!fPtYDistributionDir) AliFatalClass(Form("Directory %s not found",dirName.Data()));
+
+  // check for pt-y parametrizations
+  AliGenEMlibV2 lib;
+  TRandom* rndm;
+  TH2F* ptYTemp = NULL;
+  for (Int_t i=0; i<18; i++) {
+    Int_t ip = (Int_t)(lib.GetIp(i, ""))(rndm);
+    ptYTemp = (TH2F*)fPtYDistributionDir->Get(Form("%d_pt_y", ip));
+    if (ptYTemp) {
+      fPtYDistribution[i] = new TH2F(*ptYTemp);
+      fPtYDistribution[i]->SetName(Form("%d_pt_y", ip));
+      fPtYDistribution[i]->SetDirectory(0);
+    } else {
+      fPtYDistribution[i] = NULL;
+    }
+  }
+
+  if (!fPtYDistribution[0]) AliFatalClass(Form("File %s doesn't contain pi0 pt-y distribution",fileName.Data()));
+
+  fPtYDistributionFile->Close();
+  delete fPtYDistributionFile;
+
+  return kTRUE;
+}
+
+
+//--------------------------------------------------------------------------
+//
+//                     return pt-y distribution
+//
+//--------------------------------------------------------------------------
+TH2F* AliGenEMlibV2::GetPtYDistribution(Int_t np) {
+  if (np<18 && fPtYDistribution[np])
+    return fPtYDistribution[np];
+  else
+    return NULL;
 }
 
 

--- a/PWG/Cocktail/AliGenEMlibV2.h
+++ b/PWG/Cocktail/AliGenEMlibV2.h
@@ -19,6 +19,7 @@
 #include "TObject.h"
 #include "TF1.h"
 #include "TH1D.h"
+#include "TH2F.h"
 
 class iostream;
 class TRandom;
@@ -61,9 +62,11 @@ public:
   // General functions
   static Bool_t SetPtParametrizations(TString fileName, TString dirName);
   static void   SetMtScalingFactors(TString fileName, TString dirName);
+  static Bool_t SetPtYDistributions(TString fileName, TString dirName);
   static TF1*   GetPtParametrization(Int_t np);
   static TH1D*  GetMtScalingFactors();
-  
+  static TH2F*  GetPtYDistribution(Int_t np);
+
   static Int_t fgSelectedCollisionsSystem;                                                      // selected pT parameter
   static Int_t fgSelectedCentrality;                                                            // selected Centrality
   static Int_t fgSelectedV2Systematic;                                                          // selected v2 systematics, usefully values: -1,0,1
@@ -216,9 +219,9 @@ private:
   static TF1*     fPtParametrization[18];     // pt paramtrizations
   static TF1*     fPtParametrizationProton;   // pt paramtrization
   static TH1D*    fMtFactorHisto;             // mt scaling factors
+  static TH2F*    fPtYDistribution[18];       // pt-y distributions
 
-  ClassDef(AliGenEMlibV2,5);
-  
+  ClassDef(AliGenEMlibV2,6);
 };
 
 #endif

--- a/PWG/Cocktail/macros/AddMCEMCocktailV2.C
+++ b/PWG/Cocktail/macros/AddMCEMCocktailV2.C
@@ -10,7 +10,8 @@ AliGenerator* AddMCEMCocktailV2(  Int_t collisionsSystem      = 200,
                                   Int_t pythiaErrorTolerance  = 2000,
                                   Bool_t externalDecayer      = 0,
                                   Bool_t decayLongLived       = 0,
-                                  Bool_t dynamicalPtRange     = 0
+                                  Bool_t dynamicalPtRange     = 0,
+                                  Bool_t useYWeights          = 0
                                 )
 {
   // collisions systems defined:
@@ -40,6 +41,7 @@ AliGenerator* AddMCEMCocktailV2(  Int_t collisionsSystem      = 200,
   gener->SetNPart(numberOfParticles);                         // source multiplicity per event
   gener->SetPtRange(minPt,maxPt);
   gener->SetDynamicalPtRange(dynamicalPtRange);
+  gener->SetUseYWeighting(useYWeights);
   gener->SetYRange(-1.,1.);
   gener->SetPhiRange(0., 360.);
   gener->SetOrigin(0.,0.,0.); 

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCocktailMC.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCocktailMC.cxx
@@ -87,6 +87,7 @@ AliAnalysisTaskGammaCocktailMC::AliAnalysisTaskGammaCocktailMC(): AliAnalysisTas
   fPtParametrizationProton(NULL),
   fCocktailSettings{NULL},
   fMtScalingFactors(NULL),
+  fPtYDistributions{NULL},
   fUserInfo(NULL),
   fOutputTree(NULL),
   fIsMC(1),
@@ -128,6 +129,7 @@ AliAnalysisTaskGammaCocktailMC::AliAnalysisTaskGammaCocktailMC(const char *name)
   fPtParametrizationProton(NULL),
   fCocktailSettings{NULL},
   fMtScalingFactors(NULL),
+  fPtYDistributions{NULL},
   fUserInfo(NULL),
   fOutputTree(NULL),
   fIsMC(1),
@@ -202,11 +204,19 @@ void AliAnalysisTaskGammaCocktailMC::UserCreateOutputObjects(){
     fCocktailSettings[7] = new TObjString(Form("ptMin_%.2f",ptMin));
     fCocktailSettings[8] = new TObjString(Form("ptMax_%.2f",ptMax));
     fCocktailSettings[9] = new TObjString(Form("weightMode_%.0f",fMCCocktailGen->GetWeightingMode()));
-    for (Int_t i=0; i<10; i++) fUserInfo->Add(fCocktailSettings[i]);
+    fCocktailSettings[10] = new TObjString(Form("dynamicalPtRang_%d",fMCCocktailGen->GetDynamicalPtRangeOption()));
+    fCocktailSettings[11] = new TObjString(Form("yWeights_%d",fMCCocktailGen->GetYWeightOption()));
+    for (Int_t i=0; i<12; i++) fUserInfo->Add(fCocktailSettings[i]);
     
     // mt scaling params
     fMtScalingFactors = (TH1D*)fMCCocktailGen->GetMtScalingFactors();
     fUserInfo->Add(fMtScalingFactors);
+
+    // pt-y distributions
+    GetAndSetPtYDistributions(fMCCocktailGen);
+    for (Int_t i=0; i<17; i++) {
+      if (fHasMother[i]) fUserInfo->Add(fPtYDistributions[i]);
+    }
   } else {
     for (Int_t i=0; i<17; i++) fHasMother[i] = kTRUE;
   }
@@ -392,6 +402,40 @@ void AliAnalysisTaskGammaCocktailMC::GetAndSetPtParametrizations(AliGenEMCocktai
       if (fctName.BeginsWith("130_pt")  && fHasMother[15]) fPtParametrization[15]  = fct;
       if (fctName.BeginsWith("3122_pt") && fHasMother[16]) fPtParametrization[16]  = fct;
       if (fctName.BeginsWith("2212_pt")) fPtParametrizationProton = fct;
+    }
+  }
+}
+
+//_____________________________________________________________________________
+void AliAnalysisTaskGammaCocktailMC::GetAndSetPtYDistributions(AliGenEMCocktailV2* fMCCocktailGen)
+{
+  if (!fMCCocktailGen) return;
+
+  for (Int_t i=0; i<17; i++) fPtYDistributions[i] = NULL;
+
+  TH2F* tempPtY = NULL;
+  TString tempPtYName = "";
+  for (Int_t i=0; i<18; i++) {
+    tempPtY = (TH2F*)fMCCocktailGen->GetPtYDistribution(i);
+    if (tempPtY) {
+      tempPtYName = tempPtY->GetName();
+      if (tempPtYName.BeginsWith("111_pt_y")  && fHasMother[0])  fPtYDistributions[0]   = tempPtY;
+      if (tempPtYName.BeginsWith("221_pt_y")  && fHasMother[1])  fPtYDistributions[1]   = tempPtY;
+      if (tempPtYName.BeginsWith("331_pt_y")  && fHasMother[2])  fPtYDistributions[2]   = tempPtY;
+      if (tempPtYName.BeginsWith("223_pt_y")  && fHasMother[3])  fPtYDistributions[3]   = tempPtY;
+      if (tempPtYName.BeginsWith("113_pt_y")  && fHasMother[4])  fPtYDistributions[4]   = tempPtY;
+      if (tempPtYName.BeginsWith("213_pt_y")  && fHasMother[5])  fPtYDistributions[5]   = tempPtY;
+      if (tempPtYName.BeginsWith("-213_pt_y") && fHasMother[6])  fPtYDistributions[6]   = tempPtY;
+      if (tempPtYName.BeginsWith("333_pt_y")  && fHasMother[7])  fPtYDistributions[7]   = tempPtY;
+      if (tempPtYName.BeginsWith("443_pt_y")  && fHasMother[8])  fPtYDistributions[8]   = tempPtY;
+      if (tempPtYName.BeginsWith("1114_pt_y") && fHasMother[9])  fPtYDistributions[9]   = tempPtY;
+      if (tempPtYName.BeginsWith("2114_pt_y") && fHasMother[10]) fPtYDistributions[10]  = tempPtY;
+      if (tempPtYName.BeginsWith("2214_pt_y") && fHasMother[11]) fPtYDistributions[11]  = tempPtY;
+      if (tempPtYName.BeginsWith("2224_pt_y") && fHasMother[12]) fPtYDistributions[12]  = tempPtY;
+      if (tempPtYName.BeginsWith("3212_pt_y") && fHasMother[13]) fPtYDistributions[13]  = tempPtY;
+      if (tempPtYName.BeginsWith("310_pt_y")  && fHasMother[14]) fPtYDistributions[14]  = tempPtY;
+      if (tempPtYName.BeginsWith("130_pt_y")  && fHasMother[15]) fPtYDistributions[15]  = tempPtY;
+      if (tempPtYName.BeginsWith("3122_pt_y") && fHasMother[16]) fPtYDistributions[16]  = tempPtY;
     }
   }
 }

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCocktailMC.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCocktailMC.h
@@ -30,6 +30,7 @@ class AliAnalysisTaskGammaCocktailMC : public AliAnalysisTaskSE {
     void InitializeDecayChannelHist(TH1F* hist, Int_t np);
     void FillPythiaBranchingRatio(TH1F* histo, Int_t np);
     void GetAndSetPtParametrizations(AliGenEMCocktailV2* mcCocktailGen);
+    void GetAndSetPtYDistributions(AliGenEMCocktailV2* mcCocktailGen);
     void SetHasMother(UInt_t selectedMothers);
     Int_t GetParticlePosLocal(Int_t pdg);
     TH1* SetHist1D(TH1* hist, TString histType, TString histName, TString xTitle, TString yTitle, Int_t nBinsX, Double_t xMin, Double_t xMax, Bool_t optSumw2);
@@ -82,14 +83,15 @@ class AliAnalysisTaskGammaCocktailMC : public AliAnalysisTaskSE {
   
     TF1*                        fPtParametrization[17];         //!
     TF1*                        fPtParametrizationProton;       //!
-    TObjString*                 fCocktailSettings[10];          //!
+    TObjString*                 fCocktailSettings[12];          //!
     TH1D*                       fMtScalingFactors;              //!
+    TH2F*                       fPtYDistributions[17];          //!
 
   private:
     AliAnalysisTaskGammaCocktailMC(const AliAnalysisTaskGammaCocktailMC&);            // Prevent copy-construction
     AliAnalysisTaskGammaCocktailMC &operator=(const AliAnalysisTaskGammaCocktailMC&); // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaCocktailMC, 3);
+    ClassDef(AliAnalysisTaskGammaCocktailMC, 4);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskHadronicCocktailMC.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskHadronicCocktailMC.cxx
@@ -89,6 +89,7 @@ AliAnalysisTaskHadronicCocktailMC::AliAnalysisTaskHadronicCocktailMC(): AliAnaly
   fPtParametrizationPi0(NULL),
   fCocktailSettings{NULL},
   fMtScalingFactors(NULL),
+  fPtYDistributions{NULL},
   fUserInfo(NULL),
   fOutputTree(NULL),
   fIsMC(1),
@@ -132,6 +133,7 @@ AliAnalysisTaskHadronicCocktailMC::AliAnalysisTaskHadronicCocktailMC(const char 
   fPtParametrizationPi0(NULL),
   fCocktailSettings{NULL},
   fMtScalingFactors(NULL),
+  fPtYDistributions{NULL},
   fUserInfo(NULL),
   fOutputTree(NULL),
   fIsMC(1),
@@ -204,11 +206,19 @@ void AliAnalysisTaskHadronicCocktailMC::UserCreateOutputObjects(){
     fCocktailSettings[7] = new TObjString(Form("ptMin_%.2f", ptMin));
     fCocktailSettings[8] = new TObjString(Form("ptMax_%.2f", ptMax));
     fCocktailSettings[9] = new TObjString(Form("weightMode_%.0f", fMCCocktailGen->GetWeightingMode()));
-    for (Int_t i=0; i<10; i++) fUserInfo->Add(fCocktailSettings[i]);
+    fCocktailSettings[10] = new TObjString(Form("dynamicalPtRang_%d",fMCCocktailGen->GetDynamicalPtRangeOption()));
+    fCocktailSettings[11] = new TObjString(Form("yWeights_%d",fMCCocktailGen->GetYWeightOption()));
+    for (Int_t i=0; i<12; i++) fUserInfo->Add(fCocktailSettings[i]);
     
     // mt scaling params
     fMtScalingFactors = (TH1D*)fMCCocktailGen->GetMtScalingFactors();
     fUserInfo->Add(fMtScalingFactors);
+
+    // pt-y distributions
+    GetAndSetPtYDistributions(fMCCocktailGen);
+    for (Int_t i=0; i<13; i++) {
+      if (fHasMother[i]) fUserInfo->Add(fPtYDistributions[i]);
+    }
   } else {
     for (Int_t i=0; i<13; i++) fHasMother[i] = kTRUE;
   }
@@ -366,6 +376,36 @@ void AliAnalysisTaskHadronicCocktailMC::GetAndSetPtParametrizations(AliGenEMCock
       if (fctName.BeginsWith("2214_pt") && fHasMother[12]) fPtParametrization[12]  = fct;
       if (fctName.BeginsWith("2212_pt")) fPtParametrizationProton = fct;
       if (fctName.BeginsWith("111_pt"))  fPtParametrizationPi0    = fct;
+    }
+  }
+}
+
+//_____________________________________________________________________________
+void AliAnalysisTaskHadronicCocktailMC::GetAndSetPtYDistributions(AliGenEMCocktailV2* fMCCocktailGen)
+{
+  if (!fMCCocktailGen) return;
+
+  for (Int_t i=0; i<13; i++) fPtYDistributions[i] = NULL;
+
+  TH2F* tempPtY = NULL;
+  TString tempPtYName = "";
+  for (Int_t i=0; i<18; i++) {
+    tempPtY = (TH2F*)fMCCocktailGen->GetPtYDistribution(i);
+    if (tempPtY) {
+      tempPtYName = tempPtY->GetName();
+      if (tempPtYName.BeginsWith("221_pt_y")  && fHasMother[0])  fPtYDistributions[0]   = tempPtY;
+      if (tempPtYName.BeginsWith("310_pt_y")  && fHasMother[1])  fPtYDistributions[1]   = tempPtY;
+      if (tempPtYName.BeginsWith("130_pt_y")  && fHasMother[2])  fPtYDistributions[2]   = tempPtY;
+      if (tempPtYName.BeginsWith("3122_pt_y") && fHasMother[3])  fPtYDistributions[3]   = tempPtY;
+      if (tempPtYName.BeginsWith("113_pt_y")  && fHasMother[4])  fPtYDistributions[4]   = tempPtY;
+      if (tempPtYName.BeginsWith("331_pt_y")  && fHasMother[5])  fPtYDistributions[5]   = tempPtY;
+      if (tempPtYName.BeginsWith("223_pt_y")  && fHasMother[6])  fPtYDistributions[6]   = tempPtY;
+      if (tempPtYName.BeginsWith("213_pt_y")  && fHasMother[7])  fPtYDistributions[7]   = tempPtY;
+      if (tempPtYName.BeginsWith("-213_pt_y") && fHasMother[8])  fPtYDistributions[8]   = tempPtY;
+      if (tempPtYName.BeginsWith("333_pt_y")  && fHasMother[9])  fPtYDistributions[9]   = tempPtY;
+      if (tempPtYName.BeginsWith("443_pt_y")  && fHasMother[10]) fPtYDistributions[10]  = tempPtY;
+      if (tempPtYName.BeginsWith("2114_pt_y") && fHasMother[11]) fPtYDistributions[11]  = tempPtY;
+      if (tempPtYName.BeginsWith("2214_pt_y") && fHasMother[12]) fPtYDistributions[12]  = tempPtY;
     }
   }
 }

--- a/PWGGA/GammaConv/AliAnalysisTaskHadronicCocktailMC.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskHadronicCocktailMC.h
@@ -31,6 +31,7 @@ class AliAnalysisTaskHadronicCocktailMC : public AliAnalysisTaskSE {
     void InitializeDecayChannelHist(TH1F* hist, Int_t np);
     void FillPythiaBranchingRatio(TH1F* histo, Int_t np);
     void GetAndSetPtParametrizations(AliGenEMCocktailV2* mcCocktailGen);
+    void GetAndSetPtYDistributions(AliGenEMCocktailV2* mcCocktailGen);
     void SetHasMother(UInt_t selectedMothers);
     Int_t GetParticlePosLocal(Int_t pdg);
     TH1* SetHist1D(TH1* hist, TString histType, TString histName, TString xTitle, TString yTitle, Int_t nBinsX, Double_t xMin, Double_t xMax, Bool_t optSumw2);
@@ -86,14 +87,15 @@ class AliAnalysisTaskHadronicCocktailMC : public AliAnalysisTaskSE {
     TF1*                        fPtParametrization[13];           //!
     TF1*                        fPtParametrizationProton;         //!
     TF1*                        fPtParametrizationPi0;            //!
-    TObjString*                 fCocktailSettings[10];            //!
+    TObjString*                 fCocktailSettings[12];            //!
     TH1D*                       fMtScalingFactors;                //!
+    TH2F*                       fPtYDistributions[13];            //!
   
   private:
     AliAnalysisTaskHadronicCocktailMC(const AliAnalysisTaskHadronicCocktailMC&);              // Prevent copy-construction
     AliAnalysisTaskHadronicCocktailMC &operator=(const AliAnalysisTaskHadronicCocktailMC&);   // Prevent assignment
   
-    ClassDef(AliAnalysisTaskHadronicCocktailMC, 4);
+    ClassDef(AliAnalysisTaskHadronicCocktailMC, 5);
 };
 
 #endif


### PR DESCRIPTION
implemented option to use rapidity weighting in EM cocktail generation from input files,
settings will be stored by the corresponding analysis tasks AliAnalysisTaskGammaCocktail and AliAnalysisTaskHadronicCocktail