### PR TITLE
fix to allow correct energy and centrality selection 

### DIFF
--- a/PWGHF/vertexingHF/macros/HFPtSpectrumRaa.C
+++ b/PWGHF/vertexingHF/macros/HFPtSpectrumRaa.C
@@ -794,7 +794,6 @@ void HFPtSpectrumRaa(const char *ppfile="HFPtSpectrum_D0Kpi_method2_rebinnedth_2
 	dataPPLow = ExtractFDSyst( gSigmaPPSystData->GetErrorYlow(istartPPextr), gSigmaPPSystFeedDown->GetErrorYlow(istartPPfd) );
 	systPPUp = TMath::Sqrt( dataPPUp*dataPPUp + gSigmaPPSystTheory->GetErrorYhigh(istartPPextr)*gSigmaPPSystTheory->GetErrorYhigh(istartPPextr) );
 	systPPLow = TMath::Sqrt( dataPPLow*dataPPLow + gSigmaPPSystTheory->GetErrorYlow(istartPPextr)*gSigmaPPSystTheory->GetErrorYlow(istartPPextr) );
-	cout<<"dataPPUp = "<<dataPPUp<<"\tdataPPLow = "<<dataPPLow<<"\tsystPPUp = "<<systPPUp<<"\tsystPPLow = "<<systPPLow<<endl;
       }
       if (isRaavsEP>0.) {
 	dataPPUp = dataPPUp*0.5;

--- a/PWGHF/vertexingHF/macros/HFPtSpectrumRaa.C
+++ b/PWGHF/vertexingHF/macros/HFPtSpectrumRaa.C
@@ -310,7 +310,7 @@ void HFPtSpectrumRaa(const char *ppfile="HFPtSpectrum_D0Kpi_method2_rebinnedth_2
 	systematicsAB->SetRunNumber(15);
 	systematicsAB->SetCentrality("3050");
       }
-    }
+    
     //
     else if ( cc == kpPb0100 || cc == kpPb020 || cc == kpPb2040 || cc == kpPb4060 || cc == kpPb60100 ) {
       systematicsAB->SetCollisionType(2);
@@ -353,12 +353,16 @@ void HFPtSpectrumRaa(const char *ppfile="HFPtSpectrum_D0Kpi_method2_rebinnedth_2
 	}
       }
     }
+		}
     else { 
       cout << " Systematics not yet implemented " << endl;
       return;
     }
     if(analysisSpeciality==kLowPt){
       systematicsAB->SetIsLowPtAnalysis(true);
+    }
+		else if(analysisSpeciality==kBDT){
+      systematicsAB->SetIsBDTAnalysis(true);
     }
     //
     systematicsAB->Init(decay);
@@ -790,6 +794,7 @@ void HFPtSpectrumRaa(const char *ppfile="HFPtSpectrum_D0Kpi_method2_rebinnedth_2
 	dataPPLow = ExtractFDSyst( gSigmaPPSystData->GetErrorYlow(istartPPextr), gSigmaPPSystFeedDown->GetErrorYlow(istartPPfd) );
 	systPPUp = TMath::Sqrt( dataPPUp*dataPPUp + gSigmaPPSystTheory->GetErrorYhigh(istartPPextr)*gSigmaPPSystTheory->GetErrorYhigh(istartPPextr) );
 	systPPLow = TMath::Sqrt( dataPPLow*dataPPLow + gSigmaPPSystTheory->GetErrorYlow(istartPPextr)*gSigmaPPSystTheory->GetErrorYlow(istartPPextr) );
+	cout<<"dataPPUp = "<<dataPPUp<<"\tdataPPLow = "<<dataPPLow<<"\tsystPPUp = "<<systPPUp<<"\tsystPPLow = "<<systPPLow<<endl;
       }
       if (isRaavsEP>0.) {
 	dataPPUp = dataPPUp*0.5;


### PR DESCRIPTION
The bracket placement meant that the selection of the energy and centrality for p-Pb collisions when creating the AliHFSystErr object did not work correctly. It should be working now. I also added the option to select the BDT analysis.