### PR TITLE
Fix reorder AliV0CutsStrange

### DIFF
--- a/PWGGA/GammaConv/AliV0CutsStrange.cxx
+++ b/PWGGA/GammaConv/AliV0CutsStrange.cxx
@@ -46,22 +46,21 @@ AliV0CutsStrange::AliV0CutsStrange(const char *name,const char *title) :
   AliAnalysisCuts(name, title),
   fHistograms(NULL),
   fPIDResponse(NULL),
-  fIsQA(kFALSE),
   fV0ReaderStrangeName("V0ReaderStrange"),
   fCutString(NULL),
   fCutStringRead(""),
-  fPreSelCut(kFALSE),
+  fIsQA(kFALSE),
   fUseOnFlyV0Finder(kTRUE),
   fUseOnFlyV0FinderSameSign(0),
-  fMinClsTPC(0.),
-  fMinClsTPCToF(0.),
   fUseCorrectedTPCClsInfo(kFALSE),
+  fMinClsTPCToF(0.),
+  fMinClsTPC(0.),
   fPIDTPCnSigmaProtonLow(0),
   fPIDTPCnSigmaProtonUp(0),
-  fPIDTPCnSigmaPionLow(0),
-  fPIDTPCnSigmaPionUp(0),
   fPIDTOFnSigmaProtonLow(0),
   fPIDTOFnSigmaProtonUp(0),
+  fPIDTPCnSigmaPionLow(0),
+  fPIDTPCnSigmaPionUp(0),
   fPIDTOFnSigmaPionLow(0),
   fPIDTOFnSigmaPionUp(0),
   fHistoCutIndex(NULL),
@@ -82,7 +81,8 @@ AliV0CutsStrange::AliV0CutsStrange(const char *name,const char *title) :
   fHistoTOFdEdxPionBefore(NULL),
   fHistoTOFdEdxSigmaPionBefore(NULL),
   fHistoTOFdEdxPionAfter(NULL),
-  fHistoTOFdEdxSigmaPionAfter(NULL)
+  fHistoTOFdEdxSigmaPionAfter(NULL),
+  fPreSelCut(kFALSE)
 {
   InitPIDResponse();
   for(Int_t jj=0;jj<kNCuts;jj++){fCuts[jj]=0;}


### PR DESCRIPTION
Dear @dmuhlhei,

Another small reorder fix. Can you have a look? 

Cheers!
Hans

```c++
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGGA/GammaConv/AliV0CutsStrange.cxx:49:3: warning: field 'fIsQA' will be initialized after field 'fV0Read
erStrangeName' [-Wreorder]
  fIsQA(kFALSE),
  ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGGA/GammaConv/AliV0CutsStrange.cxx:53:3: warning: field 'fPreSelCut' will be initialized after field 'fU
seOnFlyV0Finder' [-Wreorder]
  fPreSelCut(kFALSE),
  ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGGA/GammaConv/AliV0CutsStrange.cxx:56:3: warning: field 'fMinClsTPC' will be initialized after field 'fMinClsTPCToF' [-Wreorder]
  fMinClsTPC(0.),
  ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGGA/GammaConv/AliV0CutsStrange.cxx:57:3: warning: field 'fMinClsTPCToF' will be initialized after field 'fUseCorrectedTPCClsInfo' [-Wreorder]
  fMinClsTPCToF(0.),
  ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGGA/GammaConv/AliV0CutsStrange.cxx:62:3: warning: field 'fPIDTPCnSigmaPionUp' will be initialized after field 'fPIDTOFnSigmaProtonLow' [-Wreorder]
  fPIDTPCnSigmaPionUp(0),
  ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGGA/GammaConv/AliV0CutsStrange.cxx:99:3: warning: field 'fIsQA' will be initialized after field 'fV0ReaderStrangeName' [-Wreorder]
  fIsQA(kFALSE),
  ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGGA/GammaConv/AliV0CutsStrange.cxx:103:3: warning: field 'fPreSelCut' will be initialized after field 'fUseOnFlyV0Finder' [-Wreorder]
  fPreSelCut(ref.fPreSelCut),
  ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGGA/GammaConv/AliV0CutsStrange.cxx:106:3: warning: field 'fMinClsTPC' will be initialized after field 'fMinClsTPCToF' [-Wreorder]
  fMinClsTPC(ref.fMinClsTPC),
  ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGGA/GammaConv/AliV0CutsStrange.cxx:107:3: warning: field 'fMinClsTPCToF' will be initialized after field 'fUseCorrectedTPCClsInfo' [-Wreorder]
  fMinClsTPCToF(ref.fMinClsTPCToF),
  ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGGA/GammaConv/AliV0CutsStrange.cxx:112:3: warning: field 'fPIDTPCnSigmaPionUp' will be initialized after field 'fPIDTOFnSigmaProtonLow' [-Wreorder]
  fPIDTPCnSigmaPionUp(ref.fPIDTPCnSigmaPionUp),
  ^

```