### PR TITLE
Missing protection in the IsJPsiPrimary function 

### DIFF
--- a/PWGDQ/dielectron/core/AliDielectronMC.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronMC.cxx
@@ -1654,6 +1654,8 @@ Int_t AliDielectronMC::IsJpsiPrimary(const AliDielectronPair * pair)
  //         "2" for background
  if(!HaveSameMother(pair)) return 2;
  AliVParticle *mcDaughter1=GetMCTrackFromMCEvent((pair->GetFirstDaughterP())->GetLabel());
+ AliVParticle *mcDaughter2=GetMCTrackFromMCEvent((pair->GetSecondDaughterP())->GetLabel());
+ if (!mcDaughter1 || !mcDaughter2) return 2;
  Int_t labelMother=-1;
 
   if (mcDaughter1->IsA()==AliMCParticle::Class()){


### PR DESCRIPTION
Missing protection in the AliDielectronMC::IsJpsiPrimary function.
This did not show up until now since the track were anyway rejected by the HaveSameMother condition rejecting track with negative label. After the change in HaveSameMother this is crashing.
Add the protection on the two daughters for the AliDielectronPair in IsJpsiPrimary. In this way, this function does not change at all, even after the change in HaveSameMother.
(Sorry)