### PR TITLE
Revive trigger selection framework

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerSelection.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerSelection.cxx
@@ -1,70 +1,65 @@
-/**************************************************************************
- * Copyright(c) 1998-2007, ALICE Experiment at CERN, All rights reserved. *
- *                                                                        *
- * Author: The ALICE Off-line Project.                                    *
- * Contributors are mentioned in the code where appropriate.              *
- *                                                                        *
- * Permission to use, copy, modify and distribute this software and its   *
- * documentation strictly for non-commercial purposes is hereby granted   *
- * without fee, provided that the above copyright notice appears in all   *
- * copies and that both the copyright notice and this permission notice   *
- * appear in the supporting documentation. The authors make no claims     *
- * about the suitability of this software for any purpose. It is          *
- * provided "as is" without express or implied warranty.                  *
- **************************************************************************/
-/*
- * Task providing an event selection for EMCAL-triggered events based on the
- * reconstructed EMCAL trigger patches
- *
- * Author: Markus Fasel
- */
-
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <algorithm>
+#include <vector>
 #include "AliEmcalTriggerDecision.h"
 #include "AliEmcalTriggerDecisionContainer.h"
 #include "AliEmcalTriggerSelection.h"
+#include "AliEmcalTriggerSelectionCuts.h"
 #include "AliAnalysisTaskEmcalTriggerSelection.h"
 
-ClassImp(AliAnalysisTaskEmcalTriggerSelection)
+/// \cond CLASSIMP
+ClassImp(PWG::EMCAL::AliAnalysisTaskEmcalTriggerSelection)
+/// \endcond
 
-//______________________________________________________________________________
+namespace PWG {
+namespace EMCAL {
+
 AliAnalysisTaskEmcalTriggerSelection::AliAnalysisTaskEmcalTriggerSelection():
   AliAnalysisTaskEmcal(),
-  fGlobalDecisionContainerName(),
+  fGlobalDecisionContainerName("EmcalTriggerDecision"),
   fTriggerSelections()
 {
-  /*
-   * Dummy constructor, only for I/O, not to be used by the user
-   */
   fTriggerSelections.SetOwner(kTRUE);
 }
 
-//______________________________________________________________________________
 AliAnalysisTaskEmcalTriggerSelection::AliAnalysisTaskEmcalTriggerSelection(const char* name):
   AliAnalysisTaskEmcal(name, kFALSE),
-  fGlobalDecisionContainerName(),
+  fGlobalDecisionContainerName("EmcalTriggerDecision"),
   fTriggerSelections()
 {
-  /*
-   * Main constructor, to be called by the users
-   */
   fTriggerSelections.SetOwner(kTRUE);
 }
 
-//______________________________________________________________________________
 void AliAnalysisTaskEmcalTriggerSelection::AddTriggerSelection(AliEmcalTriggerSelection * const selection){
-  /*
-   * Add trigger selection to the trigger selection task
-   *
-   * @param selection: the trigger selection to be added
-   */
   fTriggerSelections.Add(selection);
 }
 
-//______________________________________________________________________________
 Bool_t AliAnalysisTaskEmcalTriggerSelection::Run(){
-  /*
-   * Run over all trigger selections, and append the selection to the global trigger selection container
-   */
   AliEmcalTriggerDecisionContainer *cont = GetGlobalTriggerDecisionContainer();
   cont->Reset();
   TClonesArray *triggerPatches(fTriggerPatchInfo);
@@ -76,15 +71,157 @@ Bool_t AliAnalysisTaskEmcalTriggerSelection::Run(){
   return kTRUE;
 }
 
-//______________________________________________________________________________
 AliEmcalTriggerDecisionContainer *AliAnalysisTaskEmcalTriggerSelection::GetGlobalTriggerDecisionContainer(){
-  /*
-   * Find the main trigger container in the input event. If not available, create it and add it to the input event
-   */
   AliEmcalTriggerDecisionContainer *cont(dynamic_cast<AliEmcalTriggerDecisionContainer *>(fInputEvent->FindListObject(fGlobalDecisionContainerName.Data())));
   if(!cont){
     cont = new AliEmcalTriggerDecisionContainer(fGlobalDecisionContainerName.Data());
     fInputEvent->AddObject(cont);
   }
   return cont;
+}
+
+void AliAnalysisTaskEmcalTriggerSelection::AutoConfigure(const char *period) {
+  std::vector<TString> pp2016periods = {"LHC16h", "LHC16i", "LHC16j", "LHC16k", "LHC16l", "LHC16o", "LHC16p"};
+  std::vector<TString> mcpp2016periods = {"LHC17f8", "LHC17f8a", "LHC17f8b", "LHC178c", "LHC17f8d", "LHC17f8e",
+                                          "LHC17f8f", "LHC17f8g", "LHC17f8h", "LHC17f8i", "LHC17f8j", "LHC17f8k"};
+  TString periodstring(period);
+  if(std::find(pp2016periods.begin(), pp2016periods.end(), periodstring) != pp2016periods.end()) ConfigurePP2016();
+  if(std::find(mcpp2016periods.begin(), mcpp2016periods.end(), periodstring) != mcpp2016periods.end()) ConfigureMCPP2016();
+}
+
+void AliAnalysisTaskEmcalTriggerSelection::ConfigurePP2016(){
+  AliEmcalTriggerSelectionCuts *eg1cuts = new AliEmcalTriggerSelectionCuts;
+  eg1cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
+  eg1cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1GammaHighPatch);
+  eg1cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kADC);
+  eg1cuts->SetUseRecalcPatches(true);
+  eg1cuts->SetThreshold(115);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("EG1", eg1cuts));
+
+  AliEmcalTriggerSelectionCuts *eg2cuts = new AliEmcalTriggerSelectionCuts;
+  eg2cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
+  eg2cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1GammaLowPatch);
+  eg2cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kADC);
+  eg2cuts->SetUseRecalcPatches(true);
+  eg2cuts->SetUseSimpleOfflinePatches(true);
+  eg2cuts->SetThreshold(51);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("EG2", eg2cuts));
+
+  AliEmcalTriggerSelectionCuts *dg1cuts = new AliEmcalTriggerSelectionCuts;
+  dg1cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kDCALAcceptance);
+  dg1cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1GammaHighPatch);
+  dg1cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kADC);
+  dg1cuts->SetUseRecalcPatches(true);
+  dg1cuts->SetThreshold(115);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("DG1", dg1cuts));
+
+  AliEmcalTriggerSelectionCuts *dg2cuts = new AliEmcalTriggerSelectionCuts;
+  dg2cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kDCALAcceptance);
+  dg2cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1GammaLowPatch);
+  dg2cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kADC);
+  dg2cuts->SetUseRecalcPatches(true);
+  dg2cuts->SetThreshold(51);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("DG2", dg2cuts));
+
+  AliEmcalTriggerSelectionCuts *ej1cuts = new AliEmcalTriggerSelectionCuts;
+  ej1cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
+  ej1cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1JetHighPatch);
+  ej1cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kADC);
+  ej1cuts->SetUseRecalcPatches(true);
+  ej1cuts->SetThreshold(255);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("EJ1", ej1cuts));
+
+  AliEmcalTriggerSelectionCuts *ej2cuts = new AliEmcalTriggerSelectionCuts;
+  ej2cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
+  ej2cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1JetLowPatch);
+  ej2cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kADC);
+  ej2cuts->SetUseRecalcPatches(true);
+  ej2cuts->SetThreshold(204);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("EJ2", ej2cuts));
+
+  AliEmcalTriggerSelectionCuts *dj1cuts = new AliEmcalTriggerSelectionCuts;
+  dj1cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kDCALAcceptance);
+  dj1cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1JetHighPatch);
+  dj1cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kADC);
+  dj1cuts->SetUseRecalcPatches(true);
+  dj1cuts->SetThreshold(255);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("DJ1", dj1cuts));
+
+  AliEmcalTriggerSelectionCuts *dj2cuts = new AliEmcalTriggerSelectionCuts;
+  dj2cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kDCALAcceptance);
+  dj2cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1JetLowPatch);
+  dj2cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kADC);
+  dj2cuts->SetUseRecalcPatches(true);
+  dj2cuts->SetThreshold(204);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("DJ2", dj2cuts));
+
+}
+
+void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPP2016() {
+  AliEmcalTriggerSelectionCuts *eg1cuts = new AliEmcalTriggerSelectionCuts;
+  eg1cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
+  eg1cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1GammaHighPatch);
+  eg1cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
+  eg1cuts->SetUseSimpleOfflinePatches(true);
+  eg1cuts->SetThreshold(9.);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("EG1", eg1cuts));
+
+  AliEmcalTriggerSelectionCuts *eg2cuts = new AliEmcalTriggerSelectionCuts;
+  eg2cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
+  eg2cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1GammaLowPatch);
+  eg2cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
+  eg2cuts->SetUseSimpleOfflinePatches(true);
+  eg2cuts->SetThreshold(4.);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("EG2", eg2cuts));
+
+  AliEmcalTriggerSelectionCuts *dg1cuts = new AliEmcalTriggerSelectionCuts;
+  dg1cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kDCALAcceptance);
+  dg1cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1GammaHighPatch);
+  dg1cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
+  dg1cuts->SetUseSimpleOfflinePatches(true);
+  dg1cuts->SetThreshold(9.);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("DG1", dg1cuts));
+
+  AliEmcalTriggerSelectionCuts *dg2cuts = new AliEmcalTriggerSelectionCuts;
+  dg2cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kDCALAcceptance);
+  dg2cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1GammaLowPatch);
+  dg2cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
+  dg2cuts->SetUseSimpleOfflinePatches(true);
+  dg2cuts->SetThreshold(4.);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("DG2", dg2cuts));
+
+  AliEmcalTriggerSelectionCuts *ej1cuts = new AliEmcalTriggerSelectionCuts;
+  ej1cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
+  ej1cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1JetHighPatch);
+  ej1cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
+  ej1cuts->SetUseSimpleOfflinePatches(true);
+  ej1cuts->SetThreshold(9.);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("EJ1", ej1cuts));
+
+  AliEmcalTriggerSelectionCuts *ej2cuts = new AliEmcalTriggerSelectionCuts;
+  ej2cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kEMCALAcceptance);
+  ej2cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1JetLowPatch);
+  ej2cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
+  ej2cuts->SetUseSimpleOfflinePatches(true);
+  ej2cuts->SetThreshold(4.);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("EJ2", ej2cuts));
+
+  AliEmcalTriggerSelectionCuts *dj1cuts = new AliEmcalTriggerSelectionCuts;
+  dj1cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kDCALAcceptance);
+  dj1cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1JetHighPatch);
+  dj1cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
+  dj1cuts->SetUseSimpleOfflinePatches(true);
+  dj1cuts->SetThreshold(20.);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("DJ1", dj1cuts));
+
+  AliEmcalTriggerSelectionCuts *dj2cuts = new AliEmcalTriggerSelectionCuts;
+  dj2cuts->SetAcceptanceType(AliEmcalTriggerSelectionCuts::kDCALAcceptance);
+  dj2cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1JetLowPatch);
+  dj2cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
+  dj2cuts->SetUseSimpleOfflinePatches(true);
+  dj2cuts->SetThreshold(4.);
+  this->AddTriggerSelection(new AliEmcalTriggerSelection("DJ2", dj2cuts));
+}
+
+}
 }

