### PR TITLE
[WIP] EMCal Embed: Internal event selection

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
@@ -250,6 +250,7 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   void                        SetEventPlaneVsEmcal(Double_t ep)                     { fEventPlaneVsEmcal = ep                             ; }
   void                        SetForceBeamType(BeamType f)                          { fForceBeamType     = f                              ; }
   void                        SetHistoBins(Int_t nbins, Double_t min, Double_t max) { fNbins = nbins; fMinBinPt = min; fMaxBinPt = max    ; }
+  void                        SetRecycleUnusedEmbeddedEventsMode(Bool_t b)          { fRecycleUnusedEmbeddedEventsMode = b                ; }
   void                        SetIsEmbedded(Bool_t i)                               { fIsEmbedded        = i                              ; }
   void                        SetIsPythia(Bool_t i)                                 { fIsPythia          = i                              ; }
   void                        SetIsHerwig(Bool_t i)                                 { fIsHerwig          = i                              ; }
@@ -850,6 +851,7 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   Double_t                    fMinEventPlane;              ///< minimum event plane value
   Double_t                    fMaxEventPlane;              ///< maximum event plane value
   TString                     fCentEst;                    ///< name of V0 centrality estimator
+  Bool_t                      fRecycleUnusedEmbeddedEventsMode; ///< Allows the recycling of embedded events which fail internal event selection. See the embedding helper.
   Bool_t                      fIsEmbedded;                 ///< trigger, embedded signal
   Bool_t                      fIsPythia;                   ///< trigger, if it is a PYTHIA production
   Bool_t                      fIsHerwig;                   ///< trigger, if it is a HERWIG production
@@ -930,7 +932,7 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   AliAnalysisTaskEmcal &operator=(const AliAnalysisTaskEmcal&); // not implemented
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskEmcal, 17) // EMCAL base analysis task
+  ClassDef(AliAnalysisTaskEmcal, 18) // EMCAL base analysis task
   /// \endcond
 };
 

--- a/PWG/EMCAL/EMCALbase/CMakeLists.txt
+++ b/PWG/EMCAL/EMCALbase/CMakeLists.txt
@@ -27,6 +27,7 @@ include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/OADB
                     ${AliPhysics_SOURCE_DIR}/OADB/COMMON/MULTIPLICITY
                     ${AliPhysics_SOURCE_DIR}/PWG/Tools
+                    ${AliPhysics_SOURCE_DIR}/PWG/Tools/yaml-cpp/include
   )
 
 # Sources - alphabetical order

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
@@ -234,6 +234,7 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
 
   bool                        fIsEsd;                      ///< File type
   bool                        fEventInitialized;           ///< If the event is initialized properly
+  bool                        fRecycleUnusedEmbeddedEventsMode; ///< Allows the recycling of embedded events which fail internal event selection. See the embedding helper.
   Double_t                    fCent;                       //!<! Event centrality
   Int_t                       fCentBin;                    //!<! Event centrality bin
   Double_t                    fMinCent;                    ///< min centrality for event selection
@@ -255,7 +256,7 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
   TList *                     fOutput;                     //!<! Output for histograms
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionTask, 4); // EMCal correction task
+  ClassDef(AliEmcalCorrectionTask, 5); // EMCal correction task
   /// \endcond
 };
 

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -1,5 +1,6 @@
 configurationName: "Default configuration"          # Optional - Simply for user convenience
 pass: ""                                            # Attempts to automatically retrieve the pass if not specified. Usually of the form "pass#".
+recycleUnusedEmbeddedEventsMode: false              # True if embedded events should be recycled by using the internal event selection of the embedding helper.
 # Look at the documentation for a full explanation of the input objects!
 inputObjects:                                       # Define all of the input objects for the corrections
     cells:                                          # Configure cells


### PR DESCRIPTION
__Work in Progress! Please do not commit!__

Previously, good embedded events were lost when the internal event
was outside of, for example, the desired centrality range. Now,
the user should check for
`AliAnalysisTaskEmcalEmbeddingHelper::GetIstance()->IsGoodEvent()`
to ensure that the internal event passes event selection and that
the embedded event was embedded successfully. If the internal event
did not pass event selection, the embedded event is saved for the
next internal event.

The code should be ready for code review, but it is still undergoing some
testing. @aiola - Would you mind reviewing this code? I think this simple solution is
fine, but I would appreciate another set of eyes which is familiar with the embedding
framework!