### PR TITLE
Primary vertex position for selected events with D mesons

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSEHFQA.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEHFQA.cxx
@@ -234,6 +234,9 @@ AliAnalysisTaskSEHFQA::AliAnalysisTaskSEHFQA():AliAnalysisTaskSE()
   , fHisxvtxSelEv(0)
   , fHisyvtxSelEv(0)
   , fHiszvtxSelEv(0)
+  , fHisxvtxSelEvWithD(0)
+  , fHisyvtxSelEvWithD(0)
+  , fHiszvtxSelEvWithD(0)
   , fHisWhichVert(0)
   , fHisWhichVertSelEv(0)
   , fHisTrigCent(0)
@@ -244,6 +247,7 @@ AliAnalysisTaskSEHFQA::AliAnalysisTaskSEHFQA():AliAnalysisTaskSE()
   , fHisnClsITSvsNtrackletsSel(0)
   , fHiszvtxvsSPDzvtx(0)
   , fHiszvtxvsSPDzvtxSel(0)
+  , fHiszvtxvsSPDzvtxSelWithD(0)
   , fHisFEvents(0)
   , fHisTPCVZE_AngleQ(0)
   , fHisCentVsMultRPS(0)
@@ -415,6 +419,9 @@ AliAnalysisTaskSEHFQA::AliAnalysisTaskSEHFQA(const char *name, AliAnalysisTaskSE
   , fHisxvtxSelEv(0)
   , fHisyvtxSelEv(0)
   , fHiszvtxSelEv(0)
+  , fHisxvtxSelEvWithD(0)
+  , fHisyvtxSelEvWithD(0)
+  , fHiszvtxSelEvWithD(0)
   , fHisWhichVert(0)
   , fHisWhichVertSelEv(0)
   , fHisTrigCent(0)
@@ -425,6 +432,7 @@ AliAnalysisTaskSEHFQA::AliAnalysisTaskSEHFQA(const char *name, AliAnalysisTaskSE
   , fHisnClsITSvsNtrackletsSel(0)
   , fHiszvtxvsSPDzvtx(0)
   , fHiszvtxvsSPDzvtxSel(0)
+  , fHiszvtxvsSPDzvtxSelWithD(0)
   , fHisFEvents(0)
   , fHisTPCVZE_AngleQ(0)
   , fHisCentVsMultRPS(0)
@@ -1262,6 +1270,9 @@ void AliAnalysisTaskSEHFQA::UserCreateOutputObjects()
     fHisxvtxSelEv=new TH1F("hxvtxSelEv", "Distribution of x_{VTX} Selected Ev;x_{VTX} [cm];Entries",800,-1,1);
     fHisyvtxSelEv=new TH1F("hyvtxSelEv", "Distribution of y_{VTX} Selected Ev;y_{VTX} [cm];Entries",800,-1,1);
     fHiszvtxSelEv=new TH1F("hzvtxSelEv", "Distribution of z_{VTX} Selected Ev;z_{VTX} [cm];Entries",800,-30,30);
+    fHisxvtxSelEvWithD=new TH1F("hxvtxSelEvWithD", "Distribution of x_{VTX} Selected Ev w/ D mesons;x_{VTX} [cm];Entries",800,-1,1);
+    fHisyvtxSelEvWithD=new TH1F("hyvtxSelEvWithD", "Distribution of y_{VTX} Selected Ev w/ D mesons;y_{VTX} [cm];Entries",800,-1,1);
+    fHiszvtxSelEvWithD=new TH1F("hzvtxSelEvWithD", "Distribution of z_{VTX} Selected Ev w/ D mesons;z_{VTX} [cm];Entries",800,-30,30);
     fHisWhichVert=new TH1F("hWhichVert","Vertex Type",4,-1.5,2.5);
     fHisWhichVert->GetXaxis()->SetBinLabel(1,"Not found");
     fHisWhichVert->GetXaxis()->SetBinLabel(2,"Track");
@@ -1276,6 +1287,7 @@ void AliAnalysisTaskSEHFQA::UserCreateOutputObjects()
     fHisnClsITSvsNtrackletsSel=new TH2F("hnClsITSvsNtrackletsSel","number of SPD clusters vs number of SPD tracklets; n. SPD clusters; Ntracklets",200,0,6000,500,0,20000); // max values should be changed for pp data to about 200 and 1000 respectively
     fHiszvtxvsSPDzvtx=new TH2F("hzvtxvsSPDzvtx","event primary z-vertex vs SPD z-vertex - before event selection; PV z-vertex [cm]; SPD z-vertex [cm]",800,-30,30,800,-30,30);
     fHiszvtxvsSPDzvtxSel=new TH2F("hzvtxvsSPDzvtxSel","event primary z-vertex vs SPD z-vertex - after event selection; PV z-vertex [cm]; SPD z-vertex [cm]",800,-30,30,800,-30,30);
+    fHiszvtxvsSPDzvtxSelWithD=new TH2F("hzvtxvsSPDzvtxSelWithD","event primary z-vertex vs SPD z-vertex - after event selection w/ D mesons; PV z-vertex [cm]; SPD z-vertex [cm]",800,-30,30,800,-30,30);
 
     fHisTrigCent=new TH2F("hTrigCent","Centrality vs. Trigger types",24,-1.5,22.5,12,-10,110);
     fHisTrigCent->GetXaxis()->SetBinLabel(1,"All");
@@ -1409,6 +1421,9 @@ void AliAnalysisTaskSEHFQA::UserCreateOutputObjects()
     fOutputEvSelection->Add(fHisxvtxSelEv);
     fOutputEvSelection->Add(fHisyvtxSelEv);
     fOutputEvSelection->Add(fHiszvtxSelEv);
+    fOutputEvSelection->Add(fHisxvtxSelEvWithD);
+    fOutputEvSelection->Add(fHisyvtxSelEvWithD);
+    fOutputEvSelection->Add(fHiszvtxSelEvWithD);
     fOutputEvSelection->Add(fHisWhichVert);
     fOutputEvSelection->Add(fHisWhichVertSelEv);
     fOutputEvSelection->Add(fHisTrigCent);
@@ -1421,6 +1436,7 @@ void AliAnalysisTaskSEHFQA::UserCreateOutputObjects()
     fOutputEvSelection->Add(fHisnClsITSvsNtrackletsSel);
     fOutputEvSelection->Add(fHiszvtxvsSPDzvtx);
     fOutputEvSelection->Add(fHiszvtxvsSPDzvtxSel);
+    fOutputEvSelection->Add(fHiszvtxvsSPDzvtxSelWithD);
 
   }
   if(fOnOff[4]){ // FLOW OBSERVABLES
@@ -2689,6 +2705,13 @@ void AliAnalysisTaskSEHFQA::UserExec(Option_t */*option*/)
 	      if(TMath::Abs(pdgMotCode)==4) fHisNentries->Fill(11); //from primary charm
 	      if(TMath::Abs(pdgMotCode)==5) fHisNentries->Fill(12); //from beauty
 	    }
+	    // Primary vertex position for selected events with true generated (not necessarily reconstructed) D mesons
+	    const AliVVertex *vertex = aod->GetPrimaryVertex();
+	    const AliVVertex *vSPD   = aod->GetPrimaryVertexSPD();
+	    fHisxvtxSelEvWithD->Fill( vertex->GetX() );
+	    fHisyvtxSelEvWithD->Fill( vertex->GetY() );
+	    fHiszvtxSelEvWithD->Fill( vertex->GetZ() );
+	    fHiszvtxvsSPDzvtxSelWithD->Fill(vSPD->GetZ(), vertex->GetZ());
 	  }
 	}//end MC
 	fHisNentries->Fill(10);//count the candidates (data and MC)
