### PR TITLE
Lc2V0 bachelor code updates for PbPb

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelor.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelor.h
@@ -102,6 +102,8 @@ class AliAnalysisTaskSELc2V0bachelor : public AliAnalysisTaskSE
   void ReconstructSecVtx(Bool_t dummy=kTRUE) {fReconstructSecVtx=dummy;}
   Bool_t GetReconstructSecVtx() const {return fReconstructSecVtx;}
 
+  void SetAODMismatchProtection(Int_t opt=1) {fAODProtection=opt;}
+
  private:
   
   void CheckEventSelection(AliAODEvent *aodEvent);
@@ -149,6 +151,7 @@ class AliAnalysisTaskSELc2V0bachelor : public AliAnalysisTaskSE
   AliNormalizationCounter *fCounter; /// AliNormalizationCounter on output slot 2
   AliRDHFCutsLctoV0 *fAnalCuts;      /// Cuts - sent to output slot 3
   Bool_t fUseOnTheFlyV0;             /// flag to analyze also on-the-fly V0 candidates
+  Int_t     fAODProtection;       /// flag to activate protection against AOD-dAOD mismatch.
   Bool_t fIsEventSelected;           /// flag for event selected
 
   Bool_t    fWriteVariableTree;       /// flag to decide whether to write the candidate variables on a tree variables
@@ -174,7 +177,7 @@ class AliAnalysisTaskSELc2V0bachelor : public AliAnalysisTaskSE
   Bool_t fReconstructSecVtx;
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskSELc2V0bachelor,10); /// class for Lc->p K0
+  ClassDef(AliAnalysisTaskSELc2V0bachelor,11); /// class for Lc->p K0
   /// \endcond
 };
 

--- a/PWGHF/vertexingHF/AliRDHFCutsLctoV0.h
+++ b/PWGHF/vertexingHF/AliRDHFCutsLctoV0.h
@@ -92,6 +92,9 @@ class AliRDHFCutsLctoV0 : public AliRDHFCuts
   { delete fV0daughtersCuts; fV0daughtersCuts = new AliESDtrackCuts(*v0daug); }
   virtual AliESDtrackCuts *GetTrackCutsV0daughters() const {return fV0daughtersCuts;}
 
+  Double_t GetReSignedd0(AliAODRecoDecayHF *d);
+  void SetMagneticField(Double_t a){fBzkG = a;}
+
   virtual void PrintAll() const;
  protected:
 
@@ -107,11 +110,12 @@ class AliRDHFCutsLctoV0 : public AliRDHFCuts
   Float_t fLowPtCut;   /// low pT cut separation for proton identification
   Int_t   fExcludedCut; /// cut to be excluded (-1=none)
   Float_t *fMinCombinedProbability; //[fnPtBins] min value for combined PID probabilities
+  Double_t fBzkG; //Magnetic field for propagation
 
   //UShort_t fV0channel;
 
   /// \cond CLASSIMP    
-  ClassDef(AliRDHFCutsLctoV0,7);  /// class for cuts on AOD reconstructed Lc->V0+bachelor
+  ClassDef(AliRDHFCutsLctoV0,8);  /// class for cuts on AOD reconstructed Lc->V0+bachelor
   /// \endcond
 };
 

--- a/PWGHF/vertexingHF/ConfigVertexingHF.C
+++ b/PWGHF/vertexingHF/ConfigVertexingHF.C
@@ -80,8 +80,8 @@ AliAnalysisVertexingHF* ConfigVertexingHF() {
   cutsDStartoKpipi->AddTrackCutsSoftPi(esdTrackCutsSoftPi);
   vHF->SetCutsDStartoKpipi(cutsDStartoKpipi);
   AliRDHFCutsLctoV0 *cutsLctoV0 = new AliRDHFCutsLctoV0("CutsLctoV0");
-  Float_t cutsArrayLctoV0[17]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,0.0};
-  cutsLctoV0->SetCuts(17,cutsArrayLctoV0);
+  Float_t cutsArrayLctoV0[21]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,9999.,-9999.,-9999.,-9999.,0.0};
+  cutsLctoV0->SetCuts(21,cutsArrayLctoV0);
   cutsLctoV0->AddTrackCuts(esdTrackCuts);
   AliESDtrackCuts *esdV0daughterTrackCuts = new AliESDtrackCuts("AliESDtrackCutsForV0D","default cuts for V0 daughters");
   esdV0daughterTrackCuts->SetRequireTPCRefit(kTRUE);

