### PR TITLE
[WIP] User information handling in the track selection

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalAODHybridTrackCuts.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalAODHybridTrackCuts.h
@@ -27,7 +27,7 @@
 #ifndef ALIEMCALAODHYBRIDTRACKCUTS_H
 #define ALIEMCALAODHYBRIDTRACKCUTS_H
 
-#include "AliVCuts.h"
+#include "AliEmcalCutBase.h"
 
 namespace PWG {
 
@@ -46,7 +46,7 @@ namespace EMCAL {
  * fully relies on the function IsHybridTrackGlobalConstrainedGlobal from
  * AliAODTrack.
  */
- class AliEmcalAODHybridTrackCuts : public AliVCuts {
+ class AliEmcalAODHybridTrackCuts : public AliEmcalCutBase {
  public:
 
   /**
@@ -70,10 +70,9 @@ namespace EMCAL {
    * @brief Run track selection of hybrid tracks
    * 
    * @param o Object (AliAODTrack) to be tested
-   * @return true Track is an AliAODTrack and a hybrid track
-   * @return false Track is not an AliAODTrack or not a hybrid track
+   * @return Track selection result with the selection status and the hybrid track type
    */
-  virtual bool IsSelected(TObject *o);
+  virtual AliEmcalTrackSelResultPtr IsSelected(TObject *o);
 
   /**
    * @brief Switch on/off selection of hybrid tracks without ITSrefit
@@ -85,8 +84,20 @@ namespace EMCAL {
    */
   void SetSelectNonITSrefitTracks(bool doReject) { fSelectNonITSrefitTracks = doReject; }
 
+  /**
+   * @brief Set the filterbits used to distinguish the different hybrid track types
+   * 
+   * @param globalfilterbit Filterbit for global hybrid tracks
+   * @param constrainedfilterbit Filterbit for constrained hybrid tracks (+ non-refit hybrid tracks if available)
+   */
+  void SetHybridFilterBits(Int_t globalfilterbit, Int_t constrainedfilterbit) {
+    fHybridFilterBits[0] = globalfilterbit;
+    fHybridFilterBits[1] = constrainedfilterbit;
+  }
+
 private:
   Bool_t                            fSelectNonITSrefitTracks;  ///< Select non-refit tracks
+  Int_t                             fHybridFilterBits[2];      ///< Bit numbers for various hybrid filter bits
 
   /// \cond CLASSIMP
   ClassDef(AliEmcalAODHybridTrackCuts, 1);

--- a/PWG/EMCAL/EMCALbase/AliEmcalAODHybridTrackCuts.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalAODHybridTrackCuts.h
@@ -102,7 +102,106 @@ private:
   /// \cond CLASSIMP
   ClassDef(AliEmcalAODHybridTrackCuts, 1);
   /// \endcond
+};
+
+/**
+ * @class TestAliEmcalAODFilterBitCuts
+ * @brief Unit test for AOD hybrid track cuts
+ * @ingroup EMCALCOREFW
+ * @author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+ * @since Dec 18, 2017
+ * 
+ * Unit test class for AOD hybrid track cuts. Covering
+ * - 2010 definition with non-refit tracks
+ * - 2010 definition without non-refit tracks
+ * - 2011 definition
+ * In each test for each supported category one track is prepared as hybrid track of
+ * a given category, and one track is prepared as non-hybrid track. For passing the test
+ * in all cases the selection status must match (i.e. hybrid tracks true, non-hybrid tracks 
+ * false). In addition for hybrid tracks a user object of type AliEmcalTrackSelResultHybrid
+ * must be provided storing the correct track type. Non-hybrid track selection results must 
+ * not carry a user object.
+ */
+class TestAliEmcalAODHybridTrackCuts : public TObject {
+public:
+  TestAliEmcalAODHybridTrackCuts();
   
+  /**
+   * @brief Destructor
+   * 
+   * Deleting track selection objects
+   */
+  virtual ~TestAliEmcalAODHybridTrackCuts();
+
+  /**
+   * @brief Initializing track selection objects
+   */
+  void Init();
+
+  /**
+   * @brief Run all unit tests for the class AliEmcalAODHybridTrackCuts
+   * 
+   * @return true All tests passed
+   * @return false At least one failure observed
+   */
+  bool RunAllTests() const;
+
+  /**
+   * @brief Test for hybrid tracks according to the 2010 definition including non-refit tracks
+   * 
+   * Preparation of 4 AOD tracks
+   * 1) Hybrid flag set, refit true, cat 1 track
+   * 2) Hybrid flag set, refit true, cat 2 track
+   * 3) Hybrid flag set, refit false, cat 2 track
+   * 4) Hybrid flag not set
+   * Track selection must determine correcty the selection status and for true hybrid tracks also the category must match
+   * 
+   * @return true  All tests passed
+   * @return false At least one failure observed
+   */
+  bool TestDef2010wRefit() const;
+
+  /**
+   * @brief Test for hybrid tracks according to the 2010 definition excluding non-refit tracks
+   * 
+   * Preparation of 4 AOD tracks
+   * 1) Hybrid flag set, refit true, cat 1 track
+   * 2) Hybrid flag set, refit true, cat 2 track
+   * 3) Hybrid flag set, refit false, cat 2 track
+   * 4) Hybrid flag not set
+   * Track selection must determine correcty the selection status (excluding non-hybrid track and hybrid track without refit) 
+   * and for true hybrid tracks also the category must match
+   * 
+   * @return true  All tests passed
+   * @return false At least one failure observed
+   */
+  bool TestDef2010woRefit() const;
+
+  /**
+   * @brief Test for hybrid tracks according to the 2011 definition
+   * 
+   * Preparation of 3 AOD tracks
+   * 1) Hybrid flag set, cat 1 track
+   * 2) Hybrid flag set, cat 2 track
+   * 3) Hybrid flag not set
+   * Track selection must determine correctly the selection status and for true hybrid tracks also the category must match
+   * 
+   * @return true  All tests passed
+   * @return false At least one failure observed 
+   */
+  bool TestDef2011() const;
+
+private:
+  AliEmcalAODHybridTrackCuts    *fDef2010wRefit;        ///< Hybrid track definition from 2010 including non-refit tracks
+  AliEmcalAODHybridTrackCuts    *fDef2010woRefit;       ///< Hybrid track definition from 2010 excluding non-refit tracks
+  AliEmcalAODHybridTrackCuts    *fDef2011;              ///< Hybrid track definition from 2011 e
+
+  TestAliEmcalAODHybridTrackCuts(const TestAliEmcalAODHybridTrackCuts &);
+  TestAliEmcalAODHybridTrackCuts &operator=(const TestAliEmcalAODHybridTrackCuts &);
+
+  /// \cond CLASSIMP
+  ClassDef(TestAliEmcalAODHybridTrackCuts, 1);
+  /// \endcond
 };
 
 }

--- a/PWG/EMCAL/EMCALbase/AliEmcalAODTPCOnlyTrackCuts.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalAODTPCOnlyTrackCuts.cxx
@@ -1,0 +1,51 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include "AliAODTrack.h"
+#include "AliEmcalAODTPCOnlyTrackCuts.h"
+
+ClassImp(PWG::EMCAL::AliEmcalAODTPCOnlyTrackCuts)
+
+using namespace PWG::EMCAL;
+
+AliEmcalAODTPCOnlyTrackCuts::AliEmcalAODTPCOnlyTrackCuts():
+  AliEmcalCutBase()
+{
+
+}
+
+AliEmcalAODTPCOnlyTrackCuts::AliEmcalAODTPCOnlyTrackCuts(const char *name, const char *title):
+  AliEmcalCutBase()
+{
+
+}
+
+AliEmcalTrackSelResultPtr AliEmcalAODTPCOnlyTrackCuts::IsSelected(TObject *o) {
+  if(auto aodtrack = dynamic_cast<AliAODTrack *>(o)){
+    return AliEmcalTrackSelResultPtr(aodtrack, aodtrack->IsHybridTPCConstrainedGlobal());
+  }
+  return AliEmcalTrackSelResultPtr(nullptr, kFALSE);  // Not an AOD track
+}

--- a/PWG/EMCAL/EMCALbase/AliEmcalAODTPCOnlyTrackCuts.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalAODTPCOnlyTrackCuts.h
@@ -1,0 +1,83 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIEMCALTPCONLYTRACKCUTS_H
+#define ALIEMCALTPCONLYTRACKCUTS_H
+
+#include "AliEmcalCutBase.h"
+
+namespace PWG {
+
+namespace EMCAL {
+
+/**
+ * @class AliEmcalAODTPCOnlyTrackCuts
+ * @brief Virtual track selection for TPC-only tracks at AOD level
+ * @ingroup EMCALCOREFW
+ * @author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+ * @since Dec 12, 2017
+ * 
+ * Expression of the selection of TPC-only tracks at AOD-level via IsHybridTPCConstrainedGlobal
+ * as a virtual cut class implementing the AliEmcalCutBase interface.
+ */
+class AliEmcalAODTPCOnlyTrackCuts : public AliEmcalCutBase {
+public:
+  /**
+   * @brief Dummy constructor
+   */
+  AliEmcalAODTPCOnlyTrackCuts();
+
+  /**
+   * @brief Named constructor
+   * 
+   * @param name Name of the cut object
+   * @param title Title of the cut object
+   */
+  AliEmcalAODTPCOnlyTrackCuts(const char *name, const char *title);
+
+  /**
+   * @brief Destructor
+   */
+  virtual ~AliEmcalAODTPCOnlyTrackCuts() { }
+
+  /**
+   * @brief Selection of TPC-only hybrid tracks
+   * 
+   * Track is selected if IsHybridTPCConstrainedGlobal is fulfilled
+   * @param o Track to be selected
+   * @return Track result pointer with selection status true in case the track is a TPC-only track 
+   */
+  virtual AliEmcalTrackSelResultPtr IsSelected(TObject *o);
+
+  /// \cond CLASSIMP
+  ClassDef(AliEmcalAODTPCOnlyTrackCuts, 1);
+  /// \endcond
+};
+
+}
+
+}
+#endif

--- a/PWG/EMCAL/EMCALbase/AliEmcalCutBase.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalCutBase.cxx
@@ -1,0 +1,37 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include "AliEmcalCutBase.h"
+
+ClassImp(PWG::EMCAL::AliEmcalCutBase)
+
+using namespace PWG::EMCAL;
+
+AliEmcalCutBase::AliEmcalCutBase(const char *name, const char *title):
+  TNamed(name, title)
+{
+  
+}

--- a/PWG/EMCAL/EMCALbase/AliEmcalCutBase.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalCutBase.h
@@ -1,0 +1,74 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIEMCALCUTSBASE_H
+#define ALIEMCALCUTSBASE_H
+
+#include <TNamed.h>
+#include <AliEmcalTrackSelResultPtr.h>
+
+namespace PWG {
+
+namespace EMCAL {
+
+/**
+ * @class AliEmcalCutBase
+ * @brief Interface for a cut class returning selection status and user information
+ * @ingroup EMCALCOREFW
+ * @author: Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+ * @since Dec 11, 2017
+ * 
+ * This class extends the functionality of AliVCuts in the way that the cut implementation
+ * can add user information to the selection results: The method IsSelected of class AliVCuts
+ * returns a bool, representing whether an object was selected or not. For some selections,
+ * i.e. the hybrid track selection, where certain track types are defined, this is oversimplified.
+ * Instead one wants to return a selection status (track selected or not) and a user information
+ * which in case of hybrid tracks stores the hybrid track type. This is done using a smart pointer
+ * approach implemented in AliEmcalTrackSelResultPtr. 
+ * 
+ * User classes inheriting from AliEmcalCutBase must implement the function IsSelected(const TObject *),
+ * this time returning an AliEmcalTrackSelResultPtr with
+ * - Selection Status
+ * - Pointer to track processed
+ * - User information (optional)
+ */
+class AliEmcalCutBase : public TNamed {
+public:
+  AliEmcalCutBase() {}
+  AliEmcalCutBase(const char *name, const char *title);
+  virtual ~AliEmcalCutBase() {}
+
+  virtual AliEmcalTrackSelResultPtr IsSelected(TObject *o) = 0;
+
+private:
+
+  ClassDef(AliEmcalCutBase, 1);
+};
+
+}
+
+}
+#endif

--- a/PWG/EMCAL/EMCALbase/AliEmcalESDHybridTrackCuts.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalESDHybridTrackCuts.cxx
@@ -33,12 +33,17 @@
 #include "AliESDtrack.h"
 #include "AliESDtrackCuts.h"
 #include "AliEmcalESDHybridTrackCuts.h"
+#include "AliEmcalTrackSelResultHybrid.h"
 #include "AliLog.h"
+
+/// \cond CLASSIMP
+ClassImp(PWG::EMCAL::AliEmcalESDHybridTrackCuts)
+/// \endcond
 
 using namespace PWG::EMCAL;
 
 AliEmcalESDHybridTrackCuts::AliEmcalESDHybridTrackCuts():
-  AliVCuts(),
+  AliEmcalCutBase(),
   fLocalInitialized(kFALSE),
   fHybridTrackDefinition(kDef2010),
   fHybridTrackCutsGlobal(nullptr),
@@ -49,7 +54,7 @@ AliEmcalESDHybridTrackCuts::AliEmcalESDHybridTrackCuts():
 }
 
 AliEmcalESDHybridTrackCuts::AliEmcalESDHybridTrackCuts(const char *name, HybridDefinition_t hybriddef):
-  AliVCuts(name, ""),
+  AliEmcalCutBase(name, ""),
   fLocalInitialized(kFALSE),
   fHybridTrackDefinition(hybriddef),
   fHybridTrackCutsGlobal(nullptr),
@@ -65,18 +70,22 @@ AliEmcalESDHybridTrackCuts::~AliEmcalESDHybridTrackCuts(){
   if(fHybridTrackCutsNoItsRefit) delete fHybridTrackCutsNoItsRefit;
 }
 
-bool AliEmcalESDHybridTrackCuts::IsSelected(TObject *o){
+AliEmcalTrackSelResultPtr AliEmcalESDHybridTrackCuts::IsSelected(TObject *o){
   AliDebugStream(1) << "AliEmcalESDHybridTrackCuts::IsSelected(): Called" << std::endl;
   if(!fLocalInitialized) Init();
   if(auto esdtrack = dynamic_cast<AliESDtrack *>(o)) {
-    bool selected[3] = {false, false, false};
-    if(fHybridTrackCutsGlobal && fHybridTrackCutsGlobal->AcceptTrack(esdtrack)) selected[0] = true;
-    if(fHybridTrackCutsConstrained && fHybridTrackCutsConstrained->AcceptTrack(esdtrack)) selected[1] = true;
-    if(fHybridTrackCutsNoItsRefit && fHybridTrackCutsNoItsRefit->AcceptTrack(esdtrack)) selected[2]= true;
-    return selected[0] || selected[1] || selected[2];
+    AliEmcalTrackSelResultHybrid::HybridType_t tracktype = AliEmcalTrackSelResultHybrid::kUndefined;
+    if(fHybridTrackCutsGlobal && fHybridTrackCutsGlobal->AcceptTrack(esdtrack)) tracktype = AliEmcalTrackSelResultHybrid::kHybridGlobal;
+    else
+    {
+      if(fHybridTrackCutsConstrained && fHybridTrackCutsConstrained->AcceptTrack(esdtrack)) tracktype = AliEmcalTrackSelResultHybrid::kHybridConstrained;
+      else if(fHybridTrackCutsNoItsRefit && fHybridTrackCutsNoItsRefit->AcceptTrack(esdtrack)) tracktype = AliEmcalTrackSelResultHybrid::kHybridConstrainedNoITSrefit;
+    }
+    AliEmcalTrackSelResultPtr result(esdtrack, tracktype != AliEmcalTrackSelResultHybrid::kUndefined);
+    return result;
   }
   AliErrorStream() << "No ESD track" << std::endl;
-  return false;
+  return AliEmcalTrackSelResultPtr(nullptr, kFALSE);
 }
 
 void AliEmcalESDHybridTrackCuts::Init(){

--- a/PWG/EMCAL/EMCALbase/AliEmcalESDHybridTrackCuts.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalESDHybridTrackCuts.h
@@ -27,7 +27,7 @@
 #ifndef ALIEMCALESDHYBRIDTRACKCUTS_H
 #define ALIEMCALESDHYBRIDTRACKCUTS_H
 
-#include "AliVCuts.h"
+#include "AliEmcalCutBase.h"
 
 class AliESDtrackCuts;
 
@@ -47,7 +47,7 @@ namespace EMCAL {
  * cathegories (global, constrained, complementary), and a track is selected 
  * as hybrid track if at least one of the three cases is fulfilled.
  */
-class AliEmcalESDHybridTrackCuts : public AliVCuts {
+class AliEmcalESDHybridTrackCuts : public AliEmcalCutBase {
 public:
   
   /**
@@ -84,7 +84,7 @@ public:
    * @return true Track is accepted as hybrid track
    * @return false Track is not accepted as hybrid track or track is not an AliESDtrack
    */
-  virtual bool IsSelected(TObject *o);
+  virtual AliEmcalTrackSelResultPtr IsSelected(TObject *o);
 
   /**
    * @brief Set the hybrid track definition used in the hybrid track selection

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultCombined.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultCombined.cxx
@@ -1,0 +1,57 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <TObjArray.h>
+#include "AliEmcalTrackSelResultCombined.h"
+
+/// \cond CLASSIMP
+ClassImp(PWG::EMCAL::AliEmcalTrackSelResultCombined)
+/// \endcond
+
+using namespace PWG::EMCAL;
+
+AliEmcalTrackSelResultCombined::AliEmcalTrackSelResultCombined():
+  TObject(),
+  fData()
+{
+
+}
+
+AliEmcalTrackSelResultCombined::AliEmcalTrackSelResultCombined(std::vector<AliEmcalTrackSelResultPtr> singleSelPointers):
+  TObject(),
+  fData()
+{
+  for(auto o  : singleSelPointers) fData.Add(new AliEmcalTrackSelResultPtr(o));
+}
+
+AliEmcalTrackSelResultPtr &AliEmcalTrackSelResultCombined::operator[](int index) const {
+  if(index < 0 || index >= fData.GetEntriesFast()) throw IndexException(index);
+  return *(static_cast<AliEmcalTrackSelResultPtr *>(fData.At(index)));
+}
+
+Int_t AliEmcalTrackSelResultCombined::GetNumberOfSelectionResults() const {
+  return fData.GetEntriesFast();
+}

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultCombined.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultCombined.cxx
@@ -24,7 +24,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
  ************************************************************************************/
-#include <TObjArray.h>
 #include "AliEmcalTrackSelResultCombined.h"
 
 /// \cond CLASSIMP
@@ -40,11 +39,11 @@ AliEmcalTrackSelResultCombined::AliEmcalTrackSelResultCombined():
 
 }
 
-AliEmcalTrackSelResultCombined::AliEmcalTrackSelResultCombined(std::vector<AliEmcalTrackSelResultPtr> singleSelPointers):
+AliEmcalTrackSelResultCombined::AliEmcalTrackSelResultCombined(const TObjArray &singleSelPointers):
   TObject(),
   fData()
 {
-  for(auto o  : singleSelPointers) fData.Add(new AliEmcalTrackSelResultPtr(o));
+  for(auto o  : singleSelPointers) fData.Add(new AliEmcalTrackSelResultPtr(*(static_cast<AliEmcalTrackSelResultPtr *>(o))));
 }
 
 AliEmcalTrackSelResultPtr &AliEmcalTrackSelResultCombined::operator[](int index) const {

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultCombined.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultCombined.h
@@ -28,10 +28,10 @@
 #define ALIEMCALTRACKSELRESULTCOMBINED_H
 
 #include <TObject.h>
+#include <TObjArray.h>
 #include <exception>
 #include <sstream>
 #include <string>
-#include <vector>
 #include "AliEmcalTrackSelResultPtr.h"
 
 class TObjArray;
@@ -60,7 +60,7 @@ public:
   };
   
   AliEmcalTrackSelResultCombined();
-  AliEmcalTrackSelResultCombined(std::vector<AliEmcalTrackSelResultPtr> singleSelPointers);
+  AliEmcalTrackSelResultCombined(const TObjArray &singleSelPointers);
   virtual ~AliEmcalTrackSelResultCombined() {}
 
   AliEmcalTrackSelResultPtr &operator[](int index) const;

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultCombined.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultCombined.h
@@ -1,0 +1,80 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIEMCALTRACKSELRESULTCOMBINED_H
+#define ALIEMCALTRACKSELRESULTCOMBINED_H
+
+#include <TObject.h>
+#include <exception>
+#include <sstream>
+#include <string>
+#include <vector>
+#include "AliEmcalTrackSelResultPtr.h"
+
+class TObjArray;
+
+namespace PWG {
+
+namespace EMCAL {
+
+class AliEmcalTrackSelResultCombined : public TObject {
+public:
+  class IndexException : public std::exception {
+  public:
+    IndexException(int index) : std::exception(), fIndex(index), fText() {
+      std::stringstream msgbuilder;
+      msgbuilder << "Index " << index << " out of range.";
+      fText = msgbuilder.str();
+    }
+    virtual ~IndexException() throw () {}
+
+    const char *what() const throw() { return fText.data(); }
+    int GetIndex() const { return fIndex; }
+
+  private:
+    int fIndex;
+    std::string fText;
+  };
+  
+  AliEmcalTrackSelResultCombined();
+  AliEmcalTrackSelResultCombined(std::vector<AliEmcalTrackSelResultPtr> singleSelPointers);
+  virtual ~AliEmcalTrackSelResultCombined() {}
+
+  AliEmcalTrackSelResultPtr &operator[](int index) const;
+  Int_t GetNumberOfSelectionResults() const;
+
+private:
+  TObjArray                   fData;    ///< Single 
+
+  /// \cond CLASSIMP
+  ClassDef(AliEmcalTrackSelResultCombined, 1);
+  /// \endcond
+};
+
+}
+
+}
+#endif

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultHybrid.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultHybrid.cxx
@@ -1,0 +1,47 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include "AliEmcalTrackSelResultHybrid.h"
+
+/// \cond CLASSIMP
+ClassImp(PWG::EMCAL::AliEmcalTrackSelResultHybrid)
+/// \endcond
+
+using namespace PWG::EMCAL;
+
+AliEmcalTrackSelResultHybrid::AliEmcalTrackSelResultHybrid() :
+  TObject(),
+  fHybridTrackType(kUndefined)
+{
+
+}
+
+AliEmcalTrackSelResultHybrid::AliEmcalTrackSelResultHybrid(HybridType_t tracktype):
+  TObject(),
+  fHybridTrackType(tracktype)
+{
+  
+}

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultHybrid.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultHybrid.h
@@ -1,0 +1,62 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIEMCALTRACKSELRESULTHYBRID_H
+#define ALIEMCALTRACKSELRESULTHYBRID_H
+
+#include <TObject.h>
+
+namespace PWG {
+
+namespace EMCAL {
+
+class AliEmcalTrackSelResultHybrid : public TObject {
+public:
+  enum HybridType_t {
+    kUndefined,
+    kHybridGlobal,
+    kHybridConstrained,
+    kHybridConstrainedNoITSrefit
+  };
+  AliEmcalTrackSelResultHybrid();
+  AliEmcalTrackSelResultHybrid(HybridType_t tracktype);
+  virtual ~AliEmcalTrackSelResultHybrid() {}
+
+  void SetHybridTrackType(HybridType_t tracktype) { fHybridTrackType = tracktype; }
+  HybridType_t GetHybridTrackType() const { return fHybridTrackType; }
+
+private:
+  HybridType_t                  fHybridTrackType;           ///< Hybrid track type
+
+  /// \cond CLASSIMP
+  ClassDef(AliEmcalTrackSelResultHybrid, 1);
+  /// \endcond
+};
+
+}
+}
+
+#endif

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultPtr.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultPtr.cxx
@@ -133,7 +133,7 @@ void AliEmcalTrackSelResultPtr::PrintStream(std::ostream &stream) const {
           << ", HasUserInfo: " << (fUserInfo.GetData() ? "Yes" : "No");
 }
 
-std::ostream &operator<<(std::ostream &stream, const AliEmcalTrackSelResultPtr &o){
+std::ostream &PWG::EMCAL::operator<<(std::ostream &stream, const PWG::EMCAL::AliEmcalTrackSelResultPtr &o){
   o.PrintStream(stream);
   return stream;
 }

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultPtr.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultPtr.cxx
@@ -25,6 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
  ************************************************************************************/
 #include <iostream>
+#include <TNamed.h> // for user object
 #include "AliEmcalTrackSelResultPtr.h"
 #include "AliVTrack.h"
 
@@ -32,6 +33,7 @@
 ClassImp(PWG::EMCAL::AliEmcalTrackSelResultPtr)
 ClassImp(PWG::EMCAL::AliEmcalTrackSelResultUserPtr)
 ClassImp(PWG::EMCAL::AliEmcalTrackSelResultUserStorage)
+ClassImp(PWG::EMCAL::TestAliEmcalTrackSelResultPtr)
 /// \endcond
 
 using namespace PWG::EMCAL;
@@ -241,4 +243,71 @@ AliEmcalTrackSelResultUserPtr::~AliEmcalTrackSelResultUserPtr(){
     // The last pointer connected to the storage deletes it
     if(fUserStorage->GetReferenceCount() < 1) delete fUserStorage;
   }
+}
+
+bool TestAliEmcalTrackSelResultPtr::RunAllTests() const {
+  return TestOperatorBool() && TestUserInfo() && TestCopyConstructor() && TestOperatorAssign();
+}
+
+bool TestAliEmcalTrackSelResultPtr::TestOperatorBool() const {
+  AliEmcalTrackSelResultPtr testtrue(nullptr, true), testfalse(nullptr, false);
+
+  bool testresult(true);
+  if(!(testtrue == true)) testresult = false;
+  if(testfalse == true) testresult = false;
+  return testresult;
+}
+
+bool TestAliEmcalTrackSelResultPtr::TestCopyConstructor() const {
+  int failure(0);
+  for(int i = 0; i < 10; i++) {
+    TNamed *payloadTrue = new TNamed("truewith", "true, with object"), 
+           *payloadFalse = new TNamed("falsewith", "false, with user object");
+    AliEmcalTrackSelResultPtr truewith(nullptr, true, payloadTrue),
+                              truewithout(nullptr, true),
+                              falsewith(nullptr, false, payloadFalse),
+                              falsewithout(nullptr, false);
+    // make copies
+    AliEmcalTrackSelResultPtr cpytruewith(truewith), cpyfalsewith(falsewith), cpytruewithout(truewithout), cpyfalsewithout(falsewithout);
+    if(!(AssertBool(cpytruewith, true) && AssertBool(cpytruewithout, true) && AssertBool(cpyfalsewith, false) && AssertBool(cpyfalsewithout, false))) failure++;
+    if(!(AssertPayload(cpytruewith, payloadTrue) && AssertPayload(cpytruewithout, nullptr) && AssertPayload(cpyfalsewith, payloadFalse) && AssertPayload(cpyfalsewithout, nullptr))) failure++;
+  }
+  return failure == 0;
+}
+
+bool TestAliEmcalTrackSelResultPtr::TestOperatorAssign() const {
+  int failure(0);
+  for(int i = 0; i < 10; i++) {
+    TNamed *payloadTrue = new TNamed("truewith", "true, with object"), 
+           *payloadFalse = new TNamed("falsewith", "false, with user object");
+    AliEmcalTrackSelResultPtr truewith(nullptr, true, payloadTrue),
+                              truewithout(nullptr, true),
+                              falsewith(nullptr, false, payloadFalse),
+                              falsewithout(nullptr, false);
+    // make assignments
+    AliEmcalTrackSelResultPtr asgtruewith = truewith, asgfalsewith = falsewith, asgtruewithout = truewithout, asgfalsewithout = falsewithout;
+    if(!(AssertBool(asgtruewith, true) && AssertBool(asgtruewithout, true) && AssertBool(asgfalsewith, false) && AssertBool(asgfalsewithout, false))) failure++;
+    if(!(AssertPayload(asgtruewith, payloadTrue) && AssertPayload(asgtruewithout, nullptr) && AssertPayload(asgfalsewith, payloadFalse) && AssertPayload(asgfalsewithout, nullptr))) failure++;
+  }
+  return failure == 0;
+}
+
+bool TestAliEmcalTrackSelResultPtr::TestUserInfo() const {
+  int failure(0);
+  for(int i = 0; i < 10; i++) {
+    AliEmcalTrackSelResultPtr testwith(nullptr, true, new TNamed("testuserobject", "Test userobject"));
+    if(!testwith.GetUserInfo()) failure++;
+
+    AliEmcalTrackSelResultPtr testwithout(nullptr, true);
+    if(testwithout.GetUserInfo()) failure++;
+  }
+  return failure == 0;
+}
+
+bool TestAliEmcalTrackSelResultPtr::AssertBool(const AliEmcalTrackSelResultPtr &test, bool assertval) const {
+  return test.GetSelectionResult() == assertval;
+}
+
+bool TestAliEmcalTrackSelResultPtr::AssertPayload(const AliEmcalTrackSelResultPtr &test, void *payload) const {
+  return test.GetUserInfo() == reinterpret_cast<const TObject *>(payload);
 }

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultPtr.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultPtr.h
@@ -408,6 +408,100 @@ protected:
   /// \endcond
 };
 
+/**
+ * @class TestAliEmcalTrackSelResultPtr
+ * @brief Unit test for class AliEmcalTrackSelResultPtr
+ * @ingroup EMCALCOREFW
+ * @author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+ * @since Dec 18, 2017
+ * 
+ * Unit test for AliEmcalTrackSelResultPtr, covering
+ * - operator bool
+ * - Copy constructor
+ * - Assignment operator
+ * - user info
+ */
+class TestAliEmcalTrackSelResultPtr : public TObject {
+public:
+  /**
+   * @brief Constructor
+   */
+  TestAliEmcalTrackSelResultPtr() {}
+
+  /**
+   * @brief Destructor
+   */
+  virtual ~TestAliEmcalTrackSelResultPtr() {}
+
+  /**
+   * @brief Run test suite
+   * 
+   * Running all unit tests implemented for AliEmcalTrackSelResultPtr
+   * - operator bool
+   * - Assignment operator
+   * - Copy constructor
+   * - User information 
+   * 
+   * @return true All tests passed
+   * @return false At least one test failed
+   */
+  bool RunAllTests() const;
+
+  /**
+   * @brief Test for operator bool
+   * 
+   * Both cases tested:
+   * - track selection is true, operator must return true
+   * - track selection is false, operator must return false
+   * 
+   * @return true Test passed
+   * @return false Test failed
+   */
+  bool TestOperatorBool() const;
+
+  /**
+   * @brief Test copy constructor with user information
+   * 
+   * Test prepared with 10 instances of user objects and 10 instances without user objects
+   * 
+   * @return true All tests passed
+   * @return false At least one test failed
+   */
+  bool TestCopyConstructor() const;
+
+  /**
+   * @brief Tests assignment operatator with user info
+   * 
+   * Test prepared with 10 instances of user objects and 10 instances without user objects
+   * 
+   * @return true All tests passed
+   * @return false All tests failed
+   */
+  bool TestOperatorAssign() const;
+
+  /**
+   * @brief Test handling of user storage
+   * 
+   * Prepared 10 pointers with and 10 without storage. Pointer must return
+   * - user object for test with user object
+   * - nullptr for test without user object
+   * 
+   * @return true Tests passed
+   * @return false At least one test failed
+   */
+  bool TestUserInfo() const;
+
+protected:
+
+  bool AssertBool(const AliEmcalTrackSelResultPtr &test, bool testvalue) const;
+
+  bool AssertPayload(const AliEmcalTrackSelResultPtr &test, void *payload) const;
+
+  /// \cond CLASSIMP
+  ClassDef(TestAliEmcalTrackSelResultPtr, 1);
+  /// \endcond
+};
+
 }
 
 }

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultPtr.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultPtr.h
@@ -1,12 +1,220 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #ifndef ALIEMCALTRACKSELRESULTPTR_H
 #define ALIEMCALTRACKSELRESULTPTR_H
-/* Copyright(c) 1998-2015, ALICE Experiment at CERN, All rights reserved. *
- * See cxx source for full Copyright notice                               */
 
 #include <TObject.h>
 #include <iosfwd>
 
 class AliVTrack;
+
+namespace PWG {
+
+namespace EMCAL {
+
+/**
+ * @class AliEmcalTrackSelResultUserStorage
+ * @brief Helper class handling the lifetime of the user object handled by AliEmcalTrackSelResultUserPtr
+ * @ingroup EMCALCOREFW
+ * @author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+ * @since Dec 11, 2017
+ * 
+ * Common storage class for multiple instances of AliEmcalTrackSelResultUserPointers.
+ * Together with the data the storage keeps track of the number of pointer instances
+ * connected to it via the reference count. Instances can connect and disconnect
+ * by the functions Connect and Release.
+ * 
+ * This class is foreseen to be used only from within AliEmcalTrackSelResultUserPtr.
+ */
+class AliEmcalTrackSelResultUserStorage : public TObject {
+public:
+  AliEmcalTrackSelResultUserStorage();
+  
+  /**
+   * @brief Main constructor
+   * 
+   * Sets the data and the reference count to 1
+   * @param data 
+   */
+  AliEmcalTrackSelResultUserStorage(TObject *data);
+  
+  /**
+   * @brief Destructor
+   * 
+   * Deletes the data associated to the storage. Only to be used
+   * from within AliEmcalTrackSelResultUserPtr
+   */
+  virtual ~AliEmcalTrackSelResultUserStorage();
+  
+  /**
+   * @brief Connect new user pointer instance to the storage
+   * 
+   * Used in the copy constructor and assignment operator of 
+   * AliEmcalTrackSelResultUserPtr. This function is there in
+   * order to tell then storage that a new user pointer instance
+   * has connected to the storage. Increases the reference count.
+   * Not to be used outside of class AliEmcalTrackSelResultUserPtr
+   */
+  void Connect();
+
+  /**
+   * @brief Release user pointer from the storage
+   * 
+   * Used in the destructor of AliEmcalTrackSelUserPtr. This
+   * function is there in order to tell the storage that
+   * a user pointer instance has disconnected. Reduces the
+   * reference count. Not to be called ountside of class 
+   * AliEmcalTrackSelResultUserPtr.
+   */
+  void Release();
+
+  /**
+   * @brief Get the number of pointer instances connected to the storage
+   * 
+   * @return Number of pointer instances connected to the storage
+   */
+  Int_t GetReferenceCount() const { return fReferenceCount; }
+
+  /**
+   * @brief Get the user data handled by the storage
+   * 
+   * @return User data handled by the storage
+   */
+  TObject *GetData() const { return fData; }
+
+private:
+  AliEmcalTrackSelResultUserStorage(const AliEmcalTrackSelResultUserStorage &);
+  AliEmcalTrackSelResultUserStorage(const AliEmcalTrackSelResultUserStorage &&);
+  AliEmcalTrackSelResultUserStorage &operator=(const AliEmcalTrackSelResultUserStorage &);
+  AliEmcalTrackSelResultUserStorage &operator=(const AliEmcalTrackSelResultUserStorage &&);
+  TObject           *fData;               ///< User data
+  Int_t             fReferenceCount;      ///< Reference counter
+
+  /// \cond CLASSIMP
+  ClassDef(AliEmcalTrackSelResultUserStorage, 1);
+  /// \endcond
+};
+
+/**
+ * @class AliEmcalTrackSelResultUserPtr 
+ * @brief Handler for user objects attached to the track selection result ptr 
+ * @ingroup EMCALCOREFW
+ * @author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+ * @since Dec 11, 2017
+ *
+ * Handling the lifetime of the object attached to the AliEmcalTrackSelResultPtr
+ * using reference counting technique. Pointer instances created from the current
+ * pointer using the copy constructor or assignment operator connect to the 
+ * common storage and disconnect once they are constructed. The last instance connected
+ * to a storage deletes it.
+ * 
+ * This class is foreseen to be used only from within AliEmcalTrackSelResultPtr.
+ */
+class AliEmcalTrackSelResultUserPtr : public TObject {
+public:
+  /**
+   * @brief Dummy constructor
+   * 
+   * Not handling object
+   */
+  AliEmcalTrackSelResultUserPtr();
+
+  /**
+   * @brief Main constructor setting the data
+   * 
+   * Allocating the storage for the data hanlding and initializes
+   * the reference count
+   * 
+   * @param o Object to be handled by the user pointer
+   */
+  AliEmcalTrackSelResultUserPtr(TObject *o);
+
+  /**
+   * @brief Copy constructor
+   * 
+   * Creating a new pointer instance connected to the same storage
+   * 
+   * @param ref Reference for the copy
+   */
+  AliEmcalTrackSelResultUserPtr(const AliEmcalTrackSelResultUserPtr &ref);
+
+  /**
+   * @brief Move constructor
+   * 
+   * Only transferring the storage, has no consequence on the reference count
+   * 
+   * @param ref Object to be moved
+   */
+  AliEmcalTrackSelResultUserPtr(AliEmcalTrackSelResultUserPtr &&ref);
+
+  /**
+   * @brief Assignment operator
+   * 
+   * Connecting pointer instance to the storage connected to by ref. In
+   * case the pointer handles a storage itself disconnects from the storage
+   * 
+   * @param ref Reference for assignment
+   * @return Pointer instance after assignment
+   */
+  AliEmcalTrackSelResultUserPtr &operator=(const AliEmcalTrackSelResultUserPtr &ref);
+
+  /**
+   * @brief Move assignment operator
+   * 
+   * Connecting pointer instance to the storage connected to by ref. In
+   * case the pointer handles a storage itself disconnects from the storage
+   * 
+   * @param ref Object to be moved
+   * @return Pointer instance after move
+   */
+  AliEmcalTrackSelResultUserPtr &operator=(AliEmcalTrackSelResultUserPtr &&ref);
+
+  /**
+   * @brief Destructor
+   * 
+   * Disconnects pointer instance from the common storage. If it is the last
+   * pointer instance conneted to the storage deletes the storage as well.
+   */
+  virtual ~AliEmcalTrackSelResultUserPtr();
+
+  /**
+   * @brief Get the object handled by the storage
+   * 
+   * @return User object handled by the pointer if storage exists, nullptr otherwise 
+   */
+  TObject *GetData() const { return fUserStorage ? fUserStorage->GetData() : nullptr; }
+
+private:
+  AliEmcalTrackSelResultUserStorage         *fUserStorage;        ///< Underlying user storage for reference counting
+
+  /// \cond CLASSIMP
+  ClassDef(AliEmcalTrackSelResultUserPtr, 1);
+  /// \endcond
+};
 
 /**
  * @class AliEmcalTrackSelResultPtr
@@ -19,7 +227,7 @@ class AliVTrack;
  * of further information is stored.
  * - The track object itself
  * - Its selection status (true - selected, false - rejected)
- * - A flag (bitmap) determining a track category
+ * - A user-info object (of type TObject) for additional information
  * - Rejection reason
  *
  * Access to the original track is done via the operators * and ->. Using the operator->
@@ -46,17 +254,19 @@ public:
    * Default values:
    * - Track: nullptr
    * - Selection status: false
-   * - Flag: 0
+   * - User object: nullptr
    */
   AliEmcalTrackSelResultPtr();
 
   /**
    * Constructor, fully initializing the result with a track pointer,
+   * 
+   * Taking 
    * @param[in] trk Pointer to the original track
    * @param[in] selectionStatus Status of the selection (true - selected, false - rejected)
-   * @param[in] flag Flag for a track category (optional, default: 0)
+   * @param[in] userobject User information defined by the track selection (default: nullptr)
    */
-  AliEmcalTrackSelResultPtr(AliVTrack *trk, Bool_t selectionStatus, ULong_t flag = 0);
+  AliEmcalTrackSelResultPtr(AliVTrack *trk, Bool_t selectionStatus, TObject *userobject = nullptr);
 
   /**
    * Copy constructor, copying infromation (for track pointer only the pointer itself)
@@ -87,7 +297,7 @@ public:
   AliEmcalTrackSelResultPtr &operator=(AliEmcalTrackSelResultPtr &&ref);
 
   /**
-   * Destructor, nothing to do
+   * @brief Destructor
    */
   virtual ~AliEmcalTrackSelResultPtr() {}
 
@@ -153,7 +363,7 @@ public:
   void PrintStream(std::ostream &stream) const;
 
   /**
-   *
+   * @brief Set the track object handled by the track selection
    * @param track
    */
   void SetTrack(AliVTrack *track) { fTrack = track; }
@@ -168,7 +378,7 @@ public:
    * Set the track category flag
    * @param flag Flag assigned to the track
    */
-  void SetFlag(ULong_t flag) { fFlag = flag; }
+  void SetUserInfo(TObject *userinfo) { fUserInfo = AliEmcalTrackSelResultUserPtr(userinfo); }
 
   /**
    * Access to underlying track
@@ -178,9 +388,9 @@ public:
 
   /**
    * Get the flag assigned to the track selection status
-   * @return Track flag
+   * @return User information
    */
-  ULong_t GetFlag() const { return fFlag; }
+  const TObject *GetUserInfo() const { return fUserInfo.GetData(); }
 
   /**
    * Get the track selection status
@@ -191,20 +401,15 @@ public:
 protected:
   AliVTrack                               *fTrack;            ///< Pointer to selected track
   Bool_t                                   fSelectionResult;  ///< Result of the track selection (true - selected, false - rejected)
-  ULong_t                                  fFlag;             ///< Selection flag (optional)
+  AliEmcalTrackSelResultUserPtr            fUserInfo;         ///< Selection flag (optional)
 
   /// \cond CLASSIMP
   ClassDef(AliEmcalTrackSelResultPtr, 1);
   /// \endcond
 };
 
-/**
- * Streaming operator, print content of the track selection result to the
- * stream
- * @param stream Stream for the printing
- * @param ref Object to be streamed
- * @return Reference to the original stream after printing the object
- */
-std::ostream &operator<<(std::ostream &stream, const AliEmcalTrackSelResultPtr &ref);
+}
+
+}
 
 #endif /* ALIEMCALTRACKSELRESULTPTR_H */

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultPtr.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultPtr.h
@@ -274,11 +274,13 @@ public:
    */
   AliEmcalTrackSelResultPtr(const AliEmcalTrackSelResultPtr &ref);
 
+#if !defined(__CINT__) && !defined(__MAKECINT__)
   /**
    * Move constructor, implements move procedure for track selection results
    * @param[in] ref Pointer to be moved
    */
   AliEmcalTrackSelResultPtr(AliEmcalTrackSelResultPtr &&ref);
+#endif
 
   /**
    * Assignment operator, copies information from a reference into this object. As
@@ -288,6 +290,7 @@ public:
    */
   AliEmcalTrackSelResultPtr &operator=(const AliEmcalTrackSelResultPtr &ref);
 
+#if !defined(__CINT__) && !defined (__MAKECINT__)
   /**
    * Move assignment operator, copies information from a reference into this object. As
    * for the copy and move constructor only
@@ -295,6 +298,7 @@ public:
    * @return Object after assignment
    */
   AliEmcalTrackSelResultPtr &operator=(AliEmcalTrackSelResultPtr &&ref);
+#endif
 
   /**
    * @brief Destructor
@@ -347,14 +351,6 @@ public:
    */
   operator bool() const { return fSelectionResult; }
 
-  /**
-   * Streaming operator, print content of the track selection result to the
-   * stream
-   * @param stream Stream for the printing
-   * @param ref Object to be streamed
-   * @return Reference to the original stream after printing the object
-   */
-  friend std::ostream &operator<<(std::ostream &stream, const AliEmcalTrackSelResultPtr &ref);
 
   /**
    * Create a stream representation of the object and put it on then stream;
@@ -407,6 +403,15 @@ protected:
   ClassDef(AliEmcalTrackSelResultPtr, 1);
   /// \endcond
 };
+
+/**
+ * Streaming operator, print content of the track selection result to the
+ * stream
+ * @param stream Stream for the printing
+ * @param ref Object to be streamed
+ * @return Reference to the original stream after printing the object
+ */
+std::ostream &operator<<(std::ostream &stream, const AliEmcalTrackSelResultPtr &ref);
 
 /**
  * @class TestAliEmcalTrackSelResultPtr

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.cxx
@@ -90,6 +90,17 @@ void AliEmcalTrackSelection::AddTrackCuts(AliVCuts *cuts){
   } 
 }
 
+void AliEmcalTrackSelection::AddTrackCuts(PWG::EMCAL::AliEmcalCutBase *cuts) {
+  AliInfoStream() << "Adding trackc cuts " << cuts->GetName() << " of type " << cuts->IsA()->GetName() << std::endl;
+  if(!fListOfCuts){
+    fListOfCuts = new TObjArray;
+    fListOfCuts->SetOwner(true);
+  }
+  if(cuts) {
+    fListOfCuts->Add(new AliEmcalManagedObject(cuts));
+  }
+}
+
 void AliEmcalTrackSelection::AddTrackCuts(TObjArray *cuts){
   for(auto c : *cuts){
     PWG::EMCAL::AliEmcalCutBase *emccuts = dynamic_cast<PWG::EMCAL::AliEmcalCutBase*>(c);

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.cxx
@@ -32,8 +32,6 @@ ClassImp(AliEmcalTrackSelection)
 AliEmcalTrackSelection::AliEmcalTrackSelection() :
 	TObject(),
 	fListOfTracks(NULL),
-  fListOfTrackBitmaps(NULL),
-  fTrackBitmap(64),
 	fListOfCuts(NULL),
 	fSelectionModeAny(kFALSE)
 {
@@ -42,13 +40,10 @@ AliEmcalTrackSelection::AliEmcalTrackSelection() :
 AliEmcalTrackSelection::AliEmcalTrackSelection(const AliEmcalTrackSelection& ref):
 	TObject(ref),
 	fListOfTracks(NULL),
-	fListOfTrackBitmaps(NULL),
-	fTrackBitmap(64),
 	fListOfCuts(NULL),
 	fSelectionModeAny(kFALSE)
 {
 	if(ref.fListOfTracks) fListOfTracks = new TObjArray(*(ref.fListOfTracks));
-	if(ref.fListOfTrackBitmaps) fListOfTrackBitmaps = new TClonesArray(*(ref.fListOfTrackBitmaps));
 	if(ref.fListOfCuts){
 	  fListOfCuts = new TObjArray;
 	  fListOfCuts->SetOwner(true); // Ownership handled object-by-object by the smart pointer
@@ -62,7 +57,6 @@ AliEmcalTrackSelection& AliEmcalTrackSelection::operator=(const AliEmcalTrackSel
 	if(this != &ref){
 		this->~AliEmcalTrackSelection();
 		if(ref.fListOfTracks) fListOfTracks = new TObjArray(*(ref.fListOfTracks));
-		if(ref.fListOfTrackBitmaps) fListOfTrackBitmaps = new TClonesArray(*(ref.fListOfTrackBitmaps));
 		if(ref.fListOfCuts){
 		  fListOfCuts = new TObjArray;
 		  fListOfCuts->SetOwner(true);  // Ownership handled object-by-object by the smart pointer
@@ -75,7 +69,6 @@ AliEmcalTrackSelection& AliEmcalTrackSelection::operator=(const AliEmcalTrackSel
 
 AliEmcalTrackSelection::~AliEmcalTrackSelection() {
 	if(fListOfTracks) delete fListOfTracks;
-	if(fListOfTrackBitmaps) delete fListOfTrackBitmaps;
 	if(fListOfCuts) delete fListOfCuts;
 }
 
@@ -137,24 +130,12 @@ TObjArray* AliEmcalTrackSelection::GetAcceptedTracks(const TClonesArray* const t
     fListOfTracks->Clear();
   }
 
-  if (!fListOfTrackBitmaps) {
-    fListOfTrackBitmaps = new TClonesArray("TBits", 1000);
-    fListOfTrackBitmaps->SetOwner(kTRUE);
-  }
-  else {
-    fListOfTrackBitmaps->Delete();
-  }
-
-  TIter next(tracks);
-  AliVTrack* track = 0;
-  Int_t i = 0;
-  while((track = static_cast<AliVTrack*>(next()))) {
+  for(auto mytrack : *tracks) {
+    AliVTrack *track = static_cast<AliVTrack *>(mytrack);
     PWG::EMCAL::AliEmcalTrackSelResultPtr selectionResult = IsTrackAccepted(track);
     if(selectionResult) {
       fListOfTracks->AddLast(new PWG::EMCAL::AliEmcalTrackSelResultPtr(selectionResult));
     }
-    new ((*fListOfTrackBitmaps)[i]) TBits(fTrackBitmap);
-    i++;
   }
   return fListOfTracks;
 }
@@ -168,20 +149,11 @@ TObjArray* AliEmcalTrackSelection::GetAcceptedTracks(const AliVEvent* const even
     fListOfTracks->Clear();
   }
 
-  if (!fListOfTrackBitmaps) {
-    fListOfTrackBitmaps = new TClonesArray("TBits", 1000);
-    fListOfTrackBitmaps->SetOwner(kTRUE);
-  }
-  else {
-    fListOfTrackBitmaps->Delete();
-  }
-
   for(int itrk = 0; itrk < event->GetNumberOfTracks(); itrk++){
     AliVTrack *trk = static_cast<AliVTrack*>(event->GetTrack(itrk));
     PWG::EMCAL::AliEmcalTrackSelResultPtr selectionStatus = IsTrackAccepted(trk);
     if(selectionStatus)
       fListOfTracks->AddLast(new PWG::EMCAL::AliEmcalTrackSelResultPtr(selectionStatus));
-    new ((*fListOfTrackBitmaps)[itrk]) TBits(fTrackBitmap);
   }
   return fListOfTracks;
 }

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.h
@@ -287,18 +287,6 @@ public:
 	PWG::EMCAL::AliEmcalCutBase *GetTrackCuts(Int_t icut);
 
 	/**
-	 * @brief Get selection bitmap for the last handled track
-	 * @return Track selection bitmap of the last handled track
-	 */
-	const TBits& GetTrackBitmap() const { return fTrackBitmap; }
-
-	/**
-	 * Get selection bitmaps of all accepted tracks
-	 * @return Bitmaps of all selected tracks
-	 */
-	const TClonesArray* GetAcceptedTrackBitmaps() const { return fListOfTrackBitmaps; }
-
-	/**
 	 * @brief Set selection mode to any
 	 *
 	 * In this case tracks are accepted if any of the
@@ -322,8 +310,6 @@ public:
 
 protected:
 	TObjArray    *fListOfTracks;         ///< TObjArray with accepted tracks
-	TClonesArray *fListOfTrackBitmaps;   ///< TClonesArray with accepted tracks' bit maps
-	TBits         fTrackBitmap;          ///< Bitmap of last accepted/rejected track
 	TObjArray    *fListOfCuts;           ///< List of track cut objects
 	Bool_t        fSelectionModeAny;     ///< Accept track if any of the cuts is fulfilled
 

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.h
@@ -5,6 +5,7 @@
 
 #include <TObject.h>
 #include <TBits.h>
+#include "AliEmcalTrackSelResultPtr.h"
 
 class TClonesArray;
 class TList;
@@ -12,6 +13,14 @@ class TObjArray;
 class AliVCuts;
 class AliVEvent;
 class AliVTrack;
+
+namespace PWG {
+namespace EMCAL {
+
+class AliEmcalCutBase;
+
+}
+}
 
 /**
  * @class AliEmcalManagedObject
@@ -219,7 +228,7 @@ public:
 	 * @param[in] trk Track to be checked
 	 * @return True if the track is accepted, false otherwise
 	 */
-	virtual bool IsTrackAccepted(AliVTrack * const trk) = 0;
+	virtual PWG::EMCAL::AliEmcalTrackSelResultPtr IsTrackAccepted(AliVTrack * const trk) = 0;
 
 	/**
 	 * @brief Interface for track cut generators
@@ -249,6 +258,14 @@ public:
 	void AddTrackCuts(AliVCuts *cuts);
 
 	/**
+	 * @brief Add track cuts of type AliEmcalCutBase
+	 * 
+	 * Takes ownership over the cuts
+	 * @param[in] cuts New cuts to add
+	 */
+	void AddTrackCuts(PWG::EMCAL::AliEmcalCutBase *cuts);
+
+	/**
 	 * @brief Add new set of track cuts to the list of cuts
 	 *
 	 * Takes ownership over the cuts
@@ -267,7 +284,7 @@ public:
 	 * @param[in] icut Cut at position in array
 	 * @return The cuts (NULL for invalid positions)
 	 */
-	AliVCuts *GetTrackCuts(Int_t icut);
+	PWG::EMCAL::AliEmcalCutBase *GetTrackCuts(Int_t icut);
 
 	/**
 	 * @brief Get selection bitmap for the last handled track

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.cxx
@@ -1,19 +1,30 @@
-/**************************************************************************
- * Copyright(c) 1998-2015, ALICE Experiment at CERN, All rights reserved. *
- *                                                                        *
- * Author: The ALICE Off-line Project.                                    *
- * Contributors are mentioned in the code where appropriate.              *
- *                                                                        *
- * Permission to use, copy, modify and distribute this software and its   *
- * documentation strictly for non-commercial purposes is hereby granted   *
- * without fee, provided that the above copyright notice appears in all   *
- * copies and that both the copyright notice and this permission notice   *
- * appear in the supporting documentation. The authors make no claims     *
- * about the suitability of this software for any purpose. It is          *
- * provided "as is" without express or implied warranty.                  *
- **************************************************************************/
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #include <iostream>
-#include <vector>
 
 #include <TClonesArray.h>
 #include <TBits.h>
@@ -154,13 +165,13 @@ PWG::EMCAL::AliEmcalTrackSelResultPtr AliEmcalTrackSelectionAOD::IsTrackAccepted
   TBits trackbitmap(64);
   trackbitmap.ResetAllBits();
   UInt_t cutcounter(0);
-  std::vector<PWG::EMCAL::AliEmcalTrackSelResultPtr> selectionStatus;
+  TObjArray selectionStatus;
   if (fListOfCuts) {
     for (auto cutIter : *fListOfCuts){
       PWG::EMCAL::AliEmcalCutBase *trackCuts = static_cast<PWG::EMCAL::AliEmcalCutBase*>(static_cast<AliEmcalManagedObject *>(cutIter)->GetObject());
       PWG::EMCAL::AliEmcalTrackSelResultPtr cutresults = trackCuts->IsSelected(aodt);
       if (cutresults) trackbitmap.SetBitNumber(cutcounter);
-      selectionStatus.emplace_back(cutresults);
+      selectionStatus.Add(&cutresults);
       cutcounter++;
     }
   }

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.h
@@ -4,7 +4,6 @@
  * See cxx source for full Copyright notice                               */
 
 #include <AliEmcalTrackSelection.h>
-#include "AliESDtrackCuts.h"
 #include "AliEmcalTrackSelResultPtr.h"
 
 class AliVCuts;
@@ -88,7 +87,7 @@ public:
 	 *
 	 * @param filterbits Filter bits used to select tracks
 	 */
-	void AddFilterBit(UInt_t filterbits) { fFilterBits |= filterbits; }
+	void AddFilterBit(UInt_t filterbits);
 
 	/**
 	 * @brief Returns the hybrid filter bits according to a hard-coded look-up table
@@ -99,10 +98,6 @@ public:
 	static Bool_t GetHybridFilterBits(Char_t bits[], TString period);
 
 private:
-	UInt_t			fFilterBits;				    ///< Track filter bits
-	Bool_t      fFilterHybridTracks;    ///< Filter hybrid tracks using AliAODTrack::IsHybridGlobalConstrainedGlobal
-	Bool_t      fFilterTPCTracks;       ///< Filter TPC-only tracks using AliAODTrack::IsHybridGlobalConstrainedGlobal
-	Char_t      fHybridFilterBits[2];   ///< Filter bits of hybrid tracks
 
 	/// \cond CLASSIMP
 	ClassDef(AliEmcalTrackSelectionAOD, 2);

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.h
@@ -104,4 +104,79 @@ private:
 	/// \endcond
 };
 
+namespace PWG {
+
+namespace EMCAL {
+
+class AliEmcalTrackSelResultHybrid;
+
+/**
+ * @class TestAliEmcalTrackSelectionAOD
+ * @brief Unit test for the class AliEmcalTrackSelectionAOD
+ * @ingroup EMCALCOREFW
+ * @author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+ * @since Dec 19, 2018 
+ */
+class TestAliEmcalTrackSelectionAOD : public TObject {
+public:
+
+	/**
+	 * @brief Constructor
+	 */
+	TestAliEmcalTrackSelectionAOD();
+
+	/**
+	 * @brief Destructor
+	 */
+	virtual ~TestAliEmcalTrackSelectionAOD();
+
+	/**
+	 * @brief Init test suite
+	 * 
+	 * Create track selection objects for the various selections supported in the test suite
+	 */
+	void Init();
+
+	/**
+	 * @brief Run all tests
+	 * 
+	 * @return true  All tests passed
+	 * @return false At least one test failed
+	 */
+	bool RunAllTests() const;
+	bool TestHybridDef2010wRefit() const;
+	bool TestHybridDef2010woRefit() const;
+	bool TestHybridDef2011() const;
+	bool TestTPConly() const;
+
+private:
+	/**
+	 * @brief Extract hybrid track user object from a track selection result ptr
+	 * 
+	 * Tool used to extract recursively a user object of type AliEmcalTrackSelResultHybrid. 
+	 * In case the user object is of type AliEmcalTrackSelResultCombined it tries to find
+	 * the hybrid user information within the results of the combined track selection result.
+	 * 
+	 * @param data Track selection result pointer to be inspected
+	 * @return Pointer to the hybrid track selection user object (if existing), nullptr otherwise
+	 */
+	const AliEmcalTrackSelResultHybrid 			*FindHybridSelectionResult(const AliEmcalTrackSelResultPtr &data) const;
+
+	AliEmcalTrackSelectionAOD 				*fTrackSelHybrid2010wRefit;				///< Hybrid tracks from 2010 including non-refit tracks
+	AliEmcalTrackSelectionAOD					*fTrackSelHybrid2010woRefit;			///< Hybrid tracks from 2010 excluding non-refit tracks
+	AliEmcalTrackSelectionAOD					*fTrackSelHybrid2011;							///< Hybrid tracks from 2011
+	AliEmcalTrackSelectionAOD					*fTrackSelTPConly;								///< TPConly tracks
+
+	TestAliEmcalTrackSelectionAOD(const TestAliEmcalTrackSelectionAOD &);
+	TestAliEmcalTrackSelectionAOD &operator=(const TestAliEmcalTrackSelectionAOD &);
+
+	/// \cond CLASSIMP
+	ClassDef(TestAliEmcalTrackSelectionAOD, 1);
+	/// \endcond
+};
+
+}
+
+}
+
 #endif /* ALIEMCALTRACKSELECTIONAOD_H_ */

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.h
@@ -1,7 +1,31 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #ifndef ALIEMCALTRACKSELECTIONAOD_H_
 #define ALIEMCALTRACKSELECTIONAOD_H_
