### PR TITLE
PWGCF: AliFemtoCorrFctn - Implement missing Clone methods

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoAngularSpatialSeparationFunction.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoAngularSpatialSeparationFunction.h
@@ -25,16 +25,17 @@ public:
   virtual ~AliFemtoAngularSpatialSeparationFunction();
 
   virtual AliFemtoString Report();
-  
+
   void AddFirstParticle(AliFemtoParticle* particle, bool mixing=false);
   void AddSecondParticle(AliFemtoParticle* particle);
 
   void CalculateAnglesForEvent();
-  
+
   virtual void Finish();
   void WriteHistos();
   virtual TList* GetOutputList();
-  
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoAngularSpatialSeparationFunction(*this); }
+
 private:
   TH1D *fAlphaNum; // distibution of angles between direction of particle collections from the same event
   TH1D *fAlphaDen; // distibution of angles between direction of particle collections from different events
@@ -42,11 +43,11 @@ private:
   std::vector<double> phi1real;   // vector of all phi angles for particles of the first type
   std::vector<double> phi2real;   // vector of all phi angles for particles of the second type
   std::vector<double> phi1mixed;  // vector of all phi angles for particles of the first type (other event)
-  
+
   std::vector<double> theta1real; // vector of all theta angles for particles of the first type
   std::vector<double> theta2real; // vector of all theta angles for particles of the second type
   std::vector<double> theta1mixed;// vector of all theta angles for particles of the first type (other event)
-  
+
 #ifdef __ROOT__
   ClassDef(AliFemtoAngularSpatialSeparationFunction, 1)
 #endif

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBPLCMS3DCorrFctn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBPLCMS3DCorrFctn.h
@@ -48,6 +48,7 @@ public:
 
   void WriteOutHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoBPLCMS3DCorrFctn(*this); }
 
   //  void SetCoulombCorrection(AliFemtoCoulomb* Correction);
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBPLCMS3DCorrFctnKK.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBPLCMS3DCorrFctnKK.h
@@ -53,6 +53,7 @@ public:
 
   void WriteOutHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoBPLCMS3DCorrFctnKK(*this); }
 
   //  void SetCoulombCorrection(AliFemtoCoulomb* Correction);
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctn.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctn.cxx
@@ -46,11 +46,3 @@ void AliFemtoCorrFctn::CalculateAnglesForEvent()
 {
   cout << "Not implemented" << endl;
 }
-
-
-
-#ifdef __ROOT__
-  /// \cond CLASSIMP
-  ClassImp(AliFemtoCorrFctn);
-  /// \endcond
-#endif

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctn.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctn.cxx
@@ -27,22 +27,22 @@ AliFemtoCorrFctn& AliFemtoCorrFctn::operator=(const AliFemtoCorrFctn& aCorrFctn)
 
 void AliFemtoCorrFctn::AddRealPair(AliFemtoPair*)
 {
-  cout << "Not implemented" << endl;
+  cout << "AliFemtoCorrFctn::AddRealPair -- Not implemented\n";
 }
 void AliFemtoCorrFctn::AddMixedPair(AliFemtoPair*)
 {
-  cout << "Not implemented" << endl;
+  cout << "AliFemtoCorrFctn::AddMixedPair -- Not implemented\n";
 }
 
 void AliFemtoCorrFctn::AddFirstParticle(AliFemtoParticle*, bool)
 {
-  cout << "Not implemented" << endl;
+  cout << "AliFemtoCorrFctn::AddFirstParticle -- Not implemented\n";
 }
 void AliFemtoCorrFctn::AddSecondParticle(AliFemtoParticle*)
 {
-  cout << "Not implemented" << endl;
+  cout << "AliFemtoCorrFctn::AddSecondParticle -- Not implemented\n";
 }
 void AliFemtoCorrFctn::CalculateAnglesForEvent()
 {
-  cout << "Not implemented" << endl;
+  cout << "AliFemtoCorrFctn::CalculateAnglesForEvent -- Not implemented\n";
 }

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctn.h
@@ -4,13 +4,14 @@
 
 #pragma once
 
-#ifndef AliFemtoCorrFctn_hh
-#define AliFemtoCorrFctn_hh
+#ifndef ALIFEMTOCORRFCTN_H
+#define ALIFEMTOCORRFCTN_H
 
 #include "AliFemtoAnalysis.h"
 #include "AliFemtoEvent.h"
 #include "AliFemtoPair.h"
 #include "AliFemtoPairCut.h"
+
 
 /// \class AliFemtoCorrFctn
 /// \brief The pure-virtual base class for correlation functions
@@ -52,7 +53,7 @@ public:
 
   virtual TList* GetOutputList() = 0;
 
-  virtual AliFemtoCorrFctn* Clone() { return 0;}
+  virtual AliFemtoCorrFctn* Clone() const = 0;
 
   AliFemtoAnalysis* HbtAnalysis(){return fyAnalysis;};
   void SetAnalysis(AliFemtoAnalysis* aAnalysis);
@@ -92,4 +93,4 @@ inline void AliFemtoCorrFctn::EventEnd(const AliFemtoEvent* /* event */)
 
 
 
-#endif
+#endif  // ALIFEMTOCORRFCTN_H

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctn3DLCMSSym.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctn3DLCMSSym.h
@@ -51,7 +51,7 @@ public:
 
   void SetUseLCMS(int);
   int  GetUseLCMS();
-  virtual AliFemtoCorrFctn* Clone();
+  virtual AliFemtoCorrFctn* Clone() const;
 
 private:
 
@@ -69,11 +69,9 @@ private:
 #endif
 };
 
