### PR TITLE
PWGGA/GammaConv: Add task for K0 to two Pi0s.

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaPureMC.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaPureMC.cxx
@@ -808,7 +808,7 @@ void AliAnalysisTaskGammaPureMC::ProcessMCParticles()
         }
       }
 
-      if(allOK[1] && allOK[2]){
+      if(allOK[0] && allOK[1]){
             fHistPtYPi0FromKGG->Fill(particle->Pt(), particle->Y());
       }
 

--- a/PWGGA/GammaConv/AliAnalysisTaskK0toPi0Pi0.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskK0toPi0Pi0.cxx
@@ -1,0 +1,442 @@
+/**************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                   *
+ * All rights reserved.                                                               *
+ *                                                                                    *
+ * Redistribution and use in source and binary forms, with or without                 *
+ * modification, are permitted provided that the following conditions are met:        *
+ *     * Redistributions of source code must retain the above copyright               *
+ *       notice, this list of conditions and the following disclaimer.                *
+ *     * Redistributions in binary form must reproduce the above copyright            *
+ *       notice, this list of conditions and the following disclaimer in the          *
+ *       documentation and/or other materials provided with the distribution.         *
+ *     * Neither the name of the <organization> nor the                               *
+ *       names of its contributors may be used to endorse or promote products         *
+ *       derived from this software without specific prior written permission.        *
+ *                                                                                    *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND    *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED      *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE             *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY                *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES         *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;       *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND        *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT         *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS      *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                       *
+ **************************************************************************************/
+#include <array>
+
+#include <THistManager.h>
+#include <TLinearBinning.h>
+#include <TList.h>
+#include "AliAnalysisTaskK0toPi0Pi0.h"
+#include "AliAODConversionMother.h"
+#include "AliAODConversionPhoton.h"
+#include "AliCaloPhotonCuts.h"
+#include "AliClusterContainer.h"
+#include "AliConversionPhotonCuts.h"
+#include "AliConversionMesonCuts.h"
+#include "AliConvEventCuts.h"
+#include "AliLog.h"
+#include "AliVCluster.h"
+#include "AliV0ReaderV1.h"
+
+/// \cond CLASSIMP
+ClassImp(AliAnalysisTaskK0toPi0Pi0)
+/// \endcond
+
+AliAnalysisTaskK0toPi0Pi0::AliAnalysisTaskK0toPi0Pi0():
+  AliAnalysisTaskSE(),
+  fLocalInitialized(kFALSE),
+  fCurrentRun(-1),
+  fNewFile(kFALSE),
+  fV0Reader(nullptr),
+  fV0ReaderName("V0ReaderV1"),
+  fClusterContainer(nullptr),
+  fIsMC(false),
+  fWeightJetJetMC(1.),
+  fEventPlaneAngle(0.),
+  fEventCuts(nullptr),
+  fConvPhotonCuts(nullptr),
+  fCaloPhotonCuts(nullptr),
+  fPi0Cuts(nullptr),
+  fPi0CutsCaloCalo(nullptr),
+  fK0Cuts(nullptr),
+  fHistos(nullptr),
+  fOutput(nullptr)
+{
+
+}
+
+AliAnalysisTaskK0toPi0Pi0::AliAnalysisTaskK0toPi0Pi0(const char *name):
+  AliAnalysisTaskSE(name),
+  fLocalInitialized(kFALSE),
+  fCurrentRun(-1),
+  fNewFile(kFALSE),
+  fV0Reader(nullptr),
+  fV0ReaderName("V0ReaderV1"),
+  fClusterContainer(nullptr),
+  fIsMC(false),
+  fWeightJetJetMC(1.),
+  fEventPlaneAngle(0),
+  fEventCuts(nullptr),
+  fConvPhotonCuts(nullptr),
+  fCaloPhotonCuts(nullptr),
+  fPi0Cuts(nullptr),
+  fPi0CutsCaloCalo(nullptr),
+  fK0Cuts(nullptr),
+  fHistos(nullptr),
+  fOutput(nullptr)
+{
+  DefineOutput(1, TList::Class());
+}
+
+
+
+AliAnalysisTaskK0toPi0Pi0::~AliAnalysisTaskK0toPi0Pi0() {
+  if(fHistos) delete fHistos;
+}
+
+void AliAnalysisTaskK0toPi0Pi0::UserCreateOutputObjects(){
+
+   // Create output 
+  if(fOutput != NULL){
+    delete fOutput;
+    fOutput        = NULL;
+  }
+  if(fOutput == NULL){
+    fOutput        = new TList();
+    fOutput->SetOwner(kTRUE);
+  }
+  
+  // Connecting input V0 reader
+  fV0Reader=dynamic_cast<AliV0ReaderV1*>(AliAnalysisManager::GetAnalysisManager()->GetTask(fV0ReaderName.Data()));
+  if(!fV0Reader){
+    AliFatal("Error: No V0 Reader");
+  }// GetV0Reader
+
+  fEventCuts = fV0Reader->GetEventCuts();
+
+  
+  
+  // Define histograms
+  fHistos = new THistManager("K0stoPi0Pi0");
+  
+  AliDebug(2, "************* Defining Event Counter Histograms ********************");
+  
+  
+  // Event counter histograms
+  fHistos->CreateTH1("hEventQualityBefore", "Event Quality (0 = good)", 13, -0.5, 12.5);
+  fHistos->CreateTH1("hEventQualityAfter", "Event Quality (0 = good)", 13, -0.5, 12.5);
+  fHistos->CreateTH1("hVertexZ", "z-component of the primary vertex; z (cm); Number of events", 1000, -40., 40.);
+  fHistos->CreateTH1("hCaloPhotonsBefore", "Number of Events", 13, -0.5, 12.5);
+  fHistos->CreateTH1("hCaloPhotonsAfter", "Number of Events", 13, -0.5, 12.5);
+  fHistos->CreateTH1("hConvPhotonsBefore", "Number of Events", 13, -0.5, 12.5);
+  fHistos->CreateTH1("hConvPhotonsAfter", "Number of Events", 13, -0.5, 12.5);
+  
+  AliDebug(2, "************* Defining Photon QA Histograms ********************");
+  
+  // Photon QA
+  fHistos->CreateTH1("hCaloPhotonPt", "p_{t}-distribution of the conversion photons; p_{t} (GeV); Yield", 300, 0., 30.);
+  fHistos->CreateTH1("hConvPhotonPt", "p_{t}-distribution of the conversion photons; p_{t} (GeV); Yield", 300, 0., 30.);
+  fHistos->CreateTH2("hConvPhotonEtaR", "#eta vs conversion radius of conversion photons; #eta; R (cm)", 200, -1.5, 1.5, 300, 0., 300);
+
+  AliDebug(2, "************* Defining Pi0 Histograms ********************");
+  
+  // Pi0 invariant mass, alpha and opening angle distributions
+  const std::array<TString, 3> pi0rec = {"ConvConv", "ConvCalo", "CaloCalo"}; // aka PCM, EMCAL, PCM-EMCAL
+  for(const auto &reccase : pi0rec){
+    // for candidates in a wide mass region
+    fHistos->CreateTH2("hMassvsPtPi0" + reccase + "All", "inv. mass vs. p_{t} for all #pi^{0} (" + reccase + ") candidates; inv. mass (GeV/c^{2}); p_{t} (GeV/c)", 500, 0., 0.5, 300, 0.3, 30.);
+    // only for candidates in the pi0 mass region
+    fHistos->CreateTH2("hMassvsPtPi0" + reccase + "Sel", "inv. mass vs. p_{t} for selected #pi^{0} (" + reccase + ") candidates; inv. mass (GeV/c^{2}); p_{t} (GeV/c)", 500, 0., 0.5, 300, 0.3, 30.);
+    fHistos->CreateTH2("hAlphavsPtPi0" + reccase, "#alpha vs p_{t} for selected #p^i{0} (" + reccase + ") candidates; #alpha; p_{t}", 200, -1., 1., 300, 0., 30.);
+    fHistos->CreateTH2("hOpeningAnglevsPtPi0" + reccase, "Opening angle vs. p_{t} for selected #pi^{0} (" + reccase + ") candidates; opening angle; p_{t} (GeV/c)", 100, 0., 1., 300., 0.3, 30.);
+  }
+
+  AliDebug(2, "************* Defining K0 Histograms ********************");
+  
+  // K0short invariant mass distribution and opening angle distributions
+  const std::array<TString, 6> k0Shortrec = {"AllConv", "AllCalo", "DiffMixed", "SameMixed", "ConvoCalo","CaloConvo" }; // aka 6 cases 
+  for(const auto &reccase1 : k0Shortrec){
+    fHistos->CreateTH2("hMassvsPtK0Short" + reccase1, "inv. mass vs. p_{t} for #k^{0}s (" + reccase1 + ") candidates; inv. mass (GeV/c^{2}); p_{t} (GeV/c)",  500, 0.3, 0.6, 300, 0.3, 30.); 
+    fHistos->CreateTH2("hOpeningAnglevsPtK0Short"+ reccase1, "Opening angle vs. p_{t} for  k0Short (" + reccase1 + ") candidates; opening angle; p_{t} (GeV/c)",  100, 0., 1., 300., 0.3, 30.); 
+  }
+  
+  for(auto hist : *(fHistos->GetListOfHistograms())) fOutput->Add(hist);
+  fOutput->Add(fV0Reader->GetEventCutHistograms());
+  fOutput->Add(fV0Reader->GetCutHistograms());
+  
+  // Adding cut QA
+  TList *qaV0reader = new TList;
+  qaV0reader->SetName("QA_V0reader");
+  qaV0reader->SetOwner(kTRUE);
+  qaV0reader->Add(fV0Reader->GetEventCutHistograms());
+  qaV0reader->Add(fV0Reader->GetCutHistograms());
+  fOutput->Add(qaV0reader);
+  fOutput->Add(fEventCuts->GetCutHistograms());
+  fOutput->Add(fConvPhotonCuts->GetCutHistograms());
+  fOutput->Add(fCaloPhotonCuts->GetCutHistograms());
+  
+  PostData(1, fOutput);
+  
+}
+
+void AliAnalysisTaskK0toPi0Pi0::ExecOnce() {
+  if(!fClusterContainer) fClusterContainer = new AliClusterContainer(fInputEvent->IsA() == AliESDEvent::Class() ? "CaloClusters" : "caloClusters");
+  fClusterContainer->SetArray(fInputEvent);
+   
+  if(fConvPhotonCuts){
+    fConvPhotonCuts->InitPIDResponse();   
+  }
+   
+}
+
+void AliAnalysisTaskK0toPi0Pi0::UserExec(Option_t *){
+  if(!fLocalInitialized) {
+    ExecOnce();
+    fLocalInitialized = kTRUE;
+  }
+  
+  if(fCurrentRun != fInputEvent->GetRunNumber()) {
+    RunChanged();
+    fCurrentRun = fInputEvent->GetRunNumber();
+  }
+  
+  
+  // do event selection
+  // Use the same event selection as for the v0 reader
+  // Good events defined as events with event quality 0
+  Int_t eventQuality = fEventCuts->GetEventQuality();
+  fHistos->FillTH1("hEventQualityBefore", eventQuality);
+  
+  if(fEventCuts->IsEventAcceptedByCut(fV0Reader->GetEventCuts(), fInputEvent, fMCEvent, false, false)) return;
+  fHistos->FillTH1("hEventQualityAfter", eventQuality);
+  fHistos->FillTH1("hVertexZ", fInputEvent->GetPrimaryVertex()->GetZ());
+
+  
+  // get Photon candidates
+  fHistos->FillTH1("hConvPhotonsBefore",fV0Reader->GetNReconstructedGammas());
+  std::vector<AliAODConversionPhoton> conversionPhotons = MakeConversionPhotonCandidates(*fV0Reader, *fConvPhotonCuts);
+  MakePhotonQAConv(conversionPhotons, *fEventCuts);
+  Int_t numPhotons = conversionPhotons.size();
+  fHistos->FillTH1("hConvPhotonsAfter", numPhotons); 
+  
+  fHistos->FillTH1("hCaloPhotonsBefore",fClusterContainer->GetNEntries());
+  std::vector<AliAODConversionPhoton> caloPhotons = MakeCaloPhotonCandidates(*fClusterContainer, *fCaloPhotonCuts);
+  MakePhotonQACalo(caloPhotons, *fEventCuts);
+  Int_t numCaloPhotons = caloPhotons.size();
+  fHistos->FillTH1("hCaloPhotonsAfter", numCaloPhotons);
+  
+
+  
+  // get Pi0 candidates
+  std::vector<AliAODConversionMother> samePi0PCM = MakePi0Candidates(&conversionPhotons, nullptr, *fPi0Cuts),
+                                      samePi0EMCAL = MakePi0Candidates(&caloPhotons, nullptr, *fPi0CutsCaloCalo),
+                                      mixedPi0 = MakePi0Candidates(&conversionPhotons, &caloPhotons, *fPi0Cuts);
+                                      
+  MakePi0QA(samePi0PCM, "ConvConv");
+  MakePi0QA(samePi0EMCAL, "CaloCalo");
+  MakePi0QA(mixedPi0, "ConvCalo");
+  
+  
+                                      
+  // get K0Short candidates
+  // ------- ADDED----------
+  /*
+  std::vector<AliAODConversionMother> allPCM = MakeK0ShortCandidates(&samePi0PCM, nullptr, *fK0Cuts); 
+  std::vector<AliAODConversionMother> allEMC = MakeK0ShortCandidates(&samePi0EMCAL, nullptr, *fK0Cuts);
+  std::vector<AliAODConversionMother> PCMEMC = MakeK0ShortCandidates(&samePi0PCM, &mixedPi0, *fK0Cuts);
+  std::vector<AliAODConversionMother> EMCPCM = MakeK0ShortCandidates(&samePi0EMCAL, &mixedPi0, *fK0Cuts);
+  std::vector<AliAODConversionMother> mixedSame= MakeK0ShortCandidates(&samePi0EMCAL, &samePi0PCM, *fK0Cuts);
+  std::vector<AliAODConversionMother> mixedDiff = MakeK0ShortCandidates(&mixedPi0, nullptr, *fK0Cuts);
+  
+  
+  MakeK0ShortQA(allPCM, "AllConv");
+  MakeK0ShortQA(allEMC,"AllCalo");
+  MakeK0ShortQA(PCMEMC,"ConvoCalo");
+  MakeK0ShortQA(EMCPCM,"CaloConvo");
+  MakeK0ShortQA(mixedSame, "SameMixed");
+  MakeK0ShortQA(mixedDiff, "DiffMixed");
+  */
+  
+   
+  
+
+}
+
+std::vector<AliAODConversionPhoton> AliAnalysisTaskK0toPi0Pi0::MakeCaloPhotonCandidates(const AliClusterContainer &inputcont, AliCaloPhotonCuts &cuts){
+  std::vector<AliAODConversionPhoton> candidates;
+  cuts.FillHistogramsExtendedQA(fInputEvent, fIsMC);
+
+  // vertex
+  Double_t vertex[3] = {0,0,0};
+  InputEvent()->GetPrimaryVertex()->GetXYZ(vertex);
+
+  int clusterindex = 0;
+  for(auto c : inputcont.all()) {
+    clusterindex++;
+    if(!cuts.ClusterIsSelected(c, fInputEvent, fMCEvent, fIsMC, 1., c->GetID())) continue;   // weight to be added later
+
+    // TLorentzvector with cluster
+    TLorentzVector clusterVector;
+    c->GetMomentum(clusterVector,vertex);
+
+    // convert to AODConversionPhoton
+    AliAODConversionPhoton photonCandidate(&clusterVector);
+
+    // Flag Photon as CaloPhoton
+    photonCandidate.SetIsCaloPhoton();
+    photonCandidate.SetCaloClusterRef(clusterindex);
+
+    // get MC label
+    if(fIsMC>0){
+      photonCandidate.SetNCaloPhotonMCLabels(c->GetNLabels());
+      for (UInt_t k = 0; k < c->GetNLabels(); k++){
+        if(k < 50) photonCandidate.SetCaloPhotonMCLabel(k,c->GetLabels()[k]);
+      }
+    }
+
+    candidates.push_back(photonCandidate);
+  }
+
+  return candidates;
+}
+
+std::vector<AliAODConversionPhoton> AliAnalysisTaskK0toPi0Pi0::MakeConversionPhotonCandidates(const AliV0ReaderV1 &reader, AliConversionPhotonCuts &cuts) {
+  std::vector<AliAODConversionPhoton> candidates;
+  Int_t nV0 = 0;
+  std::vector<AliAODConversionPhoton *> GammaCandidatesStepOne;
+  TList GammaCandidatesStepTwo;
+  
+  // Loop over Photon Candidates allocated by ReaderV1  
+  for(auto photon : reader){
+    if(!cuts.PhotonIsSelected(photon ,fInputEvent)) continue;
+    if(!cuts.InPlaneOutOfPlaneCut(photon->GetPhotonPhi(), fEventPlaneAngle)) continue;
+    if(!cuts.UseElecSharingCut() && !cuts.UseToCloseV0sCut()){
+      candidates.push_back(*(static_cast<AliAODConversionPhoton *>(photon))); // if no second loop is required add to events good gammas
+    }else if(cuts.UseElecSharingCut()){ // if Shared Electron cut is enabled, Fill array, add to step one
+      cuts.FillElectonLabelArray(static_cast<AliAODConversionPhoton *>(photon), nV0);
+      nV0++;
+      GammaCandidatesStepOne.push_back(static_cast<AliAODConversionPhoton *>(photon));
+    }else if(!cuts.UseElecSharingCut() && cuts.UseToCloseV0sCut()){ // shared electron is disabled, step one not needed -> step two
+      GammaCandidatesStepTwo.Add(static_cast<AliAODConversionPhoton *>(photon));
+    }
+  }
+
+  if(cuts.UseElecSharingCut()){
+    int iV0 = 0;
+    for(auto photon : GammaCandidatesStepOne){
+      if(!cuts.RejectSharedElectronV0s(photon,iV0,GammaCandidatesStepOne.size())) continue;
+      if(!cuts.UseToCloseV0sCut()){ // To Close v0s cut diabled, step two not needed
+        candidates.push_back(*photon);
+      } else GammaCandidatesStepTwo.Add(photon); // Close v0s cut enabled -> add to list two
+      iV0++;
+    }
+  }
+
+  if(cuts.UseToCloseV0sCut()){
+    for(int i = 0; i < GammaCandidatesStepTwo.GetEntries(); i++){
+      AliAODConversionPhoton *photon = static_cast<AliAODConversionPhoton *>(GammaCandidatesStepTwo.At(i));
+      if(!cuts.RejectToCloseV0s(photon, &GammaCandidatesStepTwo,i)) continue;
+      candidates.push_back(*photon); // Add gamma to current cut TList
+    }
+  }
+  return candidates;
+}
+
+std::vector<AliAODConversionMother> AliAnalysisTaskK0toPi0Pi0::MakePi0Candidates(const std::vector<AliAODConversionPhoton> *primaryLeg,
+                                                                                 const std::vector<AliAODConversionPhoton> *secondaryLeg,
+                                                                                 AliConversionMesonCuts &cuts){
+  // secondary leg: optional argument, if different methods for photon identification (i.e. PCM-EMCAL) is used
+  std::vector<AliAODConversionMother> candidates;
+  if(secondaryLeg){
+    // Different methods for photon identification identification
+    for(auto primphoton : *primaryLeg){
+      for(auto secphoton : *secondaryLeg) {
+        AliAODConversionMother candidate(&primphoton, &secphoton);
+        // Do Pi0 selection
+        if(!cuts.MesonIsSelected(&candidate, kTRUE, 0)) continue;      // Rapidity shift needed when going to asymmetric systems
+        candidates.push_back(candidate);
+      }
+    }
+  } else {
+    // Same method for photon identification
+    for(auto primiter = primaryLeg->begin(); primiter != primaryLeg->end(); ++primiter){
+      for(auto seciter = primiter + 1; seciter != primaryLeg->end(); ++seciter){
+        AliAODConversionMother candidate(&(*primiter), &(*seciter));
+        // Do pi0 selection
+        if(cuts.MesonIsSelected(&candidate, kTRUE, 0)) continue;      // Rapidity shift needed when going to asymmetric systems
+        candidates.push_back(candidate);
+      }
+    }
+  }
+  return candidates;
+}
+
+std::vector<AliAODConversionMother> AliAnalysisTaskK0toPi0Pi0::MakeK0ShortCandidates(const std::vector<AliAODConversionMother> *primaryLeg,
+                                                                                     const std::vector<AliAODConversionMother> *secondaryLeg,
+                                                                                    AliConversionMesonCuts &cuts){
+  std::vector<AliAODConversionMother> candidates;
+  if(secondaryLeg) {
+    // Different methods for Pi0 identification (one same, one mixed)
+    for(auto primpi0 : *primaryLeg) {
+      for(auto secpi0 : *secondaryLeg) {
+        AliAODConversionMother candidate(&primpi0, &secpi0);
+        if(!cuts.MesonIsSelected(&candidate, kTRUE, 0)) continue;
+        candidates.push_back(candidate);
+      }
+    }
+  } else {
+    // Same methods for Pi0 identification (both same or both mixed)
+    for(auto primpi0 = primaryLeg->begin(); primpi0 != primaryLeg->end(); ++primpi0) {
+      for(auto secpi0 = primpi0 + 1; primpi0 != primaryLeg->end(); ++primpi0) {
+        AliAODConversionMother candidate(&(*primpi0), &(*secpi0));
+        if(!cuts.MesonIsSelected(&candidate, kTRUE, 0)) continue;
+        candidates.push_back(candidate);
+      }
+    }
+  }
+  return candidates;
+}
+
+
+void AliAnalysisTaskK0toPi0Pi0::MakePhotonQACalo(const std::vector<AliAODConversionPhoton> &photons, AliConvEventCuts &cuts) {
+  for(auto photon : photons) {
+    fHistos->FillTH1("hCaloPhotonPt", photon.Pt());
+  }
+}
+
+void AliAnalysisTaskK0toPi0Pi0::MakePhotonQAConv(const std::vector<AliAODConversionPhoton> &photons, AliConvEventCuts &cuts) {
+  for(auto photon : photons) {
+    fHistos->FillTH1("hConvPhotonPt", photon.Pt());
+    fHistos->FillTH2("hConvPhotonEtaR", photon.Eta(), photon.GetConversionRadius());
+  }
+}
+
+void AliAnalysisTaskK0toPi0Pi0::MakePi0QA(const std::vector<AliAODConversionMother> &pi0s, const char *reccase){
+  TString reccaseString = reccase;
+  for(auto pi0 : pi0s) {
+  	fHistos->FillTH2("hMassvsPtPi0" + reccaseString + "All", pi0.M(), pi0.Pt());
+  	// if in the pi0 mass region  
+  	if((0.08 <=pi0.M()) && (pi0.M()<= 0.145)){
+  		 fHistos->FillTH2("hMassvsPtPi0"+ reccaseString + "Sel", pi0.M(),pi0.Pt());
+  		 fHistos->FillTH2("hAlphavsPtPi0" + reccaseString, pi0.GetAlpha(), pi0.Pt());
+  		 fHistos->FillTH2("hOpeningAnglevsPtPi0" + reccaseString, pi0.GetOpeningAngle(), pi0.Pt());
+  	}
+  }
+}
+
+void AliAnalysisTaskK0toPi0Pi0::MakeK0ShortQA(const std::vector<AliAODConversionMother> &k0s,const char *reccase){
+  TString reccaseString = reccase;
+  for(auto k0: k0s) {
+  	fHistos->FillTH2("hMassvsPtK0Short" + reccaseString, k0.M(), k0.Pt());
+  	fHistos->FillTH2("hOpeningAnglevsPtK0Short" + reccaseString, k0.GetOpeningAngle(), k0.Pt());
+  }
+}
+
+AliClusterContainer *AliAnalysisTaskK0toPi0Pi0::AddClusterContainer(const char *name) {
+  fClusterContainer = new AliClusterContainer(name);
+  return fClusterContainer;
+}
+

--- a/PWGGA/GammaConv/AliAnalysisTaskK0toPi0Pi0.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskK0toPi0Pi0.h
@@ -1,0 +1,115 @@
+/**************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                   *
+ * All rights reserved.                                                               *
+ *                                                                                    *
+ * Redistribution and use in source and binary forms, with or without                 *
+ * modification, are permitted provided that the following conditions are met:        *
+ *     * Redistributions of source code must retain the above copyright               *
+ *       notice, this list of conditions and the following disclaimer.                *
+ *     * Redistributions in binary form must reproduce the above copyright            *
+ *       notice, this list of conditions and the following disclaimer in the          *
+ *       documentation and/or other materials provided with the distribution.         *
+ *     * Neither the name of the <organization> nor the                               *
+ *       names of its contributors may be used to endorse or promote products         *
+ *       derived from this software without specific prior written permission.        *
+ *                                                                                    *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND    *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED      *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE             *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY                *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES         *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;       *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND        *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT         *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS      *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                       *
+ **************************************************************************************/
+#ifndef ALIANALYSISTASKK0TOPI0PI0_H
+#define ALIANALYSISTASKK0TOPI0PI0_H
+
+#include <vector>
+#include <TString.h>
+
+#include "AliAODConversionPhoton.h"
+#include "AliAnalysisTaskSE.h"
+
+class THistManager;
+class TList;
+class AliAODConversionPhoton;
+class AliAODConversionMother;
+class AliCaloPhotonCuts;
+class AliConvEventCuts;
+class AliConversionMesonCuts;
+class AliConversionPhotonCuts;
+class AliClusterContainer;
+class AliV0ReaderV1;
+
+class AliAnalysisTaskK0toPi0Pi0 : public AliAnalysisTaskSE {
+public:
+  enum PhotonType_t {
+    kPCMPhoton = 0,
+    kEMCALPhoton = 1,
+    kUndefined = -1
+  };
+
+  AliAnalysisTaskK0toPi0Pi0();
+  AliAnalysisTaskK0toPi0Pi0(const char *name);
+  virtual ~AliAnalysisTaskK0toPi0Pi0();
+
+  AliClusterContainer *AddClusterContainer(const char *name);
+  void SetNameV0Reader(const char *name) { fV0ReaderName = name; }
+  void SetEventCuts(AliConvEventCuts *cuts) { fEventCuts = cuts; }
+  void SetConversionPhotonCuts(AliConversionPhotonCuts *cuts) { fConvPhotonCuts = cuts; }
+  void SetCaloPhotonCuts(AliCaloPhotonCuts *cuts) { fCaloPhotonCuts = cuts; }
+  void SetPi0Cuts(AliConversionMesonCuts *cuts) { fPi0Cuts = cuts; }
+  void SetPi0CutsCaloCalo(AliConversionMesonCuts *cuts) { fPi0CutsCaloCalo = cuts; }
+  void SetK0Cuts(AliConversionMesonCuts *cuts){ fK0Cuts = cuts;}
+
+protected:
+  virtual void UserCreateOutputObjects();
+  virtual void UserExec(Option_t *);
+  virtual bool UserNotify() { fNewFile = kTRUE; return kTRUE; } // File changed logics in FileChanged function, called when the first event from the file is fully constructed
+
+  virtual void ExecOnce();
+  virtual void RunChanged()   {}
+  virtual void FileChanged()  {}
+
+  // Selectors
+  std::vector<AliAODConversionPhoton> MakeCaloPhotonCandidates(const AliClusterContainer &inputcont, AliCaloPhotonCuts &cuts);
+  std::vector<AliAODConversionPhoton> MakeConversionPhotonCandidates(const AliV0ReaderV1 &reader, AliConversionPhotonCuts &cuts);
+
+  std::vector<AliAODConversionMother> MakePi0Candidates(const std::vector<AliAODConversionPhoton> *primaryLeg, const std::vector<AliAODConversionPhoton> *secondaryLeg, AliConversionMesonCuts &cuts);
+  std::vector<AliAODConversionMother> MakeK0ShortCandidates(const std::vector<AliAODConversionMother> *primaryLeg, const std::vector<AliAODConversionMother> *secondaryLeg, AliConversionMesonCuts &cuts);
+
+  void MakePhotonQACalo(const std::vector<AliAODConversionPhoton> &photons, AliConvEventCuts &cuts);
+  void MakePhotonQAConv(const std::vector<AliAODConversionPhoton> &photons, AliConvEventCuts &cuts);
+  void MakePi0QA(const std::vector<AliAODConversionMother> &pi0s, const char *reccase);
+  void MakeK0ShortQA(const std::vector<AliAODConversionMother> &k0s, const char *reccase);
+
+private:
+  Bool_t                                       fLocalInitialized;     ///< Check whether the task was initialized (triggers ExecOnce)
+  Int_t                                        fCurrentRun;           ///< Current run number (triggers RunChanged)
+  Bool_t                                       fNewFile;              ///< New file loaded (triggers fileChanged)
+  AliV0ReaderV1                               *fV0Reader;             //!<! V0 reader
+  TString                                      fV0ReaderName;         ///< Name of the V0 reader
+  AliClusterContainer                         *fClusterContainer;     ///< Cluster container
+  Bool_t                                       fIsMC;                 ///< Switch whether we run over data or MC
+  Double_t                                     fWeightJetJetMC;       ///< Weight of the jet-jet event
+  Double_t                                     fEventPlaneAngle;      ///< Event Plane Angle
+
+  AliConvEventCuts                            *fEventCuts;            ///< Event cuts
+  AliConversionPhotonCuts                     *fConvPhotonCuts;       ///< Cuts on conversion photons
+  AliCaloPhotonCuts                           *fCaloPhotonCuts;       ///< Calo photon cuts
+  AliConversionMesonCuts                      *fPi0Cuts;              ///< Cuts on the pi0
+  AliConversionMesonCuts                      *fPi0CutsCaloCalo;      ///< Cuts on the pi0 for the calo calo case
+  AliConversionMesonCuts                      *fK0Cuts;               ///< Cuts on the K0
+
+  THistManager                                *fHistos;               ///< Container for Histograms
+  TList                                       *fOutput;               ///< Global output container
+
+  /// \cond CLASSIMP
+  ClassDef(AliAnalysisTaskK0toPi0Pi0, 1);
+  /// \endcond
+};
+
+#endif /* ALIANALYSISTASKK0TOPI0PI0_H */

--- a/PWGGA/GammaConv/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConv/AliCaloPhotonCuts.cxx
@@ -2943,6 +2943,7 @@ Bool_t AliCaloPhotonCuts::InitializeCutsFromCutString(const TString analysisCutS
   for(Int_t ii=0;ii<kNCuts;ii++){
     if(!SetCut(cutIds(ii),fCuts[ii]))return kFALSE;
   }
+  
   PrintCutsWithValues();
   return kTRUE;
 }

--- a/PWGGA/GammaConv/AliCaloPhotonCuts.h
+++ b/PWGGA/GammaConv/AliCaloPhotonCuts.h
@@ -41,6 +41,37 @@ class TList;
 class AliAnalysisManager;
 class AliAODMCParticle;
 
+
+/***
+ * @class AliCaloPhotonCuts
+ * @ingroup GammaConv
+ *
+ * The cut configuration is set as a string with an 19 digit number.
+ * Each digit in the string corresponds to a certain cut type, while
+ * its values represent the cut values. The cut configuration is listed here:
+ *
+ * | Position in the cut string (from the end) | Cut type               |
+ * |                  0                        | Cluster Type           |
+ * |                  1                        | Eta Min                | 
+ * |                  2                        | Eta Max                |
+ * |                  3                        | Phi Min                |
+ * |                  4                        | Phi Max                |
+ * |                  5                        | NonLinearity1          |
+ * |                  6                        | NonLinearity2          |
+ * |                  7                        | DistanceToBadChannel   |
+ * |                  8                        | Timing                 |
+ * |                  9                        | TrackMatching          |
+ * |                  10                       | ExoticCluster          |
+ * |                  11                       | MinEnergy              |
+ * |                  12                       | MinNCells              |
+ * |                  13                       | MinM02                 |
+ * |                  14                       | MaxM02                 |
+ * |                  15                       | MinM20                 |
+ * |                  16                       | MaxM20                 | 
+ * |                  17                       | MaximumDispersion      |
+ * |                  18                       | NML                    |
+*/
+
 class AliCaloPhotonCuts : public AliAnalysisCuts {
     
   public: 
@@ -143,7 +174,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     
     //handeling of CutString
     static const char * fgkCutNames[kNCuts];
-    Bool_t      SetCutIds(TString cutString); 
+    Bool_t      SetCutIds(TString cutString);  
     Int_t       fCuts[kNCuts];
     Bool_t      SetCut(cutIds cutID, Int_t cut);
     Bool_t      UpdateCutString();

--- a/PWGGA/GammaConv/AliConvEventCuts.h
+++ b/PWGGA/GammaConv/AliConvEventCuts.h
@@ -301,7 +301,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
       static const char * fgkCutNames[kNCuts];
 
       // Setters
-      Bool_t    SetCutIds (TString cutString); 
+      Bool_t    SetCutIds (TString cutString);
       Bool_t    SetCut (cutIds cutID, Int_t cut);
       Bool_t    SetIsHeavyIon (Int_t isHeavyIon);
       Bool_t    SetCentralityMax (Int_t centralityBin);

--- a/PWGGA/GammaConv/AliConversionPhotonCuts.h
+++ b/PWGGA/GammaConv/AliConversionPhotonCuts.h
@@ -83,7 +83,7 @@ class AliConversionPhotonCuts : public AliAnalysisCuts {
     };
 
 
-    Bool_t SetCutIds(TString cutString); 
+    Bool_t SetCutIds(TString cutString);
     Int_t fCuts[kNCuts];
     Bool_t SetCut(cutIds cutID, Int_t cut);
     Bool_t UpdateCutString();

--- a/PWGGA/GammaConv/CMakeLists.txt
+++ b/PWGGA/GammaConv/CMakeLists.txt
@@ -58,6 +58,7 @@ set(SRCS
     AliAnalysisTaskMaterialHistos.cxx
     AliAnalysisTaskNeutralMesonToPiPlPiMiPiZero.cxx
     AliAnalysisTaskOmegaToPiZeroGamma.cxx
+    AliAnalysisTaskK0toPi0Pi0.cxx
     AliAnalysisTaskPi0v2.cxx
     AliAnalysisTaskResolution.cxx
     AliAnalysisTaskGammaCaloDalitzV1.cxx

--- a/PWGGA/GammaConv/PWGGAGammaConvLinkDef.h
+++ b/PWGGA/GammaConv/PWGGAGammaConvLinkDef.h
@@ -44,6 +44,7 @@
 #pragma link C++ class AliAnaConvCorrPhoton+;
 #pragma link C++ class AliAnalysisTaskdPhi+;
 #pragma link C++ class AliAnalysisTaskOmegaToPiZeroGamma+;
+#pragma link C++ class AliAnalysisTaskK0toPi0Pi0+;
 
 // Old tasks
 #pragma link C++ class AliAnalysisTaskGCPartToPWG4Part+;

--- a/PWGGA/GammaConv/macros/AddTask_K0toPi0Pi0.C
+++ b/PWGGA/GammaConv/macros/AddTask_K0toPi0Pi0.C
@@ -1,0 +1,178 @@
+/**************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                   *
+ * All rights reserved.                                                               *
+ *                                                                                    *
+ * Redistribution and use in source and binary forms, with or without                 *
+ * modification, are permitted provided that the following conditions are met:        *
+ *     * Redistributions of source code must retain the above copyright               *
+ *       notice, this list of conditions and the following disclaimer.                *
+ *     * Redistributions in binary form must reproduce the above copyright            *
+ *       notice, this list of conditions and the following disclaimer in the          *
+ *       documentation and/or other materials provided with the distribution.         *
+ *     * Neither the name of the <organization> nor the                               *
+ *       names of its contributors may be used to endorse or promote products         *
+ *       derived from this software without specific prior written permission.        *
+ *                                                                                    *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND    *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED      *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE             *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY                *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES         *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;       *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND        *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT         *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS      *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                       *
+ **************************************************************************************/
+
+void AddTask_K0toPi0Pi0(Bool_t runLightOutput = kFALSE, 
+						TString periodName = "",
+						TString periodNameV0Reader = "") {
+
+  // ================== GetAnalysisManager ===============================
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    Error("AddTask_K0toPi0Pi0", "No analysis manager found.");
+    return ;
+  }
+
+  // ================== GetInputEventHandler =============================
+  AliVEventHandler *inputHandler=mgr->GetInputEventHandler();
+  
+  AliAnalysisDataContainer *cinput = mgr->GetCommonInputContainer();
+  
+  
+  //================================================
+  //========= Add task to the ANALYSIS manager =====
+  //================================================
+  //            find input container
+  AliAnalysisTaskK0toPi0Pi0 *task=NULL;
+  task = new AliAnalysisTaskK0toPi0Pi0("TaskK0toPi0Pi0");
+  
+
+   //=========  Set Cutnumber for V0Reader ================================
+  //TString cutnumberPhoton = "00200008400000002200000000"; 
+  TString cutnumberPhoton = "00000000000000000000000000"; 
+  TString cutnumberEvent = "00000003"; 
+ 
+//========= Add V0 Reader to  ANALYSIS manager if not yet existent =====
+  TString V0ReaderName = Form("V0ReaderV1_%s_%s",cutnumberEvent.Data(),cutnumberPhoton.Data());
+  if( !(AliV0ReaderV1*)mgr->GetTask(V0ReaderName.Data()) ){
+    AliV0ReaderV1 *fV0ReaderV1 = new AliV0ReaderV1(V0ReaderName.Data());
+    if (periodNameV0Reader.CompareTo("") != 0) fV0ReaderV1->SetPeriodName(periodNameV0Reader);
+    fV0ReaderV1->SetUseOwnXYZCalculation(kTRUE);
+    fV0ReaderV1->SetCreateAODs(kFALSE);// AOD Output
+    fV0ReaderV1->SetUseAODConversionPhoton(kTRUE);
+
+    if (!mgr) {
+      Error("AddTask_V0ReaderV1", "No analysis manager found.");
+      return;
+    }
+
+    AliConvEventCuts *fEventCuts=NULL;
+    if(cutnumberEvent!=""){
+      fEventCuts= new AliConvEventCuts(cutnumberEvent.Data(),cutnumberEvent.Data());
+      fEventCuts->SetPreSelectionCutFlag(kTRUE);
+      fEventCuts->SetV0ReaderName(V0ReaderName);
+      if (periodNameV0Reader.CompareTo("") != 0) fEventCuts->SetPeriodEnum(periodNameV0Reader);
+      fEventCuts->SetLightOutput(runLightOutput);
+      if(fEventCuts->InitializeCutsFromCutString(cutnumberEvent.Data())){
+        fV0ReaderV1->SetEventCuts(fEventCuts);
+        fEventCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+
+    // Set AnalysisCut Number
+    AliConversionPhotonCuts *fCuts=NULL;
+    if(cutnumberPhoton!=""){
+      fCuts= new AliConversionPhotonCuts(cutnumberPhoton.Data(),cutnumberPhoton.Data());
+      fCuts->SetPreSelectionCutFlag(kTRUE);
+      //fCuts->SetIsHeavyIon(isHeavyIon);
+      fCuts->SetV0ReaderName(V0ReaderName);
+      fCuts->SetLightOutput(runLightOutput);
+      if(fCuts->InitializeCutsFromCutString(cutnumberPhoton.Data())){
+        fV0ReaderV1->SetConversionCuts(fCuts);
+        fCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+    
+   
+    fV0ReaderV1->Init();
+
+    AliLog::SetGlobalLogLevel(AliLog::kInfo);
+    //connect input V0Reader
+    mgr->AddTask(fV0ReaderV1);
+    mgr->ConnectInput(fV0ReaderV1,0,cinput);
+
+  }
+  
+  task->SetNameV0Reader(V0ReaderName); 
+  
+  // now for the default cuts for 8 TeV
+  TString defaultEventCut = "00010113";
+  //TString defaultEventCut = "00052113"; // EMC7
+  //TString defaultEventCut = "00081113"; // EGA
+  TString defaultConvPhotonCut = "00200009327000008250400000";
+  TString defaultCaloPhotonCut = "1111111067032230000";
+  TString defaultPi0Cut = "0163103100000010"; 
+  TString Pi0Cut = "0163103100000060"; // calo/calo
+  TString defaultK0Cut = "0163103100000000";
+  
+  //create AliCaloTrackMatcher instance, if there is none present
+  TString caloCutPos = defaultCaloPhotonCut;
+  caloCutPos.Resize(1);
+  TString TrackMatcherName = Form("CaloTrackMatcher_%s",caloCutPos.Data());
+  if( !(AliCaloTrackMatcher*)mgr->GetTask(TrackMatcherName.Data()) ){
+    AliCaloTrackMatcher* fTrackMatcher = new AliCaloTrackMatcher(TrackMatcherName.Data(),caloCutPos.Atoi());
+    fTrackMatcher->SetV0ReaderName(V0ReaderName);
+    mgr->AddTask(fTrackMatcher);
+    mgr->ConnectInput(fTrackMatcher,0,cinput);
+  }
+  
+  // ============= Set the different cut types to their default values ==============
+  AliConvEventCuts *analysisEventCuts = new AliConvEventCuts(); 
+  analysisEventCuts->SetPeriodEnum(periodName);
+  analysisEventCuts->SetV0ReaderName(V0ReaderName);
+  analysisEventCuts->InitializeCutsFromCutString(defaultEventCut.Data());
+  analysisEventCuts->SetFillCutHistograms("", kTRUE); 
+  task->SetEventCuts(analysisEventCuts); 
+
+  AliConversionPhotonCuts *analysisConvoCuts = new AliConversionPhotonCuts();  
+  analysisConvoCuts->SetV0ReaderName(V0ReaderName);
+  analysisConvoCuts->InitializeCutsFromCutString(defaultConvPhotonCut.Data());
+  analysisConvoCuts->SetFillCutHistograms("",kTRUE);
+  task->SetConversionPhotonCuts(analysisConvoCuts); 
+  
+  AliCaloPhotonCuts *analysisCaloCuts = new AliCaloPhotonCuts(); 
+  analysisCaloCuts->SetV0ReaderName(V0ReaderName);
+  analysisCaloCuts->InitializeCutsFromCutString(defaultCaloPhotonCut.Data());
+  analysisCaloCuts->SetFillCutHistograms("");
+  task->SetCaloPhotonCuts(analysisCaloCuts); 
+  
+  
+  AliConversionMesonCuts *analysisPi0Cuts = new AliConversionMesonCuts();
+  analysisPi0Cuts->InitializeCutsFromCutString(defaultPi0Cut.Data()); 
+  analysisPi0Cuts->SetFillCutHistograms(""); 
+  task->SetPi0Cuts(analysisPi0Cuts); 
+  
+  
+  AliConversionMesonCuts *analysisPi0CutsCaloCalo = new AliConversionMesonCuts();
+  analysisPi0CutsCaloCalo->InitializeCutsFromCutString(Pi0Cut.Data()); 
+  analysisPi0CutsCaloCalo->SetFillCutHistograms(""); 
+  task->SetPi0CutsCaloCalo(analysisPi0CutsCaloCalo); 
+  
+  
+  AliConversionMesonCuts *analysisK0Cuts = new AliConversionMesonCuts(); 
+  analysisK0Cuts->InitializeCutsFromCutString(defaultK0Cut.Data()); 
+  analysisK0Cuts->SetFillCutHistograms(""); 
+  task->SetK0Cuts(analysisK0Cuts); 
+  
+  
+  //connect containers
+  AliAnalysisDataContainer *coutput =
+  mgr->CreateContainer("K0toPiPi0", TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:K0toPiPi0",AliAnalysisManager::GetCommonFileName()));
+  mgr->AddTask(task);
+  mgr->ConnectInput(task,0,cinput);
+  mgr->ConnectOutput(task,1,coutput);
+  
+}


### PR DESCRIPTION
-Doing conversion and calo photon selection.
-Building Pi0 candidates for all three methods separately.
-K0 candidates still disabled.
-Task configured with loose cuts for the V0 reader and default event gamma conv and calo cuts for 2012 pp.
-Adding new class in the build.