### PR TITLE
Create a different cell branch with respect std one

### DIFF
--- a/PWG/CaloTrackCorrBase/AliCaloTrackReader.cxx
+++ b/PWG/CaloTrackCorrBase/AliCaloTrackReader.cxx
@@ -102,7 +102,8 @@ fMixedEvent(NULL),           fNMixedEvent(0),                 fVertex(NULL),
 fListMixedTracksEvents(),    fListMixedCaloEvents(),
 fLastMixedTracksEvent(-1),   fLastMixedCaloEvent(-1),
 fWriteOutputDeltaAOD(kFALSE),
-fEMCALClustersListName(""),  fZvtxCut(0.),
+fEMCALClustersListName(""),  fEMCALCellsListName(""),  
+fZvtxCut(0.),
 fAcceptFastCluster(kFALSE),  fRemoveLEDEvents(0),
 //Trigger rejection
 fRemoveBadTriggerEvents(0),  fTriggerPatchClusterMatch(0),
@@ -2420,7 +2421,10 @@ void AliCaloTrackReader::FillInputPHOS()
 //____________________________________________
 void AliCaloTrackReader::FillInputEMCALCells()
 {  
-  fEMCALCells = fInputEvent->GetEMCALCells();
+  if(fEMCALCellsListName.Length() == 0)
+    fEMCALCells = fInputEvent->GetEMCALCells();
+  else
+    fEMCALCells = (AliVCaloCells*) fInputEvent->FindListObject(fEMCALCellsListName);
 }
 
 //___________________________________________

--- a/PWG/CaloTrackCorrBase/AliCaloTrackReader.h
+++ b/PWG/CaloTrackCorrBase/AliCaloTrackReader.h
@@ -292,6 +292,9 @@ public:
   void             SetEMCALClusterListName(TString &name)  { fEMCALClustersListName = name  ; }
   TString          GetEMCALClusterListName()         const { return fEMCALClustersListName  ; }
 
+  void             SetEMCALCellsListName(TString &name)    { fEMCALCellsListName = name     ; }
+  TString          GetEMCALCellsListName()           const { return fEMCALCellsListName     ; }
+  
   // Arrays with clusters/track/cells access method
   
   virtual TObjArray*     GetCTSTracks()              const { return fCTSTracks              ; }
@@ -798,7 +801,7 @@ public:
   
   /// Temporal array with EMCAL CaloClusters.
   TObjArray      * fEMCALClusters ;                //-> 
-  
+
   /// Temporal array with DCAL CaloClusters, not needed in the normal case, use just EMCal array with DCal limits.
   TObjArray      * fDCALClusters ;                 //-> 
   
@@ -883,6 +886,7 @@ public:
   Int_t            fV0Mul[2]    ;                  ///<  Integrated V0 Multiplicity.
 
   TString          fEMCALClustersListName;         ///<  Alternative list of clusters produced elsewhere and not from InputEvent.
+  TString          fEMCALCellsListName;            ///<  Alternative list of cells produced elsewhere and not from InputEvent.
   
   //  Event selection
   
@@ -993,7 +997,7 @@ public:
   AliCaloTrackReader & operator = (const AliCaloTrackReader & r) ; 
   
   /// \cond CLASSIMP
-  ClassDef(AliCaloTrackReader,78) ;
+  ClassDef(AliCaloTrackReader,79) ;
   /// \endcond
 
 } ;

--- a/PWGGA/CaloTrackCorrelations/macros/AddTaskClusterShape.C
+++ b/PWGGA/CaloTrackCorrelations/macros/AddTaskClusterShape.C
@@ -31,7 +31,7 @@
 #include "AliESDtrackCuts.h"
 #include "CreateTrackCutsPWGJE.C"
 #include "CheckActiveEMCalTriggerPerPeriod.C"
