### PR TITLE
PWGDQ: Updated handling of AOD MC in Dielectron Framework

### DIFF
--- a/PWGDQ/dielectron/core/AliDielectronMC.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronMC.cxx
@@ -171,8 +171,8 @@ AliVParticle* AliDielectronMC::GetMCTrackFromMCEvent(Int_t label) const
     track = fMCEvent->GetTrack(label); //  tracks from MC event (ESD)
   } else if(fAnaType == kAOD) {
     if (!fMcArray){ AliError("No fMcArray"); return NULL;}
-    if (label>fMcArray->GetEntriesFast()) { AliDebug(10,Form("track %d out of array size %d",label,fMcArray->GetEntriesFast())); return NULL;}
-    track = (AliVParticle*)fMcArray->At(label); //  tracks from MC event (AOD)
+    if (label>fMcArray->GetEntriesFast()) { AliWarning(Form("track %d out of array size %d",label,fMcArray->GetEntriesFast())); return NULL;}
+    track = (AliVParticle*)fMCEvent->GetTrack(label);
   }
   return track;
 }
@@ -206,6 +206,9 @@ Bool_t AliDielectronMC::ConnectMCEvent()
     if (!aodHandler) return kFALSE;
     AliAODEvent *aod=aodHandler->GetEvent();
     if (!aod) return kFALSE;
+
+    fMCEvent = aodHandler->MCEvent();
+    if (!fMCEvent) AliError("No MCEvent available");
 
     fMcArray = dynamic_cast<TClonesArray*>(aod->FindListObject(AliAODMCParticle::StdBranchName()));
     if (!fMcArray){ /*AliError("Could not retrieve MC array!");*/ return kFALSE; }
@@ -1020,6 +1023,21 @@ Bool_t AliDielectronMC::IsPhysicalPrimary(Int_t label) const {
 }
 
 //________________________________________________________________________________
