### PR TITLE
EMCal CorrFW + Embed: Various small fixes

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterHadronicCorrection.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterHadronicCorrection.cxx
@@ -536,7 +536,7 @@ void AliEmcalCorrectionClusterHadronicCorrection::DoMatchedTracksLoop(Int_t iclu
   if (!cluster) return;
   
   // loop over matched tracks
-  Int_t Ntrks = Ntrks = cluster->GetNTracksMatched();
+  Int_t Ntrks = cluster->GetNTracksMatched();
   for (Int_t i = 0; i < Ntrks; ++i) {
     AliVTrack* track = 0;
     

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.cxx
@@ -51,12 +51,6 @@ ClassImp(AliEmcalCorrectionClusterizer);
 // Actually registers the class with the base class
 RegisterCorrectionComponent<AliEmcalCorrectionClusterizer> AliEmcalCorrectionClusterizer::reg("AliEmcalCorrectionClusterizer");
 
-const std::map <std::string, AliEmcalCorrectionClusterizer::EmbeddedCellEnergyType> AliEmcalCorrectionClusterizer::fgkEmbeddedCellEnergyTypeMap = {
-  {"kNonEmbedded", EmbeddedCellEnergyType::kNonEmbedded },
-  {"kEmbeddedDataMCOnly", EmbeddedCellEnergyType::kEmbeddedDataMCOnly },
-  {"kEmbeddedDataExcludeMC", EmbeddedCellEnergyType::kEmbeddedDataExcludeMC }
-};
-
 const std::map <std::string, AliEMCALRecParam::AliEMCALClusterizerFlag> AliEmcalCorrectionClusterizer::fgkClusterizerTypeMap = {
   {"kClusterizerv1", AliEMCALRecParam::kClusterizerv1 },
   {"kClusterizerNxN", AliEMCALRecParam::kClusterizerNxN },
@@ -89,7 +83,6 @@ AliEmcalCorrectionClusterizer::AliEmcalCorrectionClusterizer() :
   fShiftPhi(2),
   fShiftEta(2),
   fTRUShift(0),
-  fEmbeddedCellEnergyType(kNonEmbedded),
   fTestPatternInput(kFALSE),
   fSetCellMCLabelFromCluster(0),
   fSetCellMCLabelFromEdepFrac(0),
@@ -191,11 +184,6 @@ Bool_t AliEmcalCorrectionClusterizer::Initialize()
     }
   }
   
-  std::string embeddedCellEnergyTypeStr = "";
-  GetProperty("embeddedCellEnergyType", embeddedCellEnergyTypeStr);
-  fEmbeddedCellEnergyType = fgkEmbeddedCellEnergyTypeMap.at(embeddedCellEnergyTypeStr);
-  //Printf("embeddedCellEnergyType: %d",fEmbeddedCellEnergyType);
-
   // Only support one cluster container for the clusterizer!
   if (fClusterCollArray.GetEntries() > 1) {
     AliFatal("Passed more than one cluster container to the clusterizer, but the clusterizer only supports one cluster container!");
@@ -404,23 +392,6 @@ void AliEmcalCorrectionClusterizer::FillDigitsArray()
 
       if (cellAmplitude < 1e-6 || cellNumber < 0)
         continue;
-
-      if (fEmbeddedCellEnergyType == kEmbeddedDataMCOnly) {
-        if (cellMCLabel <= 0)
-          continue;
-        else {
-          cellAmplitude *= cellEFrac;
-          cellEFrac = 1;
-        }
-      }
-      else if (fEmbeddedCellEnergyType == kEmbeddedDataExcludeMC) {
-        if (cellMCLabel > 0)
-          continue;
-        else {
-          cellAmplitude *= 1 - cellEFrac;
-          cellEFrac = 0;
-        }
-      }
 
       // New way to set the cell MC labels,
       // valid only for MC productions with aliroot > v5-07-21

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.h
@@ -33,19 +33,6 @@ class TStopwatch;
 
 class AliEmcalCorrectionClusterizer : public AliEmcalCorrectionComponent {
  public:
-  /**
-   * @num EmbeddedCellEnergyType
-   * @brief Select which part of the embedded cell energy to use
-   */
-  enum EmbeddedCellEnergyType {
-    kNonEmbedded = 0,            //!<! Standard mode for all data where no cells are embedded
-    kEmbeddedDataMCOnly,         //!<! Use only MC energy in an embedded cells
-    kEmbeddedDataExcludeMC       //!<! Exclude MC energy in an embedded cells
-  };
-
-  /// Relates string to the embedded cell energy type enumeration for YAML configuration
-  static const std::map <std::string, AliEmcalCorrectionClusterizer::EmbeddedCellEnergyType> fgkEmbeddedCellEnergyTypeMap; //!<!
-
   /// Relates string to the clusterizer type enumeration for YAML configuration
   static const std::map <std::string, AliEMCALRecParam::AliEMCALClusterizerFlag> fgkClusterizerTypeMap; //!<!
 
@@ -95,7 +82,6 @@ protected:
   Int_t                  fShiftPhi;                       ///< shift in phi (for FixedWindowsClusterizer)
   Int_t                  fShiftEta;                       ///< shift in eta (for FixedWindowsClusterizer)
   Bool_t                 fTRUShift;                       ///< shifting inside a TRU (true) or through the whole calorimeter (false) (for FixedWindowsClusterizer)
-  EmbeddedCellEnergyType fEmbeddedCellEnergyType;         ///< Which selection of energy to use when embedding cells
   Bool_t                 fTestPatternInput;               ///< Use test pattern as input instead of cells
   
   // MC labels
@@ -128,7 +114,7 @@ protected:
   static RegisterCorrectionComponent<AliEmcalCorrectionClusterizer> reg;
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionClusterizer, 3); // EMCal correction clusterizer component
+  ClassDef(AliEmcalCorrectionClusterizer, 4); // EMCal correction clusterizer component
   /// \endcond
 };
 

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
@@ -880,7 +880,7 @@ void AliEmcalCorrectionTask::SetupContainer(AliEmcalContainerUtils::InputObject_
     }
   }
   // Embedded
