### PR TITLE
reverse correspondance process with high-pt trig and IDparticle associate

### DIFF
--- a/PWGCF/Correlations/DPhi/AliAnalysisTaskCorPIDTOFQA.cxx
+++ b/PWGCF/Correlations/DPhi/AliAnalysisTaskCorPIDTOFQA.cxx
@@ -13,7 +13,7 @@
  * provided "as is" without express or implied warranty.                  *
  **************************************************************************/
 
-/* AliAnaysisTaskCorPIDTOFQA
+/* AliAnaysisTaskCorPIDTOFdeut
  *
  * empty task which can serve as a starting point for building an analysis
  * as an example, one histogram is filled
@@ -99,66 +99,65 @@ fAOD(0), fOutputList(0), fPIDResponse(0),
     fHistPt(0),                 //  1
     cent_ntracks(0),            //  2
     
-    m2_pos(0),                  //  3
-    m2_neg(0),                  //  4
-    beta_p_pos(0),              //  5
-    beta_p_neg(0),              //  6
-
-    deltat_p_pos(0),            //  7
-    deltat_p_neg(0),            //  8
-    dedx_p_pos(0),              //  9
-    dedx_p_neg(0),              // 10
-    dedx_deltat_pos(0),         // 11
-    dedx_deltat_neg(0),         // 12
-    dedx_p_deltat_pos(0),       // 13
-    dedx_p_deltat_neg(0),       // 14
-
-    m2_pos_cut(0),              // 15
-    m2_neg_cut(0),              // 16
-    beta_p_pos_cut(0),          // 17
-    beta_p_neg_cut(0),          // 18
-    deltat_p_pos_cut(0),        // 19
-    deltat_p_neg_cut(0),        // 20
-
-    dedx_p_pos_cut(0),          // 21
-    dedx_p_neg_cut(0),          // 22
-
-    dedx_deltat_pos_cut(0),     // 23
-    dedx_deltat_neg_cut(0),     // 24
-    dedx_p_deltat_pos_cut(0),   // 25
-    dedx_p_deltat_neg_cut(0),   // 26
+    high_per_event_05(0),       //  3a
+    high_per_event_10(0),       //  3b
+    high_per_event_pos(0),      //  4
+    high_per_event_neg(0),      //  5
 
 
-
-
-    deut_dphi_T(0),             // 27
-    deut_dphi_pos_T(0),         // 28
-    deut_dphi_neg_T(0),         // 29
-    deut_dphi_A(0),             // 30
-    deut_dphi_pos_A(0),         // 31
-    deut_dphi_neg_A(0),         // 32
-    deut_dphi_B(0),             // 33
-    deut_dphi_pos_B(0),         // 34
-    deut_dphi_neg_B(0),         // 35
-
-    deut_per_event(0),          // 36
-    deut_per_event_pos(0),      // 37
-    deut_per_event_neg(0),      // 38
+    dphi_pt_deut_05(0),         //  6
+    dphi_et_deut_05(0),         //  7
+    dphi_en_deut_05(0),         //  8
+    dphi_kt_deut_05(0),         //  9
     
-    m2_pos_cut_T(0),            // 39
-    m2_pos_cut_A(0),            // 40
-    m2_pos_cut_B(0),            // 41
-    m2_neg_cut_T(0),            // 42
-    m2_neg_cut_A(0),            // 43
-    m2_neg_cut_B(0),            // 44
+    dphi_pt_prot_05(0),         // 10
+    dphi_et_prot_05(0),         // 11
+    dphi_en_prot_05(0),         // 12
+    dphi_kt_prot_05(0),         // 13
 
-    dphi_ket_deut_T(0),         // 45
-    dphi_ket_deut_A(0),         // 46
-    dphi_ket_deut_B(0),         // 47
+    dphi_pt_hadr_05(0),         // 14
+    dphi_et_hadr_05(0),         // 15
+    dphi_en_hadr_05(0),         // 16
+    dphi_kt_hadr_05(0),         // 17
+    
+//  high_pt_count_05(0),        // 18
+//  high_et_count_05(0),        // 19
+//  high_en_count_05(0),        // 20
+//  high_kt_count_05(0),        // 21
+    
+    deut_phi_hist_05(0),        // 22
+    prot_phi_hist_05(0),        // 23
+    hadr_phi_hist_05(0),        // 24
+    high_phi_hist_05(0),        // 25
 
-    deltat_channel(0),          // 48
+    dphi_pt_deut_10(0),         // 26
+    dphi_et_deut_10(0),         // 27
+    dphi_en_deut_10(0),         // 28
+    dphi_kt_deut_10(0),         // 29
+    
+    dphi_pt_prot_10(0),         // 30
+    dphi_et_prot_10(0),         // 31
+    dphi_en_prot_10(0),         // 32
+    dphi_kt_prot_10(0),         // 33
 
-    deut_ket_count(0)           // 49    
+    dphi_pt_hadr_10(0),         // 34
+    dphi_et_hadr_10(0),         // 35
+    dphi_en_hadr_10(0),         // 36
+    dphi_kt_hadr_10(0),         // 37
+    
+//  high_pt_count_10(0),        // 38
+//  high_et_count_10(0),        // 39
+//  high_en_count_10(0),        // 40
+//  high_kt_count_10(0),        // 41
+    
+    deut_phi_hist_10(0),        // 42
+    prot_phi_hist_10(0),        // 43
+    hadr_phi_hist_10(0),        // 44
+    high_phi_hist_10(0),        // 45    
+    
+    m2_cut(0)                   // 46
+
+    
 {
     // default constructor, don't allocate memory here!
     // this is used by root for IO purposes, it needs to remain empty
@@ -170,64 +169,64 @@ fAOD(0), fOutputList(0), fPIDResponse(0),
     fHistPt(0),                 //  1
     cent_ntracks(0),            //  2
     
-    m2_pos(0),                  //  3
-    m2_neg(0),                  //  4
-    beta_p_pos(0),              //  5
-    beta_p_neg(0),              //  6
+    high_per_event_05(0),       //  3a
+    high_per_event_10(0),       //  3b									       
+    high_per_event_pos(0),      //  4
+    high_per_event_neg(0),      //  5
 
-    deltat_p_pos(0),            //  7
-    deltat_p_neg(0),            //  8
-    dedx_p_pos(0),              //  9
-    dedx_p_neg(0),              // 10
-    dedx_deltat_pos(0),         // 11
-    dedx_deltat_neg(0),         // 12
-    dedx_p_deltat_pos(0),       // 13
-    dedx_p_deltat_neg(0),       // 14
-
-    m2_pos_cut(0),              // 15
-    m2_neg_cut(0),              // 16
-    beta_p_pos_cut(0),          // 17
-    beta_p_neg_cut(0),          // 18
-    deltat_p_pos_cut(0),        // 19
-    deltat_p_neg_cut(0),        // 20
-
-    dedx_p_pos_cut(0),          // 21
-    dedx_p_neg_cut(0),          // 22
-
-    dedx_deltat_pos_cut(0),     // 23
-    dedx_deltat_neg_cut(0),     // 24
-    dedx_p_deltat_pos_cut(0),   // 25
-    dedx_p_deltat_neg_cut(0),   // 26
-
-
-    deut_dphi_T(0),             // 27
-    deut_dphi_pos_T(0),         // 28
-    deut_dphi_neg_T(0),         // 29
-    deut_dphi_A(0),             // 30
-    deut_dphi_pos_A(0),         // 31
-    deut_dphi_neg_A(0),         // 32
-    deut_dphi_B(0),             // 33
-    deut_dphi_pos_B(0),         // 34
-    deut_dphi_neg_B(0),         // 35
-
-    deut_per_event(0),          // 36
-    deut_per_event_pos(0),      // 37
-    deut_per_event_neg(0),      // 38
+    dphi_pt_deut_05(0),         //  6
+    dphi_et_deut_05(0),         //  7
+    dphi_en_deut_05(0),         //  8
+    dphi_kt_deut_05(0),         //  9
     
-    m2_pos_cut_T(0),            // 39
-    m2_pos_cut_A(0),            // 40
-    m2_pos_cut_B(0),            // 41
-    m2_neg_cut_T(0),            // 42
-    m2_neg_cut_A(0),            // 43
-    m2_neg_cut_B(0),            // 44
+    dphi_pt_prot_05(0),         // 10
+    dphi_et_prot_05(0),         // 11
+    dphi_en_prot_05(0),         // 12
+    dphi_kt_prot_05(0),         // 13
 
-    dphi_ket_deut_T(0),         // 45
-    dphi_ket_deut_A(0),         // 46
-    dphi_ket_deut_B(0),         // 47
+    dphi_pt_hadr_05(0),         // 14
+    dphi_et_hadr_05(0),         // 15
+    dphi_en_hadr_05(0),         // 16
+    dphi_kt_hadr_05(0),         // 17
+    
+//  high_pt_count_05(0),        // 18
+//  high_et_count_05(0),        // 19
+//  high_en_count_05(0),        // 20
+//  high_kt_count_05(0),        // 21
+    
+    deut_phi_hist_05(0),        // 22
+    prot_phi_hist_05(0),        // 23
+    hadr_phi_hist_05(0),        // 24
+    high_phi_hist_05(0),        // 25
 
-    deltat_channel(0),          // 48
+    dphi_pt_deut_10(0),         // 26
+    dphi_et_deut_10(0),         // 27
+    dphi_en_deut_10(0),         // 28
+    dphi_kt_deut_10(0),         // 29
+    
+    dphi_pt_prot_10(0),         // 30
+    dphi_et_prot_10(0),         // 31
+    dphi_en_prot_10(0),         // 32
+    dphi_kt_prot_10(0),         // 33
 
-    deut_ket_count(0)           // 49
+    dphi_pt_hadr_10(0),         // 34
+    dphi_et_hadr_10(0),         // 35
+    dphi_en_hadr_10(0),         // 36
+    dphi_kt_hadr_10(0),         // 37
+    
+//  high_pt_count_10(0),        // 38
+//  high_et_count_10(0),        // 39
+//  high_en_count_10(0),        // 40
+//  high_kt_count_10(0),        // 41
+    
+    deut_phi_hist_10(0),        // 42
+    prot_phi_hist_10(0),        // 43
+    hadr_phi_hist_10(0),        // 44
+    high_phi_hist_10(0),        // 45    
+    
+    m2_cut(0)                   // 46
+
+									       
 {
     // constructor
     DefineInput(0, TChain::Class());
@@ -266,15 +265,28 @@ void AliAnalysisTaskCorPIDTOFQA::UserCreateOutputObjects()
     deut_curves[1][1][1] = 0.0709238;
     deut_curves[1][1][2] = 0.15557;
 
+
     
-//    pi = TMath::Pi();
-//    fout.open("output.txt");
+    prot_curves[0][0][0] = 0.763625;     // pos prot mean curve
+    prot_curves[0][0][1] = 0.0194772;
+    prot_curves[0][0][2] = 0.0903159;
+    prot_curves[0][0][3] =-0.000109114;
+    
+    prot_curves[0][1][0] =-0.129833;  // pos prot sigma curve
+    prot_curves[0][1][1] = 0.0625516;
+    prot_curves[0][1][2] = 0.10124;
+    prot_curves[0][1][3] = 0.000109926;
 
+    prot_curves[1][0][0] = 0.778006;     // neg prot mean curve
+    prot_curves[1][0][1] = 0.0183448;
+    prot_curves[1][0][2] = 0.0754383;
+    prot_curves[1][0][3] =-0.00010526;
 
-//  Double_t deut_curves[2][2][3];  // [charge][mean,sigma][par]
+    prot_curves[1][1][0] =-0.117123;  // neg prot sigma curve
+    prot_curves[1][1][1] = 0.0597632;
+    prot_curves[1][1][2] = 0.0921575;
+    prot_curves[1][1][3] = 0.000118412;
 
-//  TF1 *fit_deut_curve = new TF1("fit_m_mean",   "[0] + [1]*x + [2]/sqrt(x) ",       1.1, 4.4);
-//    fit_deut_curve->SetParNames("a", "b x", "c/#sqrt(x)");
 	
     fOutputList = new TList();          // this is a list which will contain all of your histograms
                                         // at the end of the analysis, the contents of this list are written
@@ -285,65 +297,68 @@ void AliAnalysisTaskCorPIDTOFQA::UserCreateOutputObjects()
 
     fHistPt               = new TH1F("fHistPt",               "Pt()",                 1000,     0,     10);                              //  1
     cent_ntracks          = new TH2F("cent_ntracks",          "cent_ntracks",          100,     0,    100,     100,       0,     800);   //  2
+
+
     
-    m2_pos                = new TH2F("m2_pos",                "m2_pos",                320,   0.0,    8.0,    2400,    -1.0,     7.0);   //  3
-    m2_neg                = new TH2F("m2_neg",                "m2_neg",                320,   0.0,    8.0,    2400,    -1.0,     7.0);   //  4
-    beta_p_pos            = new TH2F("beta_p_pos",            "beta_p_pos",            780,   0.0,    8.0,    3000,     0.1,     1.1);   //  5
-    beta_p_neg            = new TH2F("beta_p_neg",            "beta_p_neg",            780,   0.0,    8.0,    3000,     0.1,     1.1);   //  6
-    deltat_p_pos          = new TH2F("deltat_p_pos",          "deltat_p_pos",        27000,   0.3,    3.0,    1000,    -1.0,     9.0);   //  7
-    deltat_p_neg          = new TH2F("deltat_p_neg",          "deltat_p_neg",        27000,   0.3,    3.0,    1000,    -1.0,     9.0);   //  8
-    dedx_p_pos            = new TH2F("dedx_p_pos",            "dedx_p_pos",            780,   0.2,    8.0,     250,     0.0,   500.0);   //  9
-    dedx_p_neg            = new TH2F("dedx_p_neg",            "dedx_p_neg",            780,   0.2,    8.0,     250,     0.0,   500.0);   // 10
-    dedx_deltat_pos       = new TH2F("dedx_deltat_pos",       "dedx_deltat_pos",      2100,  -1.0,   20.0,     250,     0.0,   500.0);   // 11
-    dedx_deltat_neg       = new TH2F("dedx_deltat_neg",       "dedx_deltat_neg",      2100,  -1.0,   20.0,     250,     0.0,   500.0);   // 12
-    dedx_p_deltat_pos     = new TH3F("dedx_p_deltat_pos",     "dedx_p_deltat_pos",     250, 0.0, 500.0, 156, 0.2, 8.0, 420, -1.0, 20.0); // 13 //// (dedx, mom, deltat)
-    dedx_p_deltat_neg     = new TH3F("dedx_p_deltat_neg",     "dedx_p_deltat_neg",     250, 0.0, 500.0, 156, 0.2, 8.0, 420, -1.0, 20.0); // 14 //// (dedx, mom, deltat)
-    m2_pos_cut            = new TH2F("m2_pos_cut",            "m2_pos_cut",            320,   0.0,    8.0,    2400,    -1.0,     7.0);   // 15
-    m2_neg_cut            = new TH2F("m2_neg_cut",            "m2_neg_cut",            320,   0.0,    8.0,    2400,    -1.0,     7.0);   // 16
-    beta_p_pos_cut        = new TH2F("beta_p_pos_cut",        "beta_p_pos_cut",        780,   0.0,    8.0,    3000,     0.1,     1.1);   // 17
-    beta_p_neg_cut        = new TH2F("beta_p_neg_cut",        "beta_p_neg_cut",        780,   0.0,    8.0,    3000,     0.1,     1.1);   // 18
-    deltat_p_pos_cut      = new TH2F("deltat_p_pos_cut",      "deltat_p_pos_cut",    27000,   0.3,    3.0,    1000,    -1.0,     9.0);   // 19
-    deltat_p_neg_cut      = new TH2F("deltat_p_neg_cut",      "deltat_p_neg_cut",    27000,   0.3,    3.0,    1000,    -1.0,     9.0);   // 20
-    dedx_p_pos_cut        = new TH2F("dedx_p_pos_cut",        "dedx_p_pos_cut",        780,   0.2,    8.0,     250,     0.0,   500.0);   // 21
-    dedx_p_neg_cut        = new TH2F("dedx_p_neg_cut",        "dedx_p_neg_cut",        780,   0.2,    8.0,     250,     0.0,   500.0);   // 22
-    dedx_deltat_pos_cut   = new TH2F("dedx_deltat_pos_cut",   "dedx_deltat_pos_cut",  2100,  -1.0,   20.0,     250,     0.0,   500.0);   // 23
-    dedx_deltat_neg_cut   = new TH2F("dedx_deltat_neg_cut",   "dedx_deltat_neg_cut",  2100,  -1.0,   20.0,     250,     0.0,   500.0);   // 24
-    dedx_p_deltat_pos_cut = new TH3F("dedx_p_deltat_pos_cut", "dedx_p_deltat_pos_cut", 250, 0.0, 500.0, 156, 0.2, 8.0, 420, -1.0, 20.0); // 25 //// (dedx, mom, deltat)
-    dedx_p_deltat_neg_cut = new TH3F("dedx_p_deltat_neg_cut", "dedx_p_deltat_neg_cut", 250, 0.0, 500.0, 156, 0.2, 8.0, 420, -1.0, 20.0); // 26 //// (dedx, mom, deltat)
+    high_per_event_05     = new TH1I("high_per_event_05",     "high_per_event_05",      50,     0,     50);                              //  3a
+    high_per_event_10     = new TH1I("high_per_event_10",     "high_per_event_10",      50,     0,     50);                              //  3b
+    high_per_event_pos    = new TH1I("high_per_event_pos",    "high_per_event_pos",     50,     0,     50);                              //  4
+    high_per_event_neg    = new TH1I("high_per_event_neg",    "high_per_event_neg",     50,     0,     50);                              //  5
 
-    deut_dphi_T           = new TH2F("deut_dphi_T",           "deut_dphi_T",            14,   1.0,    4.5,     300, -1.6708,  4.8124);   // 27
-    deut_dphi_pos_T       = new TH2F("deut_dphi_pos_T",       "deut_dphi_pos_T",        14,   1.0,    4.5,     300, -1.6708,  4.8124);   // 28
-    deut_dphi_neg_T       = new TH2F("deut_dphi_neg_T",       "deut_dphi_neg_T",        14,   1.0,    4.5,     300, -1.6708,  4.8124);   // 29    
-    deut_dphi_A           = new TH2F("deut_dphi_A",           "deut_dphi_A",            14,   1.0,    4.5,     300, -1.6708,  4.8124);   // 30
-    deut_dphi_pos_A       = new TH2F("deut_dphi_pos_A",       "deut_dphi_pos_A",        14,   1.0,    4.5,     300, -1.6708,  4.8124);   // 31
-    deut_dphi_neg_A       = new TH2F("deut_dphi_neg_A",       "deut_dphi_neg_A",        14,   1.0,    4.5,     300, -1.6708,  4.8124);   // 32    
-    deut_dphi_B           = new TH2F("deut_dphi_B",           "deut_dphi_B",            14,   1.0,    4.5,     300, -1.6708,  4.8124);   // 33
-    deut_dphi_pos_B       = new TH2F("deut_dphi_pos_B",       "deut_dphi_pos_B",        14,   1.0,    4.5,     300, -1.6708,  4.8124);   // 34
-    deut_dphi_neg_B       = new TH2F("deut_dphi_neg_B",       "deut_dphi_neg_B",        14,   1.0,    4.5,     300, -1.6708,  4.8124);   // 35
-    deut_per_event        = new TH1I("deut_per_event",        "deut_per_event",          5,     0,     5);                               // 36
-    deut_per_event_pos    = new TH1I("deut_per_event_pos",    "deut_per_event_pos",      5,     0,     5);                               // 37
-    deut_per_event_neg    = new TH1I("deut_per_event_neg",    "deut_per_event_neg",      5,     0,     5);                               // 38
-    m2_pos_cut_T          = new TH2F("m2_pos_cut_T",          "m2_pos_cut_T",          320,   0.0,    8.0,    2400,    -1.0,     7.0);   // 39
-    m2_pos_cut_A          = new TH2F("m2_pos_cut_A",          "m2_pos_cut_A",          320,   0.0,    8.0,    2400,    -1.0,     7.0);   // 40
-    m2_pos_cut_B          = new TH2F("m2_pos_cut_B",          "m2_pos_cut_B",          320,   0.0,    8.0,    2400,    -1.0,     7.0);   // 41
-    m2_neg_cut_T          = new TH2F("m2_neg_cut_T",          "m2_neg_cut_T",          320,   0.0,    8.0,    2400,    -1.0,     7.0);   // 42
-    m2_neg_cut_A          = new TH2F("m2_neg_cut_A",          "m2_neg_cut_A",          320,   0.0,    8.0,    2400,    -1.0,     7.0);   // 43
-    m2_neg_cut_B          = new TH2F("m2_neg_cut_B",          "m2_neg_cut_B",          320,   0.0,    8.0,    2400,    -1.0,     7.0);   // 44
-    dphi_ket_deut_T       = new TH2F("dphi_ket_deut_T",       "dphi_ket_deut_T",        46, 0.445,  2.745,      60, -1.6708,  4.8124);   // 45 // dphi, ket
-    dphi_ket_deut_A       = new TH2F("dphi_ket_deut_A",       "dphi_ket_deut_A",        46, 0.445,  2.745,      60, -1.6708,  4.8124);   // 46 // dphi, ket
-    dphi_ket_deut_B       = new TH2F("dphi_ket_deut_B",       "dphi_ket_deut_B",        46, 0.445,  2.745,      60, -1.6708,  4.8124);   // 47 // dphi, ket
 
-    deltat_channel        = new TProfile("deltat_channel",    "deltat_channel",       4800,     0,   4800,    -0.6,     0.6);            // 48 // tof channel and deltat
 
-    deut_ket_count        = new TH1F("deut_ket_count",        "deut_ket_count",         46, 0.445,  2.745);                              // 49
+    dphi_pt_deut_05       = new TH2F("dphi_pt_deut_05",       "dphi_pt_deut_05",       160,  1.00,   5.00,     300, -1.6708,  4.8124);   //  6
+    dphi_et_deut_05       = new TH2F("dphi_et_deut_05",       "dphi_et_deut_05",       189,  1.00,   4.78,     300, -1.6708,  4.8124);   //  7
+    dphi_en_deut_05       = new TH2F("dphi_en_deut_05",       "dphi_en_deut_05",       189,  1.00,   4.78,     300, -1.6708,  4.8124);   //  8
+    dphi_kt_deut_05       = new TH2F("dphi_kt_deut_05",       "dphi_kt_deut_05",       189,  1.00,   4.78,     300, -1.6708,  4.8124);   //  9
+
+    dphi_pt_prot_05       = new TH2F("dphi_pt_prot_05",       "dphi_pt_prot_05",       160,  1.00,   5.00,     300, -1.6708,  4.8124);   // 10
+    dphi_et_prot_05       = new TH2F("dphi_et_prot_05",       "dphi_et_prot_05",       189,  1.00,   4.78,     300, -1.6708,  4.8124);   // 11
+    dphi_en_prot_05       = new TH2F("dphi_en_prot_05",       "dphi_en_prot_05",       189,  1.00,   4.78,     300, -1.6708,  4.8124);   // 12
+    dphi_kt_prot_05       = new TH2F("dphi_kt_prot_05",       "dphi_kt_prot_05",       189,  1.00,   4.78,     300, -1.6708,  4.8124);   // 13
+
+    dphi_pt_hadr_05       = new TH2F("dphi_pt_hadr_05",       "dphi_pt_hadr_05",       160,  1.00,   5.00,     300, -1.6708,  4.8124);   // 14
+    dphi_et_hadr_05       = new TH2F("dphi_et_hadr_05",       "dphi_et_hadr_05",       189,  1.00,   4.78,     300, -1.6708,  4.8124);   // 15
+    dphi_en_hadr_05       = new TH2F("dphi_en_hadr_05",       "dphi_en_hadr_05",       189,  1.00,   4.78,     300, -1.6708,  4.8124);   // 16
+    dphi_kt_hadr_05       = new TH2F("dphi_kt_hadr_05",       "dphi_kt_hadr_05",       189,  1.00,   4.78,     300, -1.6708,  4.8124);   // 17
+
+//  high_pt_count_05      = new TH1F("high_pt_count_05",      "high_pt_count_05",      160,  1.00,   5.00);                              // 18
+//  high_et_count_05      = new TH1F("high_et_count_05",      "high_et_count_05",      160,  1.00,   4.78);                              // 19
+//  high_en_count_05      = new TH1F("high_en_count_05",      "high_en_count_05",      160,  1.00,   4.78);                              // 20
+//  high_kt_count_05      = new TH1F("high_kt_count_05",      "high_kt_count_05",      160,  1.00,   4.78);                              // 21
+
+    deut_phi_hist_05      = new TH1F("deut_phi_hist_05",      "deut_phi_hist_05",      480, -0.10, 6.383185);                            // 22
+    prot_phi_hist_05      = new TH1F("prot_phi_hist_05",      "prot_phi_hist_05",      480, -0.10, 6.383185);                            // 23
+    hadr_phi_hist_05      = new TH1F("hadr_phi_hist_05",      "hadr_phi_hist_05",      480, -0.10, 6.383185);                            // 24
+    high_phi_hist_05      = new TH1F("high_phi_hist_05",      "high_phi_hist_05",      480, -0.10, 6.383185);                            // 25
     
-//    path_length             = new TH1F("path_length",               "path_length",             200, 382.0,  398.0);
-//    ttof                    = new TH1F("ttof",                      "time of flight",          500,  12.0,   20.0);
-//    alpha                   = new TH1F("alpha",                     "alpha",                  1000,     0,    4.0);
-//    theta                   = new TH1F("theta",                     "theta",                   100,  -7.0,    7.0);
-//    dca                     = new TH2F("dca",                       "dca",                     100,  -5.0,    5.0,     100,   -5.0,    5.0);
-//    generic                 = new TH1F("generic",                   "generic",                 4, -1,3);
-    //markc
+
+    dphi_pt_deut_10       = new TH2F("dphi_pt_deut_10",       "dphi_pt_deut_10",       160,  1.00,   5.00,     300, -1.6708,  4.8124);   // 26
+    dphi_et_deut_10       = new TH2F("dphi_et_deut_10",       "dphi_et_deut_10",       189,  1.00,   4.78,     300, -1.6708,  4.8124);   // 27
+    dphi_en_deut_10       = new TH2F("dphi_en_deut_10",       "dphi_en_deut_10",       189,  1.00,   4.78,     300, -1.6708,  4.8124);   // 28
+    dphi_kt_deut_10       = new TH2F("dphi_kt_deut_10",       "dphi_kt_deut_10",       189,  1.00,   4.78,     300, -1.6708,  4.8124);   // 29
+
+    dphi_pt_prot_10       = new TH2F("dphi_pt_prot_10",       "dphi_pt_prot_10",       160,  1.00,   5.00,     300, -1.6708,  4.8124);   // 30
+    dphi_et_prot_10       = new TH2F("dphi_et_prot_10",       "dphi_et_prot_10",       189,  1.00,   4.78,     300, -1.6708,  4.8124);   // 31
+    dphi_en_prot_10       = new TH2F("dphi_en_prot_10",       "dphi_en_prot_10",       189,  1.00,   4.78,     300, -1.6708,  4.8124);   // 32
+    dphi_kt_prot_10       = new TH2F("dphi_kt_prot_10",       "dphi_kt_prot_10",       189,  1.00,   4.78,     300, -1.6708,  4.8124);   // 33
+
+    dphi_pt_hadr_10       = new TH2F("dphi_pt_hadr_10",       "dphi_pt_hadr_10",       160,  1.00,   5.00,     300, -1.6708,  4.8124);   // 34
+    dphi_et_hadr_10       = new TH2F("dphi_et_hadr_10",       "dphi_et_hadr_10",       189,  1.00,   4.78,     300, -1.6708,  4.8124);   // 35
+    dphi_en_hadr_10       = new TH2F("dphi_en_hadr_10",       "dphi_en_hadr_10",       189,  1.00,   4.78,     300, -1.6708,  4.8124);   // 36
+    dphi_kt_hadr_10       = new TH2F("dphi_kt_hadr_10",       "dphi_kt_hadr_10",       189,  1.00,   4.78,     300, -1.6708,  4.8124);   // 37
+
+//  high_pt_count_10      = new TH1F("high_pt_count_10",      "high_pt_count_10",      160,  1.00,   5.00);                              // 38
+//  high_et_count_10      = new TH1F("high_et_count_10",      "high_et_count_10",      160,  1.00,   4.78);                              // 39
+//  high_en_count_10      = new TH1F("high_en_count_10",      "high_en_count_10",      160,  1.00,   4.78);                              // 40
+//  high_kt_count_10      = new TH1F("high_kt_count_10",      "high_kt_count_10",      160,  1.00,   4.78);                              // 41
+
+    deut_phi_hist_10      = new TH1F("deut_phi_hist_10",      "deut_phi_hist_10",      480, -0.10, 6.383185);                            // 42
+    prot_phi_hist_10      = new TH1F("prot_phi_hist_10",      "prot_phi_hist_10",      480, -0.10, 6.383185);                            // 43
+    hadr_phi_hist_10      = new TH1F("hadr_phi_hist_10",      "hadr_phi_hist_10",      480, -0.10, 6.383185);                            // 44
+    high_phi_hist_10      = new TH1F("high_phi_hist_10",      "high_phi_hist_10",      480, -0.10, 6.383185);                            // 45
+    
+    m2_cut                = new TH2F("m2_cut",                "m2_cut",                200,  1.00, 5.00,      400,    -1.00,    7.00);   // 46
 
 
     
@@ -351,58 +366,64 @@ void AliAnalysisTaskCorPIDTOFQA::UserCreateOutputObjects()
     fOutputList->Add(fHistPt);                //  1                                                             // objects added to output file
     fOutputList->Add(cent_ntracks);           //  2
     
-    fOutputList->Add(m2_pos);                 //  3
-    fOutputList->Add(m2_neg);                 //  4 
-    fOutputList->Add(beta_p_pos);             //  5
-    fOutputList->Add(beta_p_neg);             //  6
-    fOutputList->Add(deltat_p_pos);           //  7
-    fOutputList->Add(deltat_p_neg);           //  8
-    fOutputList->Add(dedx_p_pos);             //  9
-    fOutputList->Add(dedx_p_neg);             // 10
-    fOutputList->Add(dedx_deltat_pos);        // 11
-    fOutputList->Add(dedx_deltat_neg);        // 12
-    fOutputList->Add(dedx_p_deltat_pos);      // 13
-    fOutputList->Add(dedx_p_deltat_neg);      // 14
-    
-    fOutputList->Add(m2_pos_cut);             // 15
-    fOutputList->Add(m2_neg_cut);             // 16
-    fOutputList->Add(beta_p_pos_cut);         // 17
-    fOutputList->Add(beta_p_neg_cut);         // 18
-    fOutputList->Add(deltat_p_pos_cut);       // 19
-    fOutputList->Add(deltat_p_neg_cut);       // 20
-    fOutputList->Add(dedx_p_pos_cut);         // 21
-    fOutputList->Add(dedx_p_neg_cut);         // 22
-    fOutputList->Add(dedx_deltat_pos_cut);    // 23   
-    fOutputList->Add(dedx_deltat_neg_cut);    // 24
-    fOutputList->Add(dedx_p_deltat_pos_cut);  // 25  
-    fOutputList->Add(dedx_p_deltat_neg_cut);  // 26
-    fOutputList->Add(deut_dphi_T);            // 27
-    fOutputList->Add(deut_dphi_pos_T);        // 28
-    fOutputList->Add(deut_dphi_neg_T);        // 29
-    fOutputList->Add(deut_dphi_A);            // 30
-    fOutputList->Add(deut_dphi_pos_A);        // 31
-    fOutputList->Add(deut_dphi_neg_A);        // 32
-    fOutputList->Add(deut_dphi_B);            // 33
-    fOutputList->Add(deut_dphi_pos_B);        // 34
-    fOutputList->Add(deut_dphi_neg_B);        // 35
-    fOutputList->Add(deut_per_event);         // 36
-    fOutputList->Add(deut_per_event_pos);     // 37
-    fOutputList->Add(deut_per_event_neg);     // 38
-    fOutputList->Add(m2_pos_cut_T);           // 39
-    fOutputList->Add(m2_pos_cut_A);           // 40
-    fOutputList->Add(m2_pos_cut_B);	      // 41
-    fOutputList->Add(m2_neg_cut_T);           // 42
-    fOutputList->Add(m2_neg_cut_A);           // 43
-    fOutputList->Add(m2_neg_cut_B);           // 44
-    fOutputList->Add(dphi_ket_deut_T);        // 45
-    fOutputList->Add(dphi_ket_deut_A);        // 46
-    fOutputList->Add(dphi_ket_deut_B);        // 47
-    
-    fOutputList->Add(deltat_channel);         // 48
 
-    fOutputList->Add(deut_ket_count);               // 49
+    fOutputList->Add(high_per_event_05);      //  3a
+    fOutputList->Add(high_per_event_10);      //  3b
+    fOutputList->Add(high_per_event_pos);     //  4
+    fOutputList->Add(high_per_event_neg);     //  5
 
+    fOutputList->Add(dphi_pt_deut_05);        //  6
+    fOutputList->Add(dphi_et_deut_05);        //  7
+    fOutputList->Add(dphi_en_deut_05);        //  8
+    fOutputList->Add(dphi_kt_deut_05);        //  9
     
+    fOutputList->Add(dphi_pt_prot_05);        // 10
+    fOutputList->Add(dphi_et_prot_05);        // 11
+    fOutputList->Add(dphi_en_prot_05);        // 12
+    fOutputList->Add(dphi_kt_prot_05);        // 13
+
+    fOutputList->Add(dphi_pt_hadr_05);        // 14
+    fOutputList->Add(dphi_et_hadr_05);        // 15
+    fOutputList->Add(dphi_en_hadr_05);        // 16
+    fOutputList->Add(dphi_kt_hadr_05);        // 17
+    
+//  fOutputList->Add(high_pt_count_05);       // 18
+//  fOutputList->Add(high_et_count_05);       // 19
+//  fOutputList->Add(high_en_count_05);       // 20
+//  fOutputList->Add(high_kt_count_05);       // 21
+    
+    fOutputList->Add(deut_phi_hist_05);       // 22
+    fOutputList->Add(prot_phi_hist_05);       // 23
+    fOutputList->Add(hadr_phi_hist_05);       // 24
+    fOutputList->Add(high_phi_hist_05);       // 25
+
+    fOutputList->Add(dphi_pt_deut_10);        // 26
+    fOutputList->Add(dphi_et_deut_10);        // 27
+    fOutputList->Add(dphi_en_deut_10);        // 28
+    fOutputList->Add(dphi_kt_deut_10);        // 29
+    
+    fOutputList->Add(dphi_pt_prot_10);        // 30
+    fOutputList->Add(dphi_et_prot_10);        // 31
+    fOutputList->Add(dphi_en_prot_10);        // 32
+    fOutputList->Add(dphi_kt_prot_10);        // 33
+
+    fOutputList->Add(dphi_pt_hadr_10);        // 34
+    fOutputList->Add(dphi_et_hadr_10);        // 35
+    fOutputList->Add(dphi_en_hadr_10);        // 36
+    fOutputList->Add(dphi_kt_hadr_10);        // 37
+    
+//  fOutputList->Add(high_pt_count_10);       // 38
+//  fOutputList->Add(high_et_count_10);       // 39
+//  fOutputList->Add(high_en_count_10);       // 40
+//  fOutputList->Add(high_kt_count_10);       // 41
+    
+    fOutputList->Add(deut_phi_hist_10);       // 42
+    fOutputList->Add(prot_phi_hist_10);       // 43
+    fOutputList->Add(hadr_phi_hist_10);       // 44
+    fOutputList->Add(high_phi_hist_10);       // 45
+
+    fOutputList->Add(m2_cut);                 // 46
+
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     AliAnalysisManager *man            = AliAnalysisManager::GetAnalysisManager();                  //// added by Brennan
@@ -425,14 +446,10 @@ void AliAnalysisTaskCorPIDTOFQA::UserCreateOutputObjects()
 void AliAnalysisTaskCorPIDTOFQA::UserExec(Option_t *)
 {
 
-//    	Double_t pi = 3.1415926535897932384626434;
-
     fAOD = dynamic_cast<AliAODEvent*>(InputEvent());
     if(!fAOD) return;
 
     Int_t iTracks(fAOD->GetNumberOfTracks());
-
-
     
     //////////////////////////////////////// MULTIPLICITY PART ////////////////////////////////////////
 
@@ -442,19 +459,19 @@ void AliAnalysisTaskCorPIDTOFQA::UserExec(Option_t *)
 
 
 
+     
+    int NHigh_05             = 0;
+    int NHigh_pos            = 0;
+    int NHigh_neg            = 0;
+    int high_flag_05         = 0;
+
+    int high_track_num_05[100];
+
+    int NHigh_10             = 0;
+    int high_flag_10         = 0;
+
+    int high_track_num_10[100];
     
-    int NDeut           = 0;
-    int NDeut_pos       = 0;
-    int NDeut_neg       = 0;
-    int deut_flag_T          = 0;
-    int deut_flag_A          = 0;
-    int deut_flag_B          = 0;
-    int deut_track_num_T     = -9999;;
-    int deut_track_num_A     = -9999;;
-    int deut_track_num_B     = -9999;;
-    int associated_tracks   = 0;
-
-
 
 	
     struct track_node        // linked list, for efficient, dynamically allocated memory use
@@ -473,335 +490,84 @@ void AliAnalysisTaskCorPIDTOFQA::UserExec(Option_t *)
     // loop over all these tracks
     for(Int_t i(0); i < iTracks; i++)
     {
-//	NTracks++;
-
-
         AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(i));         // get a track (type AliAODTrack) from the event
         if(!track) continue;                                                       // if we failed, skip this track
 	if(!(track->IsHybridGlobalConstrainedGlobal())){   continue;   }
 
-	if(!track->IsPrimaryCandidate())   continue;
-
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////	
-	AliExternalTrackParam trkparam;
-	trkparam.CopyFromVTrack(track);
-	
-	if(trkparam.GetX() > 3.) continue; // only valid for propagation inside the beam pipe
-		
-	// impact parameters
-	Double_t b[2];
-	Double_t bCov[3];
-	if(!trkparam.PropagateToDCA(fAOD->GetPrimaryVertex(), fAOD->GetMagneticField(), 10000., b, bCov))   continue;
-	
-	Double_t dcaxy = b[0];
-	Double_t dcaz  = b[1];
-
-	if(fabs(dcaxy) > 3.0)   continue;
-	if(fabs(dcaz)  > 2.0)   continue;
-//	dca->Fill(dcaxy, dcaz);
-
-
-	UChar_t map = track->GetITSClusterMap();
-	Int_t nITSpoints = 0;
-	for(Int_t j=2; j<6; j++)
-	{
-		if(map&(1<<j)) ++nITSpoints;
-	}
-	
-
-	if(nITSpoints < 2)      continue;
-	
-	Short_t nTPCclusters     = track->GetTPCsignalN();
-	if(nTPCclusters<70)     continue;                          // No of TPC Clusters
-
-
-
-	
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////	
 
-//	if(!(track->TestFilterBit(AliAODTrack::kTrkGlobal)) ) { continue; }
-
-//	if(!fTrackSelection->IsTrackAccepted(track)){   continue;   }  // from markus' code
-//	if(!(track->TestFilterBit(AliAODTrack::klsHybridTPCCG)) ) { continue; }
-//	DCA_XY->Fill(track->XAtDCA(), track->YAtDCA());
-
-//	NGoodTracks++;
-//	associated_tracks++;
 	track_node *new_track = new track_node;
 	new_track->track_num = i;
 	new_track->next = NULL;
 	conductor->next = new_track;
 	conductor = conductor->next;
 
+	Double_t eta = track->Eta();                     	if(fabs(eta > 0.8))   continue;
 	
-	short isGlobal    = 1;
-	short isModGlobal = 0;  // is it suitable for deuteron candidate
-	
-	if(!(track->TestFilterBit(AliAODTrack::kTrkGlobal))){   isGlobal = 0;   }
-	
-	Double_t nsigmaTPC = 999.0;
-	Double_t nsigmaTOF = 999.0;
-
-	if(isGlobal == 1)  
-	{
-	    AliPIDResponse::EDetPidStatus statusTPC = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC, track, (AliPID::EParticleType) 0, nsigmaTPC);
-	    AliPIDResponse::EDetPidStatus statusTOF = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTOF, track, (AliPID::EParticleType) 0, nsigmaTOF);
-	    Bool_t tpcIsOk = (statusTPC == AliPIDResponse::kDetPidOk);     /* && trk->IsOn(AliESDtrack::kTPCpid)*/;
-	    Bool_t tofIsOk = (statusTOF == AliPIDResponse::kDetPidOk);
-
-	    if(tpcIsOk  && tofIsOk){   isModGlobal = 1;   }
-	    else                   {   isModGlobal = 0;   }
-		
-	}
-
-
-
-//	if(tpcIsOk  &&  tofIsOk)
-//	if(tofIsOk)
-//	{
-
-	    
-	Double_t mom            = track->P();
-//	Double_t energy         = track->E();
-//	float    mass           = track->M();
 	float    pt             = track->Pt();
