### PR TITLE
Small bug fixes for AliYAMLConfiguration

### DIFF
--- a/PWG/Tools/AliYAMLConfiguration.cxx
+++ b/PWG/Tools/AliYAMLConfiguration.cxx
@@ -41,6 +41,7 @@ AliYAMLConfiguration::AliYAMLConfiguration(const std::string prefixString, const
 bool AliYAMLConfiguration::AddEmptyConfiguration(const std::string configurationName)
 {
   YAML::Node node;
+  AliInfoStream() << "Adding configuration \"" << configurationName << "\" as an empty YAML node.\n";
   return AddConfiguration(node, configurationName);
 }
 
@@ -97,7 +98,7 @@ bool AliYAMLConfiguration::AddConfiguration(const YAML::Node node, std::string c
   }
 
   // Add the configuration
-  AliInfoStream() << "Adding configuration \"" << configurationName << "\"\n.";
+  AliDebugStream(2) << "Adding configuration \"" << configurationName << "\".\n";
   fConfigurations.push_back(std::make_pair(configurationName, node));
   return true;
 }
@@ -110,7 +111,7 @@ bool AliYAMLConfiguration::AddConfiguration(const YAML::Node node, std::string c
  *
  * @return True if write was successful.
  */
-bool AliYAMLConfiguration::WriteConfiguration(const int index, const std::string filename) const
+bool AliYAMLConfiguration::WriteConfiguration(const std::string filename, const int index) const
 {
   // Write to a local temp filename
   TUUID tempUUID;
@@ -138,9 +139,9 @@ bool AliYAMLConfiguration::WriteConfiguration(const int index, const std::string
  *
  * @return True if write was successful.
  */
-bool AliYAMLConfiguration::WriteConfiguration(const std::string configurationName, const std::string filename) const
+bool AliYAMLConfiguration::WriteConfiguration(const std::string filename, const std::string configurationName) const
 {
-  return WriteConfiguration(GetConfigurationIndexByName(configurationName, fConfigurations), filename);
+  return WriteConfiguration(filename, GetConfigurationIndexByName(configurationName, fConfigurations));
 }
 
 /**
@@ -187,9 +188,9 @@ void AliYAMLConfiguration::SetupReadingConfigurationFilePath(std::string & filen
       if (fileIdentifier != "") {
         localFilename = fileIdentifier + "." + localFilename;
       }
-      // Add UUID to ensure there are no conflicts if multiple correction tasks have the same configuration file name
+      // Add UUID to ensure there are no conflicts if multiple yaml configs have the same configuration file name
       TUUID tempUUID;
-      localFilename = ":" + localFilename;
+      localFilename = "." + localFilename;
       localFilename = tempUUID.AsString() + localFilename;
 
       // Copy file
@@ -202,12 +203,13 @@ void AliYAMLConfiguration::SetupReadingConfigurationFilePath(std::string & filen
 }
 
 /**
- * Write a selected YAML configuration to file.
+ * Write a selected YAML configuration to file. Practically, it copies a local file to the desired location]
+ * to ensure seamless access to AliEn.
  *
  * @param[in] filename Filename to which the configuration should be written.
  * @param[in] localFilename Filename where the configuration was written locally.
  */
-void AliYAMLConfiguration::WriteConfigurationToFilePath(std::string filename, const std::string localFilename) const
+void AliYAMLConfiguration::WriteConfigurationToFilePath(const std::string localFilename, std::string filename) const
 {
   bool cannotWriteFile = false;
   if (localFilename == "") {

--- a/PWG/Tools/AliYAMLConfiguration.h
+++ b/PWG/Tools/AliYAMLConfiguration.h
@@ -408,23 +408,26 @@ bool AliYAMLConfiguration::GetProperty(YAML::Node & node, YAML::Node & sharedPar
     {
       // Retrieve node and then recurse
       YAML::Node tempNode = node[nodeName];
-      AliDebugGeneralStream("AliYAMLConfiguration", 2) << "Retrieveing parameter \"" << tempPropertyName << "\" by going a node deeper with node \"" << nodeName << "\".\n";
+      AliDebugGeneralStream("AliYAMLConfiguration", 2) << "Attempting to retrieving property \"" << tempPropertyName << "\" by going a node deeper with node \"" << nodeName << "\".\n";
       returnValue = GetProperty(tempNode, sharedParametersNode, configurationName, tempPropertyName, property);
     }
-    else
+
+    // Check for the specialization if the nodeName is undefined.
+    // Alternatively, if the value was not returned successfully, we should also check for the specialization
+    //   such as inheritnace for input objects.
+    if (node[nodeName].IsDefined() == false || returnValue == false)
     {
       // Check for specialization
       if ((delimiterPosition = nodeName.find(specializationDelimiter)) != std::string::npos)
       {
         std::string specializationNodeName = nodeName.substr(0, delimiterPosition);
         YAML::Node tempNode = node[specializationNodeName];
-        AliDebugGeneralStream("AliYAMLConfiguration", 2) << "Retrieving parameter \"" << tempPropertyName << "\" by going a node deeper through dropping the specializtion and using node \"" << specializationNodeName << "\".\n";
+        AliDebugGeneralStream("AliYAMLConfiguration", 2) << "Attempting to retrieving property \"" << tempPropertyName << "\" by going a node deeper through dropping the specializtion and using node \"" << specializationNodeName << "\".\n";
         returnValue = GetProperty(tempNode, sharedParametersNode, configurationName, tempPropertyName, property);
       }
       else {
         returnValue = false;
       }
-
     }
   }
   else

--- a/PWG/Tools/AliYAMLConfiguration.h
+++ b/PWG/Tools/AliYAMLConfiguration.h
@@ -123,8 +123,8 @@ class AliYAMLConfiguration : public TObject {
   bool WriteProperty(std::string propertyName, T & property, std::string configurationName = "");
   #endif
 
-  bool WriteConfiguration(const int i, const std::string filename) const;
-  bool WriteConfiguration(const std::string name, const std::string filename) const;
+  bool WriteConfiguration(const std::string filename, const int i) const;
+  bool WriteConfiguration(const std::string filename, const std::string configurationName) const;
 
   void PrintConfiguration(int i = 0) const;
   void PrintConfiguration(std::string name) const;
@@ -136,7 +136,7 @@ class AliYAMLConfiguration : public TObject {
   // File utilities
   inline bool DoesFileExist(const std::string & filename) const;
   void SetupReadingConfigurationFilePath(std::string & filename, const std::string fileIdentifier) const;
-  void WriteConfigurationToFilePath(std::string filename, std::string localFilename) const;
+  void WriteConfigurationToFilePath(const std::string localFilename, std::string filename) const;
   // Configuration utilities
   template<typename T>
   int GetConfigurationIndexByName(const std::string name, const std::vector<std::pair<std::string, T>> & configurations) const;
@@ -498,6 +498,11 @@ bool AliYAMLConfiguration::WriteProperty(std::string propertyName, T & property,
   if (configurationName != "")
   {
     configurationIndex = GetConfigurationIndexByName(configurationName, fConfigurations);
+  }
+
+  if (fConfigurations.size() == 0) {
+    AliErrorStream() << "No configurations available! Property will not be written!\n";
+    return false;
   }
 
   std::pair<std::string, YAML::Node> & configPair = fConfigurations.at(configurationIndex);


### PR DESCRIPTION
Two minor bug fixes:
- Handle corner case in retrieving a specialized property
- Fix argument order for writing a configuration

@aiola - The corner case fixed here is subtle, but without the fix, it makes a common embedding configuration difficult, so could you please merge this before the tag? Thanks!