### PR TITLE
Initialize i=0 in for loop twice AliAnalysisTaskHypTritEventTree

### DIFF
--- a/PWGLF/NUCLEX/Hypernuclei/Hyp2Body/AliAnalysisTaskHypTritEventTree.h
+++ b/PWGLF/NUCLEX/Hypernuclei/Hyp2Body/AliAnalysisTaskHypTritEventTree.h
@@ -39,8 +39,8 @@ class AliAnalysisTaskHypTritEventTree : public AliAnalysisTaskSE {
   void SelectPIDcheckOnly(Bool_t pidch = kFALSE) {fPIDCheckOnly = pidch;};
   void SetPeriod(Int_t period = 2015) {fPeriod = period;};
   void SetBetheSplines(Bool_t betheSplines = kTRUE ) {fBetheSplines = betheSplines;};
-  void SetParamsHe(Double_t params[6]) { for(Int_t i; i < 6; i++) fBetheParamsHe[i] = params[i];};
-  void SetParamsT(Double_t params[6]) { for(Int_t i; i < 6; i++) fBetheParamsT[i] = params[i];};
+  void SetParamsHe(Double_t params[6]) { for(Int_t i=0; i < 6; i++) fBetheParamsHe[i] = params[i];};
+  void SetParamsT(Double_t params[6]) { for(Int_t i=0; i < 6; i++) fBetheParamsT[i] = params[i];};
 
  private:
   AliESDInputHandler     *fInputHandler;        //!<! Input handler


### PR DESCRIPTION
@strogolo what do you think?

Revealed by compiler warning:
```c++
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGLF/NUCLEX/Hypernuclei/Hyp2Body/AliAnalysisTaskHypTritEventTree.h:42:55: warning: 
      variable 'i' is uninitialized when used here [-Wuninitialized]
  void SetParamsHe(Double_t params[6]) { for(Int_t i; i < 6; i++) fBethe...
                                                      ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGLF/NUCLEX/Hypernuclei/Hyp2Body/AliAnalysisTaskHypTritEventTree.h:42:53: note: 
      initialize the variable 'i' to silence this warning
  void SetParamsHe(Double_t params[6]) { for(Int_t i; i < 6; i++) fBethe...
                                                    ^
                                                     = 0
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGLF/NUCLEX/Hypernuclei/Hyp2Body/AliAnalysisTaskHypTritEventTree.h:43:54: warning: 
      variable 'i' is uninitialized when used here [-Wuninitialized]
  void SetParamsT(Double_t params[6]) { for(Int_t i; i < 6; i++) fBetheP...
                                                     ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGLF/NUCLEX/Hypernuclei/Hyp2Body/AliAnalysisTaskHypTritEventTree.h:43:52: note: 
      initialize the variable 'i' to silence this warning
  void SetParamsT(Double_t params[6]) { for(Int_t i; i < 6; i++) fBetheP...
                                                   ^
                                                    = 0
```