### PR TITLE
Additional histos in MC, strangeness and conversions

### DIFF
--- a/PWGGA/CaloTrackCorrelations/AliAnaPi0.cxx
+++ b/PWGGA/CaloTrackCorrelations/AliAnaPi0.cxx
@@ -102,7 +102,7 @@ fhPrimEtaOpeningAngleAsym(0x0),fhPrimEtaCosOpeningAngle(0x0),
 fhPrimEtaPtCentrality(0),    fhPrimEtaPtEventPlane(0),
 fhPrimEtaAccPtCentrality(0), fhPrimEtaAccPtEventPlane(0),
 fhPrimPi0PtOrigin(0x0),      fhPrimEtaPtOrigin(0x0),
-fhPrimNotResonancePi0PtOrigin(0x0),      fhPrimPi0PtStatus(0x0),
+			 fhPrimNotResonancePi0PtOrigin(0x0),      fhPrimPi0PtStatus(0x0),
 fhMCPi0MassPtRec(0x0),       fhMCPi0MassPtTrue(0x0),
 fhMCPi0PtTruePtRec(0x0),     fhMCPi0PtTruePtRecMassCut(0x0),
 fhMCEtaMassPtRec(0x0),       fhMCEtaMassPtTrue(0x0),
@@ -114,7 +114,7 @@ fhMCEtaPtTruePtRecRat(0),    fhMCEtaPtTruePtRecDif(0), fhMCEtaPtRecOpenAngle(0),
 fhMCPi0PtTruePtRecRatMassCut(0), fhMCPi0PtTruePtRecDifMassCut(0), fhMCPi0PtRecOpenAngleMassCut(0),
 fhMCEtaPtTruePtRecRatMassCut(0), fhMCEtaPtTruePtRecDifMassCut(0), fhMCEtaPtRecOpenAngleMassCut(0),
 fhMCPi0PtOrigin(0),          fhMCEtaPtOrigin(0),
-fhMCNotResonancePi0PtOrigin(0),fhMCPi0PtStatus(0x0),
+fhMCNotResonancePi0PtOrigin(0),fhMCPi0PtStatus(0x0),fhMCPi0PtStrangeness(0x0),
 fhMCPi0ProdVertex(0),        fhMCEtaProdVertex(0),
 fhPrimPi0ProdVertex(0),      fhPrimEtaProdVertex(0),
 fhReMCFromConversion(0),     fhReMCFromNotConversion(0),   fhReMCFromMixConversion(0),
@@ -231,6 +231,11 @@ fhReSecondaryCellOutTimeWindow(0), fhMiSecondaryCellOutTimeWindow(0)
     fhMCOrgAsym    [i] =0 ;
     fhMCOrgDeltaEta[i] =0 ;
     fhMCOrgDeltaPhi[i] =0 ;
+  }
+  for(Int_t i = 0; i < 3; i++)
+  {
+    fhMCOrgPi0MassPtConversion[i] =0 ;
+    fhMCOrgEtaMassPtConversion[i] =0 ;
   }
 }
 
@@ -742,7 +747,7 @@ TList * AliAnaPi0::GetCreateOutputObjects()
       fhPrimPi0PtStatus->SetXTitle("#it{p}_{T} (GeV/#it{c})");
       fhPrimPi0PtStatus->SetYTitle("Status");
       outputContainer->Add(fhPrimPi0PtStatus) ;
-      
+
       // Eta
       fhPrimEtaPtOrigin     = new TH2F("hPrimEtaPtOrigin","Primary #pi^{0} #it{p}_{T} vs origin",nptbins,ptmin,ptmax,7,0,7) ;
       fhPrimEtaPtOrigin->SetXTitle("#it{p}_{T} (GeV/#it{c})");
@@ -1416,6 +1421,17 @@ TList * AliAnaPi0::GetCreateOutputObjects()
       fhMCPi0PtStatus->SetXTitle("#it{p}_{T} (GeV/#it{c})");
       fhMCPi0PtStatus->SetYTitle("Status");
       outputContainer->Add(fhMCPi0PtStatus) ;