-/* Copyright(c) 1998-2015, ALICE Experiment at CERN, All rights reserved. *
- * See cxx source for full Copyright notice                               */
 
 #include <AliEmcalTrackSelection.h>
 #include "AliEmcalTrackSelResultPtr.h"

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.h
@@ -5,6 +5,7 @@
 
 #include <AliEmcalTrackSelection.h>
 #include "AliESDtrackCuts.h"
+#include "AliEmcalTrackSelResultPtr.h"
 
 class AliVCuts;
 class AliVTrack;
@@ -77,7 +78,7 @@ public:
 	 * @param[in] trk Track to check
 	 * @return true if selected, false otherwise
 	 */
-	virtual bool IsTrackAccepted(AliVTrack * const trk);
+	virtual PWG::EMCAL::AliEmcalTrackSelResultPtr IsTrackAccepted(AliVTrack * const trk);
 
 	/**
 	 * @brief Add a new filter bit to the track selection.

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionESD.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionESD.cxx
@@ -127,7 +127,8 @@ PWG::EMCAL::AliEmcalTrackSelResultPtr AliEmcalTrackSelectionESD::IsTrackAccepted
     }
   }
 
-  fTrackBitmap.ResetAllBits();
+  TBits trackbitmap(64);
+  trackbitmap.ResetAllBits();
   UInt_t cutcounter = 0;
   AliDebugStream(2) << "Found cut array with " << fListOfCuts->GetEntries() << " cuts\n" << std::endl;
   std::vector<PWG::EMCAL::AliEmcalTrackSelResultPtr> selectionStatus;
@@ -135,15 +136,15 @@ PWG::EMCAL::AliEmcalTrackSelResultPtr AliEmcalTrackSelectionESD::IsTrackAccepted
     AliDebugStream(3) << "executing nect cut: " << static_cast<AliVCuts *>(static_cast<AliEmcalManagedObject *>(cutIter)->GetObject())->GetName() << std::endl;
     PWG::EMCAL::AliEmcalCutBase *mycuts = static_cast<PWG::EMCAL::AliEmcalCutBase *>(static_cast<AliEmcalManagedObject *>(cutIter)->GetObject());
     PWG::EMCAL::AliEmcalTrackSelResultPtr selresult = mycuts->IsSelected(esdt);
-    if(selresult) fTrackBitmap.SetBitNumber(cutcounter);
+    if(selresult) trackbitmap.SetBitNumber(cutcounter);
     cutcounter++;
   }
   // In case of ANY at least one bit has to be set, while in case of ALL all bits have to be set
   PWG::EMCAL::AliEmcalTrackSelResultPtr result(esdt, kFALSE, new PWG::EMCAL::AliEmcalTrackSelResultCombined(selectionStatus));
   if (fSelectionModeAny){
-    result.SetSelectionResult(fTrackBitmap.CountBits() > 0 || cutcounter == 0);
+    result.SetSelectionResult(trackbitmap.CountBits() > 0 || cutcounter == 0);
   } else {
-    result.SetSelectionResult(fTrackBitmap.CountBits() == cutcounter);
+    result.SetSelectionResult(trackbitmap.CountBits() == cutcounter);
   }
   return result;
 }

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionESD.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionESD.cxx
@@ -1,19 +1,29 @@
-/**************************************************************************
- * Copyright(c) 1998-2015, ALICE Experiment at CERN, All rights reserved. *
- *                                                                        *
- * Author: The ALICE Off-line Project.                                    *
- * Contributors are mentioned in the code where appropriate.              *
- *                                                                        *
- * Permission to use, copy, modify and distribute this software and its   *
- * documentation strictly for non-commercial purposes is hereby granted   *
- * without fee, provided that the above copyright notice appears in all   *
- * copies and that both the copyright notice and this permission notice   *
- * appear in the supporting documentation. The authors make no claims     *
- * about the suitability of this software for any purpose. It is          *
- * provided "as is" without express or implied warranty.                  *
- **************************************************************************/
-#include <vector>
-
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #include <TBits.h>
 #include <TClonesArray.h>
 #include <TList.h>