-//	Double_t tpc_mom        = track->GetTPCmomentum();
 	Short_t  charge         = track->Charge();
-//	Double_t eta            = track->Eta();
-
-	Double_t sigma_min      = -999.0;
-	int      id             = 14;
-	Double_t deut_mean      = 0.0;
-	Double_t deut_sigma     = 0.0;
-	Double_t cut_width      = 1.0;
-
-	Double_t phi = track->Phi();
-	Double_t eta = track->Eta();
-
-
-	if(fabs(eta > 0.8))   continue;
-
-	   
-	if(phi <  -TMath::PiOver2())    phi = phi + TMath::TwoPi();			if(phi <  -TMath::PiOver2())    phi = phi + TMath::TwoPi();
-	if(phi > 3*TMath::PiOver2())    phi = phi - TMath::TwoPi();			if(phi > 3*TMath::PiOver2())    phi = phi - TMath::TwoPi();
 
 
 	fHistPt->Fill(pt);
-//	if(pt >= 0.3  &&  pt < 5)   alpha->Fill(1/pt);
+ 
 
-//	if(pt >= 1.0  &&  pt < 1.05)   cout<<fPIDResponse->GetTOFResponse().GetTOFchannel(track)<<endl;
-
-	// markc
-	if(isModGlobal == 1)
+	    
+	if(charge > 0)
 	{
-	    Double_t m2tof = get_mass_squared(track);
-	    Float_t dedx   = track->GetTPCsignal();
-	    Float_t deltat = tof_minus_tpion(track);
-
-
-//    kElectron =  0;
-//    kMuon     =  1;
-//    kPion     =  2;
-//    kKaon     =  3;
-//    kProton   =  4;
-//    kDeuteron =  5;
-//    kTriton   =  6;
-//    kHe3      =  7;
-//    kAlpha    =  8;
-//    kPhoton   =  9;
-//    kPi0      = 10;
-//    kNeutron  = 11;
-//    kKaon0    = 12;
-//    kEleCon   = 13;
-//    kUnknown  = 14;  
-
-	    
-	    ////  markA
-
-	    Float_t beta_kaon = 0.0;
-	    Float_t beta      = 0.0;
-
-	    beta      = Beta(track);
-	    beta_kaon = mom / sqrt(0.2437169 + pow(mom,2));  // mass-squared of kaon is 0.2437169
-	    
-	    if(charge > 0)
+	    if(pt > 5.0)
 	    {
-		m2_pos->Fill(        pt, m2tof);
-		beta_p_pos->Fill(   mom, Beta(track));
-		dedx_p_pos->Fill(   mom, dedx);
-		if(mom >= 2.0  &&  mom < 3.0)    dedx_deltat_pos->Fill(deltat, dedx);
-		dedx_p_deltat_pos->Fill(dedx, mom, deltat);
-//		dedx_p_m2_pos->Fill(dedx, mom, m2tof);
-		deltat_p_pos->Fill(  pt, deltat);
-
-		
-		if(dedx > 7.91143*deltat+28.8714  &&  deltat > 0.07216*dedx-5.11340  &&  isGlobal == 1)
-		{
-		    if(    (1.0 <= deltat  &&  deltat < 6.0  &&  dedx <   9.6774*deltat+46.7742)
-		       ||  (0.5 <= deltat  &&  deltat < 1.0  &&  dedx <  56.4516)
-		       ||  (0.5 >  deltat  &&                    dedx <  56.4516)
-		       ||  (6.0 <= deltat  &&                    dedx <  12.9032*deltat+27.4193)
-			   )
-		    {
-			AliPIDResponse::EDetPidStatus statusTPC = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC, track, (AliPID::EParticleType) 5, nsigmaTPC);
-			if(nsigmaTPC <= 2.0)
-			{
-			    m2_pos_cut->Fill(        pt, m2tof);
-			    beta_p_pos_cut->Fill(   mom, Beta(track));
-			    deltat_p_pos_cut->Fill(  pt, deltat);
-			    dedx_p_pos_cut->Fill(   mom, dedx);
-			    if(mom >= 2.0  &&  mom < 3.0)    dedx_deltat_pos_cut->Fill(deltat, dedx);
-			    dedx_p_deltat_pos_cut->Fill(dedx, mom, deltat);
-//			    dedx_p_m2_pos_cut->Fill(dedx, mom, m2tof);
-			}
-		    }
-
-		    Int_t channel           = 0;
-		    channel                 = fPIDResponse->GetTOFResponse().GetTOFchannel(track);
-//		    Double_t xy_length      = 0.00;
-//		    xy_length               = length * TMath::Sin(track_theta);
-
-		    if(channel > -1  &&  channel < 4801)
-		    {
-			if(pt >= 0.995  &&  pt < 1.005)
-			{
-			    if(deltat >= -0.6  &&  deltat < 0.6)
-			    {
-				deltat_channel->Fill(channel, deltat);
-			    }
-			}
-		    }
-
-		    
-		    if(mom >= 1.5  &&  mom < 4.4)
-		    {
-			for(int w=0; w<3; w++){   fit_deut_curve->SetParameter(w, deut_curves[0][0][w]);   }
-			deut_mean = fit_deut_curve->Eval(mom);
-			for(int w=0; w<3; w++){   fit_deut_curve->SetParameter(w, deut_curves[0][1][w]);   }
-			deut_sigma = fit_deut_curve->Eval(mom);
-
-			if(m2tof < deut_mean + cut_width * deut_sigma  &&   m2tof > deut_mean - cut_width * deut_sigma)
-			{
-			    m2_pos_cut_T->Fill(mom,m2tof);
-			    deut_track_num_T = i;
-			    // deut_track_num_pos_T = i;
-			    NDeut++;
-			    NDeut_pos++;
-			    deut_flag_T = 1;
-			}
-			else if(m2tof < deut_mean -1 + cut_width * deut_sigma  &&   m2tof > deut_mean -1 - cut_width * deut_sigma)
-			{
-			    m2_pos_cut_A->Fill(mom,m2tof);
-			    deut_flag_A = 1;
-			    deut_track_num_A = i;
-			}
-			else if(m2tof < deut_mean +1 + cut_width * deut_sigma  &&   m2tof > deut_mean +1 - cut_width * deut_sigma)
-			{
-			    m2_pos_cut_B->Fill(mom,m2tof);
-			    deut_flag_B = 1;
-			    deut_track_num_B = i;
-			}		    
-		    }
-		    
-
-		
-
-		}
+		high_track_num_05[NHigh_05] = i;
+		NHigh_05++;
+		NHigh_pos++;
+		high_flag_05 = 1;
+	    }
+	    if(pt > 10.0)
+	    {
+		high_track_num_10[NHigh_10] = i;
+		NHigh_10++;
+		high_flag_10 = 1;
 	    }
 	    
