### PR TITLE
Change output to tree

### DIFF
--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.cxx
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.cxx
@@ -152,10 +152,7 @@ void AliAnalysisTaskEMCALAlig::DoTrackLoop()
             
             TVector3 trackposOnEMCAL;
             trackposOnEMCAL.SetPtEtaPhi(440,track->GetTrackEtaOnEMCal(),track->GetTrackPhiOnEMCal());
-            
-            Float_t phidiff = TVector2::Phi_mpi_pi(trackposOnEMCAL.Phi()-emcphi);
-            Float_t etadiff = trackposOnEMCAL.Eta() - emceta;
-            
+                        
             Float_t xdiff = trackposOnEMCAL.X() - clustpos.X();
             Float_t ydiff = trackposOnEMCAL.Y() - clustpos.Y();
             Float_t zdiff = trackposOnEMCAL.Z() - clustpos.Z();

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.cxx
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.cxx
@@ -39,34 +39,8 @@ AliAnalysisTaskEmcal(),
 fEMCALRecoUtils(NULL),
 fEMCALGeo(NULL),
 fPIDResponse(NULL),
-fNPartPt(NULL),
-fNPartPhi(NULL),
-fNPartEta(NULL),
-fPPartPt(NULL),
-fPPartPhi(NULL),
-fPPartEta(NULL),
-fTPCnSgima(NULL),
-fEOverP(NULL),
-fElectronPhiRes(NULL),
-fElectronEtaRes(NULL),
-fElectronXRes(NULL),
-fElectronYRes(NULL),
-fElectronPositronZRes(NULL),
-fPositronPhiRes(NULL),
-fPositronEtaRes(NULL),
-fPositronXRes(NULL),
-fPositronYRes(NULL),
-fAllMatchedTracksPhiRes(NULL),
-fAllMatchedTracksEtaRes(NULL),
-fElectronPhiResRU(NULL),
-fElectronEtaResRU(NULL),
-fElectronXResRU(NULL),
-fElectronYResRU(NULL),
-fElectronPositronZResRU(NULL),
-fPositronPhiResRU(NULL),
-fPositronEtaResRU(NULL),
-fPositronXResRU(NULL),
-fPositronYResRU(NULL)
+ElectronInformation(ElectronForAlignment()),
+ElectronTree(NULL)
 {
     
 }
@@ -76,35 +50,8 @@ AliAnalysisTaskEmcal(name, kTRUE),
 fEMCALRecoUtils(NULL),
 fEMCALGeo(NULL),
 fPIDResponse(NULL),
-fNPartPt(NULL),
-fNPartPhi(NULL),
-fNPartEta(NULL),
-fPPartPt(NULL),
-fPPartPhi(NULL),
-fPPartEta(NULL),
-fTPCnSgima(NULL),
-fEOverP(NULL),
-fElectronPhiRes(NULL),
-fElectronEtaRes(NULL),
-fElectronXRes(NULL),
-fElectronYRes(NULL),
-fElectronPositronZRes(NULL),
-fPositronPhiRes(NULL),
-fPositronEtaRes(NULL),
-fPositronXRes(NULL),
-fPositronYRes(NULL),
-fAllMatchedTracksPhiRes(NULL),
-fAllMatchedTracksEtaRes(NULL),
-fElectronPhiResRU(NULL),
-fElectronEtaResRU(NULL),
-fElectronXResRU(NULL),
-fElectronYResRU(NULL),
-fElectronPositronZResRU(NULL),
-fPositronPhiResRU(NULL),
-fPositronEtaResRU(NULL),
-fPositronXResRU(NULL),
-fPositronYResRU(NULL)
-
+ElectronInformation(ElectronForAlignment()),
+ElectronTree(NULL)
 {
     SetMakeGeneralHistograms(kTRUE);
 }
@@ -122,126 +69,9 @@ void AliAnalysisTaskEMCALAlig::UserCreateOutputObjects()
     
     fPIDResponse = fInputHandler->GetPIDResponse();
     
