### PR TITLE
Fix EMCAL cell multiplicity calculation

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalClustersRef.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalClustersRef.cxx
@@ -391,7 +391,7 @@ int AliAnalysisTaskEmcalClustersRef::GetEMCALCellOccupancy(double ecut){
   for(short icell = 0; icell < emccells->GetNumberOfCells(); icell++){
     if(emccells->GetAmplitude(icell) > ecut){
       int cellID = emccells->GetCellNumber(icell);
-      if(cellIDs.find(cellID) != cellIDs.end()) cellIDs.insert(cellID);
+      if(cellIDs.find(cellID) == cellIDs.end()) cellIDs.insert(cellID);
     }
   }
   return cellIDs.size();


### PR DESCRIPTION
Usage of operator!= for finding the cell ID in set prevented
any cell from being selected.