### PR TITLE
PWGGA/GammaConv: Added MCs anchored to LHC16q,t and LHC16d,e,g,h,i,j,…

### DIFF
--- a/PWGGA/GammaConv/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConv/AliCaloPhotonCuts.cxx
@@ -5399,6 +5399,17 @@ AliCaloPhotonCuts::MCSet AliCaloPhotonCuts::FindEnumForMCSet(TString namePeriod)
             namePeriod.CompareTo("LHC17f8e") == 0  )      return k16P1JJ;
   else if ( namePeriod.CompareTo("LHC16P1JJLowB") == 0 ||
             namePeriod.CompareTo("LHC17f8b") == 0  )      return k16P1JJLowB;
+  else if ( namePeriod.CompareTo("LHC17h8a") == 0 )        return k17h8a;
+  else if ( namePeriod.CompareTo("LHC17h8b") == 0 )        return k17h8b;
+  else if ( namePeriod.CompareTo("LHC17h8c") == 0 )        return k17h8c;
+  else if ( namePeriod.CompareTo("LHC17c3b1") == 0 )        return k17c3b1;
+  else if ( namePeriod.CompareTo("LHC17c3a1") == 0 )        return k17c3a1;
+  else if ( namePeriod.CompareTo("LHC17c3b2") == 0 )        return k17c3b2;
+  else if ( namePeriod.CompareTo("LHC17c3a2") == 0 )        return k17c3a2;
+  else if ( namePeriod.CompareTo("LHC17d2a_fast") == 0 )        return k17d2a_fast;
+  else if ( namePeriod.CompareTo("LHC17d2a_cent") == 0 )        return k17d2a_cent;
+  else if ( namePeriod.CompareTo("LHC17d2b_fast") == 0 )        return k17d2b_fast;
+  else if ( namePeriod.CompareTo("LHC17d2b_cent") == 0 )        return k17d2b_cent;
   else if ( namePeriod.CompareTo("LHC17j7") == 0 )        return k17j7;
   else if ( namePeriod.CompareTo("LHC17h1") == 0 )        return k17h1;
   else if ( namePeriod.CompareTo("LHC17h3") == 0 )        return k17h3;

--- a/PWGGA/GammaConv/AliCaloPhotonCuts.h
+++ b/PWGGA/GammaConv/AliCaloPhotonCuts.h
@@ -156,6 +156,18 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
       k17f4b,
       k17g8b,
       k17g8c,
+      k17h8a,
+      k17h8b,
+      k17h8c,
+      k17c3b1,
+      k17c3a1,
+      k17c3b2,
+      k17c3a2,
+      k17d2a_fast,
+      k17d2a_cent,
+      k17d2b_fast,
+      k17d2b_cent,
+      
       // 13TeV MC anc 2016 pp
       k16P1Pyt8,        //
       k16P1Pyt8LowB,    //

