### PR TITLE
DeltaPT and centrality added

### DIFF
--- a/PWGHF/jetsHF/AliAnalysisTaskEmcalJetBtagSV.h
+++ b/PWGHF/jetsHF/AliAnalysisTaskEmcalJetBtagSV.h
@@ -17,10 +17,12 @@
 //--Root--
 class TH1F;
 class TList;
+class TRandom3;
 class THn;
 class THnSparse;
 class TProfile;
 class AliAODMCHeader;
+class AliMultSelection;
 
 //--AliRoot--
 #include "AliLog.h"
@@ -52,6 +54,8 @@ public:
   void SetCorrectionMode(Bool_t mode ) {fCorrMode = mode;};
 
   void SetDoBkgRejection(Bool_t dorej) {fDoBkgRej = dorej;};
+  
+  void SetDoRandomCone(Bool_t dorndm) {fDoRndmCone = dorndm;};
 
   void SetDoFillSecVtxQA(Bool_t doqa ) {fDoQAVtx  = doqa;};
 
@@ -148,11 +152,13 @@ protected:
   Bool_t    IsAODtrkBelongToV0(std::vector<Int_t>& vctrTrkIDs, Int_t trkID);
 
   Double_t  GetExternalRho(Bool_t isMC = kFALSE);
+  Double_t  GetDeltaPtRandomCone(Double_t jetradius, Double_t rhovalue);
 
 private:
 
   Bool_t      fCorrMode;             // enable correction or data modes
-  Bool_t      fDoBkgRej;
+  Bool_t      fDoBkgRej;             // enable background rejection
+  Bool_t      fDoRndmCone;           // enable random cone method
   Bool_t      fDoQAVtx;              // enable output of qa on secondary vertex
   Bool_t      fDoFillV0Trks;         // enable V0 checks
   Bool_t      fDoDetRespMtx;        // enable detector repsonse matrix output
@@ -181,6 +187,8 @@ private:
   Double_t    fMCXsec;
   Double_t    fMCAvgTrials;
 
+  Float_t     fZNApercentile;		 // multiplicity percentile, ZNA estimator
+
   TString     fCurrFileName;         ///<  Current file path name.
 
   Bool_t      fCheckMCCrossSection;  ///<  Retrieve from the pyxsec.root file the cross section, only if requested.
@@ -196,10 +204,12 @@ private:
   AliHFJetsContainerVertex*   fhQaVtx;           //!<! vertices properties
 
   TH1F*                       fhEntries;         //!<!
+  TH1F*						  fhZNApercentQa;	 //!<! QA histo for ZNA percentile	
   TH1F*                       fhEvtRej;          //!<! Rejection criteria.
   TH1F*                       fhHFjetQa;         //!<! Various QA check on Jet.
   TH1F*                       fhRhoQa;
   TH1F*                       fhMCRhoQa;
+  TH1F* 					  fhDeltaPt;		 // delta pt distribution
 
   THnSparse*                  fhnDetRespMtx;     //!<! THnSparse to fill response matrix
   THn*                        fhnGenerated;      //!<! THn to fill MC generated histo 
@@ -209,6 +219,7 @@ private:
 
   AliVEvent*                  fEvent;            //! Input event
   AliAODMCHeader*             fMCHeader;         //! Input MC header
+  AliMultSelection*			  fMultSelection;    //! multiplicity/centrality selector
 
   AliHFJetsTaggingVertex*     fTagger;           // Jet Tagging object
 
@@ -225,11 +236,13 @@ private:
 
   map_int_bool*               fV0gTrkMap;
 
+  TRandom3* 				  fRandom;     	     // used for throwing random cone
+
   Int_t                       fGlLogLevel;
   Int_t                       fLcDebLevel;
   Int_t                       fStartBin;
 
-  ClassDef(AliAnalysisTaskEmcalJetBtagSV, 3);  // analysis task for MC study
+  ClassDef(AliAnalysisTaskEmcalJetBtagSV, 4);  // analysis task for MC study
 };
 
 //-------------------------------------------------------------------------------------