-#include "ConfigureEMCALRecoUtils.C"
+//#include "ConfigureEMCALRecoUtils.C"
 
 #endif // CINT
 

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALClusterize.cxx
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALClusterize.cxx
@@ -1044,6 +1044,9 @@ void AliAnalysisTaskEMCALClusterize::ConfigureEMCALRecoUtils
 {
   if ( debug > 0 ) printf("ConfigureEMCALRecoUtils() - **** Start ***\n");
   
+  // Init
+  if(!fRecoUtils) fRecoUtils = new AliEMCALRecoUtils ; 
+  
   // Exotic cells removal
   
   if(bExotic)

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALClusterize.cxx
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALClusterize.cxx
@@ -69,7 +69,9 @@ AliAnalysisTaskEMCALClusterize::AliAnalysisTaskEMCALClusterize(const char *name)
 , fCaloClusterArr(0),     fCaloCells(0)
 , fRecParam(0),           fClusterizer(0)
 , fUnfolder(0),           fJustUnfold(kFALSE) 
-, fOutputAODBranch(0),    fOutputAODBranchName(""),   fOutputAODBranchSet(0)
+, fOutputAODBranch(0),    fOutputAODBranchName("")   
+, fOutputAODCells (0),    fOutputAODCellsName ("")  
+, fOutputAODBranchSet(0)
 , fFillAODFile(kFALSE),   fFillAODHeader(0)
 , fFillAODCaloCells(0),   fRun(-1)
 , fRecoUtils(0),          fConfigName("")
@@ -128,7 +130,9 @@ AliAnalysisTaskEMCALClusterize::AliAnalysisTaskEMCALClusterize()
 , fCaloClusterArr(0),       fCaloCells(0)
 , fRecParam(0),             fClusterizer(0)
 , fUnfolder(0),             fJustUnfold(kFALSE) 
-, fOutputAODBranch(0),      fOutputAODBranchName(""),   fOutputAODBranchSet(0)
+, fOutputAODBranch(0),      fOutputAODBranchName("")
+, fOutputAODCells (0),      fOutputAODCellsName ("")
+, fOutputAODBranchSet(0)
 , fFillAODFile(kFALSE),     fFillAODHeader(0)
 , fFillAODCaloCells(0),     fRun(-1)
 , fRecoUtils(0),            fConfigName("")
@@ -705,10 +709,17 @@ void AliAnalysisTaskEMCALClusterize::CheckAndGetEvent()
   }
   else if( !fOutputAODBranchSet )
   {
-    // Create array and put it in the input event, if output AOD not selected, only once
+    // Create array of clusters/cells and put it in the input event, if output AOD not selected, only once
     InputEvent()->AddObject(fOutputAODBranch);
+    AliInfo(Form("Add AOD clusters branch <%s> to input event",fOutputAODBranchName.Data()));
+    
+    if ( fOutputAODBranchName.Length() > 0 )
+    {
+      InputEvent()->AddObject(fOutputAODCells);
+      AliInfo(Form("Add AOD cells branch <%s> to input event",fOutputAODCellsName.Data()));
+    }
+    
     fOutputAODBranchSet = kTRUE;
-    AliInfo(Form("Add AOD branch <%s> to input event",fOutputAODBranchName.Data()));
   }
 }
 
@@ -1045,7 +1056,7 @@ void AliAnalysisTaskEMCALClusterize::ConfigureEMCALRecoUtils
   if ( debug > 0 ) printf("ConfigureEMCALRecoUtils() - **** Start ***\n");
   
   // Init
-  if(!fRecoUtils) fRecoUtils = new AliEMCALRecoUtils ; 
+  if(!fRecoUtils) fRecoUtils = new AliEMCALRecoUtils ;
   
   // Exotic cells removal
   
@@ -1957,7 +1968,8 @@ void AliAnalysisTaskEMCALClusterize::PrintParam()
   if ( fAccessOCDB ) AliInfo(Form("OCDB path name <%s>", fOCDBpath.Data()));
   if ( fAccessOADB ) AliInfo(Form("OADB path name <%s>", fOADBFilePath.Data()));
   
-  AliInfo(Form("Just Unfold clusters <%d>, new clusters list name <%s>", fJustUnfold, fOutputAODBranchName.Data()));
+  AliInfo(Form("Just Unfold clusters <%d>, new clusters list name <%s>, new cells name <%s>", 
+               fJustUnfold, fOutputAODBranchName.Data(), fOutputAODCellsName.Data()));
   
   if ( fFillAODFile ) AliInfo(Form("Fill new AOD file with: header <%d>, cells <%d>",fFillAODHeader,fFillAODCaloCells));
   
@@ -2451,10 +2463,11 @@ void AliAnalysisTaskEMCALClusterize::SetClustersMCLabelFromOriginalClusters(AliA
 }
 
 //____________________________________________________________
-// Init geometry, create list of output clusters.
+// Init geometry, create list of output clusters and cells.
 //____________________________________________________________
 void AliAnalysisTaskEMCALClusterize::UserCreateOutputObjects()
 {
+  // Clusters
   fOutputAODBranch = new TClonesArray("AliAODCaloCluster", 0);
 
   if(fOutputAODBranchName.Length()==0)
@@ -2473,16 +2486,22 @@ void AliAnalysisTaskEMCALClusterize::UserCreateOutputObjects()
     
     AddAODBranch("TClonesArray", &fOutputAODBranch);
   }
+  
+  // Cells
+  if ( fOutputAODBranchName.Length() > 0 )
+  {
+    fOutputAODCells = new AliAODCaloCells(fOutputAODCellsName,fOutputAODCellsName,AliAODCaloCells::kEMCALCell); 
+  
+    if( fFillAODFile ) AddAODBranch("AliAODCaloCells", &fOutputAODCells);
+  }
 }
 
 //_______________________________________________________________________
