### PR TITLE
Rolling back the includes inclusion in AddTask macro

### DIFF
--- a/PWGCF/Correlations/macros/Unfoldedhistos/AddCorrelationsStudiesTask.C
+++ b/PWGCF/Correlations/macros/Unfoldedhistos/AddCorrelationsStudiesTask.C
@@ -1,3 +1,5 @@
+#ifdef __ECLIPSE_IDE
+//  few includes and external declarations just for the IDE
 #include "Riostream.h"
 #include "TROOT.h"
 #include "AliLog.h"
@@ -7,6 +9,7 @@
 #include "AliAnalysisTaskSE.h"
 #include "AliAnalysisManager.h"
 #include "AliAnalysisTaskCorrelationsStudies.h"
+#endif
 
 AliAnalysisTaskSE *AddCorrelationsStudiesTask(const char *mincenstr, const char *maxcenstr, const char *configstring, const char *corrconfigstring, const char *corrbinning) {
 


### PR DESCRIPTION
It seems that the standard include paths are not ready at
AddTask macro execution time in train scenarios. They are in local
train test scenario!