### PR TITLE
Adding THnSparses and recovertex option for MC

### DIFF
--- a/PWGPP/ITS/AliAnalysisTaskSEImpParResSparse.cxx
+++ b/PWGPP/ITS/AliAnalysisTaskSEImpParResSparse.cxx
@@ -66,6 +66,7 @@ AliAnalysisTaskSE(),
   fReadMC(kFALSE),
   fSelectedPdg(-1),
   fUseDiamond(kFALSE),
+  fUseRecoVertex(kFALSE),
   fSkipTrack(kTRUE),
   fMinMult(0),
   fMaxMult(1000000),
@@ -90,10 +91,12 @@ AliAnalysisTaskSE(),
   fImpParrphiSparsePtzVtxEtaPhi(0),
   fImpParrphiSparsePtEtaPhi(0),
   fImpParPullrphiSparsePtEtaPhi(0),
+  fImpParPullrphiSparsePtBchargePhi(0),
   fImpParzSparsePtBchargePhi(0),
   fImpParzSparsePtzVtxEtaPhi(0),
   fImpParzSparsePtEtaPhi(0),
   fImpParPullzSparsePtEtaPhi(0),
+  fImpParPullzSparsePtBchargePhi(0),
   fPtDistrib(0),
   fhPtWeights(0x0),
   fUseptWeights(0),
