### PR TITLE
Implement handling for track status bits (i.e. hybrid tracks) in the …

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalAODFilterBitCuts.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalAODFilterBitCuts.cxx
@@ -16,23 +16,61 @@
 #include "AliAODTrack.h"
 
 /// \cond CLASSIMP
-ClassImp(AliEmcalAODFilterBitCuts)
+ClassImp(PWG::EMCAL::AliEmcalAODFilterBitCuts)
 /// \endcond
+
+namespace PWG{
+
+namespace EMCAL{
 
 AliEmcalAODFilterBitCuts::AliEmcalAODFilterBitCuts():
   AliVCuts(),
   fAODfilterBits(0),
+  fAODstatusBits(0),
   fSelectionMode(kSelAny)
+{
+}
+
+AliEmcalAODFilterBitCuts::AliEmcalAODFilterBitCuts(const char *name, const char *title):
+    AliVCuts(name, title),
+    fAODfilterBits(0),
+    fAODstatusBits(0),
+    fSelectionMode(kSelAny)
 {
 }
 
 Bool_t AliEmcalAODFilterBitCuts::IsSelected(TObject *o){
   AliAODTrack *testtrack = dynamic_cast<AliAODTrack *>(o);
   if(!testtrack) return false;
-  Bool_t result = false;
-  switch(fSelectionMode){
-  case kSelAny: result = ((testtrack->GetFilterMap() & fAODfilterBits) > 0); break;
-  case kSelAll: result = ((testtrack->GetFilterMap() & fAODfilterBits) == fAODfilterBits);
+  Bool_t result(true);
+  if(fAODfilterBits){
+    if(!IsFilterBitsSelected(testtrack)) result = false;
+  }
+  if(fAODstatusBits){
+    if(!IsStatusBitsSelected(testtrack)) result = false;
   }
   return result;
+}
+
+Bool_t AliEmcalAODFilterBitCuts::IsFilterBitsSelected(const AliAODTrack *const trk) const {
+  Bool_t result(false);
+  switch(fSelectionMode){
+  case kSelAny: result = ((trk->GetFilterMap() & fAODfilterBits) > 0); break;
+  case kSelAll: result = ((trk->GetFilterMap() & fAODfilterBits) == fAODfilterBits); break;
+  };
+  return result;
+}
+
+Bool_t AliEmcalAODFilterBitCuts::IsStatusBitsSelected(const AliAODTrack *const trk) const {
+  ULong_t trackstatusbits = trk->TestBits(fAODstatusBits);
+  Bool_t result(false);
+  switch(fSelectionMode) {
+  case kSelAny: result = (trackstatusbits > fAODstatusBits); break;
+  case kSelAll: result = (trackstatusbits == fAODstatusBits); break;
+  }
+  return result;
+}
+
+}
+
 }

--- a/PWG/EMCAL/EMCALbase/AliEmcalAODFilterBitCuts.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalAODFilterBitCuts.h
@@ -5,6 +5,12 @@
 
 #include "AliVCuts.h"
 
+class AliAODTrack;
+
+namespace PWG{
+
+namespace EMCAL {
+
 /**
  * @class AliEmcalAODFilterBitCuts
  * @brief Implementation of the AOD filter bit selection as virtual cut class
@@ -59,12 +65,38 @@ public:
    */
   void AddFilterBitNumber(ULong_t bitnumber) {if(bitnumber < sizeof(ULong_t)*8) fAODfilterBits |= 1 << bitnumber; }
 
+  void AddStatusBitNumber(ULong_t bitnumber) {if(bitnumber < sizeof(ULong_t)*8) fAODstatusBits |= 1 << bitnumber; }
+
   /**
-   * Set the filter bits to be checked. Function using the bit representation, not
-   * the number of then bit.
+   * @brief Set the filter bits to be checked.
+   *
+   * Function using the bit representation, not the number of then bit.
+   * Bits will be added to the existing bits (not if doReset is true).
    * @param[in] filterbits Filter bits requested
+   * @param[in] doReset If true existing filter bits will be set to 0
    */
-  void SetFilterBits(ULong_t filterbits) { fAODfilterBits |= filterbits; }
+  void SetFilterBits(ULong_t filterbits, Bool_t doReset = false) { if(doReset) fAODfilterBits = 0; fAODfilterBits |= filterbits; }
+
+  /**
+   * @brief Set the track status bits to be checked.
+   *
+   * Function using the bit representation, not the number of then bit.
+   * Bits will be added to the existing bits (not if doReset is true).
+   * @param[in] filterbits Filter bits requested
+   * @param[in] doReset If true existing filter bits will be set to 0
+   */
+  void SetStatusBits(ULong_t statusbits, Bool_t doReset = false) { if(doReset) fAODstatusBits = 0; fAODstatusBits |= statusbits; }
+
+  /**
+   * @brief Set the selection mode
+   *
+   * Can be any (any of the filter/status) bits set, or all. Note the
+   * selection mode is applied to filter and status bits in the same way.
+   * Filter and status bit cuts must be fulfilled independently.
+   *
+   * @param[in] mode Selection mode (any/all) used in the bit selection
+   */
+  void SetSelectionMode(SelectionMode_t mode) { fSelectionMode = mode; };
 
   /**
    * Select AOD tracks according which contain any of the bits. The way of the selection
@@ -78,12 +110,32 @@ public:
   virtual Bool_t IsSelected(TObject *o);
 
 protected:
+
+  /**
+   * @brief Select track according to presence of track filter bits
+   * @param[in] trk track to check
+   * @return True if the track is selected, false otherwise
+   */
+  Bool_t IsFilterBitsSelected(const AliAODTrack *const trk) const;
+
+  /**
+   * @brief Select track according to presence of track status bits
+   * @param[in] trk track to check
+   * @return True if the track is selected, false otherwise
+   */
+  Bool_t IsStatusBitsSelected(const AliAODTrack *const trk) const;
+
   ULong_t                        fAODfilterBits;          ///< Requested filter bits
+  ULong_t                        fAODstatusBits;          ///< Requested track status bits
   SelectionMode_t                fSelectionMode;          ///< Mode of the filter bit selection (any or all)
 
   /// \cond CLASSIMP
   ClassDef(AliEmcalAODFilterBitCuts, 1)
   /// \endcond
 };
+
+}
+
+}
 
 #endif /* ALIEMCALAODFILTERBITCUT_H */

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.h
@@ -146,7 +146,8 @@ public:
     kNoTrackFilter = 0,   ///< No filter (all tracks passing)
     kCustomTrackFilter,   ///< Custom (user-defined) tracks
     kHybridTracks,        ///< Hybrid tracks
