### PR TITLE
include additional event and track information in output of AliAnalysisTaskCEP

### DIFF
--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliAnalysisTaskCEP.cxx
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliAnalysisTaskCEP.cxx
@@ -627,9 +627,11 @@ void AliAnalysisTaskCEP::UserExec(Option_t *)
   // count number of recorded triggers
   // CINT11-B-NOPF-CENTNOTRD, DG trigger has to be replaied, LHC16[d,e,h]
   // CCUP2-B-SPD1-CENTNOTRD, DG trigger has to be replaied, LHC16[h,i,j]
-  // CCUP13-B-SPD1-CENTNOTRD = DG trigger, LHC16[k,l,o,p], LHC17[g,h,i,j,k,l]
-  // CCUP25-B-SPD1-CENTNOTRD = DG trigger, LHC17[g,h,i,j,k,l]
+  // CCUP13-B-SPD1-CENTNOTRD = DG trigger, LHC16[k,l,o,p], LHC17[f,h,i,k,l]
+  // CCUP25-B-SPD1-CENTNOTRD = DG trigger, LHC17[f,h,i,k,l]
   TString firedTriggerClasses = fEvent->GetFiredTriggerClasses();
+  printf("Triggers: %s\n",firedTriggerClasses.Data());
+  
   if (firedTriggerClasses.Contains("CINT11-B-NOPF-CENTNOTRD"))
     ((TH1F*)flQArnum->At(1))->Fill(fRun);
   if (firedTriggerClasses.Contains("CCUP2-B-SPD1-CENTNOTRD"))

--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliAnalysisTaskCEP.cxx
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliAnalysisTaskCEP.cxx
@@ -709,11 +709,11 @@ void AliAnalysisTaskCEP::UserExec(Option_t *)
   for (Int_t ii=0;    ii<400; ii++) nFiredChips[2] += foMap[ii]>0 ? 1 : 0;
   for (Int_t ii=400; ii<1200; ii++) nFiredChips[3] += foMap[ii]>0 ? 1 : 0;
   
-  if (firedTriggerClasses.Contains("CCUP13-B-SPD1-CENTNOTRD")) {
-    printf("Triggers: %s\n",firedTriggerClasses.Data());
-    printf("Number of SPD chips: %i %i / %i %i\n",
-      nFiredChips[0],nFiredChips[1],nFiredChips[2],nFiredChips[3]);
-  }
+  // if (firedTriggerClasses.Contains("CCUP13-B-SPD1-CENTNOTRD")) {
+  //   printf("Triggers: %s\n",firedTriggerClasses.Data());
+  //   printf("Number of SPD chips: %i %i / %i %i\n",
+  //     nFiredChips[0],nFiredChips[1],nFiredChips[2],nFiredChips[3]);
+  // }
          
   // get trigger information using AliTriggerAnalysis.IsOfflineTriggerFired
   // kSPDGFOBits: SPD (any fired chip)
@@ -822,9 +822,9 @@ void AliAnalysisTaskCEP::UserExec(Option_t *)
       }
 	  }
     
-    if (firedTriggerClasses.Contains("CCUP13-B-SPD1-CENTNOTRD"))
-      printf("ntrk with SPD hits (of %i trks): %i / %i\n",
-        nTracksTotal,nTracksTPCITS,ntrkwSPDHit);
+    // if (firedTriggerClasses.Contains("CCUP13-B-SPD1-CENTNOTRD"))
+    //   printf("ntrk with SPD hits (of %i trks): %i / %i\n",
+    //     nTracksTotal,nTracksTPCITS,ntrkwSPDHit);
     
   }
   

--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliAnalysisTaskCEP.cxx
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliAnalysisTaskCEP.cxx
@@ -623,14 +623,13 @@ void AliAnalysisTaskCEP::UserExec(Option_t *)
   if (flVtx) {
     fCEPUtil->VtxAnalysis(fEvent,flVtx);
   }