-	    else if(charge < 0)
+	}
+	    
+	else if(charge < 0)
+	{
+	    if(pt > 5.0)
 	    {
-		m2_neg->Fill(      pt,m2tof);
-		beta_p_neg->Fill(   mom, Beta(track));
-		dedx_p_neg->Fill(   mom, dedx);
-		if(mom >= 2.0  &&  mom < 3.0)    dedx_deltat_neg->Fill(deltat, dedx);
-		dedx_p_deltat_neg->Fill(dedx, mom, deltat);
-//		dedx_p_m2_neg->Fill(dedx, mom, m2tof);
-		deltat_p_neg->Fill(  pt, deltat);
-
-		
-		if(dedx > 7.91143*deltat+28.8714  &&  deltat > 0.07216*dedx-5.11340  &&  isGlobal == 1)
-		{
-		    if(    (1.0 <= deltat  &&  deltat < 6.0  &&  dedx <   9.6774*deltat+46.7742)
-		       ||  (0.5 <= deltat  &&  deltat < 1.0  &&  dedx <  56.4516)
-		       ||  (0.5 >  deltat  &&                    dedx <  56.4516)
-		       ||  (6.0 <= deltat  &&                    dedx <  12.9032*deltat+27.4193)
-			   )
-		    {
-			AliPIDResponse::EDetPidStatus statusTPC = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC, track, (AliPID::EParticleType) 5, nsigmaTPC);
-			if(nsigmaTPC <= 2.0)
-			{	
-			    m2_neg_cut->Fill(      pt, m2tof);
-			    beta_p_neg_cut->Fill(   mom, Beta(track));
-			    deltat_p_neg_cut->Fill(  pt, deltat);
-			    dedx_p_neg_cut->Fill(   mom, dedx);
-			    if(mom >= 2.0  &&  mom < 3.0)    dedx_deltat_neg_cut->Fill(deltat, dedx);
-			    dedx_p_deltat_neg_cut->Fill(dedx, mom, deltat);
-			}
-		    }
-
-		    if(mom >= 1.5  &&  mom < 4.4)
-		    {
-			for(int w=0; w<3; w++){   fit_deut_curve->SetParameter(w, deut_curves[0][0][w]);   }
-			deut_mean = fit_deut_curve->Eval(mom);
-			for(int w=0; w<3; w++){   fit_deut_curve->SetParameter(w, deut_curves[0][1][w]);   }
-			deut_sigma = fit_deut_curve->Eval(mom);
-
-			if(m2tof < deut_mean + cut_width * deut_sigma  &&   m2tof > deut_mean - cut_width * deut_sigma)
-			{
-			    m2_neg_cut_T->Fill(mom,m2tof);
-			    deut_track_num_T = i;
-			    // deut_track_num_neg_T = i;
-			    NDeut++;
-			    NDeut_neg++;
-			    deut_flag_T = 1;
-			}
-			else if(m2tof < deut_mean -1 + cut_width * deut_sigma  &&   m2tof > deut_mean -1 - cut_width * deut_sigma)
-			{
-			    m2_neg_cut_A->Fill(mom,m2tof);
-			    deut_flag_A = 1;
-			    deut_track_num_A = i;
-			}
-			else if(m2tof < deut_mean +1 + cut_width * deut_sigma  &&   m2tof > deut_mean +1 - cut_width * deut_sigma)
-			{
-			    m2_neg_cut_B->Fill(mom,m2tof);
-			    deut_flag_B = 1;
-			    deut_track_num_B = i;
-			}		    
-		    }
-		    
-		    
-		}
+		high_track_num_05[NHigh_05] = i;
+		NHigh_05++;
+		NHigh_neg++;
+		high_flag_05 = 1;
 	    }
