### PR TITLE
Add getter checking the scaling setting

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalList.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalList.h
@@ -29,6 +29,7 @@ public:
   ~AliEmcalList() {}
   Long64_t                    Merge(TCollection *hlist);
   void                        SetUseScaling(Bool_t val) {fUseScaling = val;}
+  Bool_t                      IsUseScaling() const { return fUseScaling; }
 
 private:
   // ####### Helper functions


### PR DESCRIPTION
Getter is needed to check whether scaled merging is activated
from outside.