### PR TITLE
PWGGA/GammaConv: Adding interface function adding background mesons f…

### DIFF
--- a/PWGGA/GammaConv/AliGammaConversionAODBGHandler.cxx
+++ b/PWGGA/GammaConv/AliGammaConversionAODBGHandler.cxx
@@ -620,7 +620,7 @@ void AliGammaConversionAODBGHandler::AddMesonEvent(TList* const eventMothers, Do
 	fBGEventVertex[z][m][eventCounter].fEP = epvalue;
 
 	//first clear the vector
-    for(Int_t d=0;d<fBGEvents[z][m][eventCounter].size();d++){
+  for(Int_t d=0;d<fBGEvents[z][m][eventCounter].size();d++){
 		delete (AliAODConversionMother*)(fBGEventsMeson[z][m][eventCounter][d]);
 	}
 	fBGEventsMeson[z][m][eventCounter].clear();
@@ -632,6 +632,32 @@ void AliGammaConversionAODBGHandler::AddMesonEvent(TList* const eventMothers, Do
 	fBGEventMesonCounter[z][m]++;
 }
 
+void AliGammaConversionAODBGHandler::AddMesonEvent(const std::vector<AliAODConversionMother> &eventMother, Double_t xvalue, Double_t yvalue, Double_t zvalue, Int_t multiplicity, Double_t epvalue){
+  Int_t z = GetZBinIndex(zvalue);
+  Int_t m = GetMultiplicityBinIndex(multiplicity);
+
+  if(fBGEventMesonCounter[z][m] >= fNEvents){
+    fBGEventMesonCounter[z][m]=0;
+  }
+  Int_t eventCounter=fBGEventMesonCounter[z][m];
+
+  fBGEventVertex[z][m][eventCounter].fX = xvalue;
+  fBGEventVertex[z][m][eventCounter].fY = yvalue;
+  fBGEventVertex[z][m][eventCounter].fZ = zvalue;
+  fBGEventVertex[z][m][eventCounter].fEP = epvalue;
+
+  //first clear the vector
+  for(Int_t d=0;d<fBGEvents[z][m][eventCounter].size();d++){
+    delete (AliAODConversionMother*)(fBGEventsMeson[z][m][eventCounter][d]);
+  }
+  fBGEventsMeson[z][m][eventCounter].clear();
+
+  // add the gammas to the vector
+  for(const auto &mother : eventMother){
+    fBGEventsMeson[z][m][eventCounter].push_back(new AliAODConversionMother(mother));
+  }
+  fBGEventMesonCounter[z][m]++;
+}
 
 //_____________________________________________________________________________________________________________________________
 void AliGammaConversionAODBGHandler::AddElectronEvent(TClonesArray* const eventENeg, Double_t zvalue, Int_t multiplicity){

--- a/PWGGA/GammaConv/AliGammaConversionAODBGHandler.h
+++ b/PWGGA/GammaConv/AliGammaConversionAODBGHandler.h
@@ -21,12 +21,8 @@
 #include "TClonesArray.h"
 #include "AliESDVertex.h"
 
-#if __GNUC__ >= 3
-using namespace std;
-#endif
-
-typedef vector<AliAODConversionPhoton*> AliGammaConversionAODVector;
-typedef vector<AliAODConversionMother*> AliGammaConversionMotherAODVector;
+typedef std::vector<AliAODConversionPhoton*> AliGammaConversionAODVector;
+typedef std::vector<AliAODConversionMother*> AliGammaConversionMotherAODVector;
 
 class AliGammaConversionAODBGHandler : public TObject {
 
@@ -40,13 +36,13 @@ class AliGammaConversionAODBGHandler : public TObject {
 	
 	typedef struct GammaConversionVertex GammaConversionVertex; 																//!
 
-	typedef vector<AliGammaConversionAODVector> AliGammaConversionBGEventVector;
-	typedef vector<AliGammaConversionBGEventVector> AliGammaConversionMultipicityVector;
-	typedef vector<AliGammaConversionMultipicityVector> AliGammaConversionBGVector;
+	typedef std::vector<AliGammaConversionAODVector> AliGammaConversionBGEventVector;
+	typedef std::vector<AliGammaConversionBGEventVector> AliGammaConversionMultipicityVector;
+	typedef std::vector<AliGammaConversionMultipicityVector> AliGammaConversionBGVector;
 
-	typedef vector<AliGammaConversionMotherAODVector> AliGammaConversionMotherBGEventVector;
-	typedef vector<AliGammaConversionMotherBGEventVector> AliGammaConversionMotherMultipicityVector;
-	typedef vector<AliGammaConversionMotherMultipicityVector> AliGammaConversionMotherBGVector;
+	typedef std::vector<AliGammaConversionMotherAODVector> AliGammaConversionMotherBGEventVector;
+	typedef std::vector<AliGammaConversionMotherBGEventVector> AliGammaConversionMotherMultipicityVector;
+	typedef std::vector<AliGammaConversionMotherMultipicityVector> AliGammaConversionMotherBGVector;
 	
 
 	AliGammaConversionAODBGHandler();																							//constructor
@@ -66,6 +62,7 @@ class AliGammaConversionAODBGHandler : public TObject {
 
 	void AddEvent(TList* const eventGammas, Double_t xvalue,Double_t yvalue,Double_t zvalue, Int_t multiplicity, Double_t epvalue = -100);
 	void AddMesonEvent(TList* const eventMothers, Double_t xvalue,Double_t yvalue,Double_t zvalue, Int_t multiplicity, Double_t epvalue = -100);
+	void AddMesonEvent(const std::vector<AliAODConversionMother> &eventMother, Double_t xvalue, Double_t yvalue, Double_t zvalue, Int_t multiplicity, Double_t epvalue = -100);
 	void AddElectronEvent(TClonesArray* const eventENeg, Double_t zvalue, Int_t multiplicity);
 
 	Int_t GetNBGEvents()const {return fNEvents;}


### PR DESCRIPTION
…rom std::vector

In addition removing "using namespace std" from header file and
replacing instances with "std::" in order to avoid implicit
inclusion of the standard namespace in recursive include chains.