### PR TITLE
Additional info to do improved vertexing with KFParticle

### DIFF
--- a/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
+++ b/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
@@ -483,6 +483,14 @@ void AliAnalysisTaskReducedTreeMaker::FillEventInfo()
      estimator = multSelection->GetEstimator("RefMult08"); if(estimator) eventInfo->fMultiplicityEstimators[9] = estimator->GetValue();     
   }
   
+  if(eventVtx){
+    Double_t covTracks[6];
+    eventVtx->GetCovarianceMatrix(covTracks);
+    for(Int_t i=0;i<6;++i) {
+      eventInfo->fVtxCovMatrix[i] = covTracks[i];
+    }
+  }
+  
   AliVVertex* eventVtxSPD = 0x0;
   if(isESD) eventVtxSPD = const_cast<AliESDVertex*>(esdEvent->GetPrimaryVertexSPD());
   if(isAOD) eventVtxSPD = const_cast<AliAODVertex*>(aodEvent->GetPrimaryVertexSPD());
@@ -1165,6 +1173,20 @@ void AliAnalysisTaskReducedTreeMaker::FillTrackInfo()
       if(esdTrack->IsEMCAL()) trackInfo->fCaloClusterId = esdTrack->GetEMCALcluster();
       if(esdTrack->IsPHOS()) trackInfo->fCaloClusterId = esdTrack->GetPHOScluster();
       
+      Double_t xyz[3], pxpypz[3];
+      Double_t covMat[21];
+      esdTrack->GetXYZ(xyz);
+      esdTrack->GetPxPyPz(pxpypz);
+      esdTrack->GetCovarianceXYZPxPyPz(covMat);
+      for(Int_t i=0;i<3;++i) {
+        trackInfo->fTrackParam[i] = xyz[i];
+        trackInfo->fTrackParam[i+3] = pxpypz[i];
+      }
+      for(Int_t i=0;i<21;++i) {
+        trackInfo->fCovMatrix[i] = covMat[i];
+      }
+      
+      
       if(fFillMCInfo && hasMC) {
          AliMCParticle* truthParticle = AliDielectronMC::Instance()->GetMCTrack(esdTrack);
          if(truthParticle) {
@@ -1247,6 +1269,19 @@ void AliAnalysisTaskReducedTreeMaker::FillTrackInfo()
       if(aodTrack->IsEMCAL()) trackInfo->fCaloClusterId = aodTrack->GetEMCALcluster();
       if(aodTrack->IsPHOS()) trackInfo->fCaloClusterId = aodTrack->GetPHOScluster();
       
+      Double_t xyz[3], pxpypz[3];
+      Double_t covMat[21];
+      aodTrack->GetXYZ(xyz);
+      aodTrack->GetPxPyPz(pxpypz);
+      aodTrack->GetCovarianceXYZPxPyPz(covMat);
+      for(Int_t i=0;i<3;++i) {
+        trackInfo->fTrackParam[i] = xyz[i];
+        trackInfo->fTrackParam[i+3] = pxpypz[i];
+      }
+      for(Int_t i=0;i<21;++i) {
+        trackInfo->fCovMatrix[i] = covMat[i];
+      }
+        
       if(fFillMCInfo && hasMC) {
          AliAODMCParticle* truthParticle = AliDielectronMC::Instance()->GetMCTrack(aodTrack);
          if(truthParticle) {
@@ -1282,6 +1317,9 @@ void AliAnalysisTaskReducedTreeMaker::FillTrackInfo()
             }
          }
       }
+      
+      
+      
     }  // end if(isAOD)
 
     fReducedEvent->fNtracks[1] += 1;

--- a/PWGDQ/reducedTree/AliReducedEventInfo.cxx
+++ b/PWGDQ/reducedTree/AliReducedEventInfo.cxx
@@ -41,6 +41,7 @@ AliReducedEventInfo::AliReducedEventInfo() :
   fIsSPDPileup(kFALSE),
   fIsSPDPileupMultBins(kFALSE),
   fIRIntClosestIntMap(),
+  fVtxCovMatrix(),
   fVtxTPC(),
   fNVtxTPCContributors(0),
   fVtxSPD(),
