### PR TITLE
Changing to corrected energy, prepare for charged jets

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.h
@@ -158,6 +158,11 @@ public:
     kTNDroppedTrue = 38,
     kTNVar = 39
   };
+  enum JetType_t{
+    kFull = 0,
+    kCharged = 1
+  };
+
 	AliAnalysisTaskEmcalJetSubstructureTree();
 	AliAnalysisTaskEmcalJetSubstructureTree(const char *name);
 	virtual ~AliAnalysisTaskEmcalJetSubstructureTree();
@@ -171,7 +176,7 @@ public:
 	  fReclusterizer = reclusterizer;
 	}
 
-	static AliAnalysisTaskEmcalJetSubstructureTree *AddEmcalJetSubstructureTreeMaker(Bool_t isMC, Bool_t isData, Double_t jetradius, AliJetContainer::ERecoScheme_t recombinationScheme, const char *name);
+	static AliAnalysisTaskEmcalJetSubstructureTree *AddEmcalJetSubstructureTreeMaker(Bool_t isMC, Bool_t isData, Double_t jetradius, JetType_t jettype, AliJetContainer::ERecoScheme_t recombinationScheme, const char *name);
 
 protected:
 	virtual void UserCreateOutputObjects();

--- a/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJetSubstructureTree.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJetSubstructureTree.C
@@ -1,3 +1,3 @@
-EmcalTriggerJets::AliAnalysisTaskEmcalJetSubstructureTree *AddTaskEmcalJetSubstructureTree(Bool_t isMC, Bool_t isData, Double_t jetradius, AliJetContainer::ERecoScheme_t recoscheme, const char *trigger) {
-  return EmcalTriggerJets::AliAnalysisTaskEmcalJetSubstructureTree::AddEmcalJetSubstructureTreeMaker(isMC, isData, jetradius, recoscheme, trigger);
+EmcalTriggerJets::AliAnalysisTaskEmcalJetSubstructureTree *AddTaskEmcalJetSubstructureTree(Bool_t isMC, Bool_t isData, Double_t jetradius, EmcalTriggerJets::AliAnalysisTaskEmcalJetSubstructureTree::JetType_t jettype, AliJetContainer::ERecoScheme_t recoscheme, const char *trigger) {
+  return EmcalTriggerJets::AliAnalysisTaskEmcalJetSubstructureTree::AddEmcalJetSubstructureTreeMaker(isMC, isData, jetradius, jettype, recoscheme, trigger);
 }


### PR DESCRIPTION
- In case of energy for neutral constituents, moving
  from raw energy to energy corrected for the hadronic component
- Prepare for charged jets:
  + Making cluster container optional
  + Adding case for charged jets in the Add function