### PR TITLE
Change PID histograms to THnSpare

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerJets.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerJets.cxx
@@ -25,6 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
  ************************************************************************************/
 #include <THistManager.h>
+#include <TLinearBinning.h>
 #include <TMath.h>
 #include <TString.h>
 
@@ -77,12 +78,14 @@ void AliAnalysisTaskEmcalTriggerJets::UserCreateOutputObjects(){
   const std::array<TString, 5> kEmcalTriggers = {"INT7", "EJ1", "EJ2", "DJ1", "DJ2"};
   const int kNJetPtBins = 9;
   const int kNJetRadiusBins = 7;
-  const std::array<int, kNJetPtBins+1> kJetPtBins = {20, 40, 60, 80, 100, 120, 140, 160, 180, 200};
+
+  TLinearBinning jetptbinning(9, 20, 200), pbinning(300, 0., 30.), dEdxbinning(600, 0., 600.), massbinning(400., 0., 4.), eopbinning(150, 0., 1.5), radiusBinning(10, 0., 10.);
+  const TBinning *binningPID[5] {&jetptbinning, &pbinning, &dEdxbinning, &massbinning, &eopbinning},
+                 *binningAssociate[6] = {&jetptbinning, &pbinning, &radiusBinning, &dEdxbinning, &massbinning, &eopbinning};
   const std::array<int, 2> kJetRadii = {2, 4};
   const std::array<TString, 3> kJetTypes = {"Charged", "Full", "Neutral"};
   const std::array<TString, 2> kDetectors = {"EMCAL", "DCAL"};
   const std::array<TString, 2> kConstituentType = {"Charged", "Neutral"};
-  const std::array<double, kNJetRadiusBins+1> kRadiusBins = {0., 0.1, 0.2, 0.3, 0.4, 0.6, 0.8, 1.};
   fHistos = new THistManager("EmcalJetHistos");
   for(auto t : kEmcalTriggers){
     fHistos->CreateTH1("hEventCount" + t, "Event counter for trigger " + t, 1., 0.5, 1.5);
@@ -109,42 +112,9 @@ void AliAnalysisTaskEmcalTriggerJets::UserCreateOutputObjects(){
                   "p_{t,rel} vs. p_{t, jet} for leading " + constituent + " constituents in full jets with R=" + TString::Format("%.1f", double(radius)/10.) + " in " + det + " for trigger " + t,
                   200., 0., 200., 100, 0., 1.);
             }
-            // PID histograms for full jets (all and leading charged)
-            for(int ib  = 0; ib < kNJetPtBins; ib++){
-              fHistos->CreateTH2("hTPCdEdxFullJet" + TString::Format("Min%dMax%dR%02d", kJetPtBins[ib], kJetPtBins[ib+1], radius) + det + t,
-                                 "TPC dE/dx vs. p for jet constituents for full jets with " + TString::Format("%d < p_{t} < %d and R=%.1f", kJetPtBins[ib], kJetPtBins[ib+1], float(radius)/10.) + "in " + det + " for trigger " + t,
-                                 300, 0., 30., 1000., 0., 500.);
-              fHistos->CreateTH2("hTOFBetaFullJet" + TString::Format("Min%dMax%dR%02d", kJetPtBins[ib], kJetPtBins[ib+1], radius) + det + t,
-                                 "TOF #beta vs. p for jet constituents for full jets with " + TString::Format("%d < p_{t} < %d and R=%.1f", kJetPtBins[ib], kJetPtBins[ib+1], float(radius)/10.) + " in " + det + " for trigger " + t,
-                                 300., 0., 30., 120., 0., 1.2);
-              fHistos->CreateTH2("hEMCALEoPFullJet" + TString::Format("Min%dMax%dR%02d", kJetPtBins[ib], kJetPtBins[ib+1], radius) + det + t,
-                                 "TOF #beta vs. p for jet constituents for full jets with " + TString::Format("%d < p_{t} < %d and R=%.1f", kJetPtBins[ib], kJetPtBins[ib+1], float(radius)/10.) + " in " + det + " for trigger " + t,
-                                 300., 0., 30., 150., 0., 1.5);
-              fHistos->CreateTH2("hTPCdEdxLeadingFullJet" + TString::Format("Min%dMax%dR%02d", kJetPtBins[ib], kJetPtBins[ib+1], radius) + det + t,
-                                 "TPC dE/dx vs. p for leading jet constituents for full jets with " + TString::Format("%d < p_{t} < %d and R=%.1f", kJetPtBins[ib], kJetPtBins[ib+1], float(radius)/10.) + "in " + det + " for trigger " + t,
-                                 300, 0., 30., 1000., 0., 500.);
-              fHistos->CreateTH2("hTOFBetaLeadingFullJet" + TString::Format("Min%dMax%dR%02d", kJetPtBins[ib], kJetPtBins[ib+1], radius) + det + t,
-                                 "TOF #beta vs. p for leading jet constituents for full jets with " + TString::Format("%d < p_{t} < %d and R=%.1f", kJetPtBins[ib], kJetPtBins[ib+1], float(radius)/10.) + " in " + det + " for trigger " + t,
-                                 300., 0., 30., 120., 0., 1.2);
-              fHistos->CreateTH2("hEMCALEoPLeadingFullJet" + TString::Format("Min%dMax%dR%02d", kJetPtBins[ib], kJetPtBins[ib+1], radius) + det + t,
-                                 "TOF #beta vs. p for jet constituents for full jets with " + TString::Format("%d < p_{t} < %d and R=%.1f", kJetPtBins[ib], kJetPtBins[ib+1], float(radius)/10.) + " in " + det + " for trigger " + t,
-                                 300., 0., 30., 150., 0., 1.5);
-
-              // PID plots in bins of the jet radius
-              if(radius == 4) {
-                for(int ir = 0; ir < kNJetRadiusBins; ir++){
-                  fHistos->CreateTH2("hTPCdEdxFullJet" + TString::Format("DMin%dDMax%dPtMin%dPtMax%d", int(kRadiusBins[ir]*10.), int(kRadiusBins[ir+1]*10.), kJetPtBins[ib], kJetPtBins[ib+1]) + det + t,
-                      "TPC dE/dx vs. p for particles with " + TString::Format("%.1f < d < %.1f and %d < p_{t} < %d", kRadiusBins[ir], kRadiusBins[ir+1], kJetPtBins[ib], kJetPtBins[ib+1]) + " in " + det + " for trigger " + t,
-                      300, 0., 30., 1000., 0., 500.);
-                  fHistos->CreateTH2("hTOFBetaFullJet" + TString::Format("DMin%dDMax%dPtMin%dPtMax%d", int(kRadiusBins[ir]*10.), int(kRadiusBins[ir+1]*10.), kJetPtBins[ib], kJetPtBins[ib+1]) + det + t,
-                      "TOF #beta vs. p for particles with " + TString::Format("%.1f < d < %.1f and %d < p_{t} < %d", kRadiusBins[ir], kRadiusBins[ir+1], kJetPtBins[ib], kJetPtBins[ib+1]) + " in " + det + " for trigger " + t,
-                      300, 0., 30., 150., 0., 1.5);
-                  fHistos->CreateTH2("hEMCALEoPFullJet" + TString::Format("DMin%dDMax%dPtMin%dPtMax%d", int(kRadiusBins[ir]*10.), int(kRadiusBins[ir+1]*10.), kJetPtBins[ib], kJetPtBins[ib+1]) + det + t,
-                      "TPC dE/dx vs. p for particles with " + TString::Format("%.1f < d < %.1f and %d < p_{t} < %d", kRadiusBins[ir], kRadiusBins[ir+1], kJetPtBins[ib], kJetPtBins[ib+1]) + " in " + det + " for trigger " + t,
-                      300, 0., 30., 150., 0., 1.5);
-                }
-              }
-            }
+            fHistos->CreateTHnSparse("hPIDConstituentFullJet" + TString::Format("R%02d", radius) + det + t, TString::Format("PID for full jet constituents for R=%0.2f in %s for trigger %t", double(radius)/10., det.Data(), t.Data()), 5, binningPID);
+            fHistos->CreateTHnSparse("hPIDLeadingFullJet" + TString::Format("R%02d", radius) + det + t, TString::Format("PID for full jet leading constituents for R=%0.2f in %s for trigger %t", double(radius)/10., det.Data(), t.Data()), 5, binningPID);
+            fHistos->CreateTHnSparse("hPIDAssociateFullJet" + TString::Format("R%02d", radius) + det + t, TString::Format("PID for particles associated to full jets for R=%0.2f in %s for trigger %t", double(radius)/10., det.Data(), t.Data()), 6, binningAssociate);
           }
         }
       }
