### PR TITLE
PWGDQ: Added TOFmismatch calculation in efficiency task + ITS related variables in VarManager

### DIFF
--- a/PWGDQ/dielectron/core/AliAnalysisTaskElectronEfficiency.cxx
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskElectronEfficiency.cxx
@@ -118,12 +118,16 @@ fvDoPrefilterEff(),
 fvRejCutMee(),
 fvRejCutTheta(),
 fvRejCutPhiV(),
+fvIsTOFrequireCut(),
 fNgen_Ele(0x0),
 fvReco_Ele(),
 fvReco_Ele_poslabel(),
 fNgen_Pos(0x0),
 fvReco_Pos(),
 fvReco_Pos_poslabel(),
+fvAllPionsForRej(),
+fvPionsRejByAllSigns(),
+fvPionsRejByUnlike(),
 fNgen1_Rec_Ele(0x0),
 fNgen2_Rec_Ele(0x0),
 fvReco_Rec_Ele(),
@@ -169,12 +173,12 @@ fDeltaPhi_pt(0x0),
 fDeltaPhi_eta(0x0),
 fDeltaPhi_MCcharge(0x0),
 fDeltaPhi_charge(0x0),
-fDeltaMomNbins(1200),
-fDeltaMomMin(-10.),
-fDeltaMomMax(2.),
 fMomNbins(1000),
 fMomMin(0.),
 fMomMax(10.),
+fDeltaMomNbins(1200),
+fDeltaMomMin(-10.),
+fDeltaMomMax(2.),
 fRelMomNbins(400),
 fRelMomMin(0.),
 fRelMomMax(2.),
@@ -216,9 +220,6 @@ fResolutionCuts(0x0),
 fPairCutMee(-1),
 fPairCutTheta(-1),
 fPairCutPhiV(3.2),
-fvAllPionsForRej(),
-fvPionsRejByAllSigns(),
-fvPionsRejByUnlike(),
 fOutputList(0x0),
 fOutputListSupportHistos(0x0),
 fEventStat(0x0),
@@ -320,12 +321,16 @@ fvDoPrefilterEff(),
 fvRejCutMee(),
 fvRejCutTheta(),
 fvRejCutPhiV(),
+fvIsTOFrequireCut(),
 fNgen_Ele(0x0),
 fvReco_Ele(),
 fvReco_Ele_poslabel(),
 fNgen_Pos(0x0),
 fvReco_Pos(),
 fvReco_Pos_poslabel(),
+fvAllPionsForRej(),
+fvPionsRejByAllSigns(),
+fvPionsRejByUnlike(),
 fNgen1_Rec_Ele(0x0),
 fNgen2_Rec_Ele(0x0),
 fvReco_Rec_Ele(),
@@ -418,9 +423,6 @@ fResolutionCuts(0x0),
 fPairCutMee(-1),
 fPairCutTheta(-1),
 fPairCutPhiV(3.2),
-fvAllPionsForRej(),
-fvPionsRejByAllSigns(),
-fvPionsRejByUnlike(),
 fOutputList(0x0),
 fOutputListSupportHistos(0x0),
 fEventStat(0x0),
@@ -471,13 +473,14 @@ fSelectedByCut(0),
 fSelectedByExtraCut(0)
 {
   /// Constructor
-  
+
   fvTrackCuts.clear();
   fvExtraTrackCuts.clear();
   fvDoPrefilterEff.clear();
   fvRejCutMee.clear();
   fvRejCutTheta.clear();
   fvRejCutPhiV.clear();
+  fvIsTOFrequireCut.clear();
   fvReco_Ele.clear();
   fvReco_Ele_poslabel.clear();
   fvReco_Pos.clear();
@@ -489,14 +492,14 @@ fSelectedByExtraCut(0)
   fvAllPionsForRej.clear();
   fvPionsRejByAllSigns.clear();
   fvPionsRejByUnlike.clear();
-  
-  
+
+
   DefineInput(0, TChain::Class());
   DefineOutput(1, TList::Class());
   DefineOutput(2, TList::Class());
   DefineOutput(3, TTree::Class());
   DefineOutput(4, TH1D::Class());
-  
+
   fUsedVars = new TBits(AliDielectronVarManager::kNMaxValues);
   fUsedVars->SetBitNumber(AliDielectronVarManager::kP, kTRUE);
   fUsedVars->SetBitNumber(AliDielectronVarManager::kPIn, kTRUE);
@@ -542,21 +545,21 @@ void AliAnalysisTaskElectronEfficiency::UserCreateOutputObjects()
              "  eleFinalState->SetMotherSources(AliDielectronSignalMC::kDirect, AliDielectronSignalMC::kDirect);//equiv. to IsPrimary();\n"
              "  task->AddSignalMC(eleFinalState);\n}");
   }
-  
-  
+
+
   Printf("  __________________________________________________");
   Printf("  - centrality range:  %f  to  %f", fCentMin, fCentMax);
   Printf("  - use multiplicity selection (Run 2): %s", (fUseMultSelection)?"kTRUE":"kFALSE");
   Printf("  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^");
-  
+
   OpenFile(1, "RECREATE");
-  
+
   TList *pairEffList(0x0);
   if(fDoPairing){
     pairEffList = new TList();
     pairEffList->SetName("pairEfficiency");
     pairEffList->SetOwner();
-    
+
     if(fCalcEfficiencyGen){
       TList *lGenBinning = new TList();
       lGenBinning->SetName("generatedBinning");
@@ -591,11 +594,11 @@ void AliAnalysisTaskElectronEfficiency::UserCreateOutputObjects()
       lHF1->Add(fNgenPairsHF);
       for(UInt_t iCut=0; iCut<GetNCutsets(); ++iCut) lHF1->Add(fvRecoPairsHF.at(iCut));
       lGenBinning->Add(lHF1);
-      
+
       //lGenBinning->Print();
       pairEffList->Add(lGenBinning);
     }
-    
+
     if(fCalcEfficiencyRec){
       TList *lRecBinning = new TList();
       lRecBinning->SetName("reconstructedBinning");
@@ -630,52 +633,52 @@ void AliAnalysisTaskElectronEfficiency::UserCreateOutputObjects()
       lHF->Add(fNgenPairsRecHF);
       for(UInt_t iCut=0; iCut<GetNCutsets(); ++iCut) lHF->Add(fvRecoPairsRecHF.at(iCut));
       lRecBinning->Add(lHF);
-      
+
       //lRecBinning->Print();
       pairEffList->Add(lRecBinning);
     }
     pairEffList->Print();
   }
