### PR TITLE
Commented out unused variable AliDielectronVarManager

### DIFF
--- a/PWGDQ/dielectron/core/AliDielectronVarManager.h
+++ b/PWGDQ/dielectron/core/AliDielectronVarManager.h
@@ -2517,7 +2517,7 @@ inline void AliDielectronVarManager::FillVarVEvent(const AliVEvent *event, Doubl
 
     // VZERO event plane
     TVector2 qvec;
-    TVector2 *qVecQnFramework;
+    // TVector2 *qVecQnFramework;
     Double_t qx = 0, qy = 0;
 
     ep->CalculateVZEROEventPlane(event,10, 2, qx, qy);    qvec.Set(qx,qy);


### PR DESCRIPTION
Hello dielectron people,

Can you look at this PR? It fixes a small warning when compiling AliPhysics with -Wall, see below.

Cheers,
Hans
```c++
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGDQ/dielectron/core/AliDielectronVarManager.h:2520:15: warning: unused variable 'qVecQnFramework' [-Wunused-variable]
    TVector2 *qVecQnFramework;
              ^
```