### PR TITLE
fixes for compiler warnings

### DIFF
--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx
@@ -40,14 +40,14 @@ AliCEPUtils::AliCEPUtils():
   , fTrackEtaMax()
   , fTrackCutListPrim(0x0)
 {
-  
+
   // initialize the track cuts
   fTrackCutListPrim = new TList();
 	fTrackCutListPrim->SetOwner();
-  
+
   // initialise the V0 counters
   for (Int_t ii=0; ii<5; ii++) fnV0dp[ii] = 0;
-  
+
 }
 
 //------------------------------------------------------------------------------
@@ -106,7 +106,7 @@ TList* AliCEPUtils::GetQArnumHists(Int_t rnummin, Int_t rnummax)
   if (nch <= 0) nch=1;
   TList *lhh = new TList();
   lhh->SetOwner();
-  
+
   // define the histograms and and add them to the list lhh
   printf("Preparing QArnum histograms %i - %i\n",rnummin,rnummax);
   // number of input events
@@ -128,9 +128,9 @@ TList* AliCEPUtils::GetQArnumHists(Int_t rnummin, Int_t rnummax)
   lhh->Add(fhh08);
   TH1F* fhh09 = new TH1F("nETNDG","nETNDG",nch,rnummin,rnummax);
   lhh->Add(fhh09);
-  
+
   return lhh;
-  
+
 }
 
 //------------------------------------------------------------------------------
@@ -141,7 +141,7 @@ TList* AliCEPUtils::GetBBFlagQAHists()
   // initialisations
   TList *lhh = new TList();
   lhh->SetOwner();
-  
+
   // define the histograms and and add them to the list lhh
   printf("Preparing QABBFlag histograms\n");
   // number of input events
@@ -162,9 +162,9 @@ TList* AliCEPUtils::GetBBFlagQAHists()
   lhh->Add(fhh07);
   TH2F* fhh08 = new TH2F("ADCBGFlag","ADCBGFlag", 8,0,8,21,0,21);
   lhh->Add(fhh08);
-  
+
   return lhh;
-  
+
 }
 
 //------------------------------------------------------------------------------
@@ -176,45 +176,45 @@ TList* AliCEPUtils::GetSPDPileupQAHists()
   // initialisations
   TList *lhh = new TList();
   lhh->SetOwner();
-  
+
   // define the histograms and and add them to the list lhh
   printf("Preparing SPDVtxAnalysis histograms\n");
   TH1F* fhh01 = new TH1F("nContr","nContr",200,0,200);
   lhh->Add(fhh01);
-  
+
   TH1F* fhh02 = new TH1F("nPileupVtx","nPileupVtx",20,0,20);
   lhh->Add(fhh02);
-  
+
   TH2F* fhh03 = new TH2F(
     "nPileupVtx vs nContrPileup",
     "nPileupVtx vs nContrPileup",
     20,0,20,50,0,50);
   lhh->Add(fhh03);
-  
+
   TH1F* fhh04 = new TH1F("distZ","distZ",50,0.,5.);
   lhh->Add(fhh04);
-  
+
   TH1F* fhh05 = new TH1F("distXdiam","distXdiam",50,0.,5.);
   lhh->Add(fhh05);
-  
+
   TH1F* fhh06 = new TH1F("distYdiam","distYdiam",50,0.,5.);
   lhh->Add(fhh06);
-  
+
   TH1F* fhh07 = new TH1F("distZdiam","distZdiam",50,0.,5.);
   lhh->Add(fhh07);
-  
+
   TH2F* fhh08 = new TH2F(
     "distXdiam vs errxDist",
     "distXdiam vs errxDist",
     50,0,5.,50,0,0.5);
   lhh->Add(fhh08);
-  
+
   TH2F* fhh09 = new TH2F(
     "distYdiam vs erryDist",
     "distYdiam vs erryDist",
     50,0,5.,50,0,0.5);
   lhh->Add(fhh09);
-  
+
   TH2F* fhh10 = new TH2F(
     "distZdiam vs errzDist",
     "distZdiam vs errzDist",
@@ -222,7 +222,7 @@ TList* AliCEPUtils::GetSPDPileupQAHists()
   lhh->Add(fhh10);
 
   return lhh;
-  
+
 }
 
 //------------------------------------------------------------------------------
@@ -235,7 +235,7 @@ TList* AliCEPUtils::GetnClunTraQAHists()
   // initialisations
   TList *lhh = new TList();
   lhh->SetOwner();
-  
+
   // define the histograms and and add them to the list lhh
   printf("Preparing SPDClusterVsTrackletBGAnalysis histograms\n");
   TH1F* fhh01 = new TH1F("nClusters[0]","nClusters[0]",200,0,200);
@@ -262,7 +262,7 @@ TList* AliCEPUtils::GetVtxQAHists()
   // initialisations
   TList *lhh = new TList();
   lhh->SetOwner();
-  
+
   // define the histograms and and add them to the list lhh
   printf("Preparing VtxAnalysis histograms\n");
   TH1F* fhh01 = new TH1F("SPDVtxDisp","SPDVtxDisp",200,0.,0.5);
@@ -275,7 +275,7 @@ TList* AliCEPUtils::GetVtxQAHists()
   lhh->Add(fhh04);
 
   return lhh;
-  
+
 }
 
 //------------------------------------------------------------------------------
@@ -287,7 +287,7 @@ TList* AliCEPUtils::GetV0QAHists()
   // initialisations
   TList *lhh = new TList();
   lhh->SetOwner();
-  
+
   // define histograms and graphs and add them to the list lhh
   printf("Preparing V0Analysis histograms\n");
   TH1F* fhh01 = new TH1F("V0pointang","V0pointang",100,0.95,1.0);
@@ -316,9 +316,9 @@ TList* AliCEPUtils::GetV0QAHists()
   TGraph* fgr05 = new TGraph();
   fgr05->SetName("Armenteros cut4");
   lhh->Add(fgr05);
-  
+
   return lhh;
-  
+
 }
 
 //------------------------------------------------------------------------------
@@ -329,7 +329,7 @@ TList* AliCEPUtils::GetFMDQAHists()
   // initialisations
   TList *lhh = new TList();
   lhh->SetOwner();
-  
+
   // define histograms and graphs and add them to the list lhh
   printf("Preparing FMDAnalysis histograms\n");
   TH1F* fhh01 = new TH1F("FMDAmult","FMDAmult",500,0.,2.);
@@ -340,9 +340,9 @@ TList* AliCEPUtils::GetFMDQAHists()
   lhh->Add(fhh03);
   TH1F* fhh04 = new TH1F("FMDCtotmult","FMDCtotmult",500,0.,2.);
   lhh->Add(fhh04);
-  
+
   return lhh;
-  
+
 }
 
 //------------------------------------------------------------------------------
@@ -381,7 +381,7 @@ Int_t AliCEPUtils::GetEventType(const AliVEvent *Event)
 		return AliCEPBase::kBinEventAC;
 	}
 	return AliCEPBase::kBinEventUnknown;
-  
+
 }
 
 //------------------------------------------------------------------------------