@@ -131,11 +141,13 @@ PWG::EMCAL::AliEmcalTrackSelResultPtr AliEmcalTrackSelectionESD::IsTrackAccepted
   trackbitmap.ResetAllBits();
   UInt_t cutcounter = 0;
   AliDebugStream(2) << "Found cut array with " << fListOfCuts->GetEntries() << " cuts\n" << std::endl;
-  std::vector<PWG::EMCAL::AliEmcalTrackSelResultPtr> selectionStatus;
+  TObjArray selectionStatus;
+  selectionStatus.SetOwner(false);
   for(auto cutIter : *fListOfCuts){
     AliDebugStream(3) << "executing nect cut: " << static_cast<AliVCuts *>(static_cast<AliEmcalManagedObject *>(cutIter)->GetObject())->GetName() << std::endl;
     PWG::EMCAL::AliEmcalCutBase *mycuts = static_cast<PWG::EMCAL::AliEmcalCutBase *>(static_cast<AliEmcalManagedObject *>(cutIter)->GetObject());
     PWG::EMCAL::AliEmcalTrackSelResultPtr selresult = mycuts->IsSelected(esdt);
+    selectionStatus.Add(&selresult);
     if(selresult) trackbitmap.SetBitNumber(cutcounter);
     cutcounter++;
   }

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionESD.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionESD.h
@@ -1,7 +1,31 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #ifndef ALIEMCALTASKTRACKSELECTIONESD_H_
 #define ALIEMCALTASKTRACKSELECTIONESD_H_