-    kTPCOnlyTracks        ///< TPC-only tracks
+    kTPCOnlyTracks,       ///< TPC-only tracks
+    kITSPureTracks        ///< ITS stand-alone tracks
   };
 
   /**

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.cxx
@@ -19,8 +19,10 @@
 
 #include <AliAODEvent.h>
 #include <AliAODTrack.h>
+#include <AliEmcalAODFilterBitCuts.h>
 #include <AliEmcalTrackSelectionAOD.h>
 #include <AliESDtrack.h>
+#include <AliESDtrackCuts.h>
 #include <AliPicoTrack.h>
 
 /// \cond CLASSIMP
@@ -78,6 +80,15 @@ void AliEmcalTrackSelectionAOD::GenerateTrackCuts(ETrackFilterType_t type, const
     fHybridFilterBits[0] = -1;
     fHybridFilterBits[1] = -1;
     fFilterTPCTracks = kTRUE;
+    break;
+
+  case AliEmcalTrackSelection::kITSPureTracks:
+    if (fListOfCuts) fListOfCuts->Clear();
+    AddTrackCuts(AliESDtrackCuts::GetStandardITSSATrackCuts2010());
+    fFilterHybridTracks = kFALSE;
+    fFilterTPCTracks = kFALSE;
+    fHybridFilterBits[0] = -1;
+    fHybridFilterBits[1] = -1;
     break;
 
   default:
@@ -157,7 +168,7 @@ Bool_t AliEmcalTrackSelectionAOD::GetHybridFilterBits(Char_t bits[], TString per
       period == "lhc12i" || period == "lhc13b" || period == "lhc13c" ||
       period == "lhc13d" || period == "lhc13e" || period == "lhc13f" ||
       period == "lhc13g" ||
-      (period.Length() == 6 && period.BeginsWith("lhc15")) // all Run-2 data, excluding MC productions
+      (period.Length() == 6 && (period.BeginsWith("lhc15") || period.BeginsWith("lhc16") || period.BeginsWith("lhc17"))) // all Run-2 data, excluding MC productions
   ) {
     bits[0] = 8;
     bits[1] = 9;
@@ -166,7 +177,7 @@ Bool_t AliEmcalTrackSelectionAOD::GetHybridFilterBits(Char_t bits[], TString per
   else if (period == "lhc10f7a" || period == "lhc12a15e" || period.BeginsWith("lhc12a17") ||
       period == "lhc13b4" || period == "lhc13b4_fix" || period == "lhc13b4_plus" || period == "lhc14k1a" || period == "lhc14k1b" || period == "lhc13e4" ||
       period.BeginsWith("lhc14a1") || period.BeginsWith("lhc13b2_efix") ||
-      period.BeginsWith("lhc15g6")) {
+      period.BeginsWith("lhc15g6") || period.BeginsWith("lhc17f8")) {
     bits[0] = 8;
     bits[1] = 9;
   }

--- a/PWG/EMCAL/EMCALbase/PWGEMCALbaseLinkDef.h
+++ b/PWG/EMCAL/EMCALbase/PWGEMCALbaseLinkDef.h
@@ -12,7 +12,6 @@
 #pragma link C++ class AliEmcalContainer+;
 #pragma link C++ class AliEmcalContainerUtils+;
 #pragma link C++ class AliEmcalDownscaleFactorsOCDB+;
-#pragma link C++ class AliEmcalAODFilterBitCuts+;
 #pragma link C++ class AliEmcalESDTrackCutsGenerator+;
 #pragma link C++ class AliEmcalParticle+;
 #pragma link C++ class AliEmcalPhysicsSelection+;
@@ -31,4 +30,8 @@
 #pragma link C++ class std::pair<std::string, AliParticleContainer*>+;
 #pragma link C++ class std::map<std::string, AliClusterContainer*>+;
 #pragma link C++ class std::pair<std::string, AliClusterContainer*>+;
+
+#pragma link C++ namespace PWG;
+#pragma link C++ namespace PWG::EMCAL;
+#pragma link C++ class PWG::EMCAL::AliEmcalAODFilterBitCuts+;
 #endif

--- a/PWG/EMCAL/EMCALtasks/CMakeLists.txt
+++ b/PWG/EMCAL/EMCALtasks/CMakeLists.txt
@@ -78,6 +78,7 @@ set(SRCS
   AliEmcalCorrectionClusterHadronicCorrection.cxx
   AliEmcalCorrectionPHOSCorrections.cxx
   AliAnalysisTaskEmcalOccupancy.cxx
+  TestAliEmcalAODFilterBitCuts.cxx
   )
 
 # Headers from sources

--- a/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
+++ b/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
@@ -53,4 +53,10 @@
 #pragma link C++ class PWG::EMCAL::AliEmcalCellMonitorTask+;
 #pragma link C++ class PWG::EMCAL::AliEmcalFastOrMonitorTask+;
 #pragma link C++ class PWG::EMCAL::AliAnalysisTaskEmcalTriggerSelection+;
+
+// Unit tests
+#pragma link C++ class PWG::EMCAL::TestAliEmcalAODFilterBitCuts+;
+#pragma link C++ class PWG::EMCAL::TestImplAliEmcalAODFilterBitCuts+;
+#pragma link C++ class PWG::EMCAL::TestImplAliEmcalAODFilterBitCutsTPCconstrained+;
+#pragma link C++ class PWG::EMCAL::TestImplAliEmcalAODFilterBitCutsHybrid+;
 #endif

--- a/PWG/EMCAL/EMCALtasks/TestAliEmcalAODFilterBitCuts.cxx
+++ b/PWG/EMCAL/EMCALtasks/TestAliEmcalAODFilterBitCuts.cxx
@@ -1,0 +1,172 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include "AliAnalysisManager.h"
+#include "AliAODEvent.h"
+#include "AliAODTrack.h"
+#include "AliEmcalAODFilterBitCuts.h"
+#include "AliLog.h"
+#include <THistManager.h>
+#include <TList.h>
+#include <TObjArray.h>
+#include <TString.h>
+#include <iostream>
+
+#include "TestAliEmcalAODFilterBitCuts.h"
+
+/// \cond CLASSIMP
+ClassImp(PWG::EMCAL::TestAliEmcalAODFilterBitCuts)
+ClassImp(PWG::EMCAL::TestImplAliEmcalAODFilterBitCuts)
+ClassImp(PWG::EMCAL::TestImplAliEmcalAODFilterBitCutsTPCconstrained)
+ClassImp(PWG::EMCAL::TestImplAliEmcalAODFilterBitCutsHybrid)
+/// \endcond
+
+namespace PWG {
+namespace EMCAL {
+
+TestAliEmcalAODFilterBitCuts::TestAliEmcalAODFilterBitCuts() :
+    AliAnalysisTaskEmcalLight(),
+    fTestSuite(nullptr),
+    fTestStatus(nullptr)
+{
+
+}
+
+TestAliEmcalAODFilterBitCuts::TestAliEmcalAODFilterBitCuts(const char *name) :
+    AliAnalysisTaskEmcalLight(name, kTRUE),
+    fTestSuite(nullptr),
+    fTestStatus(nullptr)
+{
+  GenerateTestSuite();
+}
+
+TestAliEmcalAODFilterBitCuts::~TestAliEmcalAODFilterBitCuts() {
+  if(fTestSuite) delete fTestSuite;
+}
+
+void TestAliEmcalAODFilterBitCuts::AddTestImpl(TestImplAliEmcalAODFilterBitCuts *test) {
+  if(!fTestSuite) fTestSuite = new TObjArray;
+  fTestSuite->SetOwner(kTRUE);
+  AliInfoStream() << "Adding test: " << test->GetName() << std::endl;
+  fTestSuite->Add(test);
+}
+
+void TestAliEmcalAODFilterBitCuts::UserCreateOutputObjects(){
+  AliAnalysisTaskEmcalLight::UserCreateOutputObjects();
+
+  fTestStatus = new THistManager("testStatus");
+  for(auto t : *fTestSuite) fTestStatus->CreateTH1(Form("TestResult%s", t->GetName()), Form("Result Test %s", t->GetName()), 2, -0.5, 1.5);
+  for(auto h : *fTestStatus->GetListOfHistograms()) fOutput->Add(h);
+
+  PostData(1, fOutput);
+}
+
+bool TestAliEmcalAODFilterBitCuts::Run(){
+  AliAODEvent *ev = dynamic_cast<AliAODEvent *>(fInputEvent);
+  if(!ev) return false;
+  for(auto test : *fTestSuite) EvaluateTest(static_cast<TestImplAliEmcalAODFilterBitCuts *>(test), ev);
+  return true;
+}
+
+void TestAliEmcalAODFilterBitCuts::EvaluateTest(TestImplAliEmcalAODFilterBitCuts *test, const AliAODEvent *const ev) {
+  AliInfoStream() << "Running test: " << test->GetName() << std::endl;
+  fTestStatus->FillTH1(Form("TestResult%s", test->GetName()), test->RunTest(ev) ? 1 : 0);
+}
+
+void TestAliEmcalAODFilterBitCuts::GenerateTestSuite(){
+  AddTestImpl(new TestImplAliEmcalAODFilterBitCutsTPCconstrained("TPCconstrained"));
+  AddTestImpl(new TestImplAliEmcalAODFilterBitCutsHybrid("Hybridall"));
+}
+
+TestAliEmcalAODFilterBitCuts *TestAliEmcalAODFilterBitCuts::AddTestAliEmcalAODFilterBitCuts(const char *testname){
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if(!mgr){
+    std::cerr << "TestAliEmcalAODFilterBitCuts: No Analysis manager\n";
+    return nullptr;
+  }
+
+  TestAliEmcalAODFilterBitCuts *test = new TestAliEmcalAODFilterBitCuts(testname);
+  mgr->AddTask(test);
+
+  TString outname(mgr->GetCommonFileName());
+  outname += TString::Format(":%s", testname);
+
+  mgr->ConnectInput(test, 0, mgr->GetCommonInputContainer());
+  mgr->ConnectOutput(test, 1, mgr->CreateContainer(Form("Histos%s", testname), TList::Class(), AliAnalysisManager::kOutputContainer, outname));
+  return test;
+}
+
+TestImplAliEmcalAODFilterBitCuts::TestImplAliEmcalAODFilterBitCuts():
+    TNamed(),
+    fTestObject(nullptr)
+{
+}
+
+TestImplAliEmcalAODFilterBitCuts::TestImplAliEmcalAODFilterBitCuts(const char *name):
+    TNamed(name, ""),
+    fTestObject(nullptr)
+{
+}
+
+TestImplAliEmcalAODFilterBitCuts::~TestImplAliEmcalAODFilterBitCuts(){
+  if(fTestObject) delete fTestObject;
+}
+
+bool TestImplAliEmcalAODFilterBitCuts::RunTest(const AliAODEvent *const ev) {
+  int nerror(0);
+  for(int itrk = 0; itrk < ev->GetNumberOfTracks(); itrk++){
+    AliAODTrack *trk = static_cast<AliAODTrack *>(ev->GetTrack(itrk));
+    bool truth = this->IsTrueTrack(trk), test = fTestObject->IsSelected(trk);
+    if(truth != test) nerror++;
+  }
+  return nerror != 0;
+}
+
+TestImplAliEmcalAODFilterBitCutsTPCconstrained::TestImplAliEmcalAODFilterBitCutsTPCconstrained(const char *name):
+    TestImplAliEmcalAODFilterBitCuts(name)
+{
+  fTestObject = new AliEmcalAODFilterBitCuts(Form("CutsTest%s", name), "Test cuts");
+  fTestObject->SetStatusBits(static_cast<ULong_t>(AliAODTrack::kIsTPCConstrained));
+}
+
+bool TestImplAliEmcalAODFilterBitCutsTPCconstrained::IsTrueTrack(const AliAODTrack *track) const {
+  return track->IsTPCConstrained();
+}
+
+TestImplAliEmcalAODFilterBitCutsHybrid::TestImplAliEmcalAODFilterBitCutsHybrid(const char *name):
+    TestImplAliEmcalAODFilterBitCuts(name)
+{
+  fTestObject = new AliEmcalAODFilterBitCuts(Form("CutsTest%s", name), "Test cuts");
+  fTestObject->SetStatusBits(static_cast<ULong_t>(AliAODTrack::kIsHybridGCG | AliAODTrack::kIsHybridTPCCG));
+  fTestObject->SetSelectionMode(AliEmcalAODFilterBitCuts::kSelAny);
+}
+
+bool TestImplAliEmcalAODFilterBitCutsHybrid::IsTrueTrack(const AliAODTrack *track) const {
+  return track->IsHybridGlobalConstrainedGlobal() || track->IsHybridTPCConstrainedGlobal();
+}
+
+} /* namespace EMCAL */
+} /* namespace PWG */

