### PR TITLE
Adding Chi2TPCConstrainedVsGlobal to AliAnalysisPIDTrack

### DIFF
--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFfits/AliAnalysisPIDEvent.cxx
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFfits/AliAnalysisPIDEvent.cxx
@@ -40,7 +40,7 @@ Float_t AliAnalysisPIDEvent::fgTimeZeroSpread = 196.7;
 Float_t AliAnalysisPIDEvent::fgTimeZeroT0_AND_sigma = 3.87264325235363032e+01;
 Float_t AliAnalysisPIDEvent::fgTimeZeroT0_A_sigma = 8.27180042372880706e+01;
 Float_t AliAnalysisPIDEvent::fgTimeZeroT0_C_sigma = 9.73209262235003933e+01;
-Int_t AliAnalysisPIDEvent::fgFlagToCheck = 63;
+Int_t AliAnalysisPIDEvent::fgFlagToCheck = 29;
 
 //___________________________________________________________
 

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFfits/AliAnalysisPIDTrack.cxx
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFfits/AliAnalysisPIDTrack.cxx
@@ -75,6 +75,7 @@ AliAnalysisPIDTrack::AliAnalysisPIDTrack() :
   fTPCNcls(0),
   fTPCNclsF(0),
   fTPCNcr(0.),
+  fChi2TPCConstrainedVsGlobal(-10),
   fTOFIndex(0),
   fTOFTime(0.),
   fTOFExpTime(),
@@ -157,7 +158,8 @@ AliAnalysisPIDTrack::AliAnalysisPIDTrack(const AliAnalysisPIDTrack &source) :
   fTPCdEdxN(source.fTPCdEdxN),
   fTPCNcls(source.fTPCNcls),
   fTPCNclsF(source.fTPCNclsF),
-  fTPCNcr(source.fTPCNcr),  
+  fTPCNcr(source.fTPCNcr),
+  fChi2TPCConstrainedVsGlobal(source.fChi2TPCConstrainedVsGlobal),
   fTOFIndex(source.fTOFIndex),
   fTOFTime(source.fTOFTime),
   fTOFExpTime(),
@@ -231,6 +233,7 @@ AliAnalysisPIDTrack::operator=(const AliAnalysisPIDTrack &source)
   fTPCNcls = source.fTPCNcls;
   fTPCNclsF = source.fTPCNclsF;
   fTPCNcr = source.fTPCNcr;
+  fChi2TPCConstrainedVsGlobal = source.fChi2TPCConstrainedVsGlobal;
   fTOFIndex = source.fTOFIndex;
   fTOFTime = source.fTOFTime;
   for (Int_t i = 0; i < 5; i++) fTOFExpTime[i] = source.fTOFExpTime[i];
@@ -303,6 +306,7 @@ AliAnalysisPIDTrack::Reset()
   fTPCNcls = 0;
   fTPCNclsF = 0;
   fTPCNcr = 0.;
+  fChi2TPCConstrainedVsGlobal=-10;
   fTOFIndex = 0;
   fTOFTime = 0.;
   for (Int_t i = 0; i < 5; i++) fTOFExpTime[i] = 0.;

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFfits/AliAnalysisPIDTrack.h
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFfits/AliAnalysisPIDTrack.h
@@ -129,6 +129,8 @@ public TObject
   static Bool_t LoadTuningExpTimeTh(const Char_t *filename); // load tuning exp time th
   Bool_t IsAcceptedByTrackCuts(Int_t CutFlag) { return GetTrackCutFlag()&CutFlag;};
   Bool_t CheckExtraCuts(Float_t minTPCNcr=70, Float_t maxChi2PerFindableCluster = 4, Float_t maxDCAz = 2);
+  Double_t GetChi2TPCConstrainedVsGlobal() { return fChi2TPCConstrainedVsGlobal; };
+  void SetChi2TPCConstrainedVsGlobal(Double_t newval) { fChi2TPCConstrainedVsGlobal = newval; };
   //  Int_t GetTOFCalibIndex(Int_t imap) {return (Int_t)fgTOFcalibHisto.GetCalibMap(imap, fTOFIndex);}; // get TOF calib index
 
   static AliTOFPIDResponse *GetTOFResponse() {return fgTOFResponse;}; // getter
@@ -173,6 +175,7 @@ public TObject
   UShort_t fTPCNcls; // number of clusters TPC
   UShort_t fTPCNclsF; // number of findable clusters TPC
   Float_t fTPCNcr; // number of crossed rows TPC
+  Double_t fChi2TPCConstrainedVsGlobal;
   /*** TOF PID info ***/
   Int_t fTOFIndex; // index
   Float_t fTOFTime; // time
@@ -237,7 +240,7 @@ public TObject
 
   Float_t fTimeZeroSigma; //!
 
-  ClassDef(AliAnalysisPIDTrack, 3);
+  ClassDef(AliAnalysisPIDTrack, 4);
 };
 
 #endif /* ALIANALYSISPIDTRACK_H */

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFfits/AliAnalysisTaskTPCTOFPID.cxx
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFfits/AliAnalysisTaskTPCTOFPID.cxx
@@ -663,10 +663,12 @@ AliAnalysisTaskTPCTOFPID::UserExec(Option_t *option)
     const AliESDVertex *vtx = fESDEvent->GetPrimaryVertexTracks();
     if(!vtx || !vtx->GetStatus())
       vtx = fESDEvent->GetPrimaryVertexSPD();
-    if(vtx->GetStatus()) {
-      Double_t ChiConstrained = track->GetChi2TPCConstrainedVsGlobal(vtx);
-      fAnalysisTrack->SetChi2TPCConstrainedVsGlobal(ChiConstrained);
-    };
+    if(vtx)
+      if(vtx->GetStatus()) {
+	Double_t ChiConstrained = track->GetChi2TPCConstrainedVsGlobal(vtx);
+	fAnalysisTrack->SetChi2TPCConstrainedVsGlobal(ChiConstrained);
+      } else
+	fAnalysisTrack->SetChi2TPCConstrainedVsGlobal(-8);
     if(track->IsEMCAL()) {
       AliVCluster *lvcl = fESDEvent->GetCaloCluster(track->GetEMCALcluster());
       if(lvcl)

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFfits/AliAnalysisTaskTPCTOFPID.cxx
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFfits/AliAnalysisTaskTPCTOFPID.cxx
@@ -660,6 +660,13 @@ AliAnalysisTaskTPCTOFPID::UserExec(Option_t *option)
     
     /* update and add analysis track */
     fAnalysisTrack->Update(track, fMCEvent,fPIDResponse, trflag);
+    const AliESDVertex *vtx = fESDEvent->GetPrimaryVertexTracks();
+    if(!vtx || !vtx->GetStatus())
+      vtx = fESDEvent->GetPrimaryVertexSPD();
+    if(vtx->GetStatus()) {
+      Double_t ChiConstrained = track->GetChi2TPCConstrainedVsGlobal(vtx);
+      fAnalysisTrack->SetChi2TPCConstrainedVsGlobal(ChiConstrained);
+    };
     if(track->IsEMCAL()) {
       AliVCluster *lvcl = fESDEvent->GetCaloCluster(track->GetEMCALcluster());
       if(lvcl)


### PR DESCRIPTION
Added fChi2TPCConstrainedVsGlobal to AliAnalysisPIDTrack for primary selection (including getters and setters). Changed the default PIDEvent flag to 29.