### PR TITLE
Fix self assignment AliAnalysisTaskPiKpK0Lamba

### DIFF
--- a/PWG/FLOW/Tasks/AliAnalysisTaskPiKpK0Lamba.h
+++ b/PWG/FLOW/Tasks/AliAnalysisTaskPiKpK0Lamba.h
@@ -61,7 +61,7 @@ class AliAnalysisTaskPiKpK0Lamba : public AliAnalysisTaskSE {
         virtual void  SetRemovePhiReg(Bool_t remPhiReg){fRemPhiReg = remPhiReg;}
         virtual void  SetCutMultESDdif(Float_t cutMultESDdif){fCutMultESDdif = cutMultESDdif;}
         virtual void  SetCrsRowsFrcShClsCuts(Bool_t crsRowsFrcShCls){fCrsRowsFrcShCls = crsRowsFrcShCls;}
-        virtual void  SetFlagPsi42A(Bool_t flagPsi42A){flagPsi42A = flagPsi42A;}
+        virtual void  SetFlagPsi42A(Bool_t flag){flagPsi42A = flag;}
         virtual void  SetNPtBins(Int_t nPtB){fNPtBins = nPtB;}
         virtual void  SetNcrFind(Float_t ncrFind){fNcrFind = ncrFind;}
         virtual void  SetDCADghtPV(Float_t dcaDghtPV){fDCADghtPV = dcaDghtPV;}


### PR DESCRIPTION
The data member flagPsi42A was never set by a call to SetFlagPsi42A

Revealed by compiler warning:
```c++
DEBUG:AliPhysics:0: In file included from /Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWG/FLOW/Tasks/AliAnalysisTaskPiKpK0Lamba.cxx:1:
DEBUG:AliPhysics:0: /Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWG/FLOW/Tasks/AliAnalysisTaskPiKpK0Lamba.h:64:67: warning: explicitly assigning value of variable of type 'Bool_t' (aka 'bool') to itself [-Wself-assign]
DEBUG:AliPhysics:0:         virtual void  SetFlagPsi42A(Bool_t flagPsi42A){flagPsi42A = flagPsi42A;}
DEBUG:AliPhysics:0:                                                        ~~~~~~~~~~ ^ ~~~~~~~~~~
```

Can be easily tested by a simple tst.C
```c++
#include <cstdio>

class A{
public:
  A():B(0){};
  void SetB(int B){B=B;}
  int GetB(){return B;}
private:
  int B;
};

int main(){
  A a;
  a.SetB(5);
  printf("B is %d\n",a.GetB());
}
```
which prints `0`
```
hbeck-macbook:~ hbeck$ clang++ -Wall tst.C && ./a.out
tst.C:6:21: warning: explicitly assigning value of variable of type 'int' to
      itself [-Wself-assign]
  void SetB(int B){B=B;}
                   ~^~
1 warning generated.
B is 0
hbeck-macbook:~ hbeck$ 
```