### PR TITLE
[WIP] Split jet task into task + kernel

### DIFF
--- a/PWGJE/EMCALJetTasks/AliEmcalJetFinderKernel.cxx
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetFinderKernel.cxx
@@ -1,0 +1,969 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <vector>
+
+#include <TClonesArray.h>
+#include <TObjArray.h>
+#include <TMath.h>
+#include <TRandom3.h>
+
+#include <AliVCluster.h>
+#include <AliVEvent.h>
+#include <AliVParticle.h>
+#include <AliEMCALGeometry.h>
+
+#include <AliAnalysisManager.h>
+#include <AliVEventHandler.h>
+#include <AliMultiInputEventHandler.h>
+
+#include "AliTLorentzVector.h"
+#include "AliEmcalJet.h"
+#include "AliEmcalParticle.h"
+#include "AliFJWrapper.h"
+#include "AliEmcalJetUtility.h"
+#include "AliParticleContainer.h"
+#include "AliClusterContainer.h"
+#include "AliEmcalClusterJetConstituent.h"
+#include "AliEmcalParticleJetConstituent.h"
+
+#include "AliEmcalJetFinderKernel.h"
+
+using std::cout;
+using std::endl;
+using std::cerr;
+
+/// \cond CLASSIMP
+ClassImp(PWGJE::EMCALJetTasks::AliEmcalJetFinderKernel);
+/// \endcond
+
+namespace PWGJE{
+
+namespace EMCALJetTasks {
+
+const Int_t AliEmcalJetFinderKernel::fgkConstIndexShift = 100000;
+
+/**
+ * Default constructor. This constructor is only for ROOT I/O and
+ * not to be used by users.
+ */
+AliEmcalJetFinderKernel::AliEmcalJetFinderKernel() :
+  TNamed(),
+  fGeom(nullptr),
+  fParticleCollArray(),
+  fClusterCollArray(),
+  fJetType(AliJetContainer::kFullJet),
+  fJetAlgo(AliJetContainer::antikt_algorithm),
+  fRecombScheme(AliJetContainer::pt_scheme),
+  fRadius(0.4),
+  fRunNumber(-1),
+  fMinMCLabel(0),
+  fMinJetArea(0.001),
+  fMinJetPt(1.0),
+  fJetPhiMin(-10),
+  fJetPhiMax(+10),
+  fJetEtaMin(-1),
+  fJetEtaMax(+1),
+  fGhostArea(0.005),
+  fTrackEfficiency(1.),
+  fUtilities(0),
+  fTrackEfficiencyOnlyForEmbedding(kFALSE),
+  fLocked(0),
+  fFillConstituents(kTRUE),
+  fIndexMapsPrepared(kFALSE),
+  fIsInit(0),
+  fIsEmcPart(0),
+  fLegacyMode(kFALSE),
+  fFillGhost(kFALSE),
+  fJets(0),
+  fFastJetWrapper("AliEmcalJetFinderKernel","AliEmcalJetFinderKernel"),
+  fClusterContainerIndexMap(),
+  fParticleContainerIndexMap()
+{
+}
+
+/**
+ * Standard named constructor.
+ * @param name Name of the task.
+ */
+AliEmcalJetFinderKernel::AliEmcalJetFinderKernel(const char *name) :
+  TNamed(name,""),
+  fGeom(nullptr),
+  fParticleCollArray(),
+  fClusterCollArray(),
+  fJetType(AliJetContainer::kFullJet),
+  fJetAlgo(AliJetContainer::antikt_algorithm),
+  fRecombScheme(AliJetContainer::pt_scheme),
+  fRadius(0.4),
+  fRunNumber(-1),
+  fMinMCLabel(0),
+  fMinJetArea(0.001),
+  fMinJetPt(1.0),
+  fJetPhiMin(-10),
+  fJetPhiMax(+10),
+  fJetEtaMin(-1),
+  fJetEtaMax(+1),
+  fGhostArea(0.005),
+  fTrackEfficiency(1.),
+  fUtilities(0),
+  fTrackEfficiencyOnlyForEmbedding(kFALSE),
+  fLocked(0),
+  fFillConstituents(kTRUE),
+  fIndexMapsPrepared(kFALSE),
+  fIsInit(0),
+  fIsEmcPart(0),
+  fLegacyMode(kFALSE),
+  fFillGhost(kFALSE),
+  fJets(0),
+  fFastJetWrapper(name,name),
+  fClusterContainerIndexMap(),
+  fParticleContainerIndexMap()
+{
+}
+
+/**
+ * Destructor
+ */
+AliEmcalJetFinderKernel::~AliEmcalJetFinderKernel()
+{
+  if(fUtilities) delete fUtilities;
+  if(fJets) delete fJets;
+}
+
+/**
+ * Add a utility to the utility list. Utilities are instances of classes
+ * derived from AliEmcalJetUtility that implements wrappers to FastJet contribs.
+ */
+AliEmcalJetUtility* AliEmcalJetFinderKernel::AddUtility(AliEmcalJetUtility* utility)
+{
+  if (!fUtilities) fUtilities = new TObjArray();
+  fUtilities->SetOwner();
+  if (fUtilities->FindObject(utility)) {
+    Error("AddUtility", "Jet utility %s already connected.", utility->GetName());
+    return utility;
+  }   
+  fUtilities->Add(utility);
+
+  return utility;
+}
+
+/**
+ * This method is called once before analyzing the first event. It executes
+ * the Init() method of all utilities (if any).
+ */
+void AliEmcalJetFinderKernel::InitUtilities()
+{
+  TIter next(fUtilities);
+  AliEmcalJetUtility *utility = 0;
+  while ((utility=static_cast<AliEmcalJetUtility*>(next()))) utility->Init();
+}
+/**
+ * This method is called before analyzing each event. It executes
+ * the InitEvent() method of all utilities (if any).
+ */
+void AliEmcalJetFinderKernel::InitEvent()
+{
+  TIter next(fUtilities);
+  AliEmcalJetUtility *utility = 0;
+  while ((utility=static_cast<AliEmcalJetUtility*>(next()))) utility->InitEvent(fFastJetWrapper);
+}
+
+/**
+ * This method is called in the event loop after jet finding but before filling
+ * the output jet branch to prepare the utilities.
+ * It executes the Prepare() method of all utilities (if any).
+ */
+void AliEmcalJetFinderKernel::PrepareUtilities()
+{
+  TIter next(fUtilities);
+  AliEmcalJetUtility *utility = 0;
+  while ((utility=static_cast<AliEmcalJetUtility*>(next()))) utility->Prepare(fFastJetWrapper);
+}
+
+/**
+ * This method is called in the event loop for each jet found, while filling the output jet branch.
+ * It executes the ProcessJet() method of all utilities (if any).
+ */
+void AliEmcalJetFinderKernel::ExecuteUtilities(AliEmcalJet* jet, Int_t ij)
+{
+  TIter next(fUtilities);
+  AliEmcalJetUtility *utility = 0;
+  while ((utility=static_cast<AliEmcalJetUtility*>(next()))) utility->ProcessJet(jet, ij, fFastJetWrapper);
+}
+
+/**
+ * This method is called in the event loop after jet finding has been completed.
+ * It executes the Terminate() method of all utilities (if any).
+ */
+void AliEmcalJetFinderKernel::TerminateUtilities()
+{
+  TIter next(fUtilities);
+  AliEmcalJetUtility *utility = 0;
+  while ((utility=static_cast<AliEmcalJetUtility*>(next()))) utility->Terminate(fFastJetWrapper);
+}
+
+/**
+ * This method is called for each event.
+ * @return Always kTRUE
+ */
+void AliEmcalJetFinderKernel::RunJetFinder(TClonesArray *jetarray)
+{
+  InitEvent();
+  // clear the jet array (normally a null operation)
+  fJets->Delete();
+  Int_t n = FindJets();
+
+  if(n){
+    TClonesArray *outputArray = jetarray;
+    if(!outputArray){
+      if(!fJets) {
+        fJets = new TClonesArray("AliEmcalJet");
+      }
+      outputArray = fJets;
+    }
+    FillJetBranch(outputArray);
+  }
+}
+
+/**
+ * This method steers the jet finding. It first loops over all particle and cluster containers
+ * that were provided when the task was initialized. All accepted objects (tracks, particle, clusters)
+ * are added as input vectors to the FastJet wrapper. Then the jet finding is launched
+ * in the wrapper.
+ * @return Total number of jets found.
+ */
+Int_t AliEmcalJetFinderKernel::FindJets()
+{
+  if (fParticleCollArray.GetEntriesFast() == 0 && fClusterCollArray.GetEntriesFast() == 0){
+    AliError("No tracks or clusters, returning.");
+    return 0;
+  }
+
+  fFastJetWrapper.Clear();
+
+  AliDebug(2,Form("Jet type = %d", fJetType));
+
+  Int_t iColl = 1;
+  TIter nextPartColl(&fParticleCollArray);
+  AliParticleContainer* tracks = 0;
+  while ((tracks = static_cast<AliParticleContainer*>(nextPartColl()))) {
+    AliDebug(2,Form("Tracks from collection %d: '%s'. Embedded: %i, nTracks: %i", iColl-1, tracks->GetName(), tracks->GetIsEmbedding(), tracks->GetNParticles()));
+    AliParticleIterableMomentumContainer itcont = tracks->accepted_momentum();
+    for (AliParticleIterableMomentumContainer::iterator it = itcont.begin(); it != itcont.end(); it++) {
+      // artificial inefficiency
+      if (fTrackEfficiency < 1.) {
+        if (fTrackEfficiencyOnlyForEmbedding == kFALSE || (fTrackEfficiencyOnlyForEmbedding == kTRUE && tracks->GetIsEmbedding())) {
+          Double_t rnd = gRandom->Rndm();
+          if (fTrackEfficiency < rnd) {
+            AliDebug(2,Form("Track %d rejected due to artificial tracking inefficiency", it.current_index()));
+            continue;
+          }
+        }
+      }
+
+      AliDebug(2,Form("Track %d accepted (label = %d, pt = %f, eta = %f, phi = %f, E = %f, m = %f, px = %f, py = %f, pz = %f)", it.current_index(), it->second->GetLabel(), it->first.Pt(), it->first.Eta(), it->first.Phi(), it->first.E(), it->first.M(), it->first.Px(), it->first.Py(), it->first.Pz()));
+      Int_t uid = it.current_index() + fgkConstIndexShift * iColl;
+      fFastJetWrapper.AddInputVector(it->first.Px(), it->first.Py(), it->first.Pz(), it->first.E(), uid);
+    }
+    iColl++;
+  }
+
+  iColl = 1;
+  TIter nextClusColl(&fClusterCollArray);
+  AliClusterContainer* clusters = 0;
+  while ((clusters = static_cast<AliClusterContainer*>(nextClusColl()))) {
+    AliDebug(2,Form("Clusters from collection %d: '%s'. Embedded: %i, nClusters: %i", iColl-1, clusters->GetName(), clusters->GetIsEmbedding(), clusters->GetNClusters()));
+    AliClusterIterableMomentumContainer itcont = clusters->accepted_momentum();
+    for (AliClusterIterableMomentumContainer::iterator it = itcont.begin(); it != itcont.end(); it++) {
+      AliDebug(2,Form("Cluster %d accepted (label = %d, energy = %.3f)", it.current_index(), it->second->GetLabel(), it->first.E()));
+      Int_t uid = -it.current_index() - fgkConstIndexShift * iColl;
+      fFastJetWrapper.AddInputVector(it->first.Px(), it->first.Py(), it->first.Pz(), it->first.E(), uid);
+    }
+    iColl++;
+  }
+
+  if (fFastJetWrapper.GetInputVectors().size() == 0) return 0;
+
+  // run jet finder
+  fFastJetWrapper.Run();
+
+  return fFastJetWrapper.GetInclusiveJets().size();
+}
+
+/**
+ * This method fills the jet output branch (TClonesArray) with the jet found by the FastJet
+ * wrapper. Before filling the jet branch, the utilities are prepared. Then the utilities are
+ * called for each jet and finally after jet finding the terminate method of all utilities is called.
+ */
+void AliEmcalJetFinderKernel::FillJetBranch(TClonesArray *outputcont)
+{
+  PrepareUtilities();
+
+  // loop over fastjet jets
+  std::vector<fastjet::PseudoJet> jets_incl = fFastJetWrapper.GetInclusiveJets();
+  // sort jets according to jet pt
+  static Int_t indexes[9999] = {-1};
+  GetSortedArray(indexes, jets_incl);
+
+  AliDebug(1,Form("%d jets found", (Int_t)jets_incl.size()));
+  for (UInt_t ijet = 0, jetCount = 0; ijet < jets_incl.size(); ++ijet) {
+    Int_t ij = indexes[ijet];
+    AliDebug(3,Form("Jet pt = %f, area = %f", jets_incl[ij].perp(), fFastJetWrapper.GetJetArea(ij)));
+
+    if (jets_incl[ij].perp() < fMinJetPt) continue;
+    if (fFastJetWrapper.GetJetArea(ij) < fMinJetArea) continue;
+    if ((jets_incl[ij].eta() < fJetEtaMin) || (jets_incl[ij].eta() > fJetEtaMax) ||
+        (jets_incl[ij].phi() < fJetPhiMin) || (jets_incl[ij].phi() > fJetPhiMax))
+      continue;
+
+    AliEmcalJet *jet = new ((*outputcont)[jetCount])
+    		          AliEmcalJet(jets_incl[ij].perp(), jets_incl[ij].eta(), jets_incl[ij].phi(), jets_incl[ij].m());
+    jet->SetLabel(ij);
+
+    fastjet::PseudoJet area(fFastJetWrapper.GetJetAreaVector(ij));
+    jet->SetArea(area.perp());
+    jet->SetAreaEta(area.eta());
+    jet->SetAreaPhi(area.phi());
+    jet->SetAreaE(area.E());
+    jet->SetJetAcceptanceType(FindJetAcceptanceType(jet->Eta(), jet->Phi_0_2pi(), fRadius));
+
+    // Fill constituent info
+    std::vector<fastjet::PseudoJet> constituents(fFastJetWrapper.GetJetConstituents(ij));
+    FillJetConstituents(jet, constituents, constituents);
+
+    if (fGeom) {
+      if ((jet->Phi() > fGeom->GetArm1PhiMin() * TMath::DegToRad()) &&
+          (jet->Phi() < fGeom->GetArm1PhiMax() * TMath::DegToRad()) &&
+          (jet->Eta() > fGeom->GetArm1EtaMin()) &&
+          (jet->Eta() < fGeom->GetArm1EtaMax()))
+        jet->SetAxisInEmcal(kTRUE);
+    }
+
+    ExecuteUtilities(jet, ij);
+
+    AliDebug(2,Form("Added jet n. %d, pt = %f, area = %f, constituents = %d", jetCount, jet->Pt(), jet->Area(), jet->GetNumberOfConstituents()));
+    jetCount++;
+  }
+
+  TerminateUtilities();
+}
+
+/**
+ * Sorts jets by pT (decreasing)
+ * @param[out] indexes This array is used to return the indexes of the jets ordered by pT
+ * @param[in] array Vector containing the list of jets obtained by the FastJet wrapper
+ * @return kTRUE if at least one jet was found in array; kFALSE otherwise
+ */
+Bool_t AliEmcalJetFinderKernel::GetSortedArray(Int_t indexes[], std::vector<fastjet::PseudoJet> array) const
+{
+  static Float_t pt[9999] = {0};
+
+  const Int_t n = (Int_t)array.size();
+
+  if (n < 1)
+    return kFALSE;
+
+  for (Int_t i = 0; i < n; i++)
+    pt[i] = array[i].perp();
+
+  TMath::Sort(n, pt, indexes);
+
+  return kTRUE;
+}
+
+/**
+ * This method is called once before analzying the first event.
+ * It generates the output jet branch name, initializes the FastJet wrapper
+ * and the utilities (FJ contribs).
+ */
+void AliEmcalJetFinderKernel::Init()
+{
+  if (fTrackEfficiency < 1.) {
+    if (gRandom) delete gRandom;
+    gRandom = new TRandom3(0);
+  }
+
+  // setup fj wrapper
+  fFastJetWrapper.SetAreaType(fastjet::active_area_explicit_ghosts);
+  fFastJetWrapper.SetGhostArea(fGhostArea);
+  fFastJetWrapper.SetR(fRadius);
+  fFastJetWrapper.SetAlgorithm(ConvertToFJAlgo(fJetAlgo));
+  fFastJetWrapper.SetRecombScheme(ConvertToFJRecoScheme(fRecombScheme));
+  fFastJetWrapper.SetMaxRap(1);
+
+  // setting legacy mode
+  if (fLegacyMode) {
+    fFastJetWrapper.SetLegacyMode(kTRUE);
+  }
+
+  InitUtilities();
+
+}
+
+
+void AliEmcalJetFinderKernel::InitIndexMaps(){
+  fClusterContainerIndexMap.CopyMappingFrom(AliClusterContainer::GetEmcalContainerIndexMap(), fClusterCollArray);
+  fParticleContainerIndexMap.CopyMappingFrom(AliParticleContainer::GetEmcalContainerIndexMap(), fParticleCollArray);
+}
+
+/**
+ * This method is called for each jet. It loops over the jet constituents and
+ * adds them to the jet object.
+ * @param jet Pointer to the AliEmcalJet object where the jet constituents will be added
+ * @param constituents List of the jet constituents returned by the FastJet wrapper
+ * @param constituents_unsub List of jet constituents before background subtraction
+ * @param flag If kTRUE it means that the argument "constituents" is a list of subtracted constituents
+ * @param particles_sub Array containing subtracted constituents
+ */
+void AliEmcalJetFinderKernel::FillJetConstituents(AliEmcalJet *jet, std::vector<fastjet::PseudoJet>& constituents,
+    std::vector<fastjet::PseudoJet>& constituents_unsub, Int_t flag, TString particlesSubName)
+{
+  Int_t nt            = 0;
+  Int_t nc            = 0;
+  Double_t neutralE   = 0.;
+  Double_t maxCh      = 0.;
+  Double_t maxNe      = 0.;
+  Int_t gall          = 0;
+  Int_t gemc          = 0;
+  Int_t cemc          = 0;
+  Int_t ncharged      = 0;
+  Int_t nneutral      = 0;
+  Double_t mcpt       = 0.;
+  Double_t emcpt      = 0.;
+  TClonesArray * particles_sub = 0;
+
+  Int_t uid   = -1;
+
+  jet->SetNumberOfTracks(constituents.size());
+  jet->SetNumberOfClusters(constituents.size());
+
+  for (UInt_t ic = 0; ic < constituents.size(); ++ic) {
+
+    if (flag == 0) {
+      uid = constituents[ic].user_index();
+    }
+    else {
+      if (constituents[ic].perp()<1.e-10) {
+        uid=-1;
+      }
+      else {
+        uid = constituents[ic].user_index();
+      }
+      if (uid==0) {
+        AliError("correspondence between un/subtracted constituent not found");
+        continue;
+      }
+    }
+
+    AliDebug(3,Form("Processing constituent %d", uid));
+    if (uid == -1) { //ghost particle
+      ++gall;
+      if (fGeom) {
+        Double_t gphi = constituents[ic].phi();
+        if (gphi < 0) gphi += TMath::TwoPi();
+        gphi *= TMath::RadToDeg();
+        Double_t geta = constituents[ic].eta();
+        if ((gphi > fGeom->GetArm1PhiMin()) && (gphi < fGeom->GetArm1PhiMax()) &&
+            (geta > fGeom->GetArm1EtaMin()) && (geta < fGeom->GetArm1EtaMax()))
+          ++gemc;
+      }
+
+      if (fFillGhost) jet->AddGhost(constituents[ic].px(),
+          constituents[ic].py(),
+          constituents[ic].pz(),
+          constituents[ic].e());
+    }	
+    else if (uid >= fgkConstIndexShift) { // track constituent
+      Int_t iColl = uid / fgkConstIndexShift;
+      Int_t tid = uid - iColl * fgkConstIndexShift;
+      iColl--;
+      AliDebug(3,Form("Constituent %d is a track from collection %d and with ID %d", uid, iColl, tid));
+      AliParticleContainer* partCont = GetParticleContainer(iColl);
+      if (!partCont) {
+        AliError(Form("Could not find particle container %d",iColl));
+        continue;
+      }
+      AliVParticle *t = partCont->GetParticle(tid);
+      if (!t) {
+        AliError(Form("Could not find track %d",tid));
+        continue;
+      }
+      if(fFillConstituents){
+        jet->AddParticleConstituent(t, partCont->GetIsEmbedding(), fParticleContainerIndexMap.GlobalIndexFromLocalIndex(partCont, tid));
+      }
+
+      Double_t cEta = t->Eta();
+      Double_t cPhi = t->Phi();
+      Double_t cPt  = t->Pt();
+      Double_t cP   = t->P();
+      if (t->Charge() == 0) {
+        neutralE += cP;
+        ++nneutral;
+        if (cPt > maxNe) maxNe = cPt;
+      } else {
+        ++ncharged;
+        if (cPt > maxCh) maxCh = cPt;
+      }
+
+      // check if MC particle
+      if (TMath::Abs(t->GetLabel()) > fMinMCLabel) mcpt += cPt;
+
+      if (fGeom) {
+        if (cPhi < 0) cPhi += TMath::TwoPi();
+        cPhi *= TMath::RadToDeg();
+        if ((cPhi > fGeom->GetArm1PhiMin()) && (cPhi < fGeom->GetArm1PhiMax()) &&
+            (cEta > fGeom->GetArm1EtaMin()) && (cEta < fGeom->GetArm1EtaMax())) {
+          emcpt += cPt;
+          ++cemc;
+        }
+      }
+
+      if (flag == 0 || particlesSubName == "") {
+        jet->AddTrackAt(fParticleContainerIndexMap.GlobalIndexFromLocalIndex(partCont, tid), nt);
+      }
+      else {
+        // Get the particle container and array corresponding to the subtracted particles
+        partCont = GetParticleContainer(particlesSubName);
+        particles_sub = partCont->GetArray();
+        // Create the new particle in the particles_sub array and add it to the jet
+        Int_t part_sub_id = particles_sub->GetEntriesFast();
+        AliEmcalParticle* part_sub = new ((*particles_sub)[part_sub_id]) AliEmcalParticle(dynamic_cast<AliVTrack*>(t));   // SA: probably need to be fixed!!
+        part_sub->SetPtEtaPhiM(constituents[ic].perp(),constituents[ic].eta(),constituents[ic].phi(),constituents[ic].m());
+        jet->AddTrackAt(fParticleContainerIndexMap.GlobalIndexFromLocalIndex(partCont, part_sub_id), nt);
+      }
+
+      ++nt;
+    } 
+    else if (uid <= -fgkConstIndexShift) { // cluster constituent
+      Int_t iColl = -uid / fgkConstIndexShift;
+      Int_t cid = -uid - iColl * fgkConstIndexShift;
+      iColl--;
+      AliDebug(3,Form("Constituent %d is a cluster from collection %d and with ID %d", uid, iColl, cid));
+      AliClusterContainer* clusCont = GetClusterContainer(iColl);
+      AliVCluster *c = clusCont->GetCluster(cid);
+
+      if (!c) continue;
+
+      AliTLorentzVector nP;
+      clusCont->GetMomentum(nP, cid);
+
+      Double_t cEta = nP.Eta();
+      Double_t cPhi = nP.Phi_0_2pi();
+      Double_t cPt  = nP.Pt();
+      Double_t cP   = nP.P();
+      Double_t pvec[3] = {nP.Px(), nP.Py(), nP.Pz()};
+      if(fFillConstituents) jet->AddClusterConstituent(c, (AliVCluster::VCluUserDefEnergy_t)clusCont->GetDefaultClusterEnergy(), pvec, clusCont->GetIsEmbedding(), fClusterContainerIndexMap.GlobalIndexFromLocalIndex(clusCont, cid));
+
+      neutralE += cP;
+      if (cPt > maxNe) maxNe = cPt;
+
+      // MC particle
+      if (TMath::Abs(c->GetLabel()) > fMinMCLabel) mcpt += c->GetMCEnergyFraction() > 1e-6 ? cPt * c->GetMCEnergyFraction() : cPt;
+
+      if (fGeom) {
+        if (cPhi<0) cPhi += TMath::TwoPi();
+        cPhi *= TMath::RadToDeg();
+        if ((cPhi > fGeom->GetArm1PhiMin()) && (cPhi < fGeom->GetArm1PhiMax()) &&
+            (cEta > fGeom->GetArm1EtaMin()) && (cEta < fGeom->GetArm1EtaMax())) {
+          emcpt += cPt;
+          ++cemc;
+        }
+      }
+
+      if (flag == 0 || particlesSubName == "") {
+        jet->AddClusterAt(fClusterContainerIndexMap.GlobalIndexFromLocalIndex(clusCont, cid), nc);
+      }
+      else {
+        // Get the cluster container and array corresponding to the subtracted particles
+        clusCont = GetClusterContainer(particlesSubName);
+        particles_sub = clusCont->GetArray();
+        // Create the new particle in the particles_sub array and add it to the jet
+        Int_t part_sub_id = particles_sub->GetEntriesFast();
+        AliEmcalParticle* part_sub = new ((*particles_sub)[part_sub_id]) AliEmcalParticle(c);
+        part_sub->SetPtEtaPhiM(constituents[ic].perp(),constituents[ic].eta(),constituents[ic].phi(),constituents[ic].m());
+        jet->AddClusterAt(fClusterContainerIndexMap.GlobalIndexFromLocalIndex(clusCont, part_sub_id), nc);
+      }
+
+      ++nc;
+      ++nneutral;
+    } 
+    else {
+      AliError(Form("%s: No logical way to end up here (uid = %d).", GetName(), uid));
+      continue;
+    }
+  }
+
+  jet->SetNumberOfTracks(nt);
+  jet->SetNumberOfClusters(nc);
+  jet->SetNEF(neutralE / jet->E());
+  jet->SetMaxChargedPt(maxCh);
+  jet->SetMaxNeutralPt(maxNe);
+  if (gall > 0) jet->SetAreaEmc(jet->Area() * gemc / gall);
+  else jet->SetAreaEmc(-1);
+  jet->SetNEmc(cemc);
+  jet->SetNumberOfCharged(ncharged);
+  jet->SetNumberOfNeutrals(nneutral);
+  jet->SetMCPt(mcpt);
+  jet->SetPtEmc(emcpt);
+  jet->SortConstituents();
+}
+
+/**
+ * An instance of this class can be "locked". Once locked, it cannot be unlocked.
+ * If the instance is locked, attempting to change the configuration will throw a
+ * fatal and stop the execution of the program. This method checks whether the instance
+ * is locked and throw a fatal if it is locked.
+ */
+Bool_t AliEmcalJetFinderKernel::IsLocked() const
+{
+  if (fLocked) {
+    AliFatal("Jet finder task is locked! Changing properties is not allowed."); 
+    return kTRUE;
+  } 
+  else {
+    return kFALSE;
+  }
+}
+
+/**
+ * Set the eta range of the track constituents.
+ * @param emi Minimum eta
+ * @param ema Maximum eta
+ */
+void AliEmcalJetFinderKernel::SetEtaRange(Double_t emi, Double_t ema)
+{
+  if (IsLocked()) return;
+
+  TIter nextPartColl(&fParticleCollArray);
+  AliParticleContainer* tracks = 0;
+  while ((tracks = static_cast<AliParticleContainer*>(nextPartColl()))) {
+    tracks->SetParticleEtaLimits(emi, ema);
+  }
+}
+
+/**
+ * Set the minimum pT of the cluster constituents.
+ * @param min Minimum pT
+ */
+void AliEmcalJetFinderKernel::SetMinJetClusPt(Double_t min)
+{
+  if (IsLocked()) return;
+
+  TIter nextClusColl(&fClusterCollArray);
+  AliClusterContainer* clusters = 0;
+  while ((clusters = static_cast<AliClusterContainer*>(nextClusColl()))) {
+    clusters->SetClusPtCut(min);
+  }
+}
+
+/**
+ * Set the minimum energy of the cluster constituents.
+ * @param min Minimum energy
+ */
+void AliEmcalJetFinderKernel::SetMinJetClusE(Double_t min)
+{
+  if (IsLocked()) return;
+
+  TIter nextClusColl(&fClusterCollArray);
+  AliClusterContainer* clusters = 0;
+  while ((clusters = static_cast<AliClusterContainer*>(nextClusColl()))) {
+    clusters->SetClusECut(min);
+  }
+}
+
+/**
+ * Set the minimum pT of the track constituents.
+ * @param min Minimum pT
+ */
+void AliEmcalJetFinderKernel::SetMinJetTrackPt(Double_t min)
+{
+  if (IsLocked()) return;
+
+  TIter nextPartColl(&fParticleCollArray);
+  AliParticleContainer* tracks = 0;
+  while ((tracks = static_cast<AliParticleContainer*>(nextPartColl()))) {
+    tracks->SetParticlePtCut(min);
+  }
+}
+
+/**
+ * Set the phi range of the track constituents.
+ * @param pmi Minimum phi
+ * @param pma Maximum phi
+ */
+void AliEmcalJetFinderKernel::SetPhiRange(Double_t pmi, Double_t pma)
+{
+  if (IsLocked()) return;
+
+  TIter nextPartColl(&fParticleCollArray);
+  AliParticleContainer* tracks = 0;
+  while ((tracks = static_cast<AliParticleContainer*>(nextPartColl()))) {
+    tracks->SetParticlePhiLimits(pmi, pma);
+  }
+}
+
+/**
+ * Converts the internal enum values representing jet algorithms in
+ * the corresponding values accepted by the FastJet wrapper.
+ * @param algo Algorithm represented in the EJetAlgo_t enum
+ * @return Algortithm represented in the fastjet::JetAlgorithm enum
+ */
+fastjet::JetAlgorithm AliEmcalJetFinderKernel::ConvertToFJAlgo(EJetAlgo_t algo)
+{
+  switch(algo) {
+  case AliJetContainer::kt_algorithm:
+    return fastjet::kt_algorithm;
+  case AliJetContainer::antikt_algorithm:
+    return fastjet::antikt_algorithm;
+  case AliJetContainer::cambridge_algorithm:
+    return fastjet::cambridge_algorithm;
+  case AliJetContainer::genkt_algorithm:
+    return fastjet::genkt_algorithm;
+  case AliJetContainer::cambridge_for_passive_algorithm:
+    return fastjet::cambridge_for_passive_algorithm;
+  case AliJetContainer::genkt_for_passive_algorithm:
+    return fastjet::genkt_for_passive_algorithm;
+  case AliJetContainer::plugin_algorithm:
+    return fastjet::plugin_algorithm;
+  case AliJetContainer::undefined_jet_algorithm:
+    return fastjet::undefined_jet_algorithm;
+
+  default:
+    ::Error("AliEmcalJetFinderKernel::ConvertToFJAlgo", "Jet algorithm %d not recognized!!!", algo);
+    return fastjet::undefined_jet_algorithm;
+  }
+}
+
+/**
+ * Converts the internal enum values representing jet recombination schemes in
+ * the corresponding values accepted by the FastJet wrapper.
+ * @param reco Recombination scheme represented in the EJetAlgo_t enum
+ * @return Recombination scheme represented in the fastjet::JetAlgorithm enum
+ */
+fastjet::RecombinationScheme AliEmcalJetFinderKernel::ConvertToFJRecoScheme(ERecoScheme_t reco)
+{
+  switch(reco) {
+  case AliJetContainer::E_scheme:
+    return fastjet::E_scheme;
+
+  case AliJetContainer::pt_scheme:
+    return fastjet::pt_scheme;
+
+  case AliJetContainer::pt2_scheme:
+    return fastjet::pt2_scheme;
+
+  case AliJetContainer::Et_scheme:
+    return fastjet::Et_scheme;
+
+  case AliJetContainer::Et2_scheme:
+    return fastjet::Et2_scheme;
+
+  case AliJetContainer::BIpt_scheme:
+    return fastjet::BIpt_scheme;
+
+  case AliJetContainer::BIpt2_scheme:
+    return fastjet::BIpt2_scheme;
+
+  case AliJetContainer::external_scheme:
+    return fastjet::external_scheme;
+
+  default:
+    ::Error("AliEmcalJetFinderKernel::ConvertToFJRecoScheme", "Recombination scheme %d not recognized!!!", reco);
+    return fastjet::external_scheme;
+  }
+}
+
+/**
+ * Finds which geometrical acceptance types the jet satisfies.
+ * @return bitwise jet acceptance type
+ */
+UInt_t AliEmcalJetFinderKernel::FindJetAcceptanceType(Double_t eta, Double_t phi, Double_t r) {
+  
+  //This method has to be called after the run number is known because it needs the EMCal geometry object.
+  
+  UInt_t jetAcceptanceType = AliEmcalJet::kUser; // all jets satify the "no acceptance cut" condition
+  
+  // Check if TPC
+  if( eta < 0.9 && eta > -0.9 ) {
+    jetAcceptanceType |= AliEmcalJet::kTPC;
+    // Check if TPCfid
+    if (eta < 0.9 - r && eta > -0.9 + r)
+      jetAcceptanceType |= AliEmcalJet::kTPCfid;
+  }
+    
+  // Check if EMCAL
+  if( IsJetInEmcal(eta, phi, 0) ) {
+    jetAcceptanceType |= AliEmcalJet::kEMCAL;
+    // Check if EMCALfid
+    if( IsJetInEmcal(eta, phi, r) )
+      jetAcceptanceType |= AliEmcalJet::kEMCALfid;
+  }
+  
+  // Check if DCAL (i.e. eta-phi rectangle spanning DCal, which includes most of PHOS)
+  if( IsJetInDcal(eta, phi, 0) ) {
+    jetAcceptanceType |= AliEmcalJet::kDCAL;
+    // Check if DCALfid
+    if( IsJetInDcal(eta, phi, r) )
+      jetAcceptanceType |= AliEmcalJet::kDCALfid;
+  }
+  
+  // Check if DCALonly (i.e. ONLY DCal, does not include any of PHOS region)
+  if( IsJetInDcalOnly(eta, phi, 0) ) {
+    jetAcceptanceType |= AliEmcalJet::kDCALonly;
+    // Check if DCALonlyfid
+    if( IsJetInDcalOnly(eta, phi, r) )
+      jetAcceptanceType |= AliEmcalJet::kDCALonlyfid;
+  }
+  
+  // Check if PHOS
+  if( IsJetInPhos(eta, phi, 0) ) {
+    jetAcceptanceType |= AliEmcalJet::kPHOS;
+    // Check if PHOSfid
+    if( IsJetInPhos(eta, phi, r) )
+      jetAcceptanceType |= AliEmcalJet::kPHOSfid;
+  }
+ 
+  return jetAcceptanceType;
+}
+
+/**
+ * Returns whether or not jet with given eta, phi, R is in EMCal.
+ */
+Bool_t AliEmcalJetFinderKernel::IsJetInEmcal(Double_t eta, Double_t phi, Double_t r)
+{
+  if (!fGeom) return kFALSE;
+
+  if ( eta < fGeom->GetArm1EtaMax() - r && eta > fGeom->GetArm1EtaMin() + r ) {
+    if(fRunNumber >= 177295 && fRunNumber <= 197470) {//small SM masked in 2012 and 2013
+      if ( phi < 3.135 - r && phi > 1.405 + r )
+        return kTRUE;
+    }
+    else {
+      if ( phi < fGeom->GetEMCALPhiMax() * TMath::DegToRad() - r && phi > fGeom->GetArm1PhiMin() * TMath::DegToRad() + r)
+        return kTRUE;
+    }
+  }
+
+  return kFALSE;
+}
+
+/**
+ * Returns whether or not jet with given eta, phi, R is in DCal region (note: spans most of PHOS as well).
+ */
+Bool_t AliEmcalJetFinderKernel::IsJetInDcal(Double_t eta, Double_t phi, Double_t r)
+{
+  if (!fGeom) return kFALSE;
+  if (eta < fGeom->GetArm1EtaMax() - r && eta > fGeom->GetArm1EtaMin() + r ) {
+    if ( phi < fGeom->GetDCALPhiMax() * TMath::DegToRad() - r && phi > fGeom->GetDCALPhiMin() * TMath::DegToRad() + r)
+      return kTRUE;
+  }
+  return kFALSE;
+}
+
+/**
+ * Returns whether or not jet with given eta, phi, R is in DCal (note: ONLY DCal -- none of PHOS included).
+ * Assumes DCAL_8SM geometry.
+ * For r=0, use the entire DCal acceptance, including both of the connecting 1/3 SMs.
+ * For r>0, use only the two "disjoint" fiducial regions of the DCal (i.e. ignore the connecting portions of the 1/3 SMs)
+ */
+Bool_t AliEmcalJetFinderKernel::IsJetInDcalOnly(Double_t eta, Double_t phi, Double_t r)
+{
+  if (!fGeom) return kFALSE;
+  
+  if (eta < fGeom->GetArm1EtaMax() - r && eta > fGeom->GetArm1EtaMin() + r) {
+    if ( phi < fGeom->GetDCALPhiMax() * TMath::DegToRad() - r && phi > fGeom->GetDCALPhiMin() * TMath::DegToRad() + r) {
+      
+      if (TMath::Abs(eta) > fGeom->GetDCALInnerExtandedEta() + r) {
+        return kTRUE;
+      }
+      if (r < 1e-6) {
+        if (phi > fGeom->GetEMCGeometry()->GetDCALStandardPhiMax() * TMath::DegToRad())
+          return kTRUE;
+      }
+      
+    }
+  }
+  
+  return kFALSE;
+}
+
+/**
+ * Returns whether or not jet with given eta, phi, R is in PHOS.
+ */
+Bool_t AliEmcalJetFinderKernel::IsJetInPhos(Double_t eta, Double_t phi, Double_t r)
+{
+  Double_t etaMax = 0.130;
+  Double_t etaMin = -0.130;
+  Double_t phiMax = 320;
+  Double_t phiMin = 260; // Run 1
+  if (fRunNumber > 209121)
+    phiMin = 250; // Run 2
+  
+  if (eta < etaMax - r && eta > etaMin + r ) {
+    if (phi < phiMax * TMath::DegToRad() - r && phi > phiMin * TMath::DegToRad() + r)
+      return kTRUE;
+  }
+  return kFALSE;
+}
+
+AliParticleContainer *AliEmcalJetFinderKernel::GetParticleContainer(Int_t ncontainer){
+  if(ncontainer >= fParticleCollArray.GetEntriesFast()) return nullptr;
+  return static_cast<AliParticleContainer *>(fParticleCollArray.At(ncontainer));
+}
+
+AliParticleContainer *AliEmcalJetFinderKernel::GetParticleContainer(const char * ncontainer){
+  return static_cast<AliParticleContainer *>(fParticleCollArray.FindObject(ncontainer));
+}
+
+
+AliClusterContainer *AliEmcalJetFinderKernel::GetClusterContainer(Int_t ncontainer){
+  if(ncontainer >= fParticleCollArray.GetEntriesFast()) return nullptr;
+  return static_cast<AliClusterContainer *>(fParticleCollArray.At(ncontainer));
+}
+
+AliClusterContainer *AliEmcalJetFinderKernel::GetClusterContainer(const char * ncontainer){
+  return static_cast<AliClusterContainer *>(fParticleCollArray.FindObject(ncontainer));
+}
+
+void AliEmcalJetFinderKernel::AppendParticleContainer(AliParticleContainer *cont) {
+  fParticleCollArray.AddLast(cont);
+}
+
+void AliEmcalJetFinderKernel::AppendClusterContainer(AliClusterContainer *cont) {
+  fClusterCollArray.AddLast(cont);
+}
+
+void AliEmcalJetFinderKernel::SetParticleContainer(AliParticleContainer *cont, UInt_t position) {
+  fParticleCollArray.AddAt(cont, position);
+}
+
+void AliEmcalJetFinderKernel::SetClusterContainer(AliClusterContainer *cont, UInt_t position) {
+  fClusterCollArray.AddAt(cont, position);
+}
+
+}
+
+}