--- a/PWG/EMCAL/EMCALtasks/TestAliEmcalAODFilterBitCuts.h
+++ b/PWG/EMCAL/EMCALtasks/TestAliEmcalAODFilterBitCuts.h
@@ -1,0 +1,125 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef PWG_EMCAL_TESTALIEMCALAODFILTERBITCUTS_H_
+#define PWG_EMCAL_TESTALIEMCALAODFILTERBITCUTS_H_
+
+#include "AliAnalysisTaskEmcalLight.h"
+#include <TNamed.h>
+
+class THistManager;
+class TObjArray;
+class AliAODEvent;
+class AliAODTrack;
+
+namespace PWG {
+namespace EMCAL {
+
+class AliEmcalAODFilterBitCuts;
+
+class TestImplAliEmcalAODFilterBitCuts : public TNamed {
+public:
+  TestImplAliEmcalAODFilterBitCuts();
+  TestImplAliEmcalAODFilterBitCuts(const char *name);
+  virtual ~TestImplAliEmcalAODFilterBitCuts();
+
+  bool RunTest(const AliAODEvent *const ev);
+
+protected:
+  virtual bool IsTrueTrack(const AliAODTrack *const trk) const = 0;
+
+  AliEmcalAODFilterBitCuts          *fTestObject;   ///< Object to be tested
+
+private:
+  TestImplAliEmcalAODFilterBitCuts(const TestImplAliEmcalAODFilterBitCuts &);
+  TestImplAliEmcalAODFilterBitCuts &operator=(const TestImplAliEmcalAODFilterBitCuts &);
+
+  /// \cond CLASSIMP
+  ClassDef(TestImplAliEmcalAODFilterBitCuts, 1);
+  /// \endcond
+};
+
+class TestImplAliEmcalAODFilterBitCutsTPCconstrained : public TestImplAliEmcalAODFilterBitCuts {
+public:
+  TestImplAliEmcalAODFilterBitCutsTPCconstrained() : TestImplAliEmcalAODFilterBitCuts() {}
+  TestImplAliEmcalAODFilterBitCutsTPCconstrained(const char *name);
+  virtual ~TestImplAliEmcalAODFilterBitCutsTPCconstrained(){}
+
+protected:
+  virtual bool IsTrueTrack(const AliAODTrack *const trk) const;
+
+  /// \cond CLASSIMP
+  ClassDef(TestImplAliEmcalAODFilterBitCutsTPCconstrained, 1);
+  /// \endcond
+};
+
+class TestImplAliEmcalAODFilterBitCutsHybrid : public TestImplAliEmcalAODFilterBitCuts {
+public:
+  TestImplAliEmcalAODFilterBitCutsHybrid() : TestImplAliEmcalAODFilterBitCuts() {}
+  TestImplAliEmcalAODFilterBitCutsHybrid(const char *name);
+  virtual ~TestImplAliEmcalAODFilterBitCutsHybrid(){}
+
+protected:
+  virtual bool IsTrueTrack(const AliAODTrack *const trk) const;
+
+  /// \cond CLASSIMP
+  ClassDef(TestImplAliEmcalAODFilterBitCutsHybrid, 1);
+  /// \endcond
+};
+
+class TestAliEmcalAODFilterBitCuts : public AliAnalysisTaskEmcalLight{
+public:
+  TestAliEmcalAODFilterBitCuts();
+  TestAliEmcalAODFilterBitCuts(const char *testname);
+  virtual ~TestAliEmcalAODFilterBitCuts();
+
+  void AddTestImpl(TestImplAliEmcalAODFilterBitCuts *test);
+  void GenerateTestSuite();
+
+  static TestAliEmcalAODFilterBitCuts *AddTestAliEmcalAODFilterBitCuts(const char *testname);
+
+protected:
+  virtual void UserCreateOutputObjects();
+  virtual bool Run();
+
+private:
+  void EvaluateTest(TestImplAliEmcalAODFilterBitCuts *test, const AliAODEvent *const ev);
+
+  TObjArray                             *fTestSuite;    ///< Test suite to be executed
+  THistManager                          *fTestStatus;   ///< Histograms with test results
+
+  TestAliEmcalAODFilterBitCuts(const TestAliEmcalAODFilterBitCuts &);
+  TestAliEmcalAODFilterBitCuts &operator=(const TestAliEmcalAODFilterBitCuts &);
+
+  /// \cond CLASSIMP
+  ClassDef(TestAliEmcalAODFilterBitCuts, 1);
+  /// \endcond
+};
+
+} /* namespace EMCAL */
+} /* namespace PWG */
+
+#endif /* PWG_EMCAL_TESTALIEMCALAODFILTERBITCUTS_H_ */

--- a/PWG/EMCAL/macros/AddTestAliEmcalAODFilterBitCuts.C
+++ b/PWG/EMCAL/macros/AddTestAliEmcalAODFilterBitCuts.C
@@ -1,0 +1,7 @@
+#if !defined(__CLING__) && !defined(__CINT__)
+#include <TestAliEmcalAODFilterBitCuts.h>
+#endif
+
+PWG::EMCAL::TestAliEmcalAODFilterBitCuts *AddTestAliEmcalAODFilterBitCuts(const char *name){
+  return PWG::EMCAL::TestAliEmcalAODFilterBitCuts::AddTestAliEmcalAODFilterBitCuts(name);
+}


### PR DESCRIPTION
…AliEmcalAODFilterBitCuts

Handling implemented as done for the track cuts. 
Functionality is covered by a unit test (based on
an analysis task)

Once functionality is well tested the filter bit cuts will replace the manual track selection in AliEmcalTrackSelectionAOD, and once all cuts can be expressed in terms of AliVCuts the track selections for ESDs and AODs can be combined to 1 object.

In addition:
- Implementation of ITS pure stand alone track selection based on AliESDtrackCuts in AliEmcalTrackSelectionAOD
- Adding 2016 and 2017 datasets to the default hybrid track selection