### PR TITLE
Fix infinite loop AliCalorimeterUtils

### DIFF
--- a/PWG/CaloTrackCorrBase/AliCalorimeterUtils.h
+++ b/PWG/CaloTrackCorrBase/AliCalorimeterUtils.h
@@ -147,7 +147,7 @@ class AliCalorimeterUtils : public TObject {
   void          SwitchOffBadChannelsRemoval()              { fRemoveBadChannels = kFALSE ; 
                                                              fEMCALRecoUtils->SwitchOffBadChannelsRemoval()           ; }
   
-  Bool_t        IsDistanceToBadChannelRecalculated() const { return  IsDistanceToBadChannelRecalculated()             ; }
+  Bool_t        IsDistanceToBadChannelRecalculated() const { return fEMCALRecoUtils->IsDistanceToBadChannelRecalculated(); }
   void          SwitchOnDistToBadChannelRecalculation ()   { fEMCALRecoUtils->SwitchOnDistToBadChannelRecalculation() ; }
   void          SwitchOffDistToBadChannelRecalculation()   { fEMCALRecoUtils->SwitchOffDistToBadChannelRecalculation(); }
   


### PR DESCRIPTION
Forward IsDistanceToBadChannelRecalculated to data member

Revealed by compiler warning:
```c++
DEBUG:AliPhysics:0: /Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWG/CaloTrackCorrBase/AliCalorimeterUtils.h:150:60: warning: all paths through this function will call itself [-Winfinite-recursion]
DEBUG:AliPhysics:0:   Bool_t        IsDistanceToBadChannelRecalculated() const { return  IsDistanceToBadChannelRecalculated()             ; }
DEBUG:AliPhysics:0:                                                            ^
```