### PR TITLE
Setting SetTMClusterRejection() according to fTMClusterRejected (instead of fixed value), outside and inside the isolation cone

### DIFF
--- a/PWGGA/EMCALTasks/macros/AddTaskEMCALPhotonIsolation.C
+++ b/PWGGA/EMCALTasks/macros/AddTaskEMCALPhotonIsolation.C
@@ -163,6 +163,8 @@ AliAnalysisTaskEMCALPhotonIsolation* AddTaskEMCALPhotonIsolation(
   task->SetLCAnalysis(isLCAnalysis);
   task->SetIsoConeRadius(iIsoConeRadius);
   task->SetEtIsoThreshold(EtIso);
+  task->SetTMClusterRejection(bTMClusterRejection);
+  task->SetTMClusterRejectioninCone(bTMClusterRejectionInCone);
   task->SetCTMdeltaEta(TMdeta);
   task->SetCTMdeltaPhi(TMdphi);
   task->SetCTMdeltaEtaIso(TMdetaIso);


### PR DESCRIPTION
This was previously set in the run macro (or in a wagon) on the current instance of the task. Now the two parameters bTMClusterRejection and bTMClusterRejectionInCone are used directly inside the AddTask.
Calling SetTMClusterRejection()/InCone() in the run macro (or wagon) overwrites this new inside-AddTask setting so that nothing changes for a user who does not change his/her run macro (or wagon).