### PR TITLE
PWGDQ ITS TPC match eff + ep part optimisation

### DIFF
--- a/PWGDQ/dielectron/core/AliDielectronHelper.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronHelper.cxx
@@ -296,7 +296,7 @@ Int_t AliDielectronHelper::GetNacc(const AliVEvent *ev){
 }
 
 //_____________________________________________________________________________
-Double_t AliDielectronHelper::GetITSTPCMatchEff(const AliVEvent *ev, Double_t *efficiencies, Bool_t bEventPlane){
+Double_t AliDielectronHelper::GetITSTPCMatchEff(const AliVEvent *ev, Double_t *efficiencies, Bool_t bEventPlane, Bool_t useV0Cep){
   // recalulate the its-tpc matching efficiecy
   if (!ev) return -1;
   Bool_t bDebug = kFALSE;
@@ -344,6 +344,9 @@ Double_t AliDielectronHelper::GetITSTPCMatchEff(const AliVEvent *ev, Double_t *e
   Float_t tpcChi2Cl = -99.;
   Float_t eventplane = -99.;
 
+  TString epDetector = "TPC";
+  if(useV0Cep)  epDetector = "V0C";
+
 
 
   if(bEventPlane){
@@ -355,9 +358,9 @@ Double_t AliDielectronHelper::GetITSTPCMatchEff(const AliVEvent *ev, Double_t *e
         AliQnCorrectionsManager *flowQnVectorMgr = flowQnVectorTask->GetAliQnCorrectionsManager();
         TList *qnlist = flowQnVectorMgr->GetQnVectorList();
         if(qnlist != NULL){
-          const AliQnCorrectionsQnVector *qVecQnFrameworkTPC = AliDielectronQnEPcorrection::GetQnVectorFromList(qnlist,"TPC","latest","latest");
+          const AliQnCorrectionsQnVector *qVecQnFrameworkTPC = AliDielectronQnEPcorrection::GetQnVectorFromList( qnlist, epDetector.Data(), "latest", "latest" );
           if(qVecQnFrameworkTPC != NULL){
-            TVector2 qVectorTPC(qVecQnFrameworkTPC->Qx(2),qVecQnFrameworkTPC->Qy(2));
+            TVector2 qVectorTPC( qVecQnFrameworkTPC->Qx(2), qVecQnFrameworkTPC->Qy(2) );
             eventplane = TVector2::Phi_mpi_pi(qVectorTPC.Phi())/2;
           }
         }

--- a/PWGDQ/dielectron/core/AliDielectronHelper.h
+++ b/PWGDQ/dielectron/core/AliDielectronHelper.h
@@ -30,7 +30,7 @@ TVectorD* MakeArbitraryBinning(const char* bins);
   void     GetMaxPtAndPhi(const AliVEvent *ev, Double_t &ptMax, Double_t &phiOfptMax);
   Int_t    GetNch(const AliMCEvent *ev=0x0, Double_t eta=0.9, Bool_t excludeJpsiDaughters = kFALSE);
   Int_t    GetNacc(const AliVEvent *ev=0x0);
-  Double_t GetITSTPCMatchEff(const AliVEvent *ev=0x0, Double_t *efficiencies = 0x0, Bool_t bEventPlane = kFALSE); // Bools select additional criteria for the tracks relative to the Eventplane angle of the TPC
+  Double_t GetITSTPCMatchEff(const AliVEvent *ev=0x0, Double_t *efficiencies = 0x0, Bool_t bEventPlane = kFALSE, Bool_t useV0Cep = kFALSE ); // Bools select additional criteria for the tracks relative to the Eventplane angle of the TPC
   Int_t    GetNaccTrcklts(const AliVEvent *ev=0x0, Double_t etaRange=1.6);
   Double_t GetNaccTrckltsCorrected(const AliVEvent *event, Double_t uncorrectedNacc, Double_t vtxZ, Int_t type);
 

--- a/PWGDQ/dielectron/core/AliDielectronQnEPcorrection.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronQnEPcorrection.cxx
@@ -2,8 +2,8 @@
 * @Author: Pascal Dillenseger <pascaldillenseger>
 * @Date:   2016-11-11, 11:39:13
 * @Email:  pdillens@cern.ch
-* @Last modified by:   pascaldillenseger
-* @Last modified time: 2016-11-14, 11:14:44
+ * @Last modified by:   pascaldillenseger
+ * @Last modified time: 2017-08-07, 10:18:48
 */
 
 
@@ -119,7 +119,7 @@ Double_t AliDielectronQnEPcorrection::GetACcorrectedQnTPCEventplane(const AliDie
   Bool_t acceptedTrack1 = AliDielectronQnEPcorrection::IsSelected(track1);
   Bool_t acceptedTrack2 = AliDielectronQnEPcorrection::IsSelected(track2);
 
-  if(!acceptedTrack1 && !acceptedTrack2) return -tpcEPangle;
+  if(!acceptedTrack1 && !acceptedTrack2) return tpcEPangle;
   //sum the contribution to the qVector of the tracks passing the EventPlanePOIPreFilter
   if(acceptedTrack1){
     cQX += TMath::Cos(2*track1->Phi());

--- a/PWGDQ/dielectron/core/AliDielectronVarManager.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronVarManager.cxx
@@ -583,6 +583,8 @@ const char* AliDielectronVarManager::fgkParticleNames[AliDielectronVarManager::k
   {"MatchEffITSTPC",        "N_{trk}^{TPC}/N_{trk}^{ITS} #cbar_{#||{#eta}<0.9}",  ""},
   {"MatchEffITSTPCinPlane", "N_{trk}^{TPC}/N_{trk}^{ITS} #cbar_{#||{#eta}<0.9, #||{#phi^{Track}-#Psi^{TPC}} < #frac{#pi}{4} || #frac{3#pi}{4} < #||{#phi^{Track}-#Psi^{TPC}} < #pi}",  ""},
   {"MatchEffITSTPCoutPlane", "N_{trk}^{TPC}/N_{trk}^{ITS} #cbar_{#||{#eta}<0.9, #frac{#pi}{4} < #||{#phi^{Track}-#Psi^{TPC}} < #frac{3#pi}{4}}",  ""},
+  {"MatchEffITSTPCinPlaneV0C", "N_{trk}^{TPC}/N_{trk}^{ITS} #cbar_{#||{#eta}<0.9, #||{#phi^{Track}-#Psi^{V0C}} < #frac{#pi}{4} || #frac{3#pi}{4} < #||{#phi^{Track}-#Psi^{V0C}} < #pi}",  ""},
+  {"MatchEffITSTPCoutPlaneV0C", "N_{trk}^{TPC}/N_{trk}^{ITS} #cbar_{#||{#eta}<0.9, #frac{#pi}{4} < #||{#phi^{Track}-#Psi^{TPC}} < #frac{3#pi}{4}}",  ""},
   {"NaccTrcklts",            "N_{acc. trkl} #cbar_{#||{#eta}<1.6}",                ""},
   {"NaccTrcklts09",          "N_{acc. trkl} #cbar_{#||{#eta}<0.9}",                ""},
   {"NaccTrcklts10",          "N_{acc. trkl} #cbar_{#||{#eta}<1.0}",                ""},

--- a/PWGDQ/dielectron/core/AliDielectronVarManager.h
+++ b/PWGDQ/dielectron/core/AliDielectronVarManager.h
@@ -609,6 +609,8 @@ public:
     kMatchEffITSTPC,         // ruff estimate on the ITS-TPC matching efficiceny
     kMatchEffITSTPCinPlane,         // ruff estimate on the ITS-TPC matching efficiceny inPlane wrt TPC eventplane
     kMatchEffITSTPCoutPlane,         // ruff estimate on the ITS-TPC matching efficiceny outPlane wrt TPC eventplane
+    kMatchEffITSTPCinPlaneV0C,         // ruff estimate on the ITS-TPC matching efficiceny inPlane wrt V0C eventplane
+    kMatchEffITSTPCoutPlaneV0C,         // ruff estimate on the ITS-TPC matching efficiceny outPlane wrt V0C eventplane
     kNaccTrcklts,            // number of accepted SPD tracklets in |eta|<1.6
     kNaccTrcklts09,          // number of accepted SPD tracklets in |eta|<0.9
     kNaccTrcklts10,          // number of accepted SPD tracklets in |eta|<1.
@@ -2371,6 +2373,8 @@ inline void AliDielectronVarManager::FillVarVEvent(const AliVEvent *event, Doubl
   values[AliDielectronVarManager::kMatchEffITSTPC]  = 0;
   values[AliDielectronVarManager::kMatchEffITSTPCinPlane]  = 0;
   values[AliDielectronVarManager::kMatchEffITSTPCoutPlane]  = 0;
+  values[AliDielectronVarManager::kMatchEffITSTPCinPlaneV0C]  = 0;
+  values[AliDielectronVarManager::kMatchEffITSTPCoutPlaneV0C]  = 0;
   values[AliDielectronVarManager::kNaccTrcklts]     = 0;
   values[AliDielectronVarManager::kNaccTrcklts09]   = 0;
   values[AliDielectronVarManager::kNaccTrcklts10]   = 0;
@@ -2435,6 +2439,13 @@ inline void AliDielectronVarManager::FillVarVEvent(const AliVEvent *event, Doubl
     values[AliDielectronVarManager::kMatchEffITSTPC]  = AliDielectronHelper::GetITSTPCMatchEff(event, efficiencies, kTRUE);
     values[AliDielectronVarManager::kMatchEffITSTPCinPlane]  = efficiencies[0];
     values[AliDielectronVarManager::kMatchEffITSTPCoutPlane]  = efficiencies[1];
+  }
+  if(Req(kMatchEffITSTPCinPlaneV0C) || Req(kMatchEffITSTPCoutPlaneV0C)){
+
+    Double_t efficiencies[2] = {-1.};
+    values[AliDielectronVarManager::kMatchEffITSTPC]  = AliDielectronHelper::GetITSTPCMatchEff(event, efficiencies, kTRUE, kTRUE);
+    values[AliDielectronVarManager::kMatchEffITSTPCinPlaneV0C]  = efficiencies[0];
+    values[AliDielectronVarManager::kMatchEffITSTPCoutPlaneV0C]  = efficiencies[1];
   }
   else if(Req(kMatchEffITSTPC))  values[AliDielectronVarManager::kMatchEffITSTPC]  = AliDielectronHelper::GetITSTPCMatchEff(event);
   if(Req(kNaccTrcklts) || Req(kNaccTrckltsCorr))  values[AliDielectronVarManager::kNaccTrcklts]     = AliDielectronHelper::GetNaccTrcklts(event,1.6);

--- a/PWGDQ/dielectron/core/AliDielectronVarManager.h
+++ b/PWGDQ/dielectron/core/AliDielectronVarManager.h
@@ -2180,7 +2180,7 @@ inline void AliDielectronVarManager::FillVarDielectronPair(const AliDielectronPa
           if(qnlist != NULL){
             qnTPCeventplane = fgQnEPacRemoval->GetACcorrectedQnTPCEventplane(pair, qnlist); // Remove auto correlations from the eventplane for the given pair
           }
-          if(qnTPCeventplane == -999.) qnTPCeventplane = values[AliDielectronVarManager::kQnTPCrpH2];
+          if(TMath::AreEqualRel(qnTPCeventplane, -999., 1e-12)) qnTPCeventplane = values[AliDielectronVarManager::kQnTPCrpH2];
         }
       }
     }


### PR DESCRIPTION
Added the V0C as ep estimator for the in- and out of plane TPC-ITS matching efficiency calculation. Small fix and optimisation for the ac removal in the flow calculation part.