### PR TITLE
Allow daughters of V0s to pass track cuts

### DIFF
--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx
@@ -1392,7 +1392,7 @@ void AliCEPUtils::InitTrackCuts(Bool_t IsRun1, Int_t clusterCut)
   
   // with selPrimaries=kTRUE tracks associated with V0s are suppressed
   // to study V0s this needs be set to kFALSE
-  Bool_t  selPrimaries = kTRUE;
+  Bool_t  selPrimaries = kFALSE;
   
   // Run2
   if (IsRun1) {


### PR DESCRIPTION
With the old initialisation of GetStandardITSTPCTrackCuts2010 the daughter of V0s did not pass the track selection. With this modification V0 daughters pass the cut.

