### PR TITLE
PWGCF:  AliFemtoXi: Included nominal TPC info for bachelor pions.

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventReaderAOD.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventReaderAOD.cxx
@@ -1424,6 +1424,65 @@ AliFemtoXi *AliFemtoEventReaderAOD::CopyAODtoFemtoXi(AliAODcascade *tAODxi)
     //    tFemtoXi->SetTPCMomentumBac(trackbac->GetTPCmomentum());
     //    if (fShiftPosition > 0.)
 
+    float bfield = 5 * fMagFieldSign;
+    float globalPositionsAtRadiiBac[9][3];
+    GetGlobalPositionAtGlobalRadiiThroughTPC(trackbac, bfield, globalPositionsAtRadiiBac);
+    double tpcEntranceBac[3] = {globalPositionsAtRadiiBac[0][0], globalPositionsAtRadiiBac[0][1], globalPositionsAtRadiiBac[0][2]};
+    double tpcExitBac[3] = {globalPositionsAtRadiiBac[8][0], globalPositionsAtRadiiBac[8][1], globalPositionsAtRadiiBac[8][2]};
+
+
+    if (fPrimaryVertexCorrectionTPCPoints) {
+      tpcEntranceBac[0] -= fV1[0];
+      tpcEntranceBac[1] -= fV1[1];
+      tpcEntranceBac[2] -= fV1[2];
+
+      tpcExitBac[0] -= fV1[0];
+      tpcExitBac[1] -= fV1[1];
+      tpcExitBac[2] -= fV1[2];
+    }
+
+    AliFemtoThreeVector tmpVec;
+    tmpVec.SetX(tpcEntranceBac[0]);
+    tmpVec.SetY(tpcEntranceBac[1]);
+    tmpVec.SetZ(tpcEntranceBac[2]);
+    tFemtoXi->SetNominalTpcEntrancePointBac(tmpVec);
+
+    tmpVec.SetX(tpcExitBac[0]);
+    tmpVec.SetY(tpcExitBac[1]);
+    tmpVec.SetZ(tpcExitBac[2]);
+    tFemtoXi->SetNominalTpcExitPointBac(tmpVec);
+
+
+    AliFemtoThreeVector vecTpcBac[9];
+    for (int i = 0; i < 9; i++) {
+      vecTpcBac[i].SetX(globalPositionsAtRadiiBac[i][0]);
+      vecTpcBac[i].SetY(globalPositionsAtRadiiBac[i][1]);
+      vecTpcBac[i].SetZ(globalPositionsAtRadiiBac[i][2]);
+    }
+
+    if (fPrimaryVertexCorrectionTPCPoints) {
+      AliFemtoThreeVector tmpVertexVec;
+      tmpVertexVec.SetX(fV1[0]);
+      tmpVertexVec.SetY(fV1[1]);
+      tmpVertexVec.SetZ(fV1[2]);
+
+      for (int i = 0; i < 9; i ++) {
+        vecTpcBac[i] -= tmpVertexVec;
+      }
+    }
+
+    tFemtoXi->SetNominalTpcPointBac(vecTpcBac);
+
+    if (fShiftPosition > 0.) {
+      Float_t posShiftedBac[3];
+      SetShiftedPositions(trackbac, bfield, posShiftedBac, fShiftPosition);
+      AliFemtoThreeVector tmpVecBac;
+      tmpVecBac.SetX(posShiftedBac[0]);
+      tmpVecBac.SetY(posShiftedBac[1]);
+      tmpVecBac.SetZ(posShiftedBac[2]);
+      tFemtoXi->SetNominalTpcPointBacShifted(tmpVecBac);
+    }
+    tFemtoXi->SetTPCMomentumBac(trackbac->GetTPCmomentum());
     tFemtoXi->SetdedxBac(trackbac->GetTPCsignal());
 
     Float_t probMisBac = 1.0;

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoV0.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoV0.cxx
@@ -63,7 +63,7 @@ AliFemtoV0::AliFemtoV0():
 }
 // -----------------------------------------------------------------------
 AliFemtoV0::AliFemtoV0(const AliFemtoV0& v) :
