### PR TITLE
Remove return value to fix root 6 compilation

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetShapesMC.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetShapesMC.h
@@ -84,7 +84,7 @@ class AliAnalysisTaskEmcalJetShapesMC : public AliAnalysisTaskEmcalJet {
   void SetAngularWindowRecoilJet (Float_t t)                {fangWindowRecoil = t; }
   Float_t GetMinPtTriggerSelection()                        {return fminpTTrig;}
   Float_t GetMaxPtTriggerSelection()                        {return fmaxpTTrig;}
-  Float_t SetMediumParameters(Float_t t, Float_t c)         {fqhat=t; fxlength=c;}
+  void SetMediumParameters(Float_t t, Float_t c)            {fqhat=t; fxlength=c;}
   void SetCentralitySelectionOn(Bool_t t)                   { fCentSelectOn = t;}
   void SetOneConstSelectionOn(Bool_t t)                     { fOneConstSelectOn =t;}
   void SetMinCentrality(Float_t t)                          { fCentMin = t ; }


### PR DESCRIPTION
Function was given a return type of float, but doesn't return a value.
This changes the return to void.

@lcunquei - Can you please confirm that this is the desired way to change this?