### PR TITLE
Correction in Bad Channel map access

### DIFF
--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALTimeCalib.cxx
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALTimeCalib.cxx
@@ -1499,7 +1499,7 @@ void AliAnalysisTaskEMCALTimeCalib::LoadBadChannelMapOADB()
   } else AliInfo("Do NOT remove EMCAL bad channels\n"); // run array
       
   delete contBC;
-  fBadChannelMapSet=kTRUE;
+  fBadChannelMapSet = kFALSE;//BC map is not fixed at the beginning but can change r-by-r
 }  // Bad channel map loaded
 
 //____________________________________________________
@@ -1518,7 +1518,7 @@ void AliAnalysisTaskEMCALTimeCalib::LoadBadChannelMapFile()
   }
   fBadChannelMapArray = new TObjArray(1);
   fBadChannelMapArray->AddAt(hbm,0);
-  fBadChannelMapSet=kTRUE;
+  fBadChannelMapSet=kTRUE;//BC map is fixed at the beginning for whole dataset
 }  // Bad channel map loaded
 
 

--- a/PWGPP/EMCAL/macros/AddTaskEMCALTimeCalibration.C
+++ b/PWGPP/EMCAL/macros/AddTaskEMCALTimeCalibration.C
@@ -115,8 +115,10 @@ AliAnalysisTaskEMCALTimeCalib  * AddTaskEMCALTimeCalibration(TString  outputFile
 
   //bad channel map
   taskmbemcal->SetBadChannelMapSource(badMapType);
-  if(badMapType==2) taskmbemcal->SetBadChannelFileName(badMapFileName);
-
+  if(badMapType==2) {
+    taskmbemcal->SetBadChannelFileName(badMapFileName);
+    taskmbemcal->LoadBadChannelMapFile();
+  }
 
   //taskmbemcal->PrintInfo();
 

--- a/PWGPP/EMCAL/macros/runEMCALTimeCalibTask.C
+++ b/PWGPP/EMCAL/macros/runEMCALTimeCalibTask.C
@@ -154,8 +154,11 @@ void runEMCALTimeCalibTask(Int_t type=0, Bool_t isESD=kTRUE, Bool_t isPhysicsSel
   //taskmbemcal->SetPassTimeHisto(1400,-350.,350.);
 
   taskmbemcal->SetBadChannelMapSource(0);
-  if(taskmbemcal->GetBadChannelMapSource()==2) taskmbemcal->SetBadChannelFileName("badMap.root");
-
+  if(taskmbemcal->GetBadChannelMapSource()==2) {
+    taskmbemcal->SetBadChannelFileName("badMap.root");
+    taskmbemcal->LoadBadChannelMapFile();
+  }
+    
   //calibration with each cell
   taskmbemcal->SwitchOffMostEneCellOnly();
 


### PR DESCRIPTION
1. Fix the manually inserting of BC map in AddTask and local macro. No need to add one specific line when running lego trains.
2. BC map loaded from OADB can change run-by-run and is not fixed at the beginning of processing in lego trains.