### PR TITLE
EMCal CorrFW: Additional pass option

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.cxx
@@ -110,7 +110,7 @@ Bool_t AliEmcalCorrectionComponent::Initialize()
   if (fFilepass != "") {
     fGetPassFromFileName = kFALSE;
     // Handle the "default" value used in MC
-    if (fFilepass == "default") {
+    if (fFilepass == "default" || fFilepass == "usedefault") {
       AliError("Received \"default\" as pass value. Defaulting to \"pass1\"! In the case of MC, the user should set the proper pass value in their configuration file! For data, empty quotes should be set so that the pass is automatically set.");
       fFilepass = "pass1";
     }


### PR DESCRIPTION
Add option to set "usedefault" in addition to "default" for setting the
MC pass. Remember not to see the pass for data!