### PR TITLE
PWGGA/GammaConv: Added new cut variations and configs for pp + configs for material task

### DIFF
--- a/PWGGA/GammaConv/AliConversionPhotonCuts.cxx
+++ b/PWGGA/GammaConv/AliConversionPhotonCuts.cxx
@@ -2033,6 +2033,18 @@ Bool_t AliConversionPhotonCuts::SetEtaCut(Int_t etaCut){   // Set Cut
     fEtaCutMin     = -0.1;
     fLineCutZRSlopeMin = 0.;
     break;
+  case 10: // 0.2-0.9
+    fEtaCut     = 0.9;
+    fLineCutZRSlope = tan(2*atan(exp(-fEtaCut)));
+    fEtaCutMin     = 0.2;
+    fLineCutZRSlopeMin = 0.;
+    break;
+  case 11: // 0.2-0.9
+    fEtaCut     = 0.9;
+    fLineCutZRSlope = tan(2*atan(exp(-fEtaCut)));
+    fEtaCutMin     = 0.2;
+    fLineCutZRSlopeMin = tan(2*atan(exp(-fEtaCutMin)));
+    break;
   default:
     AliError(Form(" EtaCut not defined %d",etaCut));
     return kFALSE;

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pp.C
@@ -653,6 +653,11 @@ void AddTask_GammaConvV1_pp(  Int_t   trainConfig                     = 1,      
     cuts.AddCut("00010113", "00200009227300008250400000", "0152103500000000"); // no double counting
     cuts.AddCut("00010113", "00200009227300008250404000", "0152105500000000"); // meson alpha < 0.75
     cuts.AddCut("00010113", "00200009227300008250404000", "0152107500000000"); // meson alpha < 0.85
+    // eta cut variation to exclude central cathode
+  } else if (trainConfig == 130) {
+    cuts.AddCut("00010113", "00200009227300008250404000", "0152103500000000"); //standard cut from 8TeV ana
+    cuts.AddCut("00010113", "0a200009227300008250404000", "0152103500000000"); //eta cut 0.2 < |eta| < 0.9
+
     // -------- Material weights -several configs with same sets for running with various mat weights ----------
   } else if (trainConfig == 160) { // like last last two in 70 and dalitz standard 7TeV
     cuts.AddCut("00000113", "00200009227302008250400000", "0152103500000000"); //New standard cut for 7TeV analysis V0OR

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pp2.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pp2.C
@@ -215,6 +215,8 @@ void AddTask_GammaConvV1_pp2(   Int_t    trainConfig                 = 1,       
     cuts.AddCut("00010213", "00200009227300008250404000", "0152103500000000"); //standard cut pp 8 TeV + past future max rejection
   } else if (trainConfig == 24) {
     cuts.AddCut("00010513", "00200009227300008250404000", "0152103500000000"); //standard cut pp 8 TeV + past future medium rejection
+  } else if (trainConfig == 25) {
+    cuts.AddCut("00010113", "0a200009227300008250404000", "0152103500000000"); //eta cut 0.2 < |eta| < 0.9
 
   //----------------------------- configuration for  7 TeV standard cuts -----------------------------------------------------
   } else if (trainConfig == 30){

--- a/PWGGA/GammaConv/macros/AddTask_MaterialHistos_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_MaterialHistos_pp.C
@@ -310,6 +310,18 @@ void AddTask_MaterialHistos_pp( Int_t   trainConfig             = 1,            
  
   } else  if(trainConfig == 111){
     cuts.AddCut("00000003", "10000070000000000500004000");
+  // 7 TeV testconfig for pileup checks
+  } else if (trainConfig == 150) {
+    cuts.AddCut("00000103", "00000009266300008884004000");
+    cuts.AddCut("00000103", "00000009266300008804004000");
+    cuts.AddCut("00000103", "10000009266300008884004000");
+    cuts.AddCut("00000103", "10000009266300008804004000");
+    // 8 TeV testconfig for pileup checks
+  } else if (trainConfig == 151) {
+    cuts.AddCut("00010103", "00000009266300008884004000");
+    cuts.AddCut("00010103", "00000009266300008804004000");
+    cuts.AddCut("00010103", "10000009266300008884004000");
+    cuts.AddCut("00010103", "10000009266300008804004000");
 
     // ConstructGamma is used
 


### PR DESCRIPTION
This pull request adds two new cutvariations in pseudorapidity as well as new configs in the GammaConv AddTasks.
A second part of this request is the addition of two configs for the Material Budget tasks that will be used for pileup crosschecks.