### PR TITLE
add QA plots to ZDC EventPlane task

### DIFF
--- a/PWG/FLOW/Tasks/AliAnalysisTaskZDCEP.cxx
+++ b/PWG/FLOW/Tasks/AliAnalysisTaskZDCEP.cxx
@@ -76,6 +76,7 @@ AliAnalysisTaskZDCEP::AliAnalysisTaskZDCEP () :
 AliAnalysisTaskSE (),
 fOutputList(0x0),
 fHistList(0x0),
+fQAList(0x0),
 fZDCGainAlpha(0.395),
 fZDCCalibList(0x0),
 fTowerEqList(0x0),
@@ -118,17 +119,28 @@ fFlowEvent(NULL)
     fCRCZDCQVecDummyEZDCBins[i] = NULL;
   }
   for (Int_t i=0; i<2; i++) fZDCFlowVect[i] = NULL;
-  
+
   Int_t dRun15o[] = {244917, 244918, 244975, 244980, 244982, 244983, 245064, 245066, 245068, 246390, 246391, 246392, 246994, 246991, 246989, 246984, 246982, 246980, 246948, 246945, 246928, 246851, 246847, 246846, 246845, 246844, 246810, 246809, 246808, 246807, 246805, 246804, 246766, 246765, 246763, 246760, 246759, 246758, 246757, 246751, 246750, 246495, 246493, 246488, 246487, 246434, 246431, 246428, 246424, 246276, 246275, 246272, 246271, 246225, 246222, 246217, 246185, 246182, 246181, 246180, 246178, 246153, 246152, 246151, 246115, 246113, 246089, 246087, 246053, 246052, 246049, 246048, 246042, 246037, 246036, 246012, 246003, 246001, 245954, 245952, 245949, 245923, 245833, 245831, 245829, 245705, 245702, 245700, 245692, 245683, 245145, 245146, 245151, 245152, 245231, 245232, 245259, 245343, 245345, 245346, 245347, 245349, 245353, 245396, 245397, 245401, 245407, 245409, 245441, 245446, 245450, 245454, 245496, 245497, 245501, 245504, 245505, 245507, 245535, 245540, 245542, 245543, 245544, 245545, 245554};
   Double_t dVtxPosX15o[] = {0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,7.619407e-02, 7.612905e-02, 7.609009e-02, 7.610981e-02, 7.608885e-02, 7.609981e-02, 7.559263e-02, 7.563009e-02, 7.551201e-02, 7.570994e-02, 7.571927e-02, 7.575639e-02, 7.571133e-02, 7.570653e-02, 7.528412e-02, 7.535235e-02, 7.539954e-02, 7.535435e-02, 7.541641e-02, 7.543658e-02, 7.527343e-02, 7.526024e-02, 7.528295e-02, 7.533821e-02, 7.540461e-02, 7.538317e-02, 7.531677e-02, 7.539861e-02, 7.537667e-02, 7.659318e-02, 7.656796e-02, 7.662898e-02, 7.664257e-02, 7.597872e-02, 7.597437e-02, 7.599091e-02, 7.601310e-02, 7.000359e-02, 6.999659e-02, 6.992559e-02, 6.996793e-02, 7.028519e-02, 7.032696e-02, 7.033503e-02, 6.952509e-02, 6.956378e-02, 6.952446e-02, 6.959759e-02, 6.956048e-02, 6.933134e-02, 6.932882e-02, 6.939338e-02, 6.950613e-02, 6.943631e-02, 6.946196e-02, 6.950454e-02, 7.030973e-02, 7.030203e-02, 7.032272e-02, 7.030936e-02, 7.038967e-02, 7.035136e-02, 7.024752e-02, 6.942316e-02, 6.940115e-02, 6.936367e-02, 6.860689e-02, 6.881501e-02, 6.886743e-02, 6.932714e-02, 6.970325e-02, 6.966504e-02, 6.957355e-02, 6.932303e-02, 6.938184e-02, 6.944933e-02, 6.952461e-02, 6.964167e-02, 6.793435e-02, 6.802185e-02, 6.801235e-02, 6.804823e-02, 6.842972e-02, 6.839652e-02, 6.851932e-02, 6.976507e-02, 6.989692e-02, 6.994544e-02, 6.994261e-02, 6.997887e-02, 7.001687e-02, 6.934462e-02, 6.958349e-02, 6.907266e-02, 6.905944e-02, 6.895395e-02, 7.006562e-02, 7.008493e-02, 7.012736e-02, 6.964645e-02, 6.960466e-02, 6.962255e-02, 6.979086e-02, 6.985343e-02, 6.983755e-02, 6.957177e-02, 6.875991e-02, 6.871756e-02, 6.871021e-02, 6.871769e-02, 6.869493e-02, 6.874049e-02, 6.860300e-02};
   Double_t dVtxPosY15o[] = {0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,3.361709e-01, 3.361818e-01, 3.362205e-01, 3.363199e-01, 3.363092e-01, 3.362369e-01, 3.374328e-01, 3.374148e-01, 3.375140e-01, 3.361514e-01, 3.361743e-01, 3.362329e-01, 3.361395e-01, 3.361633e-01, 3.367675e-01, 3.366963e-01, 3.366845e-01, 3.366490e-01, 3.366937e-01, 3.366825e-01, 3.373764e-01, 3.373762e-01, 3.373721e-01, 3.373705e-01, 3.373943e-01, 3.373675e-01, 3.374071e-01, 3.373368e-01, 3.373442e-01, 3.375773e-01, 3.375333e-01, 3.377335e-01, 3.378285e-01, 3.362674e-01, 3.362492e-01, 3.362604e-01, 3.363473e-01, 3.295003e-01, 3.295046e-01, 3.295761e-01, 3.296100e-01, 3.291527e-01, 3.292071e-01, 3.290824e-01, 3.299371e-01, 3.300008e-01, 3.300078e-01, 3.300391e-01, 3.300740e-01, 3.300345e-01, 3.300776e-01, 3.301195e-01, 3.289427e-01, 3.289736e-01, 3.296084e-01, 3.297025e-01, 3.297724e-01, 3.298166e-01, 3.298278e-01, 3.298682e-01, 3.297381e-01, 3.296875e-01, 3.297720e-01, 3.298361e-01, 3.298561e-01, 3.299325e-01, 3.300111e-01, 3.301161e-01, 3.302630e-01, 3.289954e-01, 3.292915e-01, 3.293319e-01, 3.294174e-01, 3.314355e-01, 3.314431e-01, 3.316189e-01, 3.318682e-01, 3.323906e-01, 3.315020e-01, 3.312268e-01, 3.310778e-01, 3.310524e-01, 3.314478e-01, 3.312986e-01, 3.311297e-01, 3.324064e-01, 3.322524e-01, 3.322019e-01, 3.321221e-01, 3.321050e-01, 3.319118e-01, 3.317922e-01, 3.314658e-01, 3.315735e-01, 3.316331e-01, 3.316525e-01, 3.308030e-01, 3.308038e-01, 3.306947e-01, 3.305741e-01, 3.316492e-01, 3.316117e-01, 3.314973e-01, 3.314110e-01, 3.313450e-01, 3.313649e-01, 3.325841e-01, 3.324226e-01, 3.323649e-01, 3.323381e-01, 3.322566e-01, 3.322077e-01, 3.320860e-01};
   Double_t dVtxPosZ15o[] = {0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,5.559279e-01, 3.535446e-01, 4.846955e-01, 4.525585e-01, 3.684501e-01, 2.485494e-01, 2.372653e-01, 1.707859e-01, 3.314213e-01, 1.709195e-01, 2.209753e-01, 3.125757e-01, 3.422085e-01, 3.868156e-01, 4.859695e-01, 4.780697e-01, 4.400149e-01, 4.014992e-01, 3.049883e-01, 3.708501e-01, 3.883566e-01, 3.940632e-01, 4.197670e-01, 3.938399e-01, 3.814413e-01, 3.335539e-01, 3.181929e-01, 2.300734e-01, 2.722395e-01, 5.241033e-01, 3.225908e-01, 1.925791e-01, 1.892765e-01, 3.384066e-01, 2.026459e-01, 2.495699e-01, 3.569992e-01, 3.891381e-01, 4.603724e-01, 3.696685e-01, 3.002207e-01, 2.929533e-01, 3.095468e-01, 3.517200e-01, 2.784445e-01, 3.866626e-01, 3.058719e-01, 3.336752e-01, 3.226473e-01, 3.222815e-01, 3.428469e-01, 3.728514e-01, 2.858642e-01, 2.832485e-01, 3.378933e-01, 3.547548e-01, 3.799414e-01, 4.043543e-01, 4.314049e-01, 4.141138e-01, 3.888746e-01, 4.103586e-01, 3.871045e-01, 4.614473e-01, 4.023404e-01, 4.203531e-01, 4.401272e-01, 6.450558e-01, 6.819582e-01, 2.588529e-01, 3.693471e-01, 3.990708e-01, 3.813842e-01, 3.471682e-01, 3.356156e-01, 2.550150e-01, 3.830723e-01, 4.293259e-01, 4.723797e-01, 4.684324e-01, 4.609304e-01, 4.554974e-01, 4.523016e-01, 3.769890e-01, 4.485548e-01, 5.024484e-01, 5.200088e-01, 5.261731e-01, 5.392851e-01, 5.399264e-01, 5.155504e-01, 4.267668e-01, 5.348764e-01, 4.526746e-01, 4.045626e-01, 4.261759e-01, 5.889205e-01, 6.364843e-01, 5.896163e-01, 3.768637e-01, 4.440771e-01, 4.687029e-01, 4.794467e-01, 4.313422e-01, 3.954777e-01, 3.983129e-01, 3.608064e-01, 2.627038e-01, 3.665826e-01, 4.275667e-01, 3.335445e-01, 3.250815e-01, 3.022907e-01};
   for(Int_t r=0; r<fnRun; r++) {
     fRunList[r] = dRun15o[r];
+    fQVecRbR[r] = NULL;
   }
   fAvVtxPosX=TArrayD(fnRun,dVtxPosX15o);
   fAvVtxPosY=TArrayD(fnRun,dVtxPosY15o);
   fAvVtxPosZ=TArrayD(fnRun,dVtxPosZ15o);
