### PR TITLE
Fix ROOT 6 compilation

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoConfigObject.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoConfigObject.cxx
@@ -16,6 +16,7 @@
 
 // #include <TIter.h>
 #include <TList.h>
+#include <TBuffer.h>
 
 /// \cond CLASSIMP
 ClassImp(AliFemtoConfigObject);


### PR DESCRIPTION
Explicitly add TBuffer include. Thanks @akubera for the suggestion! I should have looked more closely at the includes and the TBuffer header to see what the problem was.

Note that you also need #2544 to compile with ROOT 6 at the moment.