### PR TITLE
Adding a histogram to study the cluster shower shape per SM

### DIFF
--- a/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.cxx
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.cxx
@@ -154,6 +154,7 @@ fPtaftFC(0),
 fPtaftM02C(0),
 fClusTime(0),
 fM02(0),
+fEtaPhiClusVsM02(0),
 fDeltaETAClusTrack(0),
 fDeltaPHIClusTrack(0),
 fDeltaETAClusTrackMatch(0),
@@ -331,6 +332,7 @@ fPtaftFC(0),
 fPtaftM02C(0),
 fClusTime(0),
 fM02(0),
+fEtaPhiClusVsM02(0),
 fDeltaETAClusTrack(0),
 fDeltaPHIClusTrack(0),
 fDeltaETAClusTrackMatch(0),
@@ -617,6 +619,10 @@ void AliAnalysisTaskEMCALPhotonIsolation::UserCreateOutputObjects(){
         fM02 = new TH2D("hM02_NC","M02 distribution for Neutral Clusters vs E",100,0.,100.,500,0.,5.);
         fM02->Sumw2();
         fOutput->Add(fM02);
+
+	fEtaPhiClusVsM02 = new TH3D ("hEtaVsPhiVsM02", "", 250, -0.8, 0.8, 250, 1.2, 3.4, 500, 0., 5.);
+        fEtaPhiClusVsM02->Sumw2();
+	fOutput->Add(fEtaPhiClusVsM02);
         
 	if(fIsoMethod==0){
 	  fEtIsoCells = new TH1D("hEtIsoCell_NC","E_{T}^{iso cone} in iso cone distribution for Neutral Clusters with EMCal Cells",200,-0.25,99.75);
@@ -1343,6 +1349,7 @@ void AliAnalysisTaskEMCALPhotonIsolation::FillQAHistograms(AliVCluster *coi, TLo
       
     case 2:
       fM02->Fill(vecCOI.E(),coi->GetM02());
+      fEtaPhiClusVsM02->Fill(vecCOI.Eta(),vecCOI.Phi(),coi->GetM02());
       break;
   }
   

--- a/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.h
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.h
@@ -320,6 +320,7 @@ class AliAnalysisTaskEMCALPhotonIsolation: public AliAnalysisTaskEmcal {
   TH2F        *fEtaTracksVSclustPt;            //!<!
   TH2F        *fTrackResolutionPtMC;           //!<!
   TH1D        *fVzBeforecut;                   //!<!
+  TH3D        *fEtaPhiClusVsM02;               //!<! Cluster eta vs. phi vs. sigma_long squared (energy integrated from 0 to 100 GeV)
   
   THnSparse   *fOutputTHnS;                    //!<! 1st Method 4 Output
   THnSparse   *fOutMCTruth;                    //!<! 1st Method 4 MC truth Output // Isolation on pTMax


### PR DESCRIPTION
This histogram will be used to study the cluster shower shape per supermodule, integrated over the whole cluster energy range for now (could be detailed per energy bin later).