### PR TITLE
PWGPPEMCAL depends on PWGEMCALbase

### DIFF
--- a/PWGPP/EMCAL/CMakeLists.txt
+++ b/PWGPP/EMCAL/CMakeLists.txt
@@ -49,7 +49,7 @@ get_directory_property(incdirs INCLUDE_DIRECTORIES)
 generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 set(ROOT_DEPENDENCIES Core Geom RIO)
-set(ALIROOT_DEPENDENCIES ANALYSIS ANALYSISalice ESDfilter AOD EMCALUtils ESD STEERBase)
+set(ALIROOT_DEPENDENCIES PWGEMCALbase ANALYSIS ANALYSISalice ESDfilter AOD EMCALUtils ESD STEERBase)
 
 # Generate the ROOT map
 # Dependecies


### PR DESCRIPTION
The loading of libraries fails and this commit fixes the issue.