### PR TITLE
EMCal CorrFW: Track to container map for had corr

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterHadronicCorrection.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterHadronicCorrection.h
@@ -43,6 +43,7 @@ class AliEmcalCorrectionClusterHadronicCorrection : public AliEmcalCorrectionCom
   Bool_t Run();
   
 protected:
+  void                   GenerateTrackToContainerMap();
   Double_t               ApplyHadCorrOneTrack(Int_t icluster, Double_t hadCorr);
   Double_t               ApplyHadCorrAllTracks(Int_t icluster, Double_t hadCorr);
   void                   DoMatchedTracksLoop(Int_t icluster, Double_t &totalTrkP, Int_t &Nmatches, Double_t &trkPMCfrac, Int_t &NMCmatches);
@@ -66,6 +67,7 @@ protected:
   AliEmcalContainerIndexMap <AliClusterContainer, AliVCluster> fClusterContainerIndexMap;    //!<! Mapping between index and cluster containers
   AliEmcalContainerIndexMap <AliParticleContainer, AliVParticle> fParticleContainerIndexMap; //!<! Mapping between index and particle containers
 #endif
+  std::map <AliVTrack *, AliParticleContainer *> fTrackToContainerMap;                       //!<! Mapping between AliVTracks and their respective particle containers. Needed for AODs only. See GenerateTrackToContainerMap() for more information.
   
   // QA plots
   TH2                   *fHistMatchEtaPhi[10][9][2];  //!<!deta vs. dphi of matched cluster-track pairs


### PR DESCRIPTION
Creates a mapping for tracks to their corresponding container in the
hadronic correction when running with AODs. AOD clusters only
provide pointers to tracks, so this map is necessary to select the
proper container, which allows the proper track
selection to be applied to each track. This is important if the
containers have different track selection conditions (as might happen
in, for example, embedding pp data into PbPb).

I've verified using the correction framework testing tools and comparison script
that this change doesn't modify the behavior of the correction when not
using embedding.