### PR TITLE
Bug fix for TPC Q-Vect

### DIFF
--- a/PWG/FLOW/Tasks/AliAnalysisTaskCMEV0.h
+++ b/PWG/FLOW/Tasks/AliAnalysisTaskCMEV0.h
@@ -47,6 +47,7 @@ public:
   void    SetInputListNUA(TList *finputNUA)           {this->fListNUACorr       =    finputNUA;}
   void    SetGainCorrZDNP(TList *finputZDN)           {this->fListZDNCorr       =    finputZDN;}
   void    SetFBEfficiencyList(TList *fFBlist)         {this->fListFBHijing      =      fFBlist;}
+  void    SetInputListforV0M(TList *finputV0M)        {this->fListV0MCorr       =    finputV0M;}
   void    SetRejectPileUp(Bool_t  pileup)             {this->fRejectPileUp      =       pileup;}
   void    SetRejectPileUpTight(Bool_t  pileupt8)      {this->fRejectPileUpTight =     pileupt8;}
   void    SetStoreTPCQnAvg(Bool_t bstoreTPCQn)        {this->bFillAvgTPCQn      =  bstoreTPCQn;} 
@@ -66,7 +67,7 @@ public:
   void    SetMCEffiDimension(TString mcDimen)         {this->sMCdimension       =      mcDimen;}
   void    SetRemoveNegTrkRndm(Bool_t remRndm)         {this->bRemNegTrkRndm     =      remRndm;}
   void    SetApplyV0MCorr(Bool_t  bV0Mcorr)           {this->bApplyV0MCorr      =     bV0Mcorr;}
-  void    SetInputFileforV0M(TString finputV0M)       {this->fFileV0MCorr       =    finputV0M;}
+
 
 
 private:
@@ -95,9 +96,11 @@ private:
 
   TList*                 fListHistos;         //! collection of output
   TList*                 fListCalibs;         //! collection of Calib Histos
+
   TList*               fListFBHijing;         // Hijing Efficiency list
   TList*                fListNUACorr;         // NUA Correction List
   TList*                fListZDNCorr;         // ZDC gain Correction Wgts
+  TList*                fListV0MCorr;
 
   Bool_t               fRejectPileUp;         //
   Bool_t          fRejectPileUpTight;         //
@@ -116,7 +119,7 @@ private:
   TString             sCentEstimator;         // Centrality Estimator
   TString                   sFileNUA;         // NUA source file.
   TString               sMCdimension;         // Dimention for MC effi Correction
-  TString               fFileV0MCorr;
+
 
 
   Int_t                  runNums[90];         //!  array of runnumbers
@@ -224,10 +227,13 @@ private:
   TH2F            *fCentDistvsRun; //! 
   TH1D              *fHCorrectV0M; //!   for V0-Mult Gain Correction per channel.
 
-
+  TProfile2D     *fCentV0MvsVzRun; //!
+  TProfile2D     *fCentCL1vsVzRun; //!
 
 
   //TRandom3                fRand; //!
+
+
 
 
 

--- a/PWGCF/FLOW/macros/AddTaskCMEV0.C
+++ b/PWGCF/FLOW/macros/AddTaskCMEV0.C
@@ -2,8 +2,6 @@
 #include "TSystem.h"
 class AliAnalysisTaskCMEV0;
 
-
- //void AddTaskCMEV0(Double_t dcentrMin=0, Double_t dcentrMax=90, TString sAnalysisFile = "AOD", TString sDataSet = "2010", 
  AliAnalysisTaskCMEV0* AddTaskCMEV0(Double_t dcentrMin=0, Double_t dcentrMax=90., Int_t gFilterBit = 768, Int_t gClusterTPC = 70, 
  Double_t fpTLow = 0.2, Double_t fpTHigh = 10.0, Double_t fEtaLow = -0.8, Double_t fEtaHigh = 0.8, TString sAnalysisFile = "AOD", 
  TString sDataSet = "2010", TString sAnalysisType = "AUTOMATIC", TString sEventTrigger = "MB", Bool_t bEventCutsQA = kFALSE, 
@@ -45,7 +43,7 @@ class AliAnalysisTaskCMEV0;
   taskFE->SetQAOn(bEventCutsQA);
   taskFE->SetAnalysisType(sAnalysisType); //sanalysisType = AUTOMATIC see the initializers!!
 
-  if(sDataSet=="2015"||sDataSet=="2015pPb"){
+  if(sDataSet=="2015"||sDataSet=="2015pPb"||sDataSet=="pPb"){
     taskFE->SelectCollisionCandidates(AliVEvent::kINT7);
   }
   else{
@@ -59,7 +57,8 @@ class AliAnalysisTaskCMEV0;
   cutsEvent->SetCheckPileup(kFALSE);
   cutsEvent->SetPrimaryVertexZrange(dVertexLow, dVertexHigh);      // vertex-z cut
   cutsEvent->SetQA(bEventCutsQA);                                  // enable the qa plots
-  if(sDataSet=="2015pPb"){
+
+  if(sDataSet=="2015pPb"||sDataSet=="pPb"){
     cutsEvent->SetCutTPCmultiplicityOutliersAOD(kFALSE); 	   // multiplicity outlier cut
   }
   else {
@@ -217,10 +216,7 @@ class AliAnalysisTaskCMEV0;
   taskQC_prot->SetSkipNestedLoop(bSkipNestedLoop);
   taskQC_prot->SetMCEffiDimension(sFBEffiDimension);
   taskQC_prot->SetRemoveNegTrkRndm(kFALSE);
-  taskQC_prot->SetInputFileforV0M(sZDCFile);
   taskQC_prot->SetApplyV0MCorr(bV0MgainCorr);
-  taskQC_prot->SetInputFileforV0M(sV0MFile);
-
 
 
 
@@ -258,7 +254,7 @@ class AliAnalysisTaskCMEV0;
      if(!fZDCGainFile) {
        printf("\n\n *** ERROR: ZDC wgt file not found! **EXIT** \n\n");
        exit(1);
-     } 
+     }
 
      TList* fZDCWgtUse = dynamic_cast<TList*>(fZDCGainFile->FindObjectAny("fZDN_ZDP_Wgts"));
   
@@ -266,10 +262,34 @@ class AliAnalysisTaskCMEV0;
        taskQC_prot->SetGainCorrZDNP(fZDCWgtUse);
      }
      else{
-       printf("\n\n !!!!**** ERROR:ZDC Channel wgt List not found **EXIT**!!!\n\n");
+       printf("\n\n !!!!**** ERROR: ZDC Channel wgt List not found **EXIT**!!!\n\n");
        exit(1);
      }
   }
+
+
+  if(bV0MgainCorr){
+    TFile* fV0MFile = TFile::Open(sV0MFile,"READ");
+     if(!fV0MFile) {
+       printf("\n\n *** ERROR: VOM Gain correction file not found! **EXIT** \n\n");
+       exit(1);
+     } 
+     else{
+       TList* fListV0MUse = dynamic_cast<TList*>(fV0MFile->FindObjectAny("fV0MChWgts"));
+     }
+
+     if(fListV0MUse) {
+       taskQC_prot->SetInputListforV0M(fListV0MUse);
+     }
+     else{
+       printf("\n\n !!!!**** ERROR: VOM Gain List not found **EXIT**!!!\n\n");
+       taskQC_prot->SetInputListforV0M(NULL);
+       //exit(1);
+     }
+  }
+
+
+ 
 
 
   /*


### PR DESCRIPTION
Bug fix for TPC Q-Vect (Remove |Qn| = 0 events).