### PR TITLE
EMCal Embed: Fix combining cell collections

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellCombineCollections.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellCombineCollections.cxx
@@ -1,6 +1,8 @@
 // AliEmcalCorrectionCellCombineCollections
 //
 
+#include <sstream>
+
 #include <AliAODEvent.h>
 #include <AliVCaloCells.h>
 #include <AliAODCaloCells.h>
@@ -25,6 +27,7 @@ AliEmcalCorrectionCellCombineCollections::AliEmcalCorrectionCellCombineCollectio
   AliEmcalCorrectionComponent("AliEmcalCorrectionCellCombineCollections"),
   fExternalCellsBranchName("emcalCells"),
   fCreatedCellsBranchName("emcalCellsCombined"),
+  fVerifyCombinedCells(true),
   fInitializedCombinedCells(false),
   fCombinedCells(0)
 {
@@ -57,6 +60,7 @@ Bool_t AliEmcalCorrectionCellCombineCollections::Initialize()
 
   GetProperty("externalCellsBranchName", fExternalCellsBranchName);
   GetProperty("combinedCellsBranchName", fCreatedCellsBranchName);
+  GetProperty("verifyCombinedCells", fVerifyCombinedCells);
 
   // Check for "usedefault"
   if (fExternalCellsBranchName == "usedefault") {
@@ -126,7 +130,7 @@ Bool_t AliEmcalCorrectionCellCombineCollections::Run()
   AliEmcalCorrectionComponent::Run();
 
   CreateCombinedCells();
-  
+
   return kTRUE;
 }
 
@@ -160,40 +164,111 @@ void AliEmcalCorrectionCellCombineCollections::CreateCombinedCells()
   // Create a new container
   fCombinedCells->CreateContainer(fCaloCells->GetNumberOfCells() + externalCells->GetNumberOfCells());
   // Add internal and external cells to the combined cells
-  AddCellsToCombinedCellObject(fCaloCells);
-  AddCellsToCombinedCellObject(externalCells);
+  AddCellsToCombinedCellObject(fCaloCells, 0);
+  AddCellsToCombinedCellObject(externalCells, fCaloCells->GetNumberOfCells());
+
+  if (fVerifyCombinedCells) {
+    VerifyCombinedCells({fCaloCells, externalCells});
+  }
 }
 
 /**
  * Takes the input cells and adds them to the combine cells. To do so,
  * the each individual cell must be duplicated.
  * 
- * @param[in] inputCells Cells to be added to the combined cells
+ * @param[in] inputCells Cells to be added to the combined cells.
+ * @param[in] indexOffset Offset into combined cell container where the inputCells should be placed.
  */