-/* Copyright(c) 1998-2015, ALICE Experiment at CERN, All rights reserved. *
- * See cxx source for full Copyright notice                               */
 
 #include "AliEmcalTrackSelection.h"
 #include "AliEmcalTrackSelResultPtr.h"

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionESD.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionESD.h
@@ -3,7 +3,8 @@
 /* Copyright(c) 1998-2015, ALICE Experiment at CERN, All rights reserved. *
  * See cxx source for full Copyright notice                               */
 
-#include <AliEmcalTrackSelection.h>
+#include "AliEmcalTrackSelection.h"
+#include "AliEmcalTrackSelResultPtr.h"
 
 class TList;
 class AliVCuts;
@@ -64,7 +65,7 @@ public:
 	 * @param[in] trk Track to check
 	 * @return true if selected, false otherwise
 	 */
-	virtual bool IsTrackAccepted(AliVTrack * const trk);
+	virtual PWG::EMCAL::AliEmcalTrackSelResultPtr IsTrackAccepted(AliVTrack * const trk);
 
   virtual void SaveQAObjects(TList *outputList);
 

--- a/PWG/EMCAL/EMCALbase/AliEmcalVCutsWrapper.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalVCutsWrapper.cxx
@@ -1,0 +1,55 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include "AliVCuts.h"
+#include "AliVTrack.h"
+#include "AliEmcalVCutsWrapper.h"
+
+ClassImp(PWG::EMCAL::AliEmcalVCutsWrapper)
+
+using namespace PWG::EMCAL;
+
+AliEmcalVCutsWrapper::AliEmcalVCutsWrapper():
+  AliEmcalCutBase(),
+  fCutObject(nullptr)
+{
+
+}
+
+AliEmcalVCutsWrapper::AliEmcalVCutsWrapper(AliVCuts *cuts):
+  AliEmcalCutBase(Form("Wrapper_%s", cuts->GetName()), cuts->GetTitle()),
+  fCutObject(cuts)
+{
+
+}
+
+AliEmcalVCutsWrapper::~AliEmcalVCutsWrapper(){
+  if(fCutObject) delete fCutObject;
+}
+
+AliEmcalTrackSelResultPtr AliEmcalVCutsWrapper::IsSelected(TObject *o) {
+  return AliEmcalTrackSelResultPtr(dynamic_cast<AliVTrack *>(o), fCutObject->IsSelected(o), nullptr);
+}