-	}    //   track has both TPC and TOF PID, tracks are o.k.
+	    if(pt > 10.0)
+	    {
+		high_track_num_10[NHigh_10] = i;
+		NHigh_10++;
+		high_flag_10 = 1;
+	    }
+	}
     }        //   end of track loop
 
 
-    deut_per_event->Fill(NDeut);
-    deut_per_event_pos->Fill(NDeut_pos);
-    deut_per_event_neg->Fill(NDeut_neg);
+    high_per_event_05->Fill(NHigh_05);
+    high_per_event_10->Fill(NHigh_10);
+    high_per_event_pos->Fill(NHigh_pos);
+    high_per_event_neg->Fill(NHigh_neg);
 
-    if(deut_flag_T > 0)
+
+
+    
+    for(int ii=0; ii < high_flag_05; ii++)
     {
-//	DeuteronCandidates++;
-	int j = deut_track_num_T;
+	int j = high_track_num_05[ii];
 
 	AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(j));
 	if(!track) {}
 	else
 	{
-	    Double_t deut_phi = track->Phi();
-	    Double_t deut_mom = track->P();
-	    Double_t deut_pt  = track->Pt();
-	    Short_t  charge   = track->Charge();
-	    Double_t deut_eta = track->Eta();
-
-	    Double_t deut_ket = 0.0;
+	    Double_t high_phi = track->Phi();
 	    
-	    deut_ket = sqrt(pow(deut_pt,2) + pow(1.87561,2)) - 1.87561;
-
-	    deut_ket_count->Fill(deut_ket);
-
+	    high_phi_hist_05->Fill(high_phi);
 	    
 	    conductor = root->next;
 	    if (conductor != 0)
@@ -810,101 +576,354 @@ void AliAnalysisTaskCorPIDTOFQA::UserExec(Option_t *)
 		{
 		    int k = conductor->track_num;
 		    conductor = conductor->next;
-		    
-		    if(k != j)  // if the k-th track is not the j-th track which is the deuteron of interest
+
+		    short match = 0;
+		    for(int kk=0; kk < high_flag_05; kk++)
 		    {
-//		    NAssociatedTracks++;
+			if(k == high_track_num_05[kk])   match = 1;
+		    }
+
+		    
+		    if(match == 0)  // if the k-th track is not the j-th track which is the trigger particle of interest
+		    {
 			AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(k));         // get a track (type AliAODTrack) from the event
 			if(!track){}                                                               // if we failed, skip this track
 			else
 			{
-			    Double_t mom            = track->P();
-			    Double_t phi            = track->Phi();
-			    
+			    Double_t pt             = track->Pt();
 
-			    if(mom > 2.0  &&  mom < 5.0)
+			    
+			    if(pt > 1.1  &&  pt < 4.4)
 			    {
-				Double_t dphi = deut_phi - phi;
-				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
-				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+				short isGlobal    = 1;
+				short isModGlobal = 0;  // is it suitable for deuteron candidate
+	
+				if(!(track->TestFilterBit(AliAODTrack::kTrkGlobal))){   isGlobal = 0;   }
+	
+				Double_t nsigmaTPC = 999.0;
+				Double_t nsigmaTOF = 999.0;
+
+				if(isGlobal == 1)  
+				{
+				    AliPIDResponse::EDetPidStatus statusTPC = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC, track, (AliPID::EParticleType) 0, nsigmaTPC);
+				    AliPIDResponse::EDetPidStatus statusTOF = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTOF, track, (AliPID::EParticleType) 0, nsigmaTOF);
+				    Bool_t tpcIsOk = (statusTPC == AliPIDResponse::kDetPidOk);  
+				    Bool_t tofIsOk = (statusTOF == AliPIDResponse::kDetPidOk);
+
+				    if(tpcIsOk  && tofIsOk){   isModGlobal = 1;   }
+				    else                   {   isModGlobal = 0;   }
+				}
+
+				if(isModGlobal == 1)
+				{
+				    AliPIDResponse::EDetPidStatus statusTPC = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC, track, (AliPID::EParticleType) 5, nsigmaTPC);
+				    if(nsigmaTPC <= 2.0)
+				    {					
+					Double_t deut_mean      = 0.00;
+					Double_t deut_sigma     = 0.00;
+					Double_t cut_width      = 1.00;
+
+					Double_t mom   = track->P();
+					Double_t m2tof = 0.00;
+					m2tof = get_mass_squared(track);
+					
+					for(int w=0; w<3; w++){   fit_deut_curve->SetParameter(w, deut_curves[0][0][w]);   }
+					deut_mean = fit_deut_curve->Eval(mom);
+					for(int w=0; w<3; w++){   fit_deut_curve->SetParameter(w, deut_curves[0][1][w]);   }
+					deut_sigma = fit_deut_curve->Eval(mom);
+					
+					if(m2tof < deut_mean + cut_width * deut_sigma  &&   m2tof > deut_mean - cut_width * deut_sigma)
+					{
+//					    Double_t mom            = track->P();
+					    Double_t phi            = track->Phi();
+
+					    Double_t et = 0.00;
+					    Double_t en = 0.00;
+					    Double_t kt = 0.00;
+	    
+					    et = sqrt(pow(pt ,2) + pow(1.87561,2));
+					    en = sqrt(pow(mom,2) + pow(1.87561,2));
+					    kt = sqrt(pow(pt ,2) + pow(1.87561,2)) - 1.87561;
 				
-				deut_dphi_T->Fill(deut_mom, dphi);
+					    Double_t dphi = 0.00;
+					    dphi = high_phi - phi;
 				
-				if(charge>0) {   deut_dphi_pos_T->Fill(deut_mom, dphi);   }
-				if(charge<0) {   deut_dphi_neg_T->Fill(deut_mom, dphi);   }
-				dphi_ket_deut_T->Fill(deut_ket, dphi);
+					    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+					    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+					    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+					    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
 				
+					    dphi_pt_deut_05->Fill(pt, dphi);
+					    dphi_et_deut_05->Fill(et, dphi);
+					    dphi_en_deut_05->Fill(en, dphi);
+					    dphi_kt_deut_05->Fill(kt, dphi);
+					    
+					    deut_phi_hist_05->Fill(phi);
+
+					    m2_cut->Fill(pt, m2tof);
+					}
+				    }
+				    statusTPC = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC, track, (AliPID::EParticleType) 4, nsigmaTPC);
+				    if(nsigmaTPC <= 2.0)
+				    {					
+					Double_t prot_mean      = 0.00;
+					Double_t prot_sigma     = 0.00;
+					Double_t cut_width      = 1.00;
+				    
+					Double_t mom            = track->P();
+					Double_t m2tof          = 0.00;
+					
+					m2tof = get_mass_squared(track);
+					
+					for(int w=0; w<4; w++){   fit_prot_curve->SetParameter(w, prot_curves[0][0][w]);   }
+					prot_mean = fit_prot_curve->Eval(mom);
+					for(int w=0; w<4; w++){   fit_prot_curve->SetParameter(w, prot_curves[0][1][w]);   }
+					prot_sigma = fit_prot_curve->Eval(mom);
+					
+					if(m2tof < prot_mean + cut_width * prot_sigma  &&   m2tof > prot_mean - cut_width * prot_sigma)
+					{
+					    Double_t phi            = track->Phi();
+					    
+					    Double_t et = 0.00;
+					    Double_t en = 0.00;
+					    Double_t kt = 0.00;
+					    
+					    et = sqrt(pow(pt ,2) + pow(0.93827,2));
+					    en = sqrt(pow(mom,2) + pow(0.93827,2));
+					    kt = sqrt(pow(pt ,2) + pow(0.93827,2)) - 0.93827;
+					    
+					    Double_t dphi = 0.00;
+					    dphi = high_phi - phi;
+					    
+					    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+					    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+					    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+					    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+					    
+					    dphi_pt_prot_05->Fill(pt, dphi);
+					    dphi_et_prot_05->Fill(et, dphi);
+					    dphi_en_prot_05->Fill(en, dphi);
+					    dphi_kt_prot_05->Fill(kt, dphi);
+					    
+					    prot_phi_hist_05->Fill(phi);
+
+					    m2_cut->Fill(pt, m2tof);
+					}
+				    }
+
+				    Double_t phi = track->Phi();
+				    Double_t mom = track->P();
+				    Double_t et  = 0.00;
+				    Double_t en  = 0.00;
+				    Double_t kt  = 0.00;
+
+				    et = sqrt(pow(pt ,2) + pow(0.29026,2));
+				    en = sqrt(pow(mom,2) + pow(0.29026,2));
+				    kt = sqrt(pow(pt ,2) + pow(0.29026,2)) - 0.29026;
+					    
+				    Double_t dphi = 0.00;
+				    dphi = high_phi - phi;
+					    
+				    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+				    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+				    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+				    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+					    
+				    dphi_pt_hadr_05->Fill(pt, dphi);
+				    dphi_et_hadr_05->Fill(et, dphi);
+				    dphi_en_hadr_05->Fill(en, dphi);
+				    dphi_kt_hadr_05->Fill(kt, dphi);
+				    
+				    hadr_phi_hist_05->Fill(phi);
+				}
 			    }
 			}
 		    }
 		}
 	    
