### PR TITLE
Update AliEventCuts

### DIFF
--- a/OADB/AliEventCuts.cxx
+++ b/OADB/AliEventCuts.cxx
@@ -22,6 +22,7 @@ using std::vector;
 #include <AliMultSelection.h>
 #include <AliVEventHandler.h>
 #include <AliVMultiplicity.h>
+#include <AliVVZERO.h>
 
 #include <AliAODEvent.h>
 #include <AliESDEvent.h>
@@ -35,14 +36,15 @@ ClassImp(AliEventCuts);
 ///
 AliEventCuts::AliEventCuts(bool saveplots) : TList(),
   fUtils{},
+  fGreenLight{false},
   fMC{false},
   fRequireTrackVertex{false},
   fMinVtz{-1000.f},
   fMaxVtz{1000.f},
-  fMaxDeltaSpdTrackAbsolute{1000.f},
-  fMaxDeltaSpdTrackNsigmaSPD{1000.f},
-  fMaxDeltaSpdTrackNsigmaTrack{20000.f},
-  fMaxResolutionSPDvertex{1000.f},
+  fMaxDeltaSpdTrackAbsolute{1.e14},
+  fMaxDeltaSpdTrackNsigmaSPD{1.e14},
+  fMaxDeltaSpdTrackNsigmaTrack{1.e14},
+  fMaxResolutionSPDvertex{1.e14f},
   fRejectDAQincomplete{false},
   fRequiredSolenoidPolarity{0},
   fUseMultiplicityDependentPileUpCuts{false},
@@ -59,6 +61,7 @@ AliEventCuts::AliEventCuts(bool saveplots) : TList(),
   fMultSelectionEvCuts{false},
   fUseVariablesCorrelationCuts{false},
   fUseEstimatorsCorrelationCut{false},
+  fUseStrongVarCorrelationCut{false},
   fEstimatorsCorrelationCoef{0.,1.},
   fEstimatorsSigmaPars{10000.,0.,0.,0.},
   fDeltaEstimatorNsigma{1.,1.},
@@ -68,6 +71,7 @@ AliEventCuts::AliEventCuts(bool saveplots) : TList(),
   fESDvsTPConlyLinearCut{1.e8,0.},
   fMultiplicityV0McorrCut{nullptr},
   fFB128vsTrklLinearCut{1.e8,0.},
+  fVZEROvsTPCoutPolCut{1.e8,0.,0.,0.,0.},
   fRequireExactTriggerMask{false},
   fTriggerMask{AliVEvent::kAny},
   fContainer{},
@@ -83,6 +87,7 @@ AliEventCuts::AliEventCuts(bool saveplots) : TList(),
   fOverrideAutoTriggerMask{false},
   fOverrideAutoPileUpCuts{false},
   fCutStats{nullptr},
+  fNormalisationHist{nullptr},
   fVtz{nullptr},
   fDeltaTrackSPDvtz{nullptr},
   fCentrality{nullptr},
@@ -91,13 +96,16 @@ AliEventCuts::AliEventCuts(bool saveplots) : TList(),
   fTOFvsFB32{nullptr},
   fTPCvsAll{nullptr},
   fMultvsV0M{nullptr},
