### PR TITLE
PWGGA/GammaConv: Full implementation of Correction Framework in tasks

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
@@ -66,6 +66,7 @@ ClassImp(AliAnalysisTaskGammaCalo)
 AliAnalysisTaskGammaCalo::AliAnalysisTaskGammaCalo(): AliAnalysisTaskSE(),
   fV0Reader(NULL),
   fV0ReaderName("V0ReaderV1"),
+  fCorrTaskSetting(""),
   fBGHandler(NULL),
   fInputEvent(NULL),
   fMCEvent(NULL),
@@ -334,6 +335,7 @@ AliAnalysisTaskGammaCalo::AliAnalysisTaskGammaCalo(const char *name):
   AliAnalysisTaskSE(name),
   fV0Reader(NULL),
   fV0ReaderName("V0ReaderV1"),
+  fCorrTaskSetting(""),
   fBGHandler(NULL),
   fInputEvent(NULL),
   fMCEvent(NULL),
@@ -2127,12 +2129,17 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
 {
 
   Int_t nclus = 0;
-  nclus = fInputEvent->GetNumberOfCaloClusters();
-
-//   cout << nclus << endl;
+  TClonesArray * arrClustersProcess = NULL;
+  if(!fCorrTaskSetting.CompareTo("")){
+    nclus = fInputEvent->GetNumberOfCaloClusters();
+  } else {
+    arrClustersProcess = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(Form("%sClustersBranch",fCorrTaskSetting.Data())));
+    if(!arrClustersProcess)
+      AliFatal(Form("%sClustersBranch was not found in AliAnalysisTaskGammaCalo! Check the correction framework settings!",fCorrTaskSetting.Data()));
+    nclus = arrClustersProcess->GetEntries();
+  }
 
   if(nclus == 0)  return;
-
   // plotting histograms on cell/tower level, only if extendedMatchAndQA > 1
   ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->FillHistogramsExtendedQA(fInputEvent,fIsMC);
 