-    //Negative Particle Histograms;
-    fNPartPt = new TH1F("fNPartPt","p_{T} distribution of Electrons ;p_{T} (GeV/c);counts",200,0,20);
-    fOutput->Add(fNPartPt);
-    fNPartPhi = new TH1F("fNPartPhi","Electron #phi distribution;#phi;counts",100,0,6.3);
-    fOutput->Add(fNPartPhi);
-    fNPartEta = new TH1F("fNPartEta","Electron #eta distribution;#eta;counts",100,-1.0,1.0);
-    fOutput->Add(fNPartEta);
-    
-    //Positive Particle Histograms;
-    fPPartPt = new TH1F("fPPartPt","p_{T} distribution of Positrons;p_{T} (GeV/c);counts",200,0,20);
-    fOutput->Add(fPPartPt);
-    fPPartPhi = new TH1F("fPPartPhi","Positron #phi distribution;#phi;counts",100,0,6.3);
-    fOutput->Add(fPPartPhi);
-    fPPartEta = new TH1F("fPPartEta","Positron #eta distribution;#eta;counts",100,-1.0,1.0);
-    fOutput->Add(fPPartEta);
-    
-    //PID Plots
-    fTPCnSgima = new TH2F("fTPCnSgima","All Track TPC Nsigma distribution;p (GeV/c);#sigma_{TPC-dE/dx}",300,0,30,200,-20,20); // TPC Nsigma as function of pT
-    fOutput->Add(fTPCnSgima);
-    
-    fEOverP = new TH2F("fEOverP", "E/p distribution;p_{T} (GeV/c);E/p", 200,0,20,60, 0.0, 3.0); // E/p as function of pT
-    fOutput->Add(fEOverP);
-    
-    
-    fElectronPhiRes = new TH2F *[21];
-    fElectronEtaRes = new TH2F *[21];
-    fElectronXRes = new TH2F *[21];
-    fElectronYRes = new TH2F *[21];
-    fElectronPositronZRes = new TH2F *[21];
-    fPositronPhiRes = new TH2F *[21];
-    fPositronEtaRes = new TH2F *[21];
-    fPositronXRes = new TH2F *[21];
-    fPositronYRes = new TH2F *[21];
-    fAllMatchedTracksPhiRes = new TH2F *[21];
-    fAllMatchedTracksEtaRes = new TH2F *[21];
-    
-    fElectronPhiResRU = new TH2F *[21];
-    fElectronEtaResRU = new TH2F *[21];
-    fElectronXResRU = new TH2F *[21];
-    fElectronYResRU = new TH2F *[21];
-    fElectronPositronZResRU = new TH2F *[21];
-    fPositronPhiResRU = new TH2F *[21];
-    fPositronEtaResRU = new TH2F *[21];
-    fPositronXResRU = new TH2F *[21];
-    fPositronYResRU = new TH2F *[21];
-    
-    
-    for(Int_t i = 0; i<21;i++)
-    {
-        fElectronPhiRes[i] = new TH2F(Form("fElectronPhiRes%d",i),"Distance (phi) of EMCAL cluster in ID electrons;#phi;#Delta#phi",100,0,2*TMath::Pi(),1000,-0.3,0.3);
-        fOutput->Add(fElectronPhiRes[i]);
-        
-        fElectronEtaRes[i] = new TH2F(Form("fElectronEtaRes%d",i),"Distance (eta) of EMCAL clusterin ID electrons;#phi;#Delta#eta",100,0,2*TMath::Pi(),1000,-0.3,0.3);
-        fOutput->Add(fElectronEtaRes[i]);
-        
-        fElectronXRes[i] = new TH2F(Form("fElectronXRes%d",i),"Distance (x) of EMCAL cluster in ID electrons;#phi;#Delta x",100,0,2*TMath::Pi(),1000,-20,20);
-        fOutput->Add(fElectronXRes[i]);
-        
-        fElectronYRes[i] = new TH2F(Form("fElectronYRes%d",i),"Distance (y) of EMCAL clusterin ID electrons;#phi;#Delta y",100,0,2*TMath::Pi(),1000,-20,20);
-        fOutput->Add(fElectronYRes[i]);
-        
-        fElectronPositronZRes[i] = new TH2F(Form("fElectronPositronZRes%d",i),"Distance (z) of EMCAL clusterin ID electrons and positrons;#phi;#Delta z",100,0,2*TMath::Pi(),1000,-20,20);
-        fOutput->Add(fElectronPositronZRes[i]);
-        
-        //Positrons
-        
-        fPositronPhiRes[i] = new TH2F(Form("fPositronPhiRes%d",i),"Distance (phi) of EMCAL cluster in ID positrons;#Delta#phi;#Delta#phi",100,0,2*TMath::Pi(),1000,-0.3,0.3);
-        fOutput->Add(fPositronPhiRes[i]);
-        
-        fPositronEtaRes[i] = new TH2F(Form("fPositronEtaRes%d",i),"Distance (eta) of EMCAL clusterin ID positrons;#phi;#Delta#eta",100,0,2*TMath::Pi(),1000,-0.3,0.3);
-        fOutput->Add(fPositronEtaRes[i]);
-        
-        fPositronXRes[i] = new TH2F(Form("fPositronXRes%d",i),"Distance (x) of EMCAL cluster in ID positrons;#phi;#Delta x",100,0,2*TMath::Pi(),1000,-20,20);
-        fOutput->Add(fPositronXRes[i]);
-        
-        fPositronYRes[i] = new TH2F(Form("fPositronYRes%d",i),"Distance (y) of EMCAL clusterin ID positrons;#phi;#Delta y",100,0,2*TMath::Pi(),1000,-20,20);
-        fOutput->Add(fPositronYRes[i]);
-        
-        //All tracks
-        
-        fAllMatchedTracksPhiRes[i] = new TH2F(Form("fAllMatchedTracksPhiRes%d",i),"Distance (phi) of EMCAL cluster in all matched tracks ;#Delta#phi;#Delta#eta",100,0,2*TMath::Pi(),100,-0.3,0.3);
-        fOutput->Add(fAllMatchedTracksPhiRes[i]);
-        
-        fAllMatchedTracksEtaRes[i] = new TH2F(Form("fAllMatchedTracksEtaRes%d",i),"Distance (phi) of EMCAL cluster in all matched tracks ;#Delta#phi;#Delta#eta",100,0,2*TMath::Pi(),100,-0.3,0.3);
-        fOutput->Add(fAllMatchedTracksEtaRes[i]);
-        
-        fElectronPhiResRU[i] = new TH2F(Form("fElectronPhiResRU%d",i),"Distance (phi) of EMCAL cluster in ID electrons RU;#phi;#Delta#phi",100,0,2*TMath::Pi(),1000,-0.3,0.3);
-        fOutput->Add(fElectronPhiResRU[i]);
-        
-        fElectronEtaResRU[i] = new TH2F(Form("fElectronEtaResRU%d",i),"Distance (eta) of EMCAL clusterin ID electrons RU;#phi;#Delta#eta",100,0,2*TMath::Pi(),1000,-0.3,0.3);
-        fOutput->Add(fElectronEtaResRU[i]);
-        
-        fElectronXResRU[i] = new TH2F(Form("fElectronXResRU%d",i),"Distance (x) of EMCAL cluster in ID electrons RU;#phi;#Delta x",100,0,2*TMath::Pi(),1000,-20,20);
-        fOutput->Add(fElectronXResRU[i]);
-        
-        fElectronYResRU[i] = new TH2F(Form("fElectronYResRU%d",i),"Distance (y) of EMCAL clusterin ID electrons RU;#phi;#Delta y",100,0,2*TMath::Pi(),1000,-20,20);
-        fOutput->Add(fElectronYResRU[i]);
-        
-        fElectronPositronZResRU[i] = new TH2F(Form("fElectronPositronZRes%dRU",i),"Distance (z) of EMCAL clusterin ID electrons and positrons RU;#phi;#Delta z",100,0,2*TMath::Pi(),1000,-20,20);
-        fOutput->Add(fElectronPositronZResRU[i]);
-        
-        //Positrons
-        
-        fPositronPhiResRU[i] = new TH2F(Form("fPositronPhiResRU%d",i),"Distance (phi) of EMCAL cluster in ID positrons RU;#Delta#phi;#Delta#eta",100,0,2*TMath::Pi(),1000,-0.3,0.3);
-        fOutput->Add(fPositronPhiResRU[i]);
-        
-        fPositronEtaResRU[i] = new TH2F(Form("fPositronEtaResRU%d",i),"Distance (eta) of EMCAL clusterin ID positrons RU;#phi;#Delta#eta",100,0,2*TMath::Pi(),1000,-0.3,0.3);
-        fOutput->Add(fPositronEtaResRU[i]);
-        
-        fPositronXResRU[i] = new TH2F(Form("fPositronXResRU%d",i),"Distance (x) of EMCAL cluster in ID positrons RU;#phi;#Delta x",100,0,2*TMath::Pi(),1000,-20,20);
-        fOutput->Add(fPositronXResRU[i]);
-        
-        fPositronYResRU[i] = new TH2F(Form("fPositronYResRU%d",i),"Distance (y) of EMCAL clusterin ID positrons RU;#phi;#Delta y",100,0,2*TMath::Pi(),1000,-20,20);
-        fOutput->Add(fPositronYResRU[i]);
-        
-        
-    }
-    
-
-    
+    ElectronTree = new TTree("electron_information","electron_information");
+    ElectronTree->Branch("electrons", &ElectronInformation);
+    fOutput->Add(ElectronTree);
     PostData(1, fOutput);
 }
 