@@ -76,6 +77,7 @@ AliReducedEventInfo::AliReducedEventInfo() :
   // Constructor
   //
   for(Int_t i=0; i<2; ++i) fIRIntClosestIntMap[i] = 0;
+  for(Int_t i=0; i<6; ++i) fVtxCovMatrix[i]=0.;
   for(Int_t i=0; i<3; ++i) fVtxTPC[i]=-999.;
   for(Int_t i=0; i<3; ++i) fVtxSPD[i]=-999.;
   for(Int_t i=0; i<10; ++i) fMultiplicityEstimators[i]=-999.;

--- a/PWGDQ/reducedTree/AliReducedEventInfo.h
+++ b/PWGDQ/reducedTree/AliReducedEventInfo.h
@@ -38,11 +38,12 @@ class AliReducedEventInfo : public AliReducedBaseEvent {
   Bool_t    IsSPDPileup()                     const {return fIsSPDPileup;}
   Bool_t    IsSPDPileupMultBins()             const {return fIsSPDPileupMultBins;}
   Int_t     IRIntClosestIntMap(Int_t id)      const {return (id>=0 && id<2 ? fIRIntClosestIntMap[id] : -999);}
+  Float_t   VertexCovMatrix(Int_t iCov = 0)   const {return (iCov>=0 && iCov<6 ? fVtxCovMatrix[iCov] : 0.0);}
   Float_t   VertexTPC(Int_t axis)             const {return (axis>=0 && axis<=2 ? fVtxTPC[axis] : 0);}
   Int_t     VertexTPCContributors()           const {return fNVtxTPCContributors;}
   Float_t   VertexSPD(Int_t axis)             const {return (axis>=0 && axis<=2 ? fVtxSPD[axis] : 0);}
   Int_t     VertexSPDContributors()           const {return fNVtxSPDContributors;}
-  Int_t     NTPCClusters()                      const {return fNTPCclusters;}
+  Int_t     NTPCClusters()                    const {return fNTPCclusters;}
   Float_t   VertexTZERO()                     const {return fT0zVertex;}
   Int_t     NpileupSPD()                      const {return fNpileupSPD;}
   Int_t     NpileupTracks()                   const {return fNpileupTracks;}
@@ -154,6 +155,7 @@ class AliReducedEventInfo : public AliReducedBaseEvent {
   Bool_t    fIsSPDPileup;           // identified as pileup event by SPD
   Bool_t    fIsSPDPileupMultBins;   // identified as pileup event by SPD in multiplicity bins
   Int_t     fIRIntClosestIntMap[2]; // out of bunch interactions, [0]-Int1, [1]-Int2 
+  Float_t   fVtxCovMatrix[6];       // Covariance matrix of the event vertex
   Float_t   fVtxTPC[3];             // TPC only event vertex       
   Int_t     fNVtxTPCContributors;   // TPC only event vertex contributors
   Float_t   fVtxSPD[3];             // SPD only event vertex

--- a/PWGDQ/reducedTree/AliReducedTrackInfo.cxx
+++ b/PWGDQ/reducedTree/AliReducedTrackInfo.cxx
@@ -58,11 +58,14 @@ AliReducedTrackInfo::AliReducedTrackInfo() :
   fTRDpid(),
   fTRDpidLQ2D(),
   fCaloClusterId(-999),
+  fTrackParam(),
+  fCovMatrix(),
   fMCMom(),
   fMCFreezeout(),
   fMCLabels(),
   fMCPdg(),
   fMCGeneratorIndex(-1)
+
 {
   //
   // Constructor
@@ -75,6 +78,8 @@ AliReducedTrackInfo::AliReducedTrackInfo() :
   fTRDpidLQ2D[0] = -999.; fTRDpidLQ2D[1] = -999.;
   for(Int_t i=0;i<3;++i) {fMCMom[i]=0.; fMCFreezeout[i]=0.;}
   for(Int_t i=0;i<4;++i) {fMCLabels[i]=-9999; fMCPdg[i]=-9999;}
+  for(Int_t i=0;i<6;++i) {fTrackParam[i]=0.;}
+  for(Int_t i=0;i<21;++i) {fCovMatrix[i]=0.;}
 }
 
 

--- a/PWGDQ/reducedTree/AliReducedTrackInfo.h
+++ b/PWGDQ/reducedTree/AliReducedTrackInfo.h
@@ -81,6 +81,9 @@ class AliReducedTrackInfo : public AliReducedBaseTrack {
   
   Int_t    CaloClusterId() const {return fCaloClusterId;}
   
+  Float_t TrackParam(Int_t iPar = 0) {return (iPar>=0 && iPar<6 ? fTrackParam[iPar] : 0.0);}
+  Float_t CovMatrix(Int_t iCov = 0) {return (iCov>=0 && iCov<22 ? fCovMatrix[iCov] : 0.0);}
+  
   Float_t MCmom(Int_t dim) {return (dim>=0 && dim<3 ? fMCMom[dim] : 0.0);}
   Float_t PtMC() {return TMath::Sqrt(fMCMom[0]*fMCMom[0]+fMCMom[1]*fMCMom[1]);}
   Float_t PMC()   const {return TMath::Sqrt(fMCMom[0]*fMCMom[0]+fMCMom[1]*fMCMom[1]+fMCMom[2]*fMCMom[2]);}
@@ -93,6 +96,8 @@ class AliReducedTrackInfo : public AliReducedBaseTrack {
   Int_t MCLabel(Int_t history=0) {return (history>=0 && history<4 ? fMCLabels[history] : -9999);}
   Int_t MCPdg(Int_t history=0) {return (history>=0 && history<4 ? fMCPdg[history] : -9999);}
   Short_t MCGeneratorIndex() {return fMCGeneratorIndex;}
+  
+
      
  protected:
   UShort_t fTrackId;            // track id 
@@ -147,12 +152,19 @@ class AliReducedTrackInfo : public AliReducedBaseTrack {
   // EMCAL/PHOS
   Int_t  fCaloClusterId;          // ID for the calorimeter cluster (if any)
   
+  // Track parameters stored at the primary vertex
+  Float_t fTrackParam[6];     // parameters: x, y, z, px, py, pz
+  Float_t fCovMatrix[21];     // covariance matrix for the track parameter
+  
+  
   // Monte-Carlo truth information
   Float_t fMCMom[3];             // MC truth 3-momentum information in cartezian coordinates
   Float_t fMCFreezeout[3];    // MC truth 3-position information in cartezian coordinates
   Int_t    fMCLabels[4];           // MC label for: [0] - the current track, [1] - mother, [2] - grand mother, [3] - grand grand mother 
   Int_t    fMCPdg[4];                // MC PDG code for: [0] - the current track, [1] - mother, [2] - grand mother, [3] - grand grand mother 
   Short_t fMCGeneratorIndex;    // generator index (used for cocktail generators ?)
+  
+
   
           
   AliReducedTrackInfo(const AliReducedTrackInfo &c);

--- a/PWGDQ/reducedTree/AliReducedTrackInfo.h
+++ b/PWGDQ/reducedTree/AliReducedTrackInfo.h
@@ -82,7 +82,7 @@ class AliReducedTrackInfo : public AliReducedBaseTrack {
   Int_t    CaloClusterId() const {return fCaloClusterId;}
   
   Float_t TrackParam(Int_t iPar = 0) {return (iPar>=0 && iPar<6 ? fTrackParam[iPar] : 0.0);}
-  Float_t CovMatrix(Int_t iCov = 0) {return (iCov>=0 && iCov<22 ? fCovMatrix[iCov] : 0.0);}
+  Float_t CovMatrix(Int_t iCov = 0) {return (iCov>=0 && iCov<21 ? fCovMatrix[iCov] : 0.0);}
   
   Float_t MCmom(Int_t dim) {return (dim>=0 && dim<3 ? fMCMom[dim] : 0.0);}
   Float_t PtMC() {return TMath::Sqrt(fMCMom[0]*fMCMom[0]+fMCMom[1]*fMCMom[1]);}


### PR DESCRIPTION
In order to use KFParticle offline it is necessary to store the 
track parameters and covariance matrix for each electron track,
therefore these parameters are included in AliReducedTrackInfo,
besides the covariance matrix of the event vertex is needed to 
use the topological constraint of the KFParticle