### PR TITLE
Update variable names and trees

### DIFF
--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.cxx
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.cxx
@@ -35,7 +35,8 @@ fEMCALRecoUtils(NULL),
 fEMCALGeo(NULL),
 fPIDResponse(NULL),
 fElectronInformation(ElectronForAlignment()),
-fElectronTree(NULL)
+fElectronTree(NULL),
+fTreeSuffix("")
 {
     
 }
@@ -46,7 +47,8 @@ fEMCALRecoUtils(NULL),
 fEMCALGeo(NULL),
 fPIDResponse(NULL),
 fElectronInformation(ElectronForAlignment()),
-fElectronTree(NULL)
+fElectronTree(NULL),
+fTreeSuffix("")
 {
     SetMakeGeneralHistograms(kTRUE);
     DefineOutput(2, TTree::Class());
@@ -56,7 +58,6 @@ fElectronTree(NULL)
 AliAnalysisTaskEMCALAlig::~AliAnalysisTaskEMCALAlig()
 {
     if (fEMCALRecoUtils) delete fEMCALRecoUtils;
-    if (fElectronTree) delete fElectronTree;
 }
 
 
@@ -66,7 +67,10 @@ void AliAnalysisTaskEMCALAlig::UserCreateOutputObjects()
     
     fPIDResponse = fInputHandler->GetPIDResponse();
     
-    fElectronTree = new TTree("electron_information","electron_information");
+    TString name_tree("electron_information");
+    name_tree += fTreeSuffix;
+    
+    fElectronTree = new TTree(name_tree,name_tree);
     fElectronTree->Branch("electrons", &fElectronInformation);
     PostData(2, fElectronTree);
 }