--- a/PWGJE/EMCALJetTasks/AliEmcalJetFinderKernel.h
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetFinderKernel.h
@@ -1,0 +1,241 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIEMCALJETFINDERKERNEL_H
+#define ALIEMCALJETFINDERKERNEL_H
+
+class TClonesArray;
+class TObjArray;
+class AliEMCALGeometry;
+class AliEmcalJetUtility;
+
+#include <AliLog.h>
+
+#include "AliFJWrapper.h"
+#include "FJ_includes.h"
+#include "AliEmcalJet.h"
+#include "AliJetContainer.h"
+#if !(defined(__CINT__) || defined(__MAKECINT__))
+#include "AliEmcalContainerIndexMap.h"
+#endif
+
+namespace fastjet {
+  class PseudoJet;
+}
+
+namespace PWGJE{
+
+namespace EMCALJetTasks{
+
+/**
+ * @class AliEmcalJetFinderKernel
+ * @brief General jet finder task implementing a wrapper for FastJet
+ * @author Constantin Lozides <cloizides@lbl.gov>, Lawrence Berkeley National Laboratory
+ * @author Marta Verweij
+ * @author Salvatore Aiola <salvatore.aiola@cern.ch>, Yale University
+ *
+ * Forked from AliEmcalJetTask, stand-alone version, not based on AliAnalysisTaskEmcal
+ *
+ * This class implements a wrapper for the FastJet jet finder. It allows
+ * to set a jet definition (jet algorithm, recombination scheme) and the
+ * list of jet constituents. Jet constituents are provided via multiple instances
+ * of AliParticleContainer and AliClusterContainer. These classes are delegated for
+ * applying cuts and filtering constituents that are then fed to the jet finder.
+ * This task will further filter constituents based on whether the jet was
+ * defined as being charged, neutral or full. The jet finding is delegated to
+ * the class AliFJWrapper which implements an interface to FastJet.
+ *
+ * The FastJet contrib utilities are available via the AliEmcalJetUtility base class
+ * and its derived classes. Utilities can be added via the AddUtility(AliEmcalJetUtility*) method.
+ * All the utilities added in the list will be executed. Users can implement new utilities
+ * deriving a new class from AliEmcalJetUtility to interface functionalities of the FastJet contribs.
+ */
+class AliEmcalJetFinderKernel : public TNamed {
+ public:
+
+  typedef AliJetContainer::EJetType_t EJetType_t;
+  typedef AliJetContainer::EJetAlgo_t EJetAlgo_t;
+  typedef AliJetContainer::ERecoScheme_t ERecoScheme_t;
+
+#if !defined(__CINT__) && !defined(__MAKECINT__)
+  typedef fastjet::JetAlgorithm FJJetAlgo;
+  typedef fastjet::RecombinationScheme FJRecoScheme;
+#endif
+
+  AliEmcalJetFinderKernel();
+  AliEmcalJetFinderKernel(const char *name);
+  virtual ~AliEmcalJetFinderKernel();
+
+  void                   Init();
+  void                   RunJetFinder(TClonesArray *outputcont = nullptr);
+
+  void                   SetGhostArea(Double_t gharea)              { if (IsLocked()) return; fGhostArea        = gharea; }
+  void                   SetJetEtaRange(Double_t emi, Double_t ema) { if (IsLocked()) return; fJetEtaMin        = emi   ; fJetEtaMax = ema; }
+  void                   SetJetPhiRange(Double_t pmi, Double_t pma) { if (IsLocked()) return; fJetPhiMin        = pmi   ; fJetPhiMax = pma; }
+  void                   SetJetAlgo(EJetAlgo_t a)                   { if (IsLocked()) return; fJetAlgo          = a     ; }
+  void                   SetJetType(EJetType_t t)                   { if (IsLocked()) return; fJetType          = t     ; }
+  void                   SetLocked()                                { fLocked = kTRUE;}
+  void                   SetMinJetArea(Double_t a)                  { if (IsLocked()) return; fMinJetArea       = a     ; }
+  void                   SetMinJetPt(Double_t j)                    { if (IsLocked()) return; fMinJetPt         = j     ; }
+  void                   SetMinMCLabel(Int_t min)                   { if (IsLocked()) return; fMinMCLabel       = min   ; }
+  void                   SetRecombScheme(ERecoScheme_t scheme)      { if (IsLocked()) return; fRecombScheme     = scheme; }
+  void                   SetTrackEfficiency(Double_t t)             { if (IsLocked()) return; fTrackEfficiency  = t     ; }
+  void                   SetTrackEfficiencyOnlyForEmbedding(Bool_t b) { if (IsLocked()) return; fTrackEfficiencyOnlyForEmbedding = b     ; }
+  void                   SetLegacyMode(Bool_t mode)                 { if (IsLocked()) return; fLegacyMode       = mode  ; }
+  void                   SetFillGhost(Bool_t b=kTRUE)               { if (IsLocked()) return; fFillGhost        = b     ; }
+  void                   SetRadius(Double_t r)                      { if (IsLocked()) return; fRadius           = r     ; }
+
+  void                   SetEtaRange(Double_t emi, Double_t ema);
+  void                   SetMinJetClusPt(Double_t min);
+  void                   SetMinJetClusE(Double_t min);
+  void                   SetMinJetTrackPt(Double_t min);
+  void                   SetPhiRange(Double_t pmi, Double_t pma);
+  void                   SetRunNumber(Int_t runnumber) { fRunNumber = runnumber; }
+
+  AliEmcalJetUtility*    AddUtility(AliEmcalJetUtility* utility);
+
+  Double_t               GetGhostArea()                   { return fGhostArea         ; }
+  Double_t               GetJetEtaMin()                   { return fJetEtaMin         ; }
+  Double_t               GetJetEtaMax()                   { return fJetEtaMax         ; }
+  Double_t               GetJetPhiMin()                   { return fJetPhiMin         ; }
+  Double_t               GetJetPhiMax()                   { return fJetPhiMax         ; }
+  EJetType_t             GetJetType()                     { return fJetType           ; }
+  EJetAlgo_t             GetJetAlgo()                     { return fJetAlgo           ; }
+  Bool_t                 GetLegacyMode()                  { return fLegacyMode        ; }
+  Double_t               GetMinJetArea()                  { return fMinJetArea        ; }
+  Double_t               GetMinJetPt()                    { return fMinJetPt          ; }
+  Int_t                  GetMinMCLabel()                  { return fMinMCLabel        ; }
+  Double_t               GetRadius()                      { return fRadius            ; }
+  ERecoScheme_t          GetRecombScheme()                { return fRecombScheme      ; }
+  Double_t               GetTrackEfficiency()             { return fTrackEfficiency   ; }
+  Bool_t                 GetTrackEfficiencyOnlyForEmbedding() { return fTrackEfficiencyOnlyForEmbedding; }
+
+  TClonesArray*          GetJets()                        { return fJets              ; }
+  TObjArray*             GetUtilities()                   { return fUtilities         ; }
+
+  void                   FillJetConstituents(AliEmcalJet *jet, std::vector<fastjet::PseudoJet>& constituents,
+                                             std::vector<fastjet::PseudoJet>& constituents_sub, Int_t flag = 0, TString particlesSubName = "");
+
+  UInt_t                 FindJetAcceptanceType(Double_t eta, Double_t phi, Double_t r);
+  
+
+  Bool_t                 IsLocked() const;
+  void                   SetType(Int_t t);
+
+  /**
+   * @brief Switch for whether to fill the AliEmcalJetConstituent objects (clusters and particles/tracks)
+   *
+   * By default jet constituent object will be filled to the jet.
+   *
+   * @param doFill Switch for filling jet consituent object
+   */
+  void                   SetFillJetConsituents(Bool_t doFill) { fFillConstituents = doFill; }
+
+#if !defined(__CINT__) && !defined(__MAKECINT__)
+  static FJJetAlgo       ConvertToFJAlgo(EJetAlgo_t algo);
+  static FJRecoScheme    ConvertToFJRecoScheme(ERecoScheme_t reco);
+#endif
+
+  AliParticleContainer *GetParticleContainer(Int_t contID);
+  AliParticleContainer *GetParticleContainer(const char * contname);
+  AliClusterContainer  *GetClusterContainer(Int_t contID);
+  AliClusterContainer  *GetClusterContainer(const char * contname);
+
+  void AppendParticleContainer(AliParticleContainer *cont);
+  void AppendClusterContainer(AliClusterContainer *cont);
+  void SetParticleContainer(AliParticleContainer *cont, UInt_t position);
+  void SetClusterContainer(AliClusterContainer *cont, UInt_t position);
+
+  void InitIndexMaps();
+
+ protected:
+
+  Int_t                  FindJets();
+  void                   FillJetBranch(TClonesArray *outputcont);
+  void                   InitEvent();
+  void                   InitUtilities();
+  void                   PrepareUtilities();
+  void                   ExecuteUtilities(AliEmcalJet* jet, Int_t ij);
+  void                   TerminateUtilities();
+  Bool_t                 GetSortedArray(Int_t indexes[], std::vector<fastjet::PseudoJet> array) const;
+  Bool_t                 IsJetInEmcal(Double_t eta, Double_t phi, Double_t r);
+  Bool_t                 IsJetInDcal(Double_t eta, Double_t phi, Double_t r);
+  Bool_t                 IsJetInDcalOnly(Double_t eta, Double_t phi, Double_t r);
+  Bool_t                 IsJetInPhos(Double_t eta, Double_t phi, Double_t r);
+
+private:
+  AliEMCALGeometry      *fGeom;                   ///< EMCAL geometry
+  TObjArray              fParticleCollArray;      ///< Particle collection array
+  TObjArray              fClusterCollArray;       ///< Cluster collection array
+
+  EJetType_t             fJetType;                ///< jet type (full, charged, neutral)
+  EJetAlgo_t             fJetAlgo;                ///< jet algorithm (kt, akt, etc)
+  ERecoScheme_t          fRecombScheme;           ///< recombination scheme used by fastjet
+  Double_t               fRadius;                 ///< jet radius
+  Int_t                  fRunNumber;              ///< current run number
+  Int_t                  fMinMCLabel;             ///< minimum MC label value for the tracks/clusters being considered MC particles
+  Double_t               fMinJetArea;             ///< min area to keep jet in output
+  Double_t               fMinJetPt;               ///< min jet pt to keep jet in output
+  Double_t               fJetPhiMin;              ///< minimum phi to keep jet in output
+  Double_t               fJetPhiMax;              ///< maximum phi to keep jet in output
+  Double_t               fJetEtaMin;              ///< minimum eta to keep jet in output
+  Double_t               fJetEtaMax;              ///< maximum eta to keep jet in output
+  Double_t               fGhostArea;              ///< ghost area
+  Double_t               fTrackEfficiency;        ///< artificial tracking inefficiency (0...1)
+  TObjArray             *fUtilities;              ///< jet utilities (gen subtractor, constituent subtractor etc.)
+  Bool_t                 fTrackEfficiencyOnlyForEmbedding; ///<tituent Apply aritificial tracking inefficiency only for embedded tracks
+  Bool_t                 fLocked;                 ///< true if lock is set
+  Bool_t	                fFillConstituents;		 ///< If true jet consituents will be filled to the AliEmcalJet
+
+  Bool_t                 fIndexMapsPrepared;      //!<!=true if index maps are already prepared
+  Bool_t                 fIsInit;                 //!<!=true if already initialized
+  Bool_t                 fIsEmcPart;              //!<!=true if emcal particles are given as input (for clusters)
+  Bool_t                 fLegacyMode;             //!<!=true to enable FJ 2.x behavior
+  Bool_t                 fFillGhost;              ///< =true ghost particles will be filled in AliEmcalJet obj
+
+  TClonesArray          *fJets;                   //!<!jet collection
+  AliFJWrapper           fFastJetWrapper;         //!<!fastjet wrapper
+
+  static const Int_t     fgkConstIndexShift;      //!<!contituent index shift
+
+#if !(defined(__CINT__) || defined(__MAKECINT__))
+  // Handle mapping between index and containers
+  AliEmcalContainerIndexMap <AliClusterContainer, AliVCluster> fClusterContainerIndexMap;    //!<! Mapping between index and cluster containers
+  AliEmcalContainerIndexMap <AliParticleContainer, AliVParticle> fParticleContainerIndexMap; //!<! Mapping between index and particle containers
+#endif
+
+ private:
+  AliEmcalJetFinderKernel(const AliEmcalJetFinderKernel&);            // not implemented
+  AliEmcalJetFinderKernel &operator=(const AliEmcalJetFinderKernel&); // not implemented
+
+  /// \cond CLASSIMP
+  ClassDef(AliEmcalJetFinderKernel, 26);
+  /// \endcond
+};
+
+}
+}
+#endif