-  fDecayLengthV0(v.fDecayLengthV0), fDecayVertexV0(v.fDecayVertexV0), fPrimaryVertex(0),
+  fDecayLengthV0(v.fDecayLengthV0), fDecayVertexV0(v.fDecayVertexV0), fPrimaryVertex(v.fPrimaryVertex),
   fDcaV0Daughters(v.fDcaV0Daughters), fDcaV0ToPrimVertex(v.fDcaV0ToPrimVertex),
   fDcaPosToPrimVertex(v.fDcaPosToPrimVertex), fDcaNegToPrimVertex(v.fDcaNegToPrimVertex),
   fMomPos(v.fMomPos), fMomNeg(v.fMomNeg),

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXi.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXi.cxx
@@ -23,8 +23,9 @@ AliFemtoXi::AliFemtoXi():
   fEXi(0), fEOmega(0), fEBacPion(0), fEBacKaon(0),
   fMassXi(0), fMassOmega(0), fRapXi(0), fRapOmega(0),
   fCTauXi(0), fCTauOmega(0),
-  fPtXi(0), fPtotXi(0), fPtBac(0), fPtotBac(0),
-  fKeyBac(0), fCosPointingAngleXi(0), fCosPointingAngleV0toXi(0), fPhiXi(0),
+  fPtXi(0), fPtotXi(0), fPtBac(0), fPtotBac(0), fKeyBac(0), 
+  fNominalTpcEntrancePointBac(0,0,0),fNominalTpcExitPointBac(0,0,0), fNominalTpcPointBacShifted(0,0,0),
+  fCosPointingAngleXi(0), fCosPointingAngleV0toXi(0), fPhiXi(0),
   fEtaXi(0), fTPCNclsBac(0), fNdofBac(0), fStatusBac(0),
   fEtaBac(0), fIdBac(0), fBacNSigmaTPCK(-999),fBacNSigmaTPCPi(-999),
   fBacNSigmaTPCP(-999), fBacNSigmaTOFK(-999), fBacNSigmaTOFPi(-999),
@@ -33,6 +34,13 @@ AliFemtoXi::AliFemtoXi():
 {
   fTopologyMapBachelor[0] = 0;
   fTopologyMapBachelor[1] = 0;
+
+  for(int i=0;i<9;i++)
+  {
+    fNominalTpcPointsBac[i].SetX(0);
+    fNominalTpcPointsBac[i].SetY(0);
+    fNominalTpcPointsBac[i].SetZ(0);
+  }
 }
 
 // -----------------------------------------------------------------------
@@ -48,8 +56,11 @@ AliFemtoXi::AliFemtoXi(const AliFemtoV0* aV0):
   fEXi(0), fEOmega(0), fEBacPion(0), fEBacKaon(0),
   fMassXi(0), fMassOmega(0), fRapXi(0), fRapOmega(0),
   fCTauXi(0), fCTauOmega(0),
-  fPtXi(0), fPtotXi(0), fPtBac(0), fPtotBac(0),
-  fKeyBac(0), fCosPointingAngleXi(0), fCosPointingAngleV0toXi(0), fPhiXi(0),
+  fPtXi(0), fPtotXi(0), fPtBac(0), fPtotBac(0), fKeyBac(0), 
+  fNominalTpcEntrancePointBac(0,0,0),
+  fNominalTpcExitPointBac(0,0,0),
+  fNominalTpcPointBacShifted(0,0,0),
+  fCosPointingAngleXi(0), fCosPointingAngleV0toXi(0), fPhiXi(0),
   fEtaXi(0), fTPCNclsBac(0), fNdofBac(0), fStatusBac(0),
   fEtaBac(0), fIdBac(0), fBacNSigmaTPCK(-999),fBacNSigmaTPCPi(-999),
   fBacNSigmaTPCP(-999), fBacNSigmaTOFK(-999), fBacNSigmaTOFPi(-999),
@@ -58,6 +69,13 @@ AliFemtoXi::AliFemtoXi(const AliFemtoV0* aV0):
 {
   fTopologyMapBachelor[0] = 0;
   fTopologyMapBachelor[1] = 0;
+
+  for(int i=0;i<9;i++)
+  {
+    fNominalTpcPointsBac[i].SetX(0);
+    fNominalTpcPointsBac[i].SetY(0);
+    fNominalTpcPointsBac[i].SetZ(0);
+  }
 }
 
 // -----------------------------------------------------------------------
