### PR TITLE
Background calculation check always against charged jets in jT analysis

### DIFF
--- a/PWGCF/Correlations/JCORRAN/Pro/AliJJetJtAnalysis.h
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJJetJtAnalysis.h
@@ -89,8 +89,8 @@ class AliJJetJtAnalysis{
 
     void ClearBeforeEvent();
     void CreateMCHistograms();
-    void FillJtHistogram( TObjArray *Jets, int iContainer , int mc);
-    void FillRandomBackground(double jetpT, double jetE, TObjArray *Jets , int iContainer, int mc);
+    void FillJtHistogram( TObjArray *Jets,TObjArray *ChargedJets, int iContainer , int mc);
+    void FillRandomBackground(double jetpT, double jetE, TObjArray *Jets , TObjArray *ChargedJets, int iContainer, int mc);
 
     void FillCorrelation( TObjArray *Jets, TObjArray *mcJets, int iContainer, int iContainerParticle);
     void FillPythia(TObjArray *Jets, int iContainer); 


### PR DESCRIPTION
Fixes a problem where background was incorrectly calculated for full jets when background region is outside EMCAL acceptance