### PR TITLE
Fix handling of filtermask

### DIFF
--- a/PWGJE/PWGJE/AliPWG4HighPtTrackQA.cxx
+++ b/PWGJE/PWGJE/AliPWG4HighPtTrackQA.cxx
@@ -1387,7 +1387,7 @@ void AliPWG4HighPtTrackQA::DoAnalysisAOD()
 
     AliAODTrack *aodtrack = dynamic_cast<AliAODTrack*>(aod->GetTrack(iTrack));
     if(!aodtrack) AliFatal("Not a standard AOD");
-    if( !aodtrack->TestFilterMask(fFilterMask) ) {
+    if( !aodtrack->TestFilterBit(fFilterMask) ) {
       fh1NTracksReject->Fill("noHybridTrack",1);
       continue;
     }

--- a/PWGJE/macros/AddTaskPWG4HighPtTrackQA.C
+++ b/PWGJE/macros/AddTaskPWG4HighPtTrackQA.C
@@ -249,7 +249,9 @@ void AddTaskPWG4HighPtTrackQAAOD(const char *prodType, Bool_t isPbPb, Int_t iAOD
       strRunPeriod == "lhc13f" || strRunPeriod == "lhc13g" || 
       strRunPeriod == "lhc12a15e" || strRunPeriod == "lhc13b4" || strRunPeriod == "lhc13b4_fix" || 
       strRunPeriod == "lhc13b4_plus" || strRunPeriod == "lhc12a15f" || strRunPeriod.Contains("lhc12a17") || strRunPeriod.Contains("lhc14a1") ||
-      strRunPeriod == "lhc15o") {
+      strRunPeriod.Contains("lhc17f8") ||
+      (strRunPeriod.Length() == 6 && (strRunPeriod.BeginsWith("lhc15") || strRunPeriod.BeginsWith("lhc16") || strRunPeriod.BeginsWith("lhc17"))) // All run2 data
+      ) {
     filterBit  = 768;
     filterBit1 = 256;
     filterBit2 = 512;


### PR DESCRIPTION
The case of both hybrid tracks (2 bits set) was handled
improperly: By using TestFilterMask the check is done
for equalty (which means AOD tracks must have both
bits set in order to be accepted), which is impossible
for hybrid tracks (can only be of one type). Changed to
TestFilterBits, which selects tracks in case any of the
bits is set.

In addition adding new datasets from run2 to the configuration.