### PR TITLE
Make AOD vertex selection optional + fix integer overflow

### DIFF
--- a/OADB/AliEventCuts.cxx
+++ b/OADB/AliEventCuts.cxx
@@ -46,6 +46,7 @@ AliEventCuts::AliEventCuts(bool saveplots) : TList(),
   fMaxDeltaSpdTrackNsigmaSPD{1.e14},
   fMaxDeltaSpdTrackNsigmaTrack{1.e14},
   fMaxResolutionSPDvertex{1.e14f},
+  fCheckAODvertex{true},
   fRejectDAQincomplete{false},
   fRequiredSolenoidPolarity{0},
   fUseMultiplicityDependentPileUpCuts{false},
@@ -150,7 +151,7 @@ bool AliEventCuts::AcceptEvent(AliVEvent *ev) {
   const AliVVertex* vtSPD = ev->GetPrimaryVertexSPD();
   /// On current AODs primary vertex could be from TPC or invalid SPD vertex
   /// The following check should be applied only on AOD.
-  bool goodAODvtx = dynamic_cast<AliAODEvent*>(ev) ? GoodPrimaryAODVertex(ev) : true;
+  bool goodAODvtx = (dynamic_cast<AliAODEvent*>(ev) ? GoodPrimaryAODVertex(ev) : true) || !fCheckAODvertex;
 
   if (vtSPD->GetNContributors() > 0) fFlag |= BIT(kVertexSPD);
   if (vtTrc->GetNContributors() > 1 && goodAODvtx) fFlag |= BIT(kVertexTracks);
@@ -324,8 +325,8 @@ void AliEventCuts::AddQAplotsToList(TList *qaList, bool addCorrelationPlots) {
     "Vertex position"
   };
 
-  fCutStats = new TH1I("fCutStats",";;Number of selected events",bin_labels.size(),-.5,bin_labels.size() - 0.5);
-  fNormalisationHist = new TH1I("fNormalisationHist",";;Number of selected events",norm_labels.size(),-.5,norm_labels.size() - 0.5);
+  fCutStats = new TH1D("fCutStats",";;Number of selected events",bin_labels.size(),-.5,bin_labels.size() - 0.5);
+  fNormalisationHist = new TH1D("fNormalisationHist",";;Number of selected events",norm_labels.size(),-.5,norm_labels.size() - 0.5);
   for (int iB = 1; iB <= bin_labels.size(); ++iB) fCutStats->GetXaxis()->SetBinLabel(iB,bin_labels[iB-1].data());
   for (int iB = 1; iB <= norm_labels.size(); ++iB) fNormalisationHist->GetXaxis()->SetBinLabel(iB,norm_labels[iB-1].data());
   qaList->Add(fCutStats);

--- a/OADB/AliEventCuts.cxx
+++ b/OADB/AliEventCuts.cxx
@@ -90,6 +90,8 @@ AliEventCuts::AliEventCuts(bool saveplots) : TList(),
   fOverrideAutoTriggerMask{false},
   fOverrideAutoPileUpCuts{false},
   fCutStats{nullptr},
+  fCutStatsAfterTrigger{nullptr},
+  fCutStatsAfterMultSelection{nullptr},
   fNormalisationHist{nullptr},
   fVtz{nullptr},
   fDeltaTrackSPDvtz{nullptr},
@@ -250,8 +252,15 @@ bool AliEventCuts::AcceptEvent(AliVEvent *ev) {
   }
   if (fCutStats) {
     for (int iCut = kNoCuts; iCut <= kAllCuts; ++iCut) {
-      if (TESTBIT(fFlag,iCut))
+      if (TESTBIT(fFlag,iCut)) {
         fCutStats->Fill(iCut);
+        if (TESTBIT(fFlag,kTrigger)) {
+          fCutStatsAfterTrigger->Fill(iCut);
+        }
+        if (TESTBIT(fFlag,kMultiplicity)) {
+          fCutStatsAfterMultSelection->Fill(iCut);
+        }
+      }
     }
   }
 
@@ -326,10 +335,18 @@ void AliEventCuts::AddQAplotsToList(TList *qaList, bool addCorrelationPlots) {
   };
 
   fCutStats = new TH1D("fCutStats",";;Number of selected events",bin_labels.size(),-.5,bin_labels.size() - 0.5);
+  fCutStatsAfterTrigger = new TH1D("fCutStatsAfterTrigger",";;Number of selected events",bin_labels.size(),-.5,bin_labels.size() - 0.5);
+  fCutStatsAfterMultSelection = new TH1D("fCutStatsAfterMultSelection",";;Number of selected events",bin_labels.size(),-.5,bin_labels.size() - 0.5);
   fNormalisationHist = new TH1D("fNormalisationHist",";;Number of selected events",norm_labels.size(),-.5,norm_labels.size() - 0.5);
-  for (int iB = 1; iB <= bin_labels.size(); ++iB) fCutStats->GetXaxis()->SetBinLabel(iB,bin_labels[iB-1].data());
+  for (int iB = 1; iB <= bin_labels.size(); ++iB) {
+    fCutStats->GetXaxis()->SetBinLabel(iB,bin_labels[iB-1].data());
+    fCutStatsAfterTrigger->GetXaxis()->SetBinLabel(iB,bin_labels[iB-1].data());
+    fCutStatsAfterMultSelection->GetXaxis()->SetBinLabel(iB,bin_labels[iB-1].data());
+  }
   for (int iB = 1; iB <= norm_labels.size(); ++iB) fNormalisationHist->GetXaxis()->SetBinLabel(iB,norm_labels[iB-1].data());
   qaList->Add(fCutStats);
+  qaList->Add(fCutStatsAfterTrigger);
+  qaList->Add(fCutStatsAfterMultSelection);
   qaList->Add(fNormalisationHist);
 
   string titles[2] = {"before event cuts","after event cuts"};

--- a/OADB/AliEventCuts.h
+++ b/OADB/AliEventCuts.h
@@ -102,6 +102,7 @@ class AliEventCuts : public TList {
 
     bool          fGreenLight;                    ///< If true it will bypass all the selections.
     bool          fMC;                            ///< Set to true by the automatic setup when analysing MC (in manual mode *you* are responsible for it). In MC the correlations cuts are disabled.
+
     bool          fRequireTrackVertex;            ///< if true all the events with only the SPD vertex are rejected
     float         fMinVtz;                        ///< Min z position for the primary vertex
     float         fMaxVtz;                        ///< Max z position for the primary vertex
@@ -109,6 +110,7 @@ class AliEventCuts : public TList {
     float         fMaxDeltaSpdTrackNsigmaSPD;     ///<
     float         fMaxDeltaSpdTrackNsigmaTrack;   ///<
     float         fMaxResolutionSPDvertex;        ///<
+    bool          fCheckAODvertex;                ///< if true it rejects the AOD primary vertices coming from TPC ESD vertices or SPD placeholder vertices
 
     bool          fRejectDAQincomplete;           ///< Reject events that have incomplete information
 
@@ -173,8 +175,8 @@ class AliEventCuts : public TList {
     bool          fOverrideAutoPileUpCuts;        ///<  If true the pile-up cuts are defined by the user.
 
     /// The following pointers are used to avoid the intense usage of FindObject. The objects pointed are owned by (TList*)this.
-    TH1I* fCutStats;               //!<! Cuts statistics: every column keeps track of how many times a cut is passed independently from the other cuts.
-    TH1I* fNormalisationHist;      //!<! Cuts statistics: every column keeps track of how many times a cut is passed once that all the other are passed.
+    TH1D* fCutStats;               //!<! Cuts statistics: every column keeps track of how many times a cut is passed independently from the other cuts.
+    TH1D* fNormalisationHist;      //!<! Cuts statistics: every column keeps track of how many times a cut is passed once that all the other are passed.
     TH1D* fVtz[2];                 //!<! Vertex z distribution
     TH1D* fDeltaTrackSPDvtz[2];    //!<! Difference between the vertex computed using SPD and the track vertex
     TH1D* fCentrality[2];          //!<! Centrality percentile distribution
@@ -190,7 +192,7 @@ class AliEventCuts : public TList {
     AliESDtrackCuts* fFB32trackCuts; //!<! Cuts corresponding to FB32 in the ESD (used only for correlations cuts in ESDs)
     AliESDtrackCuts* fTPConlyCuts;   //!<! Cuts corresponding to the standalone TPC cuts in the ESDs (used only for correlations cuts in ESDs)
 
-    ClassDef(AliEventCuts,4)
+    ClassDef(AliEventCuts,5)
 };
 
 template<typename F> F AliEventCuts::PolN(F x,F* coef, int n) {

--- a/OADB/AliEventCuts.h
+++ b/OADB/AliEventCuts.h
@@ -176,6 +176,8 @@ class AliEventCuts : public TList {
 
     /// The following pointers are used to avoid the intense usage of FindObject. The objects pointed are owned by (TList*)this.
     TH1D* fCutStats;               //!<! Cuts statistics: every column keeps track of how many times a cut is passed independently from the other cuts.
+    TH1D* fCutStatsAfterTrigger;   //!<! Cuts statistics: every column keeps track of how many times a cut is passed for events that pass the trigger selection
+    TH1D* fCutStatsAfterMultSelection; //!<! Cuts statistics: every column keeps track of how many times a cut is passed for events that pass the multiplicity selection
     TH1D* fNormalisationHist;      //!<! Cuts statistics: every column keeps track of how many times a cut is passed once that all the other are passed.
     TH1D* fVtz[2];                 //!<! Vertex z distribution
     TH1D* fDeltaTrackSPDvtz[2];    //!<! Difference between the vertex computed using SPD and the track vertex


### PR DESCRIPTION
The selection of good AOD vertex is on by default, but it can be switched off by the user.