### PR TITLE
Fix for FillStatics issue of the Physics Seleciton with ROOT v6-12-04

### DIFF
--- a/OADB/AliPhysicsSelection.cxx
+++ b/OADB/AliPhysicsSelection.cxx
@@ -500,7 +500,6 @@ void AliPhysicsSelection::FillStatistics(){
   fHistStat->SetCanExtend(TH1::kAllAxes);
 #endif
   fHistList.Add(fHistStat);
-  TH1::AddDirectory(oldStatus);
 
   Int_t nColl = fCollTrigClasses.GetEntries();
   for (Int_t i=0; i<nColl; i++) {
@@ -608,6 +607,7 @@ void AliPhysicsSelection::FillStatistics(){
   }
   fHistStat->LabelsDeflate("X");
   fHistStat->LabelsDeflate("Y");
+  TH1::AddDirectory(oldStatus);
 }
 
 void AliPhysicsSelection::Print(const Option_t *option) const{


### PR DESCRIPTION
The physics selection crashes under ROOT6 v6-12-04 in FillStatistics
when filling fHistStat. The problem seems to be due to a temporary
histogram used when extending the histogram axis, which seems to get
connected to a directory. Releasing the directory status around the
function seems to cure the problem.