### PR TITLE
Fixed usage of histograms for runwise TPC PID correction

### DIFF
--- a/PWGDQ/dielectron/core/AliDielectron.cxx
+++ b/PWGDQ/dielectron/core/AliDielectron.cxx
@@ -1775,7 +1775,7 @@ void AliDielectron::SetWidthCorrArr(TObjArray *arrFun, Bool_t bHisto, UInt_t var
       AliDielectronHistos::StoreVariables(fun, valType);
       // clone temporare histogram, otherwise it will not be streamed to file!
       fPostPIDWdthCorrArr->Add((TH1*)fun->Clone(key.Data()));
-      TH1 *histo = (TH1*) fPostPIDWdthCorrArr->At(i);
+      histo = (TH1*) fPostPIDWdthCorrArr->At(i);
     }
     if(histo){
       // check for corrections and add their variables to the fill map


### PR DESCRIPTION
Old code recreated histogram in new scope and was therefore not able to use histogram outside this scope