### PR TITLE
PWGGA/GammaConv: Changed output file naming for correction framework files

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_GammaCaloMerged_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCaloMerged_pPb.C
@@ -389,7 +389,7 @@ void AddTask_GammaCaloMerged_pPb( Int_t     trainConfig                 = 1,    
   //connect containers
   AliAnalysisDataContainer *coutput =
     mgr->CreateContainer(!(corrTaskSetting.CompareTo("")) ? Form("GammaCaloMerged_%i",trainConfig) : Form("GammaCaloMerged_%i_%s",trainConfig,corrTaskSetting.Data()), TList::Class(),
-              AliAnalysisManager::kOutputContainer,!(corrTaskSetting.CompareTo("")) ? Form("GammaCaloMerged_%i.root",trainConfig) : Form("GammaCaloMerged_%i_%s.root",trainConfig,corrTaskSetting.Data()));
+              AliAnalysisManager::kOutputContainer,Form("GammaCaloMerged_%i.root",trainConfig) );
 
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);

--- a/PWGGA/GammaConv/macros/AddTask_GammaCaloMerged_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCaloMerged_pp.C
@@ -1063,7 +1063,7 @@ void AddTask_GammaCaloMerged_pp(  Int_t     trainConfig                 = 1,    
   //connect containers
   AliAnalysisDataContainer *coutput =
     mgr->CreateContainer(!(corrTaskSetting.CompareTo("")) ? Form("GammaCaloMerged_%i",trainConfig) : Form("GammaCaloMerged_%i_%s",trainConfig,corrTaskSetting.Data()), TList::Class(),
-              AliAnalysisManager::kOutputContainer,!(corrTaskSetting.CompareTo("")) ? Form("GammaCaloMerged_%i.root",trainConfig) : Form("GammaCaloMerged_%i_%s.root",trainConfig,corrTaskSetting.Data()));
+              AliAnalysisManager::kOutputContainer, Form("GammaCaloMerged_%i.root",trainConfig) );
 
   mgr->AddTask(task);
   mgr->ConnectInput(task, 0, cinput);

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_PbPb.C
@@ -876,7 +876,7 @@ void AddTask_GammaCalo_PbPb(  Int_t     trainConfig                     = 1,    
   //connect containers
   AliAnalysisDataContainer *coutput =
     mgr->CreateContainer(!(corrTaskSetting.CompareTo("")) ? Form("GammaCalo_%i",trainConfig) : Form("GammaCalo_%i_%s",trainConfig,corrTaskSetting.Data()), TList::Class(),
-              AliAnalysisManager::kOutputContainer,!(corrTaskSetting.CompareTo("")) ? Form("GammaCalo_%i.root",trainConfig) : Form("GammaCalo_%i_%s.root",trainConfig,corrTaskSetting.Data()));
+              AliAnalysisManager::kOutputContainer,Form("GammaCalo_%i.root",trainConfig) );
 
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pPb.C
@@ -892,7 +892,7 @@ void AddTask_GammaCalo_pPb(
   //connect containers
   AliAnalysisDataContainer *coutput =
     mgr->CreateContainer(!(corrTaskSetting.CompareTo("")) ? Form("GammaCalo_%i",trainConfig) : Form("GammaCalo_%i_%s",trainConfig,corrTaskSetting.Data()), TList::Class(),
-              AliAnalysisManager::kOutputContainer,!(corrTaskSetting.CompareTo("")) ? Form("GammaCalo_%i.root",trainConfig) : Form("GammaCalo_%i_%s.root",trainConfig,corrTaskSetting.Data()));
+              AliAnalysisManager::kOutputContainer, Form("GammaCalo_%i.root",trainConfig) );
 
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
@@ -1285,7 +1285,7 @@ void AddTask_GammaCalo_pp(  Int_t     trainConfig                   = 1,        
   //connect containers
   AliAnalysisDataContainer *coutput =
     mgr->CreateContainer(!(corrTaskSetting.CompareTo("")) ? Form("GammaCalo_%i",trainConfig) : Form("GammaCalo_%i_%s",trainConfig,corrTaskSetting.Data()), TList::Class(),
-              AliAnalysisManager::kOutputContainer,!(corrTaskSetting.CompareTo("")) ? Form("GammaCalo_%i.root",trainConfig) : Form("GammaCalo_%i_%s.root",trainConfig,corrTaskSetting.Data()));
+              AliAnalysisManager::kOutputContainer,Form("GammaCalo_%i.root",trainConfig));
 
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
@@ -742,7 +742,7 @@ void AddTask_GammaConvCalo_PbPb(  Int_t     trainConfig                     = 1,
   //connect containers
   AliAnalysisDataContainer *coutput =
     mgr->CreateContainer(!(corrTaskSetting.CompareTo("")) ? Form("GammaConvCalo_%i",trainConfig) : Form("GammaConvCalo_%i_%s",trainConfig,corrTaskSetting.Data()), TList::Class(),
-              AliAnalysisManager::kOutputContainer,!(corrTaskSetting.CompareTo("")) ? Form("GammaConvCalo_%i.root",trainConfig) : Form("GammaConvCalo_%i_%s.root",trainConfig,corrTaskSetting.Data()));
+              AliAnalysisManager::kOutputContainer,Form("GammaConvCalo_%i.root",trainConfig));
 
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pPb.C
@@ -1266,7 +1266,7 @@ void AddTask_GammaConvCalo_pPb( Int_t     trainConfig                   = 1,    
   //connect containers
   AliAnalysisDataContainer *coutput =
     mgr->CreateContainer(!(corrTaskSetting.CompareTo("")) ? Form("GammaConvCalo_%i",trainConfig) : Form("GammaConvCalo_%i_%s",trainConfig,corrTaskSetting.Data()), TList::Class(),
-              AliAnalysisManager::kOutputContainer,!(corrTaskSetting.CompareTo("")) ? Form("GammaConvCalo_%i.root",trainConfig) : Form("GammaConvCalo_%i_%s.root",trainConfig,corrTaskSetting.Data()));
+              AliAnalysisManager::kOutputContainer,Form("GammaConvCalo_%i.root",trainConfig) );
 
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
@@ -1403,7 +1403,7 @@ void AddTask_GammaConvCalo_pp(  Int_t     trainConfig                   = 1,    
   //connect containers
   AliAnalysisDataContainer *coutput =
     mgr->CreateContainer(!(corrTaskSetting.CompareTo("")) ? Form("GammaConvCalo_%i",trainConfig) : Form("GammaConvCalo_%i_%s",trainConfig,corrTaskSetting.Data()), TList::Class(),
-              AliAnalysisManager::kOutputContainer,!(corrTaskSetting.CompareTo("")) ? Form("GammaConvCalo_%i.root",trainConfig) : Form("GammaConvCalo_%i_%s.root",trainConfig,corrTaskSetting.Data()));
+              AliAnalysisManager::kOutputContainer, Form("GammaConvCalo_%i.root",trainConfig) );
 
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);


### PR DESCRIPTION
Naming scheme changed from this:

GammaConvCalo_301_S500A100.root
  -> GammaConvCalo_301_S500A100
GammaConvCalo_301_S400A75.root
  -> GammaConvCalo_301_S400A75

to this:

GammaConvCalo_301.root
  -> GammaConvCalo_301_S500A100
  -> GammaConvCalo_301_S400A75

Therefore the output filename stays the same whereas the different correction framework configurations are only added to the TList names inside of the file.
