### PR TITLE
changes for the NanoAOD production of the PWGJEEMCAL tasks

### DIFF
--- a/PWG/DevNanoAOD/AliAnalysisNanoAODCutsJet.cxx
+++ b/PWG/DevNanoAOD/AliAnalysisNanoAODCutsJet.cxx
@@ -1,0 +1,73 @@
+
+#include "AliAnalysisNanoAODCutsJet.h"
+#include "AliAODTrack.h"
+#include "AliAODEvent.h"
+#include "AliNanoAODHeader.h"
+#include "AliNanoAODTrack.h"
+#include "AliMultSelection.h"
+#include "AliEventplane.h"
+#include "AliAnalysisNanoAODCuts.h"
+#include <iomanip>
+
+ClassImp(AliNanoAODSimpleSetterJet)
+
+AliNanoAODSimpleSetterJet::AliNanoAODSimpleSetterJet():
+  AliNanoAODCustomSetter(),
+  fArrayPythia(0x0),
+  fArrayPythiaName("")
+{
+// default const
+}
+void AliNanoAODSimpleSetterJet::SetNanoAODTrack (const AliAODTrack * aodTrack, AliNanoAODTrack * spTrack){
+
+    static  Int_t hybGlob  = AliNanoAODTrackMapping::GetInstance()->GetVarIndex("cstIsGlobalHybrid");
+    static  Int_t inIsPyt  = AliNanoAODTrackMapping::GetInstance()->GetVarIndex("cstIsPythiaTrack");
+    
+    if (aodTrack-> IsHybridGlobalConstrainedGlobal()) spTrack->SetVar(hybGlob,1.);
+    else spTrack->SetVar(hybGlob,0.);
+
+    Int_t nTracksPythia = fArrayPythia->GetEntries();
+
+    for(Int_t iTrackPyth = 0; iTrackPyth<nTracksPythia; iTrackPyth++){
+        AliAODTrack *pythTrack = (AliAODTrack*)fArrayPythia->At(iTrackPyth);
+        if((pythTrack->Pt()!=aodTrack->Pt())&&(pythTrack->Phi()!=aodTrack->Phi())) {
+            spTrack->SetVar(inIsPyt,0.);
+        }else{
+            spTrack->SetVar(inIsPyt,1.);
+            return;
+        }
+    }
+
+
+}
+
+void AliNanoAODSimpleSetterJet::SetNanoAODHeader(const AliAODEvent * event   , AliNanoAODHeader * head , TString varListHeader  ) {
+
+  AliNanoAODSimpleSetter *simleSetter = new AliNanoAODSimpleSetter();
+  simleSetter->SetNanoAODHeader(event,head,varListHeader);
+
+  fArrayPythia = static_cast<TClonesArray*> (event->FindListObject(fArrayPythiaName.Data()));
+
+  AliAODHeader *header = (AliAODHeader*)event->GetHeader();
+
+  Printf("fired trigger classes");
+  Printf(header->GetFiredTriggerClasses());
+  
+  static Int_t isSelIndex = head->GetVarIndex("cstIsEvSelected");
+  UInt_t sel = header->GetOfflineTrigger();
+  head->SetVar(isSelIndex,sel);
+
+  static Int_t indexEPV0 = head->GetVarIndex("cstEvPlaneV0");
+  static Int_t indexEPV0A = head->GetVarIndex("cstEvPlaneV0A");
+  static Int_t indexEPV0C = head->GetVarIndex("cstEvPlaneV0C");
+
+  AliEventplane *evPlane = header->GetEventplaneP();
+  Double_t EpV0 = evPlane->GetEventplane("V0" ,event);
+  Double_t EpV0A = evPlane->GetEventplane("V0A",event);
+  Double_t EpV0C = evPlane->GetEventplane("V0C",event);
+
+  head->SetVar(indexEPV0,EpV0);
+  head->SetVar(indexEPV0A,EpV0A);
+  head->SetVar(indexEPV0C,EpV0C);
+
+}

