### PR TITLE
Fix AddTask

### DIFF
--- a/PWGPP/EMCAL/macros/AddTaskEMCALAlig.C
+++ b/PWGPP/EMCAL/macros/AddTaskEMCALAlig.C
@@ -7,7 +7,7 @@
 /// \author Henrique Zanoli <Henrique.Zanoli@cern.ch>, University of Sao Paulo and Utrecht University
 ///
 
-AliAnalysisTaskEMCALAlig* AddTaskEmcalAlig(
+AliAnalysisTaskEMCALAlig* AddTaskEMCALAlig(
                                            const char *ntracks            = "usedefault",
                                            const char *nclusters          = "usedefault",
                                            const char* ncells             = "usedefault",


### PR DESCRIPTION
The AddTask is case sensitive in the LEGO train system, so it is needed to match the exact name on the AddTask.