### PR TITLE
Remove strong tracks cuts on the partner

### DIFF
--- a/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.cxx
@@ -2028,11 +2028,13 @@ void AliAnalysisTaskHFEpACorrelation::ElectronHadronCorrelation(AliVTrack *track
     if(fDCAcutFlag) fNonHFE->SetDCACut(fDCAcut);
     fNonHFE->SetAlgorithm("DCA"); //KF
     
-    fNonHFE->SetUseGlobalTracks();
+    //Remove strong cuts
+    //fNonHFE->SetUseGlobalTracks();
     //fNonHFE->SetNClustITS(2); Remove ITS cut from the partner. It generates aditional problems for NonID Background subtraction.
-    fNonHFE->SetDCAPartnerCuts(fDCAcutr, fDCAcutz);
-    fNonHFE->SetEtaCutForPart(fEtaCutMin, fEtaCutMax);
-    fNonHFE->SetTPCNclsForPID(60);
+    //fNonHFE->SetDCAPartnerCuts(fDCAcutr, fDCAcutz);
+    //fNonHFE->SetEtaCutForPart(fEtaCutMin, fEtaCutMax);
+    //fNonHFE->SetTPCNclsForPID(60);
+    fNonHFE->SetUseITSTPCRefit(kFALSE);
     
     
     fNonHFE->SetPIDresponse(fPidResponse);

--- a/PWGHF/hfe/macros/AddTaskHFEpACorrelation.C
+++ b/PWGHF/hfe/macros/AddTaskHFEpACorrelation.C
@@ -72,8 +72,8 @@ AliAnalysisTaskHFEpACorrelation *AddTaskHFEpACorrelation(
     
     if(pTBin ==2)
     {
-        Float_t pTBinsCorrelation[] = {1,2,4,6};
-        task->SetpTBins(4,pTBinsCorrelation);
+        Float_t pTBinsCorrelation[] = {0.5,1,2,4,6};
+        task->SetpTBins(5,pTBinsCorrelation);
     }
     
     else if (pTBin ==3)


### PR DESCRIPTION
The cuts are now only TPCOnlyTracks and |TPC Nsgima| < 3. There is also a small change in the AddTask to check the bin size effect. 