### PR TITLE
Fix reorder AliV0ReaderStrange

### DIFF
--- a/PWGGA/GammaConv/AliV0ReaderStrange.cxx
+++ b/PWGGA/GammaConv/AliV0ReaderStrange.cxx
@@ -46,9 +46,9 @@ ClassImp(AliV0ReaderStrange)
 AliV0ReaderStrange::AliV0ReaderStrange(const char *name) : AliAnalysisTaskSE(name),
   fEventCuts(NULL),
   fV0Cuts(NULL),
-  fVectorFoundGammas(0),
   fConversionGammas(NULL),
-  fEventIsSelected(kFALSE)
+  fEventIsSelected(kFALSE),
+  fVectorFoundGammas(0)
 {
   // Default constructor
 


### PR DESCRIPTION
Dear @dmuhlhei, 

Can you look at this PR? Simply fixes a small warning when compiling AliPhysics with -Wall.

Cheers,
Hans

```c++
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGGA/GammaConv/AliV0ReaderStrange.cxx:49:3: warning: field 'fVectorFoundGammas' will be initialized after
 field 'fConversionGammas' [-Wreorder]
  fVectorFoundGammas(0),
  ^
1 warning generated.
```