@@ -225,7 +195,7 @@ bool AliAnalysisTaskEmcalTriggerJets::Run(){
               }
               // Fill PID plots for particles around the main jet axis
               if(radius == 0.4) {
-                FillPIDCorrelationPlot(j, this->GetTrackContainer("tracks"), t, det);
+                FillPIDCorrelationPlot(j, this->GetTrackContainer("tracks"), radius, t, det);
               }
               AliDebugStream(1) << "Filling full jet leading constituent histograms done" << std::endl;
             }
@@ -238,19 +208,8 @@ bool AliAnalysisTaskEmcalTriggerJets::Run(){
 }
 
 void AliAnalysisTaskEmcalTriggerJets::FillJetPIDPlots(const AliEmcalJet *jet, double radius, const char *trigger, const char *detector){
-  const int kNJetPtBins = 9;
-  const std::array<int, kNJetPtBins+1> kJetPtBins = {20, 40, 60, 80, 100, 120, 140, 160, 180, 200};
-  int jetptbin = -1;
-  for(int ib = 0; ib < kNJetPtBins; ib++){
-    if(TMath::Abs(jet->Pt()) >= kJetPtBins[ib] && TMath::Abs(jet->Pt()) < kJetPtBins[ib+1]) {
-      jetptbin = ib;
-      break;
-    }
-  }
-  if(jetptbin < 0) return;
-  TString histnameTPC = TString::Format("hTPCdEdxFullJetMin%dMax%dR%02d%s%s", kJetPtBins[jetptbin], kJetPtBins[jetptbin+1], int(radius*10.), detector, trigger),
-          histnameTOF = TString::Format("hTOFBetaFullJetMin%dMax%dR%02d%s%s", kJetPtBins[jetptbin], kJetPtBins[jetptbin+1], int(radius*10.), detector, trigger),
-          histnameEMCAL = TString::Format("hEMCALEoPFullJetMin%dMax%dR%02d%s%s", kJetPtBins[jetptbin], kJetPtBins[jetptbin+1], int(radius*10.), detector, trigger);
+  if(TMath::Abs(jet->Pt()) < 20 || TMath::Abs(jet->Pt()) > 200) return;
+  TString histname = TString::Format("hPIDConstituentFullJetR%02d%s%s", int(radius * 10), detector, trigger);
   AliTrackContainer *tc = GetTrackContainer("tracks");
 
   for(int icharged = 0; icharged < jet->GetNumberOfTracks(); icharged++){
@@ -261,59 +220,40 @@ void AliAnalysisTaskEmcalTriggerJets::FillJetPIDPlots(const AliEmcalJet *jet, do
     if(!((constituent->GetStatus() & AliVTrack::kTOFout) && (constituent->GetStatus() & AliVTrack::kTIME))) continue;
     Double_t trtime = (constituent->GetTOFsignal() - fPIDResponse->GetTOFResponse().GetTimeZero()) * 1e-12;
     Double_t v = constituent->GetIntegratedLength()/(100. * trtime);
-    Double_t beta =  v / TMath::C();
-    fHistos->FillTH2(histnameTPC, TMath::Abs(constituent->P()), constituent->GetTPCsignal());
-    fHistos->FillTH2(histnameTOF, TMath::Abs(constituent->P()), beta);
+    Double_t beta =  v / TMath::C(), gamma = 1 / TMath::Sqrt(1-beta*beta), mtof = constituent->P() / (beta*gamma);
+    Double_t eop = -1.;
     if(constituent->GetEMCALcluster() >= 0) {
       AliVCluster *matched = static_cast<AliVCluster *>((*GetClusterContainer("caloClusters"))[constituent->GetEMCALcluster()]);
-      fHistos->FillTH2(histnameEMCAL, TMath::Abs(constituent->P()), TMath::Abs(matched->GetNonLinCorrEnergy()/constituent->P()));
+      if(matched) eop = TMath::Abs(matched->GetNonLinCorrEnergy()/constituent->P());
     }
+    Double_t datapoint[5] = {TMath::Abs(jet->Pt()), TMath::Abs(constituent->P()), constituent->GetTPCsignal(), mtof, eop};
+    fHistos->FillTHnSparse(histname, datapoint);
   }
 }
 
 void AliAnalysisTaskEmcalTriggerJets::FillJetPIDPlotsLeading(const AliVTrack *leading, double ptjet, double radius, const char *trigger, const char *detector){
-  const int kNJetPtBins = 9;
-  const std::array<int, kNJetPtBins+1> kJetPtBins = {20, 40, 60, 80, 100, 120, 140, 160, 180, 200};
-  int jetptbin = -1;
-  for(int ib = 0; ib < kNJetPtBins; ib++){
-    if(TMath::Abs(ptjet) >= kJetPtBins[ib] && TMath::Abs(ptjet) < kJetPtBins[ib+1]) {
-      jetptbin = ib;
-      break;
-    }
-  }
-  if(jetptbin < 0) return;
+  if(ptjet < 20 || ptjet > 200) return;
 
-  TString histnameTPC = TString::Format("hTPCdEdxLeadingFullJetMin%dMax%dR%02d%s%s", kJetPtBins[jetptbin], kJetPtBins[jetptbin+1], int(radius*10.), detector, trigger),
-          histnameTOF = TString::Format("hTOFBetaLeadingFullJetMin%dMax%dR%02d%s%s", kJetPtBins[jetptbin], kJetPtBins[jetptbin+1], int(radius*10.), detector, trigger),
-          histnameEMCAL = TString::Format("hEMCALEoPLeadingFullJetMin%dMax%dR%02d%s%s", kJetPtBins[jetptbin], kJetPtBins[jetptbin+1], int(radius*10.), detector, trigger);
+  TString histname = TString::Format("hPIDLeadingFullJetR%02d%s%s", int(radius*10.), detector, trigger);
   if(leading->GetTPCsignalN() < 30) return;
   if(!((leading->GetStatus() & AliVTrack::kTOFout) && (leading->GetStatus() & AliVTrack::kTIME))) return;
   if(leading->GetTPCSharedMapPtr()->CountBits(0) > 70) return;
   Double_t trtime = (leading->GetTOFsignal() - fPIDResponse->GetTOFResponse().GetTimeZero()) * 1e-12;
   Double_t v = leading->GetIntegratedLength()/(100. * trtime);
-  Double_t beta =  v / TMath::C();
-  fHistos->FillTH2(histnameTPC, TMath::Abs(leading->P()), leading->GetTPCsignal());
-  fHistos->FillTH2(histnameTOF, TMath::Abs(leading->P()), beta);
+  Double_t beta =  v / TMath::C(), gamma = 1 / TMath::Sqrt(1-beta*beta), mtof = leading->P() / (beta*gamma);
+  Double_t eop = -1.;
   if(leading->GetEMCALcluster() >= 0){
       AliVCluster *matched = static_cast<AliVCluster *>((*GetClusterContainer("caloClusters"))[leading->GetEMCALcluster()]);
-      fHistos->FillTH2(histnameEMCAL, TMath::Abs(leading->P()), TMath::Abs(matched->GetNonLinCorrEnergy()/leading->P()));
+      if(matched) eop = TMath::Abs(matched->GetNonLinCorrEnergy()/leading->P());
   }
+  Double_t datapoint[5] = {ptjet, TMath::Abs(leading->P()), leading->GetTPCsignal(), mtof, eop};
+  fHistos->FillTHnSparse(histname, datapoint);
 }
 
-void AliAnalysisTaskEmcalTriggerJets::FillPIDCorrelationPlot(const AliEmcalJet *jet, const AliTrackContainer *particles, const char *trigger, const char *detector) {
-  const int kNJetPtBins = 9;
-  const int kNRadiusBins = 7;
-  const std::array<int, kNJetPtBins+1> kJetPtBins = {20, 40, 60, 80, 100, 120, 140, 160, 180, 200};
-  const std::array<double, kNRadiusBins+1> kRadiusBins = {0., 0.1, 0.2, 0.3, 0.4, 0.6, 0.8, 1.};
-  int jetptbin = -1;
-  for(int ib = 0; ib < kNJetPtBins; ib++){
-    if(TMath::Abs(jet->Pt()) >= kJetPtBins[ib] && TMath::Abs(jet->Pt()) < kJetPtBins[ib+1]) {
-      jetptbin = ib;
-      break;
-    }
-  }
-  if(jetptbin < 0) return;
+void AliAnalysisTaskEmcalTriggerJets::FillPIDCorrelationPlot(const AliEmcalJet *jet, const AliTrackContainer *particles, double radius, const char *trigger, const char *detector) {
+  if(TMath::Abs(jet->Pt()) < 20 || TMath::Abs(jet->Pt()) > 200) return;
 
+  TString histname = TString::Format("hPIDAssociateFullJetR%02d%s%s", int(radius*10.), detector, trigger);
   for(auto it : *(particles->GetArray())) {
     AliVTrack *track = static_cast<AliVTrack *>(it);
     if(track->IsA() == AliAODTrack::Class()) {
@@ -324,28 +264,18 @@ void AliAnalysisTaskEmcalTriggerJets::FillPIDCorrelationPlot(const AliEmcalJet *
       if(!((track->GetStatus() & AliVTrack::kTOFout) && (track->GetStatus() & AliVTrack::kTIME))) continue;
       TVector3 partvector(track->Px(), track->Py(), track->Pz()), jetvector(jet->Px(), jet->Py(), jet->Pz());
       double dr = jetvector.DeltaR(partvector);
-      if(dr >= 1.) continue;
+      if(dr < 0 || dr >= 1.) continue;
 
-      // track is accepted, find delta_r bin
-      int drbin = 0;
-      for(int ib = 0; ib < kNRadiusBins; ib++){
-        if(dr >= kRadiusBins[ib] && dr < kRadiusBins[ib+1]) {
-          drbin = ib;
-          break;
-        }
-      }
-      TString histnameTPC = TString::Format("hTPCdEdxFullJetDMin%dDMax%dPtMin%dPtMax%d%s%s", static_cast<int>(kRadiusBins[drbin] * 10.), static_cast<int>(kRadiusBins[drbin+1] * 10.), kJetPtBins[jetptbin], kJetPtBins[jetptbin+1], detector, trigger),
-          histnameTOF = TString::Format("hTOFBetaFullJetDMin%dDMax%dPtMin%dPtMax%d%s%s", static_cast<int>(kRadiusBins[drbin] * 10.), static_cast<int>(kRadiusBins[drbin+1] * 10.), kJetPtBins[jetptbin], kJetPtBins[jetptbin+1], detector, trigger),
-          histnameEMCAL = TString::Format("hEMCALEoPFullJetDMin%dDMax%dPtMin%dPtMax%d%s%s", static_cast<int>(kRadiusBins[drbin] * 10.), static_cast<int>(kRadiusBins[drbin+1] * 10.), kJetPtBins[jetptbin], kJetPtBins[jetptbin+1], detector, trigger);
       Double_t trtime = (track->GetTOFsignal() - fPIDResponse->GetTOFResponse().GetTimeZero()) * 1e-12;
       Double_t v = track->GetIntegratedLength()/(100. * trtime);
-      Double_t beta =  v / TMath::C();
-      fHistos->FillTH2(histnameTPC, TMath::Abs(track->P()), track->GetTPCsignal());
-      fHistos->FillTH2(histnameTOF, TMath::Abs(track->P()), beta);
+      Double_t beta =  v / TMath::C(), gamma = 1 / TMath::Sqrt(1-beta*beta), mtof = track->P() / (beta*gamma);
+      Double_t eop = -1.;
       if(track->GetEMCALcluster() >= 0){
         AliVCluster *matched = static_cast<AliVCluster *>((*GetClusterContainer("caloClusters"))[track->GetEMCALcluster()]);
-        fHistos->FillTH2(histnameEMCAL, TMath::Abs(track->P()), TMath::Abs(matched->GetNonLinCorrEnergy()/track->P()));
+        if(matched) eop = TMath::Abs(matched->GetNonLinCorrEnergy()/track->P());
       }
+      Double_t datapoint[6] = {TMath::Abs(jet->Pt()), TMath::Abs(track->P()), dr, track->GetTPCsignal(), mtof, eop};
+      fHistos->FillTHnSparse(histname, datapoint);
     }
   }
 }

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerJets.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerJets.h
@@ -28,7 +28,7 @@ protected:
 
   void FillJetPIDPlots(const AliEmcalJet *jet, double radius, const char *trigger, const char *detector);
   void FillJetPIDPlotsLeading(const AliVTrack *leading, double ptjet, double radius, const char *trigger, const char *detector);
-  void FillPIDCorrelationPlot(const AliEmcalJet *jet, const AliTrackContainer *particles, const char *trigger, const char *detector);
+  void FillPIDCorrelationPlot(const AliEmcalJet *jet, const AliTrackContainer *particles, double radius, const char *trigger, const char *detector);
 
 private:
   AliAnalysisTaskEmcalTriggerJets(const AliAnalysisTaskEmcalTriggerJets &);


### PR DESCRIPTION
PID histograms are usually sparsely filled, so THnSparses are
more appropriate in order to reduce the memory consumption, in
particular when having a large amount of histograms.