### PR TITLE
PWGPP-350 - allow POSIX option parsing

### DIFF
--- a/PWGPP/scripts/test/utilities.test.sh
+++ b/PWGPP/scripts/test/utilities.test.sh
@@ -3,21 +3,27 @@
 # Test suit for the utilities.sh 
 #--------------------------------------------------------------------------------------------------
 # To run the test: 
+# ( source $AliPhysics_SRC/PWGPP/scripts/test/utilities.test.sh; test_all) | tee  test.log
+# cat test.log | grep SUCCES
 
-# ( source $ALICE_PHYSICS/../src/PWGPP/scripts/test/utilities.test.sh; test_guessRunData)
-# ( source $ALICE_PHYSICS/../src/PWGPP/scripts/test/utilities.test.sh; test_OCDBYear)
-# ( source $ALICE_PHYSICS/../src/PWGPP/scripts/test/utilities.test.sh; test_paranoidCopy )
+# Run individual tests:
+#     ( source $AliPhysics_SRC/PWGPP/scripts/test/utilities.test.sh; test_guessRunData)
+#     ( source $AliPhysics_SRC/PWGPP/scripts/test/utilities.test.sh; test_OCDBYear)
+#     ( source $AliPhysics_SRC/PWGPP/scripts/test/utilities.test.sh; test_paranoidCopy )
 
-source $ALICE_PHYSICS/../src/PWGPP/scripts/alilog4bash.sh
-source $ALICE_PHYSICS/../src/PWGPP/scripts/utilities.sh
 
