### PR TITLE
Fixes for TF1 in Root6

### DIFF
--- a/PWGHF/vertexingHF/AliAODPidHF.cxx
+++ b/PWGHF/vertexingHF/AliAODPidHF.cxx
@@ -1186,11 +1186,11 @@ void AliAODPidHF::SetIdBand(AliPID::EParticleType specie, AliPIDResponse::EDetec
 
   axis = min->GetXaxis();
   histFunc = new HistFunc(min);
-  TF1 *minFunc = new TF1(Form("IdMin_%d_%d", spe, det), histFunc, axis->GetBinLowEdge(axis->GetFirst()), axis->GetBinUpEdge(axis->GetLast()), 0, "HistFunc");
+  TF1 *minFunc = new TF1(Form("IdMin_%d_%d", spe, det), *histFunc, axis->GetBinLowEdge(axis->GetFirst()), axis->GetBinUpEdge(axis->GetLast()), 0, "HistFunc");
 
   axis = max->GetXaxis();
   histFunc = new HistFunc(max);
-  TF1 *maxFunc = new TF1(Form("IdMax_%d_%d", spe, det), histFunc, axis->GetBinLowEdge(axis->GetFirst()), axis->GetBinUpEdge(axis->GetLast()), 0, "HistFunc");
+  TF1 *maxFunc = new TF1(Form("IdMax_%d_%d", spe, det), *histFunc, axis->GetBinLowEdge(axis->GetFirst()), axis->GetBinUpEdge(axis->GetLast()), 0, "HistFunc");
 
   SetIdBand(specie, detector, minFunc, maxFunc);
 }
@@ -1231,11 +1231,11 @@ void AliAODPidHF::SetCompBand(AliPID::EParticleType specie, AliPIDResponse::EDet
 
   axis = min->GetXaxis();
   histFunc = new HistFunc(min);
-  TF1 *minFunc = new TF1(Form("CompMin_%d_%d", spe, det), histFunc, axis->GetBinLowEdge(axis->GetFirst()), axis->GetBinUpEdge(axis->GetLast()), 0, "HistFunc");
+  TF1 *minFunc = new TF1(Form("CompMin_%d_%d", spe, det), *histFunc, axis->GetBinLowEdge(axis->GetFirst()), axis->GetBinUpEdge(axis->GetLast()), 0, "HistFunc");
 
   axis = max->GetXaxis();
   histFunc = new HistFunc(max);
-  TF1 *maxFunc = new TF1(Form("CompMax_%d_%d", spe, det), histFunc, axis->GetBinLowEdge(axis->GetFirst()), axis->GetBinUpEdge(axis->GetLast()), 0, "HistFunc");
+  TF1 *maxFunc = new TF1(Form("CompMax_%d_%d", spe, det), *histFunc, axis->GetBinLowEdge(axis->GetFirst()), axis->GetBinUpEdge(axis->GetLast()), 0, "HistFunc");
 
   SetCompBand(specie, detector, minFunc, maxFunc);
 }

--- a/PWGPP/TPC/AliPerfAnalyzeInvPt.cxx
+++ b/PWGPP/TPC/AliPerfAnalyzeInvPt.cxx
@@ -76,7 +76,7 @@ ClassImp(AliPerfAnalyzeInvPt)
 
 // fit functions
 //____________________________________________________________________________________________________________________________________________
-   Double_t AliPerfAnalyzeInvPt::Polynomial(Double_t *x, const Double_t *par)
+   Double_t AliPerfAnalyzeInvPt::Polynomial(Double_t *x, Double_t *par)
 {
    // fit function for fitting of 1/pt with a polynomial of 4th order, rejecting points between  +/-par[4]
 
@@ -90,7 +90,7 @@ ClassImp(AliPerfAnalyzeInvPt)
 
 }
 //____________________________________________________________________________________________________________________________________________
-Double_t AliPerfAnalyzeInvPt::PolynomialRejP(Double_t *x, const Double_t *par)
+Double_t AliPerfAnalyzeInvPt::PolynomialRejP(Double_t *x, Double_t *par)
 {
    // fit function for fitting of 1/pt with a polynomial of 4th order to improve result (fit range and rejection zone is adjusted to first guess of minimum position)
      
@@ -108,7 +108,7 @@ Double_t AliPerfAnalyzeInvPt::PolynomialRejP(Double_t *x, const Double_t *par)
  
 }
 //____________________________________________________________________________________________________________________________________________
-Double_t AliPerfAnalyzeInvPt::InvGauss(Double_t *x, const Double_t *par)
+Double_t AliPerfAnalyzeInvPt::InvGauss(Double_t *x, Double_t *par)
 {
    // fit function for fitting of 1/pt with gaussian, rejecting points between  +/-par[4]
    if (x[0] > -par[6] && x[0] < par[6]) {
@@ -119,7 +119,7 @@ Double_t AliPerfAnalyzeInvPt::InvGauss(Double_t *x, const Double_t *par)
    return par[3]+par[0]*(TMath::Exp(-0.5*(TMath::Power((x[0]-par[1])/par[2], 2.0)))+par[4]*pow((x[0]-par[1]),2)+par[5]*pow((x[0]-par[1]),4)) ;
 }
 //____________________________________________________________________________________________________________________________________________
-Double_t AliPerfAnalyzeInvPt::InvGaussRejP(Double_t *x, const Double_t *par)
+Double_t AliPerfAnalyzeInvPt::InvGaussRejP(Double_t *x, Double_t *par)
 {
    // fit function for fitting of 1/pt with gaussian to improve result (fit range and rejection zone is adjusted to first guess of minimum position)
    Double_t pos  = par[7];//0.12;

--- a/PWGPP/TPC/AliPerfAnalyzeInvPt.h
+++ b/PWGPP/TPC/AliPerfAnalyzeInvPt.h
@@ -72,10 +72,10 @@ private:
    TF1 *fFitInvGaussRejP;//fit function for second fit with gaussian to improve result
 
    // infput for fit functions
-   static Double_t Polynomial(Double_t *x, const Double_t *par);
-   static Double_t PolynomialRejP(Double_t *x, const Double_t *par);
-   static Double_t InvGauss(Double_t *x, const Double_t *par);
-   static Double_t InvGaussRejP(Double_t *x, const Double_t *par);
+   static Double_t Polynomial(Double_t *x, Double_t *par);
+   static Double_t PolynomialRejP(Double_t *x, Double_t *par);
+   static Double_t InvGauss(Double_t *x, Double_t *par);
+   static Double_t InvGaussRejP(Double_t *x, Double_t *par);
 
    //functions for fitting procedure
    void MakeFit(TH1D *dmproy, TF1 * fitpb, Double_t &mean, Double_t &ErrMean,  Double_t &excl,Double_t &range);


### PR DESCRIPTION
Root6 expects reference to function f(double *, double*) that returns double.