+	    
 		int k = conductor->track_num;
 		conductor = conductor->next;
-//	    NAssociatedTracks++;
-		if(k != j)  // if the k-th track is not the j-th track which is the deuteron of interest
+	
+		short match = 0;
+		for(int kk=0; kk < high_flag_05; kk++)
+		{
+		    if(k == high_track_num_05[kk])   match = 1;
+		}
+
+		    
+		if(match == 0)  // if the k-th track is not the j-th track which is the trigger particle of interest
 		{
 		    AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(k));         // get a track (type AliAODTrack) from the event
 		    if(!track){}                                                               // if we failed, skip this track
 		    else
 		    {
-			Double_t mom            = track->P();
-			Double_t phi            = track->Phi();
-			
-			if(mom > 2.0  &&  mom < 5.0)
+			Double_t pt             = track->Pt();
+
+			    
+			if(pt > 1.1  &&  pt < 4.4)
 			{
-			    Double_t dphi = deut_phi - phi;
-			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
-			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
-			    
-			    deut_dphi_T->Fill(deut_mom, dphi);
-			    if(charge>0) {   deut_dphi_pos_T->Fill(deut_mom, dphi);   }
-			    if(charge<0) {   deut_dphi_neg_T->Fill(deut_mom, dphi);   }
-			    dphi_ket_deut_T->Fill(deut_ket, dphi);
+			    short isGlobal    = 1;
+			    short isModGlobal = 0;  // is it suitable for deuteron candidate
+	
+			    if(!(track->TestFilterBit(AliAODTrack::kTrkGlobal))){   isGlobal = 0;   }
+	
+			    Double_t nsigmaTPC = 999.0;
+			    Double_t nsigmaTOF = 999.0;
+
+			    if(isGlobal == 1)  
+			    {
+				AliPIDResponse::EDetPidStatus statusTPC = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC, track, (AliPID::EParticleType) 0, nsigmaTPC);
+				AliPIDResponse::EDetPidStatus statusTOF = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTOF, track, (AliPID::EParticleType) 0, nsigmaTOF);
+				Bool_t tpcIsOk = (statusTPC == AliPIDResponse::kDetPidOk);  
+				Bool_t tofIsOk = (statusTOF == AliPIDResponse::kDetPidOk);
+				
+				if(tpcIsOk  && tofIsOk){   isModGlobal = 1;   }
+				else                   {   isModGlobal = 0;   }
+			    }
+
+			    if(isModGlobal == 1)
+			    {
+				AliPIDResponse::EDetPidStatus statusTPC = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC, track, (AliPID::EParticleType) 5, nsigmaTPC);
+				if(nsigmaTPC <= 2.0)
+				{					
+				    Double_t deut_mean      = 0.0;
+				    Double_t deut_sigma     = 0.0;
+				    Double_t cut_width      = 1.0;
+				    
+				    Double_t mom   = track->P();
+				    Double_t m2tof = 0.00;
+				    m2tof = get_mass_squared(track);
+					
+				    for(int w=0; w<3; w++){   fit_deut_curve->SetParameter(w, deut_curves[0][0][w]);   }
+				    deut_mean = fit_deut_curve->Eval(mom);
+				    for(int w=0; w<3; w++){   fit_deut_curve->SetParameter(w, deut_curves[0][1][w]);   }
+				    deut_sigma = fit_deut_curve->Eval(mom);
+					
+				    if(m2tof < deut_mean + cut_width * deut_sigma  &&   m2tof > deut_mean - cut_width * deut_sigma)
+				    {
+					Double_t phi            = track->Phi();
+
+					Double_t et = 0.00;
+					Double_t en = 0.00;
+					Double_t kt = 0.00;
+	    
+					et = sqrt(pow(pt ,2) + pow(1.87561,2));
+					en = sqrt(pow(mom,2) + pow(1.87561,2));
+					kt = sqrt(pow(pt ,2) + pow(1.87561,2)) - 1.87561;
+				
+					Double_t dphi = 0.00;
+					dphi = high_phi - phi;
+				
+					if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+					if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+					if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+					if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+				
+					dphi_pt_deut_05->Fill(pt, dphi);
+					dphi_et_deut_05->Fill(et, dphi);
+					dphi_en_deut_05->Fill(en, dphi);
+					dphi_kt_deut_05->Fill(kt, dphi);
+
+					deut_phi_hist_05->Fill(phi);
+
+					m2_cut->Fill(pt, m2tof);
+				    }
+				}
+
+				statusTPC = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC, track, (AliPID::EParticleType) 4, nsigmaTPC);
+				if(nsigmaTPC <= 2.0)
+				{					
+				    Double_t prot_mean      = 0.0;
+				    Double_t prot_sigma     = 0.0;
+				    Double_t cut_width      = 1.0;
+				    
+				    Double_t mom   = track->P();
+				    Double_t m2tof = 0.00;
+				    m2tof = get_mass_squared(track);
+					
+				    for(int w=0; w<4; w++){   fit_prot_curve->SetParameter(w, prot_curves[0][0][w]);   }
+				    prot_mean = fit_prot_curve->Eval(mom);
+				    for(int w=0; w<4; w++){   fit_prot_curve->SetParameter(w, prot_curves[0][1][w]);   }
+				    prot_sigma = fit_prot_curve->Eval(mom);
+					
+				    if(m2tof < prot_mean + cut_width * prot_sigma  &&   m2tof > prot_mean - cut_width * prot_sigma)
+				    {
+					Double_t phi            = track->Phi();
+
+					Double_t et = 0.00;
+					Double_t en = 0.00;
+					Double_t kt = 0.00;
+	
+					et = sqrt(pow(pt ,2) + pow(0.93827,2));
+					en = sqrt(pow(mom,2) + pow(0.93827,2));
+					kt = sqrt(pow(pt ,2) + pow(0.93827,2)) - 0.93827;
+				
+					Double_t dphi = 0.00;
+					dphi = high_phi - phi;
+				
+					if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+					if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+					if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+					if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+				
+					dphi_pt_prot_05->Fill(pt, dphi);
+					dphi_et_prot_05->Fill(et, dphi);
+					dphi_en_prot_05->Fill(en, dphi);
+					dphi_kt_prot_05->Fill(kt, dphi);
+
+					prot_phi_hist_05->Fill(phi);
+
+					m2_cut->Fill(pt, m2tof);
+				    }
+				}
+
+				
+				Double_t phi = track->Phi();
+				Double_t mom = track->P();
+				Double_t et = 0.00;
+				Double_t en = 0.00;
+				Double_t kt = 0.00;
+
+				et = sqrt(pow(pt ,2) + pow(0.29026,2));
+				en = sqrt(pow(mom,2) + pow(0.29026,2));
+				kt = sqrt(pow(pt ,2) + pow(0.29026,2)) - 0.29026;
+					    
+				Double_t dphi = 0.00;
+				dphi = high_phi - phi;
+					    
+				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+					    
+				dphi_pt_hadr_05->Fill(pt, dphi);
+				dphi_et_hadr_05->Fill(et, dphi);
+				dphi_en_hadr_05->Fill(en, dphi);
+				dphi_kt_hadr_05->Fill(kt, dphi);
+				    
+				hadr_phi_hist_05->Fill(phi);
+			    }
 			}
