### PR TITLE
Wrong json string parsing

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoConfigObject.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoConfigObject.cxx
@@ -563,7 +563,7 @@ AliFemtoConfigObject::SetDefault(const AliFemtoConfigObject &d)
     // IDENT_PATTERN = "[a-zA-Z_]+[a-zA-Z0-9_]*(?:\\.[a-zA-Z_]+[a-zA-Z0-9_]*)*",
 
 #define LBRK_PAT "^\\s*" "\\{" "\\s*"
-#define RBRK_PAT         "\\}" "\\s*"
+#define RBRK_PAT  "\\s*" "\\}" "\\s*"
 #define LPRN_PAT        "\\(" "\\s*"
 #define RPRN_PAT         "\\)" "\\s*"
 
@@ -802,6 +802,7 @@ AliFemtoConfigObject::Parse(StringIter_t& it, const StringIter_t stop)
   }
 
   else if (std::regex_search(it, stop, match, BOOL_RX)) {
+    it = match[0].second;
     return AliFemtoConfigObject(match[0].str() == "true");
   }
 


### PR DESCRIPTION
There are two fixes included for two different issues.
- The boolean values are not correctly parsed: 'true' or 'false' are correctly taken as boolean but the parsing point is not progressed after taking them and an exception is thrown
- It is imposed a useless additional comma at the end of the map components if there are spaces before the right bracket: as an example, 
`"{type: \'AliFemtoAnalysisPionPion\' }"` throws an exception
`"{type: \'AliFemtoAnalysisPionPion\', }"` gets accepted
`"{type: \'AliFemtoAnalysisPionPion\'}"` gets accepted