--- a/PWGJE/EMCALJetTasks/AliEmcalJetTaskV1.cxx
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetTaskV1.cxx
@@ -1,0 +1,294 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <vector>
+
+#include <TClonesArray.h>
+#include <AliAnalysisManager.h>
+#include <AliVEventHandler.h>
+#include <AliVEvent.h>
+#include "AliEmcalJet.h"
+#include "AliEmcalJetFinderKernel.h"
+#include "AliEmcalJetTaskV1.h"
+
+/// \cond CLASSIMP
+ClassImp(PWGJE::EMCALJetTasks::AliEmcalJetTaskV1);
+/// \endcond
+
+namespace PWGJE {
+
+namespace EMCALJetTasks {
+
+/**
+ * Default constructor. This constructor is only for ROOT I/O and
+ * not to be used by users.
+ */
+AliEmcalJetTaskV1::AliEmcalJetTaskV1() :
+  AliAnalysisTaskEmcal(),
+  fJetFinder(nullptr),
+  fJets(nullptr),
+  fJetsTag(),
+  fJetsName()
+{
+}
+
+/**
+ * Standard named constructor.
+ * @param name Name of the task.
+ */
+AliEmcalJetTaskV1::AliEmcalJetTaskV1(const char *name) :
+  AliAnalysisTaskEmcal(name),
+  fJetFinder(nullptr),
+  fJets(nullptr),
+  fJetsTag("Jets"),
+  fJetsName()
+{
+}
+
+/**
+ * Destructor
+ */
+AliEmcalJetTaskV1::~AliEmcalJetTaskV1()
+{
+  if(fJetFinder) delete fJetFinder;
+}
+
+
+/**
+ * This method is called for each event.
+ * @return Always kTRUE
+ */
+Bool_t AliEmcalJetTaskV1::Run()
+{
+  // clear the jet array (normally a null operation)
+  fJets->Delete();
+  fJetFinder->RunJetFinder(fJets);
+  Int_t n = fJets->GetEntriesFast();
+
+  if (n == 0) return kFALSE;
+
+  return kTRUE;
+}
+
+/**
+ * This method is called once before analzying the first event.
+ * It generates the output jet branch name, initializes the FastJet wrapper
+ * and the utilities (FJ contribs).
+ */
+void AliEmcalJetTaskV1::ExecOnce()
+{
+  fJetsName = AliJetContainer::GenerateJetName(fJetFinder->GetJetType(), fJetFinder->GetJetAlgo(), fJetFinder->GetRecombScheme(), fJetFinder->GetRadius(), fJetFinder->GetParticleContainer(0), fJetFinder->GetClusterContainer(0), fJetsTag);
+  std::cout << GetName() << ": Name of the jet container: " << fJetsName << std::endl;
+  std::cout << "Use this name in order to connect jet containers in your task to connect to the collection of jets found by this jet finder" << std::endl;
+  if(auto partcont = GetParticleContainer(0)) {
+    std::cout << "Found particle container with name " << partcont->GetName() << std::endl;
+  } else {
+    std::cout << "Not particle container found for task" << std::endl;
+  }
+  if(auto clustcont = GetClusterContainer(0)){
+    std::cout << "Found cluster container with name " << clustcont->GetName() << std::endl;
+  } else {
+    std::cout << "Not cluster container found for task" << std::endl;
+  }
+
+  // add jets to event if not yet there
+  if (!(InputEvent()->FindListObject(fJetsName))) {
+    fJets = new TClonesArray("AliEmcalJet");
+    fJets->SetName(fJetsName);
+    ::Info("AliEmcalJetTask::ExecOnce", "Jet collection with name '%s' has been added to the event.", fJetsName.Data());
+    InputEvent()->AddObject(fJets);
+  }
+  else {
+    AliError(Form("%s: Object with name %s already in event! Returning", GetName(), fJetsName.Data()));
+    return;
+  }
+
+  AliAnalysisTaskEmcal::ExecOnce();
+
+  fJetFinder->Init();
+
+  // Set the particle containers
+  for(auto pcont : fParticleCollArray)
+    fJetFinder->AppendParticleContainer(static_cast<AliParticleContainer *>(pcont));
+  for(auto ccont : fClusterCollArray)
+    fJetFinder->AppendClusterContainer(static_cast<AliClusterContainer *>(ccont));
+
+  fJetFinder->InitIndexMaps();
+}
+
+void AliEmcalJetTaskV1::RunChanged(Int_t runnumber) {
+  fJetFinder->SetRunNumber(runnumber);
+}
+
+/**
+ * Add an instance of this class to the analysis manager
+ * @param nTracks name of the track collection
+ * @param nClusters name of the calorimeter cluster collection
+ * @param jetAlgo jet finding algorithm (anti-kt, kt, etc.)
+ * @param radius jet resolution parameter (0.2, 0.4, tyc.)
+ * @param jetType full, charged or neutral
+ * @param minTrPt cut on the minimum transverse momentum of tracks
+ * @param minClPt cut on the minimum transverse momentum of calorimeter clusters
+ * @param ghostArea area of ghost particles (determines the jet area resolution)
+ * @param reco recombination scheme
+ * @param tag addtional information to be appended at the end of the output jet collection name
+ * @param minJetPt cut on the minimum jet pt
+ * @param lockTask lock the task - no further changes are possible if kTRUE
+ * @param bFillGhosts add ghosts particles among the jet constituents in the output
+ * @return a pointer to the new AliEmcalJetTask instance
+ */
+AliEmcalJetTaskV1* AliEmcalJetTaskV1::AddTaskEmcalJet(
+  const TString nTracks, const TString nClusters,
+  const AliJetContainer::EJetAlgo_t jetAlgo, const Double_t radius, const AliJetContainer::EJetType_t jetType,
+  const Double_t minTrPt, const Double_t minClPt,
+  const Double_t ghostArea, const AliJetContainer::ERecoScheme_t reco,
+  const TString tag, const Double_t minJetPt,
+  const Bool_t lockTask, const Bool_t bFillGhosts
+)
+{
+  // Get the pointer to the existing analysis manager via the static access method
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    ::Error("AddTaskEmcalJet", "No analysis manager to connect to.");
+    return 0;
+  }
+
+  // Check the analysis type using the event handlers connected to the analysis manager
+  AliVEventHandler* handler = mgr->GetInputEventHandler();
+  if (!handler) {
+    ::Error("AddTaskEmcalJet", "This task requires an input event handler");
+    return 0;
+  }
+
+  EDataType_t dataType = kUnknownDataType;
+
+  if (handler->InheritsFrom("AliESDInputHandler")) {
+    dataType = kESD;
+  }
+  else if (handler->InheritsFrom("AliAODInputHandler")) {
+    dataType = kAOD;
+  }
+
+  //-------------------------------------------------------
+  // Init the task and do settings
+  //-------------------------------------------------------
+
+  TString trackName(nTracks);
+  TString clusName(nClusters);
+
+  if (trackName == "usedefault") {
+    if (dataType == kESD) {
+      trackName = "Tracks";
+    }
+    else if (dataType == kAOD) {
+      trackName = "tracks";
+    }
+    else {
+      trackName = "";
+    }
+  }
+
+  if (clusName == "usedefault") {
+    if (dataType == kESD) {
+      clusName = "CaloClusters";
+    }
+    else if (dataType == kAOD) {
+      clusName = "caloClusters";
+    }
+    else {
+      clusName = "";
+    }
+  }
+
+  AliParticleContainer* partCont = 0;
+  if (trackName == "mcparticles") {
+    AliMCParticleContainer* mcpartCont = new AliMCParticleContainer(trackName);
+    partCont = mcpartCont;
+  }
+  else if (trackName == "tracks" || trackName == "Tracks") {
+    AliTrackContainer* trackCont = new AliTrackContainer(trackName);
+    partCont = trackCont;
+  }
+  else if (!trackName.IsNull()) {
+    partCont = new AliParticleContainer(trackName);
+  }
+  if (partCont) partCont->SetParticlePtCut(minTrPt);
+
+  AliClusterContainer* clusCont = 0;
+  if (!clusName.IsNull()) {
+    clusCont = new AliClusterContainer(clusName);
+    clusCont->SetClusECut(0.);
+    clusCont->SetClusPtCut(0.);
+    clusCont->SetClusHadCorrEnergyCut(minClPt);
+    clusCont->SetDefaultClusterEnergy(AliVCluster::kHadCorr);
+  }
+
+  switch (jetType) {
+  case AliJetContainer::kChargedJet:
+    if (partCont) partCont->SetCharge(AliParticleContainer::kCharged);
+    break;
+  case AliJetContainer::kNeutralJet:
+    if (partCont) partCont->SetCharge(AliParticleContainer::kNeutral);
+    break;
+  default:
+    break;
+  }
+
+  TString name = AliJetContainer::GenerateJetName(jetType, jetAlgo, reco, radius, partCont, clusCont, tag);
+
+  Printf("Jet task name: %s", name.Data());
+
+  auto mgrTask = static_cast<AliEmcalJetTaskV1 *>(mgr->GetTask(name.Data()));
+  if (mgrTask) return mgrTask;
+
+  auto jetTask = new AliEmcalJetTaskV1(name);
+  jetTask->GetJetFinder()->SetJetType(jetType);
+  jetTask->GetJetFinder()->SetJetAlgo(jetAlgo);
+  jetTask->GetJetFinder()->SetRecombScheme(reco);
+  jetTask->GetJetFinder()->SetRadius(radius);
+  if (partCont) jetTask->AdoptParticleContainer(partCont);
+  if (clusCont) jetTask->AdoptClusterContainer(clusCont);
+  jetTask->SetJetsTag(tag);
+  jetTask->GetJetFinder()->SetMinJetPt(minJetPt);
+  jetTask->GetJetFinder()->SetGhostArea(ghostArea);
+
+  if (bFillGhosts) jetTask->GetJetFinder()->SetFillGhost();
+  if (lockTask) jetTask->GetJetFinder()->SetLocked();
+
+  // Final settings, pass to manager and set the containers
+
+  mgr->AddTask(jetTask);
+
+  // Create containers for input/output
+  AliAnalysisDataContainer* cinput = mgr->GetCommonInputContainer();
+  mgr->ConnectInput(jetTask, 0, cinput);
+
+  return jetTask;
+}
+
+}
+
+}