--- a/PWG/DevNanoAOD/AliAnalysisNanoAODCutsJet.h
+++ b/PWG/DevNanoAOD/AliAnalysisNanoAODCutsJet.h
@@ -1,0 +1,25 @@
+#ifndef _ALIANALYSISNANOAODCUTSANDSETTERSJET_H_
+#define _ALIANALYSISNANOAODCUTSANDSETTERSJET_H_
+
+#include "AliNanoAODCustomSetter.h"
+
+class AliNanoAODSimpleSetterJet : public AliNanoAODCustomSetter
+{
+public:
+  AliNanoAODSimpleSetterJet();
+  virtual ~AliNanoAODSimpleSetterJet(){;}
+
+  virtual void SetNanoAODHeader(const AliAODEvent * event   , AliNanoAODHeader * head ,TString varListHeader  );
+  virtual void SetNanoAODTrack (const AliAODTrack * aodTrack, AliNanoAODTrack * spTrack);
+
+  void SetArrayPythiaName(TString name) { fArrayPythiaName = name; } 
+
+private:
+  TClonesArray *fArrayPythia;
+  TString       fArrayPythiaName;  
+
+  ClassDef(AliNanoAODSimpleSetterJet, 1);
+
+};
+
+#endif /* _ALIANALYSISNANOAODCUTSANDSETTERS_H_ */

--- a/PWG/DevNanoAOD/CMakeLists.txt
+++ b/PWG/DevNanoAOD/CMakeLists.txt
@@ -35,6 +35,7 @@ set(SRCS
   AliNanoAODReplicator.cxx
   AliNanoAODTrack.cxx
   AliAnalysisNanoAODCutsCRCZDC.cxx
+  AliAnalysisNanoAODCutsJet.cxx
   )
 
 # Headers from sources

--- a/PWG/DevNanoAOD/PWGDevNanoAODLinkDef.h
+++ b/PWG/DevNanoAOD/PWGDevNanoAODLinkDef.h
@@ -13,5 +13,6 @@
 #pragma link C++ class AliAnalysisNanoAODTrackCutsCRCZDC+;
 #pragma link C++ class AliAnalysisNanoAODEventCutsCRCZDC+;
 #pragma link C++ class AliNanoAODSimpleSetterCRCZDC+;
+#pragma link C++ class AliNanoAODSimpleSetterJet+;
 
 #endif

