### PR TITLE
Minor Jet Framework fixes

### DIFF
--- a/PWG/JETFW/AliEmcalJet.cxx
+++ b/PWG/JETFW/AliEmcalJet.cxx
@@ -498,7 +498,7 @@ AliVCluster* AliEmcalJet::GetLeadingCluster(TClonesArray* clusters) const
 {
   AliVCluster* maxCluster = 0;
   for (Int_t i = 0; i < GetNumberOfClusters(); i++) {
-    AliVCluster* cluster = ClusterAt(i, clusters);
+    AliVCluster* cluster = Cluster(i);
     if (!cluster) {
       AliError(Form("Unable to find jet cluster %d (global index %d) in the jet", i, ClusterAt(i)));
       continue;

--- a/PWGJE/EMCALJetTasks/macros/AddTaskJetResponseMaker.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskJetResponseMaker.C
@@ -101,8 +101,11 @@ AliJetResponseMaker* AddTaskJetResponseMaker(
   jetCont2->SetFlavourCut(jetTagging);
   jetCont2->SetMaxTrackPt(1000); // disable default 100 GeV/c track cut for particle level jets
 
-    
+#ifdef __CLING__
+  jetTask->SetMatching(static_cast<AliJetResponseMaker::MatchingType>(matching), maxDistance1, maxDistance2);
+#else
   jetTask->SetMatching(matching, maxDistance1, maxDistance2);
+#endif
   jetTask->SetVzRange(-10,10);
   jetTask->SetIsPythia(kTRUE);
   jetTask->SetPtHardBin(ptHardBin);


### PR DESCRIPTION
Fix a ClusterAt() -> Cluster() in AliEmcalJet which I missed in a recent change. Note that it only would have caused problems for EMCal embedding, so it didn't adversely affect anyone's results.

Also enable ROOT 6 with the jet response maker