### PR TITLE
Fix OS X compilation

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoConfigObject.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoConfigObject.cxx
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <exception>
 #include <functional>
+#include <numeric>
 
 // #include <TIter.h>
 #include <TList.h>


### PR DESCRIPTION
To compile on OS X, needs <numeric> included for accumulate.

Some fixes for root 6 are also needed, but the implementation is not yet clear to me - see [here](https://github.com/alisw/AliPhysics/pull/2525#issuecomment-328223744)