### PR TITLE
Add possibility to cut on nsigma distance between SPD and track vertices

### DIFF
--- a/PWGHF/vertexingHF/AliRDHFCuts.h
+++ b/PWGHF/vertexingHF/AliRDHFCuts.h
@@ -33,7 +33,7 @@ class AliRDHFCuts : public AliAnalysisCuts
   enum ESelLevel {kAll,kTracks,kPID,kCandidate};
   enum EPileup {kNoPileupSelection,kRejectPileupEvent,kRejectTracksFromPileupVertex,kRejectMVPileupEvent};
   enum ESele {kD0toKpiCuts,kD0toKpiPID,kD0fromDstarCuts,kD0fromDstarPID,kDplusCuts,kDplusPID,kDsCuts,kDsPID,kLcCuts,kLcPID,kDstarCuts,kDstarPID,kLctoV0Cuts,kDplustoK0sCuts,kDstoK0sCuts};
-  enum ERejBits {kNotSelTrigger,kNoVertex,kTooFewVtxContrib,kZVtxOutFid,kPileup,kOutsideCentrality,kPhysicsSelection,kBadSPDVertex,kZVtxSPDOutFid,kCentralityFlattening,kBadTrackV0Correl,kMismatchOldNewCentrality};
+  enum ERejBits {kNotSelTrigger,kNoVertex,kTooFewVtxContrib,kZVtxOutFid,kPileup,kOutsideCentrality,kPhysicsSelection,kBadSPDVertex,kZVtxSPDOutFid,kCentralityFlattening,kBadTrackV0Correl,kMismatchOldNewCentrality,kBadTrackVertex};
   enum EV0sel  {kAllV0s = 0, kOnlyOfflineV0s = 1, kOnlyOnTheFlyV0s = 2};
 
   AliRDHFCuts(const Char_t* name="RDHFCuts", const Char_t* title="");
@@ -188,7 +188,7 @@ class AliRDHFCuts : public AliAnalysisCuts
   void SetNotUseCutOnTRKVsV0Centraltity() {fMaxDiffTRKV0Centr=-1.;}
   void SetRemoveTrackletOutliers(Bool_t opt) {fRemoveTrackletOutliers=opt;}
   void SetCutOnzVertexSPD(Int_t opt) {
-    if(opt>=0 && opt<=2) fCutOnzVertexSPD=opt;
+    if(opt>=0 && opt<=3) fCutOnzVertexSPD=opt;
     else AliError("Wrong option for cut on zVertexSPD");
   }
   void SetTriggerClass(TString trclass0, TString trclass1="") {fTriggerClass[0]=trclass0; fTriggerClass[1]=trclass1;} 
@@ -327,6 +327,9 @@ class AliRDHFCuts : public AliAnalysisCuts
   Bool_t IsEventRejectedDueToTRKV0CentralityCorrel() const {
     return fEvRejectionBits&(1<<kBadTrackV0Correl);
   }
+  Bool_t IsEventRejectedDueToBadTrackVertex() const {
+    return fEvRejectionBits&(1<<kBadTrackVertex);
+  }
   Bool_t IsEventRejectedDueToMismatchOldNewCentrality() const {
     return fEvRejectionBits&(1<<kMismatchOldNewCentrality);
   }
@@ -437,7 +440,7 @@ class AliRDHFCuts : public AliAnalysisCuts
   Bool_t fApplySPDMisalignedPP2012; /// flag to apply cut on tracks crossing SPD misaligned modules for PP2012 data
   Double_t fMaxDiffTRKV0Centr;   /// Max. difference between TRK and V0 centrality (remove TPC pileup for PbPb 2011)
   Bool_t fRemoveTrackletOutliers; /// flag to apply cut on tracklets vs. centrality for 2011 data
-  Int_t fCutOnzVertexSPD; /// cut on zSPD vertex to remove outliers in centrality vs. tracklets (0=no cut, 1= cut at 12 cm, 2= cut on difference to z of vtx tracks
+  Int_t fCutOnzVertexSPD; /// cut on zSPD vertex to remove outliers in centrality vs. tracklets (0=no cut, 1= cut at 12 cm, 2= cut on difference to z of vtx tracks, 3=cut on nsigma distance between SPD and track vertices
   Bool_t fKinkReject; /// flag to reject kink daughters
   Bool_t fUseTrackSelectionWithFilterBits; /// flag to enable/disable the check on filter bits
   Bool_t fUseCentrFlatteningInMC; /// flag for enabling/diabling centrality flattening in MC


### PR DESCRIPTION
This modification adds the possibility to reject events with large nsigma difference between SPD and track vertices. It also modified the tagging of events with large distance between the SPD and track vertices, which are now tagged as "bad vertex" and treated in the event normalization counter as events without vertex.