### PR TITLE
Init i=0 in for loop AliHFCorrFitSystematics

### DIFF
--- a/PWGHF/correlationHF/AliHFCorrFitSystematics.h
+++ b/PWGHF/correlationHF/AliHFCorrFitSystematics.h
@@ -67,7 +67,7 @@ public:
     }
     
     void Setv2ForSystematics(Double_t v2had, Double_t v2D){fv2had = v2had; fv2Dmeson = v2D; }
-    void Setv2ForSystematics(Double_t v2had, Int_t nbins, std::vector<Double_t>& v2Dbins) {fv2had = v2had; for(Int_t i;i<nbins;i++) fv2DmesonVsPt.push_back(v2Dbins.at(i));}
+    void Setv2ForSystematics(Double_t v2had, Int_t nbins, std::vector<Double_t>& v2Dbins) {fv2had = v2had; for(Int_t i=0;i<nbins;i++) fv2DmesonVsPt.push_back(v2Dbins.at(i));}
     
     
     void CheckBaselineRanges();


### PR DESCRIPTION
@arossi81 @fcolamar What do you think?
Revealed by compiler warning:
```c++
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGHF/correlationHF/AliHFCorrFitSystematics.h:70:120: warning: 
      variable 'i' is uninitialized when used here [-Wuninitialized]
  ...v2had, Int_t nbins, std::vector<Double_t>& v2Dbins) {fv2had = v2had; for(Int_t i;i<nbins;i++...
                                                                                      ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGHF/correlationHF/AliHFCorrFitSystematics.h:70:119: note: 
      initialize the variable 'i' to silence this warning
  ...Int_t nbins, std::vector<Double_t>& v2Dbins) {fv2had = v2had; for(Int_t i;i<nbins;i++) fv2Dm...
                                                                              ^
                                                                               = 0
```