-     
+  
   // count number of recorded triggers
   // CINT11-B-NOPF-CENTNOTRD, DG trigger has to be replaied, LHC16[d,e,h]
   // CCUP2-B-SPD1-CENTNOTRD, DG trigger has to be replaied, LHC16[h,i,j]
   // CCUP13-B-SPD1-CENTNOTRD = DG trigger, LHC16[k,l,o,p], LHC17[f,h,i,k,l]
   // CCUP25-B-SPD1-CENTNOTRD = DG trigger, LHC17[f,h,i,k,l]
   TString firedTriggerClasses = fEvent->GetFiredTriggerClasses();
-  printf("Triggers: %s\n",firedTriggerClasses.Data());
   
   if (firedTriggerClasses.Contains("CINT11-B-NOPF-CENTNOTRD"))
     ((TH1F*)flQArnum->At(1))->Fill(fRun);
@@ -675,6 +674,10 @@ void AliAnalysisTaskCEP::UserExec(Option_t *)
   
   } else {
   
+    // LHC2010 data
+    // there is no DG trigger
+    
+    // LHC2016 and LHC2017 data
     if (firedTriggerClasses.Contains("CCUP13-B-SPD1-CENTNOTRD") ||
       firedTriggerClasses.Contains("CCUP25-B-SPD1-CENTNOTRD") ) {
       isDGTrigger = kTRUE;
@@ -683,6 +686,7 @@ void AliAnalysisTaskCEP::UserExec(Option_t *)
       if (flBBFlag)
         fCEPUtil->BBFlagAnalysis(fEvent,flBBFlag);
     }
+    
   }
   if (isDGTrigger)
     fhStatsFlow->Fill(AliCEPBase::kBinDGTrigger);
@@ -698,6 +702,19 @@ void AliAnalysisTaskCEP::UserExec(Option_t *)
   // number of tracklets
   Int_t nTracklets = mult->GetNumberOfTracklets();
   
+  // get the number of fired FastOR trigger chips
+  Short_t nFiredChips[4] = {0};
+  nFiredChips[0] = mult->GetNumberOfFiredChips(0);
+  nFiredChips[1] = mult->GetNumberOfFiredChips(1);
+  for (Int_t ii=0;    ii<400; ii++) nFiredChips[2] += foMap[ii]>0 ? 1 : 0;
+  for (Int_t ii=400; ii<1200; ii++) nFiredChips[3] += foMap[ii]>0 ? 1 : 0;
+  
+  if (firedTriggerClasses.Contains("CCUP13-B-SPD1-CENTNOTRD")) {
+    printf("Triggers: %s\n",firedTriggerClasses.Data());
+    printf("Number of SPD chips: %i %i / %i %i\n",
+      nFiredChips[0],nFiredChips[1],nFiredChips[2],nFiredChips[3]);
+  }
+         
   // get trigger information using AliTriggerAnalysis.IsOfflineTriggerFired
   // kSPDGFOBits: SPD (any fired chip)
   // kV0A, kV0C: V0
@@ -782,11 +799,33 @@ void AliAnalysisTaskCEP::UserExec(Option_t *)
   if (fCEPUtil->checkstatus(fAnalysisStatus,
     AliCEPBase::kBitTrackCutStudy,AliCEPBase::kBitTrackCutStudy)) {
     Int_t nTracksTotal = fESDEvent->GetNumberOfTracks();
+    Int_t ntrkwSPDHit = 0;
     Int_t nTracksTPCITS = 0;
     for (Int_t ii = 0; ii < nTracksTotal; ii++) {
       AliESDtrack *track = fESDEvent->GetTrack(ii);
-	  	if (track) if (fTrackCuts->AcceptTrack(track)) nTracksTPCITS++;
+	  	if (track) {
+        if (fTrackCuts->AcceptTrack(track)) nTracksTPCITS++;
+      
+        if (track->HasPointOnITSLayer(0) || track->HasPointOnITSLayer(1))
+          ntrkwSPDHit++;
+        
+        // does track have SPD hit and is bit0 set?
+        /*
+        if (firedTriggerClasses.Contains("CCUP13-B-SPD1-CENTNOTRD")) {
+          
+          printf("track %i, ITS hits on layer",ii);
+          for (Int_t jj=0; jj<6; jj++)
+            printf(" %i/%i",jj,track->HasPointOnITSLayer(jj) ? 1:0);
+          printf("\n");
+        }
+        */
+      }
 	  }
+    
+    if (firedTriggerClasses.Contains("CCUP13-B-SPD1-CENTNOTRD"))
+      printf("ntrk with SPD hits (of %i trks): %i / %i\n",
+        nTracksTotal,nTracksTPCITS,ntrkwSPDHit);
+    
   }
   
   // get an TObjArray of tracks with the corresponding TrackStatus
