### PR TITLE
Fixes needed for compilation with Xcode 9

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBPLCMS3DCorrFctn.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBPLCMS3DCorrFctn.cxx
@@ -336,7 +336,7 @@ AliFemtoString AliFemtoBPLCMS3DCorrFctn::Report()
     report += "No PairCut specific to this CorrFctn\n";
   }
 
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 //____________________________
 void AliFemtoBPLCMS3DCorrFctn::AddRealPair( AliFemtoPair* pair)

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBPLCMS3DCorrFctnKK.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBPLCMS3DCorrFctnKK.cxx
@@ -335,7 +335,7 @@ AliFemtoString AliFemtoBPLCMS3DCorrFctnKK::Report()
     report += "No PairCut specific to this CorrFctn\n";
   }
 
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 //____________________________
 void AliFemtoBPLCMS3DCorrFctnKK::AddRealPair( AliFemtoPair* pair)

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBasicEventCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBasicEventCut.cxx
@@ -112,7 +112,7 @@ AliFemtoString AliFemtoBasicEventCut::Report()
    report += TString::Format("Vertex Z-position:\t %E - %E\n", fVertZPos[0], fVertZPos[1])
            + TString::Format("Number of events which passed:\t%ld  Number which failed:\t%ld\n", fNEventsPassed, fNEventsFailed);
 
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 void AliFemtoBasicEventCut::SetAcceptBadVertex(bool b)
 {

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBasicTrackCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBasicTrackCut.cxx
@@ -105,7 +105,7 @@ AliFemtoString AliFemtoBasicTrackCut::Report()
   report += TString::Format("Particle DCA:\t%E - %E\n", fDCA[0], fDCA[1]);
   report += TString::Format("Number of tracks which passed:\t%ld  Number which failed:\t%ld\n", fNTracksPassed, fNTracksFailed);
 
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 
 TList *AliFemtoBasicTrackCut::ListSettings()

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBetaTPairCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBetaTPairCut.cxx
@@ -69,7 +69,7 @@ AliFemtoString AliFemtoBetaTPairCut::Report()
 
   report += TString::Format("Accept pair with betaT in range %f , %f", fBetaTMin, fBetaTMax);
 
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 
 //__________________

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctn3DLCMSSym.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctn3DLCMSSym.cxx
@@ -161,7 +161,7 @@ AliFemtoString AliFemtoCorrFctn3DLCMSSym::Report()
     report += "No PairCut specific to this CorrFctn\n";
   }
 
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 //____________________________
 void AliFemtoCorrFctn3DLCMSSym::AddRealPair(AliFemtoPair* pair)

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarDEta.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarDEta.cxx
@@ -146,7 +146,7 @@ AliFemtoString AliFemtoCorrFctnDPhiStarDEta::Report()
   report += TString::Format("Number of entries in numerator:\t%E\n", fDPhiStarDEtaNumerator->GetEntries());
   report += TString::Format("Number of entries in denominator:\t%E\n", fDPhiStarDEtaDenominator->GetEntries());
   //  report += mCoulombWeight->Report();
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 
 //____________________________

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnNonIdDR.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnNonIdDR.cxx
@@ -210,7 +210,7 @@ AliFemtoString AliFemtoCorrFctnNonIdDR::Report()
   report += TString::Format("Number of entries in denominators:\t%E\n", fDenOutP->GetEntries() + fDenOutN->GetEntries());
 
   //  report += mCoulombWeight->Report();
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 //____________________________
 void AliFemtoCorrFctnNonIdDR::AddRealPair(AliFemtoPair* pair)
@@ -276,7 +276,7 @@ void AliFemtoCorrFctnNonIdDR::AddMixedPair(AliFemtoPair* pair)
   Double_t py2 = pair->Track2()->FourMomentum().vect().y();
   Double_t pz2 = pair->Track2()->FourMomentum().vect().z();
   Double_t e2 = pair->Track2()->FourMomentum().e();
-  
+
   mNtuple->Fill(px1, py1, pz1, e1,px2, py2, pz2, e2);
   }
   //finish adding