+
+      fhMCPi0PtStrangeness     = new TH2F("hMCPi0PtStrangeness","Primary #pi^{0} #it{p}_{T} vs strangeness origin",nptbins,ptmin,ptmax,5,0,5) ;
+      fhMCPi0PtStrangeness->SetXTitle("#it{p}_{T} (GeV/#it{c})");
+      fhMCPi0PtStrangeness->SetYTitle("Origin");
+      fhMCPi0PtStrangeness->GetYaxis()->SetBinLabel(1 ,"K0S");
+      fhMCPi0PtStrangeness->GetYaxis()->SetBinLabel(2 ,"K0L");
+      fhMCPi0PtStrangeness->GetYaxis()->SetBinLabel(3 ,"K+- ");
+      fhMCPi0PtStrangeness->GetYaxis()->SetBinLabel(4 ,"K*");
+      fhMCPi0PtStrangeness->GetYaxis()->SetBinLabel(5 ,"Lambda");
+      outputContainer->Add(fhMCPi0PtStrangeness) ;
+      
       
       // Eta
       
@@ -1496,6 +1512,44 @@ TList * AliAnaPi0::GetCreateOutputObjects()
         fhMCOrgDeltaPhi[i]->SetYTitle("#Delta #varphi (rad)");
         outputContainer->Add(fhMCOrgDeltaPhi[i]) ;
       }
