### PR TITLE
Updating QA trending macros for ZDC

### DIFF
--- a/PWGPP/ZDC/macros/DrawPerformanceZDCQAMatch.C
+++ b/PWGPP/ZDC/macros/DrawPerformanceZDCQAMatch.C
@@ -26,7 +26,7 @@
 #include <TLegend.h>
 #endif
 
-Int_t DrawPerformanceZDCQAMatch(const char* inFile){
+Int_t DrawPerformanceZDCQAMatch(TString inFile="trending.root"){
 
 // Draw control histograms and generate output pictures
 
@@ -47,17 +47,23 @@ gStyle->SetOptStat(0);
 gStyle->SetTitleSize(0.025);
 TH1::AddDirectory(kFALSE);
 
-TFile * fin = TFile::Open(inFile);
+TFile * fin = TFile::Open(inFile.Data());
+if (!fin){
+  Printf("File not found !!!");
+  return -1;
+}
 TTree * ttree = (TTree*) fin->Get("trending");  //in
+
 TTree * tree = new TTree("tree","tree");        //out (to be summed)
 
 if (!ttree){
   Printf("Invalid trending tree!!!!!!!!!!!!!!");
-  return 2;
+  return -2;
 }
 
-Int_t nRuns=ttree->GetEntries();
+Int_t nRuns = ttree->GetEntries();
 TList list;
+printf(" nRuns %d\n", nRuns);
 
 /*set graphic style*/
 gStyle->SetCanvasColor(kWhite);
@@ -79,7 +85,7 @@ gStyle->SetLabelOffset(0.03,"xyz");
 
 TString plotDir(".");
 
-legend = new TLegend(0.9,0.1,1.0,0.9);
+TLegend *legend = new TLegend(0.9,0.1,1.0,0.9);
 legend->SetFillColor(kWhite);
 
 Int_t runNumber=0;
@@ -140,6 +146,8 @@ ttree->SetBranchAddress("ZN_TDC_Sum_Err",&ZN_TDC_Sum_err);
 ttree->SetBranchAddress("ZN_TDC_Diff_Err",&ZN_TDC_Diff_err);
 //ttree->SetBranchAddress("ZNC_TDC",&ZNC_TDC);
 //ttree->SetBranchAddress("ZNA_TDC",&ZNA_TDC);
+
+printf(" branch addresses set\n");
 
 TH1F *hznc = new TH1F("hznc","ZNC average signal",3,-1,1);
 hznc->GetXaxis()->SetRangeUser(-1.,1.);
@@ -267,7 +275,7 @@ hzna_TDC->SetMarkerStyle(20);
 hzna_TDC->SetMarkerColor(kRed);
 hzna_TDC->SetLineColor(kRed);
 
-char runlabel[10];
+char runlabel[40];
 
 for (Int_t irun=0;irun<nRuns;irun++){
   ttree->GetEntry(irun);
@@ -280,52 +288,58 @@ sprintf(runlabel,"%i",runNumber);
 //----------------------------------------------------------------------
 
 hZNCpmcUncalib = dynamic_cast<TH1F*> (fin->Get("fhZNCpmcUncalib"));
-//hZNCpmc->GetXaxis()->SetRangeUser(0.,2000);
+if(hZNCpmcUncalib){
 if(hZNCpmcUncalib->GetEntries()>0. ) hZNCpmcUncalib->Scale(1./hZNCpmcUncalib->GetEntries());
 hZNCpmcUncalib->SetLineColor(kRed);
 hZNCpmcUncalib->SetLineWidth(2);
 hZNCpmcUncalib->SetTitle("ZNC spectrum");
 hZNCpmcUncalib->SetXTitle("ZNC signal ");
+}
 
 hZNApmcUncalib = dynamic_cast<TH1F*> (fin->Get("fhZNApmcUncalib"));
-//hZNApmc->GetXaxis()->SetRangeUser(0.,2000);
+if(hZNApmcUncalib){
 if(hZNApmcUncalib->GetEntries()>0. ) hZNApmcUncalib->Scale(1./hZNApmcUncalib->GetEntries());
 hZNApmcUncalib->SetLineColor(kRed);
 hZNApmcUncalib->SetLineWidth(2);
 hZNApmcUncalib->SetTitle("ZNA spectrum");
 hZNApmcUncalib->SetXTitle("ZNA signal ");
+}
 
 hZPCpmcUncalib = dynamic_cast<TH1F*> (fin->Get("fhZPCpmcUncalib"));
-//hZPCpmc->GetXaxis()->SetRangeUser(0.,2000);
-if(hZPCpmcUncalib->GetEntries()>0. ) hZPCpmcUncalib->Scale(1./hZPCpmcUncalib->GetEntries());
+if(hZPCpmcUncalib){
+  if(hZPCpmcUncalib->GetEntries()>0. ) hZPCpmcUncalib->Scale(1./hZPCpmcUncalib->GetEntries());
 hZPCpmcUncalib->SetLineColor(kRed);
 hZPCpmcUncalib->SetLineWidth(2);
 hZPCpmcUncalib->SetTitle("ZPC spectrum");
 hZPCpmcUncalib->SetXTitle("ZPC signal ");
+}
 
 hZPApmcUncalib = dynamic_cast<TH1F*> (fin->Get("fhZPApmcUncalib"));
-//hZPApmc->GetXaxis()->SetRangeUser(0.,2000);
+if(hZPApmcUncalib){
 if(hZPApmcUncalib->GetEntries()>0. ) hZPApmcUncalib->Scale(1./hZPApmcUncalib->GetEntries());
 hZPApmcUncalib->SetLineColor(kRed);
 hZPApmcUncalib->SetLineWidth(2);
 hZPApmcUncalib->SetTitle("ZPA spectrum");
 hZPApmcUncalib->SetXTitle("ZPA signal ");
+}
 
 hZEM1 = dynamic_cast<TH1F*> (fin->Get("fhZEM1Spectrum"));
-//hZEM1->GetXaxis()->SetRangeUser(0.,2000);
+if(hZEM1){
 if(hZEM1->GetEntries()>0.) hZEM1->Scale(1./hZEM1->GetEntries());
 hZEM1->SetLineColor(kRed);
 hZEM1->SetLineWidth(2);
 hZEM1->SetTitle("ZEM1 spectrum");
 hZEM1->SetXTitle("ZEM1 signal (ADC ch.)");
+}
 
 hZEM2 = dynamic_cast<TH1F*> (fin->Get("fhZEM2Spectrum"));
-//hZEM2->GetXaxis()->SetRangeUser(0.,2000);
+if(hZEM2){
 if(hZEM2->GetEntries()>0.) hZEM2->Scale(1./hZEM2->GetEntries());
 hZEM2->SetLineColor(kRed);
 hZEM2->SetLineWidth(2);
 hZEM2->SetTitle("ZEM2 spectrum");
 hZEM2->SetXTitle("ZEM2 signal (ADC ch.)");
+}
 
 //----------------------------------------------------------------------
 //variables vs run
@@ -423,39 +437,46 @@ hzna_TDC->GetYaxis()->SetTitle("(ns)");
 //----------------------------------------------------------------------
 
 TCanvas* cZNC_Spectra_Uncal = new TCanvas("cZNC_Spectra_Uncal","cZNC_Spectra_Uncal",0,0,1200,900);
-gPad->SetLogy();
-hZNCpmcUncalib->Draw();
-cZNC_Spectra_Uncal->Print(Form("%s/cZNC_Spectra_Uncal.png",plotDir.Data()));
+if(hZNCpmcUncalib){
+  gPad->SetLogy();
+  hZNCpmcUncalib->Draw();
+  cZNC_Spectra_Uncal->Print(Form("%s/cZNC_Spectra_Uncal.png",plotDir.Data()));
+}
 
 TCanvas* cZNA_Spectra_Uncal = new TCanvas("cZNA_Spectra_Uncal","cZNA_Spectra_Uncal",0,0,1200,900);
+if(hZNApmcUncalib){
 gPad->SetLogy();
 hZNApmcUncalib->Draw();
 cZNA_Spectra_Uncal->Print(Form("%s/cZNA_Spectra_Uncal.png",plotDir.Data()));
+}
 
 TCanvas* cZPC_Spectra_Uncal = new TCanvas("cZPC_Spectra_Uncal","cZPC_Spectra_Uncal",0,0,1200,900);
+if(hZPCpmcUncalib){
 gPad->SetLogy();
 hZPCpmcUncalib->Draw();
 cZPC_Spectra_Uncal->Print(Form("%s/cZPC_Spectra_Uncal.png",plotDir.Data()));
+}
 
 TCanvas* cZPA_Spectra_Uncal = new TCanvas("cZPA_Spectra_Uncal","cZPA_Spectra_Uncal",0,0,1200,900);
+if(hZPApmcUncalib){
 gPad->SetLogy();
 hZPApmcUncalib->Draw();
 cZPA_Spectra_Uncal->Print(Form("%s/cZPA_Spectra_Uncal.png",plotDir.Data()));
+}
 
 TCanvas* cZEM1_Spectra = new TCanvas("cZEM1_Spectra","cZEM1_Spectra",0,0,1200,900);
+if(hZEM1){
 gPad->SetLogy();
 hZEM1->Draw();
 cZEM1_Spectra->Print(Form("%s/cZEM1_Spectra.png",plotDir.Data()));
+}
 
 TCanvas* cZEM2_Spectra = new TCanvas("cZEM2_Spectra","cZEM2_Spectra",0,0,1200,900);
+if(hZEM2){
 gPad->SetLogy();
 hZEM2->Draw();
 cZEM2_Spectra->Print(Form("%s/cZEM2_Spectra.png",plotDir.Data()));
-
-
-//---------------------------------------------------------------------------------------------------
-//variables
-//---------------------------------------------------------------------------------------------------
+}
 
 //---------------------------------------------------------------------------------------------------
 //means
@@ -533,6 +554,7 @@ cTimingDiff->Print(Form("%s/cTimingDiff.png",plotDir.Data()));
 //----------------------------------------------------------------------
 //out
 //----------------------------------------------------------------------
+printf(" preparing output tree\n");
 tree->Branch("run",&runNumber,"runNumber/I");
 tree->Branch("ZNC_mean_value",&ZNC_mean,"ZNC_mean/D");
 tree->Branch("ZNA_mean_value",&ZNA_mean,"ZNA_mean/D");
@@ -558,10 +580,10 @@ tree->Branch("ZN_TDC_Sum_Err",&ZN_TDC_Sum_err,"ZN_TDC_Sum_err/D");
 tree->Branch("ZN_TDC_Diff_Err",&ZN_TDC_Diff_err,"ZN_TDC_Diff_err/D");
 tree->Fill();
 
-list.Add(cZNC_Spectra_Uncal);
-list.Add(cZNA_Spectra_Uncal);
-list.Add(cZPC_Spectra_Uncal);
-list.Add(cZPA_Spectra_Uncal);
+if(hZNCpmcUncalib) list.Add(cZNC_Spectra_Uncal);
+if(hZNApmcUncalib) list.Add(cZNA_Spectra_Uncal);
+if(hZPCpmcUncalib) list.Add(cZPC_Spectra_Uncal);
+if(hZPApmcUncalib) list.Add(cZPA_Spectra_Uncal);
 list.Add(cZEM1_Spectra);
 list.Add(cZEM2_Spectra);
 list.Add(cTimingSum);

--- a/PWGPP/ZDC/macros/DrawPerformanceZDCQAMatchTrends.C
+++ b/PWGPP/ZDC/macros/DrawPerformanceZDCQAMatchTrends.C
@@ -28,6 +28,8 @@
 #include "TStatToolkit.h"
 #endif
 
+#include "TStatToolkit.h"
+
 TTree *tree;
 
 void DrawPerformanceZDCQAMatchTrends(const char* inFile = "prodQAhistos.root"){
@@ -114,7 +116,7 @@ tree->SetBranchAddress("ZN_TDC_Sum_Err",&ZN_TDC_Sum_err);
 tree->SetBranchAddress("ZN_TDC_Diff_Err",&ZN_TDC_Diff_err);
 
   Int_t offset_signals=50;
-  Int_t offset_centroids=1.5;
+  Float_t offset_centroids=1.5;
   Int_t offset_tdc=6;
 
   //create plots of trending variables as a function of the run
@@ -135,12 +137,12 @@ tree->SetBranchAddress("ZN_TDC_Diff_Err",&ZN_TDC_Diff_err);
   TGraphErrors *gr_zntdcsum = (TGraphErrors*) TStatToolkit::MakeGraphSparse(tree,"ZN_TDC_Sum:run","",20,kPink,1.2);
   TGraphErrors *gr_zntdcdiff = (TGraphErrors*) TStatToolkit::MakeGraphSparse(tree,"ZN_TDC_Diff:run","",20,kBlue+3,1.2);
 
-  Double_t ZNC_mean=0;   Double_t ZNC_tot=0;    Double_t ZNC_avg=0;
-  Double_t ZNA_mean=0;   Double_t ZNA_tot=0;    Double_t ZNA_avg=0;
-  Double_t ZPC_mean=0;   Double_t ZPC_tot=0;    Double_t ZPC_avg=0;
-  Double_t ZPA_mean=0;   Double_t ZPA_tot=0;    Double_t ZPA_avg=0;
-  Double_t ZEM1_mean=0;  Double_t ZEM1_tot=0;   Double_t ZEM1_avg=0;
-  Double_t ZEM2_mean=0;  Double_t ZEM2_tot=0;   Double_t ZEM2_avg=0;
+  Double_t ZNC_tot=0;    Double_t ZNC_avg=0;
+  Double_t ZNA_tot=0;    Double_t ZNA_avg=0;
+  Double_t ZPC_tot=0;    Double_t ZPC_avg=0;
+  Double_t ZPA_tot=0;    Double_t ZPA_avg=0;
+  Double_t ZEM1_tot=0;   Double_t ZEM1_avg=0;
+  Double_t ZEM2_tot=0;   Double_t ZEM2_avg=0;
   Double_t ZNC_mean_uncal=0;   Double_t ZNC_uncal_tot=0;    Double_t ZNC_uncal_avg=0;
   Double_t ZNA_mean_uncal=0;   Double_t ZNA_uncal_tot=0;    Double_t ZNA_uncal_avg=0;
   Double_t ZPC_mean_uncal=0;   Double_t ZPC_uncal_tot=0;    Double_t ZPC_uncal_avg=0;

--- a/PWGPP/ZDC/macros/MakeTrendZDC.C
+++ b/PWGPP/ZDC/macros/MakeTrendZDC.C
@@ -24,7 +24,7 @@
 #include <TGaxis.h>
 #endif
 
-int MakeTrendZDC(char *infile, int run) {
+int MakeTrendZDC(TString infile, int run) {
 
   TStopwatch timer;
   timer.Start();
@@ -39,14 +39,14 @@ int MakeTrendZDC(char *infile, int run) {
   gSystem->Load("libTender");
   gSystem->Load("libPWGPP");
 
-  char *outfile = "trending.root";
+  TString outfile = "trending.root";
 
-  if (!infile) return -1;
-  if (!outfile) return -1;
+  //if(!infile) return -1;
+  //if(!outfile) return -1;
   TFile *f =0;
   f=TFile::Open(infile,"read");
-  if (!f) {
-    printf("File %s not available\n", infile);
+  if(!f) {
+    printf("File %s not available\n", infile.Data());
     return -1;
   }
 
@@ -55,14 +55,17 @@ int MakeTrendZDC(char *infile, int run) {
   char genListName[20]="QAZDCHists";
 
   TDirectoryFile * zdcQAdir=(TDirectoryFile*)f->Get(zdcQAdirName);
-  if (!zdcQAdir) {
+  if(!zdcQAdir) {
     Printf("ERROR: ZDC QA directory not present in input file.\n");
     return -1;
   }
 
   TList * generalList=(TList*)zdcQAdir->Get(genListName);
 
-  if (!generalList) Printf("WARNING: general QA histograms absent or not accessible\n");
+  if(!generalList){
+     Printf("WARNING: general QA histograms absent or not accessible\n");
+     return -1;
+  }
 
   TH1D    *fhTDCZNC           = (TH1D*)generalList->FindObject("fhTDCZNC");       //! TDC ZNC sum
   TH1D    *fhTDCZNA           = (TH1D*)generalList->FindObject("fhTDCZNA");       //! TDC DIFF sum
@@ -99,16 +102,16 @@ int MakeTrendZDC(char *infile, int run) {
   Double_t ZEM1_mean = 0.;
   Double_t ZEM2_mean = 0.;
 
-  if (fhZNCpmc->GetEntries()>0) ZNC_mean = fhZNCpmc->GetMean();
-  if (fhZNApmc->GetEntries()>0) ZNA_mean = fhZNApmc->GetMean();
-  if (fhZPCpmc->GetEntries()>0) ZPC_mean = fhZPCpmc->GetMean();
-  if (fhZPApmc->GetEntries()>0) ZPA_mean = fhZPApmc->GetMean();
-  if (fhZNCpmcUncalib->GetEntries()>0) ZNCuncalib_mean = fhZNCpmcUncalib->GetMean();
-  if (fhZPCpmcUncalib->GetEntries()>0) ZPCuncalib_mean = fhZPCpmcUncalib->GetMean();
-  if (fhZNApmcUncalib->GetEntries()>0) ZNAuncalib_mean = fhZNApmcUncalib->GetMean();
-  if (fhZPApmcUncalib->GetEntries()>0) ZPAuncalib_mean = fhZPApmcUncalib->GetMean();
-  if (fhZEM1Spectrum->GetEntries()>0) ZEM1_mean = fhZEM1Spectrum->GetMean();
-  if (fhZEM2Spectrum->GetEntries()>0) ZEM2_mean = fhZEM2Spectrum->GetMean();
+  if(fhZNCpmc && fhZNCpmc->GetEntries()>0) ZNC_mean = fhZNCpmc->GetMean();
+  if(fhZNApmc && fhZNApmc->GetEntries()>0) ZNA_mean = fhZNApmc->GetMean();
+  if(fhZPCpmc && fhZPCpmc->GetEntries()>0) ZPC_mean = fhZPCpmc->GetMean();
+  if(fhZPApmc && fhZPApmc->GetEntries()>0) ZPA_mean = fhZPApmc->GetMean();
+  if(fhZNCpmcUncalib && fhZNCpmcUncalib->GetEntries()>0) ZNCuncalib_mean = fhZNCpmcUncalib->GetMean();
+  if(fhZPCpmcUncalib && fhZPCpmcUncalib->GetEntries()>0) ZPCuncalib_mean = fhZPCpmcUncalib->GetMean();
+  if(fhZNApmcUncalib && fhZNApmcUncalib->GetEntries()>0) ZNAuncalib_mean = fhZNApmcUncalib->GetMean();
+  if(fhZPApmcUncalib && fhZPApmcUncalib->GetEntries()>0) ZPAuncalib_mean = fhZPApmcUncalib->GetMean();
+  if(fhZEM1Spectrum && fhZEM1Spectrum->GetEntries()>0) ZEM1_mean = fhZEM1Spectrum->GetMean();
+  if(fhZEM2Spectrum && fhZEM2Spectrum->GetEntries()>0) ZEM2_mean = fhZEM2Spectrum->GetMean();
 
   Double_t ZNC_XCent = fhZNCCentroid ? fhZNCCentroid->GetMean(1) : 0.;
   Double_t ZNC_YCent = fhZNCCentroid ? fhZNCCentroid->GetMean(2) : 0.;
@@ -153,29 +156,29 @@ int MakeTrendZDC(char *infile, int run) {
   ttree->Branch("ZNA_TDC",&ZNA_TDC,"ZNA_TDC/D");
 
   Printf(":::: Getting post-analysis info for run %i",run);
-  TFile * trendFile = new TFile(outfile,"recreate");
+  TFile * trendFile = new TFile(outfile.Data(),"recreate");
 
   printf("==============  Saving histograms for run %i ===============\n",run);
 
-  if (fhZEM1Spectrum) fhZEM1Spectrum->Write();
-  if (fhZEM2Spectrum) fhZEM2Spectrum->Write();
-  if (fhZNCpmc) fhZNCpmc->Write();
-  if (fhZNApmc) fhZNApmc->Write();
-  if (fhZPCpmc) fhZPCpmc->Write();
-  if (fhZPApmc) fhZPApmc->Write();
-  if (fhZNCpmcUncalib) fhZNCpmcUncalib->Write();
-  if (fhZNApmcUncalib) fhZNApmcUncalib->Write();
-  if (fhZPCpmcUncalib) fhZPCpmcUncalib->Write();
-  if (fhZPApmcUncalib) fhZPApmcUncalib->Write();
-  if (fhZNCCentroid) fhZNCCentroid->Write();
-  if (fhZNACentroid) fhZNACentroid->Write();
-  if (fhPMCZNCemd) fhPMCZNCemd->Write();
-  if (fhPMCZNAemd) fhPMCZNAemd->Write();
-  if (fDebunch) fDebunch->Write();
-  if (fhTDCZNA) fhTDCZNA->Write();
-  if (fhTDCZNC) fhTDCZNC->Write();
-  if (fhTDCZNSum) fhTDCZNSum->Write();
-  if (fhTDCZNDiff) fhTDCZNDiff->Write();
+  if(fhZEM1Spectrum) fhZEM1Spectrum->Write();
+  if(fhZEM2Spectrum) fhZEM2Spectrum->Write();
+  if(fhZNCpmc) fhZNCpmc->Write();
+  if(fhZNApmc) fhZNApmc->Write();
+  if(fhZPCpmc) fhZPCpmc->Write();
+  if(fhZPApmc) fhZPApmc->Write();
+  if(fhZNCpmcUncalib) fhZNCpmcUncalib->Write();
+  if(fhZNApmcUncalib) fhZNApmcUncalib->Write();
+  if(fhZPCpmcUncalib) fhZPCpmcUncalib->Write();
+  if(fhZPApmcUncalib) fhZPApmcUncalib->Write();
+  if(fhZNCCentroid) fhZNCCentroid->Write();
+  if(fhZNACentroid) fhZNACentroid->Write();
+  if(fhPMCZNCemd) fhPMCZNCemd->Write();
+  if(fhPMCZNAemd) fhPMCZNAemd->Write();
+  if(fDebunch) fDebunch->Write();
+  if(fhTDCZNA) fhTDCZNA->Write();
+  if(fhTDCZNC) fhTDCZNC->Write();
+  if(fhTDCZNSum) fhTDCZNSum->Write();
+  if(fhTDCZNDiff) fhTDCZNDiff->Write();
 
   ttree->Fill();
   printf("==============  Saving trending quantities in tree for run %i ===============\n",run);


### PR DESCRIPTION
This commit contains the fixes for few problems related to the fact that the ZDC offline QA histograms were changed but not synchronized with the trending tools.