@@ -70,8 +88,11 @@ AliFemtoXi::AliFemtoXi(const AliFemtoXi& aXi) :
   fDedxBachelor(aXi.fDedxBachelor), fNufDedxBachelor(aXi.fNufDedxBachelor), 
   fMomXi(0), fAlphaXi(0), fPtArmXi(0), fEXi(0), fEOmega(0), fEBacPion(0), 
   fEBacKaon(0), fMassXi(0), fMassOmega(0), fRapXi(0), fRapOmega(0), 
-  fCTauXi(0), fCTauOmega(0), fPtXi(0), fPtotXi(0), fPtBac(0), fPtotBac(0), 
-  fKeyBac(aXi.fKeyBac), fCosPointingAngleXi(aXi.fCosPointingAngleXi), fCosPointingAngleV0toXi(aXi.fCosPointingAngleV0toXi), fPhiXi(aXi.fPhiXi), fEtaXi(aXi.fEtaXi), 
+  fCTauXi(0), fCTauOmega(0), fPtXi(0), fPtotXi(0), fPtBac(0), fPtotBac(0), fKeyBac(aXi.fKeyBac), 
+  fNominalTpcEntrancePointBac(aXi.fNominalTpcEntrancePointBac),
+  fNominalTpcExitPointBac(aXi.fNominalTpcExitPointBac),
+  fNominalTpcPointBacShifted(aXi.fNominalTpcPointBacShifted),
+  fCosPointingAngleXi(aXi.fCosPointingAngleXi), fCosPointingAngleV0toXi(aXi.fCosPointingAngleV0toXi), fPhiXi(aXi.fPhiXi), fEtaXi(aXi.fEtaXi), 
   fTPCNclsBac(aXi.fTPCNclsBac), fNdofBac(aXi.fNdofBac), fStatusBac(aXi.fStatusBac), fEtaBac(aXi.fEtaBac), fIdBac(aXi.fIdBac), 
   fBacNSigmaTPCK(aXi.fBacNSigmaTPCK), fBacNSigmaTPCPi(aXi.fBacNSigmaTPCPi), fBacNSigmaTPCP(aXi.fBacNSigmaTPCP),
   fBacNSigmaTOFK(aXi.fBacNSigmaTOFK), fBacNSigmaTOFPi(aXi.fBacNSigmaTOFPi), fBacNSigmaTOFP(aXi.fBacNSigmaTOFP), fTPCMomentumBac(aXi.fTPCMomentumBac),
@@ -81,6 +102,10 @@ AliFemtoXi::AliFemtoXi(const AliFemtoXi& aXi) :
   // copy constructor
   fTopologyMapBachelor[0] = aXi.fTopologyMapBachelor[0];
   fTopologyMapBachelor[1] = aXi.fTopologyMapBachelor[1];
+
+  for (int i = 0; i < 9; i++) {
+    fNominalTpcPointsBac[i] = aXi.fNominalTpcPointsBac[i];
+  }
 
   UpdateXi();
 }
@@ -132,6 +157,9 @@ AliFemtoXi& AliFemtoXi::operator=(const AliFemtoXi& aXi)
   fPtBac = 0;
   fPtotBac = 0; 
   fKeyBac = aXi.fKeyBac;
+  fNominalTpcEntrancePointBac = aXi.fNominalTpcEntrancePointBac;
+  fNominalTpcExitPointBac = aXi.fNominalTpcExitPointBac;
+  fNominalTpcPointBacShifted = aXi.fNominalTpcPointBacShifted;
   fCosPointingAngleXi = aXi.fCosPointingAngleXi;
   fCosPointingAngleV0toXi = aXi.fCosPointingAngleV0toXi;
   fPhiXi = aXi.fPhiXi;
@@ -151,6 +179,11 @@ AliFemtoXi& AliFemtoXi::operator=(const AliFemtoXi& aXi)
   fTOFProtonTimeBac = aXi.fTOFProtonTimeBac;
   fTOFPionTimeBac = aXi.fTOFPionTimeBac;
   fTOFKaonTimeBac = aXi.fTOFKaonTimeBac;
+
+
+  for (int i = 0; i < 9; i++) {
+    fNominalTpcPointsBac[i] = aXi.fNominalTpcPointsBac[i];
+  }
 
   UpdateXi();
 