--- a/PWGHF/vertexingHF/ConfigVertexingHF_DplustoK0s_DstoK0s.C
+++ b/PWGHF/vertexingHF/ConfigVertexingHF_DplustoK0s_DstoK0s.C
@@ -80,8 +80,8 @@ AliAnalysisVertexingHF* ConfigVertexingHF() {
   cutsDStartoKpipi->AddTrackCutsSoftPi(esdTrackCutsSoftPi);
   vHF->SetCutsDStartoKpipi(cutsDStartoKpipi);
   AliRDHFCutsLctoV0 *cutsLctoV0 = new AliRDHFCutsLctoV0("CutsLctoV0");
-  Float_t cutsArrayLctoV0[17]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,0.0};
-  cutsLctoV0->SetCuts(17,cutsArrayLctoV0);
+  Float_t cutsArrayLctoV0[21]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,9999.,-9999.,-9999.,-9999.,0.0};
+  cutsLctoV0->SetCuts(21,cutsArrayLctoV0);
   cutsLctoV0->AddTrackCuts(esdTrackCuts);
   AliESDtrackCuts *esdV0daughterTrackCuts = new AliESDtrackCuts("AliESDtrackCutsForV0D","default cuts for V0 daughters");
   esdV0daughterTrackCuts->SetRequireTPCRefit(kTRUE);

--- a/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent.C
+++ b/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent.C
@@ -205,8 +205,8 @@ AliAnalysisVertexingHF* ConfigVertexingHF() {
   //--------------------------------------------------------
 
   AliRDHFCutsLctoV0 *cutsLctoV0 = new AliRDHFCutsLctoV0("CutsLctoV0");
-  Float_t cutsArrayLctoV0[17]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,0.0};
-  cutsLctoV0->SetCuts(17,cutsArrayLctoV0);
+  Float_t cutsArrayLctoV0[21]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,9999.,-9999.,-9999.,-9999.,0.0};
+  cutsLctoV0->SetCuts(21,cutsArrayLctoV0);
   cutsLctoV0->AddTrackCuts(esdTrackCuts);
 
   AliESDtrackCuts *esdV0daughterTrackCuts = new AliESDtrackCuts("AliESDtrackCutsForV0D","default cuts for V0 daughters");

--- a/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent_NoLS.C
+++ b/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent_NoLS.C
@@ -204,8 +204,8 @@ AliAnalysisVertexingHF* ConfigVertexingHF() {
   //--------------------------------------------------------
 
   AliRDHFCutsLctoV0 *cutsLctoV0 = new AliRDHFCutsLctoV0("CutsLctoV0");
-  Float_t cutsArrayLctoV0[17]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,0.0};
-  cutsLctoV0->SetCuts(17,cutsArrayLctoV0);
+  Float_t cutsArrayLctoV0[21]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,9999.,-9999.,-9999.,-9999.,0.0};
+  cutsLctoV0->SetCuts(21,cutsArrayLctoV0);
 
   AliESDtrackCuts *esdV0daughterTrackCuts = new AliESDtrackCuts("AliESDtrackCutsForV0D","default cuts for V0 daughters");
   esdV0daughterTrackCuts->SetRequireTPCRefit(kTRUE);

