### PR TITLE
PWGDQ: Efficiency task needs kinematic cuts

### DIFF
--- a/PWGDQ/dielectron/core/AliAnalysisTaskElectronEfficiency.cxx
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskElectronEfficiency.cxx
@@ -1465,14 +1465,14 @@ void AliAnalysisTaskElectronEfficiency::UserExec(Option_t *)
       } // MC track loop
       if(LMEEelectrons.size() > 0 && LMEEpositrons.size() > 0){
         for(std::vector<LMEEparticle>::iterator it1 = LMEEelectrons.begin(); it1 != LMEEelectrons.end(); ++it1){
-          Bool_t bAccGen1 = it1->genPt > fPtMinGEN && TMath::Abs(it1->genEta) < 0.8;
-          Bool_t bAccRec1 = it1->recPt > fPtMinGEN && TMath::Abs(it1->recEta) < 0.8;
+          Bool_t bAccGen1 = it1->genPt > fPtMinCut && it1->genPt < fPtMaxCut && it1->genEta < fEtaMaxCut && it1->genEta > fEtaMinCut;
+          Bool_t bAccRec1 = it1->recPt > fPtMinCut && it1->recPt < fPtMaxCut && it1->recEta < fEtaMaxCut && it1->recEta > fEtaMinCut;
           if(!(bAccGen1 || bAccRec1)) continue;
           Bool_t charm1  =  TMath::Abs(it1->mPDG) > 400 && TMath::Abs(it1->mPDG) < 440 && !(TMath::Abs(it1->grmPDG) > 500 && TMath::Abs(it1->grmPDG) < 550);
           Bool_t beauty1 = (TMath::Abs(it1->mPDG) > 400 && TMath::Abs(it1->mPDG) < 440 && TMath::Abs(it1->grmPDG) > 500  && TMath::Abs(it1->grmPDG) < 550) || (TMath::Abs(it1->mPDG) > 500 && TMath::Abs(it1->mPDG) < 550);
           for(std::vector<LMEEparticle>::iterator it2 = LMEEpositrons.begin(); it2 != LMEEpositrons.end(); ++it2){
-            Bool_t bAccGen2 = it2->genPt > fPtMinGEN && TMath::Abs(it2->genEta) < 0.8;
-            Bool_t bAccRec2 = it2->recPt > fPtMinGEN && TMath::Abs(it2->recEta) < 0.8;
+            Bool_t bAccGen2 = it2->genPt > fPtMinCut && it2->genPt < fPtMaxCut && it2->genEta < fEtaMaxCut && it2->genEta > fEtaMinCut;
+            Bool_t bAccRec2 = it2->recPt > fPtMinCut && it2->recPt < fPtMaxCut && it2->recEta < fEtaMaxCut && it2->recEta > fEtaMinCut;
             if(!(bAccGen2 || bAccRec2)) continue;
             Bool_t charm2  =  TMath::Abs(it2->mPDG) > 400 && TMath::Abs(it2->mPDG) < 440 && !(TMath::Abs(it2->grmPDG) > 500 && TMath::Abs(it2->grmPDG) < 550);
             Bool_t beauty2 = (TMath::Abs(it2->mPDG) > 400 && TMath::Abs(it2->mPDG) < 440 && TMath::Abs(it2->grmPDG) > 500  && TMath::Abs(it2->grmPDG) < 550) || (TMath::Abs(it2->mPDG) > 500 && TMath::Abs(it2->mPDG) < 550);

--- a/PWGDQ/dielectron/core/AliAnalysisTaskElectronEfficiency.h
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskElectronEfficiency.h
@@ -143,6 +143,8 @@ class AliAnalysisTaskElectronEfficiency : public AliAnalysisTaskSE {
   void          SetDeltaThetaBinning(Int_t N, Double_t min, Double_t max) {fDeltaThetaNbins=N; fDeltaThetaMin=min; fDeltaThetaMax=max;}
   void          SetDeltaPhiBinning(Int_t N, Double_t min, Double_t max)   {fDeltaPhiNbins=N; fDeltaPhiMin=min; fDeltaPhiMax=max;}
   void          SetDeltaAngleBinning(Int_t N, Double_t min, Double_t max) {fDeltaAngleNbins=N; fDeltaAngleMin=min; fDeltaAngleMax=max;}
+  void          SetPtCut(Double_t ptMin, Double_t ptMax) {fPtMinCut = ptMin; fPtMaxCut = ptMax;}
+  void          SetEtaCut(Double_t etaMin, Double_t etaMax) {fEtaMinCut = etaMin; fEtaMaxCut = etaMax;}
 
   virtual void  CreateHistograms(TString names, Int_t cutInstance);
   void          CreateHistoGen();
@@ -189,6 +191,10 @@ class AliAnalysisTaskElectronEfficiency : public AliAnalysisTaskSE {
   Double_t          fCentMin;                 // should be fCentMin=-1 for pp and p-Pb
   Double_t          fCentMax;
   Bool_t            fUseMultSelection;
+  Double_t          fPtMinCut;
+  Double_t          fPtMaxCut;
+  Double_t          fEtaMinCut;
+  Double_t          fEtaMaxCut;
   Double_t          fEtaMinGEN;
   Double_t          fEtaMaxGEN;
   Double_t          fPtMinGEN;

--- a/PWGDQ/dielectron/macrosLMEE/AddTask_caklein_ElectronEfficiency.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTask_caklein_ElectronEfficiency.C
@@ -117,6 +117,8 @@ AliAnalysisTask *AddTask_caklein_ElectronEfficiency(TString configFile="Config_c
   // pair efficiency
   task->SetDoPairing(doPairing);
   if(doPairing){
+    task->SetPtCut(PtMinCut, PtMaxCut);
+    task->SetEtaCut(EtaMinCut, EtaMaxCut);
     task->SetKineTrackCuts(SetupTrackCutsAndSettings(0));
     //task->SetPairCuts(SetupTrackCutsAndSettings(101));
     // SetupTrackCutsAndSettings(101); // this fills the pair cuts into rejCutMee,rejCutTheta,rejCutPhiV


### PR DESCRIPTION
In the pairing step the kinematic cut were not properly checked. Updated task with getter and setter for eta and pt cuts.