### PR TITLE
PWG/EMCAL and OADB/EMCAL: custom bad channel map feature added to EMCtender

### DIFF
--- a/PWG/EMCAL/macros/AddTaskEMCALTender.C
+++ b/PWG/EMCAL/macros/AddTaskEMCALTender.C
@@ -30,7 +30,8 @@ AliAnalysisTaskSE *AddTaskEMCALTender(
   Int_t  removeNMCGenerators  = 0,        // set number of accepted MC generators input (only for enableFracEMCRecalc=1)
   Bool_t enableMCGenRemovTrack= 1,        // apply the MC generators rejection also for track matching  
   TString removeMCGen1        = "",       // name of generator input to be accepted
-  TString removeMCGen2        = ""        // name of generator input to be accepted
+  TString removeMCGen2        = "",       // name of generator input to be accepted
+  TString customBCmap         = ""        // location of custom bad channel map (full path including file)
 ) 
 {
   // Get the pointer to the existing analysis manager via the static access method.
@@ -89,6 +90,8 @@ AliAnalysisTaskSE *AddTaskEMCALTender(
 
   if (pass) 
     EMCALSupply->SetPass(pass);
+  if (customBCmap!="") 
+    EMCALSupply->SetCustomBC(customBCmap);
 
   if (evhand->InheritsFrom("AliESDInputHandler")) {
     #ifdef __CLING__

--- a/TENDER/TenderSupplies/AliEMCALTenderSupply.cxx
+++ b/TENDER/TenderSupplies/AliEMCALTenderSupply.cxx
@@ -84,6 +84,7 @@ AliEMCALTenderSupply::AliEMCALTenderSupply() :
   ,fEtacut(-1)
   ,fPhicut(-1)
   ,fBasePath("")
+  ,fCustomBC("")
   ,fReClusterize(kFALSE)
   ,fClusterizer(0)
   ,fGeomMatrixSet(kFALSE)
@@ -154,6 +155,7 @@ AliEMCALTenderSupply::AliEMCALTenderSupply(const char *name, const AliTender *te
   ,fEtacut(-1)  
   ,fPhicut(-1)  
   ,fBasePath("")
+  ,fCustomBC("")
   ,fReClusterize(kFALSE)
   ,fClusterizer(0)
   ,fGeomMatrixSet(kFALSE)
@@ -224,6 +226,7 @@ AliEMCALTenderSupply::AliEMCALTenderSupply(const char *name, AliAnalysisTaskSE *
   ,fEtacut(-1)  
   ,fPhicut(-1)  
   ,fBasePath("")
+  ,fCustomBC("")
   ,fReClusterize(kFALSE)
   ,fClusterizer(0)
   ,fGeomMatrixSet(kFALSE)
@@ -385,6 +388,7 @@ void AliEMCALTenderSupply::Init()
     AliInfo("------------ Variables -------------------------"); 
     AliInfo(Form("DebugLevel : %d", fDebugLevel)); 
     AliInfo(Form("BasePath : %s", fBasePath.Data())); 
+    AliInfo(Form("CustomBCFile : %s", fCustomBC.Data())); 
     AliInfo(Form("ConfigFileName : %s", fConfigName.Data())); 
     AliInfo(Form("EMCALGeometryName : %s", fEMCALGeoName.Data())); 
     AliInfo(Form("NonLinearityFunction : %d", fNonLinearFunc)); 
@@ -1005,8 +1009,23 @@ Int_t AliEMCALTenderSupply::InitBadChannels()
     
     if (fbad) delete fbad;
     
-    contBC->InitFromFile(Form("%s/EMCALBadChannels.root",fBasePath.Data()),"AliEMCALBadChannels");    
-  } 
+    contBC->InitFromFile(Form("%s/EMCALBadChannels.root",fBasePath.Data()),"AliEMCALBadChannels");
+  }
+  else if (fCustomBC!="")
+  { //if fCustomBC specified in the ->SetCustomBC()
+    if (fDebugLevel>0) AliInfo(Form("Loading Bad Channels OADB from given path %s",fCustomBC.Data()));
+    
+    TFile *fbad=new TFile(Form("%s",fCustomBC.Data()),"read");
+    if (!fbad || fbad->IsZombie())
+    {
+      AliFatal(Form("Input file was not found in the path provided: %s",fCustomBC.Data()));
+      return 0;
+    }
+    
+    if (fbad) delete fbad;
+    
+    contBC->InitFromFile(Form("%s",fCustomBC.Data()),"AliEMCALBadChannels");
+  }
   else 
   { // Else choose the one in the $ALICE_PHYSICS directory
     if (fDebugLevel>0) AliInfo("Loading Bad Channels OADB from $ALICE_PHYSICS/OADB/EMCAL");

--- a/TENDER/TenderSupplies/AliEMCALTenderSupply.h
+++ b/TENDER/TenderSupplies/AliEMCALTenderSupply.h
@@ -63,6 +63,8 @@ public:
 
   void     SetBasePath(const Char_t *basePath)            { fBasePath = basePath             ;}
  
+  void     SetCustomBC(const Char_t *BCfile)              { fCustomBC = BCfile               ;}
+ 
   void     SetConfigFileName(const char *name)            { fConfigName = name               ;}
 
   void     SetNonLinearityFunction(Int_t fun)             { fNonLinearFunc = fun             ;}
@@ -253,6 +255,7 @@ private:
   Float_t                fEtacut;                 // eta cut for track matching  
   Float_t                fPhicut;                 // phi cut for track matching  
   TString                fBasePath;               // base folder path to get root files 
+  TString                fCustomBC;               // custom BC map file
   Bool_t                 fReClusterize;           // switch for reclustering
   AliEMCALClusterizer   *fClusterizer;            //!clusterizer 
   Bool_t                 fGeomMatrixSet;          // set geometry matrices only once, for the first event.         
@@ -293,6 +296,6 @@ private:
   AliEMCALTenderSupply(            const AliEMCALTenderSupply&c);
   AliEMCALTenderSupply& operator= (const AliEMCALTenderSupply&c);
   
-  ClassDef(AliEMCALTenderSupply, 19); // EMCAL tender task
+  ClassDef(AliEMCALTenderSupply, 20); // EMCAL tender task
 };
 #endif


### PR DESCRIPTION
With this small addition, it is now possible to load a custom bad channel map for testing purposes. The previous feature to set a different path for all calibrations remains unchanged with this update.