### PR TITLE
Incorporated unfolded two-particle correlations

### DIFF
--- a/PWGCF/Correlations/DPhi/CMakeLists.txt
+++ b/PWGCF/Correlations/DPhi/CMakeLists.txt
@@ -89,6 +89,16 @@ set(SRCS
     TriggerPID/AliAnalysisTaskPIDCORR.cxx
     TriggerPID/AliTwoParticlePIDCorr.cxx
     TriggerPID/AliTwoParticlePIDCorrKine.cxx
+    Unfoldedhistos/AliAnalysisTaskCorrelationsStudies.cxx
+    Unfoldedhistos/AliCSAnalysisCutsBase.cxx
+    Unfoldedhistos/AliCSEventCuts.cxx
+    Unfoldedhistos/AliCSPairAnalysis.cxx
+    Unfoldedhistos/AliCSPIDCuts.cxx
+    Unfoldedhistos/AliCSTrackCutsBase.cxx
+    Unfoldedhistos/AliCSTrackCuts.cxx
+    Unfoldedhistos/AliCSTrackMaps.cxx
+    Unfoldedhistos/AliCSTrackSelection.cxx
+    Unfoldedhistos/AliDptDptCorrelations.cxx
    )
 
 # Headers from sources

--- a/PWGCF/Correlations/DPhi/PWGCFCorrelationsDPhiLinkDef.h
+++ b/PWGCF/Correlations/DPhi/PWGCFCorrelationsDPhiLinkDef.h
@@ -70,4 +70,14 @@
 #pragma link C++ class AliAssociatedTrackYS+;
 #pragma link C++ class AliMixTrackYS+;
 #pragma link C++ class AliAssociatedVZEROYS+;
+#pragma link C++ class AliAnalysisTaskCorrelationsStudies+;
+#pragma link C++ class AliCSAnalysisCutsBase+;
+#pragma link C++ class AliCSEventCuts+;
+#pragma link C++ class AliCSPairAnalysis+;
+#pragma link C++ class AliCSPIDCuts+;
+#pragma link C++ class AliCSTrackCutsBase+;
+#pragma link C++ class AliCSTrackCuts+;
+#pragma link C++ class AliCSTrackMaps+;
+#pragma link C++ class AliCSTrackSelection+;
+#pragma link C++ class AliDptDptCorrelations+;
 #endif

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliAnalysisTaskCorrelationsStudies.cxx
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliAnalysisTaskCorrelationsStudies.cxx
@@ -1,0 +1,1998 @@
+/**************************************************************************
+ * Copyright(c) 1998-2016, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: The ALICE Off-line Project.                                    *
+ * Contributors are mentioned in the code where appropriate.              *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+/* AliAnalysisTaskCorrelationsStudies.cxx
+ *
+ * Template task producing a P_t spectrum and pseudorapidity distribution.
+ * Includes explanations of physics and primary track selections
+ *
+ * Instructions for adding histograms can be found below, starting with NEW HISTO
+ *
+ * Based on tutorial example from offline pages
+ * Edited by Arvinder Palaha
+ */
+#include "AliAnalysisTaskCorrelationsStudies.h"
+
+#include <TBits.h>
+#include "Riostream.h"
+#include "TGrid.h"
+#include "TChain.h"
+#include "TTree.h"
+#include "TF1.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TH3F.h"
+#include "TProfile3D.h"
+#include "TCanvas.h"
+#include "TList.h"
+#include "TFile.h"
+#include "TRandom3.h"
+#include "TParameter.h"
+
+#include "AliLog.h"
+#include "AliAnalysisTaskSE.h"
+#include "AliAnalysisManager.h"
+#include "AliStack.h"
+#include "AliCSTrackMaps.h"
+#include "AliCSEventCuts.h"
+#include "AliCSPIDCuts.h"
+#include "AliDptDptCorrelations.h"
+#include "AliCSPairAnalysis.h"
+#include "AliVEvent.h"
+#include "AliAODHeader.h"
+#include "AliMCEvent.h"
+#include "AliMCEventHandler.h"
+#include "AliAODMCHeader.h"
+#include "AliVTrack.h"
+#include "AliAODTrack.h"
+#include "AliAODMCParticle.h"
+#include "AliExternalTrackParam.h"
+
+ClassImp(AliAnalysisTaskCorrelationsStudies)
+
+const Int_t AliAnalysisTaskCorrelationsStudies::kgTHnDimension = 4;
+
+AliCSTrackMaps aodTrackMaps("AODtrackMaps", "The AOD tracks id maps"); ///< the id track maps for AOD tracks
+
+/// Default constructor
+AliAnalysisTaskCorrelationsStudies::AliAnalysisTaskCorrelationsStudies() // All data members should be initialised here
+   :AliAnalysisTaskSE(),
+    fOutput(NULL),
+    fTaskConfigurationString(""),
+    fTaskActivitiesString(""),
+    fEventCutsString(""),
+    fEfficiencyProfileToEnforce(""),
+    fEfficiencyProfileOnTrue(""),
+    fAdditionalMCRecOption(""),
+    fTrackSelectionString(""),
+    fEventCuts(NULL),
+    fTrackSelectionCuts(NULL),
+    fEnforceEfficiencyProfile(kFALSE),
+    fOnTrueEfficiencyProfile(kNoEfficiencyOnTrue),
+    fCorrectOnTrueEfficiency(kFALSE),
+    fDoProcessCorrelations(kFALSE),
+    fDoProcessPairAnalysis(kFALSE),
+    fMCRecOption(kNone),
+    fProcessCorrelations(),
+    fProcessMCRecCorrelationsWithOptions(),
+    fProcessTrueCorrelations(),
+    fProcessPairAnalysis(),
+    fProcessTruePairAnalysis(),
+    ffEfficiencyProfile(NULL),
+    fRandomGenerator(NULL),
+    fhWeightsTrack_1(NULL),
+    fhWeightsTrack_2(NULL),
+    fhEffCorrTrack_1(NULL),
+    fhEffCorrTrack_2(NULL),
+    fhPairEfficiency_PP(NULL),
+    fhPairEfficiency_PM(NULL),
+    fhPairEfficiency_MM(NULL),
+    fhPairEfficiency_MP(NULL),
+    fPositiveTrackPdf(NULL),
+    fNegativeTrackPdf(NULL),
+    fTrueToRec(NULL),
+    fTrueToRecWrong(NULL),
+    fMCRecFlags(NULL),
+    fMCTruePrimaryFlags(NULL),
+    fMCFlagsStorageSize(30*1024),
+    fhOnTrueEfficiencyProfile_1(NULL),
+    fhOnTrueEfficiencyProfile_2(NULL),
+    fhPt(NULL),
+    fhPtPos(NULL),
+    fhPtNeg(NULL),
+    fhP(NULL),
+    fhPPos(NULL),
+    fhPNeg(NULL),
+    fhTruePt(NULL),
+    fhTruePtPos(NULL),
+    fhTruePtNeg(NULL),
+    fhTrueP(NULL),
+    fhTruePPos(NULL),
+    fhTruePNeg(NULL),
+    fhPurePt(NULL),
+    fhPurePtPos(NULL),
+    fhPurePtNeg(NULL),
+    fhPureP(NULL),
+    fhPurePPos(NULL),
+    fhPurePNeg(NULL),
+    fhUnConstrainedPt(NULL),
+    fhPtDifference(NULL),
+    fhEtaB(NULL),
+    fhEtaA(NULL),
+    fhTrueEta(NULL),
+    fhPhiB(NULL),
+    fhPhiA(NULL),
+    fhTruePhi(NULL),
+    fhEtaVsPhiB(NULL),
+    fhEtaVsPhiA(NULL),
+    fhTrueEtaVsPhi(NULL),
+    fhPtVsEtaB(NULL),
+    fhPtVsEtaA(NULL),
+    fhTruePtVsEta(NULL),
+    fhPt3DB(NULL),
+    fhPt3DA(NULL),
+    fhTruePt3D(NULL),
+    fhLambdaVsMultiplicity(NULL),
+    fhAcceptedVsMultiplicity(NULL),
+    fhTrueLambdaVsPrimaries(NULL),
+    fhTrueAcceptedVsPrimaries(NULL),
+    fhTrueRecNotAccepted(NULL),
+    fhTrueNotReconstructed(NULL),
+    fhTrueMultiRec(NULL),
+    fhPtTrueMultiRec(NULL)
+{
+    // Dummy constructor ALWAYS needed for I/O.
+}
+
+/// Analysis task constructor
+/// \param name the name to assign to the task
+AliAnalysisTaskCorrelationsStudies::AliAnalysisTaskCorrelationsStudies(const char *name) // All data members should be initialized here
+   :AliAnalysisTaskSE(name),
+    fOutput(NULL),
+    fTaskConfigurationString(""),
+    fTaskActivitiesString(""),
+    fEventCutsString(""),
+    fEfficiencyProfileToEnforce(""),
+    fEfficiencyProfileOnTrue(""),
+    fAdditionalMCRecOption(""),
+    fTrackSelectionString(""),
+    fEventCuts(NULL),
+    fTrackSelectionCuts(NULL),
+    fEnforceEfficiencyProfile(kFALSE),
+    fOnTrueEfficiencyProfile(kNoEfficiencyOnTrue),
+    fCorrectOnTrueEfficiency(kFALSE),
+    fDoProcessCorrelations(kFALSE),
+    fDoProcessPairAnalysis(kFALSE),
+    fMCRecOption(kNone),
+    fProcessCorrelations("DptDptCorrelations"),
+    fProcessMCRecCorrelationsWithOptions("DptDptCorrelationsMCRecOptions"),
+    fProcessTrueCorrelations("DptDptTrueCorrelations"),
+    fProcessPairAnalysis("PairAnalysis"),
+    fProcessTruePairAnalysis("TruePairAnalysis"),
+    ffEfficiencyProfile(NULL),
+    fRandomGenerator(NULL),
+    fhWeightsTrack_1(NULL),
+    fhWeightsTrack_2(NULL),
+    fhEffCorrTrack_1(NULL),
+    fhEffCorrTrack_2(NULL),
+    fhPairEfficiency_PP(NULL),
+    fhPairEfficiency_PM(NULL),
+    fhPairEfficiency_MM(NULL),
+    fhPairEfficiency_MP(NULL),
+    fPositiveTrackPdf(NULL),
+    fNegativeTrackPdf(NULL),
+    fTrueToRec(NULL),
+    fTrueToRecWrong(NULL),
+    fMCRecFlags(NULL),
+    fMCTruePrimaryFlags(NULL),
+    fMCFlagsStorageSize(30*1024),
+    fhOnTrueEfficiencyProfile_1(NULL),
+    fhOnTrueEfficiencyProfile_2(NULL),
+    fhPt(NULL),
+    fhPtPos(NULL),
+    fhPtNeg(NULL),
+    fhP(NULL),
+    fhPPos(NULL),
+    fhPNeg(NULL),
+    fhTruePt(NULL),
+    fhTruePtPos(NULL),
+    fhTruePtNeg(NULL),
+    fhTrueP(NULL),
+    fhTruePPos(NULL),
+    fhTruePNeg(NULL),
+    fhPurePt(NULL),
+    fhPurePtPos(NULL),
+    fhPurePtNeg(NULL),
+    fhPureP(NULL),
+    fhPurePPos(NULL),
+    fhPurePNeg(NULL),
+    fhUnConstrainedPt(NULL),
+    fhPtDifference(NULL),
+    fhEtaB(NULL),
+    fhEtaA(NULL),
+    fhTrueEta(NULL),
+    fhPhiB(NULL),
+    fhPhiA(NULL),
+    fhTruePhi(NULL),
+    fhEtaVsPhiB(NULL),
+    fhEtaVsPhiA(NULL),
+    fhTrueEtaVsPhi(NULL),
+    fhPtVsEtaB(NULL),
+    fhPtVsEtaA(NULL),
+    fhTruePtVsEta(NULL),
+    fhPt3DB(NULL),
+    fhPt3DA(NULL),
+    fhTruePt3D(NULL),
+    fhLambdaVsMultiplicity(NULL),
+    fhAcceptedVsMultiplicity(NULL),
+    fhTrueLambdaVsPrimaries(NULL),
+    fhTrueAcceptedVsPrimaries(NULL),
+    fhTrueRecNotAccepted(NULL),
+    fhTrueNotReconstructed(NULL),
+    fhTrueMultiRec(NULL),
+    fhPtTrueMultiRec(NULL)
+{
+    // Constructor
+    // Define input and output slots here (never in the dummy constructor)
+    // Input slot #0 works with a TChain - it is connected to the default input container
+    DefineOutput(1, TList::Class());                                            // for output list
+    DefineOutput(2, TList::Class());                                            // for output list
+    DefineOutput(3, TList::Class());                                            // for output list
+    DefineOutput(4, TList::Class());                                            // for output list
+}
+
+/// Default destructor
+AliAnalysisTaskCorrelationsStudies::~AliAnalysisTaskCorrelationsStudies()
+{
+    // Destructor. Clean-up the output list, but not the histograms that are put inside
+    // (the list is owner and will clean-up these histograms). Protect in PROOF case.
+    if (fOutput && !AliAnalysisManager::GetAnalysisManager()->IsProofMode()) {
+        delete fOutput;
+    }
+    if (fhWeightsTrack_1 != NULL) delete fhWeightsTrack_1;
+    if (fhWeightsTrack_2 != NULL) delete fhWeightsTrack_2;
+    if (fhEffCorrTrack_1 != NULL) delete fhEffCorrTrack_1;
+    if (fhEffCorrTrack_2 != NULL) delete fhEffCorrTrack_2;
+    if (fPositiveTrackPdf != NULL) delete fPositiveTrackPdf;
+    if (fNegativeTrackPdf != NULL) delete fNegativeTrackPdf;
+    if (fTrueToRec != NULL) delete fTrueToRec;
+    if (fTrueToRecWrong != NULL) delete fTrueToRecWrong;
+    if (fMCRecFlags != NULL) delete [] fMCRecFlags;
+    if (fMCTruePrimaryFlags != NULL) delete [] fMCTruePrimaryFlags;
+    if (ffEfficiencyProfile != NULL) delete ffEfficiencyProfile;
+    if (fhOnTrueEfficiencyProfile_1 != NULL) delete fhOnTrueEfficiencyProfile_1;
+    if (fhOnTrueEfficiencyProfile_2 != NULL) delete fhOnTrueEfficiencyProfile_2;
+    if (fRandomGenerator != NULL) delete fRandomGenerator;
+    delete fEventCuts;
+    delete fTrackSelectionCuts;
+}
+
+/// \brief Builds the efficiency profiles for both rec and true if needed
+/// Information for the profiles is taken from the stored configuration
+/// strings for both rec and true.
+/// The configuration string could be a single expression depending on x (pT),
+/// or a concatenation |bin,bin,expr| terms each of them defining an initial
+/// bin, a final bin and an expression to assign the efficiency on that bin
+/// interval. In this case the expression will depend on pT bin number. Again
+/// the expression  will not depend on the pT value of the concrete bin being
+/// handled. If pT value were needed use the corresponding factor within the
+/// expression.
+Bool_t AliAnalysisTaskCorrelationsStudies::BuildEfficiencyProfiles() {
+
+  Bool_t done = kTRUE;
+
+  /* let's get the limits of the profiles */
+  Float_t ptlow = fhPt->GetXaxis()->GetBinLowEdge(1);
+  Float_t ptup = fhPt->GetXaxis()->GetBinUpEdge(fhPt->GetNbinsX());
+
+  /* let's build the efficiency profile formula if required */
+  if (fEfficiencyProfileToEnforce.Length() != 0) {
+    fEnforceEfficiencyProfile = kTRUE;
+    if (ffEfficiencyProfile != NULL) delete ffEfficiencyProfile;
+    if (fRandomGenerator != NULL) delete fRandomGenerator;
+
+    ffEfficiencyProfile = new TF1("EfficiencyProfile",fEfficiencyProfileToEnforce.Data(),ptlow,ptup);
+    fRandomGenerator = new TRandom3();
+    AliInfo(Form("Configured efficiency profile enforcement with formula: %s", ffEfficiencyProfile->GetExpFormula().ReplaceAll("x","pT").Data()));
+  }
+
+  /* let's build the efficiency profile for true data if required */
+  if (fEfficiencyProfileOnTrue.Length() != 0) {
+    fOnTrueEfficiencyProfile = kEfficiencyProfile;
+    if (fhOnTrueEfficiencyProfile_1 != NULL) delete fhOnTrueEfficiencyProfile_1;
+    if (fhOnTrueEfficiencyProfile_2 != NULL) delete fhOnTrueEfficiencyProfile_2;
+    if (fRandomGenerator != NULL) delete fRandomGenerator;
+
+    /* let's check for a single expression for the whole pT range */
+    TObjArray *intervals = fEfficiencyProfileOnTrue.Tokenize(TString("|"));
+    if (intervals->GetEntries() > 1) {
+      fhOnTrueEfficiencyProfile_1 = (TH2F*) fhPtVsEtaB->Clone("OnTrueEfficiencyProfileTrackOne");
+      fhOnTrueEfficiencyProfile_2 = (TH2F*) fhPtVsEtaB->Clone("OnTrueEfficiencyProfileTrackTwo");
+      fhOnTrueEfficiencyProfile_1->Reset();
+      fhOnTrueEfficiencyProfile_2->Reset();
+
+      for (Int_t entry = 0; entry < intervals->GetEntries(); entry++) {
+        Int_t start, end;
+        char expr[128];
+        sscanf(((TObjString *)intervals->At(entry))->String().Data(), "%d,%d,%s", &start, &end, expr);
+        AliInfo(Form("Assigning efficiency profile from bin %d to bin %d, with values: %s", start+1, end, expr));
+        TF1 *formula = new TF1(Form("OnTrue%dFormula", entry),expr,start,end);
+        for (Int_t ptbin = start; ptbin < end; ptbin++) {
+          for (Int_t etabin = 0; etabin < fhOnTrueEfficiencyProfile_1->GetNbinsX(); etabin++) {
+            fhOnTrueEfficiencyProfile_1->SetBinContent(etabin+1, ptbin+1,formula->Eval(ptbin));
+            fhOnTrueEfficiencyProfile_2->SetBinContent(etabin+1, ptbin+1,formula->Eval(ptbin));
+          }
+        }
+        delete formula;
+      }
+    }
+    else {
+      fhOnTrueEfficiencyProfile_1 = (TH2F*) fhPtVsEtaB->Clone("OnTrueEfficiencyProfileTrackOne");
+      fhOnTrueEfficiencyProfile_2 = (TH2F*) fhPtVsEtaB->Clone("OnTrueEfficiencyProfileTrackTwo");
+      fhOnTrueEfficiencyProfile_1->Reset();
+      fhOnTrueEfficiencyProfile_2->Reset();
+
+      /* we could have a file with two-dimensional histograms for efficiency */
+      if (fEfficiencyProfileOnTrue.Contains("/")) {
+        Bool_t oldstatus = TH1::AddDirectoryStatus();
+        TH1::AddDirectory(kFALSE);
+        TFile *effprofile = TFile::Open(fEfficiencyProfileOnTrue.Data());
+        if (effprofile != NULL && effprofile->IsOpen()) {
+          fhOnTrueEfficiencyProfile_1 = (TH2F*)((TH2F*) effprofile->Get("OnTrueEfficiencyProfile_1"))->Clone("StoredOnTrueEfficiencyProfile_1");
+          fhOnTrueEfficiencyProfile_2 = (TH2F*)((TH2F*) effprofile->Get("OnTrueEfficiencyProfile_2"))->Clone("StoredOnTrueEfficiencyProfile_2");
+          effprofile->Close();
+          delete effprofile;
+          if (!(fhOnTrueEfficiencyProfile_1 != NULL) || !(fhOnTrueEfficiencyProfile_1 != NULL)) {
+            AliFatal(Form("On true efficiency profiles not found in file %s. ABORTING!!!", fEfficiencyProfileOnTrue.Data()));
+          }
+        }
+        else {
+          AliFatal(Form("On true efficiency profile file %s not found. ABORTING!!!", fEfficiencyProfileOnTrue.Data()));
+        }
+        TH1::AddDirectory(oldstatus);
+      }
+      else {
+        /* we could still have a single term, check it and process it */
+        if (((TObjString *)intervals->At(0))->String().Contains(",")) {
+          Int_t start, end;
+          char expr[128];
+          sscanf(((TObjString *)intervals->At(0))->String().Data(), "%d,%d,%s", &start, &end, expr);
+          AliInfo(Form("Assigning efficiency profile from bin %d to bin %d, with values: %s", start+1, end, expr));
+          TF1 *formula = new TF1(Form("OnTrue%dFormula", 0),expr,start,end);
+          for (Int_t ptbin = start; ptbin < end; ptbin++) {
+            for (Int_t etabin = 0; etabin < fhOnTrueEfficiencyProfile_1->GetNbinsX(); etabin++) {
+              fhOnTrueEfficiencyProfile_1->SetBinContent(etabin+1, ptbin+1,formula->Eval(ptbin));
+              fhOnTrueEfficiencyProfile_2->SetBinContent(etabin+1, ptbin+1,formula->Eval(ptbin));
+            }
+          }
+          delete formula;
+        }
+        else {
+          TF1 *formulaEfficiencyProfile = new TF1("OnTrueEfficiencyProfileFormula",fEfficiencyProfileOnTrue.Data(),ptlow,ptup);
+          for (Int_t ptbin = 0; ptbin < fhOnTrueEfficiencyProfile_1->GetNbinsY(); ptbin++) {
+            for (Int_t etabin = 0; etabin < fhOnTrueEfficiencyProfile_1->GetNbinsX(); etabin++) {
+              fhOnTrueEfficiencyProfile_1->SetBinContent(etabin+1, ptbin+1,formulaEfficiencyProfile->Eval(ptbin));
+              fhOnTrueEfficiencyProfile_2->SetBinContent(etabin+1, ptbin+1,formulaEfficiencyProfile->Eval(ptbin));
+            }
+          }
+          delete formulaEfficiencyProfile;
+        }
+      }
+    }
+    delete intervals;
+    AliInfo("Configured two-dimensional efficiency profile on true data for track one");
+    for (Int_t ptbin = 0; ptbin < fhOnTrueEfficiencyProfile_1->GetNbinsY(); ptbin++) {
+      printf("%f, ", fhOnTrueEfficiencyProfile_1->GetBinContent(4,ptbin+1));
+      if ((ptbin+1)%8 == 0) printf("\n");
+    }
+    printf("\n");
+    for (Int_t ptbin = 0; ptbin < fhOnTrueEfficiencyProfile_1->GetNbinsY(); ptbin++) {
+      printf("%f, ", fhOnTrueEfficiencyProfile_1->GetBinContent(12,ptbin+1));
+      if ((ptbin+1)%8 == 0) printf("\n");
+    }
+    printf("\n");
+    AliInfo("Configured two-dimensional efficiency profile on true data for track two");
+    for (Int_t ptbin = 0; ptbin < fhOnTrueEfficiencyProfile_2->GetNbinsY(); ptbin++) {
+      printf("%f, ", fhOnTrueEfficiencyProfile_2->GetBinContent(4,ptbin+1));
+      if ((ptbin+1)%8 == 0) printf("\n");
+    }
+    printf("\n");
+    for (Int_t ptbin = 0; ptbin < fhOnTrueEfficiencyProfile_2->GetNbinsY(); ptbin++) {
+      printf("%f, ", fhOnTrueEfficiencyProfile_2->GetBinContent(12,ptbin+1));
+      if ((ptbin+1)%8 == 0) printf("\n");
+    }
+    printf("\n");
+    fRandomGenerator = new TRandom3();
+
+    if (fDoProcessCorrelations) {
+      /* should we correct true for this efficiency profile */
+      if (fCorrectOnTrueEfficiency) {
+        /* yes, so apply it as efficiency correction */
+//        fProcessTrueCorrelations.SetEfficiencyCorrection(fhOnTrueEfficiencyProfile_1,fhOnTrueEfficiencyProfile_2);
+        AliFatal("Applying two-dimensional profile as efficiency correction on true data not yet supported");
+        AliInfo("Applying the same profile as efficiency correction on true data");
+      }
+      else {
+        /* true will not apply any efficiency correction */
+        fProcessTrueCorrelations.SetEfficiencyCorrection(NULL,NULL);
+      }
+    }
+  }
+  else {
+    if (fDoProcessCorrelations) {
+      /* true will not apply any efficiency correction */
+      fProcessTrueCorrelations.SetEfficiencyCorrection(NULL,NULL);
+    }
+  }
+
+  if (fDoProcessCorrelations) {
+    /* for the time being, rec with true will never apply efficiency correction */
+    fProcessMCRecCorrelationsWithOptions.SetEfficiencyCorrection(NULL,NULL);
+  }
+
+  return done;
+}
+
+/// \brief Return the number of MC reconstructed tracks for the current event
+/// Basically this is needed due to the fact that MC information is
+/// differently stored in ESD than in AOD
+///
+/// \return the number of MC reconstructed tracks for the current event
+Int_t AliAnalysisTaskCorrelationsStudies::GetNoOfMCRecTracks() {
+  if (AliCSAnalysisCutsBase::GetMCEventHandler() != NULL) {
+    return fInputEvent->GetNumberOfTracks();
+  }
+  else {
+    AliAODHeader *header = (AliAODHeader *) fInputEvent->GetHeader();
+    return header->GetNumberOfESDTracks();
+  }
+}
+
+/// \brief Return the number of true particles for the current event
+/// Basically this is needed due to the fact that MC information is
+/// differently stored in ESD than in AOD
+///
+/// \return the number of true particles for the current event
+Int_t AliAnalysisTaskCorrelationsStudies::GetNoOfTrueParticles() {
+  if (AliCSAnalysisCutsBase::GetMCEventHandler() != NULL) {
+    return fMCEvent->GetNumberOfTracks();
+  }
+  else {
+    return AliCSAnalysisCutsBase::GetMCTrueArray()->GetEntries();
+  }
+}
+
+/// \brief Return the number of true physical primary particles for
+/// the current event
+/// Basically this is needed due to the fact that MC information is
+/// differently stored in ESD than in AOD
+///
+/// \return the number of true physical primary particles for the
+/// current event
+Int_t AliAnalysisTaskCorrelationsStudies::GetNoOfTruePrimaries() {
+  if (AliCSAnalysisCutsBase::GetMCEventHandler() != NULL) {
+    return fMCEvent->GetNumberOfPrimaries();
+  }
+  else {
+    TClonesArray *arrayMC = AliCSAnalysisCutsBase::GetMCTrueArray();
+    Int_t nNoOfPrimaries = 0;
+
+    for (Int_t itrk = 0; itrk < arrayMC->GetEntriesFast(); itrk++) {
+      AliAODMCParticle *particle = (AliAODMCParticle *) arrayMC->At(itrk);
+      if (particle != NULL && particle->IsPhysicalPrimary()) {
+        nNoOfPrimaries++;
+      }
+    }
+    return nNoOfPrimaries;
+  }
+}
+
+/// \brief Builds the true to reconstructed relation to allow quick access
+/// to both data sets
+/// The relation is materialized as an array addressed by true label
+/// or true track index value in the MC event. The object stored
+/// corresponds to the reconstructed track which has as label the
+/// index in the array under which it is stored.
+/// There are two arrays one with the reconstructed stored when their
+/// labels are positive (or zero) and the other with the reconstructed
+/// stored when their labels are negative. The index corresponds to the
+/// label absolute value
+/// The additional array with flags are addressed by the track id. The
+/// addressing takes always two steps due to the fact of a potential
+/// presence of MC AOD format
+void AliAnalysisTaskCorrelationsStudies::BuildTrueRecRelation() {
+  /* allocate the structures if they are not there */
+  if (fTrueToRec == NULL) {
+    fTrueToRec = new TObjArray(30 * 1024); /* initial value for minimize the growing of the array */
+    fTrueToRec->SetOwner(kFALSE); /* we will not own the rec tracks */
+  }
+  if (fTrueToRecWrong == NULL) {
+    fTrueToRecWrong = new TObjArray(30 * 1024); /* initial value for minimize the growing of the array */
+    fTrueToRecWrong->SetOwner(kFALSE); /* we will not own the rec tracks */
+  }
+  if (fMCRecFlags == NULL) {
+    fMCRecFlags = new UInt_t[fMCFlagsStorageSize];
+  }
+  if (fMCTruePrimaryFlags == NULL) {
+    fMCTruePrimaryFlags = new UInt_t[fMCFlagsStorageSize];
+  }
+
+  /* expand the storage if needed */
+  Int_t nNoOfTrueTracks = GetNoOfTrueParticles();
+  Int_t nNoOfTruePrimaries = GetNoOfTruePrimaries();
+  Int_t nNoOfMCRecTracks = GetNoOfMCRecTracks();
+
+  if (fTrueToRec->GetSize() < nNoOfTrueTracks)
+    fTrueToRec->Expand((Int_t(nNoOfTrueTracks/1024)+5)*1024);
+  if (fTrueToRecWrong->GetSize() < nNoOfTrueTracks)
+    fTrueToRecWrong->Expand((Int_t(nNoOfTrueTracks/1024)+5)*1024);
+  if (fMCFlagsStorageSize < TMath::Max(nNoOfTruePrimaries,nNoOfMCRecTracks)) {
+    fMCFlagsStorageSize = (Int_t(TMath::Max(nNoOfTruePrimaries,nNoOfMCRecTracks)/1024)+5)*1024;
+    delete [] fMCRecFlags;
+    delete [] fMCTruePrimaryFlags;
+    fMCRecFlags = new UInt_t[fMCFlagsStorageSize];
+    fMCTruePrimaryFlags = new UInt_t[fMCFlagsStorageSize];
+  }
+
+  /* clear previous events information */
+  fTrueToRec->Clear();
+  fTrueToRecWrong->Clear();
+  memset(fMCRecFlags,0,fMCFlagsStorageSize*sizeof(UInt_t));
+  memset(fMCTruePrimaryFlags,kNone,fMCFlagsStorageSize*sizeof(UInt_t));
+
+  AliInfo(Form("Rec flags size: %d, True to rec size: %d, True to rec wrong size: %d",
+      fMCFlagsStorageSize, fTrueToRec->GetSize(), fTrueToRecWrong->GetSize()));
+
+  AliVEvent *event = InputEvent();
+
+  for (Int_t iaod = 0; iaod < nNoOfMCRecTracks; iaod++) {
+    /* just to be sure we do not surpass the limits */
+    if (!(iaod < event->GetNumberOfTracks())) break;
+
+    AliVTrack* vtrack = dynamic_cast<AliVTrack*>(event->GetTrack(iaod)); // pointer to reconstructed track
+    if(!vtrack) {
+      fMCRecFlags[iaod] |= kNoTrack;
+      continue; /* error is reported in normal rec track processing */
+    }
+    /* so far let's handle the not constrained tracks */
+    if (vtrack->GetID() < 0) continue;
+
+    Int_t iesd = vtrack->GetID();
+
+    if (vtrack->GetLabel() < 0) {
+
+      fMCRecFlags[iesd] |= kNegativeLabel;
+
+      if (fTrackSelectionCuts->IsFromMCInjectedSignal(TMath::Abs(vtrack->GetLabel()))) {
+        fMCRecFlags[iesd] |= kFromInjectedSignal;
+        continue;
+      }
+
+      if (fTrueToRecWrong->At(TMath::Abs(vtrack->GetLabel())) != NULL) {
+        AliVTrack *prevvtrack = (AliVTrack *) fTrueToRecWrong->At(TMath::Abs(vtrack->GetLabel()));
+
+        fMCRecFlags[iesd] |= kSameNegativeLabel;
+        fMCRecFlags[prevvtrack->GetID()] |= kSameNegativeLabel;
+      }
+      else
+        fTrueToRecWrong->AddAt(vtrack, TMath::Abs(vtrack->GetLabel()));
+    }
+    else {
+      if (fTrackSelectionCuts->IsFromMCInjectedSignal(vtrack->GetLabel())) {
+        fMCRecFlags[iesd] |= kFromInjectedSignal;
+        continue;
+      }
+
+      if (fTrueToRec->At(vtrack->GetLabel()) != NULL) {
+        /* we don't build multi reconstruction information yet */
+      }
+      else
+        fTrueToRec->AddAt(vtrack, vtrack->GetLabel());
+    }
+  }
+}
+
+/// \brief Re-builds the true to reconstructed relation based on the
+/// accepted reconstructed tracks
+/// The most relevant information incorporated is the proper mapping
+/// of the true to rec when few rec point to the same true but they
+/// are not all accepted
+void AliAnalysisTaskCorrelationsStudies::BuildTrueRecAccRelation() {
+
+  AliVEvent *event = InputEvent();
+  for (Int_t iaod = 0; iaod < GetNoOfMCRecTracks(); iaod++) {
+    /* just to be sure we do not surpass the limits */
+    if (!(iaod < event->GetNumberOfTracks())) break;
+
+    AliVTrack* vtrack = dynamic_cast<AliVTrack*>(event->GetTrack(iaod)); // pointer to reconstructed track
+    if(!vtrack) {
+      continue; /* error is reported in normal rec track processing */
+    }
+
+    if (vtrack->GetLabel() < 0) {
+      Int_t iesd = vtrack->GetID();
+      if (iesd < 0) iesd = -1 - iesd;
+
+      /* track should not have been accepted */
+      if ((fMCRecFlags[iesd] & kAccepted) == kAccepted) {
+        AliInfo(Form("ERROR? - track %d with negative label %d has been accepted. AOD Constrained?",iesd,vtrack->GetLabel()));
+      }
+    }
+    else {
+      Int_t iesd = vtrack->GetID();
+      if (iesd < 0) iesd = -1 - iesd;
+
+      if (fTrueToRec->At(vtrack->GetLabel()) != NULL) {
+        AliVTrack *prevvtrack = (AliVTrack *) fTrueToRec->At(vtrack->GetLabel());
+        if ((fMCRecFlags[iesd] & kAccepted) == kAccepted) {
+          /* track has been accepted, store multi reconstruction information */
+          if (prevvtrack->GetID() != iesd) {
+            /* different tracks so update the information accordingly */
+            if ((fMCRecFlags[prevvtrack->GetID()] & kAccepted) == kAccepted) {
+              /* both tracks are accepted with the same label */
+              fMCRecFlags[iesd] |= kSamePositiveLabel;
+              fMCRecFlags[prevvtrack->GetID()] |= kSamePositiveLabel;
+              AliError(Form("ERROR - track %d and %d accepted with the same label %d",
+                  iesd, prevvtrack->GetID(), vtrack->GetLabel()));
+            }
+            else {
+              /* the previous track was not accepted, set this one instead */
+              fTrueToRec->AddAt(vtrack, vtrack->GetLabel());
+            }
+          }
+          else {
+            /* the same track so, no multi reconstruction so far */
+            fMCRecFlags[iesd] &= ~kSamePositiveLabel;
+          }
+        }
+        else {
+          /* track has not been accepted, nothing to do */
+        }
+      }
+      else {
+        /* not mapped, incorporate it to the map */
+        fTrueToRec->AddAt(vtrack, vtrack->GetLabel());
+      }
+    }
+  }
+}
+
+/// \brief Sets the task configuration by means of a configuration string
+/// \param confstring the configuration string
+/// \return kTRUE if the task was correctly configured kFALSE otherwise
+/// The configuration string will have the format
+/// Task:activities;Events:eventstring;Tracks:trackstring;PID:pidstring;
+/// In their turn, eventstring, trackstring and pidstring might have the format
+/// cutstring or cutstring+cutstring, and cutstring could start with a '-'
+/// to signal an exlusive cut.
+/// The activities could be none (empty), any of 'corr' or 'pairs' or both
+/// as 'corr+pairs' where 'corr' stands for correlation analysis and 'pairs'
+/// for track pairs analysis
+///
+/// Additionally, between the event and tracks configuration strings there are
+/// a set of options which are only effective for MC data analysis
+///
+/// - Effprof:profile;  the efficiency profile to enforce on MC rec data
+/// - Trueeffprof:profile;  the efficiency profile to enforce on MC true date
+/// - Recoption:option;   options for the additional MC rec results
+///
+/// The profile string could be a single expression depending on x (pT),
+/// or a concatenation |bin,bin,expr| terms each of them defining an initial
+/// bin, a final bin and an expression to assign the efficiency on that bin
+/// interval. In this case the expression will depend on pT bin number. Again
+/// the expression  will not depend on the pT value of the concrete bin being
+/// handled. If pT value were needed use the corresponding factor within the
+/// expression.
+///
+/// The option string could be one of the following
+/// - trueval   the reconstructed results will use reconstructed tracks but with true data
+/// - primaries   the reconstructed results will use true primary reconstructed tracks
+/// It should only be used at initial task configuration
+Bool_t AliAnalysisTaskCorrelationsStudies::Configure(const char *confstring)
+{
+  Bool_t accepted = kTRUE;
+  fTaskConfigurationString = confstring;
+  TString sztmp = confstring;
+
+  /* the task activities */
+  if (sztmp.BeginsWith("Task:")) {
+    sztmp.Remove(0,strlen("Task:"));
+    fTaskActivitiesString = sztmp(0,sztmp.Index(";"));
+    sztmp.Remove(0,sztmp.Index(";")+1);
+
+    TObjArray *tokens = fTaskActivitiesString.Tokenize("+");
+    if (tokens->GetEntries() == 2) {
+      if (((TObjString*)tokens->At(0))->String().EqualTo("corr")) {
+        if (((TObjString*)tokens->At(1))->String().EqualTo("pairs")) {
+          fDoProcessCorrelations = kTRUE;
+          fDoProcessPairAnalysis = kTRUE;
+        }
+        else {
+          AliFatal("Wrong task activities. ABORTING!!!");
+          return kFALSE;
+        }
+      }
+      else if (((TObjString*)tokens->At(1))->String().EqualTo("corr")) {
+        if (((TObjString*)tokens->At(0))->String().EqualTo("pairs")) {
+          fDoProcessCorrelations = kTRUE;
+          fDoProcessPairAnalysis = kTRUE;
+        }
+        else {
+          AliFatal("Wrong task activities. ABORTING!!!");
+          return kFALSE;
+        }
+      }
+      else {
+        AliFatal("Wrong task activities. ABORTING!!!");
+        return kFALSE;
+      }
+      delete tokens;
+    }
+    else if (tokens->GetEntries() == 1) {
+      if (((TObjString*)tokens->At(0))->String().EqualTo("corr")) {
+        fDoProcessCorrelations = kTRUE;
+      }
+      else if (((TObjString*)tokens->At(0))->String().EqualTo("pairs")) {
+          fDoProcessPairAnalysis = kTRUE;
+      }
+      else {
+        AliFatal("Wrong task activities. ABORTING!!!");
+        return kFALSE;
+      }
+    }
+    else if (tokens->GetEntries() != 0) {
+      AliFatal("Wrong task activities. ABORTING!!!");
+      return kFALSE;
+    }
+  }
+
+  /* the event cuts */
+  if (sztmp.BeginsWith("Events:")) {
+    sztmp.Remove(0,strlen("Events:"));
+    fEventCutsString = sztmp(0,sztmp.Index(";"));
+    sztmp.Remove(0,sztmp.Index(";")+1);
+  }
+  else {
+    AliFatal("No event cuts string. ABORTING!!!");
+    return kFALSE;
+  }
+
+  /* the efficiency profile to enforce */
+  if (sztmp.BeginsWith("Effprof:")) {
+    sztmp.Remove(0,strlen("Effprof:"));
+    fEfficiencyProfileToEnforce = sztmp(0, sztmp.Index(";"));
+    sztmp.Remove(0, sztmp.Index(";")+1);
+  }
+
+  /* the efficiency profile on true data */
+  if (sztmp.BeginsWith("Trueeffprof:")) {
+    sztmp.Remove(0,strlen("Trueeffprof:"));
+    fEfficiencyProfileOnTrue = sztmp(0, sztmp.Index(";"));
+    sztmp.Remove(0, sztmp.Index(";")+1);
+    if (fEfficiencyProfileOnTrue.EqualTo("onlyrec")) {
+      fEfficiencyProfileOnTrue.Clear();
+      fOnTrueEfficiencyProfile = kOnlyReconstructed;
+    }
+  }
+
+  /* options for the additional MC rec results */
+  if (sztmp.BeginsWith("Recoption:")) {
+    sztmp.Remove(0,strlen("Recoption:"));
+    fAdditionalMCRecOption = sztmp(0, sztmp.Index(";"));
+    sztmp.Remove(0, sztmp.Index(";")+1);
+
+    if (fAdditionalMCRecOption.EqualTo("trueval")) {
+      fMCRecOption = kRecWithTrue;
+    }
+    else if(fAdditionalMCRecOption.EqualTo("primaries")) {
+      fMCRecOption = kRecTruePrimaries;
+    }
+    else if(fAdditionalMCRecOption.EqualTo("notacc")) {
+      fMCRecOption = kRecWithNotAccepted;
+    }
+    else {
+      AliFatal("Unknown option for additional MC rec results. ABORTING!!!");
+      return kFALSE;
+    }
+  }
+
+  /* the track selection strings                           */
+  fTrackSelectionString = sztmp;
+  /* let's make a quick survey to detect inconsistent format */
+  /* the tracks section */
+  if (sztmp.BeginsWith("Tracks:")) {
+    sztmp.Remove(0,strlen("Tracks:"));
+    TString sztmptrk = sztmp(0,sztmp.Index(";"));
+    sztmp.Remove(0, sztmp.Index(";")+1);
+  }
+  else {
+    AliFatal("No tracks selection cuts string. ABORTING!!!");
+    return kFALSE;
+  }
+  /* the PID section */
+  if (sztmp.BeginsWith("PID:")) {
+    sztmp.Remove(0,strlen("PID:"));
+    TString sztmpid = sztmp(0, sztmp.Index(";"));
+    sztmp.Remove(0, sztmp.Index(";")+1);
+  }
+  else {
+    AliFatal("No tracks selection PID cuts string. ABORTING!!!");
+    return kFALSE;
+  }
+
+  if (!fTaskConfigurationString.EqualTo(ProduceConfigurationString())) {
+    AliError("Produced configuration ");
+    AliError(Form("\t%s",ProduceConfigurationString()));
+    AliError("does not match the passed one");
+    AliError(Form("\t%s",fTaskConfigurationString.Data()));
+    AliFatal("ABORTING!!!");
+    return kFALSE;
+  }
+
+  AliInfo("Task configured with configuration string:");
+  AliInfo(Form("\t%s", fTaskConfigurationString.Data()));
+  return accepted;
+}
+
+/// \brief Builds a configuration string out of the task variables
+/// \return the built configuration string
+const char *AliAnalysisTaskCorrelationsStudies::ProduceConfigurationString() {
+  static char buffer[2048];
+
+  sprintf(buffer, "Task:%s;Events:%s;%s%s%s%s",
+      fTaskActivitiesString.Data(),
+      fEventCutsString.Data(),
+      ((fEfficiencyProfileToEnforce.Length() != 0) ? Form("Effprof:%s;",fEfficiencyProfileToEnforce.Data()) : ""),
+      ((fEfficiencyProfileOnTrue.Length() != 0) ? Form("Trueeffprof:%s;",fEfficiencyProfileOnTrue.Data()) :
+          ((fOnTrueEfficiencyProfile == kOnlyReconstructed) ? "Trueeffprof:onlyrec;" : "")),
+      ((fAdditionalMCRecOption.Length() != 0) ? Form("Recoption:%s;",fAdditionalMCRecOption.Data()) : ""),
+      fTrackSelectionString.Data());
+
+  return buffer;
+}
+
+///\brief Establishes the processing correlations instance configuration
+/// \param confstring the configuration string
+/// \param pattern string pattern for the weigths or particle density files
+/// \param szContainerPrefix for placing the prefix of the particle and action combination
+/// \return kTRUE if everything went OK kFALSE otherwise
+Bool_t AliAnalysisTaskCorrelationsStudies::ConfigureCorrelations(const char *confstring, const char *pattern, TString &szContainerPrefix)
+{
+  TString sztmp = confstring;
+  TString szTrack1;
+  TString szTrack2;
+
+  /* the correlation configuration */
+  if (sztmp.BeginsWith("Corr:")) {
+    sztmp.Remove(0,strlen("Corr:"));
+  }
+  else {
+    AliFatal("No correlations configuration string. ABORTING!!!");
+    return kFALSE;
+  }
+
+  TObjArray *tokens = sztmp.Tokenize(",");
+  if ((tokens->GetEntries() == 3) || (tokens->GetEntries() == 4)) {
+    /* track polarities */
+    if (((TObjString*) tokens->At(0))->String().EqualTo("--")) {
+      fProcessCorrelations.SetSameSign(kTRUE);
+      fProcessCorrelations.SetRequestedCharge_1(-1);
+      fProcessCorrelations.SetRequestedCharge_2(-1);
+      fProcessMCRecCorrelationsWithOptions.SetSameSign(kTRUE);
+      fProcessMCRecCorrelationsWithOptions.SetRequestedCharge_1(-1);
+      fProcessMCRecCorrelationsWithOptions.SetRequestedCharge_2(-1);
+      fProcessTrueCorrelations.SetSameSign(kTRUE);
+      fProcessTrueCorrelations.SetRequestedCharge_1(-1);
+      fProcessTrueCorrelations.SetRequestedCharge_2(-1);
+      szTrack1 = "m1";
+      szTrack2 = "m2";
+      szContainerPrefix = "MM";
+    }
+    else if (((TObjString*) tokens->At(0))->String().EqualTo("++")) {
+      fProcessCorrelations.SetSameSign(kTRUE);
+      fProcessCorrelations.SetRequestedCharge_1(1);
+      fProcessCorrelations.SetRequestedCharge_2(1);
+      fProcessMCRecCorrelationsWithOptions.SetSameSign(kTRUE);
+      fProcessMCRecCorrelationsWithOptions.SetRequestedCharge_1(1);
+      fProcessMCRecCorrelationsWithOptions.SetRequestedCharge_2(1);
+      fProcessTrueCorrelations.SetSameSign(kTRUE);
+      fProcessTrueCorrelations.SetRequestedCharge_1(1);
+      fProcessTrueCorrelations.SetRequestedCharge_2(1);
+      szTrack1 = "p1";
+      szTrack2 = "p2";
+      szContainerPrefix = "PP";
+    }
+    else if (((TObjString*) tokens->At(0))->String().EqualTo("+-")) {
+      fProcessCorrelations.SetSameSign(kFALSE);
+      fProcessCorrelations.SetRequestedCharge_1(1);
+      fProcessCorrelations.SetRequestedCharge_2(-1);
+      fProcessMCRecCorrelationsWithOptions.SetSameSign(kFALSE);
+      fProcessMCRecCorrelationsWithOptions.SetRequestedCharge_1(1);
+      fProcessMCRecCorrelationsWithOptions.SetRequestedCharge_2(-1);
+      fProcessTrueCorrelations.SetSameSign(kFALSE);
+      fProcessTrueCorrelations.SetRequestedCharge_1(1);
+      fProcessTrueCorrelations.SetRequestedCharge_2(-1);
+      szTrack1 = "p1";
+      szTrack2 = "m2";
+      szContainerPrefix = "PM";
+    }
+    else if (((TObjString*) tokens->At(0))->String().EqualTo("-+")) {
+      fProcessCorrelations.SetSameSign(kFALSE);
+      fProcessCorrelations.SetRequestedCharge_1(-1);
+      fProcessCorrelations.SetRequestedCharge_2(1);
+      fProcessMCRecCorrelationsWithOptions.SetSameSign(kFALSE);
+      fProcessMCRecCorrelationsWithOptions.SetRequestedCharge_1(-1);
+      fProcessMCRecCorrelationsWithOptions.SetRequestedCharge_2(1);
+      fProcessTrueCorrelations.SetSameSign(kFALSE);
+      fProcessTrueCorrelations.SetRequestedCharge_1(-1);
+      fProcessTrueCorrelations.SetRequestedCharge_2(1);
+      szTrack1 = "m1";
+      szTrack2 = "p2";
+      szContainerPrefix = "MP";
+    }
+    else if (((TObjString*) tokens->At(0))->String().EqualTo("**")) {
+      fProcessCorrelations.SetSameSign(kFALSE);
+      fProcessCorrelations.SetAllCombinations(kTRUE);
+      fProcessCorrelations.SetRequestedCharge_1(1);
+      fProcessCorrelations.SetRequestedCharge_2(-1);
+      fProcessMCRecCorrelationsWithOptions.SetSameSign(kFALSE);
+      fProcessMCRecCorrelationsWithOptions.SetAllCombinations(kTRUE);
+      fProcessMCRecCorrelationsWithOptions.SetRequestedCharge_1(1);
+      fProcessMCRecCorrelationsWithOptions.SetRequestedCharge_2(-1);
+      fProcessTrueCorrelations.SetSameSign(kFALSE);
+      fProcessTrueCorrelations.SetAllCombinations(kTRUE);
+      fProcessTrueCorrelations.SetRequestedCharge_1(1);
+      fProcessTrueCorrelations.SetRequestedCharge_2(-1);
+      szTrack1 = "p1";
+      szTrack2 = "m2";
+      szContainerPrefix = "AA";
+    }
+    else {
+      AliFatal("Requested track polarities string not properly configured.ABORTING!!!");
+      return kFALSE;
+    }
+
+    /* singles or pairs */
+    if (((TObjString*) tokens->At(1))->String().EqualTo("singles")) {
+      fProcessCorrelations.SetSinglesOnly(kTRUE);
+      fProcessMCRecCorrelationsWithOptions.SetSinglesOnly(kTRUE);
+      fProcessTrueCorrelations.SetSinglesOnly(kTRUE);
+      szContainerPrefix += "_S";
+    }
+    else if (((TObjString*) tokens->At(1))->String().EqualTo("pairs")) {
+      fProcessCorrelations.SetSinglesOnly(kFALSE);
+      fProcessMCRecCorrelationsWithOptions.SetSinglesOnly(kFALSE);
+      fProcessTrueCorrelations.SetSinglesOnly(kFALSE);
+      szContainerPrefix += "_P";
+    }
+    else {
+      AliFatal("Singles / pairs string not properly configured.ABORTING!!!");
+      return kFALSE;
+    }
+
+    /* use weights or efficiency corrections or both */
+    if (((TObjString*) tokens->At(2))->String().EqualTo("weights") ||
+        ((TObjString*) tokens->At(2))->String().EqualTo("effcorr") ||
+        ((TObjString*) tokens->At(2))->String().EqualTo("weightseffcorr") ||
+        ((TObjString*) tokens->At(2))->String().EqualTo("weightspairseff") ) {
+      /* we will use weights or efficiency corrections so the weights filename has to be there */
+      if (tokens->GetEntries() == 4) {
+        /* get the weights histos */
+        TFile *weights;
+        Char_t localbuffer[2048];
+
+        TGrid::Connect("alien:");
+        weights = TFile::Open(((TObjString*) tokens->At(3))->String(),"OLD");
+        if (weights != NULL && weights->IsOpen()) {
+          /* the weights correction */
+          if (((TObjString*) tokens->At(2))->String().EqualTo("weights") ||
+              ((TObjString*) tokens->At(2))->String().EqualTo("weightseffcorr") ||
+              ((TObjString*) tokens->At(2))->String().EqualTo("weightspairseff")) {
+            sprintf(localbuffer,"%s%s", pattern,szTrack1.Data());
+            fhWeightsTrack_1 = (TH3F*) weights->Get(localbuffer);
+            sprintf(localbuffer,"%s%s", pattern,szTrack2.Data());
+            fhWeightsTrack_2 = (TH3F*) weights->Get(localbuffer);
+            if ((fhWeightsTrack_1 != NULL) && (fhWeightsTrack_2 != NULL)) {
+              fProcessCorrelations.SetUseWeights(kTRUE);
+              AliInfo("===========STORED CORRECTION WEIGHTS====================");
+              AliInfo(Form("Track 1: %c charge, weights histogram: %s", ((TObjString*) tokens->At(0))->String()[0],fhWeightsTrack_1->GetName()));
+              AliInfo(Form("Track 2: %c charge, weights histogram: %s", ((TObjString*) tokens->At(0))->String()[1],fhWeightsTrack_2->GetName()));
+              AliInfo("===========END STORED CORRECTION WEIGHTS================");
+              szContainerPrefix += "W";
+            }
+            else {
+              AliFatal(Form("Not able to find weights histograms %s in file %s. ABORTING!!!",localbuffer, ((TObjString*) tokens->At(3))->String().Data()));
+              return kFALSE;
+            }
+          }
+          if (((TObjString*) tokens->At(2))->String().EqualTo("effcorr") ||
+              ((TObjString*) tokens->At(2))->String().EqualTo("weightseffcorr") ) {
+            /* the efficiency correction */
+            sprintf(localbuffer,"%seff_%s", pattern,szTrack1.Data());
+            fhEffCorrTrack_1 = (TH1F*) weights->Get(localbuffer);
+            sprintf(localbuffer,"%seff_%s", pattern,szTrack2.Data());
+            fhEffCorrTrack_2 = (TH1F*) weights->Get(localbuffer);
+            if ((fhEffCorrTrack_1 != NULL) && (fhEffCorrTrack_2 != NULL)) {
+              AliInfo("===========STORED EFFICIENCY CORRECTION====================");
+              AliInfo(Form("Track 1: %c charge, efficiency correction histogram: %s", ((TObjString*) tokens->At(0))->String()[0],fhEffCorrTrack_1->GetName()));
+              AliInfo(Form("Track 2: %c charge, efficiency correction histogram: %s", ((TObjString*) tokens->At(0))->String()[1],fhEffCorrTrack_2->GetName()));
+              AliInfo("===========END STORED EFFICIENCY CORRECTION================");
+              szContainerPrefix += "E";
+            }
+            else {
+              AliFatal(Form("Not able to find efficiency correction histograms %s in file %s. ABORTING!!!", localbuffer, ((TObjString*) tokens->At(3))->String().Data()));
+              return kFALSE;
+            }
+          }
+          if (((TObjString*) tokens->At(2))->String().EqualTo("pairseff") ||
+              ((TObjString*) tokens->At(2))->String().EqualTo("weightspairseff") ) {
+            /* the pairs efficiencies */
+            sprintf(localbuffer,"%spairseff_PP", pattern);
+            fhPairEfficiency_PP = (THn*) weights->Get(localbuffer);
+            sprintf(localbuffer,"%spairseff_PM", pattern);
+            fhPairEfficiency_PM = (THn*) weights->Get(localbuffer);
+            sprintf(localbuffer,"%spairseff_MM", pattern);
+            fhPairEfficiency_MM = (THn*) weights->Get(localbuffer);
+            sprintf(localbuffer,"%spairseff_MP", pattern);
+            fhPairEfficiency_MP = (THn*) weights->Get(localbuffer);
+            if ((fhPairEfficiency_PP != NULL) && (fhPairEfficiency_PM != NULL) && (fhPairEfficiency_MM != NULL) && (fhPairEfficiency_MP != NULL)) {
+              AliInfo("===========STORED PAIRS EFFICIENCY=========================");
+              AliInfo(Form("Pair PP: pairs efficiency histogram: %s", fhPairEfficiency_PP->GetName()));
+              AliInfo(Form("Pair PM: pairs efficiency histogram: %s", fhPairEfficiency_PM->GetName()));
+              AliInfo(Form("Pair MM: pairs efficiency histogram: %s", fhPairEfficiency_MM->GetName()));
+              AliInfo(Form("Pair MP: pairs efficiency histogram: %s", fhPairEfficiency_MP->GetName()));
+              AliInfo("===========END STORED PAIRS EFFICIENCY=====================");
+              szContainerPrefix += "PE";
+            }
+            else {
+              AliFatal(Form("Not able to find pairs efficiency histograms %s in file %s. ABORTING!!!", localbuffer, ((TObjString*) tokens->At(3))->String().Data()));
+              return kFALSE;
+            }
+          }
+        }
+        else {
+          AliFatal(Form("Weights file %s not available.ABORTING!!!",((TObjString*) tokens->At(3))->String().Data()));
+          return kFALSE;
+        }
+      }
+      else {
+        AliFatal("Use weights required but the weights filename is not present.ABORTING!!!");
+        return kFALSE;
+      }
+    }
+    else if (((TObjString*) tokens->At(2))->String().BeginsWith("simulate")) {
+      /* get the number of events to generate per real event */
+      Int_t nSimEventsPerEvent;
+      if (((TObjString*) tokens->At(2))->String().EqualTo("simulate"))
+        nSimEventsPerEvent = 1;
+      else
+        sscanf(((TObjString*) tokens->At(2))->String().Data(), "simulate-%d", &nSimEventsPerEvent);
+
+      fProcessCorrelations.SetUseSimulation(kTRUE);
+      fProcessCorrelations.SetSimEventsPerEvent(nSimEventsPerEvent);
+      /* we will use particle profiles so the particle profiles filename has to be there */
+      if (tokens->GetEntries() == 4) {
+        /* get the weights histos */
+        TFile *trkprofiles;
+        Char_t localbuffer[2048];
+
+        TGrid::Connect("alien:");
+        trkprofiles = TFile::Open(((TObjString*) tokens->At(3))->String(),"OLD");
+        if (trkprofiles != NULL && trkprofiles->IsOpen()) {
+          /* get the positive tracks density function */
+          fPositiveTrackPdf = new TObjArray(64); fPositiveTrackPdf->SetOwner(kTRUE);
+          for (Int_t ix = 0; ;ix++) {
+            sprintf(localbuffer, "%sp_yield_%d", pattern, ix);
+            TH3F *hslot = (TH3F*) trkprofiles->Get(localbuffer);
+            if (hslot != NULL)
+              fPositiveTrackPdf->Add(hslot);
+            else
+              break;
+          }
+          printf("Took %d positive tracks slots with %s pattern\n", fPositiveTrackPdf->GetEntriesFast(), Form("%sp_yield", pattern));
+          /* and now the negative one */
+          fNegativeTrackPdf = new TObjArray(64); fNegativeTrackPdf->SetOwner(kTRUE);
+          for (Int_t ix = 0; ;ix++) {
+            sprintf(localbuffer, "%sm_yield_%d", pattern, ix);
+            TH3F *hslot = (TH3F*) trkprofiles->Get(localbuffer);
+            if (hslot != NULL)
+              fNegativeTrackPdf->Add(hslot);
+            else
+              break;
+          }
+          printf("Took %d negative tracks slots with %s pattern\n", fNegativeTrackPdf->GetEntriesFast(), Form("%sm_yield", pattern));
+          if ((fPositiveTrackPdf->GetEntriesFast() != 0) &&
+              (fNegativeTrackPdf->GetEntriesFast() != 0) &&
+              (fPositiveTrackPdf->GetEntriesFast() == fNegativeTrackPdf->GetEntriesFast())) {
+            AliInfo("=========== STORED SIMULATION TRACKS DENSITY PROFILES =================");
+            AliInfo(Form("Positive tracks: %d zvertex slots", fPositiveTrackPdf->GetEntriesFast()));
+            AliInfo(Form("Negative tracks: %d zvertex slots", fNegativeTrackPdf->GetEntriesFast()));
+            AliInfo("============= END SIMULATION TRACKS DENSITY PROFILES ==================");
+            szContainerPrefix += "SIM";
+          }
+          else {
+            AliFatal(Form("Not able to find consistent track density histograms in file %s. ABORTING!!!",((TObjString*) tokens->At(3))->String().Data()));
+            return kFALSE;
+          }
+        }
+        else {
+          AliFatal(Form("Particle profiles file %s not available.ABORTING!!!",((TObjString*) tokens->At(3))->String().Data()));
+          return kFALSE;
+        }
+      }
+      else {
+        AliFatal("Use simulation required but the particle profiles filename is not present.ABORTING!!!");
+        return kFALSE;
+      }
+    }
+    else if (((TObjString*) tokens->At(2))->String().EqualTo("effcorrtrue")) {
+      fCorrectOnTrueEfficiency = kTRUE;
+      fProcessCorrelations.SetUseWeights(kFALSE);
+      szContainerPrefix += "NW";
+    }
+    else if (((TObjString*) tokens->At(2))->String().EqualTo("noweights")) {
+      fProcessCorrelations.SetUseWeights(kFALSE);
+      szContainerPrefix += "NW";
+    }
+    else {
+      AliFatal("(no)weights string not properly configured.ABORTING!!!");
+      return kFALSE;
+    }
+
+  }
+  else {
+    AliFatal("Correlations configuration string not properly configured.ABORTING!!!");
+    return kFALSE;
+  }
+  delete tokens;
+
+  /* true will never use weights nor simulation */
+  fProcessMCRecCorrelationsWithOptions.SetUseWeights(kFALSE);
+  fProcessMCRecCorrelationsWithOptions.SetUseSimulation(kFALSE);
+  fProcessTrueCorrelations.SetUseWeights(kFALSE);
+  fProcessTrueCorrelations.SetUseSimulation(kFALSE);
+
+
+  return kTRUE;
+}
+
+/// \brief Establishes the bining for the correlation object instance
+/// \param confstring the string containing the bins configuration
+/// \return kTRUE if everything went OK kFALSE otherwise
+Bool_t AliAnalysisTaskCorrelationsStudies::ConfigureCorrelationsBinning(const char *confstring) {
+
+  TString sztmp = confstring;
+  TString szTrack1;
+  TString szTrack2;
+
+  /* the correlation configuration */
+  if (sztmp.BeginsWith("Binning:")) {
+    sztmp.Remove(0,strlen("Binning:"));
+  }
+  else {
+    AliFatal("No correlations binning configuration string. ABORTING!!!");
+    return kFALSE;
+  }
+
+  fProcessCorrelations.ConfigureBinning(sztmp.Data());
+  fProcessMCRecCorrelationsWithOptions.ConfigureBinning(sztmp.Data());
+  fProcessTrueCorrelations.ConfigureBinning(sztmp.Data());
+  fProcessPairAnalysis.ConfigureBinning(sztmp.Data());
+  fProcessTruePairAnalysis.ConfigureBinning(sztmp.Data());
+
+  return kTRUE;
+}
+
+
+/// Creates the object to be preserved on the results files
+void AliAnalysisTaskCorrelationsStudies::UserCreateOutputObjects()
+{
+  Bool_t oldstatus = TH1::AddDirectoryStatus();
+  TH1::AddDirectory(kFALSE);
+
+  // Create histograms
+  // Called once (on the worker node)
+  fOutput = new TList();
+  fOutput->SetOwner();  // IMPORTANT!
+
+  fEventCuts = new AliCSEventCuts("CS_Event_Cuts", "CS Event Cuts");
+  if (!fEventCuts->InitializeCutsFromCutString(fEventCutsString)) {
+    AliFatal("Not able to initialize event cuts. ABORTING!!!");
+  }
+
+  fEventCuts->SetQALevelOutput(AliCSAnalysisCutsBase::kQALevelHeavy);
+  fEventCuts->InitCuts();
+  fOutput->Add(fEventCuts->GetHistogramsList());
+
+  fTrackSelectionCuts = new AliCSTrackSelection("CS_Track_Selection", "CS Track Selection");
+  fTrackSelectionCuts->InitializeFromString(fTrackSelectionString);
+  fTrackSelectionCuts->SetQALevelOutput(AliCSAnalysisCutsBase::kQALevelHeavy);
+  fTrackSelectionCuts->InitCuts();
+  fOutput->Add(fTrackSelectionCuts->GetHistogramsList());
+
+  /* now initialize the processing correlations instance */
+  if (fDoProcessCorrelations) {
+    fProcessCorrelations.Initialize();
+    fProcessMCRecCorrelationsWithOptions.Initialize();
+    fProcessTrueCorrelations.Initialize();
+    fProcessCorrelations.SetWeigths(fhWeightsTrack_1, fhWeightsTrack_2);
+    fProcessCorrelations.SetEfficiencyCorrection(fhEffCorrTrack_1, fhEffCorrTrack_2);
+    fProcessCorrelations.SetPairEfficiencyCorrection(fhPairEfficiency_PP, fhPairEfficiency_PM, fhPairEfficiency_MM, fhPairEfficiency_MP);
+    fProcessCorrelations.SetSimultationPdfs(fPositiveTrackPdf, fNegativeTrackPdf);
+  }
+
+  /* now initialize the pair analysis instance */
+  if (fDoProcessPairAnalysis) {
+    fProcessPairAnalysis.Initialize();
+    fProcessTruePairAnalysis.Initialize();
+    /* we use the weights, they should contain NUA x NUE in four dimensions vtxz, eta, phi and pT */
+    fProcessPairAnalysis.SetSinglesEfficiency(fhWeightsTrack_1, fhWeightsTrack_2);
+    fProcessPairAnalysis.SetPairEfficiency(fhPairEfficiency_PP, fhPairEfficiency_PM, fhPairEfficiency_MM, fhPairEfficiency_MP);
+    /* and incorporate its histograms to the output list */
+    /* now initialize the pair analysis instance */
+    fOutput->Add(fProcessPairAnalysis.GetHistogramsList());
+    fOutput->Add(fProcessTruePairAnalysis.GetHistogramsList());
+  }
+
+  // Create histograms
+  Int_t ptbins = 30;
+  Float_t ptlow = 0.1, ptup = 3.1;
+  fhPt = new TH1F("fHistPt", "P_{T} distribution for reconstructed;P_{T} (GeV/c);dN/dP_{T} (c/GeV)", ptbins, ptlow, ptup);
+  fhPt->SetMarkerStyle(kFullCircle);
+  fhPtPos = new TH1F("fHistPtPos", "P_{T} distribution for reconstructed (#{+});P_{T} (GeV/c);dN/dP_{T} (c/GeV)", ptbins, ptlow, ptup);
+  fhPtNeg = new TH1F("fHistPtNeg", "P_{T} distribution for reconstructed (#{-});P_{T} (GeV/c);dN/dP_{T} (c/GeV)", ptbins, ptlow, ptup);
+  fhP = new TH1F("fHistP", "P distribution for reconstructed;P (GeV/c);dN/dP_{T} (c/GeV)", ptbins, ptlow, ptup);
+  fhPPos = new TH1F("fHistPPos", "P distribution for reconstructed (#{+});P (GeV/c);dN/dP (c/GeV)", ptbins, ptlow, ptup);
+  fhPNeg = new TH1F("fHistPNeg", "P distribution for reconstructed (#{-});P (GeV/c);dN/dP (c/GeV)", ptbins, ptlow, ptup);
+  fhUnConstrainedPt = new TH1F("fHistUnConstrainedPt","Unconstrained P_{T} distribution for reconstructed;P_{T} (GeV/c);dN/dP_{T} (c/GeV)", ptbins, ptlow, ptup);
+  fhPtDifference = new TH1F("fHistDifferencePt","Difference P_{T} distribution for reconstructed;P_{T} (GeV/c);dN/dP_{T} (c/GeV)", 100, -0.05, 0.05);
+
+  Int_t etabins = 40;
+  Float_t etalow = -2.0, etaup = 2.0;
+  Int_t zvtxbins = 40;
+  Float_t zvtxlow = -10.0, zvtxup = 10.0;
+  Int_t phibins = 72;
+
+  fhEtaB = new TH1F("fHistEtaB","#eta distribution for reconstructed before;#eta;counts",etabins, etalow, etaup);
+  fhEtaA = new TH1F("fHistEtaA","#eta distribution for reconstructed;#eta;counts",etabins, etalow, etaup);
+
+  fhPhiB = new TH1F("fHistPhiB","#phi distribution for reconstructed before;#phi;counts",360, 0.0, 360.0);
+  fhPhiA = new TH1F("fHistPhiA","#phi distribution for reconstructed;#phi;counts",360, 0.0, 360.0);
+
+  fhEtaVsPhiB = new TH2F(Form("CSTaskEtaVsPhiB_%s",fTaskConfigurationString.Data()),"#eta vs #phi before;#phi;#eta", 360, 0.0, 360.0, 100, etalow, etaup);
+  fhEtaVsPhiA = new TH2F(Form("CSTaskEtaVsPhiA_%s",fTaskConfigurationString.Data()),"#eta vs #phi;#phi;#eta", 360, 0.0, 360.0, 100, -2.0, 2.0);
+
+  fhPtVsEtaB = new TH2F(Form("fhPtVsEtaB_%s",fTaskConfigurationString.Data()),"p_{T} vs #eta before;#eta;p_{T} (GeV/c)",etabins,etalow,etaup,200,0.0,10.0);
+  fhPtVsEtaA = new TH2F(Form("fhPtVsEtaA_%s",fTaskConfigurationString.Data()),"p_{T} vs #eta;#eta;p_{T} (GeV/c)",etabins,etalow,etaup,200,0.0,10.0);
+
+  fhPt3DB = new TProfile3D(Form("fhPt3DB_%s",fTaskConfigurationString.Data()),"p_{T} vs #eta, #phi and vtx_{z} before;#eta;#phi;vtx_{z}",etabins,etalow,etaup,phibins,0.0,2*TMath::Pi(),zvtxbins,zvtxlow,zvtxup);
+  fhPt3DA = new TProfile3D(Form("fhPt3DA_%s",fTaskConfigurationString.Data()),"p_{T} vs #eta, #phi and vtx_{z};#eta;#phi;vtx_{z}",etabins,etalow,etaup,phibins,0.0,2*TMath::Pi(),zvtxbins,zvtxlow,zvtxup);
+
+  /* the tracking of the event multiplicity distribution for evaluating the lambda angle */
+  Int_t mBins[2] = {4000,4000};
+  Double_t mLow[2] = {0.0,0.0};
+  Double_t mUp[2] = {4000.0,4000.0};
+  fhAcceptedVsMultiplicity = new THnSparseI("AcceptedVsMultiplicity",
+      "Accepted vs Reconstructed tracks;reconstructed tracks,accepted tracks,counts",
+      2,mBins,mLow,mUp);
+  fhLambdaVsMultiplicity = new TH2I("fhLambdaVsMultipliciy","#lambda;reconstructed tracks;#lambda;counts",
+      4000,0,4000,72,-TMath::PiOver2(),TMath::PiOver2());
+
+
+  fOutput->Add(fhPt);
+  fOutput->Add(fhPtPos);
+  fOutput->Add(fhPtNeg);
+  fOutput->Add(fhP);
+  fOutput->Add(fhPPos);
+  fOutput->Add(fhPNeg);
+  fOutput->Add(fhUnConstrainedPt);
+  fOutput->Add(fhPtDifference);
+  fOutput->Add(fhEtaB);
+  fOutput->Add(fhEtaA);
+  fOutput->Add(fhPhiB);
+  fOutput->Add(fhPhiA);
+  fOutput->Add(fhEtaVsPhiB);
+  fOutput->Add(fhEtaVsPhiA);
+  fOutput->Add(fhPtVsEtaB);
+  fOutput->Add(fhPtVsEtaA);
+  fOutput->Add(fhPt3DB);
+  fOutput->Add(fhPt3DA);
+  fOutput->Add(fhAcceptedVsMultiplicity);
+  fOutput->Add(fhLambdaVsMultiplicity);
+
+  /* incorporate configuration parameters if needed */
+  if (fDoProcessCorrelations) {
+    fProcessMCRecCorrelationsWithOptions.GetHistogramsList()->AddFirst(new TParameter<Int_t>("AdditionalMCRecOption",fMCRecOption,'f'));
+  }
+
+  TH1::AddDirectory(oldstatus);
+
+  PostData(1, fOutput); // Post data for ALL output slots >0 here, to get at least an empty histogram
+  if (fDoProcessCorrelations) {
+    PostData(2, fProcessCorrelations.GetHistogramsList()); // Post data for ALL output slots >0 here, to get at least an empty histogram
+    PostData(3, fProcessMCRecCorrelationsWithOptions.GetHistogramsList()); // Post data for ALL output slots >0 here, to get at least an empty histogram
+    PostData(4, fProcessTrueCorrelations.GetHistogramsList()); // Post data for ALL output slots >0 here, to get at least an empty histogram
+  }
+  else {
+    /* we post dummy list for avoiding fatal error */
+    TList *dummy1 = new TList(); dummy1->SetOwner(kTRUE);
+    TList *dummy2 = new TList(); dummy2->SetOwner(kTRUE);
+    TList *dummy3 = new TList(); dummy3->SetOwner(kTRUE);
+    PostData(2, dummy1); // Post data for ALL output slots >0 here, to get at least an empty histogram
+    PostData(3, dummy2); // Post data for ALL output slots >0 here, to get at least an empty histogram
+    PostData(4, dummy2); // Post data for ALL output slots >0 here, to get at least an empty histogram
+  }
+}
+
+/// A new run analysis is starting
+/// Check for a potential change in the period (will always happen for the first
+/// run in the analysis) and produce all the output depending on the concrete analysis
+void AliAnalysisTaskCorrelationsStudies::NotifyRun() {
+  AliInfo("");
+
+  AliCSAnalysisCutsBase::NotifyRunGlobal();
+  fEventCuts->NotifyRun();
+  fTrackSelectionCuts->NotifyRun();
+
+  /* now we create additional MC histograms if applicable */
+  if (AliCSAnalysisCutsBase::IsMC()) {
+    Bool_t oldstatus = TH1::AddDirectoryStatus();
+    TH1::AddDirectory(kFALSE);
+
+    Int_t ptbins = fhPt->GetNbinsX();
+    Double_t ptlow = fhPt->GetXaxis()->GetBinLowEdge(1), ptup = fhPt->GetXaxis()->GetBinUpEdge(ptbins);
+
+    fhTruePt = new TH1F("fHistTruePt", "P_{T} distribution (truth);P_{T} (GeV/c);dN/dP_{T} (c/GeV)", ptbins, ptlow, ptup);
+    fhTruePtPos = new TH1F("fHistTruePtPos", "P_{T} distribution (+) (truth);P_{T} (GeV/c);dN/dP_{T} (c/GeV)", ptbins, ptlow, ptup);
+    fhTruePtNeg = new TH1F("fHistTruePtNeg", "P_{T} distribution (-) (truth);P_{T} (GeV/c);dN/dP_{T} (c/GeV)", ptbins, ptlow, ptup);
+    fhTrueP = new TH1F("fHistTrueP", "P distribution (truth);P (GeV/c);dN/dP_{T} (c/GeV)", ptbins, ptlow, ptup);
+    fhTruePPos = new TH1F("fHistTruePPos", "P distribution (+) (truth);P (GeV/c);dN/dP (c/GeV)", ptbins, ptlow, ptup);
+    fhTruePNeg = new TH1F("fHistTruePNeg", "P distribution (-) (truth);P (GeV/c);dN/dP (c/GeV)", ptbins, ptlow, ptup);
+    fhPurePt = new TH1F("fHistPurePt", "P_{T} distribution for reconstructed (pure);P_{T} (GeV/c);dN/dP_{T} (c/GeV)", ptbins, ptlow, ptup);
+    fhPurePtPos = new TH1F("fHistPurePtPos", "P_{T} distribution for reconstructed (+) (pure);P_{T} (GeV/c);dN/dP_{T} (c/GeV)", ptbins, ptlow, ptup);
+    fhPurePtNeg = new TH1F("fHistPurePtNeg", "P_{T} distribution for reconstructed (-) (pure);P_{T} (GeV/c);dN/dP_{T} (c/GeV)", ptbins, ptlow, ptup);
+    fhPureP = new TH1F("fHistPureP", "P distribution for reconstructed (pure);P (GeV/c);dN/dP_{T} (c/GeV)", ptbins, ptlow, ptup);
+    fhPurePPos = new TH1F("fHistPurePPos", "P distribution for reconstructed (+) (pure);P (GeV/c);dN/dP (c/GeV)", ptbins, ptlow, ptup);
+    fhPurePNeg = new TH1F("fHistPurePNeg", "P distribution for reconstructed (-) (pure);P (GeV/c);dN/dP (c/GeV)", ptbins, ptlow, ptup);
+
+    Int_t etabins = fhEtaB->GetNbinsX();
+    Double_t etalow = fhEtaB->GetXaxis()->GetBinLowEdge(1), etaup = fhEtaB->GetXaxis()->GetBinUpEdge(etabins);
+    Int_t zvtxbins = fhPt3DB->GetNbinsZ();
+    Double_t zvtxlow = fhPt3DB->GetZaxis()->GetBinLowEdge(1), zvtxup = fhPt3DB->GetZaxis()->GetBinUpEdge(zvtxbins);
+    Int_t phibins = fhPhiB->GetNbinsX();
+    Int_t ptvsetabins = fhPtVsEtaB->GetNbinsY();
+    Double_t ptvsetalow = fhPtVsEtaB->GetYaxis()->GetBinLowEdge(1), ptvsetaup = fhPtVsEtaB->GetYaxis()->GetBinUpEdge(ptvsetabins);
+
+    fhTrueEta = new TH1F("fHistTrueEta","#eta distribution (truth);#eta;counts",etabins, etalow, etaup);
+    fhTruePhi = new TH1F("fHistTruePhi","#phi distribution (truth);#phi;counts",360, 0.0, 360.0);
+    fhTrueEtaVsPhi = new TH2F(Form("CSTaskTrueEtaVsPhi_%s",fTaskConfigurationString.Data()),"#eta vs #phi (truth);#phi;#eta", 360, 0.0, 360.0, 100, etalow, etaup);
+    fhTruePtVsEta = new TH2F(Form("fhTruePtVsEta_%s",fTaskConfigurationString.Data()),"p_{T} vs #eta (truth);#eta;p_{T} (GeV/c)",etabins,etalow,etaup,ptvsetabins,ptvsetalow,ptvsetaup);
+
+    fhTruePt3D = new TProfile3D(Form("fhTruePt3D_%s",fTaskConfigurationString.Data()),"p_{T} vs #eta, #phi and vtx_{z} (truth);#eta;#phi;vtx_{z}",etabins,etalow,etaup,phibins,0.0,2*TMath::Pi(),zvtxbins,zvtxlow,zvtxup);
+
+    /* the tracking of the event multiplicity distribution for evaluating the lambda angle */
+    Int_t mBins[2] = {4000,4000};
+    Double_t mLow[2] = {0.0,0.0};
+    Double_t mUp[2] = {4000.0,4000.0};
+    fhTrueAcceptedVsPrimaries= new THnSparseI("TrueAcceptedVsPrimaries",
+        "Accepted vs Total tracks (truth);total tracks,primary tracks,counts",
+        2,mBins,mLow,mUp);
+    fhTrueLambdaVsPrimaries = new TH2I("fhTrueLambdaVsPrimaries","#lambda (truth);primary tracks;#lambda;counts",
+        4000,0,4000,72,-TMath::PiOver2(),TMath::PiOver2());
+
+    /* the tracking of the true reconstructed but not accepted and of the true not reconstructed */
+    Int_t bins[kgTHnDimension] = {ptbins,etabins,phibins,AliPID::kSPECIES+1};
+    Double_t low[kgTHnDimension] = {ptlow,etalow,0.0,AliPID::kElectron};
+    Double_t up[kgTHnDimension] = {ptup,etaup,360.0,AliPID::kProton+2};
+    fhTrueRecNotAccepted = new THnSparseI(Form("fhTrueRecNotAccepted_%s",fTaskConfigurationString.Data()),
+        "True reconstructed but not accepted;p_{T} (GeV/c);#eta;#phi;species",
+        kgTHnDimension,bins,low,up);
+    fhTrueNotReconstructed= new THnSparseI(Form("fhTrueNotReconstructed_%s",fTaskConfigurationString.Data()),
+        "True not reconstructed;p_{T} (GeV/c);#eta;#phi;species",
+        kgTHnDimension,bins,low,up);
+
+    fhTrueMultiRec = new TH1I(Form("fhTrueMultiRec_%s",fTaskConfigurationString.Data()),
+        "Multi reconstructed tracks;no. of multi reconstructed tracks", 20, 0, 20);
+    fhPtTrueMultiRec = new TH1I(Form("fhPtTrueMultiRec_%s",fTaskConfigurationString.Data()),
+        "p_{T} of multi reconstructed tracks;p_{T} (GeV/c)", ptbins, ptlow, ptup);
+
+
+
+    fOutput->Add(fhTruePt);
+    fOutput->Add(fhTruePtPos);
+    fOutput->Add(fhTruePtNeg);
+    fOutput->Add(fhTrueP);
+    fOutput->Add(fhTruePPos);
+    fOutput->Add(fhTruePNeg);
+    fOutput->Add(fhPurePt);
+    fOutput->Add(fhPurePtPos);
+    fOutput->Add(fhPurePtNeg);
+    fOutput->Add(fhPureP);
+    fOutput->Add(fhPurePPos);
+    fOutput->Add(fhPurePNeg);
+    fOutput->Add(fhTrueEta);
+    fOutput->Add(fhTruePhi);
+    fOutput->Add(fhTrueEtaVsPhi);
+    fOutput->Add(fhTruePtVsEta);
+    fOutput->Add(fhTruePt3D);
+    fOutput->Add(fhTrueAcceptedVsPrimaries);
+    fOutput->Add(fhTrueLambdaVsPrimaries);
+    fOutput->Add(fhTrueRecNotAccepted);
+    fOutput->Add(fhTrueNotReconstructed);
+    fOutput->Add(fhTrueMultiRec);
+    fOutput->Add(fhPtTrueMultiRec);
+
+    /* let's build the efficiency profile formula if required */
+    if (!BuildEfficiencyProfiles()) {
+      AliFatal("Something went wrong when building the efficiency profiles. ABORTING!!!");
+    }
+
+    /* if not additional MC rec results we remove the content from the output list */
+    if (fDoProcessCorrelations) {
+      if (fMCRecOption == kNone) {
+        fProcessMCRecCorrelationsWithOptions.GetHistogramsList()->Clear();
+      }
+    }
+
+    TH1::AddDirectory(oldstatus);
+  }
+  else {
+    /* if not MC we remove the content of the output list */
+    if (fDoProcessPairAnalysis) {
+      fProcessTruePairAnalysis.GetHistogramsList()->Clear();
+    }
+    if (fDoProcessCorrelations) {
+      fProcessMCRecCorrelationsWithOptions.GetHistogramsList()->Clear();
+      fProcessTrueCorrelations.GetHistogramsList()->Clear();
+    }
+  }
+}
+
+/// A new event is provided for its analysis
+void AliAnalysisTaskCorrelationsStudies::UserExec(Option_t *)
+{
+    // Main loop
+    // Called for each event
+    AliInfo("Got a new event!");
+
+    // Create pointer to reconstructed event
+    AliVEvent *event = InputEvent();
+    if (!event) { AliError("ERROR: Could not retrieve event"); return; }
+
+    // If the task accesses MC info, this can be done as in the commented block below:
+    /*
+    // Create pointer to reconstructed event
+    AliMCEvent *mcEvent = MCEvent();
+    if (!mcEvent) { Printf("ERROR: Could not retrieve MC event"); return; }
+    Printf("MC particles: %d", mcEvent->GetNumberOfTracks());
+
+    // set up a stack for use in check for primary/stable particles
+    AliStack* stack = mcEvent->Stack();
+    if( !stack ) { Printf( "Stack not available"); return; }
+    */
+
+    /* check if the event is accepted */
+    if (!fEventCuts->IsEventAccepted(fInputEvent)) return;
+
+    /* notify the new coming event to our track mapping function */
+    aodTrackMaps.NotifyEvent();
+
+    /* notify the new coming event to our cuts */
+    fEventCuts->NotifyEvent();
+    fTrackSelectionCuts->NotifyEvent();
+
+    /* build true to rec tracks relation if MC event */
+    if (fEventCuts->IsMC()) {
+      /* provide some feedback about MC */
+      AliInfo(Form("========= MC event is %s", ((fMCEvent != NULL) ? "NOT null" : "NULL")));
+      if (fMCEvent != NULL) {
+        AliInfo(Form("========= event is 0x%lX while MC event is 0x%lX", (unsigned long) fInputEvent, (unsigned long) fMCEvent));
+      }
+      BuildTrueRecRelation();
+    }
+
+    if (fDoProcessCorrelations && fProcessCorrelations.GetUseSimulation()) {
+      /* process rec tracks with potential simulation */
+      for (Int_t nsim = 0; nsim < fProcessCorrelations.GetSimEventsPerEvent(); nsim++) {
+        /* skip sensible process if additional simulation event is ongoing */
+        ProcessTracks(nsim != 0);
+      }
+    }
+    else {
+      ProcessTracks(kFALSE);
+    }
+
+    /* complete true to rec tracks relation if MC event */
+    if (fEventCuts->IsMC()) {
+      BuildTrueRecAccRelation();
+    }
+
+    /* process true tracks if MC event */
+    if (fEventCuts->IsMC()) {
+      ProcessTrueTracks();
+    }
+
+    // NEW HISTO should be filled before this point, as PostData puts the
+    // information for this iteration of the UserExec in the container
+    AliInfo("Processed event!");
+    PostData(1, fOutput);
+    if (fDoProcessCorrelations) {
+      PostData(2, fProcessCorrelations.GetHistogramsList());
+      PostData(3, fProcessMCRecCorrelationsWithOptions.GetHistogramsList());
+      PostData(4, fProcessTrueCorrelations.GetHistogramsList());
+    }
+}
+
+/// \brief Processes the tracks for the current event
+/// The processing could be invoked several times for the same event
+/// in order to simulate the tracks in the process correlations engine.
+/// In that case only the first call should be invoked with kFALSE to fill
+/// histograms only once with track real values.
+/// \param simulated if kTRUE not fill histograms, tracks will be simulated
+void AliAnalysisTaskCorrelationsStudies::ProcessTracks(Bool_t simulated) {
+  AliInfo("Start processing event tracks");
+
+  AliVEvent *event = InputEvent();
+
+  Double_t vertexz = fEventCuts->GetVertexZ();
+  Double_t centrality = fEventCuts->GetCentrality();
+
+  /* only process pair analysis if this is not an additional simulated event */
+  if (fDoProcessPairAnalysis && !simulated) {
+    /* initialize pair analysis function activities */
+    if (!fProcessPairAnalysis.StartEvent(vertexz)) return;
+  }
+
+  /* initialize correlation function activities */
+  /* reject event if not correctly initialized */
+  if (fDoProcessCorrelations) {
+    if (!fProcessCorrelations.StartEvent(centrality,vertexz)) return;
+    if (fEventCuts->IsMC()) {
+      if (fMCRecOption != kNone) {
+        if (!fProcessMCRecCorrelationsWithOptions.StartEvent(centrality,vertexz)) return;
+      }
+    }
+  }
+
+  /* prepare for a potential AOD MC data format */
+  TClonesArray *arrayMC = NULL;
+  if (fEventCuts->IsMC() && AliCSAnalysisCutsBase::GetMCEventHandler() == NULL) arrayMC = AliCSAnalysisCutsBase::GetMCTrueArray();
+
+  // Track loop for reconstructed event
+  Int_t ntracks = event->GetNumberOfTracks();
+  Int_t nNoOfAccepted = 0;
+  for(Int_t i = 0; i < ntracks; i++) {
+    AliVTrack* vtrack = dynamic_cast<AliVTrack*>(event->GetTrack(i)); // pointer to reconstructed to track
+    if(!vtrack) {
+        AliError(Form("ERROR: Could not retrieve vtrack %d",i));
+        continue;
+    }
+
+    /* enforce the efficiency profile if required */
+    if (fEnforceEfficiencyProfile) {
+      if (fRandomGenerator->Uniform(1.0) > ffEfficiencyProfile->Eval(vtrack->Pt()))
+        continue;
+    }
+
+    Bool_t bTrackAccepted = fTrackSelectionCuts->IsTrackAccepted(vtrack);
+
+    /* only fill histograms if this is not an additional simulated event */
+    if (!simulated) {
+      fhEtaB->Fill(vtrack->Eta());
+      fhPhiB->Fill(vtrack->Phi()*180.0/TMath::Pi());
+      fhEtaVsPhiB->Fill(vtrack->Phi()*180.0/TMath::Pi(),vtrack->Eta());
+      fhPtVsEtaB->Fill(vtrack->Eta(),vtrack->Pt());
+      fhPt3DB->Fill(vtrack->Eta(),vtrack->Phi(),vertexz,vtrack->Pt());
+    }
+
+    if (bTrackAccepted) {
+      /* get the original track in case of constrained track */
+      Int_t esdid = vtrack->GetID();
+      AliVTrack *origtrack = vtrack;
+      if (esdid < 0) origtrack = aodTrackMaps.GetOriginalTrack((AliAODTrack*) vtrack);
+
+      /* additional tracks quality tests for MC reconstructed */
+      if (fEventCuts->IsMC()) {
+        fMCRecFlags[origtrack->GetID()] |= kAccepted;
+        if (fMCRecFlags[origtrack->GetID()] != kAccepted && (origtrack->GetLabel() > 0)) {
+          AliError(Form("ERROR: Accepted reconstructed track with esdid %d would be rejected due to quality tests %08X",esdid,fMCRecFlags[origtrack->GetID()]));
+//          continue;
+        }
+      }
+      /* only fill histograms if this is not an additional simulated event */
+      if (!simulated) {
+        nNoOfAccepted++;
+        fhPt->Fill(vtrack->Pt());
+        fhP->Fill(vtrack->P());
+        if (vtrack->Charge() > 0) {
+          fhPtPos->Fill(vtrack->Pt());
+          fhPPos->Fill(vtrack->P());
+        }
+        if (vtrack->Charge() < 0) {
+          fhPtNeg->Fill(vtrack->Pt());
+          fhPNeg->Fill(vtrack->P());
+        }
+        fhEtaA->Fill(vtrack->Eta());
+        fhPhiA->Fill(vtrack->Phi()*180.0/TMath::Pi());
+        fhEtaVsPhiA->Fill(vtrack->Phi()*180.0/TMath::Pi(),vtrack->Eta());
+        fhPtVsEtaA->Fill(vtrack->Eta(),vtrack->Pt());
+        fhPt3DA->Fill(vtrack->Eta(),vtrack->Phi(),vertexz,vtrack->Pt());
+        fhLambdaVsMultiplicity->Fill(ntracks,TMath::PiOver2() - vtrack->Theta());
+
+        /* fill the constrained vs not constrained histograms */
+        if (esdid < 0) {
+          fhUnConstrainedPt->Fill(origtrack->Pt());
+          fhPtDifference->Fill(vtrack->Pt() - origtrack->Pt());               ///< Constrained - unconstrained \f$ p_{T} \f$ spectrum
+        }
+      }
+
+      /* only process pair analysis if this is not an additional simulated event */
+      if (fDoProcessPairAnalysis && !simulated) {
+        /* track accepted, process pair analysis function activities */
+        fProcessPairAnalysis.ProcessTrack(i, vtrack);
+      }
+
+      /* track accepted, process correlation function activities */
+      if (fDoProcessCorrelations) {
+        fProcessCorrelations.ProcessTrack(i, vtrack);
+        /* only process rec with true values if MC and this is not an additional simulated event */
+        if (fEventCuts->IsMC() && !simulated) {
+          switch (fMCRecOption) {
+          case kRecWithTrue:
+            /* additional results with reconstructed with true values */
+            if (AliCSAnalysisCutsBase::GetMCEventHandler() != NULL) {
+              fProcessMCRecCorrelationsWithOptions.ProcessTrack(i, fMCEvent->Particle(vtrack->GetLabel()));
+            }
+            else {
+              fProcessMCRecCorrelationsWithOptions.ProcessTrack(i, (AliAODMCParticle *) arrayMC->At(vtrack->GetLabel()));
+            }
+            break;
+          case kRecTruePrimaries:
+            /* additional results with true primary reconstructed tracks */
+            if (fTrackSelectionCuts->IsTruePrimary(vtrack)) {
+              fProcessMCRecCorrelationsWithOptions.ProcessTrack(i, vtrack);
+            }
+            break;
+          case kRecWithNotAccepted:
+            /* additional results with accepted and not accepted reconstructed tracks */
+            fProcessMCRecCorrelationsWithOptions.ProcessTrack(i, vtrack);
+            break;
+          default:
+            break;
+          }
+        }
+      }
+
+      /* only process purity analysis if this is not an additional simulated event */
+      if (!simulated) {
+        /* store purity information if applicable */
+        if (fEventCuts->IsMC()) {
+          if (fTrackSelectionCuts->IsTrueTrackAccepted(vtrack)) {
+            fhPurePt->Fill(vtrack->Pt());
+            fhPureP->Fill(vtrack->P());
+            if (vtrack->Charge() > 0) {
+              fhPurePtPos->Fill(vtrack->Pt());
+              fhPurePPos->Fill(vtrack->P());
+            }
+            else {
+              fhPurePtNeg->Fill(vtrack->Pt());
+              fhPurePNeg->Fill(vtrack->P());
+            }
+          }
+        }
+      }
+    }
+    else {
+      /* track not accepted, process required correlation function activities */
+      if (fEventCuts->IsMC() && !simulated) {
+        if (fDoProcessCorrelations) {
+          switch (fMCRecOption) {
+          case kRecWithNotAccepted:
+            /* additional results with accepted and not accepted reconstructed tracks */
+            /* but only with its corresponding true accepted, for the time being */
+            if (fTrackSelectionCuts->IsTrueTrackAccepted(vtrack)) {
+              fProcessMCRecCorrelationsWithOptions.ProcessTrack(i, vtrack);
+            }
+            break;
+          default:
+            break;
+          }
+        }
+      }
+    }
+  }
+  /* only process pair analysis if this is not an additional simulated event */
+  if (fDoProcessPairAnalysis && !simulated) {
+    /* and finalize pair analysis function activities */
+    fProcessPairAnalysis.ProcessEventData();
+  }
+
+  /* and finalize correlation function activities */
+  if (fDoProcessCorrelations) {
+    fProcessCorrelations.ProcessEventData();
+    /* only process rec with true if MC and this is not an additional simulated event */
+    if (fEventCuts->IsMC() && !simulated) {
+      if (fMCRecOption != kNone) {
+        fProcessMCRecCorrelationsWithOptions.ProcessEventData();
+      }
+    }
+  }
+  /* track the event multiplicity */
+  Double_t fillmdata[2] = {Double_t(ntracks+0.5),Double_t(nNoOfAccepted+0.5)};
+  fhAcceptedVsMultiplicity->Fill(fillmdata);
+
+  AliInfo(Form("TOTAL REC ACCEPTED: %d", nNoOfAccepted));
+}
+
+/// \brief Processes the true tracks for the current event
+void AliAnalysisTaskCorrelationsStudies::ProcessTrueTracks() {
+
+  AliInfo("");
+
+  Double_t vertexz = 0.0;
+  if (AliCSAnalysisCutsBase::GetMCEventHandler() != NULL) {
+    vertexz = fMCEvent->GetPrimaryVertex()->GetZ();
+  }
+  else {
+    AliVEvent *event = InputEvent();
+    AliAODMCHeader *header = (AliAODMCHeader *) event->FindListObject(AliAODMCHeader::StdBranchName());
+    vertexz = header->GetVtxZ();
+  }
+
+  Double_t centrality = fEventCuts->GetCentrality();
+
+  if (fDoProcessPairAnalysis) {
+    /* initialize pair analysis function activities */
+    if (!fProcessTruePairAnalysis.StartEvent(vertexz)) return;
+  }
+
+ /* initialize correlation function activities */
+  /* reject event if not correctly initialized */
+  if (fDoProcessCorrelations) {
+    if (!fProcessTrueCorrelations.StartEvent(centrality,vertexz)) return;
+  }
+
+  Int_t nNoOfTrueReconstructedAndAccepted = 0;
+  Int_t nNoOfTrueAccepted = 0;
+  Int_t nNoOfTrueMultiReconstructedAndAccepted = 0;
+  Int_t nNoOfReconstructed = InputEvent()->GetNumberOfTracks();
+  Int_t nNoOfTrue = GetNoOfTrueParticles();
+  Int_t nNoOfPrimaries = GetNoOfTruePrimaries();
+
+
+  Int_t ntracks = GetNoOfTrueParticles();
+  TClonesArray *arrayMC = NULL;
+  if (AliCSAnalysisCutsBase::GetMCEventHandler() == NULL) arrayMC = AliCSAnalysisCutsBase::GetMCTrueArray();
+  for(Int_t iTrack = 0; iTrack < ntracks; iTrack++ ){
+
+    if (fTrackSelectionCuts->IsTrueTrackAccepted(iTrack)) {
+      TParticle *esdpart = NULL;
+      AliAODMCParticle *aodpart = NULL;
+      Double_t p = 0.0;
+      Double_t pt = 0.0;
+      Double_t pz = 0.0;
+      Double_t eta = 0.0;
+      Double_t phi = 0.0;
+      Double_t charge = 0.0;
+      AliPID::EParticleType species = AliPID::kUnknown;
+
+      /* extract the true particle according to the ESD or AOD format */
+      if (AliCSAnalysisCutsBase::GetMCEventHandler() != NULL) {
+        esdpart = fMCEvent->Particle(iTrack);
+
+        p = esdpart->P();
+        pt = esdpart->Pt();
+        pz = esdpart->Pz();
+        eta = esdpart->Eta();
+        phi = esdpart->Phi();
+        charge = esdpart->GetPDG()->Charge();
+        species = AliCSPIDCuts::GetTrueSpecies(esdpart);
+      }
+      else {
+        aodpart = (AliAODMCParticle *) arrayMC->At(iTrack);
+
+        p = aodpart->P();
+        pt = aodpart->Pt();
+        pz = aodpart->Pz();
+        eta = aodpart->Eta();
+        phi = aodpart->Phi();
+        charge = aodpart->Charge();
+        species = AliCSPIDCuts::GetTrueSpecies(aodpart);
+      }
+
+
+      Double_t filldata[kgTHnDimension] = {pt,eta,phi*180.0/TMath::Pi(),
+          (AliPID::kProton < species) ?  AliPID::kSPECIES + 0.5 : species + 0.5};
+
+      /* the analysis just for the charged particles */
+      if (charge != 0.0) {
+        /* enforce efficiency on true if required */
+        switch (fOnTrueEfficiencyProfile) {
+        case kEfficiencyProfile:
+          /* use the stored efficiency profile */
+          if (charge > 0) {
+            if (fRandomGenerator->Uniform(1.0) > fhOnTrueEfficiencyProfile_1->GetBinContent(
+                fhOnTrueEfficiencyProfile_1->FindBin(eta,pt))) {
+              continue;
+            }
+          }
+          else {
+            if (fRandomGenerator->Uniform(1.0) > fhOnTrueEfficiencyProfile_2->GetBinContent(
+                fhOnTrueEfficiencyProfile_2->FindBin(eta,pt))) {
+              continue;
+            }
+          }
+          break;
+        case kOnlyReconstructed:
+          /* incorporate only tracks which were reconstructed */
+          if (fTrueToRec->At(iTrack) == NULL) {
+            /* not reconstructed so, skip it */
+            continue;
+          }
+          break;
+        default:
+          break;
+        }
+
+        nNoOfTrueAccepted++;
+        if (fTrueToRec->At(iTrack) != NULL) {
+          /* true was reconstructed, let's check whether it was accepted */
+          if ((fMCRecFlags[((AliVTrack *) fTrueToRec->At(iTrack))->GetID()] & kAccepted) == kAccepted) {
+            /* the reconstructed was accepted so, what? */
+            nNoOfTrueReconstructedAndAccepted++;
+            if ((fMCRecFlags[((AliVTrack *) fTrueToRec->At(iTrack))->GetID()] & kSamePositiveLabel) == kSamePositiveLabel) {
+              nNoOfTrueMultiReconstructedAndAccepted++;
+              fhPtTrueMultiRec->Fill(pt);
+            }
+          }
+          else {
+            /* the reconstructed was not accepted */
+            fhTrueRecNotAccepted->Fill(filldata);
+          }
+        }
+        else {
+          /* the track was not reconstructed */
+          fhTrueNotReconstructed->Fill(filldata);
+        }
+
+        fhTruePt->Fill(pt);
+        fhTrueP->Fill(p);
+        fhTrueEta->Fill(eta);
+        fhTruePhi->Fill(phi*180.0/TMath::Pi());
+        fhTrueEtaVsPhi->Fill(phi*180.0/TMath::Pi(), eta);
+        fhTruePtVsEta->Fill(eta,pt);
+        fhTruePt3D->Fill(eta,phi,vertexz,pt);
+        if (charge > 0) {
+          fhTruePtPos->Fill(pt);
+          fhTruePPos->Fill(p);
+          Double_t theta = ((pz == 0.0) ? TMath::PiOver2() : TMath::ACos(pz/p));
+          fhTrueLambdaVsPrimaries->Fill(nNoOfPrimaries,TMath::PiOver2() - theta);
+        }
+        else {
+          fhTruePtNeg->Fill(pt);
+          fhTruePNeg->Fill(p);
+          Double_t theta = ((pz == 0) ? TMath::PiOver2() : TMath::ACos(pz/p));
+          fhTrueLambdaVsPrimaries->Fill(nNoOfPrimaries,TMath::PiOver2() - theta);
+        }
+        if (fDoProcessPairAnalysis) {
+          /* track accepted, process pair analysis function activities */
+          if (aodpart != NULL) {
+            fProcessTruePairAnalysis.ProcessTrack(iTrack, aodpart);
+          }
+          else {
+            fProcessTruePairAnalysis.ProcessTrack(iTrack, esdpart);
+          }
+        }
+        /* track accepted, process correlation function activities */
+        if (fDoProcessCorrelations) {
+          if (aodpart != NULL) {
+            fProcessTrueCorrelations.ProcessTrack(iTrack, aodpart);
+          }
+          else {
+            fProcessTrueCorrelations.ProcessTrack(iTrack, esdpart);
+          }
+        }
+      }
+    }
+  }
+  if (fDoProcessPairAnalysis) {
+    /* and finalize pair analysis function activities */
+    fProcessTruePairAnalysis.ProcessEventData();
+  }
+  /* and finalize correlation function activities */
+  if (fDoProcessCorrelations) {
+    fProcessTrueCorrelations.ProcessEventData();
+  }
+
+  if (nNoOfTrueMultiReconstructedAndAccepted != 0)
+    fhTrueMultiRec->Fill(nNoOfTrueMultiReconstructedAndAccepted+0.5);
+
+  /* track the event multiplicity */
+  Double_t fillmdata[2] = {Double_t(nNoOfPrimaries+0.5),Double_t(nNoOfTrueAccepted+0.5)};
+  fhTrueAcceptedVsPrimaries->Fill(fillmdata);
+
+  AliInfo(Form("TOTAL TRUE: %d; TOTAL TRUE PRIMARIES: %d; TOTAL TRUE ACCEPTED: %d",
+      nNoOfTrue, nNoOfPrimaries, nNoOfTrueAccepted));
+  AliInfo(Form("TOTAL REC: %d; TOTAL TRUE REC AND ACC: %d; TOTAL TRUE ACC MULTI REC: %d",
+      nNoOfReconstructed, nNoOfTrueReconstructedAndAccepted, nNoOfTrueMultiReconstructedAndAccepted));
+}
+
+/// The analysis task is going to finish. Produce the final results to be preserved.
+void AliAnalysisTaskCorrelationsStudies::FinishTaskOutput() {
+
+  AliInfo("Starting!");
+
+  if (fDoProcessPairAnalysis) {
+    fProcessPairAnalysis.FinalizeProcess();
+    if (fEventCuts->IsMC()) {
+      fProcessTruePairAnalysis.FinalizeProcess();
+    }
+  }
+
+  if (fDoProcessCorrelations) {
+    fProcessCorrelations.FinalizeProcess();
+    if (fEventCuts->IsMC()) {
+      if (fMCRecOption != kNone) {
+        fProcessMCRecCorrelationsWithOptions.FinalizeProcess();
+      }
+      fProcessTrueCorrelations.FinalizeProcess();
+    }
+  }
+
+  if (fDoProcessCorrelations) {
+    PostData(2, fProcessCorrelations.GetHistogramsList()); // Post data for ALL output slots >0 here, to get at least an empty histogram
+    if (fEventCuts->IsMC()) {
+      if (fMCRecOption != kNone) {
+        PostData(3, fProcessMCRecCorrelationsWithOptions.GetHistogramsList()); // Post data for ALL output slots >0 here, to get at least an empty histogram
+      }
+      PostData(4, fProcessTrueCorrelations.GetHistogramsList()); // Post data for ALL output slots >0 here, to get at least an empty histogram
+    }
+  }
+
+  AliInfo("Done!");
+}
+
+/// The local task is terminated. We do nothing for the time being
+void AliAnalysisTaskCorrelationsStudies::Terminate(Option_t *)
+{
+  /* take it away for the time being */
+  if (kFALSE) {
+    // Draw result to screen, or perform fitting, normalizations
+    // Called once at the end of the query
+    fOutput = dynamic_cast<TList*> (GetOutputData(1));
+    if(!fOutput) { AliError("ERROR: could not retrieve TList fOutput"); return; }
+
+    fhPt = dynamic_cast<TH1F*> (fOutput->FindObject("fHistPt"));
+    if (!fhPt) { AliError("ERROR: could not retrieve fHistPt"); return;}
+    fhEtaA = dynamic_cast<TH1F*> (fOutput->FindObject("fHistEtaA"));
+    if (!fhEtaA) { AliError("ERROR: could not retrieve fHistEtaA"); return;}
+
+    // Get the physics selection histograms with the selection statistics
+    //AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+    //AliESDInputHandler *inputH = dynamic_cast<AliESDInputHandler*>(mgr->GetInputEventHandler());
+    //TH2F *histStat = (TH2F*)inputH->GetStatistics();
+
+
+    // NEW HISTO should be retrieved from the TList container in the above way,
+    // so it is available to draw on a canvas such as below
+
+    TCanvas *c = new TCanvas("AliAnalysisTaskCorrelationsStudies","P_{T} & #eta",10,10,1020,510);
+    c->Divide(2,1);
+    c->cd(1)->SetLogy();
+    fhPt->DrawCopy("E");
+    c->cd(2);
+    fhEtaA->DrawCopy("E");
+  }
+}

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliAnalysisTaskCorrelationsStudies.h
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliAnalysisTaskCorrelationsStudies.h
@@ -1,0 +1,204 @@
+/* Copyright(c) 1998-2016, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
+
+/* AliAnalysisTaskCorrelationsStudies.h
+ *
+ * Template task producing a P_t spectrum and pseudorapidity distribution.
+ * Includes explanations of physics and primary track selections
+ *
+ * Based on tutorial example from offline pages
+ * Edited by Arvinder Palaha
+ */
+#ifndef ALIANALYSISTASKCORRELATIONSSTUDIES_H
+#define ALIANALYSISTASKCORRELATIONSSTUDIES_H
+
+class TF1;
+class TH1F;
+class TH2F;
+class TH3F;
+class THn;
+class TProfile3D;
+class TObjArray;
+class TList;
+class TRandom3;
+
+#include <THnSparse.h>
+
+#include "AliCSEventCuts.h"
+#include "AliCSTrackSelection.h"
+#include "AliAnalysisTaskSE.h"
+#include "AliDptDptCorrelations.h"
+#include "AliCSPairAnalysis.h"
+
+/// class AliAnalysisTaskCorrelationsStudies
+/// \brief Analysis task for two particle correlations
+///
+/// \author Víctor González <victor.gonzalez@cern.ch>, UCM
+/// \date Oct 17, 2016
+
+
+
+class AliAnalysisTaskCorrelationsStudies : public AliAnalysisTaskSE {
+ public:
+                                AliAnalysisTaskCorrelationsStudies();
+                                AliAnalysisTaskCorrelationsStudies(const char *name);
+    virtual                    ~AliAnalysisTaskCorrelationsStudies();
+
+    virtual void                UserCreateOutputObjects();
+    virtual void                NotifyRun();
+    virtual void                UserExec(Option_t *option);
+    virtual void                FinishTaskOutput();
+    virtual void                Terminate(Option_t *);
+
+
+    Bool_t                      Configure(const char *confstring);
+    Bool_t                      ConfigureCorrelations(const char *confstring, const char *weighthistpattern, TString &szContainerPrefix);
+    Bool_t                      ConfigureCorrelationsBinning(const char *confstring);
+
+ private:
+    const char                 *ProduceConfigurationString();
+    virtual void                ProcessTracks(Bool_t simactive);
+    virtual void                ProcessTrueTracks();
+    Bool_t                      BuildEfficiencyProfiles();
+    void                        BuildTrueRecRelation();
+    void                        BuildTrueRecAccRelation();
+    Int_t                       GetNoOfTruePrimaries();
+    Int_t                       GetNoOfTrueParticles();
+    Int_t                       GetNoOfMCRecTracks();
+
+ private:
+    /// \enum mcRecOptions
+    /// \brief The options for additional rec analysis
+    ///
+    /// There is an additional analysis able to be done with
+    /// reconstructed tracks. These are the options for it
+    enum mcRecOptions {
+      kNone = 0,                                              ///< no additional analysis with reconstructed tracks
+      kRecWithTrue,                                           ///< additional analysis with rec tracks using true values
+      kRecTruePrimaries,                                      ///< additional analysis with rec tracks but using only the ones corresponding to true primaries
+      kRecWithNotAccepted                                     ///< additional analysis with rec tracks incorporating the reconstructed which were not accepted
+    };
+
+    /// \enum trackQualityFlags
+    /// \brief Flags for keeping track of track quality
+    enum trackQualityFlags {
+      kAccepted =           0x0001,                           ///< the track has been accepted
+      kNoTrack =            0x0002,                           ///< the track has been accepted
+      kFromInjectedSignal = 0x0004,                           ///< the track has been accepted
+      kSamePositiveLabel =  0x0010,                           ///< the track has been accepted
+      kNegativeLabel =      0x0020,                           ///< the track has been accepted
+      kSameNegativeLabel =  0x0040                            ///< the track has been accepted
+    };
+
+    /// \enum onTrueEfficiencyOptions
+    /// \brief Options for applying efficiency criteria on true tracks
+    enum onTrueEfficiencyOptions {
+      kNoEfficiencyOnTrue = 0,                                ///< no efficiency on true tracks, consider all of them within the acceptance
+      kEfficiencyProfile  = 1,                                ///< apply an efficiency profile
+      kOnlyReconstructed  = 2                                 ///< only consider true tracks which have been reconstructed
+    };
+
+    TList                      *fOutput;                      ///< Output histograms list
+    TString                     fTaskConfigurationString;     ///< the task configuration string
+    TString                     fTaskActivitiesString;        ///< the activities to perform by the task
+    TString                     fEventCutsString;             ///< the event cuts string of characters
+    TString                     fEfficiencyProfileToEnforce;  ///< the efficiency profile to enforce
+    TString                     fEfficiencyProfileOnTrue;     ///< the efficiency profile to enforce on true data
+    TString                     fAdditionalMCRecOption;       ///< the option for the additional MC rec results
+    TString                     fTrackSelectionString;        ///< the track selection cuts string
+    AliCSEventCuts             *fEventCuts;                   ///< the event cuts
+    AliCSTrackSelection        *fTrackSelectionCuts;          ///< track cuts to select tracks
+
+    Bool_t                      fEnforceEfficiencyProfile;    ///< enforce the efficiency profile, only valid for MC analysis
+    onTrueEfficiencyOptions     fOnTrueEfficiencyProfile;     ///< enforce efficiency on true data, only valid for MC analysis
+    Bool_t                      fCorrectOnTrueEfficiency;     ///< use the efficiency profile on true data for efficiency correction on true
+    Bool_t                      fDoProcessCorrelations;       ///< perform the correlation analysis data collection
+    Bool_t                      fDoProcessPairAnalysis;       ///< perform the pairs analysis data collection
+    mcRecOptions                fMCRecOption;                 ///< options for the additional MC rec results
+    AliDptDptCorrelations       fProcessCorrelations;         ///< the processing correlations instance
+    AliDptDptCorrelations       fProcessMCRecCorrelationsWithOptions; ///< the processing correlations instance for MC rec with additional options
+    AliDptDptCorrelations       fProcessTrueCorrelations;     ///< the processing correlations instance for MC truth
+    AliCSPairAnalysis           fProcessPairAnalysis;         ///< the processing pairs analysis instance
+    AliCSPairAnalysis           fProcessTruePairAnalysis;     ///< the processing pairs analysis instance for MC truth
+    TF1                        *ffEfficiencyProfile;          ///< the formula for the efficiency profile to enforce
+    TRandom3                   *fRandomGenerator;             ///< the random generator object instance for enforcing the efficiency profile
+    TH3F                       *fhWeightsTrack_1;             ///< the weights histogram for track one
+    TH3F                       *fhWeightsTrack_2;             ///< the weights histogram for track two
+    TH1F                       *fhEffCorrTrack_1;             ///< the efficiency correction for track one
+    TH1F                       *fhEffCorrTrack_2;             ///< the efficiency correction for track two
+    THn                        *fhPairEfficiency_PP;          ///< the plus plus pair efficiency
+    THn                        *fhPairEfficiency_PM;          ///< the plus minus pair efficiency
+    THn                        *fhPairEfficiency_MM;          ///< the minus minus pair efficiency
+    THn                        *fhPairEfficiency_MP;          ///< the minus plus pair efficiency
+    TObjArray                  *fPositiveTrackPdf;            ///< the distribution of positive tracks for simulation
+    TObjArray                  *fNegativeTrackPdf;            ///< the distribution of negative tracks for simulation
+    TObjArray                  *fTrueToRec;                   ///< the true to reconstructed association, via label
+    TObjArray                  *fTrueToRecWrong;              ///< the true to reconstructed association, via negative label
+    UInt_t                     *fMCRecFlags;                  //!<! the flags which qualify MC reconstructed tracks
+    UInt_t                     *fMCTruePrimaryFlags;          //!<! the flags which qualify MC primary true tracks
+    Int_t                       fMCFlagsStorageSize;          ///< the size of the MC flags storage
+
+    TH2F                       *fhOnTrueEfficiencyProfile_1;  ///< the histogram for the efficiency profile on true data for track one
+    TH2F                       *fhOnTrueEfficiencyProfile_2;  ///< the histogram for the efficiency profile on true data for track two
+    TH1F                       *fhPt;                         ///< \f$ p_{T} \f$ spectrum
+    TH1F                       *fhPtPos;                      ///< \f$ p_{T} \f$ spectrum for positive tracks
+    TH1F                       *fhPtNeg;                      ///< \f$ p_{T} \f$ spectrum for negative tracks
+    TH1F                       *fhP;                          ///< \f$ p \f$ spectrum
+    TH1F                       *fhPPos;                       ///< \f$ p \f$ spectrum for positive tracks
+    TH1F                       *fhPNeg;                       ///< \f$ p \f$ spectrum for negative tracks
+    TH1F                       *fhTruePt;                     ///< True \f$ p_{T} \f$ spectrum
+    TH1F                       *fhTruePtPos;                  ///< True \f$ p_{T} \f$ spectrum for positive tracks
+    TH1F                       *fhTruePtNeg;                  ///< True \f$ p_{T} \f$ spectrum for negative tracks
+    TH1F                       *fhTrueP;                      ///< True \f$ p \f$ spectrum
+    TH1F                       *fhTruePPos;                   ///< True \f$ p \f$ spectrum for positive tracks
+    TH1F                       *fhTruePNeg;                   ///< True \f$ p \f$ spectrum for negative tracks
+    TH1F                       *fhPurePt;                     ///< \f$ p_{T} \f$ spectrum with good PID
+    TH1F                       *fhPurePtPos;                  ///< \f$ p_{T} \f$ spectrum for positive tracks with good PID
+    TH1F                       *fhPurePtNeg;                  ///< \f$ p_{T} \f$ spectrum for negative tracks with good PID
+    TH1F                       *fhPureP;                      ///< \f$ p \f$ spectrum with good PID
+    TH1F                       *fhPurePPos;                   ///< \f$ p \f$ spectrum for positive tracks with good PID
+    TH1F                       *fhPurePNeg;                   ///< \f$ p \f$ spectrum for negative tracks with good PID
+    TH1F                       *fhUnConstrainedPt;            ///< not constrained \f$ p_{T} \f$ spectrum
+    TH1F                       *fhPtDifference;               ///< Constrained - unconstrained \f$ p_{T} \f$ spectrum
+    TH1F                       *fhEtaB;                       ///< pseudorapidity spectrum before any cut
+    TH1F                       *fhEtaA;                       ///< pseudorapidity spectrum after cuts
+    TH1F                       *fhTrueEta;                    ///< True pseudorapidity spectrum
+    TH1F                       *fhPhiB;                       ///< \f$ \phi \f$ before any cut
+    TH1F                       *fhPhiA;                       ///< \f$ \phi \f$ after all cuts
+    TH1F                       *fhTruePhi;                    ///< True \f$ \phi \f$
+    TH2F                       *fhEtaVsPhiB;                  ///< \f$ \eta \f$ vs \f$ \phi \f$ before any cut
+    TH2F                       *fhEtaVsPhiA;                  ///< \f$ \eta \f$ vs \f$ \phi \f$ after all cuts
+    TH2F                       *fhTrueEtaVsPhi;               ///< True \f$ \eta \f$ vs \f$ \phi \f$
+    TH2F                       *fhPtVsEtaB;                   ///< \f$ p_{T} \f$ vs \f$ \eta \f$ before any cut
+    TH2F                       *fhPtVsEtaA;                   ///< \f$ p_{T} \f$ vs \f$ \eta \f$ after all cuts
+    TH2F                       *fhTruePtVsEta;                ///< True\f$ p_{T} \f$ vs \f$ \eta \f$
+    TProfile3D                 *fhPt3DB;                      ///< \f$ \Sigma p_{T} \f$ vs  \f$ \eta \f$, \f$ \phi \f$ and \f$ vtx_{z} \f$ before any cut
+    TProfile3D                 *fhPt3DA;                      ///< \f$ \Sigma p_{T} \f$ vs  \f$ \eta \f$, \f$ \phi \f$ and \f$ vtx_{z} \f$ after all cuts
+    TProfile3D                 *fhTruePt3D;                   ///< True \f$ \Sigma p_{T} \f$ vs  \f$ \eta \f$, \f$ \phi \f$ and \f$ vtx_{z} \f$
+    TH2I                       *fhLambdaVsMultiplicity;       ///< track lambda angle vs event multiplicity
+    THnSparseI                 *fhAcceptedVsMultiplicity;     ///< number of accepted tracks vs event multiplicity (rec tracks)
+    TH2I                       *fhTrueLambdaVsPrimaries;      ///< True track lambda angle vs primary tracks
+    THnSparseI                 *fhTrueAcceptedVsPrimaries;    ///< True number of accepted tracks vs primary tracks
+    static const Int_t          kgTHnDimension;               ///< The dimension of the THn histograms
+    THnSparseI                 *fhTrueRecNotAccepted;         ///< True histograms of reconstructed tracks not accepted
+    THnSparseI                 *fhTrueNotReconstructed;       ///< True histograms of not reconstructed tracks
+    TH1I                       *fhTrueMultiRec;               ///< Number of true multi reconstructed tracks histogram
+    TH1I                       *fhPtTrueMultiRec;             ///< pT of true multi reconstructed tracks histogram
+
+    // NEW HISTO to be declared here
+
+    /// Copy constructor
+    /// Not allowed. Forced private.
+    AliAnalysisTaskCorrelationsStudies(const AliAnalysisTaskCorrelationsStudies&); // not implemented
+    /// Assignment operator
+    /// Not allowed. Forced private.
+    /// \return l-value reference object
+    AliAnalysisTaskCorrelationsStudies& operator=(const AliAnalysisTaskCorrelationsStudies&); // not implemented
+
+    /// \cond CLASSIMP
+    ClassDef(AliAnalysisTaskCorrelationsStudies, 3);
+    /// \endcond
+};
+
+#endif /* ALIANALYSISTASKCORRELATIONSSTUDIES_h */
+

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSAnalysisCutsBase.cxx
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSAnalysisCutsBase.cxx
@@ -1,0 +1,734 @@
+/**************************************************************************
+* Copyright(c) 1998-2016, ALICE Experiment at CERN, All rights reserved.  *
+*                                                                         *
+* Permission to use, copy, modify and distribute this software and its    *
+* documentation strictly for non-commercial purposes is hereby granted    *
+* without fee, provided that the above copyright notice appears in all    *
+* copies and that both the copyright notice and this permission notice    *
+* appear in the supporting documentation. The authors make no claims      *
+* about the suitability of this software for any purpose. It is           *
+* provided "as is" without express or implied warranty.                   *
+**************************************************************************/
+
+#include <TTree.h>
+#include <TFile.h>
+#include "AliLog.h"
+#include "AliProdInfo.h"
+#include "AliAnalysisManager.h"
+#include "AliVEvent.h"
+#include "AliCSAnalysisCutsBase.h"
+#include "AliMCEventHandler.h"
+#include "AliInputEventHandler.h"
+#include "AliMultiInputEventHandler.h"
+
+/// \file AliCSAnalysisCutsBase.cxx
+/// \brief Implementation of base analysis cuts class within the correlation studies analysis
+
+TString                             AliCSAnalysisCutsBase::fgPeriodName = "";
+AliCSAnalysisCutsBase::ProdPeriods  AliCSAnalysisCutsBase::fgDataPeriod = AliCSAnalysisCutsBase::kNoPeriod;
+AliCSAnalysisCutsBase::ProdPeriods  AliCSAnalysisCutsBase::fgAnchorPeriod = AliCSAnalysisCutsBase::kNoPeriod;
+AliCSAnalysisCutsBase::EnergyValue  AliCSAnalysisCutsBase::fgEnergy = AliCSAnalysisCutsBase::kUnset;
+Bool_t                              AliCSAnalysisCutsBase::fgIsMC = kFALSE;
+AliInputEventHandler               *AliCSAnalysisCutsBase::fgInputHandler = NULL;
+AliMCEventHandler                  *AliCSAnalysisCutsBase::fgMCHandler = NULL;
+Bool_t                              AliCSAnalysisCutsBase::fgIsESD = kTRUE;
+TClonesArray                       *AliCSAnalysisCutsBase::fgMCArray = NULL;
+
+/// Default constructor for serialization
+AliCSAnalysisCutsBase::AliCSAnalysisCutsBase() :
+    TNamed(),
+    fNParams(0),
+    fCutsString(NULL),
+    fNCuts(0),
+    fQALevel(kQALevelLight),
+    fParameters(NULL),
+    fCutsEnabledMask(TBits()),
+    fCutsActivatedMask(TBits()),
+    fDataPeriod(kNoPeriod),
+    fHistogramsList(NULL)
+{
+}
+
+/// Constructor
+/// Allocates the needed memory for the number of cuts to support
+/// \param nCuts the number of cuts to support
+/// \param nParams the number of cuts parameters
+/// \param name name of the event cuts
+/// \param title title of the event cuts
+AliCSAnalysisCutsBase::AliCSAnalysisCutsBase(Int_t nCuts, Int_t nParams, const char *name, const char *title) :
+    TNamed(name,title),
+    fNParams(nParams),
+    fNCuts(nCuts),
+    fQALevel(kQALevelLight),
+    fCutsEnabledMask(TBits(nCuts)),
+    fCutsActivatedMask(TBits(nCuts)),
+    fDataPeriod(kNoPeriod),
+    fHistogramsList(NULL)
+{
+  fParameters = new Int_t[nParams];
+  fCutsString = new Char_t[nParams+1];
+  for (Int_t i=0;i<nParams;i++) {fParameters[i]=0;}
+  for (Int_t i=0;i<nParams;i++) {fCutsString[i]='0';} fCutsString[nParams]='\0';
+  fCutsEnabledMask.ResetAllBits();
+  fCutsActivatedMask.ResetAllBits();
+}
+
+/// Destructor
+AliCSAnalysisCutsBase::~AliCSAnalysisCutsBase()
+{
+  if (fParameters != NULL) delete [] fParameters;
+  if (fCutsString != NULL) delete [] fCutsString;
+}
+
+/// The run to analyze has potentially changed
+///
+/// Stores the needed production information if required
+void AliCSAnalysisCutsBase::NotifyRunGlobal() {
+
+  TString szLHCPeriod = GetPeriodNameFromDataFilePath();
+
+  /* if period has not changed do nothing */
+  if (szLHCPeriod.EqualTo(fgPeriodName)) return;
+
+  /* period name has changed */
+  AliInfoClass(Form("Data period has changed. New data period: %s", szLHCPeriod.Data()));
+  fgPeriodName = szLHCPeriod;
+  fgDataPeriod = kNoPeriod;
+  fgAnchorPeriod = kNoPeriod;
+  fgIsMC = kFALSE;
+  fgEnergy = kUnset;
+
+  if (szLHCPeriod.CompareTo("LHC10b") == 0 ||
+      szLHCPeriod.CompareTo("LHC10c") == 0 ||
+      szLHCPeriod.CompareTo("LHC10d") == 0 ||
+      szLHCPeriod.CompareTo("LHC10e") == 0 ||
+      szLHCPeriod.CompareTo("LHC10f") == 0 ||
+      szLHCPeriod.CompareTo("LHC10g") == 0)
+  {
+    fgDataPeriod = kLHC10bg;
+    fgAnchorPeriod = kLHC10bg;
+    fgEnergy = k7TeV;
+  } else if (szLHCPeriod.CompareTo("LHC10h") == 0) {
+    fgDataPeriod = kLHC10h;
+    fgAnchorPeriod = kLHC10h;
+    fgEnergy = kPbPb2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC11a") == 0) {
+    fgDataPeriod = kLHC11a;
+    fgEnergy = k2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC11b") == 0) {
+    fgDataPeriod = kLHC11b;
+    fgAnchorPeriod = kLHC11b;
+    fgEnergy = k7TeV;
+  } else if (szLHCPeriod.CompareTo("LHC11c") == 0 ||
+      szLHCPeriod.CompareTo("LHC11d") == 0 ||
+      szLHCPeriod.CompareTo("LHC11e") == 0 ||
+      szLHCPeriod.CompareTo("LHC11f") == 0 ||
+      szLHCPeriod.CompareTo("LHC11g") == 0)
+  {
+    fgDataPeriod = kLHC11cg;
+    fgAnchorPeriod = kLHC11cg;
+    fgEnergy = k7TeV;
+  } else if (szLHCPeriod.CompareTo("LHC11h") == 0) {
+    fgDataPeriod = kLHC11h;
+    fgAnchorPeriod = kLHC11h;
+    fgEnergy = kPbPb2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC12a") == 0 ||
+      szLHCPeriod.CompareTo("LHC12b") == 0 ||
+      szLHCPeriod.CompareTo("LHC12c") == 0 ||
+      szLHCPeriod.CompareTo("LHC12d") == 0 ||
+      szLHCPeriod.CompareTo("LHC12e") == 0 ||
+      szLHCPeriod.CompareTo("LHC12f") == 0 ||
+      szLHCPeriod.CompareTo("LHC12g") == 0 ||
+      szLHCPeriod.CompareTo("LHC12h") == 0 ||
+      szLHCPeriod.CompareTo("LHC12i") == 0)
+  {
+    fgDataPeriod = kLHC12;
+    fgAnchorPeriod = kLHC12;
+    fgEnergy = k8TeV;
+  } else if (szLHCPeriod.CompareTo("LHC13b") == 0 ||
+      szLHCPeriod.CompareTo("LHC13c") == 0 ){
+    fgDataPeriod = kLHC13bc;
+    fgAnchorPeriod = kLHC13bc;
+    fgEnergy = kpPb5TeV;
+  } else if (szLHCPeriod.CompareTo("LHC13d") == 0 ||
+      szLHCPeriod.CompareTo("LHC13e") == 0 ){
+    fgDataPeriod = kLHC13de;
+    fgAnchorPeriod = kLHC13de;
+    fgEnergy = kpPb5TeV;
+  } else if (szLHCPeriod.CompareTo("LHC13f") == 0 ){
+    fgDataPeriod = kLHC13f;
+    fgAnchorPeriod = kLHC13f;
+    fgEnergy = kpPb5TeV;
+  } else if (szLHCPeriod.CompareTo("LHC13g") == 0 ){
+    fgDataPeriod = kLHC13g;
+    fgAnchorPeriod = kLHC13g;
+    fgEnergy = k2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC15f") == 0 ||
+      szLHCPeriod.CompareTo("LHC15g") == 0 ||
+      szLHCPeriod.CompareTo("LHC15h") == 0 ||
+      szLHCPeriod.CompareTo("LHC15i") == 0 ||
+      szLHCPeriod.CompareTo("LHC15j") == 0 ||
+      szLHCPeriod.CompareTo("LHC15k") == 0 ||
+      szLHCPeriod.CompareTo("LHC15l") == 0 ||
+      szLHCPeriod.CompareTo("LHC15m") == 0) {
+    fgDataPeriod = kLHC15fm;
+    fgAnchorPeriod = kLHC15fm;
+    fgEnergy = k13TeV;
+  } else if (szLHCPeriod.CompareTo("LHC15n") == 0 ){
+    fgDataPeriod = kLHC15n;
+    fgAnchorPeriod = kLHC15n;
+    fgEnergy = k5TeV;
+  } else if (szLHCPeriod.CompareTo("LHC15o") == 0 ){
+    /* we need to check if LIR or HIR                     */
+    /* we do that by checking against the LIR run numbers */
+    switch (GetCurrentRunNumber()) {
+    case 244918:
+    case 244975:
+    case 244980:
+    case 244982:
+    case 244983:
+    case 245061:
+    case 245064:
+    case 245066:
+    case 245068:
+    case 246390:
+    case 246391:
+    case 246392:
+      fgDataPeriod = kLHC15oLIR;
+      fgAnchorPeriod = kLHC15oLIR;
+      break;
+    default:
+      fgDataPeriod = kLHC15oHIR;
+      fgAnchorPeriod = kLHC15oHIR;
+    }
+    fgEnergy = kPbPb5TeV;
+  // LHC16 pp periods
+  } else if (szLHCPeriod.CompareTo("LHC16k") == 0) {
+    fgDataPeriod = kLHC16k;
+    fgAnchorPeriod = kLHC16k;
+    fgEnergy = k13TeV;
+
+  } else if (szLHCPeriod.CompareTo("LHC16l") == 0) {
+    fgDataPeriod = kLHC16l;
+    fgAnchorPeriod = kLHC16l;
+    fgEnergy = k13TeV;
+
+  // LHC10x anchored MCs
+  } else if (szLHCPeriod.CompareTo("LHC10d1") == 0){
+    fgDataPeriod = kLHC10d1;
+    fgAnchorPeriod = kLHC10bg;
+    fgIsMC = kTRUE;
+    fgEnergy = k7TeV;
+  } else if (szLHCPeriod.CompareTo("LHC10d2") == 0){
+    fgDataPeriod = kLHC10d2;
+    fgAnchorPeriod = kLHC10bg;
+    fgIsMC = kTRUE;
+    fgEnergy = k7TeV;
+  } else if (szLHCPeriod.CompareTo("LHC10d4a") == 0){
+    fgDataPeriod = kLHC10d4a;
+    fgIsMC = kTRUE;
+    fgAnchorPeriod = kLHC10bg;
+    fgEnergy = k7TeV;
+  } else if (szLHCPeriod.CompareTo("LHC10d4") == 0){
+    fgDataPeriod = kLHC10d4;
+    fgAnchorPeriod = kLHC10bg;
+    fgIsMC = kTRUE;
+    fgEnergy = k7TeV;
+  } else if (szLHCPeriod.CompareTo("LHC10e12") == 0){
+    fgDataPeriod = kLHC10e12;
+    fgAnchorPeriod = kLHC10bg;
+    fgIsMC = kTRUE;
+    fgEnergy = k900GeV;
+  } else if (szLHCPeriod.CompareTo("LHC10e13") == 0){
+    fgDataPeriod = kLHC10e13;
+    fgAnchorPeriod = kLHC10bg;
+    fgIsMC = kTRUE;
+    fgEnergy = k900GeV;
+  } else if (szLHCPeriod.CompareTo("LHC10e20") == 0){
+    fgDataPeriod = kLHC10e20;
+    fgAnchorPeriod = kLHC10bg;
+    fgIsMC = kTRUE;
+    fgEnergy = k7TeV;
+  } else if (szLHCPeriod.CompareTo("LHC10e21") == 0){
+    fgDataPeriod = kLHC10e21;
+    fgAnchorPeriod = kLHC10bg;
+    fgIsMC = kTRUE;
+    fgEnergy = k7TeV;
+  } else if (szLHCPeriod.CompareTo("LHC10f6a") == 0){
+    fgDataPeriod = kLHC10f6a;
+    fgAnchorPeriod = kLHC10bg;
+    fgIsMC = kTRUE;
+    fgEnergy = k7TeV;
+  } else if (szLHCPeriod.CompareTo("LHC10f6") == 0){
+    fgDataPeriod = kLHC10f6;
+    fgAnchorPeriod = kLHC10bg;
+    fgIsMC = kTRUE;
+    fgEnergy = k7TeV;
+  } else if (szLHCPeriod.Contains("LHC14j4")){
+    fgDataPeriod = kLHC14j4;
+    fgAnchorPeriod = kLHC10bg;
+    fgIsMC = kTRUE;
+    fgEnergy = k7TeV;
+  } else if (szLHCPeriod.CompareTo("LHC11a10a") == 0){
+    fgDataPeriod = kLHC11a10a;
+    fgAnchorPeriod = kLHC10h;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC11a10b") == 0){
+    fgDataPeriod = kLHC11a10b;
+    fgAnchorPeriod = kLHC10h;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC13d2") == 0){
+    fgDataPeriod = kLHC13d2;
+    fgAnchorPeriod = kLHC10h;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC13d2b") == 0){
+    fgDataPeriod = kLHC13d2b;
+    fgAnchorPeriod = kLHC10h;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC12a11a") == 0){
+    fgDataPeriod = kLHC12a11a;
+    fgAnchorPeriod = kLHC10h;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC12a11b") == 0){
+    fgDataPeriod = kLHC12a11b;
+    fgAnchorPeriod = kLHC10h;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC12a11c") == 0){
+    fgDataPeriod = kLHC12a11c;
+    fgAnchorPeriod = kLHC10h;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC12a11d") == 0){
+    fgDataPeriod = kLHC12a11d;
+    fgAnchorPeriod = kLHC10h;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC12a11e") == 0){
+    fgDataPeriod = kLHC12a11e;
+    fgAnchorPeriod = kLHC10h;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC12a11f") == 0){
+    fgDataPeriod = kLHC12a11f;
+    fgAnchorPeriod = kLHC10h;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb2760GeV;
+  // LHC11x anchored MCs
+  } else if (szLHCPeriod.CompareTo("LHC12a15c") == 0){
+    fgDataPeriod = kLHC12a15c;
+    fgIsMC = kTRUE;
+    fgEnergy = k2760GeV;
+  } else if (szLHCPeriod.Contains("LHC12f1a") ){
+    fgDataPeriod = kLHC12f1a;
+    fgIsMC = kTRUE;
+    fgEnergy = k2760GeV;
+  } else if (szLHCPeriod.Contains("LHC12f1b") ){
+    fgDataPeriod = kLHC12f1b;
+    fgIsMC = kTRUE;
+    fgEnergy = k2760GeV;
+  } else if (szLHCPeriod.Contains("LHC12i3") ){
+    fgDataPeriod = kLHC12i3;
+    fgIsMC = kTRUE;
+    fgEnergy = k2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC15g1a") == 0){
+    fgDataPeriod = kLHC15g1a;
+    fgIsMC = kTRUE;
+    fgEnergy = k2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC15g1b") == 0){
+    fgDataPeriod = kLHC15g1b;
+    fgIsMC = kTRUE;
+    fgEnergy = k2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC13e4") == 0){
+    fgDataPeriod = kLHC13e4;
+    fgIsMC = kTRUE;
+    fgEnergy = k7TeV;
+  } else if (szLHCPeriod.CompareTo("LHC13e5") == 0){
+    fgDataPeriod = kLHC13e5;
+    fgIsMC = kTRUE;
+    fgEnergy = k7TeV;
+  } else if (szLHCPeriod.CompareTo("LHC14k1a") == 0){
+    fgDataPeriod = kLHC14k1a;
+    fgIsMC = kTRUE;
+    fgEnergy = k7TeV;
+  } else if (szLHCPeriod.CompareTo("LHC14k1b") == 0){
+    fgDataPeriod = kLHC14k1b;
+    fgIsMC = kTRUE;
+    fgEnergy = k7TeV;
+  } else if (szLHCPeriod.CompareTo("LHC12a15f") == 0){
+    fgDataPeriod = kLHC12a15f;
+    fgIsMC = kTRUE;
+    fgEnergy = k7TeV;
+  } else if (szLHCPeriod.CompareTo("LHC12a15g") == 0){
+    fgDataPeriod = kLHC12a15g;
+    fgIsMC = kTRUE;
+    fgEnergy = k7TeV;
+  } else if (szLHCPeriod.CompareTo("LHC12f2a") == 0){
+    fgDataPeriod = kLHC12f2a;
+    fgIsMC = kTRUE;
+    fgEnergy = k7TeV;
+  } else if (szLHCPeriod.CompareTo("LHC14a1a") == 0){
+    fgDataPeriod = kLHC14a1a;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC14a1b") == 0){
+    fgDataPeriod = kLHC14a1b;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC14a1c") == 0){
+    fgDataPeriod = kLHC14a1c;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb2760GeV;
+  // LHC12x anchored MCs
+  } else if (szLHCPeriod.CompareTo("LHC14e2a") == 0){
+    fgDataPeriod = kLHC14e2a;
+    fgIsMC = kTRUE;
+    fgEnergy = k8TeV;
+  } else if (szLHCPeriod.CompareTo("LHC14e2b") == 0){
+    fgDataPeriod = kLHC14e2b;
+    fgIsMC = kTRUE;
+    fgEnergy = k8TeV;
+  } else if (szLHCPeriod.CompareTo("LHC14e2c") == 0){
+    fgDataPeriod = kLHC14e2c;
+    fgIsMC = kTRUE;
+    fgEnergy = k8TeV;
+  } else if (szLHCPeriod.Contains("LHC15h1")){
+    fgDataPeriod = kLHC15h1;
+    fgIsMC = kTRUE;
+    fgEnergy = k8TeV;
+  } else if (szLHCPeriod.Contains("LHC15h2")){
+    fgDataPeriod = kLHC15h2;
+    fgIsMC = kTRUE;
+    fgEnergy = k8TeV;
+  } else if (szLHCPeriod.CompareTo("LHC16c2") == 0){
+    fgDataPeriod = kLHC16c2;
+    fgIsMC = kTRUE;
+    fgEnergy = k8TeV;
+  // LHC13x anchored MCs
+  } else if (szLHCPeriod.Contains("LHC13b2_efix")){
+    fgDataPeriod = kLHC13b2_efix;
+    fgIsMC = kTRUE;
+    fgEnergy = kpPb5TeV;
+  } else if (szLHCPeriod.CompareTo("LHC13e7") == 0){
+    fgDataPeriod = kLHC13e7;
+    fgIsMC = kTRUE;
+    fgEnergy = kpPb5TeV;
+  } else if (szLHCPeriod.CompareTo("LHC14b2") == 0){
+    fgDataPeriod = kLHC14b2;
+    fgIsMC = kTRUE;
+    fgEnergy = kpPb5TeV;
+  } else if (szLHCPeriod.CompareTo("LHC13b4_fix") == 0){
+    fgDataPeriod = kLHC13b4_fix;
+    fgIsMC = kTRUE;
+    fgEnergy = kpPb5TeV;
+  } else if (szLHCPeriod.CompareTo("LHC13b4_plus") == 0){
+    fgDataPeriod = kLHC13b4_plus;
+    fgIsMC = kTRUE;
+    fgEnergy = kpPb5TeV;
+  } else if (szLHCPeriod.CompareTo("LHC16c3a") == 0){
+    fgDataPeriod = kLHC16c3a;
+    fgIsMC = kTRUE;
+    fgEnergy = kpPb5TeV;
+  } else if (szLHCPeriod.CompareTo("LHC16c3b") == 0){
+    fgDataPeriod = kLHC16c3b;
+    fgIsMC = kTRUE;
+    fgEnergy = kpPb5TeV;
+  } else if (szLHCPeriod.CompareTo("LHC16c3c") == 0){
+    fgDataPeriod = kLHC16c3c;
+    fgIsMC = kTRUE;
+    fgEnergy = kpPb5TeV;
+  } else if (szLHCPeriod.CompareTo("LHC15g2") == 0){
+    fgDataPeriod = kLHC15g2;
+    fgIsMC = kTRUE;
+    fgEnergy = k2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC15a3a") == 0){
+    fgDataPeriod = kLHC15a3a;
+    fgIsMC = kTRUE;
+    fgEnergy = k2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC15a3a_plus") == 0){
+    fgDataPeriod = kLHC15a3a_plus;
+    fgIsMC = kTRUE;
+    fgEnergy = k2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC15a3b") == 0){
+    fgDataPeriod = kLHC15a3b;
+    fgIsMC = kTRUE;
+    fgEnergy = k2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC15d3a") == 0){
+    fgDataPeriod = kLHC15d3a;
+    fgIsMC = kTRUE;
+    fgEnergy = k2760GeV;
+  } else if (szLHCPeriod.CompareTo("LHC15d3b") == 0){
+    fgDataPeriod = kLHC15d3b;
+    fgIsMC = kTRUE;
+    fgEnergy = k2760GeV;
+  // LHC15x anchored MCs
+  } else if (szLHCPeriod.CompareTo("LHC15g3a3") == 0){
+    fgDataPeriod = kLHC15g3a3;
+    fgIsMC = kTRUE;
+    fgEnergy = k13TeV;
+  } else if (szLHCPeriod.CompareTo("LHC15g3a") == 0){
+    fgDataPeriod = kLHC15g3a;
+    fgIsMC = kTRUE;
+    fgEnergy = k13TeV;
+  } else if (szLHCPeriod.CompareTo("LHC15g3c2") == 0){
+    fgDataPeriod = kLHC15g3c2;
+    fgIsMC = kTRUE;
+    fgEnergy = k13TeV;
+  } else if (szLHCPeriod.CompareTo("LHC15g3c3") == 0){
+    fgDataPeriod = kLHC15g3c3;
+    fgIsMC = kTRUE;
+    fgEnergy = k13TeV;
+  } else if (szLHCPeriod.CompareTo("LHC15g3") == 0){
+    fgDataPeriod = kLHC15g3;
+    fgIsMC = kTRUE;
+    fgEnergy = k13TeV;
+  } else if (szLHCPeriod.CompareTo("LHC16a2a") == 0){
+    fgDataPeriod = kLHC16a2a;
+    fgIsMC = kTRUE;
+    fgEnergy = k13TeV;
+  } else if (szLHCPeriod.CompareTo("LHC16a2b") == 0){
+    fgDataPeriod = kLHC16a2b;
+    fgIsMC = kTRUE;
+    fgEnergy = k13TeV;
+  } else if (szLHCPeriod.CompareTo("LHC16a2c") == 0){
+    fgDataPeriod = kLHC16a2c;
+    fgIsMC = kTRUE;
+    fgEnergy = k13TeV;
+  } else if (szLHCPeriod.CompareTo("LHC15l1a2") == 0){
+    fgDataPeriod = kLHC15l1a2;
+    fgIsMC = kTRUE;
+    fgEnergy = k5TeV;
+  } else if (szLHCPeriod.CompareTo("LHC15l1b2") == 0){
+    fgDataPeriod = kLHC15l1b2;
+    fgIsMC = kTRUE;
+    fgEnergy = k5TeV;
+  } else if (szLHCPeriod.Contains("LHC15k1a1")){
+    fgDataPeriod = kLHC15k1a1;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb5TeV;
+  } else if (szLHCPeriod.Contains("LHC15k1a2")){
+    fgDataPeriod = kLHC15k1a2;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb5TeV;
+  } else if (szLHCPeriod.Contains("LHC15k1a3")){
+    fgDataPeriod = kLHC15k1a3;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb5TeV;
+  } else if (szLHCPeriod.Contains("LHC16h4a")){
+    fgDataPeriod = kLHC16h4a;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb5TeV;
+  } else if (szLHCPeriod.Contains("LHC16h4b")){
+    fgDataPeriod = kLHC16h4b;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb5TeV;
+  } else if (szLHCPeriod.Contains("LHC16h4b2")){
+    fgDataPeriod = kLHC16h4b2;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb5TeV;
+  } else if (szLHCPeriod.Contains("LHC16h4c")){
+    fgDataPeriod = kLHC16h4c;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb5TeV;
+  } else if (szLHCPeriod.Contains("LHC16g1")){
+    fgDataPeriod = kLHC16g1;
+    fgAnchorPeriod = kLHC15oHIR;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb5TeV;
+  } else if (szLHCPeriod.Contains("LHC16g1a")){
+    fgDataPeriod = kLHC16g1a;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb5TeV;
+  } else if (szLHCPeriod.Contains("LHC16g1b")){
+    fgDataPeriod = kLHC16g1b;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb5TeV;
+  } else if (szLHCPeriod.Contains("LHC16g1c")){
+    fgDataPeriod = kLHC16g1c;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb5TeV;
+  } else if (szLHCPeriod.Contains("LHC16h2a")){
+    fgDataPeriod = kLHC16h2a;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb5TeV;
+  } else if (szLHCPeriod.Contains("LHC16h2b")){
+    fgDataPeriod = kLHC16h2b;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb5TeV;
+  } else if (szLHCPeriod.Contains("LHC16h2c")){
+    fgDataPeriod = kLHC16h2c;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb5TeV;
+  } else if (szLHCPeriod.CompareTo("kLHC16i3a")){
+    fgDataPeriod = kLHC16i3a;
+    fgAnchorPeriod = kLHC15oHIR;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb5TeV;
+  // MC upgrade
+  } else if (szLHCPeriod.Contains("LHC13d19")){
+    fgDataPeriod = kLHC13d19;
+    fgIsMC = kTRUE;
+    fgEnergy = kPbPb5TeV;
+  } else {
+    AliFatalClass(Form("Analysis period %s not supported. Please update the class!!!", szLHCPeriod.Data()));
+    fgDataPeriod = kNoPeriod;
+    fgEnergy = kUnset;
+  }
+
+  /* let's check the consistency of the MC flag and store the input and the MC handlers */
+  fgInputHandler = (AliInputEventHandler *)((AliAnalysisManager::GetAnalysisManager())->GetInputEventHandler());
+  if (fgInputHandler != NULL && fgInputHandler->InheritsFrom("AliESDInputHandler")) {
+    fgIsESD = kTRUE;
+    AliMultiInputEventHandler *multiInputHandler = dynamic_cast<AliMultiInputEventHandler *>(fgInputHandler);
+    if (multiInputHandler) {
+      fgInputHandler = dynamic_cast<AliInputEventHandler *>(multiInputHandler->GetFirstInputEventHandler());
+      fgMCHandler = dynamic_cast<AliMCEventHandler *>(multiInputHandler->GetFirstMCEventHandler());
+    } else {
+      fgMCHandler = dynamic_cast<AliMCEventHandler *>((AliAnalysisManager::GetAnalysisManager())->GetMCtruthEventHandler());
+    }
+
+    if (fgIsMC && !(fgMCHandler != NULL))
+      AliFatalClass("Data is from a MC production but there is no MC handler for it");
+  }
+  else {
+    /* we know data format is AOD but still don't know whether it is MC or not */
+    fgIsESD = kFALSE;
+  }
+}
+
+/// Extract the period name from the data file path
+/// \return the name of the period associated with the input data file
+TString AliCSAnalysisCutsBase::GetPeriodNameFromDataFilePath()
+{
+  TString szPeriodName = "";
+  AliAnalysisManager *man=AliAnalysisManager::GetAnalysisManager();
+
+  if(man) {
+    AliVEventHandler* inputHandler = (AliVEventHandler*) (man->GetInputEventHandler());
+
+    if (inputHandler){
+      TString szFullFileName = inputHandler->GetTree()->GetCurrentFile()->GetName();
+
+      AliInfoClass(Form("Detecting period name from filename: %s", szFullFileName.Data()));
+
+      TObjArray *tokens = szFullFileName.Tokenize("/._");
+      for (Int_t i = 0; i < tokens->GetEntriesFast();i++ ){
+        TObjString* testObjString = (TObjString*)tokens->At(i);
+        if (testObjString->GetString().BeginsWith("LHC")){
+          szPeriodName = testObjString->GetString();
+          break;
+        }
+      }
+      delete tokens;
+      if (szPeriodName.Length() == 0){
+        tokens = szFullFileName.Tokenize("__");
+        for (Int_t i = 0; i < tokens->GetEntriesFast();i++ ){
+          TObjString* testObjString = (TObjString*) tokens->At(i);
+          if (testObjString->GetString().BeginsWith("LHC")){
+            szPeriodName = testObjString->GetString();
+            break;
+          }
+        }
+        delete tokens;
+      }
+    }
+  }
+  return szPeriodName;
+}
+
+/// Get the current run number being (or going to be) analyzed
+/// \return the current run number
+Int_t AliCSAnalysisCutsBase::GetCurrentRunNumber()
+{
+  Int_t runno = -1;
+  AliAnalysisManager *man=AliAnalysisManager::GetAnalysisManager();
+
+  if(man != NULL) {
+    AliVEventHandler* inputHandler = (AliVEventHandler*) (man->GetInputEventHandler());
+
+    if (inputHandler != NULL){
+      AliVEvent *event = inputHandler->GetEvent();
+
+      if (event != NULL) {
+        runno = event->GetRunNumber();
+      }
+    }
+  }
+  return runno;
+}
+
+
+/// Update the cut string (if it has been created yet)
+/// \return kFALSE if inconsistent length or cut values
+Bool_t AliCSAnalysisCutsBase::UpdateCutsString() {
+
+  if (Int_t(strlen(fCutsString)) == fNParams) {
+    /* before touching anything check consistency */
+    for (Int_t i = 0; i < fNParams; i++) {
+      if (fParameters[i] < 0 || 9 < fParameters[i]) {
+        return kFALSE;
+      }
+    }
+  } else {
+    /* not consistent length */
+    return kFALSE;
+  }
+  /* now it is safe to do it */
+  for (Int_t i = 0; i < fNParams; i++) {
+    fCutsString[i] = '0' + fParameters[i];
+  }
+  fCutsString[fNParams] = '\0';
+
+  return kTRUE;
+}
+
+/// Gives values to the different event cuts from the passed string
+/// \param cutsSelectionString string with the values for the different cuts
+/// \return kTRUE if succeeded
+
+Bool_t AliCSAnalysisCutsBase::InitializeCutsFromCutString(const TString cutsSelectionString ) {
+  AliInfo(Form("Set Cuts String: %s",cutsSelectionString.Data()));
+  if(cutsSelectionString.Length()!=fNParams) {
+    AliError(Form("Cuts selection string has the wrong length! size is %d, number of cuts is %d", cutsSelectionString.Length(), fNParams));
+    return kFALSE;
+  }
+  if(!cutsSelectionString.IsDigit()){
+    AliError("Cut selection string contains non digits");
+    return kFALSE;
+  }
+
+  // Set Individual Cuts
+  for(Int_t i=0;i<fNParams;i++){
+    if(!SetCutAndParams(i,cutsSelectionString[i] - '0'))return kFALSE;
+  }
+  /* produce some feedback */
+  PrintCutsWithValues();
+  return kTRUE;
+}
+
+/// Prints the cuts information and values in an usere friendly way
+/// Ask to each cut to print its own information
+void AliCSAnalysisCutsBase::PrintCutsWithValues() const {
+  // Print out current Cut Selection with value
+  printf("\n=========== %s information ===============\n", GetName());
+  printf("Cuts string: %s\n",fCutsString);
+  printf("Cuts values: ");
+  for(Int_t i = 0; i < fNParams; i++) {
+    printf("%d",fParameters[i]);
+  }
+  printf("\nIndividual cut information\n");
+
+  for (Int_t i = 0; i < fNParams; i++) {
+    PrintCutWithParams(i);
+  }
+  printf("=========== %s information end ===========\n\n", GetName());
+}
+
+/// \cond CLASSIMP
+ClassImp(AliCSAnalysisCutsBase);
+/// \endcond

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSAnalysisCutsBase.h
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSAnalysisCutsBase.h
@@ -1,0 +1,314 @@
+#ifndef ALICSANALYSISCUTSBASE_H
+#define ALICSANALYSISCUTSBASE_H
+
+/// \file AliCSAnalysisCutsBase.h
+/// \brief Base analysis cuts support for the correlations studies tasks
+///
+/// Based on ideas taken from Gamma Conversion analysis under PWGGA and from AliESDTrackCuts
+
+#include <TBits.h>
+#include <TNamed.h>
+
+/// \class AliCSAnalysisCutsBase
+/// \brief Base class for correlation studies analysis cuts
+///
+/// Provides support for configuring a variable set of cuts
+/// via a string which can be then incorporated in all histograms
+/// for cut information persistence.
+///
+/// Based on Gamma Conversion analysis implementation within PWGGA
+///
+/// \author Víctor González <victor.gonzalez@cern.ch>, UCM
+/// \date Oct 17, 2016
+
+class TClonesArray;
+class AliInputEventHandler;
+class AliMCEventHandler;
+
+class AliCSAnalysisCutsBase : public TNamed {
+public:
+
+  /// \enum QALevel
+  /// \brief The level of the QA histograms output
+  enum QALevel {
+    kQALevelNone,     ///< no QA histograms output
+    kQALevelLight,    ///< light QA histograms output
+    kQALevelHeavy     ///< full QA histograms output
+  };
+
+  /// \enum ProdPeriods
+  /// \brief The supported LHC production periods
+  enum ProdPeriods {
+    kNoPeriod=0,      ///< no period
+    /// \name 2010
+    /// \brief 2010 periods
+    ///@{
+    kLHC10bg,         ///< pp 7 TeV (LHC10c incl 900 GeV)
+    kLHC10h,          ///< PbPb 2.76TeV
+    ///@}
+    /// \name 2010MC
+    /// \brief MC's corresponding to 2010 data
+    ///@{
+    kLHC10d1,         ///< anchored LHC10b pass 2
+    kLHC10d2,         ///< anchored LHC10b pass 2
+    kLHC10d4a,        ///< anchored LHC10c pass 2
+    kLHC10d4,         ///< anchored LHC10c pass 2
+    kLHC10e12,        ///< anchored LHC10c pass 2
+    kLHC10e13,        ///< anchored LHC10c pass 2
+    kLHC10f6a,        ///< anchored LHC10d pass 2
+    kLHC10f6,         ///< anchored LHC10d pass 2
+    kLHC10e20,        ///< anchored LHC10e pass 2
+    kLHC10e21,        ///< anchored LHC10e pass 2
+    kLHC14j4,         ///< anchored LHC10[b-g] pass 4
+    kLHC11a10a,       ///< anchored LHC10h pass 2
+    kLHC11a10b,       ///< anchored LHC10h pass 2
+    kLHC13d2,         ///< anchored LHC10h pass 2
+    kLHC13d2b,        ///< anchored LHC10h pass 2
+    kLHC12a11a,       ///< anchored LHC10h pass 2
+    kLHC12a11b,       ///< anchored LHC10h pass 2
+    kLHC12a11c,       ///< anchored LHC10h pass 2
+    kLHC12a11d,       ///< anchored LHC10h pass 2
+    kLHC12a11e,       ///< anchored LHC10h pass 2
+    kLHC12a11f,       ///< anchored LHC10h pass 2
+    kLHC13d19,        ///< anchored LHC10h pass 2, upgrade 5.5TeV PbPb
+    ///@}
+    /// \name 2011
+    /// \brief 2011 periods
+    ///@{
+    kLHC11a,          ///< pp 2.76TeV (part 7TeV)
+    kLHC11b,          ///< pp 7TeV
+    kLHC11cg,         ///< pp 7TeV
+    kLHC11h,          ///< PbPb 2.76TeV
+    ///@}
+    /// \name 2011MC
+    /// \brief MC's corresponding to 2011 data
+    ///@{
+    kLHC12a15c,       ///< anchored LHC11a pass 2 - JJ
+    kLHC12f1a,        ///< anchored LHC11a pass 4
+    kLHC12f1b,        ///< anchored LHC11a pass 4
+    kLHC12i3,         ///< anchored LHC11a pass 4
+    kLHC15g1a,        ///< anchored LHC11a pass 4 - JJ
+    kLHC15g1b,        ///< anchored LHC11a pass 4 - JJ
+    kLHC13e4,         ///< anchored LHC11c pass 1 - GJ
+    kLHC13e5,         ///< anchored LHC11c pass 1 - JJ
+    kLHC14k1a,        ///< anchored LHC11[c-d] pass 1 - JJ
+    kLHC14k1b,        ///< anchored LHC11[c-d] pass 1 - JJ
+    kLHC12a15f,       ///< anchored LHC11d pass 1 - JJ
+    kLHC12a15g,       ///< anchored LHC11d pass 1 - GJ
+    kLHC12f2a,        ///< anchored LHC11d pass 1 - JJ
+    kLHC14a1a,        ///< anchored LHC11h pass 2
+    kLHC14a1b,        ///< anchored LHC11h pass 2
+    kLHC14a1c,        ///< anchored LHC11h pass 2
+    ///@}
+    /// \name 2012
+    /// \brief 2012 periods
+    ///@{
+    kLHC12,           ///< pp 8TeV
+    ///@}
+    /// \name 2012MC
+    /// \brief MC's corresponding to 2012 data
+    ///@{
+    kLHC14e2a,        ///< anchored LHC12[a-h] pass 1
+    kLHC14e2b,        ///< anchored LHC12[a-h] pass 1
+    kLHC14e2c,        ///< anchored LHC12[a-h] pass 1
+    kLHC15h1,         ///< anchored LHC12[a-h] pass 2
+    kLHC15h2,         ///< anchored LHC12[a-h] pass 2
+    kLHC16c2,         ///< anchored LHC12[a-h] pass 2 - JJ
+    ///@}
+    /// \name 2013
+    /// \brief 2013 periods
+    ///@{
+    kLHC13bc,         ///< pPb 5.023TeV
+    kLHC13de,         ///< pPb 5.023TeV
+    kLHC13f,          ///< Pbp 5.023TeV
+    kLHC13g,          ///< pp 2.76TeV
+    ///@}
+    /// \name 2013MC
+    /// \brief MC's corresponding to 2013 data
+    ///@{
+    kLHC13b2_efix,    ///< anchored LHC13[b-c] pass 2
+    kLHC13e7,         ///< anchored LHC13[b-c] pass 2
+    kLHC14b2,         ///< anchored LHC13[b-c] pass 2
+    kLHC13b4_fix,     ///< anchored LHC13[b-c] pass 2 - JJ
+    kLHC13b4_plus,    ///< anchored LHC13[b-c] pass 2 - JJ
+    kLHC16c3a,        ///< anchored LHC13[d-e] pass 2 - JJ
+    kLHC16c3b,        ///< anchored LHC13[d-e] pass 2 - JJ
+    kLHC16c3c,        ///< anchored LHC13[d-e] pass 2 - GJ
+    kLHC15g2,         ///< anchored LHC13g pass 1
+    kLHC15a3a,        ///< anchored LHC13g pass 1 - JJ
+    kLHC15a3a_plus,   ///< anchored LHC13g pass 1 - JJ
+    kLHC15a3b,        ///< anchored LHC13g pass 1 - JJ
+    kLHC15d3a,        ///< anchored LHC13g pass 1
+    kLHC15d3b,        ///< anchored LHC13g pass 1
+    ///@}
+    /// \name 2015
+    /// \brief 2015 periods
+    ///@{
+    kLHC15fm,         ///< pp 13 TeV
+    kLHC15n,          ///< pp 5 TeV
+    kLHC15oLIR,       ///< PbPb 5 TeV low interaction rate
+    kLHC15oHIR,       ///< PbPb 5 TeV high interaction rate
+    ///@}
+    /// \name 2015MC
+    /// \brief MC's corresponding to 2015 data
+    ///@{
+    kLHC15g3a3,       ///< anchored LHC15f pass 1
+    kLHC15g3a,        ///< anchored LHC15f pass 1
+    kLHC15g3c2,       ///< anchored LHC15f pass 1
+    kLHC15g3c3,       ///< anchored LHC15f pass 1
+    kLHC15g3,         ///< anchored LHC15f pass 1
+    kLHC16a2a,        ///< anchored LHC15h pass 1
+    kLHC16a2b,        ///< anchored LHC15h pass 1
+    kLHC16a2c,        ///< anchored LHC15h pass 1
+    kLHC15l1a2,       ///< anchored LHC15n pass 1
+    kLHC15l1b2,       ///< anchored LHC15n pass 1
+    kLHC15k1a1,       ///< LHC15o low IR
+    kLHC15k1a2,       ///< LHC15o low IR
+    kLHC15k1a3,       ///< LHC15o low IR
+    kLHC16g1,         ///< anchored LHC15o pass1 - general purpose
+    kLHC16g1a,        ///< anchored LHC15o pass1 - general purpose 0-10%
+    kLHC16g1b,        ///< anchored LHC15o pass1 - general purpose 10-50%
+    kLHC16g1c,        ///< anchored LHC15o pass1 - general purpose 50-90%
+    kLHC16h4a,        ///< anchored LHC15o pass1 - injected signals 0-10%
+    kLHC16h4b,        ///< anchored LHC15o pass1 - injected signals 10-50%
+    kLHC16h4b2,       ///< anchored LHC15o pass1 - injected signals 10-50% with TPC gas corrections
+    kLHC16h4c,        ///< anchored LHC15o pass1 - injected signals 50-90%
+    kLHC16h2a,        ///< anchored LHC15o pass1 - jet-jet 0-10%
+    kLHC16h2b,        ///< anchored LHC15o pass1 - jet-jet 10-50%
+    kLHC16h2c,        ///< anchored LHC15o pass1 - jet-jet 50-90%
+    kLHC16i3a,        ///< anchored LHC15o HIJING + HF injected with electron decays in central events
+    ///@}
+    /// \name 2016
+    /// \brief 2016 periods
+    ///@{
+    kLHC16k,          ///< pp 13 TeV
+    kLHC16l,          ///< pp 13 TeV
+    ///@}
+  };
+
+  /// \enum EnergyValue
+  /// \brief The collision energy for the production period
+  enum EnergyValue {
+    kUnset        = 0,  ///< not defined
+    k900GeV       = 1,  ///< pp 900 GeV
+    k2760GeV      = 2,  ///< pp 2.76TeV
+    k5TeV         = 3,  ///< pp 5 TeV
+    k7TeV         = 4,  ///< pp 7 TeV
+    k8TeV         = 5,  ///< pp 8 TeV
+    k13TeV        = 6,  ///< pp 13 TeV
+    kpPb5TeV      = 7,  ///< pPb 5 TeV
+    kpPb8TeV      = 8,  ///< pPb 8 TeV
+    kPbPb2760GeV  = 9,  ///< PbPb 2.76TeV
+    kPbPb5TeV     = 10, ///< PbPb 5 TeV
+  };
+
+                                AliCSAnalysisCutsBase();
+                                AliCSAnalysisCutsBase(Int_t nCuts, Int_t nParams, const char *name="CS AnalysisCuts", const char * title="CS AnalysisCuts");
+  virtual                      ~AliCSAnalysisCutsBase();
+
+                                /// Gets the current activated cuts
+                                /// \return the mask with the activated cuts
+  const TBits                  *GetCutsActivatedMask() { return &fCutsActivatedMask; }
+
+                                /// Initializes the cuts
+                                /// \param name the name to assign to the histograms list
+  virtual void                  InitCuts(const char *name) = 0;
+                                /// Sets the desired level for the QA histograms output
+                                /// \param level the desired QA histograms output level
+  void                          SetQALevelOutput(QALevel level) { fQALevel = level; }
+                                /// Get the histograms list
+                                /// \return the histograms list
+  virtual TList                *GetHistogramsList() { return fHistogramsList; }
+
+                                /// Processes a potential change in the run number
+                                /// Pure virtual function
+  virtual void                  NotifyRun() = 0;
+                                /// A new event is coming
+                                /// Pure virtual function
+  virtual void                  NotifyEvent() = 0;
+  static void                   NotifyRunGlobal();
+                                /// Prints the activated cuts mask
+                                /// \param opt the print options
+  virtual void                  Print(Option_t *opt = "") const { fCutsActivatedMask.Print(opt); }
+
+  Bool_t                        InitializeCutsFromCutString(const TString cutSelectionString);
+                                /// Get the event cuts associated string
+                                /// \return the event cuts associated string
+  const char                   *GetCutsString() const { return fCutsString; }
+                                /// Get the period name corresponding to the current analysis
+                                /// \return the period name of the current analysis
+  static const char            *GetPeriodName() { return fgPeriodName.Data(); }
+                                /// Get the period corresponding to the current analysis
+                                /// \return the period code of the current analysis
+  static ProdPeriods            GetGlobalPeriod() { return fgDataPeriod; }
+                                /// Get the anchor period corresponding to the current analysis
+                                /// \return the anchor period code of the current analysis
+  static ProdPeriods            GetGlobalAnchorPeriod() { return fgAnchorPeriod; }
+                                /// Is a Monte Carlo data set
+                                /// \return kTRUE if it is a Monte Carlo data set, kFALSE otherwise
+  static Bool_t                 IsMC() { return fgIsMC; }
+                                /// Get the Monte Carlo event handler
+                                /// \return the Monte Carlo event handler
+  static AliMCEventHandler     *GetMCEventHandler() { return fgMCHandler; }
+                                /// Get the Input event handler
+                                /// \return the Input event handler
+  static AliInputEventHandler  *GetInputEventHandler() { return fgInputHandler; }
+                                /// Get the MC array of true particles
+                                /// \return the MC array of true particles
+  static TClonesArray          *GetMCTrueArray() { return fgMCArray; }
+
+protected:
+  Bool_t                        UpdateCutsString();
+                                /// Set the value for a concrete cut
+                                /// Pure virtual function
+                                /// \param paramID the ID of the cut of interest
+                                /// \param value the value to assign to the cut
+                                /// \return kTRUE if the cut value was accepted
+  virtual Bool_t                SetCutAndParams (Int_t paramID, Int_t value) = 0;
+  void                          PrintCutsWithValues() const ;
+                                /// Print the cut with its value
+                                /// Pure virtual function
+                                /// \param paramID the ID of the cut of interest
+  virtual void                  PrintCutWithParams(Int_t paramID) const = 0;
+
+private:
+  static TString                GetPeriodNameFromDataFilePath();
+  static Int_t                  GetCurrentRunNumber();
+
+private:
+  static TString                fgPeriodName;           ///< the period name of the ongoing analysis
+  static ProdPeriods            fgDataPeriod;           ///< the global period of ongoing analysis
+  static ProdPeriods            fgAnchorPeriod;         ///< the anchor period, different from #fgDataPeriod in case of MC data
+  Int_t                         fNParams;               ///< the number of cuts parameters
+  char                         *fCutsString;            ///< the cuts parameters associated string
+protected:
+  Int_t                         fNCuts;                 ///< the number of cuts
+  QALevel                       fQALevel;               ///< the level of the QA histograms output
+                                /// the external values for each of the cuts parameters
+  Int_t                        *fParameters;            //[fNParams]
+  TBits                         fCutsEnabledMask;       ///< the mask of enabled cuts
+  TBits                         fCutsActivatedMask;     ///< the mask of cut activated for the ongoing event
+  ProdPeriods                   fDataPeriod;            ///< the current period under analysis. Occasionally could be different from the global period
+  static EnergyValue            fgEnergy;               ///< the collision energy for the analysis period
+  static Bool_t                 fgIsMC;                 ///< MC flag from production information
+  static AliInputEventHandler  *fgInputHandler;         ///< the input handler for the current ongoing analysis
+  static AliMCEventHandler     *fgMCHandler;            ///< MC handler for the current ongoing analysis
+  static Bool_t                 fgIsESD;                ///< kTRUE if data format is ESD, kFALSE if AOD
+  static TClonesArray          *fgMCArray;              ///< the array containing true particles when MC AOD analysis
+
+  TList                        *fHistogramsList;        ///< the list of histograms used
+
+  /// Copy constructor
+  /// Not allowed. Forced private.
+  AliCSAnalysisCutsBase(const AliCSAnalysisCutsBase&);
+  /// Assignment operator
+  /// Not allowed. Forced private.
+  /// \return l-value reference object
+  AliCSAnalysisCutsBase& operator=(const AliCSAnalysisCutsBase&);
+
+  /// \cond CLASSIMP
+  ClassDef(AliCSAnalysisCutsBase,1);
+  /// \endcond
+};
+
+#endif /* ALICSANALYSISCUTSBASE_H */

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSEventCuts.cxx
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSEventCuts.cxx
@@ -1,0 +1,2204 @@
+/**************************************************************************
+* Copyright(c) 1998-2016, ALICE Experiment at CERN, All rights reserved.  *
+*                                                                         *
+* Permission to use, copy, modify and distribute this software and its    *
+* documentation strictly for non-commercial purposes is hereby granted    *
+* without fee, provided that the above copyright notice appears in all    *
+* copies and that both the copyright notice and this permission notice    *
+* appear in the supporting documentation. The authors make no claims      *
+* about the suitability of this software for any purpose. It is           *
+* provided "as is" without express or implied warranty.                   *
+**************************************************************************/
+
+#include <TFormula.h>
+#include <TF1.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include "AliVEvent.h"
+#include "AliVTrack.h"
+#include "AliCSEventCuts.h"
+#include "AliAnalysisManager.h"
+#include "AliInputEventHandler.h"
+#include "AliMCEventHandler.h"
+#include "AliMCEvent.h"
+#include "AliAODMCParticle.h"
+#include "AliAODEvent.h"
+#include "AliESDEvent.h"
+#include "AliCentrality.h"
+#include "AliMultSelection.h"
+#include "AliESDtrackCuts.h"
+#include "AliLog.h"
+
+/// \file AliCSEventCuts.cxx
+/// \brief Implementation of event cuts class within the correlation studies analysis
+
+const char *AliCSEventCuts::fgkCutsNames[AliCSEventCuts::kNCuts] = {
+    "MC without proper MC data",
+    "DAQ incomplete",
+    "No tracks",
+    "Offline trigger",
+    "Vertex contributors",
+    "Vertex quality",
+    "SPD and tracks vertex distance",
+    "z_{vtx}",
+    "Pile up",
+    "2015 Pile up",
+    "SPD clusters vs tracklets",
+    "Centrality"
+};
+
+Float_t AliCSEventCuts::fgkVertexResolutionThreshold = 0.25;
+Float_t AliCSEventCuts::fgkVertexDispersionThreshold = 0.03;
+Float_t AliCSEventCuts::fgkSPDTracksVtxDistanceThreshold = 0.2;
+Float_t AliCSEventCuts::fgkSPDTracksVtxDistanceSigmas = 10.0;
+Float_t AliCSEventCuts::fgkTrackVertexSigmas = 20.0;
+
+/// Default constructor for serialization
+AliCSEventCuts::AliCSEventCuts() :
+    AliCSAnalysisCutsBase(),
+    fSystem(kNoSystem),
+    fVertexZ(999.0),
+    fCentrality(0.0),
+    fCentralityDetector(0),
+    fCentralityModifier(0),
+    fCentralityMin(0.0),
+    fCentralityMax(1e6),
+    fOfflineTriggerMask(AliVEvent::kAny),
+    fMaxVertexZ(1000.0),
+    fUseSPDTracksVtxDist(kFALSE),
+    fVertexResolutionTh(fgkVertexResolutionThreshold),
+    fVertexDispersionTh(fgkVertexDispersionThreshold),
+    fUseNewMultFramework(kFALSE),
+    f2015V0MtoTrkTPCout(NULL),
+    fCentOutLowCut(NULL),
+    fCentOutHighCut(NULL),
+    fTOFMultOutLowCut(NULL),
+    fTOFMultOutHighCut(NULL),
+    fMultCentOutLowCut(NULL),
+    fV0MCentrality(0),
+    fV0ACentrality(0),
+    fV0CCentrality(0),
+    fCL0Centrality(0),
+    fCL1Centrality(0),
+    fReferenceMultiplicity(0),
+    fV0Multiplicity(0),
+    fNoOfAODTracks(0),
+    fNoOfESDTracks(0),
+    fNoOfFB32Tracks(0),
+    fNoOfFB128Tracks(0),
+    fNoOfFB32AccTracks(0),
+    fNoOfFB32TOFTracks(0),
+    fNoOfTPCoutTracks(0),
+    fNoOfInitialTPCoutTracks(0),
+    fAnalysisUtils(),
+    fESDFB32(NULL),
+    fESDFB128(NULL),
+    fhCutsStatistics(NULL),
+    fhUniqueCutsStatistics(NULL),
+    fhCutsCorrelation(NULL),
+    fhCentrality{NULL},
+    fhVertexZ{NULL},
+    fhSPDClustersVsTracklets{NULL},
+    fhV0MvsTracksTPCout{NULL},
+    fhV0MvsTracksInitialTPCout{NULL},
+    fhCentralityAltVsSel{NULL},
+    fhCL0vsV0MCentrality{NULL},
+    fhESDvsTPConlyMultiplicity{NULL},
+    fhTOFvsGlobalMultiplicity{NULL},
+    fhAccTrkvsV0MCentrality{NULL},
+    fhTriggerClass{NULL}
+{
+}
+
+/// Constructor
+/// \param name name of the event cuts
+/// \param title title of the event cuts
+AliCSEventCuts::AliCSEventCuts(const char *name, const char *title) :
+    AliCSAnalysisCutsBase(kNCuts,kNCutsParameters,name,title),
+    fSystem(kNoSystem),
+    fVertexZ(999.0),
+    fCentrality(0.0),
+    fCentralityDetector(0),
+    fCentralityModifier(0),
+    fCentralityMin(0.0),
+    fCentralityMax(1e6),
+    fOfflineTriggerMask(AliVEvent::kAny),
+    fMaxVertexZ(1000.0),
+    fUseSPDTracksVtxDist(kFALSE),
+    fVertexResolutionTh(fgkVertexResolutionThreshold),
+    fVertexDispersionTh(fgkVertexDispersionThreshold),
+    fUseNewMultFramework(kFALSE),
+    f2015V0MtoTrkTPCout(NULL),
+    fCentOutLowCut(NULL),
+    fCentOutHighCut(NULL),
+    fTOFMultOutLowCut(NULL),
+    fTOFMultOutHighCut(NULL),
+    fMultCentOutLowCut(NULL),
+    fV0MCentrality(0),
+    fV0ACentrality(0),
+    fV0CCentrality(0),
+    fCL0Centrality(0),
+    fCL1Centrality(0),
+    fReferenceMultiplicity(0),
+    fV0Multiplicity(0),
+    fNoOfAODTracks(0),
+    fNoOfESDTracks(0),
+    fNoOfFB32Tracks(0),
+    fNoOfFB128Tracks(0),
+    fNoOfFB32AccTracks(0),
+    fNoOfFB32TOFTracks(0),
+    fNoOfTPCoutTracks(0),
+    fNoOfInitialTPCoutTracks(0),
+    fAnalysisUtils(),
+    fESDFB32(NULL),
+    fESDFB128(NULL),
+    fhCutsStatistics(NULL),
+    fhUniqueCutsStatistics(NULL),
+    fhCutsCorrelation(NULL),
+    fhCentrality{NULL},
+    fhVertexZ{NULL},
+    fhSPDClustersVsTracklets{NULL},
+    fhV0MvsTracksTPCout{NULL},
+    fhV0MvsTracksInitialTPCout{NULL},
+    fhCentralityAltVsSel{NULL},
+    fhCL0vsV0MCentrality{NULL},
+    fhESDvsTPConlyMultiplicity{NULL},
+    fhTOFvsGlobalMultiplicity{NULL},
+    fhAccTrkvsV0MCentrality{NULL},
+    fhTriggerClass{NULL}
+{
+}
+
+/// Destructor
+AliCSEventCuts::~AliCSEventCuts()
+{
+  if (f2015V0MtoTrkTPCout != NULL)
+    delete f2015V0MtoTrkTPCout;
+  if (fCentOutLowCut != NULL)
+    delete fCentOutLowCut;
+  if (fCentOutHighCut != NULL)
+    delete fCentOutHighCut;
+  if (fTOFMultOutLowCut != NULL)
+    delete fTOFMultOutLowCut;
+  if (fTOFMultOutHighCut != NULL)
+    delete fTOFMultOutHighCut;
+  if (fMultCentOutLowCut != NULL)
+    delete fMultCentOutLowCut;
+  if (fESDFB32 != NULL)
+    delete fESDFB32;
+  if (fESDFB128 != NULL)
+    delete fESDFB128;
+}
+
+/// Processes a potential change in the run number
+///
+/// Checks if the current period under analysis has changed and if so
+/// updates the needed members. Finally, once the running cuts string is
+/// definitely known, asks for histograms allocation.
+void AliCSEventCuts::NotifyRun() {
+
+  /* checks the change in the analysis period */
+  if (AliCSAnalysisCutsBase::GetGlobalPeriod() != fDataPeriod) {
+
+    fDataPeriod = AliCSAnalysisCutsBase::GetGlobalPeriod();
+
+    /* set the system type according to the data period */
+    SetActualSystemType();
+
+    /* set the trigger according to the data period */
+    SetActualActiveTrigger();
+
+    /* set the 2015 pileup rejection according to the data period */
+    SetActual2015PileUpRemoval();
+
+    /* we adapt the different cuts accordingly with the data period */
+    fUseNewMultFramework = UseNewMultiplicityFramework();
+
+    /* set the counting tracks filter cuts according to data period */
+    SetActualFilterTracksCuts();
+
+    /* and now we ask for histogram allocation */
+    DefineHistograms();
+  }
+}
+
+/// A new event is starting to be analyzed
+/// Store MC needed data in case of AOD format
+void AliCSEventCuts::NotifyEvent() {
+  /* let's produce some feedback about MC dataset configuration */
+  if (fgIsMC) {
+    AliInfo(Form("Handling a MC event with %s format", (fgIsESD ? "ESD" : "AOD")));
+    AliInfo(Form("========= MC handler is %s", ((fgMCHandler != NULL) ? "NOT null" : "NULL")));
+  }
+
+  if (fgIsMC && !fgIsESD) {
+    fgMCArray = dynamic_cast<TClonesArray*>(((AliAODEvent *)fgInputHandler->GetEvent())->FindListObject(AliAODMCParticle::StdBranchName()));
+  }
+}
+
+/// Check whether the passed event is accepted by the different cuts
+/// \param fInputEvent the current event to evaluate
+/// \return kTRUE if the event is accepted, kFALSE otherwise
+Bool_t AliCSEventCuts::IsEventAccepted(AliVEvent *fInputEvent) {
+  Bool_t accepted = kTRUE;
+
+  /* initialize the mask of activated cuts */
+  fCutsActivatedMask.ResetAllBits();
+
+  /* check for MC event and its quality */
+  if (fgIsMC) {
+    if (fgIsESD) {
+      if (!fgMCHandler->InitOk() || !fgMCHandler->TreeK() || !fgMCHandler->TreeTR()){
+        fCutsActivatedMask.SetBitNumber(kMCdataQuality);
+        accepted = kFALSE;
+      }
+    }
+    else {
+      TClonesArray *arrayMC = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
+      if (arrayMC == NULL) {
+        fCutsActivatedMask.SetBitNumber(kMCdataQuality);
+        accepted = kFALSE;
+      }
+    }
+  }
+
+  /* is the event information complete */
+  if (fInputEvent->IsIncompleteDAQ()) {
+    fCutsActivatedMask.SetBitNumber(kDAQIncompleteCut);
+    accepted = kFALSE;
+  }
+
+  StoreEventCentralities(fInputEvent);
+  StoreEventMultiplicities(fInputEvent);
+
+  /* is the event having any track */
+  if (fReferenceMultiplicity < 0){
+    fCutsActivatedMask.SetBitNumber(kNoTracks);
+    accepted = kFALSE;
+  }
+
+  /* trigger cut */
+  UInt_t offlineTriggerMask = fOfflineTriggerMask;
+  if (fgIsMC && fSystem != kpp)
+    offlineTriggerMask = AliVEvent::kAny;
+  if (!(offlineTriggerMask & fgInputHandler->IsEventSelected())) {
+    /* cut activated, event rejected */
+    fCutsActivatedMask.SetBitNumber(kOfflineTriggerCut);
+    accepted = kFALSE;
+  }
+
+  /* vertex cut */
+  fVertexZ = GetVertexZ(fInputEvent);
+  if (fCutsEnabledMask.TestBitNumber(kVertexCut)) {
+    if (GetNumberOfVertexContributors(fInputEvent) < 1) {
+      fCutsActivatedMask.SetBitNumber(kVertexContributorsCut);
+      accepted = kFALSE;
+    }
+    if (!PassVertexResolutionAndDispersionTh(fInputEvent)) {
+      fCutsActivatedMask.SetBitNumber(kVertexQualityCut);
+      accepted = kFALSE;
+    }
+    if (fUseSPDTracksVtxDist) {
+      if (!AcceptSPDTracksVtxDist(fInputEvent)) {
+        fCutsActivatedMask.SetBitNumber(kSPDTrackVtxDistance);
+        accepted = kFALSE;
+      }
+    }
+    if (fMaxVertexZ < TMath::Abs(fVertexZ)) {
+      fCutsActivatedMask.SetBitNumber(kVertexCut);
+      accepted = kFALSE;
+    }
+  }
+
+  /* pile up cut */
+  if (fSystem == kpPb) {
+    if (fAnalysisUtils.IsFirstEventInChunk(fInputEvent)) {
+      fCutsActivatedMask.SetBitNumber(kPileUpCut);
+      accepted = kFALSE;
+    }
+  }
+  if (fCutsEnabledMask.TestBitNumber(kPileUpCut)) {
+    if(fAnalysisUtils.IsPileUpEvent(fInputEvent)){
+      fCutsActivatedMask.SetBitNumber(kPileUpCut);
+      accepted = kFALSE;
+    }
+    if (fAnalysisUtils.IsSPDClusterVsTrackletBG(fInputEvent)){
+      fCutsActivatedMask.SetBitNumber(kSPDClsVsTrkaletsCut);
+      accepted = kFALSE;
+    }
+  }
+
+  /* centrality cut */
+  fCentrality = GetEventCentrality(fInputEvent);
+  AliInfo(Form("Event centrality: %f", Float_t(fCentrality)));
+  if (fCutsEnabledMask.TestBitNumber(kCentralityCut)) {
+    if (fCentrality < fCentralityMin || fCentralityMax <= fCentrality ) {
+      fCutsActivatedMask.SetBitNumber(kCentralityCut);
+      accepted = kFALSE;
+    }
+  }
+
+  /* 2015 additional pile up cut also applicable to 2010h*/
+  /* check the additional pile up rejection if required */
+  if (fCutsEnabledMask.TestBitNumber(k2015PileUpCut)) {
+    if (Is2015PileUpEvent()) {
+      fCutsActivatedMask.SetBitNumber(k2015PileUpCut);
+      accepted = kFALSE;
+    }
+  }
+
+  if (fQALevel > kQALevelNone) {
+    /* let's fill the histograms */
+    fhCutsStatistics->Fill(fhCutsStatistics->GetBinCenter(fhCutsStatistics->GetXaxis()->FindBin("n events")));
+    fhUniqueCutsStatistics->Fill(fhUniqueCutsStatistics->GetBinCenter(fhUniqueCutsStatistics->GetXaxis()->FindBin("n events")));
+    if (!accepted)
+      fhCutsStatistics->Fill(fhCutsStatistics->GetBinCenter(fhCutsStatistics->GetXaxis()->FindBin("n cut events")));
+    else
+      fhUniqueCutsStatistics->Fill(fhUniqueCutsStatistics->GetBinCenter(fhUniqueCutsStatistics->GetXaxis()->FindBin("n passed events")));
+
+    for (Int_t i=0; i<kNCuts; i++) {
+      if (fCutsActivatedMask.TestBitNumber(i)) {
+        if ((fhCutsStatistics->GetXaxis()->FindBin(fgkCutsNames[i]) < 1) || (fhUniqueCutsStatistics->GetXaxis()->FindBin(fgkCutsNames[i]) < 1))
+          AliFatal(Form("Inconsistency! Cut %d with name %s not found", i, fgkCutsNames[i]));
+
+        fhCutsStatistics->Fill(fhCutsStatistics->GetBinCenter(fhCutsStatistics->GetXaxis()->FindBin(fgkCutsNames[i])));
+        if (fCutsActivatedMask.CountBits() == 1)
+          fhUniqueCutsStatistics->Fill(fhUniqueCutsStatistics->GetBinCenter(fhUniqueCutsStatistics->GetXaxis()->FindBin(fgkCutsNames[i])));
+      }
+
+      if (fQALevel > kQALevelLight) {
+        for (Int_t j=i; j<kNCuts; j++) {
+          if (fCutsActivatedMask.TestBitNumber(i) && fCutsActivatedMask.TestBitNumber(j)) {
+            if (fhCutsStatistics->GetXaxis()->FindBin(fgkCutsNames[j]) < 1)
+              AliFatal(Form("Inconsistency! Cut %d with name %s not found", j, fgkCutsNames[j]));
+
+            Float_t xC = fhCutsCorrelation->GetXaxis()->GetBinCenter(fhCutsCorrelation->GetXaxis()->FindBin(fgkCutsNames[i]));
+            Float_t yC = fhCutsCorrelation->GetYaxis()->GetBinCenter(fhCutsCorrelation->GetYaxis()->FindBin(fgkCutsNames[j]));
+            fhCutsCorrelation->Fill(xC, yC);
+          }
+        }
+      }
+    }
+
+    /* prepare additional data in case they were needed */
+    Int_t nClustersLayer0 = fInputEvent->GetNumberOfITSClusters(0);
+    Int_t nClustersLayer1 = fInputEvent->GetNumberOfITSClusters(1);
+    Int_t nTracklets      = fInputEvent->GetMultiplicity()->GetNumberOfTracklets();
+    Float_t altcentrality = this->GetEventAltCentrality(fInputEvent);
+
+    for (Int_t i = 0; i < 2; i++) {
+
+      fhCentrality[i]->Fill(fCentrality);
+      fhVertexZ[i]->Fill(fVertexZ);
+
+      if (fQALevel > kQALevelLight) {
+        fhSPDClustersVsTracklets[i]->Fill(nTracklets, nClustersLayer0+nClustersLayer1);
+        fhV0MvsTracksTPCout[i]->Fill(fNoOfTPCoutTracks, fV0Multiplicity);
+        fhV0MvsTracksInitialTPCout[i]->Fill(fNoOfInitialTPCoutTracks, fV0Multiplicity);
+        fhCentralityAltVsSel[i]->Fill(fCentrality,altcentrality);
+        fhCL0vsV0MCentrality[i]->Fill(fV0MCentrality,fCL0Centrality);
+        fhESDvsTPConlyMultiplicity[i]->Fill(fNoOfFB128Tracks,fNoOfESDTracks);
+        fhTOFvsGlobalMultiplicity[i]->Fill(fNoOfFB32Tracks,fNoOfFB32TOFTracks);
+        fhAccTrkvsV0MCentrality[i]->Fill(fV0MCentrality,fNoOfFB32AccTracks);
+      }
+
+      /* the trigger histogram */
+      UInt_t selectedTrigger = fgInputHandler->IsEventSelected();
+      if (selectedTrigger & AliVEvent::kMB)fhTriggerClass[i]->Fill(0);
+      if (selectedTrigger & AliVEvent::kINT7)fhTriggerClass[i]->Fill(1);
+      if (selectedTrigger & AliVEvent::kMUON)fhTriggerClass[i]->Fill(2);
+      if (selectedTrigger & AliVEvent::kHighMult)fhTriggerClass[i]->Fill(3);
+      if (selectedTrigger & AliVEvent::kEMC1)fhTriggerClass[i]->Fill(4);
+      if (selectedTrigger & AliVEvent::kCINT5)fhTriggerClass[i]->Fill(5);
+      if (selectedTrigger & AliVEvent::kCMUS5)fhTriggerClass[i]->Fill(6);
+      if (selectedTrigger & AliVEvent::kMUSH7)fhTriggerClass[i]->Fill(7);
+      if (selectedTrigger & AliVEvent::kMUL7)fhTriggerClass[i]->Fill(8);
+      if (selectedTrigger & AliVEvent::kMUU7)fhTriggerClass[i]->Fill(9);
+      if (selectedTrigger & AliVEvent::kEMC7)fhTriggerClass[i]->Fill(10);
+      if (selectedTrigger & AliVEvent::kMUS7)fhTriggerClass[i]->Fill(11);
+      if (selectedTrigger & AliVEvent::kPHI1)fhTriggerClass[i]->Fill(12);
+      if (selectedTrigger & AliVEvent::kPHI7)fhTriggerClass[i]->Fill(13);
+      if (selectedTrigger & AliVEvent::kEMCEJE)fhTriggerClass[i]->Fill(14);
+      if (selectedTrigger & AliVEvent::kEMCEGA)fhTriggerClass[i]->Fill(15);
+      if (selectedTrigger & AliVEvent::kCentral)fhTriggerClass[i]->Fill(16);
+      if (selectedTrigger & AliVEvent::kSemiCentral)fhTriggerClass[i]->Fill(17);
+      if (selectedTrigger & AliVEvent::kDG5)fhTriggerClass[i]->Fill(18);
+      if (selectedTrigger & AliVEvent::kZED)fhTriggerClass[i]->Fill(19);
+      if (selectedTrigger & AliVEvent::kSPI7)fhTriggerClass[i]->Fill(20);
+      if (selectedTrigger & AliVEvent::kINT8)fhTriggerClass[i]->Fill(21);
+      if (selectedTrigger & AliVEvent::kMuonSingleLowPt8)fhTriggerClass[i]->Fill(22);
+      if (selectedTrigger & AliVEvent::kMuonSingleHighPt8)fhTriggerClass[i]->Fill(23);
+      if (selectedTrigger & AliVEvent::kMuonLikeLowPt8)fhTriggerClass[i]->Fill(24);
+      if (selectedTrigger & AliVEvent::kMuonUnlikeLowPt8)fhTriggerClass[i]->Fill(25);
+      if (selectedTrigger & AliVEvent::kMuonUnlikeLowPt0)fhTriggerClass[i]->Fill(26);
+      if (selectedTrigger & AliVEvent::kUserDefined)fhTriggerClass[i]->Fill(27);
+      if (selectedTrigger & AliVEvent::kTRD)fhTriggerClass[i]->Fill(28);
+      if (selectedTrigger & AliVEvent::kFastOnly)fhTriggerClass[i]->Fill(29);
+      if (selectedTrigger & AliVEvent::kAnyINT)fhTriggerClass[i]->Fill(30);
+      if (selectedTrigger & AliVEvent::kAny)fhTriggerClass[i]->Fill(31);
+      if (!(selectedTrigger & AliVEvent::kFastOnly))fhTriggerClass[i]->Fill(32);
+      if (selectedTrigger == 0x0)fhTriggerClass[i]->Fill(33);
+
+      /* don't fill after if event not accepted */
+      if (!accepted) break;
+    }
+  }
+  return accepted;
+}
+
+
+
+/// Sets the individual value for the cut parameter ID
+/// \param paramID the ID of the cut parameter of interest
+/// \param value the value for the cut parameter
+/// \return kTRUE if the cut parameter value was accepted
+Bool_t AliCSEventCuts::SetCutAndParams(Int_t paramID, Int_t value) {
+
+  switch (cutsParametersIds(paramID)) {
+  case kSystem:
+    if( SetSystemType(SystemType(value))) {
+      fParameters[kSystem] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kCentralityType:
+    if( SetCentralityType(value)) {
+      fParameters[kCentralityType] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kCentralityMin:
+    if( SetCentralityMin(value)) {
+      fParameters[kCentralityMin] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kCentralityMax:
+    if( SetCentralityMax(value)) {
+      fParameters[kCentralityMax] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kActiveTrigger:
+    if( SetSelectActiveTrigger(value)) {
+      fParameters[kActiveTrigger] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kActiveSubTrigger:
+    if( SetSelectActiveSubTrigger(value)) {
+      fParameters[kActiveSubTrigger] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kRemovePileUp:
+    if( SetRemovePileUp(value)) {
+      fParameters[kRemovePileUp] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kVertex:
+    if( SetVertexCut(value)) {
+      fParameters[kVertex] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kRemove2015PileUp:
+    if( SetRemove2015PileUp(value)) {
+      fParameters[kRemove2015PileUp] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  default:
+    AliError(Form("Cut id %d out of range", paramID));
+    return kFALSE;
+  }
+}
+
+
+/// Print the whole cut information for the cut parameter ID
+/// \param paramID the ID of the cut of interest
+void AliCSEventCuts::PrintCutWithParams(Int_t paramID) const {
+
+  switch (cutsParametersIds(paramID)) {
+  case kSystem:
+    switch(fSystem) {
+    case kNoSystem:
+      printf("SYSTEM: none\n");
+      break;
+    case kpp:
+      printf("SYSTEM: p-p\n");
+      break;
+    case kpPb:
+      printf("SYSTEM: p-Pb\n");
+      break;
+    case kPbPb:
+      printf("SYSTEM: Pb-Pb\n");
+      break;
+    default:
+      printf("SYSTEM: no proper system configured\n");
+    }
+    break;
+  case kCentralityType:
+    if (fCutsEnabledMask.TestBitNumber(kCentralityCut)) {
+      TString szEstimator;
+      if (fCentralityDetector == 1)
+        szEstimator = "CL1";
+      else
+        if (fSystem == kpPb)
+          szEstimator = "V0A";
+        else
+          szEstimator = "V0M";
+
+      printf("  Centrality cut: using %s. ", szEstimator.Data());
+    }
+    else {
+      printf("  Centrality cut: not cutting in centrality\n");
+    }
+    break;
+  case kCentralityMin:
+    if (fCutsEnabledMask.TestBitNumber(kCentralityCut)) {
+      printf("Range: %.1f-", fCentralityMin);
+    }
+    break;
+  case kCentralityMax:
+    if (fCutsEnabledMask.TestBitNumber(kCentralityCut)) {
+      printf("%.1f\n", fCentralityMax);
+    }
+    break;
+  case kActiveTrigger: {
+      /* this is a first try to print trigger information for the current */
+      /* reduced set of triggers supported. Smarter version should come */
+      printf("  Offline trigger: ");
+      UInt_t triggerPrintedMask = 0x0;
+      PrintTrigger(triggerPrintedMask, AliVEvent::kAny, "kAny");
+      PrintTrigger(triggerPrintedMask, AliVEvent::kMB, "kMB");
+      PrintTrigger(triggerPrintedMask, AliVEvent::kINT7, "kINT7");
+      PrintTrigger(triggerPrintedMask, AliVEvent::kDG5, "kDG5");
+    }
+    break;
+  case kActiveSubTrigger: {
+      /* no sub-trigger supported yet */
+      printf("    sub-trigger: none\n");
+    }
+    break;
+  case kRemovePileUp:
+    /* this is a bit tricky because AnalysisUtils does not allow to get its configuration */
+    printf("  Pile up removal:\n");
+    switch(fParameters[kRemovePileUp]) {
+    case 0:
+      printf("    none\n");
+      break;
+    case 1: /* use SPD multiple vertices */
+      printf("    using SPD multiple vertices\n");
+      printf("    background rejection with cluster-vs-tracklet default cut\n");
+      break;
+    case 2: /* use SPD multiple vertices  & out-of-bunch pileup rejection */
+      printf("    using SPD multiple vertices\n");
+      printf("    background rejection with cluster-vs-tracklet default cut\n");
+      printf("    using out-of-bunch pileup rejection\n");
+      break;
+    case 3: /* use track multivertexer */
+      printf("    using track multivertexer\n");
+      printf("    background rejection with cluster-vs-tracklet default cut\n");
+      break;
+    case 4: /* use track multivertexer & out-of-bunch pileup rejection */
+      printf("    using track multivertexer\n");
+      printf("    background rejection with cluster-vs-tracklet default cut\n");
+      printf("    using out-of-bunch pileup rejection\n");
+      break;
+    default:
+      printf("    Pile up removal procedure %d not supported", fParameters[kRemovePileUp]);
+    }
+    break;
+  case kVertex:
+    printf("  Z vertex cut: ");
+    if (fCutsEnabledMask.TestBitNumber(kVertexCut)) {
+      printf("|Zvtx| < %.1f\n", fMaxVertexZ);
+      if (fUseSPDTracksVtxDist) {
+        printf("    Cutting on distance between SPD and track vertices\n");
+      }
+    }
+    else
+      printf("none\n");
+    break;
+  case kRemove2015PileUp:
+    /* this is a bit tricky because AnalysisUtils does not allow to get its configuration */
+    printf("  2015 additional pile up removal:\n");
+    switch(fParameters[kRemove2015PileUp]) {
+    case 0:
+      printf("    none\n");
+      break;
+    case 1: /* use J/psi 2015 pile up rejection initial, faulty, method */
+      printf("    using J/psi 2015 pile up rejection, initial (faulty) method of track counting\n");
+      printf("    actual cut will depend on data period\n");
+      break;
+    case 2: /* Centrality and multiplicity correlations for 2015*/
+      printf("    using centrality and multiplicity correlations for 2015 pile up rejection\n");
+      printf("    actual cut will depend on data period\n");
+      break;
+    case 3: /* use J/psi 2015 pile up rejection initial, corrected, method*/
+      printf("    using J/psi 2015 pile up rejection , initial (corrected) method of track counting\n");
+      printf("    actual cut will depend on data period\n");
+      break;
+    default:
+      printf("    2015 additional pile up removal procedure %d not supported\n", fParameters[kRemove2015PileUp]);
+    }
+    break;
+  default:
+    AliError(Form("Cut id %d out of range", paramID));
+  }
+}
+
+/// Prints trigger name
+///
+/// Trigger name is only printed if active.
+/// A check is made to print the continuation after printing the trigger name.
+/// The printed mask is updated with the current trigger if active and printed.
+/// \param printed the already printed triggers
+/// \param trigger the mask associated with the trigger to print
+/// \param name the name of the interested trigger
+void AliCSEventCuts::PrintTrigger(UInt_t &printed, UInt_t trigger, const char *name) const {
+  /* check if done */
+  if (fOfflineTriggerMask == printed) return;
+  /* check if active */
+  if ((fOfflineTriggerMask & trigger) == trigger) {
+    printf("%s", name);
+    printed = printed | trigger;
+    if ((fOfflineTriggerMask & printed) == fOfflineTriggerMask)
+      printf("\n"); /* last trigger */
+      if (trigger == AliVEvent::kAny) {
+        printf("    could depend on data period\n");
+      }
+    else
+      printf("+"); /* still more triggers to print */
+  }
+}
+
+/// Sets the system type
+/// \param system the system type
+///    |code| centrality estimator, range modifier |
+///    |:---|--------|
+///    |  AliCSEventCuts::kNoSystem | no system dependent cut |
+///    |  AliCSEventCuts::kpp  | **p-p** system |
+///    |  AliCSEventCuts::kpPb | **p-Pb** system |
+///    |  AliCSEventCuts::kPbPb  | **Pb-Pb** system |
+/// \return kTRUE if a proper and supported system
+Bool_t AliCSEventCuts::SetSystemType(SystemType system) {
+  switch(system){
+  case kNoSystem:
+    fSystem = kNoSystem;
+    break;
+  case kpp:
+    fSystem = kpp;
+    break;
+  case kpPb:
+    fSystem = kpPb;
+    break;
+  case kPbPb:
+    fSystem = kPbPb;
+    break;
+  default:
+    AliError(Form("SetSystemType not defined %d",Int_t(system)));
+    return kFALSE;
+  }
+  /* re-evaluate centralitiy ranges in case called individualy */
+  return SetCentralityType(fParameters[kCentralityType]);
+}
+
+/// Sets the acutal system type according to the data period
+void AliCSEventCuts::SetActualSystemType() {
+  SystemType system;
+  switch (GetGlobalAnchorPeriod()) {
+  case kLHC10bg:
+  case kLHC11a:
+  case kLHC11b:
+  case kLHC11cg:
+  case kLHC12:
+  case kLHC13g:
+  case kLHC15fm:
+  case kLHC15n:
+  case kLHC16k:
+  case kLHC16l:
+    system = kpp;
+    AliInfo("SYSTEM: p-p");
+    break;
+  case kLHC13bc:
+  case kLHC13de:
+  case kLHC13f:
+    system = kpPb;
+    AliInfo("SYSTEM: p-Pb");
+    break;
+  case kLHC10h:
+  case kLHC11h:
+  case kLHC15oLIR:
+  case kLHC15oHIR:
+    system = kPbPb;
+    AliInfo("SYSTEM: Pb-Pb");
+    break;
+  default:
+    system = kNoSystem;
+    AliError("SYSTEM: no system set from data files");
+  }
+
+  /* re-state system type according to data period */
+  SetSystemType(system);
+  fParameters[kSystem] = system;
+  UpdateCutsString();
+}
+
+/// Sets the type of centrality to handle
+/// \param ctype the centrality type
+///    |code| detector for centrality estimate, range modifier |
+///    |:--:|--------|
+///    |  0 | no centrality cut |
+///    |  1 | default detector for the concerned system, cut in the range 0-100% in steps of 10% |
+///    |  2 | alternative detector for the concerned system, cut in the range 0-100% in steps of 10% |
+///    |  3 | default detector for the concerned system, cut in the range 0-50% in steps of 5% |
+///    |  4 | default detector for the concerned system, cut in the range 50-100% in steps of 5% |
+///    |  5 | default detector for the concerned system, cut in the range 0-10% in steps of 1% |
+///    |  6 | default detector for the concerned system, cut in the range 10-20% in steps of 1% |
+/// \return kTRUE if proper and supported centrality type
+///
+/// The default and alternative detector for centrality estimation in the different systems
+///   | System | default detector | alternative detector |
+///   |:--|:--:|:--:|
+///   | **p-p** | **V0M** | **CL1** |
+///   | **p-pB** | **V0A** | **CL1** |
+///   | **pB-pB** | **V0M** | **CL1** |
+///
+Bool_t AliCSEventCuts::SetCentralityType(Int_t ctype)
+{   // Set Cut
+  switch(ctype){
+  case 0:
+    fCutsEnabledMask.ResetBitNumber(kCentralityCut);
+    fCentralityDetector=0;
+    fCentralityModifier=0;
+    break;
+  case 1:
+    /* default centrality detector for the concerned system */
+    /* centrality cut in the range 0-100% */
+    fCutsEnabledMask.SetBitNumber(kCentralityCut);
+    fCentralityDetector=0;
+    fCentralityModifier=0;
+    break;
+  case 2:
+    /* alternative centrality detectorfor the concerned system */
+    /* centrality cut in the range 0-100% */
+    fCutsEnabledMask.SetBitNumber(kCentralityCut);
+    fCentralityDetector=1;
+    fCentralityModifier=0;
+    break;
+  case 3:
+    /* default centrality detector for the concerned system */
+    /* centrality cut in the range 0-50% in steps of 5% */
+    fCutsEnabledMask.SetBitNumber(kCentralityCut);
+    fCentralityDetector=0;
+    fCentralityModifier=1;
+    break;
+  case 4:
+    /* default centrality detector for the concerned system */
+    /* centrality cut in the range 50-100% in steps of 5% */
+    fCutsEnabledMask.SetBitNumber(kCentralityCut);
+    fCentralityDetector=0;
+    fCentralityModifier=2;
+    break;
+  case 5:
+    /* default centrality detector for the concerned system */
+    /* centrality cut in the range 0-10% in steps of 1% */
+    fCutsEnabledMask.SetBitNumber(kCentralityCut);
+    fCentralityDetector=0;
+    fCentralityModifier=3;
+    break;
+  case 6:
+    /* default centrality detector for the concerned system */
+    /* centrality cut in the range 10-20% in steps of 1% */
+    fCutsEnabledMask.SetBitNumber(kCentralityCut);
+    fCentralityDetector=0;
+    fCentralityModifier=4;
+    break;
+  default:
+    AliError(Form("Centrality type %d not supported",ctype));
+    return kFALSE;
+  }
+  /* re-evaluate centrality ranges in case called individually */
+  return SetCentralityMax(fParameters[kCentralityMax]);
+}
+
+/// Sets the min value for the centrality cut
+/// The action is delayed until getting the max value
+/// \param min the min value for the centrality cut
+/// \return kTRUE always
+/// If \f$max < min\f$ or \f$min = max \neq 0\f$ any positive centrality value is accepted.
+///
+/// For **p-p** systems \f$min\f$ and \f$max\f$ are indexes of the array
+/// ~~~~{.cpp}
+/// static const Float_t primaryTracksFor_pp [10] = { 0, 2, 5, 10, 15, 30, 50, 100, 500, 1000};
+/// ~~~~
+Bool_t AliCSEventCuts::SetCentralityMin(Int_t min)
+{
+  /* re-evaluate centrality ranges in case called individually */
+  return SetCentralityMax(fParameters[kCentralityMax]);
+}
+
+/// Sets the max value for the centrality cut
+///
+/// min and max values are analyzed together with system type
+/// and centrality type to extract the actual min and max
+/// values for the cut.
+/// \param max the max value for the centrality cut
+/// \return kTRUE if the min and max values are consistent
+/// If \f$max < min\f$ or \f$min = max \neq 0\f$ any positive centrality value is accepted.
+///
+/// For **p-p** systems \f$min\f$ and \f$max\f$ are indexes of the array
+/// ~~~~{.cpp}
+/// static const Float_t primaryTracksFor_pp [10] = { 0, 2, 5, 10, 15, 30, 50, 100, 500, 1000};
+/// ~~~~
+/// If \f$max = 0\f$ then \f$max = 10\f$
+Bool_t AliCSEventCuts::SetCentralityMax(Int_t max)
+{
+  static const Float_t primaryTracksFor_pp [10] = { 0, 2, 5, 10, 15, 30, 50, 100, 500, 1000};
+
+  /* first check if the cut is active */
+  if (fCutsEnabledMask.TestBitNumber(kCentralityCut)) {
+    /* we rescue the min value */
+    Int_t min = fParameters[kCentralityMin];
+
+    if ((max < min) ||
+        ((min == max) && (min != 0))) {
+      /* accept everything */
+      fCentralityMin = 0.0;
+      fCentralityMax = 1e6;
+    }
+
+    if(fSystem == kpp){
+      fCentralityMin = primaryTracksFor_pp[min];
+      fCentralityMax = primaryTracksFor_pp[max];
+    }
+    else {
+      /* full range */
+      if (max == 0) max = 10;
+      switch (fCentralityModifier) {
+      case 0:
+        fCentralityMin = min * 10;
+        fCentralityMax = max * 10;
+        break;
+      case 1:
+        fCentralityMin = min * 5;
+        fCentralityMax = max * 5;
+        break;
+      case 2:
+        fCentralityMin = 50 + min * 5;
+        fCentralityMax = 50 + max * 5;
+        break;
+      case 3:
+        fCentralityMin = min;
+        fCentralityMax = max;
+        break;
+      case 4:
+        fCentralityMin = 10 + min;
+        fCentralityMax = 10 + max;
+        break;
+      default:
+        AliError("Inconsistent centrality modifier");
+        return kFALSE;
+      }
+    }
+    return kTRUE;
+  }
+  else
+    /* cut not active, accept anything */
+    return kTRUE;
+}
+
+/// Check for the use of the new multiplicity framework
+/// \return kTRUE if the new multiplicity framework has to be use, kFALSE otherwise
+Bool_t AliCSEventCuts::UseNewMultiplicityFramework() const{
+
+  switch (GetGlobalAnchorPeriod()) {
+  case kLHC15oLIR:
+  case kLHC15oHIR:
+    AliInfo("Using NEW mulitplicity framework");
+    return kTRUE;
+  default:
+    AliInfo("Using TRADITIONAL centrality framework");
+    return kFALSE;
+  }
+}
+
+/// Gets the event centrality
+///
+/// A check on the period under analysis is done to select the way to estimate centrality.
+/// Additionally the configured default or alternative detector is used.
+/// \param event the current event to analyze
+/// \return the event centrality
+
+Float_t AliCSEventCuts::GetEventCentrality(AliVEvent *event) const
+{
+  AliESDEvent *esdEvent=dynamic_cast<AliESDEvent*>(event);
+  AliAODEvent *aodEvent=dynamic_cast<AliAODEvent*>(event);
+
+  /* for p-p systems just return FB32 accepted multiplicity */
+  if (fSystem == kpp)
+    return this->fNoOfFB32AccTracks;
+
+  if (esdEvent != NULL) {
+    AliCentrality *Centrality = event->GetCentrality();
+    if (fUseNewMultFramework) {
+      AliMultSelection *MultSelection = (AliMultSelection*) event->FindListObject("MultSelection");
+      if (MultSelection == NULL) {
+        AliError("No MultSelection object instance");
+        return -1.0;
+      }
+      switch(fCentralityDetector) {
+      case 0:
+        /* default centrality detector */
+        if (fSystem == kpPb)
+          return Centrality->GetCentralityPercentile("V0A");
+        else
+          /* we don't leave Multiplicity task cuts precede our own */
+          return MultSelection->GetMultiplicityPercentile("V0M", kFALSE);
+      case 1:
+        /* alternative centrality detector */
+        /* we don't leave Multiplicity task cuts precede our own */
+        return MultSelection->GetMultiplicityPercentile("CL1", kFALSE);
+      default:
+        AliError("Wrong stored centrality detector");
+        return -1.0;
+      }
+    }
+    else {
+      switch(fCentralityDetector) {
+      case 0:
+        /* default centrality detector */
+        if (fSystem == kpPb)
+          return Centrality->GetCentralityPercentile("V0A");
+        else
+          return Centrality->GetCentralityPercentile("V0M");
+      case 1:
+        /* alternative centrality detector */
+        return Centrality->GetCentralityPercentile("CL1");
+      default:
+        AliError("Wrong stored centrality detector");
+        return -1.0;
+      }
+    }
+  }
+
+  if(aodEvent){
+    if(fUseNewMultFramework){
+      AliMultSelection *MultSelection = (AliMultSelection *)event->FindListObject("MultSelection");
+      if (MultSelection == NULL) {
+        AliError("No MultSelection object instance");
+        return -1.0;
+      }
+      switch(fCentralityDetector) {
+      case 0:
+        /* default centrality detector */
+        /* we don't leave Multiplicity task cuts precede our own */
+        return MultSelection->GetMultiplicityPercentile("V0M",kFALSE);
+      case 1:
+        /* alternative centrality detector */
+        /* we don't leave Multiplicity task cuts precede our own */
+        return MultSelection->GetMultiplicityPercentile("CL1",kFALSE);
+      default:
+        AliError("Wrong stored centrality detector");
+        return -1.0;
+      }
+    }else{
+      if(aodEvent->GetHeader()) {
+        AliCentrality *aodCentrality = ((AliVAODHeader*)aodEvent->GetHeader())->GetCentralityP();
+        if (aodCentrality != NULL) {
+          switch(fCentralityDetector) {
+          case 0:
+            /* default centrality detector */
+            if (fSystem == kpPb)
+              return aodCentrality->GetCentralityPercentile("V0A");
+            else
+              return aodCentrality->GetCentralityPercentile("V0M");
+          case 1:
+            /* alternative centrality detector */
+            return aodCentrality->GetCentralityPercentile("CL1");
+          default:
+            AliError("Wrong stored centrality detector");
+            return -1.0;
+          }
+        }
+        else {
+          AliError("No AliCentrality attached to AOD header");
+          return -1;
+        }
+      }
+      else {
+        AliError("Not a standard AOD");
+        return -1;
+      }
+    }
+  }
+  return -1;
+}
+
+
+/// Gets the event centrality from the alternative detector
+///
+/// A check on the period under analysis is done to select the way to estimate centrality.
+/// Additionally the alternative to the configured detector is used.
+/// \param event the current event to analyze
+/// \return the event centrality from the alternative detector
+
+Float_t AliCSEventCuts::GetEventAltCentrality(AliVEvent *event) const
+{
+  AliESDEvent *esdEvent=dynamic_cast<AliESDEvent*>(event);
+  AliAODEvent *aodEvent=dynamic_cast<AliAODEvent*>(event);
+
+  if (esdEvent != NULL) {
+    AliCentrality *Centrality = event->GetCentrality();
+    if (fUseNewMultFramework) {
+      AliMultSelection *MultSelection = (AliMultSelection*) event->FindListObject("MultSelection");
+      if (MultSelection == NULL) {
+        AliError("No MultSelection object instance");
+        return -1.0;
+      }
+      switch(fCentralityDetector) {
+      case 0:
+        /* default centrality detector  selected so we use the alternative one*/
+        /* we don't leave Multiplicity task cuts precede our own */
+        return MultSelection->GetMultiplicityPercentile("CL1", kFALSE);
+
+      case 1:
+        /* alternative centrality detector so we use the default one */
+        if (fSystem == kpPb)
+          return Centrality->GetCentralityPercentile("V0A");
+        else
+          /* we don't leave Multiplicity task cuts precede our own */
+          return MultSelection->GetMultiplicityPercentile("V0M", kFALSE);
+      default:
+        AliError("Wrong stored centrality detector");
+        return -1.0;
+      }
+    }
+    else {
+      switch(fCentralityDetector) {
+      case 0:
+        /* default centrality detector so we use the alternative one */
+        return Centrality->GetCentralityPercentile("CL1");
+      case 1:
+        /* alternative centrality detector so we use the default one */
+        if (fSystem == kpPb)
+          return Centrality->GetCentralityPercentile("V0A");
+        else
+          return Centrality->GetCentralityPercentile("V0M");
+      default:
+        AliError("Wrong stored centrality detector");
+        return -1.0;
+      }
+    }
+  }
+
+  if(aodEvent){
+    if(fUseNewMultFramework){
+      AliMultSelection *MultSelection = (AliMultSelection *)event->FindListObject("MultSelection");
+      if (MultSelection == NULL) {
+        AliError("No MultSelection object instance");
+        return -1.0;
+      }
+      switch(fCentralityDetector) {
+      case 0:
+        /* default centrality detector so we use the alternative one */
+        /* we don't leave Multiplicity task cuts precede our own */
+        return MultSelection->GetMultiplicityPercentile("CL1",kFALSE);
+      case 1:
+        /* alternative centrality detector so we use the default one */
+        /* we don't leave Multiplicity task cuts precede our own */
+        return MultSelection->GetMultiplicityPercentile("V0M",kFALSE);
+      default:
+        AliError("Wrong stored centrality detector");
+        return -1.0;
+      }
+    }else{
+      if(aodEvent->GetHeader()) {
+        AliCentrality *aodCentrality = ((AliVAODHeader*)aodEvent->GetHeader())->GetCentralityP();
+        if (aodCentrality != NULL) {
+          switch(fCentralityDetector) {
+          case 0:
+            /* default centrality detector so we use the alternative one */
+            return aodCentrality->GetCentralityPercentile("CL1");
+          case 1:
+            /* alternative centrality detector so we use the default one */
+            if (fSystem == kpPb)
+              return aodCentrality->GetCentralityPercentile("V0A");
+            else
+              return aodCentrality->GetCentralityPercentile("V0M");
+          default:
+            AliError("Wrong stored centrality detector");
+            return -1.0;
+          }
+        }
+        else {
+          AliError("No AliCentrality attached to AOD header");
+          return -1;
+        }
+      }
+      else {
+        AliError("Not a standard AOD");
+        return -1;
+      }
+    }
+  }
+  return -1;
+}
+
+
+
+/// Gets the names of the centrality estimator detectors
+///
+/// A check on the period under analysis is done to select the way to estimate centrality.
+/// The configured and of the alternative detector is returned.
+/// \param sel the name of the selected detector
+/// \param alt the name of the alternative selector
+
+void AliCSEventCuts::GetCentralityEstimatorNames(const char *&sel, const char *&alt) const
+{
+  /* TODO: when ESD - AOD is supported by the base clas this method needs to be adapted */
+  /* so far only considers the ESD case */
+  static const char V0A[] = "V0A";
+  static const char V0M[] = "V0M";
+  static const char CL1[] = "CL1";
+
+  sel = NULL;
+  alt = NULL;
+
+  switch(fCentralityDetector) {
+  case 0:
+    /* default centrality detector */
+    if (fSystem == kpPb) {
+      sel = V0A;
+      alt = CL1;
+    }
+    else {
+      sel = V0M;
+      alt = CL1;
+    }
+    break;
+  case 1:
+    /* alternative centrality detector */
+    if (fSystem == kpPb) {
+      sel = CL1;
+      alt = V0A;
+    }
+    else {
+      sel = CL1;
+      alt = V0M;
+    }
+    break;
+  default:
+    AliError("Wrong stored centrality detector");
+  }
+}
+
+
+
+/// Manual trigger selection
+/// \param trigger the selected trigger combination to activate
+///    |code| trigger | Observations |
+///    |:--:|--------|
+///    |  0 | AliVEvent::kAny | |
+///    |  1 | AliVEvent::kMB or AliVEvent::kINT7 | depends on period |
+///    |  5 | AliVEvent::kDG or AliVEvent::kDG5 | double gap diffractive |
+/// \return kTRUE for proper and supported active trigger selection
+Bool_t AliCSEventCuts::SetSelectActiveTrigger(Int_t trigger)
+{
+  switch(trigger){
+  case 0: /* Any */
+    fCutsEnabledMask.SetBitNumber(kOfflineTriggerCut);
+    break;
+  case 1: /* MB */
+    fCutsEnabledMask.SetBitNumber(kOfflineTriggerCut);
+    break;
+  case 5: /* Double gap diffractive */
+    fCutsEnabledMask.SetBitNumber(kOfflineTriggerCut);
+    fOfflineTriggerMask = AliVEvent::kDG5;
+    break;
+  default:
+    AliError(Form("Active trigger code %d not supported", trigger));
+    return kFALSE;
+  }
+  return kTRUE;
+}
+
+/// Manual trigger setting
+///
+/// Sets the actual active trigger according to the configurated value
+/// and the current data period under analysis.
+void AliCSEventCuts::SetActualActiveTrigger()
+{
+  switch(fParameters[kActiveTrigger]){
+  case 0: /* Any */
+    fOfflineTriggerMask = AliVEvent::kAny;
+    break;
+  case 1: /* MB */
+    switch (GetGlobalAnchorPeriod()) {
+    case kLHC15oLIR:
+    case kLHC15oHIR:
+    case kLHC16k:
+    case kLHC16l:
+      fOfflineTriggerMask = AliVEvent::kINT7;
+      AliInfo("Using AliVEvent::kINT7 as MB trigger");
+      break;
+    default:
+      fOfflineTriggerMask = AliVEvent::kMB;
+      AliInfo("Using AliVEvent::kMB as MB trigger");
+    }
+    break;
+  case 5: /* Double gap diffractive, already set */
+      break;
+  default:
+    AliError(Form("Active trigger code %d not supported", fParameters[kActiveTrigger]));
+  }
+}
+
+/// Manual sub-trigger selection
+/// \param trigger the selected sub-trigger combination to activate
+///    |code| sub-trigger |
+///    |:--:|--------|
+///    |  0 | none |
+/// \return kTRUE for proper and supported active sub-trigger selection
+Bool_t AliCSEventCuts::SetSelectActiveSubTrigger(Int_t trigger)
+{
+  switch(trigger){
+  case 0: /* none */
+    /* the only value so far supported: do nothing */
+    break;
+  default:
+    AliError(Form("Active sub-trigger code %d not supported", trigger));
+    return kFALSE;
+  }
+  return kTRUE;
+}
+
+/// Sets and configures the procedure to remove event pile up
+/// \param pupcode the pileup removal cut code
+///    |code| method |
+///    |:--:|--------|
+///    |  0 | no pileup rejection |
+///    |  1 | PileUpSPD & background rejection with cluster-vs-tracklet default cut |
+///    |  2 | PileUpSPD & background rejection with cluster-vs-tracklet default cut & out-of-bunch pileup rejection using trigger information |
+///    |  3 | PileUpMV & background rejection with cluster-vs-tracklet default cut |
+///    |  4 | PileUpMV & background rejection with cluster-vs-tracklet default cut & out-of-bunch pileup rejection using trigger information |
+/// \return kTRUE for proper and supported pile up removal procedures
+Bool_t AliCSEventCuts::SetRemovePileUp(Int_t pupcode)
+{
+  switch(pupcode) {
+  case 0:
+    fCutsEnabledMask.ResetBitNumber(kPileUpCut);
+    break;
+  case 1: /* use SPD multiple vertices */
+    fCutsEnabledMask.SetBitNumber(kPileUpCut);
+    break;
+  case 2: /* use SPD multiple vertices  & out-of-bunch pileup rejection */
+    fCutsEnabledMask.SetBitNumber(kPileUpCut);
+    fAnalysisUtils.SetUseOutOfBunchPileUp(kTRUE);
+    break;
+  case 3: /* use track multivertexer */
+    fCutsEnabledMask.SetBitNumber(kPileUpCut);
+    fAnalysisUtils.SetUseMVPlpSelection(kTRUE);
+    break;
+  case 4: /* use track multivertexer & out-of-bunch pileup rejection */
+    fCutsEnabledMask.SetBitNumber(kPileUpCut);
+    fAnalysisUtils.SetUseMVPlpSelection(kTRUE);
+    fAnalysisUtils.SetUseOutOfBunchPileUp(kTRUE);
+    break;
+  default:
+    AliError(Form("PilEup removal procedure %d not supported", pupcode));
+    return kFALSE;
+  }
+  return kTRUE;
+}
+
+/// Sets the z vertex cut
+/// \param vtxcut the z vertex cut code
+///    |code| cut                        | additional functionality                                                            |
+///    |:--:|----------------------------|-------------------------------------------------------------------------------------|
+///    |  0 | no z vertex cut            |                                                                                     |
+///    |  1 | \f$ |z_{vtx}|\f$ < 12.0 cm |                                                                                     |
+///    |  2 | \f$ |z_{vtx}|\f$ < 10.0 cm |                                                                                     |
+///    |  3 | \f$ |z_{vtx}|\f$ < 7.0 cm  |                                                                                     |
+///    |  4 | \f$ |z_{vtx}|\f$ < 5.0 cm  |                                                                                     |
+///    |  5 | \f$ |z_{vtx}|\f$ < 12.0 cm | distance between SPD and tracks vertex less than 0.5 (PbPb 2011) or 0.2 cm (PbPb 2015) |
+///    |  6 | \f$ |z_{vtx}|\f$ < 10.0 cm | distance between SPD and tracks vertex less than 0.5 (PbPb 2011) or 0.2 cm (PbPb 2015) |
+///    |  7 | \f$ |z_{vtx}|\f$ < 7.0 cm  | distance between SPD and tracks vertex less than 0.5 (PbPb 2011) or 0.2 cm (PbPb 2015) |
+///    |  8 | \f$ |z_{vtx}|\f$ < 5.0 cm  | distance between SPD and tracks vertex less than 0.5 (PbPb 2011) or 0.2 cm (PbPb 2015) |
+/// \return kTRUE for proper and supported vertex cuts
+
+Bool_t AliCSEventCuts::SetVertexCut(Int_t vtxcut) {
+
+  switch(vtxcut){
+  case 0:
+    fCutsEnabledMask.ResetBitNumber(kVertexCut);
+    fMaxVertexZ     = 1000;
+    break;
+  case 1:
+    fCutsEnabledMask.SetBitNumber(kVertexCut);
+    fMaxVertexZ     = 12.0;
+    break;
+  case 2:
+    fCutsEnabledMask.SetBitNumber(kVertexCut);
+    fMaxVertexZ     = 10.0;
+    break;
+  case 3:
+    fCutsEnabledMask.SetBitNumber(kVertexCut);
+    fMaxVertexZ     = 7.0;
+    break;
+  case 4:
+    fCutsEnabledMask.SetBitNumber(kVertexCut);
+    fMaxVertexZ     = 5.;
+    break;
+  case 5:
+    fCutsEnabledMask.SetBitNumber(kVertexCut);
+    fMaxVertexZ     = 12.0;
+    fUseSPDTracksVtxDist = kTRUE;
+    break;
+  case 6:
+    fCutsEnabledMask.SetBitNumber(kVertexCut);
+    fMaxVertexZ     = 10.0;
+    fUseSPDTracksVtxDist = kTRUE;
+    break;
+  case 7:
+    fCutsEnabledMask.SetBitNumber(kVertexCut);
+    fMaxVertexZ     = 7.0;
+    fUseSPDTracksVtxDist = kTRUE;
+    break;
+  case 8:
+    fCutsEnabledMask.SetBitNumber(kVertexCut);
+    fMaxVertexZ     = 5.;
+    fUseSPDTracksVtxDist = kTRUE;
+    break;
+  default:
+    AliError(Form("Vertex Cut %d not supported",vtxcut));
+    return kFALSE;
+  }
+  return kTRUE;
+}
+
+/// Gets the number of contributors for the vertex estimation
+/// \param event the current event to analyze
+/// \return the number of vertex contributors
+Int_t AliCSEventCuts::GetNumberOfVertexContributors(AliVEvent *event) const{
+
+  const AliVVertex *vtx = event->GetPrimaryVertex();
+
+  if (vtx != NULL){
+    if(vtx->GetNContributors()>1) {
+      return vtx->GetNContributors();
+    }
+  }
+
+  const AliVVertex *vtxSPD = event->GetPrimaryVertexSPD();
+
+  if(vtxSPD !=NULL)
+    return vtxSPD->GetNContributors();
+  return 0;
+}
+
+/// Compare the vertex resolution and dispersion with the stored limits for both of them
+/// \param event the current event to analyze
+/// \return kTRUE if values within limits, kFALSE otherwise
+Bool_t AliCSEventCuts::PassVertexResolutionAndDispersionTh(AliVEvent *event) const {
+
+  const AliVVertex *vtxSPD = event->GetPrimaryVertexSPD();
+  if (vtxSPD != NULL) {
+    Double_t cov[6] = {0};
+    vtxSPD->GetCovarianceMatrix(cov);
+    Double_t zRes = TMath::Sqrt(cov[5]);
+
+    /* check vertex resolution */
+    if (vtxSPD->IsFromVertexerZ() && (fVertexResolutionTh < zRes))
+      /* bad resolution vertex */
+      return kFALSE;
+
+    /* if ESD check vertex dispersion */
+    AliESDEvent *esd = dynamic_cast<AliESDEvent*>(event);
+    if(esd != NULL){
+      const AliESDVertex *esdVtxSPD = dynamic_cast<const AliESDVertex *>(vtxSPD);
+      if (esdVtxSPD->IsFromVertexerZ() && (fVertexDispersionTh < esdVtxSPD->GetDispersion()))
+        /* poor resolution vertex */
+        return kFALSE;
+    }
+    return kTRUE;
+  }
+  else
+    return kFALSE;
+}
+
+/// Check if the distance between SPD and tracks vertex are acceptable by the standar cut
+/// \param event the current event to analyze
+/// \return kTRUE if the vertex distance is accepted kFALSE otherwise
+Bool_t AliCSEventCuts::AcceptSPDTracksVtxDist(AliVEvent *event) const {
+
+  const AliVVertex *vtx = event->GetPrimaryVertex();
+
+  if (vtx != NULL){
+    if(vtx->GetNContributors() < 2) {
+      return kFALSE;
+    }
+  }
+  else {
+    return kFALSE;
+  }
+
+  const AliVVertex *vtxSPD = event->GetPrimaryVertexSPD();
+
+  if(vtxSPD !=NULL) {
+    if (vtxSPD->GetNContributors() < 1) {
+      return kFALSE;
+    }
+  }
+  else {
+    return kFALSE;
+  }
+
+  /* so, proper contributors and proper vertex */
+  Double_t covTrck[6], covSPD[6];
+  vtx->GetCovarianceMatrix(covTrck);
+  vtxSPD->GetCovarianceMatrix(covSPD);
+
+  Double_t dz = vtx->GetZ() - vtxSPD->GetZ();
+
+  Double_t errTot = TMath::Sqrt(covTrck[5]+covSPD[5]);
+  Double_t errTrck = TMath::Sqrt(covTrck[5]);
+  Double_t nsigTot = dz/errTot;
+  Double_t nsigTrck = dz/errTrck;
+
+  if (TMath::Abs(dz) > fgkSPDTracksVtxDistanceThreshold || TMath::Abs(nsigTot) > fgkSPDTracksVtxDistanceSigmas || TMath::Abs(nsigTrck) > fgkTrackVertexSigmas)
+     return kFALSE;
+
+  return kTRUE;
+}
+
+/// Gets the the event z vertex coordinate
+/// \param event the current event to analyze
+/// \return the event z vertex coordinate
+Double_t AliCSEventCuts::GetVertexZ(AliVEvent *event) const {
+  Double_t vertexZ = 999.0;
+  const AliVVertex *vtx = event->GetPrimaryVertex();
+  const AliVVertex *vtxSPD = event->GetPrimaryVertexSPD();
+
+  if (vtx != NULL){
+    vertexZ = vtx->GetZ();
+  }
+  else {
+    if (vtxSPD != NULL) {
+      vertexZ = vtxSPD->GetZ();
+    }
+  }
+  return vertexZ;
+}
+
+/// Sets and configures the procedure to remove 2015 additional event pileup
+/// \param pupcode the 2015 additional pileup removal cut code
+///    |code| method |
+///    |:--:|--------|
+///    |  0 | no 2015 additional pileup rejection |
+///    |  1 | J/psi analysis pileup removal, initial (faulty) track counting method |
+///    |  2 | Centrality and multiplicity correlations for 2015 |
+///    |  3 | J/psi analysis pileup removal, initial (corrected) track counting method |
+/// \return kTRUE for proper and supported 2015 additional pileup removal procedures
+Bool_t AliCSEventCuts::SetRemove2015PileUp(Int_t pupcode)
+{
+  switch(pupcode) {
+  case 0:
+    fCutsEnabledMask.ResetBitNumber(k2015PileUpCut);
+    break;
+  case 1: /* J/psi analysis pileup removal method */
+    fCutsEnabledMask.SetBitNumber(k2015PileUpCut);
+    break;
+  case 2: /* Centrality and multiplicity correlations for 2015*/
+    fCutsEnabledMask.SetBitNumber(k2015PileUpCut);
+    break;
+  case 3: /* J/psi analysis pileup removal initial method */
+    fCutsEnabledMask.SetBitNumber(k2015PileUpCut);
+    break;
+  default:
+    AliError(Form("2015 additional pileup removal procedure %d not supported", pupcode));
+    return kFALSE;
+  }
+  return kTRUE;
+}
+
+/// Sets the actual 2015 pileup removal according to the configured value
+/// and the current data period under analysis.
+void AliCSEventCuts::SetActual2015PileUpRemoval()
+{
+  switch(fParameters[kRemove2015PileUp]){
+  case 0: /* no additional pileup rejection */
+    break;
+  case 1: /* J/psi analysis pileup removal method */
+    if(f2015V0MtoTrkTPCout){
+      delete f2015V0MtoTrkTPCout;
+    }
+    switch (GetGlobalAnchorPeriod()) {
+    case kLHC10h:
+      f2015V0MtoTrkTPCout = new TFormula(Form("f2015V0MtoTrkTPCout_%s",GetCutsString()),"-1000+2.8*x"); /* pass2 with the initial, faulty, method for track count */
+      break;
+    case kLHC15oLIR:
+      /* f2015V0MtoTrkTPCout = new TFormula(Form("f2015V0MtoTrkTPCout_%s",GetCutsString()),"-4000+3.8*x"); pass2 */
+      f2015V0MtoTrkTPCout = new TFormula(Form("f2015V0MtoTrkTPCout_%s",GetCutsString()),"-800+2.93*x"); /* pass3 */
+      break;
+    case kLHC15oHIR:
+      f2015V0MtoTrkTPCout = new TFormula(Form("f2015V0MtoTrkTPCout_%s",GetCutsString()),"-2000+3.0*x");
+      break;
+    default:
+      f2015V0MtoTrkTPCout = new TFormula(Form("f2015V0MtoTrkTPCout_%s",GetCutsString()),"-450+10.5*x");
+      break;
+    }
+    AliInfo(Form("2015 pileup removal: V0 mult < %s\n", TString(f2015V0MtoTrkTPCout->GetTitle()).ReplaceAll("x","trkTPCout").Data()));
+    break;
+  case 2: /* Centrality and multiplicity correlations for 2015*/
+    if (fCentOutLowCut != NULL)
+      delete fCentOutLowCut;
+    if (fCentOutHighCut != NULL)
+      delete fCentOutHighCut;
+    if (fTOFMultOutLowCut != NULL)
+      delete fTOFMultOutLowCut;
+    if (fTOFMultOutHighCut != NULL)
+      delete fTOFMultOutHighCut;
+    if (fMultCentOutLowCut != NULL)
+      delete fMultCentOutLowCut;
+    switch (GetGlobalAnchorPeriod()) {
+    case kLHC10h:
+      /* inhibited, TODO */
+      fCutsEnabledMask.ResetBitNumber(k2015PileUpCut);
+      AliWarning("2015 pileup removal: inhibited for LHC10h anchored datasets");
+      break;
+    case kLHC15oLIR:
+      /* inhibited, TODO */
+      fCutsEnabledMask.ResetBitNumber(k2015PileUpCut);
+      AliWarning("2015 pileup removal: inhibited for LHC15oLIR anchored datasets");
+      break;
+    case kLHC15oHIR:
+      f2015V0MtoTrkTPCout = new TFormula(Form("f2015V0MtoTrkTPCout_%s",GetCutsString()),"-2000+3.0*x");
+      /* let's initialize the expressions for 2015 pile up rejection */
+      fCentOutLowCut = new TF1("fCentOutLowCut", "[0]+[1]*x - 5.*([2]+[3]*x+[4]*x*x+[5]*x*x*x)", 0, 100);
+      fCentOutLowCut->SetParameters(0.0157497, 0.973488, 0.673612, 0.0290718, -0.000546728, 5.82749e-06);
+      fCentOutHighCut = new TF1("fCentOutHighCut", "[0]+[1]*x + 5.5*([2]+[3]*x+[4]*x*x+[5]*x*x*x)", 0, 100);
+      fCentOutHighCut->SetParameters(0.0157497, 0.973488, 0.673612, 0.0290718, -0.000546728, 5.82749e-06);
+      fTOFMultOutLowCut = new TF1("fTOFMultOutLowCut", "[0]+[1]*x+[2]*x*x+[3]*x*x*x - 4.*([4]+[5]*x+[6]*x*x+[7]*x*x*x+[8]*x*x*x*x+[9]*x*x*x*x*x)", 0, 10000);
+      fTOFMultOutLowCut->SetParameters(-1.0178, 0.333132, 9.10282e-05, -1.61861e-08, 1.47848, 0.0385923, -5.06153e-05, 4.37641e-08, -1.69082e-11, 2.35085e-15);
+      fTOFMultOutHighCut = new TF1("fTOFMultOutHighCut", "[0]+[1]*x+[2]*x*x+[3]*x*x*x + 4.*([4]+[5]*x+[6]*x*x+[7]*x*x*x+[8]*x*x*x*x+[9]*x*x*x*x*x)", 0, 10000);
+      fTOFMultOutHighCut->SetParameters(-1.0178, 0.333132, 9.10282e-05, -1.61861e-08, 1.47848, 0.0385923, -5.06153e-05, 4.37641e-08, -1.69082e-11, 2.35085e-15);
+      fMultCentOutLowCut = new TF1("fMultCentOutLowCut", "[0]+[1]*x+[2]*exp([3]-[4]*x) - 5.*([5]+[6]*exp([7]-[8]*x))", 0, 100);
+      fMultCentOutLowCut->SetParameters(-6.15980e+02, 4.89828e+00, 4.84776e+03, -5.22988e-01, 3.04363e-02, -1.21144e+01, 2.95321e+02, -9.20062e-01, 2.17372e-02);
+
+      /* TODO user feedback */
+      // AliInfo(Form("2015 pileup removal: V0 mult < %s\n", TString(f2015V0MtoTrkTPCout->GetTitle()).ReplaceAll("x","trkTPCout").Data()));
+      break;
+    default:
+      /* inhibited, TODO */
+      fCutsEnabledMask.ResetBitNumber(k2015PileUpCut);
+      AliWarning("2015 pileup removal: inhibited for unknown anchored datasets");
+      break;
+    }
+    break;
+  case 3: /* J/psi analysis pileup removal initial, corrected, method */
+    if(f2015V0MtoTrkTPCout){
+      delete f2015V0MtoTrkTPCout;
+    }
+    switch (GetGlobalAnchorPeriod()) {
+    case kLHC10h:
+      f2015V0MtoTrkTPCout = new TFormula(Form("f2015V0MtoTrkTPCout_%s",GetCutsString()),"-1000+3.1*x");
+      break;
+    case kLHC15oLIR:
+      /* f2015V0MtoTrkTPCout = new TFormula(Form("f2015V0MtoTrkTPCout_%s",GetCutsString()),"-4000+3.8*x"); pass2 */
+      f2015V0MtoTrkTPCout = new TFormula(Form("f2015V0MtoTrkTPCout_%s",GetCutsString()),"-800+2.93*x"); /* pass3 */
+      break;
+    case kLHC15oHIR:
+      f2015V0MtoTrkTPCout = new TFormula(Form("f2015V0MtoTrkTPCout_%s",GetCutsString()),"-2500+5.0*x");
+      break;
+    default:
+      f2015V0MtoTrkTPCout = new TFormula(Form("f2015V0MtoTrkTPCout_%s",GetCutsString()),"-1000+2.8*x");
+      break;
+    }
+    AliInfo(Form("2015 pileup removal (initial method): V0 mult < %s\n", TString(f2015V0MtoTrkTPCout->GetTitle()).ReplaceAll("x","trkTPCout").Data()));
+    break;
+  default:
+    AliError(Form("2015 additional pileup removal code %d not supported", fParameters[kRemove2015PileUp]));
+  }
+}
+
+/// Checks whether the V0 multiplicity and the number of TPCout on tracks mark the event as pileup
+/// \return kTRUE if the event is a pileup event kFALSE otherwise
+Bool_t AliCSEventCuts::Is2015PileUpEvent() const {
+
+  switch(fParameters[kRemove2015PileUp]){
+  case 1: /* J/psi analysis pileup removal initial, faulty, method */
+    if (fV0Multiplicity  < f2015V0MtoTrkTPCout->Eval(fNoOfInitialTPCoutTracks))
+      return kTRUE;
+    return kFALSE;
+    break;
+  case 2: /* Centrality and multiplicity correlations for 2015*/ {
+      Float_t multDiffESDTPC = fNoOfESDTracks - fNoOfFB128Tracks*3.8;
+
+      if (Float_t(fCL0Centrality) < fCentOutLowCut->Eval(fV0MCentrality))
+        return kTRUE;
+
+      if (Float_t(fCL0Centrality) > fCentOutHighCut->Eval(fV0MCentrality))
+        return kTRUE;
+
+      if (multDiffESDTPC > 15000) //for stronger cuts use 700
+        return kTRUE;
+
+      if (Float_t(fNoOfFB32TOFTracks) < fTOFMultOutLowCut->Eval(Float_t(fNoOfFB32Tracks)))
+        return kTRUE;
+
+      if (Float_t(fNoOfFB32TOFTracks) > fTOFMultOutHighCut->Eval(Float_t(fNoOfFB32Tracks)))
+        return kTRUE;
+
+      if (Float_t(fNoOfFB32AccTracks) < fMultCentOutLowCut->Eval(fV0MCentrality))
+        return kTRUE;
+
+      return kFALSE;
+    }
+    break;
+  case 3: /* J/psi analysis pileup removal initial, corrected, method */
+    if (fV0Multiplicity  < f2015V0MtoTrkTPCout->Eval(fNoOfInitialTPCoutTracks))
+      return kTRUE;
+    return kFALSE;
+    break;
+  default:
+    AliFatal(Form("Inconsistent parameter value %d for removal 2015 pileup", fParameters[kRemove2015PileUp]));
+    return kFALSE;
+  }
+}
+
+/// Stores the event different centralities
+/// \param event the current event to handle
+/// \return kTRUE if the process proceeded properly kFALSE otherwise
+Bool_t AliCSEventCuts::StoreEventCentralities(AliVEvent *event) {
+
+  fV0MCentrality = -1;
+  fV0ACentrality = -1;
+  fV0CCentrality = -1;
+  fCL0Centrality = -1;
+  fCL1Centrality = -1;
+
+  AliESDEvent *esdEvent=dynamic_cast<AliESDEvent*>(event);
+  AliAODEvent *aodEvent=dynamic_cast<AliAODEvent*>(event);
+
+  if (esdEvent != NULL) {
+    if (fUseNewMultFramework) {
+      AliMultSelection *MultSelection = (AliMultSelection*) event->FindListObject("MultSelection");
+      if (MultSelection != NULL) {
+        fV0ACentrality = MultSelection->GetMultiplicityPercentile("V0A");
+        fV0CCentrality = MultSelection->GetMultiplicityPercentile("V0M");
+        fV0MCentrality = MultSelection->GetMultiplicityPercentile("V0M");
+        fCL0Centrality = MultSelection->GetMultiplicityPercentile("CL1");
+        fCL1Centrality = MultSelection->GetMultiplicityPercentile("CL1");
+      }
+      else {
+        AliError("No MultSelection object instance");
+        return kFALSE;
+      }
+    }
+    else {
+      AliCentrality *Centrality = event->GetCentrality();
+      if (Centrality != NULL) {
+        fV0ACentrality = Centrality->GetCentralityPercentile("V0A");
+        fV0CCentrality = Centrality->GetCentralityPercentile("V0C");
+        fV0MCentrality = Centrality->GetCentralityPercentile("V0M");
+        fCL0Centrality = Centrality->GetCentralityPercentile("CL0");
+        fCL1Centrality = Centrality->GetCentralityPercentile("CL1");
+      }
+      else {
+        AliError("No Centrality object instance");
+        return kFALSE;
+      }
+    }
+  }
+
+  if(aodEvent){
+    if(fUseNewMultFramework){
+      AliMultSelection *MultSelection = (AliMultSelection *)event->FindListObject("MultSelection");
+      if (MultSelection == NULL) {
+        AliError("No MultSelection object instance");
+        return kFALSE;
+      }
+      fV0ACentrality = MultSelection->GetMultiplicityPercentile("V0A");
+      fV0CCentrality = MultSelection->GetMultiplicityPercentile("V0M");
+      fV0MCentrality = MultSelection->GetMultiplicityPercentile("V0M");
+      fCL0Centrality = MultSelection->GetMultiplicityPercentile("CL1");
+      fCL1Centrality = MultSelection->GetMultiplicityPercentile("CL1");
+    }
+    else{
+      if(aodEvent->GetHeader()) {
+        AliCentrality *aodCentrality = ((AliVAODHeader*)aodEvent->GetHeader())->GetCentralityP();
+        if (aodCentrality != NULL) {
+          fV0ACentrality = aodCentrality->GetCentralityPercentile("V0A");
+          fV0CCentrality = aodCentrality->GetCentralityPercentile("V0C");
+          fV0MCentrality = aodCentrality->GetCentralityPercentile("V0M");
+          fCL0Centrality = aodCentrality->GetCentralityPercentile("CL0");
+          fCL1Centrality = aodCentrality->GetCentralityPercentile("CL1");
+        }
+        else {
+          AliError("No AliCentrality attached to AOD header");
+          return kFALSE;
+        }
+      }
+      else {
+        AliError("Not a standard AOD");
+        return kFALSE;
+      }
+    }
+  }
+
+  AliInfo(Form("Event centralities: V0A: %.2f, V0C: %.2f, V0M: %.2f, CL0: %.2f, CL1: %.2f",
+      Float_t(fV0MCentrality),
+      Float_t(fV0ACentrality),
+      Float_t(fV0CCentrality),
+      Float_t(fCL0Centrality),
+      Float_t(fCL1Centrality)));
+
+  return kTRUE;
+}
+
+/// Set the standard filtering track cuts set according to the data period
+void AliCSEventCuts::SetActualFilterTracksCuts() {
+
+  if (fESDFB32 != NULL)
+    delete fESDFB32;
+  if (fESDFB128 != NULL)
+    delete fESDFB128;
+
+  TString system = "";
+  TString period = "";
+  TString basename = "";
+  baseSystems baseSystem = kUnknownBase;
+
+
+  switch (GetGlobalAnchorPeriod()) {
+  case kLHC10bg:
+    baseSystem = k2010based;
+    basename = "2010";
+    system = "p-p";
+    period = "2010bg";
+    break;
+  case kLHC11a:
+  case kLHC11b:
+  case kLHC11cg:
+    baseSystem = k2011based;
+    basename = "2011";
+    system = "p-p";
+    period = "2011ag";
+    break;
+  case kLHC12:
+  case kLHC13g:
+  case kLHC15fm:
+  case kLHC15n:
+  case kLHC16k:
+  case kLHC16l:
+    baseSystem = k2011based;
+    basename = "2011";
+    system = "p-p";
+    period = "various";
+    break;
+  case kLHC13bc:
+  case kLHC13de:
+  case kLHC13f:
+    baseSystem = k2011based;
+    basename = "2011";
+    system = "p-Pb";
+    period = "2013bf";
+    break;
+  case kLHC10h:
+    baseSystem = k2010based;
+    basename = "2010";
+    system = "Pb-Pb";
+    period = "2010h";
+    break;
+  case kLHC11h:
+    baseSystem = k2011based;
+    basename = "2011";
+    system = "Pb-Pb";
+    period = "2011h";
+    break;
+  case kLHC15oLIR:
+  case kLHC15oHIR:
+    baseSystem = k2011based;
+    basename = "2011";
+    system = "Pb-Pb";
+    period = "2015o";
+    break;
+  default:
+    fESDFB32 = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010();
+    fESDFB128 = AliESDtrackCuts::GetStandardTPCOnlyTrackCuts();
+    fESDFB32->SetNameTitle(Form("FB32TrackCount_%s",GetCutsString()),"Filter tracks 2010: globals with tight DCA");
+    fESDFB128->SetNameTitle(Form("FB128TrackCount_%s",GetCutsString()),"Filter tracks 2010: Standard TPC only");
+    AliError("SYSTEM: no system set from data files. Standard 2010 track cuts");
+    return;
+  }
+
+  switch (baseSystem) {
+  case k2010based:
+    fESDFB32 = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010();
+    fESDFB128 = AliESDtrackCuts::GetStandardTPCOnlyTrackCuts();
+    fESDFB32->SetNameTitle(Form("FB32TrackCount_%s",GetCutsString()),"Filter tracks 2010: globals with tight DCA");
+    fESDFB128->SetNameTitle(Form("FB128TrackCount_%s",GetCutsString()),"Filter tracks 2010: Standard TPC only");
+    break;
+  case k2011based:
+    fESDFB32 = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011();
+    fESDFB128 = AliESDtrackCuts::GetStandardTPCOnlyTrackCuts();
+    fESDFB32->SetNameTitle(Form("FB32TrackCount_%s",GetCutsString()),"Filter tracks 2011: globals with tight DCA");
+    fESDFB128->SetNameTitle(Form("FB128TrackCount_%s",GetCutsString()),"Filter tracks 2011: Standard TPC only");
+    break;
+  default:
+    AliFatal("Internal inconsistency between data period and base period for track counting filter cuts selection. ABORTING!!!");
+    return;
+  }
+
+  /* report the selected cut */
+  AliInfo("=============== Track count filter cut ===========================");
+  AliInfo(Form("SYSTEM: %s; PERIOD: %s", system.Data(), period.Data()));
+  AliInfo(Form("BASED ON: %s standards cuts", basename.Data()));
+  AliInfo("=============== Track count filter cut end =======================");
+}
+
+
+/// Stores the event different multiplicities
+/// \param event the current event to handle
+/// \return kTRUE if the process proceeded properly kFALSE otherwise
+Bool_t AliCSEventCuts::StoreEventMultiplicities(AliVEvent *event) {
+
+  AliESDEvent *esdEvent=dynamic_cast<AliESDEvent*>(event);
+  AliAODEvent *aodEvent=dynamic_cast<AliAODEvent*>(event);
+
+  fNoOfAODTracks = 0;
+  fNoOfESDTracks = 0;
+  fNoOfFB32Tracks = 0;
+  fNoOfFB128Tracks = 0;
+  fNoOfFB32AccTracks = 0;
+  fNoOfFB32TOFTracks = 0;
+  fNoOfTPCoutTracks = 0;
+  fNoOfInitialTPCoutTracks = 0;
+  fReferenceMultiplicity = -1;
+
+  Int_t nTracks = 0;
+
+  fV0Multiplicity = event->GetVZEROData()->GetMTotV0A()+event->GetVZEROData()->GetMTotV0C();
+
+  AliInfo(Form("Event V0M multiplicity: %d", fV0Multiplicity));
+  if (aodEvent == NULL && esdEvent == NULL) {
+    AliError("Not a proper event");
+    return kFALSE;
+  }
+
+  if (aodEvent != NULL) {
+    if(aodEvent->GetHeader()) {
+      fReferenceMultiplicity = ((AliAODHeader*)aodEvent->GetHeader())->GetRefMultiplicityComb08();
+      fNoOfAODTracks = aodEvent->GetNumberOfTracks();
+      fNoOfESDTracks = ((AliVAODHeader*)aodEvent->GetHeader())->GetNumberOfESDTracks();
+      nTracks = fNoOfAODTracks;
+    }
+    else {
+      AliError("Not a proper AOD event. No header!");
+    }
+  }
+
+  if (esdEvent != NULL) {
+    AliESDtrackCuts::MultEstTrackType estType = esdEvent->GetPrimaryVertexTracks()->GetStatus() ? AliESDtrackCuts::kTrackletsITSTPC : AliESDtrackCuts::kTracklets;
+    fReferenceMultiplicity = AliESDtrackCuts::GetReferenceMultiplicity(esdEvent,estType,0.8);
+    fNoOfESDTracks = esdEvent->GetNumberOfTracks();
+    nTracks = fNoOfESDTracks;
+  }
+
+  for (Int_t itrk = 0; itrk < nTracks; itrk++) {
+    AliVTrack *trk = dynamic_cast<AliVTrack*>(event->GetTrack(itrk));
+
+    if (trk != NULL) {
+
+      /* the initial method of counting TPC out tracks in its two versions */
+      if (!(trk->Pt() < 0.15) && (TMath::Abs(trk->Eta()) < 0.8)) {
+        if (fParameters[kRemove2015PileUp] == 1) {
+          /* the initial method of counting TPC out tracks, faulty */
+          /* we have to force the parenthesis for silencing compiler warning */
+          /* but this is how it really looks like, that's why is faulty */
+          if (!(trk->GetStatus() & (AliVTrack::kTPCout != AliVTrack::kTPCout))) {
+            fNoOfInitialTPCoutTracks++;
+          }
+        }
+        else {
+          /* the initial method of counting TPC out tracks, corrected */
+          if ((trk->GetStatus() & AliVTrack::kTPCout) == AliVTrack::kTPCout) {
+            fNoOfInitialTPCoutTracks++;
+          }
+        }
+      }
+
+      if (trk->IsA() == AliESDtrack::Class()) {
+        if (fESDFB32->AcceptTrack(dynamic_cast<AliESDtrack *>(trk))) {
+          fNoOfFB32Tracks++;
+
+          if (TMath::Abs(trk->GetTOFsignalDz()) <= 10. && trk->GetTOFsignal() >= 12000. && trk->GetTOFsignal() <= 25000.)
+            fNoOfFB32TOFTracks++;
+
+          if ((TMath::Abs(trk->Eta()) < 0.8) && (trk->GetTPCNcls() >= 70) && (trk->Pt() >= 0.2) && (trk->Pt() < 50.)) {
+            fNoOfFB32AccTracks++;
+            if ((trk->GetStatus() & AliVTrack::kTPCout) == AliVTrack::kTPCout )
+              fNoOfTPCoutTracks++;
+          }
+        }
+        if (fESDFB128->AcceptTrack(dynamic_cast<AliESDtrack *>(trk))) {
+          /* TODO we need to enrich this to really match AOD FB128 */
+          /* there are TPC only tracks which will not become AOD FB128 tracks */
+          fNoOfFB128Tracks++;
+        }
+      }
+      else if (trk->IsA() == AliAODTrack::Class()) {
+        AliAODTrack *aodt = dynamic_cast<AliAODTrack*>(trk);
+
+        if (aodt->TestFilterBit(32)) {
+          fNoOfFB32Tracks++;
+
+          if (TMath::Abs(trk->GetTOFsignalDz()) <= 10. && trk->GetTOFsignal() >= 12000. && trk->GetTOFsignal() <= 25000.)
+            fNoOfFB32TOFTracks++;
+
+          if ((TMath::Abs(trk->Eta()) < 0.8) && (trk->GetTPCNcls() >= 70) && (trk->Pt() >= 0.2) && (trk->Pt() < 50.)) {
+            fNoOfFB32AccTracks++;
+            if ((trk->GetStatus() & AliVTrack::kTPCout) == AliVTrack::kTPCout )
+              fNoOfTPCoutTracks++;
+          }
+        }
+        if (aodt->TestFilterBit(128)) {
+          fNoOfFB128Tracks++;
+        }
+      }
+      else
+        continue;
+    }
+  }
+
+  AliInfo(Form("Event multiplicities: AOD: %d, ESD: %d, FB32: %d, FB128: %d, FB32 acc: %d", fNoOfAODTracks, fNoOfESDTracks, fNoOfFB32Tracks, fNoOfFB128Tracks, fNoOfFB32AccTracks));
+  AliInfo(Form("Event multiplicities: FB32 TOF: %d, TPC out: %d, TPC out(initial): %d, Ref: %d", fNoOfFB32TOFTracks, fNoOfTPCoutTracks, fNoOfInitialTPCoutTracks, fReferenceMultiplicity));
+
+  return kTRUE;
+}
+
+///
+/// Initializes the cuts
+///
+/// Initializes the needed data and allocates the needed histograms list if needed
+/// \param name an additional name to precede the cuts string
+void AliCSEventCuts::InitCuts(const char *name){
+
+  if (name == NULL) name = GetName();
+
+  fAnalysisUtils.SetUseSPDCutInMultBins(kTRUE);
+
+  if (fQALevel > kQALevelNone) {
+    Bool_t oldstatus = TH1::AddDirectoryStatus();
+    TH1::AddDirectory(kFALSE);
+
+    if(fHistogramsList != NULL)
+      delete fHistogramsList;
+
+    fHistogramsList =new TList();
+    fHistogramsList->SetOwner(kTRUE);
+    fHistogramsList->SetName(name);
+
+
+    TH1::AddDirectory(oldstatus);
+  }
+}
+
+/// Allocates the different histograms if needed
+///
+/// It is supposed that the current cuts string is the running one
+void AliCSEventCuts::DefineHistograms(){
+
+  if (fQALevel > kQALevelNone) {
+    Bool_t oldstatus = TH1::AddDirectoryStatus();
+    TH1::AddDirectory(kFALSE);
+
+    fHistogramsList->SetName(Form("%s_%s",fHistogramsList->GetName(),GetCutsString()));
+
+    fhCutsStatistics = new TH1F(Form("CutsStatistics_%s",GetCutsString()),"Event cuts statistics",kNCuts+4,-0.5,kNCuts+3.5);
+    fhUniqueCutsStatistics = new TH1F(Form("UniqueCutsStatistics_%s",GetCutsString()),"Unique event cuts statistics",kNCuts+4,-0.5,kNCuts+3.5);
+    fhCutsStatistics->GetXaxis()->SetBinLabel(1,"n events");
+    fhUniqueCutsStatistics->GetXaxis()->SetBinLabel(1,"n events");
+    fhCutsStatistics->GetXaxis()->SetBinLabel(2,"n cut events");
+    fhUniqueCutsStatistics->GetXaxis()->SetBinLabel(2,"n passed events");
+    for (Int_t i = 0; i < kNCuts; i++) {
+      if (fgIsMC) {
+        fhCutsStatistics->GetXaxis()->SetBinLabel(i+4, fgkCutsNames[i]);
+        fhUniqueCutsStatistics->GetXaxis()->SetBinLabel(i+4, fgkCutsNames[i]);
+      }
+      else {
+        if (i != kMCdataQuality) {
+          fhCutsStatistics->GetXaxis()->SetBinLabel(i+4, fgkCutsNames[i]);
+          fhUniqueCutsStatistics->GetXaxis()->SetBinLabel(i+4, fgkCutsNames[i]);
+        }
+        else {
+          fhCutsStatistics->GetXaxis()->SetBinLabel(i+4, "n/a");
+          fhUniqueCutsStatistics->GetXaxis()->SetBinLabel(i+4, "n/a");
+        }
+      }
+    }
+    fHistogramsList->Add(fhCutsStatistics);
+    fHistogramsList->Add(fhUniqueCutsStatistics);
+
+    if(fQALevel == kQALevelHeavy){
+      fhCutsCorrelation = new TH2F(Form("CutCorrelation_%s",GetCutsString()),"Cuts correlation",kNCuts+2,-0.5,kNCuts+1.5,kNCuts+2,-0.5,kNCuts+1.5);
+      for (Int_t i=0; i<kNCuts; i++) {
+        fhCutsCorrelation->GetXaxis()->SetBinLabel(i+2,fgkCutsNames[i]);
+        fhCutsCorrelation->GetYaxis()->SetBinLabel(i+2,fgkCutsNames[i]);
+      }
+      fHistogramsList->Add(fhCutsCorrelation);
+    }
+
+    if(fSystem  > kpp){
+      fhCentrality[0] = new TH1F(Form("CentralityB_ %s",GetCutsString()),"Centrality before cut; centrality",400,0,100);
+      fhCentrality[1] = new TH1F(Form("CentralityA_ %s",GetCutsString()),"Centrality; centrality",400,0,100);
+      fHistogramsList->Add(fhCentrality[0]);
+      fHistogramsList->Add(fhCentrality[1]);
+    }
+    else {
+      /* for pp systems use multiplicity instead */
+      fhCentrality[0] = new TH1F(Form("MultiplicityB_ %s",GetCutsString()),"Multiplicity before cut; multiplicity",400,0,400);
+      fhCentrality[1] = new TH1F(Form("MultiplicityA_ %s",GetCutsString()),"Multiplicity; multiplicity",400,0,400);
+      fHistogramsList->Add(fhCentrality[0]);
+      fHistogramsList->Add(fhCentrality[1]);
+    }
+
+    fhVertexZ[0] = new TH1F(Form("VertexZB_%s",GetCutsString()),"Vertex Z; z_{vtx}",1000,-50,50);
+    fhVertexZ[1] = new TH1F(Form("VertexZA_%s",GetCutsString()),"Vertex Z; z_{vtx}",1000,-50,50);
+    fHistogramsList->Add(fhVertexZ[0]);
+    fHistogramsList->Add(fhVertexZ[1]);
+
+    fhTriggerClass[0] = new TH1F(Form("OfflineTriggerB_%s",GetCutsString()),"OfflineTrigger before cut",34,-0.5,33.5);
+    fhTriggerClass[1] = new TH1F(Form("OfflineTriggerA_%s",GetCutsString()),"OfflineTrigger",34,-0.5,33.5);
+    for (Int_t i = 0; i < 2; i++) {
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel( 1,"kMB");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel( 2,"kINT7");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel( 3,"kMUON");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel( 4,"kHighMult");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel( 5,"kEMC1");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel( 6,"kCINT5");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel( 7,"kCMUS5/kMUSPB");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel( 8,"kMUSH7/kMUSHPB");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel( 9,"kMUL7/kMuonLikePB");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(10,"kMUU7/kMuonUnlikePB");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(11,"kEMC7/kEMC8");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(12,"kMUS7");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(13,"kPHI1");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(14,"kPHI7/kPHI8/kPHOSPb");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(15,"kEMCEJE");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(16,"kEMCEGA");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(17,"kCentral");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(18,"kSemiCentral");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(19,"kDG5");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(20,"kZED");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(21,"kSPI7/kSPI");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(22,"kINT8");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(23,"kMuonSingleLowPt8");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(24,"kMuonSingleHighPt8");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(25,"kMuonLikeLowPt8");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(26,"kMuonUnlikeLowPt8");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(27,"kMuonUnlikeLowPt0");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(28,"kUserDefined");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(29,"kTRD");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(30,"kFastOnly");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(31,"kAnyINT");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(32,"kAny");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(33,"NOT kFastOnly");
+      fhTriggerClass[i]->GetXaxis()->SetBinLabel(34,"Failed Physics Selection");
+    }
+    fHistogramsList->Add(fhTriggerClass[0]);
+    fHistogramsList->Add(fhTriggerClass[1]);
+
+    if(fQALevel == kQALevelHeavy){
+      fhSPDClustersVsTracklets[0] = new TH2F(Form("SPDClustersVsTrackletsB_%s",GetCutsString()),"SPD clusters vs tracklets before cut;tracklets;SPD clusters",200,0,3000,500,0,10000);
+      fhSPDClustersVsTracklets[1] = new TH2F(Form("SPDClustersVsTrackletsA_%s",GetCutsString()),"SPD clusters vs tracklets;tracklets;SPD clusters",200,0,3000,500,0,10000);
+      fHistogramsList->Add(fhSPDClustersVsTracklets[0]);
+      fHistogramsList->Add(fhSPDClustersVsTracklets[1]);
+
+      fhV0MvsTracksTPCout[0] =
+          new TH2F(Form("V0MvsTracksTPCoutB_%s", GetCutsString()),"V0 multiplicity vs tracks with kTPCout on before cut;# tracks with kTPCout on;V0 multiplicity",300,0,5000,300,0,40000);
+      fhV0MvsTracksTPCout[1] =
+          new TH2F(Form("V0MvsTracksTPCoutA_%s", GetCutsString()),"V0 multiplicity vs tracks with kTPCout on;# tracks with kTPCout on;V0 multiplicity",300,0,5000,300,0,40000);
+      fHistogramsList->Add(fhV0MvsTracksTPCout[0]);
+      fHistogramsList->Add(fhV0MvsTracksTPCout[1]);
+
+      fhV0MvsTracksInitialTPCout[0] =
+          new TH2F(Form("V0MvsTracksInitialTPCoutB_%s", GetCutsString()),"V0 multiplicity vs tracks with kTPCout on before cut;# tracks with kTPCout on (initial method);V0 multiplicity",300,0,30000,300,0,40000);
+      fhV0MvsTracksInitialTPCout[1] =
+          new TH2F(Form("V0MvsTracksInitialTPCoutA_%s", GetCutsString()),"V0 multiplicity vs tracks with kTPCout on;# tracks with kTPCout on (initial method);V0 multiplicity",300,0,30000,300,0,40000);
+      fHistogramsList->Add(fhV0MvsTracksInitialTPCout[0]);
+      fHistogramsList->Add(fhV0MvsTracksInitialTPCout[1]);
+
+      const char *sel;
+      const char *alt;
+      this->GetCentralityEstimatorNames(sel,alt);
+      if (sel != NULL && alt != NULL) {
+        fhCentralityAltVsSel[0] =
+            new TH2F(Form("CentralityAltVsSelB_%s", GetCutsString()),
+                Form("Centrality, alternative vs selected before cut;centrality percentile (%s);centrality percentile (%s)", sel, alt),
+                100,0,100,100,0,100);
+        fhCentralityAltVsSel[1] =
+            new TH2F(Form("CentralityAltVsSelA_%s", GetCutsString()),
+                Form("Centrality, alternative vs selected;centrality percentile (%s);centrality percentile (%s)", sel, alt),
+                100,0,100,100,0,100);
+        fHistogramsList->Add(fhCentralityAltVsSel[0]);
+        fHistogramsList->Add(fhCentralityAltVsSel[1]);
+      }
+      fhCL0vsV0MCentrality[0] =
+          new TH2F(Form("CL0vsV0MCentralityB_%s",GetCutsString()),
+              "Centrality, CL0 vs V0M, before cuts;centrality percentile (V0M);centrality percentile (CL0)",
+              100,0,100,100,0,100);
+      fhCL0vsV0MCentrality[1] =
+          new TH2F(Form("CL0vsV0MCentralityA_%s",GetCutsString()),
+              "Centrality, CL0 vs V0M;centrality percentile (V0M);centrality percentile (CL0)",
+              100,0,100,100,0,100);
+      fHistogramsList->Add(fhCL0vsV0MCentrality[0]);
+      fHistogramsList->Add(fhCL0vsV0MCentrality[1]);
+
+      fhESDvsTPConlyMultiplicity[0] =
+          new TH2F(Form("ESDvsTPConlyMultiplicityB_%s",GetCutsString()),
+              "Multiplicity, ESD vs TPC only, before cuts;multiplicity (TPC only tracks);multiplicity (ESD tracks)",
+              400,0,7000,400,0,50000);
+      fhESDvsTPConlyMultiplicity[1] =
+          new TH2F(Form("ESDvsTPConlyMultiplicityA_%s",GetCutsString()),
+              "Multiplicity, ESD vs TPC only;multiplicity (TPC only tracks);multiplicity (ESD tracks)",
+              400,0,7000,400,0,50000);
+      fHistogramsList->Add(fhESDvsTPConlyMultiplicity[0]);
+      fHistogramsList->Add(fhESDvsTPConlyMultiplicity[1]);
+
+      fhTOFvsGlobalMultiplicity[0] =
+          new TH2F(Form("TOFvsGlobalMultiplicityB_%s",GetCutsString()),
+              "global tracks in TOF vs global tracks, before cuts;multiplicity (global, FB32, tracks);multiplicity (global, FB32, TOF tracks)",
+              400,0,4000,400,0,2000);
+      fhTOFvsGlobalMultiplicity[1] =
+          new TH2F(Form("TOFvsGlobalMultiplicityA_%s",GetCutsString()),
+              "global tracks in TOF vs global tracks;multiplicity (global, FB32, tracks);multiplicity (global, FB32, TOF tracks)",
+              400,0,4000,400,0,2000);
+      fHistogramsList->Add(fhTOFvsGlobalMultiplicity[0]);
+      fHistogramsList->Add(fhTOFvsGlobalMultiplicity[1]);
+
+      fhAccTrkvsV0MCentrality[0] =
+          new TH2F(Form("AccTrkvsV0MCentralityB_%s",GetCutsString()),
+              "accepted global tracks vs V0M centrality, before cuts;centrality percentile (V0M);multiplicity (accepted global, FB32, tracks)",
+              100,0,100,400,0,3000);
+      fhAccTrkvsV0MCentrality[1] =
+          new TH2F(Form("AccTrkvsV0MCentralityA_%s",GetCutsString()),
+              "accepted global tracks vs V0M centrality;centrality percentile (V0M);multiplicity (accepted global, FB32, tracks)",
+              100,0,100,400,0,3000);
+      fHistogramsList->Add(fhAccTrkvsV0MCentrality[0]);
+      fHistogramsList->Add(fhAccTrkvsV0MCentrality[1]);
+    }
+
+    TH1::AddDirectory(oldstatus);
+  }
+}
+
+
+
+/// \cond CLASSIMP
+ClassImp(AliCSEventCuts);
+/// \endcond

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSEventCuts.h
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSEventCuts.h
@@ -1,0 +1,223 @@
+#ifndef ALICSEVENTCUTS_H
+#define ALICSEVENTCUTS_H
+
+/// \file AliCSEventCuts.h
+/// \brief Event cuts support for the correlations studies tasks
+///
+/// Based on ideas taken from Gamma Conversion analysis under PWGGA and from AliESDTrackCuts
+
+#include "AliAnalysisUtils.h"
+#include "AliCSAnalysisCutsBase.h"
+
+class TH1F;
+class TH2F;
+class TF1;
+class TFormula;
+class AliESDtrackCuts;
+
+
+/// \class AliCSEventCuts
+/// \brief Class which implements event cuts
+///
+/// Provides support for configuring event selection cuts.
+/// It is derived from #AliCSAnalysisCutsBase so it incorporates
+/// the cuts string in all output histograms.
+///
+/// Based on Gamma Conversion analysis implementation within PWGGA
+///
+/// \author Víctor González <victor.gonzalez@cern.ch>, UCM
+/// \date Oct 17, 2016
+
+class AliCSEventCuts : public AliCSAnalysisCutsBase {
+public:
+
+  /// \enum cutsParametersIds
+  /// \brief The ids of the different event cuts parameters supported
+  enum cutsParametersIds {
+    kSystem,            ///< system type
+    kCentralityType,    ///< centrality estimator
+    kCentralityMin,     ///< centrality cut minimum value
+    kCentralityMax,     ///< centrality cut maximum value
+    kActiveTrigger,     ///< trigger selection
+    kActiveSubTrigger,  ///< sub-trigger selection
+    kRemovePileUp,      ///< pile up removal
+    kVertex,            ///< vertex cut
+    kRemove2015PileUp,  ///< 2015 PbPb additional pile up removal
+    kNCutsParameters    ///< the number of event cuts parameters
+  };
+
+  /// \enum cutsIds
+  /// \brief The ids of the different cuts currently supported
+  enum cutsIds {
+    kMCdataQuality,             ///< MC analysis without proper MC data
+    kDAQIncompleteCut,          ///< Incomplete data event cut
+    kNoTracks,                  ///< Event with no tracks
+    kOfflineTriggerCut,         ///< Offline trigger cut
+    kVertexContributorsCut,     ///< Vertex contributor cut
+    kVertexQualityCut,          ///< Vertex quality cut
+    kSPDTrackVtxDistance,       ///< Distance between SPD and tracks vertex cut
+    kVertexCut,                 ///< Vertex z cut
+    kPileUpCut,                 ///< Pile up cut
+    k2015PileUpCut,             ///< 2015 PbPb additional pile up cut
+    kSPDClsVsTrkaletsCut,       ///< SPD clusters vs tracklets cut
+    kCentralityCut,             ///< Centrality cut
+    kNCuts                      ///< The number of supported cuts
+  };
+
+  /// \enum SystemType
+  /// \brief The type of the system under analysis
+  enum SystemType {
+    kNoSystem,    ///< no system defined
+    kpp,          ///< **p-p** system
+    kpPb,         ///< **p-Pb** system
+    kPbPb         ///< **Pb-Pb** system
+  };
+
+private:
+  /// \enum baseSystems
+  /// \brief The ids of the systems used as base for the filter track counting cuts
+  enum baseSystems {
+    kUnknownBase,                    ///< no system base
+    k2010based,                      ///< 2010 based system
+    k2011based                       ///< 2011 based system
+  };
+
+public:
+
+                      AliCSEventCuts();
+                      AliCSEventCuts(const char *name, const char * title);
+  virtual            ~AliCSEventCuts();
+
+  virtual void        InitCuts(const char *name = NULL);
+  virtual void        NotifyRun();
+  virtual void        NotifyEvent();
+  virtual Bool_t      IsEventAccepted(AliVEvent *fInputEvent);
+
+                      /// Get the system type
+                      /// \return the system type being analysed
+  SystemType          GetSystem() const { return fSystem; }
+                      /// Get the accepted centrality range
+                      /// \param minmax storage for the return values: index 0 minimum, index 1 maximum
+  void                GetCentralityRange(Float_t minmax[2]) const { minmax[0] = fCentralityMin; minmax[1] = fCentralityMax; }
+                      /// Get the vertex \f$z\f$ coordinate
+                      /// \return the vertex \f$z\f$ coordinate
+  Double_t            GetVertexZ() { return fVertexZ; }
+                      /// Gets the centrality of the current event
+                      /// \return event centrality in percentage
+  Double_t            GetCentrality() { return fCentrality; }
+
+private:
+  /* we set them private to force cuts string consistency */
+  Bool_t              SetSystemType(SystemType system);
+  Bool_t              SetCentralityType(Int_t code);
+  Bool_t              SetCentralityMin(Int_t code);
+  Bool_t              SetCentralityMax(Int_t code);
+  Bool_t              SetSelectActiveTrigger(Int_t code);
+  Bool_t              SetSelectActiveSubTrigger(Int_t code);
+  Bool_t              SetRemovePileUp(Int_t code);
+  Bool_t              SetVertexCut(Int_t code);
+  Bool_t              SetRemove2015PileUp(Int_t code);
+
+
+private:
+  virtual Bool_t      SetCutAndParams(Int_t paramID, Int_t value);
+  virtual void        PrintCutWithParams(Int_t paramID) const;
+  virtual void        PrintTrigger(UInt_t &printed, UInt_t trigger, const char *name) const;
+
+  Int_t               GetNumberOfVertexContributors(AliVEvent *event) const;
+  Bool_t              PassVertexResolutionAndDispersionTh(AliVEvent *event) const;
+  Bool_t              AcceptSPDTracksVtxDist(AliVEvent *event) const;
+  Bool_t              Is2015PileUpEvent() const;
+  Double_t            GetVertexZ(AliVEvent *event) const;
+  Bool_t              UseNewMultiplicityFramework() const;
+  Float_t             GetEventCentrality(AliVEvent *event) const;
+  Float_t             GetEventAltCentrality(AliVEvent *event) const;
+  Bool_t              StoreEventCentralities(AliVEvent *event);
+  Bool_t              StoreEventMultiplicities(AliVEvent *event);
+  void                GetCentralityEstimatorNames(const char *&sel, const char *&alt) const;
+  void                SetActualActiveTrigger();
+  void                SetActualSystemType();
+  void                SetActual2015PileUpRemoval();
+  void                SetActualFilterTracksCuts();
+
+  void                DefineHistograms();
+
+
+private:
+  static const char  *fgkCutsNames[kNCuts];                         ///< the names of the different event cuts
+  static Float_t      fgkVertexResolutionThreshold;                 ///< the vertex resolution threshold default value
+  static Float_t      fgkVertexDispersionThreshold;                 ///< the vertex dispersion threshold default value (for ESD only)
+  static Float_t      fgkSPDTracksVtxDistanceThreshold;             ///< the threshold for the distance between SPD and tracks vertex
+  static Float_t      fgkSPDTracksVtxDistanceSigmas;                ///< number of tolerated sigmas for the total distance between SPD and tracks vertex
+  static Float_t      fgkTrackVertexSigmas;                         ///< number of tolerated track vertex sigmas for the distance between SPD and tracks vertex
+
+  SystemType          fSystem;                ///< the type of system being analyzed
+  Double_t            fVertexZ;               ///< the vertex \f$z\f$ coordinate
+  Double_t            fCentrality;            ///< the event centrality
+  Int_t               fCentralityDetector;    ///< the detector to estimate the centrality
+  Int_t               fCentralityModifier;    ///< the modifier of the centrality cut value
+  Float_t             fCentralityMin;         ///< the minimum value for centrality cut
+  Float_t             fCentralityMax;         ///< the maximum value for centrality cut
+  UInt_t              fOfflineTriggerMask;    ///< the selected trigger mask
+  Float_t             fMaxVertexZ;            ///< the maximum value of the absolute z vertex coordinate
+  Bool_t              fUseSPDTracksVtxDist;   ///< check the distance between SPD and tracks vertex
+  Float_t             fVertexResolutionTh;    ///< vertex resolution threshold
+  Float_t             fVertexDispersionTh;    ///< vertex dispersion threshold (for ESD only)
+  Bool_t              fUseNewMultFramework;   ///< kTRUE if the new multiplicity framework for centrality estimation must be used
+  TFormula           *f2015V0MtoTrkTPCout;    ///< formula to evaluate 2015 additional pileup cut
+  TF1*                fCentOutLowCut;         ///< cut low for centrality outliers
+  TF1*                fCentOutHighCut;        ///< cut high for centrality outliers
+  TF1*                fTOFMultOutLowCut;      ///< cut low for TOF multiplicity outliers
+  TF1*                fTOFMultOutHighCut;     ///< cut high for TOF multiplicity outliers
+  TF1*                fMultCentOutLowCut;     ///< cut low for multiplicity centrality outliers
+  Float_t             fV0MCentrality;         ///< the event V0M centrality
+  Float_t             fV0ACentrality;         ///< the event V0A centrality
+  Float_t             fV0CCentrality;         ///< the event V0C centrality
+  Float_t             fCL0Centrality;         ///< the event CL0 centrality
+  Float_t             fCL1Centrality;         ///< the event CL1 centrality
+  Int_t               fReferenceMultiplicity; ///< event reference multiplicity
+  Int_t               fV0Multiplicity;        ///< the event V0 multiplicity
+  Int_t               fNoOfAODTracks;         ///< the number of AOD tracks
+  Int_t               fNoOfESDTracks;         ///< the number of ESD tracks
+  Int_t               fNoOfFB32Tracks;        ///< the number of globals tracks with tight DCA
+  Int_t               fNoOfFB128Tracks;       ///< the number of TPC only able to be constrained to SPD vertex tracks
+  Int_t               fNoOfFB32AccTracks;     ///< the number of global tracks with tight DCA accepted by standard cuts
+  Int_t               fNoOfFB32TOFTracks;     ///< the number of global tracks with tight DCA acceptable by TOF
+  Int_t               fNoOfTPCoutTracks;      ///< the number of tracks with TPCout flag on
+  Int_t               fNoOfInitialTPCoutTracks;      ///< the number of tracks with TPCout flag on, initial track counting method
+
+
+  AliAnalysisUtils    fAnalysisUtils;         ///< analysis utilities for pile up detection
+  AliESDtrackCuts    *fESDFB32;               ///< ESD tracks cuts to mirror AOD FB32
+  AliESDtrackCuts    *fESDFB128;              ///< ESD tracks cuts to mirror AOD FB128
+
+  /* histograms with two indices: before (0) / after (1) applying the cut */
+  TH1F               *fhCutsStatistics;                ///< the cuts statistics
+  TH1F               *fhUniqueCutsStatistics;          ///< the unique cuts statistics
+  TH2F               *fhCutsCorrelation;               ///< cuts correlation
+  TH1F               *fhCentrality[2];                 ///< the event centrality histogram (b/a)
+  TH1F               *fhVertexZ[2];                    ///< the event vertex z histograms (b/a)
+  TH2F               *fhSPDClustersVsTracklets[2];     ///< SPD clusters vs number of tracklets histogram (b/a)
+  TH2F               *fhV0MvsTracksTPCout[2];          ///< V0 multiplicity vs number of TPCout tracks histogram (b/a)
+  TH2F               *fhV0MvsTracksInitialTPCout[2];   ///< V0 multiplicity vs number of initial method TPCout tracks histogram (b/a)
+  TH2F               *fhCentralityAltVsSel[2];         ///< Centrality correlation alternative vs selected detector
+  TH2F               *fhCL0vsV0MCentrality[2];         ///< Centrality correlation CL0 vs V0M
+  TH2F               *fhESDvsTPConlyMultiplicity[2];   ///< Multiplicity ESD tracks vs TPC only tracks
+  TH2F               *fhTOFvsGlobalMultiplicity[2];    ///< Multiplicity TOF global tracks vs global tracks
+  TH2F               *fhAccTrkvsV0MCentrality[2];      ///< Multiplicity accepted global tracks vs V0M centraliy
+  TH1F               *fhTriggerClass[2];               ///< the fired triggers (b/a)
+
+  /// Copy constructor
+  /// Not allowed. Forced private.
+  AliCSEventCuts(const AliCSEventCuts&);
+  /// Assignment operator
+  /// Not allowed. Forced private.
+  /// \return l-value reference object
+  AliCSEventCuts& operator=(const AliCSEventCuts&);
+
+  /// \cond CLASSIMP
+  ClassDef(AliCSEventCuts,6);
+  /// \endcond
+};
+
+#endif /* ALICSEVENTCUTS_H */

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSPIDCuts.cxx
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSPIDCuts.cxx
@@ -1,0 +1,1114 @@
+/**************************************************************************
+* Copyright(c) 1998-2017, ALICE Experiment at CERN, All rights reserved.  *
+*                                                                         *
+* Permission to use, copy, modify and distribute this software and its    *
+* documentation strictly for non-commercial purposes is hereby granted    *
+* without fee, provided that the above copyright notice appears in all    *
+* copies and that both the copyright notice and this permission notice    *
+* appear in the supporting documentation. The authors make no claims      *
+* about the suitability of this software for any purpose. It is           *
+* provided "as is" without express or implied warranty.                   *
+**************************************************************************/
+
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TParticle.h>
+#include "AliStack.h"
+#include "AliVEvent.h"
+#include "AliVTrack.h"
+#include "AliAnalysisManager.h"
+#include "AliInputEventHandler.h"
+#include "AliMCEventHandler.h"
+#include "AliAODEvent.h"
+#include "AliESDEvent.h"
+#include "AliMCEvent.h"
+#include "AliAODMCParticle.h"
+#include "AliAODTrack.h"
+#include "AliPIDResponse.h"
+#include "AliLog.h"
+#include "AliCSTrackMaps.h"
+#include "AliCSPIDCuts.h"
+
+/// \file AliCSPIDCuts.cxx
+/// \brief Implementation of PID track cuts class within the correlation studies analysis
+
+/// \cond CLASSIMP
+ClassImp(AliCSPIDCuts);
+/// \endcond
+
+const char *AliCSPIDCuts::fgkCutsNames[AliCSPIDCuts::kNCuts] = {
+    "ITS dE/dx n#sigma",
+    "TPC dE/dx n#sigma",
+    "TOF n#sigma"
+};
+
+
+/// Default constructor for serialization
+AliCSPIDCuts::AliCSPIDCuts() :
+    AliCSTrackCutsBase(),
+    fMinP(0.0),
+    fMaxP(9999.0),
+//    fITSnSigmaAbove{100.0},
+//    fITSnSigmaBelow{-100.0},
+//    fTPCnSigmaAbove{100.0},
+//    fTPCnSigmaBelow{-100.0},
+//    fTOFRequired{kFALSE},
+//    fTOFnSigmaAbove{100.0},
+//    fTOFnSigmaBelow{-100.0},
+    fITSEnabledSpeciesMask(TBits()),
+    fTPCEnabledSpeciesMask(TBits()),
+    fTOFEnabledSpeciesMask(TBits()),
+    fPIDResponse(NULL),
+    fTargetSpecies(AliPID::kUnknown),
+    fhCutsStatistics(NULL),
+    fhCutsCorrelation(NULL)
+//    fhITSdEdxSigmaVsP{NULL},
+//    fhITSdEdxSignalVsP{NULL},
+//    fhTPCdEdxSigmaVsP{NULL},
+//    fhTPCdEdxSignalVsP{NULL},
+//    fhTOFSigmaVsP{NULL},
+//    fhTOFSignalVsP{NULL}
+{
+}
+
+/// Constructor
+/// \param name name of the event cuts
+/// \param title title of the event cuts
+/// \param target the PID target particle of type AliPID::EParticleType
+AliCSPIDCuts::AliCSPIDCuts(const char *name, const char *title, AliPID::EParticleType target) :
+    AliCSTrackCutsBase(kNCuts,kNCutsParameters,name,title),
+    fMinP(0.0),
+    fMaxP(9999.0),
+    //    fITSnSigmaAbove{100.0},
+    //    fITSnSigmaBelow{-100.0},
+    //    fTPCnSigmaAbove{100.0},
+    //    fTPCnSigmaBelow{-100.0},
+    //    fTOFRequired{kFALSE},
+    //    fTOFnSigmaAbove{100.0},
+    //    fTOFnSigmaBelow{-100.0},
+    fITSEnabledSpeciesMask(TBits(AliPID::kSPECIESC)),
+    fTPCEnabledSpeciesMask(TBits(AliPID::kSPECIESC)),
+    fTOFEnabledSpeciesMask(TBits(AliPID::kSPECIESC)),
+    fPIDResponse(NULL),
+    fTargetSpecies(target),
+    fhCutsStatistics(NULL),
+    fhCutsCorrelation(NULL)
+//    fhITSdEdxSigmaVsP{NULL},
+//    fhITSdEdxSignalVsP{NULL},
+//    fhTPCdEdxSigmaVsP{NULL},
+//    fhTPCdEdxSignalVsP{NULL},
+//    fhTOFSigmaVsP{NULL},
+//    fhTOFSignalVsP{NULL}
+{
+  for (Int_t spid = AliPID::kElectron; spid < AliPID::kSPECIESC; spid++) {
+    fITSnSigmaAbove[spid] = 100.0;
+    fITSnSigmaBelow[spid] = -100.0;
+    fTPCnSigmaAbove[spid] = 100.0;
+    fTPCnSigmaBelow[spid] = -100.0;
+    fTOFRequired[spid] = kFALSE;
+    fTOFnSigmaAbove[spid] = 100.0;
+    fTOFnSigmaBelow[spid] = -100.0;
+  }
+
+  for (Int_t i = 0; i < 2; i++) {
+    fhITSdEdxSigmaVsP[i] = NULL;
+    fhITSdEdxSignalVsP[i] = NULL;
+    fhTPCdEdxSigmaVsP[i] = NULL;
+    fhTPCdEdxSignalVsP[i] = NULL;
+    fhTOFSigmaVsP[i] = NULL;
+    fhTOFSignalVsP[i] = NULL;
+  }
+
+  fITSEnabledSpeciesMask.ResetAllBits();
+  fTPCEnabledSpeciesMask.ResetAllBits();
+  fTOFEnabledSpeciesMask.ResetAllBits();
+}
+
+/// Destructor
+/// We don't own anything, everything we allocate is owned
+/// by the output list
+AliCSPIDCuts::~AliCSPIDCuts()
+{
+
+}
+
+/// Processes a potential change in the run number
+///
+/// Checks if the current period under analysis has changed and if so
+/// updates the needed members
+void AliCSPIDCuts::NotifyRun() {
+
+  /* checks the change in the analysis period */
+  if (AliCSTrackCutsBase::GetGlobalPeriod() != fDataPeriod) {
+
+    fDataPeriod = AliCSTrackCutsBase::GetGlobalPeriod();
+
+    /* and now we ask for histogram allocation */
+    DefineHistograms();
+  }
+}
+
+/// Processes the start of a new event
+///
+/// Does nothin for the time being
+void AliCSPIDCuts::NotifyEvent() {
+
+}
+
+/// Check whether the passed track is recognized as the target by the different configured PID cuts
+/// \param ttrk the track to analyze whether it is recognized as the target or not
+/// \return kTRUE if the track is recognized, kFALSE otherwise
+///
+Bool_t AliCSPIDCuts::IsTrackAccepted(AliVTrack *ttrk) {
+  /* just to be sure */
+  if (ttrk == NULL) return kFALSE;
+
+  /* if not in the momentum range it is not recognized */
+  if (ttrk->P() < fMinP || fMaxP < ttrk->P()) return kFALSE;
+
+  /* for the time being */
+  Bool_t accepted = kTRUE;
+
+  /* initialize the mask of activated cuts */
+  fCutsActivatedMask.ResetAllBits();
+
+  /* we now need to consider the potential constrained track */
+  AliVTrack *trk = ttrk;
+  if (ttrk->GetID() < 0)
+    /* let's switch to the original one which has the PID information */
+    trk = AliCSTrackMaps::GetOriginalTrack(dynamic_cast<AliAODTrack*>(ttrk));
+
+
+  /* ITS PID cut */
+  if (fCutsEnabledMask.TestBitNumber(kITSdEdxSigmaCut)) {
+    if( fPIDResponse->NumberOfSigmasITS(trk, fTargetSpecies) < fITSnSigmaBelow[fTargetSpecies] ||
+        fITSnSigmaAbove[fTargetSpecies] < fPIDResponse->NumberOfSigmasITS(trk, fTargetSpecies)){
+      fCutsActivatedMask.SetBitNumber(kITSdEdxSigmaCut);
+      accepted = kFALSE;
+    }
+    else {
+      /* now check the separation if required */
+      if (fITSEnabledSpeciesMask.CountBits() > 1) {
+        AliPID::EParticleType spid = AliPID::EParticleType(fITSEnabledSpeciesMask.FirstSetBit());
+        while (spid < AliPID::kDeuteron) {
+          if (spid != fTargetSpecies) {
+            if(fITSnSigmaBelow[spid] < fPIDResponse->NumberOfSigmasITS(trk, spid) &&
+                fPIDResponse->NumberOfSigmasITS(trk, spid) < fITSnSigmaAbove[spid]){
+              fCutsActivatedMask.SetBitNumber(kITSdEdxSigmaCut);
+              accepted = kFALSE;
+              break;
+            }
+          }
+          spid = AliPID::EParticleType(fITSEnabledSpeciesMask.FirstSetBit(spid+1));
+        }
+      }
+    }
+  }
+
+  /* TPC PID cut */
+  if (fCutsEnabledMask.TestBitNumber(kTPCdEdxSigmaCut)) {
+    if( fPIDResponse->NumberOfSigmasTPC(trk, fTargetSpecies) < fTPCnSigmaBelow[fTargetSpecies] ||
+        fTPCnSigmaAbove[fTargetSpecies] < fPIDResponse->NumberOfSigmasTPC(trk, fTargetSpecies)){
+      fCutsActivatedMask.SetBitNumber(kTPCdEdxSigmaCut);
+      accepted = kFALSE;
+    }
+    else {
+      /* now check the separation if required */
+      if (fTPCEnabledSpeciesMask.CountBits() > 1) {
+        AliPID::EParticleType spid = AliPID::EParticleType(fTPCEnabledSpeciesMask.FirstSetBit());
+        while (spid < AliPID::kDeuteron) {
+          if (spid != fTargetSpecies) {
+            if(fTPCnSigmaBelow[spid] < fPIDResponse->NumberOfSigmasTPC(trk, spid) &&
+                fPIDResponse->NumberOfSigmasTPC(trk, spid) < fTPCnSigmaAbove[spid]){
+              fCutsActivatedMask.SetBitNumber(kTPCdEdxSigmaCut);
+              accepted = kFALSE;
+              break;
+            }
+          }
+          spid = AliPID::EParticleType(fTPCEnabledSpeciesMask.FirstSetBit(spid+1));
+        }
+      }
+    }
+  }
+
+  /* TOF PID cut */
+  if (fCutsEnabledMask.TestBitNumber(kTOFSigmaCut)) {
+    if ((trk->GetStatus() & AliESDtrack::kTOFin) && (!(trk->GetStatus() & AliESDtrack::kTOFmismatch))) {
+      if( fPIDResponse->NumberOfSigmasTOF(trk, fTargetSpecies) < fTOFnSigmaBelow[fTargetSpecies] ||
+          fTOFnSigmaAbove[fTargetSpecies] < fPIDResponse->NumberOfSigmasTOF(trk, fTargetSpecies)){
+        fCutsActivatedMask.SetBitNumber(kTOFSigmaCut);
+        accepted = kFALSE;
+      }
+      else {
+        /* now check the separation if required */
+        if (fTOFEnabledSpeciesMask.CountBits() > 1) {
+          AliPID::EParticleType spid = AliPID::EParticleType(fTOFEnabledSpeciesMask.FirstSetBit());
+          while (spid < AliPID::kDeuteron) {
+            if (spid != fTargetSpecies) {
+              if(fTOFnSigmaBelow[spid] < fPIDResponse->NumberOfSigmasTOF(trk, spid) &&
+                  fPIDResponse->NumberOfSigmasTOF(trk, spid) < fTOFnSigmaAbove[spid]){
+                fCutsActivatedMask.SetBitNumber(kTOFSigmaCut);
+                accepted = kFALSE;
+                break;
+              }
+            }
+            spid = AliPID::EParticleType(fTOFEnabledSpeciesMask.FirstSetBit(spid+1));
+          }
+        }
+      }
+    }
+    else {
+      if (fTOFRequired[fTargetSpecies]) {
+        fCutsActivatedMask.SetBitNumber(kTOFSigmaCut);
+        accepted = kFALSE;
+      }
+    }
+  }
+
+  if (fQALevel > kQALevelNone) {
+    /* let's fill the histograms */
+    fhCutsStatistics->Fill(fhCutsStatistics->GetBinCenter(fhCutsStatistics->GetXaxis()->FindBin("n tracks")));
+    if (!accepted)
+      fhCutsStatistics->Fill(fhCutsStatistics->GetBinCenter(fhCutsStatistics->GetXaxis()->FindBin("n cut tracks")));
+
+    for (Int_t i=0; i<kNCuts; i++) {
+      if (fhCutsStatistics->GetXaxis()->FindBin(fgkCutsNames[i]) < 1)
+        AliFatal(Form("Inconsistency! Cut %d with name %s not found", i, fgkCutsNames[i]));
+
+      if (fCutsActivatedMask.TestBitNumber(i))
+        fhCutsStatistics->Fill(fhCutsStatistics->GetBinCenter(fhCutsStatistics->GetXaxis()->FindBin(fgkCutsNames[i])));
+
+      if (fQALevel > kQALevelLight) {
+        for (Int_t j=i; j<kNCuts; j++) {
+          if (fhCutsStatistics->GetXaxis()->FindBin(fgkCutsNames[j]) < 1)
+            AliFatal(Form("Inconsistency! Cut %d with name %s not found", j, fgkCutsNames[j]));
+
+          if (fCutsActivatedMask.TestBitNumber(i) && fCutsActivatedMask.TestBitNumber(j)) {
+            Float_t xC = fhCutsCorrelation->GetXaxis()->GetBinCenter(fhCutsCorrelation->GetXaxis()->FindBin(fgkCutsNames[i]));
+            Float_t yC = fhCutsCorrelation->GetYaxis()->GetBinCenter(fhCutsCorrelation->GetYaxis()->FindBin(fgkCutsNames[j]));
+            fhCutsCorrelation->Fill(xC, yC);
+          }
+        }
+      }
+    }
+
+    for (Int_t i = 0; i < 2; i++) {
+
+      /* don't fill before if not requested */
+      if (i == 1 || (fQALevel > kQALevelLight)) {
+        fhITSdEdxSigmaVsP[i]->Fill(ttrk->P(),fPIDResponse->NumberOfSigmasITS(trk, fTargetSpecies));
+        fhITSdEdxSignalVsP[i]->Fill(ttrk->P(),trk->GetITSsignal());
+        fhTPCdEdxSigmaVsP[i]->Fill(ttrk->P(),fPIDResponse->NumberOfSigmasTPC(trk, fTargetSpecies));
+        fhTPCdEdxSignalVsP[i]->Fill(ttrk->P(),TMath::Abs(trk->GetTPCsignal()));
+        if ((trk->GetStatus() & AliESDtrack::kTOFin) && (!(trk->GetStatus() & AliESDtrack::kTOFmismatch))) {
+          static const Double_t c_cm_ps = TMath::C() * 1.0e2 * 1.0e-12;
+          Double_t tracklen_cm = trk->GetIntegratedLength();
+          Double_t toftime_ps = trk->GetTOFsignal() - fPIDResponse->GetTOFResponse().GetStartTime(ttrk->P());
+          Double_t beta = tracklen_cm / toftime_ps / c_cm_ps;
+          fhTOFSigmaVsP[i]->Fill(ttrk->P(),fPIDResponse->NumberOfSigmasTOF(trk, fTargetSpecies));
+          fhTOFSignalVsP[i]->Fill(ttrk->P(),beta);
+        }
+      }
+      /* don't fill after if event not accepted */
+      if (!accepted) break;
+    }
+  }
+  return accepted;
+}
+
+
+/// Check whether the true track associated to the passed track is accepted by the PID cuts
+/// \param trk the track to analyze whether its associated true track is accepted or not
+/// \return kTRUE if the associated true track  is accepted, kFALSE otherwise
+///
+Bool_t AliCSPIDCuts::IsTrueTrackAccepted(AliVTrack *trk) {
+
+  /* reject ghost tracks */
+  if (trk->GetLabel() < 0) return kFALSE;
+
+  return IsTrueTrackAccepted(trk->GetLabel());
+}
+
+
+/// Check whether the passed true track is recognized by the PID cut
+/// \param itrk the index of true track to analyze whether it is recognized or not
+/// \return kTRUE if the track  is recognized, kFALSE otherwise
+///
+Bool_t AliCSPIDCuts::IsTrueTrackAccepted(Int_t itrk) {
+
+  Double_t p = 0.0;
+
+  if (fgIsESD) {
+    /* get the associated particle */
+    TParticle *particle = fgMCHandler->MCEvent()->Particle(itrk);
+
+    /* just to be sure */
+    if (particle == NULL) return kFALSE;
+
+    p = particle->P();
+
+    /* if not in the momentum range it is not recognized */
+    if (p < fMinP || fMaxP < p) return kFALSE;
+
+    if (fCutsEnabledMask.TestBitNumber(kITSdEdxSigmaCut) ||
+        fCutsEnabledMask.TestBitNumber(kTPCdEdxSigmaCut) ||
+        fCutsEnabledMask.TestBitNumber(kTOFSigmaCut)) {
+      if (GetTrueSpecies(particle) != fTargetSpecies) {
+        return kFALSE;
+      }
+    }
+  }
+  else {
+    /* get the associated particle */
+    AliAODMCParticle *particle = (AliAODMCParticle *) fgMCArray->At(itrk);
+
+    /* just to be sure */
+    if (particle == NULL) return kFALSE;
+
+    p = particle->P();
+
+    /* if not in the momentum range it is not recognized */
+    if (p < fMinP || fMaxP < p) return kFALSE;
+
+    if (fCutsEnabledMask.TestBitNumber(kITSdEdxSigmaCut) ||
+        fCutsEnabledMask.TestBitNumber(kTPCdEdxSigmaCut) ||
+        fCutsEnabledMask.TestBitNumber(kTOFSigmaCut)) {
+      if (GetTrueSpecies(particle) != fTargetSpecies) {
+        return kFALSE;
+      }
+    }
+  }
+  return kTRUE;
+}
+
+/// Get the true species associated to a reconstructed track
+/// \param trk the reconstructed track
+/// \return the ID of the associated species
+AliPID::EParticleType AliCSPIDCuts::GetTrueSpecies(AliVTrack *trk) {
+
+  if (fgIsESD) {
+    TParticle *particle = fgMCHandler->MCEvent()->Particle(TMath::Abs(trk->GetLabel()));
+    return GetTrueSpecies(particle);
+  }
+  else {
+    /* get the associated particle */
+    AliAODMCParticle *particle = (AliAODMCParticle *) fgMCArray->At(TMath::Abs(trk->GetLabel()));
+    return GetTrueSpecies(particle);
+  }
+}
+
+/// Get the true species associated to a true particle
+/// \param par the true particle
+/// \return the ID of the particle species
+AliPID::EParticleType AliCSPIDCuts::GetTrueSpecies(TParticle *par) {
+
+  switch(par->GetPdgCode()) {
+  case ::kPositron:
+  case ::kElectron:
+    return AliPID::kElectron;
+    break;
+  case ::kProton:
+  case ::kProtonBar:
+    return AliPID::kProton;
+    break;
+  case ::kMuonPlus:
+  case ::kMuonMinus:
+    return AliPID::kMuon;
+    break;
+  case ::kPiPlus:
+  case ::kPiMinus:
+    return AliPID::kPion;
+    break;
+  case ::kKPlus:
+  case ::kKMinus:
+    return AliPID::kKaon;
+    break;
+  default:
+    return AliPID::kUnknown;
+  }
+}
+
+/// Get the true species associated to a true particle
+/// \param par the true particle
+/// \return the ID of the particle species
+AliPID::EParticleType AliCSPIDCuts::GetTrueSpecies(AliAODMCParticle *par) {
+
+  switch(par->GetPdgCode()) {
+  case ::kPositron:
+  case ::kElectron:
+    return AliPID::kElectron;
+    break;
+  case ::kProton:
+  case ::kProtonBar:
+    return AliPID::kProton;
+    break;
+  case ::kMuonPlus:
+  case ::kMuonMinus:
+    return AliPID::kMuon;
+    break;
+  case ::kPiPlus:
+  case ::kPiMinus:
+    return AliPID::kPion;
+    break;
+  case ::kKPlus:
+  case ::kKMinus:
+    return AliPID::kKaon;
+    break;
+  default:
+    return AliPID::kUnknown;
+  }
+}
+
+/// Sets the individual value for the cut parameter ID
+/// \param paramID the ID of the cut parameter of interest
+/// \param value the value for the cut parameter
+/// \return kTRUE if the cut parameter value was accepted
+Bool_t AliCSPIDCuts::SetCutAndParams(Int_t paramID, Int_t value) {
+
+  switch (cutsParametersIds(paramID)) {
+  case kPRangeCutParam:
+    if (SetPRange(value)) {
+      fParameters[kPRangeCutParam] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kITSdEdxSigmaCutParam_e:
+    if (SetITSdEdxSigmaCut(AliPID::kElectron, value)) {
+      fParameters[kITSdEdxSigmaCutParam_e] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kITSdEdxSigmaCutParam_mu:
+    if (SetITSdEdxSigmaCut(AliPID::kMuon, value)) {
+      fParameters[kITSdEdxSigmaCutParam_mu] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kITSdEdxSigmaCutParam_pi:
+    if (SetITSdEdxSigmaCut(AliPID::kPion, value)) {
+      fParameters[kITSdEdxSigmaCutParam_pi] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kITSdEdxSigmaCutParam_k:
+    if (SetITSdEdxSigmaCut(AliPID::kKaon, value)) {
+      fParameters[kITSdEdxSigmaCutParam_k] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kITSdEdxSigmaCutParam_p:
+    if (SetITSdEdxSigmaCut(AliPID::kProton, value)) {
+      fParameters[kITSdEdxSigmaCutParam_p] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kTPCdEdxSigmaCutParam_e:
+    if (SetTPCdEdxSigmaCut(AliPID::kElectron, value)) {
+      fParameters[kTPCdEdxSigmaCutParam_e] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kTPCdEdxSigmaCutParam_mu:
+    if (SetTPCdEdxSigmaCut(AliPID::kMuon, value)) {
+      fParameters[kTPCdEdxSigmaCutParam_mu] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kTPCdEdxSigmaCutParam_pi:
+    if (SetTPCdEdxSigmaCut(AliPID::kPion, value)) {
+      fParameters[kTPCdEdxSigmaCutParam_pi] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kTPCdEdxSigmaCutParam_k:
+    if (SetTPCdEdxSigmaCut(AliPID::kKaon, value)) {
+      fParameters[kTPCdEdxSigmaCutParam_k] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kTPCdEdxSigmaCutParam_p:
+    if (SetTPCdEdxSigmaCut(AliPID::kProton, value)) {
+      fParameters[kTPCdEdxSigmaCutParam_p] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kTOFSigmaCutParam_e:
+    if (SetTOFSigmaCut(AliPID::kElectron, value)) {
+      fParameters[kTOFSigmaCutParam_e] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kTOFSigmaCutParam_mu:
+    if (SetTOFSigmaCut(AliPID::kMuon, value)) {
+      fParameters[kTOFSigmaCutParam_mu] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kTOFSigmaCutParam_pi:
+    if (SetTOFSigmaCut(AliPID::kPion, value)) {
+      fParameters[kTOFSigmaCutParam_pi] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kTOFSigmaCutParam_k:
+    if (SetTOFSigmaCut(AliPID::kKaon, value)) {
+      fParameters[kTOFSigmaCutParam_k] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kTOFSigmaCutParam_p:
+    if (SetTOFSigmaCut(AliPID::kProton, value)) {
+      fParameters[kTOFSigmaCutParam_p] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  default:
+    AliError(Form("Cut param id %d out of supported range", paramID));
+    return kFALSE;
+  }
+}
+
+
+/// Print the whole cut iformatio for the cut ID
+/// \param paramID the ID of the cut of interest
+void AliCSPIDCuts::PrintCutWithParams(Int_t paramID) const {
+
+  switch (cutsParametersIds(paramID)) {
+  case kPRangeCutParam:
+    printf("  Cut applicable P range: ");
+    printf("%3.1f GeV < P %s", fMinP, (fMaxP < 9990) ? Form("%3.1f GeV\n", fMaxP) : "\n");
+    break;
+  case kITSdEdxSigmaCutParam_e:
+    PrintITSdEdxSigmaCut(AliPID::kElectron);
+    break;
+  case kITSdEdxSigmaCutParam_mu:
+    PrintITSdEdxSigmaCut(AliPID::kMuon);
+    break;
+  case kITSdEdxSigmaCutParam_pi:
+    PrintITSdEdxSigmaCut(AliPID::kPion);
+    break;
+  case kITSdEdxSigmaCutParam_k:
+    PrintITSdEdxSigmaCut(AliPID::kKaon);
+    break;
+  case kITSdEdxSigmaCutParam_p:
+    PrintITSdEdxSigmaCut(AliPID::kProton);
+    break;
+  case kTPCdEdxSigmaCutParam_e:
+    PrintTPCdEdxSigmaCut(AliPID::kElectron);
+    break;
+  case kTPCdEdxSigmaCutParam_mu:
+    PrintTPCdEdxSigmaCut(AliPID::kMuon);
+    break;
+  case kTPCdEdxSigmaCutParam_pi:
+    PrintTPCdEdxSigmaCut(AliPID::kPion);
+    break;
+  case kTPCdEdxSigmaCutParam_k:
+    PrintTPCdEdxSigmaCut(AliPID::kKaon);
+    break;
+  case kTPCdEdxSigmaCutParam_p:
+    PrintTPCdEdxSigmaCut(AliPID::kProton);
+    break;
+  case kTOFSigmaCutParam_e:
+    PrintTOFSigmaCut(AliPID::kElectron);
+    break;
+  case kTOFSigmaCutParam_mu:
+    PrintTOFSigmaCut(AliPID::kMuon);
+    break;
+  case kTOFSigmaCutParam_pi:
+    PrintTOFSigmaCut(AliPID::kPion);
+    break;
+  case kTOFSigmaCutParam_k:
+    PrintTOFSigmaCut(AliPID::kKaon);
+    break;
+  case kTOFSigmaCutParam_p:
+    PrintTOFSigmaCut(AliPID::kProton);
+    break;
+  default:
+    AliError(Form("Cut param id %d out of supported range", paramID));
+  }
+}
+
+/// Configures the applicable track momentum range for the PID cut
+/// \param ptcode the **P** range code
+/// | code | minimum **P** (GeV/c) | maximum **P** (GeV/c) |
+/// |:--:|:--:|:--:|
+/// | 0 | full range | full range |
+/// | 1 | 0.2 | 2.0 |
+/// | 2 | 0.2 | 3.0 |
+/// | 3 | 0.2 | 5.0 |
+/// | 4 | 0.2 | 1.4 |
+/// | 5 | 0.2 | 1.6 |
+/// | 6 | 0.2 | 1.8 |
+/// \return kTRUE if proper and supported \f$ p_{T} \f$ cut code
+///
+Bool_t AliCSPIDCuts::SetPRange(Int_t ptcode)
+{
+  switch(ptcode){
+  case 0:
+    fMinP = 0.0;
+    fMaxP = 9999.0;
+    break;
+  case 1:
+    fMinP = 0.2;
+    fMaxP = 2.0;
+    break;
+  case 2:
+    fMinP = 0.2;
+    fMaxP = 3.0;
+    break;
+  case 3:
+    fMinP = 0.2;
+    fMaxP = 5.0;
+    break;
+  case 4:
+    fMinP = 0.2;
+    fMaxP = 1.4;
+    break;
+  case 5:
+    fMinP = 0.2;
+    fMaxP = 1.6;
+    break;
+  case 6:
+    fMinP = 0.2;
+    fMaxP = 1.8;
+    break;
+  default:
+    AliError(Form("P range code %d not supported", ptcode));
+    return kFALSE;
+  }
+  return kTRUE;
+}
+
+/// Sets the range for the dEdx \f$ n \sigma \f$ cut within the ITS
+///
+/// The cut establishes an acceptance band around a concrete
+/// particle species line within the ITS. For species other than
+/// the selected target the band is a separation band.
+/// \param id the id of the species for which the band is being configured
+/// \param dEdxCode the code for the \f$ n \sigma \f$ cut
+/// | code | \f$ n \sigma \f$ below line | \f$ n \sigma \f$ above line | observations |
+/// |:--:|:--:|:--:|:--|
+/// | 0 | n/a | n/a | passive cut |
+/// | 1 | -10 | 10 | |
+/// | 2 | -6| 7 | |
+/// | 3 | -5 | 5 | |
+/// | 4 | -4 | 5 | |
+/// | 5 | -3 | 5 | |
+/// | 6 | -4 | 4 | |
+/// | 7 | -2.5 | 4 | |
+/// | 8 | -2 | 3.5 | |
+/// \return kTRUE if proper and supported dEdx code
+
+Bool_t AliCSPIDCuts::SetITSdEdxSigmaCut(AliPID::EParticleType id, Int_t dEdxCode){
+  switch(dEdxCode){
+    case 0:
+      fITSEnabledSpeciesMask.ResetBitNumber(id);
+      fITSnSigmaBelow[id] = -100.0;
+      fITSnSigmaAbove[id] = 100.0;
+      break;
+    case 1:
+      fITSEnabledSpeciesMask.SetBitNumber(id);
+      fITSnSigmaBelow[id] = -10.0;
+      fITSnSigmaAbove[id] = 10.0;
+      break;
+    case 2:
+      fITSEnabledSpeciesMask.SetBitNumber(id);
+      fITSnSigmaBelow[id] = -6.0;
+      fITSnSigmaAbove[id] = 7.0;
+      break;
+    case 3:
+      fITSEnabledSpeciesMask.SetBitNumber(id);
+      fITSnSigmaBelow[id] = -5.0;
+      fITSnSigmaAbove[id] = 5.0;
+      break;
+    case 4:
+      fITSEnabledSpeciesMask.SetBitNumber(id);
+      fITSnSigmaBelow[id] = -4.0;
+      fITSnSigmaAbove[id] = 5.0;
+      break;
+    case 5:
+      fITSEnabledSpeciesMask.SetBitNumber(id);
+      fITSnSigmaBelow[id] = -3.0;
+      fITSnSigmaAbove[id] = 5.0;
+      break;
+    case 6:
+      fITSEnabledSpeciesMask.SetBitNumber(id);
+      fITSnSigmaBelow[id] = -4.0;
+      fITSnSigmaAbove[id] = 4.0;
+      break;
+    case 7:
+      fITSEnabledSpeciesMask.SetBitNumber(id);
+      fITSnSigmaBelow[id] = -2.5;
+      fITSnSigmaAbove[id] = 4.0;
+      break;
+    case 8:
+      fITSEnabledSpeciesMask.SetBitNumber(id);
+      fITSnSigmaBelow[id] = -2.0;
+      fITSnSigmaAbove[id] = 3.5;
+      break;
+    default:
+      AliError(Form("ITS dEdx n sigmas cut code %d not supported",dEdxCode));
+      return kFALSE;
+  }
+  if (fITSEnabledSpeciesMask.CountBits() > 0)
+    fCutsEnabledMask.SetBitNumber(kITSdEdxSigmaCut);
+  else
+    fCutsEnabledMask.ResetBitNumber(kITSdEdxSigmaCut);
+  return kTRUE;
+}
+
+
+/// Prints the dEdx \f$ n \sigma \f$ cut within the ITS
+///
+/// The cut establishes an acceptance band around a concrete
+/// particle species line within the ITS. For species other than
+/// the selected target the band is a separation band.
+/// \param id the id of the species for which cut is being printed
+void AliCSPIDCuts::PrintITSdEdxSigmaCut(AliPID::EParticleType id) const {
+  if (fCutsEnabledMask.TestBitNumber(kITSdEdxSigmaCut)) {
+    printf("  ITS PID CUT %s: ", AliPID::ParticleName(fTargetSpecies));
+    if (fITSEnabledSpeciesMask.TestBitNumber(id)) {
+      if (fTargetSpecies != id) {
+        printf("nsigma %s < %3.1f OR %3.1f < nsigma %s\n",
+            AliPID::ParticleName(id),
+            fITSnSigmaBelow[id],
+            fITSnSigmaAbove[id],
+            AliPID::ParticleName(id));
+      }
+      else
+        printf("%3.1f < nsigma < %3.1f\n",
+            fITSnSigmaBelow[id],
+            fITSnSigmaAbove[id]);
+    }
+    else
+      printf("none to %s line\n",AliPID::ParticleName(id));
+  }
+  else
+    printf("  ITS PID CUT %s: none\n", AliPID::ParticleName(fTargetSpecies));
+}
+
+
+/// Sets the range for the dEdx \f$ n \sigma \f$ cut within the TPC
+///
+/// The cut establishes an acceptance band around a concrete
+/// particle species line within the TPC. For species other than
+/// the selected target the band is a separation band.
+/// \param id the id of the species for which the band is being configured
+/// \param dEdxCode the code for the \f$ n \sigma \f$ cut
+/// | code | \f$ n \sigma \f$ below line | \f$ n \sigma \f$ above line | observations |
+/// |:--:|:--:|:--:|:--|
+/// | 0 | n/a | n/a | passive cut |
+/// | 1 | -10 | 10 | |
+/// | 2 | -6| 7 | |
+/// | 3 | -5 | 5 | |
+/// | 4 | -4 | 5 | |
+/// | 5 | -4 | 4 | |
+/// | 6 | -3 | 4 | |
+/// | 7 | -3 | 3 | |
+/// | 8 | -3 | 5 | |
+/// | 9 | -2 | 3 | |
+/// \return kTRUE if proper and supported dEdx code
+
+Bool_t AliCSPIDCuts::SetTPCdEdxSigmaCut(AliPID::EParticleType id, Int_t dEdxCode){
+  AliInfo(Form("Configuring TPC dEdx cut for %s, with %d code", AliPID::ParticleName(id), dEdxCode));
+
+  switch(dEdxCode){
+    case 0:
+      fTPCEnabledSpeciesMask.ResetBitNumber(id);
+      fTPCnSigmaBelow[id] = -100.0;
+      fTPCnSigmaAbove[id] = 100.0;
+      break;
+    case 1:
+      fTPCEnabledSpeciesMask.SetBitNumber(id);
+      fTPCnSigmaBelow[id] = -10.0;
+      fTPCnSigmaAbove[id] = 10.0;
+      break;
+    case 2:
+      fTPCEnabledSpeciesMask.SetBitNumber(id);
+      fTPCnSigmaBelow[id] = -6.0;
+      fTPCnSigmaAbove[id] = 7.0;
+      break;
+    case 3:
+      fTPCEnabledSpeciesMask.SetBitNumber(id);
+      fTPCnSigmaBelow[id] = -5.0;
+      fTPCnSigmaAbove[id] = 5.0;
+      break;
+    case 4:
+      fTPCEnabledSpeciesMask.SetBitNumber(id);
+      fTPCnSigmaBelow[id] = -4.0;
+      fTPCnSigmaAbove[id] = 5.0;
+      break;
+    case 5:
+      fTPCEnabledSpeciesMask.SetBitNumber(id);
+      fTPCnSigmaBelow[id] = -4.0;
+      fTPCnSigmaAbove[id] = 4.0;
+      break;
+    case 6:
+      fTPCEnabledSpeciesMask.SetBitNumber(id);
+      fTPCnSigmaBelow[id] = -3.0;
+      fTPCnSigmaAbove[id] = 4.0;
+      break;
+    case 7:
+      fTPCEnabledSpeciesMask.SetBitNumber(id);
+      fTPCnSigmaBelow[id] = -3.0;
+      fTPCnSigmaAbove[id] = 3.0;
+      break;
+    case 8:
+      fTPCEnabledSpeciesMask.SetBitNumber(id);
+      fTPCnSigmaBelow[id] = -3.0;
+      fTPCnSigmaAbove[id] = 5.0;
+      break;
+    case 9:
+      fTPCEnabledSpeciesMask.SetBitNumber(id);
+      fTPCnSigmaBelow[id] = -2.0;
+      fTPCnSigmaAbove[id] = 3.0;
+      break;
+    default:
+      AliError(Form("TPC dEdx n sigmas cut code %d not supported",dEdxCode));
+      return kFALSE;
+  }
+  if (fTPCEnabledSpeciesMask.CountBits() > 0)
+    fCutsEnabledMask.SetBitNumber(kTPCdEdxSigmaCut);
+  else
+    fCutsEnabledMask.ResetBitNumber(kTPCdEdxSigmaCut);
+  return kTRUE;
+}
+
+
+/// Print the dEdx \f$ n \sigma \f$ cut within the TPC
+///
+/// The cut establishes an acceptance band around a concrete
+/// particle species line within the TPC. For species other than
+/// the selected target the band is a separation band.
+/// \param id the id of the species for which the cut is being printed
+
+void AliCSPIDCuts::PrintTPCdEdxSigmaCut(AliPID::EParticleType id) const {
+  if (fCutsEnabledMask.TestBitNumber(kTPCdEdxSigmaCut)) {
+    printf("  TPC PID CUT %s: ", AliPID::ParticleName(fTargetSpecies));
+    if (fTPCEnabledSpeciesMask.TestBitNumber(id)) {
+      if (fTargetSpecies != id) {
+        printf("nsigma %s < %3.1f OR %3.1f < nsigma %s\n",
+            AliPID::ParticleName(id),
+            fTPCnSigmaBelow[id],
+            fTPCnSigmaAbove[id],
+            AliPID::ParticleName(id));
+      }
+      else
+        printf("%3.1f < nsigma < %3.1f\n",
+            fTPCnSigmaBelow[id],
+            fTPCnSigmaAbove[id]);
+    }
+    else
+      printf("none to %s line\n",AliPID::ParticleName(id));
+  }
+  else
+    printf("  TPC PID CUT %s: none\n", AliPID::ParticleName(fTargetSpecies));
+}
+
+
+/// Sets the range for the \f$ n \, \sigma \f$ cut within TOF
+///
+/// The cut establishes an acceptance band around a concrete
+/// particle species line within the TOF detector. For species other than
+/// the selected target the band is a separation band.
+/// \param id the id of the species for which the band is being configured
+/// \param tofcode the code for the \f$ n \sigma \f$ cut
+/// | code | \f$ n \sigma \f$ below line | \f$ n \sigma \f$ above line | observations |
+/// |:--:|:--:|:--:|:--|
+/// | 0 | n/a | n/a | passive cut |
+/// | 1 | -7 | 7 | |
+/// | 2 | -5 | 5 | |
+/// | 3 | -3 | 5 | |
+/// | 4 | -2 | 3 | |
+/// | 5 | -3 | 3 | TOF required |
+/// \return kTRUE if proper and supported TOF code
+
+Bool_t AliCSPIDCuts::SetTOFSigmaCut(AliPID::EParticleType id, Int_t tofcode){
+  switch(tofcode){
+    case 0:
+      fTOFEnabledSpeciesMask.ResetBitNumber(id);
+      fTOFRequired[id] = kFALSE;
+      fTOFnSigmaBelow[id] = -100.0;
+      fTOFnSigmaAbove[id] = 100.0;
+      break;
+    case 1:
+      fTOFEnabledSpeciesMask.SetBitNumber(id);
+      fTOFRequired[id] = kFALSE;
+      fTOFnSigmaBelow[id] = -7.0;
+      fTOFnSigmaAbove[id] = 7.0;
+      break;
+    case 2:
+      fTOFEnabledSpeciesMask.SetBitNumber(id);
+      fTOFRequired[id] = kFALSE;
+      fTOFnSigmaBelow[id] = -5.0;
+      fTOFnSigmaAbove[id] = 5.0;
+      break;
+    case 3:
+      fTOFEnabledSpeciesMask.SetBitNumber(id);
+      fTOFRequired[id] = kFALSE;
+      fTOFnSigmaBelow[id] = -3.0;
+      fTOFnSigmaAbove[id] = 5.0;
+      break;
+    case 4:
+      fTOFEnabledSpeciesMask.SetBitNumber(id);
+      fTOFRequired[id] = kFALSE;
+      fTOFnSigmaBelow[id] = -2.0;
+      fTOFnSigmaAbove[id] = 3.0;
+      break;
+    case 5:
+      fTOFEnabledSpeciesMask.SetBitNumber(id);
+      fTOFRequired[id] = kTRUE;
+      fTOFnSigmaBelow[id] = -3.0;
+      fTOFnSigmaAbove[id] = 3.0;
+      break;
+    default:
+      AliError(Form("TOF n sigmas cut code %d not supported", tofcode));
+      return kFALSE;
+  }
+  if (fTOFEnabledSpeciesMask.CountBits() > 0)
+    fCutsEnabledMask.SetBitNumber(kTOFSigmaCut);
+  else
+    fCutsEnabledMask.ResetBitNumber(kTOFSigmaCut);
+  return kTRUE;
+}
+
+/// Prints the \f$ n \, \sigma \f$ cut within TOF
+///
+/// The cut establishes an acceptance band around a concrete
+/// particle species line within the TOF detector. For species other than
+/// the selected target the band is a separation band.
+/// \param id the id of the species for which the cut is being printed
+void AliCSPIDCuts::PrintTOFSigmaCut(AliPID::EParticleType id) const {
+  if (fCutsEnabledMask.TestBitNumber(kTOFSigmaCut)) {
+    printf("  TOF (%s) PID CUT %s: ", fTOFRequired ? "REQUIRED" : "NOT required", AliPID::ParticleName(fTargetSpecies));
+    if (fTOFEnabledSpeciesMask.TestBitNumber(id)) {
+      if (fTargetSpecies != id) {
+        printf("nsigma %s < %3.1f OR %3.1f < nsigma %s\n",
+            AliPID::ParticleName(id),
+            fTOFnSigmaBelow[id],
+            fTOFnSigmaAbove[id],
+            AliPID::ParticleName(id));
+      }
+      else
+        printf("%3.1f < nsigma < %3.1f\n",
+            fTOFnSigmaBelow[id],
+            fTOFnSigmaAbove[id]);
+    }
+    else
+      printf("none to %s line\n",AliPID::ParticleName(id));
+  }
+  else
+    printf("  TOF PID CUT %s: none\n", AliPID::ParticleName(fTargetSpecies));
+}
+
+
+/// Initializes the cuts
+///
+/// Initializes the needed data and allocates the needed histograms list if needed
+/// \param name an additional name to precede the cuts string
+void AliCSPIDCuts::InitCuts(const char *name){
+
+  if (name == NULL) name = GetName();
+
+  /* let's get the PID response instance */
+  AliAnalysisManager *manager = AliAnalysisManager::GetAnalysisManager();
+  if(manager != NULL) {
+    AliInputEventHandler* inputHandler = (AliInputEventHandler*) (manager->GetInputEventHandler());
+    fPIDResponse = (AliPIDResponse*) inputHandler->GetPIDResponse();
+    /* if we need PID response instance and it is not there we cannot continue */
+    if ((fPIDResponse == NULL) &&
+        (fCutsEnabledMask.TestBitNumber(kITSdEdxSigmaCut) ||
+            fCutsEnabledMask.TestBitNumber(kTPCdEdxSigmaCut) ||
+            fCutsEnabledMask.TestBitNumber(kTOFSigmaCut)))
+      AliFatal("No PID response instance. ABORTING!!!");
+  }
+  else {
+    AliFatal("No analysis manager instance. ABORTING!!!");
+  }
+
+  if (fQALevel > kQALevelNone) {
+    Bool_t oldstatus = TH1::AddDirectoryStatus();
+    TH1::AddDirectory(kFALSE);
+
+    if(fHistogramsList != NULL)
+      delete fHistogramsList;
+
+    fHistogramsList =new TList();
+    fHistogramsList->SetOwner(kTRUE);
+    fHistogramsList->SetName(name);
+
+    TH1::AddDirectory(oldstatus);
+  }
+}
+
+/// Allocates the different histograms if needed
+///
+/// It is supposed that the current cuts string is the running one
+void AliCSPIDCuts::DefineHistograms(){
+
+  if (fQALevel > kQALevelNone) {
+    Bool_t oldstatus = TH1::AddDirectoryStatus();
+    TH1::AddDirectory(kFALSE);
+
+    /* the original name is used as title for the statistics histogram so, preserve it */
+    TString originalTempName = fHistogramsList->GetName();
+    fHistogramsList->SetName(Form("%s_%s",fHistogramsList->GetName(),GetCutsString()));
+
+    fhCutsStatistics = new TH1F(Form("CutsStatistics_%s",GetCutsString()),Form("%s tracks cuts statistics",originalTempName.Data()),kNCuts+4,-0.5,kNCuts+3.5);
+    fhCutsStatistics->GetXaxis()->SetBinLabel(1,"n tracks");
+    fhCutsStatistics->GetXaxis()->SetBinLabel(2,"n cut tracks");
+    for (Int_t i = 0; i < kNCuts; i++)
+      fhCutsStatistics->GetXaxis()->SetBinLabel(i+4, fgkCutsNames[i]);
+    fHistogramsList->Add(fhCutsStatistics);
+
+    if(fQALevel == kQALevelHeavy){
+      fhCutsCorrelation = new TH2F(Form("CutCorrelation_%s",GetCutsString()),"Cuts correlation",kNCuts+2,-0.5,kNCuts+1.5,kNCuts+2,-0.5,kNCuts+1.5);
+      for (Int_t i=0; i<kNCuts; i++) {
+        fhCutsCorrelation->GetXaxis()->SetBinLabel(i+2,fgkCutsNames[i]);
+        fhCutsCorrelation->GetYaxis()->SetBinLabel(i+2,fgkCutsNames[i]);
+      }
+      fHistogramsList->Add(fhCutsCorrelation);
+    }
+
+    /* build the P bins */
+    const Int_t nPbins = 150;
+    Double_t minP = 0.05;
+    Double_t maxP = 20.0;
+    Double_t *edges = new Double_t [nPbins + 1];
+    Double_t factor = TMath::Power(maxP / minP, 1. / nPbins);
+    edges[0] = minP; for (Int_t bin = 0; bin < nPbins; bin++) edges[bin+1] = factor * edges[bin];
+
+    fhITSdEdxSigmaVsP[0] = new TH2F(Form("ITSdEdxSigmaB_%s",GetCutsString()),"ITS dE/dx n#sigma before;P (GeV/c);n#sigma",nPbins,edges, 400, -10, 10);
+    fhITSdEdxSigmaVsP[1] = new TH2F(Form("ITSdEdxSigmaA_%s",GetCutsString()),"ITS dE/dx n#sigma;P (GeV/c);n#sigma",nPbins,edges, 400, -10, 10);
+    fHistogramsList->Add(fhITSdEdxSigmaVsP[0]);
+    fHistogramsList->Add(fhITSdEdxSigmaVsP[1]);
+
+    fhITSdEdxSignalVsP[0] = new TH2F(Form("ITSdEdxSignalB_%s",GetCutsString()),"ITS dE/dx signal before;P (GeV/c);#frac{dE}{dx} (au)",nPbins,edges, 800, 0.0, 200);
+    fhITSdEdxSignalVsP[1] = new TH2F(Form("ITSdEdxSignalA_%s",GetCutsString()),"ITS dE/dx signal;P (GeV/c);#frac{dE}{dx} (au)",nPbins,edges, 800, 0.0, 200);
+    fHistogramsList->Add(fhITSdEdxSignalVsP[0]);
+    fHistogramsList->Add(fhITSdEdxSignalVsP[1]);
+
+    fhTPCdEdxSigmaVsP[0] = new TH2F(Form("TPCdEdxSigmaB_%s",GetCutsString()),"TPC dE/dx n#sigma before;P (GeV/c);n#sigma",nPbins,edges, 400, -10, 10);
+    fhTPCdEdxSigmaVsP[1] = new TH2F(Form("TPCdEdxSigmaA_%s",GetCutsString()),"TPC dE/dx n#sigma;P (GeV/c);n#sigma",nPbins,edges, 400, -10, 10);
+    fHistogramsList->Add(fhTPCdEdxSigmaVsP[0]);
+    fHistogramsList->Add(fhTPCdEdxSigmaVsP[1]);
+
+    fhTPCdEdxSignalVsP[0] = new TH2F(Form("TPCdEdxSignalB_%s",GetCutsString()),"TPC dE/dx signal before;P (GeV/c);#frac{dE}{dx} (au)",nPbins,edges, 800, 0.0, 200.0);
+    fhTPCdEdxSignalVsP[1] = new TH2F(Form("TPCdEdxSignalA_%s",GetCutsString()),"TPC dE/dx signal;P (GeV/c);#frac{dE}{dx} (au)",nPbins,edges, 800, 0.0, 200.0);
+    fHistogramsList->Add(fhTPCdEdxSignalVsP[0]);
+    fHistogramsList->Add(fhTPCdEdxSignalVsP[1]);
+
+    fhTOFSigmaVsP[0] = new TH2F(Form("TOFSigmaB_%s",GetCutsString()),"TOF n#sigma before;P (GeV/c);n#sigma",nPbins,edges, 400, -10, 10);
+    fhTOFSigmaVsP[1] = new TH2F(Form("TOFSigmaA_%s",GetCutsString()),"TOF n#sigma;P (GeV/c);n#sigma",nPbins,edges, 400, -10, 10);
+    fHistogramsList->Add(fhTOFSigmaVsP[0]);
+    fHistogramsList->Add(fhTOFSigmaVsP[1]);
+
+    fhTOFSignalVsP[0] = new TH2F(Form("TOFSignalB_%s",GetCutsString()),"TOF signal before;P (GeV/c);#beta",nPbins,edges, 400, 0.0, 1.1);
+    fhTOFSignalVsP[1] = new TH2F(Form("TOFSignalA_%s",GetCutsString()),"TOF signal;P (GeV/c);#beta",nPbins,edges, 400, 0.0, 1.1);
+    fHistogramsList->Add(fhTOFSignalVsP[0]);
+    fHistogramsList->Add(fhTOFSignalVsP[1]);
+
+    TH1::AddDirectory(oldstatus);
+  }
+}
+

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSPIDCuts.h
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSPIDCuts.h
@@ -1,0 +1,154 @@
+#ifndef ALICSPIDCUTS_H
+#define ALICSPIDCUTS_H
+
+/// \file AliCSPIDCuts.h
+/// \brief PID track selection cuts support for the correlations studies tasks
+///
+/// Based on ideas taken from Gamma Conversion analysis under PWGGA and from AliESDTrackCuts
+
+#include <TBits.h>
+#include "AliPID.h"
+#include "AliCSTrackCutsBase.h"
+
+class TH1F;
+class TH2F;
+class AliVTrack;
+class TParticle;
+class AliAODMCParticle;
+class AliPIDResponse;
+
+/// \class AliCSPIDCuts
+/// \brief Class which implements PID track selection cuts
+///
+/// Provides support for configuring PID track selection cuts.
+/// It is derived from #AliCSAnalysisCutsBase so it incorporates
+/// the cuts string in all output histograms.
+///
+/// There are two basic use cases
+/// - identify a track by its proximity to the selected family line in ITS and/or TPC and/or TOF
+/// - the same as above but additionally requiring a minimum separation to the other families lines
+///
+/// Both use cases can be configured on the same object instance. The parameters of the selected
+/// family are interpreted as proximity cuts while the parameter of the other families are interpreted
+/// as separation cuts. All above applicable within a configurable momentum range
+///
+/// Based on Gamma Conversion analysis implementation within PWGGA
+///
+/// \author Víctor González <victor.gonzalez@cern.ch>, UCM
+/// \date Feb 09, 2017
+
+class AliCSPIDCuts : public AliCSTrackCutsBase {
+public:
+
+  /// \enum cutsParametersIds
+  /// \brief The ids of the different PID track cuts parameters supported
+  enum cutsParametersIds {
+    kPRangeCutParam,                 ///< momentum range cut parameters
+    kITSdEdxSigmaCutParam_e,         ///< ITS dEdx \f$ n \sigma \f$ cut parameters for electron
+    kITSdEdxSigmaCutParam_mu,        ///< ITS dEdx \f$ n \sigma \f$ cut parameters for muon
+    kITSdEdxSigmaCutParam_pi,        ///< ITS dEdx \f$ n \sigma \f$ cut parameters for pion
+    kITSdEdxSigmaCutParam_k,         ///< ITS dEdx \f$ n \sigma \f$ cut parameters for kaon
+    kITSdEdxSigmaCutParam_p,         ///< ITS dEdx \f$ n \sigma \f$ cut parameters for proton
+    kTPCdEdxSigmaCutParam_e,         ///< TPC dEdx \f$ n \sigma \f$ cut parameters for electron
+    kTPCdEdxSigmaCutParam_mu,        ///< TPC dEdx \f$ n \sigma \f$ cut parameters for muon
+    kTPCdEdxSigmaCutParam_pi,        ///< TPC dEdx \f$ n \sigma \f$ cut parameters for pion
+    kTPCdEdxSigmaCutParam_k,         ///< TPC dEdx \f$ n \sigma \f$ cut parameters for kaon
+    kTPCdEdxSigmaCutParam_p,         ///< TPC dEdx \f$ n \sigma \f$ cut parameters for proton
+    kTOFSigmaCutParam_e,             ///< TOF \f$ n \sigma \f$ cut parameters for electron
+    kTOFSigmaCutParam_mu,            ///< TOF \f$ n \sigma \f$ cut parameters for muon
+    kTOFSigmaCutParam_pi,            ///< TOF \f$ n \sigma \f$ cut parameters for pion
+    kTOFSigmaCutParam_k,             ///< TOF \f$ n \sigma \f$ cut parameters for kaon
+    kTOFSigmaCutParam_p,             ///< TOF \f$ n \sigma \f$ cut parameters for proton
+    kNCutsParameters                 ///< the number of track cuts parameters
+  };
+
+  /// \enum cutsIds
+  /// \brief The ids of the different track cuts currently supported
+  enum cutsIds {
+    kITSdEdxSigmaCut,                ///< ITS dEdx \f$ n \sigma \f$ cut
+    kTPCdEdxSigmaCut,                ///< TPC dEdx \f$ n \sigma \f$ cut
+    kTOFSigmaCut,                    ///< TOF \f$ n \sigma \f$ cut
+    kNCuts                           ///< The number of supported cuts
+  };
+
+public:
+
+                                     AliCSPIDCuts();
+                                     AliCSPIDCuts(const char *name, const char * title, AliPID::EParticleType target);
+  virtual                           ~AliCSPIDCuts();
+
+  virtual void                       InitCuts(const char *name = NULL);
+  virtual void                       NotifyRun();
+  virtual void                       NotifyEvent();
+  virtual Bool_t                     IsTrackAccepted(AliVTrack *trk);
+  virtual Bool_t                     IsTrueTrackAccepted(AliVTrack *trk);
+  virtual Bool_t                     IsTrueTrackAccepted(Int_t itrk);
+
+  static AliPID::EParticleType       GetTrueSpecies(AliVTrack *trk);
+  static AliPID::EParticleType       GetTrueSpecies(TParticle *par);
+  static AliPID::EParticleType       GetTrueSpecies(AliAODMCParticle *par);
+
+private:
+  void                               DefineHistograms();
+
+private:
+  /* we set them private to force cuts string consistency */
+  Bool_t                             SetPRange(Int_t pcode);
+  Bool_t                             SetITSdEdxSigmaCut(AliPID::EParticleType id, Int_t dEdxCode);
+  Bool_t                             SetTPCdEdxSigmaCut(AliPID::EParticleType id, Int_t dEdxCode);
+  Bool_t                             SetTOFSigmaCut(AliPID::EParticleType id, Int_t tofcode);
+  void                               PrintITSdEdxSigmaCut(AliPID::EParticleType id) const;
+  void                               PrintTPCdEdxSigmaCut(AliPID::EParticleType id) const;
+  void                               PrintTOFSigmaCut(AliPID::EParticleType id) const;
+
+private:
+  virtual Bool_t                     SetCutAndParams(Int_t paramID, Int_t value);
+  virtual void                       PrintCutWithParams(Int_t paramID) const;
+
+private:
+  static const char                 *fgkCutsParametersNames[kNCutsParameters];     ///< the names of the different event cuts parameters
+  static const char                 *fgkCutsNames[kNCuts];                         ///< the names of the different event cuts
+
+  Double_t                           fMinP;                                        ///< the minimum momentum value for applying the cut
+  Double_t                           fMaxP;                                        ///< the maximum momentum value for applying the cut
+  Double_t                           fITSnSigmaAbove[AliPID::kSPECIESC];           ///< \f$ n \sigma \f$ above a species ITS line cut
+  Double_t                           fITSnSigmaBelow[AliPID::kSPECIESC];           ///< \f$ n \sigma \f$ below a species ITS line cut
+  Double_t                           fTPCnSigmaAbove[AliPID::kSPECIESC];           ///< \f$ n \sigma \f$ above a species TPC line cut
+  Double_t                           fTPCnSigmaBelow[AliPID::kSPECIESC];           ///< \f$ n \sigma \f$ below a species TPC line cut
+  Bool_t                             fTOFRequired[AliPID::kSPECIESC];              ///< track presence in TOF required
+  Double_t                           fTOFnSigmaAbove[AliPID::kSPECIESC];           ///< \f$ n \sigma \f$ above a species TOF line cut
+  Double_t                           fTOFnSigmaBelow[AliPID::kSPECIESC];           ///< \f$ n \sigma \f$ below a species TOF line cut
+
+  TBits                              fITSEnabledSpeciesMask;                       ///< mask for the species to consider within the ITS
+  TBits                              fTPCEnabledSpeciesMask;                       ///< mask for the spdcies to consider within the TPC
+  TBits                              fTOFEnabledSpeciesMask;                       ///< mask for the species to consider within the TOF
+
+  AliPIDResponse                    *fPIDResponse;                                 ///< the PID response instance
+  AliPID::EParticleType              fTargetSpecies;                               ///< the species to address with the PID cuts
+
+
+  /* histograms with two indices: before (0) / after (1) applying the cut */
+  TH1F                              *fhCutsStatistics;                             ///< the cuts statistics
+  TH2F                              *fhCutsCorrelation;                            ///< cuts correlation
+  TH2F                              *fhITSdEdxSigmaVsP[2];                         ///< ITS dE/dx \f$ \mbox{n} \sigma \f$ vs P (b/a)
+  TH2F                              *fhITSdEdxSignalVsP[2];                        ///< ITS dE/dx signal vs P (b/a)
+  TH2F                              *fhTPCdEdxSigmaVsP[2];                         ///< TPC dE/dx \f$ \mbox{n} \sigma \f$ vs P(b/a)
+  TH2F                              *fhTPCdEdxSignalVsP[2];                        ///< TPC dE/dx signal vs P(b/a)
+  TH2F                              *fhTOFSigmaVsP[2];                             ///< TOF \f$ \mbox{n} \sigma \f$ vs P(b/a)
+  TH2F                              *fhTOFSignalVsP[2];                            ///< TOF signal vs P(b/a)
+
+  /// Copy constructor
+  /// Not allowed. Forced private.
+  AliCSPIDCuts(const AliCSPIDCuts&);
+  /// Assignment operator
+  /// Not allowed. Forced private.
+  /// \return l-value reference object
+  AliCSPIDCuts& operator=(const AliCSPIDCuts&);
+
+  /// \cond CLASSIMP
+  ClassDef(AliCSPIDCuts,1);
+  /// \endcond
+};
+
+#endif /* ALICSPIDCUTS_H */
+

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSPairAnalysis.cxx
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSPairAnalysis.cxx
@@ -1,0 +1,770 @@
+/**************************************************************************
+* Copyright(c) 1998-2016, ALICE Experiment at CERN, All rights reserved.  *
+*                                                                         *
+* Permission to use, copy, modify and distribute this software and its    *
+* documentation strictly for non-commercial purposes is hereby granted    *
+* without fee, provided that the above copyright notice appears in all    *
+* copies and that both the copyright notice and this permission notice    *
+* appear in the supporting documentation. The authors make no claims      *
+* about the suitability of this software for any purpose. It is           *
+* provided "as is" without express or implied warranty.                   *
+**************************************************************************/
+
+/// \file AliCSPairAnalysis.cxx
+/// \brief Implementation of the AliCSPairAnalysis class
+
+#include <TList.h>
+#include <TObjArray.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <TH3.h>
+#include <TMath.h>
+#include <TVector3.h>
+#include <TParticle.h>
+#include <TParticlePDG.h>
+#include "AliLog.h"
+#include "AliVEvent.h"
+#include "AliVTrack.h"
+#include "AliAODMCParticle.h"
+#include "AliAnalysisManager.h"
+#include "AliCSPairAnalysis.h"
+
+#define CSPAIRANALYSISNOOFTRACKS 3000 ///< the initial number of tracks
+
+const Int_t AliCSPairAnalysis::kgHistosDimension = 4;
+
+/// Default constructor for object serialization
+AliCSPairAnalysis::AliCSPairAnalysis() :
+    TNamed(),
+    fOutput(NULL),
+
+    /* vertex bins */
+    fNBins_vertexZ(40),
+    fMin_vertexZ(-10.0),
+    fMax_vertexZ(10.0),
+    fWidth_vertexZ(0.5),
+    /* phi origin shift */
+    fNBinsPhiShift(0.0),
+    /* pT1 bins */
+    fNBins_pt(18),
+    fMin_pt(0.2),
+    fMax_pt(2.0),
+    fWidth_pt(0.1),
+    /* phi1 bins */
+    fNBins_phi(72),
+    fMin_phi(0.0),
+    fMax_phi(TMath::Pi()*2.0),
+    fWidth_phi(TMath::Pi()*2.0/72.0),
+    /* eta1 bins */
+    fNBins_eta(20),
+    fMin_eta(-1.0),
+    fMax_eta(1.0),
+    fWidth_eta(0.1),
+
+    /* the arrays with positive and negative tracks references */
+    fPlusTracksArray(NULL),
+    fMinusTracksArray(NULL),
+    /* the singles efficiency structNures */
+    fPlusEfficiency(NULL),
+    fMinusEfficiency(NULL),
+    fEventPlusEfficiency(NULL),
+    fEventMinusEfficiency(NULL),
+    /* the pairs efficiencies */
+    fPairEfficiency_PP(NULL),
+    fPairEfficiency_PM(NULL),
+    fPairEfficiency_MM(NULL),
+    fPairEfficiency_MP(NULL),
+    /* histograms */
+    fhNplus(NULL),
+    fhNminus(NULL),
+    fhPPDeltaEtaDeltaPhi(NULL),
+    fhPMDeltaEtaDeltaPhi(NULL),
+    fhMPDeltaEtaDeltaPhi(NULL),
+    fhMMDeltaEtaDeltaPhi(NULL)
+{
+
+}
+
+/// Normal constructor
+/// \param name the name for the object instance
+AliCSPairAnalysis::AliCSPairAnalysis(const char *name) :
+    TNamed(name,name),
+    fOutput(NULL),
+
+    /* vertex bins */
+    fNBins_vertexZ(40),
+    fMin_vertexZ(-10.0),
+    fMax_vertexZ(10.0),
+    fWidth_vertexZ(0.5),
+    /* phi origin shift */
+    fNBinsPhiShift(0.0),
+    /* pT1 bins */
+    fNBins_pt(18),
+    fMin_pt(0.2),
+    fMax_pt(2.0),
+    fWidth_pt(0.1),
+    /* phi1 bins */
+    fNBins_phi(72),
+    fMin_phi(0.0),
+    fMax_phi(TMath::Pi()*2.0),
+    fWidth_phi(TMath::Pi()*2.0/72.0),
+    /* eta1 bins */
+    fNBins_eta(20),
+    fMin_eta(-1.0),
+    fMax_eta(1.0),
+    fWidth_eta(0.1),
+
+    /* the arrays with positive and negative tracks references */
+    fPlusTracksArray(NULL),
+    fMinusTracksArray(NULL),
+    /* the singles efficiency structures */
+    fPlusEfficiency(NULL),
+    fMinusEfficiency(NULL),
+    fEventPlusEfficiency(NULL),
+    fEventMinusEfficiency(NULL),
+    /* the pairs efficiencies */
+    fPairEfficiency_PP(NULL),
+    fPairEfficiency_PM(NULL),
+    fPairEfficiency_MM(NULL),
+    fPairEfficiency_MP(NULL),
+    /* histograms */
+    fhNplus(NULL),
+    fhNminus(NULL),
+    fhPPDeltaEtaDeltaPhi(NULL),
+    fhPMDeltaEtaDeltaPhi(NULL),
+    fhMPDeltaEtaDeltaPhi(NULL),
+    fhMMDeltaEtaDeltaPhi(NULL)
+{
+
+}
+
+/// \brief Default destructor
+/// Deallocates the allocated memory
+AliCSPairAnalysis::~AliCSPairAnalysis() {
+  if (fPlusTracksArray != NULL) delete fPlusTracksArray;
+  if (fMinusTracksArray != NULL) delete fMinusTracksArray;
+  if (fEventPlusEfficiency != NULL) {
+    for (Int_t ieta = 0; ieta < fNBins_eta; ieta++) {
+      for (Int_t iphi = 0; iphi < fNBins_phi; iphi++) {
+        delete [] fEventPlusEfficiency[ieta][iphi];
+      }
+      delete [] fEventPlusEfficiency[ieta];
+    }
+    delete [] fEventPlusEfficiency;
+  }
+  if (fEventMinusEfficiency != NULL) {
+    for (Int_t ieta = 0; ieta < fNBins_eta; ieta++) {
+      for (Int_t iphi = 0; iphi < fNBins_phi; iphi++) {
+        delete [] fEventMinusEfficiency[ieta][iphi];
+      }
+      delete [] fEventMinusEfficiency[ieta];
+    }
+    delete [] fEventMinusEfficiency;
+  }
+}
+
+
+/// \brief Establishes the binning configuration
+/// \param confstring string containing the binning configuration parameters
+void AliCSPairAnalysis::ConfigureBinning(const char *confstring) {
+
+  Double_t min_pt, max_pt, width_pt;
+  Double_t min_eta, max_eta, width_eta;
+
+  sscanf(confstring, "phishift:%lf;%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf",
+      &fNBinsPhiShift,
+      &fMin_vertexZ, &fMax_vertexZ, &fWidth_vertexZ,
+      &min_pt, &max_pt, &width_pt,
+      &min_eta, &max_eta, &width_eta);
+
+  fMin_pt = min_pt;
+  fMax_pt = max_pt;
+  fWidth_pt = width_pt;
+  fMin_eta = min_eta;
+  fMax_eta = max_eta;
+  fWidth_eta = width_eta;
+  AliInfo("=====================================================");
+  AliInfo(Form("Configured binning: %s", GetBinningConfigurationString().Data()));
+  AliInfo("=====================================================");
+}
+
+/// \brief Build the configuration string
+/// \return the configuration string corresponding to the current configuration
+TString AliCSPairAnalysis::GetBinningConfigurationString() const {
+
+  return TString(Form("Binning:phishift:%.1f;%.1f,%.1f,%.1f,%.1f,%.1f,%.1f,%.1f,%.1f,%.1f",
+      fNBinsPhiShift,
+      fMin_vertexZ, fMax_vertexZ, fWidth_vertexZ,
+      fMin_pt, fMax_pt, fWidth_pt,
+      fMin_eta, fMax_eta, fWidth_eta));
+}
+
+
+
+/// \brief Initializes the member data structures
+/// Allocates the needed memory an create the output histograms.
+void AliCSPairAnalysis::Initialize()
+{
+  Bool_t oldstatus = TH1::AddDirectoryStatus();
+  TH1::AddDirectory(kFALSE);
+
+  fPlusTracksArray = new TObjArray(CSPAIRANALYSISNOOFTRACKS);
+  fPlusTracksArray->SetOwner(kFALSE);
+  fMinusTracksArray = new TObjArray(CSPAIRANALYSISNOOFTRACKS);
+  fMinusTracksArray->SetOwner(kFALSE);
+
+  fEventPlusEfficiency = new Float_t**[fNBins_eta];
+  fEventMinusEfficiency = new Float_t**[fNBins_eta];
+  for (Int_t ieta = 0; ieta < fNBins_eta; ieta++) {
+    fEventPlusEfficiency[ieta] = new Float_t*[fNBins_phi];
+    fEventMinusEfficiency[ieta] = new Float_t*[fNBins_phi];
+    for (Int_t iphi = 0; iphi < fNBins_phi; iphi++) {
+      fEventPlusEfficiency[ieta][iphi] = new Float_t[fNBins_pt];
+      fEventMinusEfficiency[ieta][iphi] = new Float_t[fNBins_pt];
+    }
+  }
+
+  fOutput = new TList();
+  fOutput->SetName(GetName());
+  fOutput->SetOwner();
+
+  fNBins_vertexZ     = Int_t(0.5 + (fMax_vertexZ - fMin_vertexZ) / fWidth_vertexZ);
+  fNBins_pt          = Int_t(0.5 + (fMax_pt - fMin_pt ) / fWidth_pt);
+  fNBins_eta         = Int_t(0.5 + (fMax_eta - fMin_eta) / fWidth_eta);
+  fWidth_phi         = (fMax_phi  - fMin_phi) / fNBins_phi;
+
+  fhNplus = new TH1F("Nplus", "(+) multiplicity; tracks", 400, 0, CSPAIRANALYSISNOOFTRACKS);
+  fhNminus = new TH1F("Nminus", "(-) multiplicity; tracks", 400, 0, CSPAIRANALYSISNOOFTRACKS);
+
+  Int_t nbinsaxes[kgHistosDimension] = {2*fNBins_eta-1,fNBins_phi,fNBins_pt,fNBins_pt};
+  Double_t axeslow[kgHistosDimension] = {fMin_eta-fMax_eta,fMin_phi,fMin_pt,fMin_pt};
+  Double_t axesup[kgHistosDimension] = {fMax_eta-fMin_eta,fMax_phi,fMax_pt,fMax_pt};
+
+  /* we adapt the values of the phi limits after taking the delta phi values */
+  fMax_phi           = fMax_phi - fWidth_phi * fNBinsPhiShift;
+  fMin_phi           = fMin_phi - fWidth_phi * fNBinsPhiShift;
+
+  fhPPDeltaEtaDeltaPhi = new THnF("PPDeltaEtaDeltaPhi","(+ +) #Delta #eta #Delta #varphi separation; #Delta #eta_{1};#Delta #varphi_{2};P_{T_{1}} (GeV/c)",
+      kgHistosDimension, nbinsaxes,axeslow,axesup);
+  fhPPDeltaEtaDeltaPhi->GetAxis(3)->SetTitle("P_{T_{2}} (GeV/c)");
+  fhPMDeltaEtaDeltaPhi = new THnF("PMDeltaEtaDeltaPhi","(+ -) #Delta #eta #Delta #varphi separation; #Delta #eta_{1};#Delta #varphi_{2};P_{T_{1}} (GeV/c)",
+      kgHistosDimension, nbinsaxes,axeslow,axesup);
+  fhPMDeltaEtaDeltaPhi->GetAxis(3)->SetTitle("P_{T_{2}} (GeV/c)");
+  fhMPDeltaEtaDeltaPhi = new THnF("MPDeltaEtaDeltaPhi","(- +) #Delta #eta #Delta #varphi separation; #Delta #eta_{1};#Delta #varphi_{2};P_{T_{1}} (GeV/c)",
+      kgHistosDimension, nbinsaxes,axeslow,axesup);
+  fhMPDeltaEtaDeltaPhi->GetAxis(3)->SetTitle("P_{T_{2}} (GeV/c)");
+  fhMMDeltaEtaDeltaPhi = new THnF("MMDeltaEtaDeltaPhi","(- -) #Delta #eta #Delta #varphi separation; #Delta #eta_{1};#Delta #varphi_{2};P_{T_{1}} (GeV/c)",
+      kgHistosDimension, nbinsaxes,axeslow,axesup);
+  fhMMDeltaEtaDeltaPhi->GetAxis(3)->SetTitle("P_{T_{2}} (GeV/c)");
+
+  fOutput->Add(fhNplus);
+  fOutput->Add(fhNminus);
+  fOutput->Add(fhPPDeltaEtaDeltaPhi);
+  fOutput->Add(fhPMDeltaEtaDeltaPhi);
+  fOutput->Add(fhMPDeltaEtaDeltaPhi);
+  fOutput->Add(fhMMDeltaEtaDeltaPhi);
+
+  TH1::AddDirectory(oldstatus);
+}
+
+/// \brief initializes the object instance to start a new event
+Bool_t AliCSPairAnalysis::StartEvent(Float_t zVertex) {
+
+  /* reset the tracks arrays */
+  fPlusTracksArray->Clear();
+  fMinusTracksArray->Clear();
+
+  if (fPlusEfficiency != NULL) {
+    /* initialize event efficiency from the efficiency histogram */
+    Int_t zvtxbin = fPlusEfficiency->GetXaxis()->FindBin(zVertex);
+    for (Int_t ipt = 0; ipt < fNBins_pt; ipt++) {
+      for (Int_t ieta = 0; ieta < fNBins_eta; ieta++) {
+        Int_t etaphibinbase = ieta*fNBins_phi;
+        for (Int_t iphi = 0; iphi < fNBins_phi; iphi++) {
+          fEventPlusEfficiency[ieta][iphi][ipt] = fPlusEfficiency->GetBinContent(zvtxbin,etaphibinbase+iphi+1,ipt+1);
+        }
+      }
+    }
+  }
+  else {
+    /* initialize the efficiency to one */
+    for (Int_t ieta = 0; ieta < fNBins_eta; ieta++) {
+      for (Int_t iphi = 0; iphi < fNBins_phi; iphi++) {
+        for (Int_t ipt = 0; ipt < fNBins_pt; ipt++) {
+          fEventPlusEfficiency[ieta][iphi][ipt] = 1.0;
+        }
+      }
+    }
+  }
+
+  if (fMinusEfficiency != NULL) {
+    /* initialize event efficiency from the efficiency histogram */
+    Int_t zvtxbin = fMinusEfficiency->GetXaxis()->FindBin(zVertex);
+    for (Int_t ipt = 0; ipt < fNBins_pt; ipt++) {
+      for (Int_t ieta = 0; ieta < fNBins_eta; ieta++) {
+        Int_t etaphibinbase = ieta*fNBins_phi;
+        for (Int_t iphi = 0; iphi < fNBins_phi; iphi++) {
+          fEventMinusEfficiency[ieta][iphi][ipt] = fMinusEfficiency->GetBinContent(zvtxbin,etaphibinbase+iphi+1,ipt+1);
+        }
+      }
+    }
+  }
+  else {
+    /* initialize the efficiency to one */
+    for (Int_t ieta = 0; ieta < fNBins_eta; ieta++) {
+      for (Int_t iphi = 0; iphi < fNBins_phi; iphi++) {
+        for (Int_t ipt = 0; ipt < fNBins_pt; ipt++) {
+          fEventMinusEfficiency[ieta][iphi][ipt] = 1.0;
+        }
+      }
+    }
+  }
+
+  return kTRUE;
+}
+
+/// \brief Stores track reference in the corresponding array according to its charge
+/// \param trk the intended track
+/// \return kTRUE if the track is properly stored kFALSE otherwise
+Bool_t AliCSPairAnalysis::ProcessTrack(Int_t, AliVTrack *trk) {
+
+  if (trk->Charge() == 0) return kFALSE;
+
+  /* add the track to the corresponding array */
+  if (trk->Pt() < fMin_pt || fMax_pt < trk->Pt()) return kFALSE;
+  if (trk->Eta() < fMin_eta || fMax_eta < trk->Eta()) return kFALSE;
+  if (trk->Charge() > 0) fPlusTracksArray->Add(trk);
+  else fMinusTracksArray->Add(trk);
+
+  return kTRUE;
+}
+
+/// \brief Stores particle reference in the corresponding array according to its charge
+/// \param par the intended particle
+/// \return kTRUE if the track is properly stored kFALSE otherwise
+Bool_t AliCSPairAnalysis::ProcessTrack(Int_t, TParticle *par) {
+
+  if (par->GetPDG()->Charge() == 0) return kFALSE;
+
+  /* add the track to the corresponding array */
+  if (par->Pt() < fMin_pt || fMax_pt < par->Pt()) return kFALSE;
+  if (par->Eta() < fMin_eta || fMax_eta < par->Eta()) return kFALSE;
+  if (par->GetPDG()->Charge() > 0) fPlusTracksArray->Add(par);
+  else fMinusTracksArray->Add(par);
+
+  return kTRUE;
+}
+
+/// \brief Stores particle reference in the corresponding array according to its charge
+/// \param par the intended particle
+/// \return kTRUE if the track is properly stored kFALSE otherwise
+Bool_t AliCSPairAnalysis::ProcessTrack(Int_t, AliAODMCParticle *par) {
+
+  if (par->Charge() == 0) return kFALSE;
+
+  /* add the track to the corresponding array */
+  if (par->Pt() < fMin_pt || fMax_pt < par->Pt()) return kFALSE;
+  if (par->Eta() < fMin_eta || fMax_eta < par->Eta()) return kFALSE;
+  if (par->Charge() > 0) fPlusTracksArray->Add(par);
+  else fMinusTracksArray->Add(par);
+
+  return kTRUE;
+}
+
+/// \brief Perform the pairs processing for the whole event
+
+void AliCSPairAnalysis::ProcessEventData() {
+
+  fhNplus->Fill(fPlusTracksArray->GetEntriesFast());
+  fhNminus->Fill(fMinusTracksArray->GetEntriesFast());
+
+  Bool_t trackdata = kTRUE;
+  if (fPlusTracksArray->GetEntriesFast() != 0 || fMinusTracksArray->GetEntriesFast() != 0) {
+    /* track data or particle data */
+    if (fPlusTracksArray->GetEntriesFast() != 0)
+      trackdata = fPlusTracksArray->At(0)->IsA()->InheritsFrom("AliVTrack");
+    if (fMinusTracksArray->GetEntriesFast() != 0)
+      trackdata = fMinusTracksArray->At(0)->IsA()->InheritsFrom("AliVTrack");
+  }
+  else {
+    /* no tracks stored */
+    return;
+  }
+
+  if (trackdata) {
+    for (Int_t ixplus1 = 0; ixplus1 < fPlusTracksArray->GetEntriesFast(); ixplus1++) {
+      Int_t fillbins[kgHistosDimension];
+      Int_t fillbinssw[kgHistosDimension];
+
+      /* the plus-plus pairs analysis */
+      AliVTrack *trk1 = (AliVTrack *) fPlusTracksArray->At(ixplus1);
+      Int_t ixeta1 = Int_t ((trk1->Eta() - fMin_eta) / fWidth_eta);
+      Int_t ixphi1 = Int_t ((((trk1->Phi() < fMax_phi) ? trk1->Phi() : trk1->Phi() - 2*TMath::Pi())- fMin_phi) / fWidth_phi);
+      Int_t ixpt1 = fhPPDeltaEtaDeltaPhi->GetAxis(2)->FindBin(trk1->Pt()) - 1;
+
+      /* start correcting for the efficiency on the first track, positive */
+      Float_t fillweight1 = fEventPlusEfficiency[ixeta1][ixphi1][ixpt1];
+
+      fillbins[2] = fillbinssw[3] = ixpt1+1;
+
+      for (Int_t ixplus2 = ixplus1+1; ixplus2 < fPlusTracksArray->GetEntriesFast(); ixplus2++) {
+        AliVTrack *trk2 = (AliVTrack *) fPlusTracksArray->At(ixplus2);
+        Int_t ixeta2 = Int_t ((trk2->Eta() - fMin_eta) / fWidth_eta);
+        Int_t ixphi2 = Int_t ((((trk2->Phi() < fMax_phi) ? trk2->Phi() : trk2->Phi() - 2*TMath::Pi() )- fMin_phi) / fWidth_phi);
+        Int_t ixpt2 = fhPPDeltaEtaDeltaPhi->GetAxis(3)->FindBin(trk2->Pt()) - 1;
+
+        /* correct for the efficiency on the second track, positive */
+        Float_t fillweight = fillweight1 * fEventPlusEfficiency[ixeta2][ixphi2][ixpt2];
+
+        fillbins[3] = fillbinssw[2] = ixpt2+1;
+
+        Int_t ixdeta = ixeta1 - ixeta2 + fNBins_eta - 1;
+        Int_t ixdetasw = ixeta2 - ixeta1 + fNBins_eta - 1;
+        Int_t ixdphi = ixphi1 - ixphi2; if (ixdphi < 0) ixdphi += fNBins_phi;
+        Int_t ixdphisw = ixphi2 - ixphi1; if (ixdphisw < 0) ixdphisw += fNBins_phi;
+
+        fillbins[0] = ixdeta+1;
+        fillbins[1] = ixdphi+1;
+        fillbinssw[0] = ixdetasw+1;
+        fillbinssw[1] = ixdphisw+1;
+
+        /* correct for the pair efficiency if applicable */
+        if (fPairEfficiency_PP != 0) {
+          fillweight /= fPairEfficiency_PP->GetBinContent(fillbins);
+        }
+
+        fhPPDeltaEtaDeltaPhi->AddBinContent(fillbins,fillweight);
+        fhPPDeltaEtaDeltaPhi->AddBinContent(fillbinssw,fillweight);
+      }
+      /* the plus-minus pairs analysis */
+      for (Int_t ixminus2 = 0; ixminus2 < fMinusTracksArray->GetEntriesFast(); ixminus2++) {
+        AliVTrack *trk2 = (AliVTrack *) fMinusTracksArray->At(ixminus2);
+        Int_t ixeta2 = Int_t ((trk2->Eta() - fMin_eta) / fWidth_eta);
+        Int_t ixphi2 = Int_t ((((trk2->Phi() < fMax_phi) ? trk2->Phi() : trk2->Phi() - 2*TMath::Pi() )- fMin_phi) / fWidth_phi);
+        Int_t ixpt2 = fhPMDeltaEtaDeltaPhi->GetAxis(3)->FindBin(trk2->Pt()) - 1;
+
+        /* correct for the efficiency on the second track, negative */
+        Float_t fillweight = fillweight1 * fEventMinusEfficiency[ixeta2][ixphi2][ixpt2];
+
+        fillbins[3] = ixpt2+1;
+
+        Int_t ixdeta = ixeta1 - ixeta2 + fNBins_eta - 1;
+        Int_t ixdphi = ixphi1 - ixphi2; if (ixdphi < 0) ixdphi += fNBins_phi;
+
+        fillbins[0] = ixdeta+1;
+        fillbins[1] = ixdphi+1;
+
+        /* correct for the pair efficiency if applicable */
+        if (fPairEfficiency_PM != 0) {
+          fillweight /= fPairEfficiency_PM->GetBinContent(fillbins);
+        }
+
+        fhPMDeltaEtaDeltaPhi->AddBinContent(fillbins,fillweight);
+      }
+    }
+
+
+    for (Int_t ixminus1 = 0; ixminus1 < fMinusTracksArray->GetEntriesFast(); ixminus1++) {
+      Int_t fillbins[kgHistosDimension];
+      Int_t fillbinssw[kgHistosDimension];
+
+      /* the minus-minus pairs analysis */
+      AliVTrack *trk1 = (AliVTrack *) fMinusTracksArray->At(ixminus1);
+      Int_t ixeta1 = Int_t ((trk1->Eta() - fMin_eta) / fWidth_eta);
+      Int_t ixphi1 = Int_t ((((trk1->Phi() < fMax_phi) ? trk1->Phi() : trk1->Phi() - 2*TMath::Pi() )- fMin_phi) / fWidth_phi);
+      Int_t ixpt1 = fhMMDeltaEtaDeltaPhi->GetAxis(2)->FindBin(trk1->Pt()) - 1;
+
+      /* start correcting for the efficiency on the first track, negative */
+      Float_t fillweight1 = fEventMinusEfficiency[ixeta1][ixphi1][ixpt1];
+
+      fillbins[2] = fillbinssw[3] = ixpt1+1;
+
+      for (Int_t ixminus2 = ixminus1+1; ixminus2 < fMinusTracksArray->GetEntriesFast(); ixminus2++) {
+        AliVTrack *trk2 = (AliVTrack *) fMinusTracksArray->At(ixminus2);
+        Int_t ixeta2 = Int_t ((trk2->Eta() - fMin_eta) / fWidth_eta);
+        Int_t ixphi2 = Int_t ((((trk2->Phi() < fMax_phi) ? trk2->Phi() : trk2->Phi() - 2*TMath::Pi() )- fMin_phi) / fWidth_phi);
+        Int_t ixpt2 = fhMMDeltaEtaDeltaPhi->GetAxis(3)->FindBin(trk2->Pt()) - 1;
+
+        /* correct for the efficiency on the second track, negative */
+        Float_t fillweight = fillweight1 * fEventMinusEfficiency[ixeta2][ixphi2][ixpt2];
+
+        fillbins[3] = fillbinssw[2] = ixpt2+1;
+
+        Int_t ixdeta = ixeta1 - ixeta2 + fNBins_eta - 1;
+        Int_t ixdetasw = ixeta2 - ixeta1 + fNBins_eta - 1;
+        Int_t ixdphi = ixphi1 - ixphi2; if (ixdphi < 0) ixdphi += fNBins_phi;
+        Int_t ixdphisw = ixphi2 - ixphi1; if (ixdphisw < 0) ixdphisw += fNBins_phi;
+
+        fillbins[0] = ixdeta+1;
+        fillbins[1] = ixdphi+1;
+        fillbinssw[0] = ixdetasw+1;
+        fillbinssw[1] = ixdphisw+1;
+
+        /* correct for the pair efficiency if applicable */
+        if (fPairEfficiency_MM != 0) {
+          fillweight /= fPairEfficiency_MM->GetBinContent(fillbins);
+        }
+
+        fhMMDeltaEtaDeltaPhi->AddBinContent(fillbins,fillweight);
+        fhMMDeltaEtaDeltaPhi->AddBinContent(fillbinssw,fillweight);
+      }
+
+      /* the minus-plus pairs analysis */
+      for (Int_t ixplus2 = 0; ixplus2 < fPlusTracksArray->GetEntriesFast(); ixplus2++) {
+        AliVTrack *trk2 = (AliVTrack *) fPlusTracksArray->At(ixplus2);
+        Int_t ixeta2 = Int_t ((trk2->Eta() - fMin_eta) / fWidth_eta);
+        Int_t ixphi2 = Int_t ((((trk2->Phi() < fMax_phi) ? trk2->Phi() : trk2->Phi() - 2*TMath::Pi() )- fMin_phi) / fWidth_phi);
+        Int_t ixpt2 = fhMPDeltaEtaDeltaPhi->GetAxis(3)->FindBin(trk2->Pt()) - 1;
+
+        /* correct for the efficiency on the second track, positive */
+        Float_t fillweight = fillweight1 * fEventPlusEfficiency[ixeta2][ixphi2][ixpt2];
+
+        fillbins[3] = ixpt2+1;
+
+        Int_t ixdeta = ixeta1 - ixeta2 + fNBins_eta - 1;
+        Int_t ixdphi = ixphi1 - ixphi2; if (ixdphi < 0) ixdphi += fNBins_phi;
+
+        fillbins[0] = ixdeta+1;
+        fillbins[1] = ixdphi+1;
+
+        /* correct for the pair efficiency if applicable */
+        if (fPairEfficiency_MP != 0) {
+          fillweight /= fPairEfficiency_MP->GetBinContent(fillbins);
+        }
+
+        fhMPDeltaEtaDeltaPhi->AddBinContent(fillbins,fillweight);
+      }
+    }
+  }
+  else {
+    Bool_t esdtrack = kFALSE;
+    if (fPlusTracksArray->GetEntriesFast() != 0)
+      esdtrack = fPlusTracksArray->At(0)->IsA()->InheritsFrom("AliVParticle");
+    if (fMinusTracksArray->GetEntriesFast() != 0)
+      esdtrack = fMinusTracksArray->At(0)->IsA()->InheritsFrom("AliVParticle");
+
+    if (!esdtrack) {
+      /* for ESD MC processing */
+      for (Int_t ixplus1 = 0; ixplus1 < fPlusTracksArray->GetEntriesFast(); ixplus1++) {
+        Int_t fillbins[kgHistosDimension];
+        Int_t fillbinssw[kgHistosDimension];
+
+        /* the plus-plus pairs analysis */
+        TParticle *trk1 = (TParticle *) fPlusTracksArray->At(ixplus1);
+        Int_t ixeta1 = Int_t ((trk1->Eta() - fMin_eta) / fWidth_eta);
+        Int_t ixphi1 = Int_t ((((trk1->Phi() < fMax_phi) ? trk1->Phi() : trk1->Phi() - 2*TMath::Pi() )- fMin_phi) / fWidth_phi);
+        Int_t ixpt1 = fhPPDeltaEtaDeltaPhi->GetAxis(2)->FindBin(trk1->Pt()) - 1;
+
+        fillbins[2] = fillbinssw[3] = ixpt1+1;
+
+        for (Int_t ixplus2 = ixplus1+1; ixplus2 < fPlusTracksArray->GetEntriesFast(); ixplus2++) {
+          TParticle *trk2 = (TParticle *) fPlusTracksArray->At(ixplus2);
+          Int_t ixeta2 = Int_t ((trk2->Eta() - fMin_eta) / fWidth_eta);
+          Int_t ixphi2 = Int_t ((((trk2->Phi() < fMax_phi) ? trk2->Phi() : trk2->Phi() - 2*TMath::Pi() )- fMin_phi) / fWidth_phi);
+          Int_t ixpt2 = fhPPDeltaEtaDeltaPhi->GetAxis(3)->FindBin(trk2->Pt()) - 1;
+
+          fillbins[3] = fillbinssw[2] = ixpt2+1;
+
+          Int_t ixdeta = ixeta1 - ixeta2 + fNBins_eta - 1;
+          Int_t ixdetasw = ixeta2 - ixeta1 + fNBins_eta - 1;
+          Int_t ixdphi = ixphi1 - ixphi2; if (ixdphi < 0) ixdphi += fNBins_phi;
+          Int_t ixdphisw = ixphi2 - ixphi1; if (ixdphisw < 0) ixdphisw += fNBins_phi;
+
+          fillbins[0] = ixdeta+1;
+          fillbins[1] = ixdphi+1;
+          fillbinssw[0] = ixdetasw+1;
+          fillbinssw[1] = ixdphisw+1;
+
+          fhPPDeltaEtaDeltaPhi->AddBinContent(fillbins,1.0);
+          fhPPDeltaEtaDeltaPhi->AddBinContent(fillbinssw,1.0);
+        }
+        /* the plus-minus pairs analysis */
+        for (Int_t ixminus2 = 0; ixminus2 < fMinusTracksArray->GetEntriesFast(); ixminus2++) {
+          TParticle *trk2 = (TParticle *) fMinusTracksArray->At(ixminus2);
+          Int_t ixeta2 = Int_t ((trk2->Eta() - fMin_eta) / fWidth_eta);
+          Int_t ixphi2 = Int_t ((((trk2->Phi() < fMax_phi) ? trk2->Phi() : trk2->Phi() - 2*TMath::Pi() )- fMin_phi) / fWidth_phi);
+          Int_t ixpt2 = fhPMDeltaEtaDeltaPhi->GetAxis(3)->FindBin(trk2->Pt()) - 1;
+
+          fillbins[3] = ixpt2+1;
+
+          Int_t ixdeta = ixeta1 - ixeta2 + fNBins_eta - 1;
+          Int_t ixdphi = ixphi1 - ixphi2; if (ixdphi < 0) ixdphi += fNBins_phi;
+
+          fillbins[0] = ixdeta+1;
+          fillbins[1] = ixdphi+1;
+
+          fhPMDeltaEtaDeltaPhi->AddBinContent(fillbins,1.0);
+        }
+      }
+
+      for (Int_t ixminus1 = 0; ixminus1 < fMinusTracksArray->GetEntriesFast(); ixminus1++) {
+        Int_t fillbins[kgHistosDimension];
+        Int_t fillbinssw[kgHistosDimension];
+
+        /* the minus-minus pairs analysis */
+        TParticle *trk1 = (TParticle *) fMinusTracksArray->At(ixminus1);
+        Int_t ixeta1 = Int_t ((trk1->Eta() - fMin_eta) / fWidth_eta);
+        Int_t ixphi1 = Int_t ((((trk1->Phi() < fMax_phi) ? trk1->Phi() : trk1->Phi() - 2*TMath::Pi() )- fMin_phi) / fWidth_phi);
+        Int_t ixpt1 = fhMMDeltaEtaDeltaPhi->GetAxis(2)->FindBin(trk1->Pt()) - 1;
+
+        fillbins[2] = fillbinssw[3] = ixpt1+1;
+
+        for (Int_t ixminus2 = ixminus1+1; ixminus2 < fMinusTracksArray->GetEntriesFast(); ixminus2++) {
+          TParticle *trk2 = (TParticle *) fMinusTracksArray->At(ixminus2);
+          Int_t ixeta2 = Int_t ((trk2->Eta() - fMin_eta) / fWidth_eta);
+          Int_t ixphi2 = Int_t ((((trk2->Phi() < fMax_phi) ? trk2->Phi() : trk2->Phi() - 2*TMath::Pi() )- fMin_phi) / fWidth_phi);
+          Int_t ixpt2 = fhMMDeltaEtaDeltaPhi->GetAxis(3)->FindBin(trk2->Pt()) - 1;
+
+          fillbins[3] = fillbinssw[2] = ixpt2+1;
+
+          Int_t ixdeta = ixeta1 - ixeta2 + fNBins_eta - 1;
+          Int_t ixdetasw = ixeta2 - ixeta1 + fNBins_eta - 1;
+          Int_t ixdphi = ixphi1 - ixphi2; if (ixdphi < 0) ixdphi += fNBins_phi;
+          Int_t ixdphisw = ixphi2 - ixphi1; if (ixdphisw < 0) ixdphisw += fNBins_phi;
+
+          fillbins[0] = ixdeta+1;
+          fillbins[1] = ixdphi+1;
+          fillbinssw[0] = ixdetasw+1;
+          fillbinssw[1] = ixdphisw+1;
+
+          fhMMDeltaEtaDeltaPhi->AddBinContent(fillbins,1.0);
+          fhMMDeltaEtaDeltaPhi->AddBinContent(fillbinssw,1.0);
+        }
+        /* the minus-plus pairs analysis */
+        for (Int_t ixplus2 = 0; ixplus2 < fPlusTracksArray->GetEntriesFast(); ixplus2++) {
+          TParticle *trk2 = (TParticle *) fPlusTracksArray->At(ixplus2);
+          Int_t ixeta2 = Int_t ((trk2->Eta() - fMin_eta) / fWidth_eta);
+          Int_t ixphi2 = Int_t ((((trk2->Phi() < fMax_phi) ? trk2->Phi() : trk2->Phi() - 2*TMath::Pi() )- fMin_phi) / fWidth_phi);
+          Int_t ixpt2 = fhMPDeltaEtaDeltaPhi->GetAxis(3)->FindBin(trk2->Pt()) - 1;
+
+          fillbins[3] = ixpt2+1;
+
+          Int_t ixdeta = ixeta1 - ixeta2 + fNBins_eta - 1;
+          Int_t ixdphi = ixphi1 - ixphi2; if (ixdphi < 0) ixdphi += fNBins_phi;
+
+          fillbins[0] = ixdeta+1;
+          fillbins[1] = ixdphi+1;
+
+          fhMPDeltaEtaDeltaPhi->AddBinContent(fillbins,1.0);
+        }
+      }
+    }
+    else {
+      /* for AOD MC processing */
+      for (Int_t ixplus1 = 0; ixplus1 < fPlusTracksArray->GetEntriesFast(); ixplus1++) {
+        Int_t fillbins[kgHistosDimension];
+        Int_t fillbinssw[kgHistosDimension];
+
+        /* the plus-plus pairs analysis */
+        AliAODMCParticle *trk1 = (AliAODMCParticle *) fPlusTracksArray->At(ixplus1);
+        Int_t ixeta1 = Int_t ((trk1->Eta() - fMin_eta) / fWidth_eta);
+        Int_t ixphi1 = Int_t ((((trk1->Phi() < fMax_phi) ? trk1->Phi() : trk1->Phi() - 2*TMath::Pi() )- fMin_phi) / fWidth_phi);
+        Int_t ixpt1 = fhPPDeltaEtaDeltaPhi->GetAxis(2)->FindBin(trk1->Pt()) - 1;
+
+        fillbins[2] = fillbinssw[3] = ixpt1+1;
+
+        for (Int_t ixplus2 = ixplus1+1; ixplus2 < fPlusTracksArray->GetEntriesFast(); ixplus2++) {
+          AliAODMCParticle *trk2 = (AliAODMCParticle *) fPlusTracksArray->At(ixplus2);
+          Int_t ixeta2 = Int_t ((trk2->Eta() - fMin_eta) / fWidth_eta);
+          Int_t ixphi2 = Int_t ((((trk2->Phi() < fMax_phi) ? trk2->Phi() : trk2->Phi() - 2*TMath::Pi() )- fMin_phi) / fWidth_phi);
+          Int_t ixpt2 = fhPPDeltaEtaDeltaPhi->GetAxis(3)->FindBin(trk2->Pt()) - 1;
+
+          fillbins[3] = fillbinssw[2] = ixpt2+1;
+
+          Int_t ixdeta = ixeta1 - ixeta2 + fNBins_eta - 1;
+          Int_t ixdetasw = ixeta2 - ixeta1 + fNBins_eta - 1;
+          Int_t ixdphi = ixphi1 - ixphi2; if (ixdphi < 0) ixdphi += fNBins_phi;
+          Int_t ixdphisw = ixphi2 - ixphi1; if (ixdphisw < 0) ixdphisw += fNBins_phi;
+
+          fillbins[0] = ixdeta+1;
+          fillbins[1] = ixdphi+1;
+          fillbinssw[0] = ixdetasw+1;
+          fillbinssw[1] = ixdphisw+1;
+
+          fhPPDeltaEtaDeltaPhi->AddBinContent(fillbins,1.0);
+          fhPPDeltaEtaDeltaPhi->AddBinContent(fillbinssw,1.0);
+        }
+        /* the plus-minus pairs analysis */
+        for (Int_t ixminus2 = 0; ixminus2 < fMinusTracksArray->GetEntriesFast(); ixminus2++) {
+          AliAODMCParticle *trk2 = (AliAODMCParticle *) fMinusTracksArray->At(ixminus2);
+          Int_t ixeta2 = Int_t ((trk2->Eta() - fMin_eta) / fWidth_eta);
+          Int_t ixphi2 = Int_t ((((trk2->Phi() < fMax_phi) ? trk2->Phi() : trk2->Phi() - 2*TMath::Pi() )- fMin_phi) / fWidth_phi);
+          Int_t ixpt2 = fhPMDeltaEtaDeltaPhi->GetAxis(3)->FindBin(trk2->Pt()) - 1;
+
+          fillbins[3] = ixpt2+1;
+
+          Int_t ixdeta = ixeta1 - ixeta2 + fNBins_eta - 1;
+          Int_t ixdphi = ixphi1 - ixphi2; if (ixdphi < 0) ixdphi += fNBins_phi;
+
+          fillbins[0] = ixdeta+1;
+          fillbins[1] = ixdphi+1;
+
+          fhPMDeltaEtaDeltaPhi->AddBinContent(fillbins,1.0);
+        }
+      }
+
+      for (Int_t ixminus1 = 0; ixminus1 < fMinusTracksArray->GetEntriesFast(); ixminus1++) {
+        Int_t fillbins[kgHistosDimension];
+        Int_t fillbinssw[kgHistosDimension];
+
+        /* the minus-minus pairs analysis */
+        AliAODMCParticle *trk1 = (AliAODMCParticle *) fMinusTracksArray->At(ixminus1);
+        Int_t ixeta1 = Int_t ((trk1->Eta() - fMin_eta) / fWidth_eta);
+        Int_t ixphi1 = Int_t ((((trk1->Phi() < fMax_phi) ? trk1->Phi() : trk1->Phi() - 2*TMath::Pi() )- fMin_phi) / fWidth_phi);
+        Int_t ixpt1 = fhMMDeltaEtaDeltaPhi->GetAxis(2)->FindBin(trk1->Pt()) - 1;
+
+        fillbins[2] = fillbinssw[3] = ixpt1+1;
+
+        for (Int_t ixminus2 = ixminus1+1; ixminus2 < fMinusTracksArray->GetEntriesFast(); ixminus2++) {
+          AliAODMCParticle *trk2 = (AliAODMCParticle *) fMinusTracksArray->At(ixminus2);
+          Int_t ixeta2 = Int_t ((trk2->Eta() - fMin_eta) / fWidth_eta);
+          Int_t ixphi2 = Int_t ((((trk2->Phi() < fMax_phi) ? trk2->Phi() : trk2->Phi() - 2*TMath::Pi() )- fMin_phi) / fWidth_phi);
+          Int_t ixpt2 = fhMMDeltaEtaDeltaPhi->GetAxis(3)->FindBin(trk2->Pt()) - 1;
+
+          fillbins[3] = fillbinssw[2] = ixpt2+1;
+
+          Int_t ixdeta = ixeta1 - ixeta2 + fNBins_eta - 1;
+          Int_t ixdetasw = ixeta2 - ixeta1 + fNBins_eta - 1;
+          Int_t ixdphi = ixphi1 - ixphi2; if (ixdphi < 0) ixdphi += fNBins_phi;
+          Int_t ixdphisw = ixphi2 - ixphi1; if (ixdphisw < 0) ixdphisw += fNBins_phi;
+
+          fillbins[0] = ixdeta+1;
+          fillbins[1] = ixdphi+1;
+          fillbinssw[0] = ixdetasw+1;
+          fillbinssw[1] = ixdphisw+1;
+
+          fhMMDeltaEtaDeltaPhi->AddBinContent(fillbins,1.0);
+          fhMMDeltaEtaDeltaPhi->AddBinContent(fillbinssw,1.0);
+        }
+        /* the minus-plus pairs analysis */
+        for (Int_t ixplus2 = 0; ixplus2 < fPlusTracksArray->GetEntriesFast(); ixplus2++) {
+          AliAODMCParticle*trk2 = (AliAODMCParticle *) fPlusTracksArray->At(ixplus2);
+          Int_t ixeta2 = Int_t ((trk2->Eta() - fMin_eta) / fWidth_eta);
+          Int_t ixphi2 = Int_t ((((trk2->Phi() < fMax_phi) ? trk2->Phi() : trk2->Phi() - 2*TMath::Pi() )- fMin_phi) / fWidth_phi);
+          Int_t ixpt2 = fhMPDeltaEtaDeltaPhi->GetAxis(3)->FindBin(trk2->Pt()) - 1;
+
+          fillbins[3] = ixpt2+1;
+
+          Int_t ixdeta = ixeta1 - ixeta2 + fNBins_eta - 1;
+          Int_t ixdphi = ixphi1 - ixphi2; if (ixdphi < 0) ixdphi += fNBins_phi;
+
+          fillbins[0] = ixdeta+1;
+          fillbins[1] = ixdphi+1;
+
+          fhMPDeltaEtaDeltaPhi->AddBinContent(fillbins,1.0);
+        }
+      }
+    }
+  }
+
+}
+
+/// \brief Do the final process for the end of analysis
+void  AliCSPairAnalysis::FinalizeProcess()
+{
+}
+
+
+/// \cond CLASSIMP
+ClassImp(AliCSPairAnalysis);
+/// \endcond

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSPairAnalysis.h
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSPairAnalysis.h
@@ -1,0 +1,124 @@
+#ifndef ALICSPAIRANALYSIS_H
+#define ALICSPAIRANALYSIS_H
+
+/// \file AliCSPairAnalysis.h
+/// \brief Class for analyzing particle pairs
+///
+
+#include <TNamed.h>
+#include <THn.h>
+
+/// \class AliCSPairAnalysis
+/// \brief Encapsulates the needed process and data for analyzing
+/// particle pairs
+///
+/// \author Víctor González <victor.gonzalez@cern.ch>, UCM
+/// \date Jan 30, 2017
+
+class TH3F;
+class THn;
+class TList;
+class TObjArray;
+class TParticle;
+class AliAODMCParticle;
+class AliVEvent;
+
+#include "AliVTrack.h"
+
+class AliCSPairAnalysis : public TNamed {
+public:
+                              AliCSPairAnalysis();
+                              AliCSPairAnalysis(const char *name);
+  virtual                    ~AliCSPairAnalysis();
+
+  void                        ConfigureBinning(const char *configstring);
+  TString                     GetBinningConfigurationString() const;
+
+  void                        Initialize();
+                              /// Stores the singles efficiency histograms reference for further use
+                              /// \param h3_1 the efficiency of the first track
+                              /// \param h3_2 the efficiency of the second track
+                              /// \return kTRUE always
+  Bool_t                      SetSinglesEfficiency(const TH3F *h3_1, const TH3F *h3_2)
+                              { fPlusEfficiency = h3_1; fMinusEfficiency = h3_2; return kTRUE; }
+                              /// Stores the pairs efficiency histograms reference for further use
+                              /// \param h11 the efficiency for the first first pair
+                              /// \param h12 the efficiency for the first second pair
+                              /// \param h22 the efficiency for the second second pair
+                              /// \param h21 the efficiency for the second first pair
+                              /// \return kTRUE always
+Bool_t                        SetPairEfficiency(const THn *h11, const THn *h12, const THn *h22, const THn *h21)
+                              { fPairEfficiency_PP = h11; fPairEfficiency_PM = h12; fPairEfficiency_MM = h22; fPairEfficiency_MP = h21; return kTRUE; }
+                              /// Get the histograms list
+                              /// \return the histograms list
+  TList                      *GetHistogramsList() { return fOutput; }
+  Bool_t                      StartEvent(Float_t vertexZ);
+  Bool_t                      ProcessTrack(Int_t, AliVTrack *trk);
+  Bool_t                      ProcessTrack(Int_t, TParticle *par);
+  Bool_t                      ProcessTrack(Int_t, AliAODMCParticle *par);
+  void                        ProcessEventData();
+  void                        FinalizeProcess();
+
+private:
+  static const Int_t          kgHistosDimension;            ///< the number of dimensions of the multidimensional histograms
+  TList                      *fOutput;                      //!<! Output histograms list
+
+  Int_t                       fNBins_vertexZ;               ///< the \f$z\f$ vertex component number of bins
+  Double_t                    fMin_vertexZ;                 ///< the minimum \f$z\f$ vertex component value
+  Double_t                    fMax_vertexZ;                 ///< the maximum \f$z\f$ vertex component value
+  Double_t                    fWidth_vertexZ;               ///< the \f$z\f$ vertex component bin width
+
+  Double_t                    fNBinsPhiShift;               ///< the number of bins the phi origin is shifted
+
+  Int_t                       fNBins_pt;                    ///< the \f$p_T\f$ number of bins
+  Double_t                    fMin_pt;                      ///< the minimum \f$p_T\f$ value
+  Double_t                    fMax_pt;                      ///< the maximum \f$p_T\f$ value
+  Double_t                    fWidth_pt;                    ///< the \f$p_T\f$ bin width
+  Int_t                       fNBins_phi;                   ///< the \f$\phi\f$ number of bins
+  Double_t                    fMin_phi;                     ///< the minimum \f$\phi\f$ value
+  Double_t                    fMax_phi;                     ///< the maximum \f$\phi\f$ value
+  Double_t                    fWidth_phi;                   ///< the \f$\phi\f$ bin width
+  Int_t                       fNBins_eta;                   ///< the \f$\eta\f$ number of bins
+  Double_t                    fMin_eta;                     ///< the minimum \f$\eta\f$ value
+  Double_t                    fMax_eta;                     ///< the maximum \f$\eta\f$ value
+  Double_t                    fWidth_eta;                   ///< the \f$\eta\f$ bin width
+
+  /* the arrays with plus and minus tracks */
+  TObjArray                  *fPlusTracksArray;             ///< the array of positive tracks
+  TObjArray                  *fMinusTracksArray;            ///< the array of negative tracks
+
+  /* the singles efficiency structures */
+  const TH3F                 *fPlusEfficiency;              ///< the positive track efficiency
+  const TH3F                 *fMinusEfficiency;             ///< the negative track efficiency
+  Float_t                  ***fEventPlusEfficiency;         //!<! the processed event efficiency for the positive track, according to event zvtx
+  Float_t                  ***fEventMinusEfficiency;        //!<! the processed event efficiency for the negative track, according to event zvtx
+
+  /* the pairs efficiencies */
+  const THn                  *fPairEfficiency_PP;           ///< the positive positive tracks pair efficiency
+  const THn                  *fPairEfficiency_PM;           ///< the positive negative tracks pair efficiency
+  const THn                  *fPairEfficiency_MM;           ///< the negative negative tracks pair efficiency
+  const THn                  *fPairEfficiency_MP;           ///< the negative positive tracks pair efficiency
+
+  /* histograms */
+  TH1F                       *fhNplus;                      //!<! positive particle multiplicity
+  TH1F                       *fhNminus;                     //!<! negative particle multiplicity
+  THnF                       *fhPPDeltaEtaDeltaPhi;         //!<! positive-positive delta eta delta phi separation vs pT, pT
+  THnF                       *fhPMDeltaEtaDeltaPhi;         //!<! positive-negative delta eta delta phi separation vs pT, pT
+  THnF                       *fhMPDeltaEtaDeltaPhi;         //!<! positive-negative delta eta delta phi separation vs pT, pT
+  THnF                       *fhMMDeltaEtaDeltaPhi;         //!<! negative-negative delta eta delta phi separation vs pT, pT
+
+private:
+  /// Copy constructor
+  /// Not allowed. Forced private.
+  AliCSPairAnalysis(const AliCSPairAnalysis&);
+  /// Assignment operator
+  /// Not allowed. Forced private.
+  /// \return l-value reference object
+  AliCSPairAnalysis& operator=(const AliCSPairAnalysis&);
+
+  /// \cond CLASSIMP
+  ClassDef(AliCSPairAnalysis,1);
+  /// \endcond
+};
+
+#endif // ALICSPAIRANALYSIS_H

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSTrackCuts.cxx
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSTrackCuts.cxx
@@ -1,0 +1,1636 @@
+/**************************************************************************
+* Copyright(c) 1998-2016, ALICE Experiment at CERN, All rights reserved.  *
+*                                                                         *
+* Permission to use, copy, modify and distribute this software and its    *
+* documentation strictly for non-commercial purposes is hereby granted    *
+* without fee, provided that the above copyright notice appears in all    *
+* copies and that both the copyright notice and this permission notice    *
+* appear in the supporting documentation. The authors make no claims      *
+* about the suitability of this software for any purpose. It is           *
+* provided "as is" without express or implied warranty.                   *
+**************************************************************************/
+
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TFormula.h>
+#include "AliStack.h"
+#include "AliVEvent.h"
+#include "AliVTrack.h"
+#include "TParticle.h"
+#include "AliCSTrackCuts.h"
+#include "AliAnalysisManager.h"
+#include "AliInputEventHandler.h"
+#include "AliMCEventHandler.h"
+#include "AliAODEvent.h"
+#include "AliESDEvent.h"
+#include "AliMCEvent.h"
+#include "AliAODMCParticle.h"
+#include "AliHeader.h"
+#include "AliGenCocktailEventHeader.h"
+#include "AliCentrality.h"
+#include "AliMultSelection.h"
+#include "AliESDtrackCuts.h"
+#include "AliLog.h"
+
+/// \file AliCSTrackCuts.cxx
+/// \brief Implementation of event cuts class within the correlation studies analysis
+
+const char *AliCSTrackCuts::fgkCutsNames[AliCSTrackCuts::kNCuts] = {
+    "Not constrained",
+    "#eta",
+    "Track type (ITS cls,TPC cls,DCA)",
+    "p_{t}",
+};
+
+
+/// Default constructor for serialization
+AliCSTrackCuts::AliCSTrackCuts() :
+    AliCSTrackCutsBase(),
+    fConstrain(kFALSE),
+    fBaseSystem(kUnknownBase),
+    fEtaCut(100.0),
+    fMinPt(0.0),
+    fMaxPt(9999.0),
+    fEtaShift(0.0),
+    fESDTrackCuts(NULL),
+    fAODFilterBits(0),
+    fhCutsStatistics(NULL),
+    fhCutsCorrelation(NULL),
+    fhPtVsDCAxy{NULL},
+    fhPtVsDCAz{NULL},
+    fhPtVsTPCCls{NULL},
+    fhPtVsTPCRowOverFindCls{NULL},
+    fhEtaVsPhi{NULL},
+    fhPtVsEta{NULL}
+{
+}
+
+/// Constructor
+/// \param name name of the event cuts
+/// \param title title of the event cuts
+AliCSTrackCuts::AliCSTrackCuts(const char *name, const char *title) :
+    AliCSTrackCutsBase(kNCuts,kNCutsParameters,name,title),
+    fConstrain(kFALSE),
+    fBaseSystem(kUnknownBase),
+    fEtaCut(100.0),
+    fMinPt(0.0),
+    fMaxPt(9999.0),
+    fEtaShift(0.0),
+    fESDTrackCuts(NULL),
+    fAODFilterBits(0),
+    fhCutsStatistics(NULL),
+    fhCutsCorrelation(NULL),
+    fhPtVsDCAxy{NULL},
+    fhPtVsDCAz{NULL},
+    fhPtVsTPCCls{NULL},
+    fhPtVsTPCRowOverFindCls{NULL},
+    fhEtaVsPhi{NULL},
+    fhPtVsEta{NULL}
+{
+}
+
+/// Destructor
+/// We don't own anything, everything we allocate is owned
+/// by the output list
+AliCSTrackCuts::~AliCSTrackCuts()
+{
+
+}
+
+/// Processes a potential change in the run number
+///
+/// Checks if the current period under analysis has changes and if so
+/// updates the needed members
+void AliCSTrackCuts::NotifyRun() {
+
+  /* checks the change in the analysis period */
+  if (AliCSTrackCutsBase::GetGlobalPeriod() != fDataPeriod) {
+
+    fDataPeriod = AliCSTrackCutsBase::GetGlobalPeriod();
+
+    /* Configure the cuts accordingly to the data period */
+    this->SetActualTypeOfTrackCuts();
+    this->SetActualITSClustersCut();
+    this->SetActualTPCClustersCut();
+    this->SetActualDCACut();
+
+    /* and now we ask for histogram allocation */
+    DefineHistograms();
+  }
+}
+
+/// Processes the start of a new event
+///
+/// Does nothin for the time being
+void AliCSTrackCuts::NotifyEvent() {
+
+}
+
+/// Check whether the passed track is accepted by the different cuts
+/// \param trk the track to analyze whether it is accepted or not
+/// \return kTRUE if the track  is accepted, kFALSE otherwise
+///
+/// An internal copy of the track is used in case it were needed to constrain it if the cut
+/// so decide it. The (constrained) copy is then used for further analysis or cut
+/// decisions. The #fConstrain flag is kept to inform the user she needs to constrain the track.
+Bool_t AliCSTrackCuts::IsTrackAccepted(AliVTrack *trk) {
+
+  AliVTrack *ttrk = NULL; /* it will be created once the type is known */
+  fConstrain = kFALSE; /* it will be updated with the track type */
+
+  /* just to be sure */
+  if (trk == NULL) return kFALSE;
+
+  /* if MC analysis is ongoing get rid of "ghost" tracks */
+  if (fgIsMC) if (trk->GetLabel() < 0) return kFALSE;
+
+  /* for the time being */
+  Bool_t accepted = kTRUE;
+
+  /* initialize the mask of activated cuts */
+  fCutsActivatedMask.ResetAllBits();
+
+  /* is the constrained parameter info available */
+  if (trk->IsA() == AliESDtrack::Class()) {
+    if (!trk->GetConstrainedParam()) {
+      fCutsActivatedMask.SetBitNumber(kNotConstrainedCut);
+      accepted = kFALSE;
+    }
+  }
+
+  /* Track type cut: TPC clusters, ITS clusters and DCA cuts. We will need to change this */
+  /* should we need more granularity in the output information */
+  /* The track will be constrained if the cut so decide it then the (potentially) constrained */
+  /* is returned in ttrk for further use */
+  if (!AcceptTrackType(trk,ttrk)) {
+    fCutsActivatedMask.SetBitNumber(kTrackTypeCuts);
+    accepted = kFALSE;
+  }
+
+  /* update the constrained potentially constrained track */
+  if (!fConstrain) {
+    /* not constrained so use the same track further on */
+    ttrk = trk;
+  }
+
+  /* eta cut */
+  if (fCutsEnabledMask.TestBitNumber(kEtaCut)) {
+    if ((ttrk->Eta() < (- fEtaCut + fEtaShift)) ||
+        ((fEtaCut + fEtaShift) < ttrk->Eta())) {
+      fCutsActivatedMask.SetBitNumber(kEtaCut);
+      accepted = kFALSE;
+    }
+  }
+
+  /* Pt cut */
+  if (fCutsEnabledMask.TestBitNumber(kPtCut)) {
+    if ((ttrk->Pt() < fMinPt) || (fMaxPt < ttrk->Pt())) {
+      fCutsActivatedMask.SetBitNumber(kPtCut);
+      accepted = kFALSE;
+    }
+  }
+
+  if (fQALevel > kQALevelNone) {
+    /* let's fill the histograms */
+    fhCutsStatistics->Fill(fhCutsStatistics->GetBinCenter(fhCutsStatistics->GetXaxis()->FindBin("n tracks")));
+    if (!accepted)
+      fhCutsStatistics->Fill(fhCutsStatistics->GetBinCenter(fhCutsStatistics->GetXaxis()->FindBin("n cut tracks")));
+
+    for (Int_t i=0; i<kNCuts; i++) {
+      if (fhCutsStatistics->GetXaxis()->FindBin(fgkCutsNames[i]) < 1)
+        AliFatal(Form("Inconsistency! Cut %d with name %s not found", i, fgkCutsNames[i]));
+
+      if (fCutsActivatedMask.TestBitNumber(i))
+        fhCutsStatistics->Fill(fhCutsStatistics->GetBinCenter(fhCutsStatistics->GetXaxis()->FindBin(fgkCutsNames[i])));
+
+      if (fQALevel > kQALevelLight) {
+        for (Int_t j=i; j<kNCuts; j++) {
+          if (fhCutsStatistics->GetXaxis()->FindBin(fgkCutsNames[j]) < 1)
+            AliFatal(Form("Inconsistency! Cut %d with name %s not found", j, fgkCutsNames[j]));
+
+          if (fCutsActivatedMask.TestBitNumber(i) && fCutsActivatedMask.TestBitNumber(j)) {
+            Float_t xC = fhCutsCorrelation->GetXaxis()->GetBinCenter(fhCutsCorrelation->GetXaxis()->FindBin(fgkCutsNames[i]));
+            Float_t yC = fhCutsCorrelation->GetYaxis()->GetBinCenter(fhCutsCorrelation->GetYaxis()->FindBin(fgkCutsNames[j]));
+            fhCutsCorrelation->Fill(xC, yC);
+          }
+        }
+      }
+    }
+
+    /* get some values needed for histograms filling */
+    Float_t dca[2], bCov[3];
+    if (trk->IsA() == AliESDtrack::Class()) {
+      ttrk->GetImpactParameters(dca,bCov);
+    }
+    else {
+      /* TODO: if the track is constrained this needs to be considered */
+      /* the selected tracks get a DCA of 0.0. Implement GetDCA from   */
+      /* AliDielectronVarManager but it will require access to the     */
+      /* event object                                                  */
+      AliAODTrack *aodt = dynamic_cast<AliAODTrack*>(trk);
+      Float_t pos[3];
+      if (aodt->GetPosition(pos)) {
+        dca[0] = pos[0];
+        dca[1] = pos[1];
+      }
+      else {
+        dca[0] = 0.0;
+        dca[1] = 0.0;
+      }
+    }
+
+    Float_t nCrossedRowsTPC = ttrk->GetTPCCrossedRows();
+    Float_t  ratioCrossedRowsOverFindableClustersTPC = 1.0;
+    if (ttrk->GetTPCNclsF()>0) {
+      ratioCrossedRowsOverFindableClustersTPC = nCrossedRowsTPC / ttrk->GetTPCNclsF();
+    }
+
+    for (Int_t i = 0; i < 2; i++) {
+
+      fhPtVsDCAxy[i]->Fill(dca[0],ttrk->Pt());
+      fhPtVsDCAz[i]->Fill(dca[1],ttrk->Pt());
+      fhPtVsTPCCls[i]->Fill(ttrk->GetTPCNcls(),ttrk->Pt());
+      fhPtVsTPCRowOverFindCls[i]->Fill(ratioCrossedRowsOverFindableClustersTPC,ttrk->Pt());
+      fhPtVsEta[i]->Fill(ttrk->Eta(),ttrk->Pt());
+
+      if (fQALevel > kQALevelLight) {
+        fhEtaVsPhi[i]->Fill(ttrk->Phi()*180.0/TMath::Pi(),ttrk->Eta());
+      }
+
+      /* don't fill after if event not accepted */
+      if (!accepted) break;
+    }
+  }
+  /* delete the potentially constrained track */
+  if (fConstrain) {
+    /* constrained so use delete it */
+    delete ttrk;
+  }
+
+  return accepted;
+}
+
+
+/// Check whether the true track associated to the passed track is accepted by the kinematic cuts
+/// \param trk the track to analyze whether its associated true track is accepted or not
+/// \return kTRUE if the associated true track  is accepted, kFALSE otherwise
+///
+Bool_t AliCSTrackCuts::IsTrueTrackAccepted(AliVTrack *trk) {
+
+  /* reject ghost tracks */
+  if (trk->GetLabel() < 0) return kFALSE;
+
+  return IsTrueTrackAccepted(trk->GetLabel());
+}
+
+
+/// Check whether the passed true track is accepted by the kinematic and PID cuts
+/// \param itrk the index of true track to analyze whether it is accepted or not
+/// \return kTRUE if the track  is accepted, kFALSE otherwise
+///
+Bool_t AliCSTrackCuts::IsTrueTrackAccepted(Int_t itrk) {
+
+  Double_t eta = 0.0;
+  Double_t pt = 0.0;
+
+  if (fgIsESD) {
+    /* we stay only with primary tracks */
+    if (!fgMCHandler->MCEvent()->IsPhysicalPrimary(itrk))
+      return kFALSE;
+
+    /* get the associated particle */
+    TParticle *particle = fgMCHandler->MCEvent()->Particle(itrk);
+
+    /* just to be sure */
+    if (particle == NULL) return kFALSE;
+
+    eta = particle->Eta();
+    pt = particle->Pt();
+  }
+  else {
+    /* get the associated particle */
+    AliAODMCParticle *particle = (AliAODMCParticle *) fgMCArray->At(itrk);
+
+    /* just to be sure */
+    if (particle == NULL) return kFALSE;
+
+    /* we stay only with primary tracks */
+    if (!particle->IsPhysicalPrimary())
+      return kFALSE;
+
+    eta = particle->Eta();
+    pt = particle->Pt();
+  }
+
+
+  /* eta cut */
+  if (fCutsEnabledMask.TestBitNumber(kEtaCut)) {
+    if ((eta < (- fEtaCut + fEtaShift)) ||
+        ((fEtaCut + fEtaShift) < eta)) {
+      return kFALSE;
+    }
+  }
+
+  /* Pt cut */
+  if (fCutsEnabledMask.TestBitNumber(kPtCut)) {
+    if ((pt < fMinPt) || (fMaxPt < pt)) {
+      return kFALSE;
+    }
+  }
+
+  return kTRUE;
+}
+
+/// Check whether the passed track is accepted by the track type cuts
+/// \param trk the track to analyze whether it is accepted or not
+/// \param ttrk the potential constrained track. NULL if not constrained
+/// \return kTRUE if the track  is accepted, kFALSE otherwise
+///
+/// If the selected cut requires the track being constrained, the passed track is
+/// cloned, its clone constrained, its reference returned in *ttrk* parameter and the
+/// #fConstrain flag raised.
+Bool_t AliCSTrackCuts::AcceptTrackType(AliVTrack *trk, AliVTrack *&ttrk) {
+  Bool_t accepted = kTRUE;
+
+  if (trk->IsA() == AliESDtrack::Class()) {
+    if (!fESDTrackCuts->AcceptTrack(dynamic_cast<AliESDtrack *>(trk))) {
+      accepted = kFALSE;
+    }
+    else {
+      /* the track is accepted, check special handling depending on the cut */
+      switch (fParameters[kTrackTypeCutParam]) {
+      case 5: /* special handling for TPC only tracks to constrain to the SPD vertex */
+        AliFatal("Functionality not yet supported");
+        break;
+      case 7: /* special handling for global hybrid constrained */
+          /* we have to select complementary hybrid tracks but this is period dependent */
+        AliFatal("Functionality not yet supported");
+        switch(fBaseSystem) {
+        case k2010based:
+          /* to check if HG1 or GC we just require ITS:none which complements case 6 */
+          if (trk->GetStatus() & AliESDtrack::kITSupg) {
+            /* upgraded ITS with seven layers */
+            if (trk->HasPointOnITSLayer(0) || (trk->HasPointOnITSLayer(1) && trk->HasPointOnITSLayer(2))) {
+              accepted = kFALSE;
+            }
+            AliError("We should not be here within 2010 based periods");
+          }
+          else {
+            if (trk->HasPointOnITSLayer(0) || trk->HasPointOnITSLayer(1)) {
+              accepted = kFALSE;
+            }
+          }
+          break;
+        case k2011based:
+          break;
+        default:
+          accepted = kFALSE;
+        }
+        /* so, if we reached here with the track accepted we have to constrain it */
+        if (accepted) {
+          /* constrain the track */
+          if (trk->GetConstrainedParam()) {
+            AliESDtrack *tmptrk = new AliESDtrack(*((AliESDtrack*) trk));
+            tmptrk->Set(trk->GetConstrainedParam()->GetX(),
+                trk->GetConstrainedParam()->GetAlpha(),
+                trk->GetConstrainedParam()->GetParameter(),
+                trk->GetConstrainedParam()->GetCovariance());
+            ttrk = tmptrk;
+            fConstrain = kTRUE;
+          }
+          else
+            accepted = kFALSE;
+        }
+        break;
+      default:
+        ;
+      }
+    }
+  }
+  else if (trk->IsA() == AliAODTrack::Class()) {
+    /* TODO: for the time being only the pure equivalence of FB with the */
+    /* type of track selected is used. This means that DCA cut, ITS      */
+    /* clusters cut and TPC clusters cut are not considered apart of     */
+    /* what is already implicit in the FB. As an additional comment to   */
+    /* consider, if the cut is loose than the FB, the FB is useless      */
+    /* to discard, tests with the track information available
+    Int_t a,bb,c,d;
+    Int_t clsITS[6];
+    Float_t b[2];
+    Float_t bCov[3];
+
+    trk->GetTPCClusterInfo(a,bb,c,d);
+    trk->GetTPCCrossedRows();
+    trk->GetTPCNcls();
+    trk->GetTPCNclsF();
+    trk->GetTPCSharedMapPtr();
+    trk->GetImpactParameters(b,bCov);
+    trk->GetITSclusters(clsITS);
+
+    end tests */
+
+    AliAODTrack *aodt = dynamic_cast<AliAODTrack*>(trk);
+
+    if(!aodt->TestFilterBit(fAODFilterBits)) {
+      accepted = kFALSE;
+    }
+    else {
+      /* the track is accepted, check special handling depending on the cut */
+      switch (fParameters[kTrackTypeCutParam]) {
+      case 5: /* special handling for TPC only tracks to constrain to the SPD vertex */
+        /* do nothing, the track should have already been constrained */
+        break;
+      case 7: /* special handling for global hybrid constrained */
+          /* we have to select complementary hybrid tracks but this is period dependent */
+        AliFatal("Functionality not yet supported");
+        switch(fBaseSystem) {
+        case k2010based:
+          /* to check if HG1 or GC we just require ITS:none which complements case 6 */
+          if (trk->GetStatus() & AliESDtrack::kITSupg) {
+            /* upgraded ITS with seven layers */
+            if (trk->HasPointOnITSLayer(0) || (trk->HasPointOnITSLayer(1) && trk->HasPointOnITSLayer(2))) {
+              accepted = kFALSE;
+            }
+            AliError("We should not be here within 2010 based periods");
+          }
+          else {
+            if (trk->HasPointOnITSLayer(0) || trk->HasPointOnITSLayer(1)) {
+              accepted = kFALSE;
+            }
+          }
+          break;
+        case k2011based:
+          break;
+        default:
+          accepted = kFALSE;
+        }
+        /* so, if we reached here with the track accepted we have to constrain it */
+        /* TODO: this is wrong. If we are in AOD the tracks should already be constrained */
+        if (accepted) {
+          /* constrain the track */
+          if (trk->GetConstrainedParam()) {
+            AliFatal("Functionality not yet supported");
+            fConstrain = kTRUE;
+          }
+          else
+            accepted = kFALSE;
+        }
+        break;
+      default:
+        ;
+      }
+    }
+  }
+  else {
+    AliError("Neither ESD nor AOD track!!!");
+    accepted = kFALSE;
+  }
+  return accepted;
+}
+
+/// Check whether the true particle associated to a reconstructed track is primary
+/// \param trk the reconstructed track
+/// \return kTRUE if the associated particle is primary kFALSE otherwise
+Bool_t AliCSTrackCuts::IsTruePrimary(AliVTrack *trk) {
+
+  if (fgIsESD) {
+    return fgMCHandler->MCEvent()->IsPhysicalPrimary(TMath::Abs(trk->GetLabel()));
+  }
+  else {
+    /* get the associated particle */
+    AliAODMCParticle *particle = (AliAODMCParticle *) fgMCArray->At(TMath::Abs(trk->GetLabel()));
+
+    /* just to be sure */
+    if (particle == NULL) return kFALSE;
+
+    /* we stay only with primary tracks */
+    return particle->IsPhysicalPrimary();
+  }
+}
+
+
+/// Sets the individual value for the cut parameter ID
+/// \param paramID the ID of the cut parameter of interest
+/// \param value the value for the cut parameter
+/// \return kTRUE if the cut parameter value was accepted
+Bool_t AliCSTrackCuts::SetCutAndParams(Int_t paramID, Int_t value) {
+
+  switch (cutsParametersIds(paramID)) {
+  case kTrackTypeCutParam:
+    if (SetTypeOfTrackCut(value)) {
+      fParameters[kTrackTypeCutParam] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kEtaCutParam:
+    if (SetEtaCut(value)) {
+      fParameters[kEtaCutParam] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kITSClsCutParam:
+    if (SetITSClustersCut(value) ) {
+      fParameters[kITSClsCutParam] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kTPCClsCutParam:
+    if (SetTPCClustersCut(value)) {
+      fParameters[kTPCClsCutParam] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kDCACutParam:
+    if (SetDCACut(value)) {
+      fParameters[kDCACutParam] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  case kPtCutParam:
+    if (SetPtCut(value)) {
+      fParameters[kPtCutParam] = value;
+      UpdateCutsString();
+      return kTRUE;
+    } else return kFALSE;
+  default:
+    AliError(Form("Cut param id %d out of supported range", paramID));
+    return kFALSE;
+  }
+}
+
+
+/// Print the whole cut iformatio for the cut ID
+/// \param paramID the ID of the cut of interest
+void AliCSTrackCuts::PrintCutWithParams(Int_t paramID) const {
+
+  switch (cutsParametersIds(paramID)) {
+  case kTrackTypeCutParam:
+    printf("  Type of track cut: ");
+    this->PrintTypeOfTrackCut();
+    break;
+  case kEtaCutParam:
+    printf("  Acceptance cut: ");
+    if (fCutsEnabledMask.TestBitNumber(kEtaCut))
+      printf("|eta| < %3.1f\n",fEtaCut);
+    else
+      printf("none\n");
+    break;
+  case kITSClsCutParam:
+    printf("  ITS clusters cut: ");
+    PrintITSClustersCut();
+    break;
+  case kTPCClsCutParam:
+    printf("  TPC clusters cut: ");
+    PrintTPCClustersCut();
+    break;
+  case kDCACutParam:
+    printf("  DCA cut: ");
+    PrintDCACut();
+    break;
+  case kPtCutParam:
+    printf("  Pt cut: ");
+    if (fCutsEnabledMask.TestBitNumber(kPtCut))
+      printf("%3.1f < pT %s", fMinPt, (fMaxPt < 9990) ? Form("%3.1f\n", fMaxPt) : "\n");
+    else
+      printf("none\n");
+    break;
+  default:
+    AliError(Form("Cut param id %d out of supported range", paramID));
+  }
+}
+
+/// Configures the type of track cut
+/// \param ttype The type of track the cut shall select
+/// | code | type of track |
+/// |:--:|:--|
+/// | 0 | default standard cut for the considered data period |
+/// | 1 | FB1. TPC only tracks |
+/// | 2 | FB32. Global primaries |
+/// | 3 | FB64. Global primaries complementary to code 2 ones |
+/// | 4 | FB16. Global primaries plus secondaries |
+/// | 5 | FB128. TPC only tracks to constrain to the SPD vertex |
+/// | 6 | FB256. Global hybrid primaries plus secondaries |
+/// | 7 | FB512. To constrain global hybrid primaries plus secondaries complementary to code 6 |
+/// | 9 | FBxFFFF. no cut on the type of track, i.e. accept all of them |
+/// \return kTRUE if proper and supported \f$ \eta \f$  cut code
+///
+Bool_t AliCSTrackCuts::SetTypeOfTrackCut(Int_t ttype) {
+  switch (ttype) {
+  case 0:
+    break;
+  case 1:
+    break;
+  case 2:
+    break;
+  case 3:
+    break;
+  case 4:
+    break;
+  case 5:
+    break;
+  case 6:
+    break;
+  case 7:
+    break;
+  case 9:
+    break;
+  default:
+    AliError(Form("Track type cut code %d not supported", ttype));
+    return kFALSE;
+  }
+  return kTRUE;
+}
+
+/// Prints the type of track cut
+void AliCSTrackCuts::PrintTypeOfTrackCut() const {
+  switch(fParameters[kTrackTypeCutParam]){
+    case 0:
+      printf("default standard cut for the considered data period\n");
+      break;
+    case 1:
+      printf("FB1. TPC only tracks\n");
+      break;
+    case 2:
+      printf("FB32. Global primaries. Tight DCA cut. A hit on SPD:ANY\n");
+      break;
+    case 3:
+      printf("FB64. Global primaries. Tight DCA cut. No hit on SPD\n");
+      break;
+    case 4:
+      printf("FB16. Global primaries plus secondaries. Loose DCA cut. A hit on SPD:ANY\n");
+      break;
+    case 5:
+      printf("FB128. TPC only tracks to constrain to the SPD vertex\n");
+      break;
+    case 6:
+      printf("FB256. Global hybrid primaries plus secondaries. Loose DCA cut. A hit on SPD:ANY. TPC shared clusters\n");
+      break;
+    case 7:
+      printf("FB512. Global hybrid primaries plus secondaries to constrain. Loose DCA cut. No hit on SPD or ITS refit not required. TPC shared clusters\n");
+      break;
+    case 9:
+      printf("No track type cut. Accept all\n");
+      break;
+    default:
+      AliError(Form("Wrong track type cut code %d stored", fParameters[kTrackTypeCutParam]));
+  }
+}
+
+/// Set the standard track cuts set according to the data period
+void AliCSTrackCuts::SetActualTypeOfTrackCuts() {
+
+  if (fESDTrackCuts != NULL)
+    delete fESDTrackCuts;
+  fAODFilterBits = 0;
+
+  TString system = "";
+  TString period = "";
+  TString basename = "";
+  fBaseSystem = kUnknownBase;
+
+
+  switch (GetGlobalAnchorPeriod()) {
+  case kLHC10bg:
+    fBaseSystem = k2010based;
+    basename = "2010";
+    system = "p-p";
+    period = "2010bg";
+    break;
+  case kLHC11a:
+  case kLHC11b:
+  case kLHC11cg:
+    fBaseSystem = k2011based;
+    basename = "2011";
+    system = "p-p";
+    period = "2011ag";
+    break;
+  case kLHC12:
+  case kLHC13g:
+  case kLHC15fm:
+  case kLHC15n:
+  case kLHC16k:
+  case kLHC16l:
+    fBaseSystem = k2011based;
+    basename = "2011";
+    system = "p-p";
+    period = "various";
+    break;
+  case kLHC13bc:
+  case kLHC13de:
+  case kLHC13f:
+    fBaseSystem = k2011based;
+    basename = "2011";
+    system = "p-Pb";
+    period = "2013bf";
+    break;
+  case kLHC10h:
+    fBaseSystem = k2010based;
+    basename = "2010";
+    system = "Pb-Pb";
+    period = "2010h";
+    break;
+  case kLHC11h:
+    fBaseSystem = k2011based;
+    basename = "2011";
+    system = "Pb-Pb";
+    period = "2011h";
+    break;
+  case kLHC15oLIR:
+  case kLHC15oHIR:
+    fBaseSystem = k2011based;
+    basename = "2011";
+    system = "Pb-Pb";
+    period = "2015o";
+    break;
+  default:
+    fESDTrackCuts = AliESDtrackCuts::GetStandardTPCOnlyTrackCuts();
+    fAODFilterBits = 1;
+    fESDTrackCuts->SetNameTitle(Form("TrackType_%s",GetCutsString()),"Type of tracks: Standard TPC only");
+    AliError("SYSTEM: no system set from data files. Standard TPC only track cuts");
+    return;
+  }
+
+  TString tracktype = "";
+  switch (fParameters[kTrackTypeCutParam]) {
+  case 0:
+    /* printf("default standard cut for the considered data period\n"); */
+    switch (fBaseSystem) {
+    case k2010based:
+      fESDTrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010();
+      fESDTrackCuts->SetNameTitle(Form("TrackType_%s",GetCutsString()),"Type of tracks: Standard 2010 primaries");
+      fAODFilterBits = 32;
+      tracktype = "FB32. Standard ITS+TPC 2010. Tight DCA. ITS:ANY. Number of clusters";
+      break;
+    case k2011based:
+      fESDTrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011();
+      fESDTrackCuts->SetNameTitle(Form("TrackType_%s",GetCutsString()),"Type of tracks: Standard 2011 primaries");
+      fAODFilterBits = 32;
+      tracktype = "FB32. Standard ITS+TPC 2011. Tight DCA. ITS:ANY. Number of rows";
+      break;
+    default:
+      AliFatal("Internal inconsistency between data period and base period for track cuts selection. ABORTING!!!");
+      return;
+    }
+    break;
+  case 1:
+    /* printf("TPC only tracks\n"); */
+    fESDTrackCuts = AliESDtrackCuts::GetStandardTPCOnlyTrackCuts();
+    fESDTrackCuts->SetNameTitle(Form("TrackType_%s",GetCutsString()),"Type of tracks: Standard TPC only");
+    fAODFilterBits = 1;
+    tracktype = "FB1. Standard TPC only";
+    break;
+  case 2:
+    /* printf("Global primaries. Tight DCA cut. A hit on SPD:ANY\n"); */
+    switch (fBaseSystem) {
+    case k2010based:
+      fESDTrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010();
+      fESDTrackCuts->SetNameTitle(Form("TrackType_%s",GetCutsString()),"Type of tracks: Global 2010 primaries");
+      fAODFilterBits = 32;
+      tracktype = "FB32. Global primaries ITS+TPC 2010. Tight DCA. SPD:ANY. Number of clusters";
+      break;
+    case k2011based:
+      fESDTrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011();
+      fESDTrackCuts->SetNameTitle(Form("TrackType_%s",GetCutsString()),"Type of tracks: Global 2011 primaries");
+      fAODFilterBits = 32;
+      tracktype = "FB32. Global primaries ITS+TPC 2011. Tight DCA. SPD:ANY. Number of rows";
+      break;
+    default:
+      AliFatal("Internal inconsistency between data period and base period for track cuts selection. ABORTING!!!");
+      return;
+    }
+    break;
+  case 3:
+    /* printf("Global primaries. Tight DCA cut. No hit on SPD\n"); */
+    switch (fBaseSystem) {
+    case k2010based:
+      fESDTrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010();
+      fESDTrackCuts->SetNameTitle(Form("TrackType_%s",GetCutsString()),"Type of tracks: Global SPD:NONE 2010 primaries");
+      fESDTrackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSPD, AliESDtrackCuts::kNone);
+      fESDTrackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSDD, AliESDtrackCuts::kFirst);
+      fAODFilterBits = 64;
+      tracktype = "FB64. Global primaries ITS+TPC 2010. Tight DCA. SPD:NONE, SDD:FIRST. Number of clusters";
+      break;
+    case k2011based:
+      fESDTrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011();
+      fESDTrackCuts->SetNameTitle(Form("TrackType_%s",GetCutsString()),"Type of tracks: Global SPD:NONE 2011 primaries");
+      fESDTrackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSPD, AliESDtrackCuts::kNone);
+      fESDTrackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSDD, AliESDtrackCuts::kFirst);
+      fAODFilterBits = 64;
+      tracktype = "FB64. Global primaries ITS+TPC 2011. Tight DCA. SPD:NONE, SDD:FIRST. Number of rows";
+      break;
+    default:
+      AliFatal("Internal inconsistency between data period and base period for track cuts selection. ABORTING!!!");
+      return;
+    }
+    break;
+  case 4:
+    /* printf("Global primaries plus secondaries. Loose DCA cut. A hit on SPD:ANY\n"); */
+    switch (fBaseSystem) {
+    case k2010based:
+      fESDTrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010(kFALSE);
+      fESDTrackCuts->SetNameTitle(Form("TrackType_%s",GetCutsString()),"Type of tracks: Global 2010 primaries and secondaries");
+      fESDTrackCuts->SetMaxDCAToVertexXY(2.4);
+      fESDTrackCuts->SetMaxDCAToVertexZ(3.2);
+      fESDTrackCuts->SetDCAToVertex2D(kTRUE);
+      fAODFilterBits = 16;
+      tracktype = "FB16. Global primaries plus secondaries ITS+TPC 2010. Loose DCA. ITS:ANY. Number of clusters";
+      break;
+    case k2011based:
+      fESDTrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(kFALSE);
+      fESDTrackCuts->SetNameTitle(Form("TrackType_%s",GetCutsString()),"Type of tracks: Global 2011 primaries and secondaries");
+      fESDTrackCuts->SetMaxDCAToVertexXY(2.4);
+      fESDTrackCuts->SetMaxDCAToVertexZ(3.2);
+      fESDTrackCuts->SetDCAToVertex2D(kTRUE);
+      fAODFilterBits = 16;
+      tracktype = "FB16. Global primaries plus secondaries ITS+TPC 2011. Loose DCA. ITS:ANY. Number of rows";
+      break;
+    default:
+      AliFatal("Internal inconsistency between data period and base period for track cuts selection. ABORTING!!!");
+      return;
+    }
+    break;
+  case 5:
+    /* printf("TPC only tracks to constrain to the SPD vertex\n"); */
+    switch (fBaseSystem) {
+    case k2010based:
+      fESDTrackCuts = AliESDtrackCuts::GetStandardTPCOnlyTrackCuts();
+      fESDTrackCuts->SetNameTitle(Form("TrackType_%s",GetCutsString()),"Type of tracks: Standard TPC only, to constrain to SPD vertex");
+      fESDTrackCuts->SetMinNClustersTPC(70);
+      fAODFilterBits = 128;
+      tracktype = "FB128. Standard TPC only, to constrain to SPD vertex";
+      break;
+    case k2011based:
+      fESDTrackCuts = AliESDtrackCuts::GetStandardTPCOnlyTrackCuts();
+      fESDTrackCuts->SetNameTitle(Form("TrackType_%s",GetCutsString()),"Type of tracks: Standard TPC only, to constrain to SPD vertex");
+      fAODFilterBits = 128;
+      tracktype = "FB128. Standard TPC only, to constrain to SPD vertex";
+      break;
+    default:
+      AliFatal("Internal inconsistency between data period and base period for track cuts selection. ABORTING!!!");
+      return;
+    }
+    break;
+  case 6:
+    /* printf("Global hybrid primaries plus secondaries. Loose DCA cut. A hit on SPD:ANY. TPC shared clusters\n"); */
+    switch (fBaseSystem) {
+    case k2010based: {
+        fESDTrackCuts = new AliESDtrackCuts(Form("TrackType_%s",GetCutsString()),"Type of tracks: Global 2010 hybrid tracks");
+
+        TFormula *f1NClustersTPCLinearPtDep = new TFormula("f1NClustersTPCLinearPtDep","70.+30./20.*x");
+        fESDTrackCuts->SetMinNClustersTPCPtDep(f1NClustersTPCLinearPtDep,20.);
+        fESDTrackCuts->SetMinNClustersTPC(70);
+        fESDTrackCuts->SetMaxChi2PerClusterTPC(4);
+        fESDTrackCuts->SetRequireTPCStandAlone(kTRUE);
+        fESDTrackCuts->SetAcceptKinkDaughters(kFALSE);
+        fESDTrackCuts->SetRequireTPCRefit(kTRUE);
+        fESDTrackCuts->SetMaxFractionSharedTPCClusters(0.4);
+        // ITS
+        fESDTrackCuts->SetRequireITSRefit(kTRUE);
+        fESDTrackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSPD, AliESDtrackCuts::kAny);
+        //accept secondaries
+        fESDTrackCuts->SetMaxDCAToVertexXY(2.4);
+        fESDTrackCuts->SetMaxDCAToVertexZ(3.2);
+        fESDTrackCuts->SetDCAToVertex2D(kTRUE);
+        //reject fakes
+        fESDTrackCuts->SetMaxChi2PerClusterITS(36);
+        fESDTrackCuts->SetMaxChi2TPCConstrainedGlobal(36);
+
+        fESDTrackCuts->SetRequireSigmaToVertex(kFALSE);
+
+        fESDTrackCuts->SetEtaRange(-0.9,0.9);
+        fESDTrackCuts->SetPtRange(0.15);
+
+        fAODFilterBits = 256;
+        tracktype = "Global hybrid 2010 track. Loose DCA. ITS:ANY. Number of clusters";
+      }
+      break;
+    case k2011based:
+      fESDTrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(kFALSE);
+      fESDTrackCuts->SetNameTitle(Form("TrackType_%s",GetCutsString()),"Type of tracks: Global 2011 hybrid tracks");
+      fESDTrackCuts->SetMaxDCAToVertexXY(2.4);
+      fESDTrackCuts->SetMaxDCAToVertexZ(3.2);
+      fESDTrackCuts->SetDCAToVertex2D(kTRUE);
+      fESDTrackCuts->SetMaxChi2TPCConstrainedGlobal(36);
+      fESDTrackCuts->SetMaxFractionSharedTPCClusters(0.4);
+      fAODFilterBits = 256;
+      tracktype = "Global hybrid 2011 tracks. Loose DCA. ITS:ANY. Number of rows";
+      break;
+    default:
+      AliFatal("Internal inconsistency between data period and base period for track cuts selection. ABORTING!!!");
+      return;
+    }
+    break;
+  case 7:
+    /* printf("Global hybrid primaries plus secondaries to constrain. Loose DCA cut. No hit on SPD or ITS refit not required. TPC shared clusters\n"); */
+    switch (fBaseSystem) {
+    case k2010based: {
+        fESDTrackCuts = new AliESDtrackCuts(Form("TrackType_%s",GetCutsString()),"Type of tracks: Global 2010 hybrid tracks to constrain");
+
+        TFormula *f1NClustersTPCLinearPtDep = new TFormula("f1NClustersTPCLinearPtDep","70.+30./20.*x");
+        fESDTrackCuts->SetMinNClustersTPCPtDep(f1NClustersTPCLinearPtDep,20.);
+        fESDTrackCuts->SetMinNClustersTPC(70);
+        fESDTrackCuts->SetMaxChi2PerClusterTPC(4);
+        fESDTrackCuts->SetRequireTPCStandAlone(kTRUE);
+        fESDTrackCuts->SetAcceptKinkDaughters(kFALSE);
+        fESDTrackCuts->SetRequireTPCRefit(kTRUE);
+        fESDTrackCuts->SetMaxFractionSharedTPCClusters(0.4);
+        // ITS
+        /* the full handling requires some additional processing at cut time */
+        fESDTrackCuts->SetRequireITSRefit(kFALSE);
+        fESDTrackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSPD, AliESDtrackCuts::kOff);
+        //accept secondaries
+        fESDTrackCuts->SetMaxDCAToVertexXY(2.4);
+        fESDTrackCuts->SetMaxDCAToVertexZ(3.2);
+        fESDTrackCuts->SetDCAToVertex2D(kTRUE);
+        //reject fakes
+        fESDTrackCuts->SetMaxChi2PerClusterITS(36);
+        fESDTrackCuts->SetMaxChi2TPCConstrainedGlobal(36);
+
+        fESDTrackCuts->SetRequireSigmaToVertex(kFALSE);
+
+        fESDTrackCuts->SetPtRange(0.15);
+
+        fAODFilterBits = 512;
+        tracktype = "FB 512. Global hybrid 2010 track. Loose DCA. ITS:OFF no ITS refit required. Requires processing. Number of clusters";
+      }
+      break;
+    case k2011based:
+      fESDTrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(kFALSE);
+      fESDTrackCuts->SetNameTitle(Form("TrackType_%s",GetCutsString()),"Type of tracks: Global 2011 hybrid tracks to constrain");
+      fESDTrackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSPD,AliESDtrackCuts::kNone);
+      fESDTrackCuts->SetMaxDCAToVertexXY(2.4);
+      fESDTrackCuts->SetMaxDCAToVertexZ(3.2);
+      fESDTrackCuts->SetDCAToVertex2D(kTRUE);
+      fESDTrackCuts->SetMaxChi2TPCConstrainedGlobal(36);
+      fESDTrackCuts->SetMaxFractionSharedTPCClusters(0.4);
+      fAODFilterBits = 512;
+      tracktype = "FB 512. Global hybrid 2011 tracks. Loose DCA. ITS:none. Number of rows";
+      break;
+    default:
+      AliFatal("Internal inconsistency between data period and base period for track cuts selection. ABORTING!!!");
+      return;
+    }
+    break;
+  case 9:
+    fESDTrackCuts = new AliESDtrackCuts(Form("TrackType_%s", GetCutsString()), "Type of tracks: all");
+    fAODFilterBits = 0xFFFF;
+    printf("No track type cut. Accept all\n");
+    break;
+  default:
+    AliError(Form("Stored track type cut code %d not supported", fParameters[kTrackTypeCutParam]));
+  }
+
+  /* report the selected cut */
+  AliInfo("=============== Track type cut ===========================");
+  AliInfo(Form("SYSTEM: %s; PERIOD: %s", system.Data(), period.Data()));
+  AliInfo(Form("TRACK CUT: %s", tracktype.Data()));
+  AliInfo(Form("BASED ON: %s standards cuts", basename.Data()));
+  AliInfo("=============== Track type cut end =======================");
+}
+
+/// Configures the \f$ \eta \f$ cut
+/// \param etacode the \f$ \eta \f$ cut code
+/// | code | \f$ \eta \f$ cut|
+/// |:--:|:--|
+/// | 0 | no \f$ \eta \f$ cut|
+/// | 1 | \f$ -1.4 < \eta < 1.4\f$ |
+/// | 2 | \f$ -1.2 < \eta < 1.2\f$ |
+/// | 3 | \f$ -1.0 < \eta < 1.0\f$ |
+/// | 4 | \f$ -0.9 < \eta < 0.9\f$ |
+/// | 5 | \f$ -0.8 < \eta < 0.8\f$ |
+/// | 6 | \f$ -0.7 < \eta < 0.7\f$ |
+/// | 7 | \f$ -0.6 < \eta < 0.6\f$ |
+/// | 8 | \f$ -0.5 < \eta < 0.5\f$ |
+/// | 9 | \f$ -0.4 < \eta < 0.4\f$ |
+/// \return kTRUE if proper and supported \f$ \eta \f$  cut code
+///
+Bool_t AliCSTrackCuts::SetEtaCut(Int_t etacode){
+  // Set eta Cut
+  switch(etacode){
+    case 0:
+      fCutsEnabledMask.ResetBitNumber(kEtaCut);
+      fEtaCut = 100.;
+      break;
+    case 1:
+      fCutsEnabledMask.SetBitNumber(kEtaCut);
+      fEtaCut = 1.4;
+      break;
+    case 2:
+      fCutsEnabledMask.SetBitNumber(kEtaCut);
+      fEtaCut = 1.2;
+      break;
+    case 3:
+      fCutsEnabledMask.SetBitNumber(kEtaCut);
+      fEtaCut = 1.0;
+      break;
+    case 4:
+      fCutsEnabledMask.SetBitNumber(kEtaCut);
+      fEtaCut = 0.9;
+      break;
+    case 5:
+      fCutsEnabledMask.SetBitNumber(kEtaCut);
+      fEtaCut = 0.8;
+      break;
+    case 6:
+      fCutsEnabledMask.SetBitNumber(kEtaCut);
+      fEtaCut = 0.75;
+      break;
+    case 7:
+      fCutsEnabledMask.SetBitNumber(kEtaCut);
+      fEtaCut = 0.6;
+      break;
+    case 8:
+      fCutsEnabledMask.SetBitNumber(kEtaCut);
+      fEtaCut = 0.5;
+      break;
+    case 9:
+      fCutsEnabledMask.SetBitNumber(kEtaCut);
+      fEtaCut = 0.4;
+      break;
+    default:
+      AliError(Form("Eta cut code %d not supported", etacode));
+      return kFALSE;
+  }
+  return kTRUE;
+}
+
+/// Configures the ITS clusters cut
+/// \param ITSclscode the ITS clusters cut code
+/// | code | hits in ITS | hits in SPD |
+/// |:--:|:--| :--|
+/// | 0 | as standard for selected tracks in data period | same |
+/// | 1 | n/a | at least one on first layer |
+/// | 2 | n/a | at least one on any layer |
+/// | 3 | at least 4 | at least one on first layer |
+/// | 4 | at least 3 | at least one on any layer |
+/// | 5 | at least 4 | at least one on any layer |
+/// | 6 | at least 5 | at least one on any layer |
+/// | 7 | n/a | none |
+/// | 8 | SDD:FIRST | none |
+/// | 9 | no ITS required | no ITS required |
+/// \return kTRUE if proper and supported ITS clusters cut code
+///
+Bool_t AliCSTrackCuts::SetITSClustersCut(Int_t ITSclscode){
+
+  switch(ITSclscode){
+    case 0: // as standard for selected tracks in data period
+      break;
+    case 1: //1 hit first layer of SPD
+      break;
+    case 2: //1 hit in any layer of SPD
+      break;
+    case 3: // 4 hits in total in the ITS. At least 1 hit in the first layer of SPD
+      break;
+    case 4: // 3 hits in total in the ITS. At least 1 hit in any layer of SPD
+      break;
+    case 5: // 4 hits in total in the ITS. At least 1 hit in any layer of SPD
+      break;
+    case 6: // 5 hits in total in the ITS. At least 1 hit in any layer of SPD
+      break;
+    case 7: // no hits on the SPD
+      break;
+    case 8: // hit in first layer of SDD. No hits on the SPD
+      break;
+    case 9: // no ITS required
+      break;
+    default:
+      AliError(Form("ITS cluster cut code %d not supported", ITSclscode));
+      return kFALSE;
+  }
+  return kTRUE;
+}
+
+/// Configures the actual ITS clusters cut once configured for the data period
+/// and according to the corresponding cut parameter
+void AliCSTrackCuts::SetActualITSClustersCut(){
+
+  if(!fESDTrackCuts ) {
+    AliFatal("AliESDtrackCut is not initialized. ABORTING!!!");
+  }
+
+  switch(fParameters[kITSClsCutParam]){
+    case 0: // as standard for selected tracks in data period
+      /* do nothing */
+      break;
+    case 1: //1 hit first layer of SPD
+      fESDTrackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSPD, AliESDtrackCuts::kFirst);
+      break;
+    case 2: //1 hit in any layer of SPD
+      fESDTrackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSPD, AliESDtrackCuts::kAny);
+      break;
+    case 3: // 4 hits in total in the ITS. At least 1 hit in the first layer of SPD
+      fESDTrackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSPD, AliESDtrackCuts::kFirst);
+      fESDTrackCuts->SetMinNClustersITS(4);
+      break;
+    case 4: // 3 hits in total in the ITS. At least 1 hit in any layer of SPD
+      fESDTrackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSPD, AliESDtrackCuts::kAny);
+      fESDTrackCuts->SetMinNClustersITS(3);
+      break;
+    case 5: // 4 hits in total in the ITS. At least 1 hit in any layer of SPD
+      fESDTrackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSPD, AliESDtrackCuts::kAny);
+      fESDTrackCuts->SetMinNClustersITS(4);
+      break;
+    case 6: // 5 hits in total in the ITS. At least 1 hit in any layer of SPD
+      fESDTrackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSPD, AliESDtrackCuts::kAny);
+      fESDTrackCuts->SetMinNClustersITS(5);
+      break;
+    case 7: // no hits on the SPD
+      fESDTrackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSPD, AliESDtrackCuts::kNone);
+      break;
+    case 8: // hit in first layer of SDD. No hits on any layer of SPD
+      fESDTrackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSPD, AliESDtrackCuts::kNone);
+      fESDTrackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSDD, AliESDtrackCuts::kFirst);
+      break;
+    case 9:
+      fESDTrackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSPD, AliESDtrackCuts::kOff);
+      break;
+    default:
+      AliError(Form("ITS cluster cut code %d not supported", fParameters[kITSClsCutParam]));
+  }
+}
+
+/// Prints the ITS clusters cut
+void AliCSTrackCuts::PrintITSClustersCut() const {
+  switch(fParameters[kITSClsCutParam]){
+    case 0:
+      printf("as standard for selected tracks in data period\n");
+      break;
+    case 1: //1 hit first layer of SPD
+      printf("first SPD layer required\n");
+      break;
+    case 2: //1 hit in any layer of SPD
+      printf("any of the SPD layers required\n");
+      break;
+    case 3: // 4 hits in total in the ITS. At least 1 hit in the first layer of SPD
+      printf("first SPD layer required; at least four hits in the whole ITS\n");
+      break;
+    case 4: // 3 hits in total in the ITS. At least 1 hit in any layer of SPD
+      printf("any of the SPD layers required; at least three hits in the whole ITS\n");
+      break;
+    case 5: // 4 hits in total in the ITS. At least 1 hit in any layer of SPD
+      printf("any of the SPD layers required; at least four hits in the whole ITS\n");
+      break;
+    case 6: // 5 hits in total in the ITS. At least 1 hit in any layer of SPD
+      printf("any of the SPD layers required; at least five hits in the whole ITS\n");
+      break;
+    case 7: // no hits on the SPD
+      printf("no hit on the SPD\n");
+      break;
+    case 8: // hit in first layer of SDD. No hists on the SPD
+      printf("no hit on the SPD; hit in the first layer of the SDD\n");
+      break;
+    case 9:
+      printf("no SPD hits required\n");
+      break;
+    default:
+      AliError(Form("Wrong ITS cluster cut code %d stored", fParameters[kITSClsCutParam]));
+  }
+}
+
+/// Configures the TPC clusters cut
+/// \param TPCclscode the TPC clusters cut code
+/// | code | TPC clusters cut |
+/// |:--:|:--|
+/// | 0 | as standard for selected tracks in data period |
+/// | 1 | minimum 70 clusters |
+/// | 2 | minimum 80 clusters |
+/// | 3 | minimum 100 clusters |
+/// | 4 | minimum 50 crossed rows, minimum crossed rows / findable clusters ratio 60% |
+/// | 5 | minimum 70 crossed rows, minimum crossed rows / findable clusters ratio 70% |
+/// | 6 | minimum 70 crossed rows, minimum crossed rows / findable clusters ratio 80% |
+/// | 7 | minimum 70 crossed rows, minimum crossed rows / findable clusters ratio 90% |
+/// | | |
+/// | 9 | none |
+/// \return kTRUE if proper and supported TPC clusters cut code
+///
+Bool_t AliCSTrackCuts::SetTPCClustersCut(Int_t TPCclscode){
+
+  switch(TPCclscode){
+    case 0: // as standard for selected tracks in data period
+      break;
+    case 1:  // min 70 clusters
+      break;
+    case 2:  // min 80 clusters
+      break;
+    case 3:  // min 100
+      break;
+    case 4:  // min 50 crossed rows, min 60% crossed rows over findable clusters
+      break;
+    case 5:  // min 70 crossed rows, min 70% crossed rows over findable clusters
+      break;
+    case 6:  // min 70 crossed rows, min 80% crossed rows over findable clusters
+      break;
+    case 7:  // min 70 crossed rows, min 90% crossed rows over findable clusters
+      break;
+    case 9: // disable it
+      break;
+    default:
+      AliError(Form("TPC cluster cut code %d not supported", TPCclscode));
+      return kFALSE;
+  }
+  return kTRUE;
+}
+
+/// Configures the actual TPC clusters cut once configured for the data period
+/// and according to the corresponding cut parameter
+void AliCSTrackCuts::SetActualTPCClustersCut(){
+
+  if(!fESDTrackCuts ) {
+    AliFatal("AliESDtrackCut is not initialized. ABORTING!!!");
+  }
+
+  switch(fParameters[kTPCClsCutParam]){
+    case 0: // as standard for selected tracks in data period
+      /* do nothing */
+      break;
+    case 1:  // min 70 clusters
+      fESDTrackCuts->SetMinNClustersTPC(70);
+      break;
+    case 2:  // min 80 clusters
+      fESDTrackCuts->SetMinNClustersTPC(80);
+      break;
+    case 3:  // min 100
+      fESDTrackCuts->SetMinNClustersTPC(100);
+      break;
+    case 4:  // min 50 crossed rows, min 60% crossed rows over findable clusters
+      fESDTrackCuts->SetMinNCrossedRowsTPC(50);
+      fESDTrackCuts->SetMinRatioCrossedRowsOverFindableClustersTPC(0.6);
+      break;
+    case 5:  // min 70 crossed rows, min 70% crossed rows over findable clusters
+      fESDTrackCuts->SetMinNCrossedRowsTPC(70);
+      fESDTrackCuts->SetMinRatioCrossedRowsOverFindableClustersTPC(0.7);
+      break;
+    case 6:  // min 70 crossed rows, min 80% crossed rows over findable clusters
+      fESDTrackCuts->SetMinNCrossedRowsTPC(70);
+      fESDTrackCuts->SetMinRatioCrossedRowsOverFindableClustersTPC(0.8);
+      break;
+    case 7:  // min 70 crossed rows, min 90% crossed rows over findable clusters
+      fESDTrackCuts->SetMinNCrossedRowsTPC(70);
+      fESDTrackCuts->SetMinRatioCrossedRowsOverFindableClustersTPC(0.9);
+      break;
+    case 9: // disable it
+      fESDTrackCuts->SetMinNClustersTPC();
+      break;
+    default:
+      AliError(Form("TPC cluster cut code %d not supported", fParameters[kTPCClsCutParam]));
+  }
+}
+
+/// Prints the TPC clusters cut
+void AliCSTrackCuts::PrintTPCClustersCut() const {
+
+  switch(fParameters[kTPCClsCutParam]){
+    case 0:
+      printf("TPC clusters cut as standard for selected tracks in data period\n");
+      break;
+    case 1:  // min 70 clusters
+      printf("minimum 70 clusters required\n");
+      break;
+    case 2:  // min 80 clusters
+      printf("minimum 80 clusters required\n");
+      break;
+    case 3:  // min 100
+      printf("minimum 100 clusters required\n");
+      break;
+    case 4:  // min 50 crossed rows, min 60% crossed rows over findable clusters
+      printf("minimum 50 crossed rows required, minimum 60%% crossed rows to findable clusters ratio\n");
+      break;
+    case 5:  // min 70 crossed rows, min 70% crossed rows over findable clusters
+      printf("minimum 70 crossed rows required, minimum 70%% crossed rows to findable clusters ratio\n");
+      break;
+    case 6:  // min 70 crossed rows, min 80% crossed rows over findable clusters
+      printf("minimum 70 crossed rows required, minimum 80%% crossed rows to findable clusters ratio\n");
+      break;
+    case 7:  // min 70 crossed rows, min 90% crossed rows over findable clusters
+      printf("minimum 70 crossed rows required, minimum 90%% crossed rows to findable clusters ratio\n");
+      break;
+    case 9:
+      printf("no TPC clusters cut required\n");
+      break;
+    default:
+      AliError(Form("Wrong TPC cluster cut code %d stored", fParameters[kTPCClsCutParam]));
+  }
+}
+
+/// Configures the track DCA cut
+/// \param dcacode the DCA cut code
+/// | code | max \f$ \mbox{DCA}_{XY} \f$ to vertex | max \f$ \mbox{DCA}_{Z} \f$ to vertex |
+/// |:--:|:--:|:--:|
+/// | 0 | as standard for selected tracks in data period | as standard for selected tracks in data period |
+/// | 1 | tight DCA according to the data period | tight DCA according to the data period |
+/// | 2 | loose DCA according to the data period | loose DCA according to the data period |
+/// | 3 | tight DCA according to the data period | 1 |
+/// | 4 | tight DCA according to the data period | 5 |
+/// | 5 | 1 cm | 2 cm |
+/// | 6 | \f$ 0.0525+\frac{0.175}{p_t^{1.1}} \f$ | 2 |
+/// | 9 | not active cut | not active cut |
+/// \return kTRUE if proper and supported DCA cut code
+///
+Bool_t AliCSTrackCuts::SetDCACut(Int_t dcacode)
+{
+  switch(dcacode){
+    case 0:
+      break;
+    case 1:
+      break;
+    case 2:
+      break;
+    case 3:
+      break;
+    case 4:
+      break;
+    case 5:
+      break;
+    case 6:
+      break;
+    case 9:
+      break;
+    default:
+      AliError(Form("DCA cut code %d not supported", dcacode));
+      return kFALSE;
+  }
+  return kTRUE;
+}
+
+/// Configures the actual DCA cut once configured for the data period
+/// and according to the corresponding cut parameter
+void AliCSTrackCuts::SetActualDCACut()
+{
+  if(!fESDTrackCuts ) {
+    AliFatal("AliESDtrackCut is not initialized. ABORTING!!!");
+  }
+  switch(fParameters[kDCACutParam]){
+    case 0: // as standard for selected tracks in data period
+      /* do nothing */
+      break;
+    case 1: /* tight, tight */
+      switch (fBaseSystem) {
+        case k2010based:
+          fESDTrackCuts->SetMaxDCAToVertexXYPtDep("0.0182+0.0350/pt^1.01");
+          fESDTrackCuts->SetMaxDCAToVertexZ(2);
+          fESDTrackCuts->SetDCAToVertex2D(kFALSE);
+          break;
+        case k2011based:
+          fESDTrackCuts->SetMaxDCAToVertexXYPtDep("0.0105+0.0350/pt^1.1");
+          fESDTrackCuts->SetMaxDCAToVertexZ(2);
+          fESDTrackCuts->SetDCAToVertex2D(kFALSE);
+          break;
+        default:
+        /* do nothing */
+          break;
+      }
+      break;
+    case 2: /* loose, loose */
+      switch (fBaseSystem) {
+        case k2010based:
+        case k2011based:
+          fESDTrackCuts->SetMaxDCAToVertexXY(2.4);
+          fESDTrackCuts->SetMaxDCAToVertexZ(3.2);
+          fESDTrackCuts->SetDCAToVertex2D(kTRUE);
+          break;
+        default:
+        /* do nothing */
+          break;
+      }
+      break;
+    case 3: /* tight, 1 cm */
+      switch (fBaseSystem) {
+        case k2010based:
+          fESDTrackCuts->SetMaxDCAToVertexXYPtDep("0.0182+0.0350/pt^1.01");
+          fESDTrackCuts->SetMaxDCAToVertexZ(1);
+          fESDTrackCuts->SetDCAToVertex2D(kFALSE);
+          break;
+        case k2011based:
+          fESDTrackCuts->SetMaxDCAToVertexXYPtDep("0.0105+0.0350/pt^1.1");
+          fESDTrackCuts->SetMaxDCAToVertexZ(1);
+          fESDTrackCuts->SetDCAToVertex2D(kFALSE);
+          break;
+        default:
+        /* do nothing */
+          break;
+      }
+      break;
+    case 4: /* tight, 5 cm */
+      switch (fBaseSystem) {
+        case k2010based:
+          fESDTrackCuts->SetMaxDCAToVertexXYPtDep("0.0182+0.0350/pt^1.01");
+          fESDTrackCuts->SetMaxDCAToVertexZ(5);
+          fESDTrackCuts->SetDCAToVertex2D(kFALSE);
+          break;
+        case k2011based:
+          fESDTrackCuts->SetMaxDCAToVertexXYPtDep("0.0105+0.0350/pt^1.1");
+          fESDTrackCuts->SetMaxDCAToVertexZ(5);
+          fESDTrackCuts->SetDCAToVertex2D(kFALSE);
+          break;
+        default:
+        /* do nothing */
+          break;
+      }
+      break;
+    case 5: /* 1 cm , 2, cm */
+      fESDTrackCuts->SetMaxDCAToVertexXY(1);
+      fESDTrackCuts->SetMaxDCAToVertexZ(2);
+      fESDTrackCuts->SetDCAToVertex2D(kTRUE);
+      break;
+    case 6: /* specific */
+      fESDTrackCuts->SetMaxDCAToVertexXYPtDep("0.0525+0.175/pt^1.1");
+      fESDTrackCuts->SetMaxDCAToVertexZ(2);
+      fESDTrackCuts->SetDCAToVertex2D(kFALSE);
+      break;
+    case 9:
+      fESDTrackCuts->SetMaxDCAToVertexZ(1000);
+      fESDTrackCuts->SetMaxDCAToVertexXY(1000);
+      fESDTrackCuts->SetDCAToVertex2D(kFALSE);
+      break;
+    default:
+      AliError(Form("DCA cut code %d not supported", fParameters[kDCACutParam]));
+  }
+}
+
+/// Prints the DCA cut information
+void AliCSTrackCuts::PrintDCACut() const
+{
+  switch(fParameters[kDCACutParam]){
+    case 0:
+      printf("as standard for selected tracks in data period\n");
+      break;
+    case 1:
+      printf("Z: tight according to the data period, XY: tight according to the data period\n");
+      break;
+    case 2:
+      printf("Z: loose according to the data period, XY: loose according to the data period\n");
+      break;
+    case 3:
+      printf("Z: 1 cm, XY: tight according to the data period\n");
+      break;
+    case 4:
+      printf("Z: 5 cm, XY: loose according to the data period\n");
+      break;
+    case 5:
+      printf("Z: 2 cm, XY: 1 cm\n");
+      break;
+    case 6:
+      printf("Z: 2 cm, XY: 0.0525+0.175/pt^1.1\n");
+      break;
+    case 9:
+      printf("none\n");
+      break;
+    default:
+      AliError(Form("Wrong DCA cut code %d stored", fParameters[kDCACutParam]));
+  }
+}
+
+/// Configures the \f$ p_{T} \f$ cut
+/// \param ptcode the \f$ p_{T} \f$ cut code
+/// | code | minimum \f$ p_{T} \f$ (GeV/c) | maximum \f$ p_{T} \f$ (GeV/c) |
+/// |:--:|:--:|:--:|
+/// | 0 | not active cut | not active cut |
+/// | 1 | 0.2 | 2.0 |
+/// | 2 | 0.2 | 3.0 |
+/// | 3 | 0.2 | 5.0 |
+/// | 4 | 0.2 | 1.4 |
+/// | 5 | 0.2 | 1.6 |
+/// | 6 | 0.2 | 1.8 |
+/// \return kTRUE if proper and supported \f$ p_{T} \f$ cut code
+///
+Bool_t AliCSTrackCuts::SetPtCut(Int_t ptcode)
+{
+  switch(ptcode){
+  case 0:
+    fCutsEnabledMask.ResetBitNumber(kPtCut);
+    fMinPt = 0.0;
+    fMaxPt = 9999.0;
+    break;
+  case 1:
+    fCutsEnabledMask.SetBitNumber(kPtCut);
+    fMinPt = 0.2;
+    fMaxPt = 2.0;
+    break;
+  case 2:
+    fCutsEnabledMask.SetBitNumber(kPtCut);
+    fMinPt = 0.2;
+    fMaxPt = 3.0;
+    break;
+  case 3:
+    fCutsEnabledMask.SetBitNumber(kPtCut);
+    fMinPt = 0.2;
+    fMaxPt = 5.0;
+    break;
+  case 4:
+    fCutsEnabledMask.SetBitNumber(kPtCut);
+    fMinPt = 0.2;
+    fMaxPt = 1.4;
+    break;
+  case 5:
+    fCutsEnabledMask.SetBitNumber(kPtCut);
+    fMinPt = 0.2;
+    fMaxPt = 1.6;
+    break;
+  case 6:
+    fCutsEnabledMask.SetBitNumber(kPtCut);
+    fMinPt = 0.2;
+    fMaxPt = 1.8;
+    break;
+  default:
+    AliError(Form("Pt cut code %d not supported", ptcode));
+    return kFALSE;
+  }
+  return kTRUE;
+}
+
+/// Initializes the cuts
+///
+/// Initializes the needed data and allocates the needed histograms list if needed
+/// \param name an additional name to precede the cuts string
+void AliCSTrackCuts::InitCuts(const char *name){
+
+  if (name == NULL) name = GetName();
+
+  if (fQALevel > kQALevelNone) {
+    Bool_t oldstatus = TH1::AddDirectoryStatus();
+    TH1::AddDirectory(kFALSE);
+
+    if(fHistogramsList != NULL)
+      delete fHistogramsList;
+
+    fHistogramsList =new TList();
+    fHistogramsList->SetOwner(kTRUE);
+    fHistogramsList->SetName(name);
+
+    TH1::AddDirectory(oldstatus);
+  }
+}
+
+/// Allocates the different histograms if needed
+///
+/// It is supposed that the current cuts string is the running one
+void AliCSTrackCuts::DefineHistograms(){
+
+  if (fQALevel > kQALevelNone) {
+    Bool_t oldstatus = TH1::AddDirectoryStatus();
+    TH1::AddDirectory(kFALSE);
+
+    /* the original name is used as title for the statistics histogram so, preserve it */
+    TString originalTempName = fHistogramsList->GetName();
+    fHistogramsList->SetName(Form("%s_%s",fHistogramsList->GetName(),GetCutsString()));
+
+    fhCutsStatistics = new TH1F(Form("CutsStatistics_%s",GetCutsString()),Form("%s tracks cuts statistics",originalTempName.Data()),kNCuts+4,-0.5,kNCuts+3.5);
+    fhCutsStatistics->GetXaxis()->SetBinLabel(1,"n tracks");
+    fhCutsStatistics->GetXaxis()->SetBinLabel(2,"n cut tracks");
+    for (Int_t i = 0; i < kNCuts; i++)
+      fhCutsStatistics->GetXaxis()->SetBinLabel(i+4, fgkCutsNames[i]);
+    fHistogramsList->Add(fhCutsStatistics);
+
+    if(fQALevel == kQALevelHeavy){
+      fhCutsCorrelation = new TH2F(Form("CutCorrelation_%s",GetCutsString()),"Cuts correlation",kNCuts+2,-0.5,kNCuts+1.5,kNCuts+2,-0.5,kNCuts+1.5);
+      for (Int_t i=0; i<kNCuts; i++) {
+        fhCutsCorrelation->GetXaxis()->SetBinLabel(i+2,fgkCutsNames[i]);
+        fhCutsCorrelation->GetYaxis()->SetBinLabel(i+2,fgkCutsNames[i]);
+      }
+      fHistogramsList->Add(fhCutsCorrelation);
+    }
+
+    fhPtVsDCAxy[0]  = new TH2F(Form("PtVsDCAxyPtB_%s",GetCutsString()),"p_{T} vs DCA_{XY} before;DCA_{XY} (cm);p_{T} (GeV/c)",800,-4.0,4.0,400,0.,10.);
+    fhPtVsDCAxy[1]  = new TH2F(Form("PtVsDCAxyPtA_%s",GetCutsString()),"p_{T} vs DCA_{XY};DCA_{XY} (cm);p_{T} (GeV/c)",800,-4.0,4.0,400,0.,10.);
+    fHistogramsList->Add(fhPtVsDCAxy[0]);
+    fHistogramsList->Add(fhPtVsDCAxy[1]);
+
+    fhPtVsDCAz[0]  = new TH2F(Form("PtVsDCAzPtB_%s",GetCutsString()),"p_{T} vs DCA_{Z} before;DCA_{Z} (cm);p_{T} (GeV/c)",800,-4.0,4.0,400,0.,10.);
+    fhPtVsDCAz[1]  = new TH2F(Form("PtVsDCAzPtA_%s",GetCutsString()),"p_{T} vs DCA_{Z};DCA_{Z} (cm);p_{T} (GeV/c)",800,-4.0,4.0,400,0.,10.);
+    fHistogramsList->Add(fhPtVsDCAz[0]);
+    fHistogramsList->Add(fhPtVsDCAz[1]);
+
+    fhPtVsTPCCls[0]  = new TH2F(Form("PtVsTPCClustersB_%s",GetCutsString()),"p_{T} vs no. of TPC clusters before;no of clusters;p_{T} (GeV/c)",170,0,170,400,0.,10.);
+    fhPtVsTPCCls[1]  = new TH2F(Form("PtVsTPCClustersA_%s",GetCutsString()),"p_{T} vs no. of TPC clusters;no of clusters;p_{T} (GeV/c)",170,0,170,400,0.,10.);
+    fHistogramsList->Add(fhPtVsTPCCls[0]);
+    fHistogramsList->Add(fhPtVsTPCCls[1]);
+
+    fhPtVsTPCRowOverFindCls[0] = new TH2F(Form("PtVsTPCCROFCB_%s",GetCutsString()),
+        "p_{T} vs TPC crossed rows findable clusters ratio before;crossed rows / findable clusters;p_{T} (GeV/c)",100,0,1,400,0.,10.);
+    fhPtVsTPCRowOverFindCls[1] = new TH2F(Form("PtVsTPCCROFCA_%s",GetCutsString()),
+        "p_{T} vs TPC crossed rows findable clusters ratio;crossed rows / findable clusters;p_{T} (GeV/c)",100,0,1,400,0.,10.);
+    fHistogramsList->Add(fhPtVsTPCRowOverFindCls[0]);
+    fHistogramsList->Add(fhPtVsTPCRowOverFindCls[1]);
+    fhPtVsEta[0] = new TH2F(Form("PtVsEtaB_%s",GetCutsString()),"p_{T} vs #eta before;#eta;p_{T} (GeV/c)",100,-2.0,2.0,400,0.,10.);
+    fhPtVsEta[1] = new TH2F(Form("PtVsEtaA_%s",GetCutsString()),"p_{T} vs #eta;#eta;p_{T} (GeV/c)",100,-2.0,2.0,400,0.,10.);
+    fHistogramsList->Add(fhPtVsEta[0]);
+    fHistogramsList->Add(fhPtVsEta[1]);
+
+    if(fQALevel == kQALevelHeavy){
+      fhEtaVsPhi[0] = new TH2F(Form("EtaVsPhiB_%s",GetCutsString()),"#eta vs #phi before;#phi;#eta", 360, 0.0, 360.0, 100, -2.0, 2.0);
+      fhEtaVsPhi[1] = new TH2F(Form("EtaVsPhiA_%s",GetCutsString()),"#eta vs #phi;#phi;#eta", 360, 0.0, 360.0, 100, -2.0, 2.0);
+      fHistogramsList->Add(fhEtaVsPhi[0]);
+      fHistogramsList->Add(fhEtaVsPhi[1]);
+
+      fESDTrackCuts->SetHistogramsOn(kTRUE);
+      fESDTrackCuts->DefineHistograms();
+      fHistogramsList->Add(fESDTrackCuts);
+    }
+
+    TH1::AddDirectory(oldstatus);
+  }
+}
+
+/// \cond CLASSIMP
+ClassImp(AliCSTrackCuts);
+/// \endcond

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSTrackCuts.h
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSTrackCuts.h
@@ -1,0 +1,149 @@
+#ifndef ALICSTRACKCUTS_H
+#define ALICSTRACKCUTS_H
+
+/// \file AliCSTrackCuts.h
+/// \brief Track selection cuts support for the correlations studies tasks
+///
+/// Based on ideas taken from Gamma Conversion analysis under PWGGA and from AliESDTrackCuts
+
+#include "AliAnalysisUtils.h"
+#include "AliCSTrackCutsBase.h"
+
+class TH1F;
+class TH2F;
+class AliESDtrackCuts;
+class AliVTrack;
+class TParticle;
+
+/// \class AliCSTrackCuts
+/// \brief Class which implements track selection cuts
+///
+/// Provides support for configuring track selection cuts.
+/// It is derived from #AliCSAnalysisCutsBase so it incorporates
+/// the cuts string in all output histograms.
+///
+/// Based on Gamma Conversion analysis implementation within PWGGA
+///
+/// \author Víctor González <victor.gonzalez@cern.ch>, UCM
+/// \date Oct 17, 2016
+
+class AliCSTrackCuts : public AliCSTrackCutsBase {
+public:
+
+  /// \enum cutsParametersIds
+  /// \brief The ids of the different track cuts parameters supported
+  enum cutsParametersIds {
+    kTrackTypeCutParam,              ///< The type of track cut parameters
+    kEtaCutParam,                    ///< \f$ \eta \f$ cut parameters
+    kITSClsCutParam,                 ///< ITS clusters cut parameters
+    kTPCClsCutParam,                 ///< TPC clusters cut parameters
+    kDCACutParam,                    ///< DCA cut parameters
+    kPtCutParam,                     ///< \f$ p_{T} \f$ cut parameters
+    kNCutsParameters                 ///< the number of track cuts parameters
+  };
+
+  /// \enum cutsIds
+  /// \brief The ids of the different track cuts currently supported
+  enum cutsIds {
+    kNotConstrainedCut,              ///< not constrained information cut
+    kEtaCut,                         ///< \f$ \eta \f$ cut
+    kTrackTypeCuts,                  ///< ESD track cuts machinery. Includes ITS clusters, TPC clusters and DCA cuts
+    kPtCut,                          ///< \f$ p_{T} \f$ cut
+    kNCuts                           ///< The number of supported cuts
+  };
+
+private:
+  /// \enum baseSystems
+  /// \brief The ids of the systems used as base for the track cuts
+  enum baseSystems {
+    kUnknownBase,                    ///< no system base
+    k2010based,                      ///< 2010 based system
+    k2011based                       ///< 2011 based system
+  };
+
+public:
+
+                                     AliCSTrackCuts();
+                                     AliCSTrackCuts(const char *name, const char * title);
+  virtual                           ~AliCSTrackCuts();
+
+  virtual void                       InitCuts(const char *name = NULL);
+  virtual void                       NotifyRun();
+  virtual void                       NotifyEvent();
+  virtual Bool_t                     IsTrackAccepted(AliVTrack *trk);
+  virtual Bool_t                     IsTrueTrackAccepted(AliVTrack *trk);
+  virtual Bool_t                     IsTrueTrackAccepted(Int_t itrk);
+                                     /// Does the current track need to be constrained
+                                     /// \return kTRUE if the track needs to be constrained kFALSE otherwise
+  virtual Bool_t                     GetConstrain() { return fConstrain; }
+
+  static Bool_t                      IsTruePrimary(AliVTrack *trk);
+
+private:
+  virtual Bool_t                     AcceptTrackType(AliVTrack *trk, AliVTrack *&ttrk);
+  void                               SetActualTypeOfTrackCuts();
+  void                               SetActualITSClustersCut();
+  void                               SetActualTPCClustersCut();
+  void                               SetActualDCACut();
+
+  void                               DefineHistograms();
+
+private:
+  /* we set them private to force cuts string consistency */
+  Bool_t                             SetTypeOfTrackCut(Int_t ttype);
+  Bool_t                             SetEtaCut(Int_t etacode);
+  Bool_t                             SetITSClustersCut(Int_t ITSclscode);
+  Bool_t                             SetTPCClustersCut(Int_t TPCclscode);
+  Bool_t                             SetDCACut(Int_t dcacode);
+  Bool_t                             SetPtCut(Int_t ptcode);
+
+private:
+  virtual Bool_t                     SetCutAndParams(Int_t paramID, Int_t value);
+  virtual void                       PrintCutWithParams(Int_t paramID) const;
+  void                               PrintTypeOfTrackCut() const;
+  void                               PrintITSClustersCut() const;
+  void                               PrintTPCClustersCut() const;
+  void                               PrintDCACut() const;
+
+private:
+  static const char                 *fgkCutsParametersNames[kNCutsParameters];     ///< the names of the different event cuts parameters
+  static const char                 *fgkCutsNames[kNCuts];                         ///< the names of the different event cuts
+
+  Bool_t                             fConstrain;                         ///< the current track has been constrained so, it needs to be constrained
+
+  baseSystems                        fBaseSystem;                        ///< the id of the system used as base for the cuts in the current analysis
+  Double_t                           fEtaCut;                            ///< the maximum value of \f$ | \eta | \f$
+  Double_t                           fMinPt;                             ///< the minimum \f$ p_{T} \f$ value
+  Double_t                           fMaxPt;                             ///< the maximum \f$ p_{T} \f$ value
+  Double_t                           fEtaShift;                          ///< shift in pseudo-rapidity when asymmetric system (eg. pPb)
+
+  AliESDtrackCuts                   *fESDTrackCuts;                      ///< the ESD track cuts instance
+  UInt_t                             fAODFilterBits;                     ///< the AOD track filter bits selected
+
+
+  /* histograms with two indices: before (0) / after (1) applying the cut */
+  TH1F                              *fhCutsStatistics;                   ///< the cuts statistics
+  TH2F                              *fhCutsCorrelation;                  ///< cuts correlation
+  TH2F                              *fhPtVsDCAxy[2];                     ///< \f$ p_{T} \f$ vs \f$ \mbox{DCA}_{XY} \f$ (b/a)
+  TH2F                              *fhPtVsDCAz[2];                      ///< \f$ p_{T} \f$ vs \f$ \mbox{DCA}_{Z} \f$ (b/a)
+  TH2F                              *fhPtVsTPCCls[2];                    ///< \f$ p_{T} \f$ vs TPC clusters (b/a)
+  TH2F                              *fhPtVsTPCRowOverFindCls[2];         ///< \f$ p_{T} \f$ vs TPC crossed rows findable clusters ratio (b/a)
+  TH2F                              *fhEtaVsPhi[2];                      ///< \f$ p_{T} \f$ vs \f$ \eta \f$ (b/a)
+  TH2F                              *fhPtVsEta[2];                       ///< \f$ p_{T} \f$ vs \f$ \eta \f$ (b/a)
+
+  /// Copy constructor
+  /// Not allowed. Forced private.
+  AliCSTrackCuts(const AliCSTrackCuts&);
+  /// Assignment operator
+  /// Not allowed. Forced private.
+  /// \return l-value reference object
+  AliCSTrackCuts& operator=(const AliCSTrackCuts&);
+
+  /// \cond CLASSIMP
+  ClassDef(AliCSTrackCuts,3);
+  /// \endcond
+};
+
+
+
+#endif /* ALICSTRACKCUTS_H */

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSTrackCutsBase.cxx
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSTrackCutsBase.cxx
@@ -1,0 +1,46 @@
+/**************************************************************************
+* Copyright(c) 1998-2017, ALICE Experiment at CERN, All rights reserved.  *
+*                                                                         *
+* Permission to use, copy, modify and distribute this software and its    *
+* documentation strictly for non-commercial purposes is hereby granted    *
+* without fee, provided that the above copyright notice appears in all    *
+* copies and that both the copyright notice and this permission notice    *
+* appear in the supporting documentation. The authors make no claims      *
+* about the suitability of this software for any purpose. It is           *
+* provided "as is" without express or implied warranty.                   *
+**************************************************************************/
+
+#include <TTree.h>
+#include <TFile.h>
+#include "AliLog.h"
+#include "AliCSTrackCutsBase.h"
+
+/// \file AliCSTrackCutsBase.cxx
+/// \brief Implementation of abstract base track cuts class within the correlation studies analysis
+
+/// Default constructor for serialization
+AliCSTrackCutsBase::AliCSTrackCutsBase() :
+    AliCSAnalysisCutsBase()
+{
+}
+
+/// Constructor
+/// Allocates the needed memory for the number of cuts to support
+/// \param nCuts the number of cuts to support
+/// \param nParams the number of cuts parameters
+/// \param name name of the event cuts
+/// \param title title of the event cuts
+AliCSTrackCutsBase::AliCSTrackCutsBase(Int_t nCuts, Int_t nParams, const char *name, const char *title) :
+    AliCSAnalysisCutsBase(nCuts, nParams, name, title)
+{
+}
+
+/// Destructor
+AliCSTrackCutsBase::~AliCSTrackCutsBase()
+{
+}
+
+
+/// \cond CLASSIMP
+ClassImp(AliCSTrackCutsBase);
+/// \endcond

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSTrackCutsBase.h
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSTrackCutsBase.h
@@ -1,0 +1,66 @@
+#ifndef ALICSTRACKCUTSBASE_H
+#define ALICSTRACKCUTSBASE_H
+
+/// \file AliCSTrackCutsBase.h
+/// \brief Base track cuts support for the correlations studies tasks
+///
+
+#include "AliCSAnalysisCutsBase.h"
+
+class AliVTrack;
+
+/// \class AliCSTrackCutsBase
+/// \brief Track cuts base class for correlation studies analysis
+///
+/// Abstract class support for different kind of tracks cuts.
+///
+/// \author Víctor González <victor.gonzalez@cern.ch>, UCM
+/// \date March 05, 2017
+
+class AliCSTrackCutsBase : public AliCSAnalysisCutsBase {
+public:
+
+                                AliCSTrackCutsBase();
+                                AliCSTrackCutsBase(Int_t nCuts, Int_t nParams, const char *name="CS TrackCuts", const char * title="CS TrackCuts");
+  virtual                      ~AliCSTrackCutsBase();
+
+                                /// Initializes the cuts
+                                /// Pure virtual function
+                                /// \param name the name to assign to the histograms list
+  virtual void                  InitCuts(const char *name) = 0;
+                                /// Processes a potential change in the run number
+                                /// Pure virtual function
+  virtual void                  NotifyRun() = 0;
+
+                                /// Is the track accepted by the set of cuts?
+                                /// Pure virtual function
+                                /// \param trk the track to be accepted or rejected
+                                /// \return kTRUE if the track is accepted kFALSE otherwise
+  virtual Bool_t                IsTrackAccepted(AliVTrack *trk) = 0;
+                                /// Is the corresponding true track accepted by the set of cuts?
+                                /// Pure virtual function
+                                /// \param trk the track whose corresponding true track is to be accepted or rejected
+                                /// \return kTRUE if the associated true track is accepted kFALSE otherwise
+  virtual Bool_t                IsTrueTrackAccepted(AliVTrack *trk) = 0;
+                                /// Is the true track accepted by the set of cuts?
+                                /// Pure virtual function
+                                /// \param itrk the stack track index of the true track to be accepted or rejected
+                                /// \return kTRUE if the true track is accepted kFALSE otherwise
+  virtual Bool_t                IsTrueTrackAccepted(Int_t itrk) = 0;
+
+
+private:
+  /// Copy constructor
+  /// Not allowed. Forced private.
+  AliCSTrackCutsBase(const AliCSTrackCutsBase&);
+  /// Assignment operator
+  /// Not allowed. Forced private.
+  /// \return l-value reference object
+  AliCSTrackCutsBase& operator=(const AliCSTrackCutsBase&);
+
+  /// \cond CLASSIMP
+  ClassDef(AliCSTrackCutsBase,1);
+  /// \endcond
+};
+
+#endif /* ALICSTRACKCUTSBASE_H */

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSTrackMaps.cxx
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSTrackMaps.cxx
@@ -1,0 +1,114 @@
+/**************************************************************************
+* Copyright(c) 1998-2017, ALICE Experiment at CERN, All rights reserved.  *
+*                                                                         *
+* Permission to use, copy, modify and distribute this software and its    *
+* documentation strictly for non-commercial purposes is hereby granted    *
+* without fee, provided that the above copyright notice appears in all    *
+* copies and that both the copyright notice and this permission notice    *
+* appear in the supporting documentation. The authors make no claims      *
+* about the suitability of this software for any purpose. It is           *
+* provided "as is" without express or implied warranty.                   *
+**************************************************************************/
+
+#include <TBits.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TList.h>
+#include "AliVTrack.h"
+#include "AliAnalysisManager.h"
+#include "AliInputEventHandler.h"
+#include "AliMCEventHandler.h"
+#include "AliMCEvent.h"
+#include "AliAODEvent.h"
+#include "AliAODMCHeader.h"
+#include "AliStack.h"
+#include "AliHeader.h"
+#include "AliGenCocktailEventHeader.h"
+#include "TParticle.h"
+#include "AliAODMCParticle.h"
+#include "AliESDtrack.h"
+#include "AliAODTrack.h"
+#include "AliCSTrackMaps.h"
+#include "AliCSTrackCuts.h"
+#include "AliPIDResponse.h"
+#include "AliCSPIDCuts.h"
+#include "AliLog.h"
+
+/// \file AliCSTrackMaps.cxx
+/// \brief Implementation of AOD track mapping class within the correlation studies analysis
+
+TObjArray AliCSTrackMaps::fgAODTracksIdMap = TObjArray(30*1024);
+
+/// Default constructor for serialization
+AliCSTrackMaps::AliCSTrackMaps() :
+  TNamed()
+{
+  fgAODTracksIdMap.SetOwner(kFALSE);
+}
+
+/// Constructor
+/// \param name name of the AOD track maps
+/// \param title title of the AOD track maps
+AliCSTrackMaps::AliCSTrackMaps(const char *name, const char *title) :
+  TNamed(name,title)
+{
+  fgAODTracksIdMap.SetOwner(kFALSE);
+}
+
+/// Destructor
+/// We don't own anything, everything we allocate is owned
+/// by the output list
+AliCSTrackMaps::~AliCSTrackMaps()
+{
+
+}
+
+
+/// Processes the start of a new event
+///
+/// In case of AOD event builds the AOD tracks id map
+/// needed data for track selection
+void AliCSTrackMaps::NotifyEvent() {
+
+  /* let's build the potential AOD tracks id map */
+  AliInputEventHandler *handler = AliCSAnalysisCutsBase::GetInputEventHandler();
+  if (handler != NULL && !handler->InheritsFrom("AliESDInputHandler")) {
+    AliInfo("Building the AOD tracks id map");
+
+    fgAODTracksIdMap.Clear();
+
+    AliAODEvent *event = (AliAODEvent *)handler->GetEvent();
+    AliAODHeader *header = (AliAODHeader *) event->GetHeader();
+    Int_t nesdtracks = header->GetNumberOfESDTracks();
+    if (fgAODTracksIdMap.GetSize() < nesdtracks) {
+      Int_t newsize = (int(nesdtracks / 1024) * 2) * 1024;
+      AliInfo(Form("Expanding the AOD tracks id map from %d to %d", fgAODTracksIdMap.GetSize(), newsize));
+      fgAODTracksIdMap.Expand(newsize);
+    }
+
+    for (Int_t itrk = 0; itrk < event->GetNumberOfTracks(); itrk++) {
+      AliVTrack* vtrack = dynamic_cast<AliVTrack*>(event->GetTrack(itrk)); // pointer to reconstructed track
+      if(vtrack != NULL) {
+        if (vtrack->GetID() < 0) {
+          /* check that the original track is already mapped */
+          if (!(fgAODTracksIdMap.At(-1 - vtrack->GetID()) != NULL)) {
+            AliError(Form("Original track with id: %d is not present for AOD track: %d with id: %d",
+                -1 - vtrack->GetID(), itrk, vtrack->GetID()));
+          }
+        }
+        else {
+          if (fgAODTracksIdMap.At(vtrack->GetID()) != NULL) {
+            AliError(Form("Original track with id: %d already present with id: %d",
+                vtrack->GetID(), ((AliVTrack *) fgAODTracksIdMap.At(vtrack->GetID()))->GetID()));
+          }
+          else
+            fgAODTracksIdMap.AddAt(vtrack, vtrack->GetID());
+        }
+      }
+    }
+  }
+}
+
+/// \cond CLASSIMP
+ClassImp(AliCSTrackMaps);
+/// \endcond

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSTrackMaps.h
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSTrackMaps.h
@@ -1,0 +1,59 @@
+#ifndef ALICSTRACKMAPS_H
+#define ALICSTRACKMAPS_H
+
+/// \file AliCSTrackMaps.h
+/// \brief Track selection cuts support for the correlations studies tasks
+///
+
+#include <TNamed.h>
+#include <TObjArray.h>
+#include "AliAODTrack.h"
+
+class AliVTrack;
+
+/// \class AliCSTrackMaps
+/// \brief Class which implements the track mapping needed for AOD events
+///
+/// \author Víctor González <victor.gonzalez@cern.ch>, UCM, GSI
+/// \date Oct 15, 2017
+
+class AliCSTrackMaps : public TNamed {
+public:
+                                     AliCSTrackMaps();
+                                     AliCSTrackMaps(const char *name, const char * title);
+  virtual                           ~AliCSTrackMaps();
+
+  virtual void                       NotifyEvent();
+
+  static AliVTrack                  *GetOriginalTrack(AliAODTrack *trk);
+
+private:
+  static TObjArray                   fgAODTracksIdMap;                   ///< the map for AOD tracks ID
+
+  /// Copy constructor
+  /// Not allowed. Forced private.
+  AliCSTrackMaps(const AliCSTrackMaps&);
+  /// Assignment operator
+  /// Not allowed. Forced private.
+  /// \return l-value reference object
+  AliCSTrackMaps& operator=(const AliCSTrackMaps&);
+
+  /// \cond CLASSIMP
+  ClassDef(AliCSTrackMaps,1);
+  /// \endcond
+};
+
+/// \brief Returns the associated original track for a potentially constrained AOD track
+/// \param trk the potentially constrained AOD track
+/// \return the original track associated to the potentially constrained AOD track
+inline AliVTrack *AliCSTrackMaps::GetOriginalTrack(AliAODTrack *trk)
+{
+  Int_t id = trk->GetID();
+  if (id < 0) id = -1 -id;
+
+  return (AliVTrack *) AliCSTrackMaps::fgAODTracksIdMap.At(id);
+}
+
+
+
+#endif /* ALICSTRACKMAPS_H */

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSTrackSelection.cxx
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSTrackSelection.cxx
@@ -1,0 +1,876 @@
+/**************************************************************************
+* Copyright(c) 1998-2017, ALICE Experiment at CERN, All rights reserved.  *
+*                                                                         *
+* Permission to use, copy, modify and distribute this software and its    *
+* documentation strictly for non-commercial purposes is hereby granted    *
+* without fee, provided that the above copyright notice appears in all    *
+* copies and that both the copyright notice and this permission notice    *
+* appear in the supporting documentation. The authors make no claims      *
+* about the suitability of this software for any purpose. It is           *
+* provided "as is" without express or implied warranty.                   *
+**************************************************************************/
+
+#include <TBits.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TList.h>
+#include "AliVTrack.h"
+#include "AliAnalysisManager.h"
+#include "AliInputEventHandler.h"
+#include "AliMCEventHandler.h"
+#include "AliMCEvent.h"
+#include "AliAODEvent.h"
+#include "AliAODMCHeader.h"
+#include "AliStack.h"
+#include "AliHeader.h"
+#include "AliGenCocktailEventHeader.h"
+#include "TParticle.h"
+#include "AliAODMCParticle.h"
+#include "AliESDtrack.h"
+#include "AliAODTrack.h"
+#include "AliCSTrackMaps.h"
+#include "AliCSTrackSelection.h"
+#include "AliCSTrackCuts.h"
+#include "AliPIDResponse.h"
+#include "AliCSPIDCuts.h"
+#include "AliLog.h"
+
+/// \file AliCSTrackSelection.cxx
+/// \brief Implementation of track selection class within the correlation studies analysis
+
+/// Default constructor for serialization
+AliCSTrackSelection::AliCSTrackSelection() :
+  TNamed(),
+  fQALevel(AliCSAnalysisCutsBase::kQALevelNone),
+  fInclusiveTrackCuts(),
+  fInclusivePIDCuts(),
+  fInclusiveCutsStrings(),
+  fInclusivePidCutsStrings(),
+  fExclusiveCuts(),
+  fExclusiveCutsStrings(),
+  fExclusivePidCutsStrings(),
+  fCutsActivatedMask(NULL),
+  fCutsString(""),
+  fDataPeriod(AliCSAnalysisCutsBase::kNoPeriod),
+  fHighestPrimaryLabel(0),
+  fPIDResponse(NULL),
+  fhCutsStatistics(NULL),
+  fhCutsCorrelation(NULL),
+  fHistogramsList(NULL)
+{
+  /* we own the cuts so, they will be destroyed when we are */
+  fInclusiveTrackCuts.SetOwner(kTRUE);
+  fInclusivePIDCuts.SetOwner(kTRUE);
+  fInclusiveCutsStrings.SetOwner(kTRUE);
+  fInclusivePidCutsStrings.SetOwner(kTRUE);
+  fExclusiveCuts.SetOwner(kTRUE);
+  fExclusiveCutsStrings.SetOwner(kTRUE);
+  fExclusivePidCutsStrings.SetOwner(kTRUE);
+
+  for (Int_t i = 0; i < 2; i++) {
+    fhPtVsDCAxy[i] = NULL;
+    fhPtVsDCAz[i] = NULL;
+    fhPtVsTPCCls[i] = NULL;
+    fhPtVsTPCRowOverFindCls[i] = NULL;
+    fhEtaVsPhi[i] = NULL;
+    fhPtVsEta[i] = NULL;
+    fhITSdEdxSignalVsP[i] = NULL;
+    fhTPCdEdxSignalVsP[i] = NULL;
+    fhTOFSignalVsP[i] = NULL;
+  }
+}
+
+/// Constructor
+/// \param name name of the event cuts
+/// \param title title of the event cuts
+AliCSTrackSelection::AliCSTrackSelection(const char *name, const char *title) :
+  TNamed(name,title),
+  fQALevel(AliCSAnalysisCutsBase::kQALevelNone),
+  fInclusiveTrackCuts(),
+  fInclusivePIDCuts(),
+  fInclusiveCutsStrings(),
+  fInclusivePidCutsStrings(),
+  fExclusiveCuts(),
+  fExclusiveCutsStrings(),
+  fExclusivePidCutsStrings(),
+  fCutsActivatedMask(NULL),
+  fCutsString(""),
+  fDataPeriod(AliCSAnalysisCutsBase::kNoPeriod),
+  fHighestPrimaryLabel(0),
+  fPIDResponse(NULL),
+  fhCutsStatistics(NULL),
+  fhCutsCorrelation(NULL),
+  fHistogramsList(NULL)
+{
+  /* we own the cuts so, they will be destroyed when we are */
+  fInclusiveTrackCuts.SetOwner(kTRUE);
+  fInclusivePIDCuts.SetOwner(kTRUE);
+  fInclusiveCutsStrings.SetOwner(kTRUE);
+  fInclusivePidCutsStrings.SetOwner(kTRUE);
+  fExclusiveCuts.SetOwner(kTRUE);
+  fExclusiveCutsStrings.SetOwner(kTRUE);
+  fExclusivePidCutsStrings.SetOwner(kTRUE);
+
+  for (Int_t i = 0; i < 2; i++) {
+    fhPtVsDCAxy[i] = NULL;
+    fhPtVsDCAz[i] = NULL;
+    fhPtVsTPCCls[i] = NULL;
+    fhPtVsTPCRowOverFindCls[i] = NULL;
+    fhEtaVsPhi[i] = NULL;
+    fhPtVsEta[i] = NULL;
+    fhITSdEdxSignalVsP[i] = NULL;
+    fhTPCdEdxSignalVsP[i] = NULL;
+    fhTOFSignalVsP[i] = NULL;
+  }
+}
+
+/// Destructor
+/// We don't own anything, everything we allocate is owned
+/// by the output list
+AliCSTrackSelection::~AliCSTrackSelection()
+{
+
+}
+
+/// \brief Sets the track selection configuration by means of a configuration string
+/// \param confstring the configuration string
+/// \return kTRUE if the instance was correctly configured kFALSE otherwise
+/// The configuration string will have the format
+/// Tracks:trackstring;PID:pidstring;
+/// In their turn, trackstring and pidstring might have the format
+/// cutstring,cutstring+cutstring and cutstring could start with a minus
+/// to configure rejection cuts instead of acceptance cuts. For PID
+/// strings, the first character/s (second after a potential '-') indicate
+/// the family towards the PID cut is applied: 'e' for electrons, 'pi' for
+/// pions, 'mu' for muons, 'k' for kaons and 'p' for protons.
+///
+Bool_t AliCSTrackSelection::InitializeFromString(const char *confstring)
+{
+  Bool_t accepted = kTRUE;
+  fCutsString = confstring;
+  TString sztmp = confstring;
+
+  /* the track cuts strings                           */
+  if (sztmp.BeginsWith("Tracks:")) {
+    sztmp.Remove(0,strlen("Tracks:"));
+    TString sztmptrk = sztmp(0,sztmp.Index(";"));
+    sztmp.Remove(0, sztmp.Index(";")+1);
+
+    TObjArray *tokens = sztmptrk.Tokenize("+");
+    for (Int_t icut = 0; icut < tokens->GetEntries(); icut++) {
+      if (((TObjString*) tokens->At(icut))->String().BeginsWith("-")) {
+        TObjString *posz = new TObjString(((TObjString*) tokens->At(icut))->String().Remove(0,1).Data());
+        fExclusiveCutsStrings.Add(posz);
+      }
+      else {
+        TObjString *posz = new TObjString(((TObjString*) tokens->At(icut))->String().Data());
+        fInclusiveCutsStrings.Add(posz);
+      }
+    }
+    delete tokens;
+  }
+  else {
+    AliFatal("No tracks selection cuts string. ABORTING!!!");
+    return kFALSE;
+  }
+
+  /* the PID cuts strings                                                 */
+  if (sztmp.BeginsWith("PID:")) {
+    sztmp.Remove(0,strlen("PID:"));
+    TString sztmpid = sztmp(0, sztmp.Index(";"));
+    sztmp.Remove(0, sztmp.Index(";")+1);
+
+    /* so far only reject e- after track selection */
+    TObjArray *tokens = sztmpid.Tokenize("+");
+    for (Int_t icut = 0; icut < tokens->GetEntries(); icut++) {
+      if (((TObjString*) tokens->At(icut))->String().BeginsWith("-")) {
+        TObjString *posz = new TObjString(((TObjString*) tokens->At(icut))->String().Remove(0,1).Data());
+        if (posz->String().BeginsWith("e") || posz->String().BeginsWith("mu") || posz->String().BeginsWith("pi")
+            || posz->String().BeginsWith("p") || posz->String().BeginsWith("k")) {
+          fExclusivePidCutsStrings.Add(posz);
+        }
+        else {
+          AliFatal("Wrong family in track selection PID cuts string. ABORTING!!!");
+          return kFALSE;
+        }
+      }
+      else {
+        TObjString *posz = new TObjString(((TObjString*) tokens->At(icut))->String().Data());
+        if (posz->String().BeginsWith("e") || posz->String().BeginsWith("mu") || posz->String().BeginsWith("pi")
+            || posz->String().BeginsWith("p") || posz->String().BeginsWith("k")) {
+          fInclusivePidCutsStrings.Add(posz);
+        }
+        else {
+          AliFatal("Wrong family in track selection PID cuts string. ABORTING!!!");
+          return kFALSE;
+        }
+      }
+    }
+    delete tokens;
+  }
+  else {
+    AliFatal("No tracks selection PID cuts string. ABORTING!!!");
+    return kFALSE;
+  }
+
+  /* let's get the PID response instance if needed */
+  if (fInclusivePidCutsStrings.GetEntries() != 0 || fExclusivePidCutsStrings.GetEntries() != 0) {
+    AliAnalysisManager *manager = AliAnalysisManager::GetAnalysisManager();
+    if(manager != NULL) {
+      AliInputEventHandler* inputHandler = (AliInputEventHandler*) (manager->GetInputEventHandler());
+      fPIDResponse = (AliPIDResponse*) inputHandler->GetPIDResponse();
+      /* if we need PID response instance and it is not there we cannot continue */
+      if (fPIDResponse == NULL)
+        AliFatal("No PID response instance. ABORTING!!!");
+    }
+    else {
+      AliFatal("No analysis manager instance. ABORTING!!!");
+    }
+  }
+
+  AliInfo("Stored track selection configuration string:");
+  AliInfo(Form("\t%s", fCutsString.Data()));
+  return accepted;
+}
+
+
+/// Processes a potential change in the run number
+///
+/// Checks if the current period under analysis has changes and if so
+/// updates the needed members
+void AliCSTrackSelection::NotifyRun() {
+
+  /* checks the change in the analysis period */
+  if (AliCSAnalysisCutsBase::GetGlobalPeriod() != fDataPeriod) {
+
+    fDataPeriod = AliCSAnalysisCutsBase::GetGlobalPeriod();
+
+    fCutsActivatedMask = new TBits(fInclusiveTrackCuts.GetEntriesFast()+fInclusivePIDCuts.GetEntriesFast()+fExclusiveCuts.GetEntriesFast());
+
+    /* Inform the different set of cuts */
+    for (Int_t ix = 0; ix < fInclusiveTrackCuts.GetEntriesFast(); ix++)
+      ((AliCSTrackCutsBase *) fInclusiveTrackCuts[ix])->NotifyRun();
+    for (Int_t ix = 0; ix < fInclusivePIDCuts.GetEntriesFast(); ix++)
+      ((AliCSTrackCutsBase *) fInclusivePIDCuts[ix])->NotifyRun();
+    for (Int_t ix = 0; ix < fExclusiveCuts.GetEntriesFast(); ix++)
+      ((AliCSTrackCutsBase *) fExclusiveCuts[ix])->NotifyRun();
+
+    /* and now we ask for histogram allocation */
+    DefineHistograms();
+  }
+}
+
+/// Processes the start of a new event
+///
+/// Checks if the running analysis is over MC data and stored the
+/// needed data for track selection
+void AliCSTrackSelection::NotifyEvent() {
+
+  if (AliCSAnalysisCutsBase::IsMC()) {
+    AliMCEventHandler *eventHandler = AliCSAnalysisCutsBase::GetMCEventHandler();
+
+    AliGenEventHeader *mainHeader = NULL;
+    Int_t nNoOfHeaders = 0;
+    fHighestPrimaryLabel = 0;
+
+    if (eventHandler != NULL) {
+      /* MC ESD format */
+      AliMCEvent *mcEvent = eventHandler->MCEvent();
+      AliHeader *header = mcEvent->Header();
+      if (header != NULL) {
+        AliGenCocktailEventHeader *cocktailHeader = dynamic_cast<AliGenCocktailEventHeader*> (header->GenEventHeader());
+        if (cocktailHeader != NULL) {
+          nNoOfHeaders = cocktailHeader->GetHeaders()->GetEntries();
+          mainHeader = dynamic_cast<AliGenEventHeader*> (cocktailHeader->GetHeaders()->First());
+        }
+        else {
+          if (dynamic_cast<AliGenEventHeader*>(header->GenEventHeader()) != NULL) {
+            AliInfo("From header->GenEventHeader");
+            mainHeader = dynamic_cast<AliGenEventHeader*>(header->GenEventHeader());
+            nNoOfHeaders = 1;
+          }
+          else {
+            AliError("MC analysis but no MC event cocktail header");
+          }
+        }
+      }
+      else {
+        AliError("MC analysis but no MC event header");
+      }
+    }
+    else {
+      /* MC AOD format */
+      AliInputEventHandler *handler = AliCSAnalysisCutsBase::GetInputEventHandler();
+      AliAODEvent *event = (AliAODEvent *)handler->GetEvent();
+      AliAODMCHeader* header = (AliAODMCHeader*) event->GetList()->FindObject(AliAODMCHeader::StdBranchName());
+
+      if (header != NULL) {
+        nNoOfHeaders = header->GetNCocktailHeaders();
+        mainHeader = header->GetCocktailHeader(0);
+      }
+      else {
+        AliError("MC analysis but no MC event cocktail header");
+      }
+    }
+
+    if (mainHeader != NULL) {
+      if (nNoOfHeaders > 1) {
+        AliInfo(Form("Injected signals in this event (%d headers). Keeping particles/tracks of %s. Will skip particles/tracks with labels above %d.",
+            nNoOfHeaders, mainHeader->ClassName(), mainHeader->NProduced()-1));
+        fHighestPrimaryLabel = mainHeader->NProduced();
+      }
+    }
+    else {
+      AliError("MC anlysis but no proper header");
+    }
+  }
+}
+
+/// Check whether the passed track is accepted by the different cuts
+/// \param trk the track to analyze whether it is accepted or not
+/// \return kTRUE if the track  is accepted, kFALSE otherwise
+///
+/// The track shall be accepted by any of the inclusive set of track cuts
+/// and rejected by all the exclusive ones
+Bool_t AliCSTrackSelection::IsTrackAccepted(AliVTrack *trk) {
+
+  /* just to be sure */
+  if (trk == NULL) return kFALSE;
+
+  /* if MC analysis is ongoing get rid of "ghost" tracks */
+  if(AliCSAnalysisCutsBase::IsMC()) if (trk->GetLabel() < 0) return kFALSE;
+
+  /* if MC analysis is ongoing get rid of injected signals */
+  if (AliCSAnalysisCutsBase::IsMC()) if (IsFromMCInjectedSignal(trk->GetLabel())) return kFALSE;
+
+  /* for the time being */
+  Bool_t accepted = kTRUE;
+  Bool_t inclusivetrack = (fInclusiveTrackCuts.GetEntries() == 0);
+  Bool_t inclusivepid = (fInclusivePIDCuts.GetEntries() == 0);
+  Bool_t exclusive = kFALSE;
+
+  /* initialize the mask of activated cuts */
+  fCutsActivatedMask->ResetAllBits();
+
+  /* Check first the inclusive set of track cuts */
+  for (Int_t ix = 0; ix < fInclusiveTrackCuts.GetEntriesFast(); ix++) {
+
+    Bool_t cutaccepted = ((AliCSTrackCutsBase *) fInclusiveTrackCuts[ix])->IsTrackAccepted(trk);
+    /* if track is not accepted the cut is activated */
+    fCutsActivatedMask->SetBitNumber(ix,!cutaccepted);
+    inclusivetrack = inclusivetrack || cutaccepted;
+  }
+
+  /* now the inclusive set of pid cuts */
+  for (Int_t ix = 0; ix < fInclusivePIDCuts.GetEntriesFast(); ix++) {
+
+    Bool_t cutaccepted = ((AliCSTrackCutsBase *) fInclusivePIDCuts[ix])->IsTrackAccepted(trk);
+    /* if track is not accepted the cut is activated */
+    fCutsActivatedMask->SetBitNumber(ix+fInclusiveTrackCuts.GetEntriesFast(),!cutaccepted);
+    inclusivepid = inclusivepid || cutaccepted;
+  }
+
+  /* and now the exclusive ones */
+  for (Int_t ix = 0; ix < fExclusiveCuts.GetEntriesFast(); ix++) {
+    Bool_t cutaccepted = ((AliCSTrackCutsBase *) fExclusiveCuts[ix])->IsTrackAccepted(trk);
+    /* if track is accepted the cut is activated */
+    fCutsActivatedMask->SetBitNumber(ix+fInclusiveTrackCuts.GetEntriesFast()+fInclusivePIDCuts.GetEntriesFast(),cutaccepted);
+    exclusive = exclusive || cutaccepted;
+  }
+
+  /* now decide if accepted or not */
+  accepted = inclusivetrack && inclusivepid && !exclusive;
+
+  if (fQALevel > AliCSAnalysisCutsBase::kQALevelNone) {
+    /* let's fill the histograms */
+    fhCutsStatistics->Fill(fhCutsStatistics->GetBinCenter(fhCutsStatistics->GetXaxis()->FindBin("n tracks")));
+    if (!accepted)
+      fhCutsStatistics->Fill(fhCutsStatistics->GetBinCenter(fhCutsStatistics->GetXaxis()->FindBin("n cut tracks")));
+
+    for (Int_t ix=0; ix<fInclusiveTrackCuts.GetEntriesFast(); ix++) {
+      if (fhCutsStatistics->GetXaxis()->FindBin(fInclusiveTrackCuts[ix]->GetName()) < 1)
+        AliFatal(Form("Inconsistency! Cut %d with name %s not found", ix, fInclusiveTrackCuts[ix]->GetName()));
+
+      if (fCutsActivatedMask->TestBitNumber(ix))
+        fhCutsStatistics->Fill(fhCutsStatistics->GetBinCenter(fhCutsStatistics->GetXaxis()->FindBin(fInclusiveTrackCuts[ix]->GetName())));
+
+      if (fQALevel > AliCSAnalysisCutsBase::kQALevelLight) {
+        for (Int_t jx=ix; jx<fInclusiveTrackCuts.GetEntriesFast(); jx++) {
+          if (fhCutsStatistics->GetXaxis()->FindBin(fInclusiveTrackCuts[jx]->GetName()) < 1)
+            AliFatal(Form("Inconsistency! Cut %d with name %s not found", jx, fInclusiveTrackCuts[jx]->GetName()));
+
+          if (fCutsActivatedMask->TestBitNumber(ix) && fCutsActivatedMask->TestBitNumber(jx)) {
+            Float_t xC = fhCutsCorrelation->GetXaxis()->GetBinCenter(fhCutsCorrelation->GetXaxis()->FindBin(fInclusiveTrackCuts[ix]->GetName()));
+            Float_t yC = fhCutsCorrelation->GetYaxis()->GetBinCenter(fhCutsCorrelation->GetYaxis()->FindBin(fInclusiveTrackCuts[jx]->GetName()));
+            fhCutsCorrelation->Fill(xC, yC);
+          }
+        }
+        for (Int_t jx=ix; jx<fInclusivePIDCuts.GetEntriesFast(); jx++) {
+          if (fhCutsStatistics->GetXaxis()->FindBin(fInclusivePIDCuts[jx]->GetName()) < 1)
+            AliFatal(Form("Inconsistency! Cut %d with name %s not found", jx, fInclusivePIDCuts[jx]->GetName()));
+
+          if (fCutsActivatedMask->TestBitNumber(ix) && fCutsActivatedMask->TestBitNumber(jx+fInclusiveTrackCuts.GetEntriesFast())) {
+            Float_t xC = fhCutsCorrelation->GetXaxis()->GetBinCenter(fhCutsCorrelation->GetXaxis()->FindBin(fInclusiveTrackCuts[ix]->GetName()));
+            Float_t yC = fhCutsCorrelation->GetYaxis()->GetBinCenter(fhCutsCorrelation->GetYaxis()->FindBin(fInclusivePIDCuts[jx]->GetName()));
+            fhCutsCorrelation->Fill(xC, yC);
+          }
+        }
+        for (Int_t jx=0; jx<fExclusiveCuts.GetEntriesFast(); jx++) {
+          if (fhCutsStatistics->GetXaxis()->FindBin(fExclusiveCuts[jx]->GetName()) < 1)
+            AliFatal(Form("Inconsistency! Cut %d with name %s not found", jx, fExclusiveCuts[jx]->GetName()));
+
+          if (fCutsActivatedMask->TestBitNumber(ix)
+              && fCutsActivatedMask->TestBitNumber(jx+fInclusiveTrackCuts.GetEntriesFast()+fInclusivePIDCuts.GetEntriesFast())) {
+            Float_t xC = fhCutsCorrelation->GetXaxis()->GetBinCenter(fhCutsCorrelation->GetXaxis()->FindBin(fInclusiveTrackCuts[ix]->GetName()));
+            Float_t yC = fhCutsCorrelation->GetYaxis()->GetBinCenter(fhCutsCorrelation->GetYaxis()->FindBin(fExclusiveCuts[jx]->GetName()));
+            fhCutsCorrelation->Fill(xC, yC);
+          }
+        }
+      }
+    }
+    for (Int_t ix=0; ix<fInclusivePIDCuts.GetEntriesFast(); ix++) {
+      if (fhCutsStatistics->GetXaxis()->FindBin(fInclusivePIDCuts[ix]->GetName()) < 1)
+        AliFatal(Form("Inconsistency! Cut %d with name %s not found", ix, fInclusivePIDCuts[ix]->GetName()));
+
+      if (fCutsActivatedMask->TestBitNumber(ix+fInclusiveTrackCuts.GetEntriesFast()))
+        fhCutsStatistics->Fill(fhCutsStatistics->GetBinCenter(fhCutsStatistics->GetXaxis()->FindBin(fInclusivePIDCuts[ix]->GetName())));
+
+      if (fQALevel > AliCSAnalysisCutsBase::kQALevelLight) {
+        for (Int_t jx=ix; jx<fInclusivePIDCuts.GetEntriesFast(); jx++) {
+          if (fhCutsStatistics->GetXaxis()->FindBin(fInclusivePIDCuts[jx]->GetName()) < 1)
+            AliFatal(Form("Inconsistency! Cut %d with name %s not found", jx, fInclusivePIDCuts[jx]->GetName()));
+
+          if (fCutsActivatedMask->TestBitNumber(ix+fInclusiveTrackCuts.GetEntriesFast())
+              && fCutsActivatedMask->TestBitNumber(jx+fInclusiveTrackCuts.GetEntriesFast())) {
+            Float_t xC = fhCutsCorrelation->GetXaxis()->GetBinCenter(fhCutsCorrelation->GetXaxis()->FindBin(fInclusivePIDCuts[ix]->GetName()));
+            Float_t yC = fhCutsCorrelation->GetYaxis()->GetBinCenter(fhCutsCorrelation->GetYaxis()->FindBin(fInclusivePIDCuts[jx]->GetName()));
+            fhCutsCorrelation->Fill(xC, yC);
+          }
+        }
+        for (Int_t jx=0; jx<fExclusiveCuts.GetEntriesFast(); jx++) {
+          if (fhCutsStatistics->GetXaxis()->FindBin(fExclusiveCuts[jx]->GetName()) < 1)
+            AliFatal(Form("Inconsistency! Cut %d with name %s not found", jx, fExclusiveCuts[jx]->GetName()));
+
+          if (fCutsActivatedMask->TestBitNumber(ix+fInclusiveTrackCuts.GetEntriesFast())
+              && fCutsActivatedMask->TestBitNumber(jx+fInclusiveTrackCuts.GetEntriesFast()+fInclusivePIDCuts.GetEntriesFast())) {
+            Float_t xC = fhCutsCorrelation->GetXaxis()->GetBinCenter(fhCutsCorrelation->GetXaxis()->FindBin(fInclusivePIDCuts[ix]->GetName()));
+            Float_t yC = fhCutsCorrelation->GetYaxis()->GetBinCenter(fhCutsCorrelation->GetYaxis()->FindBin(fExclusiveCuts[jx]->GetName()));
+            fhCutsCorrelation->Fill(xC, yC);
+          }
+        }
+      }
+    }
+    for (Int_t ix=0; ix<fExclusiveCuts.GetEntriesFast(); ix++) {
+      if (fhCutsStatistics->GetXaxis()->FindBin(fExclusiveCuts[ix]->GetName()) < 1)
+        AliFatal(Form("Inconsistency! Cut %d with name %s not found", ix, fExclusiveCuts[ix]->GetName()));
+
+      if (fCutsActivatedMask->TestBitNumber(ix+fInclusiveTrackCuts.GetEntriesFast()+fInclusivePIDCuts.GetEntriesFast()))
+        fhCutsStatistics->Fill(fhCutsStatistics->GetBinCenter(fhCutsStatistics->GetXaxis()->FindBin(fExclusiveCuts[ix]->GetName())));
+
+      if (fQALevel > AliCSAnalysisCutsBase::kQALevelLight) {
+        for (Int_t jx=0; jx<fExclusiveCuts.GetEntriesFast(); jx++) {
+          if (fhCutsStatistics->GetXaxis()->FindBin(fExclusiveCuts[jx]->GetName()) < 1)
+            AliFatal(Form("Inconsistency! Cut %d with name %s not found", jx, fExclusiveCuts[jx]->GetName()));
+
+          if (fCutsActivatedMask->TestBitNumber(ix+fInclusiveTrackCuts.GetEntriesFast()+fInclusivePIDCuts.GetEntriesFast())
+              && fCutsActivatedMask->TestBitNumber(jx+fInclusiveTrackCuts.GetEntriesFast()+fInclusivePIDCuts.GetEntriesFast())) {
+            Float_t xC = fhCutsCorrelation->GetXaxis()->GetBinCenter(fhCutsCorrelation->GetXaxis()->FindBin(fExclusiveCuts[ix]->GetName()));
+            Float_t yC = fhCutsCorrelation->GetYaxis()->GetBinCenter(fhCutsCorrelation->GetYaxis()->FindBin(fExclusiveCuts[jx]->GetName()));
+            fhCutsCorrelation->Fill(xC, yC);
+          }
+        }
+      }
+    }
+
+    /* get some values needed for histograms filling */
+    Float_t dca[2], bCov[3];
+    if (trk->IsA() == AliESDtrack::Class()) {
+      trk->GetImpactParameters(dca,bCov);
+    }
+    else {
+      /* TODO: if the track is constrained this needs to be considered */
+      /* the selected tracks get a DCA of 0.0. Implement GetDCA from   */
+      /* AliDielectronVarManager but it will require access to the     */
+      /* event object                                                  */
+      AliAODTrack *aodt = dynamic_cast<AliAODTrack*>(trk);
+      Float_t pos[3];
+      if (aodt->GetPosition(pos)) {
+        dca[0] = pos[0];
+        dca[1] = pos[1];
+      }
+      else {
+        dca[0] = 0.0;
+        dca[1] = 0.0;
+      }
+    }
+
+
+    /* we now need to consider the potential constrained track */
+    AliVTrack *ttrk = trk;
+    if (trk->GetID() < 0)
+      ttrk = AliCSTrackMaps::GetOriginalTrack(dynamic_cast<AliAODTrack*>(trk));
+    Float_t nCrossedRowsTPC = ttrk->GetTPCCrossedRows();
+    Float_t  ratioCrossedRowsOverFindableClustersTPC = 1.0;
+    if (ttrk->GetTPCNclsF()>0) {
+      ratioCrossedRowsOverFindableClustersTPC = nCrossedRowsTPC / ttrk->GetTPCNclsF();
+    }
+
+    for (Int_t i = 0; i < 2; i++) {
+
+      fhPtVsDCAxy[i]->Fill(dca[0],trk->Pt());
+      fhPtVsDCAz[i]->Fill(dca[1],trk->Pt());
+      fhPtVsTPCCls[i]->Fill(ttrk->GetTPCNcls(),trk->Pt());
+      fhPtVsTPCRowOverFindCls[i]->Fill(ratioCrossedRowsOverFindableClustersTPC,trk->Pt());
+      fhPtVsEta[i]->Fill(trk->Eta(),trk->Pt());
+
+      if (fQALevel > AliCSAnalysisCutsBase::kQALevelLight) {
+        fhEtaVsPhi[i]->Fill(trk->Phi()*180.0/TMath::Pi(),trk->Eta());
+      }
+
+      if (fInclusivePidCutsStrings.GetEntries() != 0 || fExclusivePidCutsStrings.GetEntries() != 0) {
+        /* don't fill before if not requested */
+        if (i == 1 || (fQALevel > AliCSAnalysisCutsBase::kQALevelLight)) {
+          fhITSdEdxSignalVsP[i]->Fill(trk->P(),ttrk->GetITSsignal());
+          fhTPCdEdxSignalVsP[i]->Fill(trk->P(),TMath::Abs(ttrk->GetTPCsignal()));
+          if ((trk->GetStatus() & AliESDtrack::kTOFin) && (!(trk->GetStatus() & AliESDtrack::kTOFmismatch))) {
+            static const Double_t c_cm_ps = TMath::C() * 1.0e2 * 1.0e-12;
+            Double_t tracklen_cm = trk->GetIntegratedLength();
+            Double_t toftime_ps = ttrk->GetTOFsignal() - fPIDResponse->GetTOFResponse().GetStartTime(trk->P());
+            Double_t beta = tracklen_cm / toftime_ps / c_cm_ps;
+            fhTOFSignalVsP[i]->Fill(trk->P(),beta);
+          }
+        }
+      }
+
+      /* don't fill after if event not accepted */
+      if (!accepted) break;
+    }
+  }
+  return accepted;
+}
+
+
+/// Check whether the true track associated to the passed track is accepted by the different cuts
+/// \param trk the track to analyze whether its associated true track is accepted or not
+/// \return kTRUE if the associated true track  is accepted, kFALSE otherwise
+///
+Bool_t AliCSTrackSelection::IsTrueTrackAccepted(AliVTrack *trk) {
+
+  /* reject ghost tracks */
+  if (trk->GetLabel() < 0) return kFALSE;
+
+  return IsTrueTrackAccepted(trk->GetLabel());
+}
+
+
+/// Check whether the passed true track is accepted by the inclusive cuts and rejected by the exclusive cuts
+/// \param itrk the index of true track to analyze whether it is accepted or not
+/// \return kTRUE if the track  is accepted, kFALSE otherwise
+///
+Bool_t AliCSTrackSelection::IsTrueTrackAccepted(Int_t itrk) {
+
+  /* discard injected signals */
+  if (IsFromMCInjectedSignal(itrk)) return kFALSE;
+
+  /* for the time being */
+  Bool_t accepted = kTRUE;
+  Bool_t inclusivetrack = (fInclusiveTrackCuts.GetEntriesFast() == 0);
+  Bool_t inclusivepid = (fInclusivePIDCuts.GetEntriesFast() == 0);
+  Bool_t exclusive = kFALSE;
+
+  /* initialize the mask of activated cuts */
+  fCutsActivatedMask->ResetAllBits();
+
+  /* Check first the inclusive set of track cuts */
+  for (Int_t ix = 0; ix < fInclusiveTrackCuts.GetEntriesFast(); ix++) {
+
+    Bool_t cutaccepted = ((AliCSTrackCutsBase *) fInclusiveTrackCuts[ix])->IsTrueTrackAccepted(itrk);
+    /* if track is not accepted the cut is activated */
+    fCutsActivatedMask->SetBitNumber(ix,!cutaccepted);
+    inclusivetrack = inclusivetrack || cutaccepted;
+  }
+
+  /* now the inclusive set of pid cuts */
+  for (Int_t ix = 0; ix < fInclusivePIDCuts.GetEntriesFast(); ix++) {
+
+    Bool_t cutaccepted = ((AliCSTrackCutsBase *) fInclusivePIDCuts[ix])->IsTrueTrackAccepted(itrk);
+    /* if track is not accepted the cut is activated */
+    fCutsActivatedMask->SetBitNumber(ix+fInclusiveTrackCuts.GetEntriesFast(),!cutaccepted);
+    inclusivepid = inclusivepid || cutaccepted;
+  }
+
+  /* and now the exclusive ones */
+  for (Int_t ix = 0; ix < fExclusiveCuts.GetEntriesFast(); ix++) {
+    Bool_t cutaccepted = ((AliCSTrackCutsBase *) fExclusiveCuts[ix])->IsTrueTrackAccepted(itrk);
+    /* if track is accepted the cut is activated */
+    fCutsActivatedMask->SetBitNumber(ix+fInclusiveTrackCuts.GetEntriesFast()+fInclusivePIDCuts.GetEntriesFast(),cutaccepted);
+    exclusive = exclusive || cutaccepted;
+  }
+
+  /* now decide if accepted or not */
+  accepted = inclusivetrack && inclusivepid && !exclusive;
+  return accepted;
+}
+
+/// Check whether the true particle associated to a reconstructed track is primary
+/// \param trk the reconstructed track
+/// \return kTRUE if the associated particle is primary kFALSE otherwise
+Bool_t AliCSTrackSelection::IsTruePrimary(AliVTrack *trk) {
+
+  return AliCSTrackCuts::IsTruePrimary(trk);
+}
+
+
+/// Check whether the passed track label is associated to a MC injected signal
+/// \param itrk label of the track to analyze whether it is associated to an injected signal
+/// \return kTRUE if the track is associated to an injected signal kFALSE otherwise
+Bool_t AliCSTrackSelection::IsFromMCInjectedSignal(Int_t itrk) {
+
+  Bool_t isassociated = kFALSE;
+
+  if (fHighestPrimaryLabel > 0) {
+    AliMCEventHandler *eventHandler = AliCSAnalysisCutsBase::GetMCEventHandler();
+
+    if (eventHandler != NULL) {
+      /* MC ESD data */
+      Int_t label = itrk;
+      AliMCEvent* mcevent = eventHandler->MCEvent();
+      TParticle *mother = mcevent->Particle(label);
+
+      /* we have to find the primary one */
+      while (!mcevent->IsPhysicalPrimary(label)) {
+        label = mother->GetFirstMother();
+        if (label < 0) break;
+        mother = mcevent->Particle(label);
+        if (mother == NULL) break;
+      }
+
+      if (!(label < 0) && (mother != NULL)) {
+        if (!(label < fHighestPrimaryLabel)) {
+          isassociated = kTRUE;
+        }
+      }
+    }
+    else {
+      /* MC ESD data */
+      Int_t label = itrk;
+      TClonesArray *arrayMC = AliCSAnalysisCutsBase::GetMCTrueArray();
+      AliAODMCParticle *mother = (AliAODMCParticle *) arrayMC->At(label);
+
+      /* we have to find the primary one */
+      while ((mother != NULL) && !(mother->IsPhysicalPrimary())) {
+        label = mother->GetMother();
+        if (label < 0) break;
+        mother = (AliAODMCParticle *) arrayMC->At(label);
+      }
+
+      if (!(label < 0) && (mother != NULL)) {
+        if (!(label < fHighestPrimaryLabel)) {
+          isassociated = kTRUE;
+        }
+      }
+    }
+  }
+  return isassociated;
+}
+
+
+/// Initializes the cuts
+///
+/// Inclusive and exclusive set of cuts are created and the needed histograms list
+/// is allocated if needed the order is forwarded to the inclusive and exclusive set of cuts.
+/// \param name an additional name to precede the cuts string
+void AliCSTrackSelection::InitCuts(const char *name){
+
+  Bool_t oldstatus = TH1::AddDirectoryStatus();
+  TH1::AddDirectory(kFALSE);
+
+  TList *tmplist = new TList();
+
+  for (Int_t icut = 0; icut < fInclusiveCutsStrings.GetEntries(); icut++) {
+    AliCSTrackCuts *cut = new AliCSTrackCuts(Form("CS_InclusiveTrackCut%d",icut),Form("CS Inclusive Track Cut %d",icut));
+    cut->InitializeCutsFromCutString(((TObjString*)fInclusiveCutsStrings.At(icut))->String().Data());
+    fInclusiveTrackCuts.Add(cut);
+    cut->SetQALevelOutput(fQALevel);
+    cut->InitCuts("Inclusive track cut");
+    if (cut->GetHistogramsList() != NULL)
+      tmplist->Add(cut->GetHistogramsList());
+  }
+
+  for (Int_t icut = 0; icut < fInclusivePidCutsStrings.GetEntries(); icut++) {
+    TString szcut = ((TObjString*)fInclusivePidCutsStrings.At(icut))->String().Data();
+    AliPID::EParticleType target = AliPID::kUnknown;
+    Int_t delchars = 0;
+    if (szcut.BeginsWith("e")) { delchars = 1; target = AliPID::kElectron; }
+    else if (szcut.BeginsWith("mu")) { delchars = 2; target = AliPID::kMuon; }
+    else if (szcut.BeginsWith("pi")) { delchars = 2; target = AliPID::kPion; }
+    else if (szcut.BeginsWith("p")) { delchars = 1; target = AliPID::kProton; }
+    else if (szcut.BeginsWith("k")) { delchars = 1; target = AliPID::kKaon; }
+    else {
+      AliFatal("Inconsistent family in track selection PID cuts string. ABORTING!!!");
+    }
+    szcut.Remove(0,delchars);
+    AliCSPIDCuts *cut = new AliCSPIDCuts(Form("CS_InclusivePidCut%d",icut),Form("CS Inclusive PID Cut %d",icut),target);
+    cut->InitializeCutsFromCutString(szcut.Data());
+    fInclusivePIDCuts.Add(cut);
+    cut->SetQALevelOutput(fQALevel);
+    cut->InitCuts("Inclusive pid cut");
+    if (cut->GetHistogramsList() != NULL)
+      tmplist->Add(cut->GetHistogramsList());
+  }
+
+  for (Int_t icut = 0; icut < fExclusiveCutsStrings.GetEntries(); icut++) {
+    AliCSTrackCuts *cut = new AliCSTrackCuts(Form("CS_ExclusiveTrackCut%d",icut),Form("CS Exclusive Track Cut %d",icut));
+    cut->InitializeCutsFromCutString(((TObjString*)fExclusiveCutsStrings.At(icut))->String().Data());
+    fExclusiveCuts.Add(cut);
+    cut->SetQALevelOutput(fQALevel);
+    cut->InitCuts("Exclusive track cut");
+    if (cut->GetHistogramsList() != NULL)
+      tmplist->Add(cut->GetHistogramsList());
+  }
+
+  for (Int_t icut = 0; icut < fExclusivePidCutsStrings.GetEntries(); icut++) {
+    TString szcut = ((TObjString*)fExclusivePidCutsStrings.At(icut))->String().Data();
+    AliPID::EParticleType target  = AliPID::kUnknown;
+    Int_t delchars = 0;
+    if (szcut.BeginsWith("e")) { delchars = 1; target = AliPID::kElectron; }
+    else if (szcut.BeginsWith("mu")) { delchars = 2; target = AliPID::kMuon; }
+    else if (szcut.BeginsWith("pi")) { delchars = 2; target = AliPID::kPion; }
+    else if (szcut.BeginsWith("p")) { delchars = 1; target = AliPID::kProton; }
+    else if (szcut.BeginsWith("k")) { delchars = 1; target = AliPID::kKaon; }
+    else {
+      AliFatal("Inconsistent family in track selection PID cuts string. ABORTING!!!");
+    }
+    szcut.Remove(0,delchars);
+    AliCSPIDCuts *cut = new AliCSPIDCuts(Form("CS_ExclusivePidCut%d",icut),Form("CS Exclusive PID Cut %d",icut),target);
+    cut->InitializeCutsFromCutString(szcut.Data());
+    fExclusiveCuts.Add(cut);
+    cut->SetQALevelOutput(fQALevel);
+    cut->InitCuts("Exclusive pid cut");
+    if (cut->GetHistogramsList() != NULL)
+      tmplist->Add(cut->GetHistogramsList());
+  }
+
+  if (name == NULL) name = GetName();
+
+  if (fQALevel > AliCSAnalysisCutsBase::kQALevelNone || tmplist->GetEntries() != 0) {
+    if(fHistogramsList != NULL)
+      delete fHistogramsList;
+
+    fHistogramsList = tmplist;
+    fHistogramsList->SetOwner(kTRUE);
+    fHistogramsList->SetName(name);
+  }
+  else {
+    delete tmplist;
+  }
+  TH1::AddDirectory(oldstatus);
+}
+
+/// Allocates the different histograms if needed
+///
+/// It is supposed that the current cuts string is the running one
+void AliCSTrackSelection::DefineHistograms(){
+
+  if (fQALevel > AliCSAnalysisCutsBase::kQALevelNone) {
+    Bool_t oldstatus = TH1::AddDirectoryStatus();
+    TH1::AddDirectory(kFALSE);
+
+    /* the original name is used as title for the statistics histogram so, preserve it */
+    TString originalTempName = fHistogramsList->GetName();
+    fHistogramsList->SetName(Form("%s_%s",fHistogramsList->GetName(),fCutsString.Data()));
+
+    Int_t nNoOfCuts = fInclusiveTrackCuts.GetEntriesFast()+fInclusivePIDCuts.GetEntriesFast()+fExclusiveCuts.GetEntriesFast();
+    fhCutsStatistics = new TH1F(Form("CutsStatistics_%s",fCutsString.Data()),Form("%s tracks cuts statistics",originalTempName.Data()),nNoOfCuts+4,-0.5,nNoOfCuts+3.5);
+    fhCutsStatistics->GetXaxis()->SetBinLabel(1,"n tracks");
+    fhCutsStatistics->GetXaxis()->SetBinLabel(2,"n cut tracks");
+    for (Int_t i = 0; i < fInclusiveTrackCuts.GetEntriesFast(); i++)
+      fhCutsStatistics->GetXaxis()->SetBinLabel(i+4, fInclusiveTrackCuts[i]->GetName());
+    for (Int_t i = 0; i < fInclusivePIDCuts.GetEntriesFast(); i++)
+      fhCutsStatistics->GetXaxis()->SetBinLabel(fInclusiveTrackCuts.GetEntriesFast()+i+4, fInclusivePIDCuts[i]->GetName());
+    for (Int_t i = 0; i < fExclusiveCuts.GetEntriesFast(); i++)
+      fhCutsStatistics->GetXaxis()->SetBinLabel(fInclusiveTrackCuts.GetEntriesFast()+fInclusivePIDCuts.GetEntriesFast()+i+4, fExclusiveCuts[i]->GetName());
+    fHistogramsList->Add(fhCutsStatistics);
+
+    if(fQALevel == AliCSAnalysisCutsBase::kQALevelHeavy){
+      fhCutsCorrelation = new TH2F(Form("CutCorrelation_%s",fCutsString.Data()),"Cuts correlation",nNoOfCuts+2,-0.5,nNoOfCuts+1.5,nNoOfCuts+2,-0.5,nNoOfCuts+1.5);
+      for (Int_t i = 0; i < fInclusiveTrackCuts.GetEntriesFast(); i++) {
+        fhCutsCorrelation->GetXaxis()->SetBinLabel(i+2, fInclusiveTrackCuts[i]->GetName());
+        fhCutsCorrelation->GetYaxis()->SetBinLabel(i+2, fInclusiveTrackCuts[i]->GetName());
+      }
+      for (Int_t i = 0; i < fInclusivePIDCuts.GetEntriesFast(); i++) {
+        fhCutsCorrelation->GetXaxis()->SetBinLabel(fInclusiveTrackCuts.GetEntriesFast()+i+2, fInclusivePIDCuts[i]->GetName());
+        fhCutsCorrelation->GetYaxis()->SetBinLabel(fInclusiveTrackCuts.GetEntriesFast()+i+2, fInclusivePIDCuts[i]->GetName());
+      }
+      for (Int_t i = 0; i < fExclusiveCuts.GetEntriesFast(); i++) {
+        fhCutsCorrelation->GetXaxis()->SetBinLabel(fInclusiveTrackCuts.GetEntriesFast()+fInclusivePIDCuts.GetEntriesFast()+i+2, fExclusiveCuts[i]->GetName());
+        fhCutsCorrelation->GetYaxis()->SetBinLabel(fInclusiveTrackCuts.GetEntriesFast()+fInclusivePIDCuts.GetEntriesFast()+i+2, fExclusiveCuts[i]->GetName());
+      }
+      fHistogramsList->Add(fhCutsCorrelation);
+    }
+
+    fhPtVsDCAxy[0]  = new TH2F(Form("PtVsDCAxyPtB_%s",fCutsString.Data()),"p_{T} vs DCA_{XY} before;DCA_{XY} (cm);p_{T} (GeV/c)",800,-4.0,4.0,400,0.,10.);
+    fhPtVsDCAxy[1]  = new TH2F(Form("PtVsDCAxyPtA_%s",fCutsString.Data()),"p_{T} vs DCA_{XY};DCA_{XY} (cm);p_{T} (GeV/c)",800,-4.0,4.0,400,0.,10.);
+    fHistogramsList->Add(fhPtVsDCAxy[0]);
+    fHistogramsList->Add(fhPtVsDCAxy[1]);
+
+    fhPtVsDCAz[0]  = new TH2F(Form("PtVsDCAzPtB_%s",fCutsString.Data()),"p_{T} vs DCA_{Z} before;DCA_{Z} (cm);p_{T} (GeV/c)",800,-4.0,4.0,400,0.,10.);
+    fhPtVsDCAz[1]  = new TH2F(Form("PtVsDCAzPtA_%s",fCutsString.Data()),"p_{T} vs DCA_{Z};DCA_{Z} (cm);p_{T} (GeV/c)",800,-4.0,4.0,400,0.,10.);
+    fHistogramsList->Add(fhPtVsDCAz[0]);
+    fHistogramsList->Add(fhPtVsDCAz[1]);
+
+    fhPtVsTPCCls[0]  = new TH2F(Form("PtVsTPCClustersB_%s",fCutsString.Data()),"p_{T} vs no. of TPC clusters before;no of clusters;p_{T} (GeV/c)",170,0,170,400,0.,10.);
+    fhPtVsTPCCls[1]  = new TH2F(Form("PtVsTPCClustersA_%s",fCutsString.Data()),"p_{T} vs no. of TPC clusters;no of clusters;p_{T} (GeV/c)",170,0,170,400,0.,10.);
+    fHistogramsList->Add(fhPtVsTPCCls[0]);
+    fHistogramsList->Add(fhPtVsTPCCls[1]);
+
+    fhPtVsTPCRowOverFindCls[0] = new TH2F(Form("PtVsTPCCROFCB_%s",fCutsString.Data()),
+        "p_{T} vs TPC crossed rows findable clusters ratio before;crossed rows / findable clusters;p_{T} (GeV/c)",100,0,1,400,0.,10.);
+    fhPtVsTPCRowOverFindCls[1] = new TH2F(Form("PtVsTPCCROFCA_%s",fCutsString.Data()),
+        "p_{T} vs TPC crossed rows findable clusters ratio;crossed rows / findable clusters;p_{T} (GeV/c)",100,0,1,400,0.,10.);
+    fHistogramsList->Add(fhPtVsTPCRowOverFindCls[0]);
+    fHistogramsList->Add(fhPtVsTPCRowOverFindCls[1]);
+    fhPtVsEta[0] = new TH2F(Form("PtVsEtaB_%s",fCutsString.Data()),"p_{T} vs #eta before;#eta;p_{T} (GeV/c)",100,-2.0,2.0,400,0.,10.);
+    fhPtVsEta[1] = new TH2F(Form("PtVsEtaA_%s",fCutsString.Data()),"p_{T} vs #eta;#eta;p_{T} (GeV/c)",100,-2.0,2.0,400,0.,10.);
+    fHistogramsList->Add(fhPtVsEta[0]);
+    fHistogramsList->Add(fhPtVsEta[1]);
+
+    if(fQALevel == AliCSAnalysisCutsBase::kQALevelHeavy){
+      fhEtaVsPhi[0] = new TH2F(Form("EtaVsPhiB_%s",fCutsString.Data()),"#eta vs #phi before;#phi;#eta", 360, 0.0, 360.0, 100, -2.0, 2.0);
+      fhEtaVsPhi[1] = new TH2F(Form("EtaVsPhiA_%s",fCutsString.Data()),"#eta vs #phi;#phi;#eta", 360, 0.0, 360.0, 100, -2.0, 2.0);
+      fHistogramsList->Add(fhEtaVsPhi[0]);
+      fHistogramsList->Add(fhEtaVsPhi[1]);
+    }
+
+    if (fInclusivePidCutsStrings.GetEntries() != 0 || fExclusivePidCutsStrings.GetEntries() != 0) {
+      /* build the P bins */
+      const Int_t nPbins = 150;
+      Double_t minP = 0.05;
+      Double_t maxP = 20.0;
+      Double_t *edges = new Double_t [nPbins + 1];
+      Double_t factor = TMath::Power(maxP / minP, 1. / nPbins);
+      edges[0] = minP; for (Int_t bin = 0; bin < nPbins; bin++) edges[bin+1] = factor * edges[bin];
+
+      fhITSdEdxSignalVsP[0] = new TH2F(Form("ITSdEdxSignalB_%s",fCutsString.Data()),"ITS dE/dx signal before;P (GeV/c);#frac{dE}{dx} (au)",nPbins,edges, 800, 0.0, 200);
+      fhITSdEdxSignalVsP[1] = new TH2F(Form("ITSdEdxSignalA_%s",fCutsString.Data()),"ITS dE/dx signal;P (GeV/c);#frac{dE}{dx} (au)",nPbins,edges, 800, 0.0, 200);
+      fHistogramsList->Add(fhITSdEdxSignalVsP[0]);
+      fHistogramsList->Add(fhITSdEdxSignalVsP[1]);
+
+      fhTPCdEdxSignalVsP[0] = new TH2F(Form("TPCdEdxSignalB_%s",fCutsString.Data()),"TPC dE/dx signal before;P (GeV/c);#frac{dE}{dx} (au)",nPbins,edges, 800, 0.0, 200.0);
+      fhTPCdEdxSignalVsP[1] = new TH2F(Form("TPCdEdxSignalA_%s",fCutsString.Data()),"TPC dE/dx signal;P (GeV/c);#frac{dE}{dx} (au)",nPbins,edges, 800, 0.0, 200.0);
+      fHistogramsList->Add(fhTPCdEdxSignalVsP[0]);
+      fHistogramsList->Add(fhTPCdEdxSignalVsP[1]);
+
+      fhTOFSignalVsP[0] = new TH2F(Form("TOFSignalB_%s",fCutsString.Data()),"TOF signal before;P (GeV/c);#beta",nPbins,edges, 400, 0.0, 1.1);
+      fhTOFSignalVsP[1] = new TH2F(Form("TOFSignalA_%s",fCutsString.Data()),"TOF signal;P (GeV/c);#beta",nPbins,edges, 400, 0.0, 1.1);
+      fHistogramsList->Add(fhTOFSignalVsP[0]);
+      fHistogramsList->Add(fhTOFSignalVsP[1]);
+    }
+
+    TH1::AddDirectory(oldstatus);
+  }
+}
+
+/// \cond CLASSIMP
+ClassImp(AliCSTrackSelection);
+/// \endcond

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSTrackSelection.h
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSTrackSelection.h
@@ -1,0 +1,104 @@
+#ifndef ALICSTRACKSELECTION_H
+#define ALICSTRACKSELECTION_H
+
+/// \file AliCSTrackSelection.h
+/// \brief Track selection cuts support for the correlations studies tasks
+///
+
+#include <TNamed.h>
+#include <TObjArray.h>
+#include "AliCSTrackCutsBase.h"
+
+class TBits;
+class TH1F;
+class TH2F;
+class AliVTrack;
+class TParticle;
+class AliPIDResponse;
+
+/// \class AliCSTrackSelection
+/// \brief Class which implements the whole set of track selection cuts
+///
+/// The track selection is based in two set of cuts one of them is the
+/// inclusive set and the other is the exclusive one. For a potential track
+/// to be accepted it has to pass at least one of the inclusive cuts and
+/// none of the exclusive ones. Otherwise the track will be rejected.
+///
+/// \author Víctor González <victor.gonzalez@cern.ch>, UCM
+/// \date Feb 12, 2017
+
+class AliCSTrackSelection : public TNamed {
+public:
+                                     AliCSTrackSelection();
+                                     AliCSTrackSelection(const char *name, const char * title);
+  virtual                           ~AliCSTrackSelection();
+
+  Bool_t                             InitializeFromString(const char *confstring);
+                                     /// Sets the desired level for the QA histograms output
+                                     /// \param level the desired QA histograms output level
+  void                               SetQALevelOutput(AliCSAnalysisCutsBase::QALevel level) { fQALevel = level; }
+                                     /// Get the histograms list
+                                     /// \return the histograms list
+  virtual TList                     *GetHistogramsList() { return fHistogramsList; }
+
+
+  virtual void                       InitCuts(const char *name = NULL);
+  virtual void                       NotifyRun();
+  virtual void                       NotifyEvent();
+  virtual Bool_t                     IsTrackAccepted(AliVTrack *trk);
+  virtual Bool_t                     IsTrueTrackAccepted(AliVTrack *trk);
+  virtual Bool_t                     IsTrueTrackAccepted(Int_t itrk);
+
+  static Bool_t                      IsTruePrimary(AliVTrack *trk);
+  Bool_t                             IsFromMCInjectedSignal(Int_t itrk);
+
+private:
+  void                               DefineHistograms();
+
+private:
+  AliCSAnalysisCutsBase::QALevel     fQALevel;                           ///< the level of the QA histograms output
+  TObjArray                          fInclusiveTrackCuts;                ///< the set of inclusive track cuts
+  TObjArray                          fInclusivePIDCuts;                  ///< the set of inclusive PID track cuts
+  TObjArray                          fInclusiveCutsStrings;              ///< the strings to configure the inclusive track cuts
+  TObjArray                          fInclusivePidCutsStrings;           ///< the strings to configure the PID inclusive cuts
+  TObjArray                          fExclusiveCuts;                     ///< the set of exclusive track cuts
+  TObjArray                          fExclusiveCutsStrings;              ///< the strings to configure the exclusive track cuts
+  TObjArray                          fExclusivePidCutsStrings;           ///< the strings to configure the PID exclusive cuts
+  TBits                             *fCutsActivatedMask;                 ///< the mask of cut activated for the ongoing event
+  TString                            fCutsString;                        ///< the string that configures the set of cuts
+
+  AliCSAnalysisCutsBase::ProdPeriods fDataPeriod;                        ///< the current period under analysis
+  Int_t                              fHighestPrimaryLabel;               ///< the highest primary label accepted when MC signals are injected
+  AliPIDResponse                    *fPIDResponse;                       ///< the PID response instance
+
+  /* histograms with two indices: before (0) / after (1) applying the cut */
+  TH1F                              *fhCutsStatistics;                   ///< the cuts statistics
+  TH2F                              *fhCutsCorrelation;                  ///< cuts correlation
+  TH2F                              *fhPtVsDCAxy[2];                     ///< \f$ p_{T} \f$ vs \f$ \mbox{DCA}_{XY} \f$ (b/a)
+  TH2F                              *fhPtVsDCAz[2];                      ///< \f$ p_{T} \f$ vs \f$ \mbox{DCA}_{Z} \f$ (b/a)
+  TH2F                              *fhPtVsTPCCls[2];                    ///< \f$ p_{T} \f$ vs TPC clusters (b/a)
+  TH2F                              *fhPtVsTPCRowOverFindCls[2];         ///< \f$ p_{T} \f$ vs TPC crossed rows findable clusters ratio (b/a)
+  TH2F                              *fhEtaVsPhi[2];                      ///< \f$ p_{T} \f$ vs \f$ \eta \f$ (b/a)
+  TH2F                              *fhPtVsEta[2];                       ///< \f$ p_{T} \f$ vs \f$ \eta \f$ (b/a)
+  TH2F                              *fhITSdEdxSignalVsP[2];              ///< ITS dE/dx signal vs P (b/a)
+  TH2F                              *fhTPCdEdxSignalVsP[2];              ///< TPC dE/dx signal vs P(b/a)
+  TH2F                              *fhTOFSignalVsP[2];                  ///< TOF signal vs P(b/a)
+
+  TList                             *fHistogramsList;                    ///< the list of histograms used
+
+  /// Copy constructor
+  /// Not allowed. Forced private.
+  AliCSTrackSelection(const AliCSTrackSelection&);
+  /// Assignment operator
+  /// Not allowed. Forced private.
+  /// \return l-value reference object
+  AliCSTrackSelection& operator=(const AliCSTrackSelection&);
+
+  /// \cond CLASSIMP
+  ClassDef(AliCSTrackSelection,1);
+  /// \endcond
+};
+
+
+
+#endif /* ALICSTRACKSELECTION_H */

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliDptDptCorrelations.cxx
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliDptDptCorrelations.cxx
@@ -1,0 +1,1523 @@
+/**************************************************************************
+* Copyright(c) 1998-2016, ALICE Experiment at CERN, All rights reserved.  *
+*                                                                         *
+* Permission to use, copy, modify and distribute this software and its    *
+* documentation strictly for non-commercial purposes is hereby granted    *
+* without fee, provided that the above copyright notice appears in all    *
+* copies and that both the copyright notice and this permission notice    *
+* appear in the supporting documentation. The authors make no claims      *
+* about the suitability of this software for any purpose. It is           *
+* provided "as is" without express or implied warranty.                   *
+**************************************************************************/
+
+/// \file AliDptDptCorrelations.cxx
+/// \brief Implementation of the AliDptDptCorrelations class
+
+#include <TList.h>
+#include <TParameter.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <TH3.h>
+#include <THn.h>
+#include <TProfile.h>
+#include <TMath.h>
+#include <TParticle.h>
+#include <TParticlePDG.h>
+#include "AliLog.h"
+#include "AliVEvent.h"
+#include "AliVTrack.h"
+#include "AliAODMCParticle.h"
+#include "AliAnalysisManager.h"
+#include "AliDptDptCorrelations.h"
+
+/// Default constructor for object serialization
+AliDptDptCorrelations::AliDptDptCorrelations() :
+    TNamed(),
+    fOutput(NULL),
+    fVertexZ(0.0),
+    fIxVertexZ(0),
+    fCentrality(0.0),
+    fSinglesOnly(kTRUE),
+    fUseWeights(kFALSE),
+    fUseSimulation(kFALSE),
+    fSameSign(kFALSE),
+    fAllCombinations(kFALSE),
+    fRequestedCharge_1(1),
+    fRequestedCharge_2(-1),
+    /* the arrays with tracks 1 and 2 information */
+    fArraySize(5*1024),
+    fNoOfTracks1(0),
+    fId_1(NULL),
+    fCharge_1(NULL),
+    fIxEtaPhi_1(NULL),
+    fIxPt_1(NULL),
+    fPt_1(NULL),
+    fCorrection_1(NULL),
+    fNoOfTracks2(0),
+    fId_2(NULL),
+    fCharge_2(NULL),
+    fIxEtaPhi_2(NULL),
+    fIxPt_2(NULL),
+    fPt_2(NULL),
+    fCorrection_2(NULL),
+    /* correction weights */
+    fCorrectionWeights_1(NULL),
+    fCorrectionWeights_2(NULL),
+    /* efficiency correction */
+    fEfficiencyCorrection_1(NULL),
+    fEfficiencyCorrection_2(NULL),
+    fPairsEfficiency_PP(NULL),
+    fPairsEfficiency_PM(NULL),
+    fPairsEfficiency_MM(NULL),
+    fPairsEfficiency_MP(NULL),
+    /* simulation pdfs */
+    fPositiveTrackPdfs(NULL),
+    fNegativeTrackPdfs(NULL),
+    fPositiveTrackCurrentPdf(NULL),
+    fNegativeTrackCurrentPdf(NULL),
+    fSimEventsPerEvent(1),
+    /* vertex bins */
+    fNBins_vertexZ(40),
+    fMin_vertexZ(-10.0),
+    fMax_vertexZ(10.0),
+    fWidth_vertexZ(0.5),
+    /* phi origin shift */
+    fNBinsPhiShift(0.0),
+    /* pT1 bins */
+    fNBins_pt_1(18),
+    fMin_pt_1(0.2),
+    fMax_pt_1(2.0),
+    fWidth_pt_1(0.1),
+    /* phi1 bins */
+    fNBins_phi_1(72),
+    fMin_phi_1(0.0),
+    fMax_phi_1(TMath::Pi()*2.0),
+    fWidth_phi_1(TMath::Pi()*2.0/72.0),
+    /* eta1 bins */
+    fNBins_eta_1(20),
+    fMin_eta_1(-1.0),
+    fMax_eta_1(1.0),
+    fWidth_eta_1(0.1),
+    fNBins_etaPhi_1(1440),
+    fNBins_etaPhiPt_1(25920),
+    fNBins_zEtaPhiPt_1(1036800),
+    /* pT2 bins */
+    fNBins_pt_2(18),
+    fMin_pt_2(0.2),
+    fMax_pt_2(2.0),
+    fWidth_pt_2(0.1),
+    /* phi2 bins */
+    fNBins_phi_2(72),
+    fMin_phi_2(0.0),
+    fMax_phi_2(TMath::Pi()*2.0),
+    fWidth_phi_2(TMath::Pi()*2.0/72.0),
+    /* eta2 bins */
+    fNBins_eta_2(20),
+    fMin_eta_2(-1.0),
+    fMax_eta_2(1.0),
+    fWidth_eta_2(0.1),
+    fNBins_etaPhi_2(1440),
+    fNBins_etaPhiPt_2(25920),
+    fNBins_zEtaPhiPt_2(1036800),
+    fNBins_etaPhi_12(2073600),
+    /* accumulated values */
+    fN1_1(0.0),
+    fN1_2(0.0),
+    fN2_12(0.0),
+    fNnw1_1(0.0),
+    fNnw1_2(0.0),
+    fNnw2_12(0.0),
+    fSum1Pt_1(0.0),
+    fSum1Pt_2(0.0),
+    fSum2PtPt_12(0.0),
+    fSum1Ptnw_1(0.0),
+    fSum1Ptnw_2(0.0),
+    fSum2PtPtnw_12(0.0),
+    fSum2NPt_12(0.0),
+    fSum2PtN_12(0.0),
+    fSum2NPtnw_12(0.0),
+    fSum2PtNnw_12(0.0),
+    /* storage arrays */
+    fN1_1_vsPt(NULL),
+    fN1_1_vsEtaPhi(NULL),
+    fSum1Pt_1_vsEtaPhi(NULL),
+    fN1_1_vsZEtaPhiPt(NULL),
+    fN1_2_vsPt(NULL),
+    fN1_2_vsEtaPhi(NULL),
+    fSum1Pt_2_vsEtaPhi(NULL),
+    fN1_2_vsZEtaPhiPt(NULL),
+    fN2_12_vsPtPt(NULL),
+    fN2_12_vsEtaPhi(NULL),
+    fSum2PtPt_12_vsEtaPhi(NULL),
+    fSum2PtN_12_vsEtaPhi(NULL),
+    fSum2NPt_12_vsEtaPhi(NULL),
+    /* histograms */
+    fhN1_1_vsPt(NULL),
+    fhN1_1_vsEtaPhi(NULL),
+    fhSum1Pt_1_vsEtaPhi(NULL),
+    fhN1_1_vsZEtaPhiPt(NULL),
+    fhN1_2_vsPt(NULL),
+    fhN1_2_vsEtaPhi(NULL),
+    fhSum1Pt_2_vsEtaPhi(NULL),
+    fhN1_2_vsZEtaPhiPt(NULL),
+    fhN2_12_vsPtPt(NULL),
+    fhN2_12_vsEtaPhi(NULL),
+    fhSum2PtPt_12_vsEtaPhi(NULL),
+    fhSum2PtN_12_vsEtaPhi(NULL),
+    fhSum2NPt_12_vsEtaPhi(NULL),
+    /* vs centrality profiles */
+    fhN1_1_vsC(NULL),
+    fhSum1Pt_1_vsC(NULL),
+    fhN1nw_1_vsC(NULL),
+    fhSum1Ptnw_1_vsC(NULL),
+    fhN1_2_vsC(NULL),
+    fhSum1Pt_2_vsC(NULL),
+    fhN1nw_2_vsC(NULL),
+    fhSum1Ptnw_2_vsC(NULL),
+    fhN2_12_vsC(NULL),
+    fhSum2PtPt_12_vsC(NULL),
+    fhSum2PtN_12_vsC(NULL),
+    fhSum2NPt_12_vsC(NULL),
+    fhN2nw_12_vsC(NULL),
+    fhSum2PtPtnw_12_vsC(NULL),
+    fhSum2PtNnw_12_vsC(NULL),
+    fhSum2NPtnw_12_vsC(NULL)
+{
+
+}
+
+/// Normal constructor
+/// \param name the name for the object instance
+AliDptDptCorrelations::AliDptDptCorrelations(const char *name) :
+    TNamed(name,name),
+    fOutput(NULL),
+    fVertexZ(0.0),
+    fIxVertexZ(0),
+    fCentrality(0.0),
+    fSinglesOnly(kTRUE),
+    fUseWeights(kFALSE),
+    fUseSimulation(kFALSE),
+    fSameSign(kFALSE),
+    fAllCombinations(kFALSE),
+    fRequestedCharge_1(1),
+    fRequestedCharge_2(-1),
+    /* the arrays with tracks 1 and 2 information */
+    fArraySize(5*1024),
+    fNoOfTracks1(0),
+    fId_1(NULL),
+    fCharge_1(NULL),
+    fIxEtaPhi_1(NULL),
+    fIxPt_1(NULL),
+    fPt_1(NULL),
+    fCorrection_1(NULL),
+    fNoOfTracks2(0),
+    fId_2(NULL),
+    fCharge_2(NULL),
+    fIxEtaPhi_2(NULL),
+    fIxPt_2(NULL),
+    fPt_2(NULL),
+    fCorrection_2(NULL),
+    /* correction weights */
+    fCorrectionWeights_1(NULL),
+    fCorrectionWeights_2(NULL),
+    /* efficiency correction */
+    fEfficiencyCorrection_1(NULL),
+    fEfficiencyCorrection_2(NULL),
+    fPairsEfficiency_PP(NULL),
+    fPairsEfficiency_PM(NULL),
+    fPairsEfficiency_MM(NULL),
+    fPairsEfficiency_MP(NULL),
+    /* simulation pdfs */
+    fPositiveTrackPdfs(NULL),
+    fNegativeTrackPdfs(NULL),
+    fPositiveTrackCurrentPdf(NULL),
+    fNegativeTrackCurrentPdf(NULL),
+    fSimEventsPerEvent(1),
+    /* vertex bins */
+    fNBins_vertexZ(40),
+    fMin_vertexZ(-10.0),
+    fMax_vertexZ(10.0),
+    fWidth_vertexZ(0.5),
+    /* phi origin shift */
+    fNBinsPhiShift(0.0),
+    /* pT1 bins */
+    fNBins_pt_1(18),
+    fMin_pt_1(0.2),
+    fMax_pt_1(2.0),
+    fWidth_pt_1(0.1),
+    /* phi1 bins */
+    fNBins_phi_1(72),
+    fMin_phi_1(0.0),
+    fMax_phi_1(TMath::Pi()*2.0),
+    fWidth_phi_1(TMath::Pi()*2.0/72.0),
+    /* eta1 bins */
+    fNBins_eta_1(20),
+    fMin_eta_1(-1.0),
+    fMax_eta_1(1.0),
+    fWidth_eta_1(0.1),
+    fNBins_etaPhi_1(1440),
+    fNBins_etaPhiPt_1(25920),
+    fNBins_zEtaPhiPt_1(1036800),
+    /* pT2 bins */
+    fNBins_pt_2(18),
+    fMin_pt_2(0.2),
+    fMax_pt_2(2.0),
+    fWidth_pt_2(0.1),
+    /* phi2 bins */
+    fNBins_phi_2(72),
+    fMin_phi_2(0.0),
+    fMax_phi_2(TMath::Pi()*2.0),
+    fWidth_phi_2(TMath::Pi()*2.0/72.0),
+    /* eta2 bins */
+    fNBins_eta_2(20),
+    fMin_eta_2(-1.0),
+    fMax_eta_2(1.0),
+    fWidth_eta_2(0.1),
+    fNBins_etaPhi_2(1440),
+    fNBins_etaPhiPt_2(25920),
+    fNBins_zEtaPhiPt_2(1036800),
+    fNBins_etaPhi_12(2073600),
+    /* accumulated values */
+    fN1_1(0.0),
+    fN1_2(0.0),
+    fN2_12(0.0),
+    fNnw1_1(0.0),
+    fNnw1_2(0.0),
+    fNnw2_12(0.0),
+    fSum1Pt_1(0.0),
+    fSum1Pt_2(0.0),
+    fSum2PtPt_12(0.0),
+    fSum1Ptnw_1(0.0),
+    fSum1Ptnw_2(0.0),
+    fSum2PtPtnw_12(0.0),
+    fSum2NPt_12(0.0),
+    fSum2PtN_12(0.0),
+    fSum2NPtnw_12(0.0),
+    fSum2PtNnw_12(0.0),
+    /* storage arrays */
+    fN1_1_vsPt(NULL),
+    fN1_1_vsEtaPhi(NULL),
+    fSum1Pt_1_vsEtaPhi(NULL),
+    fN1_1_vsZEtaPhiPt(NULL),
+    fN1_2_vsPt(NULL),
+    fN1_2_vsEtaPhi(NULL),
+    fSum1Pt_2_vsEtaPhi(NULL),
+    fN1_2_vsZEtaPhiPt(NULL),
+    fN2_12_vsPtPt(NULL),
+    fN2_12_vsEtaPhi(NULL),
+    fSum2PtPt_12_vsEtaPhi(NULL),
+    fSum2PtN_12_vsEtaPhi(NULL),
+    fSum2NPt_12_vsEtaPhi(NULL),
+    /* histograms */
+    fhN1_1_vsPt(NULL),
+    fhN1_1_vsEtaPhi(NULL),
+    fhSum1Pt_1_vsEtaPhi(NULL),
+    fhN1_1_vsZEtaPhiPt(NULL),
+    fhN1_2_vsPt(NULL),
+    fhN1_2_vsEtaPhi(NULL),
+    fhSum1Pt_2_vsEtaPhi(NULL),
+    fhN1_2_vsZEtaPhiPt(NULL),
+    fhN2_12_vsPtPt(NULL),
+    fhN2_12_vsEtaPhi(NULL),
+    fhSum2PtPt_12_vsEtaPhi(NULL),
+    fhSum2PtN_12_vsEtaPhi(NULL),
+    fhSum2NPt_12_vsEtaPhi(NULL),
+    /* vs centrality profiles */
+    fhN1_1_vsC(NULL),
+    fhSum1Pt_1_vsC(NULL),
+    fhN1nw_1_vsC(NULL),
+    fhSum1Ptnw_1_vsC(NULL),
+    fhN1_2_vsC(NULL),
+    fhSum1Pt_2_vsC(NULL),
+    fhN1nw_2_vsC(NULL),
+    fhSum1Ptnw_2_vsC(NULL),
+    fhN2_12_vsC(NULL),
+    fhSum2PtPt_12_vsC(NULL),
+    fhSum2PtN_12_vsC(NULL),
+    fhSum2NPt_12_vsC(NULL),
+    fhN2nw_12_vsC(NULL),
+    fhSum2PtPtnw_12_vsC(NULL),
+    fhSum2PtNnw_12_vsC(NULL),
+    fhSum2NPtnw_12_vsC(NULL)
+{
+
+}
+
+/// \brief Default destructor
+/// Deallocates the allocated memory
+AliDptDptCorrelations::~AliDptDptCorrelations() {
+  if (fN1_1_vsPt != NULL) delete [] fN1_1_vsPt;
+  if (fN1_1_vsEtaPhi != NULL) delete [] fN1_1_vsEtaPhi;
+  if (fSum1Pt_1_vsEtaPhi != NULL) delete [] fSum1Pt_1_vsEtaPhi;
+  if (fN1_1_vsZEtaPhiPt != NULL) delete [] fN1_1_vsZEtaPhiPt;
+  if (fN1_2_vsPt != NULL) delete [] fN1_2_vsPt;
+  if (fN1_2_vsEtaPhi != NULL) delete [] fN1_2_vsEtaPhi;
+  if (fSum1Pt_2_vsEtaPhi != NULL) delete [] fSum1Pt_2_vsEtaPhi;
+  if (fN1_2_vsZEtaPhiPt != NULL) delete [] fN1_2_vsZEtaPhiPt;
+  if (fN2_12_vsPtPt != NULL) delete [] fN2_12_vsPtPt;
+  if (fN2_12_vsEtaPhi != NULL) delete [] fN2_12_vsEtaPhi;
+  if (fSum2PtPt_12_vsEtaPhi != NULL) delete [] fSum2PtPt_12_vsEtaPhi;
+  if (fSum2PtN_12_vsEtaPhi != NULL) delete [] fSum2PtN_12_vsEtaPhi;
+  if (fSum2NPt_12_vsEtaPhi != NULL) delete [] fSum2NPt_12_vsEtaPhi;
+  if (fCorrectionWeights_1 != NULL) delete [] fCorrectionWeights_1;
+  if (fCorrectionWeights_2 != NULL) delete [] fCorrectionWeights_2;
+  if (fEfficiencyCorrection_1 != NULL) delete [] fEfficiencyCorrection_1;
+  if (fEfficiencyCorrection_2 != NULL) delete [] fEfficiencyCorrection_2;
+  if (fOutput && !AliAnalysisManager::GetAnalysisManager()->IsProofMode()) {
+      delete fOutput;
+  }
+}
+
+
+/// \brief Establishes the binning configuration
+/// \param confstring string containing the binning configuration parameters
+void AliDptDptCorrelations::ConfigureBinning(const char *confstring) {
+
+  Double_t min_pt, max_pt, width_pt;
+  Double_t min_eta, max_eta, width_eta;
+
+  sscanf(confstring, "phishift:%lf;%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf",
+      &fNBinsPhiShift,
+      &fMin_vertexZ, &fMax_vertexZ, &fWidth_vertexZ,
+      &min_pt, &max_pt, &width_pt,
+      &min_eta, &max_eta, &width_eta);
+
+  fMin_pt_1 = fMin_pt_2 = min_pt;
+  fMax_pt_1 = fMax_pt_2 = max_pt;
+  fWidth_pt_1 = fWidth_pt_2 = width_pt;
+  fMin_eta_1 = fMin_eta_2 = min_eta;
+  fMax_eta_1 = fMax_eta_2 = max_eta;
+  fWidth_eta_1 = fWidth_eta_2 = width_eta;
+  AliInfo("=====================================================");
+  AliInfo(Form("Configured binning: %s", GetBinningConfigurationString().Data()));
+  AliInfo("=====================================================");
+}
+
+/// \brief Build the configuration string
+/// \return the configuration string corresponding to the current configuration
+TString AliDptDptCorrelations::GetBinningConfigurationString() const {
+  if (fMin_pt_1 != fMin_pt_2 || fMax_pt_2 != fMax_pt_2 || fWidth_pt_1 != fWidth_pt_2 ||
+      fMin_eta_1 != fMin_eta_2 || fMax_eta_1 != fMax_eta_2 || fWidth_eta_1 != fWidth_eta_2) {
+    return TString(Form("WrongAsymmetricBinning:phishift:%.1f;%.1f,%.1f,%.1f,%.1f,%.1f,%.1f,%.1f,%.1f,%.1f",
+        fNBinsPhiShift,
+        fMin_vertexZ, fMax_vertexZ, fWidth_vertexZ,
+        fMin_pt_1, fMax_pt_1, fWidth_pt_1,
+        fMin_eta_1, fMax_eta_1, fWidth_eta_1));
+  }
+  else {
+    return TString(Form("Binning:phishift:%.1f;%.1f,%.1f,%.1f,%.1f,%.1f,%.1f,%.1f,%.1f,%.1f",
+        fNBinsPhiShift,
+        fMin_vertexZ, fMax_vertexZ, fWidth_vertexZ,
+        fMin_pt_1, fMax_pt_1, fWidth_pt_1,
+        fMin_eta_1, fMax_eta_1, fWidth_eta_1));
+  }
+}
+
+
+/// \brief Initializes the member data structures
+/// Allocates the needed memory an create the output histograms.
+void AliDptDptCorrelations::Initialize()
+{
+  Bool_t oldstatus = TH1::AddDirectoryStatus();
+  TH1::AddDirectory(kFALSE);
+
+  fOutput = new TList();
+  fOutput->SetName(GetName());
+  fOutput->SetOwner();
+
+
+  fNBins_vertexZ     = Int_t(0.5 + (fMax_vertexZ - fMin_vertexZ) / fWidth_vertexZ);
+  fNBins_pt_1        = Int_t(0.5 + (fMax_pt_1 - fMin_pt_1 ) / fWidth_pt_1);
+  fNBins_eta_1       = Int_t(0.5 + (fMax_eta_1 - fMin_eta_1) / fWidth_eta_1);
+  fWidth_phi_1       = (fMax_phi_1  - fMin_phi_1) / fNBins_phi_1;
+  fNBins_etaPhi_1    = fNBins_phi_1 * fNBins_eta_1;
+  fNBins_etaPhiPt_1  = fNBins_etaPhi_1 * fNBins_pt_1;
+  fNBins_zEtaPhiPt_1 = fNBins_vertexZ * fNBins_etaPhiPt_1;
+  fNBins_pt_2        = Int_t(0.5 + (fMax_pt_2 - fMin_pt_2 ) / fWidth_pt_2);
+  fNBins_eta_2       = Int_t(0.5 + (fMax_eta_2 - fMin_eta_2) / fWidth_eta_2);
+  fWidth_phi_2       = (fMax_phi_2  - fMin_phi_2) / fNBins_phi_2;
+  fNBins_etaPhi_2    = fNBins_phi_2 * fNBins_eta_2;
+  fNBins_etaPhiPt_2  = fNBins_etaPhi_2 * fNBins_pt_2;
+  fNBins_zEtaPhiPt_2 = fNBins_vertexZ * fNBins_etaPhiPt_2;
+  fNBins_etaPhi_12   = fNBins_etaPhi_1 * fNBins_etaPhi_2;
+
+  /* incorporate configuration parameters */
+  fOutput->Add(new TParameter<Bool_t>("HalfSymmetricResults",kTRUE,'f'));
+  fOutput->Add(new TParameter<Int_t>("NoBinsVertexZ",fNBins_vertexZ,'f'));
+  fOutput->Add(new TParameter<Int_t>("NoBinsPt",fNBins_pt_1,'f'));
+  fOutput->Add(new TParameter<Int_t>("NoBinsEta",fNBins_eta_1,'f'));
+  fOutput->Add(new TParameter<Int_t>("NoBinsPhi",fNBins_phi_1,'f'));
+  fOutput->Add(new TParameter<Double_t>("MinVertexZ",fMin_vertexZ,'f'));
+  fOutput->Add(new TParameter<Double_t>("MaxVertexZ",fMax_vertexZ,'f'));
+  fOutput->Add(new TParameter<Double_t>("MinPt",fMin_pt_1,'f'));
+  fOutput->Add(new TParameter<Double_t>("MaxPt",fMax_pt_1,'f'));
+  fOutput->Add(new TParameter<Double_t>("MinEta",fMin_eta_1,'f'));
+  fOutput->Add(new TParameter<Double_t>("MaxEta",fMax_eta_1,'f'));
+  fOutput->Add(new TParameter<Double_t>("MinPhi",fMin_phi_1,'f'));
+  fOutput->Add(new TParameter<Double_t>("MaxPhi",fMax_phi_1,'f'));
+
+  /* after the parameters dump the proper phi limits are set according to the phi shift */
+  fMax_phi_1         = fMax_phi_1 - fWidth_phi_1 * fNBinsPhiShift;
+  fMin_phi_1         = fMin_phi_1 - fWidth_phi_1 * fNBinsPhiShift;
+  fMax_phi_2         = fMax_phi_2 - fWidth_phi_2 * fNBinsPhiShift;
+  fMin_phi_2         = fMin_phi_2 - fWidth_phi_2 * fNBinsPhiShift;
+
+
+  /* track 1 storage */
+  fId_1 = new Int_t[fArraySize];
+  fCharge_1 = new Int_t[fArraySize];
+  fIxEtaPhi_1 = new Int_t[fArraySize];
+  fIxPt_1 = new Int_t[fArraySize];
+  fPt_1 = new Float_t[fArraySize];
+  fCorrection_1 = new Float_t[fArraySize];
+  fN1_1_vsPt = new Double_t[fNBins_pt_1]; for (Int_t i = 0; i < fNBins_pt_1; i++) fN1_1_vsPt[i] = 0.0;
+  fN1_1_vsEtaPhi = new Double_t[fNBins_etaPhi_1]; for (Int_t i = 0; i < fNBins_etaPhi_1; i++) fN1_1_vsEtaPhi[i] = 0.0;
+  fSum1Pt_1_vsEtaPhi = new Double_t[fNBins_etaPhi_1]; for (Int_t i = 0; i < fNBins_etaPhi_1; i++) fSum1Pt_1_vsEtaPhi[i] = 0.0;
+  fN1_1_vsZEtaPhiPt = new Float_t[fNBins_zEtaPhiPt_1]; for (Int_t i = 0; i < fNBins_zEtaPhiPt_1; i++) fN1_1_vsZEtaPhiPt[i] = 0.0;
+
+  /* track 2 storage */
+  fId_2 = new Int_t[fArraySize];
+  fCharge_2 = new Int_t[fArraySize];
+  fIxEtaPhi_2 = new Int_t[fArraySize];
+  fIxPt_2 = new Int_t[fArraySize];
+  fPt_2 = new Float_t[fArraySize];
+  fCorrection_2 = new Float_t[fArraySize];
+  fN1_2_vsPt = new Double_t[fNBins_pt_2]; for (Int_t i = 0; i < fNBins_pt_2; i++) fN1_2_vsPt[i] = 0.0;
+  fN1_2_vsEtaPhi = new Double_t[fNBins_etaPhi_2]; for (Int_t i = 0; i < fNBins_etaPhi_2; i++) fN1_2_vsEtaPhi[i] = 0.0;
+  fSum1Pt_2_vsEtaPhi = new Double_t[fNBins_etaPhi_2]; for (Int_t i = 0; i < fNBins_etaPhi_2; i++) fSum1Pt_2_vsEtaPhi[i] = 0.0;
+  fN1_2_vsZEtaPhiPt = new Float_t[fNBins_zEtaPhiPt_2]; for (Int_t i = 0; i < fNBins_zEtaPhiPt_2; i++) fN1_2_vsZEtaPhiPt[i] = 0.0;
+
+  fN2_12_vsPtPt = new Double_t[fNBins_pt_1*fNBins_pt_2]; for (Int_t i = 0; i < fNBins_pt_1*fNBins_pt_2; i++) fN2_12_vsPtPt[i] = 0.0;
+  fN2_12_vsEtaPhi = new Float_t[fNBins_etaPhi_12]; for (Int_t i = 0; i < fNBins_etaPhi_12; i++) fN2_12_vsEtaPhi[i] = 0.0;
+  fSum2PtPt_12_vsEtaPhi = new Float_t[fNBins_etaPhi_12]; for (Int_t i = 0; i < fNBins_etaPhi_12; i++) fSum2PtPt_12_vsEtaPhi[i] = 0.0;
+  fSum2PtN_12_vsEtaPhi = new Float_t[fNBins_etaPhi_12]; for (Int_t i = 0; i < fNBins_etaPhi_12; i++) fSum2PtN_12_vsEtaPhi[i] = 0.0;
+  fSum2NPt_12_vsEtaPhi = new Float_t[fNBins_etaPhi_12]; for (Int_t i = 0; i < fNBins_etaPhi_12; i++) fSum2NPt_12_vsEtaPhi[i] = 0.0;
+
+  if (fSinglesOnly)  {
+    fhN1_1_vsPt = new TH1F("n1_1_vsPt","#LT n_{1} #GT;p_{t,1} (GeV/c);#LT n_{1} #GT", fNBins_pt_1,  fMin_pt_1,  fMax_pt_1);
+    fhN1_1_vsZEtaPhiPt = new TH3F("n1_1_vsZ_vsEtaPhi_vsPt","#LT n_{1} #GT;vtx_{z};#eta_{1}#times#varphi_{1};p_{t,1} (GeV/c)",
+        fNBins_vertexZ,fMin_vertexZ,fMax_vertexZ, fNBins_etaPhi_1,0.0,Double_t(fNBins_etaPhi_1),fNBins_pt_1,fMin_pt_1,fMax_pt_1);
+
+    fhN1_2_vsPt = new TH1F("n1_2_vsPt","#LT n_{1} #GT;p_{t,2} (GeV/c);#LT n_{1} #GT", fNBins_pt_2,  fMin_pt_2,  fMax_pt_2);
+    fhN1_2_vsZEtaPhiPt = new TH3F("n1_2_vsZ_vsEtaPhi_vsPt","#LT n_{2} #GT;vtx_{z};#eta_{2}#times#varphi_{2};p_{t,2} (GeV/c)",
+        fNBins_vertexZ,fMin_vertexZ,fMax_vertexZ, fNBins_etaPhi_2,0.0,Double_t(fNBins_etaPhi_2),fNBins_pt_2,fMin_pt_2,fMax_pt_2);
+
+    fOutput->Add(fhN1_1_vsPt);
+    fOutput->Add(fhN1_1_vsZEtaPhiPt);
+    fOutput->Add(fhN1_2_vsPt);
+    fOutput->Add(fhN1_2_vsZEtaPhiPt);
+  }
+  else {
+    fhN1_1_vsEtaPhi = new TH2F("n1_1_vsEtaPhi","#LT n_{1} #GT;#eta_{1};#varphi_{1} (radian);#LT n_{1} #GT",
+        fNBins_eta_1, fMin_eta_1, fMax_eta_1,  fNBins_phi_1, fMin_phi_1, fMax_phi_1);
+    fhSum1Pt_1_vsEtaPhi = new TH2F("sumPt_1_vsEtaPhi","#LT #Sigma p_{t,1} #GT;#eta_{1};#varphi_{1} (radian);#LT #Sigma p_{t,1} #GT (GeV/c)",
+        fNBins_eta_1,fMin_eta_1,fMax_eta_1,fNBins_phi_1,fMin_phi_1,fMax_phi_1);
+    fhN1_1_vsC = new TProfile("n1_1_vsM","#LT n_{1} #GT (weighted);Centrality (%);#LT n_{1} #GT",100,0.0,100.0);
+    fhSum1Pt_1_vsC = new TProfile("sumPt_1_vsM","#LT #Sigma p_{t,1} #GT (weighted);Centrality (%);#LT #Sigma p_{t,1} #GT (GeV/c)",100,0.0,100.0);
+    fhN1nw_1_vsC = new TProfile("n1Nw_1_vsM","#LT n_{1} #GT;Centrality (%);#LT n_{1} #GT",100,0.0,100.0);
+    fhSum1Ptnw_1_vsC = new TProfile("sumPtNw_1_vsM","#LT #Sigma p_{t,1} #GT;Centrality (%);#LT #Sigma p_{t,1} #GT (GeV/c)",100,0.0,100.0);
+
+    fhN1_2_vsEtaPhi = new TH2F("n1_2_vsEtaPhi","#LT n_{1} #GT;#eta_{2};#varphi_{2} (radian);#LT n_{1} #GT",
+        fNBins_eta_2, fMin_eta_2, fMax_eta_2,  fNBins_phi_2, fMin_phi_2, fMax_phi_2);
+    fhSum1Pt_2_vsEtaPhi = new TH2F("sumPt_2_vsEtaPhi","#LT #Sigma p_{t,2} #GT;#eta_{2};#varphi_{2} (radian);#LT #Sigma p_{t,2} #GT (GeV/c)",
+        fNBins_eta_2,fMin_eta_2,fMax_eta_2,fNBins_phi_2,fMin_phi_2,fMax_phi_2);
+    fhN1_2_vsC = new TProfile("n1_2_vsM","#LT n_{1} #GT (weighted);Centrality (%);#LT n_{1} #GT",100,0.0,100.0);
+    fhSum1Pt_2_vsC = new TProfile("sumPt_2_vsM","#LT #Sigma p_{t,1} #GT (weighted);Centrality (%);#LT #Sigma p_{t,1} #GT (GeV/c)",100,0.0,100.0);
+    fhN1nw_2_vsC = new TProfile("n1Nw_2_vsM","#LT n_{1} #GT;Centrality (%);#LT n_{1} #GT",100,0.0,100.0);
+    fhSum1Ptnw_2_vsC = new TProfile("sumPtNw_2_vsM","#LT #Sigma p_{t,1} #GT;Centrality (%);#LT #Sigma p_{t,1} #GT (GeV/c)",100,0.0,100.0);
+
+    fhN2_12_vsEtaPhi = new TH1F("n2_12_vsEtaPhi","#LT n_{2} #GT;#eta_{1}#times#varphi_{1}#times#eta_{2}#times#varphi_{2};#LT n_{2} #GT",
+        fNBins_etaPhi_12,0.,Double_t(fNBins_etaPhi_12));
+    fhSum2PtPt_12_vsEtaPhi = new TH1F("sumPtPt_12_vsEtaPhi","#LT #Sigma p_{t,1}p_{t,2} #GT;#eta_{1}#times#varphi_{1}#times#eta_{2}#times#varphi_{2};#LT #Sigma p_{t,1}p_{t,2} #GT (GeV)^{2}",
+        fNBins_etaPhi_12,0.,Double_t(fNBins_etaPhi_12));
+    fhSum2PtN_12_vsEtaPhi = new TH1F("sumPtN_12_vsEtaPhi","#LT #Sigma p_{t,1}N #GT;#eta_{1}#times#varphi_{1}#times#eta_{2}#times#varphi_{2};#LT #Sigma p_{t,1}N #GT (GeV)",
+        fNBins_etaPhi_12,0.,Double_t(fNBins_etaPhi_12));
+    fhSum2NPt_12_vsEtaPhi = new TH1F("sumNPt_12_vsEtaPhi","#LT N#Sigma p_{t,2} #GT;#eta_{1}#times#varphi_{1}#times#eta_{2}#times#varphi_{2};#LT N#Sigma p_{t,2} #GT (GeV)",
+        fNBins_etaPhi_12,0.,Double_t(fNBins_etaPhi_12));
+    fhN2_12_vsPtPt = new TH2F("n2_12_vsPtVsPt","#LT n_{2} #GT;p_{t,1} (GeV/c);p_{t,2} (GeV/c);#LT n_{2} #GT",
+        fNBins_pt_1,fMin_pt_1,fMax_pt_1,fNBins_pt_2,fMin_pt_2,fMax_pt_2);
+    fhN2_12_vsC = new TProfile("n2_12_vsM","#LT n_{2} #GT (weighted);Centrality (%);#LT n_{2} #GT",100,0.0,100.0);
+    fhSum2PtPt_12_vsC = new TProfile("sumPtPt_12_vsM","#LT #Sigma p_{t,1}p_{t,2} #GT (weighted);Centrality (%);#LT #Sigma p_{t,1}p_{t,2} #GT (GeV)^{2}",100,0.0,100.0);
+    fhSum2PtN_12_vsC = new TProfile("sumPtN_12_vsM","#LT #Sigma p_{t,1}N #GT (weighted);Centrality (%);#LT #Sigma p_{t,1}N #GT (GeV)",100,0.0,100.0);
+    fhSum2NPt_12_vsC = new TProfile("sumNPt_12_vsM","#LT N#Sigma p_{t,2} #GT (weighted);Centrality (%);#LT N#Sigma p_{t,2} #GT (GeV)",100,0.0,100.0);
+    fhN2nw_12_vsC = new TProfile("n2Nw_12_vsM","#LT n_{2} #GT;Centrality (%);#LT n_{2} #GT",100,0.0,100.0);
+    fhSum2PtPtnw_12_vsC = new TProfile("sumPtPtNw_12_vsM","#LT #Sigma p_{t,1}p_{t,2} #GT;Centrality (%);#LT #Sigma p_{t,1}p_{t,2} #GT (GeV)^{2}",100,0.0,100.0);
+    fhSum2PtNnw_12_vsC = new TProfile("sumPtNNw_12_vsM","#LT #Sigma p_{t,1}N #GT;Centrality (%);#LT #Sigma p_{t,1}N #GT (GeV)",100,0.0,100.0);
+    fhSum2NPtnw_12_vsC = new TProfile("sumNPtNw_12_vsM","#LT N#Sigma p_{t,2} #GT;Centrality (%);#LT N#Sigma p_{t,2} #GT (GeV)",100,0.0,100.0);
+
+    fOutput->Add(fhN1_1_vsEtaPhi);
+    fOutput->Add(fhSum1Pt_1_vsEtaPhi);
+    fOutput->Add(fhN1_1_vsC);
+    fOutput->Add(fhSum1Pt_1_vsC);
+    fOutput->Add(fhN1nw_1_vsC);
+    fOutput->Add(fhSum1Ptnw_1_vsC);
+    fOutput->Add(fhN1_2_vsEtaPhi);
+    fOutput->Add(fhSum1Pt_2_vsEtaPhi);
+    fOutput->Add(fhN1_2_vsC);
+    fOutput->Add(fhSum1Pt_2_vsC);
+    fOutput->Add(fhN1nw_2_vsC);
+    fOutput->Add(fhSum1Ptnw_2_vsC);
+
+    fOutput->Add(fhN2_12_vsEtaPhi);
+    fOutput->Add(fhSum2PtPt_12_vsEtaPhi);
+    fOutput->Add(fhSum2PtN_12_vsEtaPhi);
+    fOutput->Add(fhSum2NPt_12_vsEtaPhi);
+    fOutput->Add(fhN2_12_vsPtPt);
+    fOutput->Add(fhN2_12_vsC);
+    fOutput->Add(fhSum2PtPt_12_vsC);
+    fOutput->Add(fhSum2PtN_12_vsC);
+    fOutput->Add(fhSum2NPt_12_vsC);
+    fOutput->Add(fhN2nw_12_vsC);
+    fOutput->Add(fhSum2PtPtnw_12_vsC);
+    fOutput->Add(fhSum2PtNnw_12_vsC);
+    fOutput->Add(fhSum2NPtnw_12_vsC);
+  }
+
+  TH1::AddDirectory(oldstatus);
+}
+
+/// \brief Stores the correction weights for both set of tracks
+/// \param h3_1 the calibration weights for the first track
+/// \param h3_2 the calibration weights for the second track
+/// \return kTRUE if correctly done kFALSE otherwise
+Bool_t AliDptDptCorrelations::SetWeigths(const TH3F *h3_1, const TH3F *h3_2) {
+  Bool_t done = kTRUE;
+
+  if (fUseWeights){
+    Int_t ixZ, ixEtaPhi, ixPt;
+    if (h3_1) {
+      /* allocate memory for track 1 weights */
+      fCorrectionWeights_1 = new Float_t[fNBins_vertexZ*fNBins_etaPhi_1*fNBins_pt_1];
+
+      for (ixZ = 0; ixZ < fNBins_vertexZ; ixZ++) {
+        for (ixEtaPhi=0; ixEtaPhi < fNBins_etaPhi_1; ixEtaPhi++) {
+          for (ixPt=0; ixPt < fNBins_pt_1; ixPt++) {
+            fCorrectionWeights_1[ixZ*fNBins_etaPhi_1*fNBins_pt_1+ixEtaPhi*fNBins_pt_1+ixPt] = h3_1->GetBinContent(ixZ+1,ixEtaPhi+1,ixPt+1);
+          }
+        }
+      }
+    } // _weight_1
+    else {
+      AliFatal("The weights one histogram is a null pointer. ABORTING!!!");
+      done = kFALSE;
+    }
+
+    if (h3_2) {
+      /* allocate memory for track 1 weights */
+      fCorrectionWeights_2 = new Float_t[fNBins_vertexZ*fNBins_etaPhi_2*fNBins_pt_2];
+
+      for (ixZ = 0; ixZ < fNBins_vertexZ; ixZ++) {
+        for (ixEtaPhi=0; ixEtaPhi < fNBins_etaPhi_2; ixEtaPhi++) {
+          for (ixPt=0; ixPt < fNBins_pt_2; ixPt++) {
+            fCorrectionWeights_2[ixZ*fNBins_etaPhi_2*fNBins_pt_2+ixEtaPhi*fNBins_pt_2+ixPt] = h3_2->GetBinContent(ixZ+1,ixEtaPhi+1,ixPt+1);
+          }
+        }
+      }
+    } // _weight_2
+    else {
+      AliFatal("The weights two histogram is a null pointer. ABORTING!!!");
+      done = kFALSE;
+    }
+  }
+  else {
+    AliError("Setting weights for a not use weights instance. Ignoring it");
+    done = kFALSE;
+  }
+  return done;
+}
+
+/// \brief Stores the efficiency correction for both set of tracks
+/// If the efficiency correction histograms are not present a efficiency correction value 1.0 is stored.
+/// The correction value are always the inverse of the efficiency ones
+///
+/// Usually the efficiency is incorporated in the weights but this method provides
+/// an additional way to incorporate pT dependent efficiency.
+/// \param h1_1 histogram with efficiency values for track one
+/// \param h1_2 histogram with efficiency values for track two
+/// \return kTRUE if everything went ok otherwise kFALSE
+Bool_t AliDptDptCorrelations::SetEfficiencyCorrection(const TH1F *h1_1, const TH1F *h1_2) {
+  Bool_t done = kTRUE;
+
+  if (h1_1 != NULL || h1_2 != NULL){
+    if (h1_1) {
+      /* allocate memory for track 1 efficiency correction */
+      fEfficiencyCorrection_1 = new Float_t[fNBins_pt_1];
+
+      for (Int_t ixPt=0; ixPt < fNBins_pt_1; ixPt++) {
+        Int_t bin = h1_1->GetXaxis()->FindBin(fMin_pt_1 + fWidth_pt_1/2.0 + ixPt*fWidth_pt_1);
+        fEfficiencyCorrection_1[ixPt] = 1.0 / h1_1->GetBinContent(bin);
+      }
+    }
+    else {
+      AliFatal("The efficiency correction histogram one is a null pointer. ABORTING!!!");
+      done = kFALSE;
+    }
+
+    if (h1_2) {
+      /* allocate memory for track 1 efficiency correction */
+      fEfficiencyCorrection_2 = new Float_t[fNBins_pt_2];
+
+      for (Int_t ixPt=0; ixPt < fNBins_pt_2; ixPt++) {
+        Int_t bin = h1_2->GetXaxis()->FindBin(fMin_pt_2 + fWidth_pt_2/2.0 + ixPt*fWidth_pt_2);
+        fEfficiencyCorrection_2[ixPt] = 1.0 / h1_2->GetBinContent(bin);
+      }
+    }
+    else {
+      AliFatal("The efficiency correction histogram two is a null pointer. ABORTING!!!");
+      done = kFALSE;
+    }
+  }
+  else {
+    AliInfo("Setting efficiency correction equal to one for both tracks");
+
+    fEfficiencyCorrection_1 = new Float_t[fNBins_pt_1];
+    for (Int_t ixPt=0; ixPt < fNBins_pt_1; ixPt++) {
+      fEfficiencyCorrection_1[ixPt] = 1.0;
+    }
+    fEfficiencyCorrection_2 = new Float_t[fNBins_pt_2];
+    for (Int_t ixPt=0; ixPt < fNBins_pt_2; ixPt++) {
+      fEfficiencyCorrection_2[ixPt] = 1.0;
+    }
+    done = kTRUE;
+  }
+  AliInfo(Form("Configured efficiency correcton on %s",GetName()));
+  printf("Track one:\n");
+  for (Int_t bin = 0; bin < fNBins_pt_1; bin++) {
+    printf("%f, ", fEfficiencyCorrection_1[bin]);
+    if ((bin+1)%8 == 0) printf("\n");
+  }
+  printf("\n");
+  printf("Track two:\n");
+  for (Int_t bin = 0; bin < fNBins_pt_2; bin++) {
+    printf("%f, ", fEfficiencyCorrection_2[bin]);
+    if ((bin+1)%8 == 0) printf("\n");
+  }
+  printf("\n");
+  return done;
+}
+
+/// \brief Stores the pairs efficiency correction for the four tracks combinations
+/// The correction value is stored as the inverse of the efficiency ones
+/// \param h11 histogram with efficiency values for the one-one pair
+/// \param h12 histogram with efficiency values for the one-two pair
+/// \param h22 histogram with efficiency values for the two-two pair
+/// \param h21 histogram with efficiency values for the two-one pair
+/// \return kTRUE if everything went ok otherwise kFALSE
+Bool_t AliDptDptCorrelations::SetPairEfficiencyCorrection(const THn *h11, const THn *h12, const THn *h22, const THn *h21) {
+  AliInfo("");
+
+  Bool_t done = kTRUE;
+
+  if (h11 != NULL || h12 != NULL || h22 != NULL || h21 != NULL){
+    if (h11) {
+      if (h11->GetNdimensions() != 4) {
+        AliFatal("Pair efficiency correction expected to have four dimensions. ABORTING!!!");
+        done = kFALSE;
+      }
+      else {
+        /* store the pair 11 efficiency histogram */
+        fPairsEfficiency_PP = h11;
+      }
+    }
+    else {
+      AliFatal("The pair efficiency correction histogram one-one is a null pointer. ABORTING!!!");
+      done = kFALSE;
+    }
+
+    if (h12) {
+      if (h12->GetNdimensions() != 4) {
+        AliFatal("Pair efficiency correction expected to have four dimensions. ABORTING!!!");
+        done = kFALSE;
+      }
+      else {
+        /* store the pair 12 efficiency histogram */
+        fPairsEfficiency_PM = h12;
+      }
+    }
+    else {
+      AliFatal("The pair efficiency correction histogram one-two is a null pointer. ABORTING!!!");
+      done = kFALSE;
+    }
+
+    if (h22) {
+      if (h22->GetNdimensions() != 4) {
+        AliFatal("Pair efficiency correction expected to have four dimensions. ABORTING!!!");
+        done = kFALSE;
+      }
+      else {
+        /* store the pair 22 efficiency histogram */
+        fPairsEfficiency_MM = h22;
+      }
+    }
+    else {
+      AliFatal("The pair efficiency correction histogram two-two is a null pointer. ABORTING!!!");
+      done = kFALSE;
+    }
+
+    if (h21) {
+      if (h21->GetNdimensions() != 4) {
+        AliFatal("Pair efficiency correction expected to have four dimensions. ABORTING!!!");
+        done = kFALSE;
+      }
+      else {
+        /* store the pair 11 efficiency histogram */
+        fPairsEfficiency_MP = h21;
+      }
+    }
+    else {
+      AliFatal("The pair efficiency correction histogram one-one is a null pointer. ABORTING!!!");
+      done = kFALSE;
+    }
+  }
+  return done;
+}
+
+/// \brief Stores the pdf for plus and minus tracks depending on z vertex bin
+///
+/// Pdf are used to generate simulated tracks
+/// \param pluspdf array with z vertex dependent pdf for positive tracks
+/// \param minuspdf array with z vertex dependent pdf for negative tracks
+/// \return kTRUE if everything went ok otherwise kFALSE
+Bool_t AliDptDptCorrelations::SetSimultationPdfs(const TObjArray *pluspdf, const TObjArray *minuspdf) {
+
+  Bool_t done = kTRUE;
+
+  if (fUseSimulation) {
+    if (pluspdf != NULL) {
+      if (pluspdf->GetEntriesFast() == fNBins_vertexZ) {
+        fPositiveTrackPdfs = pluspdf;
+      }
+      else {
+        AliFatal(Form("The positive tracks density histogram array number of pdfs %d differ from the number of zvertex bins %d. ABORTING!!!",
+            pluspdf->GetEntriesFast(), fNBins_vertexZ));
+        done = kFALSE;
+      }
+    }
+    else {
+      AliFatal("The positive tracks density histogram array is a null pointer. ABORTING!!!");
+      done = kFALSE;
+    }
+
+    if (minuspdf != NULL) {
+      if (minuspdf->GetEntriesFast() == fNBins_vertexZ) {
+        fNegativeTrackPdfs = minuspdf;
+      }
+      else {
+        AliFatal(Form("The negative tracks density histogram array number of pdfs %d differ from the number of zvertex bins %d. ABORTING!!!",
+            minuspdf->GetEntriesFast(), fNBins_vertexZ));
+        done = kFALSE;
+      }
+    }
+    else {
+      AliFatal("The negative tracks density histogram array is a null pointer. ABORTING!!!");
+      done = kFALSE;
+    }
+  }
+  else {
+    AliError("Setting tracks density profiles for a not use simulation instance. Ignoring it");
+    done = kFALSE;
+  }
+  return done;
+}
+
+
+/// \brief initializes the object instance to start a new event
+/// \param centrality the new event centrality in percentage
+/// \param vertexz the new event vertex \f$z\f$ coordinate
+/// \return kTRUE if correctly initialized kFALSE otherwise
+Bool_t AliDptDptCorrelations::StartEvent(Float_t centrality, Float_t vertexz) {
+
+  fVertexZ = vertexz;
+  fCentrality = centrality;
+  fIxVertexZ = Int_t ((fVertexZ - fMin_vertexZ) / fWidth_vertexZ);
+  if (fIxVertexZ < 0 || !(fIxVertexZ < fNBins_vertexZ)) {
+    AliError(Form("Event z vertex bin %d out of bounds. Ignoring event.", fIxVertexZ));
+    return kFALSE;
+  }
+
+  if (fVertexZ < fMin_vertexZ || fMax_vertexZ < fVertexZ)
+    AliError(Form("Wrongly accepted event with z vertex: %.2f", fVertexZ));
+
+  if (fUseSimulation) {
+    fPositiveTrackCurrentPdf = (TH3F *) fPositiveTrackPdfs->At(fIxVertexZ);
+    fNegativeTrackCurrentPdf = (TH3F *) fNegativeTrackPdfs->At(fIxVertexZ);
+  }
+
+  fNoOfTracks1 = 0;
+  fNoOfTracks2 = 0;
+
+  /* reset single counters */
+  fN1_1 = fN1_2 = fSum1Pt_1 = fSum1Pt_2 = fNnw1_1 = fNnw1_2 = fSum1Ptnw_1 = fSum1Ptnw_2 = 0;
+
+  return kTRUE;
+}
+
+/// \brief process a track and store its parameters if feasible
+///
+/// If simulation is ordered the actual track is discarded and a new one with the
+/// same charge is produced out of the corresponding track pdf
+/// \param trkId the external track Id
+/// \param trk the passed track
+/// \return kTRUE if the track is properly handled kFALSE otherwise
+Bool_t AliDptDptCorrelations::ProcessTrack(Int_t trkId, AliVTrack *trk) {
+
+  if (fUseSimulation) {
+    Double_t pT;
+    Double_t eta;
+    Double_t phi;
+
+    if (trk->Charge() < 0)
+      fNegativeTrackCurrentPdf->GetRandom3(eta,phi,pT);
+    else
+      fPositiveTrackCurrentPdf->GetRandom3(eta,phi,pT);
+
+    return ProcessTrack(trkId, Int_t(trk->Charge()), pT, eta, phi);
+  }
+  else
+    return ProcessTrack(trkId, Int_t(trk->Charge()), Float_t(trk->Pt()), Float_t(trk->Eta()), Float_t(trk->Phi()));
+}
+
+
+/// \brief process a true particle and store its parameters if feasible
+///
+/// If simulation is orderd the track is discarded and kFALSE is returned
+/// \param trkId the external particle Id
+/// \param part the passed particle
+/// \return kTRUE if the particle is properly handled kFALSE otherwise
+Bool_t AliDptDptCorrelations::ProcessTrack(Int_t trkId, TParticle *part) {
+
+  if (fUseSimulation) {
+    return kFALSE;
+  }
+  else
+    if (part->GetPDG()->Charge() != 0) {
+      return ProcessTrack(trkId, (part->GetPDG()->Charge() > 0) ? 1 : -1, Float_t(part->Pt()), Float_t(part->Eta()), Float_t(part->Phi()));
+    }
+    else {
+      return kFALSE;
+    }
+}
+
+
+/// \brief process a true particle and store its parameters if feasible
+///
+/// If simulation is orderd the track is discarded and kFALSE is returned
+/// \param trkId the external particle Id
+/// \param part the passed particle
+/// \return kTRUE if the particle is properly handled kFALSE otherwise
+Bool_t AliDptDptCorrelations::ProcessTrack(Int_t trkId, AliAODMCParticle *part) {
+
+  if (fUseSimulation) {
+    return kFALSE;
+  }
+  else
+    if (part->Charge() != 0) {
+      return ProcessTrack(trkId, (part->Charge() > 0) ? 1 : -1, Float_t(part->Pt()), Float_t(part->Eta()), Float_t(part->Phi()));
+    }
+    else {
+      return kFALSE;
+    }
+}
+
+
+/// \brief process a track and store its parameters if feasible
+/// \param trkId the external track Id
+/// \param charge the track charge
+/// \param pT the track \f$ p_T \f$
+/// \param eta the track \f$ \eta \f$
+/// \param phi the track \f$ \phi \f$
+/// \return kTRUE if the track is properly handled kFALSE otherwise
+Bool_t AliDptDptCorrelations::ProcessTrack(Int_t trkId, Int_t charge, Float_t pT, Float_t eta, Float_t phi) {
+
+  if(charge == 0) return kFALSE;
+
+  /* track 1 */
+  if (fRequestedCharge_1 == charge && pT > fMin_pt_1 && pT < fMax_pt_1)
+  {
+    if (!(fNoOfTracks1 < fArraySize)) {
+      AliError(Form("Storage for track one full: %d", fArraySize));
+      return kFALSE;
+    }
+
+    /* consider a potential phi origin shift */
+    if (!(phi < fMax_phi_1)) phi = phi - 2*TMath::Pi();
+    Int_t ixPhi = Int_t ((phi - fMin_phi_1) / fWidth_phi_1);
+    if (ixPhi < 0 || !(ixPhi < fNBins_phi_1)) {
+      AliWarning("Track one phi out of bins");
+      return kFALSE;
+    }
+
+    if (eta < fMin_eta_1 ||  fMax_eta_1 < eta) {
+      AliWarning(Form("Wrongly passed track one with eta: %.2f", eta));
+      return kFALSE;
+    }
+
+    Int_t ixEta = Int_t ((eta - fMin_eta_1) / fWidth_eta_1);
+    if (ixEta < 0 || !(ixEta < fNBins_eta_1)) {
+      AliWarning(Form("Track one eta bin %d out of bounds", ixEta));
+      return kFALSE;
+    }
+
+
+    if (pT < fMin_pt_1 ||  fMax_pt_1 < pT) {
+      AliWarning(Form("Wrongly passed track one with pT: %.2f", pT));
+      return kFALSE;
+    }
+
+    Int_t ixPt = Int_t((pT - fMin_pt_1 ) / fWidth_pt_1);
+    if (ixPt < 0  || !(ixPt < fNBins_pt_1)) {
+      AliWarning(Form("Track pT bin %d out of bounds",ixPt));
+      return kFALSE;
+    }
+
+
+    Int_t ixEtaPhi = ixEta*fNBins_phi_1+ixPhi;
+    Int_t ixVertexP1 = fIxVertexZ*fNBins_etaPhiPt_1;
+    Int_t ixZEtaPhiPt = ixVertexP1 + ixEtaPhi*fNBins_pt_1 + ixPt;
+    if (ixZEtaPhiPt < 0 || !(ixZEtaPhiPt < fNBins_zEtaPhiPt_1)) {
+      AliWarning(Form("Event zvertex and track eta phi and pt bin %d out of bounds", ixZEtaPhiPt));
+      return kFALSE;
+    }
+
+    Float_t effcorr = fEfficiencyCorrection_1[ixPt];
+    Float_t corr;
+    if (fCorrectionWeights_1)
+      corr = fCorrectionWeights_1[ixZEtaPhiPt];
+    else
+      corr = 1.0;
+
+    /* the final correction incorporates also the efficiency correction */
+    /* and affects to both, track densities and pT */
+    corr *= effcorr;
+
+    if (fSinglesOnly) {
+      fN1_1_vsPt[ixPt] += corr;
+      fN1_1_vsZEtaPhiPt[ixZEtaPhiPt] += corr;
+    }
+    else {
+      Float_t corrPt                = corr*pT;
+      fId_1[fNoOfTracks1]           = trkId;
+      fCharge_1[fNoOfTracks1]       = charge;
+      fIxEtaPhi_1[fNoOfTracks1]     = ixEtaPhi;
+      fIxPt_1[fNoOfTracks1]         = ixPt;
+      fPt_1[fNoOfTracks1]           = pT;
+      fCorrection_1[fNoOfTracks1]   = corr;
+      fN1_1                         += corr;
+      fN1_1_vsEtaPhi[ixEtaPhi]      += corr;
+      fSum1Pt_1                     += corrPt;
+      fSum1Pt_1_vsEtaPhi[ixEtaPhi]  += corrPt;
+      fNnw1_1                       += 1;
+      fSum1Ptnw_1                   += pT;
+      fNoOfTracks1++;
+      if (!(fNoOfTracks1 < fArraySize)) {
+        AliError(Form("Storage for track one full: %d", fArraySize));
+        return kFALSE;
+      }
+    }
+  }
+
+
+  /* track 2 */
+  if (fRequestedCharge_2 == charge && pT > fMin_pt_2 && pT < fMax_pt_2)
+  {
+    if (!(fNoOfTracks2 < fArraySize)) {
+      AliError(Form("Storage for track two full: %d", fArraySize));
+      return kFALSE;
+    }
+
+    /* consider a potential phi origin shift */
+    if (!(phi < fMax_phi_2)) phi = phi - 2*TMath::Pi();
+    Int_t ixPhi = Int_t ((phi - fMin_phi_2) / fWidth_phi_2);
+    if (ixPhi <0 || !(ixPhi < fNBins_phi_2)) {
+      AliWarning("Track two phi out of bins");
+      return kFALSE;
+    }
+
+    if (eta < fMin_eta_2 ||  fMax_eta_2 < eta) {
+      AliWarning(Form("Wrongly passed track two with eta: %.2f", eta));
+      return kFALSE;
+    }
+
+    Int_t ixEta = Int_t((eta - fMin_eta_2) / fWidth_eta_2);
+    if (ixEta < 0 || !(ixEta < fNBins_eta_2)) {
+      AliWarning(Form("Track two eta bin %d out of bounds", ixEta));
+      return kFALSE;
+    }
+
+    if (pT < fMin_pt_2 ||  fMax_pt_2 < pT) {
+      AliWarning(Form("Wrongly passed track two with pT: %.2f", pT));
+      return kFALSE;
+    }
+
+    Int_t ixPt = Int_t((pT - fMin_pt_2 ) / fWidth_pt_2 );
+    if (ixPt < 0 || !(ixPt < fNBins_pt_2)) {
+      AliWarning(Form("Track two pT bin %d out of bounds",ixPt));
+      return kFALSE;
+    }
+
+    Int_t ixEtaPhi = ixEta*fNBins_phi_2+ixPhi;
+    Int_t ixVertexP2 = fIxVertexZ*fNBins_etaPhiPt_2;
+    Int_t ixZEtaPhiPt = ixVertexP2 + ixEtaPhi*fNBins_pt_2 + ixPt;
+    if (ixZEtaPhiPt < 0 || !(ixZEtaPhiPt < fNBins_zEtaPhiPt_2)) {
+      AliWarning(Form("Event zvertex and track eta phi and pt bin %d out of bounds", ixZEtaPhiPt));
+      return kFALSE;
+    }
+
+    Float_t effcorr = fEfficiencyCorrection_2[ixPt];
+    Float_t corr;
+    if (fCorrectionWeights_2)
+      corr = fCorrectionWeights_2[ixZEtaPhiPt];
+    else
+      corr = 1.0;
+
+    /* the final correction incorporates also the efficiency correction */
+    /* and affects to both, track densities and pT */
+    corr *= effcorr;
+
+    if (fSinglesOnly) {
+      fN1_2_vsPt[ixPt] += corr;
+      fN1_2_vsZEtaPhiPt[ixZEtaPhiPt] += corr;
+    }
+    else {
+      Float_t corrPt                = corr*pT;
+      fId_2[fNoOfTracks2]           = trkId;
+      fCharge_2[fNoOfTracks2]       = charge;
+      fIxEtaPhi_2[fNoOfTracks2]     = ixEtaPhi;
+      fIxPt_2[fNoOfTracks2]         = ixPt;
+      fPt_2[fNoOfTracks2]           = pT;
+      fCorrection_2[fNoOfTracks2]   = corr;
+      fN1_2                         += corr;
+      fSum1Pt_2                     += corrPt;
+      fNnw1_2                       += 1;
+      fN1_2_vsEtaPhi[ixEtaPhi]      += corr;
+      fSum1Pt_2_vsEtaPhi[ixEtaPhi]  += corrPt;
+      fSum1Ptnw_2                   += pT;
+      fNoOfTracks2++;
+      if (!(fNoOfTracks2 < fArraySize)) {
+        AliError(Form("Storage for track two full: %d", fArraySize));
+        return kFALSE;
+      }
+    }
+  }
+  return kTRUE;
+}
+
+/// Process the event data when all tracks have been collected
+///
+/// Depending on the required track pair combination different processes
+/// are invoked. Finally the proper profiles are filled.
+
+void AliDptDptCorrelations::ProcessEventData() {
+
+  if (fSinglesOnly) {
+    /* everything already done */
+  }
+  else {
+    /* reset pair counters */
+    fN2_12   = fSum2PtPt_12   = fSum2NPt_12    = fSum2PtN_12    = 0;
+    fNnw2_12 = fSum2PtPtnw_12 = fSum2NPtnw_12  = fSum2PtNnw_12  = 0;
+
+    if (fSameSign) {
+      ProcessLikeSignPairs(1);
+    }
+    else {
+      if (fAllCombinations) {
+        ProcessLikeSignPairs(1);
+        ProcessLikeSignPairs(2);
+        ProcessUnlikeSignPairs();
+      }
+      else {
+        ProcessUnlikeSignPairs();
+      }
+    }
+    /* now fill the profiles */
+    fhN1_1_vsC->Fill(fCentrality, fN1_1);
+    fhSum1Pt_1_vsC->Fill(fCentrality, fSum1Pt_1);
+    fhN1nw_1_vsC->Fill(fCentrality, fNnw1_1);
+    fhSum1Ptnw_1_vsC->Fill(fCentrality, fSum1Ptnw_1);
+    fhN1_2_vsC->Fill(fCentrality, fN1_2);
+    fhSum1Pt_2_vsC->Fill(fCentrality, fSum1Pt_2);
+    fhN1nw_2_vsC->Fill(fCentrality, fNnw1_2);
+    fhSum1Ptnw_2_vsC->Fill(fCentrality, fSum1Ptnw_2);
+    fhN2_12_vsC->Fill(fCentrality, fN2_12);
+    fhSum2PtPt_12_vsC->Fill(fCentrality, fSum2PtPt_12);
+    fhSum2PtN_12_vsC->Fill(fCentrality, fSum2PtN_12);
+    fhSum2NPt_12_vsC->Fill(fCentrality, fSum2NPt_12);
+    fhN2nw_12_vsC->Fill(fCentrality, fNnw2_12);
+    fhSum2PtPtnw_12_vsC->Fill(fCentrality, fSum2PtPtnw_12);
+    fhSum2PtNnw_12_vsC->Fill(fCentrality, fSum2PtNnw_12);
+    fhSum2NPtnw_12_vsC->Fill(fCentrality, fSum2NPtnw_12);
+  }
+}
+
+/// Helper function to compute an index for a two dimensional
+/// symmetric matrix linearized in a single array to reduce
+/// memory usage
+/// \param ix the index on the x axis (zero based)
+/// \param nxbins the number of bins on the x axis
+/// \param iy the index on the y axis (zero based)
+/// \param nybins the number of bins on the y axis
+/// \return the linearized index
+
+inline Int_t getLinearSymmIndex(Int_t ix, Int_t nxbins, Int_t iy, Int_t nybins) {
+
+  if (iy < ix)
+      return iy*nxbins - Int_t((iy-1)*iy / 2) + (ix-iy);
+  else
+      return ix*nybins - Int_t((ix-1)*ix / 2) + (iy-ix);
+}
+
+/// \brief Process track combinations with the same charge
+/// \param bank the tracks bank to use
+void AliDptDptCorrelations::ProcessLikeSignPairs(Int_t bank) {
+  /* pair with same charge. The track list should be identical */
+  if (bank == 1) {
+    /* let's select the pair efficiency correction histogram */
+    const THn *effcorr = NULL;
+    if (fRequestedCharge_1 > 0)
+      effcorr = fPairsEfficiency_PP;
+    else
+      effcorr = fPairsEfficiency_MM;
+    Int_t bins[4];
+
+    /* we use only the bank one of tracks */
+    for (Int_t ix1 = 0; ix1 < fNoOfTracks1; ix1++)
+    {
+      Int_t ixEtaPhi_1 = fIxEtaPhi_1[ix1];
+      Int_t ixPt_1     = fIxPt_1[ix1];
+      Float_t corr_1   = fCorrection_1[ix1];
+      Float_t pt_1     = fPt_1[ix1];
+
+      for (Int_t ix2 = ix1+1; ix2 < fNoOfTracks1; ix2++) {
+        /* excluded self correlations */
+        Float_t corr      = corr_1 * fCorrection_1[ix2];
+
+        /* apply the pair correction if applicable */
+        if (effcorr != NULL) {
+          Int_t ieta1 = Int_t(ixEtaPhi_1/fNBins_phi_1);
+          Int_t iphi1 = ixEtaPhi_1 % fNBins_phi_1;
+          Int_t ieta2 = Int_t(fIxEtaPhi_1[ix2]/fNBins_phi_1);
+          Int_t iphi2 = fIxEtaPhi_1[ix2] % fNBins_phi_1;
+          Int_t deltaetabin = ieta1-ieta2+fNBins_eta_1;
+          Int_t ixdeltaphi = iphi1-iphi2; if (ixdeltaphi < 0) ixdeltaphi += fNBins_phi_1;
+          bins[0] = deltaetabin;
+          bins[1] = ixdeltaphi+1;
+          bins[2] = ixPt_1+1;
+          bins[3] = fIxPt_1[ix2]+1;
+          corr = corr / effcorr->GetBinContent(bins);
+        }
+
+        Int_t ij        = getLinearSymmIndex(ixEtaPhi_1, fNBins_etaPhi_1, fIxEtaPhi_1[ix2], fNBins_etaPhi_2);
+
+        fN2_12                                              += 2*corr;
+        fN2_12_vsEtaPhi[ij]                                 += corr;
+        Float_t ptpt                                         = pt_1*fPt_1[ix2];
+        fSum2PtPt_12                                        += 2*corr*ptpt;
+        fSum2PtN_12                                         += corr*pt_1 + corr*fPt_1[ix2];
+        fSum2NPt_12                                         += corr*fPt_1[ix2] + corr*pt_1;
+        fSum2PtPt_12_vsEtaPhi[ij]                           += corr*ptpt;
+        fSum2PtN_12_vsEtaPhi[ij]                            += corr*pt_1;
+        fSum2NPt_12_vsEtaPhi[ij]                            += corr*fPt_1[ix2];
+        fN2_12_vsPtPt[ixPt_1*fNBins_pt_1 + fIxPt_1[ix2]]    += corr;
+        fN2_12_vsPtPt[fIxPt_1[ix2]*fNBins_pt_1 + ixPt_1]    += corr;
+
+        fNnw2_12                    += 2;
+        fSum2PtPtnw_12              += 2*ptpt;
+        fSum2PtNnw_12               += pt_1;
+        fSum2PtNnw_12               += fPt_1[ix2];
+        fSum2NPtnw_12               += fPt_1[ix2];
+        fSum2NPtnw_12               += pt_1;
+      } //ix2
+    } //ix1
+  }
+  else if (bank == 2) {
+    /* let's select the pair efficiency correction histogram */
+    const THn *effcorr = NULL;
+    if (fRequestedCharge_2 > 0)
+      effcorr = fPairsEfficiency_PP;
+    else
+      effcorr = fPairsEfficiency_MM;
+    Int_t bins[4];
+
+    for (Int_t ix1 = 0; ix1 < fNoOfTracks2; ix1++)
+    {
+      Int_t ixEtaPhi_1 = fIxEtaPhi_2[ix1];
+      Int_t ixPt_1     = fIxPt_2[ix1];
+      Float_t corr_1   = fCorrection_2[ix1];
+      Float_t pt_1     = fPt_2[ix1];
+
+      for (Int_t ix2 = ix1+1; ix2 < fNoOfTracks2; ix2++) {
+        /* excluded self correlations */
+        Float_t corr      = corr_1 * fCorrection_2[ix2];
+
+        /* apply the pair correction if applicable */
+        if (effcorr != NULL) {
+          Int_t ieta1 = Int_t(ixEtaPhi_1/fNBins_phi_1);
+          Int_t iphi1 = ixEtaPhi_1 % fNBins_phi_1;
+          Int_t ieta2 = Int_t(fIxEtaPhi_2[ix2]/fNBins_phi_1);
+          Int_t iphi2 = fIxEtaPhi_2[ix2] % fNBins_phi_1;
+          Int_t deltaetabin = ieta1-ieta2+fNBins_eta_1;
+          Int_t ixdeltaphi = iphi1-iphi2; if (ixdeltaphi < 0) ixdeltaphi += fNBins_phi_1;
+          bins[0] = deltaetabin;
+          bins[1] = ixdeltaphi+1;
+          bins[2] = ixPt_1+1;
+          bins[3] = fIxPt_2[ix2]+1;
+          corr = corr / effcorr->GetBinContent(bins);
+        }
+
+        Int_t ij        = getLinearSymmIndex(ixEtaPhi_1, fNBins_etaPhi_1, fIxEtaPhi_2[ix2], fNBins_etaPhi_2);
+
+        fN2_12                                              += 2*corr;
+        fN2_12_vsEtaPhi[ij]                                 += corr;
+        Float_t ptpt                                         = pt_1*fPt_2[ix2];
+        fSum2PtPt_12                                        += 2*corr*ptpt;
+        fSum2PtN_12                                         += corr*pt_1 + corr*fPt_2[ix2];
+        fSum2NPt_12                                         += corr*fPt_2[ix2] + corr*pt_1;
+        fSum2PtPt_12_vsEtaPhi[ij]                           += corr*ptpt;
+        fSum2PtN_12_vsEtaPhi[ij]                            += corr*pt_1;
+        fSum2NPt_12_vsEtaPhi[ij]                            += corr*fPt_2[ix2];
+        fN2_12_vsPtPt[ixPt_1*fNBins_pt_2 + fIxPt_2[ix2]]    += corr;
+        fN2_12_vsPtPt[fIxPt_2[ix2]*fNBins_pt_2 + ixPt_1]    += corr;
+
+        fNnw2_12                    += 2;
+        fSum2PtPtnw_12              += 2*ptpt;
+        fSum2PtNnw_12               += pt_1;
+        fSum2PtNnw_12               += fPt_2[ix2];
+        fSum2NPtnw_12               += fPt_2[ix2];
+        fSum2NPtnw_12               += pt_1;
+      } //ix2
+    } //ix1
+  }
+}
+
+/// \brief Process track combinations with oposite charge
+void AliDptDptCorrelations::ProcessUnlikeSignPairs() {
+  /* pair with different charges. Both track list are different */
+  for (Int_t ix1 = 0; ix1 < fNoOfTracks1; ix1++)
+  {
+    /* let's select the pair efficiency correction histogram */
+    const THn *effcorr = NULL;
+    if (fRequestedCharge_1 > 0)
+      effcorr = fPairsEfficiency_PM;
+    else
+      effcorr = fPairsEfficiency_MP;
+    Int_t bins[4];
+
+    Int_t ixEtaPhi_1 = fIxEtaPhi_1[ix1];
+    Int_t ixPt_1     = fIxPt_1[ix1];
+    Float_t corr_1   = fCorrection_1[ix1];
+    Float_t pt_1     = fPt_1[ix1];
+
+    for (Int_t ix2 = 0; ix2 < fNoOfTracks2; ix2++) {
+      Float_t corr      = corr_1 * fCorrection_2[ix2];
+
+      /* apply the pair correction if applicable */
+      if (effcorr != NULL) {
+        Int_t ieta1 = Int_t(ixEtaPhi_1/fNBins_phi_1);
+        Int_t iphi1 = ixEtaPhi_1 % fNBins_phi_1;
+        Int_t ieta2 = Int_t(fIxEtaPhi_2[ix2]/fNBins_phi_1);
+        Int_t iphi2 = fIxEtaPhi_2[ix2] % fNBins_phi_1;
+        Int_t deltaetabin = ieta1-ieta2+fNBins_eta_1;
+        Int_t ixdeltaphi = iphi1-iphi2; if (ixdeltaphi < 0) ixdeltaphi += fNBins_phi_1;
+        bins[0] = deltaetabin;
+        bins[1] = ixdeltaphi+1;
+        bins[2] = ixPt_1+1;
+        bins[3] = fIxPt_2[ix2]+1;
+        corr = corr / effcorr->GetBinContent(bins);
+      }
+
+      Int_t ij        = getLinearSymmIndex(ixEtaPhi_1, fNBins_etaPhi_1, fIxEtaPhi_2[ix2], fNBins_etaPhi_2);
+
+      fN2_12                                              += 2*corr;
+      fN2_12_vsEtaPhi[ij]                                 += corr;
+      Float_t ptpt                                         = pt_1*fPt_2[ix2];
+      fSum2PtPt_12                                        += 2*corr*ptpt;
+      fSum2PtN_12                                         += corr*pt_1 + corr*fPt_2[ix2];
+      fSum2NPt_12                                         += corr*fPt_2[ix2] + corr*pt_1 ;
+      fSum2PtPt_12_vsEtaPhi[ij]                           += corr*ptpt;
+      fSum2PtN_12_vsEtaPhi[ij]                            += corr*pt_1;
+      fSum2NPt_12_vsEtaPhi[ij]                            += corr*fPt_2[ix2];
+      fN2_12_vsPtPt[ixPt_1*fNBins_pt_2 + fIxPt_2[ix2]]    += corr;
+      fN2_12_vsPtPt[fIxPt_2[ix2]*fNBins_pt_1 + ixPt_1]    += corr;
+
+      fNnw2_12                    += 2;
+      fSum2PtPtnw_12              += 2*ptpt;
+      fSum2PtNnw_12               += pt_1;
+      fSum2PtNnw_12               += fPt_2[ix2];
+      fSum2NPtnw_12               += fPt_2[ix2];
+      fSum2NPtnw_12               += pt_1;
+    } //ix2
+  } //ix1
+}
+
+/// \brief Fill the histograms once the whole process is finished
+void  AliDptDptCorrelations::FinalizeProcess()
+{
+
+  if (fSinglesOnly) {
+    fillHistoWithArray(fhN1_1_vsPt,              fN1_1_vsPt,            fNBins_pt_1);
+    fillHistoWithArray(fhN1_1_vsZEtaPhiPt,       fN1_1_vsZEtaPhiPt,     fNBins_vertexZ, fNBins_etaPhi_1, fNBins_pt_1);
+    fillHistoWithArray(fhN1_2_vsPt,              fN1_2_vsPt,            fNBins_pt_2);
+    fillHistoWithArray(fhN1_2_vsZEtaPhiPt,       fN1_2_vsZEtaPhiPt,     fNBins_vertexZ, fNBins_etaPhi_2, fNBins_pt_2);
+  }
+  else {
+    fillHistoWithArray(fhN1_1_vsEtaPhi,          fN1_1_vsEtaPhi,        fNBins_eta_1,   fNBins_phi_1);
+    fillHistoWithArray(fhSum1Pt_1_vsEtaPhi,      fSum1Pt_1_vsEtaPhi,    fNBins_eta_1,   fNBins_phi_1);
+    fillHistoWithArray(fhN1_2_vsEtaPhi,          fN1_2_vsEtaPhi,        fNBins_eta_2,   fNBins_phi_2);
+    fillHistoWithArray(fhSum1Pt_2_vsEtaPhi,      fSum1Pt_2_vsEtaPhi,    fNBins_eta_2,   fNBins_phi_2);
+
+    fillHistoWithArray(fhN2_12_vsEtaPhi,         fN2_12_vsEtaPhi,       fNBins_etaPhi_12);
+    fillHistoWithArray(fhSum2PtPt_12_vsEtaPhi,   fSum2PtPt_12_vsEtaPhi, fNBins_etaPhi_12);
+    fillHistoWithArray(fhSum2PtN_12_vsEtaPhi,    fSum2PtN_12_vsEtaPhi,  fNBins_etaPhi_12);
+    fillHistoWithArray(fhSum2NPt_12_vsEtaPhi,    fSum2NPt_12_vsEtaPhi,  fNBins_etaPhi_12);
+    fillHistoWithArray(fhN2_12_vsPtPt,           fN2_12_vsPtPt,         fNBins_pt_1,    fNBins_pt_2);
+  }
+}
+
+//Tools
+//===================================================================================================
+/// \brief Fills one dimension histogram from an array of float
+/// \param h one dimension histogram to fill
+/// \param array the source array
+/// \param size the number of bins in the histogram
+void  AliDptDptCorrelations::fillHistoWithArray(TH1 * h, float * array, int size)
+{
+  int i, i1;
+  float v1, ev1, v2, ev2, sum, esum;
+  for (i=0, i1=1; i<size; ++i,++i1) {
+    v1  = array[i]; ev1 = sqrt(v1);
+    v2  = h->GetBinContent(i1);
+    ev2 = h->GetBinError(i1);
+    sum = v1 + v2;
+    esum = sqrt(ev1*ev1+ev2*ev2);
+    h->SetBinContent(i1,sum);
+    h->SetBinError(i1,esum);
+  }
+}
+
+/// \brief Fills two dimensions histogram from an array of float
+/// \param h two dimensions histogram to fill
+/// \param array the source array
+/// \param size1 the number of bins in the histogram x dimension
+/// \param size2 the number of bins in the histogram y dimension
+void  AliDptDptCorrelations::fillHistoWithArray(TH2 * h, float * array, int size1, int size2)
+{
+  int i, i1;
+  int j, j1;
+  float v1, ev1, v2, ev2, sum, esum;
+  for (i=0, i1=1; i<size1; ++i,++i1) {
+    for (j=0, j1=1; j<size2; ++j,++j1) {
+      v1  = array[i*size2+j]; ev1 = sqrt(v1);
+      v2  = h->GetBinContent(i1,j1);
+      ev2 = h->GetBinError(i1,j1);
+      sum = v1 + v2;
+      esum = sqrt(ev1*ev1+ev2*ev2);
+      h->SetBinContent(i1,j1,sum);
+      h->SetBinError(i1,j1,esum);
+    }
+  }
+}
+
+/// \brief Fills three dimensions histogram from an array of float
+/// \param h three dimensions histogram to fill
+/// \param array the source array
+/// \param size1 the number of bins in the histogram x dimension
+/// \param size2 the number of bins in the histogram y dimension
+/// \param size3 the number of bins in the histogram z dimension
+void  AliDptDptCorrelations::fillHistoWithArray(TH3 * h, float * array, int size1, int size2, int size3)
+{
+  int i, i1;
+  int j, j1;
+  int k, k1;
+  float v1, ev1, v2, ev2, sum, esum;
+  int size23 = size2*size3;
+  for (i=0, i1=1; i<size1; ++i,++i1) {
+    for (j=0, j1=1; j<size2; ++j,++j1) {
+      for (k=0, k1=1; k<size3; ++k,++k1) {
+        v1  = array[i*size23+j*size3+k]; ev1 = sqrt(v1);
+        v2  = h->GetBinContent(i1,j1,k1);
+        ev2 = h->GetBinError(i1,j1,k1);
+        sum = v1 + v2;
+        esum = sqrt(ev1*ev1+ev2*ev2);
+        h->SetBinContent(i1,j1,k1,sum);
+        h->SetBinError(i1,j1,k1,esum);
+      }
+    }
+  }
+}
+
+/// \brief Fills one dimension histogram from an array of double
+/// \param h one dimension histogram to fill
+/// \param array the source array
+/// \param size the number of bins in the histogram x dimension
+void  AliDptDptCorrelations::fillHistoWithArray(TH1 * h, double * array, int size)
+{
+  int i, i1;
+  double v1, ev1, v2, ev2, sum, esum;
+  for (i=0, i1=1; i<size; ++i,++i1) {
+    v1  = array[i]; ev1 = sqrt(v1);
+    v2  = h->GetBinContent(i1);
+    ev2 = h->GetBinError(i1);
+    sum = v1 + v2;
+    esum = sqrt(ev1*ev1+ev2*ev2);
+    h->SetBinContent(i1,sum);
+    h->SetBinError(i1,esum);
+  }
+}
+
+/// \brief Fills two dimensions histogram from an array of double
+/// \param h two dimensions histogram to fill
+/// \param array the source array
+/// \param size1 the number of bins in the histogram x dimension
+/// \param size2 the number of bins in the histogram y dimension
+void  AliDptDptCorrelations::fillHistoWithArray(TH2 * h, double * array, int size1, int size2)
+{
+  int i, i1;
+  int j, j1;
+  double v1, ev1, v2, ev2, sum, esum;
+  for (i=0, i1=1; i<size1; ++i,++i1) {
+    for (j=0, j1=1; j<size2; ++j,++j1) {
+      v1  = array[i*size2+j]; ev1 = sqrt(v1);
+      v2  = h->GetBinContent(i1,j1);
+      ev2 = h->GetBinError(i1,j1);
+      sum = v1 + v2;
+      esum = sqrt(ev1*ev1+ev2*ev2);
+      h->SetBinContent(i1,j1,sum);
+      h->SetBinError(i1,j1,esum);
+    }
+  }
+}
+
+/// \brief Fills three dimensions histogram from an array of double
+/// \param h three dimensions histogram to fill
+/// \param array the source array
+/// \param size1 the number of bins in the histogram x dimension
+/// \param size2 the number of bins in the histogram y dimension
+/// \param size3 the number of bins in the histogram z dimension
+void  AliDptDptCorrelations::fillHistoWithArray(TH3 * h, double * array, int size1, int size2, int size3)
+{
+  int i, i1;
+  int j, j1;
+  int k, k1;
+  double v1, ev1, v2, ev2, sum, esum;
+  int size23 = size2*size3;
+  for (i=0, i1=1; i<size1; ++i,++i1) {
+    for (j=0, j1=1; j<size2; ++j,++j1) {
+      for (k=0, k1=1; k<size3; ++k,++k1) {
+        v1  = array[i*size23+j*size3+k]; ev1 = sqrt(v1);
+        v2  = h->GetBinContent(i1,j1,k1);
+        ev2 = h->GetBinError(i1,j1,k1);
+        sum = v1 + v2;
+        esum = sqrt(ev1*ev1+ev2*ev2);
+        h->SetBinContent(i1,j1,k1,sum);
+        h->SetBinError(i1,j1,k1,esum);
+      }
+    }
+  }
+}
+
+
+
+/// \cond CLASSIMP
+ClassImp(AliDptDptCorrelations);
+/// \endcond

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliDptDptCorrelations.h
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliDptDptCorrelations.h
@@ -1,0 +1,262 @@
+#ifndef ALIDPTDPTCORRELATIONS_H
+#define ALIDPTDPTCORRELATIONS_H
+
+/// \file AliDptDptCorrelations.h
+/// \brief Class for collecting data for \f$(\Delta p_T, \Delta p_T)\f$ correlation functions
+///
+
+#include <TNamed.h>
+
+/// \class AliDptDptCorrelations
+/// \brief Encapsulates the needed process and data for building
+/// \f$(\Delta p_T, \Delta p_T)\f$ correlation functions
+///
+/// Based on the work of P.Pujahari &amp C. Pruneau at Wayne State University
+///
+/// \author Víctor González <victor.gonzalez@cern.ch>, UCM
+/// \date Dec 04, 2016
+
+class TList;
+class TH1;
+class TH2;
+class TH3;
+class THn;
+class AliVEvent;
+class AliVTrack;
+class TParticle;
+class AliAODMCParticle;
+
+class AliDptDptCorrelations : public TNamed {
+public:
+                              AliDptDptCorrelations();
+                              AliDptDptCorrelations(const char *name);
+  virtual                    ~AliDptDptCorrelations();
+                              /// \brief Use only singles, do not produce pairs data
+                              /// \param so flag to activate deactivate
+  void                        SetSinglesOnly(Bool_t so) { fSinglesOnly = so; }
+                              /// \brief Use calibration weights
+                              /// \param uw flag to activate deactivate the use of weights
+  void                        SetUseWeights(Bool_t uw) { fUseWeights = uw; }
+                              /// \brief Use simulated tracks
+                              /// \param us flag to activate deactivate the use of simulated tracks
+  void                        SetUseSimulation(Bool_t us) { fUseSimulation = us; }
+                              /// \brief Get if simulation is being used
+                              /// \return kTRUE if track simulation is being used kFALSE otherwise
+  Bool_t                      GetUseSimulation() { return fUseSimulation; }
+                              /// \brief Set if both tracks are of the same charge sign
+                              /// \param ss kTRUE if both tracks have the same charge kFALSE otherwise
+  void                        SetSameSign(Bool_t ss) { fSameSign = ss; }
+                              /// \brief Produce data for all track combinations
+                              /// \param all kTRUE if all track combinations have to be produced kFALSE otherwise
+  void                        SetAllCombinations(Bool_t all) { fAllCombinations = all; }
+                              /// \brief The requested charge for first track
+                              /// \param q charge, greater than one if positive negative otherwise
+  void                        SetRequestedCharge_1(Int_t q) { fRequestedCharge_1 = q; }
+                              /// \brief The requested charge for second track
+                              /// \param q charge, greater than one if positive negative otherwise
+  void                        SetRequestedCharge_2(Int_t q) { fRequestedCharge_2 = q; }
+
+  void                        ConfigureBinning(const char *configstring);
+  TString                     GetBinningConfigurationString() const;
+
+
+  Bool_t                      SetWeigths(const TH3F *h3_1, const TH3F *h3_2);
+  Bool_t                      SetEfficiencyCorrection(const TH1F *h1_1, const TH1F *h1_2);
+  Bool_t                      SetPairEfficiencyCorrection(const THn *h11, const THn *h12, const THn *h22, const THn *h21);
+  Bool_t                      SetSimultationPdfs(const TObjArray *pluspdf, const TObjArray *minuspdf);
+                              /// \brief set the number of simulated events per passed event
+                              /// \param nevents the number of events to simulate per passed event
+  void                        SetSimEventsPerEvent(Int_t nevents) { fSimEventsPerEvent = nevents; }
+                              /// \brief get the number of events being simulated per passed event
+                              /// \return the number of events being simulated per passed event
+  Int_t                       GetSimEventsPerEvent() { return fSimEventsPerEvent; }
+
+  void                        Initialize();
+                              /// Get the histograms list
+                              /// \return the histograms list
+  TList                      *GetHistogramsList() { return fOutput; }
+  Bool_t                      StartEvent(Float_t centrality, Float_t vertexZ);
+  Bool_t                      ProcessTrack(Int_t trkId, AliVTrack *trk);
+  Bool_t                      ProcessTrack(Int_t trkId, TParticle *part);
+  Bool_t                      ProcessTrack(Int_t trkId, AliAODMCParticle *part);
+  Bool_t                      ProcessTrack(Int_t trkId, Int_t charge, Float_t pT, Float_t eta, Float_t phi);
+  void                        ProcessEventData();
+  void                        FinalizeProcess();
+
+private:
+  void                        ProcessLikeSignPairs(Int_t bank);
+  void                        ProcessUnlikeSignPairs();
+
+  void                        fillHistoWithArray(TH1 * h, double * array, int size);
+  void                        fillHistoWithArray(TH2 * h, double * array, int size1, int size2);
+  void                        fillHistoWithArray(TH3 * h, double * array, int size1, int size2, int size3);
+  void                        fillHistoWithArray(TH1 * h, float * array, int size);
+  void                        fillHistoWithArray(TH2 * h, float * array, int size1, int size2);
+  void                        fillHistoWithArray(TH3 * h, float * array, int size1, int size2, int size3);
+
+private:
+  TList                      *fOutput;                      //!<! Output histograms list
+
+  Float_t                     fVertexZ;                     ///< the current event vertex \f$z\f$ coordinate
+  Int_t                       fIxVertexZ;                   ///< bin index for the current event vertex \f$z\f$ coordinate
+  Float_t                     fCentrality;                  ///< current event centrality in percentage
+
+  Bool_t                      fSinglesOnly;                 ///< kTRUE if not pair calculations, just single particle calculations
+  Bool_t                      fUseWeights;                  ///< kTRUE if correction weights must be utilized
+  Bool_t                      fUseSimulation;               ///< kTRUE if particle production from stored profiles must be used
+  Bool_t                      fSameSign;                    ///< kTRUE if the same charge particles are utilized to build correlations
+  Bool_t                      fAllCombinations;             ///< kTRUE if all track pair combinations are utilized to build correlations
+  Int_t                       fRequestedCharge_1;           ///< requested charge sign for the first particle
+  Int_t                       fRequestedCharge_2;           ///< requested charge sign for the second particle
+
+  /* the arrays with tracks 1 and 2 information */
+  Int_t                       fArraySize;                   ///< the size of the array to collect accepted track information
+  Int_t                       fNoOfTracks1;                 ///< the number of stored track 1 tracks
+  Int_t                      *fId_1;                        //!<! the array of track 1 Ids
+  Int_t                      *fCharge_1;                    //!<! the array of track 1 charge
+  Int_t                      *fIxEtaPhi_1;                  //!<! the array of track 1 combined eta phi bin index
+  Int_t                      *fIxPt_1;                      //!<! the array of track 1 pT bin index
+  Float_t                    *fPt_1;                        //!<! the array of track 1 pT
+  Float_t                    *fCorrection_1;                //!<! the array of the correction to apply to track 1
+  Int_t                       fNoOfTracks2;                 ///< the number of stored track 2 tracks
+  Int_t                      *fId_2;                        //!<! the array of track 2 Ids
+  Int_t                      *fCharge_2;                    //!<! the array of track 2 charge
+  Int_t                      *fIxEtaPhi_2;                  //!<! the array of track 2 combined eta phi bin index
+  Int_t                      *fIxPt_2;                      //!<! the array of track 2 pT bin index
+  Float_t                    *fPt_2;                        //!<! the array of track 2 pT
+  Float_t                    *fCorrection_2;                //!<! the array of the correction to apply to track 2
+
+  Float_t                    *fCorrectionWeights_1;         //!<! structure with the track 1 correction weights
+  Float_t                    *fCorrectionWeights_2;         //!<! structure with the track 2 correction weights
+  Float_t                    *fEfficiencyCorrection_1;      //!<! structure with the track 1 efficiency correction weights
+  Float_t                    *fEfficiencyCorrection_2;      //!<! structure with the track 2 efficiency correction weights
+  const THn                  *fPairsEfficiency_PP;          //!<! pair efficiency correction for the plus plus pair
+  const THn                  *fPairsEfficiency_PM;          //!<! pair efficiency correction for the plus minus pair
+  const THn                  *fPairsEfficiency_MM;          //!<! pair efficiency correction for the minus minus pair
+  const THn                  *fPairsEfficiency_MP;          //!<! pair efficiency correction for the minus plus pair
+  const TObjArray            *fPositiveTrackPdfs;           //!<! the positive tracks density distributions
+  const TObjArray            *fNegativeTrackPdfs;           //!<! the negative tracks density distributions
+  TH3F                       *fPositiveTrackCurrentPdf;     //!<! current event positive tracks density distribution
+  TH3F                       *fNegativeTrackCurrentPdf;     //!<! current event negative tracks density distribution
+  Int_t                       fSimEventsPerEvent;           ///< the number of simulated events produced per real event
+
+  Int_t                       fNBins_vertexZ;               ///< the \f$z\f$ vertex component number of bins
+  Double_t                    fMin_vertexZ;                 ///< the minimum \f$z\f$ vertex component value
+  Double_t                    fMax_vertexZ;                 ///< the maximum \f$z\f$ vertex component value
+  Double_t                    fWidth_vertexZ;               ///< the \f$z\f$ vertex component bin width
+
+  Double_t                    fNBinsPhiShift;               ///< the number of bins the phi origin is shifted
+
+  Int_t                       fNBins_pt_1;                  ///< the track 1 \f$p_T\f$ number of bins
+  Double_t                    fMin_pt_1;                    ///< the track 1 minimum \f$p_T\f$ value
+  Double_t                    fMax_pt_1;                    ///< the track 1 maximum \f$p_T\f$ value
+  Double_t                    fWidth_pt_1;                  ///< the track 1 \f$p_T\f$ bin width
+  Int_t                       fNBins_phi_1;                 ///< the track 1 \f$\phi\f$ number of bins
+  Double_t                    fMin_phi_1;                   ///< the track 1 minimum \f$\phi\f$ value
+  Double_t                    fMax_phi_1;                   ///< the track 1 maximum \f$\phi\f$ value
+  Double_t                    fWidth_phi_1;                 ///< the track 1 \f$\phi\f$ bin width
+  Int_t                       fNBins_eta_1;                 ///< the track 1 \f$\eta\f$ number of bins
+  Double_t                    fMin_eta_1;                   ///< the track 1 minimum \f$\eta\f$ value
+  Double_t                    fMax_eta_1;                   ///< the track 1 maximum \f$\eta\f$ value
+  Double_t                    fWidth_eta_1;                 ///< the track 1 \f$\eta\f$ bin width
+  Int_t                       fNBins_etaPhi_1;              ///< the track 1 combined \f$\eta, \phi\f$ number of bins
+  Int_t                       fNBins_etaPhiPt_1;            ///< the track 1 combined \f$\eta, \phi, p_T\f$ number of bins
+  Int_t                       fNBins_zEtaPhiPt_1;           ///< the combined event \f$z\f$ vertex component and track 1 \f$\eta, \phi, p_T\f$ number of bins
+
+  Int_t                       fNBins_pt_2;                  ///< the track 2 \f$p_T\f$ number of bins
+  Double_t                    fMin_pt_2;                    ///< the track 2 minimum \f$p_T\f$ value
+  Double_t                    fMax_pt_2;                    ///< the track 2 maximum \f$p_T\f$ value
+  Double_t                    fWidth_pt_2;                  ///< the track 2 \f$p_T\f$ bin width
+  Int_t                       fNBins_phi_2;                 ///< the track 2 \f$\phi\f$ number of bins
+  Double_t                    fMin_phi_2;                   ///< the track 2 minimum \f$\phi\f$ value
+  Double_t                    fMax_phi_2;                   ///< the track 2 maximum \f$\phi\f$ value
+  Double_t                    fWidth_phi_2;                 ///< the track 2 \f$\phi\f$ bin width
+  Int_t                       fNBins_eta_2;                 ///< the track 2 \f$\eta\f$ number of bins
+  Double_t                    fMin_eta_2;                   ///< the track 2 minimum \f$\eta\f$ value
+  Double_t                    fMax_eta_2;                   ///< the track 2 maximum \f$\eta\f$ value
+  Double_t                    fWidth_eta_2;                 ///< the track 2 \f$\eta\f$ bin width
+  Int_t                       fNBins_etaPhi_2;              ///< the track 2 combined \f$\eta, \phi\f$ number of bins
+  Int_t                       fNBins_etaPhiPt_2;            ///< the track 2 combined \f$\eta, \phi, p_T\f$ number of bins
+  Int_t                       fNBins_zEtaPhiPt_2;           ///< the combined event \f$z\f$ vertex component and track 2 \f$\eta, \phi, p_T\f$ number of bins
+
+  Int_t                       fNBins_etaPhi_12;             ///< the track 1 and 2 combined \f$\eta, \phi\f$ number of bins
+
+  Double_t                    fN1_1;                        ///< weighted number of track 1 tracks for current event
+  Double_t                    fN1_2;                        ///< weighted number of track 2 tracks for current event
+  Double_t                    fN2_12;                       ///< weighted number of track1 track 2 pairs for current event
+  Double_t                    fNnw1_1;                      ///< not weighted number of track 1 tracks for current event
+  Double_t                    fNnw1_2;                      ///< not weighted number of track 2 tracks for current event
+  Double_t                    fNnw2_12;                     ///< not weighted number of track1 track 2 pairs for current event
+  Double_t                    fSum1Pt_1;                    ///< accumulated sum of weighted track 1 \f$p_T\f$ for current event
+  Double_t                    fSum1Pt_2;                    ///< accumulated sum of weighted track 2 \f$p_T\f$ for current event
+  Double_t                    fSum2PtPt_12;                 ///< accumulated sum of weighted track 1 track 2 \f${p_T}_1 {p_T}_2\f$ for current event
+  Double_t                    fSum1Ptnw_1;                  ///< accumulated sum of not weighted track 1 \f$p_T\f$ for current event
+  Double_t                    fSum1Ptnw_2;                  ///< accumulated sum of not weighted track 2 \f$p_T\f$ for current event
+  Double_t                    fSum2PtPtnw_12;               ///< accumulated sum of not weighted track 1 track 2 \f${p_T}_1 {p_T}_2\f$ for current event
+  Double_t                    fSum2NPt_12;                  ///< accumulated sum of weighted number of track 1 tracks times weighted track 2 \f$p_T\f$ for current event
+  Double_t                    fSum2PtN_12;                  ///< accumulated sum of weighted track 1 \f$p_T\f$ times weighted number of track 2 tracks for current event
+  Double_t                    fSum2NPtnw_12;                ///< accumulated sum of not weighted number of track 1 tracks times not weighted track 2 \f$p_T\f$ for current event
+  Double_t                    fSum2PtNnw_12;                ///< accumulated sum of not weighted track 1 \f$p_T\f$ times not weighted number of track  tracks for current event
+
+  Double_t                   *fN1_1_vsPt;                   //!<! storage for track 1 weighted single particle distribution vs \f$p_T\f$
+  Double_t                   *fN1_1_vsEtaPhi;               //!<! storage for track 1 weighted single particle distribution vs \f$\eta,\;\phi\f$
+  Double_t                   *fSum1Pt_1_vsEtaPhi;           //!<! storage for track 1 accumulated sum of weighted \f$p_T\f$ vs \f$\eta,\;\phi\f$
+  Float_t                    *fN1_1_vsZEtaPhiPt;            //!<! storage for track 1 single particle distribution vs \f$\mbox{vtx}_z,\;\eta,\;\phi,\;p_T\f$
+  Double_t                   *fN1_2_vsPt;                   //!<! storage for track 2 weighted single particle distribution vs \f$p_T\f$
+  Double_t                   *fN1_2_vsEtaPhi;               //!<! storage for track 2 weighted single particle distribution vs \f$\eta,\;\phi\f$
+  Double_t                   *fSum1Pt_2_vsEtaPhi;           //!<! storage for track 2 accumulated sum of weighted \f$p_T\f$ vs \f$\eta,\;\phi\f$
+  Float_t                    *fN1_2_vsZEtaPhiPt;            //!<! storage for track 2 single particle distribution vs \f$\mbox{vtx}_z,\;\eta,\;\phi,\;p_T\f$
+  Double_t                   *fN2_12_vsPtPt;                //!<! storage for track 1 and 2 weighted two particle distribution vs \f${p_T}_1, {p_T}_2\f$
+  Float_t                    *fN2_12_vsEtaPhi;              //!<! storage for track 1 and 2 weighted two particle distribution vs \f$\eta,\;\phi\f$
+  Float_t                    *fSum2PtPt_12_vsEtaPhi;        //!<! storage for track 1 and 2 weighted accumulated \f${p_T}_1 {p_T}_2\f$ distribution vs \f$\eta,\;\phi\f$
+  Float_t                    *fSum2PtN_12_vsEtaPhi;         //!<! storage for track 1 and 2 weighted accumulated \f${p_T}_1 n_2\f$ distribution vs \f$\eta,\;\phi\f$
+  Float_t                    *fSum2NPt_12_vsEtaPhi;         //!<! storage for track 1 and 2 weighted accumulated \f$n_1 {p_T}_2\f$ distribution vs \f$\eta,\;\phi\f$
+
+  /* histograms */
+  TH1F                       *fhN1_1_vsPt;                  //!<! track 1 weighted single particle distribution vs \f$p_T\f$
+  TH2F                       *fhN1_1_vsEtaPhi;              //!<! track 1 weighted single particle distribution vs \f$\eta,\;\phi\f$
+  TH2F                       *fhSum1Pt_1_vsEtaPhi;          //!<! track 1 accumulated sum of weighted \f$p_T\f$ vs \f$\eta,\;\phi\f$
+  TH3F                       *fhN1_1_vsZEtaPhiPt;           //!<! track 1 single particle distribution vs \f$\mbox{vtx}_z,\; \eta,\;\phi,\;p_T\f$
+  TH1F                       *fhN1_2_vsPt;                  //!<! track 2 weighted single particle distribution vs \f$p_T\f$
+  TH2F                       *fhN1_2_vsEtaPhi;              //!<! track 2 weighted single particle distribution vs \f$\eta,\;\phi\f$
+  TH2F                       *fhSum1Pt_2_vsEtaPhi;          //!<! track 2 accumulated sum of weighted \f$p_T\f$ vs \f$\eta,\;\phi\f$
+  TH3F                       *fhN1_2_vsZEtaPhiPt;           //!<! track 2 single particle distribution vs \f$\mbox{vtx}_z,\;\eta,\;\phi,\;p_T\f$
+  TH2F                       *fhN2_12_vsPtPt;               //!<! track 1 and 2 weighted two particle distribution vs \f${p_T}_1, {p_T}_2\f$
+  TH1F                       *fhN2_12_vsEtaPhi;             //!<! track 1 and 2 weighted two particle distribution vs \f$\eta,\;\phi\f$
+  TH1F                       *fhSum2PtPt_12_vsEtaPhi;       //!<! track 1 and 2 weighted accumulated \f${p_T}_1 {p_T}_2\f$ distribution vs \f$\eta,\;\phi\f$
+  TH1F                       *fhSum2PtN_12_vsEtaPhi;        //!<! track 1 and 2 weighted accumulated \f${p_T}_1 n_2\f$ distribution vs \f$\eta,\;\phi\f$
+  TH1F                       *fhSum2NPt_12_vsEtaPhi;        //!<! track 1 and 2 weighted accumulated \f$n_1 {p_T}_2\f$ distribution vs \f$\eta,\;\phi\f$
+  /* versus centrality  profiles */
+  TProfile                   *fhN1_1_vsC;                   //!<! track 1 weighted single particle distribution vs event centrality
+  TProfile                   *fhSum1Pt_1_vsC;               //!<! track 1 accumulated sum of weighted \f$p_T\f$ vs event centrality
+  TProfile                   *fhN1nw_1_vsC;                 //!<! track 1 un-weighted single particle distribution vs event centrality
+  TProfile                   *fhSum1Ptnw_1_vsC;              //!<! track 1 accumulated sum of un-weighted \f$p_T\f$ vs event centrality
+  TProfile                   *fhN1_2_vsC;                   //!<! track 2 weighted single particle distribution vs event centrality
+  TProfile                   *fhSum1Pt_2_vsC;               //!<! track 2 accumulated sum of weighted \f$p_T\f$ vs event centrality
+  TProfile                   *fhN1nw_2_vsC;                 //!<! track 2 un-weighted single particle distribution vs event centrality
+  TProfile                   *fhSum1Ptnw_2_vsC;             //!<! track 2 accumulated sum of un-weighted \f$p_T\f$ vs event centrality
+  TProfile                   *fhN2_12_vsC;                  //!<! track 1 and 2 weighted two particle distribution vs event centrality
+  TProfile                   *fhSum2PtPt_12_vsC;            //!<! track 1 and 2 weighted accumulated \f${p_T}_1 {p_T}_2\f$ distribution vs event centrality
+  TProfile                   *fhSum2PtN_12_vsC;             //!<! track 1 and 2 weighted accumulated \f${p_T}_1 n_2\f$ distribution vs event centrality
+  TProfile                   *fhSum2NPt_12_vsC;             //!<! track 1 and 2 weighted accumulated \f$n_1 {p_T}_2\f$ distribution vs event centrality
+  TProfile                   *fhN2nw_12_vsC;                //!<! track 1 and 2 un-weighted two particle distribution vs event centrality
+  TProfile                   *fhSum2PtPtnw_12_vsC;          //!<! track 1 and 2 un-weighted accumulated \f${p_T}_1 {p_T}_2\f$ distribution vs event centrality
+  TProfile                   *fhSum2PtNnw_12_vsC;           //!<! track 1 and 2 un-weighted accumulated \f${p_T}_1 n_2\f$ distribution vs event centrality
+  TProfile                   *fhSum2NPtnw_12_vsC;           //!<! track 1 and 2 un-weighted accumulated \f$n_1 {p_T}_2\f$ distribution vs event centrality
+
+
+private:
+  /// Copy constructor
+  /// Not allowed. Forced private.
+  AliDptDptCorrelations(const AliDptDptCorrelations&);
+  /// Assignment operator
+  /// Not allowed. Forced private.
+  /// \return l-value reference object
+  AliDptDptCorrelations& operator=(const AliDptDptCorrelations&);
+
+  /// \cond CLASSIMP
+  ClassDef(AliDptDptCorrelations,2);
+  /// \endcond
+};
+
+#endif // ALIDPTDPTCORRELATIONS_H

--- a/PWGCF/Correlations/macros/Unfoldedhistos/AddCorrelationsStudiesTask.C
+++ b/PWGCF/Correlations/macros/Unfoldedhistos/AddCorrelationsStudiesTask.C
@@ -1,0 +1,50 @@
+#ifdef __ECLIPSE_IDE
+//  few includes and external declarations just for the IDE
+#include "Riostream.h"
+#include "TROOT.h"
+#include "AliLog.h"
+#include "AliAnalysisTaskSE.h"
+#include "AliAnalysisManager.h"
+#include "AliAnalysisTaskCorrelationsStudies.h"
+#endif
+
+AliAnalysisTaskSE *AddCorrelationsStudiesTask(const char *suffix, const char *configstring, const char *corrconfigstring, const char *corrbinning) {
+
+  TString szContainerPrefix;
+
+  AliAnalysisTaskCorrelationsStudies* taskCS;
+  AliAnalysisManager    *mgr = AliAnalysisManager::GetAnalysisManager();
+  TString outfilename = mgr->GetCommonFileName();
+  AliAnalysisDataContainer *cinput = mgr->GetCommonInputContainer();
+
+  if (mgr != NULL) {
+
+    taskCS = new AliAnalysisTaskCorrelationsStudies(Form("Correlation Studies %s", suffix));
+    taskCS->Configure(configstring);
+    if (TString(corrconfigstring).Contains("simulate"))
+      taskCS->ConfigureCorrelations(corrconfigstring,Form("density_%s_", suffix),szContainerPrefix);
+    else
+      taskCS->ConfigureCorrelations(corrconfigstring,Form("correction_%s_", suffix),szContainerPrefix);
+    taskCS->ConfigureCorrelationsBinning(corrbinning);
+    mgr->AddTask(taskCS);
+
+    // create containers for input/output
+    AliAnalysisDataContainer *coutput1 = mgr->CreateContainer(Form("CorrelationStudies_%s_%s", szContainerPrefix.Data(), suffix), TList::Class(), AliAnalysisManager::kOutputContainer, outfilename);
+    AliAnalysisDataContainer *coutput2 = mgr->CreateContainer(Form("DptDptCorrelations_%s_%s", szContainerPrefix.Data(), suffix), TList::Class(), AliAnalysisManager::kOutputContainer, outfilename);
+    AliAnalysisDataContainer *coutput3 = mgr->CreateContainer(Form("DptDptCorrelationsMCRecOptions_%s_%s", szContainerPrefix.Data(), suffix), TList::Class(), AliAnalysisManager::kOutputContainer, outfilename);
+    AliAnalysisDataContainer *coutput4 = mgr->CreateContainer(Form("DptDptTrueCorrelations_%s_%s", szContainerPrefix.Data(), suffix), TList::Class(), AliAnalysisManager::kOutputContainer, outfilename);
+
+    // connect input/output
+    mgr->ConnectInput(taskCS, 0, cinput);
+    mgr->ConnectOutput(taskCS, 1, coutput1);
+    mgr->ConnectOutput(taskCS, 2, coutput2);
+    mgr->ConnectOutput(taskCS, 3, coutput3);
+    mgr->ConnectOutput(taskCS, 4, coutput4);
+
+    return taskCS;
+  }
+  else {
+    AliFatalGeneral("AddCorrelationsStudiesTask", "Add task needs a previously started analysis manager");
+    return NULL;
+  }
+}

--- a/PWGCF/Correlations/macros/Unfoldedhistos/CreateAlienHandler.C
+++ b/PWGCF/Correlations/macros/Unfoldedhistos/CreateAlienHandler.C
@@ -1,0 +1,103 @@
+#ifdef __ECLIPSE_IDE
+//  few includes and external declarations just for the IDE
+#include "AliAnalysisAlien.h"
+#endif // ifdef __ECLIPSE_IDE declaration and includes for the ECLIPSE IDE
+
+#include "runCorrelationsStudiesConfigMacro.H"
+
+AliAnalysisGrid* CreateAlienHandler(const char *runMode,Bool_t gridMerge)
+{
+    // Check if user has a valid token, otherwise make one. This has limitations.
+    // One can always follow the standard procedure of calling alien-token-init then
+    //   source /tmp/gclient_env_$UID in the current shell.
+
+  AliAnalysisAlien *plugin = new AliAnalysisAlien();
+
+  //Set the run mode (can be "full", "test", "offline", "submit" or "terminate")
+  plugin->SetRunMode(runMode);
+
+  plugin->SetNtestFiles(nNoOfTestFiles); // num of test files in "test" mode
+
+  if (TString(runMode).EqualTo("test"))
+    plugin->SetCheckCopy(kFALSE);
+
+
+  // Set versions of used packages
+  plugin->SetAliPhysicsVersion(szAliPhysicsVersion.Data());
+
+  plugin->AddIncludePath("-I$ALICE_ROOT/include -I$ALICE_PHYSICS/include");
+
+  /////////////////////////////////////////////////////////////////////////
+  plugin->SetDataPattern(szDataPattern.Data());
+  plugin->SetGridDataDir(szDataDir.Data()); // Data
+
+  /* CHECK: for MC seems not needed */
+  if (!szRunPrefix.IsWhitespace())
+    plugin->SetRunPrefix(szRunPrefix.Data());
+
+  /* run numbers to analyse */
+  for (Int_t i=0;i<listOfActiveRuns.GetEntriesFast();i++) {
+    plugin->AddRunNumber(((TObjString*) listOfActiveRuns.At(i))->GetString().Data());
+  }
+
+  /* alternatively provide run number */
+//  plugin->AddRunNumber( 139505 );
+// Alternatively use run range
+//  plugin->SetRunRange(138653, 138666);
+
+  // Define alien work directory where all files will be copied. Relative to alien $HOME.
+  plugin->SetGridWorkingDir(szGridWorkingDir.Data());  // NOTE: Change name here every new run!!!eclare alien output directory. Relative to working directory.
+  plugin->SetGridOutputDir("output"); // In this case will be $HOME/work/output
+  plugin->SetOutputToRunNo(); // we want the run number as output subdirectory
+  plugin->SetDefaultOutputs(kTRUE);
+
+//  plugin->SetMergeExcludes("Viscosity.root EventStat_temp.root");
+  plugin->SetMergeViaJDL(gridMerge);
+  plugin->SetMaxMergeFiles(30);
+
+  // Declare the analysis source files names separated by blancs. To be compiled runtime
+  // using ACLiC on the worker nodes.
+  plugin->SetAnalysisSource("AliCSAnalysisCutsBase.cxx "
+      "AliCSTrackCutsBase.cxx "
+      "AliCSTrackMaps.cxx "
+      "AliCSEventCuts.cxx "
+      "AliCSTrackCuts.cxx "
+      "AliCSPIDCuts.cxx "
+      "AliCSTrackSelection.cxx "
+      "AliDptDptCorrelations.cxx "
+      "AliCSPairAnalysis.cxx "
+      "AliAnalysisTaskCorrelationsStudies.cxx");
+
+  // Declare all libraries (other than the default ones for the framework. These will be
+  // loaded by the generated analysis macro. Add all extra files (task .cxx/.h) here.
+  plugin->SetAdditionalLibs("AliCSAnalysisCutsBase.cxx AliCSAnalysisCutsBase.h "
+      "AliCSTrackCutsBase.cxx AliCSTrackCutsBase.h "
+      "AliCSTrackMaps.cxx AliCSTrackMaps.h "
+      "AliCSEventCuts.cxx AliCSEventCuts.h "
+      "AliCSTrackCuts.cxx AliCSTrackCuts.h "
+      "AliCSPIDCuts.cxx AliCSPIDCuts.h "
+      "AliCSTrackSelection.cxx AliCSTrackSelection.h "
+      "AliDptDptCorrelations.cxx AliDptDptCorrelations.h "
+      "AliCSPairAnalysis.cxx AliCSPairAnalysis.h "
+      "AliAnalysisTaskCorrelationsStudies.h AliAnalysisTaskCorrelationsStudies.cxx");
+
+  // alternatively pass a par file with source information
+  // plugin->EnablePackage("PWGCFCorrelationsDPhi.par");
+
+// Declare the output file names separated by blanks.
+// (can be like: file.root or file.root@ALICE::Niham::File)
+  plugin->SetOverwriteMode(kFALSE);
+
+// Optionally set maximum number of input files/subjob (default 100, put 0 to ignore)
+  if (nNoOfInputFiles != 0)
+    plugin->SetSplitMaxInputFileNumber(nNoOfInputFiles);
+// Optionally set number of failed jobs that will trigger killing waiting sub-jobs.
+//   plugin->SetMaxInitFailed(15);
+// Optionally resubmit threshold.
+  plugin->SetMasterResubmitThreshold(90);
+// Optionally set time to live (default 30000 sec)
+  plugin->SetTTL(18000);
+// Optionally set input format (default xml-single)
+  plugin->SetInputFormat("xml-single");
+  return plugin;
+}

--- a/PWGCF/Correlations/macros/Unfoldedhistos/runCorrelationsStudiesConfigMacro.C
+++ b/PWGCF/Correlations/macros/Unfoldedhistos/runCorrelationsStudiesConfigMacro.C
@@ -1,0 +1,465 @@
+#ifdef __ECLIPSE_IDE
+//  few includes and external declarations just for the IDE
+#include <Riostream.h>
+#include <TROOT.h>
+#include <TSystem.h>
+#include <TObjString.h>
+
+#endif // #ifdef __ECLIPSE_IDE
+
+#include "runCorrelationsStudiesConfigMacro.H"
+
+void loadLocal2010hMCTestRunNumber();
+void load2010hTestRunNumber();
+void load2010hAODTestRunNumber();
+void load2010hRunNumbers();
+void load2010hBMMRunNumbers();
+void load2010hBPPRunNumbers();
+void load2010hMCRunNumbers();
+void load2010hMCTestRunNumber();
+void loadMC2010h11a10a_bisBMMRunNumbers();
+void loadMC2010h11a10a_bisBPPRunNumbers();
+void loadMC2010h11a10a_bisAODRunNumbers(Int_t);
+void loadMCAMPT2010h12A11RunNumbers();
+void loadMCAMPT2010hCentrality(const char *cent);
+void load2015oMCTestRunNumber();
+void load2015oLIRpass2RunNumbers();
+void load2015oLIRpass3RunNumbers();
+void load2015oLIRpass4RunNumbers();
+void load2015oHIRRunNumbers();
+void load2015oHIRTestRunNumber();
+void load2016kTestRunNumber();
+
+void runCorrelationsStudiesConfigMacro() {
+
+  bTrainScope                = kFALSE;
+  bGRIDPlugin                = kTRUE && !bTrainScope;
+  bMC                        = kFALSE;
+
+  /* tasks to use */
+  /* only valid if not under train scope */
+  bUsePhysicsSelection       = kTRUE;
+  bUsePIDResponse            = kTRUE;
+  // Centrality
+  bUseCentralityTask         = kTRUE;
+  bUseMultiplicityTask       = kTRUE;
+
+  /* data input */
+  isHeavyIon                 = kTRUE;
+
+  /* reconstruction pass default */
+  szpass = "2";
+
+  /* Running conditions */
+  szAliPhysicsVersion = "vAN-20171107-1";
+
+  /* the number of files we want to test */
+  nNoOfTestFiles = 2;
+
+  /* load the run numbers */
+  // loadLocal2010hMCTestRunNumber();
+  // load2010hTestRunNumber();
+  // load2010hMCTestRunNumber();
+  // load2010hAODTestRunNumber();
+  loadMC2010h11a10a_bisAODRunNumbers(-1);
+  // load2015oMCTestRunNumber();
+  // load2015oHIRTestRunNumber();
+  // load2015oLIRpass3RunNumbers();
+  // load2010hBPPRunNumbers();
+  // load2010hMCRunNumbers();
+  // load2016kTestRunNumber();
+  // loadMCAMPT2010hCentrality("0-5");
+
+
+  szRunPrefix = bMC ? "" : "000";
+  nNoOfInputFiles = 30;
+
+  /* local file list */
+  szLocalFileList = (bMC? "filelist_mc.txt" : "filelist.txt");
+}
+
+void loadLocal2010hMCTestRunNumber() {
+  bUseESD                    = kTRUE;
+  bUseAOD                    = !bUseESD;
+
+  bTrainScope                = kFALSE;
+  bGRIDPlugin                = kFALSE && !bTrainScope;
+  bMC                        = kTRUE;
+}
+
+
+
+/* 2010h period */
+static const int nNoOf2010hBmmRuns = 45;
+static const char *bmm2010hRunNumbers[nNoOf2010hBmmRuns] = {
+    "138275", "138225", "138201", "138197", "138192", "138190", "137848", "137844", "137752", "137751",
+    "137724", "137722", "137718", "137704", "137693", "137692", "137691", "137686", "137685", "137639",
+    "137638", "137608", "137595", "137549", "137546", "137544", "137541", "137539", "137531", "137530",
+    "137443", "137441", "137440", "137439", "137434", "137432", "137431", "137366", "137243", "137236",
+    "137235", "137232", "137231", "137162", "137161"
+};
+
+static const int nNoOf2010hBppRuns = 45;
+static const char *bpp2010hRunNumbers[nNoOf2010hBppRuns] = {
+    "139510", "139507", "139505", "139503", "139465", "139438", "139437", "139360", "139329", "139328",
+    "139314", "139310", "139309", "139173", "139107", "139105", "139038", "139037", "139036", "139029",
+    "139028", "138872", "138871", "138870", "138837", "138732", "138730", "138666", "138662", "138653",
+    "138652", "138638", "138624", "138621", "138583", "138582", "138579", "138578", "138534", "138469",
+    "138442", "138439", "138438", "138396", "138364"
+};
+
+void load2010hTestRunNumber() {
+  bUseESD                    = kTRUE;
+  bUseAOD                    = !bUseESD;
+
+  /* the GRID working directory */
+  szGridWorkingDir = "CorrelationStudies_2010hTest";
+
+  /* 2010h */
+  szDataDir = "/alice/data/2010/LHC10h";
+
+  /* 2010h */
+  szDataPattern = "*ESDs/pass2/*/AliESDs.root";
+
+  /* the list of runs to analyze */
+  listOfActiveRuns.Add(new TObjString("138534"));
+}
+
+void load2010hAODTestRunNumber() {
+  bUseESD                    = kFALSE;
+  bUseAOD                    = !bUseESD;
+
+  /* the GRID working directory */
+  szGridWorkingDir = "CorrelationStudies_2010hTest";
+
+  /* 2010h */
+  szDataDir = "/alice/data/2010/LHC10h";
+
+  /* 2010h */
+  szDataPattern = "*ESDs/pass2/AOD160/*/AliAOD.root";
+
+  /* the list of runs to analyze */
+  listOfActiveRuns.Add(new TObjString("138534"));
+}
+
+void load2010hMCTestRunNumber() {
+  bUseESD                    = kTRUE;
+  bUseAOD                    = !bUseESD;
+
+  /* the GRID working directory */
+  szGridWorkingDir = "CorrelationStudies_2010hMCTest";
+
+  szDataDir = "/alice/sim/LHC11a10b_bis";
+  szDataPattern = "*/AliESDs.root";
+
+  bMC = kTRUE;
+
+  /* the list of runs to analyze */
+  listOfActiveRuns.Add(new TObjString("138534"));
+}
+
+void load2010hRunNumbers() {
+
+  load2010hBMMRunNumbers();
+  load2010hBPPRunNumbers();
+
+  /* modify the GRID working directory */
+  szGridWorkingDir = "CorrelationStudies_2010h";
+}
+
+void load2010hBMMRunNumbers() {
+  bUseESD                    = kTRUE;
+  bUseAOD                    = !bUseESD;
+
+  /* the GRID working directory */
+  szGridWorkingDir = "CorrelationStudies_2010hBMM";
+
+  /* 2010h */
+  szDataDir = "/alice/data/2010/LHC10h";
+
+  /* 2010h */
+  szDataPattern = "*ESDs/pass2/*/AliESDs.root";
+
+  /* the list of runs to analyze */
+  for (Int_t run = 0; run < nNoOf2010hBmmRuns; run++)
+    listOfActiveRuns.Add(new TObjString(bmm2010hRunNumbers[run]));
+}
+void load2010hBPPRunNumbers() {
+  bUseESD                    = kTRUE;
+  bUseAOD                    = !bUseESD;
+
+  /* the GRID working directory */
+  szGridWorkingDir = "CorrelationStudies_2010hBPP";
+
+  /* 2010h */
+  szDataDir = "/alice/data/2010/LHC10h";
+
+  /* 2010h */
+  szDataPattern = "*ESDs/pass2/*/AliESDs.root";
+
+  /* the list of runs to analyze */
+  for (Int_t run = 0; run < nNoOf2010hBppRuns; run++)
+    listOfActiveRuns.Add(new TObjString(bpp2010hRunNumbers[run]));
+}
+
+void load2010hMCRunNumbers() {
+
+  loadMC2010h11a10a_bisBMMRunNumbers();
+  loadMC2010h11a10a_bisBPPRunNumbers();
+
+  /* modify the GRID working directory */
+  szGridWorkingDir = "CorrelationStudies_2010hMC";
+}
+
+void loadMC2010h11a10a_bisAODRunNumbers(Int_t step) {
+  bUseESD                    = kFALSE;
+  bUseAOD                    = !bUseESD;
+
+  /* the GRID working directory */
+  szGridWorkingDir = "CorrelationStudies_2010hAODMC";
+
+  szDataDir = "/alice/sim/LHC11a10a_bis";
+  szDataPattern = "*/AOD162/*/AliAOD.root";
+
+  bMC = kTRUE;
+
+#define NOOFRUNSPERSTEP 22
+
+  /* the list of runs to analyze */
+  Int_t nNoOfRuns;
+  Int_t nFirstRun;
+  const char **runlist;
+  switch (step) {
+  case -1:
+    nNoOfRuns = nNoOf2010hBmmRuns;
+    nFirstRun = 0;
+    runlist = bmm2010hRunNumbers;
+    break;
+  case -2:
+    nNoOfRuns = nNoOf2010hBppRuns;
+    nFirstRun = 0;
+    runlist = bpp2010hRunNumbers;
+    break;
+  case 0:
+    nNoOfRuns = NOOFRUNSPERSTEP;
+    nFirstRun = 0;
+    runlist = bmm2010hRunNumbers;
+    break;
+  case 1:
+    nNoOfRuns = nNoOf2010hBmmRuns;
+    nFirstRun = NOOFRUNSPERSTEP;
+    runlist = bmm2010hRunNumbers;
+    break;
+  case 2:
+    nNoOfRuns = NOOFRUNSPERSTEP;
+    nFirstRun = 0;
+    runlist = bpp2010hRunNumbers;
+    break;
+  case 3:
+    nNoOfRuns = nNoOf2010hBppRuns;
+    nFirstRun = NOOFRUNSPERSTEP;
+    runlist = bpp2010hRunNumbers;
+    break;
+  default:
+    Fatal("loadMC2010h11a10a_bisAODRunNumbers", "ERROR - Wrong step code %d - ABORTING", step);
+  }
+  for (Int_t run = nFirstRun; run < nNoOfRuns; run++)
+    listOfActiveRuns.Add(new TObjString(runlist[run]));
+}
+
+
+
+void loadMC2010h11a10a_bisBMMRunNumbers() {
+  bUseESD                    = kTRUE;
+  bUseAOD                    = !bUseESD;
+
+  /* the GRID working directory */
+  szGridWorkingDir = "CorrelationStudies_2010hBMMMC";
+
+  szDataDir = "/alice/sim/LHC11a10a_bis";
+  szDataPattern = "*/AliESDs.root";
+
+  bMC = kTRUE;
+
+  /* the list of runs to analyze */
+  for (Int_t run = 0; run < nNoOf2010hBmmRuns; run++)
+    listOfActiveRuns.Add(new TObjString(bmm2010hRunNumbers[run]));
+}
+
+void loadMC2010h11a10a_bisBPPRunNumbers() {
+  bUseESD                    = kTRUE;
+  bUseAOD                    = !bUseESD;
+
+  /* the GRID working directory */
+  szGridWorkingDir = "CorrelationStudies_2010hBPPMC";
+
+  szDataDir = "/alice/sim/LHC11a10a_bis";
+  szDataPattern = "*/AliESDs.root";
+
+  bMC = kTRUE;
+
+  /* the list of runs to analyze */
+  for (Int_t run = 0; run < nNoOf2010hBppRuns; run++)
+    listOfActiveRuns.Add(new TObjString(bpp2010hRunNumbers[run]));
+}
+
+void loadMCAMPT2010h12A11RunNumbers() {
+  bUseESD                    = kTRUE;
+  bUseAOD                    = !bUseESD;
+
+  /* the GRID working directory */
+  szGridWorkingDir = "CorrelationStudies_2010hAMPT";
+
+  szDataDir = "/alice/sim/2012/LHC12a11";
+  szDataPattern = "*/AliESDs.root";
+
+  bMC = kTRUE;
+
+  /* the list of runs to analyze */
+  listOfActiveRuns.Add(new TObjString("137686"));
+  listOfActiveRuns.Add(new TObjString("138534"));
+  listOfActiveRuns.Add(new TObjString("138653"));
+  listOfActiveRuns.Add(new TObjString("139038"));
+  listOfActiveRuns.Add(new TObjString("139437"));
+}
+
+void loadMCAMPT2010hCentrality(const char *cent) {
+
+  loadMCAMPT2010h12A11RunNumbers();
+  bUseMultiplicityTask       = kFALSE;
+
+  if (TString(cent).Contains("0-5")) {
+    szDataDir = szDataDir + "a";
+  }
+  else if (TString(cent).Contains("30-40")) {
+    szDataDir = szDataDir + "e";
+  }
+  else if (TString(cent).Contains("60-70")) {
+    szDataDir = szDataDir + "h";
+  }
+}
+
+void load2015oLIRRunNumbers() {
+  bUseESD                    = kTRUE;
+  bUseAOD                    = !bUseESD;
+
+  /* the GRID working directory */
+  szGridWorkingDir = "CorrelationStudies_2015oLIR";
+
+  /* 2015o */
+  szDataDir = "/alice/data/2015/LHC15o";
+
+  /* 2015o LIR */
+  szDataPattern = "*/pass3_lowIR_pidfix/*/AliESDs.root";
+
+  /* reco pass */
+  szpass = "3";
+
+  /* the list of runs to analyze 2015o LIR*/
+  /* (B: + +) */
+  listOfActiveRuns.Add(new TObjString("244918"));
+  listOfActiveRuns.Add(new TObjString("244975"));
+  listOfActiveRuns.Add(new TObjString("244982"));
+  listOfActiveRuns.Add(new TObjString("244983"));
+  listOfActiveRuns.Add(new TObjString("245064"));
+  listOfActiveRuns.Add(new TObjString("245066"));
+  listOfActiveRuns.Add(new TObjString("245068"));
+  /* (B: - -) */
+  listOfActiveRuns.Add(new TObjString("246390"));
+  listOfActiveRuns.Add(new TObjString("246391"));
+  listOfActiveRuns.Add(new TObjString("246392"));
+}
+
+void load2015oLIRpass2RunNumbers() {
+
+  /* load the 2015oLIR run numbers */
+  load2015oLIRRunNumbers();
+
+  /* reco pass */
+  szpass = "2";
+
+  /* 2015o LIR pass2 filtering */
+  szDataPattern = "*/pass2_lowIR/*/AliESDs.root";
+}
+
+void load2015oLIRpass3RunNumbers() {
+
+  /* load the 2015oLIR run numbers */
+  load2015oLIRRunNumbers();
+
+  /* reco pass */
+  szpass = "3";
+
+  /* 2015o LIR pass3 filtering */
+  szDataPattern = "*/pass3_lowIR_pidfix/*/AliESDs.root";
+}
+
+void load2015oLIRpass4RunNumbers() {
+
+  /* load the 2015oLIR run numbers */
+  load2015oLIRRunNumbers();
+
+  /* reco pass */
+  szpass = "4";
+
+  /* 2015o LIR pass4 filtering */
+  szDataPattern = "*/pass4_lowIR_pidfix_cookdedx/*/AliESDs.root";
+}
+
+
+void load2015oMCTestRunNumber() {
+  bUseESD                    = kFALSE;
+  bUseAOD                    = !bUseESD;
+
+  /* the GRID working directory */
+  szGridWorkingDir = "CorrelationStudies_2015oMC";
+
+  bMC = kTRUE;
+
+  /* reco pass */
+  szpass = "1";
+
+  /* 2015o */
+  szDataDir = "/alice/sim/2016/LHC16g1";
+  /* 2015o HIR */
+  szDataPattern = "*/AliAOD.root";
+
+  /* the list of runs to analyze 2015o HIR*/
+  listOfActiveRuns.Add(new TObjString("246994"));
+}
+
+void load2015oHIRTestRunNumber() {
+  bUseESD                    = kFALSE;
+  bUseAOD                    = !bUseESD;
+
+  /* the GRID working directory */
+  szGridWorkingDir = "CorrelationStudies_2015oHIR";
+
+  /* reco pass */
+  szpass = "1";
+
+  /* 2015o */
+  szDataDir = "/alice/data/2015/LHC15o";
+  /* 2015o HIR */
+  szDataPattern = "*/pass1/*/AliAOD.root";
+
+  /* the list of runs to analyze 2015o HIR*/
+  listOfActiveRuns.Add(new TObjString("246087"));
+}
+
+void load2016kTestRunNumber() {
+  bUseESD                    = kFALSE;
+  bUseAOD                    = !bUseESD;
+
+  /* the GRID working directory */
+  szGridWorkingDir = "Test_pp_Studies_2016k";
+
+  /* 2016ko */
+  szDataDir = "/alice/data/2016/LHC16k";
+  /* 2015o HIR */
+  szDataPattern = "*/pass1/*/AliAOD.root";
+
+  /* the list of runs to analyze 2015o HIR*/
+  listOfActiveRuns.Add(new TObjString("258454"));
+}
+

--- a/PWGCF/Correlations/macros/Unfoldedhistos/runCorrelationsStudiesConfigMacro.H
+++ b/PWGCF/Correlations/macros/Unfoldedhistos/runCorrelationsStudiesConfigMacro.H
@@ -1,0 +1,46 @@
+#ifndef RUNCORRELATIONSTUDIESCONFIG_H_
+#define RUNCORRELATIONSTUDIESCONFIG_H_
+
+Bool_t bASCIIoutput;
+
+Bool_t bGRIDPlugin;
+Bool_t bTrainScope;
+Bool_t bMC;
+
+Bool_t isHeavyIon;
+
+/* tasks to use */
+/* only valid if not under train scope */
+Bool_t bUsePhysicsSelection;
+Bool_t bUsePIDResponse;
+Bool_t bUseCentralityTask;
+Bool_t bUseMultiplicityTask;
+
+/* data input */
+Bool_t bUseESD;
+Bool_t bUseAOD;
+TString szpass;
+
+/* Task level cuts */
+Double_t centralityMin;
+Double_t centralityMax;
+Double_t zvertexMin;
+Double_t zvertexMax;
+Double_t bUseOnlyCentCalibEvents;
+
+/* Running conditions */
+TString szAliPhysicsVersion;
+TString szGridWorkingDir;
+TString szDataPattern;
+TString szDataDir;
+TString szRunPrefix;
+Int_t nNoOfTestFiles;
+Int_t nNoOfInputFiles;
+TObjArray listOfActiveRuns;
+
+/* local file list */
+TString szLocalFileList;
+
+void runCorrelationsStudiesConfigMacro();
+
+#endif /* RUNCORRELATIONSTUDIESCONFIG_H_ */

--- a/PWGCF/Correlations/macros/Unfoldedhistos/runCorrelationsStudiesTask.C
+++ b/PWGCF/Correlations/macros/Unfoldedhistos/runCorrelationsStudiesTask.C
@@ -1,0 +1,230 @@
+/**************************************************************************
+ * Copyright(c) 2013-2014, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: The ALICE Off-line Project.                                    *
+ * Contributors are mentioned in the code where appropriate.              *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+#ifdef __ECLIPSE_IDE
+//  few includes and external declarations just for the IDE
+#include "Riostream.h"
+#include "TROOT.h"
+#include "TSystem.h"
+#include "TChain.h"
+#include "AliAnalysisTaskSE.h"
+#include "AliAnalysisTask.h"
+#include "AliAnalysisManager.h"
+#include "AliAODInputHandler.h"
+#include "AliAnalysisTaskPIDResponse.h"
+#include "AliAnalysisTaskPIDqa.h"
+#include "AliPhysicsSelectionTask.h"
+#include "AliCentralitySelectionTask.h"
+#include "AliTaskCDBconnect.h"
+#include "AliAnalysisTaskPIDCombined.h"
+#include "AliESDInputHandler.h"
+#include "AliMCEventHandler.h"
+#include "AliMultSelectionTask.h"
+extern AliAnalysisGrid* CreateAlienHandler(const char *, Bool_t);
+extern AliCentralitySelectionTask *AddTaskCentrality(Bool_t fillHistos=kTRUE, Bool_t aod=kFALSE);
+extern AliAnalysisTask *AddTaskPIDResponse(Bool_t, Bool_t,Bool_t,TString);
+//extern AliAnalysisTask *AddTaskPIDqa(const char *);
+extern TChain* CreateESDChain(
+  const char* aDataDir = "ESDfiles.txt",
+  Int_t aRuns          = 20,
+  Int_t offset         = 0,
+  Bool_t addFileName   = kFALSE,
+  Bool_t addFriend     = kFALSE,
+  const char* check    = 0);
+extern TChain* CreateAODChain(
+    const char* aDataDir = "AODfiles.txt",
+    Int_t aRuns          = 20,
+    Int_t offset         = 0,
+    Bool_t addFileName   = kFALSE,
+    const char* friends  = "",
+    const char* check    = 0);
+AliPhysicsSelectionTask* AddTaskPhysicsSelection(
+    Bool_t mCAnalysisFlag = kFALSE,
+    Bool_t deprecatedFlag = kTRUE,
+    UInt_t computeBG = 0,
+    Bool_t useSpecialOutput=kFALSE);
+AliMultSelectionTask *AddTaskMultSelection(
+    Bool_t lCalibration = kFALSE,
+    TString lExtraOptions = "",
+    Int_t lNDebugEstimators = 1,
+    const TString lMasterJobSessionFlag = "");
+extern AliAnalysisTaskSE *AddCorrelationsStudiesTask(const char *, const char *, const char *, const char *);
+
+#include "runCorrelationsStudiesConfigMacro.H"
+#endif // ifdef __ECLIPSE_IDE declaration and includes for the ECLIPSE IDE
+
+void runCorrelationsStudiesTask(const char *sRunMode = "full", Bool_t gridMerge = kTRUE) {
+
+  gSystem->AddIncludePath("-I$ALICE_PHYSICS/include");
+  gSystem->AddIncludePath("-I$ALICE_ROOT/include");
+
+  gROOT->LoadMacro("$ALICE_PHYSICS/PWGCF/Correlations/macros/Unfoldedhistos/runCorrelationsStudiesConfigMacro.H");
+  gROOT->LoadMacro("$ALICE_PHYSICS/PWGCF/Correlations/macros/Unfoldedhistos/runCorrelationsStudiesConfigMacro.C");
+  runCorrelationsStudiesConfigMacro();
+
+  AliAnalysisGrid       *alienHandler   =   NULL;
+  AliAnalysisManager    *mgr;
+
+  if (!bTrainScope) {
+    mgr = new AliAnalysisManager("Correlation studies");
+
+    // Enable debug printouts
+    mgr->SetDebugLevel(AliLog::kInfo);
+    AliLog::SetGlobalLogLevel(AliLog::kInfo);
+  }
+  else {
+    mgr = AliAnalysisManager::GetAnalysisManager();
+  }
+
+
+  if (!bTrainScope) {
+    /* we only do this outside trains scope */
+    if (bUseESD) {
+      AliESDInputHandler* esdH = new AliESDInputHandler();
+      mgr->SetInputEventHandler(esdH);
+    //  esdH->SetReadFriends(kFALSE);
+    }
+    else if (bUseAOD) {
+      AliAODInputHandler* aodH = new AliAODInputHandler();
+      mgr->SetInputEventHandler(aodH);
+    }
+    else {
+      cout << "Neither AOD nor ESD data specified. ABORTING!!!" << endl;
+      return;
+    }
+
+    if (bMC && !bUseAOD){
+        AliMCEventHandler* mcH = new AliMCEventHandler();
+        mgr->SetMCtruthEventHandler(mcH);
+    }
+
+    if (bGRIDPlugin) {
+      gROOT->LoadMacro("$ALICE_PHYSICS/PWGCF/Correlations/macros/Unfoldedhistos/CreateAlienHandler.C");
+      alienHandler = CreateAlienHandler(sRunMode,gridMerge);
+      if (!alienHandler) return;
+
+      mgr->SetGridHandler(alienHandler);
+    }
+
+    if (bUsePIDResponse ) {
+      gROOT->LoadMacro("$ALICE_ROOT/ANALYSIS/macros/AddTaskPIDResponse.C");
+      AddTaskPIDResponse(bMC,kTRUE,kTRUE,szpass);
+    }
+
+    if (bUseESD) {
+      if (bUsePhysicsSelection) {
+        gROOT->LoadMacro("$ALICE_PHYSICS/OADB/macros/AddTaskPhysicsSelection.C");
+        AddTaskPhysicsSelection(bMC);
+      }
+
+      if (bUseMultiplicityTask) {
+        gROOT->LoadMacro("$ALICE_PHYSICS/OADB/COMMON/MULTIPLICITY/macros/AddTaskMultSelection.C");
+        AddTaskMultSelection(kFALSE); // user mode:
+      }
+
+      if (bUseCentralityTask) {
+        gROOT->LoadMacro("$ALICE_PHYSICS/OADB/macros/AddTaskCentrality.C");
+        AliCentralitySelectionTask *taskCentrality = AddTaskCentrality();
+        if (bMC) {
+          taskCentrality->SetMCInput();
+        }
+      }
+    }
+    /* this ends what we do outside the trains scope */
+  }
+
+  gROOT->LoadMacro("$ALICE_PHYSICS/PWGCF/Correlations/macros/Unfoldedhistos/AddCorrelationsStudiesTask.C");
+
+  /* load the configurations and start the corresponding tasks */
+  ifstream configfile;
+  configfile.open("configuration.txt");
+  while (!configfile.eof()) {
+    /* we need four configuration lines per task */
+    TString line;
+    TString firstline;
+    TString secondline;
+    TString thirdline;
+    TString fourthline;
+
+    line.ReadLine(configfile);
+    while ((line.BeginsWith("#") || line.IsWhitespace()) && !configfile.eof()) line.ReadLine(configfile);
+    firstline = line;
+    if (configfile.eof()) continue;
+
+    line.ReadLine(configfile);
+    while ((line.BeginsWith("#") || line.IsWhitespace()) && !configfile.eof()) line.ReadLine(configfile);
+    secondline = line;
+
+    line.ReadLine(configfile);
+    while ((line.BeginsWith("#") || line.IsWhitespace()) && !configfile.eof()) line.ReadLine(configfile);
+    thirdline = line;
+
+    line.ReadLine(configfile);
+    while ((line.BeginsWith("#") || line.IsWhitespace()) && !configfile.eof()) line.ReadLine(configfile);
+    fourthline = line;
+
+    if (firstline.Length() && secondline.Length() && thirdline.Length() && fourthline.Length())
+      AddCorrelationsStudiesTask(firstline.Data(),secondline.Data(),thirdline.Data(),fourthline.Data());
+    else {
+      cout << "Wrong configuration file. ABORTING!!!" << endl;
+      return;
+    }
+  }
+
+  TChain* chain = 0;
+
+  if (!bTrainScope) {
+    /* we only do this outside trains scope */
+    if (!bGRIDPlugin) {
+      Int_t numFiles = 0;
+      ifstream dataInStream;
+      dataInStream.open(szLocalFileList.Data());
+      if ( !dataInStream ) {
+        cout<<"Data list file does not exist: " << szLocalFileList.Data() << endl;
+        return;
+      }
+
+      string datafileline;
+
+      while ( !dataInStream.eof() ) {
+        getline(dataInStream, datafileline);
+        if(datafileline.compare("") != 0) {//checks if there is an empty line in the data list
+          numFiles++;
+        }
+      }
+      // No need to create a chain - this is handled by the plugin
+      if (bUseESD) {
+        gROOT->LoadMacro("$ALICE_PHYSICS/PWG/EMCAL/macros/CreateESDChain.C");
+        chain = CreateESDChain(szLocalFileList.Data(),numFiles);
+      }
+      else if (bUseAOD) {
+        gROOT->LoadMacro("$ALICE_PHYSICS/PWG/EMCAL/macros/CreateAODChain.C");
+        chain = CreateAODChain(szLocalFileList.Data(),numFiles);
+      }
+    }
+
+    if (!mgr->InitAnalysis())
+      return;
+
+    mgr->PrintStatus();
+    if (bGRIDPlugin){
+      mgr->StartAnalysis("grid");
+    }
+    else{
+      gSystem->SetFPEMask(0x0);
+      mgr->StartAnalysis("local",chain);
+    }
+    /* this ends what we do outside the trains scope */
+  }
+}


### PR DESCRIPTION
Two-particle number and transverse momentum correlations based in unfolded (eta1, eta2, phi1, phi2) data collection. Adapted to ESD and AOD format and automatically configured according to data taking period. Fully doxygen documented.