@@ -187,6 +220,15 @@ void AliFemtoXi::UpdateXi(){
    fRapOmega = 0.5*::log( (EOmega()+fMomXi.z()) / (EOmega()-fMomXi.z()) );// eO,
    fCTauOmega = kMOMEGAMINUS*(fDecayLengthXi) / ::sqrt( ::pow((double)fMomXi.Mag(),2.) );
 }
+
 // -----------------------------------------------------------------------
+AliFemtoThreeVector AliFemtoXi::NominalTpcPointBac(int i) const
+{
+  if (i < 0)
+    return fNominalTpcPointsBac[0];
+  if (i > 8)
+    return fNominalTpcPointsBac[8];
+  return fNominalTpcPointsBac[i];
+}
 
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXi.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXi.h
@@ -59,7 +59,12 @@ public:
   float PtotBac() const ;                 // Total momentum of bac. daughter		     
   float DedxBac() const;                  // dedx of Bac track				     
   unsigned short   IdBac() const;         // Id of bac. track				     
-  unsigned short   KeyBac() const;        // Id of bac. track                                
+  unsigned short   KeyBac() const;        // Id of bac. track    
+
+  AliFemtoThreeVector NominalTpcEntrancePointBac() const;
+  AliFemtoThreeVector NominalTpcPointBac(int i) const;
+  AliFemtoThreeVector NominalTpcExitPointBac() const;        
+  AliFemtoThreeVector NominalTpcPointBacShifted() const;                    
 
   void SetdecayLengthXi(const float x);  
   void SetdecayVertexXi(const AliFemtoThreeVector v);  
@@ -102,7 +107,10 @@ public:
   void SetdedxBac(float x);
   void SetkeyBac(const unsigned short& s);
 
-
+  void SetNominalTpcEntrancePointBac(AliFemtoThreeVector x);
+  void SetNominalTpcPointBac(AliFemtoThreeVector *x);
+  void SetNominalTpcExitPointBac(AliFemtoThreeVector x);
+  void SetNominalTpcPointBacShifted(AliFemtoThreeVector x);
 
   //!!!!!!!!!!! new below 1.09.2015
   void SetCosPointingAngleXi(double x);
@@ -200,6 +208,11 @@ protected:
 
   unsigned short   fKeyBac;   // Key of bac. track
 
+  AliFemtoThreeVector fNominalTpcEntrancePointBac; ///< Nominal bachelor pion track entrance point into TPC
+  AliFemtoThreeVector fNominalTpcPointsBac[9];
+  AliFemtoThreeVector fNominalTpcExitPointBac;     ///< Nominal bachelor pion track exit point from TPC
+  AliFemtoThreeVector fNominalTpcPointBacShifted;     ///< Nominal bachelor pion track at given point from TPC
+
 
   //!!!!!!!!! new below 1.09.2015
   double fCosPointingAngleXi; // Cosine of Xi pointing angle
@@ -272,6 +285,10 @@ inline unsigned long    AliFemtoXi::TrackTopologyMapBac(unsigned int word) const
 inline unsigned short   AliFemtoXi::IdBac() const { return fKeyBac; }
 inline unsigned short   AliFemtoXi::KeyBac() const { return fKeyBac; }
 
+inline AliFemtoThreeVector AliFemtoXi::NominalTpcEntrancePointBac() const {return fNominalTpcEntrancePointBac;}
+inline AliFemtoThreeVector AliFemtoXi::NominalTpcExitPointBac() const {return fNominalTpcExitPointBac;}
+inline AliFemtoThreeVector AliFemtoXi::NominalTpcPointBacShifted() const  {return fNominalTpcPointBacShifted;}
+
 inline void AliFemtoXi::SetdecayLengthXi(const float x){ fDecayLengthXi= x;}   
 inline void AliFemtoXi::SetdecayVertexXiX(const float x){ fDecayVertexXi.SetX(x);}
 inline void AliFemtoXi::SetdecayVertexXiY(const float x){ fDecayVertexXi.SetY(x);}
@@ -310,6 +327,11 @@ inline void AliFemtoXi::SetidBac(const unsigned short& s){ fKeyBac= s;}
 inline void AliFemtoXi::SetkeyBac(const unsigned short& s){ fKeyBac= s;}
 inline void AliFemtoXi::SettpcHitsBac(const int& i){fTpcHitsBac=i;} 
 inline void AliFemtoXi::SetdedxBac(float x){fDedxBachelor=x;}