-/// Create a new CaloCells container if calibration or some changes were applied.
+/// Update or create CaloCells container if calibration or some changes were applied.
 /// Delete previouly existing content in the container.
 //________________________________________________________________________
 void AliAnalysisTaskEMCALClusterize::UpdateCells()
-{
-  if ( !fUpdateCell ) return;
-  
+{  
   // Update cells only in case re-calibration was done 
   // or bad map applied or additional T-Card cells added.
   if(!fRecoUtils->IsBadChannelsRemovalSwitchedOn() && 
@@ -2494,7 +2513,13 @@ void AliAnalysisTaskEMCALClusterize::UpdateCells()
   
   const Int_t   ncells = fCaloCells->GetNumberOfCells();
   const Int_t   ndigis = fDigitsArr->GetEntries();
-  if ( ncells != ndigis ) 
+  
+  if ( fOutputAODCellsName.Length() > 0 ) 
+  {
+    fOutputAODCells->DeleteContainer();
+    fOutputAODCells->CreateContainer(ndigis);
+  }
+  else if ( ncells != ndigis ) // update case 
   {
     fCaloCells->DeleteContainer();
     fCaloCells->CreateContainer(ndigis);
@@ -2530,10 +2555,12 @@ void AliAnalysisTaskEMCALClusterize::UpdateCells()
     
     if ( cellMcEDepFrac < 0 ) cellMcEDepFrac = 0.;
       
-    fCaloCells->SetCell(idigit, cellNumber, cellAmplitude, cellTime, cellMcLabel, cellMcEDepFrac, highGain);
+    if ( fUpdateCell ) 
+      fCaloCells     ->SetCell(idigit, cellNumber, cellAmplitude, cellTime, cellMcLabel, cellMcEDepFrac, highGain);
+    else
+      fOutputAODCells->SetCell(idigit, cellNumber, cellAmplitude, cellTime, cellMcLabel, cellMcEDepFrac, highGain);
   }
 }
-
 
 //_______________________________________________________
 /// Do clusterization event by event, execute different steps
@@ -2554,7 +2581,7 @@ void AliAnalysisTaskEMCALClusterize::UserExec(Option_t *)
 
   // Remove the contents of AOD branch output list set in the previous event
   fOutputAODBranch->Clear("C");
-
+  
   LoadBranches();
   
   // Check if there is a centrality value, PbPb analysis, and if a centrality bin selection is requested
@@ -2622,7 +2649,9 @@ void AliAnalysisTaskEMCALClusterize::UserExec(Option_t *)
   
   FillCaloClusterInEvent();
   
-  UpdateCells();
+  if ( fUpdateCell || fOutputAODCellsName.Length() > 0 ) 
+    UpdateCells();
+ 
 }
 
 

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALClusterize.h
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALClusterize.h
@@ -95,6 +95,7 @@ class AliAnalysisTaskEMCALClusterize : public AliAnalysisTaskSE {
   // Outout AOD branch methods
     
   void           SetAODBranchName(TString &name)                { fOutputAODBranchName = name  ; }
+  void           SetAODCellsName(TString &name)                 { fOutputAODCellsName  = name  ; }
   void           FillAODFile(Bool_t yesno)                      { fFillAODFile         = yesno ; }
   void           FillAODCaloCells();
   void           FillAODHeader();
@@ -325,7 +326,9 @@ private:
   
   // AOD
   TClonesArray          *fOutputAODBranch;         //!<! AOD Branch with output clusters
-  TString                fOutputAODBranchName;     ///<  New of output AOD branch
+  TString                fOutputAODBranchName;     ///<  New of output clusters AOD branch
+  AliAODCaloCells       *fOutputAODCells;          //!<! AOD Branch with output cells
+  TString                fOutputAODCellsName;      ///<  New of output cells AOD branch
   Bool_t                 fOutputAODBranchSet ;     ///<  Set the AOD clusters branch in the input event once
   Bool_t                 fFillAODFile;             ///<  Fill the output AOD file with the new clusters, 
                                                    ///<  if not they will be only available for the event they were generated
@@ -419,7 +422,7 @@ private:
   AliAnalysisTaskEMCALClusterize& operator=(const AliAnalysisTaskEMCALClusterize&) ;
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskEMCALClusterize, 39) ;
+  ClassDef(AliAnalysisTaskEMCALClusterize, 40) ;
   /// \endcond
 
 };


### PR DESCRIPTION
Allow in the clusterization task the creation of different cell branches  with different corrections like induced TCard correlations, so that the analysis with different corrections can be done in the same train job without disturbing each other.
Add access methods to such branches in the CaloTrack frame.