-//			if(deut_mom >= 3.25  &&  deut_mom < 4.25)
-//			{
-//			    Double_t eta            = track->Eta();			    
-//			    Double_t dphi = deut_phi - phi;
-//			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-//			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-//			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
-//			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
-			    
-//			    if(     mom >= 0.5  &&  mom < 1.0){   deut_dphi_deta_p0510->Fill(dphi, deut_eta - eta);    }
-//			    else if(mom >= 1.0  &&  mom < 2.0){   deut_dphi_deta_p1020->Fill(dphi, deut_eta - eta);    }
-//			    else if(mom >= 2.0  &&  mom < 3.0){   deut_dphi_deta_p2030->Fill(dphi, deut_eta - eta);    }
-//			    if(     mom >= 1.0  &&  mom < 5.0){   deut_dphi_deta_p1050->Fill(dphi, deut_eta - eta);    }
-//			}
 		    }
 		}
 	    }
 	}
-    }  // end of deuteron correlation PRIMARY LOOP
+    }  // end of high-pt correlation PRIMARY LOOP
 
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    if(deut_flag_A > 0)
+    for(int ii=0; ii < high_flag_10; ii++)
     {
-//	DeuteronCandidates++;
-	int j = deut_track_num_A;
+	int j = high_track_num_10[ii];
 
 	AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(j));
 	if(!track) {}
 	else
 	{
-	    Double_t deut_phi = track->Phi();
-	    Double_t deut_mom = track->P();
-	    Double_t deut_pt  = track->Pt();
-	    Short_t  charge   = track->Charge();
-	    Double_t deut_eta = track->Eta();
-
-	    Double_t deut_ket = 0.0;
+	    Double_t high_phi = track->Phi();
 	    
-	    deut_ket = sqrt(pow(deut_pt,2) + pow(1.87561,2)) - 1.87561;
+	    high_phi_hist_10->Fill(high_phi);
 	    
 	    conductor = root->next;
 	    if (conductor != 0)
@@ -913,215 +932,333 @@ void AliAnalysisTaskCorPIDTOFQA::UserExec(Option_t *)
 		{
 		    int k = conductor->track_num;
 		    conductor = conductor->next;
-		    
-		    if(k != j)  // if the k-th track is not the j-th track which is the deuteron of interest
+
+		    short match = 0;
+		    for(int kk=0; kk < high_flag_10; kk++)
 		    {
-//		    NAssociatedTracks++;
+			if(k == high_track_num_10[kk])   match = 1;
+		    }
+
+		    
+		    if(match == 0)  // if the k-th track is not the j-th track which is the trigger particle of interest
+		    {
 			AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(k));         // get a track (type AliAODTrack) from the event
 			if(!track){}                                                               // if we failed, skip this track
 			else
 			{
-			    Double_t mom            = track->P();
-			    Double_t phi            = track->Phi();
-			    
+			    Double_t pt             = track->Pt();
 
-			    if(mom > 2.0  &&  mom < 5.0)
+			    
+			    if(pt > 1.1  &&  pt < 4.4)
 			    {
-				Double_t dphi = deut_phi - phi;
-				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
-				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+				short isGlobal    = 1;
+				short isModGlobal = 0;  // is it suitable for deuteron candidate
+	
+				if(!(track->TestFilterBit(AliAODTrack::kTrkGlobal))){   isGlobal = 0;   }
+	
+				Double_t nsigmaTPC = 999.0;
+				Double_t nsigmaTOF = 999.0;
+
+				if(isGlobal == 1)  
+				{
+				    AliPIDResponse::EDetPidStatus statusTPC = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC, track, (AliPID::EParticleType) 0, nsigmaTPC);
+				    AliPIDResponse::EDetPidStatus statusTOF = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTOF, track, (AliPID::EParticleType) 0, nsigmaTOF);
+				    Bool_t tpcIsOk = (statusTPC == AliPIDResponse::kDetPidOk);  
+				    Bool_t tofIsOk = (statusTOF == AliPIDResponse::kDetPidOk);
+
+				    if(tpcIsOk  && tofIsOk){   isModGlobal = 1;   }
+				    else                   {   isModGlobal = 0;   }
+				}
+
+				if(isModGlobal == 1)
+				{
+				    AliPIDResponse::EDetPidStatus statusTPC = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC, track, (AliPID::EParticleType) 5, nsigmaTPC);
+				    if(nsigmaTPC <= 2.0)
+				    {					
+					Double_t deut_mean      = 0.00;
+					Double_t deut_sigma     = 0.00;
+					Double_t cut_width      = 1.00;
+
+					Double_t mom   = track->P();
+					Double_t m2tof = 0.00;
+					m2tof = get_mass_squared(track);
+					
+					for(int w=0; w<3; w++){   fit_deut_curve->SetParameter(w, deut_curves[0][0][w]);   }
+					deut_mean = fit_deut_curve->Eval(mom);
+					for(int w=0; w<3; w++){   fit_deut_curve->SetParameter(w, deut_curves[0][1][w]);   }
+					deut_sigma = fit_deut_curve->Eval(mom);
+					
+					if(m2tof < deut_mean + cut_width * deut_sigma  &&   m2tof > deut_mean - cut_width * deut_sigma)
+					{
+//					    Double_t mom            = track->P();
+					    Double_t phi            = track->Phi();
+
+					    Double_t et = 0.00;
+					    Double_t en = 0.00;
+					    Double_t kt = 0.00;
+	    
+					    et = sqrt(pow(pt ,2) + pow(1.87561,2));
+					    en = sqrt(pow(mom,2) + pow(1.87561,2));
+					    kt = sqrt(pow(pt ,2) + pow(1.87561,2)) - 1.87561;
 				
-				deut_dphi_A->Fill(deut_mom, dphi);
+					    Double_t dphi = 0.00;
+					    dphi = high_phi - phi;
 				
-				if(charge>0) {   deut_dphi_pos_A->Fill(deut_mom, dphi);   }
-				if(charge<0) {   deut_dphi_neg_A->Fill(deut_mom, dphi);   }
-				dphi_ket_deut_A->Fill(deut_ket, dphi);
+					    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+					    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+					    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+					    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
 				
+					    dphi_pt_deut_10->Fill(pt, dphi);
+					    dphi_et_deut_10->Fill(et, dphi);
+					    dphi_en_deut_10->Fill(en, dphi);
+					    dphi_kt_deut_10->Fill(kt, dphi);
+					    
+					    deut_phi_hist_10->Fill(phi);
+					}
+				    }
+				    statusTPC = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC, track, (AliPID::EParticleType) 4, nsigmaTPC);
+				    if(nsigmaTPC <= 2.0)
+				    {					
+					Double_t prot_mean      = 0.00;
+					Double_t prot_sigma     = 0.00;
+					Double_t cut_width      = 1.00;
+				    
+					Double_t mom            = track->P();
+					Double_t m2tof          = 0.00;
+					
+					m2tof = get_mass_squared(track);
+					
+					for(int w=0; w<4; w++){   fit_prot_curve->SetParameter(w, prot_curves[0][0][w]);   }
+					prot_mean = fit_prot_curve->Eval(mom);
+					for(int w=0; w<4; w++){   fit_prot_curve->SetParameter(w, prot_curves[0][1][w]);   }
+					prot_sigma = fit_prot_curve->Eval(mom);
+					
+					if(m2tof < prot_mean + cut_width * prot_sigma  &&   m2tof > prot_mean - cut_width * prot_sigma)
+					{
+					    Double_t phi            = track->Phi();
+					    
+					    Double_t et = 0.00;
+					    Double_t en = 0.00;
+					    Double_t kt = 0.00;
+					    
+					    et = sqrt(pow(pt ,2) + pow(0.93827,2));
+					    en = sqrt(pow(mom,2) + pow(0.93827,2));
+					    kt = sqrt(pow(pt ,2) + pow(0.93827,2)) - 0.93827;
+					    
+					    Double_t dphi = 0.00;
+					    dphi = high_phi - phi;
+					    
+					    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+					    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+					    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+					    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+					    
+					    dphi_pt_prot_10->Fill(pt, dphi);
+					    dphi_et_prot_10->Fill(et, dphi);
+					    dphi_en_prot_10->Fill(en, dphi);
+					    dphi_kt_prot_10->Fill(kt, dphi);
+					    
+					    prot_phi_hist_10->Fill(phi);
+					}
+				    }
+
+				    Double_t phi            = track->Phi();
+				    Double_t mom = track->P();
+				    Double_t et = 0.00;
+				    Double_t en = 0.00;
+				    Double_t kt = 0.00;
+
+				    et = sqrt(pow(pt ,2) + pow(0.29026,2));
+				    en = sqrt(pow(mom,2) + pow(0.29026,2));
+				    kt = sqrt(pow(pt ,2) + pow(0.29026,2)) - 0.29026;
+					    
+				    Double_t dphi = 0.00;
+				    dphi = high_phi - phi;
+					    
+				    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+				    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+				    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+				    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+					    
+				    dphi_pt_hadr_10->Fill(pt, dphi);
+				    dphi_et_hadr_10->Fill(et, dphi);
+				    dphi_en_hadr_10->Fill(en, dphi);
+				    dphi_kt_hadr_10->Fill(kt, dphi);
+				    
+				    hadr_phi_hist_10->Fill(phi);
+				}
 			    }