+
+  for(Int_t c=0; c<4; c++) {
+    for(Int_t i=0; i<2; i++) {
+      fQVecCen[c][i] =  NULL;
+      fQVecVtx[c][i] =  NULL;
+      fQVecCorCen[c][i] =  NULL;
+      fQVecDeltaC[c][i] =  NULL;
+      fQVecCorDeltaC[c][i] =  NULL;
+    }
+  }
 }
 
 //=====================================================================
@@ -137,6 +149,7 @@ AliAnalysisTaskZDCEP::AliAnalysisTaskZDCEP(const  char* name)
 : AliAnalysisTaskSE(name),
 fOutputList(0x0),
 fHistList(0x0),
+fQAList(0x0),
 fZDCGainAlpha(0.395),
 fZDCCalibList(0x0),
 fTowerEqList(0x0),
@@ -179,20 +192,32 @@ fFlowEvent(NULL)
     fCRCZDCQVecDummyEZDCBins[i] = NULL;
   }
   for (Int_t i=0; i<2; i++) fZDCFlowVect[i] = NULL;
-  
+
   Int_t dRun15o[] = {244917, 244918, 244975, 244980, 244982, 244983, 245064, 245066, 245068, 246390, 246391, 246392, 246994, 246991, 246989, 246984, 246982, 246980, 246948, 246945, 246928, 246851, 246847, 246846, 246845, 246844, 246810, 246809, 246808, 246807, 246805, 246804, 246766, 246765, 246763, 246760, 246759, 246758, 246757, 246751, 246750, 246495, 246493, 246488, 246487, 246434, 246431, 246428, 246424, 246276, 246275, 246272, 246271, 246225, 246222, 246217, 246185, 246182, 246181, 246180, 246178, 246153, 246152, 246151, 246115, 246113, 246089, 246087, 246053, 246052, 246049, 246048, 246042, 246037, 246036, 246012, 246003, 246001, 245954, 245952, 245949, 245923, 245833, 245831, 245829, 245705, 245702, 245700, 245692, 245683, 245145, 245146, 245151, 245152, 245231, 245232, 245259, 245343, 245345, 245346, 245347, 245349, 245353, 245396, 245397, 245401, 245407, 245409, 245441, 245446, 245450, 245454, 245496, 245497, 245501, 245504, 245505, 245507, 245535, 245540, 245542, 245543, 245544, 245545, 245554};
   Double_t dVtxPosX15o[] = {0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,7.619407e-02, 7.612905e-02, 7.609009e-02, 7.610981e-02, 7.608885e-02, 7.609981e-02, 7.559263e-02, 7.563009e-02, 7.551201e-02, 7.570994e-02, 7.571927e-02, 7.575639e-02, 7.571133e-02, 7.570653e-02, 7.528412e-02, 7.535235e-02, 7.539954e-02, 7.535435e-02, 7.541641e-02, 7.543658e-02, 7.527343e-02, 7.526024e-02, 7.528295e-02, 7.533821e-02, 7.540461e-02, 7.538317e-02, 7.531677e-02, 7.539861e-02, 7.537667e-02, 7.659318e-02, 7.656796e-02, 7.662898e-02, 7.664257e-02, 7.597872e-02, 7.597437e-02, 7.599091e-02, 7.601310e-02, 7.000359e-02, 6.999659e-02, 6.992559e-02, 6.996793e-02, 7.028519e-02, 7.032696e-02, 7.033503e-02, 6.952509e-02, 6.956378e-02, 6.952446e-02, 6.959759e-02, 6.956048e-02, 6.933134e-02, 6.932882e-02, 6.939338e-02, 6.950613e-02, 6.943631e-02, 6.946196e-02, 6.950454e-02, 7.030973e-02, 7.030203e-02, 7.032272e-02, 7.030936e-02, 7.038967e-02, 7.035136e-02, 7.024752e-02, 6.942316e-02, 6.940115e-02, 6.936367e-02, 6.860689e-02, 6.881501e-02, 6.886743e-02, 6.932714e-02, 6.970325e-02, 6.966504e-02, 6.957355e-02, 6.932303e-02, 6.938184e-02, 6.944933e-02, 6.952461e-02, 6.964167e-02, 6.793435e-02, 6.802185e-02, 6.801235e-02, 6.804823e-02, 6.842972e-02, 6.839652e-02, 6.851932e-02, 6.976507e-02, 6.989692e-02, 6.994544e-02, 6.994261e-02, 6.997887e-02, 7.001687e-02, 6.934462e-02, 6.958349e-02, 6.907266e-02, 6.905944e-02, 6.895395e-02, 7.006562e-02, 7.008493e-02, 7.012736e-02, 6.964645e-02, 6.960466e-02, 6.962255e-02, 6.979086e-02, 6.985343e-02, 6.983755e-02, 6.957177e-02, 6.875991e-02, 6.871756e-02, 6.871021e-02, 6.871769e-02, 6.869493e-02, 6.874049e-02, 6.860300e-02};
   Double_t dVtxPosY15o[] = {0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,3.361709e-01, 3.361818e-01, 3.362205e-01, 3.363199e-01, 3.363092e-01, 3.362369e-01, 3.374328e-01, 3.374148e-01, 3.375140e-01, 3.361514e-01, 3.361743e-01, 3.362329e-01, 3.361395e-01, 3.361633e-01, 3.367675e-01, 3.366963e-01, 3.366845e-01, 3.366490e-01, 3.366937e-01, 3.366825e-01, 3.373764e-01, 3.373762e-01, 3.373721e-01, 3.373705e-01, 3.373943e-01, 3.373675e-01, 3.374071e-01, 3.373368e-01, 3.373442e-01, 3.375773e-01, 3.375333e-01, 3.377335e-01, 3.378285e-01, 3.362674e-01, 3.362492e-01, 3.362604e-01, 3.363473e-01, 3.295003e-01, 3.295046e-01, 3.295761e-01, 3.296100e-01, 3.291527e-01, 3.292071e-01, 3.290824e-01, 3.299371e-01, 3.300008e-01, 3.300078e-01, 3.300391e-01, 3.300740e-01, 3.300345e-01, 3.300776e-01, 3.301195e-01, 3.289427e-01, 3.289736e-01, 3.296084e-01, 3.297025e-01, 3.297724e-01, 3.298166e-01, 3.298278e-01, 3.298682e-01, 3.297381e-01, 3.296875e-01, 3.297720e-01, 3.298361e-01, 3.298561e-01, 3.299325e-01, 3.300111e-01, 3.301161e-01, 3.302630e-01, 3.289954e-01, 3.292915e-01, 3.293319e-01, 3.294174e-01, 3.314355e-01, 3.314431e-01, 3.316189e-01, 3.318682e-01, 3.323906e-01, 3.315020e-01, 3.312268e-01, 3.310778e-01, 3.310524e-01, 3.314478e-01, 3.312986e-01, 3.311297e-01, 3.324064e-01, 3.322524e-01, 3.322019e-01, 3.321221e-01, 3.321050e-01, 3.319118e-01, 3.317922e-01, 3.314658e-01, 3.315735e-01, 3.316331e-01, 3.316525e-01, 3.308030e-01, 3.308038e-01, 3.306947e-01, 3.305741e-01, 3.316492e-01, 3.316117e-01, 3.314973e-01, 3.314110e-01, 3.313450e-01, 3.313649e-01, 3.325841e-01, 3.324226e-01, 3.323649e-01, 3.323381e-01, 3.322566e-01, 3.322077e-01, 3.320860e-01};
   Double_t dVtxPosZ15o[] = {0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,5.559279e-01, 3.535446e-01, 4.846955e-01, 4.525585e-01, 3.684501e-01, 2.485494e-01, 2.372653e-01, 1.707859e-01, 3.314213e-01, 1.709195e-01, 2.209753e-01, 3.125757e-01, 3.422085e-01, 3.868156e-01, 4.859695e-01, 4.780697e-01, 4.400149e-01, 4.014992e-01, 3.049883e-01, 3.708501e-01, 3.883566e-01, 3.940632e-01, 4.197670e-01, 3.938399e-01, 3.814413e-01, 3.335539e-01, 3.181929e-01, 2.300734e-01, 2.722395e-01, 5.241033e-01, 3.225908e-01, 1.925791e-01, 1.892765e-01, 3.384066e-01, 2.026459e-01, 2.495699e-01, 3.569992e-01, 3.891381e-01, 4.603724e-01, 3.696685e-01, 3.002207e-01, 2.929533e-01, 3.095468e-01, 3.517200e-01, 2.784445e-01, 3.866626e-01, 3.058719e-01, 3.336752e-01, 3.226473e-01, 3.222815e-01, 3.428469e-01, 3.728514e-01, 2.858642e-01, 2.832485e-01, 3.378933e-01, 3.547548e-01, 3.799414e-01, 4.043543e-01, 4.314049e-01, 4.141138e-01, 3.888746e-01, 4.103586e-01, 3.871045e-01, 4.614473e-01, 4.023404e-01, 4.203531e-01, 4.401272e-01, 6.450558e-01, 6.819582e-01, 2.588529e-01, 3.693471e-01, 3.990708e-01, 3.813842e-01, 3.471682e-01, 3.356156e-01, 2.550150e-01, 3.830723e-01, 4.293259e-01, 4.723797e-01, 4.684324e-01, 4.609304e-01, 4.554974e-01, 4.523016e-01, 3.769890e-01, 4.485548e-01, 5.024484e-01, 5.200088e-01, 5.261731e-01, 5.392851e-01, 5.399264e-01, 5.155504e-01, 4.267668e-01, 5.348764e-01, 4.526746e-01, 4.045626e-01, 4.261759e-01, 5.889205e-01, 6.364843e-01, 5.896163e-01, 3.768637e-01, 4.440771e-01, 4.687029e-01, 4.794467e-01, 4.313422e-01, 3.954777e-01, 3.983129e-01, 3.608064e-01, 2.627038e-01, 3.665826e-01, 4.275667e-01, 3.335445e-01, 3.250815e-01, 3.022907e-01};
   for(Int_t r=0; r<fnRun; r++) {
     fRunList[r] = dRun15o[r];
+    fQVecRbR[r] = NULL;
   }
   fAvVtxPosX=TArrayD(fnRun,dVtxPosX15o);
   fAvVtxPosY=TArrayD(fnRun,dVtxPosY15o);
   fAvVtxPosZ=TArrayD(fnRun,dVtxPosZ15o);
