### PR TITLE
added transverse kinetic energy scaling

### DIFF
--- a/PWGCF/Correlations/DPhi/AliAnalysisTaskCorPIDTOFQA.cxx
+++ b/PWGCF/Correlations/DPhi/AliAnalysisTaskCorPIDTOFQA.cxx
@@ -104,9 +104,17 @@ fAOD(0), fOutputList(0), fPIDResponse(0), fHistPt(0),  cent_ntracks(0),
     m_squared_pos_cut(0),   beta_vs_mom_pos_cut(0),    deltat_vs_mom_pos_cut(0),
     m_squared_neg_cut(0),   beta_vs_mom_neg_cut(0),    deltat_vs_mom_neg_cut(0),
     dedx_vs_mom_pos_cut(0), dedx_vs_deltat_pos_cut(0), dedx_mom_deltat_pos_cut(0),  //     dedx_mom_m2_pos_cut(0),
-    dedx_vs_mom_neg_cut(0), dedx_vs_deltat_neg_cut(0), dedx_mom_deltat_neg_cut(0)   //     dedx_mom_m2_neg_cut(0),
+    dedx_vs_mom_neg_cut(0), dedx_vs_deltat_neg_cut(0), dedx_mom_deltat_neg_cut(0),   //     dedx_mom_m2_neg_cut(0),
 
