### PR TITLE
Fix filling number of trials for the case of AODs

### DIFF
--- a/PWGJE/PWGJE/AliPWG4HighPtTrackQA.cxx
+++ b/PWGJE/PWGJE/AliPWG4HighPtTrackQA.cxx
@@ -1364,6 +1364,24 @@ void AliPWG4HighPtTrackQA::DoAnalysisAOD()
   //
   AliAODEvent *aod = dynamic_cast<AliAODEvent*>(fEvent);
   if(!aod) return;
+
+  // ---- Get MC Header information (for MC productions in pThard bins) ----
+  Double_t ptHard = 0.;
+  Double_t nTrials = 1; // trials for MC trigger weight for real data
+
+  if(MCEvent()){
+    AliGenPythiaEventHeader*  pythiaGenHeader = GetPythiaEventHeader(MCEvent());
+    if(pythiaGenHeader){
+      nTrials = pythiaGenHeader->Trials();
+      ptHard  = pythiaGenHeader->GetPtHard();
+
+      fh1PtHard->Fill(ptHard);
+      fh1PtHardTrials->Fill(ptHard,nTrials);
+
+      fh1Trials->Fill("#sum{ntrials}",fAvgTrials);
+    }
+  }
+
   AliExternalTrackParam exParam;
   for (Int_t iTrack = 0; iTrack < fEvent->GetNumberOfTracks(); iTrack++) {
 
@@ -1557,6 +1575,10 @@ Bool_t AliPWG4HighPtTrackQA::PythiaInfoFromFile(const char* currFile,Float_t &fX
 
   if(file.Contains("root_archive.zip#")){
     Ssiz_t pos1 = file.Index("root_archive",12,TString::kExact);
+    Ssiz_t pos = file.Index("#",1,pos1,TString::kExact);
+    file.Replace(pos+1,20,"");
+  } else if(file.Contains("aod_archive.zip#")){
+    Ssiz_t pos1 = file.Index("aod_archive",11,TString::kExact);
     Ssiz_t pos = file.Index("#",1,pos1,TString::kExact);
     file.Replace(pos+1,20,"");
   }


### PR DESCRIPTION
Method to fill number of trials and pt-hard
was missing for AODs. The detection whether
the task is running on AODs is based on the
result of the MCEvent() function and does
not access the MC handler directly as in the
current implementation for ESDs.