### PR TITLE
GetAcceptedTracks returning selection result for all tracks

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.cxx
@@ -143,11 +143,7 @@ TObjArray* AliEmcalTrackSelection::GetAcceptedTracks(const TClonesArray* const t
   }
 
   for(auto mytrack : *tracks) {
-    AliVTrack *track = static_cast<AliVTrack *>(mytrack);
-    PWG::EMCAL::AliEmcalTrackSelResultPtr selectionResult = IsTrackAccepted(track);
-    if(selectionResult) {
-      fListOfTracks->AddLast(new PWG::EMCAL::AliEmcalTrackSelResultPtr(selectionResult));
-    }
+    fListOfTracks->AddLast(new PWG::EMCAL::AliEmcalTrackSelResultPtr(IsTrackAccepted(static_cast<AliVTrack *>(mytrack))));
   }
   return fListOfTracks;
 }
@@ -163,10 +159,7 @@ TObjArray* AliEmcalTrackSelection::GetAcceptedTracks(const AliVEvent* const even
   }
 
   for(int itrk = 0; itrk < event->GetNumberOfTracks(); itrk++){
-    AliVTrack *trk = static_cast<AliVTrack*>(event->GetTrack(itrk));
-    PWG::EMCAL::AliEmcalTrackSelResultPtr selectionStatus = IsTrackAccepted(trk);
-    if(selectionStatus)
-      fListOfTracks->AddLast(new PWG::EMCAL::AliEmcalTrackSelResultPtr(selectionStatus));
+    fListOfTracks->AddLast(new PWG::EMCAL::AliEmcalTrackSelResultPtr(IsTrackAccepted(static_cast<AliVTrack*>(event->GetTrack(itrk)))));
   }
   return fListOfTracks;
 }

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.h
@@ -198,19 +198,31 @@ public:
 
   /**
    * @brief Select tracks from a TClonesArray of input tracks
+	 * 
+	 * Running track selection for all tracks in the input array 
+	 * (by calling the IsTrackAccepted function) and storing the track 
+	 * selection result in the output container.
+	 * Attention: The output container contains the result for all
+	 * tracks, not only those selected. It is the user responsibility
+	 * to filter the selected tracks.
    *
    * @param[in] tracks TClonesArray of tracks (must not be null)
-   * @return TObjArray of selected tracks
+   * @return TObjArray of AliEmcalTrackSelResultPtr with the selection status for all tracks
    */
 	TObjArray *GetAcceptedTracks(const TClonesArray * const tracks);
 
 	/**
 	 * @brief Select tracks from a virtual event
 	 *
-	 * Delegates selection process to function IsTrackAccepted
-	 *
+	 * Running track selection for all tracks in the input event 
+	 * (by calling the IsTrackAccepted function) and storing the track 
+	 * selection result in the output container.
+	 * Attention: The output container contains the result for all
+	 * tracks, not only those selected. It is the user responsibility
+	 * to filter the selected tracks.
+	 * 
 	 * @param[in] event AliVEvent, via interface of virtual event (must not be null)
-	 * @return TObjArray of selected tracks
+	 * @return TObjArray of AliEmcalTrackSelResultPtr with the selection status for all tracks
 	 */
 	TObjArray *GetAcceptedTracks(const AliVEvent *const event);
 


### PR DESCRIPTION
As discussed in #3612 GetAcceptedTracks should rather return
the selection status for all tracks in order to avoid gaps
in the track container.