### PR TITLE
Comment out unused variables EmcalJetHF

### DIFF
--- a/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx
+++ b/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx
@@ -456,13 +456,13 @@ void AliAnalysisTaskEmcalJetHF::DoJetLoop()
 
 
 
-            Float_t ptLeading = jetCont->GetLeadingHadronPt(jet);
-            Float_t corrPt = jet->Pt() - rhoVal * jet->Area();
+            //Float_t ptLeading = jetCont->GetLeadingHadronPt(jet);
+            //Float_t corrPt = jet->Pt() - rhoVal * jet->Area();
             TLorentzVector leadPart;
             jetCont->GetLeadingHadronMomentum(leadPart, jet);
 
-            Double_t JetPhi = jet->Phi();
-            Double_t JetEta = jet->Eta();
+            //Double_t JetPhi = jet->Phi();
+            //Double_t JetEta = jet->Eta();
             Double_t ep = jet->Phi() - fEPV0;
             while (ep < 0) ep += TMath::Pi();
             while (ep >= TMath::Pi()) ep -= TMath::Pi();//Get Event Plane info
@@ -508,11 +508,11 @@ void AliAnalysisTaskEmcalJetHF::DoJetLoop()
                         */
 
                         Int_t    JetTrackLabel = Vtrack->GetID();
-                        Double_t JetTrackP = track->P();
-                        Double_t JetTrackPt = track->Pt();
+                        //Double_t JetTrackP = track->P();
+                        //Double_t JetTrackPt = track->Pt();
                         Double_t dphi = TVector2::Phi_0_2pi(track->Phi() - jet->Phi());
                         Double_t deta = track->Eta() - jet->Eta();
-                        Double_t dist = TMath::Sqrt(deta * deta + dphi * dphi);
+                        //Double_t dist = TMath::Sqrt(deta * deta + dphi * dphi);
 
                         //+++++----Track matching to EMCAL
                         Int_t EMCalIndex = -1;
@@ -527,9 +527,9 @@ void AliAnalysisTaskEmcalJetHF::DoJetLoop()
 
                         if(clusmatch->E() < 0.500) continue;//Bad Cluster matching below 500 MeV
                         if(!(clusmatch && clusmatch->IsEMCAL())) continue;
-                        Double_t clustMatchE = clusmatch->E();
+                        //Double_t clustMatchE = clusmatch->E();
                         Double_t clustMatchNonLinE = clusmatch->GetNonLinCorrEnergy();
-                        Double_t clustMatchHadCorr = clusmatch->GetHadCorrEnergy();
+                        //Double_t clustMatchHadCorr = clusmatch->GetHadCorrEnergy();
                         //++++---EMCal Cluster Position----
                         TVector3 clustpos;
                         Float_t  emcx[3]; // cluster pos
@@ -544,25 +544,25 @@ void AliAnalysisTaskEmcalJetHF::DoJetLoop()
                         Double_t fTPCnSigma = 0.0;
                         fTPCnSigma = fpidResponse->NumberOfSigmasTPC(Vtrack, AliPID::kElectron);
 
-                        Double_t JetElectronEovP = clustMatchNonLinE / track->P();
+                        //Double_t JetElectronEovP = clustMatchNonLinE / track->P();
                         TrackEtaEMC  = Vtrack->GetTrackEtaOnEMCal();
                         TrackPhiEMC  = Vtrack->GetTrackPhiOnEMCal();
                         TrackPEMC    = Vtrack->GetTrackPOnEMCal();
                         TrackPtEMC   = Vtrack->GetTrackPtOnEMCal();
                         detaTrckClus = TrackEtaEMC - track->Eta();
                         dphiTrckClus = TrackPhiEMC - track->Phi();
-                        Double_t M20 = clusmatch->GetM20();
-                        Double_t M02 = clusmatch->GetM02();
+                        //Double_t M20 = clusmatch->GetM20();
+                        //Double_t M02 = clusmatch->GetM02();
 
                         //if(fTPCnSigma > -1 && fTPCnSigma < 3 && JetElectronEovP>0.8 && JetElectronEovP<1.2 && M02 > 0.006 && M02 < 0.35)
                         //{
                         //++++---Photonic Electrons----
                         Bool_t fFlagPhotonicElec = kFALSE;
 
