### PR TITLE
Fix for colliding containers names

### DIFF
--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliDptDptCorrelations.cxx
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliDptDptCorrelations.cxx
@@ -829,14 +829,17 @@ Bool_t AliDptDptCorrelations::StartEvent(Float_t centrality, Float_t vertexz) {
 
   fVertexZ = vertexz;
   fCentrality = centrality;
+
+  if (fVertexZ < fMin_vertexZ || fMax_vertexZ < fVertexZ) {
+    AliInfo(Form("Event with z vertex: %.2f out of internal cuts", fVertexZ));
+    return kFALSE;
+  }
+
   fIxVertexZ = Int_t ((fVertexZ - fMin_vertexZ) / fWidth_vertexZ);
   if (fIxVertexZ < 0 || !(fIxVertexZ < fNBins_vertexZ)) {
     AliError(Form("Event z vertex bin %d out of bounds. Ignoring event.", fIxVertexZ));
     return kFALSE;
   }
-
-  if (fVertexZ < fMin_vertexZ || fMax_vertexZ < fVertexZ)
-    AliError(Form("Wrongly accepted event with z vertex: %.2f", fVertexZ));
 
   if (fUseSimulation) {
     fPositiveTrackCurrentPdf = (TH3F *) fPositiveTrackPdfs->At(fIxVertexZ);

--- a/PWGCF/Correlations/macros/Unfoldedhistos/AddCorrelationsStudiesTask.C
+++ b/PWGCF/Correlations/macros/Unfoldedhistos/AddCorrelationsStudiesTask.C
@@ -30,9 +30,9 @@ AliAnalysisTaskSE *AddCorrelationsStudiesTask(const char *suffix, const char *co
 
     // create containers for input/output
     AliAnalysisDataContainer *coutput1 = mgr->CreateContainer(Form("CorrelationStudies_%s_%s", szContainerPrefix.Data(), suffix), TList::Class(), AliAnalysisManager::kOutputContainer, outfilename);
-    AliAnalysisDataContainer *coutput2 = mgr->CreateContainer(Form("DptDptCorrelations_%s_%s", szContainerPrefix.Data(), suffix), TList::Class(), AliAnalysisManager::kOutputContainer, outfilename);
-    AliAnalysisDataContainer *coutput3 = mgr->CreateContainer(Form("DptDptCorrelationsMCRecOptions_%s_%s", szContainerPrefix.Data(), suffix), TList::Class(), AliAnalysisManager::kOutputContainer, outfilename);
-    AliAnalysisDataContainer *coutput4 = mgr->CreateContainer(Form("DptDptTrueCorrelations_%s_%s", szContainerPrefix.Data(), suffix), TList::Class(), AliAnalysisManager::kOutputContainer, outfilename);
+    AliAnalysisDataContainer *coutput2 = mgr->CreateContainer(Form("CSDptDptCorrelations_%s_%s", szContainerPrefix.Data(), suffix), TList::Class(), AliAnalysisManager::kOutputContainer, outfilename);
+    AliAnalysisDataContainer *coutput3 = mgr->CreateContainer(Form("CSDptDptCorrelationsMCRecOptions_%s_%s", szContainerPrefix.Data(), suffix), TList::Class(), AliAnalysisManager::kOutputContainer, outfilename);
+    AliAnalysisDataContainer *coutput4 = mgr->CreateContainer(Form("CSDptDptTrueCorrelations_%s_%s", szContainerPrefix.Data(), suffix), TList::Class(), AliAnalysisManager::kOutputContainer, outfilename);
 
     // connect input/output
     mgr->ConnectInput(taskCS, 0, cinput);


### PR DESCRIPTION
Container names collide with other tasks container names which could cause troubles in LEGO train scenarios.

Also allow for more stringent z vertex cuts at the data collection level. 