### PR TITLE
Adding possibility to cut on M02 for EMCAL clusters

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliClusterContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliClusterContainer.cxx
@@ -13,6 +13,7 @@
  * provided "as is" without express or implied warranty.                  *
  **************************************************************************/
 #include <algorithm>
+#include <cfloat>
 #include <iostream>
 #include <vector>
 #include <TClonesArray.h>
@@ -44,7 +45,9 @@ AliClusterContainer::AliClusterContainer():
   fIncludePHOS(kFALSE),
   fIncludePHOSonly(kFALSE),
   fPhosMinNcells(0),
-  fPhosMinM02(0)
+  fPhosMinM02(0),
+  fEmcalMinM02(DBL_MIN),
+  fEmcalMaxM02(DBL_MAX)
 {
   fBaseClassName = "AliVCluster";
   SetClassName("AliVCluster");
@@ -67,7 +70,9 @@ AliClusterContainer::AliClusterContainer(const char *name):
   fIncludePHOS(kFALSE),
   fIncludePHOSonly(kFALSE),
   fPhosMinNcells(0),
-  fPhosMinM02(0)
+  fPhosMinM02(0),
+  fEmcalMinM02(DBL_MIN),
+  fEmcalMaxM02(DBL_MAX)
 {
   fBaseClassName = "AliVCluster";
   SetClassName("AliVCluster");
@@ -366,6 +371,11 @@ Bool_t AliClusterContainer::ApplyClusterCuts(const AliVCluster* clus, UInt_t &re
     return kFALSE;
   }
   
+  if(clus->GetM02() < fEmcalMinM02 || clus->GetM02() > fEmcalMaxM02) {
+    rejectionReason |= kExoticCut; // Not really true, but there is a lack of leftover bits
+	  return kFALSE;
+  }
+
   for (Int_t i = 0; i <= AliVCluster::kLastUserDefEnergy; i++) {
     if (clus->GetUserDefEnergy((VCluUserDefEnergy_t)i) < fUserDefEnergyCut[i]) {
       rejectionReason |= kEnergyCut;

--- a/PWG/EMCAL/EMCALbase/AliClusterContainer.h
+++ b/PWG/EMCAL/EMCALbase/AliClusterContainer.h
@@ -71,6 +71,7 @@ class AliClusterContainer : public AliEmcalContainer {
   void                        SetIncludePHOSonly(Bool_t b)                 { fIncludePHOSonly = b   ; }
   void                        SetPhosMinNcells(Int_t n)                    { fPhosMinNcells = n; }
   void                        SetPhosMinM02(Double_t m)                    { fPhosMinM02 = m; }
+  void 						 SetEmcalM02Range(Double_t min, Double_t max) { fEmcalMinM02 = min; fEmcalMaxM02 = max; }
   void                        SetArray(const AliVEvent * event);
   void                        SetClusUserDefEnergyCut(Int_t t, Double_t cut);
   Double_t                    GetClusUserDefEnergyCut(Int_t t) const;
@@ -119,13 +120,15 @@ class AliClusterContainer : public AliEmcalContainer {
   Bool_t           fIncludePHOSonly;            ///< flag to accept only PHOS clusters (and reject EMCal clusters)
   Int_t            fPhosMinNcells;              ///< min number of phos cells per cluster
   Double_t         fPhosMinM02;                 ///< min value of M02 for phos clusters
+  Double_t		   fEmcalMinM02;				   ///< min value of M02 for EMCAL clusters
+  Double_t 		   fEmcalMaxM02;				   ///< max value of M02 for EMCAL clusters
 
  private:
   AliClusterContainer(const AliClusterContainer& obj); // copy constructor
   AliClusterContainer& operator=(const AliClusterContainer& other); // assignment
 
   /// \cond CLASSIMP
-  ClassDef(AliClusterContainer,9);
+  ClassDef(AliClusterContainer,10);
   /// \endcond
 };
 


### PR DESCRIPTION
By default range is set to +/- infinity using
constants in cfloat.