--- a/PWGHF/jetsHF/AliHFJetsContainer.cxx
+++ b/PWGHF/jetsHF/AliHFJetsContainer.cxx
@@ -238,9 +238,9 @@ void AliHFJetsContainer::GetBinning(TString var, Int_t &nBins, Double_t *bins, c
 	//}
 
 	Float_t binmin=0., binmax=0.;    
-	if (var.EqualTo("mult")) {
-		axistitle="Multiplicity";
-		nBins = 1000; binmin= 0.5; binmax= 1000.5;
+	if (var.EqualTo("cent")) {
+		axistitle="Multiplicity percentile";
+		nBins = 100; binmin= 0.5; binmax= 100.5;
 	}
   else if (var.EqualTo("jetPt")) {
 		axistitle="p_{T,jet} (GeV/c)";
@@ -440,8 +440,8 @@ const char *AliHFJetsContainer::GetVarName(CFVars var)
 { 
 
 	switch (var) {
-    case kCFMult:
-      return "kCFMult";
+    case kCFCent:
+      return "kCFCent";
     case kCFJetPt:
       return "kCFJetPt";
     case kCFJetEta:
@@ -460,8 +460,8 @@ const char *AliHFJetsContainer::GetVarName(CFVars var)
 
 //----------------------------------------------------------------
 Int_t AliHFJetsContainer::GetVarAxis(const char* varname){
-	if (!strncmp(varname,"kCFMult",50))
-    return kCFMult;
+	if (!strncmp(varname,"kCFCent",50))
+    return kCFCent;
   else if (!strncmp(varname,"kCFJetPt",50))
 		return kCFJetPt;
   else if (!strncmp(varname,"kCFJetEta",50))
@@ -487,7 +487,7 @@ Int_t AliHFJetsContainer::GetVarAxis(const char* varname){
 //----------------------------------------------------------------
 void AliHFJetsContainer::CreateDefaultBinning()
 {
-	TString vars("mult;jetPt;jetEta;jetPhi");
+	TString vars("cent;jetPt;jetEta;jetPhi");
 	// Get binning for each variable
 	TObjArray *arr;
 	TObjString *objstr;

--- a/PWGHF/jetsHF/AliHFJetsContainer.h
+++ b/PWGHF/jetsHF/AliHFJetsContainer.h
@@ -29,7 +29,7 @@ class AliHFJetsContainer : public TNamed
 
   // Variables relevant for corrections
   static const Int_t fgkCFVars = 4;
-  enum CFVars { kCFMult = 0, kCFJetPt, kCFJetEta, kCFJetPhi };
+  enum CFVars { kCFCent = 0, kCFJetPt, kCFJetEta, kCFJetPhi };
   
   // Constructors
   // dummy container for daughter classes
@@ -101,7 +101,7 @@ class AliHFJetsContainer : public TNamed
   void SetStepNames(AliCFContainer* container); // sets analysis step names
   const char* GetStepTitle(CFSteps step); // gets analysis step names
   TH1* StepsRatio(CFSteps num, CFSteps denom, Int_t var1, Int_t var2=-1); // 1D/2D ratio between 2 steps 
-  ClassDef(AliHFJetsContainer, 2)    // containers for HF b-jets analysis
+  ClassDef(AliHFJetsContainer, 3)    // containers for HF b-jets analysis
 };
 
 #endif

--- a/PWGHF/jetsHF/AliHFJetsContainerVertex.cxx
+++ b/PWGHF/jetsHF/AliHFJetsContainerVertex.cxx
@@ -81,7 +81,7 @@ AliHFJetsContainerVertex &AliHFJetsContainerVertex::operator=(const AliHFJetsCon
 //_____________________________________________________________________________________
 void AliHFJetsContainerVertex::FillStepJetVtxSim(CFSteps                step,
                                                  const Int_t            nSVtx,
-                                                 Double_t               evtMult,          // Event multiplicity (not used yet)
+                                                 Double_t               evtCent,          // Event multiplicity percentile (based on ZNA in pA)
                                                  Double_t               jetPt_wBkgRej,    // Jet's pt after background subtraction
                                                  vctr_pair_dbl_int     &arrVtxDisp,       // Vector of pair with SV_vtx and SV_sigma
                                                  const TClonesArray    *arrVtxHF,
@@ -99,7 +99,7 @@ void AliHFJetsContainerVertex::FillStepJetVtxSim(CFSteps                step,
 
   const Int_t kNvar = 23;
   Double_t point[kNvar] = {
-    evtMult,                            /* 0 */
+    evtCent,                            /* 0 */
     jet->Pt(),                          /* 1 */
     jet->Eta(),                         /* 2 */
     jet->Phi()-TMath::Pi(),             /* 3 */
@@ -271,7 +271,7 @@ void AliHFJetsContainerVertex::FillStepJetVtxSim(CFSteps                step,
 //_____________________________________________________________________________________
 void AliHFJetsContainerVertex::FillStepJetVtxData(CFSteps               step,
                                                   const Int_t           nSVtx,
-                                                  Double_t              evtMult,
+                                                  Double_t              evtCent,
                                                   Double_t              jetPt_wBkgRej,
                                                   vctr_pair_dbl_int    &arrVtxDisp,
                                                   const TClonesArray   *arrVtxHF,
@@ -286,7 +286,7 @@ void AliHFJetsContainerVertex::FillStepJetVtxData(CFSteps               step,
   
   const Int_t kNvar = 15;
   Double_t point[kNvar] = {
-    evtMult,                            /* 0 */
+    evtCent,                            /* 0 */
     jet->Pt(),                          /* 1 */
     jet->Eta(),                         /* 2 */
     jet->Phi()-TMath::Pi(),             /* 3 */
@@ -457,7 +457,7 @@ void AliHFJetsContainerVertex::FillStepJetVtxData(CFSteps               step,
 //_____________________________________________________________________________________
 void AliHFJetsContainerVertex::FillStepQaVtx(CFSteps                    step,
                                              const Int_t                nSVtx,
-                                             Double_t                   evtMult,
+                                             Double_t                   evtCent,
                                              const AliAODVertex        *primVtx,
                                              const AliEmcalJet         *jet,
                                              const TClonesArray        *arrVtxHF,
@@ -482,7 +482,7 @@ void AliHFJetsContainerVertex::FillStepQaVtx(CFSteps                    step,
   Int_t *indexLxy = new Int_t[nSVtx];
   const Int_t kNvar = 20;
   Double_t pointVtxProp[kNvar] = {
-    evtMult*1.,                         /* 1 */
+    evtCent*1.,                         /* 1 */
     jet->Pt(),                          /* 2 */
     jet->Eta(),                         /* 3 */
     jet->Phi()-TMath::Pi(),             /* 4 */

--- a/PWGHF/jetsHF/AliHFJetsContainerVertex.h
+++ b/PWGHF/jetsHF/AliHFJetsContainerVertex.h
@@ -117,7 +117,7 @@ private:
   
   AliHFJetsTaggingVertex *fTagger;    // to use tagging methods
 
-  ClassDef(AliHFJetsContainerVertex, 2)    // containers for HF b-jets analysis
+  ClassDef(AliHFJetsContainerVertex, 3)    // containers for HF b-jets analysis
 };
 
 #endif

--- a/PWGHF/jetsHF/macros/AddTaskEmcalJetBtagSV.C
+++ b/PWGHF/jetsHF/macros/AddTaskEmcalJetBtagSV.C
@@ -7,6 +7,7 @@ AliAnalysisTaskEmcalJetBtagSV* AddTaskEmcalJetBtagSV(const char* trkcontname   =
                                                      TString fileout   = "standard",
                                                      Bool_t corrMode   =  kFALSE,
                                                      Bool_t doBkgRej   =  kTRUE,
+                                                     Bool_t doRndmCone =  kFALSE,
                                                      Bool_t doQAvtx    =  kFALSE,
                                                      Bool_t doFillV0   =  kFALSE,
                                                      Bool_t doDetRespMtx = kFALSE,
@@ -50,6 +51,7 @@ AliAnalysisTaskEmcalJetBtagSV* AddTaskEmcalJetBtagSV(const char* trkcontname   =
 
   hfTask->SetCorrectionMode(corrMode); // kFALSE for real data
   hfTask->SetDoBkgRejection(doBkgRej);
+  hfTask->SetDoRandomCone(doRndmCone);
   hfTask->SetDoFillSecVtxQA(doQAvtx);
   hfTask->SetDoFillV0Trks(doFillV0);
   hfTask->SetDoDetRespMtx(doDetRespMtx);


### PR DESCRIPTION
1) Replaced the dummy kCFmult field in the tagged jet container with kCFcent, and fill this from the BJet tagging class with ZNA multiplicy percentile as centrality estimator.
2) Added a simple random cone method to estimate the background fluctuation (deltaPt). Created corresponding histo to fill. Incluced a switch into the class definition and also a switch 
Bool_t doRndmCone =  kFALSE into the macros/AddTaskEmcalJetBtagSV.C.