### PR TITLE
Pre-select jets based on number of constituents

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.h
@@ -255,6 +255,8 @@ protected:
   bool IsNSubjettinessBranch(const std::string &branchname) const;
   bool IsStructbranch(const std::string &branchname) const;
 
+  bool SelectJet(const AliEmcalJet &jet, const AliParticleContainer *particles) const;
+
 private:
 	TTree                       *fJetSubstructureTree;        //!<! Tree with jet substructure information
 	Double_t                     fJetTreeData[kTNVar];        ///< Variable storage for the jet tree


### PR DESCRIPTION
For jet substructure jets must have at least 1 constituent
for reclustering, consequently reclustering fails if one
only looks at charged / neutral constituents and has none
of that type's constituents. A preselection makes sure the
jet has at least one allowed constituent.