### PR TITLE
Fix passing track selection result

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.cxx
@@ -166,12 +166,13 @@ PWG::EMCAL::AliEmcalTrackSelResultPtr AliEmcalTrackSelectionAOD::IsTrackAccepted
   trackbitmap.ResetAllBits();
   UInt_t cutcounter(0);
   TObjArray selectionStatus;
+  selectionStatus.SetOwner(kTRUE);
   if (fListOfCuts) {
     for (auto cutIter : *fListOfCuts){
       PWG::EMCAL::AliEmcalCutBase *trackCuts = static_cast<PWG::EMCAL::AliEmcalCutBase*>(static_cast<AliEmcalManagedObject *>(cutIter)->GetObject());
       PWG::EMCAL::AliEmcalTrackSelResultPtr cutresults = trackCuts->IsSelected(aodt);
       if (cutresults) trackbitmap.SetBitNumber(cutcounter);
-      selectionStatus.Add(&cutresults);
+      selectionStatus.Add(new PWG::EMCAL::AliEmcalTrackSelResultPtr(cutresults));
       cutcounter++;
     }
   }

--- a/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
@@ -616,8 +616,12 @@ PWG::EMCAL::AliEmcalTrackSelResultHybrid::HybridType_t AliTrackContainer::GetHyb
   } else {
     if(auto combineddata = dynamic_cast<const PWG::EMCAL::AliEmcalTrackSelResultCombined *>(selectionResult.GetUserInfo())){
       for(int icut = 0; icut < combineddata->GetNumberOfSelectionResults(); icut++){
-        auto cutresult = GetHybridDefinition((*combineddata)[icut]);
-        if(cutresult != PWG::EMCAL::AliEmcalTrackSelResultHybrid::kUndefined) hybridDefinition = cutresult;
+        try{
+          auto cutresult = GetHybridDefinition((*combineddata)[icut]);
+          if(cutresult != PWG::EMCAL::AliEmcalTrackSelResultHybrid::kUndefined) hybridDefinition = cutresult;
+        } catch(PWG::EMCAL::AliEmcalTrackSelResultCombined::IndexException &e) {
+          AliErrorStream() << "Index error: " << e.what() << std::endl;
+        }
       }
     }
   }


### PR DESCRIPTION
Pointer to local variable in loop over the track selections was passed to the combined track selection (introduced when fixing the compilation under ROOT5 when moving from std::vector to TObjArray).  Copy introduced and TObjArray made owner of the track selection result pointers. Eventually going to TClonesArray for more efficient memory handling.