### PR TITLE
PWGDQ: Changed handling for AOD MC

### DIFF
--- a/PWGDQ/dielectron/core/AliDielectronMC.h
+++ b/PWGDQ/dielectron/core/AliDielectronMC.h
@@ -4,7 +4,7 @@
  * See cxx source for full Copyright notice                               */
 
 //#####################################################
-//#                                                   # 
+//#                                                   #
 //#              Class AliDielectronMC                #
 //#       Cut Class for Jpsi->e+e- analysis           #
 //#                                                   #
@@ -31,18 +31,18 @@ class AliAODMCHeader;
 #include "AliDielectronPair.h"
 
 class AliDielectronMC : public TObject{
-  
+
 public:
   enum AnalysisType {kUNSET=0, kESD, kAOD};
-  
+
   AliDielectronMC(AnalysisType type=kUNSET);
   virtual ~AliDielectronMC();
 
   void SetHasMC(Bool_t hasMC) { fHasMC=hasMC; }
   Bool_t HasMC() const { return fHasMC; }
-  
+
   static AliDielectronMC* Instance();
-  
+
   void Initialize();                              // initialization
   Int_t GetNMCTracks();                                     // return number of generated tracks
   Int_t GetNMCTracksFromStack();                            // return number of generated tracks from stack
@@ -60,7 +60,7 @@ public:
   Int_t GetMCProcessFromStack(const AliESDtrack* _track);         // return process number
   Int_t GetMCProcessMother(const AliESDtrack* _track);            // return process number of the mother track
   Int_t GetMCProcessMotherFromStack(const AliESDtrack* _track);   // return process number of the mother track
-  
+
   Bool_t ConnectMCEvent();
   Bool_t UpdateStack();
 
@@ -72,25 +72,27 @@ public:
   Int_t GetMothersLabel(Int_t daughterLabel) const;
   Int_t GetPdgFromLabel(Int_t label) const;
 
+  Bool_t IsPrimary(Int_t label) const;
   Bool_t IsPhysicalPrimary(Int_t label) const;  // checks if a particle is physical primary
+  Bool_t IsSecondary(Int_t label) const;
   Bool_t CheckGEANTProcess(Int_t label, TMCProcess process) const;
   Bool_t IsSecondaryFromWeakDecay(Int_t label) const;
   Bool_t IsSecondaryFromMaterial(Int_t label) const;
   //Bool_t IsEleFromInjectedSignal(Int_t label) const;
   Bool_t IsFromBGEvent(Int_t label) const;
   Bool_t CheckHijingHeader() const;
-  
+
   Bool_t HaveSameMother(const AliDielectronPair *pair) const;
-  
+
   Int_t GetLabelMotherWithPdg(const AliDielectronPair* pair, Int_t pdgMother);
   Int_t GetLabelMotherWithPdg(const AliVParticle *particle1, const AliVParticle *particle2, Int_t pdgMother);
-  
+
 //   AliVParticle* GetMCTrackFromMCEvent(const AliVParticle *track);   // return MC track directly from MC event
   AliVParticle* GetMCTrackFromMCEvent(Int_t label) const;           // return MC track directly from MC event
   TParticle* GetMCTrackFromStack(const AliESDtrack* _track);        // return MC track from stack
   AliMCParticle* GetMCTrack(const AliESDtrack* _track);             // return MC track associated with reco track
   AliAODMCParticle* GetMCTrack( const AliAODTrack* _track);          // return MC track associated with reco AOD track
-  
+
   TParticle* GetMCTrackMotherFromStack(const AliESDtrack* _track);  // return MC mother track from stack
   AliMCParticle* GetMCTrackMother(const AliESDtrack* _track);       // return MC mother track from stack
   AliAODMCParticle* GetMCTrackMother(const AliAODTrack* _track);       // return MC mother fot track AODTrack
@@ -109,7 +111,7 @@ public:
   Bool_t GetPrimaryVertex(Double_t &primVtxX, Double_t &primVtxY, Double_t &primVtxZ);
 
   AliMCEvent* GetMCEvent() { return fMCEvent; }         // return the AliMCEvent
-  
+
 private:
   AliMCEvent    *fMCEvent;  // MC event object
   AliStack      *fStack;    // MC stack
@@ -117,11 +119,11 @@ private:
   AnalysisType fAnaType;    // Analysis type
   Bool_t fHasMC;            // Do we have an MC handler?
   mutable Int_t  fHasHijingHeader;  //! //mutable needed to change it in a const function.
-  
-  static AliDielectronMC* fgInstance; //! singleton pointer
-  TClonesArray* fMcArray; //mcArray for AOD MC particles 
 
- 
+  static AliDielectronMC* fgInstance; //! singleton pointer
+  TClonesArray* fMcArray; //mcArray for AOD MC particles
+
+
   AliDielectronMC(const AliDielectronMC &c);
   AliDielectronMC &operator=(const AliDielectronMC &c);
 
@@ -130,7 +132,7 @@ private:
 
   Int_t GetLabelMotherWithPdgESD(const AliVParticle *particle1, const AliVParticle *particle2, Int_t pdgMother);
   Int_t GetLabelMotherWithPdgAOD(const AliVParticle *particle1, const AliVParticle *particle2, Int_t pdgMother);
-  
+
   Bool_t ComparePDG(Int_t particlePDG, Int_t requiredPDG, Bool_t pdgExclusion, Bool_t checkBothCharges) const;
   Bool_t CheckIsRadiative(Int_t label) const;
   Bool_t CheckRadiativeDecision(Int_t mLabel, const AliDielectronSignalMC * const signalMC) const;
@@ -158,4 +160,3 @@ inline Int_t AliDielectronMC::GetLabelMotherWithPdg(const AliDielectronPair* pai
 }
 
 #endif
-

--- a/PWGDQ/dielectron/core/AliDielectronVarManager.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronVarManager.cxx
@@ -643,7 +643,8 @@ const char* AliDielectronVarManager::fgkParticleNames[AliDielectronVarManager::k
   {"TriggerExclOFF",         "offline trigger bit (exclusive)",                    ""},
   {"Nevents",                "N_{evt}",                                            ""},
   {"RunNumber",              "run",                                                ""},
-  {"MixingBin",              "mixing bin",                                         ""}
+  {"MixingBin",              "mixing bin",                                         ""},
+  {"LegSource",              "Leg source",                                         ""}
 };
 
 AliPIDResponse* AliDielectronVarManager::fgPIDResponse      = 0x0;

--- a/PWGDQ/dielectron/core/AliDielectronVarManager.h
+++ b/PWGDQ/dielectron/core/AliDielectronVarManager.h
@@ -674,6 +674,8 @@ public:
     kRunNumber,              // run number
     kMixingBin,
 
+    kMCLegSource,            // According to AliDielectronSignalMC::ESource
+
     kNMaxValues              //
     // TODO: (for A+A) ZDCEnergy, impact parameter, Iflag??
   };