-//    path_length(0), ttof(0), theta(0)
+    deut_dphi_T(0), deut_dphi_pos_T(0), deut_dphi_neg_T(0),
+    deut_dphi_A(0), deut_dphi_pos_A(0), deut_dphi_neg_A(0),
+    deut_dphi_B(0), deut_dphi_pos_B(0), deut_dphi_neg_B(0),
+
+    deuterons_per_event(0), deuterons_per_event_pos(0), deuterons_per_event_neg(0),
+    
+    m_squared_pos_cut_T(0), m_squared_pos_cut_A(0), m_squared_pos_cut_B(0),
+    m_squared_neg_cut_T(0), m_squared_neg_cut_A(0), m_squared_neg_cut_B(0)
+  
 {
     // default constructor, don't allocate memory here!
     // this is used by root for IO purposes, it needs to remain empty
@@ -123,50 +131,64 @@ fAOD(0), fOutputList(0), fPIDResponse(0), fHistPt(0),  cent_ntracks(0),
     m_squared_pos_cut(0),   beta_vs_mom_pos_cut(0),    deltat_vs_mom_pos_cut(0),
     m_squared_neg_cut(0),   beta_vs_mom_neg_cut(0),    deltat_vs_mom_neg_cut(0),
     dedx_vs_mom_pos_cut(0), dedx_vs_deltat_pos_cut(0), dedx_mom_deltat_pos_cut(0),  //     dedx_mom_m2_pos_cut(0),
-    dedx_vs_mom_neg_cut(0), dedx_vs_deltat_neg_cut(0), dedx_mom_deltat_neg_cut(0)   //     dedx_mom_m2_neg_cut(0),
+    dedx_vs_mom_neg_cut(0), dedx_vs_deltat_neg_cut(0), dedx_mom_deltat_neg_cut(0),   //     dedx_mom_m2_neg_cut(0),
 
-//    path_length(0), ttof(0), theta(0)
+    deut_dphi_T(0), deut_dphi_pos_T(0), deut_dphi_neg_T(0),
+    deut_dphi_A(0), deut_dphi_pos_A(0), deut_dphi_neg_A(0),
+    deut_dphi_B(0), deut_dphi_pos_B(0), deut_dphi_neg_B(0),
+
+    deuterons_per_event(0), deuterons_per_event_pos(0), deuterons_per_event_neg(0),
+									   
+    m_squared_pos_cut_T(0), m_squared_pos_cut_A(0), m_squared_pos_cut_B(0),
+    m_squared_neg_cut_T(0), m_squared_neg_cut_A(0), m_squared_neg_cut_B(0)
+    
 {
     // constructor
-    DefineInput(0, TChain::Class());    // define the input of the analysis: in this case we take a 'chain' of events
-                                        // this chain is created by the analysis manager, so no need to worry about it, 
-                                        // it does its work automatically
-    DefineOutput(1, TList::Class());    // define the ouptut of the analysis: in this case it's a list of histograms 
-                                        // you can add more output objects by calling DefineOutput(2, classname::Class())
-                                        // if you add more output objects, make sure to call PostData for all of them, and to
-                                        // make changes to your AddTask macro!
+    DefineInput(0, TChain::Class());
+    DefineOutput(1, TList::Class());
 }
 //_____________________________________________________________________________
 AliAnalysisTaskCorPIDTOFQA::~AliAnalysisTaskCorPIDTOFQA()
 {
     // destructor
-    if(fOutputList) {
+    if(fOutputList)
+    {
         delete fOutputList;     // at the end of your task, it is deleted from memory by calling this function
     }
 }
 //_____________________________________________________________________________
 void AliAnalysisTaskCorPIDTOFQA::UserCreateOutputObjects()
 {
-    // create output objects
-    //
-    // this function is called ONCE at the start of your analysis (RUNTIME)
-    // here you ceate the histograms that you want to use 
-    //
-    // the histograms are in this case added to a tlist, this list is in the end saved
-    // to an output file
-    //
 
-//  fTrackSelection = new AliEmcalTrackSelectionAOD;
-//  fTrackSelection->GenerateTrackCuts(AliEmcalTrackSelection::kHybridTracks, "lhc13c");
+// old //   3.43396 0.0133493 0.0593701 -0.125677 0.0646736 0.148637 3.59796 -0.00619808 -0.107274 0.034074 0.0359503 0.0131823 
+//3.09901 0.0446792 0.469684 0.0973401 0.0424328 -0.0685078 2.91151 0.0730297 0.664744 -0.115955 0.0709238 0.15557 
+
+
+    deut_curves[0][0][0] = 3.09901;     // pos deut mean curve
+    deut_curves[0][0][1] = 0.0446792;
+    deut_curves[0][0][2] = 0.469684;
+
+    deut_curves[0][1][0] = 0.0973401;  // pos deut sigma curve
+    deut_curves[0][1][1] = 0.0424328;
+    deut_curves[0][1][2] = -0.0685078;
+
+    deut_curves[1][0][0] = 2.91151;     // neg deut mean curve
+    deut_curves[1][0][1] = 0.0730297;
+    deut_curves[1][0][2] = -0.664744;
+
+    deut_curves[1][1][0] = -0.115955;  // neg deut sigma curve
+    deut_curves[1][1][1] = 0.0709238;
+    deut_curves[1][1][2] = 0.15557;
+
+    
 //    pi = TMath::Pi();
 //    fout.open("output.txt");
 
-// 3.38835 0.0203511 0.101903 -0.0487972 0.0513143 0.0815525 3.69323 -0.0206797 -0.200752 0.00644255 0.0391803 0.0399812
-    
+
 //  Double_t deut_curves[2][2][3];  // [charge][mean,sigma][par]
 
 //  TF1 *fit_deut_curve = new TF1("fit_m_mean",   "[0] + [1]*x + [2]/sqrt(x) ",       1.1, 4.4);
-    fit_deut_curve->SetParNames("a", "b x", "c/#sqrt(x)");
+//    fit_deut_curve->SetParNames("a", "b x", "c/#sqrt(x)");
 	
     fOutputList = new TList();          // this is a list which will contain all of your histograms
                                         // at the end of the analysis, the contents of this list are written
@@ -175,16 +197,24 @@ void AliAnalysisTaskCorPIDTOFQA::UserCreateOutputObjects()
                                         // if requested (dont worry about this now)
 
 
-    fHistPt                 = new TH1F("fHistPt",                   "Pt()",                  10000,     0,     10);
+    fHistPt                 = new TH1F("fHistPt",                   "Pt()",                   1000,     0,     10);
     cent_ntracks            = new TH2F("cent_vs_ntracks",           "cent_vs_ntracks",         100,     0,    100,     100,      0,    800);
     
     m_squared_pos           = new TH2F("m_squared_pos",             "m_squared_pos",           320,   0.0,    8.0,    2400,   -1.0,    7.0);
     m_squared_neg           = new TH2F("m_squared_neg",             "m_squared_neg",           320,   0.0,    8.0,    2400,   -1.0,    7.0);
-   
+
+    m_squared_pos_cut_T     = new TH2F("m_squared_pos_cut_T",       "m_squared_pos_cut_T",     320,   0.0,    8.0,    2400,   -1.0,    7.0);
+    m_squared_pos_cut_A     = new TH2F("m_squared_pos_cut_A",       "m_squared_pos_cut_A",     320,   0.0,    8.0,    2400,   -1.0,    7.0);
+    m_squared_pos_cut_B     = new TH2F("m_squared_pos_cut_B",       "m_squared_pos_cut_B",     320,   0.0,    8.0,    2400,   -1.0,    7.0);
+
+    m_squared_neg_cut_T     = new TH2F("m_squared_neg_cut_T",       "m_squared_neg_cut_T",     320,   0.0,    8.0,    2400,   -1.0,    7.0);
+    m_squared_neg_cut_A     = new TH2F("m_squared_neg_cut_A",       "m_squared_neg_cut_A",     320,   0.0,    8.0,    2400,   -1.0,    7.0);
+    m_squared_neg_cut_B     = new TH2F("m_squared_neg_cut_B",       "m_squared_neg_cut_B",     320,   0.0,    8.0,    2400,   -1.0,    7.0);
+  
     beta_vs_mom_pos         = new TH2F("beta_vs_mom_pos",           "beta_vs_mom_pos",         780,   0.0,    8.0,    3000,    0.1,    1.1);
     beta_vs_mom_neg         = new TH2F("beta_vs_mom_neg",           "beta_vs_mom_neg",         780,   0.0,    8.0,    3000,    0.1,    1.1);
-    deltat_vs_mom_pos       = new TH2F("deltat_vs_mom_pos",         "deltat_vs_mom_pos",     17000,   0.3,    2.0,    1500,   -2.5,   12.5);
-    deltat_vs_mom_neg       = new TH2F("deltat_vs_mom_neg",         "deltat_vs_mom_neg",     17000,   0.3,    2.0,    1500,   -2.5,   12.5);
+    deltat_vs_mom_pos       = new TH2F("deltat_vs_mom_pos",         "deltat_vs_mom_pos",     27000,   0.3,    3.0,    1000,   -1.0,    9.0);
+    deltat_vs_mom_neg       = new TH2F("deltat_vs_mom_neg",         "deltat_vs_mom_neg",     27000,   0.3,    3.0,    1000,   -1.0,    9.0);
 
     dedx_vs_mom_pos         = new TH2F("dedx_vs_mom_pos",           "dedx_vs_mom_pos",         780,   0.2,    8.0,     250,    0.0,  500.0);
     dedx_vs_mom_neg         = new TH2F("dedx_vs_mom_neg",           "dedx_vs_mom_neg",         780,   0.2,    8.0,     250,    0.0,  500.0);
@@ -193,15 +223,29 @@ void AliAnalysisTaskCorPIDTOFQA::UserCreateOutputObjects()
     dedx_mom_deltat_pos     = new TH3F("dedx_mom_deltat_pos",       "dedx_mom_deltat_pos",     250,   0.0,  500.0,     156,    0.2,    8.0,      420, -1.0, 20.0);  //// (dedx, mom, deltat)
     dedx_mom_deltat_neg     = new TH3F("dedx_mom_deltat_neg",       "dedx_mom_deltat_neg",     250,   0.0,  500.0,     156,    0.2,    8.0,      420, -1.0, 20.0);  //// (dedx, mom, deltat)
 
-//  dedx_mom_m2_pos         = new TH3F("dedx_mom_m2_pos",           "dedx_mom_m2_pos",         250,   0.0,  500.0,     156,    0.2,    8.0,      240, -1.0,  7.0);  //// (dedx, mom, m2)
-//  dedx_mom_m2_neg         = new TH3F("dedx_mom_m2_neg",           "dedx_mom_m2_neg",         250,   0.0,  500.0,     156,    0.2,    8.0,      240, -1.0,  7.0);  //// (dedx, mom, m2)
+
+
+    deut_dphi_T             = new TH2F("deut_dphi_T",               "deut_dphi_T",            14,   1.0,   4.5, 300, -1.6708,  4.8124);
+    deut_dphi_A             = new TH2F("deut_dphi_A",               "deut_dphi_A",            14,   1.0,   4.5, 300, -1.6708,  4.8124);
+    deut_dphi_B             = new TH2F("deut_dphi_B",               "deut_dphi_B",            14,   1.0,   4.5, 300, -1.6708,  4.8124);
+    deut_dphi_pos_T         = new TH2F("deut_dphi_pos_T",           "deut_dphi_pos_T",        14,   1.0,   4.5, 300, -1.6708,  4.8124);
+    deut_dphi_pos_A         = new TH2F("deut_dphi_pos_A",           "deut_dphi_pos_A",        14,   1.0,   4.5, 300, -1.6708,  4.8124);
+    deut_dphi_pos_B         = new TH2F("deut_dphi_pos_B",           "deut_dphi_pos_B",        14,   1.0,   4.5, 300, -1.6708,  4.8124); 
+    deut_dphi_neg_T         = new TH2F("deut_dphi_neg_T",           "deut_dphi_neg_T",        14,   1.0,   4.5, 300, -1.6708,  4.8124);
+    deut_dphi_neg_A         = new TH2F("deut_dphi_neg_A",           "deut_dphi_neg_A",        14,   1.0,   4.5, 300, -1.6708,  4.8124);
+    deut_dphi_neg_B         = new TH2F("deut_dphi_neg_B",           "deut_dphi_neg_B",        14,   1.0,   4.5, 300, -1.6708,  4.8124);
+
+    deuterons_per_event     = new TH1I("deuterons_per_event",       "deuterons_per_event",     5,     0,     5);
+    deuterons_per_event_pos = new TH1I("deuterons_per_event_pos",   "deuterons_per_event_pos", 5,     0,     5);
+    deuterons_per_event_neg = new TH1I("deuterons_per_event_neg",   "deuterons_per_event_neg", 5,     0,     5);
+
     
     m_squared_pos_cut       = new TH2F("m_squared_pos_cut",         "m_squared_pos_cut",       320,   0.0,    8.0,    2400,   -1.0,    7.0);
     m_squared_neg_cut       = new TH2F("m_squared_neg_cut",         "m_squared_neg_cut",       320,   0.0,    8.0,    2400,   -1.0,    7.0);
     beta_vs_mom_pos_cut     = new TH2F("beta_vs_mom_pos_cut",       "beta_vs_mom_pos_cut",     780,   0.0,    8.0,    3000,    0.1,    1.1);
     beta_vs_mom_neg_cut     = new TH2F("beta_vs_mom_neg_cut",       "beta_vs_mom_neg_cut",     780,   0.0,    8.0,    3000,    0.1,    1.1);
-    deltat_vs_mom_pos_cut   = new TH2F("deltat_vs_mom_pos_cut",     "deltat_vs_mom_pos_cut", 17000,   0.3,    2.0,    1500,   -2.5,   12.5);
-    deltat_vs_mom_neg_cut   = new TH2F("deltat_vs_mom_neg_cut",     "deltat_vs_mom_neg_cut", 17000,   0.3,    2.0,    1500,   -2.5,   12.5);
+    deltat_vs_mom_pos_cut   = new TH2F("deltat_vs_mom_pos_cut",     "deltat_vs_mom_pos_cut", 27000,   0.3,    3.0,    1000,   -1.0,    9.0);
+    deltat_vs_mom_neg_cut   = new TH2F("deltat_vs_mom_neg_cut",     "deltat_vs_mom_neg_cut", 27000,   0.3,    3.0,    1000,   -1.0,    9.0);
 
     dedx_vs_mom_pos_cut     = new TH2F("dedx_vs_mom_pos_cut",       "dedx_vs_mom_pos_cut",     780,   0.2,    8.0,     250,    0.0,  500.0);
     dedx_vs_mom_neg_cut     = new TH2F("dedx_vs_mom_neg_cut",       "dedx_vs_mom_neg_cut",     780,   0.2,    8.0,     250,    0.0,  500.0);
@@ -210,9 +254,9 @@ void AliAnalysisTaskCorPIDTOFQA::UserCreateOutputObjects()
     dedx_mom_deltat_pos_cut = new TH3F("dedx_mom_deltat_pos_cut",   "dedx_mom_deltat_pos_cut", 250,   0.0,  500.0,     156,    0.2,    8.0,      420, -1.0, 20.0);  //// (dedx, mom, deltat)
     dedx_mom_deltat_neg_cut = new TH3F("dedx_mom_deltat_neg_cut",   "dedx_mom_deltat_neg_cut", 250,   0.0,  500.0,     156,    0.2,    8.0,      420, -1.0, 20.0);  //// (dedx, mom, deltat)
 
-//    dedx_mom_m2_pos_cut     = new TH3F("dedx_mom_m2_pos_cut",       "dedx_mom_m2_pos_cut",     250,   0.0,  500.0,     156,    0.2,    8.0,      240, -1.0,  7.0);  //// (dedx, mom, m2)
-//    dedx_mom_m2_neg_cut     = new TH3F("dedx_mom_m2_neg_cut",       "dedx_mom_m2_neg_cut",     250,   0.0,  500.0,     156,    0.2,    8.0,      240, -1.0,  7.0);  //// (dedx, mom, m2)
-
+    dphi_ket_deut_T           = new TH2F("dphi_ket_deut_T",   "dphi_ket_deut_T",           46, 0.445, 2.745,   60, -1.6708, 4.8124);  // dphi, ket
+    dphi_ket_deut_A           = new TH2F("dphi_ket_deut_A",   "dphi_ket_deut_A",           46, 0.445, 2.745,   60, -1.6708, 4.8124);  // dphi, ket
+    dphi_ket_deut_B           = new TH2F("dphi_ket_deut_B",   "dphi_ket_deut_B",           46, 0.445, 2.745,   60, -1.6708, 4.8124);  // dphi, ket
 //    path_length             = new TH1F("path_length",               "path_length",             200, 382.0,  398.0);
 //    ttof                    = new TH1F("ttof",                      "time of flight",          500,  12.0,   20.0);
 //    alpha                   = new TH1F("alpha",                     "alpha",                  1000,     0,    4.0);
@@ -222,15 +266,22 @@ void AliAnalysisTaskCorPIDTOFQA::UserCreateOutputObjects()
     //markc
 
 
+    
 //    fOutputList->Add(generic);
 //    fOutputList->Add(dca);
 //    fOutputList->Add(alpha);
 //    fOutputList->Add(theta);
 //    fOutputList->Add(path_length);
 //    fOutputList->Add(ttof);
+
+
     
     fOutputList->Add(fHistPt);                                                                      // objects added to output file
     fOutputList->Add(cent_ntracks);
+
+    fOutputList->Add(dphi_ket_deut_T);
+    fOutputList->Add(dphi_ket_deut_A);
+    fOutputList->Add(dphi_ket_deut_B);
     
     fOutputList->Add(m_squared_pos);
     fOutputList->Add(m_squared_pos_cut);    
@@ -245,8 +296,17 @@ void AliAnalysisTaskCorPIDTOFQA::UserCreateOutputObjects()
     fOutputList->Add(deltat_vs_mom_neg);
     fOutputList->Add(deltat_vs_mom_neg_cut);
 
-    
-    
+    fOutputList->Add(m_squared_pos_cut_T);
+    fOutputList->Add(m_squared_pos_cut_A);
+    fOutputList->Add(m_squared_pos_cut_B);	
+    fOutputList->Add(m_squared_neg_cut_T);
+    fOutputList->Add(m_squared_neg_cut_A);
+    fOutputList->Add(m_squared_neg_cut_B);    
+
+    fOutputList->Add(deuterons_per_event);
+    fOutputList->Add(deuterons_per_event_pos);
+    fOutputList->Add(deuterons_per_event_neg);
+
     fOutputList->Add(dedx_vs_mom_pos);
     fOutputList->Add(dedx_vs_mom_pos_cut);
     fOutputList->Add(dedx_vs_mom_neg);
@@ -260,10 +320,16 @@ void AliAnalysisTaskCorPIDTOFQA::UserCreateOutputObjects()
     fOutputList->Add(dedx_mom_deltat_neg);
     fOutputList->Add(dedx_mom_deltat_neg_cut);
 
-//    fOutputList->Add(dedx_mom_m2_pos);
-//    fOutputList->Add(dedx_mom_m2_pos_cut);    
-//    fOutputList->Add(dedx_mom_m2_neg);
-//    fOutputList->Add(dedx_mom_m2_neg_cut);
+    fOutputList->Add(deut_dphi_T);
+    fOutputList->Add(deut_dphi_A);
+    fOutputList->Add(deut_dphi_B);
+    fOutputList->Add(deut_dphi_pos_T);
+    fOutputList->Add(deut_dphi_pos_A);
+    fOutputList->Add(deut_dphi_pos_B);
+    fOutputList->Add(deut_dphi_neg_T);
+    fOutputList->Add(deut_dphi_neg_A);
+    fOutputList->Add(deut_dphi_neg_B);
+
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -274,9 +340,7 @@ void AliAnalysisTaskCorPIDTOFQA::UserCreateOutputObjects()
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
-    PostData(1, fOutputList);           // postdata will notify the analysis manager of changes / updates to the 
-                                        // fOutputList object. the manager will in the end take care of writing your output to file
-                                        // so it needs to know what's in the output
+    PostData(1, fOutputList);
 }
 
 
@@ -291,27 +355,12 @@ void AliAnalysisTaskCorPIDTOFQA::UserExec(Option_t *)
 
 //    	Double_t pi = 3.1415926535897932384626434;
     NEvents++;
-    // user exec
-    // this function is called once for each event
-    // the manager will take care of reading the events from file, and with the static function InputEvent() you 
-    // have access to the current event. 
-    // once you return from the UserExec function, the manager will retrieve the next event from the chain
-    fAOD = dynamic_cast<AliAODEvent*>(InputEvent());    // get an event (called fAOD) from the input file
-                                                        // there's another event format (ESD) which works in a similar wya
-                                                        // but is more cpu/memory unfriendly. for now, we'll stick with aod's
-    if(!fAOD) return;                                   // if the pointer to the event is empty (getting it failed) skip this event
-        // example part: i'll show how to loop over the tracks in an event 
-        // and extract some information from them which we'll store in a histogram
 
+    fAOD = dynamic_cast<AliAODEvent*>(InputEvent());
+    if(!fAOD) return;
 
+    Int_t iTracks(fAOD->GetNumberOfTracks());
 
-    Int_t iTracks(fAOD->GetNumberOfTracks());           // see how many tracks there are in the event
-
-
-
-//  fPIDResponse->SetTOFResponse(fAOD,AliPIDResponse::kTOF0);
-//  fPIDResponse->SetTOFResponse(fAOD,AliPIDResponse::kT00);
-//  fPIDResponse->SetTOFResponse(fAOD,AliPIDResponse::kBest0);
 
     
     //////////////////////////////////////// MULTIPLICITY PART ////////////////////////////////////////
@@ -321,6 +370,22 @@ void AliAnalysisTaskCorPIDTOFQA::UserExec(Option_t *)
     ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 
+
+    
+    int NDeuterons           = 0;
+    int NDeuterons_pos       = 0;
+    int NDeuterons_neg       = 0;
+    int deut_flag_T          = 0;
+    int deut_flag_A          = 0;
+    int deut_flag_B          = 0;
+    int deut_track_num_T     = -9999;;
+    int deut_track_num_A     = -9999;;
+    int deut_track_num_B     = -9999;;
+    int associated_tracks   = 0;
+
+
+
+	
     struct track_node        // linked list, for efficient, dynamically allocated memory use
     {
 	int track_num;
@@ -342,10 +407,8 @@ void AliAnalysisTaskCorPIDTOFQA::UserExec(Option_t *)
 
         AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(i));         // get a track (type AliAODTrack) from the event
         if(!track) continue;                                                       // if we failed, skip this track
-//	if(!(track->IsHybridGlobalConstrainedGlobal())){   continue;   }
+	if(!(track->IsHybridGlobalConstrainedGlobal())){   continue;   }
 
-//	generic->Fill(track->IsPrimaryCandidate());
-	
 	if(!track->IsPrimaryCandidate())   continue;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////	
@@ -381,8 +444,6 @@ void AliAnalysisTaskCorPIDTOFQA::UserExec(Option_t *)
 	if(nTPCclusters<70)     continue;                          // No of TPC Clusters
 
 
-
-	//generic->Fill(nPointsITS);
 
 	
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////	
@@ -473,46 +534,13 @@ void AliAnalysisTaskCorPIDTOFQA::UserExec(Option_t *)
 		Double_t length         = 0.0;
 		length                  = fPIDResponse->GetTOFResponse().GetExpectedSignal(track,AliPID::kPion)*1E-3*c; // in meters
 		length                  = length * 100;                                                                 // convert mm to c
-
-		Int_t channel           = 0;
-		channel                 = fPIDResponse->GetTOFResponse().GetTOFchannel(track);
-//		Double_t xy_length      = 0.00;
-//		xy_length               = length * TMath::Sin(track_theta);
-
-		if(channel >=4330)
-		{
-		    Double_t start_time     = fPIDResponse->GetTOFResponse().GetStartTime(track->P());                      // in ps
-		    Double_t stop_time      = track->GetTOFsignal();
-		    Double_t time_of_flight = stop_time - start_time;
-		    time_of_flight          = time_of_flight * 0.001;                                                       // convert ps to ns
-
-//		    path_length->Fill(length);
-//		    ttof->Fill(time_of_flight);
-		}
 	    }
 	    
 //	    Float_t mom_tpc = track->GetTPCmomentum();
 	    Float_t dedx   = track->GetTPCsignal();
 	    Float_t deltat = tof_minus_tpion(track);
 
-//	    int pid_cut = 0;
-//	    Double_t exptimes[20];
-//	    track->GetIntegratedTimes(exptimes);
-//	    Double_t time = track->GetTOFsignal();  //
-//	    fPIDResponse->NumberOfSigmas(AliPIDResponse::kTOF,track,(AliPID::EParticleType) 2, nsigmaTOF);  // always 1 // 2 = pion, 4 = proton
-//	    dedx_exp_deut->Fill(fPIDResponse->GetTOFResponse().GetExpectedSignal(track,AliPID::kProton));  //
-//	    if(NEvents % 200 == 0)   cout<<fPIDResponse->GetTOFResponse().GetExpectedSignal(track,AliPID::kProton)<<" ";  // 10,000 to 50,000
-//	    track->GetIntegratedTimes(exptimes, AliPID::kProton);
-//	    track->GetIntegratedTimes(exptimes, AliPID::kDeuteron);
-//	    if(NEvents % 200 == 0)   cout<<(exptimes[5]-exptimes[4])/1000<<" ";
-//	    if(NEvents % 200 == 0)   cout<<(exptimes[5])/1000<<" ";  // doesn't work
-//	    if(mom > 0.8  &&  mom < 1.0)
-//	    {
-//		if(NEvents % 200 == 0)   cout<<fPIDResponse->GetTOFResponse().GetExpectedSignal(track,AliPID::kDeuteron)*1E-3<<" ";
-//		if(NEvents % 200 == 0)   cout<<fPIDResponse->GetTOFResponse().GetExpectedSignal(track,AliPID::kProton)*1E-3<<endl;
-//	    }
-//	    dedx_exp_deut->Fill(exptimes[4]/1000);
-	    
+
 //    kElectron =  0;
 //    kMuon     =  1;
 //    kPion     =  2;
@@ -569,13 +597,41 @@ void AliAnalysisTaskCorPIDTOFQA::UserExec(Option_t *)
 //			    dedx_mom_m2_pos_cut->Fill(dedx, mom, m2tof);
 			}
 		    }
