### PR TITLE
adding flow harmonic as private member to the AliFlowCommonHist class

### DIFF
--- a/PWG/FLOW/Base/AliFlowAnalysisWithSimpleSP.cxx
+++ b/PWG/FLOW/Base/AliFlowAnalysisWithSimpleSP.cxx
@@ -128,7 +128,7 @@ void AliFlowAnalysisWithSimpleSP::Init() {
     tQARelated->SetName("QA");
     tQARelated->SetOwner();
 
-    fCommonHists = new AliFlowCommonHist("AliFlowCommonHist_SP","AliFlowCommonHist",fMinimalBook);
+    fCommonHists = new AliFlowCommonHist("AliFlowCommonHist_SP","AliFlowCommonHist",fMinimalBook, fHarmonic);
     (fCommonHists->GetHarmonic())->Fill(0.5,fHarmonic); // store harmonic 
     fHistList->Add(fCommonHists);
 

--- a/PWG/FLOW/Base/AliFlowCommonHist.cxx
+++ b/PWG/FLOW/Base/AliFlowCommonHist.cxx
@@ -73,7 +73,8 @@ AliFlowCommonHist::AliFlowCommonHist():
   fRefMultVsNoOfRPs(NULL),
   fHistRefMult(NULL),
   fHistMassPOI(NULL),
-  fHistList(NULL)
+  fHistList(NULL),
+  fHarmonicInt(2)
 {
   
   //default constructor
@@ -110,7 +111,8 @@ AliFlowCommonHist::AliFlowCommonHist(const AliFlowCommonHist& a):
   fRefMultVsNoOfRPs(new TProfile(*a.fRefMultVsNoOfRPs)),
   fHistRefMult(new TH1F(*a.fHistRefMult)),  
   fHistMassPOI(new TH2F(*a.fHistMassPOI)),  
-  fHistList(NULL)
+  fHistList(NULL),
+  fHarmonicInt(a.fHarmonicInt)
 {
   // copy constructor
 
@@ -149,7 +151,7 @@ AliFlowCommonHist::AliFlowCommonHist(const AliFlowCommonHist& a):
 
 //-----------------------------------------------------------------------
 
-  AliFlowCommonHist::AliFlowCommonHist(const char *anInput, const char *title, Bool_t bookOnlyBasic):
+  AliFlowCommonHist::AliFlowCommonHist(const char *anInput, const char *title, Bool_t bookOnlyBasic, Int_t harmonic):
     TNamed(anInput,title),
     fBookOnlyBasic(bookOnlyBasic),
     fHistMultRP(NULL),
@@ -179,7 +181,8 @@ AliFlowCommonHist::AliFlowCommonHist(const AliFlowCommonHist& a):
     fRefMultVsNoOfRPs(NULL),
     fHistRefMult(NULL),
     fHistMassPOI(NULL),
-    fHistList(NULL)
+    fHistList(NULL),
+    fHarmonicInt(harmonic)
 {
 
   //constructor creating histograms 
@@ -564,7 +567,7 @@ Bool_t AliFlowCommonHist::FillControlHistograms(AliFlowEventSimple* anEvent,TLis
 
   
   //fill the histograms
-  AliFlowVector vQ = anEvent->GetQ(2, weightsList, usePhiWeights, usePtWeights, useEtaWeights); 
+  AliFlowVector vQ = anEvent->GetQ(fHarmonicInt, weightsList, usePhiWeights, usePtWeights, useEtaWeights); 
   //weight by the Multiplicity
   Double_t dQX = 0.;
   Double_t dQY = 0.;
@@ -574,14 +577,14 @@ Bool_t AliFlowCommonHist::FillControlHistograms(AliFlowEventSimple* anEvent,TLis
   }
   vQ.Set(dQX,dQY);
   if(!fBookOnlyBasic){fHistQ->Fill(vQ.Mod());}
-  if(!fBookOnlyBasic){fHistAngleQ->Fill(vQ.Phi()/2);}
+  if(!fBookOnlyBasic){fHistAngleQ->Fill(vQ.Phi()/float(fHarmonicInt));}
 
   AliFlowVector* vQSub = new AliFlowVector[2];
-  anEvent->Get2Qsub(vQSub, 2, weightsList, usePhiWeights, usePtWeights, useEtaWeights);
+  anEvent->Get2Qsub(vQSub, fHarmonicInt, weightsList, usePhiWeights, usePtWeights, useEtaWeights);
   AliFlowVector vQa = vQSub[0];
   AliFlowVector vQb = vQSub[1];
-  if(!fBookOnlyBasic){fHistAngleQSub0->Fill(vQa.Phi()/2);}
-  if(!fBookOnlyBasic){fHistAngleQSub1->Fill(vQb.Phi()/2);}
+  if(!fBookOnlyBasic){fHistAngleQSub0->Fill(vQa.Phi()/float(fHarmonicInt));}
+  if(!fBookOnlyBasic){fHistAngleQSub1->Fill(vQb.Phi()/float(fHarmonicInt));}
 
   Double_t dMultRP = 0.;
   Double_t dMultPOI = 0.;

--- a/PWG/FLOW/Base/AliFlowCommonHist.h
+++ b/PWG/FLOW/Base/AliFlowCommonHist.h
@@ -26,7 +26,7 @@ class AliFlowCommonHist: public TNamed {
  public:
 
   AliFlowCommonHist();
-  AliFlowCommonHist(const char *name,const char *title = "AliFlowCommonHist",Bool_t bookOnlyBasic = kFALSE);
+  AliFlowCommonHist(const char *name,const char *title = "AliFlowCommonHist",Bool_t bookOnlyBasic = kFALSE, Int_t harmonic = 2);
   virtual ~AliFlowCommonHist();
   AliFlowCommonHist(const AliFlowCommonHist& aSetOfHists);
 
@@ -114,7 +114,13 @@ class AliFlowCommonHist: public TNamed {
   
   TList*    fHistList;            // list to hold all histograms  
 
-  ClassDef(AliFlowCommonHist,4)   // macro for rootcint
+  // Flow harmonic for 'internal' use (it's also an int, what a coincidence). 
+  // This cannot be set in the cc object as that's a singleton
+  // we can also not rely on the 'GetHarmonic' member of this class itself, because
+  // there is a-priori no reason to assume that it's set, and it has no default value  
+  Int_t     fHarmonicInt;         // flow harmonic (2 by default)
+  
+  ClassDef(AliFlowCommonHist,5)   // macro for rootcint
 };
 #endif
 


### PR DESCRIPTION
The motivation behind these changes is that the AliFlowCommonHist object only stores QA histograms for the 2nd order symmetry axes of events, regardless of the flow harmonic of interest. In the case of event plane calibrations that are harmonic dependent (e.g. the common V0 calibration in the flow event class) the info in these QA plots is therefore not necessarily reliable. This does not affect any results, but it's better to have histograms that make sense in QA output.

The changes are fully backward compatible - as long as you do not change anything in your own code, the behavior of the class does not change. If desired, the harmonic can be set via the constructor of the AliFlowCommonHist class.

If you suspect that code change affects your analysis, please send me a mail. 