### PR TITLE
PWGDQ new class for Event vs Track histograms

### DIFF
--- a/PWGDQ/dielectron/CMakeLists.txt
+++ b/PWGDQ/dielectron/CMakeLists.txt
@@ -69,6 +69,7 @@ set(SRCS
       core/AliDielectronV0Cuts.cxx
       core/AliDielectronVarCuts.cxx
       core/AliDielectronVarManager.cxx
+      core/AliDielectronEvtVsTrkHist.cxx
       core/AliAnalysisTaskDielectronFilter.cxx
       core/AliAnalysisTaskDielectronReadAODBranch.cxx
       core/AliAnalysisTaskMultiDielectron.cxx

--- a/PWGDQ/dielectron/PWGDQdielectronLinkDef.h
+++ b/PWGDQ/dielectron/PWGDQdielectronLinkDef.h
@@ -15,6 +15,7 @@
 #pragma link C++ class AliDielectronHFhelper+;
 #pragma link C++ class AliDielectronMC+;
 #pragma link C++ class AliDielectronQnEPcorrection+;
+#pragma link C++ class AliDielectronEvtVsTrkHist+;
 #pragma link C++ class AliDielectronVarManager+;
 #pragma link C++ class AliAnalysisTaskDielectronFilter+;
 #pragma link C++ class AliAnalysisTaskMultiDielectron+;

--- a/PWGDQ/dielectron/core/AliAnalysisTaskMultiDielectron.h
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskMultiDielectron.h
@@ -4,7 +4,7 @@
  * See cxx source for full Copyright notice                               */
 
 //#####################################################
-//#                                                   # 
+//#                                                   #
 //#        Basic Analysis task for Dielectron         #
 //#          single event analysis                    #
 //#                                                   #
@@ -28,21 +28,21 @@ class AliAnalysisCuts;
 class AliTriggerAnalysis;
 
 class AliAnalysisTaskMultiDielectron : public AliAnalysisTaskSE {
-  
+
 public:
   AliAnalysisTaskMultiDielectron();
   AliAnalysisTaskMultiDielectron(const char *name);
   virtual ~AliAnalysisTaskMultiDielectron();
 
   enum ETriggerLogig {kAny, kExact};
-  
+
 
   virtual void UserExec(Option_t *option);
   virtual void UserCreateOutputObjects();
   virtual void FinishTaskOutput();
   //temporary
 //   virtual void NotifyRun(){AliDielectronPID::SetCorrVal((Double_t)fCurrentRunNumber);}
-  
+
   void UsePhysicsSelection(Bool_t phy=kTRUE) {fSelectPhysics=phy;}
   void SetTriggerMask(ULong64_t mask) {fTriggerMask=mask;}
   UInt_t GetTriggerMask() const { return fTriggerMask; }
@@ -55,17 +55,20 @@ public:
   void SetEventFilter(AliAnalysisCuts * const filter) {fEventFilter=filter;}
   void SetTriggerOnV0AND(Bool_t v0and=kTRUE)    { fTriggerOnV0AND=v0and;    }
   void SetRejectPileup(Bool_t pileup=kTRUE)     { fRejectPileup=pileup;     }
-  void AddDielectron(AliDielectron * const die) { fListDielectron.Add(die); }
+  void AddDielectron(AliDielectron * const die) { fListDielectron.Add(die);
+                      SetEvtVsTrkHistoExists(die->GetEvtVsTrkHistExists());}
   void SetBeamEnergy(Double_t beamEbyHand=-1.)  { fBeamEnergy=beamEbyHand;  }
   void SetRandomizeDaughters(Bool_t random=kTRUE) { fRandomizeDaughters=random; }
-  
+
   void SetRequireTRDTrigger(Bool_t requireTRDtrigger) {fRequireTRDtrigger = requireTRDtrigger;}
   void SetTRDTriggerClass(AliDielectronEventCuts::ETRDTriggerClass trdTriggerClass) {fTRDTriggerClass = trdTriggerClass;}
   void SetRequireMatchedTrack(Int_t requireMatchedTrack) {fRequireMatchedTrack = requireMatchedTrack;}
-  
+
   Bool_t GetRequireTRDTrigger() const {return fRequireTRDtrigger;}
   AliDielectronEventCuts::ETRDTriggerClass GetTRDTriggerClass() const {return fTRDTriggerClass;}
   Int_t GetRequireMatchedTrack() const { return fRequireMatchedTrack;}
+
+  void SetEvtVsTrkHistoExists( Bool_t exists = kTRUE ) {fEvtVsTrkHistExists = exists;}
 
 protected:
   enum {kAllEvents=0, kSelectedEvents, kV0andEvents,  kTrdTriggeredEvents, kTrdTriggeredEventsMatched, kFilteredEvents, kPileupEvents, kNbinsEvent};
@@ -83,24 +86,27 @@ protected:
   Bool_t fRejectPileup;              // pileup rejection wanted
   Double_t fBeamEnergy;              // beam energy in GeV (set by hand)
   Bool_t   fRandomizeDaughters;      // shuffle daughters at pair creation (sorted according to pt by default, which affects PhivPair at least for Like Sign)
-  
+
   ETriggerLogig fTriggerLogic;       // trigger logic: any or all bits need to be matching
-  
+
   AliTriggerAnalysis *fTriggerAnalysis; //! trigger analysis class
-  
-  
+
+
   Bool_t fRequireTRDtrigger;         // if to require a TRD triggers
   Bool_t fRequireMatchedTrack;        // if to require that the triggered track can be matched to a global track
+
+  Bool_t fEvtVsTrkHistExists;  // (De-)Activate event vs track histo class
+
   AliDielectronEventCuts::ETRDTriggerClass fTRDTriggerClass;     // which TRD trigger to use
 
   AliAnalysisCuts *fEventFilter;     // event filter
-  
+
   TH1D *fEventStat;                  //! Histogram with event statistics
   TH1D *fEventStatTRDTrigger;           //! Histogram with TRD trigger statistics
-  
+
   AliAnalysisTaskMultiDielectron(const AliAnalysisTaskMultiDielectron &c);
   AliAnalysisTaskMultiDielectron& operator= (const AliAnalysisTaskMultiDielectron &c);
-  
+
   ClassDef(AliAnalysisTaskMultiDielectron, 4); //Analysis Task handling multiple instances of AliDielectron
 };
 #endif

--- a/PWGDQ/dielectron/core/AliDielectron.cxx
+++ b/PWGDQ/dielectron/core/AliDielectron.cxx
@@ -140,6 +140,8 @@ AliDielectron::AliDielectron() :
   fRotateMM(kFALSE),
   fDebugTree(0x0),
   fMixing(0x0),
+  fEvtVsTrkHist(0x0),
+  fEvtVsTrkHistExists(kFALSE),
   fPreFilterEventPlane(kFALSE),
   fACremovalIsSetted(kFALSE),
   fLikeSignSubEvents(kFALSE),
@@ -215,6 +217,8 @@ AliDielectron::AliDielectron(const char* name, const char* title) :
   fRotateMM(kFALSE),
   fDebugTree(0x0),
   fMixing(0x0),
+  fEvtVsTrkHist(0x0),
+  fEvtVsTrkHistExists(kFALSE),
   fPreFilterEventPlane(kFALSE),
   fACremovalIsSetted(kFALSE),
   fLikeSignSubEvents(kFALSE),
@@ -268,6 +272,7 @@ AliDielectron::~AliDielectron()
   if (fPairCandidates && fEventProcess) delete fPairCandidates;
   if (fDebugTree) delete fDebugTree;
   if (fMixing) delete fMixing;
+  if (fEvtVsTrkHist) delete fEvtVsTrkHist;
   if (fSignalsMC) delete fSignalsMC;
   if (fCfManagerPair) delete fCfManagerPair;
   if (fHistoArray) delete fHistoArray;
@@ -336,8 +341,13 @@ void AliDielectron::Init()
 
   if(fHistos) {
     (*fUsedVars)|= (*fHistos->GetUsedVars());
-  }
 
+    // Initialisation of AliDielectronEvtVsTrkHist
+    if(fHistos->GetHistogramList()->FindObject("EvtVsTrk")){
+      fEvtVsTrkHist = new AliDielectronEvtVsTrkHist("EvtVsTrkHistos", "EvtVsTrkHistos");
+      fEvtVsTrkHist->SetHistogramList(fHistos);
+    }
+  }
 }
 
 //________________________________________________________________