@@ -112,6 +115,7 @@ AliAnalysisTaskSEImpParResSparse::AliAnalysisTaskSEImpParResSparse(const char *n
   fReadMC(kFALSE),
   fSelectedPdg(-1),
   fUseDiamond(kFALSE),
+  fUseRecoVertex(kFALSE),
   fSkipTrack(kTRUE),
   fMinMult(0),
   fMaxMult(1000000),
@@ -136,10 +140,12 @@ AliAnalysisTaskSEImpParResSparse::AliAnalysisTaskSEImpParResSparse(const char *n
   fImpParrphiSparsePtzVtxEtaPhi(0),
   fImpParrphiSparsePtEtaPhi(0),
   fImpParPullrphiSparsePtEtaPhi(0),
+  fImpParPullrphiSparsePtBchargePhi(0),
   fImpParzSparsePtBchargePhi(0),
   fImpParzSparsePtzVtxEtaPhi(0),
   fImpParzSparsePtEtaPhi(0),
   fImpParPullzSparsePtEtaPhi(0),
+  fImpParPullzSparsePtBchargePhi(0),
   fPtDistrib(0),
   fhPtWeights(0x0),
   fUseptWeights(0),
@@ -169,10 +175,12 @@ AliAnalysisTaskSEImpParResSparse::~AliAnalysisTaskSEImpParResSparse()
   delete fImpParrphiSparsePtzVtxEtaPhi;
   delete fImpParrphiSparsePtEtaPhi;
   delete fImpParPullrphiSparsePtEtaPhi;
+  delete fImpParPullrphiSparsePtBchargePhi;
   delete fImpParzSparsePtBchargePhi;
   delete fImpParzSparsePtzVtxEtaPhi;
   delete fImpParzSparsePtEtaPhi;
   delete fImpParPullzSparsePtEtaPhi;
+  delete fImpParPullzSparsePtBchargePhi;
   delete fPtDistrib;
   delete fhPtWeights;
 
@@ -248,6 +256,30 @@ void AliAnalysisTaskSEImpParResSparse::UserCreateOutputObjects()
     for(Int_t iax=0; iax<5; iax++) fImpParzSparsePtzVtxEtaPhi->GetAxis(iax)->SetTitle(axTitle4[iax].Data());
     BinLogAxis(fImpParzSparsePtzVtxEtaPhi, 1);
     fOutput->Add(fImpParzSparsePtzVtxEtaPhi);
+
+    
+    //pulls
+    Int_t nbinsImpParSparse_pullPtBchargePhi[5] =       {400, 50, 4, 2, 2};
+    Double_t limitLowImpParSparse_pullPtBchargePhi[5] = {-10., 0.1, 0., 0., 0.};
+    Double_t limitUpImpParSparse_pullPtBchargePhi[5] =  {10., 25., 4., 2., 2.};
+    TString axTitle_rphi_pullPtBchargePhi[5]={"rphi pull",
+					      "#it{p}_{T} (GeV/c)",
+					      "#phi",
+					      "mag. field",
+					      "charge"};
+    fImpParPullrphiSparsePtBchargePhi=new THnSparseF("fImpParPullrphiSparsePtBchargePhi","fImpParPullrphiSparsePtBchargePhi",5,nbinsImpParSparse_pullPtBchargePhi,limitLowImpParSparse_pullPtBchargePhi,limitUpImpParSparse_pullPtBchargePhi);
+    for(Int_t iax=0; iax<5; iax++) fImpParPullrphiSparsePtBchargePhi->GetAxis(iax)->SetTitle(axTitle_rphi_pullPtBchargePhi[iax].Data());
+    BinLogAxis(fImpParPullrphiSparsePtBchargePhi, 1);
+    fOutput->Add(fImpParPullrphiSparsePtBchargePhi);
+    TString axTitle_z_pullPtBchargePhi[5]={"z pull",
+					   "#it{p}_{T} (GeV/c)",
+					   "#phi",
+					   "mag. field",
+					   "charge"};
+    fImpParPullzSparsePtBchargePhi=new THnSparseF("fImpParPullzSparsePtBchargePhi","fImpParPullzSparsePtBchargePhi",5,nbinsImpParSparse_pullPtBchargePhi,limitLowImpParSparse_pullPtBchargePhi,limitUpImpParSparse_pullPtBchargePhi);
+    for(Int_t iax=0; iax<5; iax++) fImpParPullzSparsePtBchargePhi->GetAxis(iax)->SetTitle(axTitle_z_pullPtBchargePhi[iax].Data());
+    BinLogAxis(fImpParPullzSparsePtBchargePhi, 1);
+    fOutput->Add(fImpParPullzSparsePtBchargePhi);
   }
 
   //default THnSparses
@@ -517,10 +549,12 @@ void AliAnalysisTaskSEImpParResSparse::UserExec(Option_t */*option*/)
   Double_t eta=0.;
   Double_t pointrphi[4];
   Double_t pullrphi[4];
+  Double_t pullrphi1[5];
   Double_t pointrphi1[5];
   Double_t pointrphi2[5];
   Double_t pointz[4];
   Double_t pullz[4];
+  Double_t pullz1[5];
   Double_t pointz1[5];
   Double_t pointz2[5];
 
@@ -562,10 +596,12 @@ void AliAnalysisTaskSEImpParResSparse::UserExec(Option_t */*option*/)
     if( ((Double_t)pt*10000.)-((Long_t)(pt*10000.))>weight) continue;
     
     pullrphi[1]=pt;
+    pullrphi1[1]=pt;
     pointrphi[1]=pt;
     pointrphi1[1]=pt;
     pointrphi2[1]=pt;
     pullz[1]=pt;
+    pullz1[1]=pt;
     pointz[1]=pt;
     pointz1[1]=pt;
     pointz2[1]=pt;
@@ -590,8 +626,8 @@ void AliAnalysisTaskSEImpParResSparse::UserExec(Option_t */*option*/)
     }
 
     charge=vtrack->Charge();
-    if(charge<0.) {pointrphi1[4]=0.; pointz1[4]=0.;}
-    else if(charge>0.) {pointrphi1[4]=1.; pointz1[4]=1.;}
+    if(charge<0.) {pointrphi1[4]=0.; pointz1[4]=0.; pullrphi1[4]=0.; pullz1[4]=0.;}
+    else if(charge>0.) {pointrphi1[4]=1.; pointz1[4]=1.; pullrphi1[4]=1.; pullz1[4]=1.;}
     //Printf("charge %d",charge);
 
     phi=vtrack->Phi();