--- a/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent_NoLS_16var.C
+++ b/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent_NoLS_16var.C
@@ -204,8 +204,8 @@ AliAnalysisVertexingHF* ConfigVertexingHF() {
   //--------------------------------------------------------
 
   AliRDHFCutsLctoV0 *cutsLctoV0 = new AliRDHFCutsLctoV0("CutsLctoV0");
-  Float_t cutsArrayLctoV0[17]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,0.0};
-  cutsLctoV0->SetCuts(17,cutsArrayLctoV0);
+  Float_t cutsArrayLctoV0[21]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,9999.,-9999.,-9999.,-9999.,0.0};
+  cutsLctoV0->SetCuts(21,cutsArrayLctoV0);
   cutsLctoV0->AddTrackCuts(esdTrackCuts);
 
   AliESDtrackCuts *esdV0daughterTrackCuts = new AliESDtrackCuts("AliESDtrackCutsForV0D","default cuts for V0 daughters");

--- a/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent_NoLS_NoDstar.C
+++ b/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent_NoLS_NoDstar.C
@@ -206,8 +206,8 @@ AliAnalysisVertexingHF* ConfigVertexingHF() {
   
   
   AliRDHFCutsLctoV0 *cutsLctoV0 = new AliRDHFCutsLctoV0("CutsLctoV0");
-  Float_t cutsArrayLctoV0[17]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,0.0};
-  cutsLctoV0->SetCuts(17,cutsArrayLctoV0);
+  Float_t cutsArrayLctoV0[21]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,9999.,-9999.,-9999.,-9999.,0.0};
+  cutsLctoV0->SetCuts(21,cutsArrayLctoV0);
   cutsLctoV0->AddTrackCuts(esdTrackCuts);
 
   AliESDtrackCuts *esdV0daughterTrackCuts = new AliESDtrackCuts("AliESDtrackCutsForV0D","default cuts for V0 daughters");

--- a/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent_NoLS_NoDstar_16var.C
+++ b/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent_NoLS_NoDstar_16var.C
@@ -205,8 +205,8 @@ AliAnalysisVertexingHF* ConfigVertexingHF() {
   //--------------------------------------------------------
 
   AliRDHFCutsLctoV0 *cutsLctoV0 = new AliRDHFCutsLctoV0("CutsLctoV0");
-  Float_t cutsArrayLctoV0[17]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,0.0};
-  cutsLctoV0->SetCuts(17,cutsArrayLctoV0);
+  Float_t cutsArrayLctoV0[21]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,9999.,-9999.,-9999.,-9999.,0.0};
+  cutsLctoV0->SetCuts(21,cutsArrayLctoV0);
   cutsLctoV0->AddTrackCuts(esdTrackCuts);
 
   AliESDtrackCuts *esdV0daughterTrackCuts = new AliESDtrackCuts("AliESDtrackCutsForV0D","default cuts for V0 daughters");

--- a/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent_NoLS_PIDLc.C
+++ b/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent_NoLS_PIDLc.C
@@ -222,8 +222,8 @@ AliAnalysisVertexingHF* ConfigVertexingHF() {
   //--------------------------------------------------------
 
   AliRDHFCutsLctoV0 *cutsLctoV0 = new AliRDHFCutsLctoV0("CutsLctoV0");
-  Float_t cutsArrayLctoV0[17]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,0.0};
-  cutsLctoV0->SetCuts(17,cutsArrayLctoV0);
+  Float_t cutsArrayLctoV0[21]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,9999.,-9999.,-9999.,-9999.,0.0};
+  cutsLctoV0->SetCuts(21,cutsArrayLctoV0);
   cutsLctoV0->AddTrackCuts(esdTrackCuts);
 
   AliESDtrackCuts *esdV0daughterTrackCuts = new AliESDtrackCuts("AliESDtrackCutsForV0D","default cuts for V0 daughters");

