### PR TITLE
Fix unused value AliTRDcheckPID

### DIFF
--- a/PWGPP/TRD/AliTRDcheckPID.cxx
+++ b/PWGPP/TRD/AliTRDcheckPID.cxx
@@ -1206,7 +1206,7 @@ Bool_t AliTRDcheckPID::GetRefFigure(Int_t ifig)
         h1->GetYaxis()->CenterTitle();h1->GetYaxis()->SetTitleOffset(1.2);
         h1->GetYaxis()->SetRangeUser(0.,40.);
       }
-      (TH1F*)h1->DrawClone(kFIRST ? "c" : "samec");
+      /*h = (TH1F*)*/h1->DrawClone(kFIRST ? "c" : "samec");
       //legNClus->AddEntry(h, Form("%s", AliTRDCalPID::GetPartName(is)), "l");
       kFIRST = kFALSE;
     }


### PR DESCRIPTION
Fixes a compiler warning

```c++
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGPP/TRD/AliTRDcheckPID.cxx:1209:7: warning: 
      expression result unused [-Wunused-value]
      (TH1F*)h1->DrawClone(kFIRST ? "c" : "samec");
      ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```

