### PR TITLE
Introduce a new YAML configuration class

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.cxx
@@ -28,8 +28,7 @@ AliEmcalCorrectionComponentFactory::map_type * AliEmcalCorrectionComponentFactor
  */
 AliEmcalCorrectionComponent::AliEmcalCorrectionComponent() :
   TNamed("AliEmcalCorrectionComponent", "AliEmcalCorrectionComponent"),
-  fUserConfiguration(),
-  fDefaultConfiguration(),
+  fYAMLConfig(),
   fCreateHisto(kTRUE),
   fRun(-1),
   fFilepass(""),
@@ -64,8 +63,7 @@ AliEmcalCorrectionComponent::AliEmcalCorrectionComponent() :
  */
 AliEmcalCorrectionComponent::AliEmcalCorrectionComponent(const char * name) :
   TNamed(name, name),
-  fUserConfiguration(),
-  fDefaultConfiguration(),
+  fYAMLConfig(),
   fCreateHisto(kTRUE),
   fRun(-1),
   fFilepass(""),
@@ -108,7 +106,8 @@ Bool_t AliEmcalCorrectionComponent::Initialize()
 {
   // Read in pass. If it is empty, set flag to automatically find the pass from the filename.
   std::string tempString = "";
-  GetProperty("pass", tempString);
+  // Cannot use usual helper function because "pass" is not inside of a component, but rather at the top level.
+  fYAMLConfig.GetProperty("pass", tempString, true);
   fFilepass = tempString.c_str();
   if (fFilepass != "") {
     fGetPassFromFileName = kFALSE;
@@ -230,28 +229,6 @@ Bool_t AliEmcalCorrectionComponent::CheckIfRunChanged()
     }
   }
   return runChanged;
-}
-
-/**
- * Check if value is a shared parameter, meaning we should look
- * at another node. Also edits the input string to remove "sharedParameters:"
- * if it exists, making it ready for use.
- *
- * @param[in] value String containing the string value return by the parameter.
- *
- * @return True if the value is shared.
- */
-bool AliEmcalCorrectionComponent::IsSharedValue(std::string & value)
-{
-  std::size_t sharedParameterLocation = value.find("sharedParameters:");
-  if (sharedParameterLocation != std::string::npos)
-  {
-    // "sharedParameters:" is 17 characters long
-    value.erase(sharedParameterLocation, sharedParameterLocation + 17);
-    return true;
-  }
-  // Return false otherwise
-  return false;
 }
 
 /**

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.h
@@ -4,11 +4,6 @@
 #include <map>
 #include <string>
 
-// CINT can't handle the yaml header!
-#if !(defined(__CINT__) || defined(__MAKECINT__))
-#include <yaml-cpp/yaml.h>
-#endif
-
 class TH1F;
 #include <TNamed.h>
 
@@ -19,6 +14,7 @@ class AliVTrack;
 class AliVCluster;
 class AliVEvent;
 #include <AliLog.h>
+#include "AliYAMLConfiguration.h"
 #include "AliEmcalContainerUtils.h"
 #include "AliParticleContainer.h"
 #include "AliMCParticleContainer.h"
@@ -36,8 +32,8 @@ class AliVEvent;
  * component corresponds to a correction needed for the EMCal. Creation, configuration, and execution
  * of all of the components is handled by AliEmcalCorrectionTask. Each new component is automatically
  * registered through the AliEmcalCorrectionComponentFactory class, and is thus automatically available
- * to execute. Components are configured through a set of YAML configuration files. For more information
- * about the steering, see AliEmcalCorrectionTask.
+ * to execute. Components are configured through a set of YAML configuration files stored in
+ * AliYAMLConfiguration. For more information about the steering, see AliEmcalCorrectionTask.
  *
  * @author Raymond Ehlers <raymond.ehlers@yale.edu>, Yale University
  * @author James Mulligan <james.mulligan@yale.edu>, Yale University
@@ -106,32 +102,13 @@ class AliEmcalCorrectionComponent : public TNamed {
   void SetVertex(Double_t * vertex) { fVertex[0] = vertex[0]; fVertex[1] = vertex[1]; fVertex[2] = vertex[2]; }
   void SetIsESD(Bool_t isESD) {fEsdMode = isESD; }
 
-#if !(defined(__CINT__) || defined(__MAKECINT__))
-  /// Make copy to ensure that the nodes do not point to each other (?)
-  void SetUserConfiguration(YAML::Node & node) { fUserConfiguration = node; }
-  void SetDefaultConfiguration(YAML::Node & node) { fDefaultConfiguration = node; }
-  
+  /// Set YAML Configuration
+  void SetYAMLConfiguration(AliYAMLConfiguration config) { fYAMLConfig = config; }
+
   /// Retrieve property
   template<typename T> bool GetProperty(std::string propertyName, T & property, bool requiredProperty = true, std::string correctionName = "");
-
-  /// Retrieve property driver function. It is static so that it can be used by other classes
-  template<typename T> static bool GetProperty(std::string propertyName, T & property, const YAML::Node & userConfiguration, const YAML::Node & defaultConfiguration, bool requiredProperty = true, std::string correctionName = "");
-#endif
-  static bool IsSharedValue(std::string & value);
-
  protected:
-
-#if !(defined(__CINT__) || defined(__MAKECINT__))
-  template<typename T> static bool GetPropertyFromNodes(const YAML::Node & node, const YAML::Node & sharedParametersNode, std::string propertyName, T & property, const std::string correctionName, const std::string configurationType, int nodesDeep = 0);
-  template<typename T> static bool GetPropertyFromNode(const YAML::Node & node, std::string propertyName, T & property);
-
-  template<typename T> static typename std::enable_if<!std::is_arithmetic<T>::value && !std::is_same<T, std::string>::value && !std::is_same<T, bool>::value>::type PrintRetrievedPropertyValue(T & property, std::stringstream & tempMessage);
-  template<typename T> static typename std::enable_if<std::is_arithmetic<T>::value || std::is_same<T, std::string>::value || std::is_same<T, bool>::value>::type PrintRetrievedPropertyValue(T & property, std::stringstream & tempMessage);
-
-  YAML::Node              fUserConfiguration;             //!<! User YAML configuration
-  YAML::Node              fDefaultConfiguration;          //!<! Default YAML configuration
-#endif
-
+  AliYAMLConfiguration    fYAMLConfig;                    ///< Contains the YAML configuration used to configure the component
   Bool_t                  fCreateHisto;                   ///< Flag to make some basic histograms
   Int_t                   fRun;                           //!<! Run number
   TString                 fFilepass;                      ///< Input data pass number
@@ -162,11 +139,10 @@ class AliEmcalCorrectionComponent : public TNamed {
   AliEmcalCorrectionComponent &operator=(const AliEmcalCorrectionComponent &);    // Not implemented
   
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionComponent, 3); // EMCal correction component
+  ClassDef(AliEmcalCorrectionComponent, 4); // EMCal correction component
   /// \endcond
 };
 
-#if !(defined(__CINT__) || defined(__MAKECINT__))
 /**
  * Get the requested property from the YAML configuration. This function is generally used by
  * AliEmcalCorrectionComponent derived tasks as a wrapper around the more complicated functions to
@@ -187,276 +163,9 @@ bool AliEmcalCorrectionComponent::GetProperty(std::string propertyName, T & prop
   {
     correctionName = GetName();
   }
-  bool result = GetProperty(propertyName, property, fUserConfiguration, fDefaultConfiguration, requiredProperty, correctionName);
-
-  return result;
+  // Add the correction name as a prefix of the property
+  return fYAMLConfig.GetProperty(std::vector<std::string>{correctionName, propertyName}, property, requiredProperty);
 }
-
-/**
- * General function to get a property from a set of YAML configuration files. It first calls checks
- * the user configuration, and then if the property is not found, it then checks the default configuration.
- * If the property is required but it is not found, a fatal error is thrown.
- *
- * @param[in] propertyName Name of the property to retrieve
- * @param[out] property Contains the retrieved property
- * @param[in] userConfiguration YAML user configuration node
- * @param[in] defaultConfiguration YAML default configuration node
- * @param[in] requiredProperty True if the property is required
- * @param[in] correctionName Name of the correction from where the property should be retrieved
- *
- * @return True if the property was set successfully
- */
-template<typename T>
-bool AliEmcalCorrectionComponent::GetProperty(std::string propertyName, T & property, const YAML::Node & userConfiguration, const YAML::Node & defaultConfiguration, bool requiredProperty, std::string correctionName)
-{
-  // Remove AliEmcalCorrection if in name
-  std::size_t prefixStringLocation = correctionName.find("AliEmcalCorrection");
-  if (prefixStringLocation != std::string::npos)
-  {
-    // AliEmcalCorrection is 18 characters
-    correctionName.erase(prefixStringLocation, prefixStringLocation + 18);
-  }
-
-  bool setProperty = false;
-  // IsNull checks is a node is empty. A node is empty if it is created.
-  // IsDefined checks if the node that was requested was not actually created.
-  // In this case, the user configuration node is always created. If it IsNull, then we ignore it.
-  if (userConfiguration.IsNull() != true)
-  {
-    AliDebugClass(2, "Looking for parameter in user configuration");
-    YAML::Node sharedParameters = userConfiguration["sharedParameters"];
-    //std::cout << std::endl << "User Node: " << fUserConfiguration << std::endl;
-    setProperty = AliEmcalCorrectionComponent::GetPropertyFromNodes(userConfiguration, sharedParameters, propertyName, property, correctionName, "user");
-  }
-
-  if (setProperty != true)
-  {
-    AliDebugClass(2, "Looking for parameter in default configuration");
-    YAML::Node sharedParameters = defaultConfiguration["sharedParameters"];
-    //std::cout << std::endl << "Default Node: " << fDefaultConfiguration << std::endl;
-    setProperty = AliEmcalCorrectionComponent::GetPropertyFromNodes(defaultConfiguration, sharedParameters, propertyName, property, correctionName, "default");
-  }
-
-  if (setProperty != true && requiredProperty == true)
-  {
-    std::stringstream message;
-    message << "Failed to retrieve property \""
-        << (correctionName != "" ? correctionName + ":" : "")
-        << propertyName << "\" from default config!" << std::endl;
-    AliFatalClass(message.str().c_str());
-  }
-
-  // Return whether the value was actually set
-  return setProperty;
-}
-
-/**
- * Actually handles retrieving parameters from YAML nodes.
- *
- * The retrieval procedure is as follows:
- *  - Check if the property is defined in the base of the node
- *  - If the property is found:
- *     - Check whether it requests a shared parameter
- *        - If so, attempt to retrieve the property from the shared parameter.
- *     - If not, attempt to retrieve the parameter from the correction name
- *     - In either case, through a warning (or fatal if requested) if it is not found
- *  - If not found, attempt to find a node named by the correction name:
- *     - If it exists, recurse in this function. It will not go more than two levels deep!
- *     - If it does not exist, attempt to find a substring name by removing all characters after the first "_"
- *         - Recurse if found
- *
- * @param[in] node Main YAML node containing the properties
- * @param[in] sharedParametersNode YAML node containing the shared parameters
- * @param[in] propertyName Name of the property to retrieve
- * @param[out] property Contains the retrieved property
- * @param[in] correctionName Name of the correction from where the property should be retrieved
- * @param[in] configurationType Name of the configuration type. Either "user" or "default"
- * @param[in] nodesDeep Keeps track of how many nodes deep we have recursed. Optional parameter that the user does not need to set.
- *
- * @return True if the property was set successfully
- */
-template<typename T>
-bool AliEmcalCorrectionComponent::GetPropertyFromNodes(const YAML::Node & node, const YAML::Node & sharedParametersNode, std::string propertyName, T & property, const std::string correctionName, const std::string configurationType, int nodesDeep)
-{
-  // Used as a buffer for printing complicated messages
-  std::stringstream tempMessage;
-
-  bool returnValue = false;
-  if (nodesDeep > 2)
-  {
-    // Ensure that we do not go past two levels
-    tempMessage.str("");
-    tempMessage << "Went too many levels of recursion. Bailing out on \"" << correctionName << ":" << propertyName << "\" from " << configurationType << " config at level " << nodesDeep;
-    AliDebugClass(2, TString::Format("%s", tempMessage.str().c_str()));
-    return false;
-  }
-
-  // Only want to print once to ensure the user is not overwhelmed!
-  if (nodesDeep == 0)
-  {
-    tempMessage.str("");
-    tempMessage << "Retreiving property \""
-          << (correctionName != "" ? correctionName + ":" : "")
-          << propertyName << "\" from " << configurationType << " config at level " << nodesDeep;
-    AliDebugClass(1, TString::Format("%s", tempMessage.str().c_str()));
-  }
-
-  if (node.IsDefined() == true)
-  {
-    //std::cout << "Node: " << node << std::endl;
-    if (node[propertyName])
-    {
-      bool isShared = false;
-      // Will contain the name of the property in the sharedParameters section that should be retrieved
-      // if it is requested through the user configuration.
-      std::string sharedValueName = "";
-      // Necessary because it fails on vectors and other complex objects that are YAML sequences.
-      if (std::is_arithmetic<T>::value || std::is_same<T, std::string>::value || std::is_same<T, bool>::value)
-      {
-        // Retrieve value as string to check for shared value
-        sharedValueName = node[propertyName].as<std::string>();
-        // Check for a shared value
-        isShared = AliEmcalCorrectionComponent::IsSharedValue(sharedValueName);
-      }
-
-      tempMessage.str("");
-      tempMessage << "property \"" 
-            << (nodesDeep > 0 ? correctionName + ":" : "")
-            << propertyName
-            << "\" using " << ( isShared ? "\"sharedParameters:" + sharedValueName + "\" in " : "" )
-            << "values from the " << configurationType
-            << " configuration at level " << nodesDeep;
-
-      AliDebugClass(2, TString::Format("Retrieveing %s", tempMessage.str().c_str()));
-
-      bool retrievalResult = false;
-      if (isShared == true)
-      {
-        retrievalResult = GetPropertyFromNode(sharedParametersNode, sharedValueName, property);
-      }
-      else
-      {
-        retrievalResult = GetPropertyFromNode(node, propertyName, property);
-      }
-
-      // Inform about the result
-      if (retrievalResult == true)
-      {
-        // Add the retrieved value to the message (only if trivially printable)
-        PrintRetrievedPropertyValue(property, tempMessage);
-        AliDebugClassStream(2) << "Succeeded in retrieveing " << tempMessage.str() << std::endl;
-        returnValue = true;
-      }
-      else
-      {
-        // Only fatal if we have exhausted our last option, the default
-        if (configurationType == "default")
-        {
-          AliFatalClass(TString::Format("Failed to retrieve %s", tempMessage.str().c_str()));
-        }
-        else
-        {
-          AliDebugClass(2, TString::Format("Failed to retrieve %s", tempMessage.str().c_str()));
-        }
-        returnValue = false;
-      }
-    }
-    else
-    {
-      // Go one node deeper using recursion
-      // Must create a new node, since we took the original node by reference
-      YAML::Node deeperNode = node[correctionName];
-      nodesDeep++;
-      AliDebugClass(2, TString::Format("Going a node deeper with \"%s\" to level %i", correctionName.c_str(), nodesDeep));
-      returnValue = GetPropertyFromNodes(deeperNode, sharedParametersNode, propertyName, property, correctionName, configurationType, nodesDeep);
-
-      // If we didn't find it, next try a substring
-      if (returnValue == false)
-      {
-        // Don't increment nodesDeep, because we are about to go another node deep anyway
-        std::size_t splitLocation = correctionName.find("_");
-        // We only want to look at the split if we are only one node deep and
-        // if the split is actually meaningful
-        if (splitLocation != std::string::npos && nodesDeep == 1)
-        {
-          // Split from start to underscore
-          std::string subCorrectionName = correctionName.substr(0, splitLocation);
-          AliDebugClass(2, TString::Format("Attempting to retrieve property \"%s\" from base correction \"%s\" at level %i", propertyName.c_str(), subCorrectionName.c_str(), nodesDeep));
-          // Retrieve the base correction node
-          // Need to create new node! Otherwise it will assign the correctionName node to subCorrectionName node!
-          YAML::Node subCorrectionNode = node[subCorrectionName];
-          returnValue = GetPropertyFromNodes(subCorrectionNode, sharedParametersNode, propertyName, property, subCorrectionName, configurationType, nodesDeep);
-        }
-      }
-    }
-  }
-  else
-  {
-    tempMessage.str("");
-    tempMessage << "Node is undefined for \""
-          << (correctionName != "" ? correctionName + ":" : "")
-          << propertyName << "\" from " << configurationType << " config at level " << nodesDeep;
-    AliDebugClass(2, TString::Format("%s", tempMessage.str().c_str()));
-
-    returnValue = false;
-  }
-
-  return returnValue;
-}
-
-/**
- * Prints the retrieved property value if the type is easily printable. This function handles arithmetic
- * values, strings, and bools. Further types could be handled by other functions that are selectively enabled
- * by std::enable_if<>.
- *
- * NOTE: This function retunrs void! See: https://stackoverflow.com/a/29044828
- *
- * @param[in] property Property to be printed
- * @param[in, out] tempMessage Stringstream into which the property should be streamed
- */
-template<typename T>
-typename std::enable_if<std::is_arithmetic<T>::value || std::is_same<T, std::string>::value || std::is_same<T, bool>::value>::type
-AliEmcalCorrectionComponent::PrintRetrievedPropertyValue(T & property, std::stringstream & tempMessage)
-{
-  //AliDebugClassStream(2) << " with value " << property;
-  tempMessage << " with value \"" << property << "\"";
-}
-
-/**
- * Handles all other cases where the property cannot be printed.
- *
- * NOTE: This function retunrs void! See: https://stackoverflow.com/a/29044828
- *
- * @param[in] property Property to be printed
- * @param[in, out] tempMessage Stringstream into which the property should be streamed
- */
-template<typename T>
-typename std::enable_if<!std::is_arithmetic<T>::value && !std::is_same<T, std::string>::value && !std::is_same<T, bool>::value>::type
-AliEmcalCorrectionComponent::PrintRetrievedPropertyValue(T & property, std::stringstream & tempMessage)
-{
-  // Cannot easily print these types, so just note that is the case!
-  tempMessage << " with a value that cannot be trivially printed";
-}
-
-/**
- * Utility function to retrieve the property from a already selected YAML node.
- *
- * @param[in] node YAML node from which the property should be retrieved
- * @param[in] propertyName Name of the property to retrieve
- * @param[out] property Contains the retrieved property
- */
-template<typename T>
-bool AliEmcalCorrectionComponent::GetPropertyFromNode(const YAML::Node & node, std::string propertyName, T & property)
-{
-  if (node[propertyName])
-  {
-    property = node[propertyName].as<T>();
-    return true;
-  }
-  return false;
-}
-
-#endif /* Hide yaml from CINT */
 
 /**
  * @class AliEmcalCorrectionComponentFactory

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
@@ -4,6 +4,7 @@
 //
 
 #include "AliEmcalCorrectionTask.h"
+#include "AliYAMLConfiguration.h"
 #include "AliEmcalCorrectionComponent.h"
 
 #include <vector>
@@ -14,10 +15,6 @@
 #include <algorithm>
 
 #include <TChain.h>
-#include <TSystem.h>
-#include <TGrid.h>
-#include <TFile.h>
-#include <TUUID.h>
 
 #include "AliVEventHandler.h"
 #include "AliEMCALGeometry.h"
@@ -59,11 +56,8 @@ const std::map <std::string, AliEmcalTrackSelection::ETrackFilterType_t> AliEmca
  */
 AliEmcalCorrectionTask::AliEmcalCorrectionTask() :
   AliAnalysisTaskSE("AliEmcalCorrectionTask"),
