### PR TITLE
PWGCF: Fixed a missing symbol, uninitialized member, and redundent linkdef rule

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoAnalysisAzimuthal.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoAnalysisAzimuthal.cxx
@@ -22,7 +22,7 @@
 #endif
 
 extern void FillHbtParticleCollection(AliFemtoParticleCut* partCut,
-                                      AliFemtoEvent* hbtEvent,
+                                      const AliFemtoEvent* hbtEvent,
                                       AliFemtoParticleCollection* partCollection,
                                       bool performSharedDaughterCut=kFALSE);
 
@@ -206,8 +206,8 @@ void AliFemtoAnalysisAzimuthal::ProcessEvent(const AliFemtoEvent* hbtEvent) {
     fEventCut->FillCutMonitor(hbtEvent, tmpPassEvent);
   if (tmpPassEvent) {
     fPicoEvent = new AliFemtoPicoEvent; // this is what we will make pairs from and put in Mixing Buffer, no memory leak. we will delete picoevents when they come out of the mixing buffer
-    FillHbtParticleCollection(fFemtoParticleCut,(AliFemtoEvent*)hbtEvent,fPicoEvent->FirstParticleCollection());
-    FillHbtParticleCollection(fFlowParticleCut,(AliFemtoEvent*)hbtEvent,fPicoEvent->SecondParticleCollection());
+    FillHbtParticleCollection(fFemtoParticleCut,hbtEvent,fPicoEvent->FirstParticleCollection());
+    FillHbtParticleCollection(fFlowParticleCut,hbtEvent,fPicoEvent->SecondParticleCollection());
 
       // get right mixing buffer
   double vertexZ = hbtEvent->PrimVertPos().z();

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBaryoniaAnalysis.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBaryoniaAnalysis.cxx
@@ -19,7 +19,7 @@ AliFemtoParticleCut* copyTheCut(AliFemtoParticleCut*);
 AliFemtoCorrFctn*    copyTheCorrFctn(AliFemtoCorrFctn*);
 
 extern void FillHbtParticleCollection(AliFemtoParticleCut* partCut,
-                                      AliFemtoEvent* currentEvent,
+                                      const AliFemtoEvent* currentEvent,
                                       AliFemtoParticleCollection* partCollection,
                                       bool performSharedDaughterCut=kFALSE);
 
@@ -85,9 +85,9 @@ void AliFemtoBaryoniaAnalysis::ProcessEvent(const AliFemtoEvent* currentEvent)
     return;
   }
   
-  FillHbtParticleCollection(fFirstParticleCut, (AliFemtoEvent*)currentEvent,collection1,fPerformSharedDaughterCut);
-  FillHbtParticleCollection(fSecondParticleCut,(AliFemtoEvent*)currentEvent,collection2,fPerformSharedDaughterCut);
-  FillHbtParticleCollection(fThirdParticleCut, (AliFemtoEvent*)currentEvent,collection3,fPerformSharedDaughterCut);
+  FillHbtParticleCollection(fFirstParticleCut, currentEvent,collection1,fPerformSharedDaughterCut);
+  FillHbtParticleCollection(fSecondParticleCut,currentEvent,collection2,fPerformSharedDaughterCut);
+  FillHbtParticleCollection(fThirdParticleCut, currentEvent,collection3,fPerformSharedDaughterCut);
 
   fEventCut->FillCutMonitor(currentEvent, tmpPassEvent);
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCutMonitorParticlePID.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCutMonitorParticlePID.cxx
@@ -12,102 +12,68 @@
 #include <TMath.h>
 
 AliFemtoCutMonitorParticlePID::AliFemtoCutMonitorParticlePID():
-  fTPCdEdx(0),
-  fTOFParticle(0),
-  fTOFTime(0x0),
-  fTOFNSigma(0),
-  fTPCNSigma(0),
-  fTPCTOFNSigma(0),
-  fTPCvsTOFNSigma(0),
-  fParticleOrigin(0),
-  fParticleId(0)
+  AliFemtoCutMonitor()
+  , fTOFParticle(0)
+  , fIfUsePt(false)
+  , fTPCdEdx(nullptr)
+  , fTOFTime(nullptr)
+  , fTOFNSigma(nullptr)
+  , fTPCNSigma(nullptr)
+  , fTPCTOFNSigma(nullptr)
+  , fTPCvsTOFNSigma(nullptr)
+  , fParticleOrigin(nullptr)
+  , fParticleId(nullptr)
 {
   // Default constructor
-  fTPCdEdx =  new TH2D("TPCdEdx", "TPC dEdx vs. momentum", 100, 0.0, 5.0, 250, 0.0, 500.0);
-  fTOFTime = new TH2D("TOFTime", "TOF Time vs. momentum", 100, 0.1, 5.0, 400, -4000.0, 4000.0);
-  fTOFNSigma = new TH2D("TOFNSigma","TOF NSigma vs. momentum", 100, 0.0, 5.0, 100, -5.0, 5.0);
-  fTPCNSigma = new TH2D("TPCNSigma","TPC NSigma vs. momentum", 100, 0.0, 5.0, 100, -5.0, 5.0);
-  fTPCTOFNSigma = new TH2D("TPCTOFNSigma","TPC & TOF NSigma vs. momentum", 100, 0.0, 5.0, 100, 0.0, 10.0);
+  fTPCdEdx        = new TH2D("TPCdEdx", "TPC dEdx vs. momentum", 100, 0.0, 5.0, 250, 0.0, 500.0);
+  fTOFTime        = new TH2D("TOFTime", "TOF Time vs. momentum", 100, 0.1, 5.0, 400, -4000.0, 4000.0);
+  fTOFNSigma      = new TH2D("TOFNSigma","TOF NSigma vs. momentum", 100, 0.0, 5.0, 100, -5.0, 5.0);
+  fTPCNSigma      = new TH2D("TPCNSigma","TPC NSigma vs. momentum", 100, 0.0, 5.0, 100, -5.0, 5.0);
+  fTPCTOFNSigma   = new TH2D("TPCTOFNSigma","TPC & TOF NSigma vs. momentum", 100, 0.0, 5.0, 100, 0.0, 10.0);
   fTPCvsTOFNSigma = new TH2D("TPCvsTOFNSigma","TPC vs TOF Nsigma",100, -5.0, 5.0, 100, -5.0, 5.0);
-  fParticleOrigin =  new TH1D("POrigin", "Mothers PDG Codes", 6000, 0.0, 6000.0);
-  fParticleId =  new TH1D("PId", "Particle PDG Codes", 6000, 0.0, 6000.0);
+  fParticleOrigin = new TH1D("POrigin", "Mothers PDG Codes", 6000, 0.0, 6000.0);
+  fParticleId     = new TH1D("PId", "Particle PDG Codes", 6000, 0.0, 6000.0);
 
 }
 
 AliFemtoCutMonitorParticlePID::AliFemtoCutMonitorParticlePID(const char *aName, Int_t aTOFParticle):
-  AliFemtoCutMonitor(),
-  fTPCdEdx(0),
-  fTOFParticle(aTOFParticle),
-  fTOFTime(0x0),
-  fTOFNSigma(0),
-  fTPCNSigma(0),
-  fTPCTOFNSigma(0),
-  fTPCvsTOFNSigma(0),
-  fParticleOrigin(0),
-  fParticleId(0)
+  AliFemtoCutMonitor()
+  , fTOFParticle(aTOFParticle)
+  , fIfUsePt(false)
+  , fTPCdEdx(nullptr)
+  , fTOFTime(nullptr)
+  , fTOFNSigma(nullptr)
+  , fTPCNSigma(nullptr)
+  , fTPCTOFNSigma(nullptr)
+  , fTPCvsTOFNSigma(nullptr)
+  , fParticleOrigin(nullptr)
+  , fParticleId(nullptr)
 {
   // Normal constructor
-  char name[200];
-  snprintf(name, 200, "TPCdEdx%s", aName);
-  // fTPCdEdx = new TH2D(name, "TPC dEdx vs. momentum", 100, 0.0, 6.0, 250, 0.0, 500.0);
-  fTPCdEdx = new TH2D(name, "TPC dEdx vs. momentum", 200, 0.1, 4.0, 250, 0.0, 500.0);
-
-  snprintf(name, 200, "TOFTime%s", aName);
-  fTOFTime = new TH2D(name, "TOF Time vs. momentum", 100, 0.1, 5.0, 400, -4000.0, 4000.0);
-
-  snprintf(name, 200, "TOFNSigma%s", aName);
-  fTOFNSigma = new TH2D(name,"TOF NSigma vs. momentum", 100, 0.0, 5.0, 100, -5.0, 5.0);
-
-  snprintf(name, 200, "TPCNSigma%s", aName);
-  fTPCNSigma = new TH2D(name,"TPC NSigma vs. momentum", 100, 0.0, 5.0, 100, -5.0, 5.0);
-
-  snprintf(name, 200, "TPCTOFNSigma%s", aName);
-  fTPCTOFNSigma = new TH2D(name,"TPC & TOF NSigma vs. momentum", 100, 0.0, 5.0, 100, 0.0, 10.0);
-
-  snprintf(name, 200, "TPCvsTOFNSigma%s", aName);
-  fTPCvsTOFNSigma = new TH2D(name,"TPC vs TOF Nsigma",100, -5.0, 5.0, 100, -5.0, 5.0);
-
-  snprintf(name, 200, "POrigin%s", aName);
-  fParticleOrigin =  new TH1D(name, "Mothers PDG Codes", 6000, 0.0, 6000.0);
-
-  snprintf(name, 200, "PId%s", aName);
-  fParticleId =  new TH1D(name, "Particle PDG Codes", 6000, 0.0, 6000.0);
+  fTPCdEdx        = new TH2D(TString::Format("TPCdEdx%s", aName), "TPC dEdx vs. momentum", 200, 0.1, 4.0, 250, 0.0, 500.0);
+  fTOFTime        = new TH2D(TString::Format("TOFTime%s", aName), "TOF Time vs. momentum", 100, 0.1, 5.0, 400, -4000.0, 4000.0);
+  fTOFNSigma      = new TH2D(TString::Format("TOFNSigma%s", aName), "TOF NSigma vs. momentum", 100, 0.0, 5.0, 100, -5.0, 5.0);
+  fTPCNSigma      = new TH2D(TString::Format("TPCNSigma%s", aName), "TPC NSigma vs. momentum", 100, 0.0, 5.0, 100, -5.0, 5.0);
+  fTPCTOFNSigma   = new TH2D(TString::Format("TPCTOFNSigma%s", aName), "TPC & TOF NSigma vs. momentum", 100, 0.0, 5.0, 100, 0.0, 10.0);
+  fTPCvsTOFNSigma = new TH2D(TString::Format("TPCvsTOFNSigma%s", aName), "TPC vs TOF Nsigma",100, -5.0, 5.0, 100, -5.0, 5.0);
+  fParticleOrigin = new TH1D(TString::Format("POrigin%s", aName), "Mothers PDG Codes", 6000, 0.0, 6000.0);
+  fParticleId     = new TH1D(TString::Format("PId%s", aName), "Particle PDG Codes", 6000, 0.0, 6000.0);
 }
 
 AliFemtoCutMonitorParticlePID::AliFemtoCutMonitorParticlePID(const AliFemtoCutMonitorParticlePID &aCut):
-  AliFemtoCutMonitor(),
-  fTPCdEdx(0),
-  fTOFParticle(0),
-  fTOFTime(0x0),
-  fTOFNSigma(0),
-  fTPCNSigma(0),
-  fTPCTOFNSigma(0),
-  fTPCvsTOFNSigma(0),
-  fParticleOrigin(0),
-  fParticleId(0)
-
+  AliFemtoCutMonitor(aCut)
+  , fTOFParticle(aCut.fTOFParticle)
+  , fIfUsePt(aCut.fIfUsePt)
+  , fTPCdEdx(new TH2D(*aCut.fTPCdEdx))
+  , fTOFTime(new TH2D(*aCut.fTOFTime))
+  , fTOFNSigma(new TH2D(*aCut.fTOFNSigma))
+  , fTPCNSigma(new TH2D(*aCut.fTPCNSigma))
+  , fTPCTOFNSigma(new TH2D(*aCut.fTPCTOFNSigma))
+  , fTPCvsTOFNSigma(new TH2D(*aCut.fTPCvsTOFNSigma))
+  , fParticleOrigin(new TH1D(*aCut.fParticleOrigin))
+  , fParticleId(new TH1D(*aCut.fParticleId))
 {
   // copy constructor
-  if (fTPCdEdx) delete fTPCdEdx;
-  fTPCdEdx = new TH2D(*aCut.fTPCdEdx);
-
-  if (fTOFTime) delete fTOFTime;
-  fTOFTime = new TH2D(*aCut.fTOFTime);
-
-  if (fTOFNSigma) delete fTOFNSigma;
-  fTOFNSigma= new TH2D(*aCut.fTOFNSigma);
-
-  if (fTPCNSigma) delete fTPCNSigma;
-  fTPCNSigma= new TH2D(*aCut.fTPCNSigma);
-
-  if (fTPCTOFNSigma) delete fTPCTOFNSigma;
-  fTPCTOFNSigma= new TH2D(*aCut.fTPCTOFNSigma);
-
-  if (fParticleOrigin) delete fParticleOrigin;
-  fParticleOrigin= new TH1D(*aCut.fParticleOrigin);
-
-  if (fParticleId) delete fParticleId;
-  fParticleId= new TH1D(*aCut.fParticleId);
 }
 
 AliFemtoCutMonitorParticlePID::~AliFemtoCutMonitorParticlePID()
@@ -121,7 +87,6 @@ AliFemtoCutMonitorParticlePID::~AliFemtoCutMonitorParticlePID()
   delete fTPCvsTOFNSigma;
   delete fParticleOrigin;
   delete fParticleId;
-
 }
 
 AliFemtoCutMonitorParticlePID& AliFemtoCutMonitorParticlePID::operator=(const AliFemtoCutMonitorParticlePID& aCut)
