### PR TITLE
Get centrality for Run2 pPb

### DIFF
--- a/PWGGA/GammaConv/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConv/AliConvEventCuts.cxx
@@ -1664,7 +1664,10 @@ Bool_t AliConvEventCuts::GetUseNewMultiplicityFramework(){
       fPeriodEnum == kLHC16g2 || fPeriodEnum == kLHC16g3 ||
       fPeriodEnum == kLHC16h2a || fPeriodEnum ==  kLHC16h2b || fPeriodEnum ==  kLHC16h2c ||                                // MC PbPb 5TeV jet-jet
       fPeriodEnum == kLHC15fm ||                                                                                           // pp 13TeV
-      fPeriodEnum == kLHC15g3a3 || fPeriodEnum == kLHC15g3c3                                                               // MC pp 13TeV
+      fPeriodEnum == kLHC15g3a3 || fPeriodEnum == kLHC15g3c3 ||                                                            // MC pp 13TeV
+      fPeriodEnum == kLHC16q || fPeriodEnum == kLHC16t ||                                                                  // pPb 5TeV LHC16qt
+      fPeriodEnum == kLHC17a2a || fPeriodEnum == kLHC17a2a_fast || fPeriodEnum == kLHC17a2a_cent || fPeriodEnum == kLHC17a2a_cent_woSDD || // MC pPb 5TeV LHC16qt
+      fPeriodEnum == kLHC17a2b || fPeriodEnum == kLHC17a2b_fast || fPeriodEnum == kLHC17a2b_cent || fPeriodEnum == kLHC17a2b_cent_woSDD    // MC pPb 5TeV LHC16qt
       ){
       return kTRUE;
   } else {

--- a/PWGGA/GammaConv/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConv/AliConvEventCuts.cxx
@@ -994,7 +994,7 @@ void AliConvEventCuts::PrintCutsWithValues() {
   } else if (fIsHeavyIon == 2){
     printf("Running in pPb mode \n");
     if (fDetectorCentrality == 0){
-      printf("\t centrality selection based on V0A (V0M in case Run2)\n");
+      printf("\t centrality selection based on V0A \n");
     } else if (fDetectorCentrality == 1){
       printf("\t centrality selection based on Cl1 \n");
     } 
@@ -1684,7 +1684,7 @@ Float_t AliConvEventCuts::GetCentrality(AliVEvent *event)
     if(GetUseNewMultiplicityFramework()){
       AliMultSelection *MultSelection = (AliMultSelection*)event->FindListObject("MultSelection");
       if(fDetectorCentrality==0){
-	                               return MultSelection->GetMultiplicityPercentile("V0M",kTRUE);
+	                               return MultSelection->GetMultiplicityPercentile("V0A",kTRUE); // default for pPb
       }else if(fDetectorCentrality==1) return MultSelection->GetMultiplicityPercentile("CL1",kTRUE);
     }else{
       AliCentrality *fESDCentrality = (AliCentrality*)esdEvent->GetCentrality();
@@ -4161,6 +4161,12 @@ void AliConvEventCuts::SetPeriodEnum (TString periodName){
   ) {
     fPeriodEnum = kLHC15fm;
     fEnergyEnum = k13TeV;
+  } else if (periodName.CompareTo("LHC15n") == 0 ){
+    fPeriodEnum = kLHC15n;
+    fEnergyEnum = k5TeV;
+  } else if (periodName.CompareTo("LHC15o") == 0 ){
+    fPeriodEnum = kLHC15o;
+    fEnergyEnum = kPbPb5TeV;
   } else if (periodName.CompareTo("LHC16k") == 0 || periodName.CompareTo("LHC16l") == 0 ){
     fPeriodEnum = kLHC16kl;
     fEnergyEnum = k13TeV;
@@ -4169,19 +4175,13 @@ void AliConvEventCuts::SetPeriodEnum (TString periodName){
     fEnergyEnum = kpPb5TeV;
   } else if (periodName.CompareTo("LHC16r") == 0 ){
     fPeriodEnum = kLHC16r;
-    fEnergyEnum = kpPb5TeV;
+    fEnergyEnum = kpPb8TeV;
   } else if (periodName.CompareTo("LHC16s") == 0 ){
     fPeriodEnum = kLHC16s;
-    fEnergyEnum = kpPb5TeV;
+    fEnergyEnum = kpPb8TeV;
   } else if (periodName.CompareTo("LHC16t") == 0 ){
     fPeriodEnum = kLHC16t;
     fEnergyEnum = kpPb5TeV;
-  } else if (periodName.CompareTo("LHC15n") == 0 ){
-    fPeriodEnum = kLHC15n;
-    fEnergyEnum = k5TeV;
-  } else if (periodName.CompareTo("LHC15o") == 0 ){
-    fPeriodEnum = kLHC15o;
-    fEnergyEnum = kPbPb5TeV;
     
   // LHC10x anchored MCs
   } else if (periodName.CompareTo("LHC10d1") == 0){

--- a/PWGGA/GammaConv/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConv/AliConvEventCuts.cxx
@@ -4166,6 +4166,15 @@ void AliConvEventCuts::SetPeriodEnum (TString periodName){
   } else if (periodName.CompareTo("LHC16q") == 0 ){
     fPeriodEnum = kLHC16q;
     fEnergyEnum = kpPb5TeV;
+  } else if (periodName.CompareTo("LHC16r") == 0 ){
+    fPeriodEnum = kLHC16r;
+    fEnergyEnum = kpPb5TeV;
+  } else if (periodName.CompareTo("LHC16s") == 0 ){
+    fPeriodEnum = kLHC16s;
+    fEnergyEnum = kpPb5TeV;
+  } else if (periodName.CompareTo("LHC16t") == 0 ){
+    fPeriodEnum = kLHC16t;
+    fEnergyEnum = kpPb5TeV;
   } else if (periodName.CompareTo("LHC15n") == 0 ){
     fPeriodEnum = kLHC15n;
     fEnergyEnum = k5TeV;

--- a/PWGGA/GammaConv/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConv/AliConvEventCuts.cxx
@@ -994,7 +994,7 @@ void AliConvEventCuts::PrintCutsWithValues() {
   } else if (fIsHeavyIon == 2){
     printf("Running in pPb mode \n");
     if (fDetectorCentrality == 0){
-      printf("\t centrality selection based on V0A \n");
+      printf("\t centrality selection based on V0A (V0M in case Run2)\n");
     } else if (fDetectorCentrality == 1){
       printf("\t centrality selection based on Cl1 \n");
     } 
@@ -1683,10 +1683,8 @@ Float_t AliConvEventCuts::GetCentrality(AliVEvent *event)
   if(esdEvent){
     if(GetUseNewMultiplicityFramework()){
       AliMultSelection *MultSelection = (AliMultSelection*)event->FindListObject("MultSelection");
-      AliCentrality *fESDCentrality = (AliCentrality*)esdEvent->GetCentrality();
       if(fDetectorCentrality==0){
-        if(fIsHeavyIon==2)             return fESDCentrality->GetCentralityPercentile("V0A"); // default for pPb
-        else                           return MultSelection->GetMultiplicityPercentile("V0M",kTRUE);
+	                               return MultSelection->GetMultiplicityPercentile("V0M",kTRUE);
       }else if(fDetectorCentrality==1) return MultSelection->GetMultiplicityPercentile("CL1",kTRUE);
     }else{
       AliCentrality *fESDCentrality = (AliCentrality*)esdEvent->GetCentrality();

--- a/PWGGA/GammaConv/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConv/AliConvEventCuts.cxx
@@ -1684,7 +1684,7 @@ Float_t AliConvEventCuts::GetCentrality(AliVEvent *event)
     if(GetUseNewMultiplicityFramework()){
       AliMultSelection *MultSelection = (AliMultSelection*)event->FindListObject("MultSelection");
       if(fDetectorCentrality==0){
-	                               return MultSelection->GetMultiplicityPercentile("V0A",kTRUE); // default for pPb
+	                               return MultSelection->GetMultiplicityPercentile("V0M",kTRUE); // default for pPb
       }else if(fDetectorCentrality==1) return MultSelection->GetMultiplicityPercentile("CL1",kTRUE);
     }else{
       AliCentrality *fESDCentrality = (AliCentrality*)esdEvent->GetCentrality();

--- a/PWGGA/GammaConv/AliConvEventCuts.h
+++ b/PWGGA/GammaConv/AliConvEventCuts.h
@@ -186,6 +186,9 @@ class AliConvEventCuts : public AliAnalysisCuts {
         // 2016
         kLHC16kl,         // pp 13 TeV
         kLHC16q,          // pPb 5 TeV
+	kLHC16r,          // pPb 8 TeV
+	kLHC16s,          // pPb 8 TeV
+	kLHC16t,          // pPb 5 TeV
         // MC's corresponding to 2016 data
         kLHC16j2a1,       // anchored LHC16k pass 1 - general purpose Pythia8
         kLHC16j2b1,       // anchored LHC16k pass 1 - general purpose EPOSLHC

--- a/PWGGA/GammaConv/AliConvEventCuts.h
+++ b/PWGGA/GammaConv/AliConvEventCuts.h
@@ -593,7 +593,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
       Int_t                       fDebugLevel;                            // debug level for interactive debugging
   private:
 
-      ClassDef(AliConvEventCuts,31)
+      ClassDef(AliConvEventCuts,32)
 };
 
 


### PR DESCRIPTION
-added enum lhc16rst to AliConvEventCuts
-added lhc16qt to new framework (AliMultSelection) 
-now centrality histogram should be filled properly for those periods
-use V0M instead of V0A to get centrality (not consistent for Run1 pPb )
--might be better to use p-Pb -> V0A and Pb-p -> V0C ?, think later. 