### PR TITLE
Many changes, see below

### DIFF
--- a/PWGDQ/reducedTree/AliAnalysisTaskReducedEventProcessor.h
+++ b/PWGDQ/reducedTree/AliAnalysisTaskReducedEventProcessor.h
@@ -23,14 +23,13 @@ class AliAnalysisTaskReducedEventProcessor : public AliAnalysisTaskSE {
 
 public:
   enum Constants {
-    //kMaxOutputs=100,
     kUseOnTheFlyReducedEvents=1,      // use events from exchange container published by the tree maker task
     kUseEventsFromTree=2                     // run directly over trees of reduced events
   };
   
  public:
   AliAnalysisTaskReducedEventProcessor();
-  AliAnalysisTaskReducedEventProcessor(const char *name, Int_t runningMode=kUseEventsFromTree);
+  AliAnalysisTaskReducedEventProcessor(const char *name, Int_t runningMode=kUseEventsFromTree, Bool_t writeFilteredTree=kFALSE);
   virtual ~AliAnalysisTaskReducedEventProcessor(){}
 
   void AddTask(AliReducedAnalysisTaskSE* task) {fReducedTask=task;}
@@ -44,21 +43,21 @@ public:
   Int_t GetRunningMode() const {return fRunningMode;}  
   AliReducedAnalysisTaskSE* GetReducedTask() const {return fReducedTask;}
   
+  Bool_t GetWriteFilteredTree() const {return fWriteFilteredTree;}
+  
  protected:
   AliReducedAnalysisTaskSE* fReducedTask;      // Pointer to the analysis task which will process the reduced events
- // TObject* fOutputSlot[kMaxOutputs];
- // Int_t fContainerType[kMaxOutputs]; // 0: output   1: exchange
- // Int_t fNoutputSlots;
   
   Int_t fRunningMode;                               // Running mode, as specified in options 1 and 2 from Constants
-  Long_t fEventNumber;                  // event number
   
   AliReducedBaseEvent* fReducedEvent;   //! reduced event
+  
+  Bool_t fWriteFilteredTree;                   // if kTRUE, the reduced task will produce filtered reduced trees
   
   AliAnalysisTaskReducedEventProcessor(const AliAnalysisTaskReducedEventProcessor &c);
   AliAnalysisTaskReducedEventProcessor& operator= (const AliAnalysisTaskReducedEventProcessor &c);
 
-  ClassDef(AliAnalysisTaskReducedEventProcessor, 3);
+  ClassDef(AliAnalysisTaskReducedEventProcessor, 4);
 };
 
 #endif

--- a/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
+++ b/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
@@ -1218,8 +1218,8 @@ void AliAnalysisTaskReducedTreeMaker::FillTrackInfo()
        AliESDEvent* esdEvent = static_cast<AliESDEvent*>(InputEvent());
        AliESDVertex* eventVtx = const_cast<AliESDVertex*>(esdEvent->GetPrimaryVertexTracks());
        TClass* esdClass = esdTrack->Class();
-       if( esdClass->GetMethodAny("GetChi2TPCConstrainedVsGlobal") )
-         trackInfo->fChi2TPCConstrainedVsGlobal = esdTrack->GetChi2TPCConstrainedVsGlobal(eventVtx);
+       if(esdClass->GetMethodAny("GetChi2TPCConstrainedVsGlobal"))
+          trackInfo->fChi2TPCConstrainedVsGlobal = esdTrack->GetChi2TPCConstrainedVsGlobal(eventVtx);
        
       trackInfo->fTrackId          = (UShort_t)esdTrack->GetID();
       const AliExternalTrackParam* tpcInner = esdTrack->GetTPCInnerParam();
@@ -1348,7 +1348,7 @@ void AliAnalysisTaskReducedTreeMaker::FillTrackInfo()
       trackInfo->fTOFdz         = aodTrack->GetTOFsignalDz();
       trackInfo->fTOFdeltaBC = eventInfo->fBC - aodTrack->GetTOFBunchCrossing();
       
-      trackInfo->fTrackId = aodTrack->GetID(); 
+      trackInfo->fTrackId = aodTrack->GetID();
       trackInfo->fTRDntracklets[0] = aodTrack->GetTRDntrackletsPID();
       trackInfo->fTRDntracklets[1] = aodTrack->GetTRDntrackletsPID();
       pidResponse->ComputeTRDProbability(aodTrack,AliPID::kSPECIES,trdProbab,AliTRDPIDResponse::kLQ1D);

