### PR TITLE
Removed unused variable AliEMCALTriggerOfflineQAPP

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEMCALTriggerOfflineQAPP.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEMCALTriggerOfflineQAPP.cxx
@@ -505,7 +505,6 @@ void AliEMCALTriggerOfflineQAPP::ProcessCell(const AliEMCALCellInfo& cell)
   if (cell.fEnergy < fMinCellAmp) return;
 
   if (fGeom) {
-    Double_t pos[3] = {0., 0., 0.};
     Int_t sm = fGeom->GetSuperModuleNumber(cell.fAbsId);
     if (fGeom->IsDCALSM(sm)) {
       if (!fDCalPlots) return;


### PR DESCRIPTION
Removed an unused variable in AliEMCALTriggerOfflineQAPP. Triggers a warning/error with -Wall

@mfasDa @raymondEhlers another one in the -Wall series :) 