--- a/PWGJE/EMCALJetTasks/AliEmcalJetTaskV1.h
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetTaskV1.h
@@ -1,0 +1,121 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIEMCALJETTASKV1_H
+#define ALIEMCALJETTASKV1_H
+
+#include "AliAnalysisTaskEmcal.h"
+#include "AliJetContainer.h"
+
+class TClonesArray;
+
+namespace fastjet {
+  class PseudoJet;
+}
+
+namespace PWGJE{
+
+namespace EMCALJetTasks {
+
+class AliEmcalJetFinderKernel;
+
+/**
+ * @class AliEmcalJetTaskV1
+ * @brief General jet finder task implementing a wrapper for FastJet
+ * @author Constantin Lozides <cloizides@lbl.gov>, Lawrence Berkeley National Laboratory
+ * @author Marta Verweij
+ * @author Salvatore Aiola <salvatore.aiola@cern.ch>, Yale University
+ *
+ * This class implements a wrapper for the FastJet jet finder. It allows
+ * to set a jet definition (jet algorithm, recombination scheme) and the
+ * list of jet constituents. Jet constituents are provided via multiple instances
+ * of AliParticleContainer and AliClusterContainer. These classes are delegated for
+ * applying cuts and filtering constituents that are then fed to the jet finder.
+ * This task will further filter constituents based on whether the jet was
+ * defined as being charged, neutral or full. The jet finding is delegated to
+ * the class AliFJWrapper which implements an interface to FastJet.
+ *
+ * The FastJet contrib utilities are available via the AliEmcalJetUtility base class
+ * and its derived classes. Utilities can be added via the AddUtility(AliEmcalJetUtility*) method.
+ * All the utilities added in the list will be executed. Users can implement new utilities
+ * deriving a new class from AliEmcalJetUtility to interface functionalities of the FastJet contribs.
+ */
+class AliEmcalJetTaskV1 : public AliAnalysisTaskEmcal {
+ public:
+  AliEmcalJetTaskV1();
+  AliEmcalJetTaskV1(const char *name);
+  virtual ~AliEmcalJetTaskV1();
+
+
+  TClonesArray            *GetJets()                      { return fJets; }
+  AliEmcalJetFinderKernel *GetJetFinder() const           { return fJetFinder; }
+  const TString           &GetJetsName() const            { return fJetsName; }
+  const TString           &GetJetsTag() const             { return fJetsTag; }
+
+  void SetJetsTag(const char *tag) { fJetsTag = tag; }
+
+  static AliEmcalJetTaskV1* AddTaskEmcalJet(
+      const TString nTracks                      = "usedefault",
+      const TString nClusters                    = "usedefault",
+      const AliJetContainer::EJetAlgo_t jetAlgo  = AliJetContainer::antikt_algorithm,
+      const Double_t radius                      = 0.4,
+      const AliJetContainer::EJetType_t jetType  = AliJetContainer::kFullJet,
+      const Double_t minTrPt                     = 0.15,
+      const Double_t minClPt                     = 0.30,
+      const Double_t ghostArea                   = 0.005,
+      const AliJetContainer::ERecoScheme_t reco  = AliJetContainer::pt_scheme,
+      const TString tag                          = "Jet",
+      const Double_t minJetPt                    = 0.,
+      const Bool_t lockTask                      = kTRUE,
+      const Bool_t bFillGhosts                   = kFALSE
+    );
+
+ protected:
+
+  Bool_t                 Run();
+  void                   ExecOnce();
+  void                   RunChanged(Int_t runnumber);
+
+ private:
+  AliEmcalJetFinderKernel  *fJetFinder;              ///< jet finder
+  TClonesArray             *fJets;                   //!<!jet collection
+  TString                   fJetsTag;                ///< tag of jet collection (usually = "Jets")
+  TString                   fJetsName;               //!<!name of jet collection
+
+
+ private:
+  AliEmcalJetTaskV1(const AliEmcalJetTaskV1&);            // not implemented
+  AliEmcalJetTaskV1 &operator=(const AliEmcalJetTaskV1&); // not implemented
+
+  /// \cond CLASSIMP
+  ClassDef(AliEmcalJetTaskV1, 1);
+  /// \endcond
+};
+
+}
+}
+
+#endif

