### PR TITLE
AliFemto: update for Ntrig calculation in DEtaDPhi

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiTHn.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiTHn.cxx
@@ -26,7 +26,6 @@ AliFemtoCorrFctnDEtaDPhiTHn::AliFemtoCorrFctnDEtaDPhiTHn(char* title, const int&
 AliFemtoCorrFctn(),
   fDPhiDEtaNum(0),
   fDPhiDEtaDen(0),
-  fNtrig(0),
   fphiL(0),
   fphiT(0),
   fPt1Min(pT1min),
@@ -61,15 +60,9 @@ AliFemtoCorrFctn(),
   strncat(tTitDenD,title, 100);
   fDPhiDEtaDen = new THnSparseF(tTitDenD,title,6,nbins,xmin,xmax);
 
-  // set up numerator
-  char tTitNtrig[101] = "Ntrig";
-  strncat(tTitNtrig,title, 100);
-  fNtrig = new TH3F(tTitNtrig,title,pT1Bins,pT1min,pT1max,multBins,multmin,multmax,zvtxBins,zvtxmin,zvtxmax);
-  
   // to enable error bar calculation...
   fDPhiDEtaNum->Sumw2();
   fDPhiDEtaDen->Sumw2();
-  fNtrig->Sumw2();
 }
 
 //____________________________
