### PR TITLE
option to use 2012 trigger bad map added

### DIFF
--- a/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.h
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.h
@@ -116,6 +116,7 @@ class AliAnalysisTaskEMCALPhotonIsolation: public AliAnalysisTaskEmcal {
   void                     SetNcontributorsToPileUp (Int_t nCtoPU)                         { fNContrToPileUp = nCtoPU; }
   void                     SetLightenOutput (Bool_t light)                                 { fLightOutput = light; }
   void                     SetFiducialCut(Float_t fiducial)                                { fFiducialCut = fiducial; }
+  void                     Set2012L1Analysis(Bool_t is2012L1)                              { f2012EGA = is2012L1; }
  protected:
   
   void                     FillQAHistograms(AliVCluster *coi, TLorentzVector vecCOI);                           // Fill some QA histograms
@@ -211,6 +212,7 @@ class AliAnalysisTaskEMCALPhotonIsolation: public AliAnalysisTaskEmcal {
   Bool_t      fMCtruth;                        // Enable/disable MC truth analysis
   TString     fPeriod;                         // String containing the LHC period
   Float_t     fFiducialCut;                    // Variable fiducial cut from the border of the EMCal/TPC acceptance
+  Bool_t      f2012EGA;                        // Analyze only Events with EGA recalc patches above threshold
   
   // Initialization for TTree variables
   Double_t    fEClustersT;                     // E for all clusters

--- a/PWGGA/EMCALTasks/macros/AddTaskEMCALPhotonIsolation.C
+++ b/PWGGA/EMCALTasks/macros/AddTaskEMCALPhotonIsolation.C
@@ -100,6 +100,12 @@ AliAnalysisTaskEMCALPhotonIsolation* AddTaskEMCALPhotonIsolation(
     myContName = Form("Analysis_Neutrals");
   }
   
+  // for the 2012 EGA/L1 Analysis, only events with EGA/L1 recalc patches are considered
+  // this configuration requires a TriggerMaker wagon in the train!!!
+  Bool_t is2012_EGA = kFALSE;
+  TString Period = periodstr;
+  if((triggerName.Contains("EGArecalc") || triggerName.Contains("L1recalc")) && Period.Contains("12")) is2012_EGA = kTRUE;
+  
   if(triggerName.Contains("EG1") || triggerName.Contains("EGA1")){
     triggerName = "_Trigger_EG1";
   }
@@ -121,7 +127,7 @@ AliAnalysisTaskEMCALPhotonIsolation* AddTaskEMCALPhotonIsolation(
     pileUp = "";
   }
   
-  myContName.Append(Form("%s_TM_%s_CPVe%.2lf_CPVp%.2lf_IsoMet%d_EtIsoMet%d_UEMet%d_TPCbound_%s_IsoConeR%.1f_NLMCut_%s_minNLM%d_maxNLM%d_SSsmear_%s_Width%.3f_Mean_%.3f_PureIso_%s_WhichSmear_%d%s%s",isLCAnalysis?"_LC_Yes":"",bTMClusterRejection? "On" :"Off", TMdeta , TMdphi ,iIsoMethod,iEtIsoMethod,iUEMethod,bUseofTPC ? "Yes" : "No",iIsoConeRadius,bNLMCut ? "On": "Off",minNLM, NLMCut, iSmearingSS ? "On":"Off",iWidthSSsmear,iMean_SSsmear,iExtraIsoCuts?"On":"Off",bWhichToSmear,triggerName.Data(),pileUp.Data()));
+  myContName.Append(Form("%s%s_TM_%s_CPVe%.2lf_CPVp%.2lf_IsoMet%d_EtIsoMet%d_UEMet%d_TPCbound_%s_IsoConeR%.1f_NLMCut_%s_minNLM%d_maxNLM%d_SSsmear_%s_Width%.3f_Mean_%.3f_PureIso_%s_WhichSmear_%d%s%s",is2012_EGA ? "_L1recalc":"",isLCAnalysis?"_LC_Yes":"",bTMClusterRejection? "On" :"Off", TMdeta , TMdphi ,iIsoMethod,iEtIsoMethod,iUEMethod,bUseofTPC ? "Yes" : "No",iIsoConeRadius,bNLMCut ? "On": "Off",minNLM, NLMCut, iSmearingSS ? "On":"Off",iWidthSSsmear,iMean_SSsmear,iExtraIsoCuts?"On":"Off",bWhichToSmear,triggerName.Data(),pileUp.Data()));
 
   // #### Define analysis task
   AliAnalysisTaskEMCALPhotonIsolation* task = new AliAnalysisTaskEMCALPhotonIsolation("Analysis",bHisto);
@@ -167,7 +173,7 @@ AliAnalysisTaskEMCALPhotonIsolation* AddTaskEMCALPhotonIsolation(
   TString configFilePath(configBasePath+"/"+configFileMD5);
   gROOT->LoadMacro(configFilePath.Data());
   Printf("Path of config file: %s\n",configFilePath.Data());
-  
+
   // #### Task preferences
   task->SetOutputFormat(iOutput);
   task->SetLCAnalysis(isLCAnalysis);
@@ -212,6 +218,7 @@ AliAnalysisTaskEMCALPhotonIsolation* AddTaskEMCALPhotonIsolation(
   task->SetNcontributorsToPileUp(NContrToPileUp);
   task->SetLightenOutput(lightOutput);
   task->SetFiducialCut(iFiducialCut);
+  task->Set2012L1Analysis(is2012_EGA);
 
   if(bIsMC && bMCNormalization) task->SetIsPythia(kTRUE);
   


### PR DESCRIPTION
Option that only analyses events with with L1 recalculated trigger patches (from TriggerMakerTask) over 2012 threshold added.
Needed to use trigger bad map.
triggername must contain EGArecalc or L1recalc, and periodstr must contain 12, to use this option