+Bool_t AliDielectronMC::IsPrimary(Int_t label) const {
+  //
+  if(label<0) return kFALSE;
+  if(fAnaType==kAOD) {
+    if(!fMcArray) return kFALSE;
+
+    return (static_cast<AliAODMCParticle*>(GetMCTrackFromMCEvent(label)))->IsPrimary();
+  } else if(fAnaType==kESD) {
+    if (!fMCEvent) return kFALSE;
+    return (label>=0 && label<=GetNPrimary());
+  }
+  return kFALSE;
+}
+
+//________________________________________________________________________________
 Bool_t AliDielectronMC::IsSecondaryFromWeakDecay(Int_t label) const {
   //
   // Check if the particle with label "label" is a physical secondary from weak decay according to the
@@ -1091,7 +1109,7 @@ Bool_t AliDielectronMC::CheckParticleSource(Int_t label, AliDielectronSignalMC::
       // NOTE: This includes all physics event history (initial state particles,
       //       exchange bosons, quarks, di-quarks, strings, un-stable particles, final state particles)
       //       Only the final state particles make it to the detector!!
-      return (label>=0 && label<=GetNPrimary());
+      return IsPrimary(label);
     break;
     case AliDielectronSignalMC::kFinalState :
       // primary particles created in the collision which reach the detectors
@@ -1120,7 +1138,8 @@ Bool_t AliDielectronMC::CheckParticleSource(Int_t label, AliDielectronSignalMC::
     case AliDielectronSignalMC::kSecondary :
       // particles which are created by the interaction of final state primaries with the detector
       // or particles from strange weakly decaying particles (e.g. lambda, kaons, etc.)
-      return (label>=GetNPrimary() && !IsPhysicalPrimary(label));
+      return (IsSecondaryFromWeakDecay(label) || IsSecondaryFromMaterial(label));
+      // return (label>=GetNPrimary() && !IsPhysicalPrimary(label)); // old definition
     break;
     case AliDielectronSignalMC::kSecondaryFromWeakDecay :
       // secondary particle from weak decay
@@ -1132,10 +1151,12 @@ Bool_t AliDielectronMC::CheckParticleSource(Int_t label, AliDielectronSignalMC::
       return (IsSecondaryFromMaterial(label));
     break;
     case AliDielectronSignalMC::kFromBGEvent :
+      // NOT implemented for AODs
       // used to select electrons which are not from injected signals.
       return (IsFromBGEvent(label));
       break;
     case AliDielectronSignalMC::kFinalStateFromBGEvent :
+      // NOT implemented for AODs
       // used to select electrons which are not from injected signals.
       return (IsPhysicalPrimary(label) && IsFromBGEvent(label));
       break;
@@ -1143,6 +1164,7 @@ Bool_t AliDielectronMC::CheckParticleSource(Int_t label, AliDielectronSignalMC::
       return kFALSE;
   }
   return kFALSE;
+  
 }
 
 /*
@@ -1306,6 +1328,7 @@ Bool_t AliDielectronMC::IsMCTruth(Int_t label, AliDielectronSignalMC* signalMC, 
   // NOTE:  Some particles have the sign of the label flipped. It is related to the quality of matching
   //        between the ESD and the MC track. The negative labels indicate a poor matching quality
   //if(label<0) return kFALSE;
+
   if(label<0) label *= -1;
 
   AliVParticle* part = GetMCTrackFromMCEvent(label);
@@ -1508,7 +1531,7 @@ Bool_t AliDielectronMC::IsMCTruth(const AliDielectronPair* pair, const AliDielec
     motherIsGrandmother = kFALSE;
     motherIsGrandmother = MotherIsGrandmother(labelM1,labelM2,labelG1,labelG2, signalMC->GetMotherIsGrandmother());
   }
-  
+
   return ((directTerm || crossTerm) && motherRelation && processGEANT && motherIsGrandmother && pdgInStack);
 
 }

--- a/PWGDQ/dielectron/core/AliDielectronMC.h
+++ b/PWGDQ/dielectron/core/AliDielectronMC.h
@@ -4,7 +4,7 @@
  * See cxx source for full Copyright notice                               */
 
 //#####################################################
-//#                                                   # 
+//#                                                   #
 //#              Class AliDielectronMC                #
 //#       Cut Class for Jpsi->e+e- analysis           #
 //#                                                   #
@@ -31,18 +31,18 @@ class AliAODMCHeader;
 #include "AliDielectronPair.h"
 
 class AliDielectronMC : public TObject{
-  
+
 public:
   enum AnalysisType {kUNSET=0, kESD, kAOD};
-  
+
   AliDielectronMC(AnalysisType type=kUNSET);
   virtual ~AliDielectronMC();
 
   void SetHasMC(Bool_t hasMC) { fHasMC=hasMC; }
   Bool_t HasMC() const { return fHasMC; }
-  
+
   static AliDielectronMC* Instance();
-  
+
   void Initialize();                              // initialization
   Int_t GetNMCTracks();                                     // return number of generated tracks
   Int_t GetNMCTracksFromStack();                            // return number of generated tracks from stack
@@ -60,7 +60,7 @@ public:
   Int_t GetMCProcessFromStack(const AliESDtrack* _track);         // return process number
   Int_t GetMCProcessMother(const AliESDtrack* _track);            // return process number of the mother track
   Int_t GetMCProcessMotherFromStack(const AliESDtrack* _track);   // return process number of the mother track
-  
+
   Bool_t ConnectMCEvent();
   Bool_t UpdateStack();
 
@@ -72,6 +72,7 @@ public:
   Int_t GetMothersLabel(Int_t daughterLabel) const;
   Int_t GetPdgFromLabel(Int_t label) const;
 
+  Bool_t IsPrimary(Int_t label) const;
   Bool_t IsPhysicalPrimary(Int_t label) const;  // checks if a particle is physical primary
   Bool_t CheckGEANTProcess(Int_t label, TMCProcess process) const;
   Bool_t IsSecondaryFromWeakDecay(Int_t label) const;
@@ -79,18 +80,18 @@ public:
   //Bool_t IsEleFromInjectedSignal(Int_t label) const;
   Bool_t IsFromBGEvent(Int_t label) const;
   Bool_t CheckHijingHeader() const;
-  
+
   Bool_t HaveSameMother(const AliDielectronPair *pair) const;
-  
+
   Int_t GetLabelMotherWithPdg(const AliDielectronPair* pair, Int_t pdgMother);
   Int_t GetLabelMotherWithPdg(const AliVParticle *particle1, const AliVParticle *particle2, Int_t pdgMother);
-  
+
 //   AliVParticle* GetMCTrackFromMCEvent(const AliVParticle *track);   // return MC track directly from MC event
   AliVParticle* GetMCTrackFromMCEvent(Int_t label) const;           // return MC track directly from MC event
   TParticle* GetMCTrackFromStack(const AliESDtrack* _track);        // return MC track from stack
   AliMCParticle* GetMCTrack(const AliESDtrack* _track);             // return MC track associated with reco track
   AliAODMCParticle* GetMCTrack( const AliAODTrack* _track);          // return MC track associated with reco AOD track
-  
+
   TParticle* GetMCTrackMotherFromStack(const AliESDtrack* _track);  // return MC mother track from stack
   AliMCParticle* GetMCTrackMother(const AliESDtrack* _track);       // return MC mother track from stack
   AliAODMCParticle* GetMCTrackMother(const AliAODTrack* _track);       // return MC mother fot track AODTrack
@@ -109,7 +110,7 @@ public:
   Bool_t GetPrimaryVertex(Double_t &primVtxX, Double_t &primVtxY, Double_t &primVtxZ);
 
   AliMCEvent* GetMCEvent() { return fMCEvent; }         // return the AliMCEvent
-  
+
 private:
   AliMCEvent    *fMCEvent;  // MC event object
   AliStack      *fStack;    // MC stack
@@ -117,11 +118,11 @@ private:
   AnalysisType fAnaType;    // Analysis type
   Bool_t fHasMC;            // Do we have an MC handler?
   mutable Int_t  fHasHijingHeader;  //! //mutable needed to change it in a const function.
-  
-  static AliDielectronMC* fgInstance; //! singleton pointer
-  TClonesArray* fMcArray; //mcArray for AOD MC particles 
 
- 
+  static AliDielectronMC* fgInstance; //! singleton pointer
+  TClonesArray* fMcArray; //mcArray for AOD MC particles
+
+
   AliDielectronMC(const AliDielectronMC &c);
   AliDielectronMC &operator=(const AliDielectronMC &c);
 
@@ -130,7 +131,7 @@ private:
 
   Int_t GetLabelMotherWithPdgESD(const AliVParticle *particle1, const AliVParticle *particle2, Int_t pdgMother);
   Int_t GetLabelMotherWithPdgAOD(const AliVParticle *particle1, const AliVParticle *particle2, Int_t pdgMother);
-  
+
   Bool_t ComparePDG(Int_t particlePDG, Int_t requiredPDG, Bool_t pdgExclusion, Bool_t checkBothCharges) const;
   Bool_t CheckIsRadiative(Int_t label) const;
   Bool_t CheckRadiativeDecision(Int_t mLabel, const AliDielectronSignalMC * const signalMC) const;
@@ -158,4 +159,3 @@ inline Int_t AliDielectronMC::GetLabelMotherWithPdg(const AliDielectronPair* pai
 }
 
 #endif
-

--- a/PWGDQ/dielectron/core/AliDielectronVarManager.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronVarManager.cxx
@@ -640,7 +640,8 @@ const char* AliDielectronVarManager::fgkParticleNames[AliDielectronVarManager::k
   {"TriggerExclOFF",         "offline trigger bit (exclusive)",                    ""},
   {"Nevents",                "N_{evt}",                                            ""},
   {"RunNumber",              "run",                                                ""},
-  {"MixingBin",              "mixing bin",                                         ""}
+  {"MixingBin",              "mixing bin",                                         ""},
+  {"LegSource",              "Leg source",                                         ""}
 };
 
 AliPIDResponse* AliDielectronVarManager::fgPIDResponse      = 0x0;

--- a/PWGDQ/dielectron/core/AliDielectronVarManager.h
+++ b/PWGDQ/dielectron/core/AliDielectronVarManager.h
@@ -670,6 +670,8 @@ public:
     kRunNumber,              // run number
     kMixingBin,
 
+    kMCLegSource,            // According to AliDielectronSignalMC::ESource
+
     kNMaxValues              //
     // TODO: (for A+A) ZDCEnergy, impact parameter, Iflag??
   };
@@ -971,7 +973,16 @@ inline void AliDielectronVarManager::FillVarESDtrack(const AliESDtrack *particle
   AliDielectronMC *mc=AliDielectronMC::Instance();
   if (mc->HasMC()){
     if (mc->GetMCTrack(particle)) {
-      Int_t trkLbl = TMath::Abs(mc->GetMCTrack(particle)->GetLabel());
+      Int_t trkLbl = TMath::Abs(particle->GetLabel());
+
+      values[AliDielectronVarManager::kMCLegSource] = 0;
+      if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kPrimary)) values[AliDielectronVarManager::kMCLegSource] += 1;
+      if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kFinalState)) values[AliDielectronVarManager::kMCLegSource] += 2;
+      if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kDirect)) values[AliDielectronVarManager::kMCLegSource] +=4;
+      if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kSecondary)) values[AliDielectronVarManager::kMCLegSource] +=8;
+      if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kSecondaryFromWeakDecay)) values[AliDielectronVarManager::kMCLegSource] +=16;
+      if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kSecondaryFromMaterial)) values[AliDielectronVarManager::kMCLegSource] +=32;
+
       values[AliDielectronVarManager::kPdgCode]           =mc->GetMCTrack(particle)->PdgCode();
       values[AliDielectronVarManager::kHasCocktailMother] =mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kDirect);
       values[AliDielectronVarManager::kPdgCodeMother]     =mc->GetMotherPDG(particle);