@@ -385,7 +395,7 @@ Bool_t AliDielectron::Process(AliVEvent *ev1, AliVEvent *ev2)
     ev1->SetPeriodNumber(1);
   }
 
-  // set qn vector normalisation to var manager 
+  // set qn vector normalisation to var manager
   AliDielectronVarManager::SetQnVectorNormalisation(fQnVectorNorm);
 
   // set pid correction function to var manager
@@ -733,6 +743,7 @@ void AliDielectron::FillHistograms(const AliVEvent *ev, Bool_t pairInfoOnly)
     if (fHistos->GetHistogramList()->FindObject("Event")) {
       fHistos->FillClass("Event", AliDielectronVarManager::kNMaxValues, AliDielectronVarManager::GetData());
     }
+    if(fEvtVsTrkHist)  fEvtVsTrkHist->FillHistograms(ev);
   }
 
   //Fill track information, separately for the track array candidates
@@ -2196,4 +2207,10 @@ void AliDielectron::FillHistogramsFromPairArray(Bool_t pairInfoOnly/*=kFALSE*/)
     if (legClass) arrLegs.Clear();
   }
 
+}
+
+//______________________________________________
+void AliDielectron::FinishEvtVsTrkHistoClass()
+{
+  if(fEvtVsTrkHist) fEvtVsTrkHist->CalculateMatchingEfficiency();
 }

--- a/PWGDQ/dielectron/core/AliDielectron.h
+++ b/PWGDQ/dielectron/core/AliDielectron.h
@@ -27,6 +27,7 @@
 #include "AliDielectronHistos.h"
 #include "AliDielectronHF.h"
 #include "AliDielectronCutQA.h"
+#include "AliDielectronEvtVsTrkHist.h"
 
 class AliEventplane;
 class AliVEvent;
@@ -74,6 +75,9 @@ public:
   AliAnalysisFilter& GetEventPlanePreFilter(){ return fEventPlanePreFilter; }
   AliAnalysisFilter& GetEventPlanePOIPreFilter(){ return fEventPlanePOIPreFilter; }
   AliDielectronQnEPcorrection* GetQnTPCACcuts(){ return fQnTPCACcuts; }
+
+  Bool_t GetEvtVsTrkHistExists() {return fEvtVsTrkHistExists;}
+  void SetEvtVsTrkHistExists(Bool_t doesExist = kTRUE) {fEvtVsTrkHistExists = doesExist;}
 
   void  SetMotherPdg( Int_t pdgMother ) { fPdgMother=pdgMother; }
   void  SetLegPdg(Int_t pdgLeg1, Int_t pdgLeg2) { fPdgLeg1=pdgLeg1; fPdgLeg2=pdgLeg2; }
