### PR TITLE
Fix doxygen docs for YAML config

### DIFF
--- a/PWG/Tools/AliYAMLConfiguration.cxx
+++ b/PWG/Tools/AliYAMLConfiguration.cxx
@@ -413,7 +413,8 @@ bool AliYAMLConfiguration::IsSharedValue(std::string & value) const
 /**
  * Print a particular configuration.
  *
- * @param[in] index Index of the YAML configuration.
+ * @param[in, out] stream output stream.
+ * @param[in] configPair Pair of string and YAML::Node containing the configuration to be printed.
  */
 void AliYAMLConfiguration::PrintConfiguration(std::ostream & stream, const std::pair<std::string, YAML::Node> & configPair) const
 {

--- a/PWG/Tools/AliYAMLConfiguration.h
+++ b/PWG/Tools/AliYAMLConfiguration.h
@@ -15,7 +15,7 @@
 #include <AliLog.h>
 
 /**
- * @class AliYAMLConfiguration
+ * @class PWG::Tools::AliYAMLConfiguration
  * @brief YAML configuration class for AliPhysics.
  *
  * A class to handle generic reading and writing to YAML files. This can be used to configure tasks, coordinate trains,
@@ -554,7 +554,7 @@ bool AliYAMLConfiguration::GetProperty(YAML::Node & node, YAML::Node & sharedPar
  * Write a value to a YAML configuration. Note that the value is written to the YAML configuration, but then
  * the YAML configuration needs to explicitly be written to file if the changes should be persistent.
  *
- * @param[in] propertyPath Path to the property in the YAML file.
+ * @param[in] propertyName Path to the property in the YAML file.
  * @param[in] property Property to be written.
  * @param[in] configurationName Name of the YAML configuration file to which the property should be written.
  *


### PR DESCRIPTION
The long description did not show up properly due to the
PWG::Tools namespace not being specified in the class description