--- a/PWGDQ/reducedTree/AliReducedAnalysisFilterTrees.cxx
+++ b/PWGDQ/reducedTree/AliReducedAnalysisFilterTrees.cxx
@@ -1,0 +1,749 @@
+//
+// Creation date: 2017/08/09
+// Author: Ionut-Cristian Arsene, iarsene@cern.ch, i.c.arsene@fys.uio.no
+
+#include "AliReducedAnalysisFilterTrees.h"
+
+#include <iostream>
+using std::cout;
+using std::endl;
+
+#include <TClonesArray.h>
+#include <TIterator.h>
+
+#include "AliReducedVarManager.h"
+#include "AliReducedEventInfo.h"
+#include "AliReducedBaseEvent.h"
+#include "AliReducedBaseTrack.h"
+#include "AliReducedTrackInfo.h"
+#include "AliReducedPairInfo.h"
+#include "AliHistogramManager.h"
+
+ClassImp(AliReducedAnalysisFilterTrees);
+
+
+//___________________________________________________________________________
+AliReducedAnalysisFilterTrees::AliReducedAnalysisFilterTrees() :
+  AliReducedAnalysisTaskSE(),
+  fHistosManager(new AliHistogramManager("Histogram Manager", AliReducedVarManager::kNVars)),
+  fEventCuts(),
+  fTrackCuts(),
+  fWriteFilteredTracks(kTRUE),
+  fPairCuts(),
+  fWriteFilteredPairs(kTRUE),
+  fBuildCandidatePairs(kFALSE),
+  fBuildCandidateLikePairs(kFALSE),
+  fCandidateType(AliReducedPairInfo::kJpsiToEE),
+  fLeg1Cuts(),
+  fLeg2Cuts(),
+  fCandidatePairCuts(),
+  fRunCandidatePrefilter(kFALSE),
+  fRunCandidatePrefilterOnSameCharge(kFALSE),
+  fLeg1PrefilterCuts(),
+  fLeg2PrefilterCuts(),
+  fLeg1PairPrefilterCuts(),
+  fLeg2PairPrefilterCuts(),
+  fLeg1Tracks(),
+  fLeg2Tracks(),
+  fLeg1PrefilteredTracks(),
+  fLeg2PrefilteredTracks()
+{
+  //
+  // default constructor
+  //
+}
+
+//___________________________________________________________________________
+AliReducedAnalysisFilterTrees::AliReducedAnalysisFilterTrees(const Char_t* name, const Char_t* title) :
+  AliReducedAnalysisTaskSE(name,title),
+  fHistosManager(new AliHistogramManager("Histogram Manager", AliReducedVarManager::kNVars)),
+  fEventCuts(),
+  fTrackCuts(),
+  fWriteFilteredTracks(kTRUE),
+  fPairCuts(),
+  fWriteFilteredPairs(kTRUE),
+  fBuildCandidatePairs(kFALSE),
+  fBuildCandidateLikePairs(kFALSE),
+  fCandidateType(AliReducedPairInfo::kJpsiToEE),
+  fLeg1Cuts(),
+  fLeg2Cuts(),
+  fCandidatePairCuts(),
+  fRunCandidatePrefilter(kFALSE),
+  fRunCandidatePrefilterOnSameCharge(kFALSE),
+  fLeg1PrefilterCuts(),
+  fLeg2PrefilterCuts(),
+  fLeg1PairPrefilterCuts(),
+  fLeg2PairPrefilterCuts(),
+  fLeg1Tracks(),
+  fLeg2Tracks(),
+  fLeg1PrefilteredTracks(),
+  fLeg2PrefilteredTracks()
+{
+  //
+  // named constructor
+  //
+   fEventCuts.SetOwner(kTRUE);
+   fTrackCuts.SetOwner(kTRUE);
+   fPairCuts.SetOwner(kTRUE);
+   fLeg1Cuts.SetOwner(kTRUE);
+   fLeg2Cuts.SetOwner(kTRUE);
+   fCandidatePairCuts.SetOwner(kTRUE);
+   fLeg1PrefilterCuts.SetOwner(kTRUE);
+   fLeg2PrefilterCuts.SetOwner(kTRUE);
+   fLeg1PairPrefilterCuts.SetOwner(kTRUE);
+   fLeg2PairPrefilterCuts.SetOwner(kTRUE);
+   fLeg1Tracks.SetOwner(kFALSE);
+   fLeg2Tracks.SetOwner(kFALSE);
+   fLeg1PrefilteredTracks.SetOwner(kFALSE);
+   fLeg2PrefilteredTracks.SetOwner(kFALSE);
+}
+
+//___________________________________________________________________________
+AliReducedAnalysisFilterTrees::~AliReducedAnalysisFilterTrees() 
+{
+  //
+  // destructor
+  //
+   fEventCuts.Clear("C"); fTrackCuts.Clear("C"); fPairCuts.Clear("C");
+   fLeg1Cuts.Clear("C"); fLeg2Cuts.Clear("C"); fCandidatePairCuts.Clear("C");
+   fLeg1PrefilterCuts.Clear("C"); fLeg2PrefilterCuts.Clear("C");
+   fLeg1PairPrefilterCuts.Clear("C"); fLeg2PairPrefilterCuts.Clear("C");
+   fLeg1Tracks.Clear("C"); fLeg2Tracks.Clear("C");
+   fLeg1PrefilteredTracks.Clear("C"); fLeg2PrefilteredTracks.Clear("C");
+   if(fHistosManager) delete fHistosManager;
+}
+
+//___________________________________________________________________________
+void AliReducedAnalysisFilterTrees::Init() {
+  //
+  // initialize stuff
+  //
+   AliReducedVarManager::SetDefaultVarNames();
+   fHistosManager->SetUseDefaultVariableNames(kTRUE);
+   fHistosManager->SetDefaultVarNames(AliReducedVarManager::fgVariableNames,AliReducedVarManager::fgVariableUnits);
+}
+
+//___________________________________________________________________________
+void AliReducedAnalysisFilterTrees::Process() {
+  //
+  // process the current event
+  //  
+  if(!fEvent) return;
+  AliReducedEventInfo* eventInfo = NULL;
+  if(fEvent->IsA()==AliReducedEventInfo::Class()) eventInfo = (AliReducedEventInfo*)fEvent;
+  else {
+     cout << "ERROR: AliReducedAnalysisFilterTrees::Process() needs AliReducedEventInfo events" << endl;
+     return;
+  }
+  
+  if(fEventCounter%100000==0) 
+     cout << "Event no. " << fEventCounter << endl;
+  fEventCounter++;
+  
+  AliReducedVarManager::SetEvent(fEvent);
+  
+  // reset the values array, keep only the run wise data (LHC and ALICE GRP information)
+  // NOTE: the run wise data will be updated automatically in the VarManager in case a run number change is detected
+  for(Int_t i=AliReducedVarManager::kNRunWiseVariables; i<AliReducedVarManager::kNVars; ++i) fValues[i]=-9999.;
+  
+  // fill event information before event cuts
+  AliReducedVarManager::FillEventInfo(fEvent, fValues);
+  fHistosManager->FillHistClass("Event_BeforeCuts", fValues);
+  for(UShort_t ibit=0; ibit<64; ++ibit) {
+     AliReducedVarManager::FillEventTagInput(fEvent, ibit, fValues);
+     fHistosManager->FillHistClass("EventTag_BeforeCuts", fValues);
+  }
+  for(UShort_t ibit=0; ibit<64; ++ibit) {
+      AliReducedVarManager::FillEventOnlineTrigger(ibit, fValues);
+      fHistosManager->FillHistClass("EventTriggers_BeforeCuts", fValues);
+  }
+  
+  // apply event selection
+  if(!IsEventSelected(fEvent)) return;
+  
+  // fill event info histograms after cuts
+  fHistosManager->FillHistClass("Event_AfterCuts", fValues);
+  for(UShort_t ibit=0; ibit<64; ++ibit) {
+     AliReducedVarManager::FillEventTagInput(fEvent, ibit, fValues);
+     fHistosManager->FillHistClass("EventTag_AfterCuts", fValues);
+  }
+  for(UShort_t ibit=0; ibit<64; ++ibit) {
+     AliReducedVarManager::FillEventOnlineTrigger(ibit, fValues);
+     fHistosManager->FillHistClass("EventTriggers_AfterCuts", fValues);
+  }
+  
+  CreateFilteredEvent();  
+  fFilteredTree->Fill();
+}
+
+//___________________________________________________________________________
+void AliReducedAnalysisFilterTrees::CreateFilteredEvent() {
+   //
+   // create the filtered event
+   //
+   // NOTE: The folowing information is filtered from the input event 
+   //     1) Event header (either base event or full event header)
+   //     2) selected V0 candidates -> see WriteFilteredPairs()
+   //     3) selected tracks and legs of selected V0 candidates -> see WriteFilteredTracks()
+   //     4) create candidates of the types specified in AliReducedPairInfo -> see BuildCandidatePairs()
+   if(fFilteredTreeWritingOption==kFullEventsWithBaseTracks || fFilteredTreeWritingOption==kFullEventsWithFullTracks)
+      ((AliReducedEventInfo*)fFilteredEvent)->CopyEventHeader((AliReducedEventInfo*)fEvent);
+   else
+      fFilteredEvent->CopyEventHeader(fEvent);
+   
+   if(fWriteFilteredPairs) WriteFilteredPairs();
+   if(fWriteFilteredTracks) WriteFilteredTracks();
+   if(fBuildCandidatePairs) BuildCandidatePairs();
+}
+
+//___________________________________________________________________________
+void AliReducedAnalysisFilterTrees::WriteFilteredPairs() {
+   //
+   // select and add filtered pair candidates to the filtered event
+   //
+   // loop over the pair list in the unfiltered event and evaluate all the pair cuts
+   AliReducedPairInfo* pair = 0x0;
+   TClonesArray* pairList = fEvent->GetPairs();
+   TIter nextPair(pairList);
+   for(Int_t ip=0; ip<fEvent->NPairs(); ++ip) {
+      pair = (AliReducedPairInfo*)nextPair();
+      AliReducedVarManager::FillPairInfo(pair, fValues);
+      fHistosManager->FillHistClass("Pair_BeforeCuts", fValues);
+      for(UShort_t iflag=0; iflag<32; ++iflag) {
+         AliReducedVarManager::FillPairQualityFlag(pair, iflag, fValues);
+         fHistosManager->FillHistClass("PairQualityFlags_BeforeCuts", fValues);
+      }
+      
+      if(IsPairSelected(pair, fValues)) {
+         for(Int_t icut=0; icut<fPairCuts.GetEntries(); ++icut) {
+            if(pair->TestFlag(icut)) {
+               fHistosManager->FillHistClass(Form("Pair_%s", fPairCuts.At(icut)->GetName()), fValues);
+               for(UShort_t iflag=0; iflag<32; ++iflag) {
+                  AliReducedVarManager::FillPairQualityFlag(pair, iflag, fValues);
+                  fHistosManager->FillHistClass(Form("PairQualityFlags_%s", fPairCuts.At(icut)->GetName()), fValues);
+               }
+            }
+         }
+         TClonesArray& pairs = *(fFilteredEvent->fCandidates);
+         AliReducedPairInfo* filteredPair=NULL;
+         filteredPair=new(pairs[fFilteredEvent->fNV0candidates[1]]) AliReducedPairInfo(*pair);
+         fFilteredEvent->fNV0candidates[1] += 1;
+      }
+   }  // end loop over pairs
+}
+
+//___________________________________________________________________________
+void AliReducedAnalysisFilterTrees::WriteFilteredTracks() {
+   //
+   // select and add filtered tracks to the filtered event
+   //
+   // loop over the track list and evaluate all the track cuts
+   AliReducedBaseTrack* track = 0x0;
+   TClonesArray* trackList = fEvent->GetTracks();
+   TIter nextTrack(trackList);
+   for(Int_t it=0; it<fEvent->NTracks(); ++it) {
+      track = (AliReducedBaseTrack*)nextTrack();
+      AliReducedVarManager::FillTrackInfo(track, fValues);
+      fHistosManager->FillHistClass("Track_BeforeCuts", fValues);
+      
+      Bool_t writeTrack = IsTrackSelected(track, fValues);
+      writeTrack |= TrackIsCandidateLeg(track);
+      
+      if(writeTrack) {
+         for(Int_t icut=0; icut<fTrackCuts.GetEntries(); ++icut) {
+            if(track->TestFlag(icut)) 
+               fHistosManager->FillHistClass(Form("Track_%s", fTrackCuts.At(icut)->GetName()), fValues);
+         }
+         TClonesArray& tracks = *(fFilteredEvent->fTracks);
+         AliReducedBaseTrack* filteredParticle=NULL;
+         if(fFilteredTreeWritingOption==kBaseEventsWithBaseTracks || fFilteredTreeWritingOption==kFullEventsWithBaseTracks)
+            filteredParticle=new(tracks[fFilteredEvent->fNtracks[1]]) AliReducedBaseTrack(*track);
+         if(fFilteredTreeWritingOption==kBaseEventsWithFullTracks || fFilteredTreeWritingOption==kFullEventsWithFullTracks) {
+            AliReducedTrackInfo* tempTrack = dynamic_cast<AliReducedTrackInfo*>(track);
+            filteredParticle=new(tracks[fFilteredEvent->fNtracks[1]]) AliReducedTrackInfo(*tempTrack);
+         }
+         fFilteredEvent->fNtracks[1] += 1;
+      }
+   }  // end loop over tracks
+}
+
+//___________________________________________________________________________
+void AliReducedAnalysisFilterTrees::BuildCandidatePairs() {
+   //
+   // Build candidate pairs and add them to the filtered event
+   //
+   RunCandidateLegsSelection();
+   
+   if(fRunCandidatePrefilter) {
+      RunCandidateLegsPrefilter(1);
+      RunCandidateLegsPrefilter(2);
+   }
+   
+   if(fLeg1Tracks.GetEntries() + fLeg2Tracks.GetEntries() > 1) 
+      RunSameEventPairing();
+}
+
+//___________________________________________________________________________
+void AliReducedAnalysisFilterTrees::RunCandidateLegsSelection() {
+   //
+   // select leg candidates and prefilter tracks
+   // NOTE: In the case of symmetric decay channels, the candidates are separated by charge in fLeg1Tracks and fLeg2Tracks
+   //            For asymmetric decays, the candidates for each of the LEG1 and LEG2 are not a priori separated by charge.
+   //                 It is the responsability of the analyzer to setup the track cuts such that these are separated
+   Bool_t isAsymmetricDecayChannel = IsAsymmetricDecayChannel();
+   
+   // clear the track arrays
+   fLeg1Tracks.Clear("C"); fLeg2Tracks.Clear("C"); 
+   fLeg1PrefilteredTracks.Clear("C"); fLeg2PrefilteredTracks.Clear("C");
+   
+   // loop over the track list and evaluate all the track cuts
+   AliReducedBaseTrack* track = 0x0;
+   TClonesArray* trackList = fEvent->GetTracks();
+   TIter nextTrack(trackList);
+   for(Int_t it=0; it<fEvent->NTracks(); ++it) {
+      track = (AliReducedBaseTrack*)nextTrack();
+      
+      AliReducedVarManager::FillTrackInfo(track, fValues);
+      if(isAsymmetricDecayChannel) {
+         if(IsCandidateLegSelected(track, fValues, 1)) {
+            fLeg1Tracks.Add(track);
+            FillCandidateLegHistograms("Track_LEG1_BeforePrefilter", track, fValues, 1, isAsymmetricDecayChannel);
+         }
+         if(IsCandidateLegSelected(track, fValues, 2)) {
+            fLeg2Tracks.Add(track);
+            FillCandidateLegHistograms("Track_LEG2_BeforePrefilter", track, fValues, 2, isAsymmetricDecayChannel);
+         }
+      }
+      else {
+         if(IsCandidateLegSelected(track, fValues,1)) {
+            if(track->Charge()>0) {
+               fLeg1Tracks.Add(track);
+               FillCandidateLegHistograms("Track_LEG1_BeforePrefilter", track, fValues, 1, isAsymmetricDecayChannel);
+            }
+            if(track->Charge()<0) {
+               fLeg2Tracks.Add(track);
+               FillCandidateLegHistograms("Track_LEG2_BeforePrefilter", track, fValues, 1, isAsymmetricDecayChannel);
+            }
+         } 
+      }
+      
+      if(!fRunCandidatePrefilter) continue;
+      
+      if(isAsymmetricDecayChannel) {
+         if(IsCandidateLegPrefilterSelected(track, fValues, 1)) {
+            fLeg1PrefilteredTracks.Add(track);
+            fHistosManager->FillHistClass("Track_LEG1_PrefilterTrack", fValues);
+         }
+         if(IsCandidateLegPrefilterSelected(track, fValues, 2)) {
+            fLeg2PrefilteredTracks.Add(track);
+            fHistosManager->FillHistClass("Track_LEG2_PrefilterTrack", fValues);
+         }
+      }
+      else {
+         if(IsCandidateLegPrefilterSelected(track, fValues)) {
+            if(track->Charge()>0) {
+               fLeg1PrefilteredTracks.Add(track);
+               fHistosManager->FillHistClass("Track_LEG1_PrefilterTrack", fValues);
+            }
+            if(track->Charge()<0) {
+               fLeg2PrefilteredTracks.Add(track);
+               fHistosManager->FillHistClass("Track_LEG2_PrefilterTrack", fValues);
+            }
+         }
+      }
+   }   // end loop over tracks
+}
+
+//___________________________________________________________________________
+void AliReducedAnalysisFilterTrees::RunCandidateLegsPrefilter(Int_t leg) {
+   //
+   // Run the prefilter selection
+   // At this point it is assumed that the track lists are filled
+   //
+   Bool_t isAsymmetricDecayChannel = IsAsymmetricDecayChannel();
+   
+   // initialize iterators
+   TIter iterLeg((leg==1 ? &fLeg1Tracks : &fLeg2Tracks));
+   TIter iterPrefLeg1(&fLeg1PrefilteredTracks);
+   TIter iterPrefLeg2(&fLeg2PrefilteredTracks);
+   
+   // Pair the LEG candidates with the prefilter selected tracks
+   AliReducedBaseTrack* track=0;
+   AliReducedBaseTrack* prefTrack=0;
+   for(Int_t it = 0; it<(leg==1 ? fLeg1Tracks.GetEntries() : fLeg2Tracks.GetEntries()); ++it) {
+      track = (AliReducedBaseTrack*)iterLeg();
+      
+      if((leg==1 && (isAsymmetricDecayChannel || (!isAsymmetricDecayChannel && fRunCandidatePrefilterOnSameCharge))) ||
+         (leg==2 && !isAsymmetricDecayChannel)) 
+      {
+         iterPrefLeg1.Reset();
+         for(Int_t it2 = 0; it2<fLeg1PrefilteredTracks.GetEntries(); ++it2) {
+            prefTrack = (AliReducedBaseTrack*)iterPrefLeg1();
+            
+            if(track->TrackId()==prefTrack->TrackId()) continue;       // avoid self-pairing
+            AliReducedVarManager::FillPairInfo(track, prefTrack, fCandidateType, fValues);
+            if(!IsCandidateLegPairPrefilterSelected(fValues, 1)) {
+               track->ResetFlags();
+               break;
+            }
+         }  // end loop over tracks
+      }  // end if
+      
+      if((leg==1 && !isAsymmetricDecayChannel) ||
+         (leg==2 && (isAsymmetricDecayChannel || (!isAsymmetricDecayChannel && fRunCandidatePrefilterOnSameCharge))))
+      {
+         iterPrefLeg2.Reset();
+         for(Int_t it2 = 0; it2<fLeg2PrefilteredTracks.GetEntries(); ++it2) {
+            prefTrack = (AliReducedBaseTrack*)iterPrefLeg2();
+            
+            if(track->TrackId()==prefTrack->TrackId()) continue;       // avoid self-pairing
+            AliReducedVarManager::FillPairInfo(track, prefTrack, fCandidateType, fValues);
+            if(!IsCandidateLegPairPrefilterSelected(fValues, 2)) {
+               track->ResetFlags();
+               break;
+            }
+         }  // end loop over tracks
+      }  // end if
+   }  // end loop over tracks
+   
+   // remove tracks
+   iterLeg.Reset();
+   for(Int_t it = (leg==1 ? fLeg1Tracks.GetEntries() : fLeg2Tracks.GetEntries()) - 1; it >= 0; --it) {
+      track = (AliReducedBaseTrack*)iterLeg();
+      if(!track->GetFlags()) {
+         if(leg==1) fLeg1Tracks.Remove(track);
+         if(leg==2) fLeg2Tracks.Remove(track);
+      }
+   }
+   
+   // fill histograms after the prefilter
+   iterLeg.Reset();
+   for(Int_t it = 0; it<(leg==1 ? fLeg1Tracks.GetEntries() : fLeg2Tracks.GetEntries()); ++it) {
+      track = (AliReducedBaseTrack*)iterLeg();
+      FillCandidateLegHistograms(Form("Track_LEG%d_AfterPrefilter", leg), track, fValues, (leg==2 && isAsymmetricDecayChannel ? 2 : 1), isAsymmetricDecayChannel);
+   }
+}
+
+//___________________________________________________________________________
+void AliReducedAnalysisFilterTrees::RunSameEventPairing() {
+   //
+   // Run the same event pairing
+   //   
+   Bool_t isAsymmetricDecayChannel = IsAsymmetricDecayChannel();
+   
+   TIter iterLeg1(&fLeg1Tracks);
+   TIter iterLeg2(&fLeg2Tracks);
+   
+   AliReducedBaseTrack* leg1Track=0;
+   AliReducedBaseTrack* leg2Track=0;
+   AliReducedBaseTrack* leg1Track_2=0;
+   for(Int_t it1=0; it1<fLeg1Tracks.GetEntries(); ++it1) {
+      leg1Track = (AliReducedBaseTrack*)iterLeg1();
+      
+      iterLeg2.Reset();
+      for(Int_t it2=0; it2<fLeg2Tracks.GetEntries(); ++it2) {
+         leg2Track = (AliReducedBaseTrack*)iterLeg2();
+         
+         // verify that the two current tracks have at least 1 common bit
+         ULong_t compatibilityMask = CheckTrackCompatibility(leg1Track, leg2Track, isAsymmetricDecayChannel);
+         if(!compatibilityMask) continue;
+         AliReducedVarManager::FillPairInfo(leg1Track, leg2Track, fCandidateType, fValues);
+
+         if(!IsCandidatePairSelected(fValues)) continue;
+
+         TClonesArray& pairs = *(fFilteredEvent->fCandidates);
+         AliReducedPairInfo* candidatePair = new (pairs[fFilteredEvent->fNV0candidates[1]]) AliReducedPairInfo();
+         candidatePair->SetLegIds(leg1Track->TrackId(), leg2Track->TrackId());
+         candidatePair->SetFlags(compatibilityMask);
+         SetupPair(candidatePair, fValues);
+         fFilteredEvent->fNV0candidates[1] += 1;
+         FillCandidatePairHistograms("Pair_Candidate12", candidatePair, fValues, isAsymmetricDecayChannel);
+      }  // end loop over LEG2 tracks
+      
+      if(fBuildCandidateLikePairs) {
+         for(Int_t it1_2=it1+1; it1_2<fLeg1Tracks.GetEntries(); ++it1_2) {
+            leg1Track_2 = (AliReducedBaseTrack*)fLeg1Tracks.At(it1_2);
+
+            // verify that the two current tracks have at least 1 common bit
+            ULong_t compatibilityMask = CheckTrackCompatibility(leg1Track, leg1Track_2, isAsymmetricDecayChannel);
+            if(!compatibilityMask) continue;
+            AliReducedVarManager::FillPairInfo(leg1Track, leg1Track_2, fCandidateType, fValues);
+            
+            if(!IsCandidatePairSelected(fValues)) continue;
+            TClonesArray& pairs = *(fFilteredEvent->fCandidates);
+            AliReducedPairInfo* candidatePair=new(pairs[fFilteredEvent->fNV0candidates[1]]) AliReducedPairInfo();
+            candidatePair->SetLegIds(leg1Track->TrackId(), leg1Track_2->TrackId());
+            candidatePair->SetFlags(compatibilityMask);
+            SetupPair(candidatePair, fValues);
+            fFilteredEvent->fNV0candidates[1] += 1;            
+            FillCandidatePairHistograms("Pair_Candidate11", candidatePair, fValues, isAsymmetricDecayChannel);
+         }  // end loop over LEG1 tracks
+      }  // end if(fBuildCandidateLikePairs)
+   }  // end loop over LEG1 tracks
+   
+   if(fBuildCandidateLikePairs) {
+      AliReducedBaseTrack* leg2Track_2 = 0;
+      iterLeg2.Reset();
+      for(Int_t it2=0; it2<fLeg2Tracks.GetEntries(); ++it2) {
+         leg2Track = (AliReducedBaseTrack*)iterLeg2();
+         
+         for(Int_t it2_2=it2+1; it2_2<fLeg2Tracks.GetEntries(); ++it2_2) {
+            leg2Track_2 = (AliReducedBaseTrack*)fLeg2Tracks.At(it2_2);
+            
+            // verify that the two current tracks have at least 1 common bit
+            ULong_t compatibilityMask = CheckTrackCompatibility(leg2Track, leg2Track_2, isAsymmetricDecayChannel);
+            if(!compatibilityMask) continue;
+            AliReducedVarManager::FillPairInfo(leg2Track, leg2Track_2, fCandidateType, fValues);
+            
+            if(!IsCandidatePairSelected(fValues)) continue;
+            TClonesArray& pairs = *(fFilteredEvent->fCandidates);
+            AliReducedPairInfo* candidatePair=new(pairs[fFilteredEvent->fNV0candidates[1]]) AliReducedPairInfo();
+            candidatePair->SetLegIds(leg2Track->TrackId(), leg2Track_2->TrackId());
+            candidatePair->SetFlags(compatibilityMask);
+            SetupPair(candidatePair, fValues);
+            fFilteredEvent->fNV0candidates[1] += 1;           
+            FillCandidatePairHistograms("Pair_Candidate22", candidatePair, fValues, isAsymmetricDecayChannel);
+         }  // end loop over negative tracks
+      }  // end loop over negative tracks
+   }
+}
+
+//___________________________________________________________________________
+Bool_t AliReducedAnalysisFilterTrees::IsEventSelected(AliReducedBaseEvent* event, Float_t* values/*=0x0*/) {
+   //
+   // apply event cuts
+   //
+   if(fEventCuts.GetEntries()==0) return kTRUE;
+   // loop over all the cuts and make a logical and between all cuts in the list
+   for(Int_t i=0; i<fEventCuts.GetEntries(); ++i) {
+      AliReducedInfoCut* cut = (AliReducedInfoCut*)fEventCuts.At(i);
+      if(values) { if(!cut->IsSelected(event, values)) return kFALSE; }
+      else { if(!cut->IsSelected(event)) return kFALSE; }
+   }
+   return kTRUE;
+}
+
+//___________________________________________________________________________
+Bool_t AliReducedAnalysisFilterTrees::IsTrackSelected(AliReducedBaseTrack* track, Float_t* values/*=0x0*/) {
+   //
+   // apply track cuts
+   //
+   if(fTrackCuts.GetEntries()==0) return kTRUE;
+   track->ResetFlags();
+   
+   // loop over all the cuts and toggle a filter bit if the track passes the corresponding cut
+   for(Int_t i=0; i<fTrackCuts.GetEntries(); ++i) {
+      AliReducedInfoCut* cut = (AliReducedInfoCut*)fTrackCuts.At(i);
+      if(values) { if(cut->IsSelected(track, values)) track->SetFlag(i); }
+      else { if(cut->IsSelected(track)) track->SetFlag(i); }
+   }
+   return (track->GetFlags()>0 ? kTRUE : kFALSE);
+}
+
+//___________________________________________________________________________
+Bool_t AliReducedAnalysisFilterTrees::TrackIsCandidateLeg(AliReducedBaseTrack* track) {
+   //
+   // if the track is a leg belonging to at least one of the candidate pairs written, then return kTRUE
+   //
+   AliReducedPairInfo* pair = 0x0;
+   TClonesArray* pairList = fEvent->GetPairs();
+   TIter nextPair(pairList);
+   for(Int_t ip=0; ip<fFilteredEvent->NPairs(); ++ip) {
+      pair = (AliReducedPairInfo*)nextPair();
+      if(track->TrackId()==pair->LegId(0)) return kTRUE;
+      if(track->TrackId()==pair->LegId(1)) return kTRUE;
+   }
+   return kFALSE;
+}
+
+//___________________________________________________________________________
+Bool_t AliReducedAnalysisFilterTrees::IsPairSelected(AliReducedPairInfo* pair, Float_t* values /*=0x0*/) {
+   //
+   // apply pair cuts
+   // NOTE: Multiple cut sets are supported. The decisions are encoded in the fFlags inherited from AliReducedBaseTrack
+   if(fPairCuts.GetEntries()==0) return kTRUE;
+   pair->ResetFlags();
+   
+   // loop over all the cuts and toggle a filter bit if the pair passes the corresponding cut
+   for(Int_t i=0; i<fPairCuts.GetEntries(); ++i) {
+      AliReducedInfoCut* cut = (AliReducedInfoCut*)fPairCuts.At(i);
+      if(values) { if(cut->IsSelected(pair, values)) pair->SetFlag(i); }
+      else { if(cut->IsSelected(pair)) pair->SetFlag(i); }
+   }
+   return (pair->GetFlags()>0 ? kTRUE : kFALSE);
+}
+
+//___________________________________________________________________________
+Bool_t AliReducedAnalysisFilterTrees::IsCandidateLegSelected(AliReducedBaseTrack* track, Float_t* values /*=0x0*/, Int_t whichLeg /*=1*/) {
+   //
+   // apply cuts to the candidate leg
+   //
+   Bool_t isAsymmetricDecayChannel = IsAsymmetricDecayChannel();
+   
+   if(fLeg1Cuts.GetEntries()==0) return kTRUE;
+   
+   // reset the flags for the track only if these are the cuts on LEG1
+   // For LEG2, we use the same bit map as for LEG1, which it is assumed was already evaluated so the ResetFlags() should not be called
+   // IMPORTANT: In the case of asymmetric decay channels, the LEG1 cuts have to be always evaluated before LEG2 cuts
+   if(whichLeg==1) track->ResetFlags();
+   
+   for(Int_t i=0; i<fLeg1Cuts.GetEntries(); ++i) {
+      AliReducedInfoCut* cut = (AliReducedInfoCut*)(whichLeg==2 && isAsymmetricDecayChannel ? fLeg2Cuts.At(i) : fLeg1Cuts.At(i));
+      if(values) { 
+         if(cut->IsSelected(track, values)) 
+            track->SetFlag(whichLeg==2 && isAsymmetricDecayChannel ? 32+i : i); 
+      }
+      else { 
+         if(cut->IsSelected(track)) 
+            track->SetFlag(whichLeg==2 && isAsymmetricDecayChannel ? 32+i : i); 
+      }
+   }
+   return (track->GetFlags()>0 ? kTRUE : kFALSE);
+}
+
+//___________________________________________________________________________
+Bool_t AliReducedAnalysisFilterTrees::IsCandidateLegPrefilterSelected(AliReducedBaseTrack* track, Float_t* values /*=0x0*/, Int_t whichLeg /*=1*/) {
+   //
+   // apply prefilter cuts on the candidate legs
+   //   
+   if(fLeg1PrefilterCuts.GetEntries()==0) return kTRUE;
+   Bool_t isAsymmetricDecayChannel = IsAsymmetricDecayChannel();
+   
+   for(Int_t i=0; i<fLeg1PrefilterCuts.GetEntries(); ++i) {
+      // if there are more cuts specified, we apply an AND on all of them
+      // NOTE: The analysis task could also be configured such that there is a prefilter track cut corresponding to each track cut
+      //              in which case one needs to make sure the number of prefilter cuts is the same as the number of track cuts
+      AliReducedInfoCut* cut = (AliReducedInfoCut*)(whichLeg==2 && isAsymmetricDecayChannel ? fLeg2PrefilterCuts.At(i) : fLeg1PrefilterCuts.At(i));
+      if(values) { if(!cut->IsSelected(track, values)) return kFALSE; }
+      else { if(!cut->IsSelected(track)) return kFALSE; }
+   }
+   return kTRUE;
+}
+
+//___________________________________________________________________________
+Bool_t AliReducedAnalysisFilterTrees::IsCandidatePairSelected(Float_t* values) {
+   //
+   // apply pair cuts to the built candidates
+   //
+   if(fCandidatePairCuts.GetEntries()==0) return kTRUE;
+   // loop over all the cuts and make a logical and between all cuts in the list
+   for(Int_t i=0; i<fCandidatePairCuts.GetEntries(); ++i) {
+      AliReducedInfoCut* cut = (AliReducedInfoCut*)fCandidatePairCuts.At(i);
+      if(!cut->IsSelected(values)) return kFALSE;
+   }
+   return kTRUE;
+}
+
+//___________________________________________________________________________
+Bool_t AliReducedAnalysisFilterTrees::IsCandidateLegPairPrefilterSelected(Float_t* values, Int_t whichLeg /*=1*/) {
+   //
+   // apply the prefilter pair cuts
+   //   
+   if(fLeg1PairPrefilterCuts.GetEntries()==0) return kTRUE;
+   Bool_t isAsymmetricDecayChannel = IsAsymmetricDecayChannel();
+   
+   // loop over all the cuts and make a logical OR between all cuts in the list
+   for(Int_t i=0; i<fLeg1PairPrefilterCuts.GetEntries(); ++i) {
+      AliReducedInfoCut* cut = (AliReducedInfoCut*)(whichLeg==2 && isAsymmetricDecayChannel ? fLeg2PairPrefilterCuts.At(i) : fLeg1PairPrefilterCuts.At(i));
+      if(cut->IsSelected(values)) return kTRUE;
+   }
+   return kFALSE;
+}
+
+//___________________________________________________________________________
+ULong_t AliReducedAnalysisFilterTrees::CheckTrackCompatibility(AliReducedBaseTrack* leg1, AliReducedBaseTrack* leg2, Bool_t isAsymmetricDecayChannel) {
+   //
+   // check whether the 2 tracks fulfill at least one set of common cuts
+   // NOTE: In the case of asymmetric decay channels, a track can fulfill simultaneously both the cuts of LEG1 and LEG2
+   //              and since we work with just one instance of the track object in memory, the cut flags map is shared
+   //              between the two LEG cut sets: [0-31) cuts for LEG1, [32-63) cuts for LEG2.
+   //              We should pair just tracks fulfilling cuts from the same "doublet": e.g. 0 - 32, 1-33, 2-34, ...
+   //             In the case of symmetric decays, there is only one list of cuts for which the tracks are evaluated
+   //               so here there is no problem. The flags of the tracks forming a pair are evaluated by a simple bitwise AND
+   if(!isAsymmetricDecayChannel) return (leg1->GetFlags() & leg2->GetFlags());
+   
+   ULong_t mask = 0;
+   for(Int_t i=0;i<32;++i)
+      if(leg1->TestFlag(i) && leg2->TestFlag(32+i)) 
+         mask |= (ULong_t(1)<<i);
+   return mask;
+}
+
+//___________________________________________________________________________
+void AliReducedAnalysisFilterTrees::SetupPair(AliReducedPairInfo* pair, Float_t* values) {
+   //
+   // setup pair information
+   //   
+   pair->Pt(values[AliReducedVarManager::kPt]);
+   pair->Phi(values[AliReducedVarManager::kPhi]);
+   pair->Eta(values[AliReducedVarManager::kEta]);
+   pair->Charge(0);
+   pair->CandidateId(fCandidateType);
+   pair->PairType(values[AliReducedVarManager::kPairType]);
+   pair->SetMass(values[AliReducedVarManager::kMass]);
+   pair->SetLxy(values[AliReducedVarManager::kPairLxy]);
+   pair->SetPointingAngle(values[AliReducedVarManager::kPairPointingAngle]);
+   pair->SetChisquare(values[AliReducedVarManager::kPairChisquare]);
+}
+
+//___________________________________________________________________________
+Bool_t AliReducedAnalysisFilterTrees::IsAsymmetricDecayChannel() {
+   //
+   // Check if the studied decay channel is assymetric
+   // NOTE: If the decay channel studied is asymmetric, it is assumed that the cuts on the two legs are different
+   //            and that the 2 lists of leg cuts hold the same number of cuts
+   if(fCandidateType==AliReducedPairInfo::kLambda0ToPPi) return kTRUE;
+   if(fCandidateType==AliReducedPairInfo::kALambda0ToPPi) return kTRUE;
+   if(fCandidateType==AliReducedPairInfo::kDplusToK0sPiplus) return kTRUE;
+   if(fCandidateType==AliReducedPairInfo::kDplusToK0sKplus) return kTRUE;
+   if(fCandidateType==AliReducedPairInfo::kDplusToPhiPiplus) return kTRUE;
+   if(fCandidateType==AliReducedPairInfo::kDminusToK0sPiminus) return kTRUE;
+   if(fCandidateType==AliReducedPairInfo::kDminusToK0sKminus) return kTRUE;
+   if(fCandidateType==AliReducedPairInfo::kDminusToPhiPiminus) return kTRUE;
+   if(fCandidateType==AliReducedPairInfo::kDzeroToKminusPiplus) return kTRUE;
+   if(fCandidateType==AliReducedPairInfo::kADzeroToKplusPiminus) return kTRUE;
+   if(fCandidateType==AliReducedPairInfo::kDsplusToK0sKplus) return kTRUE;
+   if(fCandidateType==AliReducedPairInfo::kDsminusToK0sKminus) return kTRUE;
+   return kFALSE;
+}
+
+//___________________________________________________________________________
+void AliReducedAnalysisFilterTrees::FillCandidateLegHistograms(TString histClass, AliReducedBaseTrack* track, Float_t* values, Int_t leg, Bool_t isAsymmetricDecayChannel) {
+   //
+   // fill track histogram lists according to the track flags 
+   //
+   for(Int_t icut=0; icut<fLeg1Cuts.GetEntries(); ++icut) {
+      if(track->TestFlag(leg==2 && isAsymmetricDecayChannel ? icut+32 : icut)) {
+         fHistosManager->FillHistClass(Form("%s_%s", histClass.Data(), (leg==2 && isAsymmetricDecayChannel ? fLeg2Cuts.At(icut)->GetName() : fLeg1Cuts.At(icut)->GetName())), fValues);
+      }
+   }
+}
+
+//___________________________________________________________________________
+void AliReducedAnalysisFilterTrees::FillCandidatePairHistograms(TString histClass, AliReducedPairInfo* pair, Float_t* values, Bool_t isAsymmetricDecayChannel) {
+   //
+   // fill track histogram lists according to the track flags 
+   //
+   for(Int_t icut=0; icut<fLeg1Cuts.GetEntries(); ++icut) {
+      if(pair->TestFlag(icut)) {
+         fHistosManager->FillHistClass(Form("%s_%s%s", histClass.Data(), fLeg1Cuts.At(icut)->GetName(), (isAsymmetricDecayChannel ? Form("_%s", fLeg2Cuts.At(icut)->GetName()) : "")), fValues);
+      }
+   }
+}
+
+//___________________________________________________________________________
+const Char_t* AliReducedAnalysisFilterTrees::GetCandidateLegCutName(Int_t i, Int_t leg) {
+   //
+   // get candidate leg cut name
+   //
+   if(leg==2 && IsAsymmetricDecayChannel())
+      return (i<fLeg2Cuts.GetEntries() ? fLeg2Cuts.At(i)->GetName() : "");
+   return (i<fLeg1Cuts.GetEntries() ? fLeg1Cuts.At(i)->GetName() : "");
+}
+
+//___________________________________________________________________________
+void AliReducedAnalysisFilterTrees::Finish() {
+  //
+  // run stuff after the event loop
+  //
+}

