### PR TITLE
Add possibility to disable ITS and TPC Refit

### DIFF
--- a/PWGHF/hfe/AliSelectNonHFE.cxx
+++ b/PWGHF/hfe/AliSelectNonHFE.cxx
@@ -79,6 +79,7 @@ AliSelectNonHFE::AliSelectNonHFE(const char *name, const Char_t *title)
 ,fNClusITS(2)
 ,fUseGlobalTracks(kFALSE)
 ,fRequirePointOnITS(kFALSE)
+,fRequireITSAndTPCRefit(kTRUE)
 ,fUseDCAPartnerCut(kFALSE)
 ,fDCAcutxyPartner(1.00)
 ,fDCAcutzPartner(2.00)
@@ -138,6 +139,7 @@ AliSelectNonHFE::AliSelectNonHFE()
 ,fNClusITS(2)
 ,fUseGlobalTracks(kFALSE)
 ,fRequirePointOnITS(kFALSE)
+,fRequireITSAndTPCRefit(kTRUE)
 ,fUseDCAPartnerCut(kFALSE)
 ,fDCAcutxyPartner(1.00)
 ,fDCAcutzPartner(2.00)
@@ -239,7 +241,11 @@ void AliSelectNonHFE::FindNonHFE(Int_t iTrack1, AliVParticle *Vtrack1, AliVEvent
             }
             
             //ITS and TPC refit
-            if((!(atrack2->GetStatus()&AliESDtrack::kITSrefit)|| (!(atrack2->GetStatus()&AliESDtrack::kTPCrefit)))) continue;
+            if (fRequireITSAndTPCRefit)
+            {
+                if((!(atrack2->GetStatus()&AliESDtrack::kITSrefit)|| (!(atrack2->GetStatus()&AliESDtrack::kTPCrefit))))
+                    continue;
+            }
             
             //Eta cut
             if (fUseEtaCutForPart)

--- a/PWGHF/hfe/AliSelectNonHFE.h
+++ b/PWGHF/hfe/AliSelectNonHFE.h
@@ -62,6 +62,7 @@ class AliSelectNonHFE : public TNamed {
   void SetNClustITS(Int_t nclus) {fNClusITS = nclus; fRequirePointOnITS = kTRUE; };
   void SetUseGlobalTracks() {fUseGlobalTracks = kTRUE;};
   void SetDCAPartnerCuts(Double_t xy, Double_t z) {fUseDCAPartnerCut = kTRUE; fDCAcutxyPartner = xy; fDCAcutzPartner = z;};
+  void SetUseITSTPCRefit(Bool_t Use) {fRequireITSAndTPCRefit = Use;};
 	
 	void SetTrackCuts(Double_t TPCnSigmaMin, Double_t TPCnSigmaMax) 
 	{
@@ -111,6 +112,8 @@ class AliSelectNonHFE : public TNamed {
   Bool_t fUseEtaCutForPart; // Use eta cut in partners
   Double_t fEtaCutMin; // min eta cut
   Double_t fEtaCutMax; // max eta cut
+   
+  Bool_t fRequireITSAndTPCRefit;
 
 	
   Int_t			*fLSPartner;	        //! Pointer for the LS partners index
@@ -126,7 +129,7 @@ class AliSelectNonHFE : public TNamed {
   AliSelectNonHFE(const AliSelectNonHFE&); // not implemented
   AliSelectNonHFE& operator=(const AliSelectNonHFE&); // not implemented
   
-  ClassDef(AliSelectNonHFE, 1); //!example of analysis
+  ClassDef(AliSelectNonHFE, 2); //!example of analysis
 };
 
 #endif


### PR DESCRIPTION
Hi,

In order to use the new cuts in the p-Pb analysis I have made a small flag to disable ITS and TPC refit. I need this commit to be able to run trains for systematics. The change doesn't modify the default behaviour of the task (fRequireITSAndTPCRefit = kTRUE).  So unless you explicit request, no other user is affected. Since this is a common task, I would suggest that someone else that also use it review the changes. I am tagging some people that I know use the task @crisjahnke @deepathoms. 