### PR TITLE
Compatibility for parton type from stack for other generators than PYTHIA

### DIFF
--- a/PWGHF/jetsHF/AliAnalysisTaskJetExtractorHF.cxx
+++ b/PWGHF/jetsHF/AliAnalysisTaskJetExtractorHF.cxx
@@ -877,8 +877,17 @@ void AliAnalysisTaskJetExtractorHF::CalculateInitialCollisionJets()
   if(MCEvent() && (MCEvent()->Stack()))
   {
     AliStack* stack = MCEvent()->Stack();
-    TParticle* parton1 = stack->Particle(6);
-    TParticle* parton2 = stack->Particle(7);
+    TParticle* parton1 = 0;
+    TParticle* parton2 = 0;
+    // PYTHIA: Get LO collision objects
+    if(stack->GetNtrack() >= 8)
+    {
+      parton1 = stack->Particle(6);
+      parton2 = stack->Particle(7);
+    }
+    else if(stack->GetNtrack() >= 7)
+      parton1 = stack->Particle(6);
+
     if(parton1)
     {
       initialParton1_eta = parton1->Eta();


### PR DESCRIPTION
For other generators than PYTHIA, it is possible to have less particles on the stacks than 8. This is now taken into account.