--- a/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerSelection.h
+++ b/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerSelection.h
@@ -1,35 +1,116 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #ifndef ALIANALYSISTASKEMCALTRIGGERSELECTION_H
 #define ALIANALYSISTASKEMCALTRIGGERSELECTION_H
-/* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
- * See cxx source for full Copyright notice                               */
-
-// Author: Markus Fasel
 
 #include <TList.h>
 #include <TString.h>
 #include "AliAnalysisTaskEmcal.h"
 
+namespace PWG{
+namespace EMCAL {
+
 class AliEmcalTriggerDecisionContainer;
 class AliEmcalTriggerSelection;
 
+/**
+ * @class AliAnalysisTaskEmcalTriggerSelection
+ * @brief Task providing an event selection for EMCAL-triggered events based on the
+ * reconstructed EMCAL trigger patches
+ * @ingroup EMCALFWTASKS
+ * @author Markus Fasel <markus.fasel@cern.ch> Oak Ridge National Laboratory
+ * @since Dec 17, 2014
+ */
 class AliAnalysisTaskEmcalTriggerSelection: public AliAnalysisTaskEmcal {
 public:
+  /**
+   * @brief Dummy constructor
+   *
+   * Only for I/O, not to be used by the user
+   */
   AliAnalysisTaskEmcalTriggerSelection();
+
+  /**
+   * @brief Main constructor
+   *
+   * To be called by the users
+   */
   AliAnalysisTaskEmcalTriggerSelection(const char *name);
   virtual ~AliAnalysisTaskEmcalTriggerSelection() {}
 
+  /**
+   * Add trigger selection to the trigger selection task
+   *
+   * @param[in] selection the trigger selection to be added
+   */
   void AddTriggerSelection(AliEmcalTriggerSelection * const selection);
   void SetGlobalDecisionContainerName(const char *name) { fGlobalDecisionContainerName = name; }
 
+  /**
+   * @brief Run over all trigger selections, and append the selection to the global trigger selection container
+   */
   virtual Bool_t Run();
 
+  /**
+   * @brief Automatically configure trigger decision handler for different periods
+   */
+  void AutoConfigure(const char *period);
+
+  /**
+   * @brief Configure the trigger selection task for pp anchored to 2016
+   *
+   * Using recalc patches (recalculated from FASTOR, no STU trigger decision) and
+   * ADC cut, where the cut values are set to the nominal ADC thresholds
+   */
+  void ConfigurePP2016();
+
+  /**
+   * @brief Configure the trigger selection task for MC anchored to pp 2016
+   *
+   * Using simple offline patches (from cells) and energy cut, where the cut
+   * values are set to the expected energy cuts
+   */
+  void ConfigureMCPP2016();
+
 protected:
+  /**
+   * @brief Find the main trigger container in the input event.
+   *
+   * If not available, create it and add it to the input event
+   */
   AliEmcalTriggerDecisionContainer *GetGlobalTriggerDecisionContainer();
 
-  TString fGlobalDecisionContainerName;     // Name of the global trigger selection
-  TList fTriggerSelections;                 // List of trigger selections
+  TString fGlobalDecisionContainerName;     ///< Name of the global trigger selection
+  TList fTriggerSelections;                 ///< List of trigger selections
 
   ClassDef(AliAnalysisTaskEmcalTriggerSelection, 1);    // Task running different EMCAL trigger selections
 };
+
+}
+}
 
 #endif /* ALIANALYSISTASKEMCALTRIGGERSELECTION_H */

