### PR TITLE
AliEventCuts pointer accessible from outside

### DIFF
--- a/PWGLF/SPECTRA/PiKaPr/ITSsa/AliAnalysisTaskSEITSsaSpectra.h
+++ b/PWGLF/SPECTRA/PiKaPr/ITSsa/AliAnalysisTaskSEITSsaSpectra.h
@@ -203,7 +203,7 @@ private:
   AliITSPIDResponse* fITSPIDResponse; //!<! class with BB parameterizations
 
   //Standard event cut
-  AliEventCuts fEventCuts;            //!<! basic cut variables for events
+  AliEventCuts fEventCuts;            //-> basic cut variables for events
 
   /////////////////////////////////////////////////////
   // List


### PR DESCRIPTION
Modification to permit the changing of the default settings of AliEventCuts event selection from the RunTask without modifying the task. 