### PR TITLE
Fix bug in cluster container that removes M02=0 clusters

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliClusterContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliClusterContainer.cxx
@@ -46,7 +46,7 @@ AliClusterContainer::AliClusterContainer():
   fIncludePHOSonly(kFALSE),
   fPhosMinNcells(0),
   fPhosMinM02(0),
-  fEmcalMinM02(DBL_MIN),
+  fEmcalMinM02(-1.),
   fEmcalMaxM02(DBL_MAX),
   fEmcalMaxM02CutEnergy(DBL_MAX)
 {
@@ -72,7 +72,7 @@ AliClusterContainer::AliClusterContainer(const char *name):
   fIncludePHOSonly(kFALSE),
   fPhosMinNcells(0),
   fPhosMinM02(0),
-  fEmcalMinM02(DBL_MIN),
+  fEmcalMinM02(-1.),
   fEmcalMaxM02(DBL_MAX),
   fEmcalMaxM02CutEnergy(DBL_MAX)
 {


### PR DESCRIPTION
Please do not approve yet.

This commit fixes a bug in PR #2680: https://github.com/alisw/AliPhysics/commit/3374c97df3cd20a7d3623c4efaaa877e4c6a3ec7. The constant DBL_MIN gives the minimum positive float, not -infinity. This had the effect of rejecting clusters with M02=0 (which can amount to up to ~10% of clusters, depending on thresholds etc.). 

This affects EMCal analyses that do not apply an M02 cut (and which use cluster containers). In particular, full jet analyses by default do not apply an M02 cut. Analyzers should be aware that between Sep 21 and now, an M02 cut at M02=0 was applied by the cluster container, and that results should be re-run with the fix.

Note: A separate discussion should determine whether a small-M02 cut _should_ be applied in jet analyses, but at present the intended default behavior is to not apply any cut, and this commit restores that behavior.