@@ -599,6 +635,8 @@ void AliAnalysisTaskSEImpParResSparse::UserExec(Option_t */*option*/)
     if(phibin<0) continue;
     pullrphi[2]=phibin;
     pullz[2]=phibin;
+    pullrphi1[2]=phibin;
+    pullz1[2]=phibin;
     pointrphi[2]=phibin;
     pointz[2]=phibin;
     pointrphi1[2]=phibin;
@@ -609,8 +647,8 @@ void AliAnalysisTaskSEImpParResSparse::UserExec(Option_t */*option*/)
 
 
     Float_t magField=event->GetMagneticField();
-    if(magField<0.) {pointrphi1[3]=0.; pointz1[3]=0.;}
-    else if(magField>0.) {pointrphi1[3]=1.; pointz1[3]=1.;}
+    if(magField<0.) {pointrphi1[3]=0.; pointz1[3]=0.; pullrphi1[3]=0.; pullz1[3]=0.;}
+    else if(magField>0.) {pointrphi1[3]=1.; pointz1[3]=1.; pullrphi1[3]=1.; pullz1[3]=1.;}
     
 
     //MC
@@ -712,7 +750,7 @@ void AliAnalysisTaskSEImpParResSparse::UserExec(Option_t */*option*/)
     }
     //delete vtxVSkip; vtxVSkip=NULL; // not needed anymore
  
-    if(fReadMC) {
+    if(fReadMC && !fUseRecoVertex) {
       vtrack->PropagateToDCA(vtxESDTrue, event->GetMagneticField(), beampiperadius, dzTrue, covdzTrue);
       dz[0]=dzTrue[0]; 
       dz[1]=dzTrue[1];
@@ -729,9 +767,11 @@ void AliAnalysisTaskSEImpParResSparse::UserExec(Option_t */*option*/)
     pointz2[0]=10000.*dz[1];
     pullrphi[0]=dz[0]/TMath::Sqrt(covdz[0]);
     pullz[0]=dz[1]/TMath::Sqrt(covdz[2]);
+    pullrphi1[0]=dz[0]/TMath::Sqrt(covdz[0]);
+    pullz1[0]=dz[1]/TMath::Sqrt(covdz[2]);
     //    Printf("point %f",pointrphi[0]);
 
-    if(fReadMC) primaryVtx=vtxESDTrue;
+    if(fReadMC && !fUseRecoVertex) primaryVtx=vtxESDTrue;
     else if(fSkipTrack) primaryVtx=vtxVSkip;
     else primaryVtx=vtxVRec;
 
@@ -746,6 +786,8 @@ void AliAnalysisTaskSEImpParResSparse::UserExec(Option_t */*option*/)
 	fImpParrphiSparsePtzVtxEtaPhi->Fill(pointrphi2);
 	fImpParzSparsePtBchargePhi->Fill(pointz1);
 	fImpParzSparsePtzVtxEtaPhi->Fill(pointz2);
+	fImpParPullrphiSparsePtBchargePhi->Fill(pullrphi1);
+	fImpParPullzSparsePtBchargePhi->Fill(pullz1);
       }
       fPtDistrib->Fill(pt);
       fImpParrphiSparsePtEtaPhi->Fill(pointrphi);
@@ -761,6 +803,8 @@ void AliAnalysisTaskSEImpParResSparse::UserExec(Option_t */*option*/)
 	fImpParrphiSparsePtzVtxEtaPhi->Fill(pointrphi2);
 	fImpParzSparsePtBchargePhi->Fill(pointz1);
 	fImpParzSparsePtzVtxEtaPhi->Fill(pointz2);
+	fImpParPullrphiSparsePtBchargePhi->Fill(pullrphi1);
+	fImpParPullzSparsePtBchargePhi->Fill(pullz1);
       }
       fPtDistrib->Fill(pt);
       fImpParrphiSparsePtEtaPhi->Fill(pointrphi);
