### PR TITLE
PWGGA/GammaConv: Fix compiler warnings concerning missing copy constr…

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskK0toPi0Pi0.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskK0toPi0Pi0.h
@@ -107,6 +107,10 @@ private:
   THistManager                                *fHistos;               ///< Container for Histograms
   TList                                       *fOutput;               ///< Global output container
 
+
+  AliAnalysisTaskK0toPi0Pi0(const AliAnalysisTaskK0toPi0Pi0 &);
+  AliAnalysisTaskK0toPi0Pi0 &operator=(const AliAnalysisTaskK0toPi0Pi0 &);
+
   /// \cond CLASSIMP
   ClassDef(AliAnalysisTaskK0toPi0Pi0, 1);
   /// \endcond

--- a/PWGGA/GammaConv/AliConversionCutHandler.cxx
+++ b/PWGGA/GammaConv/AliConversionCutHandler.cxx
@@ -45,6 +45,49 @@ fClusterCutArray(new TString[fNMaxCuts])
   }
 }
 
+AliConversionCutHandler::AliConversionCutHandler(const AliConversionCutHandler &ref):
+fValidCuts(ref.fValidCuts),
+fNCuts(ref.fNCuts),
+fNMaxCuts(ref.fNMaxCuts),
+fEventCutArray(new TString[fNMaxCuts]),
+fPhotonCutArray(new TString[fNMaxCuts]),
+fMesonCutArray(new TString[fNMaxCuts]),
+fClusterCutArray(new TString[fNMaxCuts])
+{
+  for(Int_t i=0; i<fNMaxCuts; i++) {
+	fEventCutArray[i] = ref.fEventCutArray[i];
+	fPhotonCutArray[i] = ref.fPhotonCutArray[i];
+	fMesonCutArray[i] = ref.fMesonCutArray[i];
+	fClusterCutArray[i] = ref.fClusterCutArray[i];
+  }
+}
+
+AliConversionCutHandler &AliConversionCutHandler::operator=(const AliConversionCutHandler &ref) {
+  if(this != &ref){
+    delete[] fEventCutArray;
+    delete[] fPhotonCutArray;
+    delete[] fMesonCutArray;
+    delete[] fClusterCutArray;
+
+    fValidCuts = ref.fValidCuts;
+    fNCuts = ref.fNCuts;
+    fNMaxCuts = ref.fNMaxCuts;
+    fEventCutArray = new TString[fNMaxCuts];
+    fPhotonCutArray = new TString[fNMaxCuts];
+    fMesonCutArray = new TString[fNMaxCuts];
+    fClusterCutArray = new TString[fNMaxCuts];
+    for(Int_t i=0; i<fNMaxCuts; i++) {
+      for(Int_t i=0; i<fNMaxCuts; i++) {
+      fEventCutArray[i] = ref.fEventCutArray[i];
+      fPhotonCutArray[i] = ref.fPhotonCutArray[i];
+      fMesonCutArray[i] = ref.fMesonCutArray[i];
+      fClusterCutArray[i] = ref.fClusterCutArray[i];
+      }
+    }
+  }
+  return *this;
+}
+
 AliConversionCutHandler::~AliConversionCutHandler() {
   delete[] fEventCutArray;
   delete[] fPhotonCutArray;

--- a/PWGGA/GammaConv/AliConversionCutHandler.h
+++ b/PWGGA/GammaConv/AliConversionCutHandler.h
@@ -33,6 +33,8 @@ class TString;
 class AliConversionCutHandler {
 public:
 	AliConversionCutHandler(Int_t nMax=10);
+	AliConversionCutHandler(const AliConversionCutHandler &ref);
+	AliConversionCutHandler &operator=(const AliConversionCutHandler &ref);
 	virtual ~AliConversionCutHandler();
 
 	void AddCut(TString eventCut, TString photonCut, TString mesonCut);

--- a/PWGGA/GammaConv/AliConversionMesonCuts.cxx
+++ b/PWGGA/GammaConv/AliConversionMesonCuts.cxx
@@ -47,7 +47,9 @@ class iostream;
 
 using namespace std;
 
+/// \cond CLASSIMP
 ClassImp(AliConversionMesonCuts)
+/// \endcond
 
 
 const char* AliConversionMesonCuts::fgkCutNames[AliConversionMesonCuts::kNCuts] = {

--- a/PWGGA/GammaConv/AliConversionMesonCuts.h
+++ b/PWGGA/GammaConv/AliConversionMesonCuts.h
@@ -1,9 +1,6 @@
 #ifndef ALICONVERSIONMESONCUTS_H
 #define ALICONVERSIONMESONCUTS_H
 
-// Class handling all kinds of selection cuts for Gamma Conversion analysis
-// Authors: Svein Lindal, Daniel Lohner                        *
-
 #include "AliAODpidUtil.h"
 #include "AliConversionPhotonBase.h"
 #include "AliAODConversionMother.h"
@@ -30,8 +27,11 @@ class TList;
 class AliAnalysisManager;
 
 
-/***
+/**
  * @class AliConversionMesonCuts
+ * @brief Class handling all kinds of selection cuts for Gamma Conversion analysis
+ * @author Svein Lindal
+ * @author Daniel Lohner
  * @ingroup GammaConv
  *
  * The cut configuration is set as a string with an 19 digit number.
@@ -39,6 +39,7 @@ class AliAnalysisManager;
  * its values represent the cut values. The cut configuration is listed here:
  *
  * | Position in the cut string (from the end) | Cut type                 |
+ * |-------------------------------------------|--------------------------|
  * |                  0                        | MesonKind                |
  * |                  1                        | BackgroundScheme         | 
  * |                  2                        | NumberOfBGEvents         |
@@ -180,33 +181,33 @@ class AliConversionMesonCuts : public AliAnalysisCuts {
     Double_t GetSelectionHigh() const {return fSelectionHigh;}
     
   protected:
-    TList*    fHistograms;
-    Bool_t    fDoLightOutput;             // switch for running light output, kFALSE -> normal mode, kTRUE -> light mode
-    Int_t     fMode;                      // running mode of ConversionMesonCuts to select different sets of cut parameters for different running modes
+    TList*    fHistograms;				 ///< List of QA histograms
+    Bool_t    fDoLightOutput;             ///< switch for running light output, kFALSE -> normal mode, kTRUE -> light mode
+    Int_t     fMode;                      ///< running mode of ConversionMesonCuts to select different sets of cut parameters for different running modes
 
-    AliCaloPhotonCuts* fCaloPhotonCuts;   // CaloPhotonCutObject belonging to same main task
+    AliCaloPhotonCuts* fCaloPhotonCuts;   ///< CaloPhotonCutObject belonging to same main task
 
     //cuts
-    Int_t     fMesonKind;
-    Int_t     fIsMergedClusterCut;        // flag for merged cluster and di cluster analysis
-    Double_t  fMaxR;                      // r cut  
-    Bool_t    fEnableMassCut;             // flag to enable mass cut
-    Double_t  fSelectionLow;              // lower meson inv mass window for further selection
-    Double_t  fSelectionHigh;             // higher meson inv mass window for further selection
-    Int_t     fSelectionWindowCut;        // selection window for merged ana in mass
-    Double_t  fAlphaMinCutMeson;          // min value for meson alpha cut
-    Double_t  fAlphaCutMeson;             // max value for meson alpha cut
-    Double_t  fRapidityCutMeson;          // max value for meson rapidity
-    Bool_t    fUseRotationMethodInBG;     // flag to apply rotation method for meson bg estimation
-    Bool_t    fUsePtmaxMethodForBG;       // flag to apply Ptmax method
-    Bool_t    fDoBG;                      // flag to intialize BG
-    Bool_t    fdoBGProbability;           // flag to use probability method for meson bg estimation
-    Bool_t    fUseTrackMultiplicityForBG; // flag to use track multiplicity for meson bg estimation (else V0 mult)
-    Int_t     fnDegreeRotationPMForBG;    //
-    Int_t     fNumberOfBGEvents;          //
-    Float_t   fOpeningAngle;              // min opening angle for meson
-    Bool_t    fEnableMinOpeningAngleCut;  // flag to enable min opening angle cut
-    Bool_t    fEnableOneCellDistCut;      // flag to enable 1 cell dist cut
+    Int_t     fMesonKind;				 ///<
+    Int_t     fIsMergedClusterCut;        ///< flag for merged cluster and di cluster analysis
+    Double_t  fMaxR;                      ///< r cut
+    Bool_t    fEnableMassCut;             ///< flag to enable mass cut
+    Double_t  fSelectionLow;              ///< lower meson inv mass window for further selection
+    Double_t  fSelectionHigh;             ///< higher meson inv mass window for further selection
+    Int_t     fSelectionWindowCut;        ///< selection window for merged ana in mass
+    Double_t  fAlphaMinCutMeson;          ///< min value for meson alpha cut
+    Double_t  fAlphaCutMeson;             ///< max value for meson alpha cut
+    Double_t  fRapidityCutMeson;          ///< max value for meson rapidity
+    Bool_t    fUseRotationMethodInBG;     ///< flag to apply rotation method for meson bg estimation
+    Bool_t    fUsePtmaxMethodForBG;       ///< flag to apply Ptmax method
+    Bool_t    fDoBG;                      ///< flag to intialize BG
+    Bool_t    fdoBGProbability;           ///< flag to use probability method for meson bg estimation
+    Bool_t    fUseTrackMultiplicityForBG; ///< flag to use track multiplicity for meson bg estimation (else V0 mult)
+    Int_t     fnDegreeRotationPMForBG;    ///<
+    Int_t     fNumberOfBGEvents;          ///<
+    Float_t   fOpeningAngle;              ///< min opening angle for meson
+    Bool_t    fEnableMinOpeningAngleCut;  ///< flag to enable min opening angle cut
+    Bool_t    fEnableOneCellDistCut;      ///< flag to enable 1 cell dist cut
     Bool_t    fDoToCloseV0sCut;           //
     Double_t  fminV0Dist;                 //
     Bool_t    fDoSharedElecCut;           //
@@ -220,37 +221,39 @@ class AliConversionMesonCuts : public AliAnalysisCuts {
     Bool_t    fAlphaPtDepCut;             //
     Int_t     fElectronLabelArraySize;    //
     Int_t*    fElectronLabelArray;        //[fElectronLabelArraySize] Array with elec/pos v0 label
-    Double_t  fDCAGammaGammaCut;          // cut value for the maximum distance between the two photons [cm]
-    Double_t  fDCAZMesonPrimVtxCut;       // cut value for the maximum distance in Z between the production point of the Meson & the primary vertex [cm]
-    Double_t  fDCARMesonPrimVtxCut;       // cut value for the maximum distance in R between the production point of the Meson & the primary vertex [cm]
-    Bool_t    fDCAGammaGammaCutOn;        // cut flag for the maximum distance between the two photons
-    Bool_t    fDCAZMesonPrimVtxCutOn;     // cut flag for the maximum distance in Z between the production point of the Meson & the primary vertex 
-    Bool_t    fDCARMesonPrimVtxCutOn;     // cut flag for the maximum distance in R between the production point of the Meson & the primary vertex 
-    Double_t  fMinOpanCutMeson;           //
-    TF1*      fFMinOpanCut;               //
-    Bool_t    fMinOpanPtDepCut;           //
-    Double_t  fMaxOpanCutMeson;           //
-    TF1*      fFMaxOpanCut;               //
-    Bool_t    fMaxOpanPtDepCut;           //
-    Int_t     fBackgroundHandler;         //
+    Double_t  fDCAGammaGammaCut;          ///< cut value for the maximum distance between the two photons [cm]
+    Double_t  fDCAZMesonPrimVtxCut;       ///< cut value for the maximum distance in Z between the production point of the Meson & the primary vertex [cm]
+    Double_t  fDCARMesonPrimVtxCut;       ///< cut value for the maximum distance in R between the production point of the Meson & the primary vertex [cm]
+    Bool_t    fDCAGammaGammaCutOn;        ///< cut flag for the maximum distance between the two photons
+    Bool_t    fDCAZMesonPrimVtxCutOn;     ///< cut flag for the maximum distance in Z between the production point of the Meson & the primary vertex
+    Bool_t    fDCARMesonPrimVtxCutOn;     ///< cut flag for the maximum distance in R between the production point of the Meson & the primary vertex
+    Double_t  fMinOpanCutMeson;           ///<
+    TF1*      fFMinOpanCut;               ///<
+    Bool_t    fMinOpanPtDepCut;           ///<
+    Double_t  fMaxOpanCutMeson;           ///<
+    TF1*      fFMaxOpanCut;               ///<
+    Bool_t    fMaxOpanPtDepCut;           ///<
+    Int_t     fBackgroundHandler;         ///<
     
     // Histograms
-    TObjString* fCutString;                     // cut number used for analysis
+    TObjString* fCutString;                     ///< cut number used for analysis
     TString     fCutStringRead;
-    TH2F*       fHistoMesonCuts;                // bookkeeping for meson cuts
-    TH2F*       fHistoMesonBGCuts;              // bookkeeping for meson bg cuts
-    TH1F*       fHistoDCAGGMesonBefore;         //
-    TH1F*       fHistoDCAZMesonPrimVtxBefore;   //
-    TH1F*       fHistoDCARMesonPrimVtxBefore;   //
-    TH1F*       fHistoDCAGGMesonAfter;          //
-    TH2F*       fHistoDCAZMesonPrimVtxAfter;    //
-    TH1F*       fHistoDCARMesonPrimVtxAfter;    //
-    TH1F*       fHistoInvMassBefore;            //
-    TH1F*       fHistoInvMassAfter;             //
+    TH2F*       fHistoMesonCuts;                ///< bookkeeping for meson cuts
+    TH2F*       fHistoMesonBGCuts;              ///< bookkeeping for meson bg cuts
+    TH1F*       fHistoDCAGGMesonBefore;         ///<
+    TH1F*       fHistoDCAZMesonPrimVtxBefore;   ///<
+    TH1F*       fHistoDCARMesonPrimVtxBefore;   ///<
+    TH1F*       fHistoDCAGGMesonAfter;          ///<
+    TH2F*       fHistoDCAZMesonPrimVtxAfter;    ///<
+    TH1F*       fHistoDCARMesonPrimVtxAfter;    ///<
+    TH1F*       fHistoInvMassBefore;            ///<
+    TH1F*       fHistoInvMassAfter;             ///<
 
   private:
 
+    /// \cond CLASSIMP
     ClassDef(AliConversionMesonCuts,19)
+    /// \endcond
 };
 
 

--- a/PWGGA/GammaConv/AliConversionPhotonCuts.cxx
+++ b/PWGGA/GammaConv/AliConversionPhotonCuts.cxx
@@ -59,8 +59,9 @@ class iostream;
 
 using namespace std;
 
+/// \cond CLASSIMP
 ClassImp(AliConversionPhotonCuts)
-
+/// \endcond
 
 const char* AliConversionPhotonCuts::fgkCutNames[AliConversionPhotonCuts::kNCuts] = {
   "V0FinderType",           // 0

--- a/PWGGA/GammaConv/AliConversionPhotonCuts.h
+++ b/PWGGA/GammaConv/AliConversionPhotonCuts.h
@@ -1,9 +1,6 @@
 #ifndef ALICONVERSIONPHOTONCUTS_H
 #define ALICONVERSIONPHOTONCUTS_H
 
-// Class handling all kinds of selection cuts for Gamma Conversion analysis
-// Authors: Friederike Bock
-
 #include "AliAODpidUtil.h"
 #include "AliConversionPhotonBase.h"
 #include "AliAODConversionMother.h"
@@ -35,8 +32,10 @@ class TList;
 class AliAnalysisManager;
 class AliAODMCParticle;
 
-/***
+/**
  * @class AliConversionPhotonCuts
+ * @brief Class handling all kinds of selection cuts for Gamma Conversion analysis
+ * @author Friederike Bock
  * @ingroup GammaConv
  *
  * The cut configuration is set as a string with an 19 digit number.
@@ -44,6 +43,7 @@ class AliAODMCParticle;
  * its values represent the cut values. The cut configuration is listed here:
  *
  * | Position in the cut string (from the end) | Cut type               |
+ * |-------------------------------------------|------------------------|
  * |                  0                        | V0FinderType           |
  * |                  1                        | EtaCut                 | 
  * |                  2                        | MinRCut                |
@@ -252,140 +252,141 @@ class AliConversionPhotonCuts : public AliAnalysisCuts {
     Int_t GetV0FinderSameSign(){return fUseOnFlyV0FinderSameSign;}
       
   protected:
-    TList*            fHistograms;                          //
-    AliPIDResponse*   fPIDResponse;                         //
+    TList*            fHistograms;                          ///< List of QA histograms
+    AliPIDResponse*   fPIDResponse;                         ///< PID response
 
-    Bool_t            fDoLightOutput;                       // switch for running light output, kFALSE -> normal mode, kTRUE -> light mode
-    TString           fV0ReaderName;
+    Bool_t            fDoLightOutput;                       ///< switch for running light output, kFALSE -> normal mode, kTRUE -> light mode
+    TString           fV0ReaderName;						   ///< Name of the V0 reader
 
     //cuts
-    Double_t          fMaxR;                                // r cut
-    Double_t          fMinR;                                // r cut
-    Double_t          fEtaCut;                              // eta cut
-    Double_t          fEtaCutMin;                           // eta cut
-    Float_t           fEtaForPhiCutMin;                     // eta cut for phi sector selection
-    Float_t           fEtaForPhiCutMax;                     // eta cut for phi sector selection
-    Float_t           fMinPhiCut;                           // phi sector cut
-    Float_t           fMaxPhiCut;                           // phi sector cut
-    Bool_t            fDoShrinkTPCAcceptance;               // Flag for shrinking the TPC acceptance due to different reasons
-    Double_t          fPtCut;                               // pt cut
-    Double_t          fSinglePtCut;                         // pt cut for electron/positron
-    Double_t          fSinglePtCut2;                        // second pt cut for electron/positron if asymmetric cut is chosen
-    Bool_t            fDoAsymPtCut;                         // Flag for setting asymmetric pT cut on electron/positron
-    Double_t          fMaxZ;                                // z cut
-    Double_t          fMinClsTPC;                           // minimum clusters in the TPC
-    Double_t          fMinClsTPCToF;                        // minimum clusters to findable clusters
-    Double_t          fLineCutZRSlope;                      // linecut
-    Double_t          fLineCutZValue;                       // linecut
-    Double_t          fLineCutZRSlopeMin;                   // linecut
-    Double_t          fLineCutZValueMin;                    // linecut
-    Double_t          fChi2CutConversion;                   // chi2cut
-    Double_t          fPIDProbabilityCutNegativeParticle;   //
-    Double_t          fPIDProbabilityCutPositiveParticle;   //
-    Bool_t            fDodEdxSigmaCut;                      // flag to use the dEdxCut based on sigmas
-    Bool_t            fDoTOFsigmaCut;                       // flag to use TOF pid cut RRnewTOF
-    Double_t          fPIDTRDEfficiency;                    // required electron efficiency for TRD PID
-    Bool_t            fDoTRDPID;                            // flag to use TRD pid
-    Double_t          fPIDnSigmaAboveElectronLine;          // sigma cut
-    Double_t          fPIDnSigmaBelowElectronLine;          // sigma cut
-    Double_t          fTofPIDnSigmaAboveElectronLine;       // sigma cut RRnewTOF
-    Double_t          fTofPIDnSigmaBelowElectronLine;       // sigma cut RRnewTOF 
-    Double_t          fPIDnSigmaAbovePionLine;              // sigma cut
-    Double_t          fPIDnSigmaAbovePionLineHighPt;        // sigma cut
-    Double_t          fPIDMinPnSigmaAbovePionLine;          // sigma cut
-    Double_t          fPIDMaxPnSigmaAbovePionLine;          // sigma cut
-    Double_t          fDoKaonRejectionLowP;                 // Kaon rejection at low p
-    Double_t          fDoProtonRejectionLowP;               // Proton rejection at low p
-    Double_t          fDoPionRejectionLowP;                 // Pion rejection at low p
-    Double_t          fPIDnSigmaAtLowPAroundKaonLine;       // sigma cut
-    Double_t          fPIDnSigmaAtLowPAroundProtonLine;     // sigma cut
-    Double_t          fPIDnSigmaAtLowPAroundPionLine;       // sigma cut
-    Double_t          fPIDMinPKaonRejectionLowP;            // Momentum limit to apply kaon rejection
-    Double_t          fPIDMinPProtonRejectionLowP;          // Momentum limit to apply proton rejection
-    Double_t          fPIDMinPPionRejectionLowP;            // Momentum limit to apply proton rejection
-    Bool_t            fDoQtGammaSelection;                  // Select gammas using qtMax
-    Bool_t            fDo2DQt;                              // Select gammas using ellipse cut
-    Double_t          fQtMax;                               // Maximum Qt from Armenteros to select Gammas
-    Double_t          fNSigmaMass;                          // nsigma cut
-    Bool_t            fUseEtaMinCut;                        // flag
-    Bool_t            fUseOnFlyV0Finder;                    // flag
-    Int_t             fUseOnFlyV0FinderSameSign;            // int to set same sign pairing
-    Bool_t            fDoPhotonAsymmetryCut;                // flag to use the PhotonAsymetryCut
-    Bool_t            fDoPhotonPDependentAsymCut;           // flag to use the PhotonAsymetryCut with P dependent cut
-    TF1 *             fFAsymmetryCut;                       //
-    Double_t          fMinPPhotonAsymmetryCut;              // Min Momentum for Asymmetry Cut
-    Double_t          fMinPhotonAsymmetry;                  // Asymmetry Cut
-    Bool_t            fUseCorrectedTPCClsInfo;              // flag to use corrected tpc cl info
-    Bool_t            fUseTOFpid;                           // flag to use tof pid
-    Float_t           fOpeningAngle;                        // min opening angle for meson
-    Float_t           fPsiPairCut;                          //
-    Bool_t            fDo2DPsiPairChi2;                     //
-    Bool_t            fIncludeRejectedPsiPair;              //
-    Float_t           fCosPAngleCut;                        //
-    Bool_t            fDoToCloseV0sCut;                     //
-    Double_t          fminV0Dist;                           //
-    Bool_t            fDoSharedElecCut;                     //
-    Bool_t            fDoPhotonQualitySelectionCut;         //
-    Int_t             fPhotonQualityCut;                    //
-    TRandom3          fRandom;                              //
-    Int_t             fElectronArraySize;                   // Size of electron array
+    Double_t          fMaxR;                                ///< r cut
+    Double_t          fMinR;                                ///< r cut
+    Double_t          fEtaCut;                              ///< eta cut
+    Double_t          fEtaCutMin;                           ///< eta cut
+    Float_t           fEtaForPhiCutMin;                     ///< eta cut for phi sector selection
+    Float_t           fEtaForPhiCutMax;                     ///< eta cut for phi sector selection
+    Float_t           fMinPhiCut;                           ///< phi sector cut
+    Float_t           fMaxPhiCut;                           ///< phi sector cut
+    Bool_t            fDoShrinkTPCAcceptance;               ///< Flag for shrinking the TPC acceptance due to different reasons
+    Double_t          fPtCut;                               ///< pt cut
+    Double_t          fSinglePtCut;                         ///< pt cut for electron/positron
+    Double_t          fSinglePtCut2;                        ///< second pt cut for electron/positron if asymmetric cut is chosen
+    Bool_t            fDoAsymPtCut;                         ///< Flag for setting asymmetric pT cut on electron/positron
+    Double_t          fMaxZ;                                ///< z cut
+    Double_t          fMinClsTPC;                           ///< minimum clusters in the TPC
+    Double_t          fMinClsTPCToF;                        ///< minimum clusters to findable clusters
+    Double_t          fLineCutZRSlope;                      ///< linecut
+    Double_t          fLineCutZValue;                       ///< linecut
+    Double_t          fLineCutZRSlopeMin;                   ///< linecut
+    Double_t          fLineCutZValueMin;                    ///< linecut
+    Double_t          fChi2CutConversion;                   ///< chi2cut
+    Double_t          fPIDProbabilityCutNegativeParticle;   ///<
+    Double_t          fPIDProbabilityCutPositiveParticle;   ///<
+    Bool_t            fDodEdxSigmaCut;                      ///< flag to use the dEdxCut based on sigmas
+    Bool_t            fDoTOFsigmaCut;                       ///< flag to use TOF pid cut RRnewTOF
+    Double_t          fPIDTRDEfficiency;                    ///< required electron efficiency for TRD PID
+    Bool_t            fDoTRDPID;                            ///< flag to use TRD pid
+    Double_t          fPIDnSigmaAboveElectronLine;          ///< sigma cut
+    Double_t          fPIDnSigmaBelowElectronLine;          ///< sigma cut
+    Double_t          fTofPIDnSigmaAboveElectronLine;       ///< sigma cut RRnewTOF
+    Double_t          fTofPIDnSigmaBelowElectronLine;       ///< sigma cut RRnewTOF
+    Double_t          fPIDnSigmaAbovePionLine;              ///< sigma cut
+    Double_t          fPIDnSigmaAbovePionLineHighPt;        ///< sigma cut
+    Double_t          fPIDMinPnSigmaAbovePionLine;          ///< sigma cut
+    Double_t          fPIDMaxPnSigmaAbovePionLine;          ///< sigma cut
+    Double_t          fDoKaonRejectionLowP;                 ///< Kaon rejection at low p
+    Double_t          fDoProtonRejectionLowP;               ///< Proton rejection at low p
+    Double_t          fDoPionRejectionLowP;                 ///< Pion rejection at low p
+    Double_t          fPIDnSigmaAtLowPAroundKaonLine;       ///< sigma cut
+    Double_t          fPIDnSigmaAtLowPAroundProtonLine;     ///< sigma cut
+    Double_t          fPIDnSigmaAtLowPAroundPionLine;       ///< sigma cut
+    Double_t          fPIDMinPKaonRejectionLowP;            ///< Momentum limit to apply kaon rejection
+    Double_t          fPIDMinPProtonRejectionLowP;          ///< Momentum limit to apply proton rejection
+    Double_t          fPIDMinPPionRejectionLowP;            ///< Momentum limit to apply proton rejection
+    Bool_t            fDoQtGammaSelection;                  ///< Select gammas using qtMax
+    Bool_t            fDo2DQt;                              ///< Select gammas using ellipse cut
+    Double_t          fQtMax;                               ///< Maximum Qt from Armenteros to select Gammas
+    Double_t          fNSigmaMass;                          ///< nsigma cut
+    Bool_t            fUseEtaMinCut;                        ///< flag
+    Bool_t            fUseOnFlyV0Finder;                    ///< flag
+    Int_t             fUseOnFlyV0FinderSameSign;            ///< int to set same sign pairing
+    Bool_t            fDoPhotonAsymmetryCut;                ///< flag to use the PhotonAsymetryCut
+    Bool_t            fDoPhotonPDependentAsymCut;           ///< flag to use the PhotonAsymetryCut with P dependent cut
+    TF1 *             fFAsymmetryCut;                       ///<
+    Double_t          fMinPPhotonAsymmetryCut;              ///< Min Momentum for Asymmetry Cut
+    Double_t          fMinPhotonAsymmetry;                  ///< Asymmetry Cut
+    Bool_t            fUseCorrectedTPCClsInfo;              ///< flag to use corrected tpc cl info
+    Bool_t            fUseTOFpid;                           ///< flag to use tof pid
+    Float_t           fOpeningAngle;                        ///< min opening angle for meson
+    Float_t           fPsiPairCut;                          ///<
+    Bool_t            fDo2DPsiPairChi2;                     ///<
+    Bool_t            fIncludeRejectedPsiPair;              ///<
+    Float_t           fCosPAngleCut;                        ///<
+    Bool_t            fDoToCloseV0sCut;                     ///<
+    Double_t          fminV0Dist;                           ///<
+    Bool_t            fDoSharedElecCut;                     ///<
+    Bool_t            fDoPhotonQualitySelectionCut;         ///<
+    Int_t             fPhotonQualityCut;                    ///<
+    TRandom3          fRandom;                              ///<
+    Int_t             fElectronArraySize;                   ///< Size of electron array
     Int_t*            fElectronLabelArray;                  //[fElectronArraySize]
-    Double_t          fDCAZPrimVtxCut;                      // cut value for the maximum distance in Z between the photon & the primary vertex [cm]
-    Double_t          fDCARPrimVtxCut;                      // cut value for the maximum distance in R between the photon & the primary vertex [cm]
-    Int_t             fInPlaneOutOfPlane;                   // In-Plane Out-Of Plane Analysis
-    Float_t           fConversionPointXArray;               // Array with conversion Point x
-    Float_t           fConversionPointYArray;               // Array with conversion Point y
-    Float_t           fConversionPointZArray;               // Array with conversion Point z
-    TObjString*       fCutString;                           // cut number used for analysis
-    TString           fCutStringRead;                       //
-    Int_t             fIsHeavyIon;                          // flag for pp (0), PbPb (1), pPb (2)
-    Bool_t            fUseITSpid;                           // flag to use tof pid    
-    Double_t          fITSPIDnSigmaAboveElectronLine;       // sigma cut RRnewTOF
-    Double_t          fITSPIDnSigmaBelowElectronLine;       // sigma cut RRnewTOF
-    Double_t          fMaxPtPIDITS;                         //max pt for ITS PID
-    Double_t          fTRDPIDBelowCut;                      // TRD cut range
-    Double_t          fTRDPIDAboveCut;                      // TRD cut range
-    Bool_t            fDoDoubleCountingCut;                 // Flag to reject double counting
-    Double_t          fMinRDC;                              // Min R for Double Counting Cut
-    Double_t          fDeltaR;                              // Delta R for Double Counting Cut
-    Double_t          fOpenAngle;                           // Opening Angle for Double Counting Cut
-    Bool_t            fSwitchToKappa;                       // switches from standard dEdx nSigma TPC cuts to Kappa TPC
-    Float_t           fKappaMinCut;                         // maximum Kappa cut
-    Float_t           fKappaMaxCut;                         // maximum Kappa cut
-    Bool_t            fMaterialBudgetWeightsInitialized;    // weights for conversions photons due due deviating material budget in MC compared to data
+    Double_t          fDCAZPrimVtxCut;                      ///< cut value for the maximum distance in Z between the photon & the primary vertex [cm]
+    Double_t          fDCARPrimVtxCut;                      ///< cut value for the maximum distance in R between the photon & the primary vertex [cm]
+    Int_t             fInPlaneOutOfPlane;                   ///< In-Plane Out-Of Plane Analysis
+    Float_t           fConversionPointXArray;               ///< Array with conversion Point x
+    Float_t           fConversionPointYArray;               ///< Array with conversion Point y
+    Float_t           fConversionPointZArray;               ///< Array with conversion Point z
+    TObjString*       fCutString;                           ///< cut number used for analysis
+    TString           fCutStringRead;                       ///<
+    Int_t             fIsHeavyIon;                          ///< flag for pp (0), PbPb (1), pPb (2)
+    Bool_t            fUseITSpid;                           ///< flag to use tof pid
+    Double_t          fITSPIDnSigmaAboveElectronLine;       ///< sigma cut RRnewTOF
+    Double_t          fITSPIDnSigmaBelowElectronLine;       ///< sigma cut RRnewTOF
+    Double_t          fMaxPtPIDITS;                         ///< max pt for ITS PID
+    Double_t          fTRDPIDBelowCut;                      ///< TRD cut range
+    Double_t          fTRDPIDAboveCut;                      ///< TRD cut range
+    Bool_t            fDoDoubleCountingCut;                 ///< Flag to reject double counting
+    Double_t          fMinRDC;                              ///< Min R for Double Counting Cut
+    Double_t          fDeltaR;                              ///< Delta R for Double Counting Cut
+    Double_t          fOpenAngle;                           ///< Opening Angle for Double Counting Cut
+    Bool_t            fSwitchToKappa;                       ///< switches from standard dEdx nSigma TPC cuts to Kappa TPC
+    Float_t           fKappaMinCut;                         ///< maximum Kappa cut
+    Float_t           fKappaMaxCut;                         ///< maximum Kappa cut
+    Bool_t            fMaterialBudgetWeightsInitialized;    ///< weights for conversions photons due due deviating material budget in MC compared to data
     
     // Histograms
-    TH1F*             fHistoEtaDistV0s;                     // eta-distribution of all V0s after Finder selection
-    TH1F*             fHistoEtaDistV0sAfterdEdxCuts;        // eta-distribution of all V0s after Finder selection after dEdx cuts
-    TH2F*             fHistodEdxCuts;                       // bookkeeping for dEdx cuts
-    TH2F*             fHistoTPCdEdxbefore;                  // TPC dEdx before cuts
-    TH2F*             fHistoTPCdEdxafter;                   // TPC dEdx after cuts
-    TH2F*             fHistoTPCdEdxSigbefore;               // TPC Sigma dEdx before cuts
-    TH2F*             fHistoTPCdEdxSigafter;                // TPC Sigm dEdx after cuts
-    TH2F*             fHistoKappaafter;                     // Kappa vs photon pt after cuts
-    TH2F*             fHistoTOFbefore;                      // TOF before cuts
-    TH2F*             fHistoTOFSigbefore;                   // TOF Sigma before cuts
-    TH2F*             fHistoTOFSigafter;                    // TOF Sigma after cuts
-    TH2F*             fHistoITSSigbefore;                   // ITS Sigma before cuts
-    TH2F*             fHistoITSSigafter;                    // ITS Sigma after cuts
-    TH2F*             fHistoPsiPairDeltaPhiafter;           // TOF Sigma after cuts
-    TH1F*             fHistoTrackCuts;                      // bookkeeping for track cuts
-    TH2F*             fHistoPhotonCuts;                     // bookkeeping for photon specific cuts
-    TH1F*             fHistoInvMassbefore;                  // e+e- inv mass distribution before cuts
-    TH2F*             fHistoArmenterosbefore;               // armenteros podolanski plot before cuts
-    TH1F*             fHistoInvMassafter;                   // e+e- inv mass distribution after cuts
-    TH2F*             fHistoArmenterosafter;                // armenteros podolanski plot after cuts
-    TH2F*             fHistoAsymmetryafter;                 // asymmetry plot after cuts
-    TH2F*             fHistoAcceptanceCuts;                 // bookkeeping for acceptance cuts
-    TH1F*             fHistoCutIndex;                       // bookkeeping for cuts
-    TH1F*             fHistoEventPlanePhi;                  // EventPlaneAngle Minus Photon Angle
-    Bool_t            fPreSelCut;                           // Flag for preselection cut used in V0Reader
-    Bool_t            fProcessAODCheck;                     // Flag for processing check for AOD to be contained in AliAODs.root and AliAODGammaConversion.root
+    TH1F*             fHistoEtaDistV0s;                     ///< eta-distribution of all V0s after Finder selection
+    TH1F*             fHistoEtaDistV0sAfterdEdxCuts;        ///< eta-distribution of all V0s after Finder selection after dEdx cuts
+    TH2F*             fHistodEdxCuts;                       ///< bookkeeping for dEdx cuts
+    TH2F*             fHistoTPCdEdxbefore;                  ///< TPC dEdx before cuts
+    TH2F*             fHistoTPCdEdxafter;                   ///< TPC dEdx after cuts
+    TH2F*             fHistoTPCdEdxSigbefore;               ///< TPC Sigma dEdx before cuts
+    TH2F*             fHistoTPCdEdxSigafter;                ///< TPC Sigm dEdx after cuts
+    TH2F*             fHistoKappaafter;                     ///< Kappa vs photon pt after cuts
+    TH2F*             fHistoTOFbefore;                      ///< TOF before cuts
+    TH2F*             fHistoTOFSigbefore;                   ///< TOF Sigma before cuts
+    TH2F*             fHistoTOFSigafter;                    ///< TOF Sigma after cuts
+    TH2F*             fHistoITSSigbefore;                   ///< ITS Sigma before cuts
+    TH2F*             fHistoITSSigafter;                    ///< ITS Sigma after cuts
+    TH2F*             fHistoPsiPairDeltaPhiafter;           ///< TOF Sigma after cuts
+    TH1F*             fHistoTrackCuts;                      ///< bookkeeping for track cuts
+    TH2F*             fHistoPhotonCuts;                     ///< bookkeeping for photon specific cuts
+    TH1F*             fHistoInvMassbefore;                  ///< e+e- inv mass distribution before cuts
+    TH2F*             fHistoArmenterosbefore;               ///< armenteros podolanski plot before cuts
+    TH1F*             fHistoInvMassafter;                   ///< e+e- inv mass distribution after cuts
+    TH2F*             fHistoArmenterosafter;                ///< armenteros podolanski plot after cuts
+    TH2F*             fHistoAsymmetryafter;                 ///< asymmetry plot after cuts
+    TH2F*             fHistoAcceptanceCuts;                 ///< bookkeeping for acceptance cuts
+    TH1F*             fHistoCutIndex;                       ///< bookkeeping for cuts
+    TH1F*             fHistoEventPlanePhi;                  ///< EventPlaneAngle Minus Photon Angle
+    Bool_t            fPreSelCut;                           ///< Flag for preselection cut used in V0Reader
+    Bool_t            fProcessAODCheck;                     ///< Flag for processing check for AOD to be contained in AliAODs.root and AliAODGammaConversion.root
     TProfile*         fProfileContainingMaterialBudgetWeights;      
 
   private:
-  
+    /// \cond CLASSIMP
     ClassDef(AliConversionPhotonCuts,15)
+    /// \endcond
 };
 
 #endif


### PR DESCRIPTION
…uctor and assignment operator

- Implement copy constructor and assignment operator in AliConversionCutHandler
- Make copy constructor and assignment operator private in AliAnalysisTaskK0toPi0Pi0
In addition a few small doxygen fixes on already converted classes
- Add missing condititon for classimp
- Move author declaration and brief description to doxygen header
- Move member variable documentation to doxygen format
- Fix comment format in order to make class appearing on alidoc