### PR TITLE
Enable/disable the update of the cov matrix also for PbPb (F. Prino)

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSEImproveITS.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEImproveITS.h
@@ -92,15 +92,14 @@ private:
 
   Bool_t fRunInVertexing; /// flag to run hybrid task before the vertexingHF task or in standard mode
   Bool_t fImproveTracks; /// this is always kTRUE. kFALSE only if re-running on already improved AODs
-  Bool_t fUpdateSecVertCovMat; /// flag to switch on/off the modification of the sec vert cov matrix
-    
+  Bool_t fUpdateSecVertCovMat; /// flag to swicth on/off the modification of the sec vert cov matrix
   TList   *fDebugOutput; //!<! collection of debug output
   TNtuple *fDebugNtuple; //!<! debug send on output slot 1
   Float_t *fDebugVars;   //!<! variables to store as degug info 
   Int_t   fNDebug;       /// Max number of debug entries into Ntuple
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskSEImproveITS,6);
+  ClassDef(AliAnalysisTaskSEImproveITS,7);
   /// \endcond
 };
 


### PR DESCRIPTION
FillRecoCand called before the smearing of the track parameters. Possibility enable/disable the update of the cov matrix also for PbPb (F. Prino)