@@ -959,6 +998,7 @@ void AliAnalysisTaskCEP::UserExec(Option_t *)
     fCEPEvent->SetCollissionType(fEventType);
     fCEPEvent->SetMagnField(fMagField);
     fCEPEvent->SetFiredTriggerClasses(firedTriggerClasses);
+    fCEPEvent->SetnFiredChips(nFiredChips);
     fCEPEvent->SetisSTGTriggerFired(fisSTGTriggerFired);
     fCEPEvent->SetnTOFmaxipads(fnTOFmaxipads);
     
@@ -979,7 +1019,7 @@ void AliAnalysisTaskCEP::UserExec(Option_t *)
   
     // if this is a MC event then get the MC true information
     // and save it into the event buffer
-    AliStack *stack;
+    AliStack *stack = NULL;
     if (fMCEvent) {
 	    
       // MC generator and process type
@@ -1209,7 +1249,6 @@ Bool_t AliAnalysisTaskCEP::IsSTGFired(TBits* fFOmap,Int_t dphiMin,Int_t dphiMax)
     // printf("<AliAnalysisTaskCEP::IsSTGFired> Problem with F0map - b!\n");
     return stg;
   }
-  
   
   Bool_t l0[20]={0};
   Bool_t l1[40]={0};

--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliAnalysisTaskCEP.h
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliAnalysisTaskCEP.h
@@ -60,6 +60,20 @@ public:
   // called  at  end  of  analysis
   // virtual void Terminate(Option_t* option);
   
+  // setters for the task parameters
+  void setTaskState(Int_t state) { fTaskState = state; }
+  void setRnumMin(Int_t rn) { frnummin = rn; }
+  void setRnumMax(Int_t rn) { frnummax = rn; }
+  void setnTracksMax(Int_t ntrk) { fnumTracksMax = ntrk; }
+  void setfracDG(Double_t frac) { ffracDG = frac; }
+  void setfracNDG(Double_t frac) { ffracNDG = frac; }
+  void setETmaskDG(UInt_t mask) { fETmaskDG = mask; }
+  void setETpatternDG(UInt_t pattern) { fETpatternDG = pattern; }
+  void setETmaskNDG(UInt_t mask) { fETmaskNDG = mask; }
+  void setETpatternNDG(UInt_t pattern) { fETpatternNDG = pattern; }
+  void setTTmask(UInt_t mask) { fTTmask = mask; }
+  void setTTpattern(UInt_t pattern) { fTTpattern = pattern; }
+  
 private:
 
 	AliAnalysisTaskCEP(const AliAnalysisTaskCEP  &p);
@@ -74,6 +88,7 @@ private:
   // events are saved if (ET=Event test, TT=Track test)
   // . ET conditions are met (conditions for DG and NDG)
   // . 0 < nTrack='number of tracks meeting the TT conditions' <= fnumTracksMax
+  Int_t fTaskState;
   Int_t frnummin, frnummax;
   Int_t fnumTracksMax;
   Double_t ffracDG, ffracNDG;

