### PR TITLE
Increase digits in the output string SetRangeUser

### DIFF
--- a/CORRFW/AliCFGridSparse.cxx
+++ b/CORRFW/AliCFGridSparse.cxx
@@ -715,7 +715,7 @@ void AliCFGridSparse::SetRangeUser(Int_t iVar, Double_t varMin, Double_t varMax,
   SetAxisRange(fData->GetAxis(iVar),varMin,varMax,useBins);
 	//AliInfo(Form("AliCFGridSparse axis %d range has been modified",iVar));
 	TAxis* currAxis = fData->GetAxis(iVar);
-  TString outString = Form("%s new range: %.1f < %s < %.1f", GetName(), currAxis->GetBinLowEdge(currAxis->GetFirst()), currAxis->GetTitle(), currAxis->GetBinUpEdge(currAxis->GetLast()));
+  TString outString = Form("%s new range: %.5f < %s < %.5f", GetName(), currAxis->GetBinLowEdge(currAxis->GetFirst()), currAxis->GetTitle(), currAxis->GetBinUpEdge(currAxis->GetLast()));
   TString binLabel = currAxis->GetBinLabel(currAxis->GetFirst());
   if ( ! binLabel.IsNull() ) {
     outString += " ( ";


### PR DESCRIPTION
In my analysis code I'm using many AliCFcontainer objects.
When changing the range for an axis, the method SetRangeUser prints on the screen a sentence like:
W-AliCFGridSparse::SetRangeUser: fCFContCascadeCuts_minnTPCcls70_vtxlim10.0-0.0_minptdghtrk0.0_etacutdghtrk0.8_revertex_nTPCcls70_SelStep0 new range: 0.0 < Dca(cascade daughters) (cm) < 2.0
As you can see only the first decimal digit is displayed. 
I need more digits to be displayed, to check the value of the cut applied.