### PR TITLE
Updated D0-h task: allow applying Ntrkl weights to MC events

### DIFF
--- a/PWGHF/correlationHF/AliAnalysisTaskSED0Correlations.h
+++ b/PWGHF/correlationHF/AliAnalysisTaskSED0Correlations.h
@@ -108,6 +108,12 @@ class AliAnalysisTaskSED0Correlations : public AliAnalysisTaskSE
   void SetMinDPt(Double_t minDPt) {fMinDPt=minDPt;}
   void SetFillTrees(TreeFill fillTrees, Double_t fractAccME) {fFillTrees=fillTrees; fFractAccME=fractAccME;}
  
+  void SetUseNtrklWeight(Bool_t flag=kTRUE) {fUseNtrklWeight=flag;}
+  void SetHistNtrklWeight(TH1D* h) {
+    if(fHistNtrklWeight) delete fHistNtrklWeight;
+    fHistNtrklWeight = new TH1D(*h);
+  }
+
  private:
 
   AliAnalysisTaskSED0Correlations(const AliAnalysisTaskSED0Correlations &source);
@@ -131,6 +137,7 @@ class AliAnalysisTaskSED0Correlations : public AliAnalysisTaskSE
   void ResetBranchDForCutOptim();
   Bool_t AcceptTrackForMEOffline(Double_t pt);
   void FillPurityPlots(TClonesArray* mcArray, AliReducedParticle* track, Int_t ptbin, Double_t deltaphi);
+  Double_t GetNtrklWeight(Int_t ntrkl); 
   
   Int_t             	 fNPtBinsCorr;        // number of pt bins per correlations
   std::vector<Double_t>  fBinLimsCorr;        // limits of pt bins per correlations
@@ -190,6 +197,10 @@ class AliAnalysisTaskSED0Correlations : public AliAnalysisTaskSE
   Int_t     fAODProtection;  	        // flag to activate protection against AOD-dAOD mismatch.
   Bool_t    fPurityStudies;		// flag to activate purity studies (primaries, secondaries, charm and beauth tracks rejected by DCA cut, vs pT and deltaPhi)
 
+  Bool_t    fUseNtrklWeight;            // flag to activate events weighting via Ntracklet distribution data/MC ratio
+  TH1D      *fHistNtrklWeight;          // histo with Ntracklets weights
+  Double_t  fWeight;                    // Ntrkl weight to apply to events when filling the MC THnSparse (for closure test) and MC purity plots
+
   AliHFCorrelationBranchD   *fBranchD;
   AliHFCorrelationBranchTr  *fBranchTr;
   AliD0hCutOptim	    *fBranchDCutVars; //for cut optimization!
@@ -199,7 +210,7 @@ class AliAnalysisTaskSED0Correlations : public AliAnalysisTaskSE
   TObjArray *fTrackArray;		// Array with selected tracks for association
   Bool_t    fTrackArrayFilled;		// Flag to fill fTrackArray or not (if already filled)
 
-  ClassDef(AliAnalysisTaskSED0Correlations,14); // AliAnalysisTaskSE for D0->Kpi - h correlations
+  ClassDef(AliAnalysisTaskSED0Correlations,15); // AliAnalysisTaskSE for D0->Kpi - h correlations
 };
 
 #endif

