### PR TITLE
Adding trackcuts for systematics

### DIFF
--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFfits/AliAnalysisTaskTPCTOFPID.cxx
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFfits/AliAnalysisTaskTPCTOFPID.cxx
@@ -214,7 +214,7 @@ AliAnalysisTaskTPCTOFPID::~AliAnalysisTaskTPCTOFPID()
   if (fTrackCuts2010) delete fTrackCuts2010;
   if (fTrackCuts2011) delete fTrackCuts2011;
   if (fTrackCutsTPCRefit) delete fTrackCutsTPCRefit;
-  if (fTrackCuts2011Sys) delete fTrackCuts2011Sys
+  if (fTrackCuts2011Sys) delete fTrackCuts2011Sys;
   delete fESDpid;
   delete fTOFcalib;
   delete fTOFT0maker;

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFfits/AliAnalysisTaskTPCTOFPID.h
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFfits/AliAnalysisTaskTPCTOFPID.h
@@ -103,6 +103,7 @@ public AliAnalysisTaskSE
   AliESDtrackCuts *fTrackCuts2010; //! ITSTPC track cuts 2010
   AliESDtrackCuts *fTrackCuts2011; //! ITSTPC track cuts 2011
   AliESDtrackCuts *fTrackCutsTPCRefit; //! TPC only track cuts + refit
+  AliESDtrackCuts *fTrackCuts2011Sys; //! TPC only track cuts + refit 
   AliESDpid *fESDpid; // ESD PID
   Bool_t fIsCollisionCandidate; // is collision candidate
   UInt_t fIsEventSelected; // is event selected


### PR DESCRIPTION
Added ITSTPC2011Sys cuts -- loose 2011 cuts for systematics estimation. Also, reduced gamma inv mass range even further (15 MeV) to reduce the size (1st commit) and added the missing ; (2nd commit)