-  
+
+  for(Int_t c=0; c<4; c++) {
+    for(Int_t i=0; i<2; i++) {
+      fQVecCen[c][i] =  NULL;
+      fQVecVtx[c][i] =  NULL;
+      fQVecCorCen[c][i] =  NULL;
+      fQVecDeltaC[c][i] =  NULL;
+      fQVecCorDeltaC[c][i] =  NULL;
+    }
+  }
+
   DefineInput(0,TChain::Class());
   DefineOutput(1,AliFlowEventSimple::Class());
+  DefineOutput(2,TList::Class());
 }
 
 //=====================================================================
@@ -205,6 +230,9 @@ AliAnalysisTaskZDCEP::~AliAnalysisTaskZDCEP()
   delete fFlowEvent;
   if(fAnalysisUtils) delete fAnalysisUtils;
   if(fMultSelection) delete fMultSelection;
+  if(fQAList){
+    delete fQAList;
+  }
 }
 
 //=====================================================================
@@ -214,15 +242,15 @@ void AliAnalysisTaskZDCEP::UserCreateOutputObjects ()
   //  create  a new  TList  that  OWNS  its  objects
   fOutputList = new TList();
   fOutputList->SetOwner(kTRUE);
-  
+
   for(Int_t c=0;c<2;c++) {
     fZDCFlowVect[c] = new AliFlowVector();
     fOutputList->Add(fZDCFlowVect[c]);
   }
-  
+
   fHistList = new TList();
   fHistList->SetOwner(kTRUE);
-  
+
   for(Int_t k=0; k<4; k++) {
     fZDCQHist[k] = new TProfile();
     fHistList->Add(fZDCQHist[k]);
@@ -261,18 +289,79 @@ void AliAnalysisTaskZDCEP::UserCreateOutputObjects ()
       fHistList->Add(fTowerGainEq[c][i]);
     }
   }
-  
+
   Double_t DummyEZDCBins[10][11] = {{-3.000000e+02, -4.008000e+01, -2.658000e+01, -1.686000e+01, -8.520000e+00, -7.200000e-01, 7.080000e+00, 1.542000e+01, 2.520000e+01, 3.888000e+01, 3.000000e+02},{-3.000000e+02, -3.690000e+01, -2.436000e+01, -1.530000e+01, -7.560000e+00, -3.000000e-01, 6.960000e+00, 1.476000e+01, 2.388000e+01, 3.666000e+01, 3.000000e+02},{-3.000000e+02, -3.522000e+01, -2.316000e+01, -1.446000e+01, -7.020000e+00, -6.000000e-02, 6.900000e+00, 1.434000e+01, 2.310000e+01, 3.534000e+01, 3.000000e+02},{-3.000000e+02, -3.528000e+01, -2.322000e+01, -1.452000e+01, -7.080000e+00, -1.200000e-01, 6.840000e+00, 1.434000e+01, 2.310000e+01, 3.528000e+01, 3.000000e+02},{-3.000000e+02, -3.666000e+01, -2.412000e+01, -1.506000e+01, -7.320000e+00, -6.000000e-02, 7.200000e+00, 1.500000e+01, 2.412000e+01, 3.684000e+01, 3.000000e+02},{-3.000000e+02, -3.936000e+01, -2.580000e+01, -1.602000e+01, -7.680000e+00, 1.200000e-01, 7.920000e+00, 1.632000e+01, 2.616000e+01, 3.990000e+01, 3.000000e+02},{-3.000000e+02, -4.416000e+01, -2.880000e+01, -1.776000e+01, -8.280000e+00, 5.400000e-01, 9.420000e+00, 1.890000e+01, 3.000000e+01, 4.554000e+01, 3.000000e+02},{-3.000000e+02, -5.262000e+01, -3.384000e+01, -2.028000e+01, -8.700000e+00, 2.100000e+00, 1.296000e+01, 2.454000e+01, 3.816000e+01, 5.712000e+01, 3.000000e+02},{-3.000000e+02, -6.588000e+01, -4.122000e+01, -2.340000e+01, -8.160000e+00, 6.060000e+00, 2.028000e+01, 3.552000e+01, 5.340000e+01, 7.830000e+01, 3.000000e+02},{-3.000000e+02, -8.844000e+01, -5.556000e+01, -3.186000e+01, -1.158000e+01, 7.380000e+00, 2.634000e+01, 4.662000e+01, 7.038000e+01, 1.034400e+02, 3.000000e+02}};
   for (Int_t i=0; i<10; i++) {
     fCRCZDCQVecDummyEZDCBins[i] = new TH1D(Form("fCRCZDCQVecDummyEZDCBins[%d]",i),Form("fCRCZDCQVecDummyEZDCBins[%d]",i),10,DummyEZDCBins[i]);
     fHistList->Add(fCRCZDCQVecDummyEZDCBins[i]);
   }