-  
+
   TList *resolutionList(0x0);
   if(fCalcResolution){
     resolutionList = new TList();
     resolutionList->SetName("resolution");
     resolutionList->SetOwner();
-    
+
     if(fMakeResolutionSparse){
       Int_t THnBins[6] = {fMomNbins, fRelMomNbins, fDeltaMomNbins, fDeltaThetaNbins, fDeltaEtaNbins, fDeltaPhiNbins};
       Double_t THnMin[6] = {fMomMin, fRelMomMin, fDeltaMomMin, fDeltaThetaMin, fDeltaEtaMin, fDeltaPhiMin};
       Double_t THnMax[6] = {fMomMax, fRelMomMax, fDeltaMomMax, fDeltaThetaMax, fDeltaEtaMax, fDeltaPhiMax};
       fTHnResElectrons1 = new THnSparseD("pGen_Res_Electrons1", "pGen_Res_Electrons1", 6, THnBins, THnMin, THnMax);
       fTHnResElectrons1->Sumw2();
-      
+
       fTHnResElectrons1->GetAxis(0)->SetName("pGen");
       fTHnResElectrons1->GetAxis(1)->SetName("pGen_Over_pRec");
       fTHnResElectrons1->GetAxis(2)->SetName("deltaP");
       fTHnResElectrons1->GetAxis(3)->SetName("deltaTheta");
       fTHnResElectrons1->GetAxis(4)->SetName("deltaEta");
       fTHnResElectrons1->GetAxis(5)->SetName("deltaPhi");
-      
+
       fTHnResElectrons1->GetAxis(0)->SetTitle("p^{gen} (GeV/c)");
       fTHnResElectrons1->GetAxis(1)->SetTitle("p^{rec} / p^{gen} (GeV/c)");
       fTHnResElectrons1->GetAxis(2)->SetTitle("p^{rec}_{T} - p^{gen}_{T} (GeV/c)");
       fTHnResElectrons1->GetAxis(3)->SetTitle("#theta^{rec} - #theta^{gen} (rad)");
       fTHnResElectrons1->GetAxis(4)->SetTitle("#eta^{rec} - #eta^{gen}");
       fTHnResElectrons1->GetAxis(5)->SetTitle("#varphi^{rec} - #varphi^{gen} (rad)");
-      
+
       fTHnResPositrons1 = static_cast<THnSparseD*> (fTHnResElectrons1->Clone("pGen_Res_Positrons1"));
       fTHnResPositrons1->SetTitle("pGen_Res_Positrons1");
       fTHnResPositrons1->Sumw2();
-      
+
       fTHnResElectrons2 = static_cast<THnSparseD*> (fTHnResElectrons1->Clone("pGen_Res_Electrons_negativeLabel"));
       fTHnResElectrons2->SetTitle("pGen_Res_Electrons_negativeLabel");
       fTHnResElectrons2->Sumw2();
-      
+
       fTHnResPositrons2 = static_cast<THnSparseD*> (fTHnResElectrons1->Clone("pGen_Res_Positrons_negativeLabel"));
       fTHnResPositrons2->SetTitle("pGen_Res_Positrons_negativeLabel");
       fTHnResPositrons2->Sumw2();
-            
+
       resolutionList->Add(fTHnResElectrons1);
       resolutionList->Add(fTHnResPositrons1);
       resolutionList->Add(fTHnResElectrons2);
@@ -688,14 +691,14 @@ void AliAnalysisTaskElectronEfficiency::UserCreateOutputObjects()
       fDeltaPhiAll->SetMarkerStyle(20);
       fDeltaPhiAll->SetMarkerColor(kBlack);
       fDeltaPhiAll->SetLineColor(kBlack);
-      
+
       fDeltaPhi = new TH1D("DeltaPhi","",320,-0.1,6.4);
       fDeltaPhi->GetXaxis()->SetTitle("#varphi_{gen} - #varphi_{rec}");
       fDeltaPhi->Sumw2();
       fDeltaPhi->SetMarkerStyle(20);
       fDeltaPhi->SetMarkerColor(kBlack);
       fDeltaPhi->SetLineColor(kBlack);
-      
+
       fDeltaPhi_alpha = new TH2D("DeltaPhi_alpha","",320,-0.1,6.4,140,-7.,7.);
       fDeltaPhi_alpha->Sumw2();
       fDeltaPhi_pt = new TH2D("DeltaPhi_pt","",320,-0.1,6.4,500,0.,10.);
@@ -706,7 +709,7 @@ void AliAnalysisTaskElectronEfficiency::UserCreateOutputObjects()
       fDeltaPhi_MCcharge->Sumw2();
       fDeltaPhi_charge = new TH2D("DeltaPhi_charge","",320,-0.1,6.4,3,-1.5,1.5);
       fDeltaPhi_charge->Sumw2();
-      
+
       fPGen                                = new TH1D("PGen",                               "",500,0., 5.);
       fPRec                                = new TH1D("PRec",                               "",500,0., 5.);
       fPGen_DeltaP                         = new TH2D("PGen_DeltaP",                        "",500,0.,10.,fDeltaMomNbins,fDeltaMomMin,fDeltaMomMax);
@@ -720,7 +723,7 @@ void AliAnalysisTaskElectronEfficiency::UserCreateOutputObjects()
       fEtaGen_DeltaEta                     = new TH2D("EtaGen_DeltaEta",                    "",200,-1.,1.,fDeltaEtaNbins,fDeltaEtaMin,fDeltaEtaMax);
       fThetaGen_DeltaTheta                 = new TH2D("ThetaGen_DeltaTheta",                "",220,-0.1*TMath::Pi(),1.1*TMath::Pi(),fDeltaThetaNbins,fDeltaThetaMin,fDeltaThetaMax);
       fPhiGen_DeltaPhi                     = new TH2D("PhiGen_DeltaPhi",                    "",320,-0.1*TMath::Pi(),2.1*TMath::Pi(),fDeltaPhiNbins,fDeltaPhiMin,fDeltaPhiMax);
-      
+
       fPGen                                ->Sumw2();
       fPRec                                ->Sumw2();
       fPGen_DeltaP                         ->Sumw2();
@@ -734,7 +737,7 @@ void AliAnalysisTaskElectronEfficiency::UserCreateOutputObjects()
       fEtaGen_DeltaEta                     ->Sumw2();
       fThetaGen_DeltaTheta                 ->Sumw2();
       fPhiGen_DeltaPhi                     ->Sumw2();
-      
+
       fPGen                                ->GetXaxis()->SetTitle("p^{gen} (GeV/c)");
       fPRec                                ->GetXaxis()->SetTitle("p^{rec} (GeV/c)");
       fPGen_DeltaP                         ->GetXaxis()->SetTitle("p^{gen} (GeV/c)");
@@ -759,7 +762,7 @@ void AliAnalysisTaskElectronEfficiency::UserCreateOutputObjects()
       fThetaGen_DeltaTheta                 ->GetYaxis()->SetTitle("#theta^{rec} - #theta^{gen} (rad)");
       fPhiGen_DeltaPhi                     ->GetXaxis()->SetTitle("#varphi^{gen} (rad)");
       fPhiGen_DeltaPhi                     ->GetYaxis()->SetTitle("#varphi^{rec} - #varphi^{gen} (rad)");
-      
+
       resolutionList->Add(fDeltaPhiAll);
       resolutionList->Add(fDeltaPhi_alpha);
       resolutionList->Add(fDeltaPhi_pt);
@@ -767,7 +770,7 @@ void AliAnalysisTaskElectronEfficiency::UserCreateOutputObjects()
       resolutionList->Add(fDeltaPhi_MCcharge);
       resolutionList->Add(fDeltaPhi_charge);
       resolutionList->Add(fDeltaPhi);
-      
+
       resolutionList->Add(fPGen);
       resolutionList->Add(fPRec);
       resolutionList->Add(fPGen_DeltaP);
@@ -790,11 +793,11 @@ void AliAnalysisTaskElectronEfficiency::UserCreateOutputObjects()
     fOpeningAngleGen_DeltaOpeningAngleUS ->GetYaxis()->SetTitle("#theta_{ee,US}^{rec} - #theta_{ee,US}^{gen} (rad)");
     fOpeningAngleGen_DeltaOpeningAngleLS ->GetXaxis()->SetTitle("#theta_{ee,LS}^{gen} (rad)");
     fOpeningAngleGen_DeltaOpeningAngleLS ->GetYaxis()->SetTitle("#theta_{ee,LS}^{rec} - #theta_{ee,LS}^{gen} (rad)");
-        
+
     resolutionList->Add(fOpeningAngleGen_DeltaOpeningAngleUS);
     resolutionList->Add(fOpeningAngleGen_DeltaOpeningAngleLS);
 
-    
+
     Int_t bins[4] = {50,60,100,100};
     Double_t min[4] = { 0., 0., 0., 0. };
     Double_t max[4] = { 5., 6., 2., 2. };
@@ -804,46 +807,46 @@ void AliAnalysisTaskElectronEfficiency::UserCreateOutputObjects()
     fMgen_PtGen_mRes_ptRes->GetAxis(1)->SetTitle("p_{T,ee}^{gen}");
     fMgen_PtGen_mRes_ptRes->GetAxis(2)->SetTitle("m_{ee}^{rec} / m_{ee}^{gen}");
     fMgen_PtGen_mRes_ptRes->GetAxis(3)->SetTitle("p_{T,ee}^{rec} / p_{T,ee}^{gen}");
-    
+
     fMgen_PtGen_mRes_ptRes->GetAxis(0)->SetName("m_gen");
     fMgen_PtGen_mRes_ptRes->GetAxis(1)->SetName("pt_gen");
     fMgen_PtGen_mRes_ptRes->GetAxis(2)->SetName("mResolution");
     fMgen_PtGen_mRes_ptRes->GetAxis(3)->SetName("ptResolution");
     resolutionList->Add(fMgen_PtGen_mRes_ptRes);
   }
-  
+
   TList *singleEffList = new TList();
   singleEffList->SetName("electronEfficiency");
   singleEffList->SetOwner();
-  
+
   if(fCalcEfficiencyGen){
     TList *singleEffGenList = new TList();
     singleEffGenList->SetName("generatedBinning");
     singleEffGenList->SetOwner();
-    
+
     singleEffGenList->Add(fNgen_Ele);
     for (UInt_t iCut=0; iCut<GetNCutsets(); ++iCut)
       singleEffGenList->Add(fvReco_Ele.at(iCut));
     if(fCalcEfficiencyPoslabel)
       for (UInt_t iCut=0; iCut<GetNCutsets(); ++iCut)
         singleEffGenList->Add(fvReco_Ele_poslabel.at(iCut));
-    
+
     singleEffGenList->Add(fNgen_Pos);
     for (UInt_t iCut=0; iCut<GetNCutsets(); ++iCut)
       singleEffGenList->Add(fvReco_Pos.at(iCut));
     if(fCalcEfficiencyPoslabel)
       for (UInt_t iCut=0; iCut<GetNCutsets(); ++iCut)
         singleEffGenList->Add(fvReco_Pos_poslabel.at(iCut));
-    
+
     //singleEffGenList->Print();
     singleEffList->Add(singleEffGenList);
   }
-  
+
   if(fCalcEfficiencyRec){
     TList *singleEffRecList = new TList();
     singleEffRecList->SetName("reconstructedBinning");
     singleEffRecList->SetOwner();
-    
+
     singleEffRecList->Add(fNgen1_Rec_Ele);
     singleEffRecList->Add(fNgen2_Rec_Ele);
     for (UInt_t iCut=0; iCut<GetNCutsets(); ++iCut)
@@ -851,7 +854,7 @@ void AliAnalysisTaskElectronEfficiency::UserCreateOutputObjects()
     if(fCalcEfficiencyPoslabel)
       for (UInt_t iCut=0; iCut<GetNCutsets(); ++iCut)
         singleEffRecList->Add(fvReco_Rec_Ele_poslabel.at(iCut));
-    
+
     singleEffRecList->Add(fNgen1_Rec_Pos);
     singleEffRecList->Add(fNgen2_Rec_Pos);
     for (UInt_t iCut=0; iCut<GetNCutsets(); ++iCut)
@@ -859,11 +862,11 @@ void AliAnalysisTaskElectronEfficiency::UserCreateOutputObjects()
     if(fCalcEfficiencyPoslabel)
       for (UInt_t iCut=0; iCut<GetNCutsets(); ++iCut)
         singleEffRecList->Add(fvReco_Rec_Pos_poslabel.at(iCut));
-    
+
     //singleEffRecList->Print();
     singleEffList->Add(singleEffRecList);
   }
-  
+
   for (UInt_t iCut=0; iCut<GetNCutsets(); ++iCut){
     if(fvDoPrefilterEff.at(iCut)){
       singleEffList->Add(fvAllPionsForRej.at(iCut));
@@ -872,29 +875,29 @@ void AliAnalysisTaskElectronEfficiency::UserCreateOutputObjects()
     }
   }
   singleEffList->Print();
-  
-  
+
+
   // be really careful if you need to implement this (see comments in UserExec):
   //    fOutputList->Add(fvReco_Pio.at(iCut));
   //    fOutputList->Add(fvReco_Kao.at(iCut));
   //    fOutputList->Add(fvReco_Pro.at(iCut));
-  
+
   fOutputList = new TList();
   fOutputList->SetName(GetName());
   fOutputList->SetOwner();
-  
+
   if(singleEffList)  fOutputList->Add(singleEffList);
   if(pairEffList)    fOutputList->Add(pairEffList);
   if(resolutionList) fOutputList->Add(resolutionList);
-  
+
   fOutputList->Print();
-  
+
   PostData(1, fOutputList);
-  
+
   OpenFile(2, "RECREATE");
   CreateSupportHistos();
   PostData(2, fOutputListSupportHistos);
-  
+
   OpenFile(3, "RECREATE");
   //Define Tree for Track Values
   tracksT = new TTree("tracksT","tracksT");
@@ -946,7 +949,7 @@ void AliAnalysisTaskElectronEfficiency::UserCreateOutputObjects()
   tracksT->Branch("selectedByCut",      &fSelectedByCut);
   tracksT->Branch("selectedByExtraCut", &fSelectedByExtraCut);
   PostData(3, tracksT);
-  
+
   OpenFile(4, "RECREATE");
   if (!fEventStat){
     fEventStat=new TH1D("hEventStat","Event statistics",kEventStatBins,0,kEventStatBins);
@@ -961,7 +964,7 @@ void AliAnalysisTaskElectronEfficiency::UserCreateOutputObjects()
 //________________________________________________________________________
 void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
 {
-  
+
   /// Strategy:  Process one cutInstance (or multiple ones) for analysis tracking&PID efficiency (as usual).
   ///            Process optional, separate cutInstance for prefilter efficiencies: it also produces the usual tracking&PID efficiency
   ///            (but of course for the specified prefilter track sample, so mainly for convenience and curiosity),
@@ -970,15 +973,15 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
   mcEvent = AliDielectronMC::Instance()->GetMCEvent();
   if (!mcEvent) { Printf("ERROR: mcEvent not available"); return; }
   AliDielectronVarManager::SetEvent(mcEvent);
-  
+
   AliESDInputHandler *inputHandlerESD = dynamic_cast<AliESDInputHandler*> (AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler());
   if (!inputHandlerESD) { Printf("ERROR: Could not get ESDInputHandler\n"); }
   else fESD = (AliESDEvent*)inputHandlerESD->GetEvent();
   if (!fESD) { Printf("ERROR: fESD not available"); return; }
-  
+
   if (!fPIDResponse) SetPIDResponse( ((AliESDInputHandler*)(AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler()))->GetPIDResponse() );
   AliDielectronVarManager::SetPIDResponse(fPIDResponse);
-  
+
   // set pid correction function to var manager
   if(fPostPIDCntrdCorrTPC) AliDielectronPID::SetCentroidCorrFunction(fPostPIDCntrdCorrTPC);
   if(fPostPIDWdthCorrTPC)  AliDielectronPID::SetWidthCorrFunction(fPostPIDWdthCorrTPC);
@@ -986,9 +989,9 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
   if(fPostPIDWdthCorrITS)  AliDielectronPID::SetWidthCorrFunctionITS(fPostPIDWdthCorrITS);
   if(fPostPIDCntrdCorrTOF) AliDielectronPID::SetCentroidCorrFunctionTOF(fPostPIDCntrdCorrTOF);
   if(fPostPIDWdthCorrTOF)  AliDielectronPID::SetWidthCorrFunctionTOF(fPostPIDWdthCorrTOF);
-  
+
   AliStack *fStack = mcEvent->Stack();
-  
+
   Bool_t isESD=kTRUE;
   Bool_t isAOD=kFALSE; //currently not supported!
   // taken from AliAnalysisTaskMultiDielectron::UserExec():
@@ -1017,7 +1020,7 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
   }
   // After physics selection
   fEventStat->Fill(kPhysicsSelectionEvents);
-  
+
   // Event filter
   if (fEventFilter) {
     if (!fEventFilter->IsSelected(fESD)) return; // fESD instead of 'InputEvent()'
@@ -1041,16 +1044,16 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
     vtxZGlobal = vtxESD->GetZ(); // was GetZv(); until Jan 2015
     nCtrb = vtxESD->GetNContributors();
   }
-  
+
   // After event filter
   fEventStat->Fill(kFilteredEvents);
   PostData(4,fEventStat);
-  
-  
+
+
   //  ++fEventcount;
   //  Printf("__________ next Event selected ( %i ) __________", fEventcount);
   Int_t kRunNumber = fESD->GetRunNumber();
-  
+
   // for selected events, fill some histos:
   (dynamic_cast<TH1D *>(fOutputListSupportHistos->At(0)))->Fill(0.);
   (dynamic_cast<TH1D *>(fOutputListSupportHistos->At(1)))->Fill(centralityF);
@@ -1071,7 +1074,7 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
     if (fvDoPrefilterEff.at(iCut) == kTRUE) atleastOnePrefilterSetting=kTRUE;
     fvAtleastOneEleExtra_perCut.push_back(kFALSE); // initialize vector contents
   }
-  
+
   //
   // store all accepted track IDs in vectors to use them for the Prefilter efficiency determination.
   //
@@ -1079,15 +1082,15 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
   vecTrkID.push_back(0); // first element is neccessary to hook track vector into cut vector.
   std::vector< std::vector<Int_t> > vecEleCand_perCut; // one vector per cut setting
   for (UInt_t iCut=0; iCut<GetNCutsets(); ++iCut) { vecEleCand_perCut.push_back(vecTrkID); }
-  
-  
+
+
   Int_t NEleSelected = 0;
   UInt_t ResolutionMask = 1000;
   if(fResolutionCuts) ResolutionMask=(1<<fResolutionCuts->GetCuts()->GetEntries())-1;
   if(mcEvent){
     Int_t nMCtracks = mcEvent->GetNumberOfTracks();
     //AliStack *fStack = mcEvent->Stack();
-    
+
     for(Int_t iMCtrack = 0; iMCtrack < nMCtracks; iMCtrack++){
       // New:
       // Select electrons based on an attached AliDielectronSignalMC.
@@ -1095,7 +1098,7 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
       //
       Bool_t truth1 = AliDielectronMC::Instance()->IsMCTruth(iMCtrack, (AliDielectronSignalMC*)fSignalsMC->At(0), 1);
       if (!truth1) continue;
-      
+
       AliMCParticle *mctrack = dynamic_cast<AliMCParticle *>(mcEvent->GetTrack(iMCtrack));
       if (!mctrack) continue;
       Double_t mcP     = mctrack->P();
@@ -1110,6 +1113,7 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
         else                      fNgen_Pos->Fill(mcPt,mcEta,mcPhi);
       }
       Bool_t bFilled(kFALSE);
+
       for (Int_t iTracks = 0; iTracks < fESD->GetNumberOfTracks(); iTracks++){
         fSelectedByCut = 0;
         fSelectedByExtraCut = 0;
@@ -1119,10 +1123,12 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
         Int_t abslabel = TMath::Abs( track->GetLabel() );
         if(abslabel != iMCtrack) continue;
         if(mctrack->Charge()/3 != track->Charge()) continue;
-        
+
         Double_t trackPt  = track->Pt();
         Double_t trackEta = track->Eta();
         Double_t trackPhi = track->Phi();
+
+
         UInt_t ResolutionMaskSelected = 999;
         if(fResolutionCuts) ResolutionMaskSelected = fResolutionCuts->IsSelected(track);
         if(fCalcEfficiencyRec && !bFilled && ResolutionMask == ResolutionMaskSelected){
@@ -1136,6 +1142,23 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
           //apply track cuts
           UInt_t cutMask=fvTrackCuts.at(iCut)->IsSelected(track);
           if (cutMask!=selectedMask) continue;
+
+
+          // Check for TOF Mismatch and reject for TOFRequire cutsettings
+          // Int_t fMCTOFMatch = -99;
+          if (fvIsTOFrequireCut.size() > 0){ // If "IsTOFrequire"-vector filled? If not assume it to be TOFif cut
+            Bool_t TOFout = !((track->GetStatus()&AliVTrack::kTOFout) == 0);
+            Bool_t TIME   = !((track->GetStatus()&AliVTrack::kTIME) == 0);
+            Int_t TOFTrkLabel[3] = {-1};//This can contain three particles wich occupy the same cluster
+            track->GetTOFLabel(TOFTrkLabel);// Gets the labels of the tracks matched to the TOF, this can be used to remove
+                                            // the mismatch and to compute the efficiency! The label to check is the first
+                                            // one, the others can come from different tracks
+
+            if (abslabel != TOFTrkLabel[0] && (TOFout && TIME) && (fvIsTOFrequireCut.at(iCut) == kTRUE)) { // Mismatch and PID info available and TOFrequire
+              continue;
+            }
+          }
+
           vecEleCand_perCut.at(iCut).push_back(iTracks);
           if(track->Charge() < 0){
             if(fCalcEfficiencyGen){
@@ -1224,10 +1247,10 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
           grandmother = (dynamic_cast<AliMCParticle *>(mcEvent->GetTrack(labelgrandmotherT)));
         if(grandmother)
           pdggrandmotherT = grandmother->PdgCode();
-        
+
         if(fWriteTree) // variable 'fSelectedByCut' is stored in the Tree to distinguish the cut settings...
           tracksT->Fill(); //Fill Track Tree
-        
+
         if(fSelectedByCut & 1<<fSupportedCutInstance){ // only go on if the track survived in the cut setting for which you want to fill the support histograms.
           NEleSelected++;
           Float_t pESD = track->P();
@@ -1297,7 +1320,7 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
           (dynamic_cast<TH2D *>(fOutputListSupportHistos->At(73)))->Fill(pdgmotherT, pdggrandmotherT);//hPdgCodeM_GM
         } //fSupportedCutInstance
       } // reco track loop
-      
+
       if(fCalcEfficiencyRec){
         // smear generated quantities of non-reconstructed particles with external response matrix,
         // in order to compute the efficiency consistently based on "measurable" quantities.
@@ -1306,7 +1329,7 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
         Double_t trackEta   = mcEta;
         Double_t trackTheta = mcTheta;
         Double_t trackPhi   = mcPhi;
-        
+
         if(fPhiEleResArr && fPhiPosResArr){
           Double_t phiSmearing = 0.;
           if(mctrack->Charge() < 0) phiSmearing =  GetSmearing(fPhiEleResArr,mcP);
@@ -1327,7 +1350,7 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
           else  trackP  = mcP + pSmearing;
           trackPt = TMath::Sin(trackTheta) * trackP;
         }
-        
+
         if(mctrack->Charge() < 0){
           fNgen1_Rec_Ele->Fill(trackPt,trackEta,trackPhi);
           if(!bFilled)
@@ -1339,13 +1362,13 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
             fNgen2_Rec_Pos->Fill(trackPt,trackEta,trackPhi);
         }
       }
-      
+
     } // mc track loop
-    
+
     //(dynamic_cast<TH2D *>(fOutputListSupportHistos->At(2)))->Fill(centralityF,0);//hNTrksEvent_cent
     (dynamic_cast<TH2D *>(fOutputListSupportHistos->At(3)))->Fill(centralityF,NEleSelected);//hNEleEvent_cent
     if(atleastOnePrefilterSetting && atleastOneEleExtraSelected) CalcPrefilterEff(mcEvent, vecEleCand_perCut, fvAtleastOneEleExtra_perCut);
-    
+
     if(fDoPairing){  // calculate pair efficiency from signal pairs
       std::vector<LMEEparticle> LMEEelectrons,LMEEpositrons;
       for(Int_t iMC = 0; iMC < nMCtracks; iMC++){
@@ -1383,7 +1406,7 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
               lmeeLeg.vbRec.at(iCut) = kTRUE;
           } // cut loop
         } // ESD loop
-        if(fCalcEfficiencyRec){ 
+        if(fCalcEfficiencyRec){
           if(fPhiEleResArr && fPhiPosResArr){
             Double_t phiSmearing = 0.;
             if(part->Charge() < 0) phiSmearing =  GetSmearing(fPhiEleResArr,lmeeLeg.genP);
@@ -1487,16 +1510,16 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
         } // electron iteration
       } // pairing
     } // do pairing
-    
+
     if(fCalcResolution && fResolutionCuts){ // calculate electron pt resolution
-      Int_t Nprimaries = mcEvent->GetNumberOfPrimaries();
+      // Int_t Nprimaries = mcEvent->GetNumberOfPrimaries();
       TLorentzVector l1Gen,l2Gen,l1Rec,l2Rec;
       for(Int_t iTracks = 0; iTracks < fESD->GetNumberOfTracks(); iTracks++){
         AliESDtrack *track = fESD->GetTrack(iTracks);
         if (!track) { Printf("ERROR: Could not receive track %d", iTracks); continue; }
         if(fResolutionCuts->IsSelected(track) != ResolutionMask) continue;
         Int_t label = track->GetLabel();
-        
+
         AliMCParticle *part = dynamic_cast<AliMCParticle *>(mcEvent->GetTrack(TMath::Abs(label)));
         if(!part) { Printf("ERROR: Could not receive mc track %d", TMath::Abs(label)); continue; }
         Int_t mcLabel = part->Label();
@@ -1517,13 +1540,13 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
         if(fMakeResolutionSparse){
           Double_t thnvals[6] = {mcP,recP / mcP,recP - mcP,recTheta - mcTheta,recEta - mcEta,recPhi - mcPhi};
           if(TMath::Abs(mcEta) < 0.9) {
-            if(part->Charge()<0){ 
+            if(part->Charge()<0){
               if(label > 0)
                 fTHnResElectrons1->Fill(thnvals);
               else
                 fTHnResElectrons2->Fill(thnvals);
             }
-            if(part->Charge()>0){ 
+            if(part->Charge()>0){
               if(label > 0)
                 fTHnResPositrons1->Fill(thnvals);
               else
@@ -1551,7 +1574,7 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
             fDeltaPhi->Fill(recPhi - mcPhi);
           }
         }
-        
+
         if(label < 0) continue;
         l1Gen.SetPtEtaPhiM(part ->Pt(),part ->Eta(),part ->Phi(),AliPID::ParticleMass(AliPID::kElectron));
         l1Rec.SetPtEtaPhiM(track->Pt(),track->Eta(),track->Phi(),AliPID::ParticleMass(AliPID::kElectron));
@@ -1573,12 +1596,12 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
           l2Rec.SetPtEtaPhiM(track2->Pt(),track2->Eta(),track2->Phi(),AliPID::ParticleMass(AliPID::kElectron));
           Double_t OpeningAngleGen = l1Gen.Angle(l2Gen.Vect());
           Double_t OpeningAngleRec = l1Rec.Angle(l2Rec.Vect());
-          Double_t OpeningAngleResolution = (OpeningAngleGen > 0.) ? OpeningAngleRec/OpeningAngleGen : -1.;
-          
+          // Double_t OpeningAngleResolution = (OpeningAngleGen > 0.) ? OpeningAngleRec/OpeningAngleGen : -1.;
+
           Double_t vals[4];
           vals[0] = (l1Gen+l2Gen).M();
           vals[2] = (vals[0] > 0.) ? (l1Rec+l2Rec).M()/vals[0] : -1.;
-          
+
           vals[1] = (l1Gen+l2Gen).Pt();
           vals[3] = (vals[1] > 0.) ? (l1Rec+l2Rec).Pt()/vals[1] : -1.;
           if(part->Charge() != part2->Charge()){
@@ -1606,23 +1629,23 @@ void AliAnalysisTaskElectronEfficiency::CalcPrefilterEff(AliMCEvent* mcEventLoca
   /// The prefilter pair cuts are applied to these random pairs. All and rejected testparticles are stored in 3D histograms.
   /// The advantage of this method is a huge number of random pairs, the disadvantage may be a systematic difference in the implicitly available number of pairs...
   /// (by Patrick)
-  
+
   Int_t nMCtracks  = mcEventLocal->GetNumberOfTracks();
   AliStack *fStack = mcEventLocal->Stack();
   Double_t eleMass = AliPID::ParticleMass(AliPID::kElectron);
-  
+
   for(Int_t iMCtrack = 0; iMCtrack < nMCtracks; iMCtrack++)
   {
     // select only primary, non-injected, charged pions:
     if(!fStack->IsPhysicalPrimary(iMCtrack)) continue;
     AliMCParticle *mcPion = dynamic_cast<AliMCParticle *>(mcEventLocal->GetTrack(iMCtrack));
     if( TMath::Abs(mcPion->PdgCode()) !=  211 ) continue;
-    
+
     Double_t mcPt(-1.),mcEta(-9.),mcPhi(-9.);
     mcPt = mcPion->Pt(); mcEta = mcPion->Eta(); mcPhi = mcPion->Phi();
     if(mcPt  < fPtMinGEN  || mcPt  > fPtMaxGEN)  continue;
     if(mcEta < fEtaMinGEN || mcEta > fEtaMaxGEN) continue;
-    
+
     // need TLorentzVectors for the pairing
     Double_t vMomPi[3]; mcPion->PxPyPz(vMomPi);
     Double_t momPi    = mcPion->P();
@@ -1630,7 +1653,7 @@ void AliAnalysisTaskElectronEfficiency::CalcPrefilterEff(AliMCEvent* mcEventLoca
     TLorentzVector dau1;
     dau1.SetPxPyPzE(vMomPi[0],vMomPi[1],vMomPi[2],energyPi);
     Int_t chargePion = mcPion->Charge();
-    
+
     // loop over all cut settings
     for (UInt_t iCut=0; iCut<GetNCutsets(); ++iCut)
     {
@@ -1640,7 +1663,7 @@ void AliAnalysisTaskElectronEfficiency::CalcPrefilterEff(AliMCEvent* mcEventLoca
       // flags for the pion
       Bool_t rejByAllSigns = kFALSE;
       Bool_t rejByUnlike   = kFALSE;
-      
+
       // pair the testparticle with all selected electron candidates and check for close pairs.
       // pairing starts at vec[1] because vec[0] is always set to 0, since this is needed to initialize the 2D vector (see UserExec).
       for (UInt_t iEle=1; iEle<vvEleCand.at(iCut).size(); iEle++)
@@ -1652,12 +1675,12 @@ void AliAnalysisTaskElectronEfficiency::CalcPrefilterEff(AliMCEvent* mcEventLoca
         TLorentzVector dau2;
         dau2.SetPxPyPzE(vMomEle[0],vMomEle[1],vMomEle[2],energyEle);
         Int_t chargeEle = mcEle->Charge();
-        
+
         Double_t mee   = (dau1+dau2).M();
         Double_t ptee  = (dau1+dau2).Pt();
         Double_t theta = dau1.Angle(dau2.Vect());
         Double_t phiv  = PhivPair(fESD->GetMagneticField(), chargePion, chargeEle, dau1.Vect(), dau2.Vect());
-        
+
         (dynamic_cast<TH2D *>(fOutputListSupportHistos->At(53)))->Fill(mee,ptee);//hMeePtee
         (dynamic_cast<TH3D *>(fOutputListSupportHistos->At(54)))->Fill(mee,phiv,theta);//hMeePhiVOpen
         (dynamic_cast<TH2D *>(fOutputListSupportHistos->At(55)))->Fill(mee,theta);//hMeeOpen
@@ -1665,7 +1688,7 @@ void AliAnalysisTaskElectronEfficiency::CalcPrefilterEff(AliMCEvent* mcEventLoca
         (dynamic_cast<TH2D *>(fOutputListSupportHistos->At(57)))->Fill(ptee,theta);//hPteeOpen
         (dynamic_cast<TH2D *>(fOutputListSupportHistos->At(58)))->Fill(ptee,phiv);//hPteePhiV
         (dynamic_cast<TH2D *>(fOutputListSupportHistos->At(59)))->Fill(theta,phiv);//hOpenPhiV
-        
+
         // tag the pion as rejected, if the pair falls within following cut:
         if ( (fvRejCutMee.at(iCut)   > 0. || fvRejCutTheta.at(iCut) > 0. || fvRejCutPhiV.at(iCut) < 3.14) // at least one cut must be enabled
             && (mee   < fvRejCutMee.at(iCut)   || fvRejCutMee.at(iCut)   < 0.) // -> within cut or cut disabled
@@ -1677,13 +1700,13 @@ void AliAnalysisTaskElectronEfficiency::CalcPrefilterEff(AliMCEvent* mcEventLoca
           if (chargePion!=chargeEle) rejByUnlike = kTRUE;
         }
       } //electron loop
-      
+
       //fill histograms per cut setting to determine rejection efficiency
       fvAllPionsForRej.at(iCut)->Fill(mcPt,mcEta,mcPhi); //reference histogram (denominator)
       if (rejByAllSigns) fvPionsRejByAllSigns.at(iCut)->Fill(mcPt,mcEta,mcPhi);
       if (rejByUnlike)   fvPionsRejByUnlike.at(iCut)->Fill(mcPt,mcEta,mcPhi);
     } //cut loop
-    
+
   } //pion loop
 }
 //______________________________________________
@@ -1699,11 +1722,11 @@ Double_t AliAnalysisTaskElectronEfficiency::PhivPair(Double_t MagField, Int_t ch
   /// This expected ambiguity is not seen due to sorting of track arrays in this framework.
   /// To reach the same result as for ULS (~pi), the legs are flipped for LS.
   /// from PWGDQ/dielectron/AliDielectronPair.cxx
-  
+
   //Define local buffer variables for leg properties
   Double_t px1=-9999.,py1=-9999.,pz1=-9999.;
   Double_t px2=-9999.,py2=-9999.,pz2=-9999.;
-  
+
   TVector3 fD1=dau1;
   TVector3 fD2=dau2;
   Int_t    d1Q=charge1;
@@ -1724,7 +1747,7 @@ Double_t AliAnalysisTaskElectronEfficiency::PhivPair(Double_t MagField, Int_t ch
       //d2Q=charge1;
     }
   }
-  
+
   if (charge1*charge2 > 0.) { // Like Sign
     if(MagField<0){ // inverted behaviour
       if(d1Q>0){
@@ -1750,7 +1773,7 @@ Double_t AliAnalysisTaskElectronEfficiency::PhivPair(Double_t MagField, Int_t ch
         px1 = fD1.Px();
         py1 = fD1.Py();
         pz1 = fD1.Pz();
-        
+
         px2 = fD2.Px();
         py2 = fD2.Py();
         pz2 = fD2.Pz();
@@ -1758,7 +1781,7 @@ Double_t AliAnalysisTaskElectronEfficiency::PhivPair(Double_t MagField, Int_t ch
         px1 = fD2.Px();
         py1 = fD2.Py();
         pz1 = fD2.Pz();
-        
+
         px2 = fD1.Px();
         py2 = fD1.Py();
         pz2 = fD1.Pz();
@@ -1768,7 +1791,7 @@ Double_t AliAnalysisTaskElectronEfficiency::PhivPair(Double_t MagField, Int_t ch
         px1 = fD2.Px();
         py1 = fD2.Py();
         pz1 = fD2.Pz();
-        
+
         px2 = fD1.Px();
         py2 = fD1.Py();
         pz2 = fD1.Pz();
@@ -1776,19 +1799,19 @@ Double_t AliAnalysisTaskElectronEfficiency::PhivPair(Double_t MagField, Int_t ch
         px1 = fD1.Px();
         py1 = fD1.Py();
         pz1 = fD1.Pz();
-        
+
         px2 = fD2.Px();
         py2 = fD2.Py();
         pz2 = fD2.Pz();
       }
     }
   }
-  
+
   Double_t px = px1+px2;
   Double_t py = py1+py2;
   Double_t pz = pz1+pz2;
   Double_t dppair = TMath::Sqrt(px*px+py*py+pz*pz);
-  
+
   //unit vector of (pep+pem)
   Double_t pl = dppair;
   Double_t ux = px/pl;
@@ -1796,30 +1819,30 @@ Double_t AliAnalysisTaskElectronEfficiency::PhivPair(Double_t MagField, Int_t ch
   Double_t uz = pz/pl;
   Double_t ax = uy/TMath::Sqrt(ux*ux+uy*uy);
   Double_t ay = -ux/TMath::Sqrt(ux*ux+uy*uy);
-  
+
   //momentum of e+ and e- in (ax,ay,az) axis. Note that az=0 by definition.
   //Double_t ptep = iep->Px()*ax + iep->Py()*ay;
   //Double_t ptem = iem->Px()*ax + iem->Py()*ay;
-  
+
   Double_t pxep = px1;
   Double_t pyep = py1;
   Double_t pzep = pz1;
   Double_t pxem = px2;
   Double_t pyem = py2;
   Double_t pzem = pz2;
-  
+
   //vector product of pep X pem
   Double_t vpx = pyep*pzem - pzep*pyem;
   Double_t vpy = pzep*pxem - pxep*pzem;
   Double_t vpz = pxep*pyem - pyep*pxem;
   Double_t vp = sqrt(vpx*vpx+vpy*vpy+vpz*vpz);
   //Double_t thev = acos(vpz/vp);
-  
+
   //unit vector of pep X pem
   Double_t vx = vpx/vp;
   Double_t vy = vpy/vp;
   Double_t vz = vpz/vp;
-  
+
   //The third axis defined by vector product (ux,uy,uz)X(vx,vy,vz)
   Double_t wx = uy*vz - uz*vy;
   Double_t wy = uz*vx - ux*vz;
@@ -1831,7 +1854,7 @@ Double_t AliAnalysisTaskElectronEfficiency::PhivPair(Double_t MagField, Int_t ch
   // this function then returns values close to pi!
   Double_t cosPhiV = wx*ax + wy*ay;
   Double_t phiv = TMath::ACos(cosPhiV);
-  
+
   return phiv;
 }
 //________________________________________________________________________
@@ -1840,7 +1863,7 @@ void AliAnalysisTaskElectronEfficiency::Terminate(const Option_t *)
   // Draw result to the screen
   // Called once at the end of the query
   Printf(" Now running: Terminate()");
-  
+
   //get output data and draw 'fHistPt'
   //  if (!GetOutputData(0)) return;
   //  TH1D *hist=(TH1D*)(((TObjArray*)GetOutputData(0))->FindObject("fHistPt"));
@@ -1851,9 +1874,9 @@ AliAnalysisTaskElectronEfficiency::~AliAnalysisTaskElectronEfficiency()
 {
   /// Destructor
   Printf(" Now running: ~Destructor");
-  
+
   if (fSignalsMC) delete fSignalsMC;
-  
+
   Printf("deleting TList");
   if (fOutputList) {
     fOutputList->Clear();
@@ -1861,13 +1884,13 @@ AliAnalysisTaskElectronEfficiency::~AliAnalysisTaskElectronEfficiency()
   }
   Printf("setting pointer to 0x0");
   fOutputList=0x0;
-  
+
   if (fOutputListSupportHistos) {
     fOutputListSupportHistos->Clear();
     delete fOutputListSupportHistos;
   }
   fOutputListSupportHistos=0x0;
-  
+
   // other objects (pointers) may be deleted like this:
   //  if (fTrackCutsITSSA)  delete fTrackCutsITSSA;
   //  fTrackCutsITSSA=0x0;
@@ -1876,7 +1899,7 @@ AliAnalysisTaskElectronEfficiency::~AliAnalysisTaskElectronEfficiency()
 void AliAnalysisTaskElectronEfficiency::CreateHistograms(TString names, Int_t cutInstance)
 {
   Printf(" Now running: CreateHistograms()");
-  
+
   TObjArray *arrNames=names.Tokenize(";");
   TString name=Form("%02d",cutInstance);
   if (cutInstance<arrNames->GetEntriesFast()){
@@ -1899,7 +1922,7 @@ void AliAnalysisTaskElectronEfficiency::CreateHistograms(TString names, Int_t cu
       fvReco_Pos_poslabel.push_back(hNreco_Pos_poslabel);
     }
   }
-  
+
   if(fCalcEfficiencyRec){
     TH3D *hNreco_Rec_Ele = new TH3D(Form("Nreco_Rec_Ele_%s",name.Data()),"",fNptBins,fPtBins,fNetaBins,fEtaBins,fNphiBins,fPhiBins);
     hNreco_Rec_Ele->Sumw2();
@@ -1916,7 +1939,7 @@ void AliAnalysisTaskElectronEfficiency::CreateHistograms(TString names, Int_t cu
       fvReco_Rec_Pos_poslabel.push_back(hNreco_Rec_Pos_poslabel);
     }
   }
-  
+
   // one needs the histogram 'hAllPionsForRej' for each cutInstance independently, because empty events may differ between the cutsets which run together.
   TH3D *hAllPionsForRej = new TH3D(Form("AllPionsForRej_%s",name.Data()),Form("AllPionsForRej_%s",name.Data()),fNptBins,fPtBins,fNetaBins,fEtaBins,fNphiBins,fPhiBins);
   TH3D *hNPionsRejByAllSigns = new TH3D(Form("NPionsRejByAllSigns_%s",name.Data()),Form("NPionsRejByAllSigns_%s",name.Data()),fNptBins,fPtBins,fNetaBins,fEtaBins,fNphiBins,fPhiBins);
@@ -1924,9 +1947,9 @@ void AliAnalysisTaskElectronEfficiency::CreateHistograms(TString names, Int_t cu
   fvAllPionsForRej.push_back(hAllPionsForRej);
   fvPionsRejByAllSigns.push_back(hNPionsRejByAllSigns);
   fvPionsRejByUnlike.push_back(hNPionsRejByUnlike);
-  
-  
-  if(fDoPairing){  
+
+
+  if(fDoPairing){
     if(fCalcEfficiencyGen){
       TH2D *hNrecoPairsResonances  = new TH2D(Form("NrecoPairsResonances_%s",      name.Data()),"",fNmeeBins,fMeeBins,fNpteeBins,fPteeBins);
       TH2D *hNrecoPairsDiffMothers = new TH2D(Form("NrecoPairsDifferentMothers_%s",name.Data()),"",fNmeeBins,fMeeBins,fNpteeBins,fPteeBins);
@@ -1974,7 +1997,7 @@ void AliAnalysisTaskElectronEfficiency::CreateHistograms(TString names, Int_t cu
 void AliAnalysisTaskElectronEfficiency::CreateHistoGen()
 {
   Printf(" Now running: CreateHistoGen()");
-  
+
   Printf("fNptBins=%i\t fPtBins[1]=%f\t fNetaBins=%i\t fEtaBins[1]=%f\t fNphiBins=%i\t fPhiBins[1]=%f\t ",fNptBins,fPtBins[1],fNetaBins,fEtaBins[1],fNphiBins,fPhiBins[1]);
   if(fCalcEfficiencyGen){
     fNgen_Ele       = new TH3D("Ngen_electrons","",fNptBins,fPtBins,fNetaBins,fEtaBins,fNphiBins,fPhiBins);
@@ -1987,7 +2010,7 @@ void AliAnalysisTaskElectronEfficiency::CreateHistoGen()
     fNgen2_Rec_Pos  = new TH3D("Ngen2_Rec_positrons","",fNptBins,fPtBins,fNetaBins,fEtaBins,fNphiBins,fPhiBins);
   }
   if(fDoPairing){
-    Printf("fNmeeBins=%i\t fMeeBins[1]=%f\t fNpteeBins=%i\t fPteeBins[1]=%f\t ",fNmeeBins,fMeeBins[1],fNpteeBins,fPteeBins[1]);    
+    Printf("fNmeeBins=%i\t fMeeBins[1]=%f\t fNpteeBins=%i\t fPteeBins[1]=%f\t ",fNmeeBins,fMeeBins[1],fNpteeBins,fPteeBins[1]);
     if(fCalcEfficiencyGen){
       fNgenPairsResonances     = new TH2D("NgenPairsResonances",      "",fNmeeBins,fMeeBins,fNpteeBins,fPteeBins);
       fNgenPairsDiffMothers    = new TH2D("NgenPairsDifferentMothers","",fNmeeBins,fMeeBins,fNpteeBins,fPteeBins);
@@ -2008,11 +2031,11 @@ void AliAnalysisTaskElectronEfficiency::CreateHistoGen()
 void AliAnalysisTaskElectronEfficiency::CreateSupportHistos()
 {
   Printf(" Now running: CreateSupportHistos()");
-  
+
   fOutputListSupportHistos = new TList();
   fOutputListSupportHistos->SetName(GetName());
   fOutputListSupportHistos->SetOwner();
-  
+
   // Event variables
   TH1D* hnEvents         = new TH1D("nEvents","Number of processed events after cuts;;N_{events}",1,0.,1.);//,AliDielectronVarManager::kNevents);
   TH1D* hCent            = new TH1D("centrality","N. events vs. centrality;centrality [%];N_{events}",100,0,100);//,AliDielectronVarManager::kCentrality);
@@ -2026,11 +2049,11 @@ void AliAnalysisTaskElectronEfficiency::CreateSupportHistos()
   fOutputListSupportHistos->AddAt(hNEleEvent_cent, 3);
   fOutputListSupportHistos->AddAt(hVertexZ, 4);
   fOutputListSupportHistos->AddAt(hNvertexCtrb, 5);
-  
+
   TH2D* hPInVarMgr_PInStandAlone = new TH2D("PInVarMgr_PInStandAlone","GetTPCInnerParam()->P() vs GetInnerParam()->P() (VarMgr method); PIn global tracking (VarMgr method) (GeV/c); PIn TPC standalone (GeV/c)",
                                             160,0.,8.,160,0.,8.);
   fOutputListSupportHistos->AddAt(hPInVarMgr_PInStandAlone, 6);
-  
+
   // Track variables
   TH1D* hPt      = new TH1D("Pt","Pt;Pt [GeV];#tracks",200,0,10.);//,AliDielectronVarManager::kPt);
   TH2D* hP_PIn   = new TH2D("P_PIn","TPC inner P vs P;P [GeV/c];PIn (pTPC) [GeV/c]",
@@ -2040,8 +2063,8 @@ void AliAnalysisTaskElectronEfficiency::CreateSupportHistos()
   fOutputListSupportHistos->AddAt(hPt,     7);
   fOutputListSupportHistos->AddAt(hP_PIn,  8);
   fOutputListSupportHistos->AddAt(hP_Pgen, 9);
-  
-  
+
+
   // ITS
   TH2D* hITS_dEdx_P = new TH2D("ITS_dEdx_P","ITS dEdx;P [GeV/c];ITS signal (arb units)",
                                160,0.,8.,700,0.,700.);//.,AliDielectronVarManager::kP,AliDielectronVarManager::kITSsignal,makeLogx);
@@ -2055,7 +2078,7 @@ void AliAnalysisTaskElectronEfficiency::CreateSupportHistos()
   fOutputListSupportHistos->AddAt(hITSnSigmaEle_P, 11);
   fOutputListSupportHistos->AddAt(hITSnSigmaPio_P, 12);
   fOutputListSupportHistos->AddAt(hITSnSigmaKao_P, 13);
-  
+
   // TPC
   TH2D* hTPC_dEdx_P = new TH2D("TPC_dEdx_P","TPC dEdx;PIn (pTPC) [GeV/c];TPC signal (arb units)",
                                160,0.,8.,120,0.,120.);//.,AliDielectronVarManager::kPIn,AliDielectronVarManager::kTPCsignal,makeLogx);
@@ -2075,22 +2098,22 @@ void AliAnalysisTaskElectronEfficiency::CreateSupportHistos()
   fOutputListSupportHistos->AddAt(hTPCnSigmaPio_P, 17);
   fOutputListSupportHistos->AddAt(hTPCnSigmaKao_P, 18);
   fOutputListSupportHistos->AddAt(hTPCnSigmaPro_P, 19);
-  
+
   TH1D* hUnused20 = new TH1D("hUnused20","hUnused20", 1,0.,1.);
   TH1D* hUnused21 = new TH1D("hUnused21","hUnused21", 1,0.,1.);
   fOutputListSupportHistos->AddAt(hUnused20, 20);
   fOutputListSupportHistos->AddAt(hUnused21, 21);
-  
+
   // run dependency
   // run string "fsRunBins" must be sorted in increasing order!
   TObjArray *objaRuns=fsRunBins.Tokenize(", ");
   const Int_t nRuns=objaRuns->GetEntries();
   if (nRuns<1) { fsRunBins = "-99"; cout << "warning: bins for run dependence not specified!" << endl; }
   fsRunBins.Append(Form(", %i", (Int_t) (atoi(objaRuns->At(nRuns-1)->GetName()) + 10))); // create upper limit for bin of last run!
-  
+
   Double_t* dRunBinning = (AliDielectronHelper::MakeArbitraryBinning(fsRunBins))->GetMatrixArray();
   //for (int i=0; i<nRuns+1; i++) { cout << i << " \t " << dRunBinning[i] << " \t "; }
-  
+
   Int_t nbinsPIn=80, nbinsTPCsig=50;
   TH3D* hTPC_dEdx_P_run = new TH3D("TPC_dEdx_P_run","TPC dEdx;TPC inner PIn (pTPC) [GeV/c];TPC signal (arb units);run number",
                                    nbinsPIn   , (AliDielectronHelper::MakeLinBinning(nbinsPIn   ,0.,4.))->GetMatrixArray(),
@@ -2110,7 +2133,7 @@ void AliAnalysisTaskElectronEfficiency::CreateSupportHistos()
   fOutputListSupportHistos->AddAt(hTPC_dEdx_P_run, 22);
   fOutputListSupportHistos->AddAt(hTPCnSigmaEle_P_run, 23);
   fOutputListSupportHistos->AddAt(hITSnSigmaEle_P_run, 24);
-  
+
   // TOF
   TH2D* hTOFnSigmaEle_P = new TH2D("TOFnSigmaEle_P","TOF number of sigmas Electrons;PIn (pTPC) [GeV/c];TOF number of sigmas Electrons",
                                    160,0.,8.,100,-5.,5.);//,AliDielectronVarManager::kPIn,AliDielectronVarManager::kTOFnSigmaEle,makeLogx);
@@ -2118,7 +2141,7 @@ void AliAnalysisTaskElectronEfficiency::CreateSupportHistos()
                             160,0.,8.,120,0.,1.2);//,AliDielectronVarManager::kPIn,AliDielectronVarManager::kTOFbeta,makeLogx);
   fOutputListSupportHistos->AddAt(hTOFnSigmaEle_P, 25);
   fOutputListSupportHistos->AddAt(hTOFbeta, 26);
-  
+
   // Eta and Phi
   TH1D* hEta = new TH1D("Eta","Eta; Eta;#tracks",
                         200,-2,2);//,AliDielectronVarManager::kEta);
@@ -2129,7 +2152,7 @@ void AliAnalysisTaskElectronEfficiency::CreateSupportHistos()
   fOutputListSupportHistos->AddAt(hEta, 27);
   fOutputListSupportHistos->AddAt(hPhi, 28);
   fOutputListSupportHistos->AddAt(hEta_Phi, 29);
-  
+
   TH2D* hTPC_dEdx_Eta = new TH2D("TPC_dEdx_Eta","TPC dEdx;Eta;TPC signal (arb units)",
                                  100,-1,1,120,0.,120.);//.,AliDielectronVarManager::kEta,AliDielectronVarManager::kTPCsignal);
   TH3D* hTPC_dEdx_Eta_P = new TH3D("TPC_dEdx_Eta_P","TPC dEdx;Eta;TPC signal (arb units); PIn (pTPC) [GeV/c]",
@@ -2155,7 +2178,7 @@ void AliAnalysisTaskElectronEfficiency::CreateSupportHistos()
   //                        50,-1,1,100,-10.,10.,80,0.,4.);//.,AliDielectronVarManager::kEta,AliDielectronVarManager::kTPCnSigmaKao,AliDielectronVarManager::kPIn);
   //  fOutputListSupportHistos->AddAt(hTPCnSigmaKao_Eta, 34);
   //  fOutputListSupportHistos->AddAt(hTPCnSigmaKao_Eta_P, 35);
-  
+
   // DCA
   TH1D* hdXY = new TH1D("dXY","dXY;dXY [cm];#tracks",
                         200,-2.,2.);//.,AliDielectronVarManager::kImpactParXY);
@@ -2166,7 +2189,7 @@ void AliAnalysisTaskElectronEfficiency::CreateSupportHistos()
   fOutputListSupportHistos->AddAt(hdXY, 36);
   fOutputListSupportHistos->AddAt(hdZ, 37);
   fOutputListSupportHistos->AddAt(hdXY_dZ, 38);
-  
+
   // Quality
   TH1D* hTPCcrossedRowsOverFindable = new TH1D("TPCcrossedRowsOverFindable","Number of Crossed Rows TPC over Findable;TPC crossed rows over findable;#tracks",120,0.,1.2);//,AliDielectronVarManager::kNFclsTPCfCross);
   TH1D* hTPCcrossedRows = new TH1D("TPCcrossedRows","Number of Crossed Rows TPC;TPC crossed rows;#tracks",160,-0.5,159.5);//,AliDielectronVarManager::kNFclsTPCr);
@@ -2198,9 +2221,9 @@ void AliAnalysisTaskElectronEfficiency::CreateSupportHistos()
                                       160,0.,8.,160,-0.5,159.5);//,AliDielectronVarManager::kPt,AliDielectronVarManager::kNFclsTPCr);
   fOutputListSupportHistos->AddAt(hTPCcrossedRows_TPCnCls, 51);
   fOutputListSupportHistos->AddAt(hTPCcrossedRows_Pt, 52);
-  
-  
-  
+
+
+
   // pair-prefilter histograms
   //2D and 3D histograms
   TH2D* hMeePtee    = new TH2D("InvMass_PairPt",";Inv. Mass [GeV];Pair Pt [GeV];#pairs",
@@ -2225,7 +2248,7 @@ void AliAnalysisTaskElectronEfficiency::CreateSupportHistos()
   fOutputListSupportHistos->AddAt(hPteeOpen,    57);
   fOutputListSupportHistos->AddAt(hPteePhiV,    58);
   fOutputListSupportHistos->AddAt(hOpenPhiV,    59);
-  
+
   // histograms for ITS eta and dEdx correction
   TH2D* hITSnSigmaEle_Eta = new TH2D("ITSnSigmaEle_Eta","ITS number of sigmas Electrons; Eta; ITS number of sigmas Electrons",
                                      100,-1,1,100,-5.,5.);//.,AliDielectronVarManager::kEta,AliDielectronVarManager::kITSnSigmaEle);
@@ -2240,7 +2263,7 @@ void AliAnalysisTaskElectronEfficiency::CreateSupportHistos()
   fOutputListSupportHistos->AddAt(hITSnSigmaEle_Eta_P,    61);
   fOutputListSupportHistos->AddAt(hITSnSigmaEle_Eta_RefMultTPConly, 62);
   fOutputListSupportHistos->AddAt(hITSnSigmaEle_Eta_Nacc, 63);
-  
+
   // raw sigma Ele in ITS and TPC
   TH2D* hITSnSigmaEleRaw_P = new TH2D("ITSnSigmaEleRaw_P","ITS number of sigmas Electrons (raw);P [GeV/c];ITS number of sigmas Electrons (raw)",
                                       160,0.,8.,100,-5.,5.);//.,AliDielectronVarManager::kP,AliDielectronVarManager::kITSnSigmaEleRaw);
@@ -2254,13 +2277,13 @@ void AliAnalysisTaskElectronEfficiency::CreateSupportHistos()
   fOutputListSupportHistos->AddAt(hTPCnSigmaEleRaw_P,     65);
   fOutputListSupportHistos->AddAt(hITSnSigmaEleRaw_Eta,   66);
   fOutputListSupportHistos->AddAt(hTPCnSigmaEleRaw_Eta,   67);
-  
+
   TH1D* hUnused68 = new TH1D("hUnused","hUnused",1,0,1);
   fOutputListSupportHistos->AddAt(hUnused68, 68);
   TH1D* hUnused69 = new TH1D("hUnused","hUnused",1,0,1);
   fOutputListSupportHistos->AddAt(hUnused69, 69);
-  
-  
+
+
   TH1D* hPdgCode   = new TH1D("hPdgCode",  "hPdgCode",   GetPDGcodes()->GetNrows()-1, GetPDGcodes()->GetMatrixArray());
   TH1D* hPdgCodeM  = new TH1D("hPdgCodeM", "hPdgCodeM",  GetPDGcodes()->GetNrows()-1, GetPDGcodes()->GetMatrixArray());
   TH1D* hPdgCodeGM = new TH1D("hPdgCodeGM","hPdgCodeGM", GetPDGcodes()->GetNrows()-1, GetPDGcodes()->GetMatrixArray());
@@ -2270,7 +2293,7 @@ void AliAnalysisTaskElectronEfficiency::CreateSupportHistos()
   fOutputListSupportHistos->AddAt(hPdgCodeM,    71);
   fOutputListSupportHistos->AddAt(hPdgCodeGM,   72);
   fOutputListSupportHistos->AddAt(hPdgCodeM_GM, 73);
-  
+
 }
 //__________________________________________________________________
 void AliAnalysisTaskElectronEfficiency::AddSignalMC(AliDielectronSignalMC* signal)
@@ -2549,6 +2572,6 @@ Double_t AliAnalysisTaskElectronEfficiency::GetSmearing(TObjArray *arr, Double_t
   // get smear parameter via random selection from the x slices retreived from the deltax plot
   Double_t smearing(0.);
   if(hisSlice) smearing = hisSlice->GetRandom();
-  
+
   return smearing;
 }

--- a/PWGDQ/dielectron/core/AliAnalysisTaskElectronEfficiency.h
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskElectronEfficiency.h
@@ -53,6 +53,7 @@
 #include "TParticlePDG.h"
 #include "TDatabasePDG.h"
 #include "TTreeStream.h"//why?
+#include "TRandom3.h"
 
 class TString;
 class TObject;
@@ -131,6 +132,7 @@ class AliAnalysisTaskElectronEfficiency : public AliAnalysisTaskSE {
   void          AttachRejCutMee(Double_t rejcut)              { fvRejCutMee.push_back(rejcut); }
   void          AttachRejCutTheta(Double_t rejcut)            { fvRejCutTheta.push_back(rejcut); }
   void          AttachRejCutPhiV(Double_t rejcut)             { fvRejCutPhiV.push_back(rejcut); }
+  void          AttachIsTOFrequireCut(Bool_t TOFreq)          { fvIsTOFrequireCut.push_back(TOFreq); }
   void          SetPairCutMee(Double_t cut)                   { fPairCutMee=cut; }
   void          SetPairCutTheta(Double_t cut)                 { fPairCutTheta=cut; }
   void          SetPairCutPhiV(Double_t cut)                  { fPairCutPhiV=cut; }
@@ -141,7 +143,7 @@ class AliAnalysisTaskElectronEfficiency : public AliAnalysisTaskSE {
   void          SetDeltaThetaBinning(Int_t N, Double_t min, Double_t max) {fDeltaThetaNbins=N; fDeltaThetaMin=min; fDeltaThetaMax=max;}
   void          SetDeltaPhiBinning(Int_t N, Double_t min, Double_t max)   {fDeltaPhiNbins=N; fDeltaPhiMin=min; fDeltaPhiMax=max;}
   void          SetDeltaAngleBinning(Int_t N, Double_t min, Double_t max) {fDeltaAngleNbins=N; fDeltaAngleMin=min; fDeltaAngleMax=max;}
-  
+
   virtual void  CreateHistograms(TString names, Int_t cutInstance);
   void          CreateHistoGen();
   void          CreateSupportHistos();
@@ -210,6 +212,7 @@ class AliAnalysisTaskElectronEfficiency : public AliAnalysisTaskSE {
   std::vector<Double_t>           fvRejCutMee;
   std::vector<Double_t>           fvRejCutTheta;
   std::vector<Double_t>           fvRejCutPhiV;
+  std::vector<Bool_t>             fvIsTOFrequireCut;
   //Efficiency Histograms
   TH3D*                           fNgen_Ele;
   std::vector<TH3D*>              fvReco_Ele;           // store reconstructed electrons (N vs pT, eta, phi) per cutset.

--- a/PWGDQ/dielectron/core/AliDielectronVarManager.h
+++ b/PWGDQ/dielectron/core/AliDielectronVarManager.h
@@ -1010,7 +1010,6 @@ inline void AliDielectronVarManager::FillVarESDtrack(const AliESDtrack *particle
 
 
   values[AliDielectronVarManager::kITSsignal]   =   particle->GetITSsignal();
-
   Double_t itsdEdx[4];
   particle->GetITSdEdxSamples(itsdEdx);
 
@@ -1195,8 +1194,17 @@ inline void AliDielectronVarManager::FillVarAODTrack(const AliAODTrack *particle
       if( particle->HasSharedPointOnITSLayer(i) ) itsNclsS ++;
     }
     values[AliDielectronVarManager::kNclsSITS]     = itsNclsS;
-    if(Req(kNclsSMapITS))  values[AliDielectronVarManager::kNclsSMapITS]  = 0;  //not implemented in AODs
+    if(Req(kNclsSMapITS))  values[AliDielectronVarManager::kNclsSMapITS]  = particle->GetITSSharedClusterMap();  //not implemented in AODs
     if(Req(kNclsSFracITS)) values[AliDielectronVarManager::kNclsSFracITS] = itsNclsS > 0. ? itsNclsS / particle->GetITSNcls() : 0.;
+  }
+
+  if(Req(kITSsignalSSD1) || Req(kITSsignalSSD2) || Req(kITSsignalSDD1) || Req(kITSsignalSDD2) ){
+    Double_t itsdEdx[4];
+    particle->GetITSdEdxSamples(itsdEdx);
+    values[AliDielectronVarManager::kITSsignalSSD1]   =   itsdEdx[0];
+    values[AliDielectronVarManager::kITSsignalSSD2]   =   itsdEdx[1];
+    values[AliDielectronVarManager::kITSsignalSDD1]   =   itsdEdx[2];
+    values[AliDielectronVarManager::kITSsignalSDD2]   =   itsdEdx[3];
   }
 
 

--- a/PWGDQ/dielectron/macrosLMEE/AddTask_caklein_ElectronEfficiency.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTask_caklein_ElectronEfficiency.C
@@ -88,7 +88,7 @@ AliAnalysisTask *AddTask_caklein_ElectronEfficiency(TString configFile="Config_c
 
   // resolution calculation
   task->SetCalcResolution(CalcResolution);
-  if(CalcResolution || CalcEfficiencyRec) task->SetResolutionCuts(SetupTrackCutsAndSettings(0));
+  if(CalcResolution || CalcEfficiencyRec) task->SetResolutionCuts(SetupTrackCutsAndSettings("kPbPb2015_Pt100_ResolutionCuts"));
   if(CalcResolution) {
     task->SetDeltaMomBinning(NbinsDeltaMom,DeltaMomMin,DeltaMomMax);
     task->SetRelMomBinning(NbinsRelMom,RelMomMin,RelMomMax);
@@ -143,13 +143,16 @@ AliAnalysisTask *AddTask_caklein_ElectronEfficiency(TString configFile="Config_c
 
   for (Int_t i=0; i<nDie; ++i){ //nDie defined in config file
     TString cutDefinition(arrNames->At(i)->GetName());
-    std::cout << "CUT NAME: " << cutDefinition << std::endl;
-    AliAnalysisFilter *trackCuts = SetupTrackCutsAndSettings(cutDefinition, bESDANA); // main function in config file
+    std::cout << "##############################" << std::endl;
+    std::cout << "NEW CUT SETTING WITH CUT NAME: " << cutDefinition << std::endl;
+    Bool_t IsTOFreqCut = false;
+    AliAnalysisFilter *trackCuts = SetupTrackCutsAndSettings(cutDefinition, bESDANA, IsTOFreqCut); // main function in config file
     if (!trackCuts) { std::cout << "WARNING: no TrackCuts given - skipping this Cutset ('"<<arrNames->At(i)->GetName()<<"')!" << std::endl; continue; }
     if (isPrefilterCutset) {
       Int_t success = SetupPrefilterPairCuts(i);
       if (!success) { std::cout << "WARNING: no/bad Prefilter PairCuts given - skipping this Cutset ('"<<arrNames->At(i)->GetName()<<"')!" << std::endl; continue; }
     }
+    std::cout << "Is TOFreq setting: " << (IsTOFreqCut ? "true" : "false") << std::endl;
     // fill std vectors with all information which is individual per track setting:
     task->AttachTrackCuts(trackCuts);
     task->AttachDoPrefilterEff(isPrefilterCutset);
@@ -157,8 +160,10 @@ AliAnalysisTask *AddTask_caklein_ElectronEfficiency(TString configFile="Config_c
     task->AttachRejCutMee(rejCutMee);
     task->AttachRejCutTheta(rejCutTheta);
     task->AttachRejCutPhiV(rejCutPhiV);
+    task->AttachIsTOFrequireCut(IsTOFreqCut);
 
     task->CreateHistograms(names,i);
+    std::cout << "Cutsetting added\n##############################" << std::endl;
   }
 
   mgr->AddTask(task);


### PR DESCRIPTION
There is now the option to reject TOF mismatch when computing the efficiency with the AliAnalysisTaskElectronEfficiency task.

Addition of ITS dEdx and shared cluster map for every ITS layer in VarManager.h

Cheers
Carsten