-//			    if(deut_mom >= 3.25  &&  deut_mom < 4.25)
-//			    {
-//				Double_t eta  = track->Eta();
-//				Double_t dphi = deut_phi - phi;
-//				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-//				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-//				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
-//				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
-				
-//				if(     mom >= 0.5  &&  mom < 1.0){   deut_dphi_deta_p0510->Fill(dphi, deut_eta - eta);    }
-//				else if(mom >= 1.0  &&  mom < 2.0){   deut_dphi_deta_p1020->Fill(dphi, deut_eta - eta);    }
-//				else if(mom >= 2.0  &&  mom < 3.0){   deut_dphi_deta_p2030->Fill(dphi, deut_eta - eta);    }
-//				if(     mom >= 1.0  &&  mom < 5.0){   deut_dphi_deta_p1050->Fill(dphi, deut_eta - eta);    }
-//			    }
 			}
 		    }
 		}
 	    
+	    
 		int k = conductor->track_num;
 		conductor = conductor->next;
-//	    NAssociatedTracks++;
-		if(k != j)  // if the k-th track is not the j-th track which is the deuteron of interest
+	
+		short match = 0;
+		for(int kk=0; kk < high_flag_10; kk++)
+		{
+		    if(k == high_track_num_10[kk])   match = 1;
+		}
+
+		    
+		if(match == 0)  // if the k-th track is not the j-th track which is the trigger particle of interest
 		{
 		    AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(k));         // get a track (type AliAODTrack) from the event
 		    if(!track){}                                                               // if we failed, skip this track
 		    else
 		    {
-			Double_t mom            = track->P();
-			Double_t phi            = track->Phi();
-			
-			if(mom > 2.0  &&  mom < 5.0)
+			Double_t pt             = track->Pt();
+
+			    
+			if(pt > 1.1  &&  pt < 4.4)
 			{
-			    Double_t dphi = deut_phi - phi;
-			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
-			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
-			    
-			    deut_dphi_A->Fill(deut_mom, dphi);
-			    if(charge>0) {   deut_dphi_pos_A->Fill(deut_mom, dphi);   }
-			    if(charge<0) {   deut_dphi_neg_A->Fill(deut_mom, dphi);   }
-			    dphi_ket_deut_A->Fill(deut_ket, dphi);
-			}
-//			if(deut_mom >= 3.25  &&  deut_mom < 4.25)
-//			{
-//			    Double_t eta            = track->Eta();			    
-//			    Double_t dphi = deut_phi - phi;
-//			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-//			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-//			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
-//			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
-			    
-//			    if(     mom >= 0.5  &&  mom < 1.0){   deut_dphi_deta_p0510->Fill(dphi, deut_eta - eta);    }
-//			    else if(mom >= 1.0  &&  mom < 2.0){   deut_dphi_deta_p1020->Fill(dphi, deut_eta - eta);    }
-//			    else if(mom >= 2.0  &&  mom < 3.0){   deut_dphi_deta_p2030->Fill(dphi, deut_eta - eta);    }
-//			    if(     mom >= 1.0  &&  mom < 5.0){   deut_dphi_deta_p1050->Fill(dphi, deut_eta - eta);    }
-//			}
-		    }
-		}
-	    }
-	}
-    }  // end of deuteron correlation A LOOP
+			    short isGlobal    = 1;
+			    short isModGlobal = 0;  // is it suitable for deuteron candidate
+	
+			    if(!(track->TestFilterBit(AliAODTrack::kTrkGlobal))){   isGlobal = 0;   }
+	
+			    Double_t nsigmaTPC = 999.0;
+			    Double_t nsigmaTOF = 999.0;
 
-
-    if(deut_flag_B > 0)
-    {
-//	DeuteronCandidates++;
-	int j = deut_track_num_B;
-
-	AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(j));
-	if(!track) {}
-	else
-	{
-	    Double_t deut_phi = track->Phi();
-	    Double_t deut_mom = track->P();
-	    Double_t deut_pt  = track->Pt();
-	    Short_t  charge   = track->Charge();
-	    Double_t deut_eta = track->Eta();
-
-	    Double_t deut_ket = 0.0;
-	    
-//	    deut_ket = sqrt(pow(deut_mom,2) + pow(2.224,2)) - 2.224;
-	    deut_ket = sqrt(pow(deut_pt,2) + pow(1.87561,2)) - 1.87561;
-
-	    conductor = root->next;
-	    if (conductor != 0)
-	    {
-		while(conductor->next != 0)
-		{
-		    int k = conductor->track_num;
-		    conductor = conductor->next;
-		    
-		    if(k != j)  // if the k-th track is not the j-th track which is the deuteron of interest
-		    {
-//		    NAssociatedTracks++;
-			AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(k));         // get a track (type AliAODTrack) from the event
-			if(!track){}                                                               // if we failed, skip this track
-			else
-			{
-			    Double_t mom            = track->P();
-			    Double_t phi            = track->Phi();
-			    
-
-			    if(mom > 2.0  &&  mom < 5.0)
+			    if(isGlobal == 1)  
 			    {
-				Double_t dphi = deut_phi - phi;
-				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
-				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+				AliPIDResponse::EDetPidStatus statusTPC = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC, track, (AliPID::EParticleType) 0, nsigmaTPC);
+				AliPIDResponse::EDetPidStatus statusTOF = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTOF, track, (AliPID::EParticleType) 0, nsigmaTOF);
+				Bool_t tpcIsOk = (statusTPC == AliPIDResponse::kDetPidOk);  
+				Bool_t tofIsOk = (statusTOF == AliPIDResponse::kDetPidOk);
 				
-				deut_dphi_B->Fill(deut_mom, dphi);
-				
-				if(charge>0) {   deut_dphi_pos_B->Fill(deut_mom, dphi);   }
-				if(charge<0) {   deut_dphi_neg_B->Fill(deut_mom, dphi);   }
-				dphi_ket_deut_B->Fill(deut_ket, dphi);
-				
+				if(tpcIsOk  && tofIsOk){   isModGlobal = 1;   }
+				else                   {   isModGlobal = 0;   }
 			    }
-//			    if(deut_mom >= 3.25  &&  deut_mom < 4.25)
-//			    {
-//				Double_t eta  = track->Eta();
-//				Double_t dphi = deut_phi - phi;
-//				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-//				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-//				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
-//				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
-				
-//				if(     mom >= 0.5  &&  mom < 1.0){   deut_dphi_deta_p0510->Fill(dphi, deut_eta - eta);    }
-//				else if(mom >= 1.0  &&  mom < 2.0){   deut_dphi_deta_p1020->Fill(dphi, deut_eta - eta);    }
-//				else if(mom >= 2.0  &&  mom < 3.0){   deut_dphi_deta_p2030->Fill(dphi, deut_eta - eta);    }
-//				if(     mom >= 1.0  &&  mom < 5.0){   deut_dphi_deta_p1050->Fill(dphi, deut_eta - eta);    }
-//			    }
-			}
-		    }
-		}
+
+			    if(isModGlobal == 1)
+			    {
+				AliPIDResponse::EDetPidStatus statusTPC = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC, track, (AliPID::EParticleType) 5, nsigmaTPC);
+				if(nsigmaTPC <= 2.0)
+				{					
+				    Double_t deut_mean      = 0.0;
+				    Double_t deut_sigma     = 0.0;
+				    Double_t cut_width      = 1.0;
+				    
+				    Double_t mom   = track->P();
+				    Double_t m2tof = 0.00;
+				    m2tof = get_mass_squared(track);
+					
+				    for(int w=0; w<3; w++){   fit_deut_curve->SetParameter(w, deut_curves[0][0][w]);   }
+				    deut_mean = fit_deut_curve->Eval(mom);
+				    for(int w=0; w<3; w++){   fit_deut_curve->SetParameter(w, deut_curves[0][1][w]);   }
+				    deut_sigma = fit_deut_curve->Eval(mom);
+					
+				    if(m2tof < deut_mean + cut_width * deut_sigma  &&   m2tof > deut_mean - cut_width * deut_sigma)
+				    {
+					Double_t phi            = track->Phi();
+
+					Double_t et = 0.00;
+					Double_t en = 0.00;
+					Double_t kt = 0.00;
 	    
-		int k = conductor->track_num;
-		conductor = conductor->next;
-//	    NAssociatedTracks++;
-		if(k != j)  // if the k-th track is not the j-th track which is the deuteron of interest
-		{
-		    AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(k));         // get a track (type AliAODTrack) from the event
-		    if(!track){}                                                               // if we failed, skip this track
-		    else
-		    {
-			Double_t mom            = track->P();
-			Double_t phi            = track->Phi();
-			
-			if(mom > 2.0  &&  mom < 5.0)
-			{
-			    Double_t dphi = deut_phi - phi;
-			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
-			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
-			    
-			    deut_dphi_B->Fill(deut_mom, dphi);
-			    if(charge>0) {   deut_dphi_pos_B->Fill(deut_mom, dphi);   }
-			    if(charge<0) {   deut_dphi_neg_B->Fill(deut_mom, dphi);   }
-			    dphi_ket_deut_B->Fill(deut_ket, dphi);
+					et = sqrt(pow(pt ,2) + pow(1.87561,2));
+					en = sqrt(pow(mom,2) + pow(1.87561,2));
+					kt = sqrt(pow(pt ,2) + pow(1.87561,2)) - 1.87561;
+				
+					Double_t dphi = 0.00;
+					dphi = high_phi - phi;
+				
+					if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+					if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+					if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+					if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+				
+					dphi_pt_deut_10->Fill(pt, dphi);
+					dphi_et_deut_10->Fill(et, dphi);
+					dphi_en_deut_10->Fill(en, dphi);
+					dphi_kt_deut_10->Fill(kt, dphi);
+
+					deut_phi_hist_10->Fill(phi);
+				    }
+				}
+
+				statusTPC = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC, track, (AliPID::EParticleType) 4, nsigmaTPC);
+				if(nsigmaTPC <= 2.0)
+				{					
+				    Double_t prot_mean      = 0.0;
+				    Double_t prot_sigma     = 0.0;
+				    Double_t cut_width      = 1.0;
+				    
+				    Double_t mom   = track->P();
+				    Double_t m2tof = 0.00;
+				    m2tof = get_mass_squared(track);
+					
+				    for(int w=0; w<4; w++){   fit_prot_curve->SetParameter(w, prot_curves[0][0][w]);   }
+				    prot_mean = fit_prot_curve->Eval(mom);
+				    for(int w=0; w<4; w++){   fit_prot_curve->SetParameter(w, prot_curves[0][1][w]);   }
+				    prot_sigma = fit_prot_curve->Eval(mom);
+					
+				    if(m2tof < prot_mean + cut_width * prot_sigma  &&   m2tof > prot_mean - cut_width * prot_sigma)
+				    {
+					Double_t phi            = track->Phi();
+
+					Double_t et = 0.00;
+					Double_t en = 0.00;
+					Double_t kt = 0.00;
+	
+					et = sqrt(pow(pt ,2) + pow(0.93827,2));
+					en = sqrt(pow(mom,2) + pow(0.93827,2));
+					kt = sqrt(pow(pt ,2) + pow(0.93827,2)) - 0.93827;
+				
+					Double_t dphi = 0.00;
+					dphi = high_phi - phi;
+				
+					if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+					if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+					if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+					if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+				
+					dphi_pt_prot_10->Fill(pt, dphi);
+					dphi_et_prot_10->Fill(et, dphi);
+					dphi_en_prot_10->Fill(en, dphi);
+					dphi_kt_prot_10->Fill(kt, dphi);
+
+					prot_phi_hist_10->Fill(phi);
+				    }
+				}
+
+				
+				Double_t phi = track->Phi();
+				Double_t mom = track->P();
+				Double_t et = 0.00;
+				Double_t en = 0.00;
+				Double_t kt = 0.00;
+
+				et = sqrt(pow(pt ,2) + pow(0.29026,2));
+				en = sqrt(pow(mom,2) + pow(0.29026,2));
+				kt = sqrt(pow(pt ,2) + pow(0.29026,2)) - 0.29026;
+					    
+				Double_t dphi = 0.00;
+				dphi = high_phi - phi;
+					    
+				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+				if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
+				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+				if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
+					    
+				dphi_pt_hadr_10->Fill(pt, dphi);
+				dphi_et_hadr_10->Fill(et, dphi);
+				dphi_en_hadr_10->Fill(en, dphi);
+				dphi_kt_hadr_10->Fill(kt, dphi);
+				    
+				hadr_phi_hist_10->Fill(phi);
+			    }
 			}
