### PR TITLE
PWGDQ safety check for HF-Framework and MC analysis

### DIFF
--- a/PWGDQ/dielectron/core/AliDielectronHF.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronHF.cxx
@@ -554,7 +554,12 @@ void AliDielectronHF::Init()
 
   // has MC signals
   fHasMC=AliDielectronMC::Instance()->HasMC();
+
   Int_t steps = 0;
+  if(!fSignalsMC && fHasMC){
+    AliFatal("Running on MC data but AliDielectronHF::fSignalsMC is a Nullptr - Exiting AliDielectronHF::Init() now!");
+    return;
+  }
   if(fHasMC) steps=fSignalsMC->GetEntries();
   if(fStepGenerated) steps*=2;
   if(fEventArray) steps=1;
@@ -666,7 +671,6 @@ void AliDielectronHF::Init()
     delete histArr;
     histArr=0;
   }
-
 }
 
 //______________________________________________

--- a/PWGDQ/dielectron/macrosJPSI/AddTask_pdill_JPsi.C
+++ b/PWGDQ/dielectron/macrosJPSI/AddTask_pdill_JPsi.C
@@ -15,11 +15,14 @@ AliAnalysisTask *AddTask_pdill_JPsi(TString config="1",
   printf("------------------------------------------------\n");
 
   //Do we have an MC handler?
-  TString list = gSystem->Getenv("LIST");
+  TString list = gSystem->Getenv("REFERENCE_PRODUCTION");
   if(!list.IsNull()) {
-    if( list.Contains("LHC10c")   || list.Contains("LHC11h")   ) hasMC=kFALSE;  // add periods
-    if( list.Contains("LHC11a10") || list.Contains("LHC12a17") ) hasMC=kTRUE;   // to be dapated
+    if( list.Contains("LHC16g1") || list.Contains("LHC16j1") || list.Contains("LHC16f5") ) hasMC=kTRUE;
   }
+	TString runNumString = gSystem->Getenv("RUNNO");
+	Int_t runnumber = runNumString.Atoi();
+
+	printf("HalloWelt REF_PROD: %s Run: %d %d\n", list.Data(), runnumber, __LINE__);
 
   //Do we have an AOD handler?
   Bool_t isAOD=(mgr->GetInputEventHandler()->IsA()==AliAODInputHandler::Class() ? kTRUE : kFALSE);
@@ -100,7 +103,7 @@ AliAnalysisTask *AddTask_pdill_JPsi(TString config="1",
       printf("================================================\n Skip config %02d\n",i); continue; }
 
     // load configuration
-    AliDielectron *jpsi=ConfigJpsi_pd_pp(i,hasMC,period);
+    AliDielectron *jpsi=ConfigJpsi_pd_pp(i,hasMC,runnumber,period);
     if(!jpsi) continue;
 
     // create unique title


### PR DESCRIPTION
If one runs on MC but did not add DielectronMCsignals the AliDielectronHF::Init() ended in a seg fault. Now an AliFatal is called giving a useful message where the error comes from.