-  
+
   fAnalysisUtils = new AliAnalysisUtils;
   fAnalysisUtils->SetUseMVPlpSelection(kTRUE);
   fAnalysisUtils->SetUseOutOfBunchPileUp(kTRUE);
-  
+
   fFlowEvent = new AliFlowEvent(1);
+
+  fQAList = new TList();
+  fQAList->SetOwner(kTRUE);
+
+  TString WhichQ[] = {"QCx","QCy","QAx","QAy"};
+  TString WhichCor[] = {"QAxQCx","QAyQCy","QAxQCy","QCxQAy"};
+  TString WhichMP[] = {"+","-"};
+  Double_t xmin=0.,xmax=0.,ymin=0.,ymax=0.,zmin=0.,zmax=0.;
+  // if(fDataSet==k2010) {
+  //   xmin=-0.032;
+  //   xmax=0.016;
+  //   ymin=0.146;
+  //   ymax=0.21;
+  //   zmin=-10.;
+  //   zmax=10.;
+  // }
+  // if(fDataSet==k2011) {
+  //   xmin=0.045;
+  //   xmax=0.08;
+  //   ymin=0.258;
+  //   ymax=0.292;
+  //   zmin=-10.;
+  //   zmax=10.;
+  // }
+  // if(fDataSet==k2015 || fDataSet==k2015v6 || fDataSet==k2015pidfix) {
+    xmin = -8.5e-3;
+    xmax = 8.5e-3;
+    ymin = -7.8e-3;
+    ymax = 7.8e-3;
+    zmin = -10.;
+    zmax = 10.;
+  // }
+
+  fEventCounter = new TH1D("fEventCounter","fEventCounter",5,0.,5.);
+  fEventCounter->GetXaxis()->SetBinLabel(1,"total");
+  fEventCounter->GetXaxis()->SetBinLabel(2,"passed");
+  fEventCounter->GetXaxis()->SetBinLabel(3,"den<0");
+  fEventCounter->GetXaxis()->SetBinLabel(4,"vtx out-of-boundaries");
+  fEventCounter->GetXaxis()->SetBinLabel(5,"norm=0");
+  fQAList->Add(fEventCounter);
+
+  for(Int_t c=0; c<4; c++) {
+    for(Int_t i=0; i<2; i++) {
+      fQVecCen[c][i] =  new TProfile(Form("fQVecCen[%d][%d]",c,i),Form("ZDC <%s> mag.pol. %s;centrality;<%s>",WhichQ[c].Data(),WhichMP[i].Data(),WhichQ[c].Data()),100,0.,100.);
+      fQAList->Add(fQVecCen[c][i]);
+      fQVecVtx[c][i] =  new TProfile3D(Form("fQVecVtx[%d][%d]",c,i),Form("ZDC <%s> mag.pol. %s;x_{vtx} (cm);y_{vtx} (cm);z_{vtx} (cm)",WhichQ[c].Data(),WhichMP[i].Data()),10,xmin,xmax,10,ymin,ymax,10,zmin,zmax);
+      fQAList->Add(fQVecVtx[c][i]);
+      fQVecCorCen[c][i] = new TProfile(Form("fQVecCorCen[%d][%d]",c,i),Form("ZDC <%s> mag.pol. %s;centrality;<%s>",WhichCor[c].Data(),WhichMP[i].Data(),WhichCor[c].Data()),100,0.,100.);
+      fQAList->Add(fQVecCorCen[c][i]);
+      fQVecDeltaC[c][i] = new TProfile(Form("fQVecDeltaC[%d][%d]",c,i),Form("ZDC <%s> mag.pol. %s;#Delta centroids (cm);<%s>",WhichQ[c].Data(),WhichMP[i].Data(),WhichQ[c].Data()),100,0.,2.5);
+      fQAList->Add(fQVecDeltaC[c][i]);
+      fQVecCorDeltaC[c][i] = new TProfile(Form("fQVecCorDeltaC[%d][%d]",c,i),Form("ZDC <%s> mag.pol. %s;#Delta centroids (cm);<%s>",WhichCor[c].Data(),WhichMP[i].Data(),WhichCor[c].Data()),100,0.,2.5);
+      fQAList->Add(fQVecCorDeltaC[c][i]);
+    }
+  }
+
+  // for(Int_t r=0; r<fnRun; r++) {
+  //   fQVecRbR[r] = new TProfile2D(Form("QVecRbR[%d]",fRunList[r]),Form("ZDC <Q_{i}> run %d:centrality (%):Q_{i}",fRunList[r]),20,0.,100.,4,0.,4.);
+  // }
+
+  PostData(2, fQAList);
 }
 
 //=====================================================================
@@ -297,7 +386,7 @@ void AliAnalysisTaskZDCEP::UserExec(Option_t *)
   }
   if(RunBin==-1) return;
   Int_t fCenBin = GetCenBin(Centrality);
-  
+
   if(RunNum!=fCachedRunNum) {
     fbFlagIsPosMagField = kFALSE;
     Int_t dRun15hPos[] = {246390, 246391, 246392, 246994, 246991, 246989, 246984, 246982, 246980, 246948, 246945, 246928, 246851, 246847, 246846, 246845, 246844, 246810, 246809, 246808, 246807, 246805, 246804, 246766, 246765, 246763, 246760, 246759, 246758, 246757, 246751, 246750, 246495, 246493, 246488, 246487, 246434, 246431, 246428, 246424};
@@ -305,28 +394,31 @@ void AliAnalysisTaskZDCEP::UserExec(Option_t *)
       if(RunNum==dRun15hPos[i]) fbFlagIsPosMagField = kTRUE;
     }
   }
-  
+
+  Bool_t IsGoodEvent = kTRUE;
+  fEventCounter->Fill(0.5);
+
   // get primary vertex position
   Double_t fVtxPos[3]={0.,0.,0.};
   fVtxPos[0] = ((AliAODVertex*)aod->GetPrimaryVertex())->GetX();
   fVtxPos[1] = ((AliAODVertex*)aod->GetPrimaryVertex())->GetY();
   fVtxPos[2] = ((AliAODVertex*)aod->GetPrimaryVertex())->GetZ();
   Double_t fVtxPosCor[3] = {fVtxPos[0]-fAvVtxPosX[RunBin],fVtxPos[1]-fAvVtxPosY[RunBin],fVtxPos[2]-fAvVtxPosZ[RunBin]};
-  
+
   // zdc selection
   AliAODZDC *aodZDC = aod->GetZDCData();
-  
+
   const Double_t * towZNCraw = aodZDC->GetZNCTowerEnergy();
   const Double_t * towZNAraw = aodZDC->GetZNATowerEnergy();
-  
+
   // Get centroid from ZDCs *******************************************************
-  
+
   Double_t Enucl = (RunNum < 209122 ? 1380. : 2511.);
   Double_t xyZNC[2]={0.,0.}, xyZNA[2]={0.,0.};
   Double_t towZNC[5]={0.}, towZNA[5]={0.};
-  
+
   Double_t ZNCcalib=1., ZNAcalib=1.;
