### PR TITLE
Adding a switch for the candidate-based cone area computation

### DIFF
--- a/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.cxx
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.cxx
@@ -104,6 +104,7 @@ fTest2(0),
 fMCtruth(0),
 fPeriod(""),
 fFiducialCut(0.4),
+fConeAreaPerEvent(kFALSE),
 fEClustersT(0),
 fPtClustersT(0),
 fEtClustersT(0),
@@ -293,6 +294,7 @@ fTest2(0),
 fMCtruth(0),
 fPeriod(""),
 fFiducialCut(0.4),
+fConeAreaPerEvent(kFALSE),
 fEClustersT(0),
 fPtClustersT(0),
 fEtClustersT(0),
@@ -2369,7 +2371,7 @@ void AliAnalysisTaskEMCALPhotonIsolation::EtIsoClusEtaBand(TLorentzVector c, Dou
   
   fTestEnergyCone->Fill(c.Pt(),sumEnergyConeClus,sumpTConeCharged);
 
-  if(fWho == 2 && fFiducialCut < 0.4){
+  if(fWho == 2 && fConeAreaPerEvent){
     ComputeConeArea(c, isoConeArea);
     fTestEnergyConeNorm->Fill(c.Pt(), sumEnergyConeClus/isoConeArea, sumpTConeCharged/isoConeArea);
   }

--- a/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.h
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.h
@@ -116,6 +116,7 @@ class AliAnalysisTaskEMCALPhotonIsolation: public AliAnalysisTaskEmcal {
   void                     SetNcontributorsToPileUp (Int_t nCtoPU)                         { fNContrToPileUp = nCtoPU; }
   void                     SetLightenOutput (Bool_t light)                                 { fLightOutput = light; }
   void                     SetFiducialCut(Float_t fiducial)                                { fFiducialCut = fiducial; }
+  void                     SetComputeConeAreaPerEvent(Bool_t eventCone)                    { fConeAreaPerEvent = eventCone; }
   void                     Set2012L1Analysis(Bool_t is2012L1)                              { f2012EGA = is2012L1; }
  protected:
   
@@ -213,6 +214,7 @@ class AliAnalysisTaskEMCALPhotonIsolation: public AliAnalysisTaskEmcal {
   Bool_t      fMCtruth;                        // Enable/disable MC truth analysis
   TString     fPeriod;                         // String containing the LHC period
   Float_t     fFiducialCut;                    // Variable fiducial cut from the border of the EMCal/TPC acceptance
+  Bool_t      fConeAreaPerEvent;               // Enable/disable the event-by-event cone area computation
   Bool_t      f2012EGA;                        // Analyze only Events with EGA recalc patches above threshold
   
   // Initialization for TTree variables

--- a/PWGGA/EMCALTasks/macros/AddTaskEMCALPhotonIsolation.C
+++ b/PWGGA/EMCALTasks/macros/AddTaskEMCALPhotonIsolation.C
@@ -218,7 +218,7 @@ AliAnalysisTaskEMCALPhotonIsolation* AddTaskEMCALPhotonIsolation(
   task->SetNcontributorsToPileUp(NContrToPileUp);
   task->SetLightenOutput(lightOutput);
   task->SetFiducialCut(iFiducialCut);
-  Bool_t coneAreaPerEvent = kFALSE; // TEMPORARY PLACEMENT (to be a task parameter in the future)
+  Bool_t coneAreaPerEvent = kTRUE; // TEMPORARY PLACEMENT (to be a task parameter in the future)
   task->SetComputeConeAreaPerEvent(coneAreaPerEvent);
   task->Set2012L1Analysis(is2012_EGA);
 

--- a/PWGGA/EMCALTasks/macros/AddTaskEMCALPhotonIsolation.C
+++ b/PWGGA/EMCALTasks/macros/AddTaskEMCALPhotonIsolation.C
@@ -218,6 +218,8 @@ AliAnalysisTaskEMCALPhotonIsolation* AddTaskEMCALPhotonIsolation(
   task->SetNcontributorsToPileUp(NContrToPileUp);
   task->SetLightenOutput(lightOutput);
   task->SetFiducialCut(iFiducialCut);
+  Bool_t coneAreaPerEvent = kFALSE; // TEMPORARY PLACEMENT (to be a task parameter in the future)
+  task->SetComputeConeAreaPerEvent(coneAreaPerEvent);
   task->Set2012L1Analysis(is2012_EGA);
 
   if(bIsMC && bMCNormalization) task->SetIsPythia(kTRUE);


### PR DESCRIPTION
This new switch is temporarily set to `kTRUE` in order to test a new feature. In future this should become a new parameter of the task but this will require some cleanup since we currently are at the maximal number of parameters (40).