### PR TITLE
Use static function to set up task (instead of AddTask)

### DIFF
--- a/PWGCF/Correlations/C2/AliAnalysisTaskValidation.h
+++ b/PWGCF/Correlations/C2/AliAnalysisTaskValidation.h
@@ -15,6 +15,11 @@ class AliAnalysisTaskValidation : public AliAnalysisTaskSE {
  public:
   AliAnalysisTaskValidation();
   AliAnalysisTaskValidation(const char *name);
+
+  /// Set up this task. This function acts as the AddTask macro
+  static AliAnalysisTaskValidation* ConnectTask(const char *suffix);
+  /// The Exchange container which is to be accessed by other classes
+  AliAnalysisDataContainer* GetExchangeContainter();
   virtual ~AliAnalysisTaskValidation() {};
 
   // Enums describing each event validator. These can be pushed into


### PR DESCRIPTION
A static function on this task replaces the AddTask macro. This help
keeping everything in one plasce and ensures a tight integration and
most importantly compile time checks! The latter is what one misses
out when using the ungodly .C macros.