### PR TITLE
 added system information (pp, pPb, PbPb) to event classifier base class

### DIFF
--- a/PWG/HMTF/AliAnalysisTaskHMTFMCMultEst.cxx
+++ b/PWG/HMTF/AliAnalysisTaskHMTFMCMultEst.cxx
@@ -25,14 +25,14 @@ ClassImp(AliAnalysisTaskHMTFMCMultEst)
 
 //________________________________________________________________________
 AliAnalysisTaskHMTFMCMultEst::AliAnalysisTaskHMTFMCMultEst()
-: AliAnalysisTaskSE(), fMyOut(0), fClassifiers(0), fObservables(0), fGlobalTrigger(0),
+: AliAnalysisTaskSE(), fMyOut(0), fClassifiers(0), fObservables(0), fGlobalTrigger(0), fGlobalSystem(0),
   fGlobalTriggerClassifiers(0)
 {
 }
 
 //________________________________________________________________________
 AliAnalysisTaskHMTFMCMultEst::AliAnalysisTaskHMTFMCMultEst(const char *name)
-  : AliAnalysisTaskSE(name), fMyOut(0), fClassifiers(0), fObservables(0), fGlobalTrigger(0),
+  : AliAnalysisTaskSE(name), fMyOut(0), fClassifiers(0), fObservables(0), fGlobalTrigger(0), fGlobalSystem(0),
     fGlobalTriggerClassifiers(0)
 {
   DefineOutput(1, TList::Class());
@@ -47,40 +47,40 @@ void AliAnalysisTaskHMTFMCMultEst::UserCreateOutputObjects()
   //////////////////////////////////////////
   // Multiplicity based classifiers       //
   //////////////////////////////////////////
-  // Some classifieres are used as "reference" classifiers. Ie. We do not compute N! correlation
-  // plots between N classifiers. We restrict oursefls to calculating only the correlations of every
+  // Some classifiers are used as "reference" classifiers. Ie. We do not compute N! correlation
+  // plots between N classifiers. We restrict ourselves to calculating only the correlations of every
   // classifier to a small number of reference classifiers.
   Float_t region2[] = {-0.5, 0.5};  // Use this array to pass two pass two edges to the constructor
   AliEventClassifierMult* refClassifierEtaLt05 =
-    new AliEventClassifierMult("EtaLt05", "|#eta| < 0.5", region2, 2, true, true, fMyOut);
+    new AliEventClassifierMult("EtaLt05", "|#eta| < 0.5", region2, 2, true, true, fMyOut, fGlobalSystem);
   fClassifiers.push_back(refClassifierEtaLt05);
 
   region2[0] = -0.8; region2[1] = 0.8;
-  fClassifiers.push_back(new AliEventClassifierMult("EtaLt08", "|#eta| < 0.8", region2, 2, true, true, fMyOut));
+  fClassifiers.push_back(new AliEventClassifierMult("EtaLt08", "|#eta| < 0.8", region2, 2, true, true, fMyOut, fGlobalSystem));
 
   region2[0] = -1.0; region2[1] = 1.0;
-  AliEventClassifierMult* etaLt1 = new AliEventClassifierMult("EtaLt1", "|#eta| < 1.0", region2, 2, true, true, fMyOut);
+  AliEventClassifierMult* etaLt1 = new AliEventClassifierMult("EtaLt1", "|#eta| < 1.0", region2, 2, true, true, fMyOut, fGlobalSystem);
   fClassifiers.push_back(etaLt1);
 
   region2[0] = -1.5; region2[1] = 1.5;
-  fClassifiers.push_back(new AliEventClassifierMult("EtaLt15", "|#eta| < 1.5", region2, 2, true, true, fMyOut));
+  fClassifiers.push_back(new AliEventClassifierMult("EtaLt15", "|#eta| < 1.5", region2, 2, true, true, fMyOut, fGlobalSystem));
 
   region2[0] = 2.8; region2[1] = 5.1;
-  AliEventClassifierMult* v0a = new AliEventClassifierMult("V0A", "2.8 < #eta < 5.1", region2, 2, true, true, fMyOut);
+  AliEventClassifierMult* v0a = new AliEventClassifierMult("V0A", "2.8 < #eta < 5.1", region2, 2, true, true, fMyOut, fGlobalSystem);
   fClassifiers.push_back(v0a);
 
   region2[0] = -3.7; region2[1] = -1.7;
-  AliEventClassifierMult* v0c = new AliEventClassifierMult("V0C", "-3.7 < #eta < -1.7", region2, 2, true, true, fMyOut);
+  AliEventClassifierMult* v0c = new AliEventClassifierMult("V0C", "-3.7 < #eta < -1.7", region2, 2, true, true, fMyOut, fGlobalSystem);
   fClassifiers.push_back(v0c);
 
   region2[0] = -8.7; region2[1] = 8.7; // not inclusive region, not charged!
-  fClassifiers.push_back(new AliEventClassifierMult("ZDC", "|#eta| > 8.7", region2, 2, false, false, fMyOut));
+  fClassifiers.push_back(new AliEventClassifierMult("ZDC", "|#eta| > 8.7", region2, 2, false, false, fMyOut, fGlobalSystem));
 
   Float_t region4[] = {-3.7, -1.7, 2.8, 5.1};
-  fClassifiers.push_back(new AliEventClassifierMult("V0M", "V0A + V0C", region4, 4, true, true, fMyOut));
+  fClassifiers.push_back(new AliEventClassifierMult("V0M", "V0A + V0C", region4, 4, true, true, fMyOut, fGlobalSystem));
   region4[0] = -1.5;   region4[1] = -0.8;   region4[2] = 0.8;   region4[3] = 1.5; 
   fClassifiers.push_back(new AliEventClassifierMult("Eta08_15", "0.8 < |#eta| < 1.5",
-   						    region4, 4, true, true, fMyOut));
+   						    region4, 4, true, true, fMyOut, fGlobalSystem));
 
   ////////////////////////////////////
   // nMPI and Q^2 based classifiers //
