### PR TITLE
Aditional SPD information in CEPEventBuffer and CEPTrackBuffer

### DIFF
--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliAnalysisTaskCEP.cxx
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliAnalysisTaskCEP.cxx
@@ -747,8 +747,9 @@ void AliAnalysisTaskCEP::UserExec(Option_t *)
   //     fnTOFmaxipads,firedTriggerClasses.Contains("CCUP25-B-SPD1-CENTNOTRD"));
   // }
   
-  // number of tracklets
+  // number of tracklets and singles
   Int_t nTracklets = mult->GetNumberOfTracklets();
+  Int_t nSingles   = ((AliMultiplicity*)mult)->GetNumberOfSingleClusters();
   
   // get number of ITS cluster
   Short_t nITSCluster[6] = {0};
@@ -1109,6 +1110,7 @@ void AliAnalysisTaskCEP::UserExec(Option_t *)
       fCEPEvent->AddTrl2Tr(vec,ii);
     }
     
+    fCEPEvent->SetnSingles(nSingles);
     fCEPEvent->SetnResiduals(fCEPUtil->GetResiduals(fESDEvent));
     fCEPEvent->SetnMSelection(nMartinSel);
     fCEPEvent->SetnV0(fNumV0s);

--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliAnalysisTaskCEP.h
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliAnalysisTaskCEP.h
@@ -110,6 +110,7 @@ private:
 
   CEPEventBuffer *fCEPEvent;      //! event buffer
   TObjArray      *fTracks;        //! array of tracks
+  TObjArray      *fTrl2Tr;        //! array of tracklet-track associations
   TArrayI        *fTrackStatus;   //! array of TrackStatus
   TString         fLHCPeriod;     //! LHC period
   

--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPBase.h
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliCEPBase.h
@@ -66,7 +66,7 @@ class AliCEPBase : public TObject {
 
     // type of vertex
     kVtxUnknown         = 0,
-    kVtxSPD             = BIT(0),  // from ITS
+    kVtxSPD             = BIT(0),  // from SPD tracklets
     kVtxTracks          = BIT(1),  // from tracks
     kVtxErrRes          = BIT(2),  // z-resolution of SPD vertex is out-of-bounds
     kVtxErrDif          = BIT(3),  // difference in z between SPD and track

--- a/PWGUD/DIFFRACTIVE/CEPdevel/CEPEventBuffer.cxx
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/CEPEventBuffer.cxx
@@ -36,6 +36,7 @@ CEPEventBuffer::CEPEventBuffer()
   , fnTOFmaxipads(0)
   , fEventCondition(AliCEPBase::kETBaseLine)
   , fnTracklets(0)
+  , fTrl2Tr(new TObjArray())
   , fnTracks(0)
   , fnTracksCombined(0)
   , fnTracksITSpure(0)
@@ -50,6 +51,7 @@ CEPEventBuffer::CEPEventBuffer()
   , fCEPTracks(new TObjArray())
 {
 
+  for (Int_t ii=0; ii<6; ii++) fnITSCluster[ii] = 0;
   for (Int_t ii=0; ii<4; ii++) fFiredChips[ii] = 0;
 
 }
@@ -64,6 +66,14 @@ CEPEventBuffer::~CEPEventBuffer()
 		fCEPTracks->Clear();
 		delete fCEPTracks;
 		fCEPTracks = 0x0;
+	}
+
+	// delete fTrl2Tr and all the associations it contains
+  if (fTrl2Tr) {
+		fTrl2Tr->SetOwner(kTRUE);
+		fTrl2Tr->Clear();
+		delete fTrl2Tr;
+		fTrl2Tr = 0x0;
 	}
 
 }
@@ -82,6 +92,7 @@ void CEPEventBuffer::Reset()
   fCollissionType  = AliCEPBase::kBinEventUnknown;
   fMagnField       = AliCEPBase::kdumval;
   fFiredTriggerClasses = TString("");