@@ -776,6 +820,8 @@ void AliAnalysisTaskSEImpParResSparse::UserExec(Option_t */*option*/)
 	fImpParrphiSparsePtzVtxEtaPhi->Fill(pointrphi2);
 	fImpParzSparsePtBchargePhi->Fill(pointz1);
 	fImpParzSparsePtzVtxEtaPhi->Fill(pointz2);
+	fImpParPullrphiSparsePtBchargePhi->Fill(pullrphi1);
+	fImpParPullzSparsePtBchargePhi->Fill(pullz1);
       }
       fPtDistrib->Fill(pt);
       fImpParrphiSparsePtEtaPhi->Fill(pointrphi);

--- a/PWGPP/ITS/AliAnalysisTaskSEImpParResSparse.h
+++ b/PWGPP/ITS/AliAnalysisTaskSEImpParResSparse.h
@@ -42,6 +42,7 @@ class AliAnalysisTaskSEImpParResSparse : public AliAnalysisTaskSE {
   void SetIsAOD(Bool_t isAOD) { fIsAOD=isAOD; return; }
   void SetSelectedPdg(Int_t pdg) { fSelectedPdg=pdg; return; }
   void SetUseDiamond(Bool_t use=kFALSE) { fUseDiamond=use; return; }
+  void SetUseRecoVertex(Bool_t use=kFALSE) { fUseRecoVertex=use; return; }
   void SetSkipTrack(Bool_t skip=kFALSE) { fSkipTrack=skip; return; }
   void SetMultiplicityRange(Int_t min,Int_t max) { fMinMult=min; fMaxMult=max; }
   void SetCheckSDDIsIn(Int_t check=0) { fCheckSDDIsIn=check; }
@@ -79,6 +80,7 @@ class AliAnalysisTaskSEImpParResSparse : public AliAnalysisTaskSE {
   Bool_t fReadMC;       // flag used to switch on/off MC reading
   Int_t  fSelectedPdg;  // only for a given particle species (-1 takes all tracks)
   Bool_t fUseDiamond;   // use diamond constraint in primary vertex
+  Bool_t fUseRecoVertex;   // use reco vertex also when reading MC
   Bool_t fSkipTrack;    // redo primary vertex for each track
   Int_t  fMinMult; // minimum multiplicity
   Int_t  fMaxMult; // maximum multiplicity
@@ -103,17 +105,19 @@ class AliAnalysisTaskSEImpParResSparse : public AliAnalysisTaskSE {
   THnSparseF *fImpParrphiSparsePtzVtxEtaPhi; //!<! sparse
   THnSparseF *fImpParrphiSparsePtEtaPhi; //!<! sparse
   THnSparseF *fImpParPullrphiSparsePtEtaPhi; //!<! sparse
+  THnSparseF *fImpParPullrphiSparsePtBchargePhi; //!<! sparse
   THnSparseF *fImpParzSparsePtBchargePhi; //!<! sparse
   THnSparseF *fImpParzSparsePtzVtxEtaPhi; //!<! sparse
   THnSparseF *fImpParzSparsePtEtaPhi; //!<! sparse
   THnSparseF *fImpParPullzSparsePtEtaPhi; //!<! sparse
+  THnSparseF *fImpParPullzSparsePtBchargePhi; //!<! sparse
   TH1F *fPtDistrib; //!<!
   TH1F *fhPtWeights;           // histo with pt weights
   Int_t fUseptWeights;  //0 no weights, 1 pp weights, 2 pPb weights, 3 PbPb weights
   Float_t fScalingFactPtWeight;
   TList *fOutput;  //! 
 
-  ClassDef(AliAnalysisTaskSEImpParResSparse,2); // AliAnalysisTaskSE for the study of the impact parameter resolution
+  ClassDef(AliAnalysisTaskSEImpParResSparse,3); // AliAnalysisTaskSE for the study of the impact parameter resolution
 };
 
 #endif


### PR DESCRIPTION
Adding 2 THnSparse for d0 pulls (in rphi and z) vs pt, phi, B, charge. Adding also the possibility to use reconstructed primary vertex when running with MC option enabled.