### PR TITLE
Use histograms for weights

### DIFF
--- a/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.cxx
@@ -2965,7 +2965,7 @@ Double_t AliAnalysisTaskHFEpACorrelation::CalculateWeightRun2ToData(Int_t pdg_pa
             return 1.0;
         
         Int_t bin = fBkgPi0WeightToData->FindBin(pT);
-        return fBkgPi0WeightToData->GetBinContent(bin);
+        return 1./fBkgPi0WeightToData->GetBinContent(bin);
     }
     else if (TMath::Abs(pdg_particle) == 221)
     {
@@ -2973,7 +2973,7 @@ Double_t AliAnalysisTaskHFEpACorrelation::CalculateWeightRun2ToData(Int_t pdg_pa
             return 1.0;
         
         Int_t bin = fBkgEtaWeightToData->FindBin(pT);
-        return fBkgEtaWeightToData->GetBinContent(bin);
+        return 1./fBkgEtaWeightToData->GetBinContent(bin);
     }
     
     return 1.0;

--- a/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.cxx
@@ -2958,14 +2958,23 @@ void AliAnalysisTaskHFEpACorrelation::FillHistBkgWtoData(AliAODMCParticle* Parti
 
 Double_t AliAnalysisTaskHFEpACorrelation::CalculateWeightRun2ToData(Int_t pdg_particle, Double_t pT)
 {
-    //Using a TF1 to get the weight
-    if (!fBkgPi0WeightToData || fBkgEtaWeightToData)
-        return 1.0;
     
-    if (pdg_particle == 111)
-        return fBkgPi0WeightToData->Eval(pT);
-    else if (pdg_particle == 221)
-        return fBkgEtaWeightToData->Eval(pT);
+    if (TMath::Abs(pdg_particle) == 111)
+    {
+        if (!fBkgPi0WeightToData)
+            return 1.0;
+        
+        Int_t bin = fBkgPi0WeightToData->FindBin(pT);
+        return fBkgPi0WeightToData->GetBinContent(bin);
+    }
+    else if (TMath::Abs(pdg_particle) == 221)
+    {
+        if (!fBkgEtaWeightToData)
+            return 1.0;
+        
+        Int_t bin = fBkgEtaWeightToData->FindBin(pT);
+        return fBkgEtaWeightToData->GetBinContent(bin);
+    }
     
     return 1.0;
     

--- a/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.h
+++ b/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.h
@@ -105,8 +105,8 @@ public:
     void SetBackgroundPi0Weight(TH1F *hBkgPi0W) {if(fBkgPi0Weight) delete fBkgPi0Weight; fBkgPi0Weight = (TH1F*) hBkgPi0W->Clone("fBkgPi0Weight");}
     void SetBackgroundEtaWeight(TH1F *hBkgEtaW) {if(fBkgEtaWeight) delete fBkgEtaWeight; fBkgEtaWeight = (TH1F*) hBkgEtaW->Clone("fBkgEtaWeight");}
     
-    void SetBackgroundPi0WeightToData(TF1 *Wpion) {fBkgPi0WeightToData = (TF1*) Wpion->Clone("PionWToData");}
-    void SetBackgroundEtaWeightToData(TF1 *WEta) {fBkgEtaWeightToData = (TF1*) WEta->Clone("EtaWToData");}
+    void SetBackgroundPi0WeightToData(TH1F *Wpion) {fBkgPi0WeightToData = (TH1F*) Wpion->Clone("PionWToData");}
+    void SetBackgroundEtaWeightToData(TH1F *WEta) {fBkgEtaWeightToData = (TH1F*) WEta->Clone("EtaWToData");}
 
     
     //DCA cut main particle
@@ -439,8 +439,8 @@ private:
     
     TH1F                *fBkgPi0Weight; //
     TH1F                *fBkgEtaWeight; //
-    TF1                 *fBkgPi0WeightToData; //
-    TF1                 *fBkgEtaWeightToData; //
+    TH1F                *fBkgPi0WeightToData; //
+    TH1F                *fBkgEtaWeightToData; //
     
    
     
@@ -473,7 +473,7 @@ private:
     AliAnalysisTaskHFEpACorrelation(const AliAnalysisTaskHFEpACorrelation&); 			// not implemented
     AliAnalysisTaskHFEpACorrelation& operator=(const AliAnalysisTaskHFEpACorrelation&); 		// not implemented
     
-    ClassDef(AliAnalysisTaskHFEpACorrelation, 5); 								// example of analysis
+    ClassDef(AliAnalysisTaskHFEpACorrelation, 6); 								// example of analysis
     //______________________________________________________________________
 };
 

--- a/PWGHF/hfe/macros/AddTaskHFEpACorrelation.C
+++ b/PWGHF/hfe/macros/AddTaskHFEpACorrelation.C
@@ -122,8 +122,8 @@ AliAnalysisTaskHFEpACorrelation *AddTaskHFEpACorrelation(
         
         if (fileBkgWToData)
         {
-            TF1 *Pi0W = (TF1*) fileBkgWToData->Get("Pi0W");
-            TF1 *EtaW = (TF1*) fileBkgWToData->Get("EtaW");
+            TH1F *Pi0W = (TH1F*) fileBkgWToData->Get("Pi0");
+            TH1F *EtaW = (TH1F*) fileBkgWToData->Get("Eta");
             
             if (Pi0W)
                 task->SetBackgroundPi0WeightToData(Pi0W);


### PR DESCRIPTION
When the Hijing + enhanced pi0 and eta spectra are merged, the total shape is harder to fit. It is easier to use histograms with very fine binning, since the statistics at high momentum is good due to the enhancement. 