### PR TITLE
PWGCF: AliFemtoModelWeightGenerator - Added flag & improved documentation

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoModelWeightGenerator.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoModelWeightGenerator.h
@@ -11,7 +11,7 @@
 #include "TRandom2.h"
 class AliFemtoPair;
 
-class AliFemtoModelWeightGenerator 
+class AliFemtoModelWeightGenerator
 {
  public:
   AliFemtoModelWeightGenerator();
@@ -36,62 +36,62 @@ class AliFemtoModelWeightGenerator
 
   virtual AliFemtoModelWeightGenerator* Clone() const;
 
-  static Int_t PionPlusPionPlus();  
-  static Int_t PionPlusPionMinus(); 
-  static Int_t KaonPlusKaonPlus();  
-  static Int_t KaonPlusKaonMinus(); 
-  static Int_t ProtonProton();      
-  static Int_t ProtonAntiproton();  
-  static Int_t PionPlusKaonPlus();  
-  static Int_t PionPlusKaonMinus(); 
-  static Int_t PionPlusProton();    
+  static Int_t PionPlusPionPlus();
+  static Int_t PionPlusPionMinus();
+  static Int_t KaonPlusKaonPlus();
+  static Int_t KaonPlusKaonMinus();
+  static Int_t ProtonProton();
+  static Int_t ProtonAntiproton();
+  static Int_t PionPlusKaonPlus();
+  static Int_t PionPlusKaonMinus();
+  static Int_t PionPlusProton();
   static Int_t PionPlusAntiproton();
-  static Int_t KaonPlusProton();    
+  static Int_t KaonPlusProton();
   static Int_t KaonPlusAntiproton();
   static Int_t PairTypeNone();
   static Int_t LambdaLambda();
   static Int_t AntilambdaAntilambda();
-   static Int_t LambdaAntilambda();
+  static Int_t LambdaAntilambda();
 
  protected:
-  static const Int_t fgkPairTypeNone;      // no pair type set - read from model
-  static const Int_t fgkPionPlusPionPlus;  // identical pion pair
-  static const Int_t fgkPionPlusPionMinus; // non-identical pion pair
-  static const Int_t fgkKaonPlusKaonPlus;  // identical kaon pair
-  static const Int_t fgkKaonPlusKaonMinus; // non-identical kaon pair
-  static const Int_t fgkProtonProton;      // identical proton pair
-  static const Int_t fgkProtonAntiproton;  // non-identical proton pair
-  static const Int_t fgkPionPlusKaonPlus;  // same-charge pion kaon pair
-  static const Int_t fgkPionPlusKaonMinus; // opposite-charge pion kaon pair
-  static const Int_t fgkPionPlusProton;    // same-charge pion proton pair
-  static const Int_t fgkPionPlusAntiproton;// opposite-chare pion proton pair
-  static const Int_t fgkKaonPlusProton;    // same-charge kaon proton pair
-  static const Int_t fgkKaonPlusAntiproton;// opposite-charge kaon proton pair
-  static const Int_t fgkLambdaLambda;// same-type lambdas
-  static const Int_t fgkAntilambdaAntilambda;// same-type antilambdas
-   static const Int_t fgkLambdaAntilambda;// non-same-type lambdas
+  static const Int_t fgkPairTypeNone;        ///< no pair type set - read from model
+  static const Int_t fgkPionPlusPionPlus;    ///< identical pion pair
+  static const Int_t fgkPionPlusPionMinus;   ///< non-identical pion pair
+  static const Int_t fgkKaonPlusKaonPlus;    ///< identical kaon pair
+  static const Int_t fgkKaonPlusKaonMinus;   ///< non-identical kaon pair
+  static const Int_t fgkProtonProton;        ///< identical proton pair
+  static const Int_t fgkProtonAntiproton;    ///< non-identical proton pair
+  static const Int_t fgkPionPlusKaonPlus;    ///< same-charge pion kaon pair
+  static const Int_t fgkPionPlusKaonMinus;   ///< opposite-charge pion kaon pair
+  static const Int_t fgkPionPlusProton;      ///< same-charge pion proton pair
+  static const Int_t fgkPionPlusAntiproton;  ///< opposite-chare pion proton pair
+  static const Int_t fgkKaonPlusProton;      ///< same-charge kaon proton pair
+  static const Int_t fgkKaonPlusAntiproton;  ///< opposite-charge kaon proton pair
+  static const Int_t fgkLambdaLambda;        ///< same-type lambdas
+  static const Int_t fgkAntilambdaAntilambda; ///< same-type antilambdas
+  static const Int_t fgkLambdaAntilambda;    ///< non-same-type lambdas
 
-  Int_t fPairType;     // Type of the pair for which the calculation is done
+  Int_t fPairType;     ///< Type of the pair for which the calculation is done
 
-  Double_t fKStarOut;  // relative momentum out component in PRF
-  Double_t fKStarSide; // relative momentum side component in PRF
-  Double_t fKStarLong; // relative momentum long component in PRF
-  Double_t fKStar;     // relative momentum magnitude
+  Double_t fKStarOut;  ///< relative momentum out component in PRF
+  Double_t fKStarSide; ///< relative momentum side component in PRF
+  Double_t fKStarLong; ///< relative momentum long component in PRF
+  Double_t fKStar;     ///< relative momentum magnitude
 
-  Double_t fRStarOut;  // relative separation out component in PRF
-  Double_t fRStarSide; // relative separation side component in PRF
-  Double_t fRStarLong; // relative separation long component in PRF
-  Double_t fRStar;     // relative separation magnitude
+  Double_t fRStarOut;  ///< relative separation out component in PRF
+  Double_t fRStarSide; ///< relative separation side component in PRF
+  Double_t fRStarLong; ///< relative separation long component in PRF
+  Double_t fRStar;     ///< relative separation magnitude
  private:
-  
+
 #ifdef __ROOT__
   /// \cond CLASSIMP
   ClassDef(AliFemtoModelWeightGenerator, 1);
   /// \endcond
 #endif
 
-    };
-  
+};
+
 inline Double_t AliFemtoModelWeightGenerator::GetKStar() const { return fKStar; }
 inline Double_t AliFemtoModelWeightGenerator::GetKStarOut() const { return fKStarOut; }
 inline Double_t AliFemtoModelWeightGenerator::GetKStarSide() const { return fKStarSide; }
