### PR TITLE
Changes done by Lucas Altenkamper. AliDielectronMC and AliDielectronH…

### DIFF
--- a/PWGDQ/dielectron/core/AliDielectronHelper.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronHelper.cxx
@@ -43,7 +43,6 @@
 #include <AliAODEvent.h>
 #include <AliAODTracklets.h>
 #include <AliMultiplicity.h>
-#include <AliStack.h>
 
 #include "AliDielectronVarCuts.h"
 #include "AliDielectronTrackCuts.h"
@@ -150,25 +149,21 @@ Int_t AliDielectronHelper::GetNch(const AliMCEvent *ev, Double_t etaRange, Bool_
   // determination of Nch
   if (!ev || ev->IsA()!=AliMCEvent::Class()) return -1;
 
-  AliStack *stack = ((AliMCEvent*)ev)->Stack();
-
-  if (!stack) return -1;
-
-  Int_t nParticles = stack->GetNtrack();
+  Int_t nParticles = ev->GetNumberOfTracks();
   Int_t nCh = 0;
 
   // count..
   for (Int_t iMc = 0; iMc < nParticles; ++iMc) {
-    if (!stack->IsPhysicalPrimary(iMc)) continue;
+    if (!ev->IsPhysicalPrimary(iMc)) continue;
 
-    TParticle* particle = stack->Particle(iMc);
+    TParticle* particle = ev->Particle(iMc);
     if (!particle) continue;
     if (particle->GetPDG()->Charge() == 0) continue;
 
     if(excludeJpsiDaughters){
       Int_t iMother = particle->GetMother(0);
       if( ! (iMother < 0) ) {
-        TParticle* mother = stack->Particle(iMother);
+        TParticle* mother = ev->Particle(iMother);
         if( mother && TMath::Abs( mother->GetPdgCode() ) == 443  ) continue;
       }
     }
@@ -516,17 +511,13 @@ Int_t AliDielectronHelper::GetNMothers(const AliMCEvent *ev, Double_t etaRange, 
   // counting number of mother particles generated in given eta range and 2 particle decay
   if (!ev || ev->IsA()!=AliMCEvent::Class()) return -1;
 
-  AliStack *stack = ((AliMCEvent*)ev)->Stack();
-
-  if (!stack) return -1;
-
-  Int_t nParticles = stack->GetNtrack();
+  Int_t nParticles = ev->GetNumberOfTracks();
   Int_t nMothers   = 0;
 
   // count..
   for (Int_t iMc = 0; iMc < nParticles; ++iMc) {
 
-    TParticle* particle = stack->Particle(iMc);
+    TParticle* particle = ev->Particle(iMc);
     if (!particle) continue;
     if (particle->GetPdgCode() != pdgMother)               continue;
     if (TMath::Abs(particle->Eta()) > TMath::Abs(etaRange)) continue;
@@ -536,7 +527,7 @@ Int_t AliDielectronHelper::GetNMothers(const AliMCEvent *ev, Double_t etaRange, 
     if (particle->GetFirstDaughter()>=nParticles ||
 	particle->GetFirstDaughter()<0             ) continue;
 
-    TParticle* dau1 = stack->Particle(particle->GetFirstDaughter());
+    TParticle* dau1 = ev->Particle(particle->GetFirstDaughter());
     if (TMath::Abs(dau1->GetPdgCode()) != pdgDaughter)     continue;
     if (TMath::Abs(dau1->Eta()) > TMath::Abs(etaRange)) continue;
 
@@ -544,7 +535,7 @@ Int_t AliDielectronHelper::GetNMothers(const AliMCEvent *ev, Double_t etaRange, 
     if (particle->GetLastDaughter()>=nParticles ||
 	particle->GetLastDaughter()<0             ) continue;
 
-    TParticle* dau2 = stack->Particle(particle->GetLastDaughter());
+    TParticle* dau2 = ev->Particle(particle->GetLastDaughter());
     if (TMath::Abs(dau2->GetPdgCode()) != pdgDaughter)     continue;
     if (TMath::Abs(dau2->Eta()) > TMath::Abs(etaRange)) continue;
 

--- a/PWGDQ/dielectron/core/AliDielectronMC.h
+++ b/PWGDQ/dielectron/core/AliDielectronMC.h
@@ -18,7 +18,6 @@
 #endif
 class AliESDEvent;
 class AliHFEpid;
-class AliStack;
 class AliMCEvent;
 class AliESDtrack;
 class AliAODTrack;
@@ -48,24 +47,23 @@ public:
 
   void Initialize();                              // initialization
   Int_t GetNMCTracks();                                     // return number of generated tracks
-  Int_t GetNMCTracksFromStack();                            // return number of generated tracks from stack
+  Int_t GetNMCTracksFromStack();                            // return number of generated tracks from MC event
   Int_t GetNPrimary() const;                                      // return number of primary tracks
-  Int_t GetNPrimaryFromStack();                                   // return number of primary tracks from stack
+  Int_t GetNPrimaryFromStack();                                   // return number of primary tracks from MC event
   Int_t GetMCPID(const AliESDtrack* _track);                      // return MC PID
   Int_t GetMCPID(const AliAODTrack* _track);                      // return MC PID for AODtrack
-  Int_t GetMCPIDFromStack(const AliESDtrack* _track);             // return MC PID
-  Int_t GetMotherPDG(const AliESDtrack* _track);                  // return mother PID from the MC stack
-  Int_t GetMotherPDG(const AliAODTrack* _track);                  // return mother PID from the MC stack
-  Int_t GetMotherPDG(const AliMCParticle* _track);                  // return mother PID from the MC stack
-  Int_t GetMotherPDG(const AliAODMCParticle* _track);                  // return mother PID from the MC stack
-  Int_t GetMotherPDGFromStack(const AliESDtrack* _track);         // return mother PID from the MC stack
+  Int_t GetMCPIDFromStack(const AliESDtrack* _track);             // return MC PID from MC event                                                                                       
+  Int_t GetMotherPDG(const AliESDtrack* _track);                  // return mother PID from the MC event                                                                               
+  Int_t GetMotherPDG(const AliAODTrack* _track);                  // return mother PID from the MC event                                                                               
+  Int_t GetMotherPDG(const AliMCParticle* _track);                  // return mother PID from the MC event                                                                             
+  Int_t GetMotherPDG(const AliAODMCParticle* _track);                  // return mother PID from the MC event                                                                          
+  Int_t GetMotherPDGFromStack(const AliESDtrack* _track);         // return mother PID from the MC event  
   Int_t GetMCProcess(const AliESDtrack* _track);                  // return process number
   Int_t GetMCProcessFromStack(const AliESDtrack* _track);         // return process number
   Int_t GetMCProcessMother(const AliESDtrack* _track);            // return process number of the mother track
   Int_t GetMCProcessMotherFromStack(const AliESDtrack* _track);   // return process number of the mother track
 
   Bool_t ConnectMCEvent();
-  Bool_t UpdateStack();
 
   Bool_t IsMotherPdg(const AliDielectronPair* pair, Int_t pdgMother);
   Bool_t IsMotherPdg(const AliVParticle *particle1, const AliVParticle *particle2, Int_t pdgMother);
@@ -93,14 +91,14 @@ public:
 
 //   AliVParticle* GetMCTrackFromMCEvent(const AliVParticle *track);   // return MC track directly from MC event
   AliVParticle* GetMCTrackFromMCEvent(Int_t label) const;           // return MC track directly from MC event
-  TParticle* GetMCTrackFromStack(const AliESDtrack* _track);        // return MC track from stack
+  TParticle* GetMCTrackFromStack(const AliESDtrack* _track);        // return MC track from MC event
   AliMCParticle* GetMCTrack(const AliESDtrack* _track);             // return MC track associated with reco track
   AliAODMCParticle* GetMCTrack( const AliAODTrack* _track);          // return MC track associated with reco AOD track
 
-  TParticle* GetMCTrackMotherFromStack(const AliESDtrack* _track);  // return MC mother track from stack
-  AliMCParticle* GetMCTrackMother(const AliESDtrack* _track);       // return MC mother track from stack
+  TParticle* GetMCTrackMotherFromStack(const AliESDtrack* _track);  // return MC mother track from MC event                                                                            
+  AliMCParticle* GetMCTrackMother(const AliESDtrack* _track);       // return MC mother track from MC event 
   AliAODMCParticle* GetMCTrackMother(const AliAODTrack* _track);       // return MC mother fot track AODTrack
-  AliMCParticle* GetMCTrackMother(const AliMCParticle* _particle);       // return MC mother track from stack
+  AliMCParticle* GetMCTrackMother(const AliMCParticle* _particle);       // return MC mother track from stack                                                                          
   AliAODMCParticle* GetMCTrackMother(const AliAODMCParticle* _particle);       // return MC mother track from stack
 
   Int_t NumberOfDaughters(const AliESDtrack* track);                 // return number of daughters
@@ -118,7 +116,6 @@ public:
 
 private:
   AliMCEvent    *fMCEvent;  // MC event object
-  AliStack      *fStack;    // MC stack
 
   AnalysisType fAnaType;    // Analysis type
   Bool_t fHasMC;            // Do we have an MC handler?
@@ -154,7 +151,7 @@ private:
   Bool_t LoadHFPairs();
   Int_t  IsaBhadron(Int_t pdg) const;
   
-  ClassDef(AliDielectronMC, 1)
+  ClassDef(AliDielectronMC, 2)
 };
 
 //


### PR DESCRIPTION
…elper classes updated

to use only AliMCEvent methods. The usage of AliStack has been removed as requested by DPG
to enable the use of MC-to-MC embedding.