### PR TITLE
Implement (i) mixed event (ii) track rotation from track and v0

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelor.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelor.cxx
@@ -111,7 +111,16 @@ AliAnalysisTaskSELc2V0bachelor::AliAnalysisTaskSELc2V0bachelor() : AliAnalysisTa
   fSign(2),
   fCheckOrigin(kFALSE),
   fReconstructSecVtx(kFALSE),
-  fDoSingleAnalysisForSystK0SP(0)
+  fDoSingleAnalysisForSystK0SP(0),
+  fGenerateBGEventFromTracks(0),
+  fNumberOfEventsForMixing		(10),
+  fNzVtxBins					(0), 
+  fNCentBins					(0),
+  fNOfPools(1),
+  fPoolIndex(-9999),
+  fNextResVec(),
+  fReservoirsReady(),
+  fReservoirP()
 {
   //
   /// Default ctor
@@ -120,7 +129,9 @@ AliAnalysisTaskSELc2V0bachelor::AliAnalysisTaskSELc2V0bachelor() : AliAnalysisTa
   Double_t mLcPDG = TDatabasePDG::Instance()->GetParticle(4122)->Mass();
   fMinMass=mLcPDG-0.250;
   fMaxMass=mLcPDG+0.250;
-
+  for(Int_t i=0;i<100;i++){
+    fZvtxBins[i] = 9999; fCentBins[i] = 9999;
+  }
 }
 //___________________________________________________________________________
 AliAnalysisTaskSELc2V0bachelor::AliAnalysisTaskSELc2V0bachelor(const Char_t* name,
@@ -158,7 +169,16 @@ AliAnalysisTaskSELc2V0bachelor::AliAnalysisTaskSELc2V0bachelor(const Char_t* nam
   fSign(sign),
   fCheckOrigin(origin),
   fReconstructSecVtx(kFALSE),
-  fDoSingleAnalysisForSystK0SP(0)
+  fDoSingleAnalysisForSystK0SP(0),
+  fGenerateBGEventFromTracks(0),
+  fNumberOfEventsForMixing		(10),
+  fNzVtxBins					(0), 
+  fNCentBins					(0),
+  fNOfPools(1),
+  fPoolIndex(-9999),
+  fNextResVec(),
+  fReservoirsReady(),
+  fReservoirP()
 {
   //
   /// Constructor. Initialization of Inputs and Outputs
@@ -168,6 +188,10 @@ AliAnalysisTaskSELc2V0bachelor::AliAnalysisTaskSELc2V0bachelor(const Char_t* nam
   if (fWriteVariableTree && fTrackRotation) {
     AliInfo(Form("You cannot initialize fWriteVariableTree=%d and fTrackRotation=%d => fTrackRotation=0",fWriteVariableTree,fTrackRotation));
     fTrackRotation=kFALSE;
+  }
+
+  for(Int_t i=0;i<100;i++){
+    fZvtxBins[i] = -9999; fCentBins[i] = -9999;
   }
 
   Double_t mLcPDG = TDatabasePDG::Instance()->GetParticle(4122)->Mass();
@@ -372,6 +396,12 @@ void AliAnalysisTaskSELc2V0bachelor::UserExec(Option_t *)
     if(fDoSingleAnalysisForSystK0SP==2) return;
   }
 
+  if(fGenerateBGEventFromTracks==1){
+    DoEventMixing(aodEvent,mcArray,fAnalCuts);
+  }else if(fGenerateBGEventFromTracks==2){
+    DoRotationFromTrack(aodEvent,mcArray,fAnalCuts);
+  }
+
   fEventCounter++;
 
   Int_t nSelectedAnal = 0;
@@ -491,6 +521,39 @@ void AliAnalysisTaskSELc2V0bachelor::UserCreateOutputObjects() {
   else {
     DefineTreeVariables();
     PostData(4,fVariablesTree);
+  }
+
+  if(fGenerateBGEventFromTracks==1){
+    fNzVtxBins = 10;
+    for(Int_t i=0;i<11;i++){
+      fZvtxBins[i] = -10.+2.*(Double_t)i;
+    }
+
+    fNCentBins = 10;
+    for(Int_t i=0;i<11;i++){
+      fCentBins[i] = 10.*(Double_t)i;
+    }
+
+    fNOfPools=fNCentBins*fNzVtxBins;
+    fReservoirP.resize(fNOfPools,std::vector<std::vector<TVector *>  > (fNumberOfEventsForMixing));
+    fNextResVec.resize(fNOfPools,0);
+    fReservoirsReady.resize(fNOfPools,kFALSE);
+
+    for(Int_t s=0; s<fNOfPools; s++) {
+      for(Int_t k=0;k<fNumberOfEventsForMixing;k++){
+        fReservoirP[s][k].clear();
+      }
+    }
+  }else if(fGenerateBGEventFromTracks==2){
+    fNzVtxBins = 1;
+    fZvtxBins[0] = -10.; fZvtxBins[1] = 10.;
+    fNCentBins = 1;
+    fCentBins[0] = 0.; fCentBins[1] = 100.;
+    fNOfPools=1;
+    fReservoirP.resize(fNOfPools,std::vector<std::vector<TVector *>  > (1));
+    fNextResVec.resize(fNOfPools,0);
+    fReservoirsReady.resize(fNOfPools,kFALSE);
+    fReservoirP[0][0].clear();
   }
 
   return;
@@ -1200,6 +1263,13 @@ void AliAnalysisTaskSELc2V0bachelor::DefineK0SHistos()
     Double_t xmax_subsample[3]={mLcPDG+0.25,24.,24.5};
     THnSparse *spectrumLcMassOfflineByK0SSubSample = new THnSparseF(nameHisto.Data(),titleHisto.Data(),3,bins_subsample,xmin_subsample,xmax_subsample);
     fOutputPIDBach->Add(spectrumLcMassOfflineByK0SSubSample);
+  }
+
+  if(fGenerateBGEventFromTracks>0){
+    nameHisto="histLcMassBGByK0SOffline";
+    titleHisto="#Lambda_{c} invariant mass (by K^{0}_{S}) vs p_{T}; m_{inv}(p,K^{0}_{S}) [GeV/c^{2}]; p_{T}(#Lambda_{c}) [GeV/c]";
+    TH2F* spectrumLcMassBGOfflineByK0S = new TH2F(nameHisto.Data(),titleHisto.Data(),1000,mLcPDG-0.250,mLcPDG+0.250,11,binLimpTLc);
+    fOutputPIDBach->Add(spectrumLcMassBGOfflineByK0S);
   }
 
   nameHisto="histArmPodK0SOffline0";
@@ -2291,7 +2361,7 @@ void AliAnalysisTaskSELc2V0bachelor::MakeSingleAnalysisForSystK0SP(AliAODEvent *
 
   Double_t mLPDG   = TDatabasePDG::Instance()->GetParticle(3122)->Mass();
 
-  Int_t nTracks = aodEvent->GetNumberOfTracks();
+  //Int_t nTracks = aodEvent->GetNumberOfTracks();
   Int_t nV0s = aodEvent->GetNumberOfV0s();
 
   Double_t pos[3]; fVtx1->GetXYZ(pos);
@@ -2485,10 +2555,6 @@ void AliAnalysisTaskSELc2V0bachelor::MakeSingleAnalysisForSystK0SP(AliAODEvent *
     if(TMath::Abs(v0->MassAntiLambda()-mLPDG)<0.02) LType += 2;
     if(LType==3) continue;//to avoid complexity
 
-    Bool_t okLcK0Sp = kTRUE; // K0S case
-    Bool_t okLcLambdaBarPi = kTRUE; // LambdaBar case
-    Bool_t okLcLambdaPi = kTRUE; // Lambda case
-
     AliAODMCParticle *mcv0 = 0x0;
     if(fUseMCInfo){
       Int_t pdgdgv0[2]={2212,211};
@@ -2681,6 +2747,290 @@ void AliAnalysisTaskSELc2V0bachelor::MakeSingleAnalysisForSystK0SP(AliAODEvent *
     }
   }
   return;
+}
+
+//---------------------------
+void AliAnalysisTaskSELc2V0bachelor::DoEventMixing(AliAODEvent *aodEvent,TClonesArray *mcArray,AliRDHFCutsLctoV0 *cutsAnal)
+{
+  Double_t vtxz = fVtx1->GetZ();
+  Double_t centrality = cutsAnal->GetCentrality(aodEvent);
+  fPoolIndex=GetPoolIndex(vtxz,centrality);
+  if(fPoolIndex<0) return;
+
+  Int_t nextRes( fNextResVec[fPoolIndex] );
+  while(!fReservoirP[fPoolIndex][nextRes].empty()){
+    delete fReservoirP[fPoolIndex][nextRes].back();
+    fReservoirP[fPoolIndex][nextRes].pop_back();
+  }
+
+  //Fill proton in the pool
+  Int_t nTracks = aodEvent->GetNumberOfTracks();
+  for (Int_t itrk = 0; itrk<nTracks; itrk++) {
+    AliAODTrack *trk = (AliAODTrack*)aodEvent->GetTrack(itrk);
+    if(!trk) continue;
+    if(!cutsAnal->ApplySingleProtonCuts(trk,aodEvent)) continue;
+
+    // Get AliExternalTrackParam out of the AliAODTracks
+    Double_t xyz[3], pxpypz[3], cv[21]; Short_t sign;
+    trk->PxPyPz(pxpypz);
+    trk->GetXYZ(xyz);
+    trk->GetCovarianceXYZPxPyPz(cv);
+    sign=trk->Charge();
+
+    TVector *varvec = new TVector(34);
+    for(Int_t ic=0;ic<3;ic++){
+      (*varvec)[ic] = pxpypz[ic];
+    }
+    for(Int_t ic=0;ic<3;ic++){
+      (*varvec)[ic+3] = xyz[ic];
+    }
+    for(Int_t ic=0;ic<21;ic++){
+      (*varvec)[ic+6] = cv[ic];
+    }
+    (*varvec)[27] = sign;
+    (*varvec)[28] = fVtx1->GetX();
+    (*varvec)[29] = fVtx1->GetY();
+    (*varvec)[30] = fVtx1->GetZ();
+
+    Double_t d0z0bach[2],covd0z0bach[3];
+    trk->PropagateToDCA(fVtx1,fBzkG,kVeryBig,d0z0bach,covd0z0bach);
+    (*varvec)[31] = d0z0bach[0];
+    (*varvec)[32] = TMath::Sqrt(covd0z0bach[0]);
+    (*varvec)[33] = (Float_t)trk->HasPointOnITSLayer(0);
+
+    fReservoirP[fPoolIndex][nextRes].push_back(varvec);
+  }
+
+  // Do the event mixing for fPoolIndex
+  Int_t KiddiePool = fReservoirP[fPoolIndex].size();
+  if( !fReservoirsReady[fPoolIndex] )  KiddiePool = nextRes;
+
+  if( KiddiePool>0 )
+  {
+    for(Int_t j=0;j<KiddiePool;j++){
+      if( j!=nextRes )
+      {
+        FillMixedBackground(fReservoirP[fPoolIndex][j],aodEvent,cutsAnal);
+      }
+    }
+  }
+
+  // Rolling buffer
+  nextRes++;
+  if( nextRes>=fNumberOfEventsForMixing ){
+    nextRes = 0;
+    fReservoirsReady[fPoolIndex] = kTRUE;
+  }
+  fNextResVec[fPoolIndex] = nextRes;
+}
+
+//---------------------------
+void AliAnalysisTaskSELc2V0bachelor::DoRotationFromTrack(AliAODEvent *aodEvent,TClonesArray *mcArray,AliRDHFCutsLctoV0 *cutsAnal)
+{
+
+  while(!fReservoirP[0][0].empty()){
+    delete fReservoirP[0][0].back();
+    fReservoirP[0][0].pop_back();
+  }
+
+  //Fill proton in the pool
+  Int_t nTracks = aodEvent->GetNumberOfTracks();
+  Double_t rotStep=(fMaxAngleForRot-fMinAngleForRot)/(fNRotations-1);
+  for (Int_t itrk = 0; itrk<nTracks; itrk++) {
+    AliAODTrack *trk = (AliAODTrack*)aodEvent->GetTrack(itrk);
+    if(!trk) continue;
+    if(!cutsAnal->ApplySingleProtonCuts(trk,aodEvent)) continue;
+
+    // Get AliExternalTrackParam out of the AliAODTracks
+    Double_t xyz[3], pxpypz[3], pxpypznew[3], cv[21]; Short_t sign;
+    trk->PxPyPz(pxpypz);
+    trk->GetXYZ(xyz);
+    trk->GetCovarianceXYZPxPyPz(cv);
+    sign=trk->Charge();
+
+    Double_t d0z0bach[2],covd0z0bach[3];
+    trk->PropagateToDCA(fVtx1,fBzkG,kVeryBig,d0z0bach,covd0z0bach);
+
+    for(Int_t irot=0;irot<fNRotations;irot++){
+      Double_t phirot=fMinAngleForRot+rotStep*irot;
+      Double_t tmpx=pxpypz[0];
+      Double_t tmpy=pxpypz[1];
+      pxpypznew[0] = tmpx*TMath::Cos(phirot)-tmpy*TMath::Sin(phirot);
+      pxpypznew[1] = tmpx*TMath::Sin(phirot)+tmpy*TMath::Cos(phirot);
+      pxpypznew[2] = pxpypz[2];
+
+      TVector *varvec = new TVector(34);
+      for(Int_t ic=0;ic<3;ic++){
+        (*varvec)[ic] = pxpypznew[ic];
+      }
+      for(Int_t ic=0;ic<3;ic++){
+        (*varvec)[ic+3] = xyz[ic];
+      }
+      for(Int_t ic=0;ic<21;ic++){
+        (*varvec)[ic+6] = cv[ic];
+      }
+      (*varvec)[27] = sign;
+      (*varvec)[28] = fVtx1->GetX();
+      (*varvec)[29] = fVtx1->GetY();
+      (*varvec)[30] = fVtx1->GetZ();
+
+      (*varvec)[31] = d0z0bach[0];
+      (*varvec)[32] = TMath::Sqrt(covd0z0bach[0]);
+      (*varvec)[33] = (Float_t)trk->HasPointOnITSLayer(0);
+
+      fReservoirP[0][0].push_back(varvec);
+    }
+  }
+
+  FillMixedBackground(fReservoirP[0][0],aodEvent,cutsAnal);
+}
+
+//---------------------------
+void AliAnalysisTaskSELc2V0bachelor::FillMixedBackground(std::vector<TVector * > mixTypeP, AliAODEvent *aodEvent, AliRDHFCutsLctoV0 *cutsAnal)
+{     
+  //
+  // Fill background
+  //
+  Double_t mLcPDG  = TDatabasePDG::Instance()->GetParticle(4122)->Mass();
+  Double_t mPrPDG  = TDatabasePDG::Instance()->GetParticle(2212)->Mass();
+  Double_t mK0SPDG = TDatabasePDG::Instance()->GetParticle(310)->Mass();
+  Int_t nPr = mixTypeP.size();
+  Int_t nV0s = aodEvent->GetNumberOfV0s();
+
+  for(Int_t iv0=0;iv0<nV0s;iv0++){
+    AliAODv0 *v0 = aodEvent->GetV0(iv0);
+    if(!v0) continue;
+    if(!cutsAnal->ApplySingleK0Cuts(v0,aodEvent)) continue;
+
+    AliNeutralTrackParam *trackV0=NULL;
+    const AliVTrack *trackVV0 = dynamic_cast<const AliVTrack*>(v0);
+    if(trackVV0)  trackV0 = new AliNeutralTrackParam(trackVV0);
+
+    Double_t d0z0v0[2],covd0z0v0[2];
+    trackV0->PropagateToDCA(fVtx1,fBzkG,kVeryBig,d0z0v0,covd0z0v0);
+
+    for(Int_t ip=0;ip<nPr;ip++){
+      TVector *pvars = mixTypeP[ip];
+      if(!pvars) continue;
+
+      Double_t xyzP[3], pxpypzP[3], cvP[21]; Short_t signP;
+      Double_t vtxP[3];
+      Double_t d0Pr, d0errPr;
+
+      vtxP[0] = (*pvars)[28]; vtxP[1] = (*pvars)[29]; vtxP[2] = (*pvars)[30];
+      Double_t vtxthis[3];
+      fVtx1->GetXYZ(vtxthis);
+
+      d0Pr = (*pvars)[31]; d0errPr = (*pvars)[32];
+
+      for(Int_t ic=0;ic<3;ic++){
+        pxpypzP[ic] = (*pvars)[ic];
+      }
+      for(Int_t ic=0;ic<3;ic++){
+        xyzP[ic] = (*pvars)[ic+3] +(vtxthis[ic]-vtxP[ic]);
+      }
+      for(Int_t ic=0;ic<21;ic++){
+        cvP[ic] = (*pvars)[ic+6];
+      }
+      signP = (*pvars)[27];
+
+      Bool_t spdfirst = (*pvars)[33];
+
+      Double_t pxp = pxpypzP[0];
+      Double_t pyp = pxpypzP[1];
+      Double_t pzp = pxpypzP[2];
+      Double_t Ep = TMath::Sqrt(pow(pxp,2)+pow(pyp,2)+pow(pzp,2)+pow(mPrPDG,2));
+      Double_t pxv0 = v0->Px();
+      Double_t pyv0 = v0->Py();
+      Double_t pzv0 = v0->Pz();
+      Double_t Ev0 = TMath::Sqrt(pow(pxv0,2)+pow(pyv0,2)+pow(pzv0,2)+pow(mK0SPDG,2));
+      Double_t pxtot = pxp+pxv0;
+      Double_t pytot = pyp+pyv0;
+      Double_t pztot = pzp+pzv0;
+      Double_t Etot = Ep+Ev0;
+
+      Double_t pttot = sqrt(pxtot*pxtot+pytot*pytot);
+      Double_t tmass = sqrt(pow(Etot,2)-pow(pxtot,2)-pow(pytot,2)-pow(pztot,2));
+
+      if(TMath::Abs(tmass-mLcPDG)>0.20) continue;
+      if(pttot<4.) continue;
+
+      AliExternalTrackParam *trkp = new AliExternalTrackParam(xyzP,pxpypzP,cvP,signP);
+
+      Double_t d0[2],d0err[2];
+//      Double_t d0z0bach[2],covd0z0bach[3];
+//      trkp->PropagateToDCA(fVtx1,fBzkG,kVeryBig,d0z0bach,covd0z0bach);
+//      d0[0]= d0z0bach[0];
+//      d0err[0] = TMath::Sqrt(covd0z0bach[0]);
+      d0[0]= d0Pr;
+      d0err[0] = d0errPr;
+
+      d0[1]= d0z0v0[0];
+      d0err[1] = TMath::Sqrt(covd0z0v0[0]);
+
+      Double_t px[2],py[2],pz[2];
+      px[0] = trkp->Px(); py[0] = trkp->Py(); pz[0] = trkp->Pz(); 
+      px[1] = v0->Px(); py[1] = v0->Py(); pz[1] = v0->Pz();
+
+      //
+      // FindVertexForCascades is assumed to be FALSE in the filtering
+      // Use Primary vertex as secondary Vtx and dca is 0
+      //
+      Double_t pos[3],cov[6],chi2perNDF;
+      fVtx1->GetXYZ(pos);
+      fVtx1->GetCovarianceMatrix(cov);
+      chi2perNDF = fVtx1->GetChi2perNDF();
+      AliAODVertex *secVert = new AliAODVertex(pos,cov,chi2perNDF,0x0,-1,AliAODVertex::kUndef,2);
+      Double_t dca = 0.;
+
+      AliAODRecoCascadeHF *theCascade = new AliAODRecoCascadeHF(secVert,signP,px,py,pz,d0,d0err,dca);
+      theCascade->SetOwnPrimaryVtx(fVtx1);
+      UShort_t id[2]={(UShort_t)trkp->GetID(),(UShort_t)trackV0->GetID()};
+      theCascade->SetProngIDs(2,id);
+      theCascade->GetSecondaryVtx()->AddDaughter(trkp);
+      theCascade->GetSecondaryVtx()->AddDaughter(v0);
+
+      if ( cutsAnal->IsInFiducialAcceptance(theCascade->Pt(),theCascade->Y(4122)) ){
+        if(cutsAnal->ApplyCandidateCuts(theCascade,aodEvent,(Bool_t)spdfirst))
+        {
+          ((TH2D*)(fOutputPIDBach->FindObject("histLcMassBGByK0SOffline")))->Fill(theCascade->InvMassLctoK0sP(),theCascade->Pt());
+        }
+      }
+
+      delete trkp;
+      delete secVert;
+      delete theCascade;
+    }
+    delete trackV0;
+  }
+  return;
+}
+
+
+//---------------------------
+Int_t AliAnalysisTaskSELc2V0bachelor::GetPoolIndex(Double_t zvert, Double_t mult){
+	//
+  // check in which of the pools the current event falls
+	//
+  Int_t theBinZ=-9999;
+  for(Int_t iz=0;iz<fNzVtxBins;iz++){
+    if(zvert>=fZvtxBins[iz] && zvert<fZvtxBins[iz+1]) {
+      theBinZ = iz;
+      break;
+    }
+  }
+  if(theBinZ<0) return -1;
+
+  Int_t theBinM=-9999;
+  for(Int_t ic=0;ic<fNCentBins;ic++){
+    if(mult>=fCentBins[ic] && mult<fCentBins[ic+1]){
+      theBinM = ic;
+      break;
+    }
+  }
+  if(theBinM<0) return -2;
+
+  return fNCentBins*theBinZ+theBinM;
 }
 
 //---------------------------

--- a/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelor.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelor.h
@@ -19,6 +19,7 @@
 
 #include "TROOT.h"
 #include "TSystem.h"
+#include "TVector.h"
 
 #include "AliAnalysisTaskSE.h"
 #include "AliAODEvent.h"
@@ -26,6 +27,7 @@
 #include "AliAODTrack.h"
 #include "AliRDHFCutsLctoV0.h"
 #include "AliNormalizationCounter.h"
+#include <vector>
 
 /// \class AliAnalysisTaskSELc2V0bachelor
 
@@ -61,6 +63,12 @@ class AliAnalysisTaskSELc2V0bachelor : public AliAnalysisTaskSE
  
   void MakeSingleAnalysisForSystK0SP(AliAODEvent* aodEvent,TClonesArray *mcArray, 
       AliRDHFCutsLctoV0 *cutsAnal);
+
+  void SetGenerateBGEventFromTracks(Int_t a){fGenerateBGEventFromTracks=a;}
+  Int_t GetPoolIndex(Double_t zvert, Double_t mult);
+  void DoEventMixing(AliAODEvent* aodEvent,TClonesArray *mcArray, AliRDHFCutsLctoV0 *cutsAnal);
+  void FillMixedBackground(std::vector<TVector * > mixTypePVars, AliAODEvent *aod, AliRDHFCutsLctoV0 *cutsAnal);
+  void DoRotationFromTrack(AliAODEvent* aodEvent,TClonesArray *mcArray, AliRDHFCutsLctoV0 *cutsAnal);
 
   /// set MC usage
   void SetMC(Bool_t theMCon) {fUseMCInfo = theMCon;}
@@ -189,8 +197,21 @@ class AliAnalysisTaskSELc2V0bachelor : public AliAnalysisTaskSE
 
   Int_t fDoSingleAnalysisForSystK0SP; /// Analyze p,K,D for syst (0:off, 1:on, 2:only single ana)
 
+  // Mixed event (track level)
+  Int_t fGenerateBGEventFromTracks; /// flag for (1) event mixing or (2) track rotation from tracks
+  Int_t  fNumberOfEventsForMixing; /// maximum number of events to be used in event mixing
+  Int_t fNzVtxBins;								/// number of z vrtx bins
+  Double_t fZvtxBins[100];						// [fNzVtxBinsDim]
+  Int_t fNCentBins;								/// number of centrality bins
+  Double_t fCentBins[100];						// [fNCentBinsDim]
+  Int_t  fNOfPools; /// number of pools
+  Int_t fPoolIndex; /// pool index
+  std::vector<Int_t> fNextResVec; //!<! Vector storing next reservoir ID
+  std::vector<Bool_t> fReservoirsReady; //!<! Vector storing if the reservoirs are ready
+  std::vector<std::vector< std::vector< TVector * > > > fReservoirP; //!<! reservoir
+
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskSELc2V0bachelor,13); /// class for Lc->p K0
+  ClassDef(AliAnalysisTaskSELc2V0bachelor,14); /// class for Lc->p K0
   /// \endcond
 };
 

--- a/PWGHF/vertexingHF/AliRDHFCutsLctoV0.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCutsLctoV0.cxx
@@ -1809,3 +1809,363 @@ Double_t AliRDHFCutsLctoV0::GetReSignedd0(AliAODRecoDecayHF *dd) {
 
   return signd0*TMath::Abs(d0z0bach[0]);
 }
+
+//---------------------------------------------------------------------------
+Bool_t AliRDHFCutsLctoV0::ApplySingleK0Cuts(AliAODv0 *v0, AliAODEvent* aod) {
+  //
+  // V0 selection
+  //
+
+  if(!v0){
+    AliFatal("V0 object is NULL");
+    return kFALSE;
+  }
+
+  if (!fV0daughtersCuts) {
+    AliFatal("Cut object is not defined for V0daughters. Candidate accepted.");
+    return kFALSE;
+  }
+
+  if ( v0 && ((v0->GetOnFlyStatus() == kTRUE  && GetV0Type() == AliRDHFCuts::kOnlyOfflineV0s) ||
+        (v0->GetOnFlyStatus() == kFALSE && GetV0Type() == AliRDHFCuts::kOnlyOnTheFlyV0s)) ) return kFALSE;
+
+  if (!v0->GetSecondaryVtx()) {
+    AliDebug(2,"No secondary vertex for V0 by cascade");
+    return kFALSE;
+  }
+  if (v0->GetNDaughters()!=2) {
+    AliDebug(2,Form("No 2 daughters for V0 of current cascade (onTheFly=%d, nDaughters=%d)",v0->GetOnFlyStatus(),v0->GetNDaughters()));
+    return kFALSE;
+  }
+
+  // cuts on the V0 mass: K0S case
+  Double_t mk0s    = v0->MassK0Short();
+  Double_t mk0sPDG =  TDatabasePDG::Instance()->GetParticle(310)->Mass();
+  Double_t maxcut_m = -9999;
+  for(Int_t ip=0;ip<fnPtBins;ip++){
+    if(fCutsRD[GetGlobalIndex(2,ip)]>maxcut_m) maxcut_m = fCutsRD[GetGlobalIndex(2,ip)];
+  }
+  if (TMath::Abs(mk0s-mk0sPDG) > maxcut_m) {
+    return kFALSE;
+  }
+
+  // cut on V0 pT min
+  Double_t mincut_p = 9999;
+  for(Int_t ip=0;ip<fnPtBins;ip++){
+    if(fCutsRD[GetGlobalIndex(15,ip)]<mincut_p) mincut_p = fCutsRD[GetGlobalIndex(15,ip)];
+  }
+  if (v0->Pt() < mincut_p) { // V0 pT min
+    return kFALSE;
+  }
+
+  AliAODTrack *v0positiveTrack = dynamic_cast<AliAODTrack*>(v0->GetDaughter(0));
+  if (!v0positiveTrack) return kFALSE;
+  AliAODTrack *v0negativeTrack = dynamic_cast<AliAODTrack*>(v0->GetDaughter(1));
+  if (!v0negativeTrack) return kFALSE;
+
+
+  Float_t etaMin=0, etaMax=0; fV0daughtersCuts->GetEtaRange(etaMin,etaMax);
+  if ( (v0positiveTrack->Eta()<=etaMin || v0positiveTrack->Eta()>=etaMax) ||
+       (v0negativeTrack->Eta()<=etaMin || v0negativeTrack->Eta()>=etaMax) ) return kFALSE;
+  Float_t ptMin=0, ptMax=0; fV0daughtersCuts->GetPtRange(ptMin,ptMax);
+  if ( (v0positiveTrack->Pt()<=ptMin || v0positiveTrack->Pt()>=ptMax) ||
+       (v0negativeTrack->Pt()<=ptMin || v0negativeTrack->Pt()>=ptMax) ) return kFALSE;
+
+  // Condition on nTPCclusters
+  if (fV0daughtersCuts->GetMinNClusterTPC()>0) {
+    if ( ( ( v0positiveTrack->GetTPCClusterInfo(2,1) ) < fV0daughtersCuts->GetMinNClusterTPC() ) || 
+	 ( ( v0negativeTrack->GetTPCClusterInfo(2,1) ) < fV0daughtersCuts->GetMinNClusterTPC() ) ) return kFALSE;
+  }
+
+  if (fV0daughtersCuts->GetMinRatioCrossedRowsOverFindableClustersTPC()>0.5) {
+    Float_t  ratioCrossedRowsOverFindableClustersTPCPos = 1.0;
+    Float_t  ratioCrossedRowsOverFindableClustersTPCNeg = 1.0;
+    if (v0positiveTrack->GetTPCNclsF()>0) {
+      ratioCrossedRowsOverFindableClustersTPCPos = v0positiveTrack->GetTPCClusterInfo(2,1) / v0positiveTrack->GetTPCNclsF();
+    }
+    if (v0negativeTrack->GetTPCNclsF()>0) {
+      ratioCrossedRowsOverFindableClustersTPCNeg = v0negativeTrack->GetTPCClusterInfo(2,1) / v0negativeTrack->GetTPCNclsF();
+    }
+    if ( ( ( ratioCrossedRowsOverFindableClustersTPCPos ) < fV0daughtersCuts->GetMinRatioCrossedRowsOverFindableClustersTPC() ) || 
+        ( ( ratioCrossedRowsOverFindableClustersTPCNeg ) < fV0daughtersCuts->GetMinRatioCrossedRowsOverFindableClustersTPC() ) ) return kFALSE;
+  }
+
+  // kTPCrefit status
+  if (v0->GetOnFlyStatus()==kFALSE) { // only for offline V0s
+    if (fV0daughtersCuts->GetRequireTPCRefit()) {
+      if( !(v0positiveTrack->GetStatus() & AliESDtrack::kTPCrefit)) return kFALSE;
+      if( !(v0negativeTrack->GetStatus() & AliESDtrack::kTPCrefit)) return kFALSE;
+    }
+  }
+  // kink condition
+  if (!fV0daughtersCuts->GetAcceptKinkDaughters()) {
+    AliAODVertex *maybeKinkPos = (AliAODVertex*)v0positiveTrack->GetProdVertex();
+    AliAODVertex *maybeKinkNeg = (AliAODVertex*)v0negativeTrack->GetProdVertex();
+    if (maybeKinkPos->GetType()==AliAODVertex::kKink ||
+	maybeKinkNeg->GetType()==AliAODVertex::kKink) return kFALSE;
+  }
+
+  return kTRUE;
+
+}
+
+//---------------------------------------------------------------------------
+Bool_t AliRDHFCutsLctoV0::ApplySingleProtonCuts(AliAODTrack *bachelorTrack, AliAODEvent* aod) {
+  //
+  // Daughter tracks selection
+  //
+
+  if (!fTrackCuts) {
+    AliFatal("Cut object is not defined for bachelor. Candidate accepted.");
+    return kFALSE;
+  }
+
+  if (!bachelorTrack) {
+    AliFatal("Track object is NULL.");
+    return kFALSE;
+  }
+
+  if ( fUseTrackSelectionWithFilterBits && !(bachelorTrack->TestFilterMask(BIT(4))) ) {
+    AliDebug(2,"Check on the bachelor FilterBit: no BIT(4). Candidate rejected.");
+    return kFALSE;
+  }
+
+  Float_t ptmin, ptmax;
+  fTrackCuts->GetPtRange(ptmin,ptmax);
+  if(bachelorTrack->Pt()<ptmin) return kFALSE;
+  if(bachelorTrack->Pt()>ptmax) return kFALSE;
+
+  // cut on bachelor pT min
+  Double_t mincut_p = 9999;
+  for(Int_t ip=0;ip<fnPtBins;ip++){
+    if(fCutsRD[GetGlobalIndex(4,ip)]<mincut_p) mincut_p = fCutsRD[GetGlobalIndex(4,ip)];
+  }
+  if (bachelorTrack->Pt() < mincut_p) { 
+    return kFALSE;
+  }
+
+  if (fKinkReject != (!(fTrackCuts->GetAcceptKinkDaughters())) ) {
+    AliError(Form("Not compatible setting: fKinkReject=%1d - fTrackCuts->GetAcceptKinkDaughters()=%1d",fKinkReject, fTrackCuts->GetAcceptKinkDaughters()));
+    return kFALSE;
+  }
+
+
+  AliAODVertex *vAOD = (AliAODVertex*)aod->GetPrimaryVertex();
+  Double_t pos[3]; vAOD->GetXYZ(pos);
+  Double_t cov[6]; vAOD->GetCovarianceMatrix(cov);
+  const AliESDVertex vESD(pos,cov,100.,100);
+
+  if (!IsDaughterSelected(bachelorTrack,&vESD,fTrackCuts,aod)) return kFALSE;
+
+  Bool_t okLcK0Sp = kTRUE; // K0S case
+  Bool_t dummy1 = kTRUE;
+  Bool_t dummy2 = kTRUE;
+  CheckPID(0,bachelorTrack,0,0,okLcK0Sp,dummy1,dummy2);//use the PID for the first bin. only option 9 is the candidate pT depedent, so probably OK, need to update if needed
+
+  return okLcK0Sp;
+}
+
+//---------------------------------------------------------------------------
+Bool_t AliRDHFCutsLctoV0::ApplyCandidateCuts(AliAODRecoDecayHF *obj, AliAODEvent* aod, Bool_t spdfirstflag) {
+  //
+  // Apply selection
+  //
+
+  if (!fCutsRD) {
+    AliFatal("Cut matrice not inizialized. Exit...");
+    return kFALSE;
+  }
+
+
+  AliAODRecoCascadeHF* d = (AliAODRecoCascadeHF*)obj;
+  if (!d) {
+    AliDebug(2,"AliAODRecoCascadeHF null");
+    return kFALSE;
+  }
+
+  Double_t pt=d->Pt();
+  if(pt<fMinPtCand) return kFALSE;
+  if(pt>fMaxPtCand) return kFALSE;
+  Int_t ptbin = PtBin(pt);
+
+  AliVTrack *bachelorTrack = (AliVTrack*)d->GetBachelor();
+  AliAODv0 *v0 = (AliAODv0*)d->Getv0();
+
+  if (fIsCandTrackSPDFirst && d->Pt()<fMaxPtCandTrackSPDFirst) {
+    if(!spdfirstflag) return kFALSE;
+  }
+
+  // Get the V0 daughter tracks
+  AliAODTrack *v0positiveTrack = (AliAODTrack*)v0->GetDaughter(0);
+  AliAODTrack *v0negativeTrack = (AliAODTrack*)v0->GetDaughter(1);
+  if (!v0positiveTrack || !v0negativeTrack ) {
+    AliDebug(2,"No V0 daughters' objects");
+    return kFALSE;
+  }
+
+  if (v0positiveTrack->GetID()<0 || v0negativeTrack->GetID()<0) {
+    AliDebug(2,Form("At least one of V0 daughters has negative ID %d %d",v0positiveTrack->GetID(),v0negativeTrack->GetID()));
+    return kFALSE;
+  }
+
+  AliAODVertex *vAOD = (AliAODVertex*)aod->GetPrimaryVertex();
+  Double_t posVtx[3]; vAOD->GetXYZ(posVtx);
+
+  Double_t mLcPDG  = TDatabasePDG::Instance()->GetParticle(4122)->Mass();
+  Double_t mk0sPDG = TDatabasePDG::Instance()->GetParticle(310)->Mass();
+  Double_t mLPDG   = TDatabasePDG::Instance()->GetParticle(3122)->Mass();
+
+  // K0S + p
+  Double_t mk0s    = v0->MassK0Short();
+  Double_t mLck0sp = d->InvMassLctoK0sP();
+
+  // Lambda + pi
+  Double_t mlambda  = v0->MassLambda();
+  Double_t malambda = v0->MassAntiLambda();
+  Double_t mLcLpi   = d->InvMassLctoLambdaPi();
+
+  Bool_t okK0spipi=kTRUE, okLppi=kTRUE, okLBarpip=kTRUE;
+  Bool_t isNotK0S = kTRUE, isNotLambda = kTRUE, isNotLambdaBar = kTRUE, isNotGamma = kTRUE;
+
+  Bool_t okLck0sp=kTRUE, okLcLpi=kTRUE, okLcLBarpi=kTRUE;
+
+  // cut on Lc mass with K0S+p hypothesis
+  if (TMath::Abs(mLck0sp-mLcPDG) > fCutsRD[GetGlobalIndex(0,ptbin)] && fExcludedCut!=0) {
+    okLck0sp = kFALSE;
+    AliDebug(4,Form(" cascade mass is %2.2e and does not correspond to Lambda_c into K0S+p cut",mLck0sp));
+  }
+
+  // cuts on the V0 mass: K0S case
+  if (TMath::Abs(mk0s-mk0sPDG) > fCutsRD[GetGlobalIndex(2,ptbin)] && fExcludedCut!=2) {
+    okK0spipi = kFALSE;
+    AliDebug(4,Form(" V0 mass is %2.2e and does not correspond to K0S cut",mk0s));
+  }
+
+  // cut on Lc mass with Lambda+pi hypothesis
+  if (TMath::Abs(mLcLpi-mLcPDG) > fCutsRD[GetGlobalIndex(1,ptbin)] && fExcludedCut!=1) {
+    okLcLpi = kFALSE;
+    okLcLBarpi = kFALSE;
+    AliDebug(4,Form(" cascade mass is %2.2e and does not correspond to Lambda_c into Lambda+pi cut",mLcLpi));
+  }
+
+  // cuts on the V0 mass: Lambda/LambdaBar case
+  if ( TMath::Abs(mlambda-mLPDG) > fCutsRD[GetGlobalIndex(3,ptbin)]  && fExcludedCut!=3) {
+    okLppi = kFALSE;
+    AliDebug(4,Form(" V0 mass is %2.2e and does not correspond to LambdaBar cut",mlambda));
+  }
+
+  if ( TMath::Abs(malambda-mLPDG) > fCutsRD[GetGlobalIndex(3,ptbin)]  && fExcludedCut!=3) {
+    okLBarpip = kFALSE;
+    AliDebug(4,Form(" V0 mass is %2.2e and does not correspond to LambdaBar cut",malambda));
+  }
+
+  // cut on K0S invariant mass veto
+  if (TMath::Abs(v0->MassK0Short()-mk0sPDG) < fCutsRD[GetGlobalIndex(12,ptbin)] && fExcludedCut!=12) { // K0S invariant mass veto
+    AliDebug(4,Form(" veto on K0S invariant mass doesn't pass the cut"));
+    isNotK0S=kFALSE;
+  }
+
+  // cut on Lambda/LambdaBar invariant mass veto
+  if (TMath::Abs(v0->MassLambda()-mLPDG) < fCutsRD[GetGlobalIndex(13,ptbin)] && fExcludedCut!=13) { // Lambda invariant mass veto
+    AliDebug(4,Form(" veto on Lambda invariant mass doesn't pass the cut"));
+    isNotLambda=kFALSE;
+  }
+  if (TMath::Abs(v0->MassAntiLambda()-mLPDG) < fCutsRD[GetGlobalIndex(13,ptbin)] && fExcludedCut!=13) { // LambdaBar invariant mass veto
+    AliDebug(4,Form(" veto on LambdaBar invariant mass doesn't pass the cut"));
+    isNotLambdaBar=kFALSE;
+  }
+
+  // cut on gamma invariant mass veto
+  if (v0->InvMass2Prongs(0,1,11,11) < fCutsRD[GetGlobalIndex(14,ptbin)] && fExcludedCut!=14) { // K0S invariant mass veto
+    AliDebug(4,Form(" veto on gamma invariant mass doesn't pass the cut"));
+    isNotGamma=kFALSE;
+  }
+
+  okLck0sp   = okLck0sp   && okK0spipi && isNotLambda && isNotLambdaBar && isNotGamma;
+  okLcLpi    = okLcLpi    && okLppi    && isNotK0S    && isNotLambdaBar && isNotGamma;
+  okLcLBarpi = okLcLBarpi && okLBarpip && isNotK0S    && isNotLambda    && isNotGamma;
+
+  if (!okLck0sp) return kFALSE;
+
+  // cuts on the minimum pt of the tracks
+  if (TMath::Abs(bachelorTrack->Pt()) < fCutsRD[GetGlobalIndex(4,ptbin)] && fExcludedCut!=4) {
+    AliDebug(4,Form(" bachelor track Pt=%2.2e > %2.2e",bachelorTrack->Pt(),fCutsRD[GetGlobalIndex(4,ptbin)]));
+    return kFALSE;
+  }
+  if (TMath::Abs(v0positiveTrack->Pt()) < fCutsRD[GetGlobalIndex(5,ptbin)] && fExcludedCut!=5) {
+    AliDebug(4,Form(" V0-positive track Pt=%2.2e > %2.2e",v0positiveTrack->Pt(),fCutsRD[GetGlobalIndex(5,ptbin)]));
+    return kFALSE;
+  }
+  if (TMath::Abs(v0negativeTrack->Pt()) < fCutsRD[GetGlobalIndex(6,ptbin)] && fExcludedCut!=6) {
+    AliDebug(4,Form(" V0-negative track Pt=%2.2e > %2.2e",v0negativeTrack->Pt(),fCutsRD[GetGlobalIndex(6,ptbin)]));
+    return kFALSE;
+  }
+  // cut on cascade dca (prong-to-prong)
+  if ( TMath::Abs(d->GetDCA()) > fCutsRD[GetGlobalIndex(7,ptbin)] && fExcludedCut!=7) { // prong-to-prong cascade DCA
+    AliDebug(4,Form(" cascade tracks DCA don't pass the cut"));
+    return kFALSE;
+  }
+
+  // cut on V0 dca (prong-to-prong)
+  if ( TMath::Abs(v0->GetDCA()) > fCutsRD[GetGlobalIndex(8,ptbin)] && fExcludedCut!=8) { // prong-to-prong V0 DCA
+    AliDebug(4,Form(" V0 DCA don't pass the cut"));
+    return kFALSE;
+  }
+
+  // cut on V0 cosine of pointing angle wrt PV
+  if (v0->CosPointingAngle(posVtx) < fCutsRD[GetGlobalIndex(9,ptbin)] && fExcludedCut!=9) { // cosine of V0 pointing angle wrt primary vertex
+    AliDebug(4,Form(" V0 cosine of pointing angle doesn't pass the cut"));
+    return kFALSE;
+  }
+
+  // cut on bachelor transverse impact parameter wrt PV
+  if (TMath::Abs(d->Getd0Prong(0)) > fCutsRD[GetGlobalIndex(10,ptbin)] && fExcludedCut!=10) { // bachelor transverse impact parameter wrt PV
+    AliDebug(4,Form(" bachelor transverse impact parameter doesn't pass the cut"));
+    return kFALSE;
+  }
+
+  // cut on V0 transverse impact parameter wrt PV
+  if (TMath::Abs(d->Getd0Prong(1)) > fCutsRD[GetGlobalIndex(11,ptbin)] && fExcludedCut!=11) { // V0 transverse impact parameter wrt PV
+    AliDebug(4,Form(" V0 transverse impact parameter doesn't pass the cut"));
+    return kFALSE;
+  }
+
+  // cut on V0 pT min
+  if (v0->Pt() < fCutsRD[GetGlobalIndex(15,ptbin)] && fExcludedCut!=15) { // V0 pT min
+    AliDebug(4,Form(" V0 track Pt=%2.2e > %2.2e",v0->Pt(),fCutsRD[GetGlobalIndex(15,ptbin)]));
+    return kFALSE;
+  }
+
+  // cut on Proton emission angle
+  if(TMath::Abs(fCutsRD[GetGlobalIndex(16,ptbin)])<1.1 || TMath::Abs(fCutsRD[GetGlobalIndex(17,ptbin)])<1.1){
+    Double_t cutvar = GetProtonEmissionAngleCMS(d);
+    if (cutvar > fCutsRD[GetGlobalIndex(16,ptbin)] && fExcludedCut!=16 && fExcludedCut!=17) { // Proton emission angle
+      AliDebug(4,Form(" Cos proton emission=%2.2e < %2.2e",cutvar,fCutsRD[GetGlobalIndex(16,ptbin)]));
+      return kFALSE;
+    }
+    if (cutvar < fCutsRD[GetGlobalIndex(17,ptbin)] && fExcludedCut!=16 && fExcludedCut!=17) { // Proton emission angle
+      AliDebug(4,Form(" Cos proton emission=%2.2e > %2.2e",cutvar,fCutsRD[GetGlobalIndex(17,ptbin)]));
+      return kFALSE;
+    }
+  }
+
+  // cut on  proton re-signed d0
+  if(TMath::Abs(fCutsRD[GetGlobalIndex(18,ptbin)])<0.2){
+    Double_t cutvar = GetReSignedd0(d) ;
+    if (cutvar< fCutsRD[GetGlobalIndex(18,ptbin)] && fExcludedCut!=18) { // proton d0
+      AliDebug(4,Form(" Proton d0 (re-signed)=%2.2e > %2.2e",cutvar,fCutsRD[GetGlobalIndex(18,ptbin)]));
+      return kFALSE;
+    }
+  }
+
+  // cut on Armenteros qT/|alpha|
+  if(TMath::Abs(fCutsRD[GetGlobalIndex(19,ptbin)])<0.3){
+    Double_t cutvar = v0->PtArmV0()/TMath::Abs(v0->AlphaV0());
+    if (cutvar < fCutsRD[GetGlobalIndex(19,ptbin)] && fExcludedCut!=19) { // v0 armenteros variable
+      AliDebug(4,Form(" qT/|alpha|=%2.2e > %2.2e",cutvar,fCutsRD[GetGlobalIndex(19,ptbin)]));
+      return kFALSE;
+    }
+  }
+
+  return kTRUE;
+}

--- a/PWGHF/vertexingHF/AliRDHFCutsLctoV0.h
+++ b/PWGHF/vertexingHF/AliRDHFCutsLctoV0.h
@@ -67,6 +67,9 @@ class AliRDHFCutsLctoV0 : public AliRDHFCuts
   Int_t GetPidSelectionFlag() {return fPidSelectionFlag;}
 
   Bool_t AreLctoV0DaughtersSelected(AliAODRecoDecayHF *rd, AliAODEvent* aod=0x0) const;
+  Bool_t ApplySingleProtonCuts(AliAODTrack *trk, AliAODEvent* aod);
+  Bool_t ApplySingleK0Cuts(AliAODv0 *v0, AliAODEvent* aod);
+  Bool_t ApplyCandidateCuts(AliAODRecoDecayHF *rd, AliAODEvent* aod, Bool_t spdfirst);
 
   Int_t GetV0Type();
 


### PR DESCRIPTION
Dear all, 

Background spectra generation with event-mixing and track-rotation techniques using AliAODTrack and AliAODv0 objects are implemented for Lc->pK0s analysis in Pb-Pb. 

Best regards,
Yosuke