### PR TITLE
PWGDQ DielectronMC streamlined AliAODMCParticle usage

### DIFF
--- a/PWGDQ/dielectron/core/AliDielectronMC.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronMC.cxx
@@ -83,10 +83,12 @@ AliDielectronMC* AliDielectronMC::Instance()
 //____________________________________________________________
 AliDielectronMC::AliDielectronMC(AnalysisType type):
   fMCEvent(0x0),
+  fAODMCHeader(0x0),
+  fGenCocktailHeader(0x0),
   fAnaType(type),
   fHasMC(kTRUE),
   fCheckHF(kFALSE),
-  fEvtHFtype(0),
+  fhfproc(),
   fHasHijingHeader(-1),
   fMcArray(0x0)
 {
@@ -120,14 +122,20 @@ Int_t AliDielectronMC::GetNMCTracks()
   //
   //  return the number of generated tracks from MC event
   //
-  if(fAnaType == kESD){
-    if (!fMCEvent){ AliError("No fMCEvent"); return 0; }
-    return fMCEvent->GetNumberOfTracks();}
-  else if(fAnaType == kAOD){
-    if(!fMcArray) { AliError("No fMcArray"); return 0; }
-    return fMcArray->GetEntriesFast();
+  // if(fAnaType == kESD){
+  //   if (!fMCEvent){ AliError("No fMCEvent"); return 0; }
+  //   return fMCEvent->GetNumberOfTracks();}
+  // else if(fAnaType == kAOD){
+  //   if(!fMcArray) { AliError("No fMcArray"); return 0; }
+  //   return fMcArray->GetEntriesFast();
+  // }
+  // return 0;
+  // Splitting between ESDs and AODs not needed anymore should work fine this way. PD 2017-10-05
+  if(!fMCEvent){
+    AliError("No fMCEvent");
+    return -999;
   }
-  return 0;
+  else return fMCEvent->GetNumberOfTracks();
 }
 
 //____________________________________________________________
@@ -169,14 +177,17 @@ AliVParticle* AliDielectronMC::GetMCTrackFromMCEvent(Int_t label) const
   //
   if (label<0) return NULL;
   AliVParticle * track=0x0;
-  if(fAnaType == kESD){
-    if (!fMCEvent){ AliError("No fMCEvent"); return NULL;}
-    track = fMCEvent->GetTrack(label); //  tracks from MC event (ESD)
-  } else if(fAnaType == kAOD) {
-    if (!fMcArray){ AliError("No fMcArray"); return NULL;}
-    if (label>fMcArray->GetEntriesFast()) { AliWarning(Form("track %d out of array size %d",label,fMcArray->GetEntriesFast())); return NULL;}
-    track = (AliVParticle*)fMCEvent->GetTrack(label);
-  }
+  if (!fMCEvent){ AliError("No fMCEvent"); return NULL;}
+  track = fMCEvent->GetTrack(label); //  tracks from MC event
+  //Splitting between ESD and AOD should be obsolete 2017-10-05 PD
+  // if(fAnaType == kESD){
+  //   if (!fMCEvent){ AliError("No fMCEvent"); return NULL;}
+  //   track = fMCEvent->GetTrack(label); //  tracks from MC event (ESD)
+  // } else if(fAnaType == kAOD) {
+  //   if (!fMcArray){ AliError("No fMcArray"); return NULL;}
+  //   if (label>fMcArray->GetEntriesFast()) { AliWarning(Form("track %d out of array size %d",label,fMcArray->GetEntriesFast())); return NULL;}
+  //   track = (AliVParticle*)fMCEvent->GetTrack(label);
+  // }
   return track;
 }
 
@@ -202,7 +213,7 @@ Bool_t AliDielectronMC::ConnectMCEvent()
     fMCEvent = mcEvent;
 
     if (fCheckHF){
-      fEvtHFtype=0;
+      fhfproc.clear();
       fCheckHF=LoadHFPairs(); // So far only compatible with ESD
     }
   }
@@ -214,6 +225,7 @@ Bool_t AliDielectronMC::ConnectMCEvent()
     if (!aod) return kFALSE;
 
     fMCEvent = aodHandler->MCEvent();
+    fAODMCHeader = (AliAODMCHeader*) aod->FindListObject(AliAODMCHeader::StdBranchName());
     if (!fMCEvent) AliError("No MCEvent available");
 
     fMcArray = dynamic_cast<TClonesArray*>(aod->FindListObject(AliAODMCParticle::StdBranchName()));
@@ -221,6 +233,20 @@ Bool_t AliDielectronMC::ConnectMCEvent()
     else fHasMC=kTRUE;
   }
   return kTRUE;
+}
+
+//____________________________________________________________
+AliVParticle* AliDielectronMC::GetMCTrack(const AliVParticle* _track)
+{
+  //
+  // return MC track without in/output casting
+  //
+  if (!fMCEvent){ AliError("No fMCEvent"); return NULL;}
+  Int_t nStack = fMCEvent->GetNumberOfTracks();
+  Int_t label  = TMath::Abs(_track->GetLabel()); // negative label indicate poor matching quality
+  if(label > nStack)  return NULL;
+  AliVParticle *mctrack = (fMCEvent->GetTrack(label));
+  return mctrack;
 }
 
 //____________________________________________________________
@@ -244,12 +270,12 @@ AliAODMCParticle* AliDielectronMC::GetMCTrack( const AliAODTrack* _track)
   //
   // return MC track
   //
- if(!fMcArray) { AliError("No fMcArray"); return NULL;}
- Int_t nStack = fMcArray->GetEntriesFast();
- Int_t label  = TMath::Abs(_track->GetLabel()); // negative label indicate poor matching quality
- if(label > nStack) return NULL;
- AliAODMCParticle *mctrack = (AliAODMCParticle*)fMcArray->At(label);
- return mctrack;
+  if(!fMCEvent) { AliError("No fMCEvent"); return NULL;}
+  Int_t nStack = fMCEvent->GetNumberOfTracks();
+  Int_t label  = TMath::Abs(_track->GetLabel()); // negative label indicate poor matching quality
+  if(label > nStack) return NULL;
+  AliAODMCParticle *mctrack = (AliAODMCParticle*) fMCEvent->GetTrack(label);
+  return mctrack;
 }
 
 //____________________________________________________________
@@ -258,11 +284,11 @@ TParticle* AliDielectronMC::GetMCTrackFromStack(const AliESDtrack* _track)
   //
   // return MC track from MC event
   //
-   if (!fMCEvent){ AliError("No fMCEvent"); return NULL;}                                                                                                                               
-   Int_t nStack = fMCEvent->GetNumberOfTracks();                                                                                                                                        
-   Int_t label  = TMath::Abs(_track->GetLabel());                                                                                                                                       
-   if(label > nStack) return NULL;                                                                                                                                                      
-   TParticle* mcpart = fMCEvent->Particle(label); 
+   if (!fMCEvent){ AliError("No fMCEvent"); return NULL;}
+   Int_t nStack = fMCEvent->GetNumberOfTracks();
+   Int_t label  = TMath::Abs(_track->GetLabel());
+   if(label > nStack) return NULL;
+   TParticle* mcpart = fMCEvent->Particle(label);
    if (!mcpart) return NULL;
    return mcpart;
 }
