### PR TITLE
[ALPHY-81] EMCal: Alternative cluster vertex fix

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
@@ -1527,14 +1527,12 @@ Bool_t AliAnalysisTaskEmcal::RetrieveEventObjects()
 
   TIter nextPartColl(&fParticleCollArray);
   while ((cont = static_cast<AliEmcalContainer*>(nextPartColl()))){
-    cont->NextEvent();
-    cont->SetVertex(fVertex);
+    cont->NextEvent(InputEvent());
   }
 
   TIter nextClusColl(&fClusterCollArray);
   while ((cont = static_cast<AliParticleContainer*>(nextClusColl()))){
-    cont->NextEvent();
-    cont->SetVertex(fVertex);
+    cont->NextEvent(InputEvent());
   }
 
   return kTRUE;

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.cxx
@@ -1050,8 +1050,8 @@ Bool_t AliAnalysisTaskEmcalLight::RetrieveEventObjects()
     }
   }
 
-  for (auto cont_it : fParticleCollArray) cont_it.second->NextEvent();
-  for (auto cont_it : fClusterCollArray) cont_it.second->NextEvent();
+  for (auto cont_it : fParticleCollArray) cont_it.second->NextEvent(InputEvent());
+  for (auto cont_it : fClusterCollArray) cont_it.second->NextEvent(InputEvent());
 
   return kTRUE;
 }

--- a/PWG/EMCAL/EMCALbase/AliEmcalContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalContainer.cxx
@@ -19,6 +19,7 @@
 #include "AliVParticle.h"
 #include "AliTLorentzVector.h"
 
+#include "AliEmcalContainerUtils.h"
 #include "AliAnalysisTaskEmcalEmbeddingHelper.h"
 
 #include "AliEmcalContainer.h"
@@ -126,6 +127,16 @@ void AliEmcalContainer::SetClassName(const char *clname)
 }
 
 /**
+ * Retrieve the vertex from the given event. It sets fVertex to the vertex of the current event.
+ * @param[in] event Input event containing the vertex.
+ */
+void AliEmcalContainer::GetVertexFromEvent(const AliVEvent * event)
+{
+  const AliVVertex *vertex = event->GetPrimaryVertex();
+  if (vertex) vertex->GetXYZ(fVertex);
+}
+
+/**
  * Connect the container to the array with content stored inside the virtual event.
  * The object name in the event must match the name given in the constructor
  * @param event Input event containing the array with content.
@@ -137,21 +148,12 @@ void AliEmcalContainer::SetArray(const AliVEvent *event)
     fClArrayName = GetDefaultArrayName(event);
   }
 
-  if (fIsEmbedding) {
-    // this is an embedding container
-    // will ignore the provided event and use the event
-    // from the embedding helper class
-
-    const AliAnalysisTaskEmcalEmbeddingHelper* embedding = AliAnalysisTaskEmcalEmbeddingHelper::GetInstance();
-    if (!embedding) return;
-
-    event = embedding->GetExternalEvent();
-  }
+  // Get the right event (either the current event of the embedded event)
+  event = AliEmcalContainerUtils::GetEvent(event, fIsEmbedding);
 
   if (!event) return;
 
-  const AliVVertex *vertex = event->GetPrimaryVertex();
-  if (vertex) vertex->GetXYZ(fVertex);
+  GetVertexFromEvent(event);
 
   if (!fClArrayName.IsNull() && !fClArray) {
     fClArray = dynamic_cast<TClonesArray*>(event->FindListObject(fClArrayName));
@@ -175,6 +177,20 @@ void AliEmcalContainer::SetArray(const AliVEvent *event)
   }
 
   fLabelMap = dynamic_cast<AliNamedArrayI*>(event->FindListObject(fClArrayName + "_Map"));
+}
+
+/**
+ * Preparation for the next event.
+ * @param[in] event The event to be processed.
+ */
+void AliEmcalContainer::NextEvent(const AliVEvent * event)
+{
+  // Get the right event (either the current event of the embedded event)
+  event = AliEmcalContainerUtils::GetEvent(event, fIsEmbedding);
+
+  if (!event) return;
+
+  GetVertexFromEvent(event);
 }
 
 /**

--- a/PWG/EMCAL/EMCALbase/AliEmcalContainer.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalContainer.h
@@ -160,7 +160,7 @@ class AliEmcalContainer : public TObject {
   void                        SortArray()                           { fClArray->Sort()                  ; }
 
   TClass*                     GetLoadedClass()                      { return fLoadedClass               ; }
-  virtual void                NextEvent() {;}
+  virtual void                NextEvent(const AliVEvent *event);
   void                        SetMinMCLabel(Int_t s)                            { fMinMCLabel      = s   ; }
   void                        SetMaxMCLabel(Int_t s)                            { fMaxMCLabel      = s   ; }
   void                        SetMCLabelRange(Int_t min, Int_t max)             { SetMinMCLabel(min)     ; SetMaxMCLabel(max)    ; }
@@ -202,6 +202,7 @@ class AliEmcalContainer : public TObject {
    * @return Default array name
    */
   virtual TString             GetDefaultArrayName(const AliVEvent * const ev) const { return ""; }