--- a/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
+++ b/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
@@ -28,7 +28,6 @@
 #pragma link C++ class  AliEMCALConfiguration+;
 #pragma link C++ class  AliEMCALConfigHandler+;
 #pragma link C++ class  AliEMCALConfigurationMatcher+;
-#pragma link C++ class  AliAnalysisTaskEmcalTriggerSelection+;
 #pragma link C++ class  AliAnalysisTaskEmcalIteratorTest+;
 #pragma link C++ class  AliEmcalCopyCollection+;
 #pragma link C++ class  AliEmcalCorrectionEventManager+;
@@ -53,4 +52,5 @@
 #pragma link C++ class PWG::EMCAL::AliEmcalTriggerRejectionMaker+;
 #pragma link C++ class PWG::EMCAL::AliEmcalCellMonitorTask+;
 #pragma link C++ class PWG::EMCAL::AliEmcalFastOrMonitorTask+;
+#pragma link C++ class PWG::EMCAL::AliAnalysisTaskEmcalTriggerSelection+;
 #endif

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecision.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecision.cxx
@@ -1,65 +1,59 @@
-/**************************************************************************
- * Copyright(c) 1998-2007, ALICE Experiment at CERN, All rights reserved. *
- *                                                                        *
- * Author: The ALICE Off-line Project.                                    *
- * Contributors are mentioned in the code where appropriate.              *
- *                                                                        *
- * Permission to use, copy, modify and distribute this software and its   *
- * documentation strictly for non-commercial purposes is hereby granted   *
- * without fee, provided that the above copyright notice appears in all   *
- * copies and that both the copyright notice and this permission notice   *
- * appear in the supporting documentation. The authors make no claims     *
- * about the suitability of this software for any purpose. It is          *
- * provided "as is" without express or implied warranty.                  *
- **************************************************************************/
-/*
- * Object storing the result of the EMCAL trigger decision. The result is appended to the
- * input event and can be read out by consumer tasks.
- *
- * Author: Markus Fasel
- */
-
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #include "AliEmcalTriggerDecision.h"
 #include "AliEMCALTriggerPatchInfo.h"
 
-ClassImp(AliEmcalTriggerDecision)
+ClassImp(PWG::EMCAL::AliEmcalTriggerDecision)
 
-//______________________________________________________________________________
+namespace PWG{
+
+namespace EMCAL{
+
 AliEmcalTriggerDecision::AliEmcalTriggerDecision():
   TNamed(),
   fMainPatch(NULL),
   fSelectionCuts(NULL),
   fAcceptedPatches()
 {
-  /*
-   * Dummy constructor, needed for I/O, not to be used by the user
-   */
   fAcceptedPatches.SetOwner(kFALSE);
 }
 
-//______________________________________________________________________________
 AliEmcalTriggerDecision::AliEmcalTriggerDecision(const char *name, const char *title):
   TNamed(name, title),
   fMainPatch(NULL),
   fSelectionCuts(NULL),
   fAcceptedPatches()
 {
-  /*
-   * The main (named) constructor. The decision object can be read out later by the consumer
-   * task according to the name.
-   *
-   * @param name: Name of the decision object
-   * @param title: Title of the decision object
-   */
   fAcceptedPatches.SetOwner(kFALSE);
 }
 
-//______________________________________________________________________________
 void AliEmcalTriggerDecision::AddAcceptedPatch(AliEMCALTriggerPatchInfo * const acceptedPatch){
-  /*
-   * Add accepted patch to the trigger decision
-   *
-   * @param patch: the accepted patch
-   */
   fAcceptedPatches.Add(acceptedPatch);
+}
+
+}
 }

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecision.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecision.h
@@ -74,12 +74,42 @@ public:
    */
   virtual ~AliEmcalTriggerDecision() {}
 
+  /**
+   * @brief Get the highest energetic trigger patch of the event firing the trigger
+   * @return Highest energetic trigger patch of the event
+   */
   const AliEMCALTriggerPatchInfo *GetMainPatch() const { return fMainPatch; }
+
+  /**
+   * @brief Get the selection cuts used in the trigger selection
+   * @return Selection cuts used for the corresponding trigger class
+   */
   const AliEmcalTriggerSelectionCuts *GetSelectionCuts() const { return fSelectionCuts; }
+
+  /**
+   * @brief Get the list of all patches in the event satisfying the trigger condition
+   * @return
+   */
   const TList *GetAcceptedPatches() const { return &fAcceptedPatches; }
+
+  /**
+   * @brief Check whether event is selected under the given trigger
+   *
+   * An event is selected if a main (highest energy) patch was found
+   * @return True if the event was selected, false otherwise
+   */
   Bool_t IsSelected() const { return fMainPatch != NULL; }
 
+  /**
+   * @brief Set the selection cuts used in the trigger selection
+   * @param[in] cuts Selection cuts for the given trigger class
+   */
   void SetSelectionCuts(const AliEmcalTriggerSelectionCuts * const cuts) { fSelectionCuts = cuts; }
+
+  /**
+   * @brief Set the main (highest-energetic) trigger patch
+   * @param[in] mainpatch Highest energetic trigger patch of the event firing the trigger
+   */
   void SetMainPatch(const AliEMCALTriggerPatchInfo * const mainpatch) { fMainPatch = mainpatch; }
 
   /**
@@ -94,7 +124,9 @@ protected:
   const AliEmcalTriggerSelectionCuts      *fSelectionCuts;     ///< Pointer to the cuts used for the trigger selection
   TList                                    fAcceptedPatches;   ///< All trigger patches which are accepted as well
 
+  /// \cond CLASSIMP
   ClassDef(AliEmcalTriggerDecision, 1);               // Container of the trigger decision information
+  /// \endcond
 private:
   AliEmcalTriggerDecision(const AliEmcalTriggerDecision &ref);
   AliEmcalTriggerDecision &operator=(const AliEmcalTriggerDecision &ref);

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecision.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecision.h
@@ -1,20 +1,77 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #ifndef ALIEMCALTRIGGERDECISION_H
 #define ALIEMCALTRIGGERDECISION_H
-/* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
- * See cxx source for full Copyright notice                               */
-
-// Author: Markus Fasel
 
 #include <TList.h>
 #include <TNamed.h>
 
 class AliEMCALTriggerPatchInfo;