-void AliEmcalCorrectionCellCombineCollections::AddCellsToCombinedCellObject(AliVCaloCells * inputCells)
+void AliEmcalCorrectionCellCombineCollections::AddCellsToCombinedCellObject(AliVCaloCells * inputCells, int indexOffset)
 {
   // Cell properties
   Short_t cellNumber;
-  Double_t ampltidue, time, eFrac;
+  Double_t amplitude, time, eFrac;
   Int_t mcLabel;
   Bool_t cellHighGain;
   Bool_t getCellResult = kFALSE;
 
-  AliDebugStream(3) << "Adding caloCells \"" << inputCells->GetName() << "\" with " << inputCells->GetNumberOfCells() << " cells to the combined cells" << std::endl;
+  AliDebugStream(3) << "Adding caloCells \"" << inputCells->GetName() << "\" of type \"" << inputCells->GetType() << "\" with " << inputCells->GetNumberOfCells() << " cells to the combined cells" << std::endl;
 
   // Loop over the input cells and add them to the combined cells
   for (unsigned int i = 0; i < static_cast<unsigned int>(inputCells->GetNumberOfCells()); i++)
   {
-    getCellResult = inputCells->GetCell(i, cellNumber, ampltidue, time, mcLabel, eFrac);
+    getCellResult = inputCells->GetCell(i, cellNumber, amplitude, time, mcLabel, eFrac);
     if (!getCellResult) {
       AliWarning(TString::Format("Could not get cell %i from cell collection %s", i, inputCells->GetName()));
     }
     // Get high gain attribute in addition to cell
-    cellHighGain = inputCells->GetCellHighGain(i);
+    // NOTE: GetCellHighGain() uses the cell position, not cell index, and thus should _NOT_ be used!
+    cellHighGain = inputCells->GetHighGain(i);
 
     // Set the properties in the combined cell
-    fCombinedCells->SetCell(i, cellNumber, ampltidue, time, mcLabel, eFrac, cellHighGain);
+    fCombinedCells->SetCell(i + indexOffset, cellNumber, amplitude, time, mcLabel, eFrac, cellHighGain);
   }
+}
+
+/**
+ * Explicitly check that the cells in the various input cell collections were successfully combined together
+ * to form the combined cells. NOTE: This should not be run during normal usage. It will reduce performance and
+ * provide little benefit to the user.
+ *
+ * @param[in] inputCaloCells vector of calo cells which were combined to create the combined cells.
+ */
+void AliEmcalCorrectionCellCombineCollections::VerifyCombinedCells(std::vector <AliVCaloCells *> inputCaloCells)
+{
+  // Input cell arrays properties
+  Short_t cellNumber;
+  Double_t amplitude, time, eFrac;
+  Int_t mcLabel;
+  Bool_t cellHighGain;
+  Bool_t getCellResult = kFALSE;
+  // Combined cell array properties
+  Short_t cellNumberCombined;
+  Double_t amplitudeCombined, timeCombined, eFracCombined;
+  Int_t mcLabelCombined;
+  Bool_t cellHighGainCombined;
+  Bool_t getCellResultCombined = kFALSE;
+
+  unsigned int combinedCellsIndex = 0;
+  for (auto caloCells : inputCaloCells)
+  {
+    AliDebugStream(2) << "Verifying cells from cell collection " << caloCells->GetName() << "\n";
+    for (unsigned int i = 0; i < static_cast<unsigned int>(caloCells->GetNumberOfCells()); i++)
+    {
+      // Get input calo cell
+      getCellResult = caloCells->GetCell(i, cellNumber, amplitude, time, mcLabel, eFrac);
+      if (!getCellResult) {
+        AliWarning(TString::Format("Could not get cell %i from cell collection %s", i, caloCells->GetName()));
+      }
+      // Get high gain attribute in addition to cell
+      cellHighGain = caloCells->GetHighGain(i);
+      // Get combined calo cell
+      getCellResultCombined = fCombinedCells->GetCell(combinedCellsIndex, cellNumberCombined, amplitudeCombined, timeCombined, mcLabelCombined, eFracCombined);
+      if (!getCellResultCombined) {
+        AliWarning(TString::Format("Could not get cell %i from combined cell collection %s", combinedCellsIndex, fCombinedCells->GetName()));
+      }
+      // Get high gain attribute in addition to cell
+      cellHighGainCombined = fCombinedCells->GetHighGain(combinedCellsIndex);
+
+      if (cellNumberCombined != cellNumber ||
+        amplitudeCombined != amplitude ||
+        timeCombined != time ||
+        mcLabelCombined != mcLabel ||
+        eFracCombined != eFrac ||
+        cellHighGainCombined != cellHighGain)
+      {
+        std::stringstream errorMessage;
+        errorMessage << std::boolalpha;
+        errorMessage << "Cell mistmatch at index " << i << " of cell collection " << caloCells->GetName() << ", combined cells " << combinedCellsIndex << " of combined cell collection " << fCombinedCells->GetName() << "\n";
+        errorMessage << "Input cell: cell number: " << cellNumber << ", amplitude: " << amplitude << ", time: " << time << ", mcLabel: " << mcLabel << ", eFrac: " << eFrac << ", cellHighGain: " << cellHighGain << "\n";
+        errorMessage << "Combined cell: cell number: " << cellNumberCombined << ", amplitude: " << amplitudeCombined << ", time: " << timeCombined << ", mcLabel: " << mcLabelCombined << ", eFrac: " << eFracCombined << ", cellHighGain: " << cellHighGainCombined << "\n";
+        AliFatal(errorMessage.str().c_str());
+      }
+
+      combinedCellsIndex++;
+    }
+  }
+
+  AliDebugStream(1) << "Input cells were successfully combined into the combined cells.\n";
 }
 
 /**

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellCombineCollections.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellCombineCollections.h
@@ -48,11 +48,13 @@ class AliEmcalCorrectionCellCombineCollections : public AliEmcalCorrectionCompon
 
   void SetupCombinedCells();
   void CreateCombinedCells();
-  void AddCellsToCombinedCellObject(AliVCaloCells * inputCells);
+  void AddCellsToCombinedCellObject(AliVCaloCells * inputCells, int indexOffset);
+  void VerifyCombinedCells(std::vector <AliVCaloCells *> inputCaloCells);
   void AddObjectToEvent(TObject *obj, AliVEvent * event, Bool_t attempt = kFALSE);
 
   std::string fExternalCellsBranchName; ///<  Name of the cell branch which will be copied from the external event for the combined cells.
   std::string fCreatedCellsBranchName;  ///<  Name of the cell branch which will be created for the combined cells.
+  bool fVerifyCombinedCells;            ///<  True if the task should confirm that the combined cells properly copied the input cells.
   bool fInitializedCombinedCells;       //!<! True if the combined cells object has been initialized
   AliVCaloCells *fCombinedCells;        //!<! Cells combined from the input and external events.
   
@@ -63,7 +65,7 @@ class AliEmcalCorrectionCellCombineCollections : public AliEmcalCorrectionCompon
   static RegisterCorrectionComponent<AliEmcalCorrectionCellCombineCollections> reg;
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionCellCombineCollections, 1); // EMCal correction to combine cell collections
+  ClassDef(AliEmcalCorrectionCellCombineCollections, 2); // EMCal correction to combine cell collections
   /// \endcond
 };
 

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -69,7 +69,8 @@ CellCombineCollections:                             # Utility task to combine tw
     createHistos: false                             # Whether the task should create output histograms
     externalCellsBranchName: "usedefault"           # Name of the cells branch in the embedded (external) event.
     combinedCellsBranchName: "emcalCellsCombined"   # Name of the cells branch to be created for the combined cells in the input event.
-    cellsNames:                                     # Names of the cells input objects which should be attached to the correction
+    verifyCombinedCells: false                      # True will have the task confirm that the input cells have been successfully combined together. NOTE: Don't enable this for normal usage - it will reduce performance for little benefit.
+    cellsNames:                                     # Names of the cells input objects which should be attached to the correction. NOTE: _DO NOT_ include the embedded cells input object here! Include only the cells from the input event.
         - defaultCells                              # This object is defined above in the cells section of the input objects
 Clusterizer:                                        # Clusterizer component
     enabled: false                                  # Whether to enable the task


### PR DESCRIPTION
There were some indexing bugs which prevented the cell collections from
being combined successfully. Those were fixed, with new functionality
added to verify they were successfully combined.

Note that the length of the combined array should always been the same
length as the combination of the lengths of the cell objects, but that
doesn't mean that the arrays are the same. This can only be verified by
checking each cell by hand.

cc: @jdmulligan 