### PR TITLE
PWGPP-1,PWGPP-312 - Update performance parameterization code

### DIFF
--- a/PWGPP/AliAnalysisTaskFilteredTree.cxx
+++ b/PWGPP/AliAnalysisTaskFilteredTree.cxx
@@ -1041,8 +1041,7 @@ void AliAnalysisTaskFilteredTree::ProcessAll(AliESDEvent *const esdEvent, AliMCE
         isOKtrackInnerC&= ConstrainTrackInner(trackInnerC,vtxESD,track->GetMass(),b);
         isOKtrackInnerC&= trackInnerC->Rotate(track->GetAlpha());
         isOKtrackInnerC&= trackInnerC->PropagateTo(track->GetX(),esdEvent->GetMagneticField());
-      } 
-
+      }       
       //
       // calculate chi2 between vi and vj vectors
       // with covi and covj covariance matrices
@@ -1082,8 +1081,17 @@ void AliAnalysisTaskFilteredTree::ProcessAll(AliESDEvent *const esdEvent, AliMCE
         chi2trackC = deltatrackC*mat2trackC; 
         //chi2trackC.Print();
       }
-
-
+      //
+      // Find nearest combined and ITS standaalone tracks
+      AliExternalTrackParam paramITS;     // nearest ITS track  -   chi2 distance at vertex
+      AliExternalTrackParam paramITSC;    // nearest ITS track  -   to constrained track   chi2 distance at vertex
+      AliExternalTrackParam paramComb;    // nearest comb. tack -   chi2 distance at inner wall
+      Int_t indexNearestITS   = GetNearestTrack((trackInnerV!=NULL)? trackInnerV:track, iTrack, esdEvent,0,0,paramITS); 
+      if (indexNearestITS<0)  indexNearestITS   = GetNearestTrack((trackInnerV!=NULL)? trackInnerV:track, iTrack, esdEvent,2,0,paramITS);
+      Int_t indexNearestITSC  = GetNearestTrack((trackInnerC!=NULL)? trackInnerC:track, iTrack, esdEvent,0,0,paramITSC);  
+      if (indexNearestITSC<0)  indexNearestITS   = GetNearestTrack((trackInnerC!=NULL)? trackInnerC:track, iTrack, esdEvent,2,0,paramITSC);
+      Int_t indexNearestComb  = GetNearestTrack(track->GetInnerParam(), iTrack, esdEvent,1,1,paramComb);  
+      
       //
       // Propagate ITSout to TPC inner wall 
       // and calculate chi2 distance to track (InnerParams)
