### PR TITLE
Implementing Dielectron Framework Cuts to MLTreeMaker

### DIFF
--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.cxx
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.cxx
@@ -853,7 +853,7 @@ SharedClusterCut->AddCut(trackCutsSharedCluster16);
 SharedClusterCut->AddCut(trackCutsSharedCluster32);
 
 AliDielectronTrackCuts *trackCutsDiel = new AliDielectronTrackCuts("trackCutsDiel","trackCutsDiel");
-trackCutsDiel->SetAODFilterBit(AliDielectronTrackCuts::kTest);//(1<<4) -> error
+trackCutsDiel->SetAODFilterBit(AliDielectronTrackCuts::kGlobalNoDCA);//(1<<4) -> error
 trackCutsDiel->SetClusterRequirementITS(AliDielectronTrackCuts::Detector(0),AliDielectronTrackCuts::ITSClusterRequirement(3));//(AliESDtrackCuts::kSPD,AliESDtrackCuts::kFirst) -> error
 
 //Add desired cuts to cutgroup

--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.cxx
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.cxx
@@ -110,6 +110,12 @@ AliAnalysisTaskMLTreeMaker::AliAnalysisTaskMLTreeMaker():
   dcar(),
   dcaz(),
   nITS(0),
+  ITS1S(0),
+  ITS2S(0),
+  ITS3S(0),
+  ITS4S(0),
+  ITS5S(0),
+  ITS6S(0),        
 //  fESDTrackCuts(0),
   gMultiplicity(-999),
   chi2ITS(0),
@@ -199,6 +205,12 @@ AliAnalysisTaskMLTreeMaker::AliAnalysisTaskMLTreeMaker(const char *name) :
   dcar(),
   dcaz(),
   nITS(0),
+  ITS1S(0),
+  ITS2S(0),
+  ITS3S(0),
+  ITS4S(0),
+  ITS5S(0),
+  ITS6S(0),       
 //  fESDTrackCuts(0),
   gMultiplicity(-999),
   chi2ITS(0),
