### PR TITLE
Adding corrections for SPDtrcklts vs Vtxz dependence  for periods LHC…

### DIFF
--- a/PWGDQ/dielectron/core/AliDielectronHelper.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronHelper.cxx
@@ -231,8 +231,8 @@ Double_t AliDielectronHelper::GetNaccTrckltsCorrected(const AliVEvent *event, Do
   if(runNo>121693 && runNo<126439) period = 2; // LHC10d PASS4 2015
 //  if(runNo>127711 && runNo<130841) period = 3; Org Fred Kramer Analysis
   if(runNo>127102 && runNo<130851) period = 3; // LHC10e PASS4 2015
-											   //pp 13 TeV CJ
-  if(runNo>258883 && runNo<260187) period = 4; // LHC16l pass1 2016 CJ analysis
+//pp 13 TeV CJ
+  if(runNo>254124 && runNo<264035) period = 4; // LHC16l,16k,16i,16j,16o pass1 2016 CJ analysis
 
   if(period<0 || period>4) return uncorrectedNacc;
 

--- a/PWGDQ/dielectron/core/AliDielectronVarManager.h
+++ b/PWGDQ/dielectron/core/AliDielectronVarManager.h
@@ -2964,7 +2964,7 @@ inline void AliDielectronVarManager::InitEstimatorAvg(const Char_t* filename) //
   const Char_t* estimatorNames[9] = {"SPDmult05","SPDmult10","SPDmult16",
 				     "ITSTPC05", "ITSTPC10", "ITSTPC16",
 				     "ITSSA05",  "ITSSA10",  "ITSSA16"};
-  const Char_t* periodNames[7] = {"LHC10b", "LHC10c", "LHC10d", "LHC10e", "LHC13b", "LHC13c", "LHC16l"};
+  const Char_t* periodNames[7] = {"LHC10b", "LHC10c", "LHC10d", "LHC10e", "LHC16l", "LHC13b", "LHC13c"};
   TFile* file=TFile::Open(filename);
   if(!file) return;
 


### PR DESCRIPTION
…16k, LHC16i, LHC16j, LHC16o (same corrections as in LHC16l period).