### PR TITLE
Fix multiple-deletes for TList in ROOT v6-12-04

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecision.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecision.cxx
@@ -51,6 +51,10 @@ AliEmcalTriggerDecision::AliEmcalTriggerDecision(const char *name, const char *t
   fAcceptedPatches.SetOwner(kFALSE);
 }
 
+AliEmcalTriggerDecision::~AliEmcalTriggerDecision(){
+  fAcceptedPatches.Clear("nodelete");
+}
+
 void AliEmcalTriggerDecision::AddAcceptedPatch(AliEMCALTriggerPatchInfo * const acceptedPatch){
   fAcceptedPatches.Add(acceptedPatch);
 }

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecision.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecision.h
@@ -72,7 +72,7 @@ public:
   /**
    * @brief Destructor
    */
-  virtual ~AliEmcalTriggerDecision() {}
+  virtual ~AliEmcalTriggerDecision();
 
   /**
    * @brief Get the highest energetic trigger patch of the event firing the trigger

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerDecisionContainer.cxx
@@ -38,18 +38,18 @@ AliEmcalTriggerDecisionContainer::AliEmcalTriggerDecisionContainer():
   TNamed(),
   fContainer()
 {
-  fContainer.SetOwner();
+  fContainer.SetOwner(kTRUE);
 }
 
 AliEmcalTriggerDecisionContainer::AliEmcalTriggerDecisionContainer(const char* name):
   TNamed(name, ""),
   fContainer()
 {
-  fContainer.SetOwner();
+  fContainer.SetOwner(kTRUE);
 }
 
 void AliEmcalTriggerDecisionContainer::Reset() {
-  fContainer.Clear();
+  if(fContainer.GetEntries()) fContainer.Clear();
 }
 
 void AliEmcalTriggerDecisionContainer::AddTriggerDecision(AliEmcalTriggerDecision* const decision) {


### PR DESCRIPTION
The promise that a TList will not delete objects
where it is not owner of seems to be invalid in
ROOT v6-12-04 as it tried to delete obeject in
a list where SetOwner was explicitly set to false.
When calling Clear it has to be protected with
the option "nodelete".