+
+namespace PWG {
+
+namespace EMCAL {
+
 class AliEmcalTriggerSelectionCuts;
 
+/**
+ * @class AliEmcalTriggerDecision
+ * @brief Container for trigger decision
+ * @ingroup EMCALTRGFW
+ * @author Markus Fasel <markus.fasel@cern.ch>
+ * @since Dec 17, 2014
+ *
+ * Object storing the result of the EMCAL trigger decision. The result is appended to the
+ * input event and can be read out by consumer tasks.
+ */
 class AliEmcalTriggerDecision: public TNamed {
 public:
+
+  /**
+   * @brief Dummy constructor
+   *
+   * Needed for I/O, not to be used by the user
+   */
   AliEmcalTriggerDecision();
+
+  /**
+   * @brief The main (named) constructor.
+   *
+   * The decision object can be read out later by the consumer
+   * task according to the name.
+   *
+   * @param[in] name Name of the decision object
+   * @param[in] title Title of the decision object
+   */
   AliEmcalTriggerDecision(const char *name, const char *title = "");
+
+  /**
+   * @brief Destructor
+   */
   virtual ~AliEmcalTriggerDecision() {}
 
   const AliEMCALTriggerPatchInfo *GetMainPatch() const { return fMainPatch; }
@@ -24,17 +81,26 @@ public:
 
   void SetSelectionCuts(const AliEmcalTriggerSelectionCuts * const cuts) { fSelectionCuts = cuts; }
   void SetMainPatch(const AliEMCALTriggerPatchInfo * const mainpatch) { fMainPatch = mainpatch; }
+
+  /**
+   * Add accepted patch to the trigger decision
+   *
+   * @param[in] patch the accepted patch
+   */
   void AddAcceptedPatch(AliEMCALTriggerPatchInfo * const acceptedPatch);
 
 protected:
-  const AliEMCALTriggerPatchInfo          *fMainPatch;         // Main trigger patch which fires the decision
-  const AliEmcalTriggerSelectionCuts      *fSelectionCuts;     // Pointer to the cuts used for the trigger selection
-  TList                                    fAcceptedPatches;   // All trigger patches which are accepted as well
+  const AliEMCALTriggerPatchInfo          *fMainPatch;         ///< Main trigger patch which fires the decision
+  const AliEmcalTriggerSelectionCuts      *fSelectionCuts;     ///< Pointer to the cuts used for the trigger selection
+  TList                                    fAcceptedPatches;   ///< All trigger patches which are accepted as well
 
   ClassDef(AliEmcalTriggerDecision, 1);               // Container of the trigger decision information
 private:
   AliEmcalTriggerDecision(const AliEmcalTriggerDecision &ref);
   AliEmcalTriggerDecision &operator=(const AliEmcalTriggerDecision &ref);
 };
+
+}
+}
 
 #endif /* ALIEMCALTRIGGERDECISION_H */

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.cxx
@@ -1,74 +1,68 @@
-/**************************************************************************
- * Copyright(c) 1998-2007, ALICE Experiment at CERN, All rights reserved. *
- *                                                                        *
- * Author: The ALICE Off-line Project.                                    *
- * Contributors are mentioned in the code where appropriate.              *
- *                                                                        *
- * Permission to use, copy, modify and distribute this software and its   *
- * documentation strictly for non-commercial purposes is hereby granted   *
- * without fee, provided that the above copyright notice appears in all   *
- * copies and that both the copyright notice and this permission notice   *
- * appear in the supporting documentation. The authors make no claims     *
- * about the suitability of this software for any purpose. It is          *
- * provided "as is" without express or implied warranty.                  *
- **************************************************************************/
-/*
- * Container storing all trigger decisions by the trigger selection task
- *
- * Author: Markus Fasel
- */
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #include "AliEmcalTriggerDecision.h"
 #include "AliEmcalTriggerDecisionContainer.h"
 
-ClassImp(AliEmcalTriggerDecisionContainer)
+ClassImp(PWG::EMCAL::AliEmcalTriggerDecisionContainer)
 
-//______________________________________________________________________________
+namespace PWG{
+namespace EMCAL{
+
 AliEmcalTriggerDecisionContainer::AliEmcalTriggerDecisionContainer():
   TNamed(),
   fContainer()
 {
-  /*
-   * Dummy constructor, for I/O, not to be called by the user
-   */
   fContainer.SetOwner();
 }
 
-//______________________________________________________________________________
 AliEmcalTriggerDecisionContainer::AliEmcalTriggerDecisionContainer(const char* name):
   TNamed(name, ""),
   fContainer()
 {
-  /*
-   * Main constructor, called by the user
-   */
   fContainer.SetOwner();
 }
 
-//______________________________________________________________________________
 void AliEmcalTriggerDecisionContainer::Reset() {
-  /*
-   * Clear container with trigger decisions
-   */
   fContainer.Clear();
 }
 
-//______________________________________________________________________________
 void AliEmcalTriggerDecisionContainer::AddTriggerDecision(AliEmcalTriggerDecision* const decision) {
-  /*
-   * Add trigger decision to the container
-   *
-   * @param decision: Trigger decision, created by the trigger selection task
-   */
   fContainer.Add(decision);
 }
 
-//______________________________________________________________________________
 const AliEmcalTriggerDecision* AliEmcalTriggerDecisionContainer::FindTriggerDecision(const char* decname) const {
-  /*
-   * Find a trigger decision with a given name in the trigger decision container
-   *
-   * @param decname: the name of the trigger decision object
-   * @return: the trigger decision (NULL if not found)
-   */
   return dynamic_cast<const AliEmcalTriggerDecision *>(fContainer.FindObject(decname));
+}
+
+bool AliEmcalTriggerDecisionContainer::IsEventSelected(const char *name)  const {
+  const AliEmcalTriggerDecision *trg = FindTriggerDecision(name);
+  if(trg) return trg->IsSelected();
+  return false;
+}
+
+}
 }

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.cxx
@@ -27,7 +27,9 @@
 #include "AliEmcalTriggerDecision.h"
 #include "AliEmcalTriggerDecisionContainer.h"
 
+/// \cond CLASSIMP
 ClassImp(PWG::EMCAL::AliEmcalTriggerDecisionContainer)
