### PR TITLE
Adding a parameter for a variable fiducial cut

### DIFF
--- a/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.cxx
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.cxx
@@ -102,6 +102,7 @@ fTest1(0),
 fTest2(0),
 fMCtruth(0),
 fPeriod(""),
+fFiducialCut(0.4),
 fEClustersT(0),
 fPtClustersT(0),
 fEtClustersT(0),
@@ -279,6 +280,7 @@ fTest1(0),
 fTest2(0),
 fMCtruth(0),
 fPeriod(""),
+fFiducialCut(0.4),
 fEClustersT(0),
 fPtClustersT(0),
 fEtClustersT(0),
@@ -2648,8 +2650,8 @@ Bool_t AliAnalysisTaskEMCALPhotonIsolation::CheckBoundaries(TLorentzVector vecCO
   Bool_t isINBoundaries;
   
   if(fTPC4Iso){
-    minEtaBound = -0.87+fIsoConeRadius;
-    maxEtaBound = 0.87-fIsoConeRadius;
+    minEtaBound = -0.87+fFiducialCut;
+    maxEtaBound = 0.87-fFiducialCut;
     
     if(fPeriod != ""){
       minPhiBound = (fGeom->GetArm1PhiMin())*TMath::DegToRad()+0.03;
@@ -2666,24 +2668,24 @@ Bool_t AliAnalysisTaskEMCALPhotonIsolation::CheckBoundaries(TLorentzVector vecCO
   }
   else{
     if(fPeriod != ""){
-      minEtaBound = fGeom->GetArm1EtaMin()+0.03+fIsoConeRadius;
-      maxEtaBound = fGeom->GetArm1EtaMax()-0.03-fIsoConeRadius;
-      minPhiBound = (fGeom->GetArm1PhiMin())*TMath::DegToRad()+0.03+fIsoConeRadius;
+      minEtaBound = fGeom->GetArm1EtaMin()+0.03+fFiducialCut;
+      maxEtaBound = fGeom->GetArm1EtaMax()-0.03-fFiducialCut;
+      minPhiBound = (fGeom->GetArm1PhiMin())*TMath::DegToRad()+0.03+fFiducialCut;
       
       if(fPeriod.Contains("12") || fPeriod.Contains("13"))
-        maxPhiBound = (fGeom->GetArm1PhiMax()-20.)*TMath::DegToRad()-0.03-fIsoConeRadius;
+        maxPhiBound = (fGeom->GetArm1PhiMax()-20.)*TMath::DegToRad()-0.03-fFiducialCut;
       else
-        maxPhiBound = (fGeom->GetArm1PhiMax())*TMath::DegToRad()-0.03-fIsoConeRadius;
+        maxPhiBound = (fGeom->GetArm1PhiMax())*TMath::DegToRad()-0.03-fFiducialCut;
     }
     else{
-      minEtaBound = -0.67+fIsoConeRadius;
-      maxEtaBound = 0.67-fIsoConeRadius;
-      minPhiBound = (4./9.)*TMath::Pi()+0.03+fIsoConeRadius;
-      maxPhiBound = TMath::Pi()-0.03-fIsoConeRadius;
+      minEtaBound = -0.67+fFiducialCut;
+      maxEtaBound = 0.67-fFiducialCut;
+      minPhiBound = (4./9.)*TMath::Pi()+0.03+fFiducialCut;
+      maxPhiBound = TMath::Pi()-0.03-fFiducialCut;
     }
   }
   
-  if(vecCOI.Eta() > maxEtaBound || vecCOI.Eta() < minEtaBound || vecCOI.Phi() > maxPhiBound || vecCOI.Phi() <minPhiBound)
+  if(vecCOI.Eta() > maxEtaBound || vecCOI.Eta() < minEtaBound || vecCOI.Phi() > maxPhiBound || vecCOI.Phi() < minPhiBound)
     isINBoundaries=kFALSE;
   else
     isINBoundaries=kTRUE;

--- a/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.h
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.h
@@ -115,6 +115,7 @@ class AliAnalysisTaskEMCALPhotonIsolation: public AliAnalysisTaskEmcal {
   void                     SetRejectPileUpEvent(Bool_t rpue)                               { fRejectPileUpEvent = rpue; }
   void                     SetNcontributorsToPileUp (Int_t nCtoPU)                         { fNContrToPileUp = nCtoPU; }
   void                     SetLightenOutput (Bool_t light)                                 { fLightOutput = light; }
+  void                     SetFiducialCut(Float_t fiducial)                                { fFiducialCut = fiducial; }
  protected:
   
   void                     FillQAHistograms(AliVCluster *coi, TLorentzVector vecCOI);                           // Fill some QA histograms
@@ -209,6 +210,7 @@ class AliAnalysisTaskEMCALPhotonIsolation: public AliAnalysisTaskEmcal {
   Int_t       fTest2;
   Bool_t      fMCtruth;                        // Enable/disable MC truth analysis
   TString     fPeriod;                         // String containing the LHC period
+  Float_t     fFiducialCut;                    // Variable fiducial cut from the border of the EMCal/TPC acceptance
   
   // Initialization for TTree variables
   Double_t    fEClustersT;                     // E for all clusters

--- a/PWGGA/EMCALTasks/macros/AddTaskEMCALPhotonIsolation.C
+++ b/PWGGA/EMCALTasks/macros/AddTaskEMCALPhotonIsolation.C
@@ -48,7 +48,8 @@ AliAnalysisTaskEMCALPhotonIsolation* AddTaskEMCALPhotonIsolation(
                                                                  TString                triggerName               = "",
                                                                  const Bool_t           RejectPileUpEvent         = kFALSE,
                                                                  const Int_t            NContrToPileUp            = 3,
-								 const Bool_t           lightOutput               = kFALSE
+								 const Bool_t           lightOutput               = kFALSE,
+                                                                 const Float_t          iFiducialCut              = 0.4
                                                                  )
 {
   Printf("Preparing neutral cluster analysis\n");
@@ -210,6 +211,7 @@ AliAnalysisTaskEMCALPhotonIsolation* AddTaskEMCALPhotonIsolation(
   task->SetRejectPileUpEvent(RejectPileUpEvent);
   task->SetNcontributorsToPileUp(NContrToPileUp);
   task->SetLightenOutput(lightOutput);
+  task->SetFiducialCut(iFiducialCut);
 
   if(bIsMC && bMCNormalization) task->SetIsPythia(kTRUE);
   


### PR DESCRIPTION
This commit adds the possibility to set a fiducial cut which is different than the isolation cone radius (`fIsoConeRadius`). By default, it is set at the same value than `fIsoConeRadius`, i.e. 0.4.