### PR TITLE
Optimize acceptance for particle level jets

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.cxx
@@ -467,7 +467,7 @@ AliAnalysisTaskEmcalJetSubstructureTree *AliAnalysisTaskEmcalJetSubstructureTree
                               AliJetContainer::antikt_algorithm,
                               AliJetContainer::pt_scheme,
                               jetradius,
-                              AliEmcalJet::kEMCALfid,
+                              isData ? AliEmcalJet::kEMCALfid : AliEmcalJet::kTPC,
                               particles, nullptr);
     mcjets->SetName("mcjets");
     mcjets->SetJetPtCut(20.);


### PR DESCRIPTION
- TPC acceptance in case the task runs purely with MC-true information
  (maily of relevance for the MCgen trains)
- EMCAL fiducial acceptance in case both reconstructed and true information
  are used (regular MC LEGO trains, on normal productions)