### PR TITLE
Added histograms for matching efficiency vs phi_TPCouter vs eta.

### DIFF
--- a/PWGPP/TOF/AddTaskTOFqaID.C
+++ b/PWGPP/TOF/AddTaskTOFqaID.C
@@ -108,12 +108,12 @@ AliAnalysisTaskSE * AddTaskTOFqaID(Bool_t  flagEnableAdvancedCheck = kFALSE,
   TString partName(task->GetSpeciesName(absPdgCode));
  
   // Create containers for input/output
-  AliAnalysisDataContainer *cInputTOFqa = mgr->CreateContainer("cInputTOFqa", TChain::Class(),AliAnalysisManager::kInputContainer);
-  AliAnalysisDataContainer *cGeneralTOFqa = mgr->CreateContainer(Form("base_%s%s",partName.Data(),cutName.Data()),TList::Class(),AliAnalysisManager::kOutputContainer,Form("%s:TOF",mgr->GetCommonFileName(), partName.Data()));
-  AliAnalysisDataContainer *cTimeZeroTOFqa = mgr->CreateContainer(Form("timeZero_%s%s",partName.Data(),cutName.Data()),TList::Class(),AliAnalysisManager::kOutputContainer,Form("%s:TOF",mgr->GetCommonFileName(),partName.Data()));
-   AliAnalysisDataContainer *cPIDTOFqa = mgr->CreateContainer(Form("pid_%s%s",partName.Data(),cutName.Data()),TList::Class(),AliAnalysisManager::kOutputContainer,Form("%s:TOF",mgr->GetCommonFileName(),partName.Data()));
-   AliAnalysisDataContainer *cTRDcheckTOFqa = mgr->CreateContainer(Form("trd_%s%s",partName.Data(),cutName.Data()),TList::Class(),AliAnalysisManager::kOutputContainer,Form("%s:TOF",mgr->GetCommonFileName(),partName.Data()));
-   AliAnalysisDataContainer *cTriggerTOFqa = mgr->CreateContainer(Form("trigger_%s%s",partName.Data(),cutName.Data()),TList::Class(),AliAnalysisManager::kOutputContainer,Form("%s:TOF",mgr->GetCommonFileName(),partName.Data()));
+  AliAnalysisDataContainer* cInputTOFqa = mgr->CreateContainer("cInputTOFqa", TChain::Class(), AliAnalysisManager::kInputContainer);
+  AliAnalysisDataContainer* cGeneralTOFqa = mgr->CreateContainer(Form("base_%s%s", partName.Data(), cutName.Data()), THashList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:TOF", mgr->GetCommonFileName(), partName.Data()));
+  AliAnalysisDataContainer* cTimeZeroTOFqa = mgr->CreateContainer(Form("timeZero_%s%s", partName.Data(), cutName.Data()), THashList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:TOF", mgr->GetCommonFileName(), partName.Data()));
+  AliAnalysisDataContainer* cPIDTOFqa = mgr->CreateContainer(Form("pid_%s%s", partName.Data(), cutName.Data()), THashList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:TOF", mgr->GetCommonFileName(), partName.Data()));
+  AliAnalysisDataContainer* cTRDcheckTOFqa = mgr->CreateContainer(Form("trd_%s%s", partName.Data(), cutName.Data()), THashList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:TOF", mgr->GetCommonFileName(), partName.Data()));
+  AliAnalysisDataContainer* cTriggerTOFqa = mgr->CreateContainer(Form("trigger_%s%s", partName.Data(), cutName.Data()), THashList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:TOF", mgr->GetCommonFileName(), partName.Data()));
 
   // Attach i/o
   mgr->ConnectInput(task, 0, mgr->GetCommonInputContainer());

--- a/PWGPP/TOF/AliAnalysisTaskTOFqaID.cxx
+++ b/PWGPP/TOF/AliAnalysisTaskTOFqaID.cxx
@@ -79,8 +79,7 @@ AliAnalysisTaskTOFqaID::AliAnalysisTaskTOFqaID() :
   fHlistTimeZero(0x0),
   fHlistPID(0x0),
   fHlistTRD(0x0),
-  fHlistTrigger(0x0),
-  fVariableBinsPt(0x0)
+  fHlistTrigger(0x0)
 {
   // Default constructor
 
@@ -93,6 +92,9 @@ AliAnalysisTaskTOFqaID::AliAnalysisTaskTOFqaID() :
      fTrkExpTimes[j]=0.0;
      fThExpTimes[j]=0.0;
    } 
+   for (Int_t i = 0; i <= fnBinsPt; i++)
+     fVariableBinsPt[i] = 0.0;
+   //
 }
 //________________________________________________________________________
 AliAnalysisTaskTOFqaID::AliAnalysisTaskTOFqaID(const char *name) :
@@ -135,8 +137,7 @@ AliAnalysisTaskTOFqaID::AliAnalysisTaskTOFqaID(const char *name) :
   fHlistTimeZero(0x0),
   fHlistPID(0x0),
   fHlistTRD(0x0),
-  fHlistTrigger(0x0),
-  fVariableBinsPt(0x0)
+  fHlistTrigger(0x0)
  {
   // Constructor
   // Define input and output slots here
@@ -151,6 +152,9 @@ AliAnalysisTaskTOFqaID::AliAnalysisTaskTOFqaID(const char *name) :
      fTrkExpTimes[j]=0.0;
      fThExpTimes[j]=0.0;
    }
+   for (Int_t i = 0; i <= fnBinsPt; i++)
+     fVariableBinsPt[i] = 0.0;
+   //
    // Input slot #0 works with a TChain
    DefineInput(0, TChain::Class());
 
@@ -205,8 +209,7 @@ AliAnalysisTaskTOFqaID::AliAnalysisTaskTOFqaID(const AliAnalysisTaskTOFqaID& cop
   fHlistTimeZero(copy.fHlistTimeZero),
   fHlistPID(copy.fHlistPID),
   fHlistTRD(copy.fHlistTRD),
-  fHlistTrigger(copy.fHlistTrigger),
-  fVariableBinsPt(copy.fVariableBinsPt)
+  fHlistTrigger(copy.fHlistTrigger)
 {
   // Copy constructor
    for (Int_t j=0;j<5;j++ ) {
@@ -218,8 +221,9 @@ AliAnalysisTaskTOFqaID::AliAnalysisTaskTOFqaID(const AliAnalysisTaskTOFqaID& cop
      fTrkExpTimes[j]=copy.fTrkExpTimes[j];
      fThExpTimes[j]=copy.fThExpTimes[j];
    }
-
-
+   for (Int_t i = 0; i <= fnBinsPt; i++)
+     fVariableBinsPt[i] = copy.fVariableBinsPt[i];
+   //
 }
 
 //___________________________________________________________________________
@@ -278,7 +282,9 @@ AliAnalysisTaskTOFqaID& AliAnalysisTaskTOFqaID::operator=(const AliAnalysisTaskT
     fHlistPID=copy.fHlistPID;
     fHlistTRD=copy.fHlistTRD;
     fHlistTrigger=copy.fHlistTrigger;
-    fVariableBinsPt=copy.fVariableBinsPt;
+    for (Int_t i = 0; i <= fnBinsPt; i++)
+      fVariableBinsPt[i] = copy.fVariableBinsPt[i];
+    //
   }
   return *this;
 }
@@ -690,7 +696,7 @@ Bool_t  AliAnalysisTaskTOFqaID::IsTPCTOFMatched(AliESDtrack * track, Bool_t chec
       const Int_t TrkLabel = track->GetLabel(); /*The Get*Label() getters return the label of the associated MC particle. The absolute value of this label is the index of the particle within the MC fMCStack. If the label is negative, this track was assigned a certain number of clusters that did not in fact belong to this track. */
       const Int_t AbsTrkLabel = TMath::Abs(TrkLabel);
       Int_t TOFTrkLabel[3] = {-1};//This can contain three particles wich occupy the same cluster
-      Int_t mfl, uniqueID;
+      // Int_t mfl, uniqueID;
       //Gets the labels of the tracks matched to the TOF,
       //this can be used to remove the mismatch and to compute the efficiency!
       //The label to check is the first one, the others can come from different tracks
@@ -903,13 +909,11 @@ void AliAnalysisTaskTOFqaID::AddTofBaseHisto(TList *list, Int_t charge, TString 
     return;
   }
 
-  TString cLabel;
-  if (charge == 0) cLabel.Form("all");
-  else
-    if (charge<0) cLabel.Form("neg");
-    else
-      if (charge>0) cLabel.Form("pos");
-
+  TString cLabel = "all";
+  if (charge < 0)
+    cLabel.Form("neg");
+  else if (charge > 0)
+    cLabel.Form("pos");
 
   TH1I* hTOFmulti = new TH1I(Form("hTOFmulti%s_%s",suffix.Data(), cLabel.Data()), Form("%s matched trk per event (|#eta|#leq%3.2f, #it{p}_{T}#geq0.3 GeV/#it{c})", cLabel.Data(), fMatchingEtaCut), 100, 0, 100);
   HistogramMakeUp(hTOFmulti, ((charge>0)? kRed : kBlue+2), 1, "E1", "","", "N","events");
@@ -957,12 +961,12 @@ void    AliAnalysisTaskTOFqaID::AddMatchingEffHisto(TList *list, Int_t charge, T
     AliError("Invalid list passed as argument.");
     return;
   }
-  TString cLabel;
-  if (charge == 0) cLabel.Form("all");
-  else
-    if (charge<0) cLabel.Form("neg");
-    else
-      if (charge>0) cLabel.Form("pos");
+
+  TString cLabel = "all";
+  if (charge < 0)
+    cLabel.Form("neg");
+  else if (charge > 0)
+    cLabel.Form("pos");
 
   TH1F* hMatchedP  = new TH1F(Form("hMatchedP%s_%s",suffix.Data(),cLabel.Data()), Form("%s matched trk p", cLabel.Data()), fnBinsPt, fVariableBinsPt);// 1000,0.,10.) ;
   HistogramMakeUp(hMatchedP,((charge>0)? kRed+2 : kBlue+2), 1, "E1", "","", "p (GeV/#it{c})","tracks");
@@ -1014,12 +1018,12 @@ void  AliAnalysisTaskTOFqaID::AddPidHisto(TList *list, Int_t charge, TString suf
     AliError("Invalid list passed as argument.");
     return;
   }
-  TString cLabel;
-  if (charge == 0) cLabel.Form("all");
-  else
-    if (charge<0) cLabel.Form("neg");
-    else
-      if (charge>0) cLabel.Form("pos");
+
+  TString cLabel = "all";
+  if (charge < 0)
+    cLabel.Form("neg");
+  else if (charge > 0)
+    cLabel.Form("pos");
 
   TH2F* hMatchedBetaVsP  = new TH2F(Form("hMatchedBetaVsP%s_%s",suffix.Data(),cLabel.Data()), Form("%s matched trk #beta vs. p", cLabel.Data()), fnBinsPt, fVariableBinsPt, 150, 0., 1.5) ;
   HistogramMakeUp(hMatchedBetaVsP,((charge>0)? kRed+2 : kBlue+2), 1, "colz", "","", "#it{p} (GeV/#it{c})","#beta");
@@ -1278,12 +1282,12 @@ void AliAnalysisTaskTOFqaID::FillTofBaseHisto(AliESDtrack * track, Int_t charge,
   Int_t channel=track->GetTOFCalChannel();
   Int_t volId[5]; //(sector, plate,strip,padZ,padX)
   AliTOFGeometry::GetVolumeIndices(channel,volId);
-  TString cLabel;
-  if (charge == 0) cLabel.Form("all");
-  else
-    if (charge<0) cLabel.Form("neg");
-    else
-      if (charge>0) cLabel.Form("pos");
+
+  TString cLabel = "all";
+  if (charge < 0)
+    cLabel.Form("neg");
+  else if (charge > 0)
+    cLabel.Form("pos");
 
   ((TH1F*)fHlist->FindObject(Form("hTime%s_%s",suffix.Data(),cLabel.Data())))->Fill(fTof); //ns
   ((TH1F*)fHlist->FindObject(Form("hRawTime%s_%s",suffix.Data(),cLabel.Data())))->Fill(tofTimeRaw*1E-3); //ns
@@ -1301,12 +1305,12 @@ void AliAnalysisTaskTOFqaID::FillPrimaryTrkHisto(Int_t charge, TString suffix)
 {
   // fill histos with primary tracks info
   // => denominator for matching efficiency
-  TString cLabel;
-  if (charge == 0) cLabel.Form("all");
-  else
-    if (charge<0) cLabel.Form("neg");
-    else
-      if (charge>0) cLabel.Form("pos");
+
+  TString cLabel = "all";
+  if (charge < 0)
+    cLabel.Form("neg");
+  else if (charge > 0)
+    cLabel.Form("pos");
 
   TList *theL = (suffix.Contains("Trd") ? fHlistTRD : fHlist);
   ((TH1F*)theL->FindObject(Form("hPrimaryP%s_%s",suffix.Data(),cLabel.Data())))->Fill(fP);
@@ -1324,12 +1328,13 @@ void AliAnalysisTaskTOFqaID::FillMatchedTrkHisto(Int_t charge, TString suffix)
 {
   //get matched tracks variables (matching cut to be applied externally)
   //=> numerator for matching efficiency
-  TString cLabel;
-  if (charge == 0) cLabel.Form("all");
-  else
-    if (charge<0) cLabel.Form("neg");
-    else
-      if (charge>0) cLabel.Form("pos");
+
+  TString cLabel = "all";
+  if (charge < 0)
+    cLabel.Form("neg");
+  else if (charge > 0)
+    cLabel.Form("pos");
+
   TList *theL = (suffix.Contains("Trd") ? fHlistTRD : fHlist);
   ((TH1F*)theL->FindObject(Form("hMatchedP%s_%s",suffix.Data(),cLabel.Data())))->Fill(fP);
   ((TH1F*)theL->FindObject(Form("hMatchedPt%s_%s",suffix.Data(),cLabel.Data())))->Fill(fPt);
@@ -1355,12 +1360,11 @@ void AliAnalysisTaskTOFqaID::FillPidHisto(AliESDtrack * track, Int_t charge, TSt
   }
   if (!track) return;
 
-  TString cLabel;
-  if (charge == 0) cLabel.Form("all");
-  else
-    if (charge<0) cLabel.Form("neg");
-    else
-      if (charge>0) cLabel.Form("pos");
+  TString cLabel = "all";
+  if (charge < 0)
+    cLabel.Form("neg");
+  else if (charge > 0)
+    cLabel.Form("pos");
 
   //calculate beta
   Double_t c=TMath::C()*1.E-9;// m/ns
@@ -1647,13 +1651,22 @@ void AliAnalysisTaskTOFqaID::SetPtVariableBinning()
   //
   // returns an array with variable binning in p and pT
   //
-  Double_t xBins[fnBinsPt+1];
-  for (Int_t j=0;j<fnBinsPt+1; j++) {
-    if (j<200) xBins[j] = j*0.025;
-    else xBins[j] = 5.0 + (j-200)*0.050;
+  for (Int_t j = 0; j < fnBinsPt + 1; j++) {
+    if (j < 200)
+      fVariableBinsPt[j] = 0.025 * j;
+    else
+      fVariableBinsPt[j] = 5.0 + (j - 200) * 0.050;
   }
-  fVariableBinsPt = xBins;
   return;
 }
+
+//-----------------------------------------------------------
+const Double_t AliAnalysisTaskTOFqaID::fBinsPt[2] = { 0.0, 20.0 };
+
+//-----------------------------------------------------------
+const Double_t AliAnalysisTaskTOFqaID::fBinsEta[2] = { -1.0, 1.0 };
+
+//-----------------------------------------------------------
+const Double_t AliAnalysisTaskTOFqaID::fBinsPhi[2] = { 0.0, 360.0 };
 
 #endif

--- a/PWGPP/TOF/AliAnalysisTaskTOFqaID.cxx
+++ b/PWGPP/TOF/AliAnalysisTaskTOFqaID.cxx
@@ -5,37 +5,37 @@
 #ifndef ALIANALYSISTASKTOFQAID_CXX
 #define ALIANALYSISTASKTOFQAID_CXX
 
-#include "TChain.h"
-#include "TTree.h"
-#include "TH1F.h"
-#include "TH2F.h"
-#include "TProfile.h"
-#include "TCanvas.h"
-#include "AliAnalysisTaskSE.h"
-#include "AliAnalysisManager.h"
-#include "AliVEvent.h"
-#include "AliVTrack.h"
-#include "AliESDEvent.h"
-#include "AliMCEvent.h"
-#include "AliMCParticle.h"
-#include "AliESDInputHandler.h"
-#include "AliMCEventHandler.h"
-#include "AliESDpid.h"
-#include "AliTOFPIDParams.h"
-#include "AliTOFChannelOnlineStatusArray.h"
-#include "AliCDBManager.h"
-#include "AliCDBEntry.h"
-#include "AliCDBPath.h"
-#include "AliTOFcalib.h"
-#include "AliTOFT0maker.h"
-#include "AliTOFT0v1.h"
 #include "AliAnalysisTaskTOFqaID.h"
 #include "AliAnalysisFilter.h"
+#include "AliAnalysisManager.h"
+#include "AliAnalysisTaskSE.h"
+#include "AliCDBEntry.h"
+#include "AliCDBManager.h"
+#include "AliCDBPath.h"
+#include "AliESDEvent.h"
+#include "AliESDInputHandler.h"
+#include "AliESDpid.h"
 #include "AliESDtrackCuts.h"
 #include "AliLog.h"
-#include "AliTOFRawStream.h"
+#include "AliMCEvent.h"
+#include "AliMCEventHandler.h"
+#include "AliMCParticle.h"
+#include "AliTOFChannelOnlineStatusArray.h"
 #include "AliTOFGeometry.h"
-
+#include "AliTOFPIDParams.h"
+#include "AliTOFRawStream.h"
+#include "AliTOFT0maker.h"
+#include "AliTOFT0v1.h"
+#include "AliTOFcalib.h"
+#include "AliVEvent.h"
+#include "AliVTrack.h"
+#include "TCanvas.h"
+#include "TChain.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "THashList.h"
+#include "TProfile.h"
+#include "TTree.h"
 
 ClassImp(AliAnalysisTaskTOFqaID)
 
@@ -91,7 +91,7 @@ AliAnalysisTaskTOFqaID::AliAnalysisTaskTOFqaID() :
      fSigmaSpecie[j]=0.0;
      fTrkExpTimes[j]=0.0;
      fThExpTimes[j]=0.0;
-   } 
+   }
    for (Int_t i = 0; i <= fnBinsPt; i++)
      fVariableBinsPt[i] = 0.0;
    //
@@ -160,11 +160,11 @@ AliAnalysisTaskTOFqaID::AliAnalysisTaskTOFqaID(const char *name) :
 
    // Output slot #0 writes into a TH1 container
    // Output slot #1 writes into a user defined  container
-   DefineOutput(1, TList::Class());
-   DefineOutput(2, TList::Class());
-   DefineOutput(3, TList::Class());
-   DefineOutput(4, TList::Class());
-   DefineOutput(5, TList::Class());
+   DefineOutput(1, THashList::Class());
+   DefineOutput(2, THashList::Class());
+   DefineOutput(3, THashList::Class());
+   DefineOutput(4, THashList::Class());
+   DefineOutput(5, THashList::Class());
 
  }
 
@@ -255,7 +255,7 @@ AliAnalysisTaskTOFqaID& AliAnalysisTaskTOFqaID::operator=(const AliAnalysisTaskT
     fMyTimeZeroTOFtracks=copy.fMyTimeZeroTOFtracks;
     for (Int_t j=0;j<5;j++ ) {
       if (j<3) {
-	fT0[j]=copy.fT0[j];
+        fT0[j]=copy.fT0[j];
         fNTOFtracks[j]=copy.fNTOFtracks[j];
       }
       fSigmaSpecie[j]=copy.fSigmaSpecie[j];
@@ -342,30 +342,30 @@ void AliAnalysisTaskTOFqaID::UserCreateOutputObjects()
   if (!fESDpid) AliError("PIDResponse object was not created");
   //fESDpid->SetOADBPath("$ALICE_PHYSICS/OADB");
 
-  Info("CreateOutputObjects","CreateOutputObjects (TList) of task %s", GetName());
+  Info("CreateOutputObjects","CreateOutputObjects (THashList) of task %s", GetName());
   OpenFile(1);
 
   //define variable binning for pt and p before creating histos
   SetPtVariableBinning();
 
   
-  if (!fHlist) fHlist = new TList();
+  if (!fHlist) fHlist = new THashList();
   fHlist->SetOwner(kTRUE);
   fHlist->SetName("base");
 
-  if (!fHlistTimeZero) fHlistTimeZero = new TList();
+  if (!fHlistTimeZero) fHlistTimeZero = new THashList();
   fHlistTimeZero->SetOwner(kTRUE);
   fHlistTimeZero->SetName("startTime");
 
-  if (!fHlistPID) fHlistPID = new TList();
+  if (!fHlistPID) fHlistPID = new THashList();
   fHlistPID->SetOwner(kTRUE);
   fHlistPID->SetName("pid");
 
-  if (!fHlistTRD) fHlistTRD = new TList();
+  if (!fHlistTRD) fHlistTRD = new THashList();
   fHlistTRD->SetOwner(kTRUE);
   fHlistTRD->SetName("TRD");
 
-  if (!fHlistTrigger) fHlistTrigger = new TList();
+  if (!fHlistTrigger) fHlistTrigger = new THashList();
   fHlistTrigger->SetOwner(kTRUE);
   fHlistTrigger->SetName("trigger");
 
@@ -586,7 +586,7 @@ void AliAnalysisTaskTOFqaID::UserExec(Option_t *)
 void AliAnalysisTaskTOFqaID::Terminate(Option_t *)
 {
   //check on output validity
-  fHlist = dynamic_cast<TList*> (GetOutputData(1));
+  fHlist = dynamic_cast<THashList*> (GetOutputData(1));
   if (!fHlist) {
     AliError("Base histograms list not available");
     return;
@@ -847,7 +847,7 @@ Bool_t AliAnalysisTaskTOFqaID::SelectMCspecies(AliMCEvent * ev, AliESDtrack * tr
 }
 
 //----------------------------------------------------------------------------------
-Bool_t  AliAnalysisTaskTOFqaID::ComputeMatchingEfficiency(TList* list, TString variable)
+Bool_t  AliAnalysisTaskTOFqaID::ComputeMatchingEfficiency(THashList* list, TString variable)
 {
   //computes matching efficiency from previously filled histos
   // to be called in terminate function
@@ -901,7 +901,7 @@ void AliAnalysisTaskTOFqaID::HistogramMakeUp(TH1* hist, Color_t color, Int_t mar
 }
 
 //----------------------------------------------------------------------------------
-void AliAnalysisTaskTOFqaID::AddTofBaseHisto(TList *list, Int_t charge, TString suffix)
+void AliAnalysisTaskTOFqaID::AddTofBaseHisto(THashList *list, Int_t charge, TString suffix)
 {
   //Creates histograms for monitoring TOF signal, time alignement and matching-related quantities
   if (!list){
@@ -955,7 +955,7 @@ void AliAnalysisTaskTOFqaID::AddTofBaseHisto(TList *list, Int_t charge, TString 
 }
 
 //----------------------------------------------------------------------------------
-void    AliAnalysisTaskTOFqaID::AddMatchingEffHisto(TList *list, Int_t charge, TString suffix)
+void AliAnalysisTaskTOFqaID::AddMatchingEffHisto(THashList *list, Int_t charge, TString suffix)
 {
   if (!list){
     AliError("Invalid list passed as argument.");
@@ -1011,7 +1011,7 @@ void    AliAnalysisTaskTOFqaID::AddMatchingEffHisto(TList *list, Int_t charge, T
 }
 
 //----------------------------------------------------------------------------------
-void  AliAnalysisTaskTOFqaID::AddPidHisto(TList *list, Int_t charge, TString suffix)
+void AliAnalysisTaskTOFqaID::AddPidHisto(THashList *list, Int_t charge, TString suffix)
 {
   //Creates histograms for monitoring TOF PID
   if (!list){
@@ -1116,7 +1116,7 @@ void  AliAnalysisTaskTOFqaID::AddPidHisto(TList *list, Int_t charge, TString suf
   return;
 }
 //----------------------------------------------------------------------------------
-void    AliAnalysisTaskTOFqaID::AddStartTimeHisto(TList *list, TString suffix)
+void AliAnalysisTaskTOFqaID::AddStartTimeHisto(THashList *list, TString suffix)
 {
   //Creates histograms for monitoring T0 signal and start-time related quantities
   if (!list){
@@ -1312,7 +1312,7 @@ void AliAnalysisTaskTOFqaID::FillPrimaryTrkHisto(Int_t charge, TString suffix)
   else if (charge > 0)
     cLabel.Form("pos");
 
-  TList *theL = (suffix.Contains("Trd") ? fHlistTRD : fHlist);
+  THashList *theL = (suffix.Contains("Trd") ? fHlistTRD : fHlist);
   ((TH1F*)theL->FindObject(Form("hPrimaryP%s_%s",suffix.Data(),cLabel.Data())))->Fill(fP);
   ((TH1F*)theL->FindObject(Form("hPrimaryPt%s_%s",suffix.Data(),cLabel.Data())))->Fill(fPt);
   ((TH2F*)theL->FindObject(Form("hPrimaryPtVsOutPhi%s_%s",suffix.Data(),cLabel.Data())))->Fill(fTPCOuterPhi,fPt);
@@ -1335,7 +1335,7 @@ void AliAnalysisTaskTOFqaID::FillMatchedTrkHisto(Int_t charge, TString suffix)
   else if (charge > 0)
     cLabel.Form("pos");
 
-  TList *theL = (suffix.Contains("Trd") ? fHlistTRD : fHlist);
+  THashList *theL = (suffix.Contains("Trd") ? fHlistTRD : fHlist);
   ((TH1F*)theL->FindObject(Form("hMatchedP%s_%s",suffix.Data(),cLabel.Data())))->Fill(fP);
   ((TH1F*)theL->FindObject(Form("hMatchedPt%s_%s",suffix.Data(),cLabel.Data())))->Fill(fPt);
   ((TH2F*)theL->FindObject(Form("hMatchedPtVsOutPhi%s_%s",suffix.Data(),cLabel.Data())))->Fill(fTPCOuterPhi,fPt);
@@ -1381,8 +1381,7 @@ void AliAnalysisTaskTOFqaID::FillPidHisto(AliESDtrack * track, Int_t charge, TSt
     mass = fP*TMath::Sqrt(fact);
   }
 
-  TList *theL = (suffix.Contains("Trd") ? fHlistTRD : fHlistPID);
-
+  THashList *theL = (suffix.Contains("Trd") ? fHlistTRD : fHlistPID);
   ((TH2F*) theL->FindObject(Form("hMatchedBetaVsP%s_%s",suffix.Data(),cLabel.Data())))->Fill(fP,beta);
   ((TH1F*) theL->FindObject(Form("hMatchedMass%s_%s",suffix.Data(),cLabel.Data())))->Fill(mass);
   ((TH1F*) theL->FindObject(Form("hMatchedMass2%s_%s",suffix.Data(),cLabel.Data())))->Fill(mass*mass);

--- a/PWGPP/TOF/AliAnalysisTaskTOFqaID.cxx
+++ b/PWGPP/TOF/AliAnalysisTaskTOFqaID.cxx
@@ -5,7 +5,6 @@
 #ifndef ALIANALYSISTASKTOFQAID_CXX
 #define ALIANALYSISTASKTOFQAID_CXX
 
-#include "AliAnalysisTaskTOFqaID.h"
 #include "AliAnalysisFilter.h"
 #include "AliAnalysisManager.h"
 #include "AliAnalysisTaskSE.h"
@@ -36,6 +35,8 @@
 #include "THashList.h"
 #include "TProfile.h"
 #include "TTree.h"
+//
+#include "AliAnalysisTaskTOFqaID.h"
 
 ClassImp(AliAnalysisTaskTOFqaID)
 

--- a/PWGPP/TOF/AliAnalysisTaskTOFqaID.h
+++ b/PWGPP/TOF/AliAnalysisTaskTOFqaID.h
@@ -124,13 +124,13 @@ class AliAnalysisTaskTOFqaID : public AliAnalysisTaskSE {
   TList *             fHlistTRD;  //list of general histos for positive tracks
   TList *             fHlistTrigger;  //list of general histos for TOF trg infos
 
-  const Int_t fnBinsPt = 300; // binning for pt and p 
-  const Int_t fnBinsEta = 200; // binning for eta
-  const Int_t fnBinsPhi = 72; // binning for phi and phi_TPCouter
-  const Double_t fBinsPt[2] = {0.0, 20.0}; // binning for pt and p - max and min
-  const Double_t fBinsEta[2] = {-1.0, 1.0}; // binning for eta - max and min
-  const Double_t fBinsPhi[2] = {0.0, 360.0}; // binning for phi and phi_TPCouter - max and min
-  Double_t *fVariableBinsPt; // array of bins for pt and p 
+  static const Int_t fnBinsPt = 300; // binning for pt and p 
+  static const Int_t fnBinsEta = 200; // binning for eta
+  static const Int_t fnBinsPhi = 72; // binning for phi and phi_TPCouter
+  static const Double_t fBinsPt[2]; // binning for pt and p - max and min
+  static const Double_t fBinsEta[2]; // binning for eta - max and min
+  static const Double_t fBinsPhi[2]; // binning for phi and phi_TPCouter - max and min
+  Double_t fVariableBinsPt[fnBinsPt + 1]; // array of bins for pt and p
 
   void SetPtVariableBinning(); // sets the array with variable binning in p and pT
   

--- a/PWGPP/TOF/AliAnalysisTaskTOFqaID.h
+++ b/PWGPP/TOF/AliAnalysisTaskTOFqaID.h
@@ -124,7 +124,17 @@ class AliAnalysisTaskTOFqaID : public AliAnalysisTaskSE {
   TList *             fHlistTRD;  //list of general histos for positive tracks
   TList *             fHlistTrigger;  //list of general histos for TOF trg infos
 
-  ClassDef(AliAnalysisTaskTOFqaID, 5); // example of analysis
+  const Int_t fnBinsPt = 300; // binning for pt and p 
+  const Int_t fnBinsEta = 200; // binning for eta
+  const Int_t fnBinsPhi = 72; // binning for phi and phi_TPCouter
+  const Double_t fBinsPt[2] = {0.0, 20.0}; // binning for pt and p - max and min
+  const Double_t fBinsEta[2] = {-1.0, 1.0}; // binning for eta - max and min
+  const Double_t fBinsPhi[2] = {0.0, 360.0}; // binning for phi and phi_TPCouter - max and min
+  Double_t *fVariableBinsPt; // array of bins for pt and p 
+
+  void SetPtVariableBinning(); // sets the array with variable binning in p and pT
+  
+  ClassDef(AliAnalysisTaskTOFqaID, 6); // example of analysis
 };
 
 #endif

--- a/PWGPP/TOF/AliAnalysisTaskTOFqaID.h
+++ b/PWGPP/TOF/AliAnalysisTaskTOFqaID.h
@@ -2,7 +2,7 @@
 #define ALIANALYSISTASKTOFQAID_h
 
 class TString;
-class TList;
+class THashList;
 class AliAnalysisFilter;
 class AliCDBManager;
 class AliTOFcalib;
@@ -51,10 +51,10 @@ class AliAnalysisTaskTOFqaID : public AliAnalysisTaskSE {
   void    SetOCDBInfo(const char *cdbLocation, UInt_t runN) {fOCDBLocation=cdbLocation; fRunNumber=runN;}
 
  protected:
-  void    AddTofBaseHisto(TList *list, Int_t charge, TString suffix);
-  void    AddMatchingEffHisto(TList *list, Int_t charge, TString suffix);
-  void    AddPidHisto(TList *list, Int_t charge, TString suffix);
-  void    AddStartTimeHisto(TList *list, TString suffix);
+  void    AddTofBaseHisto(THashList *list, Int_t charge, TString suffix);
+  void    AddMatchingEffHisto(THashList *list, Int_t charge, TString suffix);
+  void    AddPidHisto(THashList *list, Int_t charge, TString suffix);
+  void    AddStartTimeHisto(THashList *list, TString suffix);
   void    AddTrdHisto();
   void    AddTofTrgHisto(TString suffix);
 
@@ -69,7 +69,7 @@ class AliAnalysisTaskTOFqaID : public AliAnalysisTaskSE {
 
   Bool_t  ComputeTimeZeroByTOF1GeV();
   Bool_t  SelectMCspecies(AliMCEvent * ev, AliESDtrack * track);
-  Bool_t  ComputeMatchingEfficiency(TList* list, TString variable);
+  Bool_t  ComputeMatchingEfficiency(THashList* list, TString variable);
   Bool_t  IsTPCTOFMatched(AliESDtrack * track, Bool_t checkMatchLabel);
   Bool_t  IsInTRD(AliESDtrack * track);
   Bool_t  IsEventSelected(AliESDEvent * event);
@@ -118,11 +118,11 @@ class AliAnalysisTaskTOFqaID : public AliAnalysisTaskSE {
   AliTOFChannelOnlineStatusArray * fChannelArray; //array of channel status
   AliTOFcalib *       fCalib; //TOF calibration object
   //output objects
-  TList *             fHlist;  //list of general histos
-  TList *             fHlistTimeZero; //list of timeZero related histos
-  TList *             fHlistPID; //list of PID-related histos
-  TList *             fHlistTRD;  //list of general histos for positive tracks
-  TList *             fHlistTrigger;  //list of general histos for TOF trg infos
+  THashList *             fHlist;  //list of general histos
+  THashList *             fHlistTimeZero; //list of timeZero related histos
+  THashList *             fHlistPID; //list of PID-related histos
+  THashList *             fHlistTRD;  //list of general histos for positive tracks
+  THashList *             fHlistTrigger;  //list of general histos for TOF trg infos
 
   static const Int_t fnBinsPt = 300; // binning for pt and p 
   static const Int_t fnBinsEta = 200; // binning for eta

--- a/PWGPP/TOF/trending/MakeTrendingTOFQAv2.C
+++ b/PWGPP/TOF/trending/MakeTrendingTOFQAv2.C
@@ -8,28 +8,27 @@
  *  A feature that displays the plots in canvases must be enable when needed.
  */
 
-/*
-// #if !defined(__CINT__) || defined(__MAKECINT__)
-// #include "TCanvas.h"
-// #include "TStyle.h"
-// #include "TLegend.h"
-// #include "TGrid.h"
-// #include "TGaxis.h"
-// #include "TFile.h"
-// #include "TTree.h"
-// #include "TH1.h"
-// #include "TH2.h"
-// #include "TF1.h"
-// #include "TPaveText.h"
-// #include "AliTOFcalib.h"
-// #include "AliCDBEntry.h"
-// #include "AliCDBManager.h"
-// #include "TProfile.h"
-// #include "AliTOFChannelOnlineStatusArray.h"
-// #include "AliTOFcalibHisto.h"
-// #include "TMath.h"
-// #endif
-*/
+
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include "TCanvas.h"
+#include "TStyle.h"
+#include "TLegend.h"
+#include "TGrid.h"
+#include "TGaxis.h"
+#include "TFile.h"
+#include "TTree.h"
+#include "TH1.h"
+#include "TH2.h"
+#include "TF1.h"
+#include "TPaveText.h"
+#include "AliTOFcalib.h"
+#include "AliCDBEntry.h"
+#include "AliCDBManager.h"
+#include "TProfile.h"
+#include "AliTOFChannelOnlineStatusArray.h"
+#include "AliTOFcalibHisto.h"
+#include "TMath.h"
+#endif
 
 Int_t MakeTrendingTOFQAv2(TString qafilename,                   //full path of the QA output;
 			  Int_t runNumber,                      //run number
@@ -51,7 +50,8 @@ Double_t GetGoodTOFChannelsRatio(Int_t run = -1, Bool_t saveMap = kFALSE, TStrin
 
 ///
 ///Function to setup the histogram style
-void MakeUpHisto(TH1* histo, TString titleY = "", Int_t marker = 20, Color_t color = kBlue+2, Int_t lineWidth = 1);
+void MakeUpHisto(TH1* histo, TString titleX = "", TString titleY = "", Int_t marker = 20, Color_t color = kBlue+2, Int_t lineWidth = 1);
+void MakeUpHisto(TH2* histo, TString titleX = "", TString titleY = "", TString titleZ = "", Int_t marker = 20, Color_t color = kBlue+2, Int_t lineWidth = 1);
 
 ///
 ///Function add a label in a canvas, indicating a missing Plot
@@ -231,7 +231,7 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
     avTot=-9999., peakTot=-9999.,spreadTot=-9999.,  peakTotErr=-9999.,spreadTotErr=-9999.,
     meanResTOF=-999., spreadResTOF=-999., meanResTOFerr=-999., spreadResTOFerr=-999.,
     orphansRatio=-9999., avL=-9999., negLratio=-9999.,
-    effPt1=-9999., effPt2=-9999., matchEffLinFit1Gev=-9999.,matchEffLinFit1GevErr=-9999.;
+    matchEffIntegratedErr=-9999., matchEffIntegrated=-9999., matchEffLinFit1Gev=-9999.,matchEffLinFit1GevErr=-9999.;
   Double_t avPiDiffTime=-9999.,peakPiDiffTime=-9999., spreadPiDiffTime=-9999.,peakPiDiffTimeErr=-9999., spreadPiDiffTimeErr=-9999.;
   Double_t avT0A=-9999.,peakT0A=-9999., spreadT0A=-9999.,peakT0AErr=-9999., spreadT0AErr=-9999.;
   Double_t avT0C=-9999.,peakT0C=-9999., spreadT0C=-9999.,peakT0CErr=-9999., spreadT0CErr=-9999.;
@@ -275,8 +275,8 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
   ttree->Branch("orphansRatio",&orphansRatio,"orphansRatio/D"); //orphans ratio
   ttree->Branch("avL",&avL,"avL/D"); //mean track length
   ttree->Branch("negLratio",&negLratio,"negLratio/D");//ratio of tracks with track length <350 cm
-  ttree->Branch("effPt1",&effPt1,"effPt1/D");//matching eff at 1 GeV/c
-  ttree->Branch("effPt2",&effPt2,"effPt2/D"); //matching eff at 2 GeV/c
+  ttree->Branch("matchEffIntegrated",&effPt2matchEffIntegrated,"matchEffIntegrated/D"); //matching eff integrated in pt (1-10GeV/c)
+  ttree->Branch("matchEffIntegratedErr",&effPt2matchEffIntegratedErr,"matchEffIntegratedErr/D"); //matching eff integrated in pt (1-10GeV/c)
   ttree->Branch("matchEffLinFit1Gev",&matchEffLinFit1Gev,"matchEffLinFit1Gev/D");//matching eff fit param
   ttree->Branch("matchEffLinFit1GevErr",&matchEffLinFit1GevErr,"matchEffLinFit1GevErr/D");////matching eff fit param error
   ttree->Branch("avPiDiffTime",&avPiDiffTime,"avPiDiffTime/D"); //mean t-texp
@@ -355,7 +355,7 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
       printf("Reminder: Raw time not available in MC simulated data.");
     }
   }
-  MakeUpHisto(hRawTime, "matched tracks", 21, kGreen+2, 1);
+  MakeUpHisto(hRawTime, "", "matched tracks", 21, kGreen+2, 1);
 
   TH1F * hTime = (TH1F*)generalList->FindObject("hTime_all");
   if ((hTime)&&(hTime->GetEntries()>0)) {
@@ -368,7 +368,7 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
       spreadTimeErr=(hTime->GetFunction("landau"))->GetParError(2);
       negTimeRatio=((Double_t)hTime->Integral(1,3)*100.)/((Double_t)hTime->Integral());
     }
-    MakeUpHisto(hTime, "matched tracks", 20, kBlue+2, 1);
+    MakeUpHisto(hTime, "", "matched tracks", 20, kBlue+2, 1);
 
     TLegend *lTime = new TLegend(0.7125881,0.6052519,0.979435,0.7408306,NULL,"brNDC");
     lTime->SetTextSize(0.04281433);
@@ -389,7 +389,7 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
       spreadTotErr=(hTot->GetFunction("gaus"))->GetParError(2);
     }
   }
-  MakeUpHisto(hTot, "matched tracks", 8, kViolet-3, 1);
+  MakeUpHisto(hTot, "", "matched tracks", 8, kViolet-3, 1);
 
   char orphansTxt[200];
   if (hTot->GetEntries()>1){
@@ -410,7 +410,7 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
     avL=hL->GetMean();
     negLratio=(hL->Integral(1,750))/((Float_t) hL->GetEntries()) ;
   }
-  MakeUpHisto(hL, "matched tracks", 1, kBlue+2, 1);
+  MakeUpHisto(hL, "", "matched tracks", 1, kBlue+2, 1);
   sprintf(negLengthTxt,"trk with L<350cm /matched = %4.2f%%", negLratio*100.);
   TPaveText *tLength = new TPaveText(0.15,0.83,0.65,0.87, "NDC");
   tLength->SetBorderSize(0);
@@ -426,68 +426,92 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
 
   //--------------------------------- matching eff ----------------------------------//
   //matching as function of pT
-  TH1F * hMatchingVsPt = new TH1F("hMatchingVsPt","Matching probability vs. Pt; Pt(GeV/c); matching probability", 50, 0., 5. );
+   //matching as function of eta and phi out
+  Double_t maxPtEff2Fit = 10.0;
+  Double_t minPtEff2Fit = 1.0;
+
+  TH1F * hMatchingVsPt = NULL;
+  TH2F * hMatchingVsEtaPhiOut = NULL;
+  TH1F * hMatchingVsEta = NULL;
+  TH1F * hMatchingVsPhiOut = NULL;
+  TH1F * hMatchingVsPhi = NULL;
+
   TH1F * hDenom = (TH1F*)generalList->FindObject("hPrimaryPt_all");
   if (hDenom) {
     hDenom->Sumw2();
-    hMatchingVsPt=(TH1F*) generalList->FindObject("hMatchedPt_all")->Clone();
+    hMatchingVsPt = (TH1F*) ((TH1F*) generalList->FindObject("hMatchedPt_all"))->Clone("hMatchingVsPt");
+    //set underflow bin to the matching efficiency integrated in 1-10 GeV/c
+    Int_t imin = hMatchingVsPt->GetXaxis()->FindBin(minPtEff2Fit);
+    Int_t imax = hMatchingVsPt->GetXaxis()->FindBin(maxPtEff2Fit);
+    Double_t numN, denN, numErr, denErr;
+    numN = hMatchingVsPt->Integral(imin, imax, numErr);
+    denN = hDenom->Integral(imin, imax, denErr);
+    matchEffIntegrated = numN / denN;
+    matchEffIntegratedErr = matchEffIntegrated * TMath::Sqrt(TMath::Power(numErr/numN, 2.0) +  TMath::Power(denErr/denN, 2.0));
+    //get efficiency
     hMatchingVsPt->Sumw2();
-    // hMatchingVsPt->Rebin(5);
-    // hDenom->Rebin(5);
-    hMatchingVsPt->Divide(hDenom);
-    hMatchingVsPt->GetYaxis()->SetTitle("matching efficiency");
+    hMatchingVsPt->Divide(hMatchingVsPt, hDenom, 1., 1., "B");
     hMatchingVsPt->SetTitle("TOF matching efficiency as function of transverse momentum");
     hMatchingVsPt->GetYaxis()->SetRangeUser(0,1.2);
   }
 
   if (hMatchingVsPt->GetEntries()>0){
-    hMatchingVsPt->Fit("pol0","","",1.0,10.);
+    hMatchingVsPt->Fit("pol0","","", minPtEff2Fit, maxPtEff2Fit);
     hMatchingVsPt->Draw();
     if (hMatchingVsPt->GetFunction("pol0")){
       matchEffLinFit1Gev=(hMatchingVsPt->GetFunction("pol0"))->GetParameter(0);
       matchEffLinFit1GevErr=(hMatchingVsPt->GetFunction("pol0"))->GetParError(0);
-      //printf("Matching efficiency fit param is %f +- %f\n",matchEffLinFit1Gev,matchEffLinFit1GevErr );
     }
   } else {
     printf("WARNING: matching efficiency plot has 0 entries. Skipped!\n");
   }
-  MakeUpHisto(hMatchingVsPt, "efficiency", 1, kBlue+2, 2);
+  MakeUpHisto(hMatchingVsPt, "#it{p}_{T} (GeV/#it{c})", "matching efficiency", 1, kBlue+2, 2);
+  
+  TH2F * hDenom2D = (TH2F*) generalList->FindObject("hPrimaryEtaVsOutPhi_all");  
+  if (!hDenom2D) {
+    //matching as function of eta
+    hDenom = (TH1F*)generalList->FindObject("hPrimaryEta_all");
+    if (hDenom) {
+      hDenom->Sumw2();
+      hMatchingVsEta = (TH1F*) ((TH1F*) generalList->FindObject("hMatchedEta_all"))->Clone("hMatchingVsEta");
+      hMatchingVsEta->Sumw2();
+      hMatchingVsEta->Divide(hMatchingVsEta, hDenom, 1., 1., "B");
+    }
+  } else {
+    hMatchingVsEtaPhiOut = (TH2F*)((TH2F*)generalList->FindObject("hMatchedEtaVsOutPhi_all"))->Clone("hMatchingVsEtaPhiOut");
+    hMatchingVsEtaPhiOut->Sumw2();
+    hMatchingVsEtaPhiOut->Divide(hMatchingVsEtaPhiOut, hDenom2D, 1., 1., "B");
+    hMatchingVsEtaPhiOut->GetZaxis()->SetRangeUser(0., 1.);
+    hMatchingVsEtaPhiOut->SetTitle("TOF matching efficiency as function of #eta and #phi_{TPC,out}");
+    MakeUpHisto(hMatchingVsEtaPhiOut, "#phi_{TPC,out} (deg)", "#eta", "matching efficiency", 1, kBlue+2, 2);
 
-  //matching as function of eta
-  TH1F * hMatchingVsEta = new TH1F("hMatchingVsEta","Matching probability vs. #\Eta; #\Eta; matching probability", 20, -1., 1.);
-  hDenom->Clear();
-  hDenom=(TH1F*)generalList->FindObject("hPrimaryEta_all");
-  if (hDenom) {
-    hDenom->Sumw2();
-    hMatchingVsEta=(TH1F*) generalList->FindObject("hMatchedEta_all")->Clone();
-    hMatchingVsEta->Sumw2();
-    // hMatchingVsEta->Rebin(5);
-    // hDenom->Rebin(5);
-    hMatchingVsEta->Divide(hDenom);
-    hMatchingVsEta->GetXaxis()->SetRangeUser(-1,1);
-    hMatchingVsEta->GetYaxis()->SetTitle("matching efficiency");
-    hMatchingVsEta->GetYaxis()->SetRangeUser(0,1.2);
-    hMatchingVsEta->SetTitle("TOF matching efficiency as function of pseudorapidity");
+    hMatchingVsEta = (TH1F*) hMatchingVsEtaPhiOut->ProjectionY("hMatchingVsEta");
+    hMatchingVsEta->Scale(1./hMatchingVsEtaPhiOut->GetNbinsX());
+
+    hMatchingVsPhiOut = (TH1F*) hMatchingVsEtaPhiOut->ProjectionY("hMatchingVsPhiOut");
+    hMatchingVsPhiOut->SetTitle("TOF matching efficiency as function of #phi_{TPC,out}");
+    hMatchingVsPhiOut->Scale(1./hMatchingVsEtaPhiOut->GetNbinsY());
+    hMatchingVsPhiOut->GetYaxis()->SetRangeUser(0,1.2);
   }
-  MakeUpHisto(hMatchingVsEta, "efficiency", 1, kBlue+2, 2);
-
+  
+  if (hMatchingVsEta) {
+    hMatchingVsEta->SetTitle("TOF matching efficiency as function of #eta");
+    hMatchingVsEta->GetYaxis()->SetRangeUser(0, 1.2);
+    MakeUpHisto(hMatchingVsEta, "#eta", "matching efficiency", 1, kBlue+2, 2);
+  }
+  
   //matching as function of phi
-  TH1F * hMatchingVsPhi = new TH1F("hMatchingVsPhi","Matching probability vs. Phi; Phi(rad); matching probability", 628, 0., 6.28);
-  hDenom->Clear();
-  hDenom=(TH1F*)generalList->FindObject("hPrimaryPhi_all");
+  hDenom = (TH1F*)generalList->FindObject("hPrimaryPhi_all");
   if (hDenom) {
     hDenom->Sumw2();
-    hMatchingVsPhi=(TH1F*) generalList->FindObject("hMatchedPhi_all")->Clone();
-    // hMatchingVsPhi->Rebin(2);
-    // hDenom->Rebin(2);
+    hMatchingVsPhi = (TH1F*) ((TH1F*) generalList->FindObject("hMatchedPhi_all"))->Clone("hMatchingVsPhi");
     hMatchingVsPhi->Sumw2();
-    hMatchingVsPhi->Divide(hDenom);
-    hMatchingVsPhi->GetYaxis()->SetTitle("matching efficiency");
+    hMatchingVsPhi->Divide(hMatchingVsPhi, hDenom, 1., 1., "B");
     hMatchingVsPhi->SetTitle("TOF matching efficiency as function of phi");
     hMatchingVsPhi->GetYaxis()->SetRangeUser(0,1.2);
   }
-  MakeUpHisto(hMatchingVsPhi, "efficiency", 1, kBlue+2, 2);
-
+  MakeUpHisto(hMatchingVsPhi, "#phi (deg)", "matching efficiency", 1, kBlue+2, 2);
+    
   if (saveHisto) {
     trendFile->cd();
     hMulti->Write();
@@ -497,9 +521,11 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
     hL->Write();
     hDxPos4profile->Write();
     hTOFmatchedDzVsStrip->Write();
-    hMatchingVsPt->Write();
-    hMatchingVsEta->Write();
-    hMatchingVsPhi->Write();
+    if (hMatchingVsPt) hMatchingVsPt->Write();
+    if (hMatchingVsEta) hMatchingVsEta->Write();
+    if (hMatchingVsPhi) hMatchingVsPhi->Write();
+    if (hMatchingVsPhiOut) hMatchingVsPhiOut->Write();
+    if (hMatchingVsEtaPhiOut) hMatchingVsEtaPhiOut->Write();
   }
 
   //--------------------------------- t-texp ----------------------------------//
@@ -507,7 +533,7 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
   if (hBetaP) hBetaP->GetYaxis()->SetRangeUser(0.,1.2);
 
   TH1F * hMass=(TH1F*)pidList->FindObject("hMatchedMass_all");
-  MakeUpHisto(hMass, "tracks", 1, kBlue+2, 1);
+  MakeUpHisto(hMass, "", "tracks", 1, kBlue+2, 1);
   // hMass->SetFillColor(kAzure+10);
   // hMass->SetFillStyle(1001);
   hMass->Rebin(2);
@@ -529,7 +555,7 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
   gStyle->SetOptFit();
   cTimeCalib->cd();
   gPad->SetLogy();
-  MakeUpHisto(hPionDiff, "", 1, kBlue+1, 1);
+  MakeUpHisto(hPionDiff, "", "", 1, kBlue+1, 1);
   hPionDiff->Draw();
   TString plotDir(".");
   if (savePng) cTimeCalib->Print(Form("%s/%i%s_TOFtime.png", plotDir.Data(), runNumber, dirsuffix.Data()));
@@ -591,7 +617,7 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
   hDiffTimeT0TOFPion1GeV->Draw("colz");
   cTOFresolution->cd(2);
   hResTOF->GetXaxis()->SetRangeUser(-1000,1000);
-  MakeUpHisto(hResTOF, "", 1, kBlue+1, 1);
+  MakeUpHisto(hResTOF, "", "", 1, kBlue+1, 1);
   hResTOF->Draw();
 
   if (savePng) cTOFresolution->Print(Form("%s/%i%s_TOFresolution.png", plotDir.Data(), runNumber, dirsuffix.Data()));
@@ -857,8 +883,8 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
   hSigmaPi->FitSlicesY(f);
   TH1D * hSigmaPi_mean = (TH1D*)gDirectory->Get("hTOFpidSigmaPi_all_1")->Clone("hTOFpidSigmaPi_all_mean");
   TH1D * hSigmaPi_pull = (TH1D*)gDirectory->Get("hTOFpidSigmaPi_all_2")->Clone("hTOFpidSigmaPi_all_pull");
-  MakeUpHisto(hSigmaPi_mean, "", 1, kBlack, 2);
-  MakeUpHisto(hSigmaPi_pull, "", 1, kRed, 2);
+  MakeUpHisto(hSigmaPi_mean, "", "", 1, kBlack, 2);
+  MakeUpHisto(hSigmaPi_pull, "", "", 1, kRed, 2);
 
   //fit with signal model = gaussian + exponential tail
   if (fitSignalModel) {
@@ -868,8 +894,8 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
     for(Int_t cc = 0; cc < npars ; cc++) {
       par[0][cc] = (TH1D*)gDirectory->Get(Form("hTOFpidSigmaPi_all_%i", cc));
     }
-    MakeUpHisto(par[0][1], "", 1, kBlue, 2);
-    MakeUpHisto(par[0][2], "", 1, kMagenta+2, 2);
+    MakeUpHisto(par[0][1], "", "", 1, kBlue, 2);
+    MakeUpHisto(par[0][2], "", "", 1, kMagenta+2, 2);
   }
 
   //----- KAON ------//
@@ -880,8 +906,8 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
   hSigmaKa->FitSlicesY(f);
   TH1D * hSigmaKa_mean = (TH1D*)gDirectory->Get("hTOFpidSigmaKa_all_1")->Clone("hTOFpidSigmaKa_all_mean");
   TH1D * hSigmaKa_pull = (TH1D*)gDirectory->Get("hTOFpidSigmaKa_all_2")->Clone("hTOFpidSigmaKa_all_pull");
-  MakeUpHisto(hSigmaKa_mean, "", 1, kBlack, 2);
-  MakeUpHisto(hSigmaKa_pull, "", 1, kRed, 2);
+  MakeUpHisto(hSigmaKa_mean, "", "", 1, kBlack, 2);
+  MakeUpHisto(hSigmaKa_pull, "", "", 1, kRed, 2);
 
   //fit with signal model = gaussian + exponential tail
   if (fitSignalModel) {
@@ -891,8 +917,8 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
     for(Int_t cc = 0; cc < npars; cc++) {
       par[1][cc] = (TH1D*)gDirectory->Get(Form("hTOFpidSigmaKa_all_%i", cc));
     }
-    MakeUpHisto(par[1][1], "", 1, kBlue, 2);
-    MakeUpHisto(par[1][2], "", 1, kMagenta+2, 2);
+    MakeUpHisto(par[1][1], "", "", 1, kBlue, 2);
+    MakeUpHisto(par[1][2], "", "", 1, kMagenta+2, 2);
   }
 
   //----- PROTON ------//
@@ -903,8 +929,8 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
   hSigmaPro->FitSlicesY(f);
   TH1D * hSigmaPro_mean = (TH1D*)gDirectory->Get("hTOFpidSigmaPro_all_1")->Clone("hTOFpidSigmaPro_all_mean");
   TH1D * hSigmaPro_pull = (TH1D*)gDirectory->Get("hTOFpidSigmaPro_all_2")->Clone("hTOFpidSigmaPro_all_pull");
-  MakeUpHisto(hSigmaPro_mean, "", 1, kBlack, 2);
-  MakeUpHisto(hSigmaPro_pull, "", 1, kRed, 2);
+  MakeUpHisto(hSigmaPro_mean, "", "", 1, kBlack, 2);
+  MakeUpHisto(hSigmaPro_pull, "", "", 1, kRed, 2);
 
   //fit with signal model = gaussian + exponential tail
   if (fitSignalModel) {
@@ -914,13 +940,13 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
     for(Int_t cc = 0; cc < npars; cc++) {
       par[2][cc] = (TH1D*)gDirectory->Get(Form("hTOFpidSigmaPro_all_%i", cc));
     }
-    MakeUpHisto(par[2][1], "", 1, kBlue, 2);
-    MakeUpHisto(par[2][2], "", 1, kMagenta+2, 2);
+    MakeUpHisto(par[2][1], "", "", 1, kBlue, 2);
+    MakeUpHisto(par[2][2], "", "", 1, kMagenta+2, 2);
   }
 
   /***************************************************
    //Save parameters obtained with the signal model fit
-   //***************************************************
+   ***************************************************
   TF1 *fSignalModel_bkg = new TF1("fSignalModel_bkg", "pol1", ModelRangeFitNsigmaPIDmin, ModelRangeFitNsigmaPIDmax);
   fSignalModel_bkg->SetTitle("bkg");
   fSignalModel_bkg->SetLineColor(kMagenta);
@@ -1090,8 +1116,8 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
     hSigmaPiT0->FitSlicesY(f);
     TH1D * hSigmaPiT0_mean = (TH1D*)gDirectory->Get("hNsigmaP_TOF_pion_1")->Clone("hNsigmaP_TOF_pion_mean");
     TH1D * hSigmaPiT0_pull = (TH1D*)gDirectory->Get("hNsigmaP_TOF_pion_2")->Clone("hNsigmaP_TOF_pion_pull");
-    MakeUpHisto(hSigmaPiT0_mean, "", 1, kBlack, 2);
-    MakeUpHisto(hSigmaPiT0_pull, "", 1, kRed, 2);
+    MakeUpHisto(hSigmaPiT0_mean, "", "", 1, kBlack, 2);
+    MakeUpHisto(hSigmaPiT0_pull, "", "", 1, kRed, 2);
 
     //fit with signal model
     if (fitSignalModel) {
@@ -1101,8 +1127,8 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
       for(Int_t cc = 0; cc < npars; cc++) {
 	parT0[0][cc] = (TH1D*)gDirectory->Get(Form("hNsigmaP_TOF_pion_%i", cc));
       }
-      MakeUpHisto(parT0[0][1], "", 1, kBlue, 2);
-      MakeUpHisto(parT0[0][2], "", 1, kMagenta+2, 2);
+      MakeUpHisto(parT0[0][1], "", "", 1, kBlue, 2);
+      MakeUpHisto(parT0[0][2], "", "", 1, kMagenta+2, 2);
     }
 
     //------- KAONS ------//
@@ -1113,8 +1139,8 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
     hSigmaKaT0->FitSlicesY(f);
     TH1D * hSigmaKaT0_mean = (TH1D*)gDirectory->Get("hNsigmaP_TOF_kaon_1")->Clone("hNsigmaP_TOF_kaon_mean");
     TH1D * hSigmaKaT0_pull = (TH1D*)gDirectory->Get("hNsigmaP_TOF_kaon_2")->Clone("hNsigmaP_TOF_kaon_pull");
-    MakeUpHisto(hSigmaKaT0_mean, "", 1, kBlack, 2);
-    MakeUpHisto(hSigmaKaT0_pull, "", 1, kRed, 2);
+    MakeUpHisto(hSigmaKaT0_mean, "", "", 1, kBlack, 2);
+    MakeUpHisto(hSigmaKaT0_pull, "", "", 1, kRed, 2);
 
     //fit with signal model
     if (fitSignalModel) {
@@ -1124,8 +1150,8 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
       for(Int_t cc = 0; cc < npars; cc++) {
 	parT0[1][cc] = (TH1D*)gDirectory->Get(Form("hNsigmaP_TOF_kaon_%i", cc));
       }
-      MakeUpHisto(parT0[1][1], "", 1, kBlue, 2);
-      MakeUpHisto(parT0[1][2], "", 1, kMagenta+2, 2);
+      MakeUpHisto(parT0[1][1], "", "", 1, kBlue, 2);
+      MakeUpHisto(parT0[1][2], "", "", 1, kMagenta+2, 2);
     }
 
     //------- PROTONS ------//
@@ -1136,8 +1162,8 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
     hSigmaProT0->FitSlicesY(f);
     TH1D * hSigmaProT0_mean = (TH1D*)gDirectory->Get("hNsigmaP_TOF_proton_1")->Clone("hNsigmaP_TOF_proton_mean");
     TH1D * hSigmaProT0_pull = (TH1D*)gDirectory->Get("hNsigmaP_TOF_proton_2")->Clone("hNsigmaP_TOF_proton_pull");
-    MakeUpHisto(hSigmaProT0_mean, "", 1, kBlack, 2);
-    MakeUpHisto(hSigmaProT0_pull, "", 1, kRed, 2);
+    MakeUpHisto(hSigmaProT0_mean, "", "", 1, kBlack, 2);
+    MakeUpHisto(hSigmaProT0_pull, "", "", 1, kRed, 2);
 
     //fit with signal model
     if (fitSignalModel) {
@@ -1147,8 +1173,8 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
       for(Int_t cc = 0; cc < npars; cc++) {
 	parT0[2][cc] = (TH1D*)gDirectory->Get(Form("hNsigmaP_TOF_proton_%i", cc));
       }
-      MakeUpHisto(parT0[2][1], "", 1, kBlue, 2);
-      MakeUpHisto(parT0[2][2], "", 1, kMagenta+2, 2);
+      MakeUpHisto(parT0[2][1], "", "", 1, kBlue, 2);
+      MakeUpHisto(parT0[2][2], "", "", 1, kMagenta+2, 2);
     }
 
      //Show in canvas
@@ -1218,7 +1244,7 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
 
     /***************************************************
     //Save parameters obtained with the signal model fit
-    //***************************************************
+    ***************************************************
     for(Int_t jj = 0; jj < 3; jj++){
       TCanvas *FitParametersT0 = new TCanvas(Form("FitParametersT0%i", jj), Form("FitParametersT0%i", jj));
       FitParametersT0->Divide(2,4);
@@ -1306,7 +1332,7 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
       spreadT0AErr=(hT0A->GetFunction("gaus"))->GetParError(2);
     }
   }
-  MakeUpHisto(hT0A, "events", 8, kBlue, 2);
+  MakeUpHisto(hT0A, "", "events", 8, kBlue, 2);
   hT0A->Rebin(2);
 
   TH1F*hT0C=(TH1F*)timeZeroList->FindObject("hT0C");
@@ -1320,7 +1346,7 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
       spreadT0CErr=(hT0C->GetFunction("gaus"))->GetParError(2);
     }
   }
-  MakeUpHisto(hT0C, "events", 8, kGreen+1, 2);
+  MakeUpHisto(hT0C, "", "events", 8, kGreen+1, 2);
   hT0C->Rebin(2);
 
   TH1F*hT0AC=(TH1F*)timeZeroList->FindObject("hT0AC");
@@ -1334,7 +1360,7 @@ Int_t MakeTrendingTOFQAv2(TString qafilename,             //full path of the QA 
       spreadT0ACErr=(hT0AC->GetFunction("gaus"))->GetParError(2);
     }
   }
-  MakeUpHisto(hT0AC, "events", 8, kRed+1, 2);
+  MakeUpHisto(hT0AC, "", "events", 8, kRed+1, 2);
   hT0AC->Rebin(2);
 
   TLegend *lT0 = new TLegend(0.7125881,0.6052519,0.979435,0.7408306,NULL,"brNDC");
@@ -1536,7 +1562,7 @@ Double_t GetGoodTOFChannelsRatio(Int_t run, Bool_t saveMap , TString OCDBstorage
 }
 
 //----------------------------------------------------------
-void MakeUpHisto(TH1* histo, TString titleY, Int_t marker, Color_t color, Int_t lineWidth)
+void MakeUpHisto(TH1* histo, TString titleX, TString titleY, Int_t marker, Color_t color, Int_t lineWidth)
 {
   if (!histo) return;
   histo->SetMarkerStyle(marker);
@@ -1546,7 +1572,27 @@ void MakeUpHisto(TH1* histo, TString titleY, Int_t marker, Color_t color, Int_t 
   histo->SetLineWidth(lineWidth);
   histo->SetFillColor(kWhite);
   histo->SetFillStyle(0);
+  if (!titleX.IsNull()) histo->GetXaxis()->SetTitle(titleX.Data());
   if (!titleY.IsNull()) histo->GetYaxis()->SetTitle(titleY.Data());
+  histo->GetYaxis()->SetTitleOffset(1.35);
+  histo->GetXaxis()->SetLabelSize(0.03);
+  return;
+}
+
+//----------------------------------------------------------
+void MakeUpHisto(TH2* histo, TString titleX, TString titleY,  TString titleZ, Int_t marker, Color_t color, Int_t lineWidth)
+{
+  if (!histo) return;
+  histo->SetMarkerStyle(marker);
+  histo->SetMarkerSize(0.7);
+  histo->SetMarkerColor(color);
+  histo->SetLineColor(color);
+  histo->SetLineWidth(lineWidth);
+  histo->SetFillColor(kWhite);
+  histo->SetFillStyle(0);
+  if (!titleX.IsNull()) histo->GetXaxis()->SetTitle(titleX.Data());
+  if (!titleY.IsNull()) histo->GetYaxis()->SetTitle(titleY.Data());
+  if (!titleZ.IsNull()) histo->GetZaxis()->SetTitle(titleZ.Data());
   histo->GetYaxis()->SetTitleOffset(1.35);
   histo->GetXaxis()->SetLabelSize(0.03);
   return;


### PR DESCRIPTION
Added histograms for matching efficiency vs phi_TPCouter vs eta.
Consequently remove 1D plot for eta.
Few other improvements:
- streamline code for trd lists
- define histo ranges and binning as const members
- added method to sefine variable binning in pt
- fixed cosmetics for histogram axis labels