+/// \endcond
 
 namespace PWG{
 namespace EMCAL{

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.h
@@ -1,30 +1,103 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #ifndef ALIEMCALTRIGGERDECISIONCONTAINER_H
 #define ALIEMCALTRIGGERDECISIONCONTAINER_H
-/* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
- * See cxx source for full Copyright notice                               */
-
-// Author: Markus Fasel
 
 #include <TList.h>
 #include <TNamed.h>
 
+namespace PWG{
+
+namespace EMCAL {
+
 class AliEmcalTriggerDecision;
 
+/**
+ * @class AliEmcalTriggerDecisionContainer
+ * @brief Container for trigger decision object
+ * @ingroup EMCALTRGFW
+ * @author Markus Fasel <markus.fasel@cern.ch> Oak Ridge National Laboratory
+ * @since Dec 17, 2014
+ */
 class AliEmcalTriggerDecisionContainer: public TNamed {
 public:
+  /**
+   * @brief Dummy constructor
+   *
+   * For I/O, not to be called by the user
+   */
   AliEmcalTriggerDecisionContainer();
+
+  /**
+   * @brief Main constructor
+   *
+   * Called by the user
+   */
   AliEmcalTriggerDecisionContainer(const char *name);
+
+  /**
+   * @brief Destructor
+   */
   virtual ~AliEmcalTriggerDecisionContainer() {}
 
+  /**
+   * @brief Clear container with trigger decisions
+   */
   void Reset();
 
+  /**
+   * @brief Add trigger decision to the container
+   *
+   * @param[in] decision Trigger decision, created by the trigger selection task
+   */
   void AddTriggerDecision(AliEmcalTriggerDecision * const decision);
+
+  /**
+   * @brief Find a trigger decision with a given name in the trigger decision container
+   *
+   * @param[in] decname the name of the trigger decision object
+   * @return the trigger decision (NULL if not found)
+   */
   const AliEmcalTriggerDecision *FindTriggerDecision(const char *name) const;
 
+  /**
+   * @brief Checks whether the events is selected for a given trigger type
+   * @param[in] name Name of the EMCAL trigger
+   * @return True if the event is selected, false otherwise
+   */
+  bool IsEventSelected(const char *name)  const;
+
 protected:
-  TList     fContainer;         // List of trigger decisions
+  TList     fContainer;         ///< List of trigger decisions
 
   ClassDef(AliEmcalTriggerDecisionContainer, 1);    // Container for trigger decisions
 };
+
+}
+}
 
 #endif /* ALIEMCALTRIGGERDECISIONCONTAINER_H */

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.h
@@ -85,6 +85,12 @@ public:
   const AliEmcalTriggerDecision *FindTriggerDecision(const char *name) const;
 
   /**
+   * @brief Get container with trigger decision results
+   * @return List of trigger decision objects
+   */
+  const TList *GetListOfTriggerDecisions() const { return &fContainer; }
+
+  /**
    * @brief Checks whether the events is selected for a given trigger type
    * @param[in] name Name of the EMCAL trigger
    * @return True if the event is selected, false otherwise
@@ -94,7 +100,9 @@ public:
 protected:
   TList     fContainer;         ///< List of trigger decisions
 
+  /// \cond CLASSIMP
   ClassDef(AliEmcalTriggerDecisionContainer, 1);    // Container for trigger decisions
+  /// \endcond
 };
 
 }

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelection.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelection.cxx
@@ -25,6 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
  ************************************************************************************/
 #include <vector>
+#include <iostream>
 #include <TClonesArray.h>
 
 #include "AliEMCALTriggerPatchInfo.h"
@@ -58,7 +59,7 @@ AliEmcalTriggerDecision* AliEmcalTriggerSelection::MakeDecison(const TClonesArra
   TIter patchIter(inputPatches);
   AliEMCALTriggerPatchInfo *patch(NULL);
   std::vector<AliEMCALTriggerPatchInfo *> selectedPatches;
-  std::cout << "Number of input patches: " << inputPatches->GetEntries() << std::endl;
+  AliDebugStream(1) << "Number of input patches: " << inputPatches->GetEntries() << std::endl;
   while((patch = dynamic_cast<AliEMCALTriggerPatchInfo *>(patchIter()))){
     if(fSelectionCuts->IsSelected(patch)){
       selectedPatches.push_back(patch);

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelection.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelection.cxx
@@ -1,24 +1,29 @@
-/**************************************************************************
- * Copyright(c) 1998-2007, ALICE Experiment at CERN, All rights reserved. *
- *                                                                        *
- * Author: The ALICE Off-line Project.                                    *
- * Contributors are mentioned in the code where appropriate.              *
- *                                                                        *
- * Permission to use, copy, modify and distribute this software and its   *
- * documentation strictly for non-commercial purposes is hereby granted   *
- * without fee, provided that the above copyright notice appears in all   *
- * copies and that both the copyright notice and this permission notice   *
- * appear in the supporting documentation. The authors make no claims     *
- * about the suitability of this software for any purpose. It is          *
- * provided "as is" without express or implied warranty.                  *
- **************************************************************************/
-/*
- * Object performing an offline EMCAL trigger decision based on user defined criterions
- * (trigger patch type, energy threshold,...). The main method MakeTriggerDecision performs
- * an event selection and creates a trigger decision object with the relevant information.
- *
- * Author: Markus Fasel
- */
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #include <vector>
 #include <TClonesArray.h>
 
@@ -27,45 +32,25 @@
 #include "AliEmcalTriggerSelection.h"
 #include "AliEmcalTriggerSelectionCuts.h"
 
-ClassImp(AliEmcalTriggerSelection)
+ClassImp(PWG::EMCAL::AliEmcalTriggerSelection)
 
-//______________________________________________________________________________
+namespace PWG{
+namespace EMCAL{
+
 AliEmcalTriggerSelection::AliEmcalTriggerSelection() :
   TNamed(),
-  fSelectionCuts(NULL),
-  fOutputName("")
+  fSelectionCuts(NULL)
 {
-  /*
-   * Dummy constructor, used by I/O, not to be used by the user
-   */
 }
 
-//______________________________________________________________________________
 AliEmcalTriggerSelection::AliEmcalTriggerSelection(const char *name, const AliEmcalTriggerSelectionCuts * const cuts):
   TNamed(name, ""),
-  fSelectionCuts(cuts),
-  fOutputName("")
+  fSelectionCuts(cuts)
 {
-  /*
-   * Main constructor, initialises the trigger selection
-   *
-   * @param name: name of the trigger selection
-   * @param cuts(optional): selection cuts to be applied
-   */
 }
 
-//______________________________________________________________________________
 AliEmcalTriggerDecision* AliEmcalTriggerSelection::MakeDecison(const TClonesArray * const inputPatches) const {
-  /*
-   * Perform event selection based on user-defined criteria and create an output trigger decision containing
-   * the threshold, the main patch which fired the decision, and all other patches which would have fired the
-   * decision as well.
-   *
-   * @param input patches: A list of input patches, created by the trigger patch maker and read out from the
-   * input event
-   * @return: the trigger decision (an event is selected when it has a main patch that fired the decision)
-   */
-  AliEmcalTriggerDecision *result = new AliEmcalTriggerDecision(fOutputName.Data());
+  AliEmcalTriggerDecision *result = new AliEmcalTriggerDecision(GetName());
   TIter patchIter(inputPatches);
   AliEMCALTriggerPatchInfo *patch(NULL);
   std::vector<AliEMCALTriggerPatchInfo *> selectedPatches;
@@ -85,4 +70,7 @@ AliEmcalTriggerDecision* AliEmcalTriggerSelection::MakeDecison(const TClonesArra
   if(mainPatch) result->SetMainPatch(mainPatch);
   result->SetSelectionCuts(fSelectionCuts);
   return result;
+}
+
+}
 }

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelection.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelection.cxx
@@ -31,8 +31,11 @@
 #include "AliEmcalTriggerDecision.h"
 #include "AliEmcalTriggerSelection.h"
 #include "AliEmcalTriggerSelectionCuts.h"
+#include "AliLog.h"
 
+/// \cond CLASSIMP
 ClassImp(PWG::EMCAL::AliEmcalTriggerSelection)
+/// \endcond
 
 namespace PWG{
 namespace EMCAL{
@@ -50,15 +53,18 @@ AliEmcalTriggerSelection::AliEmcalTriggerSelection(const char *name, const AliEm
 }
 
 AliEmcalTriggerDecision* AliEmcalTriggerSelection::MakeDecison(const TClonesArray * const inputPatches) const {
+  AliDebugStream(1) << "Trigger selection " << GetName() << ": Make decision" << std::endl;
   AliEmcalTriggerDecision *result = new AliEmcalTriggerDecision(GetName());
   TIter patchIter(inputPatches);
   AliEMCALTriggerPatchInfo *patch(NULL);
   std::vector<AliEMCALTriggerPatchInfo *> selectedPatches;
+  std::cout << "Number of input patches: " << inputPatches->GetEntries() << std::endl;
   while((patch = dynamic_cast<AliEMCALTriggerPatchInfo *>(patchIter()))){
     if(fSelectionCuts->IsSelected(patch)){
       selectedPatches.push_back(patch);
     }
   }
+  AliDebugStream(1) << "Number of patches fulfilling the trigger condition: " << selectedPatches.size() << std::endl;
   // Find the main patch
   AliEMCALTriggerPatchInfo *mainPatch(NULL), *testpatch(NULL);
   for(std::vector<AliEMCALTriggerPatchInfo *>::iterator it = selectedPatches.begin(); it != selectedPatches.end(); ++it){

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelection.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelection.h
@@ -1,38 +1,106 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #ifndef ALIEMCALTRIGGERSELECTION_H
 #define ALIEMCALTRIGGERSELECTION_H
-/* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
- * See cxx source for full Copyright notice                               */
-
-// Author: Markus Fasel
 
 #include <TNamed.h>
 #include <TString.h>
 
-class AliEmcalTriggerDecision;
 class AliEMCALTriggerPatchInfo;
-class AliEmcalTriggerSelectionCuts;
 class TClonesArray;
 
+namespace PWG {
+
+namespace EMCAL {
+
+class AliEmcalTriggerDecision;
+class AliEmcalTriggerSelectionCuts;
+
+/**
+ * @class AliEmcalTriggerSelection
+ * @brief Object performing offline EMCAL trigger selection
+ * @ingroup EMCALTRGFW
+ * @author Markus Fasel <markus.fasel@cern.ch> Oak Ridge National Laboratory
+ * @since Dec 17, 2014
+ *
+ * Object performing an offline EMCAL trigger decision based on user defined criterions
+ * (trigger patch type, energy threshold,...). The main method MakeTriggerDecision performs
+ * an event selection and creates a trigger decision object with the relevant information.
+ */
 class AliEmcalTriggerSelection: public TNamed {
 public:
+
+  /**
+   * @brief Dummy constructor
+   *
+   * Used by I/O, not to be used by the user
+   */
   AliEmcalTriggerSelection();
+
+  /**
+   * @brief Main constructor
+   *
+   * Initialises the trigger selection
+   *
+   * @param name: name of the trigger selection
+   * @param cuts(optional): selection cuts to be applied
+   */
   AliEmcalTriggerSelection(const char *name, const AliEmcalTriggerSelectionCuts * const cuts);
+
+  /**
+   * @brief Destructor
+   */
   virtual ~AliEmcalTriggerSelection() {}
 
   const AliEmcalTriggerSelectionCuts *GetSelectionCuts() const { return fSelectionCuts; }
 
-  void SetOutputName(const char *name) { fOutputName = name; }
   void SetSelectionCuts(const AliEmcalTriggerSelectionCuts * const cuts) { fSelectionCuts = cuts; }
 
+  /**
+   * Perform event selection based on user-defined criteria and create an output trigger decision containing
+   * the threshold, the main patch which fired the decision, and all other patches which would have fired the
+   * decision as well.
+   *
+   * @param[in] reconstructedPatches A list of input patches, created by the trigger patch maker and read out from the
+   * input event
+   * @return the trigger decision (an event is selected when it has a main patch that fired the decision)
+   */
   AliEmcalTriggerDecision * MakeDecison(const TClonesArray * const reconstructedPatches) const;
 protected:
-  const AliEmcalTriggerSelectionCuts  *fSelectionCuts;    // Cuts used for the trigger patch selection
-  TString                              fOutputName;       // Name of the output object (AliEmcalTriggerDecision)
+  const AliEmcalTriggerSelectionCuts  *fSelectionCuts;    ///< Cuts used for the trigger patch selection
 
   ClassDef(AliEmcalTriggerSelection, 1);    // EMCAL trigger selection component
 private:
   AliEmcalTriggerSelection(const AliEmcalTriggerSelection &ref);
   AliEmcalTriggerSelection &operator=(const AliEmcalTriggerSelection &ref);
 };
+
+}
+}
+
 
 #endif /* ALIEMCALTRIGGERSELECTION_H */

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelection.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelection.h
@@ -76,8 +76,16 @@ public:
    */
   virtual ~AliEmcalTriggerSelection() {}
 
+  /**
+   * @brief Get the selection cuts used in the trigger selection
+   * @return Selection cuts used in this trigger selection
+   */
   const AliEmcalTriggerSelectionCuts *GetSelectionCuts() const { return fSelectionCuts; }
 
+  /**
+   * @brief Set the selection cuts used in this trigger selection
+   * @param[in] cuts Selection cuts used to fire the trigger
+   */
   void SetSelectionCuts(const AliEmcalTriggerSelectionCuts * const cuts) { fSelectionCuts = cuts; }
 
   /**
@@ -93,7 +101,10 @@ public:
 protected:
   const AliEmcalTriggerSelectionCuts  *fSelectionCuts;    ///< Cuts used for the trigger patch selection
 
+  /// \cond CLASSIMP
   ClassDef(AliEmcalTriggerSelection, 1);    // EMCAL trigger selection component
+  /// \endcond
+
 private:
   AliEmcalTriggerSelection(const AliEmcalTriggerSelection &ref);
   AliEmcalTriggerSelection &operator=(const AliEmcalTriggerSelection &ref);

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelectionCuts.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelectionCuts.cxx
@@ -45,11 +45,11 @@ AliEmcalTriggerSelectionCuts::AliEmcalTriggerSelectionCuts() :
 }
 
 Bool_t AliEmcalTriggerSelectionCuts::IsSelected(const AliEMCALTriggerPatchInfo * const patch) const {
-  if(fUseSimpleOffline && !patch->IsOfflineSimple()) return kFALSE;
-  else if(!fUseSimpleOffline && patch->IsOfflineSimple()) return kFALSE;
-  if(!SelectAcceptance(patch))
+  //if(fUseSimpleOffline && !patch->IsOfflineSimple()) return kFALSE;
+  //else if(!fUseSimpleOffline && patch->IsOfflineSimple()) return kFALSE;
+  if(!SelectAcceptance(patch)) return kFALSE;
   if(!SelectPatchType(patch)) return kFALSE;
-  if(GetCutPrimitive(patch) <= fThreshold) return kFALSE;
+  if(GetCutPrimitive(patch) < fThreshold) return kFALSE;
   return kTRUE;
 }
 

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelectionCuts.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelectionCuts.cxx
@@ -1,98 +1,89 @@
-/**************************************************************************
- * Copyright(c) 1998-2007, ALICE Experiment at CERN, All rights reserved. *
- *                                                                        *
- * Author: The ALICE Off-line Project.                                    *
- * Contributors are mentioned in the code where appropriate.              *
- *                                                                        *
- * Permission to use, copy, modify and distribute this software and its   *
- * documentation strictly for non-commercial purposes is hereby granted   *
- * without fee, provided that the above copyright notice appears in all   *
- * copies and that both the copyright notice and this permission notice   *
- * appear in the supporting documentation. The authors make no claims     *
- * about the suitability of this software for any purpose. It is          *
- * provided "as is" without express or implied warranty.                  *
- **************************************************************************/
-/*
- * Class for the selection of trigger patches in the EMCAL triggered event selection
- *
- * Author: Markus Fasel
- */
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #include "AliEmcalTriggerSelectionCuts.h"
 #include "AliEMCALTriggerPatchInfo.h"
 
-ClassImp(AliEmcalTriggerSelectionCuts)
+ClassImp(PWG::EMCAL::AliEmcalTriggerSelectionCuts)
 
-//______________________________________________________________________________
+namespace PWG {
+namespace EMCAL {
+
+
 AliEmcalTriggerSelectionCuts::AliEmcalTriggerSelectionCuts() :
   TObject(),
   fSelectionMethod(kADC),
   fPatchType(kAnyPatch),
+  fAcceptanceType(kEMCALDCALAcceptance),
   fThreshold(0),
-  fUseSimpleOffline(kFALSE)
+  fUseSimpleOffline(kFALSE),
+  fUseRecalc(kFALSE)
 {
-  /*
-   * Dummy constructor
-   */
 }
 
-//______________________________________________________________________________
 Bool_t AliEmcalTriggerSelectionCuts::IsSelected(const AliEMCALTriggerPatchInfo * const patch) const {
-  /*
-   * Apply selection of the given trigger patch according to the selections described in the object
-   *
-   * @param patch: the trigger patch to check
-   * @return" the decision (true if selected, false otherwise)
-   */
   if(fUseSimpleOffline && !patch->IsOfflineSimple()) return kFALSE;
   else if(!fUseSimpleOffline && patch->IsOfflineSimple()) return kFALSE;
+  if(!SelectAcceptance(patch))
   if(!SelectPatchType(patch)) return kFALSE;
   if(GetCutPrimitive(patch) <= fThreshold) return kFALSE;
   return kTRUE;
 }
 
-//______________________________________________________________________________
 Int_t AliEmcalTriggerSelectionCuts::CompareTriggerPatches(const AliEMCALTriggerPatchInfo *first, const AliEMCALTriggerPatchInfo *second) const {
-  /*
-   * Compare two patches according to the energy measure specified in the cut object
-   *
-   * @param first: the first patch
-   * @param second: the second patch
-   * @return: the result of the comparison (0 if equal, 1 if the first patch has a larger primitive,
-   *          -1 if the second patch has a larger primitive)
-   */
   Double_t valfirst = GetCutPrimitive(first), valsecond = GetCutPrimitive(second);
   if(valfirst == valsecond) return 0;
   if(valfirst > valsecond) return 1;
   return -1;
 }
 
-//______________________________________________________________________________
 Double_t AliEmcalTriggerSelectionCuts::GetCutPrimitive(const AliEMCALTriggerPatchInfo * const patch) const{
-  /*
-   * Return (energy) measure we cut on, depending on the selection method specified
-   *
-   * @param patch: The patch from which to obtain the value
-   * @return: The energy measure of the patch
-   */
-  if(fSelectionMethod == kADC) return static_cast<Double_t>(patch->GetADCAmp());
-  else if(fSelectionMethod == kEnergyRough) return patch->GetADCAmpGeVRough();
-  return patch->GetPatchE();
+  double energy(0);
+  switch(fSelectionMethod){
+  case kADC: energy = static_cast<Double_t>(patch->GetADCAmp()); break;
+  case kEnergyRough: energy = patch->GetADCAmpGeVRough(); break;
+  case kEnergyOfflineSmeared: energy = patch->GetSmearedEnergy(); break;
+  case kEnergyOffline: energy = patch->GetPatchE(); break;
+  default: energy = -1.;
+  };
+  return energy;
 }
 
-//______________________________________________________________________________
 Bool_t AliEmcalTriggerSelectionCuts::SelectPatchType(const AliEMCALTriggerPatchInfo * const patch) const{
-  /*
-   * Select type of the patch according the definitions in the header file
-   *
-   * @param patch: the patch to be checked
-   * @return: selection result (true ig the patch is selected)
-   */
   if(fPatchType == kAnyPatch) return kTRUE;
   if(fUseSimpleOffline){
     if(patch->IsJetLowSimple() && ((fPatchType == kL1JetPatch) || (fPatchType == kL1JetLowPatch))) return kTRUE;
     if(patch->IsJetHighSimple() && ((fPatchType == kL1JetPatch) || (fPatchType == kL1JetHighPatch))) return kTRUE;
     if(patch->IsGammaLowSimple() && ((fPatchType == kL1GammaPatch) || (fPatchType == kL1GammaLowPatch))) return kTRUE;
     if(patch->IsGammaHighSimple() && ((fPatchType == kL1GammaPatch) || (fPatchType == kL1GammaHighPatch))) return kTRUE;
+  } else if(fUseRecalc) {
+    if(patch->IsJetLowRecalc() && ((fPatchType == kL1JetPatch) || (fPatchType == kL1JetLowPatch))) return kTRUE;
+    if(patch->IsJetHighRecalc() && ((fPatchType == kL1JetPatch) || (fPatchType == kL1JetHighPatch))) return kTRUE;
+    if(patch->IsGammaLowRecalc() && ((fPatchType == kL1GammaPatch) || (fPatchType == kL1GammaLowPatch))) return kTRUE;
+    if(patch->IsGammaHighRecalc() && ((fPatchType == kL1GammaPatch) || (fPatchType == kL1GammaHighPatch))) return kTRUE;
   } else {
     if(patch->IsJetLow() && ((fPatchType == kL1JetPatch) || (fPatchType == kL1JetLowPatch))) return kTRUE;
     if(patch->IsJetHigh() && ((fPatchType == kL1JetPatch) || (fPatchType == kL1JetHighPatch))) return kTRUE;
@@ -101,4 +92,18 @@ Bool_t AliEmcalTriggerSelectionCuts::SelectPatchType(const AliEMCALTriggerPatchI
     if(patch->IsLevel0() && fPatchType == kL0Patch) return kTRUE;
   }
   return kFALSE;
+}
+
+Bool_t AliEmcalTriggerSelectionCuts::SelectAcceptance(const AliEMCALTriggerPatchInfo * const patch) const {
+  Bool_t selected(false);
+  switch(fAcceptanceType){
+  case kEMCALAcceptance: selected = patch->IsEMCal(); break;
+  case kDCALAcceptance: selected = patch->IsDCalPHOS(); break;
+  case kEMCALDCALAcceptance: selected = patch->IsEMCal() || patch->IsDCalPHOS(); break;
+  default: selected = false;
+  };
+  return selected;
+}
+
+}
 }

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelectionCuts.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelectionCuts.h
@@ -1,20 +1,53 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #ifndef ALIEMCALTRIGGERSELECTIONCUTS_H
 #define ALIEMCALTRIGGERSELECTIONCUTS_H
-/* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
- * See cxx source for full Copyright notice                               */
-
-// Author: Markus Fasel
 
 #include <TObject.h>
 
 class AliEMCALTriggerPatchInfo;
 
+namespace PWG {
+namespace EMCAL {
+
+/**
+ * @class AliEmcalTriggerSelectionCuts
+ * @brief Class for the selection of trigger patches in the EMCAL triggered event selection
+ * @ingroup EMCALTRGFW
+ * @author Markus Fasel <markus.fasel@cern.ch> Oak Ridge National Laboratory
+ * @since Dec 17, 2014
+ */
 class AliEmcalTriggerSelectionCuts: public TObject {
 public:
   enum SelectionMethod_t {
     kADC = 0,
     kEnergyRough = 1,
-    kEnergyOffline = 2
+    kEnergyOffline = 2,
+    kEnergyOfflineSmeared = 3
   };
   enum PatchType_t {
     kAnyPatch = 0,
@@ -26,7 +59,15 @@ public:
     kL1GammaLowPatch = 6,
     kL1GammaHighPatch = 7
   };
+  enum AcceptanceType_t {
+    kEMCALAcceptance = 0,
+    kDCALAcceptance = 1,
+    kEMCALDCALAcceptance = 2
+  };
 
+  /**
+   * @brief Dummy constructor
+   */
   AliEmcalTriggerSelectionCuts();
   virtual ~AliEmcalTriggerSelectionCuts() {}
 
@@ -36,23 +77,71 @@ public:
   Bool_t IsRequestingSimpleOfflinePatches() const { return fUseSimpleOffline; }
 
   void SetPatchType(PatchType_t patchType) { fPatchType = patchType; }
+  void SetAcceptanceType(AcceptanceType_t acceptance) { fAcceptanceType = acceptance; }
   void SetSelectionMethod(SelectionMethod_t selectionMethod) { fSelectionMethod = selectionMethod; }
   void SetThreshold(Double_t threshold) { fThreshold = threshold; }
   void SetUseSimpleOfflinePatches(Bool_t doUse = kTRUE) { fUseSimpleOffline = doUse; }
+  void SetUseRecalcPatches(Bool_t doUse = kTRUE) { fUseRecalc = doUse; }
 
+  /**
+   * @brief Apply selection of the given trigger patch according to the selections described in the object
+   *
+   * @param[in] patch the trigger patch to check
+   * @return the decision (true if selected, false otherwise)
+   */
   Bool_t IsSelected(const AliEMCALTriggerPatchInfo * const patch) const;
+
+  /**
+   * @brief Compare two patches according to the energy measure specified in the cut object
+   *
+   * @param[in] first the first patch
+   * @param[in] second the second patch
+   * @return the result of the comparison (0 if equal, 1 if the first patch has a larger primitive,
+   *          -1 if the second patch has a larger primitive)
+   */
   Int_t CompareTriggerPatches(const AliEMCALTriggerPatchInfo *first, const AliEMCALTriggerPatchInfo *second) const;
 
 protected:
+
+  /**
+   * @brief Return (energy) measure we cut on, depending on the selection method specified
+   *
+   * @param[in] patch The patch from which to obtain the value
+   * @return The energy measure of the patch
+   */
   Double_t GetCutPrimitive(const AliEMCALTriggerPatchInfo * const patch) const;
+
+  /**
+   * @brief Select type of the patch according the definitions in the header file
+   *
+   * @param[in] patch the patch to be checked
+   * @return selection result (true ig the patch is selected)
+   */
   Bool_t SelectPatchType(const AliEMCALTriggerPatchInfo * const patch) const;
 
-  SelectionMethod_t     fSelectionMethod;           // Variable to cut on
-  PatchType_t           fPatchType;                 // Type of the patch to be selected
-  Double_t              fThreshold;                 // Threshold used
-  Bool_t                fUseSimpleOffline;          // Request simple offline patches
+  /**
+   * @brief Select detector acceptance
+   *
+   * Detector acceptance can be either of
+   * - EMCAL
+   * - DCAL
+   * - EMCAL and DCAL
+   * @param patch Trigger patch to be checked
+   * @return True if the patch is within the acceptance, false otherwise
+   */
+  Bool_t SelectAcceptance(const AliEMCALTriggerPatchInfo * const patch) const;
+
+  SelectionMethod_t     fSelectionMethod;           ///< Variable to cut on
+  PatchType_t           fPatchType;                 ///< Type of the patch to be selected
+  AcceptanceType_t      fAcceptanceType;            ///< Acceptance type (EMCAL or DCAL acceptance)
+  Double_t              fThreshold;                 ///< Threshold used
+  Bool_t                fUseSimpleOffline;          ///< Request simple offline patches
+  Bool_t                fUseRecalc;                 ///< Request recalc patch
 
   ClassDef(AliEmcalTriggerSelectionCuts, 1);         // Cuts for the EMCAL Trigger selection
 };
+
+}
+}
 
 #endif /* ALIEMCALTRIGGERSELECTIONCUTS_H */

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelectionCuts.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerSelectionCuts.h
@@ -138,7 +138,9 @@ protected:
   Bool_t                fUseSimpleOffline;          ///< Request simple offline patches
   Bool_t                fUseRecalc;                 ///< Request recalc patch
 
+  /// \cond CLASSIMP
   ClassDef(AliEmcalTriggerSelectionCuts, 1);         // Cuts for the EMCAL Trigger selection
+  /// \endcond
 };
 
 }

--- a/PWG/EMCAL/EMCALtrigger/PWGEMCALtriggerLinkDef.h
+++ b/PWG/EMCAL/EMCALtrigger/PWGEMCALtriggerLinkDef.h
@@ -8,12 +8,15 @@
 #pragma link C++ class AliEmcalTriggerMakerKernel+;
 #pragma link C++ class AliEmcalTriggerMakerTask+;
 #pragma link C++ class AliEmcalTriggerSetupInfo+;
-#pragma link C++ class AliEmcalTriggerDecision+;
-#pragma link C++ class AliEmcalTriggerDecisionContainer+;
-#pragma link C++ class AliEmcalTriggerSelectionCuts++;
-#pragma link C++ class AliEmcalTriggerSelection+;
 #pragma link C++ class AliEmcalTriggerQATask+;
 #pragma link C++ class AliEMCALTriggerOfflineQAPP+;
 #pragma link C++ class AliEMCALTriggerOfflineLightQAPP+;
 #pragma link C++ class AliEMCALTriggerPatchADCInfoAP+;
+
+#pragma link C++ namespace PWG;
+#pragma link C++ namespace PWG::EMCAL;
+#pragma link C++ class PWG::EMCAL::AliEmcalTriggerDecision+;
+#pragma link C++ class PWG::EMCAL::AliEmcalTriggerDecisionContainer+;
+#pragma link C++ class PWG::EMCAL::AliEmcalTriggerSelectionCuts++;
+#pragma link C++ class PWG::EMCAL::AliEmcalTriggerSelection+;
 #endif

--- a/PWG/EMCAL/macros/AddEmcalTriggerSelectionTask.C
+++ b/PWG/EMCAL/macros/AddEmcalTriggerSelectionTask.C
@@ -1,0 +1,21 @@
+PWG::EMCAL::AliAnalysisTaskEmcalTriggerSelection *AddEmcalTriggerSelectionTask(TString suffix = "") {
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if(!mgr) {
+    Error("AddEmcalTriggerSelectionTask", "No analysis manager available");
+    return NULL;
+  }
+
+  TString taskname("EmcalTriggerSelectionTask"), outfilename(TString::Format("%s:EmcalTriggerSelectionTask", mgr->GetCommonFileName()));
+
+  if(suffix.Length()){
+    taskname += "_" + suffix;
+    outfilename += "_" + suffix;
+  }
+  PWG::EMCAL::AliAnalysisTaskEmcalTriggerSelection *trgseltask = new PWG::EMCAL::AliAnalysisTaskEmcalTriggerSelection(taskname);
+  mgr->AddTask(trgseltask);
+
+  mgr->ConnectInput(trgseltask, 0, mgr->GetCommonInputContainer());
+  mgr->ConnectOutput(trgseltask, 1, mgr->CreateContainer(taskname, AliEmcalList::Class(), AliAnalysisManager::kOutputContainer, outfilename));
+
+  return trgseltask;
+}


### PR DESCRIPTION
The trigger selection framework is used to select an emcal triggered event
based on trigger patch information (of particluar need for MC, but also
of interest for data for cleanup).

Changes:
- Move to PWG::EMCAL
- Move doxygen documentation to header
- Add acceptance type to trigger selection in order to distinguish EMCAL/DCAL acceptance
- Move classes of task in the namespacen PWG::EMCAL
- Create add macro for the task
- Make Autoconfiguration methods based on period string (currently 2016-only)
- Add option to cut on smeared energy
- Add handling for recalc patches