@@ -81,7 +85,6 @@ Bool_t AliAnalysisTaskEMCALAlig::FillHistograms()
 void AliAnalysisTaskEMCALAlig::DoTrackLoop()
 {
     AliClusterContainer* clusCont = GetClusterContainer(0);
-    //AliVCaloCells *cells = InputEvent()->GetEMCALCells();
     
     if (!clusCont)
     {

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.cxx
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.cxx
@@ -57,7 +57,10 @@ fTreeSuffix("")
 
 AliAnalysisTaskEMCALAlig::~AliAnalysisTaskEMCALAlig()
 {
-    if (fEMCALRecoUtils) delete fEMCALRecoUtils;
+    if (fEMCALRecoUtils)
+        delete fEMCALRecoUtils;
+    if (fElectronTree)
+        delete fElectronTree;
 }
 
 

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.cxx
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.cxx
@@ -13,18 +13,13 @@
  * provided "as is" without express or implied warranty.                  *
  **************************************************************************/
 
-#include <TClonesArray.h>
-#include <TH1F.h>
-#include <TH2F.h>
-#include <TList.h>
 #include <AliVCluster.h>
 #include <AliVParticle.h>
-#include <AliLog.h>
 #include "AliParticleContainer.h"
 #include "AliClusterContainer.h"
 #include "AliPIDResponse.h"
-#include "AliAnalysisTaskEMCALAlig.h"
 #include "AliInputEventHandler.h"
+#include "AliAnalysisTaskEMCALAlig.h"
 #include "AliEMCALRecoUtils.h"
 #include "AliEMCALGeometry.h"
 #include "AliExternalTrackParam.h"
@@ -39,8 +34,8 @@ AliAnalysisTaskEmcal(),
 fEMCALRecoUtils(NULL),
 fEMCALGeo(NULL),
 fPIDResponse(NULL),
-ElectronInformation(ElectronForAlignment()),
-ElectronTree(NULL)
+fElectronInformation(ElectronForAlignment()),
+fElectronTree(NULL)
 {
     
 }
@@ -50,16 +45,18 @@ AliAnalysisTaskEmcal(name, kTRUE),
 fEMCALRecoUtils(NULL),
 fEMCALGeo(NULL),
 fPIDResponse(NULL),
-ElectronInformation(ElectronForAlignment()),
-ElectronTree(NULL)
+fElectronInformation(ElectronForAlignment()),
+fElectronTree(NULL)
 {
     SetMakeGeneralHistograms(kTRUE);
+    DefineOutput(2, TTree::Class());
 }
 
 
 AliAnalysisTaskEMCALAlig::~AliAnalysisTaskEMCALAlig()
 {
-    
+    if (fEMCALRecoUtils) delete fEMCALRecoUtils;
+    if (fElectronTree) delete fElectronTree;
 }
 
 
@@ -69,10 +66,9 @@ void AliAnalysisTaskEMCALAlig::UserCreateOutputObjects()
     
     fPIDResponse = fInputHandler->GetPIDResponse();
     
-    ElectronTree = new TTree("electron_information","electron_information");
-    ElectronTree->Branch("electrons", &ElectronInformation);
-    fOutput->Add(ElectronTree);
-    PostData(1, fOutput);
+    fElectronTree = new TTree("electron_information","electron_information");
+    fElectronTree->Branch("electrons", &fElectronInformation);
+    PostData(2, fElectronTree);
 }
 
 
@@ -110,7 +106,8 @@ void AliAnalysisTaskEMCALAlig::DoTrackLoop()
             const AliVTrack* track = static_cast<const AliVTrack*>(part);
             if (!track)
                 continue;
-            //Electron PID cuts: -1 to 3 sigma TPC
+            
+            //-1.5 to 3.5 sigma TPC to reduce the size of the trees
             Double_t TPCNSgima = fPIDResponse->NumberOfSigmasTPC(track, AliPID::kElectron);
             
             if (TPCNSgima < -1.5 || TPCNSgima > 3.5)
@@ -126,9 +123,9 @@ void AliAnalysisTaskEMCALAlig::DoTrackLoop()
             if (!cluster)
                 continue;
             
-            
             Double_t EoverP = cluster->GetNonLinCorrEnergy()/track->P();
-                //E/p cut
+            
+            //Loose E/p cut to reduce tree
             if (EoverP<0.7 || EoverP>1.3)
                 continue;
             
@@ -141,15 +138,16 @@ void AliAnalysisTaskEMCALAlig::DoTrackLoop()
             
             if(emcphi < 0) emcphi = emcphi+(2*TMath::Pi());
             
-            //Int_t nCells=cluster->GetNCells();
             Int_t iSupMod = -9;
             Int_t ieta = -9;
             Int_t iphi = -9;
             Int_t icell = -9;
             Bool_t Isshared	= kFALSE;
+            
             //Get the SM number
             fEMCALRecoUtils->GetMaxEnergyCell(fEMCALGeo,fCaloCells,cluster,icell,iSupMod,ieta,iphi,Isshared);
             
+            //Default propagation
             TVector3 trackposOnEMCAL;
             trackposOnEMCAL.SetPtEtaPhi(440,track->GetTrackEtaOnEMCal(),track->GetTrackPhiOnEMCal());
                         
@@ -182,44 +180,47 @@ void AliAnalysisTaskEMCALAlig::DoTrackLoop()
             Double_t ydiffRU = trackposOnEMCALRU.Y() - clustpos.Y();
             Double_t zdiffRU = trackposOnEMCALRU.Z() - clustpos.Z();
             
+            //Save to Tree
             
-            ElectronInformation.charge = track->Charge();
-            ElectronInformation.pt = track->Pt();
-            ElectronInformation.pz = track->Pz();
-            ElectronInformation.eta_track = track->Eta();
-            ElectronInformation.phi_track = track->Phi();
+            fElectronInformation.charge = track->Charge();
+            fElectronInformation.pt = track->Pt();
+            fElectronInformation.pz = track->Pz();
+            fElectronInformation.eta_track = track->Eta();
+            fElectronInformation.phi_track = track->Phi();
             
             //cluster properties
-            ElectronInformation.energy = cluster->GetNonLinCorrEnergy();
-            ElectronInformation.M20 = cluster->GetM20();
-            ElectronInformation.M02 = cluster->GetM02();
-            ElectronInformation.eta_cluster = clustpos.Eta();
-            ElectronInformation.phi_cluster = clustpos.Phi();
+            fElectronInformation.energy = cluster->GetNonLinCorrEnergy();
+            fElectronInformation.M20 = cluster->GetM20();
+            fElectronInformation.M02 = cluster->GetM02();
+            fElectronInformation.eta_cluster = clustpos.Eta();
+            fElectronInformation.phi_cluster = clustpos.Phi();
             
             //mathing properties using default matcher
-            ElectronInformation.x_resitual_def = xdiff;
-            ElectronInformation.y_resitual_def = ydiff;
-            ElectronInformation.z_resitual_def = zdiff;
-            ElectronInformation.phi_resitual_def = cluster->GetTrackDx();
-            ElectronInformation.eta_resitual_def = cluster->GetTrackDz();
+            fElectronInformation.x_resitual_def = xdiff;
+            fElectronInformation.y_resitual_def = ydiff;
+            fElectronInformation.z_resitual_def = zdiff;
+            fElectronInformation.phi_resitual_def = cluster->GetTrackDx();
+            fElectronInformation.eta_resitual_def = cluster->GetTrackDz();
                    
             //mathing properties using electron mass
-            ElectronInformation.x_resitual_e = xdiffRU;
-            ElectronInformation.y_resitual_e = ydiffRU;
-            ElectronInformation.z_resitual_e = zdiffRU;
-            ElectronInformation.phi_resitual_e = phidiffRU;
-            ElectronInformation.eta_resitual_e = etadiffRU;
+            fElectronInformation.x_resitual_e = xdiffRU;
+            fElectronInformation.y_resitual_e = ydiffRU;
+            fElectronInformation.z_resitual_e = zdiffRU;
+            fElectronInformation.phi_resitual_e = phidiffRU;
+            fElectronInformation.eta_resitual_e = etadiffRU;
             
-            ElectronInformation.super_module_number = iSupMod;
+            fElectronInformation.super_module_number = iSupMod;
             //PID properties
-            ElectronInformation.TPCNSigmaElectron = TPCNSgima;
+            fElectronInformation.n_sigma_electron_TPC = TPCNSgima;
             
-            ElectronTree->Fill();
+            fElectronTree->Fill();
             
         }
         
         
     }
