### PR TITLE
Change integer abs -> TMath::Abs on double in AliTrackletAlg

### DIFF
--- a/PWGPP/EVCHAR/AliTrackletAlg.cxx
+++ b/PWGPP/EVCHAR/AliTrackletAlg.cxx
@@ -1192,7 +1192,7 @@ void AliTrackletAlg::FlagV0s(const AliESDVertex *vtx)
 	k0KF.SetProductionVertex(vertexKF);
 	k0KF.GetMass(mass,massErr);
 	mass -= kK0Mass;
-	if (TMath::Abs(mass)>fCutMassK0 || (massErr>0&&(abs(mass)>massErr*fCutMassK0NSigma))) break;
+	if (TMath::Abs(mass)>fCutMassK0 || (massErr>0&&(TMath::Abs(mass)>massErr*fCutMassK0NSigma))) break;
 	if (k0KF.GetS()<fCutK0SFromDecay) break;
 	k0KF.SetMassConstraint(kK0Mass,0.001);
 	chi2c = (k0KF.GetNDF()!=0) ? k0KF.GetChi2()/k0KF.GetNDF() : 1000;


### PR DESCRIPTION
This changes behavior of the task! Code intends to compare doubles but integer abs is used.

Revealed by compiler warning:
```c++
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGPP/EVCHAR/AliTrackletAlg.cxx:1195:50: warning: 
      using integer absolute value function 'abs' when argument is of floating
      point type [-Wabsolute-value]
        if (TMath::Abs(mass)>fCutMassK0 || (massErr>0&&(abs(mass)>massEr...
                                                        ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGPP/EVCHAR/AliTrackletAlg.cxx:1195:50: note: 
      use function 'std::abs' instead
        if (TMath::Abs(mass)>fCutMassK0 || (massErr>0&&(abs(mass)>massEr...
                                                        ^~~
                                                        std::abs
```