### PR TITLE
PWGDQ EvtVsTrk now only evts aft evt cuts are used

### DIFF
--- a/PWGDQ/dielectron/core/AliDielectron.cxx
+++ b/PWGDQ/dielectron/core/AliDielectron.cxx
@@ -423,10 +423,6 @@ Bool_t AliDielectron::Process(AliVEvent *ev1, AliVEvent *ev2)
   // set event
   AliDielectronVarManager::SetFillMap(fUsedVars);
   AliDielectronVarManager::SetEvent(ev1);
-  if(fEvtVsTrkHist){
-    fEvtVsTrkHist->SetPIDResponse(AliDielectronVarManager::GetPIDResponse());
-    fEvtVsTrkHist->FillHistograms(ev1);
-  }
 
   if (fMixing){
     //set mixing bin to event data
@@ -460,6 +456,11 @@ Bool_t AliDielectron::Process(AliVEvent *ev1, AliVEvent *ev2)
   if(fCutQA) fQAmonitor->Fill(cutmask,ev1);
   if ((ev1&&cutmask!=selectedMask) ||
       (ev2&&fEventFilter.IsSelected(ev2)!=selectedMask)) return 0;
+
+  if(fEvtVsTrkHist){
+    fEvtVsTrkHist->SetPIDResponse(AliDielectronVarManager::GetPIDResponse());
+    fEvtVsTrkHist->FillHistograms(ev1);
+  }
 
   //fill track arrays for the first event
   if (ev1){

--- a/PWGDQ/dielectron/core/AliDielectronEvtVsTrkHist.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronEvtVsTrkHist.cxx
@@ -4,7 +4,7 @@
  * @Email:  pdillens@cern.ch
  * @Filename: AliDielectronEvtVsTrkHist.cxx
  * @Last modified by:   pascaldillenseger
- * @Last modified time: 2017-09-13, 14:45:06
+ * @Last modified time: 2017-09-18, 15:27:33
  */
 
 
@@ -422,9 +422,10 @@ void AliDielectronEvtVsTrkHist::CalculateMatchingEfficiency()
     Double_t b22  = nCountsITS * nCountsTPC;
     if(b22 > 0) matchEffErr = (err1 * err1 + err2 * err2) / (b22 * b22);
     else matchEffErr = 0.;
+    matchEffErr = TMath::Sqrt(nCountsITS);
 
 // Now set the correct match efficiency value to the bin coordinates
-    fSparseObjs[ADEVTH::kSparseMatchEffITSTPC]->SetBinContent(coord, nCountsTPC);
+    fSparseObjs[ADEVTH::kSparseMatchEffITSTPC]->SetBinContent(coord, nCountsITS);
     errBin = fSparseObjs[ADEVTH::kSparseMatchEffITSTPC]->GetBin(coord);
 
     fSparseObjs[ADEVTH::kSparseMatchEffITSTPC]->SetBinError2(errBin, matchEffErr);


### PR DESCRIPTION
Repositioned the filling of the EvtVsTrk object in the AliDielectron class. Now it is filled after the current event had to pass the event cuts, setted by the user.