+    
+    PostData(2, fElectronTree);
 }
 
 void AliAnalysisTaskEMCALAlig::ExecOnce()

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.cxx
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.cxx
@@ -108,9 +108,9 @@ void AliAnalysisTaskEMCALAlig::DoTrackLoop()
                 continue;
             
             //-1.5 to 3.5 sigma TPC to reduce the size of the trees
-            Double_t TPCNSgima = fPIDResponse->NumberOfSigmasTPC(track, AliPID::kElectron);
+            Double_t n_sigma_electron_TPC = fPIDResponse->NumberOfSigmasTPC(track, AliPID::kElectron);
             
-            if (TPCNSgima < -1.5 || TPCNSgima > 3.5)
+            if (n_sigma_electron_TPC < -1.5 || n_sigma_electron_TPC > 3.5)
                 continue;
             
             Int_t iCluster = track->GetEMCALcluster();
@@ -211,7 +211,7 @@ void AliAnalysisTaskEMCALAlig::DoTrackLoop()
             
             fElectronInformation.super_module_number = iSupMod;
             //PID properties
-            fElectronInformation.n_sigma_electron_TPC = TPCNSgima;
+            fElectronInformation.n_sigma_electron_TPC = n_sigma_electron_TPC;
             
             fElectronTree->Fill();
             

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.h
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.h
@@ -57,7 +57,7 @@ public:
     Float_t eta_resitual_e;
     
     //PID properties
-    Float_t TPCNSigmaElectron;
+    Float_t n_sigma_electron_TPC;
     
     ElectronForAlignment()
     {
@@ -91,7 +91,7 @@ public:
         
         super_module_number = 99;
         //PID properties
-        TPCNSigmaElectron = -999;
+        n_sigma_electron_TPC = -999;
     }
     
     void Reset()
@@ -126,12 +126,12 @@ public:
         
         super_module_number = 99;
         //PID properties
-        TPCNSigmaElectron = -999;
+        n_sigma_electron_TPC = -999;
     }
     
     //Default Initializer
     
-    ClassDef(ElectronForAlignment, 1);
+    ClassDef(ElectronForAlignment, 2);
     
 };
 