@@ -255,7 +85,7 @@ Bool_t AliAnalysisTaskEMCALAlig::FillHistograms()
 void AliAnalysisTaskEMCALAlig::DoTrackLoop()
 {
     AliClusterContainer* clusCont = GetClusterContainer(0);
-  //AliVCaloCells *cells = InputEvent()->GetEMCALCells();
+    //AliVCaloCells *cells = InputEvent()->GetEMCALCells();
     
     if (!clusCont)
     {
@@ -282,140 +112,115 @@ void AliAnalysisTaskEMCALAlig::DoTrackLoop()
                 continue;
             //Electron PID cuts: -1 to 3 sigma TPC
             Double_t TPCNSgima = fPIDResponse->NumberOfSigmasTPC(track, AliPID::kElectron);
-            fTPCnSgima->Fill(track->Pt(),TPCNSgima);
             
-            if (TPCNSgima < 1.0 || TPCNSgima > 3.0)
+            if (TPCNSgima < -1.5 || TPCNSgima > 3.5)
                 continue;
             
-            if (clusCont)
-            {
-                Int_t iCluster = track->GetEMCALcluster();
-                if (iCluster >= 0)
-                {
-                    AliVCluster* cluster = clusCont->GetAcceptCluster(iCluster);
-                    
-                    if (cluster)
-                    {
-                        Double_t EoverP = cluster->GetNonLinCorrEnergy()/track->P();
-                        fEOverP->Fill(track->Pt(),EoverP);
-                        
-                        //E/p cut
-                        if (EoverP>= 0.8 && EoverP<=1.2)
-                        {
-                            if (track->Pt() > 8)
-                            {
-                                //M20cut for high pT
-                                Double_t M20 = cluster->GetM20();
-                                if ( M20<0.01 && M20>0.4)
-                                    continue;
-                            }
-                            
-                            //Cluster properties
-                            Float_t  emcx[3];
-                            cluster->GetPosition(emcx);
-                            TVector3 clustpos(emcx[0],emcx[1],emcx[2]);
-                            Double_t emcphi = clustpos.Phi();
-                            Double_t emceta = clustpos.Eta();
-                            
-                            if(emcphi < 0) emcphi = emcphi+(2*TMath::Pi());
-                            
-                          //Int_t nCells=cluster->GetNCells();
-                            Int_t iSupMod = -9;
-                            Int_t ieta = -9;
-                            Int_t iphi = -9;
-                            Int_t icell = -9;
-                            Bool_t Isshared	= kFALSE;
-                            //Get the SM number
-                            fEMCALRecoUtils->GetMaxEnergyCell(fEMCALGeo,fCaloCells,cluster,icell,iSupMod,ieta,iphi,Isshared);
-                            Int_t SMNumber = iSupMod;
-                            
-                            TVector3 trackposOnEMCAL;
-                            trackposOnEMCAL.SetPtEtaPhi(440,track->GetTrackEtaOnEMCal(),track->GetTrackPhiOnEMCal());
-                            
-                            Float_t phidiff = TVector2::Phi_mpi_pi(trackposOnEMCAL.Phi()-emcphi);
-                            Float_t etadiff = trackposOnEMCAL.Eta() - emceta;
-                            
-                            Float_t xdiff = trackposOnEMCAL.X() - clustpos.X();
-                            Float_t ydiff = trackposOnEMCAL.Y() - clustpos.Y();
-                            Float_t zdiff = trackposOnEMCAL.Z() - clustpos.Z();
-                            
-                            
-                            //Save Default residuals (from propagation to the EMCal Surface)
-                            if (track->Charge()> 0)
-                            {
-                                //Track properties
-                                fPPartPt->Fill(track->Pt());
-                                fPPartPhi->Fill(track->Phi());
-                                fPPartEta->Fill(track->Eta());
-                                //Residual from matching
-                                fPositronEtaRes[SMNumber]->Fill(emcphi,etadiff);
-                                fPositronPhiRes[SMNumber]->Fill(emcphi,phidiff);
-                                fPositronXRes[SMNumber]->Fill(emcphi,xdiff);
-                                fPositronYRes[SMNumber]->Fill(emcphi,ydiff);
-                                fElectronPositronZRes[SMNumber]->Fill(emcphi,zdiff);
-                            }
-                            else
-                            {
-                                fNPartPt->Fill(track->Pt());
-                                fNPartPhi->Fill(track->Phi());
-                                fNPartEta->Fill(track->Eta());
-                                fElectronEtaRes[SMNumber]->Fill(emcphi,etadiff);
-                                fElectronPhiRes[SMNumber]->Fill(emcphi,phidiff);
-                                fElectronXRes[SMNumber]->Fill(emcphi,xdiff);
-                                fElectronYRes[SMNumber]->Fill(emcphi,ydiff);
-                                fElectronPositronZRes[SMNumber]->Fill(emcphi,zdiff);
-                                
-                            }
-                            
-                            //propagation using electron mass
-                            
-                            Double_t xyz[3] = {0}, pxpypz[3] = {0}, cv[21] = {0};
-                            track->PxPyPz(pxpypz);
-                            track->XvYvZv(xyz);
-                            track->GetCovarianceXYZPxPyPz(cv);
-                            AliExternalTrackParam trackParam = AliExternalTrackParam(xyz,pxpypz,cv,track->Charge());
-                            
-                            Double_t trackPosExt[3] = {0.,0.,0.};
-                            Double_t ElectronMass = 0.000510998910; //Electron mass in GeV
-                            Float_t EtaResidualsForCrossCheck, PhiResidualsForCrossCheck;
-                            
-                            fEMCALRecoUtils->ExtrapolateTrackToPosition(&trackParam, emcx, ElectronMass, fEMCALRecoUtils->GetStep(), EtaResidualsForCrossCheck,PhiResidualsForCrossCheck);
-                            trackParam.GetXYZ(trackPosExt);
-                            
-                            TVector3 trackposOnEMCALRU;
-                            
-                            trackposOnEMCALRU.SetXYZ(trackPosExt[0],trackPosExt[1],trackPosExt[2]);
-                            
-                            Double_t phidiffRU = TVector2::Phi_mpi_pi(trackposOnEMCALRU.Phi()-emcphi);
-                            Double_t etadiffRU = trackposOnEMCALRU.Eta() - emceta;
-                            
-                            Double_t xdiffRU = trackposOnEMCALRU.X() - clustpos.X();
-                            Double_t ydiffRU = trackposOnEMCALRU.Y() - clustpos.Y();
-                            Double_t zdiffRU = trackposOnEMCALRU.Z() - clustpos.Z();
-                            
-                            if (track->Charge()>0)
-                            {
-                                fPositronEtaResRU[SMNumber]->Fill(emcphi,etadiffRU);
-                                fPositronPhiResRU[SMNumber]->Fill(emcphi,phidiffRU);
-                                fPositronXResRU[SMNumber]->Fill(emcphi,xdiffRU);
-                                fPositronYResRU[SMNumber]->Fill(emcphi,ydiffRU);
-                                fElectronPositronZResRU[SMNumber]->Fill(emcphi,zdiffRU);
-                            }
-                            else
-                            {
-                                fElectronEtaResRU[SMNumber]->Fill(emcphi,etadiffRU);
-                                fElectronPhiResRU[SMNumber]->Fill(emcphi,phidiffRU);
-                                fElectronXResRU[SMNumber]->Fill(emcphi,xdiffRU);
-                                fElectronYResRU[SMNumber]->Fill(emcphi,ydiffRU);
-                                fElectronPositronZResRU[SMNumber]->Fill(emcphi,zdiffRU);
-                            }
-                            
-                        }
-                    }
-                }
-                
-            }
+            Int_t iCluster = track->GetEMCALcluster();
+            
+            if (iCluster < 0)
+                continue;
+            
+            AliVCluster* cluster = clusCont->GetAcceptCluster(iCluster);
+            
+            if (!cluster)
+                continue;
+            
+            
+            Double_t EoverP = cluster->GetNonLinCorrEnergy()/track->P();
+                //E/p cut
+            if (EoverP<0.7 || EoverP>1.3)
+                continue;
+            
+            //Cluster properties
+            Float_t  emcx[3];
+            cluster->GetPosition(emcx);
+            TVector3 clustpos(emcx[0],emcx[1],emcx[2]);
+            Double_t emcphi = clustpos.Phi();
+            Double_t emceta = clustpos.Eta();
+            
+            if(emcphi < 0) emcphi = emcphi+(2*TMath::Pi());
+            
+            //Int_t nCells=cluster->GetNCells();
+            Int_t iSupMod = -9;
+            Int_t ieta = -9;
+            Int_t iphi = -9;
+            Int_t icell = -9;
+            Bool_t Isshared	= kFALSE;
+            //Get the SM number
+            fEMCALRecoUtils->GetMaxEnergyCell(fEMCALGeo,fCaloCells,cluster,icell,iSupMod,ieta,iphi,Isshared);
+            
+            TVector3 trackposOnEMCAL;
+            trackposOnEMCAL.SetPtEtaPhi(440,track->GetTrackEtaOnEMCal(),track->GetTrackPhiOnEMCal());
+            
+            Float_t phidiff = TVector2::Phi_mpi_pi(trackposOnEMCAL.Phi()-emcphi);
+            Float_t etadiff = trackposOnEMCAL.Eta() - emceta;
+            
+            Float_t xdiff = trackposOnEMCAL.X() - clustpos.X();
+            Float_t ydiff = trackposOnEMCAL.Y() - clustpos.Y();
+            Float_t zdiff = trackposOnEMCAL.Z() - clustpos.Z();
+            
+            //propagation using electron mass
+            
+            Double_t xyz[3] = {0}, pxpypz[3] = {0}, cv[21] = {0};
+            track->PxPyPz(pxpypz);
+            track->XvYvZv(xyz);
+            track->GetCovarianceXYZPxPyPz(cv);
+            AliExternalTrackParam trackParam = AliExternalTrackParam(xyz,pxpypz,cv,track->Charge());
+            
+            Double_t trackPosExt[3] = {0.,0.,0.};
+            Double_t ElectronMass = 0.000510998910; //Electron mass in GeV
+            Float_t EtaResidualsForCrossCheck, PhiResidualsForCrossCheck;
+            
+            fEMCALRecoUtils->ExtrapolateTrackToPosition(&trackParam, emcx, ElectronMass, fEMCALRecoUtils->GetStep(), EtaResidualsForCrossCheck,PhiResidualsForCrossCheck);
+            trackParam.GetXYZ(trackPosExt);
+            
+            TVector3 trackposOnEMCALRU;
+            
+            trackposOnEMCALRU.SetXYZ(trackPosExt[0],trackPosExt[1],trackPosExt[2]);
+            
+            Double_t phidiffRU = TVector2::Phi_mpi_pi(trackposOnEMCALRU.Phi()-emcphi);
+            Double_t etadiffRU = trackposOnEMCALRU.Eta() - emceta;
+            Double_t xdiffRU = trackposOnEMCALRU.X() - clustpos.X();
+            Double_t ydiffRU = trackposOnEMCALRU.Y() - clustpos.Y();
+            Double_t zdiffRU = trackposOnEMCALRU.Z() - clustpos.Z();
+            
+            
+            ElectronInformation.charge = track->Charge();
+            ElectronInformation.pt = track->Pt();
+            ElectronInformation.pz = track->Pz();
+            ElectronInformation.eta_track = track->Eta();
+            ElectronInformation.phi_track = track->Phi();
+            
+            //cluster properties
+            ElectronInformation.energy = cluster->GetNonLinCorrEnergy();
+            ElectronInformation.M20 = cluster->GetM20();
+            ElectronInformation.M02 = cluster->GetM02();
+            ElectronInformation.eta_cluster = clustpos.Eta();
+            ElectronInformation.phi_cluster = clustpos.Phi();
+            
+            //mathing properties using default matcher
+            ElectronInformation.x_resitual_def = xdiff;
+            ElectronInformation.y_resitual_def = ydiff;
+            ElectronInformation.z_resitual_def = zdiff;
+            ElectronInformation.phi_resitual_def = cluster->GetTrackDx();
+            ElectronInformation.eta_resitual_def = cluster->GetTrackDz();
+                   
+            //mathing properties using electron mass
+            ElectronInformation.x_resitual_e = xdiffRU;
+            ElectronInformation.y_resitual_e = ydiffRU;
+            ElectronInformation.z_resitual_e = zdiffRU;
+            ElectronInformation.phi_resitual_e = phidiffRU;
+            ElectronInformation.eta_resitual_e = etadiffRU;
+            
+            ElectronInformation.super_module_number = iSupMod;
+            //PID properties
+            ElectronInformation.TPCNSigmaElectron = TPCNSgima;
+            
+            ElectronTree->Fill();
+            
         }
+        
         
     }
 }

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.h
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.h
@@ -167,7 +167,7 @@ private:
     AliAnalysisTaskEMCALAlig &operator=(const AliAnalysisTaskEMCALAlig&); // not implemented
     
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskEMCALAlig, 1);
+  ClassDef(AliAnalysisTaskEMCALAlig, 2);
   /// \endcond
 
 };

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.h
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.h
@@ -15,12 +15,126 @@
 
 
 #include "AliAnalysisTaskEmcal.h"
