### PR TITLE
Disable Weffc for gcc for AliV0ReaderV1

### DIFF
--- a/PWGGA/GammaConv/AliV0ReaderV1.h
+++ b/PWGGA/GammaConv/AliV0ReaderV1.h
@@ -29,7 +29,17 @@ class TH1F;
 class TH2F;
 class AliAODConversionPhoton;
 
-using namespace std;
+#if (__GNUC__ >= 3) && !defined(__INTEL_COMPILER)
+// gcc warns in level Weffc++ about non-virtual destructor
+// in std::iterator. It is a false positive, therefore Weffc++
+// needs to be disabled for AliV0ReaderV1
+#pragma GCC system_header
+#endif
+
+#if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) >= 40600
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weffc++"
+#endif
 
 class AliV0ReaderV1 : public AliAnalysisTaskSE {
 
@@ -247,6 +257,10 @@ class AliV0ReaderV1 : public AliAnalysisTaskSE {
     ClassDef(AliV0ReaderV1, 16)
 
 };
+
+#if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) >= 40600
+#pragma GCC diagnostic pop
+#endif
 
 inline void AliV0ReaderV1::SetConversionCuts(const TString cut){
   if(fConversionCuts != NULL){


### PR DESCRIPTION
gcc implements the class std::iterator to have a non-virtual
destructor. Consequently classes inheriting from std::iterator
will raise the Weffc warning. Inheriting from std::iterator
however is a popular and easy way to make a class std::iterable,
and the way chosen in this approach. As the std::iterator doesn't
allocate memory, the warning is still vaid but harmless, and
as it cannot be handled by any implementation it should be treated
as a false positive. Therefore Weffc will be disabled for gcc
for AliVOReaderV1 in a similar way is it is done for the iterator
of ROOT's TMap.