### PR TITLE
EMCal CorrFW: Add additional config on LEGO train

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
@@ -70,9 +70,15 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
   AliEmcalCorrectionTask(AliEmcalCorrectionTask && other);
   virtual ~AliEmcalCorrectionTask();
 
-  // YAML
-  void Initialize();
-  // YAML options
+  /**
+   * Initializes the Correction Task by initializing the YAML configuration and selected correction components,
+   * including setting up the input objects (cells, clusters, and tracks).
+   *
+   * This function is the main function for initialization and should be called from a run macro!
+   * Once called, most of the configuration of the correction task and the correction components is locked in,
+   * so be certain to change any additional configuration before that!
+   */
+  void Initialize(bool removeDummyTask = false);
   /// Set the path to the user configuration filename
   void SetUserConfigurationFilename(std::string name) { fUserConfigurationFilename = name; }
   /// Set the path to the default configuration filename (Expert use only! The user should set the user configuration!)
@@ -139,8 +145,28 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
   virtual void ExecOnce();
   virtual Bool_t Run();
 
-  // Add Task
+  /**
+   * EMCal Correction Task AddTask. Should be used by most users, except for those on the LEGO train
+   * (see below).
+   *
+   * @param[in] suffix Suffix string used to select components in a YAML configuration
+   *
+   * @return A new EMCal Correction Task added to the analysis manager and ready to configure.
+   */
   static AliEmcalCorrectionTask* AddTaskEmcalCorrectionTask(TString suffix = "");
+  /**
+   * Retrieve an existing correction task by name to perform further configuration. This should
+   * _ONLY_ be used on the LEGO train. The suffix passed here must be unique to identify a user.
+   *
+   * To achieve this, a dummy task is created when the configure task is called because AliAnalysisTaskCfg
+   * requires that all wagons add a task. Then, when Initialize(true) is called on the correction task, the
+   * dummy task is removed. This is a hack, but is required to work around constraints in AliAnalysisTaskCfg.
+   *
+   * @param[in] suffix Suffix string used to uniquely identify a user and find the corresponding correction task. If using a suffix with the correction task, the suffixes must match.
+   *
+   * @return An existing (usually unconfigured) EMCal Correction Task which was retrieved from the analysis manager.
+   */
+  static AliEmcalCorrectionTask* ConfigureEmcalCorrectionTaskOnLEGOTrain(TString suffix);
 
  private:
   // Utility functions
@@ -154,6 +180,8 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
   // General utilities
   BeamType GetBeamType() const;
   void PrintRequestedContainersInformation(AliEmcalContainerUtils::InputObject_t inputObjectType, std::ostream & stream) const;
+  // LEGO Train utilities
+  void RemoveDummyTask() const;
 
   // Retrieve objects in event
   Bool_t RetrieveEventObjects();

--- a/PWG/EMCAL/READMEemcCorrections.txt
+++ b/PWG/EMCAL/READMEemcCorrections.txt
@@ -23,6 +23,7 @@ The following correction components are available:
 - [ClusterNonLinearity](\ref AliEmcalCorrectionClusterNonLinearity) -- Corrects cluster energy for non-linear response.
 - [ClusterTrackMatcher](\ref AliEmcalCorrectionClusterTrackMatcher) -- Matches each track to a single cluster, if they are in close enough proximity.
 - [ClusterHadronicCorrection](\ref AliEmcalCorrectionClusterHadronicCorrection) -- For clusters that have one or more matched tracks, reduces the cluster energy in order to avoid overestimating the particle's energy.
+- [PHOSCorrection](\ref AliEmcalCorrectionPHOSCorrection) -- Perform PHOS correction via an interface to the PHOS tender.
 
 This new correction task unifies what was previously done by tasks such as:
  - [EMCal Tender](\ref AliEmcalTenderTask)
@@ -58,7 +59,7 @@ For the instructions, please see \subpage READMEemcCorrectionsChange.
 To enable the correction task, add the following lines to your run macro:
 
 ~~~{.cxx}