@@ -130,45 +95,34 @@ AliFemtoCutMonitorParticlePID& AliFemtoCutMonitorParticlePID::operator=(const Al
   if (this == &aCut)
     return *this;
 
-  if (fTPCdEdx) delete fTPCdEdx;
-  fTPCdEdx = new TH2D(*aCut.fTPCdEdx);
+  AliFemtoCutMonitor::operator=(aCut);
 
-  if (fTOFTime) delete fTOFTime;
-  fTOFTime = new TH2D(*aCut.fTOFTime);
+  fTOFParticle = aCut.fTOFParticle;
+  fIfUsePt = aCut.fIfUsePt;
 
-  if(fTOFNSigma) delete fTOFNSigma;
-  fTOFNSigma = new TH2D(*aCut.fTOFNSigma);
-
-  if(fTPCNSigma) delete fTPCNSigma;
-  fTPCNSigma = new TH2D(*aCut.fTPCNSigma);
-
-  if(fTPCTOFNSigma) delete fTPCTOFNSigma;
-  fTPCTOFNSigma = new TH2D(*aCut.fTPCTOFNSigma);
-
-  if(fTPCvsTOFNSigma) delete fTPCvsTOFNSigma;
-  fTPCvsTOFNSigma = new TH2D(*aCut.fTPCvsTOFNSigma);
-
-  if (fParticleOrigin) delete fParticleOrigin;
-  fParticleOrigin= new TH1D(*aCut.fParticleOrigin);
-
-  if (fParticleId) delete fParticleId;
-  fParticleId= new TH1D(*aCut.fParticleId);
+  *fTPCdEdx = *aCut.fTPCdEdx;
+  *fTOFTime = *aCut.fTOFTime;
+  *fTOFNSigma = *aCut.fTOFNSigma;
+  *fTPCNSigma = *aCut.fTPCNSigma;
+  *fTPCTOFNSigma = *aCut.fTPCTOFNSigma;
+  *fTPCvsTOFNSigma = *aCut.fTPCvsTOFNSigma;
+  *fParticleOrigin = *aCut.fParticleOrigin;
+  *fParticleId = *aCut.fParticleId;
 
   return *this;
 }
 