-		}
+		    
+		    if(mom >= 1.5  &&  mom < 4.4)
+		    {
+			for(int w=0; w<3; w++){   fit_deut_curve->SetParameter(w, deut_curves[0][0][w]);   }
+			deut_mean = fit_deut_curve->Eval(mom);
+			for(int w=0; w<3; w++){   fit_deut_curve->SetParameter(w, deut_curves[0][1][w]);   }
+			deut_sigma = fit_deut_curve->Eval(mom);
+
+			if(m2tof < deut_mean + cut_width * deut_sigma  &&   m2tof > deut_mean - cut_width * deut_sigma)
+			{
+			    m_squared_pos_cut_T->Fill(mom,m2tof);
+			    deut_track_num_T = i;
+			    // deut_track_num_pos_T = i;
+			    NDeuterons++;
+			    NDeuterons_pos++;
+			    deut_flag_T = 1;
+			}
+			else if(m2tof < deut_mean -1 + cut_width * deut_sigma  &&   m2tof > deut_mean -1 - cut_width * deut_sigma)
+			{
+			    m_squared_pos_cut_A->Fill(mom,m2tof);
+			    deut_flag_A = 1;
+			    deut_track_num_A = i;
+			}
+			else if(m2tof < deut_mean +1 + cut_width * deut_sigma  &&   m2tof > deut_mean +1 - cut_width * deut_sigma)
+			{
+			    m_squared_pos_cut_B->Fill(mom,m2tof);
+			    deut_flag_B = 1;
+			    deut_track_num_B = i;
+			}		    
+		    }
+		    
+
 		
