### PR TITLE
Fix abs -> TMath::Abs in AliHMPIDTaskQA

### DIFF
--- a/PWGPP/HMPID/AliHMPIDTaskQA.cxx
+++ b/PWGPP/HMPID/AliHMPIDTaskQA.cxx
@@ -341,7 +341,7 @@ void AliHMPIDTaskQA::UserCreateOutputObjects() {
 //____________________________________________________________________________________________________________________________________
 Bool_t AliHMPIDTaskQA::Equal(Double_t x, Double_t y, Double_t tolerance)
 {
- return abs(x - y) <= tolerance ;
+  return TMath::Abs(x - y) <= tolerance ;
 }
    
 #endif


### PR DESCRIPTION
This changes the behavior of the task! Clearly, the code intends to compare doubles (explicit type) but the integer abs() is used.