-AliFemtoString AliFemtoCutMonitorParticlePID::Report(){
+AliFemtoString AliFemtoCutMonitorParticlePID::Report()
+{
   // Prepare report from the execution
-  string stemp = "*** AliFemtoCutMonitorParticlePID report";
-  AliFemtoString returnThis = stemp;
-  return returnThis;
+  TString report = "*** AliFemtoCutMonitorParticlePID report";
+  return AliFemtoString(report.Data());
 }
 
 void AliFemtoCutMonitorParticlePID::Fill(const AliFemtoTrack* aTrack)
 {
   // Fill in the monitor histograms with the values from the current track
-  float tMom = aTrack->P().Mag();
-  if(fIfUsePt) tMom = aTrack->Pt();
+  float tMom = (fIfUsePt) ? aTrack->Pt() : aTrack->P().Mag();
   float tdEdx = aTrack->TPCsignal();
   float tTOF = 0.0;
   //  short tchg = aTrack->Charge();

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCutMonitorParticlePID.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCutMonitorParticlePID.h
@@ -15,6 +15,7 @@ class AliFemtoPair; // Gael 12/04/02
 class TH1D;
 class TH2D;
 class TList;
+
 #include "AliFemtoString.h"
 #include "AliFemtoParticleCollection.h"
 #include "AliFemtoCutMonitor.h"
@@ -46,17 +47,19 @@ public:
   void SetUsePt(Bool_t usept){fIfUsePt=usept;}
   virtual TList *GetOutputList();
 
-private:
-  TH2D *fTPCdEdx;     // TPC dEdx information
-  Int_t fTOFParticle; // Select TOF time hypothesis, 0-pion, 1-kaon, 2-proton
-  TH2D *fTOFTime;     // TOF time
-  TH2D *fTOFNSigma;   // TOF NSigma values vs mom
-  TH2D *fTPCNSigma;   // TPC NSigma values vs mom
-  TH2D *fTPCTOFNSigma;   // TPC^2+ TOF^2 NSigma values vs mom
-  TH2D *fTPCvsTOFNSigma; // TPC vs TOF
-  TH1D *fParticleOrigin; //particle origin from MC
-  TH1D *fParticleId;     //true particle identification from MC
-  Bool_t fIfUsePt; // Select TOF time hypothesis, 0-pion, 1-kaon, 2-proton
+protected:
+  Int_t fTOFParticle; ///< Select TOF time hypothesis, 0-pion, 1-kaon, 2-proton
+  Bool_t fIfUsePt;    ///< Plot pT instead of p in all momentum histograms
+
+  TH2D *fTPCdEdx;        ///< TPC dEdx information
+  TH2D *fTOFTime;        ///< TOF time
+  TH2D *fTOFNSigma;      ///< TOF NSigma values vs mom
+  TH2D *fTPCNSigma;      ///< TPC NSigma values vs mom
+  TH2D *fTPCTOFNSigma;   ///< TPC^2+ TOF^2 NSigma values vs mom
+  TH2D *fTPCvsTOFNSigma; ///< TPC vs TOF
+
+  TH1D *fParticleOrigin; ///< particle origin from MC
+  TH1D *fParticleId;     ///< true particle identification from MC
 };
 
 #endif

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventAnalysis.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventAnalysis.cxx
@@ -23,7 +23,7 @@ AliFemtoParticleCut* copyTheCut(AliFemtoParticleCut*);
 AliFemtoCorrFctn*    copyTheCorrFctn(AliFemtoCorrFctn*);
 
 extern void FillHbtParticleCollection(AliFemtoParticleCut* partCut,
-                                      AliFemtoEvent* hbtEvent,
+                                      const AliFemtoEvent* hbtEvent,
                                       AliFemtoParticleCollection* partCollection,
                                       bool performSharedDaughterCut=kFALSE);
 
@@ -279,12 +279,12 @@ void AliFemtoEventAnalysis::ProcessEvent(const AliFemtoEvent* hbtEvent)
   }
   
   FillHbtParticleCollection(fFirstParticleCut,
-                            (AliFemtoEvent*)hbtEvent,
+                            hbtEvent,
                             fPicoEvent->FirstParticleCollection(),
                             fPerformSharedDaughterCut);
   
   FillHbtParticleCollection(fSecondParticleCut,
-                            (AliFemtoEvent*)hbtEvent,
+                            hbtEvent,
                             fPicoEvent->SecondParticleCollection(),
                             fPerformSharedDaughterCut);
   

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoLikeSignAnalysis.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoLikeSignAnalysis.cxx
@@ -18,10 +18,10 @@
 //  it is called from AliFemtoSimpleAnalysis::ProcessEvent()
 
 
