### PR TITLE
Minor bug fix in D*-h task when using small-sized THnSparse

### DIFF
--- a/PWGHF/correlationHF/AliAnalysisTaskDStarCorrelations.cxx
+++ b/PWGHF/correlationHF/AliAnalysisTaskDStarCorrelations.cxx
@@ -1493,7 +1493,10 @@ void AliAnalysisTaskDStarCorrelations::DefineThNSparseForAnalysis(){
     Int_t nbinsSparse[5]=      {nbinscorr, 50 ,  32, 10,nbinsPool};
     Double_t binLowLimitSparse[5]={lowcorrbin,0.142 ,-1.6,  0,-0.5};
     Double_t binUpLimitSparse[5]= {upcorrbin ,0.1495 , 1.6,  5,nbinsPool-0.5};
-    if(fUseSmallSizePlots) nbinsSparse[1]=25; nbinsSparse[2]=16;
+    if(fUseSmallSizePlots) {
+      nbinsSparse[1]=25;
+      nbinsSparse[2]=16;
+    }
     
     
   //  Int_t nbinsSparseDStarSB[5]=         {nbinscorr ,     27 ,  32, 10,nbinsPool};


### PR DESCRIPTION
(different deltaEta bin width in signal and SB THnSparse)