### PR TITLE
Fill by index and v0

### DIFF
--- a/PWGCF/Correlations/C2/AliAnalysisC2Settings.cxx
+++ b/PWGCF/Correlations/C2/AliAnalysisC2Settings.cxx
@@ -23,8 +23,9 @@ AliAnalysisC2Settings::AliAnalysisC2Settings() :
   fMultEstimatorValidTracks("ValidTracks"),
   fTriggerMask(0),
   fUseFMD(false),
-  fUseSPclusters(false),
-  fUseSPtracklets(false)
+  fUseV0(false),
+  fUseSPDclusters(false),
+  fUseSPDtracklets(false)
 {
   Double_t _ptbins[] = {3.0, 4.0, 6.0, 8.0, 15.0};
   fPtBinEdges = edgeContainer(_ptbins, _ptbins + sizeof(_ptbins) / sizeof(_ptbins[0]));

--- a/PWGCF/Correlations/C2/AliAnalysisC2Settings.h
+++ b/PWGCF/Correlations/C2/AliAnalysisC2Settings.h
@@ -69,12 +69,14 @@ class AliAnalysisC2Settings : public TObject {
 
   // If availible, trigger selection should be done throught the physics selection trigger mass
   UInt_t fTriggerMask;
-  // Is the AliAODForwardMult object needed (ie., is the fmd needed?)
+  // Use FMD in forward region; requires AliAODForwardMult object
   Bool_t fUseFMD;
-  // Is the AliAODCentralMult object needed (ie., is the fmd needed?)
-  Bool_t fUseSPclusters;
-  // Instead of clusters, we can also run on SPD tracklets.
-  Bool_t fUseSPtracklets;
+  /// Use V0 amplitudes in the forward region
+  Bool_t fUseV0;
+  /// Use SPD Clusters in the central region
+  Bool_t fUseSPDclusters;
+  /// Use SPD tracklets in the central region
+  Bool_t fUseSPDtracklets;
 
 private:
   ClassDef(AliAnalysisC2Settings, 1);

--- a/PWGCF/Correlations/C2/AliAnalysisTaskC2.cxx
+++ b/PWGCF/Correlations/C2/AliAnalysisTaskC2.cxx
@@ -246,13 +246,7 @@ void AliAnalysisTaskC2::UserExec(Option_t *)
 			    multiplicity,
 			    zvtx};
     for (auto single: this->fsingleHists) {
-      	if (// Check overflow; see comments in the loop for the pairs.
-	    single->GetAxis(cSinglesDims::kEta)->GetBinLowEdge(1) <= stuffing[cSinglesDims::kEta]
-	    && stuffing[cSinglesDims::kEta] < single->GetAxis(cSinglesDims::kEta)->
-	    GetBinUpEdge(single->GetAxis(cSinglesDims::kEta)->GetNbins()))
-	  {
-	    single->Fill(stuffing, evWeight * track.weight);
-	  }
+      single->Fill(stuffing, evWeight * track.weight);
     }
   }
 
@@ -330,16 +324,15 @@ UInt_t AliAnalysisTaskC2::GetPairHistIndex(Float_t trigger, Float_t assoc) {
 AliAnalysisTaskValidation::Tracks AliAnalysisTaskC2::GetValidTracks() {
   // Get the event validation object
   AliAnalysisTaskValidation* ev_val = dynamic_cast<AliAnalysisTaskValidation*>(this->GetInputData(1));
-  ev_val->GetFMDhits();
 
   AliAnalysisTaskValidation::Tracks ret_vector;
   // Append central tracklets
   if (this->fSettings.kRECON == this->fSettings.fDataType) {
     // Are we running on SPD clusters? If so add them to our track vector
-    if (this->fSettings.fUseSPclusters) {
+    if (this->fSettings.fUseSPDclusters) {
       AliError("SPD clusters not yet implemented");
     }
-    else if (this->fSettings.fUseSPtracklets) {
+    else if (this->fSettings.fUseSPDtracklets) {
       auto spdhits = ev_val->GetSPDtracklets();
       ret_vector.insert(ret_vector.end(), spdhits.begin(), spdhits.end());
     }
@@ -348,6 +341,9 @@ AliAnalysisTaskValidation::Tracks AliAnalysisTaskC2::GetValidTracks() {
     if (this->fSettings.fUseFMD) {
       auto fmdhits = ev_val->GetFMDhits();
       ret_vector.insert(ret_vector.end(), fmdhits.begin(), fmdhits.end());
+    } else if (this->fSettings.fUseV0){
+      auto v0amps = ev_val->GetV0hits();
+      ret_vector.insert(ret_vector.end(), v0amps.begin(), v0amps.end());
     }
   }
   // MC truth case:

--- a/PWGCF/Correlations/C2/AliAnalysisTaskValidation.cxx
+++ b/PWGCF/Correlations/C2/AliAnalysisTaskValidation.cxx
@@ -65,7 +65,7 @@ AliAnalysisTaskValidation::AliAnalysisTaskValidation(const char *name)
   fValidators.push_back(EventValidation::kHasEntriesV0);
   fValidators.push_back(EventValidation::kHasValidVertex);
   fValidators.push_back(EventValidation::kHasMultSelection);
-  fValidators.push_back(EventValidation::kNotOutOfBunchPU);
+  // fValidators.push_back(EventValidation::kNotOutOfBunchPU);
   fValidators.push_back(EventValidation::kNotMultiVertexPU);
   fValidators.push_back(EventValidation::kNotSPDPU);
   fValidators.push_back(EventValidation::kNotSPDClusterVsTrackletBG);


### PR DESCRIPTION
This reduces the number of times the bin indices have to be calculated for the pair histogram, which is a very costly operation. Also, this PR enables the usage of the V0 for cross checks