-		//Float_t beta_prot = 0.0;
-		//Float_t beta_deut = 0.0;
-		//beta_prot = mom / sqrt(0.88035 + pow(mom,2));  // mass-squared of proton is 0.88035
-		//beta_deut = mom / sqrt(3.52332 + pow(mom,2));  // mass-squared of proton is 3.52332
-		//if(fabs(beta_prot - beta) > fabs(beta_deut - beta))
+
+		}
 	    }
 	    
 	    else if(charge < 0)
@@ -606,21 +662,382 @@ void AliAnalysisTaskCorPIDTOFQA::UserExec(Option_t *)
 			    dedx_vs_mom_neg_cut->Fill(   mom, dedx);
 			    if(mom >= 2.0  &&  mom < 3.0)    dedx_vs_deltat_neg_cut->Fill(deltat, dedx);
 			    dedx_mom_deltat_neg_cut->Fill(dedx, mom, deltat);
-//			    dedx_mom_m2_neg_cut->Fill(dedx, mom, m2tof);
 			}
 		    }
-		}
 
-		//Float_t beta_prot = 0.0;
-		//Float_t beta_deut = 0.0;
-		//beta_prot = mom / sqrt(0.88035 + pow(mom,2));  // mass-squared of proton is 0.88035
-		//beta_deut = mom / sqrt(3.52332 + pow(mom,2));  // mass-squared of proton is 3.52332
-		//if(fabs(beta_prot - beta) > fabs(beta_deut - beta))
+		    if(mom >= 1.5  &&  mom < 4.4)
+		    {
+			for(int w=0; w<3; w++){   fit_deut_curve->SetParameter(w, deut_curves[0][0][w]);   }
+			deut_mean = fit_deut_curve->Eval(mom);
+			for(int w=0; w<3; w++){   fit_deut_curve->SetParameter(w, deut_curves[0][1][w]);   }
+			deut_sigma = fit_deut_curve->Eval(mom);
+
+			if(m2tof < deut_mean + cut_width * deut_sigma  &&   m2tof > deut_mean - cut_width * deut_sigma)
+			{
+			    m_squared_neg_cut_T->Fill(mom,m2tof);
+			    deut_track_num_T = i;
+			    // deut_track_num_neg_T = i;
+			    NDeuterons++;
+			    NDeuterons_neg++;
+			    deut_flag_T = 1;
+			}
+			else if(m2tof < deut_mean -1 + cut_width * deut_sigma  &&   m2tof > deut_mean -1 - cut_width * deut_sigma)
+			{
+			    m_squared_neg_cut_A->Fill(mom,m2tof);
+			    deut_flag_A = 1;
+			    deut_track_num_A = i;
+			}
+			else if(m2tof < deut_mean +1 + cut_width * deut_sigma  &&   m2tof > deut_mean +1 - cut_width * deut_sigma)
+			{
+			    m_squared_neg_cut_B->Fill(mom,m2tof);
+			    deut_flag_B = 1;
+			    deut_track_num_B = i;
+			}		    
+		    }
+		    
+		    
+		}
 	    }
 	}    //   track has both TPC and TOF PID, tracks are o.k.
     }        //   end of track loop
 
 
