### PR TITLE
total momentum cut imposed, rapidity cut removed

### DIFF
--- a/PWGCF/EBYE/Fluctuations/AliEbyEPidEfficiencyContamination.cxx
+++ b/PWGCF/EBYE/Fluctuations/AliEbyEPidEfficiencyContamination.cxx
@@ -989,7 +989,7 @@ Bool_t AliEbyEPidEfficiencyContamination::AcceptTrackL(AliVTrack *track) const {
   }
   
   Double_t ptot = track->P();
-  //if( ptot < 0.6 || ptot > 1.5 )  return kFALSE; //cut on momentum (to compare with Anar's result)
+  if( ptot < 0.6 || ptot > 1.5 )  return kFALSE; //cut on momentum (to compare with Anar's result)
   if(track->Pt() < fPtMin || track->Pt() > fPtMax )  return kFALSE;
 
   Double_t partMass = AliPID::ParticleMass(fParticleSpecies);
@@ -1001,7 +1001,7 @@ Bool_t AliEbyEPidEfficiencyContamination::AcceptTrackL(AliVTrack *track) const {
   }
   else rap = -999.;
   
-  if( TMath::Abs(rap) > 0.5 ) return kFALSE;//rapidity cut
+  //if( TMath::Abs(rap) > 0.5 ) return kFALSE;//rapidity cut
   
   if (TMath::Abs(track->Eta()) > fEtaMax) return kFALSE; 
 
@@ -1014,7 +1014,7 @@ Bool_t AliEbyEPidEfficiencyContamination::AcceptTrackLMC(AliVParticle *particle)
   if(!particle) return kFALSE;
   if (particle->Charge() == 0.0) return kFALSE; 
   Double_t ptotMC = particle->P();
-  //if ( ptotMC < 0.6 || ptotMC > 1.5 )  return kFALSE; //cut on momentum (to compare with Anar's result)
+  if ( ptotMC < 0.6 || ptotMC > 1.5 )  return kFALSE; //cut on momentum (to compare with Anar's result)
   if (particle->Pt() < fPtMin || particle->Pt() > fPtMax) return kFALSE;
 
   //rapidity cut
@@ -1027,7 +1027,7 @@ Bool_t AliEbyEPidEfficiencyContamination::AcceptTrackLMC(AliVParticle *particle)
   }
   else rap = -999;
   
-  if( TMath::Abs(rap) > 0.5 ) return kFALSE;//rapidity cut
+  //if( TMath::Abs(rap) > 0.5 ) return kFALSE;//rapidity cut
   if (TMath::Abs(particle->Eta()) > fEtaMax) return kFALSE;
   
   return kTRUE;


### PR DESCRIPTION
Total momentum cut imposed, rapidity cut removed. This change (temporary) is made to compare results with Identity method.