### PR TITLE
MLtreemaker update

### DIFF
--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.cxx
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.cxx
@@ -113,7 +113,7 @@ AliAnalysisTaskMLTreeMaker::AliAnalysisTaskMLTreeMaker():
   gMultiplicity(-999),
   chi2ITS(0),
   chi2TPC(0),
-  chi2Global(0),
+//  chi2GlobalPerNDF(0),
   nITSshared(0),
   chi2GlobalvsTPC(0),
   fCutMaxChi2TPCConstrainedVsGlobalVertexType(0),
@@ -195,7 +195,8 @@ AliAnalysisTaskMLTreeMaker::AliAnalysisTaskMLTreeMaker(const char *name) :
   fESDTrackCuts(0),
   gMultiplicity(-999),
   chi2ITS(0),
-  chi2TPC(0),
+//  chi2TPC(0),
+  chi2GlobalPerNDF(0),      
   chi2Global(0),
   nITSshared(0),
   chi2GlobalvsTPC(0),
@@ -322,8 +323,9 @@ void AliAnalysisTaskMLTreeMaker::UserCreateOutputObjects() {
   fTree->Branch("nITS", &nITS);
   fTree->Branch("nITSshared_frac", &nITSshared);
   fTree->Branch("chi2ITS", &chi2ITS);
-  fTree->Branch("chi2TPC", &chi2TPC);
-  fTree->Branch("chi2GlobalvsTPC", &chi2GlobalvsTPC);
+//  fTree->Branch("chi2TPC", &chi2TPC);
+//  fTree->Branch("chi2GlobalvsTPC", &chi2GlobalvsTPC);
+  fTree->Branch("chi2GlobalPerNDF", &chi2GlobalPerNDF);
   
   if(hasMC) {
       
@@ -481,8 +483,8 @@ Int_t AliAnalysisTaskMLTreeMaker::GetAcceptedTracks(AliVEvent *event, Double_t g
   nITS.clear();
   nITSshared.clear();
   chi2ITS.clear();
-  chi2TPC.clear();
-  chi2Global.clear();
+//  chi2TPC.clear();
+//  chi2Global.clear();
   chi2GlobalvsTPC.clear();
   pdg.clear();
   pdgmother.clear();
@@ -693,25 +695,29 @@ Int_t AliAnalysisTaskMLTreeMaker::GetAcceptedTracks(AliVEvent *event, Double_t g
       chi2ITS.push_back(track->GetITSchi2());
       chi2TPC.push_back(track->GetTPCchi2());//this variable will be always 0 for AODs (not yet in)
       
-      fCutMaxChi2TPCConstrainedVsGlobalVertexType = fESDTrackCuts->kVertexTracks | fESDTrackCuts->kVertexSPD;
+      if(isAOD) chi2GlobalPerNDF.push_back(((AliAODTrack*)track)->Chi2perNDF());
+      else      chi2GlobalvsTPC.push_back(0.);       //to be implemented!
 
-      const AliVVertex* vertex = 0;
-      if (fCutMaxChi2TPCConstrainedVsGlobalVertexType & fESDTrackCuts->kVertexTracks){
-        vertex = track->GetEvent()->GetPrimaryVertexTracks();}
-      
-      if ((!vertex || !vertex->GetStatus()) && fCutMaxChi2TPCConstrainedVsGlobalVertexType & fESDTrackCuts->kVertexSPD){
-	      vertex = track->GetEvent()->GetPrimaryVertexSPD();}
 	
-      if ((!vertex || !vertex->GetStatus()) && fCutMaxChi2TPCConstrainedVsGlobalVertexType & fESDTrackCuts->kVertexTPC){
-	      vertex = track->GetEvent()->GetPrimaryVertexTPC();}
+//      fCutMaxChi2TPCConstrainedVsGlobalVertexType = fESDTrackCuts->kVertexTracks | fESDTrackCuts->kVertexSPD;
+//
+//      const AliVVertex* vertex = 0;
+//      if (fCutMaxChi2TPCConstrainedVsGlobalVertexType & fESDTrackCuts->kVertexTracks){
+//        vertex = track->GetEvent()->GetPrimaryVertexTracks();}
+//      
+//      if ((!vertex || !vertex->GetStatus()) && fCutMaxChi2TPCConstrainedVsGlobalVertexType & fESDTrackCuts->kVertexSPD){
+//	      vertex = track->GetEvent()->GetPrimaryVertexSPD();}
+//	
+//      if ((!vertex || !vertex->GetStatus()) && fCutMaxChi2TPCConstrainedVsGlobalVertexType & fESDTrackCuts->kVertexTPC){
+//	      vertex = track->GetEvent()->GetPrimaryVertexTPC();}
 
       // golden chi2 has to be done separately
-      if (vertex->GetStatus()){
-	if(isAOD)
-	  chi2GlobalvsTPC.push_back(((AliAODTrack*)track)->GetChi2TPCConstrainedVsGlobal());
-	else
-	  chi2GlobalvsTPC.push_back(((AliESDtrack*)track)->GetChi2TPCConstrainedVsGlobal((AliESDVertex*)vertex));
-      }
+//      if (vertex->GetStatus()){
+//	if(isAOD)
+//	  chi2GlobalvsTPC.push_back(((AliAODTrack*)track)->GetChi2TPCConstrainedVsGlobal());
+//	else
+//	  chi2GlobalvsTPC.push_back(((AliESDtrack*)track)->GetChi2TPCConstrainedVsGlobal((AliESDVertex*)vertex));
+//      }
  
       // count tracks
       acceptedTracks++;

--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.cxx
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.cxx
@@ -430,8 +430,8 @@ void AliAnalysisTaskMLTreeMaker::Terminate(Option_t *) {
 
 Double_t AliAnalysisTaskMLTreeMaker::IsEventAccepted(AliVEvent *event){
 
-  if(event->GetPrimaryVertexSPD()){
-    if (TMath::Abs(event->GetPrimaryVertexSPD()->GetZ()) < 10){
+  if(event->GetPrimaryVertex()){
+    if (TMath::Abs(event->GetPrimaryVertex()->GetZ()) < 10){
       if (event->GetPrimaryVertexSPD()->GetNContributors() > 0)
 	return 1;
     }

--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.h
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.h
@@ -21,6 +21,10 @@ class AliAnalysisTaskMLTreeMaker : public AliAnalysisTaskSE {
   AliAnalysisTaskMLTreeMaker(const char *name);
   AliAnalysisTaskMLTreeMaker();
   virtual ~AliAnalysisTaskMLTreeMaker(){} 
+  
+
+  AliDielectronVarCuts* evcuts;
+  AliDielectronVarCuts* trcuts;
    
   virtual void   UserCreateOutputObjects();
   virtual void   UserExec(Option_t *option);

--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.h
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.h
@@ -229,8 +229,8 @@ class AliAnalysisTaskMLTreeMaker : public AliAnalysisTaskSE {
   std::vector<Int_t> nITS;
   std::vector<Double_t> nITSshared;
   std::vector<Double_t> chi2ITS;
-  std::vector<Double_t> chi2TPC;
-  std::vector<Double_t> chi2Global;
+//  std::vector<Double_t> chi2TPC;
+  std::vector<Double_t> chi2GlobalPerNDF;
   std::vector<Double_t> chi2GlobalvsTPC;
   Int_t	fCutMaxChi2TPCConstrainedVsGlobalVertexType;
   

--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.h
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.h
@@ -173,7 +173,7 @@ class AliAnalysisTaskMLTreeMaker : public AliAnalysisTaskSE {
   Bool_t fPionSigmas; 
   Bool_t fKaonSigmas;
 
-  Int_t fFilterBit;// track cut bit from track selection (default = 96)
+  Int_t fFilterBit;// track cut bit from track selection (default = kTPCqualSPDany)
 
   AliESDtrackCuts* fESDTrackCuts;
   

--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.h
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.h
@@ -13,6 +13,7 @@ class AliESDtrackCuts;
 #include "AliDielectronCutGroup.h"
 #include "AliDielectronPID.h"
 #include "AliAnalysisFilter.h"
+#include "AliDielectronEventCuts.h"
 #ifndef ALIANALYSISTASKSE_H
 #endif
 
@@ -26,19 +27,19 @@ class AliAnalysisTaskMLTreeMaker : public AliAnalysisTaskSE {
   virtual ~AliAnalysisTaskMLTreeMaker(){} 
   
 
-  AliDielectronVarCuts* evcuts;
+  AliDielectronEventCuts* eventCuts;
+  AliDielectronVarCuts *eventplaneCuts;
+  AliAnalysisFilter* evfilter;
   
   AliDielectronVarCuts* trcuts;
   AliDielectronTrackCuts *trfilter;
   AliDielectronPID *pidcuts;
   AliDielectronCutGroup* cuts;
+  AliAnalysisFilter* filter; 
   
   // need this to use PID in dielectron framework
   AliDielectronVarManager* varManager;
-  
-  AliAnalysisFilter* filter;
-  
-   
+     
   virtual void   UserCreateOutputObjects();
   virtual void   UserExec(Option_t *option);
   virtual void   FinishTaskOutput();
@@ -46,6 +47,7 @@ class AliAnalysisTaskMLTreeMaker : public AliAnalysisTaskSE {
 //~ 
   
   void SetupTrackCuts();
+  void SetupEventCuts();
   
   void SetCentralityPercentileRange(Double_t min, Double_t max){
     fCentralityPercentileMin = min;

--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.h
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.h
@@ -1,5 +1,3 @@
-
-
 #ifndef ALIANALYSISTASKMLTREEMAKER_H
 #define ALIANALYSISTASKMLTREEMAKER_H
 class TH1F;
@@ -34,6 +32,9 @@ class AliAnalysisTaskMLTreeMaker : public AliAnalysisTaskSE {
   AliDielectronTrackCuts *trfilter;
   AliDielectronPID *pidcuts;
   AliDielectronCutGroup* cuts;
+  
+  // need this to use PID in dielectron framework
+  AliDielectronVarManager* varManager;
   
   AliAnalysisFilter* filter;
   
@@ -257,4 +258,3 @@ class AliAnalysisTaskMLTreeMaker : public AliAnalysisTaskSE {
 
 
 #endif
-

--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.h
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.h
@@ -10,6 +10,11 @@ class AliESDtrackCuts;
 
 
 #include "AliAnalysisTaskSE.h"
+#include "AliDielectronVarCuts.h"
+#include "AliDielectronTrackCuts.h"
+#include "AliDielectronCutGroup.h"
+#include "AliDielectronPID.h"
+#include "AliAnalysisFilter.h"
 #ifndef ALIANALYSISTASKSE_H
 #endif
 
@@ -24,14 +29,23 @@ class AliAnalysisTaskMLTreeMaker : public AliAnalysisTaskSE {
   
 
   AliDielectronVarCuts* evcuts;
+  
   AliDielectronVarCuts* trcuts;
+  AliDielectronTrackCuts *trfilter;
+  AliDielectronPID *pidcuts;
+  AliDielectronCutGroup* cuts;
+  
+  AliAnalysisFilter* filter;
+  
    
   virtual void   UserCreateOutputObjects();
   virtual void   UserExec(Option_t *option);
   virtual void   FinishTaskOutput();
   virtual void   Terminate(Option_t *);
 //~ 
-
+  
+  void SetupTrackCuts();
+  
   void SetCentralityPercentileRange(Double_t min, Double_t max){
     fCentralityPercentileMin = min;
     fCentralityPercentileMax = max;

--- a/PWGDQ/dielectron/macrosLMEE/AddTaskMLTreeMaker.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTaskMLTreeMaker.C
@@ -1,3 +1,4 @@
+
 AliAnalysisTaskMLTreeMaker *AddTaskMLTreeMaker(TString taskname = "ESDExample", 
                                              Double_t etaMin = -0.8,
                                              Double_t etaMax = 0.8,
@@ -56,4 +57,4 @@ AliAnalysisTaskMLTreeMaker *taskESD = new AliAnalysisTaskMLTreeMaker(taskname);
   mgr->ConnectOutput(taskESD, 1, coutESD);
  
  return taskESD;
- }
+}

--- a/PWGDQ/dielectron/macrosLMEE/AddTaskMLTreeMaker.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTaskMLTreeMaker.C
@@ -31,11 +31,11 @@ AliAnalysisTaskMLTreeMaker *taskESD = new AliAnalysisTaskMLTreeMaker(taskname);
    // ==========================================================================
   // user customization part
 
-  taskESD->SetEtaRange(etaMin, etaMax);
-  taskESD->SetPtRange(ptMin, ptMax);
-  taskESD->SelectCollisionCandidates(AliVEvent::kINT7);
-  taskESD->SetLoCuts(kTRUE);
-  taskESD->SetFilterBit(AliDielectronTrackCuts::kTPCqualSPDany);// for AOD analyses: TPC cuts + any SPD hit
+//  taskESD->SetEtaRange(etaMin, etaMax);
+//  taskESD->SetPtRange(ptMin, ptMax);
+//  taskESD->SelectCollisionCandidates(AliVEvent::kINT7);
+//  taskESD->SetLoCuts(kTRUE);
+//  taskESD->SetFilterBit(AliDielectronTrackCuts::kTPCqualSPDany);// for AOD analyses: TPC cuts + any SPD hit
   // ==========================================================================
 
   mgr->AddTask(taskESD);

--- a/PWGDQ/dielectron/macrosLMEE/AddTaskMLTreeMaker.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTaskMLTreeMaker.C
@@ -33,7 +33,7 @@ AliAnalysisTaskMLTreeMaker *taskESD = new AliAnalysisTaskMLTreeMaker(taskname);
 
 //  taskESD->SetEtaRange(etaMin, etaMax);
 //  taskESD->SetPtRange(ptMin, ptMax);
-//  taskESD->SelectCollisionCandidates(AliVEvent::kINT7);
+  taskESD->SelectCollisionCandidates(AliVEvent::kINT7);
 //  taskESD->SetLoCuts(kTRUE);
 //  taskESD->SetFilterBit(AliDielectronTrackCuts::kTPCqualSPDany);// for AOD analyses: TPC cuts + any SPD hit
   // ==========================================================================

--- a/PWGDQ/dielectron/macrosLMEE/AddTaskMLTreeMaker.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTaskMLTreeMaker.C
@@ -34,7 +34,7 @@ AliAnalysisTaskMLTreeMaker *taskESD = new AliAnalysisTaskMLTreeMaker(taskname);
   taskESD->SetPtRange(ptMin, ptMax);
   taskESD->SelectCollisionCandidates(AliVEvent::kINT7);
   taskESD->SetLoCuts(kTRUE);
-  taskESD->SetFilterBit(4);// for AOD analyses: TPC cuts + any SPD hit
+  taskESD->SetFilterBit(AliDielectronTrackCuts::kTPCqualSPDany);// for AOD analyses: TPC cuts + any SPD hit
   // ==========================================================================
 
   mgr->AddTask(taskESD);

--- a/PWGDQ/dielectron/macrosLMEE/AddTaskMLTreeMaker.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTaskMLTreeMaker.C
@@ -21,7 +21,7 @@ if (!mgr->GetInputEventHandler()) {
 TString analysisType = mgr->GetInputEventHandler()->GetDataType(); // can be "ESD" or "AOD"
 
  if (analysisType!="ESD"){
-   ::Error("AddTaskMLTreeMaker",  "analysis type NOT ESD --> some variables might not be filled");
+   ::Warning("AddTaskMLTreeMaker",  "analysis type NOT ESD --> some variables might not be filled");
  }
       
 


### PR DESCRIPTION
- MLtreemaker now uses AliDielectron cut classes to be consistent with nanoAOD cuts
- vertex positions are now also written to tree for no MC events
- chi2Global was replaced by chi2GlobalPerNDF

treemaker cuts and nanoAOD filter cuts were checked to be consistent