@@ -157,9 +157,9 @@ protected:
     AliEMCALRecoUtils *fEMCALRecoUtils; //! EMCAL Reco utils used to recalculate the matching
     AliEMCALGeometry *fEMCALGeo; //! EMCAL geometry class
     AliPIDResponse *fPIDResponse; //! PID response task used to perform electron identification
-    ElectronForAlignment ElectronInformation;
     
-    TTree* ElectronTree;
+    ElectronForAlignment fElectronInformation; //! Object to hold the electron information
+    TTree* fElectronTree; //! Electron tree output
 
     
 private:
@@ -167,7 +167,7 @@ private:
     AliAnalysisTaskEMCALAlig &operator=(const AliAnalysisTaskEMCALAlig&); // not implemented
     
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskEMCALAlig, 2);
+  ClassDef(AliAnalysisTaskEMCALAlig, 3);
   /// \endcond
 
 };

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.h
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.h
@@ -143,8 +143,9 @@ public:
     AliAnalysisTaskEMCALAlig(const char *name);
     virtual ~AliAnalysisTaskEMCALAlig();
     
-    void                        UserCreateOutputObjects();
-    void                        Terminate(Option_t *option);
+    void UserCreateOutputObjects();
+    void Terminate(Option_t *option);
+    void SetSuffix(TString suff) { fTreeSuffix = suff;};
     
 protected:
     void                        ExecOnce();
@@ -160,6 +161,7 @@ protected:
     
     ElectronForAlignment fElectronInformation; //! Object to hold the electron information
     TTree* fElectronTree; //! Electron tree output
+    TString fTreeSuffix; // Suffix for tree name
 
     
 private:

--- a/PWGPP/EMCAL/macros/AddTaskEMCALAlig.C
+++ b/PWGPP/EMCAL/macros/AddTaskEMCALAlig.C
@@ -169,6 +169,10 @@ AliAnalysisTaskEMCALAlig* AddTaskEMCALAlig(
     sampleTask->SetHistoBins(600, 0, 300);
     sampleTask->SelectCollisionCandidates(Selection);
     
+    TString SuffixForTree(suffix);
+    SuffixForTree +="_";
+    sampleTask->SetSuffix(SuffixForTree);
+    
     
     //-------------------------------------------------------
     // Final settings, pass to manager and set the containers

--- a/PWGPP/EMCAL/macros/AddTaskEMCALAlig.C
+++ b/PWGPP/EMCAL/macros/AddTaskEMCALAlig.C
@@ -180,11 +180,17 @@ AliAnalysisTaskEMCALAlig* AddTaskEMCALAlig(
     AliAnalysisDataContainer *cinput1  = mgr->GetCommonInputContainer()  ;
     TString contname(name);
     contname += "_histos";
-    AliAnalysisDataContainer *coutput1 = mgr->CreateContainer(contname.Data(),
-                                                              TList::Class(),AliAnalysisManager::kOutputContainer,
-                                                              Form("%s", AliAnalysisManager::GetCommonFileName()));
+    
+    AliAnalysisDataContainer *coutput1 = mgr->CreateContainer(contname.Data(),TList::Class(),AliAnalysisManager::kOutputContainer,AliAnalysisManager::GetCommonFileName());
+    TString contnameTree(name);
+    contnameTree += "_tree";
+    
+    AliAnalysisDataContainer *coutput2 = mgr->CreateContainer(contnameTree.Data(),TTree::Class(),AliAnalysisManager::kOutputContainer,AliAnalysisManager::GetCommonFileName());
+    
     mgr->ConnectInput  (sampleTask, 0,  cinput1 );
     mgr->ConnectOutput (sampleTask, 1, coutput1 );
+    mgr->ConnectOutput (sampleTask, 2, coutput2 );
+
     
     return sampleTask;
 }


### PR DESCRIPTION
I have updated the variable names to match the style as requested in #3338.
I have also changed the trees as a separate container, but they are always saved with the name declared in the task rather than the container name (is this the expected behaviour?). I have changed the names by adding a suffix. If there is a better way to do that, please let me know. But I need that the trees have different names in case I run more than one wagon at the same time.

Thanks!