-  
+
   // equalize gain of all towers
   if(RunNum!=fCachedRunNum) {
     for(Int_t i=0; i<5; i++) {
@@ -338,7 +430,7 @@ void AliAnalysisTaskZDCEP::UserExec(Option_t *)
     if(fTowerGainEq[0][i]) towZNC[i] = towZNCraw[i]*fTowerGainEq[0][i]->GetBinContent(fTowerGainEq[0][i]->FindBin(Centrality));
     if(fTowerGainEq[1][i]) towZNA[i] = towZNAraw[i]*fTowerGainEq[1][i]->GetBinContent(fTowerGainEq[1][i]->FindBin(Centrality));
   }
-  
+
   if(RunNum>=245829) towZNA[2] = 0.;
   Double_t zncEnergy=0., znaEnergy=0.;
   for(Int_t i=0; i<5; i++){
@@ -348,24 +440,23 @@ void AliAnalysisTaskZDCEP::UserExec(Option_t *)
   if(RunNum>=245829) znaEnergy *= 8./7.;
   Double_t fZNCen = towZNC[0]/Enucl;
   Double_t fZNAen = towZNA[0]/Enucl;
-  
+
   const Double_t x[4] = {-1.75, 1.75, -1.75, 1.75};
   const Double_t y[4] = {-1.75, -1.75, 1.75, 1.75};
   Double_t numXZNC=0., numYZNC=0., denZNC=0., cZNC, wZNC, EZNC, SumEZNC=0.;
   Double_t numXZNA=0., numYZNA=0., denZNA=0., cZNA, wZNA, EZNA, SumEZNA=0., BadChOr;
-  Bool_t fAllChONZNC=kTRUE, fAllChONZNA=kTRUE;
-  
+
   for(Int_t i=0; i<4; i++){
     // get energy
     EZNC = towZNC[i+1];
     SumEZNC += EZNC;
-    
+
     // build centroid
     wZNC = TMath::Power(EZNC, fZDCGainAlpha);
     numXZNC += x[i]*wZNC;
     numYZNC += y[i]*wZNC;
     denZNC += wZNC;
-    
+
     // get energy
     if(i==1) {
       EZNA = towZNA[0]-towZNA[1]-towZNA[3]-towZNA[4];
@@ -373,7 +464,7 @@ void AliAnalysisTaskZDCEP::UserExec(Option_t *)
       EZNA = towZNA[i+1];
     }
     SumEZNA += EZNA;
-    
+
     // build centroid
     wZNA = TMath::Power(EZNA, fZDCGainAlpha);
     numXZNA += x[i]*wZNA;
@@ -389,6 +480,7 @@ void AliAnalysisTaskZDCEP::UserExec(Option_t *)
   }
   else{
     xyZNC[0] = xyZNC[1] = 0.;
+    IsGoodEvent = kFALSE;
   }
   if(denZNA>0.){
     Double_t nSpecnA = SumEZNA/Enucl;
@@ -399,19 +491,18 @@ void AliAnalysisTaskZDCEP::UserExec(Option_t *)
   }
   else{
     xyZNA[0] = xyZNA[1] = 0.;
+    IsGoodEvent = kFALSE;
   }
-  
+
+  if(denZNC<=0. || denZNA<=0.) fEventCounter->Fill(2.5);
+
   fZDCFlowVect[0]->Set(xyZNC[0],xyZNC[1]);
   fZDCFlowVect[1]->Set(xyZNA[0],xyZNA[1]);
   fZDCFlowVect[0]->SetMult(denZNC);
   fZDCFlowVect[1]->SetMult(denZNA);
-  
+
   // RE-CENTER ZDC Q-VECTORS ***************************************************
-  
-  Int_t qb[4] = {0};
-  if(fbFlagIsPosMagField) { qb[0]=0; qb[1]=1; qb[2]=4; qb[3]=5; }
-  else                    { qb[0]=2; qb[1]=3; qb[2]=6; qb[3]=7; }
-  
+
   // get re-centered QM*
 //  Double_t QMCrec = denZNC;
 //  Double_t QMArec = denZNA;
@@ -421,9 +512,7 @@ void AliAnalysisTaskZDCEP::UserExec(Option_t *)
 //    QMCrec -= fAvEZDCCRbRPro->GetBinContent(runbin,cenbin);
 //    QMArec -= fAvEZDCARbRPro->GetBinContent(runbin,cenbin);
 //  }
-  
-  Bool_t IsGoodEvent = kTRUE;
-  
+
   if(fZDCCalibList) {
     if(RunNum!=fCachedRunNum) {
       // get histos of run
@@ -431,19 +520,19 @@ void AliAnalysisTaskZDCEP::UserExec(Option_t *)
       fZDCQHist[1] = (TProfile*)(fZDCCalibList->FindObject(Form("Run %d",RunNum))->FindObject(Form("fCRCZDCQVecC[%d][%d]",RunNum,1)));
       fZDCQHist[2] = (TProfile*)(fZDCCalibList->FindObject(Form("Run %d",RunNum))->FindObject(Form("fCRCZDCQVecA[%d][%d]",RunNum,0)));
       fZDCQHist[3] = (TProfile*)(fZDCCalibList->FindObject(Form("Run %d",RunNum))->FindObject(Form("fCRCZDCQVecA[%d][%d]",RunNum,1)));
-      
+
       for(Int_t k=0; k<4; k++) {
         fZDCVtxHist[k] = (TProfile3D*)(fZDCCalibList->FindObject(Form("Run %d",RunNum))->FindObject(Form("fCRCZDCQVecVtxPos540[%d][%d]",RunNum,k)));
-        
+
         fZDCEcomTotHist[k] = (TProfile2D*)(fZDCCalibList->FindObject(Form("fCRCZDCQVecEComTot[%d]",k)));
       }
-      
+
       for(Int_t c=0; c<10; c++) {
         for(Int_t k=0; k<4; k++) {
           fZDCVtxCenHist[c][k] = (TProfile3D*)(fZDCCalibList->FindObject(Form("fCRCZDCQVecVtxPosCen[%d][%d]",c,k)));
         }
       }
-      
+
       for(Int_t k=0; k<4; k++) {
         fZDCVtxFitHist[k] = (TH3D*)fZDCCalibList->FindObject(Form("TH3SlopeRunCenVtx[%d]",k));
         if(fZDCVtxFitHist[k]) {
@@ -456,13 +545,13 @@ void AliAnalysisTaskZDCEP::UserExec(Option_t *)
           }
         }
       }
-      
+
       for(Int_t c=0; c<10; c++) {
         for(Int_t k=0; k<8; k++) {
           fZDCVtxCenHistMagPol[c][k] = (TProfile3D*)(fZDCCalibList->FindObject(Form("fZDCVtxCenHistMagPol[%d][%d]",c,k)));
         }
       }
-      
+
 //      for(Int_t i=0; i<10; i++) {
 //        for(Int_t z=0; z<10; z++) {
 //          for(Int_t k=0; k<4; k++) {
@@ -470,9 +559,9 @@ void AliAnalysisTaskZDCEP::UserExec(Option_t *)
 //          }
 //        }
 //      }
-      
+
     }
-    
+
     // ZDCN-C
     Double_t QCRe = fZDCFlowVect[0]->X();
     Double_t QCIm = fZDCFlowVect[0]->Y();
@@ -481,37 +570,37 @@ void AliAnalysisTaskZDCEP::UserExec(Option_t *)
     Double_t QARe = fZDCFlowVect[1]->X();
     Double_t QAIm = fZDCFlowVect[1]->Y();
     Double_t QMA  = fZDCFlowVect[1]->GetMult();
-    
+
     Double_t QCReR=QCRe, QCImR=QCIm, QAReR=QARe, QAImR=QAIm;
-    
+
     // STEP #1: re-center vs centrality (1%) vs run number
-    
+
     if (fZDCQHist[0]) {
       Double_t AvQCRe = fZDCQHist[0]->GetBinContent(fZDCQHist[0]->FindBin(Centrality));
       Double_t SDQCRe = fZDCQHist[0]->GetBinError(fZDCQHist[0]->FindBin(Centrality));
       Double_t AvQCIm = fZDCQHist[1]->GetBinContent(fZDCQHist[1]->FindBin(Centrality));
       Double_t SDQCIm = fZDCQHist[1]->GetBinError(fZDCQHist[1]->FindBin(Centrality));
-      
+
       Double_t AvQARe = fZDCQHist[2]->GetBinContent(fZDCQHist[2]->FindBin(Centrality));
       Double_t SDQARe = fZDCQHist[2]->GetBinError(fZDCQHist[2]->FindBin(Centrality));
       Double_t AvQAIm = fZDCQHist[3]->GetBinContent(fZDCQHist[3]->FindBin(Centrality));
       Double_t SDQAIm = fZDCQHist[3]->GetBinError(fZDCQHist[3]->FindBin(Centrality));
-      
+
       if(AvQCRe && AvQCIm && QMC>0. && sqrt(QCRe*QCRe+QCIm*QCIm)>1.E-6) {
         QCReR = QCRe-AvQCRe;
         QCImR = QCIm-AvQCIm;
         fZDCFlowVect[0]->Set(QCReR,QCImR);
       }
-      
+
       if(AvQARe && AvQAIm && QMA>0. && sqrt(QARe*QARe+QAIm*QAIm)>1.E-6) {
         QAReR = QARe-AvQARe;
         QAImR = QAIm-AvQAIm;
         fZDCFlowVect[1]->Set(QAReR,QAImR);
       }
     }
-    
+
     // STEP #2: re-center vs primary vtx vs centrality (10%)
-    
+
     if (fZDCVtxCenHist[fCenBin][0]) {
       Bool_t pass = kTRUE;
       if(fVtxPosCor[0] < fZDCVtxCenHist[fCenBin][0]->GetXaxis()->GetXmin() || fVtxPosCor[0] > fZDCVtxCenHist[fCenBin][0]->GetXaxis()->GetXmax()) pass = kFALSE;
@@ -519,6 +608,7 @@ void AliAnalysisTaskZDCEP::UserExec(Option_t *)
       if(fVtxPosCor[2] < fZDCVtxCenHist[fCenBin][0]->GetZaxis()->GetXmin() || fVtxPosCor[2] > fZDCVtxCenHist[fCenBin][0]->GetZaxis()->GetXmax()) pass = kFALSE;
       if(!pass) {
         IsGoodEvent = kFALSE;
+        fEventCounter->Fill(3.5);
       } else {
         QCReR -= fZDCVtxCenHist[fCenBin][0]->GetBinContent(fZDCVtxCenHist[fCenBin][0]->FindBin(fVtxPosCor[0],fVtxPosCor[1],fVtxPosCor[2]));
         QCImR -= fZDCVtxCenHist[fCenBin][1]->GetBinContent(fZDCVtxCenHist[fCenBin][1]->FindBin(fVtxPosCor[0],fVtxPosCor[1],fVtxPosCor[2]));
@@ -528,9 +618,9 @@ void AliAnalysisTaskZDCEP::UserExec(Option_t *)
         fZDCFlowVect[1]->Set(QAReR,QAImR);
       }
     }
-    
+
     // STEP #3: re-center vs primary vtx vs run number
-    
+
     if (fZDCVtxHist[0]) {
       QCReR -= fZDCVtxHist[0]->GetBinContent(fZDCVtxHist[0]->FindBin(fVtxPosCor[0],fVtxPosCor[1],fVtxPosCor[2]));
       QCImR -= fZDCVtxHist[1]->GetBinContent(fZDCVtxHist[1]->FindBin(fVtxPosCor[0],fVtxPosCor[1],fVtxPosCor[2]));
@@ -539,9 +629,9 @@ void AliAnalysisTaskZDCEP::UserExec(Option_t *)
       QAImR -= fZDCVtxHist[3]->GetBinContent(fZDCVtxHist[3]->FindBin(fVtxPosCor[0],fVtxPosCor[1],fVtxPosCor[2]));
       fZDCFlowVect[1]->Set(QAReR,QAImR);
     }
-    
+
     // STEP #4: re-center vs centrality vs energy in the common tower
-    
+
     if(fZDCEcomTotHist[0]) {
       QCReR -= fZDCEcomTotHist[0]->GetBinContent(fZDCEcomTotHist[0]->FindBin(Centrality,fZNCen));
       QCImR -= fZDCEcomTotHist[1]->GetBinContent(fZDCEcomTotHist[1]->FindBin(Centrality,fZNCen));
@@ -550,9 +640,9 @@ void AliAnalysisTaskZDCEP::UserExec(Option_t *)
       QAImR -= fZDCEcomTotHist[3]->GetBinContent(fZDCEcomTotHist[3]->FindBin(Centrality,fZNAen));
       fZDCFlowVect[1]->Set(QAReR,QAImR);
     }
-    
+
     // STEP #5: re-center vs vtx vs cen vs run number (through fits)
-    
+
     if(fZDCVtxFitHist[0]) {
       for (Int_t i=0; i<3; i++) {
         QCReR -= fVtxPosCor[i]*fZDCVtxFitCenProjHist[0][i]->Interpolate(Centrality);
@@ -563,9 +653,9 @@ void AliAnalysisTaskZDCEP::UserExec(Option_t *)
       fZDCFlowVect[0]->Set(QCReR,QCImR);
       fZDCFlowVect[1]->Set(QAReR,QAImR);
     }
-    
+
     // second iteration (2D)
-    
+
     if (fZDCVtxCenHistMagPol[fCenBin][0]) {
       if(fbFlagIsPosMagField) {
         QCReR -= fZDCVtxCenHistMagPol[fCenBin][0]->GetBinContent(fZDCVtxCenHistMagPol[fCenBin][0]->FindBin(fVtxPosCor[0],fVtxPosCor[1],fVtxPosCor[2]));
@@ -581,57 +671,101 @@ void AliAnalysisTaskZDCEP::UserExec(Option_t *)
       fZDCFlowVect[0]->Set(QCReR,QCImR);
       fZDCFlowVect[1]->Set(QAReR,QAImR);
     }
-    
+
     // STEP #6: re-center vs centrality vs total energy vs vtx
-    
-//    Int_t EZDCCBin = fCRCZDCQVecDummyEZDCBins[fCenBin]->GetXaxis()->FindBin(QMCrec)-1;
-//    Int_t EZDCABin = fCRCZDCQVecDummyEZDCBins[fCenBin]->GetXaxis()->FindBin(QMArec)-1;
-//    
-//    if(fZDCQVecVtxCenEZDC3D[0][0][0]) {
-//      printf("doing step 6 \n");
-//      Bool_t pass2=kTRUE;
-//      // exclude events with vtx outside of range
-//      if(fVtxPosCor[0] < fZDCQVecVtxCenEZDC3D[0][0][0]->GetXaxis()->GetXmin() || fVtxPosCor[0] > fZDCQVecVtxCenEZDC3D[0][0][0]->GetXaxis()->GetXmax()) pass2 = kFALSE;
-//      if(fVtxPosCor[1] < fZDCQVecVtxCenEZDC3D[0][0][0]->GetYaxis()->GetXmin() || fVtxPosCor[1] > fZDCQVecVtxCenEZDC3D[0][0][0]->GetYaxis()->GetXmax()) pass2 = kFALSE;
-//      if(fVtxPosCor[2] < fZDCQVecVtxCenEZDC3D[0][0][0]->GetZaxis()->GetXmin() || fVtxPosCor[2] > fZDCQVecVtxCenEZDC3D[0][0][0]->GetZaxis()->GetXmax()) pass2 = kFALSE;
-//      // exclude events with very low or very high total energy
-//      if(fabs(QMCrec)>100. || fabs(QMArec)>100.) pass2 = kFALSE;
-//      // get EZDC bin
-//      Int_t EZDCCBin = fCRCZDCQVecDummyEZDCBins[fCenBin]->GetXaxis()->FindBin(QMCrec)-1;
-//      Int_t EZDCABin = fCRCZDCQVecDummyEZDCBins[fCenBin]->GetXaxis()->FindBin(QMArec)-1;
-//      if(EZDCCBin<0) EZDCCBin=0;
-//      if(EZDCCBin>9) EZDCCBin=9;
-//      if(EZDCABin<0) EZDCABin=0;
-//      if(EZDCABin>9) EZDCABin=9;
-//      if(pass2) {
-//        // check if possible to interpolate
-//        Bool_t bInterp = kTRUE;
-//        Int_t bx = fZDCQVecVtxCenEZDC3D[0][0][0]->GetXaxis()->FindBin(fVtxPosCor[0]);
-//        Int_t by = fZDCQVecVtxCenEZDC3D[0][0][0]->GetYaxis()->FindBin(fVtxPosCor[1]);
-//        Int_t bz = fZDCQVecVtxCenEZDC3D[0][0][0]->GetZaxis()->FindBin(fVtxPosCor[2]);
-//        if(bx==1 || bx==fZDCQVecVtxCenEZDC3D[0][0][0]->GetXaxis()->GetNbins()) bInterp = kFALSE;
-//        if(by==1 || by==fZDCQVecVtxCenEZDC3D[0][0][0]->GetYaxis()->GetNbins()) bInterp = kFALSE;
-//        if(bz==1 || bz==fZDCQVecVtxCenEZDC3D[0][0][0]->GetZaxis()->GetNbins()) bInterp = kFALSE;
-//        if(bInterp) {
-//          QCReR -= fZDCQVecVtxCenEZDC3D[fCenBin][EZDCCBin][0]->Interpolate(fVtxPosCor[0],fVtxPosCor[1],fVtxPosCor[2]);
-//          QCImR -= fZDCQVecVtxCenEZDC3D[fCenBin][EZDCCBin][1]->Interpolate(fVtxPosCor[0],fVtxPosCor[1],fVtxPosCor[2]);
-//          QAReR -= fZDCQVecVtxCenEZDC3D[fCenBin][EZDCABin][2]->Interpolate(fVtxPosCor[0],fVtxPosCor[1],fVtxPosCor[2]);
-//          QAImR -= fZDCQVecVtxCenEZDC3D[fCenBin][EZDCABin][3]->Interpolate(fVtxPosCor[0],fVtxPosCor[1],fVtxPosCor[2]);
-//        } else {
-//          QCReR -= fZDCQVecVtxCenEZDC3D[fCenBin][EZDCCBin][0]->GetBinContent(bx,by,bz);
-//          QCImR -= fZDCQVecVtxCenEZDC3D[fCenBin][EZDCCBin][1]->GetBinContent(bx,by,bz);
-//          QAReR -= fZDCQVecVtxCenEZDC3D[fCenBin][EZDCABin][2]->GetBinContent(bx,by,bz);
-//          QAImR -= fZDCQVecVtxCenEZDC3D[fCenBin][EZDCABin][3]->GetBinContent(bx,by,bz);
-//        }
-//      } else {
-//        IsGoodEvent = kFALSE;
-//      }
-//    }
-    
+
+    //    Int_t EZDCCBin = fCRCZDCQVecDummyEZDCBins[fCenBin]->GetXaxis()->FindBin(QMCrec)-1;
+    //    Int_t EZDCABin = fCRCZDCQVecDummyEZDCBins[fCenBin]->GetXaxis()->FindBin(QMArec)-1;
+    //
+    //    if(fZDCQVecVtxCenEZDC3D[0][0][0]) {
+    //      printf("doing step 6 \n");
+    //      Bool_t pass2=kTRUE;
+    //      // exclude events with vtx outside of range
+    //      if(fVtxPosCor[0] < fZDCQVecVtxCenEZDC3D[0][0][0]->GetXaxis()->GetXmin() || fVtxPosCor[0] > fZDCQVecVtxCenEZDC3D[0][0][0]->GetXaxis()->GetXmax()) pass2 = kFALSE;
+    //      if(fVtxPosCor[1] < fZDCQVecVtxCenEZDC3D[0][0][0]->GetYaxis()->GetXmin() || fVtxPosCor[1] > fZDCQVecVtxCenEZDC3D[0][0][0]->GetYaxis()->GetXmax()) pass2 = kFALSE;
+    //      if(fVtxPosCor[2] < fZDCQVecVtxCenEZDC3D[0][0][0]->GetZaxis()->GetXmin() || fVtxPosCor[2] > fZDCQVecVtxCenEZDC3D[0][0][0]->GetZaxis()->GetXmax()) pass2 = kFALSE;
+    //      // exclude events with very low or very high total energy
+    //      if(fabs(QMCrec)>100. || fabs(QMArec)>100.) pass2 = kFALSE;
+    //      // get EZDC bin
+    //      Int_t EZDCCBin = fCRCZDCQVecDummyEZDCBins[fCenBin]->GetXaxis()->FindBin(QMCrec)-1;
+    //      Int_t EZDCABin = fCRCZDCQVecDummyEZDCBins[fCenBin]->GetXaxis()->FindBin(QMArec)-1;
+    //      if(EZDCCBin<0) EZDCCBin=0;
+    //      if(EZDCCBin>9) EZDCCBin=9;
+    //      if(EZDCABin<0) EZDCABin=0;
+    //      if(EZDCABin>9) EZDCABin=9;
+    //      if(pass2) {
+    //        // check if possible to interpolate
+    //        Bool_t bInterp = kTRUE;
+    //        Int_t bx = fZDCQVecVtxCenEZDC3D[0][0][0]->GetXaxis()->FindBin(fVtxPosCor[0]);
+    //        Int_t by = fZDCQVecVtxCenEZDC3D[0][0][0]->GetYaxis()->FindBin(fVtxPosCor[1]);
+    //        Int_t bz = fZDCQVecVtxCenEZDC3D[0][0][0]->GetZaxis()->FindBin(fVtxPosCor[2]);
+    //        if(bx==1 || bx==fZDCQVecVtxCenEZDC3D[0][0][0]->GetXaxis()->GetNbins()) bInterp = kFALSE;
+    //        if(by==1 || by==fZDCQVecVtxCenEZDC3D[0][0][0]->GetYaxis()->GetNbins()) bInterp = kFALSE;
+    //        if(bz==1 || bz==fZDCQVecVtxCenEZDC3D[0][0][0]->GetZaxis()->GetNbins()) bInterp = kFALSE;
+    //        if(bInterp) {
+    //          QCReR -= fZDCQVecVtxCenEZDC3D[fCenBin][EZDCCBin][0]->Interpolate(fVtxPosCor[0],fVtxPosCor[1],fVtxPosCor[2]);
+    //          QCImR -= fZDCQVecVtxCenEZDC3D[fCenBin][EZDCCBin][1]->Interpolate(fVtxPosCor[0],fVtxPosCor[1],fVtxPosCor[2]);
+    //          QAReR -= fZDCQVecVtxCenEZDC3D[fCenBin][EZDCABin][2]->Interpolate(fVtxPosCor[0],fVtxPosCor[1],fVtxPosCor[2]);
+    //          QAImR -= fZDCQVecVtxCenEZDC3D[fCenBin][EZDCABin][3]->Interpolate(fVtxPosCor[0],fVtxPosCor[1],fVtxPosCor[2]);
+    //        } else {
+    //          QCReR -= fZDCQVecVtxCenEZDC3D[fCenBin][EZDCCBin][0]->GetBinContent(bx,by,bz);
+    //          QCImR -= fZDCQVecVtxCenEZDC3D[fCenBin][EZDCCBin][1]->GetBinContent(bx,by,bz);
+    //          QAReR -= fZDCQVecVtxCenEZDC3D[fCenBin][EZDCABin][2]->GetBinContent(bx,by,bz);
+    //          QAImR -= fZDCQVecVtxCenEZDC3D[fCenBin][EZDCABin][3]->GetBinContent(bx,by,bz);
+    //        }
+    //      } else {
+    //        IsGoodEvent = kFALSE;
+    //      }
+    //    }
+
+    // after re-centering, cut on Q-vectors near zero *************************
+    if (sqrt(QCReR*QCReR+QCImR*QCImR)<1.E-6 || sqrt(QAReR*QAReR+QAImR*QAImR)<1.E-6) {
+      IsGoodEvent = kFALSE;
+      fEventCounter->Fill(4.5);
+    }
+
+    // store ZDC Qvectors for QA plots ****************************************
+
+    if(IsGoodEvent) {
+      Int_t qb = (fbFlagIsPosMagField?0:1);
+      QAReR = -QAReR;  // this is not a bug: QAReR --> -QAReR
+
+      fQVecCen[0][qb]->Fill(Centrality,QCReR);
+      fQVecCen[1][qb]->Fill(Centrality,QCImR);
+      fQVecCen[2][qb]->Fill(Centrality,QAReR);
+      fQVecCen[3][qb]->Fill(Centrality,QAImR);
+
+      fQVecCorCen[0][qb]->Fill(Centrality,QCReR*QAReR);
+      fQVecCorCen[1][qb]->Fill(Centrality,QCImR*QAImR);
+      fQVecCorCen[2][qb]->Fill(Centrality,QAReR*QCImR);
+      fQVecCorCen[3][qb]->Fill(Centrality,QAImR*QCReR);
+
+      if(Centrality>5. && Centrality<40.) {
+        fQVecVtx[0][qb]->Fill(fVtxPosCor[0],fVtxPosCor[1],fVtxPosCor[2],QCReR);
+        fQVecVtx[1][qb]->Fill(fVtxPosCor[0],fVtxPosCor[1],fVtxPosCor[2],QCImR);
+        fQVecVtx[2][qb]->Fill(fVtxPosCor[0],fVtxPosCor[1],fVtxPosCor[2],QAReR);
+        fQVecVtx[3][qb]->Fill(fVtxPosCor[0],fVtxPosCor[1],fVtxPosCor[2],QAImR);
+
+        Double_t DeltaC = sqrt(pow(QCReR-QAReR,2.)+pow(QCImR-QAImR,2.));
+        fQVecDeltaC[0][qb]->Fill(DeltaC,QCReR);
+        fQVecDeltaC[1][qb]->Fill(DeltaC,QCImR);
+        fQVecDeltaC[2][qb]->Fill(DeltaC,QAReR);
+        fQVecDeltaC[3][qb]->Fill(DeltaC,QAImR);
+        fQVecCorDeltaC[0][qb]->Fill(DeltaC,QCReR*QAReR);
+        fQVecCorDeltaC[1][qb]->Fill(DeltaC,QCImR*QAImR);
+        fQVecCorDeltaC[2][qb]->Fill(DeltaC,QAReR*QCImR);
+        fQVecCorDeltaC[3][qb]->Fill(DeltaC,QAImR*QCReR);
+      }
+
+      fEventCounter->Fill(1.5);
+    }
+
   } else {
     printf("WARNING: no list provided for ZDC Q-vector re-centering ! \n");
   }
-  
+
+  // pass ZDC Qvectors in output **********************************************
+
   Double_t xyZNCfinal[2]={fZDCFlowVect[0]->X(),fZDCFlowVect[0]->Y()};
   Double_t xyZNAfinal[2]={-fZDCFlowVect[1]->X(),fZDCFlowVect[1]->Y()}; // this is not a bug: QAReR --> -QAReR
   if(!IsGoodEvent) {
@@ -639,10 +773,10 @@ void AliAnalysisTaskZDCEP::UserExec(Option_t *)
     xyZNAfinal[0]=0.; xyZNAfinal[1]=0.;
   }
   fFlowEvent->SetZDC2Qsub(xyZNCfinal,denZNC,xyZNAfinal,denZNA);
-  
+
   // save run number
   fCachedRunNum = RunNum;
-  
+
   PostData(1, fFlowEvent);
 }
 
@@ -680,5 +814,3 @@ Int_t AliAnalysisTaskZDCEP::GetCenBin(Double_t Centrality)
 void AliAnalysisTaskZDCEP::Terminate(Option_t */*option*/)
 {
 }
-
-

--- a/PWG/FLOW/Tasks/AliAnalysisTaskZDCEP.h
+++ b/PWG/FLOW/Tasks/AliAnalysisTaskZDCEP.h
@@ -52,17 +52,18 @@ public:
   virtual Int_t GetCenBin(Double_t Centrality);
   //  called  at  end  of  analysis
   virtual void Terminate(Option_t* option);
-  
+
   void SetZDCCalibList(TList* const wlist) {this->fZDCCalibList = wlist;}
   TList* GetZDCCalibList() const {return this->fZDCCalibList;}
   void SetTowerEqList(TList* const wlist) {this->fTowerEqList = wlist;}
   TList* GetTowerEqList() const {return this->fTowerEqList;}
   void GetZDCQVectors(Double_t QAX, Double_t QAY, Double_t QCX, Double_t QCY);
-  
+
 private:
-  
-  TList* fOutputList;             //! output list containing ZDC q-vectors
-  TList* fHistList;               //! output list containing QA histograms
+
+  TList* fOutputList;             //! list containing ZDC q-vectors
+  TList* fHistList;               //! list for calibration histograms
+  TList* fQAList;                 //! output list for QA histograms (slot 2)
   Double_t fZDCGainAlpha;         //
   TList *fZDCCalibList;           // list for ZDC Q-vector re-centering
   TList *fTowerEqList;            // list for ZDC gain equalization
@@ -71,24 +72,33 @@ private:
   TProfile2D* fZDCEcomTotHist[4]; //!
   TH3D *fZDCVtxFitHist[4];        //!
   TH1D *fZDCVtxFitCenProjHist[4][3]; //!
-  TProfile3D *fZDCVtxCenHistMagPol[10][8]; //! 
+  TProfile3D *fZDCVtxCenHistMagPol[10][8]; //!
   TProfile3D* fZDCVtxCenHist[10][4]; //!
   TH1D* fCRCZDCQVecDummyEZDCBins[10]; //!
-  
+
+  // QA histograms
+  TProfile*   fQVecCen[4][2];      //!
+  TProfile3D* fQVecVtx[4][2];      //!
+  TProfile*   fQVecCorCen[4][2];   //!
+  TProfile* fQVecDeltaC[4][2];     //!
+  TProfile* fQVecCorDeltaC[4][2];  //!
+  TH1D* fEventCounter;             //!
+
   TH3D *fZDCQVecVtxCenEZDC3D[10][10][4]; //!
-  TH1D *fTowerGainEq[2][5];       //!
-  
+  TH1D *fTowerGainEq[2][5];              //!
+
   AliFlowVector* fZDCFlowVect[2]; //! ZDC q-vectors
   Int_t fCachedRunNum;            //
   const static Int_t fnRun = 125; //
   Int_t fRunList[fnRun];          // run list
   TList *fQVecListRun[fnRun];     //! run-by-run list
+  TProfile2D* fQVecRbR[fnRun];    //!
   TArrayD fAvVtxPosX;             // average vx position vs run number
   TArrayD fAvVtxPosY;             // average vy position vs run number
   TArrayD fAvVtxPosZ;             // average vz position vs run number
   Bool_t fbFlagIsPosMagField;     //
   AliFlowEvent* fFlowEvent;       // flowevent
-  
+
   AliAnalysisUtils* fAnalysisUtils; //!
   AliMultSelection* fMultSelection; //!
 
@@ -96,7 +106,7 @@ private:
   AliAnalysisTaskZDCEP(const AliAnalysisTaskZDCEP&);
   AliAnalysisTaskZDCEP& operator=(const AliAnalysisTaskZDCEP&);
 
-  ClassDef(AliAnalysisTaskZDCEP,3);
+  ClassDef(AliAnalysisTaskZDCEP,4);
 };
 
 #endif

--- a/PWGCF/FLOW/macros/AddTaskZDCEP.C
+++ b/PWGCF/FLOW/macros/AddTaskZDCEP.C
@@ -8,26 +8,26 @@ AliAnalysisTask * AddTaskZDCEP(TString ZDCCalibFileName,
     printf("No analysis manager to connect to!\n");
     return NULL;
   }
-  
+
   // just to see if all went well, check if the input event handler has been connected
   if (!mgr->GetInputEventHandler()) {
     printf("This task requires an input event handler!\n");
     return NULL;
   }
-  
+
   // get the default name of the output file ("AnalysisResults.root")
   TString file = "AnalysisResults";
-  
+
   // get the common input container from the analysis manager
   AliAnalysisDataContainer *cinput = mgr->GetCommonInputContainer();
-  
+
   // create the flow analysis tasks
   TString AnalysisTaskName = "AnalysisTaskZDCEP";
   AnalysisTaskName += Label;
   AnalysisTaskName += suffix;
   AliAnalysisTaskZDCEP *taskZDC = new AliAnalysisTaskZDCEP(AnalysisTaskName);
   taskZDC->SelectCollisionCandidates(AliVEvent::kINT7);
-  
+
   // add list for ZDC towers gain equalization
   TString ZDCTowerEqFileName = "alien:///alice/cern.ch/user/j/jmargutt/15oHI_EZDCcalib.root";
   TFile* ZDCTowerEqFile = TFile::Open(ZDCTowerEqFileName,"READ");
@@ -45,7 +45,7 @@ AliAnalysisTask * AddTaskZDCEP(TString ZDCCalibFileName,
     exit(1);
   }
   delete ZDCTowerEqFile;
-  
+
   // add list for ZDC Q-vector re-centering
   TFile* ZDCCalibFile = TFile::Open(ZDCCalibFileName,"READ");
   if(!ZDCCalibFile) {
@@ -61,10 +61,10 @@ AliAnalysisTask * AddTaskZDCEP(TString ZDCCalibFileName,
     exit(1);
   }
   delete ZDCCalibFile;
-  
+
   // connect the task to the analysis manager
   mgr->AddTask(taskZDC);
-  
+
   // create a data container for the output of the flow event task
   TString taskZDCEPname = "ZDCEPExchangeContainer";
   AliAnalysisDataContainer *coutputFE = mgr->CreateContainer(taskZDCEPname,
@@ -74,7 +74,16 @@ AliAnalysisTask * AddTaskZDCEP(TString ZDCCalibFileName,
   mgr->ConnectInput(taskZDC,0,cinput);
   // and connect the output to the flow event task
   mgr->ConnectOutput(taskZDC,1,coutputFE);
-  
+
+  // QA OUTPUT CONTAINER
+  TString taskZDCQAname = "AnalysisResults.root:ZDCQA";
+  AliAnalysisDataContainer* coutputZDCQA = mgr->CreateContainer(taskZDCQAname.Data(),
+                                                               TList::Class(),
+                                                               AliAnalysisManager::kOutputContainer,
+                                                               taskZDCQAname);
+  // and connect the qa output container to the flow event.
+  // this container will be written to the output file
+  mgr->ConnectOutput(taskZDC,2,coutputZDCQA);
+
   return taskZDC;
 }
-


### PR DESCRIPTION
add various QA plots in a dedicated output container ("ZDCQA")

tested to be backward compatible