### PR TITLE
Fix integer abs -> TMath::Abs AliCentralitySelectionTask

### DIFF
--- a/OADB/AliCentralitySelectionTask.cxx
+++ b/OADB/AliCentralitySelectionTask.cxx
@@ -1841,7 +1841,7 @@ void AliCentralitySelectionTask::UserExec(Option_t */*option*/)
     }
 
 
-    if ((fMB) && (abs(zvtx)<10))	fHOutMultCL1vsTKL->Fill(spdCorr,nTracklets);
+    if ((fMB) && (TMath::Abs(zvtx)<10))	fHOutMultCL1vsTKL->Fill(spdCorr,nTracklets);
 
     if (fCVHN)   fHOutCentV0MCVHN->Fill(fCentV0M);
     if (fCVLN)   fHOutCentV0MCVLN->Fill(fCentV0M);


### PR DESCRIPTION
Code is good as is, but generates warning.

@atoia what do you think?