### PR TITLE
Added base for MCLEGO trains with Therminator2

### DIFF
--- a/PWG/MCLEGO/CMakeLists.txt
+++ b/PWG/MCLEGO/CMakeLists.txt
@@ -65,3 +65,9 @@ install(DIRECTORY AMPT
   DESTINATION PWG/MCLEGO
   FILES_MATCHING PATTERN "*.ampt"
   )
+
+# install THERMINATOR2 configurations
+install(DIRECTORY Therminator2
+  DESTINATION PWG/MCLEGO
+  FILES_MATCHING PATTERN "*.ini"
+  )

--- a/PWG/MCLEGO/Therminator2/events.ini
+++ b/PWG/MCLEGO/Therminator2/events.ini
@@ -1,0 +1,99 @@
+#********************************************************************************
+#*                                                                              *
+#*             THERMINATOR 2: THERMal heavy-IoN generATOR 2                     *
+#*                                                                              *
+#* Version:                                                                     *
+#*      Release, 2.0.3, 1 February 2011                                         *
+#*                                                                              *
+#* Authors:                                                                     *
+#*      Mikolaj Chojnacki   (Mikolaj.Chojnacki@ifj.edu.pl)                      *
+#*      Adam Kisiel         (kisiel@if.pw.edu.pl)                               *
+#*      Wojciech Broniowski (Wojciech.Broniowski@ifj.edu.pl)                    *
+#*      Wojciech Florkowski (Wojciech.Florkowski@ifj.edu.pl)                    *
+#*                                                                              *
+#* Project homepage:                                                            *
+#*      http://therminator2.ifj.edu.pl/                                         *
+#*                                                                              *
+#* For the detailed description of the program and further references           *
+#* to the description of the model please refer to                              *
+#* http://arxiv.org/abs/1102.0273                                               *
+#*                                                                              *
+#* This code can be freely used and redistributed. However if you decide to     *
+#* make modifications to the code, please, inform the authors.                  *
+#* Any publication of results obtained using this code must include the         *
+#* reference to arXiv:1102.0273 and the published version of it, when           *
+#* available.                                                                   *
+#*                                                                              *
+#********************************************************************************/
+
+[FreezeOut]
+# ----------------------|-------------------------------|
+#   FreezeOutModel      |  FreezeOutModelINI            |
+# ----------------------|-------------------------------|
+#   KrakowSFO           |  fomodel/krakow.ini           |
+#   BlastWave           |  fomodel/blastwave.ini        |
+#   BWAVT               |  fomodel/bwa.ini              |
+#   BWAVTDelay          |  fomodel/bwa.ini              |
+#   BWAVLinear          |  fomodel/bwa.ini              |
+#   BWAVLinearDelay     |  fomodel/bwa.ini              |
+#   BWAVLinearFormation |  fomodel/bwa.ini              |
+#   Lhyquid3D           |  fomodel/lhyquid3d.ini        |
+#   Lhyquid2DBI         |  fomodel/lhyquid2dbi.ini      |
+# ----------------------|-------------------------------|
+# Name of the freeze-out model
+# available: see table above
+# default:	Lhyquid2DBI
+FreezeOutModel = Lhyquid2DBI
+
+# Custom freeze-out model ini file [not used by default]
+# default:
+# FreezeOutModelINI =
+
+[Event]
+# Number of events to generate 
+# default:	50000
+NumberOfEvents = 50000
+
+# Event output file format
+# available:	root, root&text, text
+# default:	root
+EventFileType = text
+
+[Primordial]
+# Distribution of primordial particles multiplicity
+# available:	Poisson
+# default:	Poisson
+MultiplicityDistribution = Poisson
+
+# Number of samples used in determination of
+# primordial multiplicity and max. integrand value
+# default:	5000000
+IntegrateSamples = 5000000
+
+[Random]
+# Start each event with a new random seed taken from current time (1)
+# or do a constant seed (0)
+# default:	1
+Randomize = 0
+
+[Directories]
+# Directory with SHARE input files
+# default:	share/
+ShareDir = share/
+
+# Directory with Freeze-Out Model parameter files
+# default:	fomodels/
+FreezeOutDir = fomodel/
+
+# Directory with ROOT macro files *.C
+# default:	macro/
+MacroDir = macro/
+
+# Directory to write the events
+# default:	events/
+EventDir = events/
+
+[Logging]
+# Log file
+# default:	therminator.log
+LogFile = therminator.log

--- a/PWG/MCLEGO/Therminator2/events.ini
+++ b/PWG/MCLEGO/Therminator2/events.ini
@@ -74,7 +74,7 @@ IntegrateSamples = 5000000
 # Start each event with a new random seed taken from current time (1)
 # or do a constant seed (0)
 # default:	1
-Randomize = 0
+Randomize = 1
 
 [Directories]
 # Directory with SHARE input files

--- a/PWG/MCLEGO/Therminator2/gen_therm2.sh
+++ b/PWG/MCLEGO/Therminator2/gen_therm2.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+if [[ $# -lt 1 ]]; then
+    echo "You must specify at least where to write output to as first parameter."
+    exit -1
+fi
+
+echo "running in `pwd`, writing HepMC to $1"
+
+# prepare environment
+# source /cvmfs/alice.cern.ch/etc/login.sh
+
+if [ -d events/ ];
+then
+    rm -rf events/
+fi
+mkdir events
+mkdir events/lhyquid2dbi-RHICAuAu200c2030Ti455ti025Tf145
+
+cp ${ALICE_PHYSICS}/PWG/MCLEGO/Therminator2/events.ini .
+cp -r $THERMINATOR2_ROOT/fomodel .
+cp -r $THERMINATOR2_ROOT/share .
+cp -r $THERMINATOR2_ROOT/macro .
+
+mkfifo events/lhyquid2dbi-RHICAuAu200c2030Ti455ti025Tf145/event.txt
+
+therm2_events events.ini 0 &
+therm2_parser events/lhyquid2dbi-RHICAuAu200c2030Ti455ti025Tf145/event.txt $1 
+


### PR DESCRIPTION
I added a default configuration file and a gen_therm2.sh script which should enable running MCLEGO trains with Therminator2 and parsing them to HepMC.