### PR TITLE
EMCal Embed: MC outliers removal, store rejection reasons

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
@@ -64,7 +64,7 @@ AliAnalysisTaskEmcalEmbeddingHelper::AliAnalysisTaskEmcalEmbeddingHelper() :
   fTreeName(),
   fAnchorRun(169838),
   fPtHardBin(-1),
-  fNPtHardBins(0),
+  fNPtHardBins(1),
   fRandomEventNumberAccess(kFALSE),
   fRandomFileAccess(kTRUE),
   fFilePattern(""),
@@ -118,7 +118,7 @@ AliAnalysisTaskEmcalEmbeddingHelper::AliAnalysisTaskEmcalEmbeddingHelper(const c
   fTreeName("aodTree"),
   fAnchorRun(169838),
   fPtHardBin(-1),
-  fNPtHardBins(0),
+  fNPtHardBins(1),
   fRandomEventNumberAccess(kFALSE),
   fRandomFileAccess(kTRUE),
   fFilePattern(""),
@@ -564,11 +564,11 @@ Bool_t AliAnalysisTaskEmcalEmbeddingHelper::CheckIsEmbeddedEventSelected()
     UInt_t res = 0;
     const AliESDEvent *eev = dynamic_cast<const AliESDEvent*>(InputEvent());
     if (eev) {
-      res = ((AliInputEventHandler*)(AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler()))->IsEventSelected();
+      res = (dynamic_cast<AliInputEventHandler*>(AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler()))->IsEventSelected();
     } else {
       const AliAODEvent *aev = dynamic_cast<const AliAODEvent*>(InputEvent());
       if (aev) {
-        res = ((AliVAODHeader*)aev->GetHeader())->GetOfflineTrigger();
+        res = (dynamic_cast<AliVAODHeader*>(aev->GetHeader()))->GetOfflineTrigger();
       }
     }
 
@@ -671,12 +671,12 @@ void AliAnalysisTaskEmcalEmbeddingHelper::UserCreateOutputObjects()
   // Cross section
   histName = "fHistXsection";
   histTitle = "Pythia Cross Section;p_{T} hard bin; XSection";
-  fHistManager.CreateTProfile(histName, histTitle, fNPtHardBins + 1, -1, fNPtHardBins);
+  fHistManager.CreateTProfile(histName, histTitle, fNPtHardBins, 0, fNPtHardBins);
 
   // Trials
   histName = "fHistTrials";
   histTitle = "Number of Pythia Trials;p_{T} hard bin;Trials";
-  fHistManager.CreateTH1(histName, histTitle, fNPtHardBins + 1, -1, fNPtHardBins);
+  fHistManager.CreateTH1(histName, histTitle, fNPtHardBins, 0, fNPtHardBins);
 
   // Pt hard spectra
   histName = "fHistPtHard";

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
@@ -180,7 +180,7 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   void            SetEmbeddedEventProperties();
   void            RecordEmbeddedEventProperties();
   Bool_t          IsEventSelected()     ;
-  Bool_t          CheckIsEmbeddedEventIsSelected();
+  Bool_t          CheckIsEmbeddedEventSelected();
   Bool_t          InitEvent()           ;
   void            InitTree()            ;
   bool            PythiaInfoFromCrossSectionFile(std::string filename);

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
@@ -136,10 +136,14 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
    * @name Options for the embedded event
    */
   UInt_t GetTriggerMask()                                   const { return fTriggerMask; }
+  bool GetMCRejectOutliers()                                const { return fMCRejectOutliers; }
+  Double_t GetPtHardJetPtRejectionFactor()                  const { return fPtHardJetPtRejectionFactor; }
   Double_t GetZVertexCut()                                  const { return fZVertexCut; }
   Double_t GetMaxVertexDistance()                           const { return fMaxVertexDist; }
 
   void SetTriggerMask(UInt_t triggerMask)                         { fTriggerMask = triggerMask; }
+  void SetMCRejectOutliers(bool reject = true)                    { fMCRejectOutliers = reject; }
+  void SetPtHardJetPtRejectionFactor(double factor)               { fPtHardJetPtRejectionFactor = factor; }
   void SetZVertexCut(Double_t zVertex)                            { fZVertexCut = zVertex; }
   void SetMaxVertexDistance(Double_t distance)                    { fMaxVertexDist = distance; }
   /* @} */
@@ -186,6 +190,8 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   bool            PythiaInfoFromCrossSectionFile(std::string filename);
 
   UInt_t                                        fTriggerMask;       ///<  Trigger selection mask
+  bool                                          fMCRejectOutliers;  ///<  If true, MC outliers will be rejected
+  Double_t                                      fPtHardJetPtRejectionFactor; ///<  Factor which the pt hard bin is multiplied by to compare against pythia header jets pt
   Double_t                                      fZVertexCut;        ///<  Z vertex cut on embedded event
   Double_t                                      fMaxVertexDist;     ///<  Max distance between Z vertex of internal and embedded event
 
@@ -235,7 +241,7 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   AliAnalysisTaskEmcalEmbeddingHelper &operator=(const AliAnalysisTaskEmcalEmbeddingHelper&); // not implemented
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskEmcalEmbeddingHelper, 3);
+  ClassDef(AliAnalysisTaskEmcalEmbeddingHelper, 4);
   /// \endcond
 };
 #endif

--- a/PWG/EMCAL/EMCALbase/AliEmcalEmbeddingQA.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalEmbeddingQA.cxx
@@ -51,12 +51,12 @@ bool AliEmcalEmbeddingQA::Initialize()
   // Cross section
   histName = "fHistXsectionAfterSel";
   histTitle = "Pythia Cross Section After Event Selection;p_{T} hard bin; XSection";
-  fHistManager.CreateTProfile(histName, histTitle, nPtHardBins + 1, -1, nPtHardBins);
+  fHistManager.CreateTProfile(histName, histTitle, nPtHardBins, 0, nPtHardBins);
 
   // Trials
   histName = "fHistTrialsAfterSel";
   histTitle = "Number of Pythia Trials After Event Selecdtion;p_{T} hard bin;Trials";
-  fHistManager.CreateTH1(histName, histTitle, nPtHardBins + 1, -1, nPtHardBins);
+  fHistManager.CreateTH1(histName, histTitle, nPtHardBins, 0, nPtHardBins);
 
   // Pt hard spectra
   histName = "fHistPtHardAfterSel";


### PR DESCRIPTION
Includes:
- Ability to remove outliers based on jets in the pythia header and the pt hard
- Rejection reason histogram to clarify why events were rejected
- Update pt hard binning of histograms to match up with other tasks (the extra bin was unnecessary)