@@ -186,6 +190,8 @@ public:
   void SetUseGammaTracks(Bool_t setValue=kTRUE) { fUseGammaTracks=setValue; }
   void  FillHistogramsFromPairArray(Bool_t pairInfoOnly=kFALSE);
 
+  void FinishEvtVsTrkHistoClass();
+
 private:
 
   Bool_t fCutQA;                    // monitor cuts
@@ -245,6 +251,9 @@ private:
   Bool_t fRotateMM; // combine rotated negative tracks
   AliDielectronDebugTree *fDebugTree;  // Debug tree output
   AliDielectronMixingHandler *fMixing; // handler for event mixing
+
+  AliDielectronEvtVsTrkHist *fEvtVsTrkHist;
+  Bool_t fEvtVsTrkHistExists; // Tells the Multi Analysis Task if it has to process the AliDielectronEvtVsTrkHist class
 
   Bool_t fPreFilterEventPlane;  //Filter for the Eventplane determination in TPC
   Bool_t fACremovalIsSetted;

--- a/PWGDQ/dielectron/core/AliDielectronEvtVsTrkHist.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronEvtVsTrkHist.cxx
@@ -1,0 +1,411 @@
+/**
+ * @Author: Pascal Dillenseger <pascaldillenseger>
+ * @Date:   2017-08-09, 17:39:09
+ * @Email:  pdillens@cern.ch
+ * @Filename: AliDielectronEvtVsTrkHist.cxx
+ * @Last modified by:   pascaldillenseger
+ * @Last modified time: 2017-08-31, 13:52:53
+ */
+
+
+
+// Class to create histograms plotting event properties versus track properties e.g. ITS-TPC matching efficiency vs. pT
+// Since these are special case histograms the filling of each histogram is kind of treated individually, therefore check if your desired histogram exists in the filling procedure
+#include <TAxis.h>
+#include <TList.h>
+#include <TMath.h>
+#include <TString.h>
+#include <TH1.h>
+
+#include "AliAODEvent.h"
+#include "AliAODHeader.h"
+#include "AliESDEvent.h"
+#include "AliDielectronTrackCuts.h"
+
+#include "AliDielectronEvtVsTrkHist.h"
+
+#define ADVM AliDielectronVarManager
+#define ADEVTH AliDielectronEvtVsTrkHist
+
+ClassImp(AliDielectronEvtVsTrkHist)
+
+
+//______________________________________________
+AliDielectronEvtVsTrkHist::AliDielectronEvtVsTrkHist(const char *name, const char *title) :
+TNamed(name, title),
+fEventNumber(-1),
+fIsAODEvent(kFALSE),
+fSameEvent(kFALSE),
+fNObjs(-1),
+fNHistos(0),
+fNSparses(0),
+fHistoList(0x0),
+fSparseObjs{0x0},
+fMatchEffITS(0x0),
+fMatchEffTPC(0x0),
+fNtracksITS(0),
+fNtracksTPC(0)
+{
+  // Default named constructor
+}
+
+//______________________________________________
+AliDielectronEvtVsTrkHist::~AliDielectronEvtVsTrkHist()
+{
+  // Default destructor
+  if(fMatchEffITS) delete fMatchEffITS;
+  if(fMatchEffTPC) delete fMatchEffTPC;
+}
+
+//______________________________________________
+void AliDielectronEvtVsTrkHist::Init()
+{
+  if(!fHistoList){
+    AliFatal("Histo list from AliDielectronHistos object not setted!");
+    return;
+  }
+  fNObjs = fHistoList->GetEntries();
+  TObject *obj;
+  for (Int_t iObj = 0; iObj < fNObjs; iObj++) {
+    obj = fHistoList->At(iObj);
+
+    if (obj->InheritsFrom(TH1::Class())) {
+      if(!ADEVTH::SetHistogramObj(obj))  continue;
+      else fNHistos++;
+    }
+
+    if (obj->InheritsFrom(THnBase::Class())) {
+      if(!ADEVTH::SetSparseObj(obj)) continue;
+      else fNSparses++;
+    }
+  }
+}
+
+//______________________________________________
+void AliDielectronEvtVsTrkHist::FillHistograms(const AliVEvent *ev)
+{
+  if (ev->IsA() == AliAODEvent::Class()) fIsAODEvent = kTRUE;
+  if(!fIsAODEvent){
+    // Fill information for ESDs
+    // Currently not implemented therefore an error is printed and the function is returned
+    AliError("Event vs. track histograms not implemented for ESDs!");
+    return;
+  }
+    if(fIsAODEvent){
+    // Fill information for AODs
+      AliAODEvent *event = (AliAODEvent*) ev;
+      AliAODHeader *header = (AliAODHeader*) ev->GetHeader();
+      fSameEvent = fEventNumber == header->GetEventNumberESDFile() ? kTRUE : kFALSE;
+      fEventNumber = header->GetEventNumberESDFile();
+      Int_t nTracks = ev->GetNumberOfTracks();
+      ADEVTH::SetEventplaneAngles(ev);
+
+
+    //Needed Vars for matching eff
+      const Int_t nDimMatchEff = fSparseObjs[ADEVTH::kSparseMatchEffITSTPC]->GetNdimensions();
+
+      Double_t *bin = new Double_t[nDimMatchEff];
+      for (Int_t iDim = 0; iDim < nDimMatchEff; iDim++) {
+        if(!fSparseIsTrackVar[ADEVTH::kSparseMatchEffITSTPC][iDim]){
+          bin[iDim] = ADEVTH::GetVarValueEvent(ev, fSparseVars[ADEVTH::kSparseMatchEffITSTPC][iDim]);
+        }
+      }
+    for (Int_t iTrack = 0; iTrack < nTracks; iTrack++) {
+      AliVTrack *track        = static_cast<AliVTrack*>(ev->GetTrack(iTrack));
+      if (!track) continue;
+
+
+      // Fill Matching efficiecy Sparse:
+      if (fSparseObjs[kSparseMatchEffITSTPC]) {
+        for (Int_t iDim = 0; iDim < nDimMatchEff; iDim++) {
+          if(fSparseIsTrackVar[ADEVTH::kSparseMatchEffITSTPC][iDim]){
+            bin[iDim] = ADEVTH::GetTrackValue(track, fSparseVars[ADEVTH::kSparseMatchEffITSTPC][iDim]);
+          }
+        }
+        if(ADEVTH::IsSelectedITS(track)){
+          fNtracksITS++;
+          fMatchEffITS->Fill(bin);
+          if(ADEVTH::IsSelectedTPC(track)){
+            fNtracksTPC++;
+            fMatchEffTPC->Fill(bin);
+          }
+          else{
+            fMatchEffTPC->Fill(bin, 0);
+          }
+        }
+      }
+    }
+    delete [] bin;
+  }
+}
+
+//______________________________________________
+Float_t AliDielectronEvtVsTrkHist::GetVarValueEvent(const AliVEvent *ev, Int_t var)
+{
+  AliMultSelection *multSelection = 0x0; // no var initialisation in switch
+
+  switch (var) {
+    case ADVM::kCentrality:
+    case ADVM::kCentralityNew:
+      multSelection = (AliMultSelection*) ev->FindListObject("MultSelection");
+      if(!multSelection) return -999.;
+      else return multSelection->GetMultiplicityPercentile("V0M",kFALSE);
+    break;
+    case ADVM::kMatchEffITSTPC:
+      return 1;
+    break;
+
+    default:
+      AliError(Form("Variable %s not defined for AliDielectronEvtVsTrkHist", ADVM::GetValueName(var)));
+      return -1.;
+    break;
+  }
+}
+
+//______________________________________________
+Float_t AliDielectronEvtVsTrkHist::GetTrackValue(AliVTrack *trk, Int_t var)
+{
+  // Call only after the eventplaneangles have been set
+  Float_t rValue = -1.;
+  switch (var) {
+    case ADVM::kPhi:
+      rValue = trk->Phi();
+    break;
+    case ADVM::kPt:
+      rValue = trk->Pt();
+    break;
+    case ADVM::kQnDeltaPhiTrackTPCrpH2:
+      rValue = TVector2::Phi_mpi_pi((trk->Phi() - fEventPlaneAngle[0]));
+    break;
+    case ADVM::kQnDeltaPhiTrackV0CrpH2:
+      rValue = TVector2::Phi_mpi_pi((trk->Phi() - fEventPlaneAngle[1]));
+    break;
+    default:
+      AliError(Form("Variable %d %s not defined for AliDielectronEvtVsTrkHist", var, ADVM::GetValueName(var)));
+    break;
+  }
+  return rValue;
+}
+
+//______________________________________________
+Bool_t AliDielectronEvtVsTrkHist::SetHistogramObj(TObject *obj)
+{
+  TString name = obj->GetName();
+
+  // for (Int_t i = 0; i < ADEVTH::kHistoNMaxValues; i++) {
+  //   if(name.Contains(ADEVTH::Get3DHistoUniqueNameInfo(i))){
+  //     f3DHisoObjs[i] = (THnSparseD*) obj;
+  //     return kTRUE;
+  //   }
+  // }
+  AliError(Form("No histogram defined for %s in AliDielectronEvtVsTrkHist!", name.Data()));
+  return kFALSE;
+}
+
+//______________________________________________
+Bool_t AliDielectronEvtVsTrkHist::SetSparseObj(TObject *obj)
+{
+  TString name = obj->GetName();
+  printf("ADEVTH - Setting sparse object %s\n", name.Data());
+  for (Int_t i = 0; i < ADEVTH::kSparseNMaxValues; i++) {
+    if(name.Contains(ADEVTH::GetSparseUniqueNameInfo(i))){
+      fSparseObjs[i] = (THnSparseD*) obj;
+      for (Int_t j = 0; j < fSparseObjs[i]->GetNdimensions(); j++) {
+        ADEVTH::SetSparseVars(i,j,fSparseObjs[i]->GetAxis(j)->GetUniqueID());
+      }
+      if(i == ADEVTH::kSparseMatchEffITSTPC){
+        fMatchEffITS = (THnSparseD*) fSparseObjs[i]->Clone();
+        fMatchEffTPC = (THnSparseD*) fSparseObjs[i]->Clone();
+      }
+      return kTRUE;
+    }
+  }
+  AliError(Form("No sparse defined for %s in AliDielectronEvtVsTrkHist!", name.Data()));
+  return kFALSE;
+}
+
+//______________________________________________
+const char* AliDielectronEvtVsTrkHist::GetSparseUniqueNameInfo( Int_t iName)
+{
+  switch (iName) {
+    case ADEVTH::kSparseMatchEffITSTPC:
+      return ADVM::GetValueName(ADVM::kMatchEffITSTPC);
+    break;
+    case ADEVTH::kSparseNMaxValues:
+      return "NotExistingSparse";
+    break;
+  }
+  return "NotExistingSparse";
+}
+
+//______________________________________________
+const char* AliDielectronEvtVsTrkHist::Get3DHistoUniqueNameInfo( Int_t iName)
+{
+  switch (iName) {
+    case ADEVTH::k3DHistoNMaxValues:
+      return "NotExisting3DHistogram";
+    break;
+  }
+  return "NotExisting3DHistogram";
+}
+
+//______________________________________________
+void AliDielectronEvtVsTrkHist::SetSparseVars(Int_t nSparse, Int_t nAxis, Int_t type)
+{
+  switch (type) {
+    case ADVM::kCentrality:
+    case ADVM::kCentralityNew:
+    case ADVM::kMatchEffITSTPC:
+      fSparseIsTrackVar[nSparse][nAxis] = kFALSE;
+    break;
+    case ADVM::kPhi:
+    case ADVM::kPt:
+    case ADVM::kQnDeltaPhiTrackTPCrpH2:
+    case ADVM::kQnDeltaPhiTrackV0CrpH2:
+        fSparseIsTrackVar[nSparse][nAxis] = kTRUE;
+    break;
+
+    default:
+      AliFatal(Form("Variable %s not defined yet please check the code!", ADVM::GetValueName(type)));
+      return;
+    break;
+  }
+  // printf("Variable added to sparse %d %s\n", nSparse, ADVM::GetValueName(type));
+  fSparseVars[nSparse][nAxis] = type;
+}
+
+//______________________________________________
+void AliDielectronEvtVsTrkHist::SetEventplaneAngles(const AliVEvent *ev)
+{
+  TString epDetector[2] = {"TPC","V0C"};
+  fEventPlaneAngle[0] = -999.;
+  fEventPlaneAngle[1] = -999.;
+
+  AliAnalysisManager *man=AliAnalysisManager::GetAnalysisManager();
+  if(man)
+  if( AliAnalysisTaskFlowVectorCorrections *flowQnVectorTask =
+      dynamic_cast<AliAnalysisTaskFlowVectorCorrections*> (man->GetTask("FlowQnVectorCorrections")) )
+    if(flowQnVectorTask != NULL){
+      AliQnCorrectionsManager *flowQnVectorMgr = flowQnVectorTask->GetAliQnCorrectionsManager();
+      TList *qnlist = flowQnVectorMgr->GetQnVectorList();
+      if(qnlist != NULL){
+        for (Int_t i = 0; i < 2; i++) {
+          const AliQnCorrectionsQnVector *qVecQnFramework = AliDielectronQnEPcorrection::GetQnVectorFromList( qnlist, epDetector[i].Data(), "latest", "latest" );
+          if(qVecQnFramework != NULL){
+            TVector2 qVector( qVecQnFramework->Qx(2), qVecQnFramework->Qy(2) );
+            fEventPlaneAngle[i] = TVector2::Phi_mpi_pi(qVector.Phi())/2;
+          }
+        }
+      }
+    }
+}
+
+//______________________________________________
+Bool_t AliDielectronEvtVsTrkHist::IsSelectedITS(AliVTrack *trk)
+{
+  if(!trk) return kFALSE;
+
+  AliDielectronTrackCuts trkCutsITS;
+  trkCutsITS.SetClusterRequirementITS(AliDielectronTrackCuts::kSPD, AliDielectronTrackCuts::kAny);
+  trkCutsITS.SetRequireITSRefit(kTRUE);
+
+  Float_t impactParXY = -99.;
+  Float_t impactParZ = -99.;
+  Float_t eta = -99.;
+
+  if(!trkCutsITS.IsSelected(trk)) return kFALSE;
+
+  if(trk->IsA() == AliESDtrack::Class())trk->GetImpactParameters(impactParXY, impactParZ);
+  else{
+    AliAODTrack *trackAOD = (AliAODTrack*) trk;
+    Double_t xyz[2] = {-100.,-100.};
+    Double_t dcaRes[3] = {-100.,-100.,-100.};
+    AliDielectronVarManager::GetDCA(trackAOD, xyz, dcaRes);
+    impactParXY = xyz[0];
+    impactParZ = xyz[1];
+  }
+
+  if(TMath::Abs(impactParXY) > 1.0) return kFALSE;
+  if(TMath::Abs(impactParZ) > 3.0) return kFALSE;
+  eta = trk->Eta();
+  if(TMath::Abs(eta) > 0.9) return kFALSE;
+
+  return kTRUE;
+}
+
+//______________________________________________
+Bool_t AliDielectronEvtVsTrkHist::IsSelectedTPC(AliVTrack *trk)
+{
+  if(!trk) return kFALSE;
+
+  AliDielectronTrackCuts trkCutsTPC;
+  trkCutsTPC.SetRequireTPCRefit(kTRUE);
+
+  if(!trkCutsTPC.IsSelected(trk)) return kFALSE;
+
+  Float_t nClsTPC = -99.;
+  Float_t tpcChi2Cl = -99.;
+
+  nClsTPC = trk->GetTPCNcls();
+  if(nClsTPC < 50. || nClsTPC > 160.) return kFALSE;
+  tpcChi2Cl = nClsTPC > 0 ? trk->GetTPCchi2() / nClsTPC : -1.;
+  if(tpcChi2Cl < 0. || tpcChi2Cl > 4.) return kFALSE;
+
+  return kTRUE;
+}
+
+//______________________________________________
+void AliDielectronEvtVsTrkHist::CalculateMatchingEfficiency()
+{
+  const Int_t nBins = fMatchEffITS->GetNbins();
+  Double_t matchEff;
+  Double_t matchEffErr;
+  Int_t matchEffDim = -1;
+  Int_t lastBin = 0;
+
+  Double_t nCountsITS;
+  Double_t nTracksTotal = 0.;
+  Double_t nCountsTPC;
+
+  const Int_t nDimMatchEff = fSparseObjs[ADEVTH::kSparseMatchEffITSTPC]->GetNdimensions();
+  for (Int_t iDim = 0; iDim < nDimMatchEff; iDim++) {
+    if(fSparseVars[ADEVTH::kSparseMatchEffITSTPC][iDim] == ADVM::kMatchEffITSTPC) matchEffDim = iDim;
+  }
+
+  Int_t *coord = new Int_t[nDimMatchEff];
+  Double_t *values = new Double_t[nDimMatchEff];
+  for (Int_t iBin = 0; iBin < nBins; iBin++) {
+    // Get the number of tracks in the bin from the TPC and ITS histograms
+    nCountsITS = fMatchEffITS->GetBinContent(iBin);
+    nCountsTPC = fMatchEffTPC->GetBinContent(iBin, coord);
+
+    if (nCountsITS < 0.9) {
+       nCountsTPC = 0.;
+       nCountsITS = 1.;
+    }
+    // Calculate the matching efficiency for the given bin
+    matchEff = nCountsTPC/nCountsITS;
+    // Set values with values of the track and event properties and the matching efficiency
+    for (Int_t iDim = 0; iDim < nDimMatchEff; iDim++) {
+      if(iDim != matchEffDim)  values[iDim] = fMatchEffTPC->GetAxis(iDim)->GetBinCenter(coord[iDim]);
+      else{
+        values[iDim] = matchEff;
+        coord[iDim] = fMatchEffTPC->GetAxis(iDim)->FindBin(matchEff);
+      }
+    }
+    //FIXME place the error calculation after the match eff is calculated fully
+    Double_t err1 = fSparseObjs[ADEVTH::kSparseMatchEffITSTPC]->GetBinError(iBin) * nCountsTPC;
+    Double_t err2 = fMatchEffITS->GetBinError(iBin) * nCountsITS;
+    Double_t b22 = nCountsITS * nCountsITS;
+    Double_t err = (err1 * err1 + err2 * err2) / (b22 * b22);
+    matchEffErr = err;
+
+// Now set the correct match efficiency value to the bin coordinates
+    fSparseObjs[ADEVTH::kSparseMatchEffITSTPC]->SetBinContent(coord, nCountsITS);
+    // fSparseObjs[ADEVTH::kSparseMatchEffITSTPC]->Fill(values, nCountsITS);
+    //FIXME Error needs a second thought how to be setted
+    fSparseObjs[ADEVTH::kSparseMatchEffITSTPC]->SetBinError2(iBin, matchEffErr);
+  }
+  delete [] coord;
+  delete [] values;
+}

