### PR TITLE
[ALPHY-81] Fix primary vertex position handling in cluster container

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
@@ -1526,10 +1526,16 @@ Bool_t AliAnalysisTaskEmcal::RetrieveEventObjects()
   AliEmcalContainer* cont = 0;
 
   TIter nextPartColl(&fParticleCollArray);
-  while ((cont = static_cast<AliEmcalContainer*>(nextPartColl()))) cont->NextEvent();
+  while ((cont = static_cast<AliEmcalContainer*>(nextPartColl()))){
+    cont->NextEvent();
+    cont->SetVertex(fVertex);
+  }
 
   TIter nextClusColl(&fClusterCollArray);
-  while ((cont = static_cast<AliParticleContainer*>(nextClusColl()))) cont->NextEvent();
+  while ((cont = static_cast<AliParticleContainer*>(nextClusColl()))){
+    cont->NextEvent();
+    cont->SetVertex(fVertex);
+  }
 
   return kTRUE;
 }

--- a/PWG/EMCAL/EMCALbase/AliEmcalContainer.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalContainer.h
@@ -154,6 +154,7 @@ class AliEmcalContainer : public TObject {
   void                        ResetCurrentID(Int_t i=-1)            { fCurrentID = i                    ; }
   virtual void                SetArray(const AliVEvent *event);
   void                        SetArrayName(const char *n)           { fClArrayName = n                  ; }
+  void                        SetVertex(Double_t *vtx)              { memcpy(fVertex, vtx, sizeof(Double_t) * 3); }
   void                        SetBitMap(UInt_t m)                   { fBitMap = m                       ; }
   void                        SetIsParticleLevel(Bool_t b)          { fIsParticleLevel = b              ; }
   void                        SortArray()                           { fClArray->Sort()                  ; }


### PR DESCRIPTION
The position of the primary vertex has to be set per event. Instead it was
handled in SetArray, which is only called in ExecOnce. A setter function for
the primary vertex was added, and it is called automatically in AliAnalysisTaskEmcal
in function run. Affects momentum vector calculation for neutral constituents in
AliEmcalJetTask (jetfinder task of the EMCAL jet framework).
(see https://alice.its.cern.ch/jira/browse/ALPHY-81 for more details)