@@ -1403,7 +1414,22 @@ inline void AliDielectronVarManager::FillVarAODTrack(const AliAODTrack *particle
   AliDielectronMC *mc=AliDielectronMC::Instance();
   if (mc->HasMC()){
     if (mc->GetMCTrack(particle)) {
-      Int_t trkLbl = TMath::Abs(mc->GetMCTrack(particle)->GetLabel());
+
+      // Int_t trkLbl = mc->GetMCTrack(particle)->GetLabel();
+      Int_t trkLbl = particle->GetLabel();
+
+      // AliAODMCParticle* mcpart = dynamic_cast<AliAODMCParticle*>(mc->GetMCTrack(particle));
+      // if (mcpart->IsPhysicalPrimary() == kTRUE) values[AliDielectronVarManager::kMCLegSource] = AliDielectronSignalMC::kPrimary;
+      // if (mcpart->IsPhysicalPrimary() == kFALSE) values[AliDielectronVarManager::kMCLegSource] = AliDielectronSignalMC::kSecondary;
+      values[AliDielectronVarManager::kMCLegSource] = 0;
+      if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kPrimary)) values[AliDielectronVarManager::kMCLegSource] += 1;
+      if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kFinalState)) values[AliDielectronVarManager::kMCLegSource] += 2;
+      if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kDirect)) values[AliDielectronVarManager::kMCLegSource] +=4;
+      if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kSecondary)) values[AliDielectronVarManager::kMCLegSource] +=8;
+      if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kSecondaryFromWeakDecay)) values[AliDielectronVarManager::kMCLegSource] +=16;
+      if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kSecondaryFromMaterial)) values[AliDielectronVarManager::kMCLegSource] +=32;
+
+
       values[AliDielectronVarManager::kPdgCode]           =mc->GetMCTrack(particle)->PdgCode();
       values[AliDielectronVarManager::kHasCocktailMother] =mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kDirect);
       values[AliDielectronVarManager::kPdgCodeMother]     =mc->GetMotherPDG(particle);
@@ -1493,7 +1519,6 @@ inline void AliDielectronVarManager::FillVarMCParticle(const AliMCParticle *part
   //
   // Fill track information available for histogramming into an array
   //
-
   values[AliDielectronVarManager::kNclsITS]       = 0;
   values[AliDielectronVarManager::kITSchi2Cl]     = 0;
   values[AliDielectronVarManager::kNclsTPC]       = 0;
@@ -1578,7 +1603,6 @@ inline void AliDielectronVarManager::FillVarMCParticle2(const AliVParticle *p1, 
   //
   // fill 2 track information starting from MC legs
   //
-
   values[AliDielectronVarManager::kNclsITS]       = 0;
   values[AliDielectronVarManager::kITSchi2Cl]     = -1;
   values[AliDielectronVarManager::kNclsTPC]       = 0;


### PR DESCRIPTION
Identifying AliAODMCParticles via their label can be tricky. Correct implementation now for kFinalState and kSecondary for ESDs and AODs. Other sources are heavily generator dependent.