-  fUserConfiguration(),
-  fDefaultConfiguration(),
+  fYAMLConfig(),
   fSuffix(""),
-  fUserConfigurationString(""),
-  fDefaultConfigurationString(""),
   fUserConfigurationFilename(""),
   fDefaultConfigurationFilename(""),
   fOrderedComponentsToExecute(),
@@ -107,11 +101,8 @@ AliEmcalCorrectionTask::AliEmcalCorrectionTask() :
  */
 AliEmcalCorrectionTask::AliEmcalCorrectionTask(const char * name) :
   AliAnalysisTaskSE(name),
-  fUserConfiguration(),
-  fDefaultConfiguration(),
+  fYAMLConfig(),
   fSuffix(""),
-  fUserConfigurationString(""),
-  fDefaultConfigurationString(""),
   fUserConfigurationFilename(""),
   fDefaultConfigurationFilename(""),
   fOrderedComponentsToExecute(),
@@ -155,11 +146,8 @@ AliEmcalCorrectionTask::AliEmcalCorrectionTask(const char * name) :
  * would be required for this to be more fully copied!
  */
 AliEmcalCorrectionTask::AliEmcalCorrectionTask(const AliEmcalCorrectionTask & task):
-  fUserConfiguration(task.fUserConfiguration),
-  fDefaultConfiguration(task.fDefaultConfiguration),
+  fYAMLConfig(task.fYAMLConfig),
   fSuffix(task.fSuffix),
-  fUserConfigurationString(task.fUserConfigurationString),
-  fDefaultConfigurationString(task.fDefaultConfigurationString),
   fUserConfigurationFilename(task.fUserConfigurationFilename),
   fDefaultConfigurationFilename(task.fDefaultConfigurationFilename),
   fOrderedComponentsToExecute(task.fOrderedComponentsToExecute),
@@ -221,11 +209,8 @@ void swap(AliEmcalCorrectionTask & first, AliEmcalCorrectionTask & second)
 {
   using std::swap;
 
-  swap(first.fUserConfiguration, second.fUserConfiguration);
-  swap(first.fDefaultConfiguration, second.fDefaultConfiguration);
+  swap(first.fYAMLConfig, second.fYAMLConfig);
   swap(first.fSuffix, second.fSuffix);
-  swap(first.fUserConfigurationString, second.fUserConfigurationString);
-  swap(first.fDefaultConfigurationString, second.fDefaultConfigurationString);
   swap(first.fUserConfigurationFilename, second.fUserConfigurationFilename);
   swap(first.fDefaultConfigurationFilename, second.fDefaultConfigurationFilename);
   swap(first.fOrderedComponentsToExecute, second.fOrderedComponentsToExecute);
@@ -354,51 +339,28 @@ void AliEmcalCorrectionTask::InitializeConfiguration()
     fDefaultConfigurationFilename = "$ALICE_PHYSICS/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml";
   }
 