--- a/PWGGA/GammaConv/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConv/AliConvEventCuts.cxx
@@ -4877,7 +4877,37 @@ void AliConvEventCuts::SetPeriodEnum (TString periodName){
   } else if ( periodName.CompareTo("LHC16P1JJLowB") == 0 || periodName.CompareTo("LHC17f8b") == 0  ){
     fPeriodEnum = kLHC16P1JJLowB;
     fEnergyEnum = k13TeVLowB;
+    
+  // 13TeV HF-MC anchors LHC16i,j,o,p
+  } else if ( periodName.CompareTo("LHC17h8c") == 0){
+    fPeriodEnum = kLHC17h8c;
+    fEnergyEnum = k13TeV;
+  // 13TeV HF-MC anchors LHC16d,e,g,h,j,o,p
+  } else if ( periodName.CompareTo("LHC17h8b") == 0){
+    fPeriodEnum = kLHC17h8b;
+    fEnergyEnum = k13TeV;
+  // 13TeV HF-MC anchors LHC16d,e,g,h,j,o,p
+  } else if ( periodName.CompareTo("LHC17h8a") == 0){
+    fPeriodEnum = kLHC17h8a;
+    fEnergyEnum = k13TeV;
+  // 13TeV HF-MC anchors LHC16k
+  } else if ( periodName.CompareTo("LHC17c3b1") == 0){
+    fPeriodEnum = kLHC17c3b1;
+    fEnergyEnum = k13TeV;
+  // 13TeV HF-MC anchors LHC16k
+  } else if ( periodName.CompareTo("LHC17c3a1") == 0){
+    fPeriodEnum = kLHC17c3a1;
+    fEnergyEnum = k13TeV;
+  // 13TeV HF-MC anchors LHC16l
+  } else if ( periodName.CompareTo("LHC17c3b2") == 0){
+    fPeriodEnum = kLHC17c3b2;
+    fEnergyEnum = k13TeV;
+  // 13TeV HF-MC anchors LHC16l
+  } else if ( periodName.CompareTo("LHC17c3a2") == 0){
+    fPeriodEnum = kLHC17c3a2;
+    fEnergyEnum = k13TeV;
 
+    
   // LHC16qt anchored MCs
   } else if (periodName.CompareTo("LHC17f2a") == 0){
     fPeriodEnum = kLHC17f2a;
@@ -4917,6 +4947,18 @@ void AliConvEventCuts::SetPeriodEnum (TString periodName){
     fEnergyEnum = kpPb5TeV;
   } else if (periodName.CompareTo("LHC17g8a_cent_woSDD") == 0){
     fPeriodEnum = kLHC17g8a_cent_woSDD;
+    fEnergyEnum = kpPb5TeV;
+  } else if (periodName.CompareTo("LHC17d2a_fast") == 0){
+    fPeriodEnum = kLHC17d2a_fast;
+    fEnergyEnum = kpPb5TeV;
+  } else if (periodName.CompareTo("LHC17d2b_fast") == 0){
+    fPeriodEnum = kLHC17d2b_fast;
+    fEnergyEnum = kpPb5TeV;
+  } else if (periodName.CompareTo("LHC17d2a_cent") == 0){
+    fPeriodEnum = kLHC17d2a_fast;
+    fEnergyEnum = kpPb5TeV;
+  } else if (periodName.CompareTo("LHC17d2b_cent") == 0){
+    fPeriodEnum = kLHC17d2b_fast;
     fEnergyEnum = kpPb5TeV;
     // LHC16r anchored MCs
   } else if (periodName.CompareTo("LHC17a3a") == 0){

--- a/PWGGA/GammaConv/AliConvEventCuts.h
+++ b/PWGGA/GammaConv/AliConvEventCuts.h
@@ -216,6 +216,13 @@ class AliConvEventCuts : public AliAnalysisCuts {
         kLHC16P1EPOS,       //!< anchored LHC16x pass 1 nom B-field - general purpose EPOS
         kLHC16P1JJ,         //!< anchored LHC16x pass 1 nom B-field - Pythia8 JJ
         kLHC16P1JJLowB,     //!< anchored LHC16f pass 1 low B-field - Pythia8 JJ
+        kLHC17h8a,             //!< anchored LHC16d,e,g,h,j,o,p pass 1 - heavy flavour MC Pythia6
+        kLHC17h8b,             //!< anchored LHC16d,e,g,h,j,o,p pass 1 - heavy flavour MC Pythia6
+        kLHC17h8c,             //!< anchored LHC16i,j,o,p pass 1 - heavy flavour MC Pythia6
+        kLHC17c3b1,            //!< anchored LHC16k pass 1 - heavy flavour MC Pythia6
+        kLHC17c3a1,            //!< anchored LHC16k pass 1 - heavy flavour MC Pythia6
+        kLHC17c3b2,            //!< anchored LHC16l pass 1 - heavy flavour MC Pythia6
+        kLHC17c3a2,            //!< anchored LHC16l pass 1 - heavy flavour MC Pythia6
 
         //General purpose- pPb
         kLHC17a3a,            //!< anchored LHC16r pass 1 - general purpose EPOSLHC
@@ -268,6 +275,12 @@ class AliConvEventCuts : public AliAnalysisCuts {
         kLHC17h1,            //!< anchored LHC17c pass 1 - general purpose MC
         kLHC17h3,            //!< anchored LHC17g pass 1 - general purpose MC
         kLHC17l5,            //!< anchored LHC17m pass 1 - general purpose MC
+        
+        //heavy flavour MC pPb k17d2a_fast,
+        kLHC17d2a_fast,          //!< anchored LHC16q,t pass 1 - heavy flavour MC Hijing, fast only
+        kLHC17d2a_cent,          //!< anchored LHC16q,t pass 1 - heavy flavour MC Hijing, CENT 
+        kLHC17d2b_fast,          //!< anchored LHC16q,t pass 1 - heavy flavour MC Hijing, fast only
+        kLHC17d2b_cent,          //!< anchored LHC16q,t pass 1 - heavy flavour MC Hijing, CENT
 
         // 2017
         kLHC17NomB,         //!< pp 13 TeV nominal B field


### PR DESCRIPTION
…k,l,o,p

HF-MCs anchored to LHC16q,t: LHC17d2a_fast, LHC17d2b_fast, LHC17d2a_cent, LHC17d2b_cent
HF-MCs anchored to LHC16d..p: LHC17h8c, LHC17h8b, LHC17h8b, LHC17c3b1, LHC17c3a1, LHC17c3b2, LHC17c3a2