@@ -299,7 +299,7 @@ void AliFemtoCorrFctnNonIdDR::Write()
   fkTMonitor->Write();
   if(fParticleP){
     mNtuple->Write();}
-  
+
 }
 
 TList* AliFemtoCorrFctnNonIdDR::GetOutputList()

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCutMonitorEventMult.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCutMonitorEventMult.cxx
@@ -258,7 +258,7 @@ AliFemtoString AliFemtoCutMonitorEventMult::Report()
 {
   // Prepare report from the execution
   TString report = "*** AliFemtoCutMonitorEventMult report";
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 
 void AliFemtoCutMonitorEventMult::Fill(const AliFemtoEvent* aEvent)

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoDeltaPtPairCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoDeltaPtPairCut.cxx
@@ -61,7 +61,7 @@ AliFemtoString AliFemtoDeltaPtPairCut::Report()
   TString report("AliFemtoKT Pair Cut\n");
   report += TString::Format("Accept pair with DeltaPt in range %f , %f",fDeltaPtMin,fDeltaPtMax);
 
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 //__________________
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSimpleAnalysis.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSimpleAnalysis.cxx
@@ -431,7 +431,7 @@ AliFemtoString AliFemtoSimpleAnalysis::Report()
 
   report += "-------------\n";
 
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 //_________________________
 void AliFemtoSimpleAnalysis::ProcessEvent(const AliFemtoEvent* hbtEvent)

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoV0PairCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoV0PairCut.cxx
@@ -156,7 +156,7 @@ AliFemtoString AliFemtoV0PairCut::Report()
   TString report = "AliFemtoV0 Pair Cut - remove shared and split pairs\n";
   report += TString::Format("Number of pairs which passed:\t%ld  Number which failed:\t%ld\n", fNPairsPassed, fNPairsFailed);
 
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 //__________________
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoV0TrackPairCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoV0TrackPairCut.cxx
@@ -357,7 +357,7 @@ AliFemtoString AliFemtoV0TrackPairCut::Report()
   TString report = "AliFemtoV0 Pair Cut - remove shared and split pairs\n";
   report += TString::Format("Number of pairs which passed:\t%ld  Number which failed:\t%ld\n", fNPairsPassed, fNPairsFailed);
 
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 //__________________
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoVertexAnalysis.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoVertexAnalysis.cxx
@@ -101,7 +101,7 @@ AliFemtoString AliFemtoVertexAnalysis::Report()
 
   report += AliFemtoSimpleAnalysis::Report();
 
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 //_________________________
 void AliFemtoVertexAnalysis::ProcessEvent(const AliFemtoEvent* hbtEvent)

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoVertexMultAnalysis.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoVertexMultAnalysis.cxx
@@ -185,7 +185,7 @@ AliFemtoString AliFemtoVertexMultAnalysis::Report()
           + TString::Format("Now adding AliFemtoSimpleAnalysis(base) Report\n")
           + AliFemtoSimpleAnalysis::Report();
 
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 
 TList* AliFemtoVertexMultAnalysis::ListSettings()

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXiPairCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXiPairCut.cxx
@@ -35,11 +35,11 @@ AliFemtoXiPairCut &AliFemtoXiPairCut::operator=(const AliFemtoXiPairCut &cut)
   fDataType = cut.fDataType;
 
 
-  return *this; 
+  return *this;
 }
 
 //__________________