-  // Setup the YAML files
-  // Default
-  SetupConfigurationFilePath(fDefaultConfigurationFilename);
-
-  if (DoesFileExist(fDefaultConfigurationFilename) == true)
-  {
-    AliInfo(TString::Format("Using default EMCal corrections configuration located at %s", fDefaultConfigurationFilename.c_str()));
-
-    fDefaultConfiguration = YAML::LoadFile(fDefaultConfigurationFilename);
-    // Check for valid file
-    if (fDefaultConfiguration.IsNull() == true)
-    {
-      AliFatal(TString::Format("Could not open the default configuration file \"%s\"!", fDefaultConfigurationFilename.c_str()));
-    }
+  // Setup and initialize configurations
+  // user is added first so that it will be checked first.
+  // User file
+  bool returnValue = fYAMLConfig.AddConfiguration(fUserConfigurationFilename, "user");
+  if (returnValue) {
+    AliInfoStream() << "Using user EMCal corrections configuration located at \"" << fUserConfigurationFilename << "\"\n";
   }
-  else
-  {
+  else {
+    AliInfoStream() << "User file at \"" << fUserConfigurationFilename << "\" does not exist! All settings will be from the default file!";
+  }
+
+  // Default file
+  returnValue = fYAMLConfig.AddConfiguration(fDefaultConfigurationFilename, "default");
+  if (returnValue) {
+    AliInfoStream() << "Using default EMCal corrections configuration located at \"" << fDefaultConfigurationFilename << "\"\n";
+  }
+  else {
     AliFatal(TString::Format("Default file located at \"%s\" does not exist!", fDefaultConfigurationFilename.c_str()));
   }
 
-  // User
-  SetupConfigurationFilePath(fUserConfigurationFilename, true);
-
-  if (DoesFileExist(fUserConfigurationFilename) == true)
-  {
-    AliInfo(TString::Format("Using user EMCal corrections configuration located at %s", fUserConfigurationFilename.c_str()));
-
-    fUserConfiguration = YAML::LoadFile(fUserConfigurationFilename);
-  }
-  else
-  {
-    AliInfo(TString::Format("User file at \"%s\" does not exist! All settings will be from the default file!", fUserConfigurationFilename.c_str()));
-  }
-
-  // Save configuration into strings so that they can be streamed
-  // Need the stringstream because YAML implements streamers
-  std::stringstream tempConfiguration;
-  tempConfiguration << fUserConfiguration;
-  fUserConfigurationString = tempConfiguration.str();
-  tempConfiguration.str("");
-  tempConfiguration << fDefaultConfiguration;
-  fDefaultConfigurationString = tempConfiguration.str();
-
-  //AliInfo(TString::Format("User configuration: %s", fUserConfigurationString.c_str()));
-  //AliInfo(TString::Format("Default configuration: %s", fDefaultConfigurationString.c_str()));
+  // Initialize
+  fYAMLConfig.Initialize();
 
   // Note that it is initialized properly so that the analysis can proceed
   fConfigurationInitialized = true;
@@ -418,15 +380,15 @@ void AliEmcalCorrectionTask::DetermineComponentsToExecute(std::vector <std::stri
 {
   std::vector <std::string> executionOrder;
   // executionOrder determines the order of tasks to execute, but it doesn't name the particular tasks
-  AliEmcalCorrectionComponent::GetProperty("executionOrder", executionOrder, fUserConfiguration, fDefaultConfiguration, true);
+  fYAMLConfig.GetProperty("executionOrder", executionOrder, true);
 
   // Possible components to create from both the user and default configurations
   // Use set so that the possible components are not repeated
   std::set <std::string> possibleComponents;
-  for (auto node : fUserConfiguration) {
+  for (auto node : fYAMLConfig.GetConfiguration("user").second) {
     possibleComponents.insert(node.first.as<std::string>());
   }
-  for (auto node : fDefaultConfiguration) {
+  for (auto node : fYAMLConfig.GetConfiguration("default").second) {
     possibleComponents.insert(node.first.as<std::string>());
   }
 
@@ -448,7 +410,7 @@ void AliEmcalCorrectionTask::DetermineComponentsToExecute(std::vector <std::stri
     if (foundComponent)
     {
       // Check if the component is enabled
-      AliEmcalCorrectionComponent::GetProperty("enabled", componentEnabled, fUserConfiguration, fDefaultConfiguration, true, expectedComponentName);
+      fYAMLConfig.GetProperty({expectedComponentName, "enabled"}, componentEnabled, true);
       // If enabled, then store the name so that it can be executed
       if (componentEnabled == true) {
         foundSuffixComponent = true;
@@ -466,7 +428,7 @@ void AliEmcalCorrectionTask::DetermineComponentsToExecute(std::vector <std::stri
       expectedComponentName = execName;
       foundComponent = CheckPossibleNamesForComponentName(expectedComponentName, possibleComponents);
       // Check if it is enabled
-      AliEmcalCorrectionComponent::GetProperty("enabled", componentEnabled, fUserConfiguration, fDefaultConfiguration, true, expectedComponentName);
+      fYAMLConfig.GetProperty({expectedComponentName, "enabled"}, componentEnabled, true);
 
       if (componentEnabled == true) {
         if (foundSuffixComponent == true) {
@@ -520,25 +482,25 @@ void AliEmcalCorrectionTask::CheckForUnmatchedUserSettings()
     userPropertyNames.clear();
     defaultPropertyNames.clear();
     // We need to remove "AliEmcalCorrection" so that the correction will be found in the configuration
-    // "AliEmcalCorrection" is 18 characters
-    tempComponentName = componentName.substr(componentName.find("AliEmcalCorrection")+18);
+    std::string prefix = "AliEmcalCorrection";
+    tempComponentName = componentName.substr(componentName.find(prefix) + prefix.length());
 
     AliDebugStream(2) << "Checking component " << componentName << " for unmatched user settings" << std::endl;
 
     // Get the user property names
-    GetPropertyNamesFromNode(tempComponentName, fUserConfiguration, userPropertyNames, false);
+    GetPropertyNamesFromNode("user", tempComponentName, userPropertyNames, false);
 
     // Get the same from default
     // Not required here because the default configuration may not have the specialized component
-    GetPropertyNamesFromNode(tempComponentName, fDefaultConfiguration, defaultPropertyNames, false);
+    GetPropertyNamesFromNode("default", tempComponentName, defaultPropertyNames, false);
 
     // We need to check the base correction as well to fill out the options
     if (tempComponentName.find("_") != std::string::npos) {
       // Get the base user component
-      GetPropertyNamesFromNode(tempComponentName.substr(0, tempComponentName.find("_")), fUserConfiguration, userPropertyNames, false);
+      GetPropertyNamesFromNode("user", tempComponentName.substr(0, tempComponentName.find("_")), userPropertyNames, false);
 
       // Required here because the default must have the base component!
-      GetPropertyNamesFromNode(tempComponentName.substr(0, tempComponentName.find("_")), fDefaultConfiguration, defaultPropertyNames, true);
+      GetPropertyNamesFromNode("default", tempComponentName.substr(0, tempComponentName.find("_")), defaultPropertyNames, true);
     }
 
     // Check each property defined in the user file for a match to the properties in the default file
@@ -584,8 +546,7 @@ void AliEmcalCorrectionTask::InitializeComponents()
     component->SetTitle(componentName.c_str());
 
     // Initialize the YAML configurations in each component
-    component->SetUserConfiguration(fUserConfiguration);
-    component->SetDefaultConfiguration(fDefaultConfiguration);
+    component->SetYAMLConfiguration(fYAMLConfig);
 
     // configure needed fields for components to properly initialize
     component->SetIsESD(fIsEsd);
@@ -625,15 +586,6 @@ void AliEmcalCorrectionTask::CreateInputObjects(AliEmcalContainerUtils::InputObj
   // Get container node
   std::string inputObjectName = GetInputFieldNameFromInputObjectType(inputObjectType);
 
-  // Get the user and default input nodes for the object type
-  YAML::Node userInputObjectNode;
-  YAML::Node defaultInputObjectNode;
-  GetNodeForInputObjects(userInputObjectNode, fUserConfiguration, inputObjectName, false);
-  GetNodeForInputObjects(defaultInputObjectNode, fDefaultConfiguration, inputObjectName, true);
-
-  AliDebugStream(3) << "userInputObjectNode: " << userInputObjectNode << std::endl;
-  AliDebugStream(3) << "defaultInputObjectNode: " << defaultInputObjectNode << std::endl;
-
   // Determine which containers we need based on which are requested by the enabled correction tasks
   std::set <std::string> requestedContainers;
   std::vector <std::string> componentRequest;
@@ -641,8 +593,9 @@ void AliEmcalCorrectionTask::CreateInputObjects(AliEmcalContainerUtils::InputObj
   {
     componentRequest.clear();
     // Not required because not all components will have all kinds of containers
-    // "AliEmcalCorrection" is 18 characters
-    AliEmcalCorrectionComponent::GetProperty(inputObjectName + "Names", componentRequest, fUserConfiguration, fDefaultConfiguration, false, componentName.substr(componentName.find("AliEmcalCorrection")+18));
+    std::string selectionName = "AliEmcalCorrection";
+    // Expliecitly initialize as a vector to avoid ambiguity.
+    fYAMLConfig.GetProperty(std::vector<std::string>{componentName.substr(componentName.find(selectionName) + selectionName.length()), inputObjectName + "Names"}, componentRequest, false);
     for ( auto & req : componentRequest )
     {
       AliDebugStream(3) << "Component " << componentName << " requested container name " << req << std::endl;
@@ -657,7 +610,7 @@ void AliEmcalCorrectionTask::CreateInputObjects(AliEmcalContainerUtils::InputObj
 
   // Create all requested containers
   AliDebug(2, TString::Format("Setting up requested containers!"));
-  SetupContainersFromInputNodes(inputObjectType, userInputObjectNode, defaultInputObjectNode, requestedContainers);
+  SetupContainersFromInputNodes(inputObjectType, requestedContainers);
 }
 
 /**
@@ -675,8 +628,9 @@ void AliEmcalCorrectionTask::AddContainersToComponent(AliEmcalCorrectionComponen
   inputObjectName = inputObjectName + "Names";
 
   std::vector <std::string> inputObjects;
-  // Not required, because not all components need Clusters or Tracks
-  AliEmcalCorrectionComponent::GetProperty(inputObjectName.c_str(), inputObjects, fUserConfiguration, fDefaultConfiguration, false, component->GetName());
+  // Property is not required, because not all components need Clusters or Tracks
+  // Expliecitly initialize as a vector to avoid ambiguity.
+  fYAMLConfig.GetProperty(std::vector<std::string>{component->GetName(), inputObjectName.c_str()}, inputObjects, false);
 
   //AliDebugStream(4) << "inputObjects.size(): " << inputObjects.size() << std::endl;
 
@@ -759,11 +713,9 @@ void AliEmcalCorrectionTask::AddContainersToComponent(AliEmcalCorrectionComponen
  * Creates the input objects containers requested by the components.
  *
  * @param[in] inputObjectType Type of the input objects to create
- * @param[in] userInputObjectNode YAML Node corresponding to the user input objects configuration
- * @param[in] defaultInputObjectNode YAML Node corresponding to the default input objects configuration
  * @param[in] requestedContainers Containers to be created
  */
-void AliEmcalCorrectionTask::SetupContainersFromInputNodes(AliEmcalContainerUtils::InputObject_t inputObjectType, YAML::Node & userInputObjectNode, YAML::Node & defaultInputObjectNode, std::set <std::string> & requestedContainers)
+void AliEmcalCorrectionTask::SetupContainersFromInputNodes(AliEmcalContainerUtils::InputObject_t inputObjectType, std::set <std::string> & requestedContainers)
 {
   // Our node contains all of the objects that we will want to create.
   for(auto & containerName : requestedContainers)
@@ -777,10 +729,10 @@ void AliEmcalCorrectionTask::SetupContainersFromInputNodes(AliEmcalContainerUtil
 
     AliDebug(2, TString::Format("Processing container %s of inputType %d", containerName.c_str(), inputObjectType));
     if (inputObjectType == AliEmcalContainerUtils::kCluster || inputObjectType == AliEmcalContainerUtils::kTrack) {
-      SetupContainer(inputObjectType, containerName, userInputObjectNode, defaultInputObjectNode);
+      SetupContainer(inputObjectType, containerName);
     }
     else if (inputObjectType == AliEmcalContainerUtils::kCaloCells) {
-      SetupCellsInfo(containerName, userInputObjectNode, defaultInputObjectNode);
+      SetupCellsInfo(containerName);
     }
   }
 }
@@ -792,22 +744,19 @@ void AliEmcalCorrectionTask::SetupContainersFromInputNodes(AliEmcalContainerUtil
  * The created cell containers is stored by in the correction task.
  *
  * @param[in] containerName Name of the container to create (as defined in the YAML configuration)
- * @param[in] userNode YAML Node corresponding to the user input object's configuration
- * @param[in] defaultNode YAML Node corresponding to the default input object's configuration
  */
-void AliEmcalCorrectionTask::SetupCellsInfo(std::string containerName, YAML::Node & userNode, YAML::Node & defaultNode)
+void AliEmcalCorrectionTask::SetupCellsInfo(std::string containerName)
 {
   // Define cell info
   AliEmcalCorrectionCellContainer * cellObj = new AliEmcalCorrectionCellContainer();
-
-  AliDebugStream(2) << "User: " << std::endl << userNode << std::endl << "default: " << std::endl << defaultNode << std::endl;
 
   // Set properties
   // Cells (object) name
   cellObj->SetName(containerName);
   // Branch name
+  std::vector <std::string> inputObjectPropertiesPath = {"inputObjects", GetInputFieldNameFromInputObjectType(AliEmcalContainerUtils::kCaloCells), containerName};
   std::string tempString = "";
-  AliEmcalCorrectionComponent::GetProperty("branchName", tempString, userNode, defaultNode, true, containerName);
+  fYAMLConfig.GetProperty(inputObjectPropertiesPath, "branchName", tempString, true);
   if (tempString == "usedefault") {
     tempString = AliEmcalContainerUtils::DetermineUseDefaultName(AliEmcalContainerUtils::kCaloCells, fIsEsd);
   }
@@ -815,7 +764,7 @@ void AliEmcalCorrectionTask::SetupCellsInfo(std::string containerName, YAML::Nod
 
   // IsEmbedding
   bool tempBool = false;
-  AliEmcalCorrectionComponent::GetProperty("embedding", tempBool, userNode, defaultNode, false, containerName);
+  fYAMLConfig.GetProperty(inputObjectPropertiesPath, "embedding", tempBool, false);
   cellObj->SetIsEmbedding(tempBool);
 
   // Add to the array to keep track of it
@@ -836,14 +785,12 @@ void AliEmcalCorrectionTask::SetupCellsInfo(std::string containerName, YAML::Nod
  *
  * @param[in] inputObjectType Type of the input object to configure
  * @param[in] containerName Name of the container to create (as defined in the YAML configuration)
- * @param[in] userNode YAML Node corresponding to the user input object's configuration
- * @param[in] defaultNode YAML Node corresponding to the default input object's configuration
  */
-void AliEmcalCorrectionTask::SetupContainer(AliEmcalContainerUtils::InputObject_t inputObjectType, std::string containerName, YAML::Node & userNode, YAML::Node & defaultNode)
+void AliEmcalCorrectionTask::SetupContainer(const AliEmcalContainerUtils::InputObject_t inputObjectType, const std::string containerName)
 {
   // Create container
   AliDebugStream(2) << "Adding container" << std::endl;
-  AliEmcalContainer * cont = AddContainer(inputObjectType, containerName, userNode, defaultNode);
+  AliEmcalContainer * cont = AddContainer(inputObjectType, containerName);
   AliDebugStream(2) << "Added container" << std::endl;
 
   // Set the container properties
@@ -852,8 +799,25 @@ void AliEmcalCorrectionTask::SetupContainer(AliEmcalContainerUtils::InputObject_
   //       which can make it a bit complicated. Those details include inheritance, pointing to member
   //       functions, etc. It should all be possible, but may not be worth all of the extra work and code.
   //       Example ccode:
-  //          SetValueInContainer("minPt", &cont::SetMinPt, tempDouble, userNode, defaultNode);
-  //          SetValueInContainer("minE", &cont::SetMinE, tempDouble, userNode, defaultNode);
+  //          SetValueInContainer(inputObjectPropertiesPath, "minPt", &cont::SetMinPt, tempDouble, false);
+  //          SetValueInContainer(inputObjectPropertiesPath, "minE", &cont::SetMinE, tempDouble, false);
+  //       std::function may be easier?
+  // See: https://isocpp.org/wiki/faq/pointers-to-members
+  //// Example
+  //// Retuire void return type and double arg type
+  // type void (AliEmcalContainer::*EmcalContainerFn)(double val);
+  // // Potential map?
+  // std::map<std::string, EmcalContainerFn> EmcalContFunctionMap;
+  // EmcalContFunctionMap["minPt"] = &AliEmcalContainer::SetMinPt;
+  // EmcalContFunctionMap["minE"] = &AliEmcalContainer::SetMinE;
+  // // Define functions (use map?)
+  // EmcalContainerFn minPt = &AliEmcalContainer::SetMinPt;
+  // EmcalContainerFn minE = &AliEmcalContainer::SetMinE;
+  // // Example invocation
+  // (cont->*minPt)(tempDouble);
+
+  // Path to the various properties
+  std::vector <std::string> inputObjectPropertiesPath = {"inputObjects", GetInputFieldNameFromInputObjectType(inputObjectType), containerName};
 
   // Temporary variables to store requested properties
   std::string tempString = "";
@@ -862,41 +826,41 @@ void AliEmcalCorrectionTask::SetupContainer(AliEmcalContainerUtils::InputObject_
 
   // AliEmcalContainer properties
   // Min Pt
-  bool result = AliEmcalCorrectionComponent::GetProperty("minPt", tempDouble, userNode, defaultNode, false, containerName);
+  bool result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "minPt", tempDouble, false);
   if (result) {
     AliDebugStream(2) << cont->GetName() << ": Setting minPt of " << tempDouble << std::endl;
     cont->SetMinPt(tempDouble);
   }
   // Min E
-  result = AliEmcalCorrectionComponent::GetProperty("minE", tempDouble, userNode, defaultNode, false, containerName);
+  result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "minE", tempDouble, false);
   if (result) {
     AliDebugStream(2) << cont->GetName() << ": Setting minE of " << tempDouble << std::endl;
     cont->SetMinE(tempDouble);
   }
   // Eta min, max
-  result = AliEmcalCorrectionComponent::GetProperty("minEta", tempDouble, userNode, defaultNode, false, containerName);
+  result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "minEta", tempDouble, false);
   if (result) {
     // Only continue checking if the min is there, since we must set both together
     Double_t tempDouble2 = 0;
-    result = AliEmcalCorrectionComponent::GetProperty("maxEta", tempDouble, userNode, defaultNode, false, containerName);
+    result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "maxEta", tempDouble, false);
     if (result) {
       AliDebugStream(2) << cont->GetName() << ": Setting eta limits of " << tempDouble << " to " << tempDouble2 << std::endl;
       cont->SetEtaLimits(tempDouble, tempDouble2);
     }
   }
   // Phi min, max
-  result = AliEmcalCorrectionComponent::GetProperty("minPhi", tempDouble, userNode, defaultNode, false, containerName);
+  result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "minPhi", tempDouble, false);
   if (result) {
     // Only continue checking if the min is there, since we must set both together
     Double_t tempDouble2 = 0;
-    result = AliEmcalCorrectionComponent::GetProperty("maxPhi", tempDouble, userNode, defaultNode, false, containerName);
+    result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "maxPhi", tempDouble, false);
     if (result) {
       AliDebugStream(2) << cont->GetName() << ": Setting phi limits of " << tempDouble << " to " << tempDouble2 << std::endl;
       cont->SetPhiLimits(tempDouble, tempDouble2);
     }
   }
   // Embedded
-  result = AliEmcalCorrectionComponent::GetProperty("embedding", tempBool, userNode, defaultNode, false, containerName);
+  result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "embedding", tempBool, false);
   if (result) {
     AliDebugStream(2) << cont->GetName() << ": Setting embedding to " << (tempBool ? "enabled" : "disabled") << std::endl;
     cont->SetIsEmbedding(tempBool);
@@ -907,7 +871,7 @@ void AliEmcalCorrectionTask::SetupContainer(AliEmcalContainerUtils::InputObject_
   if (clusterContainer) {
     // Default energy
     // Probably not needed for the corrections
-    /*result = AliEmcalCorrectionComponent::GetProperty("defaultClusterEnergy", tempString, userNode, defaultNode, false, containerName);
+    /*result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "defaultClusterEnergy", tempString, false);
     if (result) {
       // Need to get the enumeration
       AliVCluster::VCluUserDefEnergy_t clusterEnergyType = fgkClusterEnergyTypeMap.at(tempString);
@@ -916,21 +880,21 @@ void AliEmcalCorrectionTask::SetupContainer(AliEmcalContainerUtils::InputObject_
     }*/
 
     // NonLinCorrEnergyCut
-    result = AliEmcalCorrectionComponent::GetProperty("clusNonLinCorrEnergyCut", tempDouble, userNode, defaultNode, false, containerName);
+    result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "clusNonLinCorrEnergyCut", tempDouble, false);
     if (result) {
       AliDebugStream(2) << clusterContainer->GetName() << ": Setting clusNonLinCorrEnergyCut of " << tempDouble << std::endl;
       clusterContainer->SetClusNonLinCorrEnergyCut(tempDouble);
     }
 
     // HadCorrEnergyCut
-    result = AliEmcalCorrectionComponent::GetProperty("clusHadCorrEnergyCut", tempDouble, userNode, defaultNode, false, containerName);
+    result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "clusHadCorrEnergyCut", tempDouble, false);
     if (result) {
       AliDebugStream(2) << clusterContainer->GetName() << ": Setting clusHadCorrEnergyCut of " << tempDouble << std::endl;
       clusterContainer->SetClusHadCorrEnergyCut(tempDouble);
     }
 
     // SetIncludePHOS
-    result = AliEmcalCorrectionComponent::GetProperty("includePHOS", tempBool, userNode, defaultNode, false, containerName);
+    result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "includePHOS", tempBool, false);
     if (result) {
       AliDebugStream(2) << clusterContainer->GetName() << ": Setting Include PHOS to " << (tempBool ? "enabled" : "disabled") << std::endl;
       clusterContainer->SetIncludePHOS(tempBool);
@@ -943,7 +907,7 @@ void AliEmcalCorrectionTask::SetupContainer(AliEmcalContainerUtils::InputObject_
     // Track selection
     // AOD Filter bits as a sequence
     std::vector <UInt_t> filterBitsVector;
-    result = AliEmcalCorrectionComponent::GetProperty("aodFilterBits", filterBitsVector, userNode, defaultNode, false, containerName);
+    result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "aodFilterBits", filterBitsVector, false);
     if (result){
       UInt_t filterBits = 0;
       for (int filterBit : filterBitsVector) {
@@ -954,7 +918,7 @@ void AliEmcalCorrectionTask::SetupContainer(AliEmcalContainerUtils::InputObject_
     }
 
     // SetTrackFilterType enum
-    result = AliEmcalCorrectionComponent::GetProperty("trackFilterType", tempString, userNode, defaultNode, false, containerName);
+    result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "trackFilterType", tempString, false);
     if (result) {
       // Need to get the enumeration
       AliEmcalTrackSelection::ETrackFilterType_t trackFilterType = fgkTrackFilterTypeMap.at(tempString);
@@ -963,7 +927,7 @@ void AliEmcalCorrectionTask::SetupContainer(AliEmcalContainerUtils::InputObject_
     }
 
     // Track cuts period
-    result = AliEmcalCorrectionComponent::GetProperty("trackCutsPeriod", tempString, userNode, defaultNode, false, containerName);
+    result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "trackCutsPeriod", tempString, false);
     if (result) {
       // Need to get the enumeration
       AliDebugStream(2) << trackContainer->GetName() << ": Setting track cuts period to " << tempString << std::endl;
@@ -984,12 +948,10 @@ void AliEmcalCorrectionTask::SetupContainer(AliEmcalContainerUtils::InputObject_
  *
  * @param[in] contType Type of the input object to add
  * @param[in] containerName Name of the container to create (as defined in the YAML configuration)
- * @param[in] userNode YAML Node corresponding to the user input object's configuration
- * @param[in] defaultNode YAML Node corresponding to the default input object's configuration
  *
  * @return The created container
  */
-AliEmcalContainer * AliEmcalCorrectionTask::AddContainer(AliEmcalContainerUtils::InputObject_t contType, std::string & containerName, YAML::Node & userNode, YAML::Node & defaultNode)
+AliEmcalContainer * AliEmcalCorrectionTask::AddContainer(const AliEmcalContainerUtils::InputObject_t contType, const std::string containerName)
 {
   // Determine the type of branch to request
   std::string containerBranch = "";
@@ -997,11 +959,11 @@ AliEmcalContainer * AliEmcalCorrectionTask::AddContainer(AliEmcalContainerUtils:
     AliFatal("Must specify type of container when requesting branch.");
   }
 
+  // Path to the various properties
+  std::vector <std::string> inputObjectPropertiesPath = {"inputObjects", GetInputFieldNameFromInputObjectType(contType), containerName};
+
   // Retrieve branch name
-  // YAML::Node() is just an empty node
-  AliDebugStream(2) << "User Node: " << userNode << std::endl;
-  AliDebugStream(2) << "Default Node: " << defaultNode << std::endl;
-  AliEmcalCorrectionComponent::GetProperty("branchName", containerBranch, userNode, defaultNode, true, containerName);
+  fYAMLConfig.GetProperty(inputObjectPropertiesPath, "branchName", containerBranch, true);
   // Should be unnecessary, since the user can only do this if done explicitly.
   /*if (containerBranch == "")
   {
@@ -1051,30 +1013,8 @@ void AliEmcalCorrectionTask::UserCreateOutputObjects()
     AliFatal("YAML configuration must be initialized before running (ie. the AddTask, run macro or wagon)!");
   }
 
-  // Show the configurations info this is available
-  AliDebugStream(4) << "User configuration string: " << fUserConfigurationString << std::endl;
-  AliDebugStream(4) << "User configuration: " << fUserConfiguration << std::endl;
-  AliDebugStream(4) << "Default configuration string: " << fDefaultConfigurationString << std::endl;
-  AliDebugStream(4) << "Default configuration: " << fDefaultConfiguration << std::endl;
-
   // YAML Objects cannot be streamed, so we need to reinitialize them here.
-  // They need reinitialize if they are null
-  if (fUserConfiguration.IsNull() == true && fUserConfigurationString != "")
-  {
-    AliInfo("Reinitializing user configuration from string. Expected if running on grid!");
-    fUserConfiguration = YAML::Load(fUserConfigurationString);
-  }
-  if (fDefaultConfiguration.IsNull() == true)
-  {
-    AliInfo("Reinitializing default configuration from string. Expected if running on grid!");
-    fDefaultConfiguration = YAML::Load(fDefaultConfigurationString);
-  }
-
-  // Debug to check that the configuration has been (re)initiailzied has been completed correctly
-  AliDebugStream(4) << "(Re)initialized user configuration: " << fUserConfigurationString << std::endl;
-  AliDebugStream(4) << "(Re)initialized user configuration: " << fUserConfiguration << std::endl;
-  AliDebugStream(4) << "(Re)initialized default configuration: " << fDefaultConfigurationString << std::endl;
-  AliDebugStream(4) << "(Re)initialized default configuration: " << fDefaultConfiguration << std::endl;
+  fYAMLConfig.Reinitialize();
 
   if (fForceBeamType == kpp)
     fNcentBins = 1;
@@ -1383,11 +1323,11 @@ Bool_t AliEmcalCorrectionTask::UserNotify()
  */
 std::ostream & AliEmcalCorrectionTask::PrintConfigurationString(std::ostream & in, bool userConfig) const
 {
-  std::string stringToWrite = userConfig ? fUserConfigurationString : fDefaultConfigurationString;
-  if (stringToWrite == "") {
-    AliWarning(TString::Format("%s configuration is empty!", userConfig ? "User" : "Default"));
+  auto configPair = fYAMLConfig.GetConfiguration(userConfig ? "user" : "default");
+  if (configPair.second.IsNull() == true) {
+    AliWarning(TString::Format("%s configuration is empty!", configPair.first.c_str()));
   }
-  in << stringToWrite;
+  in << configPair.second;
 
   return in;
 }
@@ -1441,91 +1381,35 @@ bool AliEmcalCorrectionTask::CompareToStoredConfiguration(std::string filename, 
     {
       // Generate YAML nodes for the comparison
       YAML::Node passedNode = YAML::LoadFile(filename);
-      YAML::Node comparisonNode = YAML::Load(userConfig ? fUserConfigurationString : fDefaultConfigurationString);
+      auto configPair = fYAMLConfig.GetConfiguration(userConfig ? "user" : "default");
 
       // Need to stream the configuration back to a string to remove the comments
       // since they are not preserved in the YAML node.
       std::stringstream passedNodeSS;
       passedNodeSS << passedNode;
+      std::stringstream comparisonNodeSS;
+      comparisonNodeSS << configPair.second;
 
-      // Compare the nodes. Make the comparison as strings, as the YAML nodes do _not_ match, despite the strings matching.
-      // In fact, the YAML nodes will _not_ match even if they are generated from the same string....
-      if (passedNodeSS.str() == (userConfig ? fUserConfigurationString : fDefaultConfigurationString)) {
+      // Compare the nodes. Make the comparison as strings, as the YAML nodes do _not_ match,
+      // despite the strings matching. In fact, the YAML nodes will _not_ match even if they
+      // are generated from the same string....
+      if (passedNodeSS.str() == comparisonNodeSS.str()) {
         returnValue = true;
       }
       else {
-        AliWarningStream() << "Passed YAML config:\n" << passedNode << "\n\nStored YAML config:\n" << comparisonNode << "\nPassed config located in file \"" << filename << "\" is not the same as the stored " << (userConfig ? "user" : "default") << "configuration file! YAML configurations printed above.\n";
+        AliWarningStream() << "Passed YAML config:\n" << passedNode << "\n\nStored YAML config:\n" << configPair.second << "\nPassed config located in file \"" << filename << "\" is not the same as the stored " << configPair.first << "configuration file! YAML configurations printed above.\n";
       }
     }
     else
     {
       AliError(TString::Format("Configuration not properly initialized! Cannot compare %s configuration!", userConfig ? "user" : "default"));
     }
-
   }
   else
   {
     AliError("Please pass a valid filename instead of empty quotes!");
   }
   return returnValue;
-}
-
-/**
- * Checks if a file exists. This is done inline to make it efficient.
- * See: https://stackoverflow.com/a/19841704
- *
- * @param filename String containing the filename of the file to check.
- *
- * @return True if the file exists.
- */
-inline bool AliEmcalCorrectionTask::DoesFileExist(const std::string & filename)
-{
-  std::ifstream inFile(filename);
-  return inFile.good();
-}
-
-/**
- * Handles setting up the configuration file to be opened, including in AliPhysics and on the grid.
- * Cannot just use TFile::Open() because the YAML file is just text as opposed to a root file.
- * In the case of a file on the grid, it is copied locally.
- *
- * @param[in] filename Name of the file to be open
- * @param[in] userFile True if the file to be open is a user YAML file
- */
-void AliEmcalCorrectionTask::SetupConfigurationFilePath(std::string & filename, bool userFile)
-{
-  if (filename != "")
-  {
-    // Handle if in AliPhysics and includes $ALICE_PHYSICS
-    filename = gSystem->ExpandPathName(filename.c_str());
-
-    // Handle grid
-    if(filename.find("alien://") != std::string::npos)
-    {
-      AliDebug(2, TString::Format("Opening file \"%s\" on the grid!", filename.c_str()));
-      // Initialize alien connection if needed
-      if (!gGrid) {
-        TGrid::Connect("alien://");
-      }
-
-      // Determine the local filename and copy file to local directory
-      std::string localFilename = gSystem->BaseName(filename.c_str());
-      // Ensures that the default and user files do not conflict if both are taken from the grid and have the same filename
-      if (userFile == true) {
-        localFilename = "user." + localFilename;
-      }
-      // Add UUID to ensure there are no conflicts if multiple correction tasks have the same configuration file name
-      TUUID tempUUID;
-      localFilename = "." + localFilename;
-      localFilename = tempUUID.AsString() + localFilename;
-
-      // Copy file
-      TFile::Cp(filename.c_str(), localFilename.c_str());
-
-      // yaml-cpp should only open the local file
-      filename = localFilename;
-    }
-  }
 }
 
 /**
@@ -1682,42 +1566,34 @@ void AliEmcalCorrectionTask::PrintRequestedContainersInformation(AliEmcalContain
 }
 
 /**
- * Get the YAML node associated with the named input object. The shared parameters of the passed YAML file
- * is also retrieved and attached to the returned YAML node so that it can be used when retrieving properties.
- *
- * @param[out] inputNode The node that will contain the requested properties
- * @param[in] nodeToRetrieveFrom The node from which the input object properties should be retrieved. Usually the user or default configuration
- * @param[in] inputObjectName Name of the input object node to be retrieved
- * @param[in] requiredProperty True if the input object node is required to exist. It may not if it was not defined in the user configuration.
- */
-void AliEmcalCorrectionTask::GetNodeForInputObjects(YAML::Node & inputNode, YAML::Node & nodeToRetrieveFrom, std::string & inputObjectName, bool requiredProperty)
-{
-  // Get the user input node
-  AliEmcalCorrectionComponent::GetProperty(inputObjectName.c_str(), inputNode, YAML::Node(), nodeToRetrieveFrom, requiredProperty, "inputObjects");
-
-  // Get the user shared node and add it back to the user node so that shared parameters are available
-  if (nodeToRetrieveFrom["sharedParameters"]) {
-    inputNode["sharedParameters"] = nodeToRetrieveFrom["sharedParameters"];
-  }
-}
-
-/**
  * Utility function for CheckForUnmatchedUserSettings() which returns the names of all of the
  * properties defined in a YAML node. This can then be used to check for consistency in how properties
  * are defined in the user and default configurations.
  *
+ * This function handles the nodes by hand due to the rare requirement to handle the user and default
+ * configurations separately.
+ *
  * @param[in] componentName Name of the node from which properties are extracted
- * @param[in] node YAML Node of either the user or default configuration
  * @param[out] propertyNames Names of all of the properties that were in the desired node
  * @param[in] nodeRequired True if the node is required to exist
  */
-void AliEmcalCorrectionTask::GetPropertyNamesFromNode(const std::string & componentName, const YAML::Node & node, std::set <std::string> & propertyNames, const bool nodeRequired)
+void AliEmcalCorrectionTask::GetPropertyNamesFromNode(const std::string configurationName, const std::string componentName, std::set <std::string> & propertyNames, const bool nodeRequired)
 {
-  YAML::Node tempNode;
-  AliEmcalCorrectionComponent::GetProperty(componentName, tempNode, YAML::Node(), node, nodeRequired, "");
-  for (auto propertyName : tempNode)
+  auto configPair = fYAMLConfig.GetConfiguration(configurationName);
+  if (configPair.second[componentName])
   {
-    propertyNames.insert(propertyName.first.as<std::string>());
+    for (auto propertyName : configPair.second[componentName])
+    {
+      propertyNames.insert(propertyName.first.as<std::string>());
+    }
+  }
+  else {
+    if (nodeRequired) {
+      std::stringstream message;
+      message << "Failed to retrieve required property \""
+          << componentName << "\" from the \"" << configurationName << "\" configuration!" << std::endl;
+      AliFatal(message.str().c_str());
+    }
   }
 }
 

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
@@ -1,21 +1,17 @@
 #ifndef ALIEMCALCORRECTIONTASK_H
 #define ALIEMCALCORRECTIONTASK_H
 
-// CINT can't handle the yaml header!
-#if !(defined(__CINT__) || defined(__MAKECINT__))
-#include <yaml-cpp/yaml.h>
-#endif
-
+// YAML::Node
+class Node;
 class AliEmcalCorrectionCellContainer;
 class AliEmcalCorrectionComponent;
 class AliEMCALGeometry;
 class AliVEvent;
 
-#include <iosfwd>
-
 #include <AliAnalysisTaskSE.h>
 #include <AliVCluster.h>
 
+#include "AliYAMLConfiguration.h"
 #include "AliEmcalContainerUtils.h"
 #include "AliParticleContainer.h"
 #include "AliMCParticleContainer.h"
@@ -148,9 +144,6 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
 
  private:
   // Utility functions
-  // File utilities
-  static inline bool DoesFileExist(const std::string & filename);
-  void SetupConfigurationFilePath(std::string & filename, bool userFile = false);
   // Cell utilities
   void SetCellsObjectInCellContainerBasedOnProperties(AliEmcalCorrectionCellContainer * cellContainer);
   // Container utilities
@@ -179,32 +172,22 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
   void CreateInputObjects(AliEmcalContainerUtils::InputObject_t inputObjectType);
   void AddContainersToComponent(AliEmcalCorrectionComponent * component, AliEmcalContainerUtils::InputObject_t inputObjectType, bool checkObjectExists = false);
   
-#if !(defined(__CINT__) || defined(__MAKECINT__))
   // Hidden from CINT since it cannot handle YAML objects well
   // Input objects 
-  void SetupContainersFromInputNodes(AliEmcalContainerUtils::InputObject_t inputObjectType, YAML::Node & userInputObjectNode, YAML::Node & defaultInputObjectNode, std::set <std::string> & requestedContainers);
+  void SetupContainersFromInputNodes(AliEmcalContainerUtils::InputObject_t inputObjectType, std::set <std::string> & requestedContainers);
   // Cells
-  void SetupCellsInfo(std::string containerName, YAML::Node & userNode, YAML::Node & defaultNode);
+  void SetupCellsInfo(std::string containerName);
   // Containers
-  void SetupContainer(AliEmcalContainerUtils::InputObject_t inputObjectType, std::string containerName, YAML::Node & userNode, YAML::Node & defaultNode);
-  AliEmcalContainer * AddContainer(AliEmcalContainerUtils::InputObject_t contType, std::string & containerName, YAML::Node & userNode, YAML::Node & defaultNode);
+  void SetupContainer(const AliEmcalContainerUtils::InputObject_t inputObjectType, const std::string containerName);
+  AliEmcalContainer * AddContainer(const AliEmcalContainerUtils::InputObject_t contType, const std::string containerName);
 
   // Utilities
-  // YAML node dependent input objects utilties
-  void GetNodeForInputObjects(YAML::Node & inputNode, YAML::Node & nodeToRetrieveFrom, std::string & inputObjectName, bool requiredProperty);
   // YAML node dependent initialization utlitiles
-  void GetPropertyNamesFromNode(const std::string & componentName, const YAML::Node & node, std::set <std::string> & propertyNames, const bool nodeRequired);
-#endif
+  void GetPropertyNamesFromNode(const std::string configurationName, const std::string componentName, std::set <std::string> & propertyNames, const bool nodeRequired);
 
-#if !(defined(__CINT__) || defined(__MAKECINT__))
-  // Hidden from CINT since it cannot handle YAML objects well
-  YAML::Node                  fUserConfiguration;          //!<! User YAML Configuration
-  YAML::Node                  fDefaultConfiguration;       //!<! Default YAML Configuration
-#endif
+  AliYAMLConfiguration        fYAMLConfig;                 ///< Handles configuration from YAML.
 
-  std::string                 fSuffix;                     ///< Suffix of the Correction Task (used to select components)
-  std::string                 fUserConfigurationString;    ///< Store the user YAML configuration as a string so that it can be streamed
-  std::string                 fDefaultConfigurationString; ///< Store the default YAML configuration as a string so that it can be streamed
+  std::string                 fSuffix;                     ///< Suffix of the Correction Task (used to select specialized components)
 
   std::string                 fUserConfigurationFilename;  //!<! User YAML configruation filename
   std::string                 fDefaultConfigurationFilename; //!<! Default YAML configuration filename

--- a/PWG/Tools/AliYAMLConfiguration.cxx
+++ b/PWG/Tools/AliYAMLConfiguration.cxx
@@ -1,0 +1,356 @@
+//
+//
+
+#include "AliYAMLConfiguration.h"
+
+#include <cstdio>
+#include <fstream>
+
+#include <TSystem.h>
+#include <TGrid.h>
+#include <TFile.h>
+#include <TUUID.h>
+
+/// \cond CLASSIMP
+ClassImp(AliYAMLConfiguration);
+/// \endcond
+
+/**
+ * Default constructor.
+ *
+ * @param[in] prefixString Prefix to remove when gettnig a property.
+ * @param[in] delimiterCharacter Character that delimits between each part of the YAML path.
+ */
+AliYAMLConfiguration::AliYAMLConfiguration(const std::string prefixString, const std::string delimiterCharacter):
+  TObject(),
+  fConfigurations(),
+  fConfigurationsStrings(),
+  fInitialized(false),
+  fPrefixString(prefixString),
+  fDelimiter(delimiterCharacter)
+{
+}
+
+/**
+ * Create an empty YAML node and adds it to the available configurations.
+ *
+ * @param[in] configurationName Name of the YAML node. The node will be stored under this name.
+ *
+ * @return True if the configuration was added successfully.
+ */
+bool AliYAMLConfiguration::AddEmptyConfiguration(const std::string configurationName)
+{
+  YAML::Node node;
+  return AddConfiguration(node, configurationName);
+}
+
+/**
+ * Add YAML configuration at a given filename to the available configurations.
+ *
+ * @param[in] configurationFilename Filename of the YAML configuration file to be added.
+ * @param[in] configurationName Name of the YAML node. The node will be stored under this name.
+ *
+ * @return True if the configuration was added successfully.
+ */
+bool AliYAMLConfiguration::AddConfiguration(std::string configurationFilename, std::string configurationName)
+{
+  SetupReadingConfigurationFilePath(configurationFilename, configurationName);
+
+  // Add file
+  if (DoesFileExist(configurationFilename) == false) {
+    AliErrorStream() << "Configuration filename \"" << configurationFilename << "\" does not exist!\n";
+    return false;
+  }
+
+  // Create node from filename
+  auto node = YAML::LoadFile(configurationFilename);
+
+  if (node.IsNull() == true) {
+    AliErrorStream() << "The node at configuration filename \"" << configurationFilename << "\" is null and will not be added!\n";
+    return false;
+  }
+
+  AliInfoStream() << "Adding configuration \"" << configurationName << "\" located at \"" << configurationFilename << "\".\n";
+  return AddConfiguration(node, configurationName);
+}
+
+/**
+ * Add a YAML node to the available configurations.
+ *
+ * @param[in] node YAML node to be added.
+ * @param[in] configurationName Name of the YAML node. The node will be stored under this name.
+ *
+ * @return True if the configuration was added successfully.
+ */
+bool AliYAMLConfiguration::AddConfiguration(const YAML::Node node, std::string configurationName)
+{
+  if (configurationName == "")
+  {
+    // Attempt to get name from node
+    // It is fine if the node is empty
+    GetPropertyFromNode(node, "name", configurationName);
+  }
+
+  if (configurationName == "") {
+    AliErrorStream() << "Could not determine a name for the configuration:\n\"\n" << node << "\n\" Configuration will not be added!\n";
+    return false;
+  }
+
+  // Add the configuration
+  AliInfoStream() << "Adding configuration \"" << configurationName << "\"\n.";
+  fConfigurations.push_back(std::make_pair(configurationName, node));
+  return true;
+}
+
+/**
+ * Write a YAML configuration node to file.
+ *
+ * @param[in] index Index of the YAML configuration node.
+ * @param[in] filename Filename to write the node to.
+ *
+ * @return True if write was successful.
+ */
+bool AliYAMLConfiguration::WriteConfiguration(const int index, const std::string filename) const
+{
+  // Write to a local temp filename
+  TUUID tempUUID;
+  std::string localFilename = tempUUID.AsString();
+  localFilename += ".yaml";
+
+  auto configPair = fConfigurations.at(index);
+  std::ofstream outputFile(localFilename);
+  outputFile << configPair.second;
+  outputFile.close();
+
+  // Hanldes writing to places like AliEn
+  WriteConfigurationToFilePath(localFilename, filename);
+
+  remove(localFilename.c_str());
+
+  return true;
+}
+
+/**
+ * Write a YAML configuration node to file.
+ *
+ * @param[in] configurationName Name of the YAML configuration node.
+ * @param[in] filename Filename to write the node to.
+ *
+ * @return True if write was successful.
+ */
+bool AliYAMLConfiguration::WriteConfiguration(const std::string configurationName, const std::string filename) const
+{
+  return WriteConfiguration(GetConfigurationIndexByName(configurationName, fConfigurations), filename);
+}
+
+/**
+ * Checks if a file exists. This is done inline to make it efficient.
+ * See: https://stackoverflow.com/a/19841704
+ *
+ * @param filename String containing the filename of the file to check.
+ *
+ * @return True if the file exists.
+ */
+inline bool AliYAMLConfiguration::DoesFileExist(const std::string & filename) const
+{
+  std::ifstream inFile(filename);
+  return inFile.good();
+}
+
+/**
+ * Handles setting up the configuration file to be opened, including in AliPhysics and on the grid.
+ * Cannot just use TFile::Open() because the YAML file is just text as opposed to a root file.
+ * In the case of a file on the grid, it is copied locally.
+ *
+ * @param[in,out] filename Name of the file to be open
+ * @param[in] fileIdentifier Additional file identifier to add onto the file name
+ */
+void AliYAMLConfiguration::SetupReadingConfigurationFilePath(std::string & filename, const std::string fileIdentifier) const
+{
+  if (filename != "")
+  {
+    // Handle if in AliPhysics and includes $ALICE_PHYSICS
+    filename = gSystem->ExpandPathName(filename.c_str());
+
+    // Handle grid
+    if(filename.find("alien://") != std::string::npos)
+    {
+      AliDebug(2, TString::Format("Opening file \"%s\" on the grid!", filename.c_str()));
+      // Initialize AliEn connection if needed
+      if (!gGrid) {
+        TGrid::Connect("alien://");
+      }
+
+      // Determine the local filename and copy file to local directory
+      std::string localFilename = gSystem->BaseName(filename.c_str());
+      // Add identifier if it's not an empty string
+      if (fileIdentifier != "") {
+        localFilename = fileIdentifier + "." + localFilename;
+      }
+      // Add UUID to ensure there are no conflicts if multiple correction tasks have the same configuration file name
+      TUUID tempUUID;
+      localFilename = ":" + localFilename;
+      localFilename = tempUUID.AsString() + localFilename;
+
+      // Copy file
+      TFile::Cp(filename.c_str(), localFilename.c_str());
+
+      // yaml-cpp should only open the local file
+      filename = localFilename;
+    }
+  }
+}
+
+/**
+ * Write a selected YAML configuration to file.
+ *
+ * @param[in] filename Filename to which the configuration should be written.
+ * @param[in] localFilename Filename where the configuration was written locally.
+ */
+void AliYAMLConfiguration::WriteConfigurationToFilePath(std::string filename, const std::string localFilename) const
+{
+  bool cannotWriteFile = false;
+  if (localFilename == "") {
+    AliErrorStream() << "Local filename is null, so the file cannot be written!\n";
+    cannotWriteFile = true;
+  }
+  if (filename == "") {
+    AliErrorStream() << "Filename is null, so the file cannot be written\n";
+    cannotWriteFile = true;
+  }
+
+  if (cannotWriteFile == false) {
+    // Handle if in AliPhysics and includes $ALICE_PHYSICS
+    filename = gSystem->ExpandPathName(filename.c_str());
+
+    // Handle grid
+    if(filename.find("alien://") != std::string::npos)
+    {
+      AliDebugStream(2) << "Writing file \"" << filename << "\" on the grid!\n";
+      // Initialize AliEn connection if needed
+      if (!gGrid) {
+        TGrid::Connect("alien://");
+      }
+    }
+
+    // Copy file
+    AliDebugStream(2) << "Copying localFilename \"" << localFilename << "\" to filename \"" << filename << "\".\n";
+    TFile::Cp(localFilename.c_str(), filename.c_str());
+  }
+}
+
+/**
+ * Initialize configurations.
+ *
+ * This includes storing the contents of the YAML configurations
+ * into strings so that they can be streamed to the grid.
+ * (yaml-cpp objects do not work properly with ROOT streamers).
+ *
+ * NOTE: fConfigurationInitialized is set to true if the function is successful.
+ */
+bool AliYAMLConfiguration::Initialize()
+{
+  // Copy all configurations to their respective strings.
+  // That way, the strings will be successfully streamed by ROOT and the YAML nodes can be re-initialized on the grid.
+  std::stringstream tempSS;
+  for (auto & configPair : fConfigurations)
+  {
+    tempSS.str("");
+    tempSS << configPair.second;
+    fConfigurationsStrings.push_back(std::make_pair(configPair.first, tempSS.str()));
+  }
+
+  fInitialized = true;
+
+  return fInitialized;
+}
+
+/**
+ * Reinitialize the configurations from the strings after streaming. This is required because the YAML
+ * node objects cannot be streamed.
+ *
+ * @return True if the configurations were re-initialized.
+ */
+bool AliYAMLConfiguration::Reinitialize()
+{
+  bool returnValue = false;
+
+  // If they were not streamed then the size of the vectors should not match
+  if (fConfigurations.size() != fConfigurationsStrings.size())
+  {
+    if (fInitialized == false)
+    {
+      // Not initialized, so the strings do not represent the nodes
+      AliFatalGeneral("AliYAMLConfiguration", "Attempted to re-initialize the YAML nodes, but the string based configurations are not available. Did you remember to call initialize?");
+    }
+
+    for (const auto & configStrPair : fConfigurationsStrings)
+    {
+      YAML::Node node = YAML::Load(configStrPair.second);
+      fConfigurations.push_back(std::make_pair(configStrPair.first, node));
+    }
+
+    returnValue = true;
+  }
+
+  return returnValue;
+}
+
+/**
+ * Check if value is a shared parameter, meaning we should look
+ * at another node. Also edits the input string to remove "sharedParameters:"
+ * if it exists, making it ready for use.
+ *
+ * @param[in] value String containing the string value return by the parameter.
+ *
+ * @return True if the value is shared.
+ */
+bool AliYAMLConfiguration::IsSharedValue(std::string & value) const
+{
+  std::string stringToFind = "sharedParameters:";
+  std::size_t sharedParameterLocation = value.find(stringToFind);
+  if (sharedParameterLocation != std::string::npos)
+  {
+    value.erase(sharedParameterLocation, sharedParameterLocation + stringToFind.length());
+    return true;
+  }
+  // Return false otherwise
+  return false;
+}
+
+/**
+ * Print a particular configuration.
+ *
+ * @param[in] i Index of the YAML configuration.
+ */
+void AliYAMLConfiguration::PrintConfiguration(int i) const
+{
+  if (fConfigurations.size() > i)
+  {
+    auto & configPair = fConfigurations.at(i);
+    AliInfoStream() << "\nName: " << configPair.first << "\n\n";
+    AliInfoStream() << configPair.second << "\n";
+  }
+}
+
+/**
+ * Print a particular configuration.
+ *
+ * @param[in] name Name of the YAML configuration.
+ */
+void AliYAMLConfiguration::PrintConfiguration(std::string name) const
+{
+  PrintConfiguration(GetConfigurationIndexByName(name, fConfigurations));
+}
+
+/**
+ * Print all configurations.
+ */
+void AliYAMLConfiguration::PrintConfigurations() const
+{
+  for (unsigned int i = 0; i < fConfigurations.size(); i++)
+  {
+    PrintConfiguration(i);
+  }
+}
+

--- a/PWG/Tools/AliYAMLConfiguration.h
+++ b/PWG/Tools/AliYAMLConfiguration.h
@@ -1,0 +1,579 @@
+#ifndef ALIYAMLCONFIGURATION_H
+#define ALIYAMLCONFIGURATION_H
+
+// CINT can't handle the yaml header because it has c++11!
+#if !(defined(__CINT__) || defined(__MAKECINT__))
+#include <yaml-cpp/yaml.h>
+#endif
+
+#include <string>
+#include <vector>
+#include <ostream>
+
+#include <TObject.h>
+
+#include <AliLog.h>
+
+/**
+ * @class AliYAMLConfiguration
+ * @brief YAML configuration class for AliPhysics.
+ *
+ * A class to handle generic reading and writing to YAML files. This can be used to configure tasks, coordinate trains,
+ * or many other tasks which require configuration. While yaml-cpp can be used directly, this class handles many details
+ * such as accessing files on AliEn, as well as generally simplifying the user experience. The class can also handle
+ * multiple configuration files, first looking in the first file, and then if the value is not found, looking in
+ * subsequent configurations until the value is found. Values that are used in multiple places can be set together
+ * using "Shared Paramaters" (see the section below) or using YAML anchors.
+ *
+ * Usage information:
+ *
+ * Consider the following example YAML configuration.
+ *
+ * ~~~
+ * hello:
+ *   world:
+ *     exampleValue: 10
+ * importantValue:
+ *   - entry1
+ *   - entry2
+ *   - entry3
+ * ~~~
+ *
+ * To use the class, at least one YAML configuration file must be added to the class. To do so, use:
+ *
+ * ~~~{.cxx}
+ * AliYAMLConfiguration config;
+ * config.AddConfiguration(filename, name);
+ * // Will only be checked if a requested value is not in the first configuration.
+ * config.AddConfiguration(filename2, name2);
+ * // Can also just start with an empty configuration if desired. Perhaps for writing.
+ * config.AddEmptyConfiguration(name3);
+ *
+ * // Once all configuration is done and the YAML nodes will not be modified any more
+ * // (for example, at the end of an AddTask), call Initialize() to lock in the configurations
+ * // for streaming to the grid.
+ * config.Initialize();
+ * ~~~
+ *
+ * YAML objects cannot be streamed, so after the configuration class is streamed, it must be re-initialized. This can
+ * be done in any function after streaming has been completed, such as `UserCreateOutputObjects()`. It only needs to be
+ * performed once.
+ *
+ * ~~~{.cxx}
+ * fYAMLConfig.Reinitialize();
+ * ~~~
+ *
+ * To access a value, use the GetProperty(...) or WriteProperty(...) functions. To use them, you must define an
+ * object of the desired type that you would like to read or write, and then describe the path to the property.
+ * The path consists of the names of YAML nodes, separated by a user specified delimiter (":" is the default).
+ * For the example YAML above, to read "exampleValue", the user would define an int to be set to the read value
+ * and the path would be "hello:world:exampleValue". As a convenience, there is a helper function which simplifies
+ * specifying the path. It will instead take a std::vector of strings to specify the path, thereby also setting
+ * the proper delimiter. So the path would be `{"hello", "world", "exampleValue"}`. Note that you may need to
+ * explicitly specify such an initialization as `std::vector<std::string>` if you don't define it as a
+ * variable.
+ *
+ * That's basically all there is to using it. For more information, look at the documentation of the various
+ * GetProperty(...) and WriteProperty(...) functions.
+ *
+ * Notes on using shared parameters:
+ *
+ * sharedParameters are inherently limited. It can only retrieve values where the requested type is arithmetic, string,
+ * or bool. The retrieved shared parameters value can only be of those same types. Note that the shared parameters
+ * correspond to each configuration file. ie. If "sharedParameters:test" is requested in the first configuration file,
+ * then it will only look for the sharedParameters value in that configuration. Thus, if a sharedParameter is requested
+ * in a later configuration file, the earlier configuration shared parameter values will not be considered.
+ *
+ * Given the limitations, YAML anchors are recommended for more advanced usage as they can be much more sophisticated.
+ *
+ * @author Raymond Ehlers <raymond.ehlers@yale.edu>, Yale University
+ * @date Sept 19, 2017
+ */
+
+class AliYAMLConfiguration : public TObject {
+ public:
+  AliYAMLConfiguration(const std::string prefixString = "AliEmcalCorrection", const std::string delimiterCharacter = ":");
+  virtual ~AliYAMLConfiguration() {}
+
+  bool Initialize();
+  bool Reinitialize();
+
+  /// Add YAML configuration at configurationFilename to available configurations
+  bool AddEmptyConfiguration(const std::string configurationName);
+  bool AddConfiguration(std::string configurationFilename, std::string configurationName = "");
+  #if !(defined(__CINT__) || defined(__MAKECINT__))
+  bool AddConfiguration(const YAML::Node node, std::string configurationName = "");
+
+  const std::pair<std::string, YAML::Node> & GetConfiguration(const int i)            const { return fConfigurations.at(i); }
+  const std::pair<std::string, YAML::Node> & GetConfiguration(const std::string name) const { return fConfigurations.at(GetConfigurationIndexByName(name, fConfigurations)); }
+  std::pair<std::string, YAML::Node> & GetConfiguration(const int i)                        { return fConfigurations.at(i); }
+  std::pair<std::string, YAML::Node> & GetConfiguration(const std::string name)             { return fConfigurations.at(GetConfigurationIndexByName(name, fConfigurations)); }
+
+  // Helper functions to retrieve property values
+  template<typename T>
+  bool GetProperty(std::vector<std::string> propertyPath, const std::string propertyName, T & property, const bool requiredProperty) const;
+  template<typename T>
+  bool GetProperty(const std::vector<std::string> propertyPath, T & property, const bool requiredProperty) const;
+  // Retrieve property driver function.
+  template<typename T>
+  bool GetProperty(std::string propertyName, T & property, const bool requiredProperty = true) const;
+
+  // Write property driver function.
+  template<typename T>
+  bool WriteProperty(std::string propertyName, T & property, std::string configurationName = "");
+  #endif
+
+  bool WriteConfiguration(const int i, const std::string filename) const;
+  bool WriteConfiguration(const std::string name, const std::string filename) const;
+
+  void PrintConfiguration(int i = 0) const;
+  void PrintConfiguration(std::string name) const;
+  void PrintConfigurations() const;
+
+ protected:
+
+  // Utility functions
+  // File utilities
+  inline bool DoesFileExist(const std::string & filename) const;
+  void SetupReadingConfigurationFilePath(std::string & filename, const std::string fileIdentifier) const;
+  void WriteConfigurationToFilePath(std::string filename, std::string localFilename) const;
+  // Configuration utilities
+  template<typename T>
+  int GetConfigurationIndexByName(const std::string name, const std::vector<std::pair<std::string, T>> & configurations) const;
+
+  bool IsSharedValue(std::string & value) const;
+  #if !(defined(__CINT__) || defined(__MAKECINT__))
+  template<typename T>
+  auto PrintRetrievedPropertyValueImpl(std::stringstream & tempMessage, const T & property, int) const -> decltype(tempMessage << property, void());
+  template<typename T>
+  auto PrintRetrievedPropertyValueImpl(std::stringstream & tempMessage, const std::vector <T> & property, int) const -> decltype(property.begin(), property.end(), tempMessage << std::declval<T>(), void());
+  template<typename T>
+  void PrintRetrievedPropertyValueImpl(std::stringstream & tempMessage, const T & property, long) const;
+  template<typename T>
+  void PrintRetrievedPropertyValue(std::stringstream & tempMessage, const T & property) const;
+
+  template<typename T>
+  bool GetPropertyFromNode(const YAML::Node & node, std::string propertyName, T & property) const;
+  template<typename T>
+  bool GetProperty(YAML::Node & node, YAML::Node & sharedParametersNode, const std::string configurationName, std::string propertyName, T & property) const;
+
+  template<typename T>
+  void WriteValue(YAML::Node & node, std::string propertyName, T & proeprty);
+
+  std::vector<std::pair<std::string, YAML::Node> > fConfigurations;         //!<! Contains all YAML configurations. The first element has the highest precedence.
+  #endif
+  std::vector<std::pair<std::string, std::string> > fConfigurationsStrings; ///<  Contains all YAML configurations as strings so that they can be streamed.
+
+  bool fInitialized;                          ///< True if the configurations have been initialized.
+  std::string fPrefixString;                  ///< Contains the prefix of any names base node names which should be removed.
+  std::string fDelimiter;                     ///< Delimiter character to separate each level of the request.
+
+  /// \cond CLASSIMP
+  ClassDef(AliYAMLConfiguration, 1); // YAML Configuration
+  /// \endcond
+};
+
+#if !(defined(__CINT__) || defined(__MAKECINT__))
+/**
+ * Prints the retrieved property value if the type implements operator<<(). For more on how this achieved,
+ * see: https://stackoverflow.com/a/22759368 and https://stackoverflow.com/a/11866675.
+ * NOTE: This function should not be called directly, but through PrintRetrievedPropertyValue(...)
+ *
+ * NOTE: This function returns void!
+ *
+ * @param[in] property Property to be printed
+ * @param[in, out] tempMessage Stringstream into which the property should be streamed
+ */
+template<typename T>
+auto AliYAMLConfiguration::PrintRetrievedPropertyValueImpl(std::stringstream & tempMessage, const T & property, int) const -> decltype(tempMessage << property, void())
+{
+  tempMessage << " with value \"" << property << "\"";
+}
+
+/**
+ * Prints the retrieved values in a vector if the value is a vector (more specifically, if it implements begin() and end())
+ * and if the type of the vector can be streamed in an ostream object.
+ * NOTE: This function should not be called directly, but through PrintRetrievedPropertyValue(...)
+ *
+ * @param[in] property Property to be printed
+ * @param[in, out] tempMessage Stringstream into which the property should be streamed
+ */
+template<typename T>
+auto AliYAMLConfiguration::PrintRetrievedPropertyValueImpl(std::stringstream & tempMessage, const std::vector <T> & property, int) const -> decltype(property.begin(), property.end(), tempMessage << std::declval<T>(), void())
+{
+  tempMessage << " with value(s):";
+  for (auto it = property.begin(); it != property.end(); it++) {
+    tempMessage << "\n\t- " << *it;
+  }
+}
+
+/**
+ * Handles all other cases where the property is not covered by the other functions.
+ *
+ * NOTE: This function should not be called directly, but through PrintRetrievedPropertyValue(...)
+ *
+ * NOTE: Cannot use "..." as a function argument here as a fall back because it causes
+ * problems with ROOT dictionary generation...
+ *
+ * @param[in] property Property to be printed
+ * @param[in, out] tempMessage Stringstream into which the property should be streamed
+ */
+template<typename T>
+void AliYAMLConfiguration::PrintRetrievedPropertyValueImpl(std::stringstream & tempMessage, const T & property, long) const
+{
+  // Cannot easily print these types, so just note that is the case!
+  tempMessage << " with a value that cannot be trivially printed";
+}
+
+/**
+ * Wrapper function to resolve ambiguity in function overloading. By passing 0 as the last argument to the
+ * PrintRetrievedPropertyValueImpl(...) functions, it will first attempt to use the matching int function,
+ * and then fall back the to the long function. This is effectively a hack to help c++ properly resolve the
+ * function to call.
+ *
+ * Inspired by: https://stackoverflow.com/a/38283990
+ *
+ * @param[in] property Property to be printed
+ * @param[in, out] tempMessage Stringstream into which the property should be streamed
+ */
+template<typename T>
+void AliYAMLConfiguration::PrintRetrievedPropertyValue(std::stringstream & tempMessage, const T & property) const
+{
+  // By passing zero, it will first lookup the int, and then the long
+  AliYAMLConfiguration::PrintRetrievedPropertyValueImpl(tempMessage, property, 0);
+}
+
+/**
+ * Utility function to retrieve the property from a already selected YAML node.
+ *
+ * @param[in] node YAML node from which the property should be retrieved
+ * @param[in] propertyName Name of the property to retrieve
+ * @param[out] property Contains the retrieved property
+ *
+ * @return True if the property was set successfully
+ */
+template<typename T>
+bool AliYAMLConfiguration::GetPropertyFromNode(const YAML::Node & node, std::string propertyName, T & property) const
+{
+  if (node[propertyName])
+  {
+    property = node[propertyName].as<T>();
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Helper function for main retrieval function. It automatically adds the property name to the end of the property path.
+ * By doing so, it allows the user to specify a general property path and then vary the property name between function calls.
+ *
+ * @param[in] propertyPath Path to the property in the YAML file.
+ * @param[in] propertyName Name of the property to be retrieved.
+ * @param[out] property Contains the retrieved property.
+ * @param[in] requiredProperty True if the property is required
+ *
+ * @return True if the property was set successfully
+ */
+template<typename T>
+bool AliYAMLConfiguration::GetProperty(std::vector <std::string> propertyPath, const std::string propertyName, T & property, const bool requiredProperty) const
+{
+  propertyPath.push_back(propertyName);
+  return GetProperty(propertyPath, property, requiredProperty);
+}
+
+/**
+ * Helper function for main retrieval function. Each value in the property path will be joined together, separated by the delimiter
+ * set in the configuration class.
+ *
+ * @param[in] propertyPath Path to the property in the YAML file.
+ * @param[out] property Contains the retrieved property.
+ * @param[in] requiredProperty True if the property is required
+ *
+ * @return True if the property was set successfully
+ */
+template<typename T>
+bool AliYAMLConfiguration::GetProperty(const std::vector <std::string> propertyPath, T & property, const bool requiredProperty) const
+{
+  // Combine the requested names together
+  std::string requestedName = "";
+  for (auto & str : propertyPath)
+  {
+    if (requestedName.length() > 0) {
+      requestedName += ":" + str;
+    }
+    else {
+      requestedName = str;
+    }
+  }
+
+  // Pass on the properly requested call
+  return GetProperty(requestedName, property, requiredProperty);
+}
+
+/**
+ * Main general function to get a property from a set of YAML configuration files. It first calls checks
+ * the user configuration, and then if the property is not found, it then checks the default configuration.
+ * If the property is required but it is not found, a fatal error is thrown.
+ *
+ * @param[in] propertyName Name of the property to retrieve
+ * @param[out] property Contains the retrieved property
+ * @param[in] requiredProperty True if the property is required
+ * @param[in] correctionName Name of the correction from where the property should be retrieved
+ *
+ * @return True if the property was set successfully
+ */
+template<typename T>
+bool AliYAMLConfiguration::GetProperty(std::string propertyName, T & property, const bool requiredProperty) const
+{
+  // Remove AliEmcalCorrection if in name
+  std::size_t prefixStringLocation = propertyName.find(fPrefixString);
+  if (prefixStringLocation != std::string::npos)
+  {
+    // Remove the prefix string
+    propertyName.erase(prefixStringLocation, prefixStringLocation + fPrefixString.length());
+  }
+
+  bool setProperty = false;
+  for (auto configPair : fConfigurations)
+  {
+    if (setProperty == true) {
+      AliDebugGeneralStream("AliYAMLConfiguration", 2) << "Property \"" << propertyName << "\" found!\n";
+      break;
+    }
+
+    // IsNull checks is a node is empty. A node is empty if it is created.
+    // IsDefined checks if the node that was requested was not actually created.
+    if (configPair.second.IsNull() != true)
+    {
+      AliDebugGeneralStream("AliYAMLConfiguration", 2) << "Looking for parameter \"" << propertyName << "\" in \"" << configPair.first << "\" configuration\n";
+      // NOTE: This may not exist, but that is entirely fine.
+      YAML::Node sharedParameters = configPair.second["sharedParameters"];
+      setProperty = GetProperty(configPair.second, sharedParameters, configPair.first, propertyName, property);
+    }
+  }
+
+  if (setProperty != true && requiredProperty == true)
+  {
+    std::stringstream message;
+    message << "Failed to retrieve required property \""
+        << propertyName << "\" from available configurations!" << std::endl;
+    AliFatalGeneral("AliYAMLConfiguration", message.str().c_str());
+  }
+
+  // Return whether the value was actually set
+  return setProperty;
+}
+
+/**
+ * Actually handles retrieving parameters from YAML nodes.
+ *
+ * For propertyName = "hello:example_special:property", the retrieval procedure is as follows:
+ *  - Extract node name by searching the propertyName up to the delimiter (in this case, "hello").
+ *  - Look up the node name.
+ *    - If the node exists, recurse with node[nodeName] and with remaining propertyName = "example_special:property".
+ *    - If it doesn't exist, check for the specialization delimiter (default: "_") and take the node name as everything before the delimiter
+ *      (for example, "example_special" leads to "example").
+ *  - If the delimiter is not found, then atempt to extract the property with the remaining node name.
+ *    - If the property is arithmetic, std::string, or bool, it will check if the property is instead a shared parameter. If so, it will retrieve
+ *      the shared parameter value.
+ *    - The property is stored in the property, and true is returned if the effort was successful.
+ *
+ * @param[in] node Main YAML node containing the properties
+ * @param[in] sharedParametersNode YAML node containing the shared parameters
+ * @param[in] configurationName Name of the configuration type.
+ * @param[in] propertyName Name of the property to retrieve
+ * @param[out] property Contains the retrieved property
+ *
+ * @return True if the property was set successfully
+ */
+template<typename T>
+bool AliYAMLConfiguration::GetProperty(YAML::Node & node, YAML::Node & sharedParametersNode, const std::string configurationName, std::string propertyName, T & property) const
+{
+  // Used as a buffer for printing complicated messages
+  std::stringstream tempMessage;
+
+  bool returnValue = false;
+
+  const std::string specializationDelimiter = "_";
+  size_t delimiterPosition = 0;
+  std::string tempPropertyName = propertyName;
+
+  if ((delimiterPosition = tempPropertyName.find(fDelimiter)) != std::string::npos)
+  {
+    std::string nodeName = tempPropertyName.substr(0, delimiterPosition);
+    tempPropertyName.erase(0, delimiterPosition + fDelimiter.length());
+
+    // Attempt to use the node name
+    if (node[nodeName].IsDefined() == true)
+    {
+      // Retrieve node and then recurse
+      YAML::Node tempNode = node[nodeName];
+      AliDebugGeneralStream("AliYAMLConfiguration", 2) << "Retrieveing parameter \"" << tempPropertyName << "\" by going a node deeper with node \"" << nodeName << "\".\n";
+      returnValue = GetProperty(tempNode, sharedParametersNode, configurationName, tempPropertyName, property);
+    }
+    else
+    {
+      // Check for specialization
+      if ((delimiterPosition = nodeName.find(specializationDelimiter)) != std::string::npos)
+      {
+        std::string specializationNodeName = nodeName.substr(0, delimiterPosition);
+        YAML::Node tempNode = node[specializationNodeName];
+        AliDebugGeneralStream("AliYAMLConfiguration", 2) << "Retrieving parameter \"" << tempPropertyName << "\" by going a node deeper through dropping the specializtion and using node \"" << specializationNodeName << "\".\n";
+        returnValue = GetProperty(tempNode, sharedParametersNode, configurationName, tempPropertyName, property);
+      }
+      else {
+        returnValue = false;
+      }
+
+    }
+  }
+  else
+  {
+    // Check if node exists!
+    if (node[propertyName])
+    {
+      // Handle shared parameters
+      bool isShared = false;
+      // Will contain the name of the property in the sharedParameters section that should be retrieved
+      // if it is requested through the user configuration.
+      std::string sharedValueName = "";
+      // Necessary because it fails on vectors and other complex objects that are YAML sequences.
+      if (std::is_arithmetic<T>::value || std::is_same<T, std::string>::value || std::is_same<T, bool>::value)
+      {
+        // Retrieve value as string to check for shared value
+        sharedValueName = node[propertyName].as<std::string>();
+        // Check for a shared value
+        isShared = IsSharedValue(sharedValueName);
+      }
+
+      // Setup printable message
+      tempMessage.str("");
+      tempMessage << "property \""
+            << propertyName
+            << "\" using " << ( isShared ? "\"sharedParameters:" + sharedValueName + "\" in " : "" )
+            << "values from the " << configurationName << " configuration";
+
+      AliDebugGeneralStream("AliYAMLConfiguration", 2) << "Retrieveing " << tempMessage.str() << "\n";
+
+      // Retrieve result
+      bool retrievalResult = false;
+      if (isShared == true) {
+        // Retrieve from the shared parameter node directly.
+        retrievalResult = GetPropertyFromNode(sharedParametersNode, sharedValueName, property);
+      }
+      else {
+        retrievalResult = GetPropertyFromNode(node, propertyName, property);
+      }
+
+      // Inform about the result
+      if (retrievalResult == true) {
+        // Add the retrieved value to the message (only if trivially printable)
+        AliYAMLConfiguration::PrintRetrievedPropertyValue(tempMessage, property);
+        AliDebugGeneralStream("AliYAMLConfiguration", 2) << "Succeeded in retrieveing " << tempMessage.str() << "\n";
+        returnValue = true;
+      }
+      else {
+        returnValue = false;
+      }
+    }
+  }
+
+  return returnValue;
+}
+
+/**
+ * Write a value to a YAML configuration. Note that the value is written to the YAML configuration, but then
+ * the YAML configuration needs to explicitly be written to file if the changes should be persistent.
+ *
+ * @param[in] propertyPath Path to the property in the YAML file.
+ * @param[in] property Property to be written.
+ * @param[in] configurationName Name of the YAML configuration file to which the property should be written.
+ *
+ * @return True if the write was successful.
+ */
+template<typename T>
+bool AliYAMLConfiguration::WriteProperty(std::string propertyName, T & property, std::string configurationName)
+{
+  int configurationIndex = 0;
+  if (configurationName != "")
+  {
+    configurationIndex = GetConfigurationIndexByName(configurationName, fConfigurations);
+  }
+
+  std::pair<std::string, YAML::Node> & configPair = fConfigurations.at(configurationIndex);
+
+  WriteValue(configPair.second, propertyName, property);
+  AliDebugGeneralStream("AliYAMLConfiguration", 2) << "Final Node:\n" << configPair.second << "\n";
+
+  return true;
+}
+
+/**
+ * Determine where the value should be written and write it to the appropriate YAML node.
+ *
+ * @param[in, out] node YAML node where the property should (eventually) be written.
+ * @param[in] propertyName Name of the property to be written.
+ * @param[in] property Property to be written to the YAML node.
+ */
+template<typename T>
+void AliYAMLConfiguration::WriteValue(YAML::Node & node, std::string propertyName, T & property)
+{
+  // Find the node name we are interested in
+  // Derived from: https://stackoverflow.com/a/14266139
+  const std::string delimiter = ":";
+  size_t delimiterPosition = 0;
+  std::string tempPropertyName = propertyName;
+
+  if ((delimiterPosition = tempPropertyName.find(delimiter)) != std::string::npos)
+  {
+    std::string nodeName = tempPropertyName.substr(0, delimiterPosition);
+    tempPropertyName.erase(0, delimiterPosition + delimiter.length());
+    AliDebugGeneralStream("AliYAMLConfiguration", 2) << "nodeName: " << nodeName << "\n";
+    AliDebugGeneralStream("AliYAMLConfiguration", 2) << "Node Before:\n" << node << "\n";
+    if (node[nodeName].IsDefined()) {
+      AliDebugGeneralStream("AliYAMLConfiguration", 2) << "Using existing node\n";
+      YAML::Node tempNode = node[nodeName];
+      WriteValue(tempNode, tempPropertyName, property);
+    }
+    else {
+      AliDebugGeneralStream("AliYAMLConfiguration", 2) << "Creating new node\n";
+      YAML::Node tempNode;
+      node[nodeName] = tempNode;
+      WriteValue(tempNode, tempPropertyName, property);
+    }
+    AliDebugGeneralStream("AliYAMLConfiguration", 2) << "Node After:\n" << node << "\n";
+  }
+  else {
+    // We have finished the recursion. Now we need to save the actual property.
+    node[propertyName] = property;
+  }
+}
+
+#endif
+
+/**
+ * Get the index of the configuration given the configuration name.
+ *
+ * @param[in] name Name of the configuration.
+ * @param[in] configurations Configurations to search through (could contain YAML nodes, or the string copies).
+ *
+ * @return Index of the configuration, or -1 if not found.
+ */
+template<typename T>
+int AliYAMLConfiguration::GetConfigurationIndexByName(const std::string name, const std::vector<std::pair<std::string, T>> & configurations) const
+{
+  int index = -1;
+  for (const auto & configPair : configurations)
+  {
+    if (configPair.first == name) {
+      // Retrieve index
+      // See: https://stackoverflow.com/a/10962459
+      index = std::addressof(configPair) - std::addressof(configurations[0]);
+      break;
+    }
+  }
+
+  return index;
+}
+
+#endif /* ALIYAMLCONFIGURATION_H */

--- a/PWG/Tools/CMakeLists.txt
+++ b/PWG/Tools/CMakeLists.txt
@@ -23,6 +23,7 @@ include_directories(${AliPhysics_SOURCE_DIR}/PWG/Tools)
 # Additional includes - alphabetical order except ROOT
 include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/CORRFW
+                    ${AliPhysics_SOURCE_DIR}/PWG/Tools/yaml-cpp/include
   )
 
 # Sources - alphabetical order
@@ -42,6 +43,7 @@ set(SRCS
   TLinearBinning.cxx
   TVariableBinning.cxx
   THistManager.cxx
+  AliYAMLConfiguration.cxx
   AliJSONReader.cxx
   AliJSONData.cxx
   AliAnalysisTaskDummy.cxx
@@ -71,6 +73,9 @@ add_library_tested(${MODULE} SHARED  ${SRCS} G__${MODULE}.cxx)
 # Dependecies
 set(LIBDEPS ANALYSIS AOD CORRFW ESD STEERBase ASImage)
 generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
+
+# Link against yaml-cpp. It must be included _after_ the ROOT map because it is static rather than shared!
+set(LIBDEPS ${LIBDEPS} yaml-cpp)
 
 # Generate a PARfile target for this library
 add_target_parfile(${MODULE} "${SRCS}" "${HDRS}" "${MODULE}LinkDef.h" "${LIBDEPS}")

--- a/PWG/Tools/PWGToolsLinkDef.h
+++ b/PWG/Tools/PWGToolsLinkDef.h
@@ -30,6 +30,13 @@
 #pragma link C++ class AliJSONString+;
 #pragma link C++ class AliAnalysisTaskDummy+;
 #pragma link C++ class AliTLorentzVector+;
+#if ROOT_VERSION_CODE > ROOT_VERSION(6,4,0)
+#pragma link C++ namespace YAML;
+#pragma link C++ class YAML::Node+;
+#endif
+#pragma link C++ class std::pair<std::string, std::string>+;
+#pragma link C++ class std::vector<std::pair<std::string, std::string> >+;
+#pragma link C++ class AliYAMLConfiguration+;
 #pragma link C++ namespace TestTHistManager;
 #pragma link C++ class TestTHistManager::THistManagerTestSuite;
 #pragma link C++ function TestTHistManager::TestRunAll();


### PR DESCRIPTION
Introduces a new configuration class, AliYAMLConfiguration, that provides an interface which allows users to read and write values in YAML files. It is refactored and generalized from the functionality in the EMCal Corrections Framework.

Given the generalization, it was moved to PWG/Tools, with the hope that it can benefit other users. Documentation on usage is available in the class header.

It has been tested and validated on ROOT 5 and 6 on macOS (thanks @jdmulligan for help testing!), but given the use of templates, it may cause errors with gcc, so it may take a few iterations.