### PR TITLE
Adding settings for pPb 2016

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalESDTrackCutsGenerator.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalESDTrackCutsGenerator.cxx
@@ -520,6 +520,14 @@ AliEmcalESDTrackCutsGenerator::EDataSet_t AliEmcalESDTrackCutsGenerator::SteerDa
     dataSet = kLHC11h;
   } else if (strPeriod == "lhc13g") {
     dataSet = kLHC11h;
+  } else if (strPeriod == "lhc16q") {
+    dataSet = kLHC11h;
+  } else if (strPeriod == "lhc16r") {
+    dataSet = kLHC11h;
+  } else if (strPeriod == "lhc16s") {
+    dataSet = kLHC11h;
+  } else if (strPeriod == "lhc16t") {
+    dataSet = kLHC11h;
   } else if (strPeriod == "lhc12a15f") {
     dataSet = kLHC11h;
   } else if (strPeriod == "lhc13b4") {


### PR DESCRIPTION
Mapping hybrid-/TPConly-trackcuts for pPb 2015 to the run1
cuts.