### PR TITLE
PWGGA/GammaConv: Modified Calo AddTasks to adjust output filename

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_GammaCaloMerged_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCaloMerged_pp.C
@@ -1062,8 +1062,8 @@ void AddTask_GammaCaloMerged_pp(  Int_t     trainConfig                 = 1,    
   if (enableDetailedPrintout) task->SetEnableDetailedPrintout(enableDetailedPrintout);//Attention new switch small for Cluster QA
   //connect containers
   AliAnalysisDataContainer *coutput =
-    mgr->CreateContainer(Form("GammaCaloMerged_%i",trainConfig), TList::Class(),
-              AliAnalysisManager::kOutputContainer,Form("GammaCaloMerged_%i.root",trainConfig));
+    mgr->CreateContainer(!(corrTaskSetting.CompareTo("")) ? Form("GammaCaloMerged_%i",trainConfig) : Form("GammaCaloMerged_%i_%s",trainConfig,corrTaskSetting.Data()), TList::Class(),
+              AliAnalysisManager::kOutputContainer,!(corrTaskSetting.CompareTo("")) ? Form("GammaCaloMerged_%i.root",trainConfig) : Form("GammaCaloMerged_%i_%s.root",trainConfig,corrTaskSetting.Data()));
 
   mgr->AddTask(task);
   mgr->ConnectInput(task, 0, cinput);

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pPb.C
@@ -885,8 +885,8 @@ void AddTask_GammaCalo_pPb(
 
   //connect containers
   AliAnalysisDataContainer *coutput =
-    mgr->CreateContainer(Form("GammaCalo_%i",trainConfig), TList::Class(),
-          AliAnalysisManager::kOutputContainer,Form("GammaCalo_%i.root",trainConfig));
+    mgr->CreateContainer(!(corrTaskSetting.CompareTo("")) ? Form("GammaCalo_%i",trainConfig) : Form("GammaCalo_%i_%s",trainConfig,corrTaskSetting.Data()), TList::Class(),
+              AliAnalysisManager::kOutputContainer,!(corrTaskSetting.CompareTo("")) ? Form("GammaCalo_%i.root",trainConfig) : Form("GammaCalo_%i_%s.root",trainConfig,corrTaskSetting.Data()));
 
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
@@ -1284,8 +1284,8 @@ void AddTask_GammaCalo_pp(  Int_t     trainConfig                   = 1,        
 
   //connect containers
   AliAnalysisDataContainer *coutput =
-    mgr->CreateContainer(Form("GammaCalo_%i",trainConfig), TList::Class(),
-              AliAnalysisManager::kOutputContainer,Form("GammaCalo_%i.root",trainConfig));
+    mgr->CreateContainer(!(corrTaskSetting.CompareTo("")) ? Form("GammaCalo_%i",trainConfig) : Form("GammaCalo_%i_%s",trainConfig,corrTaskSetting.Data()), TList::Class(),
+              AliAnalysisManager::kOutputContainer,!(corrTaskSetting.CompareTo("")) ? Form("GammaCalo_%i.root",trainConfig) : Form("GammaCalo_%i_%s.root",trainConfig,corrTaskSetting.Data()));
 
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
@@ -1402,8 +1402,8 @@ void AddTask_GammaConvCalo_pp(  Int_t     trainConfig                   = 1,    
 
   //connect containers
   AliAnalysisDataContainer *coutput =
-    mgr->CreateContainer(Form("GammaConvCalo_%i",trainConfig), TList::Class(),
-              AliAnalysisManager::kOutputContainer,Form("GammaConvCalo_%i.root",trainConfig));
+    mgr->CreateContainer(!(corrTaskSetting.CompareTo("")) ? Form("GammaConvCalo_%i",trainConfig) : Form("GammaConvCalo_%i_%s",trainConfig,corrTaskSetting.Data()), TList::Class(),
+              AliAnalysisManager::kOutputContainer,!(corrTaskSetting.CompareTo("")) ? Form("GammaConvCalo_%i.root",trainConfig) : Form("GammaConvCalo_%i_%s.root",trainConfig,corrTaskSetting.Data()));
 
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);


### PR DESCRIPTION
This pull request modifies the calo addtasks to change the output filename if the correction framework is used. Filenames will be changes like this:
GammaCalo_402.root -> GammaCalo_402_S500A100.root
The same renaming is also done for the TList inside the root file.