@@ -284,15 +310,17 @@ AliMCParticle* AliDielectronMC::GetMCTrackMother(const AliESDtrack* _track)
 //______________________________________________________________
 AliAODMCParticle* AliDielectronMC::GetMCTrackMother(const AliAODTrack* _track)
 {
- //
- // return MC track mother
- //
- AliAODMCParticle* mcpart = GetMCTrack(_track);
- if (!mcpart) return NULL;
- if(mcpart->GetMother() < 0) return NULL;
- AliAODMCParticle* mcmother = dynamic_cast<AliAODMCParticle *>(fMcArray->At(mcpart->GetMother()));
- if (!mcmother) return NULL;
- return mcmother;
+  //
+  // return MC track mother
+  //
+  AliAODMCParticle* mcpart = GetMCTrack(_track);
+  if (!mcpart) return NULL;
+
+  return AliDielectronMC::GetMCTrackMother(mcpart);
+  // if(mcpart->GetMother() < 0) return NULL;
+  // AliAODMCParticle* mcmother = dynamic_cast<AliAODMCParticle *>(fMcArray->At(mcpart->GetMother()));
+  // if (!mcmother) return NULL;
+  // return mcmother;
 }
 //____________________________________________________________
 AliMCParticle* AliDielectronMC::GetMCTrackMother(const AliMCParticle* _particle){
@@ -309,8 +337,9 @@ AliAODMCParticle* AliDielectronMC::GetMCTrackMother(const AliAODMCParticle* _par
   //
   // return MC track mother
   //
+
   if( _particle->GetMother() < 0) return NULL;
-  AliAODMCParticle* mcmother = dynamic_cast<AliAODMCParticle *>(fMcArray->At(_particle->GetMother()));
+  AliAODMCParticle* mcmother = dynamic_cast<AliAODMCParticle *>(fMCEvent->GetTrack(_particle->GetMother()));
   return mcmother;
 }
 
@@ -512,23 +541,41 @@ Bool_t AliDielectronMC::IsMCMotherToEE(const AliVParticle *particle, Int_t pdgMo
   //
   // Check if the Mother 'particle' is of type pdgMother and decays to e+e-
   //
-  if (fAnaType==kESD && !fMCEvent) return kFALSE;
-  if (fAnaType==kAOD && !fMcArray) return kFALSE;
+  if(!fMCEvent) return kFALSE;
+  // if (fAnaType==kESD && !fMCEvent) return kFALSE;
+  // if (fAnaType==kAOD && !fMcArray) return kFALSE;
   if (!particle) return kFALSE;
 
-  if (particle->IsA()==AliMCParticle::Class()){
-    return IsMCMotherToEEesd(static_cast<const AliMCParticle*>(particle),pdgMother);
-  } else if (particle->IsA()==AliAODMCParticle::Class()){
-   return IsMCMotherToEEaod(static_cast<const AliAODMCParticle*>(particle),pdgMother);
-  } else {
+  if (!(particle->IsA()==AliMCParticle::Class() || particle->IsA()==AliAODMCParticle::Class())){
     AliError("Unknown particle type");
+    return kFALSE;
   }
-  return kFALSE;
+  //check pdg code
+  if (particle->PdgCode()!=pdgMother) return kFALSE;
+  Int_t ifirst = particle->GetFirstDaughter();
+  Int_t ilast  = particle->GetLastDaughter();
+
+  //check number of daughters
+  if ((ilast-ifirst)!=1) return kFALSE;
+  AliVParticle *firstD = (AliVParticle*) (GetMCTrackFromMCEvent(ifirst));
+  AliVParticle *secondD = (AliVParticle*) (GetMCTrackFromMCEvent(ilast));
+
+  //TODO: check how you can get rid of the hardcoded numbers. One should make use of the PdgCodes set in AliDielectron!!!
+  if (firstD->Charge()>0){
+    if (firstD->PdgCode()!=-11) return kFALSE;
+    if (secondD->PdgCode()!=11) return kFALSE;
+  }else{
+    if (firstD->PdgCode()!=11) return kFALSE;
+    if (secondD->PdgCode()!=-11) return kFALSE;
+  }
+
+  return kTRUE;
 }
 
 //____________________________________________________________
 Bool_t AliDielectronMC::IsMCMotherToEEesd(const AliMCParticle *particle, Int_t pdgMother)
 {
+  // Obsolete function case splitting not needed 2017-10-05 PD
   //
   // Check if the Mother 'particle' is of type pdgMother and decays to e+e-
   // ESD case
@@ -559,6 +606,7 @@ Bool_t AliDielectronMC::IsMCMotherToEEesd(const AliMCParticle *particle, Int_t p
 //____________________________________________________________
 Bool_t AliDielectronMC::IsMCMotherToEEaod(const AliAODMCParticle *particle, Int_t pdgMother)
 {
+  // Obsolete function case splitting not needed 2017-10-05 PD
   //
   // Check if the Mother 'particle' is of type pdgMother and decays to e+e-
   // AOD case
@@ -567,8 +615,8 @@ Bool_t AliDielectronMC::IsMCMotherToEEaod(const AliAODMCParticle *particle, Int_
   if (particle->GetPdgCode()!=pdgMother) return kFALSE;
   if (particle->GetNDaughters()!=2) return kFALSE;
 
-  Int_t ifirst = particle->GetDaughter(0);
-  Int_t ilast  = particle->GetDaughter(1);
+  Int_t ifirst = particle->GetFirstDaughter();
+  Int_t ilast  = particle->GetLastDaughter();
 
   //check number of daughters
   if ((ilast-ifirst)!=1) return kFALSE;
@@ -594,22 +642,34 @@ Int_t AliDielectronMC::GetLabelMotherWithPdg(const AliVParticle *particle1, cons
   //
   // test if mother of particle 1 and 2 has pdgCode pdgMother and is the same;
   //
-  if (fAnaType==kESD){
+  //TODO: check how you can get rid of the hardcoded numbers. One should make use of the PdgCodes set in AliDielectron!!!
+  //
   if (!fMCEvent) return -1;
-  return GetLabelMotherWithPdgESD(particle1, particle2, pdgMother);
-  }
-  else if (fAnaType==kAOD)
-  {
-  if (!fMcArray) return -1;
-  return GetLabelMotherWithPdgAOD(particle1, particle2, pdgMother);
-  }
 
-  return -1;
+  Int_t lblMother1=particle1->GetMother();
+  Int_t lblMother2=particle2->GetMother();
+
+  AliVParticle *mcMother1 = (AliVParticle*) GetMCTrackFromMCEvent(lblMother1);
+
+  if (!mcMother1) return -1;
+  if (lblMother1!=lblMother2) return -1;
+  if (TMath::Abs(particle1->PdgCode())!=11) return -1;
+  if (particle1->PdgCode()!=-particle2->PdgCode()) return -1;
+  if (mcMother1->PdgCode()!=pdgMother) return -1;
+
+  return lblMother1;
+
+  // AOD ESD case splitting is obsolete 2017-10-05 PD
+  // if (fAnaType==kESD) return GetLabelMotherWithPdgESD(particle1, particle2, pdgMother);
+  // if (fAnaType==kAOD) return GetLabelMotherWithPdgAOD(particle1, particle2, pdgMother);
+
+  // return -1;
 }
 
 //____________________________________________________________
 Int_t AliDielectronMC::GetLabelMotherWithPdgESD(const AliVParticle *particle1, const AliVParticle *particle2, Int_t pdgMother)
 {
+  //Obsolete function 2017-10-05 PD
   //
   // test if mother of particle 1 and 2 has pdgCode +-11 (electron),
   //    have the same mother and the mother had pdg code pdgMother
@@ -640,6 +700,7 @@ Int_t AliDielectronMC::GetLabelMotherWithPdgESD(const AliVParticle *particle1, c
 //____________________________________________________________
 Int_t AliDielectronMC::GetLabelMotherWithPdgAOD(const AliVParticle *particle1, const AliVParticle *particle2, Int_t pdgMother)
 {
+  //Obsolete function 2017-10-05 PD
   //
   // test if mother of particle 1 and 2 has pdgCode +-11 (electron),
   //    have the same mother and the mother had pdg code pdgMother
@@ -677,21 +738,17 @@ void AliDielectronMC::GetDaughters(const TObject *mother, AliVParticle* &d1, Ali
   Int_t lblD2=-1;
   d1=0;
   d2=0;
-  if (fAnaType==kAOD){
-    if(!fMcArray) return;
-    const AliAODMCParticle *aodMother=static_cast<const AliAODMCParticle*>(mother);
-    lblD1=aodMother->GetDaughter(0);
-    lblD2=aodMother->GetDaughter(1);
-    d1 = (AliVParticle*)fMcArray->At(lblD1);
-    d2 = (AliVParticle*)fMcArray->At(lblD2);
-   } else if (fAnaType==kESD){
-    if (!fMCEvent) return;
-    const AliMCParticle *aodMother=static_cast<const AliMCParticle*>(mother);
-    lblD1=aodMother->GetFirstDaughter();
-    lblD2=aodMother->GetLastDaughter();
-    d1=fMCEvent->GetTrack(lblD1);
-    d2=fMCEvent->GetTrack(lblD2);
-   }
+
+  if (!fMCEvent){
+    AliError("No fMCEvent - break!");
+    return;
+  }
+  AliVParticle *mcMother = (AliVParticle*) mother;
+  lblD1 = mcMother->GetFirstDaughter();
+  lblD2 = mcMother->GetLastDaughter();
+  d1 = fMCEvent->GetTrack(lblD1);
+  d2 = fMCEvent->GetTrack(lblD2);
+
 }
 
 
@@ -702,16 +759,9 @@ Int_t AliDielectronMC::GetMothersLabel(Int_t daughterLabel) const {
   //  NOTE: for tracks, the absolute label should be passed
   //
   if(daughterLabel<0) return -1;
-  if (fAnaType==kAOD) {
-    if(!fMcArray) return -1;
-    if(GetMCTrackFromMCEvent(daughterLabel))
-      return (static_cast<AliAODMCParticle*>(GetMCTrackFromMCEvent(daughterLabel)))->GetMother();
-  } else if(fAnaType==kESD) {
-    if (!fMCEvent) return -1;
-    if(GetMCTrackFromMCEvent(daughterLabel))
-      return (static_cast<AliMCParticle*>(GetMCTrackFromMCEvent(daughterLabel)))->GetMother();
-  }
-  return -1;
+  if (!fMCEvent) return -1;
+  Int_t momsLabel = GetMCTrackFromMCEvent(daughterLabel)->GetMother();
+  return momsLabel;
 }
 
 
@@ -722,14 +772,8 @@ Int_t AliDielectronMC::GetPdgFromLabel(Int_t label) const {
   //  NOTE: for tracks, the absolute label should be passed
   //
   if(label<0) return 0;
-  if(fAnaType==kAOD) {
-    if(!fMcArray) return 0;
-    return (static_cast<AliAODMCParticle*>(GetMCTrackFromMCEvent(label)))->PdgCode();
-  } else if(fAnaType==kESD) {
-    if (!fMCEvent) return 0;
-    return (static_cast<AliMCParticle*>(GetMCTrackFromMCEvent(label)))->PdgCode();
-  }
-  return 0;
+  if (!fMCEvent) return 0;
+  return GetMCTrackFromMCEvent(label)->PdgCode();
 }
 
 
@@ -1006,27 +1050,20 @@ Bool_t AliDielectronMC::IsPhysicalPrimary(Int_t label) const {
   // 5.) includes products of directly produced pi0 decays
   // 6.) includes products of directly produced beauty hadron decays
   //
+
+  if (!fMCEvent) return kFALSE;
   if(label<0) return kFALSE;
-  if(fAnaType==kAOD) {
-    if(!fMcArray) return kFALSE;
-    return (static_cast<AliAODMCParticle*>(GetMCTrackFromMCEvent(label)))->IsPhysicalPrimary();
-  } else if(fAnaType==kESD) {
-    if (!fMCEvent) return kFALSE;
-    return fMCEvent->IsPhysicalPrimary(label);
-  }
-  return kFALSE;
+  return GetMCTrackFromMCEvent(label)->IsPhysicalPrimary();
 }
 
 //________________________________________________________________________________
 Bool_t AliDielectronMC::IsPrimary(Int_t label) const {
   //
   if(label<0) return kFALSE;
+  if(!fMCEvent) return kFALSE;
   if(fAnaType==kAOD) {
-    if(!fMcArray) return kFALSE;
-
     return (static_cast<AliAODMCParticle*>(GetMCTrackFromMCEvent(label)))->IsPrimary();
   } else if(fAnaType==kESD) {
-    if (!fMCEvent) return kFALSE;
     return (label>=0 && label<=GetNPrimary());
   }
   return kFALSE;
@@ -1036,16 +1073,23 @@ Bool_t AliDielectronMC::IsPrimary(Int_t label) const {
 Bool_t AliDielectronMC::IsSecondary(Int_t label) const {
   //
   if(label<0) return kFALSE;
-  if(fAnaType==kAOD) {
-    if(!fMcArray) return kFALSE;
-    AliAODMCParticle* mctrack = static_cast<AliAODMCParticle*>(GetMCTrackFromMCEvent(label));
-    Bool_t isSecondary = mctrack->IsSecondaryFromMaterial() || mctrack->IsSecondaryFromWeakDecay();
-    return isSecondary;
-  } else if(fAnaType==kESD) {
-    if (!fMCEvent) return kFALSE;
-    return (label>=GetNPrimary() && !IsPhysicalPrimary(label));
-  }
-  return kFALSE;
+  if (!fMCEvent) return kFALSE;
+  if(IsPrimary(label)) return kFALSE;
+  if(IsPhysicalPrimary(label)) return kFALSE;
+
+  return kTRUE;
+
+  // Old implementation different approach for AODs and ESDs not needed anymore -- 2017-10-05 PD
+  // if(fAnaType==kAOD) {
+  //   if(!fMcArray) return kFALSE;
+  //   AliAODMCParticle* mctrack = static_cast<AliAODMCParticle*>(GetMCTrackFromMCEvent(label));
+  //   Bool_t isSecondary = mctrack->IsSecondaryFromMaterial() || mctrack->IsSecondaryFromWeakDecay();
+  //   return isSecondary;
+  // } else if(fAnaType==kESD) {
+  //   if (!fMCEvent) return kFALSE;
+  //   return (label>=GetNPrimary() && !IsPhysicalPrimary(label));
+  // }
+  // return kFALSE;
 }
 
 //________________________________________________________________________________
@@ -1055,14 +1099,20 @@ Bool_t AliDielectronMC::IsSecondaryFromWeakDecay(Int_t label) const {
   // definition in AliStack::IsSecondaryFromWeakDecay(Int_t label)
   //
   if(label<0) return kFALSE;
-  if(fAnaType==kAOD) {
-    if(!fMcArray) return kFALSE;
-    return (static_cast<AliAODMCParticle*>(GetMCTrackFromMCEvent(label)))->IsSecondaryFromWeakDecay();
-  } else if(fAnaType==kESD) {
-    if (!fMCEvent) return kFALSE;
-    return fMCEvent->IsSecondaryFromWeakDecay(label);
-  }
-  return kFALSE;
+  if(!fMCEvent) return kFALSE;
+
+  return ((AliVParticle*) GetMCTrackFromMCEvent(label))->IsSecondaryFromWeakDecay();
+
+  // Old implementation different approach for AODs and ESDs not needed anymore -- 2017-10-05 PD
+
+  // if(fAnaType==kAOD) {
+  //   if(!fMcArray) return kFALSE;
+  //   return (static_cast<AliAODMCParticle*>(GetMCTrackFromMCEvent(label)))->IsSecondaryFromWeakDecay();
+  // } else if(fAnaType==kESD) {
+  //   if(!fMCEvent) return kFALSE;
+  //   return fMCEvent->IsSecondaryFromWeakDecay(label);
+  // }
+  // return kFALSE;
 }
 
 //________________________________________________________________________________
@@ -1072,14 +1122,19 @@ Bool_t AliDielectronMC::IsSecondaryFromMaterial(Int_t label) const {
   // definition in AliStack::IsSecondaryFromMaterial(Int_t label)
   //
   if(label<0) return kFALSE;
-  if(fAnaType==kAOD) {
-    if(!fMcArray) return kFALSE;
-    return (static_cast<AliAODMCParticle*>(GetMCTrackFromMCEvent(label)))->IsSecondaryFromMaterial();
-  } else if(fAnaType==kESD) {
-    if (!fMCEvent) return kFALSE;
-    return fMCEvent->IsSecondaryFromMaterial(label);
-  }
-  return kFALSE;
+  if(!fMCEvent) return kFALSE;
+
+  return ((AliVParticle*) GetMCTrackFromMCEvent(label))->IsSecondaryFromMaterial();
+
+  // Old implementation different approach for AODs and ESDs not needed anymore -- 2017-10-05 PD
+  // if(fAnaType==kAOD) {
+  //   if(!fMcArray) return kFALSE;
+  //   return (static_cast<AliAODMCParticle*>(GetMCTrackFromMCEvent(label)))->IsSecondaryFromMaterial();
+  // } else if(fAnaType==kESD) {
+  //   if (!fMCEvent) return kFALSE;
+  //   return fMCEvent->IsSecondaryFromMaterial(label);
+  // }
+  // return kFALSE;
 }
 
 
@@ -1139,7 +1194,7 @@ Bool_t AliDielectronMC::CheckParticleSource(Int_t label, AliDielectronSignalMC::
       // 1.) Initial state particles (the 2 protons in Pythia pp collisions)
       // 2.) In some codes, with sudden freeze-out, all particles generated from the fireball are direct.
       //     There is no history for these particles.
-      // 3.) Certain particles added via MC generator cocktails (e.g. J/psi added to pythia MB events)
+      // 3.) Certain particles added via MC generator cocktails (e.g. J/psi added to pythia MB events
       return (label>=0 && GetMothersLabel(label)<0);
       break;
     case AliDielectronSignalMC::kNoCocktail :
@@ -1177,6 +1232,81 @@ Bool_t AliDielectronMC::CheckParticleSource(Int_t label, AliDielectronSignalMC::
   return kFALSE;
 
 }
+
+//___________________________________________________________________
+Bool_t AliDielectronMC::CheckParticleSource(const AliAODMCParticle *mcPart, AliDielectronSignalMC::ESource source) const {
+  //
+  //  Check the source for the particle mcPart
+  //  NOTE: preferable function for AODs, since one anyhow needs the particle to check it's source and getting the correct label is not always do able.
+  //
+
+  switch (source) {
+    case AliDielectronSignalMC::kDontCare :
+      return kTRUE;
+    break;
+    case AliDielectronSignalMC::kPrimary :
+      // true if label is in the list of particles from physics generator
+      // NOTE: This includes all physics event history (initial state particles,
+      //       exchange bosons, quarks, di-quarks, strings, un-stable particles, final state particles)
+      //       Only the final state particles make it to the detector!!
+      return mcPart->IsPrimary();
+    break;
+    case AliDielectronSignalMC::kFinalState :
+      // primary particles created in the collision which reach the detectors
+      // These would be:
+      // 1.) particles produced in the collision
+      // 2.) stable particles with respect to strong and electromagnetic interactions
+      // 3.) excludes initial state particles
+      // 4.) includes products of directly produced Sigma0 hyperon decay
+      // 5.) includes products of directly produced pi0 decays
+      // 6.) includes products of directly produced beauty hadron decays
+      return mcPart->IsPhysicalPrimary();
+    break;
+    case AliDielectronSignalMC::kDirect :
+      // Primary particles which do not have any mother
+      // This is the case for:
+      // 1.) Initial state particles (the 2 protons in Pythia pp collisions)
+      // 2.) In some codes, with sudden freeze-out, all particles generated from the fireball are direct.
+      //     There is no history for these particles.
+      // 3.) Certain particles added via MC generator cocktails (e.g. J/psi added to pythia MB events)
+      return (mcPart->GetMother() <= 0);
+      break;
+    case AliDielectronSignalMC::kNoCocktail :
+      // Particles from the HIJING event and NOT from the AliGenCocktail
+      return (mcPart->GetMother() > 0);
+      break;
+    case AliDielectronSignalMC::kSecondary :
+      // particles which are created by the interaction of final state primaries with the detector
+      // or particles from strange weakly decaying particles (e.g. lambda, kaons, etc.)
+      return (!mcPart->IsPrimary() && !mcPart->IsPhysicalPrimary());
+      // return (label>=GetNPrimary() && !IsPhysicalPrimary(label)); // old definition
+    break;
+    case AliDielectronSignalMC::kSecondaryFromWeakDecay :
+      // secondary particle from weak decay
+      // or particles from strange weakly decaying particles (e.g. lambda, kaons, etc.)
+      return (mcPart->IsSecondaryFromWeakDecay());
+    break;
+    case AliDielectronSignalMC::kSecondaryFromMaterial :
+      // secondary particle from material
+      return (mcPart->IsSecondaryFromMaterial());
+    break;
+    case AliDielectronSignalMC::kFromBGEvent :
+      // Use original esd track label to compare with nProduced particles
+      // used to select electrons which are not from injected signals.
+      return (IsFromBGEvent(mcPart->GetLabel()));
+      break;
+    case AliDielectronSignalMC::kFinalStateFromBGEvent :
+      // Use original esd track label to compare with nProduced particles
+      // used to select electrons which are not from injected signals.
+      return (mcPart->IsPhysicalPrimary() && IsFromBGEvent(mcPart->GetLabel()));
+      break;
+    default :
+      return kFALSE;
+  }
+  return kFALSE;
+
+}
+
 
 /*
 // (please keep this for reference...)
@@ -1238,21 +1368,33 @@ Bool_t AliDielectronMC::IsFromBGEvent(Int_t label) const {
   /// which means that it is not injected.
   ///
   if(label<0) return kFALSE;
-  if(fAnaType==kAOD) {
-    AliWarning("IsFromBGEvent() not implemented for AOD!");
+
+  if (!fMCEvent) return kFALSE;
+  if(!CheckHijingHeader()){
+    AliError("No Hijing generator header - selection of IsFromBGEvent not possible!");
     return kFALSE;
-//    if(!fMcArray) return kFALSE;
-//    return (static_cast<AliAODMCParticle*>(GetMCTrackFromMCEvent(label)))->IsFromBGEvent(); // IsFromBGEvent() does not exist for AliAODMCParticle.
-  } else if(fAnaType==kESD) {
-    if (!fMCEvent) return kFALSE;
-    if (CheckHijingHeader()) return fMCEvent->IsFromBGEvent(label); // Works for HIJING inside Cocktail
-    //else if (CheckSomeOtherHeader()) return ...;
-    else {
-      AliWarning("No headers to make decision! Assuming no injected signals are present.");
-      return kTRUE;
-    }
   }
-  return kFALSE;
+  Int_t nBgrdParticles = fGenCocktailHeader->NProduced();
+  return (label < nBgrdParticles);
+
+
+// Splitting between AOD-ESD analysis is obsolete. 2017-10-05 PD
+
+//   if(fAnaType==kAOD) {
+//     AliWarning("IsFromBGEvent() not implemented for AOD!");
+//     return kFALSE;
+// //    if(!fMcArray) return kFALSE;
+// //    return (static_cast<AliAODMCParticle*>(GetMCTrackFromMCEvent(label)))->IsFromBGEvent(); // IsFromBGEvent() does not exist for AliAODMCParticle.
+//   } else if(fAnaType==kESD) {
+//     if (!fMCEvent) return kFALSE;
+//     if (CheckHijingHeader()) return fMCEvent->IsFromBGEvent(label); // Works for HIJING inside Cocktail
+//     //else if (CheckSomeOtherHeader()) return ...;
+//     else {
+//       AliWarning("No headers to make decision! Assuming no injected signals are present.");
+//       return kTRUE;
+//     }
+//   }
+//   return kFALSE;
 }
 
 
@@ -1262,14 +1404,17 @@ Bool_t AliDielectronMC::CheckHijingHeader() const {
 //  if (fHasHijingHeader > -1) return Bool_t(fHasHijingHeader); // avoid many calls of the code below.
 
   if(fAnaType==kAOD) {
-    AliWarning("CheckHijingHeader() not implemented for AOD!");
-    return (fHasHijingHeader=0); //return kFALSE;
-    //    AliAODInputHandler* aodHandler=(AliAODInputHandler*)(AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler());
-    //    if (!aodHandler) return kFALSE;
-    //    AliAODEvent *aod=aodHandler->GetEvent();
-    //    if (!aod) return kFALSE;
-    //    AliAODHeader* header = aod->GetHeader(); // not sure if correct
+    if(!fAODMCHeader) AliError("No AODMCHeader - Break!");
+    TList* headerList = fAODMCHeader->GetCocktailHeaders();
+    for (Int_t i=0; i<headerList->GetEntries(); i++) {
+      if ((headerList->At(i))->IsA() == AliGenHijingEventHeader::Class()){
+        fGenCocktailHeader = (AliGenHijingEventHeader*) headerList->At(i);
+        return (fHasHijingHeader = kTRUE);
+      }
+    }
+    return (fHasHijingHeader = kFALSE);
   }
+
   else if(fAnaType==kESD) {
     // taken from AliMCEvent::IsFromBGEvent()
     if (!fMCEvent) return (fHasHijingHeader=0); //return kFALSE;
@@ -1277,6 +1422,7 @@ Bool_t AliDielectronMC::CheckHijingHeader() const {
     if (!coHeader) return (fHasHijingHeader=0); //return kFALSE;
     TList* list = coHeader->GetHeaders();
     AliGenHijingEventHeader* hijingH = dynamic_cast<AliGenHijingEventHeader*>(list->FindObject("Hijing"));
+    fGenCocktailHeader = hijingH;
     if (hijingH) return (fHasHijingHeader=1); //return kTRUE;
   }
   return (fHasHijingHeader=0);
@@ -1352,7 +1498,7 @@ Bool_t AliDielectronMC::IsMCTruth(Int_t label, AliDielectronSignalMC* signalMC, 
   if(signalMC->GetCheckGEANTProcess() && !CheckGEANTProcess(label,signalMC->GetGEANTProcess())) return kFALSE;
 
   // check the leg
-  if(!ComparePDG(part->PdgCode(),signalMC->GetLegPDG(branch),signalMC->GetLegPDGexclude(branch),signalMC->GetCheckBothChargesLegs(branch))) return kFALSE;
+  if(!ComparePDG(part->PdgCode(), signalMC->GetLegPDG(branch), signalMC->GetLegPDGexclude(branch), signalMC->GetCheckBothChargesLegs(branch))) return kFALSE;
   if(!CheckParticleSource(label, signalMC->GetLegSource(branch))) return kFALSE;
 
   // check the mother
@@ -1365,7 +1511,7 @@ Bool_t AliDielectronMC::IsMCTruth(Int_t label, AliDielectronSignalMC* signalMC, 
     }
     if(!mcMother && !signalMC->GetMotherPDGexclude(branch)) return kFALSE;
 
-    if(!ComparePDG((mcMother ? mcMother->PdgCode() : 0),signalMC->GetMotherPDG(branch),signalMC->GetMotherPDGexclude(branch),signalMC->GetCheckBothChargesMothers(branch))) return kFALSE;
+    if(!ComparePDG((mcMother ? mcMother->PdgCode() : 0), signalMC->GetMotherPDG(branch), signalMC->GetMotherPDGexclude(branch), signalMC->GetCheckBothChargesMothers(branch))) return kFALSE;
     if(!CheckParticleSource(mLabel, signalMC->GetMotherSource(branch))) return kFALSE;
 
     //check for radiative deday
@@ -1416,10 +1562,9 @@ Bool_t AliDielectronMC::IsMCTruth(const AliDielectronPair* pair, const AliDielec
   // make direct(1-1 and 2-2) and cross(1-2 and 2-1) comparisons for the whole branch
   Bool_t directTerm = kTRUE;
   // daughters
-  directTerm = directTerm && mcD1 && ComparePDG(d1Pdg,signalMC->GetLegPDG(1),signalMC->GetLegPDGexclude(1),signalMC->GetCheckBothChargesLegs(1))
-               && CheckParticleSource(labelD1, signalMC->GetLegSource(1));
+  directTerm = directTerm && mcD1 && ComparePDG(d1Pdg, signalMC->GetLegPDG(1), signalMC->GetLegPDGexclude(1), signalMC->GetCheckBothChargesLegs(1)) && CheckParticleSource(labelD1, signalMC->GetLegSource(1));
 
-  directTerm = directTerm && mcD2 && ComparePDG(d2Pdg,signalMC->GetLegPDG(2),signalMC->GetLegPDGexclude(2),signalMC->GetCheckBothChargesLegs(2))
+  directTerm = directTerm && mcD2 && ComparePDG(d2Pdg, signalMC->GetLegPDG(2), signalMC->GetLegPDGexclude(2), signalMC->GetCheckBothChargesLegs(2))
                && CheckParticleSource(labelD2, signalMC->GetLegSource(2));
 
   // mothers
@@ -1428,9 +1573,9 @@ Bool_t AliDielectronMC::IsMCTruth(const AliDielectronPair* pair, const AliDielec
     labelM1 = GetMothersLabel(labelD1);
     if(labelD1>-1 && labelM1>-1) mcM1 = GetMCTrackFromMCEvent(labelM1);
     directTerm = directTerm && (mcM1 || signalMC->GetMotherPDGexclude(1))
-                 && ComparePDG((mcM1 ? mcM1->PdgCode() : 0),signalMC->GetMotherPDG(1),signalMC->GetMotherPDGexclude(1),signalMC->GetCheckBothChargesMothers(1))
+                 && ComparePDG((mcM1 ? mcM1->PdgCode() : 0), signalMC->GetMotherPDG(1), signalMC->GetMotherPDGexclude(1),signalMC->GetCheckBothChargesMothers(1))
                  && CheckParticleSource(labelM1, signalMC->GetMotherSource(1))
-                 && CheckRadiativeDecision(labelM1,signalMC);
+                 && CheckRadiativeDecision(labelM1, signalMC);
   }
 
   Int_t labelM2 = -1;
@@ -1449,7 +1594,7 @@ Bool_t AliDielectronMC::IsMCTruth(const AliDielectronPair* pair, const AliDielec
     labelG1 = GetMothersLabel(labelM1);
     if(mcM1 && labelG1>-1) mcG1 = GetMCTrackFromMCEvent(labelG1);
     directTerm = directTerm && (mcG1 || signalMC->GetGrandMotherPDGexclude(1))
-                 && ComparePDG((mcG1 ? mcG1->PdgCode() : 0),signalMC->GetGrandMotherPDG(1),signalMC->GetGrandMotherPDGexclude(1),signalMC->GetCheckBothChargesGrandMothers(1))
+                 && ComparePDG((mcG1 ? mcG1->PdgCode() : 0), signalMC->GetGrandMotherPDG(1), signalMC->GetGrandMotherPDGexclude(1), signalMC->GetCheckBothChargesGrandMothers(1))
                  && CheckParticleSource(labelG1, signalMC->GetGrandMotherSource(1));
   }
 
@@ -1457,20 +1602,15 @@ Bool_t AliDielectronMC::IsMCTruth(const AliDielectronPair* pair, const AliDielec
   if(signalMC->GetGrandMotherPDG(2)!=0 || signalMC->GetGrandMotherSource(2)!=AliDielectronSignalMC::kDontCare) {
     labelG2 = GetMothersLabel(labelM2);
     if(mcM2 && labelG2>-1) mcG2 = GetMCTrackFromMCEvent(labelG2);
-    directTerm = directTerm && (mcG2 || signalMC->GetGrandMotherPDGexclude(2))
-                 && ComparePDG((mcG2 ? mcG2->PdgCode() : 0),signalMC->GetGrandMotherPDG(2),signalMC->GetGrandMotherPDGexclude(2),signalMC->GetCheckBothChargesGrandMothers(2))
+    directTerm = directTerm && (mcG2 || signalMC->GetGrandMotherPDGexclude(2)) && ComparePDG((mcG2 ? mcG2->PdgCode() : 0),signalMC->GetGrandMotherPDG(2),signalMC->GetGrandMotherPDGexclude(2),signalMC->GetCheckBothChargesGrandMothers(2))
                  && CheckParticleSource(labelG2, signalMC->GetGrandMotherSource(2));
   }
 
   // Cross term
   Bool_t crossTerm = kTRUE;
   // daughters
-  crossTerm = crossTerm && mcD2
-              && ComparePDG(d2Pdg,signalMC->GetLegPDG(1),signalMC->GetLegPDGexclude(1),signalMC->GetCheckBothChargesLegs(1))
-              && CheckParticleSource(labelD2, signalMC->GetLegSource(1));
-
-  crossTerm = crossTerm && mcD1
-              && ComparePDG(d1Pdg,signalMC->GetLegPDG(2),signalMC->GetLegPDGexclude(2),signalMC->GetCheckBothChargesLegs(2))
+  crossTerm = crossTerm && mcD2 && ComparePDG(d2Pdg, signalMC->GetLegPDG(1), signalMC->GetLegPDGexclude(1), signalMC->GetCheckBothChargesLegs(1)) && CheckParticleSource(labelD2, signalMC->GetLegSource(1));
+  crossTerm = crossTerm && mcD1 && ComparePDG(d1Pdg, signalMC->GetLegPDG(2), signalMC->GetLegPDGexclude(2), signalMC->GetCheckBothChargesLegs(2))
               && CheckParticleSource(labelD1, signalMC->GetLegSource(2));
 
   // mothers
@@ -1479,10 +1619,7 @@ Bool_t AliDielectronMC::IsMCTruth(const AliDielectronPair* pair, const AliDielec
       labelM2 = GetMothersLabel(labelD2);
       if(labelM2>-1) mcM2 = GetMCTrackFromMCEvent(labelM2);
     }
-    crossTerm = crossTerm && (mcM2 || signalMC->GetMotherPDGexclude(1))
-                && ComparePDG((mcM2 ? mcM2->PdgCode() : 0),signalMC->GetMotherPDG(1),signalMC->GetMotherPDGexclude(1),signalMC->GetCheckBothChargesMothers(1))
-                && CheckParticleSource(labelM2, signalMC->GetMotherSource(1))
-                && CheckRadiativeDecision(labelM2,signalMC);
+    crossTerm = crossTerm && (mcM2 || signalMC->GetMotherPDGexclude(1)) && ComparePDG((mcM2 ? mcM2->PdgCode() : 0), signalMC->GetMotherPDG(1), signalMC->GetMotherPDGexclude(1), signalMC->GetCheckBothChargesMothers(1)) && CheckParticleSource(labelM2, signalMC->GetMotherSource(1)) && CheckRadiativeDecision(labelM2,signalMC);
   }
 
   if(signalMC->GetMotherPDG(2)!=0 || signalMC->GetMotherSource(2)!=AliDielectronSignalMC::kDontCare) {
@@ -1490,10 +1627,7 @@ Bool_t AliDielectronMC::IsMCTruth(const AliDielectronPair* pair, const AliDielec
       labelM1 = GetMothersLabel(labelD1);
       if(labelM1>-1) mcM1 = GetMCTrackFromMCEvent(labelM1);
     }
-    crossTerm = crossTerm && (mcM1 || signalMC->GetMotherPDGexclude(2))
-                && ComparePDG((mcM1 ? mcM1->PdgCode() : 0),signalMC->GetMotherPDG(2),signalMC->GetMotherPDGexclude(2),signalMC->GetCheckBothChargesMothers(2))
-                && CheckParticleSource(labelM1, signalMC->GetMotherSource(2))
-                && CheckRadiativeDecision(labelM1,signalMC);
+    crossTerm = crossTerm && (mcM1 || signalMC->GetMotherPDGexclude(2)) && ComparePDG((mcM1 ? mcM1->PdgCode() : 0), signalMC->GetMotherPDG(2), signalMC->GetMotherPDGexclude(2), signalMC->GetCheckBothChargesMothers(2)) && CheckParticleSource(labelM1, signalMC->GetMotherSource(2)) && CheckRadiativeDecision(labelM1,signalMC);
   }
 
   // grand-mothers
@@ -1502,9 +1636,7 @@ Bool_t AliDielectronMC::IsMCTruth(const AliDielectronPair* pair, const AliDielec
       labelG2 = GetMothersLabel(labelM2);
       if(labelG2>-1) mcG2 = GetMCTrackFromMCEvent(labelG2);
     }
-    crossTerm = crossTerm && (mcG2 || signalMC->GetGrandMotherPDGexclude(1))
-                && ComparePDG((mcG2 ? mcG2->PdgCode() : 0),signalMC->GetGrandMotherPDG(1),signalMC->GetGrandMotherPDGexclude(1),signalMC->GetCheckBothChargesGrandMothers(1))
-                && CheckParticleSource(labelG2, signalMC->GetGrandMotherSource(1));
+    crossTerm = crossTerm && (mcG2 || signalMC->GetGrandMotherPDGexclude(1)) && ComparePDG((mcG2 ? mcG2->PdgCode() : 0), signalMC->GetGrandMotherPDG(1), signalMC->GetGrandMotherPDGexclude(1), signalMC->GetCheckBothChargesGrandMothers(1)) && CheckParticleSource(labelG2, signalMC->GetGrandMotherSource(1));
   }
 
   if(signalMC->GetGrandMotherPDG(2)!=0 || signalMC->GetGrandMotherSource(2)!=AliDielectronSignalMC::kDontCare) {
@@ -1512,9 +1644,7 @@ Bool_t AliDielectronMC::IsMCTruth(const AliDielectronPair* pair, const AliDielec
       labelG1 = GetMothersLabel(labelM1);
       if(labelG1>-1) mcG1 = GetMCTrackFromMCEvent(labelG1);
     }
-    crossTerm = crossTerm && (mcG1 || signalMC->GetGrandMotherPDGexclude(2))
-                && ComparePDG((mcG1 ? mcG1->PdgCode() : 0),signalMC->GetGrandMotherPDG(2),signalMC->GetGrandMotherPDGexclude(2),signalMC->GetCheckBothChargesGrandMothers(2))
-                && CheckParticleSource(labelG1, signalMC->GetGrandMotherSource(2));
+    crossTerm = crossTerm && (mcG1 || signalMC->GetGrandMotherPDGexclude(2)) && ComparePDG((mcG1 ? mcG1->PdgCode() : 0), signalMC->GetGrandMotherPDG(2), signalMC->GetGrandMotherPDGexclude(2), signalMC->GetCheckBothChargesGrandMothers(2)) && CheckParticleSource(labelG1, signalMC->GetGrandMotherSource(2));
   }
 
   Bool_t motherRelation = kTRUE;
@@ -1712,94 +1842,131 @@ Bool_t AliDielectronMC::GetPrimaryVertex(Double_t &primVtxX, Double_t &primVtxY,
 //____________________________________________________________
 Bool_t AliDielectronMC::LoadHFPairs()
 {
+
   //
-  // Look for all correlated c/cbar and b/bbar pairs  
+  // Look for all correlated c/cbar and b/bbar pairs
   // Attributing for each quark a HF Creation Process ID
   //
-  
+
   Int_t quark[2][2]={{0}};
   Int_t quarktmp[2][2]={{0}};
+  Int_t hadrontmp[2][2]={{0}};
 
-  //Loop over the MC event to tag all correlated c/cbar and b/bbar quarks 
+  //Loop over the MC event to tag all correlated c/cbar and b/bbar quarks
   for(Int_t i=0;i<fMCEvent->GetNumberOfTracks();i++){
     AliMCParticle *cand = dynamic_cast<AliMCParticle *>(fMCEvent->GetTrack(i));
     Int_t pdg_part = fMCEvent->GetTrack(i)->PdgCode();
     Int_t pdg_parta = TMath::Abs(pdg_part);
 
-    if(pdg_parta!=4 && pdg_parta!=5) continue;
-    
-    //The quark is requested to be a "b" or a "c" quark
-    if(!(cand->GetFirstDaughter()>-1)){
-      //childless quark to be linked!
-      if(pdg_part==4) quarktmp[0][0]=i;
-      else if(pdg_part==-4) quarktmp[0][1]=i;
-      else if(pdg_part==5) quarktmp[1][0]=i;
-      else if(pdg_part==-5) quarktmp[1][1]=i;
-      continue;
-    }
-    
-    //Check if the quark is only propagating
-    Bool_t isHFprim(kTRUE);
-    for(Int_t idau=cand->GetFirstDaughter();idau<=cand->GetLastDaughter();idau++){
-      if(fMCEvent->GetTrack(idau)->PdgCode()==pdg_part){
-	isHFprim=kFALSE;
-	break;
-      } 
-    }
-    if(!isHFprim) continue;
-
-    //quark is selected, saving its label
-    //But only keep the event if there is no more than one HF pair in it
-    if(pdg_part==4){
-      if(quark[1][0]>0 || quark[0][0]>0) return kFALSE;
-      quark[0][0]=i;
-    }
-    else if(pdg_part==-4){
-      if(quark[1][1]>0 || quark[0][1]>0) return kFALSE;
-      quark[0][1]=i;
+    if(pdg_parta==4 || pdg_parta==5){
+      //The quark is requested to create a B or D hadron -> Must have a daughter
+      if(!(cand->GetFirstDaughter()>-1)){
+	//childless quark to be linked!
+	if(pdg_part==4) quarktmp[0][0]=i;
+	else if(pdg_part==-4) quarktmp[0][1]=i;
+	else if(pdg_part==5) quarktmp[1][0]=i;
+	else if(pdg_part==-5) quarktmp[1][1]=i;
+	continue;
       }
-    else if(pdg_part==5){
-      if(quark[1][0]>0 || quark[0][0]>0) return kFALSE;
-      quark[1][0]=i;
-    }
-    else if(pdg_part==-5){
-      if(quark[1][1]>0 || quark[0][1]>0) return kFALSE;
-      quark[1][1]=i;
-    }
+
+      //Check if the quark is the one leading to the hadron
+      Bool_t isHFprim(kTRUE);
+      for(Int_t idau=cand->GetFirstDaughter();idau<=cand->GetLastDaughter();idau++){
+	if(fMCEvent->GetTrack(idau)->PdgCode()==pdg_part){
+	  isHFprim=kFALSE;
+	  break;
+	}
+      }
+      if(!isHFprim) continue;
+
+      //quark is selected, saving its label
+      if(pdg_part==4){
+	if(quark[0][0]>0) return kFALSE;
+	quark[0][0]=i;
+      }
+      else if(pdg_part==-4){
+	if(quark[0][1]>0) return kFALSE;
+	quark[0][1]=i;
+      }
+      else if(pdg_part==5){
+	if(quark[1][0]>0) return kFALSE;
+	quark[1][0]=i;
+      }
+      else if(pdg_part==-5){
+	if(quark[1][1]>0) return kFALSE;
+	quark[1][1]=i;
+      }
+    } //End looking at quarks
+
+    //Look for Motherless hadrons or hadron's mother is u/d
+    else if(pdg_parta==411 || pdg_parta==421 || pdg_parta==431 || pdg_parta==511 || pdg_parta==521 || pdg_parta==531 || pdg_parta==541 || pdg_parta==4122 || pdg_parta==5122){
+      //Access the oldest ancestor that could be link to a corresponding quark
+      AliMCParticle *mother, *daughter;
+      Bool_t Osci(kFALSE);
+      if(cand->GetMother()>-1){
+	mother = dynamic_cast<AliMCParticle *>(fMCEvent->GetTrack(cand->GetMother()));
+	if(TMath::Abs(mother->PdgCode())<6)daughter=cand;
+	else daughter=mother;
+
+	if((pdg_parta== 411 || pdg_parta== 421 || pdg_parta== 431 || pdg_parta== 4122) && IsaBhadron(mother->PdgCode())) Osci=kTRUE;
+	while (!(TMath::Abs(mother->PdgCode())<6 && TMath::Abs(mother->PdgCode())>0) && mother->GetMother()>-1){
+	  daughter = mother;
+	  mother = dynamic_cast<AliMCParticle *>(fMCEvent->GetTrack(mother->GetMother()));
+	  if((pdg_parta== 411 || pdg_parta== 421 || pdg_parta== 431 || pdg_parta== 4122) && IsaBhadron(mother->PdgCode())) Osci=kTRUE;
+	}
+      }
+      else daughter = cand;
+      mother=daughter;
+
+      //Get Original mother in History
+      Int_t pdg_moma(0);
+      if(mother->GetMother()>-1) pdg_moma=TMath::Abs(fMCEvent->GetTrack(mother->GetMother())->PdgCode());
+      if(TMath::Abs(pdg_moma)>6 && mother->GetMother()>-1) continue;
+
+      if((pdg_part== 411 || pdg_part== 421 || pdg_part== 431 || pdg_part== 4122) && !Osci){
+	if(hadrontmp[0][0]>0 && hadrontmp[0][0]!=mother->GetLabel()) return kFALSE;
+	else hadrontmp[0][0]=mother->GetLabel();//c hadron type
+      }
+      else if((pdg_part== -411 || pdg_part== -421 || pdg_part== -431 || pdg_part== -4122) && !Osci){
+	if(hadrontmp[0][1]>0 && hadrontmp[0][1]!=mother->GetLabel()) return kFALSE;
+	else hadrontmp[0][1]=mother->GetLabel();//cbar hadron type
+      }
+      else if(pdg_part== -511 || pdg_part== -521 || pdg_part== -531 || pdg_part== -541 || pdg_part==5122 || ((pdg_part== 411 || pdg_part== 421 || pdg_part== 431 || pdg_part== 4122) && Osci)){
+	if(hadrontmp[1][0]>0 && hadrontmp[1][0]!=mother->GetLabel()) return kFALSE;
+	else hadrontmp[1][0]=mother->GetLabel();//b hadron type
+      }
+      else if(pdg_part== 511 || pdg_part== 521 || pdg_part== 531 || pdg_part== 541 || pdg_part==-5122 || ((pdg_part== -411 || pdg_part== -421 || pdg_part== -431 || pdg_part== -4122) && Osci)){
+	if(hadrontmp[1][1]>0 && hadrontmp[1][1]!=mother->GetLabel()) return kFALSE;
+	else hadrontmp[1][1]=mother->GetLabel();//bbar hadron type
+      }
+    }//End checking motherless hadrons
+  }//End Loop on the Stack
+
+  //Linking childless quarks with corresponding motherless hadrons
+  if(quarktmp[0][0]>0 && hadrontmp[0][0]>0){
+    quark[0][0]=hadrontmp[0][0];
+  }
+  if(quarktmp[0][1]>0 && hadrontmp[0][1]>0){
+    quark[0][1]=hadrontmp[0][1];
+  }
+  if(quarktmp[1][0]>0 && hadrontmp[1][0]>0){
+    quark[1][0]=hadrontmp[1][0];
+  }
+  if(quarktmp[1][1]>0 && hadrontmp[1][1]>0){
+    quark[1][1]=hadrontmp[1][1];
   }
 
-  //Look at stored quarks for pairing
-  if(quark[0][0]>0 && quark[0][1]>0) fEvtHFtype=1;
+  //Pairing the quarks and attribute them a process number: c/cbar(1) and b/bar(2)
+  if(quark[0][0]>0 && quark[0][1]>0){
+    fhfproc.insert(std::pair<Int_t,Int_t>(quark[0][0],1));
+    fhfproc.insert(std::pair<Int_t,Int_t>(quark[0][1],1));
+  }
   if(quark[1][0]>0 && quark[1][1]>0){
-    if(fEvtHFtype==1) return kFALSE;
-    else fEvtHFtype=2;
-  }
-  
-  //Look at quarktmp and quark
-  if((quark[0][0]>0 && quarktmp[0][1]>0) || (quarktmp[0][0]>0 && quark[0][1]>0)){
-    if(quark[0][0]<quarktmp[0][0] && quark[0][0]!=0) return kFALSE;
-    if(quark[0][1]<quarktmp[0][1] && quark[0][1]!=0) return kFALSE;
-    if(fEvtHFtype>0) return kFALSE;
-    else fEvtHFtype=1;
-  }
-  if((quark[1][0]>0 && quarktmp[1][1]>0) || (quarktmp[1][0]>0 && quark[1][1]>0)){
-    if(quark[1][0]<quarktmp[1][0] && quark[1][0]!=0) return kFALSE;
-    if(quark[1][1]<quarktmp[1][1] && quark[1][1]!=0) return kFALSE;
-    if(fEvtHFtype>0) return kFALSE;
-    else fEvtHFtype=2;
+    fhfproc.insert(std::pair<Int_t,Int_t>(quark[1][0],2));
+    fhfproc.insert(std::pair<Int_t,Int_t>(quark[1][1],2));
   }
 
-  //Look at quarktmp and quarktmp
-  if(quarktmp[0][0]>0 && quarktmp[0][1]>0 && quarktmp[0][0]==0 && quarktmp[0][1]==0){
-    if(fEvtHFtype>0) return kFALSE;
-    else fEvtHFtype=1;
-  }
-  if(quarktmp[1][0]>0 && quarktmp[1][1]>0 && quark[1][0]==0 && quark[1][1]==0){
-    if(fEvtHFtype>0) return kFALSE;
-    else fEvtHFtype=2;
-  }
-  
-  return kTRUE;								   
+  return kTRUE;
 }
 
 //____________________________________________________________
@@ -1808,30 +1975,37 @@ Int_t AliDielectronMC::GetHFProcess(const Int_t label)
   //
   // return Heavy Flavour process number of the particle
   //
-  if(!fCheckHF) return -1; //More than one HF pair in the event -> Undeterminated (so far)
-  if(fEvtHFtype==0) return 0; //No HF pairs in the event
-  
-  AliMCParticle *part = dynamic_cast<AliMCParticle *>(fMCEvent->GetTrack(label));
-  if(part->GetMother()==-1) return 0; // Does not have mother -> cannot be linked
+  if(!fCheckHF) return -1; //More than one pair of each -> Undeterminated (so far)
+  if(fhfproc.size()==0) return 0; //No HF pairs in the event
 
+  Int_t mother_label;
+  AliMCParticle *part = dynamic_cast<AliMCParticle *>(fMCEvent->GetTrack(label));
+  if(part->GetMother()==-1) return 0;
+
+  // Looking back in the history if an ancestor is coming from an HF process
   AliMCParticle *mother = dynamic_cast<AliMCParticle *>(fMCEvent->GetTrack(part->GetMother()));
-  Int_t MotherPdg=mother->PdgCode();
-  
-  if(IsaBorDhadron(MotherPdg)) return fEvtHFtype;
-  else return 0; 
+  mother_label=mother->GetLabel();
+  for(std::map<Int_t,Int_t>::iterator it = fhfproc.begin(); it != fhfproc.end(); ++it){
+    if(mother_label==it->first) return it->second;
+  }
+
+  while (!(TMath::Abs(mother->PdgCode())==4 || TMath::Abs(mother->PdgCode())==5) && mother->GetMother()>-1){
+    mother = dynamic_cast<AliMCParticle *>(fMCEvent->GetTrack(mother->GetMother()));
+    mother_label=mother->GetLabel();
+    for(std::map<Int_t,Int_t>::iterator it = fhfproc.begin(); it != fhfproc.end(); ++it){
+      if(mother_label==it->first) return it->second;
+    }
+  }
+
+  return 0;
 }
 
 
-Bool_t AliDielectronMC::IsaBorDhadron(const Int_t PartPdg) const
-{
-  Int_t aPdg=TMath::Abs(PartPdg);
-  //Check D-mesons
-  if((aPdg>=411 && aPdg<=435) || (aPdg>=10411 && aPdg<=10433) || (aPdg>=20413 && aPdg<=20433) ) return kTRUE;
-  //Check B-mesons
-  else if((aPdg>=511 && aPdg<=545) || (aPdg>=10511 && aPdg<=10543) || (aPdg>=20513 && aPdg<=20543) ) return kTRUE;
-  //Check Charmed Baryons
-  else if(aPdg>=4112 && aPdg<=4444) return kTRUE;
-  //Check Bottom Baryons
-  else if(aPdg>=5112 && aPdg<=5554) return kTRUE;  
-  else return kFALSE;
+Int_t AliDielectronMC::IsaBhadron(Int_t pdg) const{
+  Int_t Bhadronspdg[]={511,521,10511,10521,513,523,10513,20513,20523,515,525,531,10531,533,10533,20533,535,541,10541,543,10543,20543,545};
+  Int_t size=sizeof(Bhadronspdg)/sizeof(*Bhadronspdg);
+  for(Int_t i=0;i<size;i++){
+    if(TMath::Abs(pdg==Bhadronspdg[i])) return kTRUE;
+  }
+  return kFALSE;
 }

--- a/PWGDQ/dielectron/core/AliDielectronMC.h
+++ b/PWGDQ/dielectron/core/AliDielectronMC.h
@@ -25,6 +25,7 @@ class TParticle;
 class AliMCParticle;
 class AliAODMCParticle;
 class AliAODMCHeader;
+class AliGenHijingEventHeader;
 
 #include "AliDielectronSignalMC.h"
 #include "AliDielectronPair.h"
@@ -42,7 +43,7 @@ public:
 
   void SetCheckHF(Bool_t checkHF) { fCheckHF=checkHF; }
   Bool_t CheckHF() const { return fCheckHF; }
-  
+
   static AliDielectronMC* Instance();
 
   void Initialize();                              // initialization
@@ -52,12 +53,12 @@ public:
   Int_t GetNPrimaryFromStack();                                   // return number of primary tracks from MC event
   Int_t GetMCPID(const AliESDtrack* _track);                      // return MC PID
   Int_t GetMCPID(const AliAODTrack* _track);                      // return MC PID for AODtrack
-  Int_t GetMCPIDFromStack(const AliESDtrack* _track);             // return MC PID from MC event                                                                                       
-  Int_t GetMotherPDG(const AliESDtrack* _track);                  // return mother PID from the MC event                                                                               
-  Int_t GetMotherPDG(const AliAODTrack* _track);                  // return mother PID from the MC event                                                                               
-  Int_t GetMotherPDG(const AliMCParticle* _track);                  // return mother PID from the MC event                                                                             
-  Int_t GetMotherPDG(const AliAODMCParticle* _track);                  // return mother PID from the MC event                                                                          
-  Int_t GetMotherPDGFromStack(const AliESDtrack* _track);         // return mother PID from the MC event  
+  Int_t GetMCPIDFromStack(const AliESDtrack* _track);             // return MC PID from MC event
+  Int_t GetMotherPDG(const AliESDtrack* _track);                  // return mother PID from the MC event
+  Int_t GetMotherPDG(const AliAODTrack* _track);                  // return mother PID from the MC event
+  Int_t GetMotherPDG(const AliMCParticle* _track);                  // return mother PID from the MC event
+  Int_t GetMotherPDG(const AliAODMCParticle* _track);                  // return mother PID from the MC event
+  Int_t GetMotherPDGFromStack(const AliESDtrack* _track);         // return mother PID from the MC event
   Int_t GetMCProcess(const AliESDtrack* _track);                  // return process number
   Int_t GetMCProcessFromStack(const AliESDtrack* _track);         // return process number
   Int_t GetMCProcessMother(const AliESDtrack* _track);            // return process number of the mother track
@@ -72,8 +73,8 @@ public:
   Bool_t IsMCTruth(Int_t label, AliDielectronSignalMC* signalMC, Int_t branch) const;
   Int_t GetMothersLabel(Int_t daughterLabel) const;
   Int_t GetPdgFromLabel(Int_t label) const;
-  Int_t GetHFProcess(Int_t label); 
-  
+  Int_t GetHFProcess(Int_t label);
+
   Bool_t IsPrimary(Int_t label) const;
   Bool_t IsPhysicalPrimary(Int_t label) const;  // checks if a particle is physical primary
   Bool_t IsSecondary(Int_t label) const;
@@ -92,13 +93,14 @@ public:
 //   AliVParticle* GetMCTrackFromMCEvent(const AliVParticle *track);   // return MC track directly from MC event
   AliVParticle* GetMCTrackFromMCEvent(Int_t label) const;           // return MC track directly from MC event
   TParticle* GetMCTrackFromStack(const AliESDtrack* _track);        // return MC track from MC event
+  AliVParticle* GetMCTrack(const AliVParticle* _track); // return MC track from MC event
   AliMCParticle* GetMCTrack(const AliESDtrack* _track);             // return MC track associated with reco track
   AliAODMCParticle* GetMCTrack( const AliAODTrack* _track);          // return MC track associated with reco AOD track
 
-  TParticle* GetMCTrackMotherFromStack(const AliESDtrack* _track);  // return MC mother track from MC event                                                                            
-  AliMCParticle* GetMCTrackMother(const AliESDtrack* _track);       // return MC mother track from MC event 
+  TParticle* GetMCTrackMotherFromStack(const AliESDtrack* _track);  // return MC mother track from MC event
+  AliMCParticle* GetMCTrackMother(const AliESDtrack* _track);       // return MC mother track from MC event
   AliAODMCParticle* GetMCTrackMother(const AliAODTrack* _track);       // return MC mother fot track AODTrack
-  AliMCParticle* GetMCTrackMother(const AliMCParticle* _particle);       // return MC mother track from stack                                                                          
+  AliMCParticle* GetMCTrackMother(const AliMCParticle* _particle);       // return MC mother track from stack
   AliAODMCParticle* GetMCTrackMother(const AliAODMCParticle* _particle);       // return MC mother track from stack
 
   Int_t NumberOfDaughters(const AliESDtrack* track);                 // return number of daughters
@@ -110,19 +112,24 @@ public:
   Int_t IsJpsiPrimary(const AliDielectronPair * pair);
   Int_t IsJpsiPrimary(const AliVParticle * pair);
   Bool_t CheckParticleSource(Int_t label, AliDielectronSignalMC::ESource source) const;
+  Bool_t CheckParticleSource(const AliAODMCParticle *mcPart, AliDielectronSignalMC::ESource source) const;
+
   Bool_t GetPrimaryVertex(Double_t &primVtxX, Double_t &primVtxY, Double_t &primVtxZ);
 
   AliMCEvent* GetMCEvent() { return fMCEvent; }         // return the AliMCEvent
 
 private:
   AliMCEvent    *fMCEvent;  // MC event object
+  AliAODMCHeader *fAODMCHeader; // MC AOD Header
+
+  mutable AliGenHijingEventHeader *fGenCocktailHeader; //! Generated cocktail header
 
   AnalysisType fAnaType;    // Analysis type
   Bool_t fHasMC;            // Do we have an MC handler?
   Bool_t fCheckHF;          // Do we look for HF correlated pairs?
-  
-  Int_t  fEvtHFtype;        // 0:no HF, 1:ccbar, 2:bbar
-  
+
+  std::map<Int_t,Int_t> fhfproc; // quark label and HF process
+
   mutable Int_t  fHasHijingHeader;  //! //mutable needed to change it in a const function.
 
   static AliDielectronMC* fgInstance; //! singleton pointer
@@ -149,7 +156,7 @@ private:
 
   //MC - Heavy Flavour related methods
   Bool_t LoadHFPairs();
-  Bool_t IsaBorDhadron(Int_t PartPdg) const;
+  Int_t  IsaBhadron(Int_t pdg) const;
 
   ClassDef(AliDielectronMC, 2)
 };

--- a/PWGDQ/dielectron/core/AliDielectronVarManager.h
+++ b/PWGDQ/dielectron/core/AliDielectronVarManager.h
@@ -856,7 +856,7 @@ inline void AliDielectronVarManager::FillVarVParticle(const AliVParticle *partic
     values[AliDielectronVarManager::kEtaMC]     = -999.;
     AliVParticle *mcTrack(0x0);
     if(AliDielectronMC::Instance()->HasMC())
-      mcTrack = AliDielectronMC::Instance()->GetMCTrackFromMCEvent(TMath::Abs(particle->GetLabel()));
+      mcTrack = AliDielectronMC::Instance()->GetMCTrack(particle);
     if(mcTrack){
       values[AliDielectronVarManager::kPtMC]   = mcTrack->Pt();
       values[AliDielectronVarManager::kPMC]    = mcTrack->P();
@@ -1434,30 +1434,34 @@ inline void AliDielectronVarManager::FillVarAODTrack(const AliAODTrack *particle
   values[AliDielectronVarManager::kNumberOfDaughters]=-1;
 
   AliDielectronMC *mc=AliDielectronMC::Instance();
+  AliAODMCParticle *mcParticle = 0x0;
   if (mc->HasMC()){
-    if (mc->GetMCTrack(particle)) {
+    if ((mcParticle = (AliAODMCParticle*) mc->GetMCTrack(particle))) {
 
-      Int_t trkLbl = particle->GetLabel();
+
+
+      // Int_t trkLbl = particle->GetLabel();
+      // using the label this will potentially crash since the label can be out of range for aods
 
       if (Req(kMCLegSource)){
         values[AliDielectronVarManager::kMCLegSource] = 0;
-        if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kPrimary)) values[AliDielectronVarManager::kMCLegSource] += 1;
-        if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kFinalState)) values[AliDielectronVarManager::kMCLegSource] += 2;
-        if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kDirect)) values[AliDielectronVarManager::kMCLegSource] +=4;
-        if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kSecondary)) values[AliDielectronVarManager::kMCLegSource] +=8;
-        if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kSecondaryFromWeakDecay)) values[AliDielectronVarManager::kMCLegSource] +=16;
-        if (mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kSecondaryFromMaterial)) values[AliDielectronVarManager::kMCLegSource] +=32;
+        if (mc->CheckParticleSource(mcParticle, AliDielectronSignalMC::kPrimary)) values[AliDielectronVarManager::kMCLegSource] += 1;
+        if (mc->CheckParticleSource(mcParticle, AliDielectronSignalMC::kFinalState)) values[AliDielectronVarManager::kMCLegSource] += 2;
+        if (mc->CheckParticleSource(mcParticle, AliDielectronSignalMC::kDirect)) values[AliDielectronVarManager::kMCLegSource] +=4;
+        if (mc->CheckParticleSource(mcParticle, AliDielectronSignalMC::kSecondary)) values[AliDielectronVarManager::kMCLegSource] +=8;
+        if (mc->CheckParticleSource(mcParticle, AliDielectronSignalMC::kSecondaryFromWeakDecay)) values[AliDielectronVarManager::kMCLegSource] +=16;
+        if (mc->CheckParticleSource(mcParticle, AliDielectronSignalMC::kSecondaryFromMaterial)) values[AliDielectronVarManager::kMCLegSource] +=32;
       }
 
-      if (Req(kPdgCode))           values[AliDielectronVarManager::kPdgCode]           =mc->GetMCTrack(particle)->PdgCode();
-      if (Req(kHasCocktailMother)) values[AliDielectronVarManager::kHasCocktailMother] =mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kDirect);
-      if (Req(kPdgCodeMother))     values[AliDielectronVarManager::kPdgCodeMother]     =mc->GetMotherPDG(particle);
+      if (Req(kPdgCode))           values[AliDielectronVarManager::kPdgCode]           = mcParticle->PdgCode();
+      if (Req(kHasCocktailMother)) values[AliDielectronVarManager::kHasCocktailMother] = mc->CheckParticleSource(mcParticle, AliDielectronSignalMC::kDirect);
+      if (Req(kPdgCodeMother))     values[AliDielectronVarManager::kPdgCodeMother] = mc->GetMotherPDG(mcParticle);
       if (Req(kPdgCodeGrandMother)){
-        AliAODMCParticle *motherMC=mc->GetMCTrackMother(particle); //mother
+        AliAODMCParticle *motherMC = mc->GetMCTrackMother(mcParticle); //mother
         if(motherMC) values[AliDielectronVarManager::kPdgCodeGrandMother]=mc->GetMotherPDG(motherMC);
       }
     }
-    if (Req(kNumberOfDaughters)) values[AliDielectronVarManager::kNumberOfDaughters]=mc->NumberOfDaughters(particle);
+    if (Req(kNumberOfDaughters)) values[AliDielectronVarManager::kNumberOfDaughters] = mc->NumberOfDaughters(mcParticle);
   } //if(mc->HasMC())
 
   if(Req(kTOFPIDBit))     values[AliDielectronVarManager::kTOFPIDBit]=(particle->GetStatus()&AliESDtrack::kTOFpid? 1: 0);
@@ -1772,9 +1776,9 @@ inline void AliDielectronVarManager::FillVarAODMCParticle(const AliAODMCParticle
 
   // Fill AliAODMCParticle interface specific information
   AliDielectronMC *mc=AliDielectronMC::Instance();
-  Int_t trkLbl = TMath::Abs(particle->GetLabel());
+  // Int_t trkLbl = TMath::Abs(particle->GetLabel()); // Handle with caution this is the label of the original esd track not the AODTrack
   values[AliDielectronVarManager::kPdgCode]           = particle->PdgCode();
-  values[AliDielectronVarManager::kHasCocktailMother] = mc->CheckParticleSource(trkLbl, AliDielectronSignalMC::kDirect);
+  values[AliDielectronVarManager::kHasCocktailMother] = mc->CheckParticleSource(particle, AliDielectronSignalMC::kDirect);
   values[AliDielectronVarManager::kPdgCodeMother]     = mc->GetMotherPDG(particle);
   AliAODMCParticle *motherMC=mc->GetMCTrackMother(particle); //mother
   if(motherMC) values[AliDielectronVarManager::kPdgCodeGrandMother]=mc->GetMotherPDG(motherMC);
@@ -2098,8 +2102,10 @@ inline void AliDielectronVarManager::FillVarDielectronPair(const AliDielectronPa
           values[AliDielectronVarManager::kPMC]   = -999.;
           values[AliDielectronVarManager::kPhiMC] = -999.;
           values[AliDielectronVarManager::kEtaMC] = -999.;
-          AliVParticle *mcDaughter1 = AliDielectronMC::Instance()->GetMCTrackFromMCEvent(TMath::Abs((pair->GetFirstDaughterP() )->GetLabel()));
-          AliVParticle *mcDaughter2 = AliDielectronMC::Instance()->GetMCTrackFromMCEvent(TMath::Abs((pair->GetSecondDaughterP())->GetLabel()));
+
+
+          AliVParticle *mcDaughter1 = AliDielectronMC::Instance()->GetMCTrack(pair->GetFirstDaughterP());
+          AliVParticle *mcDaughter2 = AliDielectronMC::Instance()->GetMCTrack(pair->GetSecondDaughterP());
           if(mcDaughter1 && mcDaughter2){
             TLorentzVector lv1MC,lv2MC;
             lv1MC.SetPtEtaPhiM(mcDaughter1->Pt(),mcDaughter1->Eta(),mcDaughter1->Phi(),mElectron);
@@ -2247,7 +2253,7 @@ inline void AliDielectronVarManager::FillVarDielectronPair(const AliDielectronPa
   if(Req(kQnV0rpH2FlowV2)) values[AliDielectronVarManager::kQnV0rpH2FlowV2]    = TMath::Cos( 2.*values[AliDielectronVarManager::kQnDeltaPhiV0rpH2] );
   if(Req(kQnSPDrpH2FlowV2)) values[AliDielectronVarManager::kQnSPDrpH2FlowV2]    = TMath::Cos( 2.*values[AliDielectronVarManager::kQnDeltaPhiSPDrpH2] );
 
-  AliDielectronMC *mc=AliDielectronMC::Instance();
+  AliDielectronMC *mc = AliDielectronMC::Instance();
 
   if (mc->HasMC()){
     values[AliDielectronVarManager::kPseudoProperTimeResolution] = -10.0e+10;
@@ -2261,14 +2267,21 @@ inline void AliDielectronVarManager::FillVarDielectronPair(const AliDielectronPa
     if(samemother && fgEvent) {
       if(pair->GetFirstDaughterP()->GetLabel() > 0) {
         const AliVParticle *motherMC = 0x0;
-        if(fgEvent->IsA() == AliESDEvent::Class())  motherMC = (AliMCParticle*)mc->GetMCTrackMother((AliESDtrack*)pair->GetFirstDaughterP());
-        else if(fgEvent->IsA() == AliAODEvent::Class())  motherMC = (AliAODMCParticle*)mc->GetMCTrackMother((AliAODTrack*)pair->GetFirstDaughterP());
+        Int_t motherLbl = 0;
+        if(fgEvent->IsA() == AliESDEvent::Class()){
+          motherMC = (AliMCParticle*) mc->GetMCTrackMother((AliESDtrack*) pair->GetFirstDaughterP());
+          motherLbl = motherMC->GetLabel();
+        }
+        else if(fgEvent->IsA() == AliAODEvent::Class()){
+          motherMC = (AliAODMCParticle*) mc->GetMCTrackMother((AliAODTrack*) pair->GetFirstDaughterP());
+          AliAODMCParticle *daughterMC = (AliAODMCParticle*) mc->GetMCTrack(pair->GetFirstDaughterP());
+          motherLbl = daughterMC->GetMother();
+        }
         Double_t vtxX, vtxY, vtxZ;
 	if(motherMC && mc->GetPrimaryVertex(vtxX,vtxY,vtxZ)) {
-	  Int_t motherLbl = motherMC->GetLabel();
-	  values[AliDielectronVarManager::kHasCocktailMother]=mc->CheckParticleSource(motherLbl, AliDielectronSignalMC::kDirect);
-      	  const Double_t lxyMC = ( (motherMC->Xv() - vtxX) * motherMC->Px() +
-                                   (motherMC->Yv() - vtxY) * motherMC->Py()   ) / motherMC->Pt();
+
+	  values[AliDielectronVarManager::kHasCocktailMother] = mc->CheckParticleSource(motherLbl, AliDielectronSignalMC::kDirect);
+    const Double_t lxyMC = ( (motherMC->Xv() - vtxX) * motherMC->Px() + (motherMC->Yv() - vtxY) * motherMC->Py()   ) / motherMC->Pt();
 	  const Double_t pseudoMC = lxyMC * (TDatabasePDG::Instance()->GetParticle(443)->Mass())/motherMC->Pt();
 	  values[AliDielectronVarManager::kPseudoProperTimeResolution] = values[AliDielectronVarManager::kPseudoProperTime] - pseudoMC;
           if (errPseudoProperTime2 > 0)
@@ -2323,7 +2336,7 @@ inline void AliDielectronVarManager::FillVarDielectronPair(const AliDielectronPa
   }
 
   if(kRndmPair) values[AliDielectronVarManager::kRndmPair] = gRandom->Rndm();
-}
+} // end FillVarDielectronPair
 
 inline void AliDielectronVarManager::FillVarKFParticle(const AliKFParticle *particle, Double_t * const values)
 {


### PR DESCRIPTION
The approach in the DielectronMC class was to split a lot of functions in ESD and AOD cases in the function, with new functionalities of the classes this is no longer neccessary. Additionally functions where a split is needed to use the full power of the AliAODMCParticle are now splitted and triggered by the object argument.