--- a/PWGJE/EMCALJetTasks/CMakeLists.txt
+++ b/PWGJE/EMCALJetTasks/CMakeLists.txt
@@ -220,6 +220,8 @@ if(FASTJET_FOUND)
         AliEmcalJetUtilitySoftDrop.cxx
         AliEmcalJetTask.cxx
         AliEmcalJetFinder.cxx
+        AliEmcalJetFinderKernel.cxx
+        AliEmcalJetTaskV1.cxx
         AliJetEmbeddingFromAODTask.cxx
 	AliJetEmbeddingFromPYTHIATask.cxx
         AliJetShape.cxx

--- a/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
+++ b/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
@@ -226,6 +226,8 @@
 #pragma link C++ class AliEmcalJetUtilitySoftDrop+;
 #pragma link C++ class AliEmcalJetTask+;
 #pragma link C++ class AliEmcalJetFinder+;
+#pragma link C++ class PWGJE::EMCALJetTasks::AliEmcalJetFinderKernel+;
+#pragma link C++ class PWGJE::EMCALJetTasks::AliEmcalJetTaskV1+;
 #pragma link C++ class AliJetEmbeddingFromAODTask+;
 #pragma link C++ class AliJetEmbeddingFromPYTHIATask+;
 #pragma link C++ class AliAnalysisTaskEmcalQGTagging+;


### PR DESCRIPTION
- AliEmcalJetFinderKernel: Finding jets from input particles and filling
  TClonesArray (needs to handle input containers as well)
- AliEmcalJetTaskV1: Connect to input event and attachment of output
  array with jets to the input event

Long term goal: Drop AliEmcalJetTaskV1 in favour of jet finder kernels
which are attached by the consumer task to an
AliAnalysisTaskJetFinderManager. This is a multi-step procedure
1) Split of task and functionality (with backward-compatibility test)
2) Change handling of input chain so that the jet finding is a simple
function  (jet finder itself should not deal with input containers)
still using AliEmcalJetTask
3) Drop of AliEmcalJetTask with change of interface