### PR TITLE
Remove efficiency calculation when running in data

### DIFF
--- a/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.cxx
@@ -2019,7 +2019,8 @@ void AliAnalysisTaskHFEpACorrelation::ElectronHadronCorrelation(AliVTrack *track
     Bool_t fLsIsPartner = kFALSE;
     ///#################################################################
     
-    TaggingEfficiencyCalculation(track,&lIsNHFe,&lIsHFe,&lIsOther,&lHasMother);
+    if (fIsMC)
+        TaggingEfficiencyCalculation(track,&lIsNHFe,&lIsHFe,&lIsOther,&lHasMother);
     
     
     if(fNonHFE->IsULS()) fPtElec_ULS->Fill(fPtE,fNonHFE->GetNULS());


### PR DESCRIPTION
I forgot to add the protection in case it is running in data. So the task was crashing in data. 