### PR TITLE
Implementation of hit coordinates in TOF calibration task

### DIFF
--- a/PWGPP/CalibMacros/CPass1/AddTOFAnalysisTaskCalibTree.C
+++ b/PWGPP/CalibMacros/CPass1/AddTOFAnalysisTaskCalibTree.C
@@ -1,4 +1,4 @@
-AliTOFAnalysisTaskCalibTree *AddTOFAnalysisTaskCalibTree() {
+AliTOFAnalysisTaskCalibTree *AddTOFAnalysisTaskCalibTree(Bool_t lightmode = kFALSE, Bool_t savecoords = kFALSE) {
 
   /* check analysis manager */
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
@@ -54,6 +54,10 @@ AliTOFAnalysisTaskCalibTree *AddTOFAnalysisTaskCalibTree() {
   task->SetComputeT0TOF(kTRUE);
   task->SetUseT0TOF(kFALSE);
   task->SetUseLHCClockPhase(kFALSE);
+  task->SetSaveCoordinates(savecoords);
+  task->SetLightMode(lightmode);
+ 
+
   //  task->SetSpecificStorageParOffline("alien://?folder=/alice/cern.ch/user/r/rpreghen/OCDB");
   //  task->SetSpecificStorageRunParams("alien://?folder=/alice/cern.ch/user/r/rpreghen/OCDB");
 

--- a/PWGPP/CalibMacros/CPass1/AddTOFAnalysisTaskCalibTree.C
+++ b/PWGPP/CalibMacros/CPass1/AddTOFAnalysisTaskCalibTree.C
@@ -1,4 +1,4 @@
-AliTOFAnalysisTaskCalibTree *AddTOFAnalysisTaskCalibTree(Bool_t lightmode = kFALSE, Bool_t savecoords = kFALSE) {
+AliTOFAnalysisTaskCalibTree *AddTOFAnalysisTaskCalibTree(Bool_t savecoords = kFALSE) {
 
   /* check analysis manager */
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
@@ -55,7 +55,6 @@ AliTOFAnalysisTaskCalibTree *AddTOFAnalysisTaskCalibTree(Bool_t lightmode = kFAL
   task->SetUseT0TOF(kFALSE);
   task->SetUseLHCClockPhase(kFALSE);
   task->SetSaveCoordinates(savecoords);
-  task->SetLightMode(lightmode);
  
 
   //  task->SetSpecificStorageParOffline("alien://?folder=/alice/cern.ch/user/r/rpreghen/OCDB");

--- a/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
+++ b/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
@@ -64,7 +64,6 @@ AliAnalysisTaskSE(name),
   fDeltaz(0),
   fDeltat(0),
   fDeltaraw(0),
-  fLightMode(kFALSE),
   fSaveCoordinates(kFALSE),
   fOutputTree(0x0)             
 

--- a/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
+++ b/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
@@ -53,6 +53,8 @@ AliAnalysisTaskSE(name),
   fVertexZ(99999),
   ftimezero(9999999),
   fnhits(-1),
+  fLightMode(kFALSE),
+  fSaveCoordinates(kFALSE),
   fOutputTree(0x0)             
 
 {
@@ -88,6 +90,20 @@ AliTOFAnalysisTaskCalibTree::~AliTOFAnalysisTaskCalibTree()
   delete fTOFcalib;
   delete fTOFT0maker;
   delete fTOFT0v1;
+  delete fGRPManager;
+  delete fGRPObject;
+  delete fESDEvent;
+  delete fVertex;
+
+  delete fmomentum;
+  delete flength;
+  delete findex;
+  delete ftime;
+  delete ftot;
+  delete ftexp;
+  delete fDeltax;
+  delete fDeltaz;
+
   if (fOutputTree) {
     delete fOutputTree;
     fOutputTree = 0x0;
@@ -100,7 +116,6 @@ AliTOFAnalysisTaskCalibTree::~AliTOFAnalysisTaskCalibTree()
 void
 AliTOFAnalysisTaskCalibTree::UserCreateOutputObjects()
 {
-  AliTuple[2]='root=v5-34-08 geant3=v1-15 aliroot=v5-05-68-AN '
   /*
    * user create output objects
    */
@@ -190,14 +205,23 @@ void AliTOFAnalysisTaskCalibTree::UserExec(Option_t *) {
 
     // add hit to array (if there is room)
     if (fnhits > MAXHITS) continue;
-    fmomentum[fnhits] = momentum;
-    flength[fnhits] = length;
+
+    if (!fLightMode) {  // skip track parameters if flag on
+      fmomentum[fnhits] = momentum;
+      flength[fnhits] = length;
+      ftexp[fnhits] = timei[AliPID::kPion];
+    }
+    
+    if (fSaveCoordinates) { //save pad hit coordinates if flag on
+      fDeltax[fnhits] = deltax;
+      fDeltaz[fnhits] = deltaz;
+    }
+    
+    //  save following always
     findex[fnhits] = index;
     ftime[fnhits] = time;
     ftot[fnhits] = tot;
-    ftexp[fnhits] = timei[AliPID::kPion];
-    fDeltax[fnhits] = deltax;
-    fDeltaz[fnhits] = deltaz;
+    
     fnhits++;
 
   } /* end of loop over ESD tracks */

--- a/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
+++ b/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
@@ -63,12 +63,13 @@ AliAnalysisTaskSE(name),
   fDeltaz(0),
   fLightMode(kFALSE),
   fSaveCoordinates(kFALSE),
-  fOutputTree(0x0)
+  fOutputTree(0x0)             
 
 {
   /* 
    * default constructor 
    */
+
   fmomentum = new Float_t[MAXHITS];
   flength = new Float_t[MAXHITS];
   findex = new Int_t[MAXHITS];
@@ -118,7 +119,6 @@ AliTOFAnalysisTaskCalibTree::~AliTOFAnalysisTaskCalibTree()
   delete ftexp;
   delete fDeltax;
   delete fDeltaz;
-
   if (fOutputTree) {
     delete fOutputTree;
     fOutputTree = 0x0;
@@ -138,19 +138,22 @@ AliTOFAnalysisTaskCalibTree::UserCreateOutputObjects()
   fOutputTree = new TTree("aodTree", "Tree with TOF calib output"); 
 
   /* setup output tree */
-  if (!fLightMode) { // skip some track parameters if flag on
-     fOutputTree->Branch("run", &fRunNumber, "run/I");
-     fOutputTree->Branch("timestamp", &ftimestamp, "timestamp/i");
-     fOutputTree->Branch("timezero", &ftimezero, "timezero/F");
-     fOutputTree->Branch("vertex", &fVertexZ, "vertex/F");
-     fOutputTree->Branch("momentum", &fmomentum, "momentum[nhits]/F");
-     fOutputTree->Branch("length", &flength, "length[nhits]/F");
-   }
   fOutputTree->Branch("nhits", &fnhits, "nhits/I");
   fOutputTree->Branch("index", &findex, "index[nhits]/I");
   fOutputTree->Branch("time", &ftime, "time[nhits]/F");
   fOutputTree->Branch("tot", &ftot, "tot[nhits]/F");
   fOutputTree->Branch("texp", &ftexp, "texp[nhits]/F");
+  if (!fLightMode) { // skip some track parameters if flag on
+  fOutputTree->Branch("run", &fRunNumber, "run/I");
+  fOutputTree->Branch("timestamp", &ftimestamp, "timestamp/i");
+  fOutputTree->Branch("timezero", &ftimezero, "timezero/F");
+  fOutputTree->Branch("vertex", &fVertexZ, "vertex/F");
+  fOutputTree->Branch("momentum", &fmomentum, "momentum[nhits]/F");
+  fOutputTree->Branch("length", &flength, "length[nhits]/F");
+   }
+
+
+
   if (fSaveCoordinates) { //save pad hit coordinates if flag on
      fOutputTree->Branch("deltax", &fDeltax, "deltax[nhits]/F");
      fOutputTree->Branch("deltaz", &fDeltaz, "deltaz[nhits]/F");
@@ -223,7 +226,6 @@ void AliTOFAnalysisTaskCalibTree::UserExec(Option_t *) {
 
     // add hit to array (if there is room)
     if (fnhits > MAXHITS) continue;
-
     fmomentum[fnhits] = momentum;
     flength[fnhits] = length;
     ftexp[fnhits] = timei[AliPID::kPion];
@@ -232,7 +234,6 @@ void AliTOFAnalysisTaskCalibTree::UserExec(Option_t *) {
     ftot[fnhits] = tot;
     fDeltax[fnhits] = deltax;
     fDeltaz[fnhits] = deltaz;
-    
     fnhits++;
 
   } /* end of loop over ESD tracks */

--- a/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
+++ b/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
@@ -67,6 +67,8 @@ AliAnalysisTaskSE(name),
       ftime[i] = 999999;
       ftot[i] = 999999;
       ftexp[i] = 999999;
+      fDeltax[i] = 999999;
+      fDeltaz[i] = 999999;
   }
 
   DefineOutput(1, TTree::Class());  
@@ -98,6 +100,7 @@ AliTOFAnalysisTaskCalibTree::~AliTOFAnalysisTaskCalibTree()
 void
 AliTOFAnalysisTaskCalibTree::UserCreateOutputObjects()
 {
+  AliTuple[2]='root=v5-34-08 geant3=v1-15 aliroot=v5-05-68-AN '
   /*
    * user create output objects
    */
@@ -116,6 +119,8 @@ AliTOFAnalysisTaskCalibTree::UserCreateOutputObjects()
   fOutputTree->Branch("time", &ftime, "time[nhits]/F");
   fOutputTree->Branch("tot", &ftot, "tot[nhits]/F");
   fOutputTree->Branch("texp", &ftexp, "texp[nhits]/F");
+  fOutputTree->Branch("deltax", &fDeltax, "deltax[nhits]/F");
+  fOutputTree->Branch("deltaz", &fDeltaz, "deltaz[nhits]/F");
 
   PostData(1, fOutputTree);
 
@@ -159,7 +164,7 @@ void AliTOFAnalysisTaskCalibTree::UserExec(Option_t *) {
   Int_t nTracks = fESDEvent->GetNumberOfTracks();
   AliESDtrack *track;
   Int_t index;
-  Double_t momentum, length, time, tot, timei[AliPID::kSPECIES];
+  Double_t momentum, length, time, tot, timei[AliPID::kSPECIES], deltax, deltaz;
   for (Int_t itrk = 0; itrk < nTracks; itrk++) {
     // get track
     track = fESDEvent->GetTrack(itrk);
@@ -180,6 +185,8 @@ void AliTOFAnalysisTaskCalibTree::UserExec(Option_t *) {
     time = track->GetTOFsignal();
     tot = track->GetTOFsignalToT();
     track->GetIntegratedTimes(timei);
+    deltax = track->GetTOFsignalDx();
+    deltaz = track->GetTOFsignalDz();
 
     // add hit to array (if there is room)
     if (fnhits > MAXHITS) continue;
@@ -189,6 +196,8 @@ void AliTOFAnalysisTaskCalibTree::UserExec(Option_t *) {
     ftime[fnhits] = time;
     ftot[fnhits] = tot;
     ftexp[fnhits] = timei[AliPID::kPion];
+    fDeltax[fnhits] = deltax;
+    fDeltaz[fnhits] = deltaz;
     fnhits++;
 
   } /* end of loop over ESD tracks */

--- a/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
+++ b/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
@@ -62,6 +62,8 @@ AliAnalysisTaskSE(name),
   ftexp(0),
   fDeltax(0),
   fDeltaz(0),
+  fDeltat(0),
+  fDeltaraw(0),
   fLightMode(kFALSE),
   fSaveCoordinates(kFALSE),
   fOutputTree(0x0)             
@@ -79,6 +81,8 @@ AliAnalysisTaskSE(name),
   ftexp = new Float_t[fMaxHits];
   fDeltax = new Float_t[fMaxHits];
   fDeltaz = new Float_t[fMaxHits];
+  fDeltat = new Float_t[fMaxHits];
+  fDeltaraw = new Float_t [fMaxHits]; 
   for (Int_t i = 0; i < fMaxHits; i++){
       fmomentum[i] = 999999;
       flength[i] = 999999;
@@ -88,6 +92,9 @@ AliAnalysisTaskSE(name),
       ftexp[i] = 999999;
       fDeltax[i] = 999999;
       fDeltaz[i] = 999999;
+      fDeltat[i] = 999999;
+      fDeltaraw[i] = 999999;
+
   }
 
   DefineOutput(1, TTree::Class());  
@@ -120,6 +127,8 @@ AliTOFAnalysisTaskCalibTree::~AliTOFAnalysisTaskCalibTree()
   delete ftexp;
   delete fDeltax;
   delete fDeltaz;
+  delete fDeltat;
+  delete fDeltaraw;
   if (fOutputTree) {
     delete fOutputTree;
     fOutputTree = 0x0;
@@ -139,26 +148,32 @@ AliTOFAnalysisTaskCalibTree::UserCreateOutputObjects()
   fOutputTree = new TTree("aodTree", "Tree with TOF calib output"); 
 
   /* setup output tree */
+  
+if (fSaveCoordinates) { //save reduced tree for coordinate study
+   
   fOutputTree->Branch("nhits", &fnhits, "nhits/I");
   fOutputTree->Branch("index", findex, "index[nhits]/I");
-  fOutputTree->Branch("time", ftime, "time[nhits]/F");
   fOutputTree->Branch("tot", ftot, "tot[nhits]/F");
-  fOutputTree->Branch("texp", ftexp, "texp[nhits]/F");
-  if (!fLightMode) { // skip some track parameters if flag on
+  fOutputTree->Branch("deltax", fDeltax, "deltax[nhits]/F");
+  fOutputTree->Branch("deltaz", fDeltaz, "deltaz[nhits]/F");
+  fOutputTree->Branch("deltat", fDeltat, "deltat[nhits]/F");
+  fOutputTree->Branch("deltaraw", fDeltaraw, "deltaraw[nhits]/F");
+} 
+   else { //default tree
   fOutputTree->Branch("run", &fRunNumber, "run/I");
   fOutputTree->Branch("timestamp", &ftimestamp, "timestamp/i");
   fOutputTree->Branch("timezero", &ftimezero, "timezero/F");
   fOutputTree->Branch("vertex", &fVertexZ, "vertex/F");
+  fOutputTree->Branch("nhits", &fnhits, "nhits/I");
   fOutputTree->Branch("momentum", fmomentum, "momentum[nhits]/F");
   fOutputTree->Branch("length", flength, "length[nhits]/F");
+  fOutputTree->Branch("index", findex, "index[nhits]/I");
+  fOutputTree->Branch("time", ftime, "time[nhits]/F");
+  fOutputTree->Branch("tot", ftot, "tot[nhits]/F");
+  fOutputTree->Branch("texp", ftexp, "texp[nhits]/F");
+
    }
 
-
-
-  if (fSaveCoordinates) { //save pad hit coordinates if flag on
-     fOutputTree->Branch("deltax", fDeltax, "deltax[nhits]/F");
-     fOutputTree->Branch("deltaz", fDeltaz, "deltaz[nhits]/F");
-  }
   PostData(1, fOutputTree);
 
 }
@@ -191,9 +206,10 @@ void AliTOFAnalysisTaskCalibTree::UserExec(Option_t *) {
   //Int_t timeZeroTOF_tracks = fTOFT0v1->GetResult(3);  // not used for the time being
 
   // check T0-TOF sigma 
-  if (timeZeroTOF_sigma >= 250.) ftimezero = 999999.; 
+  if (timeZeroTOF_sigma >= 250.) { ftimezero = 999999.; 
+   timeZeroTOF = 0.;}
   else ftimezero = timeZeroTOF;
-
+  
   // reset
   fnhits = 0;
   
@@ -201,7 +217,7 @@ void AliTOFAnalysisTaskCalibTree::UserExec(Option_t *) {
   Int_t nTracks = fESDEvent->GetNumberOfTracks();
   AliESDtrack *track;
   Int_t index;
-  Double_t momentum, length, time, tot, timei[AliPID::kSPECIES], deltax, deltaz;
+  Double_t momentum, length, time, tot, timei[AliPID::kSPECIES], deltax, deltaz, deltat, deltaraw;
   for (Int_t itrk = 0; itrk < nTracks; itrk++) {
     // get track
     track = fESDEvent->GetTrack(itrk);
@@ -224,7 +240,8 @@ void AliTOFAnalysisTaskCalibTree::UserExec(Option_t *) {
     track->GetIntegratedTimes(timei);
     deltax = track->GetTOFsignalDx();
     deltaz = track->GetTOFsignalDz();
-
+    deltat = (time - timei[AliPID::kPion] - timeZeroTOF);
+    deltaraw = (track->GetTOFSignalRaw() - timei[AliPID::kPion] - timeZeroTOF);
     // add hit to array (if there is room)
     if (fnhits > fMaxHits) continue;
     fmomentum[fnhits] = momentum;
@@ -235,6 +252,8 @@ void AliTOFAnalysisTaskCalibTree::UserExec(Option_t *) {
     ftot[fnhits] = tot;
     fDeltax[fnhits] = deltax;
     fDeltaz[fnhits] = deltaz;
+    fDeltat[fnhits] = deltat;
+    fDeltaraw[fnhits] = deltaraw;
     fnhits++;
 
   } /* end of loop over ESD tracks */

--- a/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
+++ b/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
@@ -49,6 +49,7 @@ AliAnalysisTaskSE(name),
   fTOFcalib(new AliTOFcalib()),             
   fTOFT0maker(new AliTOFT0maker(fESDpid, fTOFcalib)),         
   fTOFT0v1(new AliTOFT0v1(fESDpid)),
+  fMaxHits(MAXHITS),
   ftimestamp(0),
   fVertexZ(99999),
   ftimezero(9999999),
@@ -70,15 +71,15 @@ AliAnalysisTaskSE(name),
    * default constructor 
    */
 
-  fmomentum = new Float_t[MAXHITS];
-  flength = new Float_t[MAXHITS];
-  findex = new Int_t[MAXHITS];
-  ftime = new Float_t[MAXHITS];
-  ftot = new Float_t[MAXHITS];
-  ftexp = new Float_t[MAXHITS];
-  fDeltax = new Float_t[MAXHITS];
-  fDeltaz = new Float_t[MAXHITS];
-  for (Int_t i = 0; i < MAXHITS; i++){
+  fmomentum = new Float_t[fMaxHits];
+  flength = new Float_t[fMaxHits];
+  findex = new Int_t[fMaxHits];
+  ftime = new Float_t[fMaxHits];
+  ftot = new Float_t[fMaxHits];
+  ftexp = new Float_t[fMaxHits];
+  fDeltax = new Float_t[fMaxHits];
+  fDeltaz = new Float_t[fMaxHits];
+  for (Int_t i = 0; i < fMaxHits; i++){
       fmomentum[i] = 999999;
       flength[i] = 999999;
       findex[i] = -1;
@@ -139,24 +140,24 @@ AliTOFAnalysisTaskCalibTree::UserCreateOutputObjects()
 
   /* setup output tree */
   fOutputTree->Branch("nhits", &fnhits, "nhits/I");
-  fOutputTree->Branch("index", &findex, "index[nhits]/I");
-  fOutputTree->Branch("time", &ftime, "time[nhits]/F");
-  fOutputTree->Branch("tot", &ftot, "tot[nhits]/F");
-  fOutputTree->Branch("texp", &ftexp, "texp[nhits]/F");
+  fOutputTree->Branch("index", findex, "index[nhits]/I");
+  fOutputTree->Branch("time", ftime, "time[nhits]/F");
+  fOutputTree->Branch("tot", ftot, "tot[nhits]/F");
+  fOutputTree->Branch("texp", ftexp, "texp[nhits]/F");
   if (!fLightMode) { // skip some track parameters if flag on
   fOutputTree->Branch("run", &fRunNumber, "run/I");
   fOutputTree->Branch("timestamp", &ftimestamp, "timestamp/i");
   fOutputTree->Branch("timezero", &ftimezero, "timezero/F");
   fOutputTree->Branch("vertex", &fVertexZ, "vertex/F");
-  fOutputTree->Branch("momentum", &fmomentum, "momentum[nhits]/F");
-  fOutputTree->Branch("length", &flength, "length[nhits]/F");
+  fOutputTree->Branch("momentum", fmomentum, "momentum[nhits]/F");
+  fOutputTree->Branch("length", flength, "length[nhits]/F");
    }
 
 
 
   if (fSaveCoordinates) { //save pad hit coordinates if flag on
-     fOutputTree->Branch("deltax", &fDeltax, "deltax[nhits]/F");
-     fOutputTree->Branch("deltaz", &fDeltaz, "deltaz[nhits]/F");
+     fOutputTree->Branch("deltax", fDeltax, "deltax[nhits]/F");
+     fOutputTree->Branch("deltaz", fDeltaz, "deltaz[nhits]/F");
   }
   PostData(1, fOutputTree);
 
@@ -225,7 +226,7 @@ void AliTOFAnalysisTaskCalibTree::UserExec(Option_t *) {
     deltaz = track->GetTOFsignalDz();
 
     // add hit to array (if there is room)
-    if (fnhits > MAXHITS) continue;
+    if (fnhits > fMaxHits) continue;
     fmomentum[fnhits] = momentum;
     flength[fnhits] = length;
     ftexp[fnhits] = timei[AliPID::kPion];

--- a/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
+++ b/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
@@ -123,20 +123,23 @@ AliTOFAnalysisTaskCalibTree::UserCreateOutputObjects()
   fOutputTree = new TTree("aodTree", "Tree with TOF calib output"); 
 
   /* setup output tree */
-  fOutputTree->Branch("run", &fRunNumber, "run/I");
-  fOutputTree->Branch("timestamp", &ftimestamp, "timestamp/i");
-  fOutputTree->Branch("timezero", &ftimezero, "timezero/F");
-  fOutputTree->Branch("vertex", &fVertexZ, "vertex/F");
-  fOutputTree->Branch("nhits", &fnhits, "nhits/I");
-  fOutputTree->Branch("momentum", &fmomentum, "momentum[nhits]/F");
-  fOutputTree->Branch("length", &flength, "length[nhits]/F");
+  if (!fLightMode) { // skip some track parameters if flag on
+     fOutputTree->Branch("run", &fRunNumber, "run/I");
+     fOutputTree->Branch("timestamp", &ftimestamp, "timestamp/i");
+     fOutputTree->Branch("timezero", &ftimezero, "timezero/F");
+     fOutputTree->Branch("vertex", &fVertexZ, "vertex/F");
+     fOutputTree->Branch("nhits", &fnhits, "nhits/I");
+     fOutputTree->Branch("momentum", &fmomentum, "momentum[nhits]/F");
+     fOutputTree->Branch("length", &flength, "length[nhits]/F");
+   }
   fOutputTree->Branch("index", &findex, "index[nhits]/I");
   fOutputTree->Branch("time", &ftime, "time[nhits]/F");
   fOutputTree->Branch("tot", &ftot, "tot[nhits]/F");
   fOutputTree->Branch("texp", &ftexp, "texp[nhits]/F");
-  fOutputTree->Branch("deltax", &fDeltax, "deltax[nhits]/F");
-  fOutputTree->Branch("deltaz", &fDeltaz, "deltaz[nhits]/F");
-
+  if (fSaveCoordinates) { //save pad hit coordinates if flag on
+     fOutputTree->Branch("deltax", &fDeltax, "deltax[nhits]/F");
+     fOutputTree->Branch("deltaz", &fDeltaz, "deltaz[nhits]/F");
+  }
   PostData(1, fOutputTree);
 
 }
@@ -206,21 +209,14 @@ void AliTOFAnalysisTaskCalibTree::UserExec(Option_t *) {
     // add hit to array (if there is room)
     if (fnhits > MAXHITS) continue;
 
-    if (!fLightMode) {  // skip track parameters if flag on
-      fmomentum[fnhits] = momentum;
-      flength[fnhits] = length;
-      ftexp[fnhits] = timei[AliPID::kPion];
-    }
-    
-    if (fSaveCoordinates) { //save pad hit coordinates if flag on
-      fDeltax[fnhits] = deltax;
-      fDeltaz[fnhits] = deltaz;
-    }
-    
-    //  save following always
+    fmomentum[fnhits] = momentum;
+    flength[fnhits] = length;
+    ftexp[fnhits] = timei[AliPID::kPion];
     findex[fnhits] = index;
     ftime[fnhits] = time;
     ftot[fnhits] = tot;
+    fDeltax[fnhits] = deltax;
+    fDeltaz[fnhits] = deltaz;
     
     fnhits++;
 

--- a/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
+++ b/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
@@ -241,7 +241,7 @@ void AliTOFAnalysisTaskCalibTree::UserExec(Option_t *) {
     deltax = track->GetTOFsignalDx();
     deltaz = track->GetTOFsignalDz();
     deltat = (time - timei[AliPID::kPion] - timeZeroTOF);
-    deltaraw = (track->GetTOFSignalRaw() - timei[AliPID::kPion] - timeZeroTOF);
+    deltaraw = (track->GetTOFsignalRaw() - timei[AliPID::kPion] - timeZeroTOF);
     // add hit to array (if there is room)
     if (fnhits > fMaxHits) continue;
     fmomentum[fnhits] = momentum;

--- a/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
+++ b/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
@@ -53,15 +53,30 @@ AliAnalysisTaskSE(name),
   fVertexZ(99999),
   ftimezero(9999999),
   fnhits(-1),
+  fmomentum(0),
+  flength(0),
+  findex(0),
+  ftime(0),
+  ftot(0),
+  ftexp(0),
+  fDeltax(0),
+  fDeltaz(0),
   fLightMode(kFALSE),
   fSaveCoordinates(kFALSE),
-  fOutputTree(0x0)             
+  fOutputTree(0x0)
 
 {
   /* 
    * default constructor 
    */
-
+  fmomentum = new Float_t[MAXHITS];
+  flength = new Float_t[MAXHITS];
+  findex = new Int_t[MAXHITS];
+  ftime = new Float_t[MAXHITS];
+  ftot = new Float_t[MAXHITS];
+  ftexp = new Float_t[MAXHITS];
+  fDeltax = new Float_t[MAXHITS];
+  fDeltaz = new Float_t[MAXHITS];
   for (Int_t i = 0; i < MAXHITS; i++){
       fmomentum[i] = 999999;
       flength[i] = 999999;
@@ -128,10 +143,10 @@ AliTOFAnalysisTaskCalibTree::UserCreateOutputObjects()
      fOutputTree->Branch("timestamp", &ftimestamp, "timestamp/i");
      fOutputTree->Branch("timezero", &ftimezero, "timezero/F");
      fOutputTree->Branch("vertex", &fVertexZ, "vertex/F");
-     fOutputTree->Branch("nhits", &fnhits, "nhits/I");
      fOutputTree->Branch("momentum", &fmomentum, "momentum[nhits]/F");
      fOutputTree->Branch("length", &flength, "length[nhits]/F");
    }
+  fOutputTree->Branch("nhits", &fnhits, "nhits/I");
   fOutputTree->Branch("index", &findex, "index[nhits]/I");
   fOutputTree->Branch("time", &ftime, "time[nhits]/F");
   fOutputTree->Branch("tot", &ftot, "tot[nhits]/F");

--- a/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.h
+++ b/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.h
@@ -91,52 +91,53 @@ public AliAnalysisTaskSE
 
   // ESD related stuff
   Int_t fRunNumber;                   // run number
-  AliESDEvent *fESDEvent;             // ESD event
-  AliPhysicsSelection *fEventCuts;    // event cuts
-  AliESDtrackCuts *fTrackCuts;        // track cuts
-  AliESDpid *fESDpid;                 // ESD PID
+  AliESDEvent *fESDEvent;             //!<! ESD event
+  AliPhysicsSelection *fEventCuts;    //!<! event cuts
+  AliESDtrackCuts *fTrackCuts;        //!<! track cuts
+  AliESDpid *fESDpid;                 //!<! ESD PID
   UInt_t fStartTime;                  // start time
   UInt_t fEndTime;                    // end time
   UInt_t fElapsedTime;                // event time since start
   Bool_t fIsCollisionCandidate;       // is collision candidate
   Bool_t fHasVertex;                  // has vertex
-  const AliESDVertex *fVertex;        // vertex
+  const AliESDVertex *fVertex;        //!<! vertex
 
   // GRP related stuff
-  AliGRPManager *fGRPManager;         // GRP manager
-  const AliGRPObject *fGRPObject;     // GRP object
+  AliGRPManager *fGRPManager;         //!<! GRP manager
+  const AliGRPObject *fGRPObject;     //!<! GRP object
 
   // TOF related stuff
   TString fSpecificStorageParOffline; // specific storage ParOffline
   TString fSpecificStorageRunParams;  // specific storage RunParams
   Float_t fTimeResolution;            // time resolution
-  AliTOFcalib *fTOFcalib;             // TOF calib
-  AliTOFT0maker *fTOFT0maker;         // TOF-T0 maker
-  AliTOFT0v1 *fTOFT0v1;               // TOF-T0 v1
+  AliTOFcalib *fTOFcalib;             //!<! TOF calib
+  AliTOFT0maker *fTOFT0maker;         //!<! TOF-T0 maker
+  AliTOFT0v1 *fTOFT0v1;               //!<! TOF-T0 v1
 
   // task related stuff
   UInt_t ftimestamp;
   Float_t fVertexZ;
   Float_t ftimezero;
   Int_t fnhits;
-  Float_t fmomentum[MAXHITS];
-  Float_t flength[MAXHITS];
-  Int_t findex[MAXHITS];
-  Float_t ftime[MAXHITS];
-  Float_t ftot[MAXHITS];
-  Float_t ftexp[MAXHITS];
+  Float_t* fmomentum;       //[MAXHITS] momentum
+  Float_t* flength;         //[MAXHITS] length
+  Int_t* findex;            //[MAXHITS] index
+  Float_t* ftime;           //[MAXHITS] time
+  Float_t* ftot;            //[MAXHITS] time over threshold
+  Float_t* ftexp;           //[MAXHITS] texp
+
   
   //NEW task related stuff
-  Float_t fDeltax[MAXHITS];
-  Float_t fDeltaz[MAXHITS];
+  Float_t* fDeltax; //[MAXHITS]  delta-x
+  Float_t* fDeltaz; //[MAXHITS]  delta-z
 
   Bool_t fLightMode;
   Bool_t fSaveCoordinates;
    
  
-  TTree* fOutputTree;                 // output tree
+  TTree* fOutputTree;                 //!<! output tree
 
-  ClassDef(AliTOFAnalysisTaskCalibTree, 2);
+  ClassDef(AliTOFAnalysisTaskCalibTree, 3);
 };
 
 #endif /* ALIANALYSISTASKTOFCOMPACTCALIB_H */

--- a/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.h
+++ b/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.h
@@ -125,9 +125,6 @@ public AliAnalysisTaskSE
   Float_t* ftime;           //[MAXHITS] time
   Float_t* ftot;            //[MAXHITS] time over threshold
   Float_t* ftexp;           //[MAXHITS] texp
-
-  
-  //NEW task related stuff
   Float_t* fDeltax; //[MAXHITS]  delta-x
   Float_t* fDeltaz; //[MAXHITS]  delta-z
 

--- a/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.h
+++ b/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.h
@@ -130,8 +130,7 @@ public AliAnalysisTaskSE
 
   Bool_t fLightMode;
   Bool_t fSaveCoordinates;
-   
- 
+
   TTree* fOutputTree;                 //!<! output tree
 
   ClassDef(AliTOFAnalysisTaskCalibTree, 3);

--- a/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.h
+++ b/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.h
@@ -128,7 +128,8 @@ public AliAnalysisTaskSE
   Float_t* ftexp;           //[fMaxHits] texp
   Float_t* fDeltax;         //[fMaxHits]  delta-x
   Float_t* fDeltaz;         //[fMaxHits]  delta-z
-
+  Float_t* fDeltat;         //[fMaxHits] delta-t
+  Float_t* fDeltaraw;       //[fMaxHits] delta-raw
   Bool_t fLightMode;
   Bool_t fSaveCoordinates;
 

--- a/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.h
+++ b/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.h
@@ -61,7 +61,6 @@ public AliAnalysisTaskSE
   void SetSpecificStorageParOffline(Char_t *value) {fSpecificStorageParOffline = value;}; // set specific storage ParOffline
   void SetSpecificStorageRunParams(Char_t *value) {fSpecificStorageRunParams = value;}; // set specific storage RunParams
   void SetSaveCoordinates(Bool_t value = kTRUE) {fSaveCoordinates = value;}; // set flag to save hit coordinates in tree
-  void SetLightMode(Bool_t value = kTRUE) {fLightMode = value;}; // set flag to use "light mode" (don't save track parameters)
 
  protected:
 
@@ -130,7 +129,6 @@ public AliAnalysisTaskSE
   Float_t* fDeltaz;         //[fMaxHits]  delta-z
   Float_t* fDeltat;         //[fMaxHits] delta-t
   Float_t* fDeltaraw;       //[fMaxHits] delta-raw
-  Bool_t fLightMode;
   Bool_t fSaveCoordinates;
 
   TTree* fOutputTree;                 //!<! output tree

--- a/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.h
+++ b/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.h
@@ -60,6 +60,8 @@ public AliAnalysisTaskSE
   void SetUseLHCClockPhase(Bool_t value = kTRUE) {fUseLHCClockPhase = value;}; // setter
   void SetSpecificStorageParOffline(Char_t *value) {fSpecificStorageParOffline = value;}; // set specific storage ParOffline
   void SetSpecificStorageRunParams(Char_t *value) {fSpecificStorageRunParams = value;}; // set specific storage RunParams
+  void SetSaveCoordinates(Bool_t value = kTRUE) {fSaveCoordinates = value;}; // set flag to save hit coordinates in tree
+  void SetLightMode(Bool_t value = kTRUE) {fLightMode = value;}; // set flag to use "light mode" (don't save track parameters)
 
  protected:
 
@@ -123,7 +125,15 @@ public AliAnalysisTaskSE
   Float_t ftime[MAXHITS];
   Float_t ftot[MAXHITS];
   Float_t ftexp[MAXHITS];
+  
+  //NEW task related stuff
+  Float_t fDeltax[MAXHITS];
+  Float_t fDeltaz[MAXHITS];
 
+  Bool_t fLightMode;
+  Bool_t fSaveCoordinates;
+   
+ 
   TTree* fOutputTree;                 // output tree
 
   ClassDef(AliTOFAnalysisTaskCalibTree, 2);

--- a/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.h
+++ b/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.h
@@ -24,7 +24,7 @@ class AliGRPObject;
 
 class TH2F;
 
-#define MAXHITS 100000
+#define MAXHITS ((Int_t)100000)
 
 class AliTOFAnalysisTaskCalibTree :
 public AliAnalysisTaskSE
@@ -115,18 +115,19 @@ public AliAnalysisTaskSE
   AliTOFT0v1 *fTOFT0v1;               //!<! TOF-T0 v1
 
   // task related stuff
+  Int_t fMaxHits;       //array parameter
   UInt_t ftimestamp;
   Float_t fVertexZ;
   Float_t ftimezero;
   Int_t fnhits;
-  Float_t* fmomentum;       //[MAXHITS] momentum
-  Float_t* flength;         //[MAXHITS] length
-  Int_t* findex;            //[MAXHITS] index
-  Float_t* ftime;           //[MAXHITS] time
-  Float_t* ftot;            //[MAXHITS] time over threshold
-  Float_t* ftexp;           //[MAXHITS] texp
-  Float_t* fDeltax; //[MAXHITS]  delta-x
-  Float_t* fDeltaz; //[MAXHITS]  delta-z
+  Float_t* fmomentum;       //[fMaxHits] momentum
+  Float_t* flength;         //[fMaxHits] length
+  Int_t* findex;            //[fMaxHits] index
+  Float_t* ftime;           //[fMaxHits] time
+  Float_t* ftot;            //[fMaxHits] time over threshold
+  Float_t* ftexp;           //[fMaxHits] texp
+  Float_t* fDeltax;         //[fMaxHits]  delta-x
+  Float_t* fDeltaz;         //[fMaxHits]  delta-z
 
   Bool_t fLightMode;
   Bool_t fSaveCoordinates;


### PR DESCRIPTION
Adds option to save the delta-X and delta-Z coordinates in a lighter version of the output tree (in discussion with @preghenella), for studies to check calibration as function of position of hit in the pad. Also fixes handling of streamed pointers/arrays in header/destructor, which will potentially help protect against possible memory leaks.
Mode to save coordinates (and therefore tree with some removed branches for optimisation) is handled by an added flag in the AddTask macro; default behaviour is unaffected.