@@ -101,18 +101,18 @@ inline Double_t AliFemtoModelWeightGenerator::GetRStarOut() const { return fRSta
 inline Double_t AliFemtoModelWeightGenerator::GetRStarSide() const { return fRStarSide; }
 inline Double_t AliFemtoModelWeightGenerator::GetRStarLong() const { return fRStarLong; }
 
-inline Int_t AliFemtoModelWeightGenerator::PairTypeNone() { return fgkPairTypeNone; }  
-inline Int_t AliFemtoModelWeightGenerator::PionPlusPionPlus() { return fgkPionPlusPionPlus; }  
-inline Int_t AliFemtoModelWeightGenerator::PionPlusPionMinus() { return fgkPionPlusPionMinus; } 
-inline Int_t AliFemtoModelWeightGenerator::KaonPlusKaonPlus() { return fgkKaonPlusKaonPlus; }  
-inline Int_t AliFemtoModelWeightGenerator::KaonPlusKaonMinus() { return fgkKaonPlusKaonMinus; } 
-inline Int_t AliFemtoModelWeightGenerator::ProtonProton() { return fgkProtonProton; }      
-inline Int_t AliFemtoModelWeightGenerator::ProtonAntiproton() { return fgkProtonAntiproton; }  
-inline Int_t AliFemtoModelWeightGenerator::PionPlusKaonPlus() { return fgkPionPlusKaonPlus; }  
-inline Int_t AliFemtoModelWeightGenerator::PionPlusKaonMinus() { return fgkPionPlusKaonMinus; } 
-inline Int_t AliFemtoModelWeightGenerator::PionPlusProton() { return fgkPionPlusProton; }    
+inline Int_t AliFemtoModelWeightGenerator::PairTypeNone() { return fgkPairTypeNone; }
+inline Int_t AliFemtoModelWeightGenerator::PionPlusPionPlus() { return fgkPionPlusPionPlus; }
+inline Int_t AliFemtoModelWeightGenerator::PionPlusPionMinus() { return fgkPionPlusPionMinus; }
+inline Int_t AliFemtoModelWeightGenerator::KaonPlusKaonPlus() { return fgkKaonPlusKaonPlus; }
+inline Int_t AliFemtoModelWeightGenerator::KaonPlusKaonMinus() { return fgkKaonPlusKaonMinus; }
+inline Int_t AliFemtoModelWeightGenerator::ProtonProton() { return fgkProtonProton; }
+inline Int_t AliFemtoModelWeightGenerator::ProtonAntiproton() { return fgkProtonAntiproton; }
+inline Int_t AliFemtoModelWeightGenerator::PionPlusKaonPlus() { return fgkPionPlusKaonPlus; }
+inline Int_t AliFemtoModelWeightGenerator::PionPlusKaonMinus() { return fgkPionPlusKaonMinus; }
+inline Int_t AliFemtoModelWeightGenerator::PionPlusProton() { return fgkPionPlusProton; }
 inline Int_t AliFemtoModelWeightGenerator::PionPlusAntiproton() { return fgkPionPlusAntiproton; }
-inline Int_t AliFemtoModelWeightGenerator::KaonPlusProton() { return fgkKaonPlusProton; }    
+inline Int_t AliFemtoModelWeightGenerator::KaonPlusProton() { return fgkKaonPlusProton; }
 inline Int_t AliFemtoModelWeightGenerator::KaonPlusAntiproton() { return fgkKaonPlusAntiproton; }
 inline Int_t AliFemtoModelWeightGenerator::LambdaLambda() { return fgkLambdaLambda; }
 inline Int_t AliFemtoModelWeightGenerator::AntilambdaAntilambda() { return fgkAntilambdaAntilambda; }

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoModelWeightGeneratorBasic.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoModelWeightGeneratorBasic.cxx
@@ -16,13 +16,15 @@
 
 //________________________
 AliFemtoModelWeightGeneratorBasic::AliFemtoModelWeightGeneratorBasic():
-  AliFemtoModelWeightGenerator()
+  AliFemtoModelWeightGenerator(),
+  fPrintEmptyParticleNotification(true)
 {
   /* no-op */
 }
 //________________________
 AliFemtoModelWeightGeneratorBasic::AliFemtoModelWeightGeneratorBasic(const AliFemtoModelWeightGeneratorBasic &aModel) :
-  AliFemtoModelWeightGenerator(aModel)
+  AliFemtoModelWeightGenerator(aModel),
+  fPrintEmptyParticleNotification(aModel.fPrintEmptyParticleNotification)
 {
   /* no-op */
 }
@@ -38,6 +40,8 @@ AliFemtoModelWeightGeneratorBasic& AliFemtoModelWeightGeneratorBasic::operator=(
   if (this != &aModel) {
     AliFemtoModelWeightGenerator::operator=(aModel);
   }
+
+  fPrintEmptyParticleNotification = aModel.fPrintEmptyParticleNotification;
 
   return *this;
 }
@@ -88,7 +92,9 @@ Double_t AliFemtoModelWeightGeneratorBasic::GenerateWeight(AliFemtoPair *aPair)
   Double_t tM  = (tMt - tPt > 0.0) ? sqrt(tMt - tPt) : 0.0;
 
   if (tMt == 0 || tE == 0 || tM == 0 || tPt == 0 ) {
-    cout << " weight generator zero tPt || tMt || tM || tPt " << tM1 << " " << tM2 << endl;
+    if (fPrintEmptyParticleNotification) {
+      cout << " weight generator zero tPt || tMt || tM || tPt " << tM1 << " " << tM2 << endl;
+    }
     return 0;
   }
 
@@ -101,7 +107,7 @@ Double_t AliFemtoModelWeightGeneratorBasic::GenerateWeight(AliFemtoPair *aPair)
   Double_t pX=((AliFemtoModelHiddenInfo*)inf1->GetHiddenInfo())->GetTrueMomentum()->x();
   Double_t pY=((AliFemtoModelHiddenInfo*)inf1->GetHiddenInfo())->GetTrueMomentum()->y();
   Double_t pZ=((AliFemtoModelHiddenInfo*)inf1->GetHiddenInfo())->GetTrueMomentum()->z();
-	   
+
 
   // Boost to LCMS
   Double_t tBeta = tPz/tE;
@@ -169,7 +175,7 @@ Double_t AliFemtoModelWeightGeneratorBasic::GenerateWeight(AliFemtoPair *aPair)
 */
 
  Double_t tDX =((AliFemtoModelHiddenInfo*)inf1->GetHiddenInfo())->GetEmissionPoint()->x()  - ((AliFemtoModelHiddenInfo*)inf2->GetHiddenInfo())->GetEmissionPoint()->x();
-  
+
   Double_t tDY =((AliFemtoModelHiddenInfo*)inf1->GetHiddenInfo())->GetEmissionPoint()->y()  - ((AliFemtoModelHiddenInfo*)inf2->GetHiddenInfo())->GetEmissionPoint()->y();
 
  Double_t tRLong =((AliFemtoModelHiddenInfo*)inf1->GetHiddenInfo())->GetEmissionPoint()->z()  - ((AliFemtoModelHiddenInfo*)inf2->GetHiddenInfo())->GetEmissionPoint()->z();

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoModelWeightGeneratorBasic.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoModelWeightGeneratorBasic.cxx
@@ -1,8 +1,6 @@
 ///
-/// \class AliFemtoModelWeightGeneratorBasic
-/// \brief Basic femtoscopic weight generator only return a simple
-/// \author Adam Kisiel <kisiel@mps.ohio-state.edu>
-///
+/// \file AliFemtoModelWeightGeneratorBasic.cxx
+/// \author Adam Kisiel kisiel@mps.ohio-state.edu
 ///
 
 #ifdef __ROOT__

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoModelWeightGeneratorBasic.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoModelWeightGeneratorBasic.h
@@ -10,7 +10,13 @@
 #include "AliFemtoModelWeightGenerator.h"
 
 /// \class AliFemtoModelWeightGeneratorBasic
-/// \brief Basic femtoscopic weight generator only return a simple
+/// \brief Basic femtoscopic weight generator to determine a
+///        femtoscopic weight using quantum statistics
+///
+/// Generates a simple femtoscopic weight coming only from quantum
+/// statistics - symmetrization or anti-symmetrization of the pair
+/// wave function.
+///
 /// \author Adam Kisiel kisiel@mps.ohio-state.edu
 ///
 class AliFemtoModelWeightGeneratorBasic : public AliFemtoModelWeightGenerator {
@@ -29,14 +35,18 @@ public:
   virtual Int_t    GetPairType() const;
 
   /// Sets whether or not to print a notification when the generator
-  /// reads a particle with no mass, energy, momentum (i.e. "empty")
+  /// is asked to find weight of a pair with zero mass, energy, or
+  /// momentum (i.e. "empty")
   ///
-  void ShouldPrintEmptyParticleNotification(bool option) { fPrintEmptyParticleNotification = option; };
+  void ShouldPrintEmptyParticleNotification(bool option);
 
   virtual AliFemtoModelWeightGenerator* Clone() const;
 
 protected:
 
+  /// Internal flag to determine whether or not this generator should
+  /// a print notification when asked to generate weight for "empty"
+  /// AliFemtoPair
   bool fPrintEmptyParticleNotification;
 
 private:
@@ -47,8 +57,12 @@ private:
   ClassDef(AliFemtoModelWeightGeneratorBasic, 1);
   /// \endcond
 #endif
-
 };
+
+inline void AliFemtoModelWeightGeneratorBasic::ShouldPrintEmptyParticleNotification(bool option)
+{
+  fPrintEmptyParticleNotification = option;
+}
 
 #endif
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoModelWeightGeneratorBasic.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoModelWeightGeneratorBasic.h
@@ -26,11 +26,19 @@ public:
 
   virtual void     SetPairType(Int_t aPairType);
   virtual void     SetPairTypeFromPair(AliFemtoPair *aPair);
-  virtual Int_t    GetPairType() const; 
+  virtual Int_t    GetPairType() const;
+
+  /// Sets whether or not to print a notification when the generator
+  /// reads a particle with no mass, energy, momentum (i.e. "empty")
+  ///
+  void ShouldPrintEmptyParticleNotification(bool option) { fPrintEmptyParticleNotification = option; };
 
   virtual AliFemtoModelWeightGenerator* Clone() const;
+
 protected:
-  
+
+  bool fPrintEmptyParticleNotification;
+
 private:
   AliFemtoModelWeightGenerator* GetGenerator() const;
 
@@ -41,7 +49,7 @@ private:
 #endif
 
 };
-  
+
 #endif
 
 


### PR DESCRIPTION
This commit adds an internal flag `fPrintEmptyParticleNotification` to the AliFemtoModelWeightGenerator which, if false, will prevent printing a notification to stdout every time a weight is requested for a particle pair whose momentum/emergy/mass adds to zero (an "empty" pair).

This also adds and fixes some documentation and improves formatting of the files. 