### PR TITLE
change cut on numb. TPC clusters

### DIFF
--- a/PWGLF/STRANGENESS/Cascades/AliAnalysisTaskCheckCascadepp.cxx
+++ b/PWGLF/STRANGENESS/Cascades/AliAnalysisTaskCheckCascadepp.cxx
@@ -57,7 +57,8 @@
 //               Feb 2015
 //               - Added the possibility to select events in the class kINT7 for the pp@13TeV analysis through "fkSwitchINT7"
 //               - Revision of the event selections for the pp@13TeV analysis
-//
+//               May 2017
+//               - 
 //             
 //
 //-----------------------------------------------------------------
@@ -139,6 +140,7 @@ AliAnalysisTaskCheckCascadepp::AliAnalysisTaskCheckCascadepp()
     fTrackQualityCutTPCrefit        (kTRUE),
     fTrackQualityCutnTPCcls         (kTRUE),
     fMinnTPCcls                     (0),
+    fMinTPCcrossrawoverfindable     (0),
     fVtxRangeMax                    (10),
     fVtxRangeMin                    (0),
     fMinPtCutOnDaughterTracks       (0),
@@ -242,6 +244,7 @@ AliAnalysisTaskCheckCascadepp::AliAnalysisTaskCheckCascadepp(const char *name)
     fTrackQualityCutTPCrefit        (kTRUE),
     fTrackQualityCutnTPCcls         (kTRUE),
     fMinnTPCcls                     (0),
+    fMinTPCcrossrawoverfindable     (0),
     fVtxRangeMax                    (10),
     fVtxRangeMin                    (0),
     fMinPtCutOnDaughterTracks       (0),
