### PR TITLE
Three commits

### DIFF
--- a/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
+++ b/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
@@ -62,6 +62,8 @@
 #include <AliMultSelection.h>
 #include <AliMultEstimator.h>
 #include <AliCentrality.h>
+#include "AliMagF.h"
+#include "TGeoGlobalMagField.h"
 #include "AliDielectronVarManager.h"
 //#include "AliFlowTrackCuts.h"
 #include "AliReducedEventInfo.h"
@@ -481,6 +483,9 @@ void AliAnalysisTaskReducedTreeMaker::FillEventInfo()
      eventInfo->fMultiplicityEstimatorPercentiles[7] = multSelection->GetMultiplicityPercentile("SPDTracklets");
      eventInfo->fMultiplicityEstimatorPercentiles[8] = multSelection->GetMultiplicityPercentile("RefMult05");
      eventInfo->fMultiplicityEstimatorPercentiles[9] = multSelection->GetMultiplicityPercentile("RefMult08");
+     eventInfo->fMultiplicityEstimatorPercentiles[10] = multSelection->GetMultiplicityPercentile("V0M");
+     eventInfo->fMultiplicityEstimatorPercentiles[11] = multSelection->GetMultiplicityPercentile("V0A");
+     eventInfo->fMultiplicityEstimatorPercentiles[12] = multSelection->GetMultiplicityPercentile("V0C");
      AliMultEstimator* estimator = 0x0;
      estimator = multSelection->GetEstimator("OnlineV0M"); if(estimator) eventInfo->fMultiplicityEstimators[0] = estimator->GetValue();
      estimator = multSelection->GetEstimator("OnlineV0A"); if(estimator) eventInfo->fMultiplicityEstimators[1] = estimator->GetValue();
@@ -491,7 +496,10 @@ void AliAnalysisTaskReducedTreeMaker::FillEventInfo()
      estimator = multSelection->GetEstimator("SPDClusters"); if(estimator) eventInfo->fMultiplicityEstimators[6] = estimator->GetValue();
      estimator = multSelection->GetEstimator("SPDTracklets"); if(estimator) eventInfo->fMultiplicityEstimators[7] = estimator->GetValue();
      estimator = multSelection->GetEstimator("RefMult05"); if(estimator) eventInfo->fMultiplicityEstimators[8] = estimator->GetValue();
