### PR TITLE
Prevent container name to be reset

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.h
@@ -70,6 +70,15 @@ public:
   void Reset();
 
   /**
+   * @brief Clear function of the trigger decision container
+   * 
+   * Overwriting the Clear function preventing to reset the name.
+   * Onlu clearing the trigger decision objects content.
+   * @param option Not used
+   */
+  virtual void Clear(Option_t *option="") { Reset(); }
+
+  /**
    * @brief Add trigger decision to the container
    *
    * @param[in] decision Trigger decision, created by the trigger selection task

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.cxx
@@ -89,6 +89,7 @@ AliAnalysisTaskEmcalJetSubstructureTree::AliAnalysisTaskEmcalJetSubstructureTree
     fReclusterizer(kCAAlgo),
     fTriggerSelectionBits(AliVEvent::kAny),
     fTriggerSelectionString(""),
+    fNameTriggerDecisionContainer("EmcalTriggerDecision"),
     fUseDownscaleWeight(false),
     fFillPart(true),
     fFillAcceptance(true),
@@ -111,6 +112,7 @@ AliAnalysisTaskEmcalJetSubstructureTree::AliAnalysisTaskEmcalJetSubstructureTree
     fReclusterizer(kCAAlgo),
     fTriggerSelectionBits(AliVEvent::kAny),
     fTriggerSelectionString(""),
+    fNameTriggerDecisionContainer("EmcalTriggerDecision"),
     fUseDownscaleWeight(false),
     fFillPart(true),
     fFillAcceptance(true),
@@ -243,15 +245,13 @@ bool AliAnalysisTaskEmcalJetSubstructureTree::Run(){
     } else {
       if(IsSelectEmcalTriggers(fTriggerSelectionString.Data())){
         // Simulation - do EMCAL trigger selection from trigger selection object
-        PWG::EMCAL::AliEmcalTriggerDecisionContainer *mctrigger = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(fInputEvent->FindListObject("EmcalTriggerDecision"));
+        PWG::EMCAL::AliEmcalTriggerDecisionContainer *mctrigger = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(fInputEvent->FindListObject(fNameTriggerDecisionContainer));
         AliDebugStream(1) << "Found trigger decision object: " << (mctrigger ? "yes" : "no") << std::endl;
-        if(fTriggerSelectionString.Length()){
-          if(!mctrigger){
-            AliErrorStream() <<  "Trigger decision container not found in event - not possible to select EMCAL triggers" << std::endl;
-            return false;
-          }
-          if(!mctrigger->IsEventSelected(fTriggerSelectionString)) return false;
+        if(!mctrigger){
+          AliErrorStream() <<  "Trigger decision container with name " << fNameTriggerDecisionContainer << " not found in event - not possible to select EMCAL triggers" << std::endl;
+          return false;
         }
+        if(!mctrigger->IsEventSelected(fTriggerSelectionString)) return false;
       }
     }
   }

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.h
@@ -198,6 +198,7 @@ public:
 	void SetTriggerBits(UInt_t triggersel) { fTriggerSelectionBits = triggersel; }
 	void SetTriggerString(TString triggerstring) { fTriggerSelectionString = triggerstring; }
 	void SetUseDownscaleWeight(Bool_t usedownscale) { fUseDownscaleWeight = usedownscale; }
+  void SetGlobalTriggerDecisionContainerName(const char *name) { fNameTriggerDecisionContainer = name; }
 
 	void SetSoftdropDefiniion(Double_t zcut, Double_t betacut, Reclusterizer_t reclusterizer) {
 	  fSDZCut = zcut;
@@ -263,6 +264,7 @@ private:
 
 	UInt_t                       fTriggerSelectionBits;       ///< Trigger selection bits
   TString                      fTriggerSelectionString;     ///< Trigger selection string
+  TString                      fNameTriggerDecisionContainer; ///< Global trigger decision container
   Bool_t                       fUseDownscaleWeight;         ///< Use 1/downscale as weight
 
   // Fill levels for tree (save disk space when information is not needed)


### PR DESCRIPTION
List objects must overwrite Clear, otherwise TNamed::Clear is called (by the analysis manager or input handler) which resets the name of the list object.

In addition name of the trigger decision container in user task configurable.