### PR TITLE
PWGCF: AliFemtoEventReaderAOD: Included method to set fRadiusXi in AliFemtoXi 

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventReaderAOD.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventReaderAOD.cxx
@@ -1472,6 +1472,7 @@ AliFemtoXi *AliFemtoEventReaderAOD::CopyAODtoFemtoXi(AliAODcascade *tAODxi)
   tFemtoXi->SetmomXiZ(tAODxi->MomXiZ());
   AliFemtoThreeVector momxi(tAODxi->MomXiX(), tAODxi->MomXiY(), tAODxi->MomXiZ());
   tFemtoXi->SetmomXi(momxi);
+  tFemtoXi->SetRadiusXi(TMath::Sqrt(tAODxi->DecayVertexXiX()*tAODxi->DecayVertexXiX()+tAODxi->DecayVertexXiY()*tAODxi->DecayVertexXiY()));
 
   tFemtoXi->SetidBac(tAODxi->GetBachID());
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXi.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXi.cxx
@@ -30,7 +30,8 @@ AliFemtoXi::AliFemtoXi():
   fEtaBac(0), fIdBac(0), fBacNSigmaTPCK(-999),fBacNSigmaTPCPi(-999),
   fBacNSigmaTPCP(-999), fBacNSigmaTOFK(-999), fBacNSigmaTOFPi(-999),
   fBacNSigmaTOFP(-999), fTPCMomentumBac(0), fTOFProtonTimeBac(0), fTOFPionTimeBac(0),
