### PR TITLE
add PHOS_Run2 macros

### DIFF
--- a/PWGGA/PHOSTasks/CMakeLists.txt
+++ b/PWGGA/PHOSTasks/CMakeLists.txt
@@ -38,6 +38,7 @@ include_directories(${AliPhysics_SOURCE_DIR}/PWGGA/PHOSTasks
                     ${AliPhysics_SOURCE_DIR}/PWGGA/PHOSTasks/PHOS_Tagging
                     ${AliPhysics_SOURCE_DIR}/PWGGA/PHOSTasks/PHOS_TriggerQA
                     ${AliPhysics_SOURCE_DIR}/PWGGA/PHOSTasks/PHOS_pp_8TeV_2012
+                    ${AliPhysics_SOURCE_DIR}/PWGGA/PHOSTasks/PHOS_Run2
                     ${AliPhysics_SOURCE_DIR}/PWGGA/PHOSTasks/UserTasks
                     ${AliPhysics_SOURCE_DIR}/PWG/muon
                     ${AliPhysics_SOURCE_DIR}/PWG/FLOW/Base
@@ -94,6 +95,11 @@ set(SRCS
     PHOS_pp_pi0/AliCaloPhoton.cxx
     PHOS_pp_8TeV_2012/AliAnalysisTaskPHOSTrigPi0.cxx
     PHOS_pp_8TeV_2012/AliCaloTriggerSimulator.cxx
+    PHOS_Run2/AliAnalysisTaskPHOSObjectCreator.cxx
+    PHOS_Run2/AliPHOSTriggerHelper.cxx
+    PHOS_Run2/AliPHOSEventCuts.cxx
+    PHOS_Run2/AliPHOSClusterCuts.cxx
+    PHOS_Run2/AliAnalysisTaskPHOSPi0EtaToGammaGamma.cxx
     PHOS_Tagging/AliAnalysisTaskTaggedPhotons.cxx
     PHOS_TriggerQA/AliAnalysisTaskPHOSTriggerQA.cxx
     UserTasks/AliAnalysisTaskSEPHOSpPbPi0.cxx
@@ -183,6 +189,7 @@ install(DIRECTORY PHOS_pPb                  DESTINATION PWGGA/PHOSTasks)
 install(DIRECTORY PHOS_Run2embedding/macros DESTINATION PWGGA//PHOSTasks/PHOS_Run2embedding)
 install(DIRECTORY CPVperf/macros            DESTINATION PWGGA/PHOSTasks/CPVperf)
 install(DIRECTORY PHOS_pp_8TeV_2012/macros  DESTINATION PWGGA/PHOSTasks/PHOS_pp_8TeV_2012)
+install(DIRECTORY PHOS_Run2/macros          DESTINATION PWGGA/PHOSTasks/PHOS_Run2)
 install(FILES PHOS_pp_pi0/AddTaskPHOSpp.C   DESTINATION PWGGA/PHOSTasks/PHOS_pp_pi0)
 install(FILES PHOS_pp_pi0/AddTaskPHOSpi0Conversion.C DESTINATION PWGGA/PHOSTasks/PHOS_pp_pi0)
 install(FILES PHOSCalib/AddTaskEmeanCalib.C DESTINATION PWGGA/PHOSTasks/PHOSCalib)

--- a/PWGGA/PHOSTasks/PHOS_Run2/AliAnalysisTaskPHOSObjectCreator.cxx
+++ b/PWGGA/PHOSTasks/PHOS_Run2/AliAnalysisTaskPHOSObjectCreator.cxx
@@ -1,0 +1,995 @@
+#include "TF1.h"
+#include "TObject.h"
+#include "TObjArray.h"
+#include "TClonesArray.h"
+#include "TString.h"
+#include "TMath.h"
+#include "AliLog.h"
+#include "AliAnalysisTaskSE.h"
+#include "TParticle.h"
+#include "AliMCEventHandler.h"
+#include "AliMCEvent.h"
+#include "AliStack.h"
+#include "AliAODMCParticle.h"
+
+#include "AliVCluster.h"
+#include "AliVCaloCells.h"
+#include "AliCaloPhoton.h"
+#include "AliVEvent.h"
+#include "AliESDEvent.h"
+#include "AliAODEvent.h"
+#include "AliPHOSGeometry.h"
+#include "AliOADBContainer.h"
+#include "AliMagF.h"
+#include "TGeoGlobalMagField.h"
+#include "AliAnalysisManager.h"
+
+#include "AliPHOSEventCuts.h"
+#include "AliAnalysisTaskPHOSObjectCreator.h"
+
+ClassImp(AliAnalysisTaskPHOSObjectCreator)
+
+//________________________________________________________________________
+AliAnalysisTaskPHOSObjectCreator::AliAnalysisTaskPHOSObjectCreator(const char *name):
+  AliAnalysisTaskSE(name),
+  fEvent(0x0),
+  fAODEvent(0x0),
+  fESDEvent(0x0),
+  fPHOSObjectArray(NULL),
+  fPHOSGeo(0x0),
+  fNonLinCorr(0),
+  fUserNonLinCorr(0),
+  fRunNumber(0),
+  fUsePHOSTender(kTRUE),
+  fIsMC(kFALSE),
+  fBunchSpace(25),
+  fMinDistBC(-1),
+  fObjectArrayName("PHOSClusterArray"),
+  fMCArrayESD(0x0),
+  fMCArrayAOD(0x0),
+  fIsM4Excluded(kTRUE)
+{
+  // Constructor
+  for(Int_t i=0;i<3;i++){
+    fVertex[i] = 0;
+  }
+ 
+  for(Int_t i=0;i<6;i++){
+    fPHOSBadMap[i] = 0;
+  }
+
+  //Initialize non-linrarity correction
+  fNonLinCorr = new TF1("nonlin","0.0241 + 1.0504*x + 0.000249*x*x",0.,100.);
+  fUserNonLinCorr = new TF1("usernonlin","pol0(0)",0.,100.);
+  fUserNonLinCorr->SetParameter(0,1);
+ 
+//  // Define input and output slots here
+//  // Input slot #0 works with a TChain
+//  DefineInput(0, TChain::Class());
+//  // Output slot #0 id reserved by the base class for AOD
+//  // Output slot #1 writes into a TH1 container
+//  DefineOutput(1, THashList::Class());
+
+}
+//________________________________________________________________________
+AliAnalysisTaskPHOSObjectCreator::~AliAnalysisTaskPHOSObjectCreator()
+{
+  //destructor
+
+  if(fPHOSObjectArray){
+    delete fPHOSObjectArray;
+    fPHOSObjectArray = 0x0;
+  }
+
+  delete fNonLinCorr;
+  if(fUserNonLinCorr) delete fUserNonLinCorr;
+
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSObjectCreator::UserCreateOutputObjects()
+{
+  // Create histograms
+  // Called once
+
+  Init();//initialize PHOS object array
+
+  //for(Int_t i=0;i<100;i++){
+  //  Double_t e = 0.1*i;
+  //  Double_t corr = fUserNonLinCorr->Eval(e);
+  //  printf("h1->SetBinContent(%d,%f);\n",i+1,corr);
+  //}
+
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSObjectCreator::UserExec(Option_t *option) 
+{
+  // Main loop
+  // Called for each event
+
+  fEvent = dynamic_cast<AliVEvent*>(InputEvent());
+  if(!fEvent){
+    AliError("event is not available.");
+    return;
+  }
+
+  //cout << "Object Creator usePHOSTender = " << fUsePHOSTender << " , fIsMC = " << fIsMC << endl;
+
+  fESDEvent = dynamic_cast<AliESDEvent*>(fEvent);
+  fAODEvent = dynamic_cast<AliAODEvent*>(fEvent);
+
+  if(fIsMC){
+    fMCArrayESD = 0x0;
+    fMCArrayAOD = 0x0;
+    if(fESDEvent){
+      AliVEventHandler* eventHandler = AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler();
+      if(eventHandler){
+        AliMCEventHandler* mcEventHandler = dynamic_cast<AliMCEventHandler*> (eventHandler);
+        if(mcEventHandler) fMCArrayESD = static_cast<AliMCEventHandler*>(AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler())->MCEvent()->Stack();
+      }
+
+      if(!fMCArrayESD) AliError("Could not get MC Stack!");
+
+    }
+    else if(fAODEvent){
+      fMCArrayAOD = dynamic_cast<TClonesArray*>(fAODEvent->FindListObject(AliAODMCParticle::StdBranchName()));
+      if (!fMCArrayAOD) AliError("Could not retrieve MC array!");
+
+    }
+
+  }
+
+  if(fRunNumber != fEvent->GetRunNumber()) { // Check run number
+    fRunNumber = fEvent->GetRunNumber();
+    SetGeometry();
+  }
+
+  const AliVVertex *vVertex = fEvent->GetPrimaryVertex();
+  fVertex[0] = vVertex->GetX();
+  fVertex[1] = vVertex->GetY();
+  fVertex[2] = vVertex->GetZ();
+
+  AliVCaloCells *cells = dynamic_cast<AliVCaloCells*>(fEvent->GetPHOSCells());
+  Int_t multClust = fEvent->GetNumberOfCaloClusters();
+
+  fPHOSObjectArray->Clear();
+
+  TLorentzVector p1,p1core;
+
+  Double_t energy=0, tof=-999, M20=0, M02=0, R2=999, coreE=0, coreR2=999;
+  Double_t TrackDx=0, TrackDz=0, TrackPt=0, r=999;
+  Int_t TrackCharge = 0;
+  Int_t trackindex=-1;
+
+  Int_t relId[4] = {};
+  Int_t module=-1, cellx=-1, cellz=-1;
+  Int_t digMult=0;
+  Float_t position[3] = {}; 
+  AliVTrack *vtrack = 0x0;
+  AliVCluster *cluster = 0x0;
+  Double_t distance=0;
+  Int_t inPHOS=0;
+  Int_t absId = -1;
+
+  for(Int_t iclu=0; iclu<multClust; iclu++){
+
+    cluster = (AliVCluster*)fEvent->GetCaloCluster(iclu);
+
+    if(cluster->GetType() != AliVCluster::kPHOSNeutral
+        || cluster->E() < 0.1 // MIP cut
+//        || cluster->GetNCells() < 2 //accidental noise, effectively remove exotic cluster
+//        || cluster->GetM02() < 0.2 //too small shower shape
+      ) continue;
+
+    distance = cluster->GetDistanceToBadChannel();
+
+    //cout << "Ncell before = " << cluster->GetNCells() << endl;
+
+    const Double32_t * elist = cluster->GetCellsAmplitudeFraction() ;
+    Double_t ei = 0;
+    Double_t eMax = 0;
+    Int_t maxAbsId = -1;
+    Int_t Ncell = cluster->GetNCells();
+    for(Int_t i=0;i<cluster->GetNCells();i++){
+      Int_t absId_tmp = cluster->GetCellAbsId(i);
+      Double_t amp = cells->GetCellAmplitude(absId_tmp);
+      //cout << "cell amplitude = " << amp << endl;
+
+      ei = elist[i]*cells->GetCellAmplitude(absId_tmp);
+
+      if(ei > eMax){
+        maxAbsId = absId_tmp;
+        eMax = ei;
+      }
+
+      if(amp < 2e-6) //less than 2 keV
+        Ncell--;
+    }
+    //cluster->SetNCells(Ncell);
+
+    //cout << "max cell amp = " << eMax << " , absId = " << maxAbsId << endl;
+
+    //if(cluster->GetNCells() < 2) continue;//accidental noise
+
+    if(distance < fMinDistBC) continue;
+
+    cluster->GetPosition(position);
+    TVector3 global1(position);
+    fPHOSGeo->GlobalPos2RelId(global1,relId);
+
+    module = relId[0];
+    cellx  = relId[2];
+    cellz  = relId[3];
+
+    if(fIsM4Excluded && module==4) continue;
+
+    if(module < 1 || 4 < module){
+      AliError(Form("Wrong module number %d",module));
+      return;
+    }
+
+    if(!fUsePHOSTender && !IsGoodChannel("PHOS",module,cellx,cellz)) continue;
+
+    //fPHOSGeo->RelToAbsNumbering(relId, absId);
+    Bool_t isHG = cells->GetCellHighGain(maxAbsId);
+    //cout << "module = " << module << " , cellx = " << cellx << " , cellz = " << cellz << " , maxAbsId = " << maxAbsId << " , isHG = " << isHG << " , e = " << cluster->E()  << endl;
+
+    energy = cluster->E();
+    digMult = cluster->GetNCells();
+    tof = cluster->GetTOF();
+    cluster->GetMomentum(p1,fVertex);
+    cluster->GetMomentum(p1core,fVertex);
+    //cout << "Ncell after = " << digMult << endl;
+
+    //cout << "energy p1 before corr = " << p1.E() << endl;
+
+    //Double_t e_before_full = p1.E();
+    p1 *= fUserNonLinCorr->Eval(p1.E());
+
+    //cout << "e before nonlin = " << energy << " , corr = " << fUserNonLinCorr->Eval(energy) << " , e after nonlin = " << p1.E() << endl;
+
+    new((*fPHOSObjectArray)[inPHOS]) AliCaloPhoton(p1.Px(),p1.Py(),p1.Pz(),p1.E());
+    AliCaloPhoton * ph = (AliCaloPhoton*)fPHOSObjectArray->At(inPHOS); 
+    ph->SetCluster(cluster);
+    ph->SetModule(module);
+    ph->SetNCells(digMult); 
+    ph->SetTime(tof);//unit of second
+    ph->SetTOFBit(TMath::Abs(tof*1e+9) < fBunchSpace/2.);
+    ph->SetDistToBad((Int_t)(distance*100));//in unit of cm * 100
+    ph->SetEMCx((Double_t)position[0]);
+    ph->SetEMCy((Double_t)position[1]);
+    ph->SetEMCz((Double_t)position[2]);
+    ph->SetWeight(1.);
+    //if(!isHG) ph->SetTOFBit(kTRUE);//force to set kTRUE to TOFBit
+
+    if(fIsMC){
+      //Int_t label = cluster->GetLabel();
+      Bool_t sure = kTRUE;
+      Int_t label = FindPrimary(ph,sure);
+      ph->SetPrimary(label);
+    }
+
+    if(fUsePHOSTender){
+      //When PHOSTender is applied, GetM20(), GetM02() returns M20,M02 of core of cluster respectively.
+      M20 = cluster->GetM20();//M20 is short axis of elliptic shower shape.
+      M02 = cluster->GetM02();//M02 is long  axis of elliptic shower shape.
+      R2 = cluster->GetDispersion();//full dispersion
+      coreE = cluster->GetCoreEnergy();
+      coreR2 = cluster->Chi2();//core dispersion
+      r = cluster->GetEmcCpvDistance();
+    }
+    else{//no tender
+      //When PHOSTender is NOT applied, GetM20(), GetM02() returns M20,M02 of full cluster respectively.
+      M20 = cluster->GetM20();//M20 is short axis of elliptic shower shape.
+      M02 = cluster->GetM02();//M02 is long  axis of elliptic shower shape.
+      R2 = TestLambda(energy,M20,M02);
+      coreE = CoreEnergy(cluster,cells);
+      EvalCoreLambdas(cluster,cells,M02,M20);
+      coreR2 = TestCoreLambda(energy,M20,M02);
+
+      vtrack = 0x0;
+      if(fESDEvent){//for ESD
+        trackindex = cluster->GetTrackMatchedIndex();
+        if(trackindex > 0){
+          vtrack = (AliVTrack*)(fEvent->GetTrack(trackindex));
+        }//end of track matching
+      }//end of track selection in ESD
+      else if(fAODEvent){//for AOD
+        if(cluster->GetNTracksMatched() > 0){
+          vtrack = dynamic_cast<AliVTrack*>(cluster->GetTrackMatched(0));
+        }//end of track matching
+      }//end of AOD
+
+      if(vtrack){
+        TrackDx = cluster->GetTrackDx();
+        TrackDz = cluster->GetTrackDz();
+        TrackPt = vtrack->Pt();
+        TrackCharge = vtrack->Charge();
+        r = TestCPVRun2(TrackDx,TrackDz,TrackPt,TrackCharge);
+
+      }//end of track matching
+      else r = 999;//no matched track
+    }
+
+    //cout << "R2 = " << R2 << endl;
+    //cout << "coreR2 = " << coreR2 << endl;
+
+    ph->SetLambdas(M20,M02);
+    ph->SetNsigmaCPV(r);
+    ph->SetNsigmaFullDisp(TMath::Sqrt(R2));
+    ph->SetNsigmaCoreDisp(TMath::Sqrt(coreR2));
+
+    //cout << "original energy = " << energy << " , original core E = " << coreE << endl;
+
+    //coreE *= fUserNonLinCorr->Eval(coreE);
+    p1core *= coreE/energy * fUserNonLinCorr->Eval(coreE); //use core energy in PbPb.
+    ph->SetMomV2(&p1core);//core energy
+
+    //cout << "corr = " << fUserNonLinCorr->Eval(coreE) << " , coreE = " << p1core.E() << endl;
+
+    inPHOS++;
+  }
+
+  AliInfo("PHOS object array name = PHOSClusterArray.");
+
+  AliVEvent* input = InputEvent();
+  TObject* outO = input->FindListObject("PHOSClusterArray");
+  TClonesArray* outS = 0;
+
+  if(!outO){
+    fPHOSObjectArray->SetName("PHOSClusterArray");
+    input->AddObject(fPHOSObjectArray);
+  }
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSObjectCreator::Terminate(Option_t *option) 
+{
+  //Called once at the end of the query
+  //fUserNonLinCorr->Draw();
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSObjectCreator::Init() 
+{
+  //Called once at the end of the query
+ 
+  //if(fPHOSObjectArray != NULL){
+  if(fPHOSObjectArray){
+    //delete fPHOSObjectArray;
+    fPHOSObjectArray = NULL;
+    //fPHOSObjectArray->Clear();
+  }
+
+  fPHOSObjectArray = new TClonesArray("AliCaloPhoton",200);
+  fPHOSObjectArray->Delete();
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSObjectCreator::InitBadMap() 
+{
+
+  AliOADBContainer badmapContainer(Form("phosBadMap"));
+  badmapContainer.InitFromFile("$ALICE_PHYSICS/OADB/PHOS/PHOSBadMaps.root","phosBadMap");
+  TObjArray *maps = (TObjArray*)badmapContainer.GetObject(fRunNumber,"phosBadMap");
+  if(!maps){
+    AliError(Form("Can not read Bad map for run %d. \n You may choose to use your map with ForceUsingBadMap().",fRunNumber)) ;
+  }
+  else{
+    AliInfo(Form("Setting PHOS bad map with name %s.",maps->GetName())) ;
+    for(Int_t mod=0; mod<6;mod++){
+      if(fPHOSBadMap[mod]) delete fPHOSBadMap[mod];
+      TH2I * h = (TH2I*)maps->At(mod);
+      if(h) fPHOSBadMap[mod]=new TH2I(*h);
+    }
+  }
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSObjectCreator::SetGeometry()
+{
+  // Initialize the PHOS geometry
+
+  if(fUsePHOSTender){
+
+    if(fRunNumber < 209122)//Run1
+      fPHOSGeo = AliPHOSGeometry::GetInstance("IHEP") ;
+    else//Run2
+      fPHOSGeo = AliPHOSGeometry::GetInstance("Run2") ;
+  }
+  else{//PHOSTender is not applied.
+    AliOADBContainer geomContainer("phosGeo");
+
+    if(fRunNumber < 209122)//Run1
+      fPHOSGeo = AliPHOSGeometry::GetInstance("IHEP") ;
+    else//Run2
+      fPHOSGeo = AliPHOSGeometry::GetInstance("Run2") ;
+
+    if(fIsMC){ //use excatly the same geometry as in simulation, stored in esd
+      if(fESDEvent){
+        for(Int_t mod=0; mod<6; mod++) {
+          const TGeoHMatrix * m = fESDEvent->GetPHOSMatrix(mod);
+          if(m){
+            fPHOSGeo->SetMisalMatrix(m,mod) ;
+            printf(".........Adding Matrix(%d), geo=%p\n",mod,fPHOSGeo);
+            m->Print();
+          }
+        }
+      }
+      else if(fAODEvent){ //To be fixed
+        geomContainer.InitFromFile("$ALICE_PHYSICS/OADB/PHOS/PHOSMCGeometry.root","PHOSMCRotationMatrixes");
+        TObjArray *matrixes = (TObjArray*)geomContainer.GetObject(fRunNumber,"PHOSRotationMatrixes");
+        for(Int_t mod=0; mod<6; mod++){
+          if(!matrixes->At(mod)) continue;
+          fPHOSGeo->SetMisalMatrix(((TGeoHMatrix*)matrixes->At(mod)),mod);
+          printf(".........Adding Matrix(%d), geo=%p\n",mod,fPHOSGeo);
+          ((TGeoHMatrix*)matrixes->At(mod))->Print();
+        }
+      }
+    }//end of MC
+    else{ //Use best approaximation to real geometry
+      geomContainer.InitFromFile("$ALICE_PHYSICS/OADB/PHOS/PHOSGeometry.root","PHOSRotationMatrixes");
+      TObjArray *matrixes = (TObjArray*)geomContainer.GetObject(fRunNumber,"PHOSRotationMatrixes");
+      for(Int_t mod=0; mod<6; mod++){
+        if(!matrixes->At(mod)) continue;
+        fPHOSGeo->SetMisalMatrix(((TGeoHMatrix*)matrixes->At(mod)),mod);
+        printf(".........Adding Matrix(%d), geo=%p\n",mod,fPHOSGeo);
+        ((TGeoHMatrix*)matrixes->At(mod))->Print();
+      }
+    }//end of real data
+  }
+
+}
+//________________________________________________________________________
+Bool_t AliAnalysisTaskPHOSObjectCreator::IsGoodChannel(const char * det, Int_t mod, Int_t ix, Int_t iz)
+{
+  //Check if this channel belogs to the good ones
+
+  if(strcmp(det,"PHOS")==0){
+    if(mod>5 || mod<1){
+      AliError(Form("No bad map for PHOS module %d ",mod)) ;
+      return kTRUE ;
+    }
+    if(!fPHOSBadMap[mod]){
+      AliError(Form("No Bad map for PHOS module %d",mod)) ;
+      return kTRUE ;
+    }
+    if(fPHOSBadMap[mod]->GetBinContent(ix,iz)>0)
+      return kFALSE ;
+    else
+      return kTRUE ;
+  }
+  else{
+    AliError(Form("Can not find bad channels for detector %s ",det)) ;
+  }
+  return kTRUE ;
+}
+//________________________________________________________________________
+Double_t AliAnalysisTaskPHOSObjectCreator::TestCPVRun2(Double_t dx, Double_t dz, Double_t pt, Int_t charge)
+{
+  //Parameterization of LHC15o period
+  //_true if neutral_
+
+  Double_t meanX=0.;
+  Double_t meanZ=0.;
+
+  Double_t sx = TMath::Min(5.2, 1.160 + 0.52 * TMath::Exp(-0.042 * pt*pt) + 5.1/TMath::Power(pt+0.62,3));
+  Double_t sz = TMath::Min(3.3, 1.10  + 0.39 * TMath::Exp(-0.027 * pt*pt) + 0.70 /TMath::Power(pt+0.223,3));
+
+  Double_t mf1 = fEvent->GetMagneticField(); //Positive for ++ and negative for --
+
+  if(mf1<0.){ //field --
+    meanZ = 0.077;
+    if(charge>0)
+      meanX =  TMath::Min(5.8, 0.2 + 0.7 * TMath::Exp(-0.019 * pt*pt) + 34./TMath::Power(pt+1.39,3));
+    else
+      meanX = -TMath::Min(5.8, 0.1 + 0.7 * TMath::Exp(-0.014 * pt*pt) + 30./TMath::Power(pt+1.36,3));
+  }
+  else{ //Field ++
+    meanZ= 0.077;
+    if(charge>0)
+      meanX = -TMath::Min(5.8, 0.3 + 0.7 * TMath::Exp(-0.012 * pt*pt) + 35./TMath::Power(pt+1.43,3));
+    else
+      meanX =  TMath::Min(5.8, 0.2 + 0.6 * TMath::Exp(-0.014 * pt*pt) + 28./TMath::Power(pt+1.27,3));
+  }
+
+  Double_t rz=(dz-meanZ)/sz ;
+  Double_t rx=(dx-meanX)/sx ;
+  return TMath::Sqrt(rx*rx+rz*rz) ;
+
+}
+//________________________________________________________________________
+Double_t AliAnalysisTaskPHOSObjectCreator::TestLambda(Double_t e,Double_t l1,Double_t l2)
+{
+  Double_t l2Mean = 1.53126+9.50835e+06/(1.+1.08728e+07*e+1.73420e+06*e*e) ;
+  Double_t l1Mean = 1.12365+0.123770*TMath::Exp(-e*0.246551)+5.30000e-03*e ;
+  Double_t l2Sigma = 6.48260e-02+7.60261e+10/(1.+1.53012e+11*e+5.01265e+05*e*e)+9.000e-03*e;
+  Double_t l1Sigma = 4.44719e-04+6.99839e-01/(1.+1.22497e+00*e+6.78604e-07*e*e)+9.000e-03*e;
+  Double_t c=-0.35-0.550*TMath::Exp(-0.390730*e) ;
+  Double_t R2=0.5*(l1-l1Mean)*(l1-l1Mean)/l1Sigma/l1Sigma +
+    0.5*(l2-l2Mean)*(l2-l2Mean)/l2Sigma/l2Sigma +
+    0.5*c*(l1-l1Mean)*(l2-l2Mean)/l1Sigma/l2Sigma ;
+
+  return R2;
+}
+//________________________________________________________________________
+Double_t AliAnalysisTaskPHOSObjectCreator::TestCoreLambda(Double_t e, Double_t l1, Double_t l2)
+{
+  //Evaluates if lambdas correspond to photon cluster
+  //Tuned using pp date
+  //For core radius R=4.5
+
+  Double_t   l1Mean  = 1.150200 + 0.097886/(1.+1.486645*e+0.000038*e*e) ;
+  Double_t   l2Mean = 1.574706 + 0.997966*exp(-0.895075*e)-0.010666*e ;
+  Double_t   l1Sigma = 0.100255 + 0.337177*exp(-0.517684*e)+0.001170*e ;
+  Double_t   l2Sigma = 0.232580 + 0.573401*exp(-0.735903*e)-0.002325*e ;
+  Double_t   c = -0.110983 -0.017353/(1.-1.836995*e+0.934517*e*e) ;
+
+  Double_t R2=0.5*(l1-l1Mean)*(l1-l1Mean)/l1Sigma/l1Sigma +
+              0.5*(l2-l2Mean)*(l2-l2Mean)/l2Sigma/l2Sigma +
+              0.5*c*(l1-l1Mean)*(l2-l2Mean)/l1Sigma/l2Sigma ;
+  return R2 ;
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSObjectCreator::EvalCoreLambdas(AliVCluster *clu, AliVCaloCells *cells,Double_t &m02, Double_t &m20)
+{
+  //calculate dispecrsion of the cluster in the circle with radius distanceCut around the maximum
+
+  const Double_t rCut=4.5;
+
+  const Double32_t *elist = clu->GetCellsAmplitudeFraction();
+  //Calculates the center of gravity in the local PHOS-module coordinates
+  Float_t wtot = 0;
+  const Int_t mulDigit=clu->GetNCells() ;
+  Double_t xc[mulDigit] ;
+  Double_t zc[mulDigit] ;
+  Double_t wi[mulDigit] ;
+  Double_t x = 0 ;
+  Double_t z = 0 ;
+  const Double_t logWeight=4.5 ;
+  for(Int_t iDigit=0; iDigit<mulDigit; iDigit++) {
+    Int_t relid[4] ;
+    Float_t xi=0. ;
+    Float_t zi=0. ;
+    Int_t absId = clu->GetCellAbsId(iDigit) ;
+    fPHOSGeo->AbsToRelNumbering(absId, relid) ;
+    fPHOSGeo->RelPosInModule(relid, xi, zi);
+    xc[iDigit]=xi ;
+    zc[iDigit]=zi ;
+    Double_t ei = elist[iDigit]*cells->GetCellAmplitude(absId) ;
+    wi[iDigit]=0. ;
+    if (clu->E()>0 && ei>0) {
+      wi[iDigit] = TMath::Max( 0., logWeight + TMath::Log( ei / clu->E() ) ) ;
+      Double_t w=wi[iDigit];
+      x    += xc[iDigit] * w ;
+      z    += zc[iDigit] * w ;
+      wtot += w ;
+    }
+  }
+  if (wtot>0) {
+    x /= wtot ;
+    z /= wtot ;
+  }
+
+  wtot = 0. ;
+  Double_t dxx  = 0.;
+  Double_t dzz  = 0.;
+  Double_t dxz  = 0.;
+  Double_t xCut = 0.;
+  Double_t zCut = 0.;
+
+  for(Int_t iDigit=0; iDigit<mulDigit; iDigit++) {
+    Double_t w=wi[iDigit];
+    if(w>0.) {
+      Double_t xi= xc[iDigit] ;
+      Double_t zi= zc[iDigit] ;
+
+      if((xi-x)*(xi-x)+(zi-z)*(zi-z) < rCut*rCut){
+        xCut += w * xi ;
+        zCut += w * zi ;
+        dxx  += w * xi * xi ;
+        dzz  += w * zi * zi ;
+        dxz  += w * xi * zi ;
+        wtot += w ;
+      }
+    }
+
+  }
+  if(wtot>0) {
+    xCut/= wtot ;
+    zCut/= wtot ;
+    dxx /= wtot ;
+    dzz /= wtot ;
+    dxz /= wtot ;
+    dxx -= xCut * xCut ;
+    dzz -= zCut * zCut ;
+    dxz -= xCut * zCut ;
+
+    m02 =  0.5 * (dxx + dzz) + TMath::Sqrt( 0.25 * (dxx - dzz) * (dxx - dzz) + dxz * dxz )  ;
+    m20 =  0.5 * (dxx + dzz) - TMath::Sqrt( 0.25 * (dxx - dzz) * (dxx - dzz) + dxz * dxz )  ;
+  }
+  else {
+    m20=m02=0.;
+  }
+
+}
+//________________________________________________________________________
+Double_t AliAnalysisTaskPHOSObjectCreator::CoreEnergy(AliVCluster *clu, AliVCaloCells *cells)
+{
+  //calculate energy of the cluster in the circle with radius distanceCut around the maximum
+
+  //Can not use already calculated coordinates?
+  //They have incidence correction...
+  const Double_t distanceCut =3.5;//default value
+  const Double_t logWeight=4.5;
+
+  const Double32_t * elist = clu->GetCellsAmplitudeFraction() ;
+// Calculates the center of gravity in the local PHOS-module coordinates
+  Float_t wtot = 0;
+  const Int_t mulDigit=clu->GetNCells() ;
+  Double_t xc[mulDigit] ;
+  Double_t zc[mulDigit] ;
+  Double_t ei[mulDigit] ;
+  Double_t x = 0 ;
+  Double_t z = 0 ;
+  for(Int_t iDigit=0; iDigit<mulDigit; iDigit++) {
+    Int_t relid[4] ;
+    Float_t xi ;
+    Float_t zi ;
+    fPHOSGeo->AbsToRelNumbering(clu->GetCellAbsId(iDigit), relid) ;
+    fPHOSGeo->RelPosInModule(relid, xi, zi);
+    xc[iDigit]=xi ;
+    zc[iDigit]=zi ;
+    ei[iDigit]=elist[iDigit]*cells->GetCellAmplitude(clu->GetCellsAbsId()[iDigit]);
+
+    if( fDebug >= 3 )
+      printf("%f ",ei[iDigit]);
+    if (clu->E()>0 && ei[iDigit]>0) {
+      Float_t w = TMath::Max( 0., logWeight + TMath::Log( ei[iDigit] / clu->E() ) ) ;
+      x    += xc[iDigit] * w ;
+      z    += zc[iDigit] * w ;
+      wtot += w ;
+    }
+  }
+  if (wtot>0) {
+    x /= wtot ;
+    z /= wtot ;
+  }
+  Double_t coreE=0. ;
+  for(Int_t iDigit=0; iDigit < mulDigit; iDigit++) {
+    Double_t distance = TMath::Sqrt((xc[iDigit]-x)*(xc[iDigit]-x)+(zc[iDigit]-z)*(zc[iDigit]-z)) ;
+    if(distance < distanceCut)
+      coreE += ei[iDigit] ;
+  }
+
+  //Apply non-linearity correction
+  return fNonLinCorr->Eval(coreE);
+}
+//________________________________________________________________________
+Double_t AliAnalysisTaskPHOSObjectCreator::CoreEnergy(AliVCluster *clu)
+{
+ //calculate energy of the cluster in the circle with radius distanceCut around the maximum
+
+  //Can not use already calculated coordinates?
+  //They have incidence correction...
+  const Double_t distanceCut =3.5 ;
+  const Double_t logWeight=4.5 ;
+
+  Double32_t * elist = clu->GetCellsAmplitudeFraction() ;
+// Calculates the center of gravity in the local PHOS-module coordinates
+  Float_t wtot = 0;
+  Double_t xc[100]={0} ;
+  Double_t zc[100]={0} ;
+  Double_t x = 0 ;
+  Double_t z = 0 ;
+  Int_t mulDigit=TMath::Min(100,clu->GetNCells()) ;
+  for(Int_t iDigit=0; iDigit<mulDigit; iDigit++) {
+    Int_t relid[4] ;
+    Float_t xi ;
+    Float_t zi ;
+    fPHOSGeo->AbsToRelNumbering(clu->GetCellAbsId(iDigit), relid) ;
+    fPHOSGeo->RelPosInModule(relid, xi, zi);
+    xc[iDigit]=xi ;
+    zc[iDigit]=zi ;
+    if (clu->E()>0 && elist[iDigit]>0) {
+      Float_t w = TMath::Max( 0., logWeight + TMath::Log( elist[iDigit] / clu->E() ) ) ;
+      x    += xc[iDigit] * w ;
+      z    += zc[iDigit] * w ;
+      wtot += w ;
+    }
+  }
+  if (wtot>0) {
+    x /= wtot ;
+    z /= wtot ;
+  }
+  Double_t coreE=0. ;
+  for(Int_t iDigit=0; iDigit < mulDigit; iDigit++) {
+    Double_t distance = TMath::Sqrt((xc[iDigit]-x)*(xc[iDigit]-x)+(zc[iDigit]-z)*(zc[iDigit]-z)) ;
+    if(distance < distanceCut)
+      coreE += elist[iDigit] ;
+  }
+  //Apply non-linearity correction
+  return coreE ;
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSObjectCreator::EvalLambdas(AliVCluster * clu, Double_t &m02, Double_t &m20)
+{
+  //calculate dispecrsion of the cluster in the circle with radius distanceCut around the maximum
+
+  const Double_t rCut=4.5 ;
+
+  Double32_t * elist = clu->GetCellsAmplitudeFraction() ;
+// Calculates the center of gravity in the local PHOS-module coordinates
+  Float_t wtot = 0;
+  Double_t xc[100]={0} ;
+  Double_t zc[100]={0} ;
+  Double_t x = 0 ;
+  Double_t z = 0 ;
+  Int_t mulDigit=TMath::Min(100,clu->GetNCells()) ;
+  const Double_t logWeight=4.5 ;
+  for(Int_t iDigit=0; iDigit<mulDigit; iDigit++) {
+    Int_t relid[4] ;
+    Float_t xi ;
+    Float_t zi ;
+    fPHOSGeo->AbsToRelNumbering(clu->GetCellAbsId(iDigit), relid) ;
+    fPHOSGeo->RelPosInModule(relid, xi, zi);
+    xc[iDigit]=xi ;
+    zc[iDigit]=zi ;
+    if (clu->E()>0 && elist[iDigit]>0) {
+      Float_t w = TMath::Max( 0., logWeight + TMath::Log( elist[iDigit] / clu->E() ) ) ;
+      x    += xc[iDigit] * w ;
+      z    += zc[iDigit] * w ;
+      wtot += w ;
+    }
+  }
+  if (wtot>0) {
+    x /= wtot ;
+    z /= wtot ;
+  }
+
+  wtot = 0. ;
+  Double_t dxx  = 0.;
+  Double_t dzz  = 0.;
+  Double_t dxz  = 0.;
+  Double_t xCut = 0. ;
+  Double_t zCut = 0. ;
+  for(Int_t iDigit=0; iDigit<mulDigit; iDigit++) {
+    if (clu->E()>0 && elist[iDigit]>0.) {
+        Double_t w = TMath::Max( 0., logWeight + TMath::Log( elist[iDigit] / clu->E() ) ) ;
+        Double_t xi= xc[iDigit] ;
+        Double_t zi= zc[iDigit] ;
+  if((xi-x)*(xi-x)+(zi-z)*(zi-z) < rCut*rCut){
+          xCut += w * xi ;
+          zCut += w * zi ;
+          dxx  += w * xi * xi ;
+          dzz  += w * zi * zi ;
+          dxz  += w * xi * zi ;
+          wtot += w ;
+  }
+    }
+
+  }
+
+ if (wtot>0) {
+    xCut/= wtot ;
+    zCut/= wtot ;
+    dxx /= wtot ;
+    dzz /= wtot ;
+    dxz /= wtot ;
+    dxx -= xCut * xCut ;
+    dzz -= zCut * zCut ;
+    dxz -= xCut * zCut ;
+
+    m02 =  0.5 * (dxx + dzz) + TMath::Sqrt( 0.25 * (dxx - dzz) * (dxx - dzz) + dxz * dxz )  ;
+    m20 =  0.5 * (dxx + dzz) - TMath::Sqrt( 0.25 * (dxx - dzz) * (dxx - dzz) + dxz * dxz )  ;
+  }
+  else {
+    m20=m02=0.;
+  }
+
+}
+//________________________________________________________________________
+Int_t AliAnalysisTaskPHOSObjectCreator::FindTrackMatching(Int_t mod,TVector3 *locpos, Double_t &dx, Double_t &dz, Double_t &pt,Int_t &charge)
+{
+  //Find track with closest extrapolation to cluster
+  AliESDEvent *esd = fESDEvent;
+  AliAODEvent *aod = fAODEvent;
+
+  if(!esd && !aod){
+    AliError("Neither AOD nor ESD was found") ;
+    return -1;
+  }
+  Double_t  magF =0.;
+   if(esd)
+     magF = esd->GetMagneticField();
+   if(aod)
+     magF = aod->GetMagneticField();
+
+  Double_t magSign = 1.0;
+  if(magF<0)magSign = -1.0;
+
+  if (!TGeoGlobalMagField::Instance()->GetField()) {
+    AliError("Margnetic filed was not initialized, use default") ;
+    AliMagF* field = new AliMagF("Maps","Maps", magSign, magSign, AliMagF::k5kG);
+    TGeoGlobalMagField::Instance()->SetField(field);
+  }
+
+  // *** Start the matching
+  Int_t nt = 0;
+  if(esd)
+    nt = esd->GetNumberOfTracks();
+  else
+    nt = aod->GetNumberOfTracks();
+
+  //Calculate actual distance to PHOS module
+  TVector3 globaPos ;
+  fPHOSGeo->Local2Global(mod, 0.,0., globaPos) ;
+  const Double_t rPHOS = globaPos.Pt() ; //Distance to center of  PHOS module
+  const Double_t kYmax = 72.+10. ; //Size of the module (with some reserve) in phi direction
+  const Double_t kZmax = 64.+10. ; //Size of the module (with some reserve) in z direction
+  const Double_t kAlpha0=330./180.*TMath::Pi() ; //First PHOS module angular direction
+  const Double_t kAlpha= 20./180.*TMath::Pi() ; //PHOS module angular size
+  Double_t minDistance = 1.e6;
+
+  Double_t gposTrack[3] ;
+
+  Double_t bz = ((AliMagF*)TGeoGlobalMagField::Instance()->GetField())->SolenoidField();
+  bz = TMath::Sign(0.5*kAlmost0Field,bz) + bz;
+
+  Double_t b[3];
+  Int_t itr=-1 ;
+  AliESDtrack *esdTrack=0x0 ;
+  AliAODTrack *aodTrack=0x0 ;
+  Double_t xyz[3] = {0}, pxpypz[3] = {0}, cv[21] = {0};
+  for (Int_t i=0; i<nt; i++) {
+      if(esd)
+        esdTrack=esd->GetTrack(i);
+      else
+        aodTrack=(AliAODTrack*)aod->GetTrack(i);
+
+      // Skip the tracks having "wrong" status (has to be checked/tuned)
+      if(esd){
+        ULong_t status = esdTrack->GetStatus();
+        if((status & AliESDtrack::kTPCout) == 0) continue;
+      }
+      else{
+
+
+      }
+
+
+      //Continue extrapolation from TPC outer surface
+      AliExternalTrackParam outerParam;
+      if(esdTrack){
+          outerParam = *(esdTrack->GetOuterParam());
+      }
+      if(aodTrack){
+        aodTrack->GetPxPyPz(pxpypz);
+        aodTrack->GetXYZ(xyz);
+        aodTrack->GetCovarianceXYZPxPyPz(cv);
+        outerParam.Set(xyz,pxpypz,cv,aodTrack->Charge());
+      }
+
+      Double_t z;
+      if(!outerParam.GetZAt(rPHOS,bz,z))
+        continue ;
+
+      if (TMath::Abs(z) > kZmax)
+        continue; // Some tracks miss the PHOS in Z
+
+  //Direction to the current PHOS module
+      Double_t phiMod=kAlpha0-kAlpha*mod ;
+      if(!outerParam.RotateParamOnly(phiMod)) continue ; //RS use faster rotation if errors are not needed
+
+      Double_t y;                       // Some tracks do not reach the PHOS
+      if (!outerParam.GetYAt(rPHOS,bz,y)) continue; //    because of the bending
+
+      if(TMath::Abs(y) < kYmax){
+        outerParam.GetBxByBz(b) ;
+        outerParam.PropagateToBxByBz(rPHOS,b);        // Propagate to the matching module
+        //outerParam.CorrectForMaterial(...); // Correct for the TOF material, if needed
+        outerParam.GetXYZ(gposTrack) ;
+        TVector3 globalPositionTr(gposTrack) ;
+        TVector3 localPositionTr ;
+        fPHOSGeo->Global2Local(localPositionTr,globalPositionTr,mod) ;
+        Double_t ddx = locpos->X()-localPositionTr.X();
+        Double_t ddz = locpos->Z()-localPositionTr.Z();
+        Double_t d2 = ddx*ddx + ddz*ddz;
+        if(d2 < minDistance) {
+    dx = ddx ;
+      dz = ddz ;
+    minDistance=d2 ;
+    itr=i ;
+          if(esdTrack){
+            pt=esdTrack->Pt() ;
+      charge=esdTrack->Charge() ;
+          }
+          else{
+           pt=aodTrack->Pt() ;
+           charge=aodTrack->Charge() ;
+          }
+        }
+      }
+    }//Scanned all tracks
+
+   return itr ;
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSObjectCreator::DistanceToBadChannel(Int_t mod, TVector3 * locPos, Double_t &minDist)
+{
+ //Check if distance to bad channel was reduced
+  Int_t range = minDist/2.2 +1 ; //Distance at which bad channels should be serached
+
+  Int_t relid[4]={0,0,0,0} ;
+  fPHOSGeo->RelPosToRelId(mod, locPos->X(), locPos->Z(), relid) ;
+  Int_t xmin=TMath::Max(1,relid[2]-range) ;
+  Int_t xmax=TMath::Min(64,relid[2]+range) ;
+  Int_t zmin=TMath::Max(1,relid[3]-range) ;
+  Int_t zmax=TMath::Min(56,relid[3]+range) ;
+
+  Float_t x=0.,z=0.;
+  for(Int_t ix=xmin;ix<=xmax;ix++){
+    for(Int_t iz=zmin;iz<=zmax;iz++){
+      if(fPHOSBadMap[mod] && fPHOSBadMap[mod]->GetBinContent(ix,iz)>0){ //Bad channel
+        Int_t relidBC[4]={mod,0,ix,iz} ;
+        fPHOSGeo->RelPosInModule(relidBC,x,z);
+        Double_t dist = TMath::Sqrt((x-locPos->X())*(x-locPos->X()) + (z-locPos->Z())*(z-locPos->Z()));
+        if(dist<minDist) minDist = dist;
+      }
+    }
+  }
+
+}
+//________________________________________________________________________
+Int_t AliAnalysisTaskPHOSObjectCreator::FindPrimary(AliCaloPhoton *ph,  Bool_t&sure)
+{
+  //Finds primary and estimates if it unique one?
+  //First check can it be photon/electron
+  AliVCluster *clu = (AliVCluster*)ph->GetCluster();
+  const Double_t emFraction=0.9; //part of energy of cluster to be assigned to EM particle
+  Int_t n = clu->GetNLabels();
+
+  for(Int_t i=0;  i<n;  i++){
+    Int_t label = clu->GetLabelAt(i);
+    AliAODMCParticle*  p =  (AliAODMCParticle*)fMCArrayAOD->At(label);
+    Int_t pdg = p->PdgCode() ;
+    if(pdg==22  ||  pdg==11 || pdg == -11){
+      if(p->E()>emFraction*clu->E()){
+        sure=kTRUE ;
+        return label;
+      }
+    }
+  }
+
+  Double_t*  Ekin=  new  Double_t[n] ;
+
+  for(Int_t i=0;  i<n;  i++){
+    Int_t label = clu->GetLabelAt(i);
+    AliAODMCParticle* p = (AliAODMCParticle*)fMCArrayAOD->At(label);
+    Ekin[i]=p->P() ;  // estimate of kinetic energy
+    if(p->PdgCode()==-2212  ||  p->PdgCode()==-2112){
+      Ekin[i]+=1.8  ;  //due to annihilation
+    }
+  }
+  Int_t iMax=0;
+  Double_t eMax=0.,eSubMax=0. ;
+  for(Int_t i=0;  i<n;  i++){
+    if(Ekin[i]>eMax){
+      eSubMax=eMax;
+      eMax=Ekin[i];
+      iMax=i;
+    }
+  }
+  if(eSubMax>0.8*eMax)//not obvious primary
+    sure=kFALSE;
+  else
+    sure=kTRUE;
+  delete[]  Ekin;
+  return clu->GetLabelAt(iMax);
+}
+
+//________________________________________________________________________
+

--- a/PWGGA/PHOSTasks/PHOS_Run2/AliAnalysisTaskPHOSObjectCreator.h
+++ b/PWGGA/PHOSTasks/PHOS_Run2/AliAnalysisTaskPHOSObjectCreator.h
@@ -1,0 +1,89 @@
+#ifndef AliAnalysisTaskPHOSObjectCreator_cxx
+#define AliAnalysisTaskPHOSObjectCreator_cxx
+
+// Author: Daiki Sekihata (Hiroshima University)
+class TF1;
+class TObjArray;
+class TClonesArray;
+class AliPHOSGeometry;
+class TParticle;
+class AliStack;
+
+#include "AliAnalysisTaskSE.h"
+
+class AliAnalysisTaskPHOSObjectCreator : public AliAnalysisTaskSE {
+  public:
+
+    AliAnalysisTaskPHOSObjectCreator(const char *name = "PHOSObjectCreator");
+    virtual ~AliAnalysisTaskPHOSObjectCreator(); 
+
+    //AnalysisTaskSE method is overloaded.
+    void UserCreateOutputObjects();
+    void UserExec(Option_t *option);
+    void Terminate(Option_t *option);
+    //at least, these 3 functions above are necessary.
+
+    void SetTenderFlag(Bool_t tender) {fUsePHOSTender = tender;}
+    void SetMCFlag(Bool_t mc) {fIsMC = mc;}
+    void SetBunchSpace(Double_t bs) {fBunchSpace = bs;}
+    void SetMinimumDistanceFromBC(Double_t dist) {fMinDistBC = dist;}
+
+    void SetPHOSBadMap(Int_t mod,TH2I *h)
+    {
+      if(fPHOSBadMap[mod]) delete fPHOSBadMap[mod];
+      fPHOSBadMap[mod] = new TH2I(*h);
+      AliInfo(Form("Setting Bad Map Histogram  %s",fPHOSBadMap[mod]->GetName()));
+    }
+    TString GetObjectArrayName() {return fObjectArrayName;}
+
+    void SetUserDefinedNonlinearity(TF1 *f1nonlin) {fUserNonLinCorr = f1nonlin;}
+    void ExcludeM4(Bool_t flag) {fIsM4Excluded = flag;}
+
+  protected:
+    void Init();
+    void InitBadMap();//this is for internal
+
+    void SetGeometry();
+    Bool_t IsGoodChannel(const char * det, Int_t mod,Int_t ix, Int_t iz);
+    Double_t TestCPVRun2(Double_t dx, Double_t dz, Double_t pt, Int_t charge);
+    Double_t TestLambda(Double_t e,Double_t l1,Double_t l2);
+    Double_t TestCoreLambda(Double_t e,Double_t l1,Double_t l2);
+    void EvalCoreLambdas(AliVCluster * clu, AliVCaloCells * cells, Double_t &m02, Double_t &m20);
+    void EvalLambdas(AliVCluster * clu, Double_t &m02, Double_t &m20);
+    Double_t CoreEnergy(AliVCluster *clu, AliVCaloCells *cells);
+    Double_t CoreEnergy(AliVCluster *clu);
+    Int_t FindTrackMatching(Int_t mod,TVector3 *locpos,Double_t &dx, Double_t &dz, Double_t &pttrack, Int_t &charge);
+    void DistanceToBadChannel(Int_t mod, TVector3 * locPos, Double_t &minDist) ;
+    //Int_t FindHighestAmplitudeCellAbsId(AliVCluster *clu, AliVCaloCells *cells);
+    Int_t FindPrimary(AliCaloPhoton *ph,  Bool_t&sure);
+
+  protected:
+    AliVEvent *fEvent;
+    AliAODEvent *fAODEvent;
+    AliESDEvent *fESDEvent;
+    Double_t fVertex[3];
+    TClonesArray *fPHOSObjectArray;
+    AliPHOSGeometry *fPHOSGeo;
+    TH2I *fPHOSBadMap[6];
+    TF1 *fNonLinCorr;
+    TF1 *fUserNonLinCorr;
+    Int_t fRunNumber;
+    Bool_t fUsePHOSTender;
+    Bool_t fIsMC;
+    Double_t fBunchSpace;
+    Double_t fMinDistBC;
+    TString fObjectArrayName;
+    AliStack *fMCArrayESD;
+    TClonesArray *fMCArrayAOD;
+    Bool_t fIsM4Excluded;
+
+
+  private:
+    AliAnalysisTaskPHOSObjectCreator(const AliAnalysisTaskPHOSObjectCreator&);
+    AliAnalysisTaskPHOSObjectCreator& operator=(const AliAnalysisTaskPHOSObjectCreator&);
+
+    ClassDef(AliAnalysisTaskPHOSObjectCreator, 10);
+};
+
+#endif
+

--- a/PWGGA/PHOSTasks/PHOS_Run2/AliAnalysisTaskPHOSPi0EtaToGammaGamma.cxx
+++ b/PWGGA/PHOSTasks/PHOS_Run2/AliAnalysisTaskPHOSPi0EtaToGammaGamma.cxx
@@ -1,0 +1,3134 @@
+#include "TChain.h"
+#include "TTree.h"
+#include "TObjArray.h"
+#include "TClonesArray.h"
+#include "TF1.h"
+#include "TH1.h"
+#include "TH2.h"
+#include "TH3.h"
+#include "TProfile.h"
+#include "TVector3.h"
+#include "TLorentzVector.h"
+#include "TParticle.h"
+#include "THnSparse.h"
+#include "TList.h"
+#include "THashList.h"
+#include "TMath.h"
+
+#include "AliInputEventHandler.h"
+#include "AliAnalysisManager.h"
+#include "AliAnalysisTaskSE.h"
+#include "AliLog.h"
+
+#include "AliCaloPhoton.h"
+#include "AliPHOSGeometry.h"
+
+#include "AliESDtrackCuts.h"
+#include "AliESDHeader.h"
+#include "AliESDEvent.h"
+#include "AliESDVZERO.h"
+#include "AliESDTZERO.h"
+#include "AliESDCaloCells.h"
+#include "AliESDCaloCluster.h"
+#include "AliESDVertex.h"
+#include "AliESDtrack.h"
+
+#include "AliVEvent.h"
+#include "AliVHeader.h"
+#include "AliVTrack.h"
+#include "AliVCluster.h"
+#include "AliVCaloCells.h"
+#include "AliMultSelection.h"
+#include "AliEventplane.h"
+
+#include "AliPID.h"
+#include "AliPIDResponse.h"
+
+#include "AliT0digit.h"
+#include "AliAODMCHeader.h"
+#include "AliAODHeader.h"
+#include "AliAODEvent.h"
+#include "AliAODVZERO.h"
+#include "AliAODTZERO.h"
+#include "AliAODCaloCells.h"
+#include "AliAODCaloCluster.h"
+#include "AliAODVertex.h"
+#include "AliAODTrack.h"
+#include "AliAODMCParticle.h"
+#include "AliAODInputHandler.h"
+
+#include "AliMCEventHandler.h"
+#include "AliMCEvent.h"
+#include "AliStack.h"
+
+#include "AliPHOSCalibData.h"
+#include "AliCDBManager.h"
+#include "AliCDBEntry.h"
+#include "AliCDBMetaData.h"
+#include "AliPHOSAodCluster.h"
+#include "AliPHOSEsdCluster.h"
+#include "AliOADBContainer.h"
+//#include "AliEventCuts.h"
+
+#include "AliGenEventHeader.h"
+#include "AliGenPythiaEventHeader.h"
+#include "AliGenCocktailEventHeader.h"
+
+#include "AliPHOSEventCuts.h"
+#include "AliPHOSClusterCuts.h"
+#include "AliPHOSJetJetMC.h"
+#include "AliPHOSTriggerHelper.h"
+#include "AliAnalysisTaskPHOSPi0EtaToGammaGamma.h"
+
+// Author: Daiki Sekihata (Hiroshima University)
+
+ClassImp(AliAnalysisTaskPHOSPi0EtaToGammaGamma)
+
+//________________________________________________________________________
+AliAnalysisTaskPHOSPi0EtaToGammaGamma::AliAnalysisTaskPHOSPi0EtaToGammaGamma(const char *name):
+  AliAnalysisTaskSE(name),
+	fIsMC(kFALSE),
+  fIsJJMC(kFALSE),
+  fPtHardBin(-1),
+	fUsePHOSTender(kFALSE),
+  fUseCoreEnergy(kFALSE),
+  fPHOSEventCuts(0x0),
+  fPHOSClusterCuts(0x0),
+  fBunchSpace(25.),
+  fCentEdges(0),
+  fCentNMixed(0),
+  fCollisionSystem(-1),
+  fTOFEfficiency(0x0),
+  fESDtrackCutsGlobal(0x0),
+  fESDtrackCutsGlobalConstrained(0x0),
+  fAdditionalPi0PtWeight(0x0),
+  fAdditionalK0SPtWeight(0x0),
+
+  fOutputContainer(0x0),
+  fEvent(0x0),
+  fESDEvent(0x0),
+  fAODEvent(0x0),
+  fMCArrayESD(0x0),
+  fMCArrayAOD(0x0),
+  fJJMCHandler(0x0),
+  fRunNumber(0),
+  fPHOSGeo(0x0),
+  fPHOSClusterArray(NULL),
+  fEstimator("V0M"),
+  fMultSelection(0x0),
+  fCentralityV0M(0),
+  fCentralityCL0(0),
+  fCentralityCL1(0),
+  fCentralityV0A(0),
+  fCentralityV0C(0),
+  fCentralityZNA(0),
+  fCentralityZNC(0),
+  fCentralityMain(0),
+  fZvtx(-1),
+  fCenBin(-1),
+  fNHybridTrack(0),
+  fIsNonLinStudyNeeded(kFALSE)
+ // fEventCuts(0x0)
+{
+  // Constructor
+
+  for(Int_t i=0;i<10;i++){
+    for(Int_t j=0;j<10;j++){
+      fPHOSEvents[i][j] = 0;
+    }
+  }
+
+  for(Int_t i=0;i<3;i++){
+    fVertex[i] = 0;
+  }
+
+  for(Int_t i=0;i<7;i++){
+    for(Int_t j=0;j<7;j++){
+      for(Int_t k=0;k<7;k++){
+        fNonLin[i][j][k] = 0x0;
+      }
+    }
+  }
+  //fEventCuts = new AliEventCuts(kFALSE); 
+  // Define input and output slots here
+  // Input slot #0 works with a TChain
+  DefineInput(0, TChain::Class());
+  // Output slot #0 id reserved by the base class for AOD
+  // Output slot #1 writes into a TH1 container
+  DefineOutput(1, THashList::Class());
+
+}
+//________________________________________________________________________
+AliAnalysisTaskPHOSPi0EtaToGammaGamma::~AliAnalysisTaskPHOSPi0EtaToGammaGamma()
+{
+  for(Int_t i=0;i<10;i++){
+    for(Int_t j=0;j<10;j++){
+      if(fPHOSEvents[i][j]){
+        delete fPHOSEvents[i][j];
+        fPHOSEvents[i][j] = 0;
+      }
+    }
+  }
+
+  if(fIsNonLinStudyNeeded){
+    for(Int_t i=0;i<7;i++){
+      for(Int_t j=0;j<7;j++){
+        for(Int_t k=0;k<7;k++){
+          delete fNonLin[i][j][k];
+          fNonLin[i][j][k] = 0;
+        }
+      }
+    }
+  }
+
+  //delete fEventCuts;
+  if(fJJMCHandler) delete fJJMCHandler;
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::UserCreateOutputObjects()
+{
+  // Create histograms
+  // Called once
+
+  fOutputContainer = new THashList();
+  fOutputContainer->SetOwner(kTRUE);
+
+  //fEventCuts.AddQAplotsToList(fOutputContainer); /// fList is your output TList
+
+  TH1F *hEventSummary = new TH1F("hEventSummary","Event Summary",10,0.5,10.5);
+  hEventSummary->GetXaxis()->SetBinLabel(1,"all");
+  hEventSummary->GetXaxis()->SetBinLabel(2,"selected");
+  hEventSummary->GetXaxis()->SetBinLabel(3,"kINT7");
+  hEventSummary->GetXaxis()->SetBinLabel(4,"kPHI7 0PH0");
+  hEventSummary->GetXaxis()->SetBinLabel(5,"kPHI7 1PHL");
+  hEventSummary->GetXaxis()->SetBinLabel(6,"kPHI7 1PHM");
+  hEventSummary->GetXaxis()->SetBinLabel(7,"kPHI7 1PHH");
+  fOutputContainer->Add(hEventSummary);
+
+  TH1F *hPHI7Summary = new TH1F("hPHI7Summary","PHI7 Summary",4,-1.5,2.5);
+  hPHI7Summary->GetXaxis()->SetBinLabel(1,"L0");//-1
+  hPHI7Summary->GetXaxis()->SetBinLabel(2,"1PHH");//0
+  hPHI7Summary->GetXaxis()->SetBinLabel(3,"1PHM");//1
+  hPHI7Summary->GetXaxis()->SetBinLabel(4,"1PHL");//2
+  fOutputContainer->Add(hPHI7Summary);
+
+  //event character histogram
+  fOutputContainer->Add(new TH1F("hVertexZ","VertexZ",1000,-50.,50.));
+  fOutputContainer->Add(new TH1F("hVertexZSelectEvent","VertexZ SelectEvent",1000,-50.,50.));
+
+  fOutputContainer->Add(new TH2F("hVertexXY","VertexXY",100,-0.5,0.5,100,-0.5,0.5));
+  fOutputContainer->Add(new TH2F("hVertexXYSelectEvent","VertexXY SelectEvent",100,-0.5,0.5,100,-0.5,0.5));
+
+  fOutputContainer->Add(new TH2F("hCentralityV0MvsNContibutor","Centrality V0M vs. Ncontributor",100,0.,100,101,-0.5,100.5));
+  fOutputContainer->Add(new TH2F("hCentralityCL0vsNContibutor","Centrality CL0 vs. Ncontributor",100,0.,100,101,-0.5,100.5));
+  fOutputContainer->Add(new TH2F("hCentralityCL1vsNContibutor","Centrality CL1 vs. Ncontributor",100,0.,100,101,-0.5,100.5));
+  fOutputContainer->Add(new TH2F("hCentralityV0AvsNContibutor","Centrality V0A vs. Ncontributor",100,0.,100,101,-0.5,100.5));
+  fOutputContainer->Add(new TH2F("hCentralityV0CvsNContibutor","Centrality V0C vs. Ncontributor",100,0.,100,101,-0.5,100.5));
+  fOutputContainer->Add(new TH2F("hCentralityZNAvsNContibutor","Centrality ZNA vs. Ncontributor",100,0.,100,101,-0.5,100.5));
+  fOutputContainer->Add(new TH2F("hCentralityZNCvsNContibutor","Centrality ZNC vs. Ncontributor",100,0.,100,101,-0.5,100.5));
+
+  fOutputContainer->Add(new TH2F("hCentralityV0MvsCL0","Centrality V0M vs. CL0",100,0.,100,100,0.,100.));
+  fOutputContainer->Add(new TH2F("hCentralityV0MvsCL1","Centrality V0M vs. CL1",100,0.,100,100,0.,100.));
+  fOutputContainer->Add(new TH2F("hCentralityCL0vsCL1","Centrality CL0 vs. CL1",100,0.,100,100,0.,100.));
+  fOutputContainer->Add(new TH2F("hCentralityV0AvsV0C","Centrality V0A vs. V0C",100,0.,100,100,0.,100.));
+  fOutputContainer->Add(new TH2F("hCentralityZNAvsZNC","Centrality ZNA vs. ZNC",100,0.,100,100,0.,100.));
+
+  fOutputContainer->Add(new TH2F("hCentralityvsPHOSClusterMultiplicity"      ,"Centrality vs. Cluster Multiplicity"                ,100,0,100,101,-0.5,100.5));
+  fOutputContainer->Add(new TH2F("hCentralityvsPHOSClusterMultiplicityTOF"   ,"Centrality vs. Cluster Multiplicity with TOF cut"   ,100,0,100,101,-0.5,100.5));
+  fOutputContainer->Add(new TH2F("hCentralityV0MvsPHOSClusterMultiplicity"   ,"CentralityV0M vs. Cluster Multiplicity"             ,100,0,100,101,-0.5,100.5));
+  fOutputContainer->Add(new TH2F("hCentralityV0MvsPHOSClusterMultiplicityTOF","CentralityV0M vs. Cluster Multiplicity with TOF cut",100,0,100,101,-0.5,100.5));
+  fOutputContainer->Add(new TH2F("hCentralityZNAvsPHOSClusterMultiplicity"   ,"CentralityZNA vs. Cluster Multiplicity"             ,100,0,100,101,-0.5,100.5));
+  fOutputContainer->Add(new TH2F("hCentralityZNAvsPHOSClusterMultiplicityTOF","CentralityZNA vs. Cluster Multiplicity with TOF cut",100,0,100,101,-0.5,100.5));
+  fOutputContainer->Add(new TH2F("hCentralityZNCvsPHOSClusterMultiplicity"   ,"CentralityZNC vs. Cluster Multiplicity"             ,100,0,100,101,-0.5,100.5));
+  fOutputContainer->Add(new TH2F("hCentralityZNCvsPHOSClusterMultiplicityTOF","CentralityZNC vs. Cluster Multiplicity with TOF cut",100,0,100,101,-0.5,100.5));
+
+  fOutputContainer->Add(new TH2F("hCentralityvsTrackMultiplicity"   ,"Centrality vs. track Multiplicity"   ,100,0,100,5000,0,5000));
+  fOutputContainer->Add(new TH2F("hCentralityV0MvsTrackMultiplicity","CentralityV0M vs. track Multiplicity",100,0,100,5000,0,5000));
+  fOutputContainer->Add(new TH2F("hCentralityZNAvsTrackMultiplicity","CentralityZNA vs. track Multiplicity",100,0,100,5000,0,5000));
+  fOutputContainer->Add(new TH2F("hCentralityZNCvsTrackMultiplicity","CentralityZNC vs. track Multiplicity",100,0,100,5000,0,5000));
+  fOutputContainer->Add(new TH2F("hPHOSClusterMultiplicityvsTrackMultiplicity"   ,"cluster multiplicity vs. track multiplicity"         ,500,0,5000,101,-0.5,100.5));
+  fOutputContainer->Add(new TH2F("hPHOSClusterMultiplicityTOFvsTrackMultiplicity","cluster multiplicity with TOF vs. track multiplicity",500,0,5000,101,-0.5,100.5));
+
+  //track QA histograms
+  const Int_t Ntype=3;
+  const TString tracktype[Ntype] = {"Hybrid","Global","Complementary"};
+
+  for(Int_t itype=0;itype<Ntype;itype++){
+    fOutputContainer->Add(new TH1F(Form("h%sTrackMult",tracktype[itype].Data())  ,Form("Number of %s track",tracktype[itype].Data()),500,0,5000));
+    fOutputContainer->Add(new TH1F(Form("h%sTrackPt",tracktype[itype].Data())    ,Form("%s track p_{T}",tracktype[itype].Data()),100,0,100));
+    fOutputContainer->Add(new TH2F(Form("h%sTrackDCA",tracktype[itype].Data())   ,Form("%s track DCA_{xy} vs. DCA_{z}",tracktype[itype].Data()),100,-5,5,100,-5,5));//in cm.
+    fOutputContainer->Add(new TH2F(Form("h%sTrackEtaPhi",tracktype[itype].Data()),Form("%s track #eta vs. #phi",tracktype[itype].Data()),100,0,6.3,200,-1,1));
+  }
+  fOutputContainer->Add(new TH2F("hTrackTPCdEdx","TPC dE/dx vs. track momentum",200,0,20,200,0,200));
+
+  //cell QA histograms
+  const Int_t Nmod=5;
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hCellNXZM%d",imod),Form("Cell N(X,Z) M%d",imod),64,0.5,64.5,56,0.5,56.5));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hCellEXZM%d",imod),Form("Cell E(X,Z) M%d",imod),64,0.5,64.5,56,0.5,56.5));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hCellAmpTimeM%d_LG",imod),Form("Cell Amplitude vs. Time LG M%d",imod),200,0,20,1000,-500,500));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hCellAmpTimeM%d_HG",imod),Form("Cell Amplitude vs. Time HG M%d",imod),200,0,20,1000,-500,500));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH1F(Form("hCellMultEventM%d",imod),Form("PHOS cell multiplicity per event M%d",imod),1001,-0.5,1000.5));
+
+  //cluster QA histograms
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH1F(Form("hPHOSClusterMultM%d",imod)   ,Form("PHOS cluster multiplicity M%d",imod)             ,201,-0.5,200.5));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH1F(Form("hPHOSClusterMultTOFM%d",imod),Form("PHOS cluster multiplicity M%d with TOF cut",imod),201,-0.5,200.5));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH1F(Form("hPHOSClusterEnergyM%d",imod)   ,Form("PHOS cluster energy M%d",imod)             ,1000,0.,100));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH1F(Form("hPHOSClusterEnergyTOFM%d",imod),Form("PHOS cluster energy M%d with TOF cut",imod),1000,0.,100));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hCluNXZM%d",imod)    ,Form("Cluster N(X,Z) M%d",imod)     ,64,0.5,64.5, 56,0.5,56.5));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hCluEXZM%d",imod)    ,Form("Cluster E(X,Z) M%d",imod)     ,64,0.5,64.5, 56,0.5,56.5));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hCluNXZTOFM%d",imod) ,Form("Cluster N(X,Z) M%d TOF",imod) ,64,0.5,64.5, 56,0.5,56.5));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hCluEXZTOFM%d",imod) ,Form("Cluster E(X,Z) M%d TOF",imod) ,64,0.5,64.5, 56,0.5,56.5));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hCluLowNXZM%d",imod) ,Form("Cluster Low N(X,Z) M%d",imod) ,64,0.5,64.5, 56,0.5,56.5));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hCluLowEXZM%d",imod) ,Form("Cluster Low E(X,Z) M%d",imod) ,64,0.5,64.5, 56,0.5,56.5));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hCluHighNXZM%d",imod),Form("Cluster High N(X,Z) M%d",imod),64,0.5,64.5, 56,0.5,56.5));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hCluHighEXZM%d",imod),Form("Cluster High E(X,Z) M%d",imod),64,0.5,64.5, 56,0.5,56.5));
+
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hClusterEvsNM%d",imod),Form("Cluster E vs N_{cell} M%d",imod),500,0,50,100,0.5,100.5));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hClusterEvsTM%d",imod),Form("Cluster E vs TOF M%d",imod)     ,500,0,50, 1000,-500,500));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hClusterEvsM02M%d",imod),Form("Cluster E vs M02 M%d",imod),500,0,50,100,0,10));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hClusterNvsM02M%d",imod),Form("Cluster N vs M02 M%d",imod),100,0.5,100.5,100,0,10));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hFullDispvsFullEM%d",imod),Form("full dispersion vs full E M%d",imod),500,0,50,100,0,10));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hCoreDispvsCoreEM%d",imod),Form("core dispersion vs core E M%d",imod),500,0,50,100,0,10));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hFullDispvsCoreEM%d",imod),Form("full dispersion vs full E M%d",imod),500,0,50,100,0,10));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hCoreDispvsFullEM%d",imod),Form("core dispersion vs core E M%d",imod),500,0,50,100,0,10));
+  for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hRvsTrackPtM%d",imod),Form("r vs track pT M%d",imod),100,0,10,100,0,50));
+
+  fOutputContainer->Add(new TH2F("hClusterEtaPhi","Cluster eta vs.phi",200,-1,1,100,0,6.3));
+  fOutputContainer->Add(new TH2F("hEnergyvsDistanceToBadChannel","distance to closest bad channel",100,0,50,200,0,20));
+  fOutputContainer->Add(new TH3F("hEvsNvsM02","energy vs. N vs. M02",100,0,50,100,0.5,100.5,100,0,10));
+
+  fOutputContainer->Add(new TH2F("hAsymvsMgg","asymmetry vs. M_{#gamma#gamma}",100,0,1,60,0,0.24));
+  fOutputContainer->Add(new TH2F("hAsymvsPt" ,"asymmetry vs. p_{T}^{#gamma#gamma}",100,0,1,500,0,50));
+
+  const Int_t Ncen = fCentEdges.GetSize();
+
+  Int_t CenMax=0;
+  if(fCollisionSystem==0)      CenMax = Ncen;//for pp
+  else if(fCollisionSystem==1) CenMax = Ncen-1;//for PbPb
+  else if(fCollisionSystem==2) CenMax = Ncen-1;//for pPb
+
+  Int_t nM = 240;
+  Double_t Mmin = 0.;
+  Double_t Mmax = 0.96;
+
+  const Int_t NpTgg = 101;
+  Double_t pTgg[NpTgg]={};
+
+  for(Int_t i=0;i<50;i++)     pTgg[i] = 0.1 * i;            //every 0.1 GeV/c, up to 5 GeV/c
+  for(Int_t i=50;i<60;i++)    pTgg[i] = 0.5 * (i-50) + 5.0; //every 0.5 GeV/c, up to 10 GeV/c
+  for(Int_t i=60;i<NpTgg;i++) pTgg[i] = 1.0 * (i-60) + 10.0;//every 1.0 GeV/c, up to 50 GeV/c
+
+  //In order to support pp and PbPb in this same code, name for centrality binning is just 0,1,2,3...
+
+  //photon pT histograms
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH1F *h1 = new TH1F(Form("hPhotonPt_Cen%d",icen),Form("Photon pT cenbin %d",icen),NpTgg-1,pTgg);
+    h1->Sumw2();
+    fOutputContainer->Add(h1);
+  }
+
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH1F *h1 = new TH1F(Form("hPhotonPt_Cen%d_TOF",icen),Form("Photon pT with TOF cut cenbin %d",icen),NpTgg-1,pTgg);
+    h1->Sumw2();
+    fOutputContainer->Add(h1);
+  }
+
+  //const TString Asym[] = {"","_asym08","_asym07"};
+  const TString Asym[] = {"","_asym08"};
+  const Int_t Nasym = sizeof(Asym)/sizeof(Asym[0]);
+
+  for(Int_t iasym=0;iasym<Nasym;iasym++){
+
+    //Mgg vs. pT histogram
+    for(Int_t icen=0;icen<CenMax;icen++){
+      TH2F *h2 = new TH2F(Form("hMgg_Cen%d%s",icen,Asym[iasym].Data()),"M_{#gamma#gamma} vs p_{T}",240,0,0.96,NpTgg-1,pTgg);
+      h2->Sumw2();
+      fOutputContainer->Add(h2);
+    }
+    for(Int_t icen=0;icen<CenMax;icen++){
+      TH2F *h2 = new TH2F(Form("hMgg_Cen%d_TOF%s",icen,Asym[iasym].Data()),"M_{#gamma#gamma} vs p_{T}",240,0,0.96,NpTgg-1,pTgg);
+      h2->Sumw2();
+      fOutputContainer->Add(h2);
+    }//end of centrality bin loop
+
+    //Mix Mgg vs. pT histogram
+    for(Int_t icen=0;icen<CenMax;icen++){
+      TH2F *h2 = new TH2F(Form("hMixMgg_Cen%d%s",icen,Asym[iasym].Data()),"M_{#gamma#gamma}^{mix} vs p_{T}",240,0,0.96,NpTgg-1,pTgg);
+      h2->Sumw2();
+      fOutputContainer->Add(h2);
+    }
+    for(Int_t icen=0;icen<CenMax;icen++){
+      TH2F *h2 = new TH2F(Form("hMixMgg_Cen%d_TOF%s",icen,Asym[iasym].Data()),"M_{#gamma#gamma}^{mix} vs p_{T}",240,0,0.96,NpTgg-1,pTgg);
+      h2->Sumw2();
+      fOutputContainer->Add(h2);
+    }//end of centrality bin loop
+
+  }//end of asymmetry loop
+
+
+  const Int_t NpTggModule = 71;
+  Double_t pTggModule[NpTggModule]={};
+  for(Int_t i=0;i<50;i++)     pTggModule[i] = 0.1 * i;            //every 0.1 GeV/c, up to 5 GeV/c
+  for(Int_t i=50;i<60;i++)    pTggModule[i] = 0.5 * (i-50) + 5.0; //every 0.5 GeV/c, up to 10 GeV/c
+  for(Int_t i=60;i<NpTggModule;i++) pTggModule[i] = 1.0 * (i-60) + 10.0;//every 1.0 GeV/c, up to 20 GeV/c
+
+//  for(Int_t icen=0;icen<CenMax;icen++){
+    for(Int_t imod1=1;imod1<Nmod;imod1++){
+      for(Int_t imod2=imod1;imod2<Nmod;imod2++){
+        if(imod2 - imod1 > 1) continue;
+
+        TH2F *h2 = new TH2F(Form("hMgg_M%d%d",imod1,imod2),"M_{#gamma#gamma} vs p_{T}",60,0,0.24,NpTggModule-1,pTggModule);
+        h2->Sumw2();
+        fOutputContainer->Add(h2);
+      }
+    }
+    for(Int_t imod1=1;imod1<Nmod;imod1++){
+      for(Int_t imod2=imod1;imod2<Nmod;imod2++){
+        if(imod2 - imod1 > 1) continue;
+
+        TH2F *h2 = new TH2F(Form("hMixMgg_M%d%d",imod1,imod2),"M_{#gamma#gamma} vs p_{T}",60,0,0.24,NpTggModule-1,pTggModule);
+        h2->Sumw2();
+        fOutputContainer->Add(h2);
+      }
+    }
+
+    for(Int_t imod1=1;imod1<Nmod;imod1++){
+      for(Int_t imod2=imod1;imod2<Nmod;imod2++){
+        if(imod2 - imod1 > 1) continue;
+
+        TH2F *h2 = new TH2F(Form("hMgg_M%d%d_TOF",imod1,imod2),"M_{#gamma#gamma} vs p_{T}",60,0,0.24,NpTggModule-1,pTggModule);
+        h2->Sumw2();
+        fOutputContainer->Add(h2);
+      }
+    }
+
+    for(Int_t imod1=1;imod1<Nmod;imod1++){
+      for(Int_t imod2=imod1;imod2<Nmod;imod2++){
+        if(imod2 - imod1 > 1) continue;
+
+        TH2F *h2 = new TH2F(Form("hMixMgg_M%d%d_TOF",imod1,imod2),"M_{#gamma#gamma} vs p_{T}",60,0,0.24,NpTggModule-1,pTggModule);
+        h2->Sumw2();
+        fOutputContainer->Add(h2);
+      }
+    }
+
+//  }//end of centrality loop
+
+  //for PID cut efficiency
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMgg_Probe_PID_Cen%d"         ,icen),"M_{#gamma#gamma} vs E_{#gamma}^{probe}"             ,60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMgg_PassingProbe_PID_Cen%d"   ,icen),"M_{#gamma#gamma} vs E_{#gamma}^{passing probe}"      ,60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMixMgg_Probe_PID_Cen%d"      ,icen),"M_{#gamma#gamma}^{mix} vs E_{#gamma}^{probe}"       ,60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMixMgg_PassingProbe_PID_Cen%d",icen),"M_{#gamma#gamma}^{mix} vs E_{#gamma}^{passing probe}",60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+
+/*
+  //for Ncell cut efficiency
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMgg_Probe_Ncell_Cen%d"         ,icen),"M_{#gamma#gamma} vs E_{#gamma}^{probe}"             ,60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMgg_PassingProbe_Ncell_Cen%d"   ,icen),"M_{#gamma#gamma} vs E_{#gamma}^{passing probe}"      ,60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMixMgg_Probe_Ncell_Cen%d"      ,icen),"M_{#gamma#gamma}^{mix} vs E_{#gamma}^{probe}"       ,60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMixMgg_PassingProbe_Ncell_Cen%d",icen),"M_{#gamma#gamma}^{mix} vs E_{#gamma}^{passing probe}",60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+
+  //for M20 cut efficiency
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMgg_Probe_M20_Cen%d"         ,icen),"M_{#gamma#gamma} vs E_{#gamma}^{probe}"             ,60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMgg_PassingProbe_M20_Cen%d"   ,icen),"M_{#gamma#gamma} vs E_{#gamma}^{passing probe}"      ,60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMixMgg_Probe_M20_Cen%d"      ,icen),"M_{#gamma#gamma}^{mix} vs E_{#gamma}^{probe}"       ,60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMixMgg_PassingProbe_M20_Cen%d",icen),"M_{#gamma#gamma}^{mix} vs E_{#gamma}^{passing probe}",60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+
+  //for M02 cut efficiency
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMgg_Probe_M02_Cen%d"         ,icen),"M_{#gamma#gamma} vs E_{#gamma}^{probe}"             ,60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMgg_PassingProbe_M02_Cen%d"   ,icen),"M_{#gamma#gamma} vs E_{#gamma}^{passing probe}"      ,60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMixMgg_Probe_M02_Cen%d"      ,icen),"M_{#gamma#gamma}^{mix} vs E_{#gamma}^{probe}"       ,60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMixMgg_PassingProbe_M02_Cen%d",icen),"M_{#gamma#gamma}^{mix} vs E_{#gamma}^{passing probe}",60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+
+  //for STD cut efficiency
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMgg_Probe_STDCut_Cen%d"         ,icen),"M_{#gamma#gamma} vs E_{#gamma}^{probe}"             ,60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMgg_PassingProbe_STDCut_Cen%d"   ,icen),"M_{#gamma#gamma} vs E_{#gamma}^{passing probe}"      ,60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMixMgg_Probe_STDCut_Cen%d"      ,icen),"M_{#gamma#gamma}^{mix} vs E_{#gamma}^{probe}"       ,60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMixMgg_PassingProbe_STDCut_Cen%d",icen),"M_{#gamma#gamma}^{mix} vs E_{#gamma}^{passing probe}",60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+*/
+
+  //for TOF cut efficiency
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMgg_Probe_TOF_Cen%d"         ,icen),"M_{#gamma#gamma} vs E_{#gamma}^{probe}"             ,60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMgg_PassingProbe_TOF_Cen%d"   ,icen),"M_{#gamma#gamma} vs E_{#gamma}^{passing probe}"      ,60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMixMgg_Probe_TOF_Cen%d"      ,icen),"M_{#gamma#gamma}^{mix} vs E_{#gamma}^{probe}"       ,60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+  for(Int_t icen=0;icen<CenMax;icen++){
+    TH2F *h2 = new TH2F(Form("hMixMgg_PassingProbe_TOF_Cen%d",icen),"M_{#gamma#gamma}^{mix} vs E_{#gamma}^{passing probe}",60,0,0.24,NpTgg-1,pTgg);
+    h2->Sumw2();
+    fOutputContainer->Add(h2);
+  }
+
+  Bool_t IsPHOSTriggerAnalysis = fPHOSEventCuts->IsPHOSTriggerAnalysis();
+
+  if(IsPHOSTriggerAnalysis){
+    //for Trigger QA
+    fOutputContainer->Add(new TH1F("hNFiredTRUChannel","Fired TRU channel per event",101,-0.5,100.5));
+    for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH2F(Form("hFiredTRUChannelM%d",imod),Form("Fired TRU channel M%d",imod),64,0.5,64.5, 56,0.5,56.5));
+    for(Int_t imod=1;imod<Nmod;imod++) fOutputContainer->Add(new TH3F(Form("hMatchedFiredTRUChannelM%d",imod),Form("Fired TRU channel M%d",imod),64,0.5,64.5, 56,0.5,56.5,100,0,50));
+
+    const Int_t Ntru=8;
+    for(Int_t imod=1;imod<Nmod;imod++){
+      fOutputContainer->Add(new TH1F(Form("hClusterEnergyM%d",imod)       ,Form("cluster energy M%d",imod),500,0,50));
+      fOutputContainer->Add(new TH1F(Form("hMatchedClusterEnergyM%d",imod),Form("cluster energy M%d",imod),500,0,50));
+
+      fOutputContainer->Add(new TH3F(Form("hClusterHitM%d",imod)       ,Form("cluster hit M%d",imod)         ,64,0.5,64.5,56,0.5,56.5,100,0,50));
+      fOutputContainer->Add(new TH3F(Form("hMatchedClusterHitM%d",imod),Form("matched cluster hit M%d",imod) ,64,0.5,64.5,56,0.5,56.5,100,0,50));
+
+      for(Int_t itru=1;itru<=Ntru;itru++){
+        fOutputContainer->Add(new TH1F(Form("hClusterEnergyM%dTRU%d",imod,itru)       ,Form("cluster energy M%d",imod),500,0,50));
+        fOutputContainer->Add(new TH1F(Form("hMatchedClusterEnergyM%dTRU%d",imod,itru),Form("cluster energy M%d",imod),500,0,50));
+        fOutputContainer->Add(new TH3F(Form("hDistanceXZM%dTRU%d",imod,itru)        ,Form("distance TRUch-clu M%d TRU%d",imod,itru),41,-20.5,+20.5,41,-20.5,+20.5,100,0,50));
+        fOutputContainer->Add(new TH3F(Form("hMatchedDistanceXZM%dTRU%d",imod,itru) ,Form("distance TRUch-clu M%d TRU%d",imod,itru),41,-20.5,+20.5,41,-20.5,+20.5,100,0,50));
+      }
+    }
+
+    for(Int_t icen=0;icen<CenMax;icen++){
+      for(Int_t imod=1;imod<Nmod;imod++){
+        for(Int_t itru=1;itru<=Ntru;itru++){
+          fOutputContainer->Add(new TH1F(Form("hClusterE_Cen%d_M%d_TRU%d",icen,imod,itru)         ,Form("cluster energy M%d TRU%d",imod,itru)          ,NpTgg-1,pTgg));
+          fOutputContainer->Add(new TH1F(Form("hTriggeredClusterE_Cen%d_M%d_TRU%d",icen,imod,itru),Form("triggered cluster energy M%d TRU%d",imod,itru),NpTgg-1,pTgg));
+        }
+      }
+    }
+
+    //for trigger efficiency
+    for(Int_t icen=0;icen<CenMax;icen++){
+      TH2F *h2 = new TH2F(Form("hMgg_Probe_Trg_Cen%d"         ,icen),"M_{#gamma#gamma} vs E_{#gamma}^{probe}"             ,60,0,0.24,NpTgg-1,pTgg);
+      h2->Sumw2();
+      fOutputContainer->Add(h2);
+    }
+    for(Int_t icen=0;icen<CenMax;icen++){
+      TH2F *h2 = new TH2F(Form("hMgg_PassingProbe_Trg_Cen%d"   ,icen),"M_{#gamma#gamma} vs E_{#gamma}^{passing probe}"      ,60,0,0.24,NpTgg-1,pTgg);
+      h2->Sumw2();
+      fOutputContainer->Add(h2);
+    }
+    for(Int_t icen=0;icen<CenMax;icen++){
+      TH2F *h2 = new TH2F(Form("hMixMgg_Probe_Trg_Cen%d"      ,icen),"M_{#gamma#gamma}^{mix} vs E_{#gamma}^{probe}"       ,60,0,0.24,NpTgg-1,pTgg);
+      h2->Sumw2();
+      fOutputContainer->Add(h2);
+    }
+    for(Int_t icen=0;icen<CenMax;icen++){
+      TH2F *h2 = new TH2F(Form("hMixMgg_PassingProbe_Trg_Cen%d",icen),"M_{#gamma#gamma}^{mix} vs E_{#gamma}^{passing probe}",60,0,0.24,NpTgg-1,pTgg);
+      h2->Sumw2();
+      fOutputContainer->Add(h2);
+    }
+
+    for(Int_t icen=0;icen<CenMax;icen++){
+      for(Int_t imod=1;imod<Nmod;imod++){
+        for(Int_t itru=1;itru<=Ntru;itru++){
+          TH2F *h2 = new TH2F(Form("hMgg_Probe_Trg_Cen%d_M%d_TRU%d"         ,icen,imod,itru),"M_{#gamma#gamma} vs E_{#gamma}^{probe}",60,0,0.24,NpTgg-1,pTgg);
+          h2->Sumw2();
+          fOutputContainer->Add(h2);
+        }
+      }
+    }
+
+    for(Int_t icen=0;icen<CenMax;icen++){
+      for(Int_t imod=1;imod<Nmod;imod++){
+        for(Int_t itru=1;itru<=Ntru;itru++){
+          TH2F *h2 = new TH2F(Form("hMgg_PassingProbe_Trg_Cen%d_M%d_TRU%d"         ,icen,imod,itru),"M_{#gamma#gamma} vs E_{#gamma}^{passing probe}",60,0,0.24,NpTgg-1,pTgg);
+          h2->Sumw2();
+          fOutputContainer->Add(h2);
+        }
+      }
+    }
+
+    for(Int_t icen=0;icen<CenMax;icen++){
+      for(Int_t imod=1;imod<Nmod;imod++){
+        for(Int_t itru=1;itru<=Ntru;itru++){
+          TH2F *h2 = new TH2F(Form("hMixMgg_Probe_Trg_Cen%d_M%d_TRU%d"         ,icen,imod,itru),"M_{#gamma#gamma}^{mix} vs E_{#gamma}^{probe}",60,0,0.24,NpTgg-1,pTgg);
+          h2->Sumw2();
+          fOutputContainer->Add(h2);
+        }
+      }
+    }
+
+    for(Int_t icen=0;icen<CenMax;icen++){
+      for(Int_t imod=1;imod<Nmod;imod++){
+        for(Int_t itru=1;itru<=Ntru;itru++){
+          TH2F *h2 = new TH2F(Form("hMixMgg_PassingProbe_Trg_Cen%d_M%d_TRU%d"         ,icen,imod,itru),"M_{#gamma#gamma}^{mix} vs E_{#gamma}^{passing probe}",60,0,0.24,NpTgg-1,pTgg);
+          h2->Sumw2();
+          fOutputContainer->Add(h2);
+        }
+      }
+    }
+
+  }//IsPHOSTriggerAnalysis ends
+
+  if(fIsMC){
+    //const Int_t Npar = 3;
+    const TString parname[] = {"Pi0","Eta","Gamma","ChargedPion","ChargedKaon","K0S","K0L","Lambda0","Sigma0"};
+    const Int_t Npar = sizeof(parname)/sizeof(parname[0]);
+
+    for(Int_t icen=0;icen<CenMax;icen++){
+      for(Int_t ipar=0;ipar<Npar;ipar++){
+        TH1F *h1Pt = new TH1F(Form("hGen%sPt_Cen%d",parname[ipar].Data()        ,icen),Form("generated %s pT cenbin %d",parname[ipar].Data()        ,icen),NpTgg-1,pTgg);
+        h1Pt->Sumw2();
+        fOutputContainer->Add(h1Pt);
+
+        TH2F *h2EtaPhi = new TH2F(Form("hGen%sEtaPhi_Cen%d",parname[ipar].Data(),icen),Form("generated %s eta vs phi cenbin %d",parname[ipar].Data(),icen),200,-1,1,100,0,6.3);
+        h2EtaPhi->Sumw2();
+        fOutputContainer->Add(h2EtaPhi);
+
+        TH2F *h2EtaPt = new TH2F(Form("hGen%sEtaPt_Cen%d",parname[ipar].Data()  ,icen),Form("generated %s eta vs pT cenbin %d",parname[ipar].Data() ,icen),200,-1,1,NpTgg-1,pTgg);
+        h2EtaPt->Sumw2();
+        fOutputContainer->Add(h2EtaPt);
+
+      }//end of particle loop
+    }//end of centrality loop
+
+    for(Int_t icen=0;icen<CenMax;icen++){
+      TH1F *h1Pt = new TH1F(Form("hGenGammaFromPi0Pt_Cen%d",icen),Form("generated #gamma from #pi^{0} pT cenbin %d",icen),NpTgg-1,pTgg);
+      h1Pt->Sumw2();
+      fOutputContainer->Add(h1Pt);
+
+      TH2F *h2EtaPhi = new TH2F(Form("hGenGammaFromPi0EtaPhi_Cen%d",icen),Form("generated #gamma from #pi^{0} eta vs phi cenbin %d",icen),200,-1,1,100,0,6.3);
+      h2EtaPhi->Sumw2();
+      fOutputContainer->Add(h2EtaPhi);
+
+      TH2F *h2EtaPt = new TH2F(Form("hGenGammaFromPi0EtaPt_Cen%d",icen),Form("generated #gamma from #pi^{0} eta vs pT cenbin %d",icen),200,-1,1,NpTgg-1,pTgg);
+      h2EtaPt->Sumw2();
+      fOutputContainer->Add(h2EtaPt);
+
+    }//end of centrality loop
+
+    for(Int_t icen=0;icen<CenMax;icen++){
+      TH1F *h1Pt = new TH1F(Form("hPurityGamma_Cen%d",icen),Form("pT of true photon in clusters for purity cenbin %d",icen),NpTgg-1,pTgg);
+      h1Pt->Sumw2();
+      fOutputContainer->Add(h1Pt);
+    }
+
+    if(fIsNonLinStudyNeeded){
+      //for non-linearity study
+      const Int_t Na=7;
+      const Int_t Nb=7;
+
+      for(Int_t icen=0;icen<CenMax;icen++){
+        for(Int_t ia=0;ia<Na;ia++){
+          for(Int_t ib=0;ib<Nb;ib++){
+            Double_t a = -0.07 + 0.01*ia;
+            Double_t b =  0.4  + 0.1 *ib;
+
+            //fNonLin[ia][ib] = new TF1(Form("fNonLin_a%d_b%d"),"(1+[0]/(1+pow([1]*x,2.)))*1.007",0,100);
+            fNonLin[icen][ia][ib] = new TF1(Form("fNonLin_Cen%d_a%d_b%d",icen,ia,ib),"1.00*(1.+[0]*TMath::Exp(-x*x/2./[1]/[1]))",0,100);
+            fNonLin[icen][ia][ib]->SetParNames("a","b");
+            fNonLin[icen][ia][ib]->FixParameter(0,a);
+            fNonLin[icen][ia][ib]->FixParameter(1,b);
+
+            fOutputContainer->Add(new TH2F(Form("hMgg_Cen%d_a%d_b%d",icen,ia,ib),Form("a = %3.2f , b = %3.2f",a,b),60,0,0.24,NpTggModule-1,pTggModule));
+            fOutputContainer->Add(new TH2F(Form("hMixMgg_Cen%d_a%d_b%d",icen,ia,ib),Form("a = %3.2f , b = %3.2f",a,b),60,0,0.24,NpTggModule-1,pTggModule));
+          }
+        }
+      }
+    }
+
+    for(Int_t icen=0;icen<CenMax;icen++){
+      TH2F *h2 = new TH2F(Form("hPi0FromK0S_Cen%d",icen),"#pi^{0} from K_{S}^{0}",NpTgg-1,pTgg,500,0,500);
+      h2->Sumw2();
+      fOutputContainer->Add(h2);
+    }
+
+    for(Int_t iasym=0;iasym<Nasym;iasym++){
+      for(Int_t icen=0;icen<CenMax;icen++){
+        TH2F *h2 = new TH2F(Form("hMggFromK0S_Cen%d%s",icen,Asym[iasym].Data()),"M_{#gamma#gamma} from K_{S}^{0}",240,0,0.96,NpTgg-1,pTgg);
+        h2->Sumw2();
+        fOutputContainer->Add(h2);
+      }//end of centrality loop
+
+    }//end of asym loop
+
+    for(Int_t iasym=0;iasym<Nasym;iasym++){
+      for(Int_t icen=0;icen<CenMax;icen++){
+        TH2F *h2 = new TH2F(Form("hMggFromLambda0_Cen%d%s",icen,Asym[iasym].Data()),"M_{#gamma#gamma} from K_{S}^{0}",240,0,0.96,NpTgg-1,pTgg);
+        h2->Sumw2();
+        fOutputContainer->Add(h2);
+      }//end of centrality loop
+
+    }//end of asym loop
+
+
+    //for JJMC
+    if(fIsJJMC){
+      fOutputContainer->Add(new TH1F("hPtHard","pT hard in GeV/c",1000,0,1000));
+      fOutputContainer->Add(new TH1F("hNTrial","nTrial",20,0.5,20.5));
+      fOutputContainer->Add(new TProfile("hProfCrossSection","inelastic cross section",20,0.5,20.5));
+
+      TH1F *hNMerged = new TH1F("hNMerged","N merged",20,0.5,20.5);
+      hNMerged->Fill(fPtHardBin);
+      hNMerged->SetYTitle("number of merged files");
+      fOutputContainer->Add(hNMerged);
+    }//end of IsJJMC
+
+  }//end of IsMC
+
+//  TH1F *h1test = new TH1F("h1test","h1test",1000,0,100);
+//  h1test->Sumw2();
+//  TF1 *f1 = GetTOFCutEfficiencyFunction();
+//
+//  for(Int_t i=1; i <= 1000; i++){
+//    Double_t e = h1test->GetBinCenter(i);
+//    Double_t eff = f1->Eval(e);
+//    h1test->SetBinContent(i,eff);
+//  }
+//  fOutputContainer->Add(h1test);
+
+
+
+
+  PostData(1,fOutputContainer);
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::UserExec(Option_t *option) 
+{
+  // Main loop
+  // Called for each event
+
+  fEvent = dynamic_cast<AliVEvent*>(InputEvent());
+  if(!fEvent){
+    AliError("event is not available.");
+    return;
+  }
+
+  fESDEvent = dynamic_cast<AliESDEvent*>(fEvent);
+  fAODEvent = dynamic_cast<AliAODEvent*>(fEvent);
+
+  FillHistogramTH1(fOutputContainer,"hEventSummary",1);//all
+
+  const AliVVertex *vVertex = fEvent->GetPrimaryVertex();
+  fVertex[0] = vVertex->GetX();
+  fVertex[1] = vVertex->GetY();
+  fVertex[2] = vVertex->GetZ();
+  FillHistogramTH1(fOutputContainer,"hVertexZ" ,fVertex[2]);
+  FillHistogramTH2(fOutputContainer,"hVertexXY",fVertex[0],fVertex[1]);
+  fZvtx = (Int_t)((fVertex[2]+10.)/2.);//it should be 0-9.
+
+  //for JJMC
+  if(fIsMC && fIsJJMC){
+    fJJMCHandler->ConfigureJetJetMC(fEvent);//this should be called in each event to get pythia event header
+
+    AliMCEvent *mcevent = MCEvent();
+    AliGenPythiaEventHeader* pythiaGenHeader = 0x0;
+    if(fESDEvent) pythiaGenHeader      = fJJMCHandler->GetPythiaEventHeader(mcevent);
+    else if(fAODEvent) pythiaGenHeader = fJJMCHandler->GetPythiaEventHeader(fAODEvent);
+
+    Float_t pThard   = pythiaGenHeader->GetPtHard();
+    Float_t xsection = pythiaGenHeader->GetXsection();
+    Int_t nTrial     = pythiaGenHeader->Trials();
+
+    AliInfo(Form("pT-hard-bin = %d , pThard = %f GeV/c , xsection = %f mb , nTrial = %d.",fPtHardBin, pThard, xsection, nTrial));
+    FillHistogramTH1(fOutputContainer,"hNTrial",fPtHardBin,nTrial);//this should be filled in all events (no rejected/selected events).
+    FillProfile(fOutputContainer,"hProfCrossSection",fPtHardBin,xsection);//this should be filled in all events (no rejected/selected events).
+
+    if(!(fJJMCHandler->ComparePtHardBin(fEvent))) return;
+    if(!(fJJMCHandler->ComparePtHardWithJet(fEvent))) return;
+    if(!(fJJMCHandler->ComparePtHardWithSingleParticle(fEvent))) return;
+  }
+
+
+  Int_t Ncontributor  = vVertex->GetNContributors();
+
+  //const Int_t system = GetCollisionSystem();
+  if(fCollisionSystem==0){
+    //not centrality, but track multiplicity
+    //track QA to extrack number of hybrid track for centrality binning
+
+  }
+  else if(fCollisionSystem==1){//for PbPb
+    //Get Centrality
+    fMultSelection = (AliMultSelection*)fEvent->FindListObject("MultSelection");
+    if(!fMultSelection){
+      //If you get this warning (and fCentralityV0M 300) please check that the AliMultSelectionTask actually ran (before your task)
+      AliWarning("AliMultSelection object not found!");
+      return;
+    }
+    else{
+      fCentralityV0M = fMultSelection->GetMultiplicityPercentile("V0M");
+      fCentralityCL0 = fMultSelection->GetMultiplicityPercentile("CL0");
+      fCentralityCL1 = fMultSelection->GetMultiplicityPercentile("CL1");
+      fCentralityV0A = fMultSelection->GetMultiplicityPercentile("V0A");
+      fCentralityV0C = fMultSelection->GetMultiplicityPercentile("V0C");
+      fCentralityZNA = fMultSelection->GetMultiplicityPercentile("ZNA");
+      fCentralityZNC = fMultSelection->GetMultiplicityPercentile("ZNC");
+      fCentralityMain = fMultSelection->GetMultiplicityPercentile(fEstimator);
+    }
+
+    const Int_t Ncen = fCentEdges.GetSize();
+
+    if(fCentralityMain < (Float_t)fCentEdges[0] || (Float_t)fCentEdges[Ncen-1] < fCentralityMain){
+      AliInfo(Form("Reject this event because centrality %s %f %% is out of the configuration of this task.", fEstimator.Data(),fCentralityMain));
+      return;
+    }
+
+    fCenBin = GetCentralityBinPbPb(fCentralityMain);
+    AliInfo(Form("fCentralityMain estimated by %s = %f %, fCenbin = %d , Zvtx = %f cm, fZvtx = %d.",fEstimator.Data(),fCentralityMain,fCenBin,fVertex[2],fZvtx));
+
+  }
+  else if(fCollisionSystem==2){//for pPb,Pbp to be implemented
+    //Get Centrality
+    fMultSelection = (AliMultSelection*)fEvent->FindListObject("MultSelection");
+    if(!fMultSelection){
+      //If you get this warning (and fCentralityV0M 300) please check that the AliMultSelectionTask actually ran (before your task)
+      AliWarning("AliMultSelection object not found!");
+      return;
+    }
+    else{
+      fCentralityV0M = fMultSelection->GetMultiplicityPercentile("V0M");
+      fCentralityCL0 = fMultSelection->GetMultiplicityPercentile("CL0");
+      fCentralityCL1 = fMultSelection->GetMultiplicityPercentile("CL1");
+      fCentralityV0A = fMultSelection->GetMultiplicityPercentile("V0A");
+      fCentralityV0C = fMultSelection->GetMultiplicityPercentile("V0C");
+      fCentralityZNA = fMultSelection->GetMultiplicityPercentile("ZNA");
+      fCentralityZNC = fMultSelection->GetMultiplicityPercentile("ZNC");
+      fCentralityMain = fMultSelection->GetMultiplicityPercentile(fEstimator);
+    }
+
+    const Int_t Ncen = fCentEdges.GetSize();
+
+    if(fCentralityMain < (Float_t)fCentEdges[0] || (Float_t)fCentEdges[Ncen-1] < fCentralityMain){
+      AliInfo(Form("Reject this event because centrality %s %f %% is out of the configuration of this task.", fEstimator.Data(),fCentralityMain));
+      return;
+    }
+
+    fCenBin = GetCentralityBinPbPb(fCentralityMain);
+    AliInfo(Form("fCentralityMain estimated by %s = %f %, fCenbin = %d , Zvtx = %f cm, fZvtx = %d.",fEstimator.Data(),fCentralityMain,fCenBin,fVertex[2],fZvtx));
+
+  }
+  else{
+    AliInfo("collision system shuold be 0-pp , 1-PbPb, 2-pPb/Pbp.");
+    return;
+  }
+
+  FillHistogramTH2(fOutputContainer,"hCentralityV0MvsNContibutor",fCentralityV0M,Ncontributor);
+  FillHistogramTH2(fOutputContainer,"hCentralityCL0vsNContibutor",fCentralityCL0,Ncontributor);
+  FillHistogramTH2(fOutputContainer,"hCentralityCL1vsNContibutor",fCentralityCL1,Ncontributor);
+  FillHistogramTH2(fOutputContainer,"hCentralityV0AvsNContibutor",fCentralityV0A,Ncontributor);
+  FillHistogramTH2(fOutputContainer,"hCentralityV0CvsNContibutor",fCentralityV0C,Ncontributor);
+  FillHistogramTH2(fOutputContainer,"hCentralityZNAvsNContibutor",fCentralityZNA,Ncontributor);
+  FillHistogramTH2(fOutputContainer,"hCentralityZNCvsNContibutor",fCentralityZNC,Ncontributor);
+
+  //event selection
+  if(!(fPHOSEventCuts->AcceptEvent(fEvent))){
+    AliInfo("event is rejected.");
+    return;
+  }
+
+  Bool_t IsPHOSTriggerAnalysis = fPHOSEventCuts->IsPHOSTriggerAnalysis();
+  UInt_t fSelectMask = fInputHandler->IsEventSelected();
+  Bool_t isINT7selected = fSelectMask & AliVEvent::kINT7;
+
+  if(!IsPHOSTriggerAnalysis && !isINT7selected){
+    AliInfo("INT7 Event is rejected by IsEventSelected()");
+    return;
+  }
+
+  fPHOSClusterArray = (TClonesArray*)fEvent->FindListObject("PHOSClusterArray");
+  if(!fPHOSClusterArray){
+    //If you get this warning (and fCentralityV0M 300) please check that the AliMultSelectionTask actually ran (before your task)
+    AliWarning("fPHOSClusterArray object not found!");
+    return;
+  }
+
+
+  //Bool_t IsPHOSTriggerAnalysis = fPHOSEventCuts->IsPHOSTriggerAnalysis();
+  Bool_t isPHI7selected = fSelectMask & AliVEvent::kPHI7;
+  if(IsPHOSTriggerAnalysis && !isPHI7selected){
+    AliInfo("PHI7 Event is rejected by IsEventSelected()");
+    return;
+  }
+
+  //cout << "fCentralityV0M = " << fCentralityV0M << endl;
+
+  //<- end of event selection
+  //-> start physics analysis
+
+  FillHistogramTH2(fOutputContainer,"hCentralityV0MvsCL0",fCentralityV0M,fCentralityCL0);
+  FillHistogramTH2(fOutputContainer,"hCentralityV0MvsCL1",fCentralityV0M,fCentralityCL1);
+  FillHistogramTH2(fOutputContainer,"hCentralityCL0vsCL1",fCentralityCL0,fCentralityCL1);
+  FillHistogramTH2(fOutputContainer,"hCentralityV0AvsV0C",fCentralityV0A,fCentralityV0C);
+  FillHistogramTH2(fOutputContainer,"hCentralityZNAvsZNC",fCentralityZNA,fCentralityZNC);
+
+  FillHistogramTH1(fOutputContainer,"hVertexZSelectEvent" ,fVertex[2]);
+  FillHistogramTH2(fOutputContainer,"hVertexXYSelectEvent",fVertex[0],fVertex[1]);
+  FillHistogramTH1(fOutputContainer,"hEventSummary",2);//select event
+
+  Bool_t IsPH0fired = fEvent->GetHeader()->GetL0TriggerInputs() & 1 << 8;//trigger input -1
+  Bool_t IsPHHfired = fEvent->GetHeader()->GetL1TriggerInputs() & 1 << 6;//trigger input -1
+  Bool_t IsPHMfired = fEvent->GetHeader()->GetL1TriggerInputs() & 1 << 5;//trigger input -1
+  Bool_t IsPHLfired = fEvent->GetHeader()->GetL1TriggerInputs() & 1 << 4;//trigger input -1
+
+  if(IsPH0fired) FillHistogramTH1(fOutputContainer,"hEventSummary",4);//0PH0
+  if(IsPHLfired) FillHistogramTH1(fOutputContainer,"hEventSummary",5);//1PHL
+  if(IsPHMfired) FillHistogramTH1(fOutputContainer,"hEventSummary",6);//1PHM
+  if(IsPHHfired) FillHistogramTH1(fOutputContainer,"hEventSummary",7);//1PHH
+
+  if(fRunNumber != fEvent->GetRunNumber()){ // Check run number
+    fRunNumber = fEvent->GetRunNumber();
+    fPHOSGeo = GetPHOSGeometry();
+  }
+
+  //track QA
+  TrackQA();
+  if(fCollisionSystem==0){
+    //not centrality, but track multiplicity
+    //track QA to extrack number of hybrid track for centrality binning
+    fCenBin = GetCentralityBinPP(fNHybridTrack);
+    AliInfo(Form("This is pp analysis. Nybrid = %d , fCenbin = %d , Zvtx = %f cm, fZvtx = %d.",fNHybridTrack,fCenBin,fVertex[2],fZvtx));
+  }
+
+  if(fIsMC) ProcessMC();
+
+  if(fIsMC && fIsJJMC){
+    //This should be called after ProcessMC(), because fMCArrayAOD is used.
+    Int_t firstJetindex = fJJMCHandler->GetFirstJetIndex();
+    Int_t lastJetindex  = fJJMCHandler->GetLastJetIndex();
+    Int_t genIDJet      = fJJMCHandler->GetGeneratorJetIndex();
+
+    const Int_t multClust = fPHOSClusterArray->GetEntriesFast();
+    for(Int_t i=0;i<multClust;i++){
+      AliCaloPhoton *ph = (AliCaloPhoton*)fPHOSClusterArray->At(i);
+      Int_t primary = ph->GetPrimary();
+      AliAODMCParticle *p = (AliAODMCParticle*)fMCArrayAOD->At(primary);
+
+      if(p->GetGeneratorIndex() != genIDJet) fPHOSClusterArray->Remove(ph);
+    }
+    fPHOSClusterArray->Compress();
+  }
+
+  if(!fPHOSEvents[fZvtx][fCenBin]) fPHOSEvents[fZvtx][fCenBin] = new TList();
+  TList *prevPHOS = fPHOSEvents[fZvtx][fCenBin];
+
+  if(IsPHOSTriggerAnalysis){
+    TriggerQA();
+    SelectTriggeredCluster();
+    EstimateTriggerEfficiency();
+  }
+
+  //cell QA
+  CellQA();
+  //cluster QA
+  ClusterQA();
+
+  FillPhoton();
+  FillMgg();
+  FillMixMgg();
+
+  EstimatePIDCutEfficiency();
+  EstimateTOFCutEfficiency();
+
+  //EstimateNcellCutEfficiency();
+  //EstimateM20CutEfficiency();
+  //EstimateM02CutEfficiency();
+  //EstimateSTDCutEfficiency();
+
+  if(fIsNonLinStudyNeeded) DoNonLinearityStudy();
+
+  const Int_t Nmixed = fCentNMixed.GetSize();
+
+  //Now we either add current events to stack or remove
+  //If no photons in current event - no need to add it to mixed
+  if(fPHOSClusterArray->GetEntriesFast() > 0){
+    //don't call fPHOSClucster=0; this will affect original array provided from PHOSbjectCreator.
+    //prevPHOS->AddFirst(fPHOSClusterArray);
+    //fPHOSClusterArray=0;
+
+    TClonesArray *clone = new TClonesArray(*fPHOSClusterArray);
+    prevPHOS->AddFirst(clone);
+    //delete clone;
+    clone = 0;
+
+    if(prevPHOS->GetSize() > fCentNMixed[fCenBin]){//Remove redundant events
+      TClonesArray * tmp = static_cast<TClonesArray*>(prevPHOS->Last());
+      prevPHOS->RemoveLast();
+      delete tmp;
+      tmp = NULL;
+    }
+  }
+
+  PostData(1, fOutputContainer);
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::Terminate(Option_t *option) 
+{
+  //Called once at the end of the query
+  //In principle, this function is not needed...
+
+  AliInfo(Form("%s is done.",GetName()));
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::TrackQA() 
+{
+  const Int_t trackMult = fEvent->GetNumberOfTracks();
+
+  Double_t dcaXY=0, dcaZ=0, pT=0, eta=0, phi=0, dEdx=0, p=0;
+  Int_t NHybrid=0;
+  Int_t NGlobal=0;
+  Int_t NComplementary=0;
+  Int_t PID=-1, charge=0;
+
+  if(fESDEvent){
+    for(Int_t itrack=0;itrack<trackMult;itrack++){
+      AliESDtrack *esdtrack = (AliESDtrack*)fEvent->GetTrack(itrack);
+      if(TMath::Abs(esdtrack->Eta()) > 0.8) continue;
+
+      if(!fESDtrackCutsGlobal           ->AcceptTrack(esdtrack)//select global track
+      && !fESDtrackCutsGlobalConstrained->AcceptTrack(esdtrack)){//select complementary track
+        //cout << "itrack = " << itrack << " , rejected" << endl;
+        continue;
+      }
+      NHybrid++;
+      //cout << "itrack = " << itrack << " , accepted" << endl;
+      pT  = esdtrack->Pt();
+      eta = esdtrack->Eta();
+      phi = esdtrack->Phi();
+      if(phi<0) phi += TMath::TwoPi();
+      p = esdtrack->P();
+      dEdx = esdtrack->GetTPCsignal();
+      FillHistogramTH2(fOutputContainer,"hTrackTPCdEdx",p,dEdx);
+
+      FillHistogramTH1(fOutputContainer,"hHybridTrackPt",pT);
+      FillHistogramTH2(fOutputContainer,"hHybridTrackEtaPhi",phi,eta);
+      FillHistogramTH2(fOutputContainer,"hHybridTrackDCA",dcaXY,dcaZ);//in cm.
+
+      if(fESDtrackCutsGlobal->AcceptTrack(esdtrack)){//global track
+        NGlobal++;
+        FillHistogramTH1(fOutputContainer,"hGlobalTrackPt",pT);
+        FillHistogramTH2(fOutputContainer,"hGlobalTrackEtaPhi",phi,eta);
+        FillHistogramTH2(fOutputContainer,"hGlobalTrackDCA",dcaXY,dcaZ);//in cm.
+      }
+      if(fESDtrackCutsGlobalConstrained->AcceptTrack(esdtrack)){//global-constrained = complementary track
+        NComplementary++;
+        FillHistogramTH1(fOutputContainer,"hComplementaryTrackPt",pT);
+        FillHistogramTH2(fOutputContainer,"hComplementaryTrackEtaPhi",phi,eta);
+        FillHistogramTH2(fOutputContainer,"hComplementaryTrackDCA",dcaXY,dcaZ);//in cm.
+      }
+    }//end of track loop
+  }//end of ESD
+  else if(fAODEvent){
+    for(Int_t itrack=0;itrack<trackMult;itrack++){
+      AliAODTrack *aodtrack = (AliAODTrack*)fEvent->GetTrack(itrack);
+      if(TMath::Abs(aodtrack->Eta()) > 0.8) continue;
+
+      if(aodtrack->IsHybridGlobalConstrainedGlobal()){//hybrid track
+        NHybrid++;
+        pT = aodtrack->Pt();
+        dcaXY = aodtrack->DCA();
+        dcaZ  = aodtrack->ZAtDCA();
+        eta = aodtrack->Eta();
+        phi = aodtrack->Phi();
+        if(phi<0) phi += TMath::TwoPi();
+        p = aodtrack->P();
+        dEdx = aodtrack->GetTPCsignal();
+
+        FillHistogramTH2(fOutputContainer,"hTrackTPCdEdx",p,dEdx);
+
+        FillHistogramTH1(fOutputContainer,"hHybridTrackPt",pT);
+        FillHistogramTH2(fOutputContainer,"hHybridTrackEtaPhi",phi,eta);
+        FillHistogramTH2(fOutputContainer,"hHybridTrackDCA",dcaXY,dcaZ);//in cm.
+
+        if(aodtrack->IsGlobalConstrained()){//constrained to primary vertex, instead of SPD hits.//complementary track
+          NComplementary++;
+          FillHistogramTH1(fOutputContainer,"hComplementaryTrackPt",pT);
+          FillHistogramTH2(fOutputContainer,"hComplementaryTrackEtaPhi",phi,eta);
+          FillHistogramTH2(fOutputContainer,"hComplementaryTrackDCA",dcaXY,dcaZ);//in cm.
+        }
+        else{//global track
+          NGlobal++;
+          FillHistogramTH1(fOutputContainer,"hGlobalTrackPt",pT);
+          FillHistogramTH2(fOutputContainer,"hGlobalTrackEtaPhi",phi,eta);
+          FillHistogramTH2(fOutputContainer,"hGlobalTrackDCA",dcaXY,dcaZ);//in cm.
+        }
+
+      }
+    }//end of track loop
+
+
+  }//end of AOD
+
+  FillHistogramTH1(fOutputContainer,"hHybridTrackMult",NHybrid);
+  FillHistogramTH1(fOutputContainer,"hGlobalTrackMult",NGlobal);
+  FillHistogramTH1(fOutputContainer,"hComplementaryTrackMult",NComplementary);
+
+  FillHistogramTH2(fOutputContainer,"hCentralityvsTrackMultiplicity",fCentralityMain,NHybrid);
+  FillHistogramTH2(fOutputContainer,"hCentralityV0MvsTrackMultiplicity",fCentralityV0M, NHybrid);
+  FillHistogramTH2(fOutputContainer,"hCentralityZNAvsTrackMultiplicity",fCentralityZNA, NHybrid);
+  FillHistogramTH2(fOutputContainer,"hCentralityZNCvsTrackMultiplicity",fCentralityZNC, NHybrid);
+  fNHybridTrack = NHybrid;
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::CellQA() 
+{
+  AliVCaloCells *cells = dynamic_cast<AliVCaloCells*>(fEvent->GetPHOSCells());
+  const Int_t multCells = cells->GetNumberOfCells();
+
+  Int_t relId[4]={};
+  Int_t nCellModule[5] = {};
+  Double_t cellamp=0;
+  Double_t celltime=0;
+  Int_t module=0,cellx=0,cellz=0;
+  Int_t cellAbsId=0;
+  Bool_t isHG=kFALSE;
+
+  for(Int_t iCell=0; iCell<multCells; iCell++){
+    cellAbsId = cells->GetCellNumber(iCell);
+
+    if(cellAbsId<0) continue;//reject CPV
+    isHG = cells->GetCellHighGain(cellAbsId);
+    cellamp = cells->GetCellAmplitude(cellAbsId);
+    celltime = cells->GetCellTime(cellAbsId);
+
+    fPHOSGeo->AbsToRelNumbering(cellAbsId,relId);
+
+    module = relId[0];
+    cellx  = relId[2];
+    cellz  = relId[3];
+
+    if(module < 1 || module > 4){
+      AliError(Form("Wrong module number %d",module));
+      return;
+    }
+
+    if(isHG) FillHistogramTH2(fOutputContainer,Form("hCellAmpTimeM%d_HG",module),cellamp,celltime*1e+9);
+    else     FillHistogramTH2(fOutputContainer,Form("hCellAmpTimeM%d_LG",module),cellamp,celltime*1e+9);
+
+    nCellModule[module]++;
+    FillHistogramTH2(fOutputContainer,Form("hCellNXZM%d",module),cellx,cellz);
+    FillHistogramTH2(fOutputContainer,Form("hCellEXZM%d",module),cellx,cellz,cellamp);
+  }
+
+  FillHistogramTH1(fOutputContainer,"hCellMultEventM1",nCellModule[1]);
+  FillHistogramTH1(fOutputContainer,"hCellMultEventM2",nCellModule[2]);
+  FillHistogramTH1(fOutputContainer,"hCellMultEventM3",nCellModule[3]);
+  FillHistogramTH1(fOutputContainer,"hCellMultEventM4",nCellModule[4]);
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::TriggerQA() 
+{
+  const Int_t multClust = fPHOSClusterArray->GetEntriesFast();
+  AliVCaloCells *cells = dynamic_cast<AliVCaloCells*>(fEvent->GetPHOSCells());
+
+  AliAODEvent *aod = dynamic_cast<AliAODEvent*>(fEvent);
+
+  AliVCaloTrigger* trg = fEvent->GetCaloTrigger("PHOS");
+  trg->Reset();
+
+  const Int_t Nfired = trg->GetEntries();
+  //if(fPHOSTriggerAnalysis) cout << "Number of fired region = " <<trg->GetEntries() << endl;
+  FillHistogramTH1(fOutputContainer,"hNFiredTRUChannel",Nfired);
+
+  Int_t trgrelId[4]={};
+  Int_t tmod=0; //"Online" module number
+  Int_t trgabsId=0; //bottom-left 4x4 edge cell absId [1-64], [1-56]
+  Int_t trgmodule=0,trgcellx=0,trgcellz=0;
+
+  Int_t relId[4]={};
+  Int_t module=0,cellx=0,cellz=0;
+  Double_t energy=0, tof=0;
+
+  Bool_t IsMatched = kFALSE;
+  Bool_t IsFilledOnce = kFALSE;//flag to avoid double counting
+
+  AliPHOSTriggerHelper *helper = (AliPHOSTriggerHelper*)(fPHOSEventCuts->GetPHOSTriggerHelper());
+  const Int_t L1input = helper->GetL1TriggerInput();
+  const Int_t L0input = helper->GetL0TriggerInput();
+
+  Int_t L1=-999;
+  if(L1input > 0){
+    if     (L1input == 7) L1 = 0;//L1 high
+    else if(L1input == 6) L1 = 1;//L1 medium
+    else if(L1input == 5) L1 = 2;//L1 low
+  }
+  else if(L0input > 0){
+    if(L0input == 9) L1 = -1;//L0
+  }
+
+  Int_t kUsedCluster[] = {multClust*0};
+
+  while(trg->Next()){
+
+    FillHistogramTH1(fOutputContainer,"hPHI7Summary",trg->GetL1TimeSum());
+
+    if(trg->GetL1TimeSum() != L1) continue;
+
+    trg->GetPosition(tmod,trgabsId);//tmod is online module numbering. i.e., tmod=1 means half module.
+
+    //cout << "tmod = "<< tmod << " , trgabsId = " << trgabsId << endl;
+
+    fPHOSGeo->AbsToRelNumbering(trgabsId,trgrelId);
+    //for offline numbering, relId should be used.
+
+    trgmodule = trgrelId[0];
+    trgcellx  = trgrelId[2];
+    trgcellz  = trgrelId[3];
+
+    //cout << "trgmodule = "<< trgmodule << endl;
+
+    if(trgmodule < 1 || trgmodule > 4){
+      AliError(Form("Wrong module number %d",trgmodule));
+      return;
+    }
+
+    FillHistogramTH1(fOutputContainer,Form("hFiredTRUChannelM%d",trgmodule),trgcellx,trgcellz);
+
+    for(Int_t i=0;i<multClust;i++){
+      AliCaloPhoton *ph = (AliCaloPhoton*)fPHOSClusterArray->At(i);
+      AliVCluster *clu1 = (AliVCluster*)ph->GetCluster();
+      energy = ph->Energy();
+
+      Int_t maxAbsId = helper->FindHighestAmplitudeCellAbsId(clu1, cells);
+      //cout << "maxAbsId = " << maxAbsId << endl;
+
+      fPHOSGeo->AbsToRelNumbering(maxAbsId,relId);
+      module = relId[0];
+      cellx  = relId[2];
+      cellz  = relId[3];
+
+      if(module < 1 || module > 4){
+        AliError(Form("Wrong module number %d",module));
+        return;
+      }
+
+      //cout << "module = " << module << " , cellx = " << cellx << " , cellz = " << cellz << endl;
+      Int_t diffx = trgcellx - cellx;
+      Int_t diffz = trgcellz - cellz;
+      FillHistogramTH3(fOutputContainer,Form("hDistanceXZM%dTRU%d",trgmodule,helper->WhichTRU(trgcellx,trgcellz)),diffx,diffz,energy);
+
+      if(!IsFilledOnce){//to avoid double counting of energy
+        FillHistogramTH1(fOutputContainer,Form("hClusterEnergyM%d",module),energy);
+        FillHistogramTH1(fOutputContainer,Form("hClusterEnergyM%dTRU%d",module,helper->WhichTRU(cellx,cellz)),energy);
+        FillHistogramTH3(fOutputContainer,Form("hClusterHitM%d",module),cellx,cellz,energy);
+      }
+
+      if(helper->IsMatched(trgrelId,relId)){
+//        ph->SetTrig(kTRUE);
+        FillHistogramTH3(fOutputContainer,Form("hMatchedFiredTRUChannelM%d",trgmodule),trgcellx,trgcellz,energy);
+        FillHistogramTH3(fOutputContainer,Form("hMatchedDistanceXZM%dTRU%d",trgmodule,helper->WhichTRU(trgcellx,trgcellz)),diffx,diffz,energy);
+
+        if(kUsedCluster[i] == 0){
+          FillHistogramTH1(fOutputContainer,Form("hMatchedClusterEnergyM%d",module),energy);
+          FillHistogramTH1(fOutputContainer,Form("hMatchedClusterEnergyM%dTRU%d",trgmodule,helper->WhichTRU(trgcellx,trgcellz)),energy);
+          FillHistogramTH3(fOutputContainer,Form("hMatchedClusterHitM%d",module),cellx,cellz,energy);
+        }
+        kUsedCluster[i] = 1;
+      }
+
+    }//end of cluster loop
+
+    IsFilledOnce = kTRUE;
+
+  }//end of while trigger loop
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::ClusterQA() 
+{
+  const Int_t multClust = fPHOSClusterArray->GetEntriesFast();
+
+  Int_t multPHOSClust[5]={};
+  Int_t multPHOSClustTOF[5]={};
+
+  Double_t cellamp=0;
+  Int_t module=0,cellx=0,cellz=0;
+  Int_t relId[4]={};
+  Double_t position[3] = {};
+  Int_t digMult=0;
+  Double_t energy=0,tof=0,eta=0,phi=0;
+  Double_t DistToBadChannel = 0;
+  Double_t M20=0, M02=0;
+  Double_t R = 0, coreR=0;
+  Double_t coreE = 0;
+  Double_t r=999, trackPt=0;
+
+  for(Int_t i1=0;i1<multClust;i1++){
+    AliCaloPhoton *ph = (AliCaloPhoton*)fPHOSClusterArray->At(i1);
+    if(!fPHOSClusterCuts->AcceptPhoton(ph)) continue;
+
+    energy  = ph->Energy();
+    if(fUseCoreEnergy){
+      energy = (ph->GetMomV2())->Energy();
+    }
+
+    digMult = ph->GetNCells();
+    tof     = ph->GetTime();//unit is second.
+    M20 = ph->GetLambda1();
+    M02 = ph->GetLambda2();
+
+    position[0] = ph->EMCx();
+    position[1] = ph->EMCy();
+    position[2] = ph->EMCz();
+
+    relId[0] = 0; relId[1] = 0; relId[2] = 0; relId[3] = 0;
+    TVector3 global1(position);
+    fPHOSGeo->GlobalPos2RelId(global1,relId);
+
+    module = relId[0];
+    cellx  = relId[2];
+    cellz  = relId[3];
+
+    if(module < 1 || module > 4){
+      AliError(Form("Wrong module number %d",module));
+      return;
+    }
+
+    eta = global1.Eta();
+    phi = global1.Phi();
+    if(phi<0) phi += TMath::TwoPi();
+    FillHistogramTH2(fOutputContainer,"hClusterEtaPhi",eta,phi);
+
+    FillHistogramTH2(fOutputContainer,Form("hClusterEvsNM%d",module),energy,digMult);
+    FillHistogramTH2(fOutputContainer,Form("hClusterEvsTM%d",module),energy,tof*1e+9);
+    FillHistogramTH2(fOutputContainer,Form("hCluNXZM%d",module),cellx,cellz);
+    FillHistogramTH2(fOutputContainer,Form("hCluEXZM%d",module),cellx,cellz,energy);
+    FillHistogramTH3(fOutputContainer,"hEvsNvsM02",energy,digMult,M02);
+   
+    R     = ph->GetNsigmaFullDisp();
+    coreR = ph->GetNsigmaCoreDisp();
+    coreE = (ph->GetMomV2())->Energy();
+    AliVCluster *clu = (AliVCluster*)ph->GetCluster();
+    AliVTrack *track = 0x0;
+
+    if(fESDEvent){
+      Int_t trackindex = clu->GetTrackMatchedIndex();
+      if(trackindex > 0){
+        track = (AliVTrack*)(fEvent->GetTrack(trackindex));
+      }//end of track matching
+    }//end of ESD
+    else if(fAODEvent){
+      if(clu->GetNTracksMatched() > 0){
+        track = dynamic_cast<AliVTrack*>(clu->GetTrackMatched(0));
+      }//end of track matching
+    }//end of AOD
+
+    if(track){
+      trackPt = track->Pt();
+      r = ph->GetNsigmaCPV();
+      FillHistogramTH2(fOutputContainer,Form("hRvsTrackPtM%d",module),r,trackPt);
+    } 
+ 
+    FillHistogramTH2(fOutputContainer,Form("hFullDispvsFullEM%d",module),energy,R);
+    FillHistogramTH2(fOutputContainer,Form("hCoreDispvsCoreEM%d",module),coreE,coreR);
+    FillHistogramTH2(fOutputContainer,Form("hFullDispvsCoreEM%d",module),coreE,R);
+    FillHistogramTH2(fOutputContainer,Form("hCoreDispvsFullEM%d",module),energy,coreR);
+
+    DistToBadChannel = ph->DistToBad()/100.;
+    FillHistogramTH2(fOutputContainer,"hEnergyvsDistanceToBadChannel",energy,DistToBadChannel);
+
+    multPHOSClust[0]++;
+    multPHOSClust[module]++;
+
+    FillHistogramTH1(fOutputContainer,Form("hPHOSClusterEnergyM%d",module),energy);
+    if(ph->IsTOFOK()){// unit in ns.
+      multPHOSClustTOF[0]++;
+      multPHOSClustTOF[module]++;
+      FillHistogramTH2(fOutputContainer,Form("hCluNXZTOFM%d",module),cellx,cellz);
+      FillHistogramTH2(fOutputContainer,Form("hCluEXZTOFM%d",module),cellx,cellz,energy);
+      FillHistogramTH1(fOutputContainer,Form("hPHOSClusterEnergyTOFM%d",module),energy);
+    }
+
+    if(energy > 0.5){
+      if(energy < 2.){// 0.5 < energy < 2GeV
+        FillHistogramTH2(fOutputContainer,Form("hCluLowNXZM%d",module),cellx,cellz);
+        FillHistogramTH2(fOutputContainer,Form("hCluLowEXZM%d",module),cellx,cellz,energy);
+      }
+      else{//energy>=2GeV
+        FillHistogramTH2(fOutputContainer,Form("hCluHighNXZM%d",module),cellx,cellz);
+        FillHistogramTH2(fOutputContainer,Form("hCluHighEXZM%d",module),cellx,cellz,energy);
+      }
+    }
+
+    FillHistogramTH2(fOutputContainer,Form("hClusterEvsM02M%d",module),energy,M02);
+    FillHistogramTH2(fOutputContainer,Form("hClusterNvsM02M%d",module),digMult,M02);
+  }//end of cluster loop
+
+  FillHistogramTH1(fOutputContainer,"hPHOSClusterMultM1",multPHOSClust[1]);
+  FillHistogramTH1(fOutputContainer,"hPHOSClusterMultM2",multPHOSClust[2]);
+  FillHistogramTH1(fOutputContainer,"hPHOSClusterMultM3",multPHOSClust[3]);
+  FillHistogramTH1(fOutputContainer,"hPHOSClusterMultM4",multPHOSClust[4]);
+
+  //for TOF cut
+  FillHistogramTH1(fOutputContainer,"hPHOSClusterMultTOFM1",multPHOSClustTOF[1]);
+  FillHistogramTH1(fOutputContainer,"hPHOSClusterMultTOFM2",multPHOSClustTOF[2]);
+  FillHistogramTH1(fOutputContainer,"hPHOSClusterMultTOFM3",multPHOSClustTOF[3]);
+  FillHistogramTH1(fOutputContainer,"hPHOSClusterMultTOFM4",multPHOSClustTOF[4]);
+  //for tof cut end
+
+  FillHistogramTH2(fOutputContainer,"hCentralityvsPHOSClusterMultiplicity"   ,fCentralityMain  ,multPHOSClust[0]);
+  FillHistogramTH2(fOutputContainer,"hCentralityvsPHOSClusterMultiplicityTOF",fCentralityMain  ,multPHOSClustTOF[0]);
+
+  FillHistogramTH2(fOutputContainer,"hCentralityV0MvsPHOSClusterMultiplicity"   ,fCentralityV0M,multPHOSClust[0]);
+  FillHistogramTH2(fOutputContainer,"hCentralityV0MvsPHOSClusterMultiplicityTOF",fCentralityV0M,multPHOSClustTOF[0]);
+
+  FillHistogramTH2(fOutputContainer,"hCentralityZNAvsPHOSClusterMultiplicity"   ,fCentralityZNA,multPHOSClust[0]);
+  FillHistogramTH2(fOutputContainer,"hCentralityZNAvsPHOSClusterMultiplicityTOF",fCentralityZNA,multPHOSClustTOF[0]);
+
+  FillHistogramTH2(fOutputContainer,"hCentralityZNCvsPHOSClusterMultiplicity"   ,fCentralityZNA,multPHOSClust[0]);
+  FillHistogramTH2(fOutputContainer,"hCentralityZNCvsPHOSClusterMultiplicityTOF",fCentralityZNA,multPHOSClustTOF[0]);
+
+  FillHistogramTH2(fOutputContainer,"hPHOSClusterMultiplicityvsTrackMultiplicity",fNHybridTrack,multPHOSClust[0]);
+  FillHistogramTH2(fOutputContainer,"hPHOSClusterMultiplicityTOFvsTrackMultiplicity",fNHybridTrack,multPHOSClustTOF[0]);
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::FillPhoton() 
+{
+  
+  AliESDEvent *esd = dynamic_cast<AliESDEvent*>(fEvent);
+  AliAODEvent *aod = dynamic_cast<AliAODEvent*>(fEvent);
+
+  const Int_t multClust = fPHOSClusterArray->GetEntriesFast();
+  AliAODMCParticle *p = 0x0;
+
+  Double_t pT=0,energy=0;
+  Double_t eff=1;
+  TF1 *f1tof = GetTOFCutEfficiencyFunction();
+
+  Int_t firstJetindex = -1;
+  Int_t lastJetindex  = -1;
+  Int_t genIDJet = -1;
+
+  if(fIsJJMC){
+    firstJetindex = fJJMCHandler->GetFirstJetIndex();
+    lastJetindex  = fJJMCHandler->GetLastJetIndex();
+    genIDJet = fJJMCHandler->GetGeneratorJetIndex();
+  }
+  AliInfo(Form("genIDJet = %d , firstindexJet = %d , lastindexJet = %d.",genIDJet,firstJetindex,lastJetindex));
+
+  Double_t weight = 1.;
+  TF1 *f1Pi0Weight = 0x0;
+  if(fIsMC) f1Pi0Weight = (TF1*)GetAdditionalPi0PtWeightFunction();
+  Int_t primary = -1;
+  Double_t TruePi0Pt = 1.;
+
+  for(Int_t iph=0;iph<multClust;iph++){
+    AliCaloPhoton *ph = (AliCaloPhoton*)fPHOSClusterArray->At(iph);
+    if(!fPHOSClusterCuts->AcceptPhoton(ph)) continue;
+    pT = ph->Pt();
+    energy = ph->Energy();
+
+    if(fUseCoreEnergy){
+      pT = (ph->GetMomV2())->Pt();
+      energy = (ph->GetMomV2())->Energy();
+    }
+
+    eff = f1tof->Eval(energy);
+
+    if(fIsMC){
+      primary = ph->GetPrimary();
+      Bool_t isFromPi0 = IsFromPi0(primary,TruePi0Pt);
+      if(isFromPi0){
+        weight = f1Pi0Weight->Eval(TruePi0Pt);
+        //cout << "true pi0 pT = " << TruePi0Pt << endl;
+      }
+      if(fIsJJMC){
+        if(esd){
+          if(primary < firstJetindex || lastJetindex < primary) continue;
+        }
+        else if(aod){
+          //if(primary < firstJetindex || lastJetindex < primary) continue;
+          p = (AliAODMCParticle*)fMCArrayAOD->At(primary);
+          if(p->GetGeneratorIndex() != genIDJet) continue;
+        }
+      }
+    }
+
+    FillHistogramTH1(fOutputContainer,Form("hPhotonPt_Cen%d",fCenBin),pT,weight);
+    //FillHistogramTH1(fOutputContainer,Form("hPhotonPt_M%d_Cen%d",ph->Module(),fCenBin),pT,weight);
+
+    if(ph->IsTOFOK()){
+      FillHistogramTH1(fOutputContainer,Form("hPhotonPt_Cen%d_TOF",fCenBin),pT,1/eff * weight);
+      //FillHistogramTH1(fOutputContainer,Form("hPhotonPt_M%d_Cen%d_TOF",ph->Module(),fCenBin),pT,1/eff * weight);
+    }
+
+    if(fIsMC){
+      if(IsPhoton(primary)) FillHistogramTH1(fOutputContainer,Form("hPurityGamma_Cen%d",fCenBin),pT,weight);
+    }
+
+  }//end of cluster loop
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::FillMgg() 
+{
+  const Int_t multClust = fPHOSClusterArray->GetEntriesFast();
+  TLorentzVector p12, p12core;
+
+  Double_t m12=0,pt12=0,asym=0;
+  Double_t e1=0,e2=0;
+
+  Double_t eff1=1, eff2=1, eff12=1;
+  TF1 *f1tof = GetTOFCutEfficiencyFunction();
+
+  Double_t weight = 1., w1 = 1., w2 = 1.;
+  TF1 *f1Pi0Weight = 0x0;
+  TF1 *f1K0SWeight = 0x0;
+
+  if(fIsMC){
+    f1Pi0Weight = (TF1*)GetAdditionalPi0PtWeightFunction();
+    f1K0SWeight = (TF1*)GetAdditionalK0SPtWeightFunction();
+  }
+
+  Int_t primary1 = -1;
+  Int_t primary2 = -1;
+  Double_t TruePi0Pt1 = 1.;
+  Double_t TruePi0Pt2 = 1.;
+  Int_t commonID = -1;
+  AliAODMCParticle *p = 0x0;
+
+  Int_t genIDJet      = -1;
+  Int_t firstJetindex = -1;
+  Int_t lastJetindex  = -1;
+
+  if(fIsJJMC){
+    genIDJet      = fJJMCHandler->GetGeneratorJetIndex();
+    firstJetindex = fJJMCHandler->GetFirstJetIndex();
+    lastJetindex  = fJJMCHandler->GetLastJetIndex();
+    AliInfo(Form("firstindexJet = %d , lastindexJet = %d.",firstJetindex,lastJetindex));
+  }
+  Double_t TrueK0SPt = 0;
+  Double_t TrueL0Pt = 0;
+
+  for(Int_t i1=0;i1<multClust-1;i1++){
+    AliCaloPhoton *ph1 = (AliCaloPhoton*)fPHOSClusterArray->At(i1);
+    if(!fPHOSClusterCuts->AcceptPhoton(ph1)) continue;
+
+    if(fIsMC){
+      w1=1.;
+      primary1 = ph1->GetPrimary();
+      Bool_t isFromPi0 = IsFromPi0(primary1,TruePi0Pt1);
+      if(isFromPi0){
+        w1 = f1Pi0Weight->Eval(TruePi0Pt1);
+        //cout << "true pi0 pT1 = " << TruePi0Pt1 << endl;
+      }
+
+      if(fIsJJMC){
+        p = (AliAODMCParticle*)fMCArrayAOD->At(primary1);
+        if(p->GetGeneratorIndex() != genIDJet) continue;
+        //if(primary1 < firstJetindex || lastJetindex < primary1) continue;
+      }
+    }
+
+    for(Int_t i2=i1+1;i2<multClust;i2++){
+      AliCaloPhoton *ph2 = (AliCaloPhoton*)fPHOSClusterArray->At(i2);
+      if(!fPHOSClusterCuts->AcceptPhoton(ph2)) continue;
+
+      if(fIsMC){
+        w2=1.;
+        primary2 = ph2->GetPrimary();
+        Bool_t isFromPi0 = IsFromPi0(primary2,TruePi0Pt2);
+        if(isFromPi0){
+          w2 = f1Pi0Weight->Eval(TruePi0Pt2);
+          //cout << "true pi0 pT2 = " << TruePi0Pt2 << endl;
+        }
+        if(fIsJJMC){
+          p = (AliAODMCParticle*)fMCArrayAOD->At(primary2);
+          if(p->GetGeneratorIndex() != genIDJet) continue;
+          //if(primary2 < firstJetindex || lastJetindex < primary2) continue;
+        }
+      }
+
+      e1 = ph1->Energy();
+      e2 = ph2->Energy();
+
+      p12 = *ph1 + *ph2;
+      m12 = p12.M();
+      pt12 = p12.Pt();
+      asym  = TMath::Abs((ph1->Energy()-ph2->Energy())/(ph1->Energy()+ph2->Energy()));//always full energy
+
+      if(fUseCoreEnergy){
+        p12core = *(ph1->GetMomV2()) + *(ph2->GetMomV2());
+        m12 = p12core.M();
+        pt12 = p12core.Pt();
+
+        e1 = (ph1->GetMomV2())->Energy();
+        e2 = (ph2->GetMomV2())->Energy();
+
+        //cout << "core e1 = " << e1 << " , core e2 = " << e2 << endl;
+      }
+
+      eff1 = f1tof->Eval(e1);
+      eff2 = f1tof->Eval(e2);
+      eff12 = eff1 * eff2;
+
+      if(fIsMC){
+        commonID = FindCommonParent(primary1,primary2);
+        if(commonID > -1) weight = w1;
+        else weight = w1*w2;
+
+        //for feed down correction from K0S->pi0 + pi0
+        if(IsFromK0S(primary1,primary2,TrueK0SPt)){
+          weight *= f1K0SWeight->Eval(TrueK0SPt);
+          FillHistogramTH2(fOutputContainer,Form("hMggFromK0S_Cen%d",fCenBin),m12,pt12,weight);
+          if(asym < 0.8) FillHistogramTH2(fOutputContainer,Form("hMggFromK0S_Cen%d_asym08",fCenBin),m12,pt12,weight);
+          //          if(asym < 0.7) FillHistogramTH2(fOutputContainer,Form("hMggFromK0S_Cen%d_asym07",fCenBin),m12,pt12,weight);
+        }
+        if(IsFromLambda0(primary1,primary2,TrueL0Pt)){//this contibution is neglegible
+          weight *= 1.;
+          FillHistogramTH2(fOutputContainer,Form("hMggFromLambda0_Cen%d",fCenBin),m12,pt12,weight);
+          if(asym < 0.8) FillHistogramTH2(fOutputContainer,Form("hMggFromLambda0_Cen%d_asym08",fCenBin),m12,pt12,weight);
+          //          if(asym < 0.7) FillHistogramTH2(fOutputContainer,Form("hMggFromLambda0_Cen%d_asym07",fCenBin),m12,pt12,weight);
+        }
+
+      }//end of if fIsMC
+
+      if(TMath::Abs(ph1->Module()-ph2->Module()) < 2) FillHistogramTH2(fOutputContainer,Form("hMgg_M%d%d",TMath::Min(ph1->Module(),ph2->Module()), TMath::Max(ph1->Module(),ph2->Module())),m12,pt12,weight);
+      FillHistogramTH2(fOutputContainer,Form("hMgg_Cen%d",fCenBin),m12,pt12,weight);
+
+      FillHistogramTH2(fOutputContainer,"hAsymvsMgg",asym,m12,weight);
+      if(0.12 < m12 && m12 < 0.15) FillHistogramTH2(fOutputContainer,"hAsymvsPt",asym,pt12,weight);
+
+      if(asym < 0.8) FillHistogramTH2(fOutputContainer,Form("hMgg_Cen%d_asym08",fCenBin),m12,pt12,weight);
+//      if(asym < 0.7) FillHistogramTH2(fOutputContainer,Form("hMgg_Cen%d_asym07",fCenBin),m12,pt12,weight);
+
+      if(ph1->IsTOFOK() && ph2->IsTOFOK()){
+        FillHistogramTH2(fOutputContainer,Form("hMgg_Cen%d_TOF",fCenBin),m12,pt12,1/eff12 * weight);
+
+        if(TMath::Abs(ph1->Module()-ph2->Module()) < 2) FillHistogramTH2(fOutputContainer,Form("hMgg_M%d%d_TOF",TMath::Min(ph1->Module(),ph2->Module()), TMath::Max(ph1->Module(),ph2->Module())),m12,pt12,1/eff12 * weight);
+
+        if(asym < 0.8) FillHistogramTH2(fOutputContainer,Form("hMgg_Cen%d_TOF_asym08",fCenBin),m12,pt12,1/eff12 * weight);
+//        if(asym < 0.7) FillHistogramTH2(fOutputContainer,Form("hMgg_Cen%d_TOF_asym07",fCenBin),m12,pt12,1/eff12 * weight);
+
+      }//end of TOF cut
+
+    }//end of ph2
+
+  }//end of ph1
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::FillMixMgg() 
+{
+  TList *prevPHOS = fPHOSEvents[fZvtx][fCenBin];
+
+  const Int_t multClust = fPHOSClusterArray->GetEntriesFast();
+  AliAODMCParticle *p = 0x0;
+
+  TLorentzVector p12, p12core;
+  Double_t m12=0,pt12=0,asym=0,m12core=0,pt12core=0;
+  Double_t eff1=1, eff2=1, eff12=1;
+  Double_t e1=0,e2=0;
+  TF1 *f1tof = GetTOFCutEfficiencyFunction();
+
+  Int_t primary1 = -1;
+  Int_t primary2 = -1;
+
+  Int_t genIDJet      = -1;
+  Int_t firstJetindex = -1;
+  Int_t lastJetindex  = -1;
+
+  if(fIsJJMC){
+    genIDJet      = fJJMCHandler->GetGeneratorJetIndex();
+    firstJetindex = fJJMCHandler->GetFirstJetIndex();
+    lastJetindex  = fJJMCHandler->GetLastJetIndex();
+    AliInfo(Form("firstindexJet = %d , lastindexJet = %d.",firstJetindex,lastJetindex));
+  }
+
+  for(Int_t i1=0;i1<multClust;i1++){
+    AliCaloPhoton *ph1 = (AliCaloPhoton*)fPHOSClusterArray->At(i1);
+    if(!fPHOSClusterCuts->AcceptPhoton(ph1)) continue;
+
+    if(fIsJJMC){
+      primary1 = ph1->GetPrimary();
+      p = (AliAODMCParticle*)fMCArrayAOD->At(primary1);
+      if(p->GetGeneratorIndex() != genIDJet) continue;
+      //if(primary1 < firstJetindex || lastJetindex < primary1) continue;
+    }
+
+    for(Int_t ev=0;ev<prevPHOS->GetSize();ev++){
+      TClonesArray *mixPHOS = static_cast<TClonesArray*>(prevPHOS->At(ev));
+
+      for(Int_t i2=0;i2<mixPHOS->GetEntriesFast();i2++){
+        AliCaloPhoton *ph2 = (AliCaloPhoton*)mixPHOS->At(i2);
+        if(!fPHOSClusterCuts->AcceptPhoton(ph2)) continue;
+
+        //if(fIsJJMC){
+        //  primary2 = ph2->GetPrimary();
+        //  p = (AliAODMCParticle*)fMCArrayAOD->At(primary2);
+        //  if(p->GetGeneratorIndex() != genIDJet) continue;
+        //  //if(primary2 < firstJetindex || lastJetindex < primary2) continue;
+        //}
+
+        e1 = ph1->Energy();
+        e2 = ph2->Energy();
+
+        p12 = *ph1 + *ph2;
+        m12 = p12.M();
+        pt12 = p12.Pt();
+        asym  = TMath::Abs((ph1->Energy()-ph2->Energy())/(ph1->Energy()+ph2->Energy()));
+
+        if(fUseCoreEnergy){
+          p12core = *(ph1->GetMomV2()) + *(ph2->GetMomV2());
+          m12 = p12core.M();
+          pt12 = p12core.Pt();
+
+          e1 = (ph1->GetMomV2())->Energy();
+          e2 = (ph2->GetMomV2())->Energy();
+        }
+
+        eff1 = f1tof->Eval(e1);
+        eff2 = f1tof->Eval(e2);
+        eff12 = eff1 * eff2;
+
+
+        FillHistogramTH2(fOutputContainer,Form("hMixMgg_Cen%d",fCenBin),m12,pt12);
+        if(TMath::Abs(ph1->Module()-ph2->Module())<2)FillHistogramTH2(fOutputContainer,Form("hMixMgg_M%d%d",TMath::Min(ph1->Module(),ph2->Module()), TMath::Max(ph1->Module(),ph2->Module())),m12,pt12);
+
+        if(asym < 0.8) FillHistogramTH2(fOutputContainer,Form("hMixMgg_Cen%d_asym08",fCenBin),m12,pt12);
+//        if(asym < 0.7) FillHistogramTH2(fOutputContainer,Form("hMixMgg_Cen%d_asym07",fCenBin),m12,pt12);
+
+        if(ph1->IsTOFOK() && ph2->IsTOFOK()){
+          FillHistogramTH2(fOutputContainer,Form("hMixMgg_Cen%d_TOF",fCenBin),m12,pt12,1/eff12);
+          if(TMath::Abs(ph1->Module()-ph2->Module())<2)FillHistogramTH2(fOutputContainer,Form("hMixMgg_M%d%d_TOF",TMath::Min(ph1->Module(),ph2->Module()), TMath::Max(ph1->Module(),ph2->Module())),m12,pt12,1/eff12);
+
+          if(asym < 0.8) FillHistogramTH2(fOutputContainer,Form("hMixMgg_Cen%d_TOF_asym08",fCenBin),m12,pt12,1/eff12);
+//          if(asym < 0.7) FillHistogramTH2(fOutputContainer,Form("hMixMgg_Cen%d_TOF_asym07",fCenBin),m12,pt12,1/eff12);
+
+        }//end of TOF cut
+
+      }//end of mix
+
+    }//end of ph2
+
+  }//end of ph1
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::EstimatePIDCutEfficiency()
+{
+  //tag and probe method is used.
+
+  const Int_t multClust = fPHOSClusterArray->GetEntriesFast();
+
+  TLorentzVector p12, p12core;
+  Double_t m12=0,pt12=0;
+  Double_t energy=0;
+
+  for(Int_t i1=0;i1<multClust;i1++){
+    AliCaloPhoton *ph1 = (AliCaloPhoton*)fPHOSClusterArray->At(i1);
+    if(!fPHOSClusterCuts->AcceptPhoton(ph1)) continue;
+
+    for(Int_t i2=0;i2<multClust;i2++){
+      AliCaloPhoton *ph2 = (AliCaloPhoton*)fPHOSClusterArray->At(i2);
+
+      if(i2==i1) continue;//reject same cluster combination
+
+      p12 = *ph1 + *ph2;
+      m12 = p12.M();
+      energy = ph2->Energy();
+
+      if(fUseCoreEnergy){
+        p12core = *(ph1->GetMomV2()) + *(ph2->GetMomV2());
+        m12 = p12core.M();
+        energy = (ph2->GetMomV2())->Energy();
+      }
+
+      FillHistogramTH2(fOutputContainer,Form("hMgg_Probe_PID_Cen%d",fCenBin),m12,energy);
+      if(fPHOSClusterCuts->AcceptPhoton(ph2))
+        FillHistogramTH2(fOutputContainer,Form("hMgg_PassingProbe_PID_Cen%d",fCenBin),m12,energy);
+
+    }//end of ph2
+
+  }//end of ph1
+
+  //next mixed event
+  TList *prevPHOS = fPHOSEvents[fZvtx][fCenBin];
+
+  for(Int_t i1=0;i1<multClust;i1++){
+    AliCaloPhoton *ph1 = (AliCaloPhoton*)fPHOSClusterArray->At(i1);
+    if(!fPHOSClusterCuts->AcceptPhoton(ph1)) continue;
+
+    for(Int_t ev=0;ev<prevPHOS->GetSize();ev++){
+      TClonesArray *mixPHOS = static_cast<TClonesArray*>(prevPHOS->At(ev));
+
+      for(Int_t i2=0;i2<mixPHOS->GetEntriesFast();i2++){
+        AliCaloPhoton *ph2 = (AliCaloPhoton*)mixPHOS->At(i2);
+
+        p12 = *ph1 + *ph2;
+        m12 = p12.M();
+        energy = ph2->Energy();
+
+        if(fUseCoreEnergy){
+          p12core = *(ph1->GetMomV2()) + *(ph2->GetMomV2());
+          m12 = p12core.M();
+          energy = (ph2->GetMomV2())->Energy();
+        }
+
+        FillHistogramTH2(fOutputContainer,Form("hMixMgg_Probe_PID_Cen%d",fCenBin),m12,energy);
+        if(fPHOSClusterCuts->AcceptPhoton(ph2))
+          FillHistogramTH2(fOutputContainer,Form("hMixMgg_PassingProbe_PID_Cen%d",fCenBin),m12,energy);
+
+      }//end of mix
+
+    }//end of ph2
+
+  }//end of ph1
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::EstimateNcellCutEfficiency()
+{
+  //tag and probe method is used.
+
+  const Int_t multClust = fPHOSClusterArray->GetEntriesFast();
+
+  TLorentzVector p12, p12core;
+  Double_t m12=0,pt12=0;
+  Double_t energy=0;
+
+  for(Int_t i1=0;i1<multClust;i1++){
+    AliCaloPhoton *ph1 = (AliCaloPhoton*)fPHOSClusterArray->At(i1);
+    if(!fPHOSClusterCuts->AcceptPhoton(ph1)) continue;
+    if(ph1->GetNCells() < 1) continue;
+
+    for(Int_t i2=0;i2<multClust;i2++){
+      AliCaloPhoton *ph2 = (AliCaloPhoton*)fPHOSClusterArray->At(i2);
+
+      if(i2==i1) continue;//reject same cluster combination
+
+      p12 = *ph1 + *ph2;
+      m12 = p12.M();
+      energy = ph2->Energy();
+
+      if(fUseCoreEnergy){
+        p12core = *(ph1->GetMomV2()) + *(ph2->GetMomV2());
+        m12 = p12core.M();
+        energy = (ph2->GetMomV2())->Energy();
+      }
+
+      FillHistogramTH2(fOutputContainer,Form("hMgg_Probe_Ncell_Cen%d",fCenBin),m12,energy);
+      if(fPHOSClusterCuts->AcceptPhoton(ph2)){
+        if(ph2->GetNCells() > 1)
+          FillHistogramTH2(fOutputContainer,Form("hMgg_PassingProbe_Ncell_Cen%d",fCenBin),m12,energy);
+      }
+    }//end of ph2
+
+  }//end of ph1
+
+  //next mixed event
+  TList *prevPHOS = fPHOSEvents[fZvtx][fCenBin];
+
+  for(Int_t i1=0;i1<multClust;i1++){
+    AliCaloPhoton *ph1 = (AliCaloPhoton*)fPHOSClusterArray->At(i1);
+    if(!fPHOSClusterCuts->AcceptPhoton(ph1)) continue;
+    if(ph1->GetNCells() < 2) continue;
+
+    for(Int_t ev=0;ev<prevPHOS->GetSize();ev++){
+      TClonesArray *mixPHOS = static_cast<TClonesArray*>(prevPHOS->At(ev));
+
+      for(Int_t i2=0;i2<mixPHOS->GetEntriesFast();i2++){
+        AliCaloPhoton *ph2 = (AliCaloPhoton*)mixPHOS->At(i2);
+
+        p12 = *ph1 + *ph2;
+        m12 = p12.M();
+        energy = ph2->Energy();
+
+        if(fUseCoreEnergy){
+          p12core = *(ph1->GetMomV2()) + *(ph2->GetMomV2());
+          m12 = p12core.M();
+          energy = (ph2->GetMomV2())->Energy();
+        }
+
+        FillHistogramTH2(fOutputContainer,Form("hMixMgg_Probe_Ncell_Cen%d",fCenBin),m12,energy);
+        if(fPHOSClusterCuts->AcceptPhoton(ph2)){
+          if(ph2->GetNCells() > 1)
+            FillHistogramTH2(fOutputContainer,Form("hMixMgg_PassingProbe_Ncell_Cen%d",fCenBin),m12,energy);
+        }
+      }//end of mix
+
+    }//end of ph2
+
+  }//end of ph1
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::EstimateM20CutEfficiency()
+{
+  //tag and probe method is used.
+
+  const Int_t multClust = fPHOSClusterArray->GetEntriesFast();
+
+  TLorentzVector p12, p12core;
+  Double_t m12=0,pt12=0;
+  Double_t energy=0;
+
+  for(Int_t i1=0;i1<multClust;i1++){
+    AliCaloPhoton *ph1 = (AliCaloPhoton*)fPHOSClusterArray->At(i1);
+    if(!fPHOSClusterCuts->AcceptPhoton(ph1)) continue;
+    if(ph1->GetLambda1() < 0.2) continue;
+
+    for(Int_t i2=0;i2<multClust;i2++){
+      AliCaloPhoton *ph2 = (AliCaloPhoton*)fPHOSClusterArray->At(i2);
+
+      if(i2==i1) continue;//reject same cluster combination
+
+      p12 = *ph1 + *ph2;
+      m12 = p12.M();
+      energy = ph2->Energy();
+
+      if(fUseCoreEnergy){
+        p12core = *(ph1->GetMomV2()) + *(ph2->GetMomV2());
+        m12 = p12core.M();
+        energy = (ph2->GetMomV2())->Energy();
+      }
+
+      FillHistogramTH2(fOutputContainer,Form("hMgg_Probe_M20_Cen%d",fCenBin),m12,energy);
+      if(fPHOSClusterCuts->AcceptPhoton(ph2)){
+        if(ph2->GetLambda1() > 0.2)
+          FillHistogramTH2(fOutputContainer,Form("hMgg_PassingProbe_M20_Cen%d",fCenBin),m12,energy);
+      }
+    }//end of ph2
+
+  }//end of ph1
+
+  //next mixed event
+  TList *prevPHOS = fPHOSEvents[fZvtx][fCenBin];
+
+  for(Int_t i1=0;i1<multClust;i1++){
+    AliCaloPhoton *ph1 = (AliCaloPhoton*)fPHOSClusterArray->At(i1);
+    if(!fPHOSClusterCuts->AcceptPhoton(ph1)) continue;
+    if(ph1->GetLambda1() < 0.2) continue;
+
+    for(Int_t ev=0;ev<prevPHOS->GetSize();ev++){
+      TClonesArray *mixPHOS = static_cast<TClonesArray*>(prevPHOS->At(ev));
+
+      for(Int_t i2=0;i2<mixPHOS->GetEntriesFast();i2++){
+        AliCaloPhoton *ph2 = (AliCaloPhoton*)mixPHOS->At(i2);
+
+        p12 = *ph1 + *ph2;
+        m12 = p12.M();
+        energy = ph2->Energy();
+
+        if(fUseCoreEnergy){
+          p12core = *(ph1->GetMomV2()) + *(ph2->GetMomV2());
+          m12 = p12core.M();
+          energy = (ph2->GetMomV2())->Energy();
+        }
+
+        FillHistogramTH2(fOutputContainer,Form("hMixMgg_Probe_M20_Cen%d",fCenBin),m12,energy);
+        if(fPHOSClusterCuts->AcceptPhoton(ph2)){
+          if(ph2->GetLambda1() > 0.2)
+            FillHistogramTH2(fOutputContainer,Form("hMixMgg_PassingProbe_M20_Cen%d",fCenBin),m12,energy);
+        }
+      }//end of mix
+
+    }//end of ph2
+
+  }//end of ph1
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::EstimateM02CutEfficiency()
+{
+  //tag and probe method is used.
+
+  const Int_t multClust = fPHOSClusterArray->GetEntriesFast();
+
+  TLorentzVector p12, p12core;
+  Double_t m12=0,pt12=0;
+  Double_t energy=0;
+
+  for(Int_t i1=0;i1<multClust;i1++){
+    AliCaloPhoton *ph1 = (AliCaloPhoton*)fPHOSClusterArray->At(i1);
+    if(!fPHOSClusterCuts->AcceptPhoton(ph1)) continue;
+    if(ph1->GetLambda2() < 0.2) continue;
+
+    for(Int_t i2=0;i2<multClust;i2++){
+      AliCaloPhoton *ph2 = (AliCaloPhoton*)fPHOSClusterArray->At(i2);
+
+      if(i2==i1) continue;//reject same cluster combination
+
+      p12 = *ph1 + *ph2;
+      m12 = p12.M();
+      energy = ph2->Energy();
+
+      if(fUseCoreEnergy){
+        p12core = *(ph1->GetMomV2()) + *(ph2->GetMomV2());
+        m12 = p12core.M();
+        energy = (ph2->GetMomV2())->Energy();
+      }
+
+      FillHistogramTH2(fOutputContainer,Form("hMgg_Probe_M02_Cen%d",fCenBin),m12,energy);
+      if(fPHOSClusterCuts->AcceptPhoton(ph2)){
+        if(ph2->GetLambda2() > 0.2)
+          FillHistogramTH2(fOutputContainer,Form("hMgg_PassingProbe_M02_Cen%d",fCenBin),m12,energy);
+      }
+    }//end of ph2
+
+  }//end of ph1
+
+  //next mixed event
+  TList *prevPHOS = fPHOSEvents[fZvtx][fCenBin];
+
+  for(Int_t i1=0;i1<multClust;i1++){
+    AliCaloPhoton *ph1 = (AliCaloPhoton*)fPHOSClusterArray->At(i1);
+    if(!fPHOSClusterCuts->AcceptPhoton(ph1)) continue;
+    if(ph1->GetLambda2() < 0.2) continue;
+
+    for(Int_t ev=0;ev<prevPHOS->GetSize();ev++){
+      TClonesArray *mixPHOS = static_cast<TClonesArray*>(prevPHOS->At(ev));
+
+      for(Int_t i2=0;i2<mixPHOS->GetEntriesFast();i2++){
+        AliCaloPhoton *ph2 = (AliCaloPhoton*)mixPHOS->At(i2);
+
+        p12 = *ph1 + *ph2;
+        m12 = p12.M();
+        energy = ph2->Energy();
+
+        if(fUseCoreEnergy){
+          p12core = *(ph1->GetMomV2()) + *(ph2->GetMomV2());
+          m12 = p12core.M();
+          energy = (ph2->GetMomV2())->Energy();
+        }
+
+        FillHistogramTH2(fOutputContainer,Form("hMixMgg_Probe_M02_Cen%d",fCenBin),m12,energy);
+        if(fPHOSClusterCuts->AcceptPhoton(ph2)){
+          if(ph2->GetLambda2() > 0.2)
+            FillHistogramTH2(fOutputContainer,Form("hMixMgg_PassingProbe_M02_Cen%d",fCenBin),m12,energy);
+        }
+      }//end of mix
+
+    }//end of ph2
+
+  }//end of ph1
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::EstimateSTDCutEfficiency()
+{
+  //tag and probe method is used.
+
+  const Int_t multClust = fPHOSClusterArray->GetEntriesFast();
+
+  TLorentzVector p12, p12core;
+  Double_t m12=0,pt12=0;
+  Double_t energy=0;
+
+  for(Int_t i1=0;i1<multClust;i1++){
+    AliCaloPhoton *ph1 = (AliCaloPhoton*)fPHOSClusterArray->At(i1);
+    if(!fPHOSClusterCuts->AcceptPhoton(ph1)) continue;
+    if( ph1->Energy() < 0.3 // MIP cut
+        || ph1->GetNCells() < 3 //accidental noise
+        || ph1->GetLambda2() < 0.2 //too small shower shape
+      ) continue;
+
+    for(Int_t i2=0;i2<multClust;i2++){
+      AliCaloPhoton *ph2 = (AliCaloPhoton*)fPHOSClusterArray->At(i2);
+
+      if(i2==i1) continue;//reject same cluster combination
+
+      p12 = *ph1 + *ph2;
+      m12 = p12.M();
+      energy = ph2->Energy();
+
+      if(fUseCoreEnergy){
+        p12core = *(ph1->GetMomV2()) + *(ph2->GetMomV2());
+        m12 = p12core.M();
+        energy = (ph2->GetMomV2())->Energy();
+      }
+
+      FillHistogramTH2(fOutputContainer,Form("hMgg_Probe_STDCut_Cen%d",fCenBin),m12,energy);
+      if(fPHOSClusterCuts->AcceptPhoton(ph2)){
+        if(ph2->Energy() > 0.3 // MIP cut
+        && ph2->GetNCells() > 2 //accidental noise
+        && ph2->GetLambda2() > 0.2 //too small shower shape. Lambda1 = M02 (short axis), Lambda2 = M02 (long axis)
+          )
+          FillHistogramTH2(fOutputContainer,Form("hMgg_PassingProbe_STDCut_Cen%d",fCenBin),m12,energy);
+      }
+    }//end of ph2
+
+  }//end of ph1
+
+  //next mixed event
+  TList *prevPHOS = fPHOSEvents[fZvtx][fCenBin];
+
+  for(Int_t i1=0;i1<multClust;i1++){
+    AliCaloPhoton *ph1 = (AliCaloPhoton*)fPHOSClusterArray->At(i1);
+    if(!fPHOSClusterCuts->AcceptPhoton(ph1)) continue;
+    if( ph1->Energy() < 0.3 // MIP cut
+        || ph1->GetNCells() < 3 //accidental noise
+        || ph1->GetLambda2() < 0.2 //too small shower shape
+      ) continue;
+
+    for(Int_t ev=0;ev<prevPHOS->GetSize();ev++){
+      TClonesArray *mixPHOS = static_cast<TClonesArray*>(prevPHOS->At(ev));
+
+      for(Int_t i2=0;i2<mixPHOS->GetEntriesFast();i2++){
+        AliCaloPhoton *ph2 = (AliCaloPhoton*)mixPHOS->At(i2);
+
+        p12 = *ph1 + *ph2;
+        m12 = p12.M();
+        energy = ph2->Energy();
+
+        if(fUseCoreEnergy){
+          p12core = *(ph1->GetMomV2()) + *(ph2->GetMomV2());
+          m12 = p12core.M();
+          energy = (ph2->GetMomV2())->Energy();
+        }
+
+        FillHistogramTH2(fOutputContainer,Form("hMixMgg_Probe_STDCut_Cen%d",fCenBin),m12,energy);
+        if(fPHOSClusterCuts->AcceptPhoton(ph2)){
+          if(ph2->Energy() > 0.3 // MIP cut
+          && ph2->GetNCells() > 2 //accidental noise
+          && ph2->GetLambda2() > 0.2 //too small shower shape
+            )
+            FillHistogramTH2(fOutputContainer,Form("hMixMgg_PassingProbe_STDCut_Cen%d",fCenBin),m12,energy);
+        }
+      }//end of mix
+
+    }//end of ph2
+
+  }//end of ph1
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::EstimateTOFCutEfficiency()
+{
+  //tag and probe method is used.
+
+  const Int_t multClust = fPHOSClusterArray->GetEntriesFast();
+
+  TLorentzVector p12, p12core;
+  Double_t m12=0,pt12=0;
+  Double_t energy=0;
+
+  for(Int_t i1=0;i1<multClust;i1++){
+    AliCaloPhoton *ph1 = (AliCaloPhoton*)fPHOSClusterArray->At(i1);
+    if(!fPHOSClusterCuts->AcceptPhoton(ph1)) continue;
+    if(!ph1->IsTOFOK()) continue;
+
+    for(Int_t i2=0;i2<multClust;i2++){
+      AliCaloPhoton *ph2 = (AliCaloPhoton*)fPHOSClusterArray->At(i2);
+      if(!fPHOSClusterCuts->AcceptPhoton(ph2)) continue;
+
+      if(i2==i1) continue;//reject same cluster combination
+
+      p12 = *ph1 + *ph2;
+      m12 = p12.M();
+      energy = ph2->Energy();
+
+      if(fUseCoreEnergy){
+        p12core = *(ph1->GetMomV2()) + *(ph2->GetMomV2());
+        m12 = p12core.M();
+        energy = (ph2->GetMomV2())->Energy();
+      }
+
+      FillHistogramTH2(fOutputContainer,Form("hMgg_Probe_TOF_Cen%d",fCenBin),m12,energy);
+      if(ph2->IsTOFOK()) FillHistogramTH2(fOutputContainer,Form("hMgg_PassingProbe_TOF_Cen%d",fCenBin),m12,energy);
+
+    }//end of ph2
+
+  }//end of ph1
+
+  //next mixed event
+  TList *prevPHOS = fPHOSEvents[fZvtx][fCenBin];
+
+  for(Int_t i1=0;i1<multClust;i1++){
+    AliCaloPhoton *ph1 = (AliCaloPhoton*)fPHOSClusterArray->At(i1);
+    if(!fPHOSClusterCuts->AcceptPhoton(ph1)) continue;
+    if(!ph1->IsTOFOK()) continue;
+
+    for(Int_t ev=0;ev<prevPHOS->GetSize();ev++){
+      TClonesArray *mixPHOS = static_cast<TClonesArray*>(prevPHOS->At(ev));
+
+      for(Int_t i2=0;i2<mixPHOS->GetEntriesFast();i2++){
+        AliCaloPhoton *ph2 = (AliCaloPhoton*)mixPHOS->At(i2);
+        if(!fPHOSClusterCuts->AcceptPhoton(ph2)) continue;
+
+        p12 = *ph1 + *ph2;
+        m12 = p12.M();
+        energy = ph2->Energy();
+
+        if(fUseCoreEnergy){
+          p12core = *(ph1->GetMomV2()) + *(ph2->GetMomV2());
+          m12 = p12core.M();
+          energy = (ph2->GetMomV2())->Energy();
+        }
+
+        FillHistogramTH2(fOutputContainer,Form("hMixMgg_Probe_TOF_Cen%d",fCenBin),m12,energy);
+        if(ph2->IsTOFOK()) FillHistogramTH2(fOutputContainer,Form("hMixMgg_PassingProbe_TOF_Cen%d",fCenBin),m12,energy);
+
+      }//end of mix
+
+    }//end of ph2
+
+  }//end of ph1
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::SelectTriggeredCluster()
+{
+
+  Int_t trgrelId[4]={};
+  Int_t tmod=0; //"Online" module number
+  Int_t trgabsId=0; //bottom-left 4x4 edge cell absId [1-64], [1-56]
+  Int_t trgmodule=0,trgcellx=0,trgcellz=0;
+
+  Int_t relId[4]={};
+  Int_t module=0,cellx=0,cellz=0,tru=0;
+  Double_t energy=0;
+
+  AliVCaloTrigger* trg = fEvent->GetCaloTrigger("PHOS");
+  trg->Reset();
+  
+  AliVCaloCells *cells = dynamic_cast<AliVCaloCells*>(fEvent->GetPHOSCells());
+  AliPHOSTriggerHelper *helper = (AliPHOSTriggerHelper*)(fPHOSEventCuts->GetPHOSTriggerHelper());
+  const Int_t L1input = helper->GetL1TriggerInput();
+  const Int_t L0input = helper->GetL0TriggerInput();
+
+  Int_t L1=-999;
+  if(L1input > 0){
+    if     (L1input == 7) L1 = 0;//L1 high
+    else if(L1input == 6) L1 = 1;//L1 medium
+    else if(L1input == 5) L1 = 2;//L1 low
+  }
+  else if(L0input > 0){
+    if(L0input == 9) L1 = -1;//L0
+  }
+
+  const Int_t multClust = fPHOSClusterArray->GetEntriesFast();
+
+  for(Int_t i=0;i<multClust;i++){
+    AliCaloPhoton *ph = (AliCaloPhoton*)fPHOSClusterArray->At(i);
+    AliVCluster *clu1 = (AliVCluster*)ph->GetCluster();
+
+    Int_t maxAbsId = helper->FindHighestAmplitudeCellAbsId(clu1, cells);
+    //cout << "maxAbsId = " << maxAbsId << endl;
+
+    fPHOSGeo->AbsToRelNumbering(maxAbsId,relId);
+    module = relId[0];
+    cellx  = relId[2];
+    cellz  = relId[3];
+
+    if(module < 1 || module > 4){
+      AliError(Form("Wrong module number %d",module));
+      return;
+    }
+    AliInfo(Form("cluster position M:%d, X:%d , Z:%d",module,cellx,cellz));
+
+    while(trg->Next()){
+
+      if(trg->GetL1TimeSum() != L1) continue;
+
+      trg->GetPosition(tmod,trgabsId);//tmod is online module numbering. i.e., tmod=1 means half module.
+
+      //cout << "tmod = "<< tmod << " , trgabsId = " << trgabsId << endl;
+
+      fPHOSGeo->AbsToRelNumbering(trgabsId,trgrelId);
+      //for offline numbering, relId should be used.
+
+      trgmodule = trgrelId[0];
+      trgcellx  = trgrelId[2];
+      trgcellz  = trgrelId[3];
+
+      AliInfo(Form("fired TRU channel M:%d, X:%d , Z:%d",trgmodule,trgcellx,trgcellz));
+
+      if(trgmodule < 1 || trgmodule > 4){
+        AliError(Form("Wrong module number %d",trgmodule));
+        return;
+      }
+
+      if(helper->IsMatched(trgrelId,relId)){
+        ph->SetTrig(kTRUE);
+        break;
+      }
+    }//end of while trigger patch loop
+
+  }//end of cluster loop
+
+  for(Int_t i=0;i<multClust;i++){
+    AliCaloPhoton *ph = (AliCaloPhoton*)fPHOSClusterArray->At(i);
+    if(!fPHOSClusterCuts->AcceptPhoton(ph)) continue;
+
+    energy = ph->Energy();
+    if(fUseCoreEnergy) energy = (ph->GetMomV2())->Energy();
+
+    tru = helper->WhichTRU(cellx,cellz);
+    FillHistogramTH1(fOutputContainer,Form("hClusterE_Cen%d_M%d_TRU%d",fCenBin,module,tru),energy);
+    if(ph->IsTrig()) FillHistogramTH1(fOutputContainer,Form("hTriggeredClusterE_Cen%d_M%d_TRU%d",fCenBin,module,tru),energy);
+  }//end of cluster loop
+
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::EstimateTriggerEfficiency()
+{
+  //tag and probe method is used.
+
+  const Int_t multClust = fPHOSClusterArray->GetEntriesFast();
+
+  Double_t position[3] = {};
+  Double_t energy=0;
+  Int_t module_tag=0,cellx_tag=0,cellz_tag=0,tru_tag=0;
+  Int_t module=0,cellx=0,cellz=0,tru=0;
+  Int_t relId[4]={};
+
+  Int_t truch_tag = -1, chX_tag=-1, chZ_tag=-1;
+  Int_t truch = -1, chX=-1, chZ=-1;
+
+  TLorentzVector p12, p12core;
+  Double_t m12=0,pt12=0;
+
+  AliPHOSTriggerHelper *helper = (AliPHOSTriggerHelper*)(fPHOSEventCuts->GetPHOSTriggerHelper());
+
+  for(Int_t i1=0;i1<multClust;i1++){
+    AliCaloPhoton *ph1 = (AliCaloPhoton*)fPHOSClusterArray->At(i1);
+    if(!fPHOSClusterCuts->AcceptPhoton(ph1)) continue;
+    if(!ph1->IsTrig()) continue;
+
+    position[0] = ph1->EMCx();
+    position[1] = ph1->EMCy();
+    position[2] = ph1->EMCz();
+    relId[0] = 0; relId[1] = 0; relId[2] = 0; relId[3] = 0;
+    TVector3 global_tag(position);
+    fPHOSGeo->GlobalPos2RelId(global_tag,relId);
+
+    module_tag = relId[0];
+    cellx_tag  = relId[2];
+    cellz_tag  = relId[3];
+    tru_tag = helper->WhichTRU(cellx_tag,cellz_tag);
+    truch_tag = helper->WhichTRUChannel(cellx_tag,cellz_tag,chX_tag,chZ_tag);
+    //printf("cellx_tag = %d , cellz_tag = %d , chX_tag = %d , chZ_tag = %d , truch_tag = %d.\n",cellx_tag,cellz_tag,chX_tag,chZ_tag,truch_tag);
+
+    for(Int_t i2=0;i2<multClust;i2++){
+      AliCaloPhoton *ph2 = (AliCaloPhoton*)fPHOSClusterArray->At(i2);
+      if(!fPHOSClusterCuts->AcceptPhoton(ph2)) continue;
+
+      if(i2==i1) continue;//reject same cluster combination
+
+      p12 = *ph1 + *ph2;
+      m12 = p12.M();
+      energy = ph2->Energy();
+
+      if(fUseCoreEnergy){
+        p12core = *(ph1->GetMomV2()) + *(ph2->GetMomV2());
+        m12 = p12core.M();
+        energy = (ph2->GetMomV2())->Energy();
+      }
+
+      position[0] = ph2->EMCx();
+      position[1] = ph2->EMCy();
+      position[2] = ph2->EMCz();
+
+      relId[0] = 0; relId[1] = 0; relId[2] = 0; relId[3] = 0;
+      TVector3 global1(position);
+      fPHOSGeo->GlobalPos2RelId(global1,relId);
+
+      module = relId[0];
+      cellx  = relId[2];
+      cellz  = relId[3];
+      tru = helper->WhichTRU(cellx,cellz);
+      truch = helper->WhichTRUChannel(cellx,cellz,chX,chZ);
+
+      Int_t dm = module_tag - module;
+      Int_t dt = tru_tag - tru;
+      Int_t dx = chX_tag - chX;
+      Int_t dz = chZ_tag - chZ;
+
+      //if( (dm == 0)
+      //    && (dt == 0)
+      //    && (TMath::Abs(dx) < 2)
+      //    && (TMath::Abs(dz) < 2)
+      //  ) continue;//reject cluster pair where they belong to same 4x4 region.
+
+      FillHistogramTH2(fOutputContainer,Form("hMgg_Probe_Trg_Cen%d",fCenBin),m12,energy);
+      FillHistogramTH2(fOutputContainer,Form("hMgg_Probe_Trg_Cen%d_M%d_TRU%d",fCenBin,module,tru),m12,energy);
+
+      if(ph2->IsTrig()){
+        FillHistogramTH2(fOutputContainer,Form("hMgg_PassingProbe_Trg_Cen%d",fCenBin),m12,energy);
+        FillHistogramTH2(fOutputContainer,Form("hMgg_PassingProbe_Trg_Cen%d_M%d_TRU%d",fCenBin,module,tru),m12,energy);
+      }
+
+    }//end of ph2
+
+  }//end of ph1
+
+  //next mixed event
+  TList *prevPHOS = fPHOSEvents[fZvtx][fCenBin];
+
+  for(Int_t i1=0;i1<multClust;i1++){
+    AliCaloPhoton *ph1 = (AliCaloPhoton*)fPHOSClusterArray->At(i1);
+    if(!fPHOSClusterCuts->AcceptPhoton(ph1)) continue;
+    if(!ph1->IsTrig()) continue;
+
+    for(Int_t ev=0;ev<prevPHOS->GetSize();ev++){
+      TClonesArray *mixPHOS = static_cast<TClonesArray*>(prevPHOS->At(ev));
+
+      for(Int_t i2=0;i2<mixPHOS->GetEntriesFast();i2++){
+        AliCaloPhoton *ph2 = (AliCaloPhoton*)mixPHOS->At(i2);
+
+        p12 = *ph1 + *ph2;
+        m12 = p12.M();
+        energy = ph2->Energy();
+
+        if(fUseCoreEnergy){
+          p12core = *(ph1->GetMomV2()) + *(ph2->GetMomV2());
+          m12 = p12core.M();
+          energy = (ph2->GetMomV2())->Energy();
+        }
+
+        position[0] = ph2->EMCx();
+        position[1] = ph2->EMCy();
+        position[2] = ph2->EMCz();
+
+        relId[0] = 0; relId[1] = 0; relId[2] = 0; relId[3] = 0;
+        TVector3 global1(position);
+        fPHOSGeo->GlobalPos2RelId(global1,relId);
+
+        module = relId[0];
+        cellx  = relId[2];
+        cellz  = relId[3];
+        tru = helper->WhichTRU(cellx,cellz);
+
+        FillHistogramTH2(fOutputContainer,Form("hMixMgg_Probe_Trg_Cen%d",fCenBin),m12,energy);
+        FillHistogramTH2(fOutputContainer,Form("hMixMgg_Probe_Trg_Cen%d_M%d_TRU%d",fCenBin,module,tru),m12,energy);
+        if(fPHOSClusterCuts->AcceptPhoton(ph2)){
+          if(ph2->IsTrig()){
+            FillHistogramTH2(fOutputContainer,Form("hMixMgg_PassingProbe_Trg_Cen%d",fCenBin),m12,energy);
+            FillHistogramTH2(fOutputContainer,Form("hMixMgg_PassingProbe_Trg_Cen%d_M%d_TRU%d",fCenBin,module,tru),m12,energy);
+          }
+        }
+      }//end of mix
+
+    }//end of ph2
+
+  }//end of ph1
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::ProcessMC()
+{
+  //This is for analyzing general purpose MC such as pure PYTHIA, HIJING, DPMJET, PHOJET and so on.
+  //get MC information
+
+  Int_t firstJetindex = -1;
+  Int_t lastJetindex  = -1;
+  Int_t genIDJet      = -1;
+
+  if(fIsJJMC){
+    AliMCEvent *mcevent = MCEvent();
+    AliGenPythiaEventHeader* pythiaGenHeader = 0x0;
+    if(fESDEvent) pythiaGenHeader      = fJJMCHandler->GetPythiaEventHeader(mcevent);
+    else if(fAODEvent) pythiaGenHeader = fJJMCHandler->GetPythiaEventHeader(fAODEvent);
+
+    Float_t pThard   = pythiaGenHeader->GetPtHard();
+    FillHistogramTH1(fOutputContainer,"hPtHard",pThard);
+
+    firstJetindex = fJJMCHandler->GetFirstJetIndex();
+    lastJetindex  = fJJMCHandler->GetLastJetIndex();
+    genIDJet      = fJJMCHandler->GetGeneratorJetIndex();
+    AliInfo(Form("genIDJet = %d , firstindexJet = %d , lastindexJet = %d.",genIDJet,firstJetindex,lastJetindex));
+  }
+
+  TF1 *f1Pi0Weight = (TF1*)GetAdditionalPi0PtWeightFunction();
+  TF1 *f1K0SWeight = (TF1*)GetAdditionalK0SPtWeightFunction();
+
+  Int_t genID = -1;
+  Double_t pT=0, rapidity=0, phi=0;
+  Double_t weight = 1;
+  Int_t pdg = 0;
+  TString parname = "";
+  TString genname = "";
+  Int_t motherid = -1;
+  AliAODMCParticle *mp = 0x0;//mother particle
+  Double_t motherpT = 0;
+
+  if(fESDEvent){//for ESD
+    fMCArrayESD = (AliStack*)GetMCInfoESD();
+    if(!fMCArrayESD){
+      AliError("Could not get MC Stack!");
+      return;
+    }
+
+    const Int_t Ntrack = fMCArrayESD->GetNtrack();
+    for(Int_t i=0;i<Ntrack;i++){
+      TParticle *p = (TParticle*)fMCArrayESD->Particle(i);
+
+
+    }//end of generated particle loop
+
+  }
+  else if(fAODEvent){//for AOD
+    fMCArrayAOD = (TClonesArray*)GetMCInfoAOD();
+    if(!fMCArrayAOD){
+      AliError("Could not retrieve AOD event!");
+      return;
+    }
+
+    const Int_t Ntrack = fMCArrayAOD->GetEntriesFast();
+    for(Int_t i=0;i<Ntrack;i++){
+      AliAODMCParticle *p = (AliAODMCParticle*)fMCArrayAOD->At(i);
+      genID = p->GetGeneratorIndex();
+
+      //if(fIsJJMC && (i < firstJetindex || lastJetindex < i) ) continue;
+      if(fIsJJMC && genID != genIDJet) continue;
+
+      pT = p->Pt();
+      rapidity = p->Y();
+      phi = p->Phi();
+      pdg = p->PdgCode();
+
+      //rapidity is Y(), but, pseudo-rapidity is Eta();
+
+      if(pT < 1e-3) continue;//reject below 1 MeV
+      if(TMath::Abs(rapidity) > 0.5) continue;
+
+      motherid = p->GetMother();
+      if(motherid > -1 && pdg == 111){//pi0 has mother
+        mp = (AliAODMCParticle*)fMCArrayAOD->At(motherid);
+        if(mp->PdgCode() == 310)//mother is K0S
+          FillHistogramTH2(fOutputContainer,Form("hPi0FromK0S_Cen%d",fCenBin),pT,Rho(p),1.);
+      }
+
+      if(Rho(p) > 1.0) continue;
+      weight = 1.;
+
+      if(pdg==111){//pi0
+        parname = "Pi0";
+        weight = f1Pi0Weight->Eval(pT);
+        //printf("This is pi0. pT = %e GeV/c, weight = %e.\n",pT, weight);
+
+      }
+      else if(pdg==221){//eta
+        parname = "Eta";
+      }
+      else if(pdg==22){//gamma
+        parname = "Gamma";
+
+        motherid = p->GetMother();
+        while(motherid > -1){//this particle has mother.
+          mp = (AliAODMCParticle*)fMCArrayAOD->At(motherid);
+          if(mp->PdgCode() == 111){ //mother is pi0.
+            motherpT = mp->Pt();
+            weight = f1Pi0Weight->Eval(motherpT);
+            //printf("The mother of this gamma is pi0. motherpT = %e GeV/c, gamma pT = %e , weight = %e.\n",motherpT, pT, weight);
+            FillHistogramTH1(fOutputContainer,Form("hGenGammaFromPi0Pt_Cen%d"    ,fCenBin),pT          ,weight);
+            FillHistogramTH2(fOutputContainer,Form("hGenGammaFromPi0EtaPhi_Cen%d",fCenBin),rapidity,phi,weight);
+            FillHistogramTH2(fOutputContainer,Form("hGenGammaFromPi0EtaPt_Cen%d" ,fCenBin),rapidity,pT ,weight);
+            break;
+          }
+          motherid = mp->GetMother();
+        }//end of while
+
+      }
+      else if(pdg==211 || pdg==-211){//pi+ or pi-
+        parname = "ChargedPion";
+      }
+      else if(pdg==321 || pdg==-321){//K+ or K-
+        parname = "ChargedKaon";
+        weight = f1K0SWeight->Eval(pT);
+        //printf("This is K+/-. pT = %e GeV/c, weight = %e.\n",pT, weight);
+      }
+      else if(pdg==310){//K0S
+        parname = "K0S";
+        weight = f1K0SWeight->Eval(pT);
+        //printf("This is K0S. pT = %e GeV/c, weight = %e.\n",pT, weight);
+      }
+      else if(pdg==130){//K0L
+        parname = "K0L";
+        weight = f1K0SWeight->Eval(pT);
+        //printf("This is K0L. pT = %e GeV/c, weight = %e.\n",pT, weight);
+      }
+      else if(pdg==3122){//Lmabda0
+        parname = "Lambda0";
+      }
+      else if(pdg==3212){//Sigma0
+        parname = "Sigma0";
+      }
+      else{
+        continue;
+      }
+
+      FillHistogramTH1(fOutputContainer,Form("hGen%sPt_Cen%d"    ,parname.Data(),fCenBin),pT          ,weight);
+      FillHistogramTH2(fOutputContainer,Form("hGen%sEtaPhi_Cen%d",parname.Data(),fCenBin),rapidity,phi,weight);
+      FillHistogramTH2(fOutputContainer,Form("hGen%sEtaPt_Cen%d" ,parname.Data(),fCenBin),rapidity,pT ,weight);
+
+    }//end of generated particle loop
+
+
+  }
+
+
+}
+//________________________________________________________________________
+Double_t AliAnalysisTaskPHOSPi0EtaToGammaGamma::R(AliAODMCParticle* p)
+{
+  //Radius of vertex in cylindrical system.
+
+//  if(p->PdgCode() == 111){
+//    cout << "Xv = " << p->Xv() << " , fVertex[0] = " << fVertex[0] << endl;
+//    cout << "Yv = " << p->Yv() << " , fVertex[1] = " << fVertex[1] << endl;
+//    cout << "Zv = " << p->Zv() << " , fVertex[2] = " << fVertex[2] << endl;
+//  }
+
+  Double32_t x = p->Xv() - fVertex[0];
+  Double32_t y = p->Yv() - fVertex[1];
+  return sqrt(x*x + y*y);
+
+  //Double32_t x = p->Xv();
+  //Double32_t y = p->Yv();
+  //Double32_t z = p->Zv();
+  //return sqrt(x*x + y*y + z*z);
+}
+//________________________________________________________________________
+Double_t AliAnalysisTaskPHOSPi0EtaToGammaGamma::Rho(AliAODMCParticle* p)
+{
+  //Radius of vertex in spherical system.
+
+//  if(p->PdgCode() == 111){
+//    cout << "Xv = " << p->Xv() << " , fVertex[0] = " << fVertex[0] << endl;
+//    cout << "Yv = " << p->Yv() << " , fVertex[1] = " << fVertex[1] << endl;
+//    cout << "Zv = " << p->Zv() << " , fVertex[2] = " << fVertex[2] << endl;
+//  }
+
+  Double32_t x = p->Xv() - fVertex[0];
+  Double32_t y = p->Yv() - fVertex[1];
+  Double32_t z = p->Zv() - fVertex[2];
+  return sqrt(x*x + y*y + z*z);
+
+  //Double32_t x = p->Xv();
+  //Double32_t y = p->Yv();
+  //Double32_t z = p->Zv();
+  //return sqrt(x*x + y*y + z*z);
+}
+//________________________________________________________________________
+Bool_t AliAnalysisTaskPHOSPi0EtaToGammaGamma::IsFromLambda0(Int_t label1, Int_t label2, Double_t &TrueL0Pt)
+{
+  AliAODMCParticle *p1 = (AliAODMCParticle*)fMCArrayAOD->At(label1);
+  AliAODMCParticle *p2 = (AliAODMCParticle*)fMCArrayAOD->At(label2);
+
+  AliAODMCParticle *mp = 0x0;
+  Int_t motherid = -1;
+  Int_t pdg=0;
+  Double_t pT = 0;
+
+  Bool_t IsK0S1 = kFALSE;
+  Bool_t IsK0S2 = kFALSE;
+  Int_t motherID1 = -1;
+  Int_t motherID2 = -1;
+
+  motherid = p1->GetMother();
+  while(motherid > -1){
+
+    mp = (AliAODMCParticle*)fMCArrayAOD->At(motherid);
+    pdg = mp->PdgCode(); 
+    pT = mp->Pt();
+
+    if(pdg==3122){//Lambda0
+      IsK0S1 = kTRUE;
+      TrueL0Pt = pT;
+      motherID1 = motherid;
+      break;
+    }
+
+    motherid = mp->GetMother();
+
+  }
+
+  motherid = p2->GetMother();
+  while(motherid > -1){
+    mp = (AliAODMCParticle*)fMCArrayAOD->At(motherid);
+
+    pdg = mp->PdgCode();
+    if(pdg==3122){//Lambda0
+      IsK0S2 = kTRUE;
+      TrueL0Pt = pT;
+      motherID2 = motherid;
+      break;
+    }
+
+    motherid = mp->GetMother();
+
+  }
+
+  return (motherID1 == motherID2) & (IsK0S1 & IsK0S2);
+
+}
+//________________________________________________________________________
+Bool_t AliAnalysisTaskPHOSPi0EtaToGammaGamma::IsFromK0S(Int_t label1, Int_t label2, Double_t &TrueK0SPt)
+{
+  AliAODMCParticle *p1 = (AliAODMCParticle*)fMCArrayAOD->At(label1);
+  AliAODMCParticle *p2 = (AliAODMCParticle*)fMCArrayAOD->At(label2);
+
+  AliAODMCParticle *mp = 0x0;
+  Int_t motherid = -1;
+  Int_t pdg=0;
+  Double_t pT = 0;
+
+  Bool_t IsK0S1 = kFALSE;
+  Bool_t IsK0S2 = kFALSE;
+
+  Int_t motherID1 = -1;
+  Int_t motherID2 = -1;
+
+  motherid = p1->GetMother();
+  while(motherid > -1){
+
+    mp = (AliAODMCParticle*)fMCArrayAOD->At(motherid);
+    pdg = mp->PdgCode(); 
+    pT = mp->Pt();
+
+    if(pdg==310){//K0S
+      IsK0S1 = kTRUE;
+      TrueK0SPt = pT;
+      motherID1 = motherid;
+      break;
+    }
+
+    motherid = mp->GetMother();
+
+  }
+
+  motherid = p2->GetMother();
+  while(motherid > -1){
+    mp = (AliAODMCParticle*)fMCArrayAOD->At(motherid);
+    pdg = mp->PdgCode();
+    pT = mp->Pt();
+
+    if(pdg==310){//K0S
+      IsK0S2 = kTRUE;
+      TrueK0SPt = pT;
+      motherID2 = motherid;
+      break;
+    }
+
+    motherid = mp->GetMother();
+
+  }
+
+  return (motherID1 == motherID2) & (IsK0S1 & IsK0S2);
+
+}
+//________________________________________________________________________
+Bool_t AliAnalysisTaskPHOSPi0EtaToGammaGamma::IsFromPi0(Int_t label1, Double_t &TruePi0Pt)
+{
+
+  AliAODMCParticle *p1 = (AliAODMCParticle*)fMCArrayAOD->At(label1);
+ 
+  AliAODMCParticle *mp = 0x0;
+  Int_t motherid = -1;
+  Int_t pdg=0;
+  Double_t pT = 0;
+
+  Bool_t IsPi0 = kFALSE;
+  motherid = p1->GetMother();
+
+  while(motherid > -1){
+    mp = (AliAODMCParticle*)fMCArrayAOD->At(motherid);
+    pT = mp->Pt();
+    pdg = mp->PdgCode(); 
+
+    if(pdg==111 && Rho(mp) < 1.0){//pi0 from primary vertex
+      IsPi0 = kTRUE;
+      TruePi0Pt = pT;
+      break;
+    }
+
+    motherid = mp->GetMother();
+
+  }
+
+  return IsPi0;
+
+}
+//________________________________________________________________________
+Bool_t AliAnalysisTaskPHOSPi0EtaToGammaGamma::IsPhoton(Int_t label)
+{
+
+  AliAODMCParticle *p = (AliAODMCParticle*)fMCArrayAOD->At(label);
+  Int_t pdg = p->PdgCode(); 
+
+  if(pdg == 22) return kTRUE;
+  else          return kFALSE; 
+
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::DoNonLinearityStudy()
+{
+
+  const Int_t multClust = fPHOSClusterArray->GetEntriesFast();
+  TLorentzVector p12, p12core;
+
+  Double_t m12=0,pt12=0,asym=0;
+  Double_t e1=0,e2=0;
+  for(Int_t ia=0;ia<7;ia++){
+    for(Int_t ib=0;ib<7;ib++){
+
+      for(Int_t i1=0;i1<multClust-1;i1++){
+        AliCaloPhoton *ph1 = (AliCaloPhoton*)fPHOSClusterArray->At(i1);
+        if(!fPHOSClusterCuts->AcceptPhoton(ph1)) continue;
+
+        for(Int_t i2=i1+1;i2<multClust;i2++){
+          AliCaloPhoton *ph2 = (AliCaloPhoton*)fPHOSClusterArray->At(i2);
+          if(!fPHOSClusterCuts->AcceptPhoton(ph2)) continue;
+
+          e1 = ph1->Energy();
+          e2 = ph2->Energy();
+
+          p12 = *ph1*fNonLin[fCenBin][ia][ib]->Eval(e1) + *ph2*fNonLin[fCenBin][ia][ib]->Eval(e2);
+          m12 = p12.M();
+          pt12 = p12.Pt();
+
+          if(fUseCoreEnergy){
+            e1 = (ph1->GetMomV2())->Energy();
+            e2 = (ph2->GetMomV2())->Energy();
+
+            p12core = *(ph1->GetMomV2())*fNonLin[fCenBin][ia][ib]->Eval(e1) + *(ph2->GetMomV2())*fNonLin[fCenBin][ia][ib]->Eval(e2);
+            m12 = p12core.M();
+            pt12 = p12core.Pt();
+          }
+
+          FillHistogramTH2(fOutputContainer,Form("hMgg_Cen%d_a%d_b%d",fCenBin,ia,ib),m12,pt12);
+
+        }//end of ph2
+      }//end of ph1
+    }
+  }
+
+  TList *prevPHOS = fPHOSEvents[fZvtx][fCenBin];
+
+  for(Int_t ia=0;ia<7;ia++){
+    for(Int_t ib=0;ib<7;ib++){
+
+      for(Int_t i1=0;i1<multClust;i1++){
+        AliCaloPhoton *ph1 = (AliCaloPhoton*)fPHOSClusterArray->At(i1);
+        if(!fPHOSClusterCuts->AcceptPhoton(ph1)) continue;
+
+        for(Int_t ev=0;ev<prevPHOS->GetSize();ev++){
+          TClonesArray *mixPHOS = static_cast<TClonesArray*>(prevPHOS->At(ev));
+
+          for(Int_t i2=0;i2<mixPHOS->GetEntriesFast();i2++){
+            AliCaloPhoton *ph2 = (AliCaloPhoton*)mixPHOS->At(i2);
+            if(!fPHOSClusterCuts->AcceptPhoton(ph2)) continue;
+
+            e1 = ph1->Energy();
+            e2 = ph2->Energy();
+
+            p12 = *ph1*fNonLin[fCenBin][ia][ib]->Eval(e1) + *ph2*fNonLin[fCenBin][ia][ib]->Eval(e2);
+            m12 = p12.M();
+            pt12 = p12.Pt();
+
+            if(fUseCoreEnergy){
+              e1 = (ph1->GetMomV2())->Energy();
+              e2 = (ph2->GetMomV2())->Energy();
+              p12core = *(ph1->GetMomV2())*fNonLin[fCenBin][ia][ib]->Eval(e1) + *(ph2->GetMomV2())*fNonLin[fCenBin][ia][ib]->Eval(e2);
+              m12 = p12core.M();
+              pt12 = p12core.Pt();
+            }
+
+            FillHistogramTH2(fOutputContainer,Form("hMixMgg_Cen%d_a%d_b%d",fCenBin,ia,ib),m12,pt12);
+
+          }//end of mix
+
+        }//end of ph2
+
+      }//end of ph1
+
+    }
+
+  }
+
+}
+//________________________________________________________________________
+Int_t AliAnalysisTaskPHOSPi0EtaToGammaGamma::FindCommonParent(Int_t iPart, Int_t jPart)
+{
+  //check if there is a common parent for particles i and j
+  // -1: no common parent or wrong iPart/jPart
+
+  Int_t ntrack = fMCArrayAOD->GetEntriesFast();
+  if(iPart==-1 || iPart>=ntrack || jPart==-1 || jPart>=ntrack) return -1;
+
+  Int_t iprim1 = iPart;
+
+  while(iprim1>-1){
+    Int_t iprim2=jPart;
+
+    while(iprim2>-1){
+      if(iprim1==iprim2) return iprim1;
+      iprim2 = dynamic_cast<AliAODMCParticle*>(fMCArrayAOD->At(iprim2))->GetMother();
+    }
+
+    iprim1 = dynamic_cast<AliAODMCParticle*>(fMCArrayAOD->At(iprim1))->GetMother();
+  }
+
+  return -1;
+}
+//________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::FillHistogramTH1(TList *list, const Char_t *hname, Double_t x, Double_t w, Option_t *opt) const
+{
+  //FillHistogram
+  TH1 * hist = dynamic_cast<TH1*>(list->FindObject(hname));
+  if(!hist){
+    AliError(Form("can not find histogram (of instance TH1) <%s> ",hname));
+    return;
+  }
+  else{
+    TString optstring(opt);
+    Double_t myweight = optstring.Contains("w") ? 1. : w;
+    if(optstring.Contains("wx")){
+      // use bin width as weight
+      Int_t bin = hist->GetXaxis()->FindBin(x);
+      // check if not overflow or underflow bin
+      if(bin != 0 && bin != hist->GetXaxis()->GetNbins()){
+        Double_t binwidth = hist->GetXaxis()->GetBinWidth(bin);
+        myweight = w/binwidth;
+      }
+    }
+    hist->Fill(x, myweight);
+    return;
+  }
+}
+//_____________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::FillHistogramTH2(TList *list, const Char_t *name, Double_t x, Double_t y, Double_t w, Option_t *opt) const
+{
+  TH2 * hist = dynamic_cast<TH2*>(list->FindObject(name));
+  if(!hist){
+    AliError(Form("can not find histogram (of instance TH2) <%s> ",name));
+    return;
+  }
+  else{
+    TString optstring(opt);
+    Double_t myweight = optstring.Contains("w") ? 1. : w;
+    if(optstring.Contains("wx")){
+      Int_t binx = hist->GetXaxis()->FindBin(x);
+      if(binx != 0 && binx != hist->GetXaxis()->GetNbins()) myweight *= 1./hist->GetXaxis()->GetBinWidth(binx);
+    }
+    if(optstring.Contains("wy")){
+      Int_t biny = hist->GetYaxis()->FindBin(y);
+      if(biny != 0 && biny != hist->GetYaxis()->GetNbins()) myweight *= 1./hist->GetYaxis()->GetBinWidth(biny);
+    }
+    hist->Fill(x, y, myweight);
+    return;
+  }
+}
+//_____________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::FillHistogramTH3(TList *list, const Char_t *name, Double_t x, Double_t y, Double_t z, Double_t w, Option_t *opt) const
+{
+  TH3 * hist = dynamic_cast<TH3*>(list->FindObject(name));
+  if(!hist){
+    AliError(Form("can not find histogram (of instance TH3) <%s> ",name));
+    return;
+  }
+  else{
+    TString optstring(opt);
+    Double_t myweight = optstring.Contains("w") ? 1. : w;
+    if(optstring.Contains("wx")){
+      Int_t binx = hist->GetXaxis()->FindBin(x);
+      if(binx != 0 && binx != hist->GetXaxis()->GetNbins()) myweight *= 1./hist->GetXaxis()->GetBinWidth(binx);
+    }
+    if(optstring.Contains("wy")){
+      Int_t biny = hist->GetYaxis()->FindBin(y);
+      if(biny != 0 && biny != hist->GetYaxis()->GetNbins()) myweight *= 1./hist->GetYaxis()->GetBinWidth(biny);
+    }
+    if(optstring.Contains("wz")){
+      Int_t binz = hist->GetZaxis()->FindBin(z);
+      if(binz != 0 && binz != hist->GetZaxis()->GetNbins()) myweight *= 1./hist->GetZaxis()->GetBinWidth(binz);
+    }
+    hist->Fill(x, y, z, myweight);
+    return;
+  }
+}
+//_____________________________________________________________________________
+void AliAnalysisTaskPHOSPi0EtaToGammaGamma::FillProfile(TList *list, const Char_t *name, Double_t x, Double_t y) const
+{
+  TProfile * hist = dynamic_cast<TProfile*>(list->FindObject(name));
+  if(!hist){
+    AliError(Form("can not find histogram (of instance TH3) <%s> ",name));
+    return;
+  }
+  else{
+    hist->Fill(x,y);
+    return;
+  }
+
+}
+//_____________________________________________________________________________
+AliPHOSGeometry *AliAnalysisTaskPHOSPi0EtaToGammaGamma::GetPHOSGeometry()
+{
+  AliAODEvent *aod = dynamic_cast<AliAODEvent*>(fEvent);
+  AliESDEvent *esd = dynamic_cast<AliESDEvent*>(fEvent);
+  Int_t RunNumber = fEvent->GetRunNumber();
+
+  //Initialize the PHOS geometry
+
+  fPHOSGeo = 0x0;
+
+  if(fUsePHOSTender){
+    AliInfo("PHOSTender is used.");
+
+    if(RunNumber < 209122)//Run1
+      fPHOSGeo = AliPHOSGeometry::GetInstance("IHEP") ;
+    else//Run2
+      fPHOSGeo = AliPHOSGeometry::GetInstance("Run2") ;
+  }
+  else{//PHOSTender is not applied.
+    AliOADBContainer geomContainer("phosGeo");
+
+    if(RunNumber < 209122)//Run1
+      fPHOSGeo = AliPHOSGeometry::GetInstance("IHEP") ;
+    else//Run2
+      fPHOSGeo = AliPHOSGeometry::GetInstance("Run2") ;
+
+    if(fIsMC){ //use excatly the same geometry as in simulation, stored in esd
+      if(esd){
+        for(Int_t mod=0; mod<6; mod++) {
+          const TGeoHMatrix * m = esd->GetPHOSMatrix(mod);
+          if(m){
+            fPHOSGeo->SetMisalMatrix(m,mod) ;
+            printf(".........Adding Matrix(%d), geo=%p\n",mod,fPHOSGeo);
+            m->Print();
+          }
+        }
+      }
+      else if(aod){ //To be fixed
+        geomContainer.InitFromFile("$ALICE_PHYSICS/OADB/PHOS/PHOSMCGeometry.root","PHOSMCRotationMatrixes");
+        TObjArray *matrixes = (TObjArray*)geomContainer.GetObject(RunNumber,"PHOSRotationMatrixes");
+        for(Int_t mod=0; mod<6; mod++){
+          if(!matrixes->At(mod)) continue;
+          fPHOSGeo->SetMisalMatrix(((TGeoHMatrix*)matrixes->At(mod)),mod);
+          printf(".........Adding Matrix(%d), geo=%p\n",mod,fPHOSGeo);
+          ((TGeoHMatrix*)matrixes->At(mod))->Print();
+        }
+      }
+    }//end of MC
+    else{ //Use best approaximation to real geometry
+      geomContainer.InitFromFile("$ALICE_PHYSICS/OADB/PHOS/PHOSGeometry.root","PHOSRotationMatrixes");
+      TObjArray *matrixes = (TObjArray*)geomContainer.GetObject(RunNumber,"PHOSRotationMatrixes");
+      for(Int_t mod=0; mod<6; mod++){
+        if(!matrixes->At(mod)) continue;
+        fPHOSGeo->SetMisalMatrix(((TGeoHMatrix*)matrixes->At(mod)),mod);
+        printf(".........Adding Matrix(%d), geo=%p\n",mod,fPHOSGeo);
+        ((TGeoHMatrix*)matrixes->At(mod))->Print();
+      }
+    }//end of real data
+  }
+
+  return fPHOSGeo;
+
+}
+//_______________________________________________________________________________
+AliStack *AliAnalysisTaskPHOSPi0EtaToGammaGamma::GetMCInfoESD() 
+{
+  AliStack *fStack = 0x0;
+  AliVEventHandler* eventHandler = AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler();
+  if(eventHandler){
+    AliMCEventHandler* mcEventHandler = dynamic_cast<AliMCEventHandler*> (eventHandler);
+    if(mcEventHandler) fStack = static_cast<AliMCEventHandler*>(AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler())->MCEvent()->Stack();
+  }
+
+  if(!fStack) AliError("Could not get MC Stack!");
+
+  return fStack;
+
+}
+//_______________________________________________________________________________
+TClonesArray *AliAnalysisTaskPHOSPi0EtaToGammaGamma::GetMCInfoAOD() 
+{
+  TClonesArray *fMCArray = 0x0;
+  AliAODInputHandler* aodHandler=dynamic_cast<AliAODInputHandler*>(AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler());
+
+  if(aodHandler){
+    AliAODEvent *aod=aodHandler->GetEvent();
+    if(aod){
+      fMCArray = dynamic_cast<TClonesArray*>(aod->FindListObject(AliAODMCParticle::StdBranchName()));
+      if (!fMCArray) AliError("Could not retrieve MC array!");
+    }
+    else AliError("Could not retrieve AOD event!");
+  }
+
+  return fMCArray;
+
+}
+//_______________________________________________________________________________

--- a/PWGGA/PHOSTasks/PHOS_Run2/AliAnalysisTaskPHOSPi0EtaToGammaGamma.h
+++ b/PWGGA/PHOSTasks/PHOS_Run2/AliAnalysisTaskPHOSPi0EtaToGammaGamma.h
@@ -1,0 +1,201 @@
+#ifndef AliAnalysisTaskPHOSPi0EtaToGammaGamma_cxx
+#define AliAnalysisTaskPHOSPi0EtaToGammaGamma_cxx
+
+// Author: Daiki Sekihata (Hiroshima University)
+
+class TList;
+class AliVEvent;
+class AliESDEvent;
+class AliAODEvent;
+class AliPHOSGeometry;
+class TClonesArray;
+class AliESDtrackCuts;
+class AliMultSelection;
+class AliStack;
+//class AliEventCuts;
+
+#include "AliAnalysisTaskSE.h"
+#include "AliPHOSTriggerHelper.h"
+#include "AliPHOSEventCuts.h"
+#include "AliPHOSClusterCuts.h"
+#include "AliPHOSJetJetMC.h"
+
+class AliAnalysisTaskPHOSPi0EtaToGammaGamma : public AliAnalysisTaskSE {
+  public:
+
+    AliAnalysisTaskPHOSPi0EtaToGammaGamma(const char *name = "Pi0EtaToGammaGamma");
+    virtual ~AliAnalysisTaskPHOSPi0EtaToGammaGamma(); 
+    void SetNonLinearityStudyFlag(Bool_t flag) {fIsNonLinStudyNeeded = flag;}
+
+    void SetESDtrackCutsForGlobal(AliESDtrackCuts* cuts){fESDtrackCutsGlobal = cuts;}
+    void SetESDtrackCutsForGlobalConstrained(AliESDtrackCuts* cuts){fESDtrackCutsGlobalConstrained = cuts;}
+
+    void SetTenderFlag(Bool_t tender) {fUsePHOSTender = tender;}
+    void SetMCFlag(Bool_t mc) {fIsMC = mc;}
+    void SetCoreEnergyFlag(Bool_t iscore) {fUseCoreEnergy = iscore;}
+    void SetEventCuts(AliPHOSEventCuts *cuts) {fPHOSEventCuts = cuts;}
+    void SetClusterCuts(AliPHOSClusterCuts *cuts) {fPHOSClusterCuts = cuts;}
+    void SetBunchSpace(Double_t bs) {fBunchSpace = bs;}
+    void SetCollisionSystem(Int_t id) {fCollisionSystem = id;}
+
+    void SetPtHardBin(Int_t pThardbin) {
+      fPtHardBin = pThardbin;
+      fIsJJMC = kTRUE;
+      fJJMCHandler = new AliPHOSJetJetMC(pThardbin);
+    }
+
+    void SetTOFCutEfficiencyFunction(TF1 *f1) {fTOFEfficiency = f1;}
+    void SetAdditionalPi0PtWeightFunction(TF1 *f1) {fAdditionalPi0PtWeight = f1;}
+    void SetAdditionalK0SPtWeightFunction(TF1 *f1) {fAdditionalK0SPtWeight = f1;}
+
+    void SetCentralityBinningPbPb(const TArrayD& edges, const TArrayI& nMixed)
+    {
+      // Define centrality bins by their edges
+      for(int i=0; i<edges.GetSize()-1; ++i)
+        if(edges.At(i) > edges.At(i+1)) AliFatal("edges are not sorted");
+      if(edges.GetSize() != nMixed.GetSize()+1) AliFatal("edges and nMixed don't have appropriate relative sizes");//Pb-Pb,pPb
+
+      fCentEdges = edges;
+      fCentNMixed = nMixed;
+    }
+
+    void SetCentralityBinningPP(const TArrayD& edges, const TArrayI& nMixed)
+    {
+      // Define centrality bins by their edges
+      for(int i=0; i<edges.GetSize()-1; ++i)
+        if(edges.At(i) > edges.At(i+1)) AliFatal("edges are not sorted");
+      if(edges.GetSize() != nMixed.GetSize()) AliFatal("edges and nMixed don't have appropriate relative sizes");//pp
+
+      fCentEdges = edges;
+      fCentNMixed = nMixed;
+    }
+
+  void SetCentralityEstimator(TString estimator) {fEstimator = estimator;}
+
+  protected:
+    virtual void UserCreateOutputObjects();
+    virtual void UserExec(Option_t *option);
+    virtual void Terminate(Option_t *option);
+    virtual void ProcessMC();
+    void TrackQA();
+    void CellQA();
+    void TriggerQA();
+    virtual void ClusterQA();
+    virtual void FillPhoton();
+    virtual void FillMgg();
+    virtual void FillMixMgg();
+    virtual void EstimatePIDCutEfficiency();
+
+    virtual void EstimateNcellCutEfficiency();
+    virtual void EstimateM20CutEfficiency();
+    virtual void EstimateM02CutEfficiency();
+    virtual void EstimateSTDCutEfficiency();
+
+    void EstimateTOFCutEfficiency();
+    void EstimateTriggerEfficiency();
+    void SelectTriggeredCluster();
+
+    Bool_t IsFromLambda0(Int_t label1, Int_t label2, Double_t &TrueL0Pt);
+    Bool_t IsFromK0S(Int_t label1, Int_t label2, Double_t &TrueK0SPt);
+    Bool_t IsFromPi0(Int_t label1, Double_t &TruePi0Pt);
+    Bool_t IsPhoton(Int_t label);
+
+    Double_t R(AliAODMCParticle *p);//in cylindrical system
+    Double_t Rho(AliAODMCParticle *p);//in sperical system
+
+    virtual Int_t FindCommonParent(Int_t iPart, Int_t jPart);
+
+    virtual void DoNonLinearityStudy();
+
+    void FillHistogramTH1(TList *list, const Char_t *name, Double_t x, Double_t w=1., Option_t *opt = "") const ;
+    void FillHistogramTH2(TList *list, const Char_t *name, Double_t x, Double_t y, Double_t w=1., Option_t *opt = "") const ;
+    void FillHistogramTH3(TList *list, const Char_t *name, Double_t x, Double_t y, Double_t z, Double_t w=1., Option_t *opt = "") const ;
+    void FillProfile(TList *list, const Char_t *name, Double_t x, Double_t y) const ;
+
+    TF1 *GetTOFCutEfficiencyFunction() {return fTOFEfficiency;}
+    TF1 *GetAdditionalPi0PtWeightFunction() {return fAdditionalPi0PtWeight;}
+    TF1 *GetAdditionalK0SPtWeightFunction() {return fAdditionalK0SPtWeight;}
+
+    Int_t GetCentralityBinPbPb(Float_t centrality)
+    {
+      if(centrality < fCentEdges[0]) return -1;
+      Int_t lastBinUpperIndex = fCentEdges.GetSize()-1;
+
+      //if(centrality >= fCentEdges[lastBinUpperIndex]) return lastBinUpperIndex-1;
+      //if(centrality >= fCentEdges[lastBinUpperIndex]) return lastBinUpperIndex;
+      if(centrality >= fCentEdges[lastBinUpperIndex]) return -1;
+      else return TMath::BinarySearch<Double_t>( lastBinUpperIndex, fCentEdges.GetArray(), centrality);
+    }
+
+    Int_t GetCentralityBinPP(Int_t multiplicity)
+    {
+      if((Double_t)multiplicity < fCentEdges[0]) return -1;//this should not happen. only for protection
+      Int_t lastBinUpperIndex = fCentEdges.GetSize()-1;
+
+      if((Double_t)multiplicity >= fCentEdges[lastBinUpperIndex]) return lastBinUpperIndex;
+      else return TMath::BinarySearch<Double_t>(lastBinUpperIndex, fCentEdges.GetArray(), (Double_t)multiplicity);
+    }
+
+    AliStack *GetMCInfoESD();
+    TClonesArray *GetMCInfoAOD();
+    AliGenPythiaEventHeader* GetPythiaEventHeader(AliVEvent *event);
+    Bool_t ComparePtHardWithJet(AliVEvent *event);
+    Bool_t ComparePtHardWithSingleParticle(AliVEvent *event);
+
+    AliPHOSGeometry *GetPHOSGeometry();
+
+  protected:
+    Bool_t fIsMC;
+    Bool_t fIsJJMC;//jet jet MC
+    Int_t fPtHardBin;//your selected pT hard bin for jet jet MC
+    Bool_t fUsePHOSTender;
+    Bool_t fUseCoreEnergy;
+    AliPHOSEventCuts *fPHOSEventCuts;
+    AliPHOSClusterCuts *fPHOSClusterCuts;
+    Double_t fBunchSpace;// in unit of ns.
+    TArrayD fCentEdges;  // Centrality Bin Lower edges
+    TArrayI fCentNMixed; // Number of mixed events for each centrality bin
+    Int_t fCollisionSystem;//colliions system : pp=0, PbPb=1, pPb (Pbp)=2;
+    TF1 *fTOFEfficiency;//TOF cut efficiency as a function of cluster energy;
+    AliESDtrackCuts *fESDtrackCutsGlobal;//good global track
+    AliESDtrackCuts *fESDtrackCutsGlobalConstrained;//global track but constrained to IP because of SPD dead area
+    TF1 *fAdditionalPi0PtWeight;//weight function for pT distribution
+    TF1 *fAdditionalK0SPtWeight;//weight function for pT distribution
+
+    THashList *fOutputContainer;
+    AliVEvent *fEvent;
+    AliESDEvent *fESDEvent;
+    AliAODEvent *fAODEvent;
+    AliStack *fMCArrayESD;     //MC particles array in ESD
+    TClonesArray *fMCArrayAOD; //MC particles array in AOD
+    AliPHOSJetJetMC *fJJMCHandler;
+    Int_t fRunNumber;
+    AliPHOSGeometry *fPHOSGeo;
+    TList *fPHOSEvents[10][10];
+    TClonesArray *fPHOSClusterArray;
+    TString fEstimator;
+    AliMultSelection *fMultSelection;
+    Float_t fCentralityV0M;
+    Float_t fCentralityCL0;
+    Float_t fCentralityCL1;
+    Float_t fCentralityV0A;
+    Float_t fCentralityV0C;
+    Float_t fCentralityZNA;
+    Float_t fCentralityZNC;
+    Float_t fCentralityMain;
+    Double_t fVertex[3];
+    Int_t fZvtx;
+    Int_t fCenBin;
+    Int_t fNHybridTrack;
+    Bool_t fIsNonLinStudyNeeded;
+    TF1 *fNonLin[7][7][7];
+//    AliEventCuts fEventCuts;
+
+  private:
+    AliAnalysisTaskPHOSPi0EtaToGammaGamma(const AliAnalysisTaskPHOSPi0EtaToGammaGamma&); // not implemented
+    AliAnalysisTaskPHOSPi0EtaToGammaGamma& operator=(const AliAnalysisTaskPHOSPi0EtaToGammaGamma&); // not implemented
+
+    ClassDef(AliAnalysisTaskPHOSPi0EtaToGammaGamma, 13); // example of analysis
+};
+
+#endif

--- a/PWGGA/PHOSTasks/PHOS_Run2/AliPHOSClusterCuts.cxx
+++ b/PWGGA/PHOSTasks/PHOS_Run2/AliPHOSClusterCuts.cxx
@@ -1,0 +1,75 @@
+#include "TObject.h"
+#include "AliLog.h"
+#include "AliCaloPhoton.h"
+#include "AliPHOSClusterCuts.h"
+
+// Author: Daiki Sekihata (Hiroshima University)
+
+ClassImp(AliPHOSClusterCuts)
+
+//________________________________________________________________________
+AliPHOSClusterCuts::AliPHOSClusterCuts(const char *name):
+  fUseCPV(kFALSE),
+  fUseDisp(kFALSE),
+  fNsigmaCPV(-1),
+  fNsigmaDisp(-1),
+  fIsCore(kFALSE)
+{
+  //Constructor
+  SetName(name);
+  AliInfo(Form("Cut Parameter | CPV:%2.1f sigma , Dispersion:%2.1f sigma.",fNsigmaCPV,fNsigmaDisp));
+
+}
+//________________________________________________________________________
+AliPHOSClusterCuts::~AliPHOSClusterCuts()
+{
+  //destructor
+
+
+}
+//________________________________________________________________________
+Bool_t AliPHOSClusterCuts::AcceptPhoton(AliCaloPhoton *ph)
+{
+  if(!IsNeutral(ph))  return kFALSE;
+  if(!AcceptDisp(ph)) return kFALSE;
+
+  return kTRUE;
+}
+//________________________________________________________________________
+Bool_t AliPHOSClusterCuts::IsNeutral(AliCaloPhoton *ph)
+{
+  //be careful! criteria of CPV and Disp is opposite sign of inequality.
+  Double_t sigma = 999;
+
+  if(fUseCPV){
+    sigma = ph->GetNsigmaCPV();
+    if(sigma < fNsigmaCPV) return kFALSE;
+  }
+
+  return kTRUE;
+}
+//________________________________________________________________________
+Bool_t AliPHOSClusterCuts::AcceptDisp(AliCaloPhoton *ph)
+{
+  //be careful! criteria of CPV and Disp is opposite sign of inequality.
+  Double_t sigma = 999;
+
+  if(fUseDisp){
+    if(fIsCore){
+      sigma = ph->GetNsigmaCoreDisp();
+      if(sigma > fNsigmaDisp) return kFALSE;
+    }
+    else{
+      sigma = ph->GetNsigmaFullDisp();
+      if(sigma > fNsigmaDisp) return kFALSE;
+    }
+  }
+
+  return kTRUE;
+}
+//________________________________________________________________________
+Bool_t AliPHOSClusterCuts::AcceptChargedParticle(AliCaloPhoton *ph)
+{
+  return !IsNeutral(ph);
+}
+//________________________________________________________________________

--- a/PWGGA/PHOSTasks/PHOS_Run2/AliPHOSClusterCuts.h
+++ b/PWGGA/PHOSTasks/PHOS_Run2/AliPHOSClusterCuts.h
@@ -1,0 +1,51 @@
+#ifndef AliPHOSClusterCuts_cxx
+#define AliPHOSClusterCuts_cxx
+
+//Author: Daiki Sekihata (Hiroshima University)
+//this analsyis class provides cluster selection.
+
+class AliCaloPhoton;
+
+#include "AliAnalysisCuts.h"
+#include "AliCaloPhoton.h"
+
+class AliPHOSClusterCuts : public AliAnalysisCuts {
+
+  public:
+    AliPHOSClusterCuts(const char *name = "AliPHOSClusterCuts");
+    virtual ~AliPHOSClusterCuts(); 
+
+    virtual Bool_t IsSelected(TObject* obj) {return kTRUE;}
+    virtual Bool_t IsSelected(TList* /*list*/) {return kTRUE;}
+
+    void SetNsigmaCPV(Double_t nsigma)  {if(nsigma > 0) fUseCPV  = kTRUE; fNsigmaCPV  = nsigma;}
+    void SetNsigmaDisp(Double_t nsigma) {if(nsigma > 0) fUseDisp = kTRUE; fNsigmaDisp = nsigma;}
+    void SetUseCoreDispersion(Bool_t isCore) {fIsCore=isCore;}
+
+    Bool_t AcceptPhoton(AliCaloPhoton *ph);
+    Bool_t AcceptChargedParticle(AliCaloPhoton *ph);//only for E/p ratio
+
+  protected:
+    Bool_t IsNeutral(AliCaloPhoton *ph);
+    Bool_t AcceptDisp(AliCaloPhoton *ph);
+
+    //Double_t GetCPVParameter()  {return fNsigmaCPV;}
+    //Double_t GetDispParameter() {return fNsigmaDisp;}
+
+  private:
+    Bool_t fUseCPV;
+    Bool_t fUseDisp;
+    Double_t fNsigmaCPV;
+    Double_t fNsigmaDisp;
+    Bool_t fIsCore;
+
+  private:
+    AliPHOSClusterCuts(const AliPHOSClusterCuts&);
+    AliPHOSClusterCuts& operator=(const AliPHOSClusterCuts&);
+
+    ClassDef(AliPHOSClusterCuts, 9);
+
+};
+
+#endif
+

--- a/PWGGA/PHOSTasks/PHOS_Run2/AliPHOSEventCuts.cxx
+++ b/PWGGA/PHOSTasks/PHOS_Run2/AliPHOSEventCuts.cxx
@@ -1,0 +1,174 @@
+#include "stdio.h"
+#include "iostream"
+#include "TH2.h"
+#include "TMath.h"
+#include "TObjArray.h"
+#include "TString.h"
+
+#include "AliLog.h"
+#include "AliVEvent.h"
+#include "AliESDEvent.h"
+#include "AliAODEvent.h"
+#include "AliPHOSGeometry.h"
+#include "AliOADBContainer.h"
+
+#include "AliESDEvent.h"
+#include "AliAODEvent.h"
+#include "AliVEvent.h"
+#include "AliVHeader.h"
+#include "AliVCaloTrigger.h"
+#include "AliVCluster.h"
+#include "AliVCaloCells.h"
+#include "AliAnalysisUtils.h"
+
+#include "AliPHOSTriggerHelper.h"
+#include "AliPHOSEventCuts.h"
+
+using namespace std;
+
+// Author: Daiki Sekihata (Hiroshima University)
+
+ClassImp(AliPHOSEventCuts)
+
+//________________________________________________________________________
+AliPHOSEventCuts::AliPHOSEventCuts(const char *name):
+	fIsMC(kFALSE),
+  fUsePHOSTender(kTRUE),
+  fMaxAbsZvtx(10.),
+  fRejectPileup(kTRUE),
+  fRejectDAQIncomplete(kTRUE),
+  fIsPHOSTriggerAnalysis(kFALSE),
+  fTriggerHelper(0x0),
+  fPHOSGeo(0x0)
+{
+  // Constructor
+
+  for(Int_t i=0;i<6;i++){
+    fPHOSTRUBadMap[i] = 0x0;
+  }
+
+  AliInfo("event selection constructor");
+}
+//________________________________________________________________________
+AliPHOSEventCuts::~AliPHOSEventCuts()
+{
+  AliInfo("event selection destructor");
+
+
+
+}
+//________________________________________________________________________
+Bool_t AliPHOSEventCuts::AcceptEvent(AliVEvent *event)
+{
+  AliAODEvent *fAODEvent = dynamic_cast<AliAODEvent*>(event);
+  AliESDEvent *fESDEvent = dynamic_cast<AliESDEvent*>(event);
+
+  //select event which PHOS was readout from trigger cluster point of view.
+  //for example, PHOS was not in MUFAST cluster.
+  TString trigClasses = event->GetFiredTriggerClasses();
+
+  if(!fIsMC && !trigClasses.Contains("CENT") && !trigClasses.Contains("FAST")){
+    //At least, PHOS must be in CENT or FAST as a readout cluster. INT7 or PHI7 do not matter.
+    AliWarning(Form("Skip event with triggers %s",trigClasses.Data()));
+    return kFALSE;
+  }
+
+  Int_t run = event->GetRunNumber();
+
+  if(fUsePHOSTender){
+    if(run<209122) //Run1
+      fPHOSGeo = AliPHOSGeometry::GetInstance("IHEP");
+    else
+      fPHOSGeo = AliPHOSGeometry::GetInstance("Run2");
+  }
+  else{
+    if(run<209122) //Run1
+      fPHOSGeo = AliPHOSGeometry::GetInstance("IHEP");
+    else
+      fPHOSGeo = AliPHOSGeometry::GetInstance("Run2");
+
+    AliOADBContainer geomContainer("phosGeo");
+    geomContainer.InitFromFile("$ALICE_PHYSICS/OADB/PHOS/PHOSGeometry.root","PHOSRotationMatrixes");
+    TObjArray *matrixes = (TObjArray*)geomContainer.GetObject(run,"PHOSRotationMatrixes");
+
+    for(Int_t mod=0; mod<6; mod++) {
+      if(!matrixes->At(mod)) {
+        AliError(Form("No PHOS Matrix for mod:%d, geo=%p\n", mod, fPHOSGeo));
+        continue;
+      }
+      else {
+        fPHOSGeo->SetMisalMatrix(((TGeoHMatrix*)matrixes->At(mod)),mod) ;
+        AliInfo(Form("Adding PHOS Matrix for mod:%d, geo=%p\n", mod, fPHOSGeo));
+      }
+    }//end of module loop
+
+  }
+
+  Bool_t IsZvtxOut       = kFALSE;
+  Bool_t IsDAQIncomplete = kFALSE;
+  Bool_t eventPileup     = kFALSE;
+
+  if(event->IsIncompleteDAQ()){
+    AliWarning("This is IncompleteDAQ.");
+    IsDAQIncomplete = kTRUE;
+  }
+
+  const AliVVertex *vVertex    = event->GetPrimaryVertex();
+  //const AliVVertex *vVertexSPD = event->GetPrimaryVertexSPD();
+
+  if(vVertex->GetNContributors()<1){
+    AliInfo("vertex N contributors is less than 1. reject.");
+    return kFALSE;
+  }
+
+  Double_t vertex[3] = {};
+  vertex[0] = vVertex->GetX();
+  vertex[1] = vVertex->GetY();
+  vertex[2] = vVertex->GetZ();
+
+  if(TMath::Abs(vertex[2]) > fMaxAbsZvtx){
+    AliInfo(Form("Zvtx %f cm is out of threshold %f cm.", vertex[2], fMaxAbsZvtx));
+    IsZvtxOut = kTRUE;
+  }
+
+//  if(fESDEvent){
+//    if(fESDEvent->IsPileupFromSPD()) {
+//      eventPileup = kTRUE;
+//      AliInfo("This is pile up event.");
+//    }
+//  }//end of ESD pile up
+//  else if(fAODEvent){
+//    if(fAODEvent->IsPileupFromSPD()){
+//      eventPileup = kTRUE;
+//      AliInfo("This is pile up event.");
+//    }
+//  }//end of AOD pileup
+
+  const Int_t minContributors=5;
+  const Float_t minChi2=5.;
+  const Float_t minWeiZDiff=15;
+  const Bool_t checkPlpFromDifferentBC=kFALSE;
+
+  AliAnalysisUtils utils;
+  utils.SetMinPlpContribMV(minContributors);
+  utils.SetMaxPlpChi2MV(minChi2);
+  utils.SetMinWDistMV(minWeiZDiff);
+  utils.SetCheckPlpFromDifferentBCMV(checkPlpFromDifferentBC);
+  eventPileup = utils.IsPileUpMV(event);
+
+  if(IsZvtxOut)                               return kFALSE; //reject event with Zvtx > threshold
+  if(fRejectPileup && eventPileup)            return kFALSE; //reject pile up event
+  if(fRejectDAQIncomplete && IsDAQIncomplete) return kFALSE; //reject DAQ imcopmelete event
+
+  Bool_t IsPHI7fired = kFALSE;
+  //additional criteriat for only PHOS trigger analysis
+  if(fIsPHOSTriggerAnalysis){
+    IsPHI7fired = fTriggerHelper->IsPHI7(event);
+    if(!IsPHI7fired) return kFALSE;
+  }//end of PHOS trigger decision.
+
+
+  return kTRUE;
+}
+//________________________________________________________________________
+

--- a/PWGGA/PHOSTasks/PHOS_Run2/AliPHOSEventCuts.h
+++ b/PWGGA/PHOSTasks/PHOS_Run2/AliPHOSEventCuts.h
@@ -1,0 +1,59 @@
+#ifndef AliPHOSEventCuts_cxx
+#define AliPHOSEventCuts_cxx
+
+// Author: Daiki Sekihata (Hiroshima University)
+//this analsyis class provides event selection.
+//e.g., reject pileup event, Incomplete event, |zvtx|>10cm.
+
+class TH2;
+class AliPHOSGeometry;
+class AliPHOSTriggerHelper;
+
+#include "AliPHOSTriggerHelper.h"
+#include "AliAnalysisCuts.h"
+
+class AliPHOSEventCuts : public AliAnalysisCuts {
+
+  public:
+    AliPHOSEventCuts(const char *name = "AliPHOSEventCuts");
+    virtual ~AliPHOSEventCuts(); 
+
+    virtual Bool_t IsSelected(TObject* obj) {return AcceptEvent((AliVEvent*)obj);}
+    virtual Bool_t IsSelected(TList* /*list*/) {return kTRUE;}
+    Bool_t AcceptEvent(AliVEvent *event);
+    Bool_t IsPHOSTriggerAnalysis() {return fIsPHOSTriggerAnalysis;}
+
+    void SetMCFlag(Bool_t mc) {fIsMC = mc;}
+    void SetMaxAbsZvtx(Double_t maxZ) {fMaxAbsZvtx = maxZ;}
+    void SetRejectPileup(Bool_t reject) {fRejectPileup = reject;}
+    void SetRejectDAQIncompleteEvent(Bool_t reject) {fRejectDAQIncomplete = reject;}
+
+    void DoPHOSTriggerAnalysis(Bool_t flag, TObject *obj=0x0){
+      fIsPHOSTriggerAnalysis = flag;
+      if(flag) fTriggerHelper = (AliPHOSTriggerHelper*)obj;
+    }
+
+    Bool_t IsMC() {return fIsMC;}
+
+    AliPHOSTriggerHelper *GetPHOSTriggerHelper() {return fTriggerHelper;}
+
+  private:
+    Bool_t fIsMC;
+    Bool_t fUsePHOSTender;
+    Double_t fMaxAbsZvtx;
+    Bool_t fRejectPileup;
+    Bool_t fRejectDAQIncomplete;
+    Bool_t fIsPHOSTriggerAnalysis;
+    AliPHOSTriggerHelper *fTriggerHelper;
+    AliPHOSGeometry *fPHOSGeo;
+    TH2I* fPHOSTRUBadMap[6];
+
+  private:
+    AliPHOSEventCuts(const AliPHOSEventCuts&);
+    AliPHOSEventCuts& operator=(const AliPHOSEventCuts&);
+
+    ClassDef(AliPHOSEventCuts, 5); // example of analysis
+};
+
+#endif
+

--- a/PWGGA/PHOSTasks/PHOS_Run2/AliPHOSJetJetMC.cxx
+++ b/PWGGA/PHOSTasks/PHOS_Run2/AliPHOSJetJetMC.cxx
@@ -1,0 +1,440 @@
+#include <TObject.h>
+#include <TClonesArray.h>
+#include <TH2.h>
+#include <AliLog.h>
+#include <AliPHOSGeometry.h>
+#include <AliVEvent.h>
+#include <AliESDEvent.h>
+#include <AliAODEvent.h>
+#include <AliVCaloTrigger.h>
+#include <AliVCluster.h>
+#include <AliPHOSJetJetMC.h>
+#include <AliCaloPhoton.h>
+
+#include "AliESDInputHandler.h"
+#include "AliAODInputHandler.h"
+#include "AliAODMCParticle.h"
+
+
+#include "TParticle.h"
+#include "AliMCEventHandler.h"
+#include "AliMCEvent.h"
+#include "AliStack.h"
+#include "AliGenEventHeader.h"
+#include "AliGenPythiaEventHeader.h"
+#include "AliGenCocktailEventHeader.h"
+#include "AliAnalysisManager.h"
+
+// Author: Daiki Sekihata (Hiroshima University)
+ClassImp(AliPHOSJetJetMC)
+
+//________________________________________________________________________
+AliPHOSJetJetMC::AliPHOSJetJetMC():
+  fPtHardBin(-1),
+  fPtHard(0),
+  fXsection(0),
+  fNTrials(0),
+  fPtHardAndJetPtFactor(3),
+  fPtHardAndSinglePtFactor(1.5),
+  fFirstJetIndex(-1),
+  fLastJetIndex(-1),
+  fGenJetID(-1)
+{
+  //Constructor
+  
+
+}
+//________________________________________________________________________
+AliPHOSJetJetMC::AliPHOSJetJetMC(Int_t pThardbin):
+  fPtHardBin(-1),
+  fPtHard(0),
+  fXsection(0),
+  fNTrials(0),
+  fPtHardAndJetPtFactor(3),
+  fPtHardAndSinglePtFactor(1.5),
+  fFirstJetIndex(-1),
+  fLastJetIndex(-1),
+  fGenJetID(-1)
+{
+  //Constructor
+  fPtHardBin = pThardbin; 
+  AliInfo(Form("pT-hard-bin : %d",fPtHardBin));
+
+}
+//________________________________________________________________________
+AliPHOSJetJetMC::~AliPHOSJetJetMC()
+{
+
+
+
+}
+//________________________________________________________________________
+void AliPHOSJetJetMC::ConfigureJetJetMC(AliVEvent *event)
+{
+  AliESDEvent *esd = dynamic_cast<AliESDEvent*>(event);
+  AliAODEvent *aod = dynamic_cast<AliAODEvent*>(event);
+
+  AliMCEvent *mcevent = 0x0;
+  AliGenPythiaEventHeader* pythiaGenHeader = 0x0;
+
+  if(esd){
+    AliVEventHandler* eventHandler = AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler();
+    if(eventHandler){
+      AliMCEventHandler* mcEventHandler = dynamic_cast<AliMCEventHandler*>(eventHandler);
+      if(mcEventHandler) mcevent = static_cast<AliMCEventHandler*>(AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler())->MCEvent();
+    }
+    pythiaGenHeader = GetPythiaEventHeader(mcevent);
+  }
+  else if(aod) pythiaGenHeader = GetPythiaEventHeader(aod);
+
+  Int_t pdg=0;
+  Double_t pT=0;
+  Int_t firstindexJet = 0;
+  Int_t lastindexJet = -1;
+  Int_t genIDJet = -1;
+
+  if(esd){
+    AliStack *stack = (AliStack*)mcevent->Stack();
+    if(!stack){
+      AliError("Could not get MC Stack!");
+      return;
+    }
+
+    TList *genHeaders = GetGenHeaderList(mcevent);
+    Int_t Ngen = genHeaders->GetEntries();
+    AliInfo(Form("Ngen = %d.",Ngen));
+    for(Int_t igen=0;igen<Ngen;igen++){
+      AliGenEventHeader *gh = (AliGenEventHeader*)genHeaders->At(igen);
+      TString GeneratorName = gh->GetName();
+
+      AliInfo(Form("GeneratorName = %s , NProduced = %d.",GeneratorName.Data(),gh->NProduced()));
+      lastindexJet += gh->NProduced();
+
+      if(GeneratorName.Contains("Jets",TString::kIgnoreCase) || GeneratorName.Contains("Pythia",TString::kIgnoreCase)){
+        //this string supports LHC16h3, LHC16h4.
+        genIDJet = igen;
+        break;
+      }
+      firstindexJet = gh->NProduced();
+    }
+
+    AliInfo(Form("genID of jet = %d , firstindexJet = %d , lastindexJet = %d.",genIDJet,firstindexJet,lastindexJet));
+    fFirstJetIndex = firstindexJet;
+    fLastJetIndex = lastindexJet;
+    fGenJetID = genIDJet;
+ 
+    const Int_t Ntrack = stack->GetNtrack();
+    AliInfo(Form("%d MC particles are generated in ESD.",Ntrack));
+
+  }//end of ESD
+  else if(aod){
+    TClonesArray *MCArray = dynamic_cast<TClonesArray*>(aod->FindListObject(AliAODMCParticle::StdBranchName()));
+    if(!MCArray){
+      AliError("Could not retrieve AOD event!");
+      return;
+    }
+
+    TList *genHeaders = GetGenHeaderList(aod);
+    Int_t Ngen = genHeaders->GetEntries();
+    AliInfo(Form("Ngen = %d.",Ngen));
+    for(Int_t igen=0;igen<Ngen;igen++){
+      AliGenEventHeader *gh = (AliGenEventHeader*)genHeaders->At(igen);
+      TString GeneratorName = gh->GetName();
+
+      AliInfo(Form("GeneratorName = %s , NProduced = %d.",GeneratorName.Data(),gh->NProduced()));
+      lastindexJet += gh->NProduced();
+
+      if(GeneratorName.Contains("Jets",TString::kIgnoreCase) || GeneratorName.Contains("Pythia",TString::kIgnoreCase)){
+        //this string supports LHC16h3, LHC16h4.
+        //genIDJet = igen;
+        genIDJet = igen;
+        break;
+      }
+      firstindexJet = gh->NProduced();
+    }
+
+    AliInfo(Form("genID of jet = %d , firstindexJet = %d , lastindexJet = %d.",genIDJet,firstindexJet,lastindexJet));
+    fFirstJetIndex = firstindexJet;
+    fLastJetIndex = lastindexJet;
+    fGenJetID = genIDJet;
+
+    const Int_t Ntrack = MCArray->GetEntriesFast();
+    AliInfo(Form("%d MC particles are generated in AOD.",Ntrack));
+
+  }//end of AOD
+
+
+}
+//________________________________________________________________________
+AliGenPythiaEventHeader* AliPHOSJetJetMC::GetPythiaEventHeader(AliVEvent *MCEvent)
+{
+  Int_t NTrials = -1;
+  Float_t XSection = -1;
+
+  AliGenCocktailEventHeader* cHeader = 0;
+  AliAODMCHeader *cHeaderAOD = 0;
+  Bool_t headerFound = kFALSE;
+
+  if(MCEvent->IsA()==AliMCEvent::Class()){
+    if(dynamic_cast<AliMCEvent*>(MCEvent)){
+      cHeader                  = dynamic_cast<AliGenCocktailEventHeader*>(dynamic_cast<AliMCEvent*>(MCEvent)->GenEventHeader());
+      if(cHeader) headerFound  = kTRUE;
+    }
+  }
+  if(MCEvent->IsA()==AliAODEvent::Class()){ // MCEvent is a AODEvent in case of AOD
+    cHeaderAOD                 = dynamic_cast<AliAODMCHeader*>(MCEvent->FindListObject(AliAODMCHeader::StdBranchName()));
+    if(cHeaderAOD) headerFound = kTRUE;
+  }
+
+  if(headerFound){
+    TList *genHeaders = 0x0;
+    if(cHeader) genHeaders = cHeader->GetHeaders();
+    if(cHeaderAOD){
+      genHeaders = cHeaderAOD->GetCocktailHeaders();
+
+    }
+    AliGenEventHeader* gh = 0;
+    for(Int_t i = 0; i<genHeaders->GetEntries();i++){
+      gh = (AliGenEventHeader*)genHeaders->At(i);
+      TString GeneratorName   = gh->GetName();
+      AliGenPythiaEventHeader* gPythia = dynamic_cast<AliGenPythiaEventHeader*>(gh);
+      if(gPythia){
+        //if dynamic_cast is successfully done, gPythia should not by 0x0.
+        //this is a property of dynamic_cast.
+        NTrials = gPythia->Trials();
+        XSection = gPythia->GetXsection();
+
+        return gPythia;
+      }
+    }
+
+    //AliGenPythiaEventHeader are not found.
+    NTrials = -1;
+    XSection = -1;
+    AliWarningGeneral(Form(" %s:%d",(char*)__FILE__,__LINE__),"Pythia event header not found");
+    return 0;
+
+  }
+  else {
+    AliGenEventHeader * eventHeader = dynamic_cast<AliMCEvent*>(MCEvent)->GenEventHeader();
+    TString eventHeaderName  = eventHeader->ClassName();
+    if (eventHeaderName.CompareTo("AliGenPythiaEventHeader") == 0){
+      AliGenPythiaEventHeader* gPythia = dynamic_cast<AliGenPythiaEventHeader*>(eventHeader);
+      NTrials = gPythia->Trials();
+      XSection = gPythia->GetXsection();
+      return gPythia;
+    }
+    else{
+      NTrials = -1;
+      XSection = -1;
+      AliWarningGeneral(Form(" %s:%d",(char*)__FILE__,__LINE__),"Pythia event header not found");
+      return 0;
+    }
+
+  }
+
+}
+//_______________________________________________________________________________
+Bool_t AliPHOSJetJetMC::ComparePtHardBin(AliVEvent *event)
+{
+  const Double_t pthardbin_loweredges[20]  = {5, 7,  9, 12, 16, 21, 28, 36, 45, 57, 70, 85,  99, 115, 132, 150, 169, 190, 212, 235};
+  const Double_t pthardbin_higheredges[20] = {7, 9, 12, 16, 21, 28, 36, 45, 57, 70, 85, 99, 115, 132, 150, 169, 190, 212, 235,  -1};
+
+  AliESDEvent *esd = dynamic_cast<AliESDEvent*>(event);
+  AliAODEvent *aod = dynamic_cast<AliAODEvent*>(event);
+
+  AliMCEvent *mcevent = 0x0;
+  AliGenPythiaEventHeader* pythiaGenHeader = 0x0;
+
+  if(esd){
+    AliVEventHandler* eventHandler = AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler();
+    if(eventHandler){
+      AliMCEventHandler* mcEventHandler = dynamic_cast<AliMCEventHandler*> (eventHandler);
+      if(mcEventHandler) mcevent = static_cast<AliMCEventHandler*>(AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler())->MCEvent();
+    }
+    pythiaGenHeader = GetPythiaEventHeader(mcevent);
+  }
+  else if(aod) pythiaGenHeader = GetPythiaEventHeader(aod);
+
+  Float_t xsection = pythiaGenHeader->GetXsection();
+  Float_t pThard   = pythiaGenHeader->GetPtHard();
+
+  if(pThard < pthardbin_loweredges[fPtHardBin-1]){
+    //printf("pT-hard = %f GeV/c , this value is lower than edge of pT-hard-bin[%d] settings. reject!\n",pThard,fPtHardBin);
+    AliInfo(Form("pT-hard = %f GeV/c , this value is lower than edge of pT-hard-bin[%d] settings. reject!",pThard,fPtHardBin));
+    return kFALSE;
+  }
+  if(fPtHardBin < 20 && pthardbin_higheredges[fPtHardBin-1] < pThard){
+    AliInfo(Form("pT-hard = %f GeV/c , this value is higher than edge of pT-hard-bin[%d] settings. reject!",pThard,fPtHardBin));
+    return kFALSE;
+  }
+
+  return kTRUE;
+}
+//_______________________________________________________________________________
+Bool_t AliPHOSJetJetMC::ComparePtHardWithJet(AliVEvent *event)
+{
+  AliESDEvent *esd = dynamic_cast<AliESDEvent*>(event);
+  AliAODEvent *aod = dynamic_cast<AliAODEvent*>(event);
+
+  AliMCEvent *mcevent = 0x0;
+  AliGenPythiaEventHeader* pythiaGenHeader = 0x0;
+
+  if(esd){
+    AliVEventHandler* eventHandler = AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler();
+    if(eventHandler){
+      AliMCEventHandler* mcEventHandler = dynamic_cast<AliMCEventHandler*> (eventHandler);
+      if(mcEventHandler) mcevent = static_cast<AliMCEventHandler*>(AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler())->MCEvent();
+    }
+    pythiaGenHeader = GetPythiaEventHeader(mcevent);
+  }
+  else if(aod) pythiaGenHeader = GetPythiaEventHeader(aod);
+
+  Float_t xsection = pythiaGenHeader->GetXsection();
+  Float_t pThard   = pythiaGenHeader->GetPtHard();
+
+  TParticle * jet = 0;
+  Int_t nTriggerJets =  pythiaGenHeader->NTriggerJets();
+
+  AliInfo(Form("Njets: %d, pT Hard %f",nTriggerJets, pThard));
+
+  Float_t tmpjet[]={0,0,0,0};
+  for(Int_t ijet = 0; ijet< nTriggerJets; ijet++)
+  {
+    pythiaGenHeader->TriggerJet(ijet, tmpjet);
+    jet = new TParticle(94, 21, -1, -1, -1, -1, tmpjet[0],tmpjet[1],tmpjet[2],tmpjet[3], 0,0,0,0);
+
+    AliInfo(Form("jet %d; pycell jet pT %f",ijet, jet->Pt()));
+
+    //Compare jet pT and pt Hard
+    if(jet->Pt() > fPtHardAndJetPtFactor * pThard)
+    {
+      AliInfo(Form("Reject jet event with : pT Hard %2.2f, pycell jet pT %2.2f, rejection factor %1.1f\n", pThard, jet->Pt(), fPtHardAndJetPtFactor));
+      if(jet) delete jet;
+      return kFALSE;
+    }
+  }
+
+  if(jet) delete jet;
+
+  return kTRUE;
+
+}
+//_______________________________________________________________________________
+Bool_t AliPHOSJetJetMC::ComparePtHardWithSingleParticle(AliVEvent *event)
+{
+  AliESDEvent *esd = dynamic_cast<AliESDEvent*>(event);
+  AliAODEvent *aod = dynamic_cast<AliAODEvent*>(event);
+
+  Int_t pdg=0;
+  Double_t pT=0;
+  Int_t firstindexJet = 0;
+  Int_t lastindexJet = -1;
+  Int_t genIDJet = -1;
+  AliGenPythiaEventHeader* pythiaGenHeader = 0x0;
+
+  if(esd){
+    AliMCEvent *mcevent = 0x0;
+    AliVEventHandler* eventHandler = AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler();
+
+    if(eventHandler){
+      AliMCEventHandler* mcEventHandler = dynamic_cast<AliMCEventHandler*>(eventHandler);
+      if(mcEventHandler) mcevent = static_cast<AliMCEventHandler*>(AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler())->MCEvent();
+    }
+
+    pythiaGenHeader = GetPythiaEventHeader(mcevent);
+    Float_t xsection = pythiaGenHeader->GetXsection();
+    Float_t pThard   = pythiaGenHeader->GetPtHard();
+
+    AliStack *stack = (AliStack*)mcevent->Stack();
+    if(!stack){
+      AliError("Could not get MC Stack!");
+      return kFALSE;
+    }
+ 
+    AliInfo(Form("genID of jet = %d , firstindexJet = %d , lastindexJet = %d.",fGenJetID,fFirstJetIndex,fLastJetIndex));
+    const Int_t Ntrack = stack->GetNtrack();
+    AliInfo(Form("%d MC particles are generated in ESD.",Ntrack));
+    for(Int_t i=fFirstJetIndex;i<=fLastJetIndex;i++){
+      TParticle *p = (TParticle*)stack->Particle(i);
+      pdg = p->GetPdgCode();
+
+      if(pdg==111 || pdg==221 || pdg==22){
+        pT = p->Pt();
+        if(pT > fPtHardAndSinglePtFactor*pThard){
+          AliInfo(Form("Reject jet event with : pT Hard %2.2f, particle %d : pT %2.2f, rejection factor %1.1f\n", pThard, pdg, pT, fPtHardAndSinglePtFactor));
+          return kFALSE;//reject this event
+        }
+
+      }//end of particle selection
+
+    }
+  }//end of ESD
+  else if(aod){
+    pythiaGenHeader = GetPythiaEventHeader(aod);
+    Float_t xsection = pythiaGenHeader->GetXsection();
+    Float_t pThard   = pythiaGenHeader->GetPtHard();
+
+    TClonesArray *MCArray = dynamic_cast<TClonesArray*>(aod->FindListObject(AliAODMCParticle::StdBranchName()));
+    if(!MCArray){
+      AliError("Could not retrieve AOD event!");
+      return kFALSE;
+    }
+    AliInfo(Form("genID of jet = %d , firstindexJet = %d , lastindexJet = %d.",fGenJetID,fFirstJetIndex,fLastJetIndex));
+
+    const Int_t Ntrack = MCArray->GetEntriesFast();
+    AliInfo(Form("%d MC particles are generated in AOD.",Ntrack));
+    for(Int_t i=fFirstJetIndex;i<=fLastJetIndex;i++){
+      AliAODMCParticle *p = (AliAODMCParticle*)MCArray->At(i);
+      pdg = p->PdgCode();
+      //another way to select particles generated by JJMC is to use AliAODMCParticle::GetGeneratorIndex()
+
+      if(pdg==111 || pdg==221 || pdg==22){
+        pT = p->Pt();
+        if(pT > fPtHardAndSinglePtFactor*pThard){
+          AliInfo(Form("Reject jet event with : pT Hard %2.2f, particle %d : pT %2.2f, rejection factor %1.1f", pThard, pdg, pT, fPtHardAndSinglePtFactor));
+          return kFALSE;//reject this event
+        }
+
+      }//end of particle selection
+
+    }//end of mc particle loop
+
+  }//end of AOD
+
+  return kTRUE;//accept this event
+
+}
+//________________________________________________________________________
+TList *AliPHOSJetJetMC::GetGenHeaderList(AliVEvent *MCEvent)
+{
+  AliGenCocktailEventHeader* cHeader = 0;
+  AliAODMCHeader *cHeaderAOD = 0;
+  Bool_t headerFound = kFALSE;
+
+  if(MCEvent->IsA()==AliMCEvent::Class()){
+    if(dynamic_cast<AliMCEvent*>(MCEvent)){
+      cHeader                  = dynamic_cast<AliGenCocktailEventHeader*>(dynamic_cast<AliMCEvent*>(MCEvent)->GenEventHeader());
+      if(cHeader) headerFound  = kTRUE;
+    }
+  }
+  if(MCEvent->IsA()==AliAODEvent::Class()){ // MCEvent is a AODEvent in case of AOD
+    cHeaderAOD                 = dynamic_cast<AliAODMCHeader*>(MCEvent->FindListObject(AliAODMCHeader::StdBranchName()));
+    if(cHeaderAOD) headerFound = kTRUE;
+  }
+
+  TList *genHeaders = 0x0;
+  if(cHeader){
+    genHeaders = cHeader->GetHeaders();
+    return genHeaders;
+  }
+  if(cHeaderAOD){
+    genHeaders = cHeaderAOD->GetCocktailHeaders();
+    return genHeaders;
+  }
+  return genHeaders;
+}
+//________________________________________________________________________
+//________________________________________________________________________
+//________________________________________________________________________
+

--- a/PWGGA/PHOSTasks/PHOS_Run2/AliPHOSJetJetMC.h
+++ b/PWGGA/PHOSTasks/PHOS_Run2/AliPHOSJetJetMC.h
@@ -1,0 +1,57 @@
+#ifndef AliPHOSJetJetMC_cxx
+#define AliPHOSJetJetMC_cxx
+
+//Author: Daiki Sekihata (Hiroshima University)
+
+#include "TObject.h"
+#include "AliVEvent.h"
+#include "AliGenPythiaEventHeader.h"
+
+class AliVEvent;
+class AliGenPythiaEventHeader;
+
+class AliPHOSJetJetMC : public TObject {
+
+  public:
+    AliPHOSJetJetMC();
+    AliPHOSJetJetMC(Int_t pThardbin);
+    virtual ~AliPHOSJetJetMC();
+ 
+    Int_t GetPtHardBin()  {return fPtHardBin;}
+    //Float_t GetPtHard()   {return fPtHard;}
+    //Float_t GetXsection() {return fXsection;}
+    //Int_t GetNTrials()    {return fNTrials;}
+
+    AliGenPythiaEventHeader* GetPythiaEventHeader(AliVEvent *event);
+    Bool_t ComparePtHardWithJet(AliVEvent *event);
+    Bool_t ComparePtHardWithSingleParticle(AliVEvent *event);
+    Bool_t ComparePtHardBin(AliVEvent *event);
+
+    Int_t GetFirstJetIndex() {return fFirstJetIndex;}
+    Int_t GetLastJetIndex()  {return fLastJetIndex;}
+    Int_t GetGeneratorJetIndex() {return fGenJetID;}
+    void ConfigureJetJetMC(AliVEvent *event);
+
+  protected:
+    TList *GetGenHeaderList(AliVEvent *event);
+      
+  private:
+    Int_t fPtHardBin;
+    Float_t fPtHard;
+    Float_t fXsection;
+    Int_t fNTrials;
+    Double_t fPtHardAndJetPtFactor;
+    Double_t fPtHardAndSinglePtFactor;
+    Int_t fFirstJetIndex;
+    Int_t fLastJetIndex;
+    Int_t fGenJetID;
+
+    AliPHOSJetJetMC(const AliPHOSJetJetMC&);
+    AliPHOSJetJetMC& operator=(const AliPHOSJetJetMC&);
+
+    ClassDef(AliPHOSJetJetMC, 5);
+
+};
+
+#endif
+

--- a/PWGGA/PHOSTasks/PHOS_Run2/AliPHOSTriggerHelper.cxx
+++ b/PWGGA/PHOSTasks/PHOS_Run2/AliPHOSTriggerHelper.cxx
@@ -1,0 +1,322 @@
+#include <TObject.h>
+#include <TClonesArray.h>
+#include <TH2.h>
+#include <AliLog.h>
+#include <AliPHOSGeometry.h>
+#include <AliVEvent.h>
+#include <AliESDEvent.h>
+#include <AliAODEvent.h>
+#include <AliVCaloTrigger.h>
+#include <AliVCluster.h>
+#include <AliPHOSTriggerHelper.h>
+#include <AliCaloPhoton.h>
+
+// Author: Daiki Sekihata (Hiroshima University)
+ClassImp(AliPHOSTriggerHelper)
+
+//________________________________________________________________________
+AliPHOSTriggerHelper::AliPHOSTriggerHelper():
+  fPHOSGeo(0x0),
+  fXmin(-3),
+  fXmax(3),
+  fZmin(-3),
+  fZmax(3),
+  fEvent(0x0),
+  fESDEvent(0x0),
+  fAODEvent(0x0),
+	fTriggerInputL1(-1),//5:1PHL, 6:1PHM, 7:1PHH
+	fTriggerInputL0(-1),//9:0PH0
+  fIsMC(kFALSE),
+  fCaloTrigger(0x0)
+{
+  //Constructor
+  
+  for(Int_t i=0;i<6;i++){
+    fPHOSTRUBadMap[i] = 0x0;
+  }
+
+}
+//________________________________________________________________________
+AliPHOSTriggerHelper::AliPHOSTriggerHelper(Int_t inputL1, Int_t inputL0):
+  fPHOSGeo(0x0),
+  fXmin(-3),
+  fXmax(3),
+  fZmin(-3),
+  fZmax(3),
+  fEvent(0x0),
+  fESDEvent(0x0),
+  fAODEvent(0x0),
+	fTriggerInputL1(-1),//5:1PHL, 6:1PHM, 7:1PHH
+	fTriggerInputL0(-1),//9:0PH0
+  fIsMC(kFALSE),
+  fCaloTrigger(0x0)
+{
+  //Constructor
+  
+  for(Int_t i=0;i<6;i++){
+    fPHOSTRUBadMap[i] = 0x0;
+  }
+
+  fTriggerInputL1 = inputL1;
+  fTriggerInputL0 = inputL0;
+
+  if(fTriggerInputL1 > 0 && fTriggerInputL0 > 0){
+    AliError("Both L1 and L0 are selected. Analyzer must select either L1 or L0. L1 has higher priority in this class.");
+  }
+  AliInfo(Form("Your choice L1:%d , L0:%d",fTriggerInputL1,fTriggerInputL0));
+
+}
+//________________________________________________________________________
+AliPHOSTriggerHelper::~AliPHOSTriggerHelper()
+{
+
+  for(Int_t i=0;i<6;i++){
+    if(fPHOSTRUBadMap[i]) delete fPHOSTRUBadMap[i];
+  }
+
+
+
+}
+//________________________________________________________________________
+Bool_t AliPHOSTriggerHelper::IsPHI7(AliVEvent *event)
+{
+
+  fEvent    = dynamic_cast<AliVEvent*>(event);
+  fESDEvent = dynamic_cast<AliESDEvent*>(event);
+  fAODEvent = dynamic_cast<AliAODEvent*>(event);
+  Int_t run = fEvent->GetRunNumber();
+
+  //if L1 trigger is used, L1 has higher priority
+  Bool_t IsPHI7fired = kFALSE;
+
+  if(fTriggerInputL1 > 0)
+    IsPHI7fired = event->GetHeader()->GetL1TriggerInputs() & 1 << fTriggerInputL1 - 1;//trigger input -1
+  else if(fTriggerInputL0 > 0)
+    IsPHI7fired = event->GetHeader()->GetL0TriggerInputs() & 1 << fTriggerInputL0 - 1;//trigger input -1
+  else{
+    AliInfo("Which PHOS triggered data do you analyze? Please set trigger input (L0 or L1).");
+    return kFALSE;
+  }
+
+  if(!IsPHI7fired){
+    if(fTriggerInputL1 > 0)      AliInfo(Form("Your choice of L1 trigger input %d did not fire.",fTriggerInputL1));
+    else if(fTriggerInputL0 > 0) AliInfo(Form("Your choice of L0 trigger input %d did not fire.",fTriggerInputL0));
+    return kFALSE;
+  }
+
+  if(fTriggerInputL1 > 0)      AliInfo(Form("Your choice of L1 trigger input %d fired.",fTriggerInputL1));
+  else if(fTriggerInputL0 > 0) AliInfo(Form("Your choice of L0 trigger input %d fired.",fTriggerInputL0));
+
+  TString trigClasses = event->GetFiredTriggerClasses();
+  if(245917 <= run && run <= 246994){//LHC15o
+    if(!fIsMC && fTriggerInputL1 == 7 && !trigClasses.Contains("CINT7PHH")) return kFALSE;
+    if(!fIsMC && fTriggerInputL1 == 6 && !trigClasses.Contains("CPER7PHM")) return kFALSE;
+  }
+
+  if(fTriggerInputL1 > 0) AliInfo(Form("Your choice of L1 trigger input %d matches with fired trigger classes : %s",fTriggerInputL1,trigClasses.Data()));
+
+  if(run<209122) //Run1
+    fPHOSGeo = AliPHOSGeometry::GetInstance("IHEP");
+  else
+    fPHOSGeo = AliPHOSGeometry::GetInstance("Run2");
+
+  fCaloTrigger = (AliVCaloTrigger*)event->GetCaloTrigger("PHOS"); 
+  fCaloTrigger->Reset();
+
+  const Int_t Nfired = fCaloTrigger->GetEntries();
+  AliInfo(Form("%d TRU patches fired in PHOS.",Nfired));
+
+  Int_t multClust = 0;
+  TClonesArray *array = (TClonesArray*)fEvent->FindListObject("PHOSClusterArray");
+  if(array){
+    AliInfo("PHOSClusterArray is found!");
+    multClust = array->GetEntriesFast();
+  }
+  else{
+    AliInfo("PHOSClusterArray is NOT found! clusters from AliVEvent will be used.");
+    multClust = fEvent->GetNumberOfCaloClusters();
+  }
+  AliVCaloCells *cells = dynamic_cast<AliVCaloCells*>(fEvent->GetPHOSCells());
+
+  Int_t trgrelId[4]={};
+  Int_t tmod=0; //"Online" module number
+  Int_t trgabsId=0; //bottom-left 4x4 edge cell absId [1-64], [1-56]
+  Int_t trgmodule=0,trgcellx=0,trgcellz=0;
+  Int_t maxId=0;
+  Int_t relId[4]={};
+  Int_t module=0,cellx=0,cellz=0;
+  AliVCluster *clu1;
+
+  Int_t L1=-999;
+  if(fTriggerInputL1 > 0){
+    if     (fTriggerInputL1 == 7) L1 = 0;//L1 high
+    else if(fTriggerInputL1 == 6) L1 = 1;//L1 medium
+    else if(fTriggerInputL1 == 5) L1 = 2;//L1 low
+  }
+  else if(fTriggerInputL0 > 0){
+    if(fTriggerInputL0 == 9) L1 = -1;//L0
+  }
+
+  while(fCaloTrigger->Next()){
+    // L1 threshold: -1-L0, 0-PHH, 1-PHM, 2-PHL
+
+    if(fCaloTrigger->GetL1TimeSum() != L1){
+      AliInfo(Form("This patch fired as %d, which does not match with your choice %d.",fCaloTrigger->GetL1TimeSum(),L1));
+      continue;
+    }
+    AliInfo(Form("This patch fired as %d",fCaloTrigger->GetL1TimeSum()));
+    fCaloTrigger->GetPosition(tmod,trgabsId);//tmod is online module numbering. i.e., tmod=1 means half module.
+
+    //cout << "tmod = "<< tmod << " , trgabsId = " << trgabsId << endl;
+
+    fPHOSGeo->AbsToRelNumbering(trgabsId,trgrelId);
+    //for offline numbering, relId should be used.
+
+    trgmodule = trgrelId[0];
+    trgcellx  = trgrelId[2];
+    trgcellz  = trgrelId[3];
+
+    if(trgmodule == 4) continue;
+
+    for(Int_t i=0;i<multClust;i++){
+      if(array){
+        AliCaloPhoton *ph = (AliCaloPhoton*)array->At(i);
+        clu1 = (AliVCluster*)ph->GetCluster();
+      }
+      else{
+        clu1 = (AliVCluster*)fEvent->GetCaloCluster(i);
+        if(clu1->GetType() != AliVCluster::kPHOSNeutral
+        || clu1->E() < 0.1
+//        || clu1->GetNCells() < 2
+          ) continue;
+      }
+
+      Int_t maxAbsId = FindHighestAmplitudeCellAbsId(clu1,cells);
+
+      fPHOSGeo->AbsToRelNumbering(maxAbsId,relId);
+      module = relId[0];
+      cellx  = relId[2];
+      cellz  = relId[3];
+
+      if(module == 4) continue;
+
+      if(IsMatched(trgrelId,relId) && IsGoodTRUChannel("PHOS",trgrelId[0],trgrelId[2],trgrelId[3])) return kTRUE;
+      //if(IsMatched(trgrelId,relId)) return kTRUE;
+
+    }//end of fired trigger channel loop
+
+  }
+  return kFALSE;
+}
+//________________________________________________________________________
+Bool_t AliPHOSTriggerHelper::IsMatched(Int_t *trgrelid, Int_t *clurelid)
+{
+  //Returns kTRUE if cluster position coincides with 4x4 position.
+
+  Int_t diffx = trgrelid[2] - clurelid[2];
+  Int_t diffz = trgrelid[3] - clurelid[3];
+
+  if(trgrelid[0] != clurelid[0])     return kFALSE; // different modules!
+  if(diffx < fXmin || fXmax < diffx) return kFALSE; // X-distance too large!
+  if(diffz < fZmin || fZmax < diffz) return kFALSE; // Z-distance too large!
+
+  AliInfo(Form("Accepted : diffx = %d , diffz = %d | fXmin = %d , fZmin = %d , fXmax = %d , fZmax = %d.\n",diffx,diffz,fXmin,fZmin,fXmax,fZmax));
+
+  //if(WhichTRU(trgrelid[2],trgrelid[3]) != WhichTRU(clurelid[2],clurelid[3])) return kFALSE;// different TRU.
+
+  return kTRUE;
+}
+//________________________________________________________________________
+Int_t AliPHOSTriggerHelper::FindHighestAmplitudeCellAbsId(AliVCluster *clu, AliVCaloCells *cells)
+{
+  Int_t cellAbsId=-1;
+  Double_t cellamp=0;
+  Int_t digMult = clu->GetNCells();
+  UShort_t *dlist = clu->GetCellsAbsId();
+
+  Double_t max=0;
+  Int_t index=-1;
+
+  for(Int_t iDigit=0;iDigit<digMult;iDigit++){
+    cellAbsId = dlist[iDigit];
+    cellamp = cells->GetCellAmplitude(cellAbsId) * clu->GetCellAmplitudeFraction(iDigit);
+
+    if(cellamp > max){
+      max = cellamp;
+      index = cellAbsId;
+    }
+
+  }//end of cell loop
+
+  return index;
+}
+//________________________________________________________________________
+Int_t AliPHOSTriggerHelper::WhichTRU(Int_t cellx, Int_t cellz)
+{
+  Int_t tru = -1;
+  if(cellx<1 || 64<cellx){
+    AliError("cellx is wrong! tru=-1 will return.");
+    return -1;
+  }
+  if(cellz<1 || 56<cellz){
+    AliError("cellz is wrong! tru=-1 will return.");
+    return -1;
+  }
+
+  Int_t XID = (cellx -1) / 16 + 1;
+  Int_t ZID = (cellz -1) / 28;
+
+  tru = 2*XID - ZID;
+  //cout << "cellx = " << cellx << " , cellz = " << cellz << " , tru = " << tru << endl;
+
+  return tru;
+}
+//________________________________________________________________________
+Int_t AliPHOSTriggerHelper::WhichTRUChannel(Int_t cellx, Int_t cellz, Int_t &chX, Int_t &chZ)
+{
+  //this will return TRU channel 0-111.
+  Int_t ch = -1;
+  if(cellx<1 || 64<cellx){
+    AliError("cellx is wrong! tru=-1 will return.");
+    return -1;
+  }
+  if(cellz<1 || 56<cellz){
+    AliError("cellz is wrong! tru=-1 will return.");
+    return -1;
+  }
+
+  chX = ((cellx -1)/2) %  8;
+  chZ = ((cellz -1)/2) % 14;
+
+  ch = 8*chZ + chX;
+  //printf("cellx = %d , cellz = %d , chX = %d , chZ = %d , ch = %d.\n",cellx,cellz,chX,chZ,ch);
+
+  return ch;
+}
+//________________________________________________________________________
+Bool_t AliPHOSTriggerHelper::IsGoodTRUChannel(const char * det, Int_t mod, Int_t ix, Int_t iz)
+{
+  //Check if this channel belogs to the good ones
+
+  if(strcmp(det,"PHOS")==0){
+    if(mod>5 || mod<1){
+      AliError(Form("No bad map for PHOS module %d ",mod)) ;
+      return kTRUE ;
+    }
+    if(!fPHOSTRUBadMap[mod]){
+      AliError(Form("No Bad map for PHOS module %d",mod)) ;
+      return kTRUE ;
+    }
+    if(fPHOSTRUBadMap[mod]->GetBinContent(ix,iz)>0)
+      return kFALSE ;
+    else
+      return kTRUE ;
+  }
+  else{
+    AliError(Form("Can not find bad channels for detector %s ",det)) ;
+  }
+  return kTRUE ;
+}
+//________________________________________________________________________
+//________________________________________________________________________
+//________________________________________________________________________

--- a/PWGGA/PHOSTasks/PHOS_Run2/AliPHOSTriggerHelper.h
+++ b/PWGGA/PHOSTasks/PHOS_Run2/AliPHOSTriggerHelper.h
@@ -1,0 +1,73 @@
+#ifndef AliPHOSTriggerHelper_cxx
+#define AliPHOSTriggerHelper_cxx
+
+//Author: Daiki Sekihata (Hiroshima University)
+
+#include "TObject.h"
+#include "AliPHOSGeometry.h"
+#include "AliVEvent.h"
+#include "AliVCaloTrigger.h"
+
+class AliPHOSGeometry;
+class AliVEvent;
+
+class AliPHOSTriggerHelper : public TObject {
+
+  public:
+    AliPHOSTriggerHelper();
+    AliPHOSTriggerHelper(Int_t inputL1, Int_t inputL0);
+    //AliPHOSTriggerHelper(Int_t xmin, Int_t zmin, Int_t xmax, Int_t zmax);
+    virtual ~AliPHOSTriggerHelper();
+
+    void SetPHOSTRUBadMap(Int_t mod, TH2I *h)
+    {
+      if(fPHOSTRUBadMap[mod]) delete fPHOSTRUBadMap[mod];
+      fPHOSTRUBadMap[mod] = new TH2I(*h);
+      AliInfo(Form("Setting Bad Map Histogram  %s",fPHOSTRUBadMap[mod]->GetName()));
+    }
+
+    TH2I* GetPHOSTRUBadMap(Int_t mod) {return fPHOSTRUBadMap[mod];}
+ 
+    Bool_t IsGoodTRUChannel(const char * det, Int_t mod,Int_t ix, Int_t iz);
+    Int_t WhichTRU(Int_t cellx, Int_t cellz);
+    Int_t WhichTRUChannel(Int_t cellx, Int_t cellz, Int_t &chX, Int_t &chZ);
+    Int_t FindHighestAmplitudeCellAbsId(AliVCluster *clu, AliVCaloCells *cells);
+    Bool_t IsMatched(Int_t *trgrelid, Int_t *clurelid);
+
+    Int_t GetL1TriggerInput(){return fTriggerInputL1;}
+    Int_t GetL0TriggerInput(){return fTriggerInputL0;}
+
+    void SetMatchingDistance(Int_t xmin, Int_t zmin, Int_t xmax, Int_t zmax){
+      fXmin = xmin;
+      fXmax = xmax;
+      fZmin = zmin;
+      fZmax = zmax;
+    }
+
+    Bool_t IsPHI7(AliVEvent *event);
+
+  private:
+    AliPHOSGeometry *fPHOSGeo;
+    TH2I* fPHOSTRUBadMap[6];
+    Int_t fXmin;
+    Int_t fXmax;
+    Int_t fZmin;
+    Int_t fZmax;
+    AliVEvent *fEvent;
+    AliESDEvent* fESDEvent;
+    AliAODEvent* fAODEvent;
+    Int_t fTriggerInputL1;//1PHL:5,1PHM:6,1PHH:7
+    Int_t fTriggerInputL0;//0PH0 should be 9
+    Bool_t fIsMC;
+    AliVCaloTrigger* fCaloTrigger;
+
+  private:
+    AliPHOSTriggerHelper(const AliPHOSTriggerHelper&);
+    AliPHOSTriggerHelper& operator=(const AliPHOSTriggerHelper&);
+
+    ClassDef(AliPHOSTriggerHelper, 4);
+
+};
+
+#endif
+

--- a/PWGGA/PHOSTasks/PHOS_Run2/macros/AddTaskPHOSObjectCreator.C
+++ b/PWGGA/PHOSTasks/PHOS_Run2/macros/AddTaskPHOSObjectCreator.C
@@ -1,0 +1,71 @@
+AliAnalysisTaskPHOSObjectCreator* AddTaskPHOSObjectCreator(
+    const char* name     = "PHOSObjectCreator",
+    const UInt_t trigger = AliVEvent::kINT7|AliVEvent::kPHI7,
+    const Bool_t usePHOSTender = kTRUE,
+    const Bool_t isMC = kFALSE,
+    const Double_t BunchSpace = 25,
+    const Double_t distanceBC = 0,
+    const TString period = "LHC15n"
+    )
+{
+  //Add a task AliAnalysisTaskPHOSObjectCreator to the analysis train
+  //Author: Daiki Sekihata
+  /* $Id$ */
+
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    ::Error("AddTaskPHOSObjectCreator", "No analysis manager to connect to");
+    return NULL;
+  }
+  
+  if (!mgr->GetInputEventHandler()) {
+    ::Error("AddTaskPHOSObjectCreator", "This task requires an input event handler");
+    return NULL;
+  }
+
+
+  TString taskname = Form("%s_BS%dns_DBC%dcm",name,(Int_t)BunchSpace,(Int_t)(distanceBC*10));
+
+  AliAnalysisTaskPHOSObjectCreator* task = new AliAnalysisTaskPHOSObjectCreator(taskname);
+  task->SelectCollisionCandidates(trigger);
+  task->SetTenderFlag(usePHOSTender);
+  task->SetMCFlag(isMC);
+  task->SetBunchSpace(BunchSpace);//in unit of ns
+  task->SetMinimumDistanceFromBC(distanceBC);
+
+  if(isMC){  
+    TF1 *f1nonlin = new TF1("f1nonlin","[2]*(1.+[0]*TMath::Exp(-x*x/2./[1]/[1]))",0,100);
+    f1nonlin->SetNpx(1000);
+    f1nonlin->SetParNames("a","b");
+    //f1nonlin->FixParameter(0,0);//for core E
+    //f1nonlin->FixParameter(1,1);//for core E
+    //f1nonlin->FixParameter(0,-0.03);//for core E at ZS5
+    //f1nonlin->FixParameter(1,  0.6);//for core E at ZS5
+    //f1nonlin->FixParameter(0,-0.06); //for full E at ZS5 ;
+    //f1nonlin->FixParameter(1,  0.4); //for full E at ZS5 ;
+    if(period.Contains("LHC15n")){
+      cout << "pp LHC15n is called." << endl;
+      f1nonlin->FixParameter(0,-0.05); //for full E, ZS = 20MeV;
+      f1nonlin->FixParameter(1,  0.6); //for full E, ZS = 20MeV;
+      f1nonlin->FixParameter(2,1.006); //for full E, ZS = 20MeV;//decalib 3% on M123
+      //f1nonlin->FixParameter(0,-0.03);//for core E at ZS 20 MeV
+      //f1nonlin->FixParameter(1,  0.9);//for core E at ZS 20 MeV
+    }
+    else if(period.Contains("LHC15o")){
+      cout << "PbPb LHC15o is called." << endl;
+      f1nonlin->FixParameter(0,-0.04);//for core E at ZS 20 MeV with only MIP cut
+      f1nonlin->FixParameter(1,  0.8);//for core E at ZS 20 MeV with only MIP cut
+      f1nonlin->FixParameter(2, 0.99);//for core E at ZS 20 MeV with only MIP cut
+    }
+    task->SetUserDefinedNonlinearity(f1nonlin);
+  }
+
+  mgr->AddTask(task);
+  mgr->ConnectInput(task, 0, mgr->GetCommonInputContainer());
+
+  //AliAnalysisDataContainer *coutput1 = mgr->CreateContainer(Form("%s",prefix.Data()), THashList::Class(), AliAnalysisManager::kOutputContainer, outputFile.Data());//event characerization
+  //mgr->ConnectOutput(task, 1, coutput1);
+
+  return task;
+}
+

--- a/PWGGA/PHOSTasks/PHOS_Run2/macros/AddTaskPHOSPi0EtaToGammaGamma.C
+++ b/PWGGA/PHOSTasks/PHOS_Run2/macros/AddTaskPHOSPi0EtaToGammaGamma.C
@@ -1,0 +1,221 @@
+AliAnalysisTaskPHOSPi0EtaToGammaGamma* AddTaskPHOSPi0EtaToGammaGamma(
+    const char* name     = "Pi0EtaToGammaGamma",
+    const UInt_t trigger = AliVEvent::kINT7,
+    const TString CollisionSystem = "pp",
+    const Bool_t isMC = kFALSE,
+    const Int_t L1input = -1,
+    const Int_t L0input = -1,
+    const Bool_t useCoreE = kFALSE,
+    const Bool_t useCoreDisp = kFALSE,
+    const Double_t NsigmaCPV  = 2.5,
+    const Double_t NsigmaDisp = 2.5,
+    const Bool_t usePHOSTender = kTRUE,
+    const Double_t bs = 25.,//bunch space in ns.
+    const Double_t distBC = -1,//minimum distance to bad channel.
+    const Int_t pThardbin = -1
+    )
+{
+  //Add a task AliAnalysisTaskPHOSPi0EtaToGammaGamma to the analysis train
+  //Author: Daiki Sekihata
+  /* $Id$ */
+
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    ::Error("AddTaskPHOSPi0EtaToGammaGamma", "No analysis manager to connect to");
+    return NULL;
+  }
+  
+  if (!mgr->GetInputEventHandler()) {
+    ::Error("AddTaskPHOSPi0EtaToGammaGamma", "This task requires an input event handler");
+    return NULL;
+  }
+
+	TString TriggerName="";
+	if     (trigger == (UInt_t)AliVEvent::kAny)  TriggerName = "kAny";
+	else if(trigger == (UInt_t)AliVEvent::kINT7) TriggerName = "kINT7";
+	else if(trigger == (UInt_t)AliVEvent::kPHI7) TriggerName = "kPHI7";
+
+  const Bool_t rejectPileup = kTRUE;
+  const Bool_t rejectDAQincomplete = kTRUE;
+  const Double_t MaxAbsZ = 10.;
+
+  gROOT->LoadMacro("CreatePHOSEventCuts.C");
+  AliPHOSTriggerHelper *helper = 0x0;
+
+  if(trigger == (UInt_t)AliVEvent::kPHI7){
+    if(L1input > -1 && L0input > -1){
+      ::Error("AddTaskPHOSPi0EtaToGammaGamma", "Please select L0 or L1 trigger input.");
+      return NULL;
+    }
+
+    if(L1input > -1){
+      if     (L1input==7) TriggerName += "_L1H";
+      else if(L1input==6) TriggerName += "_L1M";
+      else if(L1input==5) TriggerName += "_L1L";
+    }
+    else if(L0input > -1){
+      if(L0input==9)      TriggerName += "_L0";
+    }
+    else{
+      ::Error("AddTaskPHOSPi0EtaToGammaGamma", "PHOS trigger analysis requires at least trigger input (L0 or L1).");
+      return NULL;
+    }
+
+    helper = new AliPHOSTriggerHelper(L1input,L0input);
+    helper->SetMatchingDistance(-3,-3,0,0);
+
+    const TString pathBCMTRU = "alien:///alice/cern.ch/user/d/dsekihat/BadMap/TRUBadMap_LHC15n.root";
+    TFile *rootfile_TRUmap = TFile::Open(pathBCMTRU,"READ");
+    for(Int_t imod=1;imod<5;imod++){
+      TH2I *h2 = (TH2I*)rootfile_TRUmap->Get(Form("hTRUBadMap_M%d",imod));
+      helper->SetPHOSTRUBadMap(imod,h2);
+    }
+
+
+  }
+  AliPHOSEventCuts *eventcuts = CreatePHOSEventCuts(kMC,helper);
+
+  Int_t systemID = -1;
+  if(CollisionSystem=="pp")                                 systemID = 0;
+  else if(CollisionSystem=="PbPb")                          systemID = 1;
+  else if(CollisionSystem=="pPb" || CollisionSystem=="Pbp") systemID = 2;
+
+  gROOT->LoadMacro("CreatePHOSClusterCuts.C");
+  AliPHOSClusterCuts *clustercuts = CreatePHOSClusterCuts(useCoreDisp,NsigmaCPV,NsigmaDisp);
+
+  TString PIDname="";
+  if(NsigmaCPV > 0) PIDname += Form("_CPV%d",(Int_t)(NsigmaCPV*10));
+  if(NsigmaDisp > 0){
+    if(useCoreDisp) PIDname += Form("_CoreDisp%d",(Int_t)(NsigmaDisp*10));
+    else            PIDname += Form("_FullDisp%d",(Int_t)(NsigmaDisp*10));
+  }
+  if(useCoreE) PIDname += "_CoreE";
+  else         PIDname += "_FullE";
+
+  TString taskname = Form("%s_%s_%s%s_BS%dns_DBC%02dmm",name,CollisionSystem.Data(),TriggerName.Data(),PIDname.Data(),(Int_t)bs,(Int_t)(distBC*10));
+
+  AliAnalysisTaskPHOSPi0EtaToGammaGamma* task = new AliAnalysisTaskPHOSPi0EtaToGammaGamma(taskname);
+  task->SelectCollisionCandidates(trigger);
+  task->SetCollisionSystem(systemID);//colliions system : pp=0, PbPb=1, pPb (Pbp)=2;
+  if(pThardbin>0) task->SetPtHardBin(pThardbin);
+
+  task->SetTenderFlag(usePHOSTender);
+  task->SetMCFlag(isMC);
+  task->SetCoreEnergyFlag(useCoreE);
+
+  task->SetEventCuts(eventcuts);
+  task->SetClusterCuts(clustercuts);
+
+  //centrality setting
+  if(CollisionSystem=="pp"){//for pp
+    const Int_t nbins = 0;
+    Double_t cbin_data[nbins+1] = {0};//added lastbin + 1 as "Ntrack is greater than cbin[lastbin] upto infinity"
+    Double_t cbin_MBMC[nbins+1] = {0};//added lastbin + 1 as "Ntrack is greater than cbin[lastbin] upto infinity"
+    Double_t cbin_JJMC[nbins+1] = {0};//added lastbin + 1 as "Ntrack is greater than cbin[lastbin] upto infinity"
+
+    TArrayD tbin;
+    if(!isMC)           tbin = TArrayD(nbins+1, cbin_data);//data
+    else{//for MC
+      if(pThardbin < 0) tbin = TArrayD(nbins+1, cbin_MBMC);//MB MC to get same cluster occupance on PHOS
+      else              tbin = TArrayD(nbins+1, cbin_JJMC);//MB MC to get same cluster occupance on PHOS
+    }
+
+    Int_t nMixed[nbins+1] = {100};
+    TArrayI tNMixed(nbins+1, nMixed);
+    task->SetCentralityBinningPP(tbin, tNMixed);
+  }
+  else if(CollisionSystem=="PbPb"){//for PbPb
+    task->SetCentralityEstimator("V0M");
+
+    const Int_t nbins = 9;
+    Double_t cbin_data[nbins+1] = {0,10,20,30,40,50,60,70,80,90};//for data
+    Double_t cbin_MBMC[nbins+1] = {1,11,21,31,41,51,61,71,81,91};//for MBMC to get same cluster occupance on PHOS
+    Double_t cbin_JJMC[nbins+1] = {2,12,22,32,42,52,62,72,82,92};//for JJMC to get same cluster occupance on PHOS
+
+    TArrayD tbin;
+    if(!isMC)           tbin = TArrayD(nbins+1, cbin_data);//data
+    else{//for MC
+      if(pThardbin < 0) tbin = TArrayD(nbins+1, cbin_MBMC);//MB MC
+      else              tbin = TArrayD(nbins+1, cbin_JJMC);//MB MC
+    }
+
+    Int_t nMixed[nbins] = {10,10,20,20,50,50,100,100,200};
+    TArrayI tNMixed(nbins, nMixed);
+    task->SetCentralityBinningPbPb(tbin, tNMixed);
+  }
+  else if(CollisionSystem=="pPb" || CollisionSystem=="Pbp"){//for pPb
+    if(CollisionSystem == "pPb")      task->SetCentralityEstimator("V0A");//Pb-going side C->A
+    else if(CollisionSystem == "Pbp") task->SetCentralityEstimator("V0C");//Pb-going side A->C
+
+    const Int_t nbins = 5;
+    Double_t cbin_data[nbins+1] = {0,20,40,60,80,100};//for data
+    Double_t cbin_MBMC[nbins+1] = {0,20,40,60,80,100};//for MBMC to get same cluster occupance on PHOS
+    Double_t cbin_JJMC[nbins+1] = {0,20,40,60,80,100};//for JJMC to get same cluster occupance on PHOS
+
+    TArrayD tbin;
+    if(!isMC)           tbin = TArrayD(nbins+1, cbin_data);//data
+    else{//for MC
+      if(pThardbin < 0) tbin = TArrayD(nbins+1, cbin_MBMC);//MB MC
+      else              tbin = TArrayD(nbins+1, cbin_JJMC);//MB MC
+    }
+
+    Int_t nMixed[nbins] = {20,20,50,100,100};
+    TArrayI tNMixed(nbins, nMixed);
+    task->SetCentralityBinningPbPb(tbin, tNMixed);
+  }
+
+  //setting esd track selection for hybrid track
+  gROOT->LoadMacro("$ALICE_PHYSICS/PWGJE/macros/CreateTrackCutsPWGJE.C");
+  AliESDtrackCuts *cutsG = CreateTrackCutsPWGJE(10001008);//for good global tracks
+  task->SetESDtrackCutsForGlobal(cutsG);
+  AliESDtrackCuts *cutsGC = CreateTrackCutsPWGJE(10011008);//for good global-constrained tracks
+  task->SetESDtrackCutsForGlobalConstrained(cutsGC);
+
+  //bunch space for TOF cut
+  if(CollisionSystem=="pp"){//pp
+    task->SetBunchSpace(25.);//in unit of ns.
+    TF1 *f1tof = new TF1("f1TOFCutEfficiency","[0] * (2/(1+exp(-[1]*(x-[2]))) - 1) - ( 0 + [3]/(exp( -(x-[4]) / [5] ) + 1)  )",0,100);
+    f1tof->SetParameters(0.996,2.45,0.039,0.31,7.16,0.620);
+
+    //TF1 *f1tof = new TF1("f1TOFCutEfficiency","1.",0,100);
+
+    task->SetTOFCutEfficiencyFunction(f1tof);
+  }
+  else if(CollisionSystem=="PbPb"){//PbPb
+    task->SetBunchSpace(100.);//in unit of ns.
+    TF1 *f1tof = new TF1("f1TOFCutEfficiency","[0] * (2/(1+exp(-[1]*x)) - 1) - ( 0 + [2]/(exp( -(x-[3]) / [4] ) + 1)  )",0,100);
+    f1tof->SetParameters(0.997,7.38,0.029,7.6,0.5);
+    task->SetTOFCutEfficiencyFunction(f1tof);
+  }
+  else if(CollisionSystem=="pPb" || CollisionSystem=="pPb"){//pPb
+    task->SetBunchSpace(100.);//in unit of ns.
+    //TF1 *f1tof = new TF1("f1TOFCutEfficiency","1.",0,100);
+    TF1 *f1tof = new TF1("f1TOFCutEfficiency","[0] * (2/(1+exp(-[1]*(x-[2]))) - 1) - ( 0 + [3]/(exp( -(x-[4]) / [5] ) + 1)  )",0,100);
+    f1tof->SetParameters(0.996,6.79,0.0035,0.114,7.67,0.455);
+    task->SetTOFCutEfficiencyFunction(f1tof);
+  }
+
+  if(isMC){
+    //TF1 *f1Pi0Weight = new TF1("f1Pi0Weight","1+[0]*exp(-[1]*x)",0,100);
+    //f1Pi0Weight->SetParameters(0.77,0.57);
+    TF1 *f1Pi0Weight = new TF1("f1Pi0Weight","1.",0,100);
+    task->SetAdditionalPi0PtWeightFunction(f1Pi0Weight);
+
+    TF1 *f1K0SWeight = new TF1("f1K0SWeight","[0] * (2/(1+exp(-[1]*x)) - 1) - ( 0 + [2]/(exp( -(x-[3]) / [4] ) + 1)  )",0,100);
+    f1K0SWeight->SetParameters(1.37,4.98,0.156,2.79,0.238);
+    task->SetAdditionalK0SPtWeightFunction(f1K0SWeight);
+  }
+
+
+  mgr->AddTask(task);
+  mgr->ConnectInput(task, 0, mgr->GetCommonInputContainer() );
+ 
+  TString outputFile = AliAnalysisManager::GetCommonFileName();
+
+  TString prefix = Form("hist_%s",taskname.Data());
+  AliAnalysisDataContainer *coutput1 = mgr->CreateContainer(Form("%s",prefix.Data()), THashList::Class(), AliAnalysisManager::kOutputContainer, outputFile.Data());//event characerization
+  mgr->ConnectOutput(task, 1, coutput1);
+
+  return task;
+}
+

--- a/PWGGA/PHOSTasks/PWGGAPHOSTasksLinkDef.h
+++ b/PWGGA/PHOSTasks/PWGGAPHOSTasksLinkDef.h
@@ -7,6 +7,15 @@
 // ClusterSelection
 #pragma link C++ class AliPHOSTriggerUtils+;
 
+
+// PHOS_Run2
+#pragma link C++ class AliAnalysisTaskPHOSObjectCreator+;
+#pragma link C++ class AliPHOSEventCuts+;
+#pragma link C++ class AliPHOSClusterCuts+;
+#pragma link C++ class AliPHOSTriggerHelper+;
+#pragma link C++ class AliAnalysisTaskPHOSPi0EtaToGammaGamma+;
+
+
 // PHOS_pp_8TeV_2012 
 #pragma link C++ class AliCaloPhoton+;
 #pragma link C++ class AliAnalysisTaskPHOSTrigPi0+;


### PR DESCRIPTION
Macros to analyze Run2 PHOS data are uploaded. These macros support pp/PbPb/pPb data.
An array which contains PHOS clusters is created by PHOSObjectCreator at first.
Then, this array is analyzed by Pi0EtaToGammaGamma.
Event selection is done by AliPHOSEventCuts, and clusters are selected by AliPHOSClusterCuts.