### PR TITLE
PWGCF: AliUEHistograms.cxx uninitialized data member in copy ctor. Fi…

### DIFF
--- a/PWGCF/Correlations/Base/AliUEHistograms.cxx
+++ b/PWGCF/Correlations/Base/AliUEHistograms.cxx
@@ -213,7 +213,7 @@ AliUEHistograms::AliUEHistograms(const char* name, const char* histograms, const
 
 //_____________________________________________________________________________
 AliUEHistograms::AliUEHistograms(const AliUEHistograms &c) :
-  TNamed(fName, fTitle),
+  TNamed(c.fName, c.fTitle),
   fNumberDensitypT(0),
   fSumpT(0),
   fNumberDensityPhi(0),


### PR DESCRIPTION
…xes compiler warning.

Compilation tested on macOS. Old compilation warning below. Rüdiger was the last person to touch the code but prefers me to make this PR.

```
DEBUG:AliPhysics:0: /Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0_ROOT6/0/PWGCF/Correlations/Base/AliUEHistograms.cxx:216:10: warning: base class 'TNamed' is uninitialized when used here to access 'TNamed::fName' [-Wuninitialized]
DEBUG:AliPhysics:0:   TNamed(fName, fTitle),
DEBUG:AliPhysics:0:          ^
DEBUG:AliPhysics:0: /Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0_ROOT6/0/PWGCF/Correlations/Base/AliUEHistograms.cxx:216:17: warning: base class 'TNamed' is uninitialized when used here to access 'TNamed::fTitle' [-Wuninitialized]
DEBUG:AliPhysics:0:   TNamed(fName, fTitle),
DEBUG:AliPhysics:0:                 ^
DEBUG:AliPhysics:0: 2 warnings generated.
```