### PR TITLE
Fix reorder, unused var, leak, string BGMonitorQATrain

### DIFF
--- a/PWGPP/BeamGasMonitoring/AliAnalysisBGMonitorQATrain.cxx
+++ b/PWGPP/BeamGasMonitoring/AliAnalysisBGMonitorQATrain.cxx
@@ -56,13 +56,13 @@ fSpdC1(0),
 fSpdC2(0),
 fSpdT(0),
 ntracks(0),
-bgID(0),
-ntr(0),
-nbunch(0),
 nV0A(0),
 nV0C(0),
 nV0ABG(0),
 nV0CBG(0)
+bgID(0),
+ntr(0),
+nbunch(0),
 {
 }
 //________________________________________________________________________
@@ -77,13 +77,13 @@ fSpdC1(0),
 fSpdC2(0),
 fSpdT(0),
 ntracks(0),
-bgID(0),
-ntr(0),
-nbunch(0),
 nV0A(0),
 nV0C(0),
 nV0ABG(0),
 nV0CBG(0)
+bgID(0),
+ntr(0),
+nbunch(0),
 {
     // Constructor
     DefineInput(0, TChain::Class());

--- a/PWGPP/BeamGasMonitoring/AliAnalysisBGMonitorQATrain.cxx
+++ b/PWGPP/BeamGasMonitoring/AliAnalysisBGMonitorQATrain.cxx
@@ -174,8 +174,8 @@ void AliAnalysisBGMonitorQATrain::Exec(Option_t *)
     ntr = 10;
     nbunch = 21;
     AliVVZERO *vzero = fESD->GetVZEROData();
-    AliAnalysisUtils *utils = new AliAnalysisUtils();
-    bgID = utils->IsSPDClusterVsTrackletBG(fESD);
+    AliAnalysisUtils utils; // Hans: suggest to make this a data member
+    bgID = utils.IsSPDClusterVsTrackletBG(fESD);
     //--- SPD cluster and tracklets
     const AliMultiplicity* mult = fESD->GetMultiplicity();
     fSpdC1 = 0;

--- a/PWGPP/BeamGasMonitoring/AliAnalysisBGMonitorQATrain.cxx
+++ b/PWGPP/BeamGasMonitoring/AliAnalysisBGMonitorQATrain.cxx
@@ -250,7 +250,7 @@ void AliAnalysisBGMonitorQATrain::FillHist(Int_t* ftrigger, Int_t fSpdT, Int_t f
     for(Int_t itrig = 0 ; itrig<9 ; itrig++){
         if(ftrigger[itrig]){
             Bool_t SelGoodEvent = 0;
-            Printf(Form("%s triggred",fNames[itrig]));
+            Printf("%s triggred",fNames[itrig]);
             ((TH1F*)fList->FindObject(Form("hTotalTrkVsClsSPID_%s",fNames[itrig])))->Fill(fSpdT, fSpdC1+fSpdC2); // No PF Selection
                //((TH1F*)fList->At(hTotalTrkVsClsSPID[itrig][0]))->Fill(fSpdT, fSpdC1+fSpdC2); //Not working
             for(Int_t ii=1; ii<33; ii++){

--- a/PWGPP/BeamGasMonitoring/AliAnalysisBGMonitorQATrain.cxx
+++ b/PWGPP/BeamGasMonitoring/AliAnalysisBGMonitorQATrain.cxx
@@ -173,7 +173,6 @@ void AliAnalysisBGMonitorQATrain::Exec(Option_t *)
     runNumber = fESD->GetRunNumber();
     ntr = 10;
     nbunch = 21;
-    static AliTriggerAnalysis * triggerAnalysis = new AliTriggerAnalysis();
     AliVVZERO *vzero = fESD->GetVZEROData();
     AliAnalysisUtils *utils = new AliAnalysisUtils();
     bgID = utils->IsSPDClusterVsTrackletBG(fESD);
@@ -227,7 +226,6 @@ void AliAnalysisBGMonitorQATrain::Exec(Option_t *)
     if(ftrigger[0]==1)((TH1F*)fList->FindObject("hNumEvents"))->Fill(1);
     if(ftrigger[1]==1)((TH1F*)fList->FindObject("hNumEvents"))->Fill(2);
     if(ftrigger[2]==1)((TH1F*)fList->FindObject("hNumEvents"))->Fill(3);
-    static Bool_t SelGoodEvent;
     //
     // List of the information needed to fill the histograms---------------------------------------------------
     // fSpdT: GetNumberOfTracklets(), Int value

--- a/PWGPP/BeamGasMonitoring/AliAnalysisBGMonitorQATrain.cxx
+++ b/PWGPP/BeamGasMonitoring/AliAnalysisBGMonitorQATrain.cxx
@@ -59,10 +59,10 @@ ntracks(0),
 nV0A(0),
 nV0C(0),
 nV0ABG(0),
-nV0CBG(0)
+nV0CBG(0),
 bgID(0),
 ntr(0),
-nbunch(0),
+nbunch(0)
 {
 }
 //________________________________________________________________________
@@ -80,10 +80,10 @@ ntracks(0),
 nV0A(0),
 nV0C(0),
 nV0ABG(0),
-nV0CBG(0)
+nV0CBG(0),
 bgID(0),
 ntr(0),
-nbunch(0),
+nbunch(0)
 {
     // Constructor
     DefineInput(0, TChain::Class());


### PR DESCRIPTION
Fixed reorder, unused variable, memory leak, and printing a string in AliAnalysisBGMonitorQATrain

triggered by compiler warnings:
```c++
DEBUG:AliPhysics:0: /Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGPP/BeamGasMonitoring/AliAnalysisBGMonitorQATrain.cxx:61:1: warning: field 'nbunch' will be initialized after field 'nV0A' [-Wreorder]
DEBUG:AliPhysics:0: nbunch(0),
DEBUG:AliPhysics:0: ^
DEBUG:AliPhysics:0: /Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGPP/BeamGasMonitoring/AliAnalysisBGMonitorQATrain.cxx:82:1: warning: field 'nbunch' will be initialized after field 'nV0A' [-Wreorder]
DEBUG:AliPhysics:0: nbunch(0),
DEBUG:AliPhysics:0: ^
DEBUG:AliPhysics:0: /Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGPP/BeamGasMonitoring/AliAnalysisBGMonitorQATrain.cxx:230:19: warning: unused variable 'SelGoodEvent' [-Wunused-variable]
DEBUG:AliPhysics:0:     static Bool_t SelGoodEvent;
DEBUG:AliPhysics:0:                   ^
DEBUG:AliPhysics:0: /Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGPP/BeamGasMonitoring/AliAnalysisBGMonitorQATrain.cxx:176:33: warning: unused variable 'triggerAnalysis' [-Wunused-variable]
DEBUG:AliPhysics:0:     static AliTriggerAnalysis * triggerAnalysis = new AliTriggerAnalysis();
DEBUG:AliPhysics:0:                                 ^
DEBUG:AliPhysics:0: /Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGPP/BeamGasMonitoring/AliAnalysisBGMonitorQATrain.cxx:255:20: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
DEBUG:AliPhysics:0:             Printf(Form("%s triggred",fNames[itrig]));
DEBUG:AliPhysics:0:                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DEBUG:AliPhysics:0: /Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGPP/BeamGasMonitoring/AliAnalysisBGMonitorQATrain.cxx:255:20: note: treat the string as an argument to avoid this
DEBUG:AliPhysics:0:             Printf(Form("%s triggred",fNames[itrig]));
DEBUG:AliPhysics:0:                    ^
DEBUG:AliPhysics:0:                    "%s", 
```