### PR TITLE
fix memory safety of fHitFlags in AliTOFAnalysisTaskCalibTree

### DIFF
--- a/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
+++ b/PWGPP/TOF/AliTOFAnalysisTaskCalibTree.cxx
@@ -264,7 +264,7 @@ void AliTOFAnalysisTaskCalibTree::UserExec(Option_t *) {
     fDeltaz[fnhits] = deltaz;
     fDeltat[fnhits] = deltat;
     fDeltaraw[fnhits] = deltaraw;
-   
+    fHitFlag[fnhits] = 0; 
     if (fSaveCoordinates){ // set hit flags
      
          SetClusterFlags(track,fnhits);  // check for multiple hits & adjjacent clusters in X and Z (flags 1,2,4)


### PR DESCRIPTION
patch to ensure re-initialising fHitFlags[] to 0 for each event (previously was being kept from event to event).

[NB I don't know why git decided to flag the entire file as "changed", but the relevant edit is line 267]