### PR TITLE
Bug fix: define PDGcode variables as Long_t instead of Short_t. 

### DIFF
--- a/PWGLF/RESONANCES/AliRsnCut.cxx
+++ b/PWGLF/RESONANCES/AliRsnCut.cxx
@@ -46,6 +46,34 @@ AliRsnCut::AliRsnCut(const char *name, RSNTARGET target) :
 
 //______________________________________________________________________________
 AliRsnCut::AliRsnCut
+(const char *name, RSNTARGET target, Long_t imin, Long_t imax, Double_t dmin, Double_t dmax) :
+   AliRsnTarget(name, target),
+   fMinI(imin),
+   fMaxI(imax),
+   fMinD(dmin),
+   fMaxD(dmax),
+   fMinIptdep(0),
+   fMaxIptdep(0),
+   fMinDptdep(0),
+   fMaxDptdep(0),
+   fCutValueI(0),
+   fCutValueD(0.0),
+   fPtDepCut(kFALSE),
+   fRefPtValueD(0.0),
+   fMaxPt(1E20),
+   fMinPt(0.0),
+   fPtDepCutMaxFormula(""),
+   fPtDepCutMinFormula(""),
+   fCutResult(kTRUE)
+{
+//
+// Constructor with arguments.
+// This is provided to allow a quick setting of all data members.
+//
+}
+
+//______________________________________________________________________________
+AliRsnCut::AliRsnCut
 (const char *name, RSNTARGET target, Int_t imin, Int_t imax, Double_t dmin, Double_t dmax) :
    AliRsnTarget(name, target),
    fMinI(imin),

