### PR TITLE
PWGCF: AliFemtoEventReaderAOD: Began work on hidden info for MC Cascades

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.cxx
@@ -1286,7 +1286,7 @@ AliFemtoAvgSepCorrFctn* AliFemtoAnalysisLambdaKaon::CreateAvgSepCorrFctn(const c
 //___________________________________________________________________
 AliFemtoModelCorrFctnKStarFull* AliFemtoAnalysisLambdaKaon::CreateModelCorrFctnKStarFull(const char* name, unsigned int bins, double min, double max)
 {
-  bool tUseWeightGenerator = true;
+  bool tUseWeightGenerator = fAnalysisParams.useMCWeightGenerator;
 
   AliFemtoModelCorrFctnKStarFull *cf = new AliFemtoModelCorrFctnKStarFull(TString::Format("KStarModelCf_%s",name),bins,min,max);
     cf->SetRemoveMisidentified(fAnalysisParams.removeMisidentifiedMCParticles);
@@ -1607,6 +1607,7 @@ AliFemtoAnalysisLambdaKaon::DefaultAnalysisParams()
   tReturnParams.monitorPart1CutPassOnly = false;
   tReturnParams.monitorPart2CutPassOnly = false;
   tReturnParams.monitorPairCutPassOnly = false;
+  tReturnParams.useMCWeightGenerator = false;
 
   return tReturnParams;
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.h
@@ -102,6 +102,7 @@ struct AnalysisParams
   bool monitorPart1CutPassOnly;
   bool monitorPart2CutPassOnly;
   bool monitorPairCutPassOnly;
+  bool useMCWeightGenerator;
 };
 
 struct EventCutParams


### PR DESCRIPTION
PWGCF: AliFemtoEventReaderAOD: Began work on hidden info for MC Cascades.  For now, in the AliFemtoHiddenInfo object, the V0 will be stored as the positive daughter, and the bachelor pion will be stored as the negative daughter.  In the future, either AliFemtoHiddenInfo will be expanded to allow of Xi storage, or a new daughter class will be built.