-  fTOFKaonTimeBac(0)
+  fTOFKaonTimeBac(0),
+  fRadiusXi(0.)
 {
   fTopologyMapBachelor[0] = 0;
   fTopologyMapBachelor[1] = 0;
@@ -65,7 +66,8 @@ AliFemtoXi::AliFemtoXi(const AliFemtoV0* aV0):
   fEtaBac(0), fIdBac(0), fBacNSigmaTPCK(-999),fBacNSigmaTPCPi(-999),
   fBacNSigmaTPCP(-999), fBacNSigmaTOFK(-999), fBacNSigmaTOFPi(-999),
   fBacNSigmaTOFP(-999), fTPCMomentumBac(0), fTOFProtonTimeBac(0), fTOFPionTimeBac(0),
-  fTOFKaonTimeBac(0)
+  fTOFKaonTimeBac(0),
+  fRadiusXi(0.)
 {
   fTopologyMapBachelor[0] = 0;
   fTopologyMapBachelor[1] = 0;
@@ -96,7 +98,7 @@ AliFemtoXi::AliFemtoXi(const AliFemtoXi& aXi) :
   fTPCNclsBac(aXi.fTPCNclsBac), fNdofBac(aXi.fNdofBac), fStatusBac(aXi.fStatusBac), fEtaBac(aXi.fEtaBac), fIdBac(aXi.fIdBac), 
   fBacNSigmaTPCK(aXi.fBacNSigmaTPCK), fBacNSigmaTPCPi(aXi.fBacNSigmaTPCPi), fBacNSigmaTPCP(aXi.fBacNSigmaTPCP),
   fBacNSigmaTOFK(aXi.fBacNSigmaTOFK), fBacNSigmaTOFPi(aXi.fBacNSigmaTOFPi), fBacNSigmaTOFP(aXi.fBacNSigmaTOFP), fTPCMomentumBac(aXi.fTPCMomentumBac),
-  fTOFProtonTimeBac(aXi.fTOFProtonTimeBac), fTOFPionTimeBac(aXi.fTOFPionTimeBac), fTOFKaonTimeBac(aXi.fTOFKaonTimeBac)
+  fTOFProtonTimeBac(aXi.fTOFProtonTimeBac), fTOFPionTimeBac(aXi.fTOFPionTimeBac), fTOFKaonTimeBac(aXi.fTOFKaonTimeBac), fRadiusXi(aXi.fRadiusXi)
   
 {
   // copy constructor
@@ -179,6 +181,7 @@ AliFemtoXi& AliFemtoXi::operator=(const AliFemtoXi& aXi)
   fTOFProtonTimeBac = aXi.fTOFProtonTimeBac;
   fTOFPionTimeBac = aXi.fTOFPionTimeBac;
   fTOFKaonTimeBac = aXi.fTOFKaonTimeBac;
+  fRadiusXi = aXi.fRadiusXi;
 
 
   for (int i = 0; i < 9; i++) {

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXi.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXi.h
@@ -163,6 +163,8 @@ public:
 
   int ChargeXi() const;
 
+  void SetRadiusXi(double aRadiusXi);
+  double RadiusXi() const;
 
 protected: 
   int   fCharge;                           // Charge                
@@ -242,6 +244,8 @@ protected:
   double fTOFProtonTimeBac;
   double fTOFPionTimeBac;
   double fTOFKaonTimeBac;
+
+  double fRadiusXi;
   
 };
 
@@ -382,6 +386,8 @@ inline float AliFemtoXi::BacNSigmaTOFP() const {return fBacNSigmaTOFP;}
 
 inline int AliFemtoXi::ChargeXi() const {return fCharge;}
  
+inline void AliFemtoXi::SetRadiusXi(double aRadiusXi) {fRadiusXi = aRadiusXi;}
+inline double AliFemtoXi::RadiusXi() const {return fRadiusXi;}
 
 #endif
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXiTrackCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXiTrackCut.cxx
@@ -10,7 +10,7 @@
 
 
 //------------------------------
-AliFemtoXiTrackCut::AliFemtoXiTrackCut() : AliFemtoV0TrackCut(), fMaxEtaXi(100), fMinPtXi(0), fMaxPtXi(100), fChargeXi(1.0), fMaxEtaBac(100), fMinPtBac(0), fMaxPtBac(100), fTPCNclsBac(0), fNdofBac(100), fStatusBac(0), fMaxDcaXi(0), fMinDcaXiBac(0), fMaxDcaXiDaughters(0), fMinCosPointingAngleXi(0), fMinCosPointingAngleV0toXi(0), fMaxDecayLengthXi(100.0), fInvMassXiMin(0), fInvMassXiMax(1000), fBuildPurityAidXi(false), fMinvPurityAidHistoXi(0)
+AliFemtoXiTrackCut::AliFemtoXiTrackCut() : AliFemtoV0TrackCut(), fMaxEtaXi(100), fMinPtXi(0), fMaxPtXi(100), fChargeXi(1.0), fMaxEtaBac(100), fMinPtBac(0), fMaxPtBac(100), fTPCNclsBac(0), fNdofBac(100), fStatusBac(0), fMaxDcaXi(0), fMinDcaXiBac(0), fMaxDcaXiDaughters(0), fMinCosPointingAngleXi(0), fMinCosPointingAngleV0toXi(0), fMaxDecayLengthXi(100.0), fInvMassXiMin(0), fInvMassXiMax(1000), fParticleTypeXi(kXiMinus), fRadiusXiMin(0.), fRadiusXiMax(99999.0), fBuildPurityAidXi(false), fMinvPurityAidHistoXi(0)
 {
   // Default constructor
 }
@@ -28,7 +28,7 @@ AliFemtoXiTrackCut::AliFemtoXiTrackCut(const AliFemtoXiTrackCut& aCut) :
   fNdofBac(aCut.fNdofBac),fStatusBac(aCut.fStatusBac),fMaxDcaXi(aCut.fMaxDcaXi),fMinDcaXiBac(aCut.fMinDcaXiBac),
   fMaxDcaXiDaughters(aCut.fMaxDcaXiDaughters),fMinCosPointingAngleXi(aCut.fMinCosPointingAngleXi), fMinCosPointingAngleV0toXi(aCut.fMinCosPointingAngleV0toXi),
   fMaxDecayLengthXi(aCut.fMaxDecayLengthXi),fInvMassXiMin(aCut.fInvMassXiMin),fInvMassXiMax(aCut.fInvMassXiMax),
-  fParticleTypeXi(aCut.fParticleTypeXi),fBuildPurityAidXi(aCut.fBuildPurityAidXi)
+  fParticleTypeXi(aCut.fParticleTypeXi), fRadiusXiMin(aCut.fRadiusXiMin), fRadiusXiMax(aCut.fRadiusXiMax), fBuildPurityAidXi(aCut.fBuildPurityAidXi)
 {
   //copy constructor
   if(aCut.fMinvPurityAidHistoXi) fMinvPurityAidHistoXi = new TH1D(*aCut.fMinvPurityAidHistoXi);
@@ -62,6 +62,8 @@ AliFemtoXiTrackCut& AliFemtoXiTrackCut::operator=(const AliFemtoXiTrackCut& aCut
   fInvMassXiMin = aCut.fInvMassXiMin;
   fInvMassXiMax = aCut.fInvMassXiMax;
   fParticleTypeXi = aCut.fParticleTypeXi;
+  fRadiusXiMin = aCut.fRadiusXiMin;
+  fRadiusXiMax = aCut.fRadiusXiMax;
   fBuildPurityAidXi = aCut.fBuildPurityAidXi;
 
   if(aCut.fMinvPurityAidHistoXi) fMinvPurityAidHistoXi = new TH1D(*aCut.fMinvPurityAidHistoXi);
@@ -149,6 +151,10 @@ bool AliFemtoXiTrackCut::Pass(const AliFemtoXi* aXi)
     
     //decay length
     if(aXi->DecayLengthXi()>fMaxDecayLengthXi)
+      return false;
+
+    //fiducial volume radius
+    if(aXi->RadiusXi()<fRadiusXiMin || aXi->RadiusXi()>fRadiusXiMax)
       return false;
     
  

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXiTrackCut.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXiTrackCut.h
@@ -54,6 +54,9 @@ class AliFemtoXiTrackCut : public AliFemtoV0TrackCut
   void SetMinCosPointingAngleV0toXi(double min);
   void SetParticleTypeXi(short x);
 
+  void SetRadiusXiMin(double aRadiusMin);
+  void SetRadiusXiMax(double aRadiusMax);
+
   //-----The fMinvPurityAidHistoXi is built immediately before the (final) invariant mass cut, and thus may be used to calculate the purity of the Xi collection
   void SetMinvPurityAidHistoXi(const char* name, const char* title, const int& nbins, const float& aInvMassMin, const float& aInvMassMax);  //set the Minv histogram attributes and automatically sets flag fBuildPurityAidXi=true
   TH1D* GetMinvPurityAidHistoXi();
@@ -86,6 +89,9 @@ class AliFemtoXiTrackCut : public AliFemtoV0TrackCut
   double fInvMassXiMax;
   short  fParticleTypeXi;
 
+  double fRadiusXiMin;
+  double fRadiusXiMax;
+
   bool fBuildPurityAidXi;
   TH1D* fMinvPurityAidHistoXi;
 
@@ -97,4 +103,9 @@ class AliFemtoXiTrackCut : public AliFemtoV0TrackCut
 };
 
 inline TH1D* AliFemtoXiTrackCut::GetMinvPurityAidHistoXi() {return fMinvPurityAidHistoXi;}
+
+inline void AliFemtoXiTrackCut::SetRadiusXiMin(double aRadiusMin) {fRadiusXiMin = aRadiusMin;}
+inline void AliFemtoXiTrackCut::SetRadiusXiMax(double aRadiusMax) {fRadiusXiMax = aRadiusMax;}
+
+
 #endif

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.cxx
@@ -1048,6 +1048,8 @@ AliFemtoXiTrackCutNSigmaFilter* AliFemtoAnalysisLambdaKaon::CreateXiCut(XiCutPar
   tXiCut->SetMinCosPointingAngleXi(aCutParams.minCosPointingAngleXi);
   tXiCut->SetMinCosPointingAngleV0toXi(aCutParams.minCosPointingAngleV0toXi);
   tXiCut->SetMaxDcaXi(aCutParams.maxDcaXi);
+  tXiCut->SetRadiusXiMin(aCutParams.radiusXiMin);
+  tXiCut->SetRadiusXiMax(aCutParams.radiusXiMax);
     //XiDaughters
     tXiCut->SetMaxDcaXiDaughters(aCutParams.maxDcaXiDaughters);
 
@@ -1058,7 +1060,6 @@ AliFemtoXiTrackCutNSigmaFilter* AliFemtoAnalysisLambdaKaon::CreateXiCut(XiCutPar
   tXiCut->SetTPCnclsBac(aCutParams.minTPCnclsBac);
   tXiCut->SetPtBac(aCutParams.minPtBac,aCutParams.maxPtBac);
   tXiCut->SetStatusBac(AliESDtrack::kTPCrefit);  //yes or no?
-
 
   //Lambda cuts (regular V0)
   tXiCut->SetParticleType(aCutParams.v0Type); //0=lambda
@@ -1958,6 +1959,9 @@ AliFemtoAnalysisLambdaKaon::DefaultXiCutParams()
   tReturnParams.minPtBac = 0.;
   tReturnParams.maxPtBac = 100.;
 
+  tReturnParams.radiusXiMin = 0.0;      //for now, these are default, wide open values
+  tReturnParams.radiusXiMax = 99999.0;
+
   tReturnParams.v0Type = 0;
   tReturnParams.minDcaV0 = 0.2;
   tReturnParams.minInvMassV0 = LambdaMass-0.005;
@@ -2022,6 +2026,9 @@ AliFemtoAnalysisLambdaKaon::DefaultAXiCutParams()
   tReturnParams.minTPCnclsBac = 70;
   tReturnParams.minPtBac = 0.;
   tReturnParams.maxPtBac = 100.;
+
+  tReturnParams.radiusXiMin = 0.0;      //for now, these are default, wide open values
+  tReturnParams.radiusXiMax = 99999.0;
 
   tReturnParams.v0Type = 1;
   tReturnParams.minDcaV0 = 0.2;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.h
@@ -236,6 +236,9 @@ struct XiCutParams
   double minPtBac,
          maxPtBac;
 
+  double radiusXiMin,
+         radiusXiMax;
+
   int v0Type;
   double minDcaV0;
   double minInvMassV0,

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoXiTrackCutNSigmaFilter.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoXiTrackCutNSigmaFilter.cxx
@@ -169,6 +169,9 @@ bool AliFemtoXiTrackCutNSigmaFilter::Pass(const AliFemtoXi* aXi)
     if(aXi->DecayLengthXi()>fMaxDecayLengthXi)
       return false;
     
+    //fiducial volume radius
+    if(aXi->RadiusXi()<fRadiusXiMin || aXi->RadiusXi()>fRadiusXiMax)
+      return false;
  
   if(fParticleTypeXi == kAll)
     return true;


### PR DESCRIPTION
PWGCF: AliFemtoEventReaderAOD: Included method to set fRadiusXi in AliFemtoXi class (fiducial volume radius, parallels fRadiusV0 in AliFemtoV0 class).  Also added attributes/methods in AliFemtoXi and AliFemtoXiTrackCut classes to handle this new information.