### PR TITLE
TClonesArray / Fix memory leak

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultCombined.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultCombined.cxx
@@ -39,11 +39,11 @@ AliEmcalTrackSelResultCombined::AliEmcalTrackSelResultCombined():
 
 }
 
-AliEmcalTrackSelResultCombined::AliEmcalTrackSelResultCombined(const TObjArray &singleSelPointers):
+AliEmcalTrackSelResultCombined::AliEmcalTrackSelResultCombined(const TObjArray *singleSelPointers):
   TObject(),
-  fData()
+  fData("PWG::EMCAL::AliEmcalTrackSelResultPtr", singleSelPointers->GetEntries())
 {
-  for(auto o  : singleSelPointers) fData.Add(new AliEmcalTrackSelResultPtr(*(static_cast<AliEmcalTrackSelResultPtr *>(o))));
+  for(auto o  : *singleSelPointers) new(fData[fData.GetEntries()]) AliEmcalTrackSelResultPtr(*(static_cast<AliEmcalTrackSelResultPtr *>(o)));
 }
 
 AliEmcalTrackSelResultPtr &AliEmcalTrackSelResultCombined::operator[](int index) const {

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultCombined.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultCombined.h
@@ -28,7 +28,7 @@
 #define ALIEMCALTRACKSELRESULTCOMBINED_H
 
 #include <TObject.h>
-#include <TObjArray.h>
+#include <TClonesArray.h>
 #include <exception>
 #include <sstream>
 #include <string>
@@ -60,14 +60,14 @@ public:
   };
   
   AliEmcalTrackSelResultCombined();
-  AliEmcalTrackSelResultCombined(const TObjArray &singleSelPointers);
+  AliEmcalTrackSelResultCombined(const TObjArray *singleSelPointers);
   virtual ~AliEmcalTrackSelResultCombined() {}
 
   AliEmcalTrackSelResultPtr &operator[](int index) const;
   Int_t GetNumberOfSelectionResults() const;
 
 private:
-  TObjArray                   fData;    ///< Single 
+  TClonesArray                   fData;    ///< Single 
 
   /// \cond CLASSIMP
   ClassDef(AliEmcalTrackSelResultCombined, 1);

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultPtr.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultPtr.cxx
@@ -26,6 +26,7 @@
  ************************************************************************************/
 #include <iostream>
 #include <TNamed.h> // for user object
+#include <TClass.h>
 #include "AliEmcalTrackSelResultPtr.h"
 #include "AliVTrack.h"
 
@@ -138,6 +139,11 @@ std::ostream &PWG::EMCAL::operator<<(std::ostream &stream, const PWG::EMCAL::Ali
   return stream;
 }
 
+/*************************************************************
+ *                                                           *
+ * Content of class AliEmcalTrackSelResultUserStorage        *
+ *                                                           *
+ *************************************************************/
 
 AliEmcalTrackSelResultUserStorage::AliEmcalTrackSelResultUserStorage():
   TObject(),
