### PR TITLE
PWGGA/GammaConv: Added cocktail task subwagon feature via division of rapidity

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_GammaCocktailMC.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCocktailMC.C
@@ -1,6 +1,7 @@
 void AddTask_GammaCocktailMC(Bool_t runLightOutput = kFALSE, TString maxyset = "0.80") {
 
   Double_t maxy = maxyset.Atof();
+  maxy         /= 100;  // needed to enable subwagon feature on grid
 
   // ================== GetAnalysisManager ===============================
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();

--- a/PWGGA/GammaConv/macros/AddTask_HadronicCocktailMC.C
+++ b/PWGGA/GammaConv/macros/AddTask_HadronicCocktailMC.C
@@ -1,6 +1,7 @@
 void AddTask_HadronicCocktailMC(Int_t particleFlag = 0, Bool_t runLightOutput = kFALSE, TString maxyset = "0.8") {
 
   Double_t maxy = maxyset.Atof();
+  maxy         /= 100;  // needed to enable subwagon feature on grid
 
   // ================== GetAnalysisManager ===============================
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();


### PR DESCRIPTION
The rapidity string that is given as argument to the AddTasks must now be for example "80" instead of "0.8" as the rapidity gets divided by 100 in the task itself. This allows us to use the subwagon feature on the grid.