+#include "TObject.h"
 
 class AliEMCALRecoUtils;
 class AliPIDResponse;
 class TH1F;
 class TH2F;
 class AliEMCALGeometry;
+class TTree;
+
+class ElectronForAlignment : public TObject {
+public:
+    
+    //General Track properties
+    Short_t charge;
+    Float_t pt;
+    Float_t pz;
+    Float_t eta_track;
+    Float_t phi_track;
+    
+    //cluster properties
+    Float_t energy;
+    Float_t M20;
+    Float_t M02;
+    Float_t eta_cluster;
+    Float_t phi_cluster;
+    UShort_t super_module_number;
+    
+    //mathing properties using default matcher
+    Float_t x_resitual_def;
+    Float_t y_resitual_def;
+    Float_t z_resitual_def;
+    Float_t phi_resitual_def;
+    Float_t eta_resitual_def;
+    
+    //mathing properties using electron mass
+    Float_t x_resitual_e;
+    Float_t y_resitual_e;
+    Float_t z_resitual_e;
+    Float_t phi_resitual_e;
+    Float_t eta_resitual_e;
+    
+    //PID properties
+    Float_t TPCNSigmaElectron;
+    
+    ElectronForAlignment()
+    {
+        //General Track properties
+        charge = -9;
+        pt = -999;
+        pz = -999;
+        eta_track = -999;
+        phi_track = -999;
+        
+        //cluster properties
+        energy = -999;
+        M20 = -999;
+        M02 = -999;
+        eta_cluster = -999;
+        phi_cluster = -999;
+        
+        //mathing properties using default matcher
+        x_resitual_def = -999;
+        y_resitual_def = -999;
+        z_resitual_def = -999;
+        phi_resitual_def = -999;
+        eta_resitual_def = -999;
+        
+        //mathing properties using electron mass
+        x_resitual_e = -999;
+        y_resitual_e = -999;
+        z_resitual_e = -999;
+        phi_resitual_e = -999;
+        eta_resitual_e = -999;
+        
+        super_module_number = 99;
+        //PID properties
+        TPCNSigmaElectron = -999;
+    }
+    
+    void Reset()
+    {
+        //General Track properties
+        charge = -9;
+        pt = -999;
+        pz = -999;
+        eta_track = -999;
+        phi_track = -999;
+        
+        //cluster properties
+        energy = -999;
+        M20 = -999;
+        M02 = -999;
+        eta_cluster = -999;
+        phi_cluster = -999;
+        
+        //mathing properties using default matcher
+        x_resitual_def = -999;
+        y_resitual_def = -999;
+        z_resitual_def = -999;
+        phi_resitual_def = -999;
+        eta_resitual_def = -999;
+        
+        //mathing properties using electron mass
+        x_resitual_e = -999;
+        y_resitual_e = -999;
+        z_resitual_e = -999;
+        phi_resitual_e = -999;
+        eta_resitual_e = -999;
+        
+        super_module_number = 99;
+        //PID properties
+        TPCNSigmaElectron = -999;
+    }
+    
+    //Default Initializer
+    
+    ClassDef(ElectronForAlignment, 1);
+    
+};
+
 
 class AliAnalysisTaskEMCALAlig : public AliAnalysisTaskEmcal {
 public:
@@ -43,46 +157,9 @@ protected:
     AliEMCALRecoUtils *fEMCALRecoUtils; //! EMCAL Reco utils used to recalculate the matching
     AliEMCALGeometry *fEMCALGeo; //! EMCAL geometry class
     AliPIDResponse *fPIDResponse; //! PID response task used to perform electron identification
+    ElectronForAlignment ElectronInformation;
     
-    //Negative Particle Histograms;
-    TH1F *fNPartPt; //! Electron transverse momemtum distribution
-    TH1F *fNPartPhi; //! Electron azimuthal angle distribution
-    TH1F *fNPartEta; //! Electron pseudorapidity distribution
-    
-    //Positive Particle Histograms;
-    TH1F *fPPartPt; //! Positron transverse momemtum distribution
-    TH1F *fPPartPhi; //! Positron azimuthal angle distribution
-    TH1F *fPPartEta; //! Positron pseudorapidity distribution
-    
-    //PID Plots
-    TH2F* fTPCnSgima; //! TPC Nsigma as function of pT
-    TH2F* fEOverP; //! E/p as function of pT
-    
-    //Matching Residual Plots
-    TH2F        **fElectronPhiRes; //! Electron matching residual in phi as function of EMCAL SuperModule using propagation to EMCAL surface
-    TH2F        **fElectronEtaRes; //! Electron matching residual in eta as function of EMCAL SuperModule using propagation to EMCAL surface
-    TH2F        **fElectronXRes; //! Electron matching residual in x as function of EMCAL SuperModule using propagation to EMCAL surface
-    TH2F        **fElectronYRes; //! Electron matching residual in y as function of EMCAL SuperModule using propagation to EMCAL surface
-    TH2F        **fElectronPositronZRes; //! Electron and positron matching residual in z as function of EMCAL SuperModule using propagation to EMCAL surface
-    
-    TH2F        **fPositronPhiRes; //! Positron matching residual in phi as function of EMCAL SuperModule using propagation to EMCAL surface
-    TH2F        **fPositronEtaRes; //! Positron matching residual in eta as function of EMCAL SuperModule using propagation to EMCAL surface
-    TH2F        **fPositronXRes; //! Positron matching residual in x as function of EMCAL SuperModule using propagation to EMCAL surface
-    TH2F        **fPositronYRes; //! Positron  matching residual in y as function of EMCAL SuperModule using propagation to EMCAL surface
-    
-    TH2F        **fAllMatchedTracksPhiRes; //! All tracks mathing residual in Phi
-    TH2F        **fAllMatchedTracksEtaRes; //! All tracks mathing residual in Eta
-    
-    TH2F        **fElectronPhiResRU; //! Electron matching residual in phi as function of EMCAL SuperModule using propagation to cluster (done by EMCALRecoUtils)
-    TH2F        **fElectronEtaResRU; //! Electron matching residual in eta as function of EMCAL SuperModule using propagation to cluster (done by EMCALRecoUtils)
-    TH2F        **fElectronXResRU; //! Electron matching residual in x as function of EMCAL SuperModule using propagation to cluster (done by EMCALRecoUtils)
-    TH2F        **fElectronYResRU; //! Electron matching residual in y as function of EMCAL SuperModule using propagation to cluster (done by EMCALRecoUtils)
-    TH2F        **fElectronPositronZResRU; //! Electron and positron matching residual in z as function of EMCAL SuperModule using propagation to cluster (done by EMCALRecoUtils)
-    
-    TH2F        **fPositronPhiResRU; //! Positron matching residual in phi as function of EMCAL SuperModule using propagation to cluster (done by EMCALRecoUtils)
-    TH2F        **fPositronEtaResRU; //! Positron matching residual in eta as function of EMCAL SuperModule using propagation to cluster (done by EMCALRecoUtils)
-    TH2F        **fPositronXResRU; //! Positron matching residual in x as function of EMCAL SuperModule using propagation to cluster (done by EMCALRecoUtils)
-    TH2F        **fPositronYResRU; //! Positron  matching residual in y as function of EMCAL SuperModule using propagation to cluster (done by EMCALRecoUtils)
+    TTree* ElectronTree;
 
     
 private:

--- a/PWGPP/EMCAL/PWGPPEMCALLinkDef.h
+++ b/PWGPP/EMCAL/PWGPPEMCALLinkDef.h
@@ -12,5 +12,6 @@
 #pragma link C++ class AliAnalysisTaskEMCALTriggerQA+;
 #pragma link C++ class AliAnalysisTaskEMCALTimeCalib+;
 #pragma link C++ class BadChannelAna+;
+#pragma link C++ class ElectronForAlignment+;
 
 #endif


### PR DESCRIPTION
I have changed the output to trees instead of histograms. The total number of electrons is relatively small (for example ~270k electrons for 16k), so the tree output is still quite small. 
I need to change this to investigate if there is some pT (or any of the other cuts applied) in the matching residuals. 