@@ -152,10 +158,10 @@ AliEmcalTrackSelResultUserStorage::AliEmcalTrackSelResultUserStorage(TObject *da
   fData(data),
   fReferenceCount(1)
 {
-  
 }
 
 AliEmcalTrackSelResultUserStorage::~AliEmcalTrackSelResultUserStorage(){
+  //std::cout << "Destructing user storage with reference count 0" << std::endl;
   if(fData) delete fData;
 }
 
@@ -167,6 +173,12 @@ void AliEmcalTrackSelResultUserStorage::Release(){
   fReferenceCount--;
 }
 
+/*************************************************************
+ *                                                           *
+ * Content of class AliEmcalTrackSelResultUserPtr            *
+ *                                                           *
+ *************************************************************/
+
 AliEmcalTrackSelResultUserPtr::AliEmcalTrackSelResultUserPtr():
   TObject(),
   fUserStorage(nullptr)
@@ -176,9 +188,9 @@ AliEmcalTrackSelResultUserPtr::AliEmcalTrackSelResultUserPtr():
 
 AliEmcalTrackSelResultUserPtr::AliEmcalTrackSelResultUserPtr(TObject *data):
   TObject(),
-  fUserStorage(new AliEmcalTrackSelResultUserStorage(data))
+  fUserStorage(nullptr)
 {
-  
+  if(data) fUserStorage = new AliEmcalTrackSelResultUserStorage(data);
 }
 
 AliEmcalTrackSelResultUserPtr::AliEmcalTrackSelResultUserPtr(const AliEmcalTrackSelResultUserPtr &ref):
@@ -208,7 +220,7 @@ AliEmcalTrackSelResultUserPtr &AliEmcalTrackSelResultUserPtr::operator=(const Al
   if(&ref != this){
     if(fUserStorage) {
       fUserStorage->Release();
-      if(fUserStorage->GetReferenceCount() < 1) delete fUserStorage;
+     // if(fUserStorage->GetReferenceCount() < 1) delete fUserStorage;
     } 
 
     if(ref.fUserStorage) {
@@ -225,7 +237,7 @@ AliEmcalTrackSelResultUserPtr &AliEmcalTrackSelResultUserPtr::operator=(AliEmcal
   if(&ref != this){
     if(fUserStorage) {
       fUserStorage->Release();
-      if(fUserStorage->GetReferenceCount() < 1) delete fUserStorage;
+      //if(fUserStorage->GetReferenceCount() < 1) delete fUserStorage;
     } 
 
     if(ref.fUserStorage) {
@@ -241,7 +253,7 @@ AliEmcalTrackSelResultUserPtr::~AliEmcalTrackSelResultUserPtr(){
   if(fUserStorage) {
     fUserStorage->Release();
     // The last pointer connected to the storage deletes it
-    if(fUserStorage->GetReferenceCount() < 1) delete fUserStorage;
+    //if(fUserStorage->GetReferenceCount() < 1) delete fUserStorage;
   }
 }
 

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultPtr.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultPtr.h
@@ -48,7 +48,8 @@ namespace EMCAL {
  * connected to it via the reference count. Instances can connect and disconnect
  * by the functions Connect and Release.
  * 
- * This class is foreseen to be used only from within AliEmcalTrackSelResultUserPtr.
+ * This class is foreseen to be used only from within AliEmcalTrackSelResultUserPtr. It
+ * is a suicide object which kills itself once it goes out-of-scope.
  */
 class AliEmcalTrackSelResultUserStorage : public TObject {
 public:
@@ -61,14 +62,6 @@ public:
    * @param data 
    */
   AliEmcalTrackSelResultUserStorage(TObject *data);
-  
-  /**
-   * @brief Destructor
-   * 
-   * Deletes the data associated to the storage. Only to be used
-   * from within AliEmcalTrackSelResultUserPtr
-   */
-  virtual ~AliEmcalTrackSelResultUserStorage();
   
   /**
    * @brief Connect new user pointer instance to the storage
@@ -105,6 +98,16 @@ public:
    * @return User data handled by the storage
    */
   TObject *GetData() const { return fData; }
+
+protected:
+
+  /**
+   * @brief Destructor
+   * 
+   * Deletes the data associated to the storage. Only to be used
+   * from within AliEmcalTrackSelResultUserPtr
+   */
+  virtual ~AliEmcalTrackSelResultUserStorage();
 
 private:
   AliEmcalTrackSelResultUserStorage(const AliEmcalTrackSelResultUserStorage &);

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.cxx
@@ -136,6 +136,7 @@ TObjArray* AliEmcalTrackSelection::GetAcceptedTracks(const TClonesArray* const t
 {
   if (!fListOfTracks) {
     fListOfTracks = new TObjArray;
+    fListOfTracks->SetOwner(kTRUE);
   }
   else {
     fListOfTracks->Clear();
@@ -155,6 +156,7 @@ TObjArray* AliEmcalTrackSelection::GetAcceptedTracks(const AliVEvent* const even
 {
   if (!fListOfTracks) {
     fListOfTracks = new TObjArray;
+    fListOfTracks->SetOwner(kTRUE);
   }
   else {
     fListOfTracks->Clear();

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.cxx
@@ -165,19 +165,19 @@ PWG::EMCAL::AliEmcalTrackSelResultPtr AliEmcalTrackSelectionAOD::IsTrackAccepted
   TBits trackbitmap(64);
   trackbitmap.ResetAllBits();
   UInt_t cutcounter(0);
-  TObjArray selectionStatus;
+  TClonesArray selectionStatus("PWG::EMCAL::AliEmcalTrackSelResultPtr", fListOfCuts->GetEntries());
   selectionStatus.SetOwner(kTRUE);
   if (fListOfCuts) {
     for (auto cutIter : *fListOfCuts){
       PWG::EMCAL::AliEmcalCutBase *trackCuts = static_cast<PWG::EMCAL::AliEmcalCutBase*>(static_cast<AliEmcalManagedObject *>(cutIter)->GetObject());
       PWG::EMCAL::AliEmcalTrackSelResultPtr cutresults = trackCuts->IsSelected(aodt);
       if (cutresults) trackbitmap.SetBitNumber(cutcounter);
-      selectionStatus.Add(new PWG::EMCAL::AliEmcalTrackSelResultPtr(cutresults));
+      new(selectionStatus[selectionStatus.GetEntries()]) PWG::EMCAL::AliEmcalTrackSelResultPtr(cutresults);
       cutcounter++;
     }
   }
 
-  PWG::EMCAL::AliEmcalTrackSelResultPtr result(aodt, kFALSE, new PWG::EMCAL::AliEmcalTrackSelResultCombined(selectionStatus));
+  PWG::EMCAL::AliEmcalTrackSelResultPtr result(aodt, kFALSE, new PWG::EMCAL::AliEmcalTrackSelResultCombined(&selectionStatus));
   if (fSelectionModeAny){
     // In case of ANY one of the cuts need to be fulfilled (equivalent to one but set)
     result.SetSelectionResult(trackbitmap.CountBits() > 0 || cutcounter == 0);

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionESD.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionESD.cxx
@@ -152,7 +152,7 @@ PWG::EMCAL::AliEmcalTrackSelResultPtr AliEmcalTrackSelectionESD::IsTrackAccepted
     cutcounter++;
   }
   // In case of ANY at least one bit has to be set, while in case of ALL all bits have to be set
-  PWG::EMCAL::AliEmcalTrackSelResultPtr result(esdt, kFALSE, new PWG::EMCAL::AliEmcalTrackSelResultCombined(selectionStatus));
+  PWG::EMCAL::AliEmcalTrackSelResultPtr result(esdt, kFALSE, new PWG::EMCAL::AliEmcalTrackSelResultCombined(&selectionStatus));
   if (fSelectionModeAny){
     result.SetSelectionResult(trackbitmap.CountBits() > 0 || cutcounter == 0);
   } else {


### PR DESCRIPTION
- Move to TClonesArray for the combined track results
  in order to reduce dynamic memory allocation
- Fixing memory leak (SetOwner missing for TObjArray
  in both functions GetAcceptedTracks)
- Make storage suicide object: Once the ref count is 0
  the storage deletes itself automatically, not handled
  anymore by the pointers referencing it.