### PR TITLE
AliEmcalJetByJetCorrection fix reorder&unused value

### DIFF
--- a/PWGJE/EMCALJetTasks/AliEmcalJetByJetCorrection.cxx
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetByJetCorrection.cxx
@@ -60,8 +60,8 @@ AliEmcalJetByJetCorrection::AliEmcalJetByJetCorrection(const char* name) :
   fCorrectpTtrack(0),
   fNpPoisson(0),
   fExternalNmissed(0),
-  fNMissedTracks(-1),
   fRndm(0),
+  fNMissedTracks(-1),
   fpAppliedEfficiency(0),
   fhNmissing(0),
   fListOfOutput(0)
@@ -118,8 +118,8 @@ AliEmcalJetByJetCorrection::AliEmcalJetByJetCorrection(const AliEmcalJetByJetCor
   fhSmoothEfficiency(other.fhSmoothEfficiency),
   fCorrectpTtrack(other.fCorrectpTtrack),
   fpAppliedEfficiency(other.fpAppliedEfficiency),
-  fhNmissing(other.fhNmissing),
   fRndm(other.fRndm)
+  fhNmissing(other.fhNmissing),
 {
   // Copy constructor.
 }
@@ -241,7 +241,7 @@ void AliEmcalJetByJetCorrection::Init() {
       for(Int_t i=0;i<nBinsEfSmth;i++){
       	 Double_t binCentreT=fhSmoothEfficiency->GetBinCenter(i+1);
       	 Int_t bin = fhEfficiency->FindBin(binCentreT);
-      	 Double_t binEff = fhEfficiency->GetBinContent(bin);
+      	 //Double_t binEff = fhEfficiency->GetBinContent(bin);
       	 
       	 //fill histogram fhSmoothEfficiency by interpolation or function
       	 if(fhEfficiency->GetBinWidth(bin) > smallBinW){

--- a/PWGJE/EMCALJetTasks/AliEmcalJetByJetCorrection.cxx
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetByJetCorrection.cxx
@@ -118,8 +118,8 @@ AliEmcalJetByJetCorrection::AliEmcalJetByJetCorrection(const AliEmcalJetByJetCor
   fhSmoothEfficiency(other.fhSmoothEfficiency),
   fCorrectpTtrack(other.fCorrectpTtrack),
   fpAppliedEfficiency(other.fpAppliedEfficiency),
-  fRndm(other.fRndm)
-  fhNmissing(other.fhNmissing),
+  fRndm(other.fRndm),
+  fhNmissing(other.fhNmissing)
 {
   // Copy constructor.
 }


### PR DESCRIPTION
Hello JE,

This PR fixes three small harmless warnings in the code of Chiara and Marta.

Cheers,
Hans

```c++
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/EMCALJetTasks/AliEmcalJetByJetCorrection.cxx:63:3: warning: field 'fNMissedTracks' will be initialized after field 'fRndm' [-Wreorder]
  fNMissedTracks(-1),
  ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/EMCALJetTasks/AliEmcalJetByJetCorrection.cxx:121:3: warning: field 'fhNmissing' will be initialized after field 'fRndm' [-Wreorder]
  fhNmissing(other.fhNmissing),
  ^
/Users/hbeck/alice/alibuild/sw/SOURCES/AliPhysics/0/0/PWGJE/EMCALJetTasks/AliEmcalJetByJetCorrection.cxx:244:18: warning: unused variable 'binEff' [-Wunused-variable]
         Double_t binEff = fhEfficiency->GetBinContent(bin);
                  ^
3 warnings generated.
```