+
+inline void AliFemtoXi::SetNominalTpcEntrancePointBac(AliFemtoThreeVector x) {fNominalTpcEntrancePointBac=x;}
+inline void AliFemtoXi::SetNominalTpcPointBac(AliFemtoThreeVector *x) {for(int i=0;i<9;i++) fNominalTpcPointsBac[i]=x[i];}
+inline void AliFemtoXi::SetNominalTpcExitPointBac(AliFemtoThreeVector x) {fNominalTpcExitPointBac=x;}
+inline void AliFemtoXi::SetNominalTpcPointBacShifted(AliFemtoThreeVector x) {fNominalTpcPointBacShifted=x;}
 
 //!!!!!!!!! new below 1.09.2015
 inline void AliFemtoXi::SetCosPointingAngleXi(double x) {fCosPointingAngleXi = x;}

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXiTrackPairCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXiTrackPairCut.cxx
@@ -11,17 +11,19 @@
 
 //__________________
 AliFemtoXiTrackPairCut::AliFemtoXiTrackPairCut():
+  fV0TrackPairCut(nullptr),
   fNPairsPassed(0),
   fNPairsFailed(0),
+  fMinAvgSepTrackBacPion(0.),
   fDataType(kAOD),
   fTrackTPCOnly(0)
 {
-  /* no-op */
+  fV0TrackPairCut = new AliFemtoV0TrackPairCut();
 }
 //__________________
 AliFemtoXiTrackPairCut::~AliFemtoXiTrackPairCut()
 {
-  /* no-op */
+  delete fV0TrackPairCut;
 }
 
 AliFemtoXiTrackPairCut &AliFemtoXiTrackPairCut::operator=(const AliFemtoXiTrackPairCut &cut)
@@ -33,8 +35,12 @@ AliFemtoXiTrackPairCut &AliFemtoXiTrackPairCut::operator=(const AliFemtoXiTrackP
   AliFemtoPairCut::operator=(cut);
   fNPairsPassed = cut.fNPairsPassed;
   fNPairsFailed = cut.fNPairsFailed;
+  fMinAvgSepTrackBacPion = cut.fMinAvgSepTrackBacPion;
   fDataType = cut.fDataType;
   fTrackTPCOnly = cut.fTrackTPCOnly;
+
+  if(fV0TrackPairCut) delete fV0TrackPairCut;
+  fV0TrackPairCut = new AliFemtoV0TrackPairCut(*cut.fV0TrackPairCut);
 
   return *this; 
 }
@@ -68,6 +74,49 @@ bool AliFemtoXiTrackPairCut::Pass(const AliFemtoPair *pair)
     return false;
   }
 
+  //Calling tPassV0 = fV0TrackPairCut->Pass(tPair) below will handle the average separation of
+  //the V0 daughters to the track.  So, all that needs to be checked here in the average separation
+  //of the bachelor pion to the track
+  UInt_t bac_point_cnt = 0;
+  Double_t bac_avgSep = 0.0;
+
+  // loop through NominalTpcPoints of the track and bachelor pion
+  for (int i = 0; i < 8; i++) {
+    // Grab references to each of the i'th points
+    const AliFemtoThreeVector &bac_p = Xi->NominalTpcPointBac(i),
+                            &track_p = track->NominalTpcPoint(i);
+
+    // if any track points are outside the boundary - skip
+    if (track_p.x() < -9990.0 || track_p.y() < -9990.0 || track_p.z() < -9990.0) {
+      continue;
+    }
+
+    // If the bachelor pion points are not bad, increment point count and
+    // increase the cumulative average separation
+    if (!(bac_p.x() < -9990.0 || bac_p.y() < -9990.0 || bac_p.z() < -9990.0)) {
+      bac_avgSep += (bac_p - track_p).Mag();
+      bac_point_cnt++;
+    }
+  }
+
+  if (bac_point_cnt == 0 || bac_avgSep / bac_point_cnt < fMinAvgSepTrackBacPion) {
+    fNPairsFailed++;
+    return false;
+  }
+
+
+
+
+  //Make sure it passes AliFemtoV0TrackPairCuts
+  double tLambdaMass = 1.115683;
+  double tPionMass = 0.19357018;
+  AliFemtoPair *tPair = new AliFemtoPair();
+  tPair->SetTrack1(new AliFemtoParticle((AliFemtoV0*)Xi, tLambdaMass));
+  tPair->SetTrack2(new AliFemtoParticle(track, tPionMass));
+  bool tPassV0 = false;
+  tPassV0 = fV0TrackPairCut->Pass(tPair);
+  delete tPair;
+  if(!tPassV0) return false;
 
   return true;
 }

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXiTrackPairCut.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXiTrackPairCut.h
@@ -2,6 +2,15 @@
 #define ALIFEMTOXITRACKPAIRCUT_H
 
 #include "AliFemtoPairCut.h"