--- a/PWGDQ/dielectron/core/AliDielectronEvtVsTrkHist.h
+++ b/PWGDQ/dielectron/core/AliDielectronEvtVsTrkHist.h
@@ -1,0 +1,96 @@
+#ifndef ALIDIELECTRONEVTVSTRKHIST_H
+#define ALIDIELECTRONEVTVSTRKHIST_H
+
+/**
+ * @Author: Pascal Dillenseger <pascaldillenseger>
+ * @Date:   2017-08-09, 17:39:28
+ * @Email:  pdillens@cern.ch
+ * @Filename: AliDielectronEvtVsTrkHist.h
+ * @Last modified by:   pascaldillenseger
+ * @Last modified time: 2017-08-31, 13:40:29
+ */
+
+#include <TArray.h>
+#include <THashList.h>
+#include <THnSparse.h>
+#include <TNamed.h>
+#include <TObject.h>
+
+#include "AliVEvent.h"
+#include "AliVTrack.h"
+
+#include "AliDielectronHistos.h"
+#include "AliDielectronVarManager.h"
+
+
+//______________________________________________
+class AliDielectronEvtVsTrkHist : public TNamed {
+
+public:
+  // Sparse enumerator
+  enum eEvtVsTrkSparses
+  {
+    kSparseMatchEffITSTPC = 0,
+    kSparseNMaxValues
+  };
+
+  // Histogram enumerator
+  enum eEvtVsTrk3DHistos
+  {
+    k3DHistoNMaxValues = 0
+  };
+
+// Init
+  AliDielectronEvtVsTrkHist(const char *name = "EvtVsTrkHist", const char *title = "EvtVsTrkHist");
+  virtual ~AliDielectronEvtVsTrkHist();
+
+  void Init();
+
+  Float_t GetVarValueEvent(const AliVEvent *ev, Int_t var);
+  Float_t GetTrackValue(AliVTrack *trk, Int_t var);
+
+  const char* GetSparseUniqueNameInfo( Int_t iName);
+  const char* Get3DHistoUniqueNameInfo( Int_t iName);
+
+  void FillHistograms(const AliVEvent *ev);
+
+  void SetHistogramList(AliDielectronHistos *dieHistos) {fHistoList = (THashList*) dieHistos->GetHistogramList()->FindObject("EvtVsTrk"); AliDielectronEvtVsTrkHist::Init();} // All histograms from the EvtVsTrk list are used
+  Bool_t SetHistogramObj (TObject *obj);
+  Bool_t SetSparseObj(TObject *obj);
+
+  void SetSparseVars(Int_t nSparse, Int_t nAxis, Int_t type);
+  void SetEventplaneAngles(const AliVEvent *ev);
+
+  Bool_t IsSelectedITS(AliVTrack *trk);
+  Bool_t IsSelectedTPC(AliVTrack *trk);
+
+  void CalculateMatchingEfficiency();
+
+private:
+
+  Int_t  fEventNumber;   // Event number in ESD file
+  Bool_t fIsAODEvent;
+  Bool_t fSameEvent;     // Check if it is still the same event in the loop to not fill the event vars for every track
+
+  Int_t  fNObjs;       // Number of obj to be filled
+  Int_t  fNHistos;       // Number of histos to be filled
+  Int_t  fNSparses;       // Number of sparses to be filled
+
+  Int_t fNtracksITS;    // to be removed only for crosscheck
+  Int_t fNtracksTPC;    // to be removed only for crosscheck
+
+  THashList *fHistoList;
+  // TH3F *f3DHisoObjs[AliDielectronEvtVsTrkHist::k3DHistoNMaxValues]; // Activate if a 3D histogram is defined
+  THnSparseD *fSparseObjs[AliDielectronEvtVsTrkHist::kSparseNMaxValues];
+
+  Int_t fSparseVars[AliDielectronEvtVsTrkHist::kSparseNMaxValues][20];
+  Bool_t fSparseIsTrackVar[AliDielectronEvtVsTrkHist::kSparseNMaxValues][20];
+  Float_t fEventPlaneAngle[2]; // 0 = TPC, 1 = V0C
+
+  THnSparseD *fMatchEffITS;  // Sparse object to normalize the matching eff
+  THnSparseD *fMatchEffTPC;  // Sparse object to normalize the matching eff
+
+  ClassDef(AliDielectronEvtVsTrkHist,1);
+};
+
+#endif