@@ -2710,8 +2733,9 @@ void AliAnalysisTaskSEHFQA::UserExec(Option_t */*option*/)
 
 
 	  // filtering cut level
+	  Int_t isSelectedCand = fCuts->IsSelected(d, AliRDHFCuts::kAll, aod);
 
-	  if (fCuts->IsInFiducialAcceptance(d->Pt(),d->Y(pdg)) && fCuts->IsSelected(d,AliRDHFCuts::kAll,aod)) {
+	  if (fCuts->IsInFiducialAcceptance(d->Pt(),d->Y(pdg)) && isSelectedCand) {
 
 	    Int_t label=0;
 	    if(fReadMC)label=track->GetLabel();
@@ -2735,6 +2759,30 @@ void AliAnalysisTaskSEHFQA::UserExec(Option_t */*option*/)
 		  fHisd0zdauphi_filt->Fill(phidaughter,d0rphiz[1]);
 		}
 	      }
+	    }
+
+	    // If the reconstructed candidate is within mPDG +/- 40 MeV/c2, then it is considered as a good candidate
+	    Bool_t isGoodCandidate = kFALSE;
+	    Double_t pdgMass = TDatabasePDG::Instance()->GetParticle(pdg)->Mass();
+
+	    if (fDecayChannel==kD0toKpi) {
+	       if (isSelectedCand==1 || isSelectedCand==3) { // D0
+	          if (TMath::Abs((dynamic_cast<AliAODRecoDecayHF2Prong*>(d))->InvMassD0() - pdgMass) < 0.04) isGoodCandidate=kTRUE;
+	       }
+	       if (isSelectedCand==2 || isSelectedCand==3) { // D0bar
+	          if (TMath::Abs((dynamic_cast<AliAODRecoDecayHF2Prong*>(d))->InvMassD0bar() - pdgMass) < 0.04) isGoodCandidate=kTRUE;
+	       }
+	    } else if (fDecayChannel==kDplustoKpipi) {
+	       if (TMath::Abs((dynamic_cast<AliAODRecoDecayHF3Prong*>(d))->InvMassDplus() - pdgMass) < 0.04) isGoodCandidate=kTRUE;
+	    }
+
+	    if (isGoodCandidate) {
+	       const AliVVertex *vertex = aod->GetPrimaryVertex();
+	       const AliVVertex *vSPD   = aod->GetPrimaryVertexSPD();
+	       fHisxvtxSelEvWithD->Fill( vertex->GetX() );
+	       fHisyvtxSelEvWithD->Fill( vertex->GetY() );
+	       fHiszvtxSelEvWithD->Fill( vertex->GetZ() );
+	       fHiszvtxvsSPDzvtxSelWithD->Fill(vSPD->GetZ(), vertex->GetZ());
 	    }
 	  }
 
