### PR TITLE
Fixing logics bug in selection of EMCAL triggers

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerBase.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerBase.cxx
@@ -214,7 +214,7 @@ void AliAnalysisTaskEmcalTriggerBase::TriggerSelection(){
       for(int iclass = 0; iclass < AliEmcalTriggerOfflineSelection::kTrgn; iclass++){
         emcalTriggers[iclass] &= bool(selectionstatus & kSelectTriggerBits[iclass]);
         emc8Triggers[iclass] &= bool(selectionstatus & kSelectTriggerBits[iclass]);
-        if(fRequireL0forL1 || !bool(selectionstatus & (AliVEvent::kEMC7|AliVEvent::kEMC8))) {
+        if(fRequireL0forL1 && !bool(selectionstatus & (AliVEvent::kEMC7|AliVEvent::kEMC8))) {
           emcalTriggers[iclass] = false;
           emc8Triggers[iclass] = false;
         }


### PR DESCRIPTION
- Bug was introdued in commit 21e76b1,
  dealing with the preparation for pp 8 TeV
- EMCAL-triggered events were only selected if they
  were at the same time a level0 trigger due to
  incorrect logical or condition