--- a/PWGDQ/dielectron/core/AliDielectronHistos.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronHistos.cxx
@@ -17,10 +17,10 @@
 // Generic Histogram container with support for groups and filling of groups by passing
 // a vector of data
 //
-// Authors: 
-//   Jens Wiechula <Jens.Wiechula@cern.ch> 
-//   Julian Book   <Julian.Book@cern.ch> 
-// 
+// Authors:
+//   Jens Wiechula <Jens.Wiechula@cern.ch>
+//   Julian Book   <Julian.Book@cern.ch>
+//
 
 #include <TH1.h>
 #include <TH1F.h>
@@ -110,7 +110,7 @@ void AliDielectronHistos::UserProfile(const char* histClass,const char *name, co
   //
 
   TVectorD *binLimX=0x0;
-  
+
   if (logBinX) {
     binLimX=AliDielectronHelper::MakeLogBinning(nbinsX, xmin, xmax);
   } else {
@@ -135,7 +135,7 @@ void AliDielectronHistos::UserProfile(const char* histClass,const char *name, co
 
   TVectorD *binLimX=0x0;
   TVectorD *binLimY=0x0;
-  
+
   if (logBinX) {
     binLimX=AliDielectronHelper::MakeLogBinning(nbinsX, xmin, xmax);
   } else {
@@ -168,19 +168,19 @@ void AliDielectronHistos::UserProfile(const char* histClass,const char *name, co
   TVectorD *binLimX=0x0;
   TVectorD *binLimY=0x0;
   TVectorD *binLimZ=0x0;
-  
+
   if (logBinX) {
     binLimX=AliDielectronHelper::MakeLogBinning(nbinsX, xmin, xmax);
   } else {
     binLimX=AliDielectronHelper::MakeLinBinning(nbinsX, xmin, xmax);
   }
-  
+
   if (logBinY) {
     binLimY=AliDielectronHelper::MakeLogBinning(nbinsY, ymin, ymax);
   } else {
     binLimY=AliDielectronHelper::MakeLinBinning(nbinsY, ymin, ymax);
   }
-  
+
   if (logBinZ) {
     binLimZ=AliDielectronHelper::MakeLogBinning(nbinsZ, zmin, zmax);
   } else {
@@ -259,7 +259,7 @@ void AliDielectronHistos::UserProfile(const char* histClass,const char *name, co
     else
       UserHistogram(histClass, hist, 999);
   }
-  
+
   delete binsX;
 }
 
@@ -285,7 +285,7 @@ void AliDielectronHistos::UserProfile(const char* histClass,const char *name, co
     if(valTypeP==kNoProfile) {
       hist=new TH2F(name,title,
                     binsX->GetNrows()-1,binsX->GetMatrixArray(),
-                    binsY->GetNrows()-1,binsY->GetMatrixArray()); 
+                    binsY->GetNrows()-1,binsY->GetMatrixArray());
     }
     else  {
       TString opt=""; Double_t pmin=0., pmax=0.;
@@ -324,10 +324,10 @@ void AliDielectronHistos::UserProfile(const char* histClass,const char *name, co
     else
       UserHistogram(histClass, hist, 999);
   }
-  
+
   delete binsX;
   delete binsY;
-  
+
 }
 
 //_____________________________________________________________________________
@@ -395,7 +395,7 @@ void AliDielectronHistos::UserProfile(const char* histClass,const char *name, co
     else
       UserHistogram(histClass, hist, 999);
   }
-  
+
   delete binsX;
   delete binsY;
   delete binsZ;
@@ -597,7 +597,7 @@ void AliDielectronHistos::UserHistogram(const char* histClass, TObject* hist, UI
   // Add any type of user histogram
   //
 
-  //special case for the calss Pair. where histograms will be created for all pair classes
+  //special case for the class Pair. where histograms will be created for all pair classes
   Bool_t isReserved=fReservedWords->Contains(histClass);
   if (isReserved) {
     UserHistogramReservedWords(histClass, hist, valTypes);
@@ -791,7 +791,7 @@ TObject* AliDielectronHistos::GetHist(const char* cutClass, const char* histClas
   // return object from list of list of histograms
   // this function is thought for retrieving histograms if a list of AliDielectronHistos is set
   //
-  
+
   if (!fList) return 0x0;
   THashList *h=dynamic_cast<THashList*>(fList->FindObject(cutClass));
   if (!h)return 0x0;
@@ -853,7 +853,7 @@ void AliDielectronHistos::Draw(const Option_t* option)
     c->cd();
 //     c=new TCanvas;
   }
-  
+
   TIter nextClass(&fHistoList);
   THashList *classTable=0;
 //   Bool_t first=kTRUE;
@@ -881,7 +881,7 @@ void AliDielectronHistos::Draw(const Option_t* option)
 //       }
     }
     if (nCols>1||nRows>1) c->Divide(nCols,nRows);
-    
+
     //loop over histograms and draw them
     TIter nextHist(classTable);
     Int_t iPad=0;
@@ -906,7 +906,7 @@ void AliDielectronHistos::Draw(const Option_t* option)
     if (gVirtualPS) {
       c->Update();
     }
-    
+
   }
 //   if (gVirtualPS) delete c;
 }
@@ -955,7 +955,7 @@ void AliDielectronHistos::PrintStructure() const
         while ( (o=nextHist()) )
           printf("|  | ->%s\n",o->GetName());
       }
-      
+
     }
   }
 }
