### PR TITLE
Make optional the symmetrization for results size reduction

### DIFF
--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSPairAnalysis.cxx
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliCSPairAnalysis.cxx
@@ -170,8 +170,10 @@ void AliCSPairAnalysis::ConfigureBinning(const char *confstring) {
 
   Double_t min_pt, max_pt, width_pt;
   Double_t min_eta, max_eta, width_eta;
+  Char_t buffer[24];
 
-  sscanf(confstring, "phishift:%lf;%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf",
+  sscanf(confstring, "halfsymm:%3s;phishift:%lf;%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf",
+      buffer,
       &fNBinsPhiShift,
       &fMin_vertexZ, &fMax_vertexZ, &fWidth_vertexZ,
       &min_pt, &max_pt, &width_pt,

--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliDptDptCorrelations.h
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliDptDptCorrelations.h
@@ -85,7 +85,9 @@ public:
 
 private:
   void                        ProcessLikeSignPairs(Int_t bank);
+  void                        ProcessNotHalfSymmLikeSignPairs(Int_t bank);
   void                        ProcessUnlikeSignPairs();
+  void                        ProcessNotHalfSymmUnlikeSignPairs();
 
   void                        fillHistoWithArray(TH1 * h, double * array, int size);
   void                        fillHistoWithArray(TH2 * h, double * array, int size1, int size2);
@@ -101,6 +103,7 @@ private:
   Int_t                       fIxVertexZ;                   ///< bin index for the current event vertex \f$z\f$ coordinate
   Float_t                     fCentrality;                  ///< current event centrality in percentage
 
+  Bool_t                      fHalfSymmetrize;              ///< kTRUE if half symmetrizing for memory layout reduction
   Bool_t                      fSinglesOnly;                 ///< kTRUE if not pair calculations, just single particle calculations
   Bool_t                      fUseWeights;                  ///< kTRUE if correction weights must be utilized
   Bool_t                      fUseSimulation;               ///< kTRUE if particle production from stored profiles must be used


### PR DESCRIPTION
Today the results size is reduced by only incorporating half of the symmetrized data. 
For some particular tests the results should not be symmetrized so, the possibility of symmetrize data is made optional via a configuration parameter. 