### PR TITLE
Added methods in CEPEventBuffer to retrieve PFB[B,G]Flags[V0,AD]

### DIFF
--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx
@@ -818,7 +818,7 @@ Int_t AliCEPUtils::AnalyzeTracks(AliESDEvent* fESDEvent,
     trackstat = AliCEPBase::kTTBaseLine;
     
     // TOFBunchCrossing
-    if (track->GetTOFBunchCrossing() ==0) ;
+    if (track->GetTOFBunchCrossing() == 0) ;
       trackstat |=  AliCEPBase::kTTTOFBunchCrossing;
 
     // number of TPC shared clusters <= fTPCnclsS(3)    
@@ -1419,7 +1419,6 @@ void AliCEPUtils::InitTrackCuts(Bool_t IsRun1, Int_t clusterCut)
   
     // ITS+TPC
 		AliESDtrackCuts *fcutITSTPC_P = new AliESDtrackCuts;
-    //fcutITSTPC_P->SetClusterRequirementITS(AliESDtrackCuts::kSPD,AliESDtrackCuts::kOff);
 		fcutITSTPC_P -> SetRequireTPCRefit(kTRUE);
 		fcutITSTPC_P -> SetAcceptKinkDaughters(kFALSE);
 
@@ -1430,15 +1429,14 @@ void AliCEPUtils::InitTrackCuts(Bool_t IsRun1, Int_t clusterCut)
     
 		fcutITSTPC_P -> SetRequireITSRefit(kTRUE);
 		fcutITSTPC_P -> SetClusterRequirementITS(AliESDtrackCuts::kSPD,AliESDtrackCuts::kAny);
-		fcutITSTPC_P -> SetMaxChi2PerClusterITS(36);
     
     if (selPrimaries) {
 		  fcutITSTPC_P -> SetMaxDCAToVertexXYPtDep("(0.0182+0.0350/pt^1.01)");
 		  fcutITSTPC_P -> SetMaxChi2TPCConstrainedGlobal(36);
     }
 		
+		fcutITSTPC_P -> SetMaxChi2PerClusterITS(36);
     fcutITSTPC_P -> SetMaxDCAToVertexZ(maxdcazITSTPC);
-    
 		fcutITSTPC_P -> SetEtaRange(-2.0,2.0);
 		fcutITSTPC_P -> SetPtRange(0.15);
     

--- a/PWGUD/DIFFRACTIVE/CEPdevel/CEPEventBuffer.h
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/CEPEventBuffer.h
@@ -106,6 +106,10 @@ class CEPEventBuffer : public TObject {
     Int_t GetCollissionType()const { return fCollissionType; }
     Double_t GetMagnField()  const { return fMagnField; }
     TString GetFiredTriggerClasses() const { return fFiredTriggerClasses; }
+    Bool_t* GetPFBBFlagV0() { return fPFBBFlagV0; }
+    Bool_t* GetPFBGFlagV0() { return fPFBGFlagV0; }
+    Bool_t* GetPFBBFlagAD() { return fPFBBFlagAD; }
+    Bool_t* GetPFBGFlagAD() { return fPFBGFlagAD; }
 
     // different ways of retrieving number of tracks
     Int_t GetnTracksTotal()  const { return fnTracksTotal; }


### PR DESCRIPTION
These changes provide methods to retrieve the past-future protection flags of V0 and AD