### PR TITLE
Fix filter bit track cut in CFTree

### DIFF
--- a/PWGCF/Correlations/Base/AliAnalysisTaskCFTree.cxx
+++ b/PWGCF/Correlations/Base/AliAnalysisTaskCFTree.cxx
@@ -576,7 +576,7 @@ void AliAnalysisTaskCFTree::UserExec(Option_t *){
         // track selection based on filter mask (if set)
         // or ITSsa cuts
 	if (fTrackFilterBit != 0) {
-          if (mask & fTrackFilterBit == 0)
+          if ((mask & fTrackFilterBit) == 0)
             continue;
         }
         else if (track->InheritsFrom("AliAODTrack")) {


### PR DESCRIPTION
The & operator has lower precedence than ==. Added parentheses such that the filter bit "mask" selects on filter bits. 

@qgp can you have a look? 
Warning: this changes the behavior of the task! (For good, I hope.)

Generates a warning with gcc when using -Wall flag, see here:
http://www.physi.uni-heidelberg.de/~hbeck/Wall-log.txt
Clang has even nicer diagnostics on this one:
```c++
tst.C:6:12: warning: & has lower precedence than ==; == will be evaluated first
      [-Wparentheses]
  if (mask & fTrackFilterBit == 0){
           ^~~~~~~~~~~~~~~~~~~~~~
tst.C:6:12: note: place parentheses around the '==' expression to silence this
      warning
  if (mask & fTrackFilterBit == 0){
           ^
             (                   )
tst.C:6:12: note: place parentheses around the & expression to evaluate it first
  if (mask & fTrackFilterBit == 0){
           ^
      (                     )
1 warning generated.
```