### PR TITLE
Disable root history when performing ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,5 +254,6 @@ foreach(TEST_LIB ${ALILIBSTESTED})
     env
     LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{LD_LIBRARY_PATH}
     DYLD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{DYLD_LIBRARY_PATH}
+    ROOT_HIST=0
     root -n -l -b -q "${CMAKE_INSTALL_PREFIX}/test/load_library/LoadLib.C(\"lib${TEST_LIB}\")")
 endforeach()


### PR DESCRIPTION
The ctest runs a series of load-libraries commands that are stored in the root history.
Since there are lots of libraries, the user history basically goes outside the buffer.
The patch disable the root history before loading the libraries.