### PR TITLE
EMCal Time calibration macros

### DIFF
--- a/PWGPP/EMCAL/TiCMacros/MakeReferenceFinalPass.C
+++ b/PWGPP/EMCAL/TiCMacros/MakeReferenceFinalPass.C
@@ -1,0 +1,12 @@
+void MakeReferenceFinalPass(TString output="Reference_LHC15i_final.root") {
+
+  char tmpin[256];
+  char tmpout[256];
+
+    sprintf(tmpin,"AnalysisResults.root");
+    //sprintf(tmpout,"Reference_LHC15i_calib_final.root");
+    //AliAnalysisTaskEMCALTimeCalib::ProduceCalibConsts(tmpin,tmpout,kTRUE);
+    AliAnalysisTaskEMCALTimeCalib::ProduceCalibConsts(tmpin,output.Data(),kTRUE);
+
+}
+

--- a/PWGPP/EMCAL/TiCMacros/MakeReferencePass1.C
+++ b/PWGPP/EMCAL/TiCMacros/MakeReferencePass1.C
@@ -1,0 +1,20 @@
+void MakeReferencePass1() {
+
+  char tmpin[256];
+  char tmpout[256];
+  Int_t runno[]={
+     259867, 259703, 259091, 260187, 259954, 259471, 259470, 259379, 259095
+
+  };
+  Int_t nruns=9;//172;
+
+  for (Int_t i=0;i<nruns;i++){
+    sprintf(tmpin,"%d/AnalysisResults.root",runno[i]);
+    sprintf(tmpout,"Reference_%d.pass1.root",runno[i]);
+    AliAnalysisTaskEMCALTimeCalib::ProduceCalibConsts(tmpin,tmpout,kFALSE);
+  }
+
+
+
+}
+

--- a/PWGPP/EMCAL/TiCMacros/MakeReferenceSM.C
+++ b/PWGPP/EMCAL/TiCMacros/MakeReferenceSM.C
@@ -1,0 +1,28 @@
+void MakeReferenceSM(TString outname="ReferenceSM_LHC15o_mcp1_v1.root") {
+
+  char tmpin[256];
+  char tmpout[256];
+  Int_t runno[]={
+   238097, 238164, 238170, 238176, 238179, 238184, 238432, 238451, 238454, 238455, 238456, 238457, 238458, 238459, 238460, 238468, 238469, 238470, 238474
+  };
+  Int_t nruns=19;
+
+  for (Int_t i=0;i<nruns;i++){
+    sprintf(tmpin,"Reference_%d.pass1.root",runno[i]);
+    TFile *file=new TFile(tmpin);
+    if(!file) {
+
+      file->ls();
+      delete file;
+
+      continue;
+    }
+    //sprintf(tmpout,"ReferenceSM_LHC15o_muon_calo_pass1_v1.root");
+    sprintf(tmpout,outname.Data());
+    AliAnalysisTaskEMCALTimeCalib::ProduceOffsetForSMsV2(runno[i],tmpin,tmpout,kFALSE,kTRUE);
+  }
+
+
+
+}
+

--- a/PWGPP/EMCAL/TiCMacros/copyFiles.sh
+++ b/PWGPP/EMCAL/TiCMacros/copyFiles.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+
+# run it:
+# ./copyfiles 2016 LHC16l muon_calo_pass1 752_20170220-2207 runlist.txt
+
+# year=2016
+# period=LHC16l
+# pass=muon_calo_pass1
+# train=752_20170220-2207
+# list=runlist.txt
+
+year=$1
+period=$2
+pass=$3
+train=$4
+list=$5
+
+for i in `cat ${list}`
+do
+    
+    runnumber=`basename --suffix=, $i`
+
+    if [ ! -d ${runnumber} ]
+    then
+	mkdir ${runnumber}
+    fi
+
+    alien_cp -m -t 100 alien:///alice/data/${year}/${period}/000${runnumber}/${pass}/PWGPP/PP_EMCAL_Calibration/${train}/AnalysisResults.root ./${runnumber}/
+
+done
+    

--- a/PWGPP/EMCAL/doxymodules.h
+++ b/PWGPP/EMCAL/doxymodules.h
@@ -43,10 +43,10 @@
  *
  * Time Calibration code
  * ---------------------
- * + macro1.C
- * + macro2.C
- * + macro3.C
- *
+ * + copyFiles.sh
+ * + MakeReferenceFinalPass.C
+ * + MakeReferencePass1.C
+ * + MakeReferenceSM.C
  *
  * Bad Channel Analysis code
  * ---------------------


### PR DESCRIPTION
Changes: 
- doxymodules.h - added 4 macros
- copyFiles.sh - to copy files from LEGO train
- MakeReferencePass1.C - to make input for L1 phase calculation for each run
- MakeReferenceSM.C - to calculate L1 phases
- MakeReferenceFinalPass.C - to calculate time offsets in 2nd and 3rd step 