### PR TITLE
Fix parentheses AliAnalysisTaskSEDs

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSEDs.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEDs.cxx
@@ -1110,7 +1110,7 @@ void AliAnalysisTaskSEDs::UserExec(Option_t */*option*/)
 	  fMassHist[index]->Fill(invMass,weightKKpi);
 	  fPtVsMass->Fill(invMass,ptCand,weightKKpi);
         
-	  if(fDoBkgPhiSB && 0.010<TMath::Abs(massKK-massPhi)<0.030) {
+	  if(fDoBkgPhiSB && (0.010<TMath::Abs(massKK-massPhi)) && (TMath::Abs(massKK-massPhi)<0.030) ) {
             if(massKK<massPhi)fMassLSBkgHistPhi[iPtBin]->Fill(invMass);
             else fMassRSBkgHistPhi[iPtBin]->Fill(invMass);
 	  }
@@ -1163,7 +1163,7 @@ void AliAnalysisTaskSEDs::UserExec(Option_t */*option*/)
 	  fMassHist[index]->Fill(invMass,weightpiKK);
 	  fPtVsMass->Fill(invMass,ptCand,weightpiKK);
               
-	  if(fDoBkgPhiSB && 0.010<TMath::Abs(massKK-massPhi)<0.030) {
+	  if(fDoBkgPhiSB && (0.010<TMath::Abs(massKK-massPhi)) && (TMath::Abs(massKK-massPhi)<0.030) ) {
 	    if(massKK<massPhi)fMassLSBkgHistPhi[iPtBin]->Fill(invMass);
 	    else fMassRSBkgHistPhi[iPtBin]->Fill(invMass);
 	  }
@@ -1676,7 +1676,7 @@ void AliAnalysisTaskSEDs::GenerateRotBkg(AliAODRecoDecayHF3Prong *d, Int_t dec, 
       energysum += TMath::Sqrt(mProng[j]*mProng[j]+P2Prong[j]);
     }
     Double_t mass = TMath::Sqrt(energysum*energysum-P2);
-    if(fminMass<=mass<fmaxMass) fMassRotBkgHistPhi[iPtBin]->Fill(mass);
+    if( (fminMass<=mass) && (mass<fmaxMass) ) fMassRotBkgHistPhi[iPtBin]->Fill(mass);
   }
 }
 //_________________________________________________________________________


### PR DESCRIPTION
Fixed three logical mass window comparisons. The mathematical 0.1 < 0.2 < 0.3 does not translate into a c++ 0.1 < 0.2 < 0.3, which in a boolean usage like if(0.1<0.2<0.3) evaluates to false: 0.1<0.2 evaluates to a boolean true which turns into a 1. The final comparison 1<0.3 is not true. Triggered by compiling AliPhysics with -Wall.