### PR TITLE
PWGCF: AliFemtoConfigObject - Improved iteration methods

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoConfigObject.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoConfigObject.cxx
@@ -737,56 +737,54 @@ AliFemtoConfigObject::ParseMap(StringIter_t& it, const StringIter_t stop)
   it = match[0].second;
 
   // loop until we match right bracket }
-  for (; !std::regex_search(it, stop, match, RBRK_RX); ) {
-      // load key
-      if (!std::regex_search(it, stop, match, KEY_RX)) {
-        // throw std::runtime_error("Expected a Key or '}", it);
-      }
+  while (!std::regex_search(it, stop, match, RBRK_RX)) {
+    // load key into match[0]
+    if (!std::regex_search(it, stop, match, KEY_RX)) {
+      throw UnexpectedCharacter(START, "Map", "Expected beginning of key or '}' char");
+    }
 
-      std::string key = match.str();
+    auto keys = parse_map_key_unchecked(match[0].first, match[0].second);
+
+    if (!std::regex_search(match[0].second, stop, match, COLON_RX)) {
+      throw UnexpectedCharacter(START, "Map", "Expected colon ':' after key " + match[0].str());
+    }
+    // 'it' now should point to beginning of value
+    it = match[0].second;
+    AliFemtoConfigObject value = Parse(it, stop);
+
+    if (std::regex_search(it, stop, match, COMMA_RX)) {
       it = match[0].second;
+    } else if (!std::regex_search(it, stop, match, RBRK_RX)) {
+      throw UnexpectedCharacter(START, "Map", "Expected closing brace '}'");
+    }
 
-      auto keys = parse_map_key_unchecked(match[0].first, match[0].second);
+    // push key-value pairs into back
+    if (keys.size() > 1) {
+      auto key_it = keys.rbegin(),
+           key_it_stop = keys.rend();
 
-      if (!std::regex_search(match[0].second, stop, match, COLON_RX)) {
-          // throw std::runtime_error("Expected colon after key");
-          throw UnexpectedCharacter(START, "Map", "colon after key");
+      AliFemtoConfigObject::MapValue_t tmp_map;
+
+      // loop until last one
+      for (; std::next(key_it) != key_it_stop; ++key_it) {
+        tmp_map.emplace(*key_it, std::move(value)); // value should now be empty
+        value = std::move(tmp_map); // tmp_map should now be empty - value is new map object
       }
-      it = match[0].second;
-      AliFemtoConfigObject value = Parse(it, stop);
+    }
 
-      if (std::regex_search(it, stop, match, COMMA_RX)) {
-          it = match[0].second;
-      } else if (!std::regex_search(it, stop, match, RBRK_RX)) {
-        std::cerr << " --- Error: " << *it << "\n";
-          throw std::runtime_error("Expected '}'");
-      }
-
-      // push key-value pairs into back
-      if (keys.size() > 1) {
-        auto key_it = keys.rbegin(),
-             key_it_stop = keys.rend();
-
-        AliFemtoConfigObject::MapValue_t tmp_map;
-
-        // loop until last one
-        for (; std::next(key_it) != key_it_stop; ++key_it) {
-            tmp_map.emplace(*key_it, std::move(value)); // value should now be empty
-            value = std::move(tmp_map); // tmp_map should now be empty - value is new map object
-        }
-      }
-
-      result_map.emplace(keys.front(), std::move(value));
+    result_map.emplace(keys.front(), std::move(value));
   }
 
   it = match[0].second;
   return AliFemtoConfigObject(std::move(result_map));
 }
 
-template <typename List_t>
-void
-parse_matched_rangelist(const std::smatch& m, List_t& result)
+AliFemtoConfigObject
+match_to_rangelist(const std::smatch& m)
 {
+  AliFemtoConfigObject::RangeListValue_t result;
+  using Float_t = AliFemtoConfigObject::RangeListValue_t::value_type::first_type;
+
   const std::regex comma_re(COMMA_PAT),
                    colon_re(COLON_PAT);
 
@@ -797,15 +795,24 @@ parse_matched_rangelist(const std::smatch& m, List_t& result)
 
     std::sregex_token_iterator num(group->first, group->second, colon_re, -1);
 
-    typename List_t::value_type::first_type first = std::stod(*num++),
-                                            second;
+    Float_t first = std::stod(*num++);
 
     for (num++; num != stop; ++num) {
-      second = std::stod(*num);
+      Float_t second = std::stod(*num);
       result.emplace_back(first, second);
       first = second;
     }
   }
+
+  return AliFemtoConfigObject(result);
+}
+
+AliFemtoConfigObject
+match_to_range(const std::smatch &match)
+{
+  AliFemtoConfigObject::FloatValue_t range_start = std::stod(match[1].str()),
+                                      range_stop = std::stod(match[2].str());
+  return AliFemtoConfigObject(range_start, range_stop);
 }
 
 AliFemtoConfigObject