@@ -976,16 +978,29 @@ inline void AliDielectronVarManager::FillVarESDtrack(const AliESDtrack *particle
   AliDielectronMC *mc=AliDielectronMC::Instance();
   if (mc->HasMC()){
     if (mc->GetMCTrack(particle)) {
-      Int_t trkLbl = TMath::Abs(mc->GetMCTrack(particle)->GetLabel());
-      values[AliDielectronVarManager::kPdgCode]           =mc->GetMCTrack(particle)->PdgCode();
-      values[AliDielectronVarManager::kHasCocktailMother] =mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kDirect);
-      values[AliDielectronVarManager::kPdgCodeMother]     =mc->GetMotherPDG(particle);
-      AliMCParticle *motherMC=mc->GetMCTrackMother(particle); //mother
-      if(motherMC) values[AliDielectronVarManager::kPdgCodeGrandMother]=mc->GetMotherPDG(motherMC);
-      AliMCParticle *MCpart = mc->GetMCTrack(particle);
+      Int_t trkLbl = TMath::Abs(particle->GetLabel());
+
+      if (Req(kMCLegSource)){
+        values[AliDielectronVarManager::kMCLegSource] = 0;
+        if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kPrimary)) values[AliDielectronVarManager::kMCLegSource] += 1;
+        if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kFinalState)) values[AliDielectronVarManager::kMCLegSource] += 2;
+        if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kDirect)) values[AliDielectronVarManager::kMCLegSource] +=4;
+        if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kSecondary)) values[AliDielectronVarManager::kMCLegSource] +=8;
+        if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kSecondaryFromWeakDecay)) values[AliDielectronVarManager::kMCLegSource] +=16;
+        if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kSecondaryFromMaterial)) values[AliDielectronVarManager::kMCLegSource] +=32;
+      }
+
+      if (Req(kPdgCode))           values[AliDielectronVarManager::kPdgCode]           =mc->GetMCTrack(particle)->PdgCode();
+      if (Req(kHasCocktailMother)) values[AliDielectronVarManager::kHasCocktailMother] =mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kDirect);
+      if (Req(kPdgCodeMother))     values[AliDielectronVarManager::kPdgCodeMother]     =mc->GetMotherPDG(particle);
+      if (Req(kPdgCodeGrandMother)){
+        AliMCParticle *motherMC=mc->GetMCTrackMother(particle); //mother
+        if(motherMC) values[AliDielectronVarManager::kPdgCodeGrandMother]=mc->GetMotherPDG(motherMC);
+      }
       // Fill distance of primary vertex to secondary vertex (as an alternative to the IP)
       // Pure MC variable by intention, no reconstucted value filled.
       if (Req(kDistPrimToSecVtxXYMC) || Req(kDistPrimToSecVtxZMC)) {
+        AliMCParticle *MCpart = mc->GetMCTrack(particle);
         values[AliDielectronVarManager::kDistPrimToSecVtxXYMC] = TMath::Sqrt(  TMath::Power(MCpart->Xv() - values[AliDielectronVarManager::kXvPrimMCtruth],2) + TMath::Power(MCpart->Yv() - values[AliDielectronVarManager::kYvPrimMCtruth],2));
         values[AliDielectronVarManager::kDistPrimToSecVtxZMC] = TMath::Abs(MCpart->Zv() - values[AliDielectronVarManager::kZvPrimMCtruth]);
       }