+  void                        GetVertexFromEvent(const AliVEvent * event);
 
   TString                     fName;                    ///< object name
   TString                     fClArrayName;             ///< name of branch

--- a/PWG/EMCAL/EMCALbase/AliEmcalContainerUtils.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalContainerUtils.cxx
@@ -94,7 +94,35 @@ std::string AliEmcalContainerUtils::DetermineUseDefaultName(InputObject_t objTyp
 
 /**
  * Get the proper event based on whether embedding is enabled or not. Useful when determining from which event
- * an input object should be retrieved. It could either be the current input event or an embedded event.
+ * an input object should be retrieved. It could either be the current input event or an embedded event. This is
+ * the const version.
+ *
+ * @param[in] inputEvent The input event of the analysis. Will be returned if nothing else is requested. Usually just InputEvent().
+ * @param[in] isEmbedding True if the event from embedding should be used.
+ *
+ * @return The input event to be used
+ */
+const AliVEvent * AliEmcalContainerUtils::GetEvent(const AliVEvent * inputEvent, bool isEmbedding)
+{
+  const AliVEvent * event = nullptr;
+  if (isEmbedding) {
+    const AliAnalysisTaskEmcalEmbeddingHelper* embedding = AliAnalysisTaskEmcalEmbeddingHelper::GetInstance();
+    if (!embedding) return nullptr;
+
+    // Need the const cast as GetExternalEvent() returns a non-const event
+    event = const_cast<const AliVEvent *>(embedding->GetExternalEvent());
+  }
+  else {
+    event = inputEvent;
+  }
+
+  return event;
+}
+
+/**
+ * Get the proper event based on whether embedding is enabled or not. Useful when determining from which event
+ * an input object should be retrieved. It could either be the current input event or an embedded event. This is
+ * the non-const version.
  *
  * @param[in] inputEvent The input event of the analysis. Will be returned if nothing else is requested. Usually just InputEvent().
  * @param[in] isEmbedding True if the event from embedding should be used.
@@ -103,17 +131,6 @@ std::string AliEmcalContainerUtils::DetermineUseDefaultName(InputObject_t objTyp
  */
 AliVEvent * AliEmcalContainerUtils::GetEvent(AliVEvent * inputEvent, bool isEmbedding)
 {
-  AliVEvent * event = 0;
-  if (isEmbedding) {
-    const AliAnalysisTaskEmcalEmbeddingHelper* embedding = AliAnalysisTaskEmcalEmbeddingHelper::GetInstance();
-    if (!embedding) return 0;
-
-    event = embedding->GetExternalEvent();
-  }
-  else {
-    event = inputEvent;
-  }
-
-  return event;
+  return const_cast<AliVEvent *>(GetEvent(const_cast<const AliVEvent *>(inputEvent), isEmbedding));
 }
 

--- a/PWG/EMCAL/EMCALbase/AliEmcalContainerUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalContainerUtils.h
@@ -50,6 +50,7 @@ class AliEmcalContainerUtils {
 
   // Utility functions
   static std::string DetermineUseDefaultName(InputObject_t objType, bool esdMode, bool returnObjectType = false);
+  static const AliVEvent * GetEvent(const AliVEvent * inputEvent, bool isEmbedding = false);
   static AliVEvent * GetEvent(AliVEvent * inputEvent, bool isEmbedding = false);
 
 #if !(defined(__CINT__) || defined(__MAKECINT__))

--- a/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
@@ -149,8 +149,10 @@ void AliTrackContainer::SetArray(const AliVEvent *event)
  * selection of all bit and store the pointers to
  * selected tracks in a separate array.
  */
-void AliTrackContainer::NextEvent()
+void AliTrackContainer::NextEvent(const AliVEvent * event)
 {
+  AliParticleContainer::NextEvent(event);
+
   fTrackTypes.Reset(kUndefined);
   if (fEmcalTrackSelection) {
     fFilteredTracks = fEmcalTrackSelection->GetAcceptedTracks(fClArray);

--- a/PWG/EMCAL/EMCALbase/AliTrackContainer.h
+++ b/PWG/EMCAL/EMCALbase/AliTrackContainer.h
@@ -91,7 +91,7 @@ class AliTrackContainer : public AliParticleContainer {
   void SetSelectionModeAny() { fSelectionModeAny = kTRUE ; }
   void SetSelectionModeAll() { fSelectionModeAny = kFALSE; }
 
-  void                        NextEvent();
+  void                        NextEvent(const AliVEvent* event);
 
   static void                 SetDefTrackCutsPeriod(const char* period)       { fgDefTrackCutsPeriod = period; }
   static TString              GetDefTrackCutsPeriod()                         { return fgDefTrackCutsPeriod  ; }

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
@@ -1330,10 +1330,10 @@ Bool_t AliEmcalCorrectionTask::RetrieveEventObjects()
   AliEmcalContainer* cont = 0;
 
   TIter nextPartColl(&fParticleCollArray);
-  while ((cont = static_cast<AliEmcalContainer*>(nextPartColl()))) cont->NextEvent();
+  while ((cont = static_cast<AliEmcalContainer*>(nextPartColl()))) cont->NextEvent(InputEvent());
 
   TIter nextClusColl(&fClusterCollArray);
-  while ((cont = static_cast<AliEmcalContainer*>(nextClusColl()))) cont->NextEvent();
+  while ((cont = static_cast<AliEmcalContainer*>(nextClusColl()))) cont->NextEvent(InputEvent());
 
   return kTRUE;
 }

--- a/PWG/JETFW/AliAnalysisTaskEmcalJet.cxx
+++ b/PWG/JETFW/AliAnalysisTaskEmcalJet.cxx
@@ -239,7 +239,7 @@ Bool_t AliAnalysisTaskEmcalJet::RetrieveEventObjects()
   AliEmcalContainer* cont = 0;
 
   TIter nextJetColl(&fJetCollArray);
-  while ((cont = static_cast<AliEmcalContainer*>(nextJetColl()))) cont->NextEvent();
+  while ((cont = static_cast<AliEmcalContainer*>(nextJetColl()))) cont->NextEvent(InputEvent());
 
   return kTRUE;
 }

--- a/PWG/JETFW/AliAnalysisTaskEmcalJetLight.cxx
+++ b/PWG/JETFW/AliAnalysisTaskEmcalJetLight.cxx
@@ -103,7 +103,7 @@ Bool_t AliAnalysisTaskEmcalJetLight::RetrieveEventObjects()
 {
   if (!AliAnalysisTaskEmcalLight::RetrieveEventObjects()) return kFALSE;
 
-  for (auto cont_it : fJetCollArray) cont_it.second->NextEvent();
+  for (auto cont_it : fJetCollArray) cont_it.second->NextEvent(InputEvent());
 
   return kTRUE;
 }

--- a/PWGJE/EMCALJetTasks/UserTasks/AliTrackContainerV0.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliTrackContainerV0.cxx
@@ -72,9 +72,9 @@ void AliTrackContainerV0::SetArray(const AliVEvent *event)
 
 /// Preparation for next event. 
 /// Run in each event (via AliAnalysisTaskEmcal::RetrieveEventObjects)
-void AliTrackContainerV0::NextEvent()
+void AliTrackContainerV0::NextEvent(const AliVEvent * event)
 {
-  AliTrackContainer::NextEvent();
+  AliTrackContainer::NextEvent(event);
   
   if (fFilterDaughterTracks) {
     // V0s daughter tracks will be removed from track sample

--- a/PWGJE/EMCALJetTasks/UserTasks/AliTrackContainerV0.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliTrackContainerV0.h
@@ -44,7 +44,7 @@ class AliTrackContainerV0 : public AliTrackContainer {
 
   	// reimplementation of inherited methods
   	virtual void    SetArray(const AliVEvent *event);
-  	virtual void    NextEvent();
+  	virtual void    NextEvent(const AliVEvent *event);
   	virtual Bool_t	ApplyTrackCuts(const AliVTrack* vp, UInt_t &rejectionReason) const;
 		
 		void ExtractDaughters(AliAODv0* cand);


### PR DESCRIPTION
Replaces the previous fix in 098573b2 with an solution that also works
seamlessly for embedding.

Further discussion is available at the [JIRA Ticket](https://alice.its.cern.ch/jira/browse/ALPHY-81).