@@ -825,10 +832,8 @@ AliFemtoConfigObject::Parse(StringIter_t& it, const StringIter_t stop)
   }
 
   else if (std::regex_search(it, stop, match, RANGE_RX)) {
-    FloatValue_t start = std::stod(match[1].str()),
-                  stop = std::stod(match[2].str());
     it = match[0].second;
-    return AliFemtoConfigObject(start, stop);
+    return match_to_range(match);
   }
 
   else if (std::regex_search(it, stop, match, BOOL_RX)) {
@@ -837,7 +842,6 @@ AliFemtoConfigObject::Parse(StringIter_t& it, const StringIter_t stop)
   }
 
   else if (std::regex_search(it, stop, match, FLT_RX)) {
-    // std::cout << " Matched float " << match.str() << "\n";
     it = match[0].second;
     return AliFemtoConfigObject(std::stod(match.str()));
   }
@@ -852,6 +856,11 @@ AliFemtoConfigObject::Parse(StringIter_t& it, const StringIter_t stop)
     return AliFemtoConfigObject(std::string(match[0].first + 1, it - 1));
   }
 
+  else if (std::regex_search(it, stop, match, RANGELIST_RX)) {
+    it = match[0].second;
+    return match_to_rangelist(match);
+  }
+
   else if (*it == '{') {
     return ParseMap(it, stop);
   }
@@ -860,18 +869,7 @@ AliFemtoConfigObject::Parse(StringIter_t& it, const StringIter_t stop)
     return ParseArray(it, stop);
   }
 
-  else if (*it == '(' && std::regex_search(it, stop, match, RANGELIST_RX)) {
-    // std::cout << " Matching range-list " << match.str() << "\n";
-
-    RangeListValue_t ranges;
-    parse_matched_rangelist(match, ranges);
-
-    it = match[0].second;
-    return AliFemtoConfigObject(std::move(ranges));
-  }
-
   throw UnexpectedLeadingChar(it, "undetermined-type", "");
-  // std::runtime_error(std::string("Unknown character '") + *it + "'");
 }
 
 namespace std {
@@ -1062,4 +1060,3 @@ AliFemtoConfigObject::WithoutKeys(const std::vector<Key_t> &keys) const
   }
   return result;
 }
-

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoConfigObject.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoConfigObject.h
@@ -391,6 +391,121 @@ public:
 
   /// @}
 
