### PR TITLE
10 cent bins to shrink output

### DIFF
--- a/PWGHF/jetsHF/AliHFJetsContainer.cxx
+++ b/PWGHF/jetsHF/AliHFJetsContainer.cxx
@@ -240,7 +240,7 @@ void AliHFJetsContainer::GetBinning(TString var, Int_t &nBins, Double_t *bins, c
 	Float_t binmin=0., binmax=0.;    
 	if (var.EqualTo("cent")) {
 		axistitle="Multiplicity percentile";
-		nBins = 100; binmin= 0.; binmax= 100.;
+		nBins = 10; binmin= 0.; binmax= 100.;
 	}
   else if (var.EqualTo("jetPt")) {
 		axistitle="p_{T,jet} (GeV/c)";

--- a/PWGHF/jetsHF/macros/AddTaskEmcalJetBtagSV.C
+++ b/PWGHF/jetsHF/macros/AddTaskEmcalJetBtagSV.C
@@ -16,8 +16,8 @@ AliAnalysisTaskEmcalJetBtagSV* AddTaskEmcalJetBtagSV(const char* trkcontname   =
                                                      Bool_t useWeight  =  kFALSE,
                                                      const char* ptHname  =  "",
                                                      const char* ptHpatt  =  "",
-                                                     Int_t gbLogLevel  = 1,
-                                                     Int_t lcDebLevel  = 2,
+                                                     Int_t gbLogLevel  = AliLog::kInfo,  //=2
+                                                     Int_t lcDebLevel  = AliLog::kFatal, //=0
                                                      Double_t tagRadius = 0.4,
                                                      TString cutflname = "",
                                                      Float_t minPt = 0., Float_t maxPt = 100.,
@@ -64,8 +64,8 @@ AliAnalysisTaskEmcalJetBtagSV* AddTaskEmcalJetBtagSV(const char* trkcontname   =
   hfTask->SetCheckMCCrossSection(checkXsec);  
   if (useWeight) hfTask->SetUseWeightOn();
 
-  hfTask->SetGlLogLevel(AliLog::kInfo);
-  hfTask->SetLcDebLevel(0);
+  hfTask->SetGlLogLevel(gbLogLevel);
+  hfTask->SetLcDebLevel(lcDebLevel);
 
   // choose the method to select on the flavor of the jet and, if needed, select the pt-hard bin via the minimum pt-hard
   // also set mc jet and particle container


### PR DESCRIPTION
AliHFJetsContainer: number of mult bins decreased from 100 to 10 to shrink the output size.
AddTaskEmCalJetBtagSV: allow to set verbosity level in function call