--- a/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent_NoLS_PIDLc_PtDepSel_LooseIP.C
+++ b/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent_NoLS_PIDLc_PtDepSel_LooseIP.C
@@ -278,10 +278,10 @@ AliAnalysisVertexingHF* ConfigVertexingHF() {
   //--------------------------------------------------------
 
   AliRDHFCutsLctoV0 *cutsLctoV0 = new AliRDHFCutsLctoV0("CutsLctoV0");
-  Float_t cutsArrayLctoV0[17]={0.2,0.,0.05,0.05,0.5,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.5,1};
+  Float_t cutsArrayLctoV0[21]={0.2,0.,0.05,0.05,0.5,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.5,9999.,-9999.,-9999.,-9999.,1};
   cutsLctoV0->SetUseTrackSelectionWithFilterBits(kFALSE);
   cutsLctoV0->SetMinPtCandidate(4.);
-  cutsLctoV0->SetCuts(17,cutsArrayLctoV0);
+  cutsLctoV0->SetCuts(21,cutsArrayLctoV0);
   cutsLctoV0->AddTrackCuts(esdTrackCuts);
 
   AliESDtrackCuts *esdV0daughterTrackCuts = new AliESDtrackCuts("AliESDtrackCutsForV0D","default cuts for V0 daughters");

--- a/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent_NoLS_PIDLc_PtDepSel_LooseIP_Central.C
+++ b/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent_NoLS_PIDLc_PtDepSel_LooseIP_Central.C
@@ -278,10 +278,10 @@ AliAnalysisVertexingHF* ConfigVertexingHF() {
   //--------------------------------------------------------
 
   AliRDHFCutsLctoV0 *cutsLctoV0 = new AliRDHFCutsLctoV0("CutsLctoV0");
-  Float_t cutsArrayLctoV0[17]={0.2,0.,0.05,0.05,0.5,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.5,1};
+  Float_t cutsArrayLctoV0[21]={0.2,0.,0.05,0.05,0.5,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.5,9999.,-9999.,-9999.,-9999.,1};
   cutsLctoV0->SetUseTrackSelectionWithFilterBits(kFALSE);
   cutsLctoV0->SetMinPtCandidate(4.);
-  cutsLctoV0->SetCuts(17,cutsArrayLctoV0);
+  cutsLctoV0->SetCuts(21,cutsArrayLctoV0);
   cutsLctoV0->AddTrackCuts(esdTrackCuts);
 
   AliESDtrackCuts *esdV0daughterTrackCuts = new AliESDtrackCuts("AliESDtrackCutsForV0D","default cuts for V0 daughters");

--- a/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent_NoLS_PIDLc_PtDepSel_LooseIP_SemiCentral.C
+++ b/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent_NoLS_PIDLc_PtDepSel_LooseIP_SemiCentral.C
@@ -278,10 +278,10 @@ AliAnalysisVertexingHF* ConfigVertexingHF() {
   //--------------------------------------------------------
 
   AliRDHFCutsLctoV0 *cutsLctoV0 = new AliRDHFCutsLctoV0("CutsLctoV0");
-  Float_t cutsArrayLctoV0[17]={0.2,0.,0.05,0.05,0.5,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.5,1};
+  Float_t cutsArrayLctoV0[21]={0.2,0.,0.05,0.05,0.5,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.5,9999.,-9999.,-9999.,-9999.,1};
   cutsLctoV0->SetUseTrackSelectionWithFilterBits(kFALSE);
   cutsLctoV0->SetMinPtCandidate(4.);
-  cutsLctoV0->SetCuts(17,cutsArrayLctoV0);
+  cutsLctoV0->SetCuts(21,cutsArrayLctoV0);
   cutsLctoV0->AddTrackCuts(esdTrackCuts);
 
   AliESDtrackCuts *esdV0daughterTrackCuts = new AliESDtrackCuts("AliESDtrackCutsForV0D","default cuts for V0 daughters");

--- a/PWGHF/vertexingHF/ConfigVertexingHF_Pb_Cent2080.C
+++ b/PWGHF/vertexingHF/ConfigVertexingHF_Pb_Cent2080.C
@@ -168,8 +168,8 @@ AliAnalysisVertexingHF* ConfigVertexingHF() {
   //--------------------------------------------------------
 
   AliRDHFCutsLctoV0 *cutsLctoV0 = new AliRDHFCutsLctoV0("CutsLctoV0");
-  Float_t cutsArrayLctoV0[17]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,0.0};
-  cutsLctoV0->SetCuts(17,cutsArrayLctoV0);
+  Float_t cutsArrayLctoV0[21]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,9999.,-9999.,-9999.,-9999.,0.0};
+  cutsLctoV0->SetCuts(21,cutsArrayLctoV0);
   cutsLctoV0->AddTrackCuts(esdTrackCuts);
   AliESDtrackCuts *esdV0daughterTrackCuts = new AliESDtrackCuts("AliESDtrackCutsForV0D","default cuts for V0 daughters");
   esdV0daughterTrackCuts->SetRequireTPCRefit(kTRUE);

--- a/PWGHF/vertexingHF/ConfigVertexingHF_TrackRel.C
+++ b/PWGHF/vertexingHF/ConfigVertexingHF_TrackRel.C
@@ -81,8 +81,8 @@ AliAnalysisVertexingHF* ConfigVertexingHF() {
   cutsDStartoKpipi->AddTrackCutsSoftPi(esdTrackCutsSoftPi);
   vHF->SetCutsDStartoKpipi(cutsDStartoKpipi);
   AliRDHFCutsLctoV0 *cutsLctoV0 = new AliRDHFCutsLctoV0("CutsLctoV0");
-  Float_t cutsArrayLctoV0[17]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,0.0};
-  cutsLctoV0->SetCuts(17,cutsArrayLctoV0);
+  Float_t cutsArrayLctoV0[21]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,9999.,-9999.,-9999.,-9999.,0.0};
+  cutsLctoV0->SetCuts(21,cutsArrayLctoV0);
   cutsLctoV0->AddTrackCuts(esdTrackCuts);
   AliESDtrackCuts *esdV0daughterTrackCuts = new AliESDtrackCuts("AliESDtrackCutsForV0D","default cuts for V0 daughters");
   esdV0daughterTrackCuts->SetRequireTPCRefit(kTRUE);

--- a/PWGHF/vertexingHF/ConfigVertexingHF_highmult.C
+++ b/PWGHF/vertexingHF/ConfigVertexingHF_highmult.C
@@ -166,8 +166,8 @@ AliAnalysisVertexingHF* ConfigVertexingHF() {
   //--------------------------------------------------------
 
   AliRDHFCutsLctoV0 *cutsLctoV0 = new AliRDHFCutsLctoV0("CutsLctoV0");
-  Float_t cutsArrayLctoV0[17]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,0.0};
-  cutsLctoV0->SetCuts(17,cutsArrayLctoV0);
+  Float_t cutsArrayLctoV0[21]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,9999.,-9999.,-9999.,-9999.,0.0};
+  cutsLctoV0->SetCuts(21,cutsArrayLctoV0);
   cutsLctoV0->AddTrackCuts(esdTrackCuts);
   AliESDtrackCuts *esdV0daughterTrackCuts = new AliESDtrackCuts("AliESDtrackCutsForV0D","default cuts for V0 daughters");
   esdV0daughterTrackCuts->SetRequireTPCRefit(kTRUE);

