### PR TITLE
PWGCF: Enforce const-correct character string parameters

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBPLCMS3DCorrFctn.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBPLCMS3DCorrFctn.cxx
@@ -17,7 +17,7 @@
 
 //____________________________
 AliFemtoBPLCMS3DCorrFctn::AliFemtoBPLCMS3DCorrFctn(
-    char* title,
+    const char* title,
     const int& nbins,
     const float& QLo,
     const float& QHi

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBPLCMS3DCorrFctn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBPLCMS3DCorrFctn.h
@@ -21,7 +21,7 @@
 
 class AliFemtoBPLCMS3DCorrFctn : public AliFemtoCorrFctn {
 public:
-  AliFemtoBPLCMS3DCorrFctn(char* title, const int& nbins, const float& QLo, const float& QHi);
+  AliFemtoBPLCMS3DCorrFctn(const char* title, const int& nbins, const float& QLo, const float& QHi);
   AliFemtoBPLCMS3DCorrFctn(const AliFemtoBPLCMS3DCorrFctn& aCorrFctn);
   virtual ~AliFemtoBPLCMS3DCorrFctn();
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBPLCMS3DCorrFctnKK.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBPLCMS3DCorrFctnKK.cxx
@@ -15,7 +15,7 @@
 
 //____________________________
 AliFemtoBPLCMS3DCorrFctnKK::AliFemtoBPLCMS3DCorrFctnKK(
-  char* title,
+  const char* title,
   const int& nbins,
   const float& QLo,
   const float& QHi

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBPLCMS3DCorrFctnKK.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBPLCMS3DCorrFctnKK.h
@@ -26,7 +26,7 @@
 
 class AliFemtoBPLCMS3DCorrFctnKK : public AliFemtoCorrFctn {
 public:
-  AliFemtoBPLCMS3DCorrFctnKK(char* title, const int& nbins, const float& QLo, const float& QHi);
+  AliFemtoBPLCMS3DCorrFctnKK(const char* title, const int& nbins, const float& QLo, const float& QHi);
   AliFemtoBPLCMS3DCorrFctnKK(const AliFemtoBPLCMS3DCorrFctnKK& aCorrFctn);
   virtual ~AliFemtoBPLCMS3DCorrFctnKK();
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctn3DSpherical.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctn3DSpherical.cxx
@@ -19,7 +19,7 @@
 #endif
 
 //____________________________
-  AliFemtoCorrFctn3DSpherical::AliFemtoCorrFctn3DSpherical(char* title, const int& nqbins, const float& QLo, const float& QHi, const int& nphibins, const int& ncthetabins):
+  AliFemtoCorrFctn3DSpherical::AliFemtoCorrFctn3DSpherical(const char* title, const int& nqbins, const float& QLo, const float& QHi, const int& nphibins, const int& ncthetabins):
   fNumerator(0),
   fDenominator(0) //,
 							  //  fPairCut(0x0)

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctn3DSpherical.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctn3DSpherical.h
@@ -16,7 +16,7 @@
 class AliFemtoCorrFctn3DSpherical : public AliFemtoCorrFctn {
 public:
 
-  AliFemtoCorrFctn3DSpherical(char* title,
+  AliFemtoCorrFctn3DSpherical(const char* title,
                               const int& nqbins,
                               const float& QLo,
                               const float& QHi,

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarDEta.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarDEta.cxx
@@ -24,7 +24,7 @@
 #define PIT 6.28318530717958623
 
 //____________________________
-AliFemtoCorrFctnDPhiStarDEta::AliFemtoCorrFctnDPhiStarDEta(char* title,
+AliFemtoCorrFctnDPhiStarDEta::AliFemtoCorrFctnDPhiStarDEta(const char* title,
                                                            double radius=0.8,
                                                            const int& aEtaBins=50,
                                                            double aEtaRangeLow=-0.1,

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarDEta.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarDEta.h
@@ -20,7 +20,7 @@
 class AliFemtoCorrFctnDPhiStarDEta : public AliFemtoCorrFctn {
 public:
 
-  AliFemtoCorrFctnDPhiStarDEta(char* title, double radius, const int& aEtaBins, double aEtaRangeLow, double aEtaRangeUp, const int& aPhiStarBins, double aPhiStarRangeLow, double aPhiStarRangeUp);
+  AliFemtoCorrFctnDPhiStarDEta(const char* title, double radius, const int& aEtaBins, double aEtaRangeLow, double aEtaRangeUp, const int& aPhiStarBins, double aPhiStarRangeLow, double aPhiStarRangeUp);
   AliFemtoCorrFctnDPhiStarDEta(const AliFemtoCorrFctnDPhiStarDEta& aCorrFctn);
   virtual ~AliFemtoCorrFctnDPhiStarDEta();
 
@@ -39,7 +39,7 @@ public:
   void SetMagneticFieldSign(int magsign);
 
 private:
-  
+
   TH2D *fDPhiStarDEtaNumerator;      // Numerator of dPhiStar dEta function
   TH2D *fDPhiStarDEtaDenominator;    // Denominator of dPhiStar dEta function
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarDEtaStar.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarDEtaStar.cxx
@@ -15,7 +15,7 @@
 #endif
 
 //____________________________
-AliFemtoCorrFctnDPhiStarDEtaStar::AliFemtoCorrFctnDPhiStarDEtaStar(char* title,
+AliFemtoCorrFctnDPhiStarDEtaStar::AliFemtoCorrFctnDPhiStarDEtaStar(const char* title,
 								   double radius=1.2,
 								   const int& aEtaBins=50,
 								   double aEtaRangeLow=0.0,

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarDEtaStar.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarDEtaStar.h
@@ -68,7 +68,14 @@ class AliFemtoCorrFctnDPhiStarDEtaStar : public AliFemtoCorrFctn {
   /**
    * Construct with histogram parameters
    */
-  AliFemtoCorrFctnDPhiStarDEtaStar(char* title, double radius, const int& aEtaBins, double aEtaRangeLow, double aEtaRangeUp, const int& aPhiStarBins, double aPhiStarRangeLow, double aPhiStarRangeUp);
+  AliFemtoCorrFctnDPhiStarDEtaStar(const char* title,
+                                   double radius,
+                                   const int& aEtaBins,
+                                   double aEtaRangeLow,
+                                   double aEtaRangeUp,
+                                   const int& aPhiStarBins,
+                                   double aPhiStarRangeLow,
+                                   double aPhiStarRangeUp);
 
   /// Copy Constructor
   AliFemtoCorrFctnDPhiStarDEtaStar(const AliFemtoCorrFctnDPhiStarDEtaStar& aCorrFctn);

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction.cxx
@@ -20,12 +20,12 @@
   ClassImp(AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction);
   /// \endcond
 #endif
-  
+
 #define PIH 1.57079632679489656
 #define PIT 6.28318530717958623
 
 //____________________________
-AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction::AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction(char* title, Double_t aRadiusMin, Double_t aRadiusMax, Double_t aDistanceMax, Double_t aDEtaMax, const int& aKStarBins, Double_t aKStarRangeLow, Double_t aKStarRangeUp, const Int_t& aPhiStarBins, Double_t aPhiStarRangeLow, Double_t aPhiStarRangeUp):
+AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction::AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction(const char* title, Double_t aRadiusMin, Double_t aRadiusMax, Double_t aDistanceMax, Double_t aDEtaMax, const int& aKStarBins, Double_t aKStarRangeLow, Double_t aKStarRangeUp, const Int_t& aPhiStarBins, Double_t aPhiStarRangeLow, Double_t aPhiStarRangeUp):
 AliFemtoCorrFctn(),
   fDPhiStarKStarMergedNumerator(0),
   fDPhiStarKStarTotalNumerator(0),
@@ -47,11 +47,11 @@ AliFemtoCorrFctn(),
   fKStarRangeUp = aKStarRangeUp;
   fDPhiStarRangeLow = aPhiStarRangeLow;
   fDPhiStarRangeUp = aPhiStarRangeUp;
-  
+
   // Calculate parameters:
   fDistanceMax = aDistanceMax;
   fDEtaMax = aDEtaMax;
-  
+
   // Calculate radii range:
   fRadiusMin = aRadiusMin;
   fRadiusMax = aRadiusMax;
@@ -122,7 +122,7 @@ AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction::AliFemtoCorrFctnDPhiSt
   fRadiusMin = aCorrFctn.fRadiusMin;
   fRadiusMax = aCorrFctn.fRadiusMax;
   fMagSign = aCorrFctn.fMagSign;
-  
+
 }
 
 //____________________________
@@ -244,12 +244,12 @@ void AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction::AddRealPair( AliF
   double afsi1b_radiusmin = -0.07510020733*chg2*fMagSign*fRadiusMin/pt2;
   Double_t dphistar_radiusmin =  phi2 - phi1 + TMath::ASin(afsi1b_radiusmin) - TMath::ASin(afsi0b_radiusmin);
   dphistar_radiusmin = TVector2::Phi_mpi_pi(dphistar_radiusmin);
-  
+
   if(TMath::Abs(deta) < TMath::Abs(fDEtaMax)) {
-    
+
     // Iterate through all radii in range (fRadiusMin, fRadiusMax):
     for(double irad = fRadiusMin; irad < fRadiusMax; irad += 0.01) {
-      
+
       // Calculate dPhiStar:
       double afsi0b = -0.07510020733*chg1*fMagSign*irad/pt1;
       double afsi1b = -0.07510020733*chg2*fMagSign*irad/pt2;
@@ -311,12 +311,12 @@ void AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction::AddMixedPair( Ali
   double afsi1b_radiusmin = -0.07510020733*chg2*fMagSign*fRadiusMin/pt2;
   Double_t dphistar_radiusmin =  phi2 - phi1 + TMath::ASin(afsi1b_radiusmin) - TMath::ASin(afsi0b_radiusmin);
   dphistar_radiusmin = TVector2::Phi_mpi_pi(dphistar_radiusmin);
-  
+
   if(TMath::Abs(deta) < TMath::Abs(fDEtaMax)) {
-    
+
     // Iterate through all radii in range (fRadiusMin, fRadiusMax):
     for(double irad = fRadiusMin; irad < fRadiusMax; irad += 0.01) {
-      
+
       // Calculate dPhiStar:
       double afsi0b = -0.07510020733*chg1*fMagSign*irad/pt1;
       double afsi1b = -0.07510020733*chg2*fMagSign*irad/pt2;
@@ -349,12 +349,12 @@ TList* AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction::GetOutputList()
 {
   // Prepare the list of objects to be written to the output
   TList *tOutputList = new TList();
-  
+
   tOutputList->Add(fDPhiStarKStarMergedNumerator);
   tOutputList->Add(fDPhiStarKStarTotalNumerator);
   tOutputList->Add(fDPhiStarKStarMergedDenominator);
   tOutputList->Add(fDPhiStarKStarTotalDenominator);
-  
+
   return tOutputList;
 }
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction.h
@@ -23,7 +23,7 @@
 class AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction : public AliFemtoCorrFctn {
 public:
 
-  AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction(char* title, Double_t aRadiusMin, Double_t aRadiusMax, Double_t aDistanceMax, Double_t aDEtaMax, const int& aKStarBins, Double_t aKStarRangeLow, Double_t aKStarRangeUp, const Int_t& aPhiStarBins, Double_t aPhiStarRangeLow, Double_t aPhiStarRangeUp);
+  AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction(const char* title, Double_t aRadiusMin, Double_t aRadiusMax, Double_t aDistanceMax, Double_t aDEtaMax, const int& aKStarBins, Double_t aKStarRangeLow, Double_t aKStarRangeUp, const Int_t& aPhiStarBins, Double_t aPhiStarRangeLow, Double_t aPhiStarRangeUp);
   AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction(const AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction& aCorrFctn);
   virtual ~AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction();
 
@@ -46,7 +46,7 @@ public:
   void SetMagneticFieldSign(int magsign);
 
 private:
-  
+
   TH2D *fDPhiStarKStarMergedNumerator;              // Numerator of dPhi* k* function for "merged" fraction of points
   TH2D *fDPhiStarKStarTotalNumerator;               // Numerator of dPhi* k* function for all points
   TH2D *fDPhiStarKStarMergedDenominator;            // Denominator of dPhi* k* function for "merged" fraction of points
@@ -63,7 +63,7 @@ private:
 
   Double_t fRadiusMin;              // Minimum radius at which the pair separation is calculated [m]
   Double_t fRadiusMax;              // Maximum radius at which the pair separation is calculated [m]
-  
+
   Int_t fMagSign;                    // Magnetic field sign
 
 #ifdef __ROOT__

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarKStarMergedFraction.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarKStarMergedFraction.cxx
@@ -19,12 +19,12 @@
   ClassImp(AliFemtoCorrFctnDPhiStarKStarMergedFraction);
   /// \endcond
 #endif
-  
+
 #define PIH 1.57079632679489656
 #define PIT 6.28318530717958623
 
 //____________________________
-AliFemtoCorrFctnDPhiStarKStarMergedFraction::AliFemtoCorrFctnDPhiStarKStarMergedFraction(char* title, Double_t aRadiusMin, Double_t aRadiusMax, Double_t aDistanceMax, Double_t aMergedFractionLimit, Double_t aDEtaMax, const int& aKStarBins, Double_t aKStarRangeLow, Double_t aKStarRangeUp, const Int_t& aPhiStarBins, Double_t aPhiStarRangeLow, Double_t aPhiStarRangeUp):
+AliFemtoCorrFctnDPhiStarKStarMergedFraction::AliFemtoCorrFctnDPhiStarKStarMergedFraction(const char* title, Double_t aRadiusMin, Double_t aRadiusMax, Double_t aDistanceMax, Double_t aMergedFractionLimit, Double_t aDEtaMax, const int& aKStarBins, Double_t aKStarRangeLow, Double_t aKStarRangeUp, const Int_t& aPhiStarBins, Double_t aPhiStarRangeLow, Double_t aPhiStarRangeUp):
 AliFemtoCorrFctn(),
   fDPhiStarKStarMergedNumerator(0),
   fDPhiStarKStarTotalNumerator(0),
@@ -47,12 +47,12 @@ AliFemtoCorrFctn(),
   fKStarRangeUp = aKStarRangeUp;
   fDPhiStarRangeLow = aPhiStarRangeLow;
   fDPhiStarRangeUp = aPhiStarRangeUp;
-  
+
   // Calculate parameters:
   fDistanceMax = aDistanceMax;
   fMergedFractionLimit = aMergedFractionLimit;
   fDEtaMax = aDEtaMax;
-  
+
   // Calculate radii range
   fRadiusMin = aRadiusMin;
   fRadiusMax = aRadiusMax;
@@ -125,7 +125,7 @@ AliFemtoCorrFctnDPhiStarKStarMergedFraction::AliFemtoCorrFctnDPhiStarKStarMerged
   fRadiusMin = aCorrFctn.fRadiusMin;
   fRadiusMax = aCorrFctn.fRadiusMax;
   fMagSign = aCorrFctn.fMagSign;
-  
+
 }
 
 //____________________________
@@ -242,15 +242,15 @@ void AliFemtoCorrFctnDPhiStarKStarMergedFraction::AddRealPair( AliFemtoPair* pai
 
   // Calculate dEta:
   double deta = eta2 - eta1;
-  
+
   if(TMath::Abs(deta) < TMath::Abs(fDEtaMax)) {
-    
+
     Double_t badpoints = 0.0;
     Double_t allpoints = 0.0;
-    
+
     // Iterate through all radii in range (fRadiusMin, fRadiusMax):
     for(double irad = fRadiusMin; irad < fRadiusMax; irad += 0.01) {
-      
+
       // Calculate dPhiStar:
       double afsi0b = -0.07510020733*chg1*fMagSign*irad/pt1;
       double afsi1b = -0.07510020733*chg2*fMagSign*irad/pt2;
@@ -265,13 +265,13 @@ void AliFemtoCorrFctnDPhiStarKStarMergedFraction::AddRealPair( AliFemtoPair* pai
 	badpoints += 1.0;
       }
       allpoints += 1.0;
-      
+
     }
 
     if(allpoints != 0.0) {
       // Calculate fraction:
       Double_t fraction = badpoints / allpoints;
-      
+
       // Add pair if the fraction is above limit:
       if(fraction > fMergedFractionLimit) {
 	double rad = fRadiusMin;
@@ -327,15 +327,15 @@ void AliFemtoCorrFctnDPhiStarKStarMergedFraction::AddMixedPair( AliFemtoPair* pa
 
   // Calculate dEta:
   double deta = eta2 - eta1;
-  
+
   if(TMath::Abs(deta) < TMath::Abs(fDEtaMax)) {
-    
+
     Double_t badpoints = 0.0;
     Double_t allpoints = 0.0;
-    
+
     // Iterate through all radii in range (fRadiusMin, fRadiusMax):
     for(double irad = fRadiusMin; irad < fRadiusMax; irad += 0.01) {
-      
+
       // Calculate dPhiStar:
       double afsi0b = -0.07510020733*chg1*fMagSign*irad/pt1;
       double afsi1b = -0.07510020733*chg2*fMagSign*irad/pt2;
@@ -350,13 +350,13 @@ void AliFemtoCorrFctnDPhiStarKStarMergedFraction::AddMixedPair( AliFemtoPair* pa
 	badpoints += 1.0;
       }
       allpoints += 1.0;
-      
+
     }
 
     if(allpoints != 0.0) {
       // Calculate fraction:
       Double_t fraction = badpoints / allpoints;
-      
+
       // Add pair if the fraction is above limit:
       if(fraction > fMergedFractionLimit) {
 	double rad = fRadiusMin;
@@ -389,12 +389,12 @@ TList* AliFemtoCorrFctnDPhiStarKStarMergedFraction::GetOutputList()
 {
   // Prepare the list of objects to be written to the output
   TList *tOutputList = new TList();
-  
+
   tOutputList->Add(fDPhiStarKStarMergedNumerator);
   tOutputList->Add(fDPhiStarKStarTotalNumerator);
   tOutputList->Add(fDPhiStarKStarMergedDenominator);
   tOutputList->Add(fDPhiStarKStarTotalDenominator);
-  
+
   return tOutputList;
 }
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarKStarMergedFraction.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarKStarMergedFraction.h
@@ -21,7 +21,7 @@
 class AliFemtoCorrFctnDPhiStarKStarMergedFraction : public AliFemtoCorrFctn {
 public:
 
-  AliFemtoCorrFctnDPhiStarKStarMergedFraction(char* title, Double_t aRadiusMin, Double_t aRadiusMax, Double_t aDistanceMax, Double_t aMergedFractionLimit, Double_t aDEtaMax, const int& aKStarBins, Double_t aKStarRangeLow, Double_t aKStarRangeUp, const Int_t& aPhiStarBins, Double_t aPhiStarRangeLow, Double_t aPhiStarRangeUp);
+  AliFemtoCorrFctnDPhiStarKStarMergedFraction(const char* title, Double_t aRadiusMin, Double_t aRadiusMax, Double_t aDistanceMax, Double_t aMergedFractionLimit, Double_t aDEtaMax, const int& aKStarBins, Double_t aKStarRangeLow, Double_t aKStarRangeUp, const Int_t& aPhiStarBins, Double_t aPhiStarRangeLow, Double_t aPhiStarRangeUp);
   AliFemtoCorrFctnDPhiStarKStarMergedFraction(const AliFemtoCorrFctnDPhiStarKStarMergedFraction& aCorrFctn);
   virtual ~AliFemtoCorrFctnDPhiStarKStarMergedFraction();
 
@@ -44,7 +44,7 @@ public:
   void SetMagneticFieldSign(int magsign);
 
 private:
-  
+
   TH2D *fDPhiStarKStarMergedNumerator;              // Numerator of dPhi* k* function for pairs which are "merged"
   TH2D *fDPhiStarKStarTotalNumerator;               // Numerator of dPhi* k* function for all pairs
   TH2D *fDPhiStarKStarMergedDenominator;            // Denominator of dPhi* k* function for pairs which are "merged"
@@ -62,7 +62,7 @@ private:
 
   Double_t fRadiusMin;              // Minimum radius at which the pair separation is calculated [m]
   Double_t fRadiusMax;              // Maximum radius at which the pair separation is calculated [m]
-  
+
   Int_t fMagSign;                    // Magnetic field sign
 
 #ifdef __ROOT__

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoQinvCorrFctn.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoQinvCorrFctn.cxx
@@ -16,7 +16,7 @@
 #endif
 
 //____________________________
-AliFemtoQinvCorrFctn::AliFemtoQinvCorrFctn(char* title, const int& nbins, const float& QinvLo, const float& QinvHi):
+AliFemtoQinvCorrFctn::AliFemtoQinvCorrFctn(const char* title, const int& nbins, const float& QinvLo, const float& QinvHi):
   fNumerator(0),
   fDenominator(0),
   fRatio(0),

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoQinvCorrFctn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoQinvCorrFctn.h
@@ -58,7 +58,7 @@
 
 class AliFemtoQinvCorrFctn : public AliFemtoCorrFctn {
 public:
-  AliFemtoQinvCorrFctn(char* title, const int& nbins, const float& QinvLo, const float& QinvHi);
+  AliFemtoQinvCorrFctn(const char* title, const int& nbins, const float& QinvLo, const float& QinvHi);
   AliFemtoQinvCorrFctn(const AliFemtoQinvCorrFctn& aCorrFctn);
   virtual ~AliFemtoQinvCorrFctn();
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSimpleAnalysis.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSimpleAnalysis.cxx
@@ -66,7 +66,7 @@ void DoFillParticleCollection(TrackCutType *cut,
 // The actual loop implementation has been moved to the collection-generic
 // DoFillParticleCollection() function
 void FillHbtParticleCollection(AliFemtoParticleCut *partCut,
-                               AliFemtoEvent *hbtEvent,
+                               const AliFemtoEvent *hbtEvent,
                                AliFemtoParticleCollection *partCollection,
                                bool performSharedDaughterCut=kFALSE)
 {
@@ -478,14 +478,14 @@ void AliFemtoSimpleAnalysis::ProcessEvent(const AliFemtoEvent* hbtEvent)
   // hbtEvent which pass fFirstParticleCut. Uses cut's "Type()" to determine
   // which track collection to pull from hbtEvent.
   FillHbtParticleCollection(fFirstParticleCut,
-                            (AliFemtoEvent*)hbtEvent,
+                            hbtEvent,
                             fPicoEvent->FirstParticleCollection(),
                             fPerformSharedDaughterCut);
 
   // fill second particle cut if not analyzing identical particles
   if ( !AnalyzeIdenticalParticles() ) {
       FillHbtParticleCollection(fSecondParticleCut,
-                                (AliFemtoEvent*)hbtEvent,
+                                hbtEvent,
                                 fPicoEvent->SecondParticleCollection(),
                                 fPerformSharedDaughterCut);
   }

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliTwoTrackRes.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliTwoTrackRes.h
@@ -29,9 +29,9 @@
 class AliTwoTrackRes : public AliAnalysisTask {
 
 public:
-  
-  AliTwoTrackRes() : AliAnalysisTask("",""), fChain(0), fESDEvent(0), fOutContainer(0), 
-    fTrackCuts(0), fNTuple1(0), fNTuple2(0), fP1(), fP2(), fPb1(), fPb2(), fP(), 
+
+  AliTwoTrackRes() : AliAnalysisTask("",""), fChain(0), fESDEvent(0), fOutContainer(0),
+    fTrackCuts(0), fNTuple1(0), fNTuple2(0), fP1(), fP2(), fPb1(), fPb2(), fP(),
     fQ(), fTpcEnt1(), fTpcEnt2(), fTpcDist(), fOutFilename() {}
   AliTwoTrackRes(const char *name);
   AliTwoTrackRes(const AliTwoTrackRes& aTwoTrackRes);
@@ -61,11 +61,11 @@ public:
   double DPhi()    const {return TVector2::Phi_mpi_pi(fP2.Phi()-fP1.Phi());}
   void   NoSwap()        {fPb1 = fP1; fPb2 = fP2;}
   void   Swap()          {fPb1 = fP2; fPb2 = fP1;}
-  void   FillNTuple1(double minsep, double sep, double corr, double qf, 
+  void   FillNTuple1(double minsep, double sep, double corr, double qf,
 		     int ns1, int ns2);
-  void   FillNTuple2(double minsep, double sep, double corr, double qf, 
+  void   FillNTuple2(double minsep, double sep, double corr, double qf,
 		     int ns1, int ns2);
-  void   SetOutfile(char *outfil) {fOutFilename = outfil;}
+  void   SetOutfile(const char *outfil) {fOutFilename = outfil;}
 
 private:
 
@@ -83,7 +83,7 @@ private:
   TLorentzVector  fQ;             // Four-momentum difference (lab)
   TVector3        fTpcEnt1;       // Nominal TPC entrance point track 1
   TVector3        fTpcEnt2;       // Nominal TPC entrance point track 2
-  TVector3        fTpcDist;       // Nominal TPC entrance separation 
+  TVector3        fTpcDist;       // Nominal TPC entrance separation
   TString         fOutFilename;   // Output filename
 
   ClassDef(AliTwoTrackRes, 0);

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisAzimuthalPbPb.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisAzimuthalPbPb.cxx
@@ -35,7 +35,7 @@
 #include "AliFemtoPicoEventCollectionVector.h"
 #include "AliFemtoPicoEventCollectionVectorHideAway.h"
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoAnalysisAzimuthalPbPb)
 #endif
 
@@ -55,7 +55,7 @@ void FillHbtParticleCollection(       AliFemtoParticleCut*         partCut,
 	pParticle = *pIter;
 	bool tmpPassParticle = pCut->Pass(pParticle);
 	pCut->FillCutMonitor(pParticle, tmpPassParticle);
-	if (tmpPassParticle){	
+	if (tmpPassParticle){
 	  AliFemtoParticle* particle = new AliFemtoParticle(pParticle,pCut->Mass());
 	  picoevent->FirstParticleCollection()->push_back(particle);
 	}
@@ -64,17 +64,17 @@ void FillHbtParticleCollection(       AliFemtoParticleCut*         partCut,
 
 //____________________________
 AliFemtoAnalysisAzimuthalPbPb::AliFemtoAnalysisAzimuthalPbPb(unsigned int binsVertex, double minVertex, double maxVertex,
-						       unsigned int binsMult, double minMult, double maxMult, unsigned short binsRP) 
-  : 
+						       unsigned int binsMult, double minMult, double maxMult, unsigned short binsRP)
+  :
   fFirstParticleCut(0),
   fSecondParticleCut(0),
   fPairCutRD(0),
   fPicoEventRP(0),
-  fVertexZBins(binsVertex), 
-  fOverFlowVertexZ(0), 
+  fVertexZBins(binsVertex),
+  fOverFlowVertexZ(0),
   fUnderFlowVertexZ(0),
   fMultBins(binsMult),
-  fOverFlowMult(0),    
+  fOverFlowMult(0),
   fUnderFlowMult(0),
   fRPBins(binsRP),
   fRP(0),
@@ -95,7 +95,7 @@ AliFemtoAnalysisAzimuthalPbPb::AliFemtoAnalysisAzimuthalPbPb(unsigned int binsVe
   fPicoEventCollectionVectorHideAway = new AliFemtoPicoEventCollectionVectorHideAway(fVertexZBins,fVertexZ[0],fVertexZ[1],
 										     fMultBins,fMult[0],fMult[1],
 										     fRPBins,0.0,TMath::Pi());
-  
+
   fphidist = new TH1F("fphidist","fphidist; Phi Distribution",100,-TMath::Pi(),TMath::Pi());
   fpairphi = new TH1F("fpairphi","fpairphi; Pair Phi Distribution",100,0,TMath::TwoPi());
   fRPdist = new TH1F("fRPdist","fRPdist; RP Distribution",100,0,TMath::Pi());
@@ -106,17 +106,17 @@ AliFemtoAnalysisAzimuthalPbPb::AliFemtoAnalysisAzimuthalPbPb(unsigned int binsVe
 
 //____________________________
 
-AliFemtoAnalysisAzimuthalPbPb::AliFemtoAnalysisAzimuthalPbPb(const AliFemtoAnalysisAzimuthalPbPb& a) : 
+AliFemtoAnalysisAzimuthalPbPb::AliFemtoAnalysisAzimuthalPbPb(const AliFemtoAnalysisAzimuthalPbPb& a) :
   AliFemtoSimpleAnalysis(),
   fFirstParticleCut(0),
   fSecondParticleCut(0),
   fPairCutRD(0),
   fPicoEventRP(0),
-  fVertexZBins(a.fVertexZBins), 
-  fOverFlowVertexZ(0), 
+  fVertexZBins(a.fVertexZBins),
+  fOverFlowVertexZ(0),
   fUnderFlowVertexZ(0),
   fMultBins(a.fMultBins) ,
-  fOverFlowMult(0),    
+  fOverFlowMult(0),
   fUnderFlowMult(0),
   fRPBins(a.fRPBins),
   fRP(0),
@@ -125,14 +125,14 @@ AliFemtoAnalysisAzimuthalPbPb::AliFemtoAnalysisAzimuthalPbPb(const AliFemtoAnaly
   fRPdist(0),
   fsubRPdist(0),
   frealpsi(0),
-  fmixedpsi(0) 
+  fmixedpsi(0)
 
 {
   fCorrFctnCollection= 0;
   fCorrFctnCollection = new AliFemtoCorrFctnCollection;
-  fVertexZ[0] = a.fVertexZ[0]; 
+  fVertexZ[0] = a.fVertexZ[0];
   fVertexZ[1] = a.fVertexZ[1];
-  fMult[0] = a.fMult[0]; 
+  fMult[0] = a.fMult[0];
   fMult[1] = a.fMult[1];
   if (fMixingBuffer) delete fMixingBuffer;
   fPicoEventCollectionVectorHideAway = new AliFemtoPicoEventCollectionVectorHideAway(fVertexZBins,fVertexZ[0],fVertexZ[1],
@@ -146,7 +146,7 @@ AliFemtoAnalysisAzimuthalPbPb::AliFemtoAnalysisAzimuthalPbPb(const AliFemtoAnaly
   fSecondParticleCut = a.fSecondParticleCut->Clone();
   // find the right pair cut
   fPairCut = a.fPairCut->Clone();
-  
+
   if ( fEventCut ) {
       SetEventCut(fEventCut); // this will set the myAnalysis pointer inside the cut
   }
@@ -176,9 +176,9 @@ AliFemtoAnalysisAzimuthalPbPb& AliFemtoAnalysisAzimuthalPbPb::operator=(const Al
 
   fCorrFctnCollection= 0;
   fCorrFctnCollection = new AliFemtoCorrFctnCollection;
-  fVertexZ[0] = a.fVertexZ[0]; 
+  fVertexZ[0] = a.fVertexZ[0];
   fVertexZ[1] = a.fVertexZ[1];
-  fMult[0] = a.fMult[0]; 
+  fMult[0] = a.fMult[0];
   fMult[1] = a.fMult[1];
   if (fMixingBuffer) delete fMixingBuffer;
   fPicoEventCollectionVectorHideAway = new AliFemtoPicoEventCollectionVectorHideAway(fVertexZBins,fVertexZ[0],fVertexZ[1],
@@ -192,7 +192,7 @@ AliFemtoAnalysisAzimuthalPbPb& AliFemtoAnalysisAzimuthalPbPb::operator=(const Al
   fSecondParticleCut = a.fSecondParticleCut->Clone();
   // find the right pair cut
   fPairCut = a.fPairCut->Clone();
-  
+
   if ( fEventCut ) {
       SetEventCut(fEventCut); // this will set the myAnalysis pointer inside the cut
   }
@@ -214,7 +214,7 @@ AliFemtoAnalysisAzimuthalPbPb& AliFemtoAnalysisAzimuthalPbPb::operator=(const Al
   fNumEventsToMix = a.fNumEventsToMix;
 
   return *this;
-  
+
 }
 
 //____________________________
@@ -230,8 +230,8 @@ void AliFemtoAnalysisAzimuthalPbPb::ProcessEvent(const AliFemtoEvent* hbtEvent) 
   fFirstParticleCut->EventBegin(hbtEvent);
   double vertexZ = hbtEvent->PrimVertPos().z();
   double mult = hbtEvent->UncorrectedNumberOfPrimaries();
-  double RP = hbtEvent->ReactionPlaneAngle();  
-  fMixingBuffer = fPicoEventCollectionVectorHideAway->PicoEventCollection(vertexZ,mult,RP); 
+  double RP = hbtEvent->ReactionPlaneAngle();
+  fMixingBuffer = fPicoEventCollectionVectorHideAway->PicoEventCollection(vertexZ,mult,RP);
   if (!fMixingBuffer) {
 //     cout << "no mixing buffer!!!" << endl;
     if ( vertexZ < fVertexZ[0] ) fUnderFlowVertexZ++;
@@ -244,12 +244,12 @@ void AliFemtoAnalysisAzimuthalPbPb::ProcessEvent(const AliFemtoEvent* hbtEvent) 
   // Add event to processed events
   fPicoEventRP=0; // we will get a new pico event, if not prevent corr. fctn to access old pico event
   fNeventsProcessed++;
- 
+
   fFirstParticleCut->EventBegin(hbtEvent);
   fSecondParticleCut->EventBegin(hbtEvent);
   fPairCut->EventBegin(hbtEvent);
   fPairCutRD->EventBegin(hbtEvent);
-  
+
   int magsign = 0;
   if(hbtEvent->MagneticField()>0) magsign = 1;
   else if(hbtEvent->MagneticField()<0) magsign = -1;
@@ -258,7 +258,7 @@ void AliFemtoAnalysisAzimuthalPbPb::ProcessEvent(const AliFemtoEvent* hbtEvent) 
   for (AliFemtoCorrFctnIterator iter=fCorrFctnCollection->begin(); iter!=fCorrFctnCollection->end();iter++){
     (*iter)->EventBegin(hbtEvent);
   }
-  
+
   // event cut and event cut monitor
   bool tmpPassEvent = fEventCut->Pass(hbtEvent);
   if (!tmpPassEvent) {
@@ -286,7 +286,7 @@ void AliFemtoAnalysisAzimuthalPbPb::ProcessEvent(const AliFemtoEvent* hbtEvent) 
         storedEvent = (AliFemtoPicoEventRP*) *fPicoEventIter;
           MakePairs("mixed",fPicoEventRP,
                             storedEvent );
-        
+
       }
 
       if ( MixingBufferFull() ) {
@@ -311,7 +311,7 @@ void AliFemtoAnalysisAzimuthalPbPb::ProcessEvent(const AliFemtoEvent* hbtEvent) 
   fPairCutRD->EventEnd(hbtEvent);
   for (AliFemtoCorrFctnIterator iter=fCorrFctnCollection->begin(); iter!=fCorrFctnCollection->end();iter++){
     (*iter)->EventEnd(hbtEvent);
-  } 
+  }
   }
 }
 
@@ -365,8 +365,8 @@ void AliFemtoAnalysisAzimuthalPbPb::MakePairs(const char* typeIn, AliFemtoPicoEv
  	  swpart = 1;
 	}
       }
-      
-      
+
+
       //For getting the pair angle wrt EP
   if (type == "real"){
 	Double_t PairAngleEP=0;
@@ -378,7 +378,7 @@ void AliFemtoAnalysisAzimuthalPbPb::MakePairs(const char* typeIn, AliFemtoPicoEv
 	while (PairAngleEP < 0) PairAngleEP += 180;
 	while (PairAngleEP > 180) PairAngleEP -= 180;
 	tPair->SetPairAngleEP(PairAngleEP);
-	frealpsi->Fill(PairAngleEP);	
+	frealpsi->Fill(PairAngleEP);
 	fphidist->Fill(tPair->Track1()->FourMomentum().Phi());
 	fphidist->Fill(tPair->Track2()->FourMomentum().Phi());
 	fpairphi->Fill(tPair->EmissionAngle()*TMath::DegToRad());
@@ -393,7 +393,7 @@ void AliFemtoAnalysisAzimuthalPbPb::MakePairs(const char* typeIn, AliFemtoPicoEv
 	q2 = picoevent2->PicoEventplane()->GetQVector();
 	Double_t PairAngleEP=0;
 
-	
+
 	float psi1 = q1->Phi()/2;
 	float psi2 = q2->Phi()/2;
 	PairAngleEP = TMath::RadToDeg()*(TMath::ATan2(((tPair->Track1()->Track()->Pt()*TMath::Sin(tPair->Track1()->FourMomentum().Phi() - psi1))+(tPair->Track2()->Track()->Pt()*TMath::Sin(tPair->Track2()->FourMomentum().Phi() - psi2))),((tPair->Track1()->Track()->Pt()*TMath::Cos(tPair->Track1()->FourMomentum().Phi() - psi1))+(tPair->Track2()->Track()->Pt()*TMath::Cos(tPair->Track2()->FourMomentum().Phi() - psi2)))));
@@ -412,7 +412,7 @@ void AliFemtoAnalysisAzimuthalPbPb::MakePairs(const char* typeIn, AliFemtoPicoEv
 	  else if(type == "mixed") {
             tCorrFctn->AddMixedPair(tPair);
 	  }
-       
+
 	}
       }
     }    // loop over second particle
@@ -420,12 +420,12 @@ void AliFemtoAnalysisAzimuthalPbPb::MakePairs(const char* typeIn, AliFemtoPicoEv
   }      // loop over first particle
 
   delete tPair;
-  
+
 }
 
 //_____________________________________________
 TVector2 AliFemtoAnalysisAzimuthalPbPb::GetQVector(AliFemtoParticleCollection* particlecollection){
-  
+
   TVector2 mQ;
   float mQx=0, mQy=0;
 
@@ -443,7 +443,7 @@ TVector2 AliFemtoAnalysisAzimuthalPbPb::GetQVector(AliFemtoParticleCollection* p
     mQx += (cos(2*flowparticle->FourMomentum().Phi()))*(flowparticle->Track()->Pt());
     mQy += (sin(2*flowparticle->FourMomentum().Phi()))*(flowparticle->Track()->Pt());
   }
-  
+
   mQ.Set(mQx,mQy);
   return mQ;
 }
@@ -455,7 +455,7 @@ double AliFemtoAnalysisAzimuthalPbPb::GetCurrentReactionPlane()
 }
 
 //______________________________________________________________________________
-void AliFemtoAnalysisAzimuthalPbPb::SetEPhistname(char* histname)
+void AliFemtoAnalysisAzimuthalPbPb::SetEPhistname(const char* histname)
 {
   fphidist->SetName(Form("fphidist%s",histname));
   fpairphi->SetName(Form("fpairphi%s",histname));
@@ -476,7 +476,7 @@ TList* AliFemtoAnalysisAzimuthalPbPb::GetOutputList()
   AliFemtoCorrFctnIterator iter;
   for (iter=fCorrFctnCollection->begin(); iter!=fCorrFctnCollection->end();iter++){
     TList *tListCf = (*iter)->GetOutputList();
-    
+
     TIter nextListCf(tListCf);
     while (TObject *obj = nextListCf()) {
       tOutputList->Add(obj);
@@ -491,5 +491,5 @@ TList* AliFemtoAnalysisAzimuthalPbPb::GetOutputList()
   tOutputList->Add(fmixedpsi);
 
   return tOutputList;
-  
+
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisAzimuthalPbPb.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisAzimuthalPbPb.h
@@ -47,7 +47,7 @@ public:
   virtual void MakePairs(const char* typeIn, AliFemtoPicoEventRP *coll1, AliFemtoPicoEventRP *coll2=0);
   virtual TList* GetOutputList();
   virtual void Finish() {;}
-	
+
  // Get the particle cuts
   virtual AliFemtoParticleCut*   FirstParticleCut() {return fFirstParticleCut;}
   virtual AliFemtoParticleCut*   SecondParticleCut() {return fSecondParticleCut;}
@@ -57,12 +57,12 @@ public:
   void SetEventCut(AliFemtoEventCut* x) {fEventCut = x; x->SetAnalysis((AliFemtoAnalysis*)this);}
   void SetPairCut(AliFemtoPairCut* x) {fPairCut = x; x->SetAnalysis((AliFemtoAnalysis*)this);}
   void SetPairCutRD(AliFemtoPairCutRadialDistanceLM* x) {fPairCutRD = x; x->SetAnalysis((AliFemtoAnalysis*)this);}
-  void SetEPhistname(char* histname);
+  void SetEPhistname(const char* histname);
 
 protected:
 
-  AliFemtoParticleCut*         	fFirstParticleCut;    //  select particles of type #1 
-  AliFemtoParticleCut*  	fSecondParticleCut;   //  select particles of type #2 
+  AliFemtoParticleCut*         	fFirstParticleCut;    //  select particles of type #1
+  AliFemtoParticleCut*  	fSecondParticleCut;   //  select particles of type #2
   AliFemtoPairCutRadialDistanceLM* fPairCutRD;
   AliFemtoPicoEventRP*		fPicoEventRP;
 
@@ -86,7 +86,7 @@ protected:
 #ifdef __ROOT__
   ClassDef(AliFemtoAnalysisAzimuthalPbPb, 0)
 #endif
-    
+
 };
 
 #endif

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisAzimuthalPbPb2Order.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisAzimuthalPbPb2Order.cxx
@@ -46,7 +46,7 @@ static void FillHbtParticleCollection(       AliFemtoParticleCut*         partCu
     AliEventplane* evpl;
     evpl = picoevent->PicoEventplane();
     *evpl = *hbtEvent->EP();
-    
+
     AliFemtoTrackCut* pCut = (AliFemtoTrackCut*) partCut;
     AliFemtoTrack* pParticle;
     AliFemtoTrackIterator pIter;
@@ -96,7 +96,7 @@ fmixedpsi(0)
     fPicoEventCollectionVectorHideAway = new AliFemtoPicoEventCollectionVectorHideAway(fVertexZBins,fVertexZ[0],fVertexZ[1],
                                                                                        fMultBins,fMult[0],fMult[1],
                                                                                        fRPBins,0.0,TMath::Pi());
-    
+
     fphidist = new TH1F("fphidist","fphidist; Phi Distribution",100,-TMath::Pi(),TMath::Pi());
     fpairphi = new TH1F("fpairphi","fpairphi; Pair Phi Distribution",100,0,TMath::TwoPi());
     fRPdist = new TH1F("fRPdist","fRPdist; RP Distribution2",100,0,TMath::Pi());
@@ -147,7 +147,7 @@ fmixedpsi(0)
     fSecondParticleCut = a.fSecondParticleCut->Clone();
     // find the right pair cut
     fPairCut = a.fPairCut->Clone();
-    
+
     if ( fEventCut ) {
         SetEventCut(fEventCut); // this will set the myAnalysis pointer inside the cut
     }
@@ -160,7 +160,7 @@ fmixedpsi(0)
     if ( fPairCut ) {
         SetPairCut(fPairCut); // this will set the myAnalysis pointer inside the cut
     }
-    
+
     AliFemtoCorrFctnIterator iter;
     for (iter=a.fCorrFctnCollection->begin(); iter!=a.fCorrFctnCollection->end();iter++){
         AliFemtoCorrFctn* fctn = (*iter)->Clone();
@@ -174,7 +174,7 @@ AliFemtoAnalysisAzimuthalPbPb2Order& AliFemtoAnalysisAzimuthalPbPb2Order::operat
     // Assignment operator
     if (this == &a)
         return *this;
-    
+
     fCorrFctnCollection= 0;
     fCorrFctnCollection = new AliFemtoCorrFctnCollection;
     fVertexZ[0] = a.fVertexZ[0];
@@ -193,7 +193,7 @@ AliFemtoAnalysisAzimuthalPbPb2Order& AliFemtoAnalysisAzimuthalPbPb2Order::operat
     fSecondParticleCut = a.fSecondParticleCut->Clone();
     // find the right pair cut
     fPairCut = a.fPairCut->Clone();
-    
+
     if ( fEventCut ) {
         SetEventCut(fEventCut); // this will set the myAnalysis pointer inside the cut
     }
@@ -206,16 +206,16 @@ AliFemtoAnalysisAzimuthalPbPb2Order& AliFemtoAnalysisAzimuthalPbPb2Order::operat
     if ( fPairCut ) {
         SetPairCut(fPairCut); // this will set the myAnalysis pointer inside the cut
     }
-    
+
     AliFemtoCorrFctnIterator iter;
     for (iter=a.fCorrFctnCollection->begin(); iter!=a.fCorrFctnCollection->end();iter++){
         AliFemtoCorrFctn* fctn = (*iter)->Clone();
         if (fctn) AddCorrFctn(fctn);
     }
     fNumEventsToMix = a.fNumEventsToMix;
-    
+
     return *this;
-    
+
 }
 
 //____________________________
@@ -228,7 +228,7 @@ AliFemtoAnalysisAzimuthalPbPb2Order::~AliFemtoAnalysisAzimuthalPbPb2Order(){
 void AliFemtoAnalysisAzimuthalPbPb2Order::ProcessEvent(const AliFemtoEvent* hbtEvent) {
     // Perform event processing in bins of z vertex, multiplicity and Reaction Plane angle
     //****from AliFemtoSimpleAnalysis****
-    
+
     //AliEventplane* eventPlane = InputEvent()->GetEventplane();
     //double psiPlane = hbtEvent->GetEventplane("V0",hbtEvent,2);
     //cout<<"psiplane :: "<<psiPlane<<endl;
@@ -236,12 +236,12 @@ void AliFemtoAnalysisAzimuthalPbPb2Order::ProcessEvent(const AliFemtoEvent* hbtE
     fFirstParticleCut->EventBegin(hbtEvent);
     double vertexZ = hbtEvent->PrimVertPos().z();
     double mult = hbtEvent->UncorrectedNumberOfPrimaries();
-    
+
     double RP = hbtEvent->ReactionPlaneAngle(); //was *2
     //double RP2=GetPsiAngle(
     //fPicoEventRP2=0; // we will get a new pico event, if not prevent corr. fctn to access old pico event
     //fPicoEventRP2 = new AliFemtoPicoEventRP; // this is what we will make pairs from and put in Mixing Buffer
-    
+
     fMixingBuffer = fPicoEventCollectionVectorHideAway->PicoEventCollection(vertexZ,mult,RP);
     if (!fMixingBuffer) {
         //     cout << "no mixing buffer!!!" << endl;
@@ -251,32 +251,32 @@ void AliFemtoAnalysisAzimuthalPbPb2Order::ProcessEvent(const AliFemtoEvent* hbtE
         if ( mult > fMult[1] ) fOverFlowMult++;
         return;
     }
-    
+
     // Add event to processed events
     fPicoEventRP=0; // we will get a new pico event, if not prevent corr. fctn to access old pico event
     fNeventsProcessed++;
-    
+
     fFirstParticleCut->EventBegin(hbtEvent);
     fSecondParticleCut->EventBegin(hbtEvent);
     fPairCut->EventBegin(hbtEvent);
     fPairCutRD->EventBegin(hbtEvent);
-    
+
     int magsign = 0;
     if(hbtEvent->MagneticField()>0) magsign = 1;
     else if(hbtEvent->MagneticField()<0) magsign = -1;
     fPairCutRD->SetMagneticFieldSign(magsign);
-    
+
     for (AliFemtoCorrFctnIterator iter=fCorrFctnCollection->begin(); iter!=fCorrFctnCollection->end();iter++){
         (*iter)->EventBegin(hbtEvent);
     }
-    
+
     // event cut and event cut monitor
     bool tmpPassEvent = fEventCut->Pass(hbtEvent);
     if (!tmpPassEvent) {
         fEventCut->FillCutMonitor(hbtEvent, tmpPassEvent);
     }
     if (tmpPassEvent) {
-        
+
         if (RP>0){
             fPicoEventRP = new AliFemtoPicoEventRP; // this is what we will make pairs from and put in Mixing Buffer
             // no memory leak. we will delete picoevents when they come out of the mixing buffer
@@ -285,30 +285,30 @@ void AliFemtoAnalysisAzimuthalPbPb2Order::ProcessEvent(const AliFemtoEvent* hbtE
                 fEventCut->FillCutMonitor(hbtEvent, tmpPassEvent);
                 // fRPdist->Fill(fPicoEventRP->PicoEventplane()->GetQVector()->Phi()/2); //fill with reaction plane angle  (was RP)
                 fRPdist->Fill(RP); //fill with reaction plane angle  (was RP)
-                
+
                 fsubRPdist->Fill(fPicoEventRP->PicoEventplane()->GetQsubRes());
-                
+
                 MakePairs("real", fPicoEventRP);
-                
-                
+
+
                 //---- Make pairs for mixed events, looping over events in mixingBuffer ----//
-                
+
                 AliFemtoPicoEventRP* storedEvent;
                 AliFemtoPicoEventIterator fPicoEventIter;
                 for (fPicoEventIter=MixingBuffer()->begin();fPicoEventIter!=MixingBuffer()->end();fPicoEventIter++){
                     storedEvent = (AliFemtoPicoEventRP*) *fPicoEventIter;
                     MakePairs("mixed",fPicoEventRP,
                               storedEvent );
-                    
+
                 }
-                
+
                 if ( MixingBufferFull() ) {
                     delete MixingBuffer()->back();
                     MixingBuffer()->pop_back();
                 }
-                
+
                 MixingBuffer()->push_front(fPicoEventRP);
-                
+
             }  // if ParticleCollections are big enough (mal jun2002)
             else{
                 //       cout << "here down" << endl;
@@ -332,19 +332,19 @@ void AliFemtoAnalysisAzimuthalPbPb2Order::ProcessEvent(const AliFemtoEvent* hbtE
 void AliFemtoAnalysisAzimuthalPbPb2Order::MakePairs(const char* typeIn, AliFemtoPicoEventRP *picoevent1,
                                                     AliFemtoPicoEventRP *picoevent2){
     string type = typeIn;
-    
+
     int swpart = fNeventsProcessed % 2;
-    
+
     AliFemtoParticleCollection* partCollection1 = picoevent1->FirstParticleCollection();
     AliFemtoParticleCollection* partCollection2 = 0;
     if (picoevent2)
         partCollection2 = picoevent2->FirstParticleCollection();
     AliFemtoPair* tPair = new AliFemtoPair;
-    
+
     AliFemtoCorrFctnIterator tCorrFctnIter;
-    
+
     AliFemtoParticleIterator tPartIter1, tPartIter2;
-    
+
     AliFemtoParticleIterator tStartOuterLoop = partCollection1->begin();  // always
     AliFemtoParticleIterator tEndOuterLoop   = partCollection1->end();    // will be one less if identical
     AliFemtoParticleIterator tStartInnerLoop;
@@ -365,7 +365,7 @@ void AliFemtoAnalysisAzimuthalPbPb2Order::MakePairs(const char* typeIn, AliFemto
         tPair->SetTrack1(*tPartIter1);
         for (tPartIter2 = tStartInnerLoop; tPartIter2!=tEndInnerLoop;tPartIter2++) {
             tPair->SetTrack2(*tPartIter2);
-            
+
             if (!partCollection2) {
                 if (swpart) {
                     tPair->SetTrack1(*tPartIter2);
@@ -378,19 +378,19 @@ void AliFemtoAnalysisAzimuthalPbPb2Order::MakePairs(const char* typeIn, AliFemto
                     swpart = 1;
                 }
             }
-            
-            
+
+
             //For getting the pair angle wrt EP
             if (type == "real"){
                 Double_t PairAngleEP=0;
                 TVector2* q=0;
                 q = picoevent1->PicoEventplane()->GetQVector();  //
-                
+
                 float psi = q->Phi()/2;
                 // cout<<"psi reg: "<<psi<<endl;
                 //float psi2 = q->Phi();
                 // cout<<"psi reg2: "<<psi2<<endl;
-                
+
                 PairAngleEP = (tPair->EmissionAngle() - TMath::RadToDeg()*psi);
                 while (PairAngleEP < 0) PairAngleEP += 180;
                 while (PairAngleEP > 180) PairAngleEP -= 180;
@@ -399,18 +399,18 @@ void AliFemtoAnalysisAzimuthalPbPb2Order::MakePairs(const char* typeIn, AliFemto
                 fphidist->Fill(tPair->Track1()->FourMomentum().Phi());
                 fphidist->Fill(tPair->Track2()->FourMomentum().Phi());
                 fpairphi->Fill(tPair->EmissionAngle()*TMath::DegToRad());
-                
+
             }
-            
+
             if (type == "mixed"){
-                
+
                 TVector2* q1=0;
                 TVector2* q2=0;
                 q1 = picoevent1->PicoEventplane()->GetQVector();
                 q2 = picoevent2->PicoEventplane()->GetQVector();
                 Double_t PairAngleEP=0;
-                
-                
+
+
                 float psi1 = q1->Phi()/2;
                 float psi2 = q2->Phi()/2;
                 PairAngleEP = TMath::RadToDeg()*(TMath::ATan2(((tPair->Track1()->Track()->Pt()*TMath::Sin(tPair->Track1()->FourMomentum().Phi() - psi1))+(tPair->Track2()->Track()->Pt()*TMath::Sin(tPair->Track2()->FourMomentum().Phi() - psi2))),((tPair->Track1()->Track()->Pt()*TMath::Cos(tPair->Track1()->FourMomentum().Phi() - psi1))+(tPair->Track2()->Track()->Pt()*TMath::Cos(tPair->Track2()->FourMomentum().Phi() - psi2)))));
@@ -419,7 +419,7 @@ void AliFemtoAnalysisAzimuthalPbPb2Order::MakePairs(const char* typeIn, AliFemto
                 fmixedpsi->Fill(PairAngleEP);
                 tPair->SetPairAngleEP(PairAngleEP);
             }
-            
+
             if (fPairCutRD->Pass(tPair)){
                 for (tCorrFctnIter=fCorrFctnCollection->begin();
                      tCorrFctnIter!=fCorrFctnCollection->end();tCorrFctnIter++){
@@ -429,28 +429,28 @@ void AliFemtoAnalysisAzimuthalPbPb2Order::MakePairs(const char* typeIn, AliFemto
                     else if(type == "mixed") {
                         tCorrFctn->AddMixedPair(tPair);
                     }
-                    
+
                 }
             }
         }    // loop over second particle
-        
+
     }      // loop over first particle
-    
+
     delete tPair;
-    
+
 }
 
 //_____________________________________________
 TVector2 AliFemtoAnalysisAzimuthalPbPb2Order::GetQVector(AliFemtoParticleCollection* particlecollection){
-    
+
     TVector2 mQ;
     float mQx=0, mQy=0;
-    
+
     if (!particlecollection) {
         mQ.Set(0.0, 0.0);
         return mQ;
     }
-    
+
     AliFemtoParticle* flowparticle;
     AliFemtoParticleIterator pIter;
     AliFemtoParticleIterator startLoop = particlecollection->begin();
@@ -460,23 +460,23 @@ TVector2 AliFemtoAnalysisAzimuthalPbPb2Order::GetQVector(AliFemtoParticleCollect
         mQx += (cos(2*flowparticle->FourMomentum().Phi()))*(flowparticle->Track()->Pt());
         mQy += (sin(2*flowparticle->FourMomentum().Phi()))*(flowparticle->Track()->Pt());
     }
-    
+
     mQ.Set(mQx,mQy);
     return mQ;
 }
 
 //_______________________________________
 float AliFemtoAnalysisAzimuthalPbPb2Order::GetPsiAngle(AliFemtoParticleCollection* particlecollection){
-    
+
     TVector2 mQ;
     float mypsi=0;
     float mQx=0, mQy=0;
-    
+
     /*if (!particlecollection) {
      mQ.Set(0.0, 0.0);
      return mQ;
      }*/
-    
+
     AliFemtoParticle* flowparticle;
     AliFemtoParticleIterator pIter;
     AliFemtoParticleIterator startLoop = particlecollection->begin();
@@ -486,9 +486,9 @@ float AliFemtoAnalysisAzimuthalPbPb2Order::GetPsiAngle(AliFemtoParticleCollectio
         mQx += (cos(2*flowparticle->FourMomentum().Phi()))*(flowparticle->Track()->Pt());
         mQy += (sin(2*flowparticle->FourMomentum().Phi()))*(flowparticle->Track()->Pt());
     }
-    
+
     mQ.Set(mQx,mQy);
-    
+
     mypsi=TMath::ATan2(mQy,mQx)/2;
     cout<<"mypsi :"<<mypsi<<endl;
     return mypsi;
@@ -501,7 +501,7 @@ double AliFemtoAnalysisAzimuthalPbPb2Order::GetCurrentReactionPlane()
 }
 
 //______________________________________________________________________________
-void AliFemtoAnalysisAzimuthalPbPb2Order::SetEPhistname(char* histname)
+void AliFemtoAnalysisAzimuthalPbPb2Order::SetEPhistname(const char* histname)
 {
     fphidist->SetName(Form("fphidist%s",histname));
     fpairphi->SetName(Form("fpairphi%s",histname));
@@ -515,27 +515,27 @@ void AliFemtoAnalysisAzimuthalPbPb2Order::SetEPhistname(char* histname)
 TList* AliFemtoAnalysisAzimuthalPbPb2Order::GetOutputList()
 {
     // Collect the list of output objects to be written
-    
+
     TList *tOutputList = new TList();
-    
-    
+
+
     AliFemtoCorrFctnIterator iter;
     for (iter=fCorrFctnCollection->begin(); iter!=fCorrFctnCollection->end();iter++){
         TList *tListCf = (*iter)->GetOutputList();
-        
+
         TIter nextListCf(tListCf);
         while (TObject *obj = nextListCf()) {
             tOutputList->Add(obj);
         }
     }
-    
+
     tOutputList->Add(fphidist);
     tOutputList->Add(fpairphi);
     tOutputList->Add(fRPdist);
     tOutputList->Add(fsubRPdist);
     tOutputList->Add(frealpsi);
     tOutputList->Add(fmixedpsi);
-    
+
     return tOutputList;
-    
+
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisAzimuthalPbPb2Order.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisAzimuthalPbPb2Order.h
@@ -27,14 +27,14 @@ class TVector2;
 class AliFemtoPicoEventRP;
 
 class AliFemtoAnalysisAzimuthalPbPb2Order : public AliFemtoSimpleAnalysis {
-    
+
 public:
-    
+
     AliFemtoAnalysisAzimuthalPbPb2Order(unsigned int binsVertex=10, double minVertex=-100., double maxVertex=+100., unsigned int binsMult=10, double minMult=-1.e9, double maxMult=+1.e9, unsigned short binsRP=10);
     AliFemtoAnalysisAzimuthalPbPb2Order(const AliFemtoAnalysisAzimuthalPbPb2Order& TheOriginalAnalysis);  // copy constructor
-    
+
     AliFemtoAnalysisAzimuthalPbPb2Order& operator=(const AliFemtoAnalysisAzimuthalPbPb2Order& aAna);
-    
+
     //   virtual void FillHBTParticleCollectionRP(AliFemtoParticleCut* partCut, AliFemtoEvent* hbtEvent, AliFemtoPicoEventRP* picoevent);
     virtual void ProcessEvent(const AliFemtoEvent* ProcessThisEvent);
     virtual ~AliFemtoAnalysisAzimuthalPbPb2Order();
@@ -45,11 +45,11 @@ public:
     double GetCurrentReactionPlane();
     TVector2 GetQVector(AliFemtoParticleCollection* particlecollection);
     float  GetPsiAngle(AliFemtoParticleCollection* particlecollection);
-    
+
     virtual void MakePairs(const char* typeIn, AliFemtoPicoEventRP *coll1, AliFemtoPicoEventRP *coll2=0);
     virtual TList* GetOutputList();
     virtual void Finish() {;}
-    
+
     // Get the particle cuts
     virtual AliFemtoParticleCut*   FirstParticleCut() {return fFirstParticleCut;}
     virtual AliFemtoParticleCut*   SecondParticleCut() {return fSecondParticleCut;}
@@ -59,17 +59,17 @@ public:
     void SetEventCut(AliFemtoEventCut* x) {fEventCut = x; x->SetAnalysis((AliFemtoAnalysis*)this);}
     void SetPairCut(AliFemtoPairCut* x) {fPairCut = x; x->SetAnalysis((AliFemtoAnalysis*)this);}
     void SetPairCutRD(AliFemtoPairCutRadialDistanceKK* x) {fPairCutRD = x; x->SetAnalysis((AliFemtoAnalysis*)this);}
-    void SetEPhistname(char* histname);
-    
+    void SetEPhistname(const char* histname);
+
 protected:
-    
+
     AliFemtoParticleCut*         	fFirstParticleCut;    //  select particles of type #1
     AliFemtoParticleCut*  	fSecondParticleCut;   //  select particles of type #2
     AliFemtoPairCutRadialDistanceKK* fPairCutRD;
     AliFemtoPicoEventRP*		fPicoEventRP;
-    
-    
-    
+
+
+
     double fVertexZ[2];                 /* min/max z-vertex position allowed to be processed */
     unsigned int fVertexZBins;          /* number of VERTEX mixing bins in z-vertex in EventMixing Buffer */
     unsigned int fOverFlowVertexZ;      /* number of events encountered which had too large z-vertex */
@@ -86,11 +86,11 @@ protected:
     TH1F* fsubRPdist;
     TH1F* frealpsi;			// Psi distribution for real pairs as control histogram
     TH1F* fmixedpsi;			// Psi distribution for mixed pairs as control histogram
-    
+
 #ifdef __ROOT__
     ClassDef(AliFemtoAnalysisAzimuthalPbPb2Order, 0)
 #endif
-    
+
 };
 
 #endif

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisAzimuthalPbPbThird.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisAzimuthalPbPbThird.cxx
@@ -46,7 +46,7 @@ static void FillHbtParticleCollection(       AliFemtoParticleCut*         partCu
     AliEventplane* evpl;
     evpl = picoevent->PicoEventplane();
     *evpl = *hbtEvent->EP();
-    
+
     AliFemtoTrackCut* pCut = (AliFemtoTrackCut*) partCut;
     AliFemtoTrack* pParticle;
     AliFemtoTrackIterator pIter;
@@ -96,14 +96,14 @@ fmixedpsi(0)
     fPicoEventCollectionVectorHideAway = new AliFemtoPicoEventCollectionVectorHideAway(fVertexZBins,fVertexZ[0],fVertexZ[1],
                                                                                        fMultBins,fMult[0],fMult[1],
                                                                                        fRPBins,-1*TMath::Pi()*1/3,TMath::Pi()*1/3);
-    
+
     fphidist = new TH1F("fphidist","fphidist; Phi Distribution",100,-TMath::Pi(),TMath::Pi());
     fpairphi = new TH1F("fpairphi","fpairphi; Pair Phi Distribution",100,-1*TMath::TwoPi(),TMath::TwoPi());
     fRPdist = new TH1F("fRPdist","fRPdist; RP Distribution2",100,-1*TMath::Pi(),TMath::Pi());
     fsubRPdist = new TH1F("fsubRPdist","fsubRPdist; sub RP Distribution",200,-TMath::Pi(),TMath::Pi());
     //   frealpsi = new TH1F("frealpsi","frealpsi; real Psi Distribution",100,0,TMath::RadToDeg()*TMath::Pi());
     frealpsi = new TH1F("frealpsi","frealpsi; real Psi Distribution",100,0,TMath::RadToDeg()*TMath::Pi());
-    
+
     fmixedpsi = new TH1F("fmixedpsi","fmixedpsi; mixed Psi Distribution",100,0,TMath::RadToDeg()*TMath::Pi());
 }
 
@@ -149,7 +149,7 @@ fmixedpsi(0)
     fSecondParticleCut = a.fSecondParticleCut->Clone();
     // find the right pair cut
     fPairCut = a.fPairCut->Clone();
-    
+
     if ( fEventCut ) {
         SetEventCut(fEventCut); // this will set the myAnalysis pointer inside the cut
     }
@@ -162,7 +162,7 @@ fmixedpsi(0)
     if ( fPairCut ) {
         SetPairCut(fPairCut); // this will set the myAnalysis pointer inside the cut
     }
-    
+
     AliFemtoCorrFctnIterator iter;
     for (iter=a.fCorrFctnCollection->begin(); iter!=a.fCorrFctnCollection->end();iter++){
         AliFemtoCorrFctn* fctn = (*iter)->Clone();
@@ -176,7 +176,7 @@ AliFemtoAnalysisAzimuthalPbPbThird& AliFemtoAnalysisAzimuthalPbPbThird::operator
     // Assignment operator
     if (this == &a)
         return *this;
-    
+
     fCorrFctnCollection= 0;
     fCorrFctnCollection = new AliFemtoCorrFctnCollection;
     fVertexZ[0] = a.fVertexZ[0];
@@ -195,7 +195,7 @@ AliFemtoAnalysisAzimuthalPbPbThird& AliFemtoAnalysisAzimuthalPbPbThird::operator
     fSecondParticleCut = a.fSecondParticleCut->Clone();
     // find the right pair cut
     fPairCut = a.fPairCut->Clone();
-    
+
     if ( fEventCut ) {
         SetEventCut(fEventCut); // this will set the myAnalysis pointer inside the cut
     }
@@ -208,16 +208,16 @@ AliFemtoAnalysisAzimuthalPbPbThird& AliFemtoAnalysisAzimuthalPbPbThird::operator
     if ( fPairCut ) {
         SetPairCut(fPairCut); // this will set the myAnalysis pointer inside the cut
     }
-    
+
     AliFemtoCorrFctnIterator iter;
     for (iter=a.fCorrFctnCollection->begin(); iter!=a.fCorrFctnCollection->end();iter++){
         AliFemtoCorrFctn* fctn = (*iter)->Clone();
         if (fctn) AddCorrFctn(fctn);
     }
     fNumEventsToMix = a.fNumEventsToMix;
-    
+
     return *this;
-    
+
 }
 
 //____________________________
@@ -230,7 +230,7 @@ AliFemtoAnalysisAzimuthalPbPbThird::~AliFemtoAnalysisAzimuthalPbPbThird(){
 void AliFemtoAnalysisAzimuthalPbPbThird::ProcessEvent(const AliFemtoEvent* hbtEvent) {
     // Perform event processing in bins of z vertex, multiplicity and Reaction Plane angle
     //****from AliFemtoSimpleAnalysis****
-    
+
     //AliEventplane* eventPlane = InputEvent()->GetEventplane();
     //double psiPlane = hbtEvent->GetEventplane("V0",hbtEvent,2);
     //cout<<"psiplane :: "<<psiPlane<<endl;
@@ -238,7 +238,7 @@ void AliFemtoAnalysisAzimuthalPbPbThird::ProcessEvent(const AliFemtoEvent* hbtEv
     fFirstParticleCut->EventBegin(hbtEvent);
     double vertexZ = hbtEvent->PrimVertPos().z();
     double mult = hbtEvent->UncorrectedNumberOfPrimaries();
-    
+
     double RP = hbtEvent->ReactionPlaneAngle(); //was *2
     //   while (RP<0) {
     //       RP+=TMath::Pi()*2/3;
@@ -246,7 +246,7 @@ void AliFemtoAnalysisAzimuthalPbPbThird::ProcessEvent(const AliFemtoEvent* hbtEv
     //double RP2=GetPsiAngle(
     //fPicoEventRP2=0; // we will get a new pico event, if not prevent corr. fctn to access old pico event
     //fPicoEventRP2 = new AliFemtoPicoEventRP; // this is what we will make pairs from and put in Mixing Buffer
-    
+
     fMixingBuffer = fPicoEventCollectionVectorHideAway->PicoEventCollection(vertexZ,mult,RP);
     if (!fMixingBuffer) {
         //     cout << "no mixing buffer!!!" << endl;
@@ -256,32 +256,32 @@ void AliFemtoAnalysisAzimuthalPbPbThird::ProcessEvent(const AliFemtoEvent* hbtEv
         if ( mult > fMult[1] ) fOverFlowMult++;
         return;
     }
-    
+
     // Add event to processed events
     fPicoEventRP=0; // we will get a new pico event, if not prevent corr. fctn to access old pico event
     fNeventsProcessed++;
-    
+
     fFirstParticleCut->EventBegin(hbtEvent);
     fSecondParticleCut->EventBegin(hbtEvent);
     fPairCut->EventBegin(hbtEvent);
     fPairCutRD->EventBegin(hbtEvent);
-    
+
     int magsign = 0;
     if(hbtEvent->MagneticField()>0) magsign = 1;
     else if(hbtEvent->MagneticField()<0) magsign = -1;
     fPairCutRD->SetMagneticFieldSign(magsign);
-    
+
     for (AliFemtoCorrFctnIterator iter=fCorrFctnCollection->begin(); iter!=fCorrFctnCollection->end();iter++){
         (*iter)->EventBegin(hbtEvent);
     }
-    
+
     // event cut and event cut monitor
     bool tmpPassEvent = fEventCut->Pass(hbtEvent);
     if (!tmpPassEvent) {
         fEventCut->FillCutMonitor(hbtEvent, tmpPassEvent);
     }
     if (tmpPassEvent) {
-        
+
         //   if (RP>0){  Moe Changed it august 8 2016
         fPicoEventRP = new AliFemtoPicoEventRP; // this is what we will make pairs from and put in Mixing Buffer
         // no memory leak. we will delete picoevents when they come out of the mixing buffer
@@ -290,30 +290,30 @@ void AliFemtoAnalysisAzimuthalPbPbThird::ProcessEvent(const AliFemtoEvent* hbtEv
             fEventCut->FillCutMonitor(hbtEvent, tmpPassEvent);
             // fRPdist->Fill(fPicoEventRP->PicoEventplane()->GetQVector()->Phi()/2); //fill with reaction plane angle  (was RP)
             fRPdist->Fill(RP); //fill with reaction plane angle  (was RP)
-            
+
             fsubRPdist->Fill(fPicoEventRP->PicoEventplane()->GetQsubRes());
-            
+
             MakePairs("real", fPicoEventRP);
-            
-            
+
+
             //---- Make pairs for mixed events, looping over events in mixingBuffer ----//
-            
+
             AliFemtoPicoEventRP* storedEvent;
             AliFemtoPicoEventIterator fPicoEventIter;
             for (fPicoEventIter=MixingBuffer()->begin();fPicoEventIter!=MixingBuffer()->end();fPicoEventIter++){
                 storedEvent = (AliFemtoPicoEventRP*) *fPicoEventIter;
                 MakePairs("mixed",fPicoEventRP,
                           storedEvent );
-                
+
             }
-            
+
             if ( MixingBufferFull() ) {
                 delete MixingBuffer()->back();
                 MixingBuffer()->pop_back();
             }
-            
+
             MixingBuffer()->push_front(fPicoEventRP);
-            
+
         }  // if ParticleCollections are big enough (mal jun2002)
         else{
             //       cout << "here down" << endl;
@@ -337,19 +337,19 @@ void AliFemtoAnalysisAzimuthalPbPbThird::ProcessEvent(const AliFemtoEvent* hbtEv
 void AliFemtoAnalysisAzimuthalPbPbThird::MakePairs(const char* typeIn, AliFemtoPicoEventRP *picoevent1,
                                                    AliFemtoPicoEventRP *picoevent2){
     string type = typeIn;
-    
+
     int swpart = fNeventsProcessed % 2;
-    
+
     AliFemtoParticleCollection* partCollection1 = picoevent1->FirstParticleCollection();
     AliFemtoParticleCollection* partCollection2 = 0;
     if (picoevent2)
         partCollection2 = picoevent2->FirstParticleCollection();
     AliFemtoPair* tPair = new AliFemtoPair;
-    
+
     AliFemtoCorrFctnIterator tCorrFctnIter;
-    
+
     AliFemtoParticleIterator tPartIter1, tPartIter2;
-    
+
     AliFemtoParticleIterator tStartOuterLoop = partCollection1->begin();  // always
     AliFemtoParticleIterator tEndOuterLoop   = partCollection1->end();    // will be one less if identical
     AliFemtoParticleIterator tStartInnerLoop;
@@ -370,7 +370,7 @@ void AliFemtoAnalysisAzimuthalPbPbThird::MakePairs(const char* typeIn, AliFemtoP
         tPair->SetTrack1(*tPartIter1);
         for (tPartIter2 = tStartInnerLoop; tPartIter2!=tEndInnerLoop;tPartIter2++) {
             tPair->SetTrack2(*tPartIter2);
-            
+
             if (!partCollection2) {
                 if (swpart) {
                     tPair->SetTrack1(*tPartIter2);
@@ -383,34 +383,34 @@ void AliFemtoAnalysisAzimuthalPbPbThird::MakePairs(const char* typeIn, AliFemtoP
                     swpart = 1;
                 }
             }
-            
-            
+
+
             //For getting the pair angle wrt 3rd harmonic EP
             if (type == "real"){
                 Double_t PairAngleEP=0;
                 Double_t PhiAngleEP2=0;
-                
+
                 Double_t qx=0;
                 Double_t qy=0;
                 Double_t q=0;
-                
+
                 qx = picoevent1->PicoEventplane()->GetQVector()->Px();  //
                 qy = picoevent1->PicoEventplane()->GetQVector()->Py();  //
                 q=TMath::ATan2(qy,qx)/3;
-                
+
                 Double_t psi=q;
                 PairAngleEP = (tPair->EmissionAngle() - TMath::RadToDeg()*psi);
                 while (PairAngleEP < 0) PairAngleEP += 120;
                 while (PairAngleEP > 120) PairAngleEP -= 120;
-                
+
                 tPair->SetPairAngleEP(PairAngleEP);
                 frealpsi->Fill(PairAngleEP);
                 fphidist->Fill(tPair->Track1()->FourMomentum().Phi());
                 fphidist->Fill(tPair->Track2()->FourMomentum().Phi());
                 fpairphi->Fill(tPair->EmissionAngle()*TMath::DegToRad());
-                
+
             }
-            
+
             if (type == "mixed"){
                 /*
                  TVector2* q1=0;
@@ -424,25 +424,25 @@ void AliFemtoAnalysisAzimuthalPbPbThird::MakePairs(const char* typeIn, AliFemtoP
                 q1x = picoevent1->PicoEventplane()->GetQVector()->Px();  //
                 q1y = picoevent1->PicoEventplane()->GetQVector()->Py();
                 q1=TMath::ATan2(q1y,q1x)/3;
-                
+
                 Double_t q2=0;
                 Double_t q2x=0;
                 Double_t q2y=0;
                 q2x = picoevent2->PicoEventplane()->GetQVector()->Px();  //
                 q2y = picoevent2->PicoEventplane()->GetQVector()->Py();
                 q2=TMath::ATan2(q2y,q2x)/3;
-                
+
                 Double_t PairAngleEP=0;
                 Double_t psi1=q1;
                 Double_t psi2=q2;
                 PairAngleEP = TMath::RadToDeg()*(TMath::ATan2(((tPair->Track1()->Track()->Pt()*TMath::Sin(tPair->Track1()->FourMomentum().Phi() - psi1))+(tPair->Track2()->Track()->Pt()*TMath::Sin(tPair->Track2()->FourMomentum().Phi() - psi2))),((tPair->Track1()->Track()->Pt()*TMath::Cos(tPair->Track1()->FourMomentum().Phi() - psi1))+(tPair->Track2()->Track()->Pt()*TMath::Cos(tPair->Track2()->FourMomentum().Phi() - psi2)))));
                 while (PairAngleEP < 0) PairAngleEP += 120;
                 while (PairAngleEP > 120) PairAngleEP -= 120;
-                
+
                 fmixedpsi->Fill(PairAngleEP);
                 tPair->SetPairAngleEP(PairAngleEP);
             }
-            
+
             if (fPairCutRD->Pass(tPair)){
                 for (tCorrFctnIter=fCorrFctnCollection->begin();
                      tCorrFctnIter!=fCorrFctnCollection->end();tCorrFctnIter++){
@@ -452,28 +452,28 @@ void AliFemtoAnalysisAzimuthalPbPbThird::MakePairs(const char* typeIn, AliFemtoP
                     else if(type == "mixed") {
                         tCorrFctn->AddMixedPair(tPair);
                     }
-                    
+
                 }
             }
         }    // loop over second particle
-        
+
     }      // loop over first particle
-    
+
     delete tPair;
-    
+
 }
 
 //_____________________________________________
 TVector2 AliFemtoAnalysisAzimuthalPbPbThird::GetQVector(AliFemtoParticleCollection* particlecollection){
-    
+
     TVector2 mQ;
     float mQx=0, mQy=0;
-    
+
     if (!particlecollection) {
         mQ.Set(0.0, 0.0);
         return mQ;
     }
-    
+
     AliFemtoParticle* flowparticle;
     AliFemtoParticleIterator pIter;
     AliFemtoParticleIterator startLoop = particlecollection->begin();
@@ -483,23 +483,23 @@ TVector2 AliFemtoAnalysisAzimuthalPbPbThird::GetQVector(AliFemtoParticleCollecti
         mQx += (cos(3*flowparticle->FourMomentum().Phi()))*(flowparticle->Track()->Pt());
         mQy += (sin(3*flowparticle->FourMomentum().Phi()))*(flowparticle->Track()->Pt());
     }
-    
+
     mQ.Set(mQx,mQy);
     return mQ;
 }
 
 //_______________________________________
 float AliFemtoAnalysisAzimuthalPbPbThird::GetPsiAngle(AliFemtoParticleCollection* particlecollection){
-    
+
     TVector2 mQ;
     float mypsi=0;
     float mQx=0, mQy=0;
-    
+
     /*if (!particlecollection) {
      mQ.Set(0.0, 0.0);
      return mQ;
      }*/
-    
+
     AliFemtoParticle* flowparticle;
     AliFemtoParticleIterator pIter;
     AliFemtoParticleIterator startLoop = particlecollection->begin();
@@ -509,9 +509,9 @@ float AliFemtoAnalysisAzimuthalPbPbThird::GetPsiAngle(AliFemtoParticleCollection
         mQx += (cos(3*flowparticle->FourMomentum().Phi()))*(flowparticle->Track()->Pt());
         mQy += (sin(3*flowparticle->FourMomentum().Phi()))*(flowparticle->Track()->Pt());
     }
-    
+
     mQ.Set(mQx,mQy);
-    
+
     mypsi=TMath::ATan2(mQy,mQx)/3;
     return mypsi;
 }
@@ -523,7 +523,7 @@ double AliFemtoAnalysisAzimuthalPbPbThird::GetCurrentReactionPlane()
 }
 
 //______________________________________________________________________________
-void AliFemtoAnalysisAzimuthalPbPbThird::SetEPhistname(char* histname)
+void AliFemtoAnalysisAzimuthalPbPbThird::SetEPhistname(const char* histname)
 {
     fphidist->SetName(Form("fphidist%s",histname));
     fpairphi->SetName(Form("fpairphi%s",histname));
@@ -537,27 +537,27 @@ void AliFemtoAnalysisAzimuthalPbPbThird::SetEPhistname(char* histname)
 TList* AliFemtoAnalysisAzimuthalPbPbThird::GetOutputList()
 {
     // Collect the list of output objects to be written
-    
+
     TList *tOutputList = new TList();
-    
-    
+
+
     AliFemtoCorrFctnIterator iter;
     for (iter=fCorrFctnCollection->begin(); iter!=fCorrFctnCollection->end();iter++){
         TList *tListCf = (*iter)->GetOutputList();
-        
+
         TIter nextListCf(tListCf);
         while (TObject *obj = nextListCf()) {
             tOutputList->Add(obj);
         }
     }
-    
+
     tOutputList->Add(fphidist);
     tOutputList->Add(fpairphi);
     tOutputList->Add(fRPdist);
     tOutputList->Add(fsubRPdist);
     tOutputList->Add(frealpsi);
     tOutputList->Add(fmixedpsi);
-    
+
     return tOutputList;
-    
+
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisAzimuthalPbPbThird.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisAzimuthalPbPbThird.h
@@ -49,7 +49,7 @@ public:
   virtual void MakePairs(const char* typeIn, AliFemtoPicoEventRP *coll1, AliFemtoPicoEventRP *coll2=0);
   virtual TList* GetOutputList();
   virtual void Finish() {;}
-	
+
  // Get the particle cuts
   virtual AliFemtoParticleCut*   FirstParticleCut() {return fFirstParticleCut;}
   virtual AliFemtoParticleCut*   SecondParticleCut() {return fSecondParticleCut;}
@@ -59,16 +59,16 @@ public:
   void SetEventCut(AliFemtoEventCut* x) {fEventCut = x; x->SetAnalysis((AliFemtoAnalysis*)this);}
   void SetPairCut(AliFemtoPairCut* x) {fPairCut = x; x->SetAnalysis((AliFemtoAnalysis*)this);}
   void SetPairCutRD(AliFemtoPairCutRadialDistanceKK* x) {fPairCutRD = x; x->SetAnalysis((AliFemtoAnalysis*)this);}
-  void SetEPhistname(char* histname);
+  void SetEPhistname(const char* histname);
 
 protected:
 
-  AliFemtoParticleCut*         	fFirstParticleCut;    //  select particles of type #1 
-  AliFemtoParticleCut*  	fSecondParticleCut;   //  select particles of type #2 
+  AliFemtoParticleCut*         	fFirstParticleCut;    //  select particles of type #1
+  AliFemtoParticleCut*  	fSecondParticleCut;   //  select particles of type #2
   AliFemtoPairCutRadialDistanceKK* fPairCutRD;
   AliFemtoPicoEventRP*		fPicoEventRP;
 
-	
+
 
   double fVertexZ[2];                 /* min/max z-vertex position allowed to be processed */
   unsigned int fVertexZBins;          /* number of VERTEX mixing bins in z-vertex in EventMixing Buffer */
@@ -90,7 +90,7 @@ protected:
 #ifdef __ROOT__
   ClassDef(AliFemtoAnalysisAzimuthalPbPbThird, 0)
 #endif
-    
+
 };
 
 #endif

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoBPLCMS3DCorrFctnEMCIC.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoBPLCMS3DCorrFctnEMCIC.cxx
@@ -15,12 +15,12 @@
  *        2)   E1 * E2
  *        3)   Pt1*Pt2
  *        4)   Pz1*Pz2
- *  
+ *
  * The class is derived from AliFemtoBPLCMS3DCorrFctn, therefore it produces
- * also the histograms in that class. 
- * 
- * NOTE: The EMCIC histograms are not averaged in this class, to obtain 
- * the average, the user needs to divide the real pair histograms by 
+ * also the histograms in that class.
+ *
+ * NOTE: The EMCIC histograms are not averaged in this class, to obtain
+ * the average, the user needs to divide the real pair histograms by
  * the numerator, and the mixed pair histograms by the denominator
  *
  ***************************************************************************
@@ -46,27 +46,27 @@
 #include <cstdio>
 #include <TVector2.h>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoBPLCMS3DCorrFctnEMCIC)
 #endif
 
 //____________________________
-AliFemtoBPLCMS3DCorrFctnEMCIC::AliFemtoBPLCMS3DCorrFctnEMCIC(char* title, const int& nbins, const float& QLo, const float& QHi)
+AliFemtoBPLCMS3DCorrFctnEMCIC::AliFemtoBPLCMS3DCorrFctnEMCIC(const char* title, const int& nbins, const float& QLo, const float& QHi)
 :
 AliFemtoCorrFctn(),
-//fEnergyTotalReal(0),  
-// fEnergyMultReal(0),        
-//fPzMultReal(0),      
-//fPtMultReal(0), 
+//fEnergyTotalReal(0),
+// fEnergyMultReal(0),
+//fPzMultReal(0),
+//fPtMultReal(0),
   fNumerator(0),
   fDenominator(0),
-  fEnergyTotalMix(0),      
-  fEnergyMultMix(0),      
-  fPzMultMix(0),            
+  fEnergyTotalMix(0),
+  fEnergyMultMix(0),
+  fPzMultMix(0),
   fPtMultMix(0),
   fUseRPSelection(0)
 {
-  
+
   // set up numerator
   char tTitNum[101] = "Num";
   strncat(tTitNum,title, 100);
@@ -80,43 +80,43 @@ AliFemtoCorrFctn(),
   /*char tTitNum1[100] = "ESumReal";
   strncat(tTitNum1,title, 100);
   fEnergyTotalReal = new TH3D(tTitNum1,title,nbins,QLo,QHi,nbins,QLo,QHi,nbins,QLo,QHi);
-  
+
   //Setup EnergyMultReal
   char tTitNum2[100] = "EMultReal";
   strncat(tTitNum2,title, 100);
   fEnergyMultReal = new TH3D(tTitNum2,title,nbins,QLo,QHi,nbins,QLo,QHi,nbins,QLo,QHi);
-  
+
   //Setup Pz MultReal
   char tTitNum3[100] = "PzMultReal";
   strncat(tTitNum3,title, 100);
   fPzMultReal = new TH3D(tTitNum3,title,nbins,QLo,QHi,nbins,QLo,QHi,nbins,QLo,QHi);
-  
+
   //Setup Pt MultReal
   char tTitNum4[100] = "PtMultReal";
   strncat(tTitNum4,title, 100);
   fPtMultReal = new TH3D(tTitNum4,title,nbins,QLo,QHi,nbins,QLo,QHi,nbins,QLo,QHi);  */
-  
+
   //Setup EnergyTotalMix
   char tTitNum5[101] = "ESumMix";
   strncat(tTitNum5,title, 100);
   fEnergyTotalMix = new TH3D(tTitNum5,title,nbins,QLo,QHi,nbins,QLo,QHi,nbins,QLo,QHi);
-  
+
   //Setup EnergyMultMix
   char tTitNum6[101] = "EMultMix";
   strncat(tTitNum6,title, 100);
   fEnergyMultMix = new TH3D(tTitNum6,title,nbins,QLo,QHi,nbins,QLo,QHi,nbins,QLo,QHi);
-  
+
   //Setup Pz MultMix
   char tTitNum7[101] = "PzMultMix";
   strncat(tTitNum7,title, 100);
   fPzMultMix = new TH3D(tTitNum7,title,nbins,QLo,QHi,nbins,QLo,QHi,nbins,QLo,QHi);
-  
+
   //Setup Pt MultMix
   char tTitNum8[101] = "PtMultMix";
   strncat(tTitNum8,title, 100);
   fPtMultMix = new TH3D(tTitNum8,title,nbins,QLo,QHi,nbins,QLo,QHi,nbins,QLo,QHi);
   // To enable error bar calculation
-  
+
   /*fEnergyTotalReal->Sumw2();
   fEnergyMultReal->Sumw2();
   fPzMultReal->Sumw2();
@@ -127,23 +127,23 @@ AliFemtoCorrFctn(),
   fEnergyMultMix->Sumw2();
   fPzMultMix->Sumw2();
   fPtMultMix->Sumw2();
-  
+
 }
 
 
 // Variable bin size constructor :
 //qBins array of low-edges for each bin. This is an array of size nbins+1
-AliFemtoBPLCMS3DCorrFctnEMCIC::AliFemtoBPLCMS3DCorrFctnEMCIC(char* title, const int& nbins, const float* qBins):
+AliFemtoBPLCMS3DCorrFctnEMCIC::AliFemtoBPLCMS3DCorrFctnEMCIC(const char* title, const int& nbins, const float* qBins):
 AliFemtoCorrFctn(),
   fNumerator(0),
   fDenominator(0),
-  fEnergyTotalMix(0),      
-  fEnergyMultMix(0),      
-  fPzMultMix(0),            
+  fEnergyTotalMix(0),
+  fEnergyMultMix(0),
+  fPzMultMix(0),
   fPtMultMix(0),
   fUseRPSelection(0)
 {
-  
+
   // set up numerator
   char tTitNum[101] = "Num";
   strncat(tTitNum,title, 100);
@@ -157,43 +157,43 @@ AliFemtoCorrFctn(),
   /*char tTitNum1[100] = "ESumReal";
   strncat(tTitNum1,title, 100);
   fEnergyTotalReal = new TH3D(tTitNum1,title,nbins,qBins,nbins,qBins,nbins,qBins);
-  
+
   //Setup EnergyMultReal
   char tTitNum2[100] = "EMultReal";
   strncat(tTitNum2,title, 100);
   fEnergyMultReal = new TH3D(tTitNum2,title,nbins,qBins,nbins,qBins,nbins,qBins);
-  
+
   //Setup Pz MultReal
   char tTitNum3[100] = "PzMultReal";
   strncat(tTitNum3,title, 100);
   fPzMultReal = new TH3D(tTitNum3,title,nbins,qBins,nbins,qBins,nbins,qBins);
-  
+
   //Setup Pt MultReal
   char tTitNum4[100] = "PtMultReal";
   strncat(tTitNum4,title, 100);
   fPtMultReal = new TH3D(tTitNum4,title,nbins,qBins,nbins,qBins,nbins,qBins);  */
-  
+
   //Setup EnergyTotalMix
   char tTitNum5[101] = "ESumMix";
   strncat(tTitNum5,title, 100);
   fEnergyTotalMix = new TH3D(tTitNum5,title,nbins,qBins,nbins,qBins,nbins,qBins);
-  
+
   //Setup EnergyMultMix
   char tTitNum6[101] = "EMultMix";
   strncat(tTitNum6,title, 100);
   fEnergyMultMix = new TH3D(tTitNum6,title,nbins,qBins,nbins,qBins,nbins,qBins);
-  
+
   //Setup Pz MultMix
   char tTitNum7[101] = "PzMultMix";
   strncat(tTitNum7,title, 100);
   fPzMultMix = new TH3D(tTitNum7,title,nbins,qBins,nbins,qBins,nbins,qBins);
-  
+
   //Setup Pt MultMix
   char tTitNum8[101] = "PtMultMix";
   strncat(tTitNum8,title, 100);
   fPtMultMix = new TH3D(tTitNum8,title,nbins,qBins,nbins,qBins,nbins,qBins);
   // To enable error bar calculation
-  
+
   /*fEnergyTotalReal->Sumw2();
   fEnergyMultReal->Sumw2();
   fPzMultReal->Sumw2();
@@ -205,7 +205,7 @@ AliFemtoCorrFctn(),
   fPzMultMix->Sumw2();
   fPtMultMix->Sumw2();
 }
-  
+
 
 
 
@@ -214,15 +214,15 @@ AliFemtoCorrFctn(),
 
 AliFemtoBPLCMS3DCorrFctnEMCIC::AliFemtoBPLCMS3DCorrFctnEMCIC(const AliFemtoBPLCMS3DCorrFctnEMCIC& aCorrFctn) :
   AliFemtoCorrFctn(aCorrFctn),
-  /*fEnergyTotalReal(0),  
-  fEnergyMultReal(0),        
-  fPzMultReal(0),      
-  fPtMultReal(0),*/     
+  /*fEnergyTotalReal(0),
+  fEnergyMultReal(0),
+  fPzMultReal(0),
+  fPtMultReal(0),*/
   fNumerator(0),
   fDenominator(0),
-  fEnergyTotalMix (0),      
-  fEnergyMultMix (0),  
-  fPzMultMix(0),          
+  fEnergyTotalMix (0),
+  fEnergyMultMix (0),
+  fPzMultMix(0),
   fPtMultMix(0),
   fUseRPSelection(0)
 {
@@ -242,14 +242,14 @@ AliFemtoBPLCMS3DCorrFctnEMCIC::AliFemtoBPLCMS3DCorrFctnEMCIC(const AliFemtoBPLCM
 AliFemtoBPLCMS3DCorrFctnEMCIC::~AliFemtoBPLCMS3DCorrFctnEMCIC(){
   // Destructor
   /*  delete fEnergyTotalReal;
-  delete fEnergyMultReal;        
-  delete fPzMultReal;     
+  delete fEnergyMultReal;
+  delete fPzMultReal;
   delete fPtMultReal;  */
   delete fNumerator;
   delete fDenominator;
-  delete fEnergyTotalMix;      
-  delete fEnergyMultMix; 
-  delete fPzMultMix;   
+  delete fEnergyTotalMix;
+  delete fEnergyMultMix;
+  delete fPzMultMix;
   delete fPtMultMix;
 }
 //_________________________
@@ -279,7 +279,7 @@ AliFemtoBPLCMS3DCorrFctnEMCIC& AliFemtoBPLCMS3DCorrFctnEMCIC::operator=(const Al
   fPzMultMix = new TH3D(*aCorrFctn.fPzMultMix);
   if (fPtMultMix) delete fPtMultMix;
   fPtMultMix = new TH3D(*aCorrFctn.fPtMultMix);
-  
+
   fUseRPSelection = aCorrFctn.fUseRPSelection;
 
   return *this;
@@ -287,17 +287,17 @@ AliFemtoBPLCMS3DCorrFctnEMCIC& AliFemtoBPLCMS3DCorrFctnEMCIC::operator=(const Al
 
 //_________________________
 void AliFemtoBPLCMS3DCorrFctnEMCIC::WriteOutHistos(){
-  
+
   fNumerator->Write();
   fDenominator->Write();
   //fEnergyTotalReal->Write();
-  //fEnergyMultReal->Write();        
-  //fPzMultReal->Write();      
-  //fPtMultReal->Write();            
-  fEnergyTotalMix->Write();      
-  fEnergyMultMix->Write();      
-  fPzMultMix->Write();            
-  fPtMultMix->Write(); 
+  //fEnergyMultReal->Write();
+  //fPzMultReal->Write();
+  //fPtMultReal->Write();
+  fEnergyTotalMix->Write();
+  fEnergyMultMix->Write();
+  fPzMultMix->Write();
+  fPtMultMix->Write();
   //cout << "write histos emcics" << endl;
 }
 //______________________________
@@ -309,12 +309,12 @@ TList* AliFemtoBPLCMS3DCorrFctnEMCIC::GetOutputList()
   tOutputList->Add(fNumerator);
   tOutputList->Add(fDenominator);
   /*tOutputList->Add(fEnergyTotalReal);
-  tOutputList->Add(fEnergyMultReal);        
-  tOutputList->Add(fPzMultReal);      
-  tOutputList->Add(fPtMultReal);     */       
-  tOutputList->Add(fEnergyTotalMix );      
-  tOutputList->Add(fEnergyMultMix );      
-  tOutputList->Add(fPzMultMix);            
+  tOutputList->Add(fEnergyMultReal);
+  tOutputList->Add(fPzMultReal);
+  tOutputList->Add(fPtMultReal);     */
+  tOutputList->Add(fEnergyTotalMix );
+  tOutputList->Add(fEnergyMultMix );
+  tOutputList->Add(fPzMultMix);
   tOutputList->Add(fPtMultMix);
   return tOutputList;
 }
@@ -324,11 +324,11 @@ TList* AliFemtoBPLCMS3DCorrFctnEMCIC::GetOutputList()
 //____________________________
 void AliFemtoBPLCMS3DCorrFctnEMCIC::AddRealPair( AliFemtoPair* pair){
   // perform operations on real pairs
-  
+
   if (fPairCut){
     if (fUseRPSelection) {
       AliFemtoKTPairCut *ktc = dynamic_cast<AliFemtoKTPairCut *>(fPairCut);
-      if (!ktc) { 
+      if (!ktc) {
 	cout << "RP aware cut requested, but not connected to the CF" << endl;
 	if (!(fPairCut->Pass(pair))) return;
       }
@@ -344,27 +344,27 @@ void AliFemtoBPLCMS3DCorrFctnEMCIC::AddRealPair( AliFemtoPair* pair){
     else
       if (!(fPairCut->Pass(pair))) return;
   }
-  
-  double qOut  = fabs(pair->QOutCMS());  
+
+  double qOut  = fabs(pair->QOutCMS());
   double qSide = fabs( pair->QSideCMS());
   double qLong = fabs(pair->QLongCMS());
 
   fNumerator->Fill(qOut,qSide,qLong);
-  
+
   /*AliFemtoLorentzVector tMom1 = pair->Track1()->FourMomentum();
   AliFemtoLorentzVector tMom2 = pair->Track2()->FourMomentum();
   double tE1 = tMom1.e();
   double tE2 = tMom2.e();
   double tPz1 = tMom1.pz();
   double tPz2 = tMom2.pz();
-  TVector2 tPt1;  
-  TVector2 tPt2; 
+  TVector2 tPt1;
+  TVector2 tPt2;
   tPt1.Set(tMom1.px(),tMom1.py());
   tPt2.Set(tMom2.px(),tMom2.py());
-  
-  
+
+
   double tPt1DotPt2 = tPt1*tPt2;
-  
+
   fEnergyTotalReal->Fill(qOut,qSide,qLong,tE1+tE2);
   fEnergyMultReal->Fill(qOut,qSide,qLong,tE1*tE2);
   fPzMultReal->Fill(qOut,qSide,qLong,tPz1*tPz2);
@@ -381,7 +381,7 @@ void AliFemtoBPLCMS3DCorrFctnEMCIC::AddMixedPair( AliFemtoPair* pair){
   if (fPairCut){
     if (fUseRPSelection) {
       AliFemtoKTPairCut *ktc = dynamic_cast<AliFemtoKTPairCut *>(fPairCut);
-      if (!ktc) { 
+      if (!ktc) {
 	cout << "RP aware cut requested, but not connected to the CF" << endl;
 	if (!(fPairCut->Pass(pair))) return;
       }
@@ -398,7 +398,7 @@ void AliFemtoBPLCMS3DCorrFctnEMCIC::AddMixedPair( AliFemtoPair* pair){
       if (!(fPairCut->Pass(pair))) return;
   }
 
-  
+
   double qOut = fabs(pair->QOutCMS());
   double qSide = fabs(pair->QSideCMS());
   double qLong = fabs(pair->QLongCMS());
@@ -411,17 +411,17 @@ void AliFemtoBPLCMS3DCorrFctnEMCIC::AddMixedPair( AliFemtoPair* pair){
   double tE2 = tMom2.e();
   double tPz1 = tMom1.pz();
   double tPz2 = tMom2.pz();
-  TVector2 tPt1;  
-  TVector2 tPt2; 
+  TVector2 tPt1;
+  TVector2 tPt2;
   tPt1.Set(tMom1.px(),tMom1.py());
   tPt2.Set(tMom2.px(),tMom2.py());
   double tPt1DotPt2 = tPt1*tPt2;
-  
+
   fEnergyTotalMix->Fill(qOut,qSide,qLong,tE1+tE2);
   fEnergyMultMix->Fill(qOut,qSide,qLong,tE1*tE2);
   fPzMultMix->Fill(qOut,qSide,qLong,tPz1*tPz2);
   fPtMultMix->Fill(qOut,qSide,qLong,tPt1DotPt2);
-  
+
 }
 
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoBPLCMS3DCorrFctnEMCIC.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoBPLCMS3DCorrFctnEMCIC.h
@@ -15,12 +15,12 @@
  *        2)   E1 * E2
  *        3)   Pt1*Pt2
  *        4)   Pz1*Pz2
- *  
+ *
  * The class is derived from AliFemtoBPLCMS3DCorrFctn, therefore it produces
- * also the histograms in that class. 
- * 
- * NOTE: The EMCIC histograms are not averaged in this class, to obtain 
- * the average, the user needs to divide the real pair histograms by 
+ * also the histograms in that class.
+ *
+ * NOTE: The EMCIC histograms are not averaged in this class, to obtain
+ * the average, the user needs to divide the real pair histograms by
  * the numerator, and the mixed pair histograms by the denominator
  *
  ***************************************************************************
@@ -37,11 +37,11 @@
 
 class AliFemtoBPLCMS3DCorrFctnEMCIC : public AliFemtoCorrFctn{
 public:
-  AliFemtoBPLCMS3DCorrFctnEMCIC(char* title, const int& nbins, const float& QLo, const float& QHi);
+  AliFemtoBPLCMS3DCorrFctnEMCIC(const char* title, const int& nbins, const float& QLo, const float& QHi);
   // Variable bin size constructor :
   //qBins array of low-edges for each bin. This is an array of size nbins+1
-  AliFemtoBPLCMS3DCorrFctnEMCIC(char* title, const int& nbins, const float* qBins);
-  
+  AliFemtoBPLCMS3DCorrFctnEMCIC(const char* title, const int& nbins, const float* qBins);
+
   AliFemtoBPLCMS3DCorrFctnEMCIC(const AliFemtoBPLCMS3DCorrFctnEMCIC& aCorrFctn);
   virtual ~AliFemtoBPLCMS3DCorrFctnEMCIC();
 
@@ -59,7 +59,7 @@ public:
   virtual TList* GetOutputList();
 
  private:
-  
+
   TH3D* fNumerator;         // numerator
   TH3D* fDenominator;       // denominator
   //EMCIC histograms
@@ -71,11 +71,11 @@ public:
   TH3D* fEnergyMultMix;        // E1*E2
   TH3D* fPzMultMix;            // Pz1*Pz2
   TH3D* fPtMultMix;            // Pt1*Pt2
-   
+
  protected:
   unsigned short fUseRPSelection;  // The pair cut uses RP selection
-  
-  
+
+
 
 #ifdef __ROOT__
   ClassDef(AliFemtoBPLCMS3DCorrFctnEMCIC, 1)

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoChi2CorrFctn.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoChi2CorrFctn.cxx
@@ -11,12 +11,12 @@
 //#include "AliFemtoHisto.hh"
 #include <cstdio>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoChi2CorrFctn)
 #endif
 
 //____________________________
-AliFemtoChi2CorrFctn::AliFemtoChi2CorrFctn(char* title, const int& nbins, const float& QinvLo, const float& QinvHi):
+AliFemtoChi2CorrFctn::AliFemtoChi2CorrFctn(const char* title, const int& nbins, const float& QinvLo, const float& QinvHi):
   AliFemtoCorrFctn(),
   fChi2ITSSUMNumerator(0),
   fChi2ITSSUMDenominator(0),
@@ -214,16 +214,16 @@ void AliFemtoChi2CorrFctn::AddRealPair( AliFemtoPair* pair){
 
   if ((pair->Track1()->Track()->ITSncls() == 0) && (pair->Track2()->Track()->ITSncls() == 0))
     fChi2ITSSUMNumerator->Fill(tQinv, 1000.0);
-  else 
-    fChi2ITSSUMNumerator->Fill(tQinv, 
-			       (pair->Track1()->Track()->ITSchi2() + 
+  else
+    fChi2ITSSUMNumerator->Fill(tQinv,
+			       (pair->Track1()->Track()->ITSchi2() +
 				pair->Track2()->Track()->ITSchi2())/
 			       (pair->Track1()->Track()->ITSncls() +
 				pair->Track2()->Track()->ITSncls()));
   if ((pair->Track1()->Track()->TPCncls() == 0) && (pair->Track2()->Track()->TPCncls() == 0))
     fChi2TPCSUMNumerator->Fill(tQinv, 1000.0);
   else
-    fChi2TPCSUMNumerator->Fill(tQinv, 
+    fChi2TPCSUMNumerator->Fill(tQinv,
 			       (pair->Track1()->Track()->TPCchi2() +
 				pair->Track2()->Track()->TPCchi2())/
 			       (pair->Track1()->Track()->TPCncls() +
@@ -267,11 +267,11 @@ void AliFemtoChi2CorrFctn::AddRealPair( AliFemtoPair* pair){
   }
 
   if (pair->Track1()->Track()->SigmaToVertex() > pair->Track2()->Track()->SigmaToVertex()) {
-    fSigmaToVertexNumerator->Fill(tQinv, 
+    fSigmaToVertexNumerator->Fill(tQinv,
 				  pair->Track1()->Track()->SigmaToVertex());
   }
   else {
-    fSigmaToVertexNumerator->Fill(tQinv, 
+    fSigmaToVertexNumerator->Fill(tQinv,
 				  pair->Track2()->Track()->SigmaToVertex());
   }
 }
@@ -282,16 +282,16 @@ void AliFemtoChi2CorrFctn::AddMixedPair( AliFemtoPair* pair){
 
   if ((pair->Track1()->Track()->ITSncls() == 0) && (pair->Track2()->Track()->ITSncls() == 0))
     fChi2ITSSUMDenominator->Fill(tQinv, 1000.0);
-  else 
-    fChi2ITSSUMDenominator->Fill(tQinv, 
-				 (pair->Track1()->Track()->ITSchi2() + 
+  else
+    fChi2ITSSUMDenominator->Fill(tQinv,
+				 (pair->Track1()->Track()->ITSchi2() +
 				  pair->Track2()->Track()->ITSchi2())/
 				 (pair->Track1()->Track()->ITSncls() +
 				  pair->Track2()->Track()->ITSncls()));
   if ((pair->Track1()->Track()->TPCncls() == 0) && (pair->Track2()->Track()->TPCncls() == 0))
     fChi2TPCSUMDenominator->Fill(tQinv, 1000.0);
   else
-    fChi2TPCSUMDenominator->Fill(tQinv, 
+    fChi2TPCSUMDenominator->Fill(tQinv,
 				 (pair->Track1()->Track()->TPCchi2() +
 				  pair->Track2()->Track()->TPCchi2())/
 				 (pair->Track1()->Track()->TPCncls() +
@@ -334,11 +334,11 @@ void AliFemtoChi2CorrFctn::AddMixedPair( AliFemtoPair* pair){
     fChi2TPCONEDenominator->Fill(tQinv, chi2perpointTPC2);
   }
   if (pair->Track1()->Track()->SigmaToVertex() > pair->Track2()->Track()->SigmaToVertex()) {
-    fSigmaToVertexDenominator->Fill(tQinv, 
+    fSigmaToVertexDenominator->Fill(tQinv,
 				  pair->Track1()->Track()->SigmaToVertex());
   }
   else {
-    fSigmaToVertexDenominator->Fill(tQinv, 
+    fSigmaToVertexDenominator->Fill(tQinv,
 				  pair->Track2()->Track()->SigmaToVertex());
   }
 }
@@ -357,7 +357,7 @@ void AliFemtoChi2CorrFctn::WriteHistos()
   fChi2TPCONEDenominator->Write();
   fSigmaToVertexNumerator->Write();
   fSigmaToVertexDenominator->Write();
-  
+
 }
 
 TList* AliFemtoChi2CorrFctn::GetOutputList()
@@ -375,7 +375,7 @@ TList* AliFemtoChi2CorrFctn::GetOutputList()
   tOutputList->Add(fChi2TPCONEDenominator);
   tOutputList->Add(fSigmaToVertexNumerator);
   tOutputList->Add(fSigmaToVertexDenominator);
-  
+
   return tOutputList;
 
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoChi2CorrFctn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoChi2CorrFctn.h
@@ -16,7 +16,7 @@
 
 class AliFemtoChi2CorrFctn : public AliFemtoCorrFctn {
 public:
-  AliFemtoChi2CorrFctn(char* title, const int& nbins, const float& QinvLo, const float& QinvHi);
+  AliFemtoChi2CorrFctn(const char* title, const int& nbins, const float& QinvLo, const float& QinvHi);
   AliFemtoChi2CorrFctn(const AliFemtoChi2CorrFctn& aCorrFctn);
   virtual ~AliFemtoChi2CorrFctn();
 
@@ -31,16 +31,16 @@ public:
   void WriteHistos();
   virtual TList* GetOutputList();
 private:
-  
+
   TH2D *fChi2ITSSUMNumerator;        // Numerator as a function of ITS quality sum for the pair
   TH2D *fChi2ITSSUMDenominator;      // Denominator as a function of ITS quality sum for the pair
- 
+
   TH2D *fChi2TPCSUMNumerator;        // Numerator as a function of TPC quality sum for the pair
   TH2D *fChi2TPCSUMDenominator;      // Denominator as a function of TPC quality sum for the pair
 
   TH2D *fChi2ITSONENumerator;        // Numerator as a function of ITS quality for the worse track
   TH2D *fChi2ITSONEDenominator;      // Denominator as a function of ITS quality for the worse track
- 
+
   TH2D *fChi2TPCONENumerator;        // Numerator as a function of TPC quality for the worse track
   TH2D *fChi2TPCONEDenominator;      // Denominator as a function of TPC quality for the worse track
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DPRF.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DPRF.cxx
@@ -12,11 +12,11 @@
 
 #include <cstdio>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoCorrFctn3DPRF)
 #endif
 //____________________________
-AliFemtoCorrFctn3DPRF::AliFemtoCorrFctn3DPRF(char* title, const int& nbins, const float& QHi)
+AliFemtoCorrFctn3DPRF::AliFemtoCorrFctn3DPRF(const char* title, const int& nbins, const float& QHi)
   :
   AliFemtoCorrFctn(),
   fNumerator(0),
@@ -104,10 +104,10 @@ TList* AliFemtoCorrFctn3DPRF::GetOutputList()
   // Prepare the list of objects to be written to the output
   TList *tOutputList = new TList();
 
-  tOutputList->Add(fNumerator); 
-  tOutputList->Add(fDenominator);  
-  //tOutputList->Add(fNumeratorW); 
-  //tOutputList->Add(fDenominatorW);  
+  tOutputList->Add(fNumerator);
+  tOutputList->Add(fDenominator);
+  //tOutputList->Add(fNumeratorW);
+  //tOutputList->Add(fDenominatorW);
 
   return tOutputList;
 }
@@ -138,7 +138,7 @@ AliFemtoString AliFemtoCorrFctn3DPRF::Report(){
     stemp += ctemp;
   }
 
-  //  
+  //
   AliFemtoString returnThis = stemp;
   return returnThis;
 }
@@ -158,7 +158,7 @@ void AliFemtoCorrFctn3DPRF::AddRealPair( AliFemtoPair* pair){
     //fNumeratorW->Fill(qOut,qSide,qLong,qqinv);
 
 
-   
+
 }
 //____________________________
 void AliFemtoCorrFctn3DPRF::AddMixedPair( AliFemtoPair* pair){
@@ -177,7 +177,7 @@ void AliFemtoCorrFctn3DPRF::AddMixedPair( AliFemtoPair* pair){
     //fDenominatorW->Fill(qOut,qSide,qLong,qqqinv);
 
 
- 
+
 }
 
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DPRF.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DPRF.h
@@ -14,7 +14,7 @@
 
 class AliFemtoCorrFctn3DPRF : public AliFemtoCorrFctn {
 public:
-  AliFemtoCorrFctn3DPRF(char* title, const int& nbins, const float& QHi);
+  AliFemtoCorrFctn3DPRF(const char* title, const int& nbins, const float& QHi);
   AliFemtoCorrFctn3DPRF(const AliFemtoCorrFctn3DPRF& aCorrFctn);
   virtual ~AliFemtoCorrFctn3DPRF();
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DPRF_qosl_q.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DPRF_qosl_q.cxx
@@ -12,11 +12,11 @@
 
 #include <cstdio>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoCorrFctn3DPRF_qosl_q)
 #endif
 //____________________________
-AliFemtoCorrFctn3DPRF_qosl_q::AliFemtoCorrFctn3DPRF_qosl_q(char* title, const int& nbins, const float& QHi)
+AliFemtoCorrFctn3DPRF_qosl_q::AliFemtoCorrFctn3DPRF_qosl_q(const char* title, const int& nbins, const float& QHi)
   :
   AliFemtoCorrFctn(),
   fNumerator(0),
@@ -126,12 +126,12 @@ TList* AliFemtoCorrFctn3DPRF_qosl_q::GetOutputList()
   // Prepare the list of objects to be written to the output
   TList *tOutputList = new TList();
 
-  //tOutputList->Add(fNumerator); 
-  //tOutputList->Add(fDenominator);  
-  //tOutputList->Add(fNumeratorW); 
-  //tOutputList->Add(fDenominatorW); 
-  tOutputList->Add(fNumS); 
-  tOutputList->Add(fDenS); 
+  //tOutputList->Add(fNumerator);
+  //tOutputList->Add(fDenominator);
+  //tOutputList->Add(fNumeratorW);
+  //tOutputList->Add(fDenominatorW);
+  tOutputList->Add(fNumS);
+  tOutputList->Add(fDenS);
 
   return tOutputList;
 }
@@ -162,7 +162,7 @@ AliFemtoString AliFemtoCorrFctn3DPRF_qosl_q::Report(){
     stemp += ctemp;
   }
 
-  //  
+  //
   AliFemtoString returnThis = stemp;
   return returnThis;
 }
@@ -194,7 +194,7 @@ void AliFemtoCorrFctn3DPRF_qosl_q::AddRealPair( AliFemtoPair* pair){
     //fNumeratorW->Fill(qOut,qSide,qLong,qqinv);
 
 
-   
+
 }
 //____________________________
 void AliFemtoCorrFctn3DPRF_qosl_q::AddMixedPair( AliFemtoPair* pair){
@@ -226,7 +226,7 @@ void AliFemtoCorrFctn3DPRF_qosl_q::AddMixedPair( AliFemtoPair* pair){
     //fDenominatorW->Fill(qOut,qSide,qLong,qqqinv);
 
 
- 
+
 }
 
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DPRF_qosl_q.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DPRF_qosl_q.h
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////
 //                                                                       //
 // AliFemtoCorrFctn3DPRF_qosl_q: a class to calculate 3D correlation        //
-// for pairs of particles in PRF   
+// for pairs of particles in PRF
 //Written by Ashutosh Kumar Pandey (ashutosh.kumar.pandey@cern.ch) for Source Imaging//
 //                                                                       //
 ///////////////////////////////////////////////////////////////////////////
@@ -16,7 +16,7 @@
 
 class AliFemtoCorrFctn3DPRF_qosl_q : public AliFemtoCorrFctn {
 public:
-  AliFemtoCorrFctn3DPRF_qosl_q(char* title, const int& nbins, const float& QHi);
+  AliFemtoCorrFctn3DPRF_qosl_q(const char* title, const int& nbins, const float& QHi);
   AliFemtoCorrFctn3DPRF_qosl_q(const AliFemtoCorrFctn3DPRF_qosl_q& aCorrFctn);
   virtual ~AliFemtoCorrFctn3DPRF_qosl_q();
 
@@ -32,7 +32,7 @@ public:
   TH3F* Denominator();
   TH3F* NumeratorW();//Weighed by qinv
   TH3F* DenominatorW();
-  THnSparse* NumeratorS(); //numerator	
+  THnSparse* NumeratorS(); //numerator
   THnSparse* DenominatorS(); //denominator
 
   void WriteOutHistos();
@@ -44,7 +44,7 @@ private:
   TH3F* fDenominator;       // denominator
   TH3F* fNumeratorW;         // numerator
   TH3F* fDenominatorW;       // denominator
-  THnSparse* fNumS; //numerator	
+  THnSparse* fNumS; //numerator
   THnSparse* fDenS; //denominator
 #ifdef __ROOT__
   ClassDef(AliFemtoCorrFctn3DPRF_qosl_q, 1)

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DSphericalEMCIC.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DSphericalEMCIC.cxx
@@ -6,7 +6,7 @@
  ***************************************************************************
  *
  * Description: Calculates of the 3D Correlation Function in Spherical
- *              coordinates, and also produces histograms to calculate 
+ *              coordinates, and also produces histograms to calculate
  *              Energy Momentum Conservation Induced Correlations  (EMCICs)
  *
  * This Class produces the following histograms as function of Q, theta, phi
@@ -15,12 +15,12 @@
  *        2)   E1 * E2
  *        3)   Pt1*Pt2
  *        4)   Pz1*Pz2
- *  
+ *
  * This class is similar to AliFemtoCorrFctn3DSpherical, but it uses Q
- * instead of K to do the binning. 
- * 
- * NOTE: The EMCIC histograms are not averaged in this class, to obtain 
- * the average, the user needs to divide the real pair histograms by 
+ * instead of K to do the binning.
+ *
+ * NOTE: The EMCIC histograms are not averaged in this class, to obtain
+ * the average, the user needs to divide the real pair histograms by
  * the numerator, and the mixed pair histograms by the denominator.
  *
  ***************************************************************************
@@ -33,27 +33,27 @@
 #include <TVector2.h>
 #include <cstdio>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoCorrFctn3DSphericalEMCIC)
 #endif
 
 
 //____________________________
-AliFemtoCorrFctn3DSphericalEMCIC::AliFemtoCorrFctn3DSphericalEMCIC(char* title, const int& nqbins, const float& QLo, const float& QHi, const int& nphibins, const int& ncthetabins):
+AliFemtoCorrFctn3DSphericalEMCIC::AliFemtoCorrFctn3DSphericalEMCIC(const char* title, const int& nqbins, const float& QLo, const float& QHi, const int& nphibins, const int& ncthetabins):
   AliFemtoCorrFctn(),
   fNumerator(0),
   fDenominator(0),
-/*fEnergyTotalReal(0),  
-  fEnergyMultReal(0),        
-  fPzMultReal(0),      
-  fPtMultReal(0),*/            
-  fEnergyTotalMix (0),      
-  fEnergyMultMix (0),      
-  fPzMultMix(0),            
+/*fEnergyTotalReal(0),
+  fEnergyMultReal(0),
+  fPzMultReal(0),
+  fPtMultReal(0),*/
+  fEnergyTotalMix (0),
+  fEnergyMultMix (0),
+  fPzMultMix(0),
   fPtMultMix(0),
   fPairCut(0x0)
 {
-  
+
   // To better sample on phi shift bin low edge by binsize/2 = Pi/numBins.
   Double_t shiftPhi=TMath::Pi()/nphibins;
   // set up numerator
@@ -73,13 +73,13 @@ AliFemtoCorrFctn3DSphericalEMCIC::AliFemtoCorrFctn3DSphericalEMCIC(char* title, 
   strncat(tTitNum1,title, 100);
   fEnergyTotalReal = new TH3D(tTitNum1,title,nqbins,QLo,QHi,nphibins,
 			      -TMath::Pi()-shiftPhi,TMath::Pi()-shiftPhi,ncthetabins,-1.0,1.0);
- 
+
   //Setup EnergyMultReal
   char tTitNum2[101] = "EMultReal";
   strncat(tTitNum2,title, 100);
   fEnergyMultReal = new TH3D(tTitNum2,title,nqbins,QLo,QHi,nphibins,
 			     -TMath::Pi()-shiftPhi,TMath::Pi()-shiftPhi,ncthetabins,-1.0,1.0);
-  
+
   //Setup Pz MultReal
   char tTitNum3[101] = "PzMultReal";
   strncat(tTitNum3,title, 100);
@@ -91,7 +91,7 @@ AliFemtoCorrFctn3DSphericalEMCIC::AliFemtoCorrFctn3DSphericalEMCIC(char* title, 
   strncat(tTitNum4,title, 100);
   fPtMultReal = new TH3D(tTitNum4,title,nqbins,QLo,QHi,nphibins,
 			 -TMath::Pi()-shiftPhi,TMath::Pi()-shiftPhi,ncthetabins,-1.0,1.0);
-  */ 
+  */
 
 
   //Setup EnergyTotalMix
@@ -99,13 +99,13 @@ AliFemtoCorrFctn3DSphericalEMCIC::AliFemtoCorrFctn3DSphericalEMCIC(char* title, 
   strncat(tTitNum5,title, 100);
   fEnergyTotalMix = new TH3D(tTitNum5,title,nqbins,QLo,QHi,nphibins,
 			     -TMath::Pi()-shiftPhi,TMath::Pi()-shiftPhi,ncthetabins,-1.0,1.0);
-  
+
   //Setup EnergyMultMix
   char tTitNum6[101] = "EMultMix";
   strncat(tTitNum6,title, 100);
   fEnergyMultMix = new TH3D(tTitNum6,title,nqbins,QLo,QHi,nphibins,
 			    -TMath::Pi()-shiftPhi,TMath::Pi()-shiftPhi,ncthetabins,-1.0,1.0);
-  
+
   //Setup Pz MultMix
   char tTitNum7[101] = "PzMultMix";
   strncat(tTitNum7,title, 100);
@@ -139,12 +139,12 @@ AliFemtoCorrFctn3DSphericalEMCIC::AliFemtoCorrFctn3DSphericalEMCIC(const AliFemt
   fNumerator(0),
   fDenominator(0),
   /*fEnergyTotalReal(0),
-  fEnergyMultReal(0),        
-  fPzMultReal(0),      
+  fEnergyMultReal(0),
+  fPzMultReal(0),
   fPtMultReal(0),            */
-  fEnergyTotalMix (0),      
-  fEnergyMultMix (0),      
-  fPzMultMix(0),            
+  fEnergyTotalMix (0),
+  fEnergyMultMix (0),
+  fPzMultMix(0),
   fPtMultMix(0),
   fPairCut(0x0)
 {
@@ -167,12 +167,12 @@ AliFemtoCorrFctn3DSphericalEMCIC::~AliFemtoCorrFctn3DSphericalEMCIC(){
   delete fNumerator;
   delete fDenominator;
   /*delete fEnergyTotalReal;
-  delete fEnergyMultReal;        
-  delete fPzMultReal;     
+  delete fEnergyMultReal;
+  delete fPzMultReal;
   delete fPtMultReal;            */
-  delete fEnergyTotalMix;      
-  delete fEnergyMultMix; 
-  delete fPzMultMix;   
+  delete fEnergyTotalMix;
+  delete fEnergyMultMix;
+  delete fPzMultMix;
   delete fPtMultMix;
 }
 //_________________________
@@ -203,7 +203,7 @@ AliFemtoCorrFctn3DSphericalEMCIC& AliFemtoCorrFctn3DSphericalEMCIC::operator=(co
   if (fPtMultMix) delete fPtMultMix;
   fPtMultMix = new TH3D(*aCorrFctn.fPtMultMix);
   fPairCut = aCorrFctn.fPairCut;
-  
+
   return *this;
 }
 
@@ -213,12 +213,12 @@ void AliFemtoCorrFctn3DSphericalEMCIC::WriteOutHistos(){
   fNumerator->Write();
   fDenominator->Write();
   /*fEnergyTotalReal->Write();
-  fEnergyMultReal->Write();        
-  fPzMultReal->Write();      
+  fEnergyMultReal->Write();
+  fPzMultReal->Write();
   fPtMultReal->Write();            */
-  fEnergyTotalMix->Write();      
-  fEnergyMultMix->Write();      
-  fPzMultMix->Write();            
+  fEnergyTotalMix->Write();
+  fEnergyMultMix->Write();
+  fPzMultMix->Write();
   fPtMultMix->Write();
 }
 //______________________________
@@ -227,15 +227,15 @@ TList* AliFemtoCorrFctn3DSphericalEMCIC::GetOutputList()
   // Prepare the list of objects to be written to the output
   TList *tOutputList = new TList();
 
-  tOutputList->Add(fNumerator); 
-  tOutputList->Add(fDenominator);  
+  tOutputList->Add(fNumerator);
+  tOutputList->Add(fDenominator);
   /*  tOutputList->Add(fEnergyTotalReal);
-  tOutputList->Add(fEnergyMultReal);        
-  tOutputList->Add(fPzMultReal);      
+  tOutputList->Add(fEnergyMultReal);
+  tOutputList->Add(fPzMultReal);
   tOutputList->Add(fPtMultReal);            */
-  tOutputList->Add(fEnergyTotalMix );      
-  tOutputList->Add(fEnergyMultMix );      
-  tOutputList->Add(fPzMultMix);            
+  tOutputList->Add(fEnergyTotalMix );
+  tOutputList->Add(fEnergyMultMix );
+  tOutputList->Add(fPzMultMix);
   tOutputList->Add(fPtMultMix);
   return tOutputList;
 }
@@ -265,7 +265,7 @@ AliFemtoString AliFemtoCorrFctn3DSphericalEMCIC::Report(){
     stemp += ctemp;
   }
 
-  //  
+  //
   AliFemtoString returnThis = stemp;
   return returnThis;
 }
@@ -281,10 +281,10 @@ void AliFemtoCorrFctn3DSphericalEMCIC::AddRealPair( AliFemtoPair* pair){
       if (!(ktc->Pass(pair))) return;
   }
 
-  //                          
-  double tQO = pair->QOutCMS();  
-  double tQS = pair->QSideCMS();  
-  double tQL = pair->QLongCMS();  
+  //
+  double tQO = pair->QOutCMS();
+  double tQS = pair->QSideCMS();
+  double tQL = pair->QLongCMS();
 
   double tQR = sqrt(tQO*tQO + tQS*tQS + tQL*tQL);
   double tQC = 0;
@@ -293,26 +293,26 @@ void AliFemtoCorrFctn3DSphericalEMCIC::AddRealPair( AliFemtoPair* pair){
   double tQP = atan2(tQS,tQO);
 
   fNumerator->Fill(tQR,tQP,tQC);
-  
-  // EMCICs  
+
+  // EMCICs
   /*AliFemtoLorentzVector tMom1 = pair->Track1()->FourMomentum();
   AliFemtoLorentzVector tMom2 = pair->Track2()->FourMomentum();
   double tE1 = tMom1.e();
   double tE2 = tMom2.e();
   double tPz1 = tMom1.pz();
   double tPz2 = tMom2.pz();
-  
-  TVector2 tPt1;  
-  TVector2 tPt2; 
+
+  TVector2 tPt1;
+  TVector2 tPt2;
   tPt1.Set(tMom1.px(),tMom1.py());
   tPt2.Set(tMom2.px(),tMom2.py());
   double tPt1DotPt2 = tPt1*tPt2;
-  
+
   fEnergyTotalReal->Fill(tQR,tQP,tQC,tE1+tE2);
   fEnergyMultReal->Fill(tQR,tQP,tQC,tE1*tE2);
   fPzMultReal->Fill(tQR,tQP,tQC,tPz1*tPz2);
   fPtMultReal->Fill(tQR,tQP,tQC,tPt1DotPt2);*/
-   
+
 
 }
 //____________________________
@@ -326,13 +326,13 @@ void AliFemtoCorrFctn3DSphericalEMCIC::AddMixedPair( AliFemtoPair* pair){
     else
       if (!(ktc->Pass(pair))) return;
   }
-  
+
 
 
  //                          //Changed K to Q to be in LCMS, N. Bock
-  double tQO = pair->QOutCMS();  
-  double tQS = pair->QSideCMS();   
-  double tQL = pair->QLongCMS();  
+  double tQO = pair->QOutCMS();
+  double tQS = pair->QSideCMS();
+  double tQL = pair->QLongCMS();
 
   double tQR = sqrt(tQO*tQO + tQS*tQS + tQL*tQL);
   double tQC;
@@ -342,24 +342,24 @@ void AliFemtoCorrFctn3DSphericalEMCIC::AddMixedPair( AliFemtoPair* pair){
 
   fDenominator->Fill(tQR,tQP,tQC);
 
-  // EMCICs   
+  // EMCICs
   AliFemtoLorentzVector tMom1 = pair->Track1()->FourMomentum();
   AliFemtoLorentzVector tMom2 = pair->Track2()->FourMomentum();
   double tE1 = tMom1.e();
   double tE2 = tMom2.e();
   double tPz1 = tMom1.pz();
   double tPz2 = tMom2.pz();
-  
-  TVector2 tPt1;  
-  TVector2 tPt2; 
+
+  TVector2 tPt1;
+  TVector2 tPt2;
   tPt1.Set(tMom1.px(),tMom1.py());
   tPt2.Set(tMom2.px(),tMom2.py());
   double tPt1DotPt2 = tPt1*tPt2;
-  
+
   fEnergyTotalMix->Fill(tQR,tQP,tQC,tE1+tE2);
   fEnergyMultMix->Fill(tQR,tQP,tQC,tE1*tE2);
   fPzMultMix->Fill(tQR,tQP,tQC,tPz1*tPz2);
   fPtMultMix->Fill(tQR,tQP,tQC,tPt1DotPt2);
-  
+
 }
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DSphericalEMCIC.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DSphericalEMCIC.h
@@ -16,7 +16,7 @@
 
 class AliFemtoCorrFctn3DSphericalEMCIC : public AliFemtoCorrFctn{
 public:
-  AliFemtoCorrFctn3DSphericalEMCIC(char* title, 
+  AliFemtoCorrFctn3DSphericalEMCIC(const char* title,
 			      const int& nqbins, const float& QLo, const float& QHi,
 			      const int& nphibins, const int& ncthetabins);
   AliFemtoCorrFctn3DSphericalEMCIC(const AliFemtoCorrFctn3DSphericalEMCIC& aCorrFctn);
@@ -36,7 +36,7 @@ public:
   void SetSpecificPairCut(AliFemtoPairCut* aCut);
 
  private:
-  
+
   TH3D* fNumerator;         // numerator
   TH3D* fDenominator;       // denominator
   //EMCIC histograms:

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhi.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhi.cxx
@@ -14,15 +14,15 @@
 #include <cstdio>
 #include <TMath.h>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoCorrFctnDEtaDPhi)
 #endif
-  
+
 #define PIH 1.57079632679489656
 #define PIT 6.28318530717958623
 
 //____________________________
-AliFemtoCorrFctnDEtaDPhi::AliFemtoCorrFctnDEtaDPhi(char* title, const int& aPhiBins=20, const int& aEtaBins=20):
+AliFemtoCorrFctnDEtaDPhi::AliFemtoCorrFctnDEtaDPhi(const char* title, const int& aPhiBins=20, const int& aEtaBins=20):
   AliFemtoCorrFctn(),
   fDPhiDEtaNumerator(0),
   fDPhiDEtaDenominator(0),
@@ -91,7 +91,7 @@ AliFemtoCorrFctnDEtaDPhi::AliFemtoCorrFctnDEtaDPhi(char* title, const int& aPhiB
   char tTitEta[101] = "Eta";
   strncat(tTitEta,title, 100);
   fEta = new TH1D(tTitEta,title,90,-1.2,1.2);
-  
+
 
   // THnSparse(const char* name, const char* title, Int_t dim,
   //           const Int_t* nbins, const Double_t* xmin, const Double_t* xmax,
@@ -198,12 +198,12 @@ AliFemtoCorrFctnDEtaDPhi::AliFemtoCorrFctnDEtaDPhi(const AliFemtoCorrFctnDEtaDPh
 
  if (aCorrFctn.fYtYtNumerator)
    fYtYtNumerator = new TH2D(*aCorrFctn.fDPhiDEtaDenominator);
- else 
+ else
    fYtYtNumerator = 0;
 
  if (aCorrFctn.fYtYtDenominator)
    fYtYtDenominator = new TH2D(*aCorrFctn.fDPhiDEtaDenominator);
- else 
+ else
    fYtYtDenominator = 0;
 
   fphiL = aCorrFctn.fphiL;
@@ -211,12 +211,12 @@ AliFemtoCorrFctnDEtaDPhi::AliFemtoCorrFctnDEtaDPhi(const AliFemtoCorrFctnDEtaDPh
 
 //  if (aCorrFctn.fPtCorrectionsNum)
 //    fPtCorrectionsNum = new THnSparseF(*aCorrFctn.fPtCorrectionsNum);
-//    else 
+//    else
 //    fPtCorrectionsNum = 0;
 
 // if (aCorrFctn.fPtCorrectionsDen)
 //    fPtCorrectionsDen = new THnSparseF(*aCorrFctn.fPtCorrectionsDen);
-//  else 
+//  else
 //    fPtCorrectionsDen = 0;
 
 
@@ -320,12 +320,12 @@ AliFemtoCorrFctnDEtaDPhi& AliFemtoCorrFctnDEtaDPhi::operator=(const AliFemtoCorr
 
  if (aCorrFctn.fYtYtNumerator)
    fYtYtNumerator = new TH2D(*aCorrFctn.fDPhiDEtaDenominator);
- else 
+ else
    fYtYtNumerator = 0;
 
  if (aCorrFctn.fYtYtDenominator)
    fYtYtDenominator = new TH2D(*aCorrFctn.fDPhiDEtaDenominator);
- else 
+ else
    fYtYtDenominator = 0;
 
  fIfCorrectionHist = kNone;
@@ -335,12 +335,12 @@ AliFemtoCorrFctnDEtaDPhi& AliFemtoCorrFctnDEtaDPhi::operator=(const AliFemtoCorr
 
 // if (aCorrFctn.fPtCorrectionsNum)
 //    fPtCorrectionsNum = new THnSparseF(*aCorrFctn.fPtCorrectionsNum);
-//  else 
+//  else
 //    fPtCorrectionsNum = 0;
 
 // if (aCorrFctn.fPtCorrectionsDen)
 //    fPtCorrectionsDen = new THnSparseF(*aCorrFctn.fPtCorrectionsDen);
-//  else 
+//  else
 //    fPtCorrectionsDen = 0;
 
 
@@ -428,7 +428,7 @@ void AliFemtoCorrFctnDEtaDPhi::AddRealPair( AliFemtoPair* pair){
   fPhi->Fill(phi1);
   fEta->Fill(eta1);
 
- 
+
   if(fIfCorrectionHist)
     {
       if(fIfCorrectionHist == kPt){
@@ -465,14 +465,14 @@ void AliFemtoCorrFctnDEtaDPhi::AddMixedPair( AliFemtoPair* pair){
 
   double deta = eta1 - eta2;
 
- 
+
 
   fDPhiDEtaDenominator->Fill(dphi, deta);
 
     double px1 = pair->Track1()->Track()->P().x();
     double py1 = pair->Track1()->Track()->P().y();
     //double pz1 = pair->Track1()->Track()->P().z();
-    
+
     double px2 = pair->Track2()->Track()->P().x();
     double py2 = pair->Track2()->Track()->P().y();
     //double pz2 = pair->Track2()->Track()->P().z();
@@ -536,7 +536,7 @@ void AliFemtoCorrFctnDEtaDPhi::WriteHistos()
   }
   fPhi->Write();
   fEta->Write();
-  
+
   if(fIfCorrectionHist){
     if(fIfCorrectionHist==kPt){
     fPtCorrectionsNum->Write();
@@ -588,7 +588,7 @@ TList* AliFemtoCorrFctnDEtaDPhi::GetOutputList()
 void AliFemtoCorrFctnDEtaDPhi::SetDoPtAnalysis(int do2d)
 {
   fDoPtAnalysis = do2d;
-  
+
   int aPhiBins = fDPhiDEtaNumerator->GetNbinsX();
   int aEtaBins = fDPhiDEtaNumerator->GetNbinsY();
   const char *title = fDPhiDEtaNumerator->GetTitle();
@@ -628,7 +628,7 @@ void AliFemtoCorrFctnDEtaDPhi::SetDoPtAnalysis(int do2d)
   fDPhiPtDenominator->Sumw2();
   fDCosPtNumerator->Sumw2();
   fDCosPtDenominator->Sumw2();
-  
+
 }
 
 void AliFemtoCorrFctnDEtaDPhi::SetDo4DCorrectionHist(CorrectionType doCorr)

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhi.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhi.h
@@ -21,7 +21,7 @@ public:
   enum CorrectionType {kNone=0, kPt=1, kEta=2};
   typedef enum CorrectionType ReadCorrectionType;
 
-  AliFemtoCorrFctnDEtaDPhi(char* title, const int& aPhiBins, const int& aEtaBins);
+  AliFemtoCorrFctnDEtaDPhi(const char* title, const int& aPhiBins, const int& aEtaBins);
   AliFemtoCorrFctnDEtaDPhi(const AliFemtoCorrFctnDEtaDPhi& aCorrFctn);
   virtual ~AliFemtoCorrFctnDEtaDPhi();
 
@@ -38,7 +38,7 @@ public:
   void WriteHistos();
   virtual TList* GetOutputList();
 private:
-  
+
   TH2D *fDPhiDEtaNumerator;          // Numerator of dEta dPhi function
   TH2D *fDPhiDEtaDenominator;        // Denominator of dEta dPhi function
 
@@ -61,7 +61,7 @@ private:
   TH1D *fPtSumDist;
 
   TH2D *fYtYtNumerator;
-  TH2D *fYtYtDenominator; 
+  TH2D *fYtYtDenominator;
 
   CorrectionType fIfCorrectionHist;
   THnSparseF *fPtCorrectionsNum;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiCorrections.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiCorrections.cxx
@@ -15,10 +15,10 @@
 #include <TMath.h>
 #include "THn.h"
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoCorrFctnDEtaDPhiCorrections)
 #endif
-  
+
 #define PIH 1.57079632679489656
 #define PIT 6.28318530717958623
 
@@ -26,7 +26,7 @@ ClassImp(AliFemtoCorrFctnDEtaDPhiCorrections)
 
 
 //____________________________
-AliFemtoCorrFctnDEtaDPhiCorrections::AliFemtoCorrFctnDEtaDPhiCorrections(char* title, const int& aPhiBins=20, const int& aEtaBins=20):
+AliFemtoCorrFctnDEtaDPhiCorrections::AliFemtoCorrFctnDEtaDPhiCorrections(const char* title, const int& aPhiBins=20, const int& aEtaBins=20):
   AliFemtoCorrFctn(),
   fDPhiDEtaNumerator(0),
   fDPhiDEtaDenominator(0),
@@ -101,7 +101,7 @@ AliFemtoCorrFctnDEtaDPhiCorrections::AliFemtoCorrFctnDEtaDPhiCorrections(char* t
   // to enable error bar calculation...
 
 
-  
+
 
 }
 
@@ -198,24 +198,24 @@ AliFemtoCorrFctnDEtaDPhiCorrections::AliFemtoCorrFctnDEtaDPhiCorrections(const A
 
  if (aCorrFctn.fYtYtNumerator)
    fYtYtNumerator = new TH2D(*aCorrFctn.fDPhiDEtaDenominator);
- else 
+ else
    fYtYtNumerator = 0;
 
  if (aCorrFctn.fYtYtDenominator)
    fYtYtDenominator = new TH2D(*aCorrFctn.fDPhiDEtaDenominator);
- else 
+ else
     fYtYtDenominator = 0;
 
 
  if (aCorrFctn.fPairPurity)
    fPairPurity = new TH2F(*aCorrFctn.fPairPurity);
- else 
+ else
     fPairPurity = 0;
- 
+
 
  if (aCorrFctn.fDPhiDEtaNumeratorNoCorr)
    fDPhiDEtaNumeratorNoCorr = new TH2F(*aCorrFctn.fDPhiDEtaNumeratorNoCorr);
- else 
+ else
    fDPhiDEtaNumeratorNoCorr = 0;
 
   fphiL = aCorrFctn.fphiL;
@@ -225,12 +225,12 @@ AliFemtoCorrFctnDEtaDPhiCorrections::AliFemtoCorrFctnDEtaDPhiCorrections(const A
 
 //  if (aCorrFctn.fPtCorrectionsNum)
 //    fPtCorrectionsNum = new THnSparseF(*aCorrFctn.fPtCorrectionsNum);
-//    else 
+//    else
 //    fPtCorrectionsNum = 0;
 
 // if (aCorrFctn.fPtCorrectionsDen)
 //    fPtCorrectionsDen = new THnSparseF(*aCorrFctn.fPtCorrectionsDen);
-//  else 
+//  else
 //    fPtCorrectionsDen = 0;
 
 
@@ -247,7 +247,7 @@ AliFemtoCorrFctnDEtaDPhiCorrections::~AliFemtoCorrFctnDEtaDPhiCorrections(){
       delete fPairPurity;
       delete fDPhiDEtaNumeratorNoCorr;
   }
- 
+
   if (fDoFullAnalysis) {
     delete fDPhiNumerator;
     delete fDPhiDenominator;
@@ -332,24 +332,24 @@ AliFemtoCorrFctnDEtaDPhiCorrections& AliFemtoCorrFctnDEtaDPhiCorrections::operat
 
  if (aCorrFctn.fYtYtNumerator)
    fYtYtNumerator = new TH2D(*aCorrFctn.fDPhiDEtaDenominator);
- else 
+ else
    fYtYtNumerator = 0;
 
  if (aCorrFctn.fYtYtDenominator)
    fYtYtDenominator = new TH2D(*aCorrFctn.fDPhiDEtaDenominator);
- else 
+ else
    fYtYtDenominator = 0;
- 
+
 
  if (aCorrFctn.fPairPurity)
    fPairPurity = new TH2F(*aCorrFctn.fPairPurity);
- else 
+ else
     fPairPurity = 0;
 
 
  if (aCorrFctn.fDPhiDEtaNumeratorNoCorr)
    fDPhiDEtaNumeratorNoCorr = new TH2F(*aCorrFctn.fDPhiDEtaNumeratorNoCorr);
- else 
+ else
    fDPhiDEtaNumeratorNoCorr = 0;
 
   fphiL = aCorrFctn.fphiL;
@@ -359,12 +359,12 @@ AliFemtoCorrFctnDEtaDPhiCorrections& AliFemtoCorrFctnDEtaDPhiCorrections::operat
 
 // if (aCorrFctn.fPtCorrectionsNum)
 //    fPtCorrectionsNum = new THnSparseF(*aCorrFctn.fPtCorrectionsNum);
-//  else 
+//  else
 //    fPtCorrectionsNum = 0;
 
 // if (aCorrFctn.fPtCorrectionsDen)
 //    fPtCorrectionsDen = new THnSparseF(*aCorrFctn.fPtCorrectionsDen);
-//  else 
+//  else
 //    fPtCorrectionsDen = 0;
 
 
@@ -434,9 +434,9 @@ void AliFemtoCorrFctnDEtaDPhiCorrections::AddRealPair( AliFemtoPair* pair){
   double vert2[3];
   pair->Track2()->Track()->GetPrimaryVertex(vert2);
 
-  double corrweight=0; //double corrweightpT1=1;  double corrweightpT2=1; 
+  double corrweight=0; //double corrweightpT1=1;  double corrweightpT2=1;
   //if (fIfCorrection) corrweight = CalculateCorrectionWeight(pt1, pt2);
-  if (fIfCorrection) 
+  if (fIfCorrection)
     {
       corrweight = CalculateCorrectionWeight(pt1, pt2, eta1, eta2, phi1, phi2, vert1[2], vert2[2]);
     }
@@ -529,7 +529,7 @@ void AliFemtoCorrFctnDEtaDPhiCorrections::AddMixedPair( AliFemtoPair* pair){
 
   double corrweight=-999;
   //if (fIfCorrection) corrweight = CalculateCorrectionWeight(pt1, pt2);
-  if (fIfCorrection) 
+  if (fIfCorrection)
     {
       corrweight = CalculateCorrectionWeight(pt1, pt2, eta1, eta2, phi1, phi2, vert1[2], vert2[2]);
     }
@@ -537,8 +537,8 @@ void AliFemtoCorrFctnDEtaDPhiCorrections::AddMixedPair( AliFemtoPair* pair){
     {
       corrweight = CalculateCorrectionWeight(pt1, pt2);
     }
-  
-  
+
+
   if(fIfCorrection || fCorr1D)
     fDPhiDEtaDenominator->Fill(dphi, deta, corrweight);
   else
@@ -580,7 +580,7 @@ void AliFemtoCorrFctnDEtaDPhiCorrections::WriteHistos()
     }*/
   // fPhi->Write();
   // fEta->Write();
-  
+
 }
 
 TList* AliFemtoCorrFctnDEtaDPhiCorrections::GetOutputList()
@@ -736,7 +736,7 @@ void AliFemtoCorrFctnDEtaDPhiCorrections::SetDoFullAnalysis(Bool_t do2d)
 void AliFemtoCorrFctnDEtaDPhiCorrections::LoadCorrectionTabFromROOTFile(const char *file, ParticleType partType1, ParticleType partType2, bool doPtCorr, bool doEtaCorr, bool doPhiCorr, bool doZVertCorr)
 {
   fIfCorrection = kTRUE;
- 
+
   ifileCorrTab = TFile::Open(file);
   fdoPtCorr = doPtCorr;
   fdoEtaCorr = doEtaCorr;
@@ -804,7 +804,7 @@ void AliFemtoCorrFctnDEtaDPhiCorrections::LoadCorrectionTabFromROOTFile(const ch
 	  fh1Reco2 = (TH1F*)(fhntReco2->Projection(0))->Clone();
 	  fh1Reco1->Scale(1./fhntReco1_nbins*fh1Reco1->GetNbinsX());
 	  fh1Reco2->Scale(1./fhntReco2_nbins*fh1Reco2->GetNbinsX());
-	    
+
 	}
 
       else if(fdoEtaCorr == 1)
@@ -838,7 +838,7 @@ void AliFemtoCorrFctnDEtaDPhiCorrections::LoadCorrectionTabFromROOTFile(const ch
       if(fdoPtCorr == 1 && fdoEtaCorr == 1)
 	{
 	  fh2Reco1 = (TH2F*)(fhntReco1->Projection(1,0))->Clone();
-	  fh2Reco2 = (TH2F*)(fhntReco2->Projection(1,0))->Clone();	  
+	  fh2Reco2 = (TH2F*)(fhntReco2->Projection(1,0))->Clone();
 	  fh2Reco1->Scale(1./fhntReco1_nbins*fh2Reco1->GetNbinsX()*fh2Reco1->GetNbinsY());
 	  fh2Reco2->Scale(1./fhntReco2_nbins*fh2Reco2->GetNbinsX()*fh2Reco2->GetNbinsY());
 	}
@@ -848,7 +848,7 @@ void AliFemtoCorrFctnDEtaDPhiCorrections::LoadCorrectionTabFromROOTFile(const ch
 	  fh2Reco1 = (TH2F*)(fhntReco1->Projection(2,0))->Clone();
 	  fh2Reco2 = (TH2F*)(fhntReco2->Projection(2,0))->Clone();
 	  fh2Reco1->Scale(1./fhntReco1_nbins*fh2Reco1->GetNbinsX()*fh2Reco1->GetNbinsY());
-	  fh2Reco2->Scale(1./fhntReco2_nbins*fh2Reco2->GetNbinsX()*fh2Reco2->GetNbinsY());	 
+	  fh2Reco2->Scale(1./fhntReco2_nbins*fh2Reco2->GetNbinsX()*fh2Reco2->GetNbinsY());
 	}
 
       else if(fdoPtCorr == 1 && fdoZVertCorr == 1)
@@ -887,7 +887,7 @@ void AliFemtoCorrFctnDEtaDPhiCorrections::LoadCorrectionTabFromROOTFile(const ch
       if(fdoPtCorr == 1 && fdoEtaCorr == 1 && fdoPhiCorr == 1)
 	{
 	  fh3Reco1 = (TH3F*)(fhntReco1->Projection(0,1,2))->Clone();
-	  fh3Reco2 = (TH3F*)(fhntReco2->Projection(0,1,2))->Clone(); 
+	  fh3Reco2 = (TH3F*)(fhntReco2->Projection(0,1,2))->Clone();
 	  fh3Reco1->Scale(1./fhntReco1_nbins*fh3Reco1->GetNbinsX()*fh3Reco1->GetNbinsY()*fh3Reco1->GetNbinsZ());
 	  fh3Reco2->Scale(1./fhntReco2_nbins*fh3Reco2->GetNbinsX()*fh3Reco2->GetNbinsY()*fh3Reco2->GetNbinsZ());
 
@@ -896,7 +896,7 @@ void AliFemtoCorrFctnDEtaDPhiCorrections::LoadCorrectionTabFromROOTFile(const ch
       else if(fdoPtCorr == 1 && fdoEtaCorr == 1 && fdoZVertCorr == 1)
 	{
 	  fh3Reco1 = (TH3F*)(fhntReco1->Projection(0,1,3))->Clone();
-	  fh3Reco2 = (TH3F*)(fhntReco2->Projection(0,1,3))->Clone(); 
+	  fh3Reco2 = (TH3F*)(fhntReco2->Projection(0,1,3))->Clone();
 	  fh3Reco1->Scale(1./fhntReco1_nbins*fh3Reco1->GetNbinsX()*fh3Reco1->GetNbinsY()*fh3Reco1->GetNbinsZ());
 	  fh3Reco2->Scale(1./fhntReco2_nbins*fh3Reco2->GetNbinsX()*fh3Reco2->GetNbinsY()*fh3Reco2->GetNbinsZ());
 	}
@@ -904,7 +904,7 @@ void AliFemtoCorrFctnDEtaDPhiCorrections::LoadCorrectionTabFromROOTFile(const ch
       else if(fdoPtCorr == 1 && fdoPhiCorr == 1 && fdoZVertCorr == 1)
 	{
 	  fh3Reco1 = (TH3F*)(fhntReco1->Projection(0,2,3))->Clone();
-	  fh3Reco2 = (TH3F*)(fhntReco2->Projection(0,2,3))->Clone(); 
+	  fh3Reco2 = (TH3F*)(fhntReco2->Projection(0,2,3))->Clone();
 	  fh3Reco1->Scale(1./fhntReco1_nbins*fh3Reco1->GetNbinsX()*fh3Reco1->GetNbinsY()*fh3Reco1->GetNbinsZ());
 	  fh3Reco2->Scale(1./fhntReco2_nbins*fh3Reco2->GetNbinsX()*fh3Reco2->GetNbinsY()*fh3Reco2->GetNbinsZ());
 	}
@@ -912,7 +912,7 @@ void AliFemtoCorrFctnDEtaDPhiCorrections::LoadCorrectionTabFromROOTFile(const ch
       else if(fdoEtaCorr == 1 && fdoPhiCorr == 1 && fdoZVertCorr == 1)
 	{
 	  fh3Reco1 = (TH3F*)(fhntReco1->Projection(1,2,3))->Clone();
-	  fh3Reco2 = (TH3F*)(fhntReco2->Projection(1,2,3))->Clone(); 
+	  fh3Reco2 = (TH3F*)(fhntReco2->Projection(1,2,3))->Clone();
 	  fh3Reco1->Scale(1./fhntReco1_nbins*fh3Reco1->GetNbinsX()*fh3Reco1->GetNbinsY()*fh3Reco1->GetNbinsZ());
 	  fh3Reco2->Scale(1./fhntReco2_nbins*fh3Reco2->GetNbinsX()*fh3Reco2->GetNbinsY()*fh3Reco2->GetNbinsZ());
 	}
@@ -936,7 +936,7 @@ void AliFemtoCorrFctnDEtaDPhiCorrections::LoadCorrectionTabFromROOTFile1D(const 
   fpartType2 = partType2;
 
 
-  char type1[12]; 
+  char type1[12];
   char type2[12];
 
 
@@ -960,7 +960,7 @@ void AliFemtoCorrFctnDEtaDPhiCorrections::LoadCorrectionTabFromROOTFile1D(const 
 
   fhCont1 = (TH1D*)(ifileCorrTab->Get(Form("CorrectionFactorPtEffandCont%s",type1)));//->Clone();
   fhCont2 = (TH1D*)(ifileCorrTab->Get(Form("CorrectionFactorPtEffandCont%s",type2)));//->Clone();
-   
+
 
   if(fCalculatePairPurity){
     fSinglePurity1 = (TH1F*)(ifileCorrTab->Get(Form("hPurity%s",type1)));
@@ -1021,9 +1021,9 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::CalculateCorrectionWeight(double pT1
      {
        w1 = fhCont1->GetBinContent(fhCont1->FindFixBin(pT1));
        w2 = fhCont2->GetBinContent(fhCont2->FindFixBin(pT2));
-       
+
        return w1*w2;
-     } 
+     }
    else
      return 0;
 }
@@ -1036,14 +1036,14 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::CalculateCorrectionWeight(double pT1
      {
        w1 = fhCont1->GetBinContent(fhCont1->FindFixBin(pT1));
        return w1;
-     } 
+     }
    else
      return 0;
 }
 
 double AliFemtoCorrFctnDEtaDPhiCorrections::CalculateCorrectionWeight(double pT1, double pT2, double eta1, double eta2, double phi1, double phi2, double zvert1, double zvert2)
 {
-  
+
     double w1=0., w2=0.;
     double eps1=0., eps2=0;
     double cont1=0., cont2=0; //w=(1-cont)/eps
@@ -1072,13 +1072,13 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::CalculateCorrectionWeight(double pT1
 	      {
 		eps1 = fh1Reco1->GetBinContent(fh1Reco1->FindFixBin(pT1));
 		eps2 = fh1Reco2->GetBinContent(fh1Reco2->FindFixBin(pT2));
-		
+
 		w1 = (1-cont1)/eps1;
 		w2 = (1-cont2)/eps2;
 		return w1*w2;
 	      }
 	    else
-	      return 0;	    
+	      return 0;
 	  }
 
 	else if(fdoEtaCorr == 1)
@@ -1087,7 +1087,7 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::CalculateCorrectionWeight(double pT1
 	      {
 		eps1 = fh1Reco1->GetBinContent(fh1Reco1->FindFixBin(eta1));
 		eps2 = fh1Reco2->GetBinContent(fh1Reco2->FindFixBin(eta2));
-	  
+
 		w1 = (1-cont1)/eps1;
 		w2 = (1-cont2)/eps2;
 
@@ -1106,7 +1106,7 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::CalculateCorrectionWeight(double pT1
 
 		w1 = (1-cont1)/eps1;
 		w2 = (1-cont2)/eps2;
-	  
+
 		return w1*w2;
 	      }
 	    else
@@ -1120,7 +1120,7 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::CalculateCorrectionWeight(double pT1
 	      {
 		eps1 = fh1Reco1->GetBinContent(fh1Reco1->FindFixBin(zvert1));
 		eps2 = fh1Reco2->GetBinContent(fh1Reco2->FindFixBin(zvert2));
-	  
+
 		w1 = (1-cont1)/eps1;
 		w2 = (1-cont2)/eps2;
 
@@ -1141,7 +1141,7 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::CalculateCorrectionWeight(double pT1
 		eps1 = fh2Reco1->GetBinContent(fh2Reco1->GetXaxis()->FindFixBin(pT1),fh2Reco1->GetYaxis()->FindFixBin(eta1));
 		eps2 = fh2Reco2->GetBinContent(fh2Reco2->GetXaxis()->FindFixBin(pT2),fh2Reco2->GetYaxis()->FindFixBin(eta2));
 
-		w1 = (1-cont1)/eps1; 
+		w1 = (1-cont1)/eps1;
 		w2 = (1-cont2)/eps2;
 
 		return w1*w2;
@@ -1153,12 +1153,12 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::CalculateCorrectionWeight(double pT1
 
 	if(fdoPtCorr == 1 && fdoPhiCorr == 1)
 	  {
-	 
+
 	    if(pT1 > fh2Reco1->GetXaxis()->GetXmin() && pT1 < fh2Reco1->GetXaxis()->GetXmax() && pT2 > fh2Reco2->GetXaxis()->GetXmin() && pT2 < fh2Reco2->GetXaxis()->GetXmax() && phi1 > fh2Reco1->GetYaxis()->GetXmin() && phi1 < fh2Reco1->GetYaxis()->GetXmax() && phi2 > fh2Reco2->GetYaxis()->GetXmin() && phi2 < fh2Reco2->GetYaxis()->GetXmax())
 	      {
 		eps1 = fh2Reco1->GetBinContent(fh2Reco1->GetXaxis()->FindFixBin(pT1),fh2Reco1->GetYaxis()->FindFixBin(phi1));
 		eps2 = fh2Reco2->GetBinContent(fh2Reco2->GetXaxis()->FindFixBin(pT2),fh2Reco2->GetYaxis()->FindFixBin(phi2));
-	  
+
 		w1 = (1-cont1)/eps1;
 		w2 = (1-cont2)/eps2;
 
@@ -1179,7 +1179,7 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::CalculateCorrectionWeight(double pT1
 
 		w1 = (1-cont1)/eps1;
 		w2 = (1-cont2)/eps2;
-	  
+
 		return w1*w2;
 	      }
 	    else
@@ -1192,7 +1192,7 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::CalculateCorrectionWeight(double pT1
 	      {
 		eps1 = fh2Reco1->GetBinContent(fh2Reco1->GetXaxis()->FindFixBin(eta1),fh2Reco1->GetYaxis()->FindFixBin(phi1));
 		eps2 = fh2Reco2->GetBinContent(fh2Reco2->GetXaxis()->FindFixBin(eta2),fh2Reco2->GetYaxis()->FindFixBin(phi2));
-	  
+
 		w1 = (1-cont1)/eps1;
 		w2 = (1-cont2)/eps2;
 
@@ -1214,7 +1214,7 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::CalculateCorrectionWeight(double pT1
 
 		w1 = (1-cont1)/eps1;
 		w2 = (1-cont2)/eps2;
-	  
+
 		return w1*w2;
 	      }
 	    else
@@ -1231,7 +1231,7 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::CalculateCorrectionWeight(double pT1
 
 		w1 = (1-cont1)/eps1;
 		w2 = (1-cont2)/eps2;
-	  
+
 		return w1*w2;
 	      }
 	    else
@@ -1245,16 +1245,16 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::CalculateCorrectionWeight(double pT1
       {
 	if(fdoPtCorr == 1 && fdoEtaCorr == 1 && fdoPhiCorr == 1)
 	  {
-	    if(pT1 >fh3Reco1->GetXaxis()->GetXmin() && pT1 <fh3Reco1->GetXaxis()->GetXmax() && 
-               pT2 > fh3Reco2->GetXaxis()->GetXmin() && pT2 <fh3Reco2->GetXaxis()->GetXmax() && 
-               eta1 > fh3Reco1->GetYaxis()->GetXmin() && eta1 <fh3Reco1->GetYaxis()->GetXmax() &&  
-               eta2 > fh3Reco2->GetYaxis()->GetXmin() && eta2 <fh3Reco2->GetYaxis()->GetXmax() &&  
-               phi1 > fh3Reco1->GetZaxis()->GetXmin() && phi1 < fh3Reco1->GetZaxis()->GetXmax() && 
+	    if(pT1 >fh3Reco1->GetXaxis()->GetXmin() && pT1 <fh3Reco1->GetXaxis()->GetXmax() &&
+               pT2 > fh3Reco2->GetXaxis()->GetXmin() && pT2 <fh3Reco2->GetXaxis()->GetXmax() &&
+               eta1 > fh3Reco1->GetYaxis()->GetXmin() && eta1 <fh3Reco1->GetYaxis()->GetXmax() &&
+               eta2 > fh3Reco2->GetYaxis()->GetXmin() && eta2 <fh3Reco2->GetYaxis()->GetXmax() &&
+               phi1 > fh3Reco1->GetZaxis()->GetXmin() && phi1 < fh3Reco1->GetZaxis()->GetXmax() &&
                phi2 > fh3Reco2->GetZaxis()->GetXmin() && phi2 < fh3Reco2->GetZaxis()->GetXmax())
 	      {
 		eps1 = fh3Reco1->GetBinContent(fh3Reco1->GetXaxis()->FindFixBin(pT1),fh3Reco1->GetYaxis()->FindFixBin(eta1),fh3Reco1->GetZaxis()->FindFixBin(phi1));
 		eps2 = fh3Reco2->GetBinContent(fh3Reco2->GetXaxis()->FindFixBin(pT2),fh3Reco2->GetYaxis()->FindFixBin(eta2),fh3Reco2->GetZaxis()->FindFixBin(phi2));
-	  
+
 		w1 = (1-cont1)/eps1;
 		w2 = (1-cont2)/eps2;
 
@@ -1273,7 +1273,7 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::CalculateCorrectionWeight(double pT1
 	      {
 		eps1 = fh3Reco1->GetBinContent(fh3Reco1->GetXaxis()->FindFixBin(pT1),fh3Reco1->GetYaxis()->FindFixBin(eta1),fh3Reco1->GetZaxis()->FindFixBin(zvert1));
 		eps2 = fh3Reco2->GetBinContent(fh3Reco2->GetXaxis()->FindFixBin(pT2),fh3Reco2->GetYaxis()->FindFixBin(eta2),fh3Reco2->GetZaxis()->FindFixBin(zvert2));
-	  
+
 		w1 = (1-cont1)/eps1;
 		w2 = (1-cont2)/eps2;
 
@@ -1290,7 +1290,7 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::CalculateCorrectionWeight(double pT1
 	      {
 		eps1 = fh3Reco1->GetBinContent(fh3Reco1->GetXaxis()->FindFixBin(pT1),fh3Reco1->GetYaxis()->FindFixBin(phi1),fh3Reco1->GetZaxis()->FindFixBin(zvert1));
 		eps2 = fh3Reco2->GetBinContent(fh3Reco2->GetXaxis()->FindFixBin(pT2),fh3Reco2->GetYaxis()->FindFixBin(phi2),fh3Reco2->GetZaxis()->FindFixBin(zvert2));
-	  
+
 		w1 = (1-cont1)/eps1;
 		w2 = (1-cont2)/eps2;
 
@@ -1308,7 +1308,7 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::CalculateCorrectionWeight(double pT1
 	      {
 		eps1 = fh3Reco1->GetBinContent(fh3Reco1->GetXaxis()->FindFixBin(eta1),fh3Reco1->GetYaxis()->FindFixBin(phi1),fh3Reco1->GetZaxis()->FindFixBin(zvert1));
 		eps2 = fh3Reco2->GetBinContent(fh3Reco2->GetXaxis()->FindFixBin(eta2),fh3Reco2->GetYaxis()->FindFixBin(phi2),fh3Reco2->GetZaxis()->FindFixBin(zvert2));
-	  
+
 		w1 = (1-cont1)/eps1;
 		w2 = (1-cont2)/eps2;
 
@@ -1322,28 +1322,28 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::CalculateCorrectionWeight(double pT1
 
     else if(boolSum == 4)
       {
-							  
+
 	if(pT1 > fhntReco1->GetAxis(0)->GetXmin() && pT1 < fhntReco1->GetAxis(0)->GetXmax() && pT2 > fhntReco2->GetAxis(0)->GetXmin() && pT2 < fhntReco2->GetAxis(0)->GetXmax() && eta1 > fhntReco1->GetAxis(1)->GetXmin() && eta1 <fhntReco1->GetAxis(1)->GetXmax() && eta2 > fhntReco2->GetAxis(1)->GetXmin() && eta2 < fhntReco2->GetAxis(1)->GetXmax() && phi1 > fhntReco1->GetAxis(2)->GetXmin() && phi2 < fhntReco2->GetAxis(2)->GetXmax() && phi2 > fhntReco2->GetAxis(2)->GetXmin() && phi2 < fhntReco2->GetAxis(2)->GetXmax() && zvert1 > fhntReco1->GetAxis(3)->GetXmin() && zvert1 < fhntReco1->GetAxis(3)->GetXmax() && zvert2 > fhntReco2->GetAxis(3)->GetXmin() && zvert2 < fhntReco2->GetAxis(3)->GetXmax())
 	      {
 
 		int tab1[] = {fhntReco1->GetAxis(0)->FindFixBin(pT1),fhntReco1->GetAxis(1)->FindFixBin(eta1),fhntReco1->GetAxis(2)->FindFixBin(phi1),fhntReco1->GetAxis(3)->FindFixBin(zvert1)};
 		int tab2[] = {fhntReco2->GetAxis(0)->FindFixBin(pT2),fhntReco2->GetAxis(1)->FindFixBin(eta2),fhntReco2->GetAxis(2)->FindFixBin(phi2),fhntReco2->GetAxis(3)->FindFixBin(zvert2)};
-       
+
 		eps1 = fhntReco1->GetBinContent(tab1);
 		eps2 = fhntReco2->GetBinContent(tab2);
 
 		w1 = (1-cont1)/eps1;
 		w2 = (1-cont2)/eps2;
 		return w1*w2;
-		  
+
 	      }
 	    else
 	      return 0;
 
       }
-    
+
     return 0;
-      
+
 }
 
 
@@ -1356,7 +1356,7 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::GetPurity(double pT1, int n)
       {
 	w1 = fSinglePurity1->GetBinContent(fSinglePurity1->FindFixBin(pT1));
 	return w1;
-      } 
+      }
     else
       return 0;
   }
@@ -1365,9 +1365,9 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::GetPurity(double pT1, int n)
       {
 	w1 = fSinglePurity2->GetBinContent(fSinglePurity2->FindFixBin(pT1));
 	return w1;
-      } 
+      }
     else
       return 0;
   }
-  
+
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiCorrections.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiCorrections.h
@@ -27,7 +27,7 @@ public:
   enum ParticleType {kNoCorrection=0, kPion=1, kKaon=2, kProton=3, kAll=4, kPionMinus=5, kKaonMinus=6, kProtonMinus=7};
   typedef enum CorrectionType ReadCorrectionType;
 
-  AliFemtoCorrFctnDEtaDPhiCorrections(char* title, const int& aPhiBins, const int& aEtaBins);
+  AliFemtoCorrFctnDEtaDPhiCorrections(const char* title, const int& aPhiBins, const int& aEtaBins);
   AliFemtoCorrFctnDEtaDPhiCorrections(const AliFemtoCorrFctnDEtaDPhiCorrections& aCorrFctn);
   virtual ~AliFemtoCorrFctnDEtaDPhiCorrections();
 
@@ -52,7 +52,7 @@ public:
   void WriteHistos();
   virtual TList* GetOutputList();
 private:
-  
+
   TH2D *fDPhiDEtaNumerator;          // Numerator of dEta dPhi function
   TH2D *fDPhiDEtaDenominator;        // Denominator of dEta dPhi function
 
@@ -70,7 +70,7 @@ private:
   TH1D *fPtSumDist;
 
   TH2D *fYtYtNumerator;
-  TH2D *fYtYtDenominator; 
+  TH2D *fYtYtDenominator;
 
   TH2F *fPairPurity;
   TH2F *fDPhiDEtaNumeratorNoCorr;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimple.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimple.cxx
@@ -22,7 +22,7 @@ ClassImp(AliFemtoCorrFctnDEtaDPhiSimple)
 #define PIT 6.28318530717958623
 
 //____________________________
-AliFemtoCorrFctnDEtaDPhiSimple::AliFemtoCorrFctnDEtaDPhiSimple(char* title, const int& aPhiBins=20, const int& aEtaBins=20):
+AliFemtoCorrFctnDEtaDPhiSimple::AliFemtoCorrFctnDEtaDPhiSimple(const char* title, const int& aPhiBins=20, const int& aEtaBins=20):
   AliFemtoCorrFctn(),
   fDPhiDEtaNumerator(0),
   fDPhiDEtaDenominator(0),

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimple.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimple.h
@@ -34,7 +34,7 @@ public:
     kLambda=8
   };
 
-  AliFemtoCorrFctnDEtaDPhiSimple(char* title, const int& aPhiBins, const int& aEtaBins);
+  AliFemtoCorrFctnDEtaDPhiSimple(const char* title, const int& aPhiBins, const int& aEtaBins);
   AliFemtoCorrFctnDEtaDPhiSimple(const AliFemtoCorrFctnDEtaDPhiSimple& aCorrFctn);
   virtual ~AliFemtoCorrFctnDEtaDPhiSimple();
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections.cxx
@@ -12,15 +12,15 @@
 #include <cstdio>
 #include <TMath.h>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections)
 #endif
-  
+
 #define PIH 1.57079632679489656
 #define PIT 6.28318530717958623
 
 //____________________________
-AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections(char* title, const int& aPhiBins=20, const int& aEtaBins=20):
+AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections(const char* title, const int& aPhiBins=20, const int& aEtaBins=20):
   AliFemtoCorrFctn(),
   fDPhiDEtaNumerator(0),
   fDPhiDEtaDenominator(0),
@@ -37,7 +37,7 @@ AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AliFemtoCorrFctnDEtaDPhiSimpleWit
   fDPhiDEtaHiddenSecWeakNumeratorData(0),
   fDPhiDEtaHiddenSecWeakDenominatorData(0),
   fDPhiDEtaHiddenSecMatNumeratorData(0),
-  fDPhiDEtaHiddenSecMatDenominatorData(0),  
+  fDPhiDEtaHiddenSecMatDenominatorData(0),
   fphiL(0),
   fphiT(0),
   fEtaBins(0),
@@ -51,7 +51,7 @@ AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AliFemtoCorrFctnDEtaDPhiSimpleWit
 
   fEtaBins = aEtaBins;
   fPhiBins = aPhiBins;
-  
+
   ftitle = new char[100];
   strcpy(ftitle,title);
 
@@ -65,12 +65,12 @@ AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AliFemtoCorrFctnDEtaDPhiSimpleWit
   fDPhiDEtaDenominator = new TH2D(tTitDenD,title,aPhiBins,fphiL,fphiT,aEtaBins,-2.0,2.0);
 
 
-  
+
   // to enable error bar calculation...
   fDPhiDEtaNumerator->Sumw2();
   fDPhiDEtaDenominator->Sumw2();
 
- 
+
 
 
 }
@@ -93,7 +93,7 @@ AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AliFemtoCorrFctnDEtaDPhiSimpleWit
   fDPhiDEtaHiddenSecWeakNumeratorData(0),
   fDPhiDEtaHiddenSecWeakDenominatorData(0),
   fDPhiDEtaHiddenSecMatNumeratorData(0),
-  fDPhiDEtaHiddenSecMatDenominatorData(0),  
+  fDPhiDEtaHiddenSecMatDenominatorData(0),
   fphiL(0),
   fphiT(0),
   fEtaBins(0),
@@ -103,11 +103,11 @@ AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AliFemtoCorrFctnDEtaDPhiSimpleWit
 {
   fEtaBins = aCorrFctn.fEtaBins;
   fPhiBins = aCorrFctn.fPhiBins;
-  
+
   ftitle = new char[100];
   strncat(ftitle,aCorrFctn.ftitle,100);
 
-  
+
   // copy constructor
   if (aCorrFctn.fDPhiDEtaNumerator)
     fDPhiDEtaNumerator = new TH2D(*aCorrFctn.fDPhiDEtaNumerator);
@@ -121,7 +121,7 @@ AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AliFemtoCorrFctnDEtaDPhiSimpleWit
   fReadHiddenInfo = aCorrFctn.fReadHiddenInfo;
   if(fReadHiddenInfo)
     {
- 
+
       if (aCorrFctn.fDPhiDEtaHiddenNumerator)
 	fDPhiDEtaHiddenNumerator = new TH2D(*aCorrFctn.fDPhiDEtaHiddenNumerator);
       else
@@ -191,7 +191,7 @@ AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AliFemtoCorrFctnDEtaDPhiSimpleWit
       else
 	fDPhiDEtaHiddenSecMatDenominatorData = 0;
     }
-  
+
 
 
 }
@@ -219,8 +219,8 @@ AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::~AliFemtoCorrFctnDEtaDPhiSimpleWi
       delete fDPhiDEtaHiddenSecMatNumeratorData;
       delete fDPhiDEtaHiddenSecMatDenominatorData;
     }
-    
-  
+
+
 }
 //_________________________
 AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections& AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::operator=(const AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections& aCorrFctn)
@@ -231,7 +231,7 @@ AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections& AliFemtoCorrFctnDEtaDPhiSimpleWit
 
   fEtaBins = aCorrFctn.fEtaBins;
   fPhiBins = aCorrFctn.fPhiBins;
-  
+
   ftitle = new char[100];
   strncat(ftitle,aCorrFctn.ftitle,100);
 
@@ -267,8 +267,8 @@ AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections& AliFemtoCorrFctnDEtaDPhiSimpleWit
 	fDPhiDEtaHiddenPrimaryDenominator = new TH2D(*aCorrFctn.fDPhiDEtaHiddenPrimaryDenominator);
       else
 	fDPhiDEtaHiddenPrimaryDenominator = 0;
-  
-  
+
+
       if (aCorrFctn.fDPhiDEtaHiddenSecWeakNumerator)
 	fDPhiDEtaHiddenSecWeakNumerator = new TH2D(*aCorrFctn.fDPhiDEtaHiddenSecWeakNumerator);
       else
@@ -321,8 +321,8 @@ AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections& AliFemtoCorrFctnDEtaDPhiSimpleWit
 
     }
 
-  
-    
+
+
 
   return *this;
 }
@@ -386,7 +386,7 @@ AliFemtoString AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::Report(){
       snprintf(ctemp , 100, "Number of entries in hidden second. material denominator data:\t%E\n",fDPhiDEtaHiddenSecMatDenominatorData->GetEntries());
       stemp += ctemp;
     }
-  
+
   //  stemp += mCoulombWeight->Report();
   AliFemtoString returnThis = stemp;
   return returnThis;
@@ -411,27 +411,27 @@ void AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AddRealPair( AliFemtoPair* p
   float weight = 1;
 
   if(pair->Track1()->Track()){
-    if(part1==kPion) weight = pair->Track1()->Track()->CorrectionPion();  
-    else if(part1==kKaon) weight = pair->Track1()->Track()->CorrectionKaon();  
+    if(part1==kPion) weight = pair->Track1()->Track()->CorrectionPion();
+    else if(part1==kKaon) weight = pair->Track1()->Track()->CorrectionKaon();
     else if(part1==kProton) weight = pair->Track1()->Track()->CorrectionProton();
-    else if(part1==kPionMinus) weight = pair->Track1()->Track()->CorrectionPionMinus();  
-    else if(part1==kKaonMinus) weight = pair->Track1()->Track()->CorrectionKaonMinus();  
-    else if(part1==kProtonMinus) weight = pair->Track1()->Track()->CorrectionProtonMinus();  
-    else if(part1==kAll) weight = pair->Track1()->Track()->CorrectionAll();  
+    else if(part1==kPionMinus) weight = pair->Track1()->Track()->CorrectionPionMinus();
+    else if(part1==kKaonMinus) weight = pair->Track1()->Track()->CorrectionKaonMinus();
+    else if(part1==kProtonMinus) weight = pair->Track1()->Track()->CorrectionProtonMinus();
+    else if(part1==kAll) weight = pair->Track1()->Track()->CorrectionAll();
   }
   if(pair->Track1()->V0()){
     if(part1==kLambda) weight = pair->Track1()->V0()->CorrectionLambda();
-    if(part1==kLambdaMinus) weight = pair->Track1()->V0()->CorrectionLambdaMinus();  
+    if(part1==kLambdaMinus) weight = pair->Track1()->V0()->CorrectionLambdaMinus();
   }
 
   if(pair->Track2()->Track()){
-    if(part2==kPion) weight *= pair->Track2()->Track()->CorrectionPion();  
-    else if(part2==kKaon) weight *= pair->Track2()->Track()->CorrectionKaon();  
+    if(part2==kPion) weight *= pair->Track2()->Track()->CorrectionPion();
+    else if(part2==kKaon) weight *= pair->Track2()->Track()->CorrectionKaon();
     else if(part2==kProton) weight *= pair->Track2()->Track()->CorrectionProton();
-    else if(part2==kPionMinus) weight *= pair->Track2()->Track()->CorrectionPionMinus();  
-    else if(part2==kKaonMinus) weight *= pair->Track2()->Track()->CorrectionKaonMinus();  
-    else if(part2==kProtonMinus) weight *= pair->Track2()->Track()->CorrectionProtonMinus();  
-    else if(part2==kAll) weight *= pair->Track2()->Track()->CorrectionAll();  
+    else if(part2==kPionMinus) weight *= pair->Track2()->Track()->CorrectionPionMinus();
+    else if(part2==kKaonMinus) weight *= pair->Track2()->Track()->CorrectionKaonMinus();
+    else if(part2==kProtonMinus) weight *= pair->Track2()->Track()->CorrectionProtonMinus();
+    else if(part2==kAll) weight *= pair->Track2()->Track()->CorrectionAll();
   }
   if(pair->Track2()->V0()){
     if(part2==kLambda)
@@ -442,7 +442,7 @@ void AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AddRealPair( AliFemtoPair* p
 
   fDPhiDEtaNumerator->Fill(dphi, deta, weight);
 
- 
+
 
   if(fReadHiddenInfo)
     {
@@ -470,7 +470,7 @@ void AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AddRealPair( AliFemtoPair* p
 	{
 	  AliFemtoThreeVector *v1 = hInfo1->GetTrueMomentum();
 	  AliFemtoThreeVector *v2 = hInfo2->GetTrueMomentum();
-   
+
 	  double hphi1 = v1->Phi();
 	  double hphi2 = v2->Phi();
 	  double heta1 = v1->PseudoRapidity();
@@ -499,10 +499,10 @@ void AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AddRealPair( AliFemtoPair* p
 	      fDPhiDEtaHiddenSecMatNumerator->Fill(dhphi,dheta,weight);
 	      fDPhiDEtaHiddenSecMatNumeratorData->Fill(dphi,deta,weight);
 	    }
-	  
+
 	}
     }
-  
+
 
 }
 //____________________________
@@ -525,27 +525,27 @@ void AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AddMixedPair( AliFemtoPair* 
   float weight = 1;
 
   if(pair->Track1()->Track()){
-    if(part1==kPion) weight = pair->Track1()->Track()->CorrectionPion();  
-    else if(part1==kKaon) weight = pair->Track1()->Track()->CorrectionKaon();  
+    if(part1==kPion) weight = pair->Track1()->Track()->CorrectionPion();
+    else if(part1==kKaon) weight = pair->Track1()->Track()->CorrectionKaon();
     else if(part1==kProton) weight = pair->Track1()->Track()->CorrectionProton();
-    else if(part1==kPionMinus) weight = pair->Track1()->Track()->CorrectionPionMinus();  
-    else if(part1==kKaonMinus) weight = pair->Track1()->Track()->CorrectionKaonMinus();  
-    else if(part1==kProtonMinus) weight = pair->Track1()->Track()->CorrectionProtonMinus();  
-    else if(part1==kAll) weight = pair->Track1()->Track()->CorrectionAll();  
+    else if(part1==kPionMinus) weight = pair->Track1()->Track()->CorrectionPionMinus();
+    else if(part1==kKaonMinus) weight = pair->Track1()->Track()->CorrectionKaonMinus();
+    else if(part1==kProtonMinus) weight = pair->Track1()->Track()->CorrectionProtonMinus();
+    else if(part1==kAll) weight = pair->Track1()->Track()->CorrectionAll();
    }
   if(pair->Track1()->V0()){
     if(part1==kLambda) weight = pair->Track1()->V0()->CorrectionLambda();
-    else if(part1==kLambdaMinus) weight = pair->Track1()->V0()->CorrectionLambdaMinus();  
+    else if(part1==kLambdaMinus) weight = pair->Track1()->V0()->CorrectionLambdaMinus();
   }
 
   if(pair->Track2()->Track()){
-    if(part2==kPion) weight *= pair->Track2()->Track()->CorrectionPion();  
-    else if(part2==kKaon) weight *= pair->Track2()->Track()->CorrectionKaon();  
+    if(part2==kPion) weight *= pair->Track2()->Track()->CorrectionPion();
+    else if(part2==kKaon) weight *= pair->Track2()->Track()->CorrectionKaon();
     else if(part2==kProton) weight *= pair->Track2()->Track()->CorrectionProton();
-    else if(part2==kPionMinus) weight *= pair->Track2()->Track()->CorrectionPionMinus();  
-    else if(part2==kKaonMinus) weight *= pair->Track2()->Track()->CorrectionKaonMinus();  
-    else if(part2==kProtonMinus) weight *= pair->Track2()->Track()->CorrectionProtonMinus();  
-    else if(part2==kAll) weight *= pair->Track2()->Track()->CorrectionAll();  
+    else if(part2==kPionMinus) weight *= pair->Track2()->Track()->CorrectionPionMinus();
+    else if(part2==kKaonMinus) weight *= pair->Track2()->Track()->CorrectionKaonMinus();
+    else if(part2==kProtonMinus) weight *= pair->Track2()->Track()->CorrectionProtonMinus();
+    else if(part2==kAll) weight *= pair->Track2()->Track()->CorrectionAll();
    }
   if(pair->Track2()->V0()){
     if(part2==kLambda) weight *= pair->Track2()->V0()->CorrectionLambda();
@@ -577,13 +577,13 @@ void AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AddMixedPair( AliFemtoPair* 
 	    hInfo2 = (AliFemtoModelHiddenInfo*)pair->Track2()->V0()->GetHiddenInfo();
 	}
 
- 
+
       if(hInfo1 && hInfo2)
 	{
 	  AliFemtoThreeVector *v1 = hInfo1->GetTrueMomentum();
-	  AliFemtoThreeVector *v2 = hInfo2->GetTrueMomentum(); 
+	  AliFemtoThreeVector *v2 = hInfo2->GetTrueMomentum();
 
-      
+
 	  double hphi1 = v1->Phi();
 	  double hphi2 = v2->Phi();
 	  double heta1 = v1->PseudoRapidity();
@@ -594,9 +594,9 @@ void AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AddMixedPair( AliFemtoPair* 
 	  while (dhphi<fphiL) dhphi+=PIT;
 	  while (dhphi>fphiT) dhphi-=PIT;
 
-	  double dheta = heta1 - heta2;      
+	  double dheta = heta1 - heta2;
 
-	  
+
 	  fDPhiDEtaHiddenDenominator->Fill(dhphi, dheta,weight);
 	  if(hInfo1->GetOrigin()==0 && hInfo2->GetOrigin()==0)
 	    {
@@ -614,10 +614,10 @@ void AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AddMixedPair( AliFemtoPair* 
 	      fDPhiDEtaHiddenSecMatDenominator->Fill(dphi,deta,weight);
 	    }
 
-	  
+
 	}
     }
-  
+
 
 }
 
@@ -631,7 +631,7 @@ void AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::WriteHistos()
     {
       fDPhiDEtaHiddenNumerator->Write();
       fDPhiDEtaHiddenDenominator->Write();
-      
+
       fDPhiDEtaHiddenPrimaryNumerator->Write();
       fDPhiDEtaHiddenPrimaryDenominator->Write();
 
@@ -667,19 +667,19 @@ TList* AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::GetOutputList()
 
       tOutputList->Add(fDPhiDEtaHiddenPrimaryNumerator);
       tOutputList->Add(fDPhiDEtaHiddenPrimaryDenominator);
-      
+
       tOutputList->Add(fDPhiDEtaHiddenSecWeakNumerator);
       tOutputList->Add(fDPhiDEtaHiddenSecWeakDenominator);
-      
+
       tOutputList->Add(fDPhiDEtaHiddenSecMatNumerator);
       tOutputList->Add(fDPhiDEtaHiddenSecMatDenominator);
 
       tOutputList->Add(fDPhiDEtaHiddenPrimaryNumeratorData);
       tOutputList->Add(fDPhiDEtaHiddenPrimaryDenominatorData);
-      
+
       tOutputList->Add(fDPhiDEtaHiddenSecWeakNumeratorData);
       tOutputList->Add(fDPhiDEtaHiddenSecWeakDenominatorData);
-      
+
       tOutputList->Add(fDPhiDEtaHiddenSecMatNumeratorData);
       tOutputList->Add(fDPhiDEtaHiddenSecMatDenominatorData);
     }
@@ -795,5 +795,5 @@ void AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::SetReadHiddenInfo(bool read)
   fDPhiDEtaHiddenSecWeakDenominatorData->Sumw2();
   fDPhiDEtaHiddenSecMatNumeratorData->Sumw2();
   fDPhiDEtaHiddenSecMatDenominatorData->Sumw2();
-  
+
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections.h
@@ -19,7 +19,7 @@ class AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections : public AliFemtoCorrFctn {
 public:
   enum ParticleType {kNoCorrection=0, kPion=1, kKaon=2, kProton=3, kAll=4, kPionMinus=5, kKaonMinus=6, kProtonMinus=7, kLambda=8, kLambdaMinus=9};
 
-  AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections(char* title, const int& aPhiBins, const int& aEtaBins);
+  AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections(const char* title, const int& aPhiBins, const int& aEtaBins);
   AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections(const AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections& aCorrFctn);
   virtual ~AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections();
 
@@ -40,7 +40,7 @@ public:
   void WriteHistos();
   virtual TList* GetOutputList();
 private:
-  
+
   TH2D *fDPhiDEtaNumerator;          // Numerator of dEta dPhi function
   TH2D *fDPhiDEtaDenominator;        // Denominator of dEta dPhi function
   TH2D *fDPhiDEtaHiddenNumerator;          // Numerator of dEta dPhi function from MC
@@ -63,7 +63,7 @@ private:
 
   TH2D *fDPhiDEtaHiddenSecMatNumeratorData;          // Numerator of dEta dPhi function from MC, secondaries from material, filled with data values
   TH2D *fDPhiDEtaHiddenSecMatDenominatorData;        // Denominator of dEta dPhi function from MC, secondaries from material, filled with data values
-    
+
   double fphiL;
   double fphiT;
 
@@ -71,7 +71,7 @@ private:
   int fPhiBins;
 
   char *ftitle;
-  
+
   ParticleType part1;
   ParticleType part2;
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiTHn.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiTHn.cxx
@@ -14,15 +14,15 @@
 #include <cstdio>
 #include <TMath.h>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoCorrFctnDEtaDPhiTHn)
 #endif
-  
+
 #define PIH 1.57079632679489656
 #define PIT 6.28318530717958623
 
 //____________________________
-AliFemtoCorrFctnDEtaDPhiTHn::AliFemtoCorrFctnDEtaDPhiTHn(char* title, const int& aPhiBins=20, const int& aEtaBins=20, const int &pT1Bins=1, const double& pT1min=0, const double& pT1max=4, const int &pT2Bins=1, const double& pT2min=0, const double& pT2max=4, const int &zvtxBins=10, const double& zvtxmin=-10, const double& zvtxmax=10, const int &multBins=5, const int& multmin=0, const int& multmax=100):
+AliFemtoCorrFctnDEtaDPhiTHn::AliFemtoCorrFctnDEtaDPhiTHn(const char* title, const int& aPhiBins=20, const int& aEtaBins=20, const int &pT1Bins=1, const double& pT1min=0, const double& pT1max=4, const int &pT2Bins=1, const double& pT2min=0, const double& pT2max=4, const int &zvtxBins=10, const double& zvtxmin=-10, const double& zvtxmax=10, const int &multBins=5, const int& multmin=0, const int& multmax=100):
 AliFemtoCorrFctn(),
   fDPhiDEtaNum(0),
   fDPhiDEtaDen(0),
@@ -35,26 +35,26 @@ AliFemtoCorrFctn(),
   fZvtxMin(zvtxmin),
   fZvtxMax(zvtxmax),
   fMultMin(multmin),
-  fMultMax(multmax)  
+  fMultMax(multmax)
 {
   fphiL = (-(int)(aPhiBins/4)+0.5)*2.*TMath::Pi()/aPhiBins;
   fphiT = 2*TMath::Pi()+(-(int)(aPhiBins/4)+0.5)*2.*TMath::Pi()/aPhiBins;
 
- 
+
   // THnSparse(const char* name, const char* title, Int_t dim,
   //           const Int_t* nbins, const Double_t* xmin, const Double_t* xmax,
   //           Int_t chunksize);
 
- 
+
   const Int_t nbins[] = {aPhiBins,aEtaBins,pT1Bins,pT2Bins,multBins,zvtxBins};
   const Double_t xmin[] = {fphiL,-2.0 ,pT1min,pT2min,fMultMin,zvtxmin};
   const Double_t xmax[] = {fphiT, 2.0 ,pT1max,pT2max,fMultMax,zvtxmax};
-  
+
   // set up numerator
   char tTitNumD[101] = "NumDPhiDEta";
   strncat(tTitNumD,title, 100);
   fDPhiDEtaNum = new THnSparseF(tTitNumD,title,6,nbins,xmin,xmax);
-  
+
   // set up denominator
   char tTitDenD[101] = "DenDPhiDEta";
   strncat(tTitDenD,title, 100);
@@ -79,7 +79,7 @@ AliFemtoCorrFctnDEtaDPhiTHn::AliFemtoCorrFctnDEtaDPhiTHn(const AliFemtoCorrFctnD
   fZvtxMin(aCorrFctn.fZvtxMin),
   fZvtxMax(aCorrFctn.fZvtxMax),
   fMultMin(aCorrFctn.fMultMin),
-  fMultMax(aCorrFctn.fMultMax)  
+  fMultMax(aCorrFctn.fMultMax)
 {
   // copy constructor
   /*
@@ -87,7 +87,7 @@ AliFemtoCorrFctnDEtaDPhiTHn::AliFemtoCorrFctnDEtaDPhiTHn(const AliFemtoCorrFctnD
     fDPhiDEtaNum = new THnSparseF(*aCorrFctn.fDPhiDEtaNum);
   else
     fDPhiDEtaNum = 0;
-  
+
   if (aCorrFctn.fDPhiDEtaDen)
     fDPhiDEtaDen = new THnSparseF(*aCorrFctn.fDPhiDEtaDen);
   else
@@ -100,22 +100,22 @@ AliFemtoCorrFctnDEtaDPhiTHn::AliFemtoCorrFctnDEtaDPhiTHn(const AliFemtoCorrFctnD
     Int_t   pT2Bins=1;
     Int_t   multBins=5;
     Int_t   zvtxBins=10;
-   
+
     const Int_t nbins[] = {aPhiBins,aEtaBins,pT1Bins,pT2Bins,multBins,zvtxBins};
     const Double_t xmin[] = {fphiL,-2,0,0,0,-10};
     const Double_t xmax[] = {fphiT,2,4,4,100,10};
-  
+
     // set up numerator
     char tTitNumD[101] = "NumDPhiDEta";
     strncat(tTitNumD,title, 100);
     fDPhiDEtaNum = new THnSparseF(tTitNumD,title,6,nbins,xmin,xmax);
-  
+
     // set up denominator
     char tTitDenD[101] = "DenDPhiDEta";
     strncat(tTitDenD,title, 100);
     fDPhiDEtaDen = new THnSparseF(tTitDenD,title,6,nbins,xmin,xmax);
-     
-    
+
+
   fphiL = aCorrFctn.fphiL;
   fphiT = aCorrFctn.fphiT;
 
@@ -141,16 +141,16 @@ AliFemtoCorrFctnDEtaDPhiTHn& AliFemtoCorrFctnDEtaDPhiTHn::operator=(const AliFem
     Int_t   pT2Bins=1;
     Int_t   multBins=5;
     Int_t   zvtxBins=10;
-   
+
     const Int_t nbins[] = {aPhiBins,aEtaBins,pT1Bins,pT2Bins,multBins,zvtxBins};
     const Double_t xmin[] = {fphiL,-2,0,0,0,-10};
     const Double_t xmax[] = {fphiT,2,4,4,100,10};
-  
+
     // set up numerator
     char tTitNumD[101] = "NumDPhiDEta";
     strncat(tTitNumD,title, 100);
     fDPhiDEtaNum = new THnSparseF(tTitNumD,title,6,nbins,xmin,xmax);
-  
+
     // set up denominator
     char tTitDenD[101] = "DenDPhiDEta";
     strncat(tTitDenD,title, 100);
@@ -246,7 +246,7 @@ void AliFemtoCorrFctnDEtaDPhiTHn::AddRealPair( AliFemtoPair* pair){
     zvtx = pair->Track1()->V0()->Zvtx();
   }
 
-   
+
   //fDPhiDEtaNumerator->Fill(dphi, deta);
   //cout<<dphi<<" "<<deta<<" "<<pt1<<" "<<pt2<<" "<<mult<<" "<<zvtx<<endl;
   Double_t value[] = {dphi, deta, pt1, pt2, mult, zvtx};

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiTHn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiTHn.h
@@ -19,7 +19,7 @@
 
 class AliFemtoCorrFctnDEtaDPhiTHn : public AliFemtoCorrFctn {
  public:
-  AliFemtoCorrFctnDEtaDPhiTHn(char* title, const int& aPhiBins, const int& aEtaBins, const int &pT1Bins, const double &pT1min, const double &pT1max,  const int &pT2Bins, const double &pT2min, const double &pT2max,  const int &zvtxBins, const double &zvtxmin,  const double &zvtxmax, const int &multBins, const int &multmin, const int &multmax );
+  AliFemtoCorrFctnDEtaDPhiTHn(const char* title, const int& aPhiBins, const int& aEtaBins, const int &pT1Bins, const double &pT1min, const double &pT1max,  const int &pT2Bins, const double &pT2min, const double &pT2max,  const int &zvtxBins, const double &zvtxmin,  const double &zvtxmax, const int &multBins, const int &multmin, const int &multmax );
   AliFemtoCorrFctnDEtaDPhiTHn(const AliFemtoCorrFctnDEtaDPhiTHn& aCorrFctn);
   virtual ~AliFemtoCorrFctnDEtaDPhiTHn();
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiWithWeights.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiWithWeights.cxx
@@ -16,15 +16,15 @@
 #include <cstdio>
 #include <TMath.h>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoCorrFctnDEtaDPhiWithWeights)
 #endif
-  
+
 #define PIH 1.57079632679489656
 #define PIT 6.28318530717958623
 
 //____________________________
-AliFemtoCorrFctnDEtaDPhiWithWeights::AliFemtoCorrFctnDEtaDPhiWithWeights(char* title, TH2D *filter1, TH2D *filter2, const int& aPhiBins=20, const int& aEtaBins=20):
+AliFemtoCorrFctnDEtaDPhiWithWeights::AliFemtoCorrFctnDEtaDPhiWithWeights(const char* title, TH2D *filter1, TH2D *filter2, const int& aPhiBins=20, const int& aEtaBins=20):
   AliFemtoCorrFctn(),
   fDPhiDEtaNumerator(0),
   fDPhiDEtaDenominator(0),
@@ -95,7 +95,7 @@ AliFemtoCorrFctnDEtaDPhiWithWeights::AliFemtoCorrFctnDEtaDPhiWithWeights(char* t
   char tTitEta[101] = "Eta";
   strncat(tTitEta,title, 100);
   fEta = new TH1D(tTitEta,title,500,-5.0,5.0);
-    
+
 
   // THnSparse(const char* name, const char* title, Int_t dim,
   //           const Int_t* nbins, const Double_t* xmin, const Double_t* xmax,
@@ -204,35 +204,35 @@ AliFemtoCorrFctnDEtaDPhiWithWeights::AliFemtoCorrFctnDEtaDPhiWithWeights(const A
 
  if (aCorrFctn.fYtYtNumerator)
    fYtYtNumerator = new TH2D(*aCorrFctn.fDPhiDEtaDenominator);
- else 
+ else
    fYtYtNumerator = 0;
 
  if (aCorrFctn.fYtYtDenominator)
    fYtYtDenominator = new TH2D(*aCorrFctn.fDPhiDEtaDenominator);
- else 
+ else
    fYtYtDenominator = 0;
-   
+
  if (aCorrFctn.fYPtWeightsParticle1)
    fYPtWeightsParticle1 = new TH2D(*aCorrFctn.fYPtWeightsParticle1);
- else 
+ else
    fYPtWeightsParticle1 = 0;
-   
+
  if (aCorrFctn.fYPtWeightsParticle2)
    fYPtWeightsParticle2 = new TH2D(*aCorrFctn.fYPtWeightsParticle2);
- else 
-   fYPtWeightsParticle2 = 0; 
+ else
+   fYPtWeightsParticle2 = 0;
 
   fphiL = aCorrFctn.fphiL;
   fphiT = aCorrFctn.fphiT;
 
 //  if (aCorrFctn.fPtCorrectionsNum)
 //    fPtCorrectionsNum = new THnSparseF(*aCorrFctn.fPtCorrectionsNum);
-//    else 
+//    else
 //    fPtCorrectionsNum = 0;
 
 // if (aCorrFctn.fPtCorrectionsDen)
 //    fPtCorrectionsDen = new THnSparseF(*aCorrFctn.fPtCorrectionsDen);
-//  else 
+//  else
 //    fPtCorrectionsDen = 0;
 
 
@@ -270,7 +270,7 @@ AliFemtoCorrFctnDEtaDPhiWithWeights::~AliFemtoCorrFctnDEtaDPhiWithWeights(){
   delete fEtaCorrectionsDen;
   if(fYPtWeightsParticle1) delete fYPtWeightsParticle1;
   if(fYPtWeightsParticle2) delete fYPtWeightsParticle2;
- 
+
 }
 //_________________________
 AliFemtoCorrFctnDEtaDPhiWithWeights& AliFemtoCorrFctnDEtaDPhiWithWeights::operator=(const AliFemtoCorrFctnDEtaDPhiWithWeights& aCorrFctn)
@@ -339,22 +339,22 @@ AliFemtoCorrFctnDEtaDPhiWithWeights& AliFemtoCorrFctnDEtaDPhiWithWeights::operat
 
  if (aCorrFctn.fYtYtNumerator)
    fYtYtNumerator = new TH2D(*aCorrFctn.fDPhiDEtaDenominator);
- else 
+ else
    fYtYtNumerator = 0;
 
  if (aCorrFctn.fYtYtDenominator)
    fYtYtDenominator = new TH2D(*aCorrFctn.fDPhiDEtaDenominator);
- else 
+ else
    fYtYtDenominator = 0;
 
  if (aCorrFctn.fYPtWeightsParticle1)
    fYPtWeightsParticle1 = new TH2D(*aCorrFctn.fYPtWeightsParticle1);
- else 
+ else
    fYPtWeightsParticle1 = 0;
 
  if (aCorrFctn.fYPtWeightsParticle2)
    fYPtWeightsParticle2 = new TH2D(*aCorrFctn.fYPtWeightsParticle2);
- else 
+ else
    fYPtWeightsParticle2 = 0;
  fIfCorrectionHist = kNone;
 
@@ -363,12 +363,12 @@ AliFemtoCorrFctnDEtaDPhiWithWeights& AliFemtoCorrFctnDEtaDPhiWithWeights::operat
 
 // if (aCorrFctn.fPtCorrectionsNum)
 //    fPtCorrectionsNum = new THnSparseF(*aCorrFctn.fPtCorrectionsNum);
-//  else 
+//  else
 //    fPtCorrectionsNum = 0;
 
 // if (aCorrFctn.fPtCorrectionsDen)
 //    fPtCorrectionsDen = new THnSparseF(*aCorrFctn.fPtCorrectionsDen);
-//  else 
+//  else
 //    fPtCorrectionsDen = 0;
 
 
@@ -402,11 +402,11 @@ AliFemtoString AliFemtoCorrFctnDEtaDPhiWithWeights::Report(){
 }
 //____________________________
 void AliFemtoCorrFctnDEtaDPhiWithWeights::AddRealPair( AliFemtoPair* pair){
-	
+
   // add real (effect) pair
   if (fPairCut)
     if (!fPairCut->Pass(pair)) return;
-  
+
 
   /*double phi1 = pair->Track1()->Track()->P().Phi();
     double phi2 = pair->Track2()->Track()->P().Phi();
@@ -436,7 +436,7 @@ void AliFemtoCorrFctnDEtaDPhiWithWeights::AddRealPair( AliFemtoPair* pair){
   double pt2 = TMath::Hypot(px2, py2);
   //   double ptmin = pt1>pt2 ? pt2 : pt1;
   fPtSumDist->Fill(pt1+pt2);
-  
+
   double y1 = pair->Track1()->FourMomentum().Rapidity();
   double y2 = pair->Track2()->FourMomentum().Rapidity();
   //   double cosphi = (px1*px2 + py1*py2 + pz1*pz2)/
@@ -461,7 +461,7 @@ void AliFemtoCorrFctnDEtaDPhiWithWeights::AddRealPair( AliFemtoPair* pair){
   fPhi->Fill(phi1, weight1);
   fEta->Fill(eta1, weight1);
 
- 
+
   if(fIfCorrectionHist)
     {
       if(fIfCorrectionHist == kPt){
@@ -500,7 +500,7 @@ void AliFemtoCorrFctnDEtaDPhiWithWeights::AddMixedPair( AliFemtoPair* pair){
 
   double y1 = pair->Track1()->FourMomentum().Rapidity();
   double y2 = pair->Track2()->FourMomentum().Rapidity();
-  
+
   double px1Mix = pair->Track1()->Track()->P().x();
   double py1Mix = pair->Track1()->Track()->P().y();
   //double pz1 = pair->Track1()->Track()->P().z();
@@ -514,14 +514,14 @@ void AliFemtoCorrFctnDEtaDPhiWithWeights::AddMixedPair( AliFemtoPair* pair){
 
   double weight1 = fYPtWeightsParticle1->GetBinContent(fYPtWeightsParticle1->FindBin(y1, pt1Mix));
   double weight2 = fYPtWeightsParticle2->GetBinContent(fYPtWeightsParticle2->FindBin(y2, pt2Mix));
- 
+
 
   fDPhiDEtaDenominator->Fill(dphi, deta, weight1 * weight2);
 
     double px1 = pair->Track1()->Track()->P().x();
     double py1 = pair->Track1()->Track()->P().y();
     //double pz1 = pair->Track1()->Track()->P().z();
-    
+
     double px2 = pair->Track2()->Track()->P().x();
     double py2 = pair->Track2()->Track()->P().y();
     //double pz2 = pair->Track2()->Track()->P().z();
@@ -585,7 +585,7 @@ void AliFemtoCorrFctnDEtaDPhiWithWeights::WriteHistos()
   }
   fPhi->Write();
   fEta->Write();
-  
+
   if(fIfCorrectionHist){
     if(fIfCorrectionHist==kPt){
     fPtCorrectionsNum->Write();
@@ -637,7 +637,7 @@ TList* AliFemtoCorrFctnDEtaDPhiWithWeights::GetOutputList()
 void AliFemtoCorrFctnDEtaDPhiWithWeights::SetDoPtAnalysis(int do2d)
 {
   fDoPtAnalysis = do2d;
-  
+
   int aPhiBins = fDPhiDEtaNumerator->GetNbinsX();
   int aEtaBins = fDPhiDEtaNumerator->GetNbinsY();
   const char *title = fDPhiDEtaNumerator->GetTitle();
@@ -677,7 +677,7 @@ void AliFemtoCorrFctnDEtaDPhiWithWeights::SetDoPtAnalysis(int do2d)
   fDPhiPtDenominator->Sumw2();
   fDCosPtNumerator->Sumw2();
   fDCosPtDenominator->Sumw2();
-  
+
 }
 
 void AliFemtoCorrFctnDEtaDPhiWithWeights::SetDo4DCorrectionHist(CorrectionType doCorr)

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiWithWeights.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiWithWeights.h
@@ -21,7 +21,7 @@ public:
   enum CorrectionType {kNone=0, kPt=1, kEta=2};
   typedef enum CorrectionType ReadCorrectionType;
 
-  AliFemtoCorrFctnDEtaDPhiWithWeights(char* title, TH2D *filter1, TH2D *filter2, const int& aPhiBins, const int& aEtaBins);
+  AliFemtoCorrFctnDEtaDPhiWithWeights(const char* title, TH2D *filter1, TH2D *filter2, const int& aPhiBins, const int& aEtaBins);
   AliFemtoCorrFctnDEtaDPhiWithWeights(const AliFemtoCorrFctnDEtaDPhiWithWeights& aCorrFctn);
   virtual ~AliFemtoCorrFctnDEtaDPhiWithWeights();
 
@@ -38,7 +38,7 @@ public:
   void WriteHistos();
   virtual TList* GetOutputList();
 private:
-  
+
   TH2D *fDPhiDEtaNumerator;          // Numerator of dEta dPhi function
   TH2D *fDPhiDEtaDenominator;        // Denominator of dEta dPhi function
 
@@ -61,12 +61,12 @@ private:
   TH1D *fPtSumDist;
 
   TH2D *fYtYtNumerator;
-  TH2D *fYtYtDenominator; 
-  
+  TH2D *fYtYtDenominator;
+
   TH2D *fYPtWeightsParticle1;
   TH2D *fYPtWeightsParticle2;
-  
-  
+
+
   CorrectionType fIfCorrectionHist;
   THnSparseF *fPtCorrectionsNum;
   THnSparseF *fPtCorrectionsDen;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDYDPhi.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDYDPhi.cxx
@@ -15,15 +15,15 @@
 #include <cstdio>
 #include <TMath.h>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoCorrFctnDYDPhi)
 #endif
-  
+
 #define PIH 1.57079632679489656
 #define PIT 6.28318530717958623
 
 //____________________________
-AliFemtoCorrFctnDYDPhi::AliFemtoCorrFctnDYDPhi(char* title, const int& aPhiBins=20, const int& aYBins=20, const double& mass=0):
+AliFemtoCorrFctnDYDPhi::AliFemtoCorrFctnDYDPhi(const char* title, const int& aPhiBins=20, const int& aYBins=20, const double& mass=0):
   AliFemtoCorrFctn(),
   fDPhiDYNumerator(0),
   fDPhiDYDenominator(0),
@@ -94,7 +94,7 @@ AliFemtoCorrFctnDYDPhi::AliFemtoCorrFctnDYDPhi(char* title, const int& aPhiBins=
   char tTitY[101] = "Y";
   strncat(tTitY,title, 100);
   fY = new TH1D(tTitY,title,90,-1.2,1.2);
-  
+
   // set up numerator
   char tTitYtNum[101] = "NumYtYt";
   strncat(tTitYtNum,title, 100);
@@ -237,12 +237,12 @@ AliFemtoCorrFctnDYDPhi::AliFemtoCorrFctnDYDPhi(const AliFemtoCorrFctnDYDPhi& aCo
 
  if (aCorrFctn.fYtYtNumerator)
    fYtYtNumerator = new TH2D(*aCorrFctn.fDPhiDYDenominator);
- else 
+ else
    fYtYtNumerator = 0;
 
  if (aCorrFctn.fYtYtDenominator)
    fYtYtDenominator = new TH2D(*aCorrFctn.fDPhiDYDenominator);
- else 
+ else
    fYtYtDenominator = 0;
 
   fphiL = aCorrFctn.fphiL;
@@ -251,12 +251,12 @@ AliFemtoCorrFctnDYDPhi::AliFemtoCorrFctnDYDPhi(const AliFemtoCorrFctnDYDPhi& aCo
 
 //  if (aCorrFctn.fPtCorrectionsNum)
 //    fPtCorrectionsNum = new THnSparseF(*aCorrFctn.fPtCorrectionsNum);
-//    else 
+//    else
 //    fPtCorrectionsNum = 0;
 
 // if (aCorrFctn.fPtCorrectionsDen)
 //    fPtCorrectionsDen = new THnSparseF(*aCorrFctn.fPtCorrectionsDen);
-//  else 
+//  else
 //    fPtCorrectionsDen = 0;
 
 
@@ -358,12 +358,12 @@ AliFemtoCorrFctnDYDPhi& AliFemtoCorrFctnDYDPhi::operator=(const AliFemtoCorrFctn
 
  if (aCorrFctn.fYtYtNumerator)
    fYtYtNumerator = new TH2D(*aCorrFctn.fDPhiDYDenominator);
- else 
+ else
    fYtYtNumerator = 0;
 
  if (aCorrFctn.fYtYtDenominator)
    fYtYtDenominator = new TH2D(*aCorrFctn.fDPhiDYDenominator);
- else 
+ else
    fYtYtDenominator = 0;
 
  fIfCorrectionHist = kNone;
@@ -374,12 +374,12 @@ AliFemtoCorrFctnDYDPhi& AliFemtoCorrFctnDYDPhi::operator=(const AliFemtoCorrFctn
 
 // if (aCorrFctn.fPtCorrectionsNum)
 //    fPtCorrectionsNum = new THnSparseF(*aCorrFctn.fPtCorrectionsNum);
-//  else 
+//  else
 //    fPtCorrectionsNum = 0;
 
 // if (aCorrFctn.fPtCorrectionsDen)
 //    fPtCorrectionsDen = new THnSparseF(*aCorrFctn.fPtCorrectionsDen);
-//  else 
+//  else
 //    fPtCorrectionsDen = 0;
 
 
@@ -573,7 +573,7 @@ void AliFemtoCorrFctnDYDPhi::WriteHistos()
   }
   fPhi->Write();
   fY->Write();
-  
+
   if(fIfCorrectionHist){
     if(fIfCorrectionHist==kPt){
     fPtCorrectionsNum->Write();
@@ -624,7 +624,7 @@ TList* AliFemtoCorrFctnDYDPhi::GetOutputList()
 void AliFemtoCorrFctnDYDPhi::SetDoPtAnalysis(int do2d)
 {
   fDoPtAnalysis = do2d;
-  
+
   int aPhiBins = fDPhiDYNumerator->GetNbinsX();
   const char *title = fDPhiDYNumerator->GetTitle();
 
@@ -650,7 +650,7 @@ void AliFemtoCorrFctnDYDPhi::SetDoPtAnalysis(int do2d)
   fDPhiPtDenominator->Sumw2();
   fDCosPtNumerator->Sumw2();
   fDCosPtDenominator->Sumw2();
-  
+
 }
 
 void AliFemtoCorrFctnDYDPhi::SetDo4DCorrectionHist(CorrectionType doCorr)

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDYDPhi.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDYDPhi.h
@@ -22,7 +22,7 @@ public:
   enum CorrectionType {kNone=0, kPt=1, kY=2};
   typedef enum CorrectionType ReadCorrectionType;
 
-  AliFemtoCorrFctnDYDPhi(char* title, const int& aPhiBins, const int& aYBins, const double& mass);
+  AliFemtoCorrFctnDYDPhi(const char* title, const int& aPhiBins, const int& aYBins, const double& mass);
   AliFemtoCorrFctnDYDPhi(const AliFemtoCorrFctnDYDPhi& aCorrFctn);
   virtual ~AliFemtoCorrFctnDYDPhi();
 
@@ -39,7 +39,7 @@ public:
   void WriteHistos();
   virtual TList* GetOutputList();
 private:
-  
+
   TH2D *fDPhiDYNumerator;            // Numerator of dY dPhi function
   TH2D *fDPhiDYDenominator;          // Denominator of dY dPhi function
 
@@ -62,7 +62,7 @@ private:
   TH1D *fPtSumDist;
 
   TH2D *fYtYtNumerator;
-  TH2D *fYtYtDenominator; 
+  TH2D *fYtYtDenominator;
 
   CorrectionType fIfCorrectionHist;
   THnSparseF *fPtCorrectionsNum;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDYDPhiSimple.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDYDPhiSimple.cxx
@@ -15,15 +15,15 @@
 #include <cstdio>
 #include <TMath.h>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoCorrFctnDYDPhiSimple)
 #endif
-  
+
 #define PIH 1.57079632679489656
 #define PIT 6.28318530717958623
 
 //____________________________
-AliFemtoCorrFctnDYDPhiSimple::AliFemtoCorrFctnDYDPhiSimple(char* title, const int& aPhiBins=20, const int& aYBins=20, const double& mass1=0, const double& mass2=0):
+AliFemtoCorrFctnDYDPhiSimple::AliFemtoCorrFctnDYDPhiSimple(const char* title, const int& aPhiBins=20, const int& aYBins=20, const double& mass1=0, const double& mass2=0):
   AliFemtoCorrFctn(),
   fDPhiDYNumerator(0),
   fDPhiDYDenominator(0),
@@ -57,7 +57,7 @@ AliFemtoCorrFctnDYDPhiSimple::AliFemtoCorrFctnDYDPhiSimple(char* title, const in
   char tTitY[101] = "Y";
   strncat(tTitY,title, 100);
   fY = new TH1D(tTitY,title,90,-1.2,1.2);
-  
+
 
   // to enable error bar calculation...
   fDPhiDYNumerator->Sumw2();
@@ -111,7 +111,7 @@ AliFemtoCorrFctnDYDPhiSimple::~AliFemtoCorrFctnDYDPhiSimple(){
   // destructor
   delete fDPhiDYNumerator;
   delete fDPhiDYDenominator;
-  
+
   delete fPhi;
   delete fY;
 
@@ -262,7 +262,7 @@ void AliFemtoCorrFctnDYDPhiSimple::WriteHistos()
 
   fPhi->Write();
   fY->Write();
-  
+
 }
 
 TList* AliFemtoCorrFctnDYDPhiSimple::GetOutputList()

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDYDPhiSimple.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDYDPhiSimple.h
@@ -19,7 +19,7 @@
 
 class AliFemtoCorrFctnDYDPhiSimple : public AliFemtoCorrFctn {
 public:
-  AliFemtoCorrFctnDYDPhiSimple(char* title, const int& aPhiBins, const int& aYBins, const double& mass1, const double& mass2);
+  AliFemtoCorrFctnDYDPhiSimple(const char* title, const int& aPhiBins, const int& aYBins, const double& mass1, const double& mass2);
   AliFemtoCorrFctnDYDPhiSimple(const AliFemtoCorrFctnDYDPhiSimple& aCorrFctn);
   virtual ~AliFemtoCorrFctnDYDPhiSimple();
 
@@ -34,7 +34,7 @@ public:
   void WriteHistos();
   virtual TList* GetOutputList();
 private:
-  
+
   TH2D *fDPhiDYNumerator;            // Numerator of dY dPhi function
   TH2D *fDPhiDYDenominator;          // Denominator of dY dPhi function
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnGammaMonitor.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnGammaMonitor.cxx
@@ -13,12 +13,12 @@
 #include <cstdio>
 #include <TMath.h>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoCorrFctnGammaMonitor)
 #endif
 
 //____________________________
-AliFemtoCorrFctnGammaMonitor::AliFemtoCorrFctnGammaMonitor(char* title, const int& aMinvBins=20, const int& aDThetaBins=20):
+AliFemtoCorrFctnGammaMonitor::AliFemtoCorrFctnGammaMonitor(const char* title, const int& aMinvBins=20, const int& aDThetaBins=20):
   AliFemtoCorrFctn(),
   fNumPMinvDTheta(0),
   fDenPMinvDTheta(0),
@@ -151,12 +151,12 @@ void AliFemtoCorrFctnGammaMonitor::AddRealPair( AliFemtoPair* pair){
   double e1 = TMath::Sqrt(me*me + pair->Track1()->Track()->P().Mag2());
   double e2 = TMath::Sqrt(me*me + pair->Track2()->Track()->P().Mag2());
 
-  double minv = 2*me*me + 2*(e1*e2 - 
+  double minv = 2*me*me + 2*(e1*e2 -
 			     pair->Track1()->Track()->P().x()*pair->Track2()->Track()->P().x() -
 			     pair->Track1()->Track()->P().y()*pair->Track2()->Track()->P().y() -
 			     pair->Track1()->Track()->P().z()*pair->Track2()->Track()->P().z());
 
-  if (pair->KSide()>0.0) 
+  if (pair->KSide()>0.0)
     fNumPMinvDTheta->Fill(minv, dtheta);
   else
     fNumNMinvDTheta->Fill(minv, dtheta);
@@ -173,12 +173,12 @@ void AliFemtoCorrFctnGammaMonitor::AddMixedPair( AliFemtoPair* pair){
   double e1 = TMath::Sqrt(me*me + pair->Track1()->Track()->P().Mag2());
   double e2 = TMath::Sqrt(me*me + pair->Track2()->Track()->P().Mag2());
 
-  double minv = 2*me*me + 2*(e1*e2 - 
+  double minv = 2*me*me + 2*(e1*e2 -
 			     pair->Track1()->Track()->P().x()*pair->Track2()->Track()->P().x() -
 			     pair->Track1()->Track()->P().y()*pair->Track2()->Track()->P().y() -
 			     pair->Track1()->Track()->P().z()*pair->Track2()->Track()->P().z());
 
-  if (pair->KSide()>0.0) 
+  if (pair->KSide()>0.0)
     fDenPMinvDTheta->Fill(minv, dtheta);
   else
     fDenNMinvDTheta->Fill(minv, dtheta);

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnGammaMonitor.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnGammaMonitor.h
@@ -17,7 +17,7 @@
 
 class AliFemtoCorrFctnGammaMonitor : public AliFemtoCorrFctn {
 public:
-  AliFemtoCorrFctnGammaMonitor(char* title, const int& aMinvBins, const int& aDThetaBins);
+  AliFemtoCorrFctnGammaMonitor(const char* title, const int& aMinvBins, const int& aDThetaBins);
   AliFemtoCorrFctnGammaMonitor(const AliFemtoCorrFctnGammaMonitor& aCorrFctn);
   virtual ~AliFemtoCorrFctnGammaMonitor();
 
@@ -32,7 +32,7 @@ public:
   void WriteHistos();
   virtual TList* GetOutputList();
 private:
-  
+
   TH2D *fNumPMinvDTheta;        // Numerator Minv vs. DTheta Positive kSide
   TH2D *fDenPMinvDTheta;        // Denominator Minv vs. DTheta Positive kSide
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnGammaMonitorAlpha.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnGammaMonitorAlpha.cxx
@@ -13,12 +13,12 @@
 #include <cstdio>
 #include <TMath.h>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoCorrFctnGammaMonitorAlpha)
 #endif
 
 //____________________________
-AliFemtoCorrFctnGammaMonitorAlpha::AliFemtoCorrFctnGammaMonitorAlpha(char* title, const int& aMinvBins=20, const int& aDAlphaBins=20):
+AliFemtoCorrFctnGammaMonitorAlpha::AliFemtoCorrFctnGammaMonitorAlpha(const char* title, const int& aMinvBins=20, const int& aDAlphaBins=20):
   AliFemtoCorrFctn(),
   fNumPMinvDAlpha(0),
   fDenPMinvDAlpha(0),
@@ -151,7 +151,7 @@ void AliFemtoCorrFctnGammaMonitorAlpha::AddRealPair( AliFemtoPair* pair){
   double e1 = TMath::Sqrt(me*me + pair->Track1()->Track()->P().Mag2());
   double e2 = TMath::Sqrt(me*me + pair->Track2()->Track()->P().Mag2());
 
-  double minv = (2*me*me + 2*(e1*e2 - 
+  double minv = (2*me*me + 2*(e1*e2 -
 			     pair->Track1()->Track()->P().x()*pair->Track2()->Track()->P().x() -
 			     pair->Track1()->Track()->P().y()*pair->Track2()->Track()->P().y() -
 					 pair->Track1()->Track()->P().z()*pair->Track2()->Track()->P().z()));
@@ -178,7 +178,7 @@ void AliFemtoCorrFctnGammaMonitorAlpha::AddMixedPair( AliFemtoPair* pair){
   double e1 = TMath::Sqrt(me*me + pair->Track1()->Track()->P().Mag2());
   double e2 = TMath::Sqrt(me*me + pair->Track2()->Track()->P().Mag2());
 
-  double minv = (2*me*me + 2*(e1*e2 - 
+  double minv = (2*me*me + 2*(e1*e2 -
 			     pair->Track1()->Track()->P().x()*pair->Track2()->Track()->P().x() -
 			     pair->Track1()->Track()->P().y()*pair->Track2()->Track()->P().y() -
 					 pair->Track1()->Track()->P().z()*pair->Track2()->Track()->P().z()));

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnGammaMonitorAlpha.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnGammaMonitorAlpha.h
@@ -17,7 +17,7 @@
 
 class AliFemtoCorrFctnGammaMonitorAlpha : public AliFemtoCorrFctn {
 public:
-  AliFemtoCorrFctnGammaMonitorAlpha(char* title, const int& aMinvBins, const int& aDAlphaBins);
+  AliFemtoCorrFctnGammaMonitorAlpha(const char* title, const int& aMinvBins, const int& aDAlphaBins);
   AliFemtoCorrFctnGammaMonitorAlpha(const AliFemtoCorrFctnGammaMonitorAlpha& aCorrFctn);
   virtual ~AliFemtoCorrFctnGammaMonitorAlpha();
 
@@ -32,7 +32,7 @@ public:
   void WriteHistos();
   virtual TList* GetOutputList();
 private:
-  
+
   TH2D *fNumPMinvDAlpha;        // Numerator Minv vs. DAlpha Positive kSide
   TH2D *fDenPMinvDAlpha;        // Denominator Minv vs. DAlpha Positive kSide
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnMinvMonitor.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnMinvMonitor.cxx
@@ -17,7 +17,7 @@ ClassImp(AliFemtoCorrFctnMinvMonitor)
 #endif
 
 //____________________________
-AliFemtoCorrFctnMinvMonitor::AliFemtoCorrFctnMinvMonitor(char* title):
+AliFemtoCorrFctnMinvMonitor::AliFemtoCorrFctnMinvMonitor(const char* title):
    AliFemtoCorrFctn(),
    fMinveeFail(0),
    fMinvee(0),

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnMinvMonitor.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnMinvMonitor.h
@@ -16,7 +16,7 @@
 
 class AliFemtoCorrFctnMinvMonitor : public AliFemtoCorrFctn {
 public:
-  AliFemtoCorrFctnMinvMonitor(char* title);
+  AliFemtoCorrFctnMinvMonitor(const char* title);
   AliFemtoCorrFctnMinvMonitor(const AliFemtoCorrFctnMinvMonitor& aCorrFctn);
   virtual ~AliFemtoCorrFctnMinvMonitor();
 
@@ -30,7 +30,7 @@ public:
   void WriteHistos();
   virtual TList* GetOutputList();
 private:
-  
+
   TH1D *fMinveeFail;   // ee mass assumption - failed pairs
   TH1D *fMinvee;   // ee mass assumption - passed pairs
   TH1D *fMinv2piFail;   // 2 pi mass assumption - failed pairs

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnPairFractions.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnPairFractions.cxx
@@ -24,7 +24,7 @@
 #define PIT 6.28318530717958623
 
 //____________________________
-AliFemtoCorrFctnPairFractions::AliFemtoCorrFctnPairFractions(char* title):
+AliFemtoCorrFctnPairFractions::AliFemtoCorrFctnPairFractions(const char* title):
 AliFemtoCorrFctn(),
   fPairFractions(0),
   fPairFractionsDen(0),

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnPairFractions.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnPairFractions.h
@@ -21,7 +21,7 @@ public:
   enum CorrectionType {kNone=0, kPt=1, kEta=2};
   typedef enum CorrectionType ReadCorrectionType;
 
-  AliFemtoCorrFctnPairFractions(char* title);
+  AliFemtoCorrFctnPairFractions(const char* title);
   AliFemtoCorrFctnPairFractions(const AliFemtoCorrFctnPairFractions& aCorrFctn);
   virtual ~AliFemtoCorrFctnPairFractions();
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnTPCNcls.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnTPCNcls.cxx
@@ -11,12 +11,12 @@
 //#include "AliFemtoHisto.hh"
 #include <cstdio>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoCorrFctnTPCNcls)
 #endif
 
 //____________________________
-AliFemtoCorrFctnTPCNcls::AliFemtoCorrFctnTPCNcls(char* title, const int& nbins, const float& QinvLo, const float& QinvHi):
+AliFemtoCorrFctnTPCNcls::AliFemtoCorrFctnTPCNcls(const char* title, const int& nbins, const float& QinvLo, const float& QinvHi):
   AliFemtoCorrFctn(),
   fNclsTPCMinNumerator(0),
   fNclsTPCMinDenominator(0)
@@ -132,7 +132,7 @@ TList* AliFemtoCorrFctnTPCNcls::GetOutputList()
 
   tOutputList->Add(fNclsTPCMinNumerator);
   tOutputList->Add(fNclsTPCMinDenominator);
-  
+
   return tOutputList;
 
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnTPCNcls.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnTPCNcls.h
@@ -16,7 +16,7 @@
 
 class AliFemtoCorrFctnTPCNcls : public AliFemtoCorrFctn {
 public:
-  AliFemtoCorrFctnTPCNcls(char* title, const int& nbins, const float& QinvLo, const float& QinvHi);
+  AliFemtoCorrFctnTPCNcls(const char* title, const int& nbins, const float& QinvLo, const float& QinvHi);
   AliFemtoCorrFctnTPCNcls(const AliFemtoCorrFctnTPCNcls& aCorrFctn);
   virtual ~AliFemtoCorrFctnTPCNcls();
 
@@ -31,8 +31,8 @@ public:
   void WriteHistos();
   virtual TList* GetOutputList();
 private:
-  
-  TH2D *fNclsTPCMinNumerator;        // Numerator as a function of lower TPC Ncls of the pair 
+
+  TH2D *fNclsTPCMinNumerator;        // Numerator as a function of lower TPC Ncls of the pair
   TH2D *fNclsTPCMinDenominator;      // Denominator as a function of lower TPC Ncls of the pair
 
 #ifdef __ROOT__

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelBPLCMSCorrFctn.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelBPLCMSCorrFctn.cxx
@@ -18,7 +18,7 @@ ClassImp(AliFemtoModelBPLCMSCorrFctn)
 #endif
 
 //____________________________
-AliFemtoModelBPLCMSCorrFctn::AliFemtoModelBPLCMSCorrFctn(char* title, const int& nbins, const float& QLo, const float& QHi)
+AliFemtoModelBPLCMSCorrFctn::AliFemtoModelBPLCMSCorrFctn(const char* title, const int& nbins, const float& QLo, const float& QHi)
   :
   AliFemtoModelCorrFctn(title, nbins, QLo, QHi),
   fNumerator3DTrue(0),

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelBPLCMSCorrFctn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelBPLCMSCorrFctn.h
@@ -24,7 +24,7 @@ class AliFemtoModelBPLCMSCorrFctn : public AliFemtoModelCorrFctn {
     fQinvHisto(0),
     fPairCut(0),
     fUseRPSelection(0){}
-  AliFemtoModelBPLCMSCorrFctn(char* title, const int& nbins, const float& QLo, const float& QHi);
+  AliFemtoModelBPLCMSCorrFctn(const char* title, const int& nbins, const float& QLo, const float& QHi);
   AliFemtoModelBPLCMSCorrFctn(const AliFemtoModelBPLCMSCorrFctn& aCorrFctn);
   virtual ~AliFemtoModelBPLCMSCorrFctn();
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelBPLCMSCorrFctnKK.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelBPLCMSCorrFctnKK.cxx
@@ -18,7 +18,7 @@ ClassImp(AliFemtoModelBPLCMSCorrFctnKK)
 #endif
 
 //____________________________
-AliFemtoModelBPLCMSCorrFctnKK::AliFemtoModelBPLCMSCorrFctnKK(char* title, const int& nbins, const float& QLo, const float& QHi)
+AliFemtoModelBPLCMSCorrFctnKK::AliFemtoModelBPLCMSCorrFctnKK(const char* title, const int& nbins, const float& QLo, const float& QHi)
   :
   AliFemtoModelCorrFctn(title, nbins, QLo, QHi),
   fNumerator3DTrue(0),

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelBPLCMSCorrFctnKK.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelBPLCMSCorrFctnKK.h
@@ -27,7 +27,7 @@ class AliFemtoModelBPLCMSCorrFctnKK : public AliFemtoModelCorrFctn {
     fNumerator3DTrueIdeal(0),
     fNumerator3DFakeIdeal(0),
     fDenominator3DIdeal(0){}
-  AliFemtoModelBPLCMSCorrFctnKK(char* title, const int& nbins, const float& QLo, const float& QHi);
+  AliFemtoModelBPLCMSCorrFctnKK(const char* title, const int& nbins, const float& QLo, const float& QHi);
   AliFemtoModelBPLCMSCorrFctnKK(const AliFemtoModelBPLCMSCorrFctnKK& aCorrFctn);
   virtual ~AliFemtoModelBPLCMSCorrFctnKK();
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctn3DLCMSSpherical.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctn3DLCMSSpherical.cxx
@@ -13,12 +13,12 @@
 #include <TMath.h>
 #include <cstdio>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoModelCorrFctn3DLCMSSpherical)
 #endif
 
 //____________________________
-  AliFemtoModelCorrFctn3DLCMSSpherical::AliFemtoModelCorrFctn3DLCMSSpherical(char* title, const int& nqbins, const float& QLo, const float& QHi, const int& nphibins, const int& ncthetabins):
+  AliFemtoModelCorrFctn3DLCMSSpherical::AliFemtoModelCorrFctn3DLCMSSpherical(const char* title, const int& nqbins, const float& QLo, const float& QHi, const int& nphibins, const int& ncthetabins):
   fTrueNumeratorSph(0),
   fFakeNumeratorSph(0),
   fDenominatorSph(0),
@@ -76,9 +76,9 @@ AliFemtoModelCorrFctn3DLCMSSpherical& AliFemtoModelCorrFctn3DLCMSSpherical::oper
   fFakeNumeratorSph = new TH3D(*aCorrFctn.fFakeNumeratorSph);
   if (fDenominatorSph) delete fDenominatorSph;
   fDenominatorSph = new TH3D(*aCorrFctn.fDenominatorSph);
-  
+
   fPairCut = aCorrFctn.fPairCut;
-  
+
   return *this;
 }
 
@@ -95,9 +95,9 @@ TList* AliFemtoModelCorrFctn3DLCMSSpherical::GetOutputList()
   // Prepare the list of objects to be written to the output
   TList *tOutputList = new TList();
 
-  tOutputList->Add(fTrueNumeratorSph); 
-  tOutputList->Add(fFakeNumeratorSph); 
-  tOutputList->Add(fDenominatorSph);  
+  tOutputList->Add(fTrueNumeratorSph);
+  tOutputList->Add(fFakeNumeratorSph);
+  tOutputList->Add(fDenominatorSph);
 
   return tOutputList;
 }
@@ -127,7 +127,7 @@ AliFemtoString AliFemtoModelCorrFctn3DLCMSSpherical::Report(){
     stemp += ctemp;
   }
 
-  //  
+  //
   AliFemtoString returnThis = stemp;
   return returnThis;
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctn3DLCMSSpherical.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctn3DLCMSSpherical.h
@@ -15,7 +15,7 @@
 
 class AliFemtoModelCorrFctn3DLCMSSpherical : public AliFemtoModelCorrFctn {
 public:
-  AliFemtoModelCorrFctn3DLCMSSpherical(char* title, 
+  AliFemtoModelCorrFctn3DLCMSSpherical(const char* title,
 			      const int& nqbins, const float& QLo, const float& QHi,
 			      const int& nphibins, const int& ncthetabins);
   AliFemtoModelCorrFctn3DLCMSSpherical(const AliFemtoModelCorrFctn3DLCMSSpherical& aCorrFctn);

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctn3DSpherical.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctn3DSpherical.cxx
@@ -14,12 +14,12 @@
 #include <cstdio>
 //#include <Math/SpecFunc.h>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoModelCorrFctn3DSpherical)
 #endif
 
 //____________________________
-AliFemtoModelCorrFctn3DSpherical::AliFemtoModelCorrFctn3DSpherical(char* title, const int& nqbins, const float& QLo, const float& QHi, const int& nphibins, const int& ncthetabins):
+AliFemtoModelCorrFctn3DSpherical::AliFemtoModelCorrFctn3DSpherical(const char* title, const int& nqbins, const float& QLo, const float& QHi, const int& nphibins, const int& ncthetabins):
   AliFemtoModelCorrFctn(),
   fTrueNumeratorSph(0),
   fFakeNumeratorSph(0),
@@ -78,9 +78,9 @@ AliFemtoModelCorrFctn3DSpherical& AliFemtoModelCorrFctn3DSpherical::operator=(co
   fFakeNumeratorSph = new TH3D(*aCorrFctn.fFakeNumeratorSph);
   if (fDenominatorSph) delete fDenominatorSph;
   fDenominatorSph = new TH3D(*aCorrFctn.fDenominatorSph);
-  
+
   fPairCut = aCorrFctn.fPairCut;
-  
+
   return *this;
 }
 
@@ -97,9 +97,9 @@ TList* AliFemtoModelCorrFctn3DSpherical::GetOutputList()
   // Prepare the list of objects to be written to the output
   TList *tOutputList = new TList();
 
-  tOutputList->Add(fTrueNumeratorSph); 
-  tOutputList->Add(fFakeNumeratorSph); 
-  tOutputList->Add(fDenominatorSph);  
+  tOutputList->Add(fTrueNumeratorSph);
+  tOutputList->Add(fFakeNumeratorSph);
+  tOutputList->Add(fDenominatorSph);
 
   return tOutputList;
 }
@@ -129,7 +129,7 @@ AliFemtoString AliFemtoModelCorrFctn3DSpherical::Report(){
     stemp += ctemp;
   }
 
-  //  
+  //
   AliFemtoString returnThis = stemp;
   return returnThis;
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctn3DSpherical.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctn3DSpherical.h
@@ -15,7 +15,7 @@
 
 class AliFemtoModelCorrFctn3DSpherical : public AliFemtoModelCorrFctn {
 public:
-  AliFemtoModelCorrFctn3DSpherical(char* title, 
+  AliFemtoModelCorrFctn3DSpherical(const char* title,
 			      const int& nqbins, const float& QLo, const float& QHi,
 			      const int& nphibins, const int& ncthetabins);
   AliFemtoModelCorrFctn3DSpherical(const AliFemtoModelCorrFctn3DSpherical& aCorrFctn);

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhi.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhi.cxx
@@ -13,7 +13,7 @@
 #include <cstdio>
 #include <TMath.h>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoModelCorrFctnDEtaDPhi)
 #endif
 
@@ -29,7 +29,7 @@ ClassImp(AliFemtoModelCorrFctnDEtaDPhi)
 //
 
 //____________________________
-AliFemtoModelCorrFctnDEtaDPhi::AliFemtoModelCorrFctnDEtaDPhi(char* title, const int& aPhiBins=20, const int& aEtaBins=20):
+AliFemtoModelCorrFctnDEtaDPhi::AliFemtoModelCorrFctnDEtaDPhi(const char* title, const int& aPhiBins=20, const int& aEtaBins=20):
   AliFemtoModelCorrFctn(),
   fDPhiDEtaNumeratorTrue(0),
   fDPhiDEtaNumeratorFake(0),

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhi.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhi.h
@@ -20,7 +20,7 @@
 
 class AliFemtoModelCorrFctnDEtaDPhi : public AliFemtoModelCorrFctn {
 public:
-  AliFemtoModelCorrFctnDEtaDPhi(char* title, const int& aPhiBins, const int& aEtaBins);
+  AliFemtoModelCorrFctnDEtaDPhi(const char* title, const int& aPhiBins, const int& aEtaBins);
   AliFemtoModelCorrFctnDEtaDPhi(const AliFemtoModelCorrFctnDEtaDPhi& aCorrFctn);
   virtual ~AliFemtoModelCorrFctnDEtaDPhi();
 
@@ -35,12 +35,12 @@ public:
   void WriteHistos();
   virtual TList* GetOutputList();
 private:
-  
+
   TH2D *fDPhiDEtaNumeratorTrue;      // Numerator of dEta dPhi true function
   TH2D *fDPhiDEtaNumeratorFake;      // Numerator of dEta dPhi fake function
   TH2D *fDPhiDEtaDenominator;        // Denominator of dEta dPhi function
 
-  TH2D *fDPhiDEtaColNumerator;       // Numerator of colinear dEta dPhi function 
+  TH2D *fDPhiDEtaColNumerator;       // Numerator of colinear dEta dPhi function
   TH2D *fDPhiDEtaColDenominator;     // Denominator of colinear dEta dPhi function
 
   TH1D *fDPhiNumeratorTrue;          // Numerator of dPhi true correlation

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhiRM.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhiRM.cxx
@@ -13,7 +13,7 @@
 #include <cstdio>
 #include <TMath.h>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoModelCorrFctnDEtaDPhiRM)
 #endif
 
@@ -29,7 +29,7 @@ ClassImp(AliFemtoModelCorrFctnDEtaDPhiRM)
 //
 
 //____________________________
-AliFemtoModelCorrFctnDEtaDPhiRM::AliFemtoModelCorrFctnDEtaDPhiRM(char* title, const int& aPhiBins=20, const int& aEtaBins=20, const double m1=0.13956995, const double m2=0.13956995):
+AliFemtoModelCorrFctnDEtaDPhiRM::AliFemtoModelCorrFctnDEtaDPhiRM(const char* title, const int& aPhiBins=20, const int& aEtaBins=20, const double m1=0.13956995, const double m2=0.13956995):
   AliFemtoModelCorrFctn(),
   fDPhiDEtaNumeratorTrue(0),
   fDPhiDEtaNumeratorFake(0),
@@ -125,7 +125,7 @@ AliFemtoModelCorrFctnDEtaDPhiRM::AliFemtoModelCorrFctnDEtaDPhiRM(char* title, co
   strncat(tTitNum,title, 100);
   fPtSumDist = new TH1D(tTitNum,title,200,0,10);
   fPtSumDist->Sumw2();
-  
+
   char tTitInvMass[101] = "InvariantMassDist";
   strncat(tTitInvMass,title, 100);
   fInvMassDist = new TH1D(tTitInvMass,title,2000,0,4);
@@ -464,7 +464,7 @@ void AliFemtoModelCorrFctnDEtaDPhiRM::AddRealPair( AliFemtoPair* pair){
 
   double e1 = TMath::Sqrt(fM1*fM1 + p21);
   double e2 = TMath::Sqrt(fM2*fM2 + p22);
-   
+
   double minv = TMath::Sqrt(fM1*fM1 + fM2*fM2 + 2*(e1*e2 - Invpx1*Invpx2 - Invpy1*Invpy2 - Invpz1*Invpz2));
   fInvMassDist->Fill(minv);
   // cout<<"Corr: "<<minv<<" masses "<<fM1<<" "<<fM2<<endl;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhiRM.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhiRM.h
@@ -20,7 +20,7 @@
 
 class AliFemtoModelCorrFctnDEtaDPhiRM : public AliFemtoModelCorrFctn {
 public:
-  AliFemtoModelCorrFctnDEtaDPhiRM(char* title, const int& aPhiBins, const int& aEtaBins, const double m1, const double m2);
+  AliFemtoModelCorrFctnDEtaDPhiRM(const char* title, const int& aPhiBins, const int& aEtaBins, const double m1, const double m2);
   AliFemtoModelCorrFctnDEtaDPhiRM(const AliFemtoModelCorrFctnDEtaDPhiRM& aCorrFctn);
   virtual ~AliFemtoModelCorrFctnDEtaDPhiRM();
 
@@ -35,12 +35,12 @@ public:
   void WriteHistos();
   virtual TList* GetOutputList();
 private:
-  
+
   TH2D *fDPhiDEtaNumeratorTrue;      // Numerator of dEta dPhi true function
   TH2D *fDPhiDEtaNumeratorFake;      // Numerator of dEta dPhi fake function
   TH2D *fDPhiDEtaDenominator;        // Denominator of dEta dPhi function
 
-  TH2D *fDPhiDEtaColNumerator;       // Numerator of colinear dEta dPhi function 
+  TH2D *fDPhiDEtaColNumerator;       // Numerator of colinear dEta dPhi function
   TH2D *fDPhiDEtaColDenominator;     // Denominator of colinear dEta dPhi function
 
   TH1D *fDPhiNumeratorTrue;          // Numerator of dPhi true correlation

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhiWithWeights.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhiWithWeights.cxx
@@ -14,7 +14,7 @@
 #include <TMath.h>
 #include <stdexcept>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoModelCorrFctnDEtaDPhi)
 #endif
 
@@ -30,7 +30,7 @@ ClassImp(AliFemtoModelCorrFctnDEtaDPhi)
 //
 
 //____________________________
-AliFemtoModelCorrFctnDEtaDPhiWithWeights::AliFemtoModelCorrFctnDEtaDPhiWithWeights(char* title,  TH2D* filter1,  TH2D* filter2, const int& aPhiBins=20, const int& aEtaBins=20):
+AliFemtoModelCorrFctnDEtaDPhiWithWeights::AliFemtoModelCorrFctnDEtaDPhiWithWeights(const char* title,  TH2D* filter1,  TH2D* filter2, const int& aPhiBins=20, const int& aEtaBins=20):
   AliFemtoModelCorrFctn(),
   fDPhiDEtaNumeratorTrue(0),
   fDPhiDEtaNumeratorFake(0),
@@ -119,7 +119,7 @@ AliFemtoModelCorrFctnDEtaDPhiWithWeights::AliFemtoModelCorrFctnDEtaDPhiWithWeigh
   char tTitDenDCosPt[101] = "DenDCosPt";
   strncat(tTitDenDCosPt,title, 100);
   fDCosPtDenominator = new TH2D(tTitDenDCosPt,title,aPhiBins*2,-1.0,1.0, 30, 0.0, 3.0);
-  
+
   // to enable error bar calculation...
   fDPhiDEtaNumeratorTrue->Sumw2();
   fDPhiDEtaNumeratorFake->Sumw2();

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhiWithWeights.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhiWithWeights.h
@@ -20,7 +20,7 @@
 
 class AliFemtoModelCorrFctnDEtaDPhiWithWeights : public AliFemtoModelCorrFctn {
 public:
-  AliFemtoModelCorrFctnDEtaDPhiWithWeights(char* title,  TH2D* filter1,  TH2D* filter2, const int& aPhiBins, const int& aEtaBins);
+  AliFemtoModelCorrFctnDEtaDPhiWithWeights(const char* title,  TH2D* filter1,  TH2D* filter2, const int& aPhiBins, const int& aEtaBins);
   AliFemtoModelCorrFctnDEtaDPhiWithWeights(const AliFemtoModelCorrFctnDEtaDPhiWithWeights& aCorrFctn);
   virtual ~AliFemtoModelCorrFctnDEtaDPhiWithWeights();
 
@@ -37,12 +37,12 @@ public:
 private:
   TH2D *filterHist1; //filter hisotgram used for the first particle
   TH2D *filterHist2; //filter hisotgram used for the second particle
-  
+
   TH2D *fDPhiDEtaNumeratorTrue;      // Numerator of dEta dPhi true function
   TH2D *fDPhiDEtaNumeratorFake;      // Numerator of dEta dPhi fake function
   TH2D *fDPhiDEtaDenominator;        // Denominator of dEta dPhi function
 
-  TH2D *fDPhiDEtaColNumerator;       // Numerator of colinear dEta dPhi function 
+  TH2D *fDPhiDEtaColNumerator;       // Numerator of colinear dEta dPhi function
   TH2D *fDPhiDEtaColDenominator;     // Denominator of colinear dEta dPhi function
 
   TH1D *fDPhiNumeratorTrue;          // Numerator of dPhi true correlation

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnNonIdDR.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnNonIdDR.cxx
@@ -13,30 +13,30 @@
 //#include "AliFemtoHisto.h"
 #include <cstdio>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoModelCorrFctnNonIdDR)
 #endif
 
 //____________________________
-AliFemtoModelCorrFctnNonIdDR::AliFemtoModelCorrFctnNonIdDR(char* title, const int& nbins, const float& QinvLo, const float& QinvHi):
+AliFemtoModelCorrFctnNonIdDR::AliFemtoModelCorrFctnNonIdDR(const char* title, const int& nbins, const float& QinvLo, const float& QinvHi):
   AliFemtoModelCorrFctn(title, nbins, QinvLo, QinvHi),
-  fNumTOutP(0), 
-  fNumTOutN(0),  
-  fNumTSideP(0), 
-  fNumTSideN(0), 
-  fNumTLongP(0), 
-  fNumTLongN(0), 
-  fNumFOutP(0), 
-  fNumFOutN(0),  
-  fNumFSideP(0), 
-  fNumFSideN(0), 
-  fNumFLongP(0), 
-  fNumFLongN(0), 
-  fDenOutP(0),  
-  fDenOutN(0),  
-  fDenSideP(0), 
-  fDenSideN(0), 
-  fDenLongP(0), 
+  fNumTOutP(0),
+  fNumTOutN(0),
+  fNumTSideP(0),
+  fNumTSideN(0),
+  fNumTLongP(0),
+  fNumTLongN(0),
+  fNumFOutP(0),
+  fNumFOutN(0),
+  fNumFSideP(0),
+  fNumFSideN(0),
+  fNumFLongP(0),
+  fNumFLongN(0),
+  fDenOutP(0),
+  fDenOutN(0),
+  fDenSideP(0),
+  fDenSideN(0),
+  fDenLongP(0),
   fDenLongN(0)
 {
   // Default constructor
@@ -85,46 +85,46 @@ AliFemtoModelCorrFctnNonIdDR::AliFemtoModelCorrFctnNonIdDR(char* title, const in
   fDenLongN = new TH1D(bufname,title,nbins,QinvLo,QinvHi);
 
   // to enable error bar calculation...
-  fNumTOutP->Sumw2(); 
-  fNumTOutN->Sumw2();  
-  fNumTSideP->Sumw2(); 
-  fNumTSideN->Sumw2(); 
-  fNumTLongP->Sumw2(); 
-  fNumTLongN->Sumw2(); 
-  fNumFOutP->Sumw2(); 
-  fNumFOutN->Sumw2();  
-  fNumFSideP->Sumw2(); 
-  fNumFSideN->Sumw2(); 
-  fNumFLongP->Sumw2(); 
-  fNumFLongN->Sumw2(); 
-  fDenOutP->Sumw2();  
-  fDenOutN->Sumw2();  
-  fDenSideP->Sumw2(); 
-  fDenSideN->Sumw2(); 
-  fDenLongP->Sumw2(); 
+  fNumTOutP->Sumw2();
+  fNumTOutN->Sumw2();
+  fNumTSideP->Sumw2();
+  fNumTSideN->Sumw2();
+  fNumTLongP->Sumw2();
+  fNumTLongN->Sumw2();
+  fNumFOutP->Sumw2();
+  fNumFOutN->Sumw2();
+  fNumFSideP->Sumw2();
+  fNumFSideN->Sumw2();
+  fNumFLongP->Sumw2();
+  fNumFLongN->Sumw2();
+  fDenOutP->Sumw2();
+  fDenOutN->Sumw2();
+  fDenSideP->Sumw2();
+  fDenSideN->Sumw2();
+  fDenLongP->Sumw2();
   fDenLongN->Sumw2();
 }
 
 //____________________________
 AliFemtoModelCorrFctnNonIdDR::AliFemtoModelCorrFctnNonIdDR(const AliFemtoModelCorrFctnNonIdDR& aCorrFctn) :
   AliFemtoModelCorrFctn(),
-  fNumTOutP(0), 
-  fNumTOutN(0),  
-  fNumTSideP(0), 
-  fNumTSideN(0), 
-  fNumTLongP(0), 
-  fNumTLongN(0), 
-  fNumFOutP(0), 
-  fNumFOutN(0),  
-  fNumFSideP(0), 
-  fNumFSideN(0), 
-  fNumFLongP(0), 
-  fNumFLongN(0), 
-  fDenOutP(0),  
-  fDenOutN(0),  
-  fDenSideP(0), 
-  fDenSideN(0), 
-  fDenLongP(0), 
+  fNumTOutP(0),
+  fNumTOutN(0),
+  fNumTSideP(0),
+  fNumTSideN(0),
+  fNumTLongP(0),
+  fNumTLongN(0),
+  fNumFOutP(0),
+  fNumFOutN(0),
+  fNumFSideP(0),
+  fNumFSideN(0),
+  fNumFLongP(0),
+  fNumFLongN(0),
+  fDenOutP(0),
+  fDenOutN(0),
+  fDenSideP(0),
+  fDenSideN(0),
+  fDenLongP(0),
   fDenLongN(0)
 {
   // copy constructor
@@ -170,23 +170,23 @@ AliFemtoModelCorrFctnNonIdDR::AliFemtoModelCorrFctnNonIdDR(const AliFemtoModelCo
 //____________________________
 AliFemtoModelCorrFctnNonIdDR::~AliFemtoModelCorrFctnNonIdDR(){
   // Destructor
-  delete fNumTOutP; 
-  delete fNumTOutN;  
-  delete fNumTSideP; 
-  delete fNumTSideN; 
-  delete fNumTLongP; 
-  delete fNumTLongN; 
-  delete fNumFOutP; 
-  delete fNumFOutN;  
-  delete fNumFSideP; 
-  delete fNumFSideN; 
-  delete fNumFLongP; 
-  delete fNumFLongN; 
-  delete fDenOutP;  
-  delete fDenOutN;  
-  delete fDenSideP; 
-  delete fDenSideN; 
-  delete fDenLongP; 
+  delete fNumTOutP;
+  delete fNumTOutN;
+  delete fNumTSideP;
+  delete fNumTSideN;
+  delete fNumTLongP;
+  delete fNumTLongN;
+  delete fNumFOutP;
+  delete fNumFOutN;
+  delete fNumFSideP;
+  delete fNumFSideN;
+  delete fNumFLongP;
+  delete fNumFLongN;
+  delete fDenOutP;
+  delete fDenOutN;
+  delete fDenSideP;
+  delete fDenSideN;
+  delete fDenLongP;
   delete fDenLongN;
 }
 //_________________________
@@ -325,23 +325,23 @@ void AliFemtoModelCorrFctnNonIdDR::AddMixedPair(AliFemtoPair* pair){
 //____________________________
 void AliFemtoModelCorrFctnNonIdDR::Write(){
   // Write out histos
-  fNumTOutP->Write(); 
-  fNumTOutN->Write();  
-  fNumTSideP->Write(); 
-  fNumTSideN->Write(); 
-  fNumTLongP->Write(); 
-  fNumTLongN->Write(); 
-  fNumFOutP->Write(); 
-  fNumFOutN->Write();  
-  fNumFSideP->Write(); 
-  fNumFSideN->Write(); 
-  fNumFLongP->Write(); 
-  fNumFLongN->Write(); 
-  fDenOutP->Write();  
-  fDenOutN->Write();  
-  fDenSideP->Write(); 
-  fDenSideN->Write(); 
-  fDenLongP->Write(); 
+  fNumTOutP->Write();
+  fNumTOutN->Write();
+  fNumTSideP->Write();
+  fNumTSideN->Write();
+  fNumTLongP->Write();
+  fNumTLongN->Write();
+  fNumFOutP->Write();
+  fNumFOutN->Write();
+  fNumFSideP->Write();
+  fNumFSideN->Write();
+  fNumFLongP->Write();
+  fNumFLongN->Write();
+  fDenOutP->Write();
+  fDenOutN->Write();
+  fDenSideP->Write();
+  fDenSideN->Write();
+  fDenLongP->Write();
   fDenLongN->Write();
 }
 
@@ -350,23 +350,23 @@ TList* AliFemtoModelCorrFctnNonIdDR::GetOutputList()
   // Prepare the list of objects to be written to the output
   TList *tOutputList = new TList();
 
-  tOutputList->Add(fNumTOutP); 
-  tOutputList->Add(fNumTOutN);  
-  tOutputList->Add(fNumTSideP); 
-  tOutputList->Add(fNumTSideN); 
-  tOutputList->Add(fNumTLongP); 
-  tOutputList->Add(fNumTLongN); 
-  tOutputList->Add(fNumFOutP); 
-  tOutputList->Add(fNumFOutN);  
-  tOutputList->Add(fNumFSideP); 
-  tOutputList->Add(fNumFSideN); 
-  tOutputList->Add(fNumFLongP); 
-  tOutputList->Add(fNumFLongN); 
-  tOutputList->Add(fDenOutP);  
-  tOutputList->Add(fDenOutN);  
-  tOutputList->Add(fDenSideP); 
-  tOutputList->Add(fDenSideN); 
-  tOutputList->Add(fDenLongP); 
+  tOutputList->Add(fNumTOutP);
+  tOutputList->Add(fNumTOutN);
+  tOutputList->Add(fNumTSideP);
+  tOutputList->Add(fNumTSideN);
+  tOutputList->Add(fNumTLongP);
+  tOutputList->Add(fNumTLongN);
+  tOutputList->Add(fNumFOutP);
+  tOutputList->Add(fNumFOutN);
+  tOutputList->Add(fNumFSideP);
+  tOutputList->Add(fNumFSideN);
+  tOutputList->Add(fNumFLongP);
+  tOutputList->Add(fNumFLongN);
+  tOutputList->Add(fDenOutP);
+  tOutputList->Add(fDenOutN);
+  tOutputList->Add(fDenSideP);
+  tOutputList->Add(fDenSideN);
+  tOutputList->Add(fDenLongP);
   tOutputList->Add(fDenLongN);
 
   return tOutputList;
@@ -377,6 +377,6 @@ AliFemtoModelCorrFctn* AliFemtoModelCorrFctnNonIdDR::Clone()
 {
   // Create clone
   AliFemtoModelCorrFctnNonIdDR *tCopy = new AliFemtoModelCorrFctnNonIdDR(*this);
-  
+
   return tCopy;
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnNonIdDR.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnNonIdDR.h
@@ -15,7 +15,7 @@
 
 class AliFemtoModelCorrFctnNonIdDR : public AliFemtoModelCorrFctn {
 public:
-  AliFemtoModelCorrFctnNonIdDR(char* title, const int& nbins, const float& QinvLo, const float& QinvHi);
+  AliFemtoModelCorrFctnNonIdDR(const char* title, const int& nbins, const float& QinvLo, const float& QinvHi);
   AliFemtoModelCorrFctnNonIdDR(const AliFemtoModelCorrFctnNonIdDR& aCorrFctn);
   virtual ~AliFemtoModelCorrFctnNonIdDR();
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoQinvCorrFctnEMCIC.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoQinvCorrFctnEMCIC.cxx
@@ -6,7 +6,7 @@
  ***************************************************************************
  *
  * Description: Calculates of the Qinv Correlation Function, and also
- *              produces histograms to calculate EMCICs          
+ *              produces histograms to calculate EMCICs
  *
  ***************************************************************************
  *
@@ -18,12 +18,12 @@
 #include <cstdio>
 #include <TVector2.h>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoQinvCorrFctnEMCIC)
 #endif
 
 //____________________________
-AliFemtoQinvCorrFctnEMCIC::AliFemtoQinvCorrFctnEMCIC(char* title, const int& nbins, const float& QinvLo, const float& QinvHi):
+AliFemtoQinvCorrFctnEMCIC::AliFemtoQinvCorrFctnEMCIC(const char* title, const int& nbins, const float& QinvLo, const float& QinvHi):
 AliFemtoQinvCorrFctn(title, nbins, QinvLo, QinvHi),
 /*fESumReal(0),
   fEMultReal(0),
@@ -35,7 +35,7 @@ AliFemtoQinvCorrFctn(title, nbins, QinvLo, QinvHi),
   fPzMultMix(0)
 
 {
-  
+
 
   // set up emcic histograms
   /*char tTitESum[100] = "ESumReal";
@@ -50,7 +50,7 @@ AliFemtoQinvCorrFctn(title, nbins, QinvLo, QinvHi),
   char tTitPz[100] = "PzMultReal";
   strncat(tTitPz,title, 100);
   fPzMultReal = new TH1D(tTitPz,title,nbins,QinvLo,QinvHi);*/
- 
+
   char tTitESum2[101] = "ESumMix";
   strncat(tTitESum2,title, 100);
   fESumMix = new TH1D(tTitESum2,title,nbins,QinvLo,QinvHi);
@@ -67,7 +67,7 @@ AliFemtoQinvCorrFctn(title, nbins, QinvLo, QinvHi),
 
 
   // to enable error bar calculation...
-  
+
   /*  fESumReal->Sumw2();
   fEMultReal->Sumw2();
   fPtMultReal->Sumw2();
@@ -91,7 +91,7 @@ AliFemtoQinvCorrFctnEMCIC::AliFemtoQinvCorrFctnEMCIC(const AliFemtoQinvCorrFctnE
   fPzMultMix(0)
 {
   // copy constructor
-  
+
   /*fESumReal= new TH1D(*aCorrFctn.fESumReal);
   fEMultReal= new TH1D(*aCorrFctn.fEMultReal);
   fPtMultReal= new TH1D(*aCorrFctn.fPtMultReal);
@@ -105,7 +105,7 @@ AliFemtoQinvCorrFctnEMCIC::AliFemtoQinvCorrFctnEMCIC(const AliFemtoQinvCorrFctnE
 //____________________________
 AliFemtoQinvCorrFctnEMCIC::~AliFemtoQinvCorrFctnEMCIC(){
   // destructor
-  
+
   /*delete fESumReal;
   delete fEMultReal;
   delete fPtMultReal;
@@ -132,7 +132,7 @@ AliFemtoQinvCorrFctnEMCIC& AliFemtoQinvCorrFctnEMCIC::operator=(const AliFemtoQi
   if (fPzMultReal) delete fPzMultReal;
   fPzMultReal= new TH1D(*aCorrFctn.fPzMultReal);
   if (fESumMix) delete fESumMix;*/
-  
+
   fESumMix= new TH1D(*aCorrFctn.fESumMix);
   if (fEMultMix) delete fEMultMix;
   fEMultMix= new TH1D(*aCorrFctn.fEMultMix);
@@ -147,14 +147,14 @@ AliFemtoQinvCorrFctnEMCIC& AliFemtoQinvCorrFctnEMCIC::operator=(const AliFemtoQi
 //____________________________
 void AliFemtoQinvCorrFctnEMCIC::AddRealPair(AliFemtoPair* pair){
   // add true pair
-  
+
   if (fPairCut)
     if (!fPairCut->Pass(pair)) return;
   AliFemtoQinvCorrFctn::AddRealPair(pair);
-  
- 
+
+
   //double tQinv = fabs(pair->QInv());   // note - qInv() will be negative for identical pairs...
-  
+
 // The EMCICs are calculated here for real pairs
   /*AliFemtoLorentzVector tMom1 = pair->Track1()->FourMomentum();
   AliFemtoLorentzVector tMom2 = pair->Track2()->FourMomentum();
@@ -162,13 +162,13 @@ void AliFemtoQinvCorrFctnEMCIC::AddRealPair(AliFemtoPair* pair){
   double tE2 = tMom2.e();
   double tPz1 = tMom1.pz();
   double tPz2 = tMom2.pz();
-  
-  TVector2 tPt1;  
-  TVector2 tPt2; 
+
+  TVector2 tPt1;
+  TVector2 tPt2;
   tPt1.Set(tMom1.px(),tMom1.py());
   tPt2.Set(tMom2.px(),tMom2.py());
   double tPt1DotPt2 = tPt1*tPt2;
-  
+
   fESumReal->Fill(tQinv,tE1+tE2);
   fEMultReal->Fill(tQinv,tE1*tE2);
   fPzMultReal->Fill(tQinv,tPz1*tPz2);
@@ -182,7 +182,7 @@ void AliFemtoQinvCorrFctnEMCIC::AddMixedPair(AliFemtoPair* pair){
     if (!fPairCut->Pass(pair)) return;
   AliFemtoQinvCorrFctn::AddMixedPair(pair);
   double tQinv = fabs(pair->QInv());   // note - qInv() will be negative for identical pairs...
-  
+
 
   // The EMCICs are calculated here for mixed pairs
   AliFemtoLorentzVector tMom1 = pair->Track1()->FourMomentum();
@@ -191,13 +191,13 @@ void AliFemtoQinvCorrFctnEMCIC::AddMixedPair(AliFemtoPair* pair){
   double tE2 = tMom2.e();
   double tPz1 = tMom1.pz();
   double tPz2 = tMom2.pz();
-  
-  TVector2 tPt1;  
-  TVector2 tPt2; 
+
+  TVector2 tPt1;
+  TVector2 tPt2;
   tPt1.Set(tMom1.px(),tMom1.py());
   tPt2.Set(tMom2.px(),tMom2.py());
   double tPt1DotPt2 = tPt1*tPt2;
-  
+
   fESumMix->Fill(tQinv,tE1+tE2);
   fEMultMix->Fill(tQinv,tE1*tE2);
   fPzMultMix->Fill(tQinv,tPz1*tPz2);

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoQinvCorrFctnEMCIC.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoQinvCorrFctnEMCIC.h
@@ -15,12 +15,12 @@
  *        2)   E1 * E2
  *        3)   Pt1*Pt2
  *        4)   Pz1*Pz2
- *  
+ *
  * The class is derived from AliFemtoQinvCorrFctn, therefore it produces
- * also the histograms in that class. 
- * 
- * NOTE: The EMCIC histograms are not averaged in this class, to obtain 
- * the average, the user needs to divide the real pair histograms by 
+ * also the histograms in that class.
+ *
+ * NOTE: The EMCIC histograms are not averaged in this class, to obtain
+ * the average, the user needs to divide the real pair histograms by
  * the numerator, and the mixed pairs by denominator
  *
  ***************************************************************************
@@ -35,31 +35,31 @@
 #include "AliFemtoQinvCorrFctn.h"
 
 
-class AliFemtoQinvCorrFctnEMCIC : public AliFemtoQinvCorrFctn 
+class AliFemtoQinvCorrFctnEMCIC : public AliFemtoQinvCorrFctn
 {
  public:
-  AliFemtoQinvCorrFctnEMCIC(char* title, const int& nbins, 
+  AliFemtoQinvCorrFctnEMCIC(const char* title, const int& nbins,
 			    const float& QinvLo, const float& QinvHi);
   AliFemtoQinvCorrFctnEMCIC(const AliFemtoQinvCorrFctnEMCIC& aCorrFctn);
   virtual ~AliFemtoQinvCorrFctnEMCIC();
-  
+
   AliFemtoQinvCorrFctnEMCIC& operator=(const AliFemtoQinvCorrFctnEMCIC& aCorrFctn);
 
   virtual void AddRealPair(AliFemtoPair* aPair);
   virtual void AddMixedPair(AliFemtoPair* aPair);
 
-  
+
 
   virtual TList* GetOutputList();
   void Write();
-  
+
  private:
-  //Emcic histograms:  
-  /*TH1D* fESumReal;   //  <E1+E2>   from real Pairs 
-  TH1D* fEMultReal;  //  <E1*E2>   from real Pairs 
-  TH1D* fPtMultReal; //  <Pt1*Pt2> from real Pairs 
+  //Emcic histograms:
+  /*TH1D* fESumReal;   //  <E1+E2>   from real Pairs
+  TH1D* fEMultReal;  //  <E1*E2>   from real Pairs
+  TH1D* fPtMultReal; //  <Pt1*Pt2> from real Pairs
   TH1D* fPzMultReal; //  <Pz1*Pz2> from real Pairs */
-  TH1D* fESumMix;    //  <E1+E2>   from mixed Pairs 
+  TH1D* fESumMix;    //  <E1+E2>   from mixed Pairs
   TH1D* fEMultMix;   //  <E1*E2>   from mixed Pairs
   TH1D* fPtMultMix;  //  <PT1*Pt2> from mixed Pairs
   TH1D* fPzMultMix;  //  <Pz1*Pz2> from mixed Pairs

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoQinvCorrFctnWithWeights.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoQinvCorrFctnWithWeights.cxx
@@ -16,7 +16,7 @@
 #endif
 
 //____________________________
-AliFemtoQinvCorrFctnWithWeights::AliFemtoQinvCorrFctnWithWeights(char* title, const int& nbins, const float& QinvLo, const float& QinvHi, TH2D *filter1, TH2D *filter2):
+AliFemtoQinvCorrFctnWithWeights::AliFemtoQinvCorrFctnWithWeights(const char* title, const int& nbins, const float& QinvLo, const float& QinvHi, TH2D *filter1, TH2D *filter2):
   fNumerator(0),
   fDenominator(0),
   fRatio(0),
@@ -115,16 +115,16 @@ AliFemtoQinvCorrFctnWithWeights::AliFemtoQinvCorrFctnWithWeights(const AliFemtoQ
   fRaddedps = aCorrFctn.fRaddedps;
 
   fPairKinematics = aCorrFctn.fPairKinematics;
-  
+
   if (aCorrFctn.fYPtWeightsParticle1)
     fYPtWeightsParticle1 = new TH2D(*aCorrFctn.fYPtWeightsParticle1);
-  else 
+  else
     fYPtWeightsParticle1 = 0;
-   
+
   if (aCorrFctn.fYPtWeightsParticle2)
     fYPtWeightsParticle2 = new TH2D(*aCorrFctn.fYPtWeightsParticle2);
-  else 
-    fYPtWeightsParticle2 = 0; 
+  else
+    fYPtWeightsParticle2 = 0;
 
   if (aCorrFctn.PairReader)
     PairReader = (TNtuple*)aCorrFctn.PairReader;
@@ -169,10 +169,10 @@ AliFemtoQinvCorrFctnWithWeights& AliFemtoQinvCorrFctnWithWeights::operator=(cons
   fRaddedps = aCorrFctn.fRaddedps;
 
   fPairKinematics = aCorrFctn.fPairKinematics;
-  
+
    if(fYPtWeightsParticle1) delete fYPtWeightsParticle1;
-   fYPtWeightsParticle1 = new TH2D(*aCorrFctn.fYPtWeightsParticle1); 
-   
+   fYPtWeightsParticle1 = new TH2D(*aCorrFctn.fYPtWeightsParticle1);
+
    if(fYPtWeightsParticle2) delete fYPtWeightsParticle2;
    fYPtWeightsParticle2 = new TH2D(*aCorrFctn.fYPtWeightsParticle2);
 
@@ -222,7 +222,7 @@ void AliFemtoQinvCorrFctnWithWeights::AddRealPair(AliFemtoPair* pair){
     double ptv2 = pair->Track2()->Track()->Pt();
     double y1 = pair->Track1()->FourMomentum().Rapidity();
     double y2 = pair->Track2()->FourMomentum().Rapidity();
-    
+
     double weight1 = fYPtWeightsParticle1->GetBinContent(fYPtWeightsParticle1->FindBin(y1, ptv1));
 	double weight2 = fYPtWeightsParticle2->GetBinContent(fYPtWeightsParticle2->FindBin(y2, ptv2));
 
@@ -293,7 +293,7 @@ void AliFemtoQinvCorrFctnWithWeights::AddMixedPair(AliFemtoPair* pair){
   double ptv2 = pair->Track2()->Track()->Pt();
   double y1 = pair->Track1()->FourMomentum().Rapidity();
   double y2 = pair->Track2()->FourMomentum().Rapidity();
-    
+
   double weight1 = fYPtWeightsParticle1->GetBinContent(fYPtWeightsParticle1->FindBin(y1, ptv1));
   double weight2 = fYPtWeightsParticle2->GetBinContent(fYPtWeightsParticle2->FindBin(y2, ptv2));
   fDenominator->Fill(tQinv,weight1 * weight2);

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoQinvCorrFctnWithWeights.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoQinvCorrFctnWithWeights.h
@@ -58,7 +58,7 @@
 
 class AliFemtoQinvCorrFctnWithWeights : public AliFemtoCorrFctn {
 public:
-  AliFemtoQinvCorrFctnWithWeights(char* title, const int& nbins, const float& QinvLo, const float& QinvHi, TH2D *filter1, TH2D *filter2);
+  AliFemtoQinvCorrFctnWithWeights(const char* title, const int& nbins, const float& QinvLo, const float& QinvHi, TH2D *filter1, TH2D *filter2);
   AliFemtoQinvCorrFctnWithWeights(const AliFemtoQinvCorrFctnWithWeights& aCorrFctn);
   virtual ~AliFemtoQinvCorrFctnWithWeights();
 
@@ -85,7 +85,7 @@ private:
   TH1D* fDenominator;        // denominator - mixed pairs
   TH1D* fRatio;              // ratio - correlation function
   TH1D* fkTMonitor;          // Monitor the kT of pairs in the function
-  
+
   TH2D *fYPtWeightsParticle1;
   TH2D *fYPtWeightsParticle2;
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoShareQualityCorrFctn.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoShareQualityCorrFctn.cxx
@@ -10,12 +10,12 @@
 //#include "AliFemtoHisto.hh"
 #include <cstdio>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoShareQualityCorrFctn)
 #endif
 
 //____________________________
-AliFemtoShareQualityCorrFctn::AliFemtoShareQualityCorrFctn(char* title, const int& nbins, const float& QinvLo, const float& QinvHi):
+AliFemtoShareQualityCorrFctn::AliFemtoShareQualityCorrFctn(const char* title, const int& nbins, const float& QinvLo, const float& QinvHi):
   AliFemtoCorrFctn(),
   fShareNumerator(0),
   fShareDenominator(0),
@@ -66,7 +66,7 @@ AliFemtoShareQualityCorrFctn::AliFemtoShareQualityCorrFctn(char* title, const in
 
   fQualityNumerator->Sumw2();
   fQualityDenominator->Sumw2();
-  
+
   fTPCSepNumerator->Sumw2();
   fTPCSepDenominator->Sumw2();
 }
@@ -174,23 +174,23 @@ void AliFemtoShareQualityCorrFctn::AddRealPair( AliFemtoPair* pair){
   Int_t nh = 0;
   Int_t an = 0;
   Int_t ns = 0;
-  
+
   for (unsigned int imap=0; imap<pair->Track1()->Track()->TPCclusters().GetNbits(); imap++) {
     // If both have clusters in the same row
-    if (pair->Track1()->Track()->TPCclusters().TestBitNumber(imap) && 
+    if (pair->Track1()->Track()->TPCclusters().TestBitNumber(imap) &&
 	pair->Track2()->Track()->TPCclusters().TestBitNumber(imap)) {
       // Do they share it ?
       if (pair->Track1()->Track()->TPCsharing().TestBitNumber(imap) &&
 	  pair->Track2()->Track()->TPCsharing().TestBitNumber(imap))
 	{
 // 	  if (tQinv < 0.01) {
-// 	    cout << "Shared cluster in row " << imap << endl; 
+// 	    cout << "Shared cluster in row " << imap << endl;
 // 	  }
 	  an++;
 	  nh+=2;
 	  ns+=2;
 	}
-      
+
       // Different hits on the same padrow
       else {
 	an--;
@@ -247,12 +247,12 @@ void AliFemtoShareQualityCorrFctn::AddRealPair( AliFemtoPair* pair){
 //       else cout << " X ";
 //       cout << endl;
 //     }
-//     cout << "Momentum1 " 
-// 	 << pair->Track1()->Track()->P().x() << " " 
-// 	 << pair->Track1()->Track()->P().y() << " "  
-// 	 << pair->Track1()->Track()->P().z() << " "  
-// 	 << pair->Track1()->Track()->Label() << " "  
-// 	 << pair->Track1()->Track()->TrackId() << " "  
+//     cout << "Momentum1 "
+// 	 << pair->Track1()->Track()->P().x() << " "
+// 	 << pair->Track1()->Track()->P().y() << " "
+// 	 << pair->Track1()->Track()->P().z() << " "
+// 	 << pair->Track1()->Track()->Label() << " "
+// 	 << pair->Track1()->Track()->TrackId() << " "
 // 	 << pair->Track1()->Track()->Flags() << " "
 // 	 << pair->Track1()->Track()->KinkIndex(0) << " "
 // 	 << pair->Track1()->Track()->KinkIndex(1) << " "
@@ -262,13 +262,13 @@ void AliFemtoShareQualityCorrFctn::AddRealPair( AliFemtoPair* pair){
 // 	 << pair->Track1()->Track()->TPCchi2() << " "
 // 	 << pair->Track1()->Track()->TPCncls() << " "
 // 	 << endl;
-//     cout << "Momentum2 " 
-// 	 << pair->Track2()->Track()->P().x() << " "  
-// 	 << pair->Track2()->Track()->P().y() << " "  
-// 	 << pair->Track2()->Track()->P().z() << " "  
-// 	 << pair->Track2()->Track()->Label() << " "  
-// 	 << pair->Track2()->Track()->TrackId() << " "  
-// 	 << pair->Track2()->Track()->Flags() << " " 
+//     cout << "Momentum2 "
+// 	 << pair->Track2()->Track()->P().x() << " "
+// 	 << pair->Track2()->Track()->P().y() << " "
+// 	 << pair->Track2()->Track()->P().z() << " "
+// 	 << pair->Track2()->Track()->Label() << " "
+// 	 << pair->Track2()->Track()->TrackId() << " "
+// 	 << pair->Track2()->Track()->Flags() << " "
 // 	 << pair->Track2()->Track()->KinkIndex(0) << " "
 // 	 << pair->Track2()->Track()->KinkIndex(1) << " "
 // 	 << pair->Track2()->Track()->KinkIndex(2) << " "
@@ -302,24 +302,24 @@ void AliFemtoShareQualityCorrFctn::AddMixedPair( AliFemtoPair* pair){
   Int_t nh = 0;
   Int_t an = 0;
   Int_t ns = 0;
-  
+
   for (unsigned int imap=0; imap<pair->Track1()->Track()->TPCclusters().GetNbits(); imap++) {
     // If both have clusters in the same row
-    if (pair->Track1()->Track()->TPCclusters().TestBitNumber(imap) && 
+    if (pair->Track1()->Track()->TPCclusters().TestBitNumber(imap) &&
 	pair->Track2()->Track()->TPCclusters().TestBitNumber(imap)) {
       // Do they share it ?
       if (pair->Track1()->Track()->TPCsharing().TestBitNumber(imap) &&
 	  pair->Track2()->Track()->TPCsharing().TestBitNumber(imap))
 	{
 	  //	  cout << "A shared cluster !!!" << endl;
-	  //	cout << "imap idx1 idx2 " 
+	  //	cout << "imap idx1 idx2 "
 	  //	     << imap << " "
 	  //	     << tP1idx[imap] << " " << tP2idx[imap] << endl;
 	  an++;
 	  nh+=2;
 	  ns+=2;
 	}
-      
+
       // Different hits on the same padrow
       else {
 	an--;
@@ -333,7 +333,7 @@ void AliFemtoShareQualityCorrFctn::AddMixedPair( AliFemtoPair* pair){
       nh++;
     }
   }
-  
+
   Float_t hsmval = 0.0;
   Float_t hsfval = 0.0;
 
@@ -363,7 +363,7 @@ void AliFemtoShareQualityCorrFctn::WriteHistos()
   fQualityDenominator->Write();
   fTPCSepNumerator->Write();
   fTPCSepDenominator->Write();
-  
+
 }
 //______________________________
 TList* AliFemtoShareQualityCorrFctn::GetOutputList()
@@ -371,12 +371,12 @@ TList* AliFemtoShareQualityCorrFctn::GetOutputList()
   // Prepare the list of objects to be written to the output
   TList *tOutputList = new TList();
 
-  tOutputList->Add(fShareNumerator); 
-  tOutputList->Add(fShareDenominator);  
-  tOutputList->Add(fQualityNumerator);  
-  tOutputList->Add(fQualityDenominator);  
-  tOutputList->Add(fTPCSepNumerator);  
-  tOutputList->Add(fTPCSepDenominator);  
+  tOutputList->Add(fShareNumerator);
+  tOutputList->Add(fShareDenominator);
+  tOutputList->Add(fQualityNumerator);
+  tOutputList->Add(fQualityDenominator);
+  tOutputList->Add(fTPCSepNumerator);
+  tOutputList->Add(fTPCSepDenominator);
 
   return tOutputList;
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoShareQualityCorrFctn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoShareQualityCorrFctn.h
@@ -15,7 +15,7 @@
 
 class AliFemtoShareQualityCorrFctn : public AliFemtoCorrFctn {
 public:
-  AliFemtoShareQualityCorrFctn(char* title, const int& nbins, const float& QinvLo, const float& QinvHi);
+  AliFemtoShareQualityCorrFctn(const char* title, const int& nbins, const float& QinvLo, const float& QinvHi);
   AliFemtoShareQualityCorrFctn(const AliFemtoShareQualityCorrFctn& aCorrFctn);
   virtual ~AliFemtoShareQualityCorrFctn();
 
@@ -30,15 +30,15 @@ public:
   void WriteHistos();
   virtual TList* GetOutputList();
 private:
-  
+
   TH2D *fShareNumerator;        // Share fraction for real pairs
   TH2D *fShareDenominator;      // share fraction for mixed pairs
- 
+
   TH2D *fQualityNumerator;      // quality for real pairs
-  TH2D *fQualityDenominator;    // quality for mixed pairs 
+  TH2D *fQualityDenominator;    // quality for mixed pairs
 
   TH2D *fTPCSepNumerator;       // TPCSep for real pairs
-  TH2D *fTPCSepDenominator;     // TPCSep for mixed pairs 
+  TH2D *fTPCSepDenominator;     // TPCSep for mixed pairs
 
 #ifdef __ROOT__
   ClassDef(AliFemtoShareQualityCorrFctn, 1)

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoTPCInnerCorrFctn.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoTPCInnerCorrFctn.cxx
@@ -11,12 +11,12 @@
 //#include "AliFemtoHisto.hh"
 #include <cstdio>
 
-#ifdef __ROOT__ 
+#ifdef __ROOT__
 ClassImp(AliFemtoTPCInnerCorrFctn)
 #endif
 
 //____________________________
-AliFemtoTPCInnerCorrFctn::AliFemtoTPCInnerCorrFctn(char* title, const int& nbins, const float& QinvLo, const float& QinvHi):
+AliFemtoTPCInnerCorrFctn::AliFemtoTPCInnerCorrFctn(const char* title, const int& nbins, const float& QinvLo, const float& QinvHi):
   fDTPCNumerator(0),
   fDTPCDenominator(0),
   fRadDNumerator(0),
@@ -221,10 +221,10 @@ TList* AliFemtoTPCInnerCorrFctn::GetOutputList()
   // Prepare the list of objects to be written to the output
   TList *tOutputList = new TList();
 
-  tOutputList->Add(fDTPCNumerator); 
-  tOutputList->Add(fDTPCDenominator);  
-  tOutputList->Add(fRadDNumerator); 
-  tOutputList->Add(fRadDDenominator);  
+  tOutputList->Add(fDTPCNumerator);
+  tOutputList->Add(fDTPCDenominator);
+  tOutputList->Add(fRadDNumerator);
+  tOutputList->Add(fRadDDenominator);
 
   return tOutputList;
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoTPCInnerCorrFctn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoTPCInnerCorrFctn.h
@@ -16,7 +16,7 @@
 
 class AliFemtoTPCInnerCorrFctn : public AliFemtoCorrFctn {
 public:
-  AliFemtoTPCInnerCorrFctn(char* title, const int& nbins, const float& QinvLo, const float& QinvHi);
+  AliFemtoTPCInnerCorrFctn(const char* title, const int& nbins, const float& QinvLo, const float& QinvHi);
   AliFemtoTPCInnerCorrFctn(const AliFemtoTPCInnerCorrFctn& aCorrFctn);
   virtual ~AliFemtoTPCInnerCorrFctn();
 
@@ -32,7 +32,7 @@ public:
   void WriteHistos();
   virtual TList* GetOutputList();
 private:
-  
+
   TH2D *fDTPCNumerator;        // Distance at the entrance to the TPC for real pairs
   TH2D *fDTPCDenominator;      // Distance at the entrance to tht TPC for mixed pairs
   TH2D *fRadDNumerator;        // Distance at the radius for real pairs


### PR DESCRIPTION
`ISO C++11 does not allow conversion from string literal to 'char *'`
^ This rule would cause errors when trying to construct an AliFemto
object using a standard string literal when using root6.

This commit changes `char *` parameters to `const char *` (and in the
process of saving, also removed trailing whitespace in affected files).

AliFemtoCorrFctnDPhiStarDEtaStar - Broke up long line