### PR TITLE
Fix AliCFDataGrid::Copy

### DIFF
--- a/CORRFW/AliCFDataGrid.cxx
+++ b/CORRFW/AliCFDataGrid.cxx
@@ -135,7 +135,7 @@ void AliCFDataGrid::ApplyBGCorrection(const AliCFDataGrid &c)
 void AliCFDataGrid::Copy(TObject& c) const
 {
   // copy function
-  Copy(c);
+  AliCFGridSparse::Copy(c);
   AliCFDataGrid& target = (AliCFDataGrid &) c;
   target.fContainer=fContainer;
   target.fSelData=fSelData;


### PR DESCRIPTION
Function was calling itself infinitely

Revealed by a compiler warning.