--- a/PWG/EMCAL/EMCALbase/AliEmcalVCutsWrapper.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalVCutsWrapper.h
@@ -1,0 +1,63 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIEMCALVCUTSWRAPPER_H
+#define ALIEMCALVCUTSWRAPPER_H
+
+#include "AliEmcalCutBase.h"
+#include "AliEmcalTrackSelResultPtr.h"
+
+class AliVCuts;
+
+namespace PWG {
+
+namespace EMCAL {
+
+/**
+ * @class AliEmcalVCutsWrapper
+ * @brief Wrapper class handling AliVCuts as AliEmcalCutBase
+ * 
+ */
+class AliEmcalVCutsWrapper : public AliEmcalCutBase {
+public:
+  AliEmcalVCutsWrapper();
+  AliEmcalVCutsWrapper(AliVCuts *cuts);
+  virtual ~AliEmcalVCutsWrapper();
+
+  AliEmcalTrackSelResultPtr IsSelected(TObject *o);
+  AliVCuts *GetCutObject() const { return fCutObject; }
+
+private:
+  AliVCuts              *fCutObject;        ///<  Object on which cuts are performed 
+
+  ClassDef(AliEmcalVCutsWrapper, 1);
+};
+
+}
+
+}
+
+#endif

--- a/PWG/EMCAL/EMCALbase/AliTrackContainer.h
+++ b/PWG/EMCAL/EMCALbase/AliTrackContainer.h
@@ -1,7 +1,31 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 #ifndef ALITRACKCONTAINER_H
 #define ALITRACKCONTAINER_H
