### PR TITLE
Fix simple reorder in AliAnalysisMuMuMinv

### DIFF
--- a/PWG/muon/AliAnalysisMuMuMinv.cxx
+++ b/PWG/muon/AliAnalysisMuMuMinv.cxx
@@ -40,16 +40,16 @@ fWeightMuon(kFALSE),
 fAccEffHisto(0x0),
 fMinvBinSeparator("+"),
 fsystLevel(systLevel),
+fPtFuncOld(0x0),
+fPtFuncNew(0x0),
+fYFuncOld(0x0),
+fYFuncNew(0x0),
 fBinsToFill(0x0),
 fMinvBinSize(0.025),
 fMinvMin(0.0),
 fMinvMax(16.0),
 fmcptcutmin(0.0),
-fmcptcutmax(12.0),
-fPtFuncOld(0x0),
-fPtFuncNew(0x0),
-fYFuncOld(0x0),
-fYFuncNew(0x0)
+fmcptcutmax(12.0)
 {
   // FIXME ? find the AccxEff histogram from HistogramCollection()->Histo("/EXCHANGE/JpsiAccEff")
 


### PR DESCRIPTION
Hello muon people!

This commit doesn't change any behavior, just silences a warning, allowing to focus on other, serious warnings. 

Cheers,
Hans

```c++
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWG/muon/AliAnalysisMuMuMinv.cxx:48:1: warning: field 'fmcptcutmax' will be initialized after field 'fPtFuncOld' [-Wreorder]
fmcptcutmax(12.0),
^
```