### PR TITLE
EMCal: Fix reorder warning in AliEmcalContainerIndexMap.h

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalContainerIndexMap.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalContainerIndexMap.h
@@ -125,8 +125,8 @@ class AliEmcalContainerIndexMap {
  */
 template<class U, class V>
 AliEmcalContainerIndexMap<U, V>::AliEmcalContainerIndexMap():
-  fOffset(100000),
   fGlobalIndexMap(),
+  fOffset(100000),
   fClass(TClass::GetClass(typeid(V)))
 {
 }
@@ -136,8 +136,8 @@ AliEmcalContainerIndexMap<U, V>::AliEmcalContainerIndexMap():
  */
 template<class U, class V>
 AliEmcalContainerIndexMap<U, V>::AliEmcalContainerIndexMap(const AliEmcalContainerIndexMap<U, V> & map):
-  fOffset(map.fOffset),
   fGlobalIndexMap(map.fGlobalIndexMap),
+  fOffset(map.fOffset),
   fClass(map.fClass) // Should be okay to be the same pointer, as it just points to the class type
 {
 }


### PR DESCRIPTION
Together with the -Werror of EMCal this fix is needed in case one turns on more warnings. The implementation has to follow the order of data members in the definition.

Hi EMCal! 

I turned on -Wall in AliPhysics [1] and compilation stops in the EMCal part. While I don't know yet how useful -Wall will be, it would be great to have the compilation succeed and see the warnings from the whole AliPhysics. Below [2] the warning, full log here: http://www.physi.uni-heidelberg.de/~hbeck/EMCalLog.txt

Cheers,
Hans

[1] Turned on -Wall like this:
```bash
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 5551c18a8b..e566fc0cb0 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,12 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
   endif()
 
+  # Switch on warnings
+  check_cxx_compiler_flag(-Wall CXX_COMPILER_HAS_WALL)
+  if(CXX_COMPILER_HAS_WALL)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+  endif()
+  
   # Turn some common warnings into errors
   check_cxx_compiler_flag(-Werror=mismatched-new-delete CXX_COMPILER_HAS_MISMATCHED_NEW_DELETE)
   if(CXX_COMPILER_HAS_MISMATCHED_NEW_DELETE)
```


[2] The EMCal warning
```bash
                                         ^
In file included from /misc/alidata100/alice_u/hbeck/alibuild/sw/SOURCES/AliPhysics/0/0/PWG/EMCAL/EMCALbase/AliClusterContainer.h:15:0,
                 from /misc/alidata100/alice_u/hbeck/alibuild/sw/SOURCES/AliPhysics/0/0/PWG/EMCAL/EMCALbase/AliClusterContainer.cxx:26:
/misc/alidata100/alice_u/hbeck/alibuild/sw/SOURCES/AliPhysics/0/0/PWG/EMCAL/EMCALbase/AliEmcalContainerIndexMap.h: In instantiation of 'AliEmcalContainer\
IndexMap<U, V>::AliEmcalContainerIndexMap() [with U = TClonesArray; V = AliVCluster]':
/misc/alidata100/alice_u/hbeck/alibuild/sw/SOURCES/AliPhysics/0/0/PWG/EMCAL/EMCALbase/AliClusterContainer.cxx:33:76:   required from here
/misc/alidata100/alice_u/hbeck/alibuild/sw/SOURCES/AliPhysics/0/0/PWG/EMCAL/EMCALbase/AliEmcalContainerIndexMap.h:119:7: error: 'AliEmcalContainerIndexMa\
p<TClonesArray, AliVCluster>::fOffset' will be initialized after [-Werror=reorder]
   int fOffset;                         ///< Offset between each TClonesArray
       ^
/misc/alidata100/alice_u/hbeck/alibuild/sw/SOURCES/AliPhysics/0/0/PWG/EMCAL/EMCALbase/AliEmcalContainerIndexMap.h:117:23: error:   'std::map<int, TClones\
Array*, std::less<int>, std::allocator<std::pair<const int, TClonesArray*> > > AliEmcalContainerIndexMap<TClonesArray, AliVCluster>::fGlobalIndexMap' [-W\
error=reorder]
   std::map <int, U *> fGlobalIndexMap; //!<! Map between index and input object
                       ^
/misc/alidata100/alice_u/hbeck/alibuild/sw/SOURCES/AliPhysics/0/0/PWG/EMCAL/EMCALbase/AliEmcalContainerIndexMap.h:127:1: error:   when initialized here [\
-Werror=reorder]
 AliEmcalContainerIndexMap<U, V>::AliEmcalContainerIndexMap():
 ^
```

