### PR TITLE
Fix copy ctor AliTwoPlusOneContainer

### DIFF
--- a/PWGCF/Correlations/Base/AliTwoPlusOneContainer.cxx
+++ b/PWGCF/Correlations/Base/AliTwoPlusOneContainer.cxx
@@ -98,7 +98,7 @@ AliTwoPlusOneContainer::AliTwoPlusOneContainer(const char* name, const char* uEH
 
 //_____________________________________________________________________________
 AliTwoPlusOneContainer::AliTwoPlusOneContainer(const AliTwoPlusOneContainer &c) :
-  TNamed(fName, fTitle),
+  TNamed(c),
   fTwoPlusOne(0),
   fAsymmetry(0),
   fAsymmetryMixed(0),


### PR DESCRIPTION
Prevents code from using uninitialized data member. Revealed by a compiler warning:
```c++
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGCF/Correlations/Base/AliTwoPlusOneContainer.cxx:101:10: warning: 
      base class 'TNamed' is uninitialized when used here to access
      'TNamed::fName' [-Wuninitialized]
  TNamed(fName, fTitle),
         ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGCF/Correlations/Base/AliTwoPlusOneContainer.cxx:101:17: warning: 
      base class 'TNamed' is uninitialized when used here to access
      'TNamed::fTitle' [-Wuninitialized]
  TNamed(fName, fTitle),
                ^
2 warnings generated.
```

@mazimm what do you think?