-void FillHbtParticleCollection(AliFemtoParticleCut*         partCut,
-			       AliFemtoEvent*               hbtEvent,
-			       AliFemtoParticleCollection*  partCollection,
-			       bool performSharedDaughterCut=kFALSE);
+extern void FillHbtParticleCollection(AliFemtoParticleCut* partCut,
+                                      const AliFemtoEvent* hbtEvent,
+                                      AliFemtoParticleCollection* partCollection,
+                                      bool performSharedDaughterCut=kFALSE);
 
 //____________________________
 AliFemtoLikeSignAnalysis::AliFemtoLikeSignAnalysis(unsigned int bins, double min, double max) :
@@ -127,9 +127,9 @@ void AliFemtoLikeSignAnalysis::ProcessEvent(const AliFemtoEvent* hbtEvent) {
       cout << " #track=" << hbtEvent->TrackCollection()->size();
       // OK, analysis likes the event-- build a pico event from it, using tracks the analysis likes...
       AliFemtoPicoEvent* picoEvent = new AliFemtoPicoEvent;       // this is what we will make pairs from and put in Mixing Buffer
-      FillHbtParticleCollection(fFirstParticleCut,(AliFemtoEvent*)hbtEvent,picoEvent->FirstParticleCollection());
+      FillHbtParticleCollection(fFirstParticleCut,hbtEvent,picoEvent->FirstParticleCollection());
       if ( !(AnalyzeIdenticalParticles()) )
-	FillHbtParticleCollection(fSecondParticleCut,(AliFemtoEvent*)hbtEvent,picoEvent->SecondParticleCollection());
+	FillHbtParticleCollection(fSecondParticleCut, hbtEvent,picoEvent->SecondParticleCollection());
       cout <<"   #particles in First, Second Collections: " <<
 	picoEvent->FirstParticleCollection()->size() << " " <<
 	picoEvent->SecondParticleCollection()->size() << endl;

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSimpleAnalysis.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSimpleAnalysis.cxx
@@ -59,6 +59,7 @@ void DoFillParticleCollection(TrackCutType *cut,
   }
 }
 
