### PR TITLE
PWGCF: AliFemtoESDTrackCutNSigmaFilter: Added class member fUseIsProb…

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.cxx
@@ -957,6 +957,7 @@ AliFemtoESDTrackCutNSigmaFilter* AliFemtoAnalysisLambdaKaon::CreateESDCut(ESDCut
   if(aCutParams.useCustomMisID) AddCustomESDRejectionFilters(aCutParams.particlePDGType,tESDCut);
 
   tESDCut->SetUseCustomElectronRejection(aCutParams.useCustomElectronRejection);
+  tESDCut->SetUseIsProbableElectronMethod(aCutParams.useIsProbableElectronMethod);
 
   return tESDCut;
 }
@@ -1970,6 +1971,7 @@ AliFemtoAnalysisLambdaKaon::DefaultKchCutParams(int aCharge)
   tReturnParams.useCustomMisID = true;
   tReturnParams.useElectronRejection = true;
   tReturnParams.useCustomElectronRejection = true;
+  tReturnParams.useIsProbableElectronMethod = true;
   tReturnParams.usePionRejection = true;
 
   return tReturnParams;
@@ -2017,6 +2019,7 @@ AliFemtoAnalysisLambdaKaon::DefaultPiCutParams(int aCharge)
   tReturnParams.useCustomMisID = false;
   tReturnParams.useElectronRejection = false;
   tReturnParams.useCustomElectronRejection = false;
+  tReturnParams.useIsProbableElectronMethod = false;
   tReturnParams.usePionRejection = false;
 
   return tReturnParams;
@@ -2254,6 +2257,7 @@ AliFemtoAnalysisLambdaKaon::LambdaPurityPiCutParams(int aCharge)
   tReturnParams.useCustomMisID = false;
   tReturnParams.useElectronRejection = false;
   tReturnParams.useCustomElectronRejection = false;
+  tReturnParams.useIsProbableElectronMethod = false;
   tReturnParams.usePionRejection = false;
 
   return tReturnParams;
@@ -2315,6 +2319,7 @@ AliFemtoAnalysisLambdaKaon::K0ShortPurityPiCutParams(int aCharge)
   tReturnParams.useCustomMisID = false;
   tReturnParams.useElectronRejection = false;
   tReturnParams.useCustomElectronRejection = false;
+  tReturnParams.useIsProbableElectronMethod = false;
   tReturnParams.usePionRejection = false;
 
   return tReturnParams;
@@ -2380,6 +2385,7 @@ AliFemtoAnalysisLambdaKaon::LambdaPurityProtonCutParams(int aCharge)
   tReturnParams.useCustomMisID = false;
   tReturnParams.useElectronRejection = false;
   tReturnParams.useCustomElectronRejection = false;
+  tReturnParams.useIsProbableElectronMethod = false;
   tReturnParams.usePionRejection = false;
 
   return tReturnParams;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisLambdaKaon.h
@@ -209,6 +209,7 @@ struct ESDCutParams
   bool useCustomMisID;
   bool useElectronRejection;
   bool useCustomElectronRejection;
+  bool useIsProbableElectronMethod;
   bool usePionRejection;
 };
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoESDTrackCutNSigmaFilter.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoESDTrackCutNSigmaFilter.cxx
@@ -21,6 +21,7 @@ AliFemtoESDTrackCutNSigmaFilter::AliFemtoESDTrackCutNSigmaFilter() :
   , fUseCustomKaonNSigmaFilter(false)
   , fUseCustomProtonNSigmaFilter(false)
   , fUseCustomElectronNSigmaFilter(false)
+  , fUseIsProbableElectronMethod(true)
 
   , fPionNSigmaFilter(NULL)
   , fKaonNSigmaFilter(NULL)
@@ -38,6 +39,7 @@ AliFemtoESDTrackCutNSigmaFilter::AliFemtoESDTrackCutNSigmaFilter(const AliFemtoE
   fUseCustomKaonNSigmaFilter(aCut.fUseCustomKaonNSigmaFilter),
   fUseCustomProtonNSigmaFilter(aCut.fUseCustomProtonNSigmaFilter),
   fUseCustomElectronNSigmaFilter(aCut.fUseCustomElectronNSigmaFilter),
+  fUseIsProbableElectronMethod(aCut.fUseIsProbableElectronMethod),
   fPionRejection(aCut.fPionRejection)
 {
   if(aCut.fPionNSigmaFilter) fPionNSigmaFilter = new AliFemtoNSigmaFilter(*aCut.fPionNSigmaFilter);
@@ -58,6 +60,7 @@ AliFemtoESDTrackCutNSigmaFilter& AliFemtoESDTrackCutNSigmaFilter::operator=(cons
   fUseCustomKaonNSigmaFilter = aCut.fUseCustomKaonNSigmaFilter;
   fUseCustomProtonNSigmaFilter = aCut.fUseCustomProtonNSigmaFilter;
   fUseCustomElectronNSigmaFilter = aCut.fUseCustomElectronNSigmaFilter;
+  fUseIsProbableElectronMethod = aCut.fUseIsProbableElectronMethod;
   fPionRejection = aCut.fPionRejection;
 
   if(aCut.fPionNSigmaFilter) fPionNSigmaFilter = new AliFemtoNSigmaFilter(*aCut.fPionNSigmaFilter);
@@ -242,8 +245,15 @@ bool AliFemtoESDTrackCutNSigmaFilter::Pass(const AliFemtoTrack* track)
   {
     if(fUseCustomElectronNSigmaFilter)
     {
-//      if(IsElectronNSigma(track->P().Mag(), track->NSigmaTPCE(), track->NSigmaTOFE())) return false;
-      if(IsProbableElectron(track)) return false;
+      if(fUseIsProbableElectronMethod)
+      {
+        if(IsProbableElectron(track)) return false;
+      }
+      else 
+      {
+        if(IsElectronNSigma(track->P().Mag(), track->NSigmaTPCE(), track->NSigmaTOFE())) return false;
+      }
+      
     }
     else
     {

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoESDTrackCutNSigmaFilter.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoESDTrackCutNSigmaFilter.h
@@ -50,6 +50,7 @@ public:
 
   void SetPionRejection(bool aReject);
   void SetUseCustomElectronRejection(bool aReject);
+  void SetUseIsProbableElectronMethod(bool aUse);
 
 private:
   //Used in IsKaonNSigma, IsPionNSigma, and IsProtonNSigma methods
@@ -57,6 +58,7 @@ private:
   bool fUseCustomKaonNSigmaFilter;
   bool fUseCustomProtonNSigmaFilter;
   bool fUseCustomElectronNSigmaFilter;
+  bool fUseIsProbableElectronMethod;
 
   AliFemtoNSigmaFilter *fPionNSigmaFilter;
   AliFemtoNSigmaFilter *fKaonNSigmaFilter;
@@ -81,5 +83,6 @@ private:
 
 inline void AliFemtoESDTrackCutNSigmaFilter::SetPionRejection(bool aReject) {fPionRejection = aReject;}
 inline void AliFemtoESDTrackCutNSigmaFilter::SetUseCustomElectronRejection(bool aReject) {fUseCustomElectronNSigmaFilter = aReject;}
+inline void AliFemtoESDTrackCutNSigmaFilter::SetUseIsProbableElectronMethod(bool aUse) {fUseIsProbableElectronMethod = aUse;}
 
 #endif


### PR DESCRIPTION
…ableElectronMethod.  When using a custom electron nsigmafilter to reject electrons, this allows the user to choose between the methods IsProbableElectron and IsElectronNSigma.  This will allow me to easily reproduce my 20161027 results