-AliEmcalCorrectionTask * correctionTask = AddTaskEmcalCorrectionTask();
+AliEmcalCorrectionTask * correctionTask = AliEmcalCorrectionTask::AddTaskEmcalCorrectionTask();
 correctionTask->SelectCollisionCandidates(kPhysSel);
 // Set the user configuration file, assuming that your file is called "userConfiguration.yaml" and is located in
 // the current directory. This also supports alien:// paths!
@@ -68,13 +69,29 @@ correctionTask->SetUserConfigurationFilename("userConfiguration.yaml");
 correctionTask->Initialize();
 ~~~
 
-Don't forget to also load the macro with:
+## LEGO Train Wagon                                             {#emcCorrectionsLEGOTrainWagon}
+
+There are some special procedures for the LEGO train. There will be a centralized EMCal Correction Task wagon which
+contains standard settings such as physics selection, etc. Then the user will create a wagon which calls
+`PWG/EMCAL/macros/ConfigureEmcalCorrectionTaskOnLEGOTrain(std::string suffix)`. This will return an EMCal Correction Task
+for you to configure with your particular YAML configuration file and then initialize.
+
+To setup this wagon, use the macro listed above. One argument is required: the suffix. This suffix should be some unique
+identifier for your analysis - it could be your name, your analysis, whatever you like. The precise value only matters
+if you are using [specialization](\ref emcCorrectionsSpecialization) - in such a case, your suffix for the configuration
+wagon must match the specialization suffix.
+
+Then in the macro customization of your configuration wagon, you specify your YAML configuration file and initialize
+the configuration. It should looks something like the following:
 
 ~~~{.cxx}
-gROOT->LoadMacro("$ALICE_PHYSICS/PWG/EMCAL/macros/AddTaskEmcalCorrectionTask.C");
+// Set your user configuration
+__R_ADDTASK__->SetUserConfigurationFilename("userConfiguration.yaml");
+// It is extremely important to pass "true" to Initialize().
+__R_ADDTASK__->Initialize(true);
 ~~~
 
-# Configuring Corrections                                      {#configureEMCalCorrections}
+# Configuring Corrections                                       {#configureEMCalCorrections}
 
 The corrections configuration file is specified via a file written in the YAML markup language. YAML is quite
 readable and is commonly used for configuration files. Although it should be straightforward to read and write,
@@ -267,7 +284,7 @@ Correction2:
 
 In the example, any change to ``aMinimumValue`` will be propagated to ``exampleValue`` in ``Correction1`` and ``anotherExample`` in ``Correction2``. Note that the parameter name (here, ``aMinimumValu``) can be anything that the user desires. When setting the value, don't forget to prepend "sharedParameters:" (in our example, "sharedParameters:aMinimumValu")!
 
-#### Running multiple corrections at once ("specializing")
+#### Running multiple corrections at once ("specializing")                      {#emcCorrectionsSpecialization}
 
 Often, a user would like to run two nearly identical corrections. For instance, one could run two clusterizers with the same configuration, but perhaps different input cells and output clusters. In such a case, the clusterizer can be "specialized", such that each of the two clusterizers will inherit the same settings except for the cells. Consider the following example YAML configuration file:
 

--- a/PWG/EMCAL/macros/ConfigureEmcalCorrectionTaskOnLEGOTrain.C
+++ b/PWG/EMCAL/macros/ConfigureEmcalCorrectionTaskOnLEGOTrain.C
@@ -1,0 +1,4 @@
+AliEmcalCorrectionTask * ConfigureEmcalCorrectionTaskOnLEGOTrain(TString suffix = "")
+{
+  return AliEmcalCorrectionTask::ConfigureEmcalCorrectionTaskOnLEGOTrain(suffix);
+}


### PR DESCRIPTION
New function to retrieve an existing correction task so that it can be
configured further in a different wagon on the LEGO train.

To achieve this, a dummy task is created when the configure task is
called because AliAnalysisAlien requires that all wagons add a task.
Then, when Initialize(true) is called on the correction task, the dummy
task is removed.

cc: @mfasDa , @jdmulligan , @aiola 