@@ -389,57 +389,57 @@ Int_t AliCEPUtils::GetEventType(const AliVEvent *Event)
 // https://twiki.cern.ch/twiki/bin/view/ALICE/PWGPPEvSelRun2pp
 UInt_t AliCEPUtils::GetVtxPos(AliVEvent *Event, TVector3 *fVtxPos)
 {
-    
+
   // initialize
   UInt_t fVtxType = AliCEPBase::kVtxUnknown;
   fVtxPos->SetXYZ(-999.9,-999.9,-999.9);
 
   // On AOD, only one primary vertex is stored: aodEv->GetPrimaryVertex()
   if (Event->GetDataLayoutType()==AliVEvent::kAOD) {
-    
+
     fVtxType |= AliCEPBase::kVtxAOD;
-  
+
   } else {
-  
+
     const AliESDVertex *trkVertex = ((AliESDEvent*)Event)->GetPrimaryVertexTracks();
     const AliESDVertex *spdVertex = ((AliESDEvent*)Event)->GetPrimaryVertexSPD();
     Bool_t hasSPD = spdVertex->GetStatus();
     Bool_t hasTrk = trkVertex->GetStatus();
-  
+
     // SPD/track vertex?
     if (hasSPD) fVtxType |= AliCEPBase::kVtxSPD;
     if (hasTrk) fVtxType |= AliCEPBase::kVtxTracks;
-    
+
     // Note that AliVertex::GetStatus checks that N_contributors is > 0
     // reject events if both are explicitly requested and none is available
     if (!(hasSPD && hasTrk)) return AliCEPBase::kVtxUnknown;
-  
+
     // check the spd vertex resolution and reject if not satisfied
     if (hasSPD) {
       if (spdVertex->IsFromVertexerZ() &&
         !(spdVertex->GetDispersion()<0.04 &&
         spdVertex->GetZRes()<0.25)) fVtxType |= AliCEPBase::kVtxErrRes;
     }
-  
+
     // check the proximity between the spd vertex and trak vertex, and reject if not satisfied
     if (hasSPD && hasTrk) {
       if (TMath::Abs(spdVertex->GetZ() - trkVertex->GetZ())>0.5)
         fVtxType |= AliCEPBase::kVtxErrDif;
     }
-  
+
   }
-  
+
   // Cut on the vertex z position
   const AliVVertex *vertex = Event->GetPrimaryVertex();
   if (vertex->GetStatus()) {
     if (TMath::Abs(vertex->GetZ())>10) fVtxType |= AliCEPBase::kVtxErrZ;
-  
+
     // set the vertex position fVtxPos
     fVtxPos->SetXYZ(vertex->GetX(),vertex->GetY(),vertex->GetZ());
   }
-  
+
   return fVtxType;
-  
+
 }
 
 //------------------------------------------------------------------------------
@@ -448,7 +448,7 @@ void AliCEPUtils::BBFlagAnalysis (
   AliVEvent *Event,
   TList *lhh)
 {
-  
+
   if (!lhh) return;
 
   // V0
@@ -462,7 +462,7 @@ void AliCEPUtils::BBFlagAnalysis (
         if (esdV0->GetPFBGFlag(ch+32,bc)>0) ((TH2F*)lhh->At(4))->Fill(ch,bc);
       }
     }
-    
+
     // side C
     for (Int_t ch=0; ch<32; ch++) {
       for (Int_t bc=0; bc<21; bc++) {
@@ -471,7 +471,7 @@ void AliCEPUtils::BBFlagAnalysis (
       }
     }
   }
-  
+
   // AD
   // there are 16 channels - 8 channels per side (A, C) - and 21 bc values
   AliESDAD* esdAD = (AliESDAD*)Event->GetADData();