--- a/PWGLF/RESONANCES/AliRsnCut.h
+++ b/PWGLF/RESONANCES/AliRsnCut.h
@@ -24,6 +24,7 @@ class AliRsnCut : public AliRsnTarget {
 public:
 
    AliRsnCut(const char *name = "dummy", RSNTARGET target = AliRsnTarget::kTargetTypes);
+   AliRsnCut(const char *name, RSNTARGET target, Long_t    imin, Long_t    imax = 0 , Double_t dmin = 0., Double_t dmax = 0.);
    AliRsnCut(const char *name, RSNTARGET target, Int_t    imin, Int_t    imax = 0 , Double_t dmin = 0., Double_t dmax = 0.);
    AliRsnCut(const char *name, RSNTARGET target, Double_t dmin, Double_t dmax = 0., Int_t    imin = 0 , Int_t    imax = 0);
    AliRsnCut(const AliRsnCut &copy);

--- a/PWGLF/RESONANCES/AliRsnCutEventUtils.cxx
+++ b/PWGLF/RESONANCES/AliRsnCutEventUtils.cxx
@@ -25,8 +25,8 @@ AliRsnCut(name, AliRsnCut::kEvent),
   fCheckPileUppA2013(checkPileUppA2013),
   fUseMVPlpSelection(kFALSE),
   fMinPlpContribMV(5),
-  fMinPlpContribSPD(5),
   fCheckPileUpMultBins(kFALSE),
+  fMinPlpContribSPD(5),
   fUseVertexSelection2013pA(kFALSE),
   fUseVertexSelection2013pAspectra(kFALSE),
   fMaxVtxZ(10.0),
@@ -59,8 +59,8 @@ AliRsnCutEventUtils::AliRsnCutEventUtils(const AliRsnCutEventUtils &copy) :
   fCheckPileUppA2013(copy.fCheckPileUppA2013),
   fUseMVPlpSelection(copy.fUseMVPlpSelection),
   fMinPlpContribMV(copy.fMinPlpContribMV),
-  fMinPlpContribSPD(copy.fMinPlpContribSPD),
   fCheckPileUpMultBins(copy.fCheckPileUpMultBins),
+  fMinPlpContribSPD(copy.fMinPlpContribSPD),
   fUseVertexSelection2013pA(copy.fUseVertexSelection2013pA),
   fUseVertexSelection2013pAspectra(copy.fUseVertexSelection2013pAspectra),
   fMaxVtxZ(copy.fMaxVtxZ),
@@ -96,8 +96,8 @@ AliRsnCutEventUtils &AliRsnCutEventUtils::operator=(const AliRsnCutEventUtils &c
   fCheckPileUppA2013=copy.fCheckPileUppA2013;
   fUseMVPlpSelection=copy.fUseMVPlpSelection;
   fMinPlpContribMV=copy.fMinPlpContribMV;
-  fMinPlpContribSPD=copy.fMinPlpContribSPD;
   fCheckPileUpMultBins=copy.fCheckPileUpMultBins;
+  fMinPlpContribSPD=copy.fMinPlpContribSPD;
   fUseVertexSelection2013pA=copy.fUseVertexSelection2013pA;
   fUseVertexSelection2013pAspectra=copy.fUseVertexSelection2013pAspectra;
   fMaxVtxZ=copy.fMaxVtxZ;
@@ -259,7 +259,7 @@ Bool_t AliRsnCutEventUtils::IsVertexSelected2013pAIDspectra(AliVEvent *event)
 
 Bool_t AliRsnCutEventUtils::IsPileUpMultBins(){
   if(!fEvent) return kFALSE;
-  AliAODEvent* aodEvt=0;
+  //AliAODEvent* aodEvt=0;
   Bool_t isAOD=fEvent->IsAOD();
   if(isAOD) return kFALSE;//not yet available for AODs
 

--- a/PWGLF/RESONANCES/AliRsnCutPID.cxx
+++ b/PWGLF/RESONANCES/AliRsnCutPID.cxx
@@ -227,7 +227,7 @@ Int_t AliRsnCutPID::PerfectPID(AliRsnDaughter *const daughter)
    if (!daughter->GetRefMC()) return AliPID::kUnknown;
 
    // get the PDG code of the particle
-   Int_t pdg = daughter->GetPDG();
+   Long_t pdg = daughter->GetPDG();
 
    // loop over all species listed in AliPID to find the match
    Int_t i;

--- a/PWGLF/RESONANCES/AliRsnCutTrue.cxx
+++ b/PWGLF/RESONANCES/AliRsnCutTrue.cxx
@@ -12,7 +12,7 @@
 ClassImp(AliRsnCutTrue)
 
 //__________________________________________________________________________________________________
-AliRsnCutTrue::AliRsnCutTrue(const char *name, Int_t pdg) :
+AliRsnCutTrue::AliRsnCutTrue(const char *name, Long_t pdg) :
    AliRsnCut(name, AliRsnTarget::kDaughter, pdg)
 {
 //

--- a/PWGLF/RESONANCES/AliRsnCutTrue.h
+++ b/PWGLF/RESONANCES/AliRsnCutTrue.h
@@ -17,7 +17,7 @@ class AliRsnCutTrue : public AliRsnCut {
 
 public:
 
-   AliRsnCutTrue(const char *name, Int_t pdg);
+   AliRsnCutTrue(const char *name, Long_t pdg);
    AliRsnCutTrue(const char *name, AliRsnDaughter::ESpecies species);
    AliRsnCutTrue(const AliRsnCutTrue &copy);
    AliRsnCutTrue &operator=(const AliRsnCutTrue &copy);
@@ -27,7 +27,7 @@ public:
 
 private:
 
-   ClassDef(AliRsnCutTrue,1)    // AliRsnCutTrue class
+   ClassDef(AliRsnCutTrue, 1)    // AliRsnCutTrue class
 
 };
 

--- a/PWGLF/RESONANCES/AliRsnDaughter.cxx
+++ b/PWGLF/RESONANCES/AliRsnDaughter.cxx
@@ -89,7 +89,7 @@ void AliRsnDaughter::Reset()
 }
 
 //_____________________________________________________________________________
-Int_t AliRsnDaughter::GetPDG()
+Long_t AliRsnDaughter::GetPDG()
 {
 //
 // Return the PDG code of the particle from MC ref (if any).
@@ -186,7 +186,7 @@ const char *AliRsnDaughter::SpeciesName(ESpecies species)
 }
 
 //______________________________________________________________________________
-Int_t AliRsnDaughter::SpeciesPDG(ESpecies species)
+Long_t AliRsnDaughter::SpeciesPDG(ESpecies species)
 {
 //
 // Return the PDG code of a particle species (abs value)
@@ -216,7 +216,7 @@ Double_t AliRsnDaughter::SpeciesMass(ESpecies species)
    TDatabasePDG *db = TDatabasePDG::Instance();
    TParticlePDG *part = 0x0;
 
-   Int_t pdg = SpeciesPDG(species);
+   Long_t pdg = SpeciesPDG(species);
    if (pdg) {
       part = db->GetParticle(pdg);
       return part->Mass();

--- a/PWGLF/RESONANCES/AliRsnDaughter.h
+++ b/PWGLF/RESONANCES/AliRsnDaughter.h
@@ -57,7 +57,7 @@ public:
    // basic getters
    Bool_t          IsOK()          const {return fOK;}
    Int_t           GetLabel()      const {return fLabel;}
-   Int_t           GetMotherPDG()  const {return fMotherPDG;}
+   Long_t          GetMotherPDG()  const {return fMotherPDG;}
    Int_t           GetRsnID()      const {return fRsnID;}
    AliVParticle   *GetRef()              {return fRef;}
    AliVParticle   *GetRefMC()            {return fRefMC;}
@@ -65,8 +65,8 @@ public:
    TLorentzVector &P(Bool_t mc)          {return (mc ? fPsim : fPrec);}
    TLorentzVector &Prec()                {return fPrec;}
    TLorentzVector &Psim()                {return fPsim;}
-   Int_t           GetPDG();
-   Int_t           GetPDGAbs()           {return TMath::Abs(GetPDG());}
+   Long_t          GetPDG();
+   Long_t          GetPDGAbs()           {return TMath::Abs(GetPDG());}
    Int_t           GetID();
    Int_t           GetMother();
 
@@ -76,7 +76,7 @@ public:
    void  SetBad()                      {fOK = kFALSE;}
    void  SetGood()                     {fOK = kTRUE;}
    void  SetLabel(Int_t label)         {fLabel = label;}
-   void  SetMotherPDG(Int_t value)     {fMotherPDG = value;}
+   void  SetMotherPDG(Long_t value)    {fMotherPDG = value;}
    void  SetRsnID(Int_t id)            {fRsnID = id;}
    void  SetRef(AliVParticle *p)       {fRef = p;}
    void  SetRefMC(AliVParticle *p)     {fRefMC = p;}
@@ -121,7 +121,7 @@ public:
    static ERefType    RefType(ESpecies species);
    static Bool_t      IsCharged(ESpecies species) {return (species <= kProton);}
    static const char *SpeciesName(ESpecies species);
-   static Int_t       SpeciesPDG(ESpecies species);
+   static Long_t       SpeciesPDG(ESpecies species);
    static Double_t    SpeciesMass(ESpecies species);
    static EPARTYPE    ToAliPID(ESpecies species);
    static ESpecies    FromAliPID(EPARTYPE species);
@@ -130,7 +130,7 @@ private:
 
    Bool_t         fOK;          // internal utility flag which is kFALSE when this object should not be used
    Int_t          fLabel;       // index of MC particle
-   Int_t          fMotherPDG;   // PDG code of mother (makes sense only if fRefMC is defined)
+   Long_t         fMotherPDG;   // PDG code of mother (makes sense only if fRefMC is defined)
    Int_t          fRsnID;       // internal ID for monitoring purposes
 
    TLorentzVector fPrec;        // 4-momentum for rec
@@ -140,7 +140,7 @@ private:
    AliVParticle  *fRefMC;       // reference to corresponding MC particle
    AliRsnEvent   *fOwnerEvent;  // pointer to owner event
 
-   ClassDef(AliRsnDaughter, 12)
+   ClassDef(AliRsnDaughter, 13)
 };
 
 //__________________________________________________________________________________________________

--- a/PWGLF/RESONANCES/AliRsnDaughterDef.h
+++ b/PWGLF/RESONANCES/AliRsnDaughterDef.h
@@ -50,7 +50,7 @@ public:
    Bool_t MatchesPID(AliRsnDaughter *daughter);
    Bool_t MatchesCharge(AliRsnDaughter *daughter)  const;
    Bool_t MatchesRefType(AliRsnDaughter *daughter) const;
-   Bool_t MatchesPDG(Int_t pdgCode)                  {return (AliRsnDaughter::SpeciesPDG(fPID) == pdgCode);}
+   Bool_t MatchesPDG(Long_t pdgCode)                  {return (AliRsnDaughter::SpeciesPDG(fPID) == pdgCode);}
    Bool_t MatchesChargeS(Short_t charge) const       {return (GetChargeS() == charge);}
    Bool_t MatchesChargeC(Char_t charge)  const       {return (GetChargeC() == charge);}
 

--- a/PWGLF/RESONANCES/AliRsnLoopDaughter.cxx
+++ b/PWGLF/RESONANCES/AliRsnLoopDaughter.cxx
@@ -199,7 +199,7 @@ Int_t AliRsnLoopDaughter::LoopTrueMC(AliRsnEvent *rsn)
    Int_t ipart, count = 0;
    TObjArrayIter next(&fOutputs);
    AliRsnListOutput *out = 0x0;
-   Int_t pdg = AliRsnDaughter::SpeciesPDG(fDef->GetPID());
+   Long_t pdg = AliRsnDaughter::SpeciesPDG(fDef->GetPID());
 
 
    // loop over particles

--- a/PWGLF/RESONANCES/AliRsnLoopPair.cxx
+++ b/PWGLF/RESONANCES/AliRsnLoopPair.cxx
@@ -249,7 +249,7 @@ Bool_t AliRsnLoopPair::IsTrueMother()
 
    // check #1:
    // daughters have same mother with the right PDG code
-   Int_t commonPDG = fMother.CommonMother();
+   Long_t commonPDG = fMother.CommonMother();
    if (commonPDG != fPairDef->GetMotherPDG()) return kFALSE;
    AliDebugClass(1, "Found a true mother");
 

--- a/PWGLF/RESONANCES/AliRsnMiniOutput.h
+++ b/PWGLF/RESONANCES/AliRsnMiniOutput.h
@@ -71,9 +71,9 @@ public:
    Int_t           GetCutID(Int_t i)    const {if (i <= 0) return fCutID [0]; else return fCutID [1];}
    RSNPID          GetDaughter(Int_t i) const {if (i <= 0) return fDaughter[0]; else return fDaughter[1];}
    Double_t        GetMass(Int_t i)     const {return AliRsnDaughter::SpeciesMass(GetDaughter(i));}
-   Int_t           GetPDG(Int_t i)      const {return AliRsnDaughter::SpeciesPDG(GetDaughter(i));}
+   Long_t          GetPDG(Int_t i)      const {return AliRsnDaughter::SpeciesPDG(GetDaughter(i));}
    Int_t           GetCharge(Int_t i)   const {if (i <= 0) return fCharge[0]; else return fCharge[1];}
-   Int_t           GetMotherPDG()       const {return fMotherPDG;}
+   Long_t          GetMotherPDG()       const {return fMotherPDG;}
    Double_t        GetMotherMass()      const {return fMotherMass;}
    Bool_t          GetFillHistogramOnlyInRange() { return fCheckHistRange; }
    Short_t         GetMaxNSisters()           {return fMaxNSisters;}
@@ -83,7 +83,7 @@ public:
    void            SetCutID(Int_t i, Int_t   value)   {if (i <= 0) fCutID [0] = value; else fCutID [1] = value;}
    void            SetDaughter(Int_t i, RSNPID value) {if (i <= 0) fDaughter[0] = value; else fDaughter[1] = value;}
    void            SetCharge(Int_t i, Char_t  value)  {if (i <= 0) fCharge[0] = value; else fCharge[1] = value;}
-   void            SetMotherPDG(Int_t pdg)            {fMotherPDG = pdg;}
+   void            SetMotherPDG(Long_t pdg)           {fMotherPDG = pdg;}
    void            SetMotherMass(Double_t mass)       {fMotherMass = mass;}
    void            SetPairCuts(AliRsnCutSet *set)     {fPairCuts = set;}
    void            SetFillHistogramOnlyInRange(Bool_t fillInRangeOnly) { fCheckHistRange = fillInRangeOnly; }
@@ -118,7 +118,7 @@ private:
    Int_t            fCutID[2];         //  ID of cut set used to select tracks
    RSNPID           fDaughter[2];      //  species of daughters
    Char_t           fCharge[2];        //  required track charge
-   Int_t            fMotherPDG;        //  PDG code of resonance
+   Long_t           fMotherPDG;        //  PDG code of resonance
    Double_t         fMotherMass;       //  nominal resonance mass
    AliRsnCutSet    *fPairCuts;         //  cuts on the pair
 
@@ -138,7 +138,7 @@ private:
    Bool_t 	    fRejectIfNoQuark;  // flag to remove events not generated with PYTHIA
    Bool_t           fCheckHistRange;   //  check if values is in histogram range
 
-   ClassDef(AliRsnMiniOutput, 5)  // AliRsnMiniOutput class
+   ClassDef(AliRsnMiniOutput, 6)  // AliRsnMiniOutput class
 };
 
 #endif

--- a/PWGLF/RESONANCES/AliRsnMiniPair.h
+++ b/PWGLF/RESONANCES/AliRsnMiniPair.h
@@ -23,7 +23,7 @@ public:
    AliRsnMiniPair() : fDCA1(0), fDCA2(0), fMother(-1), fMotherPDG(0), fNSisters(-1), fIsFromB(kFALSE), fIsQuarkFound(kFALSE),fContainsV0Daughter(kFALSE) {Int_t i = 3; while (i--) fPmother[i] = 0.0;}
   
    Int_t          &Mother()    {return fMother;}
-   Int_t          &MotherPDG() {return fMotherPDG;}
+   Long_t         &MotherPDG() {return fMotherPDG;}
    Bool_t         &IsFromB()      {return fIsFromB;}
    Bool_t         &IsQuarkFound() {return fIsQuarkFound;}
    Bool_t         &ContainsV0Daughter() {return fContainsV0Daughter;}
@@ -76,14 +76,14 @@ public:
    Double_t       fDCA2;      // 2nd daughter DCA 
    
    Int_t          fMother;    // label of mothers (when common)
-   Int_t          fMotherPDG; // PDG code of mother (when common)
+   Long_t         fMotherPDG; // PDG code of mother (when common)
    Short_t        fNSisters;  // total number of mother's daughters in the MC stack
    Bool_t         fIsFromB;	      // is the particle from B meson flag	
    Bool_t         fIsQuarkFound;      // is the particle from a quark flag (used to reject or accept Hijing event)
    Float_t        fPmother[3];// MC momentum of the pair corresponding mother
    Bool_t         fContainsV0Daughter; // Flag if one of particle is part of V0's daughter
    
-   ClassDef(AliRsnMiniPair,5)
+   ClassDef(AliRsnMiniPair, 6)
      };
 
 #endif

--- a/PWGLF/RESONANCES/AliRsnMiniParticle.h
+++ b/PWGLF/RESONANCES/AliRsnMiniParticle.h
@@ -36,24 +36,24 @@ public:
    Float_t       &Px(Bool_t mc)              {return (mc ? fPsim[0] : fPrec[0]);}
    Float_t       &Py(Bool_t mc)              {return (mc ? fPsim[1] : fPrec[1]);}
    Float_t       &Pz(Bool_t mc)              {return (mc ? fPsim[2] : fPrec[2]);}
-   Short_t       &PDG()                      {return fPDG;}
-   Short_t        PDGAbs()                   {return TMath::Abs(fPDG);}
-   Double_t       Mass();
+   Long_t        &PDG()                      {return fPDG;}
+   Long_t        PDGAbs()                    {return TMath::Abs(fPDG);}
+   Double_t      Mass();
    Int_t         &Mother()                   {return fMother;}
-   Short_t       &MotherPDG()                {return fMotherPDG;}
+   Long_t        &MotherPDG()                {return fMotherPDG;}
    Bool_t        &IsFromB()                  {return fIsFromB;}
    Bool_t        &IsQuarkFound()             {return fIsQuarkFound;}
    UShort_t      &CutBits()                  {return fCutBits;}
-   Double_t       DCA()                      {return fDCA;}
-   Short_t        NTotSisters()              {return fNTotSisters;}
-   Bool_t         HasCutBit(Int_t i)         {UShort_t bit = 1 << i; return ((fCutBits & bit) != 0);}
-   void           SetCutBit(Int_t i)         {UShort_t bit = 1 << i; fCutBits |=   bit;}
-   void           ClearCutBit(Int_t i)       {UShort_t bit = 1 << i; fCutBits &= (~bit);}
+   Double_t      DCA()                      {return fDCA;}
+   Short_t       NTotSisters()              {return fNTotSisters;}
+   Bool_t        HasCutBit(Int_t i)         {UShort_t bit = 1 << i; return ((fCutBits & bit) != 0);}
+   void          SetCutBit(Int_t i)         {UShort_t bit = 1 << i; fCutBits |=   bit;}
+   void          ClearCutBit(Int_t i)       {UShort_t bit = 1 << i; fCutBits &= (~bit);}
 
-   void           Clear(Option_t *opt="");
+   void          Clear(Option_t *opt="");
 
-   void           Set4Vector(TLorentzVector &v, Float_t mass=-1.0, Bool_t mc=kFALSE);
-   void           CopyDaughter(AliRsnDaughter *daughter);
+   void          Set4Vector(TLorentzVector &v, Float_t mass=-1.0, Bool_t mc=kFALSE);
+   void          CopyDaughter(AliRsnDaughter *daughter);
 
 private:
 
@@ -63,16 +63,16 @@ private:
    Float_t   fPsim[3];      // MC momentum of the track
    Float_t   fPrec[3];      // reconstructed momentum of the track
    Float_t   fPmother[3];   // MC momentum of the track's mother
-   Short_t   fPDG;          // particle PDG code
+   Long_t    fPDG;          // particle PDG code
    Int_t     fMother;       // index of mother in its container
-   Short_t   fMotherPDG;    // PDG code of mother
+   Long_t    fMotherPDG;    // PDG code of mother
    Double_t  fDCA;          // DCA of the particle
    Short_t   fNTotSisters;  // number of  daughters of the particle
    Bool_t    fIsFromB;	    // is the particle from B meson flag	
    Bool_t    fIsQuarkFound; // is the particle from a quark flag (used to reject or accept Hijing event)
    UShort_t  fCutBits;      // list of bits used to know what cuts were passed by this track
 
-   ClassDef(AliRsnMiniParticle,7)
+   ClassDef(AliRsnMiniParticle, 8)
 };
 
 #endif

--- a/PWGLF/RESONANCES/AliRsnPairDef.cxx
+++ b/PWGLF/RESONANCES/AliRsnPairDef.cxx
@@ -54,7 +54,7 @@ AliRsnPairDef::AliRsnPairDef() :
 
 //_____________________________________________________________________________
 AliRsnPairDef::AliRsnPairDef
-(EPARTYPE type1, Char_t ch1, EPARTYPE type2, Char_t ch2, Int_t pdg, Double_t mass) :
+(EPARTYPE type1, Char_t ch1, EPARTYPE type2, Char_t ch2, Long_t pdg, Double_t mass) :
    fMotherMass(mass),
    fMotherPDG(pdg),
    fDef1(type1, ch1),
@@ -68,7 +68,7 @@ AliRsnPairDef::AliRsnPairDef
 
 //_____________________________________________________________________________
 AliRsnPairDef::AliRsnPairDef
-(AliRsnDaughter::ESpecies type1, Char_t ch1, AliRsnDaughter::ESpecies type2, Char_t ch2, Int_t pdg, Double_t mass) :
+(AliRsnDaughter::ESpecies type1, Char_t ch1, AliRsnDaughter::ESpecies type2, Char_t ch2, Long_t pdg, Double_t mass) :
    fMotherMass(mass),
    fMotherPDG(pdg),
    fDef1(type1, ch1),

--- a/PWGLF/RESONANCES/AliRsnPairDef.h
+++ b/PWGLF/RESONANCES/AliRsnPairDef.h
@@ -17,20 +17,20 @@ class AliRsnPairDef : public TObject {
 public:
 
    AliRsnPairDef();
-   AliRsnPairDef(EPARTYPE type1, Char_t ch1, EPARTYPE type2, Char_t ch2, Int_t motherPDG = 0, Double_t motherMass = 0.0);
-   AliRsnPairDef(AliRsnDaughter::ESpecies type1, Char_t ch1, AliRsnDaughter::ESpecies type2, Char_t ch2, Int_t motherPDG = 0, Double_t motherMass = 0.0);
+   AliRsnPairDef(EPARTYPE type1, Char_t ch1, EPARTYPE type2, Char_t ch2, Long_t motherPDG = 0, Double_t motherMass = 0.0);
+   AliRsnPairDef(AliRsnDaughter::ESpecies type1, Char_t ch1, AliRsnDaughter::ESpecies type2, Char_t ch2, Long_t motherPDG = 0, Double_t motherMass = 0.0);
    AliRsnPairDef(const AliRsnPairDef &copy);
    AliRsnPairDef &operator= (const AliRsnPairDef &copy);
    virtual ~AliRsnPairDef() { }
 
    virtual const char      *GetName()       const {return Form("%s_%s", fDef1.GetName(), fDef2.GetName());}
-   Int_t                    GetMotherPDG()  const {return fMotherPDG;}
-   Double_t                 GetMotherMass() const {return fMotherMass;}
+   Long_t                  GetMotherPDG()  const {return fMotherPDG;}
+   Double_t                GetMotherMass() const {return fMotherMass;}
    AliRsnDaughterDef       &GetDef1()             {return fDef1;}
    AliRsnDaughterDef       &GetDef2()             {return fDef2;}
    AliRsnDaughterDef       &GetDef(Int_t i)       {if (i<1) return GetDef1(); else return GetDef2();}
 
-   void SetMotherPDG(Int_t pdg)                 {fMotherPDG = pdg;}
+   void SetMotherPDG(Long_t pdg)                {fMotherPDG = pdg;}
    void SetMotherMass(Double_t mass)            {fMotherMass = mass;}
    void SetDef1(const AliRsnDaughterDef *def)   {if (def) fDef1 = (*def);}
    void SetDef2(const AliRsnDaughterDef *def)   {if (def) fDef2 = (*def);}
@@ -42,12 +42,12 @@ public:
 private:
 
    Double_t          fMotherMass;  // nominal mass of true mother
-   Int_t             fMotherPDG;   // PDG code of true mother (if known)
+   Long_t            fMotherPDG;  // PDG code of true mother (if known)
    AliRsnDaughterDef fDef1;        // definitions for daughter #1 (see class)
    AliRsnDaughterDef fDef2;        // definitions for daughter #2 (see class)
 
    // ROOT dictionary
-   ClassDef(AliRsnPairDef, 1)
+   ClassDef(AliRsnPairDef, 2)
 };
 
 #endif


### PR DESCRIPTION
Consistently use Long_t everywhere for PDG code.
Also added fix for few compilation warnings.