### PR TITLE
AliPhysics libraries might need system libraries

### DIFF
--- a/test/load_library/LoadLib.C
+++ b/test/load_library/LoadLib.C
@@ -1,4 +1,10 @@
 Int_t LoadLib(const TString &libName)
 {
+  if (libName.Contains("PWGPP") ||
+      libName.Contains("PWGUDdiffractive")) {
+    // Might need system-installed libraries (e.g. libzmq.so)
+    gSystem->AddDynamicPath("/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64:/usr/lib/x86_64-linux-gnu");
+  }
+
   return gSystem->Load(libName);
 }


### PR DESCRIPTION
During the library load tests the system libraries path has to
be incorporated for them to be properly loaded.