### PR TITLE
allow Time Stamp selection for AODs; include new selection based on C…

### DIFF
--- a/PWG/CaloTrackCorrBase/AliCaloTrackReader.cxx
+++ b/PWG/CaloTrackCorrBase/AliCaloTrackReader.cxx
@@ -120,6 +120,8 @@ fUseEventsWithPrimaryVertex(kFALSE),
 fTimeStampEventSelect(0),
 fTimeStampEventFracMin(0),   fTimeStampEventFracMax(0),
 fTimeStampRunMin(0),         fTimeStampRunMax(0),
+fTimeStampEventCTPBCCorrExclude(0),
+fTimeStampEventCTPBCCorrMin(0), fTimeStampEventCTPBCCorrMax(0),
 fNPileUpClusters(-1),        fNNonPileUpClusters(-1),         fNPileUpClustersCut(3),
 fVertexBC(-200),             fRecalculateVertexBC(0),
 fUseAliCentrality(0),        fCentralityClass(""),            fCentralityOpt(0),
@@ -1115,6 +1117,9 @@ void AliCaloTrackReader::InitParameters()
   fTimeStampEventFracMin = -1;
   fTimeStampEventFracMax = 2;
   
+  fTimeStampEventCTPBCCorrMin = -1;
+  fTimeStampEventCTPBCCorrMax = 1e12;
+  
   for(Int_t i = 0; i < 19; i++)
   {
     fEMCalBCEvent   [i] = 0;
@@ -1290,24 +1295,36 @@ Bool_t AliCaloTrackReader::FillInputEvent(Int_t iEntry, const char * /*curFileNa
   // Event rejection depending on time stamp
   //------------------------------------------------------
   
-  if(fDataType==kESD && fTimeStampEventSelect)
+  if ( fTimeStampEventSelect )
   {
-    AliESDEvent* esd = dynamic_cast<AliESDEvent*> (fInputEvent);
-    if(esd)
-    {
-      Int_t timeStamp = esd->GetTimeStamp();
-      Float_t timeStampFrac = 1.*(timeStamp-fTimeStampRunMin) / (fTimeStampRunMax-fTimeStampRunMin);
-      
-      //printf("stamp0 %d, max0 %d, frac %f\n", timeStamp-fTimeStampRunMin,fTimeStampRunMax-fTimeStampRunMin, timeStampFrac);
-      
-      if(timeStampFrac < fTimeStampEventFracMin || timeStampFrac > fTimeStampEventFracMax) return kFALSE;
-    }
+    Int_t timeStamp = fInputEvent->GetTimeStamp();
+    Float_t timeStampFrac = 1.*(timeStamp-fTimeStampRunMin) / (fTimeStampRunMax-fTimeStampRunMin);
+    
+    //printf("stamp0 %d, max0 %d, frac %f\n", timeStamp-fTimeStampRunMin,fTimeStampRunMax-fTimeStampRunMin, timeStampFrac);
+    
+    if(timeStampFrac < fTimeStampEventFracMin || timeStampFrac > fTimeStampEventFracMax) return kFALSE;
     
     AliDebug(1,"Pass Time Stamp rejection");
     
     fhNEventsAfterCut->Fill(8.5);
   }
 
+  if(fDataType==kESD && fTimeStampEventCTPBCCorrExclude)
+  {
+    AliESDEvent* esd = dynamic_cast<AliESDEvent*> (fInputEvent);
+    if(esd)
+    {
+      Int_t timeStamp = esd->GetTimeStampCTPBCCorr();
+      
+      if(timeStamp > fTimeStampEventCTPBCCorrMin && timeStamp <= fTimeStampEventCTPBCCorrMax) return kFALSE;
+    }
+    
+    AliDebug(1,"Pass Time Stamp CTPBCCorr rejection");
+    
+    fhNEventsAfterCut->Fill(8.5);
+  }
+
+  
   //------------------------------------------------------
   // Event rejection depending on vertex, pileup, v0and
   //------------------------------------------------------

--- a/PWG/CaloTrackCorrBase/AliCaloTrackReader.h
+++ b/PWG/CaloTrackCorrBase/AliCaloTrackReader.h
@@ -442,6 +442,21 @@ public:
   void             SwitchOffSelectEventTimeStamp()         { fTimeStampEventSelect = kFALSE  ; }
   
   Bool_t           IsSelectEventTimeStampOn()              { return  fTimeStampEventSelect   ; }
+
+  // Time Stamp CTP corrected
+    
+  Double_t         GetTimeStampEventCTPBCCorrMin()   const { return fTimeStampEventCTPBCCorrMin ; }
+  Double_t         GetTimeStampEventCTPBCCorrMax()   const { return fTimeStampEventCTPBCCorrMax ; }
+  
+  void             SetTimeStampEventCTPBCCorrRange(Double_t a, Double_t b) { 
+                                                             fTimeStampEventCTPBCCorrMin = a    ;
+                                                             fTimeStampEventCTPBCCorrMax = b    ; } // seconds
+  
+  void             SwitchOnExcludeEventTimeCTPBCCorrStamp() { fTimeStampEventCTPBCCorrExclude = kTRUE   ; }
+  void             SwitchOffExcludeEventTimeCTPBCCorrStamp(){ fTimeStampEventCTPBCCorrExclude = kFALSE  ; }
+  
+  Bool_t           IsExcludeEventTimeStampCTPBCCorrOn()     { return  fTimeStampEventCTPBCCorrExclude ; }
+
   
   // Event tagging as pile-up
   
@@ -908,6 +923,10 @@ public:
   Double_t         fTimeStampRunMin;               ///<  Minimum value of time stamp in run.
   Double_t         fTimeStampRunMax;               ///<  Maximum value of time stamp in run.
   
+  Bool_t           fTimeStampEventCTPBCCorrExclude; ///<  Activate event selection within a range of data taking time CTP corrected. ESD only.
+  Double_t         fTimeStampEventCTPBCCorrMin;    ///<  Minimum value of time stamp corrected by CTP in run.
+  Double_t         fTimeStampEventCTPBCCorrMax;    ///<  Maximum value of time stamp corrected by CTP in run.
+  
   ///< Parameters to pass to method IsPileupFromSPD:
   ///< Int_t minContributors, Double_t minZdist, Double_t nSigmaZdist,Double_t nSigmaDiamXY,Double_t nSigmaDiamZ
   Double_t         fPileUpParamSPD[5];
@@ -974,7 +993,7 @@ public:
   AliCaloTrackReader & operator = (const AliCaloTrackReader & r) ; 
   
   /// \cond CLASSIMP
-  ClassDef(AliCaloTrackReader,77) ;
+  ClassDef(AliCaloTrackReader,78) ;
   /// \endcond
 
 } ;


### PR DESCRIPTION
…TP corrected Time stamp, only for ESDs