@@ -506,10 +506,10 @@ void AliCEPUtils::BBFlagAnalysis (
 //  . dist[X,Y,Z]diam vs esd->GetSigma2Diamond[X,Y,Z]()
 void AliCEPUtils::SPDVtxAnalysis (
   AliVEvent *Event,
-  Int_t minContributors, 
-  Double_t minZdist, 
-  Double_t nSigmaZdist, 
-  Double_t nSigmaDiamXY, 
+  Int_t minContributors,
+  Double_t minZdist,
+  Double_t nSigmaZdist,
+  Double_t nSigmaDiamXY,
   Double_t nSigmaDiamZ,
   TList *lhh)
 {
@@ -521,17 +521,17 @@ void AliCEPUtils::SPDVtxAnalysis (
 
   // get the primary SPD vertex
   const AliESDVertex *SPVtx = esd->GetPrimaryVertexSPD();
-  
+
   // skip events with few tracks
   Int_t nc1=SPVtx->GetNContributors();
   ((TH1F*)lhh->At(0))->Fill(nc1);
-    
+
   if(nc1<1) return;
   Int_t nPileVert=esd->GetNumberOfPileupVerticesSPD();
   ((TH1F*)lhh->At(1))->Fill(nPileVert);
   //printf("<I - SPDVtxAnalysis> Number of pile-up vertices %i\n",nPileVert);
   if(nPileVert==0) return;
-  
+
   // loop over the pile-up vertices
   for(Int_t i=0; i<nPileVert;i++){
     const AliESDVertex* pv=esd->GetPileupVertexSPD(i);
@@ -546,7 +546,7 @@ void AliCEPUtils::SPDVtxAnalysis (
     if(esd->GetSigma2DiamondZ()<0.0001)cutZdiam=99999.; //protection for missing z diamond information
     ((TH1F*)lhh->At(3))->Fill(distZ);
     ((TH1F*)lhh->At(6))->Fill(distZdiam);
-    
+
     //printf("<I - SPDVtxAnalysis> Distances %f %f %f %f\n",
     //  distZ,minZdist,distZdiam,cutZdiam);
 	  Double_t x2=pv->GetX();
@@ -555,8 +555,8 @@ void AliCEPUtils::SPDVtxAnalysis (
 	  Double_t distYdiam=TMath::Abs(y2-esd->GetDiamondY());
     ((TH1F*)lhh->At(4))->Fill(distXdiam);
     ((TH1F*)lhh->At(5))->Fill(distYdiam);
-	  
-    Double_t cov1[6],cov2[6];	
+
+    Double_t cov1[6],cov2[6];
 	  SPVtx->GetCovarianceMatrix(cov1);
 	  pv->GetCovarianceMatrix(cov2);
 	  Double_t errxDist=TMath::Sqrt(cov2[0]+esd->GetSigma2DiamondX());
@@ -569,7 +569,7 @@ void AliCEPUtils::SPDVtxAnalysis (
     ((TH2F*)lhh->At(7))->Fill(distXdiam,errxDist);
     ((TH2F*)lhh->At(8))->Fill(distYdiam,erryDist);
     ((TH2F*)lhh->At(9))->Fill(distZdiam,errzDist);
-    
+
     //printf("<I - SPDVtxAnalysis> Resolution %f %f %f %f %f %f\n",
     //  distXdiam,cutXdiam,distYdiam,cutYdiam,distZ,nSigmaZdist*errzDist);
 
@@ -590,7 +590,7 @@ void AliCEPUtils::SPDClusterVsTrackletBGAnalysis (
   TList *lhh)
 {
   if (!lhh) return;
-  
+
   // currently only works with ESDEvent
   const AliESDEvent *esd = dynamic_cast<const AliESDEvent*>(Event);
   if (!esd) return;
@@ -603,7 +603,7 @@ void AliCEPUtils::SPDClusterVsTrackletBGAnalysis (
   ((TH1F*)lhh->At(2))->Fill(nClustersLayer0+nClustersLayer1);
   ((TH1F*)lhh->At(3))->Fill(nTracklets);
   ((TH2F*)lhh->At(4))->Fill(nClustersLayer0+nClustersLayer1,nTracklets);
-  
+
   return;
 
 }
@@ -622,14 +622,14 @@ void AliCEPUtils::VtxAnalysis (
   TList *lhh)
 {
   if (!lhh) return;
-  
+
   // currently only works with ESDEvent
   const AliESDEvent *esd = dynamic_cast<const AliESDEvent*>(Event);
   if (!esd) return;
 
   const AliESDVertex *trkVertex = esd->GetPrimaryVertexTracks();
   const AliESDVertex *spdVertex = esd->GetPrimaryVertexSPD();
-  
+
   // Note that AliVertex::GetStatus checks that N_contributors is > 0
   Bool_t hasSPD = spdVertex->GetStatus();
   Bool_t hasTrk = trkVertex->GetStatus();
@@ -638,18 +638,18 @@ void AliCEPUtils::VtxAnalysis (
   if (hasSPD) {
     ((TH1F*)lhh->At(0))->Fill(spdVertex->GetDispersion());
     ((TH1F*)lhh->At(1))->Fill(spdVertex->GetZRes());
-    
+
     if (hasTrk) {
       ((TH1F*)lhh->At(2))->Fill(
         TMath::Abs(spdVertex->GetZ() - trkVertex->GetZ()));
     }
   }
-  
+
   const AliVVertex *vertex = Event->GetPrimaryVertex();
   ((TH1F*)lhh->At(3))->Fill(TMath::Abs(vertex->GetZ()));
-  
+
   return;
-  
+
 }
 
 //------------------------------------------------------------------------------
@@ -659,7 +659,7 @@ void AliCEPUtils::V0Analysis (
   TList *lhh)
 {
   if (!lhh) return;
-  
+
   // initialisations
   AliESDv0 *V0;
   AliESDtrack *trackPos, *trackNeg;
@@ -700,14 +700,14 @@ void AliCEPUtils::V0Analysis (
     // modify the parameter in the respective call in AliCEPUtils::InitTrackCuts
     // or comment the next line
     goodPair = cut->AcceptTrack(trackPos) && cut->AcceptTrack(trackNeg);
-    
+
     // check distance to main vertex
     V0->XvYvZv(pos1);
     d = sqrt(
       (pos0[0]-pos1[0])*(pos0[0]-pos1[0])+
       (pos0[1]-pos1[1])*(pos0[1]-pos1[1])+
       (pos0[2]-pos1[2])*(pos0[2]-pos1[2]) );
-    
+
     // compute further cut parameters and fill them into the histograms
     pV0           = V0->P();
     pointingAngle = V0->GetV0CosineOfPointingAngle();
@@ -727,43 +727,43 @@ void AliCEPUtils::V0Analysis (
     pTArm    = V0->PtArmV0();
     alphaArm = V0->AlphaV0();
     printf("V0[%i] alpha/pT = %f/%f\n",fnV0dp[0],alphaArm,pTArm);
-    
+
     // not cuts
     gr = (TGraph*)lhh->At(5);
     gr->Expand(fnV0dp[0]+1,10);
     gr->SetPoint(fnV0dp[0],V0->AlphaV0(),V0->PtArmV0());
     fnV0dp[0]++;
-    
+
     // cuts 1
     if ( pointingAngle < 0.99 ) continue;
     gr = (TGraph*)lhh->At(6);
     gr->Expand(fnV0dp[1]+1,10);
     gr->SetPoint(fnV0dp[1],V0->AlphaV0(),V0->PtArmV0());
     fnV0dp[1]++;
-    
+
     // cuts 2
     if ( daughtersDCA > 0.005 ) continue;
     gr = (TGraph*)lhh->At(7);
     gr->Expand(fnV0dp[2]+1,10);
     gr->SetPoint(fnV0dp[2],V0->AlphaV0(),V0->PtArmV0());
     fnV0dp[2]++;
-    
+
     // cuts 3
     if ( d < 0.2 ) continue;
     gr = (TGraph*)lhh->At(8);
     gr->Expand(fnV0dp[3]+1,10);
     gr->SetPoint(fnV0dp[3],V0->AlphaV0(),V0->PtArmV0());
     fnV0dp[3]++;
-    
+
     // cuts 4
     if ( !goodPair ) continue;
     gr = (TGraph*)lhh->At(9);
     gr->Expand(fnV0dp[4]+1,10);
     gr->SetPoint(fnV0dp[4],V0->AlphaV0(),V0->PtArmV0());
     fnV0dp[4]++;
-    
+
   }
-  
+
 }
 
 //------------------------------------------------------------------------------
@@ -775,27 +775,27 @@ void AliCEPUtils::FMDAnalysis (
   TList *lhh)
 {
   if (!lhh) return;
-  
+
   // initialisations
   AliTriggerAnalysis::AliceSide side;
   Int_t detFrom, detTo;
-  
+
   // Workaround for AliESDEvent::GetFMDData is not const!
   const AliESDFMD* fmdData = (AliESDFMD*)Event->GetFMDData();
   if (!fmdData) {
     AliError("AliESDFMD not available");
     return;
   }
-    
+
   // loop over A and C side
   for (Int_t ii=0; ii<2; ii++) {
-  
+
     if (ii == 0) side == AliTriggerAnalysis::kASide;
     if (ii == 1) side == AliTriggerAnalysis::kCSide;
-    
+
     detFrom = (side == AliTriggerAnalysis::kASide) ? 1 : 3;
     detTo   = (side == AliTriggerAnalysis::kASide) ? 2 : 3;
-  
+
     Float_t totalMult = 0;
     for (UShort_t det=detFrom;det<=detTo;det++) {
       Int_t nRings = (det == 1 ? 1 : 2);
@@ -844,7 +844,7 @@ Int_t AliCEPUtils::AnalyzeTracks(AliESDEvent* fESDEvent,
 
   // prepare for pplication of track cuts
   AliESDtrackCuts *cut;
-  
+
   // prepare for the FiredChips test
   const AliMultiplicity *mult = fESDEvent->GetMultiplicity();
   Int_t statusLay;
@@ -852,29 +852,29 @@ Int_t AliCEPUtils::AnalyzeTracks(AliESDEvent* fESDEvent,
   Float_t xloc,zloc;
   UInt_t Modules[2],eq,hs,chip;
   Bool_t goodtrack,ktmp;
-  
+
   // get the fired chips
   TArrayI *fFiredChips = new TArrayI(1200);
   Int_t nFiredChips = 0;
   for (Int_t ii=0; ii<1200; ii++) {
     // was chip fired?
     if (!mult->TestFiredChipMap(ii)) continue;
-    
+
     // get the module of the fired chip
     AliSPDUtils::GetOnlineFromOfflineChipKey(ii,eq,hs,chip);
     fFiredChips->SetAt(AliSPDUtils::GetOfflineModuleFromOnline(eq,hs,chip),nFiredChips);
     nFiredChips++;
   }
   fFiredChips->Set(nFiredChips);
-  
+
   // retrieve main vertex
   const AliVVertex *vtx = fESDEvent->GetPrimaryVertex();
-  
+
   // prepare magnetic field for propagation to DCA
   Double_t bfield = fESDEvent->GetMagneticField();
   Double_t dca[2], cov[3];
 
-  // initialize V0 daughters    
+  // initialize V0 daughters
   TArrayI *v0daughters = new TArrayI(nTracks);
   v0daughters->Reset(kFALSE);
   Int_t nV0  = fESDEvent->GetNumberOfV0s();
@@ -887,7 +887,7 @@ Int_t AliCEPUtils::AnalyzeTracks(AliESDEvent* fESDEvent,
     v0daughters->SetAt(kTRUE,V0->GetNindex());
     // printf("V0 daughters: %i - %i %i\n",nTracks,V0->GetPindex(),V0->GetNindex());
   }
-  
+
   // loop over all tracks of fESDEvent
   // determine the TrackStatus
   AliESDtrack* track = NULL;
@@ -895,32 +895,32 @@ Int_t AliCEPUtils::AnalyzeTracks(AliESDEvent* fESDEvent,
     track = (AliESDtrack*) fESDEvent->GetTrack(ii);
     track->SetESDEvent(fESDEvent);
     if (!track) continue;
-    
+
     // add track to buffer
     fTracks->Add(track);
-    
+
     // go through the list of selection tests
     // and update the TrackStatus word trackstat accordingly
     // see AliCEPBase.h for a definition of the TrackStatus word bits
     // initialize trackstat
     trackstat = AliCEPBase::kTTBaseLine;
-    
+
     // TOFBunchCrossing
     if (track->GetTOFBunchCrossing() == 0) ;
       trackstat |=  AliCEPBase::kTTTOFBunchCrossing;
 
-    // number of TPC shared clusters <= fTPCnclsS(3)    
+    // number of TPC shared clusters <= fTPCnclsS(3)
     if (track->GetTPCnclsS() <= fTPCnclsS)
       trackstat |=  AliCEPBase::kTTTPCScluster;
-    
+
     // DCA to vertex is < 500
     if (vtx) {
       Bool_t DCAok =
-        track->PropagateToDCA(vtx,bfield,fTrackDCA,dca,cov); 
+        track->PropagateToDCA(vtx,bfield,fTrackDCA,dca,cov);
        if (DCAok)
         trackstat |=  AliCEPBase::kTTDCA;
     }
-    
+
     // is a daughter of a V0
     if (v0daughters->At(ii))
       trackstat |= AliCEPBase::kTTV0;
@@ -932,11 +932,11 @@ Int_t AliCEPUtils::AnalyzeTracks(AliESDEvent* fESDEvent,
     // |Zv-VtxZ| <= fTrackDCAz(6)
     if (vtx) {
       Bool_t DCAzok = TMath::Abs(track->Zv() - vtx->GetZ()) <= fTrackDCAz;
-      if (DCAzok) 
+      if (DCAzok)
         trackstat |= AliCEPBase::kTTZv;
     }
-    
-    // fTrackEtaMin(-0.9)<eta<fTrackEtaMax(0.9)    
+
+    // fTrackEtaMin(-0.9)<eta<fTrackEtaMax(0.9)
     if (track->Eta() >= fTrackEtaMin && track->Eta() <= fTrackEtaMax)
       trackstat |= AliCEPBase::kTTeta;
 
@@ -952,7 +952,7 @@ Int_t AliCEPUtils::AnalyzeTracks(AliESDEvent* fESDEvent,
       if (cut->AcceptTrack(track))
         trackstat |= AliCEPBase::kTTAccITSSA;
 	  }
-    
+
     // FiredChips test
     // test whether both modules associated with the track are modules
     // with fired chips
@@ -961,7 +961,7 @@ Int_t AliCEPUtils::AnalyzeTracks(AliESDEvent* fESDEvent,
     if (retc && statusLay!=5) Modules[0] = idet;
     retc = track->GetITSModuleIndexInfo(1,idet,statusLay,xloc,zloc);
     if (retc && statusLay!=5) Modules[1] = idet;
-    
+
     // check whether both modules are modules of fired chips
     goodtrack = kTRUE;
     for (Int_t iM = 0; iM<2; iM++) {
@@ -981,11 +981,11 @@ Int_t AliCEPUtils::AnalyzeTracks(AliESDEvent* fESDEvent,
     }
     if (goodtrack)
       trackstat |= AliCEPBase::kTTFiredChips;
-    
+
     // save trackstat
     fTrackStatus->AddAt(trackstat,ii);
   }
-  
+
   fFiredChips->Reset();
   delete fFiredChips;
   v0daughters->Reset();
@@ -998,7 +998,7 @@ Int_t AliCEPUtils::AnalyzeTracks(AliESDEvent* fESDEvent,
 // ------------------------------------------------------------------------------
 Bool_t AliCEPUtils::checkstatus(UInt_t stat, UInt_t mask, UInt_t pattern)
 {
-  
+
   // mask defines which bits of stat and pattern must agree
   return (stat & mask) == pattern;
 
@@ -1007,14 +1007,14 @@ Bool_t AliCEPUtils::checkstatus(UInt_t stat, UInt_t mask, UInt_t pattern)
 // ------------------------------------------------------------------------------
 Int_t AliCEPUtils::countstatus(TArrayI *stats, UInt_t mask, UInt_t pattern)
 {
-  
+
   // initialisations
   Int_t ngood = 0;
-  
+
   for (Int_t ii=0; ii<stats->GetSize(); ii++) {
     if (checkstatus(stats->At(ii),mask,pattern)) ngood++;
   }
-  
+
   return ngood;
 
 }
@@ -1027,13 +1027,13 @@ Int_t AliCEPUtils::countstatus(TArrayI *stats, UInt_t mask, UInt_t pattern, TArr
   Int_t ngood = 0;
   indices->Reset(0);
   indices->Set(stats->GetSize());
-  
+
   for (Int_t ii=0; ii<stats->GetSize(); ii++) {
     if (checkstatus(stats->At(ii),mask,pattern)) {
-      
+
       // increment the counter
       ngood++;
-    
+
       // update the indices
       indices->SetAt(ii,ngood-1);
       // printf("%i ",ii);
@@ -1041,7 +1041,7 @@ Int_t AliCEPUtils::countstatus(TArrayI *stats, UInt_t mask, UInt_t pattern, TArr
   }
   indices->Set(ngood);
   // printf("\n");
-  
+
   return ngood;
 
 }
@@ -1053,7 +1053,7 @@ Int_t AliCEPUtils::countstatus(TArrayI *stats,
 
   // checks status words with masks and patterns
   // makes logical OR of all tests
-  
+
   // initialisations
   Bool_t ktmp;
   Int_t ngood = 0;
@@ -1064,20 +1064,20 @@ Int_t AliCEPUtils::countstatus(TArrayI *stats,
   Int_t nstats = stats->GetSize();
 
   for (Int_t ii=0; ii<nstats; ii++) {
-    
+
     ktmp = kFALSE;
     for (Int_t jj=0; jj<ntests;jj++) {
-      
+
       if (checkstatus(stats->At(ii),masks->At(jj),patterns->At(jj))) {
         ktmp = kTRUE;
         break;
       }
     }
-      
+
     if (ktmp) ngood++;
 
   }
-  
+
   return ngood;
 
 }
@@ -1089,7 +1089,7 @@ Int_t AliCEPUtils::countstatus(TArrayI *stats,
 
   // checks status words with masks and patterns
   // makes logical OR of all tests
-  
+
   // initialisations
   Bool_t ktmp;
   Int_t ngood = 0;
@@ -1102,7 +1102,7 @@ Int_t AliCEPUtils::countstatus(TArrayI *stats,
   indices->Set(nstats);
 
   for (Int_t ii=0; ii<nstats; ii++) {
-    
+
     // printf("status[%i]: %i\n",ii,stats->At(ii));
     ktmp = kFALSE;
     for (Int_t jj=0; jj<ntests;jj++) {
@@ -1115,21 +1115,21 @@ Int_t AliCEPUtils::countstatus(TArrayI *stats,
       }
     }
     // printf("\n");
-      
+
     if (ktmp) {
       // increment the counter
       ngood++;
-    
+
       // update the indices
       indices->SetAt(ii,ngood-1);
       // printf("%i ",ii);
-      
+
     }
 
   }
   indices->Set(ngood);
   // printf("\n");
-  
+
   return ngood;
 
 }
@@ -1147,7 +1147,7 @@ Int_t AliCEPUtils::GetCEPTracks (
   // 4. 3. && kTTeta && (kTTAccITSTPC || kTTAccITSSA) -> nTrackAccept
   // 5. nTrackSel>=npureITSTracks && nTrackSel>=nTracklets && nTrackAccept==nTrackSel
   // 6. pass fpassedFiredChipsTest
-  //  
+  //
   // if all criteria are met the event is accepted and the number of
   // good tracks is nTrackSel = nMartinSel
   //
@@ -1157,7 +1157,7 @@ Int_t AliCEPUtils::GetCEPTracks (
   //  -4: more tracklets or ITSpure tracks than selected tracks
   //  -3: one of the selected tracks has missed a further tests
   //  -5: not all fired chips are associated with a selected track
-  
+
   // initialisations
   UInt_t mask, pattern;
   TArrayI *masks    = new TArrayI();
@@ -1169,7 +1169,7 @@ Int_t AliCEPUtils::GetCEPTracks (
   pattern = 0;
   Int_t nbad = countstatus(stats,mask,pattern);
   if (nbad > 0) return -1;
-    
+
   // the number of tracks which are considered for further testing
   mask = AliCEPBase::kTTDCA+AliCEPBase::kTTV0+AliCEPBase::kTTITSpure+
     AliCEPBase::kTTZv;
@@ -1180,12 +1180,12 @@ Int_t AliCEPUtils::GetCEPTracks (
   mask = AliCEPBase::kTTITSpure;
   pattern = AliCEPBase::kTTITSpure;
   Int_t npureITSTracks = countstatus(stats,mask,pattern);
-    
+
   // nTrackSel>=npureITSTracks && nTrackSel>=nTracklets
   const AliMultiplicity *mult = ESDEvent->GetMultiplicity();
   Int_t nTracklets = mult->GetNumberOfTracklets();
   if (nTrackSel<npureITSTracks || nTrackSel<nTracklets) return -4;
-  
+
   // further track tests
   Int_t nTrackAccept;
   mask = AliCEPBase::kTTeta;
@@ -1199,7 +1199,7 @@ Int_t AliCEPUtils::GetCEPTracks (
   nTrackAccept = countstatus(stats,masks,patterns,indices);
   // printf("nTrackSel, nTrackAccept: %i, %i\n",nTrackSel,nTrackAccept);
   if (nTrackAccept<nTrackSel) return -3;
-  
+
   // FiredChips test
   Bool_t fpassedFiredChipsTest = TestFiredChips(ESDEvent,indices);
   if (!fpassedFiredChipsTest) return -5;
@@ -1212,7 +1212,7 @@ Int_t AliCEPUtils::GetCEPTracks (
   printf("<I - UserExec> FiredChipsTest  : %i\n",fpassedFiredChipsTest);
   printf("<I - UserExec> nTrackAccept    : %i\n",nTrackAccept);
   */
-  
+
   // clean up
   if (masks) {
     delete masks;
@@ -1226,16 +1226,16 @@ Int_t AliCEPUtils::GetCEPTracks (
     delete indices;
     indices = 0x0;
   }
-  
+
   return nTrackAccept;
-  
+
 }
 
 // ------------------------------------------------------------------------------
 Int_t AliCEPUtils::GetResiduals(AliESDEvent* fESDEvent)
 {
 
-	// determines the number of tracklets in an event, which are not 
+	// determines the number of tracklets in an event, which are not
   // associated with a track
 
 	// initialisations
@@ -1244,13 +1244,13 @@ Int_t AliCEPUtils::GetResiduals(AliESDEvent* fESDEvent)
 
 	const AliMultiplicity *mult = fESDEvent->GetMultiplicity();
 	if (mult) {
-  
+
 		for (Int_t ii = 0; ii < mult->GetNumberOfTracklets(); ii++) {
 			if (!mult->GetTrackletTrackIDs(ii,0,id1,id2))
         nResiduals++;
 		}
 	}
-  
+
   return nResiduals;
 
 }
@@ -1258,19 +1258,19 @@ Int_t AliCEPUtils::GetResiduals(AliESDEvent* fESDEvent)
 // ------------------------------------------------------------------------------
 Bool_t AliCEPUtils::TestFiredChips(AliESDEvent *esd, TArrayI *indices)
 {
-  
+
   // All fired chips must be associated with a track listed in indices
   // If there is at least one fired chip without associated track, then
-  // return kFALSE 
+  // return kFALSE
   // If no chips are fired then return kFALSE
-  
+
   // initialisations
   Bool_t retc;
   UInt_t eq,hs,chip,module;
   Int_t statusLay,idet = -1;
   Float_t xloc,zloc;
   Int_t nFiredChips = 0;
-  
+
   const AliMultiplicity *mult = esd->GetMultiplicity();
   Int_t Ntracks = indices->GetSize();
   UInt_t *Modules = new UInt_t[2*Ntracks];
@@ -1291,7 +1291,7 @@ Bool_t AliCEPUtils::TestFiredChips(AliESDEvent *esd, TArrayI *indices)
   {
     if (!mult->TestFiredChipMap(ii)) continue;
     nFiredChips++;
-    
+
     AliSPDUtils::GetOnlineFromOfflineChipKey(ii,eq,hs,chip);
     module = AliSPDUtils::GetOfflineModuleFromOnline(eq,hs,chip);
 
@@ -1300,7 +1300,7 @@ Bool_t AliCEPUtils::TestFiredChips(AliESDEvent *esd, TArrayI *indices)
     {
       if (Modules[iM]==module) ktmp = kTRUE;
     }
-    if(!ktmp) 
+    if(!ktmp)
     {
       // printf("module without track %i\n",module);
       delete[] Modules;
@@ -1364,7 +1364,7 @@ void AliCEPUtils::DetermineMCprocessType (
 
 	if (fMCEvent) {
 		AliGenEventHeader* header = fMCEvent->GenEventHeader();
-    
+
     if (header) {
 			// cover all possible generators
       //
@@ -1381,11 +1381,11 @@ void AliCEPUtils::DetermineMCprocessType (
       // Hijing
       // Pythia     Pythia
       // Toy
-      // 
+      //
       // this is the list of generators without specific header
       // DIME       Dime
       // Starlight
-		  
+
       // get the name of this generator
       fMCGenerator = TString(header->GetName());
       // printf("MC generator name: %s\n",fMCGenerator.Data());
@@ -1405,16 +1405,16 @@ void AliCEPUtils::DetermineMCprocessType (
 				default:  fMCProcessType = AliCEPBase::kProctypeND; break;
 				}
 			}
-			
+
       // DIME
 			else if (fMCGenerator == "Dime") {
 				fMCProcessType = AliCEPBase::kProctypeCD;
 			}
-			
+
       // DPMjet = Phojet
 			else if (fMCGenerator == "DPMJET") {
 				// see TDPMjet.h for definition of process codes
-        
+
         fMCProcess = ((AliGenDPMjetEventHeader*)header)->ProcessType();
 				//printf("DPMjet process type: %i\n",fMCProcess);
 				switch(fMCProcess) {
@@ -1427,14 +1427,14 @@ void AliCEPUtils::DetermineMCprocessType (
 				default: fMCProcessType = AliCEPBase::kProctypeND; break;
 				}
 			}
-      
+
 		}
-    
+
     // if (fMCProcessType == AliCEPBase::kProctypeCD)
     //   printf("Central Diffractive Event detected!\n");
     // printf("MC process ID %i\n",fMCProcess);
 	}
-  
+
 }
 
 // ------------------------------------------------------------------------------
@@ -1445,7 +1445,7 @@ void AliCEPUtils::InitTrackCuts(Bool_t IsRun1, Int_t clusterCut)
 
 	// Important message for 7TeV analysis (LHC10b,c,d,e)
 	/*
-	   Alexander Kalweit 
+	   Alexander Kalweit
 	   Email to PWG conveners on 22 Apr 2014
 	   LHC10b&c (pass2):
 	   ==================
@@ -1470,25 +1470,25 @@ void AliCEPUtils::InitTrackCuts(Bool_t IsRun1, Int_t clusterCut)
 
 	// Will be used as standard trackcuts
   // distinguish between run1 and run 2 data
-  
+
   Int_t    minclsTPC = 70;
   Int_t    minXrowsTPC = 70;
-  Float_t  minNCrossedRowsTPC = 120; 
-  Float_t  minRatioCrossedRowsOverFindableClustersTPC = 0.8; 
+  Float_t  minNCrossedRowsTPC = 120;
+  Float_t  minRatioCrossedRowsOverFindableClustersTPC = 0.8;
   Float_t  maxFractionSharedTPCCluster = 0.4;
   Double_t maxchi2perTPCcl = 4.;
   Double_t maxdcazITSTPC = 2.0;
-  
+
   // with selPrimaries=kTRUE tracks associated with V0s are suppressed
   // to study V0s this needs be set to kFALSE
   Bool_t  selPrimaries = kFALSE;
-  
+
   // Run2
   if (IsRun1) {
 
     // ITS+TPC
     AliESDtrackCuts *fcutITSTPC_P = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010(selPrimaries,clusterCut);
-    
+
     fcutITSTPC_P->SetClusterRequirementITS(AliESDtrackCuts::kSPD,AliESDtrackCuts::kOff);
 		if (clusterCut == 1) {
 			fcutITSTPC_P->SetMinNCrossedRowsTPC(minXrowsTPC);
@@ -1497,7 +1497,7 @@ void AliCEPUtils::InitTrackCuts(Bool_t IsRun1, Int_t clusterCut)
 		}
 		fcutITSTPC_P->SetName("ITSTPC");
 		AddTrackCut(fcutITSTPC_P);
-		
+
     // ITS
     AliESDtrackCuts *fcutITSSA_P = AliESDtrackCuts::GetStandardITSSATrackCuts2010(selPrimaries, 0);
 		fcutITSSA_P->SetClusterRequirementITS(AliESDtrackCuts::kSPD,AliESDtrackCuts::kOff);
@@ -1505,7 +1505,7 @@ void AliCEPUtils::InitTrackCuts(Bool_t IsRun1, Int_t clusterCut)
 		AddTrackCut(fcutITSSA_P);
 
   } else { //Run2
-  
+
     // ITS+TPC
 		AliESDtrackCuts *fcutITSTPC_P = new AliESDtrackCuts;
 		fcutITSTPC_P -> SetRequireTPCRefit(kTRUE);
@@ -1515,29 +1515,29 @@ void AliCEPUtils::InitTrackCuts(Bool_t IsRun1, Int_t clusterCut)
 		fcutITSTPC_P -> SetMinRatioCrossedRowsOverFindableClustersTPC(minRatioCrossedRowsOverFindableClustersTPC);
 		fcutITSTPC_P -> SetMaxChi2PerClusterTPC(maxchi2perTPCcl);
 		fcutITSTPC_P -> SetMaxFractionSharedTPCClusters(maxFractionSharedTPCCluster);
-    
+
 		fcutITSTPC_P -> SetRequireITSRefit(kTRUE);
 		fcutITSTPC_P -> SetClusterRequirementITS(AliESDtrackCuts::kSPD,AliESDtrackCuts::kAny);
-    
+
     if (selPrimaries) {
 		  fcutITSTPC_P -> SetMaxDCAToVertexXYPtDep("(0.0182+0.0350/pt^1.01)");
 		  fcutITSTPC_P -> SetMaxChi2TPCConstrainedGlobal(36);
     }
-		
+
 		fcutITSTPC_P -> SetMaxChi2PerClusterITS(36);
     fcutITSTPC_P -> SetMaxDCAToVertexZ(maxdcazITSTPC);
 		fcutITSTPC_P -> SetEtaRange(-2.0,2.0);
 		fcutITSTPC_P -> SetPtRange(0.15);
-    
+
 		fcutITSTPC_P->SetName("ITSTPC");
 		AddTrackCut(fcutITSTPC_P);
-		
+
     // ITS
     AliESDtrackCuts *fcutITSSA_P = AliESDtrackCuts::GetStandardITSSATrackCuts2010(kTRUE, 0);
 		fcutITSSA_P->SetClusterRequirementITS(AliESDtrackCuts::kSPD,AliESDtrackCuts::kOff);
 		fcutITSSA_P->SetName("ITSSA");
 		AddTrackCut(fcutITSSA_P);
-  
+
 	}
 
 }

--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx
@@ -790,8 +790,8 @@ void AliCEPUtils::FMDAnalysis (
   // loop over A and C side
   for (Int_t ii=0; ii<2; ii++) {
 
-    if (ii == 0) side == AliTriggerAnalysis::kASide;
-    if (ii == 1) side == AliTriggerAnalysis::kCSide;
+    if (ii == 0) side = AliTriggerAnalysis::kASide;
+    if (ii == 1) side = AliTriggerAnalysis::kCSide;
 
     detFrom = (side == AliTriggerAnalysis::kASide) ? 1 : 3;
     detTo   = (side == AliTriggerAnalysis::kASide) ? 2 : 3;
@@ -906,7 +906,7 @@ Int_t AliCEPUtils::AnalyzeTracks(AliESDEvent* fESDEvent,
     trackstat = AliCEPBase::kTTBaseLine;
 
     // TOFBunchCrossing
-    if (track->GetTOFBunchCrossing() == 0) ;
+    if (track->GetTOFBunchCrossing() == 0)
       trackstat |=  AliCEPBase::kTTTOFBunchCrossing;
 
     // number of TPC shared clusters <= fTPCnclsS(3)
@@ -941,17 +941,17 @@ Int_t AliCEPUtils::AnalyzeTracks(AliESDEvent* fESDEvent,
       trackstat |= AliCEPBase::kTTeta;
 
     // accepted by ITSTPC and ITSSA criteria
-    if (cut = (AliESDtrackCuts*)fTrackCutListPrim->At(0))
+    if ((cut = (AliESDtrackCuts*)fTrackCutListPrim->At(0)))
     {
       if (cut->AcceptTrack(track)) {
         trackstat |= AliCEPBase::kTTAccITSTPC;
-	    }
+      }
     }
-    if (cut = (AliESDtrackCuts*)fTrackCutListPrim->At(1))
+    if ((cut = (AliESDtrackCuts*)fTrackCutListPrim->At(1)))
     {
       if (cut->AcceptTrack(track))
         trackstat |= AliCEPBase::kTTAccITSSA;
-	  }
+    }
 
     // FiredChips test
     // test whether both modules associated with the track are modules

--- a/PWGUD/UPC/AliAnalysisTaskUpcEtaC.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUpcEtaC.cxx
@@ -1581,11 +1581,11 @@ void AliAnalysisTaskUpcEtaC::RunAODtree()
     fTrigger[5]  = trigger.Contains("CTEST59-B"); // *0VBA *0VBC *0UBA *0UBC 0STP
     fTrigger[6]  = trigger.Contains("CTEST60-B"); // *0VBA *0VBC *0UBA *0UBC 0OM2
     fTrigger[7]  = trigger.Contains("CTEST61-B"); // *0VBA *0VBC *0UBA *0UBC 0OMU
-    fTrigger[8]  = trigger.Contains("CCUP8-B"); //*0VBA *0VBC *0UBA *0UBC 0STP 0OMU
-    fTrigger[9]  = trigger.Contains("CCUP9-B"); //*0VBA *0VBC *0UBA *0UBC 0STP
-    fTrigger[10]  = trigger.Contains("CCUP10-B"); //*0VBA *0VBC *0UBA *0UBC 0SH1
-    fTrigger[11]  = trigger.Contains("CCUP11-B"); //*0UBA *0UBC 0STP 0OMU
-    fTrigger[12]  = trigger.Contains("CCUP12-B"); //*0UBA *0UBC 0STP
+    fTrigger[8]  = trigger.Contains("CCUP8-B"); // *0VBA *0VBC *0UBA *0UBC 0STP 0OMU
+    fTrigger[9]  = trigger.Contains("CCUP9-B"); // *0VBA *0VBC *0UBA *0UBC 0STP
+    fTrigger[10]  = trigger.Contains("CCUP10-B"); // *0VBA *0VBC *0UBA *0UBC 0SH1
+    fTrigger[11]  = trigger.Contains("CCUP11-B"); // *0UBA *0UBC 0STP 0OMU
+    fTrigger[12]  = trigger.Contains("CCUP12-B"); // *0UBA *0UBC 0STP
     fTrigger[13]  = trigger.Contains("CTRUE-B"); //Unbiased trigger
   }
   if(fTracking == 8) {
@@ -2289,8 +2289,8 @@ void AliAnalysisTaskUpcEtaC::RunESDtree()
   fTrigger[5]  = trigger.Contains("CTEST59-B"); // *0VBA *0VBC *0UBA *0UBC 0STP
   fTrigger[6]  = trigger.Contains("CTEST60-B"); // *0VBA *0VBC *0UBA *0UBC 0OM2
   fTrigger[7]  = trigger.Contains("CTEST61-B"); // *0VBA *0VBC *0UBA *0UBC 0OMU
-  fTrigger[8]  = trigger.Contains("CCUP8-B"); //*0VBA *0VBC *0UBA *0UBC 0STP 0OMU
-  fTrigger[9]  = trigger.Contains("CCUP9-B"); //*0VBA *0VBC *0UBA *0UBC 0STP
+  fTrigger[8]  = trigger.Contains("CCUP8-B"); // *0VBA *0VBC *0UBA *0UBC 0STP 0OMU
+  fTrigger[9]  = trigger.Contains("CCUP9-B"); // *0VBA *0VBC *0UBA *0UBC 0STP
   
   Bool_t isTriggered = kFALSE;
   for(Int_t i=0; i<ntrg; i++) {

--- a/PWGUD/UPC/AliAnalysisTaskUpcTree.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUpcTree.cxx
@@ -582,9 +582,9 @@ void AliAnalysisTaskUpcTree::UserExec(Option_t *){
       for (Int_t ipart=0;ipart<fInputEvent->GetNumberOfTracks();ipart++){
         AliESDtrack* track = (AliESDtrack*) fInputEvent->GetTrack(ipart);
         ULong_t status = track->GetStatus();
-        if (status & AliESDtrack::kITSin     == 0) continue;
-        if (status & AliESDtrack::kTPCin     != 0) continue;
-        if (status & AliESDtrack::kITSpureSA != 0) continue;
+        if ((status & AliESDtrack::kITSin)     == 0) continue;
+        if ((status & AliESDtrack::kTPCin)     != 0) continue;
+        if ((status & AliESDtrack::kITSpureSA) != 0) continue;
         UChar_t itsMap = track->GetITSClusterMap();
         if (!TESTBIT(itsMap,0) && !TESTBIT(itsMap,1)) continue;
         Float_t pt     = track->Pt();

--- a/PWGUD/UPC/nanoAOD/AliAnalysisTaskFilterUPCNanoAOD.cxx
+++ b/PWGUD/UPC/nanoAOD/AliAnalysisTaskFilterUPCNanoAOD.cxx
@@ -93,11 +93,11 @@ void AliAnalysisTaskFilterUPCNanoAOD::UserExec(Option_t*)
   if(trigger.Contains("CTEST59-B")) isTriggered = kTRUE; // *0VBA *0VBC *0UBA *0UBC 0STP
   if(trigger.Contains("CTEST60-B")) isTriggered = kTRUE; // *0VBA *0VBC *0UBA *0UBC 0OM2
   if(trigger.Contains("CTEST61-B")) isTriggered = kTRUE; // *0VBA *0VBC *0UBA *0UBC 0OMU
-  if(trigger.Contains("CCUP8-B")) isTriggered = kTRUE; //*0VBA *0VBC *0UBA *0UBC 0STP 0OMU
-  if(trigger.Contains("CCUP9-B")) isTriggered = kTRUE; //*0VBA *0VBC *0UBA *0UBC 0STP
-  if(trigger.Contains("CCUP10-B")) isTriggered = kTRUE; //*0VBA *0VBC *0UBA *0UBC 0SH1
-  if(trigger.Contains("CCUP11-B")) isTriggered = kTRUE; //*0UBA *0UBC 0STP 0OMU
-  if(trigger.Contains("CCUP12-B")) isTriggered = kTRUE; //*0UBA *0UBC 0STP
+  if(trigger.Contains("CCUP8-B")) isTriggered = kTRUE; // *0VBA *0VBC *0UBA *0UBC 0STP 0OMU
+  if(trigger.Contains("CCUP9-B")) isTriggered = kTRUE; // *0VBA *0VBC *0UBA *0UBC 0STP
+  if(trigger.Contains("CCUP10-B")) isTriggered = kTRUE; // *0VBA *0VBC *0UBA *0UBC 0SH1
+  if(trigger.Contains("CCUP11-B")) isTriggered = kTRUE; // *0UBA *0UBC 0STP 0OMU
+  if(trigger.Contains("CCUP12-B")) isTriggered = kTRUE; // *0UBA *0UBC 0STP
   /*/
   
   if(trigger.Contains("CCUP")) isTriggered = kTRUE; // UPC central barrel


### PR DESCRIPTION
`/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx:793:23: warning: equality comparison result unused
      [-Wunused-comparison]
    if (ii == 0) side == AliTriggerAnalysis::kASide;
                 ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx:793:23: note: use '=' to turn this equality comparison
      into an assignment
    if (ii == 0) side == AliTriggerAnalysis::kASide;
                      ^~
                      =
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx:794:23: warning: equality comparison result unused
      [-Wunused-comparison]
    if (ii == 1) side == AliTriggerAnalysis::kCSide;
                 ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx:794:23: note: use '=' to turn this equality comparison
      into an assignment
    if (ii == 1) side == AliTriggerAnalysis::kCSide;
                      ^~
                      =
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx:909:44: warning: if statement has empty body
      [-Wempty-body]
    if (track->GetTOFBunchCrossing() == 0) ;
                                           ^
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx:909:44: note: put the semicolon on a separate line to
      silence this warning
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx:944:13: warning: using the result of an assignment as a
      condition without parentheses [-Wparentheses]
    if (cut = (AliESDtrackCuts*)fTrackCutListPrim->At(0))
        ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx:944:13: note: place parentheses around the assignment to
      silence this warning
    if (cut = (AliESDtrackCuts*)fTrackCutListPrim->At(0))
            ^
        (                                               )
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx:944:13: note: use '==' to turn this assignment into an
      equality comparison
    if (cut = (AliESDtrackCuts*)fTrackCutListPrim->At(0))
            ^
            ==
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx:950:13: warning: using the result of an assignment as a
      condition without parentheses [-Wparentheses]
    if (cut = (AliESDtrackCuts*)fTrackCutListPrim->At(1))
        ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx:950:13: note: place parentheses around the assignment to
      silence this warning
    if (cut = (AliESDtrackCuts*)fTrackCutListPrim->At(1))
            ^
        (                                               )
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx:950:13: note: use '==' to turn this assignment into an
      equality comparison
    if (cut = (AliESDtrackCuts*)fTrackCutListPrim->At(1))
            ^
            ==
5 warnings generated.
`

`/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/AliAnalysisTaskUpcEtaC.cxx:1584:50: warning: '/*' within block comment [-Wcomment]
    fTrigger[8]  = trigger.Contains("CCUP8-B"); //*0VBA *0VBC *0UBA *0UBC 0STP 0OMU
                                                 ^
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/AliAnalysisTaskUpcEtaC.cxx:1585:50: warning: '/*' within block comment [-Wcomment]
    fTrigger[9]  = trigger.Contains("CCUP9-B"); //*0VBA *0VBC *0UBA *0UBC 0STP
                                                 ^
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/AliAnalysisTaskUpcEtaC.cxx:1586:52: warning: '/*' within block comment [-Wcomment]
    fTrigger[10]  = trigger.Contains("CCUP10-B"); //*0VBA *0VBC *0UBA *0UBC 0SH1
                                                   ^
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/AliAnalysisTaskUpcEtaC.cxx:1587:52: warning: '/*' within block comment [-Wcomment]
    fTrigger[11]  = trigger.Contains("CCUP11-B"); //*0UBA *0UBC 0STP 0OMU
                                                   ^
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/AliAnalysisTaskUpcEtaC.cxx:1588:52: warning: '/*' within block comment [-Wcomment]
    fTrigger[12]  = trigger.Contains("CCUP12-B"); //*0UBA *0UBC 0STP
                                                   ^
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/AliAnalysisTaskUpcEtaC.cxx:2292:48: warning: '/*' within block comment [-Wcomment]
  fTrigger[8]  = trigger.Contains("CCUP8-B"); //*0VBA *0VBC *0UBA *0UBC 0STP 0OMU
                                               ^
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/AliAnalysisTaskUpcEtaC.cxx:2293:48: warning: '/*' within block comment [-Wcomment]
  fTrigger[9]  = trigger.Contains("CCUP9-B"); //*0VBA *0VBC *0UBA *0UBC 0STP
                                               ^
7 warnings generated.
`

`/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/AliAnalysisTaskUpcTree.cxx:585:20: warning: & has lower precedence than ==; == will be
      evaluated first [-Wparentheses]
        if (status & AliESDtrack::kITSin     == 0) continue;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/AliAnalysisTaskUpcTree.cxx:585:20: note: place parentheses around the '==' expression to
      silence this warning
        if (status & AliESDtrack::kITSin     == 0) continue;
                   ^
                     (                           )
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/AliAnalysisTaskUpcTree.cxx:585:20: note: place parentheses around the & expression to
      evaluate it first
        if (status & AliESDtrack::kITSin     == 0) continue;
                   ^
            (                           )
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/AliAnalysisTaskUpcTree.cxx:586:20: warning: & has lower precedence than !=; != will be
      evaluated first [-Wparentheses]
        if (status & AliESDtrack::kTPCin     != 0) continue;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/AliAnalysisTaskUpcTree.cxx:586:20: note: place parentheses around the '!=' expression to
      silence this warning
        if (status & AliESDtrack::kTPCin     != 0) continue;
                   ^
                     (                           )
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/AliAnalysisTaskUpcTree.cxx:586:20: note: place parentheses around the & expression to
      evaluate it first
        if (status & AliESDtrack::kTPCin     != 0) continue;
                   ^
            (                           )
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/AliAnalysisTaskUpcTree.cxx:587:20: warning: & has lower precedence than !=; != will be
      evaluated first [-Wparentheses]
        if (status & AliESDtrack::kITSpureSA != 0) continue;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/AliAnalysisTaskUpcTree.cxx:587:20: note: place parentheses around the '!=' expression to
      silence this warning
        if (status & AliESDtrack::kITSpureSA != 0) continue;
                   ^
                     (                           )
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/AliAnalysisTaskUpcTree.cxx:587:20: note: place parentheses around the & expression to
      evaluate it first
        if (status & AliESDtrack::kITSpureSA != 0) continue;
                   ^
            (                               )
3 warnings generated.
`

`/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/nanoAOD/AliAnalysisTaskFilterUPCNanoAOD.cxx:96:57: warning: '/*' within block comment
      [-Wcomment]
  if(trigger.Contains("CCUP8-B")) isTriggered = kTRUE; //*0VBA *0VBC *0UBA *0UBC 0STP 0OMU
                                                        ^
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/nanoAOD/AliAnalysisTaskFilterUPCNanoAOD.cxx:97:57: warning: '/*' within block comment
      [-Wcomment]
  if(trigger.Contains("CCUP9-B")) isTriggered = kTRUE; //*0VBA *0VBC *0UBA *0UBC 0STP
                                                        ^
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/nanoAOD/AliAnalysisTaskFilterUPCNanoAOD.cxx:98:58: warning: '/*' within block comment
      [-Wcomment]
  if(trigger.Contains("CCUP10-B")) isTriggered = kTRUE; //*0VBA *0VBC *0UBA *0UBC 0SH1
                                                         ^
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/nanoAOD/AliAnalysisTaskFilterUPCNanoAOD.cxx:99:58: warning: '/*' within block comment
      [-Wcomment]
  if(trigger.Contains("CCUP11-B")) isTriggered = kTRUE; //*0UBA *0UBC 0STP 0OMU
                                                         ^
/Users/chm/alice/sw/SOURCES/AliPhysics/0/0/PWGUD/UPC/nanoAOD/AliAnalysisTaskFilterUPCNanoAOD.cxx:100:58: warning: '/*' within block comment
      [-Wcomment]
  if(trigger.Contains("CCUP12-B")) isTriggered = kTRUE; //*0UBA *0UBC 0STP
                                                         ^
5 warnings generated.
`