--- a/PWGDQ/reducedTree/AliReducedAnalysisFilterTrees.h
+++ b/PWGDQ/reducedTree/AliReducedAnalysisFilterTrees.h
@@ -1,0 +1,115 @@
+//
+// Creation date: 2017/08/09
+// Author: Ionut-Cristian Arsene, iarsene@cern.ch, i.c.arsene@fys.uio.no
+
+#ifndef ALIREDUCEDANALYSISFILTERTREES_H
+#define ALIREDUCEDANALYSISFILTERTREES_H
+
+#include <TList.h>
+
+#include "AliReducedAnalysisTaskSE.h"
+#include "AliReducedInfoCut.h"
+#include "AliReducedBaseEvent.h"
+#include "AliReducedBaseTrack.h"
+#include "AliReducedTrackInfo.h"
+#include "AliReducedPairInfo.h"
+#include "AliHistogramManager.h"
+
+//________________________________________________________________
+class AliReducedAnalysisFilterTrees : public AliReducedAnalysisTaskSE {
+  
+public:
+  AliReducedAnalysisFilterTrees();
+  AliReducedAnalysisFilterTrees(const Char_t* name, const Char_t* title);
+  virtual ~AliReducedAnalysisFilterTrees();
+  
+  virtual void Init();
+  virtual void Process();
+  virtual void Finish();
+  
+  // setters
+  void AddEventCut(AliReducedInfoCut* cut) {fEventCuts.Add(cut);}
+  void AddTrackCut(AliReducedInfoCut* cut) {fTrackCuts.Add(cut);}
+  void AddPairCut(AliReducedInfoCut* cut) {fPairCuts.Add(cut);}
+  void SetWriteFilteredTracks(Bool_t option=kTRUE) {fWriteFilteredTracks=option;}
+  void SetWriteFilteredPairs(Bool_t option=kTRUE) {fWriteFilteredPairs=option;}
+  
+  void SetBuildCandidatePairs(AliReducedPairInfo::CandidateType type) {fBuildCandidatePairs=kTRUE; fCandidateType=type;}
+  void SetBuildCandidateLikePairs(Bool_t option=kTRUE) {fBuildCandidateLikePairs=option;}
+  void AddCandidateLeg1Cut(AliReducedInfoCut* cut) {fLeg1Cuts.Add(cut);}
+  void AddCandidateLeg2Cut(AliReducedInfoCut* cut) {fLeg2Cuts.Add(cut);}
+  void AddCandidatePairCut(AliReducedInfoCut* cut) {fCandidatePairCuts.Add(cut);}
+  void SetRunCandidatePrefilter(Bool_t option=kTRUE) {fRunCandidatePrefilter=option;}
+  void SetRunCandidatePrefilterOnSameCharge(Bool_t option=kTRUE) {fRunCandidatePrefilterOnSameCharge=option;}
+  void AddCandidateLeg1PrefilterCut(AliReducedInfoCut* cut) {fLeg1PrefilterCuts.Add(cut);}
+  void AddCandidateLeg2PrefilterCut(AliReducedInfoCut* cut) {fLeg2PrefilterCuts.Add(cut);}
+  void AddCandidateLeg1PairPrefilterCut(AliReducedInfoCut* cut) {fLeg1PairPrefilterCuts.Add(cut);}
+  void AddCandidateLeg2PairPrefilterCut(AliReducedInfoCut* cut) {fLeg2PairPrefilterCuts.Add(cut);}
+  
+  // getters
+  virtual AliHistogramManager* GetHistogramManager() const {return fHistosManager;}
+  Bool_t GetWriteFilteredTracks() const {return fWriteFilteredTracks;}
+  Int_t GetNTrackCuts() const {return fTrackCuts.GetEntries();}
+  const Char_t* GetTrackCutName(Int_t i) const {return (i<fTrackCuts.GetEntries() ? fTrackCuts.At(i)->GetName() : "");} 
+  Bool_t GetWriteFilteredPairs() const {return fWriteFilteredPairs;}
+  Int_t GetNPairCuts() const {return fPairCuts.GetEntries();}
+  const Char_t* GetPairCutName(Int_t i) const {return (i<fPairCuts.GetEntries() ? fPairCuts.At(i)->GetName() : "");} 
+  Bool_t GetBuildCandidatePairs() const {return fBuildCandidatePairs;}
+  Bool_t GetBuildCandidateLikePairs() const {return fBuildCandidateLikePairs;}
+  Int_t GetCandidateType() const {return fCandidateType;}
+  Bool_t GetRunCandidatePrefilter() const {return fRunCandidatePrefilter;}
+  Int_t GetNCandidateLegCuts() const {return fLeg1Cuts.GetEntries();}
+  const Char_t* GetCandidateLegCutName(Int_t i, Int_t leg);
+  Bool_t IsAsymmetricDecayChannel();
+  
+protected:
+   AliHistogramManager* fHistosManager;   // Histogram manager
+   
+   TList fEventCuts;               // array of event cuts used for filtering
+   TList fTrackCuts;               // array of track cuts used for filtering
+   Bool_t fWriteFilteredTracks;   // filter the track list
+   TList fPairCuts;                  // array of pair cuts used for filtering
+   Bool_t fWriteFilteredPairs;   // filter the pair list
+   
+   Bool_t fBuildCandidatePairs;   // if true, build additional candidate pairs from selected tracks 
+   Bool_t fBuildCandidateLikePairs;  // if true, build also like pairs (e.g. like-sign for symmetric decay channels)
+   Int_t fCandidateType;             // candidate type, see AliReducedPairInfo::CandidateType 
+   TList fLeg1Cuts;                      // list of track cuts for LEG1  (these cuts will be used also for LEG2 if the decay channel is symmetric)
+   TList fLeg2Cuts;                      // list of tracks cuts for LEG2 (NOTE: fLeg1Cuts and fLeg2Cuts must contain the same number of cuts)
+   TList fCandidatePairCuts;          // list of cuts for pair candidates
+   Bool_t fRunCandidatePrefilter;   // if true, run a prefilter on the selected legs
+   Bool_t fRunCandidatePrefilterOnSameCharge;   // default FALSE (unlike charged pairs only);
+                                                                // if true, run the prefilter on same charge pairs also;
+   TList fLeg1PrefilterCuts;            // cuts for tracks used in the prefilter for LEG1  
+   TList fLeg2PrefilterCuts;            // cuts for tracks used in the prefilter for LEG2
+   TList fLeg1PairPrefilterCuts;      // cuts on the prefilter pairs for LEG1
+   TList fLeg2PairPrefilterCuts;      // cuts on the prefilter pairs for LEG2
+   TList fLeg1Tracks;                    // list of selected LEG1 tracks in the current event
+   TList fLeg2Tracks;                    // list of selected LEG2 tracks in the current event
+   TList fLeg1PrefilteredTracks;    // list of prefilter selected LEG1 tracks in the current event
+   TList fLeg2PrefilteredTracks;    // list of prefilter selected LEG2 tracks in the current event
+   
+   Bool_t IsEventSelected(AliReducedBaseEvent* event, Float_t* values=0x0);
+   Bool_t IsTrackSelected(AliReducedBaseTrack* track, Float_t* values=0x0);
+   Bool_t IsPairSelected(AliReducedPairInfo* pair, Float_t* values=0x0);
+   void CreateFilteredEvent();
+   Bool_t TrackIsCandidateLeg(AliReducedBaseTrack* track);
+   void WriteFilteredPairs();
+   void WriteFilteredTracks();
+   Bool_t IsCandidateLegSelected(AliReducedBaseTrack* track, Float_t* values=0x0, Int_t whichLeg=1); 
+   Bool_t IsCandidatePairSelected(Float_t* values);
+   Bool_t IsCandidateLegPrefilterSelected(AliReducedBaseTrack* track, Float_t* values=0x0, Int_t whichLeg=1);
+   Bool_t IsCandidateLegPairPrefilterSelected(Float_t* values, Int_t whichLeg=1);
+   void BuildCandidatePairs();
+   void RunCandidateLegsSelection();
+   void RunCandidateLegsPrefilter(Int_t leg);
+   void RunSameEventPairing();
+   void SetupPair(AliReducedPairInfo* pair, Float_t* values);
+   ULong_t CheckTrackCompatibility(AliReducedBaseTrack* leg1, AliReducedBaseTrack* leg2, Bool_t isAsymmetricDecayChannel);
+   void FillCandidateLegHistograms(TString histClass, AliReducedBaseTrack* track, Float_t* values, Int_t leg, Bool_t isAsymmetricDecayChannel);
+   void FillCandidatePairHistograms(TString histClass, AliReducedPairInfo* pair, Float_t* values, Bool_t isAsymmetricDecayChannel);
+   
+  ClassDef(AliReducedAnalysisFilterTrees,1);
+};
+
+#endif