@@ -77,7 +70,6 @@ AliFemtoCorrFctnDEtaDPhiTHn::AliFemtoCorrFctnDEtaDPhiTHn(const AliFemtoCorrFctnD
   AliFemtoCorrFctn(),
   fDPhiDEtaNum(0),
   fDPhiDEtaDen(0),
-  fNtrig(0),
   fphiL(0),
   fphiT(0),
   fPt1Min(aCorrFctn.fPt1Min),
@@ -122,13 +114,7 @@ AliFemtoCorrFctnDEtaDPhiTHn::AliFemtoCorrFctnDEtaDPhiTHn(const AliFemtoCorrFctnD
     char tTitDenD[101] = "DenDPhiDEta";
     strncat(tTitDenD,title, 100);
     fDPhiDEtaDen = new THnSparseF(tTitDenD,title,6,nbins,xmin,xmax);
- 
-  // set up numerator
-  char tTitNtrig[101] = "Ntrig";
-  strncat(tTitNtrig,title, 100);
-  fNtrig = new TH3F(tTitNtrig,title,100,0,100,multBins,0,100,zvtxBins,-10,10);
-   
-    
+     
     
   fphiL = aCorrFctn.fphiL;
   fphiT = aCorrFctn.fphiT;
@@ -141,7 +127,6 @@ AliFemtoCorrFctnDEtaDPhiTHn::~AliFemtoCorrFctnDEtaDPhiTHn(){
 
   delete fDPhiDEtaNum;
   delete fDPhiDEtaDen;
-  delete fNtrig;
 }
 //_________________________
 AliFemtoCorrFctnDEtaDPhiTHn& AliFemtoCorrFctnDEtaDPhiTHn::operator=(const AliFemtoCorrFctnDEtaDPhiTHn& aCorrFctn)
@@ -266,7 +251,7 @@ void AliFemtoCorrFctnDEtaDPhiTHn::AddRealPair( AliFemtoPair* pair){
   //cout<<dphi<<" "<<deta<<" "<<pt1<<" "<<pt2<<" "<<mult<<" "<<zvtx<<endl;
   Double_t value[] = {dphi, deta, pt1, pt2, mult, zvtx};
   fDPhiDEtaNum->Fill(value);
-  fNtrig->Fill(pt1,mult,zvtx);
+
 }
 
 //____________________________
@@ -319,7 +304,6 @@ void AliFemtoCorrFctnDEtaDPhiTHn::AddMixedPair( AliFemtoPair* pair){
   //fDPhiDEtaNumerator->Fill(dphi, deta);
   Double_t value[] = {dphi, deta, pt1, pt2, mult, zvtx};
   fDPhiDEtaDen->Fill(value);
-  fNtrig->Fill(pt1,mult,zvtx);
 }
 
 
@@ -328,7 +312,6 @@ void AliFemtoCorrFctnDEtaDPhiTHn::WriteHistos()
   // Write out result histograms
   fDPhiDEtaNum->Write();
   fDPhiDEtaDen->Write();
-  fNtrig->Write();
 }
 
 TList* AliFemtoCorrFctnDEtaDPhiTHn::GetOutputList()
@@ -337,7 +320,6 @@ TList* AliFemtoCorrFctnDEtaDPhiTHn::GetOutputList()
   TList *tOutputList = new TList();
   tOutputList->Add(fDPhiDEtaNum);
   tOutputList->Add(fDPhiDEtaDen);
-  tOutputList->Add(fNtrig);
   return tOutputList;
 
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiTHn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiTHn.h
@@ -36,7 +36,6 @@ class AliFemtoCorrFctnDEtaDPhiTHn : public AliFemtoCorrFctn {
  private:
   THnSparseF *fDPhiDEtaNum;  // Numerator of dEta dPhi function
   THnSparseF *fDPhiDEtaDen;  // Denominator of dEta dPhi function
-  TH3F       *fNtrig;        //Number of triggers
   double fphiL;
   double fphiT;
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCutMonitorParticleNumber.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCutMonitorParticleNumber.cxx
@@ -1,0 +1,113 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+// AliFemtoCutMonitorParticleNumber - the cut monitor for particles to study    //
+// the difference between reconstructed and true momentum                     //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+#include "AliFemtoCutMonitorParticleNumber.h"
+#include "AliFemtoModelHiddenInfo.h"
+#include <TH3F.h>
+#include <TList.h>
+#include <TMath.h>
+
+AliFemtoCutMonitorParticleNumber::AliFemtoCutMonitorParticleNumber():
+  fNtrig(0)
+{
+  // Default constructor
+}
+
+AliFemtoCutMonitorParticleNumber::AliFemtoCutMonitorParticleNumber(const char *title, const int &pT1Bins=1, const double& pT1min=0, const double& pT1max=4, const int &zvtxBins=10, const double& zvtxmin=-10, const double& zvtxmax=10, const int &multBins=5, const int& multmin=0, const int& multmax=100):
+  AliFemtoCutMonitor(),
+  fNtrig(0)
+{
+  // Normal constructor
+ 
+  // set up numerator
+  char tTitNtrig[101] = "Ntrig";
+  strncat(tTitNtrig,title, 100);
+  fNtrig = new TH3F(tTitNtrig,title,pT1Bins,pT1min,pT1max,multBins,multmin,multmax,zvtxBins,zvtxmin,zvtxmax);
+  
+  // to enable error bar calculation...
+  fNtrig->Sumw2();
+}
+
+AliFemtoCutMonitorParticleNumber::AliFemtoCutMonitorParticleNumber(const AliFemtoCutMonitorParticleNumber &aCut):
+  AliFemtoCutMonitor(),
+  fNtrig(0)
+{
+  // copy constructor
+  fNtrig= new TH3F(*aCut.fNtrig);
+  
+}
+
+AliFemtoCutMonitorParticleNumber::~AliFemtoCutMonitorParticleNumber()
+{
+  // Destructor
+  delete fNtrig;
+}
+
+AliFemtoCutMonitorParticleNumber& AliFemtoCutMonitorParticleNumber::operator=(const AliFemtoCutMonitorParticleNumber& aCut)
+{
+  // assignment operator
+  if (this == &aCut) 
+    return *this;
+
+  if (fNtrig) delete fNtrig;
+  fNtrig = new TH3F(*aCut.fNtrig);
+    
+  return *this;
+}
+
+AliFemtoString AliFemtoCutMonitorParticleNumber::Report(){ 
+  // Prepare report from the execution
+  string stemp = "*** AliFemtoCutMonitorParticleNumber report"; 
+  AliFemtoString returnThis = stemp;
+  return returnThis; 
+}
+
+void AliFemtoCutMonitorParticleNumber::Fill(const AliFemtoTrack* aTrack)
+{
+  // Fill in the monitor histograms with the values from the current track
+
+  double mult = -1;
+  double zvtx = -11;
+
+  double px1 = aTrack->P().x();
+  double py1 = aTrack->P().y();
+  double pt1 = TMath::Hypot(px1, py1);
+  
+  mult = aTrack->Multiplicity();
+  zvtx = aTrack->Zvtx();
+  fNtrig->Fill(pt1,mult,zvtx);  
+ 
+}
+
+
+void AliFemtoCutMonitorParticleNumber::Fill(const AliFemtoV0* aV0)
+{
+  // Fill in the monitor histograms with the values from the current V0
+
+  double mult = -1;
+  double zvtx = -11;
+  
+  double pt1 = aV0->PtV0();
+    
+  mult = aV0->Multiplicity();
+  zvtx = aV0->Zvtx();
+  fNtrig->Fill(pt1,mult,zvtx);  
+ 
+}
+
+void AliFemtoCutMonitorParticleNumber::Write()
+{
+  // Write out the relevant histograms
+  fNtrig->Write();
+}
+
+TList *AliFemtoCutMonitorParticleNumber::GetOutputList()
+{
+  TList *tOutputList = new TList();
+  tOutputList->Add(fNtrig);
+
+  return tOutputList;
+}

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCutMonitorParticleNumber.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCutMonitorParticleNumber.h
@@ -1,0 +1,58 @@
+////////////////////////////////////////////////////////////////////////////////
+///                                                                          ///
+/// AliFemtoCutMonitorParticleNumber - the cut monitor for particles to study  ///
+/// the difference between reconstructed and true momentum    ///
+///                                                                          ///
+////////////////////////////////////////////////////////////////////////////////
+#ifndef ALIFEMTOCUTMONITORPARTICLENUMBER_H
+#define ALIFEMTOCUTMONITORPARTICLENUMBER_H
+
+class AliFemtoEvent;
+class AliFemtoTrack;
+class AliFemtoV0;
+class AliFemtoKink;
+class AliFemtoPair; // Gael 12/04/02
+class TH3F;
+class TList;
+#include "AliFemtoString.h"
+#include "AliFemtoParticleCollection.h"
+#include "AliFemtoCutMonitor.h"
+
+class AliFemtoCutMonitorParticleNumber : public AliFemtoCutMonitor{
+  
+public:
+  AliFemtoCutMonitorParticleNumber();
+  AliFemtoCutMonitorParticleNumber(const char *title, const int &pT1Bins, const double& pT1min, const double& pT1max, const int &zvtxBins, const double& zvtxmin, const double& zvtxmax, const int &multBins, const int& multmin, const int& multmax);
+  AliFemtoCutMonitorParticleNumber(const AliFemtoCutMonitorParticleNumber &aCut);
+  virtual ~AliFemtoCutMonitorParticleNumber();
+
+  AliFemtoCutMonitorParticleNumber& operator=(const AliFemtoCutMonitorParticleNumber& aCut);
+
+  virtual AliFemtoString Report();
+  virtual void Fill(const AliFemtoEvent* aEvent) {AliFemtoCutMonitor::Fill(aEvent);}
+  virtual void Fill(const AliFemtoTrack* aTrack);
+  virtual void Fill(const AliFemtoV0* aV0);
+  virtual void Fill(const AliFemtoKink* aKink) {AliFemtoCutMonitor::Fill(aKink);}
+  virtual void Fill(const AliFemtoPair* aPair) {AliFemtoCutMonitor::Fill(aPair);}
+  virtual void Fill(const AliFemtoParticleCollection* aCollection) {AliFemtoCutMonitor::Fill(aCollection);}
+  virtual void Fill(const AliFemtoEvent* aEvent,const AliFemtoParticleCollection* aCollection)
+  {AliFemtoCutMonitor::Fill(aEvent, aCollection);}
+  virtual void Fill(const AliFemtoParticleCollection* aCollection1,const AliFemtoParticleCollection* aCollection2) {AliFemtoCutMonitor::Fill(aCollection1, aCollection2);}
+
+
+  void Write();
+
+  virtual TList *GetOutputList();
+
+private:
+  TH3F *fNtrig;        //Number of triggers
+  
+  
+  //TH2D *fYPhi;   // Rapidity cs. Phi monitor
+  //TH2D *fPtPhi;  // Pt vs. Phi monitor
+  //TH2D *fEtaPhi; // Pseudorapidity vs. Phi monitor
+  //TH2D *fEtaPt;  // Pseudorapidity vs. Pt monitor
+};
+
+#endif
+

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/CMakeLists.txt
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/CMakeLists.txt
@@ -66,6 +66,7 @@ set(SRCS
   AliFemtoCutMonitorParticleMomRes.cxx
   AliFemtoCutMonitorParticlePtPDG.cxx
   AliFemtoCutMonitorParticlePtPDGV0.cxx
+  AliFemtoCutMonitorParticleNumber.cxx
   AliFemtoPionLambdaCutMonitor.cxx
   AliFemtoCutMonitorPionPion.cxx
   AliFemtoCutMonitorTrackTPCchiNdof.cxx

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/PWGCFfemtoscopyUserLinkDef.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/PWGCFfemtoscopyUserLinkDef.h
@@ -55,6 +55,7 @@
 #pragma link C++ class AliFemtoCutMonitorParticlePtPDG;
 #pragma link C++ class AliFemtoCutMonitorParticlePtPDGV0;
 #pragma link C++ class AliFemtoCutMonitorParticleEtCorr;
+#pragma link C++ class AliFemtoCutMonitorParticleNumber;
 #pragma link C++ class AliFemtoCorrFctnGammaMonitor;
 #pragma link C++ class AliFemtoCorrFctnMinvMonitor;
 #pragma link C++ class AliFemtoPairCutAntiGamma;

--- a/PWGCF/FEMTOSCOPY/macros/Train/DEtaDPhi/2017/THn/NoCorr/ConfigFemtoAnalysis.C
+++ b/PWGCF/FEMTOSCOPY/macros/Train/DEtaDPhi/2017/THn/NoCorr/ConfigFemtoAnalysis.C
@@ -211,6 +211,12 @@ AliFemtoManager* ConfigFemtoAnalysis(const char* params) {
 	AliFemtoCutMonitorParticleYPt   *cutFail3YPtetaphitpc[numOfMultBins*numOfChTypes];
 	AliFemtoCutMonitorParticlePID   *cutPass3PIDetaphitpc[numOfMultBins*numOfChTypes];
 	AliFemtoCutMonitorParticlePID   *cutFail3PIDetaphitpc[numOfMultBins*numOfChTypes];
+	AliFemtoCutMonitorParticleNumber *cutPassNtrigetaphitpc[numOfMultBins*numOfChTypes];
+	AliFemtoCutMonitorParticleNumber *cutFailNtrigetaphitpc[numOfMultBins*numOfChTypes];
+	AliFemtoCutMonitorParticleNumber *cutPass2Ntrigetaphitpc[numOfMultBins*numOfChTypes];
+	AliFemtoCutMonitorParticleNumber *cutFail2Ntrigetaphitpc[numOfMultBins*numOfChTypes];
+	
+		  
 	AliFemtoCutMonitorV0            *cutPass1V0[numOfMultBins*numOfChTypes];
 	AliFemtoCutMonitorV0            *cutFail1V0[numOfMultBins*numOfChTypes];
 	AliFemtoCutMonitorV0            *cutPass2V0[numOfMultBins*numOfChTypes];
@@ -348,7 +354,7 @@ AliFemtoManager* ConfigFemtoAnalysis(const char* params) {
 
 					//*********V0 cuts********************
 					//V0 first particle cut
-					dtc4etaphitpc[aniter] = new AliFemtoV0TrackCut();
+					dtc4etaphitpc[aniter] = new AliFemtoV0TrackCut(); //lambda
 					dtc4etaphitpc[aniter]->SetMass(LambdaMass);
 					dtc4etaphitpc[aniter]->SetEta(0.8); //0.8
 					if(ichg>=20 && ichg<=26)
@@ -379,7 +385,7 @@ AliFemtoManager* ConfigFemtoAnalysis(const char* params) {
 					dtc4etaphitpc[aniter]->SetRequireTOFProton(false);
 				      
 					//V0 second particle cut
-					dtc5etaphitpc[aniter] = new AliFemtoV0TrackCut();
+					dtc5etaphitpc[aniter] = new AliFemtoV0TrackCut(); //anti-lambda
 					dtc5etaphitpc[aniter]->SetMass(LambdaMass);
 					dtc5etaphitpc[aniter]->SetEta(0.8);
 					if(ichg>=20 && ichg<=26)
@@ -455,6 +461,7 @@ AliFemtoManager* ConfigFemtoAnalysis(const char* params) {
 					}
 					//**************** track Monitors ***************
 
+	
 					if(ifMonitors)//ichg>8)
 					  {
 
@@ -673,7 +680,42 @@ AliFemtoManager* ConfigFemtoAnalysis(const char* params) {
 					  }
 
 
+					cutPassNtrigetaphitpc[aniter] = new AliFemtoCutMonitorParticleNumber(Form("Pass%stpcM%i", chrgs[ichg], imult),4,0,4 ,10, -10, 10, 30,0,150);//0-pion,1-kaon,2-proton
+					cutFailNtrigetaphitpc[aniter] = new AliFemtoCutMonitorParticleNumber(Form("Fail%stpcM%i", chrgs[ichg], imult),4,0,4 ,10, -10, 10, 30,0,150);
 
+
+					cutPass2Ntrigetaphitpc[aniter] = new AliFemtoCutMonitorParticleNumber(Form("Pass2%stpcM%i", chrgs[ichg], imult),4,0,4 ,10, -10, 10, 30,0,150);//0-pion,1-kaon,2-proton
+					cutFail2Ntrigetaphitpc[aniter] = new AliFemtoCutMonitorParticleNumber(Form("Fail2%stpcM%i", chrgs[ichg], imult),4,0,4 ,10, -10, 10, 30,0,150);
+
+					//numbers below checked few times, but something may be set incorectly; take note
+					//positive tracks
+					if (ichg == 0 ||ichg == 2 || ichg==3 || ichg==5 || ichg==6 || ichg==8 || ichg==10 || ichg==12 ||  ichg==13 || ichg==14 || ichg==20 || ichg==21  || ichg==27 || ichg==28)
+					  dtc1etaphitpc[aniter]->AddCutMonitor(cutPassNtrigetaphitpc[aniter],cutFailNtrigetaphitpc[aniter]);
+
+					//negative tracks
+					if (ichg == 1 || ichg==4 ||  ichg==7 ||  ichg==11 || ichg==15 || ichg==16 || ichg==22 || ichg==23 || ichg==29 || ichg == 30)
+					  dtc2etaphitpc[aniter]->AddCutMonitor(cutPassNtrigetaphitpc[aniter],cutFailNtrigetaphitpc[aniter]);
+
+					//lambda
+					if ( ichg == 17 || ichg == 18  || ichg == 24 || ichg == 25 || ichg == 29 || ichg == 31 || ichg == 32)
+					  dtc4etaphitpc[aniter]->AddCutMonitor(cutPassNtrigetaphitpc[aniter],cutFailNtrigetaphitpc[aniter]);
+
+					//anti-lambda
+					if (  ichg == 19 || ichg == 26 || ichg == 28 || ichg == 32 || ichg == 33)		
+					  dtc5etaphitpc[aniter]->AddCutMonitor(cutPassNtrigetaphitpc[aniter],cutFailNtrigetaphitpc[aniter]);
+
+
+					if(ichg == 2 || ichg==5 ||ichg==8 ||ichg==12)
+					  dtc2etaphitpc[aniter]->AddCutMonitor(cutPass2Ntrigetaphitpc[aniter],cutFail2Ntrigetaphitpc[aniter]);
+
+					if(ichg == 13 || ichg == 15 ||  ichg == 20 || ichg == 22 || ichg == 27|| ichg==29)
+					  dtc4etaphitpc[aniter]->AddCutMonitor(cutPass2Ntrigetaphitpc[aniter],cutFail2Ntrigetaphitpc[aniter]);
+					
+					if(ichg == 14 || ichg == 16 || ichg == 18 || ichg == 21 || ichg == 23 ||  ichg == 25  || ichg==28 || ichg == 30 || ichg == 32)
+					  dtc5etaphitpc[aniter]->AddCutMonitor(cutPass2Ntrigetaphitpc[aniter],cutFail2Ntrigetaphitpc[aniter]);
+
+
+					
 					//**** Correlation functions *******	
 					//***without corrections*****
 					if(ichg >= 13)
@@ -687,6 +729,10 @@ AliFemtoManager* ConfigFemtoAnalysis(const char* params) {
 					else
 					  cdedpetaphiTHn[aniter] = new AliFemtoCorrFctnDEtaDPhiTHn(Form("cdedpTHn%stpcM%i", chrgs[ichg], imult),29, 29, 4, 0, 4, 4,0,4 ,10, -10, 10, 30,0,150);
 					anetaphitpc[aniter]->AddCorrFctn(cdedpetaphiTHn[aniter]);
+
+
+
+					
 					/*
 					if(ichg==0 || ichg==1 || ichg==31 || ichg==33) //PP, aPaP, LL, ALAL
                                         {


### PR DESCRIPTION
New correlation function in AliFemto, which calculates deta-dphi using 6D histograms S(deta,dphi,pT1,pT2,centrality,z-vtx) + B(deta,dphi,pT1,pT2,centrality,z-vtx) and Ntrig histogram allowing to applying different normalization.
Works for AOD only (for now).

Update of calculation of Ntrig histogram.