### PR TITLE
Fix for GetAcceptedTracks + fixes of Add-macros for ROOT6

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
@@ -541,6 +541,7 @@ Bool_t AliTrackContainer::AcceptTrack(const AliVTrack *vp, UInt_t &rejectionReas
  */
 Bool_t AliTrackContainer::AcceptTrack(Int_t i, UInt_t &rejectionReason) const
 {
+  if(fTrackTypes[i] == kRejected) return false; // track was rejected by the track selection
   Bool_t r = ApplyTrackCuts(GetTrack(i), rejectionReason);
   if (!r) return kFALSE;
 
@@ -626,6 +627,37 @@ PWG::EMCAL::AliEmcalTrackSelResultHybrid::HybridType_t AliTrackContainer::GetHyb
     }
   }
   return hybridDefinition;
+}
+
+Bool_t AliTrackContainer::CheckArrayConsistency() const {
+  bool teststatus = true;
+  auto selected = fFilteredTracks.GetData();
+  if(selected->GetEntries() != fClArray->GetEntries()) {
+    std::cout << "Mismatch array size: selected " << selected->GetEntries() << ", input " << fClArray->GetEntries() << std::endl; 
+    teststatus = false;
+  } else {
+    std::cout << "Array size consistent: " << selected->GetEntries() << std::endl;
+  }
+
+  // Now check whehter tracks are stored in the same indices:
+  if(teststatus){
+    int nmatch(0), nfail(0);
+    for(int i = 0; i < fClArray->GetEntries(); i++) {
+      AliVTrack *trackAll = dynamic_cast<AliVTrack *>(fClArray->At(i));
+      AliVTrack *trackSel = dynamic_cast<AliVTrack *>(selected->At(i));
+      if(trackSel == trackAll) {
+        nmatch++;    
+      } else {
+        std::cout << "Mismatch in array position: " << i << std::endl;
+        nfail++;
+      }
+    }
+    if(nfail) {
+      std::cout << "found " << nfail << "mismatches" << std::endl;
+      teststatus = false;
+    }
+  }
+  return teststatus;
 }
 
 /**

--- a/PWG/EMCAL/EMCALbase/AliTrackContainer.h
+++ b/PWG/EMCAL/EMCALbase/AliTrackContainer.h
@@ -161,6 +161,13 @@ class AliTrackContainer : public AliParticleContainer {
 
   const char*                 GetTitle() const;
 
+  /**
+   * @brief Test function checking whether the entries in the track array are the same as in the input array
+   * 
+   * @return Bool_t CheckArrayConsistency 
+   */
+  Bool_t CheckArrayConsistency() const;
+
 #if !(defined(__CINT__) || defined(__MAKECINT__))
   const AliTrackIterableContainer      all() const;
   const AliTrackIterableContainer      accepted() const;

--- a/PWGJE/EMCALJetTasks/macros/AddTaskEmcalQGTagging.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskEmcalQGTagging.C
@@ -15,10 +15,10 @@ AliAnalysisTaskEmcalQGTagging* AddTaskEmcalQGTagging(const char * njetsBase,
 						     TString     trigClass      = "",
 						     TString     kEmcalTriggers = "",
 						     TString     tag            = "",
-						     AliAnalysisTaskEmcalQGTagging::JetShapeType jetShapeType,
-						     AliAnalysisTaskEmcalQGTagging::JetShapeSub jetShapeSub,
-						     AliAnalysisTaskEmcalQGTagging::JetSelectionType jetSelection,
-                 Float_t minpTHTrigger =0.,  Float_t maxpTHTrigger =0., AliAnalysisTaskEmcalQGTagging::DerivSubtrOrder derivSubtrOrder = 0 ) {
+						     AliAnalysisTaskEmcalQGTagging::JetShapeType jetShapeType = AliAnalysisTaskEmcalQGTagging::kMCTrue,
+						     AliAnalysisTaskEmcalQGTagging::JetShapeSub jetShapeSub = AliAnalysisTaskEmcalQGTagging::kNoSub,
+						     AliAnalysisTaskEmcalQGTagging::JetSelectionType jetSelection = AliAnalysisTaskEmcalQGTagging::kInclusive,
+                 Float_t minpTHTrigger =0.,  Float_t maxpTHTrigger =0., AliAnalysisTaskEmcalQGTagging::DerivSubtrOrder derivSubtrOrder = AliAnalysisTaskEmcalQGTagging::kSecondOrder ) {
  
 
   

--- a/PWGJE/EMCALJetTasks/macros/AddTaskRhoMass.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskRhoMass.C
@@ -38,7 +38,7 @@ AliAnalysisTaskRhoMass* AddTaskRhoMass(
   //-------------------------------------------------------
 
   TString name(Form("%s_%s_%s", taskname, nJets,cutType));
-  AliAnalysisTaskRhoMass* mgrTask = mgr->GetTask(name.Data());
+  AliAnalysisTaskRhoMass* mgrTask = dynamic_cast<AliAnalysisTaskRhoMass*>(mgr->GetTask(name.Data()));
   if (mgrTask) return mgrTask;
 
   AliAnalysisTaskRhoMass *rhomtask = new AliAnalysisTaskRhoMass(name, histo);


### PR DESCRIPTION
Fixing issue that GetAcceptedTracks returns also non-accepted tracks, introduced in #3702 (extra check needed as the track selection now returns the selection status of all tracks and not only the accepted tracks).

In addition two macros were made ROOT6-aware (mismatch in types + missing default arguments).