--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPBase.h
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPBase.h
@@ -49,26 +49,28 @@ class AliCEPBase : public TObject {
 
 		// track status bits
 		kTTBaseLine        = 0,
-    kTTTOFBunchCrossing= (1<< 0), // TOFBunchCrossing==0
-    kTTTPCScluster     = (1<< 1), // number of TPC shared clusters <= fTPCnclsS(3)
-    kTTDCA             = (1<< 2), // DCA to vertex is < 500
-    kTTV0              = (1<< 3), // is a daughter of a V0
-    kTTITSpure         = (1<< 4), // is an ITS pure track
-    kTTZv              = (1<< 5), // |Zv-VtxZ| <= 6
-    kTTeta             = (1<< 6), // -0.9<eta<0.9
-    kTTAccITSTPC       = (1<< 7), // accepted by ITSTPC criteria
-    kTTAccITSSA        = (1<< 8), // accepted by ITSSA  criteria
-    kTTFiredChips      = (1<< 9), // passed FiredChips test
+    kTTTOFBunchCrossing= BIT( 0), // TOFBunchCrossing==0
+    kTTTPCScluster     = BIT( 1), // number of TPC shared clusters <= fTPCnclsS(3)
+    kTTDCA             = BIT( 2), // DCA to vertex is < 500
+    kTTV0              = BIT( 3), // is a daughter of a V0
+    kTTITSpure         = BIT( 4), // is an ITS pure track
+    kTTZv              = BIT( 5), // |Zv-VtxZ| <= 6
+    kTTeta             = BIT( 6), // -0.9<eta<0.9
+    kTTAccITSTPC       = BIT( 7), // accepted by ITSTPC criteria
+    kTTAccITSSA        = BIT( 8), // accepted by ITSSA  criteria
+    kTTFiredChips      = BIT( 9), // passed FiredChips test
+    kTTAccTPCOnly      = BIT(10), // passed standard TPCOnly criteria
+    kTTSPDHit          = BIT(11), // has at least one SPD hit
 
     // type of vertex
     kVtxUnknown         = 0,
-    kVtxSPD             = (1<< 0),  // from ITS
-    kVtxTracks          = (1<< 1),  // from tracks
-    kVtxErrRes          = (1<< 2),  // z-resolution of SPD vertex is out-of-bounds
-    kVtxErrDif          = (1<< 3),  // difference in z between SPD and track
+    kVtxSPD             = BIT(0),  // from ITS
+    kVtxTracks          = BIT(1),  // from tracks
+    kVtxErrRes          = BIT(2),  // z-resolution of SPD vertex is out-of-bounds
+    kVtxErrDif          = BIT(3),  // difference in z between SPD and track
                                     // vertex is out-of-bounds
-    kVtxErrZ            = (1<< 4),  // z-position of vertex is out-of-bounds
-    kVtxAOD             = (1<< 5),  // On AOD only primary vertex is stored
+    kVtxErrZ            = BIT(4),  // z-position of vertex is out-of-bounds
+    kVtxAOD             = BIT(5),  // On AOD only primary vertex is stored
 
 		// StatsFlow histogram entries
 		// names for the bins are specified in AliCEPUtils.cxx
@@ -94,30 +96,30 @@ class AliCEPBase : public TObject {
 		kBinLastValue,
 
 		// definition of bits in AliAnalysisTaskCEP::fCurrentEventCondition
-		kETBaseLine       = (1<< 0),
-    kETEventCut       = (1<< 1),
-    kETPhyssel        = (1<< 2),
-    kETPileup         = (1<< 3),
-    kETClusterCut     = (1<< 4),
-		kETDGTrigger      = (1<< 5),
-    kETVtx            = (1<< 6),
-		kETMBOR           = (1<< 7),
-    kETMBAND          = (1<< 8),
-		kETSPDA           = (1<< 9),
-		kETSPDC           = (1<<10),
-		kETTPCA           = (1<<11),
-		kETTPCC           = (1<<12),
-    kETV0A            = (1<<13),
-		kETV0C            = (1<<14),
-		kETFMDA           = (1<<15),
-		kETFMDC           = (1<<16),
-		kETADA            = (1<<17),
-		kETADC            = (1<<18), 
-		kETZDCA           = (1<<19), 
-		kETZDCC           = (1<<20), 
-		kETZDNA           = (1<<21),
-		kETZDNC           = (1<<22),
-    kETSClusterCut    = (1<<23),
+		kETBaseLine       = BIT( 0),
+    kETEventCut       = BIT( 1),
+    kETPhyssel        = BIT( 2),
+    kETPileup         = BIT( 3),
+    kETClusterCut     = BIT( 4),
+		kETDGTrigger      = BIT( 5),
+    kETVtx            = BIT( 6),
+		kETMBOR           = BIT( 7),
+    kETMBAND          = BIT( 8),
+		kETSPDA           = BIT( 9),
+		kETSPDC           = BIT(10),
+		kETTPCA           = BIT(11),
+		kETTPCC           = BIT(12),
+    kETV0A            = BIT(13),
+		kETV0C            = BIT(14),
+		kETFMDA           = BIT(15),
+		kETFMDC           = BIT(16),
+		kETADA            = BIT(17),
+		kETADC            = BIT(18), 
+		kETZDCA           = BIT(19), 
+		kETZDCC           = BIT(20), 
+		kETZDNA           = BIT(21),
+		kETZDNC           = BIT(22),
+    kETSClusterCut    = BIT(23),
 
     // MC process types
     kProctypeUnknown = 0,
@@ -132,19 +134,19 @@ class AliCEPBase : public TObject {
 		// analysis task status bits
 		// do not change the order in order to be backward compatible!
     
-		kBitConfigurationSet      = (1<< 0), // if not set everything is active
-    kBitisRun1                = (1<< 1), // is it run1
-    kBitSaveAllEvents         = (1<< 2), // save all events
-    kBitisMC                  = (1<< 3), // is Monte Carlo
-    kBitQArnumStudy           = (1<< 4), // QA as function of rnum
-    kBitSPDPileupStudy        = (1<< 5), // SPD pileup study
-    kBitnClunTraStudy         = (1<< 6), // cluster vs tracklet study
-    kBitVtxStudy              = (1<< 7), // Vtx study
-    kBitTrackCutStudy         = (1<< 8), // track cut study
-    kBitBBFlagStudy           = (1<< 9), // BBFlag study
-    kBitV0Study               = (1<<10), // V0 study
-    kBitFMDStudy              = (1<<11), // FMD study
-		kBitConfigurationVersion  = (1<<12)  // always set, last bit
+		kBitConfigurationSet      = BIT( 0), // if not set everything is active
+    kBitisRun1                = BIT( 1), // is it run1
+    kBitSaveAllEvents         = BIT( 2), // save all events
+    kBitisMC                  = BIT( 3), // is Monte Carlo
+    kBitQArnumStudy           = BIT( 4), // QA as function of rnum
+    kBitSPDPileupStudy        = BIT( 5), // SPD pileup study
+    kBitnClunTraStudy         = BIT( 6), // cluster vs tracklet study
+    kBitVtxStudy              = BIT( 7), // Vtx study
+    kBitTrackCutStudy         = BIT( 8), // track cut study
+    kBitBBFlagStudy           = BIT( 9), // BBFlag study
+    kBitV0Study               = BIT(10), // V0 study
+    kBitFMDStudy              = BIT(11), // FMD study
+		kBitConfigurationVersion  = BIT(12)  // always set, last bit
 	
   };
 

--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx
@@ -958,7 +958,19 @@ Int_t AliCEPUtils::AnalyzeTracks(AliESDEvent* fESDEvent,
       if (cut->AcceptTrack(track))
         trackstat |= AliCEPBase::kTTAccITSSA;
     }
+    
+    // accepted by standard TPCOnly cuts
+    cut = AliESDtrackCuts::GetStandardTPCOnlyTrackCuts();
+    if (cut) {
+      if (cut->AcceptTrack(track))
+        trackstat |= AliCEPBase::kTTAccTPCOnly;
+    }
 
+    // has at least one SPD hit
+    if (track->HasPointOnITSLayer(0) || track->HasPointOnITSLayer(1))
+      trackstat |= AliCEPBase::kTTSPDHit;
+    
+    
     // FiredChips test
     // test whether both modules associated with the track are modules
     // with fired chips

--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPUtils.cxx
@@ -585,7 +585,7 @@ void AliCEPUtils::SPDVtxAnalysis (
 }
 
 //------------------------------------------------------------------------------
-// This function compiles parameters which are relevant fpr the
+// This function compiles parameters which are relevant for the
 // number-of-SPD-clusters-vs-number-of-tracklets BG rejection
 // see e.g. AliAnalysisUtils::IsSPDClusterVsTrackletBG
 // histograms include (see AliCEPUtils::GetnClunTraQAHists)
@@ -1489,7 +1489,7 @@ void AliCEPUtils::InitTrackCuts(Bool_t IsRun1, Int_t clusterCut)
   // to study V0s this needs be set to kFALSE
   Bool_t  selPrimaries = kFALSE;
 
-  // Run2
+  // Run1
   if (IsRun1) {
 
     // ITS+TPC

--- a/PWGUD/DIFFRACTIVE/CEPdevel/CEPEventBuffer.cxx
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/CEPEventBuffer.cxx
@@ -50,6 +50,8 @@ CEPEventBuffer::CEPEventBuffer()
   , fCEPTracks(new TObjArray())
 {
 
+  for (Int_t ii=0; ii<4; ii++) fFiredChips[ii] = 0;
+
 }
 
 // ----------------------------------------------------------------------------
@@ -80,6 +82,7 @@ void CEPEventBuffer::Reset()
   fCollissionType  = AliCEPBase::kBinEventUnknown;
   fMagnField       = AliCEPBase::kdumval;
   fFiredTriggerClasses = TString("");
+  for (Int_t ii=0; ii<4; ii++) fFiredChips[ii] = 0;
 
   // general event features
   fEventCutsel     = kFALSE;

--- a/PWGUD/DIFFRACTIVE/CEPdevel/CEPEventBuffer.h
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/CEPEventBuffer.h
@@ -32,6 +32,8 @@ class CEPEventBuffer : public TObject {
     Bool_t fPhysel;
     Bool_t fisPileup;
     Bool_t fisClusterCut;
+    Short_t fFiredChips[4];   // Number of FastOR chips in the two SPD layers
+                              // and number of offline fired chips
     Bool_t fisDGTrigger;
     Bool_t fisSTGTriggerFired;
     Int_t  fnTOFmaxipads;
@@ -76,6 +78,10 @@ class CEPEventBuffer : public TObject {
     void SetMagnField(Double_t magnf)   { fMagnField = magnf; }
     void SetFiredTriggerClasses(TString ftc)   { fFiredTriggerClasses = ftc; }
     void SetPFFlags(AliVEvent *Event);
+    void SetnFiredChips(Short_t chips[4]) {
+      fFiredChips[0]=chips[0]; fFiredChips[1]=chips[1]; 
+      fFiredChips[2]=chips[2]; fFiredChips[3]=chips[3]; 
+    }
     void SetisSTGTriggerFired(Bool_t stgtrig) { fisSTGTriggerFired = stgtrig; }
     void SetnTOFmaxipads(Int_t nmaxipads) { fnTOFmaxipads = nmaxipads; }
 
@@ -114,6 +120,8 @@ class CEPEventBuffer : public TObject {
     Bool_t* GetPFBGFlagV0() { return fPFBGFlagV0; }
     Bool_t* GetPFBBFlagAD() { return fPFBBFlagAD; }
     Bool_t* GetPFBGFlagAD() { return fPFBGFlagAD; }
+    Short_t GetnFiredChips(Int_t layer) {
+      return (layer>=0 && layer<=3) ? fFiredChips[layer] : -1; }
     Bool_t  GetisSTGTriggerFired() { return fisSTGTriggerFired; }
     Int_t   GetnTOFmaxipads() { return fnTOFmaxipads; }
 


### PR DESCRIPTION
output include now:
. number of triggered OFO and IFO
. number of offline triggered SPD chips
. track has at least 1 SPD hit
. track passes standard TPCOnly track cuts