### PR TITLE
Fixing operator ambiguity

### DIFF
--- a/PWGCF/Correlations/JCORRAN/Base/AliJFFlucAnalysis.cxx
+++ b/PWGCF/Correlations/JCORRAN/Base/AliJFFlucAnalysis.cxx
@@ -535,7 +535,7 @@ void AliJFFlucAnalysis::UserExec(Option_t *) {
 		qw1_4 = qcn4;
 		qw1 = qcn;
 		qw1_10 = qcn_10;
-		qw2_10 = qcn_10*((QvectorQCeta10[0][kSubA]-1)*(QvectorQCeta10[0][kSubB]-1)).Re();
+		qw2_10 = qcn_10*((QvectorQCeta10[0][kSubA]-TComplex(1,0))*(QvectorQCeta10[0][kSubB]-TComplex(1,0))).Re();
 	}
 
 	TComplex corr10[kNH][nKL];


### PR DESCRIPTION
Due to the implementation of the casting operators and
arithmetic operators with int/float types in TComplex,
there is an ambiguity on whether to use
- operator- from TComplex with TComplex and int
- operator- from int with TComplex implicitly casted to int
In order to fix the ambiguity the complex value needs to
be explicitly defined, or the integer can be converted to
complex using the value as real part of the complex number.
The proposed solution does the subtraction on complex level.

Needed for ROOT6 builds.