### PR TITLE
Use THnSparse to correlate constituents observables

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetConstituentQA.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetConstituentQA.cxx
@@ -31,6 +31,7 @@
 #include <sstream>
 #include <string>
 #include <THistManager.h>
+#include <TLinearBinning.h>
 #include <TLorentzVector.h>
 
 #include "AliAnalysisManager.h"
@@ -80,16 +81,19 @@ AliAnalysisTaskEmcalJetConstituentQA::~AliAnalysisTaskEmcalJetConstituentQA(){
 void AliAnalysisTaskEmcalJetConstituentQA::UserCreateOutputObjects(){
   AliAnalysisTaskEmcalJet::UserCreateOutputObjects();
 
+  TLinearBinning binningz(50, 0., 1), multbinning(51, -0.5, 50.5), binningnef(50, 0., 1.), binningptconst(200, 0., 200.), binningptjet(20, 0., 200.);
+
+  const TBinning *jetbinning[4] = {&binningptjet, &binningnef, &multbinning, &multbinning},
+                 *chargedbinning[6] = {&binningptjet, &binningnef, &multbinning, &multbinning, &binningptconst, &binningz},
+                 *neutralbinning[7] = {&binningptjet, &binningnef, &multbinning, &multbinning, &binningptconst, &binningptconst, &binningz};
+
   fHistos = new THistManager(Form("histos_%s", GetName()));
   for(auto c : fNamesJetContainers){
     auto contname = dynamic_cast<TObjString *>(c);
     if(!contname) continue;
-    fHistos->CreateTH2(Form("hPtChargedConstituents%s", contname->String().Data()), "Charged jet constituents; p_{t, jet} (GeV/c); p_{t,ch}", 200, 0., 200., 200., 0., 200.);
-    fHistos->CreateTH2(Form("hPtNeutralConstituents%s", contname->String().Data()), "Neutral jet constituents; p_{t, jet} (GeV/c); p_{t,ne}", 200, 0., 200., 200., 0., 200.);
-    fHistos->CreateTH2(Form("hENeutralConstituents%s", contname->String().Data()), "Neutral jet constituents; p_{t, jet} (GeV/c); E_{ne}", 200, 0., 200., 200., 0., 200.);
-    fHistos->CreateTH2(Form("hENeutralConstituentsNoSub%s", contname->String().Data()), "Neutral jet constituent without hadronic correction; p_{t, jet} (GeV/c); E_{ne}", 200, 0., 200., 200., 0., 200.);
-    fHistos->CreateTH2(Form("hZChargedConstituents%s", contname->String().Data()), "Charged jet constituents; p_{t, jet} (GeV/c); z", 200, 0., 200., 100., 0., 1.);
-    fHistos->CreateTH2(Form("hZNeutralConstituents%s", contname->String().Data()), "Neutral jet constituent without hadronic correction; p_{t, jet} (GeV/c); z", 200, 0., 200., 100., 0., 1.);
+    fHistos->CreateTHnSparse(Form("hJetCounter%s", contname->String().Data()), Form("jet counter for jets %s", contname->String().Data()), 4, jetbinning);
+    fHistos->CreateTHnSparse(Form("hChargedConstituents%s", contname->String().Data()), Form("charged constituents in jets %s", contname->String().Data()), 6, chargedbinning);
+    fHistos->CreateTHnSparse(Form("hNeutralConstituents%s", contname->String().Data()), Form("neutral constituents in jets %s", contname->String().Data()), 7, neutralbinning);
   }
 
   for(auto h : *(fHistos->GetListOfHistograms())) fOutput->Add(h);  
@@ -131,21 +135,26 @@ bool AliAnalysisTaskEmcalJetConstituentQA::Run(){
 
     for(auto jet : jetcont->accepted()){
       AliDebugStream(3) << "Next accepted jet, found " << jet->GetNumberOfTracks() << " tracks and " << jet->GetNumberOfClusters() << " clusters." << std::endl;
+      Double_t pointjet[4] = {std::abs(jet->Pt()), jet->NEF(), static_cast<double>(jet->GetNumberOfTracks()), static_cast<double>(jet->GetNumberOfClusters())}, 
+               pointcharged[6] = {std::abs(jet->Pt()), jet->NEF(), static_cast<double>(jet->GetNumberOfTracks()), static_cast<double>(jet->GetNumberOfClusters()), -1., 1.}, 
+               pointneutral[7] = {std::abs(jet->Pt()), jet->NEF(), static_cast<double>(jet->GetNumberOfTracks()), static_cast<double>(jet->GetNumberOfClusters()), -1., 1., -1.};
+      fHistos->FillTHnSparse(Form("hJetCounter%s", contname->String().Data()), pointjet);
       for(decltype(jet->GetNumberOfTracks()) itrk = 0; itrk < jet->GetNumberOfTracks(); itrk++){
         const auto trk = jet->TrackAt(itrk, tracks->GetArray());
         if(!trk) continue;
-        fHistos->FillTH2(Form("hPtChargedConstituents%s", contname->String().Data()), std::abs(jet->Pt()), std::abs(trk->Pt()));
-        fHistos->FillTH2(Form("hZChargedConstituents%s", contname->String().Data()), std::abs(jet->Pt()), jet->GetZ(trk));
+        pointcharged[4] = std::abs(trk->Pt());
+        pointcharged[5] = std::abs(jet->GetZ(trk));
+        fHistos->FillTHnSparse(Form("hChargedConstituents%s", contname->String().Data()), pointcharged);
       }
       for(decltype(jet->GetNumberOfClusters()) icl = 0; icl < jet->GetNumberOfClusters(); icl++){
         const auto clust = jet->ClusterAt(icl, clusters->GetArray());
         if(!clust) continue; 
         TLorentzVector ptvec;
         clust->GetMomentum(ptvec, this->fVertex, AliVCluster::kHadCorr);
-        fHistos->FillTH2(Form("hPtNeutralConstituents%s", contname->String().Data()), std::abs(jet->Pt()), std::abs(ptvec.Pt()));
-        fHistos->FillTH2(Form("hENeutralConstituents%s",  contname->String().Data()), std::abs(jet->Pt()), std::abs(clust->GetHadCorrEnergy()));
-        fHistos->FillTH2(Form("hENeutralConstituentsNoSub%s",  contname->String().Data()), std::abs(jet->Pt()), std::abs(clust->GetNonLinCorrEnergy()));
-        fHistos->FillTH2(Form("hZNeutralConstituents%s", contname->String().Data()), std::abs(jet->Pt()), jet->GetZ(ptvec.Px(), ptvec.Py(), ptvec.Pz()));
+        pointneutral[4] = std::abs(clust->GetHadCorrEnergy());
+        pointneutral[5] = std::abs(clust->GetNonLinCorrEnergy());
+        pointneutral[6] = jet->GetZ(ptvec.Px(), ptvec.Py(), ptvec.Pz());
+        fHistos->FillTHnSparse(Form("hNeutralConstituents%s", contname->String().Data()), pointneutral);
       }
     }
   }


### PR DESCRIPTION
Move observable histograms to THnSparse addressing correlations:
- THnSparse per jet with ptjet, NEF, ncharged, nneutral
- THnSparse per charged with jetpt, NEF, ncharged, nneutral, ptch, z
- THnSparse per neutral with jetpt, NEF, ncharged, nneutral, Ehcorr,
  Enlcorr, z