### PR TITLE
PWGGA/GammaConv: Added more pT cut variations and trainconfigs for PCM 7 and 8 TeV

### DIFF
--- a/PWGGA/GammaConv/AliConversionPhotonCuts.cxx
+++ b/PWGGA/GammaConv/AliConversionPhotonCuts.cxx
@@ -2263,28 +2263,43 @@ Bool_t AliConversionPhotonCuts::SetSinglePtCut(Int_t singlePtCut){   // Set Cut
     fSinglePtCut = 0.050;
     fPtCut       = 0.100;
     break;
-  case 10:  // 0.050 GeV + min gamma pT cut of 150 MeV
+  case 10:  //a: 0.050 GeV + min gamma pT cut of 150 MeV
     fSinglePtCut = 0.050;
     fPtCut       = 0.150;
     break;
-  case 11:  // 0.050 GeV + min gamma pT cut of 200 MeV
+  case 11:  //b: 0.050 GeV + min gamma pT cut of 200 MeV
     fSinglePtCut = 0.050;
     fPtCut       = 0.200;
     break;
-  case 12:  // 0.060 GeV
+  case 12:  //c: 0.060 GeV
     fSinglePtCut = 0.060;
     break;
-  case 13:  // 0.060 GeV + min gamma pT cut of 100 MeV
+  case 13:  //d: 0.060 GeV + min gamma pT cut of 100 MeV
     fSinglePtCut = 0.060;
     fPtCut       = 0.100;
     break;
-  case 14:  // 0.060 GeV + min gamma pT cut of 150 MeV
+  case 14:  //e: 0.060 GeV + min gamma pT cut of 150 MeV
     fSinglePtCut = 0.060;
     fPtCut       = 0.150;
     break;
-  case 15:  // 0.060 GeV + min gamma pT cut of 200 MeV
+  case 15:  //f: 0.060 GeV + min gamma pT cut of 200 MeV
     fSinglePtCut = 0.060;
     fPtCut       = 0.200;
+    break;
+  case 16:  //g: 0.075 GeV + min gamma pT cut of 150 MeV
+    fSinglePtCut = 0.075;
+    fPtCut       = 0.150;
+    break;
+  case 17:  //h: 0.100 GeV + min gamma pT cut of 200 MeV
+    fSinglePtCut = 0.100;
+    fPtCut       = 0.200;
+    break;
+  case 18:  //i: 0.150 GeV + min gamma pT cut of 300 MeV
+    fSinglePtCut = 0.150;
+    fPtCut       = 0.300;
+    break;
+  case 19:  //j: 0.150 GeV
+    fSinglePtCut = 0.150;
     break;
   default:
     AliError(Form("singlePtCut not defined %d",singlePtCut));

--- a/PWGGA/GammaConv/AliConversionPhotonCuts.h
+++ b/PWGGA/GammaConv/AliConversionPhotonCuts.h
@@ -233,6 +233,8 @@ class AliConversionPhotonCuts : public AliAnalysisCuts {
     Bool_t            fDoShrinkTPCAcceptance;               // Flag for shrinking the TPC acceptance due to different reasons
     Double_t          fPtCut;                               // pt cut
     Double_t          fSinglePtCut;                         // pt cut for electron/positron
+    Double_t          fSinglePtCut2;                        // second pt cut for electron/positron if asymmetric cut is chosen
+    Bool_t            fDoAsymPtCut;                         // Flag for setting asymmetric pT cut on electron/positron
     Double_t          fMaxZ;                                // z cut
     Double_t          fMinClsTPC;                           // minimum clusters in the TPC
     Double_t          fMinClsTPCToF;                        // minimum clusters to findable clusters
@@ -346,7 +348,7 @@ class AliConversionPhotonCuts : public AliAnalysisCuts {
 
   private:
   
-    ClassDef(AliConversionPhotonCuts,14)
+    ClassDef(AliConversionPhotonCuts,15)
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pp.C
@@ -681,6 +681,16 @@ void AddTask_GammaConvV1_pp(  Int_t   trainConfig                     = 1,      
     cuts.AddCut("00000113", "002000d9227300008250404000", "0152103500000000"); // gamma pT > 0.1 GeV/c
     cuts.AddCut("00000113", "002000e9227300008250404000", "0152103500000000"); // gamma pT > 0.15 GeV/c
     cuts.AddCut("00000113", "002000f9227300008250404000", "0152103500000000"); // gamma pT > 0.2 GeV/c
+  } else if (trainConfig == 136) { // 8 TeV
+    cuts.AddCut("00010113", "002000g9227300008250404000", "0152103500000000"); // 0.075 GeV + min gamma pT cut of 150 MeV
+    cuts.AddCut("00010113", "002000h9227300008250404000", "0152103500000000"); // 0.100 GeV + min gamma pT cut of 200 MeV
+    cuts.AddCut("00010113", "002000i9227300008250404000", "0152103500000000"); // 0.150 GeV + min gamma pT cut of 300 MeV
+    cuts.AddCut("00010113", "002000j9227300008250404000", "0152103500000000"); // 0.150 GeV
+  } else if (trainConfig == 137) { // 7 TeV
+    cuts.AddCut("00000113", "002000g9227300008250404000", "0152103500000000"); // 0.075 GeV + min gamma pT cut of 150 MeV
+    cuts.AddCut("00000113", "002000h9227300008250404000", "0152103500000000"); // 0.100 GeV + min gamma pT cut of 200 MeV
+    cuts.AddCut("00000113", "002000i9227300008250404000", "0152103500000000"); // 0.150 GeV + min gamma pT cut of 300 MeV
+    cuts.AddCut("00000113", "002000j9227300008250404000", "0152103500000000"); // 0.150 GeV
 
     // -------- Material weights -several configs with same sets for running with various mat weights ----------
   } else if (trainConfig == 160) { // like last last two in 70 and dalitz standard 7TeV

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pp2.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pp2.C
@@ -220,9 +220,9 @@ void AddTask_GammaConvV1_pp2(   Int_t    trainConfig                 = 1,       
   } else if (trainConfig == 26) {
     cuts.AddCut("00010613", "00200009227300008250404000", "0152103500000000"); //V0M vs TPCout cut6
   } else if (trainConfig == 27) {
-    cuts.AddCut("00010113", "002000g9227300008250404000", "0152103500000000"); //0.075 GeV + min gamma pT cut of 150 MeV
+    cuts.AddCut("00010113", "002000j9227300008250404000", "0152103500000000"); //asym pT cut: 0.100 GeV and 0.075 GeV
   } else if (trainConfig == 28) {
-    cuts.AddCut("00010113", "002000i9227300008250404000", "0152103500000000"); //0.150 GeV + min gamma pT cut of 300 MeV
+    cuts.AddCut("00010113", "002000l9227300008250404000", "0152103500000000"); //asym pT cut: 0.200 GeV and 0.075 GeV
   } else if (trainConfig == 29) {
     cuts.AddCut("00010113", "002000f9227300008250404000", "0152103500000000"); //gamma pT > 0.2 GeV/c
   //----------------------------- configuration for  7 TeV standard cuts -----------------------------------------------------

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pp2.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pp2.C
@@ -218,13 +218,13 @@ void AddTask_GammaConvV1_pp2(   Int_t    trainConfig                 = 1,       
   } else if (trainConfig == 25) {
     cuts.AddCut("00010113", "0a200009227300008250404000", "0152103500000000"); //eta cut 0.2 < |eta| < 0.9
   } else if (trainConfig == 26) {
-    cuts.AddCut("00010113", "002000c9227300008250404000", "0152103500000000"); // 8 TeV std, but min electron pT > 0.6 for all configs
+    cuts.AddCut("00010613", "00200009227300008250404000", "0152103500000000"); //V0M vs TPCout cut6
   } else if (trainConfig == 27) {
-    cuts.AddCut("00010113", "002000b9227300008250404000", "0152103500000000"); // gamma pT > 0.1 GeV/c
+    cuts.AddCut("00010113", "002000g9227300008250404000", "0152103500000000"); //0.075 GeV + min gamma pT cut of 150 MeV
   } else if (trainConfig == 28) {
-    cuts.AddCut("00010113", "002000e9227300008250404000", "0152103500000000"); // gamma pT > 0.15 GeV/c
+    cuts.AddCut("00010113", "002000i9227300008250404000", "0152103500000000"); //0.150 GeV + min gamma pT cut of 300 MeV
   } else if (trainConfig == 29) {
-    cuts.AddCut("00010113", "002000f9227300008250404000", "0152103500000000"); // gamma pT > 0.2 GeV/c
+    cuts.AddCut("00010113", "002000f9227300008250404000", "0152103500000000"); //gamma pT > 0.2 GeV/c
   //----------------------------- configuration for  7 TeV standard cuts -----------------------------------------------------
   } else if (trainConfig == 30) {
     cuts.AddCut("00000113", "00200009227300008250404000", "0152103500000000"); //New standard cut pp 7 TeV direct photon


### PR DESCRIPTION
This pull request adds several new pT cut variations on the electron and photon level in AliConversionPhotonCuts.cxx.
For running and testing of these variations, several trainconfigs have been added.