### PR TITLE
Last round of warnings (found by clang)

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMaker.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMaker.cxx
@@ -192,7 +192,7 @@ void AliEmcalTriggerMaker::UserCreateOutputObjects()
 
   if(fDoQA && fOutput){
     fQAHistos = new THistManager("TriggerQA");
-    std::array<std::string, 3> patchtypes = {"Online", "Offline", "Recalc"};
+    std::array<std::string, 3> patchtypes = {{"Online", "Offline", "Recalc"}};
 
     for(int itype = 0; itype < 5; itype++){
       for(const auto & patchtype : patchtypes){

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
@@ -90,8 +90,8 @@ AliEmcalTriggerMakerTask::~AliEmcalTriggerMakerTask() {
  */
 void AliEmcalTriggerMakerTask::UserCreateOutputObjects(){
   AliAnalysisTaskEmcal::UserCreateOutputObjects();
-  const std::array<const TString, 3>  kTriggerTypeNames = {"EJE", "EGA", "EL0"},
-                                      kPatchTypes = {"Online", "Offline", "Recalc"};
+  const std::array<const TString, 3>  kTriggerTypeNames = {{"EJE", "EGA", "EL0"}},
+                                      kPatchTypes = {{"Online", "Offline", "Recalc"}};
 
   if(fDoQA) AliInfoStream() << "Trigger maker - QA requested" << std::endl;
   else AliInfoStream() << "Trigger maker - no QA requested" << std::endl;


### PR DESCRIPTION
Fix double-initialization (aggregate + list-initilization)
for several initializations of std::array. Fixing last
leftovers from #2193 