-inline AliFemtoCorrFctn* AliFemtoCorrFctn3DLCMSSym::Clone()
+inline AliFemtoCorrFctn* AliFemtoCorrFctn3DLCMSSym::Clone() const
 {
-  // const keeps us out of trouble
-  const AliFemtoCorrFctn3DLCMSSym& self = *this;
-  return new AliFemtoCorrFctn3DLCMSSym(self);
+  return new AliFemtoCorrFctn3DLCMSSym(*this);
 }
 
 inline  TH3F* AliFemtoCorrFctn3DLCMSSym::Numerator()

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctn3DSpherical.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctn3DSpherical.h
@@ -36,6 +36,7 @@ public:
 
   void WriteOutHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctn3DSpherical(*this); }
 
   //  void SetSpecificPairCut(AliFemtoPairCut* aCut);
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarDEta.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarDEta.cxx
@@ -153,8 +153,9 @@ AliFemtoString AliFemtoCorrFctnDPhiStarDEta::Report()
 void AliFemtoCorrFctnDPhiStarDEta::AddRealPair(AliFemtoPair* pair)
 {
   // Add real (effect) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   const AliFemtoTrack *track1 = pair->Track1()->Track(),
                       *track2 = pair->Track2()->Track();
@@ -214,8 +215,9 @@ void AliFemtoCorrFctnDPhiStarDEta::AddRealPair(AliFemtoPair* pair)
 //____________________________
 void AliFemtoCorrFctnDPhiStarDEta::AddMixedPair( AliFemtoPair* pair){
   // Add mixed (background) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   // Prepare variables:
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarDEta.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarDEta.h
@@ -34,6 +34,7 @@ public:
 
   void WriteHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctnDPhiStarDEta(*this); }
 
   void SetMinimumRadius(double minrad);
   void SetMagneticFieldSign(int magsign);

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarDEtaStar.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarDEtaStar.cxx
@@ -477,8 +477,9 @@ static void StoreDPhiStarDEtaStarBetweenV0s(const AliFemtoV0 *V0_1,
 void AliFemtoCorrFctnDPhiStarDEtaStar::AddRealPair( AliFemtoPair* pair){
 
   // Add real (effect) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   const AliFemtoParticle *track_1 = pair->Track1();
   const AliFemtoParticle *track_2 = pair->Track2();
@@ -518,8 +519,9 @@ void AliFemtoCorrFctnDPhiStarDEtaStar::AddRealPair( AliFemtoPair* pair){
 //____________________________
 void AliFemtoCorrFctnDPhiStarDEtaStar::AddMixedPair( AliFemtoPair* pair){
   // Add mixed (background) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   const AliFemtoParticle *track_1 = pair->Track1();
   const AliFemtoParticle *track_2 = pair->Track2();

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarDEtaStar.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarDEtaStar.h
@@ -93,6 +93,7 @@ class AliFemtoCorrFctnDPhiStarDEtaStar : public AliFemtoCorrFctn {
   virtual void Finish();
   void WriteHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctnDPhiStarDEtaStar(*this); }
 
   void SetRadius(double minrad);
   void SetPairType(AliFemtoPairType pairtype);

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction.h
@@ -45,6 +45,8 @@ public:
   void SetDEtaMax(double deta);
   void SetMagneticFieldSign(int magsign);
 
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctnDPhiStarKStarAverageMergedPointsFraction(*this); }
+
 private:
 
   TH2D *fDPhiStarKStarMergedNumerator;              // Numerator of dPhi* k* function for "merged" fraction of points

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarKStarMergedFraction.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarKStarMergedFraction.cxx
@@ -30,10 +30,10 @@ AliFemtoCorrFctn(),
   fDPhiStarKStarTotalNumerator(0),
   fDPhiStarKStarMergedDenominator(0),
   fDPhiStarKStarTotalDenominator(0),
-  fKStarRangeLow(0),
-  fKStarRangeUp(0),
   fDPhiStarRangeLow(0),
   fDPhiStarRangeUp(0),
+  fKStarRangeLow(0),
+  fKStarRangeUp(0),
   fDistanceMax(0.0),
   fMergedFractionLimit(0.0),
   fDEtaMax(0.0),
@@ -86,10 +86,10 @@ AliFemtoCorrFctnDPhiStarKStarMergedFraction::AliFemtoCorrFctnDPhiStarKStarMerged
   fDPhiStarKStarTotalNumerator(0),
   fDPhiStarKStarMergedDenominator(0),
   fDPhiStarKStarTotalDenominator(0),
-  fKStarRangeLow(0),
-  fKStarRangeUp(0),
   fDPhiStarRangeLow(0),
   fDPhiStarRangeUp(0),
+  fKStarRangeLow(0),
+  fKStarRangeUp(0),
   fDistanceMax(0.0),
   fMergedFractionLimit(0.0),
   fDEtaMax(0.0),
@@ -208,8 +208,9 @@ AliFemtoString AliFemtoCorrFctnDPhiStarKStarMergedFraction::Report(){
 //____________________________
 void AliFemtoCorrFctnDPhiStarKStarMergedFraction::AddRealPair( AliFemtoPair* pair){
   // Add real (effect) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   // Prepare variables:
   double phi1 = pair->Track1()->Track()->P().Phi();
@@ -293,8 +294,9 @@ void AliFemtoCorrFctnDPhiStarKStarMergedFraction::AddRealPair( AliFemtoPair* pai
 //____________________________
 void AliFemtoCorrFctnDPhiStarKStarMergedFraction::AddMixedPair( AliFemtoPair* pair){
   // Add real (effect) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   // Prepare variables:
   double phi1 = pair->Track1()->Track()->P().Phi();

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarKStarMergedFraction.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnDPhiStarKStarMergedFraction.h
@@ -35,6 +35,8 @@ public:
 
   void WriteHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctnDPhiStarKStarMergedFraction(*this); }
+
 
   void SetRadiusMin(double minrad);
   void SetRadiusMax(double maxrad);

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnNonIdDR.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoCorrFctnNonIdDR.h
@@ -39,6 +39,8 @@ public:
   virtual AliFemtoCorrFctn* Clone();
   void FillParticleP(bool);
 
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctnNonIdDR(*this); }
+
 protected:
   TH1D *fNumOutP;     ///< Numerator for pair with positive k*out
   TH1D *fNumOutN;     ///< Numerator for pair with negative k*out

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoLikeSignCorrFctn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoLikeSignCorrFctn.h
@@ -22,10 +22,8 @@ public:
   virtual void AddLikeSignPositivePair(const AliFemtoPair* aPair) = 0;
   virtual void AddLikeSignNegativePair(const AliFemtoPair* aPair) = 0;
 
-  virtual AliFemtoLikeSignCorrFctn* Clone() { return 0;}
   virtual TList* GetOutputList() = 0;
 
-  // the following allows "back-pointing" from the CorrFctn to the "parent" Analysis
 };
 //________________________________________
 inline AliFemtoLikeSignCorrFctn::AliFemtoLikeSignCorrFctn(const AliFemtoLikeSignCorrFctn& /* c */):AliFemtoCorrFctn() { fyAnalysis =0; }

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoModelCorrFctn.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoModelCorrFctn.cxx
@@ -46,7 +46,7 @@ AliFemtoCorrFctn(),
         fkTdists[i] = new TH1D(Form("fkTdists[%i]",i),Form("fkTdists[%i]",i),100,0.0,5.0);
         fkTdists[i]->Sumw2();
     }
-    
+
   fNumeratorTrue->Sumw2();
   fNumeratorFake->Sumw2();
   fDenominator->Sumw2();
@@ -96,7 +96,7 @@ AliFemtoModelCorrFctn::AliFemtoModelCorrFctn(const char *title, Int_t aNbins, Do
         fkTdists[i] = new TH1D(Form("fkTdists[%i]_%s",i,title),Form("fkTdists[%i]_%s",i,title),100,0.0,5.0);
         fkTdists[i]->Sumw2();
     }
-    
+
   fNumeratorTrue->Sumw2();
   fNumeratorFake->Sumw2();
   fDenominator->Sumw2();
@@ -142,7 +142,7 @@ AliFemtoModelCorrFctn::AliFemtoModelCorrFctn(const AliFemtoModelCorrFctn& aCorrF
         if(aCorrFctn.fkTdists[i])
             fkTdists[i] = aCorrFctn.fkTdists[i];
     }
-    
+
   fManager = aCorrFctn.fManager;
 }
 //_______________________
@@ -158,7 +158,7 @@ AliFemtoModelCorrFctn::~AliFemtoModelCorrFctn()
   if (fDenominatorIdeal) delete fDenominatorIdeal;
 
   if (fQgenQrec) delete fQgenQrec;
-    
+
     for(int i=0;i<fNbbPairs;i++){
         if(fkTdists[i]) delete fkTdists[i];
     }
@@ -196,7 +196,7 @@ AliFemtoModelCorrFctn& AliFemtoModelCorrFctn::operator=(const AliFemtoModelCorrF
         fkTdists[i] = (aCorrFctn.fkTdists[i])
         ? new TH1D(*aCorrFctn.fkTdists[i])
         : nullptr;
-  
+
     }
   delete fNumeratorTrueIdeal;
   fNumeratorTrueIdeal = (aCorrFctn.fNumeratorTrueIdeal)
@@ -237,20 +237,22 @@ AliFemtoString AliFemtoModelCorrFctn::Report()
 //_______________________
 void AliFemtoModelCorrFctn::AddRealPair(AliFemtoPair* aPair)
 {
-  if (fPairCut)
-    if (!fPairCut->Pass(aPair)) return;//SetPairSelectionCut() in ConfigFemtoAnalysis.C
+  if (fPairCut && !fPairCut->Pass(aPair)) {
+    return;
+  }
+
   if(!fKaonPDG) {
     // cout<<" AliFemtoModelCorrFcn add real pair "<<endl;
     Double_t weight = fManager->GetWeight(aPair);
     //cout<<" wight "<< weight<<endl;
     //cout<<"Qinv"<<aPair->QInv()<<endl;
-    
+
     fNumeratorTrue->Fill(aPair->QInv(), weight);
-    
+
     Double_t tQinvTrue = GetQinvTrue(aPair);
-    
+
     fNumeratorTrueIdeal->Fill(tQinvTrue, weight);
-    
+
     //cout<<"Qinv true"<<tQinvTrue<<endl;
   }
   //Special MC analysis for K selected by PDG code -->
@@ -264,22 +266,24 @@ void AliFemtoModelCorrFctn::AddRealPair(AliFemtoPair* aPair)
 //_______________________
 void AliFemtoModelCorrFctn::AddMixedPair(AliFemtoPair* aPair)
 {
-  if (fPairCut)
-    if (!fPairCut->Pass(aPair)) return;//SetPairSelectionCut() in ConfigFemtoAnalysis.C
+  if (fPairCut && !fPairCut->Pass(aPair)) {
+    return;
+  }
+
   if(!fKaonPDG) {
     Double_t weight = fManager->GetWeight(aPair);
     fNumeratorFake->Fill(aPair->QInv(), weight);
     fDenominator->Fill(aPair->QInv(), 1.0);
-    
+
     Double_t tQinvTrue = GetQinvTrue(aPair);
-    
+
     fNumeratorFakeIdeal->Fill(tQinvTrue, weight);
     fDenominatorIdeal->Fill(tQinvTrue, 1.0);
-    
+
       if(fFillkT)
       {
           int pairNumber = GetPairNumber(aPair);
-          
+
           if(pairNumber >= 0){
               if(fkTdists[pairNumber]){
                   fkTdists[pairNumber]->Fill(GetParentsKt(aPair));
@@ -311,20 +315,20 @@ void AliFemtoModelCorrFctn::AddMixedPair(AliFemtoPair* aPair)
 Double_t AliFemtoModelCorrFctn::GetQinvTrue(AliFemtoPair* aPair)
 {
   if(!fKaonPDG) {
-      
+
       AliFemtoParticle *first = (AliFemtoParticle*)aPair->Track1();
       AliFemtoParticle *second = (AliFemtoParticle*)aPair->Track2();
-      
+
       if(!first || !second) return -1;
-      
+
       AliFemtoModelHiddenInfo *inf1 = (AliFemtoModelHiddenInfo*)first->GetHiddenInfo();
       AliFemtoModelHiddenInfo *inf2 = (AliFemtoModelHiddenInfo*)second->GetHiddenInfo();
-      
+
       if(!inf1 || !inf2){
 //          cout<<"no hidden info"<<endl;
           return -1;
       }
-      
+
       AliFemtoLorentzVector fm1;
       AliFemtoThreeVector* temp = inf1->GetTrueMomentum();
       fm1.SetVect(*temp);
@@ -332,18 +336,18 @@ Double_t AliFemtoModelCorrFctn::GetQinvTrue(AliFemtoPair* aPair)
       Double_t am2 = inf2->GetMass();
       double ener = TMath::Sqrt(temp->Mag2()+am1*am1);
       fm1.SetE(ener);
-      
+
       AliFemtoLorentzVector fm2;
       AliFemtoThreeVector* temp2 =  inf2->GetTrueMomentum();
       fm2.SetVect(*temp2);
       ener = TMath::Sqrt(temp2->Mag2()+am2*am2);
       fm2.SetE(ener);
-      
+
       //std::cout<<" CFModel mass1 mass2 "<<am1<<" "<<am2<<std::endl;
-      
+
       AliFemtoLorentzVector tQinvTrueVec = (fm1-fm2);
       Double_t tQinvTrue = -1.* tQinvTrueVec.m();
-      
+
       return tQinvTrue;
   }
   //Special MC analysis for K selected by PDG code -->
@@ -356,13 +360,13 @@ Double_t AliFemtoModelCorrFctn::GetQinvTrue(AliFemtoPair* aPair)
   fm1.SetVect(*temp);
   Double_t am1 = ((AliFemtoModelHiddenInfo*)inf1->GetHiddenInfo())->GetMass();
   Double_t am2 = ((AliFemtoModelHiddenInfo*)inf2->GetHiddenInfo())->GetMass();
- 
+
   am1=0.493677;
   am2=0.493677;
- 
+
   //Double_t pdg1 = ((AliFemtoModelHiddenInfo*)inf1->GetHiddenInfo())->GetPDGPid();
   //Double_t pdg2 = ((AliFemtoModelHiddenInfo*)inf2->GetHiddenInfo())->GetPDGPid();
- 
+
   double ener = TMath::Sqrt(temp->Mag2()+am1*am1);
   fm1.SetE(ener);
 
@@ -372,10 +376,10 @@ Double_t AliFemtoModelCorrFctn::GetQinvTrue(AliFemtoPair* aPair)
   ener = TMath::Sqrt(temp2->Mag2()+am2*am2);
   fm2.SetE(ener);
 
- 
+
   AliFemtoLorentzVector tQinvTrueVec = (fm1-fm2);
   Double_t tQinvTrue = -1.* tQinvTrueVec.m();
-  
+
  // if(tQinvTrue<0 && am1!=0 && am2!=0)std::cout<<" CFModel Qinv mass1 mass2 "<<aPair->QInv()<<" Qinv_true "<<tQinvTrue<<" "<<am1<<" "<<am2<<" pdg1 "<<pdg1<<" pdg2 "<<pdg2<<std::endl;
  // if(pdg1!=211 || pdg2!=211)std::cout<<" CFModel Qinv mass1 mass2 "<<aPair->QInv()<<" Qinv_true "<<tQinvTrue<<" "<<am1<<" "<<am2<<" pdg1 "<<pdg1<<" pdg2 "<<pdg2<<std::endl;
 
@@ -455,7 +459,7 @@ double AliFemtoModelCorrFctn::GetParentsKt(AliFemtoPair *pair)
 {
     AliFemtoParticle *first = new AliFemtoParticle(*(pair->Track1()));
     AliFemtoParticle *second = new AliFemtoParticle(*(pair->Track2()));
-    
+
     if(!first)
     {
         if(second) delete second;
@@ -466,10 +470,10 @@ double AliFemtoModelCorrFctn::GetParentsKt(AliFemtoPair *pair)
         if(first) delete first;
         return -1;
     }
-    
+
     AliFemtoModelHiddenInfo *info1 = (AliFemtoModelHiddenInfo*)first->GetHiddenInfo();
     AliFemtoModelHiddenInfo *info2 = (AliFemtoModelHiddenInfo*)second->GetHiddenInfo();
-    
+
     if(!info1 || !info2)
     {
         if(first) delete first;
@@ -478,7 +482,7 @@ double AliFemtoModelCorrFctn::GetParentsKt(AliFemtoPair *pair)
     }
     AliFemtoThreeVector* p1 = info1->GetMotherMomentum();
     AliFemtoThreeVector* p2 = info2->GetMotherMomentum();
-    
+
     if(!p1 || !p2)
     {
         if(first) delete first;
@@ -488,9 +492,9 @@ double AliFemtoModelCorrFctn::GetParentsKt(AliFemtoPair *pair)
     double px = p1->x() + p2->x();
     double py = p1->y() + p2->y();
     double pT = sqrt(px*px + py*py);
-    
+
     delete first;delete second;
-    
+
     return pT/2.;
 }
 
@@ -498,7 +502,7 @@ int AliFemtoModelCorrFctn::GetPairNumber(AliFemtoPair *pair)
 {
     AliFemtoParticle *first = new AliFemtoParticle(*(pair->Track1()));
     AliFemtoParticle *second = new AliFemtoParticle(*(pair->Track2()));
-    
+
     if(!first)
     {
         if(second) delete second;
@@ -509,29 +513,29 @@ int AliFemtoModelCorrFctn::GetPairNumber(AliFemtoPair *pair)
         if(first) delete first;
         return -1;
     }
-    
+
     AliFemtoModelHiddenInfo *info1 = (AliFemtoModelHiddenInfo*)first->GetHiddenInfo();
     AliFemtoModelHiddenInfo *info2 = (AliFemtoModelHiddenInfo*)second->GetHiddenInfo();
-    
+
     if(!info1 || !info2)
     {
         if(first) delete first;
         if(second) delete second;
         return -1;
     }
-        
+
     int pdg1 = TMath::Abs(info1->GetMotherPdgCode());
     int pdg2 = TMath::Abs(info2->GetMotherPdgCode());
-    
+
     int tmp;
     if(pdg2 < pdg1){
         tmp = pdg1;
         pdg1 = pdg2;
         pdg2 = tmp;
     }
-    
+
     delete first;delete second;
-    
+
     if(pdg1 == 2212 && pdg2 == 2212) return 0; // pp
     if(pdg1 == 2212 && pdg2 == 3122) return 1; // pΛ
     if(pdg1 == 3122 && pdg2 == 3122) return 2; // ΛΛ
@@ -553,7 +557,7 @@ int AliFemtoModelCorrFctn::GetPairNumber(AliFemtoPair *pair)
     if(pdg1 == 3212 && pdg2 == 3322) return 18; // Σ0Ξ0
     if(pdg1 == 3212 && pdg2 == 3312) return 19; // Σ0Ξ-
     if(pdg1 == 3212 && pdg2 == 3212) return 20; // Σ0Σ0
-    
+
     return -1;
 }
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoModelCorrFctn.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoModelCorrFctn.cxx
@@ -423,14 +423,6 @@ void AliFemtoModelCorrFctn::Write()
 
 
 }
-//_______________________
-AliFemtoModelCorrFctn* AliFemtoModelCorrFctn::Clone()
-{
-  // Create clone
-  AliFemtoModelCorrFctn *tCopy = new AliFemtoModelCorrFctn(*this);
-
-  return tCopy;
-}
 //_________________________
 TList* AliFemtoModelCorrFctn::GetOutputList()
 {

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoModelCorrFctn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoModelCorrFctn.h
@@ -37,12 +37,12 @@ public:
   virtual TList* GetOutputList();
   virtual void Write();
 
-  virtual AliFemtoModelCorrFctn* Clone();
+  virtual AliFemtoModelCorrFctn* Clone() const { return new AliFemtoModelCorrFctn(*this); }
 
-    void SetFillkT(bool fillkT){fFillkT = fillkT;}
-    
+  void SetFillkT(bool fillkT){fFillkT = fillkT;}
+
   Double_t GetQinvTrue(AliFemtoPair*);
-  
+
   //Special MC analysis for K selected by PDG code -->
   void SetKaonPDG(Bool_t aSetKaonAna);
 
@@ -61,7 +61,7 @@ protected:
 
 
 private:
-  
+
   //Special MC analysis for K selected by PDG code -->
   Bool_t fKaonPDG;
 
@@ -70,7 +70,7 @@ private:
     TH1D *fkTdists[21]; // histograms with kT distributions for different BB pairs
     double GetParentsKt(AliFemtoPair *pair);
     int GetPairNumber(AliFemtoPair *pair); // returns pair code
-    
+
 #ifdef __ROOT__
   /// \cond CLASSIMP
   ClassDef(AliFemtoModelCorrFctn, 1);

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoModelCorrFctn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoModelCorrFctn.h
@@ -34,9 +34,8 @@ public:
   virtual void EventEnd(const AliFemtoEvent* aEvent);
   virtual void Finish();
 
-  virtual TList* GetOutputList();
   virtual void Write();
-
+  virtual TList* GetOutputList();
   virtual AliFemtoModelCorrFctn* Clone() const { return new AliFemtoModelCorrFctn(*this); }
 
   void SetFillkT(bool fillkT){fFillkT = fillkT;}

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoQinvCorrFctn.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoQinvCorrFctn.cxx
@@ -191,8 +191,9 @@ AliFemtoString AliFemtoQinvCorrFctn::Report(){
 //____________________________
 void AliFemtoQinvCorrFctn::AddRealPair(AliFemtoPair* pair){
   // add true pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   double tQinv = fabs(pair->QInv());   // note - qInv() will be negative for identical pairs...
 
@@ -256,8 +257,9 @@ void AliFemtoQinvCorrFctn::AddRealPair(AliFemtoPair* pair){
 //____________________________
 void AliFemtoQinvCorrFctn::AddMixedPair(AliFemtoPair* pair){
   // add mixed (background) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   double weight = 1.0;
   double tQinv = fabs(pair->QInv());   // note - qInv() will be negative for identical pairs...

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoQinvCorrFctn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoQinvCorrFctn.h
@@ -80,6 +80,8 @@ public:
   virtual TList* GetOutputList();
   void Write();
 
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoQinvCorrFctn(*this); }
+
 private:
   TH1D* fNumerator;          // numerator - real pairs
   TH1D* fDenominator;        // denominator - mixed pairs

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSpatialSeparationFunction.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSpatialSeparationFunction.h
@@ -32,6 +32,8 @@ public:
   virtual void Finish();
   void WriteHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoSpatialSeparationFunction(*this); }
+
   
 private:
   TH1D *fAlphaNum; // distibution of angles between momenta of particle collections from the same event

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisPionPionObjectConstructor.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisPionPionObjectConstructor.h
@@ -548,8 +548,8 @@ struct Configuration<AliFemtoPairCutAntiGamma> : Configuration<AliFemtoShareQual
 //------------------------
 
 
-#if defined(AliFemtoCorrFctn_hh) && !defined(ALIFEMTOCONSTRUCTOR_AliFemtoCorrFctn_hh)
-#define ALIFEMTOCONSTRUCTOR_AliFemtoCorrFctn_hh
+#if defined(ALIFEMTOCORRFCTN_H) && !defined(ALIFEMTOCONSTRUCTOR_ALIFEMTOCORRFCTN_H)
+#define ALIFEMTOCONSTRUCTOR_ALIFEMTOCORRFCTN_H
 template<>
 struct AbstractConfiguration<AliFemtoCorrFctn> {
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAvgSepCorrFctn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAvgSepCorrFctn.h
@@ -91,6 +91,8 @@ public:
   TH1D *Ratio();
 
   virtual TList *GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoAvgSepCorrFctn(*this); }
+
   void Write();
   void SetPairType(AliFemtoPairType pairtype);
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoBPLCMS3DCorrFctnEMCIC.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoBPLCMS3DCorrFctnEMCIC.h
@@ -57,6 +57,7 @@ public:
 
   void WriteOutHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoBPLCMS3DCorrFctnEMCIC(*this); }
 
  private:
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoChi2CorrFctn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoChi2CorrFctn.h
@@ -30,6 +30,8 @@ public:
 
   void WriteHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoChi2CorrFctn(*this); }
+
 private:
 
   TH2D *fChi2ITSSUMNumerator;        // Numerator as a function of ITS quality sum for the pair

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DPRF.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DPRF.cxx
@@ -145,8 +145,8 @@ AliFemtoString AliFemtoCorrFctn3DPRF::Report(){
 //____________________________
 void AliFemtoCorrFctn3DPRF::AddRealPair( AliFemtoPair* pair){
   // perform operations on real pairs
-  if (fPairCut){
-    if (!(fPairCut->Pass(pair))) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
   }
 
   double kOut = (pair->KOut());
@@ -163,8 +163,8 @@ void AliFemtoCorrFctn3DPRF::AddRealPair( AliFemtoPair* pair){
 //____________________________
 void AliFemtoCorrFctn3DPRF::AddMixedPair( AliFemtoPair* pair){
   // perform operations on mixed pairs
-  if (fPairCut){
-    if (!(fPairCut->Pass(pair))) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
   }
 
   double kOut = (pair->KOut());
@@ -175,9 +175,6 @@ void AliFemtoCorrFctn3DPRF::AddMixedPair( AliFemtoPair* pair){
 
     fDenominator->Fill(kOut,kSide,kLong,1.0);
     //fDenominatorW->Fill(qOut,qSide,qLong,qqqinv);
-
-
-
 }
 
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DPRF.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DPRF.h
@@ -34,6 +34,7 @@ public:
 
   void WriteOutHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctn3DPRF(*this); }
 
 private:
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DPRF_qosl_q.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DPRF_qosl_q.cxx
@@ -169,8 +169,8 @@ AliFemtoString AliFemtoCorrFctn3DPRF_qosl_q::Report(){
 //____________________________
 void AliFemtoCorrFctn3DPRF_qosl_q::AddRealPair( AliFemtoPair* pair){
   // perform operations on real pairs
-  if (fPairCut){
-    if (!(fPairCut->Pass(pair))) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
   }
      Double_t x[4];
     for (Int_t d = 0; d < 4; ++d) {
@@ -199,8 +199,8 @@ void AliFemtoCorrFctn3DPRF_qosl_q::AddRealPair( AliFemtoPair* pair){
 //____________________________
 void AliFemtoCorrFctn3DPRF_qosl_q::AddMixedPair( AliFemtoPair* pair){
   // perform operations on mixed pairs
-  if (fPairCut){
-    if (!(fPairCut->Pass(pair))) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
   }
      Double_t x[4];
     for (Int_t d = 0; d < 4; ++d) {

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DPRF_qosl_q.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DPRF_qosl_q.h
@@ -37,6 +37,7 @@ public:
 
   void WriteOutHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctn3DPRF_qosl_q(*this); }
 
 private:
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DSphericalEMCIC.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctn3DSphericalEMCIC.h
@@ -32,6 +32,7 @@ public:
 
   void WriteOutHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctn3DSphericalEMCIC(*this); }
 
   void SetSpecificPairCut(AliFemtoPairCut* aCut);
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhi.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhi.cxx
@@ -375,8 +375,9 @@ AliFemtoString AliFemtoCorrFctnDEtaDPhi::Report(){
 //____________________________
 void AliFemtoCorrFctnDEtaDPhi::AddRealPair( AliFemtoPair* pair){
   // add real (effect) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   /*double phi1 = pair->Track1()->Track()->P().Phi();
     double phi2 = pair->Track2()->Track()->P().Phi();
@@ -446,8 +447,9 @@ void AliFemtoCorrFctnDEtaDPhi::AddRealPair( AliFemtoPair* pair){
 //____________________________
 void AliFemtoCorrFctnDEtaDPhi::AddMixedPair( AliFemtoPair* pair){
   // add mixed (background) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   /*double phi1 = pair->Track1()->Track()->P().Phi();
   double phi2 = pair->Track2()->Track()->P().Phi();

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhi.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhi.h
@@ -37,6 +37,9 @@ public:
 
   void WriteHistos();
   virtual TList* GetOutputList();
+
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctnDEtaDPhi(*this); }
+
 private:
 
   TH2D *fDPhiDEtaNumerator;          // Numerator of dEta dPhi function

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiCorrections.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiCorrections.cxx
@@ -399,8 +399,9 @@ AliFemtoString AliFemtoCorrFctnDEtaDPhiCorrections::Report(){
 //____________________________
 void AliFemtoCorrFctnDEtaDPhiCorrections::AddRealPair( AliFemtoPair* pair){
   // add real (effect) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   /*double phi1 = pair->Track1()->Track()->P().Phi();
     double phi2 = pair->Track2()->Track()->P().Phi();
@@ -488,8 +489,9 @@ void AliFemtoCorrFctnDEtaDPhiCorrections::AddRealPair( AliFemtoPair* pair){
 //____________________________
 void AliFemtoCorrFctnDEtaDPhiCorrections::AddMixedPair( AliFemtoPair* pair){
   // add mixed (background) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   /*double phi1 = pair->Track1()->Track()->P().Phi();
     double phi2 = pair->Track2()->Track()->P().Phi();
@@ -1369,5 +1371,6 @@ double AliFemtoCorrFctnDEtaDPhiCorrections::GetPurity(double pT1, int n)
     else
       return 0;
   }
-
+  return 0;
 }
+

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiCorrections.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiCorrections.h
@@ -51,6 +51,8 @@ public:
 
   void WriteHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctnDEtaDPhiCorrections(*this); }
+
 private:
 
   TH2D *fDPhiDEtaNumerator;          // Numerator of dEta dPhi function

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimple.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimple.cxx
@@ -389,8 +389,9 @@ AliFemtoString AliFemtoCorrFctnDEtaDPhiSimple::Report(){
 //____________________________
 void AliFemtoCorrFctnDEtaDPhiSimple::AddRealPair( AliFemtoPair* pair){
   // add real (effect) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   /*double phi1 = pair->Track1()->Track()->P().Phi();
     double phi2 = pair->Track2()->Track()->P().Phi();
@@ -476,8 +477,9 @@ void AliFemtoCorrFctnDEtaDPhiSimple::AddRealPair( AliFemtoPair* pair){
 //____________________________
 void AliFemtoCorrFctnDEtaDPhiSimple::AddMixedPair( AliFemtoPair* pair){
   // add mixed (background) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   /*double phi1 = pair->Track1()->Track()->P().Phi();
   double phi2 = pair->Track2()->Track()->P().Phi();

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimple.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimple.h
@@ -56,6 +56,7 @@ public:
 
   void WriteHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctnDEtaDPhiSimple(*this); }
 
 protected:
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections.cxx
@@ -42,7 +42,7 @@ AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AliFemtoCorrFctnDEtaDPhiSimpleWit
   fphiT(0),
   fEtaBins(0),
   fPhiBins(0),
-  ftitle(0),
+  ftitle(title),
   fReadHiddenInfo(false)
 {
 
@@ -51,9 +51,6 @@ AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AliFemtoCorrFctnDEtaDPhiSimpleWit
 
   fEtaBins = aEtaBins;
   fPhiBins = aPhiBins;
-
-  ftitle = new char[100];
-  strcpy(ftitle,title);
 
   // set up numerator
   char tTitNumD[101] = "NumDPhiDEta";
@@ -98,15 +95,11 @@ AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AliFemtoCorrFctnDEtaDPhiSimpleWit
   fphiT(0),
   fEtaBins(0),
   fPhiBins(0),
-  ftitle(0),
+  ftitle(aCorrFctn.ftitle),
   fReadHiddenInfo(false)
 {
   fEtaBins = aCorrFctn.fEtaBins;
   fPhiBins = aCorrFctn.fPhiBins;
-
-  ftitle = new char[100];
-  strncat(ftitle,aCorrFctn.ftitle,100);
-
 
   // copy constructor
   if (aCorrFctn.fDPhiDEtaNumerator)
@@ -201,7 +194,6 @@ AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::~AliFemtoCorrFctnDEtaDPhiSimpleWi
 
   delete fDPhiDEtaNumerator;
   delete fDPhiDEtaDenominator;
-  delete ftitle;
   if(fReadHiddenInfo)
     {
       delete fDPhiDEtaHiddenNumerator;
@@ -232,8 +224,7 @@ AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections& AliFemtoCorrFctnDEtaDPhiSimpleWit
   fEtaBins = aCorrFctn.fEtaBins;
   fPhiBins = aCorrFctn.fPhiBins;
 
-  ftitle = new char[100];
-  strncat(ftitle,aCorrFctn.ftitle,100);
+  ftitle = aCorrFctn.ftitle;
 
   if (aCorrFctn.fDPhiDEtaNumerator)
     fDPhiDEtaNumerator = new TH2D(*aCorrFctn.fDPhiDEtaNumerator);

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections.cxx
@@ -394,8 +394,9 @@ AliFemtoString AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::Report(){
 //____________________________
 void AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AddRealPair( AliFemtoPair* pair){
   // add real (effect) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   double phi1 = pair->Track1()->FourMomentum().Phi();
   double phi2 = pair->Track2()->FourMomentum().Phi();
@@ -508,8 +509,9 @@ void AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AddRealPair( AliFemtoPair* p
 //____________________________
 void AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections::AddMixedPair( AliFemtoPair* pair){
   // add mixed (background) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   double phi1 = pair->Track1()->FourMomentum().Phi();
   double phi2 = pair->Track2()->FourMomentum().Phi();

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections.h
@@ -73,7 +73,7 @@ private:
   int fEtaBins;
   int fPhiBins;
 
-  char *ftitle;
+  TString ftitle;
 
   ParticleType part1;
   ParticleType part2;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections.h
@@ -39,6 +39,9 @@ public:
 
   void WriteHistos();
   virtual TList* GetOutputList();
+
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections(*this); }
+
 private:
 
   TH2D *fDPhiDEtaNumerator;          // Numerator of dEta dPhi function

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiTHn.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiTHn.cxx
@@ -203,8 +203,9 @@ AliFemtoString AliFemtoCorrFctnDEtaDPhiTHn::Report(){
 //____________________________
 void AliFemtoCorrFctnDEtaDPhiTHn::AddRealPair( AliFemtoPair* pair){
   // add real (effect) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   /*double phi1 = pair->Track1()->Track()->P().Phi();
     double phi2 = pair->Track2()->Track()->P().Phi();
@@ -257,8 +258,9 @@ void AliFemtoCorrFctnDEtaDPhiTHn::AddRealPair( AliFemtoPair* pair){
 //____________________________
 void AliFemtoCorrFctnDEtaDPhiTHn::AddMixedPair( AliFemtoPair* pair){
   // add mixed (background) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   /*double phi1 = pair->Track1()->Track()->P().Phi();
     double phi2 = pair->Track2()->Track()->P().Phi();

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiTHn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiTHn.h
@@ -32,6 +32,7 @@ class AliFemtoCorrFctnDEtaDPhiTHn : public AliFemtoCorrFctn {
   virtual void Finish();
   void WriteHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctnDEtaDPhiTHn(*this); }
 
  private:
   THnSparseF *fDPhiDEtaNum;  // Numerator of dEta dPhi function

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiWithWeights.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiWithWeights.cxx
@@ -42,13 +42,13 @@ AliFemtoCorrFctnDEtaDPhiWithWeights::AliFemtoCorrFctnDEtaDPhiWithWeights(const c
   fPtSumDist(0),
   fYtYtNumerator(0),
   fYtYtDenominator(0),
+  fYPtWeightsParticle1(filter1),
+  fYPtWeightsParticle2(filter2),
   fIfCorrectionHist(kNone),
   fPtCorrectionsNum(0),
   fPtCorrectionsDen(0),
   fEtaCorrectionsNum(0),
   fEtaCorrectionsDen(0),
-  fYPtWeightsParticle1(filter1),
-  fYPtWeightsParticle2(filter2),
   fphiL(0),
   fphiT(0)
 {
@@ -133,13 +133,13 @@ AliFemtoCorrFctnDEtaDPhiWithWeights::AliFemtoCorrFctnDEtaDPhiWithWeights(const A
   fPtSumDist(0),
   fYtYtNumerator(0),
   fYtYtDenominator(0),
+  fYPtWeightsParticle1(0),
+  fYPtWeightsParticle2(0),
   fIfCorrectionHist(kNone),
   fPtCorrectionsNum(0),
   fPtCorrectionsDen(0),
   fEtaCorrectionsNum(0),
   fEtaCorrectionsDen(0),
-  fYPtWeightsParticle1(0),
-  fYPtWeightsParticle2(0),
   fphiL(0),
   fphiT(0)
 {
@@ -401,12 +401,12 @@ AliFemtoString AliFemtoCorrFctnDEtaDPhiWithWeights::Report(){
   return returnThis;
 }
 //____________________________
-void AliFemtoCorrFctnDEtaDPhiWithWeights::AddRealPair( AliFemtoPair* pair){
-
+void AliFemtoCorrFctnDEtaDPhiWithWeights::AddRealPair(AliFemtoPair* pair)
+{
   // add real (effect) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
-
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   /*double phi1 = pair->Track1()->Track()->P().Phi();
     double phi2 = pair->Track2()->Track()->P().Phi();
@@ -477,10 +477,12 @@ void AliFemtoCorrFctnDEtaDPhiWithWeights::AddRealPair( AliFemtoPair* pair){
 
 }
 //____________________________
-void AliFemtoCorrFctnDEtaDPhiWithWeights::AddMixedPair( AliFemtoPair* pair){
+void AliFemtoCorrFctnDEtaDPhiWithWeights::AddMixedPair(AliFemtoPair* pair)
+{
   // add mixed (background) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   /*double phi1 = pair->Track1()->Track()->P().Phi();
   double phi2 = pair->Track2()->Track()->P().Phi();

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiWithWeights.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDEtaDPhiWithWeights.h
@@ -37,6 +37,8 @@ public:
 
   void WriteHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctnDEtaDPhiWithWeights(*this); }
+
 private:
 
   TH2D *fDPhiDEtaNumerator;          // Numerator of dEta dPhi function

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDYDPhi.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDYDPhi.cxx
@@ -414,8 +414,9 @@ AliFemtoString AliFemtoCorrFctnDYDPhi::Report(){
 //____________________________
 void AliFemtoCorrFctnDYDPhi::AddRealPair( AliFemtoPair* pair){
   // add real (effect) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   double px1 = pair->Track1()->Track()->P().x();
   double py1 = pair->Track1()->Track()->P().y();
@@ -488,8 +489,9 @@ void AliFemtoCorrFctnDYDPhi::AddRealPair( AliFemtoPair* pair){
 //____________________________
 void AliFemtoCorrFctnDYDPhi::AddMixedPair( AliFemtoPair* pair){
   // add mixed (background) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   double px1 = pair->Track1()->Track()->P().x();
   double py1 = pair->Track1()->Track()->P().y();

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDYDPhi.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDYDPhi.h
@@ -38,6 +38,9 @@ public:
 
   void WriteHistos();
   virtual TList* GetOutputList();
+
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctnDYDPhi(*this); }
+
 private:
 
   TH2D *fDPhiDYNumerator;            // Numerator of dY dPhi function

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDYDPhiSimple.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDYDPhiSimple.cxx
@@ -178,8 +178,9 @@ AliFemtoString AliFemtoCorrFctnDYDPhiSimple::Report(){
 //____________________________
 void AliFemtoCorrFctnDYDPhiSimple::AddRealPair( AliFemtoPair* pair){
   // add real (effect) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   double px1 = pair->Track1()->FourMomentum().px();
   double py1 = pair->Track1()->FourMomentum().py();
@@ -218,8 +219,9 @@ void AliFemtoCorrFctnDYDPhiSimple::AddRealPair( AliFemtoPair* pair){
 //____________________________
 void AliFemtoCorrFctnDYDPhiSimple::AddMixedPair( AliFemtoPair* pair){
   // add mixed (background) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   double px1 = pair->Track1()->FourMomentum().px();
   double py1 = pair->Track1()->FourMomentum().py();

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDYDPhiSimple.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDYDPhiSimple.h
@@ -33,6 +33,9 @@ public:
 
   void WriteHistos();
   virtual TList* GetOutputList();
+
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctnDYDPhiSimple(*this); }
+
 private:
 
   TH2D *fDPhiDYNumerator;            // Numerator of dY dPhi function

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDirectYlm.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDirectYlm.cxx
@@ -77,7 +77,7 @@ AliFemtoCorrFctnDirectYlm::AliFemtoCorrFctnDirectYlm(const char *name, int maxl,
     }
   }
   while (el <= maxl);
-  
+
   // *DEB*  for (il=0; il<fMaxJM; il++)
   // *DEB*    cout << "il el em " << il << " " << felsi[il] << " " << femsi[il] << endl;
 
@@ -92,7 +92,7 @@ AliFemtoCorrFctnDirectYlm::AliFemtoCorrFctnDirectYlm(const char *name, int maxl,
   fnumsimag = (TH1D **) malloc(sizeof(TH1D *) * fMaxJM);
   fdensreal = (TH1D **) malloc(sizeof(TH1D *) * fMaxJM);
   fdensimag = (TH1D **) malloc(sizeof(TH1D *) * fMaxJM);
-  
+
   char bufname[200];
   for (int ihist=0; ihist<fMaxJM; ihist++) {
     snprintf(bufname , 200,  "NumReYlm%i%i%s", felsi[ihist], femsi[ihist]<0 ? felsi[ihist]-femsi[ihist] : femsi[ihist], name);
@@ -117,7 +117,7 @@ AliFemtoCorrFctnDirectYlm::AliFemtoCorrFctnDirectYlm(const char *name, int maxl,
   fbinctd = new TH1D(bufname, bufname, ibin, vmin, vmax);
 
   fYlmBuffer = (complex<double> *) malloc(sizeof(complex<double>) * fMaxJM);
-  
+
   // Covariance matrices
   fcovmnum = (double *) malloc(sizeof(double) * fMaxJM * fMaxJM * 4 * ibin);
   fcovmden = (double *) malloc(sizeof(double) * fMaxJM * fMaxJM * 4 * ibin);
@@ -219,12 +219,12 @@ AliFemtoCorrFctnDirectYlm::AliFemtoCorrFctnDirectYlm(const AliFemtoCorrFctnDirec
     }
   }
   while (el <= fMaxL);
-  
+
   fnumsreal = (TH1D **) malloc(sizeof(TH1D *) * fMaxJM);
   fnumsimag = (TH1D **) malloc(sizeof(TH1D *) * fMaxJM);
   fdensreal = (TH1D **) malloc(sizeof(TH1D *) * fMaxJM);
   fdensimag = (TH1D **) malloc(sizeof(TH1D *) * fMaxJM);
-  
+
   for (int ihist=0; ihist<fMaxJM; ihist++) {
     if (aCorrFctn.fnumsreal[ihist])
       fnumsreal[ihist] = new TH1D(*aCorrFctn.fnumsreal[ihist]);
@@ -244,17 +244,17 @@ AliFemtoCorrFctnDirectYlm::AliFemtoCorrFctnDirectYlm(const AliFemtoCorrFctnDirec
       fdensimag[ihist] = 0;
   }
 
-  if (aCorrFctn.fbinctn) 
+  if (aCorrFctn.fbinctn)
     fbinctn = new TH1D(*aCorrFctn.fbinctn);
   else
     fbinctn = 0;
-  if (aCorrFctn.fbinctd) 
+  if (aCorrFctn.fbinctd)
     fbinctd = new TH1D(*aCorrFctn.fbinctd);
   else
     fbinctd = 0;
 
   fYlmBuffer = (complex<double> *) malloc(sizeof(complex<double>) * fMaxJM);
-  
+
   // Covariance matrices
   fcovmnum = (double *) malloc(sizeof(double) * fMaxJM * fMaxJM * 4 * ibin);
   fcovmden = (double *) malloc(sizeof(double) * fMaxJM * fMaxJM * 4 * ibin);
@@ -288,7 +288,7 @@ AliFemtoCorrFctnDirectYlm& AliFemtoCorrFctnDirectYlm::operator=(const AliFemtoCo
   // assignment operator
   if (this == &aCorrFctn)
     return *this;
-  
+
   int ibin = 0;
   if (aCorrFctn.fbinctn)
     ibin = aCorrFctn.fbinctn->GetNbinsX();
@@ -308,7 +308,7 @@ AliFemtoCorrFctnDirectYlm& AliFemtoCorrFctnDirectYlm::operator=(const AliFemtoCo
   int el = 0;
   int em = 0;
   int il = 0;
-  
+
   if (fels) free (fels);
   if (fems) free (fems);
   if (felsi) free (felsi);
@@ -332,17 +332,17 @@ AliFemtoCorrFctnDirectYlm& AliFemtoCorrFctnDirectYlm::operator=(const AliFemtoCo
     }
   }
   while (el <= fMaxL);
-  
+
   if (fnumsreal) free (fnumsreal);
-  if (fnumsimag) free (fnumsimag);  
-  if (fdensreal) free (fdensreal);   
-  if (fdensimag) free (fdensimag);   
+  if (fnumsimag) free (fnumsimag);
+  if (fdensreal) free (fdensreal);
+  if (fdensimag) free (fdensimag);
 
   fnumsreal = (TH1D **) malloc(sizeof(TH1D *) * fMaxJM);
   fnumsimag = (TH1D **) malloc(sizeof(TH1D *) * fMaxJM);
   fdensreal = (TH1D **) malloc(sizeof(TH1D *) * fMaxJM);
   fdensimag = (TH1D **) malloc(sizeof(TH1D *) * fMaxJM);
-  
+
   for (int ihist=0; ihist<fMaxJM; ihist++) {
     if (aCorrFctn.fnumsreal[ihist])
       fnumsreal[ihist] = new TH1D(*aCorrFctn.fnumsreal[ihist]);
@@ -362,11 +362,11 @@ AliFemtoCorrFctnDirectYlm& AliFemtoCorrFctnDirectYlm::operator=(const AliFemtoCo
       fdensimag[ihist] = 0;
   }
 
-  if (aCorrFctn.fbinctn) 
+  if (aCorrFctn.fbinctn)
     fbinctn = new TH1D(*aCorrFctn.fbinctn);
   else
     fbinctn = 0;
-  if (aCorrFctn.fbinctd) 
+  if (aCorrFctn.fbinctd)
     fbinctd = new TH1D(*aCorrFctn.fbinctd);
   else
     fbinctd = 0;
@@ -374,11 +374,11 @@ AliFemtoCorrFctnDirectYlm& AliFemtoCorrFctnDirectYlm::operator=(const AliFemtoCo
   if (fYlmBuffer) free (fYlmBuffer);
 
   fYlmBuffer = (complex<double> *) malloc(sizeof(complex<double>) * fMaxJM);
-  
+
   // Covariance matrices
 
   if (fcovmnum) free (fcovmnum);
-  if (fcovmden) free (fcovmden);  
+  if (fcovmden) free (fcovmden);
 
   fcovmnum = (double *) malloc(sizeof(double) * fMaxJM * fMaxJM * 4 * ibin);
   fcovmden = (double *) malloc(sizeof(double) * fMaxJM * fMaxJM * 4 * ibin);
@@ -401,7 +401,7 @@ AliFemtoCorrFctnDirectYlm& AliFemtoCorrFctnDirectYlm::operator=(const AliFemtoCo
   fSside = aCorrFctn.fSside;
   fSlong = aCorrFctn.fSlong;
 
-  if (aCorrFctn.fPairCut) 
+  if (aCorrFctn.fPairCut)
     fPairCut = aCorrFctn.fPairCut;
 
   fUseLCMS = aCorrFctn.fUseLCMS;
@@ -479,7 +479,7 @@ double AliFemtoCorrFctnDirectYlm::ClebschGordan(double aJot1, double aEm1, doubl
 	       factorials[lrint(aJot2+aEm2-titer)] *
 	       factorials[lrint(aJot-aJot2+aEm1+titer)] *
 	       factorials[lrint(aJot-aJot1-aEm2+titer)]);
-      
+
       cgc += coef;
     }
 
@@ -507,22 +507,22 @@ double AliFemtoCorrFctnDirectYlm::DeltaJ(double aJot1, double aJot2, double aJot
     //    cout << "J1+J2+J3+1 < 0 !!!" << " " << aJot1 << " " << aJot2 << " " << aJot << endl;
     return 0;
   }
-  double res = TMath::Sqrt(1.0 * 
-			   factorials[lrint(aJot1+aJot2-aJot)] * 
-			   factorials[lrint(aJot1-aJot2+aJot)] * 
-			   factorials[lrint(-aJot1+aJot2+aJot)] / 
+  double res = TMath::Sqrt(1.0 *
+			   factorials[lrint(aJot1+aJot2-aJot)] *
+			   factorials[lrint(aJot1-aJot2+aJot)] *
+			   factorials[lrint(-aJot1+aJot2+aJot)] /
 			   factorials[lrint(aJot1+aJot2+aJot+1)]);
-  
+
   return res;
 }
 
 double AliFemtoCorrFctnDirectYlm::WignerSymbol(double aJot1, double aEm1, double aJot2, double aEm2, double aJot, double aEm)
 {
   // Get Wigner symbol
-  if (lrint(aEm1+aEm2+aEm) != 0.0) 
+  if (lrint(aEm1+aEm2+aEm) != 0.0)
     return 0.0;
   double cge = ClebschGordan(aJot1, aEm1, aJot2, aEm2, aJot, -aEm);
-  if (lrint(abs(aJot1 - aJot2 - aEm)) % 2) 
+  if (lrint(abs(aJot1 - aJot2 - aEm)) % 2)
     cge *= -1.0;
   cge /= sqrt(2*aJot + 1);
 
@@ -538,7 +538,7 @@ void AliFemtoCorrFctnDirectYlm::GetMtilde(complex<double> *aMat, double *aMTilde
   double lzero, mzero;
   double lprim, mprim;
   double lbis, mbis;
- 
+
   int lzeroi, mzeroi;
   int lprimi, mprimi;
   int lbisi, mbisi;
@@ -559,7 +559,7 @@ void AliFemtoCorrFctnDirectYlm::GetMtilde(complex<double> *aMat, double *aMTilde
 
 	if (abs(mzeroi) % 2) mcomp = complex<double>(-1.0, 0.0); // (-1)^m
 	else mcomp = complex<double>(1.0, 0.0);
-	
+
 	mcomp *= sqrt((2*lzero+1)*(2*lprim+1)*(2*lbis+1));   // P1
 	mcomp *= WignerSymbol(lzero, 0, lprim, 0, lbis, 0); // W1
 	mcomp *= WignerSymbol(lzero, -mzero, lprim, mprim, lbis, mbis); // W2
@@ -570,10 +570,10 @@ void AliFemtoCorrFctnDirectYlm::GetMtilde(complex<double> *aMat, double *aMTilde
       aMTilde[(izero*2+1)*(2*GetMaxJM()) + (ibis*2)]   =  imag(val);
       if (imag(val) != 0.0)
 	aMTilde[(izero*2)*(2*GetMaxJM()) + (ibis*2+1)]   = -imag(val);
-      else 
+      else
 	aMTilde[(izero*2)*(2*GetMaxJM()) + (ibis*2+1)]   = 0.0;
       aMTilde[(izero*2+1)*(2*GetMaxJM()) + (ibis*2+1)] =  real(val);
-      
+
     }
   }
 }
@@ -607,7 +607,7 @@ void AliFemtoCorrFctnDirectYlm::AddRealPair(double qout, double qside, double ql
   // Fill numerator
   double kv = sqrt(qout*qout + qside*qside + qlong*qlong);
   int nqbin = fbinctn->GetXaxis()->FindFixBin(kv) - 1;
-  
+
   // Use saved ylm values for same qout, qside, qlong
   if ((qout != fSout) || (qside != fSside) || (qlong != fSlong)) {
     AliFemtoYlm::YlmUpToL(fMaxL, qout, qside, qlong, fYlmBuffer);
@@ -631,16 +631,16 @@ void AliFemtoCorrFctnDirectYlm::AddRealPair(double qout, double qside, double ql
 	fcovmnum[GetBin(nqbin, ilmzero, 0, ilmprim, 1)] += real(fYlmBuffer[ilmzero])*-imag(fYlmBuffer[ilmprim])*weight*weight;
 	fcovmnum[GetBin(nqbin, ilmzero, 1, ilmprim, 0)] += -imag(fYlmBuffer[ilmzero])*real(fYlmBuffer[ilmprim])*weight*weight;
 	fcovmnum[GetBin(nqbin, ilmzero, 1, ilmprim, 1)] += -imag(fYlmBuffer[ilmzero])*-imag(fYlmBuffer[ilmprim])*weight*weight;
-	
+
       }
-  
+
 }
 
 void AliFemtoCorrFctnDirectYlm::AddMixedPair(double qout, double qside, double qlong, double weight)
 {
   // Fill denominator
   double kv = sqrt(qout*qout + qside*qside + qlong*qlong);
-  
+
   // Use saved ylm values for same qout, qside, qlong
   if ((qout != fSout) || (qside != fSside) || (qlong != fSlong)) {
     AliFemtoYlm::YlmUpToL(fMaxL, qout, qside, qlong, fYlmBuffer);
@@ -665,7 +665,7 @@ void AliFemtoCorrFctnDirectYlm::AddMixedPair(double qout, double qside, double q
 	fcovmden[GetBin(nqbin, ilmzero, 0, ilmprim, 1)] += real(fYlmBuffer[ilmzero])*-imag(fYlmBuffer[ilmprim]);
 	fcovmden[GetBin(nqbin, ilmzero, 1, ilmprim, 0)] += -imag(fYlmBuffer[ilmzero])*real(fYlmBuffer[ilmprim]);
 	fcovmden[GetBin(nqbin, ilmzero, 1, ilmprim, 1)] += -imag(fYlmBuffer[ilmzero])*-imag(fYlmBuffer[ilmprim]);
-	
+
     }
 }
 
@@ -762,7 +762,7 @@ void AliFemtoCorrFctnDirectYlm::ReadFromFile(TFile *infile, const char *name, in
   else {
 
     cout << "Creating fake covariance matrices" << endl;
-  
+
     for (int ibin=1; ibin<=fnumsreal[0]->GetNbinsX(); ibin++) {
       double nent = fnumsreal[0]->GetEntries();
       double nentd = fdensreal[0]->GetEntries();
@@ -788,7 +788,7 @@ void AliFemtoCorrFctnDirectYlm::ReadFromFile(TFile *infile, const char *name, in
 	  t1t2ri = fdensreal[ilmx]->GetBinContent(ibin)*fdensimag[ilmy]->GetBinContent(ibin)/nentd/nentd;
 	  t1t2ir = fdensimag[ilmx]->GetBinContent(ibin)*fdensreal[ilmy]->GetBinContent(ibin)/nentd/nentd;
 	  t1t2ii = fdensimag[ilmx]->GetBinContent(ibin)*fdensimag[ilmy]->GetBinContent(ibin)/nentd/nentd;
-	  
+
 	  fcovmden[GetBin(ibin-1, ilmx, 0, ilmy, 0)] = nentd*t1t2rr;
 	  fcovmden[GetBin(ibin-1, ilmx, 0, ilmy, 1)] = nentd*t1t2ri;
 	  fcovmden[GetBin(ibin-1, ilmx, 1, ilmy, 0)] = nentd*t1t2ir;
@@ -815,7 +815,7 @@ int AliFemtoCorrFctnDirectYlm::PackYlmVector(const double *invec, double *outvec
       continue;
     outvec[ioutcount++] = invec[ilm*2 + 1];
   }
-  
+
   return ioutcount;
 }
 
@@ -859,10 +859,10 @@ int AliFemtoCorrFctnDirectYlm::PackYlmMatrix(const double *inmat, double *outmat
       outmat[ioutcountz*finalsize + ioutcountp] = inmat[GetBin(0, ilmz, 1, ilmp, 1)];
       ioutcountp++;
     }
-    ioutcountz++;    
-  }	
-  
-  return ioutcountz;  
+    ioutcountz++;
+  }
+
+  return ioutcountz;
 }
 
 void AliFemtoCorrFctnDirectYlm::PackCovariances()
@@ -872,12 +872,12 @@ void AliFemtoCorrFctnDirectYlm::PackCovariances()
   snprintf(bufname , 200,  "CovNum%s", fnumsreal[0]->GetName()+10);
 
   //  if (fcovnum) delete fcovnum;
-  if (!fcovnum) 
-    fcovnum = new TH3D(bufname,bufname, 
+  if (!fcovnum)
+    fcovnum = new TH3D(bufname,bufname,
 		       fnumsreal[0]->GetNbinsX(), fnumsreal[0]->GetXaxis()->GetXmin(), fnumsreal[0]->GetXaxis()->GetXmax(),
 		       GetMaxJM()*2, -0.5, GetMaxJM()*2 - 0.5,
 		       GetMaxJM()*2, -0.5, GetMaxJM()*2 - 0.5);
-  
+
   for (int ibin=1; ibin<=fcovnum->GetNbinsX(); ibin++)
     for (int ilmz=0; ilmz<GetMaxJM()*2; ilmz++)
       for (int ilmp=0; ilmp<GetMaxJM()*2; ilmp++)
@@ -887,11 +887,11 @@ void AliFemtoCorrFctnDirectYlm::PackCovariances()
 
   //  if (fcovden) delete fcovden;
   if (!fcovden)
-    fcovden  = new TH3D(bufname,bufname, 
+    fcovden  = new TH3D(bufname,bufname,
 			fdensreal[0]->GetNbinsX(), fdensreal[0]->GetXaxis()->GetXmin(), fdensreal[0]->GetXaxis()->GetXmax(),
 			GetMaxJM()*2, -0.5, GetMaxJM()*2 - 0.5,
 			GetMaxJM()*2, -0.5, GetMaxJM()*2 - 0.5);
-		     
+
   for (int ibin=1; ibin<=fcovden->GetNbinsX(); ibin++)
     for (int ilmz=0; ilmz<GetMaxJM()*2; ilmz++)
       for (int ilmp=0; ilmp<GetMaxJM()*2; ilmp++)
@@ -907,7 +907,7 @@ void AliFemtoCorrFctnDirectYlm::UnpackCovariances()
       for (int ilmz=0; ilmz<GetMaxJM()*2; ilmz++)
 	for (int ilmp=0; ilmp<GetMaxJM()*2; ilmp++)
 	  fcovmnum[GetBin(ibin-1, ilmz/2, ilmz%2, ilmp/2, ilmp%2)] = fcovnum->GetBinContent(ibin, ilmz+1, ilmp+1);
-    
+
   }
   if (fcovden) {
     for (int ibin=1; ibin<=fcovden->GetNbinsX(); ibin++)
@@ -931,7 +931,7 @@ TH1D *AliFemtoCorrFctnDirectYlm::GetNumRealHist(int el, int em)
   // Get numerator hist for a given l,m
   if (GetIndexForLM(el, em)>=0)
     return fnumsreal[GetIndexForLM(el, em)];
-  else 
+  else
     return 0;
 }
 TH1D *AliFemtoCorrFctnDirectYlm::GetNumImagHist(int el, int em)
@@ -939,7 +939,7 @@ TH1D *AliFemtoCorrFctnDirectYlm::GetNumImagHist(int el, int em)
   // Get numerator hist for a given l,m
   if (GetIndexForLM(el, em)>=0)
     return fnumsimag[GetIndexForLM(el, em)];
-  else 
+  else
     return 0;
 }
 
@@ -948,7 +948,7 @@ TH1D *AliFemtoCorrFctnDirectYlm::GetDenRealHist(int el, int em)
   // Get denominator hist for a given l,m
   if (GetIndexForLM(el, em)>=0)
     return fdensreal[GetIndexForLM(el, em)];
-  else 
+  else
     return 0;
 }
 TH1D *AliFemtoCorrFctnDirectYlm::GetDenImagHist(int el, int em)
@@ -956,7 +956,7 @@ TH1D *AliFemtoCorrFctnDirectYlm::GetDenImagHist(int el, int em)
   // Get denominator hist for a given l,m
   if (GetIndexForLM(el, em)>=0)
     return fdensimag[GetIndexForLM(el, em)];
-  else 
+  else
     return 0;
 }
 
@@ -968,8 +968,9 @@ AliFemtoString AliFemtoCorrFctnDirectYlm::Report()
 void AliFemtoCorrFctnDirectYlm::AddRealPair(AliFemtoPair* aPair)
 {
   // Fill in the numerator
-  if (fPairCut)
-    if (!fPairCut->Pass(aPair)) return;
+  if (fPairCut && !fPairCut->Pass(aPair)) {
+    return;
+  }
 
   if (fUseLCMS)
     AddRealPair(aPair->QOutCMS(), aPair->QSideCMS(), aPair->QLongCMS(), 1.0);
@@ -980,9 +981,10 @@ void AliFemtoCorrFctnDirectYlm::AddRealPair(AliFemtoPair* aPair)
 void AliFemtoCorrFctnDirectYlm::AddMixedPair(AliFemtoPair* aPair)
 {
   // Fill in the denominator
-  if (fPairCut)
-    if (!fPairCut->Pass(aPair)) return;
-  
+  if (fPairCut && !fPairCut->Pass(aPair)) {
+    return;
+  }
+
   if (fUseLCMS)
     AddMixedPair(aPair->QOutCMS(), aPair->QSideCMS(), aPair->QLongCMS(), 1.0);
   else

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDirectYlm.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnDirectYlm.h
@@ -59,13 +59,15 @@ class AliFemtoCorrFctnDirectYlm: public AliFemtoCorrFctn {
   void SetUseLCMS(int aUseLCMS);
   int  GetUseLCMS();
 
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctnDirectYlm(*this); }
+
  private:
   double ClebschGordan(double aJot1, double aEm1, double aJot2, double aEm2, double aJot, double aEm);
   double DeltaJ(double aJot1, double aJot2, double aJot);
   double WignerSymbol(double aJot1, double aEm1, double aJot2, double aEm2, double aJot, double aEm);
-  
-  void GetMtilde(complex<double>* aMat, double *aMTilde); 
-  
+
+  void GetMtilde(complex<double>* aMat, double *aMTilde);
+
   int  GetMaxJM() const;
   void GetElEmForIndex(int aIndex, double *aEl, double *aEm) const;
   void GetElEmForIndex(int aIndex, int *aEl, int *aEm) const;
@@ -81,7 +83,7 @@ class AliFemtoCorrFctnDirectYlm: public AliFemtoCorrFctn {
 
   TH1D **fnumsreal;            // Real parts of Ylm components of the numerator
   TH1D **fnumsimag;            // Imaginary parts of Ylm components of the numerator
-  TH1D **fdensreal;            // Real parts of Ylm components of the denominator	    
+  TH1D **fdensreal;            // Real parts of Ylm components of the denominator
   TH1D **fdensimag;            // Imaginary parts of Ylm components of the denominator
 
   TH1D *fbinctn;               // Bin occupation for the numerator
@@ -110,6 +112,7 @@ class AliFemtoCorrFctnDirectYlm: public AliFemtoCorrFctn {
 
   int    fUseLCMS;             // 0 - Use PRF, 1 - Use LCMS
 };
+
 
 #endif
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnGammaMonitor.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnGammaMonitor.h
@@ -31,6 +31,8 @@ public:
 
   void WriteHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctnGammaMonitor(*this); }
+
 private:
 
   TH2D *fNumPMinvDTheta;        // Numerator Minv vs. DTheta Positive kSide

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnGammaMonitorAlpha.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnGammaMonitorAlpha.h
@@ -31,6 +31,8 @@ public:
 
   void WriteHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctnGammaMonitorAlpha(*this); }
+
 private:
 
   TH2D *fNumPMinvDAlpha;        // Numerator Minv vs. DAlpha Positive kSide

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnKStar.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnKStar.cxx
@@ -98,12 +98,12 @@ AliFemtoCorrFctnKStar::AliFemtoCorrFctnKStar(const AliFemtoCorrFctnKStar& aCorrF
   AliFemtoCorrFctn(aCorrFctn),
   fTitle(aCorrFctn.fTitle),
   fNbinsKStar(aCorrFctn.fNbinsKStar),
+  fKStarLow(aCorrFctn.fKStarLow),
+  fKStarHigh(aCorrFctn.fKStarHigh),
 
   fNumerator(aCorrFctn.fNumerator ? new TH1D(*aCorrFctn.fNumerator) : nullptr),
   fDenominator(aCorrFctn.fDenominator ? new TH1D(*aCorrFctn.fDenominator) : nullptr),
 
-  fKStarLow(aCorrFctn.fKStarLow),
-  fKStarHigh(aCorrFctn.fKStarHigh),
   fDetaDphiscal(aCorrFctn.fDetaDphiscal),
   fPairKinematics(aCorrFctn.fPairKinematics),
   fRaddedps(aCorrFctn.fRaddedps),

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnKStar.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnKStar.h
@@ -91,6 +91,8 @@ public:
   TH1D* Denominator();
   TH1D* Ratio();
 
+  virtual AliFemtoCorrFctn* Clone() const  { return new AliFemtoCorrFctnKStar(*this); }
+
 protected:
   TString fTitle;
   int fNbinsKStar;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnMinvMonitor.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnMinvMonitor.h
@@ -29,6 +29,8 @@ public:
 
   void WriteHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctnMinvMonitor(*this); }
+
 private:
 
   TH1D *fMinveeFail;   // ee mass assumption - failed pairs

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnPairFractions.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnPairFractions.cxx
@@ -190,9 +190,9 @@ void AliFemtoCorrFctnPairFractions::AddRealPair(AliFemtoPair* pair)
   // add real (effect) pair
 
   //Applying pair cuts
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
-
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
 
   Int_t pdg1=0;
@@ -273,10 +273,9 @@ void AliFemtoCorrFctnPairFractions::AddRealPair(AliFemtoPair* pair)
 void AliFemtoCorrFctnPairFractions::AddMixedPair(AliFemtoPair* pair)
 {
   // add mixed (background) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
-
-
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   Int_t pdg1=0;
   AliFemtoModelHiddenInfo *info1 = ( AliFemtoModelHiddenInfo *) pair->Track1()->GetHiddenInfo();

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnPairFractions.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnPairFractions.h
@@ -34,6 +34,7 @@ public:
   virtual void Finish();
   void WriteHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctnPairFractions(*this); }
 
   void SetDoDEtaDPhiMaps(bool dodedp=true);
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnTPCNcls.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoCorrFctnTPCNcls.h
@@ -30,6 +30,8 @@ public:
 
   void WriteHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoCorrFctnTPCNcls(*this); }
+
 private:
 
   TH2D *fNclsTPCMinNumerator;        // Numerator as a function of lower TPC Ncls of the pair

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoKtBinnedCorrFunc.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoKtBinnedCorrFunc.h
@@ -96,6 +96,8 @@ public:
   /// Constant to return if no correlation is found
   static const UInt_t NPos = static_cast<UInt_t>(-1);
 
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoKtBinnedCorrFunc(*this); }
+
 protected:
   /// Name of the output TObjArray
   TString fName;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelBPLCMSCorrFctn.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelBPLCMSCorrFctn.cxx
@@ -227,7 +227,7 @@ void AliFemtoModelBPLCMSCorrFctn::AddMixedPair( AliFemtoPair* pair){
   fQinvHisto->Fill(qOut, qSide, qLong, pair->QInv() );
 }
 //_______________________
-AliFemtoModelCorrFctn* AliFemtoModelBPLCMSCorrFctn::Clone()
+AliFemtoModelCorrFctn* AliFemtoModelBPLCMSCorrFctn::Clone() const
 {
   // Clone the correlation function
   AliFemtoModelBPLCMSCorrFctn *tCopy = new AliFemtoModelBPLCMSCorrFctn(*this);

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelBPLCMSCorrFctn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelBPLCMSCorrFctn.h
@@ -42,7 +42,7 @@ class AliFemtoModelBPLCMSCorrFctn : public AliFemtoModelCorrFctn {
   void SetSpecificPairCut(AliFemtoPairCut* aCut);
   void SetUseRPSelection(unsigned short aRPSel);
 
-  virtual AliFemtoModelCorrFctn* Clone();
+  virtual AliFemtoModelCorrFctn* Clone() const;
 
 protected:
   TH3D* fNumerator3DTrue;            // 3D Numerator with pairs from same event only

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelBPLCMSCorrFctnKK.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelBPLCMSCorrFctnKK.h
@@ -41,6 +41,7 @@ class AliFemtoModelBPLCMSCorrFctnKK : public AliFemtoModelCorrFctn {
 
   virtual void Write();
   virtual TList* GetOutputList();
+  virtual AliFemtoModelCorrFctn* Clone() const { return new AliFemtoModelBPLCMSCorrFctnKK(*this); }
 
   void SetSpecificPairCut(AliFemtoPairCut* aCut);
   void SetUseRPSelection(unsigned short aRPSel);

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctn3DLCMSSpherical.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctn3DLCMSSpherical.h
@@ -31,6 +31,7 @@ public:
 
   void WriteOutHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoModelCorrFctn* Clone() const { return new AliFemtoModelCorrFctn3DLCMSSpherical(*this); }
 
   void SetSpecificPairCut(AliFemtoPairCut* aCut);
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhi.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhi.h
@@ -34,6 +34,8 @@ public:
 
   void WriteHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoModelCorrFctn* Clone() const { return new AliFemtoModelCorrFctnDEtaDPhi(*this); }
+
 private:
 
   TH2D *fDPhiDEtaNumeratorTrue;      // Numerator of dEta dPhi true function

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhiRM.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhiRM.cxx
@@ -396,10 +396,11 @@ AliFemtoString AliFemtoModelCorrFctnDEtaDPhiRM::Report(){
   return returnThis;
 }
 //____________________________
-void AliFemtoModelCorrFctnDEtaDPhiRM::AddRealPair( AliFemtoPair* pair){
-
-   if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+void AliFemtoModelCorrFctnDEtaDPhiRM::AddRealPair( AliFemtoPair* pair)
+{
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   // add real (effect) pair
   double phi1 = pair->Track1()->Track()->P().Phi();
@@ -470,9 +471,12 @@ void AliFemtoModelCorrFctnDEtaDPhiRM::AddRealPair( AliFemtoPair* pair){
   // cout<<"Corr: "<<minv<<" masses "<<fM1<<" "<<fM2<<endl;
 }
 //____________________________
-void AliFemtoModelCorrFctnDEtaDPhiRM::AddMixedPair( AliFemtoPair* pair){
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+void AliFemtoModelCorrFctnDEtaDPhiRM::AddMixedPair( AliFemtoPair* pair)
+{
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
+
   // add mixed (background) pair
   double phi1 = pair->Track1()->Track()->P().Phi();
   double phi2 = pair->Track2()->Track()->P().Phi();

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhiStar.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhiStar.h
@@ -105,7 +105,7 @@ public:
   void WriteHistos();
   virtual TList* GetOutputList();
   virtual TList* AppendOutputList(TList &);
-
+  virtual AliFemtoModelCorrFctn* Clone() const { return new AliFemtoModelCorrFctnDEtaDPhiStar(*this); }
   static Builder Build() { return Builder(); };
 
   virtual void EventBegin(const AliFemtoEvent *);

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhiWithWeights.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDEtaDPhiWithWeights.cxx
@@ -32,6 +32,8 @@ ClassImp(AliFemtoModelCorrFctnDEtaDPhi)
 //____________________________
 AliFemtoModelCorrFctnDEtaDPhiWithWeights::AliFemtoModelCorrFctnDEtaDPhiWithWeights(const char* title,  TH2D* filter1,  TH2D* filter2, const int& aPhiBins=20, const int& aEtaBins=20):
   AliFemtoModelCorrFctn(),
+  filterHist1(filter1),
+  filterHist2(filter2),
   fDPhiDEtaNumeratorTrue(0),
   fDPhiDEtaNumeratorFake(0),
   fDPhiDEtaDenominator(0),
@@ -46,9 +48,7 @@ AliFemtoModelCorrFctnDEtaDPhiWithWeights::AliFemtoModelCorrFctnDEtaDPhiWithWeigh
   fDPhiPtNumerator(0),
   fDPhiPtDenominator(0),
   fDCosPtNumerator(0),
-  fDCosPtDenominator(0),
-  filterHist1(filter1),
-  filterHist2(filter2)
+  fDCosPtDenominator(0)
 {
   // set up numerator
   char tTitNumDT[101] = "NumDPhiDEtaTrue";
@@ -141,6 +141,8 @@ AliFemtoModelCorrFctnDEtaDPhiWithWeights::AliFemtoModelCorrFctnDEtaDPhiWithWeigh
 //____________________________
 AliFemtoModelCorrFctnDEtaDPhiWithWeights::AliFemtoModelCorrFctnDEtaDPhiWithWeights(const AliFemtoModelCorrFctnDEtaDPhiWithWeights& aCorrFctn) :
   AliFemtoModelCorrFctn(),
+  filterHist1(0),
+  filterHist2(0),
   fDPhiDEtaNumeratorTrue(0),
   fDPhiDEtaNumeratorFake(0),
   fDPhiDEtaDenominator(0),
@@ -155,9 +157,7 @@ AliFemtoModelCorrFctnDEtaDPhiWithWeights::AliFemtoModelCorrFctnDEtaDPhiWithWeigh
   fDPhiPtNumerator(0),
   fDPhiPtDenominator(0),
   fDCosPtNumerator(0),
-  fDCosPtDenominator(0),
-  filterHist1(0),
-  filterHist2(0)
+  fDCosPtDenominator(0)
 {
   // copy constructor
   if (aCorrFctn.fDPhiDEtaNumeratorTrue)

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDirectYlm.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDirectYlm.cxx
@@ -13,9 +13,9 @@
 #include "AliFemtoModelGausLCMSFreezeOutGenerator.h"
 #include "AliFemtoModelHiddenInfo.h"
 #include "AliFemtoModelCorrFctnDirectYlm.h"
-    
+
 //_______________________
-AliFemtoModelCorrFctnDirectYlm::AliFemtoModelCorrFctnDirectYlm(): 
+AliFemtoModelCorrFctnDirectYlm::AliFemtoModelCorrFctnDirectYlm():
   AliFemtoModelCorrFctn(),
   fCYlmTrue(0),
   fCYlmFake(0),
@@ -72,29 +72,29 @@ AliFemtoModelCorrFctnDirectYlm& AliFemtoModelCorrFctnDirectYlm::operator=(const 
   if (this != &aCorrFctn) {
 
     fUseLCMS = aCorrFctn.fUseLCMS;
-    
+
     if (fCYlmTrue) delete fCYlmTrue;
     if (aCorrFctn.fCYlmTrue)
       fCYlmTrue = new AliFemtoCorrFctnDirectYlm(*aCorrFctn.fCYlmTrue);
     else fCYlmTrue = 0;
-    
+
     if (fCYlmFake) delete fCYlmFake;
     if (aCorrFctn.fCYlmFake)
       fCYlmFake = new AliFemtoCorrFctnDirectYlm(*aCorrFctn.fCYlmFake);
     else fCYlmFake = 0;
-    
+
     if (fNumeratorTrue) delete fNumeratorTrue;
     if (aCorrFctn.fNumeratorTrue)
       fNumeratorTrue = new TH1D(*aCorrFctn.fNumeratorTrue);
     else
       fNumeratorTrue = 0;
-    
+
     if (fNumeratorFake) delete fNumeratorFake;
     if (aCorrFctn.fNumeratorFake)
       fNumeratorFake = new TH1D(*aCorrFctn.fNumeratorFake);
     else
       fNumeratorFake = 0;
-    
+
     if (fDenominator) delete fDenominator;
     if (aCorrFctn.fDenominator)
       fDenominator = new TH1D(*aCorrFctn.fDenominator);
@@ -117,11 +117,12 @@ AliFemtoString AliFemtoModelCorrFctnDirectYlm::Report()
 void AliFemtoModelCorrFctnDirectYlm::AddRealPair(AliFemtoPair* aPair)
 {
   // add real (effect) pair
-  if (fPairCut)
-    if (!(fPairCut->Pass(aPair))) return;
+  if (fPairCut && !fPairCut->Pass(aPair)) {
+    return;
+  }
 
   Double_t weight = fManager->GetWeight(aPair);
-  
+
   if (fUseLCMS)
     fCYlmTrue->AddRealPair(aPair->QOutCMS(), aPair->QSideCMS(), aPair->QLongCMS(), weight);
   else
@@ -131,8 +132,9 @@ void AliFemtoModelCorrFctnDirectYlm::AddRealPair(AliFemtoPair* aPair)
 void AliFemtoModelCorrFctnDirectYlm::AddMixedPair(AliFemtoPair* aPair)
 {
   // add mixed (background) pair
-  if (fPairCut)
-    if (!(fPairCut->Pass(aPair))) return;
+  if (fPairCut && !fPairCut->Pass(aPair)) {
+    return;
+  }
 
   Double_t weight = fManager->GetWeight(aPair);
 
@@ -151,7 +153,7 @@ void AliFemtoModelCorrFctnDirectYlm::AddMixedPair(AliFemtoPair* aPair)
 void AliFemtoModelCorrFctnDirectYlm::Write()
 {
   // write out all the histograms
-  
+
   fCYlmTrue->Write();
   fCYlmFake->Write();
 }
@@ -163,14 +165,14 @@ TList* AliFemtoModelCorrFctnDirectYlm::GetOutputList()
   tOutputList->Clear();
 
   TList *tListCfTrue = fCYlmTrue->GetOutputList();
-    
+
   TIter nextListCfTrue(tListCfTrue);
   while (TObject *obj = nextListCfTrue()) {
     tOutputList->Add(obj);
   }
 
   TList *tListCfFake = fCYlmFake->GetOutputList();
-    
+
   TIter nextListCfFake(tListCfFake);
   while (TObject *obj = nextListCfFake()) {
     tOutputList->Add(obj);
@@ -185,7 +187,7 @@ AliFemtoModelCorrFctn* AliFemtoModelCorrFctnDirectYlm::Clone()
 {
   // Clone the correlation function
   AliFemtoModelCorrFctnDirectYlm *tCopy = new AliFemtoModelCorrFctnDirectYlm(*this);
-  
+
   return tCopy;
 }
 //_______________________

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDirectYlm.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDirectYlm.cxx
@@ -183,7 +183,7 @@ TList* AliFemtoModelCorrFctnDirectYlm::GetOutputList()
   return tOutputList;
 }
 //_______________________
-AliFemtoModelCorrFctn* AliFemtoModelCorrFctnDirectYlm::Clone()
+AliFemtoModelCorrFctn* AliFemtoModelCorrFctnDirectYlm::Clone() const
 {
   // Clone the correlation function
   AliFemtoModelCorrFctnDirectYlm *tCopy = new AliFemtoModelCorrFctnDirectYlm(*this);

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDirectYlm.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnDirectYlm.h
@@ -34,7 +34,7 @@ public:
   virtual void Write();
   virtual TList* GetOutputList();
 
-  virtual AliFemtoModelCorrFctn* Clone();
+  virtual AliFemtoModelCorrFctn* Clone() const;
 
   void SetUseLCMS(int aUseLCMS);
   int  GetUseLCMS();

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnKK.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnKK.cxx
@@ -48,14 +48,14 @@ AliFemtoModelCorrFctnKK::AliFemtoModelCorrFctnKK():
   fdP = new TH1D("Delta_P","Delta_P", 50,-0.1,0.1);
   fdPt = new TH1D("Delta_Pt","Delta_Pt", 50,-0.1,0.1);
   fdPtvsPt = new TH2D("Delta_PtvsPt","Delta_PtvsPt",50,0.0,2.0,50,-0.1,0.1);
-  
+
   /*
     for(int i=0;i<fNbbPairs;i++){
         fkTdists[i] = new TH1D(Form("fkTdists[%i]",i),Form("fkTdists[%i]",i),100,0.0,5.0);
         fkTdists[i]->Sumw2();
     }
   */
-  
+
   fNumeratorTrue->Sumw2();
   fNumeratorFake->Sumw2();
   fDenominator->Sumw2();
@@ -65,7 +65,7 @@ AliFemtoModelCorrFctnKK::AliFemtoModelCorrFctnKK():
   fDenominatorIdeal->Sumw2();
 
   fQgenQrec->Sumw2();
-  
+
   fdP->Sumw2();
   fdPt->Sumw2();
 
@@ -106,7 +106,7 @@ AliFemtoModelCorrFctnKK::AliFemtoModelCorrFctnKK(const char *title, Int_t aNbins
   fQgenQrec = new TH2D(buf,buf,aNbins,aQinvLo,aQinvHi,aNbins,aQinvLo,aQinvHi);
   //test
   //fQgenQrec = new TH2D(buf,buf,aNbins,aQinvLo,aQinvHi,aNbins,-0.05,0.05);
-  
+
   snprintf(buf , 100,  "DeltaP_%s", title);
   fdP = new TH1D(buf,buf,50,-0.1,0.1);
   snprintf(buf , 100,  "DeltaPT_%s", title);
@@ -120,7 +120,7 @@ AliFemtoModelCorrFctnKK::AliFemtoModelCorrFctnKK(const char *title, Int_t aNbins
         fkTdists[i]->Sumw2();
     }
   */
-  
+
   fNumeratorTrue->Sumw2();
   fNumeratorFake->Sumw2();
   fDenominator->Sumw2();
@@ -176,14 +176,14 @@ AliFemtoModelCorrFctnKK::AliFemtoModelCorrFctnKK(const AliFemtoModelCorrFctnKK& 
     fdPt = new TH1D(*(aCorrFctn.fdPt));
    if (aCorrFctn.fdPtvsPt)
     fdPtvsPt = new TH2D(*(aCorrFctn.fdPtvsPt));
- 
+
   /*
     for(int i=0;i<fNbbPairs;i++){
         if(aCorrFctn.fkTdists[i])
             fkTdists[i] = aCorrFctn.fkTdists[i];
     }
   */
-  
+
   fManager = aCorrFctn.fManager;
 }
 //_______________________
@@ -259,7 +259,7 @@ AliFemtoModelCorrFctnKK& AliFemtoModelCorrFctnKK::operator=(const AliFemtoModelC
         fkTdists[i] = (aCorrFctn.fkTdists[i])
         ? new TH1D(*aCorrFctn.fkTdists[i])
         : nullptr;
-  
+
     }
   */
   delete fNumeratorTrueIdeal;
@@ -301,20 +301,22 @@ AliFemtoString AliFemtoModelCorrFctnKK::Report()
 //_______________________
 void AliFemtoModelCorrFctnKK::AddRealPair(AliFemtoPair* aPair)
 {
-  if (fPairCut)
-    if (!fPairCut->Pass(aPair)) return;//SetPairSelectionCut() in ConfigFemtoAnalysis.C
+  if (fPairCut && !fPairCut->Pass(aPair)) {
+    return;
+  }
+
   if(!fKaonPDG) {
     // cout<<" AliFemtoModelCorrFcn add real pair "<<endl;
     Double_t weight = fManager->GetWeight(aPair);
     //cout<<" wight "<< weight<<endl;
     //cout<<"Qinv"<<aPair->QInv()<<endl;
-    
+
     fNumeratorTrue->Fill(aPair->QInv(), weight);
-    
+
     Double_t tQinvTrue = GetQinvTrue(aPair);
-    
+
     fNumeratorTrueIdeal->Fill(tQinvTrue, weight);
-    
+
     //cout<<"Qinv true"<<tQinvTrue<<endl;
   }
   //Special MC analysis for K selected by PDG code -->
@@ -329,11 +331,11 @@ void AliFemtoModelCorrFctnKK::AddRealPair(AliFemtoPair* aPair)
     //true and recontructed momntum to get delta_p/p -->
     Double_t pdg1 = ((AliFemtoModelHiddenInfo*)inf1->GetHiddenInfo())->GetPDGPid();
     Double_t pdg2 = ((AliFemtoModelHiddenInfo*)inf2->GetHiddenInfo())->GetPDGPid();
-    
+
     //if(pdg1 != 321 || pdg2 != -321) cout<<"____________ ++++Kaons : pdg1="<<pdg1<<" pdg2="<<pdg2<<endl;
 
     if(pdg1 == 321 && pdg2 == -321) { //to be sure PID does not change MR
-    
+
     AliFemtoLorentzVector p_true_1;//true momentum
     AliFemtoThreeVector* temp1 =
       ((AliFemtoModelHiddenInfo*)inf1->GetHiddenInfo())->GetTrueMomentum();
@@ -348,7 +350,7 @@ void AliFemtoModelCorrFctnKK::AddRealPair(AliFemtoPair* aPair)
     AliFemtoLorentzVector p_rec_1 = aPair->Track1()->FourMomentum();
     AliFemtoLorentzVector p_rec_2 = aPair->Track2()->FourMomentum();
     Double_t P, deltaP, Pt, deltaPt;
-    
+
     if(fP1x != p_true_1.x()) {
       // cout<<"#+1>_____________________ True: x="<<p_true_1.x()<<"  y="<<p_true_1.y()<<" z="<<p_true_1.z()<<
       //" Rec: x="<<p_rec_1.x()<<"  y="<<p_rec_1.y()<<" z="<<p_rec_1.z()<<endl;
@@ -369,8 +371,8 @@ void AliFemtoModelCorrFctnKK::AddRealPair(AliFemtoPair* aPair)
     fdPtvsPt->Fill(Pt,deltaPt/Pt);
     }
     }
-    
-    
+
+
     if(fP2x != p_true_2.x()) {
       //cout<<"#+2>_____________________ True: x="<<p_true_2.x()<<"  y="<<p_true_2.y()<<" z="<<p_true_2.z()<<
       //" Rec: x="<<p_rec_2.x()<<"  y="<<p_rec_2.y()<<" z="<<p_rec_2.z()<<endl;
@@ -389,7 +391,7 @@ void AliFemtoModelCorrFctnKK::AddRealPair(AliFemtoPair* aPair)
     fdPt->Fill(deltaPt/Pt);
     fdPtvsPt->Fill(Pt,deltaPt/Pt);
     }
-    
+
     /*Double_t deltaP=TMath::Sqrt(
 				(p_true_2.x()-p_rec_2.x())*(p_true_2.x()-p_rec_2.x())+
 				(p_true_2.y()-p_rec_2.y())*(p_true_2.y()-p_rec_2.y())+
@@ -407,15 +409,17 @@ void AliFemtoModelCorrFctnKK::AddRealPair(AliFemtoPair* aPair)
 //_______________________
 void AliFemtoModelCorrFctnKK::AddMixedPair(AliFemtoPair* aPair)
 {
-  if (fPairCut)
-    if (!fPairCut->Pass(aPair)) return;//SetPairSelectionCut() in ConfigFemtoAnalysis.C
+  if (fPairCut && !fPairCut->Pass(aPair)) {
+    return;
+  }
+
   if(!fKaonPDG) {
     Double_t weight = fManager->GetWeight(aPair);
     fNumeratorFake->Fill(aPair->QInv(), weight);
     fDenominator->Fill(aPair->QInv(), 1.0);
-    
+
     Double_t tQinvTrue = GetQinvTrue(aPair);
-    
+
     fNumeratorFakeIdeal->Fill(tQinvTrue, weight);
     fDenominatorIdeal->Fill(tQinvTrue, 1.0);
 
@@ -423,7 +427,7 @@ void AliFemtoModelCorrFctnKK::AddMixedPair(AliFemtoPair* aPair)
       if(fFillkT)
       {
           int pairNumber = GetPairNumber(aPair);
-          
+
           if(pairNumber >= 0){
               if(fkTdists[pairNumber]){
                   fkTdists[pairNumber]->Fill(GetParentsKt(aPair));
@@ -476,20 +480,20 @@ void AliFemtoModelCorrFctnKK::AddMixedPair(AliFemtoPair* aPair)
 Double_t AliFemtoModelCorrFctnKK::GetQinvTrue(AliFemtoPair* aPair)
 {
   if(!fKaonPDG) {
-      
+
       AliFemtoParticle *first = (AliFemtoParticle*)aPair->Track1();
       AliFemtoParticle *second = (AliFemtoParticle*)aPair->Track2();
-      
+
       if(!first || !second) return -1;
-      
+
       AliFemtoModelHiddenInfo *inf1 = (AliFemtoModelHiddenInfo*)first->GetHiddenInfo();
       AliFemtoModelHiddenInfo *inf2 = (AliFemtoModelHiddenInfo*)second->GetHiddenInfo();
-      
+
       if(!inf1 || !inf2){
 //          cout<<"no hidden info"<<endl;
           return -1;
       }
-      
+
       AliFemtoLorentzVector fm1;
       AliFemtoThreeVector* temp = inf1->GetTrueMomentum();
       fm1.SetVect(*temp);
@@ -497,18 +501,18 @@ Double_t AliFemtoModelCorrFctnKK::GetQinvTrue(AliFemtoPair* aPair)
       Double_t am2 = inf2->GetMass();
       double ener = TMath::Sqrt(temp->Mag2()+am1*am1);
       fm1.SetE(ener);
-      
+
       AliFemtoLorentzVector fm2;
       AliFemtoThreeVector* temp2 =  inf2->GetTrueMomentum();
       fm2.SetVect(*temp2);
       ener = TMath::Sqrt(temp2->Mag2()+am2*am2);
       fm2.SetE(ener);
-      
+
       //std::cout<<" CFModel mass1 mass2 "<<am1<<" "<<am2<<std::endl;
-      
+
       AliFemtoLorentzVector tQinvTrueVec = (fm1-fm2);
       Double_t tQinvTrue = -1.* tQinvTrueVec.m();
-      
+
       return tQinvTrue;
   }
   //Special MC analysis for K selected by PDG code -->
@@ -521,13 +525,13 @@ Double_t AliFemtoModelCorrFctnKK::GetQinvTrue(AliFemtoPair* aPair)
   fm1.SetVect(*temp);
   Double_t am1 = ((AliFemtoModelHiddenInfo*)inf1->GetHiddenInfo())->GetMass();
   Double_t am2 = ((AliFemtoModelHiddenInfo*)inf2->GetHiddenInfo())->GetMass();
- 
+
   am1=0.493677;
   am2=0.493677;
- 
+
   //Double_t pdg1 = ((AliFemtoModelHiddenInfo*)inf1->GetHiddenInfo())->GetPDGPid();
   //Double_t pdg2 = ((AliFemtoModelHiddenInfo*)inf2->GetHiddenInfo())->GetPDGPid();
- 
+
   double ener = TMath::Sqrt(temp->Mag2()+am1*am1);
   fm1.SetE(ener);
 
@@ -537,10 +541,10 @@ Double_t AliFemtoModelCorrFctnKK::GetQinvTrue(AliFemtoPair* aPair)
   ener = TMath::Sqrt(temp2->Mag2()+am2*am2);
   fm2.SetE(ener);
 
- 
+
   AliFemtoLorentzVector tQinvTrueVec = (fm1-fm2);
   Double_t tQinvTrue = -1.* tQinvTrueVec.m();
-  
+
  // if(tQinvTrue<0 && am1!=0 && am2!=0)std::cout<<" CFModel Qinv mass1 mass2 "<<aPair->QInv()<<" Qinv_true "<<tQinvTrue<<" "<<am1<<" "<<am2<<" pdg1 "<<pdg1<<" pdg2 "<<pdg2<<std::endl;
  // if(pdg1!=211 || pdg2!=211)std::cout<<" CFModel Qinv mass1 mass2 "<<aPair->QInv()<<" Qinv_true "<<tQinvTrue<<" "<<am1<<" "<<am2<<" pdg1 "<<pdg1<<" pdg2 "<<pdg2<<std::endl;
 
@@ -614,7 +618,7 @@ TList* AliFemtoModelCorrFctnKK::GetOutputList()
   tOutputList->Add(fNumeratorFakeIdeal);
   tOutputList->Add(fDenominatorIdeal);
   tOutputList->Add(fQgenQrec);
-  
+
   tOutputList->Add(fdP);
   tOutputList->Add(fdPt);
   tOutputList->Add(fdPtvsPt);
@@ -637,7 +641,7 @@ double AliFemtoModelCorrFctnKK::GetParentsKt(AliFemtoPair *pair)
 {
     AliFemtoParticle *first = new AliFemtoParticle(*(pair->Track1()));
     AliFemtoParticle *second = new AliFemtoParticle(*(pair->Track2()));
-    
+
     if(!first)
     {
         if(second) delete second;
@@ -648,10 +652,10 @@ double AliFemtoModelCorrFctnKK::GetParentsKt(AliFemtoPair *pair)
         if(first) delete first;
         return -1;
     }
-    
+
     AliFemtoModelHiddenInfo *info1 = (AliFemtoModelHiddenInfo*)first->GetHiddenInfo();
     AliFemtoModelHiddenInfo *info2 = (AliFemtoModelHiddenInfo*)second->GetHiddenInfo();
-    
+
     if(!info1 || !info2)
     {
         if(first) delete first;
@@ -660,7 +664,7 @@ double AliFemtoModelCorrFctnKK::GetParentsKt(AliFemtoPair *pair)
     }
     AliFemtoThreeVector* p1 = info1->GetMotherMomentum();
     AliFemtoThreeVector* p2 = info2->GetMotherMomentum();
-    
+
     if(!p1 || !p2)
     {
         if(first) delete first;
@@ -670,9 +674,9 @@ double AliFemtoModelCorrFctnKK::GetParentsKt(AliFemtoPair *pair)
     double px = p1->x() + p2->x();
     double py = p1->y() + p2->y();
     double pT = sqrt(px*px + py*py);
-    
+
     delete first;delete second;
-    
+
     return pT/2.;
 }
 */
@@ -681,7 +685,7 @@ int AliFemtoModelCorrFctnKK::GetPairNumber(AliFemtoPair *pair)
 {
     AliFemtoParticle *first = new AliFemtoParticle(*(pair->Track1()));
     AliFemtoParticle *second = new AliFemtoParticle(*(pair->Track2()));
-    
+
     if(!first)
     {
         if(second) delete second;
@@ -692,29 +696,29 @@ int AliFemtoModelCorrFctnKK::GetPairNumber(AliFemtoPair *pair)
         if(first) delete first;
         return -1;
     }
-    
+
     AliFemtoModelHiddenInfo *info1 = (AliFemtoModelHiddenInfo*)first->GetHiddenInfo();
     AliFemtoModelHiddenInfo *info2 = (AliFemtoModelHiddenInfo*)second->GetHiddenInfo();
-    
+
     if(!info1 || !info2)
     {
         if(first) delete first;
         if(second) delete second;
         return -1;
     }
-        
+
     int pdg1 = TMath::Abs(info1->GetMotherPdgCode());
     int pdg2 = TMath::Abs(info2->GetMotherPdgCode());
-    
+
     int tmp;
     if(pdg2 < pdg1){
         tmp = pdg1;
         pdg1 = pdg2;
         pdg2 = tmp;
     }
-    
+
     delete first;delete second;
-    
+
     if(pdg1 == 2212 && pdg2 == 2212) return 0; // pp
     if(pdg1 == 2212 && pdg2 == 3122) return 1; // pΛ
     if(pdg1 == 3122 && pdg2 == 3122) return 2; // ΛΛ
@@ -736,7 +740,7 @@ int AliFemtoModelCorrFctnKK::GetPairNumber(AliFemtoPair *pair)
     if(pdg1 == 3212 && pdg2 == 3322) return 18; // Σ0Ξ0
     if(pdg1 == 3212 && pdg2 == 3312) return 19; // Σ0Ξ-
     if(pdg1 == 3212 && pdg2 == 3212) return 20; // Σ0Σ0
-    
+
     return -1;
 }
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnKK.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnKK.cxx
@@ -597,7 +597,7 @@ void AliFemtoModelCorrFctnKK::Write()
 
 }
 //_______________________
-AliFemtoModelCorrFctn* AliFemtoModelCorrFctnKK::Clone()
+AliFemtoModelCorrFctn* AliFemtoModelCorrFctnKK::Clone() const
 {
   // Create clone
   AliFemtoModelCorrFctnKK *tCopy = new AliFemtoModelCorrFctnKK(*this);

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnKK.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnKK.h
@@ -48,7 +48,7 @@ public:
   virtual TList* GetOutputList();
   virtual void Write();
 
-  virtual AliFemtoModelCorrFctn* Clone();
+  virtual AliFemtoModelCorrFctn* Clone() const;
   
   //void SetFillkT(bool fillkT){fFillkT = fillkT;} //i do not need this
    

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnKStar.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnKStar.cxx
@@ -146,7 +146,7 @@ AliFemtoString
 AliFemtoModelCorrFctnKStar::Report()
 {
   TString report;
-  return AliFemtoString((const char *)report);
+  return AliFemtoString(report.Data());
 }
 
 
@@ -199,34 +199,42 @@ static inline int GetTruthBinFrom(const AliFemtoModelHiddenInfo *info)
   }
 }
 
-void AliFemtoModelCorrFctnKStar::AddRealPair(AliFemtoPair* aPair)
+void AliFemtoModelCorrFctnKStar::AddRealPair(AliFemtoPair* pair)
 {
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
+
   const AliFemtoModelHiddenInfo
-    *info1 = dynamic_cast<const AliFemtoModelHiddenInfo*>(aPair->Track1()->HiddenInfo()),
-    *info2 = dynamic_cast<const AliFemtoModelHiddenInfo*>(aPair->Track2()->HiddenInfo());
+    *info1 = static_cast<const AliFemtoModelHiddenInfo*>(pair->Track1()->HiddenInfo()),
+    *info2 = static_cast<const AliFemtoModelHiddenInfo*>(pair->Track2()->HiddenInfo());
 
   if (info1 == NULL || info2 == NULL) {
     return;
   }
 
-  const Float_t kstar = CalcTrueKStar(aPair);
+  const Float_t kstar = CalcTrueKStar(pair);
   fResNum->Fill(kstar);
 
   const int truth_bin = GetTruthBinFrom(info1);
   fTrueNum->Fill(kstar, truth_bin);
 }
 
-void AliFemtoModelCorrFctnKStar::AddMixedPair(AliFemtoPair* aPair)
+void AliFemtoModelCorrFctnKStar::AddMixedPair(AliFemtoPair* pair)
 {
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
+
   const AliFemtoModelHiddenInfo
-    *info1 = dynamic_cast<const AliFemtoModelHiddenInfo*>(aPair->Track1()->HiddenInfo()),
-    *info2 = dynamic_cast<const AliFemtoModelHiddenInfo*>(aPair->Track2()->HiddenInfo());
+    *info1 = static_cast<const AliFemtoModelHiddenInfo*>(pair->Track1()->HiddenInfo()),
+    *info2 = static_cast<const AliFemtoModelHiddenInfo*>(pair->Track2()->HiddenInfo());
 
   if (info1 == NULL || info2 == NULL) {
     return;
   }
 
-  const Float_t kstar = CalcTrueKStar(aPair);
+  const Float_t kstar = CalcTrueKStar(pair);
   fResDen->Fill(kstar);
 
   const int truth_bin = GetTruthBinFrom(info1);

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnKStarFull.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnKStarFull.h
@@ -45,6 +45,7 @@ public:
   virtual void AddMixedPair(AliFemtoPair* aPair);
 
   virtual TList* GetOutputList();
+  virtual AliFemtoModelCorrFctn* Clone() const { return new AliFemtoModelCorrFctnKStarFull(*this); }
   virtual void Write();
 
   /// Sets the PDG particle codes that this correlation function will check

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnNonIdDR.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnNonIdDR.cxx
@@ -373,7 +373,7 @@ TList* AliFemtoModelCorrFctnNonIdDR::GetOutputList()
 }
 
 //_______________________
-AliFemtoModelCorrFctn* AliFemtoModelCorrFctnNonIdDR::Clone()
+AliFemtoModelCorrFctn* AliFemtoModelCorrFctnNonIdDR::Clone() const
 {
   // Create clone
   AliFemtoModelCorrFctnNonIdDR *tCopy = new AliFemtoModelCorrFctnNonIdDR(*this);

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnNonIdDR.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnNonIdDR.h
@@ -27,7 +27,7 @@ public:
 
   virtual void Finish();
 
-  virtual AliFemtoModelCorrFctn* Clone();
+  virtual AliFemtoModelCorrFctn* Clone() const;
 
   virtual TList* GetOutputList();
   void Write();

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnQinv.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnQinv.cxx
@@ -134,8 +134,7 @@ AliFemtoModelCorrFctnQinv::AliFemtoModelCorrFctnQinv(const AliFemtoModelCorrFctn
 }
 
 AliFemtoModelCorrFctn*
-// AliFemtoModelCorrFctnQinv::Clone() const
-AliFemtoModelCorrFctnQinv::Clone()
+AliFemtoModelCorrFctnQinv::Clone() const
 {
   AliFemtoModelCorrFctnQinv *result = new AliFemtoModelCorrFctnQinv(*this);
   result->fRecNum->Reset();

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnQinv.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnQinv.h
@@ -59,8 +59,7 @@ public:
   /// all stored data.
   /// No pointers are shared between this object and the clone.
   ///
-  // virtual AliFemtoModelCorrFctn* Clone() const;
-  virtual AliFemtoModelCorrFctn* Clone();
+  virtual AliFemtoModelCorrFctn* Clone() const;
 
 
   /// Destructor

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnSource.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnSource.cxx
@@ -271,14 +271,6 @@ TList* AliFemtoModelCorrFctnSource::GetOutputList()
   return tOutputList;
 }
 //_______________________
-AliFemtoModelCorrFctn* AliFemtoModelCorrFctnSource::Clone()
-{
-  // Clone the correlation function
-  AliFemtoModelCorrFctnSource *tCopy = new AliFemtoModelCorrFctnSource(*this);
-  
-  return tCopy;
-}
-
 void AliFemtoModelCorrFctnSource::SetUseRPSelection(unsigned short aRPSel)
 {
   fUseRPSelection = aRPSel;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnSource.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnSource.h
@@ -32,8 +32,7 @@ public:
 
   virtual void Write();
   virtual TList* GetOutputList();
-
-  virtual AliFemtoModelCorrFctn* Clone();
+  virtual AliFemtoModelCorrFctn* Clone() const { return new AliFemtoModelCorrFctnSource(*this); }
 
   void SetUseRPSelection(unsigned short aRPSel);
 protected:

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnTrueQ.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnTrueQ.cxx
@@ -129,7 +129,7 @@ TList* AliFemtoModelCorrFctnTrueQ::GetOutputList()
   return tOutputList;
 }
 //_______________________
-AliFemtoModelCorrFctn* AliFemtoModelCorrFctnTrueQ::Clone()
+AliFemtoModelCorrFctn* AliFemtoModelCorrFctnTrueQ::Clone() const
 {
   // Clone the correlation function
   AliFemtoModelCorrFctnTrueQ *tCopy = new AliFemtoModelCorrFctnTrueQ(*this);

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnTrueQ.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnTrueQ.h
@@ -31,8 +31,7 @@ public:
 
   virtual void Write();
   virtual TList* GetOutputList();
-
-  virtual AliFemtoModelCorrFctn* Clone();
+  virtual AliFemtoModelCorrFctn* Clone() const;
 
 protected:
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnTrueQ3D.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnTrueQ3D.h
@@ -94,7 +94,7 @@ public:
   virtual TList* GetOutputList();
   virtual TList* AppendOutputList(TList &);
 
-  virtual AliFemtoCorrFctn* Clone();
+  virtual AliFemtoCorrFctn* Clone() const;
 
   Double_t GetQinvTrue(AliFemtoPair*);
 
@@ -137,7 +137,7 @@ AliFemtoModelCorrFctnTrueQ3D::Finish()
 
 inline
 AliFemtoCorrFctn*
-AliFemtoModelCorrFctnTrueQ3D::Clone()
+AliFemtoModelCorrFctnTrueQ3D::Clone() const
 {
   return new AliFemtoModelCorrFctnTrueQ3D(*this);
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnWithWeights.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnWithWeights.cxx
@@ -357,7 +357,7 @@ void AliFemtoModelCorrFctnWithWeights::Write()
 
 }
 //_______________________
-AliFemtoModelCorrFctnWithWeights* AliFemtoModelCorrFctnWithWeights::Clone()
+AliFemtoModelCorrFctnWithWeights* AliFemtoModelCorrFctnWithWeights::Clone() const
 {
   // Create clone
   AliFemtoModelCorrFctnWithWeights *tCopy = new AliFemtoModelCorrFctnWithWeights(*this);

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnWithWeights.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnWithWeights.cxx
@@ -21,6 +21,8 @@
 //_______________________
 AliFemtoModelCorrFctnWithWeights::AliFemtoModelCorrFctnWithWeights(TH2D *filter1, TH2D *filter2):
 AliFemtoCorrFctn(),
+  filterHist1(filter1),
+  filterHist2(filter2),
   fManager(0),
   fNumeratorTrue(0),
   fNumeratorFake(0),
@@ -28,9 +30,7 @@ AliFemtoCorrFctn(),
   fNumeratorTrueIdeal(0),
   fNumeratorFakeIdeal(0),
   fDenominatorIdeal(0),
-  fQgenQrec(0),
-  filterHist1(filter1),
-  filterHist2(filter2)
+  fQgenQrec(0)
 {
   // Default constructor
   fNumeratorTrue = new TH1D("ModelNumTrue","ModelNumTrue",50,0.0,0.5);
@@ -57,6 +57,8 @@ AliFemtoCorrFctn(),
 //_______________________
 AliFemtoModelCorrFctnWithWeights::AliFemtoModelCorrFctnWithWeights(const char *title, TH2D *filter1, TH2D *filter2, Int_t aNbins, Double_t aQinvLo, Double_t aQinvHi):
   AliFemtoCorrFctn(),
+  filterHist1(filter1),
+  filterHist2(filter2),
   fManager(0),
   fNumeratorTrue(0),
   fNumeratorFake(0),
@@ -64,9 +66,7 @@ AliFemtoModelCorrFctnWithWeights::AliFemtoModelCorrFctnWithWeights(const char *t
   fNumeratorTrueIdeal(0),
   fNumeratorFakeIdeal(0),
   fDenominatorIdeal(0),
-  fQgenQrec(0),
-  filterHist1(filter1),
-  filterHist2(filter2)
+  fQgenQrec(0)
 {
   // Normal constructor
   char buf[100];
@@ -100,6 +100,8 @@ AliFemtoModelCorrFctnWithWeights::AliFemtoModelCorrFctnWithWeights(const char *t
 //_______________________
 AliFemtoModelCorrFctnWithWeights::AliFemtoModelCorrFctnWithWeights(const AliFemtoModelCorrFctnWithWeights& aCorrFctn) :
   AliFemtoCorrFctn(),
+  filterHist1(0),
+  filterHist2(0),
   fManager(0),
   fNumeratorTrue(0),
   fNumeratorFake(0),
@@ -107,9 +109,7 @@ AliFemtoModelCorrFctnWithWeights::AliFemtoModelCorrFctnWithWeights(const AliFemt
   fNumeratorTrueIdeal(0),
   fNumeratorFakeIdeal(0),
   fDenominatorIdeal(0),
-  fQgenQrec(0),
-  filterHist1(0),
-  filterHist2(0)
+  fQgenQrec(0)
 {
   // Copy constructor
   if (aCorrFctn.fNumeratorTrue)
@@ -232,7 +232,7 @@ AliFemtoString AliFemtoModelCorrFctnWithWeights::Report()
 //_______________________
 void AliFemtoModelCorrFctnWithWeights::AddRealPair(AliFemtoPair* aPair)
 {
- 
+
  // cout<<" AliFemtoModelCorrFcn add real pair "<<endl;
   Double_t weight = fManager->GetWeight(aPair);
 
@@ -256,11 +256,11 @@ void AliFemtoModelCorrFctnWithWeights::AddRealPair(AliFemtoPair* aPair)
   fNumeratorTrue->Fill(aPair->QInv(), totalWeight);
 
   Double_t tQinvTrue = GetQinvTrue(aPair);
-   
+
   fNumeratorTrueIdeal->Fill(tQinvTrue, totalWeight);
-  
+
   //cout<<"Qinv true"<<tQinvTrue<<endl;
-  
+
 }
 //_______________________
 void AliFemtoModelCorrFctnWithWeights::AddMixedPair(AliFemtoPair* aPair)

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnWithWeights.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnWithWeights.h
@@ -37,7 +37,7 @@ public:
   virtual TList* GetOutputList();
   virtual void Write();
 
-  virtual AliFemtoModelCorrFctnWithWeights* Clone();
+  virtual AliFemtoModelCorrFctnWithWeights* Clone() const;
 
   Double_t GetQinvTrue(AliFemtoPair*);
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoQinvCorrFctnEMCIC.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoQinvCorrFctnEMCIC.cxx
@@ -145,11 +145,13 @@ AliFemtoQinvCorrFctnEMCIC& AliFemtoQinvCorrFctnEMCIC::operator=(const AliFemtoQi
 }
 
 //____________________________
-void AliFemtoQinvCorrFctnEMCIC::AddRealPair(AliFemtoPair* pair){
+void AliFemtoQinvCorrFctnEMCIC::AddRealPair(AliFemtoPair* pair)
+{
   // add true pair
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
   AliFemtoQinvCorrFctn::AddRealPair(pair);
 
 
@@ -178,8 +180,9 @@ void AliFemtoQinvCorrFctnEMCIC::AddRealPair(AliFemtoPair* pair){
 //____________________________
 void AliFemtoQinvCorrFctnEMCIC::AddMixedPair(AliFemtoPair* pair){
   // add mixed (background) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
   AliFemtoQinvCorrFctn::AddMixedPair(pair);
   double tQinv = fabs(pair->QInv());   // note - qInv() will be negative for identical pairs...
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoQinvCorrFctnWithWeights.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoQinvCorrFctnWithWeights.cxx
@@ -21,13 +21,13 @@ AliFemtoQinvCorrFctnWithWeights::AliFemtoQinvCorrFctnWithWeights(const char* tit
   fDenominator(0),
   fRatio(0),
   fkTMonitor(0),
+  fYPtWeightsParticle1(filter1),
+  fYPtWeightsParticle2(filter2),
   fDetaDphiscal(kFALSE),
   fPairKinematics(kFALSE),
   fRaddedps(1.2),
   fNumDEtaDPhiS(0),
   fDenDEtaDPhiS(0),
-  fYPtWeightsParticle1(filter1),
-  fYPtWeightsParticle2(filter2),
   PairReader(0)// ,
   // fTrack1(NULL),
   // fTrack2(NULL)
@@ -90,13 +90,13 @@ AliFemtoQinvCorrFctnWithWeights::AliFemtoQinvCorrFctnWithWeights(const AliFemtoQ
   fDenominator(0),
   fRatio(0),
   fkTMonitor(0),
+  fYPtWeightsParticle1(0),
+  fYPtWeightsParticle2(0),
   fDetaDphiscal(kFALSE),
   fPairKinematics(kFALSE),
   fRaddedps(1.2),
   fNumDEtaDPhiS(0),
   fDenDEtaDPhiS(0),
-  fYPtWeightsParticle1(0),
-  fYPtWeightsParticle2(0),
   PairReader(0)// ,
   // fTrack1(NULL),
   // fTrack2(NULL)
@@ -213,8 +213,9 @@ AliFemtoString AliFemtoQinvCorrFctnWithWeights::Report(){
 //____________________________
 void AliFemtoQinvCorrFctnWithWeights::AddRealPair(AliFemtoPair* pair){
   // add true pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   double tQinv = fabs(pair->QInv());   // note - qInv() will be negative for identical pairs...
 
@@ -285,8 +286,9 @@ void AliFemtoQinvCorrFctnWithWeights::AddRealPair(AliFemtoPair* pair){
 void AliFemtoQinvCorrFctnWithWeights::AddMixedPair(AliFemtoPair* pair)
 {
   // add mixed (background) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   // double weight = 1.0;
   double tQinv = fabs(pair->QInv());   // note - qInv() will be negative for identical pairs...

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoQinvCorrFctnWithWeights.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoQinvCorrFctnWithWeights.h
@@ -77,8 +77,10 @@ public:
   TH1D* Denominator();
   TH1D* Ratio();
 
-  virtual TList* GetOutputList();
   void Write();
+  virtual TList* GetOutputList();
+
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoQinvCorrFctnWithWeights(*this); }
 
 private:
   TH1D* fNumerator;          // numerator - real pairs

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoShareQualityCorrFctn.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoShareQualityCorrFctn.cxx
@@ -167,8 +167,9 @@ AliFemtoString AliFemtoShareQualityCorrFctn::Report(){
 //____________________________
 void AliFemtoShareQualityCorrFctn::AddRealPair( AliFemtoPair* pair){
   // add real (effect) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   double tQinv = fabs(pair->QInv());   // note - qInv() will be negative for identical pairs...
   Int_t nh = 0;
@@ -294,8 +295,9 @@ void AliFemtoShareQualityCorrFctn::AddRealPair( AliFemtoPair* pair){
 //____________________________
 void AliFemtoShareQualityCorrFctn::AddMixedPair( AliFemtoPair* pair){
   // add mixed (background) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   double weight = 1.0;
   double tQinv = fabs(pair->QInv());   // note - qInv() will be negative for identical pairs...

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoShareQualityCorrFctn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoShareQualityCorrFctn.h
@@ -29,6 +29,8 @@ public:
 
   void WriteHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoShareQualityCorrFctn(*this); }
+
 private:
 
   TH2D *fShareNumerator;        // Share fraction for real pairs

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoTPCInnerCorrFctn.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoTPCInnerCorrFctn.cxx
@@ -134,8 +134,9 @@ AliFemtoString AliFemtoTPCInnerCorrFctn::Report(){
 //____________________________
 void AliFemtoTPCInnerCorrFctn::AddRealPair( AliFemtoPair* pair){
   // add real (effect) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   double pih = TMath::Pi();
   double pit = TMath::Pi()*2;
@@ -171,8 +172,9 @@ void AliFemtoTPCInnerCorrFctn::AddRealPair( AliFemtoPair* pair){
 //____________________________
 void AliFemtoTPCInnerCorrFctn::AddMixedPair( AliFemtoPair* pair){
   // add mixed (background) pair
-  if (fPairCut)
-    if (!fPairCut->Pass(pair)) return;
+  if (fPairCut && !fPairCut->Pass(pair)) {
+    return;
+  }
 
   double pih = TMath::Pi();
   double pit = TMath::Pi()*2;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoTPCInnerCorrFctn.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoTPCInnerCorrFctn.h
@@ -31,6 +31,8 @@ public:
 
   void WriteHistos();
   virtual TList* GetOutputList();
+  virtual AliFemtoCorrFctn* Clone() const { return new AliFemtoTPCInnerCorrFctn(*this); }
+
 private:
 
   TH2D *fDTPCNumerator;        // Distance at the entrance to the TPC for real pairs

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoV0PurityBgdEstimator.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoV0PurityBgdEstimator.cxx
@@ -87,6 +87,8 @@ AliFemtoV0PurityBgdEstimator::AliFemtoV0PurityBgdEstimator(const AliFemtoV0Purit
   AliFemtoCorrFctn(aCorrFctn),
   fTitle(aCorrFctn.fTitle),
   fNbinsMinv(aCorrFctn.fNbinsMinv),
+  fMinvLow(aCorrFctn.fMinvLow),
+  fMinvHigh(aCorrFctn.fMinvHigh),
 
   fNumeratorWithoutSharedDaughterCut(aCorrFctn.fNumeratorWithoutSharedDaughterCut ? new TH1D(*aCorrFctn.fNumeratorWithoutSharedDaughterCut) : nullptr),
   fDenominatorWithoutSharedDaughterCut(aCorrFctn.fDenominatorWithoutSharedDaughterCut ? new TH1D(*aCorrFctn.fDenominatorWithoutSharedDaughterCut) : nullptr),
@@ -97,10 +99,8 @@ AliFemtoV0PurityBgdEstimator::AliFemtoV0PurityBgdEstimator(const AliFemtoV0Purit
   fFemtoV0TrackCut(aCorrFctn.fFemtoV0TrackCut ? new AliFemtoV0TrackCutNSigmaFilter(*aCorrFctn.fFemtoV0TrackCut) : nullptr),
 
   fRealV0Collection(aCorrFctn.fRealV0Collection ? new AliFemtoV0Collection(*aCorrFctn.fRealV0Collection) : nullptr),
-  fMixedV0Collection(aCorrFctn.fMixedV0Collection ? new AliFemtoV0Collection(*aCorrFctn.fMixedV0Collection) : nullptr),
+  fMixedV0Collection(aCorrFctn.fMixedV0Collection ? new AliFemtoV0Collection(*aCorrFctn.fMixedV0Collection) : nullptr)
 
-  fMinvLow(aCorrFctn.fMinvLow),
-  fMinvHigh(aCorrFctn.fMinvHigh)
 {
   // copy constructor
   fRatioWithoutSharedDaughterCut = (aCorrFctn.fRatioWithoutSharedDaughterCut) ? new TH1D(*aCorrFctn.fRatioWithoutSharedDaughterCut) : nullptr;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoV0PurityBgdEstimator.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoV0PurityBgdEstimator.cxx
@@ -152,9 +152,9 @@ AliFemtoV0PurityBgdEstimator& AliFemtoV0PurityBgdEstimator::operator=(const AliF
 }
 
 //____________________________
-AliFemtoV0PurityBgdEstimator* AliFemtoV0PurityBgdEstimator::Clone()
+AliFemtoV0PurityBgdEstimator* AliFemtoV0PurityBgdEstimator::Clone() const
 {
-  return(new AliFemtoV0PurityBgdEstimator(*this));
+  return new AliFemtoV0PurityBgdEstimator(*this);
 }
 
 //____________________________

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoV0PurityBgdEstimator.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoV0PurityBgdEstimator.h
@@ -77,7 +77,7 @@ public:
 
   AliFemtoV0PurityBgdEstimator(const AliFemtoV0PurityBgdEstimator& aCorrFctn);
   AliFemtoV0PurityBgdEstimator& operator=(const AliFemtoV0PurityBgdEstimator& aCorrFctn);
-  virtual AliFemtoV0PurityBgdEstimator* Clone();
+  virtual AliFemtoV0PurityBgdEstimator* Clone() const;
 
   virtual ~AliFemtoV0PurityBgdEstimator();
 


### PR DESCRIPTION
The `Clone()` method, used to copy an object without knowing its type, was left to the default base-class implementation of just returning NULL for most correlation function objects, despite their copy constructors being implemented. This changeset makes `Clone()` pure-virtual and `const` in the base class `AliFemtoCorrFctn`, and provides trivial implementations for classes missing them.

Also:
- Fixed out-of-order initialization warnings
- Merged `if` statements checking for pair-cut existence and if pair passes cut
- Fixed warning in AliFemtoCorrFctnDEtaDPhiSimpleWithCorrections copy constructor
- Auto-removed trailing whitespace