### PR TITLE
[WIP] Fix needed to overcome double-delete issue with ROOT v6-12-04

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
@@ -294,6 +294,9 @@ AliAnalysisTaskEmcal::AliAnalysisTaskEmcal(const char *name, Bool_t histo) :
 
 AliAnalysisTaskEmcal::~AliAnalysisTaskEmcal()
 {
+  if(fOutput) delete fOutput;
+  if(fAliAnalysisUtils) delete fAliAnalysisUtils;
+  if(fPythiaInfo) delete fPythiaInfo;
 }
 
 void AliAnalysisTaskEmcal::SetClusPtCut(Double_t cut, Int_t c)

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
@@ -83,6 +83,8 @@ AliEmcalTriggerMakerTask::AliEmcalTriggerMakerTask(const char *name, Bool_t doQA
 
 AliEmcalTriggerMakerTask::~AliEmcalTriggerMakerTask() {
   if(fTriggerMaker) delete fTriggerMaker;
+  if(fQAHistos) delete fQAHistos;
+  if(fCaloTriggersOut) delete fCaloTriggersOut;
 }
 
 /**
@@ -154,6 +156,7 @@ void AliEmcalTriggerMakerTask::UserCreateOutputObjects(){
       fQAHistos->CreateTH2("FastORDiffEsmearADCrough", "FastOR ADC rough - smeared energy", 4994, -0.5, 4993.5, 200, -10., 10);
 
       for(auto h : *(fQAHistos->GetListOfHistograms())) fOutput->Add(h);
+      fQAHistos->GetListOfHistograms()->SetOwner(false);
       PostData(1, fOutput);
     } else {
       AliWarningStream() << "QA requested but no output container initialized - QA needs to be disabled" << std::endl;

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerBase.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerBase.cxx
@@ -117,6 +117,8 @@ AliAnalysisTaskEmcalTriggerBase::~AliAnalysisTaskEmcalTriggerBase() {
   if(fTriggerSelection) delete fTriggerSelection;
   if(fHistos) delete fHistos;
   if(fDownscaleOADB) delete fDownscaleOADB;
+  if(fMaskedFastorOADB) delete fMaskedFastorOADB;
+  if(fDownscaleFactors) delete fDownscaleFactors;
 }
 
 void AliAnalysisTaskEmcalTriggerBase::UserCreateOutputObjects() {
@@ -143,6 +145,7 @@ void AliAnalysisTaskEmcalTriggerBase::UserCreateOutputObjects() {
   CreateUserHistos();
 
   for(auto h : *(fHistos->GetListOfHistograms())) fOutput->Add(h);
+  fHistos->GetListOfHistograms()->SetOwner(false);
 
   PostData(1, fOutput);
 }


### PR DESCRIPTION
It turned out that the double-delete issue with ROOT v6-12-04
appears for objects, in particular inheriting from TCollection,
which are bound to a TFile but not delete in the task destructor.
Once deleting them in the destructor the crash disappears.

This affects the destruction at the end of the ROOT session and
works as long as there is only one task writing to the same output
file. As soon as there is a second instance of a task (same task
or different) writing to the same output file the segfault reappears.