### PR TITLE
Fix doxygen typos and issues

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliClusterContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliClusterContainer.cxx
@@ -326,8 +326,9 @@ Bool_t AliClusterContainer::AcceptCluster(const AliVCluster* clus, UInt_t &rejec
 
 /**
  * Return true if cluster is accepted.
- * @param clus
- * @return
+ * @param clus The cluster to which the cuts will be applied
+ * @param rejectionReason Contains the bit specifying the rejection reason
+ * @return True if the cluster is accepted.
  */
 Bool_t AliClusterContainer::ApplyClusterCuts(const AliVCluster* clus, UInt_t &rejectionReason) const
 {

--- a/PWG/EMCAL/READMEemcCorrections.txt
+++ b/PWG/EMCAL/READMEemcCorrections.txt
@@ -507,7 +507,7 @@ For your component to be accessible to the correction task, it must be registere
 To do so, add the following to your component header:
 
 ```{.cxx}
-// Allows the registration of the class so that it is availble to be used by the correction task.
+// // Allows the registration of the class so that it is availble to be used by the correction task.
 static RegisterCorrectionComponent<AliEmcalCorrectionYourNewComponent> reg;
 ```
 

--- a/PWG/JETFW/AliEmcalJet.h
+++ b/PWG/JETFW/AliEmcalJet.h
@@ -236,7 +236,7 @@ class AliEmcalJet : public AliVParticle
 
   /**
    * @brief Checks whether a given particle is a jet constituent
-   * @param[in] Particle trajectory to check
+   * @param[in] part Particle to check
    * @return True if the particle is a jet constituent, false otherwise
    */
   bool HasParticleConstituent(const AliVParticle *const part) const;


### PR DESCRIPTION
The first `//` is eaten by doxygen in the EMCal corrections readme for
no apparent reason (as the exact same type of code is shown directly
below without the `//` being lost), so they are doubled up to ensure
that the comment is displayed properly.

Also fixes a few typos.

@jdmulligan - This fixes the issue that I commented on (although it's a rather ridiculous fix). Let me know if you have another idea - otherwise I will commit this