--- a/PWGHF/correlationHF/macros/AddTaskD0Correlations.C
+++ b/PWGHF/correlationHF/macros/AddTaskD0Correlations.C
@@ -1,4 +1,4 @@
-AliAnalysisTaskSED0Correlations *AddTaskD0Correlations(Bool_t readMC=kFALSE, Bool_t mixing=kFALSE, Bool_t recoTrMC=kFALSE, Bool_t recoD0MC = kFALSE,  Bool_t flagsoftpicut = kTRUE, Bool_t MEthresh = kFALSE, Bool_t pporpPb_lims=kFALSE /*0=pp,1=pPb limits*/, TString cutsfilename="D0toKpiCuts.root", TString cutsfilename2="AssocPartCuts_Std_NewPools.root", TString effD0namec="D0Eff_From_c_wLimAcc_2D.root", TString effD0nameb="D0Eff_From_b_wLimAcc_2D.root", TString effName = "3D_eff_Std.root", TString cutsD0name="D0toKpiCuts", TString cutsTrkname="AssociatedTrkCuts", Double_t etacorr=1.5, Int_t system=0/*0=useMultipl(pp),1=useCentral(PbPb,pA depends)-*/, Int_t flagD0D0bar=0, Float_t minC=0, Float_t maxC=0, TString finDirname="Output", Bool_t flagAOD049=kFALSE, Int_t standardbins=1, Bool_t stdcuts=kFALSE, Bool_t analyszeKaon=kFALSE, Bool_t speed=kTRUE, Bool_t mergepools=kFALSE, Bool_t useDeff=kTRUE, Bool_t useTrackeff=kTRUE, Bool_t useCutFileSBRanges=kFALSE, Double_t ptAssocLim=1., Int_t fillTrees=AliAnalysisTaskSED0Correlations::kNoTrees, Double_t fractAccME=100., Double_t minDPt=2., Int_t AODprot=1, Bool_t puritystudies=kFALSE)
+AliAnalysisTaskSED0Correlations *AddTaskD0Correlations(Bool_t readMC=kFALSE, Bool_t mixing=kFALSE, Bool_t recoTrMC=kFALSE, Bool_t recoD0MC = kFALSE,  Bool_t flagsoftpicut = kTRUE, Bool_t MEthresh = kFALSE, Bool_t pporpPb_lims=kFALSE /*0=pp,1=pPb limits*/, TString cutsfilename="D0toKpiCuts.root", TString cutsfilename2="AssocPartCuts_Std_NewPools.root", TString effD0namec="D0Eff_From_c_wLimAcc_2D.root", TString effD0nameb="D0Eff_From_b_wLimAcc_2D.root", TString effName = "3D_eff_Std.root", TString cutsD0name="D0toKpiCuts", TString cutsTrkname="AssociatedTrkCuts", Double_t etacorr=1.5, Int_t system=0/*0=useMultipl(pp),1=useCentral(PbPb,pA depends)-*/, Int_t flagD0D0bar=0, Float_t minC=0, Float_t maxC=0, TString finDirname="Output", Bool_t flagAOD049=kFALSE, Int_t standardbins=1, Bool_t stdcuts=kFALSE, Bool_t analyszeKaon=kFALSE, Bool_t speed=kTRUE, Bool_t mergepools=kFALSE, Bool_t useDeff=kTRUE, Bool_t useTrackeff=kTRUE, Bool_t useCutFileSBRanges=kFALSE, Double_t ptAssocLim=1., Int_t fillTrees=AliAnalysisTaskSED0Correlations::kNoTrees, Double_t fractAccME=100., Double_t minDPt=2., Int_t AODprot=1, Bool_t puritystudies=kFALSE, Bool_t reweighMC=kFALSE, TString filenameWeights="")
 {
   //
   // AddTask for the AliAnalysisTaskSE for D0 candidates
@@ -209,6 +209,20 @@ AliAnalysisTaskSED0Correlations *AddTaskD0Correlations(Bool_t readMC=kFALSE, Boo
   massD0Task->SetAODMismatchProtection(AODprot);
   massD0Task->SetPurityStudies(puritystudies);
   if(analyszeKaon) massD0Task->SetKaonCorrelations(kTRUE);
+
+  // multiplicity weights
+  if(reweighMC) {
+      printf(" Loading Ntracklet weights...\n");
+      TFile* filewgt = TFile::Open(filenameWeights);
+      TH1D* hWeight = (TH1D*)filewgt->Get("hNtrUnCorrEvWithCandWeight");
+      if(!hWeight) {
+          printf("Error! Weights for Ntracklets not correctly loaded!");
+          return;
+      }
+      massD0Task->SetUseNtrklWeight(kTRUE);
+      massD0Task->SetHistNtrklWeight(hWeight);
+  }
+
 
 //*********************
 //correlation settings


### PR DESCRIPTION
Mainly for:
- Purity studies (and systematics) vs centrality
- MC closure test vs centrality