### PR TITLE
Update TRD classes for Run-2 analyses

### DIFF
--- a/PWG/TRD/AliAnalysisTaskTRDtriggerCheck.cxx
+++ b/PWG/TRD/AliAnalysisTaskTRDtriggerCheck.cxx
@@ -139,11 +139,11 @@ void AliAnalysisTaskTRDtriggerCheck::UserExec(Option_t * /* option */)
   if ((fDebug > 0) && esdEvent)
     printf("event: %s-%06i\n", CurrentFileName(), esdEvent->GetEventNumberInFile());
 
-  if (!InputEvent()->GetFiredTriggerClasses().Contains("WU")) {
-    if (fDebug > 0)
-      printf("no TRD, returning\n");
-    return;
-  }
+//  if (!InputEvent()->GetFiredTriggerClasses().Contains("WU")) {
+//    if (fDebug > 0)
+//      printf("no TRD, returning\n");
+//    return;
+//  }
 
   // reproduce hardware decision
   AliTRDTriggerAnalysis trgAnalysis;

--- a/PWG/TRD/AliTRDTriggerAnalysis.cxx
+++ b/PWG/TRD/AliTRDTriggerAnalysis.cxx
@@ -141,13 +141,13 @@ Bool_t AliTRDTriggerAnalysis::CalcTriggers(const AliVEvent *event)
   TString trgClasses = event->GetFiredTriggerClasses();
   if (trgClasses.Contains("TRDCO2"))
     MarkClass(kHCO);
-  if (trgClasses.Contains("WUHJT"))
+  if (trgClasses.Contains("HJT"))
     MarkClass(kHJT);
-  if (trgClasses.Contains("WUHSE"))
+  if (trgClasses.Contains("HSE"))
     MarkClass(kHSE);
-  if (trgClasses.Contains("WUHQU"))
+  if (trgClasses.Contains("HQU"))
     MarkClass(kHQU);
-  if (trgClasses.Contains("WUHEE"))
+  if (trgClasses.Contains("HEE"))
     MarkClass(kHEE);
 
   // evaluate trigger inputs


### PR DESCRIPTION
In Run-2, the wake-up trigger was not used anymore for the TRD triggers, so the trigger string changed and does not contain "WU" anymore, but in this class it was still used, so it could not be used for Run-2 data.