--- a/PWGHF/vertexingHF/ConfigVertexingHF_pPb.C
+++ b/PWGHF/vertexingHF/ConfigVertexingHF_pPb.C
@@ -81,8 +81,8 @@ AliAnalysisVertexingHF* ConfigVertexingHF() {
   cutsDStartoKpipi->AddTrackCutsSoftPi(esdTrackCutsSoftPi);
   vHF->SetCutsDStartoKpipi(cutsDStartoKpipi);
   AliRDHFCutsLctoV0 *cutsLctoV0 = new AliRDHFCutsLctoV0("CutsLctoV0");
-  Float_t cutsArrayLctoV0[17]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,0.0};
-  cutsLctoV0->SetCuts(17,cutsArrayLctoV0);
+  Float_t cutsArrayLctoV0[21]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,9999.,-9999.,-9999.,-9999.,0.0};
+  cutsLctoV0->SetCuts(21,cutsArrayLctoV0);
   cutsLctoV0->AddTrackCuts(esdTrackCuts);
   AliESDtrackCuts *esdV0daughterTrackCuts = new AliESDtrackCuts("AliESDtrackCutsForV0D","default cuts for V0 daughters");
   esdV0daughterTrackCuts->SetRequireTPCRefit(kTRUE);

--- a/PWGHF/vertexingHF/ConfigVertexingHF_pPbRHF.C
+++ b/PWGHF/vertexingHF/ConfigVertexingHF_pPbRHF.C
@@ -80,8 +80,8 @@ AliAnalysisVertexingHF* ConfigVertexingHF() {
   cutsDStartoKpipi->AddTrackCutsSoftPi(esdTrackCutsSoftPi);
   vHF->SetCutsDStartoKpipi(cutsDStartoKpipi);
   AliRDHFCutsLctoV0 *cutsLctoV0 = new AliRDHFCutsLctoV0("CutsLctoV0");
-  Float_t cutsArrayLctoV0[17]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,0.0};
-  cutsLctoV0->SetCuts(17,cutsArrayLctoV0);
+  Float_t cutsArrayLctoV0[21]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,9999.,-9999.,-9999.,-9999.,0.0};
+  cutsLctoV0->SetCuts(21,cutsArrayLctoV0);
   cutsLctoV0->AddTrackCuts(esdTrackCuts);
   AliESDtrackCuts *esdV0daughterTrackCuts = new AliESDtrackCuts("AliESDtrackCutsForV0D","default cuts for V0 daughters");
   esdV0daughterTrackCuts->SetRequireTPCRefit(kTRUE);

