### PR TITLE
Bug fixed for AliHFEminiTrack.h

### DIFF
--- a/PWGHF/hfe/AliHFEminiEvent.cxx
+++ b/PWGHF/hfe/AliHFEminiEvent.cxx
@@ -17,8 +17,8 @@
 // Contributors: Nirbhay K. Behera, Jiyeon Kwon, Jonghan Park
 
 #include "TObjArray.h"
-#include "AliHFEminiTrack.h"
 #include "AliHFEreducedMCParticle.h"
+#include "AliHFEminiTrack.h"
 #include "AliHFEminiEvent.h"
 
 ClassImp(AliHFEminiEvent)

--- a/PWGHF/hfe/AliHFEminiEvent.h
+++ b/PWGHF/hfe/AliHFEminiEvent.h
@@ -22,8 +22,9 @@
 #include <TObject.h>
 
 class TObjArray;
-class AliHFEminiTrack;
 class AliHFEreducedMCParticle;
+class AliHFEminiTrack;
+
 
 class AliHFEminiEvent : public TObject{
  public:

--- a/PWGHF/hfe/AliHFEminiEventCreator.cxx
+++ b/PWGHF/hfe/AliHFEminiEventCreator.cxx
@@ -64,11 +64,10 @@
 #include "AliHFEextraCuts.h"
 #include "AliHFEmcQA.h"
 #include "AliHFEpidTPC.h"
-#include "AliHFEminiEvent.h"
-#include "AliHFEminiTrack.h"
-#include "AliHFEreducedMCParticle.h"
 #include "AliHFEsignalCuts.h"
 #include "AliHFEV0taginfo.h"
+#include "AliHFEminiEvent.h"
+#include "AliHFEminiTrack.h"
 
 
 #include "AliHFEminiEventCreator.h"

--- a/PWGHF/hfe/AliHFEminiEventCreator.h
+++ b/PWGHF/hfe/AliHFEminiEventCreator.h
@@ -41,8 +41,9 @@ class AliHFEcuts;
 class AliHFEextraCuts;
 class AliHFEpidTPC;
 class AliHFEsignalCuts;
-class AliHFEminiEvent;
 class AliHFEV0taginfo;
+class AliHFEminiEvent;
+class AliHFEminiTrack;
 
 class AliHFEminiEventCreator : public AliAnalysisTaskSE{
   public:

--- a/PWGHF/hfe/AliHFEminiTrack.h
+++ b/PWGHF/hfe/AliHFEminiTrack.h
@@ -16,8 +16,8 @@
 // Base class for AliHFEminiEventCreator.cxx/h
 // Contributors: Nirbhay K. Behera, Jiyeon Kwon, Jonghan Park
 
-#ifndef ALIHFEREDUCEDTRACK_H
-#define ALIHFEREDUCEDTRACK_H
+#ifndef ALIHFEMINITRACK_H
+#define ALIHFEMINITRACK_H
 
 #include <TObject.h>
 #include <TMath.h>

--- a/PWGHF/hfe/CMakeLists.txt
+++ b/PWGHF/hfe/CMakeLists.txt
@@ -108,6 +108,9 @@ set(SRCS
   AliHFEreducedEvent.cxx
   AliHFEreducedTrack.cxx
   AliHFEreducedMCParticle.cxx
+  AliHFEminiTrack.cxx
+  AliHFEminiEvent.cxx
+  AliHFEminiEventCreator.cxx
   AliAnalysisTaskHFEQA.cxx
   AliAnalysisTaskHFEemcQA.cxx
   AliAnalysisTaskBeautyCal.cxx

--- a/PWGHF/hfe/PWGHFhfeLinkDef.h
+++ b/PWGHF/hfe/PWGHFhfeLinkDef.h
@@ -94,6 +94,9 @@
 #pragma link C++ class  AliHFEreducedEvent+;
 #pragma link C++ class  AliHFEreducedTrack+;
 #pragma link C++ class  AliHFEreducedMCParticle+;
+#pragma link C++ class  AliHFEminiTrack+;
+#pragma link C++ class  AliHFEminiEvent+;
+#pragma link C++ class  AliHFEminiEventCreator+;
 #pragma link C++ class  AliAnalysisTaskHFEQA+;
 #pragma link C++ class  AliAnalysisTaskHFEemcQA+;
 #pragma link C++ class  AliAnalysisTaskBeautyCal+;


### PR DESCRIPTION
The compilation error due to class AliHFEminiTrack (forward declaration error) is now fixed. 