+  /// \class list_iterator
+  /// \brief Iterates over object if it is a list
+  ///
+  /// Use this class by calling `list_begin()` and `list_end()` on a
+  /// config object.
+  /// If the object is not a list, then list_begin() will return the
+  /// same value as list_end(), and there is no iteration (using
+  /// standard iteration rules)
+  ///
+  class list_iterator : public std::iterator<std::bidirectional_iterator_tag, ArrayValue_t::value_type> {
+    AliFemtoConfigObject *fParent;
+    bool fIsArray;
+    ArrayValue_t::iterator fInternal;
+    friend class AliFemtoConfigObject;
+
+    list_iterator(AliFemtoConfigObject *obj, ArrayValue_t::iterator it):
+      fParent(obj), fIsArray(true), fInternal(it) {}
+
+  public:
+    /// construct from config object
+    list_iterator(AliFemtoConfigObject &obj): fParent(&obj), fIsArray(obj.is_array()) {
+      if (fIsArray) {
+        fInternal = obj.fValueArray.begin();
+      }
+    }
+
+    value_type& operator*() {
+      return *fInternal;
+    }
+
+    list_iterator& operator++(int) {
+      fInternal++;
+      return *this;
+    }
+
+    bool operator!=(list_iterator const &rhs) const {
+      return rhs.fParent != fParent                  // if we don't have same parent - different
+          || fIsArray ? (fInternal != rhs.fInternal) // if array, compare internal iterator
+                      : false;                       // if not array, we are equal
+    }
+  };
+
+  ///
+  list_iterator list_begin() {
+    return list_iterator(*this);
+  }
+
+  ///
+  list_iterator list_end() {
+    if (is_array()) {
+      return list_iterator(this, fValueArray.end());
+    }
+    return list_iterator(*this);
+  }
+
+
+  /// \class map_iterator
+  /// \brief Iterates over object if it is a map
+  ///
+  /// Use this class by calling `map_begin()` and `map_end()` on a
+  /// config object.
+  /// If the object is not a list, then map_begin() will return the
+  /// same value as map_end(), and there is no iteration (using
+  /// standard iteration rules)
+  ///
+  class map_iterator : public std::iterator<std::bidirectional_iterator_tag, MapValue_t::value_type> {
+    AliFemtoConfigObject *fParent;
+    bool fIsMap;
+    MapValue_t::iterator fInternal;
+    friend class AliFemtoConfigObject;
+
+    map_iterator(AliFemtoConfigObject *obj, MapValue_t::iterator it):
+      fParent(obj), fIsMap(true), fInternal(it) {}
+
+  public:
+    /// construct from config object
+    map_iterator(AliFemtoConfigObject &obj): fParent(&obj), fIsMap(obj.is_map()) {
+      if (fIsMap) {
+        fInternal = obj.fValueMap.begin();
+      }
+    }
+
+    value_type& operator*() {
+      return *fInternal;
+    }
+
+    map_iterator& operator++(int) {
+      fInternal++;
+      return *this;
+    }
+
+    bool operator!=(map_iterator const &rhs) const {
+      return rhs.fParent != fParent                // if we don't have same parent - different
+          || fIsMap ? (fInternal != rhs.fInternal) // if array, compare internal iterator
+                    : false;                       // if not array, we are equal
+    }
+  };
+
+  ///
+  map_iterator map_begin() {
+    return map_iterator(*this);
+  }
+
+  ///
+  map_iterator map_end() {
+    if (is_map()) {
+      return map_iterator(this, fValueMap.end());
+    }
+    return map_iterator(*this);
+  }
+
+
+
+
+
   /// \class Popper
   /// \brief Struct used for 'poping' many values from object
   struct Popper {

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/PWGCFfemtoscopyUserLinkDef.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/PWGCFfemtoscopyUserLinkDef.h
@@ -126,6 +126,14 @@
 #pragma link C++ class AliFemtoConfigObject-;
 #pragma link C++ class AliFemtoConfigObject::Painter;
 #pragma link C++ class AliFemtoConfigObject::BuildMap;
+#pragma link C++ class AliFemtoConfigObject::list_iterator;
+#pragma link C++ class AliFemtoConfigObject::map_iterator;
+#pragma link C++ class std::map<std::string, AliFemtoConfigObject>;
+#pragma link C++ class std::vector<AliFemtoConfigObject>;
+#pragma link C++ class std::vector<AliFemtoConfigObject>::iterator;
+#pragma link C++ class std::pair<double, double>;
+#pragma link C++ class std::vector<std::pair<double, double>>;
+// ^ these std:: classes required here for use in ROOT-5 macros (ROOT-6 should be ok)
 
 #pragma link C++ class AliFemtoAnalysisLambdaKaon+;
 #pragma link C++ class AliFemtoAnalysisLambdaKaon::AnalysisParams+;


### PR DESCRIPTION
- Added new `list_begin(), list_end()` & `map_begin(), map_end()` methods for easy iteration over containers in for loops
- Added `items_in_list()` & `items_in_map()` methods for easy iteration in C++11 foreach loops
- Also cleaned and "standardized" more of the parsing code