@@ -2829,7 +2877,7 @@ void AliAnalysisTaskSEHFQA::UserExec(Option_t */*option*/)
 	    }
 
 
-	    if (fCuts->IsSelected(d,AliRDHFCuts::kAll,aod) && fOnOff[1]){
+	    if (isSelectedCand && fOnOff[1]){
 	       fHisNentries->Fill(8); //candidates passing analysis cuts
 
 	    AliAODPid *pid = track->GetDetPid();

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEHFQA.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEHFQA.h
@@ -229,6 +229,9 @@ class AliAnalysisTaskSEHFQA : public AliAnalysisTaskSE
  TH1F* fHisxvtxSelEv;                        //!<!  Histo. of output slot #7 (fOutputEvSelection)
  TH1F* fHisyvtxSelEv;                        //!<!  Histo. of output slot #7 (fOutputEvSelection)
  TH1F* fHiszvtxSelEv;                        //!<!  Histo. of output slot #7 (fOutputEvSelection)
+ TH1F* fHisxvtxSelEvWithD;                   //!<!  Histo. of output slot #7 (fOutputEvSelection)
+ TH1F* fHisyvtxSelEvWithD;                   //!<!  Histo. of output slot #7 (fOutputEvSelection)
+ TH1F* fHiszvtxSelEvWithD;                   //!<!  Histo. of output slot #7 (fOutputEvSelection)
  TH1F* fHisWhichVert;                        //!<!  Histo. of output slot #7 (fOutputEvSelection)
  TH1F* fHisWhichVertSelEv;                   //!<!  Histo. of output slot #7 (fOutputEvSelection)
  TH2F* fHisTrigCent;                         //!<!  Histo. of output slot #7 (fOutputEvSelection)
@@ -239,6 +242,7 @@ class AliAnalysisTaskSEHFQA : public AliAnalysisTaskSE
  TH2F* fHisnClsITSvsNtrackletsSel;           //!<!  Histo. of output slot #7 (fOutputEvSelection)
  TH2F* fHiszvtxvsSPDzvtx;                    //!<!  Histo. of output slot #7 (fOutputEvSelection)
  TH2F* fHiszvtxvsSPDzvtxSel;                 //!<!  Histo. of output slot #7 (fOutputEvSelection)
+ TH2F* fHiszvtxvsSPDzvtxSelWithD;            //!<!  Histo. of output slot #7 (fOutputEvSelection)
  TH2F* fHisFEvents;                          //!<!  Histo. of output slot #8 (fOutputFlowObs)
  TH3F* fHisTPCVZE_AngleQ;                    //!<!  Histo. of output slot #8 (fOutputFlowObs)
  TH2F* fHisCentVsMultRPS;                    //!<!  Histo. of output slot #8 (fOutputFlowObs)
@@ -247,7 +251,7 @@ class AliAnalysisTaskSEHFQA : public AliAnalysisTaskSE
  TProfile2D *fHisQ[3];                       //!<!  Histo. of output slot #8 (fOutputFlowObs)
 
  /// \cond CLASSIMP
- ClassDef(AliAnalysisTaskSEHFQA,17); ///AnalysisTaskSE for the quality assurance of HF in hadrons
+ ClassDef(AliAnalysisTaskSEHFQA,18); ///AnalysisTaskSE for the quality assurance of HF in hadrons
  /// \endcond
 };
 


### PR DESCRIPTION
Add histograms monitoring the primary vertex position for selected events with D mesons.
- When running on MC: histograms are filled if the event contains a true D meson (from MC truth).
- When running on Data: histograms are filled if the the D candidate pass through all the selection cuts (topo+PID) and if its reconstructed invariant mass is within +/- 40 MeV/c2 around the PDG value. Currently, it works only for D+ and D0.