### PR TITLE
PWGDQ fix MC AOD + reorder GetNch in Helper

### DIFF
--- a/PWGDQ/dielectron/core/AliDielectron.cxx
+++ b/PWGDQ/dielectron/core/AliDielectron.cxx
@@ -1614,6 +1614,7 @@ void AliDielectron::FillMCHistograms(const AliVEvent *ev) {
   TString className,className2,className3;
   Double_t values[AliDielectronVarManager::kNMaxValues]={0.};
   AliDielectronVarManager::SetFillMap(fUsedVars);
+  // AliDielectronVarManager::Fill(ev, values);
   // not needed to get event information here, because done in FillVarVParticle() [and FillVarDielectronPair()].
 
   //loop over all added mc signals

--- a/PWGDQ/dielectron/core/AliDielectronEvtVsTrkHist.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronEvtVsTrkHist.cxx
@@ -4,7 +4,7 @@
  * @Email:  pdillens@cern.ch
  * @Filename: AliDielectronEvtVsTrkHist.cxx
  * @Last modified by:   pascaldillenseger
- * @Last modified time: 2017-09-18, 15:27:33
+ * @Last modified time: 2017-10-02, 11:21:56
  */
 
 
@@ -43,6 +43,7 @@ fNtracksITS(0),
 fNtracksTPC(0),
 fHistoList(0x0),
 fSparseObjs{0x0},
+fPIDResponse(0x0),
 fMatchEffITS(0x0),
 fMatchEffTPC(0x0)
 {

--- a/PWGDQ/dielectron/core/AliDielectronHelper.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronHelper.cxx
@@ -147,36 +147,60 @@ void AliDielectronHelper::GetMaxPtAndPhi(const AliVEvent *ev, Double_t &ptMax, D
 //_____________________________________________________________________________
 Int_t AliDielectronHelper::GetNch(const AliMCEvent *ev, Double_t etaRange, Bool_t excludeJpsiDaughters){
   // determination of Nch
+  // Obsolete function see CountMCtracks
   if (!ev || ev->IsA()!=AliMCEvent::Class()) return -1;
-
   Int_t nParticles = ev->GetNumberOfTracks();
   Int_t nCh = 0;
+  if(!ev->Particle(1) && !ev->GetTrack(1))  return -1;
 
-  // count..
-  for (Int_t iMc = 0; iMc < nParticles; ++iMc) {
-    if (!ev->IsPhysicalPrimary(iMc)) continue;
+  Bool_t isAOD = kFALSE;
+  if(ev->GetTrack(1)->IsA() == AliAODMCParticle::Class()) isAOD = kTRUE;
+  if(isAOD){
+    for (Int_t iParticle = 1; iParticle < nParticles; iParticle++) {
+      AliAODMCParticle *mcPar = (AliAODMCParticle*) ev->GetTrack(iParticle);
+      if(!mcPar) continue;
+      if(!mcPar->IsPhysicalPrimary()) continue;
+      if(mcPar->Charge() == 0) continue;
 
-    TParticle* particle = ev->Particle(iMc);
-    if (!particle) continue;
-    if (particle->GetPDG()->Charge() == 0) continue;
-
-    if(excludeJpsiDaughters){
-      Int_t iMother = particle->GetMother(0);
-      if( ! (iMother < 0) ) {
-        TParticle* mother = ev->Particle(iMother);
-        if( mother && TMath::Abs( mother->GetPdgCode() ) == 443  ) continue;
+      if(excludeJpsiDaughters){
+        Int_t iMother = mcPar->GetMother();
+        if(iMother > 0){
+          AliAODMCParticle *mcParMother = (AliAODMCParticle*) ev->GetTrack(iMother);
+          if(mcParMother)
+          if(TMath::Abs(mcParMother->GetPdgCode()) == 443) continue;
+        }
       }
+      Float_t eta = mcPar->Eta();
+      if (TMath::Abs(eta) < TMath::Abs(etaRange)) nCh++;
     }
-    Float_t eta = particle->Eta();
-    if (TMath::Abs(eta) < TMath::Abs(etaRange)) nCh++;
   }
+  // count.. for ESD input
+  else{
+    for (Int_t iMc = 0; iMc < nParticles; ++iMc) {
+      if (!ev->IsPhysicalPrimary(iMc)) continue;
 
+      TParticle* particle = ev->Particle(iMc);
+      if (!particle) continue;
+      if (particle->GetPDG()->Charge() == 0) continue;
+
+      if(excludeJpsiDaughters){
+        Int_t iMother = particle->GetMother(0);
+        if( ! (iMother < 0) ) {
+          TParticle* mother = ev->Particle(iMother);
+          if( mother && TMath::Abs( mother->GetPdgCode() ) == 443  ) continue;
+        }
+      }
+      Float_t eta = particle->Eta();
+      if (TMath::Abs(eta) < TMath::Abs(etaRange)) nCh++;
+    }
+  }
   return nCh;
 }
 
 
 //_____________________________________________________________________________
-Int_t AliDielectronHelper::GetNaccTrcklts(const AliVEvent *ev, Double_t etaRange){
+Int_t AliDielectronHelper::GetNaccTrcklts(const AliVEvent *ev, Double_t etaRange)
+{
   // Compute the collision multiplicity based on AOD or ESD tracklets
   // Code taken from: AliAnalysisTaskMuonCollisionMultiplicity::ComputeMultiplicity()
   if (!ev) return -1;
@@ -207,7 +231,8 @@ Int_t AliDielectronHelper::GetNaccTrcklts(const AliVEvent *ev, Double_t etaRange
 
 
 //________________________________________________________________
-Double_t AliDielectronHelper::GetNaccTrckltsCorrected(const AliVEvent *event, Double_t uncorrectedNacc, Double_t vtxZ, Int_t type) {
+Double_t AliDielectronHelper::GetNaccTrckltsCorrected(const AliVEvent *event, Double_t uncorrectedNacc, Double_t vtxZ, Int_t type)
+{
   //
   // Correct the number of accepted tracklets based on the period and event vertex
   //
@@ -217,15 +242,15 @@ Double_t AliDielectronHelper::GetNaccTrckltsCorrected(const AliVEvent *event, Do
   Int_t period = -1;   // 0-LHC10b, 1-LHC10c, 2-LHC10d, 3-LHC10e
   Double_t refMult = 0.0;   // reference multiplicity
 
-//  if(runNo>114930 && runNo<117223) period = 0; Org Fred Kramer Analysis
+  //  if(runNo>114930 && runNo<117223) period = 0; Org Fred Kramer Analysis
   if(runNo>114736 && runNo<117224) period = 0; // LHC10b PASS4 2015
-//  if(runNo>119158 && runNo<120830) period = 1; Org Fred Kramer Analysis
+  //  if(runNo>119158 && runNo<120830) period = 1; Org Fred Kramer Analysis
   if(runNo>118358 && runNo<121041) period = 1; // LHC10c PASS4 2015
-//  if(runNo>122373 && runNo<126438) period = 2; Org Fred Kramer Analysis
+  //  if(runNo>122373 && runNo<126438) period = 2; Org Fred Kramer Analysis
   if(runNo>121693 && runNo<126439) period = 2; // LHC10d PASS4 2015
-//  if(runNo>127711 && runNo<130841) period = 3; Org Fred Kramer Analysis
+  //  if(runNo>127711 && runNo<130841) period = 3; Org Fred Kramer Analysis
   if(runNo>127102 && runNo<130851) period = 3; // LHC10e PASS4 2015
-//pp 13 TeV CJ
+  //pp 13 TeV CJ
   if(runNo>254124 && runNo<264035) period = 4; // LHC16l,16k,16i,16j,16o pass1 2016 CJ analysis
 
   if(period<0 || period>4) return uncorrectedNacc;
@@ -291,7 +316,8 @@ Int_t AliDielectronHelper::GetNacc(const AliVEvent *ev){
 }
 
 //_____________________________________________________________________________
-Double_t AliDielectronHelper::GetITSTPCMatchEff(const AliVEvent *ev, Double_t *efficiencies, Bool_t bEventPlane, Bool_t useV0Cep){
+Double_t AliDielectronHelper::GetITSTPCMatchEff(const AliVEvent *ev, Double_t *efficiencies, Bool_t bEventPlane, Bool_t useV0Cep)
+{
   // recalulate the its-tpc matching efficiecy
   if (!ev) return -1;
 
@@ -323,8 +349,8 @@ Double_t AliDielectronHelper::GetITSTPCMatchEff(const AliVEvent *ev, Double_t *e
   //   varCutsEPoutP.AddCut(AliDielectronVarManager::kQnDeltaPhiTrackTPCrpH2, 2.35, 3.15, kTRUE);
   // }
 
-// @TODO: IsSelected() sets the VarManager fgFillMap to the 'trkCutsITS' fillmap.
-// Since 'trkCutsITS' is a stack object and will be deleted, the VarManager fgFillMap goes into an undefined state.
+  // @TODO: IsSelected() sets the VarManager fgFillMap to the 'trkCutsITS' fillmap.
+  // Since 'trkCutsITS' is a stack object and will be deleted, the VarManager fgFillMap goes into an undefined state.
 
   Int_t nRecoTracks = ev->GetNumberOfTracks();
   Double_t nTPC = 0, nITS = 0;
@@ -505,49 +531,83 @@ void AliDielectronHelper::RotateKFParticle(AliKFParticle * kfParticle,Double_t a
 }
 
 //_____________________________________________________________________________
-Int_t AliDielectronHelper::GetNMothers(const AliMCEvent *ev, Double_t etaRange, Int_t pdgMother, Int_t pdgDaughter, Int_t prim){
-  // TODO: add AODs
+Int_t AliDielectronHelper::GetNMothers(const AliMCEvent *ev, Double_t etaRange, Int_t pdgMother, Int_t pdgDaughter, Int_t prim)
+{
+  // Obsolete function see CountMCtracks
   // counting number of mother particles generated in given eta range and 2 particle decay
   if (!ev || ev->IsA()!=AliMCEvent::Class()) return -1;
+
+  if(!ev->Particle(1) && !ev->GetTrack(1))  return -1;
+
+  Bool_t isAOD = kFALSE;
+  if(ev->GetTrack(1)->IsA() == AliAODMCParticle::Class()) isAOD = kTRUE;
 
   Int_t nParticles = ev->GetNumberOfTracks();
   Int_t nMothers   = 0;
 
-  // count..
-  for (Int_t iMc = 0; iMc < nParticles; ++iMc) {
+  // count.. for ESDs
+  if(isAOD)
+  {
+    for (Int_t iMc = 1; iMc < nParticles; ++iMc) {
+      AliAODMCParticle *mcPar = (AliAODMCParticle*) ev->GetTrack(iMc);
+      if(!mcPar) continue;
+      if(mcPar->GetPdgCode() != pdgMother) continue;
+      if(TMath::Abs(mcPar->Eta()) > TMath::Abs(etaRange)) continue;
 
-    TParticle* particle = ev->Particle(iMc);
-    if (!particle) continue;
-    if (particle->GetPdgCode() != pdgMother)               continue;
-    if (TMath::Abs(particle->Eta()) > TMath::Abs(etaRange)) continue;
+      // Daughters
+      if(mcPar->GetNDaughters() != 2) continue;
+      if(mcPar->GetFirstDaughter() >= nParticles || mcPar->GetFirstDaughter() < 0) continue;
+      AliAODMCParticle *mcParDau1 = (AliAODMCParticle*) ev->GetTrack(mcPar->GetFirstDaughter());
+      if(!mcParDau1) continue;
+      if(TMath::Abs(mcParDau1->GetPdgCode()) != pdgDaughter) continue;
+      if(TMath::Abs(mcParDau1->Eta()) > TMath::Abs(etaRange)) continue;
 
-    if (particle->GetNDaughters() != 2)                 continue;
-    // 1st daugther
-    if (particle->GetFirstDaughter()>=nParticles ||
-	particle->GetFirstDaughter()<0             ) continue;
-
-    TParticle* dau1 = ev->Particle(particle->GetFirstDaughter());
-    if (TMath::Abs(dau1->GetPdgCode()) != pdgDaughter)     continue;
-    if (TMath::Abs(dau1->Eta()) > TMath::Abs(etaRange)) continue;
-
-    // 2nd daughter
-    if (particle->GetLastDaughter()>=nParticles ||
-	particle->GetLastDaughter()<0             ) continue;
-
-    TParticle* dau2 = ev->Particle(particle->GetLastDaughter());
-    if (TMath::Abs(dau2->GetPdgCode()) != pdgDaughter)     continue;
-    if (TMath::Abs(dau2->Eta()) > TMath::Abs(etaRange)) continue;
-
-    // primary
-    if (prim != -1) {
-      if(particle->IsPrimary() != prim) continue;
+      if(mcPar->GetLastDaughter() >= nParticles || mcPar->GetLastDaughter() < 0) continue;
+      AliAODMCParticle *mcParDau2 = (AliAODMCParticle*) ev->GetTrack(mcPar->GetLastDaughter());
+      if(!mcParDau2) continue;
+      if(TMath::Abs(mcParDau2->GetPdgCode()) != pdgDaughter) continue;
+      if(TMath::Abs(mcParDau2->Eta()) > TMath::Abs(etaRange)) continue;
+      if(prim != -1 && mcPar->IsPhysicalPrimary() != prim) continue;
+      nMothers++;
     }
-    nMothers++;
   }
+  else{
+    for (Int_t iMc = 0; iMc < nParticles; ++iMc) {
+
+      TParticle* particle = ev->Particle(iMc);
+      if (!particle) continue;
+      if (particle->GetPdgCode() != pdgMother)               continue;
+      if (TMath::Abs(particle->Eta()) > TMath::Abs(etaRange)) continue;
+
+      if (particle->GetNDaughters() != 2)                 continue;
+      // 1st daugther
+      if (particle->GetFirstDaughter()>=nParticles ||
+  	particle->GetFirstDaughter()<0             ) continue;
+
+      TParticle* dau1 = ev->Particle(particle->GetFirstDaughter());
+      if (TMath::Abs(dau1->GetPdgCode()) != pdgDaughter)     continue;
+      if (TMath::Abs(dau1->Eta()) > TMath::Abs(etaRange)) continue;
+
+      // 2nd daughter
+      if (particle->GetLastDaughter()>=nParticles ||
+  	particle->GetLastDaughter()<0             ) continue;
+
+      TParticle* dau2 = ev->Particle(particle->GetLastDaughter());
+      if (TMath::Abs(dau2->GetPdgCode()) != pdgDaughter)     continue;
+      if (TMath::Abs(dau2->Eta()) > TMath::Abs(etaRange)) continue;
+
+      // primary
+      if (prim != -1) {
+        if(particle->IsPrimary() != prim) continue;
+      }
+      nMothers++;
+    }
+  }
+  printf("HalloWelt nMothers = %d\n", nMothers);
   return nMothers;
 }
 
-//_____________________________________________________________________________
+//______________________________________________
 Bool_t AliDielectronHelper::IsInPlane(Float_t trackPhi, Float_t eventPhi){
   Float_t deltaPhi = TVector2::Phi_mpi_pi(trackPhi - eventPhi);
   if(TMath::Abs(deltaPhi) < TMath::Pi()/4 || (TMath::Abs(deltaPhi) < TMath::Pi() && TMath::Abs(deltaPhi) > TMath::Pi()*3/4) )  return kTRUE;
@@ -558,4 +618,141 @@ Bool_t AliDielectronHelper::IsOutOfPlane(Float_t trackPhi, Float_t eventPhi){
   Float_t deltaPhi = TVector2::Phi_mpi_pi(trackPhi - eventPhi);
   if(TMath::Abs(deltaPhi) > TMath::Pi()/4 && TMath::Abs(deltaPhi) < TMath::Pi()*3/4)  return kTRUE;
   else return kFALSE;
+}
+
+//______________________________________________
+void AliDielectronHelper::CountMCtracks(const AliMCEvent *ev, Double_t numbers[11], Int_t pdgMother, Int_t pdgDaughter)
+{
+  /* Count the number of charged tracks, jpsi mothers and so on in one loop (more efficient then running GetNch and GetNMothers several times from the VarManager) */
+  // 0 - N charged tracks, eta 1.6, incl jpsi daughters
+  // 1 - N charged tracks, eta 1.6, excl jpsi daughters
+  // 2 - N charged tracks, eta 0.5, incl jpsi daughters
+  // 3 - N charged tracks, eta 0.5, excl jpsi daughters
+  // 4 - N charged tracks, eta 1.0, incl jpsi daughters
+  // 5 - N charged tracks, eta 1.0, excl jpsi daughters
+  // 6 - N charged tracks, eta 0.9, incl jpsi daughters
+  // 7 - N charged tracks, eta 0.9, excl jpsi daughters
+
+  // 8 - N Jpsis, eta 0.9
+  // 9 - N Prompt Jpsis, eta 0.9
+  // 10 - N Non-Prompt Jpsis, eta 0.9
+
+  for (Int_t i = 0; i < 11; i++) {
+    numbers[i] = 0;
+  }
+
+  if (!ev || ev->IsA()!=AliMCEvent::Class()) return;
+
+  if(!ev->Particle(1) && !ev->GetTrack(1))  return;
+
+  Bool_t isAOD = kFALSE;
+  if(ev->GetTrack(1)->IsA() == AliAODMCParticle::Class()) isAOD = kTRUE;
+
+  Int_t nParticles = ev->GetNumberOfTracks();
+
+  // count.. for ESDs
+  if(isAOD)
+  {
+    for (Int_t iMc = 1; iMc < nParticles; ++iMc) {
+      AliAODMCParticle *mcPar = (AliAODMCParticle*) ev->GetTrack(iMc);
+      if(!mcPar) continue;
+      Float_t eta = mcPar->Eta();
+      if(mcPar->IsPhysicalPrimary() && mcPar->Charge() != 0){
+        // count nCharged
+        if(TMath::Abs(eta) < TMath::Abs(1.6))  numbers[0]++;
+        if(TMath::Abs(eta) < TMath::Abs(0.5))  numbers[2]++;
+        if(TMath::Abs(eta) < TMath::Abs(1.0))  numbers[4]++;
+        if(TMath::Abs(eta) < TMath::Abs(0.9))  numbers[6]++;
+        // count nCharged without jpsis daughters
+        Int_t iMother = mcPar->GetMother();
+        if(iMother > 0){
+          AliAODMCParticle *mcParMother = (AliAODMCParticle*) ev->GetTrack(iMother);
+          if(mcParMother)
+          if(TMath::Abs(mcParMother->GetPdgCode()) != pdgMother){
+            if(TMath::Abs(eta) < TMath::Abs(1.6))  numbers[1]++;
+            if(TMath::Abs(eta) < TMath::Abs(0.5))  numbers[3]++;
+            if(TMath::Abs(eta) < TMath::Abs(1.0))  numbers[5]++;
+            if(TMath::Abs(eta) < TMath::Abs(0.9))  numbers[7]++;
+          }
+        }
+      } // End of counting nCharged
+      // njpsis counting
+      if(mcPar->GetPdgCode() != pdgMother) continue;
+
+      // Daughters
+      if(mcPar->GetNDaughters() != 2) continue;
+      if(mcPar->GetFirstDaughter() >= nParticles || mcPar->GetFirstDaughter() < 0) continue;
+
+      AliAODMCParticle *mcParDau1 = (AliAODMCParticle*) ev->GetTrack(mcPar->GetFirstDaughter());
+      if(!mcParDau1) continue;
+      if(TMath::Abs(mcParDau1->GetPdgCode()) != pdgDaughter) continue;
+
+      if(mcPar->GetLastDaughter() >= nParticles || mcPar->GetLastDaughter() < 0) continue;
+      AliAODMCParticle *mcParDau2 = (AliAODMCParticle*) ev->GetTrack(mcPar->GetLastDaughter());
+      if(!mcParDau2) continue;
+      if(TMath::Abs(mcParDau2->GetPdgCode()) != pdgDaughter) continue;
+
+      if((TMath::Abs(eta) > TMath::Abs(0.9)) && (TMath::Abs(mcParDau1->Eta()) > TMath::Abs(0.9)) && (TMath::Abs(mcParDau2->Eta()) > TMath::Abs(0.9)))
+      {
+        numbers[8]++;
+        if(mcPar->IsPhysicalPrimary()) numbers[9]++;
+        if(!mcPar->IsPhysicalPrimary()) numbers[10]++;
+      }
+    }
+  }
+  else{
+    for (Int_t iMc = 0; iMc < nParticles; ++iMc) {
+      // Ncharged counting
+      TParticle* particle = ev->Particle(iMc);
+      if(!particle) continue;
+      Float_t eta = particle->Eta();
+      if (ev->IsPhysicalPrimary(iMc))
+      {
+        if (particle->GetPDG()->Charge() != 0)
+        {
+          if(TMath::Abs(eta) < TMath::Abs(1.6))  numbers[0]++;
+          if(TMath::Abs(eta) < TMath::Abs(0.5))  numbers[2]++;
+          if(TMath::Abs(eta) < TMath::Abs(1.0))  numbers[4]++;
+          if(TMath::Abs(eta) < TMath::Abs(0.9))  numbers[6]++;
+        }
+        Int_t iMother = particle->GetMother(0);
+        if(iMother >= 0)
+        {
+          TParticle* mother = ev->Particle(iMother);
+          if( !mother || TMath::Abs( mother->GetPdgCode() ) != pdgMother  )
+          {
+            if(TMath::Abs(eta) < TMath::Abs(1.6))  numbers[1]++;
+            if(TMath::Abs(eta) < TMath::Abs(0.5))  numbers[3]++;
+            if(TMath::Abs(eta) < TMath::Abs(1.0))  numbers[5]++;
+            if(TMath::Abs(eta) < TMath::Abs(0.9))  numbers[7]++;
+          }
+        }
+      } // end of n charged counting
+
+      //njpsis counting
+      if (particle->GetPdgCode() != pdgMother)               continue;
+      if (particle->GetNDaughters() != 2)                 continue;
+
+      // 1st daugther
+      if (particle->GetFirstDaughter()>=nParticles ||
+    particle->GetFirstDaughter()<0             ) continue;
+      TParticle* dau1 = ev->Particle(particle->GetFirstDaughter());
+      if (TMath::Abs(dau1->GetPdgCode()) != pdgDaughter)     continue;
+
+      // 2nd daughter
+      if (particle->GetLastDaughter()>=nParticles ||
+    particle->GetLastDaughter()<0             ) continue;
+      TParticle* dau2 = ev->Particle(particle->GetLastDaughter());
+      if (TMath::Abs(dau2->GetPdgCode()) != pdgDaughter)     continue;
+
+      if (TMath::Abs(eta) > TMath::Abs(0.9)) continue;
+      if (TMath::Abs(dau1->Eta()) > TMath::Abs(0.9)) continue;
+      if (TMath::Abs(dau2->Eta()) > TMath::Abs(0.9)) continue;
+      numbers[8]++;
+      // prompt
+      if(particle->IsPrimary()) numbers[9]++;
+      // non prompt
+      if(!particle->IsPrimary()) numbers[10]++;
+    }
+  }
 }

--- a/PWGDQ/dielectron/core/AliDielectronHelper.h
+++ b/PWGDQ/dielectron/core/AliDielectronHelper.h
@@ -39,6 +39,7 @@ TVectorD* MakeArbitraryBinning(const char* bins);
 
 void RotateKFParticle(AliKFParticle * kfParticle,Double_t angle, const AliVEvent * const ev=0x0);
 Int_t GetNMothers(const AliMCEvent *ev=0x0, Double_t etaRange=0.9, Int_t pdgMother=-999, Int_t pdgDaughter=-999, Int_t prim=-1);
+  void CountMCtracks(const AliMCEvent *ev, Double_t numbers[11], Int_t pdgMother, Int_t pdgDaughter);
 
 
 }

--- a/PWGDQ/dielectron/core/AliDielectronVarManager.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronVarManager.cxx
@@ -624,6 +624,8 @@ const char* AliDielectronVarManager::fgkParticleNames[AliDielectronVarManager::k
   {"Nch05JpsiExcl",           "N_{ch} #cbar_{#||{#eta}<0.5} without J/#psi daughters ",  ""},
   {"Nch10",                  "N_{ch} #cbar_{#||{#eta}<1.0}",                       ""},
   {"Nch10JpsiExcl",           "N_{ch} #cbar_{#||{#eta}<1.0} without J/#psi daughters ",  ""},
+  {"Nch09",                  "N_{ch} #cbar_{#||{#eta}<0.9}",                       ""},
+  {"Nch09JpsiExcl",           "N_{ch} #cbar_{#||{#eta}<0.9} without J/#psi daughters ",  ""},
   {"Centrality",             "centrality_{V0M}",                                  "(%)"},
   {"CentralityV0A",          "centrality_{V0A}",                                  "(%)"},
   {"CentralityV0C",          "centrality_{V0C}",                                  "(%)"},

--- a/PWGDQ/dielectron/core/AliDielectronVarManager.h
+++ b/PWGDQ/dielectron/core/AliDielectronVarManager.h
@@ -651,6 +651,8 @@ public:
     kNch05JpsiExcl,          // MC true number of charged particles in |eta|<0.5 without J/psi daughter tracks
     kNch10,                  // MC true number of charged particles in |eta|<1.0
     kNch10JpsiExcl,          // MC true number of charged particles in |eta|<1.0 without J/psi daughter tracks
+    kNch09,                  // MC true number of charged particles in |eta|<1.0
+    kNch09JpsiExcl,          // MC true number of charged particles in |eta|<1.0 without J/psi daughter tracks
 
     kCentrality,             // event centrality fraction V0M
     kCentralityV0A,          // event centrality fraction V0A
@@ -2519,7 +2521,6 @@ inline void AliDielectronVarManager::FillVarVEvent(const AliVEvent *event, Doubl
 
     // VZERO event plane
     TVector2 qvec;
-    // TVector2 *qVecQnFramework;
     Double_t qx = 0, qy = 0;
 
     ep->CalculateVZEROEventPlane(event,10, 2, qx, qy);    qvec.Set(qx,qy);
@@ -2911,16 +2912,33 @@ inline void AliDielectronVarManager::FillVarMCEvent(const AliMCEvent *event, Dou
   values[AliDielectronVarManager::kYvPrimMCtruth]       = values[AliDielectronVarManager::kYvPrim];
   values[AliDielectronVarManager::kZvPrimMCtruth]       = values[AliDielectronVarManager::kZvPrim];
   // Fill AliMCEvent interface specific information
-  values[AliDielectronVarManager::kNch]   = AliDielectronHelper::GetNch(event, 1.6);
-  values[AliDielectronVarManager::kNchJpsiExcl]   = AliDielectronHelper::GetNch(event, 1.6, kTRUE);
-  values[AliDielectronVarManager::kNch05] = AliDielectronHelper::GetNch(event, 0.5);
-  values[AliDielectronVarManager::kNch05JpsiExcl] = AliDielectronHelper::GetNch(event, 0.5, kTRUE);
-  values[AliDielectronVarManager::kNch10] = AliDielectronHelper::GetNch(event, 1.0);
-  values[AliDielectronVarManager::kNch10JpsiExcl] = AliDielectronHelper::GetNch(event, 1.0, kTRUE);
+  Double_t numbers[11] = {0};
 
-  values[AliDielectronVarManager::kNumberOfJPsis] = AliDielectronHelper::GetNMothers(event, 0.9, 443, 11);
-  values[AliDielectronVarManager::kNumberOfJPsisPrompt]  = AliDielectronHelper::GetNMothers(event, 0.9, 443, 11, 1);
-  values[AliDielectronVarManager::kNumberOfJPsisNPrompt] = AliDielectronHelper::GetNMothers(event, 0.9, 443, 11, 0);
+  AliDielectronHelper::CountMCtracks(event, numbers, 443, 11);
+  printf("HalloWelt Nch = %f\n", numbers[0]);
+  values[AliDielectronVarManager::kNch]           = numbers[0];
+  values[AliDielectronVarManager::kNchJpsiExcl]   = numbers[1];
+  values[AliDielectronVarManager::kNch05]         = numbers[2];
+  values[AliDielectronVarManager::kNch05JpsiExcl] = numbers[3];
+  values[AliDielectronVarManager::kNch10]         = numbers[4];
+  values[AliDielectronVarManager::kNch10JpsiExcl] = numbers[5];
+  values[AliDielectronVarManager::kNch09]         = numbers[6];
+  values[AliDielectronVarManager::kNch09JpsiExcl] = numbers[7];
+
+  values[AliDielectronVarManager::kNumberOfJPsis]        = numbers[8];
+  values[AliDielectronVarManager::kNumberOfJPsisPrompt]  = numbers[9];
+  values[AliDielectronVarManager::kNumberOfJPsisNPrompt] = numbers[10];
+
+  // values[AliDielectronVarManager::kNch]   = AliDielectronHelper::GetNch(event, 1.6);
+  // values[AliDielectronVarManager::kNchJpsiExcl]   = AliDielectronHelper::GetNch(event, 1.6, kTRUE);
+  // values[AliDielectronVarManager::kNch05] = AliDielectronHelper::GetNch(event, 0.5);
+  // values[AliDielectronVarManager::kNch05JpsiExcl] = AliDielectronHelper::GetNch(event, 0.5, kTRUE);
+  // values[AliDielectronVarManager::kNch10] = AliDielectronHelper::GetNch(event, 1.0);
+  // values[AliDielectronVarManager::kNch10JpsiExcl] = AliDielectronHelper::GetNch(event, 1.0, kTRUE);
+  //
+  // values[AliDielectronVarManager::kNumberOfJPsis] = AliDielectronHelper::GetNMothers(event, 0.9, 443, 11);
+  // values[AliDielectronVarManager::kNumberOfJPsisPrompt]  = AliDielectronHelper::GetNMothers(event, 0.9, 443, 11, 1);
+  // values[AliDielectronVarManager::kNumberOfJPsisNPrompt] = AliDielectronHelper::GetNMothers(event, 0.9, 443, 11, 0);
 }
 
 inline void AliDielectronVarManager::FillVarTPCEventPlane(const AliEventplane *evplane, Double_t * const values)


### PR DESCRIPTION
Small Warning fix in AliDielectronEvtVsTrkHistos, fixed GetNch and GetNmothers in AliDielectronHelper for AODs (was broken due to fix updates for the new AliStack usage), changed the way the VarManager gets the values from GetNch and GetNmothers, now only one loop instead of eight is used to calculate the values.