### PR TITLE
added equalized AD multiplicities to AliMultSelectionTask

### DIFF
--- a/OADB/CMakeLists.txt
+++ b/OADB/CMakeLists.txt
@@ -64,7 +64,7 @@ generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 # Generate the ROOT map
 # Dependecies
-set(LIBDEPS STEERBase AOD ESD STEER ANALYSIS ANALYSISalice CDB ITSrec VZERObase)
+set(LIBDEPS STEERBase AOD ESD STEER ANALYSIS ANALYSISalice CDB ITSrec VZERObase ADbase)
 generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
 
 # Generate a PARfile target for this library

--- a/OADB/COMMON/MULTIPLICITY/AliMultInput.h
+++ b/OADB/COMMON/MULTIPLICITY/AliMultInput.h
@@ -1,29 +1,36 @@
 #ifndef AliMultInput_H
 #define AliMultInput_H
 #include <TNamed.h>
+#include <TList.h>
 #include "AliMultVariable.h"
 
 class AliMultInput : public TNamed {
-    
+
 public:
     AliMultInput();
     AliMultInput(const char * name, const char * title = "MultInput");
     AliMultInput(const AliMultInput& o);
     AliMultInput& operator=(const AliMultInput& o);
-    ~AliMultInput();
+    virtual ~AliMultInput();
 
     void     AddVariable ( AliMultVariable *lVar );
     AliMultVariable* GetVariable (const TString& lName) const;
     AliMultVariable* GetVariable (Long_t iIdx) const;
-    Long_t GetNVariables         () const { return fNVars; }
+    Long_t GetNVariables         () const { return fVariableList ? fVariableList->GetEntries() : 0; }
     void Clear(Option_t* option="");
     void Set(const AliMultInput* other);
     void Print(Option_t* option="") const;
-    
-private:
-    Long_t fNVars;
+
+    Bool_t SetValue(TString name, Float_t val);
+    Bool_t SetValue(TString name, Int_t val);
+    Bool_t IncrementValue(TString name, Int_t increment=1);
+
+    Int_t   GetValueInteger(TString name) const;
+    Float_t GetValue(TString name) const;
+
+ private:
     TList *fVariableList; //List containing all AliMultVariables
-    
-    ClassDef(AliMultInput, 1)
+
+    ClassDef(AliMultInput, 2);
 };
 #endif

--- a/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibrator.h
+++ b/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibrator.h
@@ -14,7 +14,7 @@ class AliMultSelectionCalibrator : public TNamed {
 public:
 
     AliMultSelectionCalibrator(const char * name="AliMultSelectionCalibrator", const char * title = "Multiplicity Calibration Class");
-    ~AliMultSelectionCalibrator();
+    virtual ~AliMultSelectionCalibrator();
 
     //void    Print(Option_t *option="") const;
 
@@ -29,7 +29,7 @@ public:
     void SetBoundaries ( Long_t lNB, Double_t *lB ){
         if ( lNB<2 || lNB > 1e+6 ){
             cout<<"Please make sure you are using a reasonable number of boundaries!"<<endl;
-            lNB = -1;
+            lNB = 0;
         }
         lDesiredBoundaries.Set(lNB, lB);
     }

--- a/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibrator.h
+++ b/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibrator.h
@@ -3,28 +3,27 @@
 
 #include <iostream>
 #include "TNamed.h"
+#include "TArrayD.h"
+#include "TArrayI.h"
 //For Run Ranges functionality
 #include <map>
 
 using namespace std;
 class AliESDEvent;
 class AliMultSelectionCalibrator : public TNamed {
-    
 public:
-    
-    //Constructors/Destructor
-    AliMultSelectionCalibrator();
-    AliMultSelectionCalibrator(const char * name, const char * title = "Multiplicity Calibration Class");
+
+    AliMultSelectionCalibrator(const char * name="AliMultSelectionCalibrator", const char * title = "Multiplicity Calibration Class");
     ~AliMultSelectionCalibrator();
-    
+
     //void    Print(Option_t *option="") const;
-    
+
     //_________________________________________________________________________
     //Interface: steering functions to be used in calibration macro
-  
+
     //Set Filenames
-    void SetInputFile ( TString lFile ) { fInputFileName = lFile.Data(); } 
-    void SetBufferFile ( TString lFile ) { fBufferFileName = lFile.Data(); } 
+    void SetInputFile ( TString lFile ) { fInputFileName = lFile.Data(); }
+    void SetBufferFile ( TString lFile ) { fBufferFileName = lFile.Data(); }
     void SetOutputFile ( TString lFile ) { fOutputFileName = lFile.Data(); }
     //Set Boundaries to find
     void SetBoundaries ( Long_t lNB, Double_t *lB ){
@@ -32,73 +31,71 @@ public:
             cout<<"Please make sure you are using a reasonable number of boundaries!"<<endl;
             lNB = -1;
         }
-        lDesiredBoundaries = lB;
-        lNDesiredBoundaries = lNB;
+        lDesiredBoundaries.Set(lNB, lB);
     }
-    
+
     //Run Ranges Interface
     Long_t GetNRunRanges() const {return fNRunRanges; }
     void AddRunRange ( Int_t lFirst, Int_t lLast, AliMultSelection *lMultSelProvided );
-    
+
     //Getter for event selection criteria
     AliMultSelectionCuts * GetEventCuts() const { return fMultSelectionCuts;     }
-    
+
     //Getter for MultSelection object
     AliMultSelection * GetMultSelection() const { return fSelection;     }
-    
-    //Setter (warning: not a copy...) 
+
+    //Setter (warning: not a copy...)
     void SetMultSelection(AliMultSelection *lMultSelProvided ){ fSelection = lMultSelProvided; }
 
     //Getter for MultInput object
     AliMultInput * GetMultInput() const { return fInput;     }
-    
+
     //Setter for golden run
     void SetRunToUseAsDefault ( Int_t lRunNumber ) { fRunToUseAsDefault = lRunNumber; }
-    
+
     //Getter for golden run
-    Int_t GetRunToUseAsDefault() const { return fRunToUseAsDefault; } 
-    
+    Int_t GetRunToUseAsDefault() const { return fRunToUseAsDefault; }
+
     //Configure standard input
     void SetupStandardInput();
-    
+
     //Master Function in this Class: To be called once filenames are set
     Bool_t Calibrate();
-    
+
     //Helper
     Float_t MinVal( Float_t A, Float_t B );
-    
+
 private:
     AliMultInput     *fInput;     //Object for all input
     AliMultSelection *fSelection; //(current) transient pointer object
 
     //Calibration Boundaries to locate
-    Double_t *lDesiredBoundaries;
-    Long_t   lNDesiredBoundaries;
-    
-    Int_t fRunToUseAsDefault; //Give preference for this run to be the default 
-    
+    TArrayD lDesiredBoundaries;
+
+    Int_t fRunToUseAsDefault; //Give preference for this run to be the default
+
     //Run Ranges map - master storage
     Long_t fNRunRanges;
     std::map<int, int> fRunRangesMap;
-    Int_t fFirstRun[1000];
-    Int_t fLastRun[1000]; 
-    
-    TList *fMultSelectionList; // List of AliMultSelection objects to be used per run period 
-    
+    TArrayI fFirstRun;
+    TArrayI fLastRun;
+
+    TList *fMultSelectionList; // List of AliMultSelection objects to be used per run period
+
     TString fInputFileName;  // Filename for TTree object for calibration purposes
     TString fBufferFileName; // Filename for TTree object (buffer file)
     TString fOutputFileName; // Filename for calibration OADB output
-    
+
     // Object for storing event selection configuration
     AliMultSelectionCuts *fMultSelectionCuts;
-    
-    // TList object for storing histograms
-    TList *fCalibHists; 
 
-    ClassDef(AliMultSelectionCalibrator, 2);
+    // TList object for storing histograms
+    TList *fCalibHists;
+
+    ClassDef(AliMultSelectionCalibrator, 3);
     //(this classdef is only for bookkeeping, class will not usually
     // be streamed according to current workflow except in very specific
-    // tests!) 
+    // tests!)
     //2 - Adjustments of extra event selections
 };
 #endif

--- a/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibratorMC.cxx
+++ b/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibratorMC.cxx
@@ -271,8 +271,8 @@ Bool_t AliMultSelectionCalibratorMC::Calibrate() {
     }
 
     //Add Timer
-    TStopwatch* timer = new TStopwatch();
-    timer->Start ( kTRUE );
+    TStopwatch timer;
+    timer.Start ( kTRUE );
 
     //Compute events-per-hour performance metric
     Double_t lEventsPerSecond = 0;
