### PR TITLE
EMCAL: Fix EMCal container titles

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliMCParticleContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliMCParticleContainer.cxx
@@ -238,6 +238,7 @@ const AliMCParticleIterableMomentumContainer AliMCParticleContainer::accepted_mo
  */
 const char* AliMCParticleContainer::GetTitle() const
 {
-  static TString trackString = TString::Format("%s_pT%04d", GetArrayName().Data(), static_cast<int>(GetMinPt()*1000.0));
+  static TString trackString;
+  trackString = TString::Format("%s_pT%04d", GetArrayName().Data(), static_cast<int>(GetMinPt()*1000.0));
   return trackString.Data();
 }

--- a/PWG/EMCAL/EMCALbase/AliParticleContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliParticleContainer.cxx
@@ -433,7 +433,8 @@ Int_t AliParticleContainer::GetNAcceptedParticles() const
  */
 const char* AliParticleContainer::GetTitle() const
 {
-  static TString trackString = TString::Format("%s_pT%04d", GetArrayName().Data(), static_cast<int>(GetMinPt()*1000.0));
+  static TString trackString;
+  trackString = TString::Format("%s_pT%04d", GetArrayName().Data(), static_cast<int>(GetMinPt()*1000.0));
   return trackString.Data();
 }
 

--- a/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
@@ -598,7 +598,8 @@ const AliTrackIterableMomentumContainer AliTrackContainer::accepted_momentum() c
  */
 const char* AliTrackContainer::GetTitle() const
 {
-  static TString trackString = TString::Format("%s_pT%04d", GetArrayName().Data(), static_cast<int>(GetMinPt()*1000.0));
+  static TString trackString;
+  trackString = TString::Format("%s_pT%04d", GetArrayName().Data(), static_cast<int>(GetMinPt()*1000.0));
   return trackString.Data();
 }
 

--- a/PWG/JETFW/AliAnalysisTaskEmcalJet.cxx
+++ b/PWG/JETFW/AliAnalysisTaskEmcalJet.cxx
@@ -180,9 +180,12 @@ void AliAnalysisTaskEmcalJet::ExecOnce()
       std::stringstream foundbranches;
       bool first(true);
       for(auto e : *(fInputEvent->GetList())){
-        if(!first){
-          foundbranches << ", ";
+        if(first){
+          // Skip printing a comma on the first time through
           first = false;
+        }
+        else {
+          foundbranches << ", ";
         }
         foundbranches << e->GetName();
       }


### PR DESCRIPTION
The titles were not getting the current minimum pt setting correctly.
Separating the definition and assignment seems to resolve the issue.
This is particularly important as the titles are relied upon to find
jet collections.

Also updates the branches print out