### PR TITLE
Several changes

### DIFF
--- a/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
+++ b/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
@@ -1262,7 +1262,6 @@ UInt_t AliAnalysisTaskReducedTreeMaker::MatchMCsignals(Int_t iparticle) {
    if(!nMCsignals) return 0;
    
    AliMCEvent* event = AliDielectronMC::Instance()->GetMCEvent();
-   AliVParticle* particle = event->GetTrack(iparticle);
    
    UInt_t mcSignalsMap = 0;
    for(Int_t isig=0; isig<nMCsignals; ++isig) {
@@ -1343,6 +1342,7 @@ void AliAnalysisTaskReducedTreeMaker::FillMCTruthInfo()
          reducedParticle=new(tracks[currentTrackIdx]) AliReducedTrackInfo();
       
       reducedParticle->fMCFlags = mcSignalsMap;
+      reducedParticle->fIsMCTruth = kTRUE;
       reducedParticle->PxPyPz(particle->Px(), particle->Py(), particle->Pz());
       reducedParticle->Charge(particle->Charge());
    
@@ -1657,6 +1657,12 @@ void AliAnalysisTaskReducedTreeMaker::FillTrackInfo()
    
     // If we want to write only AliReducedBaseTrack objects, then we stop here
     if (fSelectedTrackIsBaseTrack) {
+       if(fFillMCInfo && hasMC) {
+          AliVParticle* mcTruth = AliDielectronMC::Instance()->GetMCTrack(particle);
+          if(mcTruth)
+             reducedParticle->fMCFlags = MatchMCsignals(mcTruth->GetLabel());    // check which MC signals match this particle
+       }
+       
       fReducedEvent->fNtracks[1] += 1;
       continue;
     }
@@ -1774,6 +1780,8 @@ void AliAnalysisTaskReducedTreeMaker::FillTrackInfo()
       if(fFillMCInfo && hasMC) {
          AliMCParticle* truthParticle = AliDielectronMC::Instance()->GetMCTrack(esdTrack);
          if(truthParticle) {
+           trackInfo->fMCFlags = MatchMCsignals(truthParticle->GetLabel());    // check which MC signals match this particle and fill the bit map
+                      
            trackInfo->fMCMom[0] = truthParticle->Px();
            trackInfo->fMCMom[1] = truthParticle->Py();
            trackInfo->fMCMom[2] = truthParticle->Pz();
@@ -1870,6 +1878,8 @@ void AliAnalysisTaskReducedTreeMaker::FillTrackInfo()
       if(fFillMCInfo && hasMC) {
          AliAODMCParticle* truthParticle = AliDielectronMC::Instance()->GetMCTrack(aodTrack);
          if(truthParticle) {
+            trackInfo->fMCFlags = MatchMCsignals(aodTrack->GetLabel());    // check which MC signals match this particle and fill the bit map
+            
             trackInfo->fMCMom[0] = truthParticle->Px();
             trackInfo->fMCMom[1] = truthParticle->Py();
             trackInfo->fMCMom[2] = truthParticle->Pz();

--- a/PWGDQ/reducedTree/AliMixingHandler.cxx
+++ b/PWGDQ/reducedTree/AliMixingHandler.cxx
@@ -129,6 +129,16 @@ void AliMixingHandler::AddMixingVariable(AliReducedVarManager::Variables var, In
    AliReducedVarManager::SetUseVariable(var);
 }
 
+//_________________________________________________________________________
+void AliMixingHandler::AddMixingVariable(AliReducedVarManager::Variables var, Int_t nBins, const Double_t* binLims) {
+   //
+   // copy of the AddMixingVariable(AliReducedVarManager::Variables var, Int_t nBins, const Float_t* binLims) function
+   //   just to support also Double array as bin limits
+   //
+   Float_t* bins = new Float_t[nBins];
+   for(Int_t i=0;i<nBins;++i) bins[i] = binLims[i];
+   AddMixingVariable(var, nBins, bins);
+}
 
 //_________________________________________________________________________
 void AliMixingHandler::Init() {

--- a/PWGDQ/reducedTree/AliMixingHandler.h
+++ b/PWGDQ/reducedTree/AliMixingHandler.h
@@ -34,6 +34,7 @@ public:
   
   // setters
   void AddMixingVariable(AliReducedVarManager::Variables var, Int_t nBins, const Float_t* binLims);
+  void AddMixingVariable(AliReducedVarManager::Variables var, Int_t nBins, const Double_t* binLims);
   void SetMixLikeSign(Bool_t flag) {fMixLikeSign = flag;}
   void SetMixLikePairs(Bool_t flag) {SetMixLikeSign(flag);}      // synonim function to SetMixLikeSign
   void SetPoolDepth(Int_t n) {fPoolDepth = n;}

--- a/PWGDQ/reducedTree/AliReducedAnalysisJpsi2ee.cxx
+++ b/PWGDQ/reducedTree/AliReducedAnalysisJpsi2ee.cxx
@@ -44,7 +44,10 @@ AliReducedAnalysisJpsi2ee::AliReducedAnalysisJpsi2ee() :
   fNegTracks(),
   fPrefilterPosTracks(),
   fPrefilterNegTracks(),
-  fJpsiCandidates()
+  fJpsiCandidates(),
+  fLegCandidatesMCcuts(),
+  fJpsiMotherMCcuts(),
+  fJpsiElectronMCcuts()
 {
   //
   // default constructor
@@ -73,7 +76,10 @@ AliReducedAnalysisJpsi2ee::AliReducedAnalysisJpsi2ee(const Char_t* name, const C
   fNegTracks(),
   fPrefilterPosTracks(),
   fPrefilterNegTracks(),
-  fJpsiCandidates()
+  fJpsiCandidates(),
+  fLegCandidatesMCcuts(),
+  fJpsiMotherMCcuts(),
+  fJpsiElectronMCcuts()
 {
   //
   // named constructor
@@ -88,6 +94,9 @@ AliReducedAnalysisJpsi2ee::AliReducedAnalysisJpsi2ee(const Char_t* name, const C
    fPrefilterPosTracks.SetOwner(kFALSE);
    fPrefilterNegTracks.SetOwner(kFALSE);
    fJpsiCandidates.SetOwner(kTRUE);
+   fLegCandidatesMCcuts.SetOwner(kTRUE);
+   fJpsiMotherMCcuts.SetOwner(kTRUE);
+   fJpsiElectronMCcuts.SetOwner(kTRUE);
 }
 
 
@@ -313,51 +322,88 @@ void AliReducedAnalysisJpsi2ee::FillTrackHistograms(TString trackClass /*= "Trac
    // Fill all track histograms
    //
    for(Int_t i=0;i<36; ++i) fValues[AliReducedVarManager::kNtracksAnalyzedInPhiBins+i] = 0.;
-   AliReducedTrackInfo* track=0;
+   AliReducedBaseTrack* track=0;
    TIter nextPosTrack(&fPosTracks);
    for(Int_t i=0;i<fPosTracks.GetEntries();++i) {
-      track = (AliReducedTrackInfo*)nextPosTrack();
+      track = (AliReducedBaseTrack*)nextPosTrack();
       //Int_t tpcSector = TMath::FloorNint(18.*track->Phi()/TMath::TwoPi());
       fValues[AliReducedVarManager::kNtracksAnalyzedInPhiBins+(track->Eta()<0.0 ? 0 : 18) + TMath::FloorNint(18.*track->Phi()/TMath::TwoPi())] += 1;
+      // reset track variables
+      for(Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedEOverP; ++i) fValues[i]=-9999.;
+      
       AliReducedVarManager::FillTrackInfo(track, fValues);
       FillTrackHistograms(track, trackClass);
    }
    TIter nextNegTrack(&fNegTracks);
    for(Int_t i=0;i<fNegTracks.GetEntries();++i) {
-      track = (AliReducedTrackInfo*)nextNegTrack();
+      track = (AliReducedBaseTrack*)nextNegTrack();
       //Int_t tpcSector = TMath::FloorNint(18.*track->Phi()/TMath::TwoPi());
       fValues[AliReducedVarManager::kNtracksAnalyzedInPhiBins+(track->Eta()<0.0 ? 0 : 18) + TMath::FloorNint(18.*track->Phi()/TMath::TwoPi())] += 1;
+      // reset track variables
+      for(Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedEOverP; ++i) fValues[i]=-9999.;
+      
       AliReducedVarManager::FillTrackInfo(track, fValues);
       FillTrackHistograms(track, trackClass);
-      //cout << "Neg track " << i << ": "; AliReducedVarManager::PrintBits(track->Status()); cout << endl;
    }
 }
 
 
 //___________________________________________________________________________
-void AliReducedAnalysisJpsi2ee::FillTrackHistograms(AliReducedTrackInfo* track, TString trackClass /*="Track"*/) {
+void AliReducedAnalysisJpsi2ee::FillTrackHistograms(AliReducedBaseTrack* track, TString trackClass /*="Track"*/) {
    //
    // fill track level histograms
    //
-   Bool_t isMCTruth = fOptionRunOverMC && IsMCTruth(track);
+   UInt_t mcDecisionMap = 0;
+   if(fOptionRunOverMC) mcDecisionMap = CheckReconstructedLegMCTruth(track);      
+   
    for(Int_t icut=0; icut<fTrackCuts.GetEntries(); ++icut) {
       if(track->TestFlag(icut)) {
          fHistosManager->FillHistClass(Form("%s_%s", trackClass.Data(), fTrackCuts.At(icut)->GetName()), fValues);
-         if(isMCTruth) fHistosManager->FillHistClass(Form("%s_%s_MCTruth", trackClass.Data(), fTrackCuts.At(icut)->GetName()), fValues);
+         if(mcDecisionMap) {       // Fill histograms for tracks identified as MC truth
+            for(Int_t iMC=0; iMC<=fLegCandidatesMCcuts.GetEntries(); ++iMC) {
+               if(mcDecisionMap & (UInt_t(1)<<iMC))
+                  fHistosManager->FillHistClass(Form("%s_%s_%s", trackClass.Data(), fTrackCuts.At(icut)->GetName(), 
+                                                                  fLegCandidatesMCcuts.At(iMC)->GetName()), fValues);
+            }
+         }
+         
+         if(track->IsA() != AliReducedTrackInfo::Class()) continue;
+         
+         AliReducedTrackInfo* trackInfo = dynamic_cast<AliReducedTrackInfo*>(track);
+         if(!trackInfo) continue;
+         
          for(UInt_t iflag=0; iflag<AliReducedVarManager::kNTrackingFlags; ++iflag) {
-            AliReducedVarManager::FillTrackingFlag(track, iflag, fValues);
+            AliReducedVarManager::FillTrackingFlag(trackInfo, iflag, fValues);
             fHistosManager->FillHistClass(Form("%sStatusFlags_%s", trackClass.Data(), fTrackCuts.At(icut)->GetName()), fValues);
-            if(isMCTruth) fHistosManager->FillHistClass(Form("%sStatusFlags_%s_MCTruth", trackClass.Data(), fTrackCuts.At(icut)->GetName()), fValues);
+            if(mcDecisionMap) {
+               for(Int_t iMC=0; iMC<=fLegCandidatesMCcuts.GetEntries(); ++iMC) {
+                  if(mcDecisionMap & (UInt_t(1)<<iMC))
+                     fHistosManager->FillHistClass(Form("%sStatusFlags_%s_%s", trackClass.Data(), fTrackCuts.At(icut)->GetName(),
+                                                                     fLegCandidatesMCcuts.At(iMC)->GetName()), fValues);
+               }
+            }
          }
          for(Int_t iLayer=0; iLayer<6; ++iLayer) {
-            AliReducedVarManager::FillITSlayerFlag(track, iLayer, fValues);
+            AliReducedVarManager::FillITSlayerFlag(trackInfo, iLayer, fValues);
             fHistosManager->FillHistClass(Form("%sITSclusterMap_%s", trackClass.Data(), fTrackCuts.At(icut)->GetName()), fValues);
-            if(isMCTruth) fHistosManager->FillHistClass(Form("%sITSclusterMap_%s_MCTruth", trackClass.Data(), fTrackCuts.At(icut)->GetName()), fValues);
+            if(mcDecisionMap) {
+               for(Int_t iMC=0; iMC<=fLegCandidatesMCcuts.GetEntries(); ++iMC) {
+                  if(mcDecisionMap & (UInt_t(1)<<iMC))
+                     fHistosManager->FillHistClass(Form("%sITSclusterMap_%s_%s", trackClass.Data(), fTrackCuts.At(icut)->GetName(),
+                                                                     fLegCandidatesMCcuts.At(iMC)->GetName()), fValues);
+               }
+            }
          }
          for(Int_t iLayer=0; iLayer<8; ++iLayer) {
-            AliReducedVarManager::FillTPCclusterBitFlag(track, iLayer, fValues);
+            AliReducedVarManager::FillTPCclusterBitFlag(trackInfo, iLayer, fValues);
             fHistosManager->FillHistClass(Form("%sTPCclusterMap_%s", trackClass.Data(), fTrackCuts.At(icut)->GetName()), fValues);
-            if(isMCTruth) fHistosManager->FillHistClass(Form("%sTPCclusterMap_%s_MCTruth", trackClass.Data(), fTrackCuts.At(icut)->GetName()), fValues);
+            if(mcDecisionMap) {
+               for(Int_t iMC=0; iMC<=fLegCandidatesMCcuts.GetEntries(); ++iMC) {
+                  if(mcDecisionMap & (UInt_t(1)<<iMC))
+                     fHistosManager->FillHistClass(Form("%sTPCclusterMap_%s_%s", trackClass.Data(), fTrackCuts.At(icut)->GetName(),
+                                                                     fLegCandidatesMCcuts.At(iMC)->GetName()), fValues);
+               }
+            }
          }
       } // end if(track->TestFlag(icut))
    }  // end loop over cuts
@@ -365,7 +411,7 @@ void AliReducedAnalysisJpsi2ee::FillTrackHistograms(AliReducedTrackInfo* track, 
 
 
 //___________________________________________________________________________
-void AliReducedAnalysisJpsi2ee::FillPairHistograms(ULong_t mask, Int_t pairType, TString pairClass /*="PairSE"*/, Bool_t isMCTruth /* = kFALSE*/) {
+void AliReducedAnalysisJpsi2ee::FillPairHistograms(ULong_t mask, Int_t pairType, TString pairClass /*="PairSE"*/, UInt_t mcDecisions /* = 0*/) {
    //
    // fill pair level histograms
    // NOTE: pairType can be 0,1 or 2 corresponding to ++, +- or -- pairs
@@ -373,7 +419,12 @@ void AliReducedAnalysisJpsi2ee::FillPairHistograms(ULong_t mask, Int_t pairType,
    for(Int_t icut=0; icut<fTrackCuts.GetEntries(); ++icut) {
       if(mask & (ULong_t(1)<<icut)) {
          fHistosManager->FillHistClass(Form("%s%s_%s", pairClass.Data(), typeStr[pairType].Data(), fTrackCuts.At(icut)->GetName()), fValues);
-         if(isMCTruth && pairType==1) fHistosManager->FillHistClass(Form("%s%s_%s_MCTruth", pairClass.Data(), typeStr[pairType].Data(), fTrackCuts.At(icut)->GetName()), fValues);
+         if(mcDecisions && pairType==1) {
+            for(Int_t iMC=0; iMC<=fLegCandidatesMCcuts.GetEntries(); ++iMC) {
+               if(mcDecisions & (UInt_t(1)<<iMC))
+                  fHistosManager->FillHistClass(Form("%s%s_%s_%s", pairClass.Data(), typeStr[pairType].Data(), fTrackCuts.At(icut)->GetName(), fLegCandidatesMCcuts.At(iMC)->GetName()), fValues);
+            }
+         }
       }
    }  // end loop over cuts
 }
@@ -398,33 +449,45 @@ void AliReducedAnalysisJpsi2ee::LoopOverTracks(Int_t arrayOption /*=1*/) {
    //
    // Loop over a given track array, apply cuts and add selected tracks to arrays
    //
-   AliReducedTrackInfo* track = 0x0;
+   AliReducedBaseTrack* track = 0x0;
    TClonesArray* trackList = (arrayOption==1 ? fEvent->GetTracks() : fEvent->GetTracks2());
    
    TIter nextTrack(trackList);
    for(Int_t it=0; it<trackList->GetEntries(); ++it) {
-      track = (AliReducedTrackInfo*)nextTrack();
-      if(fOptionRunOverMC && track->IsMCTruth()) continue;
-      //cout << "track " << it << ": "; AliReducedVarManager::PrintBits(track->Status()); cout << endl;
+      track = (AliReducedBaseTrack*)nextTrack();
+      // do not loop over pure MC truth tracks 
+      // NOTE: this can be also handled via AliReducedTrackCut::SetRejectPureMC()
+      if(fOptionRunOverMC && track->IsMCTruth()) continue;     
+      // reset track variables
+      for(Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedEOverP; ++i) fValues[i]=-9999.;
+
       AliReducedVarManager::FillTrackInfo(track, fValues);
       fHistosManager->FillHistClass("Track_BeforeCuts", fValues);
-      for(UInt_t iflag=0; iflag<AliReducedVarManager::kNTrackingStatus; ++iflag) {
-         //cout << "track / tracking flags :: " << track << " / "; AliReducedVarManager::PrintBits(track->Status()); cout << endl;
-         AliReducedVarManager::FillTrackingFlag(track, iflag, fValues);
-         fHistosManager->FillHistClass("TrackStatusFlags_BeforeCuts", fValues);
+      
+      if(track->IsA() == AliReducedTrackInfo::Class()) {
+         AliReducedTrackInfo* trackInfo = dynamic_cast<AliReducedTrackInfo*>(track);
+         if(trackInfo) {
+            for(UInt_t iflag=0; iflag<AliReducedVarManager::kNTrackingStatus; ++iflag) {
+               AliReducedVarManager::FillTrackingFlag(trackInfo, iflag, fValues);
+               fHistosManager->FillHistClass("TrackStatusFlags_BeforeCuts", fValues);
+            }
+            for(Int_t iLayer=0; iLayer<6; ++iLayer) {
+               AliReducedVarManager::FillITSlayerFlag(trackInfo, iLayer, fValues);
+               fHistosManager->FillHistClass("TrackITSclusterMap_BeforeCuts", fValues);
+            }
+            for(Int_t iLayer=0; iLayer<8; ++iLayer) {
+               AliReducedVarManager::FillTPCclusterBitFlag(trackInfo, iLayer, fValues);
+               fHistosManager->FillHistClass("TrackTPCclusterMap_BeforeCuts", fValues);
+            }
+         }
       }
-      for(Int_t iLayer=0; iLayer<6; ++iLayer) {
-         AliReducedVarManager::FillITSlayerFlag(track, iLayer, fValues);
-         fHistosManager->FillHistClass("TrackITSclusterMap_BeforeCuts", fValues);
-      }
-      for(Int_t iLayer=0; iLayer<8; ++iLayer) {
-         AliReducedVarManager::FillTPCclusterBitFlag(track, iLayer, fValues);
-         fHistosManager->FillHistClass("TrackTPCclusterMap_BeforeCuts", fValues);
-      }
+      
       if(IsTrackSelected(track, fValues)) {
-         fValues[AliReducedVarManager::kEvAverageTPCchi2] += track->TPCchi2();
          if(track->Charge()>0) fPosTracks.Add(track);
          if(track->Charge()<0) fNegTracks.Add(track);
+         
+         if(track->IsA() == AliReducedTrackInfo::Class())
+            fValues[AliReducedVarManager::kEvAverageTPCchi2] += ((AliReducedTrackInfo*)track)->TPCchi2();
       }
       if(IsTrackPrefilterSelected(track, fValues)) {
          if(track->Charge()>0) fPrefilterPosTracks.Add(track);
@@ -444,22 +507,22 @@ void AliReducedAnalysisJpsi2ee::RunSameEventPairing(TString pairClass /*="PairSE
    TIter nextPosTrack(&fPosTracks);
    TIter nextNegTrack(&fNegTracks);
    
-   AliReducedTrackInfo* pTrack=0;
-   AliReducedTrackInfo* pTrack2=0;
-   AliReducedTrackInfo* nTrack=0;
-   AliReducedTrackInfo* nTrack2=0;
+   AliReducedBaseTrack* pTrack=0;
+   AliReducedBaseTrack* pTrack2=0;
+   AliReducedBaseTrack* nTrack=0;
+   AliReducedBaseTrack* nTrack2=0;
    for(Int_t ip=0; ip<fPosTracks.GetEntries(); ++ip) {
-      pTrack = (AliReducedTrackInfo*)nextPosTrack();
+      pTrack = (AliReducedBaseTrack*)nextPosTrack();
       
       nextNegTrack.Reset();
       for(Int_t in=0; in<fNegTracks.GetEntries(); ++in) {
-         nTrack = (AliReducedTrackInfo*)nextNegTrack();
+         nTrack = (AliReducedBaseTrack*)nextNegTrack();
          
          // verify that the two current tracks have at least 1 common bit
          if(!(pTrack->GetFlags() & nTrack->GetFlags())) continue;
          AliReducedVarManager::FillPairInfo(pTrack, nTrack, AliReducedPairInfo::kJpsiToEE, fValues);
          if(IsPairSelected(fValues)) {
-            FillPairHistograms(pTrack->GetFlags() & nTrack->GetFlags(), 1, pairClass, fOptionRunOverMC && IsMCTruth(pTrack, nTrack));    // 1 is for +- pairs 
+            FillPairHistograms(pTrack->GetFlags() & nTrack->GetFlags(), 1, pairClass, (fOptionRunOverMC ? CheckReconstructedLegMCTruth(pTrack, nTrack) : 0));    // 1 is for +- pairs 
             fValues[AliReducedVarManager::kNpairsSelected] += 1.0;
             if(fOptionStoreJpsiCandidates) {
                AliReducedPairInfo* pair = new AliReducedPairInfo();
@@ -476,7 +539,7 @@ void AliReducedAnalysisJpsi2ee::RunSameEventPairing(TString pairClass /*="PairSE
       
       if(fOptionRunLikeSignPairing) {
          for(Int_t ip2=ip+1; ip2<fPosTracks.GetEntries(); ++ip2) {
-            pTrack2 = (AliReducedTrackInfo*)fPosTracks.At(ip2);
+            pTrack2 = (AliReducedBaseTrack*)fPosTracks.At(ip2);
          
             // verify that the two current tracks have at least 1 common bit
             if(!(pTrack->GetFlags() & pTrack2->GetFlags())) continue;
@@ -502,10 +565,10 @@ void AliReducedAnalysisJpsi2ee::RunSameEventPairing(TString pairClass /*="PairSE
    if(fOptionRunLikeSignPairing) {
       nextNegTrack.Reset();
       for(Int_t in=0; in<fNegTracks.GetEntries(); ++in) {
-         nTrack = (AliReducedTrackInfo*)nextNegTrack();
+         nTrack = (AliReducedBaseTrack*)nextNegTrack();
       
          for(Int_t in2=in+1; in2<fNegTracks.GetEntries(); ++in2) {
-            nTrack2 = (AliReducedTrackInfo*)fNegTracks.At(in2);
+            nTrack2 = (AliReducedBaseTrack*)fNegTracks.At(in2);
          
             // verify that the two current tracks have at least 1 common bit
             if(!(nTrack->GetFlags() & nTrack2->GetFlags())) continue;
@@ -542,14 +605,14 @@ void AliReducedAnalysisJpsi2ee::RunPrefilter() {
    TIter nextNegPrefilterTrack(&fPrefilterNegTracks);
    
    // First pair the positive trackes with the prefilter selected tracks
-   AliReducedTrackInfo* track=0;
-   AliReducedTrackInfo* trackPref=0;
+   AliReducedBaseTrack* track=0;
+   AliReducedBaseTrack* trackPref=0;
    for(Int_t ip = 0; ip<fPosTracks.GetEntries(); ++ip) {
-      track = (AliReducedTrackInfo*)nextPosTrack();
+      track = (AliReducedBaseTrack*)nextPosTrack();
       
       nextPosPrefilterTrack.Reset();
       for(Int_t ipp = 0; ipp<fPrefilterPosTracks.GetEntries(); ++ipp) {
-         trackPref = (AliReducedTrackInfo*)nextPosPrefilterTrack();
+         trackPref = (AliReducedBaseTrack*)nextPosPrefilterTrack();
          
          if(track->TrackId()==trackPref->TrackId()) continue;       // avoid self-pairing
          AliReducedVarManager::FillPairInfo(track, trackPref, AliReducedPairInfo::kJpsiToEE, fValues);
@@ -561,7 +624,7 @@ void AliReducedAnalysisJpsi2ee::RunPrefilter() {
       
       nextNegPrefilterTrack.Reset();
       for(Int_t ipn = 0; ipn<fPrefilterNegTracks.GetEntries(); ++ipn) {
-         trackPref = (AliReducedTrackInfo*)nextNegPrefilterTrack();
+         trackPref = (AliReducedBaseTrack*)nextNegPrefilterTrack();
          
          AliReducedVarManager::FillPairInfo(track, trackPref, AliReducedPairInfo::kJpsiToEE, fValues);
          if(!IsPairPreFilterSelected(fValues)) {
@@ -572,11 +635,11 @@ void AliReducedAnalysisJpsi2ee::RunPrefilter() {
    }  // end loop over the positive tracks
 
    for(Int_t in = 0; in<fNegTracks.GetEntries(); ++in) {
-      track = (AliReducedTrackInfo*)nextNegTrack();
+      track = (AliReducedBaseTrack*)nextNegTrack();
       
       nextPosPrefilterTrack.Reset();
       for(Int_t ipp = 0; ipp<fPrefilterPosTracks.GetEntries(); ++ipp) {
-         trackPref = (AliReducedTrackInfo*)nextPosPrefilterTrack();
+         trackPref = (AliReducedBaseTrack*)nextPosPrefilterTrack();
          
          AliReducedVarManager::FillPairInfo(track, trackPref, AliReducedPairInfo::kJpsiToEE, fValues);
          if(!IsPairPreFilterSelected(fValues)) {
@@ -587,7 +650,7 @@ void AliReducedAnalysisJpsi2ee::RunPrefilter() {
       
       nextNegPrefilterTrack.Reset();
       for(Int_t ipn = 0; ipn<fPrefilterNegTracks.GetEntries(); ++ipn) {
-         trackPref = (AliReducedTrackInfo*)nextNegPrefilterTrack();
+         trackPref = (AliReducedBaseTrack*)nextNegPrefilterTrack();
          
          if(track->TrackId()==trackPref->TrackId()) continue;       // avoid self-pairing
          AliReducedVarManager::FillPairInfo(track, trackPref, AliReducedPairInfo::kJpsiToEE, fValues);
@@ -601,14 +664,14 @@ void AliReducedAnalysisJpsi2ee::RunPrefilter() {
    // remove tracks
    nextPosTrack.Reset();
    for(Int_t ip = fPosTracks.GetEntries()-1 ; ip >= 0; --ip) {
-     track = (AliReducedTrackInfo*)nextPosTrack();
+     track = (AliReducedBaseTrack*)nextPosTrack();
      if(!track->GetFlags()) {
         fPosTracks.Remove(track);
      }
    }
   nextNegTrack.Reset();
   for(Int_t ip = fNegTracks.GetEntries()-1 ; ip >= 0; --ip) {
-    track = (AliReducedTrackInfo*)nextNegTrack();
+    track = (AliReducedBaseTrack*)nextNegTrack();
     if(!track->GetFlags()) {
        fNegTracks.Remove(track);
     }
@@ -626,29 +689,48 @@ void AliReducedAnalysisJpsi2ee::Finish() {
 
 
 //___________________________________________________________________________
-Bool_t AliReducedAnalysisJpsi2ee::IsMCTruth(AliReducedTrackInfo* track) {
+UInt_t AliReducedAnalysisJpsi2ee::CheckReconstructedLegMCTruth(AliReducedBaseTrack* track) {
    //
-   // check whether the track is an electron from a J/psi decay
+   // Check a reconstructed track against all the specified MC truth cuts
    //
-   if(TMath::Abs(track->MCPdg(0)) != 11) return kFALSE;
-   if(TMath::Abs(track->MCPdg(1)) != 443) return kFALSE;
-   //   if(track->MCPdg(2) != -9999) return kFALSE;
-   return kTRUE;
+   // TODO: In the fLegCandidatesMCcuts one can also add AliSignalMC objects which can then be tested
+   //             using the AliReducedTrackInfo::fMCPdg[]
+   //
+   if(fLegCandidatesMCcuts.GetEntries()==0) return 0;
+   
+   UInt_t decisionMap = 0;
+   for(Int_t i=0; i<fLegCandidatesMCcuts.GetEntries(); ++i) {
+      AliReducedInfoCut* cut = (AliReducedInfoCut*)fLegCandidatesMCcuts.At(i);
+      if(cut->IsSelected(track)) 
+         decisionMap |= (UInt_t(1)<<i);
+   }
+   
+   return decisionMap;
 }
 
 //___________________________________________________________________________
-Bool_t AliReducedAnalysisJpsi2ee::IsMCTruth(AliReducedTrackInfo* ptrack, AliReducedTrackInfo* ntrack) {
+UInt_t AliReducedAnalysisJpsi2ee::CheckReconstructedLegMCTruth(AliReducedBaseTrack* ptrack, AliReducedBaseTrack* ntrack) {
    //
-   // check whether the tracks are electrons from a common J/psi decay
+   // check the pair of tracks to see if they match the defined MC cuts and in addition
+   // that they have the same mother
+   // NOTE: The condition for the 2 tracks to have the same mother requires information on the MC label,
+   //             which is available just in the full track information (AliReducedTrackInfo::fMCLabels[]).
+   //           The consequence is that for the jpsi2ee analysis, the reconstructed tracks need to be always written as full tracks 
    //
-   if(TMath::Abs(ptrack->MCPdg(0)) != 11) return kFALSE;
-   if(TMath::Abs(ntrack->MCPdg(0)) != 11) return kFALSE;
-   if(TMath::Abs(ptrack->MCPdg(1)) != 443) return kFALSE;
-   if(TMath::Abs(ntrack->MCPdg(1)) != 443) return kFALSE;
-   //if(ptrack->MCPdg(2) != -9999) return kFALSE;
-   //if(ntrack->MCPdg(2) != -9999) return kFALSE;   
-   if(TMath::Abs(ptrack->MCLabel(1)) != TMath::Abs(ntrack->MCLabel(1))) return kFALSE;
-   return kTRUE;
+   
+   // check that both tracks are full tracks
+   if(ptrack->IsA() != AliReducedTrackInfo::Class()) return 0;
+   if(ntrack->IsA() != AliReducedTrackInfo::Class()) return 0;
+   
+   // check that the tracks have the same mother
+   if(TMath::Abs(((AliReducedTrackInfo*)ptrack)->MCLabel(1)) != TMath::Abs(((AliReducedTrackInfo*)ntrack)->MCLabel(1))) return 0;
+   
+   // check the MC requirements on each of the leg and their logical intersection
+   if(fLegCandidatesMCcuts.GetEntries()==0) return 0;
+   UInt_t pTrackDecisions = CheckReconstructedLegMCTruth(ptrack);
+   if(!pTrackDecisions) return 0;
+   UInt_t nTrackDecisions = CheckReconstructedLegMCTruth(ntrack);
+   return (pTrackDecisions & nTrackDecisions);
 }
 
 //___________________________________________________________________________
@@ -656,57 +738,139 @@ void AliReducedAnalysisJpsi2ee::FillMCTruthHistograms() {
   //
   // fill histograms with pure signal
   //   
-  AliReducedTrackInfo* track = 0x0;
-  Int_t leg1Id = -1;
-  Int_t leg2Id = -1;
-  AliReducedTrackInfo* leg1=0x0;
-  AliReducedTrackInfo* leg2=0x0;
-  TClonesArray* trackList = fEvent->GetTracks();
-  TIter nextTrack(trackList);
-  for(Int_t it=0; it<fEvent->NTracks(); ++it) {
-     track = (AliReducedTrackInfo*)nextTrack();
-     if(!track->IsMCTruth()) continue;
-     
-     if(track->MCPdg(0)==443 && TMath::Abs(track->Rapidity(3.1))<0.9) {       // TODO: use the correct PDG mass and dynamic kinematic selection
-       leg1Id = -1; leg2Id = -1;
-       FindJpsiTruthLegs(track, leg1Id, leg2Id);
-       leg1 = (leg1Id>-1 ? (AliReducedTrackInfo*)fEvent->GetTrack(leg1Id) : 0x0);
-       leg2 = (leg2Id>-1 ? (AliReducedTrackInfo*)fEvent->GetTrack(leg2Id) : 0x0);
-       AliReducedVarManager::FillMCTruthInfo(track, fValues, leg1, leg2);
-       fHistosManager->FillHistClass("MCTruth_BeforeSelection", fValues);
-       if(!leg1) continue;
-       if(!leg2) continue;
-       if(TMath::Abs(leg1->EtaMC())>0.9) continue;                       // TODO: use dynamic kinematic cut on legs
-       if(TMath::Abs(leg2->EtaMC())>0.9) continue;
-       if(leg1->PtMC()<1.0) continue;
-       if(leg2->PtMC()<1.0) continue;
-       fHistosManager->FillHistClass("MCTruth_AfterSelection", fValues);
-     }
-  }
+   // loop over the first track array
+  LoopOverMCTracks(1);
+  // and over the second
+  // NOTE: In the current model, handling the MC truth info requires the labels, which are properties of the full track,
+  //         so there is no point in looping over the second track array which, if it exists, contains just base tracks
+  //LoopOverMCTracks(2);
 }
 
 //___________________________________________________________________________
-void AliReducedAnalysisJpsi2ee::FindJpsiTruthLegs(AliReducedTrackInfo* mother, Int_t& leg1, Int_t& leg2) {
+void AliReducedAnalysisJpsi2ee::LoopOverMCTracks(Int_t trackArray /*=1*/) {
+   //
+   // loop over the track array and check the pure MC tracks against the defined MC selections
+   //   
+   AliReducedTrackInfo* mother=0x0;
+   AliReducedTrackInfo* daughter1 = 0x0;
+   AliReducedTrackInfo* daughter2 = 0x0;
+   
+   TClonesArray* trackList = (trackArray==1 ? fEvent->GetTracks() : fEvent->GetTracks2());
+   if(!trackList) return;
+   TIter nextTrack(trackList);
+   for(Int_t it=0; it<trackList->GetEntries(); ++it) {
+      mother = (AliReducedTrackInfo*)nextTrack();
+      if(!mother->IsMCKineParticle()) continue;
+      
+      // apply selections on the jpsi mother
+      UInt_t motherDecisions = CheckMotherMCTruth(mother);
+      if(!motherDecisions) continue;
+      
+      // find the jpsi daughters (needed to compute 2-track properties like the polarization, etc.)
+      Int_t daughter1Label = 0; Int_t daughter2Label = 0;
+      FindJpsiTruthLegs(mother, daughter1Label, daughter2Label);   
+      daughter1 = FindMCtruthTrackByLabel(daughter1Label);
+      daughter2 = FindMCtruthTrackByLabel(daughter2Label);
+      
+      // reset track variables and fill info
+      for(Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedEOverP; ++i) fValues[i]=-9999.;
+      AliReducedVarManager::FillMCTruthInfo(mother, fValues, daughter1, daughter2);
+      
+      // loop over jpsi mother selections and fill histograms before the kine cuts on electrons
+      for(Int_t iCut = 0; iCut<fJpsiMotherMCcuts.GetEntries(); ++iCut) {
+         if(!(motherDecisions & (UInt_t(1)<<iCut)))  continue;
+         fHistosManager->FillHistClass(Form("%s_PureMCTruth_BeforeSelection", fJpsiMotherMCcuts.At(iCut)->GetName()), fValues);         
+      }
+      if(!daughter1) continue;
+      if(!daughter2) continue;
+      
+      // apply selections on pure MC daughter electrons (kine cuts)
+      UInt_t daughter1Decisions = CheckDaughterMCTruth(daughter1);
+      if(!daughter1Decisions) continue;
+      UInt_t daughtersDecisions = daughter1Decisions & CheckDaughterMCTruth(daughter2);
+      if(!daughtersDecisions) continue;
+      
+      for(Int_t iCut = 0; iCut<fJpsiMotherMCcuts.GetEntries(); ++iCut) {
+         if(!(motherDecisions & (UInt_t(1)<<iCut)))  continue;
+         if(!(daughtersDecisions & (UInt_t(1)<<iCut)))  continue;
+         fHistosManager->FillHistClass(Form("%s_PureMCTruth_AfterSelection", fJpsiMotherMCcuts.At(iCut)->GetName()), fValues);         
+      }
+   }  // end loop over tracks
+   return;
+}
+
+//___________________________________________________________________________
+UInt_t AliReducedAnalysisJpsi2ee::CheckMotherMCTruth(AliReducedTrackInfo* mother) {
+   //
+   // Check the mother pure MC truth against all defined selections and return a bit map with all decisions
+   //
+   if(fJpsiMotherMCcuts.GetEntries()==0) return 0;
+   
+   UInt_t decisionMap = 0;
+   for(Int_t i=0; i<fJpsiMotherMCcuts.GetEntries(); ++i) {
+      AliReducedInfoCut* cut = (AliReducedInfoCut*)fJpsiMotherMCcuts.At(i);
+      if(cut->IsSelected(mother)) 
+         decisionMap |= (UInt_t(1)<<i);
+   }
+   
+   return decisionMap;
+}
+
+//___________________________________________________________________________
+UInt_t AliReducedAnalysisJpsi2ee::CheckDaughterMCTruth(AliReducedTrackInfo* daughter) {
+   //
+   // Check the daughter pure MC truth against all defined selections and return a bit map with all decisions
+   //
+   if(fJpsiElectronMCcuts.GetEntries()==0) return 0;
+   
+   UInt_t decisionMap = 0;
+   for(Int_t i=0; i<fJpsiElectronMCcuts.GetEntries(); ++i) {
+      AliReducedInfoCut* cut = (AliReducedInfoCut*)fJpsiElectronMCcuts.At(i);
+      if(cut->IsSelected(daughter)) 
+         decisionMap |= (UInt_t(1)<<i);
+   }
+   
+   return decisionMap;
+}
+
+//___________________________________________________________________________
+AliReducedTrackInfo* AliReducedAnalysisJpsi2ee::FindMCtruthTrackByLabel(Int_t label) {
+   //
+   // search the track list for pure MC track with label and return the track pointer
+   //
+   AliReducedTrackInfo* track=0x0;
+   TClonesArray* trackList = fEvent->GetTracks();
+   TIter nextTrack(trackList);
+   for(Int_t it=0; it<trackList->GetEntries(); ++it) {
+      track = (AliReducedTrackInfo*)nextTrack();
+      if(!track->IsMCKineParticle()) continue;
+      if(track->MCLabel(0)==label) return track;
+   }
+   return 0x0;
+}
+
+//___________________________________________________________________________
+void AliReducedAnalysisJpsi2ee::FindJpsiTruthLegs(AliReducedTrackInfo* mother, Int_t& leg1Label, Int_t& leg2Label) {
    //
    // find the jpsi legs in the list of pure MC truth particles
    //
    Int_t mLabel = mother->MCLabel(0);
    AliReducedTrackInfo* track=0x0;
+   
+   Int_t legsFound = 0;
+   
+   // loop over the first track array
    TClonesArray* trackList = fEvent->GetTracks();
    TIter nextTrack(trackList);
-   Int_t legsFound = 0;
-   for(Int_t it=0; it<fEvent->NTracks(); ++it) {
+   for(Int_t it=0; it<trackList->GetEntries(); ++it) {
       if(legsFound==2) return;
       track = (AliReducedTrackInfo*)nextTrack();
-      if(!track->IsMCTruth()) continue;
+      if(!track->IsMCKineParticle()) continue;
       if(track->MCLabel(1)==mLabel && TMath::Abs(track->MCPdg(0))==11) {
          legsFound += 1;
-         if(legsFound==1) leg1 = it;
-         if(legsFound==2) leg2 = it;
-         //if(TMath::Abs(track->EtaMC())>0.9) return kFALSE;                       // TODO: use dynamic kinematic cut on legs
-         //if(track->PtMC()<1.0) return kFALSE;
+         if(legsFound==1) leg1Label = track->MCLabel(0);
+         if(legsFound==2) leg2Label = track->MCLabel(0);
       }
    }
    return;
 }
-

--- a/PWGDQ/reducedTree/AliReducedBaseTrack.cxx
+++ b/PWGDQ/reducedTree/AliReducedBaseTrack.cxx
@@ -19,7 +19,8 @@ AliReducedBaseTrack::AliReducedBaseTrack() :
   fCharge(0),
   fFlags(0),
   fQualityFlags(0),
-  fMCFlags(0)
+  fMCFlags(0),
+  fIsMCTruth(kFALSE)
 {
   //
   // Constructor
@@ -35,7 +36,8 @@ AliReducedBaseTrack::AliReducedBaseTrack(const AliReducedBaseTrack &c) :
   fCharge(c.Charge()),
   fFlags(c.GetFlags()),
   fQualityFlags(c.GetQualityFlags()),
-  fMCFlags(c.GetMCFlags())
+  fMCFlags(c.GetMCFlags()),
+  fIsMCTruth(c.IsMCTruth())
 {
   //
   // Copy constructor

--- a/PWGDQ/reducedTree/AliReducedBaseTrack.h
+++ b/PWGDQ/reducedTree/AliReducedBaseTrack.h
@@ -38,8 +38,8 @@ class AliReducedBaseTrack : public TObject {
     ULong_t GetQualityFlags()             const {return fQualityFlags;}
     Bool_t UsedForQvector()               const {return fQualityFlags&(UShort_t(1)<<0);}
     Bool_t TestQualityFlag(UShort_t iflag)  const {return ((iflag<(8*sizeof(ULong_t))) ? fQualityFlags&(ULong_t(1)<<iflag) : kFALSE);}
-    Bool_t IsMCTruth()                        const {return fQualityFlags&(ULong_t(1)<<63);}
-    Bool_t HasMCTruthInfo()               const {return fQualityFlags&(ULong_t(1)<<22);}
+    Bool_t IsMCTruth()                        const {return (fIsMCTruth ? kTRUE : kFALSE);}
+    //Bool_t HasMCTruthInfo()               const {return (fMCFlags ? kTRUE : kFALSE);}
     Bool_t IsTRDmatch()                     const {return fQualityFlags&(ULong_t(1)<<26);}
     Bool_t IsGammaLeg()                   const {return fQualityFlags&(ULong_t(1)<<1);}
     Bool_t IsPureGammaLeg()            const {return fQualityFlags&(ULong_t(1)<<8);}
@@ -55,7 +55,7 @@ class AliReducedBaseTrack : public TObject {
     
     UInt_t GetMCFlags()                      const {return fMCFlags;}
     Bool_t TestMCFlag(UShort_t iflag) const {return ((iflag<(8*sizeof(UInt_t))) ? fMCFlags & (UInt_t(1)<<iflag) : kFALSE);}
-    Bool_t IsMCKineParticle()              const {return (fMCFlags ? kTRUE : kFALSE);}
+    Bool_t IsMCKineParticle()              const {return (fIsMCTruth ? kTRUE : kFALSE);}
     
     // setters
     void   Px(Float_t px) {fP[0] = px; fIsCartesian=kTRUE;}
@@ -76,7 +76,8 @@ class AliReducedBaseTrack : public TObject {
     void    SetMCFlags(UInt_t flags) {fMCFlags = flags;}
     Bool_t SetMCFlag(UShort_t iflag) {if(iflag>=8*sizeof(UInt_t)) return kFALSE; fMCFlags |= (UInt_t(1)<<iflag); return kTRUE;}
     Bool_t UnsetMCFlag(UShort_t iflag) {if(iflag>=8*sizeof(UInt_t)) return kFALSE; if(TestMCFlag(iflag)) fMCFlags ^= (UInt_t(1)<<iflag); return kTRUE;}
-        
+    void SetIsMCTruth(Bool_t flag=kTRUE) {fIsMCTruth = flag;}
+   
   protected:
     UShort_t fTrackId;            // track id 
     Float_t fP[3];         // 3-momentum vector
@@ -108,10 +109,11 @@ class AliReducedBaseTrack : public TObject {
                                                    // BIT3 toggled for pure V0 anti-Lambda candidates
                                                    // BIT4 toggled for pure V0 photon candidates
     UInt_t fMCFlags;                     // flags used to encode Monte-Carlo information
+    Bool_t fIsMCTruth;                  // TRUE: if the particle is pure MC track; FALSE: if the particle is a reconstructed track
         
     AliReducedBaseTrack& operator= (const AliReducedBaseTrack &c);
     
-    ClassDef(AliReducedBaseTrack, 4)
+    ClassDef(AliReducedBaseTrack, 5)
 };
 
 //_______________________________________________________________________________

--- a/PWGDQ/reducedTree/AliReducedTrackCut.h
+++ b/PWGDQ/reducedTree/AliReducedTrackCut.h
@@ -34,12 +34,18 @@ class AliReducedTrackCut : public AliReducedVarCut {
   
   void SetRejectPureMC(Bool_t reject=kTRUE) {fRejectPureMC=reject;}
   
+  void SetMCFilterMap(UInt_t map, Bool_t useAND=kTRUE) {fCutOnMCFilterMap = map; fUseANDonMCFilterMap=useAND;}
+  void SetMCFilterBit(Int_t bit) {if(bit>=0 && bit<32) fCutOnMCFilterMap |= (UInt_t(1)<<bit);}
+  void SetUseANDonMCFilterMap(Bool_t useAND=kTRUE) {fUseANDonMCFilterMap=useAND;}
+  
   Bool_t GetRejectKinks() const {return fRejectKinks;}
   Bool_t GetRejectTaggedGamma() const {return fRejectTaggedGamma;}
   Bool_t GetRejectTaggedPureGamma() const {return fRejectTaggedPureGamma;}
   UInt_t GetTrackFilterMap() const {return fCutOnTrackFilterMap;}
   Bool_t GetUseANDonTrackFilterMap() const {return fUseANDonTrackFilterMap;}
   Bool_t GetRejectPureMC() const {return fRejectPureMC;}
+  UInt_t GetMCFilterMap() const {return fCutOnMCFilterMap;}
+  Bool_t GetUseANDonMCFilterMap() const {return fUseANDonMCFilterMap;}
   Bool_t GetRequestITSrefit() const {return fRequestITSrefit;}
   Bool_t GetRequestTPCrefit() const {return fRequestTPCrefit;}
   UChar_t GetITShitMapRequest() const {return fCutOnITShitMap;}
@@ -60,11 +66,15 @@ class AliReducedTrackCut : public AliReducedVarCut {
   Bool_t    fRejectTaggedPureGamma;  // if true, reject only the high purity tagged gamma conversions
   
   // selections on the track filter map 
-  UInt_t    fCutOnTrackFilterMap;       // map encoding the various requests on track filters
+  UInt_t    fCutOnTrackFilterMap;         // map encoding the various requests on track filters
   Bool_t    fUseANDonTrackFilterMap;  // if false, at least one of the enabled positions in the cut map should be on in the track filters map
    
    // Reject pure MC tracks
    Bool_t   fRejectPureMC;    
+   
+   // selections on the MC signals bit map 
+   UInt_t    fCutOnMCFilterMap;         // map encoding the various requests on MC signals
+   Bool_t    fUseANDonMCFilterMap;  // if false, at least one of the enabled positions in the cut map should be on in the track MC signals map
    
    // ITS quantities
   Bool_t    fRequestITSrefit;                // if true, request kITSrefit flag to be on
@@ -89,7 +99,7 @@ class AliReducedTrackCut : public AliReducedVarCut {
   AliReducedTrackCut(const AliReducedTrackCut &c);
   AliReducedTrackCut& operator= (const AliReducedTrackCut &c);
   
-  ClassDef(AliReducedTrackCut,2);
+  ClassDef(AliReducedTrackCut,3);
 };
 
 #endif

--- a/PWGDQ/reducedTree/macros/AddTask_iarsene_dstXeXe.C
+++ b/PWGDQ/reducedTree/macros/AddTask_iarsene_dstXeXe.C
@@ -1,0 +1,760 @@
+void AddFMDTask();
+
+//__________________________________________________________________________________________
+AliAnalysisTask *AddTask_iarsene_dst(Int_t reducedEventType=-1, Bool_t writeTree=kTRUE, TString prod="LHC10h"){
+  //get the current analysis manager
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    Error("AddTask_iarsene_dst", "No analysis manager found.");
+    return 0;
+  }
+
+  //Do we have an MC handler?
+  Bool_t hasMC=(AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler()!=0x0);
+  Bool_t isAOD=mgr->GetInputEventHandler()->IsA()==AliAODInputHandler::Class();
+  
+  Int_t collSystem = 0;
+  if(!prod.CompareTo("LHC10h")) collSystem = 1;    // minimum bias Pb-Pb
+  if(!prod.CompareTo("LHC11h")) collSystem = 2;    // centrality triggered Pb-Pb
+  if(!prod.CompareTo("LHC15o")) collSystem = 3;    // minimum bias Pb-Pb
+  if(!prod.CompareTo("LHC10b") || !prod.CompareTo("LHC10c") || !prod.CompareTo("LHC10d") || 
+     !prod.CompareTo("LHC10e") || !prod.CompareTo("LHC10f")) collSystem = 4;   // minimum bias pp
+  if(!prod.CompareTo("LHC13b") || !prod.CompareTo("LHC13c")) collSystem = 5;   // minimum bias p-Pb   
+  if(!prod.CompareTo("LHC16l")) collSystem = 6;    // minimum bias pp and Pb-Pb
+  if(!prod.CompareTo("LHC16q") || !prod.CompareTo("LHC16r") || !prod.CompareTo("LHC16s") || !prod.CompareTo("LHC16t")) collSystem = 7;    // triggered p-Pb (2016 data)
+  if(!prod.CompareTo("LHC17n")) collSystem = 8;
+  
+  if(!collSystem && !hasMC) {
+     collSystem = 1;
+     printf("WARNING: In AddTask_iarsene_dst(), no proper production name specified, or not supported! \n");
+     printf("                 Using collSystem=1 (min bias 2010 Pb-Pb) as default \n");
+  }
+  
+  //create task and add it to the manager
+  AliAnalysisTaskReducedTreeMaker *task=new AliAnalysisTaskReducedTreeMaker("DSTTreeMaker", kTRUE);
+  if(collSystem==1) task->SetTriggerMask(AliVEvent::kMB);
+  if(collSystem==2)
+    task->SetTriggerMask(AliVEvent::kMB+AliVEvent::kCentral+AliVEvent::kSemiCentral);
+  if(collSystem==3) task->SetTriggerMask(AliVEvent::kINT7);
+  if(collSystem==4) task->SetTriggerMask(AliVEvent::kMB);
+  if(collSystem==5) task->SetTriggerMask(AliVEvent::kINT7);
+  if(collSystem==6) task->SetTriggerMask(AliVEvent::kMB+AliVEvent::kINT7+AliVEvent::kHighMultSPD+AliVEvent::kHighMultV0);
+  if(collSystem==7) task->SetTriggerMask(AliVEvent::kINT7+AliVEvent::kTRD);
+  if(collSystem==8) task->SetTriggerMask(AliVEvent::kINT7);
+  
+  //if(collSystem==4)
+  //  task->SetRejectPileup();
+    
+  //task->UsePhysicsSelection(kTRUE);
+  task->SetUseAnalysisUtils(kTRUE);
+  
+  task->SetFillV0Info(kFALSE);
+  //task->SetFillGammaConversions(kFALSE);
+  //task->SetFillK0s(kFALSE);
+  //task->SetFillLambda(kFALSE);
+  //task->SetFillALambda(kFALSE);
+  task->SetFillCaloClusterInfo(kFALSE);
+  //task->SetFillDielectronInfo(kFALSE);
+  //task->SetFillFriendInfo(kFALSE);
+  
+  task->SetEventFilter(CreateEventFilter(isAOD));
+  //task->SetTrackFilter(CreateGlobalTrackFilter(isAOD));
+  CreateTrackFilters(task, isAOD);
+  
+  //  task->SetFlowTrackFilter(CreateFlowTrackFilter(isAOD));
+  //task->SetK0sPionCuts(CreateK0sPionCuts(isAOD));
+  //task->SetLambdaProtonCuts(CreateLambdaProtonCuts(isAOD));
+  //task->SetLambdaPionCuts(CreateLambdaPionCuts(isAOD));
+  //task->SetGammaElectronCuts(CreateGammaConvElectronCuts(isAOD));
+  //task->SetK0sMassRange(0.44,0.55);
+  //task->SetLambdaMassRange(1.090,1.14);
+  //task->SetGammaConvMassRange(0.0,0.1);
+  task->SetV0OpenCuts(CreateV0OpenCuts(AliESDv0KineCuts::kPurity, AliESDv0KineCuts::kPbPb));
+  task->SetV0StrongCuts(CreateV0StrongCuts(AliESDv0KineCuts::kPurity, AliESDv0KineCuts::kPbPb));
+  //task->SetFillFMDInfo(); AddFMDTask();
+  if(hasMC) {
+     task->SetFillMCInfo(kTRUE);
+     AddMCSignals(task);
+  }
+  //task->SetFillEventPlaneInfo(kTRUE);
+
+  //task->SetTreeWritingOption(AliAnalysisTaskReducedTreeMaker::kFullEventsWithFullTracks);
+  //task->SetTreeWritingOption(AliAnalysisTaskReducedTreeMaker::kBaseEventsWithBaseTracks);
+  if(reducedEventType!=-1)
+    task->SetTreeWritingOption(reducedEventType);
+  task->SetWriteTree(writeTree);
+  //task->SetWriteEventsWithNoSelectedTracks(kFALSE);
+  
+  SetInactiveBranches(task);
+  
+  mgr->AddTask(task);
+    
+  AliAnalysisDataContainer *cReducedTree = 0x0;
+  AliAnalysisDataContainer *cEventStatsInfo = 0x0;
+  AliAnalysisDataContainer *cTrackStatsInfo = 0x0;
+  AliAnalysisDataContainer *cMCStatsInfo = 0x0;
+  if(task->WriteTree()) {
+    cReducedTree = mgr->CreateContainer("dstTree", TTree::Class(),
+                                          AliAnalysisManager::kOutputContainer, "dstTree.root");
+    cEventStatsInfo = mgr->CreateContainer("EventStats", TH2I::Class(),
+       AliAnalysisManager::kOutputContainer, "dstTree.root");
+    cTrackStatsInfo = mgr->CreateContainer("TrackStats", TH2I::Class(),
+                                           AliAnalysisManager::kOutputContainer, "dstTree.root");
+    cMCStatsInfo = mgr->CreateContainer("MCStats", TH2I::Class(),
+                                           AliAnalysisManager::kOutputContainer, "dstTree.root");
+  }
+  
+  AliAnalysisDataContainer *cReducedEvent =
+  mgr->CreateContainer("ReducedEventDQ",
+                         AliReducedBaseEvent::Class(),
+                         AliAnalysisManager::kExchangeContainer,
+                         "reducedEvent");
+  
+  mgr->ConnectInput(task,  0, mgr->GetCommonInputContainer());
+  mgr->ConnectOutput(task, 1, cReducedEvent);
+  if(task->WriteTree()) {
+     mgr->ConnectOutput(task, 2, cReducedTree);
+     mgr->ConnectOutput(task, 3, cEventStatsInfo);
+     mgr->ConnectOutput(task, 4, cTrackStatsInfo);
+     if(hasMC) mgr->ConnectOutput(task, 5, cMCStatsInfo);
+  }
+  
+  return task;
+}
+
+//_______________________________________________________________________________________________
+void AddMCSignals(AliAnalysisTaskReducedTreeMaker* task) {
+   //
+   // Add the MC signals to be filtered
+   //
+   AliSignalMC* jpsiInclusive=new AliSignalMC("JpsiInclusive", "",1,1);
+   jpsiInclusive->SetPDGcode(0, 0, 443, kFALSE);
+   task->AddMCsignal(jpsiInclusive, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   AliSignalMC* jpsiFromB=new AliSignalMC("JpsiFromB","",1,2);
+   jpsiFromB->SetPDGcode(0, 0, 443, kFALSE);
+   jpsiFromB->SetPDGcode(0, 1, 500, kTRUE);
+   task->AddMCsignal(jpsiFromB, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   AliSignalMC* jpsiPrompt=new AliSignalMC("JpsiNotFromB","",1,2);
+   jpsiPrompt->SetPDGcode(0, 0, 443, kFALSE);
+   jpsiPrompt->SetPDGcode(0, 1, 500, kTRUE, kTRUE);
+   task->AddMCsignal(jpsiPrompt, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   AliSignalMC* jpsiInclusiveRadiative=new AliSignalMC("JpsiInclusiveRadiative","",1,1);
+   jpsiInclusiveRadiative->SetPDGcode(0, 0, 443, kFALSE);
+   jpsiInclusiveRadiative->SetSourceBit(0, 0, AliSignalMC::kRadiativeDecay);
+   task->AddMCsignal(jpsiInclusiveRadiative, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   AliSignalMC* jpsiInclusiveNonRadiative=new AliSignalMC("JpsiInclusiveNonRadiative","",1,1);
+   jpsiInclusiveNonRadiative->SetPDGcode(0, 0, 443, kFALSE);
+   jpsiInclusiveNonRadiative->SetSourceBit(0, 0, AliSignalMC::kRadiativeDecay, kTRUE);
+   task->AddMCsignal(jpsiInclusiveNonRadiative, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   AliSignalMC* jpsiFromBRadiative=new AliSignalMC("JpsiFromBRadiative","",1,2);
+   jpsiFromBRadiative->SetPDGcode(0, 0, 443, kFALSE);
+   jpsiFromBRadiative->SetPDGcode(0, 1, 500, kTRUE);
+   jpsiFromBRadiative->SetSourceBit(0, 0, AliSignalMC::kRadiativeDecay, kFALSE);
+   //task->AddMCsignal(jpsiFromBRadiative, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   AliSignalMC* jpsiFromBNonRadiative=new AliSignalMC("JpsiFromBNonRadiative","",1,2);
+   jpsiFromBNonRadiative->SetPDGcode(0, 0, 443, kFALSE);
+   jpsiFromBNonRadiative->SetPDGcode(0, 1, 500, kTRUE);
+   jpsiFromBNonRadiative->SetSourceBit(0, 0, AliSignalMC::kRadiativeDecay, kTRUE);
+   //task->AddMCsignal(jpsiFromBNonRadiative, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   
+   AliSignalMC* electronFromJpsi=new AliSignalMC("electronFromJpsi","",1,2);
+   electronFromJpsi->SetPDGcode(0, 0, 11, kTRUE);
+   electronFromJpsi->SetPDGcode(0, 1, 443);
+   task->AddMCsignal(electronFromJpsi, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   AliSignalMC* electronFromJpsiPrompt=new AliSignalMC(1,3);
+   electronFromJpsiPrompt->SetPDGcode(0, 0, 11, kTRUE);
+   electronFromJpsiPrompt->SetPDGcode(0, 1, 443);
+   electronFromJpsiPrompt->SetPDGcode(0, 2, 500, kTRUE, kTRUE);    //
+   //task->AddMCsignal(electronFromJpsiPrompt, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   AliSignalMC* electronFromJpsiNonPrompt=new AliSignalMC(1,3);
+   electronFromJpsiNonPrompt->SetPDGcode(0, 0, 11, kTRUE);
+   electronFromJpsiNonPrompt->SetPDGcode(0, 1, 443);
+   electronFromJpsiNonPrompt->SetPDGcode(0, 2, 500, kTRUE);      //
+   //task->AddMCsignal(electronFromJpsiNonPrompt, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   AliSignalMC* photonFromJpsiDecay=new AliSignalMC("photonFromJpsiDecay","",1,2);
+   photonFromJpsiDecay->SetPDGcode(0, 0, 22);
+   photonFromJpsiDecay->SetPDGcode(0, 1, 443);
+   task->AddMCsignal(photonFromJpsiDecay, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+}
+
+//_______________________________________________________________________________________________
+void SetInactiveBranches(AliAnalysisTaskReducedTreeMaker* task) {
+   //
+   // Set inactive branches
+   //
+   // You can define the active branches of the tree, all other branches will be set to inactive
+   //task->SetTreeActiveBranch("Event");
+   //task->SetTreeActiveBranch("fRunNo");
+   // Alternatively, you can define the inactive branches of the tree, all other branches will be set to active
+
+   
+   //task->SetTreeInactiveBranch("fEventTag");
+   //task->SetTreeInactiveBranch("fRunNo");
+   //task->SetTreeInactiveBranch("fVtx*");
+   //task->SetTreeInactiveBranch("fNVtxContributors");
+   //task->SetTreeInactiveBranch("fCentrality*");
+   //task->SetTreeInactiveBranch("fCentQuality");
+   //task->SetTreeInactiveBranch("fNtracks*");
+   //task->SetTreeInactiveBranch("fNV0candidates*");
+   //task->SetTreeInactiveBranch("fTracks.*");
+   //task->SetTreeInactiveBranch("fCandidates.*");
+   task->SetTreeInactiveBranch("fEventNumberInFile");
+   task->SetTreeInactiveBranch("fL0TriggerInputs");
+   task->SetTreeInactiveBranch("fL1TriggerInputs");
+   task->SetTreeInactiveBranch("fL2TriggerInputs");
+   //task->SetTreeInactiveBranch("fBC");
+   task->SetTreeInactiveBranch("fTimeStamp");
+   task->SetTreeInactiveBranch("fEventType");
+   //task->SetTreeInactiveBranch("fTriggerMask");
+   task->SetTreeInactiveBranch("fMultiplicityEstimators*");
+   task->SetTreeInactiveBranch("fMultiplicityEstimatorPercentiles*");
+   //task->SetTreeInactiveBranch("fIsPhysicsSelection");
+   task->SetTreeInactiveBranch("fIsSPDPileup");
+   task->SetTreeInactiveBranch("fIsSPDPileupMultBins");
+   task->SetTreeInactiveBranch("fIRIntClosestIntMap*");
+   task->SetTreeInactiveBranch("fVtxTPC*");
+   task->SetTreeInactiveBranch("fNVtxTPCContributors");
+   task->SetTreeInactiveBranch("fVtxSPD*");
+   task->SetTreeInactiveBranch("fNVtxSPDContributors");
+   task->SetTreeInactiveBranch("fNpileupSPD");
+   task->SetTreeInactiveBranch("fNpileupTracks");
+   //task->SetTreeInactiveBranch("fNTPCclusters");
+   task->SetTreeInactiveBranch("fNPMDtracks");
+   task->SetTreeInactiveBranch("fNTRDtracks");
+   task->SetTreeInactiveBranch("fNTRDtracklets");
+   //task->SetTreeInactiveBranch("fSPDntracklets");
+   task->SetTreeInactiveBranch("fSPDntrackletsEta*");
+   //task->SetTreeInactiveBranch("fSPDFiredChips*");
+   task->SetTreeInactiveBranch("fITSClusters*");
+   task->SetTreeInactiveBranch("fSPDnSingle");
+   task->SetTreeInactiveBranch("fNtracksPerTrackingFlag*");
+   task->SetTreeInactiveBranch("fVZEROMult*");
+   //task->SetTreeInactiveBranch("fVZEROTotalMult*");
+   task->SetTreeInactiveBranch("fZDCnEnergy*");
+   task->SetTreeInactiveBranch("fZDCpEnergy*");
+   //task->SetTreeInactiveBranch("fZDCnTotalEnergy*");
+   //task->SetTreeInactiveBranch("fZDCpTotalEnergy*");
+   task->SetTreeInactiveBranch("fT0amplitude*");
+   task->SetTreeInactiveBranch("fT0TOF*");
+   task->SetTreeInactiveBranch("fT0TOFbest*");
+   task->SetTreeInactiveBranch("fT0zVertex");
+   task->SetTreeInactiveBranch("fT0start");
+   //task->SetTreeInactiveBranch("fT0pileup");
+   //task->SetTreeInactiveBranch("fT0sattelite");
+   //task->SetTreeInactiveBranch("fNCaloClusters");
+   //task->SetTreeInactiveBranch("fCaloClusters.*");
+   //task->SetTreeInactiveBranch("fFMD.*");
+   //task->SetTreeInactiveBranch("fEventPlane.*");
+   
+   //task->SetTreeInactiveBranch("fTracks2.*");
+   //task->SetTreeInactiveBranch("fTracks.fP*");
+   //task->SetTreeInactiveBranch("fTracks.fIsCartesian");
+   //task->SetTreeInactiveBranch("fTracks.fCharge");
+   //task->SetTreeInactiveBranch("fTracks.fFlags");
+   //task->SetTreeInactiveBranch("fTracks.fQualityFlags");
+   //task->SetTreeInactiveBranch("fTracks.fTrackId");
+   //task->SetTreeInactiveBranch("fTracks.fStatus");
+   task->SetTreeInactiveBranch("fTracks.fTPCPhi");
+   task->SetTreeInactiveBranch("fTracks.fTPCPt");
+   task->SetTreeInactiveBranch("fTracks.fTPCEta");
+   //task->SetTreeInactiveBranch("fTracks.fMomentumInner");
+   //task->SetTreeInactiveBranch("fTracks.fDCA*");
+   task->SetTreeInactiveBranch("fTracks.fTPCDCA*");
+   task->SetTreeInactiveBranch("fTracks.fTrackLength");
+   task->SetTreeInactiveBranch("fTracks.fMassForTracking");
+   //task->SetTreeInactiveBranch("fTracks.fChi2TPCConstrainedVsGlobal");
+   task->SetTreeInactiveBranch("fTracks.fHelixCenter*");
+   task->SetTreeInactiveBranch("fTracks.fHelixRadius");
+   //task->SetTreeInactiveBranch("fTracks.fITSclusterMap");
+   //task->SetTreeInactiveBranch("fTracks.fITSSharedClusterMap");
+   task->SetTreeInactiveBranch("fTracks.fITSsignal");
+   task->SetTreeInactiveBranch("fTracks.fITSnSig*");
+   //task->SetTreeInactiveBranch("fTracks.fITSchi2");
+   //task->SetTreeInactiveBranch("fTracks.fTPCNcls");
+   //task->SetTreeInactiveBranch("fTracks.fTPCCrossedRows");
+   //task->SetTreeInactiveBranch("fTracks.fTPCNclsF");
+   //task->SetTreeInactiveBranch("fTracks.fTPCNclsShared");
+   //task->SetTreeInactiveBranch("fTracks.fTPCClusterMap");
+   //task->SetTreeInactiveBranch("fTracks.fTPCsignal");
+   //task->SetTreeInactiveBranch("fTracks.fTPCsignalN");
+   //task->SetTreeInactiveBranch("fTracks.fTPCnSig*");
+   //task->SetTreeInactiveBranch("fTracks.fTPCchi2");
+   task->SetTreeInactiveBranch("fTracks.fTPCActiveLength");
+   task->SetTreeInactiveBranch("fTracks.fTPCGeomLength");
+   //task->SetTreeInactiveBranch("fTracks.fTOFbeta");
+   task->SetTreeInactiveBranch("fTracks.fTOFtime");
+   task->SetTreeInactiveBranch("fTracks.fTOFdx");
+   task->SetTreeInactiveBranch("fTracks.fTOFdz");
+   task->SetTreeInactiveBranch("fTracks.fTOFmismatchProbab");
+   task->SetTreeInactiveBranch("fTracks.fTOFchi2");
+   task->SetTreeInactiveBranch("fTracks.fTOFnSig*");
+   task->SetTreeInactiveBranch("fTracks.fTOFdeltaBC");
+   task->SetTreeInactiveBranch("fTracks.fTRDntracklets*");
+   task->SetTreeInactiveBranch("fTracks.fTRDpid*");
+   task->SetTreeInactiveBranch("fTracks.fTRDpidLQ2D*");
+   task->SetTreeInactiveBranch("fTracks.fCaloClusterId");
+   //task->SetTreeInactiveBranch("fTracks.fMCMom*");
+   //task->SetTreeInactiveBranch("fTracks.fMCFreezeout*");
+   //task->SetTreeInactiveBranch("fTracks.fMCLabels*");
+   //task->SetTreeInactiveBranch("fTracks.fMCPdg*");
+   //task->SetTreeInactiveBranch("fTracks.fMCGeneratorIndex");
+  
+   //task->SetTreeInactiveBranch("fCandidates.fP*");
+   //task->SetTreeInactiveBranch("fCandidates.fIsCartesian");
+   //task->SetTreeInactiveBranch("fCandidates.fCharge");
+   //task->SetTreeInactiveBranch("fCandidates.fFlags");
+   //task->SetTreeInactiveBranch("fCandidates.fQualityFlags");
+   //task->SetTreeInactiveBranch("fCandidates.fCandidateId");
+   //task->SetTreeInactiveBranch("fCandidates.fPairType");
+   //task->SetTreeInactiveBranch("fCandidates.fLegIds*");
+   //task->SetTreeInactiveBranch("fCandidates.fMass*");
+   //task->SetTreeInactiveBranch("fCandidates.fLxy");
+   //task->SetTreeInactiveBranch("fCandidates.fPointingAngle");
+   //task->SetTreeInactiveBranch("fCandidates.fChisquare");
+   
+}
+
+
+//_______________________________________________________________________________________________
+AliAnalysisCuts* CreateEventFilter(Bool_t isAOD) {
+  //
+  // Event wise cuts
+  //
+  AliDielectronEventCuts *eventCuts=new AliDielectronEventCuts("eventCuts","Vertex Track && |vtxZ|<10 && ncontrib>0");
+  if(isAOD) eventCuts->SetVertexType(AliDielectronEventCuts::kVtxAny);
+  eventCuts->SetRequireVertex();
+  eventCuts->SetMinVtxContributors(1);
+  eventCuts->SetVertexZ(-10.,10.);
+  return eventCuts;
+}
+
+
+//_______________________________________________________________________________________________
+AliAnalysisCuts* CreateGlobalTrackFilter(Bool_t isAOD) {
+  //
+  // Cuts for tracks to be written in the dst
+  //
+  AliDielectronCutGroup* cuts = new AliDielectronCutGroup("cuts","cuts",AliDielectronCutGroup::kCompAND);
+  // general cuts ---------------------------------
+  //if(isAOD) {
+  AliDielectronVarCuts *trackCuts = new AliDielectronVarCuts("trackCuts","track cuts");
+  trackCuts->AddCut(AliDielectronVarManager::kImpactParXY,-3.0,3.0);
+  trackCuts->AddCut(AliDielectronVarManager::kImpactParZ,-10.0,10.0);
+  trackCuts->AddCut(AliDielectronVarManager::kEta,-0.9,0.9);
+  trackCuts->AddCut(AliDielectronVarManager::kP,1.0,1.0e+30);
+  trackCuts->AddCut(AliDielectronVarManager::kNclsTPC,70.0,161.0);
+  //  trackCuts->AddCut(AliDielectronVarManager::kTPCchi2Cl,0.1,4.0);
+  
+  //trackCuts->AddCut(AliDielectronVarManager::kP,1.0,1.0e+30);
+  //trackCuts->AddCut(AliDielectronVarManager::kNclsTPC,70.0,161.0);
+  cuts->AddCut(trackCuts);
+  AliDielectronTrackCuts* trackCuts2 = new AliDielectronTrackCuts("trackCuts2","track cuts");
+  //trackCuts2->SetRequireITSRefit(kTRUE);
+  trackCuts2->SetRequireTPCRefit(kTRUE);
+  if(isAOD) trackCuts2->SetAODFilterBit(AliDielectronTrackCuts::kTPCqual);
+  cuts->AddCut(trackCuts2);
+    //}
+  /*else {
+    AliESDtrackCuts *esdTrackCuts = new AliESDtrackCuts;
+    // basic track quality cuts  (basicQ)
+    esdTrackCuts->SetMaxDCAToVertexZ(10.0);
+    esdTrackCuts->SetMaxDCAToVertexXY(10.0);
+    esdTrackCuts->SetEtaRange(-0.90, 0.90);
+    //  esdTrackCuts->SetAcceptKinkDaughters(kFALSE);
+    //esdTrackCuts->SetRequireITSRefit(kTRUE);
+    //esdTrackCuts->SetRequireTPCRefit(kTRUE);
+    esdTrackCuts->SetPRange(0.2,1e30);
+    //esdTrackCuts->SetPtRange(0.15,1e30);
+    esdTrackCuts->SetMinNClustersTPC(50);
+    esdTrackCuts->SetMaxChi2PerClusterTPC(4);
+    //  esdTrackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSPD,AliESDtrackCuts::kAny);
+    //  esdTrackCuts->SetClusterRequirementITS(AliESDtrackCuts::kSPD,AliESDtrackCuts::kFirst);
+    cuts->AddCut(esdTrackCuts);
+  }*/
+  
+  AliDielectronPID *electronPid = new AliDielectronPID("PID","PID cut");
+  electronPid->AddCut(AliDielectronPID::kTPC,AliPID::kElectron,-4.0, 4.0, 0.0, 0.0, kFALSE, AliDielectronPID::kRequire); // TPC 3-sigma inclusion for electron    
+  //electronPid->AddCut(AliDielectronPID::kTPC,AliPID::kProton,-2.0, 2.0, 0.0, 0.0, kTRUE, AliDielectronPID::kRequire); // TPC 3-sigma inclusion for proton
+  //electronPid->AddCut(AliDielectronPID::kTPC,AliPID::kKaon,-3.0, 3.0, 0.0, 0.0, kTRUE, AliDielectronPID::kRequire); // TPC 3-sigma inclusion for kaon
+  //electronPid->AddCut(AliDielectronPID::kTOF,AliPID::kProton,  -3.0, 3.0, -2.0, 2.0, kTRUE, AliDielectronPID::kIfAvailable, AliDielectronVarManager::kTPCnSigmaPro); // TPC exclusion for proton   
+  cuts->AddCut(electronPid);
+  
+  return cuts;
+}
+
+
+//______________________________________________________________________________________
+void CreateTrackFilters(AliAnalysisTaskReducedTreeMaker* task, Bool_t isAOD) {
+   //
+   // add track filters
+   //
+   AliDielectronCutGroup* basicCut = new AliDielectronCutGroup("basicCut","J/psi candidate electron (basic cut)",AliDielectronCutGroup::kCompAND);
+   AliDielectronVarCuts *basicVarCuts = new AliDielectronVarCuts("basicVarCuts","basic var track cuts");
+   basicVarCuts->AddCut(AliDielectronVarManager::kImpactParXY,-1.0,1.0);
+   basicVarCuts->AddCut(AliDielectronVarManager::kImpactParZ,-3.0,3.0);
+   basicVarCuts->AddCut(AliDielectronVarManager::kEta,-0.9,0.9);
+   basicVarCuts->AddCut(AliDielectronVarManager::kPIn,1.0,1.0e+30);
+   basicVarCuts->AddCut(AliDielectronVarManager::kITSchi2Cl, 0.01, 15.0);
+   basicVarCuts->AddCut(AliDielectronVarManager::kNclsTPC,70.0,161.0);   
+   basicVarCuts->AddCut(AliDielectronVarManager::kTPCchi2Cl, 0.01, 4.0);
+   basicVarCuts->AddCut(AliDielectronVarManager::kTPCnSigmaEle, -4.0, 4.0);
+   basicVarCuts->AddCut(AliDielectronVarManager::kTPCnSigmaPro, -20000.0, 2.0, kTRUE);
+   basicVarCuts->AddCut(AliDielectronVarManager::kTPCnSigmaPio, -20000.0, 2.0, kTRUE);
+   basicCut->AddCut(basicVarCuts);
+   AliDielectronTrackCuts* basicTrackCuts = new AliDielectronTrackCuts("basicTrackCuts","basic track cuts");
+   basicTrackCuts->SetRequireITSRefit(kTRUE);
+   basicTrackCuts->SetRequireTPCRefit(kTRUE);
+   if(isAOD) basicTrackCuts->SetAODFilterBit(AliDielectronTrackCuts::kTPCqual);
+   basicCut->AddCut(basicTrackCuts);
+   task->AddTrackFilter(basicCut, kFALSE);   // basic cut, no SPD requirements
+   
+   AliDielectronCutGroup* spdAny = new AliDielectronCutGroup("spdAny","J/psi candidate electron (basic cut + SPD any)", AliDielectronCutGroup::kCompAND);
+   spdAny->AddCut(basicCut);
+   AliDielectronVarCuts *spdAnyVarCuts = new AliDielectronVarCuts("spdAnyVarCuts","SPD any");
+   spdAnyVarCuts->AddCut(AliDielectronVarManager::kITSLayerFirstCls, 0., 1.);        // SPDany
+   spdAny->AddCut(spdAnyVarCuts);
+   task->AddTrackFilter(spdAny, kTRUE);  // basic cut + SPD any
+   
+   AliDielectronCutGroup* spdFirst = new AliDielectronCutGroup("spdFirst","J/psi candidate electron (basic cut + SPD first)", AliDielectronCutGroup::kCompAND);
+   spdFirst->AddCut(basicCut);
+   AliDielectronVarCuts *spdFirstVarCuts = new AliDielectronVarCuts("spdFirstVarCuts","SPD first");
+   spdFirstVarCuts->AddCut(AliDielectronVarManager::kITSLayerFirstCls, 0., 0.);        // SPDfirst
+   spdFirst->AddCut(spdFirstVarCuts);
+   task->AddTrackFilter(spdFirst, kTRUE);  // basic cut + SPD first
+   
+   AliDielectronCutGroup* tpc100 = new AliDielectronCutGroup("tpc100","J/psi candidate electron (basic cut + TPC ncls>100)", AliDielectronCutGroup::kCompAND);
+   tpc100->AddCut(basicCut);
+   AliDielectronVarCuts *tpc100VarCuts = new AliDielectronVarCuts("tpc100VarCuts","TPC ncls>100");
+   tpc100VarCuts->AddCut(AliDielectronVarManager::kNclsTPC, 100., 161.);        // 
+   tpc100->AddCut(tpc100VarCuts);
+   task->AddTrackFilter(tpc100, kTRUE);  // basic cut + TPC>100 cls
+   
+   AliDielectronCutGroup* tpc120 = new AliDielectronCutGroup("tpc120","J/psi candidate electron (basic cut + TPC ncls>120)", AliDielectronCutGroup::kCompAND);
+   tpc120->AddCut(basicCut);
+   AliDielectronVarCuts *tpc120VarCuts = new AliDielectronVarCuts("tpc120VarCuts","TPC ncls>100");
+   tpc120VarCuts->AddCut(AliDielectronVarManager::kNclsTPC, 120., 161.);        // 
+   tpc120->AddCut(tpc120VarCuts);
+   task->AddTrackFilter(tpc120, kTRUE);  // basic cut + TPC>120 cls
+   
+   AliDielectronCutGroup* tpcChi2_3 = new AliDielectronCutGroup("tpcChi2_3","J/psi candidate electron (basic cut + TPC chi2<3)", AliDielectronCutGroup::kCompAND);
+   tpcChi2_3->AddCut(basicCut);
+   AliDielectronVarCuts *tpcChi2_3VarCuts = new AliDielectronVarCuts("tpcChi2_3VarCuts","TPC chi2<3");
+   tpcChi2_3VarCuts->AddCut(AliDielectronVarManager::kTPCchi2Cl, 0.01, 3.);        // 
+   tpcChi2_3->AddCut(tpcChi2_3VarCuts);
+   task->AddTrackFilter(tpcChi2_3, kTRUE);  // basic cut + TPC chi2<3
+   
+   AliDielectronCutGroup* itsChi2_10 = new AliDielectronCutGroup("itsChi2_10","J/psi candidate electron (basic cut + ITS chi2<10)", AliDielectronCutGroup::kCompAND);
+   itsChi2_10->AddCut(basicCut);
+   AliDielectronVarCuts *itsChi2_10VarCuts = new AliDielectronVarCuts("itsChi2_10VarCuts","ITS chi2<10");
+   itsChi2_10VarCuts->AddCut(AliDielectronVarManager::kITSchi2Cl, 0.01, 10.);        // 
+   itsChi2_10->AddCut(itsChi2_10VarCuts);
+   task->AddTrackFilter(itsChi2_10, kTRUE);  // basic cut + ITS chi2<10
+   
+   AliDielectronCutGroup* eleInclusion_35 = new AliDielectronCutGroup("eleInclusion_35","J/psi candidate electron (basic cut + sigmaEle<3.5)", AliDielectronCutGroup::kCompAND);
+   eleInclusion_35->AddCut(basicCut);
+   AliDielectronVarCuts *eleInclusion_35VarCuts = new AliDielectronVarCuts("eleInclusion_35VarCuts","nSigEle<3.5");
+   eleInclusion_35VarCuts->AddCut(AliDielectronVarManager::kTPCnSigmaEle, -3.5, 3.5);        // 
+   eleInclusion_35->AddCut(eleInclusion_35VarCuts);
+   task->AddTrackFilter(eleInclusion_35, kTRUE);  // basic cut + nSigEle<3.5
+   
+   AliDielectronCutGroup* eleInclusion_30 = new AliDielectronCutGroup("eleInclusion_30","J/psi candidate electron (basic cut + sigmaEle<3.0)", AliDielectronCutGroup::kCompAND);
+   eleInclusion_30->AddCut(basicCut);
+   AliDielectronVarCuts *eleInclusion_30VarCuts = new AliDielectronVarCuts("eleInclusion_30VarCuts","nSigEle<3.0");
+   eleInclusion_30VarCuts->AddCut(AliDielectronVarManager::kTPCnSigmaEle, -3.0, 3.0);        // 
+   eleInclusion_30->AddCut(eleInclusion_30VarCuts);
+   task->AddTrackFilter(eleInclusion_30, kTRUE);  // basic cut + nSigEle<3.0
+   
+   AliDielectronCutGroup* protRej_30 = new AliDielectronCutGroup("protRej_30","J/psi candidate electron (basic cut + sigmaPro>3.0)", AliDielectronCutGroup::kCompAND);
+   protRej_30->AddCut(basicCut);
+   AliDielectronVarCuts *protRej_30VarCuts = new AliDielectronVarCuts("protRej_30VarCuts","nSigPro>3.0");
+   protRej_30VarCuts->AddCut(AliDielectronVarManager::kTPCnSigmaPro, -20000.0, 3.0, kTRUE);        // 
+   protRej_30->AddCut(protRej_30VarCuts);
+   task->AddTrackFilter(protRej_30, kTRUE);  // basic cut + nSigPro>3.0
+   
+   AliDielectronCutGroup* protRej_35 = new AliDielectronCutGroup("protRej_35","J/psi candidate electron (basic cut + sigmaPro>3.5)", AliDielectronCutGroup::kCompAND);
+   protRej_35->AddCut(basicCut);
+   AliDielectronVarCuts *protRej_35VarCuts = new AliDielectronVarCuts("protRej_35VarCuts","nSigPro>3.5");
+   protRej_35VarCuts->AddCut(AliDielectronVarManager::kTPCnSigmaPro, -20000.0, 3.5, kTRUE);        // 
+   protRej_35->AddCut(protRej_35VarCuts);
+   task->AddTrackFilter(protRej_35, kTRUE);  // basic cut + nSigPro>3.5
+   
+   AliDielectronCutGroup* protRej_40 = new AliDielectronCutGroup("protRej_40","J/psi candidate electron (basic cut + sigmaPro>4.0)", AliDielectronCutGroup::kCompAND);
+   protRej_40->AddCut(basicCut);
+   AliDielectronVarCuts *protRej_40VarCuts = new AliDielectronVarCuts("protRej_40VarCuts","nSigPro>4.0");
+   protRej_40VarCuts->AddCut(AliDielectronVarManager::kTPCnSigmaPro, -20000.0, 4.0, kTRUE);        // 
+   protRej_40->AddCut(protRej_40VarCuts);
+   task->AddTrackFilter(protRej_40, kTRUE);  // basic cut + nSigPro>4.0
+   
+   AliDielectronCutGroup* pionRej_30 = new AliDielectronCutGroup("pionRej_30","J/psi candidate electron (basic cut + sigmaPio>3.0)", AliDielectronCutGroup::kCompAND);
+   pionRej_30->AddCut(basicCut);
+   AliDielectronVarCuts *pionRej_30VarCuts = new AliDielectronVarCuts("pionRej_30VarCuts","nSigPio>3.0");
+   pionRej_30VarCuts->AddCut(AliDielectronVarManager::kTPCnSigmaPio, -20000.0, 3.0, kTRUE);        // 
+   pionRej_30->AddCut(pionRej_30VarCuts);
+   task->AddTrackFilter(pionRej_30, kTRUE);  // basic cut + nSigPio>3.0
+   
+   AliDielectronCutGroup* pionRej_35 = new AliDielectronCutGroup("pionRej_35","J/psi candidate electron (basic cut + sigmaPio>3.5)", AliDielectronCutGroup::kCompAND);
+   pionRej_35->AddCut(basicCut);
+   AliDielectronVarCuts *pionRej_35VarCuts = new AliDielectronVarCuts("pionRej_35VarCuts","nSigPio>3.5");
+   pionRej_35VarCuts->AddCut(AliDielectronVarManager::kTPCnSigmaPio, -20000.0, 3.5, kTRUE);        // 
+   pionRej_35->AddCut(pionRej_35VarCuts);
+   task->AddTrackFilter(pionRej_35, kTRUE);  // basic cut + nSigPio>3.5
+   
+   AliDielectronCutGroup* pionRej_40 = new AliDielectronCutGroup("pionRej_40","J/psi candidate electron (basic cut + sigmaPio>4.0)", AliDielectronCutGroup::kCompAND);
+   pionRej_40->AddCut(basicCut);
+   AliDielectronVarCuts *pionRej_40VarCuts = new AliDielectronVarCuts("pionRej_40VarCuts","nSigPio>4.0");
+   pionRej_40VarCuts->AddCut(AliDielectronVarManager::kTPCnSigmaPio, -20000.0, 4.0, kTRUE);        // 
+   pionRej_40->AddCut(pionRej_40VarCuts);
+   task->AddTrackFilter(pionRej_40, kTRUE);  // basic cut + nSigPio>4.0
+   
+   AliDielectronCutGroup* basicCutRandom = new AliDielectronCutGroup("basicCutRandom","J/psi candidate electron (basic cut)", AliDielectronCutGroup::kCompAND);
+   basicCutRandom->AddCut(basicCut);
+   AliDielectronVarCuts *basicCutRandomVarCuts = new AliDielectronVarCuts("basicCutRandomVarCuts","basic cut, random");
+   basicCutRandomVarCuts->AddCut(AliDielectronVarManager::kRndm, 0.0, 0.1);        // 
+   basicCutRandom->AddCut(basicCutRandomVarCuts);
+   task->AddTrackFilter(basicCutRandom, kFALSE);  // basic cut + random rejection
+}
+
+
+//_________________________________________________________________________________________________________________
+void AddFMDTask(){
+
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+
+  gSystem->Load("libPWGLFforward2");  // for FMD
+
+  // Create the FMD task and add it to the manager
+  //===========================================================================
+
+
+  //--- AOD output handler -----------------------------------------
+  AliAODHandler* ret = new AliAODHandler();
+  //ret->SetFillAOD(kTRUE);
+  ret->SetOutputFileName("AliAOD.pass2.root");
+  mgr->SetOutputEventHandler(ret);
+  ////AliVEventHandler*  outputHandlernew AliAODInputHandler();
+  //
+
+
+  //gROOT->LoadClass("AliAODForwardMult", "libPWGLFforward2");
+  gSystem->Load("libESDfilter.so");
+  gROOT->LoadMacro("$ALICE_ROOT/ANALYSIS/ESDfilter/macros/AddTaskESDFilter.C");
+  AliAnalysisTaskESDfilter *esdfilter = AddTaskESDFilter(kTRUE, kFALSE, kFALSE, kFALSE, kFALSE, kTRUE);
+  //AliAnalysisTaskESDfilter *esdfilter = AddTaskESDFilter();
+
+  // Create ONLY the output containers for the data produced by the task.
+  // Get and connect other common input/output containers via the manager as below
+  //==============================================================================
+  mgr->ConnectInput  (esdfilter,  0, mgr->GetCommonInputContainer());
+  mgr->ConnectOutput (esdfilter,  0, mgr->GetCommonOutputContainer());
+
+  gROOT->LoadMacro("$ALICE_PHYSICS/PWGLF/FORWARD/analysis2/AddTaskForwardMult.C");
+
+  Bool_t   mc  = false; // false: real data, true: simulated data
+  ULong_t run = 0; // 0: get from data???
+  UShort_t sys = 0; // 0: get from data, 1: pp, 2: AA 
+  UShort_t sNN = 0; // 0: get from data, otherwise center of mass energy (per nucleon pair)
+  Short_t  fld = 0; // 0: get from data, otherwise L3 field in kG
+  //AliAnalysisTask *taskFmd  = AddTaskForwardMult(mc, sys, sNN, fld);
+  //const Char_t* config = "$ALICE_PHYSICS/PWGDQ/dielectron/ReducedTreeMaker/ForwardAODConfig2.C";
+  const Char_t* config = "ForwardAODConfig2.C";  // to be changed to the above line when config is committed
+  AliAnalysisTask *taskFmd  = AddTaskForwardMult(mc, run, sys, sNN, fld, config);
+
+
+
+  // --- Make the output container and connect it --------------------
+  AliAnalysisDataContainer* histOut = 
+    mgr->CreateContainer("Forward", TList::Class(), 
+        AliAnalysisManager::kExchangeContainer,
+        "Forward");
+  //AliAnalysisManager::GetCommonFileName());
+  AliAnalysisDataContainer *output = 
+    mgr->CreateContainer("ForwardResults", TList::Class(), 
+        AliAnalysisManager::kParamContainer, 
+        "ForwardResults");
+  //AliAnalysisManager::GetCommonFileName());
+
+  mgr->ConnectInput(taskFmd, 0, mgr->GetCommonInputContainer());
+  mgr->ConnectOutput(taskFmd, 1, histOut);
+  //mgr->ConnectOutput(taskFmd, 2, output);
+  mgr->AddTask(taskFmd);
+}
+
+//_______________________________________________________________________________________________
+AliAnalysisCuts* CreateFlowTrackFilter(Bool_t isAOD) {
+  //
+  // Cuts for tracks to be used for the event plane q-vector
+  // These cuts are applied aditionally to the global track cuts
+  //
+  if(!isAOD) {
+    AliESDtrackCuts *esdTrackCuts = new AliESDtrackCuts;
+    esdTrackCuts->SetPtRange(0.2,2.0);
+    esdTrackCuts->SetEtaRange(-0.8, 0.8);
+    esdTrackCuts->SetMinNClustersTPC(70);
+    return esdTrackCuts;
+  }
+  else return 0;
+}
+
+
+//_______________________________________________________________________________________________
+AliAnalysisCuts* CreateK0sPionCuts(Bool_t isAOD) {
+  //
+  // Cuts on the K0s pions (tracking cuts, pid cuts, ...) 
+  //
+  if(!isAOD) {
+    AliESDtrackCuts *pionCuts = new AliESDtrackCuts;
+    pionCuts->SetPtRange(0.15,100.0);
+    pionCuts->SetEtaRange(-1.6,1.6);
+    pionCuts->SetRequireTPCRefit(kTRUE);
+    pionCuts->SetMinNClustersTPC(50);
+    return pionCuts;
+  }
+  else return 0;
+}
+
+//_______________________________________________________________________________________________
+AliAnalysisCuts* CreateLambdaPionCuts(Bool_t isAOD) {
+  //
+  // Cuts on the Lambda pions (tracking cuts, pid cuts, ...) 
+  //
+  if(!isAOD) {
+    AliESDtrackCuts *pionCuts = new AliESDtrackCuts;
+    pionCuts->SetPtRange(0.15,100.0);
+    pionCuts->SetEtaRange(-1.6,1.6);
+    pionCuts->SetRequireTPCRefit(kTRUE);
+    pionCuts->SetMinNClustersTPC(50);
+    return pionCuts;
+  }
+  else return 0;
+}
+
+
+//_______________________________________________________________________________________________
+AliAnalysisCuts* CreateLambdaProtonCuts(Bool_t isAOD) {
+  //
+  // Cuts on the Lambda protons (tracking cuts, pid cuts, ...) 
+  //
+  if(!isAOD) {
+    AliESDtrackCuts *protonCuts = new AliESDtrackCuts;
+    protonCuts->SetPtRange(0.15,100.0);
+    protonCuts->SetEtaRange(-1.6,1.6);
+    protonCuts->SetRequireTPCRefit(kTRUE);
+    protonCuts->SetMinNClustersTPC(50);
+    return protonCuts;
+  }
+  else return 0;
+}
+
+
+//______________________________________________________________________________________
+AliAnalysisCuts* CreateGammaConvElectronCuts(Bool_t isAOD) {
+  //
+  // Cuts for the selection of electrons from gamma conversions
+  //
+  if(!isAOD) {
+    AliESDtrackCuts* electronCuts = new AliESDtrackCuts;
+    electronCuts->SetPtRange(0.15,100.0);
+    electronCuts->SetEtaRange(-1.6,1.6);
+    electronCuts->SetRequireTPCRefit(kTRUE);
+    electronCuts->SetMinNClustersTPC(50);
+    return electronCuts;
+  }
+}
+
+//______________________________________________________________________________________
+AliESDv0KineCuts* CreateV0StrongCuts(Int_t mode, Int_t type) {
+  //
+  // cuts for the selection of gamma conversions
+  //
+  AliESDv0KineCuts* cuts = new AliESDv0KineCuts();
+  cuts->SetMode(mode, type);
+  
+  // leg cuts
+  cuts->SetNTPCclusters(50);
+  cuts->SetTPCrefit(kTRUE);
+  cuts->SetTPCchi2perCls(4.0);
+  cuts->SetTPCclusterratio(0.6);
+  cuts->SetNoKinks(kTRUE);
+  // gamma cuts                                                                                                                      
+  cuts->SetGammaCutChi2NDF(10.0);
+  Float_t cosPoint[2] = {0.0, 0.02};
+  cuts->SetGammaCutCosPoint(cosPoint);
+  Float_t cutDCA[2] = {0.0, 0.25};
+  cuts->SetGammaCutDCA(cutDCA);
+  Float_t vtxR[2] = {3.0, 90.0};
+  cuts->SetGammaCutVertexR(vtxR);
+  Float_t psiPairCut[2]={0.0,0.05};
+  cuts->SetGammaCutPsiPair(psiPairCut);
+  cuts->SetGammaCutInvMass(0.05);
+  // K0s cuts
+  cuts->SetK0CutChi2NDF(10.0);
+  Float_t cosPointK0s[2] = {0.0, 0.02};
+  cuts->SetK0CutCosPoint(cosPointK0s);
+  Float_t cutDCAK0s[2] = {0.0, 0.2};
+  cuts->SetK0CutDCA(cutDCAK0s);
+  Float_t vtxRK0s[2] = {2.0, 30.0};
+  cuts->SetK0CutVertexR(vtxRK0s);
+  Float_t k0sInvMass[2] = {0.486, 0.508};
+  cuts->SetK0CutInvMass(k0sInvMass);
+  // Lambda and anti-Lambda cuts
+  cuts->SetLambdaCutChi2NDF(10.0);
+  Float_t cosPointLambda[2] = {0.0, 0.02};
+  cuts->SetLambdaCutCosPoint(cosPointLambda);
+  Float_t cutDCALambda[2] = {0.0, 0.2};
+  cuts->SetLambdaCutDCA(cutDCALambda);
+  Float_t vtxRLambda[2] = {2.0, 40.0};
+  cuts->SetLambdaCutVertexR(vtxRLambda);
+  Float_t lambdaInvMass[2] = {1.11, 1.12};
+  cuts->SetLambdaCutInvMass(lambdaInvMass);
+  
+  return cuts;
+}
+
+//______________________________________________________________________________________
+AliESDv0KineCuts* CreateV0OpenCuts(Int_t mode, Int_t type) {
+  //
+  // cuts for the selection of gamma conversions
+  //
+  AliESDv0KineCuts* cuts = new AliESDv0KineCuts();
+  cuts->SetMode(mode, type);
+  
+  // leg cuts
+  cuts->SetNTPCclusters(50);
+  cuts->SetTPCrefit(kTRUE);
+  cuts->SetTPCchi2perCls(4.0);
+  cuts->SetTPCclusterratio(0.6);
+  cuts->SetNoKinks(kTRUE);
+  // gamma cuts                                                                                                                      
+  cuts->SetGammaCutChi2NDF(10.0);
+  Float_t cosPoint[2] = {0.0, 0.05};  //  Float_t cosPoint[2] = {0.0, 0.02};
+  cuts->SetGammaCutCosPoint(cosPoint);
+  Float_t cutDCA[2] = {0.0, 1.0};  //  Float_t cutDCA[2] = {0.0, 0.25};
+  cuts->SetGammaCutDCA(cutDCA);
+  Float_t vtxR[2] = {3.0, 90.0};
+  cuts->SetGammaCutVertexR(vtxR);
+  Float_t psiPairCut[2]={0.0,0.20};  //Float_t psiPairCut[2]={0.0,0.05};
+  cuts->SetGammaCutPsiPair(psiPairCut);
+  cuts->SetGammaCutInvMass(0.1); //  cuts->SetGammaCutInvMass(0.05);
+  // K0s cuts
+  cuts->SetK0CutChi2NDF(10.0);
+  Float_t cosPointK0s[2] = {0.0, 0.1};  //  Float_t cosPointK0s[2] = {0.0, 0.02};
+  cuts->SetK0CutCosPoint(cosPointK0s);
+  Float_t cutDCAK0s[2] = {0.0, 1.0};  //  Float_t cutDCAK0s[2] = {0.0, 0.2};
+  cuts->SetK0CutDCA(cutDCAK0s);
+  Float_t vtxRK0s[2] = {2.0, 90.0};  //  Float_t vtxRK0s[2] = {2.0, 30.0};
+  cuts->SetK0CutVertexR(vtxRK0s);
+  Float_t k0sInvMass[2] = {0.44, 0.55};  //  Float_t k0sInvMass[2] = {0.486, 0.508};
+  cuts->SetK0CutInvMass(k0sInvMass);
+  // Lambda and anti-Lambda cuts
+  cuts->SetLambdaCutChi2NDF(10.0);
+  Float_t cosPointLambda[2] = {0.0, 0.1};  //  Float_t cosPointLambda[2] = {0.0, 0.02};
+  cuts->SetLambdaCutCosPoint(cosPointLambda);
+  Float_t cutDCALambda[2] = {0.0, 1.0};  //  Float_t cutDCALambda[2] = {0.0, 0.2};
+  cuts->SetLambdaCutDCA(cutDCALambda);
+  Float_t vtxRLambda[2] = {2.0, 90.0};  //  Float_t vtxRLambda[2] = {2.0, 40.0};
+  cuts->SetLambdaCutVertexR(vtxRLambda);
+  Float_t lambdaInvMass[2] = {1.09, 1.14};  //  Float_t lambdaInvMass[2] = {1.11, 1.12};
+  cuts->SetLambdaCutInvMass(lambdaInvMass);
+  
+  return cuts;
+}

--- a/PWGDQ/reducedTree/macros/AddTask_iarsene_jpsi2ee_XeXe.C
+++ b/PWGDQ/reducedTree/macros/AddTask_iarsene_jpsi2ee_XeXe.C
@@ -1,0 +1,676 @@
+//void Setup(AliReducedAnalysisJpsi2ee* processor, TString prod="LHC10h");
+//AliHistogramManager* SetupHistogramManager(TString prod="LHC10h");
+//void DefineHistograms(AliHistogramManager* man, TString prod="LHC10h");
+
+enum TrackFilters {
+   kBasicCut=0,
+   kSPDany,
+   kSPDfirst,
+   kTPC100,
+   kTPC120,
+   kTPCchi2_3,
+   kITSchi2_10,
+   kEleInclusion_35,
+   kEleInclusion_30,
+   kProtRejection_30,
+   kProtRejection_35,
+   kProtRejection_40,
+   kPionRejection_30,
+   kPionRejection_35,
+   kPionRejection_40,
+   kNTrackFilters
+};
+
+enum MCFilters {
+   kJpsiInclusive=0,
+   kJpsiNonPrompt,
+   kJpsiPrompt,
+   kJpsiRadiative,
+   kJpsiNonRadiative,
+   kJpsiDecayElectron,
+   kJpsiDecayPhoton
+};
+
+// run list string used for run IDs in the VarManager
+const Int_t gkNRuns = 2;
+TString gRunList = "280234;280235";
+
+// centrality binning used for event mixing and main pair histograms
+const Int_t gkNCentBins = 15;
+Double_t gCentLims[gkNCentBins] = {
+   0.0, 2.5, 5.0, 7.5, 10., 
+   15.0, 20., 25., 30., 40., 
+   50.0,  60.0, 70.0, 80., 90.0
+};
+
+// pt binning
+const Int_t gkNPtBins = 23;
+Double_t gPtLims[gkNPtBins] = {
+   0.0, 0.25, 0.50, 0.75, 1.0, 
+   1.5, 2.0, 2.5, 3.0, 3.5, 
+   4.0, 4.5, 5.0, 6.0, 7.0,
+   8.0, 9.0, 10., 12., 15., 
+   20., 25., 30. 
+};
+
+// mass binning
+const Int_t gkNMassBins = 126;
+Double_t gMassBins[gkNMassBins] = {0.};
+
+
+//__________________________________________________________________________________________
+AliAnalysisTask* AddTask_iarsene_jpsi2ee_XeXe(Bool_t isAliRoot=kTRUE, Int_t runMode=1, TString prod="LHC10h"){    
+   //
+   // isAliRoot=kTRUE for ESD/AOD analysis in AliROOT, kFALSE for root analysis on reduced trees
+   // runMode=1 (AliAnalysisTaskReducedEventProcessor::kUseOnTheFlyReducedEvents)
+   //               =2 (AliAnalysisTaskReducedEventProcessor::kUseEventsFromTree)
+   //
+   //get the current analysis manager
+
+  printf("INFO on AddTask_iarsene_jpsi2ee(): (isAliRoot, runMode) :: (%d,%d) \n", isAliRoot, runMode);
+
+  AliReducedAnalysisJpsi2ee* jpsi2eeAnalysis = new AliReducedAnalysisJpsi2ee("Jpsi2eeAnalysis","Jpsi->ee analysis");
+  jpsi2eeAnalysis->Init();
+  //jpsi2eeAnalysis->SetLoopOverTracks(kFALSE);
+  //jpsi2eeAnalysis->SetRunEventMixing(kFALSE);
+  //jpsi2eeAnalysis->SetRunPairing(kFALSE);
+  jpsi2eeAnalysis->SetRunOverMC(kTRUE);
+  //jpsi2eeAnalysis->SetRunLikeSignPairing(kFALSE);
+  Setup(jpsi2eeAnalysis, prod);
+  // initialize an AliAnalysisTask which will wrapp the AliReducedAnalysisJpsi2ee such that it can be run in an aliroot analysis train (e.g. LEGO, local analysis etc)
+  AliAnalysisTaskReducedEventProcessor* task = new AliAnalysisTaskReducedEventProcessor("ReducedEventAnalysisManager", runMode);
+  task->AddTask(jpsi2eeAnalysis);
+  
+  if(isAliRoot){
+     AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+     if (!mgr) {
+        Error("AddTask_iarsene_dst", "No analysis manager found.");
+        return 0;
+     }
+     
+     AliAnalysisDataContainer* cReducedEvent = NULL;
+     if(runMode==AliAnalysisTaskReducedEventProcessor::kUseOnTheFlyReducedEvents) {
+       printf("INFO on AddTask_iarsene_jpsi2ee(): use on the fly events ");
+       cReducedEvent = (AliAnalysisDataContainer*)mgr->GetContainers()->FindObject("ReducedEventDQ");
+       if(!cReducedEvent) {
+         printf("ERROR: In AddTask_iarsene_jpsi2ee(), couldn't find exchange container with ReducedEvent! ");
+         printf("             You need to use AddTask_iarsene_dst() in the on-the-fly reduced events mode!");
+         return 0x0;
+       }
+     }
+            
+     mgr->AddTask(task);
+      
+     if(runMode==AliAnalysisTaskReducedEventProcessor::kUseEventsFromTree) 
+        mgr->ConnectInput(task,  0, mgr->GetCommonInputContainer());
+      
+     if(runMode==AliAnalysisTaskReducedEventProcessor::kUseOnTheFlyReducedEvents) 
+       mgr->ConnectInput(task, 0, cReducedEvent);
+  
+     AliAnalysisDataContainer *cOutputHist = mgr->CreateContainer("jpsi2eeHistos", THashList::Class(),
+                                                                  AliAnalysisManager::kOutputContainer, "AnalysisHistograms_jpsi2ee_XeXe.root");
+     mgr->ConnectOutput(task, 1, cOutputHist );
+  }
+  else {
+    // nothing at the moment   
+  }
+  
+  return task;
+}
+
+
+//_________________________________________________________________
+void Setup(AliReducedAnalysisJpsi2ee* processor, TString prod /*="LHC10h"*/) {
+  //
+  // Configure the analysis task
+  // Setup histograms, handlers, cuts, etc.
+  //
+  
+  // Set event cuts
+  AliReducedEventCut* evCut1 = new AliReducedEventCut("Centrality","Centrality selection");
+  evCut1->AddCut(AliReducedVarManager::kCentVZERO, 0., 90.);
+  evCut1->AddCut(AliReducedVarManager::kVtxZ, -10.0, 10.0);
+  evCut1->AddCut(AliReducedVarManager::kIsPhysicsSelection, 0.1, 2.);   // request physics selection
+  evCut1->EnableVertexDistanceCut();
+  
+  processor->AddEventCut(evCut1);
+  
+  /*
+  // Set track cuts
+  AliReducedTrackCut* standardCut = new AliReducedTrackCut("standard","");
+  standardCut->AddCut(AliReducedVarManager::kP, 1.0,30.0);
+  standardCut->AddCut(AliReducedVarManager::kEta, -0.9,0.9);
+  standardCut->AddCut(AliReducedVarManager::kDcaXY, -1.0,1.0);
+  standardCut->AddCut(AliReducedVarManager::kDcaZ, -3.0,3.0);
+  standardCut->AddCut(AliReducedVarManager::kTPCncls, 70.,160.0);
+  standardCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kProton, 3.5, 30000.0);
+  standardCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kPion, 3.0, 30000.0);
+  standardCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, -3.0, 3.0);
+  standardCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, -2.0, 3.0, kFALSE, AliReducedVarManager::kEta, -0.9, -0.75);
+  standardCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, -2.6, 3.0, kFALSE, AliReducedVarManager::kEta, 0.75, 0.9);
+  standardCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, -2.4, 3.0, kFALSE, AliReducedVarManager::kEta, -0.4, 0.4);
+  standardCut->SetRejectKinks();
+  standardCut->SetRequestITSrefit();
+  standardCut->SetRequestTPCrefit();
+  //standardCut->SetRequestTOFout();
+  standardCut->SetRequestSPDany();
+  standardCut->AddCut(AliReducedVarManager::kTPCchi2, 0., 4.0);
+  standardCut->AddCut(AliReducedVarManager::kITSchi2, 0., 10.);
+  standardCut->AddCut(AliReducedVarManager::kTPCNclusBitsFired, 6., 9.);
+  standardCut->AddCut(AliReducedVarManager::kTPCnclsSharedRatio, 0.3, 2., kTRUE);
+  standardCut->AddCut(AliReducedVarManager::kTPCcrossedRowsOverFindableClusters, 0.8, 2.);
+  //standardCut->AddCut(AliReducedVarManager::kChi2TPCConstrainedVsGlobal, 36., 1.0e+10, kTRUE);
+  processor->AddTrackCut(standardCut); 
+  */
+  
+  AliReducedTrackCut* standardCut = new AliReducedTrackCut("standardCut","");
+  standardCut->AddCut(AliReducedVarManager::kPt, 1.0, 100.);
+  standardCut->SetRejectKinks();
+  standardCut->SetTrackFilterBit(kSPDany);
+  standardCut->SetTrackFilterBit(kEleInclusion_30);
+  standardCut->SetTrackFilterBit(kProtRejection_30);
+  standardCut->SetTrackFilterBit(kPionRejection_30);  
+  processor->AddTrackCut(standardCut);
+  
+  AliReducedTrackCut* spdFirstCut = new AliReducedTrackCut("spdFirstCut","");
+  spdFirstCut->AddCut(AliReducedVarManager::kPt, 1.0, 100.);
+  spdFirstCut->SetRejectKinks();
+  spdFirstCut->SetTrackFilterBit(kSPDfirst);
+  spdFirstCut->SetTrackFilterBit(kEleInclusion_30);
+  spdFirstCut->SetTrackFilterBit(kProtRejection_30);
+  spdFirstCut->SetTrackFilterBit(kPionRejection_30);  
+  processor->AddTrackCut(spdFirstCut);
+  
+  AliReducedTrackCut* protRej30pionRej35 = new AliReducedTrackCut("protRej30pionRej35","");
+  protRej30pionRej35->AddCut(AliReducedVarManager::kPt, 1.0, 100.);
+  protRej30pionRej35->SetRejectKinks();
+  protRej30pionRej35->SetTrackFilterBit(kSPDany);
+  protRej30pionRej35->SetTrackFilterBit(kEleInclusion_30);
+  protRej30pionRej35->SetTrackFilterBit(kProtRejection_30);
+  protRej30pionRej35->SetTrackFilterBit(kPionRejection_35);
+  processor->AddTrackCut(protRej30pionRej35);
+  
+  AliReducedTrackCut* protRej30pionRej40 = new AliReducedTrackCut("protRej30pionRej40","");
+  protRej30pionRej40->AddCut(AliReducedVarManager::kPt, 1.0, 100.);
+  protRej30pionRej40->SetRejectKinks();
+  protRej30pionRej40->SetTrackFilterBit(kSPDany);
+  protRej30pionRej40->SetTrackFilterBit(kEleInclusion_30);
+  protRej30pionRej40->SetTrackFilterBit(kProtRejection_30);
+  protRej30pionRej40->SetTrackFilterBit(kPionRejection_40);
+  processor->AddTrackCut(protRej30pionRej40);
+  
+  AliReducedTrackCut* protRej35pionRej30 = new AliReducedTrackCut("protRej35pionRej30","");
+  protRej35pionRej30->AddCut(AliReducedVarManager::kPt, 1.0, 100.);
+  protRej35pionRej30->SetRejectKinks();
+  protRej35pionRej30->SetTrackFilterBit(kSPDany);
+  protRej35pionRej30->SetTrackFilterBit(kEleInclusion_30);
+  protRej35pionRej30->SetTrackFilterBit(kProtRejection_35);
+  protRej35pionRej30->SetTrackFilterBit(kPionRejection_30);
+  processor->AddTrackCut(protRej35pionRej30);
+  
+  AliReducedTrackCut* protRej35pionRej35 = new AliReducedTrackCut("protRej35pionRej35","");
+  protRej35pionRej35->AddCut(AliReducedVarManager::kPt, 1.0, 100.);
+  protRej35pionRej35->SetRejectKinks();
+  protRej35pionRej35->SetTrackFilterBit(kSPDany);
+  protRej35pionRej35->SetTrackFilterBit(kEleInclusion_30);
+  protRej35pionRej35->SetTrackFilterBit(kProtRejection_35);
+  protRej35pionRej35->SetTrackFilterBit(kPionRejection_35);
+  processor->AddTrackCut(protRej35pionRej35);
+  
+  AliReducedTrackCut* protRej35pionRej40 = new AliReducedTrackCut("protRej35pionRej40","");
+  protRej35pionRej40->AddCut(AliReducedVarManager::kPt, 1.0, 100.);
+  protRej35pionRej40->SetRejectKinks();
+  protRej35pionRej40->SetTrackFilterBit(kSPDany);
+  protRej35pionRej40->SetTrackFilterBit(kEleInclusion_30);
+  protRej35pionRej40->SetTrackFilterBit(kProtRejection_35);
+  protRej35pionRej40->SetTrackFilterBit(kPionRejection_40);
+  processor->AddTrackCut(protRej35pionRej40);
+  
+  AliReducedTrackCut* protRej40pionRej30 = new AliReducedTrackCut("protRej40pionRej30","");
+  protRej40pionRej30->AddCut(AliReducedVarManager::kPt, 1.0, 100.);
+  protRej40pionRej30->SetRejectKinks();
+  protRej40pionRej30->SetTrackFilterBit(kSPDany);
+  protRej40pionRej30->SetTrackFilterBit(kEleInclusion_30);
+  protRej40pionRej30->SetTrackFilterBit(kProtRejection_40);
+  protRej40pionRej30->SetTrackFilterBit(kPionRejection_30);
+  processor->AddTrackCut(protRej40pionRej30);
+  
+  AliReducedTrackCut* protRej40pionRej35 = new AliReducedTrackCut("protRej40pionRej35","");
+  protRej40pionRej35->AddCut(AliReducedVarManager::kPt, 1.0, 100.);
+  protRej40pionRej35->SetRejectKinks();
+  protRej40pionRej35->SetTrackFilterBit(kSPDany);
+  protRej40pionRej35->SetTrackFilterBit(kEleInclusion_30);
+  protRej40pionRej35->SetTrackFilterBit(kProtRejection_40);
+  protRej40pionRej35->SetTrackFilterBit(kPionRejection_35);
+  processor->AddTrackCut(protRej40pionRej35);
+  
+  AliReducedTrackCut* protRej40pionRej40 = new AliReducedTrackCut("protRej40pionRej40","");
+  protRej40pionRej40->AddCut(AliReducedVarManager::kPt, 1.0, 100.);
+  protRej40pionRej40->SetRejectKinks();
+  protRej40pionRej40->SetTrackFilterBit(kSPDany);
+  protRej40pionRej40->SetTrackFilterBit(kEleInclusion_30);
+  protRej40pionRej40->SetTrackFilterBit(kProtRejection_40);
+  protRej40pionRej40->SetTrackFilterBit(kPionRejection_40);
+  processor->AddTrackCut(protRej40pionRej40);
+  
+  // set track prefilter cuts
+  AliReducedTrackCut* prefTrackCut1 = new AliReducedTrackCut("prefCutPt09","prefilter P selection");
+  prefTrackCut1->AddCut(AliReducedVarManager::kPt, 0.8,100.0);
+  prefTrackCut1->SetRequestTPCrefit();
+  processor->AddPrefilterTrackCut(prefTrackCut1);  
+  
+  // MC truth info for reconstructed electron candidates
+  AliReducedTrackCut* trueElectron = new AliReducedTrackCut("TrueElectron", "reconstructed electrons with MC truth");
+  trueElectron->SetMCFilterBit(kJpsiDecayElectron);
+  processor->AddLegCandidateMCcut(trueElectron);  
+  
+  // MC truth selections(s) for the J/psi mother and electron daughters
+  AliReducedTrackCut* mcTruthJpsi = new AliReducedTrackCut("mcTruthJpsi", "Pure MC truth J/psi");
+  mcTruthJpsi->SetMCFilterBit(kJpsiInclusive);
+  mcTruthJpsi->AddCut(AliReducedVarManager::kRap, -0.9, 0.9);
+  AliReducedTrackCut* mcTruthJpsiElectron = new AliReducedTrackCut("mcTruthJpsiElectron", "Pure MC truth electron from J/psi");
+  mcTruthJpsiElectron->SetMCFilterBit(kJpsiDecayElectron);
+  mcTruthJpsiElectron->AddCut(AliReducedVarManager::kEta, -0.9, 0.9);
+  mcTruthJpsiElectron->AddCut(AliReducedVarManager::kPt, 1.0, 100.0);
+  processor->AddJpsiMotherMCCut(mcTruthJpsi, mcTruthJpsiElectron);  
+  
+  // set pair prefilter cuts
+  AliReducedVarCut* prefPairCut = new AliReducedVarCut("prefCutM50MeV","prefilter pair cuts");
+  prefPairCut->AddCut(AliReducedVarManager::kMass, 0.0, 0.05, kTRUE);
+  processor->AddPrefilterPairCut(prefPairCut);
+  
+  // Set pair cuts
+  AliReducedTrackCut* pairCut1 = new AliReducedTrackCut("Ptpair","Pt pair selection");
+  pairCut1->AddCut(AliReducedVarManager::kPt, 0.0,100.0);
+  pairCut1->AddCut(AliReducedVarManager::kRap, -0.9,0.9);
+  processor->AddPairCut(pairCut1);
+  
+  
+  
+  SetupHistogramManager(processor, prod);
+  SetupMixingHandler(processor);
+}
+
+
+//_________________________________________________________________
+void SetupMixingHandler(AliReducedAnalysisJpsi2ee* task) {
+   //
+   // setup the mixing handler
+   //
+   AliMixingHandler* handler = task->GetMixingHandler();
+   handler->SetPoolDepth(50);
+   handler->SetMixingThreshold(1.0);
+   handler->SetDownscaleEvents(1);
+   handler->SetDownscaleTracks(1);
+   
+   handler->AddMixingVariable(AliReducedVarManager::kCentVZERO, gkNCentBins, gCentLims);
+}
+
+
+//_________________________________________________________________
+void SetupHistogramManager(AliReducedAnalysisJpsi2ee* task, TString prod /*="LHC10h"*/) {
+  //
+  // setup the histograms manager
+  //
+  AliReducedVarManager::SetDefaultVarNames();
+  
+  DefineHistograms(task, prod);
+  
+  AliReducedVarManager::SetUseVars(task->GetHistogramManager()->GetUsedVars());
+}
+
+
+//_________________________________________________________________
+void DefineHistograms(AliReducedAnalysisJpsi2ee* task, TString prod /*="LHC10h"*/) {
+  //
+  // define histograms
+  // NOTE: The DefineHistograms need to be called after the track cuts are defined because the name of the cuts
+  //           are used in the histogram lists
+   // NOTE: The name of the pair histogram lists for event mixing need to contain "PairMEPP", "PairMEPM", "PairMEMM", in their name, see below.
+   //  TODO: make needed changes such that this becomes less prone to mistakes
+   
+  AliHistogramManager* man = task->GetHistogramManager(); 
+   
+  TString histClasses = "";
+  histClasses += "Event_BeforeCuts;";
+  histClasses += "Event_AfterCuts;";
+  if(!task->GetRunOverMC()) {
+    histClasses += "EventTag_BeforeCuts;";   
+    histClasses += "EventTag_AfterCuts;";   
+    histClasses += "EventTriggers_BeforeCuts;";
+    histClasses += "EventTriggers_AfterCuts;";   
+  }
+  if(task->GetLoopOverTracks())
+    histClasses += "Track_BeforeCuts;";
+  if(!task->GetRunOverMC()) {
+    histClasses += "TrackStatusFlags_BeforeCuts;";
+  }
+  if(task->GetLoopOverTracks()) {
+    histClasses += "TrackITSclusterMap_BeforeCuts;";
+    histClasses += "TrackTPCclusterMap_BeforeCuts;";
+  }
+  if(task->GetRunOverMC()) {
+     for(Int_t mcSel=0; mcSel<task->GetNJpsiMotherMCCuts(); ++mcSel) {
+        histClasses += Form("%s_PureMCTruth_BeforeSelection;", task->GetJpsiMotherMCcutName(mcSel));
+        histClasses += Form("%s_PureMCTruth_AfterSelection;", task->GetJpsiMotherMCcutName(mcSel));
+     }
+  }
+  if(task->GetLoopOverTracks()) {
+    for(Int_t i=0; i<task->GetNTrackCuts(); ++i) {
+      TString cutName = task->GetTrackCutName(i);
+      histClasses += Form("Track_%s;", cutName.Data());
+      if(!task->GetRunOverMC()) {
+        histClasses += Form("TrackStatusFlags_%s;", cutName.Data());
+      }
+      histClasses += Form("TrackITSclusterMap_%s;", cutName.Data());
+      histClasses += Form("TrackTPCclusterMap_%s;", cutName.Data());
+      if(task->GetRunOverMC()) {
+         for(Int_t mcSel=0; mcSel<task->GetNLegCandidateMCcuts(); ++mcSel) {
+            histClasses += Form("Track_%s_%s;", cutName.Data(), task->GetLegCandidateMCcutName(mcSel));
+            histClasses += Form("TrackStatusFlags_%s_%s;", cutName.Data(), task->GetLegCandidateMCcutName(mcSel));
+            histClasses += Form("TrackITSclusterMap_%s_%s;", cutName.Data(), task->GetLegCandidateMCcutName(mcSel));
+            histClasses += Form("TrackTPCclusterMap_%s_%s;", cutName.Data(), task->GetLegCandidateMCcutName(mcSel));
+         }
+      }
+      if(!task->GetRunLikeSignPairing())
+         histClasses += Form("PairSEPM_%s;", cutName.Data());
+      else
+         histClasses += Form("PairSEPP_%s;PairSEPM_%s;PairSEMM_%s;", cutName.Data(), cutName.Data(), cutName.Data());
+      if(!task->GetRunOverMC())
+        histClasses += Form("PairMEPP_%s;PairMEPM_%s;PairMEMM_%s;", cutName.Data(), cutName.Data(), cutName.Data());
+      if(task->GetRunOverMC()) {
+         for(Int_t mcSel=0; mcSel<task->GetNLegCandidateMCcuts(); ++mcSel)
+            histClasses += Form("PairSEPM_%s_%s;", cutName.Data(), task->GetLegCandidateMCcutName(mcSel));
+      }
+    }
+  }
+  
+  AliReducedVarManager::SetRunNumbers(gRunList);
+  
+  const Int_t kNBCBins = 3600;
+  Double_t bcHistRange[2] = {-0.5,3599.5};
+  
+  // set the mass bin limits
+  for(Int_t i=0; i<gkNMassBins;++i) gMassBins[i] = 0.0+i*0.04;
+  
+  TString classesStr(histClasses);
+  TObjArray* arr=classesStr.Tokenize(";");
+  
+  cout << "Histogram classes included in the Histogram Manager" << endl;
+  for(Int_t iclass=0; iclass<arr->GetEntries(); ++iclass) {
+    TString classStr = arr->At(iclass)->GetName();
+    
+    if(classStr.Contains("PureMCTruth_")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       
+       man->AddHistogram(classStr.Data(), "MassMC_Pt_CentVZERO", "", kFALSE, gkNMassBins-1, gMassBins, AliReducedVarManager::kMassMC, gkNPtBins-1, gPtLims, AliReducedVarManager::kPtMC, gkNCentBins-1, gCentLims, AliReducedVarManager::kCentVZERO);
+       
+       man->AddHistogram(classStr.Data(), "MassMC", "MC mass", kFALSE, 200, 0., 5.0, AliReducedVarManager::kMassMC);
+       man->AddHistogram(classStr.Data(), "RapidityMC", "MC rapidity", kFALSE, 48, -1.2, 1.2, AliReducedVarManager::kRapMC);
+       man->AddHistogram(classStr.Data(), "PtMC", "p_{T} MC", kFALSE, 1000, 0., 10.0, AliReducedVarManager::kPtMC);
+       man->AddHistogram(classStr.Data(), "PtMC_coarse", "p_{T} MC", kFALSE, 20, 0., 20.0, AliReducedVarManager::kPtMC);
+       man->AddHistogram(classStr.Data(), "PhiMC", "MC #varphi", kFALSE, 100, 0., 6.3, AliReducedVarManager::kPhiMC);
+       man->AddHistogram(classStr.Data(), "EtaMC", "MC #eta", kFALSE, 100, -1.5, 1.5, AliReducedVarManager::kEtaMC);
+       man->AddHistogram(classStr.Data(), "PtMC_RapMC", "", kFALSE, 100, -1.2, 1.2, AliReducedVarManager::kRapMC, 100, 0., 15., AliReducedVarManager::kPtMC);
+       man->AddHistogram(classStr.Data(), "CosThetaStarCS", "cos(#theta^{*})_{CS}", kFALSE, 22, -1.1, 1.1, AliReducedVarManager::kPairThetaCS);
+       man->AddHistogram(classStr.Data(), "CosThetaStarCS_ptMC", "cos(#theta^{*})_{CS} vs MC pt", kFALSE, 22, -1.1, 1.1, AliReducedVarManager::kPairThetaCS, 50, 0., 1., AliReducedVarManager::kPtMC);
+       man->AddHistogram(classStr.Data(), "CosThetaStarHE", "cos(#theta^{*})_{HE}", kFALSE, 22, -1.1, 1.1, AliReducedVarManager::kPairThetaHE);
+       man->AddHistogram(classStr.Data(), "CosThetaStarHE_ptMC", "cos(#theta^{*})_{HE} vs MC pt", kFALSE, 22, -1.1, 1.1, AliReducedVarManager::kPairThetaHE, 100, 0., 1., AliReducedVarManager::kPtMC);
+       man->AddHistogram(classStr.Data(), "CosThetaStarHE_ptMC_coarse", "cos(#theta^{*})_{HE} vs MC pt", kFALSE, 10, -1.0, 1.0, AliReducedVarManager::kPairThetaHE, 20, 0., 20., AliReducedVarManager::kPtMC);
+       man->AddHistogram(classStr.Data(), "PhiStarCS", "#varphi^{*}_{CS}", kFALSE, 22, -3.3, 3.3, AliReducedVarManager::kPairPhiCS);
+       man->AddHistogram(classStr.Data(), "PhiStarHE", "#varphi^{*}_{HE}", kFALSE, 22, -3.3, 3.3, AliReducedVarManager::kPairPhiHE);
+       
+       continue;
+    }
+    
+    // Event wise histograms
+    if(classStr.Contains("EventTag_")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       TString tagNames = "";
+       tagNames += "AliAnalysisUtils 2013 selection;";
+       tagNames += "AliAnalysisUtils MV pileup;";
+       tagNames += "AliAnalysisUtils MV pileup, no BC check;";
+       tagNames += "AliAnalysisUtils MV pileup, min wght dist 10;";
+       tagNames += "AliAnalysisUtils MV pileup, min wght dist 5;";
+       tagNames += "IsPileupFromSPD(3,0.6,3.,2.,5.);";
+       tagNames += "IsPileupFromSPD(4,0.6,3.,2.,5.);";
+       tagNames += "IsPileupFromSPD(5,0.6,3.,2.,5.);";
+       tagNames += "IsPileupFromSPD(6,0.6,3.,2.,5.);";
+       tagNames += "IsPileupFromSPD(3,0.8,3.,2.,5.);";
+       tagNames += "IsPileupFromSPD(4,0.8,3.,2.,5.);";
+       tagNames += "IsPileupFromSPD(5,0.8,3.,2.,5.);";
+       tagNames += "IsPileupFromSPD(6,0.8,3.,2.,5.);";
+       tagNames += "vtx distance selected;";
+       man->AddHistogram(classStr.Data(), "EventTags", "Event tags", kFALSE,
+                         20, -0.5, 19.5, AliReducedVarManager::kEventTag, 0, 0.0, 0.0, AliReducedVarManager::kNothing, 0, 0.0, 0.0, AliReducedVarManager::kNothing, tagNames.Data());
+       man->AddHistogram(classStr.Data(), "EventTags_CentVZERO", "Event tags vs VZERO centrality", kFALSE,
+                         20, -0.5, 19.5, AliReducedVarManager::kEventTag, 9, 0.0, 90.0, AliReducedVarManager::kCentVZERO, 0, 0.0, 0.0, AliReducedVarManager::kNothing, tagNames.Data());
+       continue;
+    }
+    
+    if(classStr.Contains("EventTriggers_")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       TString triggerNames = "";
+       for(Int_t i=0; i<64; ++i) {triggerNames += AliReducedVarManager::fgkOfflineTriggerNames[i]; triggerNames+=";";}
+       
+       man->AddHistogram(classStr.Data(), "Triggers2", "", kFALSE,
+                         64, -0.5, 63.5, AliReducedVarManager::kOnlineTriggerFired2, 0, 0.0, 0.0, AliReducedVarManager::kNothing, 0, 0.0, 0.0, AliReducedVarManager::kNothing, triggerNames.Data());
+       man->AddHistogram(classStr.Data(), "CentVZERO_Triggers2", "", kFALSE,
+                         64, -0.5, 63.5, AliReducedVarManager::kOnlineTriggerFired2, 9, 0.0, 90.0, AliReducedVarManager::kCentVZERO, 0, 0.0, 0.0, AliReducedVarManager::kNothing, triggerNames.Data());
+       continue;
+    }
+    
+    if(classStr.Contains("Event_")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      man->AddHistogram(classStr.Data(),"RunNo","Run numbers",kFALSE, gkNRuns, -0.5, -0.5+gkNRuns, AliReducedVarManager::kRunID);
+      man->AddHistogram(classStr.Data(),"VtxX","Vtx X",kFALSE,300,-0.4,0.4,AliReducedVarManager::kVtxX);
+      man->AddHistogram(classStr.Data(),"VtxY","Vtx Y",kFALSE,300,-0.4,0.4,AliReducedVarManager::kVtxY);
+      man->AddHistogram(classStr.Data(),"VtxZ","Vtx Z",kFALSE,300,-15.,15.,AliReducedVarManager::kVtxZ);
+      man->AddHistogram(classStr.Data(),"CentVZERO","Centrality(VZERO)",kFALSE, 100, 0.0, 100.0, AliReducedVarManager::kCentVZERO);
+      man->AddHistogram(classStr.Data(),"CentVZERO_VtxZ","Centrality(VZERO) vs vtxZ",kFALSE, 50, 0.0, 100.0, AliReducedVarManager::kCentVZERO,
+         50, -10., 10., AliReducedVarManager::kVtxZ);
+      man->AddHistogram(classStr.Data(),"CentSPD","Centrality(SPD)",kFALSE, 100, 0.0, 100.0, AliReducedVarManager::kCentSPD);
+      man->AddHistogram(classStr.Data(),"CentSPD_VtxZ","Centrality(SPD) vs vtxZ",kFALSE, 50, 0.0, 100.0, AliReducedVarManager::kCentSPD,
+         50, -10., 10., AliReducedVarManager::kVtxZ);
+      man->AddHistogram(classStr.Data(),"CentQuality","Centrality quality",kFALSE, 500, 0., 500., AliReducedVarManager::kCentQuality);
+      man->AddHistogram(classStr.Data(),"SPDntracklets", "SPD #tracklets in |#eta|<1.0", kFALSE, 200, 0., 5000., AliReducedVarManager::kSPDntracklets);
+
+      man->AddHistogram(classStr.Data(),"VZEROmult", "", kFALSE, 500, 0.0, 50000., AliReducedVarManager::kVZEROTotalMult);
+      man->AddHistogram(classStr.Data(),"VZEROmult_VtxContributors", "", kFALSE, 
+		   200, 0.0, 40000., AliReducedVarManager::kVZEROTotalMult, 200, 0.0, 10000., AliReducedVarManager::kNVtxContributors);
+      man->AddHistogram(classStr.Data(),"VZEROmult_SPDntracklets", "", kFALSE, 
+                        200, 0.0, 5000., AliReducedVarManager::kSPDntracklets, 200, 0.0, 40000., AliReducedVarManager::kVZEROTotalMult);
+      man->AddHistogram(classStr.Data(),"IsPhysicsSelection","Physics selection flag",kFALSE,
+                        2,-0.5,1.5,AliReducedVarManager::kIsPhysicsSelection, 0,0.0,0.0,AliReducedVarManager::kNothing, 0,0.0,0.0,AliReducedVarManager::kNothing, "off;on");
+
+      man->AddHistogram(classStr.Data(),"NPosTracksAnalyzed","#positrons per event",kFALSE,100,0.,100.,AliReducedVarManager::kNtracksPosAnalyzed);
+      man->AddHistogram(classStr.Data(),"NNegTracksAnalyzed","#electrons per event",kFALSE,100,0.,100.,AliReducedVarManager::kNtracksNegAnalyzed);
+      man->AddHistogram(classStr.Data(),"NTotalTracksAnalyzed","#leg candidates per event",kFALSE,100,0.,100.,AliReducedVarManager::kNtracksAnalyzed);
+      man->AddHistogram(classStr.Data(),"NTotalPairsAnalyzed","#dielectron candidates per event",kFALSE,100,0.,100.,AliReducedVarManager::kNpairsSelected);
+
+      man->AddHistogram(classStr.Data(),"NTracksTPCout","",kFALSE,1800,0.,30000.,AliReducedVarManager::kNTracksPerTrackingStatus+AliReducedVarManager::kTPCout);
+      man->AddHistogram(classStr.Data(),"NTracksTPCout_VZEROmult","",kFALSE,900,0.,30000.,AliReducedVarManager::kNTracksPerTrackingStatus+AliReducedVarManager::kTPCout, 300, 0., 40000., AliReducedVarManager::kVZEROTotalMult);
+      
+      man->AddHistogram(classStr.Data(),"NTracksAnalyzed_VZEROmult","",kFALSE,100,0.,100.,AliReducedVarManager::kNtracksAnalyzed, 300, 0., 40000., AliReducedVarManager::kVZEROTotalMult);
+      man->AddHistogram(classStr.Data(),"NTracksTPCoutVsVZEROmult","",kFALSE,1000,0.,10.,AliReducedVarManager::kNTracksTPCoutVsVZEROTotalMult);
+      man->AddHistogram(classStr.Data(),"NTracksTPCoutVsVZEROmult_CentVZERO","",kFALSE, 20, 0., 100., AliReducedVarManager::kCentVZERO, 1000,0.,10.,AliReducedVarManager::kNTracksTPCoutVsVZEROTotalMult);
+      man->AddHistogram(classStr.Data(),"NTracksAnalyzed_RunNo_prof","",kTRUE, gkNRuns, -0.5, -0.5 + gkNRuns, AliReducedVarManager::kRunID, 10, 0., 10., AliReducedVarManager::kNtracksAnalyzed);
+      man->AddHistogram(classStr.Data(),"NPairsAnalyzed_RunNo_prof","",kTRUE, gkNRuns, -0.5, -0.5 + gkNRuns, AliReducedVarManager::kRunID, 10, 0., 10., AliReducedVarManager::kNpairsSelected);
+      continue;
+    }  // end if className contains "Event"    
+    
+    // Track histograms
+    if(classStr.Contains("TrackITSclusterMap_")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       man->AddHistogram(classStr.Data(), "ITSlayerHit", "Hits in the ITS layers", kFALSE,
+                         6, 0.5, 6.5, AliReducedVarManager::kITSlayerHit);
+       man->AddHistogram(classStr.Data(), "ITSlayerHit_Phi", "Hits in the ITS layers vs #varphi", kFALSE,
+                         180, 0.0, 6.29, AliReducedVarManager::kPhi, 6, 0.5, 6.5, AliReducedVarManager::kITSlayerHit);
+       man->AddHistogram(classStr.Data(), "ITSlayerHit_Eta", "Hits in the ITS layers vs #eta", kFALSE,
+                         100, -1.0, 1.0, AliReducedVarManager::kEta, 6, 0.5, 6.5, AliReducedVarManager::kITSlayerHit);
+       continue;
+    }  // end of ITSclusterMap histogram definitions
+    
+    if(classStr.Contains("TrackTPCclusterMap_")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       man->AddHistogram(classStr.Data(), "TPCclusterMap", "TPC cluster map", kFALSE,
+                         8, -0.5, 7.5, AliReducedVarManager::kTPCclusBitFired);
+       man->AddHistogram(classStr.Data(), "TPCclusterMap_Phi", "TPC cluster map vs #varphi", kFALSE,
+                         180, 0.0, 6.29, AliReducedVarManager::kPhi, 8, -0.5, 7.5, AliReducedVarManager::kTPCclusBitFired);
+       man->AddHistogram(classStr.Data(), "TPCclusterMap_Eta", "TPC cluster map vs #eta", kFALSE,
+                         100, -1.0, 1.0, AliReducedVarManager::kEta, 8, -0.5, 7.5, AliReducedVarManager::kTPCclusBitFired);
+       man->AddHistogram(classStr.Data(), "TPCclusterMap_Pt", "TPC cluster map vs p_{T}", kFALSE,
+                         100, 0.0, 10.0, AliReducedVarManager::kPt, 8, -0.5, 7.5, AliReducedVarManager::kTPCclusBitFired);
+       continue;
+    }  // end of TPCclusterMap histogram definitions
+    
+    TString trkStatusNames = "";
+    for(Int_t iflag=0; iflag<AliReducedVarManager::kNTrackingStatus; ++iflag) {
+       trkStatusNames += AliReducedVarManager::fgkTrackingStatusNames[iflag];
+       trkStatusNames += ";";
+    }
+    if(classStr.Contains("TrackStatusFlags_")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       man->AddHistogram(classStr.Data(), "TrackingFlags", "Tracking flags;;", kFALSE,
+                         AliReducedVarManager::kNTrackingStatus, -0.5, AliReducedVarManager::kNTrackingStatus-0.5, AliReducedVarManager::kTrackingFlag, 
+                         0, 0.0, 0.0, AliReducedVarManager::kNothing, 0, 0.0, 0.0, AliReducedVarManager::kNothing, trkStatusNames.Data());
+       continue;
+    }
+    
+    if(classStr.Contains("Track_")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      man->AddHistogram(classStr.Data(), "P_Pin", "P vs Pin", kFALSE, 200, 0.0, 10.0, AliReducedVarManager::kP, 200, 0.0, 10.0, AliReducedVarManager::kPin);
+      man->AddHistogram(classStr.Data(), "Pt", "p_{T} distribution", kFALSE, 1000, 0.0, 50.0, AliReducedVarManager::kPt);
+      man->AddHistogram(classStr.Data(), "Eta", "", kFALSE, 1000, -1.5, 1.5, AliReducedVarManager::kEta);
+      man->AddHistogram(classStr.Data(), "Eta_Phi", "", kFALSE, 100, -1.0, 1.0, AliReducedVarManager::kEta, 100, 0., 6.3, AliReducedVarManager::kPhi);
+      man->AddHistogram(classStr.Data(), "Phi", "", kFALSE, 1000, 0.0, 6.3, AliReducedVarManager::kPhi);
+      man->AddHistogram(classStr.Data(), "DCAxy_Pt", "DCAxy", kFALSE, 100, -2.0, 2.0, AliReducedVarManager::kDcaXY, 50, 0.0, 5.0, AliReducedVarManager::kPt);
+      man->AddHistogram(classStr.Data(), "DCAxy", "DCAxy", kFALSE, 200, -5.0, 5.0, AliReducedVarManager::kDcaXY);
+      man->AddHistogram(classStr.Data(), "DCAz", "DCAz", kFALSE, 200, -5.0, 5.0, AliReducedVarManager::kDcaZ);
+      man->AddHistogram(classStr.Data(), "DCAz_Pt", "DCAz", kFALSE, 100, -3.0, 3.0, AliReducedVarManager::kDcaZ, 50, 0.0, 5.0, AliReducedVarManager::kPt);
+      
+        man->AddHistogram(classStr.Data(),"ITSncls", "ITS nclusters", kFALSE, 7,-0.5,6.5,AliReducedVarManager::kITSncls);
+        man->AddHistogram(classStr.Data(),"ITSnclsShared", "ITS nclusters shared", kFALSE, 7,-0.5,6.5,AliReducedVarManager::kITSnclsShared);
+        man->AddHistogram(classStr.Data(),"Eta_Phi_ITSncls_prof","ITS <nclusters> vs (#eta,#phi)",kTRUE,
+                     36, -0.9, 0.9, AliReducedVarManager::kEta, 90, 0.0, 2.0*TMath::Pi(), AliReducedVarManager::kPhi, 7, -0.5, 6.5, AliReducedVarManager::kITSncls);
+        man->AddHistogram(classStr.Data(),"Eta_Phi_ITSnclsShared_prof","ITS <nclusters-shared> vs (#eta,#phi)",kTRUE,
+                          36, -0.9, 0.9, AliReducedVarManager::kEta, 90, 0.0, 2.0*TMath::Pi(), AliReducedVarManager::kPhi, 7, -0.5, 6.5, AliReducedVarManager::kITSnclsShared);
+	man->AddHistogram(classStr.Data(),"ITSchi2", "ITS #chi^{2}", kFALSE, 200,0.0,50.0, AliReducedVarManager::kITSchi2);
+        man->AddHistogram(classStr.Data(),"ITSchi2_RunID_prof","",kTRUE, gkNRuns, -0.5, -0.5+gkNRuns, AliReducedVarManager::kRunID, 10, 0., 10., AliReducedVarManager::kITSchi2);
+        man->AddHistogram(classStr.Data(),"ITSchi2_ITSncls", "ITS #chi^{2} vs ITS clusters", kFALSE, 100,0.0,100.0, AliReducedVarManager::kITSchi2,7,-0.5,6.5, AliReducedVarManager::kITSncls);
+	man->AddHistogram(classStr.Data(),"Eta_Phi_ITSchi2_prof","ITS <#chi^{2}> vs (#eta,#phi)",kTRUE,
+                     36, -0.9, 0.9, AliReducedVarManager::kEta, 90, 0.0, 2.0*TMath::Pi(), AliReducedVarManager::kPhi, 100, 0.0, 1000, AliReducedVarManager::kITSchi2);        
+        man->AddHistogram(classStr.Data(),"Chi2TPCConstrainedVsGlobal","",kFALSE,200,0.,200.,AliReducedVarManager::kChi2TPCConstrainedVsGlobal);
+        
+        man->AddHistogram(classStr.Data(),"TPCncls","",kFALSE,160,-0.5,159.5,AliReducedVarManager::kTPCncls);
+        man->AddHistogram(classStr.Data(),"TPCncls_RunID_prof","",kTRUE, gkNRuns, -0.5, -0.5+gkNRuns, AliReducedVarManager::kRunID, 10, 0., 10., AliReducedVarManager::kTPCncls);
+	man->AddHistogram(classStr.Data(),"TPCcrossedRows","", kFALSE, 160,-0.5,159.5,AliReducedVarManager::kTPCcrossedRows);
+        man->AddHistogram(classStr.Data(),"TPCfindableClusters","", kFALSE, 160,-0.5,159.5,AliReducedVarManager::kTPCnclsF);
+        man->AddHistogram(classStr.Data(),"TPCcrossedRowsOverFindableClusters","", kFALSE, 200,0.0,1.5,AliReducedVarManager::kTPCcrossedRowsOverFindableClusters);
+	man->AddHistogram(classStr.Data(),"TPCnclsShared","",kFALSE, 160,-0.5,159.5,AliReducedVarManager::kTPCnclsShared);
+        man->AddHistogram(classStr.Data(),"TPCnclsSharedRatio","",kFALSE, 200,0.,1.,AliReducedVarManager::kTPCnclsSharedRatio);        
+        
+        man->AddHistogram(classStr.Data(),"TPCchi2","",kFALSE, 200,0.0,10.0,AliReducedVarManager::kTPCchi2);
+        man->AddHistogram(classStr.Data(),"TPCchi2_Pt","",kFALSE, 200,0.0,10.0,AliReducedVarManager::kTPCchi2, 100, 0., 10.0, AliReducedVarManager::kPt);
+        man->AddHistogram(classStr.Data(),"TPCchi2_TPCncls", "TPC #chi^{2} vs TPC clusters", kFALSE, 100,0.0,10.0, AliReducedVarManager::kTPCchi2,160,0.,160., AliReducedVarManager::kTPCncls);
+        man->AddHistogram(classStr.Data(),"TPCsegments","",kFALSE, 9,0.0,9.0,AliReducedVarManager::kTPCNclusBitsFired);
+
+        man->AddHistogram(classStr.Data(),"Eta_Phi_TPCncls_prof","TPC <nclusters> vs (#eta,#phi)",kTRUE,
+                     36, -0.9, 0.9, AliReducedVarManager::kEta, 90, 0.0, 2.0*TMath::Pi(), AliReducedVarManager::kPhi, 160, -0.5, 159.5, AliReducedVarManager::kTPCncls);    
+	man->AddHistogram(classStr.Data(),"Eta_Phi_TPCcrossedRows_prof","TPC <n crossed rows> vs (#eta,#phi)",kTRUE,
+                     36, -0.9, 0.9, AliReducedVarManager::kEta, 90, 0.0, 2.0*TMath::Pi(), AliReducedVarManager::kPhi, 160, -0.5, 159.5, AliReducedVarManager::kTPCcrossedRows);
+	man->AddHistogram(classStr.Data(),"Eta_Phi_TPCnclsF_prof","TPC <nclusters findable> vs (#eta,#phi)",kTRUE,
+                     36, -0.9, 0.9, AliReducedVarManager::kEta, 90, 0.0, 2.0*TMath::Pi(), AliReducedVarManager::kPhi, 160, -0.5, 159.5, AliReducedVarManager::kTPCnclsF);
+	man->AddHistogram(classStr.Data(),"Eta_Phi_TPCchi2_prof","TPC <#chi^{2}> vs (#eta,#phi)",kTRUE,
+                     36, -0.9, 0.9, AliReducedVarManager::kEta, 90, 0.0, 2.0*TMath::Pi(), AliReducedVarManager::kPhi, 160, -0.5, 159.5, AliReducedVarManager::kTPCchi2);
+        man->AddHistogram(classStr.Data(),"Eta_Phi_TPCchi2","TPC #chi^{2} vs (#eta,#phi)",kFALSE,
+                          36, -0.9, 0.9, AliReducedVarManager::kEta, 90, 0.0, 2.0*TMath::Pi(), AliReducedVarManager::kPhi, 100, 0., 10.0, AliReducedVarManager::kTPCchi2);
+        man->AddHistogram(classStr.Data(),"TPCsignal_Pin","TPC dE/dx vs. inner param P",kFALSE,
+                     300,0.0,30.0,AliReducedVarManager::kPin,200,-0.5,199.5,AliReducedVarManager::kTPCsignal);
+	man->AddHistogram(classStr.Data(),"TPCsignalN","",kFALSE,160,-0.5,159.5,AliReducedVarManager::kTPCsignalN);
+	man->AddHistogram(classStr.Data(),"Eta_Phi_TPCsignalN_prof","TPC <nclusters pid> vs (#eta,#phi)",kTRUE,
+                     36, -0.9, 0.9, AliReducedVarManager::kEta, 90, 0.0, 2.0*TMath::Pi(), AliReducedVarManager::kPhi, 160, -0.5, 159.5, AliReducedVarManager::kTPCsignalN);    
+        man->AddHistogram(classStr.Data(),"TPCnsigElectron_Pin","TPC N_{#sigma} electron vs. inner param P",kFALSE,
+                     100,0.0,10.0,AliReducedVarManager::kPin,100,-5.0,5.0,AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron);
+        man->AddHistogram(classStr.Data(),"TPCnsigElectron_Eta","TPC N_{#sigma} electron vs. #eta",kFALSE,
+                          36,-0.9,0.9,AliReducedVarManager::kEta,100,-5.0,5.0,AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron);
+        man->AddHistogram(classStr.Data(),"TOFbeta_P","TOF #beta vs P",kFALSE,
+                     200,0.0,20.0,AliReducedVarManager::kP, 220,0.0,1.1,AliReducedVarManager::kTOFbeta);
+        
+        man->AddHistogram(classStr.Data(),"TPCchi2_ITSchi2","",kFALSE, 100,0.0,10.0,AliReducedVarManager::kTPCchi2, 100,0.0,40.0,AliReducedVarManager::kITSchi2);
+        man->AddHistogram(classStr.Data(),"ITSchi2_Chi2TPCconstrainedVsGlobal","",kFALSE, 500,0.0,1000.0,AliReducedVarManager::kChi2TPCConstrainedVsGlobal, 100,0.0,40.0,AliReducedVarManager::kITSchi2);
+        man->AddHistogram(classStr.Data(),"TPCchi2_Chi2TPCconstrainedVsGlobal","",kFALSE, 500,0.0,1000.0,AliReducedVarManager::kChi2TPCConstrainedVsGlobal, 100,0.0,10.0,AliReducedVarManager::kTPCchi2);
+        
+        if(classStr.Contains("MCTruth")) {
+          man->AddHistogram(classStr.Data(), "PtMC", "p_{T} MC", kFALSE, 150, 0., 15.0, AliReducedVarManager::kPtMC);
+          man->AddHistogram(classStr.Data(), "PtRec_PtMC", "p_{T} MC vs p_{T} reconstructed", kFALSE, 150, 0., 15.0, AliReducedVarManager::kPtMC, 150, 0., 15.0, AliReducedVarManager::kPt);
+          man->AddHistogram(classStr.Data(), "PhiMC", "#varphi MC", kFALSE, 180, 0., 6.3, AliReducedVarManager::kPhiMC);
+          man->AddHistogram(classStr.Data(), "PhiRec_PhiMC", "#varphi MC vs #varphi reconstructed", kFALSE, 180, 0., 6.3, AliReducedVarManager::kPhiMC, 180, 0., 6.3, AliReducedVarManager::kPhi);
+          man->AddHistogram(classStr.Data(), "EtaMC", "#eta MC", kFALSE, 100, -1.0, 1.0, AliReducedVarManager::kEtaMC);
+          man->AddHistogram(classStr.Data(), "EtaRec_EtaMC", "#eta MC vs #eta reconstructed", kFALSE, 100, -1.0, 1.0, AliReducedVarManager::kEtaMC, 100, -1.0, 1.0, AliReducedVarManager::kEta);          
+          man->AddHistogram(classStr.Data(), "PDGcode0", "PDG code of the track", kFALSE, 12000, -6000., 6000.0, AliReducedVarManager::kPdgMC);
+          man->AddHistogram(classStr.Data(), "PDGcode1", "PDG code of the track's mother", kFALSE, 12000, -6000., 6000.0, AliReducedVarManager::kPdgMC+1);
+          man->AddHistogram(classStr.Data(), "PDGcode2", "PDG code of the track's grand-mother", kFALSE, 12000, -6000., 6000.0, AliReducedVarManager::kPdgMC+2);
+          man->AddHistogram(classStr.Data(), "PDGcode3", "PDG code of the track's grand-grand mother", kFALSE, 12000, -6000., 6000.0, AliReducedVarManager::kPdgMC+3);
+        }
+      continue;
+    }  // end if "TrackQA"
+        
+     Int_t vars[3] = {AliReducedVarManager::kMass, AliReducedVarManager::kPt, AliReducedVarManager::kCentVZERO};
+       
+    TArrayD pairHistBinLimits[3];
+    pairHistBinLimits[0] = TArrayD(gkNMassBins, gMassBins);
+    pairHistBinLimits[1] = TArrayD(gkNPtBins, gPtLims);
+    pairHistBinLimits[2] = TArrayD(gkNCentBins, gCentLims);
+    
+    // Histograms for pairs
+    if(classStr.Contains("Pair")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      man->AddHistogram(classStr.Data(), "PairInvMass", "Differential pair inv. mass", 3, vars, pairHistBinLimits);
+      if(classStr.Contains("PairSE") || classStr.Contains("PairPrefilterSE")) {
+        man->AddHistogram(classStr.Data(), "PairType", "Pair type", kFALSE, 4, -0.5, 3.5, AliReducedVarManager::kPairType);
+	man->AddHistogram(classStr.Data(), "Mass", "Invariant mass", kFALSE, gkNMassBins-1, gMassBins, AliReducedVarManager::kMass);
+        man->AddHistogram(classStr.Data(), "Pt", "", kFALSE, 1000, 0.0, 10.0, AliReducedVarManager::kPt);
+        man->AddHistogram(classStr.Data(), "Pt_coarse", "", kFALSE, 20, 0.0, 20.0, AliReducedVarManager::kPt);
+	man->AddHistogram(classStr.Data(), "Rapidity", "Rapidity", kFALSE, 240, -1.2, 1.2, AliReducedVarManager::kRap);
+	man->AddHistogram(classStr.Data(), "Phi", "Azimuthal distribution", kFALSE, 315, 0.0, 6.3, AliReducedVarManager::kPhi);
+      }   // end if "QA"
+      
+      if(classStr.Contains("MCTruth")) {
+         man->AddHistogram(classStr.Data(), "PtMC", "p_{T} MC", kFALSE, 1000, 0., 10.0, AliReducedVarManager::kPtMC);
+         man->AddHistogram(classStr.Data(), "PtMC_coarse", "p_{T} MC", kFALSE, 20, 0., 20.0, AliReducedVarManager::kPtMC);
+         man->AddHistogram(classStr.Data(), "MassMC_Mass", "Invariant mass, MC vs reconstructed", kFALSE, 150, 2.0, 3.5, AliReducedVarManager::kMass,
+            150, 2.0, 3.5, AliReducedVarManager::kMassMC);
+         man->AddHistogram(classStr.Data(), "PtMC_Pt", "pair pT, MC vs reconstructed", kFALSE, 150, 0.0, 15., AliReducedVarManager::kPt,
+                           150, 0.0, 15.0, AliReducedVarManager::kPtMC);
+         man->AddHistogram(classStr.Data(), "PtMC_MassMC", "", kFALSE, 100, 0.0, 1., AliReducedVarManager::kPtMC,
+                           30, 2.7, 3.3, AliReducedVarManager::kMassMC);
+         man->AddHistogram(classStr.Data(), "Pt_Mass", "", kFALSE, 100, 0.0, 1., AliReducedVarManager::kPt,
+                           30, 2.7, 3.3, AliReducedVarManager::kMass);
+         man->AddHistogram(classStr.Data(), "PtMC_Mass", "", kFALSE, 100, 0.0, 1., AliReducedVarManager::kPtMC,
+                           30, 2.7, 3.3, AliReducedVarManager::kMass);
+         man->AddHistogram(classStr.Data(), "Pt_MassMC", "", kFALSE, 100, 0.0, 1., AliReducedVarManager::kPt,
+                           30, 2.7, 3.3, AliReducedVarManager::kMassMC);
+         man->AddHistogram(classStr.Data(), "PtMC_Pt_lowPtZoom", "pair pT, MC vs reconstructed", kFALSE, 100, 0.0, 0.5, AliReducedVarManager::kPt,
+                           100, 0.0, 0.5, AliReducedVarManager::kPtMC);
+         man->AddHistogram(classStr.Data(), "PtMC_Pt_Mass", "pair pT, MC vs reconstructed, vs mass", kFALSE, 100, 0.0, 0.5, AliReducedVarManager::kPt,
+                           100, 0.0, 0.5, AliReducedVarManager::kPtMC, 15, 2.72, 3.32, AliReducedVarManager::kMass);
+         man->AddHistogram(classStr.Data(), "PtMC_Pt_Mass_coarse", "pair pT, MC vs reconstructed, vs mass", kFALSE, 25, 0.0, 0.5, AliReducedVarManager::kPt,
+                           25, 0.0, 0.5, AliReducedVarManager::kPtMC, 15, 2.72, 3.32, AliReducedVarManager::kMass);
+         
+         man->AddHistogram(classStr.Data(), "Mass_Pt_CentVZERO", "", kFALSE, gkNMassBins-1, gMassBins, AliReducedVarManager::kMass, gkNPtBins-1, gPtLims, AliReducedVarManager::kPt, gkNCentBins-1, gCentLims, AliReducedVarManager::kCentVZERO);
+      }
+      
+      continue;
+    }   // end if for Pair classes of histograms
+  }  // end loop over histogram classes
+}

--- a/PWGDQ/reducedTree/macros/AddTask_iarsene_testTask.C
+++ b/PWGDQ/reducedTree/macros/AddTask_iarsene_testTask.C
@@ -48,7 +48,7 @@ AliAnalysisTask* AddTask_iarsene_testTask(Bool_t isAliRoot=kTRUE, Int_t runMode=
        mgr->ConnectInput(task, 0, cReducedEvent);
   
      AliAnalysisDataContainer *cOutputHist = mgr->CreateContainer("testHistos", THashList::Class(),
-                                                                  AliAnalysisManager::kOutputContainer, "dstAnalysisHistograms.root");
+                                                                  AliAnalysisManager::kOutputContainer, "AnalysisHistograms_testTask.root");
      mgr->ConnectOutput(task, 1, cOutputHist );
   }
   
@@ -97,9 +97,12 @@ void Setup(AliReducedAnalysisTest* processor, TString prod /*="LHC10h"*/) {
   // add pure MC filter names
   if(processor->ProcessMC()) {
      processor->AddMCBitNames("JpsiInclusive;JpsiFromB;JpsiNotFromB;");
-     processor->AddMCBitNames("JpsiInclusiveRadiative;JpsiInclusiveNonRadiative;JpsiFromBRadiative;JpsiFromBNonRadiative;");
+     processor->AddMCBitNames("JpsiInclusiveRadiative;JpsiInclusiveNonRadiative;");
+     processor->AddMCBitNames("electronFromJpsi;photonFromJpsiDecay;");
   }
-  processor->SetTrackFilterBitNames("JpsiElectrons;AssocHadr;AssocHadr_noITS;AssocHadr_Pion;AssocHadr_Kaon;AssocHadr_Proton;");
+  processor->AddTrackFilterBitNames("basicCuts;spdAny;spdFirst;tpc100;tpc120;tpcChi2_3;itsChi2_10;");
+  processor->AddTrackFilterBitNames("eleInclusion_35;eleInclusion_30;protRej_30;protRej_35;protRej_40;");
+  processor->AddTrackFilterBitNames("pionRej_30;pionRej_35;pionRej_40;basicCutRandom;");
   
   SetupHistogramManager(processor, processor->GetHistogramManager(), prod);
 }

--- a/PWGDQ/reducedTree/macros/runAnalysisTrain.C
+++ b/PWGDQ/reducedTree/macros/runAnalysisTrain.C
@@ -22,7 +22,7 @@ TChain* makeChain(const Char_t* filename, const Char_t* inputType);
 //______________________________________________________________________________________________________________________________________
 void runAnalysisTrain(const Char_t* infile, const Char_t* runmode = "local", const Char_t* inputType="ESD", Bool_t hasMC = kFALSE,
                                      Int_t reducedEventType = -1, Bool_t writeTree = kFALSE, TString tasks="dst", TString prod = "LHC10h",
-                      Int_t nEntries=1234567890, Int_t firstEntry=0, TString pathForMacros="$ALICE_PHYSICS/PWGDQ/reducedTree/macros")
+                      Int_t nEntries=-1, Int_t firstEntry=0, TString pathForMacros="$ALICE_PHYSICS/PWGDQ/reducedTree/macros")
 {
    //
    // infile: list of input files if mode is local, or list of runs for job submission if mode is grid
@@ -230,6 +230,7 @@ void runAnalysisTrain(const Char_t* infile, const Char_t* runmode = "local", con
    
    mgr->PrintStatus();
    // Start analysis
+   if(nEntries==-1) nEntries=1234567890;
    if(runmodestr.Contains("local"))
       mgr->StartAnalysis("local", chain, nEntries, firstEntry);
    if(runmodestr.Contains("proof"))


### PR DESCRIPTION
AliReducedBaseTrack
   Added a boolean flag to mark the track as pure MC truth particle
AliReducedTrackCut
   Added possibility to cut on the MC flags of AliReducedBaseTrack
AliReducedTrackInfo
   Small fix
AliReducedAnalysisJpsi2ee
   Major update of Monte Carlo information handling which allows the study of multiple simultanoues
   MC signals with their kine cuts and which can be set dynamically in the AddTask
AliMixingHandler
   Small fix to allow adding variable binning also as doubles
AliAnalysisTaskReducedTreeMaker
   Small fix to set the new boolean flag implemented for the base track;
   The MC match map for signals is also written for reconstructed tracks
AliResonanceFits
   Implemented setter for the MC signal shape;
   Implemented getters to retrieve output information and histograms
AliReducedVarManager
   Small fix

AddTask macros updated with the latest implemeted features
macros/AddTask_iarsene_dstXeXe.C : tree maker for Xe-Xe trees
macros/AddTask_iarsene_testTask  :  the test task
macros/AddTask_iarsene_jpsi2ee_XeXe.C : jpsi Raa analysis for the Xe-Xe run