-  fTPCvsTrkl{nullptr}
+  fTPCvsTrkl{nullptr},
+  fVZEROvsTPCout{nullptr}
 {
   SetName("AliEventCuts");
   SetOwner(true);
 }
 
 bool AliEventCuts::AcceptEvent(AliVEvent *ev) {
+  if (fGreenLight) return true; /// Bypass all the selections
+
   /// If not specified the cuts are set according to the run period
   const int current_run = ev->GetRunNumber();
   if (!fManualMode && current_run != fCurrentRun) {
@@ -127,28 +135,33 @@ bool AliEventCuts::AcceptEvent(AliVEvent *ev) {
   if ((selected_trigger == fTriggerMask && fRequireExactTriggerMask) || (selected_trigger && !fRequireExactTriggerMask))
     fFlag |= BIT(kTrigger);
 
-  /// Vertex selection
+  /// Vertex existance
   const AliVVertex* vtTrc = ev->GetPrimaryVertex();
   const AliVVertex* vtSPD = ev->GetPrimaryVertexSPD();
+  if (vtSPD->GetNContributors() > 0) fFlag |= BIT(kVertexSPD);
+  if (vtTrc->GetNContributors() > 1) fFlag |= BIT(kVertexTracks);
+  if (((fFlag & BIT(kVertexTracks)) ||  !fRequireTrackVertex) && (fFlag & BIT(kVertexSPD))) fFlag |= BIT(kVertex);
   const AliVVertex* &vtx = (vtTrc->GetNContributors() < 2) ? vtSPD : vtTrc;
+  fPrimaryVertex = const_cast<AliVVertex*>(vtx);
+
+  /// Vertex position cut
+  if (vtSPD->GetZ() >= fMinVtz && vtSPD->GetZ() <= fMaxVtz) fFlag |= BIT(kVertexPositionSPD);
+  if (vtTrc->GetZ() >= fMinVtz && vtTrc->GetZ() <= fMaxVtz) fFlag |= BIT(kVertexPositionTracks);
+  if (vtx->GetZ()   >= fMinVtz && vtx->GetZ()   <= fMaxVtz) fFlag |= BIT(kVertexPosition);
+
+  /// Vertex quality cuts
   double covTrc[6],covSPD[6];
   vtTrc->GetCovarianceMatrix(covTrc);
   vtSPD->GetCovarianceMatrix(covSPD);
-  double dz = vtTrc->GetZ() - vtSPD->GetZ();
+  double dz = bool(fFlag & kVertexSPD) && bool(fFlag & kVertexTracks) ? vtTrc->GetZ() - vtSPD->GetZ() : 0.; /// If one of the two vertices is not available this cut is always passed.
   double errTot = TMath::Sqrt(covTrc[5]+covSPD[5]);
   double errTrc = TMath::Sqrt(covTrc[5]);
   double nsigTot = TMath::Abs(dz) / errTot, nsigTrc = TMath::Abs(dz) / errTrc;
-
-  /// Vertex position cut
-  if (vtx->GetZ() >= fMinVtz && vtx->GetZ() <= fMaxVtz) fFlag |= BIT(kVertexPosition);
-
-  /// Vertex quality cuts
-  if (((vtTrc->GetNContributors() >= 2 ||  !fRequireTrackVertex) && vtSPD->GetNContributors() >= 1) && // Check if SPD vertex is there and (if required) check if Track vertex is present.
+  if (
       (TMath::Abs(dz) <= fMaxDeltaSpdTrackAbsolute && nsigTot <= fMaxDeltaSpdTrackNsigmaSPD && nsigTrc <= fMaxDeltaSpdTrackNsigmaTrack) && // discrepancy track-SPD vertex
       (!vtSPD->IsFromVertexerZ() || TMath::Sqrt(covSPD[5]) <= fMaxResolutionSPDvertex)
      ) // quality cut on vertexer SPD z
     fFlag |= BIT(kVertexQuality);
-  fPrimaryVertex = const_cast<AliVVertex*>(vtx);
 
   /// Pile-up rejection
   AliVMultiplicity* mult = ev->GetMultiplicity();
@@ -158,7 +171,6 @@ bool AliEventCuts::AcceptEvent(AliVEvent *ev) {
     else if (ntrkl < 50) fSPDpileupMinContributors = 4;
     else fSPDpileupMinContributors = 5;
   }
-  fUtils.SetMinPlpContribMV(fSPDpileupMinContributors);
   if (!ev->IsPileupFromSPD(fSPDpileupMinContributors,fSPDpileupMinZdist,fSPDpileupNsigmaZdist,fSPDpileupNsigmaDiamXY,fSPDpileupNsigmaDiamZ) &&
       (!fTrackletBGcut || !fUtils.IsSPDClusterVsTrackletBG(ev)) &&
       (!fPileUpCutMV || !fUtils.IsPileUpMV(ev)))
@@ -193,17 +205,25 @@ bool AliEventCuts::AcceptEvent(AliVEvent *ev) {
     const double fb32tof = fContainer.fMultTrkFB32TOF;
     const double fb128 = fContainer.fMultTrkTPC;
     const double esd = fContainer.fMultESD;
+
     const double mu32tof = PolN(fb32,fTOFvsFB32correlationPars,3);
     const double sigma32tof = PolN(fb32,fTOFvsFB32sigmaPars, 5);
+    const double vzero_tpcout_limit = PolN(double(fContainer.fMultTrkTPCout),fVZEROvsTPCoutPolCut,4);
+
     const bool multV0Mcut = (fMultiplicityV0McorrCut) ? fb32acc > fMultiplicityV0McorrCut->Eval(fCentPercentiles[0]) : true;
+
     if ((fb32tof <= mu32tof + fTOFvsFB32nSigmaCut[0] * sigma32tof && fb32tof >= mu32tof - fTOFvsFB32nSigmaCut[1] * sigma32tof) &&
         (esd < fESDvsTPConlyLinearCut[0] + fESDvsTPConlyLinearCut[1] * fb128) &&
         multV0Mcut &&
-        (fb128 < fFB128vsTrklLinearCut[0] + fFB128vsTrklLinearCut[1] * ntrkl))
+        (fb128 < fFB128vsTrklLinearCut[0] + fFB128vsTrklLinearCut[1] * ntrkl) &&
+        (!fUseStrongVarCorrelationCut || fContainer.fMultVZERO > vzero_tpcout_limit)
+        )
       fFlag |= BIT(kCorrelations);
   } else fFlag |= BIT(kCorrelations);
 
-  bool allcuts = (fFlag == (BIT(kAllCuts) - 1));
+  /// Ignore the vertex position and vertex 
+  unsigned long allcuts_mask = (BIT(kAllCuts) - 1) ^ (BIT(kVertexPositionSPD) | BIT(kVertexPositionTracks) | BIT(kVertexSPD) | BIT(kVertexTracks));
+  bool allcuts = ((fFlag & allcuts_mask) == allcuts_mask);
   if (allcuts) fFlag |= BIT(kAllCuts);
   if (fCutStats) {
     for (int iCut = kNoCuts; iCut <= kAllCuts; ++iCut) {
@@ -212,6 +232,17 @@ bool AliEventCuts::AcceptEvent(AliVEvent *ev) {
     }
   }
 
+  /// Filling normalisation histogram
+  array <unsigned long,4> norm_masks {
+    BIT(kNoCuts),
+    allcuts_mask ^ (BIT(kVertex) | BIT(kVertexPosition) | BIT(kVertexQuality)),
+    allcuts_mask ^ (BIT(kVertex) | BIT(kVertexQuality)),
+    allcuts_mask
+  };
+  for (int iC = 0; iC < 4; ++iC) {
+    if ((fFlag & norm_masks[iC]) == norm_masks[iC])
+      if (fNormalisationHist) fNormalisationHist->Fill(iC);
+  }
 
   /// Filling the monitoring histograms (first iteration always filled, second iteration only for selected events.
   for (int befaft = 0; befaft < 2; ++befaft) {
@@ -224,6 +255,7 @@ bool AliEventCuts::AcceptEvent(AliVEvent *ev) {
     if (fTPCvsAll[befaft])  fTPCvsAll[befaft]->Fill(fContainer.fMultTrkTPC,float(fContainer.fMultESD) - fESDvsTPConlyLinearCut[1] * fContainer.fMultTrkTPC);
     if (fMultvsV0M[befaft]) fMultvsV0M[befaft]->Fill(GetCentrality(),fContainer.fMultTrkFB32Acc);
     if (fTPCvsTrkl[befaft]) fTPCvsTrkl[befaft]->Fill(ntrkl,fContainer.fMultTrkTPC);
+    if (fVZEROvsTPCout[befaft]) fVZEROvsTPCout[befaft]->Fill(fContainer.fMultTrkTPCout,fContainer.fMultVZERO);
     if (!allcuts) return false; /// Do not fill the "after" histograms if the event does not pass the cuts.
   }
 
@@ -239,10 +271,37 @@ void AliEventCuts::AddQAplotsToList(TList *qaList, bool addCorrelationPlots) {
   }
   static_cast<TList*>(this)->Delete();
 
-  vector<string> bin_labels = {"No cuts","DAQ Incomplete","Magnetic field choice","Trigger selection","Vertex position","Vertex quality","Pile-up","Centrality selection","Correlations","All cuts"};
+  vector<string> bin_labels = {
+    "No cuts",
+    "DAQ Incomplete",
+    "Magnetic field choice",
+    "Trigger selection",
+    "SPD vertex reconstruction",
+    "Track vertex reconstruction",
+    "Vertex reconstruction",
+    "SPD vertex position",
+    "Track vertex position",
+    "Vertex position",
+    "Vertex quality",
+    "Pile-up",
+    "Centrality selection",
+    "Correlations",
+    "All cuts"
+  };
+
+  vector<string> norm_labels = {
+    "No cuts",
+    "Event selection",
+    "Vertex reconstruction and quality",
+    "Vertex position"
+  };
+
   fCutStats = new TH1I("fCutStats",";;Number of selected events",bin_labels.size(),-.5,bin_labels.size() - 0.5);
+  fNormalisationHist = new TH1I("fNormalisationHist",";;Number of selected events",norm_labels.size(),-.5,norm_labels.size() - 0.5);
   for (int iB = 1; iB <= bin_labels.size(); ++iB) fCutStats->GetXaxis()->SetBinLabel(iB,bin_labels[iB-1].data());
+  for (int iB = 1; iB <= norm_labels.size(); ++iB) fNormalisationHist->GetXaxis()->SetBinLabel(iB,norm_labels[iB-1].data());
   qaList->Add(fCutStats);
+  qaList->Add(fNormalisationHist);
 
   string titles[2] = {"before event cuts","after event cuts"};
   for (int iS = 0; iS < 2; ++iS) {
@@ -263,10 +322,12 @@ void AliEventCuts::AddQAplotsToList(TList *qaList, bool addCorrelationPlots) {
       fTPCvsAll[iS] = new TH2F(Form("fTPCvsAll_%s",fkLabels[iS].data()),Form("%s;Multiplicity TPC;Multiplicity ESD - a_{0} #times Multiplicity TPC",titles[iS].data()),300,0.,3000.,3000,-200.,28800.);
       fMultvsV0M[iS] = new TH2F(Form("fMultvsV0M_%s",fkLabels[iS].data()),Form("%s;Centrality (V0M);FB32",titles[iS].data()),100,0.,100.,500,0.,3000.);
       fTPCvsTrkl[iS] = new TH2F(Form("fTPCvsTrkl_%s",fkLabels[iS].data()),Form("%s;SPD tracklets;FB128",titles[iS].data()),2500,0.,5000.,2500,0.,5000.);
+      fVZEROvsTPCout[iS] = new TH2F(Form("fVZEROvsTPCout_%s",fkLabels[iS].data()),Form("%s;Tracks with kTPCout on;VZERO multiplicity",titles[iS].data()),2000,0.,20000.,2000,0.,40000.);
       qaList->Add(fTOFvsFB32[iS]);
       qaList->Add(fTPCvsAll[iS]);
       qaList->Add(fMultvsV0M[iS]);
       qaList->Add(fTPCvsTrkl[iS]);
+      qaList->Add(fVZEROvsTPCout[iS]);
     }
   }
 
@@ -364,10 +425,13 @@ void AliEventCuts::ComputeTrackMultiplicity(AliVEvent *ev) {
   tmp_cont->fMultTrkFB32Acc = 0;
   tmp_cont->fMultTrkFB32TOF = 0;
   tmp_cont->fMultTrkTPC = 0;
+  tmp_cont->fMultTrkTPCout = 0;
   for (int it = 0; it < nTracks; it++) {
     if (isAOD) {
       AliAODTrack* trk = (AliAODTrack*)ev->GetTrack(it);
       if (!trk) continue;
+      if ((trk->GetStatus() & AliESDtrack::kTPCout) &&
+          trk->GetID() > 0) tmp_cont->fMultTrkTPCout++;
       if (trk->TestFilterBit(32)) {
         tmp_cont->fMultTrkFB32++;
         if ( TMath::Abs(trk->GetTOFsignalDz()) <= 10. && trk->GetTOFsignal() >= 12000. && trk->GetTOFsignal() <= 25000.)
@@ -380,6 +444,8 @@ void AliEventCuts::ComputeTrackMultiplicity(AliVEvent *ev) {
     } else {
       AliESDtrack* esdTrack = (AliESDtrack*)ev->GetTrack(it);
       if (!esdTrack) continue;
+
+      if (esdTrack->GetStatus() & AliESDtrack::kTPCout) tmp_cont->fMultTrkTPCout++;
 
       if (FB32cuts->AcceptTrack(esdTrack)) {
         tmp_cont->fMultTrkFB32++;
@@ -405,6 +471,12 @@ void AliEventCuts::ComputeTrackMultiplicity(AliVEvent *ev) {
       tmp_cont->fMultTrkTPC++;
     }
   }
+  AliVVZERO *vzero = (AliVVZERO*)ev->GetVZEROData();
+  if(vzero) {
+    tmp_cont->fMultVZERO = 0.;
+    for(int ich=0; ich < 64; ich++)
+      tmp_cont->fMultVZERO += vzero->GetMultiplicity(ich);
+  }
   ev->AddObject(tmp_cont);
   fContainer = *tmp_cont;
 }
@@ -417,8 +489,8 @@ void AliEventCuts::SetupRun2pp() {
   fMinVtz = -10.f;
   fMaxVtz = 10.f;
   fMaxDeltaSpdTrackAbsolute = 0.5f;
-  fMaxDeltaSpdTrackNsigmaSPD = 2000.f;
-  fMaxDeltaSpdTrackNsigmaTrack = 2000.f;
+  fMaxDeltaSpdTrackNsigmaSPD = 1.e14f;
+  fMaxDeltaSpdTrackNsigmaTrack = 1.e14;
   fMaxResolutionSPDvertex = 0.25f;
 
   fRejectDAQincomplete = true;
@@ -439,8 +511,6 @@ void AliEventCuts::SetupRun2pp() {
   else if (fCentralityFramework == 1) {
     fCentEstimators[0] = "V0M";
     fCentEstimators[1] = "CL0";
-    fMinCentrality = 0.f;
-    fMaxCentrality = 100.f;
   }
 
   fFB128vsTrklLinearCut[0] = 32.077;
@@ -504,6 +574,10 @@ void AliEventCuts::SetupLHC15o() {
   fESDvsTPConlyLinearCut[0] = 15000.;
   fESDvsTPConlyLinearCut[1] = 3.38;
 
+  array<double,5> vzero_tpcout_polcut = {-2000.,2.1,3.5e-5,0.,0.};
+  std::copy(vzero_tpcout_polcut.begin(),vzero_tpcout_polcut.end(),fVZEROvsTPCoutPolCut);
+  fUseStrongVarCorrelationCut = false;
+
   if(!fMultiplicityV0McorrCut) fMultiplicityV0McorrCut = new TF1("fMultiplicityV0McorrCut","[0]+[1]*x+[2]*exp([3]-[4]*x) - 5.*([5]+[6]*exp([7]-[8]*x))",0,100);
   fMultiplicityV0McorrCut->SetParameters(-6.15980e+02, 4.89828e+00, 4.84776e+03, -5.22988e-01, 3.04363e-02, -1.21144e+01, 2.95321e+02, -9.20062e-01, 2.17372e-02);
 
@@ -534,12 +608,14 @@ void AliEventCuts::SetupRun2pA(int iPeriod) {
   fMaxDeltaSpdTrackNsigmaSPD = 20.f;
   fMaxDeltaSpdTrackNsigmaTrack = 40.f;
 
-  /// No centrality cuts by default
-  fCentralityFramework = 1;
-  fUseEstimatorsCorrelationCut = false;
+  /// p-Pb MC do not have the ZDC, the following line avoid any crashes.
+  if (!fMC) {
+    fCentralityFramework = 1;
+    fUseEstimatorsCorrelationCut = false;
 
-  fCentEstimators[0] = iPeriod ? "ZNC" : "ZNA";
-  fCentEstimators[1] = iPeriod ? "V0C" : "V0A";
+    fCentEstimators[0] = iPeriod ? "ZNC" : "ZNA";
+    fCentEstimators[1] = iPeriod ? "V0C" : "V0A";
+  }
 }
 
 void  AliEventCuts::OverridePileUpCuts(int minContrib, float minZdist, float nSigmaZdist, float nSigmaDiamXY, float nSigmaDiamZ, bool ov) {

--- a/OADB/AliEventCuts.h
+++ b/OADB/AliEventCuts.h
@@ -25,7 +25,9 @@ class AliEventCutsContainer : public TNamed {
     fMultTrkFB32(-1),
     fMultTrkFB32Acc(-1),
     fMultTrkFB32TOF(-1),
-    fMultTrkTPC(-1) {}
+    fMultTrkTPC(-1),
+    fMultTrkTPCout(-1),
+    fMultVZERO(-1.) {}
 
     unsigned long fEventId;
     int fMultESD;
@@ -33,7 +35,9 @@ class AliEventCutsContainer : public TNamed {
     int fMultTrkFB32Acc;
     int fMultTrkFB32TOF;
     int fMultTrkTPC;
-  ClassDef(AliEventCutsContainer,1)
+    int fMultTrkTPCout;
+    double fMultVZERO;
+  ClassDef(AliEventCutsContainer,2)
 };
 
 class AliEventCuts : public TList {
@@ -45,6 +49,11 @@ class AliEventCuts : public TList {
       kDAQincomplete,
       kBfield,
       kTrigger,
+      kVertexSPD,
+      kVertexTracks,
+      kVertex,
+      kVertexPositionSPD,
+      kVertexPositionTracks,
       kVertexPosition,
       kVertexQuality,
       kPileUp,
@@ -65,7 +74,7 @@ class AliEventCuts : public TList {
     void   SetupRun2pp();
     void   SetupRun2pA(int iPeriod);
 
-    /// While the general philosophy here is to avoid setters and getters (this is not an API we expose)
+    /// While the general philosophy here is to avoid setters and getters
     /// for some variables (like the max z vertex position) standard the cuts usually follow some patterns
     /// (e.g. the max vertex z position is always symmetric wrt the nominal beam collision point) thus
     /// is convenient having special setters in this case.
@@ -79,6 +88,7 @@ class AliEventCuts : public TList {
 
     AliAnalysisUtils fUtils;                      ///< Analysis utils for the pileup rejection
 
+    bool          fGreenLight;                    ///< If true it will bypass all the selections.
     bool          fMC;                            ///< Set to true by the automatic setup when analysing MC (in manual mode *you* are responsible for it). In MC the correlations cuts are disabled.
     bool          fRequireTrackVertex;            ///< if true all the events with only the SPD vertex are rejected
     float         fMinVtz;                        ///< Min z position for the primary vertex
@@ -109,6 +119,7 @@ class AliEventCuts : public TList {
 
     bool          fUseVariablesCorrelationCuts;   ///< Switch on/off the cuts on the correlation between event variables
     bool          fUseEstimatorsCorrelationCut;   ///< Switch on/off the cut on the correlation between centrality estimators
+    bool          fUseStrongVarCorrelationCut;    ///< Switch on/off the strong cuts on the correlation between event variables
     double        fEstimatorsCorrelationCoef[2];  ///< fCentEstimators[0] = [0] + [1] * fCentEstimators[1]
     double        fEstimatorsSigmaPars[4];        ///< Sigma parametrisation fCentEstimators[1] vs fCentEstimators[0]
     double        fDeltaEstimatorNsigma[2];       ///< Number of sigma to cut on fCentEstimators[1] vs fCentEstimators[0]
@@ -118,6 +129,7 @@ class AliEventCuts : public TList {
     double        fESDvsTPConlyLinearCut[2];      ///< Linear cut in the ESD track vs TPC only track plane
     TF1          *fMultiplicityV0McorrCut;        //!<! Cut on the FB128 vs V0M plane
     double        fFB128vsTrklLinearCut[2];       ///< Cut on the FB128 vs Tracklet plane
+    double        fVZEROvsTPCoutPolCut[5];        ///< Cut on VZERO multipliciy vs the number of tracks with kTPCout on
 
     bool          fRequireExactTriggerMask;       ///< If true the event selection mask is required to be equal to fTriggerMask
     unsigned long fTriggerMask;                   ///< Trigger mask
@@ -126,8 +138,8 @@ class AliEventCuts : public TList {
     const string  fkLabels[2];                    ///< Histograms labels (raw/selected)
 
   private:
-    AliEventCuts(const AliEventCuts& copy) {}
-    AliEventCuts operator=(const AliEventCuts& copy) {return *this;}
+    AliEventCuts(const AliEventCuts& copy);
+    AliEventCuts operator=(const AliEventCuts& copy);
     void          AutomaticSetup (AliVEvent *ev);
     void          ComputeTrackMultiplicity(AliVEvent *ev);
     template<typename F> F PolN(F x, F* coef, int n);
@@ -148,7 +160,8 @@ class AliEventCuts : public TList {
     bool          fOverrideAutoPileUpCuts;        ///<  If true the pile-up cuts are defined by the user.
 
     /// The following pointers are used to avoid the intense usage of FindObject. The objects pointed are owned by (TList*)this.
-    TH1I* fCutStats;               //!<! Cuts statistics
+    TH1I* fCutStats;               //!<! Cuts statistics: every column keeps track of how many times a cut is passed independently from the other cuts.
+    TH1I* fNormalisationHist;      //!<! Cuts statistics: every column keeps track of how many times a cut is passed once that all the other are passed.
     TH1D* fVtz[2];                 //!<! Vertex z distribution
     TH1D* fDeltaTrackSPDvtz[2];    //!<! Difference between the vertex computed using SPD and the track vertex
     TH1D* fCentrality[2];          //!<! Centrality percentile distribution
@@ -159,8 +172,9 @@ class AliEventCuts : public TList {
     TH2F* fTPCvsAll[2];            //!<!
     TH2F* fMultvsV0M[2];           //!<!
     TH2F* fTPCvsTrkl[2];           //!<!
+    TH2F* fVZEROvsTPCout[2];       //!<!
 
-    ClassDef(AliEventCuts,1)
+    ClassDef(AliEventCuts,2)
 };
 
 template<typename F> F AliEventCuts::PolN(F x,F* coef, int n) {


### PR DESCRIPTION
- Add Ionut's cut among the options for Run2 Pb-Pb
- Disable centrality in p-Pb MC
- Add normalisation histogram for pp analyses
- Add the possibility of skipping all selections by setting a green
light variable
- Minor changes and fixes