-                        Double_t Me  = 0.0005109989;
-                        Double_t Me2 = Me * Me;
+                        //Double_t Me  = 0.0005109989;
+                        //Double_t Me2 = Me * Me;
 
-                        AliParticleContainer* partContHFE = 0;
+                        //AliParticleContainer* partContHFE = 0;
                         TIter next(&fParticleCollArray);
 
                         SelectPhotonicElectron(JetTrackLabel, Vtrack, fFlagPhotonicElec);
@@ -581,7 +581,7 @@ void AliAnalysisTaskEmcalJetHF::DoJetLoop()
                         */
 
                         //++++---Jet HFE Electron Correlations----
-                        Double_t dPhiJetTrk = -999., dEtaJetPhi = -999.;
+                        //Double_t dPhiJetTrk = -999., dEtaJetPhi = -999.;
 
 
                         fHistJetEovP->Fill(clustMatchNonLinE / Vtrack->P());
@@ -795,7 +795,7 @@ void AliAnalysisTaskEmcalJetHF::ExecOnce()
  */
 Bool_t AliAnalysisTaskEmcalJetHF::Run()
 {
-    UInt_t evSelMask=((AliInputEventHandler*)(AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler()))->IsEventSelected();
+    //UInt_t evSelMask=((AliInputEventHandler*)(AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler()))->IsEventSelected();
 
     fVevent = dynamic_cast<AliVEvent*>(InputEvent());
     if (!fVevent) {
@@ -827,8 +827,8 @@ Bool_t AliAnalysisTaskEmcalJetHF::Run()
     ntracks = fVevent->GetNumberOfTracks();
     //printf("There are %d tracks in this event\n",ntracks);
 
-    Double_t Zvertex = -100, Xvertex = -100, Yvertex = -100;
-    Double_t NcontV = pVtx->GetNContributors();
+    //Double_t Zvertex = -100, Xvertex = -100, Yvertex = -100;
+    //Double_t NcontV = pVtx->GetNContributors();
 
    // if(NcontV<2)return kTRUE;  //Events with 2 Tracks
 

--- a/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx
+++ b/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx
@@ -510,8 +510,8 @@ void AliAnalysisTaskEmcalJetHF::DoJetLoop()
                         Int_t    JetTrackLabel = Vtrack->GetID();
                         //Double_t JetTrackP = track->P();
                         //Double_t JetTrackPt = track->Pt();
-                        Double_t dphi = TVector2::Phi_0_2pi(track->Phi() - jet->Phi());
-                        Double_t deta = track->Eta() - jet->Eta();
+                        //Double_t dphi = TVector2::Phi_0_2pi(track->Phi() - jet->Phi());
+                        //Double_t deta = track->Eta() - jet->Eta();
                         //Double_t dist = TMath::Sqrt(deta * deta + dphi * dphi);
 
                         //+++++----Track matching to EMCAL
@@ -815,7 +815,7 @@ Bool_t AliAnalysisTaskEmcalJetHF::Run()
         //return;
     }
 
-    const AliVVertex *pVtx = fVevent->GetPrimaryVertex();
+    //const AliVVertex *pVtx = fVevent->GetPrimaryVertex();
 
     fpidResponse = fInputHandler->GetPIDResponse();
     if (!fpidResponse) {

--- a/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx
+++ b/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx
@@ -74,13 +74,13 @@ ClassImp(AliAnalysisTaskEmcalJetHF);
  */
 AliAnalysisTaskEmcalJetHF::AliAnalysisTaskEmcalJetHF() :
 AliAnalysisTaskEmcalJet(),
+fHistManager(),
 fVevent(),
 fESD(),
 fAOD(),
 fpidResponse(),
 fEventCounter(),
 fInvmassCut(),
-fHistManager(),
 fdEdx(),  //Histo's
 fM20(),
 fM02(),
@@ -108,13 +108,13 @@ fHistClusTrackMatchdEta()
  */
 AliAnalysisTaskEmcalJetHF::AliAnalysisTaskEmcalJetHF(const char *name) :
 AliAnalysisTaskEmcalJet(name, kTRUE),
+fHistManager(name),
 fVevent(0),
 fESD(0),
 fAOD(0),
 fpidResponse(0),
 fEventCounter(0),
 fInvmassCut(0),
-fHistManager(name),
 fdEdx(0),  //Histo's
 fM20(0),
 fM02(0),


### PR DESCRIPTION
Hello!

This PR fixes a few warnings when compiling AliPhysics with -Wall. @AndrewCastro, you want to comment?

Cheers,
Hans
```c++
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:82:1: warning: field 'fInvmassCut' will be initialized after field 'fHistManager' [-Wreorder]
fInvmassCut(),
^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:116:1: warning: field 'fInvmassCut' will be initialized after field 'fHistManager' [-Wreorder]
fInvmassCut(0),
^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:532:34: warning: unused variable 'clustMatchHadCorr' [-Wunused-variable]
                        Double_t clustMatchHadCorr = clusmatch->GetHadCorrEnergy();
                                 ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:554:34: warning: unused variable 'M20' [-Wunused-variable]
                        Double_t M20 = clusmatch->GetM20();
                                 ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:555:34: warning: unused variable 'M02' [-Wunused-variable]
                        Double_t M02 = clusmatch->GetM02();
                                 ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:584:34: warning: unused variable 'dPhiJetTrk' [-Wunused-variable]
                        Double_t dPhiJetTrk = -999., dEtaJetPhi = -999.;
                                 ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:584:54: warning: unused variable 'dEtaJetPhi' [-Wunused-variable]
                        Double_t dPhiJetTrk = -999., dEtaJetPhi = -999.;
                                                     ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:530:34: warning: unused variable 'clustMatchE' [-Wunused-variable]
                        Double_t clustMatchE = clusmatch->E();
                                 ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:512:34: warning: unused variable 'JetTrackPt' [-Wunused-variable]
                        Double_t JetTrackPt = track->Pt();
                                 ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:563:34: warning: unused variable 'Me2' [-Wunused-variable]
                        Double_t Me2 = Me * Me;
                                 ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:565:47: warning: unused variable 'partContHFE' [-Wunused-variable]
                        AliParticleContainer* partContHFE = 0;
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:511:34: warning: unused variable 'JetTrackP' [-Wunused-variable]
                        Double_t JetTrackP = track->P();
                                 ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:547:34: warning: unused variable 'JetElectronEovP' [-Wunused-variable]
                        Double_t JetElectronEovP = clustMatchNonLinE / track->P();
                                 ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:515:34: warning: unused variable 'dist' [-Wunused-variable]
                        Double_t dist = TMath::Sqrt(deta * deta + dphi * dphi);
                                 ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:459:21: warning: unused variable 'ptLeading' [-Wunused-variable]
            Float_t ptLeading = jetCont->GetLeadingHadronPt(jet);
                    ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:460:21: warning: unused variable 'corrPt' [-Wunused-variable]
            Float_t corrPt = jet->Pt() - rhoVal * jet->Area();
                    ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:464:22: warning: unused variable 'JetPhi' [-Wunused-variable]
            Double_t JetPhi = jet->Phi();
                     ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:465:22: warning: unused variable 'JetEta' [-Wunused-variable]
            Double_t JetEta = jet->Eta();
                     ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:830:46: warning: unused variable 'Yvertex' [-Wunused-variable]
    Double_t Zvertex = -100, Xvertex = -100, Yvertex = -100;
                                             ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:798:12: warning: unused variable 'evSelMask' [-Wunused-variable]
    UInt_t evSelMask=((AliInputEventHandler*)(AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler()))->IsEventSelected();
           ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:831:14: warning: unused variable 'NcontV' [-Wunused-variable]
    Double_t NcontV = pVtx->GetNContributors();
             ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:830:30: warning: unused variable 'Xvertex' [-Wunused-variable]
    Double_t Zvertex = -100, Xvertex = -100, Yvertex = -100;
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/FlavourJetTasks/AliAnalysisTaskEmcalJetHF.cxx:830:14: warning: unused variable 'Zvertex' [-Wunused-variable]
    Double_t Zvertex = -100, Xvertex = -100, Yvertex = -100;
             ^
```