--- a/PWGHF/vertexingHF/ConfigVertexingHF_pPbRHF_DplustoK0s_DstoK0s.C
+++ b/PWGHF/vertexingHF/ConfigVertexingHF_pPbRHF_DplustoK0s_DstoK0s.C
@@ -80,8 +80,8 @@ AliAnalysisVertexingHF* ConfigVertexingHF() {
   cutsDStartoKpipi->AddTrackCutsSoftPi(esdTrackCutsSoftPi);
   vHF->SetCutsDStartoKpipi(cutsDStartoKpipi);
   AliRDHFCutsLctoV0 *cutsLctoV0 = new AliRDHFCutsLctoV0("CutsLctoV0");
-  Float_t cutsArrayLctoV0[17]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,0.0};
-  cutsLctoV0->SetCuts(17,cutsArrayLctoV0);
+  Float_t cutsArrayLctoV0[21]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,9999.,-9999.,-9999.,-9999.,0.0};
+  cutsLctoV0->SetCuts(21,cutsArrayLctoV0);
   cutsLctoV0->AddTrackCuts(esdTrackCuts);
   AliESDtrackCuts *esdV0daughterTrackCuts = new AliESDtrackCuts("AliESDtrackCutsForV0D","default cuts for V0 daughters");
   esdV0daughterTrackCuts->SetRequireTPCRefit(kTRUE);

--- a/PWGHF/vertexingHF/ConfigVertexingHF_pp_LambdaC.C
+++ b/PWGHF/vertexingHF/ConfigVertexingHF_pp_LambdaC.C
@@ -82,8 +82,8 @@ AliAnalysisVertexingHF* ConfigVertexingHF() {
   cutsDStartoKpipi->AddTrackCutsSoftPi(esdTrackCutsSoftPi);
   vHF->SetCutsDStartoKpipi(cutsDStartoKpipi);
   AliRDHFCutsLctoV0 *cutsLctoV0 = new AliRDHFCutsLctoV0("CutsLctoV0");
-  Float_t cutsArrayLctoV0[17]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,0.0};
-  cutsLctoV0->SetCuts(17,cutsArrayLctoV0);
+  Float_t cutsArrayLctoV0[21]={1.0,1.0,0.05,0.05,0.0,0.0,0.0,1000.,1000.,0.99,3.,1000.,0.,0.,0.,0.,9999.,-9999.,-9999.,-9999.,0.0};
+  cutsLctoV0->SetCuts(21,cutsArrayLctoV0);
   cutsLctoV0->AddTrackCuts(esdTrackCuts);
   AliESDtrackCuts *esdV0daughterTrackCuts = new AliESDtrackCuts("AliESDtrackCutsForV0D","default cuts for V0 daughters");
   esdV0daughterTrackCuts->SetRequireTPCRefit(kTRUE);