--- a/PWGDQ/reducedTree/AliReducedAnalysisJpsi2ee.cxx
+++ b/PWGDQ/reducedTree/AliReducedAnalysisJpsi2ee.cxx
@@ -40,8 +40,7 @@ AliReducedAnalysisJpsi2ee::AliReducedAnalysisJpsi2ee() :
   fPosTracks(),
   fNegTracks(),
   fPrefilterPosTracks(),
-  fPrefilterNegTracks(),
-  fEventCounter(0)
+  fPrefilterNegTracks()
 {
   //
   // default constructor
@@ -67,8 +66,7 @@ AliReducedAnalysisJpsi2ee::AliReducedAnalysisJpsi2ee(const Char_t* name, const C
   fPosTracks(),
   fNegTracks(),
   fPrefilterPosTracks(),
-  fPrefilterNegTracks(),
-  fEventCounter(0)
+  fPrefilterNegTracks()
 {
   //
   // named constructor
@@ -147,7 +145,7 @@ Bool_t AliReducedAnalysisJpsi2ee::IsTrackSelected(AliReducedBaseTrack* track, Fl
 //___________________________________________________________________________
 Bool_t AliReducedAnalysisJpsi2ee::IsTrackPrefilterSelected(AliReducedBaseTrack* track, Float_t* values/*=0x0*/) {
    //
-   // apply event cuts
+   // apply track prefilter cuts
    //
    if(fPreFilterTrackCuts.GetEntries()==0) return kTRUE;
    
@@ -163,7 +161,7 @@ Bool_t AliReducedAnalysisJpsi2ee::IsTrackPrefilterSelected(AliReducedBaseTrack* 
 //___________________________________________________________________________
 Bool_t AliReducedAnalysisJpsi2ee::IsPairSelected(Float_t* values) {
   //
-  // apply event cuts
+  // apply pair cuts
   //
   if(fPairCuts.GetEntries()==0) return kTRUE;
   // loop over all the cuts and make a logical and between all cuts in the list

--- a/PWGDQ/reducedTree/AliReducedAnalysisJpsi2ee.h
+++ b/PWGDQ/reducedTree/AliReducedAnalysisJpsi2ee.h
@@ -78,8 +78,6 @@ protected:
    TList fPrefilterPosTracks;  // list of prefilter selected positive tracks in the current event
    TList fPrefilterNegTracks; // list of prefilter selected negative tracks in the current event
    
-   ULong_t fEventCounter;   // event counter
-   
   Bool_t IsEventSelected(AliReducedBaseEvent* event, Float_t* values=0x0);
   Bool_t IsTrackSelected(AliReducedBaseTrack* track, Float_t* values=0x0);
   Bool_t IsTrackPrefilterSelected(AliReducedBaseTrack* track, Float_t* values=0x0);

--- a/PWGDQ/reducedTree/AliReducedAnalysisTaskSE.h
+++ b/PWGDQ/reducedTree/AliReducedAnalysisTaskSE.h
@@ -22,6 +22,13 @@
 class AliReducedAnalysisTaskSE : public TObject {
   
 public:
+   enum ETreeWritingOptions {
+      kBaseEventsWithBaseTracks=0,    // write basic event info and basic track info
+      kBaseEventsWithFullTracks,           // write basic event info and full track info
+      kFullEventsWithBaseTracks,           // write full event info and base track info
+      kFullEventsWithFullTracks              // write full event info and full track info
+   };
+   
   AliReducedAnalysisTaskSE();
   AliReducedAnalysisTaskSE(const Char_t* name, const Char_t* title);
   virtual ~AliReducedAnalysisTaskSE();
@@ -35,20 +42,24 @@ public:
   virtual void Finish();
   // add output objects;
   
+  void InitFilteredTree();
+  
   // setters
   void SetEvent(AliReducedBaseEvent* event) {fEvent = event;}
-  //void SetHistogramManager(AliHistogramManager* histos) {fHistosManager = histos;}  
+  
+  void SetFilteredTreeWritingOption(Int_t option)         {fFilteredTreeWritingOption = option;}
+  void SetFilteredTreeActiveBranch(TString b)   {fActiveBranches+=b+";";}
+  void SetFilteredTreeInactiveBranch(TString b) {fInactiveBranches+=b+";";}
   
   // getters
-  //AliHistogramManager* GetHistogramManager() const {return fHistosManager;}
-  virtual AliHistogramManager* GetHistogramManager() const = 0;  //{return 0x0;}
+  virtual AliHistogramManager* GetHistogramManager() const = 0;
   AliReducedBaseEvent* GetEvent() const {return fEvent;}
+  TTree* GetFilteredTree() {return fFilteredTree;}
+  Int_t GetFilteredTreeWritingOption() const {return fFilteredTreeWritingOption;}
   
 protected:
   AliReducedAnalysisTaskSE(const AliReducedAnalysisTaskSE& task);             
   AliReducedAnalysisTaskSE& operator=(const AliReducedAnalysisTaskSE& task);      
-  
-  //AliHistogramManager* fHistosManager;   // Histogram manager
   
   TString fName;             // name
   TString fTitle;                // title
@@ -56,7 +67,15 @@ protected:
   AliReducedBaseEvent* fEvent;           //! current event to be processed
   Float_t fValues[AliReducedVarManager::kNVars];   // array of values to hold information for histograms
   
-  ClassDef(AliReducedAnalysisTaskSE, 2)
+  TTree *fFilteredTree;                          //! tree to hold filtered reduced events
+  TString fActiveBranches;                   // list of active output tree branches 
+  TString fInactiveBranches;                // list of inactive output tree branches
+  AliReducedBaseEvent *fFilteredEvent;     // filtered reduced event
+  Int_t     fFilteredTreeWritingOption;     // one of the options described by ETreeWritingOptions
+  
+  ULong_t fEventCounter;   // event counter
+  
+  ClassDef(AliReducedAnalysisTaskSE, 3)
 };
 
 #endif

--- a/PWGDQ/reducedTree/AliReducedAnalysisTest.cxx
+++ b/PWGDQ/reducedTree/AliReducedAnalysisTest.cxx
@@ -272,6 +272,7 @@ void AliReducedAnalysisTest::Process() {
         AliReducedVarManager::FillPairQualityFlag(pair, iflag, fValues);
         fHistosManager->FillHistClass(Form("PairQualityFlags_%s",pairTypeStr.Data()), fValues);
       }
+      TString type[3]={"PP","PM","MM"};
       
       AliReducedVarManager::FillPairInfo(pair, fValues);
       switch (pair->CandidateId()) {
@@ -291,6 +292,12 @@ void AliReducedAnalysisTest::Process() {
 	  fHistosManager->FillHistClass(Form("PairQA_%sALambda", pairTypeStr.Data()),fValues);
 	  if(pair->IsPureV0ALambda()) fHistosManager->FillHistClass(Form("PairQA_%sPureALambda",pairTypeStr.Data()),fValues);
 	  break;
+        case AliReducedPairInfo::kJpsiToEE :
+           fHistosManager->FillHistClass(Form("PairQA_Jpsi2EE_%s", type[pair->PairType()].Data()),fValues);
+           break;  
+        case AliReducedPairInfo::kADzeroToKplusPiminus :
+           fHistosManager->FillHistClass(Form("PairQA_ADzeroToKplusPiminus_%s", type[pair->PairType()].Data()),fValues);
+           break;     
       };
       fValues[AliReducedVarManager::kNpairsSelected] += 1.0;
     }  // end loop over pairs

--- a/PWGDQ/reducedTree/AliReducedBaseEvent.cxx
+++ b/PWGDQ/reducedTree/AliReducedBaseEvent.cxx
@@ -84,6 +84,23 @@ AliReducedBaseEvent::~AliReducedBaseEvent()
   //
 }
 
+//____________________________________________________________________________
+void AliReducedBaseEvent::CopyEventHeader(const AliReducedBaseEvent* other) {
+   //
+   // assignment operator overloading
+   // NOTE: the fTracks and fCandidates arrays are not copied
+   //
+   ClearEvent();
+   fEventTag = other->fEventTag;
+   fRunNo = other->fRunNo;
+   for(Int_t i=0; i<3; ++i) fVtx[i] = other->fVtx[i];
+   fNVtxContributors = other->fNVtxContributors;
+   for(Int_t i=0; i<7; ++i) fCentrality[i] = other->fCentrality[i];
+   fCentQuality = other->fCentQuality;
+   fNtracks[0] = other->fNtracks[0]; 
+   fNV0candidates[0] = other->fNV0candidates[0];
+}
+
 //_____________________________________________________________________________
 void AliReducedBaseEvent::ClearEvent() {
   //
@@ -94,9 +111,9 @@ void AliReducedBaseEvent::ClearEvent() {
   fEventTag = 0;
   fRunNo = 0;
   fCentQuality = 0;
-  for(Int_t i=0;i<7;++i) fCentrality[i] = -1.0;
+  for(Int_t i=0;i<7;++i) fCentrality[i] = -9999.0;
   fNtracks[0] = 0; fNtracks[1] = 0;
   fNV0candidates[0] = 0; fNV0candidates[1] = 0;
-  for(Int_t i=0; i<3; ++i) {fVtx[i]=-999.;}
+  for(Int_t i=0; i<3; ++i) {fVtx[i]=-9999.;}
   fNVtxContributors = 0;
 }

--- a/PWGDQ/reducedTree/AliReducedBaseEvent.h
+++ b/PWGDQ/reducedTree/AliReducedBaseEvent.h
@@ -15,6 +15,7 @@ class AliReducedPairInfo;
 class AliReducedBaseEvent : public TObject {
 
   friend class AliAnalysisTaskReducedTreeMaker;     // friend analysis task which fills the object
+  friend class AliReducedAnalysisFilterTrees;
   
  public:
   enum ETrackOption {
@@ -27,6 +28,8 @@ class AliReducedBaseEvent : public TObject {
   AliReducedBaseEvent();
   AliReducedBaseEvent(const Char_t* name, Int_t trackOption=kNoInit);
   virtual ~AliReducedBaseEvent();
+  
+  virtual void CopyEventHeader(const AliReducedBaseEvent* other);
 
   // getters
   ULong64_t EventTag()                        const {return fEventTag;}
@@ -46,12 +49,15 @@ class AliReducedBaseEvent : public TObject {
   Int_t     NTracks()                         const {return fNtracks[1];}
   Int_t     NV0CandidatesTotal()              const {return fNV0candidates[0];}
   Int_t     NV0Candidates()                   const {return fNV0candidates[1];}
+  Int_t     NPairs()                   const {return fCandidates->GetEntries();}
   
   AliReducedBaseTrack* GetTrack(Int_t i) const {return (i<fNtracks[1] ? (AliReducedBaseTrack*)fTracks->At(i) : 0x0);}
   TClonesArray* GetTracks()          const {return fTracks;}
   
   AliReducedPairInfo* GetV0Pair(Int_t i)         const 
   {return (i>=0 && i<fNV0candidates[1] ? (AliReducedPairInfo*)fCandidates->At(i) : 0x0);}
+  AliReducedPairInfo* GetPair(Int_t i)         const 
+  {return (i>=0 && i<fCandidates->GetEntries() ? (AliReducedPairInfo*)fCandidates->At(i) : 0x0);}
   TClonesArray* GetPairs()                       const {return fCandidates;}
   
   Bool_t    TestEventTag(UShort_t iflag) const {return (iflag<8*sizeof(ULong64_t) ? fEventTag&(ULong64_t(1)<<iflag) : kFALSE);}
@@ -75,8 +81,8 @@ class AliReducedBaseEvent : public TObject {
   TClonesArray* fCandidates;        //->   array containing pair candidates
   static TClonesArray* fgCandidates;  // pair candidates
   
-  AliReducedBaseEvent(const AliReducedBaseEvent &c);
   AliReducedBaseEvent& operator= (const AliReducedBaseEvent &c);
+  AliReducedBaseEvent(const AliReducedBaseEvent &c);
 
   ClassDef(AliReducedBaseEvent, 2);
 };

--- a/PWGDQ/reducedTree/AliReducedBaseTrack.cxx
+++ b/PWGDQ/reducedTree/AliReducedBaseTrack.cxx
@@ -14,6 +14,7 @@ ClassImp(AliReducedBaseTrack)
 
 //_______________________________________________________________________________
 AliReducedBaseTrack::AliReducedBaseTrack() :
+  fTrackId(0),
   fIsCartesian(kFALSE),
   fCharge(0),
   fFlags(0),
@@ -28,6 +29,7 @@ AliReducedBaseTrack::AliReducedBaseTrack() :
 //_______________________________________________________________________________
 AliReducedBaseTrack::AliReducedBaseTrack(const AliReducedBaseTrack &c) :
   TObject(c),
+  fTrackId(c.fTrackId),
   fIsCartesian(c.IsCartesian()),
   fCharge(c.Charge()),
   fFlags(c.GetFlags()),

--- a/PWGDQ/reducedTree/AliReducedBaseTrack.h
+++ b/PWGDQ/reducedTree/AliReducedBaseTrack.h
@@ -15,9 +15,11 @@ class AliReducedBaseTrack : public TObject {
   
   public:
     AliReducedBaseTrack();
+    AliReducedBaseTrack(const AliReducedBaseTrack &c);
     virtual ~AliReducedBaseTrack();
   
     // getters
+    UShort_t TrackId()                     const {return fTrackId;}
     Float_t Px()  const {return (fIsCartesian ? fP[0] : TMath::Abs(fP[0])*TMath::Cos(fP[1]));}
     Float_t Py()  const {return (fIsCartesian ? fP[1] : TMath::Abs(fP[0])*TMath::Sin(fP[1]));}
     Float_t Pz()  const {return (fIsCartesian ? fP[2] : TMath::Abs(fP[0])*TMath::SinH(fP[2]));}
@@ -69,6 +71,7 @@ class AliReducedBaseTrack : public TObject {
     Bool_t UnsetQualityFlag(UShort_t iflag)  {if (iflag>=8*sizeof(ULong_t)) return kFALSE; if(TestQualityFlag(iflag)) fQualityFlags^=(ULong_t(1)<<iflag); return kTRUE;}
         
   protected:
+    UShort_t fTrackId;            // track id 
     Float_t fP[3];         // 3-momentum vector
     Bool_t  fIsCartesian;  // if false then the 3-momentum vector is in spherical coordinates (pt,phi,eta)
     Char_t  fCharge;       // electrical charge
@@ -108,10 +111,9 @@ class AliReducedBaseTrack : public TObject {
                                                    // BIT4 toggled for pure V0 photon candidates
                                                    
         
-    AliReducedBaseTrack(const AliReducedBaseTrack &c);      
     AliReducedBaseTrack& operator= (const AliReducedBaseTrack &c);
     
-    ClassDef(AliReducedBaseTrack, 2)
+    ClassDef(AliReducedBaseTrack, 3)
 };
 
 //_______________________________________________________________________________

--- a/PWGDQ/reducedTree/AliReducedEventInfo.cxx
+++ b/PWGDQ/reducedTree/AliReducedEventInfo.cxx
@@ -183,6 +183,64 @@ AliReducedEventInfo::~AliReducedEventInfo()
   //
 }
 
+
+void AliReducedEventInfo::CopyEventHeader(const AliReducedEventInfo* other) {
+   //
+   // overloading assignment operator
+   //   
+   ClearEvent();
+   AliReducedBaseEvent::CopyEventHeader(other);
+   
+   fEventNumberInFile = other->fEventNumberInFile;
+   fL0TriggerInputs = other->fL0TriggerInputs;
+   fL1TriggerInputs = other->fL1TriggerInputs;
+   fL2TriggerInputs = other->fL2TriggerInputs;
+   fBC = other->fBC;
+   fTimeStamp = other->fTimeStamp;
+   fEventType = other->fEventType;
+   fTriggerMask = other->fTriggerMask;
+   for(Int_t i=0; i<10; ++i) {
+      fMultiplicityEstimators[i] = other->fMultiplicityEstimators[i];
+      fMultiplicityEstimatorPercentiles[i] = other->fMultiplicityEstimatorPercentiles[i];
+   }
+   fIsPhysicsSelection = other->fIsPhysicsSelection;
+   fIsSPDPileup = other->fIsSPDPileup;
+   fIsSPDPileupMultBins = other->fIsSPDPileupMultBins;
+   for(Int_t i=0; i<2; ++i) fIRIntClosestIntMap[i] = other->fIRIntClosestIntMap[i];
+   for(Int_t i=0; i<6; ++i) fVtxCovMatrix[i] = other->fVtxCovMatrix[i];
+   for(Int_t i=0; i<3; ++i) fVtxTPC[i] = other->fVtxTPC[i];
+   fNVtxTPCContributors = other->fNVtxTPCContributors;
+   for(Int_t i=0; i<3; ++i) fVtxSPD[i] = other->fVtxSPD[i];
+   fNVtxSPDContributors = other->fNVtxSPDContributors;
+   fNpileupSPD = other->fNpileupSPD;
+   fNpileupTracks = other->fNpileupTracks;
+   fNTPCclusters = other->fNTPCclusters;
+   fNPMDtracks = other->fNPMDtracks;
+   fNTRDtracks = other->fNTRDtracks;
+   fNTRDtracklets = other->fNTRDtracklets;
+   fSPDntracklets = other->fSPDntracklets;
+   for(Int_t i=0; i<32; ++i) fSPDntrackletsEta[i] = other->fSPDntrackletsEta[i];
+   for(Int_t i=0; i<2; ++i) fSPDFiredChips[i] = other->fSPDFiredChips[i];
+   for(Int_t i=0; i<6; ++i) fITSClusters[i] = other->fITSClusters[i];
+   fSPDnSingle = other->fSPDnSingle;
+   for(Int_t i=0; i<32; ++i) fNtracksPerTrackingFlag[i] = other->fNtracksPerTrackingFlag[i];
+   for(Int_t i=0; i<64; ++i) fVZEROMult[i] = other->fVZEROMult[i];
+   for(Int_t i=0; i<2; ++i) fVZEROTotalMult[i] = other->fVZEROTotalMult[i];
+   for(Int_t i=0; i<10; ++i) fZDCnEnergy[i] = other->fZDCnEnergy[i];
+   for(Int_t i=0; i<10; ++i) fZDCpEnergy[i] = other->fZDCpEnergy[i];
+   for(Int_t i=0; i<2; ++i) fZDCnTotalEnergy[i] = other->fZDCnTotalEnergy[i];
+   for(Int_t i=0; i<2; ++i) fZDCpTotalEnergy[i] = other->fZDCpTotalEnergy[i];
+   for(Int_t i=0; i<26; ++i) fT0amplitude[i] = other->fT0amplitude[i];
+   for(Int_t i=0; i<3; ++i) fT0TOF[i] = other->fT0TOF[i];
+   for(Int_t i=0; i<3; ++i) fT0TOFbest[i] = other->fT0TOFbest[i];
+   fT0zVertex = other->fT0zVertex;
+   fT0start = other->fT0start;
+   fT0pileup = other->fT0pileup;
+   fT0sattelite = other->fT0sattelite;
+   fEventPlane.CopyEvent(&other->fEventPlane);
+}
+
+
 //_____________________________________________________________________________
 void AliReducedEventInfo::ClearEvent() {
   //

--- a/PWGDQ/reducedTree/AliReducedEventInfo.h
+++ b/PWGDQ/reducedTree/AliReducedEventInfo.h
@@ -16,12 +16,15 @@ class AliReducedTrackInfo;
 class AliReducedEventInfo : public AliReducedBaseEvent {
 
   friend class AliAnalysisTaskReducedTreeMaker;     // friend analysis task which fills the object
-
+  friend class AliReducedAnalysisFilterTrees;
+  
  public:
   AliReducedEventInfo();
   AliReducedEventInfo(const Char_t* name, Int_t trackOption = AliReducedBaseEvent::kNoInit);
   virtual ~AliReducedEventInfo();
 
+  virtual void CopyEventHeader(const AliReducedEventInfo* c);
+  
   // getters
   Int_t     EventNumberInFile()               const {return fEventNumberInFile;}
   UInt_t    L0TriggerInputs()                 const {return fL0TriggerInputs;}
@@ -195,8 +198,8 @@ class AliReducedEventInfo : public AliReducedBaseEvent {
   //AliReducedEventPlaneInfo* fEventPlane;     //-> container for event plane information
   AliReducedEventPlaneInfo fEventPlane;     // container for event plane information
   
-  AliReducedEventInfo(const AliReducedEventInfo &c);
   AliReducedEventInfo& operator= (const AliReducedEventInfo &c);
+  AliReducedEventInfo(const AliReducedEventInfo &c);
 
   ClassDef(AliReducedEventInfo, 6);
 };

--- a/PWGDQ/reducedTree/AliReducedPairInfo.cxx
+++ b/PWGDQ/reducedTree/AliReducedPairInfo.cxx
@@ -12,6 +12,25 @@
 
 ClassImp(AliReducedPairInfo)
 
+const Char_t* AliReducedPairInfo::fgkDecayChannelNames[AliReducedPairInfo::kNMaxCandidateTypes][4] = 
+{
+   "GammaConv",               "#gamma #rightarrow e^{+} e^{-}",                     "e^{+}", "e^{-}",
+   "K0sToPiPi",                    "K^{0}_{s} #rightarrow #pi^{+} #pi^{-}",           "#pi^{+}", "#pi^{-}",
+   "Lambda0ToPPi",            "#Lambda^{0} #rightarrow p #pi^{-}",                  "p", "#pi^{-}",
+   "ALambda0ToPPi",          "#bar{#Lambda} #rightarrow #bar{p} #pi^{+}", "#bar{p}", "#pi^{+}",
+   "PhiToKK",                       "#phi #rightarrow K^{+} K^{-}",                            "K^{+}", "K^{-}",
+   "JpsiToEE",                      "J/#psi #rightarrow e^{+} e^{-}",                           "e^{+}", "e^{-}",
+   "Upsilon",                        "#Upsilon #rightarrow e^{+} e^{-}",                      "e^{+}", "e^{-}",
+   "DplusToK0sPiplus",        "D^{+} #rightarrow K^{0}_{s} #pi^{+}",            "K^{0}_{s}", "#pi^{+}",
+   "DplusToK0sKplus",         "D^{+} #rightarrow K^{0}_{s} K^{+}",               "K^{0}_{s}", "K^{+}",
+   "DplusToPhiPiplus",         "D^{+} #rightarrow #phi #pi^{+}",                      "#phi", "#pi^{+}",
+   "DminusToK0sPiminus",  "D^{-} #rightarrow K^{0}_{s} #pi^{-}",              "K^{0}_{s}", "#pi^{-}",
+   "DminusToK0sKminus",   "D^{-} #rightarrow K^{0}_{s} K^{-}",                 "K^{0}_{s}", "K^{-}",
+   "DminusToPhiPiminus",   "D^{-} #rightarrow #phi #pi^{-}",                        "#phi", "#pi^{-}",
+   "ADzeroToKplusPiminus", "#bar{D^{0}} #rightarrow K^{+} #pi^{-}",       "K^{+}", "#pi^{-}",
+   "DsplusToK0sKplus",         "D^{+}_{s} #rightarrow K^{0}_{s} K^{+}",     "K^{0}_{s}", "K^{+}",
+   "DsminusToK0sKminus",   "D^{-}_{s} #rightarrow K^{0}_{s} K^{-}",        "K^{0}_{s}", "K^{-}", 
+};
 
 //_______________________________________________________________________________
 AliReducedPairInfo::AliReducedPairInfo() :

--- a/PWGDQ/reducedTree/AliReducedPairInfo.h
+++ b/PWGDQ/reducedTree/AliReducedPairInfo.h
@@ -35,6 +35,7 @@ class AliReducedPairInfo : public AliReducedBaseTrack {
     kDsminusToK0sKminus,     // Ds-          -> K0s K-
     kNMaxCandidateTypes
   };
+  static const Char_t* fgkDecayChannelNames[kNMaxCandidateTypes][4];
   
   AliReducedPairInfo();
   AliReducedPairInfo(const AliReducedPairInfo &c);
@@ -45,6 +46,9 @@ class AliReducedPairInfo : public AliReducedBaseTrack {
   void PairType(Char_t type) {fPairType=type;}
   void SetMass(Float_t m) {fMass[0]=m;}
   void SetLegIds(UShort_t leg1, UShort_t leg2) {fLegIds[0]=leg1;fLegIds[1]=leg2;}
+  void SetLxy(Float_t lxy) {fLxy = lxy;}
+  void SetPointingAngle(Float_t pa) {fPointingAngle = pa;}
+  void SetChisquare(Float_t chi2) {fChisquare = chi2;}
   
   // getters
   Char_t   CandidateId()         const {return fCandidateId;}

--- a/PWGDQ/reducedTree/AliReducedTrackInfo.cxx
+++ b/PWGDQ/reducedTree/AliReducedTrackInfo.cxx
@@ -18,7 +18,6 @@ ClassImp(AliReducedTrackInfo)
 //_______________________________________________________________________________
 AliReducedTrackInfo::AliReducedTrackInfo() :
   AliReducedBaseTrack(),
-  fTrackId(0),
   fStatus(0),
   fTPCPhi(0.0),
   fTPCPt(0.0),
@@ -71,6 +70,7 @@ AliReducedTrackInfo::AliReducedTrackInfo() :
   // Constructor
   //
   fDCA[0] = 0.0; fDCA[1]=0.0;
+  fTPCDCA[0] = 0.0; fTPCDCA[1]=0.0;
   for(Int_t i=0; i<4; ++i) {fTPCnSig[i]=-999.; fTOFnSig[i]=-999.; fITSnSig[i]=-999.; }
   fHelixCenter[0] = 0.0; fHelixCenter[1] = 0.0;
   fTRDntracklets[0]=0; fTRDntracklets[1]=0;
@@ -82,6 +82,57 @@ AliReducedTrackInfo::AliReducedTrackInfo() :
   for(Int_t i=0;i<21;++i) {fCovMatrix[i]=0.;}
 }
 
+//_______________________________________________________________________________
+AliReducedTrackInfo::AliReducedTrackInfo(const AliReducedTrackInfo &c) :
+  AliReducedBaseTrack(c),
+  fStatus(c.fStatus),
+  fTPCPhi(c.fTPCPhi),
+  fTPCPt(c.fTPCPt),
+  fTPCEta(c.fTPCEta),
+  fMomentumInner(c.fMomentumInner),
+  fTrackLength(c.fTrackLength),
+  fMassForTracking(c.fMassForTracking),
+  fChi2TPCConstrainedVsGlobal(c.fChi2TPCConstrainedVsGlobal),
+  fHelixRadius(c.fHelixRadius),
+  fITSclusterMap(c.fITSclusterMap),
+  fITSSharedClusterMap(c.fITSSharedClusterMap),
+  fITSsignal(c.fITSsignal),
+  fITSchi2(c.fITSchi2),
+  fTPCNcls(c.fTPCNcls),
+  fTPCCrossedRows(c.fTPCCrossedRows),
+  fTPCNclsF(c.fTPCNclsF),
+  fTPCNclsShared(c.fTPCNclsShared),
+  fTPCClusterMap(c.fTPCClusterMap),
+  fTPCsignal(c.fTPCsignal),
+  fTPCsignalN(c.fTPCsignalN),
+  fTPCchi2(c.fTPCchi2),
+  fTPCActiveLength(c.fTPCActiveLength),
+  fTPCGeomLength(c.fTPCGeomLength),
+  fTOFbeta(c.fTOFbeta),
+  fTOFtime(c.fTOFtime),
+  fTOFdx(c.fTOFdx),
+  fTOFdz(c.fTOFdz),
+  fTOFmismatchProbab(c.fTOFmismatchProbab),
+  fTOFchi2(c.fTOFchi2),
+  fTOFdeltaBC(c.fTOFdeltaBC),
+  fCaloClusterId(c.fCaloClusterId),
+  fMCGeneratorIndex(c.fMCGeneratorIndex)
+{
+   //
+   // copy constructor
+   //
+   fDCA[0] = c.fDCA[0]; fDCA[1]=c.fDCA[1];
+   fTPCDCA[0] = c.fTPCDCA[0]; fTPCDCA[1]=c.fTPCDCA[1];
+   fHelixCenter[0] = c.fHelixCenter[0]; fHelixCenter[1] = c.fHelixCenter[1];
+   fTRDntracklets[0]=c.fTRDntracklets[0]; fTRDntracklets[1]=c.fTRDntracklets[1];
+   fTRDpid[0]=c.fTRDpid[0]; fTRDpid[1]=c.fTRDpid[1];
+   fTRDpidLQ2D[0] = c.fTRDpidLQ2D[0]; fTRDpidLQ2D[1] = c.fTRDpidLQ2D[1];
+   for(Int_t i=0; i<4; ++i) {fTPCnSig[i]=c.fTPCnSig[i]; fTOFnSig[i]=c.fTOFnSig[i]; fITSnSig[i]=c.fITSnSig[i];}
+   for(Int_t i=0;i<6;++i) {fTrackParam[i]=c.fTrackParam[i];}
+   for(Int_t i=0;i<21;++i) {fCovMatrix[i]=c.fCovMatrix[i];}
+   for(Int_t i=0;i<3;++i) {fMCMom[i]=c.fMCMom[i]; fMCFreezeout[i]=c.fMCFreezeout[i];}
+   for(Int_t i=0;i<4;++i) {fMCLabels[i]=c.fMCLabels[i]; fMCPdg[i]=c.fMCPdg[i];}
+}
 
 //_______________________________________________________________________________
 AliReducedTrackInfo::~AliReducedTrackInfo()

--- a/PWGDQ/reducedTree/AliReducedTrackInfo.h
+++ b/PWGDQ/reducedTree/AliReducedTrackInfo.h
@@ -15,10 +15,10 @@ class AliReducedTrackInfo : public AliReducedBaseTrack {
   
  public:
   AliReducedTrackInfo();
+  AliReducedTrackInfo(const AliReducedTrackInfo &c);
   virtual ~AliReducedTrackInfo();
 
   // getters
-  UShort_t TrackId()                     const {return fTrackId;}
   ULong_t  Status()                      const {return fStatus;}
   Bool_t   CheckTrackStatus(UInt_t flag) const {return (flag<8*sizeof(ULong_t) ? (fStatus&(1<<flag)) : kFALSE);}
   Float_t  PxTPC()                       const {return fTPCPt*TMath::Cos(fTPCPhi);}
@@ -100,7 +100,6 @@ class AliReducedTrackInfo : public AliReducedBaseTrack {
 
      
  protected:
-  UShort_t fTrackId;            // track id 
   ULong_t fStatus;              // tracking status
   Float_t fTPCPhi;              // inner param phi
   Float_t fTPCPt;               // inner param pt  
@@ -163,14 +162,10 @@ class AliReducedTrackInfo : public AliReducedBaseTrack {
   Int_t    fMCLabels[4];           // MC label for: [0] - the current track, [1] - mother, [2] - grand mother, [3] - grand grand mother 
   Int_t    fMCPdg[4];                // MC PDG code for: [0] - the current track, [1] - mother, [2] - grand mother, [3] - grand grand mother 
   Short_t fMCGeneratorIndex;    // generator index (used for cocktail generators ?)
-  
 
-  
-          
-  AliReducedTrackInfo(const AliReducedTrackInfo &c);
   AliReducedTrackInfo& operator= (const AliReducedTrackInfo &c);
-
-  ClassDef(AliReducedTrackInfo, 4);
+  
+  ClassDef(AliReducedTrackInfo, 5);
 };
 
 //_______________________________________________________________________________

--- a/PWGDQ/reducedTree/CMakeLists.txt
+++ b/PWGDQ/reducedTree/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SRCS
       AliAnalysisTaskReducedTreeMaker.cxx
       AliHistogramManager.cxx
       AliMixingHandler.cxx
+      AliReducedAnalysisFilterTrees.cxx
       AliReducedAnalysisJpsi2ee.cxx
       AliReducedAnalysisJpsi2eeMult.cxx
       AliReducedAnalysisTaskSE.cxx

--- a/PWGDQ/reducedTree/PWGDQreducedTreeLinkDef.h
+++ b/PWGDQ/reducedTree/PWGDQreducedTreeLinkDef.h
@@ -10,6 +10,7 @@
 #pragma link C++ class AliAnalysisTaskReducedTreeMaker+;
 #pragma link C++ class AliHistogramManager+;
 #pragma link C++ class AliMixingHandler+;
+#pragma link C++ class AliReducedAnalysisFilterTrees+;
 #pragma link C++ class AliReducedAnalysisJpsi2ee+;
 #pragma link C++ class AliReducedAnalysisJpsi2eeMult+;
 #pragma link C++ class AliReducedAnalysisTaskSE+;


### PR DESCRIPTION
1) AliReducedBaseTrack
    * TrackID data member moved from the derived AliReducedTrackInfo to this class
2) AliReduceTrackInfo
    * TrackID data member removed (see item 1)
    * Implemented copy constructor
3) AliReducedPairInfo
   * Added a few setters for data members
   * Added const strings to define decay channel names
4) AliReducedBaseEvent
   * Added method to copy event header from another event
   * added a new friend class (AliReducedAnalysisFilterTrees)
5) AliReducedEventInfo
   * Added method to copy event header from another event
   * added a new friend class (AliReducedAnalysisFilterTrees)
6) AliAnalysisTaskReducedEventProcessor and AliReducedAnalysisTaskSE
   * Implemented functionality to allow writing of a filtered event
7) AliReducedAnalysisJpsi2ee
   * the event counter data member is droped as it was implemented in the base class
8) AliReducedAnalysisTest
   * Added histogram classes for J/psi and D-meson candidates
9) AliAnalysisTaskReducedTreeMaker
   * TrackId data member filled now in the base track, not derived classes
10) AlireducedAnalysisFilterTrees
  * first commit of the reduced analysis task which creates filtered trees out of existing reduced trees
11) CMake and LinkDef files updated accordingly to accomodate item 10