### PR TITLE
Modifying filling of one histogram

### DIFF
--- a/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.cxx
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.cxx
@@ -1402,7 +1402,7 @@ Bool_t AliAnalysisTaskEMCALPhotonIsolation::ClustTrackMatching(AliVCluster *clus
   Int_t nbMObj = clust -> GetNTracksMatched();
   if(tracks->GetTrackFilterType() != AliEmcalTrackSelection::kTPCOnlyTracks)  AliError(Form("NO TPC only tracks"));
   
-  Double_t distCT=0.;
+  Double_t distCT=0.,maxdist=10.;
   
   if(nbMObj == 0)
     return kFALSE;
@@ -1444,7 +1444,8 @@ Bool_t AliAnalysisTaskEMCALPhotonIsolation::ClustTrackMatching(AliVCluster *clus
     }
     
     distCT = TMath::Sqrt(deta*deta+dphi*dphi);
-    fCTdistVSpTNC->Fill(vecClust.Pt(),distCT);
+    if(distCT<maxdist)
+      maxdist=distCT;
     
     if(candidate){
       deltaEta = fdetacut;
@@ -1463,6 +1464,8 @@ Bool_t AliAnalysisTaskEMCALPhotonIsolation::ClustTrackMatching(AliVCluster *clus
       return kTRUE;
     }
   }
+  fCTdistVSpTNC->Fill(vecClust.Pt(),distCT);
+
   return kFALSE;
 }
 


### PR DESCRIPTION
To compute an (in)efficiency for randomly rejecting neutral clusters I modified the filling of one histograms to have the distance "cluster-*closest* track" as a function of the transverse energy of the cluster.