### PR TITLE
Prepare jetfinding with ITS pure stand alone tracks

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionESD.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionESD.cxx
@@ -62,6 +62,10 @@ void AliEmcalTrackSelectionESD::GenerateTrackCuts(ETrackFilterType_t type, const
     AliEmcalESDTrackCutsGenerator::AddTPCOnlyTrackCuts(this, period);
     break;
 
+  case kITSPureTracks:
+    AddTrackCuts(AliESDtrackCuts::GetStandardITSPureSATrackCuts2010(kTRUE, kFALSE));
+    break;
+
   default:
     break;
   }


### PR DESCRIPTION
- Add ITS stand alone track cuts to the AliEmcalTrackSelectionESD
- Move from hard coded container names to container names handled
  by the EMCAL analysis factory in the jetsubstructuretree task