### PR TITLE
relaxed DCA cut for fine-tuned analysis

### DIFF
--- a/PWGCF/Correlations/DPhi/AliAnalysisTaskCorPIDTOFQA.cxx
+++ b/PWGCF/Correlations/DPhi/AliAnalysisTaskCorPIDTOFQA.cxx
@@ -143,6 +143,8 @@ AliAnalysisTaskCorPIDTOFQA::~AliAnalysisTaskCorPIDTOFQA()
 void AliAnalysisTaskCorPIDTOFQA::UserCreateOutputObjects()
 {
     fAnalysisUtils = new AliAnalysisUtils;
+//  fAnalysisUtils−>SetCutOnZVertexSPD(0);
+    fAnalysisUtils->SetCutOnZVertexSPD(0);
     
     fOutputList = new TList();          // this is a list which will contain all of your histograms
                                         // at the end of the analysis, the contents of this list are written
@@ -223,6 +225,8 @@ void AliAnalysisTaskCorPIDTOFQA::UserExec(Option_t *)
 
 
     if(!fAnalysisUtils->IsVertexSelected2013pA(fAOD)) return;
+
+
     if(fAnalysisUtils->IsPileUpSPD(fAOD)) return;
 
     primary_vertex_z_cut->Fill(pv);
@@ -276,8 +280,6 @@ void AliAnalysisTaskCorPIDTOFQA::UserExec(Option_t *)
 
 
 	Short_t charge        = track->Charge();
-	Float_t deut_mean     = 0.0;  // values set below using fit curves
-	Float_t deut_sigma    = 0.0;  // values set below using fit curves
 
 
 	Float_t m2tof  = get_mass_squared(track);

--- a/PWGCF/Correlations/DPhi/AliAnalysisTaskCorPIDTOFQA.h
+++ b/PWGCF/Correlations/DPhi/AliAnalysisTaskCorPIDTOFQA.h
@@ -31,10 +31,10 @@ class AliAnalysisTaskCorPIDTOFQA : public AliAnalysisTaskSE
 	virtual Double_t      get_mass_squared(AliAODTrack *track);
 
 
-	Double_t deut_curves[2][2][3];  /* [charge][mean,sigma][par]  */
-	TF1 *fit_deut_curve = new TF1("fit_m_mean",   "[0] + [1]*x + [2]/sqrt(x)",  1.0, 4.4);
+//	Double_t deut_curves[2][2][3];  /* [charge][mean,sigma][par]  */
+//	TF1 *fit_deut_curve = new TF1("fit_m_mean",   "[0] + [1]*x + [2]/sqrt(x)",  1.0, 4.4);
 
-	Double_t cut_width  = 3.0;
+//	Double_t cut_width  = 3.0;
 	
     private:
 


### PR DESCRIPTION
In intend to use this skim to carefully test the results of DCA cut selection.  This course follows ANA-3952.