### PR TITLE
Add -Wall to AliPhysics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,16 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=delete-non-virtual-dtor")
   endif()
 
+  # Turn on "all" warnings, but skip missing braces warning
+  check_cxx_compiler_flag(-Wall CXX_COMPILER_HAS_WALL)
+  if(CXX_COMPILER_HAS_WALL)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+  endif()
+  check_cxx_compiler_flag(-Wno-missing-braces CXX_COMPILER_HAS_WNO_MISSING_BRACES)
+  if(CXX_COMPILER_HAS_WNO_MISSING_BRACES)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces")
+  endif()
+  
   # Issue a warning if AliRoot Core does not have AliEn support (this is wrong in most cases)
   if(NOT AliRoot_HASALIEN)
       message(WARNING "AliRoot Core has been built without with AliEn support: some features might be unavailable!")


### PR DESCRIPTION
Added -Wall -Wno-missing-braces warning to AliPhysics. Missing braces is
included in Wall in clang but not in gcc>=4.8.

Hello @pzhristov @dberzano @rbertens @mfasDa @raymondEhlers @loizides @aiola @ddobrigk @cbourjau !

This PR is meant as a place to discuss the possibility of adding the -Wall warning to AliPhysics. The compiler warnings can help in catching some unintended behavior in our physics analyses. Looking at the warnings of -Wall, most warnings are harmless reordering but a substantial amount of warnings points out code which does not do what it is intended to do. 

A counterargument is the additional work load on coders, fixing harmless reorder warnings. I'd like to argue that making coders aware of such issues is a benefit on its own and the few harmful cases we catch outweigh the effort in easily&quickly fixing harmless cases. 

I added -Wno-missing-braces to have uniform behavior between clang and gcc. 
@dberzano the build system check only runs gcc, right? In general, we might run into problems when clang is more sensitive than gcc. It could cause non-compilation with clang since some parts of AliPhysics have a -Werror flag. The vast majority of code in AliPhysics is compiled without the -Werror flag, so different behavior with various compilers will mostly only cause different warning messages. 

Raymond Ehlers, Markus Fasel, and I successfully exercised fixing all -Wall warnings in the EMCal part of AliPhysics. While it was some work, I think all of the fixes were straightforward and did not cause too much extra work. 

I think this would also good to be discussed on Monday in the Computing Board.

Cheers,
Hans