### PR TITLE
ATO-245: Possibility to change default downscale from env.varaible

### DIFF
--- a/PWGPP/macros/AddTaskFilteredTree.C
+++ b/PWGPP/macros/AddTaskFilteredTree.C
@@ -8,8 +8,8 @@ AliAnalysisTask* AddTaskFilteredTree(TString outputFile="")
   gSystem->Load("libTPCcalib");
   gSystem->Load("libPWGPP");
   gSystem->Load("libPWGLFspectra");
-
-
+  ::Info("AddTaskFilteredTree","BEGIN");
+  printf("AddTaskFilteredTree::BEGIN\n");
   gRandom->SetSeed(0);
 
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
@@ -65,7 +65,6 @@ AliAnalysisTask* AddTaskFilteredTree(TString outputFile="")
   } else {
     esdTrackCuts->SetHistogramsOn(kTRUE);
   }
-
   Bool_t hasMC=(AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler()!=0x0);
 
   //
@@ -79,6 +78,22 @@ AliAnalysisTask* AddTaskFilteredTree(TString outputFile="")
   task->SetLowPtV0DownscaligF(2.e3);
   task->SetProcessAll(kTRUE);
   task->SetProcessCosmics(kTRUE);
+  if (gSystem->Getenv("AliAnalysisTaskFilteredTree_SetLowPtTrackDownscalingF")) {
+    Float_t downscale=TString(gSystem->Getenv("AliAnalysisTaskFilteredTree_SetLowPtTrackDownscalingF")).Atof();
+    task->SetLowPtTrackDownscaligF(downscale);
+    printf("AliAnalysisTaskFilteredTree_SetLowPtTrackDownscalingF: From env. variable\t%f\n", downscale);
+  }else {
+    ::Info("AliAnalysisTaskFilteredTree__SetLowPtTrackDownscalingF", "Use default");
+    printf("AliAnalysisTaskFilteredTree_SetLowPtV0DownscalingF::Use DEFAULT\t%s\n",task->GetLowPtTracksDownscaligF());
+  }
+  if (gSystem->Getenv("AliAnalysisTaskFilteredTree_SetLowPtV0DownscalingF")) {
+    Float_t downscale=TString(gSystem->Getenv("AliAnalysisTaskFilteredTree_SetLowPtV0DownscalingF")).Atof();
+    task->SetLowPtV0DownscaligF(downscale);
+    printf("AliAnalysisTaskFilteredTree_SetLowPtV0DownscalingF:From enc. variable\t%f\n",downscale);
+  }else {
+    printf("AliAnalysisTaskFilteredTree_SetLowPtV0DownscalingF::Use DEFAULT\t%f\n",task->GetLowPtV0DownscaligF());
+  }
+  //task->Dump();
   //task->SetProcessAll(kFALSE);
   //task->SetFillTrees(kFALSE); // only histograms are filled
 
@@ -128,7 +143,8 @@ AliAnalysisTask* AddTaskFilteredTree(TString outputFile="")
   AliAnalysisDataContainer *coutput7 = mgr->CreateContainer("histo7", TList::Class(), AliAnalysisManager::kOutputContainer, outputFileHisto.Data());
   mgr->ConnectOutput(task, 7, coutput7);
 
-
+   ::Info("AddTaskFilteredTree","END");
+  printf("AddTaskFilteredTree::END\n");
   return task;
 }
 


### PR DESCRIPTION
* Needed to adjust downscaling for different generators resp, triggered samples
  * MC - e,g for AliGenPerformance down-scaling factor 10 for low pt tracks instead of default factor 10^5 for minimum bias simulation
  * Real data - for triggered data sample also factor ~ 10-100 instead of default 10^5
````
if (gSystem->Getenv("AliAnalysisTaskFilteredTree_SetLowPtTrackDownscalingF")) {
+    Float_t downscale=TString(gSystem->Getenv("AliAnalysisTaskFilteredTree_SetLowPtTrackDownscalingF")).Atof();
+    task->SetLowPtTrackDownscaligF(downscale);
+    printf("AliAnalysisTaskFilteredTree_SetLowPtTrackDownscalingF: From env. variable\t%f\n", downscale);
+  }

+  if (gSystem->Getenv("AliAnalysisTaskFilteredTree_SetLowPtV0DownscalingF")) {
+    Float_t downscale=TString(gSystem->Getenv("AliAnalysisTaskFilteredTree_SetLowPtV0DownscalingF")).Atof();
+    task->SetLowPtV0DownscaligF(downscale);
+    printf("AliAnalysisTaskFilteredTree_SetLowPtV0DownscalingF:From enc. variable\t%f\n",downscale);
+  }
````