### PR TITLE
PWGDQ fixes in match eff calc for EvtVsTrk class

### DIFF
--- a/PWGDQ/dielectron/core/AliDielectron.cxx
+++ b/PWGDQ/dielectron/core/AliDielectron.cxx
@@ -423,7 +423,10 @@ Bool_t AliDielectron::Process(AliVEvent *ev1, AliVEvent *ev2)
   // set event
   AliDielectronVarManager::SetFillMap(fUsedVars);
   AliDielectronVarManager::SetEvent(ev1);
-  if(fEvtVsTrkHist)  fEvtVsTrkHist->FillHistograms(ev1);
+  if(fEvtVsTrkHist){
+    fEvtVsTrkHist->SetPIDResponse(AliDielectronVarManager::GetPIDResponse());
+    fEvtVsTrkHist->FillHistograms(ev1);
+  }
 
   if (fMixing){
     //set mixing bin to event data

--- a/PWGDQ/dielectron/core/AliDielectronEvtVsTrkHist.h
+++ b/PWGDQ/dielectron/core/AliDielectronEvtVsTrkHist.h
@@ -7,7 +7,7 @@
  * @Email:  pdillens@cern.ch
  * @Filename: AliDielectronEvtVsTrkHist.h
  * @Last modified by:   pascaldillenseger
- * @Last modified time: 2017-08-31, 13:40:29
+ * @Last modified time: 2017-09-12, 14:22:00
  */
 
 #include <TArray.h>
@@ -61,8 +61,11 @@ public:
   void SetSparseVars(Int_t nSparse, Int_t nAxis, Int_t type);
   void SetEventplaneAngles(const AliVEvent *ev);
 
+  void SetPIDResponse(AliPIDResponse *pidResponse) {fPIDResponse = pidResponse;}
+
   Bool_t IsSelectedITS(AliVTrack *trk);
   Bool_t IsSelectedTPC(AliVTrack *trk);
+  Bool_t IsSelectedKinematics(AliVTrack *trk);
 
   void CalculateMatchingEfficiency();
 
@@ -86,6 +89,8 @@ private:
   Int_t fSparseVars[AliDielectronEvtVsTrkHist::kSparseNMaxValues][20];
   Bool_t fSparseIsTrackVar[AliDielectronEvtVsTrkHist::kSparseNMaxValues][20];
   Float_t fEventPlaneAngle[2]; // 0 = TPC, 1 = V0C
+
+  AliPIDResponse *fPIDResponse; // Used for the pid cut
 
   THnSparseD *fMatchEffITS;  // Sparse object to normalize the matching eff
   THnSparseD *fMatchEffTPC;  // Sparse object to normalize the matching eff

--- a/PWGDQ/dielectron/core/AliDielectronHelper.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronHelper.cxx
@@ -294,7 +294,6 @@ Int_t AliDielectronHelper::GetNacc(const AliVEvent *ev){
 Double_t AliDielectronHelper::GetITSTPCMatchEff(const AliVEvent *ev, Double_t *efficiencies, Bool_t bEventPlane, Bool_t useV0Cep){
   // recalulate the its-tpc matching efficiecy
   if (!ev) return -1;
-  Bool_t bDebug = kFALSE;
 
 
   // AliDielectronVarCuts varCutsTPC;


### PR DESCRIPTION
Matching efficiency is now calculated more ALICE common as nTracksITS/nTracksTPC. Some more cuts are applied on the track sample to get a more realistic result for the Jpsi track sample.