### PR TITLE
EMCal CorrFW: Helper for accessing component

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.h
@@ -79,6 +79,7 @@ class AliEmcalCorrectionComponent : public TNamed {
   AliTrackContainer      *GetTrackContainer(const char* name)              const { return dynamic_cast<AliTrackContainer*>(GetParticleContainer(name))     ; }
   void                    RemoveParticleContainer(Int_t i=0)                     { fParticleCollArray.RemoveAt(i)                      ; }
   void                    RemoveClusterContainer(Int_t i=0)                      { fClusterCollArray.RemoveAt(i)                       ; }
+  AliEMCALRecoUtils      *GetRecoUtils()  const { return fRecoUtils; }
   AliVCaloCells          *GetCaloCells()  const { return fCaloCells; }
   TList                  *GetOutputList() const { return fOutput; }
   

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
@@ -1593,6 +1593,27 @@ void AliEmcalCorrectionTask::GetPropertyNamesFromNode(const std::string configur
 }
 
 /**
+ * Helper function to return a particular correction component. For example, it could be used for retrieving the
+ * currently loaded bad channel map. You are strongly advised _NOT_ to use this to configure a component!
+ *
+ * @param[in] name Correction component name (Usually the standard names of the components)
+ *
+ * @return The requested component (or nullptr if not found)
+ */
+AliEmcalCorrectionComponent * AliEmcalCorrectionTask::GetCorrectionComponent(const std::string & name) const
+{
+  AliEmcalCorrectionComponent * returnComponent = nullptr;
+  for (auto component : fCorrectionComponents)
+  {
+    if (name == component->GetName()) {
+      returnComponent = component;
+      break;
+    }
+  }
+  return returnComponent;
+}
+
+/**
  * Finds the desired cell container by name.
  *
  * @param cellsContainerName Name of the desired cells container

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
@@ -118,6 +118,7 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
    * reflected in the stored YAML configuration.
    */
   const std::vector<AliEmcalCorrectionComponent *> & CorrectionComponents() { return fCorrectionComponents; }
+  AliEmcalCorrectionComponent * GetCorrectionComponent(const std::string & name) const;
 
   // Containers and cells
   AliParticleContainer       *AddParticleContainer(const char *n)                   { return AliEmcalContainerUtils::AddContainer<AliParticleContainer>(n, fParticleCollArray); }


### PR DESCRIPTION
Helper function which enables users to more easily access a
particular component, allowing them to access data such as the bad
channel map from an outside task.

@jdmulligan - I'm adding this helper function requested by @nschmidtALICE to access the EMCal RecoUtils (and therefore the bad channel map) from an outside task. Let me know if you have any thoughts!