### PR TITLE
JETFW: Fix cluster constituent access

### DIFF
--- a/PWG/JETFW/AliEmcalJet.cxx
+++ b/PWG/JETFW/AliEmcalJet.cxx
@@ -498,7 +498,7 @@ AliVCluster* AliEmcalJet::GetLeadingCluster(TClonesArray* clusters) const
 {
   AliVCluster* maxCluster = 0;
   for (Int_t i = 0; i < GetNumberOfClusters(); i++) {
-    AliVCluster* cluster = ClusterAt(i, clusters);
+    AliVCluster* cluster = Cluster(i);
     if (!cluster) {
       AliError(Form("Unable to find jet cluster %d (global index %d) in the jet", i, ClusterAt(i)));
       continue;


### PR DESCRIPTION
Fix a ClusterAt() -> Cluster() in AliEmcalJet which I missed in a recent
change. Note that it only would have caused problems for EMCal
embedding, so it didn't adversely affect anyone's results.