--- a/PWGJE/EMCALJetTasks/AliNanoAODArrayMaker.cxx
+++ b/PWGJE/EMCALJetTasks/AliNanoAODArrayMaker.cxx
@@ -1,0 +1,124 @@
+#include "AliAnalysisTask.h"
+#include "AliAnalysisManager.h"
+
+#include "AliAODEvent.h"
+#include "AliNanoAODTrack.h"
+#include "AliAODTrack.h"
+
+#include <TClonesArray.h>
+
+#include "AliNanoAODArrayMaker.h"
+
+ClassImp(AliNanoAODArrayMaker)
+
+//________________________________________________________________________
+AliNanoAODArrayMaker::AliNanoAODArrayMaker(const char *name) 
+  : AliAnalysisTaskSE(name), fOutputArrayName(), fOutputArray(0), fOutputArrayPythiaName(), fPythiaArray(0), fOutputList(0x0)
+{
+  // Constructor
+
+  // Output slot #0 id reserved by the base class for AOD
+  // Output slot #1 writes into a TH1 container
+  DefineOutput(1, TList::Class());
+}
+
+//________________________________________________________________________
+void AliNanoAODArrayMaker::UserCreateOutputObjects()
+{
+  // Create histograms
+  // Called once
+
+  fOutputList = new TList();
+  fOutputList->SetOwner(kTRUE); 
+
+  fOutputArray = new TClonesArray("AliAODTrack");
+  fOutputArray->SetName(fOutputArrayName.Data());
+  Printf("%s \n", fOutputArrayName.Data());
+
+  fDataArray = new TClonesArray("AliAODTrack");
+  fDataArray->SetName(fOutputArrayDataName.Data());
+  Printf("%s \n", fOutputArrayDataName.Data());
+
+  fPythiaArray = new TClonesArray("AliAODTrack");
+  fPythiaArray->SetName(fOutputArrayPythiaName.Data());
+  Printf("%s \n", fOutputArrayPythiaName.Data());
+
+  PostData(1,fOutputList);
+
+}
+//________________________________________________________________________
+void AliNanoAODArrayMaker::UserExec(Option_t *) 
+{
+  // Main loop
+  // Called for each event
+  InputEvent()->AddObject(fOutputArray);
+  InputEvent()->AddObject(fPythiaArray);
+  InputEvent()->AddObject(fDataArray);
+
+  TClonesArray *particleArray = static_cast<TClonesArray*> (InputEvent()->FindListObject("Nanotracks"));
+  Int_t nTracks = particleArray->GetEntries();
+
+  Int_t accTracks = 0;
+  Int_t accTracksPythia = 0;
+  Int_t accTracksData = 0;
+
+  Int_t indexHybGlob = AliNanoAODTrackMapping::GetInstance()->GetVarIndex("cstIsGlobalHybrid");
+  Int_t indexIsPyth = AliNanoAODTrackMapping::GetInstance()->GetVarIndex("cstIsPythiaTrack");
+
+  fOutputArray->Clear("C");   
+  fPythiaArray->Clear("C"); 
+  fDataArray->Clear("C"); 
+
+  for(Int_t iPart=0; iPart<nTracks; iPart++){
+   AliNanoAODTrack *nanoTrack = (AliNanoAODTrack*) particleArray->At(iPart);
+    
+    if (nanoTrack->GetVar(indexIsPyth)==1){
+        new ((*fPythiaArray)[accTracksPythia]) AliAODTrack(*(GetAODTrack(nanoTrack)));
+        new ((*fOutputArray)[accTracks]) AliAODTrack(*(GetAODTrack(nanoTrack)));
+        accTracksPythia++;
+    }else{
+        new ((*fDataArray)[accTracksData]) AliAODTrack(*(GetAODTrack(nanoTrack,indexHybGlob)));
+        new ((*fOutputArray)[accTracks]) AliAODTrack(*(GetAODTrack(nanoTrack,indexHybGlob)));
+        accTracksData++;
+    }
+    accTracks++;
+  }
+}      
+
+//________________________________________________________________________
+void AliNanoAODArrayMaker::Terminate(Option_t *) 
+{
+  // Called once at the end of the query
+
+
+}
+//_____________________________________________________________________________________________________
+AliAODTrack* AliNanoAODArrayMaker::GetAODTrack(AliNanoAODTrack* track, Int_t index)
+{
+  AliAODTrack* newTrack = new AliAODTrack();
+  newTrack->SetPt(track->Pt());
+  newTrack->SetTheta(2.*atan(exp(-track->Eta()))); // the same as in AliAnalysisTaskParticleRandomizer
+  newTrack->SetPhi(track->Phi());
+  newTrack->SetCharge(track->Charge());
+  newTrack->SetLabel(track->GetLabel());
+  if (track->GetVar(index) == 1) newTrack->SetIsHybridGlobalConstrainedGlobal();
+  newTrack->SetFilterMap(track->GetFilterMap());
+
+  return newTrack;
+}
+//_____________________________________________________________________________________________________
+AliAODTrack* AliNanoAODArrayMaker::GetAODTrack(AliNanoAODTrack* track){
+
+  AliAODTrack* newTrack = new AliAODTrack();
+  newTrack->SetPt(track->Pt());
+  newTrack->SetTheta(2.*atan(exp(-track->Eta()))); // the same as in AliAnalysisTaskParticleRandomizer
+  newTrack->SetPhi(track->Phi());
+  newTrack->SetCharge(track->Charge());
+  newTrack->SetLabel(track->GetLabel());
+
+  // Hybrid tracks (compatible with LHC11h)
+  UInt_t filterMap = BIT(8) | BIT(9);
+  newTrack->SetIsHybridGlobalConstrainedGlobal();
+  newTrack->SetFilterMap(track->GetFilterMap());
+  return newTrack;
+}

--- a/PWGJE/EMCALJetTasks/AliNanoAODArrayMaker.h
+++ b/PWGJE/EMCALJetTasks/AliNanoAODArrayMaker.h
@@ -1,0 +1,46 @@
+#ifndef ALIANALYSISTASKARRAYMAKER_H
+#define ALIANALYSISTASKARRAYMAKER_H
+
+class AliNanoAODTrack;
+class TClonesArray;
+class TString;
+
+#include "AliAnalysisTaskSE.h"
+
+class AliNanoAODArrayMaker : public AliAnalysisTaskSE {
+ public:
+  AliNanoAODArrayMaker() : AliAnalysisTaskSE(), fOutputArrayName(), fOutputArray(0), fOutputList(0x0) {}
+  AliNanoAODArrayMaker(const char *name);
+  virtual ~AliNanoAODArrayMaker() {}
+  
+  virtual void   UserCreateOutputObjects();
+  virtual void   UserExec(Option_t *option);
+  virtual void   Terminate(Option_t *);
+
+  void SetOutputArrayName(const char* name) {fOutputArrayName = name;}
+  void SetOutputArrayPythiaName(const char* name) {fOutputArrayPythiaName = name;}
+  void SetOutputArrayDataName(const char* name) {fOutputArrayDataName = name;}
+
+  AliAODTrack*        GetAODTrack(AliNanoAODTrack* track, Int_t index);
+  AliAODTrack*        GetAODTrack(AliNanoAODTrack* track);
+
+ private:
+  TString             fOutputArrayName; ///
+  TClonesArray*       fOutputArray; //!<!
+
+  TString             fOutputArrayPythiaName; ///
+  TClonesArray*       fPythiaArray; //!<!
+
+  TString             fOutputArrayDataName; ///
+  TClonesArray*       fDataArray; //!<!
+    
+  TList* fOutputList;
+
+  AliNanoAODArrayMaker(const AliNanoAODArrayMaker&); // not implemented
+  AliNanoAODArrayMaker& operator=(const AliNanoAODArrayMaker&); // not implemented   
+
+  
+  ClassDef(AliNanoAODArrayMaker, 1); // example of analysis
+};
+
+#endif

