### PR TITLE
Increased PID array size for 6 particle (3PiPi) channel

### DIFF
--- a/PWGUD/UPC/AliAnalysisTaskUpcEtaC.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUpcEtaC.cxx
@@ -156,7 +156,7 @@ void AliAnalysisTaskUpcEtaC::Init()
   	fTrigger[i] = kFALSE;
 	fTriggerInputsMC[i] = kFALSE;
 	}
-  for(Int_t i=0; i<4; i++) {
+  for(Int_t i=0; i<7; i++) {
 	fPIDTPCMuon[i] = -666;
 	fPIDTPCElectron[i] = -666;
 	fPIDTPCPion[i] = -666;
@@ -171,7 +171,7 @@ void AliAnalysisTaskUpcEtaC::Init()
 	
 	fIsVtxContributor[i] = kFALSE;
 	}
-  for(Int_t i=0; i<4; i++) {
+  for(Int_t i=0; i<7; i++) {
 	fPIDTPCMuonPos[i] = -666;
 	fPIDTPCElectronPos[i] = -666;
 	fPIDTPCPionPos[i] = -666;

--- a/PWGUD/UPC/AliAnalysisTaskUpcEtaC.h
+++ b/PWGUD/UPC/AliAnalysisTaskUpcEtaC.h
@@ -72,42 +72,42 @@ class AliAnalysisTaskUpcEtaC : public AliAnalysisTaskSE {
   Bool_t fIsPhysicsSelected;
 
   //PID for EtC->Pi+Pi-K+K- Channel  
-  Double_t fPIDTPCMuon[4];
-  Double_t fPIDTPCElectron[4];
-  Double_t fPIDTPCPion[4];
-  Double_t fPIDTPCKaon[4];
-  Double_t fPIDTPCProton[4];
+  Double_t fPIDTPCMuon[7];
+  Double_t fPIDTPCElectron[7];
+  Double_t fPIDTPCPion[7];
+  Double_t fPIDTPCKaon[7];
+  Double_t fPIDTPCProton[7];
   
-  Double_t fPIDTOFMuon[4];
-  Double_t fPIDTOFElectron[4];
-  Double_t fPIDTOFPion[4];
-  Double_t fPIDTOFKaon[4];
-  Double_t fPIDTOFProton[4];
+  Double_t fPIDTOFMuon[7];
+  Double_t fPIDTOFElectron[7];
+  Double_t fPIDTOFPion[7];
+  Double_t fPIDTOFKaon[7];
+  Double_t fPIDTOFProton[7];
 
   //PID for EtC->K0s K+- Pi-+ Channel
-  Double_t fPIDTPCMuonPos[4];
-  Double_t fPIDTPCElectronPos[4];
-  Double_t fPIDTPCPionPos[4];
-  Double_t fPIDTPCKaonPos[4];
-  Double_t fPIDTPCProtonPos[4];
+  Double_t fPIDTPCMuonPos[7];
+  Double_t fPIDTPCElectronPos[7];
+  Double_t fPIDTPCPionPos[7];
+  Double_t fPIDTPCKaonPos[7];
+  Double_t fPIDTPCProtonPos[7];
   
-  Double_t fPIDTOFMuonPos[4];
-  Double_t fPIDTOFElectronPos[4];
-  Double_t fPIDTOFPionPos[4];
-  Double_t fPIDTOFKaonPos[4];
-  Double_t fPIDTOFProtonPos[4];
+  Double_t fPIDTOFMuonPos[7];
+  Double_t fPIDTOFElectronPos[7];
+  Double_t fPIDTOFPionPos[7];
+  Double_t fPIDTOFKaonPos[7];
+  Double_t fPIDTOFProtonPos[7];
  
-  Double_t fPIDTPCMuonNeg[4];
-  Double_t fPIDTPCElectronNeg[4];
-  Double_t fPIDTPCPionNeg[4];
-  Double_t fPIDTPCKaonNeg[4];
-  Double_t fPIDTPCProtonNeg[4];
+  Double_t fPIDTPCMuonNeg[7];
+  Double_t fPIDTPCElectronNeg[7];
+  Double_t fPIDTPCPionNeg[7];
+  Double_t fPIDTPCKaonNeg[7];
+  Double_t fPIDTPCProtonNeg[7];
   
-  Double_t fPIDTOFMuonNeg[4];
-  Double_t fPIDTOFElectronNeg[4];
-  Double_t fPIDTOFPionNeg[4];
-  Double_t fPIDTOFKaonNeg[4];
-  Double_t fPIDTOFProtonNeg[4];
+  Double_t fPIDTOFMuonNeg[7];
+  Double_t fPIDTOFElectronNeg[7];
+  Double_t fPIDTOFPionNeg[7];
+  Double_t fPIDTOFKaonNeg[7];
+  Double_t fPIDTOFProtonNeg[7];
   
   Int_t fVtxContrib;
   Double_t fVtxPos[3];


### PR DESCRIPTION
Increased the PID array sizes (fPIDTPCMuon[i], etc.) from i=4 to i=7 to make sure it can safely handle the 6 particle 3(Pi+Pi-) channel without a seg fault.