@@ -726,19 +729,19 @@ void AliAnalysisTaskCheckCascadepp::UserCreateOutputObjects() {
  TString sddstatus = "";
  if      (fCollidingSystem == 0 && fApplyEvSelSDDstatus && fwithSDD)  sddstatus = "_wSDDon";
  else if (fCollidingSystem == 0 && fApplyEvSelSDDstatus && !fwithSDD) sddstatus = "_wSDDoff";
- TString cfcontname_cascpidximinus = Form("fCFContCascadePIDXiMinus_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
+ TString cfcontname_cascpidximinus = Form("fCFContCascadePIDXiMinus_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fMinTPCcrossrawoverfindable,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
  cfcontname_cascpidximinus.Append(Form("%s",sddstatus.Data()));
  cfcontname_cascpidximinus.Append(Form("%s",fSuffix.Data()));
- TString cfcontname_cascpidxiplus = Form("fCFContCascadePIDXiPlus_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
+ TString cfcontname_cascpidxiplus = Form("fCFContCascadePIDXiPlus_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fMinTPCcrossrawoverfindable,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
  cfcontname_cascpidxiplus.Append(Form("%s",sddstatus.Data()));
  cfcontname_cascpidxiplus.Append(Form("%s",fSuffix.Data()));
- TString cfcontname_cascpidomegaminus = Form("fCFContCascadePIDOmegaMinus_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
+ TString cfcontname_cascpidomegaminus = Form("fCFContCascadePIDOmegaMinus_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fMinTPCcrossrawoverfindable,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
  cfcontname_cascpidomegaminus.Append(Form("%s",sddstatus.Data()));
  cfcontname_cascpidomegaminus.Append(Form("%s",fSuffix.Data()));
- TString cfcontname_cascpidomegaplus = Form("fCFContCascadePIDOmegaPlus_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
+ TString cfcontname_cascpidomegaplus = Form("fCFContCascadePIDOmegaPlus_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fMinTPCcrossrawoverfindable,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
  cfcontname_cascpidomegaplus.Append(Form("%s",sddstatus.Data()));
  cfcontname_cascpidomegaplus.Append(Form("%s",fSuffix.Data()));
- TString cfcontname_casccuts = Form("fCFContCascadeCuts_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
+ TString cfcontname_casccuts = Form("fCFContCascadeCuts_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fMinTPCcrossrawoverfindable,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
  cfcontname_casccuts.Append(Form("%s",sddstatus.Data()));
  cfcontname_casccuts.Append(Form("%s",fSuffix.Data()));
  // - CFContainer PID study Xi minus
@@ -1527,9 +1530,12 @@ void AliAnalysisTaskCheckCascadepp::UserExec(Option_t *) {
       Double_t lPosXi[3]                   = { -1000.0, -1000.0, -1000.0 };
       Double_t lXiRadius                   = -1000. ;
       // - 2nd part of initialisation : Nbr of clusters within TPC for the 3 daughter cascade tracks
-      UShort_t lPosTPCClusters             = -1; // For ESD only ...
-      UShort_t lNegTPCClusters             = -1; // For ESD only ...
-      UShort_t lBachTPCClusters            = -1; // For ESD only ...
+      Double_t lPosTPCClusters             = -1; // For ESD only ...
+      Double_t lNegTPCClusters             = -1; // For ESD only ...
+      Double_t lBachTPCClusters            = -1; // For ESD only ...
+      Double_t lPosTPCFindClusters         = -1; // For ESD only ...
+      Double_t lNegTPCFindClusters         = -1; // For ESD only ...
+      Double_t lBachTPCFindClusters        = -1; // For ESD only ...
       Double_t lInnerWallMomCascDghters[3] = {-100., -100., -100.};
       Double_t lTPCSignalCascDghters   [3] = {-100., -100., -100.};
       // - 3rd part of initialisation : about V0 part in cascades
@@ -1627,10 +1633,14 @@ void AliAnalysisTaskCheckCascadepp::UserExec(Option_t *) {
                AliWarning("ERROR: Could not retrieve one of the 3 ESD daughter tracks of the cascade ...");
                continue;
           }
-          // - Get the TPCnumber of cluster for the daughters
-          lPosTPCClusters   = pTrackXi->GetTPCNcls();
-          lNegTPCClusters   = nTrackXi->GetTPCNcls();
-          lBachTPCClusters  = bachTrackXi->GetTPCNcls();
+          // - Get the number of TPC clusters for the daughters
+          lPosTPCClusters   = pTrackXi->GetTPCClusterInfo(2,1);             // Old for #TPCclusters: ->GetTPCNcls();
+          lNegTPCClusters   = nTrackXi->GetTPCClusterInfo(2,1);             // Old for #TPCclusters: ->GetTPCNcls();
+          lBachTPCClusters  = bachTrackXi->GetTPCClusterInfo(2,1);          // Old for #TPCclusters: ->GetTPCNcls();
+          // - Get the number TPC findable clusters for daughters
+          lPosTPCFindClusters   = pTrackXi->GetTPCNclsF();                  // New
+          lNegTPCFindClusters   = nTrackXi->GetTPCNclsF();                  // New
+          lBachTPCFindClusters  = bachTrackXi->GetTPCNclsF();               // New
 
           //-------------------------------------
           // - Rejection of a poor quality tracks
@@ -1648,6 +1658,11 @@ void AliAnalysisTaskCheckCascadepp::UserExec(Option_t *) {
                 if (lPosTPCClusters  < fMinnTPCcls) { AliWarning(Form("Pb / V0 Pos. track has less than %i TPC clusters ... continue!",fMinnTPCcls)); continue; }
                 if (lNegTPCClusters  < fMinnTPCcls) { AliWarning(Form("Pb / V0 Neg. track has less than %i TPC clusters ... continue!",fMinnTPCcls)); continue; }
                 if (lBachTPCClusters < fMinnTPCcls) { AliWarning(Form("Pb / Bach.   track has less than %i TPC clusters ... continue!",fMinnTPCcls)); continue; }
+                // - Poor quality related to clusters/findable
+                if( lPosTPCFindClusters <= 0 || lNegTPCFindClusters <= 0 || lBachTPCFindClusters ) { AliWarning("Pb / Number of findable cluster <= 0 ... continue!"); continue; }
+                if ((lPosTPCClusters/lPosTPCFindClusters)    < fMinTPCcrossrawoverfindable) { AliWarning(Form("Pb / V0 Pos. track has ratio clusters/findable < %f ... continue!",fMinTPCcrossrawoverfindable)); continue; }
+                if ((lNegTPCClusters/lNegTPCFindClusters)    < fMinTPCcrossrawoverfindable) { AliWarning(Form("Pb / V0 Neg. track has ratio clusters/findable < %f ... continue!",fMinTPCcrossrawoverfindable)); continue; }
+                if ((lBachTPCClusters/lBachTPCFindClusters)  < fMinTPCcrossrawoverfindable) { AliWarning(Form("Pb / Bach. track has ratio clusters/findable < %f ... continue!",fMinTPCcrossrawoverfindable)); continue; }
           }
 
           //-----------------------------------
@@ -1661,29 +1676,29 @@ void AliAnalysisTaskCheckCascadepp::UserExec(Option_t *) {
           if (nExtTrack) {
                 lInnerWallMomCascDghters[1] = nExtTrack->GetP() * nExtTrack->Charge();
                 lTPCSignalCascDghters   [1] = nTrackXi->GetTPCsignal();
-           }
-           if (bachExtTrack) {
+          }
+          if (bachExtTrack) {
                 lInnerWallMomCascDghters[2] = bachExtTrack->GetP() * bachExtTrack->Charge();
                 lTPCSignalCascDghters   [2] = bachTrackXi->GetTPCsignal();
-           }
-           etaPos  = pTrackXi->Eta();
-           etaNeg  = nTrackXi->Eta();
-           etaBach = bachTrackXi->Eta();
-           lInvMassLambdaAsCascDghter = xi->GetEffMass(); //This value shouldn't change, whatever the working hyp. is : Xi-, Xi+, Omega-, Omega+
-           lDcaV0DaughtersXi 	      = xi->GetDcaV0Daughters(); 
-           lV0CosineOfPointingAngleXi = xi->GetV0CosineOfPointingAngle(lBestPrimaryVtxPos[0],
-                                                                       lBestPrimaryVtxPos[1],
-                                                                       lBestPrimaryVtxPos[2] );
-           lDcaV0ToPrimVertexXi = xi->GetD( lBestPrimaryVtxPos[0], lBestPrimaryVtxPos[1], lBestPrimaryVtxPos[2] );
-           lDcaBachToPrimVertexXi = TMath::Abs( bachTrackXi->GetD( lBestPrimaryVtxPos[0], lBestPrimaryVtxPos[1], lMagneticField ) ); //Note: AliExternalTrackParam::GetD returns an algebraic value ...
-           xi->GetXYZ( lPosV0Xi[0],  lPosV0Xi[1], lPosV0Xi[2] ); 
-           lV0RadiusXi = TMath::Sqrt( lPosV0Xi[0]*lPosV0Xi[0] + lPosV0Xi[1]*lPosV0Xi[1] );	
-           lDcaPosToPrimVertexXi = TMath::Abs( pTrackXi	->GetD(	lBestPrimaryVtxPos[0], lBestPrimaryVtxPos[1], lMagneticField ) ); 
-           lDcaNegToPrimVertexXi = TMath::Abs( nTrackXi	->GetD(	lBestPrimaryVtxPos[0], lBestPrimaryVtxPos[1], lMagneticField ) ); 
+          }
+          etaPos  = pTrackXi->Eta();
+          etaNeg  = nTrackXi->Eta();
+          etaBach = bachTrackXi->Eta();
+          lInvMassLambdaAsCascDghter = xi->GetEffMass(); //This value shouldn't change, whatever the working hyp. is : Xi-, Xi+, Omega-, Omega+
+          lDcaV0DaughtersXi 	      = xi->GetDcaV0Daughters(); 
+          lV0CosineOfPointingAngleXi = xi->GetV0CosineOfPointingAngle(lBestPrimaryVtxPos[0],
+                                                                      lBestPrimaryVtxPos[1],
+                                                                      lBestPrimaryVtxPos[2] );
+          lDcaV0ToPrimVertexXi = xi->GetD( lBestPrimaryVtxPos[0], lBestPrimaryVtxPos[1], lBestPrimaryVtxPos[2] );
+          lDcaBachToPrimVertexXi = TMath::Abs( bachTrackXi->GetD( lBestPrimaryVtxPos[0], lBestPrimaryVtxPos[1], lMagneticField ) ); //Note: AliExternalTrackParam::GetD returns an algebraic value ...
+          xi->GetXYZ( lPosV0Xi[0],  lPosV0Xi[1], lPosV0Xi[2] ); 
+          lV0RadiusXi = TMath::Sqrt( lPosV0Xi[0]*lPosV0Xi[0] + lPosV0Xi[1]*lPosV0Xi[1] );	
+          lDcaPosToPrimVertexXi = TMath::Abs( pTrackXi	->GetD(	lBestPrimaryVtxPos[0], lBestPrimaryVtxPos[1], lMagneticField ) ); 
+          lDcaNegToPrimVertexXi = TMath::Abs( nTrackXi	->GetD(	lBestPrimaryVtxPos[0], lBestPrimaryVtxPos[1], lMagneticField ) ); 
 
-           //-----------------------------------------
-	   // - Extra-selection for cascade candidates
-           if (fExtraSelections) { //in AliCascadeVertexer
+          //-----------------------------------------
+          // - Extra-selection for cascade candidates
+          if (fExtraSelections) { //in AliCascadeVertexer
                 if (lDcaXiDaughters > 0.3) continue;                                              // in AliCascadeVertexer
                 if (lXiCosineOfPointingAngle < 0.999 ) continue;                                  // in AliCascadeVertexer
                 if (lDcaV0ToPrimVertexXi < 0.05) continue;                                        // in AliCascadeVertexer
@@ -1695,11 +1710,11 @@ void AliAnalysisTaskCheckCascadepp::UserExec(Option_t *) {
                 if (lDcaNegToPrimVertexXi < 0.1) continue;                                        // in AliV0vertexer
                 if (lXiRadius < .9) continue;                                                     // in AliCascadeVertexer
                 if (lV0RadiusXi < 0.9) continue;                                                  // in AliV0vertexer
-           }
+          }
 
-           //---------------------------------------------------------------------------------------------------	
-           // - Around effective masses. Change mass hypotheses to cover all the possibilities:  Xi-/+, Omega-/+
-           if ( bachTrackXi->Charge() < 0 )	{
+          //---------------------------------------------------------------------------------------------------	
+          // - Around effective masses. Change mass hypotheses to cover all the possibilities:  Xi-/+, Omega-/+
+          if ( bachTrackXi->Charge() < 0 )	{
                 //Calculate the effective mass of the Xi- candidate: Xi- hyp. (pdg code 3312)
                 lV0quality = 0.;
                 xi->ChangeMassHypothesis(lV0quality , 3312); 	
@@ -1711,8 +1726,8 @@ void AliAnalysisTaskCheckCascadepp::UserExec(Option_t *) {
                 //Back to "default" hyp. (Xi-)
                 lV0quality = 0.;
                 xi->ChangeMassHypothesis(lV0quality , 3312); 
-           } // end if negative bachelor
-           if ( bachTrackXi->Charge() >  0 ) {
+          } // end if negative bachelor
+          if ( bachTrackXi->Charge() >  0 ) {
                 //Calculate the effective mass of the Xi- candidate: Xi+ hyp. (pdg code -3312)
                 lV0quality = 0.;
                 xi->ChangeMassHypothesis(lV0quality , -3312); 	
@@ -1724,27 +1739,27 @@ void AliAnalysisTaskCheckCascadepp::UserExec(Option_t *) {
                 //Back to "default" hyp. (Xi-)
                 lV0quality = 0.;
                 xi->ChangeMassHypothesis(lV0quality , -3312); 	
-           } // end if positive bachelor
+          } // end if positive bachelor
 
-           //--------------------------------
-           // - PID on the daughter tracks
-	   // - Combined PID ->  removed, add when will be used
+          //--------------------------------
+          // - PID on the daughter tracks
+          // - Combined PID ->  removed, add when will be used
 
-	   // - TPC PID : 3-sigma bands on Bethe-Bloch curve
-           //Bachelor
-           if (TMath::Abs(fPIDResponse->NumberOfSigmasTPC( bachTrackXi,AliPID::kKaon)) < fTPCPIDsigma) lIsBachelorKaonForTPC = kTRUE;
-           if (TMath::Abs(fPIDResponse->NumberOfSigmasTPC( bachTrackXi,AliPID::kPion)) < fTPCPIDsigma) lIsBachelorPionForTPC = kTRUE;
-           //Negative V0 daughter
-           if (TMath::Abs(fPIDResponse->NumberOfSigmasTPC( nTrackXi,AliPID::kPion   )) < fTPCPIDsigma) lIsNegPionForTPC   = kTRUE;
-           if (TMath::Abs(fPIDResponse->NumberOfSigmasTPC( nTrackXi,AliPID::kProton )) < fTPCPIDsigma) lIsNegProtonForTPC = kTRUE;
-           //Positive V0 daughter
-           if (TMath::Abs(fPIDResponse->NumberOfSigmasTPC( pTrackXi,AliPID::kPion   )) < fTPCPIDsigma) lIsPosPionForTPC   = kTRUE;
-           if (TMath::Abs(fPIDResponse->NumberOfSigmasTPC( pTrackXi,AliPID::kProton )) < fTPCPIDsigma) lIsPosProtonForTPC = kTRUE;
-           /*
-           const AliExternalTrackParam *pInnerWallTrackXi    = pTrackXi    ->GetInnerParam();
-           const AliExternalTrackParam *nInnerWallTrackXi    = nTrackXi    ->GetInnerParam();
-           const AliExternalTrackParam *bachInnerWallTrackXi = bachTrackXi ->GetInnerParam();
-           if (pInnerWallTrackXi && nInnerWallTrackXi && bachInnerWallTrackXi ) { 
+          // - TPC PID : 3-sigma bands on Bethe-Bloch curve
+          //Bachelor
+          if (TMath::Abs(fPIDResponse->NumberOfSigmasTPC( bachTrackXi,AliPID::kKaon)) < fTPCPIDsigma) lIsBachelorKaonForTPC = kTRUE;
+          if (TMath::Abs(fPIDResponse->NumberOfSigmasTPC( bachTrackXi,AliPID::kPion)) < fTPCPIDsigma) lIsBachelorPionForTPC = kTRUE;
+          //Negative V0 daughter
+          if (TMath::Abs(fPIDResponse->NumberOfSigmasTPC( nTrackXi,AliPID::kPion   )) < fTPCPIDsigma) lIsNegPionForTPC   = kTRUE;
+          if (TMath::Abs(fPIDResponse->NumberOfSigmasTPC( nTrackXi,AliPID::kProton )) < fTPCPIDsigma) lIsNegProtonForTPC = kTRUE;
+          //Positive V0 daughter
+          if (TMath::Abs(fPIDResponse->NumberOfSigmasTPC( pTrackXi,AliPID::kPion   )) < fTPCPIDsigma) lIsPosPionForTPC   = kTRUE;
+          if (TMath::Abs(fPIDResponse->NumberOfSigmasTPC( pTrackXi,AliPID::kProton )) < fTPCPIDsigma) lIsPosProtonForTPC = kTRUE;
+          /*
+          const AliExternalTrackParam *pInnerWallTrackXi    = pTrackXi    ->GetInnerParam();
+          const AliExternalTrackParam *nInnerWallTrackXi    = nTrackXi    ->GetInnerParam();
+          const AliExternalTrackParam *bachInnerWallTrackXi = bachTrackXi ->GetInnerParam();
+          if (pInnerWallTrackXi && nInnerWallTrackXi && bachInnerWallTrackXi ) { 
                 Double_t pMomInnerWall    = pInnerWallTrackXi   ->GetP();
                 Double_t nMomInnerWall    = nInnerWallTrackXi   ->GetP();
                 Double_t bachMomInnerWall = bachInnerWallTrackXi->GetP();
@@ -1760,37 +1775,37 @@ void AliAnalysisTaskCheckCascadepp::UserExec(Option_t *) {
                 if (TMath::Abs(fESDpid->NumberOfSigmasTPC( pTrackXi,AliPID::kPion   )) < 3 )                            lIsPosPionForTPC   = kTRUE;
                 if (pMomInnerWall < 0.6  && TMath::Abs(fESDpid->NumberOfSigmasTPC( pTrackXi,AliPID::kProton )) < 5)     lIsPosProtonForTPC = kTRUE;
                 if (pMomInnerWall > 0.6  && TMath::Abs(fESDpid->NumberOfSigmasTPC( pTrackXi,AliPID::kProton )) < 3)     lIsPosProtonForTPC = kTRUE;
-           }*/
+          }*/
 		
-           //---------------------------------
-           // - Extra info for QA (ESD)
-           // Miscellaneous pieces of info that may help regarding data quality assessment.
-           // Cascade transverse and total momentum
-           xi->GetPxPyPz( lXiMomX, lXiMomY, lXiMomZ );
-           lXiTransvMom	= TMath::Sqrt( lXiMomX*lXiMomX + lXiMomY*lXiMomY );
-           lXiTotMom  	= TMath::Sqrt( lXiMomX*lXiMomX + lXiMomY*lXiMomY + lXiMomZ*lXiMomZ );
-           // V0 total momentum
-           xi->GetNPxPyPz(lV0NMomX,lV0NMomY,lV0NMomZ);
-           xi->GetPPxPyPz(lV0PMomX,lV0PMomY,lV0PMomZ);
-           lV0TotMom = TMath::Sqrt(TMath::Power(lV0NMomX+lV0PMomX,2) + TMath::Power(lV0NMomY+lV0PMomY,2) + TMath::Power(lV0NMomZ+lV0PMomZ,2));
-           // Bachelor total momentum
-           xi->GetBPxPyPz(  lBachMomX,  lBachMomY,  lBachMomZ );
-           lBachTransvMom  = TMath::Sqrt( lBachMomX*lBachMomX + lBachMomY*lBachMomY );
-           lBachTotMom     = TMath::Sqrt( lBachMomX*lBachMomX + lBachMomY*lBachMomY + lBachMomZ*lBachMomZ );
-           lnTrackTransvMom = TMath::Sqrt( lV0NMomX*lV0NMomX   + lV0NMomY*lV0NMomY );
-           lpTrackTransvMom = TMath::Sqrt( lV0PMomX*lV0PMomX   + lV0PMomY*lV0PMomY );
-           lChargeXi       = xi->Charge();
-           lV0toXiCosineOfPointingAngle = xi->GetV0CosineOfPointingAngle( lPosXi[0], lPosXi[1], lPosXi[2] );
-           lRapXi    = xi->RapXi();
-           lRapOmega = xi->RapOmega();
-           lEta      = xi->Eta();
-           lTheta    = xi->Theta()*180.0/TMath::Pi();
-           lPhi      = xi->Phi()*180.0/TMath::Pi();
-           lAlphaXi  = xi->AlphaXi();
-           lPtArmXi  = xi->PtArmXi();
-	   // Extra-cut = Anti-splitting cut for lambda daughters
-           Bool_t kAntiSplittingLambda = kFALSE;	
-           if (kAntiSplittingLambda) { // not used
+          //---------------------------------
+          // - Extra info for QA (ESD)
+          // Miscellaneous pieces of info that may help regarding data quality assessment.
+          // Cascade transverse and total momentum
+          xi->GetPxPyPz( lXiMomX, lXiMomY, lXiMomZ );
+          lXiTransvMom	= TMath::Sqrt( lXiMomX*lXiMomX + lXiMomY*lXiMomY );
+          lXiTotMom  	= TMath::Sqrt( lXiMomX*lXiMomX + lXiMomY*lXiMomY + lXiMomZ*lXiMomZ );
+          // V0 total momentum
+          xi->GetNPxPyPz(lV0NMomX,lV0NMomY,lV0NMomZ);
+          xi->GetPPxPyPz(lV0PMomX,lV0PMomY,lV0PMomZ);
+          lV0TotMom = TMath::Sqrt(TMath::Power(lV0NMomX+lV0PMomX,2) + TMath::Power(lV0NMomY+lV0PMomY,2) + TMath::Power(lV0NMomZ+lV0PMomZ,2));
+          // Bachelor total momentum
+          xi->GetBPxPyPz(  lBachMomX,  lBachMomY,  lBachMomZ );
+          lBachTransvMom  = TMath::Sqrt( lBachMomX*lBachMomX + lBachMomY*lBachMomY );
+          lBachTotMom     = TMath::Sqrt( lBachMomX*lBachMomX + lBachMomY*lBachMomY + lBachMomZ*lBachMomZ );
+          lnTrackTransvMom = TMath::Sqrt( lV0NMomX*lV0NMomX   + lV0NMomY*lV0NMomY );
+          lpTrackTransvMom = TMath::Sqrt( lV0PMomX*lV0PMomX   + lV0PMomY*lV0PMomY );
+          lChargeXi       = xi->Charge();
+          lV0toXiCosineOfPointingAngle = xi->GetV0CosineOfPointingAngle( lPosXi[0], lPosXi[1], lPosXi[2] );
+          lRapXi    = xi->RapXi();
+          lRapOmega = xi->RapOmega();
+          lEta      = xi->Eta();
+          lTheta    = xi->Theta()*180.0/TMath::Pi();
+          lPhi      = xi->Phi()*180.0/TMath::Pi();
+          lAlphaXi  = xi->AlphaXi();
+          lPtArmXi  = xi->PtArmXi();
+	  // Extra-cut = Anti-splitting cut for lambda daughters
+          Bool_t kAntiSplittingLambda = kFALSE;	
+          if (kAntiSplittingLambda) { // not used
                Double_t lNMomX = 0., lNMomY = 0., lNMomZ = 0.;
                Double_t lPMomX = 0., lPMomY = 0., lPMomZ = 0.;
                xi->GetPPxPyPz(lPMomX, lPMomY, lPMomZ); 
@@ -1800,142 +1815,148 @@ void AliAnalysisTaskCheckCascadepp::UserExec(Option_t *) {
 	       } else {                //Xi+ or Omega+
 	           if(TMath::Abs(lBachTransvMom - TMath::Sqrt( lPMomX*lPMomX + lPMomY*lPMomY ) ) < 0.075) continue;
 	       }
-           }
+          }
 
     } // end of ESD treatment
  
     else if (fAnalysisType == "AOD") {
 
-           // -------------------------------------
-           // - Load the cascades from the handler
-           const AliAODcascade *xi = lAODevent->GetCascade(iXi);
-           if (!xi) continue;
+          // -------------------------------------
+          // - Load the cascades from the handler
+          const AliAODcascade *xi = lAODevent->GetCascade(iXi);
+          if (!xi) continue;
 		
-           //----------------------------------------------------------------------------        
-           // - Assigning the necessary variables for specific AliESDcascade data members		
-           lEffMassXi        	   = xi->MassXi(); // default working hypothesis : cascade = Xi- decay
-           lDcaXiDaughters	   = xi->DcaXiDaughters();
-           lXiCosineOfPointingAngle = xi->CosPointingAngleXi( lBestPrimaryVtxPos[0], 
-		  					      lBestPrimaryVtxPos[1], 
-		 					      lBestPrimaryVtxPos[2] );
-           lPosXi[0] = xi->DecayVertexXiX();
-           lPosXi[1] = xi->DecayVertexXiY();
-           lPosXi[2] = xi->DecayVertexXiZ();
-           lXiRadius = TMath::Sqrt( lPosXi[0]*lPosXi[0] + lPosXi[1]*lPosXi[1] );
+          //----------------------------------------------------------------------------        
+          // - Assigning the necessary variables for specific AliESDcascade data members		
+          lEffMassXi        	   = xi->MassXi(); // default working hypothesis : cascade = Xi- decay
+          lDcaXiDaughters	   = xi->DcaXiDaughters();
+          lXiCosineOfPointingAngle = xi->CosPointingAngleXi( lBestPrimaryVtxPos[0], 
+                                                             lBestPrimaryVtxPos[1], 
+		 					     lBestPrimaryVtxPos[2] );
+          lPosXi[0] = xi->DecayVertexXiX();
+          lPosXi[1] = xi->DecayVertexXiY();
+          lPosXi[2] = xi->DecayVertexXiZ();
+          lXiRadius = TMath::Sqrt( lPosXi[0]*lPosXi[0] + lPosXi[1]*lPosXi[1] );
 
-           //-------------------------------------------------------------------------------------------------------------------------------
-           // - Around the tracks: Bach + V0 (ESD). Necessary variables for ESDcascade data members coming from the ESDv0 part (inheritance)
-           AliAODTrack *pTrackXi    = dynamic_cast<AliAODTrack*>( xi->GetDaughter(0) );
-           AliAODTrack *nTrackXi    = dynamic_cast<AliAODTrack*>( xi->GetDaughter(1) );
-           AliAODTrack *bachTrackXi = dynamic_cast<AliAODTrack*>( xi->GetDecayVertexXi()->GetDaughter(0) );
-           if (!pTrackXi || !nTrackXi || !bachTrackXi ) {
+          //-------------------------------------------------------------------------------------------------------------------------------
+          // - Around the tracks: Bach + V0 (ESD). Necessary variables for ESDcascade data members coming from the ESDv0 part (inheritance)
+          AliAODTrack *pTrackXi    = dynamic_cast<AliAODTrack*>( xi->GetDaughter(0) );
+          AliAODTrack *nTrackXi    = dynamic_cast<AliAODTrack*>( xi->GetDaughter(1) );
+          AliAODTrack *bachTrackXi = dynamic_cast<AliAODTrack*>( xi->GetDecayVertexXi()->GetDaughter(0) );
+          if (!pTrackXi || !nTrackXi || !bachTrackXi ) {
                 AliWarning("ERROR: Could not retrieve one of the 3 AOD daughter tracks of the cascade ...");
                 continue;
-           }
-           UInt_t lIdxPosXi  = (UInt_t) TMath::Abs( pTrackXi->GetID() );  
-           UInt_t lIdxNegXi  = (UInt_t) TMath::Abs( nTrackXi->GetID() );
-           UInt_t lBachIdx   = (UInt_t) TMath::Abs( bachTrackXi->GetID() );
+          }
+          UInt_t lIdxPosXi  = (UInt_t) TMath::Abs( pTrackXi->GetID() );  
+          UInt_t lIdxNegXi  = (UInt_t) TMath::Abs( nTrackXi->GetID() );
+          UInt_t lBachIdx   = (UInt_t) TMath::Abs( bachTrackXi->GetID() );
                                                 // Care track label can be negative in MC production (linked with the track quality)
                                                 // However = normally, not the case for track index ...
-           // - Rejection of a double use of a daughter track (nothing but just a crosscheck of what is done in the cascade vertexer)
-           if (lBachIdx == lIdxNegXi) { AliWarning("Pb / Idx(Bach. track) = Idx(Neg. track) ... continue!"); continue; }
-           if (lBachIdx == lIdxPosXi) { AliWarning("Pb / Idx(Bach. track) = Idx(Pos. track) ... continue!"); continue; }
-           // - Get the TPCnumber of cluster for the daughters
-           lPosTPCClusters   = pTrackXi->GetTPCNcls(); // FIXME: Is this ok? or something like in LambdaK0PbPb task AOD?
-           lNegTPCClusters   = nTrackXi->GetTPCNcls();
-           lBachTPCClusters  = bachTrackXi->GetTPCNcls();
+          // - Rejection of a double use of a daughter track (nothing but just a crosscheck of what is done in the cascade vertexer)
+          if (lBachIdx == lIdxNegXi) { AliWarning("Pb / Idx(Bach. track) = Idx(Neg. track) ... continue!"); continue; }
+          if (lBachIdx == lIdxPosXi) { AliWarning("Pb / Idx(Bach. track) = Idx(Pos. track) ... continue!"); continue; }
+          // - Get the TPCnumber of cluster for the daughters
+          lPosTPCClusters   = pTrackXi->GetTPCClusterInfo(2,1);             // Old for #TPCclusters: ->GetTPCNcls();
+          lNegTPCClusters   = nTrackXi->GetTPCClusterInfo(2,1);             // Old for #TPCclusters: ->GetTPCNcls();
+          lBachTPCClusters  = bachTrackXi->GetTPCClusterInfo(2,1);          // Old for #TPCclusters: ->GetTPCNcls();
+          // - Get the number TPC findable clusters for daughters
+          lPosTPCFindClusters   = pTrackXi->GetTPCNclsF();                  // New
+          lNegTPCFindClusters   = nTrackXi->GetTPCNclsF();                  // New
+          lBachTPCFindClusters  = bachTrackXi->GetTPCNclsF();               // New
 
-           //-------------------------------------
-           // - Rejection of a poor quality tracks
-           if (fTrackQualityCutTPCrefit) {
+          //-------------------------------------
+          // - Rejection of a poor quality tracks
+          if (fTrackQualityCutTPCrefit) {
                 // - Poor quality related to TPCrefit
-                if (!(pTrackXi->IsOn(AliAODTrack::kTPCrefit))) { AliWarning("Pb / V0 Pos. track has no TPCrefit ... continue!"); continue; }
-                if (!(nTrackXi->IsOn(AliAODTrack::kTPCrefit))) { AliWarning("Pb / V0 Neg. track has no TPCrefit ... continue!"); continue; }
+                if (!(pTrackXi->IsOn(AliAODTrack::kTPCrefit)))    { AliWarning("Pb / V0 Pos. track has no TPCrefit ... continue!"); continue; }
+                if (!(nTrackXi->IsOn(AliAODTrack::kTPCrefit)))    { AliWarning("Pb / V0 Neg. track has no TPCrefit ... continue!"); continue; }
                 if (!(bachTrackXi->IsOn(AliAODTrack::kTPCrefit))) { AliWarning("Pb / Bach.   track has no TPCrefit ... continue!"); continue; }
-           }
-           if (fTrackQualityCutnTPCcls) {
+          }
+          if (fTrackQualityCutnTPCcls) {
                 // - Poor quality related to TPC clusters
-                if (lPosTPCClusters  < fMinnTPCcls) { //AliWarning("Pb / V0 Pos. track has less than 80 TPC clusters ... continue!");
-                    continue; }
-                if (lNegTPCClusters  < fMinnTPCcls) { //AliWarning("Pb / V0 Neg. track has less than 80 TPC clusters ... continue!");
-                    continue; }
-                if (lBachTPCClusters < fMinnTPCcls) { //AliWarning("Pb / Bach.   track has less than 80 TPC clusters ... continue!");
-                    continue; }
-           }
+                if (lPosTPCClusters  < fMinnTPCcls) { AliWarning(Form("Pb / V0 Pos. track has less than %i TPC clusters ... continue!",fMinnTPCcls)); continue; }
+                if (lNegTPCClusters  < fMinnTPCcls) { AliWarning(Form("Pb / V0 Neg. track has less than %i TPC clusters ... continue!",fMinnTPCcls)); continue; }
+                if (lBachTPCClusters < fMinnTPCcls) { AliWarning(Form("Pb / Bach. track has less than %i TPC clusters ... continue!",fMinnTPCcls)); continue; }
+                // - Poor quality related to clusters/findable
+                if( lPosTPCFindClusters <= 0 || lNegTPCFindClusters <= 0 || lBachTPCFindClusters ) { AliWarning("Pb / Number of findable cluster <= 0 ... continue!"); continue; }
+                if ((lPosTPCClusters/lPosTPCFindClusters)    < fMinTPCcrossrawoverfindable) { AliWarning(Form("Pb / V0 Pos. track has ratio clusters/findable < %f ... continue!",fMinTPCcrossrawoverfindable)); continue; }
+                if ((lNegTPCClusters/lNegTPCFindClusters)    < fMinTPCcrossrawoverfindable) { AliWarning(Form("Pb / V0 Neg. track has ratio clusters/findable < %f ... continue!",fMinTPCcrossrawoverfindable)); continue; }
+                if ((lBachTPCClusters/lBachTPCFindClusters)  < fMinTPCcrossrawoverfindable) { AliWarning(Form("Pb / Bach. track has ratio clusters/findable < %f ... continue!",fMinTPCcrossrawoverfindable)); continue; }
+          }
 
-           //---------------------------------------
-           // - Around the tracks: Bach + V0 (AOD). Necessary variables for AODcascade data members coming from the AODv0 part (inheritance)
-           etaPos  = pTrackXi->Eta();
-           etaNeg  = nTrackXi->Eta();
-           etaBach = bachTrackXi->Eta();
-           lChargeXi = xi->ChargeXi();
-           if ( lChargeXi < 0) lInvMassLambdaAsCascDghter = xi->MassLambda();
-           else 	       lInvMassLambdaAsCascDghter = xi->MassAntiLambda();
-           lDcaV0DaughtersXi  	  = xi->DcaV0Daughters(); 
-           lDcaV0ToPrimVertexXi   = xi->DcaV0ToPrimVertex();
-           lDcaBachToPrimVertexXi = xi->DcaBachToPrimVertex(); 
-           lPosV0Xi[0] = xi->DecayVertexV0X();
-           lPosV0Xi[1] = xi->DecayVertexV0Y();
-           lPosV0Xi[2] = xi->DecayVertexV0Z(); 
-           lV0RadiusXi = TMath::Sqrt( lPosV0Xi[0]*lPosV0Xi[0] + lPosV0Xi[1]*lPosV0Xi[1] );
-           lV0CosineOfPointingAngleXi = xi->CosPointingAngle( lBestPrimaryVtxPos ); 
-           lDcaPosToPrimVertexXi      = xi->DcaPosToPrimVertex(); 
-           lDcaNegToPrimVertexXi      = xi->DcaNegToPrimVertex(); 
+          //---------------------------------------
+          // - Around the tracks: Bach + V0 (AOD). Necessary variables for AODcascade data members coming from the AODv0 part (inheritance)
+          etaPos  = pTrackXi->Eta();
+          etaNeg  = nTrackXi->Eta();
+          etaBach = bachTrackXi->Eta();
+          lChargeXi = xi->ChargeXi();
+          if ( lChargeXi < 0) lInvMassLambdaAsCascDghter = xi->MassLambda();
+          else 	       lInvMassLambdaAsCascDghter = xi->MassAntiLambda();
+          lDcaV0DaughtersXi  	  = xi->DcaV0Daughters(); 
+          lDcaV0ToPrimVertexXi   = xi->DcaV0ToPrimVertex();
+          lDcaBachToPrimVertexXi = xi->DcaBachToPrimVertex(); 
+          lPosV0Xi[0] = xi->DecayVertexV0X();
+          lPosV0Xi[1] = xi->DecayVertexV0Y();
+          lPosV0Xi[2] = xi->DecayVertexV0Z(); 
+          lV0RadiusXi = TMath::Sqrt( lPosV0Xi[0]*lPosV0Xi[0] + lPosV0Xi[1]*lPosV0Xi[1] );
+          lV0CosineOfPointingAngleXi = xi->CosPointingAngle( lBestPrimaryVtxPos ); 
+          lDcaPosToPrimVertexXi      = xi->DcaPosToPrimVertex(); 
+          lDcaNegToPrimVertexXi      = xi->DcaNegToPrimVertex(); 
 
-           //----------------------------------------------------------------------------------------------------       
-           // - Around effective masses. Change mass hypotheses to cover all the possibilities:  Xi-/+, Omega -/+
-           if ( lChargeXi < 0 )	lInvMassXiMinus	   = xi->MassXi();
-           if ( lChargeXi > 0 )	lInvMassXiPlus 	   = xi->MassXi();
-           if ( lChargeXi < 0 )	lInvMassOmegaMinus = xi->MassOmega();
-           if ( lChargeXi > 0 )	lInvMassOmegaPlus  = xi->MassOmega();
+          //----------------------------------------------------------------------------------------------------       
+          // - Around effective masses. Change mass hypotheses to cover all the possibilities:  Xi-/+, Omega -/+
+          if ( lChargeXi < 0 )	lInvMassXiMinus	   = xi->MassXi();
+          if ( lChargeXi > 0 )	lInvMassXiPlus 	   = xi->MassXi();
+          if ( lChargeXi < 0 )	lInvMassOmegaMinus = xi->MassOmega();
+          if ( lChargeXi > 0 )	lInvMassOmegaPlus  = xi->MassOmega();
 
-           //--------------------------------
-           // - PID on the daughter tracks
-           // - Combined PID ->  removed, add when will be used
+          //--------------------------------
+          // - PID on the daughter tracks
+          // - Combined PID ->  removed, add when will be used
 
-           // - TPC PID : 3-sigma bands on Bethe-Bloch curve
-           //Bachelor
-           if(TMath::Abs(fPIDResponse->NumberOfSigmasTPC( bachTrackXi,AliPID::kKaon)) < fTPCPIDsigma) lIsBachelorKaonForTPC = kTRUE;
-           if(TMath::Abs(fPIDResponse->NumberOfSigmasTPC( bachTrackXi,AliPID::kPion)) < fTPCPIDsigma) lIsBachelorPionForTPC = kTRUE;
-           //Negative V0 daughter
-           if(TMath::Abs(fPIDResponse->NumberOfSigmasTPC( nTrackXi,AliPID::kPion   )) < fTPCPIDsigma) lIsNegPionForTPC   = kTRUE;
-           if(TMath::Abs(fPIDResponse->NumberOfSigmasTPC( nTrackXi,AliPID::kProton )) < fTPCPIDsigma) lIsNegProtonForTPC = kTRUE;
-           //Positive V0 daughter
-           if(TMath::Abs(fPIDResponse->NumberOfSigmasTPC( pTrackXi,AliPID::kPion   )) < fTPCPIDsigma) lIsPosPionForTPC   = kTRUE;
-           if(TMath::Abs(fPIDResponse->NumberOfSigmasTPC( pTrackXi,AliPID::kProton )) < fTPCPIDsigma) lIsPosProtonForTPC = kTRUE;
+          // - TPC PID : 3-sigma bands on Bethe-Bloch curve
+          //Bachelor
+          if(TMath::Abs(fPIDResponse->NumberOfSigmasTPC( bachTrackXi,AliPID::kKaon)) < fTPCPIDsigma) lIsBachelorKaonForTPC = kTRUE;
+          if(TMath::Abs(fPIDResponse->NumberOfSigmasTPC( bachTrackXi,AliPID::kPion)) < fTPCPIDsigma) lIsBachelorPionForTPC = kTRUE;
+          //Negative V0 daughter
+          if(TMath::Abs(fPIDResponse->NumberOfSigmasTPC( nTrackXi,AliPID::kPion   )) < fTPCPIDsigma) lIsNegPionForTPC   = kTRUE;
+          if(TMath::Abs(fPIDResponse->NumberOfSigmasTPC( nTrackXi,AliPID::kProton )) < fTPCPIDsigma) lIsNegProtonForTPC = kTRUE;
+          //Positive V0 daughter
+          if(TMath::Abs(fPIDResponse->NumberOfSigmasTPC( pTrackXi,AliPID::kPion   )) < fTPCPIDsigma) lIsPosPionForTPC   = kTRUE;
+          if(TMath::Abs(fPIDResponse->NumberOfSigmasTPC( pTrackXi,AliPID::kProton )) < fTPCPIDsigma) lIsPosProtonForTPC = kTRUE;
 
-           //---------------------------------
-           // - Extra info for QA (AOD)
-           // Miscellaneous pieces of info that may help regarding data quality assessment.
-           // Cascade transverse and total momentum	
-           lXiMomX = xi->MomXiX();
-           lXiMomY = xi->MomXiY();
-           lXiMomZ = xi->MomXiZ();
-           lXiTransvMom = TMath::Sqrt( lXiMomX*lXiMomX + lXiMomY*lXiMomY );
-           lXiTotMom  	= TMath::Sqrt( lXiMomX*lXiMomX + lXiMomY*lXiMomY + lXiMomZ*lXiMomZ );
-           Double_t lV0MomX = xi->MomV0X();
-           Double_t lV0MomY = xi->MomV0Y();
-           Double_t lV0MomZ = xi->MomV0Z();
-           lV0TotMom = TMath::Sqrt(TMath::Power(lV0MomX,2)+TMath::Power(lV0MomY,2)+TMath::Power(lV0MomZ,2));
-           lBachMomX = xi->MomBachX();
-           lBachMomY = xi->MomBachY();
-           lBachMomZ = xi->MomBachZ();		
-           lBachTransvMom = TMath::Sqrt( lBachMomX*lBachMomX + lBachMomY*lBachMomY );
-           lBachTotMom    = TMath::Sqrt( lBachMomX*lBachMomX + lBachMomY*lBachMomY + lBachMomZ*lBachMomZ );
-           lV0NMomX = xi->MomNegX();
-           lV0NMomY = xi->MomNegY();
-           lV0PMomX = xi->MomPosX();
-           lV0PMomY = xi->MomPosY();
-           lnTrackTransvMom = TMath::Sqrt( lV0NMomX*lV0NMomX   + lV0NMomY*lV0NMomY );
-           lpTrackTransvMom = TMath::Sqrt( lV0PMomX*lV0PMomX   + lV0PMomY*lV0PMomY );
-           lV0toXiCosineOfPointingAngle = xi->CosPointingAngle( xi->GetDecayVertexXi() );
-           lRapXi    = xi->RapXi();
-           lRapOmega = xi->RapOmega();
-           lEta      = xi->Eta();	              	// Will not work ! need a method Pz(), Py() Px() 
-           lTheta    = xi->Theta() *180.0/TMath::Pi();  // in AODcascade.
-           lPhi      = xi->Phi()   *180.0/TMath::Pi();  // Here, we will get eta, theta, phi for the V0 ...
-           lAlphaXi  = xi->AlphaXi();
-           lPtArmXi  = xi->PtArmXi();
+          //---------------------------------
+          // - Extra info for QA (AOD)
+          // Miscellaneous pieces of info that may help regarding data quality assessment.
+          // Cascade transverse and total momentum	
+          lXiMomX = xi->MomXiX();
+          lXiMomY = xi->MomXiY();
+          lXiMomZ = xi->MomXiZ();
+          lXiTransvMom = TMath::Sqrt( lXiMomX*lXiMomX + lXiMomY*lXiMomY );
+          lXiTotMom  	= TMath::Sqrt( lXiMomX*lXiMomX + lXiMomY*lXiMomY + lXiMomZ*lXiMomZ );
+          Double_t lV0MomX = xi->MomV0X();
+          Double_t lV0MomY = xi->MomV0Y();
+          Double_t lV0MomZ = xi->MomV0Z();
+          lV0TotMom = TMath::Sqrt(TMath::Power(lV0MomX,2)+TMath::Power(lV0MomY,2)+TMath::Power(lV0MomZ,2));
+          lBachMomX = xi->MomBachX();
+          lBachMomY = xi->MomBachY();
+          lBachMomZ = xi->MomBachZ();		
+          lBachTransvMom = TMath::Sqrt( lBachMomX*lBachMomX + lBachMomY*lBachMomY );
+          lBachTotMom    = TMath::Sqrt( lBachMomX*lBachMomX + lBachMomY*lBachMomY + lBachMomZ*lBachMomZ );
+          lV0NMomX = xi->MomNegX();
+          lV0NMomY = xi->MomNegY();
+          lV0PMomX = xi->MomPosX();
+          lV0PMomY = xi->MomPosY();
+          lnTrackTransvMom = TMath::Sqrt( lV0NMomX*lV0NMomX   + lV0NMomY*lV0NMomY );
+          lpTrackTransvMom = TMath::Sqrt( lV0PMomX*lV0PMomX   + lV0PMomY*lV0PMomY );
+          lV0toXiCosineOfPointingAngle = xi->CosPointingAngle( xi->GetDecayVertexXi() );
+          lRapXi    = xi->RapXi();
+          lRapOmega = xi->RapOmega();
+          lEta      = xi->Eta();	              	// Will not work ! need a method Pz(), Py() Px() 
+          lTheta    = xi->Theta() *180.0/TMath::Pi();  // in AODcascade.
+          lPhi      = xi->Phi()   *180.0/TMath::Pi();  // Here, we will get eta, theta, phi for the V0 ...
+          lAlphaXi  = xi->AlphaXi();
+          lPtArmXi  = xi->PtArmXi();
 
     } // end of AOD treatment
 

--- a/PWGLF/STRANGENESS/Cascades/AliAnalysisTaskCheckCascadepp.h
+++ b/PWGLF/STRANGENESS/Cascades/AliAnalysisTaskCheckCascadepp.h
@@ -43,31 +43,32 @@ class AliAnalysisTaskCheckCascadepp : public AliAnalysisTaskSE {
         virtual Int_t  DoESDTrackWithTPCrefitMultiplicity(const AliESDEvent *lESDevent);
         virtual void   Terminate(Option_t *);
         //Setters   
-        void SetAnalysisType                 (const char* analysisType                 ) { fAnalysisType                   = analysisType;                 }
-        void SetCollidingSystem              (Int_t  collidingSystem                   ) { fCollidingSystem                = collidingSystem;              }
-        void SetSelectedTriggerClass         (AliVEvent::EOfflineTriggerTypes trigType ) { fkTriggerClass                  = trigType;                     }
-        void SetEventSelSDDstatus            (Bool_t eventselSDDstatus                 ) { fApplyEvSelSDDstatus            = eventselSDDstatus;            }
-        void SetEventSelDAQIncomplete        (Bool_t eventselDAQincomplete             ) { fApplyEvSelDAQincomplete        = eventselDAQincomplete;        }
-        void SetEventSelSPDclustervstracklet (Bool_t eventselSPDclustervstracklet      ) { fApplyEvSelSPDclustervstracklet = eventselSPDclustervstracklet; }
-        void SetEventSelPileup               (Bool_t eventselPileup                    ) { fApplyEvSelPileup               = eventselPileup;               }
-        void SetEventSelPhysicsSel           (Bool_t eventselPhysicsSel                ) { fApplyEvSelPhysicsSel           = eventselPhysicsSel;           }
-        void SetEventSelNoTPConlyPrimVtx     (Bool_t eventselNoTPConlyPrimVtx          ) { fApplyEvSelNoTPConlyPrimVtx     = eventselNoTPConlyPrimVtx;     }
-        void SetEventSelSPDvtxres            (Bool_t eventselSPDvtxres                 ) { fApplyEvSelSPDvtxres            = eventselSPDvtxres;            }
-        void SetEventSelVtxProximity         (Bool_t eventselVtxProximity              ) { fApplyEvSelVtxProximity         = eventselVtxProximity;         }
-        void SetEventSelZprimVtxPos          (Bool_t eventselZprimVtxPos               ) { fApplyEvSelZprimVtxPos          = eventselZprimVtxPos;          }
-        void SetRelaunchV0CascVertexers      (Bool_t rerunV0CascVertexers              ) { fRerunV0CascVertexers           = rerunV0CascVertexers;         }
-        void SetWithSDDOn                    (Bool_t withsddOn                         ) { fwithSDD                        = withsddOn;                    }
-        void SetExtraSelections              (Bool_t extraSelections                   ) { fExtraSelections                = extraSelections;              }
-        void SetTrackQualityCutTPCrefit      (Bool_t trackqualityCutTPCrefit           ) { fTrackQualityCutTPCrefit        = trackqualityCutTPCrefit;      }
-        void SetTrackQualityCutnTPCcls       (Bool_t trackqualityCutnTPCcls            ) { fTrackQualityCutnTPCcls         = trackqualityCutnTPCcls;       }
-        void SetQualityCutMinnTPCcls         (Int_t  minnTPCcls                        ) { fMinnTPCcls                     = minnTPCcls;                   }
-        void SetVertexRange                  (Float_t vtxrangemin, Float_t vtxrangemax ) { fVtxRangeMax                    = vtxrangemax;     
-                                                                                           fVtxRangeMin                    = vtxrangemin;                  }
-        void SetMinptCutOnDaughterTracks     (Float_t minptdaughtrks                   ) { fMinPtCutOnDaughterTracks       = minptdaughtrks;               }
-        void SetEtaCutOnDaughterTracks       (Float_t etadaughtrks                     ) { fEtaCutOnDaughterTracks         = etadaughtrks;                 }
-        void SetSPDPileUpminContributors     (Int_t   spdpileupmincontributors         ) { fSPDPileUpminContributors       = spdpileupmincontributors;     }
-        void SetNumTPCPIDsigma               (Double_t ftpcpidsigma                    ) { fTPCPIDsigma                    = ftpcpidsigma;                 }
-        void SetSuffix                       (const char* suffix                       ) { fSuffix                         = suffix;                       }
+        void SetAnalysisType                  (const char* analysisType                 ) { fAnalysisType                   = analysisType;                 }
+        void SetCollidingSystem               (Int_t  collidingSystem                   ) { fCollidingSystem                = collidingSystem;              }
+        void SetSelectedTriggerClass          (AliVEvent::EOfflineTriggerTypes trigType ) { fkTriggerClass                  = trigType;                     }
+        void SetEventSelSDDstatus             (Bool_t   eventselSDDstatus               ) { fApplyEvSelSDDstatus            = eventselSDDstatus;            }
+        void SetEventSelDAQIncomplete         (Bool_t   eventselDAQincomplete           ) { fApplyEvSelDAQincomplete        = eventselDAQincomplete;        }
+        void SetEventSelSPDclustervstracklet  (Bool_t   eventselSPDclustervstracklet    ) { fApplyEvSelSPDclustervstracklet = eventselSPDclustervstracklet; }
+        void SetEventSelPileup                (Bool_t   eventselPileup                  ) { fApplyEvSelPileup               = eventselPileup;               }
+        void SetEventSelPhysicsSel            (Bool_t   eventselPhysicsSel              ) { fApplyEvSelPhysicsSel           = eventselPhysicsSel;           }
+        void SetEventSelNoTPConlyPrimVtx      (Bool_t   eventselNoTPConlyPrimVtx        ) { fApplyEvSelNoTPConlyPrimVtx     = eventselNoTPConlyPrimVtx;     }
+        void SetEventSelSPDvtxres             (Bool_t   eventselSPDvtxres               ) { fApplyEvSelSPDvtxres            = eventselSPDvtxres;            }
+        void SetEventSelVtxProximity          (Bool_t   eventselVtxProximity            ) { fApplyEvSelVtxProximity         = eventselVtxProximity;         }
+        void SetEventSelZprimVtxPos           (Bool_t   eventselZprimVtxPos             ) { fApplyEvSelZprimVtxPos          = eventselZprimVtxPos;          }
+        void SetRelaunchV0CascVertexers       (Bool_t   rerunV0CascVertexers            ) { fRerunV0CascVertexers           = rerunV0CascVertexers;         }
+        void SetWithSDDOn                     (Bool_t   withsddOn                       ) { fwithSDD                        = withsddOn;                    }
+        void SetExtraSelections               (Bool_t   extraSelections                 ) { fExtraSelections                = extraSelections;              }
+        void SetTrackQualityCutTPCrefit       (Bool_t   trackqualityCutTPCrefit         ) { fTrackQualityCutTPCrefit        = trackqualityCutTPCrefit;      }
+        void SetTrackQualityCutnTPCcls        (Bool_t   trackqualityCutnTPCcls          ) { fTrackQualityCutnTPCcls         = trackqualityCutnTPCcls;       }
+        void SetQualityCutMinnTPCcls          (Int_t    minnTPCcls                      ) { fMinnTPCcls                     = minnTPCcls;                   }
+        void SetQualityCutClusterOverFindable (Float_t minTPCcrossrawoverfindable       ) { fMinTPCcrossrawoverfindable     = minTPCcrossrawoverfindable;   }
+        void SetVertexRange                   (Float_t vtxrangemin, Float_t vtxrangemax ) { fVtxRangeMax                    = vtxrangemax;     
+                                                                                            fVtxRangeMin                    = vtxrangemin;                  }
+        void SetMinptCutOnDaughterTracks      (Float_t minptdaughtrks                   ) { fMinPtCutOnDaughterTracks       = minptdaughtrks;               }
+        void SetEtaCutOnDaughterTracks        (Float_t etadaughtrks                     ) { fEtaCutOnDaughterTracks         = etadaughtrks;                 }
+        void SetSPDPileUpminContributors      (Int_t   spdpileupmincontributors         ) { fSPDPileUpminContributors       = spdpileupmincontributors;     }
+        void SetNumTPCPIDsigma                (Double_t ftpcpidsigma                    ) { fTPCPIDsigma                    = ftpcpidsigma;                 }
+        void SetSuffix                        (const char* suffix                       ) { fSuffix                         = suffix;                       }
         //Setters for the V0 and cascade Vertexer Parameters
         void SetV0VertexerMaxChisquare           (Double_t lParameter){ fV0Sels[0] = lParameter; }
         void SetV0VertexerDCAFirstToPV           (Double_t lParameter){ fV0Sels[1] = lParameter; }
@@ -112,6 +113,7 @@ class AliAnalysisTaskCheckCascadepp : public AliAnalysisTaskSE {
         Bool_t            fTrackQualityCutTPCrefit;        //
         Bool_t            fTrackQualityCutnTPCcls;         //
         Int_t             fMinnTPCcls;                     // Minimum number of TPC cluster for daughter tracks
+        Float_t           fMinTPCcrossrawoverfindable;     // Minimum value for clusters/findable ratio 
         Float_t           fVtxRangeMax;                    // to select events with |zvtx|<fVtxRange cm
         Float_t           fVtxRangeMin;                    // to select events with |zvtx|>fVtxRangeMin cm
         Float_t           fMinPtCutOnDaughterTracks;       // minimum pt cut on daughter tracks

--- a/PWGLF/STRANGENESS/Cascades/AliAnalysisTaskCheckPerformanceCascadepp.cxx
+++ b/PWGLF/STRANGENESS/Cascades/AliAnalysisTaskCheckPerformanceCascadepp.cxx
@@ -127,6 +127,7 @@ AliAnalysisTaskCheckPerformanceCascadepp::AliAnalysisTaskCheckPerformanceCascade
     fTrackQualityCutTPCrefit        (kTRUE),
     fTrackQualityCutnTPCcls         (kTRUE),
     fMinnTPCcls                     (0),
+    fMinTPCcrossrawoverfindable     (0),
     fkExtraSelections               (0),
     fVtxRangeMax                    (0),
     fVtxRangeMin                    (0),
@@ -372,6 +373,7 @@ AliAnalysisTaskCheckPerformanceCascadepp::AliAnalysisTaskCheckPerformanceCascade
     fTrackQualityCutTPCrefit        (kTRUE),
     fTrackQualityCutnTPCcls         (kTRUE),
     fMinnTPCcls                     (0),
+    fMinTPCcrossrawoverfindable     (0),
     fkExtraSelections               (0),
     fVtxRangeMax                    (0),
     fVtxRangeMin                    (0),
@@ -1379,19 +1381,19 @@ void AliAnalysisTaskCheckPerformanceCascadepp::UserCreateOutputObjects() {
   TString sddstatus = "";
   if      (fCollidingSystem == 0 && fApplyEvSelSDDstatus && fwithSDD)  sddstatus = "_wSDDon";
   else if (fCollidingSystem == 0 && fApplyEvSelSDDstatus && !fwithSDD) sddstatus = "_wSDDoff";
-  TString cfcontname_cascpidximinus = Form("fCFContCascadePIDAsXiMinus_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
+  TString cfcontname_cascpidximinus = Form("fCFContCascadePIDAsXiMinus_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fMinTPCcrossrawoverfindable,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
   cfcontname_cascpidximinus.Append(Form("%s",sddstatus.Data()));
   cfcontname_cascpidximinus.Append(Form("%s",fSuffix.Data()));
-  TString cfcontname_cascpidxiplus = Form("fCFContCascadePIDAsXiPlus_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
+  TString cfcontname_cascpidxiplus = Form("fCFContCascadePIDAsXiPlus_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fMinTPCcrossrawoverfindable,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
   cfcontname_cascpidxiplus.Append(Form("%s",sddstatus.Data()));
   cfcontname_cascpidxiplus.Append(Form("%s",fSuffix.Data()));
-  TString cfcontname_cascpidomegaminus = Form("fCFContCascadePIDAsOmegaMinus_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
+  TString cfcontname_cascpidomegaminus = Form("fCFContCascadePIDAsOmegaMinus_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fMinTPCcrossrawoverfindable,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
   cfcontname_cascpidomegaminus.Append(Form("%s",sddstatus.Data()));
   cfcontname_cascpidomegaminus.Append(Form("%s",fSuffix.Data()));
-  TString cfcontname_cascpidomegaplus = Form("fCFContCascadePIDAsOmegaPlus_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
+  TString cfcontname_cascpidomegaplus = Form("fCFContCascadePIDAsOmegaPlus_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fMinTPCcrossrawoverfindable,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
   cfcontname_cascpidomegaplus.Append(Form("%s",sddstatus.Data()));
   cfcontname_cascpidomegaplus.Append(Form("%s",fSuffix.Data()));
-  TString cfcontname_casccuts = Form("fCFContAsCascadeCuts_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
+  TString cfcontname_casccuts = Form("fCFContAsCascadeCuts_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f",fMinnTPCcls,fMinTPCcrossrawoverfindable,fVtxRangeMax,fVtxRangeMin,fMinPtCutOnDaughterTracks,fEtaCutOnDaughterTracks);
   cfcontname_casccuts.Append(Form("%s",sddstatus.Data()));
   cfcontname_casccuts.Append(Form("%s",fSuffix.Data()));
   // -- PID container Xi-
@@ -2702,8 +2704,25 @@ void AliAnalysisTaskCheckPerformanceCascadepp::UserExec(Option_t *) {
    //-----------------------------------------	
    // - Loop over the reconstructed candidates
    //-----------------------------------------
-   Int_t nAssoXiMinus = 0, nAssoXiPlus = 0, nAssoOmegaMinus = 0, nAssoOmegaPlus = 0, lPosTPCClusters = 0, lNegTPCClusters = 0, lBachTPCClusters = 0, 
-         lblBachForPID, lblPosV0Dghter, lblNegV0Dghter, lblMotherPosV0Dghter, lblMotherNegV0Dghter, lblBach, lblGdMotherPosV0Dghter, lblGdMotherNegV0Dghter, lblMotherBach;
+   Int_t nAssoXiMinus     = 0;
+   Int_t nAssoXiPlus      = 0;
+   Int_t nAssoOmegaMinus  = 0;
+   Int_t nAssoOmegaPlus   = 0;
+   Int_t lPosTPCClusters  = 0;
+   Int_t lNegTPCClusters  = 0;
+   Int_t lBachTPCClusters = 0;
+   Int_t lblBachForPID; 
+   Int_t lblPosV0Dghter; 
+   Int_t lblNegV0Dghter; 
+   Int_t lblMotherPosV0Dghter;
+   Int_t lblMotherNegV0Dghter; 
+   Int_t lblBach;
+   Int_t lblGdMotherPosV0Dghter; 
+   Int_t lblGdMotherNegV0Dghter; 
+   Int_t lblMotherBach;
+   Double_t lPosTPCFindClusters         = -1;
+   Double_t lNegTPCFindClusters         = -1;
+   Double_t lBachTPCFindClusters        = -1;
    Double_t lDcaXiDaughters = 0., lDcaBachToPrimVertexXi = 0., lXiCosineOfPointingAngle = 0., lXiRadius = 0., lInvMassLambdaAsCascDghter = 0., lDcaV0DaughtersXi = 0., lV0CosineOfPointingAngleXi = 0., 
             lV0CosineOfPointingAngle = 0., lV0RadiusXi = 0., lDcaV0ToPrimVertexXi = 0., lDcaPosToPrimVertexXi = 0., lDcaNegToPrimVertexXi = 0., lChargeXi = 0. , lV0mom = 0., lmcPt = 0., lmcRapCasc = 0., 
             lmcEta = 0., lmcTransvRadius = 0., lrecoPt = 0., lrecoTransvRadius = 0., lDeltaPhiMcReco = 0., lBachTransvMom = 0., lpTrackTransvMom = 0., lnTrackTransvMom = 0., lmcPtPosV0Dghter = 0., 
@@ -2730,8 +2749,12 @@ void AliAnalysisTaskCheckPerformanceCascadepp::UserExec(Option_t *) {
 
 
    //-------------------------------
-   // - Begining of the Cascade Loop
+   // - Beginning of the Cascade Loop
    for (Int_t iXi = 0; iXi < ncascades; iXi++) {
+
+
+
+printf(Form(" ----- fMinTPCcrossrawoverfindable ----- :  %.1f",fMinTPCcrossrawoverfindable));
 
         lIsPosInXiProton      = kFALSE;
         lIsPosInXiPion        = kFALSE;
@@ -2812,13 +2835,22 @@ void AliAnalysisTaskCheckPerformanceCascadepp::UserExec(Option_t *) {
                  if ((nStatus&AliESDtrack::kTPCrefit)    == 0) { AliWarning("Pb / V0 Neg. track has no TPCrefit ... continue!"); continue; }
                  if ((bachStatus&AliESDtrack::kTPCrefit) == 0) { AliWarning("Pb / Bach.   track has no TPCrefit ... continue!"); continue; }
              } 
-             if(fTrackQualityCutnTPCcls){  // - Poor quality related to TPC clusters
-                lPosTPCClusters = 0;  lPosTPCClusters   = pTrackXi->GetTPCNcls();
-                lNegTPCClusters = 0;  lNegTPCClusters   = nTrackXi->GetTPCNcls();
-                lBachTPCClusters = 0;  lBachTPCClusters  = bachTrackXi->GetTPCNcls();
+             if(fTrackQualityCutnTPCcls){ 
+                lPosTPCClusters = 0;     lPosTPCClusters  = pTrackXi->GetTPCClusterInfo(2,1);      //GetTPCNcls();
+                lNegTPCClusters = 0;     lNegTPCClusters  = nTrackXi->GetTPCClusterInfo(2,1);      //->GetTPCNcls();
+                lBachTPCClusters = 0;    lBachTPCClusters = bachTrackXi->GetTPCClusterInfo(2,1);   //->GetTPCNcls();
+                lPosTPCFindClusters   = pTrackXi->GetTPCNclsF();                  // New
+                lNegTPCFindClusters   = nTrackXi->GetTPCNclsF();                  // New
+                lBachTPCFindClusters  = bachTrackXi->GetTPCNclsF();               // New
+                // - Poor quality related to TPC clusters
                 if(lPosTPCClusters  < fMinnTPCcls) { AliWarning("Pb / V0 Pos. track has less than 80 TPC clusters ... continue!"); continue; }
                 if(lNegTPCClusters  < fMinnTPCcls) { AliWarning("Pb / V0 Neg. track has less than 80 TPC clusters ... continue!"); continue; }
                 if(lBachTPCClusters < fMinnTPCcls) { AliWarning("Pb / Bach.   track has less than 80 TPC clusters ... continue!"); continue; }
+                // - Poor quality related to clusters/findable
+                if( lPosTPCFindClusters <= 0 || lNegTPCFindClusters <= 0 || lBachTPCFindClusters ) { AliWarning("Pb / Number of findable cluster <= 0 ... continue!"); continue; }
+                if ((lPosTPCClusters/lPosTPCFindClusters)    < fMinTPCcrossrawoverfindable) { AliWarning(Form("Pb / V0 Pos. track has ratio clusters/findable < %f ... continue!",fMinTPCcrossrawoverfindable)); continue; }
+                if ((lNegTPCClusters/lNegTPCFindClusters)    < fMinTPCcrossrawoverfindable) { AliWarning(Form("Pb / V0 Neg. track has ratio clusters/findable < %f ... continue!",fMinTPCcrossrawoverfindable)); continue; }
+                if ((lBachTPCClusters/lBachTPCFindClusters)  < fMinTPCcrossrawoverfindable) { AliWarning(Form("Pb / Bach. track has ratio clusters/findable < %f ... continue!",fMinTPCcrossrawoverfindable)); continue; }
              }
 
              const AliExternalTrackParam *pExtTrack    = pTrackXi->GetInnerParam();
@@ -3066,13 +3098,21 @@ void AliAnalysisTaskCheckPerformanceCascadepp::UserExec(Option_t *) {
                  if (!(bachTrackXiaod->IsOn(AliAODTrack::kTPCrefit))) { AliWarning("Pb / Bach.   track has no TPCrefit ... continue!"); continue; }
              }
              if (fTrackQualityCutnTPCcls) {
-                lPosTPCClusters = 0;  lPosTPCClusters  = pTrackXiaod->GetTPCNcls();
-                lNegTPCClusters = 0;  lNegTPCClusters  = nTrackXiaod->GetTPCNcls();
-                lBachTPCClusters = 0;  lBachTPCClusters = bachTrackXiaod->GetTPCNcls();
+                 lPosTPCClusters = 0;  lPosTPCClusters  = pTrackXiaod->GetTPCClusterInfo(2,1);     //->GetTPCNcls();
+                 lNegTPCClusters = 0;  lNegTPCClusters  = nTrackXiaod->GetTPCClusterInfo(2,1);     //->GetTPCNcls();
+                 lBachTPCClusters = 0; lBachTPCClusters = bachTrackXiaod->GetTPCClusterInfo(2,1);  //->GetTPCNcls();
+                 lPosTPCFindClusters   = pTrackXiaod->GetTPCNclsF();                  // New
+                 lNegTPCFindClusters   = nTrackXiaod->GetTPCNclsF();                  // New
+                 lBachTPCFindClusters  = bachTrackXiaod->GetTPCNclsF();               // New
                  // - Poor quality related to TPC clusters
                  if(lPosTPCClusters  < fMinnTPCcls) { AliWarning("Pb / V0 Pos. track has less than 80 TPC clusters ... continue!"); continue; }
                  if(lNegTPCClusters  < fMinnTPCcls) { AliWarning("Pb / V0 Neg. track has less than 80 TPC clusters ... continue!"); continue; }
                  if(lBachTPCClusters < fMinnTPCcls) { AliWarning("Pb / Bach.   track has less than 80 TPC clusters ... continue!"); continue; }
+                 // - Poor quality related to clusters/findable
+                 if( lPosTPCFindClusters <= 0 || lNegTPCFindClusters <= 0 || lBachTPCFindClusters ) { AliWarning("Pb / Number of findable cluster <= 0 ... continue!"); continue; }
+                 if ((lPosTPCClusters/lPosTPCFindClusters)    < fMinTPCcrossrawoverfindable) { AliWarning(Form("Pb / V0 Pos. track has ratio clusters/findable < %f ... continue!",fMinTPCcrossrawoverfindable)); continue; }
+                 if ((lNegTPCClusters/lNegTPCFindClusters)    < fMinTPCcrossrawoverfindable) { AliWarning(Form("Pb / V0 Neg. track has ratio clusters/findable < %f ... continue!",fMinTPCcrossrawoverfindable)); continue; }
+                 if ((lBachTPCClusters/lBachTPCFindClusters)  < fMinTPCcrossrawoverfindable) { AliWarning(Form("Pb / Bach. track has ratio clusters/findable < %f ... continue!",fMinTPCcrossrawoverfindable)); continue; }
              }
              etaPos  = pTrackXiaod->Eta();
              etaNeg  = nTrackXiaod->Eta();

--- a/PWGLF/STRANGENESS/Cascades/AliAnalysisTaskCheckPerformanceCascadepp.h
+++ b/PWGLF/STRANGENESS/Cascades/AliAnalysisTaskCheckPerformanceCascadepp.h
@@ -37,31 +37,32 @@ class AliAnalysisTaskCheckPerformanceCascadepp : public AliAnalysisTaskSE {
   virtual void   UserExec(Option_t *option);
   virtual void   Terminate(Option_t *);
 
-  void SetAnalysisType                 (const char* analysisType            = "ESD"  ) { fAnalysisType                   = analysisType;                 }
-  void SetCollidingSystem              (Int_t  collidingSystem              = 0      ) { fCollidingSystem                = collidingSystem;              }
-  void SetSelectedTriggerClass         (AliVEvent::EOfflineTriggerTypes trigType     ) { fkTriggerClass                  = trigType;                     }
-  void SetEventSelSDDstatus            (Bool_t eventselSDDstatus            = kFALSE ) { fApplyEvSelSDDstatus            = eventselSDDstatus;            }
-  void SetEventSelDAQIncomplete        (Bool_t eventselDAQincomplete        = kTRUE  ) { fApplyEvSelDAQincomplete        = eventselDAQincomplete;        }
-  void SetEventSelSPDclustervstracklet (Bool_t eventselSPDclustervstracklet = kTRUE  ) { fApplyEvSelSPDclustervstracklet = eventselSPDclustervstracklet; }
-  void SetEventSelPileup               (Bool_t eventselPileup               = kTRUE  ) { fApplyEvSelPileup               = eventselPileup;               }
-  void SetEventSelPhysicsSel           (Bool_t eventselPhysicsSel           = kTRUE  ) { fApplyEvSelPhysicsSel           = eventselPhysicsSel;           }
-  void SetEventSelNoTPConlyPrimVtx     (Bool_t eventselNoTPConlyPrimVtx     = kTRUE  ) { fApplyEvSelNoTPConlyPrimVtx     = eventselNoTPConlyPrimVtx;     }
-  void SetEventSelSPDvtxres            (Bool_t eventselSPDvtxres            = kTRUE  ) { fApplyEvSelSPDvtxres            = eventselSPDvtxres;            }
-  void SetEventSelVtxProximity         (Bool_t eventselVtxProximity         = kTRUE  ) { fApplyEvSelVtxProximity         = eventselVtxProximity;         }
-  void SetEventSelZprimVtxPos          (Bool_t eventselZprimVtxPos          = kTRUE  ) { fApplyEvSelZprimVtxPos          = eventselZprimVtxPos;          }
-  void SetRelaunchV0CascVertexers      (Bool_t rerunV0CascVertexers         = kFALSE ) { fRerunV0CascVertexers           = rerunV0CascVertexers;         }
-  void SetWithSDDOn                    (Bool_t withsddOn                    = kTRUE  ) { fwithSDD                        = withsddOn;                    }
-  void SetTrackQualityCutTPCrefit      (Bool_t trackqualityCutTPCrefit      = kTRUE  ) { fTrackQualityCutTPCrefit        = trackqualityCutTPCrefit;      }
-  void SetTrackQualityCutnTPCcls       (Bool_t trackqualityCutnTPCcls       = kTRUE  ) { fTrackQualityCutnTPCcls         = trackqualityCutnTPCcls;       }
-  void SetQualityCutMinnTPCcls         (Int_t  minnTPCcls                   = 70     ) { fMinnTPCcls                     = minnTPCcls;                   }
-  void SetVertexRange                  (Float_t vtxrangemin, Float_t vtxrangemax     ) { fVtxRangeMax = vtxrangemax;     fVtxRangeMin = vtxrangemin;     }
-  void SetApplyAccCut                  (Bool_t  acccut                      = kFALSE ) { fApplyAccCut                    = acccut;                       }
-  void SetMinptCutOnDaughterTracks     (Float_t minptdaughtrks              = 0.0    ) { fMinPtCutOnDaughterTracks       = minptdaughtrks;               }
-  void SetExtraSelections              (Bool_t  extraSelections             = kFALSE ) { fkExtraSelections               = extraSelections;              }
-  void SetEtaCutOnDaughterTracks       (Float_t etadaughtrks                = 0.8    ) { fEtaCutOnDaughterTracks         = etadaughtrks;                 }
-  void SetSPDPileUpminContributors     (Int_t   spdpileupmincontributors    = 3      ) { fSPDPileUpminContributors       = spdpileupmincontributors;     }
-  void SetNumTPCPIDsigma               (Double_t ftpcpidsigma               = 4      ) { fTPCPIDsigma                    = ftpcpidsigma;                 }
-  void SetSuffix                       (const char* suffix                  = ""     ) { fSuffix                         = suffix;                       }
+  void SetAnalysisType                  (const char* analysisType            = "ESD"  ) { fAnalysisType                   = analysisType;                 }
+  void SetCollidingSystem               (Int_t  collidingSystem              = 0      ) { fCollidingSystem                = collidingSystem;              }
+  void SetSelectedTriggerClass          (AliVEvent::EOfflineTriggerTypes trigType     ) { fkTriggerClass                  = trigType;                     }
+  void SetEventSelSDDstatus             (Bool_t eventselSDDstatus            = kFALSE ) { fApplyEvSelSDDstatus            = eventselSDDstatus;            }
+  void SetEventSelDAQIncomplete         (Bool_t eventselDAQincomplete        = kTRUE  ) { fApplyEvSelDAQincomplete        = eventselDAQincomplete;        }
+  void SetEventSelSPDclustervstracklet  (Bool_t eventselSPDclustervstracklet = kTRUE  ) { fApplyEvSelSPDclustervstracklet = eventselSPDclustervstracklet; }
+  void SetEventSelPileup                (Bool_t eventselPileup               = kTRUE  ) { fApplyEvSelPileup               = eventselPileup;               }
+  void SetEventSelPhysicsSel            (Bool_t eventselPhysicsSel           = kTRUE  ) { fApplyEvSelPhysicsSel           = eventselPhysicsSel;           }
+  void SetEventSelNoTPConlyPrimVtx      (Bool_t eventselNoTPConlyPrimVtx     = kTRUE  ) { fApplyEvSelNoTPConlyPrimVtx     = eventselNoTPConlyPrimVtx;     }
+  void SetEventSelSPDvtxres             (Bool_t eventselSPDvtxres            = kTRUE  ) { fApplyEvSelSPDvtxres            = eventselSPDvtxres;            }
+  void SetEventSelVtxProximity          (Bool_t eventselVtxProximity         = kTRUE  ) { fApplyEvSelVtxProximity         = eventselVtxProximity;         }
+  void SetEventSelZprimVtxPos           (Bool_t eventselZprimVtxPos          = kTRUE  ) { fApplyEvSelZprimVtxPos          = eventselZprimVtxPos;          }
+  void SetRelaunchV0CascVertexers       (Bool_t rerunV0CascVertexers         = kFALSE ) { fRerunV0CascVertexers           = rerunV0CascVertexers;         }
+  void SetWithSDDOn                     (Bool_t withsddOn                    = kTRUE  ) { fwithSDD                        = withsddOn;                    }
+  void SetTrackQualityCutTPCrefit       (Bool_t trackqualityCutTPCrefit      = kTRUE  ) { fTrackQualityCutTPCrefit        = trackqualityCutTPCrefit;      }
+  void SetTrackQualityCutnTPCcls        (Bool_t trackqualityCutnTPCcls       = kTRUE  ) { fTrackQualityCutnTPCcls         = trackqualityCutnTPCcls;       }
+  void SetQualityCutMinnTPCcls          (Int_t  minnTPCcls                   = 70     ) { fMinnTPCcls                     = minnTPCcls;                   }
+  void SetQualityCutClusterOverFindable (Float_t minTPCcrossrawoverfindable  = 0.8    ) { fMinTPCcrossrawoverfindable     = minTPCcrossrawoverfindable;   }
+  void SetVertexRange                   (Float_t vtxrangemin, Float_t vtxrangemax     ) { fVtxRangeMax = vtxrangemax;     fVtxRangeMin = vtxrangemin;     }
+  void SetApplyAccCut                   (Bool_t  acccut                      = kFALSE ) { fApplyAccCut                    = acccut;                       }
+  void SetMinptCutOnDaughterTracks      (Float_t minptdaughtrks              = 0.0    ) { fMinPtCutOnDaughterTracks       = minptdaughtrks;               }
+  void SetExtraSelections               (Bool_t  extraSelections             = kFALSE ) { fkExtraSelections               = extraSelections;              }
+  void SetEtaCutOnDaughterTracks        (Float_t etadaughtrks                = 0.8    ) { fEtaCutOnDaughterTracks         = etadaughtrks;                 }
+  void SetSPDPileUpminContributors      (Int_t   spdpileupmincontributors    = 3      ) { fSPDPileUpminContributors       = spdpileupmincontributors;     }
+  void SetNumTPCPIDsigma                (Double_t ftpcpidsigma               = 4      ) { fTPCPIDsigma                    = ftpcpidsigma;                 }
+  void SetSuffix                        (const char* suffix                  = ""     ) { fSuffix                         = suffix;                       }
   //Setters for the V0 and cascade Vertexer Parameters
   void SetV0VertexerMaxChisquare           (Double_t lParameter){ fV0Sels[0] = lParameter; }
   void SetV0VertexerDCAFirstToPV           (Double_t lParameter){ fV0Sels[1] = lParameter; }
@@ -105,6 +106,7 @@ class AliAnalysisTaskCheckPerformanceCascadepp : public AliAnalysisTaskSE {
         Bool_t            fTrackQualityCutTPCrefit;        //
         Bool_t            fTrackQualityCutnTPCcls;         //
         Int_t             fMinnTPCcls;                     // Minimum number of TPC cluster for daughter tracks
+        Float_t           fMinTPCcrossrawoverfindable;     // Minimum value for clusters/findable ratio 
         Bool_t            fkExtraSelections;               // Boolean : kTRUE = apply tighter selections, before starting the analysis
         Float_t           fVtxRangeMax;                    // to select events with |zvtx|<fVtxRange cm
         Float_t           fVtxRangeMin;                    // to select events with |zvtx|>fVtxRangeMin cm

--- a/PWGLF/STRANGENESS/Cascades/macros/AddTaskCheckCascadepp.C
+++ b/PWGLF/STRANGENESS/Cascades/macros/AddTaskCheckCascadepp.C
@@ -20,6 +20,7 @@
 AliAnalysisTaskCheckCascadepp *AddTaskCheckCascadepp( Int_t    collidingSystem                     = 0,
                                                       AliVEvent::EOfflineTriggerTypes triggerclass = AliVEvent::kINT7, 
                                                       Int_t    minnTPCcls                          = 70,
+                                                      Float_t  minTPCcrossrawoverfindable          = 0.8,
                                                       Float_t  vtxlimmax                           = 10.0,
                                                       Float_t  vtxlimmin                           = 0.0,
                                                       Bool_t   ksddselection                       = kFALSE,
@@ -53,20 +54,21 @@ AliAnalysisTaskCheckCascadepp *AddTaskCheckCascadepp( Int_t    collidingSystem  
    const Char_t *sddstatus = "";
    if      (collidingSystem == 0 && ksddselection && kwithsdd)   sddstatus = "_wSDDon";
    else if (collidingSystem == 0 && ksddselection && !kwithsdd)  sddstatus = "_wSDDoff";
-   TString taskname = Form("TaskCheckCascadepp_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
+   TString taskname = Form("TaskCheckCascadepp_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,minTPCcrossrawoverfindable,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
    taskname.Append(Form("%s",suffix.Data()));
 
    AliAnalysisTaskCheckCascadepp *taskcheckcascadepp = new AliAnalysisTaskCheckCascadepp(taskname);
-     taskcheckcascadepp->SetAnalysisType               (type);                   // "ESD" or "AOD"
-     taskcheckcascadepp->SetCollidingSystem            (collidingSystem);        // choose the collision system to run on: "pp" and "pPb"
-     taskcheckcascadepp->SetSelectedTriggerClass       (triggerclass);           // trigger selection
-     taskcheckcascadepp->SetEventSelSDDstatus          (ksddselection);
-     taskcheckcascadepp->SetWithSDDOn                  (kwithsdd);
-     taskcheckcascadepp->SetQualityCutMinnTPCcls       (minnTPCcls);             // which value do you want apply for the minTPCcls cut?
-     taskcheckcascadepp->SetVertexRange                (vtxlimmin,vtxlimmax);
-     taskcheckcascadepp->SetMinptCutOnDaughterTracks   (minptondaughtertracks);  // which value do you want apply for cut on min pt daughter track?
-     taskcheckcascadepp->SetEtaCutOnDaughterTracks     (etacutondaughtertracks); // which value do you want apply for cut on eta daughter track?
-     taskcheckcascadepp->SetSuffix                     (suffix);
+     taskcheckcascadepp->SetAnalysisType                 (type);                   // "ESD" or "AOD"
+     taskcheckcascadepp->SetCollidingSystem              (collidingSystem);        // choose the collision system to run on: "pp" and "pPb"
+     taskcheckcascadepp->SetSelectedTriggerClass         (triggerclass);           // trigger selection
+     taskcheckcascadepp->SetEventSelSDDstatus            (ksddselection);
+     taskcheckcascadepp->SetWithSDDOn                    (kwithsdd);
+     taskcheckcascadepp->SetQualityCutMinnTPCcls         (minnTPCcls);             // which value do you want apply for the minTPCcls cut?
+     taskcheckcascadepp->SetQualityCutClusterOverFindable(minTPCcrossrawoverfindable); //
+     taskcheckcascadepp->SetVertexRange                  (vtxlimmin,vtxlimmax);
+     taskcheckcascadepp->SetMinptCutOnDaughterTracks     (minptondaughtertracks);  // which value do you want apply for cut on min pt daughter track?
+     taskcheckcascadepp->SetEtaCutOnDaughterTracks       (etacutondaughtertracks); // which value do you want apply for cut on eta daughter track?
+     taskcheckcascadepp->SetSuffix                       (suffix);
 
    mgr->AddTask(taskcheckcascadepp);
 
@@ -77,12 +79,12 @@ AliAnalysisTaskCheckCascadepp *AddTaskCheckCascadepp( Int_t    collidingSystem  
    // Directory name
    TString outputFileName = Form("%s:PWGLFStrangeness.outputCheckCascade", AliAnalysisManager::GetCommonFileName());
    // Objects name
-   TString outputname0 = Form("clistCasc_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
-   TString outputname1 = Form("cfcontPIDXiM_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
-   TString outputname2 = Form("cfcontPIDXiP_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
-   TString outputname3 = Form("cfcontPIDOmegaM_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
-   TString outputname4 = Form("cfcontPIDOmegaP_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
-   TString outputname5 = Form("cfcontCuts_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
+   TString outputname0 = Form("clistCasc_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,minTPCcrossrawoverfindable,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
+   TString outputname1 = Form("cfcontPIDXiM_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,minTPCcrossrawoverfindable,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
+   TString outputname2 = Form("cfcontPIDXiP_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,minTPCcrossrawoverfindable,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
+   TString outputname3 = Form("cfcontPIDOmegaM_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,minTPCcrossrawoverfindable,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
+   TString outputname4 = Form("cfcontPIDOmegaP_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,minTPCcrossrawoverfindable,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
+   TString outputname5 = Form("cfcontCuts_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,minTPCcrossrawoverfindable,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
    outputname0.Append(Form("%s",suffix.Data()));
    outputname1.Append(Form("%s",suffix.Data()));
    outputname2.Append(Form("%s",suffix.Data()));

--- a/PWGLF/STRANGENESS/Cascades/macros/AddTaskCheckPerformanceCascadepp.C
+++ b/PWGLF/STRANGENESS/Cascades/macros/AddTaskCheckPerformanceCascadepp.C
@@ -20,6 +20,7 @@
 AliAnalysisTaskCheckPerformanceCascadepp *AddTaskCheckPerformanceCascadepp( Int_t  collidingSystem                       = 0,
                                                                             AliVEvent::EOfflineTriggerTypes triggerclass = AliVEvent::kINT7,
                                                                             Int_t    minnTPCcls                          = 70,
+                                                                            Float_t  minTPCcrossrawoverfindable          = 0.8,
                                                                             Float_t  vtxlimmax                           = 10.,
                                                                             Float_t  vtxlimmin                           = 0.,
                                                                             Bool_t   ksddselection                       = kFALSE,                                                                                  
@@ -56,20 +57,21 @@ AliAnalysisTaskCheckPerformanceCascadepp *AddTaskCheckPerformanceCascadepp( Int_
    const Char_t *sddstatus = "";
    if      (collidingSystem == 0 && ksddselection && kwithsdd)   sddstatus = "_wSDDon";
    else if (collidingSystem == 0 && ksddselection && !kwithsdd)  sddstatus = "_wSDDoff";
-   TString tasknameperf = Form("TaskCheckPerformanceCascade_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
+   TString tasknameperf = Form("TaskCheckPerformanceCascade_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,minptondaughtertracks,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
    tasknameperf.Append(Form("%s",suffix.Data()));
    AliAnalysisTaskCheckPerformanceCascadepp *taskCheckPerfCascadepp = new AliAnalysisTaskCheckPerformanceCascadepp(tasknameperf);
-     taskCheckPerfCascadepp->SetAnalysisType               (type);                   // "ESD" or "AOD"
-     taskCheckPerfCascadepp->SetCollidingSystem            (collidingSystem);        // choose the collision system to run on: "pp" and "pPb"
-     taskCheckPerfCascadepp->SetSelectedTriggerClass       (triggerclass);           // trigger selection
-     taskCheckPerfCascadepp->SetEventSelSDDstatus          (ksddselection);
-     taskCheckPerfCascadepp->SetWithSDDOn                  (kwithsdd);
-     taskCheckPerfCascadepp->SetQualityCutMinnTPCcls       (minnTPCcls);             // which value do you want apply for the minTPCcls cut?
-     taskCheckPerfCascadepp->SetVertexRange                (vtxlimmin,vtxlimmax);
-     taskCheckPerfCascadepp->SetMinptCutOnDaughterTracks   (minptondaughtertracks);  // which value do you want apply for cut on min pt daughter track?
-     taskCheckPerfCascadepp->SetEtaCutOnDaughterTracks     (etacutondaughtertracks); // which value do you want apply for cut on eta daughter track?
-     taskCheckPerfCascadepp->SetApplyAccCut                (kacccut);                // choose if apply acceptance cut
-     taskCheckPerfCascadepp->SetSuffix                     (suffix);
+     taskCheckPerfCascadepp->SetAnalysisType                 (type);                   // "ESD" or "AOD"
+     taskCheckPerfCascadepp->SetCollidingSystem              (collidingSystem);        // choose the collision system to run on: "pp" and "pPb"
+     taskCheckPerfCascadepp->SetSelectedTriggerClass         (triggerclass);           // trigger selection
+     taskCheckPerfCascadepp->SetEventSelSDDstatus            (ksddselection);
+     taskCheckPerfCascadepp->SetWithSDDOn                    (kwithsdd);
+     taskCheckPerfCascadepp->SetQualityCutMinnTPCcls         (minnTPCcls);             // which value do you want apply for the minTPCcls cut?
+     taskCheckPerfCascadepp->SetQualityCutClusterOverFindable(minTPCcrossrawoverfindable);
+     taskCheckPerfCascadepp->SetVertexRange                  (vtxlimmin,vtxlimmax);
+     taskCheckPerfCascadepp->SetMinptCutOnDaughterTracks     (minptondaughtertracks);  // which value do you want apply for cut on min pt daughter track?
+     taskCheckPerfCascadepp->SetEtaCutOnDaughterTracks       (etacutondaughtertracks); // which value do you want apply for cut on eta daughter track?
+     taskCheckPerfCascadepp->SetApplyAccCut                  (kacccut);                // choose if apply acceptance cut
+     taskCheckPerfCascadepp->SetSuffix                       (suffix);
 
    mgr->AddTask(taskCheckPerfCascadepp);
 
@@ -81,12 +83,12 @@ AliAnalysisTaskCheckPerformanceCascadepp *AddTaskCheckPerformanceCascadepp( Int_
    // - Directory name
    TString outputFileNamePerf = Form("%s:PWGLFStrangeness.outputCheckPerformanceCascade", AliAnalysisManager::GetCommonFileName());
    // - Objects name
-   TString outputnameperf0 = Form("clistCascPerf_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
-   TString outputnameperf1 = Form("cfcontPIDAsXiM_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
-   TString outputnameperf2 = Form("cfcontPIDAsXiP_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
-   TString outputnameperf3 = Form("cfcontPIDAsOmegaM_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
-   TString outputnameperf4 = Form("cfcontPIDAsOmegaP_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
-   TString outputnameperf5 = Form("cfcontAsCuts_minnTPCcls%i_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
+   TString outputnameperf0 = Form("clistCascPerf_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,minTPCcrossrawoverfindable,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
+   TString outputnameperf1 = Form("cfcontPIDAsXiM_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,minTPCcrossrawoverfindable,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
+   TString outputnameperf2 = Form("cfcontPIDAsXiP_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,minTPCcrossrawoverfindable,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
+   TString outputnameperf3 = Form("cfcontPIDAsOmegaM_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,minTPCcrossrawoverfindable,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
+   TString outputnameperf4 = Form("cfcontPIDAsOmegaP_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,minTPCcrossrawoverfindable,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
+   TString outputnameperf5 = Form("cfcontAsCuts_minnTPCcls%i_clsfindratio%.1f_vtxlim%.1f-%.1f_minptdghtrk%.1f_etacutdghtrk%.1f%s",minnTPCcls,minTPCcrossrawoverfindable,vtxlimmax,vtxlimmin,minptondaughtertracks,etacutondaughtertracks,sddstatus);
    outputnameperf0.Append(Form("%s",suffix.Data()));
    outputnameperf1.Append(Form("%s",suffix.Data()));
    outputnameperf2.Append(Form("%s",suffix.Data()));


### PR DESCRIPTION
The track quality selection based on TPC cluster has been changed from the simple request on on the number of TPC cluster (GetTPCNcls) to the double request:
    — Number of TPC crossed Rows > 70
    — TPC Crossed Rows / Findable Ratio > 0.8