@@ -289,13 +289,13 @@ Bool_t AliMultSelectionCalibratorMC::Calibrate() {
         if ( iEv % 100000 == 0 ) {
             Double_t complete = 100. * ( double ) ( iEv ) / ( double ) ( fTree->GetEntries() );
             cout << "(Data Loop 1) Event # " << iEv << "/" << fTree->GetEntries() << " (" << complete << "%, Time Left: ";
-            timer->Stop();
-            Double_t time = timer->RealTime();
+            timer.Stop();
+            Double_t time = timer.RealTime();
 
             //events per hour:
             lEventsPerSecond = ( ( Double_t ) ( iEv ) ) /time;
 
-            timer->Start ( kFALSE );
+            timer.Start ( kFALSE );
             Double_t secondsperstep = time / ( Double_t ) ( iEv+1 );
             Double_t secondsleft = ( Double_t ) ( fTree->GetEntries()-iEv-1 ) * secondsperstep;
             Long_t minutesleft = ( Long_t ) ( secondsleft / 60. );
@@ -355,21 +355,21 @@ Bool_t AliMultSelectionCalibratorMC::Calibrate() {
     //==============================================================================
 
     //Stop, reset Timer
-    timer->Stop();
-    timer->Start(kTRUE);
+    timer.Stop();
+    timer.Start(kTRUE);
 
     for(Long64_t iEv = 0; iEv<fTreeMC->GetEntries(); iEv++) {
 
         if ( iEv % 100000 == 0 ) {
             Double_t complete = 100. * ( double ) ( iEv ) / ( double ) ( fTreeMC->GetEntries() );
             cout << "(MC Loop 1) Event # " << iEv << "/" << fTreeMC->GetEntries() << " (" << complete << "%, Time Left: ";
-            timer->Stop();
-            Double_t time = timer->RealTime();
+            timer.Stop();
+            Double_t time = timer.RealTime();
 
             //events per hour:
             lEventsPerSecond = ( ( Double_t ) ( iEv ) ) /time;
 
-            timer->Start ( kFALSE );
+            timer.Start ( kFALSE );
             Double_t secondsperstep = time / ( Double_t ) ( iEv+1 );
             Double_t secondsleft = ( Double_t ) ( fTreeMC->GetEntries()-iEv-1 ) * secondsperstep;
             Long_t minutesleft = ( Long_t ) ( secondsleft / 60. );

--- a/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibratorMC.h
+++ b/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibratorMC.h
@@ -3,96 +3,94 @@
 
 #include <iostream>
 #include "TNamed.h"
+#include "TArrayD.h"
 
 using namespace std;
 class AliESDEvent;
 class AliMultSelectionCalibratorMC : public TNamed {
-    
+
 public:
-    
+
     //Constructors/Destructor
-    AliMultSelectionCalibratorMC();
-    AliMultSelectionCalibratorMC(const char * name, const char * title = "Multiplicity Calibration Class");
-    ~AliMultSelectionCalibratorMC();
-    
+    AliMultSelectionCalibratorMC(const char * name="AliMultSelectionCalibratorMC", const char * title = "Multiplicity Calibration Class");
+    virtual ~AliMultSelectionCalibratorMC();
+
     //void    Print(Option_t *option="") const;
-    
+
     //_________________________________________________________________________
     //Interface: steering functions to be used in calibration macro
-  
+
     //Set Filenames
     void SetInputFileData ( TString lFile ) { fInputFileNameData = lFile.Data(); }
     void SetInputFileOADB ( TString lFile ) { fInputFileNameOADB = lFile.Data(); }
-    void SetInputFileMC   ( TString lFile ) { fInputFileNameMC = lFile.Data(); } 
-    
+    void SetInputFileMC   ( TString lFile ) { fInputFileNameMC = lFile.Data(); }
+
     void SetBufferFileData    ( TString lFile ) { fBufferFileNameData = lFile.Data(); }
-    void SetBufferFileMC      ( TString lFile ) { fBufferFileNameMC   = lFile.Data(); } 
+    void SetBufferFileMC      ( TString lFile ) { fBufferFileNameMC   = lFile.Data(); }
     void SetOutputFile    ( TString lFile ) { fOutputFileName = lFile.Data(); }
     //Set Boundaries to find
     void SetBoundaries ( Long_t lNB, Double_t *lB ){
         if ( lNB<2 || lNB > 1e+6 ){
             cout<<"Please make sure you are using a reasonable number of boundaries!"<<endl;
-            lNB = -1;
+            lNB = 0;
         }
-        lDesiredBoundaries = lB;
-        lNDesiredBoundaries = lNB;
+        lDesiredBoundaries.Set(lNB, lB);
     }
-    
+
     //Getter for event selection criteria
     AliMultSelectionCuts * GetEventCuts() const { return fMultSelectionCuts;     }
-    
+
     //Getter for MultSelection object
-    //WARNING - should not be used in this case! 
+    //WARNING - should not be used in this case!
     AliMultSelection * GetMultSelection() const { return fSelection;     }
 
     //Getter for MultInput object
     AliMultInput * GetMultInput() const { return fInput;     }
-    
+
     //Setter for golden run
     void SetRunToUseAsDefault ( Int_t lRunNumber ) { fRunToUseAsDefault = lRunNumber; }
-    
+
     //Getter for golden run
     Int_t GetRunToUseAsDefault() const { return fRunToUseAsDefault; }
-    
+
     //Configure standard input
     void SetupStandardInput();
-    
+
     //Switch to configure <Ntracklet> fit type
-    void SetUseQuadraticMapping(Bool_t lOpt){ fkUseQuadraticMapping=lOpt; } 
-    
+    void SetUseQuadraticMapping(Bool_t lOpt){ fkUseQuadraticMapping=lOpt; }
+
     //Master Function in this Class: To be called once filenames are set
     Bool_t Calibrate();
-    
+
     //Helper
     Float_t MinVal( Float_t A, Float_t B );
-    
+
 private:
     AliMultInput     *fInput;     //Object for all input
     AliMultSelection *fSelection; //Object for all estimators
 
     //Calibration Boundaries to locate
-    Double_t *lDesiredBoundaries;
-    Long_t   lNDesiredBoundaries;
-    
+    TArrayD lDesiredBoundaries;
+
     //Run to use as default for scaling factor in this period
     Int_t fRunToUseAsDefault;
-    
+
     TString fInputFileNameData;  // Filename for TTree object for calibration purposes
     TString fInputFileNameOADB;  // Filename for TTree object for calibration purposes
     TString fInputFileNameMC;    // Filename for TTree object for calibration purposes
     TString fBufferFileNameData; // Filename for TTree object (buffer file)
     TString fBufferFileNameMC;   // Filename for TTree object (buffer file)
     TString fOutputFileName;     // Filename for calibration OADB output (MC)
-    
+
     //Configuration
     Bool_t fkUseQuadraticMapping; //switch to toggle quadratic <Ntracklets> fits
-    
+
     // Object for storing event selection configuration
     AliMultSelectionCuts *fMultSelectionCuts;
-    
-    // TList object for storing histograms
-    TList *fCalibHists; 
 
-    ClassDef(AliMultSelectionCalibratorMC, 1);
+    // TList object for storing histograms
+    TList *fCalibHists;
+
+    ClassDef(AliMultSelectionCalibratorMC, 2);
 };
 #endif

--- a/OADB/COMMON/MULTIPLICITY/AliMultSelectionTask.cxx
+++ b/OADB/COMMON/MULTIPLICITY/AliMultSelectionTask.cxx
@@ -130,50 +130,6 @@ AliMultSelectionTask::AliMultSelectionTask(const char *name, TString lExtraOptio
   , fESDtrackCuts(nullptr)
   , fUtils(nullptr)
 
-  , fAmplitude_V0A(nullptr)
-  , fAmplitude_V0A1(nullptr)
-  , fAmplitude_V0A2(nullptr)
-  , fAmplitude_V0A3(nullptr)
-  , fAmplitude_V0A4(nullptr)
-  , fAmplitude_V0C(nullptr)
-  , fAmplitude_V0C1(nullptr)
-  , fAmplitude_V0C2(nullptr)
-  , fAmplitude_V0C3(nullptr)
-  , fAmplitude_V0C4(nullptr)
-  , fAmplitude_V0Apartial(nullptr)
-  , fAmplitude_V0Cpartial(nullptr)
-  , fAmplitude_V0AEq(nullptr)
-  , fAmplitude_V0CEq(nullptr)
-  , fAmplitude_OnlineV0A(nullptr)
-  , fAmplitude_OnlineV0C(nullptr)
-  , fAmplitude_V0AADC(nullptr)
-  , fAmplitude_V0CADC(nullptr)
-
-  , fnSPDClusters(nullptr)
-  , fnSPDClusters0(nullptr)
-  , fnSPDClusters1(nullptr)
-  , fnTracklets(nullptr)
-  , fnTracklets08(nullptr)
-  , fnTracklets15(nullptr)
-  , fRefMultEta5(0)
-  , fRefMultEta8(0)
-
-  , fMultiplicity_AD  (nullptr)
-  , fMultiplicity_ADA (nullptr)
-  , fMultiplicity_ADC (nullptr)
-
-  , fZncEnergy(nullptr)
-  , fZpcEnergy(nullptr)
-  , fZnaEnergy(nullptr)
-  , fZpaEnergy(nullptr)
-  , fZem1Energy(nullptr)
-  , fZem2Energy(nullptr)
-  , fZnaTower(nullptr)
-  , fZncTower(nullptr)
-  , fZpaTower(nullptr)
-  , fZpcTower(nullptr)
-
-  , fEvSel_VtxZ(nullptr)
   , fEvSel_VtxZCut(kFALSE)
   , fEvSel_IsNotPileup(kFALSE)
   , fEvSel_IsNotPileupMV(kFALSE)
@@ -193,17 +149,7 @@ AliMultSelectionTask::AliMultSelectionTask(const char *name, TString lExtraOptio
   , fTrackCutsGlobal2015(nullptr)
   , fTrackCutsITSsa2010(nullptr)
 
-  , fZnaFired(nullptr)
-  , fZncFired(nullptr)
-  , fZpaFired(nullptr)
-  , fZpcFired(nullptr)
-
-  , fNTracks(nullptr)
-  , fNTracksGlobal2015(nullptr)
-  , fNTracksGlobal2015Trigger(nullptr)
-  , fNTracksITSsa2010(nullptr)
-
-  , fQuantiles()
+  , fQuantiles(100)
   , fEvSelCode(0)
   , fNDebug(1)
 
@@ -267,7 +213,7 @@ AliMultSelectionTask::AliMultSelectionTask(const char *name, TString lExtraOptio
   , fOadbMultSelection(nullptr)
   , fInput(nullptr)
 {
-  std::fill_n(fQuantiles, 100, -1.0);
+  std::fill_n(fQuantiles.GetArray(), fQuantiles.GetSize(), -1.0);
 
   DefineOutput(1, TList::Class()); // Event Counter Histo
   if (fkCalibration)
@@ -278,22 +224,15 @@ AliMultSelectionTask::AliMultSelectionTask(const char *name, TString lExtraOptio
   fNDebug = lNDebugEstimators;
 
   //Special Debug Options (more to be added as needed)
-  // A - Debug AliCentrality
-  // B - Debug AliPPVsMultUtils
-  // M - Extra MC variables
-
-  fkDebugAliCentrality    = lExtraOptions.Contains("A");
-  fkDebugAliPPVsMultUtils = lExtraOptions.Contains("B");
-  fkDebugIsMC             = lExtraOptions.Contains("M");
+  fkDebugAliCentrality    = lExtraOptions.Contains("A"); // Debug AliCentrality
+  fkDebugAliPPVsMultUtils = lExtraOptions.Contains("B"); // Debug AliPPVsMultUtils
+  fkDebugIsMC             = lExtraOptions.Contains("M"); // Extra MC variables
 }
 
 
 AliMultSelectionTask::~AliMultSelectionTask()
 {
-  //if (fTreeEvent) {
-  //    delete fTreeEvent;
-  //    fTreeEvent = 0x0;
-  //}
+  //  SafeDelete(fTreeEvent);
   SafeDelete(fESDtrackCuts);
   SafeDelete(fTrackCuts);
   SafeDelete(fTrackCutsITSsa2010);
@@ -312,117 +251,67 @@ void AliMultSelectionTask::UserCreateOutputObjects()
 
     //Create input variables in AliMultInput Class
     //V0 related
-    fAmplitude_V0A        = new AliMultVariable("fAmplitude_V0A");
-    fAmplitude_V0A1       = new AliMultVariable("fAmplitude_V0A1");
-    fAmplitude_V0A2       = new AliMultVariable("fAmplitude_V0A2");
-    fAmplitude_V0A3       = new AliMultVariable("fAmplitude_V0A3");
-    fAmplitude_V0A4       = new AliMultVariable("fAmplitude_V0A4");
-    fAmplitude_V0C        = new AliMultVariable("fAmplitude_V0C");
-    fAmplitude_V0C1       = new AliMultVariable("fAmplitude_V0C1");
-    fAmplitude_V0C2       = new AliMultVariable("fAmplitude_V0C2");
-    fAmplitude_V0C3       = new AliMultVariable("fAmplitude_V0C3");
-    fAmplitude_V0C4       = new AliMultVariable("fAmplitude_V0C4");
-    fAmplitude_V0Apartial = new AliMultVariable("fAmplitude_V0Apartial");
-    fAmplitude_V0Cpartial = new AliMultVariable("fAmplitude_V0Cpartial");
-    fAmplitude_V0AEq      = new AliMultVariable("fAmplitude_V0AEq");
-    fAmplitude_V0CEq      = new AliMultVariable("fAmplitude_V0CEq");
-    fAmplitude_OnlineV0A  = new AliMultVariable("fAmplitude_OnlineV0A");
-    fAmplitude_OnlineV0C  = new AliMultVariable("fAmplitude_OnlineV0C");
-    fAmplitude_V0AADC     = new AliMultVariable("fAmplitude_V0AADC");
-    fAmplitude_V0CADC     = new AliMultVariable("fAmplitude_V0CADC");
+    fInput->AddVariable(new AliMultVariable("fAmplitude_V0A"));
+    fInput->AddVariable(new AliMultVariable("fAmplitude_V0A1"));
+    fInput->AddVariable(new AliMultVariable("fAmplitude_V0A2"));
+    fInput->AddVariable(new AliMultVariable("fAmplitude_V0A3"));
+    fInput->AddVariable(new AliMultVariable("fAmplitude_V0A4"));
+    fInput->AddVariable(new AliMultVariable("fAmplitude_V0C"));
+    fInput->AddVariable(new AliMultVariable("fAmplitude_V0C1"));
+    fInput->AddVariable(new AliMultVariable("fAmplitude_V0C2"));
+    fInput->AddVariable(new AliMultVariable("fAmplitude_V0C3"));
+    fInput->AddVariable(new AliMultVariable("fAmplitude_V0C4"));
+    fInput->AddVariable(new AliMultVariable("fAmplitude_V0Apartial"));
+    fInput->AddVariable(new AliMultVariable("fAmplitude_V0Cpartial"));
+    fInput->AddVariable(new AliMultVariable("fAmplitude_V0AEq"));
+    fInput->AddVariable(new AliMultVariable("fAmplitude_V0CEq"));
+    fInput->AddVariable(new AliMultVariable("fAmplitude_OnlineV0A"));
+    fInput->AddVariable(new AliMultVariable("fAmplitude_OnlineV0C"));
+    fInput->AddVariable(new AliMultVariable("fAmplitude_V0AADC"));
+    fInput->AddVariable(new AliMultVariable("fAmplitude_V0CADC"));
     //SPD Related
-    fnSPDClusters         = new AliMultVariable("fnSPDClusters", "Mult Variable", kTRUE);
-    fnSPDClusters0        = new AliMultVariable("fnSPDClusters0", "Mult Variable", kTRUE);
-    fnSPDClusters1        = new AliMultVariable("fnSPDClusters1", "Mult Variable", kTRUE);
+    fInput->AddVariable(new AliMultVariable("fnSPDClusters", "Mult Variable", kTRUE));
+    fInput->AddVariable(new AliMultVariable("fnSPDClusters0", "Mult Variable", kTRUE));
+    fInput->AddVariable(new AliMultVariable("fnSPDClusters1", "Mult Variable", kTRUE));
 
     //AD Related
-    fMultiplicity_AD      = new AliMultVariable("fMultiplicity_AD");
-    fMultiplicity_ADA     = new AliMultVariable("fMultiplicity_ADA");
-    fMultiplicity_ADC     = new AliMultVariable("fMultiplicity_ADC");
+    fInput->AddVariable(new AliMultVariable("fMultiplicity_AD"));
+    fInput->AddVariable(new AliMultVariable("fMultiplicity_ADA"));
+    fInput->AddVariable(new AliMultVariable("fMultiplicity_ADC"));
 
-    fnTracklets   = new AliMultVariable("fnTracklets", "Mult Variable", kTRUE);
-    fnTracklets08 = new AliMultVariable("fnTracklets08", "Mult Variable", kTRUE);
-    fnTracklets15 = new AliMultVariable("fnTracklets15", "Mult Variable", kTRUE);
+    fInput->AddVariable(new AliMultVariable("fnTracklets", "Mult Variable", kTRUE));
+    fInput->AddVariable(new AliMultVariable("fnTracklets08", "Mult Variable", kTRUE));
+    fInput->AddVariable(new AliMultVariable("fnTracklets15", "Mult Variable", kTRUE));
 
-    fRefMultEta5 = new AliMultVariable("fRefMultEta5", "Mult Variable", kTRUE);
-    fRefMultEta8 = new AliMultVariable("fRefMultEta8", "Mult Variable", kTRUE);
+    fInput->AddVariable(new AliMultVariable("fRefMultEta5", "Mult Variable", kTRUE));
+    fInput->AddVariable(new AliMultVariable("fRefMultEta8", "Mult Variable", kTRUE));
 
     //ZDC Related
-    fZncEnergy  = new AliMultVariable("fZncEnergy");
-    fZpcEnergy  = new AliMultVariable("fZpcEnergy");
-    fZnaEnergy  = new AliMultVariable("fZnaEnergy");
-    fZpaEnergy  = new AliMultVariable("fZpaEnergy");
-    fZem1Energy = new AliMultVariable("fZem1Energy");
-    fZem2Energy = new AliMultVariable("fZem2Energy");
+    fInput->AddVariable(new AliMultVariable("fZncEnergy"));
+    fInput->AddVariable(new AliMultVariable("fZpcEnergy"));
+    fInput->AddVariable(new AliMultVariable("fZnaEnergy"));
+    fInput->AddVariable(new AliMultVariable("fZpaEnergy"));
+    fInput->AddVariable(new AliMultVariable("fZem1Energy"));
+    fInput->AddVariable(new AliMultVariable("fZem2Energy"));
 
-    fZnaTower  = new AliMultVariable("fZnaTower");
-    fZncTower  = new AliMultVariable("fZncTower");
-    fZpaTower  = new AliMultVariable("fZpaTower");
-    fZpcTower  = new AliMultVariable("fZpcTower");
+    fInput->AddVariable(new AliMultVariable("fZnaTower"));
+    fInput->AddVariable(new AliMultVariable("fZncTower"));
+    fInput->AddVariable(new AliMultVariable("fZpaTower"));
+    fInput->AddVariable(new AliMultVariable("fZpcTower"));
 
     //Fired or not booleans (stored as integer for compatibility)
-    fZnaFired  = new AliMultVariable("fZnaFired", "Mult Variable", kTRUE);
-    fZncFired  = new AliMultVariable("fZncFired", "Mult Variable", kTRUE);
-    fZpaFired  = new AliMultVariable("fZpaFired", "Mult Variable", kTRUE);
-    fZpcFired  = new AliMultVariable("fZpcFired", "Mult Variable", kTRUE);
+    fInput->AddVariable(new AliMultVariable("fZnaFired", "Mult Variable", kTRUE));
+    fInput->AddVariable(new AliMultVariable("fZncFired", "Mult Variable", kTRUE));
+    fInput->AddVariable(new AliMultVariable("fZpaFired", "Mult Variable", kTRUE));
+    fInput->AddVariable(new AliMultVariable("fZpcFired", "Mult Variable", kTRUE));
 
     //Track counters (now useable as AliMultVariables as well)
-    fNTracks                  = new AliMultVariable("fNTracks", "Mult Variable", kTRUE);
-    fNTracksGlobal2015        = new AliMultVariable("fNTracksGlobal2015", "Mult Variable", kTRUE);
-    fNTracksGlobal2015Trigger = new AliMultVariable("fNTracksGlobal2015Trigger", "Mult Variable", kTRUE);
-    fNTracksITSsa2010         = new AliMultVariable("fNTracksITSsa2010", "Mult Variable", kTRUE);
+    fInput->AddVariable(new AliMultVariable("fNTracks", "Mult Variable", kTRUE));
+    fInput->AddVariable(new AliMultVariable("fNTracksGlobal2015", "Mult Variable", kTRUE));
+    fInput->AddVariable(new AliMultVariable("fNTracksGlobal2015Trigger", "Mult Variable", kTRUE));
+    fInput->AddVariable(new AliMultVariable("fNTracksITSsa2010", "Mult Variable", kTRUE));
 
-    fEvSel_VtxZ = new AliMultVariable("fEvSel_VtxZ");
-
-    //Add to AliMultInput Object, will later bind to TTree object in a loop
-    fInput->AddVariable( fAmplitude_V0A );
-    fInput->AddVariable( fAmplitude_V0A1 );
-    fInput->AddVariable( fAmplitude_V0A2 );
-    fInput->AddVariable( fAmplitude_V0A3 );
-    fInput->AddVariable( fAmplitude_V0A4 );
-    fInput->AddVariable( fAmplitude_V0C );
-    fInput->AddVariable( fAmplitude_V0C1 );
-    fInput->AddVariable( fAmplitude_V0C2 );
-    fInput->AddVariable( fAmplitude_V0C3 );
-    fInput->AddVariable( fAmplitude_V0C4 );
-    fInput->AddVariable( fAmplitude_V0Apartial );
-    fInput->AddVariable( fAmplitude_V0Cpartial );
-    fInput->AddVariable( fAmplitude_V0AEq );
-    fInput->AddVariable( fAmplitude_V0CEq );
-    fInput->AddVariable( fAmplitude_OnlineV0A );
-    fInput->AddVariable( fAmplitude_OnlineV0C );
-    fInput->AddVariable( fAmplitude_V0AADC );
-    fInput->AddVariable( fAmplitude_V0CADC );
-    fInput->AddVariable( fnSPDClusters );
-    fInput->AddVariable( fnSPDClusters0 );
-    fInput->AddVariable( fnSPDClusters1 );
-    fInput->AddVariable( fnTracklets );
-    fInput->AddVariable( fnTracklets08 );
-    fInput->AddVariable( fnTracklets15 );
-    fInput->AddVariable( fRefMultEta5 );
-    fInput->AddVariable( fRefMultEta8 );
-    fInput->AddVariable( fMultiplicity_AD );
-    fInput->AddVariable( fMultiplicity_ADA );
-    fInput->AddVariable( fMultiplicity_ADC );
-    fInput->AddVariable( fZncEnergy );
-    fInput->AddVariable( fZpcEnergy );
-    fInput->AddVariable( fZnaEnergy );
-    fInput->AddVariable( fZpaEnergy );
-    fInput->AddVariable( fZem1Energy );
-    fInput->AddVariable( fZem2Energy );
-    fInput->AddVariable( fZnaTower );
-    fInput->AddVariable( fZncTower );
-    fInput->AddVariable( fZpaTower );
-    fInput->AddVariable( fZpcTower );
-    fInput->AddVariable( fZnaFired );
-    fInput->AddVariable( fZncFired );
-    fInput->AddVariable( fZpaFired );
-    fInput->AddVariable( fZpcFired );
-    fInput->AddVariable( fNTracks                  );
-    fInput->AddVariable( fNTracksGlobal2015        );
-    fInput->AddVariable( fNTracksGlobal2015Trigger );
-    fInput->AddVariable( fNTracksITSsa2010         );
-    fInput->AddVariable( fEvSel_VtxZ );
+    fInput->AddVariable(new AliMultVariable("fEvSel_VtxZ"));
 
     if( fkCalibration ) {
         TDirectory *owd = gDirectory;
@@ -498,7 +387,6 @@ void AliMultSelectionTask::UserCreateOutputObjects()
         fESDtrackCuts->SetPtRange(0.15);  // adding pt cut
         fESDtrackCuts->SetEtaRange(-1.0, 1.0);
     }
-
 
     //Create TPC only track cuts
     if(!fTrackCuts) fTrackCuts = AliESDtrackCuts::GetStandardTPCOnlyTrackCuts();
@@ -833,11 +721,11 @@ void AliMultSelectionTask::UserExec(Option_t *)
     fEvSel_IsNotAsymmetricInVZERO = kFALSE;
     fEvSel_IsNotIncompleteDAQ     = kFALSE;
     fEvSel_HasGoodVertex2016      = kFALSE;
-    //fnSPDClusters = -1;
-    fnSPDClusters -> SetValueInteger(-1);
-    fnSPDClusters0 -> SetValueInteger( -1) ;
-    fnSPDClusters1 -> SetValueInteger( -1) ;
-    fEvSel_VtxZ ->SetValue( -100 );
+
+    fInput->SetValue("fnSPDClusters",  -1);
+    fInput->SetValue("fnSPDClusters0", -1);
+    fInput->SetValue("fnSPDClusters1", -1);
+    fInput->SetValue("fEvSel_VtxZ",  -100.0f);
 
     fMC_NchV0A = -1;
     fMC_NchV0C = -1;
@@ -900,7 +788,6 @@ void AliMultSelectionTask::UserExec(Option_t *)
         AliMCEventHandler* eventHandler = (AliMCEventHandler*)anMan->GetMCtruthEventHandler();
         AliStack*    stack=0;
         AliMCEvent*  mcEvent=0;
-
 
         if (eventHandler && (mcEvent=eventHandler->MCEvent()) && (stack=mcEvent->Stack())) {
 
@@ -1025,7 +912,8 @@ void AliMultSelectionTask::UserExec(Option_t *)
         //FIXME Passed default 10.0cm selection!
         fEvSel_VtxZCut = kTRUE;
     }
-    fEvSel_VtxZ -> SetValue( lBestPrimaryVtxPos[2] ); //Set for later use
+    const Float_t evSel_VtxZ = lBestPrimaryVtxPos[2];
+    fInput->SetValue("fEvSel_VtxZ", evSel_VtxZ); //Set for later use
 
     //===============================================
     // End Event Selection Variables Section
@@ -1131,15 +1019,15 @@ void AliMultSelectionTask::UserExec(Option_t *)
 
     //Set Desired Variables
 
-    fAmplitude_V0A->SetValue(multV0A);
-    fAmplitude_V0C->SetValue(multV0C);
+    fInput->SetValue("fAmplitude_V0A", multV0A);
+    fInput->SetValue("fAmplitude_V0C", multV0C);
 
     //Implementation of V0 ADC information
     // FIXME: THIS ONLY WORKS IN ESDS FOR NOW
     Float_t  multV0AADC  = 0;            //  multiplicity from V0 reco side A from ADC
     Float_t  multV0CADC  = 0;            //  multiplicity from V0 reco side C from ADC
-    fAmplitude_V0AADC->SetValue(0);
-    fAmplitude_V0CADC->SetValue(0);
+    fInput->SetValue("fAmplitude_V0AADC", 0);
+    fInput->SetValue("fAmplitude_V0CADC", 0);
 
     /* FIXME: THIS DOES NOT WORK !!
      for(Int_t iCh = 0; iCh < 32; iCh++){
@@ -1152,35 +1040,35 @@ void AliMultSelectionTask::UserExec(Option_t *)
      }
      */
 
-    fAmplitude_V0AADC->SetValue(multV0AADC);
-    fAmplitude_V0CADC->SetValue(multV0CADC);
+    fInput->SetValue("fAmplitude_V0AADC", multV0AADC);
+    fInput->SetValue("fAmplitude_V0CADC", multV0CADC);
 
     if ( lVerbose ) {
         Printf(" V0A Amplitude: %.5f", multV0A );
         Printf(" V0C Amplitude: %.5f", multV0C );
     }
 
-    fAmplitude_OnlineV0A->SetValue(multonlineV0A);
-    fAmplitude_OnlineV0C->SetValue(multonlineV0C);
+    fInput->SetValue("fAmplitude_OnlineV0A", multonlineV0A);
+    fInput->SetValue("fAmplitude_OnlineV0C", multonlineV0C);
 
-    fAmplitude_V0Apartial->SetValue(multV0Apartial);
-    fAmplitude_V0Cpartial->SetValue(multV0Cpartial);
+    fInput->SetValue("fAmplitude_V0Apartial", multV0Apartial);
+    fInput->SetValue("fAmplitude_V0Cpartial", multV0Cpartial);
 
     //A.T. (vertex correction for all rings?!?)
-    fAmplitude_V0A1 -> SetValue( multV0A1 );
-    fAmplitude_V0A2 -> SetValue( multV0A2 );
-    fAmplitude_V0A3 -> SetValue( multV0A3 );
-    fAmplitude_V0A4 -> SetValue( multV0A4 );
-    fAmplitude_V0C1 -> SetValue( multV0C1 );
-    fAmplitude_V0C2 -> SetValue( multV0C2 );
-    fAmplitude_V0C3 -> SetValue( multV0C3 );
-    fAmplitude_V0C4 -> SetValue( multV0C4 );
+    fInput->SetValue("fAmplitude_V0A1",  multV0A1 );
+    fInput->SetValue("fAmplitude_V0A2",  multV0A2 );
+    fInput->SetValue("fAmplitude_V0A3",  multV0A3 );
+    fInput->SetValue("fAmplitude_V0A4",  multV0A4 );
+    fInput->SetValue("fAmplitude_V0C1",  multV0C1 );
+    fInput->SetValue("fAmplitude_V0C2",  multV0C2 );
+    fInput->SetValue("fAmplitude_V0C3",  multV0C3 );
+    fInput->SetValue("fAmplitude_V0C4",  multV0C4 );
 
     //AD scintillator Data added to Event Tree
     if (lVAD) {
-        fMultiplicity_AD ->SetValue(multAD);
-        fMultiplicity_ADA->SetValue(multADA);
-        fMultiplicity_ADC->SetValue(multADC);
+      fInput->SetValue("fMultiplicity_AD", multAD);
+      fInput->SetValue("fMultiplicity_ADA", multADA);
+      fInput->SetValue("fMultiplicity_ADC", multADC);
     }
 
     // Equalized signals // From AliCentralitySelectionTask // Updated
@@ -1192,48 +1080,48 @@ void AliMultSelectionTask::UserExec(Option_t *)
         Double_t mult = lVevent->GetVZEROEqMultiplicity(iCh);
         multV0CEq += mult;
     }
-    fAmplitude_V0AEq->SetValue(multV0AEq);
-    fAmplitude_V0CEq->SetValue(multV0CEq);
+    fInput->SetValue("fAmplitude_V0AEq", multV0AEq);
+    fInput->SetValue("fAmplitude_V0CEq", multV0CEq);
 
     //Integer Estimators
-    fnTracklets->SetValueInteger(lVevent->GetMultiplicity()->GetNumberOfTracklets());
+    fInput->SetValue("fnTracklets", lVevent->GetMultiplicity()->GetNumberOfTracklets());
     //Tracklets in specific eta windows
-    fnTracklets08->SetValueInteger(AliESDtrackCuts::GetReferenceMultiplicity((AliESDEvent*)lVevent, AliESDtrackCuts::kTracklets, 0.8));
-    fnTracklets15->SetValueInteger(AliESDtrackCuts::GetReferenceMultiplicity((AliESDEvent*)lVevent, AliESDtrackCuts::kTracklets, 1.5));
+    fInput->SetValue("fnTracklets08", AliESDtrackCuts::GetReferenceMultiplicity((AliESDEvent*)lVevent, AliESDtrackCuts::kTracklets, 0.8));
+    fInput->SetValue("fnTracklets15", AliESDtrackCuts::GetReferenceMultiplicity((AliESDEvent*)lVevent, AliESDtrackCuts::kTracklets, 1.5));
 
-    fnSPDClusters->SetValueInteger(lVevent->GetNumberOfITSClusters(0) + lVevent->GetNumberOfITSClusters(1));
-    fnSPDClusters0 -> SetValueInteger(lVevent->GetNumberOfITSClusters(0));
-    fnSPDClusters1 -> SetValueInteger(lVevent->GetNumberOfITSClusters(1));
+    fInput->SetValue("fnSPDClusters",  lVevent->GetNumberOfITSClusters(0) + lVevent->GetNumberOfITSClusters(1));
+    fInput->SetValue("fnSPDClusters0", lVevent->GetNumberOfITSClusters(0));
+    fInput->SetValue("fnSPDClusters1", lVevent->GetNumberOfITSClusters(1));
     //===============================================
     //This part requires separation of AOD and ESD
     //===============================================
 
     //Setting variables to non-sense values
-    fRefMultEta5 -> SetValueInteger ( -5 ); //not acquired
-    fRefMultEta8 -> SetValueInteger ( -5 ); //not acquired
-    fNTracks                    -> SetValueInteger( -10 );
+    fInput->SetValue("fRefMultEta5",  -5 ); //not acquired
+    fInput->SetValue("fRefMultEta8",  -5 ); //not acquired
+    fInput->SetValue("fNTracks",     -10 );
 
 
     //Set ZDC variables to defaults
-    fZncEnergy->SetValue(-1e6);
-    fZpcEnergy->SetValue(-1e6);
-    fZnaEnergy->SetValue(-1e6);
-    fZpaEnergy->SetValue(-1e6);
-    fZem1Energy->SetValue(-1e6);
-    fZem2Energy->SetValue(-1e6);
-    fZnaTower->SetValue(-1e6);
-    fZncTower->SetValue(-1e6);
-    fZpaTower->SetValue(-1e6);
-    fZpcTower->SetValue(-1e6);
-    fZnaFired->SetValueInteger( 0 );
-    fZncFired->SetValueInteger( 0 );
-    fZpaFired->SetValueInteger( 0 );
-    fZpcFired->SetValueInteger( 0 );
+    fInput->SetValue("fZncEnergy", -1e6f);
+    fInput->SetValue("fZpcEnergy", -1e6f);
+    fInput->SetValue("fZnaEnergy", -1e6f);
+    fInput->SetValue("fZpaEnergy", -1e6f);
+    fInput->SetValue("fZem1Energy", -1e6f);
+    fInput->SetValue("fZem2Energy", -1e6f);
+    fInput->SetValue("fZnaTower", -1e6f);
+    fInput->SetValue("fZncTower", -1e6f);
+    fInput->SetValue("fZpaTower", -1e6f);
+    fInput->SetValue("fZpcTower", -1e6f);
+    fInput->SetValue("fZnaFired",  0 );
+    fInput->SetValue("fZncFired",  0 );
+    fInput->SetValue("fZpaFired",  0 );
+    fInput->SetValue("fZpcFired",  0 );
 
     //Set Track Counters to zero
-    fNTracksGlobal2015          -> SetValueInteger( 0 );
-    fNTracksGlobal2015Trigger   -> SetValueInteger( 0 );
-    fNTracksITSsa2010           -> SetValueInteger( 0 );
+    fInput->SetValue("fNTracksGlobal2015",         0 );
+    fInput->SetValue("fNTracksGlobal2015Trigger",  0 );
+    fInput->SetValue("fNTracksITSsa2010",          0 );
 
     //Count tracks with various selections
     for(Long_t itrack = 0; itrack<lVevent->GetNumberOfTracks(); itrack++) {
@@ -1242,18 +1130,18 @@ void AliMultSelectionTask::UserExec(Option_t *)
 
         //Only ITSsa tracks
         if ( fTrackCutsITSsa2010 -> AcceptVTrack (track) ) {
-            fNTracksITSsa2010 -> SetValueInteger( fNTracksITSsa2010->GetValueInteger() + 1);
+          fInput->IncrementValue("fNTracksITSsa2010");
         }
 
         if ( !fTrackCutsGlobal2015 -> AcceptVTrack (track) ) continue;
 
         //Only for accepted tracks
-        fNTracksGlobal2015 -> SetValueInteger( fNTracksGlobal2015->GetValueInteger() + 1);
+        fInput->IncrementValue("fNTracksGlobal2015");
 
         //Count accepted + TOF time window (info from Alberica)
         //Warning: 30 is a value that is good for Pb-Pb (12.5 is more appropriate for pp)
         if ( TMath::Abs( track -> GetTOFExpTDiff() ) < 30 )
-            fNTracksGlobal2015Trigger -> SetValueInteger( fNTracksGlobal2015Trigger->GetValueInteger() + 1);
+          fInput->IncrementValue("fNTracksGlobal2015Trigger");
     }
 
     if(lVerbose) Printf("Doing ESD/AOD part...");
@@ -1261,62 +1149,53 @@ void AliMultSelectionTask::UserExec(Option_t *)
         AliESDEvent *esdevent = dynamic_cast<AliESDEvent *>(lVevent);
 
         //Standard GetReferenceMultiplicity Estimator (0.5 and 0.8)
-        fRefMultEta5 -> SetValueInteger ( fESDtrackCuts->GetReferenceMultiplicity(esdevent, AliESDtrackCuts::kTrackletsITSTPC,0.5) );
-        fRefMultEta8 -> SetValueInteger ( fESDtrackCuts->GetReferenceMultiplicity(esdevent, AliESDtrackCuts::kTrackletsITSTPC,0.8) );
+        const Int_t refMultEta5 = fESDtrackCuts->GetReferenceMultiplicity(esdevent, AliESDtrackCuts::kTrackletsITSTPC,0.5);
+        const Int_t refMultEta8 = fESDtrackCuts->GetReferenceMultiplicity(esdevent, AliESDtrackCuts::kTrackletsITSTPC,0.8);
 
         //Use fallback in case of return value of -3 or -4
         //This is what will happen in AODs: -3 will use fallback
         //HOWEVER: -4 will not. Inconsistency requires use of "HasNoInconsistentSPDandTrackVertices"!
-        if ( fRefMultEta5 -> GetValueInteger() < -2 ) {
-            fRefMultEta5 -> SetValueInteger ( fESDtrackCuts->GetReferenceMultiplicity(esdevent, AliESDtrackCuts::kTracklets,0.5) );
-        }
-        if ( fRefMultEta8 -> GetValueInteger() < -2 ) {
-            fRefMultEta8 -> SetValueInteger ( fESDtrackCuts->GetReferenceMultiplicity(esdevent, AliESDtrackCuts::kTracklets,0.8) );
-        }
+        fInput->SetValue("fRefMultEta5", refMultEta5 < -2 ? fESDtrackCuts->GetReferenceMultiplicity(esdevent, AliESDtrackCuts::kTracklets,0.5) : refMultEta5);
+        fInput->SetValue("fRefMultEta8", refMultEta8 < -2 ? fESDtrackCuts->GetReferenceMultiplicity(esdevent, AliESDtrackCuts::kTracklets,0.8) : refMultEta8);
 
         //A.T.
-        fNTracks -> SetValueInteger( fTrackCuts ? (Short_t)fTrackCuts->GetReferenceMultiplicity(esdevent,kTRUE):-1 );
+        fInput->SetValue("fNTracks",  fTrackCuts ? (Short_t)fTrackCuts->GetReferenceMultiplicity(esdevent,kTRUE) : -1 );
 
         // ***** ZDC info
         AliESDZDC *lESDZDC = esdevent->GetESDZDC();
-        Float_t CalF=0;
-        if (lESDZDC->AliESDZDC::TestBit(AliESDZDC::kEnergyCalibratedSignal))  CalF=1.0; //! if zdc is calibrated (in pass2)
-        else CalF=8.0;
+        //! if zdc is calibrated (in pass2)
+        const Float_t CalF = (lESDZDC->AliESDZDC::TestBit(AliESDZDC::kEnergyCalibratedSignal) ? 1.0f : 0.8f);
 
-        fZncEnergy -> SetValue ( (Float_t) (lESDZDC->GetZDCN1Energy())/CalF );
-        fZpcEnergy -> SetValue ( (Float_t) (lESDZDC->GetZDCP1Energy())/CalF );
-        fZnaEnergy -> SetValue ( (Float_t) (lESDZDC->GetZDCN2Energy())/CalF );
-        fZpaEnergy -> SetValue ( (Float_t) (lESDZDC->GetZDCP2Energy())/CalF );
+        fInput->SetValue("fZncEnergy", Float_t(lESDZDC->GetZDCN1Energy())/CalF );
+        fInput->SetValue("fZpcEnergy", Float_t(lESDZDC->GetZDCP1Energy())/CalF );
+        fInput->SetValue("fZnaEnergy", Float_t(lESDZDC->GetZDCN2Energy())/CalF );
+        fInput->SetValue("fZpaEnergy", Float_t(lESDZDC->GetZDCP2Energy())/CalF );
 
-        fZem1Energy -> SetValue ( (Float_t) (lESDZDC->GetZDCEMEnergy(0))/CalF );
-        fZem2Energy -> SetValue ( (Float_t) (lESDZDC->GetZDCEMEnergy(1))/CalF );
+        fInput->SetValue("fZem1Energy", Float_t(lESDZDC->GetZDCEMEnergy(0))/CalF );
+        fInput->SetValue("fZem2Energy", Float_t(lESDZDC->GetZDCEMEnergy(1))/CalF );
 
-        Int_t detCh_ZNA = lESDZDC->GetZNATDCChannel();
-        Int_t detCh_ZNC = lESDZDC->GetZNCTDCChannel();
-        Int_t detCh_ZPA = lESDZDC->GetZPATDCChannel();
-        Int_t detCh_ZPC = lESDZDC->GetZPCTDCChannel();
+        const Int_t detCh_ZNA = lESDZDC->GetZNATDCChannel();
+        const Int_t detCh_ZNC = lESDZDC->GetZNCTDCChannel();
+        const Int_t detCh_ZPA = lESDZDC->GetZPATDCChannel();
+        const Int_t detCh_ZPC = lESDZDC->GetZPCTDCChannel();
 
         for (Int_t j = 0; j < 4; ++j) {
-	   if (lESDZDC->GetZDCTDCData(detCh_ZNA,j) != 0)      fZnaFired -> SetValueInteger(1);
-	   if (lESDZDC->GetZDCTDCData(detCh_ZNC,j) != 0)      fZncFired -> SetValueInteger(1);
-	   if (lESDZDC->GetZDCTDCData(detCh_ZPA,j) != 0)      fZpaFired -> SetValueInteger(1);
-	   if (lESDZDC->GetZDCTDCData(detCh_ZPC,j) != 0)      fZpcFired -> SetValueInteger(1);
+          if (lESDZDC->GetZDCTDCData(detCh_ZNA,j) != 0)      fInput->SetValue("fZnaFired", 1);
+          if (lESDZDC->GetZDCTDCData(detCh_ZNC,j) != 0)      fInput->SetValue("fZncFired", 1);
+          if (lESDZDC->GetZDCTDCData(detCh_ZPA,j) != 0)      fInput->SetValue("fZpaFired", 1);
+          if (lESDZDC->GetZDCTDCData(detCh_ZPC,j) != 0)      fInput->SetValue("fZpcFired", 1);
         }
 
-        const Double_t *ZNAtower = lESDZDC->GetZNATowerEnergy();
-        const Double_t *ZNCtower = lESDZDC->GetZNCTowerEnergy();
-        const Double_t *ZPAtower = lESDZDC->GetZPATowerEnergy();
-        const Double_t *ZPCtower = lESDZDC->GetZPCTowerEnergy();
-        fZnaTower -> SetValue ( (Float_t) ZNAtower[0] );
-        fZncTower -> SetValue ( (Float_t) ZNCtower[0] );
-        fZpaTower -> SetValue ( (Float_t) ZPAtower[0] );
-        fZpcTower -> SetValue ( (Float_t) ZPCtower[0] );
+        fInput->SetValue("fZnaTower", Float_t(lESDZDC->GetZNATowerEnergy()[0]));
+        fInput->SetValue("fZncTower", Float_t(lESDZDC->GetZNCTowerEnergy()[0]));
+        fInput->SetValue("fZpaTower", Float_t(lESDZDC->GetZPATowerEnergy()[0]));
+        fInput->SetValue("fZpcTower", Float_t(lESDZDC->GetZPCTowerEnergy()[0]));
 
     } else if (lVevent->InheritsFrom("AliAODEvent")) {
         AliAODEvent *aodevent = dynamic_cast<AliAODEvent *>(lVevent);
         AliAODHeader * header = dynamic_cast<AliAODHeader*>(aodevent->GetHeader());
-        fRefMultEta5 -> SetValueInteger ( header->GetRefMultiplicityComb05() );
-        fRefMultEta8 -> SetValueInteger ( header->GetRefMultiplicityComb08() );
+        fInput->SetValue("fRefMultEta5", header->GetRefMultiplicityComb05() );
+        fInput->SetValue("fRefMultEta8", header->GetRefMultiplicityComb08() );
 
         //FIXME: get ZDC information in AOD in a fully consistent way
         AliAODZDC *lAODZDC = aodevent->GetZDCData();
@@ -1324,20 +1203,15 @@ void AliMultSelectionTask::UserExec(Option_t *)
         //Only do this bit if the AOD has ZDC data
         if( lAODZDC ){
             for (Int_t j = 0; j < 4; ++j) {
-                if (lAODZDC->GetZNATDCm(j) > -998) fZnaFired -> SetValueInteger(1);
-                if (lAODZDC->GetZNCTDCm(j) > -998) fZncFired -> SetValueInteger(1);
-                if (lAODZDC->GetZPATDCm(j) > -998) fZpaFired -> SetValueInteger(1);
-                if (lAODZDC->GetZPCTDCm(j) > -998) fZpcFired -> SetValueInteger(1);
+              if (lAODZDC->GetZNATDCm(j) > -998) fInput->SetValue("fZnaFired", 1);
+              if (lAODZDC->GetZNCTDCm(j) > -998) fInput->SetValue("fZncFired", 1);
+              if (lAODZDC->GetZPATDCm(j) > -998) fInput->SetValue("fZpaFired", 1);
+              if (lAODZDC->GetZPCTDCm(j) > -998) fInput->SetValue("fZpcFired", 1);
             }
-
-            const Double_t *ZNAtower = lAODZDC->GetZNATowerEnergy();
-            const Double_t *ZNCtower = lAODZDC->GetZNCTowerEnergy();
-            const Double_t *ZPAtower = lAODZDC->GetZPATowerEnergy();
-            const Double_t *ZPCtower = lAODZDC->GetZPCTowerEnergy();
-            fZnaTower -> SetValue ( (Float_t) ZNAtower[0] );
-            fZncTower -> SetValue ( (Float_t) ZNCtower[0] );
-            fZpaTower -> SetValue ( (Float_t) ZPAtower[0] );
-            fZpcTower -> SetValue ( (Float_t) ZPCtower[0] );
+            fInput->SetValue("fZnaTower", Float_t(lAODZDC->GetZNATowerEnergy()[0]) );
+            fInput->SetValue("fZncTower", Float_t(lAODZDC->GetZNCTowerEnergy()[0]) );
+            fInput->SetValue("fZpaTower", Float_t(lAODZDC->GetZPATowerEnergy()[0]) );
+            fInput->SetValue("fZpcTower", Float_t(lAODZDC->GetZPCTowerEnergy()[0]) );
         }
     }
 
@@ -1407,7 +1281,7 @@ void AliMultSelectionTask::UserExec(Option_t *)
 	lSelection -> SetThisEventPassesTrackletVsCluster   ( fEvSel_PassesTrackletVsCluster   );
 	lSelection -> SetThisEventIsNotAsymmetricInVZERO    ( fEvSel_IsNotAsymmetricInVZERO    );
 	lSelection -> SetThisEventIsNotIncompleteDAQ        ( fEvSel_IsNotIncompleteDAQ        );
-    lSelection -> SetThisEventHasGoodVertex2016         ( fEvSel_HasGoodVertex2016         );
+        lSelection -> SetThisEventHasGoodVertex2016         ( fEvSel_HasGoodVertex2016         );
 
         if( lMultCuts->GetTriggerCut()    && ! fEvSel_Triggered           )
             lSelection->SetEvSelCode(AliMultSelectionCuts::kRejTrigger);
@@ -1415,7 +1289,7 @@ void AliMultSelectionTask::UserExec(Option_t *)
         if( lMultCuts->GetINELgtZEROCut() && ! fEvSel_INELgtZERO          )
             lSelection->SetEvSelCode(AliMultSelectionCuts::kRejINELgtZERO);
 
-        if( TMath::Abs(fEvSel_VtxZ->GetValue() ) > lMultCuts->GetVzCut()      )
+        if( TMath::Abs(evSel_VtxZ) > lMultCuts->GetVzCut())
             lSelection->SetEvSelCode(AliMultSelectionCuts::kRejVzCut);
 
         if( lMultCuts->GetRejectPileupInMultBinsCut() && ! fEvSel_IsNotPileupInMultBins      )
@@ -1478,7 +1352,7 @@ void AliMultSelectionTask::UserExec(Option_t *)
         Float_t lZNC = lSelection->GetMultiplicityPercentile("ZNC");
         Float_t lZNApp = lSelection->GetMultiplicityPercentile("ZNApp");
         Float_t lZNCpp = lSelection->GetMultiplicityPercentile("ZNCpp");
-        Int_t ltracklets = fnTracklets->GetValueInteger();
+        Int_t ltracklets = fInput->GetValueInteger("fnTracklets");
 
         fHistQA_V0M -> Fill( lV0M );
         fHistQA_V0A -> Fill( lV0A );
@@ -1523,6 +1397,9 @@ void AliMultSelectionTask::UserExec(Option_t *)
         fHistQASelected_TrackletsVsCL0 -> Fill( lCL0, ltracklets );
         fHistQASelected_TrackletsVsCL1 -> Fill( lCL1, ltracklets );
 
+        const Int_t nTracksGlobal2015 = fInput->GetValueInteger("fNTracksGlobal2015");
+        const Int_t nTracksITSsa2010  = fInput->GetValueInteger("fNTracksITSsa2010");
+
         //Track momentum QA
         for(Long_t itrack = 0; itrack<lVevent->GetNumberOfTracks(); itrack++) {
             AliVTrack *track = lVevent -> GetVTrack( itrack );
@@ -1543,12 +1420,12 @@ void AliMultSelectionTask::UserExec(Option_t *)
             fHistQASelected_PtGlobalVsCL1 -> Fill( lCL1, track->Pt() );
         }
 
-        fHistQASelected_NTracksGlobalVsV0M -> Fill( lV0M, fNTracksGlobal2015->GetValueInteger() );
-        fHistQASelected_NTracksGlobalVsCL0 -> Fill( lCL0, fNTracksGlobal2015->GetValueInteger() );
-        fHistQASelected_NTracksGlobalVsCL1 -> Fill( lCL1, fNTracksGlobal2015->GetValueInteger() );
-        fHistQASelected_NTracksITSsaVsV0M  -> Fill( lV0M, fNTracksITSsa2010->GetValueInteger() );
-        fHistQASelected_NTracksITSsaVsCL0  -> Fill( lCL0, fNTracksITSsa2010->GetValueInteger() );
-        fHistQASelected_NTracksITSsaVsCL1  -> Fill( lCL1, fNTracksITSsa2010->GetValueInteger() );
+        fHistQASelected_NTracksGlobalVsV0M -> Fill( lV0M, nTracksGlobal2015);
+        fHistQASelected_NTracksGlobalVsCL0 -> Fill( lCL0, nTracksGlobal2015);
+        fHistQASelected_NTracksGlobalVsCL1 -> Fill( lCL1, nTracksGlobal2015);
+        fHistQASelected_NTracksITSsaVsV0M  -> Fill( lV0M, nTracksITSsa2010);
+        fHistQASelected_NTracksITSsaVsCL0  -> Fill( lCL0, nTracksITSsa2010);
+        fHistQASelected_NTracksITSsaVsCL1  -> Fill( lCL1, nTracksITSsa2010);
         //=============================================================================
 
         //Add to AliVEvent
@@ -2377,12 +2254,11 @@ TString AliMultSelectionTask::GetSystemTypeByRunNumber() const
 }
 //______________________________________________________________________
 Bool_t AliMultSelectionTask::CheckOADB(TString lProdName) const {
-    //This helper function checks if an OADB exists for the production named lProdName
-    //Determine file name
-    TString fileName = Form("%s/COMMON/MULTIPLICITY/data/OADB-%s.root", AliAnalysisManager::GetOADBPath(), lProdName.Data() );
-
-    Bool_t lInverseThis = !gSystem->AccessPathName(fileName.Data());
-    return lInverseThis;
+  //This helper function checks if an OADB exists for the production named lProdName
+  //Determine file name
+  const TString fileName    = TString::Format("%s/COMMON/MULTIPLICITY/data/OADB-%s.root", AliAnalysisManager::GetOADBPath(), lProdName.Data() );
+  const Bool_t lInverseThis = !gSystem->AccessPathName(fileName.Data());
+  return lInverseThis;
 }
 
 //______________________________________________________________________
@@ -2425,7 +2301,7 @@ Bool_t AliMultSelectionTask::IsDPMJet() const {
 
 //______________________________________________________________________
 Bool_t AliMultSelectionTask::IsEPOSLHC() const {
-    //Function to check if this is DPMJet
+    //Function to check if this is EPOSLHC
     Bool_t lReturnValue = kFALSE;
     AliMCEvent*  mcEvent = MCEvent();
     if (mcEvent) {

--- a/OADB/COMMON/MULTIPLICITY/AliMultSelectionTask.h
+++ b/OADB/COMMON/MULTIPLICITY/AliMultSelectionTask.h
@@ -46,7 +46,6 @@ class AliESDEvent;
 class AliPhysicsSelection;
 class AliCFContainer;
 class AliESDAD;
-class AliMultVariable;
 class AliMultEstimator;
 class AliMultInput;
 class AliMultSelection;
@@ -54,7 +53,7 @@ class AliMultSelectionCuts;
 class AliOADBMultSelection;
 class AliADChargeEqualization;
 
-//#include "TString.h"
+#include "TArrayF.h"
 //#include "AliESDtrackCuts.h"
 //#include "AliAnalysisTaskSE.h"
 
@@ -178,57 +177,6 @@ private:
     //To perform event selection
     //AliMultSelectionCuts *fMultSelectionCuts; //To perform event selections
 
-    //===========================================================================
-    //   Variables for Multiplicity Determination
-    //===========================================================================
-    AliMultVariable *fAmplitude_V0A;
-    AliMultVariable *fAmplitude_V0A1;
-    AliMultVariable *fAmplitude_V0A2;
-    AliMultVariable *fAmplitude_V0A3;
-    AliMultVariable *fAmplitude_V0A4;
-    AliMultVariable *fAmplitude_V0C;
-    AliMultVariable *fAmplitude_V0C1;
-    AliMultVariable *fAmplitude_V0C2;
-    AliMultVariable *fAmplitude_V0C3;
-    AliMultVariable *fAmplitude_V0C4;
-    AliMultVariable *fAmplitude_V0Apartial;
-    AliMultVariable *fAmplitude_V0Cpartial;
-    AliMultVariable *fAmplitude_V0AEq;
-    AliMultVariable *fAmplitude_V0CEq;
-    AliMultVariable *fAmplitude_OnlineV0A;
-    AliMultVariable *fAmplitude_OnlineV0C;
-    AliMultVariable *fAmplitude_V0AADC;
-    AliMultVariable *fAmplitude_V0CADC;
-
-    //Integer Variables
-    AliMultVariable *fnSPDClusters;
-    AliMultVariable *fnSPDClusters0;
-    AliMultVariable *fnSPDClusters1;
-    AliMultVariable *fnTracklets; //tracklet estimator
-    AliMultVariable *fnTracklets08; //tracklet estimator
-    AliMultVariable *fnTracklets15; //tracklet estimator
-    AliMultVariable *fRefMultEta5; //tracklet estimator
-    AliMultVariable *fRefMultEta8; //tracklet estimator
-    //AD Related
-    AliMultVariable *fMultiplicity_AD;   // AD A+C-side
-    AliMultVariable *fMultiplicity_ADA;  // AD A-side
-    AliMultVariable *fMultiplicity_ADC;  // AD C-side
-    //ZDC Related
-    AliMultVariable *fZncEnergy;
-    AliMultVariable *fZpcEnergy;
-    AliMultVariable *fZnaEnergy;
-    AliMultVariable *fZpaEnergy;
-    AliMultVariable *fZem1Energy;
-    AliMultVariable *fZem2Energy;
-    //ZDC Tower info
-    AliMultVariable *fZnaTower;
-    AliMultVariable *fZncTower;
-    AliMultVariable *fZpaTower;
-    AliMultVariable *fZpcTower;
-
-    //Event selection snippet for VtxZ as AliMultVariable
-    AliMultVariable *fEvSel_VtxZ;
-
     //Event Characterization Variables - optional
     Bool_t fEvSel_VtxZCut;                  //!
     Bool_t fEvSel_IsNotPileup;              //!
@@ -255,17 +203,7 @@ private:
     AliESDtrackCuts* fTrackCutsGlobal2015;  // optional track cuts
     AliESDtrackCuts* fTrackCutsITSsa2010; // optional track cuts
 
-    AliMultVariable *fZnaFired;
-    AliMultVariable *fZncFired;
-    AliMultVariable *fZpaFired;
-    AliMultVariable *fZpcFired;
-
-    AliMultVariable *fNTracks;             //!  no. tracks
-    AliMultVariable *fNTracksGlobal2015;             //!  no. tracks (2015 Global track cuts)
-    AliMultVariable *fNTracksGlobal2015Trigger;             //!  no. tracks (2015 glob. + TOF-based selection for trigger event)
-    AliMultVariable *fNTracksITSsa2010;                     //!  no. tracks ITSsa (2010 ITSsa track cuts)
-
-    Float_t fQuantiles[100]; //! percentiles
+    TArrayF fQuantiles; //! percentiles
     Int_t fEvSelCode; //Final code in event selection
     Int_t fNDebug; // number of percentiles
 
@@ -339,7 +277,7 @@ private:
     AliMultSelectionTask(const AliMultSelectionTask&);            // not implemented
     AliMultSelectionTask& operator=(const AliMultSelectionTask&); // not implemented
 
-    ClassDef(AliMultSelectionTask, 5);
+    ClassDef(AliMultSelectionTask, 6);
     //3 - extra QA histograms
 };
 

--- a/OADB/COMMON/MULTIPLICITY/AliMultSelectionTask.h
+++ b/OADB/COMMON/MULTIPLICITY/AliMultSelectionTask.h
@@ -52,6 +52,7 @@ class AliMultInput;
 class AliMultSelection;
 class AliMultSelectionCuts;
 class AliOADBMultSelection;
+class AliADChargeEqualization;
 
 //#include "TString.h"
 //#include "AliESDtrackCuts.h"
@@ -59,12 +60,11 @@ class AliOADBMultSelection;
 
 class AliMultSelectionTask : public AliAnalysisTaskSE {
 public:
-    
-    AliMultSelectionTask();
-    AliMultSelectionTask(const char *name, TString lExtraOptions = "", Bool_t lCalib = kFALSE, Int_t lNDebugEstimators = 1);
+
+    AliMultSelectionTask(const char *name="AliMultSelectionTask", TString lExtraOptions = "", Bool_t lCalib = kFALSE, Int_t lNDebugEstimators = 1);
     virtual ~AliMultSelectionTask();
-    
-    //Static Event Selection Functions 
+
+    //Static Event Selection Functions
     static Bool_t IsSelectedTrigger                    (AliVEvent* event, AliVEvent::EOfflineTriggerTypes lCheckedTrig);
     static Bool_t IsINELgtZERO                         (AliVEvent *event);
     static Bool_t IsAcceptedVertexPosition             (AliVEvent *event);
@@ -74,30 +74,31 @@ public:
     static Bool_t IsNotAsymmetricInVZERO               (AliVEvent *event);
     static Bool_t IsNotIncompleteDAQ                   (AliVEvent *event);
     static Bool_t HasGoodVertex2016                    (AliVEvent *event);
-    
+
     void SetSelectedTriggerClass(AliVEvent::EOfflineTriggerTypes trigType) { fkTrigger = trigType;}
-    
+
     //Get Period name (can be static)
     TString GetPeriodNameByLPM(TString lTag); //try userInfo first
     TString GetPeriodNameByPath( const TString lPath ) const; //no input required, will have all info in globals...
     TString GetPeriodNameByRunNumber()  const; //no input required, use fCurrentRun
     TString GetSystemTypeByRunNumber()  const; //no input required, use fCurrentRun
     Bool_t CheckOADB( TString lProdName ) const;
-    
+
     //Check MC type
     Bool_t IsHijing()  const;
     Bool_t IsDPMJet()  const;
     Bool_t IsEPOSLHC() const;
- 
+
     void CreateEmptyOADB(); //In case we really didn't get anything ...
-    
-    //Cannot be static: requires AliAnalysisUtils Object (why not static?) 
+
+    //Cannot be static: requires AliAnalysisUtils Object (why not static?)
     Bool_t IsNotPileupMV           (AliVEvent *event);
     Bool_t PassesTrackletVsCluster (AliVEvent *event);
-    
-    //Setup Run if needed (depends on run number!)     
-    Int_t SetupRun( const AliVEvent* const esd );
-    
+
+    //Setup Run if needed (depends on run number!)
+    void  LoadADEqualizationFromOCDB();
+    Int_t SetupRun();
+
     //removed to avoid accidental usage!
     //void SetSaveCalibInfo( Bool_t lVar ) { fkCalibration = lVar; } ;
     void SetAddInfo      ( Bool_t lVar ) { fkAddInfo     = lVar; } ;
@@ -105,38 +106,39 @@ public:
     void SetDebug        ( Bool_t lVar ) { fkDebug       = lVar; } ;
     void SetNDebug       ( Int_t  lVar ) { fNDebug       = lVar; } ;
     void SetHighMultQABinning( Bool_t lVar ) { fkHighMultQABinning = lVar; }
-    
+
     //override for getting estimator definitions from different OADB file
     //FIXME: should preferably be protected, extra functionality required
     void SetAlternateOADBforEstimators      ( TString lFile ){ fAlternateOADBForEstimators      = lFile.Data(); }
     void SetAlternateOADBFullManualBypass   ( TString lFile ){ fAlternateOADBFullManualBypass   = lFile.Data(); }
     void SetAlternateOADBFullManualBypassMC ( TString lFile ){ fAlternateOADBFullManualBypassMC = lFile.Data(); }
-    
+
     //Customize AliMultSelection object name
     void SetStoredObjectName ( TString lObjName ){ fStoredObjectName = lObjName.Data(); }
-    
+
     //Default Setters
     void SetUseDefaultCalib   ( Bool_t lVar ){ fkUseDefaultCalib = lVar; }
     Bool_t GetUseDefaultCalib () const { return fkUseDefaultCalib; }
-    
+
     void SetUseDefaultMCCalib ( Bool_t lVar ){ fkUseDefaultMCCalib = lVar; }
     Bool_t GetUseDefaultMCCalib () const { return fkUseDefaultMCCalib; }
-    
+
     //Calibration mode downscaling for manageable output
     void SetDownscaleFactor ( Double_t lDownscale ) { fDownscaleFactor = lDownscale; }
-    
+
     virtual void   UserCreateOutputObjects();
+    virtual void   NotifyRun();
     virtual void   UserExec(Option_t *option);
     virtual void   Terminate(Option_t *);
     //---------------------------------------------------------------------------------------
 
 private:
-    
+
     // Note : In ROOT, "//!" means "do not stream the data from Master node to Worker node" ...
     // your data member object is created on the worker nodes and streaming is not needed.
     // http://root.cern.ch/download/doc/11InputOutput.pdf, page 14
-    TList  *fListHist;  //! List of Cascade histograms
-    TTree  *fTreeEvent;              //! Output Tree, Events
+    TList  *fListHist;    //! List of Cascade histograms
+    TTree  *fTreeEvent;   //! Output Tree, Events
 
     //Objects Controlling Task Behaviour
     Bool_t fkCalibration; //if true, save Calibration object
@@ -144,38 +146,38 @@ private:
     Bool_t fkFilterMB;    //if true, save only kMB events
     Bool_t fkAttached;    //if true, has already attached to ESD (AOD)
     Bool_t fkHighMultQABinning; //if true, use narrow binning for percentile histograms
-    
+
     //Debug Options
     Bool_t fkDebug;       //if true, saves percentiles in TTree for debugging
     Bool_t fkDebugAliCentrality; //if true, adds V0M percentiles from AliCentrality in TTree
     Bool_t fkDebugAliPPVsMultUtils; //if true, adds V0M percentiles from AliCentrality in TTree
     Bool_t fkDebugIsMC; //if true, adds some MC info for cross-checks (needs MC)
-    
+
     //Default options
     Bool_t fkUseDefaultCalib; //if true, allow for default data calibration
     Bool_t fkUseDefaultMCCalib; //if true, allow for default scaling factor in MC
-    
+
     //Downscale factor:
     //-> if smaller than unity, reduce change of accepting a given event for calib tree
     Double_t fDownscaleFactor;
     TRandom3 *fRand; //PRNG (MT) for random downscaling
-    
+
     //Trigger selection
     AliVEvent::EOfflineTriggerTypes fkTrigger; //kMB, kINT7, etc as needed
-    
+
     TString fAlternateOADBForEstimators;
     TString fAlternateOADBFullManualBypass;
     TString fAlternateOADBFullManualBypassMC;
-    
+
     //Object name for attaching to ESD/AOD
     TString fStoredObjectName;
-    
+
     AliESDtrackCuts *fESDtrackCuts;
     AliAnalysisUtils *fUtils;         // analysis utils
-    
+
     //To perform event selection
     //AliMultSelectionCuts *fMultSelectionCuts; //To perform event selections
-    
+
     //===========================================================================
     //   Variables for Multiplicity Determination
     //===========================================================================
@@ -198,7 +200,7 @@ private:
     AliMultVariable *fAmplitude_V0AADC;
     AliMultVariable *fAmplitude_V0CADC;
 
-    //Integer Variables 
+    //Integer Variables
     AliMultVariable *fnSPDClusters;
     AliMultVariable *fnSPDClusters0;
     AliMultVariable *fnSPDClusters1;
@@ -208,8 +210,9 @@ private:
     AliMultVariable *fRefMultEta5; //tracklet estimator
     AliMultVariable *fRefMultEta8; //tracklet estimator
     //AD Related
-    AliMultVariable *fMultiplicity_ADA;
-    AliMultVariable *fMultiplicity_ADC;
+    AliMultVariable *fMultiplicity_AD;   // AD A+C-side
+    AliMultVariable *fMultiplicity_ADA;  // AD A-side
+    AliMultVariable *fMultiplicity_ADC;  // AD C-side
     //ZDC Related
     AliMultVariable *fZncEnergy;
     AliMultVariable *fZpcEnergy;
@@ -222,11 +225,9 @@ private:
     AliMultVariable *fZncTower;
     AliMultVariable *fZpaTower;
     AliMultVariable *fZpcTower;
-    
+
     //Event selection snippet for VtxZ as AliMultVariable
     AliMultVariable *fEvSel_VtxZ;
-
-    Int_t fRunNumber;                    
 
     //Event Characterization Variables - optional
     Bool_t fEvSel_VtxZCut;                  //!
@@ -240,10 +241,10 @@ private:
     Bool_t fEvSel_IsNotAsymmetricInVZERO;   //!
     Bool_t fEvSel_IsNotIncompleteDAQ;       //!
     Bool_t fEvSel_HasGoodVertex2016;        //!
-    
+
     //Full Physics Selection Trigger info
     UInt_t fEvSel_TriggerMask; //! save full info for checking later
-    
+
     //Other Selections: more dedicated filtering to be studied!
 
     // A.T.
@@ -253,26 +254,24 @@ private:
     AliESDtrackCuts* fTrackCuts;        // optional track cuts
     AliESDtrackCuts* fTrackCutsGlobal2015;  // optional track cuts
     AliESDtrackCuts* fTrackCutsITSsa2010; // optional track cuts
-    
+
     AliMultVariable *fZnaFired;
     AliMultVariable *fZncFired;
     AliMultVariable *fZpaFired;
     AliMultVariable *fZpcFired;
-    
+
     AliMultVariable *fNTracks;             //!  no. tracks
     AliMultVariable *fNTracksGlobal2015;             //!  no. tracks (2015 Global track cuts)
     AliMultVariable *fNTracksGlobal2015Trigger;             //!  no. tracks (2015 glob. + TOF-based selection for trigger event)
     AliMultVariable *fNTracksITSsa2010;                     //!  no. tracks ITSsa (2010 ITSsa track cuts)
-    
-    Int_t fCurrentRun;
-    
+
     Float_t fQuantiles[100]; //! percentiles
-    Int_t fEvSelCode; //Final code in event selection 
+    Int_t fEvSelCode; //Final code in event selection
     Int_t fNDebug; // number of percentiles
-    
-    Float_t fAliCentralityV0M; //! percentiles from AliCentrality (for debugging) 
+
+    Float_t fAliCentralityV0M; //! percentiles from AliCentrality (for debugging)
     Float_t fPPVsMultUtilsV0M; //! percentiles from AliPPVsMultUtils (for debugging)
-    
+
     //Data needed for Monte Carlo
     Int_t fMC_NColl;
     Int_t fMC_NPart;
@@ -281,16 +280,16 @@ private:
     Int_t fMC_NchEta05;
     Int_t fMC_NchEta08;
     Int_t fMC_NchEta10;
-    
+
     //Histograms / Anything else as needed
     TH1D *fHistEventCounter; //!
-    TH2D *fHistEventSelections; //! For keeping track of 
-    
+    TH2D *fHistEventSelections; //! For keeping track of
+
     //Simple QA histograms
     TH1D *fHistQA_V0M;
     TH1D *fHistQA_V0A;
     TH1D *fHistQA_V0C;
-    TH1D *fHistQA_CL0; 
+    TH1D *fHistQA_CL0;
     TH1D *fHistQA_CL1;
     TH1D *fHistQA_SPDClusters;
     TH1D *fHistQA_SPDTracklets;
@@ -298,14 +297,14 @@ private:
     TH1D *fHistQA_ZNC;
     TH1D *fHistQA_ZNApp;
     TH1D *fHistQA_ZNCpp;
-    TProfile *fHistQA_TrackletsVsV0M; 
-    TProfile *fHistQA_TrackletsVsCL0; 
-    TProfile *fHistQA_TrackletsVsCL1; 
-    
+    TProfile *fHistQA_TrackletsVsV0M;
+    TProfile *fHistQA_TrackletsVsCL0;
+    TProfile *fHistQA_TrackletsVsCL1;
+
     TH1D *fHistQASelected_V0M;
     TH1D *fHistQASelected_V0A;
     TH1D *fHistQASelected_V0C;
-    TH1D *fHistQASelected_CL0; 
+    TH1D *fHistQASelected_CL0;
     TH1D *fHistQASelected_CL1;
     TH1D *fHistQASelected_SPDClusters;
     TH1D *fHistQASelected_SPDTracklets;
@@ -314,15 +313,15 @@ private:
     TH1D *fHistQASelected_ZNApp;
     TH1D *fHistQASelected_ZNCpp;
     TProfile *fHistQASelected_TrackletsVsV0M;
-    TProfile *fHistQASelected_TrackletsVsCL0; 
-    TProfile *fHistQASelected_TrackletsVsCL1; 
+    TProfile *fHistQASelected_TrackletsVsCL0;
+    TProfile *fHistQASelected_TrackletsVsCL1;
 
-    TProfile *fHistQASelected_NTracksGlobalVsV0M; 
-    TProfile *fHistQASelected_NTracksGlobalVsCL0; 
-    TProfile *fHistQASelected_NTracksGlobalVsCL1; 
-    TProfile *fHistQASelected_PtGlobalVsV0M; 
-    TProfile *fHistQASelected_PtGlobalVsCL0; 
-    TProfile *fHistQASelected_PtGlobalVsCL1; 
+    TProfile *fHistQASelected_NTracksGlobalVsV0M;
+    TProfile *fHistQASelected_NTracksGlobalVsCL0;
+    TProfile *fHistQASelected_NTracksGlobalVsCL1;
+    TProfile *fHistQASelected_PtGlobalVsV0M;
+    TProfile *fHistQASelected_PtGlobalVsCL0;
+    TProfile *fHistQASelected_PtGlobalVsCL1;
 
     TProfile *fHistQASelected_NTracksITSsaVsV0M;
     TProfile *fHistQASelected_NTracksITSsaVsCL0;
@@ -331,6 +330,8 @@ private:
     TProfile *fHistQASelected_PtITSsaVsCL0;
     TProfile *fHistQASelected_PtITSsaVsCL1;
 
+    AliADChargeEqualization *fADChargeEqualization;
+
     //AliMultSelection Framework
     AliOADBMultSelection *fOadbMultSelection;
     AliMultInput         *fInput;
@@ -338,7 +339,7 @@ private:
     AliMultSelectionTask(const AliMultSelectionTask&);            // not implemented
     AliMultSelectionTask& operator=(const AliMultSelectionTask&); // not implemented
 
-    ClassDef(AliMultSelectionTask, 4);
+    ClassDef(AliMultSelectionTask, 5);
     //3 - extra QA histograms
 };
 

--- a/OADB/COMMON/MULTIPLICITY/AliMultVariable.cxx
+++ b/OADB/COMMON/MULTIPLICITY/AliMultVariable.cxx
@@ -1,9 +1,9 @@
 /**********************************************
  *
- * This is the basic input variable definition 
+ * This is the basic input variable definition
  * class
- * 
- * Requires a definition of a callsign and 
+ *
+ * Requires a definition of a callsign and
  * a definition of a substitution value
  *
  **********************************************/
@@ -17,19 +17,19 @@ AliMultVariable::AliMultVariable() :
   TNamed(), fIsInteger(kFALSE), fValue(0), fValueInteger(0), fMean(0)
 {
   // Constructor
-  
+
 }
 //________________________________________________________________
-AliMultVariable::AliMultVariable(const char * name, const char * title):
-TNamed(name,title), fIsInteger(kFALSE), fValue(0), fValueInteger(0), fMean(0)
+AliMultVariable::AliMultVariable(const char * name, const char * title, Bool_t isInteger):
+TNamed(name,title), fIsInteger(isInteger), fValue(0), fValueInteger(0), fMean(0)
 {
   // Constructor
-  
+
 }
 //________________________________________________________________
 AliMultVariable::~AliMultVariable(){
   // destructor
-  
+
 }
 //________________________________________________________________
 void AliMultVariable::Print(Option_t* option) const

--- a/OADB/COMMON/MULTIPLICITY/AliMultVariable.h
+++ b/OADB/COMMON/MULTIPLICITY/AliMultVariable.h
@@ -3,10 +3,10 @@
 #include <TNamed.h>
 
 class AliMultVariable : public TNamed {
-    
+
 public:
     AliMultVariable();
-    AliMultVariable(const char * name, const char * title = "Mult Variable");
+    AliMultVariable(const char * name, const char * title = "Mult Variable", Bool_t isInteger=kFALSE);
     AliMultVariable(const AliMultVariable& o)
       : TNamed(o),
         fIsInteger(o.fIsInteger),
@@ -34,37 +34,37 @@ public:
             SetValue(other->GetValue());
     }
     ~AliMultVariable();
-    
+
     void Clear(Option_t*)
     {
         fValue = 0;
         fValueInteger = 0;
     }
-    
+
     void     SetValue ( Float_t lVal ) { fValue = lVal; }
     Float_t GetValue () const  { return fValue; }
     //(specialized) use with care
     Float_t& GetRValue () { return fValue; }
-    
+
     void     SetValueInteger ( Int_t lVal ) { fValueInteger = lVal; }
     Int_t GetValueInteger () const { return fValueInteger; }
     //(specialized) use with care
     Int_t& GetRValueInteger () { return fValueInteger; }
-    
+
     void     SetMean ( Float_t lVal ) { fMean = lVal; }
     Float_t GetMean () const { return fMean; }
-    
+
     void     SetIsInteger( Bool_t lVal ){ fIsInteger = lVal; }
     Bool_t  IsInteger() const { return fIsInteger; }
-    
+
     void Print(Option_t* option="") const;
-    
+
 private:
     Bool_t fIsInteger; //If Integer
     Float_t fValue;    //Variable value
     Int_t   fValueInteger; //Variable value if integer
     Float_t fMean;     //Variable mean
-    
+
     ClassDef(AliMultVariable, 1)
 };
 #endif

--- a/PWGUD/DIFFRACTIVE/legotrain/AliAnalysisTaskDG.cxx
+++ b/PWGUD/DIFFRACTIVE/legotrain/AliAnalysisTaskDG.cxx
@@ -327,6 +327,8 @@ AliAnalysisTaskDG::AliAnalysisTaskDG(const char *name)
   , fVertexSPD()
   , fVertexTPC()
   , fVertexTracks()
+  , fV0()
+  , fAD()
   , fTOFHeader()
   , fTriggerIRs("AliTriggerIR", 3)
   , fFiredTriggerClasses()
@@ -391,6 +393,18 @@ void AliAnalysisTaskDG::SetBranches(TTree* t, Bool_t isAOD) {
       t->Branch("VertexTracks", &fVertexTracks.second, 32000, 0);
     else
       t->Branch("VertexTracks", &fVertexTracks.first,  32000, 0);
+  }
+  if (fTreeBranchNames.Contains("V0")) {
+    if (isAOD)
+      t->Branch("V0", &fV0.second, 32000, 0);
+    else
+      t->Branch("V0", &fV0.first,  32000, 0);
+  }
+  if (fTreeBranchNames.Contains("AD")) {
+    if (isAOD)
+      t->Branch("AD", &fAD.second, 32000, 0);
+    else
+      t->Branch("AD", &fAD.first,  32000, 0);
   }
   if (fTreeBranchNames.Contains("TOFHeader")) {
     t->Branch("TOFHeader", &fTOFHeader, 32000, 0);
@@ -695,10 +709,14 @@ void AliAnalysisTaskDG::UserExec(Option_t *)
     fVertexSPD.first    = *esdEvent->GetPrimaryVertexSPD();
     fVertexTPC.first    = *esdEvent->GetPrimaryVertexTPC();
     fVertexTracks.first = *esdEvent->GetPrimaryVertexTracks();
+    fV0.first           = *esdEvent->GetVZEROData();
+    fAD.first           = *esdEvent->GetADData();
   } else {
     fVertexSPD.second    = *aodEvent->GetPrimaryVertexSPD();
     fVertexTPC.second    = *aodEvent->GetPrimaryVertexTPC();
     fVertexTracks.second = *aodEvent->GetPrimaryVertex();
+    fV0.second           = *aodEvent->GetVZEROData();
+    fAD.second           = *aodEvent->GetADData();
   }
   fTOFHeader    = *(vEvent->GetTOFHeader());
 

--- a/PWGUD/DIFFRACTIVE/legotrain/AliAnalysisTaskDG.h
+++ b/PWGUD/DIFFRACTIVE/legotrain/AliAnalysisTaskDG.h
@@ -21,6 +21,10 @@ class AliESDtrackCuts;
 
 #include "AliAODVertex.h"
 #include "AliESDVertex.h"
+#include "AliAODVZERO.h"
+#include "AliESDVZERO.h"
+#include "AliAODAD.h"
+#include "AliESDAD.h"
 #include "AliAnalysisTaskSE.h"
 #include "AliTOFHeader.h"
 #include "AliTriggerAnalysis.h"
@@ -284,6 +288,10 @@ private:
   VtxPairType      fVertexSPD;           //!
   VtxPairType      fVertexTPC;           //!
   VtxPairType      fVertexTracks;        //!
+  typedef std::pair<AliESDVZERO, AliAODVZERO> V0PairType;
+  V0PairType       fV0;                  //!
+  typedef std::pair<AliESDAD, AliAODAD> ADPairType;
+  ADPairType       fAD;                  //!
   AliTOFHeader     fTOFHeader;           //!
   TClonesArray     fTriggerIRs;          //!
   TString          fFiredTriggerClasses; //!
@@ -294,7 +302,7 @@ private:
   TClonesArray     fMCTracks;            //!
   AliESDtrackCuts *fTrackCuts;           //!
 
-  ClassDef(AliAnalysisTaskDG, 16);
+  ClassDef(AliAnalysisTaskDG, 17);
 } ;
 
 #endif // ALIANALYSISTASKDG_H


### PR DESCRIPTION
This commit depends on availability of `AliADChargeEqualization` (https://github.com/alisw/AliRoot/pull/484/commits/a08212c88664c01ffd06bd80b0bd52fe5ba69aa2) which is in AliRoot master and in v5-09-19.

Besides adding equalized AD multiplicities I have made these changes
- removed default constructor and added default arguments to the constructor
- fixed wrong ordering of initialization in the constructor
- added a default argument to `AliMultVariable`
- replaced member variables `fRunNumber`, `fCurrentRun` with `fCurrentRunNumber` which is available from the base class `AliAnalysisTaskSE`
- `SetupRun()` is now called in `NotifyRun() `which is called by the framework whenever the run changes
- `fTreeEvent` is now associated with a file so it is not kept in memory which should reduced the memory footprint of `AliMultSelectionTask`

Please check carefully. I hope I did not break anything.
