### PR TITLE
Add missing self-destruction

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultPtr.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultPtr.cxx
@@ -171,6 +171,7 @@ void AliEmcalTrackSelResultUserStorage::Connect() {
 
 void AliEmcalTrackSelResultUserStorage::Release(){
   fReferenceCount--;
+  if(!fReferenceCount) delete this;
 }
 
 /*************************************************************


### PR DESCRIPTION
Should have been part of the previous commit when changing storage handler to self-destruction, was lost somehow. Essential part of the reference counting.