### PR TITLE
Fix array index access AliAnalysisTaskPID

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskPID.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskPID.cxx
@@ -1376,7 +1376,7 @@ void AliAnalysisTaskPID::UserExec(Option_t *)
         
         if (fDoPID) {
           Double_t valuesGenYield[kGenYieldNumAxes] = {  static_cast<Double_t>(mcID), mcPart->Pt(), centralityPercentile, -1, -1, -1, -1 };
-          valuesGenYield[GetIndexOfChargeAxisGenYield(), -1, -1] = chargeMC;
+          valuesGenYield[GetIndexOfChargeAxisGenYield()] = chargeMC;
           
           if (isMultSelected)
             fhMCgeneratedYieldsPrimaries->Fill(valuesGenYield);


### PR DESCRIPTION
Changes behavior of task!

Old code was always assigning array at index -1. For what the old code did:
https://stackoverflow.com/questions/29933444/c-multi-dimensional-array-comma-index-address
> A comma operator is a binary operator which evaluates all the comma separated expressions completing its side effects and discards it until the last expression in the list. 

Revealed by compiler warning:
```c++
sers/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskPID.cxx:1379:58: warning: 
      expression result unused [-Wunused-value]
          valuesGenYield[GetIndexOfChargeAxisGenYield(), -1, -1] = chargeMC;
                                                         ^~
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskPID.cxx:1379:11: warning: 
      array index -1 is before the beginning of the array [-Warray-bounds]
          valuesGenYield[GetIndexOfChargeAxisGenYield(), -1, -1] = chargeMC;
          ^              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskPID.cxx:1378:11: note: 
      array 'valuesGenYield' declared here
          Double_t valuesGenYield[kGenYieldNumAxes] = {  static_cast<Dou...
```