+
 // This little function is used to apply ParticleCuts (TrackCuts or V0Cuts) and
 // fill ParticleCollections from tacks in picoEvent. It is called from
 // AliFemtoSimpleAnalysis::ProcessEvent().
@@ -156,6 +157,17 @@ void FillHbtParticleCollection(AliFemtoParticleCut *partCut,
 
   partCut->FillCutMonitor(hbtEvent, partCollection);
 }
+
+// Leave this here to appease any legacy code that expected a non-const AliFemtoEvent
+void FillHbtParticleCollection(AliFemtoParticleCut *partCut,
+                               AliFemtoEvent *hbtEvent,
+                               AliFemtoParticleCollection *partCollection,
+                               bool performSharedDaughterCut)
+{
+  FillHbtParticleCollection(partCut, const_cast<const AliFemtoEvent*>(hbtEvent), partCollection, performSharedDaughterCut);
+}
+
+
 //____________________________
 AliFemtoSimpleAnalysis::AliFemtoSimpleAnalysis():
   fPicoEventCollectionVectorHideAway(nullptr),

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/PWGCFfemtoscopyUserLinkDef.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/PWGCFfemtoscopyUserLinkDef.h
@@ -131,7 +131,6 @@
 #pragma link C++ class std::map<std::string, AliFemtoConfigObject>;
 #pragma link C++ class std::vector<AliFemtoConfigObject>;
 #pragma link C++ class std::vector<AliFemtoConfigObject>::iterator;
-#pragma link C++ class std::pair<double, double>;
 #pragma link C++ class std::vector<std::pair<double, double>>;
 // ^ these std:: classes required here for use in ROOT-5 macros (ROOT-6 should be ok)
 


### PR DESCRIPTION
* "extern" uses of `FillHbtParticleCollection` are now const-correct
* `AliFemtoCutMonitorParticlePID::fIfUsePt` is initialized to false
* `std::pair<double, double>` removed from linkdef