### PR TITLE
Fix char* -> const char* in AliRsnTOFT0maker.h

### DIFF
--- a/PWGLF/RESONANCES/extra/AliRsnTOFT0maker.cxx
+++ b/PWGLF/RESONANCES/extra/AliRsnTOFT0maker.cxx
@@ -281,7 +281,7 @@ Double_t AliRsnTOFT0maker::GetT0Fill(Int_t nrun) const
 }
 
 //____________________________________________________________________________
-void  AliRsnTOFT0maker::LoadChannelMap(char *filename)
+void  AliRsnTOFT0maker::LoadChannelMap(const char *filename)
 {
    // Load the histo with the channel off map
    TFile *f = new TFile(filename);

--- a/PWGLF/RESONANCES/extra/AliRsnTOFT0maker.h
+++ b/PWGLF/RESONANCES/extra/AliRsnTOFT0maker.h
@@ -58,7 +58,7 @@ public:
    void      SetTimeResolution(Double_t timeresolution) {fTimeResolution = timeresolution;}; // TOF timeresolution in [s] e.g. for 120 ps -> 1.2e-10
    Double_t  GetTimeResolution() const {return fTimeResolution;}
 
-   void LoadChannelMap(char *filename = "$ALICE_ROOT/TOF/enableMap.104892.root"); //load the enable channel map
+   void LoadChannelMap(const char *filename = "$ALICE_ROOT/TOF/enableMap.104892.root"); //load the enable channel map
    void ApplyMask(AliESDEvent *esd);
 
    void SetNoTOFT0(Bool_t status = kTRUE) {fNoTOFT0 = status;}; // disable the TOF T0 info


### PR DESCRIPTION
No longer valid ISO C++. Generates lots fo warnings since header is included in many places.