@@ -307,25 +319,12 @@ void AliAnalysisTaskMLTreeMaker::UserCreateOutputObjects() {
   
   fTree->Branch("PsigTPC", &PsigTPC);
   
-//  fTree->Branch("NClustersITS", &NClustersITS);
   fTree->Branch("NCrossedRowsTPC", &NCrossedRowsTPC);
   fTree->Branch("NClustersTPC", &NClustersTPC);
   fTree->Branch("RatioCrossedRowsFindableClusters", &RatioCrossedRowsFindableClusters);
   fTree->Branch("HasSPDfirstHit", &HasSPDfirstHit);   
   fTree->Branch("NTPCSignal", &NTPCSignal); 
-  
-  
-//  if(fPionSigmas){
-//    fTree->Branch("PsigTPC", &PsigTPC);
-//    fTree->Branch("PsigITS", &PsigITS);
-//    fTree->Branch("PsigTOF", &PsigTOF);
-//  }
-//  if(fKaonSigmas){
-//    fTree->Branch("KsigTPC", &KsigTPC);
-//    fTree->Branch("KsigITS", &KsigITS);
-//    fTree->Branch("KsigTOF", &KsigTOF);
-//  }
-  
+
   fTree->Branch("DCAxy", &dcar);
   fTree->Branch("DCAz", &dcaz);
   
@@ -334,6 +333,12 @@ void AliAnalysisTaskMLTreeMaker::UserCreateOutputObjects() {
   fTree->Branch("vertz", &vertz);
   
   fTree->Branch("nITS", &nITS);
+  fTree->Branch("ITS1Shared", &ITS1S);
+  fTree->Branch("ITS2Shared", &ITS2S); 
+  fTree->Branch("ITS3Shared", &ITS3S); 
+  fTree->Branch("ITS4Shared", &ITS4S); 
+  fTree->Branch("ITS5Shared", &ITS5S); 
+  fTree->Branch("ITS6Shared", &ITS6S);   
   fTree->Branch("nITSshared_frac", &nITSshared);
   fTree->Branch("chi2ITS", &chi2ITS);
 //  fTree->Branch("chi2TPC", &chi2TPC);
@@ -499,6 +504,13 @@ Int_t AliAnalysisTaskMLTreeMaker::GetAcceptedTracks(AliVEvent *event, Double_t g
   MCvertx.clear();
   MCverty.clear();
   MCvertz.clear();
+  ITS1S.clear();
+  ITS2S.clear();
+  ITS3S.clear();
+  ITS4S.clear();
+  ITS5S.clear();
+  ITS6S.clear(); 
+  
   
   // Loop over tracks in event
   AliGenCocktailEventHeader* coHeader;
@@ -674,10 +686,24 @@ Int_t AliAnalysisTaskMLTreeMaker::GetAcceptedTracks(AliVEvent *event, Double_t g
       charge.push_back(track->Charge());   
 
       NCrossedRowsTPC.push_back(track->GetTPCCrossedRows());
-      NClustersTPC.push_back(track->GetNumberOfTPCClusters());
+      NClustersTPC.push_back(track->GetTPCNcls();//->GetNumberOfTPCClusters());
       HasSPDfirstHit.push_back(track->HasPointOnITSLayer(0)); 
       RatioCrossedRowsFindableClusters.push_back((Double_t) track->GetTPCCrossedRows()/ (Double_t) track->GetTPCNclsF());       
       NTPCSignal.push_back(track->GetTPCsignalN());
+      
+
+      if( track->HasSharedPointOnITSLayer(0) ) {ITS1S.push_back(1);}
+      else {ITS1S.push_back(0);}
+      if( track->HasSharedPointOnITSLayer(1) ) {ITS2S.push_back(1);}
+      else {ITS2S.push_back(0);}
+      if( track->HasSharedPointOnITSLayer(2) ) {ITS3S.push_back(1);}
+      else {ITS3S.push_back(0);}
+      if( track->HasSharedPointOnITSLayer(3) ) {ITS4S.push_back(1);}
+      else {ITS4S.push_back(0);}
+      if( track->HasSharedPointOnITSLayer(4) ) {ITS5S.push_back(1);}
+      else {ITS5S.push_back(0);}
+      if( track->HasSharedPointOnITSLayer(5) ) {ITs6S.push_back(1);}
+      else {ITS6S.push_back(0);}
       
        //Get DCA position
       if(isAOD){

--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.cxx
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.cxx
@@ -814,7 +814,7 @@ pidcuts->AddCut(AliDielectronPID::kITS,AliPID::kElectron,-4.,4.);
 
 
 
-//Define Carsten Cut set 3 (as specified in e mail from Carsten from 10.01.2018)
+//Define Carsten's Cut set 3 (as specified in e mail from Carsten from 10.01.2018)
 
 AliDielectronPID *PIDcut_3 = new AliDielectronPID("PIDcut_3","PIDcut_3");
 PIDcut_3->AddCut(AliDielectronPID::kTPC,AliPID::kElectron, -1.5, 3.0 , 0. ,100., kFALSE);

--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.cxx
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.cxx
@@ -853,7 +853,7 @@ SharedClusterCut->AddCut(trackCutsSharedCluster16);
 SharedClusterCut->AddCut(trackCutsSharedCluster32);
 
 AliDielectronTrackCuts *trackCutsDiel = new AliDielectronTrackCuts("trackCutsDiel","trackCutsDiel");
-trackCutsDiel->SetAODFilterBit(AliDielectronTrackCuts::kTPCqualSPDany);//(1<<4) -> error
+trackCutsDiel->SetAODFilterBit(AliDielectronTrackCuts::kTest);//(1<<4) -> error
 trackCutsDiel->SetClusterRequirementITS(AliDielectronTrackCuts::Detector(0),AliDielectronTrackCuts::ITSClusterRequirement(3));//(AliESDtrackCuts::kSPD,AliESDtrackCuts::kFirst) -> error
 
 //Add desired cuts to cutgroup

--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.h
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskMLTreeMaker.h
@@ -234,6 +234,14 @@ class AliAnalysisTaskMLTreeMaker : public AliAnalysisTaskSE {
   
   std::vector<Int_t> nITS;
   std::vector<Double_t> nITSshared;
+  
+  std::vector<Int_t> ITS1S;
+  std::vector<Int_t> ITS2S;
+  std::vector<Int_t> ITS3S;
+  std::vector<Int_t> ITS4S;
+  std::vector<Int_t> ITS5S;
+  std::vector<Int_t> ITS6S;
+  
   std::vector<Double_t> chi2ITS;
 //  std::vector<Double_t> chi2TPC;
   std::vector<Double_t> chi2GlobalPerNDF;

--- a/PWGDQ/dielectron/core/AliDielectronTrackCuts.h
+++ b/PWGDQ/dielectron/core/AliDielectronTrackCuts.h
@@ -30,7 +30,7 @@ public:
                     kSDD0=0x0004, kSDD1=0x0008,
                     kSSD0=0x0010, kSSD1=0x0020};
   enum ITSclusterCutType { kOneOf=0, kAtLeast, kExact };
-  enum EFilterBit  { kSwitchOff=0, kTPCqual=1, kITSonly=2, kTPCqualSPDany=4, kTPCqualSPDanyPIDele=8, kTest=16, kTPConly=128 };
+  enum EFilterBit  { kSwitchOff=0, kTPCqual=1, kITSonly=2, kTPCqualSPDany=4, kTPCqualSPDanyPIDele=8, kGlobalNoDCA=16, kTPConly=128 };
 
   AliDielectronTrackCuts();
   AliDielectronTrackCuts(const char*name, const char* title);

--- a/PWGDQ/dielectron/core/AliDielectronTrackCuts.h
+++ b/PWGDQ/dielectron/core/AliDielectronTrackCuts.h
@@ -30,7 +30,7 @@ public:
                     kSDD0=0x0004, kSDD1=0x0008,
                     kSSD0=0x0010, kSSD1=0x0020};
   enum ITSclusterCutType { kOneOf=0, kAtLeast, kExact };
-  enum EFilterBit  { kSwitchOff=0, kTPCqual=1, kITSonly=2, kTPCqualSPDany=4, kTPCqualSPDanyPIDele=8, kTPConly=128 };
+  enum EFilterBit  { kSwitchOff=0, kTPCqual=1, kITSonly=2, kTPCqualSPDany=4, kTPCqualSPDanyPIDele=8, kTest=16, kTPConly=128 };
 
   AliDielectronTrackCuts();
   AliDielectronTrackCuts(const char*name, const char* title);


### PR DESCRIPTION
-  using cuts of cut based PbPb analysis in MLTreeMaker

-  adding AODFilterBit: kGlobalNoDCA=16 to AliDielectronTrackCuts (currently used in cut based PbPb analysis)