### PR TITLE
Added tree option for correlations

### DIFF
--- a/PWGHF/jetsHF/AliAnalysisTaskHFJetIPQA.h
+++ b/PWGHF/jetsHF/AliAnalysisTaskHFJetIPQA.h
@@ -158,6 +158,9 @@ public:
     {
         fDoJetProb = value;
     }
+    void useTreeForCorrelations(Bool_t value){
+        fUseTreeForCorrelations = value;
+    }
     //virtual Bool_t IsEventSelected();
     void FillCorrelations(bool bn[3], double v[3], double jetpt);
     void setFFillCorrelations(const Bool_t &value);
@@ -171,8 +174,6 @@ private:
     void GetOutOfJetParticleComposition(AliEmcalJet * jet, int flavour);
     void FillParticleCompositionSpectra(AliEmcalJet * jet,const char * histname );
     void FillParticleCompositionEvent();
-
-
     void DoJetLoop(); //jet matching function 2/4
     void SetMatchingLevel(AliEmcalJet *jet1, AliEmcalJet *jet2, Int_t matching=0);
     void GetGeometricalMatchingLevel(AliEmcalJet *jet1, AliEmcalJet *jet2, Double_t &d) const;
@@ -211,6 +212,7 @@ private:
     TH1D * GetHist1D(const char * name){return (TH1D*)fOutput->FindObject(name);}
     TH2D * GetHist2D(const char * name){return (TH2D*)fOutput->FindObject(name);}
 private:
+
     Bool_t   fUsePIDJetProb;//
     Bool_t   fFillCorrelations;//
     Double_t fParam_Smear_Sigma;//
@@ -265,7 +267,14 @@ private:
     Bool_t   fIsSameEvent_n1;
     Bool_t   fIsSameEvent_n2;
     Bool_t   fIsSameEvent_n3;
-
+    Bool_t   fUseTreeForCorrelations;
+    TTree *  fCorrelationCrossCheck;//!
+    Float_t  fTREE_n1;
+    Float_t  fTREE_n2;
+    Float_t  fTREE_n3;
+    Float_t  fTREE_pt;
+    
+    
     void SetMixDCA(int n , Double_t v){
     if(n==1){
             if(fIsMixSignalReady_n1) return;

--- a/PWGHF/jetsHF/macros/AddTaskHFJetIPQA.C
+++ b/PWGHF/jetsHF/macros/AddTaskHFJetIPQA.C
@@ -14,6 +14,7 @@ AliAnalysisTaskHFJetIPQA* AddTaskHFJetIPQA(
                                            TString PathToJetProbabilityInput = "alien:///alice/cern.ch/user/l/lfeldkam/dummy_ResFct_XYSignificance_pp7TeV.root",
                                            Bool_t GenerateMeanSigmaCorrectionTable=kTRUE,
                                            Int_t nITSReq=6,
+                                           Bool_t useCorrelationTree=kFALSE,
                                            const char* suffix = ""
                                            )
 {
@@ -70,6 +71,7 @@ AliAnalysisTaskHFJetIPQA* AddTaskHFJetIPQA(
     TString name(taskname),combinedName;
     combinedName.Form("%s%s", name.Data(),suffix);
     AliAnalysisTaskHFJetIPQA* jetTask = new AliAnalysisTaskHFJetIPQA(combinedName);
+    if(useCorrelationTree) jetTask->useTreeForCorrelations(kTRUE);
     if(isMC && filecorrectionfactors){
         TH1F * h[20] = {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0};
         const char * nampart[20] = {"pi0","eta","etap","rho","phi","omega","k0s","lambda","pi","kaon","proton","D0","Dp","Dsp","Ds","lambdac","bplus","b0","lambdab","bsp"};
@@ -110,8 +112,12 @@ AliAnalysisTaskHFJetIPQA* AddTaskHFJetIPQA(
     }
     //==============================================================================
     TH1::AddDirectory(0);
-    if( PathToJetProbabilityInput.EqualTo("") ) {
-    } else {
+    if( PathToJetProbabilityInput.EqualTo("") ) 
+    {
+
+    } 
+    else 
+    {
         jetTask->SetResFunctionPID(PathToJetProbabilityInput.Data());
     }
     // Set Monte Carlo / Data status
@@ -152,14 +158,13 @@ AliAnalysisTaskHFJetIPQA* AddTaskHFJetIPQA(
     AliAnalysisDataContainer *cinput1  = mgr->GetCommonInputContainer()  ;
     TString contname(combinedName);
     contname += "_histos";
- 
+    TString contnamecorr(combinedName);
+    contnamecorr += "_correlations";
 
     AliAnalysisDataContainer *coutput1 = mgr->CreateContainer(contname.Data(),
                                                               TList::Class(),AliAnalysisManager::kOutputContainer,
                                                               Form("%s", AliAnalysisManager::GetCommonFileName()));
- 
 
-    
     mgr->ConnectInput  (jetTask, 0,  cinput1 );
     mgr->ConnectOutput (jetTask, 1, coutput1 );
 


### PR DESCRIPTION
Add a switch to verify the extracted n1, n2, n3 correlation coefficents via fully stored information as opposed to the th2d
approach that might be affected by the binning