-//			if(deut_mom >= 3.25  &&  deut_mom < 4.25)
-//			{
-//			    Double_t eta            = track->Eta();			    
-//			    Double_t dphi = deut_phi - phi;
-//			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-//			    if(dphi <  -TMath::PiOver2())    dphi = dphi + TMath::TwoPi();
-//			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
-//			    if(dphi > 3*TMath::PiOver2())    dphi = dphi - TMath::TwoPi();
-			    
-//			    if(     mom >= 0.5  &&  mom < 1.0){   deut_dphi_deta_p0510->Fill(dphi, deut_eta - eta);    }
-//			    else if(mom >= 1.0  &&  mom < 2.0){   deut_dphi_deta_p1020->Fill(dphi, deut_eta - eta);    }
-//			    else if(mom >= 2.0  &&  mom < 3.0){   deut_dphi_deta_p2030->Fill(dphi, deut_eta - eta);    }
-//			    if(     mom >= 1.0  &&  mom < 5.0){   deut_dphi_deta_p1050->Fill(dphi, deut_eta - eta);    }
-//			}
 		    }
 		}
 	    }
 	}
-    }  // end of deuteron correlation PRIMARY LOOP
-
-     
+    }
+    
                                                      // continue until all the tracks are processed
     PostData(1, fOutputList);                           // stream the results the analysis of this event to
                                                         // the output manager which will take care of writing
@@ -1161,7 +1298,6 @@ Double_t AliAnalysisTaskCorPIDTOFQA::Beta(AliAODTrack *track)
 Double_t AliAnalysisTaskCorPIDTOFQA::tof_minus_tpion(AliAODTrack *track)
 {
     Double_t start_time     = fPIDResponse->GetTOFResponse().GetStartTime(track->P());                      // in ps
-//  Double_t start_time     = fPIDResponse->GetTOFResponse().GetTimeZero() * 1e-12;
     Double_t stop_time      = track->GetTOFsignal();
     Double_t c              = TMath::C()*1.E-9;                                                             // in m/ns
     Double_t time_of_flight = stop_time - start_time;
@@ -1179,7 +1315,6 @@ Double_t AliAnalysisTaskCorPIDTOFQA::tof_minus_tpion(AliAODTrack *track)
 Double_t AliAnalysisTaskCorPIDTOFQA::get_mass_squared(AliAODTrack *track)
 {
     Double_t start_time     = fPIDResponse->GetTOFResponse().GetStartTime(track->P());                      // in ps
-//  Double_t start_time     = fPIDResponse->GetTOFResponse().GetTimeZero() * 1e-12;                         // lower resolution than previous line
     Double_t stop_time      = track->GetTOFsignal();
     Double_t c              = TMath::C()*1.E-9;                                                             // in m/ns
     Double_t tof            = stop_time - start_time;

--- a/PWGCF/Correlations/DPhi/AliAnalysisTaskCorPIDTOFQA.h
+++ b/PWGCF/Correlations/DPhi/AliAnalysisTaskCorPIDTOFQA.h
@@ -19,7 +19,7 @@ class AliAnalysisTaskCorPIDTOFQA : public AliAnalysisTaskSE
     public:
                                 AliAnalysisTaskCorPIDTOFQA();
                                 AliAnalysisTaskCorPIDTOFQA(const char *name);
-        virtual                 ~AliAnalysisTaskCorPIDTOFQA();
+        virtual                ~AliAnalysisTaskCorPIDTOFQA();
 
         virtual void            UserCreateOutputObjects();
         virtual void            UserExec(Option_t* option);
@@ -30,64 +30,75 @@ class AliAnalysisTaskCorPIDTOFQA : public AliAnalysisTaskSE
 
 
 	Double_t deut_curves[2][2][3];  /* [charge][mean,sigma][par]  */
-	TF1 *fit_deut_curve = new TF1("fit_m_mean",   "[0] + [1]*x + [2]/sqrt(x)",  1.1, 4.4);
-
+	Double_t prot_curves[2][2][4];  /* [charge][mean,sigma][par]  */
+	
+	TF1 *fit_deut_curve = new TF1("fit_d_mean",   "[0] + [1]*x + [2]/sqrt(x)",            1.1, 4.4);
+	TF1 *fit_prot_curve = new TF1("fit_p_mean",   "[0] + [1]*x + [2]/sqrt(x) + [3]*x^5",  1.0, 4.4);
+	
     private:
 
         AliAODEvent*            fAOD;               //! input event
         TList*                  fOutputList;        //! output list
 	AliPIDResponse*         fPIDResponse;
 	
-	TH1F*                   fHistPt;                //  1
-	TH2F*                   cent_ntracks;           //  2
-	TH2F*                   m2_pos;                 //  3
-	TH2F*                   m2_neg;                 //  4
-	TH2F*                   beta_p_pos;             //  5
-	TH2F*                   beta_p_neg;             //  6
-	TH2F*	                deltat_p_pos;           //  7
-	TH2F*	                deltat_p_neg;           //  8
-	TH2F*                   dedx_p_pos;             //  9
-	TH2F*                   dedx_p_neg;             // 10
-	TH2F*                   dedx_deltat_pos;        // 11
-	TH2F*                   dedx_deltat_neg;        // 12
-	TH3F*                   dedx_p_deltat_pos;      // 13
-	TH3F*                   dedx_p_deltat_neg;      // 14
-	TH2F*                   m2_pos_cut;             // 15
-	TH2F*                   m2_neg_cut;	        // 16
-	TH2F*                   beta_p_pos_cut;         // 17
-	TH2F*                   beta_p_neg_cut;         // 18
-	TH2F*	                deltat_p_pos_cut;       // 19
-	TH2F*	                deltat_p_neg_cut;       // 20
-	TH2F*                   dedx_p_pos_cut;         // 21
-	TH2F*                   dedx_p_neg_cut;         // 22
-	TH2F*                   dedx_deltat_pos_cut;    // 23
-	TH2F*                   dedx_deltat_neg_cut;    // 24
-	TH3F*                   dedx_p_deltat_pos_cut;  // 25
-	TH3F*                   dedx_p_deltat_neg_cut;  // 26
-	TH2F*                   deut_dphi_T;            // 27
-	TH2F*                   deut_dphi_pos_T;        // 28
-	TH2F*                   deut_dphi_neg_T;        // 29
-	TH2F*                   deut_dphi_A;            // 30
-	TH2F*                   deut_dphi_pos_A;        // 31
-	TH2F*                   deut_dphi_neg_A;	// 32
-	TH2F*                   deut_dphi_B;            // 33
-	TH2F*                   deut_dphi_pos_B;        // 34
-	TH2F*                   deut_dphi_neg_B;        // 35
-	TH1I*                   deut_per_event;         // 36
-	TH1I*                   deut_per_event_pos;     // 37
-	TH1I*                   deut_per_event_neg;	// 38
-	TH2F*                   m2_pos_cut_T;           // 39
-	TH2F*                   m2_pos_cut_A;           // 40
-	TH2F*                   m2_pos_cut_B;           // 41
-	TH2F*                   m2_neg_cut_T;           // 42
-	TH2F*                   m2_neg_cut_A;           // 43
-	TH2F*                   m2_neg_cut_B;           // 44
-	TH2F*                   dphi_ket_deut_T;        // 45
-	TH2F*                   dphi_ket_deut_A;        // 46
-	TH2F*                   dphi_ket_deut_B;        // 47
-	TProfile*               deltat_channel;         // 48
 
-	TH1F*                   deut_ket_count;         // 49
+	TH1F*	    fHistPt;             //  1
+	TH2F*       cent_ntracks;        //  2
+    
+	TH1I*       high_per_event_05;   //  3a
+	TH1I*       high_per_event_10;   //  3b
+	TH1I*       high_per_event_pos;  //  4
+	TH1I*       high_per_event_neg;  //  5
+
+	TH2F*       dphi_pt_deut_05;     //  6
+	TH2F*       dphi_et_deut_05;     //  7
+	TH2F*       dphi_en_deut_05;     //  8
+	TH2F*       dphi_kt_deut_05;     //  9
+	TH2F*       dphi_pt_prot_05;     // 10
+	TH2F*       dphi_et_prot_05;     // 11
+	TH2F*       dphi_en_prot_05;     // 12
+	TH2F*       dphi_kt_prot_05;     // 13
+	TH2F*       dphi_pt_hadr_05;     // 14
+	TH2F*       dphi_et_hadr_05;     // 15
+	TH2F*       dphi_en_hadr_05;     // 16
+	TH2F*       dphi_kt_hadr_05;     // 17
+    
+//	TH1F*       high_pt_count_05;    // 18
+//	TH1F*       high_et_count_05;    // 19
+//	TH1F*       high_en_count_05;    // 20
+//	TH1F*       high_kt_count_05;    // 21
+    
+	TH1F*       deut_phi_hist_05;    // 22
+	TH1F*       prot_phi_hist_05;    // 23
+	TH1F*       hadr_phi_hist_05;    // 24
+	TH1F*       high_phi_hist_05;    // 25
+
+
+	TH2F*       dphi_pt_deut_10;     // 26
+	TH2F*       dphi_et_deut_10;     // 27
+	TH2F*       dphi_en_deut_10;     // 28
+	TH2F*       dphi_kt_deut_10;     // 29    
+	TH2F*       dphi_pt_prot_10;     // 30
+	TH2F*       dphi_et_prot_10;     // 31
+	TH2F*       dphi_en_prot_10;     // 32
+	TH2F*       dphi_kt_prot_10;     // 33
+	TH2F*       dphi_pt_hadr_10;     // 34
+	TH2F*       dphi_et_hadr_10;     // 35
+	TH2F*       dphi_en_hadr_10;     // 36
+	TH2F*       dphi_kt_hadr_10;     // 37
+    
+//	TH1F*       high_pt_count_10;    // 38
+//	TH1F*       high_et_count_10;    // 39
+//	TH1F*       high_en_count_10;    // 40
+//	TH1F*       high_kt_count_10;    // 41
+    
+	TH1F*       deut_phi_hist_10;    // 42
+	TH1F*       prot_phi_hist_10;    // 43
+	TH1F*       hadr_phi_hist_10;    // 44
+	TH1F*       high_phi_hist_10;    // 45
+
+	TH2F*       m2_cut;              // 46
+
 	
         AliAnalysisTaskCorPIDTOFQA(const AliAnalysisTaskCorPIDTOFQA&);                        // not implemented
         AliAnalysisTaskCorPIDTOFQA& operator=(const AliAnalysisTaskCorPIDTOFQA&);             // not implemented


### PR DESCRIPTION
this code compares events with both a high-pt track and deuteron, to events with a high-pt track and proton, and high-pt track and unidentified hadron.  Two thresholds are used for the high-pt trigger: 5, 10 GeV/c.