--- a/PWGHF/vertexingHF/macros/makeTFile4CutsLctoV0bachelor.C
+++ b/PWGHF/vertexingHF/macros/makeTFile4CutsLctoV0bachelor.C
@@ -17,7 +17,7 @@
 
 //macro to make a .root file which contains an AliRDHFCutsLctoV0 for AliAnalysisTaskSELc2pK0S task
 
-enum ECollisionSystem{kpp7TeV,kpPb};
+enum ECollisionSystem{kpp7TeV,kpPb,kPbPb};
 enum EDataKind{kData,kLHC10f7a,kLHC11b2,kLHC15a2a,kLHC13d3};
 enum EReconstructionPass{kPass2,kPass4};
 
@@ -114,6 +114,9 @@ void makeInputAliAnalysisTaskSELctoV0bachelor(){
                                           // 7 -> if (p<1) TPC@2s else if (1<=p<2.5) {if (TOF) TOF@3s else TPC@3s} else (p>=2.5) {if (TOF) -2s<TOF<3s else TPC@3s}
                                           // 8 -> if (p<1) TPC@2s else if (1<=p<2.5) {if (TOF) TOF@3s else TPC@3s} else (p>=2.5) {if (TOF) -2s<TOF<3s else -2<TPC<3s}
                                           // 9 -> combined: TOF, TPC
+  } else if (fCollisionSystem==kPbPb) {
+    RDHFLctoV0An->SetHighPtCut(999.); // default value 2.5 GeV/c
+    RDHFLctoV0An->SetPidSelectionFlag(10); // 10: -2<tof<3 for pt>3 GeV/c, -3<tpc<2 for pt>4 GeV/c 
   }
   RDHFLctoV0An->SetNPtBins(nptbins);
 
@@ -128,7 +131,7 @@ void makeInputAliAnalysisTaskSELctoV0bachelor(){
   ptbins[6]= 12.;
   RDHFLctoV0An->SetPtBins(nptbins+1,ptbins);
 
-  const Int_t nvars=17;
+  const Int_t nvars=21;
 
   Float_t** anacutsval;
   anacutsval=new Float_t*[nvars];
@@ -142,7 +145,11 @@ void makeInputAliAnalysisTaskSELctoV0bachelor(){
    anacutsval[9][ipt2]=0.99;   // cosPA V0 cut // it's 0.90 x offline V0s at reconstruction level, 0.99 at filtering level
    anacutsval[12][ipt2]=0.;    // mass K0S veto [GeV/c2]
    anacutsval[13][ipt2]=0.005; // mass Lambda/LambdaBar veto [GeV/c2]
-   anacutsval[16][ipt2]=0.;    // V0 type cut
+   anacutsval[16][ipt2]=9999; // max cos proton emission angle in Lc CMS max
+   anacutsval[17][ipt2]=-9999; // min cos proton emission angle in Lc CMS max
+   anacutsval[18][ipt2]=-9999; // Re-signed d0 min [cm]
+   anacutsval[19][ipt2]=-9999; // V0 qT/|alpha| min
+   anacutsval[20][ipt2]=0.;    // V0 type cut
   }
 
   if (fCollisionSystem==kpp7TeV) {


### PR DESCRIPTION
Dear all,

I made the following modifications to the codes to analyze Lc->pK0s in PbPb. 
I contacted the original authors (Annalisa,Elisa) of the codes and they agreed that I make modifications to the codes.  

AliRDHFCutsLctoV0.cxx(h)
- Added 4 variables to the array of cut variables
  - If the cut values are not in reasonable ranges, the cuts are not applied at all. This is intended to avoid any impacts on the past analyses.
- Added functions to calculate the variables
- Added one more option for PID

makeTFile4CutsLctoV0bachelor.C
- Added the 4 variables accordingly

AliAnalysisTaskSELc2V0bachelor.cxx(h)
- Added AOD protection against AOD-dAOD mismatch
- Added histograms for the variables

ConfigVertexingHF_****.C
- The number of cut variables and the cut arrays are updated accordingly. 

Best regards,
Yosuke