### PR TITLE
Changes to CF (Lc,D0) tasks: i) new Falcon mode ii) fill less steps

### DIFF
--- a/PWGHF/vertexingHF/AliCFTaskVertexingHF.h
+++ b/PWGHF/vertexingHF/AliCFTaskVertexingHF.h
@@ -66,7 +66,8 @@ class AliCFTaskVertexingHF: public AliAnalysisTaskSE {
 
   enum {
     kSnail = 0,    /// slow configuration, all variables
-    kCheetah = 1   /// fast configuration, only a subset of variables
+    kCheetah = 1,   /// fast configuration, only a subset of variables
+    kFalcon = 2   /// super fast configuration, only (pt,y,centrality)
   };
 
   enum {
@@ -263,6 +264,9 @@ class AliCFTaskVertexingHF: public AliAnalysisTaskSE {
   void SetUseCascadeTaskForLctoV0bachelor(Bool_t useCascadeTaskForLctoV0bachelor) {fUseCascadeTaskForLctoV0bachelor = useCascadeTaskForLctoV0bachelor;}
   Bool_t GetUseCascadeTaskForLctoV0bachelor() const {return fUseCascadeTaskForLctoV0bachelor;}
 
+  void SetFillMinimumSteps(Bool_t FillMinimumSteps) {fFillMinimumSteps = FillMinimumSteps;}
+  Bool_t GetFillMinimumSteps() const {return fFillMinimumSteps;}
+
   void SetCutOnMomConservation(Float_t cut) {fCutOnMomConservation = cut;}
   Bool_t GetCutOnMomConservation() const {return fCutOnMomConservation;}
 
@@ -326,10 +330,11 @@ class AliCFTaskVertexingHF: public AliAnalysisTaskSE {
   Bool_t fUseCutsForTMVA;     /// flag to use additional cuts needed for Lc --> K0S + p, TMVA
   /// these are the pre-selection cuts for the TMVA
   Bool_t fUseCascadeTaskForLctoV0bachelor;   /// flag to define which task to use for Lc --> K0S+p
+  Bool_t fFillMinimumSteps;   /// Skip filling the unneed steps for most of the analyses to save disk space
   Float_t fCutOnMomConservation; /// cut on momentum conservation
 
   /// \cond CLASSIMP     
-  ClassDef(AliCFTaskVertexingHF,25); /// class for HF corrections as a function of many variables
+  ClassDef(AliCFTaskVertexingHF,26); /// class for HF corrections as a function of many variables
   /// \endcond
 };
 

--- a/PWGHF/vertexingHF/AliCFVertexingHF2Prong.cxx
+++ b/PWGHF/vertexingHF/AliCFVertexingHF2Prong.cxx
@@ -227,6 +227,12 @@ Bool_t AliCFVertexingHF2Prong::GetGeneratedValuesFromMCParticle(Double_t* vector
 		vectorMC[6] = 1. ;  // fake: always filling with 1 at MC level 
 		vectorMC[7] = fMultiplicity;   // dummy value for d0pi, meaningless in MC, in micron
 		break;
+	case AliCFTaskVertexingHF::kFalcon:
+		vectorMC[0] = fmcPartCandidate->Pt();
+		vectorMC[1] = fmcPartCandidate->Y() ;
+		vectorMC[2] = fCentValue;   // dummy value for dca, meaningless in MC
+		vectorMC[3] = fMultiplicity;   // dummy value for dca, meaningless in MC
+		break;
 	}
 	delete decay;
 	bGenValues = kTRUE;
@@ -309,6 +315,12 @@ Bool_t AliCFVertexingHF2Prong::GetRecoValuesFromCandidate(Double_t *vectorReco) 
 		vectorReco[5] = fCentValue;   
 		vectorReco[6] = fFake ; 
 		vectorReco[7] = fMultiplicity;  
+		break;
+	case AliCFTaskVertexingHF::kFalcon:
+		vectorReco[0] = pt;
+		vectorReco[1] = rapidity ;
+		vectorReco[2] = fCentValue;   
+		vectorReco[3] = fMultiplicity;   
 		break;
 	}
 

--- a/PWGHF/vertexingHF/AliCFVertexingHFLctoV0bachelor.cxx
+++ b/PWGHF/vertexingHF/AliCFVertexingHFLctoV0bachelor.cxx
@@ -386,16 +386,16 @@ Bool_t AliCFVertexingHFLctoV0bachelor::GetRecoValuesFromCandidate(Double_t *vect
 
   }
 
-  vectorReco[0]  = pt;
-  vectorReco[1]  = rapidity;
-  vectorReco[2]  = phi;
-  vectorReco[3]  = onTheFlyStatus;
-  vectorReco[4]  = fzPrimVertex;
-  vectorReco[5]  = fCentValue;
-  vectorReco[6]  = fFake; // whether the reconstructed candidate was a fake (fFake = 0) or not (fFake = 2) 
-  vectorReco[7]  = fMultiplicity;
 
   if (fConfiguration==AliCFTaskVertexingHF::kSnail) {
+    vectorReco[0]  = pt;
+    vectorReco[1]  = rapidity;
+    vectorReco[2]  = phi;
+    vectorReco[3]  = onTheFlyStatus;
+    vectorReco[4]  = fzPrimVertex;
+    vectorReco[5]  = fCentValue;
+    vectorReco[6]  = fFake; // whether the reconstructed candidate was a fake (fFake = 0) or not (fFake = 2) 
+    vectorReco[7]  = fMultiplicity;
     //vectorReco[8]  = pTbachelor;
     vectorReco[8]  = pbachelor;
     vectorReco[9]  = v0toDaughters->Pt();
@@ -411,6 +411,22 @@ Bool_t AliCFVertexingHFLctoV0bachelor::GetRecoValuesFromCandidate(Double_t *vect
     vectorReco[15] = cosPointingAngleLc;
     //vectorReco[16] = cTV0*1.E4; // in micron
     //vectorReco[17] = cTLc*1.E4; // in micron
+  }
+  else if (fConfiguration==AliCFTaskVertexingHF::kCheetah) {
+    vectorReco[0]  = pt;
+    vectorReco[1]  = rapidity;
+    vectorReco[2]  = phi;
+    vectorReco[3]  = onTheFlyStatus;
+    vectorReco[4]  = fzPrimVertex;
+    vectorReco[5]  = fCentValue;
+    vectorReco[6]  = fFake; // whether the reconstructed candidate was a fake (fFake = 0) or not (fFake = 2) 
+    vectorReco[7]  = fMultiplicity;
+  }
+  else if (fConfiguration==AliCFTaskVertexingHF::kFalcon) {
+    vectorReco[0]  = pt;
+    vectorReco[1]  = rapidity;
+    vectorReco[2]  = fCentValue;
+    vectorReco[3]  = fMultiplicity;
   }
 
   bFillRecoValues = kTRUE;
@@ -1074,16 +1090,16 @@ Bool_t AliCFVertexingHFLctoV0bachelor::FillVectorFromMCarray(AliAODMCParticle *m
   }
   delete decay;
 
-  vectorMC[0]  = fmcPartCandidate->Pt();
-  vectorMC[1]  = fmcPartCandidate->Y() ;
-  vectorMC[2]  = fmcPartCandidate->Phi();
-  vectorMC[3]  = 0; // dummy value x MC, onTheFlyStatus
-  vectorMC[4]  = fzMCVertex;
-  vectorMC[5]  = fCentValue; // reconstructed centrality
-  vectorMC[6]  = 1; // dummy value x MC, fFake
-  vectorMC[7]  = fMultiplicity; // reconstructed multiplicity
 
   if (fConfiguration==AliCFTaskVertexingHF::kSnail) {
+    vectorMC[0]  = fmcPartCandidate->Pt();
+    vectorMC[1]  = fmcPartCandidate->Y() ;
+    vectorMC[2]  = fmcPartCandidate->Phi();
+    vectorMC[3]  = 0; // dummy value x MC, onTheFlyStatus
+    vectorMC[4]  = fzMCVertex;
+    vectorMC[5]  = fCentValue; // reconstructed centrality
+    vectorMC[6]  = 1; // dummy value x MC, fFake
+    vectorMC[7]  = fMultiplicity; // reconstructed multiplicity
     //vectorMC[8]  = pTbach;
     vectorMC[8]  = pbach;
     vectorMC[9]  = mcPartDaughterV0->Pt();
@@ -1095,6 +1111,22 @@ Bool_t AliCFVertexingHFLctoV0bachelor::FillVectorFromMCarray(AliAODMCParticle *m
     vectorMC[15] = cosPAwrtPrimVtxLc;
     //vectorMC[16] = cTV0*1.E4; // in micron
     //vectorMC[17] = cTLc*1.E4; // in micron
+  }
+  else if (fConfiguration==AliCFTaskVertexingHF::kCheetah) {
+    vectorMC[0]  = fmcPartCandidate->Pt();
+    vectorMC[1]  = fmcPartCandidate->Y() ;
+    vectorMC[2]  = fmcPartCandidate->Phi();
+    vectorMC[3]  = 0; // dummy value x MC, onTheFlyStatus
+    vectorMC[4]  = fzMCVertex;
+    vectorMC[5]  = fCentValue; // reconstructed centrality
+    vectorMC[6]  = 1; // dummy value x MC, fFake
+    vectorMC[7]  = fMultiplicity; // reconstructed multiplicity
+  }
+  else if (fConfiguration==AliCFTaskVertexingHF::kFalcon) {
+    vectorMC[0]  = fmcPartCandidate->Pt();
+    vectorMC[1]  = fmcPartCandidate->Y() ;
+    vectorMC[2]  = fCentValue; // reconstructed centrality
+    vectorMC[3]  = fMultiplicity; // reconstructed multiplicity
   }
 
   bGenValues = kTRUE;

--- a/PWGHF/vertexingHF/macros/AddTaskCFVertexingHF.C
+++ b/PWGHF/vertexingHF/macros/AddTaskCFVertexingHF.C
@@ -72,6 +72,9 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF(const char* cutFile = "./D0toKpiCuts.
 	else if (configuration == AliCFTaskVertexingHF::kCheetah){
 		printf("The configuration is set to be FAST --> using only pt, y, ct, phi, zvtx, centrality, fake, multiplicity to fill the CF\n");
 	}
+	else if (configuration == AliCFTaskVertexingHF::kFalcon){
+		printf("The configuration is set to be FAST --> using only pt, y, centrality to fill the CF\n");
+	}
 	else{
 		printf("The configuration is not defined! returning\n");
 		return;
@@ -526,6 +529,38 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF(const char* cutFile = "./D0toKpiCuts.
 		container -> SetVarTitle(icentFast, "centrality");
 		container -> SetVarTitle(ifakeFast, "fake");
 		container -> SetVarTitle(imultFast, "multiplicity");
+  }
+	else if (configuration == AliCFTaskVertexingHF::kFalcon){
+		//arrays for the number of bins in each dimension
+		const Int_t nvar = 4;
+
+		const UInt_t ipTSuperFast = 0;
+		const UInt_t iySuperFast = 1;
+		const UInt_t icentSuperFast = 2;
+		const UInt_t imultSuperFast = 3;
+
+		Int_t iBinSuperFast[nvar];
+		iBinSuperFast[ipTSuperFast] = iBin[ipT];
+		iBinSuperFast[iySuperFast] = iBin[iy];
+		iBinSuperFast[icentSuperFast] = iBin[icent];
+		iBinSuperFast[imultSuperFast] = iBin[imult];
+
+		container = new AliCFContainer(nameContainer,"container for tracks",nstep,nvar,iBinSuperFast);
+		printf("pt\n");
+		if(isFinePtBin) container -> SetBinLimits(ipTSuperFast,binLimpTFine); 
+		else      	container -> SetBinLimits(ipTSuperFast,binLimpT);
+		printf("y\n");
+		container -> SetBinLimits(iySuperFast,binLimy);
+		printf("centrality\n");
+		container -> SetBinLimits(icentSuperFast,binLimcent);
+		printf("multiplicity\n");
+		if(isFineNtrkBin) container -> SetBinLimits(imultSuperFast,binLimmultFine);
+		else              container -> SetBinLimits(imultSuperFast,binLimmult);
+
+		container -> SetVarTitle(ipTSuperFast,"pt");
+		container -> SetVarTitle(iySuperFast,"y");
+		container -> SetVarTitle(icentSuperFast, "centrality");
+		container -> SetVarTitle(imultSuperFast, "multiplicity");
 	}
 
 	container -> SetStepTitle(0, "MCLimAcc");

--- a/PWGHF/vertexingHF/macros/AddTaskCFVertexingHFLctoV0bachelor.C
+++ b/PWGHF/vertexingHF/macros/AddTaskCFVertexingHFLctoV0bachelor.C
@@ -81,6 +81,9 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelor(const char* cutFile = "
   else if (configuration == AliCFTaskVertexingHF::kCheetah){
     printf("The configuration is set to be FAST --> using only pt, y, ct, phi, zvtx, centrality, fake, multiplicity to fill the CF\n");
   }
+  else if (configuration == AliCFTaskVertexingHF::kFalcon){
+    printf("The configuration is set to be FAST --> using only pt, y, centrality to fill the CF\n");
+  }
   else{
     printf("The configuration is not defined! returning\n");
     return;
@@ -351,32 +354,26 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelor(const char* cutFile = "
   AliCFContainer* container;
   if (configuration == AliCFTaskVertexingHF::kSnail) {
     container = new AliCFContainer(nameContainer,"container for tracks",nstep,nvarTot,iBin);
-  }
-  else if (configuration == AliCFTaskVertexingHF::kCheetah) {
-    container = new AliCFContainer(nameContainer,"container for tracks",nstep,8,iBin);
-  }
+    //setting the bin limits
+    container -> SetBinLimits(ipT,binLimpT);
+    container -> SetBinLimits(iy,binLimy);
+    container -> SetBinLimits(iphi,binLimphi);
+    container -> SetBinLimits(ionFly,binLimonFlyV0);
+    container -> SetBinLimits(iZvtx,binLimzvtx);
+    container -> SetBinLimits(icent,binLimcent);
+    container -> SetBinLimits(ifake,binLimfake);
+    if (isFineNtrkBin) container->SetBinLimits(imult, binLimmultFine);
+    else               container->SetBinLimits(imult, binLimmult);
 
-  //setting the bin limits
-  container -> SetBinLimits(ipT,binLimpT);
-  container -> SetBinLimits(iy,binLimy);
-  container -> SetBinLimits(iphi,binLimphi);
-  container -> SetBinLimits(ionFly,binLimonFlyV0);
-  container -> SetBinLimits(iZvtx,binLimzvtx);
-  container -> SetBinLimits(icent,binLimcent);
-  container -> SetBinLimits(ifake,binLimfake);
-  if (isFineNtrkBin) container->SetBinLimits(imult, binLimmultFine);
-  else               container->SetBinLimits(imult, binLimmult);
+    container -> SetVarTitle(ipT,"p_{T}(#Lambda_{c}) [GeV/c]");
+    container -> SetVarTitle(iy,"y(#Lambda_{c})");
+    container -> SetVarTitle(iphi,"#phi(#Lambda_{c}) [rad]");
+    container -> SetVarTitle(ionFly,"onTheFlyStatusV0");
+    container -> SetVarTitle(iZvtx,"z_{vtx} [cm]");
+    container -> SetVarTitle(icent,"centrality");
+    container -> SetVarTitle(ifake,"fake");
+    container -> SetVarTitle(imult,"multiplicity");
 
-  container -> SetVarTitle(ipT,"p_{T}(#Lambda_{c}) [GeV/c]");
-  container -> SetVarTitle(iy,"y(#Lambda_{c})");
-  container -> SetVarTitle(iphi,"#phi(#Lambda_{c}) [rad]");
-  container -> SetVarTitle(ionFly,"onTheFlyStatusV0");
-  container -> SetVarTitle(iZvtx,"z_{vtx} [cm]");
-  container -> SetVarTitle(icent,"centrality");
-  container -> SetVarTitle(ifake,"fake");
-  container -> SetVarTitle(imult,"multiplicity");
-
-  if (configuration == AliCFTaskVertexingHF::kSnail) {
     container -> SetBinLimits(ipbach,binLimpbach);
     container -> SetBinLimits(ipTV0,binLimpTV0);
     container -> SetBinLimits(iyV0,binLimyV0);
@@ -398,6 +395,51 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelor(const char* cutFile = "
     container -> SetVarTitle(icosPA,"cosine pointing angle (#Lambda_{c})");
     //container -> SetVarTitle(,"c#tau -V0-");
     //container -> SetVarTitle(,"c#tau");
+  }
+  else if (configuration == AliCFTaskVertexingHF::kCheetah) {
+    container = new AliCFContainer(nameContainer,"container for tracks",nstep,8,iBin);
+    //setting the bin limits
+    container -> SetBinLimits(ipT,binLimpT);
+    container -> SetBinLimits(iy,binLimy);
+    container -> SetBinLimits(iphi,binLimphi);
+    container -> SetBinLimits(ionFly,binLimonFlyV0);
+    container -> SetBinLimits(iZvtx,binLimzvtx);
+    container -> SetBinLimits(icent,binLimcent);
+    container -> SetBinLimits(ifake,binLimfake);
+    if (isFineNtrkBin) container->SetBinLimits(imult, binLimmultFine);
+    else               container->SetBinLimits(imult, binLimmult);
+
+    container -> SetVarTitle(ipT,"p_{T}(#Lambda_{c}) [GeV/c]");
+    container -> SetVarTitle(iy,"y(#Lambda_{c})");
+    container -> SetVarTitle(iphi,"#phi(#Lambda_{c}) [rad]");
+    container -> SetVarTitle(ionFly,"onTheFlyStatusV0");
+    container -> SetVarTitle(iZvtx,"z_{vtx} [cm]");
+    container -> SetVarTitle(icent,"centrality");
+    container -> SetVarTitle(ifake,"fake");
+    container -> SetVarTitle(imult,"multiplicity");
+  }
+  else if (configuration == AliCFTaskVertexingHF::kFalcon) {
+    Int_t iBinSuperFast[4];
+		const UInt_t ipTSuperFast = 0;
+		const UInt_t iySuperFast = 1;
+		const UInt_t icentSuperFast = 2;
+		const UInt_t imultSuperFast = 3;
+    iBinSuperFast[ipTSuperFast]=iBin[ipT];
+    iBinSuperFast[iySuperFast]=iBin[iy];
+    iBinSuperFast[icentSuperFast]=iBin[icent];
+    iBinSuperFast[imultSuperFast]=iBin[imult];
+    container = new AliCFContainer(nameContainer,"container for tracks",nstep,4,iBinSuperFast);
+    //setting the bin limits
+    container -> SetBinLimits(ipTSuperFast,binLimpT);
+    container -> SetBinLimits(iySuperFast,binLimy);
+    container -> SetBinLimits(icentSuperFast,binLimcent);
+    if (isFineNtrkBin) container->SetBinLimits(imultSuperFast, binLimmultFine);
+    else               container->SetBinLimits(imultSuperFast, binLimmult);
+
+    container -> SetVarTitle(ipTSuperFast,"p_{T}(#Lambda_{c}) [GeV/c]");
+    container -> SetVarTitle(iySuperFast,"y(#Lambda_{c})");
+    container -> SetVarTitle(icentSuperFast,"centrality");
+    container -> SetVarTitle(imultSuperFast,"multiplicity");
   }
 
   container -> SetStepTitle(0, "MCLimAcc");


### PR DESCRIPTION
Dear all,

These are changes to the D2H CF framework (not my private codes) as described below. Also, please wait for pushing until Andrea R gives green light. He told me he will have a look via e-mail. 

As we mentioned in the PWGHF, the large output size of CF tasks are creating merging problems on LEGO trains already for 2015 data. I (after the discussion with Alessandro, Andrea F, Andrea R, Francesco) made two changes : 
i) Addition of a falcon mode that is lighter than Snail and Cheetah
ii) Option to fill only (MCLimAcc, MCAcc, RecoPPR, RecoPID)

Currently, the changes are made only for Lc and D0. I am planning to proceed as follows:
1) upload the attached code to git (D0 and Lc->pK0s only. Using the falcon mode for other mesons/baryons results in AliFatal with an appropriate message.)
2) test the output size for D0 and Lc->pK0s using LEGO train.
3) Implement the similar changes for other mesons/baryons
4) notify analyzers about the updates with some cautions, like the centrality/mult axes number is different from Cheetah, and ask them to check if they are OK. Recommend them to use the falcon mode + reduced steps unless the other axes are needed.

Thanks! 
Best regards,
Yosuke