-/* Copyright(c) 1998-2016, ALICE Experiment at CERN, All rights reserved. *
- * See cxx source for full Copyright notice                               */
 
 class AliVEvent;
 class AliVParticle;
@@ -29,6 +53,42 @@ typedef EMCALIterableContainer::AliEmcalIterableContainerT<AliVTrack, EMCALItera
  */
 class AliTrackContainer : public AliParticleContainer {
  public:
+ 
+  /**
+   * @class TrackOwnerHandler
+   * @brief Unique_ptr implementation for ROOT5 compatibility
+   * @ingroup EMCALCOREFW
+   * @author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+   * @since Dec. 20, 2017
+   * 
+   * This class treats ownership over a shared object in the way a unique_ptr would 
+   * do this: Ownership can only be transfered.
+   */
+  class TrackOwnerHandler : public TObject {
+  public:
+    TrackOwnerHandler();
+    TrackOwnerHandler(TObjArray *managedobject, Bool_t ownership);
+    TrackOwnerHandler(const TrackOwnerHandler &other);
+    TrackOwnerHandler &operator=(const TrackOwnerHandler &other);
+    virtual ~TrackOwnerHandler();
+
+    void SetObject(TObjArray *obj);
+    void SetOwner(Bool_t owner);
+
+    TObjArray *GetData() const { return fManagedObject; }
+    Bool_t IsOwner() const { return fOwnership; }
+
+    void TransferOwnershipTo(TrackOwnerHandler &target);
+    void ReceiveOwnershipFrom(TrackOwnerHandler &source);
+
+  private:
+    TObjArray          *fManagedObject;            ///< Object managed by the handler
+    Bool_t              fOwnership;                 ///< Ownership implementation
+    
+    /// @cond CLASSIMP
+    ClassDef(TrackOwnerHandler, 1);
+    /// @endcond
+  };
 
   typedef AliEmcalTrackSelection::ETrackFilterType_t ETrackFilterType_t;
 
@@ -131,7 +191,7 @@ class AliTrackContainer : public AliParticleContainer {
   UInt_t                      fAODFilterBits;                 ///< track filter bits
   TString                     fTrackCutsPeriod;               ///< period string used to generate track cuts
   AliEmcalTrackSelection     *fEmcalTrackSelection;           //!<! track selection object
-  TObjArray                  *fFilteredTracks;                //!<! tracks filtered using fEmcalTrackSelection
+  TrackOwnerHandler           fFilteredTracks;                //!<! tracks filtered using fEmcalTrackSelection
   TArrayC                     fTrackTypes;                    //!<! track types
 
  private:

--- a/PWG/EMCAL/EMCALbase/AliTrackContainer.h
+++ b/PWG/EMCAL/EMCALbase/AliTrackContainer.h
@@ -12,6 +12,7 @@ class AliTLorentzVector;
 
 #include "AliVTrack.h"
 #include "AliEmcalTrackSelection.h"
+#include "AliEmcalTrackSelResultHybrid.h"
 #include "AliParticleContainer.h"
 
 #if !(defined(__CINT__) || defined(__MAKECINT__))
@@ -118,6 +119,8 @@ class AliTrackContainer : public AliParticleContainer {
    * @return Appropriate default array name
    */
   virtual TString             GetDefaultArrayName(const AliVEvent * const ev) const;
+
+  PWG::EMCAL::AliEmcalTrackSelResultHybrid::HybridType_t  GetHybridDefinition(const PWG::EMCAL::AliEmcalTrackSelResultPtr &selectionResult) const;
 
   static TString              fgDefTrackCutsPeriod;           //!<! default period string used to generate track cuts
 

--- a/PWG/EMCAL/EMCALbase/CMakeLists.txt
+++ b/PWG/EMCAL/EMCALbase/CMakeLists.txt
@@ -104,3 +104,27 @@ install(TARGETS ${MODULE}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib)
 install(FILES ${HDRS} DESTINATION include)
+
+# Unit tests
+
+add_test(func_PWGEMCALbase_AliEmcalTrackSelResultPtr
+    env
+    LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{LD_LIBRARY_PATH}
+    DYLD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{DYLD_LIBRARY_PATH}
+    ROOT_HIST=0
+    root -n -l -b -q "${CMAKE_INSTALL_PREFIX}/PWG/EMCAL/macros/TestAliEmcalTrackSelResultPtr.C)")
+
+add_test(func_PWGEMCALbase_AliEmcalAODHybridTrackCuts
+    env
+    LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{LD_LIBRARY_PATH}
+    DYLD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{DYLD_LIBRARY_PATH}
+    ROOT_HIST=0
+    root -n -l -b -q "${CMAKE_INSTALL_PREFIX}/PWG/EMCAL/macros/TestAliEmcalAODHybridTrackCuts.C)")
+
+add_test(func_PWGEMCALbase_AliEmcalTrackSelectionAOD
+    env
+    LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{LD_LIBRARY_PATH}
+    DYLD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{DYLD_LIBRARY_PATH}
+    ROOT_HIST=0
+    root -n -l -b -q "${CMAKE_INSTALL_PREFIX}/PWG/EMCAL/macros/TestAliEmcalTrackSelectionAOD.C)")
+    

--- a/PWG/EMCAL/EMCALbase/CMakeLists.txt
+++ b/PWG/EMCAL/EMCALbase/CMakeLists.txt
@@ -37,6 +37,8 @@ set(SRCS
   AliEmcalContainer.cxx
   AliEmcalContainerUtils.cxx
   AliEmcalDownscaleFactorsOCDB.cxx
+  AliEmcalCutBase.cxx
+  AliEmcalVCutsWrapper.cxx
   AliEmcalAODFilterBitCuts.cxx
   AliEmcalAODHybridTrackCuts.cxx
   AliEmcalContainerUtils.cxx
@@ -47,6 +49,8 @@ set(SRCS
   AliEmcalPhysicsSelection.cxx
   AliEmcalPythiaInfo.cxx
   AliEmcalTrackSelResultPtr.cxx
+  AliEmcalTrackSelResultCombined.cxx
+  AliEmcalTrackSelResultHybrid.cxx
   AliEmcalTrackSelection.cxx
   AliEmcalTrackSelectionESD.cxx
   AliEmcalTrackSelectionAOD.cxx

--- a/PWG/EMCAL/EMCALbase/CMakeLists.txt
+++ b/PWG/EMCAL/EMCALbase/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SRCS
   AliEmcalVCutsWrapper.cxx
   AliEmcalAODFilterBitCuts.cxx
   AliEmcalAODHybridTrackCuts.cxx
+  AliEmcalAODTPCOnlyTrackCuts.cxx
   AliEmcalContainerUtils.cxx
   AliEmcalESDTrackCutsGenerator.cxx
   AliEmcalESDHybridTrackCuts.cxx

--- a/PWG/EMCAL/EMCALbase/PWGEMCALbaseLinkDef.h
+++ b/PWG/EMCAL/EMCALbase/PWGEMCALbaseLinkDef.h
@@ -24,6 +24,7 @@
 #pragma link C++ class AliPicoTrack+;
 #pragma link C++ class AliMCParticleContainer+;
 #pragma link C++ class AliTrackContainer+;
+#pragma link C++ class AliTrackContainer::TrackOwnerHandler+;
 #pragma link C++ class AliEmcalList+;
 #pragma link C++ class std::map<std::string, AliParticleContainer*>+;
 #pragma link C++ class std::pair<std::string, AliParticleContainer*>+;

--- a/PWG/EMCAL/EMCALbase/PWGEMCALbaseLinkDef.h
+++ b/PWG/EMCAL/EMCALbase/PWGEMCALbaseLinkDef.h
@@ -41,6 +41,7 @@
 #pragma link C++ class PWG::EMCAL::AliEmcalCutBase+;
 #pragma link C++ class PWG::EMCAL::AliEmcalVCutsWrapper+;
 #pragma link C++ class PWG::EMCAL::AliEmcalAODHybridTrackCuts+;
+#pragma link C++ class PWG::EMCAL::AliEmcalAODTPCOnlyTrackCuts+;
 #pragma link C++ class PWG::EMCAL::AliEmcalESDHybridTrackCuts+;
 #pragma link C++ class PWG::EMCAL::AliEmcalESDtrackCutsWrapper+;
 #endif

--- a/PWG/EMCAL/EMCALbase/PWGEMCALbaseLinkDef.h
+++ b/PWG/EMCAL/EMCALbase/PWGEMCALbaseLinkDef.h
@@ -44,4 +44,7 @@
 #pragma link C++ class PWG::EMCAL::AliEmcalAODTPCOnlyTrackCuts+;
 #pragma link C++ class PWG::EMCAL::AliEmcalESDHybridTrackCuts+;
 #pragma link C++ class PWG::EMCAL::AliEmcalESDtrackCutsWrapper+;
+#pragma link C++ class PWG::EMCAL::TestAliEmcalTrackSelResultPtr+;
+#pragma link C++ class PWG::EMCAL::TestAliEmcalAODHybridTrackCuts+;
+#pragma link C++ class PWG::EMCAL::TestAliEmcalTrackSelectionAOD+;
 #endif

--- a/PWG/EMCAL/EMCALbase/PWGEMCALbaseLinkDef.h
+++ b/PWG/EMCAL/EMCALbase/PWGEMCALbaseLinkDef.h
@@ -16,7 +16,6 @@
 #pragma link C++ class AliEmcalParticle+;
 #pragma link C++ class AliEmcalPhysicsSelection+;
 #pragma link C++ class AliEmcalPythiaInfo+;
-#pragma link C++ class AliEmcalTrackSelResultPtr+;
 #pragma link C++ class AliEmcalManagedObject+;
 #pragma link C++ class AliEmcalTrackSelection+;
 #pragma link C++ class AliEmcalTrackSelectionESD+;
@@ -33,7 +32,14 @@
 
 #pragma link C++ namespace PWG;
 #pragma link C++ namespace PWG::EMCAL;
+#pragma link C++ class PWG::EMCAL::AliEmcalTrackSelResultPtr+;
+#pragma link C++ class PWG::EMCAL::AliEmcalTrackSelResultUserPtr+;
+#pragma link C++ class PWG::EMCAL::AliEmcalTrackSelResultUserStorage+;
+#pragma link C++ class PWG::EMCAL::AliEmcalTrackSelResultCombined+;
+#pragma link C++ class PWG::EMCAL::AliEmcalTrackSelResultHybrid+;
 #pragma link C++ class PWG::EMCAL::AliEmcalAODFilterBitCuts+;
+#pragma link C++ class PWG::EMCAL::AliEmcalCutBase+;
+#pragma link C++ class PWG::EMCAL::AliEmcalVCutsWrapper+;
 #pragma link C++ class PWG::EMCAL::AliEmcalAODHybridTrackCuts+;
 #pragma link C++ class PWG::EMCAL::AliEmcalESDHybridTrackCuts+;
 #pragma link C++ class PWG::EMCAL::AliEmcalESDtrackCutsWrapper+;

--- a/PWG/EMCAL/macros/TestAliEmcalAODHybridTrackCuts.C
+++ b/PWG/EMCAL/macros/TestAliEmcalAODHybridTrackCuts.C
@@ -1,0 +1,6 @@
+int TestAliEmcalAODHybridTrackCuts() {
+  PWG::EMCAL::TestAliEmcalAODHybridTrackCuts testrunner;
+  testrunner.Init();
+  if(testrunner.RunAllTests()) return 0;
+  return 1; 
+}

--- a/PWG/EMCAL/macros/TestAliEmcalTrackSelResultPtr.C
+++ b/PWG/EMCAL/macros/TestAliEmcalTrackSelResultPtr.C
@@ -1,0 +1,5 @@
+int TestAliEmcalTrackSelResultPtr() {
+  PWG::EMCAL::TestAliEmcalTrackSelResultPtr testrunner;
+  if(testrunner.RunAllTests()) return 0;
+  return 1; 
+}

--- a/PWG/EMCAL/macros/TestAliEmcalTrackSelectionAOD.C
+++ b/PWG/EMCAL/macros/TestAliEmcalTrackSelectionAOD.C
@@ -1,0 +1,6 @@
+int TestAliEmcalTrackSelectionAOD(){
+  PWG::EMCAL::TestAliEmcalTrackSelectionAOD testrunner;
+  testrunner.Init();
+  if(testrunner.RunAllTests()) return 0;
+  return 1; 
+}

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskPtEMCalTrigger.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskPtEMCalTrigger.cxx
@@ -52,6 +52,9 @@
 #include "AliEmcalTrackSelection.h"
 #include "AliEmcalTrackSelectionESD.h"
 #include "AliEmcalTrackSelectionAOD.h"
+#include "AliEmcalCutBase.h"
+#include "AliEmcalVCutsWrapper.h"
+#include "AliEmcalESDtrackCutsWrapper.h"
 #include "AliJetContainer.h"
 #include "AliParticleContainer.h"
 #include "AliPicoTrack.h"
@@ -294,10 +297,14 @@ namespace EMCalTriggerPtAnalysis {
       TIter cutIter(fListTrackCuts);
       AliEmcalTrackSelection *cutObject(NULL);
       while((cutObject = dynamic_cast<AliEmcalTrackSelection *>(cutIter()))){
-        AliESDtrackCuts *cuts = dynamic_cast<AliESDtrackCuts *>(cutObject->GetTrackCuts(0));
-        if(cuts){
-          cuts->DefineHistograms();
-          fOutput->Add(cuts);
+        PWG::EMCAL::AliEmcalVCutsWrapper *trackcuts = dynamic_cast<PWG::EMCAL::AliEmcalVCutsWrapper *>(cutObject->GetTrackCuts(0));
+        if(trackcuts){
+          PWG::EMCAL::AliEmcalESDtrackCutsWrapper *esdcuts = dynamic_cast<PWG::EMCAL::AliEmcalESDtrackCutsWrapper *>(trackcuts->GetCutObject());
+          if(esdcuts) {
+            AliESDtrackCuts *mycuts = esdcuts->GetTrackCuts();
+            mycuts->DefineHistograms();
+            fOutput->Add(mycuts);
+          }
         }
       }
     }

--- a/PWGJE/EMCALJetTasks/Tracks/AliEmcalAnalysisFactory.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliEmcalAnalysisFactory.cxx
@@ -53,15 +53,15 @@ AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cutstr
   AliEmcalTrackSelection *result = NULL;
   std::unique_ptr<TObjArray> cuts(cutstring.Tokenize(","));
   std::cout << "Creating track cuts for " << (aod ? "AODs" : "ESDs") << std::endl;
+  TObjArray trackcuts;
   if(!aod){
-    std::vector<AliVCuts *> trackcuts;
     for(auto c : *cuts){
       TString &cut = static_cast<TObjString *>(c)->String();
       if(cut == "standard"){
         auto esdcuts = GenerateDefaultCutsESD();
         esdcuts->SetName("standardRAA");
         esdcuts->SetTitle("Standard Track cuts");
-        trackcuts.push_back(esdcuts);
+        trackcuts.Add(esdcuts);
       }
       if(cut == "standardcrossedrows"){
         auto esdcuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(true, 1);
@@ -70,38 +70,38 @@ AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cutstr
         esdcuts->SetTitle("Standard Track cuts");
         esdcuts->SetMinNCrossedRowsTPC(120);
         esdcuts->SetMaxDCAToVertexXYPtDep("0.0182+0.0350/pt^1.01");
-        trackcuts.push_back(esdcuts);
+        trackcuts.Add(esdcuts);
       }
       if(cut == "hybrid"){
         std::cout << "Configuring standard hybrid track cuts" << std::endl;
         auto esdcuts = GenerateLooseDCACutsESD();
         esdcuts->SetTitle("hybridglobal");
         esdcuts->SetTitle("Global Hybrid tracks, loose DCA");
-        trackcuts.push_back(esdcuts);
+        trackcuts.Add(esdcuts);
       }
       if(cut == "hybrid2010_wNoRefit"){
         std::cout << "Configuring hybrid track cuts 2010, including non-ITSrefit tracks" << std::endl;
         auto hybridcuts = new PWG::EMCAL::AliEmcalESDHybridTrackCuts("2010_wNoRefit", PWG::EMCAL::AliEmcalESDHybridTrackCuts::kDef2010);
         hybridcuts->SetUseNoITSrefitTracks(kTRUE);
-        trackcuts.push_back(hybridcuts);
+        trackcuts.Add(hybridcuts);
       }
       if(cut == "hybrid2010_woNoRefit"){
         std::cout << "Configuring hybrid track cuts 2010, excluding non-ITSrefit tracks" << std::endl;
         auto hybridcuts = new PWG::EMCAL::AliEmcalESDHybridTrackCuts("2010_woNoRefit", PWG::EMCAL::AliEmcalESDHybridTrackCuts::kDef2010);
         hybridcuts->SetUseNoITSrefitTracks(kFALSE);
-        trackcuts.push_back(hybridcuts); 
+        trackcuts.Add(hybridcuts); 
      }
       if(cut == "hybrid2011_wNoRefit"){
         std::cout << "Configuring hybrid track cuts 2011, including non-ITSrefit tracks" << std::endl;
         auto hybridcuts = new PWG::EMCAL::AliEmcalESDHybridTrackCuts("2011_wNoRefit", PWG::EMCAL::AliEmcalESDHybridTrackCuts::kDef2011);
         hybridcuts->SetUseNoITSrefitTracks(kTRUE);
-        trackcuts.push_back(hybridcuts);
+        trackcuts.Add(hybridcuts);
       }
       if(cut == "hybrid2011_woNoRefit"){
         std::cout << "Configuring hybrid track cuts 2011, excluding non-ITSrefit tracks" << std::endl;
         auto hybridcuts = new PWG::EMCAL::AliEmcalESDHybridTrackCuts("2011_woNoRefit", PWG::EMCAL::AliEmcalESDHybridTrackCuts::kDef2011);
         hybridcuts->SetUseNoITSrefitTracks(kFALSE);
-        trackcuts.push_back(hybridcuts);
+        trackcuts.Add(hybridcuts);
       }
 
       ////////////////////////////////////////////////////////////////
@@ -115,7 +115,7 @@ AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cutstr
         esdcuts->SetName(TString::Format("VarITSchi2Cut%04d", static_cast<int>(cutvalue * 10.)));
         esdcuts->SetTitle(TString::Format("Default cuts - variation ITS chi2 cut at %f", cutvalue));
         esdcuts->SetMaxChi2PerClusterITS(cutvalue);
-        trackcuts.push_back(esdcuts);
+        trackcuts.Add(esdcuts);
       }
       if(cut.Contains("VarTPCchi2") && !cut.Contains("Constrained")){
         double cutvalue = ValueDecoder(cut, "VarTPCchi2");
@@ -123,7 +123,7 @@ AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cutstr
         esdcuts->SetName(TString::Format("VarTPCchi2Cut%04d", static_cast<int>(cutvalue * 10.)));
         esdcuts->SetTitle(TString::Format("Default cuts - variation TPC chi2 cut at %f", cutvalue));
         esdcuts->SetMaxChi2PerClusterTPC(cutvalue);
-        trackcuts.push_back(esdcuts);
+        trackcuts.Add(esdcuts);
       }
       if(cut.Contains("VarTPCchi2Constrained")){
         double cutvalue = ValueDecoder(cut, "VarTPCchi2Constrained"); // in number of sigmas
@@ -131,7 +131,7 @@ AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cutstr
         esdcuts->SetName(TString::Format("VarTPCchi2ConstrainedCut%04d", static_cast<int>(cutvalue * 10.)));
         esdcuts->SetTitle(TString::Format("Default cuts - variation TPC chi2 constrained cut at %f", cutvalue));
         esdcuts->SetMaxChi2TPCConstrainedGlobal(cutvalue);
-        trackcuts.push_back(esdcuts);
+        trackcuts.Add(esdcuts);
       }
       if(cut.Contains("VarDCAz")){
         double cutvalue = ValueDecoder(cut, "VarDCAz");
@@ -139,7 +139,7 @@ AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cutstr
         esdcuts->SetName(TString::Format("VarDCAzCut%04d", static_cast<int>(cutvalue * 10.)));
         esdcuts->SetTitle(TString::Format("Default cuts - variation DCAz cut at %f", cutvalue));
         esdcuts->SetMaxDCAToVertexZ(cutvalue);
-        trackcuts.push_back(esdcuts);
+        trackcuts.Add(esdcuts);
       }
       if(cut.Contains("VarDCAr")){
         double cutvalue = ValueDecoder(cut, "VarDCAr");
@@ -148,7 +148,7 @@ AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cutstr
         esdcuts->SetName(TString::Format("VarDCArCut%04d", static_cast<int>(cutvalue * 10.)));
         esdcuts->SetTitle(TString::Format("Default cuts - variation DCAr cut at %f sigma", cutvalue));
         esdcuts->SetMaxDCAToVertexXYPtDep(TString::Format("%f + %f/pt^1.01", p1, p2));
-        trackcuts.push_back(esdcuts);
+        trackcuts.Add(esdcuts);
       }
       if(cut.Contains("VarRatioCrossedRowsFindable")){
         double cutvalue = ValueDecoder(cut, "VarRatioCrossedRowsFindable");
@@ -156,7 +156,7 @@ AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cutstr
         esdcuts->SetName(TString::Format("VarRatioCRFindableCut%04d", static_cast<int>(cutvalue * 10.)));
         esdcuts->SetTitle(TString::Format("Default cuts - variation ratio crossed rows over findable cut at %f", cutvalue));
         esdcuts->SetMinRatioCrossedRowsOverFindableClustersTPC(cutvalue);
-        trackcuts.push_back(esdcuts);
+        trackcuts.Add(esdcuts);
       }
       if(cut.Contains("VarFractionTPCshared")){
         double cutvalue = ValueDecoder(cut, "VarFractionTPCshared");
@@ -164,7 +164,7 @@ AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cutstr
         esdcuts->SetName(TString::Format("VarFractionTPCShared%04d", static_cast<int>(cutvalue * 10.)));
         esdcuts->SetTitle(TString::Format("Default cuts - variation fraction TPC shared clusters %f", cutvalue));
         esdcuts->SetMaxFractionSharedTPCClusters(cutvalue);
-        trackcuts.push_back(esdcuts);
+        trackcuts.Add(esdcuts);
       }
       if(cut.Contains("VarTrackLengthDeadArea")){
         double cutvalue = ValueDecoder(cut, "VarTrackLengthDeadArea");
@@ -172,7 +172,7 @@ AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cutstr
         esdcuts->SetName(TString::Format("VarTLDeadAreaCut%04d", static_cast<int>(cutvalue * 10.)));
         esdcuts->SetTitle(TString::Format("Default cuts - variation track length dead area cut at %f", cutvalue));
         esdcuts->SetCutGeoNcrNcl(cutvalue, 130., 1.5, 0.0, 0.0);
-        trackcuts.push_back(esdcuts);
+        trackcuts.Add(esdcuts);
       }
       if(cut.Contains("VarTrackLengthTPCLength")){
         double cutvalue = ValueDecoder(cut, "VarTrackLengthTPCLength");
@@ -180,7 +180,7 @@ AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cutstr
         esdcuts->SetName(TString::Format("VarTLTPCLengthCut%04d", static_cast<int>(cutvalue * 10.)));
         esdcuts->SetTitle(TString::Format("Default cuts - variation track length TPC length cut at %f", cutvalue));
         esdcuts->SetCutGeoNcrNcl(3., cutvalue, 1.5, 0.0, 0.0);
-        trackcuts.push_back(esdcuts);
+        trackcuts.Add(esdcuts);
       }
       if(cut.Contains("VarSPDhit")){
         double cutvalue = ValueDecoder(cut, "VarSPDhit");
@@ -193,7 +193,7 @@ AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cutstr
           esdcuts->SetTitle("Default cuts - variation SPD hit requirement off");
           esdcuts->SetClusterRequirementITS(AliESDtrackCuts::kSPD, AliESDtrackCuts::kOff);
         }
-        trackcuts.push_back(esdcuts);
+        trackcuts.Add(esdcuts);
       }
       ////////////////////////////////////////////////////////////////
       /// Test cuts - for tracking studies                         ///
@@ -212,7 +212,7 @@ AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cutstr
         esdcuts->SetMaxChi2PerClusterITS(itscut);
         // Set cut on the TPC global constrained chi2 to very loose
         esdcuts->SetMaxChi2TPCConstrainedGlobal(100);
-        trackcuts.push_back(esdcuts);
+        trackcuts.Add(esdcuts);
       }
       if(cut.Contains("TestTPCchi2")){
         double tpccut = ValueDecoder(cut,"TestTPCchi2");
@@ -224,7 +224,7 @@ AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cutstr
 
         // Do the variation
         esdcuts->SetMaxChi2PerClusterTPC(tpccut);
-        trackcuts.push_back(esdcuts);
+        trackcuts.Add(esdcuts);
       }
       if(cut.Contains("TestTPCchi2Constrained")){
         double tpcconstrainedcut = ValueDecoder(cut, "TestTPCchi2Constrained");
@@ -238,30 +238,28 @@ AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cutstr
         esdcuts->SetMaxChi2TPCConstrainedGlobal(tpcconstrainedcut);
         // Set ITS chi2 cut to very loose
         esdcuts->SetMaxChi2PerClusterITS(100);
-        trackcuts.push_back(esdcuts);
+        trackcuts.Add(esdcuts);
       }
       if(cut.Contains("geo")){
         auto geocuts = new AliEMCalTriggerExtraCuts();
         geocuts->SetName("geocuts");
         geocuts->SetTitle("TPC track length cut");
         geocuts->SetMinTPCTrackLengthCut();
-        trackcuts.push_back(geocuts);
+        trackcuts.Add(geocuts);
       }
     }
     result = new AliEmcalTrackSelectionESD;
-    for(std::vector<AliVCuts *>::iterator it = trackcuts.begin(); it != trackcuts.end(); ++it)
-      result->AddTrackCuts(*it);
+    result->AddTrackCuts(&trackcuts);
   } else {
     AliEmcalTrackSelectionAOD *aodsel = new AliEmcalTrackSelectionAOD;
     result = aodsel;
-    std::vector<AliVCuts *> trackcuts;
     // C++11 Lambda: Do not create multiple extra cut objects in case of AODs. If extra cut object does already exist -
     // specify new cut in the same object.
-    std::function<AliEMCalTriggerExtraCuts *(const std::vector<AliVCuts *> &)> FindTrackCuts = [] (const std::vector<AliVCuts *> &cuts) -> AliEMCalTriggerExtraCuts * {
+    auto FindTrackCuts = [] (const TObjArray &cuts) -> AliEMCalTriggerExtraCuts * {
       AliEMCalTriggerExtraCuts *found = nullptr;
-      for(std::vector<AliVCuts *>::const_iterator cutiter = cuts.begin(); cutiter != cuts.end(); ++cutiter){
-        if((*cutiter)->IsA() == AliEMCalTriggerExtraCuts::Class()){
-          found = static_cast<AliEMCalTriggerExtraCuts *>(*cutiter);
+      for(auto cutiter : cuts){
+        if(cutiter->IsA() == AliEMCalTriggerExtraCuts::Class()){
+          found = static_cast<AliEMCalTriggerExtraCuts *>(cutiter);
           break;
         }
       }
@@ -274,7 +272,7 @@ AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cutstr
         AliEMCalTriggerExtraCuts *extracuts = FindTrackCuts(trackcuts);
         if(!extracuts){
           extracuts = new AliEMCalTriggerExtraCuts;
-          trackcuts.push_back(extracuts);
+          trackcuts.Add(extracuts);
         }
         extracuts->SetMinTPCCrossedRows(120);
       }
@@ -297,13 +295,12 @@ AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cutstr
         AliEMCalTriggerExtraCuts *extracuts = FindTrackCuts(trackcuts);
         if(!extracuts){
           extracuts = new AliEMCalTriggerExtraCuts;
-          trackcuts.push_back(extracuts);
+          trackcuts.Add(extracuts);
         }
         extracuts->SetMinTPCTrackLengthCut();
       }
     }
-    for(std::vector<AliVCuts *>::iterator it = trackcuts.begin(); it != trackcuts.end(); ++it)
-      result->AddTrackCuts(*it);
+    result->AddTrackCuts(&trackcuts);
   }
 
   return result;


### PR DESCRIPTION
The current ALICE cut framework only provides information whether an object (i.e. a track) is selected or not. Cut classes cannot pass the circumstance among which it was selected. For i.e. hybrid tracks this approach is too simple as hybrid tracks are categorized in different classes, where different classes need to be treated differently. So in addition to the selection status one needs to provide a user information encoding the classification of the object.

Using integer values can work as long as only one cut is applied at a time. Once the cuts are combined with other cuts (i.e. the geometrical cut) an integer value would no longer be well-defined any more as there will be an ambiguity about how each class will define its return value.

In any kind of implementation the interface needs to be changed, either with a different return value or with different function arguments. Compatibility to cut objects based on the existing ALICE cut framework can be reached with wrappers. The implementation here advocates the usage of an object as return value containing
- the selection status
- a reference to the object to be selected
- an (optional) user-defined object containing further information about the return value

This approach has multiple benefits: 
- By overloading operator bool the return value can be treated as simple boolean
- Combining results of multiple cuts will be trivial - a user-defined return object contains the return object of the separate pointers in a TObjArray.
- Clear interface: Arguments are input parameters, return value is the output

As the object contains only one bool and two pointers copy operations are cheap, and in addition c++11 move-semantics is supported as well. The handling of the user-information is done via reference counting: As the user information is depending on the cut class implementation the memory management must be dynamic in this case. This is best achieved with a shared pointer having all copies of the same selection result pointer sharing the same object. To overcome the issue that c++11 is not allowed in header files in order to allow compatibility with antique ROOT versions the shared pointer is re-implemented in the library (quite some unnecessary code overhead).

Various selections used in the AliEmcalTrackSelectionAOD/ESD are expressed as cut object inheriting from the new AliEmcalCutBase class - allowing for the combination of the selection functions. They are still separate, with however identical implementations, and will be combined to one in AliEmcalTrackSelection with removal of AliEmcalTrackSelectionESD/AOD at the same time at a later stage.

As usual for new object the classes are put into the namespace PWG::EMCAL in order to protect them from being re-defined in other translation units.