### PR TITLE
Fix self assignment HFE cuts

### DIFF
--- a/PWGHF/hfe/AliHFEV0cuts.cxx
+++ b/PWGHF/hfe/AliHFEV0cuts.cxx
@@ -1620,14 +1620,12 @@ Bool_t AliHFEV0cuts::GetHelixCenter(AliESDtrack * const track, Double_t b,Int_t 
     }
 
     if(charge < 0){
-      xpoint =  xpoint;
-      ypoint =  ypoint;
+      // Do nothing
     }
   }
   if(b>0){
     if(charge > 0){
-      xpoint =  xpoint;
-      ypoint =  ypoint;
+      // Do nothing
     }
 
     if(charge < 0){


### PR DESCRIPTION
Fixes compiler warnings

/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGHF/hfe/AliHFEV0cuts.cxx:1623:14: warning: explicitly assigning value of variable of type 'Double_t' (aka 'double') to itself [-Wself-assign]
      xpoint =  xpoint;
      ~~~~~~ ^  ~~~~~~
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGHF/hfe/AliHFEV0cuts.cxx:1624:14: warning: explicitly assigning value of variable of type 'Double_t' (aka 'double') to itself [-Wself-assign]
      ypoint =  ypoint;
      ~~~~~~ ^  ~~~~~~
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGHF/hfe/AliHFEV0cuts.cxx:1629:14: warning: explicitly assigning value of variable of type 'Double_t' (aka 'double') to itself [-Wself-assign]
      xpoint =  xpoint;
      ~~~~~~ ^  ~~~~~~
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGHF/hfe/AliHFEV0cuts.cxx:1630:14: warning: explicitly assigning value of variable of type 'Double_t' (aka 'double') to itself [-Wself-assign]
      ypoint =  ypoint;
      ~~~~~~ ^  ~~~~~~
4 warnings generated.