@@ -1407,14 +1422,28 @@ inline void AliDielectronVarManager::FillVarAODTrack(const AliAODTrack *particle
   AliDielectronMC *mc=AliDielectronMC::Instance();
   if (mc->HasMC()){
     if (mc->GetMCTrack(particle)) {
-      Int_t trkLbl = TMath::Abs(mc->GetMCTrack(particle)->GetLabel());
-      values[AliDielectronVarManager::kPdgCode]           =mc->GetMCTrack(particle)->PdgCode();
-      values[AliDielectronVarManager::kHasCocktailMother] =mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kDirect);
-      values[AliDielectronVarManager::kPdgCodeMother]     =mc->GetMotherPDG(particle);
-      AliAODMCParticle *motherMC=mc->GetMCTrackMother(particle); //mother
-      if(motherMC) values[AliDielectronVarManager::kPdgCodeGrandMother]=mc->GetMotherPDG(motherMC);
+
+      Int_t trkLbl = particle->GetLabel();
+
+      if (Req(kMCLegSource)){
+        values[AliDielectronVarManager::kMCLegSource] = 0;
+        if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kPrimary)) values[AliDielectronVarManager::kMCLegSource] += 1;
+        if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kFinalState)) values[AliDielectronVarManager::kMCLegSource] += 2;
+        if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kDirect)) values[AliDielectronVarManager::kMCLegSource] +=4;
+        if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kSecondary)) values[AliDielectronVarManager::kMCLegSource] +=8;
+        if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kSecondaryFromWeakDecay)) values[AliDielectronVarManager::kMCLegSource] +=16;
+        if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kSecondaryFromMaterial)) values[AliDielectronVarManager::kMCLegSource] +=32;
+      }
+
+      if (Req(kPdgCode))           values[AliDielectronVarManager::kPdgCode]           =mc->GetMCTrack(particle)->PdgCode();
+      if (Req(kHasCocktailMother)) values[AliDielectronVarManager::kHasCocktailMother] =mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kDirect);
+      if (Req(kPdgCodeMother))     values[AliDielectronVarManager::kPdgCodeMother]     =mc->GetMotherPDG(particle);
+      if (Req(kPdgCodeGrandMother)){
+        AliAODMCParticle *motherMC=mc->GetMCTrackMother(particle); //mother
+        if(motherMC) values[AliDielectronVarManager::kPdgCodeGrandMother]=mc->GetMotherPDG(motherMC);
+      }
     }
-    values[AliDielectronVarManager::kNumberOfDaughters]=mc->NumberOfDaughters(particle);
+    if (Req(kNumberOfDaughters)) values[AliDielectronVarManager::kNumberOfDaughters]=mc->NumberOfDaughters(particle);
   } //if(mc->HasMC())
 
   if(Req(kTOFPIDBit))     values[AliDielectronVarManager::kTOFPIDBit]=(particle->GetStatus()&AliESDtrack::kTOFpid? 1: 0);
@@ -1497,7 +1526,6 @@ inline void AliDielectronVarManager::FillVarMCParticle(const AliMCParticle *part
   //
   // Fill track information available for histogramming into an array
   //
-
   values[AliDielectronVarManager::kNclsITS]       = 0;
   values[AliDielectronVarManager::kITSchi2Cl]     = 0;
   values[AliDielectronVarManager::kNclsTPC]       = 0;
@@ -1582,7 +1610,6 @@ inline void AliDielectronVarManager::FillVarMCParticle2(const AliVParticle *p1, 
   //
   // fill 2 track information starting from MC legs
   //
-
   values[AliDielectronVarManager::kNclsITS]       = 0;
   values[AliDielectronVarManager::kITSchi2Cl]     = -1;
   values[AliDielectronVarManager::kNclsTPC]       = 0;


### PR DESCRIPTION
The handling of AOD MC in the dielectron framework is tricky. Up to now the tracks are compared via their label on the stack. This is not working for AODs therefore a few changes are made. The handling for ESDs is unaffected by this patch.