### PR TITLE
PWGGA/GammaConv:Removed LHC17a2[a,b], added LHC17f2a_fix, set IsPileU…

### DIFF
--- a/PWGGA/GammaConv/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConv/AliConvEventCuts.cxx
@@ -613,23 +613,31 @@ Bool_t AliConvEventCuts::EventIsSelected(AliVEvent *event, AliMCEvent *mcEvent){
 
   // Pile Up Rejection
   if (fIsHeavyIon == 2){
-    if(fUtils->IsFirstEventInChunk(event)){
-      if(fHistoEventCuts)fHistoEventCuts->Fill(cutindex);
-      fEventQuality = 6;
-      return kFALSE;
-    }
-    if(fRemovePileUp){
-      if(fUtils->IsPileUpEvent(event)){
-        if(fHistoEventCuts)fHistoEventCuts->Fill(cutindex);
-        if (hPileupVertexToPrimZSPDPileup) hPileupVertexToPrimZSPDPileup->Fill(distZMax);
-        fEventQuality = 6;
-        return kFALSE;
+    if(GetUseNewMultiplicityFramework()){// for Run2 pPb
+      if(fUtils->IsPileUpMV(event)){
+	if(fHistoEventCuts)fHistoEventCuts->Fill(cutindex);
+	fEventQuality = 6;
+	return kFALSE;
       }
-      if (fUtils->IsSPDClusterVsTrackletBG(event)){
-        if(fHistoEventCuts)fHistoEventCuts->Fill(cutindex);
-        if (hPileupVertexToPrimZTrackletvsHits) hPileupVertexToPrimZTrackletvsHits->Fill(distZMax);
-        fEventQuality = 11;
-        return kFALSE;
+    } else{
+      if(fUtils->IsFirstEventInChunk(event)){
+	if(fHistoEventCuts)fHistoEventCuts->Fill(cutindex);
+	fEventQuality = 6;
+	return kFALSE;
+      }
+      if(fRemovePileUp){
+	if(fUtils->IsPileUpEvent(event)){
+	  if(fHistoEventCuts)fHistoEventCuts->Fill(cutindex);
+	  if (hPileupVertexToPrimZSPDPileup) hPileupVertexToPrimZSPDPileup->Fill(distZMax);
+	  fEventQuality = 6;
+	  return kFALSE;
+	}
+	if (fUtils->IsSPDClusterVsTrackletBG(event)){
+	  if(fHistoEventCuts)fHistoEventCuts->Fill(cutindex);
+	  if (hPileupVertexToPrimZTrackletvsHits) hPileupVertexToPrimZTrackletvsHits->Fill(distZMax);
+	  fEventQuality = 11;
+	  return kFALSE;
+	}
       }
     }
   } else if(fRemovePileUp){
@@ -1880,7 +1888,8 @@ Bool_t AliConvEventCuts::SetVertexCut(Int_t vertexCut) {
 
 //-------------------------------------------------------------
 Bool_t AliConvEventCuts::GetUseNewMultiplicityFramework(){
-  if (fPeriodEnum == kLHC15o ||                                                                                            // PbPb 5TeV
+  if (fPeriodEnum == kLHC15n ||                                                                                            // pp 5TeV
+      fPeriodEnum == kLHC15o ||                                                                                            // PbPb 5TeV
       fPeriodEnum == kLHC15k1a1 || fPeriodEnum == kLHC15k1a2 || fPeriodEnum == kLHC15k1a3  || fPeriodEnum == kLHC16j7 ||   // MC PbPb 5TeV LowIR
       fPeriodEnum == kLHC16h4 ||                                                                                           // MC PbPb 5TeV added signals
       fPeriodEnum == kLHC16g1 || fPeriodEnum == kLHC16g1a || fPeriodEnum == kLHC16g1b || fPeriodEnum == kLHC16g1c ||       // MC PbPb 5TeV general purpose
@@ -1889,8 +1898,9 @@ Bool_t AliConvEventCuts::GetUseNewMultiplicityFramework(){
       fPeriodEnum == kLHC15fm ||                                                                                           // pp 13TeV
       fPeriodEnum == kLHC15g3a3 || fPeriodEnum == kLHC15g3c3 ||                                                            // MC pp 13TeV
       fPeriodEnum == kLHC16q || fPeriodEnum == kLHC16t ||                                                                  // pPb 5TeV LHC16qt
-      fPeriodEnum == kLHC17a2a || fPeriodEnum == kLHC17a2a_fast || fPeriodEnum == kLHC17a2a_cent || fPeriodEnum == kLHC17a2a_cent_woSDD || // MC pPb 5TeV LHC16qt
-      fPeriodEnum == kLHC17a2b || fPeriodEnum == kLHC17a2b_fast || fPeriodEnum == kLHC17a2b_cent || fPeriodEnum == kLHC17a2b_cent_woSDD    // MC pPb 5TeV LHC16qt
+      fPeriodEnum == kLHC17f2a || fPeriodEnum == kLHC17f2a_fast || fPeriodEnum == kLHC17f2a_cent || fPeriodEnum == kLHC17f2a_cent_woSDD || // MC pPb 5TeV LHC16qt
+      fPeriodEnum == kLHC17f2a_fast_fix || fPeriodEnum == kLHC17f2a_cent_fix || fPeriodEnum == kLHC17f2a_cent_woSDD_fix                 || // MC pPb 5TeV LHC16qt
+      fPeriodEnum == kLHC17f2b || fPeriodEnum == kLHC17f2b_fast || fPeriodEnum == kLHC17f2b_cent || fPeriodEnum == kLHC17f2b_cent_woSDD    // MC pPb 5TeV LHC16qt
       ){
       return kTRUE;
   } else {
@@ -4799,30 +4809,6 @@ void AliConvEventCuts::SetPeriodEnum (TString periodName){
     fPeriodEnum = kLHC17f8e;
     fEnergyEnum = k13TeV;
   // LHC16qt anchored MCs
-  } else if (periodName.CompareTo("LHC17a2a") == 0){
-    fPeriodEnum = kLHC17a2a;
-    fEnergyEnum = kpPb5TeV;
-  } else if (periodName.CompareTo("LHC17a2a_fast") == 0){
-    fPeriodEnum = kLHC17a2a_fast;
-    fEnergyEnum = kpPb5TeV;
-  } else if (periodName.CompareTo("LHC17a2a_cent") == 0){
-    fPeriodEnum = kLHC17a2a_cent;
-    fEnergyEnum = kpPb5TeV;
-  } else if (periodName.CompareTo("LHC17a2a_cent_woSDD") == 0){
-    fPeriodEnum = kLHC17a2a_cent_woSDD;
-    fEnergyEnum = kpPb5TeV;
-  } else if (periodName.CompareTo("LHC17a2b") == 0){
-    fPeriodEnum = kLHC17a2b;
-    fEnergyEnum = kpPb5TeV;
-  } else if (periodName.CompareTo("LHC17a2b_fast") == 0){
-    fPeriodEnum = kLHC17a2b_fast;
-    fEnergyEnum = kpPb5TeV;
-  } else if (periodName.CompareTo("LHC17a2b_cent") == 0){
-    fPeriodEnum = kLHC17a2b_cent;
-    fEnergyEnum = kpPb5TeV;
-  } else if (periodName.CompareTo("LHC17a2b_cent_woSDD") == 0){
-    fPeriodEnum = kLHC17a2b_cent_woSDD;
-    fEnergyEnum = kpPb5TeV;
   } else if (periodName.CompareTo("LHC17f2a") == 0){
     fPeriodEnum = kLHC17f2a;
     fEnergyEnum = kpPb5TeV;
@@ -4834,6 +4820,15 @@ void AliConvEventCuts::SetPeriodEnum (TString periodName){
     fEnergyEnum = kpPb5TeV;
   } else if (periodName.CompareTo("LHC17f2a_cent_woSDD") == 0){
     fPeriodEnum = kLHC17f2a_cent_woSDD;
+    fEnergyEnum = kpPb5TeV;
+  } else if (periodName.CompareTo("LHC17f2a_fast_fix") == 0){
+    fPeriodEnum = kLHC17f2a_fast_fix;
+    fEnergyEnum = kpPb5TeV;
+  } else if (periodName.CompareTo("LHC17f2a_cent_fix") == 0){
+    fPeriodEnum = kLHC17f2a_cent_fix;
+    fEnergyEnum = kpPb5TeV;
+  } else if (periodName.CompareTo("LHC17f2a_cent_woSDD_fix") == 0){
+    fPeriodEnum = kLHC17f2a_cent_woSDD_fix;
     fEnergyEnum = kpPb5TeV;
   } else if (periodName.CompareTo("LHC17f2b") == 0){
     fPeriodEnum = kLHC17f2b;

--- a/PWGGA/GammaConv/AliConvEventCuts.h
+++ b/PWGGA/GammaConv/AliConvEventCuts.h
@@ -244,14 +244,6 @@ class AliConvEventCuts : public AliAnalysisCuts {
 	kLHC17f8d,         //!< anchored LHC16j pass 1 - Pythia8+JJ 
 	kLHC17f8e,         //!< anchored LHC16o pass 1 - Pythia8+JJ   
 	//General purpose- pPb
-        kLHC17a2a,            //!< anchored LHC16qt pass 1 - general purpose EPOSLHC
-        kLHC17a2a_fast,       //!< anchored LHC16qt pass 1 - general purpose EPOSLHC, fast only
-        kLHC17a2a_cent,       //!< anchored LHC16qt pass 1 - general purpose EPOSLHC, CENT
-        kLHC17a2a_cent_woSDD, //!< anchored LHC16qt pass 1 - general purpose EPOSLHC, CENT woSDD
-        kLHC17a2b,            //!< anchored LHC16qt pass 1 - general purpose DPMJET
-        kLHC17a2b_fast,       //!< anchored LHC16qt pass 1 - general purpose DPMJET,  fast only
-        kLHC17a2b_cent,       //!< anchored LHC16qt pass 1 - general purpose DPMJET,  CENT
-        kLHC17a2b_cent_woSDD, //!< anchored LHC16qt pass 1 - general purpose DPMJET,  CENT woSDD
         kLHC17a3a,            //!< anchored LHC16r pass 1 - general purpose EPOSLHC
         kLHC17a3a_fast,       //!< anchored LHC16r pass 1 - general purpose EPOSLHC, fast only
         kLHC17a3a_cent,       //!< anchored LHC16r pass 1 - general purpose EPOSLHC, CENT
@@ -268,11 +260,13 @@ class AliConvEventCuts : public AliAnalysisCuts {
         kLHC17a4b_fast,       //!< anchored LHC16s pass 1 - general purpose DPMJET,  fast only
         kLHC17a4b_cent,       //!< anchored LHC16s pass 1 - general purpose DPMJET,  CENT
         kLHC17a4b_cent_woSDD, //!< anchored LHC16s pass 1 - general purpose DPMJET,  CENT woSDD
-
         kLHC17f2a,            //!< anchored LHC16qt pass 1 - general purpose EPOSLHC
         kLHC17f2a_fast,       //!< anchored LHC16qt pass 1 - general purpose EPOSLHC, fast only
         kLHC17f2a_cent,       //!< anchored LHC16qt pass 1 - general purpose EPOSLHC, CENT
         kLHC17f2a_cent_woSDD, //!< anchored LHC16qt pass 1 - general purpose EPOSLHC, CENT woSDD
+        kLHC17f2a_fast_fix,       //!< anchored LHC16qt pass 1 - general purpose EPOSLHC, fast only  2nd cycle
+        kLHC17f2a_cent_fix,       //!< anchored LHC16qt pass 1 - general purpose EPOSLHC, CENT       2nd cycle
+        kLHC17f2a_cent_woSDD_fix, //!< anchored LHC16qt pass 1 - general purpose EPOSLHC, CENT woSDD 2nd cycle
         kLHC17f2b,            //!< anchored LHC16qt pass 1 - general purpose DPMJET
         kLHC17f2b_fast,       //!< anchored LHC16qt pass 1 - general purpose DPMJET,  fast only
         kLHC17f2b_cent,       //!< anchored LHC16qt pass 1 - general purpose DPMJET,  CENT
@@ -653,7 +647,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
   private:
 
       /// \cond CLASSIMP
-      ClassDef(AliConvEventCuts,34)
+      ClassDef(AliConvEventCuts,35)
       /// \endcond
 };
 


### PR DESCRIPTION
1. LHC17a2[a,b] are deleted and LHC17f2[a,b] (_fix) are re-produced. [https://alice.its.cern.ch/jira/browse/ALIROOT-7100?page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&focusedCommentId=195093](url) 
2. Use IsPileUpMV() as default pileup cut for Run2 pPb
[https://indico.cern.ch/event/642267/contributions/2607214/attachments/1466276/2266861/MultiVertPileup-pp-pPb.pdf](url)