--- a/PWGJE/EMCALJetTasks/CMakeLists.txt
+++ b/PWGJE/EMCALJetTasks/CMakeLists.txt
@@ -26,6 +26,7 @@ include_directories(${AliPhysics_SOURCE_DIR}/PWGJE/EMCALJetTasks
 include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/CORRFW
                     ${AliPhysics_SOURCE_DIR}/OADB
+		    ${AliPhysics_SOURCE_DIR}/PWG/DevNanoAOD
                     ${AliPhysics_SOURCE_DIR}/PWG/EMCAL/EMCALbase
                     ${AliPhysics_SOURCE_DIR}/PWG/EMCAL/EMCALtrigger
                     ${AliPhysics_SOURCE_DIR}/PWG/JETFW
@@ -66,6 +67,7 @@ set(SRCS
     AliJetRandomizerTask.cxx
     AliJetResponseMaker.cxx
     AliJetTriggerSelectionTask.cxx
+    AliNanoAODArrayMaker.cxx
     Tracks/AliAnalysisTaskEmcalTriggerBase.cxx
     Tracks/AliAnalysisTaskEmcalTriggerPosition.cxx
     Tracks/AliAnalysisTaskPtEMCalTrigger.cxx

--- a/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
+++ b/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
@@ -53,6 +53,7 @@
 #pragma link C++ class AliAnalysisTaskEmcalJetTree<AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetInfoSummaryPbPb, AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPbPb>+;
 #pragma link C++ class AliAnalysisTaskEmcalJetTree<AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetInfoSummaryPbPbCharged, AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPbPb>+;
 #pragma link C++ class AliAnalysisTaskEmcalJetTree<AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetInfoSummaryEmbedding, AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPbPb>+;
+#pragma link C++ class AliNanoAODArrayMaker+;
 
 // user task
 #pragma link C++ class AliAnalysisTaskBackFlucRandomCone+;

--- a/PWGJE/EMCALJetTasks/macros/AddTaskArrayMaker.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskArrayMaker.C
@@ -1,0 +1,36 @@
+AliAnalysisTask * AddTaskArrayMaker(const char *output    = 0 , const char *outputPythia    = 0, const char *outputdata    = 0 ) {
+  // Adds my task
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    ::Error("AddTaskArrayMaker", "No analysis manager to connect to.");
+    return NULL;
+  }  
+  // Check the analysis type using the event handlers connected to the analysis manager.
+  //==============================================================================
+  if (!mgr->GetInputEventHandler()) {
+    ::Error("AddTaskArrayMaker", "This task requires an input event handler");
+    return NULL;
+  }
+  TString inputDataType = mgr->GetInputEventHandler()->GetDataType(); // can be "ESD" or "AOD"
+  // Configure analysis
+  //===========================================================================
+
+  AliNanoAODArrayMaker* task = new AliNanoAODArrayMaker("maker");
+  task->SetOutputArrayName(output);
+  task->SetOutputArrayPythiaName(outputPythia);
+  task->SetOutputArrayDataName(outputdata);
+
+  mgr->AddTask(task);
+
+  mgr->ConnectInput(task, 0, mgr->GetCommonInputContainer());
+
+  const char* containerName = "list";
+  const char* folderName = "Array_Maker";
+  TString fileName = AliAnalysisManager::GetCommonFileName();
+  AliAnalysisDataContainer *coutput = mgr->CreateContainer(containerName, TList::Class(),AliAnalysisManager::kOutputContainer,Form("%s:%s", fileName.Data(), folderName));
+  mgr->ConnectOutput(task, 1, coutput);
+
+  return task;
+
+
+}


### PR DESCRIPTION
Hi all,

this pull request is a code change from Markus (Zimmermann) to allow my jet task (inheriting from the EMCalJet base task) to run on NanoAODs.

The work was done by Markus and his summer student Lucia, I am just supporting him from the EMCalJet/testing point-of-view and by spreading the word in the PWG.

This patch lays the ground also for other tasks inheriting from the EMCalJet base task to be in principle compatible to NanoAODs. More information on this will follow soon.

The changes in the underlying EMCalJet framework are just minor, so we foresee no problems.