+  for (Int_t ii=0; ii<6; ii++) fnITSCluster[ii] = 0;
   for (Int_t ii=0; ii<4; ii++) fFiredChips[ii] = 0;
 
   // general event features
@@ -92,6 +103,8 @@ void CEPEventBuffer::Reset()
   fisDGTrigger     = kFALSE;
 
   fnTracklets     = 0;
+  fTrl2Tr->SetOwner(kTRUE);
+  fTrl2Tr->Clear();
   fnTracks        = 0;
   fnTracksCombined= 0;
   fnTracksITSpure = 0;

--- a/PWGUD/DIFFRACTIVE/CEPdevel/CEPEventBuffer.h
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/CEPEventBuffer.h
@@ -46,6 +46,8 @@ class CEPEventBuffer : public TObject {
 
     // summary track information
     Int_t fnTracklets;      // total number of tracklets
+    Int_t fnSingles;        // number of clusters on SPD layer 1 and 2
+                            // not associated with a tracklet on other SPD 
     Int_t fnTracksTotal;    // total number of tracks
     Int_t fnTracks;         // number of tracks in fCEPTracks
     Int_t fnTracksCombined; // ITS+TPC
@@ -109,6 +111,7 @@ class CEPEventBuffer : public TObject {
     void SetnTracksTotal(Int_t ntrks)   { fnTracksTotal = ntrks; }
     
     void SetnTracklets(Int_t ntrklts)   { fnTracklets = ntrklts; }
+    void SetnSingles(Int_t nsingle)     { fnSingles = nsingle; }
     void AddTrl2Tr(TVector2 *vec, Int_t pos)        {
       fTrl2Tr->AddAt((TObject*)vec,pos);
     }
@@ -168,6 +171,7 @@ class CEPEventBuffer : public TObject {
     Int_t GetnTracksCombined() const { return fnTracksCombined; }
     Int_t GetnITSpureTracks()  const { return fnTracksITSpure; }
     Int_t GetnTracklets()      const { return fnTracklets; }
+    Int_t GetnSingles()        const { return fnSingles; }
     TObjArray* GetTrl2Tr()           { return fTrl2Tr; }
     Int_t GetnResiduals()      const { return fnResiduals; }
     Int_t GetnMSelection()     const { return fnMSelection; }

--- a/PWGUD/DIFFRACTIVE/CEPdevel/CEPEventBuffer.h
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/CEPEventBuffer.h
@@ -33,6 +33,8 @@ class CEPEventBuffer : public TObject {
     Bool_t fPhysel;
     Bool_t fisPileup;
     Bool_t fisClusterCut;
+    Short_t fnITSCluster[6];  // Number of ITS clusters on all 6 layers
+                              // and number of offline fired chips
     Short_t fFiredChips[4];   // Number of FastOR chips in the two SPD layers
                               // and number of offline fired chips
     Bool_t fisDGTrigger;
@@ -68,6 +70,9 @@ class CEPEventBuffer : public TObject {
     
     // list of tracks
     TObjArray *fCEPTracks;
+    // tracklet - track associations
+    TObjArray *fTrl2Tr;
+    
     
   public:
     CEPEventBuffer();
@@ -84,9 +89,11 @@ class CEPEventBuffer : public TObject {
     void SetMagnField(Double_t magnf)   { fMagnField = magnf; }
     void SetFiredTriggerClasses(TString ftc)   { fFiredTriggerClasses = ftc; }
     void SetPFFlags(AliVEvent *Event);
+    void SetnITSCluster(Short_t nclus[6]) {
+      for (Int_t ii=0; ii<6; ii++) fnITSCluster[ii]=nclus[ii];
+    }
     void SetnFiredChips(Short_t chips[4]) {
-      fFiredChips[0]=chips[0]; fFiredChips[1]=chips[1]; 
-      fFiredChips[2]=chips[2]; fFiredChips[3]=chips[3]; 
+      for (Int_t ii=0; ii<4; ii++) fFiredChips[ii]=chips[ii];
     }
     void SetisSTGTriggerFired(UInt_t stgtrig) { fisSTGTriggerFired = stgtrig; }
     void SetnTOFmaxipads(Int_t nmaxipads) { fnTOFmaxipads = nmaxipads; }
@@ -100,7 +107,12 @@ class CEPEventBuffer : public TObject {
     // the number of tracklets and residuals, as well as the enumber
     // of tracks passing Martin's selection have to be set separately
     void SetnTracksTotal(Int_t ntrks)   { fnTracksTotal = ntrks; }
+    
     void SetnTracklets(Int_t ntrklts)   { fnTracklets = ntrklts; }
+    void AddTrl2Tr(TVector2 *vec, Int_t pos)        {
+      fTrl2Tr->AddAt((TObject*)vec,pos);
+    }
+      
     void SetnResiduals(Int_t nres)      { fnResiduals = nres; }
     void SetnMSelection(Int_t nMsel)    { fnMSelection = nMsel; }
     
@@ -138,6 +150,8 @@ class CEPEventBuffer : public TObject {
     Bool_t* GetPFBGFlagV0() { return fPFBGFlagV0; }
     Bool_t* GetPFBBFlagAD() { return fPFBBFlagAD; }
     Bool_t* GetPFBGFlagAD() { return fPFBGFlagAD; }
+    Short_t GetnITSCluster(Int_t layer) {
+      return (layer>=0 && layer<=5) ? fnITSCluster[layer] : -1; }
     Short_t GetnFiredChips(Int_t layer) {
       return (layer>=0 && layer<=3) ? fFiredChips[layer] : -1; }
     UInt_t  GetisSTGTriggerFired() { return fisSTGTriggerFired; }
@@ -154,6 +168,7 @@ class CEPEventBuffer : public TObject {
     Int_t GetnTracksCombined() const { return fnTracksCombined; }
     Int_t GetnITSpureTracks()  const { return fnTracksITSpure; }
     Int_t GetnTracklets()      const { return fnTracklets; }
+    TObjArray* GetTrl2Tr()           { return fTrl2Tr; }
     Int_t GetnResiduals()      const { return fnResiduals; }
     Int_t GetnMSelection()     const { return fnMSelection; }
 
@@ -207,7 +222,7 @@ class CEPEventBuffer : public TObject {
     CEPTrackBuffer* GetTrack(Int_t ind);
     Bool_t RemoveTrack(Int_t ind);
 
-    ClassDef(CEPEventBuffer, 4)     // CEP event buffer
+    ClassDef(CEPEventBuffer, 5)     // CEP event buffer
 
 };
 

--- a/PWGUD/DIFFRACTIVE/CEPdevel/CEPTrackBuffer.cxx
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/CEPTrackBuffer.cxx
@@ -24,6 +24,7 @@ CEPTrackBuffer::CEPTrackBuffer()
   , fTPCncls(CEPTrackBuffer::kdumval)
   , fTRDncls(CEPTrackBuffer::kdumval)
   , fTPCnclsS(CEPTrackBuffer::kdumval)
+  , finVertex(kFALSE)
   , fZv(CEPTrackBuffer::kdumval)
   , fMomentum(TVector3(0,0,0))
   , fPID(0)
@@ -59,6 +60,7 @@ void CEPTrackBuffer::Reset()
   fTPCncls          = CEPTrackBuffer::kdumval;
   fTRDncls          = CEPTrackBuffer::kdumval;
   fTPCnclsS         = CEPTrackBuffer::kdumval;
+  finVertex         = kFALSE;
   fZv               = CEPTrackBuffer::kdumval;
   fMomentum         = TVector3(0,0,0);
   

--- a/PWGUD/DIFFRACTIVE/CEPdevel/CEPTrackBuffer.h
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/CEPTrackBuffer.h
@@ -8,13 +8,15 @@ class CEPTrackBuffer : public TObject {
 
   private:
     // general information
+    UInt_t   fTrackIndex;      // original track index
     UInt_t   fTrackStatus;     // see AliCEPBase.h for definition of bits
     Double_t fTOFBunchCrossing;// TOF Bunch Crossing time
     Int_t    fChargeSign;      // charge sign
-    Int_t    fITSncls;         // number of ITS clusters
+    UChar_t  fITSncls;         // ITS cluster map one bit per layer
     Int_t    fTPCncls;         // number of TPC clusters
     Int_t    fTRDncls;         // number of TRD clusters
     Int_t    fTPCnclsS;        // number of shared TPC clusters
+    Bool_t   finVertex;        // is used in vertex determination
     Double_t fZv;              // closest approach to vertex in z
     TVector3 fMomentum;        // momentum vector
    
@@ -51,16 +53,18 @@ class CEPTrackBuffer : public TObject {
     // Modifiers
     void Reset();
     
+    void SetTrackIndex(UInt_t trkind) { fTrackIndex = trkind; }
     void SetTrackStatus(UInt_t TTest) { fTrackStatus = TTest; }
     void SetTrackStatus(UInt_t TTest, Bool_t yn)
       { fTrackStatus = (fTrackStatus & ~TTest) | (yn*TTest); }
     void SetTOFBunchCrossing(Double_t tofbc) { fTOFBunchCrossing = tofbc; }
 
     void SetChargeSign(Int_t chs)    { fChargeSign = chs; }
-    void SetITSncls(Int_t ncls)      { fITSncls = ncls; }
+    void SetITSncls(UChar_t ncls)    { fITSncls = ncls; }
     void SetTPCncls(Int_t ncls)      { fTPCncls = ncls; }
     void SetTRDncls(Int_t ncls)      { fTRDncls = ncls; }
     void SetTPCnclsS(Int_t nclss)    { fTPCnclsS = nclss; }
+    void SetinVertex(Bool_t invert)  { finVertex = invert; }
     void SetZv(Int_t zv)             { fZv = zv; }
     void SetMomentum(TVector3 mom)   { fMomentum = mom; }
     
@@ -81,15 +85,17 @@ class CEPTrackBuffer : public TObject {
     void SetMCMomentum(TVector3 mom)    { fMCMomentum = mom; }
     
     // Accessors
+    UInt_t GetTrackindex()        const { return fTrackIndex; }
     UInt_t GetTrackStatus()       const { return fTrackStatus; }
     Bool_t TTisSet(UInt_t TTest)  const { return (fTrackStatus & TTest) == TTest; }
     Double_t GetTOFBunchCrossing()const { return fTOFBunchCrossing; }
 
     Int_t GetChargeSign()  const { return fChargeSign; }
-    Int_t GetITSncls()     const { return fITSncls; }
+    UChar_t GetITSncls()   const { return fITSncls; }
     Int_t GetTPCncls()     const { return fTPCncls; }
     Int_t GetTRDncls()     const { return fTRDncls; }
     Int_t GetTPCnclsS()    const { return fTPCnclsS; }
+    Bool_t GetinVertex()   const { return finVertex; }
     Double_t GetZv()       const { return fZv; }
     TVector3 GetMomentum() const { return fMomentum; }
 
@@ -109,7 +115,7 @@ class CEPTrackBuffer : public TObject {
     Float_t GetMCMass()         const { return fMCMass; }
     TVector3 GetMCMomentum()    const { return fMCMomentum; }
     
-  ClassDef(CEPTrackBuffer,1)     // CEP track buffer
+  ClassDef(CEPTrackBuffer, 5)     // CEP track buffer
 
 };
 


### PR DESCRIPTION
the additional SPD parameters allow to study the SPD behaviour in detail, like ...
. ITS hits in all layers
. tracklets
. singles
. tracks associated with tracklets
. track used for vertex determination

