### PR TITLE
Removed unused value AliPhysicsSelection

### DIFF
--- a/OADB/AliPhysicsSelection.cxx
+++ b/OADB/AliPhysicsSelection.cxx
@@ -463,7 +463,6 @@ Bool_t AliPhysicsSelection::Initialize(Int_t runNumber){
       else h.ReadPITConditionsFromDB(runNumber,man->GetDefaultStorage()->GetURI().Data());
       AliITSTriggerConditions* tri = h.GetTriggerConditions();
       if (tri) {
-        Int_t thresholdInner = tri->GetAlgoParamValueLI("0SH1",0); // algorithm name and param index 0
         if (fTriggerOADB->GetSH1OuterThreshold()<0) {
           Int_t val = tri->GetAlgoParamValueLI("0SH1",1);
           AliInfo(Form("  SH1OuterThreshold set to %i",val));


### PR DESCRIPTION
Removed unused value in AliPhysicsSelection. The function used to obtain this value is const, thus the function call itself has also no effect.

@BerserkerTroll @cbourjau @ekryshen please look. This commit does not change behavior of the task, but the warning that some value is unused might also mean that one forgot to use it.

Revealed by compiler warning:
```c++
DEBUG:AliPhysics:0: /Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/OADB/AliPhysicsSelection.cxx:466:15: warning: unused variable 'thresholdInner' [-Wunused-variable]
DEBUG:AliPhysics:0:         Int_t thresholdInner = tri->GetAlgoParamValueLI("0SH1",0); // algorithm name and param index 0
DEBUG:AliPhysics:0:               ^
```

Cheers,
Hans