-     estimator = multSelection->GetEstimator("RefMult08"); if(estimator) eventInfo->fMultiplicityEstimators[9] = estimator->GetValue();     
+     estimator = multSelection->GetEstimator("RefMult08"); if(estimator) eventInfo->fMultiplicityEstimators[9] = estimator->GetValue();   
+     estimator = multSelection->GetEstimator("V0M"); if(estimator) eventInfo->fMultiplicityEstimators[10] = estimator->GetValue();
+     estimator = multSelection->GetEstimator("V0A"); if(estimator) eventInfo->fMultiplicityEstimators[11] = estimator->GetValue();
+     estimator = multSelection->GetEstimator("V0C"); if(estimator) eventInfo->fMultiplicityEstimators[12] = estimator->GetValue();  
   }
   
   if(eventVtx){
@@ -1219,9 +1227,12 @@ void AliAnalysisTaskReducedTreeMaker::FillTrackInfo()
        
        AliESDEvent* esdEvent = static_cast<AliESDEvent*>(InputEvent());
        AliESDVertex* eventVtx = const_cast<AliESDVertex*>(esdEvent->GetPrimaryVertexTracks());
+
+       AliMagF* fld = (AliMagF*)TGeoGlobalMagField::Instance()->GetField();
        TClass* esdClass = esdTrack->Class();
-       if(esdClass->GetMethodAny("GetChi2TPCConstrainedVsGlobal"))
-          trackInfo->fChi2TPCConstrainedVsGlobal = esdTrack->GetChi2TPCConstrainedVsGlobal(eventVtx);
+       if( esdClass->GetMethodAny("GetChi2TPCConstrainedVsGlobal") && fld)
+         trackInfo->fChi2TPCConstrainedVsGlobal = esdTrack->GetChi2TPCConstrainedVsGlobal(eventVtx);
+//       if(fReducedEvent->fRunNo>245000. && fReducedEvent->fRunNo<247000.)
        
       const AliExternalTrackParam* tpcInner = esdTrack->GetTPCInnerParam();
 

--- a/PWGDQ/reducedTree/AliReducedEventInfo.h
+++ b/PWGDQ/reducedTree/AliReducedEventInfo.h
@@ -70,6 +70,10 @@ class AliReducedEventInfo : public AliReducedBaseEvent {
   Float_t   MultEstimatorSPDTracklets()   const {return fMultiplicityEstimators[7];}
   Float_t   MultEstimatorRefMult05()   const {return fMultiplicityEstimators[8];}
   Float_t   MultEstimatorRefMult08()   const {return fMultiplicityEstimators[9];}
+  Float_t   MultEstimatorV0M()   const {return fMultiplicityEstimators[10];}
+  Float_t   MultEstimatorV0A()   const {return fMultiplicityEstimators[11];}
+  Float_t   MultEstimatorV0C()   const {return fMultiplicityEstimators[12];}
+  
   Float_t   MultEstimatorPercentileOnlineV0M()   const {return fMultiplicityEstimatorPercentiles[0];}
   Float_t   MultEstimatorPercentileOnlineV0A()   const {return fMultiplicityEstimatorPercentiles[1];}
   Float_t   MultEstimatorPercentileOnlineV0C()   const {return fMultiplicityEstimatorPercentiles[2];}
@@ -80,6 +84,9 @@ class AliReducedEventInfo : public AliReducedBaseEvent {
   Float_t   MultEstimatorPercentileSPDTracklets()   const {return fMultiplicityEstimatorPercentiles[7];}
   Float_t   MultEstimatorPercentileRefMult05()   const {return fMultiplicityEstimatorPercentiles[8];}
   Float_t   MultEstimatorPercentileRefMult08()   const {return fMultiplicityEstimatorPercentiles[9];}
+  Float_t   MultEstimatorPercentileV0M()   const {return fMultiplicityEstimatorPercentiles[10];}
+  Float_t   MultEstimatorPercentileV0A()   const {return fMultiplicityEstimatorPercentiles[11];}
+  Float_t   MultEstimatorPercentileV0C()   const {return fMultiplicityEstimatorPercentiles[12];}
   
   Float_t   MultChannelVZERO(Int_t channel)   const {return (channel>=0 && channel<=63 ? fVZEROMult[channel] : -999.);}
   Float_t   MultVZEROA()                      const;
@@ -152,8 +159,8 @@ class AliReducedEventInfo : public AliReducedBaseEvent {
   UInt_t    fTimeStamp;             // time stamp of the event                
   UInt_t    fEventType;             // event type                             
   ULong64_t fTriggerMask;           // trigger mask
-  Float_t   fMultiplicityEstimators[10];   // multiplicity estimators: "OnlineV0M", "OnlineV0A", "OnlineV0C", "ADM", "ADA", "ADC", "SPDClusters", "SPDTracklets", "RefMult05", "RefMult08"
-  Float_t   fMultiplicityEstimatorPercentiles[10];   // multiplicity estimators: "OnlineV0M", "OnlineV0A", "OnlineV0C", "ADM", "ADA", "ADC", "SPDClusters", "SPDTracklets", "RefMult05", "RefMult08"
+  Float_t   fMultiplicityEstimators[13];   // multiplicity estimators: "OnlineV0M", "OnlineV0A", "OnlineV0C", "ADM", "ADA", "ADC", "SPDClusters", "SPDTracklets", "RefMult05", "RefMult08"
+  Float_t   fMultiplicityEstimatorPercentiles[13];   // multiplicity estimators: "OnlineV0M", "OnlineV0A", "OnlineV0C", "ADM", "ADA", "ADC", "SPDClusters", "SPDTracklets", "RefMult05", "RefMult08"
   Bool_t    fIsPhysicsSelection;    // PhysicsSelection passed event
   Bool_t    fIsSPDPileup;           // identified as pileup event by SPD
   Bool_t    fIsSPDPileupMultBins;   // identified as pileup event by SPD in multiplicity bins

--- a/PWGDQ/reducedTree/AliReducedVarManager.cxx
+++ b/PWGDQ/reducedTree/AliReducedVarManager.cxx
@@ -131,8 +131,16 @@ TH1I* AliReducedVarManager::fgRunTimeStart = 0x0;
 TH1I* AliReducedVarManager::fgRunTimeEnd = 0x0;
 std::vector<Int_t>  AliReducedVarManager::fgRunNumbers;
 Int_t AliReducedVarManager::fgRunID = -1;
-TH1* AliReducedVarManager::fgAvgMultVsVertex[3] = {0x0, 0x0, 0x0};
-Double_t AliReducedVarManager::fgRefMult[3] = {0., 0., 0.};
+TH1* AliReducedVarManager::fgAvgMultVsVtxGlobal      [kNMultiplicityEstimators] = {0x0};
+TH1* AliReducedVarManager::fgAvgMultVsVtxRunwise     [kNMultiplicityEstimators] = {0x0};
+TH1* AliReducedVarManager::fgAvgMultVsRun            [kNMultiplicityEstimators] = {0x0};
+TH2* AliReducedVarManager::fgAvgMultVsVtxAndRun      [kNMultiplicityEstimators] = {0x0};
+
+Double_t AliReducedVarManager::fgRefMultVsVtxGlobal  [kNMultiplicityEstimators] [kNReferenceMultiplicities] = {0.};
+Double_t AliReducedVarManager::fgRefMultVsVtxRunwise [kNMultiplicityEstimators] [kNReferenceMultiplicities] = {0.};
+Double_t AliReducedVarManager::fgRefMultVsRun        [kNMultiplicityEstimators] [kNReferenceMultiplicities] = {0.};
+Double_t AliReducedVarManager::fgRefMultVsVtxAndRun  [kNMultiplicityEstimators] [kNReferenceMultiplicities] = {0.};
+
 TString AliReducedVarManager::fgVZEROCalibrationPath = "";
 TProfile2D* AliReducedVarManager::fgAvgVZEROChannelMult[64] = {0x0};
 TProfile2D* AliReducedVarManager::fgVZEROqVecRecentering[4] = {0x0};
@@ -272,15 +280,12 @@ void AliReducedVarManager::SetVariableDependencies() {
   }
   if(fgUsedVars[kNTracksITSoutVsSPDtracklets] || fgUsedVars[kNTracksTPCoutVsSPDtracklets] ||
      fgUsedVars[kNTracksTOFoutVsSPDtracklets] || fgUsedVars[kNTracksTRDoutVsSPDtracklets])
-     fgUsedVars[kSPDntracklets] = kTRUE;
+     fgUsedVars[GetMultiplicityEstimator(kSPDntracklets10)] = kTRUE;
   
   if(fgUsedVars[kRapMC]) fgUsedVars[kMassMC] = kTRUE;
 
   if(fgUsedVars[kPairPhiV]){
     fgUsedVars[kL3Polarity] = kTRUE;
-  }
-  if(fgUsedVars[kSPDntrackletsCorr]){
-    fgUsedVars[kSPDntracklets] = kTRUE;
   }
   if(fgUsedVars[kMassDcaPtCorr] ) {
     fgUsedVars[kMass]          = kTRUE;
@@ -309,13 +314,7 @@ void AliReducedVarManager::FillEventInfo(BASEEVENT* baseEvent, Float_t* values, 
   // fill event wise info
   //
   // Basic event information
-  values[kRunNo]                   = baseEvent->RunNo();
-  if(fgUsedVars[kRunID]){
-    if( fgRunID < 0 ){
-      for( fgRunID = 0; fgRunNumbers[ fgRunID ] != values[kRunNo] && fgRunID< fgRunNumbers.size() ; ++fgRunID );
-    }
-    values[kRunID] = fgRunID;
-  }
+
   values[kVtxX]                      = baseEvent->Vertex(0);
   values[kVtxY]                       = baseEvent->Vertex(1);
   values[kVtxZ]                      = baseEvent->Vertex(2);
@@ -384,7 +383,57 @@ void AliReducedVarManager::FillEventInfo(BASEEVENT* baseEvent, Float_t* values, 
       }
       calibFile->Close();
     }
+
+    if(fgUsedVars[kRunID]){
+      if( fgRunID < 0 ){
+        for( fgRunID = 0; fgRunNumbers[ fgRunID ] != fgCurrentRunNumber && fgRunID< fgRunNumbers.size() ; ++fgRunID );
+      }
+    }
+    for( int iEstimator =0 ; iEstimator < kNMultiplicityEstimators ; ++iEstimator ){
+      if( fgAvgMultVsVtxAndRun[iEstimator] ){
+        Bool_t fillGlobal = !fgAvgMultVsVtxGlobal[iEstimator];
+        fgAvgMultVsVtxRunwise  [iEstimator] = fgAvgMultVsVtxAndRun[iEstimator]->ProfileY( Form("AvgMultVsVtxRunwise%d",iEstimator )   , fgRunID, fgRunID);
+        if( fillGlobal ){
+          fgAvgMultVsVtxGlobal [iEstimator] = fgAvgMultVsVtxAndRun[iEstimator]->ProfileY( Form("AvgMultVsVtxGlobal%d", iEstimator)    );
+          fgAvgMultVsRun       [iEstimator] = fgAvgMultVsVtxAndRun[iEstimator]->ProfileX( Form("AvgMultVsRun%d", iEstimator)  );
+        }
+        for( int iReference = 0; iReference < kNReferenceMultiplicities; ++ iReference  ){
+          Double_t refVsVtx, refVsVtxGlobal, refVsRun;
+          switch ( iReference ){
+            case kMaximumMultiplicity :
+              refVsVtx = fgAvgMultVsVtxRunwise[iEstimator]->GetMaximum();
+              if( fillGlobal ){
+                refVsVtxGlobal = fgAvgMultVsVtxGlobal[iEstimator]->GetMaximum();
+                refVsRun       = fgAvgMultVsVtxAndRun[iEstimator]->GetMaximum();
+              }
+              break;
+            case kMinimumMultiplicity :
+              refVsVtx = fgAvgMultVsVtxRunwise[iEstimator]->GetMinimum();
+              if( fillGlobal ){
+                refVsVtxGlobal = fgAvgMultVsVtxGlobal[iEstimator]->GetMinimum();
+                refVsRun       = fgAvgMultVsVtxAndRun[iEstimator]->GetMinimum();
+              }
+              break;
+            case kMeanMultiplicity :
+              refVsVtx = 0.5 * ( fgAvgMultVsVtxRunwise[iEstimator]->GetMaximum() +  fgAvgMultVsVtxRunwise[iEstimator]->GetMinimum() );
+              if( fillGlobal ){
+                refVsVtxGlobal = 0.5 * ( fgAvgMultVsVtxGlobal[iEstimator]->GetMaximum() + fgAvgMultVsVtxGlobal[iEstimator]->GetMinimum() ) ;
+                refVsRun       = 0.5 * ( fgAvgMultVsVtxAndRun[iEstimator]->GetMaximum() + fgAvgMultVsVtxAndRun[iEstimator]->GetMinimum() );
+              }
+              break;
+          }
+          fgRefMultVsVtxRunwise  [iEstimator][iReference] = refVsVtx;
+          if(fillGlobal){
+            fgRefMultVsVtxGlobal [iEstimator][iReference] = refVsVtxGlobal;
+            fgRefMultVsRun       [iEstimator][iReference] = refVsRun;
+          }
+        }
+      }
+    }
   }
+
+  values[kRunNo] = fgCurrentRunNumber;
+  values[kRunID] = fgRunID;
   
   values[kEventNumberInFile]    = event->EventNumberInFile();
   values[kBC]                   = event->BC();
@@ -400,6 +449,7 @@ void AliReducedVarManager::FillEventInfo(BASEEVENT* baseEvent, Float_t* values, 
   values[kIsPhysicsSelection]   = (event->IsPhysicsSelection() ? 1.0 : 0.0);
   values[kIsSPDPileup]          = event->IsSPDPileup();
   values[kIsSPDPileup5]         = event->EventTag(11);
+  values[kIsPileupMV]           = event->EventTag(1);
   values[kIsSPDPileupMultBins]  = event->IsSPDPileupMultBins();
   values[kNSPDpileups]          = event->NpileupSPD();
   values[kNTrackPileups]        = event->NpileupTracks();
@@ -453,28 +503,131 @@ void AliReducedVarManager::FillEventInfo(BASEEVENT* baseEvent, Float_t* values, 
     values[kNTracksTOFoutVsTRDout] = values[kNTracksPerTrackingStatus+kTOFout]/values[kNTracksPerTrackingStatus+kTRDout];
   else
      fgUsedVars[kNTracksTOFoutVsTRDout] = kFALSE;
+
+  // Multiplicity estimators
+
+  values[ GetMultiplicityEstimator(kVZEROATotalMult) ] = event->MultVZEROA();
+  values[ GetMultiplicityEstimator(kVZEROCTotalMult) ] = event->MultVZEROC();
+  values[ GetMultiplicityEstimator(kVZEROTotalMult)  ]  = event->MultVZERO();
+
+  values[ GetMultiplicityEstimator(kSPDntracklets10) ]   = event->SPDntracklets();
+  values[ GetMultiplicityEstimator(kSPDntracklets08) ] = 0.;
+  values[ GetMultiplicityEstimator(kSPDntracklets16) ] = 0.;
+  values[ GetMultiplicityEstimator(kSPDntrackletsOuterEta) ] = 0.;
+  values[ GetMultiplicityEstimator(kSPDnTrackletsEtaVtxCorr) ] = 0.;
   
-  values[kSPDntracklets]   = event->SPDntracklets();
-  if( fgUsedVars[kSPDntrackletsCorr] || fgUsedVars[kSPDntrackletsCorrSmear] ){
-      values[kSPDntrackletsCorr] = values[kSPDntracklets];
-      values[kSPDntrackletsCorrSmear] = values[kSPDntracklets];
-      if( fgAvgMultVsVertex[0] && TMath::Abs(baseEvent->Vertex(2)) < 10. ){
-        if( !fgRefMult[0] ) fgRefMult[0] = fgAvgMultVsVertex[0]->GetMaximum();
-        Double_t localAvg = fgAvgMultVsVertex[0]->GetBinContent( fgAvgMultVsVertex[0]->FindBin(baseEvent->Vertex(2)) );
-        Double_t deltaM = values[kSPDntracklets] * (fgRefMult[0]/localAvg - 1);
-        values[kSPDntrackletsCorrSmear] += (deltaM>0 ? 1. : -1.) * gRandom->Poisson(TMath::Abs(deltaM));
-        values[kSPDntrackletsCorr]      *= fgRefMult[0]/localAvg;
-      }
+  
+  
+  
+  for(Int_t ieta=0;ieta<32;++ieta) {
+    values[ GetMultiplicityEstimator(kSPDntrackletsEtaBin+ieta) ] = event->SPDntracklets(ieta);
+    if( ieta > 7 && ieta < 24 ) values[ GetMultiplicityEstimator(kSPDntracklets08) ] += event->SPDntracklets(ieta);
+    if( ieta < 7 || ieta > 24 ) values[ GetMultiplicityEstimator(kSPDntrackletsOuterEta) ] += event->SPDntracklets(ieta);
   }
+
+  for( Int_t iEstimator = 0; iEstimator < kNMultiplicityEstimators; ++iEstimator){
+    if( iEstimator == kVZEROACTotalMult || iEstimator == kSPDnTrackletsEtaVtxCorr ){
+       for( Int_t iCorrection = 0; iCorrection < kNCorrections; ++iCorrection  ){
+          for(Int_t iReference = 0 ; iReference <  kNReferenceMultiplicities; ++iReference ){
+            Int_t indexNotSmeared = GetMultiplicityEstimator( iEstimator, iCorrection, iReference, kNoSmearing );
+            Int_t indexSmeared    = GetMultiplicityEstimator( iEstimator, iCorrection, iReference, kPoissonSmearing );
+            values[indexNotSmeared] = 0.;
+            values[indexSmeared] = 0.;
+
+            if( iEstimator == kSPDnTrackletsEtaVtxCorr ){
+              for( Int_t ieta=6; ieta<26; ++ieta ) {
+                Int_t indexBinNotSmeared = GetMultiplicityEstimator( kSPDntrackletsEtaBin+ieta, iCorrection, iReference, kNoSmearing );
+                Int_t indexBinSmeared    = GetMultiplicityEstimator( kSPDntrackletsEtaBin+ieta, iCorrection, iReference, kPoissonSmearing );
+                
+                if( fgUsedVars[indexBinNotSmeared]) values[ indexNotSmeared ] += values[ indexBinNotSmeared ];
+                if( fgUsedVars[indexBinSmeared]) values[ indexSmeared ] += values[ indexBinSmeared ];
+              }
+            }
+            else{
+              Int_t indexAnotSmeared = GetMultiplicityEstimator( kVZEROATotalMult, iCorrection, iReference, kNoSmearing );
+              Int_t indexCnotSmeared = GetMultiplicityEstimator( kVZEROCTotalMult, iCorrection, iReference, kNoSmearing );
+              
+              Int_t indexAsmeared = GetMultiplicityEstimator( kVZEROATotalMult, iCorrection, iReference, kPoissonSmearing );
+              Int_t indexCsmeared = GetMultiplicityEstimator( kVZEROCTotalMult, iCorrection, iReference, kPoissonSmearing );
+              
+              values[ indexNotSmeared ] = values[ indexAnotSmeared ] + values[ indexCnotSmeared ];
+              values[ indexSmeared ]    = values[ indexAsmeared ] + values[ indexCsmeared ];
+            }
+            
+            
+          }
+       }
+      
+      
+      
+    }
+    
+    else{
+      if( fgAvgMultVsVtxAndRun[iEstimator] ){
+        Int_t vtxBin = fgAvgMultVsVtxAndRun[iEstimator]->GetYaxis()->FindBin( values[kVtxZ] );
+        Int_t runBin = fgAvgMultVsVtxAndRun[iEstimator]->GetXaxis()->FindBin( values[kRunID] );
+        Double_t multRaw = values[ GetMultiplicityEstimator(iEstimator) ];
+        for( Int_t iCorrection = 0; iCorrection < kNCorrections; ++iCorrection  ){
+          for(Int_t iReference = 0 ; iReference <  kNReferenceMultiplicities; ++iReference ){
+            Int_t indexNotSmeared = GetMultiplicityEstimator( iEstimator, iCorrection, iReference, kNoSmearing );
+            Int_t indexSmeared    = GetMultiplicityEstimator( iEstimator, iCorrection, iReference, kPoissonSmearing );
+            Double_t multCorr        = multRaw;
+            Double_t multCorrSmeared = multRaw;
+    // apply vertex and gain loss correction simultaneously
+            if( iCorrection == kVertexCorrection2D  ){
+              Double_t localAvg = fgAvgMultVsVtxAndRun[iEstimator]->GetBinContent( vtxBin, runBin);
+              Double_t refMult  = fgRefMultVsVtxAndRun[iEstimator][iReference];
+              multCorr *=  localAvg ?  refMult / localAvg : 1.;
+              Double_t deltaM =  localAvg ?  multRaw * ( refMult/localAvg - 1) : 0.;
+              multCorrSmeared += (deltaM>0 ? 1. : -1.) * gRandom->Poisson(TMath::Abs(deltaM));
+            }
+            else{
+    // first apply vertex correction
+              Double_t localAvgVsVtx, refMultVsVtx;
+              switch( iCorrection ){
+                case kVertexCorrectionGlobal:
+                case kVertexCorrectionGlobalGainLoss:
+                  localAvgVsVtx = fgAvgMultVsVtxGlobal[iEstimator]->GetBinContent( vtxBin );
+                  refMultVsVtx = fgRefMultVsVtxGlobal[iEstimator][iReference];
+                  break;
+                case kVertexCorrectionRunwise:
+                case kVertexCorrectionRunwiseGainLoss:
+                  localAvgVsVtx = fgAvgMultVsVtxRunwise[iEstimator]->GetBinContent( vtxBin );
+                  refMultVsVtx = fgRefMultVsVtxRunwise[iEstimator][iReference];
+                  break;
+              }
+              multCorr        *= localAvgVsVtx ? refMultVsVtx / localAvgVsVtx : 1.;
+              Double_t deltaM  = localAvgVsVtx ? multRaw  * ( refMultVsVtx/localAvgVsVtx - 1) : 0.;
+              multCorrSmeared += (deltaM>0 ? 1. : -1.) * gRandom->Poisson(TMath::Abs(deltaM));
+    // then apply gain loss correction
+              if( iCorrection == kVertexCorrectionGlobalGainLoss || iCorrection == kVertexCorrectionRunwiseGainLoss  ){
+                Double_t localAvgVsRun = fgAvgMultVsRun[iEstimator]->GetBinContent( runBin );
+                Double_t refMultVsRun  = fgRefMultVsRun[iEstimator][iReference];
+                multCorr        *= localAvgVsRun ? refMultVsRun / localAvgVsRun : 1.;
+                deltaM           = localAvgVsRun ? multCorrSmeared  * ( refMultVsRun/localAvgVsRun - 1) : 0;
+                multCorrSmeared += (deltaM>0 ? 1. : -1.) * gRandom->Poisson(TMath::Abs(deltaM));
+              }
+            }
+            values[ indexNotSmeared ] = multCorr;
+            values[ indexSmeared ]    = multCorrSmeared;
+            fgUsedVars [indexNotSmeared] = kTRUE;
+            fgUsedVars [indexSmeared] = kTRUE;
+            
+          }
+        }
+      }
+    }
+  }
+
   fgUsedVars[kNTracksITSoutVsSPDtracklets] = kTRUE;  
   fgUsedVars[kNTracksTPCoutVsSPDtracklets] = kTRUE;
   fgUsedVars[kNTracksTRDoutVsSPDtracklets] = kTRUE;
   fgUsedVars[kNTracksTOFoutVsSPDtracklets] = kTRUE;
-  if(values[kSPDntracklets]>0.01) {
-    values[kNTracksITSoutVsSPDtracklets] = values[kNTracksPerTrackingStatus+kITSout]/values[kSPDntracklets];
-    values[kNTracksTPCoutVsSPDtracklets] = values[kNTracksPerTrackingStatus+kTPCout]/values[kSPDntracklets];
-    values[kNTracksTRDoutVsSPDtracklets] = values[kNTracksPerTrackingStatus+kTRDout]/values[kSPDntracklets];
-    values[kNTracksTOFoutVsSPDtracklets] = values[kNTracksPerTrackingStatus+kTOFout]/values[kSPDntracklets];
+  if(values[GetMultiplicityEstimator(kSPDntracklets10)]>0.01) {
+    values[kNTracksITSoutVsSPDtracklets] = values[kNTracksPerTrackingStatus+kITSout]/values[GetMultiplicityEstimator(kSPDntracklets10)];
+    values[kNTracksTPCoutVsSPDtracklets] = values[kNTracksPerTrackingStatus+kTPCout]/values[GetMultiplicityEstimator(kSPDntracklets10)];
+    values[kNTracksTRDoutVsSPDtracklets] = values[kNTracksPerTrackingStatus+kTRDout]/values[GetMultiplicityEstimator(kSPDntracklets10)];
+    values[kNTracksTOFoutVsSPDtracklets] = values[kNTracksPerTrackingStatus+kTOFout]/values[GetMultiplicityEstimator(kSPDntracklets10)];
   }
   else {
      fgUsedVars[kNTracksITSoutVsSPDtracklets] = kFALSE;  
@@ -485,26 +638,7 @@ void AliReducedVarManager::FillEventInfo(BASEEVENT* baseEvent, Float_t* values, 
     
   values[kNCaloClusters]   = event->GetNCaloClusters();
   values[kNTPCclusters]    = event->NTPCClusters();
-  values[kSPDntracklets08] = 0.;
-  values[kSPDntracklets16] = 0.;
-  values[kSPDntrackletsOuter] = 0.;
-  for(Int_t ieta=0;ieta<32;++ieta) {
-    values[kSPDntrackletsEta+ieta] = event->SPDntracklets(ieta);
-    values[kSPDntracklets16] += event->SPDntracklets(ieta);
-    if(ieta >7 && ieta <24 ) values[kSPDntracklets08] += event->SPDntracklets(ieta);
-    if( ieta <7 || ieta > 24 ) values[kSPDntrackletsOuter] += event->SPDntracklets(ieta);
-  }
-  if( fgUsedVars[kSPDntrackletsOuterCorr] || fgUsedVars[kSPDntrackletsOuterCorrSmear] ){
-      values[kSPDntrackletsOuterCorr] = values[kSPDntrackletsOuter];
-      values[kSPDntrackletsOuterCorrSmear] = values[kSPDntrackletsOuter];
-      if( fgAvgMultVsVertex[1] && TMath::Abs(baseEvent->Vertex(2)) < 10. ){
-        if( !fgRefMult[1] ) fgRefMult[1] = fgAvgMultVsVertex[1]->GetMaximum();
-        Double_t localAvg = fgAvgMultVsVertex[1]->GetBinContent( fgAvgMultVsVertex[1]->FindBin(baseEvent->Vertex(2)) );
-        Double_t deltaM = values[kSPDntrackletsOuter] * (fgRefMult[1]/localAvg - 1);
-        values[kSPDntrackletsOuterCorrSmear] += (deltaM>0 ? 1. : -1.) * gRandom->Poisson(TMath::Abs(deltaM));
-        values[kSPDntrackletsOuterCorr]      *= fgRefMult[1]/localAvg;
-      }
-  }
+
   
   
   for(Int_t i=0;i<2;++i) values[kSPDFiredChips+i] = event->SPDFiredChips(i+1);
@@ -512,24 +646,9 @@ void AliReducedVarManager::FillEventInfo(BASEEVENT* baseEvent, Float_t* values, 
   values[kSPDnSingleClusters] = event->SPDnSingleClusters();
 
   //VZERO detector information
-  values[kVZEROATotalMult] = event->MultVZEROA();
-  values[kVZEROCTotalMult] = event->MultVZEROC();
-  values[kVZEROTotalMult]  = event->MultVZERO();
-  
-    if( fgUsedVars[kVZEROTotalMultCorr] || fgUsedVars[kVZEROTotalMultCorrSmear] ){
-      values[kVZEROTotalMultCorr] = values[kVZEROTotalMult];
-      values[kVZEROTotalMultCorrSmear] = values[kVZEROTotalMult];
-      if( fgAvgMultVsVertex[1] && TMath::Abs(baseEvent->Vertex(2)) < 10. ){
-        if( !fgRefMult[2] ) fgRefMult[2] = fgAvgMultVsVertex[2]->GetMaximum();
-        Double_t localAvg = fgAvgMultVsVertex[2]->GetBinContent( fgAvgMultVsVertex[2]->FindBin(baseEvent->Vertex(2)) );
-        Double_t deltaM = values[kVZEROTotalMult] * (fgRefMult[2]/localAvg - 1);
-        values[kVZEROTotalMultCorrSmear] += (deltaM>0 ? 1. : -1.) * gRandom->Poisson(TMath::Abs(deltaM));
-        values[kVZEROTotalMultCorr]      *= fgRefMult[2]/localAvg;
-      }
-  }
   fgUsedVars[kNTracksTPCoutVsVZEROTotalMult] = kTRUE;
-  if(values[kVZEROTotalMult]>1.0e-5) 
-     values[kNTracksTPCoutVsVZEROTotalMult] = values[kNTracksPerTrackingStatus+kTPCout] / values[kVZEROTotalMult];
+  if(values[GetMultiplicityEstimator(kVZEROTotalMult)]>1.0e-5)
+     values[kNTracksTPCoutVsVZEROTotalMult] = values[kNTracksPerTrackingStatus+kTPCout] / values[GetMultiplicityEstimator(kVZEROTotalMult)];
   else
      fgUsedVars[kNTracksTPCoutVsVZEROTotalMult] = kFALSE;
   
@@ -554,8 +673,8 @@ void AliReducedVarManager::FillEventInfo(BASEEVENT* baseEvent, Float_t* values, 
   }
   
   fgUsedVars[kNTracksTPCoutFromPileup] = kTRUE;
-  if(values[kVZEROTotalMult]>0.0)
-     values[kNTracksTPCoutFromPileup] = values[kNTracksPerTrackingStatus+kTPCout] - (-2.55+TMath::Sqrt(2.55*2.55+4.0e-5*values[kVZEROTotalMult]))/2.0e-5;
+  if(values[GetMultiplicityEstimator(kVZEROTotalMult)]>0.0)
+     values[kNTracksTPCoutFromPileup] = values[kNTracksPerTrackingStatus+kTPCout] - (-2.55+TMath::Sqrt(2.55*2.55+4.0e-5*values[GetMultiplicityEstimator(kVZEROTotalMult)]))/2.0e-5;
   else fgUsedVars[kNTracksTPCoutFromPileup] = kFALSE;
   
   if(!eventF && (fgUsedVars[kVZEROQvecX+0*6+1] || fgUsedVars[kVZEROQvecY+0*6+1] || fgUsedVars[kVZERORP+0*6+1])) {
@@ -1562,6 +1681,10 @@ void AliReducedVarManager::FillPairInfo(BASETRACK* t1, BASETRACK* t2, Int_t type
     TVector3 v2(t2->Px(), t2->Py(), t2->Pz());
     values[kPairOpeningAngle] = v1.Angle(v2);
   }
+  values[kDeltaEta] = TMath::Abs( t1->Eta() - t2->Eta()  );
+  values[kDeltaPhi] = TMath::Abs( t1->Phi() - t2->Phi()  );
+
+
 
   if(  t1->IsA()==TRACK::Class() && t2->IsA()==TRACK::Class()     ) {
     TRACK* ti1=(TRACK*)t1;
@@ -1862,6 +1985,7 @@ void AliReducedVarManager::SetDefaultVarNames() {
   fgVariableNames[kIsPhysicsSelection]   = "Physics selection ON";            fgVariableUnits[kIsPhysicsSelection]   = "";
   fgVariableNames[kIsSPDPileup]          = "SPD pileup ON";                   fgVariableUnits[kIsSPDPileup]          = "";
   fgVariableNames[kIsSPDPileup5]          = "SPD pileup (5 contributors) ON";                   fgVariableUnits[kIsSPDPileup5]          = "";
+  fgVariableNames[kIsPileupMV]          = "MV pileup ON";                   fgVariableUnits[kIsPileupMV]          = "";
   fgVariableNames[kIsSPDPileupMultBins]  = "SPD pileup multiplicity bins ON"; fgVariableUnits[kIsSPDPileupMultBins]  = "";
   fgVariableNames[kNSPDpileups]          = "Number of SPD pileup events";     fgVariableUnits[kNSPDpileups]          = "";
   fgVariableNames[kNTrackPileups]        = "Number of track pileup events";   fgVariableUnits[kNTrackPileups]        = "";
@@ -1941,17 +2065,100 @@ void AliReducedVarManager::SetDefaultVarNames() {
   fgVariableNames[kNtracksEventPlane]           = "No.tracks";                       fgVariableUnits[kNtracksEventPlane]      = "";  
   fgVariableNames[kNCaloClusters]               = "No.calorimeter clusters";         fgVariableUnits[kNCaloClusters]          = "";
   fgVariableNames[kNTPCclusters]                = "No. TPC clusters";                  fgVariableUnits[kNTPCclusters]  = "";
-  fgVariableNames[kSPDntracklets]               = "No.SPD tracklets in |#eta| < 1.0";                fgVariableUnits[kSPDntracklets]          = "";
-  fgVariableNames[kSPDntracklets08]             = "No.SPD tracklets in |#eta| < 0.8";                fgVariableUnits[kSPDntracklets08]        = "";
-  fgVariableNames[kSPDntracklets16]             = "No.SPD tracklets in |#eta| < 1.6";                fgVariableUnits[kSPDntracklets16]        = "";
-  fgVariableNames[kSPDntrackletsCorr]           = "Corrected no. SPD tracklets in |#eta| < 1.0";     fgVariableUnits[kSPDntrackletsCorr]      = "";
-  fgVariableNames[kSPDntrackletsCorrSmear]      = "Corrected no. SPD tracklets in |#eta| < 1.0, Poisson smeared";    
-  fgVariableNames[kSPDntrackletsOuterCorr]      = "Corrected no. SPD tracklets in outer eta region";   fgVariableUnits[kSPDntrackletsOuterCorr]     = "";
-  fgVariableNames[kSPDntrackletsOuterCorrSmear]          = "Corrected no.SPD tracklets in outer eta region, Poisson smeared";                fgVariableUnits[kSPDntrackletsOuterCorrSmear]     = ""; fgVariableUnits[kSPDntrackletsCorrSmear]      = "";
-  for(Int_t ieta=0;ieta<32;++ieta) {
-    fgVariableNames[kSPDntrackletsEta+ieta] = Form("No.SPD tracklets in %.1f<#eta<%.1f", -1.6+0.1*ieta, -1.6+0.1*(ieta+1));
-    fgVariableUnits[kSPDntrackletsEta+ieta] = "";
+
+  TString multEstimators[kNMultiplicityEstimators] = {
+    "SPDntracklets10",
+    "SPDntracklets08",
+    "SPDntracklets16",
+    "SPDntrackletsOuterEta",
+    "SPDntrackletsEtaBin00",
+    "SPDntrackletsEtaBin01",
+    "SPDntrackletsEtaBin02",
+    "SPDntrackletsEtaBin03",
+    "SPDntrackletsEtaBin04",
+    "SPDntrackletsEtaBin05",
+    "SPDntrackletsEtaBin06",
+    "SPDntrackletsEtaBin07",
+    "SPDntrackletsEtaBin08",
+    "SPDntrackletsEtaBin09",
+    "SPDntrackletsEtaBin10",
+    "SPDntrackletsEtaBin11",
+    "SPDntrackletsEtaBin12",
+    "SPDntrackletsEtaBin13",
+    "SPDntrackletsEtaBin14",
+    "SPDntrackletsEtaBin15",
+    "SPDntrackletsEtaBin16",
+    "SPDntrackletsEtaBin17",
+    "SPDntrackletsEtaBin18",
+    "SPDntrackletsEtaBin19",
+    "SPDntrackletsEtaBin20",
+    "SPDntrackletsEtaBin21",
+    "SPDntrackletsEtaBin22",
+    "SPDntrackletsEtaBin23",
+    "SPDntrackletsEtaBin24",
+    "SPDntrackletsEtaBin25",
+    "SPDntrackletsEtaBin26",
+    "SPDntrackletsEtaBin27",
+    "SPDntrackletsEtaBin28",
+    "SPDntrackletsEtaBin29",
+    "SPDntrackletsEtaBin30",
+    "SPDntrackletsEtaBin31",
+    "SPDntrackletsVtxEta",
+    "VZEROTotalMult",
+    "VZEROATotalMult",
+    "VZEROCTotalMult",
+    "VZEROAplusCTotalMult"
+  };
+
+
+  
+  
+  
+  TString corrections[kNCorrections] = {
+    ", Vtx. corr. (global)",
+    ", Vtx. corr. (run-wise)",
+    ", Vtx. corr. (global) + gain loss correction",
+    ", Vtx. corr. (run-wise) + gain loss correction",
+    ", 2D Vertex + gain loss correction"
+  };
+
+  TString referenceMultiplicities[kNReferenceMultiplicities] = {
+    ", (max mult)",
+    ", (min mult)",
+    ", (mean mult)"
+  };
+
+  TString smearingMethods[kNSmearingMethods] = {
+    "",
+    ", Poisson smeared"
+  };
+
+  for( int iEstimator=0; iEstimator < kNMultiplicityEstimators; ++iEstimator){
+    for( int iCorrection=-1; iCorrection < kNCorrections; ++iCorrection){
+      if ( iCorrection > -1 ) {
+        for( int iReference=0; iReference < kNReferenceMultiplicities; ++iReference ){
+          for( int iSmearing=0; iSmearing < kNSmearingMethods; ++iSmearing){
+            Int_t index = GetMultiplicityEstimator( iEstimator, iCorrection, iReference, iSmearing );
+            fgVariableNames[index] = Form("%s%s%s%s",
+                                          multEstimators[iEstimator].Data(),
+                                          corrections[iCorrection].Data(),
+                                          referenceMultiplicities[iReference].Data(),
+                                          smearingMethods[iSmearing].Data()
+                                        );
+            fgVariableUnits[index] = "";
+          }
+        }
+      }
+      else{
+        Int_t index = GetMultiplicityEstimator( iEstimator ) ;
+        fgVariableNames[index] = multEstimators[iEstimator];
+        fgVariableUnits[index]  = "";
+      }
+    }
   }
+
+  
+
   for(Int_t il=0;il<2;++il) {
     fgVariableNames[kSPDFiredChips+il] = Form("Fired chips in SPD layer %d", il+1); 
     fgVariableUnits[kSPDFiredChips+il] = "";
@@ -1962,11 +2169,6 @@ void AliReducedVarManager::SetDefaultVarNames() {
   }
   fgVariableNames[kSPDnSingleClusters]  = "SPD single clusters";    fgVariableUnits[kSPDnSingleClusters]  = "";  
   fgVariableNames[kEventMixingId]       = "Event mixing id";        fgVariableUnits[kEventMixingId]       = "";  
-  fgVariableNames[kVZEROATotalMult]     = "Multiplicity VZERO-A";   fgVariableUnits[kVZEROATotalMult]     = "";
-  fgVariableNames[kVZEROCTotalMult]     = "Multiplicity VZERO-C";   fgVariableUnits[kVZEROCTotalMult]     = "";
-  fgVariableNames[kVZEROTotalMult]      = "Multiplicity VZERO";     fgVariableUnits[kVZEROTotalMult]      = "";
-  fgVariableNames[kVZEROTotalMultCorr]      = "Corrected Multiplicity VZERO";     fgVariableUnits[kVZEROTotalMult]      = "";
-  fgVariableNames[kVZEROTotalMultCorrSmear]      = "Corrected Multiplicity VZERO, Poisson smeared";     fgVariableUnits[kVZEROTotalMult]      = "";
   fgVariableNames[kVZEROAemptyChannels] = "VZERO-A empty channels"; fgVariableUnits[kVZEROAemptyChannels] = "";
   fgVariableNames[kVZEROCemptyChannels] = "VZERO-C empty channels"; fgVariableUnits[kVZEROCemptyChannels] = "";
   for(Int_t ich=0;ich<64;++ich) {
@@ -2470,17 +2672,20 @@ void AliReducedVarManager::SetRunNumbers( TString runNumbers ){
 }
 
 //____________________________________________________________________________________
-void AliReducedVarManager::SetMultiplicityProfile(TH1* profile, Int_t estimator) {
+void AliReducedVarManager::SetMultiplicityProfile(TH2* profile, MultiplicityEstimators estimator) {
    //
    // initialize the profile for the z-vertex equalization of the multiplicity estimator
    //
-   if(profile) {
-     fgAvgMultVsVertex[estimator] = (TH1*)profile->Clone(Form("AliReducedVarManager_AverageMultiplicityVsVertex"));
-     fgAvgMultVsVertex[estimator]->SetDirectory(0x0);
-   }
-   else{
-     cout <<"AliReducedVarManager::SetMultiplicityProfile : Profile empty. " << estimator << endl;
-   }
+  if( estimator >= kNMultiplicityEstimators ){
+    cout << "Multiplcity estimator " << estimator << " not defined!" <<endl;
+    return;
+  }
+  if(!profile){
+    cout <<"AliReducedVarManager::SetMultiplicityProfile : Profile null!"  << endl;
+    return;
+  }
+  fgAvgMultVsVtxAndRun[estimator] = (TH2*)profile->Clone( Form("profile_%d", estimator  ));
+  fgAvgMultVsVtxAndRun[estimator]->SetDirectory(0x0);
 }
 
 //____________________________________________________________________________________
@@ -2506,4 +2711,24 @@ void AliReducedVarManager::SetRecenterVZEROqVector(Bool_t option) {
    //   
    fgOptionRecenterVZEROqVec = option;
    //if(fgOptionRecenterVZEROqVec) fgOptionCalibrateVZEROqVec = kTRUE;
+}
+
+
+Int_t AliReducedVarManager::GetMultiplicityEstimator( Int_t iEstimator,  Int_t iCorrection, Int_t iReference, Int_t iSmearing ){
+  //
+  // Return the index of the multiplicity estimator, for given
+  // - estimator
+  // - correction ( no correcttion OR correction wrt. vertex, vertex and run number (1D or 2D) )
+  // - reference bin (bin with maximum or minimum efficiency)
+  // - smearing method
+  //
+
+Int_t ret = kMultiplicity + iEstimator * ( 1 + kNCorrections * kNReferenceMultiplicities * kNSmearingMethods );
+  if ( iCorrection > -1 ) {
+    ret++;
+    ret += iCorrection * kNReferenceMultiplicities * kNSmearingMethods;
+    ret += iReference * kNSmearingMethods;
+    ret += iSmearing;
+  }
+  return ret;
 }

--- a/PWGDQ/reducedTree/AliReducedVarManager.h
+++ b/PWGDQ/reducedTree/AliReducedVarManager.h
@@ -160,6 +160,42 @@ class AliReducedVarManager : public TObject {
     kNTrackingFlags
   };
 
+  enum MultiplicityEstimators {
+    kSPDntracklets10,
+    kSPDntracklets08,
+    kSPDntracklets16,
+    kSPDntrackletsOuterEta,
+    kSPDntrackletsEtaBin,
+    kSPDnTrackletsEtaVtxCorr = kSPDntrackletsEtaBin + 32,
+    kVZEROTotalMult,
+    kVZEROATotalMult,
+    kVZEROCTotalMult,
+    kVZEROACTotalMult,
+    kNMultiplicityEstimators
+  };
+
+  enum Corrections {
+    kVertexCorrectionGlobal,
+    kVertexCorrectionRunwise,
+    kVertexCorrectionGlobalGainLoss,
+    kVertexCorrectionRunwiseGainLoss,
+    kVertexCorrection2D,
+    kNCorrections
+  };
+
+  enum ReferenceMultiplicities {
+   kMaximumMultiplicity,
+   kMinimumMultiplicity,
+   kMeanMultiplicity,
+   kNReferenceMultiplicities
+  };
+
+  enum SmearingMethods {
+   kNoSmearing,
+   kPoissonSmearing,
+   kNSmearingMethods
+  };
+
   
   static const Float_t fgkParticleMass[kNSpecies];
   
@@ -200,6 +236,7 @@ class AliReducedVarManager : public TObject {
     kIsPhysicsSelection,    // physics selection 
     kIsSPDPileup,          // whether is SPD pileup
     kIsSPDPileup5,          // whether is SPD pileup (5 vertex contributors)
+    kIsPileupMV,            // pileup from multi vertexer
     kIsSPDPileupMultBins,  // whether is SPD pileup in multiplicity bins
     kNSPDpileups,         // number of pileup events from SPD
     kNTrackPileups,       // number of pileup events from tracks
@@ -274,25 +311,12 @@ class AliReducedVarManager : public TObject {
     kNtracksEventPlane, // number of tracks used for event plane                
     kNCaloClusters,     // number of calorimeter clusters
     kNTPCclusters,    // number of TPC clusters
-    kSPDntracklets,     // SPD number of tracklets in |eta|<1.0                 
-    kSPDntracklets08,     // SPD number of tracklets in |eta|<0.8
-    kSPDntracklets16,     // SPD number of tracklets in |eta|<1.6
-    kSPDntrackletsCorr, // SPD number of tracklets in |eta|<1.0, corrected for detector effects
-    kSPDntrackletsCorrSmear, // SPD number of tracklets in |eta|<1.0, corrected for detector effects, Poisson smeared
-    kSPDntrackletsOuter,     // SPD number of tracklets in outer eta region
-    kSPDntrackletsOuterCorr,     // SPD number of tracklets in outer eta region, corrected for detector effects
-    kSPDntrackletsOuterCorrSmear,     // SPD number of tracklets in outer eta region, corrected for detector effects, Poisson smeared
-    kSPDntrackletsEta,  // SPD number of tracklets in -1.6+0.1*i < eta < -1.6+0.1*(i+1)
-    kSPDFiredChips=kSPDntrackletsEta+32,   // SPD fired chips in first and second layer
+    kMultiplicity,
+    kSPDFiredChips = kMultiplicity + kNMultiplicityEstimators * ( 1 + kNCorrections * kNReferenceMultiplicities * kNSmearingMethods ), // SPD fired chips in first and second layer
     kITSnClusters=kSPDFiredChips+2,        // number of ITS clusters in each layer
     kSPDnSingleClusters=kITSnClusters+6,   // number of clusters in SPD layer 1 not mached to tracklets from layer 2
     kEventMixingId,     // Id of the event mixing category 
     // VZERO event plane related variables
-    kVZEROATotalMult,   // total multiplicity of VZEROA                         
-    kVZEROCTotalMult,   // total multiplicity of VZEROC                         
-    kVZEROTotalMult,    // total multiplicity of VZERO                          
-    kVZEROTotalMultCorr,    // total multiplicity of VZERO, corrected for detector effects
-    kVZEROTotalMultCorrSmear,    // total multiplicity of VZERO, corrected for detector effects, Poisson smeared
     kVZEROAemptyChannels,  // Number of empty VZERO channels in A side          
     kVZEROCemptyChannels,  // Number of empty VZERO channels in C side          
     kVZEROChannelMult,                        // VZERO multiplicity per channel           
@@ -350,7 +374,7 @@ class AliReducedVarManager : public TObject {
     kTZEROstartTime,                           // TZERO event start time
     kTZEROpileup,                              // TZERO pileup flag
     kTZEROsatellite,                           // TZERO satellite flag
-    // Multiplicity estimators
+    // External Multiplicity estimators
     kMultEstimatorOnlineV0M,
     kMultEstimatorOnlineV0A,
     kMultEstimatorOnlineV0C,
@@ -592,10 +616,11 @@ class AliReducedVarManager : public TObject {
   static void SetLHCDataInfo(TH1F* totalLumi, TH1F* totalInt0, TH1F* totalInt1, TH1I* fillNumber);
   static void SetGRPDataInfo(TH1I* dipolePolarity, TH1I* l3Polarity, TH1I* timeStart, TH1I* timeStop);
   static void SetRunNumbers( TString runNumbers );
-  static void SetMultiplicityProfile( TH1* profile, Int_t estimator = 0 );
+  static void SetMultiplicityProfile( TH2* profile, MultiplicityEstimators estimator );
   static void SetVZEROCalibrationPath(const Char_t* path);
   static void SetCalibrateVZEROqVector(Bool_t option);
   static void SetRecenterVZEROqVector(Bool_t option);
+  static Int_t GetMultiplicityEstimator( Int_t iEstimator, Int_t iCorrection = -1, Int_t iReference = 0, Int_t iSmearing = 0 );
   
  private:
   static Int_t     fgCurrentRunNumber;               // current run number
@@ -632,8 +657,14 @@ class AliReducedVarManager : public TObject {
   static TH1I* fgRunTimeEnd;                  // run stop time, GRP/GRP/Data::GetTimeEnd()
   static std::vector<Int_t> fgRunNumbers;     // vector with run numbers (for histograms vs. run number)
   static Int_t fgRunID;                       // run ID
-  static TH1* fgAvgMultVsVertex[3];           // average multiplicity vs. z-vertex position
-  static Double_t fgRefMult[3];                  // reference multiplicity for z-vertex correction
+  static TH1* fgAvgMultVsVtxGlobal      [kNMultiplicityEstimators];        // average multiplicity vs. z-vertex position (global)
+  static TH1* fgAvgMultVsVtxRunwise     [kNMultiplicityEstimators];        // average multiplicity vs. z-vertex position (run-by-run)
+  static TH1* fgAvgMultVsRun            [kNMultiplicityEstimators];           // average multiplicity vs. run number
+  static TH2* fgAvgMultVsVtxAndRun      [kNMultiplicityEstimators];  // 2D : average multiplicity vs. run number and z-vertex position
+  static Double_t fgRefMultVsVtxGlobal  [kNMultiplicityEstimators] [kNReferenceMultiplicities];  // reference multiplicity for z-vertex correction (global)
+  static Double_t fgRefMultVsVtxRunwise [kNMultiplicityEstimators] [kNReferenceMultiplicities];  // reference multiplicity for z-vertex correction (run-by-run)
+  static Double_t fgRefMultVsRun        [kNMultiplicityEstimators] [kNReferenceMultiplicities];  // reference multiplicity for run correction
+  static Double_t fgRefMultVsVtxAndRun  [kNMultiplicityEstimators] [kNReferenceMultiplicities];  // reference multiplicity for run, vtx correction
   static TString fgVZEROCalibrationPath;       // path to the VZERO calibration histograms
   static TProfile2D* fgAvgVZEROChannelMult[64];       // average multiplicity in VZERO channels vs (vtxZ,centSPD)
   static TProfile2D* fgVZEROqVecRecentering[4];       // (vtxZ,centSPD) maps of the VZERO A and C recentering Qvector offsets


### PR DESCRIPTION
1st is for the signal extraction via fit, which was very outdated
2nd is a large update on how the multiplicity estimators are filled in the reduced tree framework
3rd adds the offline V0 information to the trees in the tree filling task; plus a fix to only fill the constrained chi^2 information if the magnetic field is correctly set ( can crash otherwise)