### PR TITLE
Add cluster container name to output container

### DIFF
--- a/PWGGA/EMCALTasks/macros/AddTaskEMCALPhotonIsolation.C
+++ b/PWGGA/EMCALTasks/macros/AddTaskEMCALPhotonIsolation.C
@@ -94,10 +94,10 @@ AliAnalysisTaskEMCALPhotonIsolation* AddTaskEMCALPhotonIsolation(
 
   TString myContName("");
   if(bIsMC){
-    myContName = Form("Analysis_Neutrals_MC");
+    myContName = Form("Analysis_Neutrals_MC_%s",clusName.Data());
   }
   else{
-    myContName = Form("Analysis_Neutrals");
+    myContName = Form("Analysis_Neutrals_%s",clusName.Data());
   }
   
   // For the 2012 EGA/L1 Analysis, only events with EGA/L1 recalc patches are considered


### PR DESCRIPTION
The change is necessary to run more then one instance of AliAnalysisTaskEMCALPhotonIsolation in one train over different cluster selections.