### PR TITLE
EMCal FW: Add container usedefault utility

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalContainerUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalContainerUtils.h
@@ -49,6 +49,7 @@ class AliEmcalContainerUtils {
   };
 
   // Utility functions
+  static std::string DetermineUseDefaultName(InputObject_t objType);
   static std::string DetermineUseDefaultName(InputObject_t objType, bool esdMode, bool returnObjectType = false);
   static const AliVEvent * GetEvent(const AliVEvent * inputEvent, bool isEmbedding = false);
   static AliVEvent * GetEvent(AliVEvent * inputEvent, bool isEmbedding = false);


### PR DESCRIPTION
Adds a simple helper function which builds on the other "usedefault"
functionality, making the (often true) assumption that the file type can
be determined from an existing analysis manager