-  result = AliEmcalCorrectionComponent::GetProperty("IsEmbedded", tempBool, userNode, defaultNode, false, containerName);
+  result = AliEmcalCorrectionComponent::GetProperty("embedding", tempBool, userNode, defaultNode, false, containerName);
   if (result) {
     AliDebugStream(2) << cont->GetName() << ": Setting embedding to " << (tempBool ? "enabled" : "disabled") << std::endl;
     cont->SetIsEmbedding(tempBool);
@@ -1656,7 +1656,7 @@ void AliEmcalCorrectionTask::PrintRequestedContainersInformation(AliEmcalContain
     AliEmcalContainer * cont = 0;
     for (auto containerInfo : (inputObjectType == AliEmcalContainerUtils::kCluster ? fClusterCollArray : fParticleCollArray) ) {
       cont = static_cast<AliEmcalContainer *>(containerInfo);
-      stream << "\tName: " << cont->GetName() << "\tBranch: " << cont->GetArrayName() << "\tTitle: " << cont->GetTitle() << "\tIsEmbedding:" << std::boolalpha << cont->GetIsEmbedding() << std::endl;
+      stream << "\tName: " << cont->GetName() << "\tBranch: " << cont->GetArrayName() << "\tTitle: " << cont->GetTitle() << "\tIsEmbedding: " << std::boolalpha << cont->GetIsEmbedding() << std::endl;
     }
   }
   else {

--- a/PWG/EMCAL/EMCALtasks/AliHadCorrTask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliHadCorrTask.cxx
@@ -569,7 +569,7 @@ void AliHadCorrTask::DoMatchedTracksLoop(Int_t icluster,
   if (!cluster) return;
   
   // loop over matched tracks
-  Int_t Ntrks = Ntrks = cluster->GetNTracksMatched();
+  Int_t Ntrks = cluster->GetNTracksMatched();
   for (Int_t i = 0; i < Ntrks; ++i) {
     AliVTrack* track = 0;
 

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -90,7 +90,6 @@ Clusterizer:                                        # Clusterizer component
     setCellMCLabelFromCluster: 0                    # Enables setting the cell MC label from the cluster. There are different modes depending on the value
     diffEAggregation: 0.03                          # difference E in aggregation of cells (i.e. stop aggregation if E_{new} > E_{prev} + diffEAggregation)
     useTestPatternForInput: false                   # Use test pattern for input instead of cells. Intended for testing and debugging.
-    embeddedCellEnergyType: kNonEmbedded            # Select which part of the embedded energy to use for clusterization. Disabled by default.
     cellsNames:                                     # Names of the cells input objects which should be attached to the correction
         - defaultCells                              # This object is defined above in the cells section of the input objects
     clusterContainersNames:                         # Names of the cluster input objects which should be attached to the correction


### PR DESCRIPTION
Fixes include:
- Standardize embedding options in the EMCal Correction Framework
- Fix old typos
- Resolve TRefArray errors in cluster-track matcher

See the commits for further information.

Also includes:
- Removing obsolete code to avoid confusion