### PR TITLE
Fixes for EMCAL MC trigger selection

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerSelection.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerSelection.cxx
@@ -222,7 +222,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPP2016() {
   ej1cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1JetHighPatch);
   ej1cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
   ej1cuts->SetUseSimpleOfflinePatches(true);
-  ej1cuts->SetThreshold(9.);
+  ej1cuts->SetThreshold(20.);
   this->AddTriggerSelection(new AliEmcalTriggerSelection("EJ1", ej1cuts));
 
   AliEmcalTriggerSelectionCuts *ej2cuts = new AliEmcalTriggerSelectionCuts;
@@ -230,7 +230,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPP2016() {
   ej2cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1JetLowPatch);
   ej2cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
   ej2cuts->SetUseSimpleOfflinePatches(true);
-  ej2cuts->SetThreshold(4.);
+  ej2cuts->SetThreshold(16.);
   this->AddTriggerSelection(new AliEmcalTriggerSelection("EJ2", ej2cuts));
 
   AliEmcalTriggerSelectionCuts *dj1cuts = new AliEmcalTriggerSelectionCuts;
@@ -246,7 +246,7 @@ void AliAnalysisTaskEmcalTriggerSelection::ConfigureMCPP2016() {
   dj2cuts->SetPatchType(AliEmcalTriggerSelectionCuts::kL1JetLowPatch);
   dj2cuts->SetSelectionMethod(AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared);
   dj2cuts->SetUseSimpleOfflinePatches(true);
-  dj2cuts->SetThreshold(4.);
+  dj2cuts->SetThreshold(16.);
   this->AddTriggerSelection(new AliEmcalTriggerSelection("DJ2", dj2cuts));
 }
 

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.h
@@ -237,18 +237,19 @@ protected:
 
 	void DoConstituentQA(const AliEmcalJet *jet, const AliParticleContainer *tracks, const AliClusterContainer *clusters);
 
-  void LinkOutputBranch(const TString &branchname, Double_t *datalocation);
+  void LinkOutputBranch(const std::string &branchname, Double_t *datalocation);
 
   std::vector<Triggerinfo> DecodeTriggerString(const std::string &triggerstring) const;
-  TString MatchTrigger(const TString &triggerclass) const;
+  std::string MatchTrigger(const std::string &triggerclass) const;
+  bool IsSelectEmcalTriggers(const std::string &triggerstring) const;
 
-  bool IsPartBranch(const TString &branchname) const;
-  bool IsAcceptanceBranch(const TString &branchname) const;
-  bool IsRhoBranch(const TString &branchname) const;
-  bool IsMassBranch(const TString &branchname) const;
-  bool IsSoftdropBranch(const TString &branchname) const;
-  bool IsNSubjettinessBranch(const TString &branchname) const;
-  bool IsStructbranch(const TString &branchname) const;
+  bool IsPartBranch(const std::string &branchname) const;
+  bool IsAcceptanceBranch(const std::string &branchname) const;
+  bool IsRhoBranch(const std::string &branchname) const;
+  bool IsMassBranch(const std::string &branchname) const;
+  bool IsSoftdropBranch(const std::string &branchname) const;
+  bool IsNSubjettinessBranch(const std::string &branchname) const;
+  bool IsStructbranch(const std::string &branchname) const;
 
 private:
 	TTree                       *fJetSubstructureTree;        //!<! Tree with jet substructure information


### PR DESCRIPTION
- In trigger selection task fix jet thresholds for 2016 pp
   LHC16h-k
- In substructure tree task run MC trigger selection only
   when an EMCAL trigger is in the selection string
-  In substructure tree task move from TString to std::string
   / std::stringstream (works a bit better with lldb/gdb)