### PR TITLE
Fix logic & unused var warnings AliAnalysisCombinedHadronSpectra2MC

### DIFF
--- a/PWGLF/SPECTRA/PiKaPr/TOF/pp7/AliAnalysisCombinedHadronSpectra2MC.cxx
+++ b/PWGLF/SPECTRA/PiKaPr/TOF/pp7/AliAnalysisCombinedHadronSpectra2MC.cxx
@@ -1015,10 +1015,10 @@ void AliAnalysisCombinedHadronSpectra2MC::UserExec(Option_t *)
     
 
     if (!fESDtrackCuts->AcceptTrack(track)) {continue;}
-    if (!(track->GetStatus()&AliESDtrack::kTOFout)==0) {fTOFout=1;}else {fTOFout=0;}
-    if (!(track->GetStatus()&AliESDtrack::kTIME)==0) {ftime=1;}else {ftime=0;}  
-    if (!(track->GetStatus()&AliESDtrack::kTRDout)==0) {ftrdout=1;}else {ftrdout=0;}  
-    if (!(track->GetStatus()&AliESDtrack::kTOFmismatch)==0) {fmatch=0;}else {fmatch=1;}  
+    if (track->GetStatus()&AliESDtrack::kTOFout) {fTOFout=1;}else {fTOFout=0;}
+    if (track->GetStatus()&AliESDtrack::kTIME) {ftime=1;}else {ftime=0;}  
+    if (track->GetStatus()&AliESDtrack::kTRDout) {ftrdout=1;}else {ftrdout=0;}  
+    if (track->GetStatus()&AliESDtrack::kTOFmismatch) {fmatch=0;}else {fmatch=1;}  
     track->GetImpactParameters(fDCAXY, fDCAZ);
 
     track->GetTOFpid(r1);
@@ -1027,7 +1027,7 @@ void AliAnalysisCombinedHadronSpectra2MC::UserExec(Option_t *)
     if(!(TMath::Abs(feta)<0.9))continue;
     
     fmom=track->GetP();  // This function returns the track momentum
-    Double_t *trackT0;
+    // Double_t *trackT0;
     // trackT0 = t0maker->GetT0p(fmom);// [0]=to -- [1] = sigma T0
 //     fT0meas=trackT0[0]; 
 //     fT0sigma=trackT0[1];


### PR DESCRIPTION
Hello LF people!

The old logic in AliAnalysisCombinedHadronSpectra2MC is correct but over-complicates the problem and raises a warning. Simplified the logic, please have a look at the new logic.
Task was last touched by Riccardo Russo 3 years ago. Warnings below.

Cheers,
Hans

```c++
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGLF/SPECTRA/PiKaPr/TOF/pp7/AliAnalysisCombinedHadronSpectra2MC.cxx:1018:9: warning: logical not is only 
applied to the left hand side of this comparison [-Wlogical-not-parentheses]
    if (!(track->GetStatus()&AliESDtrack::kTOFout)==0) {fTOFout=1;}else {fTOFout=0;}
        ^                                         ~~
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGLF/SPECTRA/PiKaPr/TOF/pp7/AliAnalysisCombinedHadronSpectra2MC.cxx:1018:9: note: add parentheses after t
he '!' to evaluate the comparison first
    if (!(track->GetStatus()&AliESDtrack::kTOFout)==0) {fTOFout=1;}else {fTOFout=0;}
        ^
         (                                           )
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGLF/SPECTRA/PiKaPr/TOF/pp7/AliAnalysisCombinedHadronSpectra2MC.cxx:1018:9: note: add parentheses around 
left hand side expression to silence this warning
    if (!(track->GetStatus()&AliESDtrack::kTOFout)==0) {fTOFout=1;}else {fTOFout=0;}
        ^
        (                                         )
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGLF/SPECTRA/PiKaPr/TOF/pp7/AliAnalysisCombinedHadronSpectra2MC.cxx:1019:9: warning: logical not is only 
applied to the left hand side of this comparison [-Wlogical-not-parentheses]
    if (!(track->GetStatus()&AliESDtrack::kTIME)==0) {ftime=1;}else {ftime=0;}  
        ^                                       ~~
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGLF/SPECTRA/PiKaPr/TOF/pp7/AliAnalysisCombinedHadronSpectra2MC.cxx:1019:9: note: add parentheses after t
he '!' to evaluate the comparison first
    if (!(track->GetStatus()&AliESDtrack::kTIME)==0) {ftime=1;}else {ftime=0;}  
        ^
         (                                         )
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGLF/SPECTRA/PiKaPr/TOF/pp7/AliAnalysisCombinedHadronSpectra2MC.cxx:1019:9: note: add parentheses around 
left hand side expression to silence this warning
    if (!(track->GetStatus()&AliESDtrack::kTIME)==0) {ftime=1;}else {ftime=0;}  
        ^
        (                                       )
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGLF/SPECTRA/PiKaPr/TOF/pp7/AliAnalysisCombinedHadronSpectra2MC.cxx:1020:9: warning: logical not is only 
applied to the left hand side of this comparison [-Wlogical-not-parentheses]
    if (!(track->GetStatus()&AliESDtrack::kTRDout)==0) {ftrdout=1;}else {ftrdout=0;}  
        ^                                         ~~
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGLF/SPECTRA/PiKaPr/TOF/pp7/AliAnalysisCombinedHadronSpectra2MC.cxx:1020:9: note: add parentheses after the '!' to evaluate the comparison first
    if (!(track->GetStatus()&AliESDtrack::kTRDout)==0) {ftrdout=1;}else {ftrdout=0;}  
        ^
         (                                           )
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGLF/SPECTRA/PiKaPr/TOF/pp7/AliAnalysisCombinedHadronSpectra2MC.cxx:1020:9: note: add parentheses around left hand side expression to silence this warning
    if (!(track->GetStatus()&AliESDtrack::kTRDout)==0) {ftrdout=1;}else {ftrdout=0;}  
        ^
        (                                         )
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGLF/SPECTRA/PiKaPr/TOF/pp7/AliAnalysisCombinedHadronSpectra2MC.cxx:1021:9: warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]
    if (!(track->GetStatus()&AliESDtrack::kTOFmismatch)==0) {fmatch=0;}else {fmatch=1;}  
        ^                                              ~~
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGLF/SPECTRA/PiKaPr/TOF/pp7/AliAnalysisCombinedHadronSpectra2MC.cxx:1021:9: note: add parentheses after the '!' to evaluate the comparison first
    if (!(track->GetStatus()&AliESDtrack::kTOFmismatch)==0) {fmatch=0;}else {fmatch=1;}  
        ^
         (                                                )
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGLF/SPECTRA/PiKaPr/TOF/pp7/AliAnalysisCombinedHadronSpectra2MC.cxx:1021:9: note: add parentheses around left hand side expression to silence this warning
    if (!(track->GetStatus()&AliESDtrack::kTOFmismatch)==0) {fmatch=0;}else {fmatch=1;}  
        ^
        (                                              )
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGLF/SPECTRA/PiKaPr/TOF/pp7/AliAnalysisCombinedHadronSpectra2MC.cxx:1030:15: warning: unused variable 'trackT0' [-Wunused-variable]
    Double_t *trackT0;
              ^

```