### PR TITLE
Therminator2 parameters configuration

### DIFF
--- a/PWG/MCLEGO/CMakeLists.txt
+++ b/PWG/MCLEGO/CMakeLists.txt
@@ -69,5 +69,7 @@ install(DIRECTORY AMPT
 # install THERMINATOR2 configurations
 install(DIRECTORY Therminator2
   DESTINATION PWG/MCLEGO
-  FILES_MATCHING PATTERN "*.ini"
+  FILES_MATCHING
+  PATTERN "*.ini"
+  PATTERN "*.py"
   )

--- a/PWG/MCLEGO/Therminator2/apply_custom_config.py
+++ b/PWG/MCLEGO/Therminator2/apply_custom_config.py
@@ -1,0 +1,109 @@
+#!/usr/bin/python
+
+from os import environ as env
+import os
+import subprocess
+from sys import argv
+
+model_to_file = {
+    "KrakowSFO": "krakow.ini",
+    "BlastWave": "blastwave.ini",
+    "BWAVT": "bwa.ini",
+    "BWAVTDelay": "bwa.ini",
+    "BWAVLinear": "bwa.ini",
+    "BWAVLinearDelay": "bwa.ini",
+    "BWAVLinearFormation": "bwa.ini",
+    "Lhyquid3D": "lhyquid3d.ini",
+    "Lhyquid2DBI": "lhyquid2dbi.ini"
+}
+
+def print_usage():
+    print("Configure the Therminator2 files based on env variables.")
+    print("Run this script in the directory where you run Therminator2 (where events.ini and fomodel/ are).")
+    print("This script replaces variables in configuration files based on the $THERM2_PARAMS_<parameter_name> environmental variables if they exist.")
+    print("It also downloads and sets the proper freeze-out xml file if the $THERM2_PARAMS_XML_PATH is set.")
+    print("Script usage:")
+    print("%s [-verbose]" % argv[0])
+
+
+def v_print(text):
+    if len(argv)>1:
+        if argv[1] in ["-v", "-verbose"]:
+            print(text)
+
+
+def apply_config_for_file(path):
+    contents = None
+    temp_file = "%s.tmp" % path
+    with open(path, "r") as f:
+        contents = f.read()
+    
+    parameters = [] 
+    with open(temp_file, "w") as f:
+        for line in contents.splitlines():
+            if not line:
+                continue
+            if line[0] in "#[":
+                continue
+            
+            line = "".join(line.split()) # remove all whitespace from string
+            key, value = line.split("=")
+            parameters.append(key)
+            write_key_value(f, key, value)
+
+    os.remove(path)
+    os.rename(temp_file, path)
+    return parameters
+            
+
+def write_key_value(file, key, default_val):
+    val = env.get("THERM2_PARAMS_%s" % key, default_val)
+    try:
+        v_print("Got non-default value for %s: %s" % (key, env["THERM2_PARAMS_%s" % key]))
+    except:
+        pass
+    file.write("%s=%s\n" % (key, val))
+    
+
+def set_param(key, val):
+    env["THERM2_PARAMS_%s" % key] = str(val)
+
+
+def main():
+
+    if len(argv)>1:
+        if argv[1] not in ["-v", "-verbose"]:
+            print_usage()
+            exit()
+
+    set_param("EventFileType", "text")  # the parser works with text files
+    set_param("EventSubDir", "./")      # easy to handle
+    apply_config_for_file("events.ini")
+
+    model = env.get("THERM2_PARAMS_FreezeOutModel", "Lhyquid2DBI")
+    custom_xml = env.get("THERM2_PARAMS_XML_PATH", -1)
+    if custom_xml != -1:
+        v_print("Got nonzero XML_PATH: %s" % custom_xml)
+        if custom_xml[:6] == "alien:":  # if it's a GRID path, download the file
+            v_print("It's a GRID path, downloading it")
+            subprocess.call(["alien_cp", custom_xml, "fomodel/."])
+            set_param("FreezeFile", custom_xml.split("/")[-1])    # Set the path to xml file name
+            v_print("Downloaded and set XML_PATH")
+        else:
+            set_param("FreezeFile", custom_xml)   # local path
+            v_print("It's a local path. Set.")
+
+    model_file = "fomodel/%s" % model_to_file[model]
+    model_params = apply_config_for_file(model_file)
+    if model in ["Lhyquid3D", "Lhyquid2DBI"]:
+        if "EventSubDir" not in model_params:
+            v_print("Model is hydro, setting EventSubDir manually")
+            with open(model_file, "a") as f:    # by default this option is commented out in these models
+                f.write("EventSubDir=./")       # so apply_config_for_file won't change it
+
+
+if __name__ == "__main__":
+    main()
+
+
+

--- a/PWG/MCLEGO/Therminator2/gen_therm2.sh
+++ b/PWG/MCLEGO/Therminator2/gen_therm2.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 set -e
 
 if [[ $# -lt 1 ]]; then
@@ -17,15 +18,21 @@ then
     rm -rf events/
 fi
 mkdir events
-mkdir events/lhyquid2dbi-RHICAuAu200c2030Ti455ti025Tf145
 
 cp ${ALICE_PHYSICS}/PWG/MCLEGO/Therminator2/events.ini .
+cp ${ALICE_PHYSICS}/PWG/MCLEGO/Therminator2/apply_custom_config.py .
 cp -r $THERMINATOR2_ROOT/fomodel .
 cp -r $THERMINATOR2_ROOT/share .
 cp -r $THERMINATOR2_ROOT/macro .
 
-mkfifo events/lhyquid2dbi-RHICAuAu200c2030Ti455ti025Tf145/event.txt
+mkfifo events/event.txt
 
-therm2_events events.ini 0 &
-therm2_parser events/lhyquid2dbi-RHICAuAu200c2030Ti455ti025Tf145/event.txt $1 
+# set the key=value pairs in the configuration files
+# also downloads and sets the proper xml file (if hydro model is selected and custom xml path set)
+python apply_custom_config.py
+
+# start the generator and the parser
+therm2_parser events/event.txt $1 &
+therm2_events events.ini 0
+ 
 


### PR DESCRIPTION
This pull request adds the possibility to configure Therminator2 using custom parameters. It uses a python script to scan environment variables and set the key=value pairs in configuration files according to them.

The script works by scanning the configuration files line by line. When it finds a parameter_name=value pair, it checks if the corresponding THERM2_PARAMS_<parameter_name> env variable is set. If yes, the default value in the line is substituted for env variable value.

The scanning is first done on the general [events.ini](https://github.com/alisw/therminator/blob/alice/v2.0.3/events.ini) file. Then, according to the selected model, a proper .ini file in [fomodel](https://github.com/alisw/therminator/tree/alice/v2.0.3/fomodel) directory is changed.

An example of using the environment variables to set the Krakow model with non-default temperature of 140MeV:
`gSystem->Setenv("THERM2_PARAMS_FreezeOutModel", "KrakowSFO"); //Set in events.ini`
`gSystem->Setenv("THERM2_PARAMS_Temperature", "140.0"); //Set in fomodel/krakow.ini`

There is also a way to select a custom xml path (via the THERM2_PARAMS_XML_PATH) to the freeze-out hypersurface in case one of the hydro models is selected. It can either be a local path to the built-in xml files, relative to the fomodel directory (such as lhyquid2dbi/LHCPbPb5500c0005Ti500ti100Tf145.xml) or a GRID path to the custom xml, beginning with the "alien:" prefix (such as alien:/alice/cern.ch/user/m/mbuczyns/Therminator2_custom_hypersurface/custom_lhc_5.5TeV_c0005.xml)