### PR TITLE
Updates of CosThetaStar for Lc->pK0s analysis

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelor.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelor.cxx
@@ -3671,8 +3671,8 @@ void  AliAnalysisTaskSELc2V0bachelor::FillAnalysisHistograms(AliAODRecoCascadeHF
   //cout << fillthis << endl;
   cutsAnal->SetExcludedCut(16);
   if ( ((cutsAnal->IsSelected(part,AliRDHFCuts::kCandidate))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
-    ((TH2F*)(fOutputAll->FindObject(fillthis)))->Fill(lambdacpt,part->CosThetaStar(0,4122,2212,310));
-    if (isBachelorID)((TH2F*)(fOutputPIDBach->FindObject(fillthis)))->Fill(lambdacpt,part->CosThetaStar(0,4122,2212,310));
+    ((TH2F*)(fOutputAll->FindObject(fillthis)))->Fill(lambdacpt,cutsAnal->GetProtonEmissionAngleCMS(part));
+    if (isBachelorID)((TH2F*)(fOutputPIDBach->FindObject(fillthis)))->Fill(lambdacpt,cutsAnal->GetProtonEmissionAngleCMS(part));
   }
 
   fillthis="histResignedD0"+appendthis;
@@ -4130,7 +4130,7 @@ void AliAnalysisTaskSELc2V0bachelor::TrackRotation(AliRDHFCutsLctoV0 * cuts, Ali
       //cout << fillthis << endl;
       cuts->SetExcludedCut(16);
       if ( ((cuts->IsSelected(partCopy,AliRDHFCuts::kAll))&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr) ) {
-        ((TH2F*)(fOutputPIDBachTR->FindObject(fillthis)))->Fill(pt,partCopy->CosThetaStar(0,4122,2212,310));
+        ((TH2F*)(fOutputPIDBachTR->FindObject(fillthis)))->Fill(pt,cuts->GetProtonEmissionAngleCMS(partCopy));
       }
 
       fillthis="histResignedD0"+appendthis;

--- a/PWGHF/vertexingHF/AliRDHFCutsLctoV0.h
+++ b/PWGHF/vertexingHF/AliRDHFCutsLctoV0.h
@@ -92,6 +92,7 @@ class AliRDHFCutsLctoV0 : public AliRDHFCuts
   { delete fV0daughtersCuts; fV0daughtersCuts = new AliESDtrackCuts(*v0daug); }
   virtual AliESDtrackCuts *GetTrackCutsV0daughters() const {return fV0daughtersCuts;}
 
+  Double_t GetProtonEmissionAngleCMS(AliAODRecoDecayHF *d);
   Double_t GetReSignedd0(AliAODRecoDecayHF *d);
   void SetMagneticField(Double_t a){fBzkG = a;}
 


### PR DESCRIPTION
Dear all,

The calculation of the proton emission angle was performed in the Lc rest frame, but it is changed to the pK0s pair rest frame. The old method assumes the mass of Lc even when the pair has an invariant mass far away from the Lc peak. 

Best regards,
Yosuke