+#include "AliFemtoV0TrackPairCut.h"
+
+/// \class AliFemtoXiTrackPairCut
+/// \brief A pair cut used for testing a track and a reconstructed Xi particle
+/// Note:  It will be useful for this class to have access to the methods available
+///        in AliFemtoV0TrackPair cut.  However, at this point, this class will continue
+///        to derive from AliFemtoPair cut, and will contain a AliFemtoV0TrackPairCut object.
+///        In the future, this idea may want to be revisited, and instead having this class
+///        derive directly from AliFemtoV0TrackPairCut may be ideal.
 
 class AliFemtoXiTrackPairCut : public AliFemtoPairCut {
 public:
@@ -17,9 +26,16 @@ public:
   void SetDataType(AliFemtoDataType type);
   void SetTPCOnly(Bool_t tpconly);
 
+  AliFemtoV0TrackPairCut* GetV0TrackPairCut(); //allows one to set fV0TrackPairCut attributes, so no need to explicitly state here
+  void SetMinAvgSepTrackBacPion(double aMin);
+
 protected:
+  AliFemtoV0TrackPairCut* fV0TrackPairCut;
+
   long fNPairsPassed;          ///< Number of pairs consideered that passed the cut
   long fNPairsFailed;          ///< Number of pairs consideered that failed the cut
+
+  double fMinAvgSepTrackBacPion;
 
   AliFemtoDataType fDataType;  ///< Use ESD / AOD / Kinematics.
   Bool_t fTrackTPCOnly;       ///< Track ids will be converted to appropriate TPC/Global value
@@ -33,12 +49,14 @@ protected:
 
 inline AliFemtoXiTrackPairCut::AliFemtoXiTrackPairCut(const AliFemtoXiTrackPairCut &c):
   AliFemtoPairCut(c),
+  fV0TrackPairCut(c.fV0TrackPairCut ? new AliFemtoV0TrackPairCut(*c.fV0TrackPairCut) : nullptr),
   fNPairsPassed(c.fNPairsPassed),
   fNPairsFailed(c.fNPairsFailed),
+  fMinAvgSepTrackBacPion(c.fMinAvgSepTrackBacPion),
   fDataType(c.fDataType),
   fTrackTPCOnly(c.fTrackTPCOnly)
 {
-  /// no-op
+
 }
 
 inline AliFemtoPairCut *AliFemtoXiTrackPairCut::Clone()
@@ -47,5 +65,8 @@ inline AliFemtoPairCut *AliFemtoXiTrackPairCut::Clone()
   // Should we set fNPairsPassed & fNPairsFailed to 0 here? How will Clone() be used?
   return c;
 }
+
+inline AliFemtoV0TrackPairCut* AliFemtoXiTrackPairCut::GetV0TrackPairCut() {return fV0TrackPairCut;}
+inline void AliFemtoXiTrackPairCut::SetMinAvgSepTrackBacPion(double aMin) {fMinAvgSepTrackBacPion = aMin;}
 
 #endif

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoV0PurityBgdEstimator.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoV0PurityBgdEstimator.cxx
@@ -167,6 +167,9 @@ AliFemtoV0PurityBgdEstimator::~AliFemtoV0PurityBgdEstimator()
   delete fNumerator;
   delete fDenominator;
   delete fRatio;
+
+  delete fFemtoV0;
+  delete fFemtoV0TrackCut;
 }
 
 //____________________________


### PR DESCRIPTION
PWGCF:  AliFemtoXi: Included nominal TPC info for bachelor pions.  AliFemtoXiTrackPairCut: began to make more sophisticated pair cuts.  AliFemtoEventReaderAOD: included methods to set the nominal TPC attributes for the bachelor pions