@@ -2151,8 +2158,17 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
   for(Long_t i = 0; i < nclus; i++){
 
     AliVCluster* clus = NULL;
-    if(fInputEvent->IsA()==AliESDEvent::Class()) clus = new AliESDCaloCluster(*(AliESDCaloCluster*)fInputEvent->GetCaloCluster(i));
-    else if(fInputEvent->IsA()==AliAODEvent::Class()) clus = new AliAODCaloCluster(*(AliAODCaloCluster*)fInputEvent->GetCaloCluster(i));
+    if(fInputEvent->IsA()==AliESDEvent::Class()){
+      if(arrClustersProcess)
+        clus = new AliESDCaloCluster(*(AliESDCaloCluster*)arrClustersProcess->At(i));
+      else
+        clus = new AliESDCaloCluster(*(AliESDCaloCluster*)fInputEvent->GetCaloCluster(i));
+    } else if(fInputEvent->IsA()==AliAODEvent::Class()){
+      if(arrClustersProcess)
+        clus = new AliAODCaloCluster(*(AliAODCaloCluster*)arrClustersProcess->At(i));
+      else
+        clus = new AliAODCaloCluster(*(AliAODCaloCluster*)fInputEvent->GetCaloCluster(i));
+    }
 
     if(!clus) continue;
     if(!((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelected(clus,fInputEvent,fMCEvent,fIsMC,fWeightJetJetMC,i)){
@@ -2245,8 +2261,18 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
       if( mapIsClusterAccepted[i] != 1 ) continue;
 
       AliVCluster* clus = NULL;
-      if(fInputEvent->IsA()==AliESDEvent::Class()) clus = new AliESDCaloCluster(*(AliESDCaloCluster*)fInputEvent->GetCaloCluster(i));
-      else if(fInputEvent->IsA()==AliAODEvent::Class()) clus = new AliAODCaloCluster(*(AliAODCaloCluster*)fInputEvent->GetCaloCluster(i));
+      if(fInputEvent->IsA()==AliESDEvent::Class()){
+        if(arrClustersProcess)
+          clus = new AliESDCaloCluster(*(AliESDCaloCluster*)arrClustersProcess->At(i));
+        else
+          clus = new AliESDCaloCluster(*(AliESDCaloCluster*)fInputEvent->GetCaloCluster(i));
+      } else if(fInputEvent->IsA()==AliAODEvent::Class()){
+        if(arrClustersProcess)
+          clus = new AliAODCaloCluster(*(AliAODCaloCluster*)arrClustersProcess->At(i));
+        else
+          clus = new AliAODCaloCluster(*(AliAODCaloCluster*)fInputEvent->GetCaloCluster(i));
+      }
+      
       if(!clus) continue;
 
       Int_t cellID = ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->FindLargestCellInCluster(clus,fInputEvent);
@@ -2291,8 +2317,18 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
       if( mapIsClusterAcceptedWithoutTrackMatch[i] != 1 ) continue;
 
       AliVCluster* clus = NULL;
-      if(fInputEvent->IsA()==AliESDEvent::Class()) clus = new AliESDCaloCluster(*(AliESDCaloCluster*)fInputEvent->GetCaloCluster(i));
-      else if(fInputEvent->IsA()==AliAODEvent::Class()) clus = new AliAODCaloCluster(*(AliAODCaloCluster*)fInputEvent->GetCaloCluster(i));
+      if(fInputEvent->IsA()==AliESDEvent::Class()){
+        if(arrClustersProcess)
+          clus = new AliESDCaloCluster(*(AliESDCaloCluster*)arrClustersProcess->At(i));
+        else
+          clus = new AliESDCaloCluster(*(AliESDCaloCluster*)fInputEvent->GetCaloCluster(i));
+      } else if(fInputEvent->IsA()==AliAODEvent::Class()){
+        if(arrClustersProcess)
+          clus = new AliAODCaloCluster(*(AliAODCaloCluster*)arrClustersProcess->At(i));
+        else
+          clus = new AliAODCaloCluster(*(AliAODCaloCluster*)fInputEvent->GetCaloCluster(i));
+      }
+
       if(!clus) continue;
 
       fClusterE = clus->E();
@@ -2387,8 +2423,18 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
         if( mapIsClusterAcceptedWithoutTrackMatch[j] != 1 ) continue;
 
         AliVCluster* secondClus = NULL;
-        if(fInputEvent->IsA()==AliESDEvent::Class()) secondClus = new AliESDCaloCluster(*(AliESDCaloCluster*)fInputEvent->GetCaloCluster(j));
-        else if(fInputEvent->IsA()==AliAODEvent::Class()) secondClus = new AliAODCaloCluster(*(AliAODCaloCluster*)fInputEvent->GetCaloCluster(j));
+        if(fInputEvent->IsA()==AliESDEvent::Class()){
+          if(arrClustersProcess)
+            secondClus = new AliESDCaloCluster(*(AliESDCaloCluster*)arrClustersProcess->At(j));
+          else
+            secondClus = new AliESDCaloCluster(*(AliESDCaloCluster*)fInputEvent->GetCaloCluster(j));
+        } else if(fInputEvent->IsA()==AliAODEvent::Class()){
+          if(arrClustersProcess)
+            secondClus = new AliAODCaloCluster(*(AliAODCaloCluster*)arrClustersProcess->At(j));
+          else
+            secondClus = new AliAODCaloCluster(*(AliAODCaloCluster*)fInputEvent->GetCaloCluster(j));
+        }
+
         if(!secondClus) continue;
         secondClus->GetPosition(secondClsPos);
         TVector3 secondClsPosVec(secondClsPos);
@@ -3361,8 +3407,23 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidates(AliAODConversionMother
 
 //     cout << vertex[0] << "\t" << vertex[1] << "\t" << vertex[2] << endl;
 
+    TClonesArray * arrClustersMesonCand = NULL;
+    if(fCorrTaskSetting.CompareTo(""))
+      arrClustersMesonCand = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(Form("%sClustersBranch",fCorrTaskSetting.Data())));
+
     AliVCluster* clus1 = NULL;
-    clus1 = fInputEvent->GetCaloCluster(TrueGammaCandidate0->GetCaloClusterRef());
+    if(fInputEvent->IsA()==AliESDEvent::Class()){
+      if(arrClustersMesonCand)
+        clus1 = new AliESDCaloCluster(*(AliESDCaloCluster*)arrClustersMesonCand->At(TrueGammaCandidate0->GetCaloClusterRef()));
+      else
+        clus1 = fInputEvent->GetCaloCluster(TrueGammaCandidate0->GetCaloClusterRef());
+    } else if(fInputEvent->IsA()==AliAODEvent::Class()){
+      if(arrClustersMesonCand)
+        clus1 = new AliAODCaloCluster(*(AliAODCaloCluster*)arrClustersMesonCand->At(TrueGammaCandidate0->GetCaloClusterRef()));
+      else
+        clus1 = fInputEvent->GetCaloCluster(TrueGammaCandidate0->GetCaloClusterRef());
+    }
+    
     if (!clus1) return;
     TLorentzVector clusterVector1;
     clus1->GetMomentum(clusterVector1,vertex);
@@ -3375,7 +3436,18 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidates(AliAODConversionMother
 
 
     AliVCluster* clus2 = NULL;
-    clus2 = fInputEvent->GetCaloCluster(TrueGammaCandidate1->GetCaloClusterRef());
+    if(fInputEvent->IsA()==AliESDEvent::Class()){
+      if(arrClustersMesonCand)
+        clus2 = new AliESDCaloCluster(*(AliESDCaloCluster*)arrClustersMesonCand->At(TrueGammaCandidate1->GetCaloClusterRef()));
+      else
+        clus2 = fInputEvent->GetCaloCluster(TrueGammaCandidate1->GetCaloClusterRef());
+    } else if(fInputEvent->IsA()==AliAODEvent::Class()){
+      if(arrClustersMesonCand)
+        clus2 = new AliAODCaloCluster(*(AliAODCaloCluster*)arrClustersMesonCand->At(TrueGammaCandidate1->GetCaloClusterRef()));
+      else
+        clus2 = fInputEvent->GetCaloCluster(TrueGammaCandidate1->GetCaloClusterRef());
+    }
+
     if (!clus2) return;
     TLorentzVector clusterVector2;
     clus2->GetMomentum(clusterVector2,vertex);
@@ -4382,7 +4454,17 @@ void AliAnalysisTaskGammaCalo::EventDebugMethod(){
   fOutputLocalDebug.open("debugOutput.txt",ios::out|ios::app);
   if(!fOutputLocalDebug.is_open()) return;
 
-  Long_t nclus = fInputEvent->GetNumberOfCaloClusters();
+  Int_t nclus = 0;
+  TClonesArray * arrClustersDebug = NULL;
+  if(!fCorrTaskSetting.CompareTo("")){
+    nclus = fInputEvent->GetNumberOfCaloClusters();
+  } else {
+    arrClustersDebug = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(Form("%sClustersBranch",fCorrTaskSetting.Data())));
+    if(!arrClustersDebug)
+      AliFatal(Form("%sClustersBranch was not found in AliAnalysisTaskGammaCalo! Check the correction framework settings!",fCorrTaskSetting.Data()));
+    nclus = arrClustersDebug->GetEntries();
+  }
+  
   AliVCaloCells* cells = fInputEvent->GetEMCALCells();
   fOutputLocalDebug << "--event--" << endl;
   fOutputLocalDebug << "nclusters " << nclus << endl;
@@ -4393,8 +4475,17 @@ void AliAnalysisTaskGammaCalo::EventDebugMethod(){
 
   for(Long_t i = 0; i < nclus; i++){
     AliVCluster* clus = NULL;
-    if(fInputEvent->IsA()==AliESDEvent::Class()) clus = new AliESDCaloCluster(*(AliESDCaloCluster*)fInputEvent->GetCaloCluster(i));
-    else if(fInputEvent->IsA()==AliAODEvent::Class()) clus = new AliAODCaloCluster(*(AliAODCaloCluster*)fInputEvent->GetCaloCluster(i));
+    if(fInputEvent->IsA()==AliESDEvent::Class()){
+      if(arrClustersDebug)
+        clus = new AliESDCaloCluster(*(AliESDCaloCluster*)arrClustersDebug->At(i));
+      else
+        clus = new AliESDCaloCluster(*(AliESDCaloCluster*)fInputEvent->GetCaloCluster(i));
+    } else if(fInputEvent->IsA()==AliAODEvent::Class()){
+      if(arrClustersDebug)
+        clus = new AliAODCaloCluster(*(AliAODCaloCluster*)arrClustersDebug->At(i));
+      else
+        clus = new AliAODCaloCluster(*(AliAODCaloCluster*)fInputEvent->GetCaloCluster(i));
+    }
 
     if(!clus) continue;
     if(!((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelected(clus,fInputEvent,fMCEvent,fIsMC,fWeightJetJetMC,i)){

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
@@ -108,6 +108,9 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
 
     // Function to enable local debugging mode
     void SetLocalDebugFlag(Int_t iF) {fLocalDebugFlag = iF;}
+    
+    // Function to set correction task setting
+    void SetCorrectionTaskSetting(TString setting) {fCorrTaskSetting = setting;}
 
     void EventDebugMethod();
     void DebugMethod(AliAODConversionMother *pi0cand, AliAODConversionPhoton *gamma0, AliAODConversionPhoton *gamma1);
@@ -116,6 +119,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
   protected:
     AliV0ReaderV1*        fV0Reader;                                            // basic photon Selection Task
     TString               fV0ReaderName;
+    TString               fCorrTaskSetting;
     AliGammaConversionAODBGHandler**  fBGHandler;                               // BG handler for Conversion
     AliVEvent*            fInputEvent;                                          // current event
     AliMCEvent*           fMCEvent;                                             // corresponding MC event
@@ -401,7 +405,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaCalo(const AliAnalysisTaskGammaCalo&);                  // Prevent copy-construction
     AliAnalysisTaskGammaCalo &operator=(const AliAnalysisTaskGammaCalo&);       // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaCalo, 42);
+    ClassDef(AliAnalysisTaskGammaCalo, 43);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMerged.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMerged.h
@@ -35,7 +35,9 @@ class AliAnalysisTaskGammaCaloMerged : public AliAnalysisTaskSE {
                                                             return                                                                                        ;
                                                           }
     void SetIsHeavyIon(Int_t flag)                        { fIsHeavyIon                 = flag                                                            ; }
-
+    
+    // Function to set correction task setting
+    void SetCorrectionTaskSetting(TString setting)        { fCorrTaskSetting = setting                                                                    ; }
     // base functions for selecting photon and meson candidates in reconstructed data
     void ProcessClusters();
 
@@ -105,6 +107,7 @@ class AliAnalysisTaskGammaCaloMerged : public AliAnalysisTaskSE {
   protected:
     AliV0ReaderV1*          fV0Reader;                                          // basic photon Selection Task
     TString                 fV0ReaderName;
+    TString                 fCorrTaskSetting;
     Bool_t                  fDoLightOutput;                                     // switch for running light output, kFALSE -> normal mode, kTRUE -> light mode
     AliVEvent*              fInputEvent;                                        // current event
     AliMCEvent*             fMCEvent;                                           // corresponding MC event
@@ -274,7 +277,7 @@ class AliAnalysisTaskGammaCaloMerged : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaCaloMerged(const AliAnalysisTaskGammaCaloMerged&); // Prevent copy-construction
     AliAnalysisTaskGammaCaloMerged &operator=(const AliAnalysisTaskGammaCaloMerged&); // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaCaloMerged, 25);
+    ClassDef(AliAnalysisTaskGammaCaloMerged, 26);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.h
@@ -36,6 +36,8 @@ class AliAnalysisTaskGammaConvCalo : public AliAnalysisTaskSE {
     void SetIsHeavyIon(Int_t flag){
       fIsHeavyIon = flag;
     }
+    // Function to set correction task setting
+    void SetCorrectionTaskSetting(TString setting) {fCorrTaskSetting = setting;}
 
     // base functions for selecting photon and meson candidates in reconstructed data
     void ProcessClusters();
@@ -141,6 +143,7 @@ class AliAnalysisTaskGammaConvCalo : public AliAnalysisTaskSE {
   protected:
     AliV0ReaderV1*                      fV0Reader;              // basic photon Selection Task
     TString                             fV0ReaderName;
+    TString                             fCorrTaskSetting;       // Correction Task Special Name
     AliGammaConversionAODBGHandler**    fBGHandler;             // BG handler for Conversion
     AliConversionAODBGHandlerRP**       fBGHandlerRP;           // BG handler for Conversion (possibility to mix with respect to RP)
     AliGammaConversionAODBGHandler**    fBGClusHandler;         // BG handler for Cluster
@@ -481,7 +484,7 @@ class AliAnalysisTaskGammaConvCalo : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaConvCalo(const AliAnalysisTaskGammaConvCalo&); // Prevent copy-construction
     AliAnalysisTaskGammaConvCalo &operator=(const AliAnalysisTaskGammaConvCalo&); // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaConvCalo, 41);
+    ClassDef(AliAnalysisTaskGammaConvCalo, 42);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConv/AliCaloPhotonCuts.cxx
@@ -1195,7 +1195,6 @@ void AliCaloPhotonCuts::InitializeEMCAL(AliVEvent *event){
       if(!emcaltender)
         emcalCorrTask  = (AliEmcalCorrectionTask*) AliAnalysisManager::GetAnalysisManager()->GetTopTasks()->FindObject("AliEmcalCorrectionTask_defaultSetting");
     }
-
     if(alitender){
       TIter next(alitender->GetSupplies());
       AliTenderSupply *supply;
@@ -1207,8 +1206,10 @@ void AliCaloPhotonCuts::InitializeEMCAL(AliVEvent *event){
       fEMCALBadChannelsMap  = fEMCALRecUtils->GetEMCALBadChannelStatusMapArray();
     } else if(emcalCorrTask){
       AliEmcalCorrectionComponent * emcalCorrComponent = emcalCorrTask->GetCorrectionComponent("AliEmcalCorrectionCellBadChannel_defaultSetting");
-      fEMCALRecUtils        = emcalCorrComponent->GetRecoUtils();
-      fEMCALBadChannelsMap  = fEMCALRecUtils->GetEMCALBadChannelStatusMapArray();
+      if(emcalCorrComponent){
+        fEMCALRecUtils        = emcalCorrComponent->GetRecoUtils();
+        fEMCALBadChannelsMap  = fEMCALRecUtils->GetEMCALBadChannelStatusMapArray();
+      }
     }
     if (fEMCALRecUtils) fEMCALInitialized = kTRUE;
 

--- a/PWGGA/GammaConv/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConv/AliCaloPhotonCuts.cxx
@@ -1188,12 +1188,12 @@ void AliCaloPhotonCuts::InitializeEMCAL(AliVEvent *event){
     if(event->IsA()==AliESDEvent::Class()){
       alitender         = (AliTender*) AliAnalysisManager::GetAnalysisManager()->GetTopTasks()->FindObject("AliTender");
       if(!alitender){
-        emcalCorrTask  = (AliEmcalCorrectionTask*) AliAnalysisManager::GetAnalysisManager()->GetTopTasks()->FindObject("AliEmcalCorrectionTask_defaultSeed");
+        emcalCorrTask  = (AliEmcalCorrectionTask*) AliAnalysisManager::GetAnalysisManager()->GetTopTasks()->FindObject("AliEmcalCorrectionTask_defaultSetting");
       }
     } else if( event->IsA()==AliAODEvent::Class()){
       emcaltender       = (AliEmcalTenderTask*) AliAnalysisManager::GetAnalysisManager()->GetTopTasks()->FindObject("AliEmcalTenderTask");
       if(!emcaltender)
-        emcalCorrTask  = (AliEmcalCorrectionTask*) AliAnalysisManager::GetAnalysisManager()->GetTopTasks()->FindObject("AliEmcalCorrectionTask_defaultSeed");
+        emcalCorrTask  = (AliEmcalCorrectionTask*) AliAnalysisManager::GetAnalysisManager()->GetTopTasks()->FindObject("AliEmcalCorrectionTask_defaultSetting");
     }
 
     if(alitender){
@@ -1206,7 +1206,7 @@ void AliCaloPhotonCuts::InitializeEMCAL(AliVEvent *event){
       fEMCALRecUtils        = ((AliEMCALTenderSupply*)emcaltender->GetEMCALTenderSupply())->GetRecoUtils();
       fEMCALBadChannelsMap  = fEMCALRecUtils->GetEMCALBadChannelStatusMapArray();
     } else if(emcalCorrTask){
-      AliEmcalCorrectionComponent * emcalCorrComponent = emcalCorrTask->GetCorrectionComponent("AliEmcalCorrectionCellBadChannel_defaultSeed");
+      AliEmcalCorrectionComponent * emcalCorrComponent = emcalCorrTask->GetCorrectionComponent("AliEmcalCorrectionCellBadChannel_defaultSetting");
       fEMCALRecUtils        = emcalCorrComponent->GetRecoUtils();
       fEMCALBadChannelsMap  = fEMCALRecUtils->GetEMCALBadChannelStatusMapArray();
     }

--- a/PWGGA/GammaConv/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConv/AliCaloPhotonCuts.cxx
@@ -46,6 +46,8 @@
 #include "AliTrackerBase.h"
 #include "AliVCaloCells.h"
 #include "AliVCluster.h"
+#include "AliEmcalCorrectionTask.h"
+#include "AliEmcalCorrectionComponent.h"
 #include "AliTender.h"
 #include "AliTenderSupply.h"
 #include "AliEMCALTenderSupply.h"
@@ -109,6 +111,7 @@ AliCaloPhotonCuts::AliCaloPhotonCuts(Int_t isMC, const char *name,const char *ti
   fIsMC(0),
   fIsCurrentClusterAcceptedBeforeTM(kFALSE),
   fV0ReaderName("V0ReaderV1"),
+  fCorrTaskSetting(""),
   fCaloTrackMatcherName("CaloTrackMatcher_1"),
   fPeriodName(""),
   fCurrentMC(kNoMC),
@@ -281,6 +284,7 @@ AliCaloPhotonCuts::AliCaloPhotonCuts(const AliCaloPhotonCuts &ref) :
   fIsMC(ref.fIsMC),
   fIsCurrentClusterAcceptedBeforeTM(kFALSE),
   fV0ReaderName(ref.fV0ReaderName),
+  fCorrTaskSetting(ref.fCorrTaskSetting),
   fCaloTrackMatcherName(ref.fCaloTrackMatcherName),
   fPeriodName(ref.fPeriodName),
   fCurrentMC(ref.fCurrentMC),
@@ -1180,11 +1184,17 @@ void AliCaloPhotonCuts::InitializeEMCAL(AliVEvent *event){
   if (fClusterType == 1 || fClusterType == 3){
     AliTender* alitender=0x0;
     AliEmcalTenderTask* emcaltender=0x0;
-
-    if(event->IsA()==AliESDEvent::Class())
+    AliEmcalCorrectionTask* emcalCorrTask=0x0;
+    if(event->IsA()==AliESDEvent::Class()){
       alitender         = (AliTender*) AliAnalysisManager::GetAnalysisManager()->GetTopTasks()->FindObject("AliTender");
-    else if( event->IsA()==AliAODEvent::Class())
+      if(!alitender){
+        emcalCorrTask  = (AliEmcalCorrectionTask*) AliAnalysisManager::GetAnalysisManager()->GetTopTasks()->FindObject("AliEmcalCorrectionTask_defaultSeed");
+      }
+    } else if( event->IsA()==AliAODEvent::Class()){
       emcaltender       = (AliEmcalTenderTask*) AliAnalysisManager::GetAnalysisManager()->GetTopTasks()->FindObject("AliEmcalTenderTask");
+      if(!emcaltender)
+        emcalCorrTask  = (AliEmcalCorrectionTask*) AliAnalysisManager::GetAnalysisManager()->GetTopTasks()->FindObject("AliEmcalCorrectionTask_defaultSeed");
+    }
 
     if(alitender){
       TIter next(alitender->GetSupplies());
@@ -1194,6 +1204,10 @@ void AliCaloPhotonCuts::InitializeEMCAL(AliVEvent *event){
       fEMCALBadChannelsMap  = fEMCALRecUtils->GetEMCALBadChannelStatusMapArray();
     } else if(emcaltender){
       fEMCALRecUtils        = ((AliEMCALTenderSupply*)emcaltender->GetEMCALTenderSupply())->GetRecoUtils();
+      fEMCALBadChannelsMap  = fEMCALRecUtils->GetEMCALBadChannelStatusMapArray();
+    } else if(emcalCorrTask){
+      AliEmcalCorrectionComponent * emcalCorrComponent = emcalCorrTask->GetCorrectionComponent("AliEmcalCorrectionCellBadChannel_defaultSeed");
+      fEMCALRecUtils        = emcalCorrComponent->GetRecoUtils();
       fEMCALBadChannelsMap  = fEMCALRecUtils->GetEMCALBadChannelStatusMapArray();
     }
     if (fEMCALRecUtils) fEMCALInitialized = kTRUE;
@@ -1776,7 +1790,6 @@ void AliCaloPhotonCuts::FillHistogramsExtendedQA(AliVEvent *event, Int_t isMC)
   Int_t* nCellsBigger100MeV;
   Int_t* nCellsBigger1500MeV;
   Double_t* EnergyOfMod;
-
   if( (fClusterType == 1 || fClusterType == 3) && !fEMCALInitialized ) InitializeEMCAL(event);
   if( fClusterType == 2 && ( !fPHOSInitialized || (fPHOSCurrentRun != event->GetRunNumber()) ) ) InitializePHOS(event);
 
@@ -1861,12 +1874,30 @@ void AliCaloPhotonCuts::FillHistogramsExtendedQA(AliVEvent *event, Int_t isMC)
   delete[] EnergyOfMod;EnergyOfMod=0x0;
 
   //fill distClusterTo_withinTiming/outsideTiming
-  Int_t nclus = event->GetNumberOfCaloClusters();
+  Int_t nclus = 0;
+  TClonesArray * arrClustersExtQA = NULL;
+  if(!fCorrTaskSetting.CompareTo("")){
+    nclus = event->GetNumberOfCaloClusters();
+  } else {
+    arrClustersExtQA = dynamic_cast<TClonesArray*>(event->FindListObject(Form("%sClustersBranch",fCorrTaskSetting.Data())));
+    if(!arrClustersExtQA)
+      AliFatal(Form("%sClustersBranch was not found in AliCaloPhotonCuts::FillHistogramsExtendedQA! Check the correction framework settings!",fCorrTaskSetting.Data()));
+    nclus = arrClustersExtQA->GetEntries();
+  }
   AliVCluster* cluster = 0x0;
   AliVCluster* clusterMatched = 0x0;
   for(Int_t iClus=0; iClus<nclus ; iClus++){
-    if(event->IsA()==AliESDEvent::Class()) cluster = new AliESDCaloCluster(*(AliESDCaloCluster*)event->GetCaloCluster(iClus));
-    else if(event->IsA()==AliAODEvent::Class()) cluster = new AliAODCaloCluster(*(AliAODCaloCluster*)event->GetCaloCluster(iClus));
+    if(event->IsA()==AliESDEvent::Class()){
+      if(arrClustersExtQA)
+        cluster = new AliESDCaloCluster(*(AliESDCaloCluster*)arrClustersExtQA->At(iClus));
+      else
+        cluster = new AliESDCaloCluster(*(AliESDCaloCluster*)event->GetCaloCluster(iClus));
+    } else if(event->IsA()==AliAODEvent::Class()){
+      if(arrClustersExtQA)
+        cluster = new AliAODCaloCluster(*(AliAODCaloCluster*)arrClustersExtQA->At(iClus));
+      else
+        cluster = new AliAODCaloCluster(*(AliAODCaloCluster*)event->GetCaloCluster(iClus));
+    }
 
     if( (fClusterType == 1 || fClusterType == 3) && !cluster->IsEMCAL()){delete cluster; continue;}
     if( fClusterType == 2 && cluster->GetType() !=AliVCluster::kPHOSNeutral){delete cluster; continue;}
@@ -1903,8 +1934,17 @@ void AliCaloPhotonCuts::FillHistogramsExtendedQA(AliVEvent *event, Int_t isMC)
     if(largestCelliMod < 0) AliFatal("FillHistogramsExtendedQA: GetModuleNumberAndCellPosition found SM with ID<0?");
 
     for(Int_t iClus2=iClus+1; iClus2<nclus; iClus2++){
-      if(event->IsA()==AliESDEvent::Class()) clusterMatched = new AliESDCaloCluster(*(AliESDCaloCluster*)event->GetCaloCluster(iClus2));
-      else if(event->IsA()==AliAODEvent::Class()) clusterMatched = new AliAODCaloCluster(*(AliAODCaloCluster*)event->GetCaloCluster(iClus2));
+      if(event->IsA()==AliESDEvent::Class()){
+        if(arrClustersExtQA)
+          clusterMatched = new AliESDCaloCluster(*(AliESDCaloCluster*)arrClustersExtQA->At(iClus2));
+        else
+          clusterMatched = new AliESDCaloCluster(*(AliESDCaloCluster*)event->GetCaloCluster(iClus2));
+      } else if(event->IsA()==AliAODEvent::Class()){
+        if(arrClustersExtQA)
+          clusterMatched = new AliAODCaloCluster(*(AliAODCaloCluster*)arrClustersExtQA->At(iClus2));
+        else
+          clusterMatched = new AliAODCaloCluster(*(AliAODCaloCluster*)event->GetCaloCluster(iClus2));
+      }
 
       if( (fClusterType == 1 || fClusterType == 3) && !clusterMatched->IsEMCAL()){delete clusterMatched; continue;}
       if( fClusterType == 2 && clusterMatched->GetType() !=AliVCluster::kPHOSNeutral){delete clusterMatched; continue;}
@@ -1992,7 +2032,6 @@ void AliCaloPhotonCuts::FillHistogramsExtendedQA(AliVEvent *event, Int_t isMC)
 
     delete cluster;
   }
-
   return;
 }
 
@@ -2754,7 +2793,16 @@ void AliCaloPhotonCuts::MatchTracksToClusters(AliVEvent* event, Double_t weight,
 
   fVectorMatchedClusterIDs.clear();
 
-  Int_t nClus = event->GetNumberOfCaloClusters();
+  Int_t nClus = 0;
+  TClonesArray * arrClustersMatch = NULL;
+  if(!fCorrTaskSetting.CompareTo("")){
+    nClus = event->GetNumberOfCaloClusters();
+  } else {
+    arrClustersMatch = dynamic_cast<TClonesArray*>(event->FindListObject(Form("%sClustersBranch",fCorrTaskSetting.Data())));
+    if(!arrClustersMatch)
+      AliFatal(Form("%sClustersBranch was not found in AliCaloPhotonCuts::FillHistogramsExtendedQA! Check the correction framework settings!",fCorrTaskSetting.Data()));
+    nClus = arrClustersMatch->GetEntries();
+  }
   //Int_t nModules = 0;
 
   if(fClusterType == 1 || fClusterType == 3){
@@ -2845,15 +2893,23 @@ void AliCaloPhotonCuts::MatchTracksToClusters(AliVEvent* event, Double_t weight,
 
     Float_t clsPos[3] = {0.,0.,0.};
     for(Int_t iclus=0;iclus < nClus;iclus++){
-      AliVCluster* cluster = event->GetCaloCluster(iclus);
+      AliVCluster * cluster = NULL;
+      if(arrClustersMatch){
+        if(esdev)
+            cluster = new AliESDCaloCluster(*(AliESDCaloCluster*)arrClustersMatch->At(iclus));
+        else if(aodev)
+            cluster = new AliAODCaloCluster(*(AliAODCaloCluster*)arrClustersMatch->At(iclus));
+      } else {
+        cluster = event->GetCaloCluster(iclus);
+      }
+
       if (!cluster) continue;
       Float_t dEta, dPhi;
       if(!fCaloTrackMatcher->GetTrackClusterMatchingResidual(inTrack->GetID(),cluster->GetID(),dEta,dPhi)) continue;
       cluster->GetPosition(clsPos);
       Float_t clusterR = TMath::Sqrt( clsPos[0]*clsPos[0] + clsPos[1]*clsPos[1] );
       Float_t dR2 = dPhi*dPhi + dEta*dEta;
-//      cout << "dEta/dPhi: " << dEta << ", " << dPhi << " - ";
-//      cout << dR2 << endl;
+
       if(isEMCalOnly && fHistDistanceTrackToClusterBeforeQA)fHistDistanceTrackToClusterBeforeQA->Fill(TMath::Sqrt(dR2), weight);
       if(isEMCalOnly && fHistClusterdEtadPhiBeforeQA) fHistClusterdEtadPhiBeforeQA->Fill(dEta, dPhi, weight);
       if(isEMCalOnly && fHistClusterRBeforeQA) fHistClusterRBeforeQA->Fill(clusterR, weight);
@@ -2881,6 +2937,7 @@ void AliCaloPhotonCuts::MatchTracksToClusters(AliVEvent* event, Double_t weight,
 
       Bool_t match_dEta = (TMath::Abs(dEta) < fMaxDistTrackToClusterEta) ? kTRUE : kFALSE;
       Bool_t match_dPhi = kFALSE;
+      
       if( (inTrack->Charge() > 0) && (dPhi > fMinDistTrackToClusterPhi) && (dPhi < fMaxDistTrackToClusterPhi) ) match_dPhi = kTRUE;
       else if( (inTrack->Charge() < 0) && (dPhi < -fMinDistTrackToClusterPhi) && (dPhi > -fMaxDistTrackToClusterPhi) ) match_dPhi = kTRUE;
 
@@ -2894,7 +2951,7 @@ void AliCaloPhotonCuts::MatchTracksToClusters(AliVEvent* event, Double_t weight,
 
       if(match_dEta && match_dPhi){
         fVectorMatchedClusterIDs.push_back(cluster->GetID());
-//        cout << "MATCHED!!!!!!!!!!!!!!!!!!!!!!!!! - " << cluster->GetID() << endl;
+       // cout << "MATCHED!!!!!!!!!!!!!!!!!!!!!!!!! - " << cluster->GetID() << endl;
         if(isEMCalOnly){
           if(fHistClusterdEtadPtAfterQA) fHistClusterdEtadPtAfterQA->Fill(dEta,inTrack->Pt());
           if(fHistClusterdPhidPtAfterQA) fHistClusterdPhidPtAfterQA->Fill(dPhi,inTrack->Pt());
@@ -2909,7 +2966,7 @@ void AliCaloPhotonCuts::MatchTracksToClusters(AliVEvent* event, Double_t weight,
           else fHistClusterdEtadPhiNegTracksAfterQA->Fill(dEta, dPhi, weight);
           fHistClusterM20M02AfterQA->Fill(clusM20, clusM02, weight);
         }
-//        cout << "no match" << endl;
+       // cout << "no match" << endl;
       }
     }
 
@@ -3164,6 +3221,7 @@ void AliCaloPhotonCuts::PrintCutsWithValues() {
   if (fUseM20) printf("\t %3.2f < M20 < %3.2f\n", fMinM20, fMaxM20 );
   if (fUseDispersion) printf("\t dispersion < %3.2f\n", fMaxDispersion );
   if (fUseNLM) printf("\t %d < NLM < %d\n", fMinNLM, fMaxNLM );
+  printf("Correction Task Setting: %s \n",fCorrTaskSetting.Data());
 
   printf("NonLinearity Correction: \n");
   printf("VO Reader name: %s \n",fV0ReaderName.Data());

--- a/PWGGA/GammaConv/AliCaloPhotonCuts.h
+++ b/PWGGA/GammaConv/AliCaloPhotonCuts.h
@@ -359,7 +359,10 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     Bool_t      AcceptCellByBadChannelMap (Int_t absID );
     void        SetExoticsMinCellEnergyCut(Double_t minE)       { fExoticMinEnergyCell = minE; return;}
     void        SetExoticsQA(Bool_t enable)                     { fDoExoticsQA         = enable; return;}
-
+    
+    // Function to set correction task setting
+    void SetCorrectionTaskSetting(TString setting) {fCorrTaskSetting = setting;}
+    
     AliEMCALGeometry* GetGeomEMCAL(){return fGeomEMCAL;}
     AliPHOSGeometry*  GetGeomPHOS() {return fGeomPHOS;}
 
@@ -388,6 +391,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
 
     //for NonLinearity correction
     TString   fV0ReaderName;                            // Name of V0Reader
+    TString   fCorrTaskSetting;                         // Name of Correction Task Setting
     TString   fCaloTrackMatcherName;                    // Name of global TrackMatching instance
     TString   fPeriodName;                              // PeriodName of MC
     MCSet     fCurrentMC;                               // enum for current MC set being processed

--- a/PWGGA/GammaConv/AliCaloTrackMatcher.h
+++ b/PWGGA/GammaConv/AliCaloTrackMatcher.h
@@ -27,6 +27,7 @@ class AliCaloTrackMatcher : public AliAnalysisTaskSE {
     TList* GetCaloTrackMatcherHistograms() {return fListHistos;}
 
     void SetV0ReaderName(TString name)    {fV0ReaderName = name; return;}
+    void SetCorrectionTaskSetting(TString setting) {fCorrTaskSetting = setting;}
     void SetAnalysisTrainMode(TString mode){fAnalysisTrainMode = mode; return;}
     void SetMatchingResidual(Float_t res) {fMatchingResidual = res; return;}
     void SetMatchingWindow(Float_t win) {fMatchingWindow = win; return;}
@@ -95,6 +96,7 @@ class AliCaloTrackMatcher : public AliAnalysisTaskSE {
     // basic variables/objects
     Int_t                 fClusterType;            // EMCal(1), PHOS(2) or not running (0)
     TString               fV0ReaderName;           // Name of V0Reader
+    TString               fCorrTaskSetting;        // Name of Corr Task Setting
     TString               fAnalysisTrainMode;      // AnalysisTrainMode: Grid or GSI //Grid by default
     Double_t              fMatchingWindow;         // matching window to prevent unnecessary propagations
     Float_t               fMatchingResidual;       // matching residual below which track <-> cluster associations should be stored
@@ -124,7 +126,7 @@ class AliCaloTrackMatcher : public AliAnalysisTaskSE {
     TH2F*                 fHistControlMatches;     // bookkeeping for processed tracks/clusters and succesful matches
     TH2F*                 fSecHistControlMatches;  // bookkeeping for processed V0-tracks/clusters and succesful matches
 
-    ClassDef(AliCaloTrackMatcher,3)
+    ClassDef(AliCaloTrackMatcher,4)
 };
 
 #endif

--- a/PWGGA/GammaConv/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConv/AliConvEventCuts.cxx
@@ -2967,7 +2967,7 @@ Bool_t AliConvEventCuts::MimicTrigger(AliVEvent *event, Bool_t isMC ){
       arrClustersMimic = dynamic_cast<TClonesArray*>(event->FindListObject(Form("%sClustersBranch",fCorrTaskSetting.Data())));
       if(!arrClustersMimic)
         AliFatal(Form("%sClustersBranch was not found in AliConvEventCuts! Check the correction framework settings!",fCorrTaskSetting.Data()));
-      nclus = arrClustersProcess->GetEntries();
+      nclus = arrClustersMimic->GetEntries();
     }
 
     if(nclus == 0)  return kFALSE;
@@ -2976,12 +2976,12 @@ Bool_t AliConvEventCuts::MimicTrigger(AliVEvent *event, Bool_t isMC ){
     Bool_t eventIsAccepted = kFALSE;
     for(Int_t i = 0; i < nclus; i++){
       AliVCluster* clus = NULL;
-      if(fInputEvent->IsA()==AliESDEvent::Class()){
+      if(event->IsA()==AliESDEvent::Class()){
         if(arrClustersMimic)
           clus = new AliESDCaloCluster(*(AliESDCaloCluster*)arrClustersMimic->At(i));
         else
           clus = event->GetCaloCluster(i);
-      } else if(fInputEvent->IsA()==AliAODEvent::Class()){
+      } else if(event->IsA()==AliAODEvent::Class()){
         if(arrClustersMimic)
           clus = new AliAODCaloCluster(*(AliAODCaloCluster*)arrClustersMimic->At(i));
         else
@@ -3025,13 +3025,14 @@ Bool_t AliConvEventCuts::MimicTrigger(AliVEvent *event, Bool_t isMC ){
 //       cout << runnumber << "\t"<< binRun << "\t L1 \t"<< threshold << endl;
 
       TClonesArray * arrClustersMimic = NULL;
+      Int_t nclus = 0;
       if(!fCorrTaskSetting.CompareTo("")){
         nclus = event->GetNumberOfCaloClusters();
       } else {
         arrClustersMimic = dynamic_cast<TClonesArray*>(event->FindListObject(Form("%sClustersBranch",fCorrTaskSetting.Data())));
         if(!arrClustersMimic)
           AliFatal(Form("%sClustersBranch was not found in AliConvEventCuts! Check the correction framework settings!",fCorrTaskSetting.Data()));
-        nclus = arrClustersProcess->GetEntries();
+        nclus = arrClustersMimic->GetEntries();
       }
 
       if(nclus == 0)  return kFALSE;
@@ -3040,12 +3041,12 @@ Bool_t AliConvEventCuts::MimicTrigger(AliVEvent *event, Bool_t isMC ){
       Bool_t eventIsAccepted = kFALSE;
       for(Int_t i = 0; i < nclus; i++){
         AliVCluster* clus = NULL;
-        if(fInputEvent->IsA()==AliESDEvent::Class()){
+        if(event->IsA()==AliESDEvent::Class()){
           if(arrClustersMimic)
             clus = new AliESDCaloCluster(*(AliESDCaloCluster*)arrClustersMimic->At(i));
           else
             clus = event->GetCaloCluster(i);
-        } else if(fInputEvent->IsA()==AliAODEvent::Class()){
+        } else if(event->IsA()==AliAODEvent::Class()){
           if(arrClustersMimic)
             clus = new AliAODCaloCluster(*(AliAODCaloCluster*)arrClustersMimic->At(i));
           else
@@ -3088,7 +3089,7 @@ Bool_t AliConvEventCuts::MimicTrigger(AliVEvent *event, Bool_t isMC ){
         arrClustersMimic = dynamic_cast<TClonesArray*>(event->FindListObject(Form("%sClustersBranch",fCorrTaskSetting.Data())));
         if(!arrClustersMimic)
           AliFatal(Form("%sClustersBranch was not found in AliConvEventCuts! Check the correction framework settings!",fCorrTaskSetting.Data()));
-        nclus = arrClustersProcess->GetEntries();
+        nclus = arrClustersMimic->GetEntries();
       }
 
       if(nclus == 0)  return kFALSE;
@@ -3097,12 +3098,12 @@ Bool_t AliConvEventCuts::MimicTrigger(AliVEvent *event, Bool_t isMC ){
       Bool_t eventIsAccepted = kFALSE;
       for(Int_t i = 0; i < nclus; i++){
         AliVCluster* clus = NULL;
-        if(fInputEvent->IsA()==AliESDEvent::Class()){
+        if(event->IsA()==AliESDEvent::Class()){
           if(arrClustersMimic)
             clus = new AliESDCaloCluster(*(AliESDCaloCluster*)arrClustersMimic->At(i));
           else
             clus = event->GetCaloCluster(i);
-        } else if(fInputEvent->IsA()==AliAODEvent::Class()){
+        } else if(event->IsA()==AliAODEvent::Class()){
           if(arrClustersMimic)
             clus = new AliAODCaloCluster(*(AliAODCaloCluster*)arrClustersMimic->At(i));
           else

--- a/PWGGA/GammaConv/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConv/AliConvEventCuts.cxx
@@ -153,6 +153,7 @@ AliConvEventCuts::AliConvEventCuts(const char *name,const char *title) :
   hSPDClusterTrackletBackgroundBefore(NULL),
   hSPDClusterTrackletBackground(NULL),
   fV0ReaderName(""),
+  fCorrTaskSetting(""),
   fCaloTriggers(NULL),
   fTriggerPatchInfo(NULL),
   fMainTriggerPatchEMCAL(NULL),
@@ -266,6 +267,7 @@ AliConvEventCuts::AliConvEventCuts(const AliConvEventCuts &ref) :
   hSPDClusterTrackletBackgroundBefore(NULL),
   hSPDClusterTrackletBackground(NULL),
   fV0ReaderName(ref.fV0ReaderName),
+  fCorrTaskSetting(ref.fCorrTaskSetting),
   fCaloTriggers(NULL),
   fTriggerPatchInfo(NULL),
   fMainTriggerPatchEMCAL(NULL),
@@ -2957,9 +2959,16 @@ Bool_t AliConvEventCuts::MimicTrigger(AliVEvent *event, Bool_t isMC ){
     }
 
 //     cout << runnumber << "\t"<< binRun << "\t"<< threshold << endl;
-
     Int_t nclus = 0;
-    nclus = event->GetNumberOfCaloClusters();
+    TClonesArray * arrClustersMimic = NULL;
+    if(!fCorrTaskSetting.CompareTo("")){
+      nclus = event->GetNumberOfCaloClusters();
+    } else {
+      arrClustersMimic = dynamic_cast<TClonesArray*>(event->FindListObject(Form("%sClustersBranch",fCorrTaskSetting.Data())));
+      if(!arrClustersMimic)
+        AliFatal(Form("%sClustersBranch was not found in AliConvEventCuts! Check the correction framework settings!",fCorrTaskSetting.Data()));
+      nclus = arrClustersProcess->GetEntries();
+    }
 
     if(nclus == 0)  return kFALSE;
 
@@ -2967,7 +2976,18 @@ Bool_t AliConvEventCuts::MimicTrigger(AliVEvent *event, Bool_t isMC ){
     Bool_t eventIsAccepted = kFALSE;
     for(Int_t i = 0; i < nclus; i++){
       AliVCluster* clus = NULL;
-      clus = event->GetCaloCluster(i);
+      if(fInputEvent->IsA()==AliESDEvent::Class()){
+        if(arrClustersMimic)
+          clus = new AliESDCaloCluster(*(AliESDCaloCluster*)arrClustersMimic->At(i));
+        else
+          clus = event->GetCaloCluster(i);
+      } else if(fInputEvent->IsA()==AliAODEvent::Class()){
+        if(arrClustersMimic)
+          clus = new AliAODCaloCluster(*(AliAODCaloCluster*)arrClustersMimic->At(i));
+        else
+          clus = event->GetCaloCluster(i);
+      }
+
       if (!clus) continue;
       if (!clus->IsEMCAL()) continue;
       if (clus->GetM02()<0.1) continue;
@@ -3004,8 +3024,15 @@ Bool_t AliConvEventCuts::MimicTrigger(AliVEvent *event, Bool_t isMC ){
 
 //       cout << runnumber << "\t"<< binRun << "\t L1 \t"<< threshold << endl;
 
-      Int_t nclus = 0;
-      nclus = event->GetNumberOfCaloClusters();
+      TClonesArray * arrClustersMimic = NULL;
+      if(!fCorrTaskSetting.CompareTo("")){
+        nclus = event->GetNumberOfCaloClusters();
+      } else {
+        arrClustersMimic = dynamic_cast<TClonesArray*>(event->FindListObject(Form("%sClustersBranch",fCorrTaskSetting.Data())));
+        if(!arrClustersMimic)
+          AliFatal(Form("%sClustersBranch was not found in AliConvEventCuts! Check the correction framework settings!",fCorrTaskSetting.Data()));
+        nclus = arrClustersProcess->GetEntries();
+      }
 
       if(nclus == 0)  return kFALSE;
 
@@ -3013,7 +3040,17 @@ Bool_t AliConvEventCuts::MimicTrigger(AliVEvent *event, Bool_t isMC ){
       Bool_t eventIsAccepted = kFALSE;
       for(Int_t i = 0; i < nclus; i++){
         AliVCluster* clus = NULL;
-        clus = event->GetCaloCluster(i);
+        if(fInputEvent->IsA()==AliESDEvent::Class()){
+          if(arrClustersMimic)
+            clus = new AliESDCaloCluster(*(AliESDCaloCluster*)arrClustersMimic->At(i));
+          else
+            clus = event->GetCaloCluster(i);
+        } else if(fInputEvent->IsA()==AliAODEvent::Class()){
+          if(arrClustersMimic)
+            clus = new AliAODCaloCluster(*(AliAODCaloCluster*)arrClustersMimic->At(i));
+          else
+            clus = event->GetCaloCluster(i);
+        }
         if (!clus) continue;
         if (!clus->IsEMCAL()) continue;
         if (clus->GetM02()<0.1) continue;
@@ -3044,7 +3081,15 @@ Bool_t AliConvEventCuts::MimicTrigger(AliVEvent *event, Bool_t isMC ){
 //       cout << runnumber << "\t"<< binRun << "\t L2 \t"<< threshold << endl;
 
       Int_t nclus = 0;
-      nclus = event->GetNumberOfCaloClusters();
+      TClonesArray * arrClustersMimic = NULL;
+      if(!fCorrTaskSetting.CompareTo("")){
+        nclus = event->GetNumberOfCaloClusters();
+      } else {
+        arrClustersMimic = dynamic_cast<TClonesArray*>(event->FindListObject(Form("%sClustersBranch",fCorrTaskSetting.Data())));
+        if(!arrClustersMimic)
+          AliFatal(Form("%sClustersBranch was not found in AliConvEventCuts! Check the correction framework settings!",fCorrTaskSetting.Data()));
+        nclus = arrClustersProcess->GetEntries();
+      }
 
       if(nclus == 0)  return kFALSE;
 
@@ -3052,7 +3097,17 @@ Bool_t AliConvEventCuts::MimicTrigger(AliVEvent *event, Bool_t isMC ){
       Bool_t eventIsAccepted = kFALSE;
       for(Int_t i = 0; i < nclus; i++){
         AliVCluster* clus = NULL;
-        clus = event->GetCaloCluster(i);
+        if(fInputEvent->IsA()==AliESDEvent::Class()){
+          if(arrClustersMimic)
+            clus = new AliESDCaloCluster(*(AliESDCaloCluster*)arrClustersMimic->At(i));
+          else
+            clus = event->GetCaloCluster(i);
+        } else if(fInputEvent->IsA()==AliAODEvent::Class()){
+          if(arrClustersMimic)
+            clus = new AliAODCaloCluster(*(AliAODCaloCluster*)arrClustersMimic->At(i));
+          else
+            clus = event->GetCaloCluster(i);
+        }
         if (!clus) continue;
         if (!clus->IsEMCAL()) continue;
         if (clus->GetM02()<0.1) continue;

--- a/PWGGA/GammaConv/AliConvEventCuts.h
+++ b/PWGGA/GammaConv/AliConvEventCuts.h
@@ -340,6 +340,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
       Bool_t    SetVertexCut(Int_t vertexCut);
       void    SetPeriodEnum (TString periodName);
       void    SetPeriodEnumExplicit ( PeriodVar periodEnum )                        { fPeriodEnum = periodEnum                                  ; }
+      void    SetCorrectionTaskSetting(TString setting)                             { fCorrTaskSetting = setting                                ; }
       void    SetTriggerMimicking(Bool_t value)                                     { fMimicTrigger = value                                     ;
                                                                                       if(value)AliInfo("enabled trigger mimicking")             ; }
       void    SetTriggerOverlapRejecion (Bool_t value)                              { fRejectTriggerOverlap = value                             ;
@@ -625,6 +626,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
       TH2F*                       hSPDClusterTrackletBackground;          ///< SPD tracklets vs SPD clusters for background-correction
       // trigger information
       TString                     fV0ReaderName;                          ///< Name of V0Reader
+      TString                     fCorrTaskSetting;                       ///< Name of Corr Task Setting
       AliVCaloTrigger*            fCaloTriggers;                          //!<! calo triggers
       TClonesArray*               fTriggerPatchInfo;                      //!<! trigger patch info array
       AliEMCALTriggerPatchInfo *  fMainTriggerPatchEMCAL;                 ///< main trigger patch, will be cached after first call

--- a/PWGGA/GammaConv/AliConvEventCuts.h
+++ b/PWGGA/GammaConv/AliConvEventCuts.h
@@ -653,7 +653,7 @@ class AliConvEventCuts : public AliAnalysisCuts {
   private:
 
       /// \cond CLASSIMP
-      ClassDef(AliConvEventCuts,41)
+      ClassDef(AliConvEventCuts,42)
       /// \endcond
 };
 

--- a/PWGGA/GammaConv/config/PWGGA_CF_config.yaml
+++ b/PWGGA/GammaConv/config/PWGGA_CF_config.yaml
@@ -1,0 +1,151 @@
+configurationName: "PWGGA configuration"
+pass: "pass4"
+inputObjects:
+    cells:
+        defaultCells:
+            branchName: "usedefault"
+    clusterContainers:
+        defaultClusterContainer:
+            branchName: "usedefault"
+        ClusterContainerS500A100:
+            branchName: "S500A100ClustersBranch"
+        ClusterContainerS500A100W3:
+            branchName: "S500A100W3ClustersBranch"
+        ClusterContainerS500A100W5:
+            branchName: "S500A100W5ClustersBranch"
+        ClusterContainerS400A100:
+            branchName: "S400A100ClustersBranch"
+        ClusterContainerS600A100:
+            branchName: "S600A100ClustersBranch"
+        ClusterContainerS500A75:
+            branchName: "S500A75ClustersBranch"
+        ClusterContainerS500A125:
+            branchName: "S500A125ClustersBranch"
+        ClusterContainerS500A150:
+            branchName: "S500A150ClustersBranch"
+    trackContainers:
+        defaultTrackContainer:
+            branchName: "usedefault"
+CellEnergy:
+    createHistos: true
+CellEnergy_defaultSeed:
+    enabled: true
+
+CellBadChannel:
+    createHistos: true
+CellBadChannel_defaultSeed:
+    enabled: true
+
+CellTimeCalib:
+    createHistos: true
+CellTimeCalib_defaultSeed:
+    enabled: true
+
+Clusterizer:
+    createHistos: true
+    clusterizer: kClusterizerv2
+    cellTimeMin: -500e-9
+    cellTimeMax: +500e-9
+    clusterTimeLength: 1e6
+    recalDistToBadChannels: true
+    remapMcAod: false
+    diffEAggregation: 0.0
+    cellsNames:
+        - defaultCells
+Clusterizer_defaultSeed:
+    # w0 standard is 4.5
+    enabled: true
+    cellE: 0.1
+    seedE: 0.5
+    clusterContainersNames:
+        - defaultClusterContainer
+Clusterizer_S500A100:
+    enabled: true
+    cellE: 0.1
+    seedE: 0.5
+    clusterContainersNames:
+        - ClusterContainerS500A100
+Clusterizer_S500A100W3:
+    enabled: true
+    cellE: 0.1
+    seedE: 0.5
+    clusterContainersNames:
+        - ClusterContainerS500A100W3
+Clusterizer_S500A100W5:
+    enabled: true
+    cellE: 0.1
+    seedE: 0.5
+    w0: 3
+    clusterContainersNames:
+        - ClusterContainerS500A100W5
+Clusterizer_S400A100:
+    enabled: true
+    cellE: 0.1
+    seedE: 0.4
+    w0: 5
+    clusterContainersNames:
+        - ClusterContainerS400A100
+Clusterizer_S600A100:
+    enabled: true
+    cellE: 0.1
+    seedE: 0.6
+    clusterContainersNames:
+        - ClusterContainerS600A100
+Clusterizer_S500A75:
+    enabled: true
+    cellE: 0.075
+    seedE: 0.5
+    clusterContainersNames:
+        - ClusterContainerS500A75
+Clusterizer_S500A125:
+    enabled: true
+    cellE: 0.125
+    seedE: 0.5
+    clusterContainersNames:
+        - ClusterContainerS500A125
+Clusterizer_S500A150:
+    enabled: true
+    cellE: 0.15
+    seedE: 0.5
+    clusterContainersNames:
+        - ClusterContainerS500A150
+
+ClusterNonLinearity:
+    createHistos: true
+    nonLinFunct: kNoCorrection
+ClusterNonLinearity_defaultSeed:
+    enabled: true
+    clusterContainersNames:
+        - defaultClusterContainer
+ClusterNonLinearity_S500A100:
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A100
+ClusterNonLinearity_S500A100W3:
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A100W3
+ClusterNonLinearity_S500A100W5:
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A100W5
+ClusterNonLinearity_S400A100:
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS400A100
+ClusterNonLinearity_S600A100:
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS600A100
+ClusterNonLinearity_S500A75:
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A75
+ClusterNonLinearity_S500A125:
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A125
+ClusterNonLinearity_S500A150:
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A150

--- a/PWGGA/GammaConv/config/PWGGA_CF_config.yaml
+++ b/PWGGA/GammaConv/config/PWGGA_CF_config.yaml
@@ -69,20 +69,20 @@ Clusterizer_S500A100W3:
     enabled: true
     cellE: 0.1
     seedE: 0.5
+    w0: 3
     clusterContainersNames:
         - ClusterContainerS500A100W3
 Clusterizer_S500A100W5:
     enabled: true
     cellE: 0.1
     seedE: 0.5
-    w0: 3
+    w0: 5
     clusterContainersNames:
         - ClusterContainerS500A100W5
 Clusterizer_S400A100:
     enabled: true
     cellE: 0.1
     seedE: 0.4
-    w0: 5
     clusterContainersNames:
         - ClusterContainerS400A100
 Clusterizer_S600A100:

--- a/PWGGA/GammaConv/config/PWGGA_CF_config.yaml
+++ b/PWGGA/GammaConv/config/PWGGA_CF_config.yaml
@@ -28,17 +28,17 @@ inputObjects:
             branchName: "usedefault"
 CellEnergy:
     createHistos: true
-CellEnergy_defaultSeed:
+CellEnergy_defaultSetting:
     enabled: true
 
 CellBadChannel:
     createHistos: true
-CellBadChannel_defaultSeed:
+CellBadChannel_defaultSetting:
     enabled: true
 
 CellTimeCalib:
     createHistos: true
-CellTimeCalib_defaultSeed:
+CellTimeCalib_defaultSetting:
     enabled: true
 
 Clusterizer:
@@ -52,7 +52,7 @@ Clusterizer:
     diffEAggregation: 0.0
     cellsNames:
         - defaultCells
-Clusterizer_defaultSeed:
+Clusterizer_defaultSetting:
     # w0 standard is 4.5
     enabled: true
     cellE: 0.1
@@ -113,7 +113,7 @@ Clusterizer_S500A150:
 ClusterNonLinearity:
     createHistos: true
     nonLinFunct: kNoCorrection
-ClusterNonLinearity_defaultSeed:
+ClusterNonLinearity_defaultSetting:
     enabled: true
     clusterContainersNames:
         - defaultClusterContainer

--- a/PWGGA/GammaConv/config/PWGGA_CF_config_MC.yaml
+++ b/PWGGA/GammaConv/config/PWGGA_CF_config_MC.yaml
@@ -1,0 +1,191 @@
+configurationName: "PWGGA configuration"
+pass: "pass4"
+inputObjects:
+    cells:
+        defaultCells:
+            branchName: "usedefault"
+    clusterContainers:
+        defaultClusterContainer:
+            branchName: "usedefault"
+        ClusterContainerS500A100:
+            branchName: "S500A100ClustersBranch"
+        ClusterContainerS500A100W3:
+            branchName: "S500A100W3ClustersBranch"
+        ClusterContainerS500A100W35:
+            branchName: "S500A100W35ClustersBranch"
+        ClusterContainerS500A100W4:
+            branchName: "S500A100W4ClustersBranch"
+        ClusterContainerS500A100W5:
+            branchName: "S500A100W5ClustersBranch"
+        ClusterContainerS500A100W55:
+            branchName: "S500A100W55ClustersBranch"
+        ClusterContainerS400A100:
+            branchName: "S400A100ClustersBranch"
+        ClusterContainerS600A100:
+            branchName: "S600A100ClustersBranch"
+        ClusterContainerS500A75:
+            branchName: "S500A75ClustersBranch"
+        ClusterContainerS500A125:
+            branchName: "S500A125ClustersBranch"
+        ClusterContainerS500A150:
+            branchName: "S500A150ClustersBranch"
+    trackContainers:
+        defaultTrackContainer:
+            branchName: "usedefault"
+
+CellEnergy:
+    createHistos: false
+CellEnergy_defaultSetting:
+    enabled: false
+
+CellBadChannel:
+    createHistos: true
+CellBadChannel_defaultSetting:
+    enabled: true
+
+CellTimeCalib:
+    createHistos: false
+CellTimeCalib_defaultSetting:
+    enabled: false
+
+Clusterizer:
+    createHistos: true
+    clusterizer: kClusterizerv2
+    cellTimeMin: -1000e-9
+    cellTimeMax: +1000e-9
+    clusterTimeLength: 1e6
+    recalDistToBadChannels: true
+    remapMcAod: false
+    diffEAggregation: 0.0
+    cellsNames:
+        - defaultCells
+Clusterizer_defaultSetting:
+    # w0 standard is 4.5
+    enabled: true
+    cellE: 0.1
+    seedE: 0.5
+    clusterContainersNames:
+        - defaultClusterContainer
+Clusterizer_S500A100:
+    enabled: true
+    cellE: 0.1
+    seedE: 0.5
+    clusterContainersNames:
+        - ClusterContainerS500A100
+Clusterizer_S500A100W3:
+    enabled: true
+    cellE: 0.1
+    seedE: 0.5
+    w0: 3
+    clusterContainersNames:
+        - ClusterContainerS500A100W3
+Clusterizer_S500A100W35:
+    enabled: true
+    cellE: 0.1
+    seedE: 0.5
+    w0: 3.5
+    clusterContainersNames:
+        - ClusterContainerS500A100W35
+Clusterizer_S500A100W4:
+    enabled: true
+    cellE: 0.1
+    seedE: 0.5
+    w0: 4.0
+    clusterContainersNames:
+        - ClusterContainerS500A100W4
+Clusterizer_S500A100W5:
+    enabled: true
+    cellE: 0.1
+    seedE: 0.5
+    w0: 5.0
+    clusterContainersNames:
+        - ClusterContainerS500A100W5
+Clusterizer_S500A100W55:
+    enabled: true
+    cellE: 0.1
+    seedE: 0.5
+    w0: 5.5
+    clusterContainersNames:
+        - ClusterContainerS500A100W55
+Clusterizer_S400A100:
+    enabled: true
+    cellE: 0.1
+    seedE: 0.4
+    clusterContainersNames:
+        - ClusterContainerS400A100
+Clusterizer_S600A100:
+    enabled: true
+    cellE: 0.1
+    seedE: 0.6
+    clusterContainersNames:
+        - ClusterContainerS600A100
+Clusterizer_S500A75:
+    enabled: true
+    cellE: 0.075
+    seedE: 0.5
+    clusterContainersNames:
+        - ClusterContainerS500A75
+Clusterizer_S500A125:
+    enabled: true
+    cellE: 0.125
+    seedE: 0.5
+    clusterContainersNames:
+        - ClusterContainerS500A125
+Clusterizer_S500A150:
+    enabled: true
+    cellE: 0.15
+    seedE: 0.5
+    clusterContainersNames:
+        - ClusterContainerS500A150
+
+ClusterNonLinearity:
+    createHistos: true
+    nonLinFunct: kNoCorrection
+ClusterNonLinearity_defaultSetting:
+    enabled: true
+    clusterContainersNames:
+        - defaultClusterContainer
+ClusterNonLinearity_S500A100:
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A100
+ClusterNonLinearity_S500A100W3:
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A100W3
+ClusterNonLinearity_S500A100W35:
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A100W35
+ClusterNonLinearity_S500A100W4:
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A100W4
+ClusterNonLinearity_S500A100W5:
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A100W5
+ClusterNonLinearity_S500A100W55:
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A100W55
+ClusterNonLinearity_S400A100:
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS400A100
+ClusterNonLinearity_S600A100:
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS600A100
+ClusterNonLinearity_S500A75:
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A75
+ClusterNonLinearity_S500A125:
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A125
+ClusterNonLinearity_S500A150:
+    enabled: true
+    clusterContainersNames:
+        - ClusterContainerS500A150

--- a/PWGGA/GammaConv/macros/AddTask_GammaCaloMerged_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCaloMerged_pp.C
@@ -78,6 +78,7 @@ void AddTask_GammaCaloMerged_pp(  Int_t     trainConfig                 = 1,    
                                   Double_t  minEnergyForExoticsCut      = 1.0,                // minimum energy to be used for exotics CutHandler
                                   Bool_t    runQAForExotics             = kFALSE,             // switch to run QA for exotic clusters
                                   Bool_t    runDetailedM02              = kFALSE,             // switch on very detailed M02 distribution
+                                  TString   corrTaskSetting             = "",                // select which correction task setting to use
                                   TString   additionalTrainConfig       = "0"                 // additional counter for trainconfig, always has to be last parameter
 ) {
   TH1S* histoAcc = 0x0;         // histo for modified acceptance
@@ -111,6 +112,7 @@ void AddTask_GammaCaloMerged_pp(  Int_t     trainConfig                 = 1,    
     trainConfig = trainConfig + sAdditionalTrainConfig.Atoi();
     cout << "INFO: AddTask_GammaCaloMerged_pp running additionalTrainConfig '" << sAdditionalTrainConfig.Atoi() << "', train config: '" << trainConfig << "'" << endl;
   }
+  cout << "corrTaskSetting: " << corrTaskSetting.Data() << endl;
 
   Int_t isHeavyIon = 0;
 
@@ -202,6 +204,7 @@ void AddTask_GammaCaloMerged_pp(  Int_t     trainConfig                 = 1,    
   task->SetIsMC(isMC);
   task->SetV0ReaderName(V0ReaderName);
   task->SetLightOutput(runLightOutput);
+  task->SetCorrectionTaskSetting(corrTaskSetting);
 
   //create cut handler
   CutHandlerCaloMerged cuts;
@@ -975,6 +978,7 @@ void AddTask_GammaCaloMerged_pp(  Int_t     trainConfig                 = 1,    
     if( !(AliCaloTrackMatcher*)mgr->GetTask(TrackMatcherName.Data()) ){
       AliCaloTrackMatcher* fTrackMatcher = new AliCaloTrackMatcher(TrackMatcherName.Data(),caloCutPos.Atoi());
       fTrackMatcher->SetV0ReaderName(V0ReaderName);
+      fTrackMatcher->SetCorrectionTaskSetting(corrTaskSetting);
       mgr->AddTask(fTrackMatcher);
       mgr->ConnectInput(fTrackMatcher,0,cinput);
     }
@@ -996,6 +1000,7 @@ void AddTask_GammaCaloMerged_pp(  Int_t     trainConfig                 = 1,    
     analysisEventCuts[i]->SetTriggerOverlapRejecion(enableTriggerOverlapRej);
     analysisEventCuts[i]->SetMaxFacPtHard(maxFacPtHard);
     analysisEventCuts[i]->SetV0ReaderName(V0ReaderName);
+    analysisEventCuts[i]->SetCorrectionTaskSetting(corrTaskSetting);
     if(periodNameV0Reader.CompareTo("") != 0) analysisEventCuts[i]->SetPeriodEnum(periodNameV0Reader);
     analysisEventCuts[i]->SetLightOutput(runLightOutput);
     analysisEventCuts[i]->InitializeCutsFromCutString((cuts.GetEventCut(i)).Data());
@@ -1006,6 +1011,7 @@ void AddTask_GammaCaloMerged_pp(  Int_t     trainConfig                 = 1,    
     analysisClusterCuts[i]->SetIsPureCaloCut(2);
     analysisClusterCuts[i]->SetHistoToModifyAcceptance(histoAcc);
     analysisClusterCuts[i]->SetV0ReaderName(V0ReaderName);
+    analysisClusterCuts[i]->SetCorrectionTaskSetting(corrTaskSetting);
     analysisClusterCuts[i]->SetCaloTrackMatcherName(TrackMatcherName);
     analysisClusterCuts[i]->SetLightOutput(runLightOutput);
     analysisClusterCuts[i]->SetExoticsMinCellEnergyCut(minEnergyForExoticsCut);
@@ -1039,6 +1045,7 @@ void AddTask_GammaCaloMerged_pp(  Int_t     trainConfig                 = 1,    
   }
   task->SetEnableDetailedM02Distribtuon(runDetailedM02);
   task->SetSelectedMesonID(selectedMeson);
+  task->SetCorrectionTaskSetting(corrTaskSetting);
   task->SetEventCutList(numberOfCuts,EventCutList);
   task->SetCaloCutList(numberOfCuts,ClusterCutList);
   task->SetCaloMergedCutList(numberOfCuts,ClusterMergedCutList);

--- a/PWGGA/GammaConv/macros/AddTask_GammaCaloMerged_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCaloMerged_pp.C
@@ -78,10 +78,10 @@ void AddTask_GammaCaloMerged_pp(  Int_t     trainConfig                 = 1,    
                                   Double_t  minEnergyForExoticsCut      = 1.0,                // minimum energy to be used for exotics CutHandler
                                   Bool_t    runQAForExotics             = kFALSE,             // switch to run QA for exotic clusters
                                   Bool_t    runDetailedM02              = kFALSE,             // switch on very detailed M02 distribution
-                                  TString   corrTaskSetting             = "",                // select which correction task setting to use
                                   TString   additionalTrainConfig       = "0"                 // additional counter for trainconfig, always has to be last parameter
 ) {
   TH1S* histoAcc = 0x0;         // histo for modified acceptance
+  TString corrTaskSetting = ""; // sets which correction task setting to use
   //parse additionalTrainConfig flag
   TObjArray *rAddConfigArr = additionalTrainConfig.Tokenize("_");
   if(rAddConfigArr->GetEntries()<1){cout << "ERROR: AddTask_GammaCaloMerged_pp during parsing of additionalTrainConfig String '" << additionalTrainConfig.Data() << "'" << endl; return;}
@@ -103,6 +103,10 @@ void AddTask_GammaCaloMerged_pp(  Int_t     trainConfig                 = 1,    
         histoAcc = (TH1S*) w->Get(tempType.Data());
         if(!histoAcc) {cout << "ERROR: Could not find histo: " << tempType.Data() << endl;return;}
         cout << "found: " << histoAcc << endl;
+      }else if(tempStr.BeginsWith("CF")){
+        cout << "INFO: AddTask_GammaCaloMerged_pp will use custom branch from Correction Framework!" << endl;
+        corrTaskSetting = tempStr;
+        corrTaskSetting.Replace(0,2,"");
       }
     }
   }

--- a/PWGGA/GammaConv/macros/AddTask_GammaCaloMerged_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCaloMerged_pp.C
@@ -1025,6 +1025,7 @@ void AddTask_GammaCaloMerged_pp(  Int_t     trainConfig                 = 1,    
     analysisClusterMergedCuts[i]->SetIsPureCaloCut(1);
     analysisClusterMergedCuts[i]->SetHistoToModifyAcceptance(histoAcc);
     analysisClusterMergedCuts[i]->SetV0ReaderName(V0ReaderName);
+    analysisClusterMergedCuts[i]->SetCorrectionTaskSetting(corrTaskSetting);
     analysisClusterMergedCuts[i]->SetCaloTrackMatcherName(TrackMatcherName);
     analysisClusterMergedCuts[i]->SetLightOutput(runLightOutput);
     analysisClusterMergedCuts[i]->SetExoticsMinCellEnergyCut(minEnergyForExoticsCut);

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pPb.C
@@ -76,12 +76,12 @@ void AddTask_GammaCalo_pPb(
                             TString   periodNameAnchor              = "",               // name of anchor period for weighting
                             Bool_t     enableSortingMCLabels        = kTRUE,            // enable sorting for MC cluster labels
                             Bool_t     runLightOutput               = kFALSE,           // switch to run light output (only essential histograms for afterburner)
-                            TString   corrTaskSetting               = "",                // select which correction task setting to use
                             TString    additionalTrainConfig        = "0"               // additional counter for trainconfig
                            ) {
 
   Bool_t doTreeEOverP = kFALSE; // switch to produce EOverP tree
   TH1S* histoAcc = 0x0;         // histo for modified acceptance
+  TString corrTaskSetting = ""; // select which correction task setting to use
   //parse additionalTrainConfig flag
   TObjArray *rAddConfigArr = additionalTrainConfig.Tokenize("_");
   if(rAddConfigArr->GetEntries()<1){cout << "ERROR: AddTask_GammaCalo_pPb during parsing of additionalTrainConfig String '" << additionalTrainConfig.Data() << "'" << endl; return;}
@@ -106,6 +106,10 @@ void AddTask_GammaCalo_pPb(
         histoAcc = (TH1S*) w->Get(tempType.Data());
         if(!histoAcc) {cout << "ERROR: Could not find histo: " << tempType.Data() << endl;return;}
         cout << "found: " << histoAcc << endl;
+      }else if(tempStr.BeginsWith("CF")){
+        cout << "INFO: AddTask_GammaCalo_pPb will use custom branch from Correction Framework!" << endl;
+        corrTaskSetting = tempStr;
+        corrTaskSetting.Replace(0,2,"");
       }
     }
   }

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pPb.C
@@ -76,6 +76,7 @@ void AddTask_GammaCalo_pPb(
                             TString   periodNameAnchor              = "",               // name of anchor period for weighting
                             Bool_t     enableSortingMCLabels        = kTRUE,            // enable sorting for MC cluster labels
                             Bool_t     runLightOutput               = kFALSE,           // switch to run light output (only essential histograms for afterburner)
+                            TString   corrTaskSetting               = "",                // select which correction task setting to use
                             TString    additionalTrainConfig        = "0"               // additional counter for trainconfig
                            ) {
 
@@ -113,6 +114,7 @@ void AddTask_GammaCalo_pPb(
     trainConfig = trainConfig + sAdditionalTrainConfig.Atoi();
     cout << "INFO: AddTask_GammaCalo_pPb running additionalTrainConfig '" << sAdditionalTrainConfig.Atoi() << "', train config: '" << trainConfig << "'" << endl;
   }
+  cout << "corrTaskSetting: " << corrTaskSetting.Data() << endl;
 
   Int_t isHeavyIon = 2;
 
@@ -201,6 +203,7 @@ void AddTask_GammaCalo_pPb(
   task->SetIsHeavyIon(isHeavyIon);
   task->SetIsMC(isMC);
   task->SetV0ReaderName(V0ReaderName);
+  task->SetCorrectionTaskSetting(corrTaskSetting);
   task->SetLightOutput(runLightOutput);
 
   //create cut handler
@@ -817,6 +820,7 @@ void AddTask_GammaCalo_pPb(
     if( !(AliCaloTrackMatcher*)mgr->GetTask(TrackMatcherName.Data()) ){
       AliCaloTrackMatcher* fTrackMatcher = new AliCaloTrackMatcher(TrackMatcherName.Data(),caloCutPos.Atoi());
       fTrackMatcher->SetV0ReaderName(V0ReaderName);
+      fTrackMatcher->SetCorrectionTaskSetting(corrTaskSetting);
       mgr->AddTask(fTrackMatcher);
       mgr->ConnectInput(fTrackMatcher,0,cinput);
     }
@@ -836,6 +840,7 @@ void AddTask_GammaCalo_pPb(
     analysisEventCuts[i]->SetTriggerOverlapRejecion(enableTriggerOverlapRej);
     analysisEventCuts[i]->SetMaxFacPtHard(maxFacPtHard);
     analysisEventCuts[i]->SetV0ReaderName(V0ReaderName);
+    analysisEventCuts[i]->SetCorrectionTaskSetting(corrTaskSetting);
     analysisEventCuts[i]->SetLightOutput(runLightOutput);
     if (periodNameV0Reader.CompareTo("") != 0) analysisEventCuts[i]->SetPeriodEnum(periodNameV0Reader);
     analysisEventCuts[i]->InitializeCutsFromCutString((cuts.GetEventCut(i)).Data());
@@ -845,6 +850,7 @@ void AddTask_GammaCalo_pPb(
     analysisClusterCuts[i] = new AliCaloPhotonCuts(isMC);
     analysisClusterCuts[i]->SetHistoToModifyAcceptance(histoAcc);
     analysisClusterCuts[i]->SetV0ReaderName(V0ReaderName);
+    analysisClusterCuts[i]->SetCorrectionTaskSetting(corrTaskSetting);
     analysisClusterCuts[i]->SetCaloTrackMatcherName(TrackMatcherName);
     analysisClusterCuts[i]->SetLightOutput(runLightOutput);
     analysisClusterCuts[i]->InitializeCutsFromCutString((cuts.GetClusterCut(i)).Data());
@@ -864,6 +870,7 @@ void AddTask_GammaCalo_pPb(
   task->SetEventCutList(numberOfCuts,EventCutList);
   task->SetCaloCutList(numberOfCuts,ClusterCutList);
   task->SetMesonCutList(numberOfCuts,MesonCutList);
+  task->SetCorrectionTaskSetting(corrTaskSetting);
   task->SetDoMesonAnalysis(kTRUE);
   task->SetDoMesonQA(enableQAMesonTask); //Attention new switch for Pi0 QA
   task->SetDoClusterQA(enableQAClusterTask);  //Attention new switch small for Cluster QA

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
@@ -75,11 +75,11 @@ void AddTask_GammaCalo_pp(  Int_t     trainConfig                   = 1,        
                             TString   periodNameAnchor              = "",                           // name of anchor period for weighting
                             Bool_t    enableSortingMCLabels         = kTRUE,                        // enable sorting for MC cluster labels
                             Bool_t    runLightOutput                = kFALSE,                       // switch to run light output (only essential histograms for afterburner)
-                            TString   corrTaskSetting               = "",                // select which correction task setting to use
                             TString   additionalTrainConfig         = "0"                           // additional counter for trainconfig
 ) {
   Bool_t doTreeEOverP = kFALSE; // switch to produce EOverP tree
   TH1S* histoAcc = 0x0;         // histo for modified acceptance
+  TString corrTaskSetting = ""; // sets which correction task setting to use
   Int_t localDebugFlag = 0;
   //parse additionalTrainConfig flag
   TObjArray *rAddConfigArr = additionalTrainConfig.Tokenize("_");
@@ -111,6 +111,10 @@ void AddTask_GammaCalo_pp(  Int_t     trainConfig                   = 1,        
         tempType.Replace(0,14,"");
         localDebugFlag = tempType.Atoi();
         cout << "INFO: debug flag set to '" << localDebugFlag << "'" << endl;
+      }else if(tempStr.BeginsWith("CF")){
+        cout << "INFO: AddTask_GammaCalo_pp will use custom branch from Correction Framework!" << endl;
+        corrTaskSetting = tempStr;
+        corrTaskSetting.Replace(0,2,"");
       }
     }
   }

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
@@ -75,9 +75,9 @@ void AddTask_GammaCalo_pp(  Int_t     trainConfig                   = 1,        
                             TString   periodNameAnchor              = "",                           // name of anchor period for weighting
                             Bool_t    enableSortingMCLabels         = kTRUE,                        // enable sorting for MC cluster labels
                             Bool_t    runLightOutput                = kFALSE,                       // switch to run light output (only essential histograms for afterburner)
+                            TString   corrTaskSetting               = "",                // select which correction task setting to use
                             TString   additionalTrainConfig         = "0"                           // additional counter for trainconfig
 ) {
-
   Bool_t doTreeEOverP = kFALSE; // switch to produce EOverP tree
   TH1S* histoAcc = 0x0;         // histo for modified acceptance
   Int_t localDebugFlag = 0;
@@ -119,6 +119,7 @@ void AddTask_GammaCalo_pp(  Int_t     trainConfig                   = 1,        
     trainConfig = trainConfig + sAdditionalTrainConfig.Atoi();
     cout << "INFO: AddTask_GammaCalo_pp running additionalTrainConfig '" << sAdditionalTrainConfig.Atoi() << "', train config: '" << trainConfig << "'" << endl;
   }
+  cout << "corrTaskSetting: " << corrTaskSetting.Data() << endl;
 
   Int_t isHeavyIon = 0;
 
@@ -210,6 +211,7 @@ void AddTask_GammaCalo_pp(  Int_t     trainConfig                   = 1,        
   task->SetIsMC(isMC);
   task->SetV0ReaderName(V0ReaderName);
   task->SetLightOutput(runLightOutput);
+  task->SetCorrectionTaskSetting(corrTaskSetting);
 
   //create cut handler
   CutHandlerCalo cuts;
@@ -1187,6 +1189,7 @@ void AddTask_GammaCalo_pp(  Int_t     trainConfig                   = 1,        
     if( !(AliCaloTrackMatcher*)mgr->GetTask(TrackMatcherName.Data()) ){
       AliCaloTrackMatcher* fTrackMatcher = new AliCaloTrackMatcher(TrackMatcherName.Data(),caloCutPos.Atoi());
       fTrackMatcher->SetV0ReaderName(V0ReaderName);
+      fTrackMatcher->SetCorrectionTaskSetting(corrTaskSetting);
       mgr->AddTask(fTrackMatcher);
       mgr->ConnectInput(fTrackMatcher,0,cinput);
     }
@@ -1232,6 +1235,7 @@ void AddTask_GammaCalo_pp(  Int_t     trainConfig                   = 1,        
     analysisEventCuts[i]->SetTriggerOverlapRejecion(enableTriggerOverlapRej);
     analysisEventCuts[i]->SetMaxFacPtHard(maxFacPtHard);
     analysisEventCuts[i]->SetV0ReaderName(V0ReaderName);
+    analysisEventCuts[i]->SetCorrectionTaskSetting(corrTaskSetting);
     analysisEventCuts[i]->SetLightOutput(runLightOutput);
     if (periodNameV0Reader.CompareTo("") != 0) analysisEventCuts[i]->SetPeriodEnum(periodNameV0Reader);
     analysisEventCuts[i]->InitializeCutsFromCutString((cuts.GetEventCut(i)).Data());
@@ -1241,6 +1245,7 @@ void AddTask_GammaCalo_pp(  Int_t     trainConfig                   = 1,        
     analysisClusterCuts[i] = new AliCaloPhotonCuts(isMC);
     analysisClusterCuts[i]->SetHistoToModifyAcceptance(histoAcc);
     analysisClusterCuts[i]->SetV0ReaderName(V0ReaderName);
+    analysisClusterCuts[i]->SetCorrectionTaskSetting(corrTaskSetting);
     analysisClusterCuts[i]->SetCaloTrackMatcherName(TrackMatcherName);
     analysisClusterCuts[i]->SetLightOutput(runLightOutput);
     analysisClusterCuts[i]->InitializeCutsFromCutString((cuts.GetClusterCut(i)).Data());
@@ -1261,6 +1266,7 @@ void AddTask_GammaCalo_pp(  Int_t     trainConfig                   = 1,        
   task->SetCaloCutList(numberOfCuts,ClusterCutList);
   task->SetMesonCutList(numberOfCuts,MesonCutList);
   task->SetDoMesonAnalysis(kTRUE);
+  task->SetCorrectionTaskSetting(corrTaskSetting);
   task->SetDoMesonQA(enableQAMesonTask); //Attention new switch for Pi0 QA
   task->SetDoClusterQA(enableQAClusterTask);  //Attention new switch small for Cluster QA
   task->SetDoTHnSparse(isUsingTHnSparse);

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
@@ -84,6 +84,7 @@ void AddTask_GammaConvCalo_pp(  Int_t     trainConfig                   = 1,    
                                 Double_t  smearPar                      = 0.,                     // conv photon smearing params
                                 Double_t  smearParConst                 = 0.,                     // conv photon smearing params
                                 Bool_t    doPrimaryTrackMatching        = kTRUE,                  // enable basic track matching for all primary tracks to cluster
+                                TString   corrTaskSetting               = "",                // select which correction task setting to tuse
                                 TString   additionalTrainConfig         = "0"                     // additional counter for trainconfig, this has to be always the last parameter
               ) {
 
@@ -121,7 +122,7 @@ void AddTask_GammaConvCalo_pp(  Int_t     trainConfig                   = 1,    
     trainConfig = trainConfig + sAdditionalTrainConfig.Atoi();
     cout << "INFO: AddTask_GammaConvCalo_pp running additionalTrainConfig '" << sAdditionalTrainConfig.Atoi() << "', train config: '" << trainConfig << "'" << endl;
   }
-
+  cout << "corrTaskSetting: " << corrTaskSetting.Data() << endl;
   Int_t isHeavyIon = 0;
 
   // ================== GetAnalysisManager ===============================
@@ -1295,6 +1296,7 @@ void AddTask_GammaConvCalo_pp(  Int_t     trainConfig                   = 1,    
     if( !(AliCaloTrackMatcher*)mgr->GetTask(TrackMatcherName.Data()) ){
       AliCaloTrackMatcher* fTrackMatcher = new AliCaloTrackMatcher(TrackMatcherName.Data(),caloCutPos.Atoi());
       fTrackMatcher->SetV0ReaderName(V0ReaderName);
+      fTrackMatcher->SetCorrectionTaskSetting(corrTaskSetting);
       mgr->AddTask(fTrackMatcher);
       mgr->ConnectInput(fTrackMatcher,0,cinput);
     }
@@ -1342,6 +1344,7 @@ void AddTask_GammaConvCalo_pp(  Int_t     trainConfig                   = 1,    
     analysisEventCuts[i]->SetTriggerOverlapRejecion(enableTriggerOverlapRej);
     analysisEventCuts[i]->SetMaxFacPtHard(maxFacPtHard);
     analysisEventCuts[i]->SetV0ReaderName(V0ReaderName);
+    analysisEventCuts[i]->SetCorrectionTaskSetting(corrTaskSetting);
     if (periodNameV0Reader.CompareTo("") != 0) analysisEventCuts[i]->SetPeriodEnum(periodNameV0Reader);
     if (runLightOutput > 0) analysisEventCuts[i]->SetLightOutput(kTRUE);
     analysisEventCuts[i]->InitializeCutsFromCutString((cuts.GetEventCut(i)).Data());
@@ -1359,6 +1362,7 @@ void AddTask_GammaConvCalo_pp(  Int_t     trainConfig                   = 1,    
     analysisClusterCuts[i] = new AliCaloPhotonCuts(isMC);
     analysisClusterCuts[i]->SetHistoToModifyAcceptance(histoAcc);
     analysisClusterCuts[i]->SetV0ReaderName(V0ReaderName);
+    analysisClusterCuts[i]->SetCorrectionTaskSetting(corrTaskSetting);
     analysisClusterCuts[i]->SetCaloTrackMatcherName(TrackMatcherName);
     if (runLightOutput > 0) analysisClusterCuts[i]->SetLightOutput(kTRUE);
     analysisClusterCuts[i]->InitializeCutsFromCutString((cuts.GetClusterCut(i)).Data());
@@ -1382,6 +1386,7 @@ void AddTask_GammaConvCalo_pp(  Int_t     trainConfig                   = 1,    
   task->SetMesonCutList(numberOfCuts,MesonCutList);
   task->SetMoveParticleAccordingToVertex(kTRUE);
   task->SetDoMesonAnalysis(kTRUE);
+  task->SetCorrectionTaskSetting(corrTaskSetting);
   task->SetDoMesonQA(enableQAMesonTask); //Attention new switch for Pi0 QA
   task->SetDoPhotonQA(enableQAPhotonTask);  //Attention new switch small for Photon QA
   task->SetDoClusterQA(1);  //Attention new switch small for Cluster QA

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
@@ -84,12 +84,12 @@ void AddTask_GammaConvCalo_pp(  Int_t     trainConfig                   = 1,    
                                 Double_t  smearPar                      = 0.,                     // conv photon smearing params
                                 Double_t  smearParConst                 = 0.,                     // conv photon smearing params
                                 Bool_t    doPrimaryTrackMatching        = kTRUE,                  // enable basic track matching for all primary tracks to cluster
-                                TString   corrTaskSetting               = "",                // select which correction task setting to tuse
                                 TString   additionalTrainConfig         = "0"                     // additional counter for trainconfig, this has to be always the last parameter
               ) {
 
   Bool_t doTreeClusterShowerShape = kFALSE; // enable tree for meson cand EMCal shower shape studies
   TH1S* histoAcc = 0x0;                     // histo for modified acceptance
+  TString corrTaskSetting = "";             // sets which correction task setting to use
   //parse additionalTrainConfig flag
   TObjArray *rAddConfigArr = additionalTrainConfig.Tokenize("_");
   if(rAddConfigArr->GetEntries()<1){cout << "ERROR: AddTask_GammaConvCalo_pp during parsing of additionalTrainConfig String '" << additionalTrainConfig.Data() << "'" << endl; return;}
@@ -114,6 +114,10 @@ void AddTask_GammaConvCalo_pp(  Int_t     trainConfig                   = 1,    
         histoAcc = (TH1S*) w->Get(tempType.Data());
         if(!histoAcc) {cout << "ERROR: Could not find histo: " << tempType.Data() << endl;return;}
         cout << "found: " << histoAcc << endl;
+      }else if(tempStr.BeginsWith("CF")){
+        cout << "INFO: AddTask_GammaConvCalo_pp will use custom branch from Correction Framework!" << endl;
+        corrTaskSetting = tempStr;
+        corrTaskSetting.Replace(0,2,"");
       }
     }
   }


### PR DESCRIPTION
This pull request handles the full implementation of the correction framework in the conversion group tasks. 
Using the correction framework will require adding two AliEmcalCorrectionTasks. One with the name "defaultSetting" in order to properly obtain calibrated cells and another one named i.e. "S500A100". Possible configurations can be found in the yaml file. 
Furthermore, it is possible to use several clusterizers by simply adding more CorrectionTasks.
The clusters from the different settings can then be accessed via the last argument in our AddTasks (additionalTrainConfig) by setting it to i.e. "402_CFS500A100". The "CF" in front of the setting is required as it will otherwise not work.