### PR TITLE
Modifying the L1triggerName parameter name and options + simplifying the container naming

### DIFF
--- a/PWGGA/EMCALTasks/macros/AddTaskEMCALPhotonIsolation.C
+++ b/PWGGA/EMCALTasks/macros/AddTaskEMCALPhotonIsolation.C
@@ -45,9 +45,9 @@ AliAnalysisTaskEMCALPhotonIsolation* AddTaskEMCALPhotonIsolation(
                                                                  const Double_t         TMdphiIso                 = 0.03,
                                                                  const Bool_t           bmcTruth                  = kTRUE,
                                                                  const Bool_t           isLCAnalysis              = kFALSE,
-                                                                 TString                L1triggerName             = "",
-                                                                 const Bool_t           RejectPileUpEvent        = kFALSE,
-                                                                 const Int_t            NContrToPileUp           = 3
+                                                                 TString                triggerName               = "",
+                                                                 const Bool_t           RejectPileUpEvent         = kFALSE,
+                                                                 const Int_t            NContrToPileUp            = 3
                                                                  )
 {
   Printf("Preparing neutral cluster analysis\n");
@@ -98,29 +98,28 @@ AliAnalysisTaskEMCALPhotonIsolation* AddTaskEMCALPhotonIsolation(
     myContName = Form("Analysis_Neutrals");
   }
   
-  if(L1triggerName.Contains("EG1") || L1triggerName.Contains("EGA1")){
-    L1triggerName = "EG1";
+  if(triggerName.Contains("EG1") || triggerName.Contains("EGA1")){
+    triggerName = "_Trigger_EG1";
   }
-  else if(L1triggerName.Contains("EG2") || L1triggerName.Contains("EGA2")){
-    L1triggerName = "EG2";
+  else if(triggerName.Contains("EG2") || triggerName.Contains("EGA2")){
+    triggerName = "_Trigger_EG2";
+  }
+  else if(triggerName.Contains("MB")){
+    triggerName = "_Trigger_MB";
   }
   else{
-    L1triggerName = "";
+    triggerName = "";
   }
+
   TString pileUp;
   if(RejectPileUpEvent){
-    pileUp=Form("_PU_ON%d",NContrToPileUp);
+    pileUp = Form("_PU_ON%d", NContrToPileUp);
   }
   else{
-    pileUp="";
+    pileUp = "";
   }
   
-  if(L1triggerName != ""){
-    myContName.Append(Form("%s_TM_%s_CPVe%.2lf_CPVp%.2lf_IsoMet%d_EtIsoMet%d_UEMet%d_TPCbound_%s_IsoConeR%.1f_NLMCut_%s_minNLM%d_maxNLM%d_SSsmear_%s_Width%.3f_Mean_%.3f_PureIso_%s_WhichSmear_%d_Trigger_%s%s",isLCAnalysis?"_LC_Yes":"",bTMClusterRejection? "On" :"Off", TMdeta , TMdphi ,iIsoMethod,iEtIsoMethod,iUEMethod,bUseofTPC ? "Yes" : "No",iIsoConeRadius,bNLMCut ? "On": "Off",minNLM, NLMCut, iSmearingSS ? "On":"Off",iWidthSSsmear,iMean_SSsmear,iExtraIsoCuts?"On":"Off",bWhichToSmear,L1triggerName.Data(),pileUp.Data()));
-  }
-  else{
-    myContName.Append(Form("%s_TM_%s_CPVe%.2lf_CPVp%.2lf_IsoMet%d_EtIsoMet%d_UEMet%d_TPCbound_%s_IsoConeR%.1f_NLMCut_%s_minNLM%d_maxNLM%d_SSsmear_%s_Width%.3f_Mean_%.3f_PureIso_%s_WhichSmear_%d%s",isLCAnalysis?"_LC_Yes":"",bTMClusterRejection? "On" :"Off", TMdeta , TMdphi ,iIsoMethod,iEtIsoMethod,iUEMethod,bUseofTPC ? "Yes" : "No",iIsoConeRadius,bNLMCut ? "On": "Off",minNLM, NLMCut, iSmearingSS ? "On":"Off",iWidthSSsmear,iMean_SSsmear,iExtraIsoCuts?"On":"Off",bWhichToSmear,pileUp.Data()));
-  }
+  myContName.Append(Form("%s_TM_%s_CPVe%.2lf_CPVp%.2lf_IsoMet%d_EtIsoMet%d_UEMet%d_TPCbound_%s_IsoConeR%.1f_NLMCut_%s_minNLM%d_maxNLM%d_SSsmear_%s_Width%.3f_Mean_%.3f_PureIso_%s_WhichSmear_%d%s%s",isLCAnalysis?"_LC_Yes":"",bTMClusterRejection? "On" :"Off", TMdeta , TMdphi ,iIsoMethod,iEtIsoMethod,iUEMethod,bUseofTPC ? "Yes" : "No",iIsoConeRadius,bNLMCut ? "On": "Off",minNLM, NLMCut, iSmearingSS ? "On":"Off",iWidthSSsmear,iMean_SSsmear,iExtraIsoCuts?"On":"Off",bWhichToSmear,triggerName.Data(),pileUp.Data()));
 
   // #### Define analysis task
   AliAnalysisTaskEMCALPhotonIsolation* task = new AliAnalysisTaskEMCALPhotonIsolation("Analysis",bHisto);


### PR DESCRIPTION
The L1triggerName parameter is now named triggerName and allows to pass "MB" as argument. The output container naming process is simplified by implementing triggerName according to its value (with '\_Trigger\_').