-test_guessRunData()
-{
+if [ -z `type -t alilog_info` ]; then
+    source $AliPhysics_SRC/PWGPP/scripts/alilog4bash.sh
+    source $AliPhysics_SRC/PWGPP/scripts/utilities.sh
+fi;
+
+test_guessRunData(){
 #
 #  test functionalitu of guessRunNumber, guessYear, guessRunNumber from utilities.sh library
 #  Few test use cases used. True values compared with "guessed" using utilities functionality
 #  alilog_error generated in case of mismatch
-#   guessRecoPass  to be added to the list ? 
+#   guessRecoPass  to be added to the list ?
+    alilog_info test_guessRunData.Begin
     arrayPath=("/alice/data/2012/LHC12g/000188362/cpass1_tpc_validation/OCDB/spaceMap_4_4" \
                "alien:///alice/data/2012/LHC12a/000177011/cpass0_tpc_validation/OCDB/meanITSVertex.root" \
                "http://aliqatpc.web.cern.ch/aliqatpc/data/2010/LHC10e/pass4/000127729/TPC_dEdx_track_info.png" \
@@ -29,9 +35,6 @@ test_guessRunData()
     periodTrue=("LHC12g" "LHC12a" "LHC10e"  "LHC10b" "LHC10e" "LHC10e" );
     runTrue=("188362" "177011" "127729"  "117086" "" "127712");
     passTrue=("cpass1_tpc_validation" "cpass0_tpc_validation" "pass4" "pass4_AOD" "pass4" "pass2_lego140");
-    echo ===================================================================================================
-    alilog "RUNNING TEST: test_guessRunData";
-    echo ===================================================================================================
     #
     arrayLength=${#arrayPath[@]};	
     for (( i=0; i<${arrayLength}; i++ ));  do
@@ -49,9 +52,7 @@ test_guessRunData()
         [[ "${guessPass}"    != "${passTrue[$i]}" ]] && alilog_error        "test_guessPassData: Pass   ${guessPass}   ${passTrue[$i]}    ${periodTrue[$i]} ${arrayPath[$i]}"
         [[ "${guessPass}"    =  "${passTrue[$i]}" ]] && alilog_success      "test_guessPassData: Pass   ${guessPass}   ${passTrue[$i]}"
     done;
-    echo ===================================================================================================
-    alilog "END TEST: test_guessRunData";
-    echo ===================================================================================================
+    alilog_info test_guessRunData.End
 }
 
 test_OCDBYear(){
@@ -60,6 +61,7 @@ test_OCDBYear(){
     #  some slashes disapeared
     #  !!!!  In the guessRunData ocdbStorage is overwritten  !!!  
     #
+    alilog_info test_OCDBYear.Begin
     ocdbStorage="local:///cvmfs/alice.gsi.de/alice/data/2010/OCDB/"
     newYear=2012
     newocdbStorage=$(setYear ${newYear} ${ocdbStorage})    
@@ -67,13 +69,15 @@ test_OCDBYear(){
     newocdbStorage=$(setYear ${newYear} ${newocdbStorage})    
     [[  "${ocdbStorage}"  =   "${newocdbStorage}" ]] && alilog_success      "testOCDBYear: Pass"
     [[  "${ocdbStorage}"  !=   "${newocdbStorage}" ]] && alilog_error      "testOCDBYear: FAILED $ocdbStorage => $newocdbStorage"
+    alilog_info test_OCDBYear.End
 }
 
 
 test_paranoidCopy(){
     #
-    # 1.) test the bug deleting of directoris
+    # 1.) test the bug deleting of directories
     #
+    alilog_info test_paranoidCopy.Begin
     wdir=`pwd`;
     mkdir -p $wdir/testdirParanoidCopySource
     mkdir -p $wdir/testdirParanoidCopyDest
@@ -86,5 +90,40 @@ test_paranoidCopy(){
     resultDiff=`diff -r  testdirParanoidCopySource testdirParanoidCopyDest/testdirParanoidCopySource`
     hrlen=${#resultDiff}
     [ $hrlen = 0 ]   && alilog_success     "test_paranoidCopy"	
-    [ $hrlen != 0 ] && alilog_error      "test_paranoidCopy"	
+    [ $hrlen != 0 ] && alilog_error      "test_paranoidCopy"
+    alilog_info test_paranoidCopy.End
+}
+
+test_parseConfig(){
+    #
+    #
+    alilog_info test_parseConfig.Begin
+    # parse cofig as for alihadd.sh
+    parseConfig -v 1 -s 100 -q xxx  -testInput highPt -prefetch 1 test.root
+    alilog_info "test_parseConfig parseConfig -v 1 -s 100 -q xxx  -testInput highPt -prefetch 1 test.root"
+    if [[ $v == 1 ]] ; then
+        alilog_success "-v= $v = 1";
+    else
+        alilog_error "-v= $v != 1";
+    fi
+    if [[ $s == 100 ]] ; then
+        alilog_success "-s= $s = 100";
+    else
+        alilog_error "-s= $s != 100";
+    fi
+    if [[ $testInput == "highPt" ]] ; then
+        alilog_success testInput="highPt";
+    else
+        alilog_error testInput!="highPt";
+    fi
+
+    alilog_info test_parseConfig.End
+}
+
+
+test_all(){
+    test_guessRunData;
+    test_OCDBYear;
+    test_paranoidCopy;
+    test_parseConfig;
 }

--- a/PWGPP/scripts/utilities.sh
+++ b/PWGPP/scripts/utilities.sh
@@ -30,6 +30,10 @@ parseConfig()
 {
   # parse command line arguments, they have to be in the form
   #  option=value
+  #    --or--
+  #  -option value
+  #    --or--
+  #  --option value
   # they are then set in the environment
   # additionally another variable named: parseConfig__ORIGINAL__${option}
   # is set to have a fallback.
@@ -71,15 +75,28 @@ parseConfig()
   done
 
   #then, parse the options as they override the options from configFile
+  local var=""
+  local value=""
   for opt in "${args[@]}"; do
     [[ -n ${encodedSpaces} ]] && opt="$(decSpaces ${opt})"
     if [[ ! "${opt}" =~ .*=.* ]]; then
-      echo "badly formatted option ${var}, should be: option=value, stopping..."
-      return 1
+      if [[ "${opt}" =~ ^-.? && -z "$expectPosixOptionValue" ]]; then
+        var="${opt#--}"
+        var="${var#-}"
+        expectPosixOptionValue=1
+        continue
+      elif [[ -n "$expectPosixOptionValue" ]]; then
+        value="${opt}"
+        unset expectPosixOptionValue
+      else
+        echo "badly formatted option ${var}, should be: option=value (or -var value) stopping..."
+        return 1
+      fi
+    else
+      var="${opt%%=*}"
+      value="${opt#*=}"
     fi
-    local var="${opt%%=*}"
-    local value="${opt#*=}"
-    #echo "${var}=${value}"
+    #echo "setting ${var}=${value}"
     export ${var}="${value}"
     [[ -n ${originalOptionPrefix} ]] && export ${originalOptionPrefix}${var}="${value}"
   done

--- a/PWGPP/scripts/utilities.sh
+++ b/PWGPP/scripts/utilities.sh
@@ -89,8 +89,9 @@ parseConfig()
         value="${opt}"
         unset expectPosixOptionValue
       else
-        echo "badly formatted option ${var}, should be: option=value (or -var value) stopping..."
-        return 1
+        continue;  # non option string should be allowed - e.g parsing parameters for alihadd
+        #echo "badly formatted option ${var}, should be: option=value (or -var value) stopping..."
+        #return 1
       fi
     else
       var="${opt%%=*}"


### PR DESCRIPTION
### 	bd6145c (Mikolaj): Allow posix like options on the command line in parseConfig

### 	e41511b (MI) PWGPP-350 - allow POSIX option parsing
* patch utilities.sh:parseConfig
* add test/utilities.test.sh:test_parseConfig
```
( source $AliPhysics_SRC/PWGPP/scripts/test/utilities.test.sh; test_parseConfig)
[2017-07-07 07:00:06 CEST] [lxbk0198] [INFO] test_parseConfig.Begin
[2017-07-07 07:00:06 CEST] [lxbk0198] [INFO] test_parseConfig parseConfig -v 1 -s 100 -q xxx  -testInput highPt -prefetch 1 test.root
[2017-07-07 07:00:06 CEST] [lxbk0198] [SUCCESS] -v= 1 = 1
[2017-07-07 07:00:06 CEST] [lxbk0198] [SUCCESS] -s= 100 = 100
[2017-07-07 07:00:06 CEST] [lxbk0198] [SUCCESS] testInput=highPt
[2017-07-07 07:00:06 CEST] [lxbk0198] [INFO] test_parseConfig.End
```