### PR TITLE
PWG/CALO: fix for missing return value in AliCaloNonlinearity.h

### DIFF
--- a/PWG/CALO/AliCaloNonLinearity.h
+++ b/PWG/CALO/AliCaloNonLinearity.h
@@ -88,7 +88,7 @@ class AliCaloNonLinearity : public AliAnalysisCuts {
     Float_t     FunctionNL_kSDMv6(Float_t e);
     Float_t     FunctionNL_kTestBeamv2(Float_t e);
     Float_t     FunctionNL_kTestBeamv3(Float_t e);
-    Bool_t      IsSelected(TList*   /* list */ ) {;}
+    Bool_t      IsSelected(TList*   /* list */ ) {return kTRUE;}
 
   protected:
 


### PR DESCRIPTION
- this request fixes a compilation error for the new PWGCALO library