@@ -1070,7 +1070,7 @@ void AliDielectronHistos::DrawSame(const char* histName, const Option_t *opt)
   }
 
   if (optLeg) leg=new TLegend(.8,.3,.99,.9);
-  
+
   Int_t i=0;
   TIter next(&fHistoList);
   THashList *classTable=0;
@@ -1444,7 +1444,7 @@ void AliDielectronHistos::AdaptNameTitle(TH1 *hist, const char* histClass) {
 	hist->GetYaxis()->SetNameTitle(AliDielectronVarManager::GetValueName(vary),
 				       Form("%s%s%s%s %s",
 					(bStdOpt ? "#LT" : "RMS("),
-					AliDielectronVarManager::GetValueLabel(vary), 
+					AliDielectronVarManager::GetValueLabel(vary),
 					(bStdOpt ? "#GT" : ")"),
 					calcrange.Data(),
 					AliDielectronVarManager::GetValueUnit(vary))
@@ -1508,6 +1508,3 @@ Int_t AliDielectronHistos::GetPrecision(Double_t value) {
   return precision;
 
 }
-
-
-

--- a/PWGDQ/dielectron/core/AliDielectronVarManager.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronVarManager.cxx
@@ -564,6 +564,7 @@ const char* AliDielectronVarManager::fgkParticleNames[AliDielectronVarManager::k
 //
   {"QnDeltaPhiTPCrpH2",         "#phi^{pair}-#Psi^{TPC}",                     ""},
   {"QnDeltaPhiTrackTPCrpH2",    "#phi^{Track}-#Psi^{TPC}",                     ""},
+  {"QnDeltaPhiTrackV0CrpH2",    "#phi^{Track}-#Psi^{V0C}",                     ""},
   {"QnDeltaPhiV0ArpH2",         "#phi^{pair}-#Psi^{V0A}",                     ""},
   {"QnDeltaPhiV0CrpH2",         "#phi^{pair}-#Psi^{V0C}",                     ""},
   {"QnDeltaPhiV0rpH2",          "#phi^{pair}-#Psi^{V0}",                      ""},

--- a/PWGDQ/dielectron/core/AliDielectronVarManager.h
+++ b/PWGDQ/dielectron/core/AliDielectronVarManager.h
@@ -589,6 +589,7 @@ public:
 
     kQnDeltaPhiTPCrpH2,
     kQnDeltaPhiTrackTPCrpH2, // Track delta phi for cross-checks
+    kQnDeltaPhiTrackV0CrpH2, // Track delta phi for cross-checks
     kQnDeltaPhiV0ArpH2,
     kQnDeltaPhiV0CrpH2,
     kQnDeltaPhiV0rpH2,
@@ -1167,6 +1168,7 @@ inline void AliDielectronVarManager::FillVarAODTrack(const AliAODTrack *particle
   Double_t tpcNcls=particle->GetTPCNcls();
 
   if(Req(kQnDeltaPhiTrackTPCrpH2))   values[AliDielectronVarManager::kQnDeltaPhiTrackTPCrpH2]  = TVector2::Phi_mpi_pi(values[AliDielectronVarManager::kPhi] - values[AliDielectronVarManager::kQnTPCrpH2]);
+  if(Req(kQnDeltaPhiTrackV0CrpH2))   values[AliDielectronVarManager::kQnDeltaPhiTrackV0CrpH2]  = TVector2::Phi_mpi_pi(values[AliDielectronVarManager::kPhi] - values[AliDielectronVarManager::kQnV0CrpH2]);
 
   Double_t tpcNclsS = -99.;
   if(Req(kNclsSTPC) || Req(kNclsSFracTPC)) tpcNclsS = particle->GetTPCnclsS();


### PR DESCRIPTION
New class in the dq-framework, to create histograms plotting event variables versus track variables. Currently only the ITS-TPC matching efficiency is implemented but further options can now more or less easily be added. Although one always has to implement the recalculation of the event variable.