### PR TITLE
Implemanetation of exclusion of NLM=2 clusters

### DIFF
--- a/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.h
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.h
@@ -256,93 +256,95 @@ class AliAnalysisTaskEMCALPhotonIsolation: public AliAnalysisTaskEmcal {
   std::vector<Double_t>        fBinsDecay;                      ///<
   
   //IMPLEMENT ALL THE HISTOGRAMS AND ALL THE OUTPUT OBJECTS WE WANT!!!
-  TH1D                       * fTrackMult;                      ///< Track Multiplicity ---QA
-  TH2D                       * fPtvsSumUE_MC;                   ///<
-  TH2D                       * fEtaPhiClus;                     ///< EMCal Cluster Distribution EtaPhi ---QA
-  TH2D                       * fClusEvsClusT;                   ///< Cluster Energy vs Cluster Time ---QA
-  TH1D                       * fPT;                             ///< Pt distribution
-  TH1D                       * fE;                              ///< E distribution
-  TH2D                       * fNLM;                            ///< NLM distribution
-  TH2D                       * fNLM2_NC_Acc;                    ///< NLM ( 1, 2 ) distribution for Neutral Clusters in Acceptance
-  TH1D                       * fVz;                             ///< Vertex Z distribution
-  TH1D                       * fEvents;                         ///< Number of Events
-  TH1D                       * fPtaftTime;                      ///< E distribution for clusters after Cluster Time cut
-  TH1D                       * fPtaftCell;                      ///< Pt distribution for clusters after NCells cut
-  TH1D                       * fPtaftNLM;                       ///< Pt distribution for clusters after NLM cut
-  TH3F                       * fClusEtVsEtaPhiMatched;          ///< Track-matched cluster eta vs. phi vs. E_T
-  TH3F                       * fClusEtVsEtaPhiUnmatched;        ///< Not track-matched cluster eta vs. phi vs. E_T
-  TH1D                       * fPtaftTM;                        ///< E distribution for neutral clusters
-  TH1D                       * fPtaftDTBC;                      ///< E distribution for NC after DistanceToBadChannel cut
-  TH1D                       * fPtaftFC;                        ///< E distribution for clusters after Fiducial cut
-  TH1D                       * fPtaftM02C;                      ///< E distribution for clusters after Shower Shape cut
-  TH1D                       * fClusTime;                       ///< Time distribution for clusters
-  TH2D                       * fM02;                            ///< Squared_Lambda0 ( Squared_sigma_long ) distribution
-  TH3F                       * fEtaPhiClusVsM02;                ///< Cluster eta vs. phi vs. sigma_long squared ( cluster energy from 14 to 16 GeV )
-  TH3F                       * fEtaPhiClusVsEtIsoClus;          ///< Cluster eta vs. phi vs. neutral contribution to the energy in isolation cone ( cluster energy from 14 to 16 GeV )
-  TH3F                       * fEtaPhiClusVsPtIsoTrack;         ///< Cluster eta vs. phi vs. charged contribution to the energy in isolation cone ( cluster energy from 14 to 16 GeV )
-  TH3F                       * fEtaPhiClusVsPtUETrackCside;     ///< Cluster eta vs. phi vs. charged contribution to the energy in C-side UE ( cluster energy from 14 to 16 GeV )
-  TH3F                       * fEtaPhiClusVsPtUETrackAside;     ///< Cluster eta vs. phi vs. charged contribution to the energy in A-side UE ( cluster energy from 14 to 16 GeV )
-  TH1D                       * fDeltaETAClusTrack;              ///< dEta Cluster-Track
-  TH1D                       * fDeltaPHIClusTrack;              ///< dPhi Cluster-Track
-  TH1D                       * fDeltaETAClusTrackMatch;         ///< dEta Cluster-Track matched
-  TH1D                       * fDeltaPHIClusTrackMatch;         ///< dPhi Cluster-Track matched
-  TH1D                       * fEtIsoCells;                     ///< Isolation Energy with EMCal Cells
-  TH2D                       * fEtIsoClust;                     ///< Isolation Energy with EMCal Clusters
-  TH2D                       * fPtIsoTrack;                     ///< Isolation Pt with Tracks
-  TH1D                       * fPtEtIsoTC;                      ///< Isolation with Pt from Tracks and Et from NON-Matched Clusters
-  TH2D                       * fPhiBandUEClust;                 ///< UE with Phi Band ( Clusters )
-  TH2D                       * fEtaBandUEClust;                 ///< UE with Eta Band ( Clusters )
-  TH2D                       * fPhiBandUECells;                 ///< UE with Phi Band ( Cells )
-  TH2D                       * fEtaBandUECells;                 ///< UE with Eta Band ( Cells )
-  TH2D                       * fPhiBandUETracks;                ///< UE with Phi Band ( Tracks )
-  TH2D                       * fEtaBandUETracks;                ///< UE with Eta Band ( Tracks )
-  TH2D                       * fPerpConesUETracks;              ///< UE with Cones ( Tracks ONLY )
-  TH2D                       * fTPCWithoutIsoConeB2BbandUE;     ///< UE with Full TPC except IsoCone and EtaBand in Back2Back
-  TH1D                       * fNTotClus10GeV;                  ///< Number of TOTAL clusters with Energy bigger than 10 GeV
-  TH1D                       * fEtIsolatedCells;                ///< Isolated photons, isolation with cells
-  TH1D                       * fEtIsolatedClust;                ///< Isolated photons, isolation with clusters
-  TH1D                       * fPtIsolatedNClust;               ///< Isolated neutral clusters
-  TH1D                       * fPtIsolatedNTracks;              ///< Isolated neutral clusters with tracks
-  TH1D                       * fEtIsolatedTracks;               ///< Isolated photons, isolation with tracks
-  TH2D                       * fPtvsM02iso;                     ///< Isolated clusters, Pt distribution vs M02
-  TH2D                       * fPtvsM02noiso;                   ///< Non isolated clusters, pt distribution vs M02
-  TH2D                       * fTestIndex;                      ///< Index and local index test
-  TH2D                       * fTestIndexE;                     ///< Index vs cluster energy test
-  TH2D                       * fTestLocalIndexE;                ///< Local index vs cluster energy test
-  TH3F                       * fTestEnergyCone;                 ///< Energy cone clusters vs tracks test
-  /* TH1D                       * fConeArea;                       ///< Cone area distribution ( depending on the cluster position ) */
-  /* TH1D                       * fEtaBandArea;                    ///< Eta-band area distribution ( depending on the cluster position ) */
-  TH2F                       * fEtaBandVsConeArea;              ///< Eta-band vs. cone area distribution ( depending on the cluster position )
-  TH3F                       * fPtVsConeVsEtaBand;              ///< Energy cone clusters vs tracks test ( not normalised )
-  TH3F                       * fPtVsNormConeVsNormEtaBand;      ///< Energy cone clusters vs tracks test ( area normalised )
-  TH3D                       * fPtvsM02vsSumUE_Norm;            ///<
-  TH2D                       * fTestEtaPhiCone;                 ///< Eta vs phi test for clusters in cone
-  TH3D                       * fInvMassM02iso;                  ///<
-  TH3D                       * fInvMassM02noiso;                ///<
-  TH3D                       * fPtvsM02vsSumPi0;                ///<
-  TH3D                       * fPtvsM02vsSumEta;                ///<
-  TH3D                       * fPtvsM02vsSum;                   ///<
-  TH3D                       * fPtvsM02vsSumUE;                 ///<
-  TH3D                       * fTrackMultvsSumChargedvsUE;      ///<
-  TH2D                       * fTrackMultvsPt;                  ///<
-  TH3D                       * fTracksConeEtaPt;                ///<
-  TH3D                       * fTracksConeEtaM02;               ///<
-  TH1F                       * fHistXsection;                   ///<
-  TH1F                       * fHistTrials;                     ///<
-  TH2F                       * fPtTracksVSpTNC;                 ///<
-  TH2F                       * fCTdistVSpTNC;                   ///<
-  TH2F                       * fPtTracksVSpTNC_MC;              ///<
-  TH3F                       * fpi0VSclusterVSIsolation;        ///<
-  TH3F                       * fpi0VSclusterVSM02;              ///<
-  TH3F                       * fpi0VSM02VSIsolation;            ///<
-  TH3F                       * fEtVSM02VSEisoclust;             ///<
-  TH3F                       * fEtVSM02VSPisotrack;             ///<
-  TH2F                       * fPhiTracksVSclustPt;             ///<
-  TH2F                       * fEtaTracksVSclustPt;             ///<
-  TH2F                       * fTracksPhiVsPt;                  ///<
-  TH2F                       * fTracksEtaVsPt;                  ///<
-  TH2F                       * fTrackResolutionPtMC;            ///<
-  TH1D                       * fVzBeforecut;                    ///<
+
+  TH1D                       * fTrackMult;                      ///<  Track Multiplicity ---QA
+  TH2D                       * fPtvsSumUE_MC;                   //!<!
+  TH2D                       * fEtaPhiClus;                     ///<  EMCal Cluster Distribution EtaPhi ---QA
+  TH2D                       * fClusEvsClusT;                   //!<! Cluster Energy vs Cluster Time ---QA
+  TH1D                       * fPT;                             //!<! Pt distribution
+  TH1D                       * fE;                              //!<! E distribution
+  TH2D                       * fNLM;                            //!<! NLM distribution
+  TH2D                       * fNLM2_NC_Acc;                    //!<! NLM (1,2) distribution for Neutral Clusters in Acceptance
+  TH2D                       * fNLM2_NC_Acc_noTcard;            //!<! NLM (1,2) distribution for Neutral Clusters in Acceptance w/o NLM=2 in SameT
+  TH1D                       * fVz;                             //!<! Vertex Z distribution
+  TH1D                       * fEvents;                         //!<! Number of Events
+  TH1D                       * fPtaftTime;                      //!<! E distribution for clusters after Cluster Time cut
+  TH1D                       * fPtaftCell;                      //!<! Pt distribution for clusters after NCells cut
+  TH1D                       * fPtaftNLM;                       //!<! Pt distribution for clusters after NLM cut
+  TH3F                       * fClusEtVsEtaPhiMatched;          //!<! Track-matched cluster eta vs. phi vs. E_T
+  TH3F                       * fClusEtVsEtaPhiUnmatched;        //!<! Not track-matched cluster eta vs. phi vs. E_T
+  TH1D                       * fPtaftTM;                        //!<! E distribution for neutral clusters
+  TH1D                       * fPtaftDTBC;                      //!<! E distribution for NC after DistanceToBadChannel cut
+  TH1D                       * fPtaftFC;                        //!<! E distribution for clusters after Fiducial cut
+  TH1D                       * fPtaftM02C;                      //!<! E distribution for clusters after Shower Shape cut
+  TH1D                       * fClusTime;                       //!<! Time distribution for clusters
+  TH2D                       * fM02;                            //!<! Squared_Lambda0 (Squared_sigma_long) distribution
+  TH3F                       * fEtaPhiClusVsM02;                //!<! Cluster eta vs. phi vs. sigma_long squared (cluster energy from 14 to 16 GeV)
+  TH3F                       * fEtaPhiClusVsEtIsoClus;          //!<! Cluster eta vs. phi vs. neutral contribution to the energy in isolation cone (cluster energy from 14 to 16 GeV)
+  TH3F                       * fEtaPhiClusVsPtIsoTrack;         //!<! Cluster eta vs. phi vs. charged contribution to the energy in isolation cone (cluster energy from 14 to 16 GeV)
+  TH3F                       * fEtaPhiClusVsPtUETrackCside;     //!<! Cluster eta vs. phi vs. charged contribution to the energy in C-side UE (cluster energy from 14 to 16 GeV)
+  TH3F                       * fEtaPhiClusVsPtUETrackAside;     //!<! Cluster eta vs. phi vs. charged contribution to the energy in A-side UE (cluster energy from 14 to 16 GeV)
+  TH1D                       * fDeltaETAClusTrack;              //!<! dEta Cluster-Track
+  TH1D                       * fDeltaPHIClusTrack;              //!<! dPhi Cluster-Track
+  TH1D                       * fDeltaETAClusTrackMatch;         //!<! dEta Cluster-Track matched
+  TH1D                       * fDeltaPHIClusTrackMatch;         //!<! dPhi Cluster-Track matched
+  TH1D                       * fEtIsoCells;                     //!<! Isolation Energy with EMCal Cells
+  TH2D                       * fEtIsoClust;                     //!<! Isolation Energy with EMCal Clusters
+  TH2D                       * fPtIsoTrack;                     //!<! Isolation Pt with Tracks
+  TH1D                       * fPtEtIsoTC;                      //!<! Isolation with Pt from Tracks and Et from NON-Matched Clusters
+  TH2D                       * fPhiBandUEClust;                 //!<! UE with Phi Band (Clusters)
+  TH2D                       * fEtaBandUEClust;                 //!<! UE with Eta Band (Clusters)
+  TH2D                       * fPhiBandUECells;                 //!<! UE with Phi Band (Cells)
+  TH2D                       * fEtaBandUECells;                 //!<! UE with Eta Band (Cells)
+  TH2D                       * fPhiBandUETracks;                //!<! UE with Phi Band (Tracks)
+  TH2D                       * fEtaBandUETracks;                //!<! UE with Eta Band (Tracks)
+  TH2D                       * fPerpConesUETracks;              //!<! UE with Cones (Tracks ONLY)
+  TH2D                       * fTPCWithoutIsoConeB2BbandUE;     //!<! UE with Full TPC except IsoCone and EtaBand in Back2Back
+  TH1D                       * fNTotClus10GeV;                  //!<! Number of TOTAL clusters with Energy bigger than 10 GeV
+  TH1D                       * fEtIsolatedCells;                //!<! Isolated photons, isolation with cells
+  TH1D                       * fEtIsolatedClust;                //!<! Isolated photons, isolation with clusters
+  TH1D                       * fPtIsolatedNClust;               //!<! Isolated neutral clusters
+  TH1D                       * fPtIsolatedNTracks;              //!<! Isolated neutral clusters with tracks
+  TH1D                       * fEtIsolatedTracks;               //!<! Isolated photons, isolation with tracks
+  TH2D                       * fPtvsM02iso;                     //!<! Isolated clusters, Pt distribution vs M02
+  TH2D                       * fPtvsM02noiso;                   //!<! Non isolated clusters, pt distribution vs M02
+  TH2D                       * fTestIndex;                      //!<! Index and local index test
+  TH2D                       * fTestIndexE;                     //!<! Index vs cluster energy test
+  TH2D                       * fTestLocalIndexE;                //!<! Local index vs cluster energy test
+  TH3F                       * fTestEnergyCone;                 //!<! Energy cone clusters vs tracks test
+  /* TH1D                       * fConeArea;                       //!<! Cone area distribution (depending on the cluster position) */
+  /* TH1D                       * fEtaBandArea;                    //!<! Eta-band area distribution (depending on the cluster position) */
+  TH2F                       * fEtaBandVsConeArea;              //!<! Eta-band vs. cone area distribution (depending on the cluster position)
+  TH3F                       * fPtVsConeVsEtaBand;              //!<! Energy cone clusters vs tracks test (not normalised)
+  TH3F                       * fPtVsNormConeVsNormEtaBand;      //!<! Energy cone clusters vs tracks test (area normalised)
+  TH3F                       * fPtvsM02vsSumUE_Norm;
+  TH2D                       * fTestEtaPhiCone;                 //!<! Eta vs phi test for clusters in cone
+  TH3D                       * fInvMassM02iso;                  //!<!
+  TH3D                       * fInvMassM02noiso;                //!<!
+  TH3D                       * fPtvsM02vsSumPi0;                //!<!
+  TH3D                       * fPtvsM02vsSumEta;                //!<!
+  TH3D                       * fPtvsM02vsSum;                   //!<!
+  TH3D                       * fPtvsM02vsSumUE;                 //!<!
+  TH3D                       * fTrackMultvsSumChargedvsUE;      //!<!
+  TH2D                       * fTrackMultvsPt;                  //!<!
+  TH3D                       * fTracksConeEtaPt;                //!<!
+  TH3D                       * fTracksConeEtaM02;               //!<!
+  TH1F                       * fHistXsection;                   //!<!
+  TH1F                       * fHistTrials;                     //!<!
+  TH2F                       * fPtTracksVSpTNC;                 //!<!
+  TH2F                       * fCTdistVSpTNC;                   //!<!
+  TH2F                       * fPtTracksVSpTNC_MC;              //!<!
+  TH3F                       * fpi0VSclusterVSIsolation;        //!<!
+  TH3F                       * fpi0VSclusterVSM02;              //!<!
+  TH3F                       * fpi0VSM02VSIsolation;            //!<!
+  TH3F                       * fEtVSM02VSEisoclust;             //!<!
+  TH3F                       * fEtVSM02VSPisotrack;             //!<!
+  TH2F                       * fPhiTracksVSclustPt;             //!<!
+  TH2F                       * fEtaTracksVSclustPt;             //!<!
+  TH2F                       * fTracksPhiVsPt;                  //!<!
+  TH2F                       * fTracksEtaVsPt;                  //!<!
+  TH2F                       * fTrackResolutionPtMC;            //!<!
+  TH1D                       * fVzBeforecut;                    //!<!
   
   THnSparse                  * fOutputTHnS;                     ///< 1st Method 4 Output
   THnSparse                  * fOutMCTruth;                     ///< 1st Method 4 MC truth Output // Isolation on pTMax

--- a/PWGGA/EMCALTasks/macros/AddTaskEMCALPhotonIsolation.C
+++ b/PWGGA/EMCALTasks/macros/AddTaskEMCALPhotonIsolation.C
@@ -44,7 +44,8 @@ AliAnalysisTaskEMCALPhotonIsolation* AddTaskEMCALPhotonIsolation(
                                                                  TString                triggerName               = "",
                                                                  const Bool_t           RejectPileUpEvent         = kFALSE,
                                                                  const Int_t            NContrToPileUp            = 3,
-                                                                 const Float_t          iFiducialCut              = 0.4
+                                                                 const Float_t          iFiducialCut              = 0.4,
+                                                                 const Bool_t           bANwithNoSameTcard        = kFALSE
                                                                  )
 {
   Printf("Preparing neutral cluster analysis\n");
@@ -127,7 +128,7 @@ AliAnalysisTaskEMCALPhotonIsolation* AddTaskEMCALPhotonIsolation(
     pileUp = "";
   }
   
-  myContName.Append(Form("%s_TM_%s_CPVe%.2lf_CPVp%.2lf_IsoMet%d_EtIsoMet%d_UEMet%d_TPCbound_%s_IsoConeR%.1f_NLMCut_%s_minNLM%d_maxNLM%d_SSsmear_%s_Width%.3f_Mean_%.3f_PureIso_%s_WhichSmear_%d%s%s",is2012_EGA ? "_L1recalc":"",bTMClusterRejection? "On" :"Off", TMdeta , TMdphi ,iIsoMethod,iEtIsoMethod,iUEMethod,bUseofTPC ? "Yes" : "No",iIsoConeRadius,bNLMCut ? "On": "Off",minNLM, NLMCut, iSmearingSS ? "On":"Off",iWidthSSsmear,iMean_SSsmear,iExtraIsoCuts?"On":"Off",bWhichToSmear,triggerName.Data(),pileUp.Data()));
+  myContName.Append(Form("%s_TM_%s_CPVe%.2lf_CPVp%.2lf_IsoMet%d_EtIsoMet%d_UEMet%d_TPCbound_%s_IsoConeR%.1f_NLMCut_%s_minNLM%d_maxNLM%d_SSsmear_%s_Width%.3f_Mean_%.3f_PureIso_%s_WhichSmear_%d%s%s%s",is2012_EGA ? "_L1recalc":"",bTMClusterRejection? "On" :"Off", TMdeta , TMdphi ,iIsoMethod,iEtIsoMethod,iUEMethod,bUseofTPC ? "Yes" : "No",iIsoConeRadius,bNLMCut ? "On": "Off",minNLM, NLMCut, iSmearingSS ? "On":"Off",iWidthSSsmear,iMean_SSsmear,iExtraIsoCuts?"On":"Off",bWhichToSmear,triggerName.Data(),pileUp.Data(),bANwithNoSameTcard?"_NoSameTcard":""));
 
   // Switch on/off the p-Pb analysis features
   Bool_t i_pPb = kFALSE;
@@ -236,6 +237,7 @@ AliAnalysisTaskEMCALPhotonIsolation* AddTaskEMCALPhotonIsolation(
   task->SetNcontributorsToPileUp(NContrToPileUp);
   task->SetFiducialCut(iFiducialCut);
   task->Set2012L1Analysis(is2012_EGA);
+  task->SetANWithNoSameTcard(bANwithNoSameTcard);
 
   if(triggerName.Contains("EG1") || triggerName.Contains("EGA1")){
     if(bIsMC)


### PR DESCRIPTION
with both NLM=2 from same T card. 
This is done because of the newly found cross talk problem within the Tcards of EMCal.