+
+      //reconstructed gamma clusters coming pi0 (validated in MC true) both not from conversion, with one or two conversions
+      fhMCOrgPi0MassPtConversion[0] = new TH2F("hMCOrgPi0MassPtConversion0","Invariant mass of 2 clusters (ancestor #pi^{0}) not originated in conversions",
+					       nptbins,ptmin,ptmax,nmassbins,massmin,massmax);
+      fhMCOrgPi0MassPtConversion[0]->SetXTitle("#it{p}_{T} (GeV/#it{c})");
+      fhMCOrgPi0MassPtConversion[0]->SetYTitle("#it{M}_{#gamma,#gamma} (GeV/#it{c}^{2})");
+      outputContainer->Add(fhMCOrgPi0MassPtConversion[0]) ;
+
+      fhMCOrgPi0MassPtConversion[1] = new TH2F("hMCOrgPi0MassPtConversion1","Invariant mass of 2 clusters (ancestor #pi^{0}) one from conversion and the other not",
+					       nptbins,ptmin,ptmax,nmassbins,massmin,massmax);
+      fhMCOrgPi0MassPtConversion[1]->SetXTitle("#it{p}_{T} (GeV/#it{c})");
+      fhMCOrgPi0MassPtConversion[1]->SetYTitle("#it{M}_{#gamma,#gamma} (GeV/#it{c}^{2})");
+      outputContainer->Add(fhMCOrgPi0MassPtConversion[1]) ;
+
+      fhMCOrgPi0MassPtConversion[2] = new TH2F("hMCOrgPi0MassPtConversion2","Invariant mass of 2 clusters (ancestor #pi^{0}) originated in conversions",
+					       nptbins,ptmin,ptmax,nmassbins,massmin,massmax);
+      fhMCOrgPi0MassPtConversion[2]->SetXTitle("#it{p}_{T} (GeV/#it{c})");
+      fhMCOrgPi0MassPtConversion[2]->SetYTitle("#it{M}_{#gamma,#gamma} (GeV/#it{c}^{2})");
+      outputContainer->Add(fhMCOrgPi0MassPtConversion[2]) ;
+
+      //reconstructed gamma clusters coming eta (validated in MC true) both not from conversion, with one or two conversions
+      fhMCOrgEtaMassPtConversion[0] = new TH2F("hMCOrgEtaMassPtConversion0","Invariant mass of 2 clusters (ancestor #eta) not originated in conversions",
+					       nptbins,ptmin,ptmax,nmassbins,massmin,massmax);
+      fhMCOrgEtaMassPtConversion[0]->SetXTitle("#it{p}_{T} (GeV/#it{c})");
+      fhMCOrgEtaMassPtConversion[0]->SetYTitle("#it{M}_{#gamma,#gamma} (GeV/#it{c}^{2})");
+      outputContainer->Add(fhMCOrgEtaMassPtConversion[0]) ;
+
+      fhMCOrgEtaMassPtConversion[1] = new TH2F("hMCOrgEtaMassPtConversion1","Invariant mass of 2 clusters (ancestor #eta) one from conversion and the other not",
+					       nptbins,ptmin,ptmax,nmassbins,massmin,massmax);
+      fhMCOrgEtaMassPtConversion[1]->SetXTitle("#it{p}_{T} (GeV/#it{c})");
+      fhMCOrgEtaMassPtConversion[1]->SetYTitle("#it{M}_{#gamma,#gamma} (GeV/#it{c}^{2})");
+      outputContainer->Add(fhMCOrgEtaMassPtConversion[1]) ;
+
+      fhMCOrgEtaMassPtConversion[2] = new TH2F("hMCOrgEtaMassPtConversion2","Invariant mass of 2 clusters (ancestor #eta) originated in conversions",
+					       nptbins,ptmin,ptmax,nmassbins,massmin,massmax);
+      fhMCOrgEtaMassPtConversion[2]->SetXTitle("#it{p}_{T} (GeV/#it{c})");
+      fhMCOrgEtaMassPtConversion[2]->SetYTitle("#it{M}_{#gamma,#gamma} (GeV/#it{c}^{2})");
+      outputContainer->Add(fhMCOrgEtaMassPtConversion[2]) ;
       
       if(fMultiCutAnaSim)
       {
@@ -2797,7 +2851,7 @@ void AliAnaPi0::FillAcceptanceHistograms()
           else if(mompdg    == 213) fhPrimPi0PtOrigin->Fill(mesonPt, 4.5, GetEventWeight()*weightPt);//rho
           else if(mompdg    == 223) fhPrimPi0PtOrigin->Fill(mesonPt, 5.5, GetEventWeight()*weightPt);//omega
           else if(mompdg    >= 310   && mompdg <= 323)
-                                    fhPrimPi0PtOrigin->Fill(mesonPt, 6.5, GetEventWeight()*weightPt);//k0S, k+-,k*
+	                            fhPrimPi0PtOrigin->Fill(mesonPt, 6.5, GetEventWeight()*weightPt);//k0S, k+-,k*
           else if(mompdg    == 130) fhPrimPi0PtOrigin->Fill(mesonPt, 6.5, GetEventWeight()*weightPt);//k0L
           else if(momstatus == 11 || momstatus == 12 )
                                     fhPrimPi0PtOrigin->Fill(mesonPt, 3.5, GetEventWeight()*weightPt);//resonances
@@ -3266,14 +3320,19 @@ void AliAnaPi0::FillMCVersusRecDataHistograms(Int_t ancLabel , Int_t ancPDG,
               else if(mompdg    >= 310   && mompdg    <= 323) {
                 fhMCPi0PtOrigin->Fill(pt, 6.5, GetEventWeight()*weightPt);//k0S, k+-,k*
                 fhMCPi0Radius[6]->Fill(pt,prodR,GetEventWeight()*weightPt);
+		if(mompdg==310) fhMCPi0PtStrangeness->Fill(pt, 0.5, GetEventWeight()*weightPt);//k0S
+		else if(TMath::Abs(mompdg)==321) fhMCPi0PtStrangeness->Fill(pt, 2.5, GetEventWeight()*weightPt);//k+-
+		else fhMCPi0PtStrangeness->Fill(pt, 3.5, GetEventWeight()*weightPt);//k*
               }
               else if(mompdg    == 130) {
                 fhMCPi0PtOrigin->Fill(pt, 6.5, GetEventWeight()*weightPt);//k0L
                 fhMCPi0Radius[6]->Fill(pt,prodR,GetEventWeight()*weightPt);
+		fhMCPi0PtStrangeness->Fill(pt, 1.5, GetEventWeight()*weightPt);//k0L
               }
               else if(momstatus == 11 || momstatus  == 12 ) {
                 fhMCPi0PtOrigin->Fill(pt, 3.5, GetEventWeight()*weightPt);//resonances
                 fhMCPi0Radius[3]->Fill(pt,prodR,GetEventWeight()*weightPt);
+		if(mompdg==3122) fhMCPi0PtStrangeness->Fill(pt, 4.5, GetEventWeight()*weightPt);//lambda 
               }
               else {
                 fhMCPi0PtOrigin->Fill(pt, 7.5, GetEventWeight()*weightPt);//other? py8 resonances?
@@ -3580,6 +3639,36 @@ void AliAnaPi0::FillMCVersusRecDataHistograms(Int_t ancLabel , Int_t ancPDG,
   fhMCOrgAsym    [mcIndex]->Fill(pt, asym, GetEventWeight()*weightPt);
   fhMCOrgDeltaEta[mcIndex]->Fill(pt, deta, GetEventWeight()*weightPt);
   fhMCOrgDeltaPhi[mcIndex]->Fill(pt, dphi, GetEventWeight()*weightPt);
+
+  if(mcIndex==2) {//pi0 only check conversions
+    if(GetMCAnalysisUtils()->CheckTagBit(mctag1,AliMCAnalysisUtils::kMCConversion) &&
+       GetMCAnalysisUtils()->CheckTagBit(mctag2,AliMCAnalysisUtils::kMCConversion)) {
+      //both conversions
+      fhMCOrgPi0MassPtConversion[2]->Fill(pt, mass, GetEventWeight()*weightPt);
+    } else if(!GetMCAnalysisUtils()->CheckTagBit(mctag1,AliMCAnalysisUtils::kMCConversion) &&
+	      !GetMCAnalysisUtils()->CheckTagBit(mctag2,AliMCAnalysisUtils::kMCConversion)) {
+      //no conversion
+      fhMCOrgPi0MassPtConversion[0]->Fill(pt, mass, GetEventWeight()*weightPt);
+    } else {
+      //one conversion and one not
+      fhMCOrgPi0MassPtConversion[1]->Fill(pt, mass, GetEventWeight()*weightPt);
+    }
+  }
+
+  if(mcIndex==3) {//eta only, check conversions
+    if(GetMCAnalysisUtils()->CheckTagBit(mctag1,AliMCAnalysisUtils::kMCConversion) &&
+       GetMCAnalysisUtils()->CheckTagBit(mctag2,AliMCAnalysisUtils::kMCConversion)) {
+      //both conversions
+      fhMCOrgEtaMassPtConversion[2]->Fill(pt, mass, GetEventWeight()*weightPt);
+    } else if(!GetMCAnalysisUtils()->CheckTagBit(mctag1,AliMCAnalysisUtils::kMCConversion) &&
+	      !GetMCAnalysisUtils()->CheckTagBit(mctag2,AliMCAnalysisUtils::kMCConversion)) {
+      //no conversion
+      fhMCOrgEtaMassPtConversion[0]->Fill(pt, mass, GetEventWeight()*weightPt);
+    } else {
+      //one conversion and one not
+      fhMCOrgEtaMassPtConversion[1]->Fill(pt, mass, GetEventWeight()*weightPt);
+    }
+  }
   
   if( IsStudyClusterOverlapsPerGeneratorOn() )
   {      

--- a/PWGGA/CaloTrackCorrelations/AliAnaPi0.h
+++ b/PWGGA/CaloTrackCorrelations/AliAnaPi0.h
@@ -461,7 +461,11 @@ class AliAnaPi0 : public AliAnaCaloTrackCorrBaseClass {
   TH2F *   fhMCOrgAsym[17];            //!<! Asymmetry vs pt of real pairs, check common origin of pair
   TH2F *   fhMCOrgDeltaEta[17];        //!<! Delta Eta vs pt of real pairs, check common origin of pair
   TH2F *   fhMCOrgDeltaPhi[17];        //!<! Delta Phi vs pt of real pairs, check common origin of pair
-  
+
+  //reconstructed and validated (true) pi0 and eta either zero, one or two photons from conversion
+  TH2F *   fhMCOrgPi0MassPtConversion[3]; //!<! Mass vs pt of real pairs (with 0,1,2 conversion) with ancestor pi0
+  TH2F *   fhMCOrgEtaMassPtConversion[3]; //!<! Mass vs pt of real pairs (with 0,1,2 conversion) with ancestor eta
+    
   // Multiple cuts in simulation, origin pi0 or eta
     
   /// Real pi0 pairs, reconstructed mass vs reconstructed pt of original pair.
@@ -514,6 +518,9 @@ class AliAnaPi0 : public AliAnaCaloTrackCorrBaseClass {
   TH2F *   fhMCNotResonancePi0PtOrigin;//!<! Mass of reconstructed pi0 pairs in calorimeter vs mother origin ID, pi0 status 1.
   TH2F *   fhMCPi0PtStatus ;           //!<! Mass of reconstructed pi0 pairs in calorimeter vs mother status.
 
+  // Primaries origin - subcategory - strangeness
+  TH2F *   fhMCPi0PtStrangeness ;         //!<! Spectrum of reconstructed pi0 pairs in calorimeter vs mother strangeness
+  
   TH2F *   fhMCPi0ProdVertex;          //!<! Spectrum of selected pi0 vs production vertex
   TH2F *   fhMCEtaProdVertex;          //!<! Spectrum of selected eta vs production vertex
   TH2F *   fhPrimPi0ProdVertex;        //!<! Spectrum of primary pi0 vs production vertex


### PR DESCRIPTION
Additional histograms in MC. Subcategories in:
1. conversions; three TH2F histograms with invariant mass of reconstructed and validated pi0 or eta meson decaying to two photons where one or two photons are coming from conversions or no photon is coming from conversion vs pT.
2. strangeness; separate histogram TH2F for K0S, K0L, K+-, K* and Lambda