### PR TITLE
Z coordinate values taken from CPass1

### DIFF
--- a/PWGPP/ITS/AliMeanVertexPreprocessorOffline.h
+++ b/PWGPP/ITS/AliMeanVertexPreprocessorOffline.h
@@ -23,7 +23,8 @@ class AliMeanVertexPreprocessorOffline: public TNamed
 	Int_t GetStatus();
 
 	void SetShowPlots(Bool_t showPlots){fShowPlots = showPlots;}
-	
+
+	void ModObject(const char* url, double zv, double zs, const char* commentAdd);
 
   private:
 	AliMeanVertexPreprocessorOffline(const AliMeanVertexPreprocessorOffline & proc); // copy constructor	
@@ -37,6 +38,7 @@ class AliMeanVertexPreprocessorOffline: public TNamed
 	  kWriteMeanVertexSPD, /*write MeanVertex computed online*/
 	  kUseOfflineSPDvtx,  /*write SPD vtx offline*/
 	  kLumiRegCovMatrixProblem, /*lumi region or cov matrix computation problems, default values set*/
+	  kFitUpdateZFailed, /*problem in fitting the Z for the update in  CPass1*/
 	  kNStatusCodes
 	};
 


### PR DESCRIPTION
Due to the HM trigger selection a bias in the evaluation of the Z coordinate in CPass0 was found. These values are now taken from CPass1 and the correspondent OCDB objects are updated (both GRP/Calib/MeanVertex and GRP/Calib/MeanVertexSPD). 