### PR TITLE
PWGCF: AliFemtoV0TrackCut:  Switch to ignore on-fly-status value of the V0

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoV0TrackCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoV0TrackCut.cxx
@@ -69,7 +69,8 @@ AliFemtoV0TrackCut::AliFemtoV0TrackCut():
   fInvMassRejectAntiLambdaMax(0.0),
   fK0sMassOfMisIDV0(0),
   fLambdaMassOfMisIDV0(0),
-  fAntiLambdaMassOfMisIDV0(0)
+  fAntiLambdaMassOfMisIDV0(0),
+  fIgnoreOnFlyStatus(false)
 
 {
   // Default constructor
@@ -141,7 +142,8 @@ AliFemtoV0TrackCut::AliFemtoV0TrackCut(const AliFemtoV0TrackCut& aCut) :
   fInvMassRejectLambdaMin(aCut.fInvMassRejectLambdaMin),
   fInvMassRejectLambdaMax(aCut.fInvMassRejectLambdaMax),
   fInvMassRejectAntiLambdaMin(aCut.fInvMassRejectAntiLambdaMin),
-  fInvMassRejectAntiLambdaMax(aCut.fInvMassRejectAntiLambdaMax)
+  fInvMassRejectAntiLambdaMax(aCut.fInvMassRejectAntiLambdaMax),
+  fIgnoreOnFlyStatus(aCut.fIgnoreOnFlyStatus)
 {
   //copy constructor
   if(aCut.fMinvPurityAidHistoV0) fMinvPurityAidHistoV0 = new TH1D(*aCut.fMinvPurityAidHistoV0);
@@ -230,6 +232,8 @@ AliFemtoV0TrackCut& AliFemtoV0TrackCut::operator=(const AliFemtoV0TrackCut& aCut
   if(aCut.fAntiLambdaMassOfMisIDV0) fAntiLambdaMassOfMisIDV0 = new TH1D(*aCut.fAntiLambdaMassOfMisIDV0);
     else fAntiLambdaMassOfMisIDV0 = 0;
 
+  fIgnoreOnFlyStatus = aCut.fIgnoreOnFlyStatus;
+
   return *this;
 }
 
@@ -286,7 +290,7 @@ bool AliFemtoV0TrackCut::Pass(const AliFemtoV0* aV0)
 
 
   //quality cuts
-  if (aV0->OnFlyStatusV0() != fOnFlyStatus) return false;
+  if(!fIgnoreOnFlyStatus) {if (aV0->OnFlyStatusV0() != fOnFlyStatus) return false;}
   if (aV0->StatusNeg() == 999 || aV0->StatusPos() == 999) return false;
   if (aV0->TPCNclsPos() < fTPCNclsDaughters) return false;
   if (aV0->TPCNclsNeg() < fTPCNclsDaughters) return false;

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoV0TrackCut.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoV0TrackCut.h
@@ -116,6 +116,8 @@ public:
 
   bool GetBuildMisIDHistograms();
 
+  void SetIgnoreOnFlyStatus(bool aIgnore);
+
  protected:   // here are the quantities I want to cut on...
 
   double fInvMassLambdaMin;        ///< invariant mass Lambda min
@@ -189,7 +191,9 @@ public:
   TH1D *fLambdaMassOfMisIDV0;          // Mass assuming Lambda hypothesis for V0s rejected by misidentification cut
   TH1D *fAntiLambdaMassOfMisIDV0;      // Mass assuming AntiLambda hypothesis for V0s rejected by misidentification cut
 
-
+  bool fIgnoreOnFlyStatus;  //This will accept V0s with aV0->OnFlyStatusV0()==true and aV0->OnFlyStatusV0()==false
+                            //NOTE IMPORTANT: If you set this to true, be sure to call AliFemtoSimpleAnalysis::SetV0SharedDaughterCut(true)
+                            //otherwise, in many cases, you will receive multiple copies of the same V0.
 
 #ifdef __ROOT__
   /// \cond CLASSIMP
@@ -201,5 +205,6 @@ public:
 
 inline TH1D* AliFemtoV0TrackCut::GetMinvPurityAidHistoV0() {return fMinvPurityAidHistoV0;}
 inline bool AliFemtoV0TrackCut::GetBuildMisIDHistograms() {return fBuildMisIDHistograms;}
+inline void AliFemtoV0TrackCut::SetIgnoreOnFlyStatus(bool aIgnore) {fIgnoreOnFlyStatus = aIgnore;}
 
 #endif

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.cxx
@@ -1064,6 +1064,7 @@ AliFemtoXiTrackCutNSigmaFilter* AliFemtoAnalysisLambdaKaon::CreateXiCut(XiCutPar
   tXiCut->SetEta(aCutParams.etaV0);
   tXiCut->SetPt(aCutParams.minPtV0,aCutParams.maxPtV0);
   tXiCut->SetOnFlyStatus(aCutParams.onFlyStatusV0);
+  tXiCut->SetIgnoreOnFlyStatus(aCutParams.ignoreOnFlyStatusV0);
   tXiCut->SetMaxV0DecayLength(aCutParams.maxV0DecayLength);
     //Lambda daughter cuts
     tXiCut->SetMinDaughtersToPrimVertex(aCutParams.minV0PosDaughterToPrimVertex,aCutParams.minV0NegDaughterToPrimVertex);
@@ -1929,14 +1930,14 @@ AliFemtoAnalysisLambdaKaon::DefaultXiCutParams()
   tReturnParams.maxDcaXi = 0.3;
   tReturnParams.maxDcaXiDaughters = 0.3;
 
-  tReturnParams.minDcaXiBac = 0.03;
+  tReturnParams.minDcaXiBac = 0.1;
   tReturnParams.etaBac = 0.8;
   tReturnParams.minTPCnclsBac = 70;
   tReturnParams.minPtBac = 0.;
   tReturnParams.maxPtBac = 100.;
 
   tReturnParams.v0Type = 0;
-  tReturnParams.minDcaV0 = 0.1;
+  tReturnParams.minDcaV0 = 0.2;
   tReturnParams.minInvMassV0 = LambdaMass-0.005;
   tReturnParams.maxInvMassV0 = LambdaMass+0.005;
   tReturnParams.minCosPointingAngleV0 = 0.;  //TODO was 0.998, might need to revert back
@@ -1961,6 +1962,8 @@ AliFemtoAnalysisLambdaKaon::DefaultXiCutParams()
   tReturnParams.useCustomV0MisID = true;
   tReturnParams.useCustomBacPionFilter = true;
   tReturnParams.useCustomBacPionMisID = false;
+
+  tReturnParams.ignoreOnFlyStatusV0 = false;
 
   return tReturnParams;
 }
@@ -1989,14 +1992,14 @@ AliFemtoAnalysisLambdaKaon::DefaultAXiCutParams()
   tReturnParams.maxDcaXi = 0.3;
   tReturnParams.maxDcaXiDaughters = 0.3;
 
-  tReturnParams.minDcaXiBac = 0.03;
+  tReturnParams.minDcaXiBac = 0.1;
   tReturnParams.etaBac = 0.8;
   tReturnParams.minTPCnclsBac = 70;
   tReturnParams.minPtBac = 0.;
   tReturnParams.maxPtBac = 100.;
 
   tReturnParams.v0Type = 1;
-  tReturnParams.minDcaV0 = 0.1;
+  tReturnParams.minDcaV0 = 0.2;
   tReturnParams.minInvMassV0 = LambdaMass-0.005;
   tReturnParams.maxInvMassV0 = LambdaMass+0.005;
   tReturnParams.minCosPointingAngleV0 = 0.;  //TODO was 0.998, might need to revert back
@@ -2021,6 +2024,8 @@ AliFemtoAnalysisLambdaKaon::DefaultAXiCutParams()
   tReturnParams.useCustomV0MisID = true;
   tReturnParams.useCustomBacPionFilter = false;
   tReturnParams.useCustomBacPionMisID = false;
+
+  tReturnParams.ignoreOnFlyStatusV0 = false;
 
   return tReturnParams;
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.h
@@ -256,6 +256,8 @@ struct XiCutParams
   bool useCustomV0MisID;
   bool useCustomBacPionFilter;
   bool useCustomBacPionMisID;
+
+  bool ignoreOnFlyStatusV0;
 };
 
 struct PairCutParams

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoV0TrackCutNSigmaFilter.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoV0TrackCutNSigmaFilter.cxx
@@ -175,7 +175,7 @@ bool AliFemtoV0TrackCutNSigmaFilter::Pass(const AliFemtoV0* aV0)
 
 
   //quality cuts
-  if (aV0->OnFlyStatusV0() != fOnFlyStatus) return false;
+  if(!fIgnoreOnFlyStatus) {if (aV0->OnFlyStatusV0() != fOnFlyStatus) return false;}
   if (aV0->StatusNeg() == 999 || aV0->StatusPos() == 999) return false;
   if (aV0->TPCNclsPos() < fTPCNclsDaughters) return false;
   if (aV0->TPCNclsNeg() < fTPCNclsDaughters) return false;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoXiTrackCutNSigmaFilter.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoXiTrackCutNSigmaFilter.cxx
@@ -259,6 +259,7 @@ void AliFemtoXiTrackCutNSigmaFilter::UpdateDaughterV0Filter()
   fDaughterV0Filter->SetPtPosDaughter(fPtMinPosDaughter,fPtMaxPosDaughter);
   fDaughterV0Filter->SetPtNegDaughter(fPtMinNegDaughter,fPtMaxNegDaughter);
   fDaughterV0Filter->SetOnFlyStatus(fOnFlyStatus);
+  fDaughterV0Filter->SetIgnoreOnFlyStatus(fIgnoreOnFlyStatus);
   fDaughterV0Filter->SetMinAvgSeparation(fMinAvgSepDaughters);
 
   fDaughterV0Filter->SetRadiusV0Min(fRadiusV0Min);

--- a/PWGCF/FEMTOSCOPY/macros/Train/LambdaKaonFemto/ConfigFemtoAnalysis.C
+++ b/PWGCF/FEMTOSCOPY/macros/Train/LambdaKaonFemto/ConfigFemtoAnalysis.C
@@ -539,9 +539,7 @@ BuildParticleConfiguration(
       const TString tParticleType = ((TObjString*)tCutFullLine->At(1))->String().Strip(TString::kBoth, ' ');
       const TString tParticleCut = ((TObjString*)tCutFullLine->At(2))->String().Strip(TString::kBoth, ' ');
 
-      if(tParticleType.EqualTo("ALL")) tDesiredName = TString("ALL");
-      if(tParticleType.EqualTo("ALLV0S")) tDesiredName = TString("ALLV0S");
-      if(tParticleType.EqualTo(tDesiredName)) tCmd = tV0CutVarName + "." + tParticleCut(0, tParticleCut.Length());
+      if(tParticleType.EqualTo(tDesiredName) || tParticleType.EqualTo("ALL") || tParticleType.EqualTo("ALLV0S")) tCmd = tV0CutVarName + "." + tParticleCut(0, tParticleCut.Length());
 
       if(tParticleType.EqualTo("CLAM"))  //do for both Lam and ALam
       {
@@ -616,9 +614,7 @@ BuildParticleConfiguration(
       const TString tParticleType = ((TObjString*)tCutFullLine->At(1))->String().Strip(TString::kBoth, ' ');
       const TString tParticleCut = ((TObjString*)tCutFullLine->At(2))->String().Strip(TString::kBoth, ' ');
 
-      if(tParticleType.EqualTo("ALL")) tDesiredName = TString("ALL");
-      if(tParticleType.EqualTo("ALLTRACKS")) tDesiredName = TString("ALLTRACKS");
-      if(tParticleType.EqualTo(tDesiredName)) tCmd = tESDCutVarName + "." + tParticleCut(0, tParticleCut.Length());
+      if(tParticleType.EqualTo(tDesiredName) || tParticleType.EqualTo("ALL") || tParticleType.EqualTo("ALLTRACKS")) tCmd = tESDCutVarName + "." + tParticleCut(0, tParticleCut.Length());
     }
 
     if(!tCmd.IsNull())
@@ -672,9 +668,7 @@ BuildParticleConfiguration(
       const TString tParticleType = ((TObjString*)tCutFullLine->At(1))->String().Strip(TString::kBoth, ' ');
       const TString tParticleCut = ((TObjString*)tCutFullLine->At(2))->String().Strip(TString::kBoth, ' ');
 
-      if(tParticleType.EqualTo("ALL")) tDesiredName = TString("ALL");
-      if(tParticleType.EqualTo("ALLXIS")) tDesiredName = TString("ALLXIS");
-      if(tParticleType.EqualTo(tDesiredName)) tCmd = tXiCutVarName + "." + tParticleCut(0, tParticleCut.Length());
+      if(tParticleType.EqualTo(tDesiredName) || tParticleType.EqualTo("ALL") || tParticleType.EqualTo("ALLXIS")) tCmd = tXiCutVarName + "." + tParticleCut(0, tParticleCut.Length());
     }
 
     if(!tCmd.IsNull())

--- a/PWGCF/FEMTOSCOPY/macros/Train/LambdaKaonFemto/ConfigFemtoAnalysisSystematics.C
+++ b/PWGCF/FEMTOSCOPY/macros/Train/LambdaKaonFemto/ConfigFemtoAnalysisSystematics.C
@@ -609,9 +609,7 @@ BuildParticleConfiguration(
       const TString tParticleType = ((TObjString*)tCutFullLine->At(1))->String().Strip(TString::kBoth, ' ');
       const TString tParticleCut = ((TObjString*)tCutFullLine->At(2))->String().Strip(TString::kBoth, ' ');
 
-      if(tParticleType.EqualTo("ALL")) tDesiredName = TString("ALL");
-      if(tParticleType.EqualTo("ALLV0S")) tDesiredName = TString("ALLV0S");
-      if(tParticleType.EqualTo(tDesiredName)) tCmd = tV0CutVarName + "." + tParticleCut(0, tParticleCut.Length());
+      if(tParticleType.EqualTo(tDesiredName) || tParticleType.EqualTo("ALL") || tParticleType.EqualTo("ALLV0S")) tCmd = tV0CutVarName + "." + tParticleCut(0, tParticleCut.Length());
 
       if(tParticleType.EqualTo("CLAM"))  //do for both Lam and ALam
       {
@@ -686,9 +684,7 @@ BuildParticleConfiguration(
       const TString tParticleType = ((TObjString*)tCutFullLine->At(1))->String().Strip(TString::kBoth, ' ');
       const TString tParticleCut = ((TObjString*)tCutFullLine->At(2))->String().Strip(TString::kBoth, ' ');
 
-      if(tParticleType.EqualTo("ALL")) tDesiredName = TString("ALL");
-      if(tParticleType.EqualTo("ALLTRACKS")) tDesiredName = TString("ALLTRACKS");
-      if(tParticleType.EqualTo(tDesiredName)) tCmd = tESDCutVarName + "." + tParticleCut(0, tParticleCut.Length());
+      if(tParticleType.EqualTo(tDesiredName) || tParticleType.EqualTo("ALL") || tParticleType.EqualTo("ALLTRACKS")) tCmd = tESDCutVarName + "." + tParticleCut(0, tParticleCut.Length());
     }
 
     if(!tCmd.IsNull())
@@ -742,9 +738,7 @@ BuildParticleConfiguration(
       const TString tParticleType = ((TObjString*)tCutFullLine->At(1))->String().Strip(TString::kBoth, ' ');
       const TString tParticleCut = ((TObjString*)tCutFullLine->At(2))->String().Strip(TString::kBoth, ' ');
 
-      if(tParticleType.EqualTo("ALL")) tDesiredName = TString("ALL");
-      if(tParticleType.EqualTo("ALLXIS")) tDesiredName = TString("ALLXIS");
-      if(tParticleType.EqualTo(tDesiredName)) tCmd = tXiCutVarName + "." + tParticleCut(0, tParticleCut.Length());
+      if(tParticleType.EqualTo(tDesiredName) || tParticleType.EqualTo("ALL") || tParticleType.EqualTo("ALLXIS")) tCmd = tXiCutVarName + "." + tParticleCut(0, tParticleCut.Length());
     }
 
     if(!tCmd.IsNull())

--- a/PWGCF/FEMTOSCOPY/macros/Train/LambdaKaonFemto/ConfigFemtoAnalysisSystematics2.C
+++ b/PWGCF/FEMTOSCOPY/macros/Train/LambdaKaonFemto/ConfigFemtoAnalysisSystematics2.C
@@ -622,9 +622,7 @@ BuildParticleConfiguration(
       const TString tParticleType = ((TObjString*)tCutFullLine->At(1))->String().Strip(TString::kBoth, ' ');
       const TString tParticleCut = ((TObjString*)tCutFullLine->At(2))->String().Strip(TString::kBoth, ' ');
 
-      if(tParticleType.EqualTo("ALL")) tDesiredName = TString("ALL");
-      if(tParticleType.EqualTo("ALLV0S")) tDesiredName = TString("ALLV0S");
-      if(tParticleType.EqualTo(tDesiredName)) tCmd = tV0CutVarName + "." + tParticleCut(0, tParticleCut.Length());
+      if(tParticleType.EqualTo(tDesiredName) || tParticleType.EqualTo("ALL") || tParticleType.EqualTo("ALLV0S")) tCmd = tV0CutVarName + "." + tParticleCut(0, tParticleCut.Length());
 
       if(tParticleType.EqualTo("CLAM"))  //do for both Lam and ALam
       {
@@ -699,9 +697,7 @@ BuildParticleConfiguration(
       const TString tParticleType = ((TObjString*)tCutFullLine->At(1))->String().Strip(TString::kBoth, ' ');
       const TString tParticleCut = ((TObjString*)tCutFullLine->At(2))->String().Strip(TString::kBoth, ' ');
 
-      if(tParticleType.EqualTo("ALL")) tDesiredName = TString("ALL");
-      if(tParticleType.EqualTo("ALLTRACKS")) tDesiredName = TString("ALLTRACKS");
-      if(tParticleType.EqualTo(tDesiredName)) tCmd = tESDCutVarName + "." + tParticleCut(0, tParticleCut.Length());
+      if(tParticleType.EqualTo(tDesiredName) || tParticleType.EqualTo("ALL") || tParticleType.EqualTo("ALLTRACKS")) tCmd = tESDCutVarName + "." + tParticleCut(0, tParticleCut.Length());
     }
 
     if(!tCmd.IsNull())
@@ -755,9 +751,7 @@ BuildParticleConfiguration(
       const TString tParticleType = ((TObjString*)tCutFullLine->At(1))->String().Strip(TString::kBoth, ' ');
       const TString tParticleCut = ((TObjString*)tCutFullLine->At(2))->String().Strip(TString::kBoth, ' ');
 
-      if(tParticleType.EqualTo("ALL")) tDesiredName = TString("ALL");
-      if(tParticleType.EqualTo("ALLXIS")) tDesiredName = TString("ALLXIS");
-      if(tParticleType.EqualTo(tDesiredName)) tCmd = tXiCutVarName + "." + tParticleCut(0, tParticleCut.Length());
+      if(tParticleType.EqualTo(tDesiredName) || tParticleType.EqualTo("ALL") || tParticleType.EqualTo("ALLXIS")) tCmd = tXiCutVarName + "." + tParticleCut(0, tParticleCut.Length());
     }
 
     if(!tCmd.IsNull())


### PR DESCRIPTION
Included switch to ignore on-fly-status value of the V0.  NOTE IMPORTANT: If you set this to true, be sure to call AliFemtoSimpleAnalysis::SetV0SharedDaughterCut(true) otherwise, in many cases, you will receive multiple copies of the same V0.