-bool AliFemtoXiPairCut::Pass(const AliFemtoPair *pair) 
+bool AliFemtoXiPairCut::Pass(const AliFemtoPair *pair)
 {
   const AliFemtoXi *Xi_1 = pair->Track1()->Xi(),
                    *Xi_2 = pair->Track2()->Xi();
@@ -76,7 +76,7 @@ AliFemtoString AliFemtoXiPairCut::Report()
   TString report = "AliFemtoXi Pair Cut - remove shared and split pairs\n";
   report += TString::Format("Number of pairs which passed:\t%ld  Number which failed:\t%ld\n", fNPairsPassed, fNPairsFailed);
 
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 //__________________
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXiTrackPairCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXiTrackPairCut.cxx
@@ -42,11 +42,11 @@ AliFemtoXiTrackPairCut &AliFemtoXiTrackPairCut::operator=(const AliFemtoXiTrackP
   if(fV0TrackPairCut) delete fV0TrackPairCut;
   fV0TrackPairCut = new AliFemtoV0TrackPairCut(*cut.fV0TrackPairCut);
 
-  return *this; 
+  return *this;
 }
 
 //__________________
-bool AliFemtoXiTrackPairCut::Pass(const AliFemtoPair *pair) 
+bool AliFemtoXiTrackPairCut::Pass(const AliFemtoPair *pair)
 {
   //Track1 - Xi
   //Track2 - track
@@ -130,7 +130,7 @@ AliFemtoString AliFemtoXiTrackPairCut::Report()
   TString report = "AliFemtoXi Pair Cut - remove shared and split pairs\n";
   report += TString::Format("Number of pairs which passed:\t%ld  Number which failed:\t%ld\n", fNPairsPassed, fNPairsFailed);
 
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 //__________________
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXiV0PairCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoXiV0PairCut.cxx
@@ -144,7 +144,7 @@ AliFemtoString AliFemtoXiV0PairCut::Report()
   TString report = "AliFemtoXi Pair Cut - remove shared and split pairs\n";
   report += TString::Format("Number of pairs which passed:\t%ld  Number which failed:\t%ld\n", fNPairsPassed, fNPairsFailed);
 
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 //__________________
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoConfigObject.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoConfigObject.h
@@ -177,11 +177,13 @@ public:
     // constructors with all associated value-types (IntValue_t, MapValue_t, etc..)
     FORWARD_STANDARD_TYPES(ConstructorDef);
 
-    ConstructorDef(TString, kSTRING, fValueString);
+    //ConstructorDef(TString, kSTRING, fValueString);   // implicit cast - not allowed by clang 9.0, must be declared explicitly
     ConstructorDef(char *, kSTRING, fValueString);
     ConstructorDef(int, kINT, fValueInt);
     ConstructorDef(float, kFLOAT, fValueFloat);
   #undef ConstructorDef
+  // Explicit constructor for TString - needed for clang 9.0
+  AliFemtoConfigObject(TString &v) : fTypeTag(kSTRING), fValueString((const char *)v), fPainter(nullptr) {}
 
   // iterator-based constructors
   #define ConstructorDefItor(__type, __tag, __dest) \

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnKStar.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnKStar.cxx
@@ -234,7 +234,7 @@ AliFemtoString AliFemtoCorrFctnKStar::Report()
   report += TString::Format("Number of entries in numerator:\t%E\n", fNumerator->GetEntries());
   report += TString::Format("Number of entries in denominator:\t%E\n", fDenominator->GetEntries());
   report += TString::Format("Number of entries in ratio:\t%E\n", fRatio->GetEntries());
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 
 //______________________________

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoEventCutCentrality.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoEventCutCentrality.cxx
@@ -59,5 +59,5 @@ AliFemtoString AliFemtoEventCutCentrality::Report()
            + TString::Format("Vertex Z-position:\t %E - %E\n", fVertZPos.first, fVertZPos.second)
            + TString::Format("Number of events which passed:\t%lu  Number which failed:\t%lu\n", fNEventsPassed, fNEventsFailed);
 
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhiStar.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhiStar.cxx
@@ -281,5 +281,5 @@ AliFemtoModelCorrFctnDEtaDPhiStar::Report()
   report += TString::Format("Number of entries in ideal unweighted numerator:\t%0.2f\n", fDPhiStarDEtaNumeratorIdealUnweighted->GetEntries());
   report += TString::Format("Number of entries in denominator:\t%0.2f\n", fDPhiStarDEtaIdealDenominator->GetEntries());
 
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnKStar.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnKStar.cxx
@@ -146,7 +146,7 @@ AliFemtoString
 AliFemtoModelCorrFctnKStar::Report()
 {
   TString report;
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnQinv.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnQinv.cxx
@@ -157,7 +157,7 @@ AliFemtoString
 AliFemtoModelCorrFctnQinv::Report()
 {
   TString report;
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnTrueQ3D.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnTrueQ3D.cxx
@@ -133,11 +133,11 @@ Qcms(const AliFemtoLorentzVector &p1, const AliFemtoLorentzVector &p2)
 
   Double_t beta = p.z()/p.t(),
           gamma = 1.0 / TMath::Sqrt((1.0-beta)*(1.0+beta));
-  
+
   Double_t qlong = gamma * (d.z() - beta*d.t());
 
   // double qlong = (p.t()*d.z() - p.z()*d.t()) / TMath::Sqrt(p.t()*p.t() - p.z()*p.z());
-  
+
   return std::make_tuple(qout, qside, qlong);
 }
 
@@ -146,7 +146,7 @@ static void
 AddPair(const AliFemtoParticle &particle1, const AliFemtoParticle &particle2, TH3D *gen_hist, TH3D *rec_hist, Double_t weight)
 {
   Double_t q_out, q_side, q_long;
-  
+
   // Fill reconstructed histogram with "standard" particle momentum
   std::tie(q_out, q_side, q_long) = Qcms(particle1.FourMomentum(), particle2.FourMomentum());
   rec_hist->Fill(q_out, q_side, q_long, weight);
@@ -162,7 +162,7 @@ AddPair(const AliFemtoParticle &particle1, const AliFemtoParticle &particle2, TH
 
   const Float_t mass1 = info1->GetMass(),
                 mass2 = info2->GetMass();
-  
+
   // block all zero-mass particles from the correlation function
   if (mass1 == 0.0 || mass2 == 0.0) {
     return;
@@ -173,10 +173,10 @@ AddPair(const AliFemtoParticle &particle1, const AliFemtoParticle &particle2, TH
 
   const Double_t e1 = sqrt(mass1 * mass1 + true_momentum1->Mag2()),
                  e2 = sqrt(mass2 * mass2 + true_momentum2->Mag2());
-  
+
   const AliFemtoLorentzVector p1 = AliFemtoLorentzVector(e1, *true_momentum1),
                               p2 = AliFemtoLorentzVector(e2, *true_momentum2);
-  
+
   // Fill generated-momentum histogram with "true" particle momentum
   std::tie(q_out, q_side, q_long) = Qcms(p1, p2);
   gen_hist->Fill(q_out, q_side, q_long, weight);
@@ -216,5 +216,5 @@ AliFemtoString
 AliFemtoModelCorrFctnTrueQ3D::Report()
 {
   TString report;
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoPairCutPt.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoPairCutPt.cxx
@@ -81,7 +81,7 @@ AliFemtoString AliFemtoPairCutPt::Report()
   TString report("AliFemtoPairCutPt Pair Cut\n");
   report += TString::Format("Number of pairs which passed:\t%ld  Number which failed:\t%ld\n", (long int)fNPairsPassed, (long int)fNPairsFailed);
 
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 //__________________
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoShareQualityPairCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoShareQualityPairCut.cxx
@@ -136,7 +136,7 @@ AliFemtoString AliFemtoShareQualityPairCut::Report()
   // Prepare the report from the execution
   TString report("AliFemtoShareQuality Pair Cut - remove shared and split pairs\n");
   report += TString::Format("Number of pairs which passed:\t%ld  Number which failed:\t%ld\n", fNPairsPassed, fNPairsFailed);
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 
 //__________________

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoV0PurityBgdEstimator.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoV0PurityBgdEstimator.cxx
@@ -257,11 +257,11 @@ void AliFemtoV0PurityBgdEstimator::UseCorrectedDaughterHelices(const AliFemtoTra
   //When the helix was built, it assumed that particles come directly from event vertex
   //This is not useful for me, so I build new ones with more correct (hopefully) origins
   //Also, define relative to event vertex, this is necessary in the mixed event case
-  const AliFmThreeVector<double> tOriginPos(tTrackPos->XatDCA()-tHelixPosOG.Origin().x(), 
-                                            tTrackPos->YatDCA()-tHelixPosOG.Origin().y(), 
+  const AliFmThreeVector<double> tOriginPos(tTrackPos->XatDCA()-tHelixPosOG.Origin().x(),
+                                            tTrackPos->YatDCA()-tHelixPosOG.Origin().y(),
                                             tTrackPos->ZatDCA()-tHelixPosOG.Origin().z());
-  const AliFmThreeVector<double> tOriginNeg(tTrackNeg->XatDCA()-tHelixNegOG.Origin().x(), 
-                                            tTrackNeg->YatDCA()-tHelixNegOG.Origin().y(), 
+  const AliFmThreeVector<double> tOriginNeg(tTrackNeg->XatDCA()-tHelixNegOG.Origin().x(),
+                                            tTrackNeg->YatDCA()-tHelixNegOG.Origin().y(),
                                             tTrackNeg->ZatDCA()-tHelixNegOG.Origin().z());
 
   const AliFmPhysicalHelixD tHelixPos(tHelixPosOG.Curvature(), tHelixPosOG.DipAngle(), tHelixPosOG.Phase(), tOriginPos, tHelixPosOG.H());
@@ -318,7 +318,7 @@ void AliFemtoV0PurityBgdEstimator::BuildV0(AliFemtoPair* aPair)
 
   //Due to relative shift above in UseCorrectedDaughterHelices, use the primary vertex = {0,0,0} in
   //decay length etc. calculations below.
-  //  However, still call AliFemtoV0::SetPrimaryVertex to set primary vertex to actual value, 
+  //  However, still call AliFemtoV0::SetPrimaryVertex to set primary vertex to actual value,
   //  as, for now, the position of the event primary vertex is how we distinguish events in IsSameEvent function
 
   double tEventPrimVtx[3];
@@ -389,7 +389,7 @@ AliFemtoString AliFemtoV0PurityBgdEstimator::Report()
   report += TString::Format("Number of entries in denominatorWithoutSharedDaughterCut:\t%E\n", fDenominatorWithoutSharedDaughterCut->GetEntries());
   report += TString::Format("Number of entries in numerator:\t%E\n", fNumerator->GetEntries());
   report += TString::Format("Number of entries in denominator:\t%E\n", fDenominator->GetEntries());
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 
 //______________________________
@@ -467,6 +467,3 @@ void AliFemtoV0PurityBgdEstimator::AddMixedPair(AliFemtoPair* aPair)
   fDenominatorWithoutSharedDaughterCut->Fill(tMinv,weight);
 
 }
-
-
-

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoV0TrackCutNSigmaFilter.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoV0TrackCutNSigmaFilter.cxx
@@ -111,24 +111,24 @@ AliFemtoV0TrackCutNSigmaFilter::~AliFemtoV0TrackCutNSigmaFilter()
   delete fProtonNSigmaFilter;
   delete fMinvPurityAidHistoV0;
 
-//TODO            TODO           TODO               TODO 
+//TODO            TODO           TODO               TODO
   if(fUseCustomK0sRejectionFilters)
   {
     fK0sRejectionFilters.clear();
     fK0sRejectionFilters.shrink_to_fit();
-  } 
+  }
 
   if(fUseCustomLambdaRejectionFilters)
   {
     fLambdaRejectionFilters.clear();
     fLambdaRejectionFilters.shrink_to_fit();
-  } 
+  }
 
   if(fUseCustomAntiLambdaRejectionFilters)
   {
     fAntiLambdaRejectionFilters.clear();
     fAntiLambdaRejectionFilters.shrink_to_fit();
-  } 
+  }
 }
 
 bool AliFemtoV0TrackCutNSigmaFilter::Pass(const AliFemtoV0* aV0)
@@ -223,7 +223,7 @@ bool AliFemtoV0TrackCutNSigmaFilter::Pass(const AliFemtoV0* aV0)
 
   bool pid_check = false;
   // Looking for lambdas = proton + pim
-  if(fParticleType == kLambda) 
+  if(fParticleType == kLambda)
   {
     if(IsProtonNSigma(aV0->PtPos(), aV0->PosNSigmaTPCP(), aV0->PosNSigmaTOFP(),fNsigmaPosDaughterTPC,fNsigmaPosDaughterTOF,fRequireTOFProton)) //proton
     {
@@ -338,7 +338,7 @@ AliFemtoString AliFemtoV0TrackCutNSigmaFilter::Report()
           + TString::Format("Usings custom Kaon NSigma Filter:\t%i\n", fUseCustomKaonNSigmaFilter)
           + TString::Format("Usings custom Proton NSigma Filter:\t%i\n", fUseCustomProtonNSigmaFilter)
           + AliFemtoV0TrackCut::Report();
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 
 
@@ -453,7 +453,7 @@ void AliFemtoV0TrackCutNSigmaFilter::CreateCustomV0Rejection(AliFemtoV0Type aV0T
     fAntiLambdaRejectionFilters.emplace_back(); //add AliFemtoNSigmaFilter object for (positive) daughter 1
     fAntiLambdaRejectionFilters.emplace_back(); //add AliFemtoNSigmaFilter object for (negative) daughter 2
     break;
-      
+
   default:
     cerr << "E-AliFemtoV0TrackCutNSigmaFilter::CreateCustomV0Rejection: Invalid V0Type"
             "selection '" << aV0TypeToReject << "'.  No rejection filter will be initialized!!!!!" << endl;
@@ -482,7 +482,7 @@ void AliFemtoV0TrackCutNSigmaFilter::AddTPCAndTOFNSigmaCutToV0Rejection(AliFemto
   case kAntiLambda:
     fAntiLambdaRejectionFilters[iDaughter].AddTPCAndTOFCut(aMomMin,aMomMax,aNSigmaValueTPC,aNSigmaValueTOF);
     break;
-      
+
   default:
     cerr << "E-AliFemtoV0TrackCutNSigmaFilter::AddTPCAndTOFNSigmaCutToV0Rejection: Invalid V0Type"
             "selection '" << aV0Type << "'.  No cut will be initialized!!!!!" << endl;
@@ -509,7 +509,7 @@ void AliFemtoV0TrackCutNSigmaFilter::AddTPCAndTOFNSigmaCutToV0Rejection(AliFemto
     fAntiLambdaRejectionFilters[0].AddTPCAndTOFCut(aMomMinPos,aMomMaxPos,aNSigmaValueTPCPos,aNSigmaValueTOFPos);
     fAntiLambdaRejectionFilters[1].AddTPCAndTOFCut(aMomMinNeg,aMomMaxNeg,aNSigmaValueTPCNeg,aNSigmaValueTOFNeg);
     break;
-      
+
   default:
     cerr << "E-AliFemtoV0TrackCutNSigmaFilter::AddTPCAndTOFNSigmaCutToV0Rejection: Invalid V0Type"
             "selection '" << aV0Type << "'.  No cut will be initialized!!!!!" << endl;
@@ -538,7 +538,7 @@ void AliFemtoV0TrackCutNSigmaFilter::AddTPCNSigmaCutToV0Rejection(AliFemtoV0Type
   case kAntiLambda:
     fAntiLambdaRejectionFilters[iDaughter].AddTPCCut(aMomMin,aMomMax,aNSigmaValueTPC);
     break;
-      
+
   default:
     cerr << "E-AliFemtoV0TrackCutNSigmaFilter::AddTPCNSigmaCutToV0Rejection: Invalid V0Type"
             "selection '" << aV0Type << "'.  No cut will be initialized!!!!!" << endl;
@@ -564,7 +564,7 @@ void AliFemtoV0TrackCutNSigmaFilter::AddTPCNSigmaCutToV0Rejection(AliFemtoV0Type
     fAntiLambdaRejectionFilters[0].AddTPCCut(aMomMinPos,aMomMaxPos,aNSigmaValueTPCPos);
     fAntiLambdaRejectionFilters[1].AddTPCCut(aMomMinNeg,aMomMaxNeg,aNSigmaValueTPCNeg);
     break;
-      
+
   default:
     cerr << "E-AliFemtoV0TrackCutNSigmaFilter::AddTPCNSigmaCutToV0Rejection: Invalid V0Type"
             "selection '" << aV0Type << "'.  No cut will be initialized!!!!!" << endl;
@@ -593,7 +593,7 @@ void AliFemtoV0TrackCutNSigmaFilter::AddTOFNSigmaCutToV0Rejection(AliFemtoV0Type
   case kAntiLambda:
     fAntiLambdaRejectionFilters[iDaughter].AddTOFCut(aMomMin,aMomMax,aNSigmaValueTOF);
     break;
-      
+
   default:
     cerr << "E-AliFemtoV0TrackCutNSigmaFilter::AddTOFNSigmaCutToV0Rejection: Invalid V0Type"
             "selection '" << aV0Type << "'.  No cut will be initialized!!!!!" << endl;
@@ -619,7 +619,7 @@ void AliFemtoV0TrackCutNSigmaFilter::AddTOFNSigmaCutToV0Rejection(AliFemtoV0Type
     fAntiLambdaRejectionFilters[0].AddTOFCut(aMomMinPos,aMomMaxPos,aNSigmaValueTOFPos);
     fAntiLambdaRejectionFilters[1].AddTOFCut(aMomMinNeg,aMomMaxNeg,aNSigmaValueTOFNeg);
     break;
-      
+
   default:
     cerr << "E-AliFemtoV0TrackCutNSigmaFilter::AddTOFNSigmaCutToV0Rejection: Invalid V0Type"
             "selection '" << aV0Type << "'.  No cut will be initialized!!!!!" << endl;
@@ -746,4 +746,3 @@ TList *AliFemtoV0TrackCutNSigmaFilter::GetOutputList()
 
   return tOutputList;
 }
-

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoXiTrackCutNSigmaFilter.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoXiTrackCutNSigmaFilter.cxx
@@ -13,7 +13,7 @@
 #endif
 
 
-AliFemtoXiTrackCutNSigmaFilter::AliFemtoXiTrackCutNSigmaFilter() : 
+AliFemtoXiTrackCutNSigmaFilter::AliFemtoXiTrackCutNSigmaFilter() :
   AliFemtoXiTrackCut(),
 
   fIsDaughterV0FilterUpdated(false),
@@ -102,23 +102,23 @@ bool AliFemtoXiTrackCutNSigmaFilter::PassV0(const AliFemtoXi* aXi)
 
 bool AliFemtoXiTrackCutNSigmaFilter::Pass(const AliFemtoXi* aXi)
 {
-  // test the particle and return 
+  // test the particle and return
   // true if it meets all the criteria
   // false if it doesn't meet at least one of the criteria
-   
+
   Float_t pt = aXi->PtXi();
   Float_t eta = aXi->EtaXi();
-  
+
   if(aXi->ChargeXi()==0)
     return false;
 
 
   //ParticleType selection
-  //If fParticleTypeXi=kAll, any charged candidate will pass 
-  if(fParticleTypeXi == AliFemtoXiTrackCut::kXiPlus && aXi->ChargeXi() == -1) 
+  //If fParticleTypeXi=kAll, any charged candidate will pass
+  if(fParticleTypeXi == AliFemtoXiTrackCut::kXiPlus && aXi->ChargeXi() == -1)
     return false;
 
-  if(fParticleTypeXi == AliFemtoXiTrackCut::kXiMinus && aXi->ChargeXi() == 1) 
+  if(fParticleTypeXi == AliFemtoXiTrackCut::kXiMinus && aXi->ChargeXi() == 1)
     return false;
 
   //kinematic cuts
@@ -126,19 +126,19 @@ bool AliFemtoXiTrackCutNSigmaFilter::Pass(const AliFemtoXi* aXi)
   if(pt < fMinPtXi) return false;
   if(pt > fMaxPtXi) return false;
   if(TMath::Abs(aXi->EtaBac()) > fMaxEtaBac) return false;
-  if(aXi->PtBac()< fMinPtBac) return false; 
-  if(aXi->PtBac()> fMaxPtBac) return false; 
+  if(aXi->PtBac()< fMinPtBac) return false;
+  if(aXi->PtBac()> fMaxPtBac) return false;
 
-  
+
 
     //Xi from kinematics information
     if (fParticleTypeXi == AliFemtoXiTrackCut::kXiMinusMC || fParticleTypeXi == AliFemtoXiTrackCut::kXiPlusMC) {
       if(!(aXi->MassXi()>fInvMassXiMin && aXi->MassXi()<fInvMassXiMax) || !(aXi->BacNSigmaTPCPi()==0))
-	return false; 
+	return false;
       else
 	{
-	  return true;  
-	} 
+	  return true;
+	}
     }
 
 
@@ -160,19 +160,19 @@ bool AliFemtoXiTrackCutNSigmaFilter::Pass(const AliFemtoXi* aXi)
     //DCA Xi daughters
     if(TMath::Abs(aXi->DcaXiDaughters())>fMaxDcaXiDaughters)
       return false;
-    
+
     //cos pointing angle
     if(aXi->CosPointingAngleXi()<fMinCosPointingAngleXi)
-      return false; 
-    
+      return false;
+
     //decay length
     if(aXi->DecayLengthXi()>fMaxDecayLengthXi)
       return false;
-    
+
     //fiducial volume radius
     if(aXi->RadiusXi()<fRadiusXiMin || aXi->RadiusXi()>fRadiusXiMax)
       return false;
- 
+
   if(fParticleTypeXi == kAll)
     return true;
 
@@ -199,8 +199,8 @@ bool AliFemtoXiTrackCutNSigmaFilter::Pass(const AliFemtoXi* aXi)
   if(aXi->MassXi()<fInvMassXiMin || aXi->MassXi()>fInvMassXiMax)
    {
      return false;
-   }  
-  
+   }
+
   fCTauXi->Fill(GetCTauXi(aXi));
   return true;
 }
@@ -212,14 +212,14 @@ AliFemtoString AliFemtoXiTrackCutNSigmaFilter::Report()
   report += TString::Format("Usings custom BacPion NSigma Filter:\t%i\n", fUseCustomBacPionNSigmaFilter)
           + AliFemtoXiTrackCut::Report()
           + fDaughterV0Filter->Report();
-  return AliFemtoString(report);
+  return AliFemtoString((const char *)report);
 }
 
 TList *AliFemtoXiTrackCutNSigmaFilter::ListSettings()
 {
   // return a list of settings in a writable form
   TList *tListSetttings = new TList();
- 
+
   return tListSetttings;
 }
 
@@ -239,7 +239,7 @@ TList *AliFemtoXiTrackCutNSigmaFilter::GetOutputList()
 
 void AliFemtoXiTrackCutNSigmaFilter::UpdateDaughterV0Filter()
 {
-  //TODO find more robust way of doing this, so it can evolve is AliFemtoV0Track cut 
+  //TODO find more robust way of doing this, so it can evolve is AliFemtoV0Track cut
   //  gains more attributes
   fDaughterV0Filter->SetInvariantMassLambda(fInvMassLambdaMin,fInvMassLambdaMax);
   fDaughterV0Filter->SetInvariantMassK0s(fInvMassK0sMin,fInvMassK0sMax);
@@ -270,7 +270,7 @@ void AliFemtoXiTrackCutNSigmaFilter::UpdateDaughterV0Filter()
 
   fDaughterV0Filter->SetRequireTOFPion(fRequireTOFPion);
   fDaughterV0Filter->SetRequireTOFProton(fRequireTOFProton);
-  
+
   fDaughterV0Filter->SetNsigmaPosDaughter(fNsigmaPosDaughterTPC);
   fDaughterV0Filter->SetNsigmaNegDaughter(fNsigmaNegDaughterTPC);
   fDaughterV0Filter->SetNsigmaPosDaughter(fNsigmaPosDaughterTPC,fNsigmaPosDaughterTOF);
@@ -404,6 +404,3 @@ void AliFemtoXiTrackCutNSigmaFilter::SetCTauHistoV0(int aNbins, double aMin, dou
 {
   fDaughterV0Filter->SetCTauHistoV0(aNbins,aMin,aMax);
 }
-
-
-


### PR DESCRIPTION
Similar ambiguity issue introduced by Xcode 9 as in AliRoot PR 417 (https://github.com/alisw/AliRoot/pull/417). 

@akubera: Due to the ambiguity the constructor generation in AliFemtoConfigObject doesn't work for TString, as an explicit cast is needed in order to resolve the ambiguity. The constructor is added manually.