### PR TITLE
ensure clusterizer only calibrates EMCal clusters

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.cxx
@@ -625,8 +625,12 @@ void AliEmcalCorrectionClusterizer::CalibrateClusters()
   Int_t nclusters = fCaloClusters->GetEntriesFast();
   for (Int_t icluster=0; icluster < nclusters; ++icluster) {
     AliVCluster *clust = static_cast<AliVCluster*>(fCaloClusters->At(icluster));
-    if (!clust)
+    if (!clust) {
       continue;
+    }
+    if (!clust->IsEMCAL()) {
+      continue;
+    }
     
     // SHOWER SHAPE -----------------------------------------------
     if (fRecalShowerShape)


### PR DESCRIPTION
In the clusterizer, recalculations for shower shape and distance to bad channels currently loops through all caloClusters, not just EMCal clusters. For some users this causes a crash. For those users for which the code does not crash, the corrections for EMCal clusters work as expected (but PHOS clusters could be affected). This commit ensures that these calibrations are only performed on EMCal clusters.

@raymondEhlers @efranzis
 