@@ -101,7 +101,7 @@ void AliAnalysisTaskHMTFMCMultEst::UserCreateOutputObjects()
   fClassifiers.push_back(refClassifierSphericity);
 
   // Set the global trigger if one was defined for this task
-  // Remember to reset the classifieres used here as well (if new ones are defined just for the trigger)
+  // Remember to reset the classifiers used here as well (if new ones are defined just for the trigger)
   if (fGlobalTrigger == kINEL) {
     SetupInelAsGlobalTrigger();
     cout << "INEL global trigger set" << endl;

--- a/PWG/HMTF/AliAnalysisTaskHMTFMCMultEst.h
+++ b/PWG/HMTF/AliAnalysisTaskHMTFMCMultEst.h
@@ -18,6 +18,7 @@ class AliAnalysisTaskHMTFMCMultEst : public AliAnalysisTaskSE {
 
   // set the name of the global trigger in the AddTask marcro through this function
   void SetGlobalTrigger(Int_t triggerEnum) {fGlobalTrigger = triggerEnum;};
+  void SetGlobalSystem(Int_t systemEnum) {fGlobalSystem = systemEnum;}
  private:
   TList *fMyOut;                          // Output list
   std::vector<AliEventClassifierBase*> fClassifiers;
@@ -25,6 +26,8 @@ class AliAnalysisTaskHMTFMCMultEst : public AliAnalysisTaskSE {
 
   Int_t fGlobalTrigger;
   enum {kINEL, kINELGT0, kV0AND};
+  Int_t fGlobalSystem;
+  enum {kPP, kPPB, kPBPB};
 
   void SetupInelAsGlobalTrigger();
   void SetupInelGt0AsGlobalTrigger(AliEventClassifierBase* etaLt1);
@@ -40,7 +43,7 @@ class AliAnalysisTaskHMTFMCMultEst : public AliAnalysisTaskSE {
   AliAnalysisTaskHMTFMCMultEst(const AliAnalysisTaskHMTFMCMultEst&); // not implemented
   AliAnalysisTaskHMTFMCMultEst& operator=(const AliAnalysisTaskHMTFMCMultEst&); // not implemented
 
-  ClassDef(AliAnalysisTaskHMTFMCMultEst, 1); // example of analysis
+  ClassDef(AliAnalysisTaskHMTFMCMultEst, 2); // example of analysis
 };
 
 #endif

--- a/PWG/HMTF/AliEventClassifierBase.cxx
+++ b/PWG/HMTF/AliEventClassifierBase.cxx
@@ -16,17 +16,19 @@ AliEventClassifierBase::AliEventClassifierBase()
   fClassifierValue(0),
   fExpectedMinValue(0),
   fExpectedMaxValue(0),
+  fCollisionSystem(0),
   fClassifierValueIsCached(false),
   fClassifierOutputList(0),
   fTaskOutputList(0)
 {
   
 }
-AliEventClassifierBase::AliEventClassifierBase(const char* name, const char* title, TList *taskOutputList)
+AliEventClassifierBase::AliEventClassifierBase(const char* name, const char* title, TList *taskOutputList, Int_t collisionSystem)
   : TNamed(name, title),
     fClassifierValue(0),
     fExpectedMinValue(0),
     fExpectedMaxValue(0),
+    fCollisionSystem(collisionSystem),
     fClassifierValueIsCached(false),
     fClassifierOutputList(0),
     fTaskOutputList(taskOutputList)

--- a/PWG/HMTF/AliEventClassifierBase.h
+++ b/PWG/HMTF/AliEventClassifierBase.h
@@ -10,7 +10,7 @@
 class AliEventClassifierBase : public TNamed {
  public:
   AliEventClassifierBase();
-  AliEventClassifierBase(const char* name, const char* title, TList *fTaskOutputList);
+  AliEventClassifierBase(const char* name, const char* title, TList *fTaskOutputList, Int_t fCollisionSystem = 0);
   virtual ~AliEventClassifierBase() {}
 
   Float_t GetClassifierValue(AliMCEvent *event, AliStack *stack);
@@ -25,11 +25,12 @@ class AliEventClassifierBase : public TNamed {
   Float_t fClassifierValue;           // The value for this classifier for the current event
   Int_t fExpectedMinValue;            // The expected min value produced by this estimator, used for hists
   Int_t fExpectedMaxValue;            // The expected max value produced by this estimator, used for hists
+  Int_t fCollisionSystem;             // 0 = pp, 1 = ppb, 2 = pbpb. Only used for some derived classes (e.g. multiplicity classifier) , some others (e.g. spherocity) are system 'agnostic' by definition
   
   TList *fClassifierOutputList;  // The "folder" in which the hists binned in this classifier a saved
   TList *fTaskOutputList;        // The list for the entire task
 
-  ClassDef(AliEventClassifierBase, 1);
+  ClassDef(AliEventClassifierBase, 2);
 };
 
 #endif

--- a/PWG/HMTF/AliEventClassifierMult.cxx
+++ b/PWG/HMTF/AliEventClassifierMult.cxx
@@ -17,13 +17,22 @@ AliEventClassifierMult::AliEventClassifierMult(const char* name, const char* tit
 						 Int_t lengthRegions,
 						 Bool_t regionsAreInclusive,
 						 Bool_t countCharged,
-						 TList *taskOutputList)
-  : AliEventClassifierBase(name, title, taskOutputList),
+						 TList *taskOutputList,
+                                                 Int_t collisionSystem)
+  : AliEventClassifierBase(name, title, taskOutputList, collisionSystem),
   fRegionsAreInclusive(regionsAreInclusive),
   fCountCharged(countCharged)
 {
-  fExpectedMinValue = 0;
-  fExpectedMaxValue = 250;
+  if(fCollisionSystem == 0) {
+      fExpectedMinValue = 0;
+      fExpectedMaxValue = 250;
+  } else if (fCollisionSystem == 1) {
+      fExpectedMinValue = 0;
+      fExpectedMaxValue = 250;
+  } else {
+      fExpectedMinValue = 0;
+      fExpectedMaxValue = 1500;
+  }
   std::vector<Float_t> v(2);
   for (Int_t i=0; i<lengthRegions; i+=2){
     v[0] = regions[i];

--- a/PWG/HMTF/AliEventClassifierMult.h
+++ b/PWG/HMTF/AliEventClassifierMult.h
@@ -12,7 +12,8 @@ class AliEventClassifierMult : public AliEventClassifierBase {
 			  Int_t lengthRegions,   //how many points are in "regions"
 			  Bool_t regionsAreInclusive,
 			  Bool_t countCharged,
-			  TList *taskOutputList);
+			  TList *taskOutputList,
+                          Int_t collisionSystem);
   virtual ~AliEventClassifierMult() {}
 
  private:

--- a/PWG/HMTF/AliEventClassifierSphericity.cxx
+++ b/PWG/HMTF/AliEventClassifierSphericity.cxx
@@ -52,7 +52,7 @@ void AliEventClassifierSphericity::CalculateClassifierValue(AliMCEvent *event, A
     s11 += (py * py) / track->Pt();
     totalpt += track->Pt();
   }
-  // did we have valid tracks or did we never reach the bottome of the for loop?
+  // did we have valid tracks or did we never reach the bottom of the for loop?
   if (!(totalpt > 0)) {
     fClassifierValue = -1;
     return;


### PR DESCRIPTION
- system information can be supplied to the AliAnalysisTaskHMTFMCMultEst class via the public member functin 'SetGlobalSystem'

- system information is then passed on to the event classifier classes for which system is relevant, e.g. multiplicity (so that appropriate bounds can be set)

- change is fully backward compatible: if not set, pp is used, which forces the task to use the 'standard' defaults, so no user intervention is necessary