### PR TITLE
Fix handling of neutral jets

### DIFF
--- a/PWG/JETFW/AliJetContainer.cxx
+++ b/PWG/JETFW/AliJetContainer.cxx
@@ -886,7 +886,7 @@ TString AliJetContainer::GenerateJetName(EJetType_t jetType, EJetAlgo_t jetAlgo,
   TString radiusString = TString::Format("R%03.0f", radius*100.0);
 
   TString trackString;
-  if (jetType != kNeutralJet && partCont) {
+  if (partCont) { //Neutral jets on particle level, can have praticle containers
     trackString = "_" + TString(partCont->GetTitle());
   }
 

--- a/PWGJE/EMCALJetTasks/AliEmcalJetTask.cxx
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetTask.cxx
@@ -383,12 +383,12 @@ void AliEmcalJetTask::ExecOnce()
   if(auto partcont = GetParticleContainer(0)) {
     std::cout << "Found particle container with name " << partcont->GetName() << std::endl;
   } else {
-    std::cout << "Not found particle container" << std::endl;
+    std::cout << "Not particle container found for task" << std::endl;
   }
   if(auto clustcont = GetClusterContainer(0)){
     std::cout << "Found cluster container with name " << clustcont->GetName() << std::endl;
   } else {
-    std::cout << "Not found cluster container" << std::endl;
+    std::cout << "Not cluster container found for task" << std::endl;
   }
 
   // add jets to event if not yet there

--- a/PWGJE/EMCALJetTasks/AliEmcalJetTask.cxx
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetTask.cxx
@@ -378,6 +378,18 @@ void AliEmcalJetTask::ExecOnce()
   }
 
   fJetsName = AliJetContainer::GenerateJetName(fJetType, fJetAlgo, fRecombScheme, fRadius, GetParticleContainer(0), GetClusterContainer(0), fJetsTag);
+  std::cout << GetName() << ": Name of the jet container: " << fJetsName << std::endl;
+  std::cout << "Use this name in order to connect jet containers in your task to connect to the collection of jets found by this jet finder" << std::endl;
+  if(auto partcont = GetParticleContainer(0)) {
+    std::cout << "Found particle container with name " << partcont->GetName() << std::endl;
+  } else {
+    std::cout << "Not found particle container" << std::endl;
+  }
+  if(auto clustcont = GetClusterContainer(0)){
+    std::cout << "Found cluster container with name " << clustcont->GetName() << std::endl;
+  } else {
+    std::cout << "Not found cluster container" << std::endl;
+  }
 
   // add jets to event if not yet there
   if (!(InputEvent()->FindListObject(fJetsName))) {

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.h
@@ -110,14 +110,21 @@ public:
     ReclusterizerException() : std::exception() {}
     virtual ~ReclusterizerException() throw() {}
 
-    const char *what() const throw() { return "Error in reclusterizing in fastjet"; }
+    virtual const char *what() const throw() { return "Error in reclusterizing in fastjet"; }
   };
   class SubstructureException : public std::exception {
   public:
     SubstructureException() : std::exception() {}
     virtual ~SubstructureException() throw() {}
 
-    const char *what() const throw() { return "Error in builing substructure observable"; }
+    virtual const char *what() const throw() { return "Error in builing substructure observable"; }
+  };
+  class SoftDropException : public std::exception {
+  public:
+    SoftDropException() : std::exception() {}
+    virtual ~SoftDropException() throw() {}
+
+    virtual const char *what() const throw() { return "No associated softdrop structure found for jet - softdrop algorithm failing"; }
   };
   enum Reclusterizer_t {
     kCAAlgo = 0,

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetTagger.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetTagger.cxx
@@ -15,7 +15,7 @@
 
 #include "AliAnalysisTaskEmcalJetTagger.h"
 
-ClassImp(AliAnalysisTaskEmcalJetTagger)
+ClassImp(AliAnalysisTaskEmcalJetTagger);
 
 //________________________________________________________________________
 AliAnalysisTaskEmcalJetTagger::AliAnalysisTaskEmcalJetTagger() : 
@@ -357,6 +357,9 @@ void AliAnalysisTaskEmcalJetTagger::MatchJetsGeo(Int_t c1, Int_t c2,
   const Int_t nJets2 = GetNJets(c2);
 
   if(nJets1==0 || nJets2==0) return;
+
+  AliDebugStream(1) << "Jets Base (" << GetJetContainer(c1)->GetNJets() << ", accepted " << GetJetContainer(c1)->GetNAcceptedJets() << "), jets tag("
+            << GetJetContainer(c2)->GetNJets() << ", accepted " << GetJetContainer(c2)->GetNAcceptedJets() << "), max distance " << maxDist << std::endl;
 
   if(bReset) {
     ResetTagging(c1);


### PR DESCRIPTION
- Adapt jet container to generate proper name also for particle level neutral jets
- Add verbosity about jet branch names to AliEmcalJetTask
- Add AliDebugs to AliAnalysisTaskEmcalJetTagger
- Handle cases of failure of the Softdrop algorithm due to jets with single constituents only