### PR TITLE
PWGDQ/reducedTree: fix for use of old trees

### DIFF
--- a/PWGDQ/reducedTree/AliReducedAnalysisJpsi2ee.cxx
+++ b/PWGDQ/reducedTree/AliReducedAnalysisJpsi2ee.cxx
@@ -400,7 +400,8 @@ void AliReducedAnalysisJpsi2ee::LoopOverTracks(Int_t arrayOption /*=1*/) {
    //
    AliReducedTrackInfo* track = 0x0;
    TClonesArray* trackList = (arrayOption==1 ? fEvent->GetTracks() : fEvent->GetTracks2());
-   
+   if (!trackList) return;
+
    TIter nextTrack(trackList);
    for(Int_t it=0; it<trackList->GetEntries(); ++it) {
       track = (AliReducedTrackInfo*)nextTrack();

--- a/PWGDQ/reducedTree/AliReducedAnalysisJpsi2eeCorrelations.cxx
+++ b/PWGDQ/reducedTree/AliReducedAnalysisJpsi2eeCorrelations.cxx
@@ -171,6 +171,7 @@ void AliReducedAnalysisJpsi2eeCorrelations::LoopOverAssociatedTracks(Int_t array
    //
    AliReducedTrackInfo*  track     = 0x0;
    TClonesArray*         trackList = (arrayOption==1 ? fEvent->GetTracks() : fEvent->GetTracks2());
+   if (!trackList) return;
    TIter nextTrack(trackList);
    for (Int_t itr=0; itr<trackList->GetEntries(); ++itr) {
       track = (AliReducedTrackInfo*)nextTrack();

--- a/PWGDQ/reducedTree/macros/runAnalysisTrain.C
+++ b/PWGDQ/reducedTree/macros/runAnalysisTrain.C
@@ -284,6 +284,7 @@ void runAnalysisTrain(const Char_t* infile, const Char_t* runmode = "local", con
       TFile* tmpOut = (TFile*)mgr->OpenFile((AliAnalysisDataContainer*)outputs->At(i), "UPDATE", kTRUE);
       if (!tmpOut) continue;
       if (((TString)tmpOut->GetName()).Contains("dstTree")) continue;
+      if (!histArr->GetEntries()) continue;
       cout << "Writing histograms to " << tmpOut->GetName() << endl;
       for (Int_t j=0; j<histArr->GetEntries(); j++) histArr->At(j)->Write();
       tmpOut->Close();


### PR DESCRIPTION
- fix in analysis task for use of trees w/o second track array
- slight modification of writing of histograms from tree to analysis output file