### PR TITLE
Migrate TOF calibration AddTasks from AliRoot to AliPhysics

### DIFF
--- a/PWGPP/CMakeLists.txt
+++ b/PWGPP/CMakeLists.txt
@@ -326,6 +326,7 @@ install(FILES ITS/QA/MakeTrendingITSQA.C
 install(FILES TOF/AddTaskTOFQA.C
               TOF/AddTaskTOFqaID.C
               TOF/AddTOFAnalysisTaskCalibTree.C
+              TOF/AddTOFAnalysistaskCalibPass0.C
               DESTINATION PWGPP/TOF)
 install(FILES TOF/trending/MakeTrendingTOFQA.C
 	      TOF/trending/DrawTrendingTOFQA.C

--- a/PWGPP/CMakeLists.txt
+++ b/PWGPP/CMakeLists.txt
@@ -325,6 +325,7 @@ install(FILES ITS/QA/MakeTrendingITSQA.C
 	      DESTINATION PWGPP/ITS/QA)
 install(FILES TOF/AddTaskTOFQA.C
               TOF/AddTaskTOFqaID.C
+              TOF/AddTOFAnalysisTaskCalibTree.C
               DESTINATION PWGPP/TOF)
 install(FILES TOF/trending/MakeTrendingTOFQA.C
 	      TOF/trending/DrawTrendingTOFQA.C

--- a/PWGPP/CMakeLists.txt
+++ b/PWGPP/CMakeLists.txt
@@ -326,7 +326,7 @@ install(FILES ITS/QA/MakeTrendingITSQA.C
 install(FILES TOF/AddTaskTOFQA.C
               TOF/AddTaskTOFqaID.C
               TOF/AddTOFAnalysisTaskCalibTree.C
-              TOF/AddTOFAnalysistaskCalibPass0.C
+              TOF/AddTOFAnalysisTaskCalibPass0.C
               DESTINATION PWGPP/TOF)
 install(FILES TOF/trending/MakeTrendingTOFQA.C
 	      TOF/trending/DrawTrendingTOFQA.C

--- a/PWGPP/TOF/AddTOFAnalysisTaskCalibPass0.C
+++ b/PWGPP/TOF/AddTOFAnalysisTaskCalibPass0.C
@@ -1,0 +1,74 @@
+AliTOFAnalysisTaskCalibPass0 *
+AddTOFAnalysisTaskCalibPass0()
+{
+
+  /* check analysis manager */
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    Error("AddAnalysisTaskEventTime", "cannot get analysis manager");
+    return NULL;
+  }
+
+  /* check input event handler */
+  if (!mgr->GetInputEventHandler()) {
+    Error("AddAnalysisTaskEventTime", "cannot get input event handler");
+    return NULL;
+  }
+  
+  /* check input data type */
+  TString str = mgr->GetInputEventHandler()->GetDataType();
+  if (str.CompareTo("ESD")) {
+    Error("AddAnalysisTaskEventTime", "input data type is not \"ESD\"");
+    return NULL;
+  }
+
+  /* get common input data container */
+  AliAnalysisDataContainer *inputc = mgr->GetCommonInputContainer();
+  if (!inputc) {
+    Error("AddAnalysisTaskEventTime", "cannot get common input container");
+    return NULL;
+  }
+  
+  /* create output data container */
+  AliAnalysisDataContainer *outputc1 = mgr->CreateContainer("TOFHistos", TList::Class(), AliAnalysisManager::kOutputContainer, "AliESDfriends_v1.root");
+  if (!outputc1) {
+    Error("AddAnalysisTaskEventTime", "cannot create output container \"Histos\"");
+    return NULL;
+  }
+
+  /*  create task and connect input/output */
+  AliTOFAnalysisTaskCalibPass0 *task = new AliTOFAnalysisTaskCalibPass0();
+
+  // adding the task
+  mgr->AddTask(task);
+
+  mgr->ConnectInput(task, 0, inputc);
+  mgr->ConnectOutput(task, 1, outputc1);
+
+  /* setup task */
+  task->SetEventSelectionFlag(kTRUE);
+  task->SetVertexSelectionFlag(kTRUE);
+  task->SetVertexCut(25.0);
+  /* setup TOF calib */
+  task->GetTOFcalib()->SetRemoveMeanT0(kFALSE);
+  task->GetTOFcalib()->SetUseLHCClockPhase(kTRUE);
+  task->GetTOFcalib()->SetCalibrateTOFsignal(kTRUE);
+  task->GetTOFcalib()->SetCorrectTExp(kFALSE);
+  /* setup track cuts */
+  AliESDtrackCuts *trackCuts = task->GetTrackCuts();
+  trackCuts->SetPtRange(0.5, 10.);
+  trackCuts->SetEtaRange(-1.0, 1.0);
+  trackCuts->SetRequireITSRefit(kTRUE);
+  trackCuts->SetMinNClustersITS(1);
+  trackCuts->SetRequireTPCRefit(kTRUE);
+  trackCuts->SetMinNClustersTPC(70);
+  trackCuts->SetMaxChi2PerClusterTPC(4.);
+  trackCuts->SetAcceptKinkDaughters(kFALSE);
+  trackCuts->SetMaxDCAToVertexZ(3.2);
+  trackCuts->SetMaxDCAToVertexXY(2.4);
+  trackCuts->SetDCAToVertex2D(kTRUE);
+
+  /* return task */
+  return task;
+
+}

--- a/PWGPP/TOF/AddTOFAnalysisTaskCalibTree.C
+++ b/PWGPP/TOF/AddTOFAnalysisTaskCalibTree.C
@@ -1,0 +1,98 @@
+AliTOFAnalysisTaskCalibTree *AddTOFAnalysisTaskCalibTree()
+{
+
+  // check analysis manager 
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    Error("AddTOFAnalysisTaskCalibTree", "cannot get analysis manager");
+    return NULL;
+  }
+
+  //check input event handler
+  if (!mgr->GetInputEventHandler()) {
+    Error("AddTOFAnalysisTaskCalibTree", "cannot get input event handler");
+    return NULL;
+  }
+  
+  // check input data type 
+  TString str = mgr->GetInputEventHandler()->GetDataType();
+  if (str.CompareTo("ESD")) {
+    Error("AddTOFAnalysisTaskCalibTree", "input data type is not \"ESD\"");
+    return NULL;
+  }
+
+  // get common input data container
+  AliAnalysisDataContainer *inputc = mgr->GetCommonInputContainer();
+  if (!inputc) {
+    Error("AddTOFAnalysisTaskCalibTree", "cannot get common input container");
+    return NULL;
+  }
+  
+  // setup output event handler
+
+  // old way: expecting to use AOD tree
+  // AliAODHandler *outputh = (AliAODHandler *)mgr->GetOutputEventHandler();
+  // outputh->SetCreateNonStandardAOD();
+  // outputh->SetOutputFileName("TOFcalibTree.root");
+
+  // new way:
+  AliAnalysisDataContainer *coutput   = mgr->CreateContainer(Form("aodTree"), TTree::Class(), AliAnalysisManager::kOutputContainer, "TOFcalibTree.root"); // tree
+  if (!coutput) {
+    Error("AddTOFAnalysisTaskCalibTree", "cannot create output container");
+    return NULL;
+  }
+
+  //  create task and connect input/output 
+  AliTOFAnalysisTaskCalibTree *task = new AliTOFAnalysisTaskCalibTree();
+  mgr->ConnectInput(task, 0, inputc);
+  mgr->ConnectOutput(task, 1, coutput);
+
+  // setup task 
+  task->SetEventSelectionFlag(kFALSE);
+  task->SetVertexSelectionFlag(kTRUE);
+  task->SetVertexCut(50.0);
+  task->SetDiscardPileupEventFlag(kFALSE);
+  task->SetPrimaryDCASelectionFlag(kFALSE);
+  task->SetCalibrateTOFsignal(kTRUE);
+  task->SetComputeT0TOF(kTRUE);
+  task->SetUseT0TOF(kFALSE);
+  task->SetUseLHCClockPhase(kFALSE);
+  //  task->SetSpecificStorageParOffline("alien://?folder=/alice/cern.ch/user/r/rpreghen/OCDB");
+  //  task->SetSpecificStorageRunParams("alien://?folder=/alice/cern.ch/user/r/rpreghen/OCDB");
+
+  // setup event cuts 
+  task->GetEventCuts()->SetAnalyzeMC(kFALSE);
+
+  // setup TOF calib 
+  task->GetTOFcalib()->SetRemoveMeanT0(kFALSE);
+  task->GetTOFcalib()->SetCalibrateTOFsignal(kTRUE);
+  task->GetTOFcalib()->SetCorrectTExp(kFALSE);
+
+  //setup resolution 
+  Double_t timeReso = 100.;
+
+  // setup TOF response 
+  //task->GetESDpid()->GetTOFResponse().SetTimeResolution(timeReso);
+
+  // setup TOF-T0 maker 
+  task->GetTOFT0maker()->SetTimeResolution(timeReso);
+
+  // setup track cuts 
+  AliESDtrackCuts *trackCuts = task->GetTrackCuts();
+  trackCuts->SetPtRange(0.15, 10.);
+  trackCuts->SetEtaRange(-1.0, 1.0);
+  trackCuts->SetRequireITSRefit(kTRUE);
+  trackCuts->SetMinNClustersITS(1);
+  //  trackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSPD, AliESDtrackCuts::kAny);
+  trackCuts->SetRequireTPCRefit(kTRUE);
+  trackCuts->SetMinNClustersTPC(70);
+  trackCuts->SetMaxChi2PerClusterTPC(4.);
+  trackCuts->SetAcceptKinkDaughters(kFALSE);
+  trackCuts->SetMaxDCAToVertexZ(3.2);
+  trackCuts->SetMaxDCAToVertexXY(2.4);
+  trackCuts->SetDCAToVertex2D(kTRUE);
+
+  // return task 
+  return task;
+
+}


### PR DESCRIPTION
Tasks AliTOFAnalysisTaskCalibTree & AliTOFAnalysisTaskCalibPass0 had been migrated to AliPhysics after AliRoot/AliPhysics split, but AddTask macros were orphaned in AliRoot (& not added to any CMakeLists, so inaccessible from LEGO train system). This patch migrates the missing macros to where they should be.