+    deuterons_per_event->Fill(NDeuterons);
+    deuterons_per_event_pos->Fill(NDeuterons_pos);
+    deuterons_per_event_neg->Fill(NDeuterons_neg);
+
+    if(deut_flag_T > 0)
+    {
+//	DeuteronCandidates++;
+	int j = deut_track_num_T;
+
+	AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(j));
+	if(!track) {}
+	else
+	{
+	    Double_t deut_phi = track->Phi();
+	    Double_t deut_mom = track->P();
+	    Short_t  charge   = track->Charge();
+	    Double_t deut_eta = track->Eta();
+
+	    Double_t deut_ket = 0.0;
+	    
+	    deut_ket = sqrt(pow(deut_mom,2) + pow(2.224,2)) - 2.224;
+	    
+	    conductor = root->next;
+	    if (conductor != 0)
+	    {
+		while(conductor->next != 0)
+		{
+		    int k = conductor->track_num;
+		    conductor = conductor->next;
+		    
+		    if(k != j)  // if the k-th track is not the j-th track which is the deuteron of interest
+		    {
+//		    NAssociatedTracks++;
+			AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(k));         // get a track (type AliAODTrack) from the event
+			if(!track){}                                                               // if we failed, skip this track
+			else
+			{
+			    Double_t mom            = track->P();
+			    Double_t phi            = track->Phi();
+			    
+
+			    if(mom > 2.0  &&  mom < 5.0)
+			    {
+				Double_t dphi = deut_phi - phi;
+				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+				
+				deut_dphi_T->Fill(deut_mom, dphi);
+				
+				if(charge>0) {   deut_dphi_pos_T->Fill(deut_mom, dphi);   }
+				if(charge<0) {   deut_dphi_neg_T->Fill(deut_mom, dphi);   }
+				dphi_ket_deut_T->Fill(deut_ket, dphi);
+				
+			    }
+			}
+		    }
+		}
+	    
+		int k = conductor->track_num;
+		conductor = conductor->next;
+//	    NAssociatedTracks++;
+		if(k != j)  // if the k-th track is not the j-th track which is the deuteron of interest
+		{
+		    AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(k));         // get a track (type AliAODTrack) from the event
+		    if(!track){}                                                               // if we failed, skip this track
+		    else
+		    {
+			Double_t mom            = track->P();
+			Double_t phi            = track->Phi();
+			
+			if(mom > 2.0  &&  mom < 5.0)
+			{
+			    Double_t dphi = deut_phi - phi;
+			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+			    
+			    deut_dphi_T->Fill(deut_mom, dphi);
+			    if(charge>0) {   deut_dphi_pos_T->Fill(deut_mom, dphi);   }
+			    if(charge<0) {   deut_dphi_neg_T->Fill(deut_mom, dphi);   }
+			    dphi_ket_deut_T->Fill(deut_ket, dphi);
+			}
+//			if(deut_mom >= 3.25  &&  deut_mom < 4.25)
+//			{
+//			    Double_t eta            = track->Eta();			    
+//			    Double_t dphi = deut_phi - phi;
+//			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+//			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+//			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+//			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+			    
+//			    if(     mom >= 0.5  &&  mom < 1.0){   deut_dphi_deta_p0510->Fill(dphi, deut_eta - eta);    }
+//			    else if(mom >= 1.0  &&  mom < 2.0){   deut_dphi_deta_p1020->Fill(dphi, deut_eta - eta);    }
+//			    else if(mom >= 2.0  &&  mom < 3.0){   deut_dphi_deta_p2030->Fill(dphi, deut_eta - eta);    }
+//			    if(     mom >= 1.0  &&  mom < 5.0){   deut_dphi_deta_p1050->Fill(dphi, deut_eta - eta);    }
+//			}
+		    }
+		}
+	    }
+	}
+    }  // end of deuteron correlation PRIMARY LOOP
+
+
+    if(deut_flag_A > 0)
+    {
+//	DeuteronCandidates++;
+	int j = deut_track_num_A;
+
+	AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(j));
+	if(!track) {}
+	else
+	{
+	    Double_t deut_phi = track->Phi();
+	    Double_t deut_mom = track->P();
+	    Short_t  charge   = track->Charge();
+	    Double_t deut_eta = track->Eta();
+
+	    Double_t deut_ket = 0.0;
+	    
+	    deut_ket = sqrt(pow(deut_mom,2) + pow(2.224,2)) - 2.224;
+	    
+	    conductor = root->next;
+	    if (conductor != 0)
+	    {
+		while(conductor->next != 0)
+		{
+		    int k = conductor->track_num;
+		    conductor = conductor->next;
+		    
+		    if(k != j)  // if the k-th track is not the j-th track which is the deuteron of interest
+		    {
+//		    NAssociatedTracks++;
+			AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(k));         // get a track (type AliAODTrack) from the event
+			if(!track){}                                                               // if we failed, skip this track
+			else
+			{
+			    Double_t mom            = track->P();
+			    Double_t phi            = track->Phi();
+			    
+
+			    if(mom > 2.0  &&  mom < 5.0)
+			    {
+				Double_t dphi = deut_phi - phi;
+				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+				
+				deut_dphi_A->Fill(deut_mom, dphi);
+				
+				if(charge>0) {   deut_dphi_pos_A->Fill(deut_mom, dphi);   }
+				if(charge<0) {   deut_dphi_neg_A->Fill(deut_mom, dphi);   }
+				dphi_ket_deut_A->Fill(deut_ket, dphi);
+				
+			    }
+//			    if(deut_mom >= 3.25  &&  deut_mom < 4.25)
+//			    {
+//				Double_t eta  = track->Eta();
+//				Double_t dphi = deut_phi - phi;
+//				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+//				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+//				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+//				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+				
+//				if(     mom >= 0.5  &&  mom < 1.0){   deut_dphi_deta_p0510->Fill(dphi, deut_eta - eta);    }
+//				else if(mom >= 1.0  &&  mom < 2.0){   deut_dphi_deta_p1020->Fill(dphi, deut_eta - eta);    }
+//				else if(mom >= 2.0  &&  mom < 3.0){   deut_dphi_deta_p2030->Fill(dphi, deut_eta - eta);    }
+//				if(     mom >= 1.0  &&  mom < 5.0){   deut_dphi_deta_p1050->Fill(dphi, deut_eta - eta);    }
+//			    }
+			}
+		    }
+		}
+	    
+		int k = conductor->track_num;
+		conductor = conductor->next;
+//	    NAssociatedTracks++;
+		if(k != j)  // if the k-th track is not the j-th track which is the deuteron of interest
+		{
+		    AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(k));         // get a track (type AliAODTrack) from the event
+		    if(!track){}                                                               // if we failed, skip this track
+		    else
+		    {
+			Double_t mom            = track->P();
+			Double_t phi            = track->Phi();
+			
+			if(mom > 2.0  &&  mom < 5.0)
+			{
+			    Double_t dphi = deut_phi - phi;
+			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+			    
+			    deut_dphi_A->Fill(deut_mom, dphi);
+			    if(charge>0) {   deut_dphi_pos_A->Fill(deut_mom, dphi);   }
+			    if(charge<0) {   deut_dphi_neg_A->Fill(deut_mom, dphi);   }
+			    dphi_ket_deut_A->Fill(deut_ket, dphi);
+			}
+//			if(deut_mom >= 3.25  &&  deut_mom < 4.25)
+//			{
+//			    Double_t eta            = track->Eta();			    
+//			    Double_t dphi = deut_phi - phi;
+//			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+//			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+//			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+//			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+			    
+//			    if(     mom >= 0.5  &&  mom < 1.0){   deut_dphi_deta_p0510->Fill(dphi, deut_eta - eta);    }
+//			    else if(mom >= 1.0  &&  mom < 2.0){   deut_dphi_deta_p1020->Fill(dphi, deut_eta - eta);    }
+//			    else if(mom >= 2.0  &&  mom < 3.0){   deut_dphi_deta_p2030->Fill(dphi, deut_eta - eta);    }
+//			    if(     mom >= 1.0  &&  mom < 5.0){   deut_dphi_deta_p1050->Fill(dphi, deut_eta - eta);    }
+//			}
+		    }
+		}
+	    }
+	}
+    }  // end of deuteron correlation A LOOP
+
+
+    if(deut_flag_B > 0)
+    {
+//	DeuteronCandidates++;
+	int j = deut_track_num_B;
+
+	AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(j));
+	if(!track) {}
+	else
+	{
+	    Double_t deut_phi = track->Phi();
+	    Double_t deut_mom = track->P();
+	    Short_t  charge   = track->Charge();
+	    Double_t deut_eta = track->Eta();
+
+	    Double_t deut_ket = 0.0;
+	    
+	    deut_ket = sqrt(pow(deut_mom,2) + pow(2.224,2)) - 2.224;
+	    
+	    conductor = root->next;
+	    if (conductor != 0)
+	    {
+		while(conductor->next != 0)
+		{
+		    int k = conductor->track_num;
+		    conductor = conductor->next;
+		    
+		    if(k != j)  // if the k-th track is not the j-th track which is the deuteron of interest
+		    {
+//		    NAssociatedTracks++;
+			AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(k));         // get a track (type AliAODTrack) from the event
+			if(!track){}                                                               // if we failed, skip this track
+			else
+			{
+			    Double_t mom            = track->P();
+			    Double_t phi            = track->Phi();
+			    
+
+			    if(mom > 2.0  &&  mom < 5.0)
+			    {
+				Double_t dphi = deut_phi - phi;
+				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+				
+				deut_dphi_B->Fill(deut_mom, dphi);
+				
+				if(charge>0) {   deut_dphi_pos_B->Fill(deut_mom, dphi);   }
+				if(charge<0) {   deut_dphi_neg_B->Fill(deut_mom, dphi);   }
+				dphi_ket_deut_B->Fill(deut_ket, dphi);
+				
+			    }
+//			    if(deut_mom >= 3.25  &&  deut_mom < 4.25)
+//			    {
+//				Double_t eta  = track->Eta();
+//				Double_t dphi = deut_phi - phi;
+//				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+//				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+//				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+//				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+				
+//				if(     mom >= 0.5  &&  mom < 1.0){   deut_dphi_deta_p0510->Fill(dphi, deut_eta - eta);    }
+//				else if(mom >= 1.0  &&  mom < 2.0){   deut_dphi_deta_p1020->Fill(dphi, deut_eta - eta);    }
+//				else if(mom >= 2.0  &&  mom < 3.0){   deut_dphi_deta_p2030->Fill(dphi, deut_eta - eta);    }
+//				if(     mom >= 1.0  &&  mom < 5.0){   deut_dphi_deta_p1050->Fill(dphi, deut_eta - eta);    }
+//			    }
+			}
+		    }
+		}
+	    
+		int k = conductor->track_num;
+		conductor = conductor->next;
+//	    NAssociatedTracks++;
+		if(k != j)  // if the k-th track is not the j-th track which is the deuteron of interest
+		{
+		    AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(k));         // get a track (type AliAODTrack) from the event
+		    if(!track){}                                                               // if we failed, skip this track
+		    else
+		    {
+			Double_t mom            = track->P();
+			Double_t phi            = track->Phi();
+			
+			if(mom > 2.0  &&  mom < 5.0)
+			{
+			    Double_t dphi = deut_phi - phi;
+			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+			    
+			    deut_dphi_B->Fill(deut_mom, dphi);
+			    if(charge>0) {   deut_dphi_pos_B->Fill(deut_mom, dphi);   }
+			    if(charge<0) {   deut_dphi_neg_B->Fill(deut_mom, dphi);   }
+			    dphi_ket_deut_B->Fill(deut_ket, dphi);
+			}
+//			if(deut_mom >= 3.25  &&  deut_mom < 4.25)
+//			{
+//			    Double_t eta            = track->Eta();			    
+//			    Double_t dphi = deut_phi - phi;
+//			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+//			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+//			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+//			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+			    
+//			    if(     mom >= 0.5  &&  mom < 1.0){   deut_dphi_deta_p0510->Fill(dphi, deut_eta - eta);    }
+//			    else if(mom >= 1.0  &&  mom < 2.0){   deut_dphi_deta_p1020->Fill(dphi, deut_eta - eta);    }
+//			    else if(mom >= 2.0  &&  mom < 3.0){   deut_dphi_deta_p2030->Fill(dphi, deut_eta - eta);    }
+//			    if(     mom >= 1.0  &&  mom < 5.0){   deut_dphi_deta_p1050->Fill(dphi, deut_eta - eta);    }
+//			}
+		    }
+		}
+	    }
+	}
+    }  // end of deuteron correlation PRIMARY LOOP
 
      
                                                      // continue until all the tracks are processed