@@ -1463,6 +1471,16 @@ void AliAnalysisTaskFilteredTree::ProcessAll(AliESDEvent *const esdEvent, AliMCE
             "chi2InnerC="<<chi2trackC(0,0)<<        // chi2s  of tracks TPCinner to the combined
             "chi2OuterITS="<<chi2OuterITS(0,0)<<    // chi2s  of tracks TPC at inner wall to the ITSout
             "centralityF="<<centralityF;
+	  // info for 2 track resolution studies and matching efficency studies 
+	  //
+	  (*fTreeSRedirector)<<"highPt"<<
+	    "paramITS.="<<&paramITS<<                // nearest ITS track  -   chi2 distance at vertex
+	    "paramITSC.="<<&paramITSC<<              // nearest ITS track  -  to constrained track   chi2 distance at vertex
+	    "paramComb.="<<&paramComb<<              // nearest comb. tack -   chi2 distance at inner wall
+	    "indexNearestITS="<<indexNearestITS<<    // index of  nearest ITS track
+	    "indexNearestITSC="<<indexNearestITSC<<  // index of  nearest ITS track for constrained track
+	    "indexNearestComb="<<indexNearestComb;   // index of  nearest track for constrained track
+
           if (mcEvent){
             static AliTrackReference refDummy;
             if (!refITS) refITS = &refDummy;
@@ -2879,15 +2897,20 @@ void AliAnalysisTaskFilteredTree::ProcessTrackMatch(AliESDEvent *const /*esdEven
 */
 }
 
-Int_t   AliAnalysisTaskFilteredTree::GetNearestTrackAtVertex(AliExternalTrackParam * trackMatch, Int_t indexSkip, AliESDEvent*event, Int_t trackType, Int_t paramType){
+Int_t   AliAnalysisTaskFilteredTree::GetNearestTrack(const AliExternalTrackParam * trackMatch, Int_t indexSkip, AliESDEvent*event, Int_t trackType, Int_t paramType, AliExternalTrackParam & paramNearest){
   //
   // Find track with closest chi2 distance  (assume all track ae propagated to the DCA)
   //   trackType = 0 - find closets ITS standalone
   //               1 - find closest track with TPC
+  //               2 - closest track with ITS and TPC
   //   paramType = 0 - global track
   //               1 - track at inner wall of TPC
   //
   //          
+  if (trackMatch==NULL){
+    ::Error("AliAnalysisTaskFilteredTree::GetNearestTrack","invalid track pointer");
+    return -1;
+  }
   Int_t ntracks=event->GetNumberOfTracks();
   const Double_t ktglCut=0.1;
   const Double_t kqptCut=0.4;
@@ -2898,28 +2921,37 @@ Int_t   AliAnalysisTaskFilteredTree::GetNearestTrackAtVertex(AliExternalTrackPar
   for (Int_t itrack=0; itrack<ntracks; itrack++){
     if (itrack==indexSkip) continue;
     AliESDtrack *ptrack=event->GetTrack(itrack);
-    if (trackType==0 && ptrack->IsOn(0x10)>0)  continue; // looks for track without TPC information
-    if (trackType==1 && ptrack->IsOn(0x10)==0) continue; // looks for tracks with TPC information
-    if (ptrack->GetKinkIndex(0)<0) continue;         // skip kink daughters
-    const AliExternalTrackParam * track=0;
-    if (trackType==0) track=ptrack;
-    if (trackType==1) track=ptrack->GetInnerParam();
+    if (ptrack==NULL) continue;
+    if (trackType==0 && (ptrack->IsOn(0x1)==kFALSE || ptrack->IsOn(0x10)==kTRUE))  continue;     // looks for track without TPC information
+    if (trackType==1 && (ptrack->IsOn(0x10)==kFALSE))   continue;                                // looks for tracks with   TPC information
+    if (trackType==2 && (ptrack->IsOn(0x1)==kFALSE || ptrack->IsOn(0x10)==kFALSE)) continue;      // looks for tracks with   TPC+ITS information
+    
+    if (ptrack->GetKinkIndex(0)<0) continue;              // skip kink daughters
+    const AliExternalTrackParam * track=0;                // 
+    if (paramType==0) track=ptrack;                       // Global track         
+    if (paramType==1) track=ptrack->GetInnerParam();      // TPC only track at inner wall of TPC
+    if (track==NULL) {
+      continue;
+    }
+    // first rough cuts
     // fP3 cut
     if (TMath::Abs((track->GetTgl()-trackMatch->GetTgl()))>ktglCut) continue; 
     // fP4 cut 
     if (TMath::Abs((track->GetSigned1Pt()-trackMatch->GetSigned1Pt()))>kqptCut) continue; 
     // fAlpha cut
-    Double_t alphaDist=TMath::Abs((track->GetAlpha()-trackMatch->GetAlpha()));
+    //Double_t alphaDist=TMath::Abs((track->GetAlpha()-trackMatch->GetAlpha()));
+    Double_t alphaDist=TMath::Abs(TMath::ATan2(track->Py(),track->Px())-TMath::ATan2(trackMatch->Py(),trackMatch->Py()));
     if (alphaDist>TMath::Pi()) alphaDist-=TMath::TwoPi();
     if (alphaDist>kAlphaCut) continue;
     // calculate and extract track with smallest chi2 distance
     AliExternalTrackParam param(*track);
-    param.Rotate(trackMatch->GetAlpha());
-    param.PropagateTo(trackMatch->GetX(),trackMatch->GetBz());
+    if (param.Rotate(trackMatch->GetAlpha())==kFALSE) continue;
+    if (param.PropagateTo(trackMatch->GetX(),trackMatch->GetBz())==kFALSE) continue;
     Double_t chi2=trackMatch->GetPredictedChi2(&param);
     if (chi2<chi2Min){
       indexMin=itrack;
       chi2Min=chi2;
+      paramNearest=param;
     }
   }
   return indexMin;
@@ -3050,7 +3082,8 @@ void  AliAnalysisTaskFilteredTree::SetDefaultAliasesHighPt(TTree *tree){
   tree->SetAlias("ITSOn0","esdTrack.fITSncls>4&&esdTrack.HasPointOnITSLayer(0)&&esdTrack.HasPointOnITSLayer(1)");
   tree->SetAlias("ITSOn01","esdTrack.fITSncls>3&&(esdTrack.HasPointOnITSLayer(0)||esdTrack.HasPointOnITSLayer(1))");
   tree->SetAlias("nclCut","(esdTrack.GetTPCClusterInfo(3,1)+esdTrack.fTRDncls)>140-5*(abs(esdTrack.fP[4]))");
-  tree->SetAlias("IsPrim4","abs(esdTrack.fD/sqrt(esdTrack.fCdd))<4");
+  tree->SetAlias("IsPrim4","sqrt((esdTrack.fD**2)/esdTrack.fCdd+(esdTrack.fZ**2)/esdTrack.fCzz)<4");
+  tree->SetAlias("IsPrim4TPC","sqrt((esdTrack.fdTPC**2)/esdTrack.fCddTPC+(esdTrack.fzTPC**2)/esdTrack.fCzzTPC)<4");
   
 
   const char * chName[5]={"r#phi","z","sin(#phi)","tan(#theta)", "q/p_{t}"};
@@ -3060,10 +3093,17 @@ void  AliAnalysisTaskFilteredTree::SetDefaultAliasesHighPt(TTree *tree){
   for (Int_t iPar=0; iPar<5; iPar++){
     tree->SetAlias(TString::Format("covarP%dITS",iPar).Data(),TString::Format("sqrt(esdTrack.fC[%d]+0)",AliExternalTrackParam::GetIndex(iPar,iPar)).Data());    
     tree->SetAlias(TString::Format("covarP%d",iPar).Data(),TString::Format("sqrt(%s.fC[%d]+0)",refBranch,AliExternalTrackParam::GetIndex(iPar,iPar)).Data());
-    tree->SetAlias(TString::Format("covarCP%d",iPar).Data(),TString::Format("sqrt(extInnerParamC.fC[%d]+0)",AliExternalTrackParam::GetIndex(iPar,iPar)).Data());
+    tree->SetAlias(TString::Format("covarPC%d",iPar).Data(),TString::Format("sqrt(extInnerParamC.fC[%d]+0)",AliExternalTrackParam::GetIndex(iPar,iPar)).Data());
+    tree->SetAlias(TString::Format("covarP%dNorm",iPar).Data(),TString::Format("sqrt(%s.fC[%d]+0)/sqrt(1+(1*esdTrack.fP[4])**2)/sqrt(1+(1*esdTrack.fP[4])**2)",refBranch,AliExternalTrackParam::GetIndex(iPar,iPar)).Data());
+    tree->SetAlias(TString::Format("covarPC%dNorm",iPar).Data(),TString::Format("sqrt(extInnerParamC.fC[%d]+0)/sqrt(1+(5*esdTrack.fP[4])**2)",AliExternalTrackParam::GetIndex(iPar,iPar)).Data());
 
     tree->SetAlias(TString::Format("deltaP%d",iPar).Data(),TString::Format("(%s.fP[%d]-esdTrack.fCp.fP[%d])",refBranch,iPar,iPar).Data());
     tree->SetAlias(TString::Format("deltaPC%d",iPar).Data(),TString::Format("(extInnerParamC.fP[%d]-esdTrack.fCp.fP[%d])",iPar,iPar).Data());
+    // rough  normalization of the residual sigma ~ sqrt(1+*k/pt)^2) 
+    // histogramming pt normalized deltas enable us to use wider bins in q/pt and also less bins in deltas 
+    tree->SetAlias(TString::Format("deltaP%dNorm",iPar).Data(),TString::Format("(%s.fP[%d]-esdTrack.fCp.fP[%d])/sqrt(1+(1*esdTrack.fP[4])**2)",refBranch,iPar,iPar).Data());
+    tree->SetAlias(TString::Format("deltaPC%dNorm",iPar).Data(),TString::Format("(extInnerParamC.fP[%d]-esdTrack.fCp.fP[%d])/sqrt(1.+(5.*esdTrack.fP[4])**2)",iPar,iPar).Data());
+    //
     tree->SetAlias(TString::Format("pullP%d",iPar).Data(),
 		   TString::Format("(%s.fP[%d]-esdTrack.fCp.fP[%d])/sqrt(%s.fC[%d]+esdTrack.fCp.fC[%d])",refBranch,
 				   iPar,iPar,refBranch,AliExternalTrackParam::GetIndex(iPar,iPar),AliExternalTrackParam::GetIndex(iPar,iPar)).Data());

--- a/PWGPP/AliAnalysisTaskFilteredTree.h
+++ b/PWGPP/AliAnalysisTaskFilteredTree.h
@@ -114,7 +114,7 @@ class AliAnalysisTaskFilteredTree : public AliAnalysisTaskSE {
   Bool_t GetFillTrees() { return fFillTree ;}
 
   void FillHistograms(AliESDtrack* const ptrack, AliExternalTrackParam* const ptpcInnerC, Double_t centralityF, Double_t chi2TPCInnerC);
-  Int_t   GetNearestTrackAtVertex(AliExternalTrackParam * trackMatch, Int_t indexSkip, AliESDEvent*event, Int_t trackType, Int_t paramType);
+  Int_t   GetNearestTrack(const AliExternalTrackParam * trackMatch, Int_t indexSkip, AliESDEvent*event, Int_t trackType, Int_t paramType,  AliExternalTrackParam & paramNearest);
   static void SetDefaultAliasesV0(TTree *treeV0);
   static void SetDefaultAliasesHighPt(TTree *treeV0);
  private:

--- a/PWGPP/TPC/macros/comparePerformanceMaps.C
+++ b/PWGPP/TPC/macros/comparePerformanceMaps.C
@@ -26,12 +26,12 @@ TPRegexp regTreeNotK0Qpt("hisK0.*(Alpha|DSec)");
 TPRegexp regTreeK0QptDSec("hisK0.*QPtTglDSec_1_1_5_1Dist");
 TPRegexp regTreeK0Alpha("hisK0.*AlphaDist");
 //TPRegexp regTreeDelta("(his|qahis).*(Delta|Pull|Covar|ncl|Chi2).*_tglDist");  // regular expression for standard trees
-TPRegexp regTreeDelta("^(his|qahis).*(Delta|Pull|Covar|ncl|Chi2).*_tglDist$");  // regular expression for standard trees
+TPRegexp regTreeDelta("^(his|qahis).*(Delta|Pull|Covar|ncl|Chi2|covar|delta|pull).*_tglDist$");  // regular expression for standard trees
 TPRegexp regTreeNotDeltaInt("his.*(lpha|DSec)");
 //
 TPRegexp regCovar("hisCovar");
-TPRegexp regTreeDeltaAlpha("(his|qahis)(Delta|Pull|Covar|ncl|Chi2).*alphaVDist$");
-TPRegexp regTreeDeltaDAlphaQ("(his|qahis)(Delta|Pull|Covarr|ncl|Chi2).*_dalphaQDist$");
+TPRegexp regTreeDeltaAlpha("(his|qahis)(Delta|Pull|Covar|ncl|Chi2|covar|delta|pull).*alphaVDist$");
+TPRegexp regTreeDeltaDAlphaQ("(his|qahis)(Delta|Pull|Covarr|ncl|Chi2|covar|delta|pull).*_dalphaQDist$");
 
 TTree * treeDelta0,  *treeK0proj_0_1,  *treeK0QptDSec, * treeCovar, * treeDeltaAlpha, *treeDeltaDAlphaQ, *treeK0Alpha;
 TCanvas *canvasDraw=0;

--- a/PWGPP/TPC/macros/performanceFiltered.C
+++ b/PWGPP/TPC/macros/performanceFiltered.C
@@ -230,27 +230,46 @@ TObjArray * FillPerfomanceHisto(Int_t maxEntries){
   //      return array of histograms
   //
   /*
-    Int_t maxEntries=200000;
+    Int_t maxEntries=200000; 
   */
   Int_t nTracks=chain->GetEntries();
   chain->SetEstimate(chain->GetEntries());
   TString timeRange=TString::Format( "%d,%.0f,%.0f",timeBins,timeStart, timeEnd);
   //
-  TString defaultCut="esdTrack.fTPCncls>60&&esdTrack.IsOn(0x1)>0";
-  const Int_t nqaHistos=14;
+  TString defaultCut="esdTrack.GetTPCClusterInfo(3,1)>60&&esdTrack.IsOn(0x1)>0";
+  TString defaultCutMatch="esdTrack.GetTPCClusterInfo(3,1)>60";
+  const Int_t nqaHistos=23;
   const char * qaHistos[nqaHistos]={"nclITS","nclTPC","nclTRD",		\
 				    "normChi2ITS","normChi2TPC","normChi2TRD", \
 				    "nclROC0","nclROC1","nclROC2", "nclROCA", \
-				    "nclFROC0","nclFROC1","nclFROC2","nclFROCA"};
-  const Int_t histosBins[nqaHistos]={8,160,160,	\
-				     100,100,100,	\
+				    "nclFROC0","nclFROC1","nclFROC2","nclFROCA", \
+				    "deltaPC2Norm", "deltaPC3Norm", "deltaPC4Norm", \
+				    "pullPC2", "pullPC3", "pullPC4", \
+				    "covarPC2Norm", "covarPC3Norm", "covarPC4Norm"};
+
+  const Int_t histosBins[nqaHistos]={8,80,80,	\
+				     50,50,50,	\
 				     64,64,32,160,	\
-				     55,55,55,55};
+				     55,55,55,55,\
+				     60,60,50, \
+				     50,50,50, \
+				     50,50,50 };
+  const Double_t histosMin[nqaHistos]={0,0,0,	\
+				       0,0,0,	\
+				       0,0,0,0,	\
+				       0,0,0,0, \
+				       -0.015,-0.015,-0.1, \
+				       -10,-10,-10, \
+				       0.00,0.00,0.0};
   const Double_t histosMax[nqaHistos]={8,160,160,	\
-				    20,20,20,	\
-				    64,64,32,160,	\
-				    1.1,1.1,1.1,1.1};
- 
+				       20,20,20,	\
+				       64,64,32,160,	\
+				       1.1,1.1,1.1,1.1, \
+				       0.015,0.015,0.1, \
+				       10,10,10, \
+				       0.01,0.01,0.1};
+  
+
   TString hisString="";
   {
     // Standard kinematic histograms
@@ -259,17 +278,36 @@ TObjArray * FillPerfomanceHisto(Int_t maxEntries){
     hisString+="esdTrack.fIp.Pt():#(esdTrack.fFlags&0x4)>0>>hisPtTPCOnly(100,1,30);";  
     hisString+="esdTrack.fP[4]:tgl:secInner:#esdTrack.fTPCncls>60>>hisQptTglSecAll(40,-2,2,10,-1,1,90,0,18);"; 
   }
+  // QA variables histograms
   for (Int_t iPar=0; iPar<nqaHistos; iPar++){
     // 
-    hisString+=TString::Format("%s:qPt:tgl:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>qahis%s_v_qPt_tgl(%d,0,%f,200,-5,5,10,-1,1);", \
-			       qaHistos[iPar],qaHistos[iPar],histosBins[iPar],histosMax[iPar]);
-    hisString+=TString::Format("%s:qPt:tgl:smdEdx:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>qahis%s_v_qPt_tgl_smdEdx(%d,0,%f,50,-5,5,10,-1,1,10,0,1);", \
-			       qaHistos[iPar],qaHistos[iPar],histosBins[iPar],histosMax[iPar]);
-    hisString+=TString::Format("%s:qPt:tgl:dalphaQ:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>qahis%s_v_qPt_tgl_dalphaQ(%d,0,%f,48,-3,3,10,-1,1,50,-0.18,0.18);", \
-			       qaHistos[iPar],qaHistos[iPar],histosBins[iPar],histosMax[iPar]);
-    hisString+=TString::Format("%s:qPt:tgl:alphaV:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>qahis%s_v_qPt_tgl_alphaV(%d,0,%f,48,-3,3,10,-1,1,90,-3.145,3.145);",\
-			       qaHistos[iPar],qaHistos[iPar],histosBins[iPar],histosMax[iPar]);
+    hisString+=TString::Format("%s:qPt:tgl:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>qahis%s_v_qPt_tgl(%d,%f,%f,200,-5,5,10,-1,1);", \
+			       qaHistos[iPar],qaHistos[iPar],histosBins[iPar],histosMin[iPar],histosMax[iPar]);
+    hisString+=TString::Format("%s:qPt:tgl:smdEdx:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>qahis%s_v_qPt_tgl_smdEdx(%d,%f,%f,50,-5,5,10,-1,1,10,0,1);", \
+			       qaHistos[iPar],qaHistos[iPar],histosBins[iPar],histosMin[iPar],histosMax[iPar]);
+    hisString+=TString::Format("%s:qPt:tgl:dalphaQ:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>qahis%s_v_qPt_tgl_dalphaQ(%d,%f,%f,48,-3,3,10,-1,1,50,-0.18,0.18);", \
+			       qaHistos[iPar],qaHistos[iPar],histosBins[iPar],histosMin[iPar],histosMax[iPar]);
+    hisString+=TString::Format("%s:qPt:tgl:alphaV:#IsPrim4&&TPCOn&&ITSRefit&&ITSOn01&&nclCut>>qahis%s_v_qPt_tgl_alphaV(%d,%f,%f,48,-3,3,10,-1,1,90,-3.145,3.145);",\
+			       qaHistos[iPar],qaHistos[iPar],histosBins[iPar],histosMin[iPar],histosMax[iPar]);
   }
+  // Matchin efficiency histograms for primary +-4 sigma tracks
+  //
+  const Int_t nmatchHistos=4;
+  const char * matchHistos[nmatchHistos]={"ITSOn","ITSRefit","TPCRefit","TRDOn"};
+   // QA variables histograms 
+  TString hisMatch="";
+  for (Int_t iPar=0; iPar<nmatchHistos; iPar++){
+    // 
+    hisMatch+=TString::Format("%s:qPt:tgl:#TPCOn&&TOFOn&&IsPrim4&&IsPrim4TPC>>matchhis%s_v_qPt_tgl(2,-0.5,1.5,200,-5,5,10,-1,1);", \
+			       matchHistos[iPar],matchHistos[iPar]);
+    hisMatch+=TString::Format("%s:qPt:tgl:dalphaQ:#TPCOn&&TOFOn&&IsPrim4&&IsPrim4TPC>>matchhis%s_v_qPt_tgl_dalphaQ(2,-0.5,1.5,48,-3,3,10,-1,1,50,-0.18,0.18);", \
+			       matchHistos[iPar],matchHistos[iPar]);
+    hisMatch+=TString::Format("%s:qPt:tgl:alphaV:#TPCOn&&TOFOn&&IsPrim4&&IsPrim4TPC>>matchhis%s_v_qPt_tgl_alphaV(2,-0.5,1.5,48,-3,3,10,-1,1,90,-3.145,3.145);", \
+			       matchHistos[iPar],matchHistos[iPar]);
+  }
+  
+
+
 
   {
     // N clusters per time;
@@ -356,12 +394,17 @@ TObjArray * FillPerfomanceHisto(Int_t maxEntries){
   TStopwatch timer;
 
   timer.Start();
-  hisArrayV0 = AliTreePlayer::MakeHistograms(chainV0, hisV0String, "",0,maxEntries,10000000,15);
+  hisArrayV0 = AliTreePlayer::MakeHistograms(chainV0, hisV0String, "",0,maxEntries,200000,15);
   timer.Print();
 
   timer.Start();
-  hisArray = AliTreePlayer::MakeHistograms(chain, hisString, defaultCut,0,maxEntries,10000000,15);
+  hisArray = AliTreePlayer::MakeHistograms(chain, hisString, defaultCut,0,maxEntries,200000,15);
   timer.Print();
+  
+  timer.Start();
+  TObjArray * hisArrayMatch = AliTreePlayer::MakeHistograms(chain, hisMatch, defaultCutMatch,0,maxEntries,200000,15);
+  timer.Print();
+  hisArray->AddAll(hisArrayMatch);
 
 
   (*pcstream).GetFile()->cd();
@@ -633,32 +676,58 @@ void MakeResidualDistortionMaps(){
   }
   TTreeSRedirector * pcstream = new TTreeSRedirector("residualMap.root","recreate");
   // Residual histogram -> maps creation
-  TPRegexp regexpDelta("(eltaP|ullP|covar).*phaV");    // make residual maps for each delta histogram  
+  TPRegexp regexpHis("^(his|matchhis|qahis)");    // make residual maps for each delta histogram  
+  TPRegexp regexpMatch("^matchhis");  
+  TPRegexp regexpK0("hisK0");   
+  //
+  //
   TMatrixD projectionInfo(4,5);
   projectionInfo(0,0)=0;  projectionInfo(0,1)=0;  projectionInfo(0,2)=0;   
   projectionInfo(1,0)=1;  projectionInfo(1,1)=1;  projectionInfo(1,2)=0; 
   projectionInfo(2,0)=2;  projectionInfo(2,1)=0;  projectionInfo(2,2)=0;  
   projectionInfo(3,0)=3;  projectionInfo(3,1)=1;  projectionInfo(3,2)=0;    
   for (Int_t iHis=0; iHis<hisArray->GetEntries(); iHis++){
-    if (regexpDelta.Match(TString(hisArray->At(iHis)->GetName()))){
+    Int_t proj[5]={0,1,2,3,4,5};
+    THn * hisInput=(THn*)hisArray->At(iHis);    
+    THnBase *hisProj=0;
+    if (regexpHis.Match(TString(hisArray->At(iHis)->GetName())) && regexpK0.Match(TString(hisArray->At(iHis)->GetName()))==0){
+      Double_t fraction=(regexpMatch.Match(TString(hisInput->GetName()))>0)?0.0:0.1;
       hisArray->At(iHis)->Print(); 
-      THn * hisInput=(THn*)hisArray->At(iHis);
-      TStatToolkit::MakeDistortionMapFast(hisInput,pcstream,projectionInfo,1,0.1);
+      TStatToolkit::MakeDistortionMapFast(hisInput,pcstream,projectionInfo,0,fraction);
+      Int_t nDim=hisInput->GetNdim();
+      hisProj=hisInput->ProjectionND(nDim-1,proj);
+      hisProj->SetName(TString::Format("%sProj%d",hisInput->GetName(),nDim).Data());
+      TStatToolkit::MakeDistortionMapFast(hisProj,pcstream,projectionInfo,0,fraction);
+      delete hisProj;
     }
   }
   // Track performance maps
-  TPRegexp regexpPerf("(eltaP|ullP|hisCovar|qa).*");  
+  TPRegexp regexpPerf("_qPt_tgl$");  
   for (Int_t iHis=0; iHis<hisArray->GetEntries(); iHis++){
-    if ( (regexpPerf.Match(TString(hisArray->At(iHis)->GetName()))>0) && (regexpDelta.Match(TString(hisArray->At(iHis)->GetName()))==0) ){
+    THnBase *hisProj=0;
+    Int_t proj[5]={0,1};
+    if ( (regexpPerf.Match(TString(hisArray->At(iHis)->GetName()))>0) && (regexpK0.Match(TString(hisArray->At(iHis)->GetName()))==0) ){
       hisArray->At(iHis)->Print(); 
       THn * hisInput=(THn*)hisArray->At(iHis);
-      TStatToolkit::MakeDistortionMapFast(hisInput,pcstream,projectionInfo,0,0.1);
+      Double_t fraction=(regexpMatch.Match(TString(hisInput->GetName()))>0)?0.0:0.1;
+      //A side
+      hisInput->GetAxis(2)->SetRangeUser(0,1);
+      hisProj=hisInput->ProjectionND(2,proj);
+      hisProj->SetName(TString::Format("%sASide",hisInput->GetName()).Data());
+      TStatToolkit::MakeDistortionMapFast(hisProj,pcstream,projectionInfo,0,fraction);
+      delete hisProj;
+      //C side
+      hisInput->GetAxis(2)->SetRangeUser(-1,0);
+      hisProj=hisInput->ProjectionND(2,proj);
+      hisProj->SetName(TString::Format("%sCSide",hisInput->GetName()).Data());
+      TStatToolkit::MakeDistortionMapFast(hisProj,pcstream,projectionInfo,0,fraction);
+      delete hisProj;
     }
   }
   //
   // V0 performance maps
   //
-  TPRegexp regexpK0("hisK0");  
+  //  TPRegexp regexpK0("hisK0");  
   projectionInfo(0,0)=0;  projectionInfo(0,1)=0;  projectionInfo(0,2)=0;   // merge pt bins
   projectionInfo(1,0)=1;  projectionInfo(1,1)=0;  projectionInfo(1,2)=0; 
   projectionInfo(2,0)=2;  projectionInfo(2,1)=1;  projectionInfo(2,2)=0;  


### PR DESCRIPTION
### Add two track resolution information ￼…
* add nearest ITSonly track
  * Currently low efficiency TPC+ITS->ITS standalone . To be debugged
*  used for matching efficiency studies for primaries
### Add: include additional qa trees to the maps 
* constrained track delta
*  matchin eff
### Add: delta of constrained param and matching eff. ￼…
* Reducing number of bins per histogram to stay below 4 GBy (memory leak in AliESDV0 fixed in AliRoot)
* In order to save memory in THn - residuals and co-variance matrix are scaled by sqrt(1+(k/p)**2)
  * renomalizing deltas and covariance matrix histogram range needed can be reduced
* Adding matching flag histograms
  * another default cuts - therefore one more loop over data
* Adding map  for projection of the last dimension for all Nd hitograms