--- a/PWGCF/Correlations/DPhi/AliAnalysisTaskCorPIDTOFQA.h
+++ b/PWGCF/Correlations/DPhi/AliAnalysisTaskCorPIDTOFQA.h
@@ -54,9 +54,6 @@ class AliAnalysisTaskCorPIDTOFQA : public AliAnalysisTaskSE
 	TH2F*                   dedx_vs_deltat_neg;
 	TH3F*                   dedx_mom_deltat_pos;
 	TH3F*                   dedx_mom_deltat_neg;
-
-//	TH3F*                   dedx_mom_m2_pos;
-//	TH3F*                   dedx_mom_m2_neg;
 	
 	TH2F*                   m_squared_pos_cut;
 	TH2F*                   m_squared_neg_cut;	
@@ -72,9 +69,30 @@ class AliAnalysisTaskCorPIDTOFQA : public AliAnalysisTaskSE
 	TH3F*                   dedx_mom_deltat_pos_cut;
 	TH3F*                   dedx_mom_deltat_neg_cut;
 
-//	TH3F*                   dedx_mom_m2_pos_cut;
-//	TH3F*                   dedx_mom_m2_neg_cut;
+	TH2F*                   dphi_ket_deut_T;
+	TH2F*                   dphi_ket_deut_A;
+	TH2F*                   dphi_ket_deut_B;
 
+	
+	TH2F*                   m_squared_pos_cut_T;
+	TH2F*                   m_squared_pos_cut_A;
+	TH2F*                   m_squared_pos_cut_B;
+	TH2F*                   m_squared_neg_cut_T;
+	TH2F*                   m_squared_neg_cut_A;
+	TH2F*                   m_squared_neg_cut_B;
+	TH2F*                   deut_dphi_T;
+	TH2F*                   deut_dphi_A;
+	TH2F*                   deut_dphi_B;
+	TH2F*                   deut_dphi_pos_T;
+	TH2F*                   deut_dphi_pos_A;
+	TH2F*                   deut_dphi_pos_B;
+	TH2F*                   deut_dphi_neg_T;
+	TH2F*                   deut_dphi_neg_A;
+	TH2F*                   deut_dphi_neg_B;
+	
+	TH1I*                   deuterons_per_event;
+	TH1I*                   deuterons_per_event_pos;
+	TH1I*                   deuterons_per_event_neg;
 	
 //	TH2F*                   mom_compare_pos;
 //	TH2F*                   mom_compare_neg;


### PR DESCRIPTION
KET scaling is added so that comparisons of deuteron correlations can better be made with hadron-hadron and proton-hadron correlations