### PR TITLE
Hyperon Femtoscopy Analysis in pPb - AliFemtoDream 

### DIFF
--- a/PWGCF/FEMTOSCOPY/CMakeLists.txt
+++ b/PWGCF/FEMTOSCOPY/CMakeLists.txt
@@ -14,5 +14,6 @@ add_subdirectory(K0Analysis)
 add_subdirectory(UNICOR)
 add_subdirectory(V0LamAnalysis)
 add_subdirectory(PLamAnalysisPP)
+add_subdirectory(FemtoDream)
 
 install(DIRECTORY macros DESTINATION PWGCF/FEMTOSCOPY)

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AddTaskFemtoDream.C
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AddTaskFemtoDream.C
@@ -1,0 +1,270 @@
+#ifndef ADDTASKFEMTODREAM_C
+#define ADDTASKFEMTODREAM_C
+#include "AliFemtoDreamEventCuts.h"
+#include "AliFemtoDreamTrackCuts.h"
+#include "AliAnalysisTaskFemtoDream.h"
+#include "TROOT.h"
+
+void AddTaskFemtoDream(bool isMC=false, TString CentEst="kInt7") {
+  gROOT->ProcessLine(".include $ALICE_ROOT/include");
+  gROOT->ProcessLine(".include $ALICE_PHYSICS/include");
+  gROOT->ProcessLine(".include $ROOTSYS/include");
+
+  // the manager is static, so get the existing manager via the static method
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+
+  if (!mgr)
+  {
+    printf("No analysis manager to connect to!\n");
+    return;
+  }
+  // just to see if all went well, check if the input event handler has been
+  // connected
+  if (!mgr->GetInputEventHandler()) {
+    printf("This task requires an input event handler!\n");
+    return;
+  }
+  AliFemtoDreamEventCuts *evtCuts=
+      AliFemtoDreamEventCuts::StandardCutsRun1();
+  bool DCAPlots=false;
+  bool CPAPlots=false;
+  bool CombSigma=false;
+  bool ContributionSplitting=false;
+  bool ContributionSplittingDaug=false;
+
+  //Track Cuts
+  AliFemtoDreamTrackCuts *TrackCuts=
+      AliFemtoDreamTrackCuts::PrimProtonCuts(
+          isMC,DCAPlots,CombSigma,ContributionSplitting);
+  TrackCuts->SetCutCharge(1);
+  AliFemtoDreamTrackCuts *AntiTrackCuts=
+      AliFemtoDreamTrackCuts::PrimProtonCuts(
+          isMC,DCAPlots,CombSigma,ContributionSplitting);
+  AntiTrackCuts->SetCutCharge(-1);
+
+  //Lambda Cuts
+  AliFemtoDreamv0Cuts *v0Cuts=
+      AliFemtoDreamv0Cuts::LambdaCuts(isMC,CPAPlots,ContributionSplitting);
+  AliFemtoDreamTrackCuts *Posv0Daug=AliFemtoDreamTrackCuts::DecayProtonCuts(
+      isMC,ContributionSplittingDaug);
+  AliFemtoDreamTrackCuts *Negv0Daug=AliFemtoDreamTrackCuts::DecayPionCuts(
+      isMC,ContributionSplittingDaug);
+  v0Cuts->SetPosDaugterTrackCuts(Posv0Daug);
+  v0Cuts->SetNegDaugterTrackCuts(Negv0Daug);
+  v0Cuts->SetPDGCodePosDaug(2212);//Proton
+  v0Cuts->SetPDGCodeNegDaug(211);//Pion
+  v0Cuts->SetPDGCodev0(3122);//Lambda
+  AliFemtoDreamv0Cuts *Antiv0Cuts=
+      AliFemtoDreamv0Cuts::LambdaCuts(isMC,CPAPlots,ContributionSplitting);
+  AliFemtoDreamTrackCuts *PosAntiv0Daug=AliFemtoDreamTrackCuts::DecayPionCuts(
+      isMC,ContributionSplittingDaug);
+  PosAntiv0Daug->SetCutCharge(1);
+  AliFemtoDreamTrackCuts *NegAntiv0Daug=AliFemtoDreamTrackCuts::DecayProtonCuts(
+      isMC,ContributionSplittingDaug);
+  NegAntiv0Daug->SetCutCharge(-1);
+  Antiv0Cuts->SetPosDaugterTrackCuts(PosAntiv0Daug);
+  Antiv0Cuts->SetNegDaugterTrackCuts(NegAntiv0Daug);
+  Antiv0Cuts->SetPDGCodePosDaug(211);//Pion
+  Antiv0Cuts->SetPDGCodeNegDaug(2212);//Proton
+  Antiv0Cuts->SetPDGCodev0(3122);//Lambda
+
+  //Cascade Cuts
+  AliFemtoDreamCascadeCuts *CascadeCuts=
+      AliFemtoDreamCascadeCuts::XiCuts(false);
+  CascadeCuts->SetXiCharge(-1);
+  AliFemtoDreamTrackCuts *XiNegCuts=
+      AliFemtoDreamTrackCuts::Xiv0PionCuts(false,false);
+  AliFemtoDreamTrackCuts *XiPosCuts=
+      AliFemtoDreamTrackCuts::Xiv0ProtonCuts(false,false);
+  AliFemtoDreamTrackCuts *XiBachCuts=
+      AliFemtoDreamTrackCuts::XiBachPionCuts(false,false);
+  AliFemtoDreamCascadeCuts *AntiCascadeCuts=
+      AliFemtoDreamCascadeCuts::XiCuts(false);
+  CascadeCuts->Setv0Negcuts(XiNegCuts);
+  CascadeCuts->Setv0PosCuts(XiPosCuts);
+  CascadeCuts->SetBachCuts(XiBachCuts);
+  AntiCascadeCuts->SetXiCharge(1);
+
+  AliFemtoDreamTrackCuts *AntiXiNegCuts=
+      AliFemtoDreamTrackCuts::Xiv0ProtonCuts(false,false);
+  AntiXiNegCuts->SetCutCharge(-1);
+  AliFemtoDreamTrackCuts *AntiXiPosCuts=
+      AliFemtoDreamTrackCuts::Xiv0PionCuts(false,false);
+  AntiXiPosCuts->SetCutCharge(1);
+  AliFemtoDreamTrackCuts *AntiXiBachCuts=
+      AliFemtoDreamTrackCuts::XiBachPionCuts(false,false);
+  AntiCascadeCuts->Setv0Negcuts(AntiXiNegCuts);
+  AntiCascadeCuts->Setv0PosCuts(AntiXiPosCuts);
+  AntiCascadeCuts->SetBachCuts(AntiXiBachCuts);
+  AntiXiBachCuts->SetCutCharge(1);
+
+  std::vector<int> PDGParticles ={2212,2212,3122,3122};
+  std::vector<double> ZVtxBins = {-10,-8,-6,-4,-2,0,2,4,6,8,10};
+  std::vector<int> MultBins = {0,4,8,12,16,20,24,28,32,36,40,44,48,52,56,60,64,80};
+  std::vector<int> NBins={750,750,150,150,750,150,150,150,150,150};
+  std::vector<double> kMin={0.,0.,0.,0.,0.,0.,0.,0.,0.,0.};
+  std::vector<double> kMax={3.,3.,3.,3.,3.,3.,3.,3.,3.,3.};
+  AliFemtoDreamCollConfig *config=new AliFemtoDreamCollConfig("Femto","Femto");
+  config->SetZBins(ZVtxBins);
+  config->SetMultBins(MultBins);
+  config->SetPDGCodes(PDGParticles);
+  config->SetNBinsHist(NBins);
+  config->SetMinKRel(kMin);
+  config->SetMaxKRel(kMax);
+  config->SetMixingDepth(10);
+
+  AliAnalysisTaskFemtoDream *task=new AliAnalysisTaskFemtoDream("FemtoDream",isMC);
+  if(CentEst == "kInt7"){
+    task->SelectCollisionCandidates(AliVEvent::kINT7);
+    task->SetMVPileUp(kTRUE);
+  }else if(CentEst == "kMB"){
+    task->SelectCollisionCandidates(AliVEvent::kMB);
+    task->SetMVPileUp(kFALSE);
+  }else{
+    std::cout << "=====================================================================" << std::endl;
+    std::cout << "=====================================================================" << std::endl;
+    std::cout << "Centrality Estimator not set, fix it else your Results will be empty!" << std::endl;
+    std::cout << "=====================================================================" << std::endl;
+    std::cout << "=====================================================================" << std::endl;
+  }
+  task->SetDebugLevel(0);
+  task->SetEvtCutQA(true);
+  task->SetTrackBufferSize(2500);
+  task->SetEventCuts(evtCuts);
+  task->SetTrackCuts(TrackCuts);
+  task->SetAntiTrackCuts(AntiTrackCuts);
+  task->Setv0Cuts(v0Cuts);
+  task->SetAntiv0Cuts(Antiv0Cuts);
+  task->SetCascadeCuts(CascadeCuts);
+  task->SetAntiCascadeCuts(AntiCascadeCuts);
+  task->SetCollectionConfig(config);
+  mgr->AddTask(task);
+//  TString QAOutput="AnalysisQA.root";
+//  TString TrackOutput="AnalysisQATracks.root";
+//  TString v0Output="AnalysisQAv0.root";
+//  TString CascadeOutput="AnalysisQACascade.root";
+
+  TString file = AliAnalysisManager::GetCommonFileName();
+
+  AliAnalysisDataContainer *cinput = mgr->GetCommonInputContainer();
+
+  mgr->ConnectInput(task, 0, cinput);
+
+  AliAnalysisDataContainer *coutputQA;
+  TString QAName = Form("QA");
+  coutputQA = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      QAName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), QAName.Data()));
+  mgr->ConnectOutput(task, 1, coutputQA);
+
+  AliAnalysisDataContainer *coutputEvtCuts;
+  TString EvtCutsName = Form("EvtCuts");
+  coutputEvtCuts = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      EvtCutsName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), EvtCutsName.Data()));
+  mgr->ConnectOutput(task, 2, coutputEvtCuts);
+
+  AliAnalysisDataContainer *couputTrkCuts;
+  TString TrackCutsName = Form("TrackCuts");
+  couputTrkCuts = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      TrackCutsName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), TrackCutsName.Data()));
+  mgr->ConnectOutput(task, 3, couputTrkCuts);
+
+  AliAnalysisDataContainer *coutputAntiTrkCuts;
+  TString AntiTrackCutsName = Form("AntiTrackCuts");
+  coutputAntiTrkCuts = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      AntiTrackCutsName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), AntiTrackCutsName.Data()));
+  mgr->ConnectOutput(task, 4, coutputAntiTrkCuts);
+
+  AliAnalysisDataContainer *coutputv0Cuts;
+  TString v0CutsName = Form("v0Cuts");
+  coutputv0Cuts = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      v0CutsName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), v0CutsName.Data()));
+  mgr->ConnectOutput(task, 5, coutputv0Cuts);
+
+  AliAnalysisDataContainer *coutputAntiv0Cuts;
+  TString Antiv0CutsName = Form("Antiv0Cuts");
+  coutputAntiv0Cuts = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      Antiv0CutsName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), Antiv0CutsName.Data()));
+  mgr->ConnectOutput(task, 6, coutputAntiv0Cuts);
+
+  AliAnalysisDataContainer *coutputCascadeCuts;
+  TString CascadeCutsName = Form("CascadeCuts");
+  coutputCascadeCuts = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      CascadeCutsName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), CascadeCutsName.Data()));
+  mgr->ConnectOutput(task, 7, coutputCascadeCuts);
+
+  AliAnalysisDataContainer *coutputAntiCascadeCuts;
+  TString AntiCascadeCutsName = Form("AntiCascadeCuts");
+  coutputAntiCascadeCuts = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      AntiCascadeCutsName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), AntiCascadeCutsName.Data()));
+  mgr->ConnectOutput(task, 8, coutputAntiCascadeCuts);
+
+  AliAnalysisDataContainer *coutputResults;
+  TString ResultsName = Form("Results");
+  coutputResults = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      ResultsName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), ResultsName.Data()));
+  mgr->ConnectOutput(task, 9, coutputResults);
+
+  AliAnalysisDataContainer *coutputResultQA;
+  TString ResultQAName = Form("ResultQA");
+  coutputResultQA = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      ResultQAName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), ResultQAName.Data()));
+  mgr->ConnectOutput(task, 10, coutputResultQA);
+  if (isMC) {
+    AliAnalysisDataContainer *coutputTrkCutsMC;
+    TString TrkCutsMCName = Form("TrkCutsMC");
+    coutputTrkCutsMC = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+        TrkCutsMCName.Data(), TList::Class(),
+        AliAnalysisManager::kOutputContainer,
+        Form("%s:%s", file.Data(), TrkCutsMCName.Data()));
+    mgr->ConnectOutput(task, 11, coutputTrkCutsMC);
+
+    AliAnalysisDataContainer *coutputAntiTrkCutsMC;
+    TString AntiTrkCutsMCName = Form("AntiTrkCutsMC");
+    coutputAntiTrkCutsMC = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+        AntiTrkCutsMCName.Data(), TList::Class(),
+        AliAnalysisManager::kOutputContainer,
+        Form("%s:%s", file.Data(), AntiTrkCutsMCName.Data()));
+    mgr->ConnectOutput(task, 12, coutputAntiTrkCutsMC);
+
+    AliAnalysisDataContainer *coutputv0CutsMC;
+    TString v0CutsMCName = Form("v0CutsMC");
+    coutputv0CutsMC = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+        v0CutsMCName.Data(), TList::Class(),
+        AliAnalysisManager::kOutputContainer,
+        Form("%s:%s", file.Data(), v0CutsMCName.Data()));
+    mgr->ConnectOutput(task, 13, coutputv0CutsMC);
+
+    AliAnalysisDataContainer *coutputAntiv0CutsMC;
+    TString Antiv0CutsMCName = Form("Antiv0CutsMC");
+    coutputAntiv0CutsMC = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+        Antiv0CutsMCName.Data(), TList::Class(),
+        AliAnalysisManager::kOutputContainer,
+        Form("%s:%s", file.Data(), Antiv0CutsMCName.Data()));
+    mgr->ConnectOutput(task, 14, coutputAntiv0CutsMC);
+  }
+  if (!mgr->InitAnalysis()) {
+    return;
+  }
+  return;
+}
+#endif

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskFemtoDream.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskFemtoDream.cxx
@@ -1,0 +1,356 @@
+/*
+ * AliAnalysisTaskFemtoPlotration.cxx
+ *
+ *  Created on: 24 Nov 2017
+ *      Author: bernhardhohlweger
+ */
+
+#include "AliAnalysisTaskFemtoDream.h"
+#include "AliLog.h"
+ClassImp(AliAnalysisTaskFemtoDream)
+
+AliAnalysisTaskFemtoDream::AliAnalysisTaskFemtoDream()
+:AliAnalysisTaskSE()
+,fTrackBufferSize(0)
+,fMVPileUp(false)
+,fEvtCutQA(false)
+,fIsMC(false)
+,fAnalysis()
+,fQA()
+,fEvtCuts()
+,fEvtHistList(0)
+,fTrackCuts()
+,fTrackCutHistList(0)
+,fTrackCutHistMCList(0)
+,fAntiTrackCuts()
+,fAntiTrackCutHistList(0)
+,fAntiTrackCutHistMCList(0)
+,fv0Cuts()
+,fv0CutHistList(0)
+,fv0CutHistMCList(0)
+,fAntiv0Cuts()
+,fAntiv0CutHistList(0)
+,fAntiv0CutHistMCList(0)
+,fCascCuts()
+,fCascCutList(0)
+,fAntiCascCuts()
+,fAntiCascCutList(0)
+,fConfig()
+,fResults()
+,fResultQA()
+{}
+
+AliAnalysisTaskFemtoDream::AliAnalysisTaskFemtoDream(const char *name,bool isMC)
+:AliAnalysisTaskSE(name)
+,fTrackBufferSize(0)
+,fMVPileUp(false)
+,fEvtCutQA(false)
+,fIsMC(isMC)
+,fAnalysis()
+,fQA()
+,fEvtCuts()
+,fEvtHistList(0)
+,fTrackCuts()
+,fTrackCutHistList(0)
+,fTrackCutHistMCList(0)
+,fAntiTrackCuts()
+,fAntiTrackCutHistList(0)
+,fAntiTrackCutHistMCList(0)
+,fv0Cuts()
+,fv0CutHistList(0)
+,fv0CutHistMCList(0)
+,fAntiv0Cuts()
+,fAntiv0CutHistList(0)
+,fAntiv0CutHistMCList(0)
+,fCascCuts()
+,fCascCutList(0)
+,fAntiCascCuts()
+,fAntiCascCutList(0)
+,fConfig()
+,fResults()
+,fResultQA()
+{
+  DefineOutput(1, TList::Class());  //Output for the Event Class and Pair Cleaner
+  DefineOutput(2, TList::Class());  //Output for the Event Cuts
+  DefineOutput(3, TList::Class());  //Output for the Track Cuts
+  DefineOutput(4, TList::Class());  //Output for the Antitrack Cuts
+  DefineOutput(5, TList::Class());  //Output for the v0 Cuts
+  DefineOutput(6, TList::Class());  //Output for the Antiv0 Cuts
+  DefineOutput(7, TList::Class());  //Output for the Cascade Cuts
+  DefineOutput(8, TList::Class());  //Output for the Anti Cascade
+  DefineOutput(9, TList::Class());  //Output for the Results
+  DefineOutput(10, TList::Class());  //Output for the Results QA
+  if (fIsMC) {
+    DefineOutput(11, TList::Class());  //Output for the Track Cut MC Info
+    DefineOutput(12, TList::Class()); //Output for the AntiTrack Cut MC Info
+    DefineOutput(13, TList::Class()); //Output for the v0 Cut MC Info
+    DefineOutput(14, TList::Class()); //Output for the Antiv0 Cut MC Info
+  }
+}
+
+AliAnalysisTaskFemtoDream::~AliAnalysisTaskFemtoDream() {
+  if (fAnalysis) {
+    delete fAnalysis;
+  }
+}
+
+void AliAnalysisTaskFemtoDream::UserCreateOutputObjects() {
+  fAnalysis=new AliFemtoDreamAnalysis();
+  fAnalysis->SetTrackBufferSize(fTrackBufferSize);
+  fAnalysis->SetMVPileUp(fMVPileUp);
+  fAnalysis->SetEvtCutQA(fEvtCutQA);
+  if (fEvtCuts) {
+    fAnalysis->SetEventCuts(fEvtCuts);
+  } else {
+    AliFatal("Event cuts missing!");
+  }
+  if (fTrackCuts) {
+    fAnalysis->SetTrackCuts(fTrackCuts);
+  } else {
+    AliFatal("TrackCuts missing!");
+  }
+  if (fAntiTrackCuts) {
+    fAnalysis->SetAntiTrackCuts(fAntiTrackCuts);
+  } else {
+    AliFatal("Antitrack cuts missing");
+  }
+  if (fv0Cuts) {
+    fAnalysis->Setv0Cuts(fv0Cuts);
+  } else {
+    AliFatal("v0 cuts missing");
+  }
+  if (fAntiv0Cuts) {
+    fAnalysis->SetAntiv0Cuts(fAntiv0Cuts);
+  } else {
+    AliFatal("Antiv0 cuts missing");
+  }
+  if (fCascCuts) {
+    fAnalysis->SetCascadeCuts(fCascCuts);
+  } else {
+    AliFatal("Cascade cuts missing");
+  }
+  if (fAntiCascCuts) {
+    fAnalysis->SetAntiCascadeCuts(fAntiCascCuts);
+  } else {
+    AliFatal("AntiCascade cuts missing");
+  }
+  if (fConfig) {
+    fAnalysis->SetCollectionConfig(fConfig);
+  } else {
+    AliFatal("Event Collection Config missing");
+  }
+  fAnalysis->Init();
+
+  if (fAnalysis->GetQAList()) {
+    fQA=fAnalysis->GetQAList();
+  } else {
+    AliFatal("QA Histograms not available");
+  }
+  if (fAnalysis->GetEventCutHists()) {
+    fEvtHistList=fAnalysis->GetEventCutHists();
+  } else {
+    AliFatal("Event Cut Histograms not available");
+  }
+  if (fAnalysis->GetTrackCutHists()) {
+    fTrackCutHistList=fAnalysis->GetTrackCutHists();
+  } else {
+    AliFatal("Event Cut Histograms not available");
+  }
+  if (fAnalysis->GetAntitrackCutHists()) {
+    fAntiTrackCutHistList=fAnalysis->GetAntitrackCutHists();
+  } else {
+    AliFatal("Event Cut Histograms not available");
+  }
+  if (fAnalysis->Getv0CutHist()) {
+//      &&
+//      fAnalysis->Getv0PosDaugHist()&&fAnalysis->Getv0NegDaugHist()) {
+    fv0CutHistList=fAnalysis->Getv0CutHist();
+//    TList *PosDaug=fAnalysis->Getv0PosDaugHist();
+//    PosDaug->SetName("ProtonDaughter");
+//    fv0CutHistList->Add(PosDaug);
+//    TList *NegDaug=fAnalysis->Getv0NegDaugHist();
+//    NegDaug->SetName("PionDaughter");
+//    fv0CutHistList->Add(NegDaug);
+  } else {
+    AliFatal("v0 Cut Histograms not available");
+  }
+  if (fAnalysis->GetAntiv0CutHist()) {
+//  &&
+//      fAnalysis->GetAntiv0PosDaugHist()&&fAnalysis->GetAntiv0NegDaugHist()) {
+    fAntiv0CutHistList=fAnalysis->GetAntiv0CutHist();
+//    TList *PosDaug=fAnalysis->GetAntiv0PosDaugHist();
+//    PosDaug->SetName("PionDaughter");
+//    fAntiv0CutHistList->Add(PosDaug);
+//    TList *NegDaug=fAnalysis->GetAntiv0NegDaugHist();
+//    NegDaug->SetName("AntiProtonDaughter");
+//    fAntiv0CutHistList->Add(NegDaug);
+  } else {
+    AliFatal("Antiv0 Cut Histograms not available");
+  }
+  if (fAnalysis->GetCascadeCutHist()) {
+    fCascCutList=fAnalysis->GetCascadeCutHist();
+  } else {
+    AliFatal("Cascade Cut Histograms not availabl");
+  }
+  if (fAnalysis->GetAntiCascadeCutHist()) {
+    fAntiCascCutList=fAnalysis->GetAntiCascadeCutHist();
+  } else {
+    AliFatal("AntiCascade Cut Histograms not available");
+  }
+  if (fAnalysis->GetResultList()) {
+    fResults=fAnalysis->GetResultList();
+  } else {
+    AliFatal("Results List not Available");
+  }
+  if (fAnalysis->GetResultQAList()) {
+    fResultQA=fAnalysis->GetResultQAList();
+  } else {
+    AliFatal("Results QA List not Available");
+  }
+  PostData(1,fQA);
+  PostData(2,fEvtHistList);
+  PostData(3,fTrackCutHistList);
+  PostData(4,fAntiTrackCutHistList);
+  PostData(5,fv0CutHistList);
+  PostData(6,fAntiv0CutHistList);
+  PostData(7,fCascCutList);
+  PostData(8,fAntiCascCutList);
+  PostData(9,fResults);
+  PostData(10,fResultQA);
+
+  if (fIsMC) {
+    if (fTrackCuts->GetMCQAHists()) {
+      fTrackCutHistMCList=fTrackCuts->GetMCQAHists();
+    } else {
+      AliFatal("No Track Cut MC Histograms!");
+    }
+    if (fAntiTrackCuts->GetMCQAHists()) {
+      fAntiTrackCutHistMCList=fAntiTrackCuts->GetMCQAHists();
+    } else {
+      AliFatal("No Antitrack Cut MC Histograms!");
+    }
+    if (fv0Cuts->GetMCQAHists()) {
+      fv0CutHistMCList=fv0Cuts->GetMCQAHists();
+    } else {
+      AliFatal("No v0 cut MC Histograms");
+    }
+    if (fAntiv0Cuts->GetMCQAHists()) {
+      fAntiv0CutHistMCList=fAntiv0Cuts->GetMCQAHists();
+    } else {
+      AliFatal("No Antiv0 cut MC Histograms");
+    }
+    PostData(11,fTrackCutHistMCList);
+    PostData(12,fAntiTrackCutHistMCList);
+    PostData(13,fv0CutHistMCList);
+    PostData(14,fAntiv0CutHistMCList);
+  }
+}
+
+void AliAnalysisTaskFemtoDream::UserExec(Option_t *) {
+  AliAODEvent *Event=static_cast<AliAODEvent*>(fInputEvent);
+  if (!Event) {
+    AliFatal("No Input Event");
+  } else {
+    fAnalysis->Make(Event);
+    if (fAnalysis->GetQAList()) {
+       fQA=fAnalysis->GetQAList();
+     } else {
+       AliFatal("QA Histograms not available");
+     }
+    if (fAnalysis->GetEventCutHists()) {
+      fEvtHistList=fAnalysis->GetEventCutHists();
+    } else {
+      AliFatal("Event Cut Histograms not available");
+    }
+    if (fAnalysis->GetTrackCutHists()) {
+      fTrackCutHistList=fAnalysis->GetTrackCutHists();
+    } else {
+      AliFatal("Event Cut Histograms not available");
+    }
+    if (fAnalysis->GetAntitrackCutHists()) {
+      fAntiTrackCutHistList=fAnalysis->GetAntitrackCutHists();
+    } else {
+      AliFatal("Event Cut Histograms not available");
+    }
+    if (fAnalysis->Getv0CutHist()) {//&&
+//        fAnalysis->Getv0PosDaugHist()&&fAnalysis->Getv0NegDaugHist()) {
+      fv0CutHistList=fAnalysis->Getv0CutHist();
+//      TList *PosDaug=fAnalysis->Getv0PosDaugHist();
+//      PosDaug->SetName("ProtonDaughter");
+//      fv0CutHistList->Add(PosDaug);
+//      TList *NegDaug=fAnalysis->Getv0NegDaugHist();
+//      NegDaug->SetName("PionDaughter");
+//      fv0CutHistList->Add(NegDaug);
+    } else {
+      AliFatal("v0 Cut Histograms not available");
+    }
+    if (fAnalysis->GetAntiv0CutHist()) {//&&
+//        fAnalysis->GetAntiv0PosDaugHist()&&fAnalysis->GetAntiv0NegDaugHist()) {
+      fAntiv0CutHistList=fAnalysis->GetAntiv0CutHist();
+//      TList *PosDaug=fAnalysis->GetAntiv0PosDaugHist();
+//      PosDaug->SetName("PionDaughter");
+//      fAntiv0CutHistList->Add(PosDaug);
+//      TList *NegDaug=fAnalysis->GetAntiv0NegDaugHist();
+//      NegDaug->SetName("AntiProtonDaughter");
+//      fAntiv0CutHistList->Add(NegDaug);
+    } else {
+      AliFatal("Antiv0 Cut Histograms not available");
+    }
+    if (fAnalysis->GetCascadeCutHist()) {
+      fCascCutList=fAnalysis->GetCascadeCutHist();
+    } else {
+      AliFatal("Cascade Cut Histograms not availabl");
+    }
+    if (fAnalysis->GetAntiCascadeCutHist()) {
+      fAntiCascCutList=fAnalysis->GetAntiCascadeCutHist();
+    } else {
+      AliFatal("AntiCascade Cut Histograms not availabl");
+    }
+    if (fAnalysis->GetResultList()) {
+      fResults=fAnalysis->GetResultList();
+    } else {
+      AliFatal("Results List not Available");
+    }
+    if (fAnalysis->GetResultQAList()) {
+      fResultQA=fAnalysis->GetResultQAList();
+    } else {
+      AliFatal("Results QA List not Available");
+    }
+    PostData(1,fQA);
+    PostData(2,fEvtHistList);
+    PostData(3,fTrackCutHistList);
+    PostData(4,fAntiTrackCutHistList);
+    PostData(5,fv0CutHistList);
+    PostData(6,fAntiv0CutHistList);
+    PostData(7,fCascCutList);
+    PostData(8,fAntiCascCutList);
+    PostData(9,fResults);
+    PostData(10,fResultQA);
+    if (fIsMC) {
+      if (fTrackCuts->GetMCQAHists()) {
+        fTrackCutHistMCList=fTrackCuts->GetMCQAHists();
+      } else {
+        AliFatal("No Track Cut MC Histograms!");
+      }
+      if (fAntiTrackCuts->GetMCQAHists()) {
+        fAntiTrackCutHistMCList=fAntiTrackCuts->GetMCQAHists();
+      } else {
+        AliFatal("No Antitrack Cut MC Histograms!");
+      }
+      if (fv0Cuts->GetMCQAHists()) {
+        fv0CutHistMCList=fv0Cuts->GetMCQAHists();
+      } else {
+        AliFatal("No v0 cut MC Histograms");
+      }
+      if (fAntiv0Cuts->GetMCQAHists()) {
+        fAntiv0CutHistMCList=fAntiv0Cuts->GetMCQAHists();
+      } else {
+        AliFatal("No Antiv0 cut MC Histograms");
+      }
+      PostData(11,fTrackCutHistMCList);
+      PostData(12,fAntiTrackCutHistMCList);
+      PostData(13,fv0CutHistMCList);
+      PostData(14,fAntiv0CutHistMCList);
+    }
+  }
+}

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskFemtoDream.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskFemtoDream.cxx
@@ -139,7 +139,7 @@ void AliAnalysisTaskFemtoDream::UserCreateOutputObjects() {
   } else {
     AliFatal("Event Collection Config missing");
   }
-  fAnalysis->Init();
+  fAnalysis->Init(fIsMC);
 
   if (fAnalysis->GetQAList()) {
     fQA=fAnalysis->GetQAList();
@@ -162,28 +162,12 @@ void AliAnalysisTaskFemtoDream::UserCreateOutputObjects() {
     AliFatal("Event Cut Histograms not available");
   }
   if (fAnalysis->Getv0CutHist()) {
-//      &&
-//      fAnalysis->Getv0PosDaugHist()&&fAnalysis->Getv0NegDaugHist()) {
     fv0CutHistList=fAnalysis->Getv0CutHist();
-//    TList *PosDaug=fAnalysis->Getv0PosDaugHist();
-//    PosDaug->SetName("ProtonDaughter");
-//    fv0CutHistList->Add(PosDaug);
-//    TList *NegDaug=fAnalysis->Getv0NegDaugHist();
-//    NegDaug->SetName("PionDaughter");
-//    fv0CutHistList->Add(NegDaug);
   } else {
     AliFatal("v0 Cut Histograms not available");
   }
   if (fAnalysis->GetAntiv0CutHist()) {
-//  &&
-//      fAnalysis->GetAntiv0PosDaugHist()&&fAnalysis->GetAntiv0NegDaugHist()) {
     fAntiv0CutHistList=fAnalysis->GetAntiv0CutHist();
-//    TList *PosDaug=fAnalysis->GetAntiv0PosDaugHist();
-//    PosDaug->SetName("PionDaughter");
-//    fAntiv0CutHistList->Add(PosDaug);
-//    TList *NegDaug=fAnalysis->GetAntiv0NegDaugHist();
-//    NegDaug->SetName("AntiProtonDaughter");
-//    fAntiv0CutHistList->Add(NegDaug);
   } else {
     AliFatal("Antiv0 Cut Histograms not available");
   }
@@ -217,24 +201,23 @@ void AliAnalysisTaskFemtoDream::UserCreateOutputObjects() {
   PostData(8,fAntiCascCutList);
   PostData(9,fResults);
   PostData(10,fResultQA);
-
   if (fIsMC) {
-    if (fTrackCuts->GetMCQAHists()) {
+    if (fTrackCuts->GetIsMonteCarlo()) {
       fTrackCutHistMCList=fTrackCuts->GetMCQAHists();
     } else {
       AliFatal("No Track Cut MC Histograms!");
     }
-    if (fAntiTrackCuts->GetMCQAHists()) {
+    if (fAntiTrackCuts->GetIsMonteCarlo()) {
       fAntiTrackCutHistMCList=fAntiTrackCuts->GetMCQAHists();
     } else {
       AliFatal("No Antitrack Cut MC Histograms!");
     }
-    if (fv0Cuts->GetMCQAHists()) {
+    if (fv0Cuts->GetIsMonteCarlo()) {
       fv0CutHistMCList=fv0Cuts->GetMCQAHists();
     } else {
       AliFatal("No v0 cut MC Histograms");
     }
-    if (fAntiv0Cuts->GetMCQAHists()) {
+    if (fAntiv0Cuts->GetIsMonteCarlo()) {
       fAntiv0CutHistMCList=fAntiv0Cuts->GetMCQAHists();
     } else {
       AliFatal("No Antiv0 cut MC Histograms");
@@ -273,26 +256,12 @@ void AliAnalysisTaskFemtoDream::UserExec(Option_t *) {
       AliFatal("Event Cut Histograms not available");
     }
     if (fAnalysis->Getv0CutHist()) {//&&
-//        fAnalysis->Getv0PosDaugHist()&&fAnalysis->Getv0NegDaugHist()) {
       fv0CutHistList=fAnalysis->Getv0CutHist();
-//      TList *PosDaug=fAnalysis->Getv0PosDaugHist();
-//      PosDaug->SetName("ProtonDaughter");
-//      fv0CutHistList->Add(PosDaug);
-//      TList *NegDaug=fAnalysis->Getv0NegDaugHist();
-//      NegDaug->SetName("PionDaughter");
-//      fv0CutHistList->Add(NegDaug);
     } else {
       AliFatal("v0 Cut Histograms not available");
     }
     if (fAnalysis->GetAntiv0CutHist()) {//&&
-//        fAnalysis->GetAntiv0PosDaugHist()&&fAnalysis->GetAntiv0NegDaugHist()) {
       fAntiv0CutHistList=fAnalysis->GetAntiv0CutHist();
-//      TList *PosDaug=fAnalysis->GetAntiv0PosDaugHist();
-//      PosDaug->SetName("PionDaughter");
-//      fAntiv0CutHistList->Add(PosDaug);
-//      TList *NegDaug=fAnalysis->GetAntiv0NegDaugHist();
-//      NegDaug->SetName("AntiProtonDaughter");
-//      fAntiv0CutHistList->Add(NegDaug);
     } else {
       AliFatal("Antiv0 Cut Histograms not available");
     }
@@ -327,22 +296,22 @@ void AliAnalysisTaskFemtoDream::UserExec(Option_t *) {
     PostData(9,fResults);
     PostData(10,fResultQA);
     if (fIsMC) {
-      if (fTrackCuts->GetMCQAHists()) {
+      if (fTrackCuts->GetIsMonteCarlo()) {
         fTrackCutHistMCList=fTrackCuts->GetMCQAHists();
       } else {
         AliFatal("No Track Cut MC Histograms!");
       }
-      if (fAntiTrackCuts->GetMCQAHists()) {
+      if (fAntiTrackCuts->GetIsMonteCarlo()) {
         fAntiTrackCutHistMCList=fAntiTrackCuts->GetMCQAHists();
       } else {
         AliFatal("No Antitrack Cut MC Histograms!");
       }
-      if (fv0Cuts->GetMCQAHists()) {
+      if (fv0Cuts->GetIsMonteCarlo()) {
         fv0CutHistMCList=fv0Cuts->GetMCQAHists();
       } else {
         AliFatal("No v0 cut MC Histograms");
       }
-      if (fAntiv0Cuts->GetMCQAHists()) {
+      if (fAntiv0Cuts->GetIsMonteCarlo()) {
         fAntiv0CutHistMCList=fAntiv0Cuts->GetMCQAHists();
       } else {
         AliFatal("No Antiv0 cut MC Histograms");

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskFemtoDream.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskFemtoDream.h
@@ -1,0 +1,68 @@
+/*
+ * AliAnalysisTaskFemtoPlotration.h
+ *
+ *  Created on: 24 Nov 2017
+ *      Author: bernhardhohlweger
+ */
+
+#ifndef ALIANALYSISTASKFEMTODREAM_H_
+#define ALIANALYSISTASKFEMTODREAM_H_
+#include "AliAnalysisTaskSE.h"
+#include "AliFemtoDreamAnalysis.h"
+#include "AliFemtoDreamCollConfig.h"
+#include "AliFemtoDreamEventCuts.h"
+#include "AliFemtoDreamTrackCuts.h"
+#include "AliFemtoDreamv0Cuts.h"
+#include "AliFemtoDreamCascadeCuts.h"
+#include "TList.h"
+class AliAnalysisTaskFemtoDream : public AliAnalysisTaskSE {
+ public:
+  AliAnalysisTaskFemtoDream();
+  AliAnalysisTaskFemtoDream(const char *name,bool isMC);
+  virtual ~AliAnalysisTaskFemtoDream();
+  virtual void UserCreateOutputObjects();
+  virtual void UserExec(Option_t *);
+  virtual void Terminate(Option_t *){};
+  void SetMVPileUp(bool mvPileUp){fMVPileUp=mvPileUp;};
+  void SetEvtCutQA(bool setQA){fEvtCutQA=setQA;};
+  void SetEventCuts(AliFemtoDreamEventCuts *cuts){fEvtCuts=cuts;};
+  void SetTrackCuts(AliFemtoDreamTrackCuts *cuts){fTrackCuts=cuts;};
+  void SetAntiTrackCuts(AliFemtoDreamTrackCuts *cuts){fAntiTrackCuts=cuts;};
+  void Setv0Cuts(AliFemtoDreamv0Cuts *cuts){fv0Cuts=cuts;};
+  void SetAntiv0Cuts(AliFemtoDreamv0Cuts *cuts){fAntiv0Cuts=cuts;};
+  void SetCascadeCuts(AliFemtoDreamCascadeCuts *cuts){fCascCuts=cuts;};
+  void SetAntiCascadeCuts(AliFemtoDreamCascadeCuts *cuts){fAntiCascCuts=cuts;};
+  void SetTrackBufferSize(int size){fTrackBufferSize=size;};
+  void SetCollectionConfig(AliFemtoDreamCollConfig *conf) {fConfig=conf;};
+ private:
+  int fTrackBufferSize;                     //
+  bool fMVPileUp;                           //
+  bool fEvtCutQA;                           //
+  bool fIsMC;                               //
+  AliFemtoDreamAnalysis *fAnalysis;         //!
+  TList *fQA;                               //!
+  AliFemtoDreamEventCuts *fEvtCuts;         //
+  TList *fEvtHistList;                      //!
+  AliFemtoDreamTrackCuts *fTrackCuts;       //
+  TList *fTrackCutHistList;                 //!
+  TList *fTrackCutHistMCList;               //!
+  AliFemtoDreamTrackCuts *fAntiTrackCuts;   //
+  TList *fAntiTrackCutHistList;             //!
+  TList *fAntiTrackCutHistMCList;           //!
+  AliFemtoDreamv0Cuts *fv0Cuts;             //
+  TList *fv0CutHistList;                    //!
+  TList *fv0CutHistMCList;                  //!
+  AliFemtoDreamv0Cuts *fAntiv0Cuts;         //
+  TList *fAntiv0CutHistList;                //!
+  TList *fAntiv0CutHistMCList;              //!
+  AliFemtoDreamCascadeCuts *fCascCuts;      //
+  TList *fCascCutList;                      //!
+  AliFemtoDreamCascadeCuts *fAntiCascCuts;  //
+  TList *fAntiCascCutList;                  //!
+  AliFemtoDreamCollConfig *fConfig;         //
+  TList *fResults;                          //!
+  TList *fResultQA;                         //!
+  ClassDef(AliAnalysisTaskFemtoDream,1)
+};
+
+#endif /* ALIANALYSISTASKFEMTODREAM_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamAnalysis.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamAnalysis.cxx
@@ -1,0 +1,262 @@
+/*
+ * AliFemtoDreamAnalysis.cxx
+ *
+ *  Created on: 24 Nov 2017
+ *      Author: bernhardhohlweger
+ */
+#include <vector>
+#include "AliFemtoDreamAnalysis.h"
+#include "TClonesArray.h"
+#include <iostream>
+ClassImp(AliFemtoDreamAnalysis)
+AliFemtoDreamAnalysis::AliFemtoDreamAnalysis()
+:fMVPileUp(false)
+,fEvtCutQA(false)
+,fQA(0)
+,fFemtoTrack()
+,fFemtov0()
+,fFemtoCasc()
+,fEvent()
+,fEvtCuts()
+,fTrackCuts()
+,fAntiTrackCuts()
+,fv0Cuts()
+,fAntiv0Cuts()
+,fCascCuts()
+,fAntiCascCuts()
+,fPairCleaner(new AliFemtoDreamPairCleaner(2,2))
+,fTrackBufferSize(0)
+,fGTI(0)
+,fConfig(0)
+,fPartColl(0)
+{
+
+}
+
+AliFemtoDreamAnalysis::~AliFemtoDreamAnalysis() {
+  if (fFemtoTrack) {
+    delete fFemtoTrack;
+  }
+  if (fFemtov0) {
+    delete fFemtov0;
+  }
+  if (fFemtoCasc) {
+    delete fFemtoCasc;
+  }
+}
+
+void AliFemtoDreamAnalysis::Init() {
+  fFemtoTrack=new AliFemtoDreamTrack();
+  fFemtoTrack->SetUseMCInfo(fTrackCuts->GetIsMonteCarlo());
+  fFemtov0=new AliFemtoDreamv0();
+  fFemtov0->SetUseMCInfo(fv0Cuts->GetIsMonteCarlo());
+  fFemtov0->SetPDGDaughterPos(fv0Cuts->GetPDGPosDaug());//order doesnt play a role
+  fFemtov0->SetPDGDaughterNeg(fv0Cuts->GetPDGNegDaug());//only used for MC Matching
+  fFemtoCasc=new AliFemtoDreamCascade();
+  fEvtCuts->InitQA();
+  fTrackCuts->Init();
+  fAntiTrackCuts->Init();
+  fv0Cuts->Init();
+  fAntiv0Cuts->Init();
+  fCascCuts->Init();
+  fAntiCascCuts->Init();
+  fGTI=new AliAODTrack*[fTrackBufferSize];
+  fQA=new TList();
+  fQA->SetOwner();
+  fQA->SetName("QA");
+
+  fQA->Add(fPairCleaner->GetHistList());
+  fEvent=new AliFemtoDreamEvent(fMVPileUp,fEvtCutQA);
+  fQA->Add(fEvent->GetEvtCutList());
+
+  fPartColl=new AliFemtoDreamPartCollection(fConfig);
+  return;
+}
+
+void AliFemtoDreamAnalysis::ResetGlobalTrackReference(){
+  //This method was inherited form H. Beck analysis
+
+  // Sets all the pointers to zero. To be called at
+  // the beginning or end of an event
+  for(UShort_t i=0;i<fTrackBufferSize;i++)
+  {
+    fGTI[i]=0;
+  }
+}
+void AliFemtoDreamAnalysis::StoreGlobalTrackReference(AliAODTrack *track){
+  //This method was inherited form H. Beck analysis
+
+  //bhohlweg@cern.ch: We ask for the Unique Track ID that points back to the
+  //ESD. Seems like global tracks have a positive ID, Tracks with Filterbit
+  //128 only have negative ID, this is used to match the Tracks later to their
+  //global counterparts
+
+  // Stores the pointer to the global track
+
+  // This was AOD073
+  // // Don't use the filter bits 2 (ITS standalone) and 128 TPC only
+  // // Remove this return statement and you'll see they don't have
+  // // any TPC signal
+  // if(track->TestFilterBit(128) || track->TestFilterBit(2))
+  //   return;
+  // This is AOD086
+  // Another set of tracks was introduced: Global constrained.
+  // We only want filter bit 1 <-- NO! we also want no
+  // filter bit at all, which are the v0 tracks
+  //  if(!track->TestFilterBit(1))
+  //    return;
+
+  // There are also tracks without any filter bit, i.e. filter map 0,
+  // at the beginning of the event: they have ~id 1 to 5, 1 to 12
+  // This are tracks that didn't survive the primary track filter but
+  // got written cause they are V0 daughters
+
+  // Check whether the track has some info
+  // I don't know: there are tracks with filter bit 0
+  // and no TPC signal. ITS standalone V0 daughters?
+  // if(!track->GetTPCsignal()){
+  //   printf("Warning: track has no TPC signal, "
+  //     //    "not adding it's info! "
+  //     "ID: %d FilterMap: %d\n"
+  //     ,track->GetID(),track->GetFilterMap());
+  //   //    return;
+  // }
+
+  // Check that the id is positive
+  const int trackID = track->GetID();
+  if(trackID<0){
+    return;
+  }
+
+  // Check id is not too big for buffer
+  if(trackID>=fTrackBufferSize){
+    printf("Warning: track ID too big for buffer: ID: %d, buffer %d\n"
+        ,trackID,fTrackBufferSize);
+    return;
+  }
+
+  // Warn if we overwrite a track
+  if(fGTI[trackID])
+  {
+    // Seems like there are FilterMap 0 tracks
+    // that have zero TPCNcls, don't store these!
+    if( (!track->GetFilterMap()) && (!track->GetTPCNcls()) ){
+      return;
+    }
+    // Imagine the other way around, the zero map zero clusters track
+    // is stored and the good one wants to be added. We ommit the warning
+    // and just overwrite the 'bad' track
+    if( fGTI[trackID]->GetFilterMap() || fGTI[trackID]->GetTPCNcls()  ){
+      // If we come here, there's a problem
+      printf("Warning! global track info already there!");
+      printf("         TPCNcls track1 %u track2 %u",
+             (fGTI[trackID])->GetTPCNcls(),track->GetTPCNcls());
+      printf("         FilterMap track1 %u track2 %u\n",
+             (fGTI[trackID])->GetFilterMap(),track->GetFilterMap());
+    }
+  } // Two tracks same id
+
+  // // There are tracks with filter bit 0,
+  // // do they have TPCNcls stored?
+  // if(!track->GetFilterMap()){
+  //   printf("Filter map is zero, TPCNcls: %u\n"
+  //     ,track->GetTPCNcls());
+  // }
+
+  // Assign the pointer
+  (fGTI[trackID]) = track;
+}
+
+void AliFemtoDreamAnalysis::Make(AliAODEvent *evt) {
+  if (!evt) {
+    AliFatal("No Input Event");
+  }
+
+  fEvent->SetEvent(evt);
+  if (!fEvtCuts->isSelected(fEvent)) {
+    return;
+  }
+  //  std::cout << "=============================" <<std::endl;
+  //  std::cout << "=============================" <<std::endl;
+  //  std::cout << "=========new Event===========" <<std::endl;
+  //  std::cout << "=============================" <<std::endl;
+  //  std::cout << "=============================" <<std::endl;
+  ResetGlobalTrackReference();
+  for(int iTrack = 0;iTrack<evt->GetNumberOfTracks();++iTrack){
+    AliAODTrack *track=static_cast<AliAODTrack*>(evt->GetTrack(iTrack));
+    if (!track) {
+      AliFatal("No Standard AOD");
+      return;
+    }
+    StoreGlobalTrackReference(track);
+  }
+  std::vector<AliFemtoDreamBasePart> Particles;
+  std::vector<AliFemtoDreamBasePart> AntiParticles;
+  fFemtoTrack->SetGlobalTrackInfo(fGTI,fTrackBufferSize);
+  for (int iTrack = 0;iTrack<evt->GetNumberOfTracks();++iTrack) {
+    AliAODTrack *track=static_cast<AliAODTrack*>(evt->GetTrack(iTrack));
+    if (!track) {
+      AliFatal("No Standard AOD");
+      return;
+    }
+    fFemtoTrack->SetTrack(track);
+    if (fTrackCuts->isSelected(fFemtoTrack)) {
+      //      std::cout << "ID Tracks from AOD:" << fGTI[-track->GetID()-1]->GetID() << std::endl;
+      //      std::cout << "Proton ID: "<<fFemtoTrack->GetIDTracks().at(0)<<std::endl;
+      Particles.push_back(*fFemtoTrack);
+    }
+    if (fAntiTrackCuts->isSelected(fFemtoTrack)) {
+      AntiParticles.push_back(*fFemtoTrack);
+    }
+  }
+  std::vector<AliFemtoDreamBasePart> Decays;
+  std::vector<AliFemtoDreamBasePart> AntiDecays;
+  //  Look for the lambda, store it in an event
+  //  Get a V0 from the event:
+  TClonesArray *v01 = static_cast<TClonesArray*>(evt->GetV0s());
+  //number of V0s:
+
+  fFemtov0->SetGlobalTrackInfo(fGTI,fTrackBufferSize);
+  int entriesV0= v01->GetEntriesFast();
+  for (int iv0=0; iv0<entriesV0; iv0++) {
+    AliAODv0 *v0 = evt->GetV0(iv0);
+    fFemtov0->Setv0(evt, v0);
+    if (fv0Cuts->isSelected(fFemtov0)) {
+      Decays.push_back(*fFemtov0);
+    }
+    if (fAntiv0Cuts->isSelected(fFemtov0)) {
+      AntiDecays.push_back(*fFemtov0);
+    }
+  }
+  int numcascades = evt->GetNumberOfCascades();
+  for (int iXi=0;iXi<numcascades;++iXi) {
+    AliAODcascade *xi = evt->GetCascade(iXi);
+    if (!xi) continue;
+    fFemtoCasc->SetCascade(evt,xi);
+    if (fCascCuts->isSelected(fFemtoCasc)) {
+      //
+    }
+    if (fAntiCascCuts->isSelected(fFemtoCasc)) {
+      //
+    }
+  }
+
+  //  std::cout << "=============================" <<std::endl;
+  //  std::cout << "=============================" <<std::endl;
+  //  std::cout << "======Particle Cleaner=======" <<std::endl;
+  //  std::cout << "=============================" <<std::endl;
+  //  std::cout << "=============================" <<std::endl;
+
+  fPairCleaner->ResetArray();
+  fPairCleaner->CleanTrackAndDecay(&Particles,&Decays,0);
+  fPairCleaner->CleanTrackAndDecay(&AntiParticles,&AntiDecays,1);
+  fPairCleaner->CleanDecay(&Decays,0);
+  fPairCleaner->CleanDecay(&AntiDecays,1);
+  fPairCleaner->StoreParticle(Particles);
+  fPairCleaner->StoreParticle(AntiParticles);
+  fPairCleaner->StoreParticle(Decays);
+  fPairCleaner->StoreParticle(AntiDecays);
+  fPartColl->SetEvent(fPairCleaner->GetCleanParticles(),fEvent->GetZVertex(),
+                      fEvent->GetSPDMult());
+}
+

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamAnalysis.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamAnalysis.cxx
@@ -45,13 +45,15 @@ AliFemtoDreamAnalysis::~AliFemtoDreamAnalysis() {
   }
 }
 
-void AliFemtoDreamAnalysis::Init() {
+void AliFemtoDreamAnalysis::Init(bool isMonteCarlo) {
   fFemtoTrack=new AliFemtoDreamTrack();
-  fFemtoTrack->SetUseMCInfo(fTrackCuts->GetIsMonteCarlo());
+  fFemtoTrack->SetUseMCInfo(isMonteCarlo);
   fFemtov0=new AliFemtoDreamv0();
-  fFemtov0->SetUseMCInfo(fv0Cuts->GetIsMonteCarlo());
+  fFemtov0->SetUseMCInfo(isMonteCarlo);
   fFemtov0->SetPDGDaughterPos(fv0Cuts->GetPDGPosDaug());//order doesnt play a role
+  fFemtov0->GetPosDaughter()->SetUseMCInfo(isMonteCarlo);
   fFemtov0->SetPDGDaughterNeg(fv0Cuts->GetPDGNegDaug());//only used for MC Matching
+  fFemtov0->GetNegDaughter()->SetUseMCInfo(isMonteCarlo);
   fFemtoCasc=new AliFemtoDreamCascade();
   fEvtCuts->InitQA();
   fTrackCuts->Init();
@@ -176,11 +178,6 @@ void AliFemtoDreamAnalysis::Make(AliAODEvent *evt) {
   if (!fEvtCuts->isSelected(fEvent)) {
     return;
   }
-  //  std::cout << "=============================" <<std::endl;
-  //  std::cout << "=============================" <<std::endl;
-  //  std::cout << "=========new Event===========" <<std::endl;
-  //  std::cout << "=============================" <<std::endl;
-  //  std::cout << "=============================" <<std::endl;
   ResetGlobalTrackReference();
   for(int iTrack = 0;iTrack<evt->GetNumberOfTracks();++iTrack){
     AliAODTrack *track=static_cast<AliAODTrack*>(evt->GetTrack(iTrack));
@@ -201,8 +198,6 @@ void AliFemtoDreamAnalysis::Make(AliAODEvent *evt) {
     }
     fFemtoTrack->SetTrack(track);
     if (fTrackCuts->isSelected(fFemtoTrack)) {
-      //      std::cout << "ID Tracks from AOD:" << fGTI[-track->GetID()-1]->GetID() << std::endl;
-      //      std::cout << "Proton ID: "<<fFemtoTrack->GetIDTracks().at(0)<<std::endl;
       Particles.push_back(*fFemtoTrack);
     }
     if (fAntiTrackCuts->isSelected(fFemtoTrack)) {
@@ -221,25 +216,25 @@ void AliFemtoDreamAnalysis::Make(AliAODEvent *evt) {
   for (int iv0=0; iv0<entriesV0; iv0++) {
     AliAODv0 *v0 = evt->GetV0(iv0);
     fFemtov0->Setv0(evt, v0);
-    if (fv0Cuts->isSelected(fFemtov0)) {
-      Decays.push_back(*fFemtov0);
-    }
-    if (fAntiv0Cuts->isSelected(fFemtov0)) {
-      AntiDecays.push_back(*fFemtov0);
-    }
+//    if (fv0Cuts->isSelected(fFemtov0)) {
+//      Decays.push_back(*fFemtov0);
+//    }
+//    if (fAntiv0Cuts->isSelected(fFemtov0)) {
+//      AntiDecays.push_back(*fFemtov0);
+//    }
   }
-  int numcascades = evt->GetNumberOfCascades();
-  for (int iXi=0;iXi<numcascades;++iXi) {
-    AliAODcascade *xi = evt->GetCascade(iXi);
-    if (!xi) continue;
-    fFemtoCasc->SetCascade(evt,xi);
-    if (fCascCuts->isSelected(fFemtoCasc)) {
-      //
-    }
-    if (fAntiCascCuts->isSelected(fFemtoCasc)) {
-      //
-    }
-  }
+//  int numcascades = evt->GetNumberOfCascades();
+//  for (int iXi=0;iXi<numcascades;++iXi) {
+//    AliAODcascade *xi = evt->GetCascade(iXi);
+//    if (!xi) continue;
+//    fFemtoCasc->SetCascade(evt,xi);
+//    if (fCascCuts->isSelected(fFemtoCasc)) {
+//      //
+//    }
+//    if (fAntiCascCuts->isSelected(fFemtoCasc)) {
+//      //
+//    }
+//  }
 
   //  std::cout << "=============================" <<std::endl;
   //  std::cout << "=============================" <<std::endl;

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamAnalysis.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamAnalysis.cxx
@@ -216,9 +216,9 @@ void AliFemtoDreamAnalysis::Make(AliAODEvent *evt) {
   for (int iv0=0; iv0<entriesV0; iv0++) {
     AliAODv0 *v0 = evt->GetV0(iv0);
     fFemtov0->Setv0(evt, v0);
-//    if (fv0Cuts->isSelected(fFemtov0)) {
-//      Decays.push_back(*fFemtov0);
-//    }
+    if (fv0Cuts->isSelected(fFemtov0)) {
+      Decays.push_back(*fFemtov0);
+    }
 //    if (fAntiv0Cuts->isSelected(fFemtov0)) {
 //      AntiDecays.push_back(*fFemtov0);
 //    }

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamAnalysis.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamAnalysis.h
@@ -57,7 +57,7 @@ class AliFemtoDreamAnalysis {
   TList *GetQAList() {return fQA;};
   void SetTrackBufferSize(int size){fTrackBufferSize=size;};
   void SetCollectionConfig(AliFemtoDreamCollConfig *conf) {fConfig=conf;};
-  void Init();
+  void Init(bool isMonteCarlo);
   TString ClassName() {return "AliFemtoDreamAnalysis";};
   void Make(AliAODEvent *evt);
   virtual ~AliFemtoDreamAnalysis();

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamAnalysis.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamAnalysis.h
@@ -1,0 +1,89 @@
+/*
+ * AliFemtoDreamAnalysis.h
+ *
+ *  Created on: 24 Nov 2017
+ *      Author: bernhardhohlweger
+ */
+
+#ifndef ALIFEMTODREAMANALYSIS_H_
+#define ALIFEMTODREAMANALYSIS_H_
+
+#include "AliAODEvent.h"
+#include "AliAODTrack.h"
+#include "AliFemtoDreamEvent.h"
+#include "AliFemtoDreamEventCuts.h"
+#include "AliFemtoDreamPairCleaner.h"
+#include "AliFemtoDreamPartCollection.h"
+#include "AliFemtoDreamTrack.h"
+#include "AliFemtoDreamTrackCuts.h"
+#include "AliFemtoDreamv0.h"
+#include "AliFemtoDreamv0Cuts.h"
+#include "AliFemtoDreamCascade.h"
+#include "AliFemtoDreamCascadeCuts.h"
+#include "Rtypes.h"
+class AliFemtoDreamAnalysis {
+ public:
+  AliFemtoDreamAnalysis();
+  void SetMVPileUp(bool mvPileUp){fMVPileUp=mvPileUp;};
+  void SetEvtCutQA(bool setQA){fEvtCutQA=setQA;};
+  void SetEventCuts(AliFemtoDreamEventCuts *cuts){fEvtCuts=cuts;};
+  TList *GetEventCutHists(){return fEvtCuts->GetHistList();};
+  void SetTrackCuts(AliFemtoDreamTrackCuts *cuts){fTrackCuts=cuts;};
+  TList *GetTrackCutHists(){return fTrackCuts->GetQAHists();};
+  TList *GetTrackCutHistsMC(){return fTrackCuts->GetMCQAHists();};
+  void SetAntiTrackCuts(AliFemtoDreamTrackCuts *cuts){fAntiTrackCuts=cuts;};
+  TList *GetAntitrackCutHists(){return fAntiTrackCuts->GetQAHists();};
+  TList *GetAntitrackCutHistsMC(){return fAntiTrackCuts->GetMCQAHists();};
+  void Setv0Cuts(AliFemtoDreamv0Cuts *cuts){fv0Cuts=cuts;};
+  TList *Getv0CutHist(){return fv0Cuts->GetQAHists();};
+  TList *Getv0MCHist(){return fv0Cuts->GetMCQAHists();};
+//  TList *Getv0PosDaugHist(){return fv0Cuts->GetQAHistsPosDaug();};
+//  TList *Getv0PosDaugMCHist(){return fv0Cuts->GetMCQAHistsPosDaug();};
+//  TList *Getv0NegDaugHist(){return fv0Cuts->GetQAHistsNegDaug();};
+//  TList *Getv0NegDaugMCHist(){return fv0Cuts->GetMCQAHistsNegDaug();};
+  void SetAntiv0Cuts(AliFemtoDreamv0Cuts *cuts){fAntiv0Cuts=cuts;};
+  TList *GetAntiv0CutHist(){return fAntiv0Cuts->GetQAHists();};
+  TList *GetAntiv0MCHist(){return fAntiv0Cuts->GetMCQAHists();};
+//  TList *GetAntiv0PosDaugHist(){return fAntiv0Cuts->GetQAHistsPosDaug();};
+//  TList *GetAntiv0PosDaugMCHist(){return fAntiv0Cuts->GetMCQAHistsPosDaug();};
+//  TList *GetAntiv0NegDaugHist(){return fAntiv0Cuts->GetQAHistsNegDaug();};
+//  TList *GetAntiv0NegDaugMCHist(){return fAntiv0Cuts->GetMCQAHistsNegDaug();};
+  void SetCascadeCuts(AliFemtoDreamCascadeCuts *cuts){fCascCuts=cuts;};
+  TList *GetCascadeCutHist(){return fCascCuts->GetQAHists();};
+  void SetAntiCascadeCuts(AliFemtoDreamCascadeCuts *cuts){fAntiCascCuts=cuts;};
+  TList *GetAntiCascadeCutHist(){return fAntiCascCuts->GetQAHists();};
+  TList *GetResultList() {return fPartColl->GetHistList();};
+  TList *GetResultQAList() {return fPartColl->GetQAList();};
+  TList *GetQAList() {return fQA;};
+  void SetTrackBufferSize(int size){fTrackBufferSize=size;};
+  void SetCollectionConfig(AliFemtoDreamCollConfig *conf) {fConfig=conf;};
+  void Init();
+  TString ClassName() {return "AliFemtoDreamAnalysis";};
+  void Make(AliAODEvent *evt);
+  virtual ~AliFemtoDreamAnalysis();
+ private:
+  void ResetGlobalTrackReference();
+  void StoreGlobalTrackReference(AliAODTrack *track);
+  bool fMVPileUp;                           //!
+  bool fEvtCutQA;                           //!
+  TList *fQA;                               //!
+  AliFemtoDreamTrack *fFemtoTrack;          //!
+  AliFemtoDreamv0 *fFemtov0;                //!
+  AliFemtoDreamCascade *fFemtoCasc;         //!
+  AliFemtoDreamEvent *fEvent;               //!
+  AliFemtoDreamEventCuts *fEvtCuts;         //!
+  AliFemtoDreamTrackCuts *fTrackCuts;       //!
+  AliFemtoDreamTrackCuts *fAntiTrackCuts;   //!
+  AliFemtoDreamv0Cuts *fv0Cuts;             //!
+  AliFemtoDreamv0Cuts *fAntiv0Cuts;         //!
+  AliFemtoDreamCascadeCuts *fCascCuts;      //!
+  AliFemtoDreamCascadeCuts *fAntiCascCuts;  //!
+  AliFemtoDreamPairCleaner *fPairCleaner;   //!
+  int fTrackBufferSize;
+  AliAODTrack           **fGTI;             //!
+  AliFemtoDreamCollConfig *fConfig;         //!
+  AliFemtoDreamPartCollection *fPartColl;   //!
+  ClassDef(AliFemtoDreamAnalysis,1)
+};
+
+#endif /* ALIFEMTODREAMANALYSIS_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamBasePart.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamBasePart.cxx
@@ -1,0 +1,40 @@
+/*
+ * AliFemtoPPbpbLamBaseParticle.cxx
+ *
+ *  Created on: Aug 29, 2017
+ *      Author: gu74req
+ */
+
+#include "AliFemtoDreamBasePart.h"
+ClassImp(AliFemtoDreamBasePart)
+AliFemtoDreamBasePart::AliFemtoDreamBasePart()
+:fIsReset(false)
+,fGTI(0)
+,fTrackBufferSize(0)
+,fP()
+,fMCP()
+,fPt(0)
+,fMCPt(0)
+,fP_TPC(0)
+,fEta(0)
+,fTheta(0)
+,fMCTheta(0)
+,fPhi(0)
+,fMCPhi(0)
+,fIDTracks(0)
+,fCharge(0)
+,fCPA(0)
+,fOrigin(kUnknown)
+,fPDGCode(0)
+,fMCPDGCode(0)
+,fPDGMotherWeak(0)
+,fIsMC(false)
+,fUse(true)
+,fIsSet(true)
+{
+}
+
+AliFemtoDreamBasePart::~AliFemtoDreamBasePart() {
+}
+
+

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamBasePart.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamBasePart.h
@@ -1,0 +1,95 @@
+/*
+ * AliFemtoPPbpbLamBaseParticle.h
+ *
+ *  Created on: Aug 29, 2017
+ *      Author: gu74req
+ */
+
+#ifndef ALIFEMTODREAMBASEPART_H_
+#define ALIFEMTODREAMBASEPART_H_
+#include "AliAODTrack.h"
+#include "Rtypes.h"
+#include "TVector3.h"
+
+class AliFemtoDreamBasePart {
+ public:
+  AliFemtoDreamBasePart();
+  virtual ~AliFemtoDreamBasePart();
+  enum PartOrigin {
+    kPhysPrimary=0,
+    kWeak=1,
+    kMaterial=2,
+    kContamination=3,
+    kUnknown=4
+  };
+
+  void SetMomentum(double px,double py,double pz) {fP.SetXYZ(px,py,pz);};
+  TVector3 GetMomentum() const {return fP;};
+  void SetMCMomentum(double px,double py,double pz) {fMCP.SetXYZ(px,py,pz);};
+  TVector3 GetMCMomentum() const {return fMCP;};
+  void SetPt(double pT){fPt=pT;};
+  double GetPt() const {return fPt;};
+  void SetMCPt(double pT){fMCPt=pT;};
+  double GetMCPt() const {return fMCPt;};
+  void SetMomTPC(double pTPC){fP_TPC=pTPC;};
+  double GetMomTPC() const {return fP_TPC;};
+  void SetEta(double eta){fEta.push_back(eta);};
+  std::vector<double>  GetEta()  const {return fEta;};
+  void SetTheta(double theta){fTheta.push_back(theta);};
+  std::vector<double>  GetTheta()  const {return fTheta;};
+  void SetMCTheta(double theta){fMCTheta.push_back(theta);};
+  std::vector<double>  GetMCTheta()  const {return fMCTheta;};
+  void SetPhi(double phi){fPhi.push_back(phi);};
+  std::vector<double>  GetPhi()  const {return fPhi;};
+  void SetMCPhi(double phi){fMCPhi.push_back(phi);};
+  std::vector<double>  GetMCPhi()  const {return fMCPhi;};
+  void SetIDTracks(int idTracks) {fIDTracks.push_back(idTracks);};
+  std::vector<int> GetIDTracks() {return fIDTracks;};
+  void SetCharge(int charge){fCharge.push_back(charge);};
+  std::vector<int> GetCharge() const {return fCharge;};
+  void SetCPA(double cpa) {fCPA=cpa;};
+  double GetCPA() const {return fCPA;};
+  void SetParticleOrigin(PartOrigin org){fOrigin=org;};
+  PartOrigin GetParticleOrigin() const {return fOrigin;};
+  void SetPDGCode(int pdgCode) {fPDGCode=pdgCode;};
+  int GetPDGCode() const {return fPDGCode;};
+  void SetMCPDGCode(int pdgCode) {fMCPDGCode=pdgCode;};
+  int GetMCPDGCode() const {return fMCPDGCode;};
+  void SetPDGMotherWeak(int PDGMother){fPDGMotherWeak=PDGMother;};
+  int GetMotherWeak() const {return fPDGMotherWeak;};
+  void SetUseMCInfo(bool useMC) {fIsMC=useMC;};
+  bool IsSet() const {return fIsSet;};
+  void SetUse(bool use) {fUse=use;};
+  bool UseParticle() const {return fUse;};
+  void SetGlobalTrackInfo(AliAODTrack **GTI, Int_t size)
+  {fGTI = GTI; fTrackBufferSize = size;};
+ protected:
+  bool fIsReset;
+  AliAODTrack **fGTI;
+  int fTrackBufferSize;
+  TVector3 fP;
+  TVector3 fMCP;
+  double fPt;
+  double fMCPt;
+  double fP_TPC;
+  std::vector<double> fEta;
+  std::vector<double> fTheta;
+  std::vector<double> fMCTheta;
+  std::vector<double> fPhi;
+  std::vector<double> fMCPhi;
+  std::vector<int> fIDTracks;
+  std::vector<int> fCharge;
+  double fCPA;
+  PartOrigin fOrigin;
+  // pdg code as set by the track cuts, used for invariant mass calculation/mc matching in v0s
+  int fPDGCode;
+  // pdg code as obtained from the MC for this particle
+  int fMCPDGCode;
+  int fPDGMotherWeak;
+  bool fIsMC;
+  bool fUse;
+  bool fIsSet;
+  ClassDef(AliFemtoDreamBasePart,1);
+};
+
+#endif /* ALIFEMTODREAMBASEPART_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCascade.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCascade.cxx
@@ -1,0 +1,205 @@
+/*
+ * AliFemtoDreamCascade.cxx
+ *
+ *  Created on: Jan 11, 2018
+ *      Author: gu74req
+ */
+
+#include "AliFemtoDreamCascade.h"
+#include "TMath.h"
+#include "AliLog.h"
+#include "AliAnalysisManager.h"
+#include "AliInputEventHandler.h"
+ClassImp(AliFemtoDreamCascade)
+AliFemtoDreamCascade::AliFemtoDreamCascade()
+:AliFemtoDreamBasePart()
+,fPosDaug(new AliFemtoDreamTrack())
+,fNegDaug(new AliFemtoDreamTrack())
+,fBach(new AliFemtoDreamTrack())
+,fXiMass(0)
+,fOmegaMass(0)
+,fDCAXiDaug(0)
+,fTransRadius(0)
+,fRapXi(0)
+,fAlphaXi(0)
+,fPtArmXi(0)
+,fXiLength(0)
+,fOmegaLength(0)
+,fMassv0(0)
+,fv0DCADaug(0)
+,fv0DCAPrimVtx(0)
+,fv0Momentum()
+,fDCABachPrimVtx(0)
+,fv0TransRadius(0)
+,fv0CPA(0)
+,fv0PosToPrimVtx(0)
+,fv0NegToPrimVtx(0)
+,fv0ToXiPointAngle(0)
+,fv0Length(0)
+,fDCAv0Xi(0)
+{
+}
+
+AliFemtoDreamCascade::~AliFemtoDreamCascade() {
+  if (fPosDaug) {
+    delete fPosDaug;
+  }
+  if (fNegDaug) {
+    delete fNegDaug;
+  }
+  if (fBach) {
+    delete fBach;
+  }
+}
+
+void AliFemtoDreamCascade::SetCascade(AliAODEvent *evt,AliAODcascade *casc) {
+  //xi business
+  Reset();
+  fIsReset=false;
+  double PrimVtx[3]={99.,99.,99};
+  double decayPosXi[3]={casc->DecayVertexXiX(),casc->DecayVertexXiY(),
+      casc->DecayVertexXiZ()};
+
+  fXiMass=casc->MassXi();
+  fOmegaMass=casc->MassOmega();
+  fDCAXiDaug=casc->DcaXiDaughters();
+  evt->GetPrimaryVertex()->GetXYZ(PrimVtx);
+  fCPA=casc->CosPointingAngleXi(PrimVtx[0],PrimVtx[1],PrimVtx[2]);
+  fTransRadius=TMath::Sqrt(
+      decayPosXi[0]*decayPosXi[0]+decayPosXi[1]*decayPosXi[1]);
+  this->SetCharge(casc->ChargeXi());
+  this->SetMomentum(casc->MomXiX(),casc->MomXiY(),casc->MomXiZ());
+  this->SetPt(casc->MomXiX()*casc->MomXiX()+casc->MomXiY()*casc->MomXiY());
+  fRapXi=casc->RapXi();
+  this->SetEta(casc->Eta());
+  this->SetTheta(casc->Theta());
+  this->SetPhi(casc->Phi());
+  fAlphaXi=casc->AlphaXi();
+  fPtArmXi=casc->PtArmXi();
+  fXiLength=TMath::Sqrt(TMath::Power((decayPosXi[0]-PrimVtx[0]),2)+
+                        TMath::Power((decayPosXi[1]-PrimVtx[1]),2)+
+                        TMath::Power((decayPosXi[2]-PrimVtx[2]),2));
+  fOmegaLength=fXiLength;
+  double XiPDGMass=1.321;
+  double OmegaPDGMass=1.672;
+  if (this->GetMomentum().Mag()>0) {
+    fXiLength=fXiLength*XiPDGMass/this->GetMomentum().Mag()>0;
+    fOmegaLength=fOmegaLength*OmegaPDGMass/this->GetMomentum().Mag()>0;
+  } else {
+    fXiLength=-1.;
+  }
+
+  //From here daughter business
+  AliAODTrack *nTrackXi=dynamic_cast<AliAODTrack*>(casc->GetDaughter(1));
+  AliAODTrack *pTrackXi=dynamic_cast<AliAODTrack*>(casc->GetDaughter(0));
+  AliAODTrack *bachTrackXi=dynamic_cast<AliAODTrack*>(
+      casc->GetDecayVertexXi()->GetDaughter(0));
+  fNegDaug->SetTrack(nTrackXi);
+  fPosDaug->SetTrack(pTrackXi);
+  fBach->SetTrack(bachTrackXi);
+
+  fNegDaug->SetMomentum(casc->MomNegX(),casc->MomNegY(),casc->MomNegZ());
+  fPosDaug->SetMomentum(casc->MomPosX(),casc->MomPosY(),casc->MomPosZ());
+  fBach->SetMomentum(casc->MomBachX(),casc->MomBachY(),casc->MomBachZ());
+
+  this->SetIDTracks(nTrackXi->GetID());
+  this->SetIDTracks(pTrackXi->GetID());
+  this->SetIDTracks(bachTrackXi->GetID());
+
+  this->SetEta(nTrackXi->Eta());
+  this->SetEta(pTrackXi->Eta());
+  this->SetEta(bachTrackXi->Eta());
+
+  this->SetTheta(nTrackXi->Theta());
+  this->SetTheta(pTrackXi->Theta());
+  this->SetTheta(bachTrackXi->Theta());
+
+  this->SetPhi(nTrackXi->Phi());
+  this->SetPhi(pTrackXi->Phi());
+  this->SetPhi(bachTrackXi->Phi());
+
+  this->SetCharge(nTrackXi->Charge());
+  this->SetCharge(pTrackXi->Charge());
+  this->SetCharge(bachTrackXi->Charge());
+
+  //v0 business
+  if (casc->ChargeXi()<0) {//Xi minus
+    fMassv0=casc->MassLambda();
+  } else {//Xi plus case
+    fMassv0=casc->MassAntiLambda();
+  }
+  fv0Momentum.SetXYZ(casc->MomV0X(),casc->MomV0Y(),casc->MomV0Z());
+  fv0DCADaug=casc->DcaV0Daughters();
+  fv0DCAPrimVtx=casc->DcaV0ToPrimVertex();
+  fDCABachPrimVtx=casc->DcaBachToPrimVertex();
+  double decayPosV0[3]={casc->DecayVertexV0X(),
+      casc->DecayVertexV0Y(),casc->DecayVertexV0Z()};
+  fv0TransRadius=TMath::Sqrt(decayPosV0[0]*decayPosV0[0]+
+                             decayPosV0[1]*decayPosV0[1]);
+  fv0CPA=casc->CosPointingAngle(evt->GetPrimaryVertex());
+  fv0PosToPrimVtx=casc->DcaPosToPrimVertex();
+  fv0NegToPrimVtx=casc->DcaNegToPrimVertex();
+  fv0ToXiPointAngle=casc->CosPointingAngle(casc->GetDecayVertexXi());
+  double LamPDGMass=1.115683;
+  fv0Length=TMath::Sqrt(
+      TMath::Power((decayPosV0[0]-decayPosXi[0]),2)+
+      TMath::Power((decayPosV0[1]-decayPosXi[1]),2)+
+      TMath::Power((decayPosV0[2]-decayPosXi[2]),2));
+//  Float_t lctauV0 = -1.;
+  if (fv0Momentum.Mag()>0) {
+    fv0Length=fv0Length*LamPDGMass/fv0Momentum.Mag();
+  } else {
+    fv0Length=-1.;
+  }
+  fDCAv0Xi=TMath::Sqrt(
+      TMath::Power((decayPosV0[0]-decayPosXi[0]),2)+
+      TMath::Power((decayPosV0[1]-decayPosXi[1]),2));
+}
+
+void AliFemtoDreamCascade::Reset() {
+  if (!fIsReset) {
+    fXiMass=0;
+    fOmegaMass=0;
+    fDCAXiDaug=0;
+    fTransRadius=0;
+    fRapXi=-99;
+    fAlphaXi=99;
+    fPtArmXi=99;
+    fXiLength=0;
+    fOmegaLength=0;
+    fMassv0=0;
+    fv0DCADaug=0;
+    fv0DCAPrimVtx=0;
+    fv0Momentum.SetXYZ(0,0,0);
+    fDCABachPrimVtx=0;
+    fv0TransRadius=0;
+    fv0CPA=0;
+    fv0PosToPrimVtx=0;
+    fv0NegToPrimVtx=0;
+    fv0ToXiPointAngle=0;
+    fv0Length=0;
+    fDCAv0Xi=0;
+    fP.SetXYZ(0,0,0);
+    fMCP.SetXYZ(0,0,0);
+    fPt=0;
+    fMCPt=0;
+    fMCPt=0;
+    fP_TPC=0;
+    fEta.clear();
+    fTheta.clear();
+    fMCTheta.clear();
+    fPhi.clear();
+    fMCPhi.clear();
+    fIDTracks.clear();
+    fCharge.clear();
+    fCPA=0;
+    fOrigin=AliFemtoDreamBasePart::kUnknown;
+    //we don't want to reset the fPDGCode
+    fMCPDGCode=0;
+    fPDGMotherWeak=0;
+    //we don't want to reset isMC
+    fUse=false;
+    fIsSet=false;
+    fIsReset=true;
+  }
+}

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCascade.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCascade.h
@@ -1,0 +1,75 @@
+/*
+ * AliFemtoDreamCascade.h
+ *
+ *  Created on: Jan 11, 2018
+ *      Author: gu74req
+ */
+
+#ifndef ALIFEMTODREAMCASCADE_H_
+#define ALIFEMTODREAMCASCADE_H_
+#include "Rtypes.h"
+#include "TVector3.h"
+
+#include "AliFemtoDreamBasePart.h"
+#include "AliFemtoDreamTrack.h"
+#include "AliAODEvent.h"
+#include "AliAODcascade.h"
+class AliFemtoDreamCascade : public AliFemtoDreamBasePart {
+ public:
+  AliFemtoDreamCascade();
+  virtual ~AliFemtoDreamCascade();
+  void SetCascade(AliAODEvent *evt,AliAODcascade *casc);
+  TString ClassName(){return "Cascade";};
+  double GetXiMass() {return fXiMass;};
+  double GetOmegaMass() {return fOmegaMass;};
+  double GetXiDCADaug() {return fDCAXiDaug;};
+  double GetXiTransverseRadius() {return fTransRadius;};
+  double GetXiRapidity() {return fRapXi;};
+  double GetXiAlpha() {return fAlphaXi;};
+  double GetXiDecayLength() {return fXiLength;};
+  double GetOmegaDecayLength() {return fOmegaLength;};
+  double BachDCAPrimVtx() {return fDCABachPrimVtx;};
+  double Getv0Mass() {return fMassv0;};
+  double Getv0DCADaug() {return fv0DCADaug;};
+  double Getv0DCAPrimVtx() {return fv0DCAPrimVtx;};
+  double Getv0TransverseRadius() {return fv0TransRadius;};
+  double Getv0CPA() {return fv0CPA;};
+  double Getv0PosToPrimVtx() {return fv0PosToPrimVtx;};
+  double Getv0NegToPrimVtx() {return fv0NegToPrimVtx;};
+  double Getv0XiPointingAngle() {return fv0ToXiPointAngle;};
+  double Getv0DecayLength() {return fv0Length;};
+  double GetDCAv0Xi() {return fDCAv0Xi;};
+  TVector3 Getv0P() {return fv0Momentum;};
+  AliFemtoDreamTrack *GetPosDaug()const{return fPosDaug;};
+  AliFemtoDreamTrack *GetNegDaug()const{return fNegDaug;};
+  AliFemtoDreamTrack *GetBach()const{return fBach;};
+ private:
+  void Reset();
+  AliFemtoDreamTrack *fPosDaug;
+  AliFemtoDreamTrack *fNegDaug;
+  AliFemtoDreamTrack *fBach;
+  double fXiMass;
+  double fOmegaMass;
+  double fDCAXiDaug;
+  double fTransRadius;
+  double fRapXi;
+  double fAlphaXi;
+  double fPtArmXi;
+  double fXiLength;
+  double fOmegaLength;
+  double fMassv0;
+  double fv0DCADaug;
+  double fv0DCAPrimVtx;
+  TVector3 fv0Momentum;
+  double fDCABachPrimVtx;
+  double fv0TransRadius;
+  double fv0CPA;
+  double fv0PosToPrimVtx;
+  double fv0NegToPrimVtx;
+  double fv0ToXiPointAngle;
+  double fv0Length;
+  double fDCAv0Xi;
+  ClassDef(AliFemtoDreamCascade,1)
+};
+
+#endif /* ALIFEMTODREAMCASCADE_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCascadeCuts.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCascadeCuts.cxx
@@ -1,0 +1,265 @@
+/*
+ * AliFemtoDreamCascadeCuts.cxx
+ *
+ *  Created on: Jan 11, 2018
+ *      Author: gu74req
+ */
+
+#include "vector"
+#include "AliFemtoDreamCascadeCuts.h"
+#include "AliLog.h"
+ClassImp(AliFemtoDreamCascadeCuts)
+AliFemtoDreamCascadeCuts::AliFemtoDreamCascadeCuts()
+:fHist(0)
+,fNegCuts(0)
+,fPosCuts(0)
+,fBachCuts(0)
+,fHistList(0)
+,fcutXiMass(false)
+,fXiMass(0)
+,fXiMassWidth(0)
+,fcutXiCharge(false)
+,fXiCharge(0)
+,fcutDCAXiDaug(false)
+,fMaxDCAXiDaug(0)
+,fcutMinDistVtxBach(false)
+,fMinDistVtxBach(0)
+,fcutCPAXi(false)
+,fCPAXi(0)
+,fcutXiTransRadius(false)
+,fMinXiTransRadius(0)
+,fMaxXiTransRadius(0)
+,fcutv0Mass(false)
+,fv0Mass(0)
+,fv0Width(0)
+,fcutv0MaxDCADaug(false)
+,fv0MaxDCADaug(0)
+,fcutCPAv0(false)
+,fCPAv0(0)
+,fcutv0TransRadius(false)
+,fMinv0TransRadius(0)
+,fMaxv0TransRadius(0)
+,fcutv0MinDistVtx(false)
+,fv0MinDistVtx(0)
+,fcutv0DaugMinDistVtx(false)
+,fv0DaugMinDistVtx(0)
+{
+}
+
+AliFemtoDreamCascadeCuts::~AliFemtoDreamCascadeCuts() {
+  if (fNegCuts) {
+    delete fNegCuts;
+  }
+  if (fPosCuts) {
+    delete fPosCuts;
+  }
+  if (fBachCuts) {
+    delete fBachCuts;
+  }
+}
+
+AliFemtoDreamCascadeCuts* AliFemtoDreamCascadeCuts::XiCuts(bool isMC) {
+  AliFemtoDreamCascadeCuts *XiCuts=new AliFemtoDreamCascadeCuts();
+  XiCuts->SetXiMassRange(1.31486,0.05);
+  XiCuts->SetCutXiDaughterDCA(1.6);
+  XiCuts->SetCutXiMinDistBachToPrimVtx(0.05);
+  XiCuts->SetCutXiCPA(0.97);
+  XiCuts->SetCutXiTransverseRadius(0.8,200);
+  XiCuts->Setv0MassRange(1.116,0.006);
+  XiCuts->SetCutv0MaxDaughterDCA(1.6);
+  XiCuts->SetCutv0CPA(0.97);
+  XiCuts->SetCutv0TransverseRadius(1.4,200);
+  XiCuts->SetCutv0MinDistToPrimVtx(0.07);
+  XiCuts->SetCutv0MinDaugDistToPrimVtx(0.04);
+  return XiCuts;
+}
+
+bool AliFemtoDreamCascadeCuts::isSelected(AliFemtoDreamCascade *casc) {
+  bool pass=true;
+  fHist->FillCutCounter(0);
+  if (fcutXiCharge) {
+    if (!(casc->GetCharge().at(0)==fXiCharge)) {
+      pass=false;
+    } else {
+      fHist->FillCutCounter(1);
+    }
+  }
+  if (pass) {
+    std::vector<int> IDTracks=casc->GetIDTracks();
+    if (IDTracks[0]==IDTracks[1]) {
+      pass=false;
+    } else {
+      fHist->FillCutCounter(2);
+    }
+    if (IDTracks[0]==IDTracks[2]) {
+      pass=false;
+    } else {
+      fHist->FillCutCounter(3);
+    }
+    if (IDTracks[1]==IDTracks[2]) {
+      pass=false;
+    } else {
+      fHist->FillCutCounter(4);
+    }
+  }
+  if (pass) {
+    if (!fNegCuts->isSelected(casc->GetNegDaug())) {
+      pass=false;
+    } else {
+      fHist->FillCutCounter(5);
+    }
+  }
+  if (pass) {
+    if (!fPosCuts->isSelected(casc->GetPosDaug())) {
+      pass=false;
+    } else {
+      fHist->FillCutCounter(6);
+    }
+  }
+  if (pass) {
+    if (!fBachCuts->isSelected(casc->GetBach())) {
+      pass=false;
+    } else {
+      fHist->FillCutCounter(7);
+    }
+  }
+  if (pass&&fcutDCAXiDaug) {
+    if (casc->GetXiDCADaug()>fMaxDCAXiDaug) {
+      pass=false;
+    } else {
+      fHist->FillCutCounter(23);
+    }
+  }
+  if (pass&&fcutMinDistVtxBach) {
+    if (casc->BachDCAPrimVtx()<fMinDistVtxBach) {
+      pass=false;
+    } else {
+      fHist->FillCutCounter(24);
+    }
+  }
+  if (pass&&fcutCPAXi) {
+    if (casc->GetCPA()<fCPAXi) {
+      pass=false;
+    } else {
+      fHist->FillCutCounter(25);
+    }
+  }
+  if (pass&&fcutXiTransRadius) {
+    if ((casc->GetXiTransverseRadius()<fMinXiTransRadius)||
+        (casc->GetXiTransverseRadius()>fMaxXiTransRadius)) {
+      pass=false;
+    } else {
+      fHist->FillCutCounter(26);
+    }
+  }
+  if (pass&&fcutv0MaxDCADaug) {
+    if (casc->Getv0DCADaug()>fv0MaxDCADaug) {
+      pass=false;
+    } else {
+      fHist->FillCutCounter(27);
+    }
+  }
+  if (pass&&fcutCPAv0) {
+    if (casc->Getv0CPA()<fCPAv0) {
+      pass=false;
+    } else {
+      fHist->FillCutCounter(28);
+    }
+  }
+  if (pass&&fcutv0TransRadius) {
+    if ((casc->Getv0TransverseRadius()<fMinv0TransRadius)||
+        (casc->Getv0TransverseRadius()>fMaxv0TransRadius)) {
+      pass=false;
+    } else {
+      fHist->FillCutCounter(29);
+    }
+  }
+  if (pass&&fcutv0MinDistVtx) {
+    if (casc->Getv0DCAPrimVtx()<fv0MinDistVtx) {
+      pass=false;
+    } else {
+      fHist->FillCutCounter(30);
+    }
+  }
+  if (pass&&fcutv0DaugMinDistVtx) {
+    if ((casc->Getv0PosToPrimVtx()<fv0DaugMinDistVtx)||
+        (casc->Getv0NegToPrimVtx()<fv0DaugMinDistVtx)) {
+      pass=false;
+    } else {
+      fHist->FillCutCounter(31);
+    }
+  }
+  if (pass) {
+    fHist->FillInvMassPtv0(casc->GetPt(),casc->Getv0Mass());
+  }
+  if (pass&&fcutv0Mass) {
+    if ((casc->Getv0Mass()<(fv0Mass-fv0Width))||
+        (casc->Getv0Mass()>(fv0Mass+fv0Width))) {
+      pass=false;
+    } else {
+      fHist->FillCutCounter(32);
+    }
+  }
+  if (pass) {
+    fHist->FillInvMassPtXi(casc->GetPt(),casc->GetXiMass());
+  }
+  if (pass&&fcutXiMass) {
+    if ((casc->GetXiMass()<(fXiMass-fXiMassWidth))||
+        (casc->GetXiMass()>(fXiMass+fXiMassWidth))) {
+      pass=false;
+    } else {
+      fHist->FillCutCounter(33);
+    }
+  }
+  casc->SetUse(pass);
+  casc->GetNegDaug()->SetUse(pass);
+  casc->GetPosDaug()->SetUse(pass);
+  casc->GetBach()->SetUse(pass);
+  BookQA(casc);
+  return pass;
+}
+
+void AliFemtoDreamCascadeCuts::Init() {
+  fHist=new AliFemtoDreamCascadeHist(fXiMass);
+  if (!(fNegCuts||fPosCuts||fBachCuts)) {
+      AliFatal("Track Cuts Object Missing");
+  }
+  fNegCuts->Init();
+  fPosCuts->Init();
+  fBachCuts->Init();
+  fHistList=new TList();
+  fHistList->SetOwner();
+  fHistList->SetName("CascadeCuts");
+  fHistList->Add(fHist->GetHistList());
+  fNegCuts->SetName("NegCuts");
+  fHistList->Add(fNegCuts->GetQAHists());
+  fPosCuts->SetName("PosCuts");
+  fHistList->Add(fPosCuts->GetQAHists());
+  fBachCuts->SetName("BachelorCuts");
+  fHistList->Add(fBachCuts->GetQAHists());
+}
+
+void AliFemtoDreamCascadeCuts::BookQA(AliFemtoDreamCascade *casc) {
+  for (int i=0;i<2;++i) {
+    if (i==0||(i==1&&casc->UseParticle())) {
+      fHist->FillInvMassXi(i,casc->GetXiMass());
+      fHist->FillInvMassLambda(i,casc->Getv0Mass());
+      fHist->FillXiPt(i,casc->GetMomentum().Pt());
+      fHist->FillMomRapXi(i,casc->GetXiRapidity(),casc->GetMomentum().Mag());
+      fHist->FillDCAXiDaug(i,casc->GetXiDCADaug());
+      fHist->FillMinDistPrimVtxBach(i,casc->BachDCAPrimVtx());
+      fHist->FillCPAXi(i,casc->GetCPA());
+      fHist->FillTransverseRadiusXi(i,casc->GetXiTransverseRadius());
+      fHist->FillMaxDCAv0Daug(i,casc->Getv0DCADaug());
+      fHist->FillCPAv0(i,casc->Getv0CPA());
+      fHist->FillTransverseRadiusv0(i,casc->Getv0TransverseRadius());
+      fHist->FillMinDistPrimVtxv0(i,casc->Getv0DCAPrimVtx());
+      fHist->FillMinDistPrimVtxv0DaugPos(i,casc->Getv0PosToPrimVtx());
+      fHist->FillMinDistPrimVtxv0DaugNeg(i,casc->Getv0NegToPrimVtx());
+    }
+  }
+  fNegCuts->BookQA(casc->GetNegDaug());
+  fPosCuts->BookQA(casc->GetPosDaug());
+  fBachCuts->BookQA(casc->GetBach());
+  return;
+}

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCascadeCuts.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCascadeCuts.h
@@ -1,0 +1,88 @@
+/*
+ * AliFemtoDreamCascadeCuts.h
+ *
+ *  Created on: Jan 11, 2018
+ *      Author: gu74req
+ */
+
+#ifndef ALIFEMTODREAMCASCADECUTS_H_
+#define ALIFEMTODREAMCASCADECUTS_H_
+#include "Rtypes.h"
+#include "TList.h"
+#include "AliFemtoDreamCascade.h"
+#include "AliFemtoDreamCascadeHist.h"
+#include "AliFemtoDreamTrackCuts.h"
+class AliFemtoDreamCascadeCuts {
+ public:
+  AliFemtoDreamCascadeCuts();
+  virtual ~AliFemtoDreamCascadeCuts();
+  static AliFemtoDreamCascadeCuts *XiCuts(bool isMC);
+  void Setv0Negcuts(AliFemtoDreamTrackCuts *cuts){fNegCuts=cuts;};
+  void Setv0PosCuts(AliFemtoDreamTrackCuts *cuts){fPosCuts=cuts;};
+  void SetBachCuts(AliFemtoDreamTrackCuts *cuts){fBachCuts=cuts;};
+  void SetXiMassRange(double mass,double width){
+    fcutXiMass=true;fXiMass=mass;fXiMassWidth=width;};
+  void SetXiCharge(int charge){fcutXiCharge=true;fXiCharge=charge;}
+  void SetCutXiDaughterDCA(double maxDCA){
+    fcutDCAXiDaug=true;fMaxDCAXiDaug=maxDCA;};
+  void SetCutXiMinDistBachToPrimVtx(double minDist){
+    fcutMinDistVtxBach=true;fMinDistVtxBach=minDist;};
+  void SetCutXiCPA(double cpa){fcutCPAXi=true;fCPAXi=cpa;};
+  void SetCutXiTransverseRadius(double minRad,double maxRad){
+    fcutXiTransRadius=true;fMinXiTransRadius=minRad;fMaxXiTransRadius=maxRad;}
+  void Setv0MassRange(double mass,double width){
+    fcutv0Mass=true;fv0Mass=mass;fv0Width=width;}
+  void SetCutv0MaxDaughterDCA(double maxDCA){
+    fcutv0MaxDCADaug=true;fv0MaxDCADaug=maxDCA;}
+  void SetCutv0CPA(double CPA){
+    fcutCPAv0=true;fCPAv0=CPA;}
+  void SetCutv0TransverseRadius(double minRad,double maxRad){
+    fcutv0TransRadius=true;fMinv0TransRadius=minRad;fMaxv0TransRadius=maxRad;}
+  void SetCutv0MinDistToPrimVtx(double minDist){
+    fcutv0MinDistVtx=true;fv0MinDistVtx=minDist;}
+  void SetCutv0MinDaugDistToPrimVtx(double minDist){
+    fcutv0DaugMinDistVtx=true;fv0DaugMinDistVtx=minDist;};
+  TString ClassName()const{return "AliFemtoDreamCascadeCuts";};
+  void Init();
+  bool isSelected(AliFemtoDreamCascade *casc);
+  void BookQA(AliFemtoDreamCascade *casc);
+  TList *GetQAHists() {return fHistList;};
+ private:
+  AliFemtoDreamCascadeHist *fHist;
+  AliFemtoDreamTrackCuts *fNegCuts;
+  AliFemtoDreamTrackCuts *fPosCuts;
+  AliFemtoDreamTrackCuts *fBachCuts;
+  TList *fHistList;
+  bool fcutXiMass;
+  double fXiMass;
+  double fXiMassWidth;
+  bool fcutXiCharge;
+  int fXiCharge;
+  bool fcutDCAXiDaug;
+  double fMaxDCAXiDaug;
+  bool fcutMinDistVtxBach;
+  double fMinDistVtxBach;
+  bool fcutCPAXi;
+  double fCPAXi;
+  bool fcutXiTransRadius;
+  double fMinXiTransRadius;
+  double fMaxXiTransRadius;
+  bool fcutv0Mass;
+  double fv0Mass;
+  double fv0Width;
+  bool fcutv0MaxDCADaug;
+  double fv0MaxDCADaug;
+  bool fcutCPAv0;
+  double fCPAv0;
+  bool fcutv0TransRadius;
+  double fMinv0TransRadius;
+  double fMaxv0TransRadius;
+  bool fcutv0MinDistVtx;
+  double fv0MinDistVtx;
+  bool fcutv0DaugMinDistVtx;
+  double fv0DaugMinDistVtx;
+
+  ClassDef(AliFemtoDreamCascadeCuts,1)
+};
+
+#endif /* ALIFEMTODREAMCASCADECUTS_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCascadeHist.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCascadeHist.cxx
@@ -1,0 +1,210 @@
+/*
+ * AliFemtoDreamCascadeHist.cxx
+ *
+ *  Created on: Jan 11, 2018
+ *      Author: gu74req
+ */
+
+#include "AliFemtoDreamCascadeHist.h"
+
+ClassImp(AliFemtoDreamCascadeHist)
+
+AliFemtoDreamCascadeHist::AliFemtoDreamCascadeHist()
+:fHistList()
+,fCutCounter(0)
+,fConfig(0)
+,fInvMassPtXi(0)
+,fInvMassPtv0(0)
+{
+  for (int i=0;i<2;++i) {
+    fCascadeQA[i]=0;
+    fInvMass[i]=0;
+    fInvMassv0[i]=0;
+    fXiPt[i]=0;;
+    fP_Y_Xi[i]=0;;
+    fDCAXiDaug[i]=0;;
+    fMinDistVtxBach[i]=0;;
+    fCPAXi[i]=0;;
+    fTransRadiusXi[i]=0;;
+    fv0MaxDCADaug[i]=0;;
+    fCPAv0[i]=0;;
+    fTransRadiusv0[i]=0;;
+    fMinDistVtxv0[i]=0;;
+    fMinDistVtxv0DaugPos[i]=0;;
+    fMinDistVtxv0DaugNeg[i]=0;;
+  }
+}
+AliFemtoDreamCascadeHist::AliFemtoDreamCascadeHist(double mass) {
+  fHistList=new TList();
+  fHistList->SetName("Cascade");
+  fHistList->SetOwner();
+
+  fCutCounter = new TH1F("CutCounter", "Cut Counter", 40, 0, 40);
+  fCutCounter->GetXaxis()->SetBinLabel(1, "Input");
+  fCutCounter->GetXaxis()->SetBinLabel(2, "Charge");
+  fCutCounter->GetXaxis()->SetBinLabel(3, "Id Neg Pos");
+  fCutCounter->GetXaxis()->SetBinLabel(4, "Id Neg Bach");
+  fCutCounter->GetXaxis()->SetBinLabel(5, "Id Pos Bach");
+  fCutCounter->GetXaxis()->SetBinLabel(6, "ReqITSTOFHit Pos");
+  fCutCounter->GetXaxis()->SetBinLabel(7, "ReqITSTOFHit Neg");
+  fCutCounter->GetXaxis()->SetBinLabel(8, "ReqITSTOFHit Bach");
+  fCutCounter->GetXaxis()->SetBinLabel(9, "ReqTPCRefit Pos");
+  fCutCounter->GetXaxis()->SetBinLabel(10, "ReqTPCRefit Neg");
+  fCutCounter->GetXaxis()->SetBinLabel(11, "ReqTPCRefit Bach");
+  fCutCounter->GetXaxis()->SetBinLabel(12, "Crossed Rows Pos");
+  fCutCounter->GetXaxis()->SetBinLabel(13, "Crossed Rows Neg");
+  fCutCounter->GetXaxis()->SetBinLabel(14, "Crossed Rows Bach");
+  fCutCounter->GetXaxis()->SetBinLabel(15, "NClst TPC Pos");
+  fCutCounter->GetXaxis()->SetBinLabel(16, "NClst TPC Neg");
+  fCutCounter->GetXaxis()->SetBinLabel(17, "NClst TPC Bach");
+  fCutCounter->GetXaxis()->SetBinLabel(18, "nSigmaTPC Pos");
+  fCutCounter->GetXaxis()->SetBinLabel(19, "nSigmaTPC Neg");
+  fCutCounter->GetXaxis()->SetBinLabel(20, "nSigmaTPC Bach");
+  fCutCounter->GetXaxis()->SetBinLabel(21, "P_{T,min} Pos");
+  fCutCounter->GetXaxis()->SetBinLabel(22, "P_{T,min} Neg");
+  fCutCounter->GetXaxis()->SetBinLabel(23, "P_{T,min} Bach");
+  fCutCounter->GetXaxis()->SetBinLabel(24, "DCAXiDaug");
+  fCutCounter->GetXaxis()->SetBinLabel(25, "Min Dist Prim Vtx Bach");
+  fCutCounter->GetXaxis()->SetBinLabel(26, "CPA Xi");
+  fCutCounter->GetXaxis()->SetBinLabel(27, "Xi TransRadius");
+  fCutCounter->GetXaxis()->SetBinLabel(28, "DCA v0 Vtx Daug");
+  fCutCounter->GetXaxis()->SetBinLabel(29, "CPA v0");
+  fCutCounter->GetXaxis()->SetBinLabel(30, "v0 TransRadius");
+  fCutCounter->GetXaxis()->SetBinLabel(31, "Min Dist Prim Vtx v0");
+  fCutCounter->GetXaxis()->SetBinLabel(32, "Min Dist Prim Vtx v0 Daughter");
+  fCutCounter->GetXaxis()->SetBinLabel(33, "Inv Mass Lambda");
+  fCutCounter->GetXaxis()->SetBinLabel(34, "Inv Mass Xi");
+
+  fHistList->Add(fCutCounter);
+
+  fConfig=new TProfile("Config","Config",22,0,22);
+  fConfig->SetStats(0);
+  fConfig->GetXaxis()->SetBinLabel(1,"Require ITSTOF Hit");
+  fConfig->GetXaxis()->SetBinLabel(2,"Require TOF Refit Daug");
+  fConfig->GetXaxis()->SetBinLabel(3,"Ratio CR");
+  fConfig->GetXaxis()->SetBinLabel(4,"NCls TPC");
+  fConfig->GetXaxis()->SetBinLabel(5,"N#Sigma_{TPC}");
+  fConfig->GetXaxis()->SetBinLabel(6,"P_{T,Daug-min}");
+  fConfig->GetXaxis()->SetBinLabel(7,"#Xi_{Mass}");
+  fConfig->GetXaxis()->SetBinLabel(8,"#Xi_{Width}");
+  fConfig->GetXaxis()->SetBinLabel(9,"#Xi Charge");
+  fConfig->GetXaxis()->SetBinLabel(10,"DCA #Xi Daug");
+  fConfig->GetXaxis()->SetBinLabel(11,"Min Dist. Bach To Vtx");
+  fConfig->GetXaxis()->SetBinLabel(12,"CPA #Xi");
+  fConfig->GetXaxis()->SetBinLabel(13,"Min Trans. Radius #Xi");
+  fConfig->GetXaxis()->SetBinLabel(14,"Max Trans. Radius #Xi");
+  fConfig->GetXaxis()->SetBinLabel(15,"v0_{Mass}");
+  fConfig->GetXaxis()->SetBinLabel(16,"v0_{Width}");
+  fConfig->GetXaxis()->SetBinLabel(17,"DCA v0 Daug");
+  fConfig->GetXaxis()->SetBinLabel(18,"CPAv0");
+  fConfig->GetXaxis()->SetBinLabel(19,"Min Trans. Radius v0");
+  fConfig->GetXaxis()->SetBinLabel(20,"Max Trans. Radius v0");
+  fConfig->GetXaxis()->SetBinLabel(21,"Min Dist. v0 To Vtx");
+  fConfig->GetXaxis()->SetBinLabel(22,"Min Dist. v0 Daug to Vtx");
+  fHistList->Add(fConfig);
+
+  fInvMassPtXi=new TH2F("InvMassXiPt","InvMassXiPt",19,0.6,6.5,500,mass*0.9,mass*1.3);
+  fInvMassPtXi->Sumw2();
+  fInvMassPtXi->GetXaxis()->SetTitle("P_{T}");
+  fInvMassPtXi->GetYaxis()->SetTitle("Inv Mass");
+  fHistList->Add(fInvMassPtXi);
+
+  fInvMassPtv0=new TH2F("InvMassv0Pt","InvMassv0Pt",19,0.6,6.5,400,0.9,1.2);
+  fInvMassPtv0->Sumw2();
+  fInvMassPtv0->GetXaxis()->SetTitle("P_{T}");
+  fInvMassPtv0->GetYaxis()->SetTitle("Inv Mass");
+  fHistList->Add(fInvMassPtv0);
+
+  TString sName[2]={"before","after"};
+  for (int i=0;i<2;++i) {
+    fCascadeQA[i]=new TList();
+    fCascadeQA[i]->SetOwner();
+    fCascadeQA[i]->SetName(sName[i].Data());
+    fHistList->Add(fCascadeQA[i]);
+
+    TString InvMassXiName=Form("InvariantMassXi_%s",sName[i].Data());
+    fInvMass[i]=new TH1F(InvMassXiName.Data(),InvMassXiName.Data(),500,mass*0.9,mass*1.3);
+    fInvMass[i]->Sumw2();
+    fCascadeQA[i]->Add(fInvMass[i]);
+
+    TString InvMassv0Name=Form("InvariantMassv0_%s",sName[i].Data());
+    fInvMassv0[i]=new TH1F(InvMassv0Name.Data(),InvMassv0Name.Data()
+                           ,500,1.116*0.9,1.116*1.3);
+    fInvMassv0[i]->Sumw2();
+    fCascadeQA[i]->Add(fInvMassv0[i]);
+
+    TString XiPtName=Form("XiPt_%s",sName[i].Data());
+    fXiPt[i]=new TH1F(XiPtName.Data(),XiPtName.Data(),19,0.6,6.5);
+    fXiPt[i]->Sumw2();
+    fCascadeQA[i]->Add(fXiPt[i]);
+
+    TString P_Y_XiName=Form("Xi_P_Y_%s",sName[i].Data());
+    fP_Y_Xi[i]=new TH2F(P_Y_XiName.Data(),P_Y_XiName.Data(),50,-3.,3.,50,0.,5.);
+    fP_Y_Xi[i]->GetXaxis()->SetName("Rapidity Y");
+    fP_Y_Xi[i]->GetYaxis()->SetName("P");
+    fP_Y_Xi[i]->Sumw2();
+    fCascadeQA[i]->Add(fP_Y_Xi[i]);
+
+    TString DCAXiDaugName=Form("DCAXiDaug_%s",sName[i].Data());
+    fDCAXiDaug[i]=new TH1F(DCAXiDaugName.Data(),DCAXiDaugName.Data(),50,0,10);
+    fDCAXiDaug[i]->Sumw2();
+    fCascadeQA[i]->Add(fDCAXiDaug[i]);
+
+    TString MinDistVtxBachName=Form("MinDistVtxBach_%s",sName[i].Data());
+    fMinDistVtxBach[i]=new TH1F(MinDistVtxBachName.Data(),
+                                MinDistVtxBachName.Data(),50,0,10);
+    fMinDistVtxBach[i]->Sumw2();
+    fCascadeQA[i]->Add(fMinDistVtxBach[i]);
+
+    TString CPAXiName=Form("CPAXi_%s",sName[i].Data());
+    fCPAXi[i]=new TH1F(CPAXiName.Data(),CPAXiName.Data(),100,0.97,1);
+    fCPAXi[i]->Sumw2();
+    fCascadeQA[i]->Add(fCPAXi[i]);
+
+    TString TransRadiusXiName=Form("TransRadiusXi_%s",sName[i].Data());
+    fTransRadiusXi[i]=new TH1F(TransRadiusXiName.Data(),
+                               TransRadiusXiName.Data(),200,0,200);
+    fTransRadiusXi[i]->Sumw2();
+    fCascadeQA[i]->Add(fTransRadiusXi[i]);
+
+    TString v0MaxDCADaugName=Form("v0MaxDCADaug_%s",sName[i].Data());
+    fv0MaxDCADaug[i]=new TH1F(v0MaxDCADaugName.Data(),v0MaxDCADaugName.Data(),
+                              50,0,10);
+    fv0MaxDCADaug[i]->Sumw2();
+    fCascadeQA[i]->Add(fv0MaxDCADaug[i]);
+
+    TString CPAv0Name=Form("CPAv0_%s",sName[i].Data());
+    fCPAv0[i]=new TH1F(CPAv0Name.Data(),CPAv0Name.Data(),100,0.97,1);
+    fCPAv0[i]->Sumw2();
+    fCascadeQA[i]->Add(fCPAv0[i]);
+
+    TString TransRadiusv0Name=Form("TransRadiusv0_%s",sName[i].Data());
+    fTransRadiusv0[i]=new TH1F(TransRadiusv0Name.Data(),
+                               TransRadiusv0Name.Data(),200,0,200);
+    fTransRadiusv0[i]->Sumw2();
+    fCascadeQA[i]->Add(fTransRadiusv0[i]);
+
+    TString MinDistVtxv0Name=Form("MinDistVtxv0_%s",sName[i].Data());
+    fMinDistVtxv0[i]=new TH1F(MinDistVtxv0Name.Data(),MinDistVtxv0Name.Data(),
+                              50,0,10);
+    fMinDistVtxv0[i]->Sumw2();
+    fCascadeQA[i]->Add(fMinDistVtxv0[i]);
+
+    TString MinDistVtxv0DaugPosName=Form("MinDistVtxv0DaugPos_%s",sName[i].Data());
+    fMinDistVtxv0DaugPos[i]=new TH1F(MinDistVtxv0DaugPosName.Data(),
+                                  MinDistVtxv0DaugPosName.Data(),50,0,10);
+    fMinDistVtxv0DaugPos[i]->Sumw2();
+    fCascadeQA[i]->Add(fMinDistVtxv0DaugPos[i]);
+
+    TString MinDistVtxv0DaugNameNeg=Form("MinDistVtxv0DaugNeg_%s",sName[i].Data());
+    fMinDistVtxv0DaugNeg[i]=new TH1F(MinDistVtxv0DaugNameNeg.Data(),
+                                  MinDistVtxv0DaugNameNeg.Data(),50,0,10);
+    fMinDistVtxv0DaugNeg[i]->Sumw2();
+    fCascadeQA[i]->Add(fMinDistVtxv0DaugNeg[i]);
+  }
+}
+
+AliFemtoDreamCascadeHist::~AliFemtoDreamCascadeHist() {
+
+}
+

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCascadeHist.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCascadeHist.h
@@ -1,0 +1,64 @@
+/*
+ * AliFemtoDreamCascadeHist.h
+ *
+ *  Created on: Jan 11, 2018
+ *      Author: gu74req
+ */
+
+#ifndef ALIFEMTODREAMCASCADEHIST_H_
+#define ALIFEMTODREAMCASCADEHIST_H_
+#include "Rtypes.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TProfile.h"
+#include "TList.h"
+
+class AliFemtoDreamCascadeHist {
+ public:
+  AliFemtoDreamCascadeHist();
+  AliFemtoDreamCascadeHist(double mass);
+  virtual ~AliFemtoDreamCascadeHist();
+  void FillCutCounter(int bin) {fCutCounter->Fill(bin);};
+  void FillConfig(int iBin,double val){fConfig->Fill(iBin,val);};
+  void FillInvMassXi(int iBin,double mass){fInvMass[iBin]->Fill(mass);};
+  void FillInvMassPtXi(double Pt,double mass){fInvMassPtXi->Fill(Pt,mass);};
+  void FillInvMassPtv0(double Pt,double mass){fInvMassPtv0->Fill(Pt,mass);};
+  void FillInvMassLambda(int iBin,double mass){fInvMassv0[iBin]->Fill(mass);};
+  void FillXiPt(int iBin,double pT){fXiPt[iBin]->Fill(pT);};
+  void FillMomRapXi(int iBin,double rap,double pT){fP_Y_Xi[iBin]->Fill(rap,pT);};
+  void FillDCAXiDaug(int iBin,double DCA){fDCAXiDaug[iBin]->Fill(DCA);};
+  void FillMinDistPrimVtxBach(int iBin,double dist){fMinDistVtxBach[iBin]->Fill(dist);};
+  void FillCPAXi(int iBin,double cpa){fCPAXi[iBin]->Fill(cpa);};
+  void FillTransverseRadiusXi(int iBin,double rad){fTransRadiusXi[iBin]->Fill(rad);};
+  void FillMaxDCAv0Daug(int iBin,double dca){fv0MaxDCADaug[iBin]->Fill(dca);};
+  void FillCPAv0(int iBin,double cpa){fCPAv0[iBin]->Fill(cpa);};
+  void FillTransverseRadiusv0(int iBin,double rad){fTransRadiusv0[iBin]->Fill(rad);};
+  void FillMinDistPrimVtxv0(int iBin,double dist){fMinDistVtxv0[iBin]->Fill(dist);};
+  void FillMinDistPrimVtxv0DaugPos(int iBin,double dist){fMinDistVtxv0DaugPos[iBin]->Fill(dist);};
+  void FillMinDistPrimVtxv0DaugNeg(int iBin,double dist){fMinDistVtxv0DaugNeg[iBin]->Fill(dist);};
+  TList *GetHistList() {return fHistList;};
+  private:
+  TList *fHistList;
+  TH1F *fCutCounter;
+  TProfile *fConfig;
+  TList *fCascadeQA[2];
+  TH2F *fInvMassPtXi;
+  TH2F *fInvMassPtv0;
+  TH1F *fInvMass[2];
+  TH1F *fInvMassv0[2];
+  TH1F *fXiPt[2];
+  TH2F *fP_Y_Xi[2];
+  TH1F *fDCAXiDaug[2];
+  TH1F *fMinDistVtxBach[2];
+  TH1F *fCPAXi[2];
+  TH1F *fTransRadiusXi[2];
+  TH1F *fv0MaxDCADaug[2];
+  TH1F *fCPAv0[2];
+  TH1F *fTransRadiusv0[2];
+  TH1F *fMinDistVtxv0[2];
+  TH1F *fMinDistVtxv0DaugPos[2];
+  TH1F *fMinDistVtxv0DaugNeg[2];
+  ClassDef(AliFemtoDreamCascadeHist,1)
+};
+
+#endif /* ALIFEMTODREAMCASCADEHIST_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCollConfig.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCollConfig.cxx
@@ -1,0 +1,174 @@
+/*
+ * AliFemtoDreamCollConfig.cxx
+ *
+ *  Created on: Sep 13, 2017
+ *      Author: gu74req
+ */
+#include "TMath.h"
+#include "AliFemtoDreamCollConfig.h"
+ClassImp(AliFemtoDreamCollConfig)
+AliFemtoDreamCollConfig::AliFemtoDreamCollConfig()
+:TNamed()
+,fZVtxBins(0)
+,fMultBins(0)
+,fPDGParticleSpecies(0)
+,fNBinsHists(0)
+,fMinK_rel(0)
+,fMaxK_rel(0)
+,fMixingDepth(0)
+{
+  //should not be used, since we need a name to deal with root objects
+}
+
+AliFemtoDreamCollConfig::AliFemtoDreamCollConfig(const char *name,
+                                                 const char *title)
+:TNamed(name,title)
+,fMixingDepth(0)
+{
+  fZVtxBins=new TNtuple("ZBins","ZBins","zvtx");
+  fMultBins=new TNtuple("MultBins","MultBins","mult");
+  fPDGParticleSpecies=new TNtuple("PDGCodes","PDGCodes","PDGCodes");
+  fNBinsHists=new TNtuple("NmbBins","NmbBins","NmbBins");
+  fMinK_rel=new TNtuple("MinK_rel","MinK_rel","minkRel");
+  fMaxK_rel=new TNtuple("MaxK_rel","MaxK_rel","maxkRel");
+}
+
+AliFemtoDreamCollConfig::~AliFemtoDreamCollConfig() {
+  delete fZVtxBins;
+  delete fMultBins;
+  delete fPDGParticleSpecies;
+  delete fNBinsHists;
+  delete fMinK_rel;
+  delete fMaxK_rel;
+
+}
+
+void AliFemtoDreamCollConfig::SetZBins(std::vector<double> ZBins) {
+  //Make sure to set the entries in ascending order!
+  //Todo: maybe build in a check for this
+  for (std::vector<double>::iterator it=ZBins.begin();it!=ZBins.end();++it) {
+    fZVtxBins->Fill(*it);
+  }
+}
+std::vector<double> AliFemtoDreamCollConfig::GetZVtxBins() {
+  //Make sure to set the entries in ascending order!
+  std::vector<double> ZBins;
+  float out=0;
+  fZVtxBins->SetBranchAddress("zvtx",&out);
+  for (int iBins=0;iBins<fZVtxBins->GetEntries();++iBins) {
+    fZVtxBins->GetEntry(iBins);
+    ZBins.push_back(out);
+  }
+  return ZBins;
+}
+void AliFemtoDreamCollConfig::SetMultBins(std::vector<int> MultBins) {
+  //Make sure to set the entries in ascending order! The last bin to infinite
+  //is implicit
+  //Todo: maybe build in a check for this
+  for (std::vector<int>::iterator it=MultBins.begin();it!=MultBins.end();++it)
+  {
+    fMultBins->Fill(*it);
+  }
+}
+std::vector<int> AliFemtoDreamCollConfig::GetMultBins() {
+  std::vector<int> MultBins;
+  float out=0;
+  fMultBins->SetBranchAddress("mult",&out);
+  for (int iBins=0;iBins<fMultBins->GetEntries();++iBins) {
+    fMultBins->GetEntry(iBins);
+    MultBins.push_back(out);
+  }
+  return MultBins;
+}
+void AliFemtoDreamCollConfig::SetPDGCodes(std::vector<int> PDGCodes) {
+  //the order needs to correspond the first particle array in your vector that
+  //you hand over in the AliFemtoDreamPartCollection::SetEvent Method!
+  for (std::vector<int>::iterator it=PDGCodes.begin();it!=PDGCodes.end();++it)
+  {
+    fPDGParticleSpecies->Fill(*it);
+  }
+}
+std::vector<int> AliFemtoDreamCollConfig::GetPDGCodes() {
+  std::vector<int> PDGCodes;
+  float out=0;
+  fPDGParticleSpecies->SetBranchAddress("PDGCodes",&out);
+  for (int iBins=0;iBins<fPDGParticleSpecies->GetEntries();++iBins) {
+    fPDGParticleSpecies->GetEntry(iBins);
+    PDGCodes.push_back(out);
+  }
+  return PDGCodes;
+}
+int AliFemtoDreamCollConfig::GetNParticleCombinations(){
+  //The possible number of combinations for pairing two particles species
+  //with itself and all other species is for n species given by:
+  //-Combinations within the same species n
+  //-Combinations with all other species Binominal(n,2)
+  int comb=fPDGParticleSpecies->GetEntries();
+  if(comb>1){
+    comb+=TMath::Binomial(comb,2);
+  }
+  return comb;
+}
+
+void AliFemtoDreamCollConfig::SetNBinsHist(std::vector<int> NBins) {
+  //The way the histograms are assigned later is going to be for example for
+  //4 different particle species X1,X2,X3,X4:
+  //    X1  X2  X3  X4
+  //X1  1   2   3   4
+  //X2      5   6   7
+  //X3          8   9
+  //X4              10<-----Number of the Histogram=Position in input vector
+  //Assign your binnig accordingly. X1 corresponds the first particle array
+  //in your vector that you hand over in the
+  //AliFemtoDreamPartCollection::SetEvent Method, X2 to the second and so on.
+  //Same binning and ranges for Same Event and Mixed Event Distribution
+  for (std::vector<int>::iterator it=NBins.begin();it!=NBins.end();++it)
+  {
+    fNBinsHists->Fill(*it);
+  }
+}
+std::vector<int> AliFemtoDreamCollConfig::GetNBinsHist() {
+  std::vector<int> NBinsHist;
+  float out=0;
+  fNBinsHists->SetBranchAddress("NmbBins",&out);
+  for (int iBins=0;iBins<fNBinsHists->GetEntries();++iBins) {
+    fNBinsHists->GetEntry(iBins);
+    NBinsHist.push_back(out);
+  }
+  return NBinsHist;
+}
+void AliFemtoDreamCollConfig::SetMinKRel(std::vector<double> minKRel) {
+  //See SetNBinsHist
+  for (std::vector<double>::iterator it=minKRel.begin();it!=minKRel.end();++it)
+  {
+    fMinK_rel->Fill(*it);
+  }
+}
+std::vector<double> AliFemtoDreamCollConfig::GetMinKRel() {
+  std::vector<double> MinKRel;
+  float out=0;
+  fMinK_rel->SetBranchAddress("minkRel",&out);
+  for (int iBins=0;iBins<fMinK_rel->GetEntries();++iBins) {
+    fMinK_rel->GetEntry(iBins);
+    MinKRel.push_back(out);
+  }
+  return MinKRel;
+}
+void AliFemtoDreamCollConfig::SetMaxKRel(std::vector<double> maxKRel) {
+  //See SetNBinsHist
+  for (std::vector<double>::iterator it=maxKRel.begin();it!=maxKRel.end();++it)
+  {
+    fMaxK_rel->Fill(*it);
+  }
+}
+std::vector<double> AliFemtoDreamCollConfig::GetMaxKRel() {
+  std::vector<double> MaxKRel;
+  float out=0;
+  fMaxK_rel->SetBranchAddress("maxkRel",&out);
+  for (int iBins=0;iBins<fMaxK_rel->GetEntries();++iBins) {
+    fMaxK_rel->GetEntry(iBins);
+    MaxKRel.push_back(out);
+  }
+  return MaxKRel;
+}
+

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCollConfig.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCollConfig.h
@@ -1,0 +1,50 @@
+/*
+ * AliFemtoDreamCollConfig.h
+ *
+ *  Created on: Sep 13, 2017
+ *      Author: gu74req
+ */
+
+#ifndef ALIFEMTODREAMCOLLCONFIG_H_
+#define ALIFEMTODREAMCOLLCONFIG_H_
+#include <vector>
+#include "Rtypes.h"
+#include "TNamed.h"
+#include "TNtuple.h"
+
+class AliFemtoDreamCollConfig : public TNamed {
+ public:
+  AliFemtoDreamCollConfig();
+  AliFemtoDreamCollConfig(const char *name, const char *title);
+  virtual ~AliFemtoDreamCollConfig();
+  void SetZBins(std::vector<double> ZBins);
+  void SetMultBins(std::vector<int> MultBins);
+  void SetPDGCodes(std::vector<int> PDGCodes);
+  void SetNBinsHist(std::vector<int> NBins);
+  void SetMinKRel(std::vector<double> minKRel);
+  void SetMaxKRel(std::vector<double> maxKRel);
+  void SetMixingDepth(int MixingDepth){fMixingDepth=MixingDepth;};
+
+  std::vector<double> GetZVtxBins();
+  int GetNZVtxBins(){return (fZVtxBins->GetEntries()-1);};
+  std::vector<int> GetMultBins();
+  int GetNMultBins(){return fMultBins->GetEntries();};
+  std::vector<int> GetPDGCodes();
+  int GetNParticles() {return fPDGParticleSpecies->GetEntries();};
+  int GetNParticleCombinations();
+  std::vector<int> GetNBinsHist();
+  std::vector<double> GetMinKRel();
+  std::vector<double> GetMaxKRel();
+  int GetMixingDepth(){return fMixingDepth;};
+ private:
+  TNtuple *fZVtxBins;           //
+  TNtuple *fMultBins;           //
+  TNtuple *fPDGParticleSpecies; //
+  TNtuple *fNBinsHists;         //
+  TNtuple *fMinK_rel;           //
+  TNtuple *fMaxK_rel;           //
+  int fMixingDepth;             //
+  ClassDef(AliFemtoDreamCollConfig,1);
+};
+
+#endif /* ALIFEMTODREAMCOLLCONFIG_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.cxx
@@ -1,0 +1,134 @@
+/*
+ * AliFemtoDreamCorrHists.cxx
+ *
+ *  Created on: Sep 12, 2017
+ *      Author: gu74req
+ */
+#include <iostream>
+#include <vector>
+#include "AliFemtoDreamCorrHists.h"
+#include "TMath.h"
+ClassImp(AliFemtoDreamCorrHists)
+AliFemtoDreamCorrHists::AliFemtoDreamCorrHists()
+:fQA(0)
+,fResults(0)
+,fPairs(0)
+,fPairQA(0)
+,fSameEventDist(0)
+,fPairCounterSE(0)
+,fMixedEventDist(0)
+,fPairCounterME(0)
+{
+}
+
+AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf) {
+
+  fResults=new TList();
+  fResults->SetName("Results");
+  fResults->SetOwner();
+
+  fQA=new TList();
+  fQA->SetName("PairQA");
+  fQA->SetOwner();
+
+  int nParticles=conf->GetNParticles();
+  const int nHists=conf->GetNParticleCombinations();
+  std::vector<int> NBinsHist=conf->GetNBinsHist();
+  std::vector<int>::iterator itNBins=NBinsHist.begin();
+  std::vector<double> kRelMin=conf->GetMinKRel();
+  std::vector<double>::iterator itKMin=kRelMin.begin();
+  std::vector<double> kRelMax=conf->GetMaxKRel();
+  std::vector<double>::iterator itKMax=kRelMax.begin();
+
+  if (nHists!=(int)NBinsHist.size() || nHists!=(int)kRelMin.size() ||
+      nHists!=(int)kRelMax.size()) {
+    //Todo: Replace by AliFatal!
+    std::cout<<"something went horribly wrong!"<<std::endl;
+  }
+  //The way the histograms are assigned later is going to be for example for
+  //4 different particle species X1,X2,X3,X4:
+  //    X1  X2  X3  X4
+  //X1  1   2   3   4
+  //X2      5   6   7
+  //X3          8   9
+  //X4              10<-----Number of the Histogram=Position in input vector
+  //X1 corresponds the first particle array in your vector that you hand over
+  //in the AliFemtoDreamPartCollection::SetEvent Method, X2 to the second and
+  //so on.
+  fPairs=new TList*[nHists];
+  fPairQA=new TList*[nHists];
+  fSameEventDist=new TH1F*[nHists];
+  fPairCounterSE=new TH2F*[nHists];
+  fMixedEventDist=new TH1F*[nHists];
+  fPairCounterME=new TH2F*[nHists];
+
+  int Counter=0;
+  for (int iPar1 = 0; iPar1 < nParticles; ++iPar1) {
+    for (int iPar2 = iPar1; iPar2 < nParticles; ++iPar2) {
+      fPairs[Counter]=new TList();
+      TString PairFolderName=Form("Particle%d_Particle%d",iPar1,iPar2);
+      fPairs[Counter]->SetName(PairFolderName.Data());
+      fPairs[Counter]->SetOwner();
+      fResults->Add(fPairs[Counter]);
+
+      fPairQA[Counter]=new TList();
+      TString PairQAName=Form("QA_Particle%d_Particle%d",iPar1,iPar2);
+      fPairQA[Counter]->SetName(PairQAName.Data());
+      fPairQA[Counter]->SetOwner();
+      fQA->Add(fPairQA[Counter]);
+
+      TString SameEventName=Form("SEDist_Particle%d_Particle%d",iPar1,iPar2);
+      fSameEventDist[Counter]=new TH1F(SameEventName.Data(),
+                                       SameEventName.Data(),
+                                       *itNBins,*itKMin,*itKMax);
+      fSameEventDist[Counter]->Sumw2();
+      fPairs[Counter]->Add(fSameEventDist[Counter]);
+
+      TString PairCounterSEName=
+          Form("SEPairs_Particle%d_Particle%d",iPar1,iPar2);
+      fPairCounterSE[Counter]=new TH2F(
+          PairCounterSEName.Data(),PairCounterSEName.Data(),20,0,20,20,0,20);
+      fPairCounterSE[Counter]->Sumw2();
+      fPairCounterSE[Counter]->GetXaxis()->SetTitle(Form("Particle%d",iPar1));
+      fPairCounterSE[Counter]->GetYaxis()->SetTitle(Form("Particle%d",iPar2));
+      fPairQA[Counter]->Add(fPairCounterSE[Counter]);
+
+      TString MixedEventName=Form("MEDist_Particle%d_Particle%d",iPar1,iPar2);
+      fMixedEventDist[Counter]=new TH1F(MixedEventName.Data(),
+                                        MixedEventName.Data(),
+                                       *itNBins,*itKMin,*itKMax);
+      fMixedEventDist[Counter]->Sumw2();
+      fPairs[Counter]->Add(fMixedEventDist[Counter]);
+
+      TString PairCounterMEName=
+          Form("MEPairs_Particle%d_Particle%d",iPar1,iPar2);
+      fPairCounterME[Counter]=new TH2F(
+          PairCounterMEName.Data(),PairCounterMEName.Data(),20,0,20,20,0,20);
+      fPairCounterME[Counter]->Sumw2();
+      fPairCounterME[Counter]->GetXaxis()->SetTitle(Form("Particle%d",iPar1));
+      fPairCounterME[Counter]->GetYaxis()->SetTitle(Form("Particle%d",iPar2));
+      fPairQA[Counter]->Add(fPairCounterME[Counter]);
+
+      ++Counter;
+      ++itNBins;
+      ++itKMin;
+      ++itKMax;
+    }
+  }
+}
+
+AliFemtoDreamCorrHists::~AliFemtoDreamCorrHists() {
+  if (fPairs) {
+    delete [] fPairs;
+    delete fPairs;
+  }
+  if (fSameEventDist) {
+    delete [] fSameEventDist;
+    delete fSameEventDist;
+  }
+  if (fMixedEventDist) {
+    delete [] fMixedEventDist;
+    delete fMixedEventDist;
+  }
+}
+

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.h
@@ -1,0 +1,45 @@
+/*
+ * AliFemtoDreamCorrHists.h
+ *
+ *  Created on: Sep 12, 2017
+ *      Author: gu74req
+ */
+
+#ifndef ALIFEMTODREAMCORRHISTS_H_
+#define ALIFEMTODREAMCORRHISTS_H_
+#include "Rtypes.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TList.h"
+
+#include "AliFemtoDreamCollConfig.h"
+
+class AliFemtoDreamCorrHists {
+ public:
+  AliFemtoDreamCorrHists();
+  AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf);
+  virtual ~AliFemtoDreamCorrHists();
+  void FillSameEventDist(int i,double RelK){fSameEventDist[i]->Fill(RelK);};
+  void FillMixedEventDist(int i,double RelK){fMixedEventDist[i]->Fill(RelK);};
+  void FillPartnersSE(int hist,int nPart1,int nPart2){
+    fPairCounterSE[hist]->Fill(nPart1,nPart2);
+  }
+  void FillPartnersME(int hist,int nPart1,int nPart2){
+    fPairCounterME[hist]->Fill(nPart1,nPart2);
+  }
+  TList* GetHistList(){return fResults;};
+  TList* GetQAHists(){return fQA;};
+ private:
+  TList         *fQA;
+  TList         *fResults;
+  TList         **fPairs;
+  TList         **fPairQA;
+  TH1F          **fSameEventDist;
+  TH2F          **fPairCounterSE;
+  TH1F          **fMixedEventDist;
+  TH2F          **fPairCounterME;
+
+  ClassDef(AliFemtoDreamCorrHists,1);
+};
+
+#endif /* ALIFEMTODREAMCORRHISTS_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEvent.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEvent.cxx
@@ -1,0 +1,131 @@
+/*
+ * AliFemtoDreamEvent.cxx
+ *
+ *  Created on: 22 Nov 2017
+ *      Author: bernhardhohlweger
+ */
+
+#include "AliFemtoDreamEvent.h"
+#include "AliAODHeader.h"
+#include "AliAODVertex.h"
+#include "AliAODVZERO.h"
+ClassImp(AliFemtoDreamEvent)
+AliFemtoDreamEvent::AliFemtoDreamEvent()
+:fUtils(new AliAnalysisUtils())
+,fEvtCuts(new AliEventCuts())
+,fEvtCutList()
+,fxVtx(0)
+,fyVtx(0)
+,fzVtx(0)
+,fSPDMult(0)
+,fRefMult08(0)
+,fV0AMult(0)
+,fV0CMult(0)
+,fnContrib(0)
+,fPassAliEvtSelection(false)
+,fisPileUp(false)
+,fHasVertex(false)
+,fHasMagField(false)
+,fisSelected(false)
+{
+
+}
+
+AliFemtoDreamEvent::AliFemtoDreamEvent(bool mvPileUp,bool EvtCutQA)
+:fUtils(new AliAnalysisUtils())
+,fEvtCuts(new AliEventCuts())
+,fxVtx(0)
+,fyVtx(0)
+,fzVtx(0)
+,fSPDMult(0)
+,fRefMult08(0)
+,fV0AMult(0)
+,fV0CMult(0)
+,fnContrib(0)
+,fPassAliEvtSelection(false)
+,fisPileUp(false)
+,fHasVertex(false)
+,fHasMagField(false)
+,fisSelected(false)
+{
+//  if (mvPileUp) {
+//    //For pPb this is necessary according to DPG Processing status news
+//    //(week 29 April - 5 May 2017)
+//    fUtils->SetUseMVPlpSelection(true);
+//  } else {
+//    //Following the analysis in pp Run1 of O.Arnold
+//    fUtils->SetMinPlpContribSPD(3);
+//  }
+  if (EvtCutQA) {
+    fEvtCutList=new TList();
+    fEvtCutList->SetName("AliEventCuts");
+    fEvtCutList->SetOwner(true);
+    fEvtCuts->AddQAplotsToList(fEvtCutList);
+  } else {
+    fEvtCutList=nullptr;
+  }
+}
+
+AliFemtoDreamEvent::~AliFemtoDreamEvent() {
+  if (fEvtCutList) {
+    delete fEvtCutList;
+  }
+  if (fEvtCutList) {
+    delete fEvtCutList;
+  }
+  if (fEvtCuts) {
+    delete fEvtCuts;
+  }
+//  if (fUtils) {
+//    delete fUtils;
+//  }
+}
+
+void AliFemtoDreamEvent::SetEvent(AliAODEvent *evt) {
+  AliAODVertex *vtx=evt->GetPrimaryVertex();
+  AliAODVZERO *vZERO = evt->GetVZEROData();
+  AliAODHeader *header = dynamic_cast<AliAODHeader*>(evt->GetHeader());
+  if (!vtx) {
+    this->fHasVertex=false;
+  } else {
+    this->fHasVertex=true;
+  }
+  if (TMath::Abs(evt->GetMagneticField())< 0.001) {
+    this->fHasMagField=false;
+  } else {
+    this->fHasMagField=true;
+  }
+  this->fnContrib=vtx->GetNContributors();
+  this->fxVtx=vtx->GetX();
+  this->fyVtx=vtx->GetY();
+  this->fzVtx=vtx->GetZ();
+//  if (fUtils->IsPileUpEvent(evt)) {
+//    this->fisPileUp=true;
+//  } else {
+//    this->fisPileUp=false;
+//  }
+  if (fEvtCuts->AcceptEvent(evt)) {
+    this->fPassAliEvtSelection=true;
+  } else {
+    this->fPassAliEvtSelection=false;
+  }
+  this->fSPDMult=CalculateITSMultiplicity(evt);
+  this->fV0AMult=vZERO->GetMTotV0A();
+  this->fV0CMult=vZERO->GetMTotV0C();
+  this->fRefMult08=header->GetRefMultiplicityComb08();
+  return;
+}
+
+int AliFemtoDreamEvent::CalculateITSMultiplicity(AliAODEvent *evt) {
+  AliAODTracklets* tracklets=evt->GetTracklets();
+  int nTr=tracklets->GetNumberOfTracklets();
+  int count=0;
+  for(int iTr=0; iTr<nTr; iTr++){
+    double theta=tracklets->GetTheta(iTr);
+    double eta=-TMath::Log(TMath::Tan(theta/2.));
+    if(TMath::Abs(eta) < 0.8){
+      count++;
+    }
+  }
+  return count;
+}

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEvent.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEvent.h
@@ -1,0 +1,69 @@
+/*
+ * AliFemtoDreamEvent.h
+ *
+ *  Created on: 22 Nov 2017
+ *      Author: bernhardhohlweger
+ */
+
+#ifndef ALIFEMTODREAMEVENT_H_
+#define ALIFEMTODREAMEVENT_H_
+#include "AliAnalysisUtils.h"
+#include "AliAODEvent.h"
+#include "AliEventCuts.h"
+#include "Rtypes.h"
+#include "TList.h"
+class AliFemtoDreamEvent {
+ public:
+  AliFemtoDreamEvent();
+  AliFemtoDreamEvent(bool mvPileUp,bool EvtCutQA);
+  virtual ~AliFemtoDreamEvent();
+  void SetEvent(AliAODEvent *evt);
+  TList *GetEvtCutList() const {return fEvtCutList;};
+  void SetXVertex(double xvtx){fxVtx=xvtx;};
+  double GetXVertex() const {return fxVtx;};
+  void SetYVertex(double yvtx){fyVtx=yvtx;};
+  double GetYVertex() const {return fyVtx;};
+  void SetZVertex(double zvtx){fzVtx=zvtx;};
+  double GetZVertex() const {return fzVtx;};
+  void SetSPDMult(int spdMult){fSPDMult=spdMult;};
+  int GetSPDMult() const {return fSPDMult;};
+  void SetRefMult08(int refMult){fRefMult08=refMult;};
+  int GetRefMult08() const {return fRefMult08;};
+  void SetV0AMult(int v0AMult){fV0AMult=v0AMult;};
+  int GetV0AMult() const {return fV0AMult;};
+  void SetV0CMult(int v0CMult){fV0CMult=v0CMult;};
+  int GetV0CMult() const {return fV0CMult;};
+  void SetNumberOfContributers(int nContrib){fnContrib=nContrib;};
+  int GetNumberOfContributers() const {return fnContrib;};
+  void SetPassAliEvtSelection(bool pass){fPassAliEvtSelection=pass;};
+  bool PassAliEvtSelection() const {return fPassAliEvtSelection;};
+  void SetIsPileUp(bool PileUp) {fisPileUp=PileUp;};
+  bool GetIsPileUp() const {return fisPileUp;};
+  void SetHasVertex(bool HasVtx){fHasVertex=HasVtx;};
+  bool GetHasVertex() const {return fHasVertex;};
+  void SetMagneticField(bool HasField){fHasMagField=HasField;};
+  bool GetMagneticField() const {return fHasMagField;};
+  void SetSelectionStatus(bool pass){fisSelected=pass;};
+  bool GetSelectionStatus() const {return fisSelected;};
+ private:
+  int CalculateITSMultiplicity(AliAODEvent *evt);
+  AliAnalysisUtils *fUtils;   //!
+  AliEventCuts *fEvtCuts;     //!
+  TList *fEvtCutList;         //!
+  double fxVtx;               //!
+  double fyVtx;               //!
+  double fzVtx;               //!
+  int fSPDMult;               //!
+  int fRefMult08;             //!
+  int fV0AMult;               //!
+  int fV0CMult;               //!
+  int fnContrib;              //!
+  bool fPassAliEvtSelection;  //!
+  bool fisPileUp;             //!
+  bool fHasVertex;            //!
+  bool fHasMagField;          //!
+  bool fisSelected;           //!
+  ClassDef(AliFemtoDreamEvent,1)
+};
+
+#endif /* ALIFEMTODREAMEVENT_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEventCuts.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEventCuts.cxx
@@ -1,0 +1,206 @@
+/*
+ * AliFemtoEventCuts.cxx
+ *
+ *  Created on: Nov 22, 2017
+ *      Author: gu74req
+ */
+
+#include "AliFemtoDreamEventCuts.h"
+ClassImp(AliFemtoDreamEventCuts)
+AliFemtoDreamEventCuts::AliFemtoDreamEventCuts()
+:fHist(0)
+,fCutMinContrib(false)
+,fMinContrib(2)
+,fCutZVtx(false)
+,fzVtxLow(0)
+,fzVtxUp(0)
+,fPileUpRejection(false)
+,fUseMVPileUpRej(false)
+,fCleanEvtMult(false)
+,fUseSPDMult(false)
+,fUseV0AMult(false)
+,fUseV0CMult(false)
+,fUseRef08Mult(false)
+,fUseAliEvtCuts(false)
+{
+}
+
+AliFemtoDreamEventCuts::~AliFemtoDreamEventCuts() {
+
+}
+
+bool AliFemtoDreamEventCuts::isSelected(AliFemtoDreamEvent *evt) {
+  bool pass=true;
+  fHist->FillEvtCounter(0);
+  if (fUseAliEvtCuts) {
+    if (!evt->PassAliEvtSelection()) {
+      pass=false;
+    } else {
+      fHist->FillEvtCounter(1);
+    }
+  } else {
+    //This needs to be always the case!
+    if (!(evt->GetMagneticField()||evt->GetHasVertex())) {
+      pass=false;
+    } else {
+      fHist->FillEvtCounter(2);
+    }
+    if (pass&&fCutMinContrib) {
+      if (evt->GetNumberOfContributers()<fMinContrib) {
+        pass=false;
+      } else {
+        fHist->FillEvtCounter(3);
+      }
+    }
+    if (pass&&fCutZVtx) {
+      if (evt->GetZVertex()<=fzVtxLow||evt->GetZVertex()>=fzVtxUp) {
+        pass=false;
+      } else {
+        fHist->FillEvtCounter(4);
+      }
+    }
+    if (pass&&fPileUpRejection) {
+      if (evt->GetIsPileUp()) {
+        pass=false;
+      } else {
+        fHist->FillEvtCounter(5);
+      }
+    }
+    if (pass&&fCleanEvtMult) {
+      if (pass&&fUseSPDMult) {
+        if (!(evt->GetSPDMult()>0)) {
+          pass=false;
+        } else {
+          fHist->FillEvtCounter(6);
+        }
+      }
+      if (pass&&fUseV0AMult) {
+        if (!(evt->GetV0AMult()>0)) {
+          pass=false;
+        } else {
+          fHist->FillEvtCounter(7);
+          //Fill Hist
+        }
+      }
+      if (pass&&fUseV0CMult) {
+        if (!(evt->GetV0CMult()>0)) {
+          pass=false;
+        } else {
+          fHist->FillEvtCounter(8);
+          //Fill Hist
+        }
+      }
+      if (pass&&fUseRef08Mult) {
+        if (!(evt->GetRefMult08()>0)) {
+          pass=false;
+        } else {
+          fHist->FillEvtCounter(9);
+        }
+      }
+    }
+  }
+  evt->SetSelectionStatus(pass);
+  BookQA(evt);
+  return pass;
+}
+
+void AliFemtoDreamEventCuts::InitQA() {
+  fHist=new AliFemtoDreamEventHist();
+  BookCuts();
+}
+
+AliFemtoDreamEventCuts* AliFemtoDreamEventCuts::StandardCutsRun1() {
+  AliFemtoDreamEventCuts *evtCuts=new AliFemtoDreamEventCuts();
+  evtCuts->SetCutMinContrib(2);
+  evtCuts->SetZVtxPosition(-10.,10.);
+  evtCuts->PileUpRejection(true);
+  evtCuts->CleanUpMult(true,false,false,false);
+  evtCuts->UseDontWorryEvtCuts(false);
+  return evtCuts;
+}
+
+AliFemtoDreamEventCuts* AliFemtoDreamEventCuts::StandardCutsRun2() {
+  AliFemtoDreamEventCuts *evtCuts=new AliFemtoDreamEventCuts();
+  evtCuts->UseDontWorryEvtCuts(true);
+  return evtCuts;
+}
+void AliFemtoDreamEventCuts::BookQA(AliFemtoDreamEvent *evt) {
+  for (int i=0;i<2;++i) {
+    if (i==0||(i==1&&evt->GetSelectionStatus())) {
+      fHist->FillEvtNCont(i,evt->GetNumberOfContributers());
+      fHist->FillEvtVtxX(i,evt->GetXVertex());
+      fHist->FillEvtVtxY(i,evt->GetYVertex());
+      fHist->FillEvtVtxZ(i,evt->GetZVertex());
+      fHist->FillMultSPD(i,evt->GetSPDMult());
+      fHist->FillMultV0A(i,evt->GetV0AMult());
+      fHist->FillMultV0C(i,evt->GetV0CMult());
+      fHist->FillMultRef08(i,evt->GetRefMult08());
+    }
+  }
+}
+void AliFemtoDreamEventCuts::BookCuts() {
+  if (fCutMinContrib) {
+    fHist->FillCuts(0,fMinContrib);
+  } else {
+    fHist->FillCuts(0,0);
+  }
+  if (fCutZVtx) {
+    fHist->FillCuts(1,1);
+    fHist->FillCuts(2,fzVtxLow);
+    fHist->FillCuts(3,fzVtxUp);
+  } else {
+    fHist->FillCuts(1,0);
+    fHist->FillCuts(2,0);
+    fHist->FillCuts(3,0);
+  }
+  if (fPileUpRejection) {
+    fHist->FillCuts(4,1);
+  } else {
+    fHist->FillCuts(4,0);
+  }
+  if (fUseMVPileUpRej) {
+    fHist->FillCuts(5,1);
+  } else {
+    fHist->FillCuts(5,0);
+  }
+  if (fCleanEvtMult) {
+    if (fUseSPDMult) {
+      fHist->FillCuts(6,1);
+    } else {
+      fHist->FillCuts(6,0);
+    }
+    if (fUseV0AMult) {
+      fHist->FillCuts(7,1);
+    } else {
+      fHist->FillCuts(7,0);
+    }
+    if (fUseV0CMult) {
+      fHist->FillCuts(8,1);
+    } else {
+      fHist->FillCuts(8,0);
+    }
+    if (fUseRef08Mult) {
+      fHist->FillCuts(9,1);
+    } else {
+      fHist->FillCuts(9,0);
+    }
+  } else {
+      fHist->FillCuts(6,0);
+      fHist->FillCuts(7,0);
+      fHist->FillCuts(8,0);
+      fHist->FillCuts(9,0);
+  }
+  if (fUseAliEvtCuts) {
+    fHist->FillCuts(10,1);
+  } else {
+    fHist->FillCuts(10,0);
+  }
+}
+
+
+
+
+
+
+
+

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEventCuts.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEventCuts.h
@@ -1,0 +1,58 @@
+/*
+ * AliFemtoEventCuts.h
+ *
+ *  Created on: Nov 22, 2017
+ *      Author: gu74req
+ */
+
+#ifndef ALIFEMTODREAMEVENTCUTS_H_
+#define ALIFEMTODREAMEVENTCUTS_H_
+#include "Rtypes.h"
+#include "AliFemtoDreamEvent.h"
+#include "AliFemtoDreamEventHist.h"
+class AliFemtoDreamEventCuts {
+ public:
+  AliFemtoDreamEventCuts();
+  virtual ~AliFemtoDreamEventCuts();
+  bool isSelected(AliFemtoDreamEvent *evt);
+  static AliFemtoDreamEventCuts* StandardCutsRun1();
+  static AliFemtoDreamEventCuts* StandardCutsRun2();
+  void SetCutMinContrib(int nMinContrib) {
+    fCutMinContrib=true;fMinContrib=nMinContrib;
+  };
+  void SetZVtxPosition(double zVtxLow,double zVtxUp) {
+    fzVtxLow=zVtxLow;fzVtxUp=zVtxUp;fCutZVtx=true;
+  };
+  void SetMVPileUpRejection(bool apply){fUseMVPileUpRej=apply;};
+  bool GetMVPileUpRejection() const {return fUseMVPileUpRej;};
+  void PileUpRejection(bool apply){fPileUpRejection=apply;};
+  void CleanUpMult(bool SPD,bool v0A, bool v0C, bool RefMult) {
+    fUseSPDMult=SPD;fUseV0AMult=v0A;fUseV0CMult=v0C;
+    fUseRef08Mult=RefMult;fCleanEvtMult=true;
+  }
+  //Everything else disabled if you use the following option:
+  void UseDontWorryEvtCuts(bool apply) {fUseAliEvtCuts=apply;};
+  void InitQA();
+  TList *GetHistList() const {return fHist->GetHistList();};
+ private:
+  void BookQA(AliFemtoDreamEvent *evt);
+  void BookCuts();
+  AliFemtoDreamEventHist *fHist;  //!
+  bool fCutMinContrib;            //
+  int fMinContrib;                //
+  bool fCutZVtx;                  //
+  double fzVtxLow;                //
+  double fzVtxUp;                 //
+  bool fPileUpRejection;          //
+  bool fUseMVPileUpRej;           // Which method of Pile Up Rej should be used
+  bool fCleanEvtMult;             //
+  bool fUseSPDMult;               //
+  bool fUseV0AMult;               //
+  bool fUseV0CMult;               //
+  bool fUseRef08Mult;             //
+  //Use evt cuts tuned by expert(don't worry solution)
+  bool fUseAliEvtCuts;            //
+  ClassDef(AliFemtoDreamEventCuts,1)
+};
+
+#endif /* ALIFEMTODREAMEVENTCUTS_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEventHist.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEventHist.cxx
@@ -1,0 +1,107 @@
+/*
+ * AliFemtoDreamEventHist.cxx
+ *
+ *  Created on: Nov 22,2017
+ *      Author: gu74req
+ */
+
+#include "AliFemtoDreamEventHist.h"
+ClassImp(AliFemtoDreamEventHist)
+AliFemtoDreamEventHist::AliFemtoDreamEventHist()
+{
+  fEventCutList=new TList();
+  fEventCutList->SetName("Event Cuts");
+  fEventCutList->SetOwner();
+
+  fEvtCounter=new TH1F("EventCounter","Event Counter",10,0,10);
+  fEvtCounter->GetXaxis()->SetBinLabel(1,"Events");
+  fEvtCounter->GetXaxis()->SetBinLabel(2,"AliEventCuts");
+  fEvtCounter->GetXaxis()->SetBinLabel(3,"Phys. Sel.");
+  fEvtCounter->GetXaxis()->SetBinLabel(4,"nContrib");
+  fEvtCounter->GetXaxis()->SetBinLabel(5,"zVtx");
+  fEvtCounter->GetXaxis()->SetBinLabel(6,"PileUp");
+  fEvtCounter->GetXaxis()->SetBinLabel(7,"SPD Mult Cleanup");
+  fEvtCounter->GetXaxis()->SetBinLabel(8,"V0A Mult Cleanup");
+  fEvtCounter->GetXaxis()->SetBinLabel(9,"V0C Mult Cleanup");
+  fEvtCounter->GetXaxis()->SetBinLabel(10,"RefMult08 Cleanup");
+  fEventCutList->Add(fEvtCounter);
+
+  fCutConfig=new TProfile("CutConfig","Cut Config",20,0,20);
+  fCutConfig->GetXaxis()->SetBinLabel(1,"Min Contrib");
+  fCutConfig->GetXaxis()->SetBinLabel(2,"CutZvtx");
+  fCutConfig->GetXaxis()->SetBinLabel(3,"Min Zvtx");
+  fCutConfig->GetXaxis()->SetBinLabel(4,"Max ZVtx");
+  fCutConfig->GetXaxis()->SetBinLabel(5,"PileUp Rejection");
+  fCutConfig->GetXaxis()->SetBinLabel(6,"MV PileUp Rejection");
+  fCutConfig->GetXaxis()->SetBinLabel(7,"SPD Mult");
+  fCutConfig->GetXaxis()->SetBinLabel(8,"V0A Mult");
+  fCutConfig->GetXaxis()->SetBinLabel(9,"V0C Mult");
+  fCutConfig->GetXaxis()->SetBinLabel(10,"RefMult08");
+  fCutConfig->GetXaxis()->SetBinLabel(11,"AliEvtCuts");
+  fEventCutList->Add(fCutConfig);
+
+  TString sName[2]={"before","after"};
+
+  for(int i=0;i<2;++i){
+
+    fEvtCutQA[i]=new TList();
+    fEvtCutQA[i]->SetName(sName[i].Data());
+    fEvtCutQA[i]->SetOwner();
+
+    fEventCutList->Add(fEvtCutQA[i]);
+
+    TString nEvtNContName=Form("nContributors_%s",sName[i].Data());
+    fEvtNCont[i]=new TH1F(nEvtNContName.Data(),nEvtNContName.Data(),350.,-0.5,349.5);
+    fEvtNCont[i]->Sumw2();
+    fEvtNCont[i]->GetXaxis()->SetTitle("Number of Contributors");
+    fEvtCutQA[i]->Add(fEvtNCont[i]);
+
+    TString EvtVtxXName=Form("VtxX_%s",sName[i].Data());
+    fEvtVtxX[i]=new TH1F(EvtVtxXName.Data(),EvtVtxXName.Data(),50,-2.5 ,2.5);
+    fEvtVtxX[i]->Sumw2();
+    fEvtVtxX[i]->GetXaxis()->SetTitle("DCA_{x}");
+    fEvtCutQA[i]->Add(fEvtVtxX[i]);
+
+    TString EvtVtxYName=Form("VtxY_%s",sName[i].Data());
+    fEvtVtxY[i]=new TH1F(EvtVtxYName.Data(),EvtVtxYName.Data(),50,-2.5 ,2.5);
+    fEvtVtxY[i]->Sumw2();
+    fEvtVtxY[i]->GetXaxis()->SetTitle("DCA_{y}");
+    fEvtCutQA[i]->Add(fEvtVtxY[i]);
+
+    TString EvtVtxZName=Form("VtxZ_%s",sName[i].Data());
+    fEvtVtxZ[i]=new TH1F(EvtVtxZName.Data(),EvtVtxZName.Data(),300,-15. ,15.);
+    fEvtVtxZ[i]->Sumw2();
+    fEvtVtxZ[i]->GetXaxis()->SetTitle("DCA_{z}");
+    fEvtCutQA[i]->Add(fEvtVtxZ[i]);
+
+    TString MultNameSPD=Form("MultiplicitySPD_%s",sName[i].Data());
+    fMultDistSPD[i]=new TH1F(MultNameSPD.Data(),MultNameSPD.Data(),600,0.,600.);
+    fMultDistSPD[i]->Sumw2();
+    fMultDistSPD[i]->GetXaxis()->SetTitle("Multiplicity (SPD)");
+    fEvtCutQA[i]->Add(fMultDistSPD[i]);
+
+    TString MultNameV0A=Form("MultiplicityV0A_%s",sName[i].Data());
+    fMultDistV0A[i]=new TH1F(MultNameV0A.Data(),MultNameV0A.Data(),600,0.,600.);
+    fMultDistV0A[i]->Sumw2();
+    fMultDistV0A[i]->GetXaxis()->SetTitle("Multiplicity (V0A)");
+    fEvtCutQA[i]->Add(fMultDistV0A[i]);
+
+    TString MultNameV0C=Form("MultiplicityV0C_%s",sName[i].Data());
+    fMultDistV0C[i]=new TH1F(MultNameV0C.Data(),MultNameV0C.Data(),600,0.,600.);
+    fMultDistV0C[i]->Sumw2();
+    fMultDistV0C[i]->GetXaxis()->SetTitle("Multiplicity (V0C)");
+    fEvtCutQA[i]->Add(fMultDistV0C[i]);
+
+    TString MultNameRefMult08=Form("MultiplicityRef08_%s",sName[i].Data());
+    fMultDistRef08[i]=new TH1F(
+        MultNameRefMult08.Data(),MultNameRefMult08.Data(),600,0.,600.);
+    fMultDistRef08[i]->Sumw2();
+    fMultDistRef08[i]->GetXaxis()->SetTitle("Multiplicity (RefMult08)");
+    fEvtCutQA[i]->Add(fMultDistRef08[i]);
+  }
+}
+
+AliFemtoDreamEventHist::~AliFemtoDreamEventHist() {
+
+}
+

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEventHist.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEventHist.h
@@ -1,0 +1,45 @@
+/*
+ * AliFemtoDreamEventHist.h
+ *
+ *  Created on: Nov 22, 2017
+ *      Author: gu74req
+ */
+
+#ifndef ALIFEMTODREAMEVENTHIST_H_
+#define ALIFEMTODREAMEVENTHIST_H_
+#include "Rtypes.h"
+#include "TList.h"
+#include "TH1F.h"
+#include "TProfile.h"
+class AliFemtoDreamEventHist {
+ public:
+  AliFemtoDreamEventHist();
+  virtual ~AliFemtoDreamEventHist();
+  void FillEvtCounter(int iBin){fEvtCounter->Fill(iBin);};
+  void FillCuts(int iBin,double val){fCutConfig->Fill(iBin,val);};
+  void FillEvtNCont(int i, double val){fEvtNCont[i]->Fill(val);};
+  void FillEvtVtxX(int i, double val){fEvtVtxX[i]->Fill(val);};
+  void FillEvtVtxY(int i, double val){fEvtVtxY[i]->Fill(val);};
+  void FillEvtVtxZ(int i, double val){fEvtVtxZ[i]->Fill(val);};
+  void FillMultSPD(int i, double val){fMultDistSPD[i]->Fill(val);};
+  void FillMultV0A(int i, double val){fMultDistV0A[i]->Fill(val);};
+  void FillMultV0C(int i, double val){fMultDistV0C[i]->Fill(val);};
+  void FillMultRef08(int i, double val){fMultDistRef08[i]->Fill(val);};
+  TList *GetHistList() {return fEventCutList;};
+ private:
+  TList *fEventCutList;     //!
+  TList *fEvtCutQA[2];      //!
+  TH1F *fEvtCounter;        //!
+  TProfile *fCutConfig;     //!
+  TH1F *fEvtNCont[2];       //!
+  TH1F *fEvtVtxX[2];        //!
+  TH1F *fEvtVtxY[2];        //!
+  TH1F *fEvtVtxZ[2];        //!
+  TH1F *fMultDistSPD[2];    //!
+  TH1F *fMultDistV0A[2];    //!
+  TH1F *fMultDistV0C[2];    //!
+  TH1F *fMultDistRef08[2];  //!
+  ClassDef(AliFemtoDreamEventHist,1)
+};
+
+#endif /* ALIFEMTODREAMEVENTHIST_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPairCleaner.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPairCleaner.cxx
@@ -1,0 +1,143 @@
+/*
+ * AliFemtoDreamPairCleaner.cxx
+ *
+ *  Created on: 8 Nov 2017
+ *      Author: bernhardhohlweger
+ */
+
+#include <iostream>
+#include "AliFemtoDreamPairCleaner.h"
+ClassImp(AliFemtoDreamPairCleaner)
+AliFemtoDreamPairCleaner::AliFemtoDreamPairCleaner()
+:fHists(0)
+{
+}
+AliFemtoDreamPairCleaner::AliFemtoDreamPairCleaner(
+    int nTrackDecayChecks, int nDecayDecayChecks)
+{
+  fHists=new AliFemtoDreamPairCleanerHists(
+      nTrackDecayChecks,nDecayDecayChecks);
+}
+
+AliFemtoDreamPairCleaner::~AliFemtoDreamPairCleaner() {
+  if (fHists) {
+    delete fHists;
+  }
+}
+
+void AliFemtoDreamPairCleaner::CleanTrackAndDecay(
+    std::vector<AliFemtoDreamBasePart> *Tracks,
+    std::vector<AliFemtoDreamBasePart> *Decay, int histnumber)
+{
+  int counter=0;
+  for (auto itTrack=Tracks->begin();itTrack!=Tracks->end();++itTrack) {
+    //std::cout  << "New Track" << std::endl;
+    for (auto itDecay=Decay->begin();itDecay!=Decay->end();++itDecay) {
+      if (itDecay->UseParticle()) {
+        //std::cout  << "New v0" << std::endl;
+        std::vector<int> IDTrack=itTrack->GetIDTracks();
+        std::vector<int> IDDaug=itDecay->GetIDTracks();
+        for (auto itIDs=IDDaug.begin();itIDs!=IDDaug.end();++itIDs) {
+          //std::cout <<"ID of Track: "<<IDTrack.at(0)<<" IDs of Daughter: "
+//              <<*itIDs<<'\n';
+          if (*itIDs==IDTrack.at(0)) {
+            itDecay->SetUse(false);
+            counter++;
+          }
+        }
+      } else {
+        continue;
+      }
+    }
+  }
+  fHists->FillDaughtersSharedTrack(histnumber,counter);
+}
+void AliFemtoDreamPairCleaner::CleanDecayAndDecay(
+    std::vector<AliFemtoDreamBasePart> *Decay1,
+    std::vector<AliFemtoDreamBasePart> *Decay2, int histnumber) {
+  int counter=0;
+  for (auto itDecay1=Decay1->begin();itDecay1!=Decay1->end();++itDecay1) {
+    if (itDecay1->UseParticle()) {
+      for (auto itDecay2=Decay2->begin();itDecay2!=Decay2->end();++itDecay2) {
+        if (itDecay1->UseParticle()) {
+          std::vector<int> IDDaug1=itDecay1->GetIDTracks();
+          std::vector<int> IDDaug2=itDecay2->GetIDTracks();
+          for (auto itID1s=IDDaug1.begin();itID1s!=IDDaug1.end();++itID1s) {
+            for (auto itID2s=IDDaug2.begin();itID2s!=IDDaug2.end();++itID2s) {
+              if (*itID1s==*itID2s) {
+                if (itDecay1->GetCPA() < itDecay2->GetCPA()) {
+                  itDecay1->SetUse(false);
+                  counter++;
+                } else {
+                  itDecay2->SetUse(false);
+                  counter++;
+                }
+              }
+            }
+          }
+        } else {
+          continue;
+        }
+      }
+    } else {
+      continue;
+    }
+  }
+  fHists->FillDaughtersSharedDaughter(histnumber,counter);
+}
+
+void AliFemtoDreamPairCleaner::CleanDecay(
+    std::vector<AliFemtoDreamBasePart> *Decay,int histnumber)
+{
+  int counter=0;
+  for (std::vector<AliFemtoDreamBasePart>::iterator itDecay1=Decay->begin();
+      itDecay1!=Decay->end();++itDecay1) {
+    if (itDecay1->UseParticle()) {
+      //std::cout  << "New Particle 1" << std::endl;
+      for (auto itDecay2=itDecay1+1;itDecay2!=Decay->end();++itDecay2) {
+        if (itDecay2->UseParticle()) {
+          //std::cout  << "New Particle 2" << std::endl;
+          std::vector<int> IDDaug1=itDecay1->GetIDTracks();
+          std::vector<int> IDDaug2=itDecay2->GetIDTracks();
+          for (auto itID1s=IDDaug1.begin();itID1s!=IDDaug1.end();++itID1s) {
+            for (auto itID2s=IDDaug2.begin();itID2s!=IDDaug2.end();++itID2s) {
+              //std::cout <<"ID of Daug v01: "<<*itID1s<<" ID of Daug v02: "
+//                  <<*itID2s<<'\n';
+              if (*itID1s==*itID2s) {
+                if (itDecay1->GetCPA() < itDecay2->GetCPA()) {
+                  itDecay1->SetUse(false);
+                  counter++;
+                } else {
+                  itDecay2->SetUse(false);
+                  counter++;                }
+              }
+            }
+          }
+        } else {
+          continue;
+        }
+      }
+    } else {
+      continue;
+    }
+  }
+  fHists->FillDaughtersSharedDaughter(histnumber,counter);
+}
+
+void AliFemtoDreamPairCleaner::StoreParticle(
+    std::vector<AliFemtoDreamBasePart> Particles)
+{
+  int counter=0;
+  std::vector<AliFemtoDreamBasePart> tmpParticles;
+  for (auto itPart:Particles) {
+    if (itPart.UseParticle()) {
+      tmpParticles.push_back(itPart);
+    } else {
+      counter++;
+    }
+  }
+  fParticles.push_back(tmpParticles);
+}
+void AliFemtoDreamPairCleaner::ResetArray() {
+  fParticles.clear();
+}

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPairCleaner.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPairCleaner.h
@@ -1,0 +1,38 @@
+/*
+ * AliFemtoDreamPairCleaner.h
+ *
+ *  Created on: 8 Nov 2017
+ *      Author: bernhardhohlweger
+ */
+
+#ifndef ALIFEMTODREAMPAIRCLEANER_H_
+#define ALIFEMTODREAMPAIRCLEANER_H_
+#include <vector>
+#include "Rtypes.h"
+#include "AliFemtoDreamBasePart.h"
+#include "AliFemtoDreamPairCleanerHists.h"
+class AliFemtoDreamPairCleaner {
+ public:
+  AliFemtoDreamPairCleaner();
+  AliFemtoDreamPairCleaner(
+      int nTrackDecayChecks, int nDecayDecayChecks);
+  virtual ~AliFemtoDreamPairCleaner();
+  void CleanTrackAndDecay(std::vector<AliFemtoDreamBasePart> *Tracks,
+                          std::vector<AliFemtoDreamBasePart> *Decay,
+                          int histnumber);
+  void CleanDecay(std::vector<AliFemtoDreamBasePart> *Decay,int histnumber);
+  void CleanDecayAndDecay(std::vector<AliFemtoDreamBasePart> *Decay1,
+                          std::vector<AliFemtoDreamBasePart> *Decay2,
+                          int histnumber);
+  void StoreParticle(std::vector<AliFemtoDreamBasePart> Particles);
+  TList* GetHistList(){return fHists->GetHistList();};
+  std::vector<std::vector<AliFemtoDreamBasePart>>& GetCleanParticles()
+      {return fParticles;};
+  void ResetArray();
+ private:
+  std::vector<std::vector<AliFemtoDreamBasePart>> fParticles;
+  AliFemtoDreamPairCleanerHists *fHists;
+  ClassDef(AliFemtoDreamPairCleaner,1)
+};
+
+#endif /* ALIFEMTODREAMPAIRCLEANER_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPairCleanerHists.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPairCleanerHists.cxx
@@ -1,0 +1,41 @@
+/*
+ * AliFemtoPairCleanerHists.cxx
+ *
+ *  Created on: 22 Dec 2017
+ *      Author: bernhardhohlweger
+ */
+
+#include "AliFemtoDreamPairCleanerHists.h"
+ClassImp(AliFemtoDreamPairCleanerHists)
+AliFemtoDreamPairCleanerHists::AliFemtoDreamPairCleanerHists()
+:fTrackDecays(0)
+,fDecayDecays(0)
+,fOutput(0)
+{
+}
+
+AliFemtoDreamPairCleanerHists::AliFemtoDreamPairCleanerHists(
+    int nTrackDecays,int nDecayDecays)
+{
+  fOutput = new TList();
+  fOutput->SetOwner();
+  fOutput->SetName("PairCleaner");
+
+  fTrackDecays=new TH1F*[nTrackDecays];
+  for (int i=0;i<nTrackDecays;++i) {
+    TString histName=Form("DaugthersSharedTracks_%d",i);
+    fTrackDecays[i]=new TH1F(histName.Data(),histName.Data(),20,0,20);
+    fOutput->Add(fTrackDecays[i]);
+  }
+  fDecayDecays=new TH1F*[nDecayDecays];
+  for (int i=0;i<nTrackDecays;++i) {
+    TString histName=Form("DaugthersSharedDaughters_%d",i);
+    fDecayDecays[i]=new TH1F(histName.Data(),histName.Data(),20,0,20);
+    fOutput->Add(fDecayDecays[i]);
+  }
+}
+
+AliFemtoDreamPairCleanerHists::~AliFemtoDreamPairCleanerHists() {
+  // TODO Auto-generated destructor stub
+}
+

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPairCleanerHists.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPairCleanerHists.h
@@ -1,0 +1,31 @@
+/*
+ * AliFemtoPairCleanerHists.h
+ *
+ *  Created on: 22 Dec 2017
+ *      Author: bernhardhohlweger
+ */
+
+#ifndef ALIFEMTODREAMPAIRCLEANERHISTS_H_
+#define ALIFEMTODREAMPAIRCLEANERHISTS_H_
+#include "Rtypes.h"
+#include "TH1F.h"
+#include "TList.h"
+class AliFemtoDreamPairCleanerHists {
+ public:
+  AliFemtoDreamPairCleanerHists();
+  AliFemtoDreamPairCleanerHists(int nTrackDecays,int nDecayDecays);
+  virtual ~AliFemtoDreamPairCleanerHists();
+  void FillDaughtersSharedTrack(int Hist,int counter) {
+    fTrackDecays[Hist]->Fill(counter);
+  };
+  void FillDaughtersSharedDaughter(int Hist,int counter) {
+    fDecayDecays[Hist]->Fill(counter);
+  };
+  TList *GetHistList(){return fOutput;};
+  TH1F **fTrackDecays;
+  TH1F **fDecayDecays;
+  TList *fOutput;
+  ClassDef(AliFemtoDreamPairCleanerHists,1)
+};
+
+#endif /* ALIFEMTODREAMPAIRCLEANERHISTS_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPartCollection.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPartCollection.cxx
@@ -1,0 +1,87 @@
+/*
+ * AliFemtoPPbpbLamPartCollection.cxx
+
+ *
+ *  Created on: Aug 29, 2017
+ *      Author: gu74req
+ */
+#include <iostream>
+#include "AliFemtoDreamPartCollection.h"
+ClassImp(AliFemtoDreamPartCollection)
+AliFemtoDreamPartCollection::AliFemtoDreamPartCollection()
+:fResults()
+,fNSpecies(0)
+,fZVtxMultBuffer()
+,fValuesZVtxBins()
+,fValuesMultBins()
+{
+
+}
+AliFemtoDreamPartCollection::AliFemtoDreamPartCollection(
+    AliFemtoDreamCollConfig *conf)
+:fResults(new AliFemtoDreamCorrHists(conf))
+,fNSpecies(conf->GetNParticles())
+,fZVtxMultBuffer(conf->GetNZVtxBins(),
+                 std::vector<AliFemtoDreamZVtxMultContainer>(
+                     conf->GetNMultBins(),
+                     AliFemtoDreamZVtxMultContainer(conf)))
+,fValuesZVtxBins(conf->GetZVtxBins())
+,fValuesMultBins(conf->GetMultBins())
+{
+}
+
+AliFemtoDreamPartCollection::~AliFemtoDreamPartCollection() {
+}
+
+void AliFemtoDreamPartCollection::SetEvent(
+    std::vector<std::vector<AliFemtoDreamBasePart>> &Particles,
+    double ZVtx,double Mult)
+{
+  if (Particles.size()!=fNSpecies) {
+    std::cout<<"Particles too small!"<<std::endl;
+  }
+  int bins[2] = {0,0};
+  FindBin(ZVtx,Mult,bins);
+  if (bins[0]==-99||bins[1]==-99) {
+    //TODO: error msg!
+  }
+  auto itZVtx=fZVtxMultBuffer.begin();
+  itZVtx+=bins[0];
+  auto itMult=itZVtx->begin();
+  itMult+=bins[1];
+  itMult->PairParticlesSE(Particles,fResults);
+  itMult->PairParticlesME(Particles,fResults);
+  itMult->SetEvent(Particles);
+  return;
+}
+
+void AliFemtoDreamPartCollection::PrintEvent(int ZVtx,int Mult) {
+  auto itZVtx=fZVtxMultBuffer.begin();
+  itZVtx+=ZVtx;
+  auto itMult=itZVtx->begin();
+  itMult+=Mult;
+  return;
+}
+
+void AliFemtoDreamPartCollection::FindBin(double ZVtxPos,double Multiplicity,
+                                          int *returnBins) {
+  returnBins[0]=-99;
+  returnBins[1]=-99;
+  for (auto itBin=fValuesZVtxBins.begin();itBin!=fValuesZVtxBins.end()-1;
+      ++itBin) {
+    if (*itBin<ZVtxPos && ZVtxPos<=*(itBin+1)) {
+      returnBins[0]=itBin-fValuesZVtxBins.begin();
+      break;
+    }
+  }
+  int binCounter = fValuesMultBins.size();
+  for (std::vector<int>::reverse_iterator itBin=fValuesMultBins.rbegin();
+      itBin!=fValuesMultBins.rend();++itBin) {
+    binCounter--;
+    if (Multiplicity>=*itBin) {
+      returnBins[1]=binCounter;
+      break;
+    }
+  }
+  return;
+}

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPartCollection.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPartCollection.h
@@ -1,0 +1,40 @@
+/*
+ * AliFemtoPPbpbLamPartCollection.h
+ *
+ *  Created on: Aug 29, 2017
+ *      Author: gu74req
+ */
+
+#ifndef ALIFEMTODREAMPARTCOLLECTION_H_
+#define ALIFEMTODREAMPARTCOLLECTION_H_
+#include <deque>
+#include <vector>
+#include "Rtypes.h"
+#include "TList.h"
+
+#include "AliFemtoDreamCollConfig.h"
+#include "AliFemtoDreamCorrHists.h"
+#include "AliFemtoDreamZVtxMultContainer.h"
+//Class containing all the different multiplicity containers for all the
+//particles
+class AliFemtoDreamPartCollection {
+ public:
+  AliFemtoDreamPartCollection();
+  AliFemtoDreamPartCollection(AliFemtoDreamCollConfig *conf);
+  virtual ~AliFemtoDreamPartCollection();
+  void SetEvent(std::vector<std::vector<AliFemtoDreamBasePart>> &Particles,
+                double ZVtx,double Mult);
+  void PrintEvent(int ZVtx,int Mult);
+  TList* GetHistList(){return fResults->GetHistList();};
+  TList* GetQAList(){return fResults->GetQAHists();};
+ private:
+  void FindBin(double ZVtxPos,double Multiplicity,int *returnBins);
+  AliFemtoDreamCorrHists *fResults;
+  unsigned int fNSpecies;
+  std::vector<std::vector<AliFemtoDreamZVtxMultContainer>> fZVtxMultBuffer;
+  std::vector<double> fValuesZVtxBins;
+  std::vector<int> fValuesMultBins;
+  ClassDef(AliFemtoDreamPartCollection,1);
+};
+
+#endif /* ALIFEMTODREAMPARTCOLLECTION_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPartContainer.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPartContainer.cxx
@@ -1,0 +1,76 @@
+/*
+ * AliFemtoPPbpbLamPartContainer.cxx
+ *
+ *  Created on: Aug 30, 2017
+ *      Author: gu74req
+ */
+
+
+#include <iostream>
+#include "AliFemtoDreamPartContainer.h"
+#include "TLorentzVector.h"
+#include "TVector3.h"
+ClassImp(AliFemtoDreamPartContainer)
+AliFemtoDreamPartContainer::AliFemtoDreamPartContainer() : fPartBuffer(),
+    fMixingDepth(0)
+{
+
+}
+
+AliFemtoDreamPartContainer::AliFemtoDreamPartContainer(int MixingDepth)
+:fPartBuffer(),
+ fMixingDepth(MixingDepth)
+{
+
+}
+
+AliFemtoDreamPartContainer& AliFemtoDreamPartContainer::operator=(
+     const AliFemtoDreamPartContainer&obj){
+  if(this == &obj){
+    return *this;
+  }
+//  std::deque<std::deque<AliFemtoDreamBasePart>>::iterator copyIter;
+//  std::deque<std::deque<AliFemtoDreamBasePart>>::iterator objIter;
+//  for (objIter=obj.fPartBuffer.begin();objIter!=obj.fPartBuffer.end();
+//      ++objIter)
+//  {
+//
+//  }
+  this->fMixingDepth=obj.fMixingDepth;
+  this->fPartBuffer=obj.fPartBuffer;
+  return (*this);
+}
+
+AliFemtoDreamPartContainer::~AliFemtoDreamPartContainer() {
+}
+
+void AliFemtoDreamPartContainer::SetEvent(
+    std::vector<AliFemtoDreamBasePart> &Particles)
+{
+  if (!(fPartBuffer.size() < fMixingDepth)){
+//    std::cout << "Popping Front" << std::endl;
+    fPartBuffer.pop_front();
+  }
+  fPartBuffer.push_back(Particles);
+//  std::cout << "PartBuffer Size: "<<fPartBuffer.size()<<'\t'<<"Input Size: "
+//      << Particles.size() << '\n';
+  return;
+}
+
+void AliFemtoDreamPartContainer::PrintLastEvent() {
+  for (std::deque<std::vector<AliFemtoDreamBasePart>>::iterator itEvt=
+      fPartBuffer.begin(); itEvt!=fPartBuffer.end();++itEvt) {
+    std::cout << "Printing Last Event with size: "<<itEvt->size() << '\n';
+    for (std::vector<AliFemtoDreamBasePart>::iterator itPart=itEvt->begin();
+        itPart!=itEvt->end();++itPart) {
+      TVector3 P(itPart->GetMomentum());
+      std::cout<<"Px: "<<P.X()<<'\t'<<"Py: "<<P.Y()<<'\t'<<"Pz: "<<
+          P.Z()<<std::endl;
+    }
+  }
+}
+std::vector<AliFemtoDreamBasePart> &AliFemtoDreamPartContainer::GetEvent(int Depth) {
+  std::deque<std::vector<AliFemtoDreamBasePart>>::iterator itEvt=
+        fPartBuffer.begin()+Depth;
+  return *itEvt;
+}

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPartContainer.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPartContainer.h
@@ -1,0 +1,37 @@
+/*
+ * AliFemtoPPbpbLamPartContainer.h
+ *
+ *  Created on: Aug 30, 2017
+ *      Author: gu74req
+ */
+
+#ifndef ALIFEMTODREAMPARTCONTAINER_H_
+#define ALIFEMTODREAMPARTCONTAINER_H_
+#include <deque>
+#include <vector>
+#include "Rtypes.h"
+
+#include "AliFemtoDreamBasePart.h"
+
+//Class Containing the Particles from previous Events up to a certain mixing
+//depth for one Particle Species and Mult/ZVtx Bin
+//ZVtx bin.
+class AliFemtoDreamPartContainer {
+ public:
+  AliFemtoDreamPartContainer();
+  AliFemtoDreamPartContainer(int MixingDepth);
+  AliFemtoDreamPartContainer& operator=(const AliFemtoDreamPartContainer& obj);
+  virtual ~AliFemtoDreamPartContainer();
+  void PrintLastEvent();
+  void SetEvent(std::vector<AliFemtoDreamBasePart> &Particles);
+  std::deque<std::vector<AliFemtoDreamBasePart>> GetEventBuffer()
+      const {return fPartBuffer;};
+  std::vector<AliFemtoDreamBasePart> &GetEvent(int Depth);
+  unsigned int GetMixingDepth() const {return fPartBuffer.size();};
+ private:
+  std::deque<std::vector<AliFemtoDreamBasePart>> fPartBuffer;
+  unsigned int fMixingDepth;
+  ClassDef(AliFemtoDreamPartContainer,1);
+};
+
+#endif /* ALIFEMTODREAMPARTCONTAINER_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrack.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrack.cxx
@@ -1,0 +1,329 @@
+/*
+ * AliFemtoDreamTrack.cxx
+ *
+ *  Created on: Nov 14, 2017
+ *      Author: gu74req
+ */
+#include "AliAnalysisManager.h"
+#include "AliAODPid.h"
+#include "AliAODTrack.h"
+#include "AliAODEvent.h"
+#include "AliAODMCParticle.h"
+#include "AliInputEventHandler.h"
+#include "AliFemtoDreamTrack.h"
+#include "AliLog.h"
+#include "TClonesArray.h"
+#include <iostream>
+ClassImp(AliFemtoDreamTrack)
+AliFemtoDreamTrack::AliFemtoDreamTrack()
+:AliFemtoDreamBasePart()
+,fPIDResponse(0)
+,fstatusTPC(AliPIDResponse::kDetNoParams)
+,fstatusTOF(AliPIDResponse::kDetNoParams)
+,fFilterMap(0)
+,fdcaXY(-99)
+,fdcaZ(-99)
+,fdcaXYProp(-99)
+,fdcaZProp(-99)
+,fNClsTPC(0)
+,fTPCCrossedRows(0)
+,fRatioCR(0)
+,fnoSharedClst(0)
+,fTPCClsS(0)
+,fSharedClsITSLayer(0)
+,fHasSharedClsITSLayer(false)
+,fdEdxTPC(0)
+,fbetaTOF(0)
+,fHasITSHit(false)
+,fITSHit(0)
+,fTOFTiming(false)
+,fTPCRefit(false)
+,fTrack(0)
+,fGlobalTrack(0)
+{
+  for (int i=0;i<5;++i) {
+    fnSigmaTPC[i]=0;
+    fnSigmaTOF[i]=0;
+  }
+}
+
+AliFemtoDreamTrack::~AliFemtoDreamTrack() {
+  // TODO Auto-generated destructor stub
+}
+
+void AliFemtoDreamTrack::SetTrack(AliAODTrack *track) {
+  this->Reset();
+  fTrack=track;
+  int trackID=fTrack->GetID();
+  if (trackID<0) {
+    if(!fGTI){
+      AliFatal("AliFemtoSPTrack::SetTrack No fGTI Set");
+      fGlobalTrack=NULL;
+    }else if(-trackID-1 >= fTrackBufferSize){
+      AliFatal("Buffer Size too small");
+      fGlobalTrack=NULL;
+    }else if(!CheckGlobalTrack(trackID)){
+      fGlobalTrack=NULL;
+    }else{
+      fGlobalTrack=fGTI[-trackID-1];
+    }
+  }else{
+    fGlobalTrack=track;
+  }
+  fIsReset=false;
+  if (fGlobalTrack&&fTrack) {
+    this->SetIDTracks(fGlobalTrack->GetID());
+    this->SetTrackingInformation();
+    this->SetPIDInformation();
+    if (fIsMC) {
+      this->SetMCInformation();
+    }
+  } else {
+    this->fIsSet=false;
+  }
+}
+
+void AliFemtoDreamTrack::SetTrackingInformation() {
+  this->fFilterMap=fTrack->GetFilterMap();
+  this->SetEta(fTrack->Eta());
+  this->SetPhi(fTrack->Phi());
+  this->SetTheta(fTrack->Theta());
+  this->SetCharge(fTrack->Charge());
+  this->SetMomentum(fTrack->Px(), fTrack->Py(), fTrack->Pz());
+  this->SetMomTPC(fGlobalTrack->GetTPCmomentum());
+  this->SetPt(fTrack->Pt());
+  this->fdcaXY=fTrack->DCA();
+  this->fdcaZ=fTrack->ZAtDCA();
+  double dcaVals[2] = {-99., -99.};
+  double covar[3]={0.,0.,0.};
+  AliAODTrack copy(*fGlobalTrack);
+  if (copy.PropagateToDCA(copy.GetAODEvent()->GetPrimaryVertex(),
+                          copy.GetAODEvent()->GetMagneticField(),
+                          10, dcaVals, covar))
+  {
+    this->fdcaXYProp = dcaVals[0];
+    this->fdcaZProp  = dcaVals[1];
+  }else{
+    this->fdcaXYProp = -99;
+    this->fdcaZProp  = -99;
+  }
+  //loop over the 6 ITS Layrs and check for a hit!
+  for (int i=0;i<6;++i) {
+    fITSHit.push_back(fGlobalTrack->HasPointOnITSLayer(i));
+    if (fGlobalTrack->HasPointOnITSLayer(i)) {
+      this->fHasITSHit=true;
+    }
+  }
+  if (fTrack->IsOn(AliAODTrack::kTPCrefit)) {
+    fTPCRefit=true;
+  }
+  if (fGlobalTrack->GetTOFBunchCrossing()==0) {
+    this->fTOFTiming=true;
+  } else {
+    this->fTOFTiming=false;
+  }
+
+  this->fNClsTPC=fTrack->GetTPCNcls();
+  //This method was inherited from H. Beck analysis
+  // In the documents
+  // https://alisoft.cern.ch/AliRoot/trunk/TPC/doc/Definitions/Definitions.pdf
+  // TPC people describe the cut strategy for the TPC. It is explicitly
+  // stated that a cut on the number of crossed rows and a cut on the
+  // number of crossed rows over findable clusters is recommended to
+  // remove fakes. In the pdf a cut value of .83 on the ratio
+  // is stated, no value for the number of crossed rows. Looking at the
+  // AliESDTrackCuts.cxx one sees that exactly this cut is used with
+  // 0.8 on the ratio and 70 on the crossed rows.
+
+  // Checked the filter task and AliAODTrack and AliESDtrack and
+  // AliESDtrackCuts and the Definitions.pdf:
+  // The function to get the findable clusters is GetTPCNclsF()
+
+  // For the number fo crossed rows for ESD tracks, the function
+  // GetTPCCrossedRows() usually is used. Looking at the AliESDtrack.cxx
+  // one sees that it's just an alias (with additional caching) for
+  // GetTPCClusterInfo(2, 1); The identical function exists in the
+  // AliAODTrack.cxx
+  this->fTPCCrossedRows=fTrack->GetTPCClusterInfo(2, 1);
+  if (!fTrack->GetTPCNclsF()) {
+    this->fRatioCR=0.;
+  } else {
+    this->fRatioCR=
+        fTrack->GetTPCClusterInfo(2, 1)/double(fTrack->GetTPCNclsF());
+  }
+  const TBits sharedMap=fTrack->GetTPCSharedMap();
+  if ((sharedMap.CountBits()) >= 1) {
+    // Bad Track, has too many shared clusters!
+    this->fnoSharedClst=false;
+  }else{
+    this->fnoSharedClst=true;
+  }
+  for (int i=0;i<6;++i) {
+    fSharedClsITSLayer.push_back(fTrack->HasSharedPointOnITSLayer(i));
+    if (fTrack->HasSharedPointOnITSLayer(i)) {
+      fHasSharedClsITSLayer=true;
+    }
+  }
+  this->fTPCClsS=fTrack->GetTPCnclsS();
+}
+
+void AliFemtoDreamTrack::SetPIDInformation() {
+  AliPID::EParticleType particleID[5] = {AliPID::kElectron,AliPID::kMuon,
+      AliPID::kPion,AliPID::kKaon,AliPID::kProton};
+  AliAnalysisManager *man=AliAnalysisManager::GetAnalysisManager();
+  if (man) {
+    AliInputEventHandler* inputHandler=
+        (AliInputEventHandler*)(man->GetInputEventHandler());
+    if (inputHandler) {
+      fPIDResponse=inputHandler->GetPIDResponse();
+      if (!fPIDResponse) {
+        AliFatal("No PID Response, did you run your PID Task?");
+      }
+    } else {
+      AliFatal("No Input Handler");
+    }
+  }else{
+    AliFatal("No PID Response");
+  }
+  AliPIDResponse::EDetPidStatus statusTPC =
+      fPIDResponse->CheckPIDStatus(AliPIDResponse::kTPC,fGlobalTrack);
+  AliPIDResponse::EDetPidStatus statusTOF =
+      fPIDResponse->CheckPIDStatus(AliPIDResponse::kTOF,fGlobalTrack);
+  this->fstatusTPC=statusTPC;
+  this->fstatusTOF=statusTOF;
+  this->fdEdxTPC=fGlobalTrack->GetTPCsignal();
+  this->fbetaTOF=GetBeta(fGlobalTrack);
+  for (int i=0;i<5;++i) {
+    if(statusTPC == AliPIDResponse::kDetPidOk){
+      (this->fnSigmaTPC)[i] =
+          fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC,fGlobalTrack,particleID[i]);
+    }else{
+      (this->fnSigmaTPC)[i] = -999.;
+    }
+    if(statusTOF == AliPIDResponse::kDetPidOk){
+      (this->fnSigmaTOF)[i] =
+          fPIDResponse->NumberOfSigmas(AliPIDResponse::kTOF,fGlobalTrack,particleID[i]);
+    }else{
+      (this->fnSigmaTOF)[i] = -999.;
+    }
+  }
+}
+
+void AliFemtoDreamTrack::SetMCInformation() {
+  //Set the phi at radii at the TPC information
+  //      SetPhiStar(track,fphiAtRadius);
+  TClonesArray *mcarray =
+      dynamic_cast<TClonesArray*>(fGlobalTrack->GetAODEvent()
+          ->FindListObject(AliAODMCParticle::StdBranchName()));
+  if (!mcarray) {
+    AliError("SPTrack: MC Array not found");
+  }
+  if (fGlobalTrack->GetLabel()>0) {
+    AliAODMCParticle * mcPart = (AliAODMCParticle*)mcarray->At(fGlobalTrack->GetLabel());;
+    if (!(mcPart)) {
+      this->fIsSet=false;
+    } else {
+      this->SetMCPhi(mcPart->Phi());
+      this->SetMCTheta(mcPart->Theta());
+      this->SetMCPDGCode(mcPart->PdgCode());
+      this->SetMCPt(mcPart->Pt());
+      this->SetMCMomentum(mcPart->Px(),mcPart->Py(),mcPart->Pz());
+
+      //check for secondary and set origin and mother
+      if (mcPart->IsPhysicalPrimary() && !mcPart->IsSecondaryFromWeakDecay()) {
+        this->SetParticleOrigin(AliFemtoDreamBasePart::kPhysPrimary);
+      } else if(mcPart->IsSecondaryFromWeakDecay() && !mcPart->IsSecondaryFromMaterial()) {
+        this->SetParticleOrigin(AliFemtoDreamBasePart::kWeak);
+        this->SetPDGMotherWeak(((AliAODMCParticle*)mcarray->At(mcPart->GetMother()))->PdgCode());
+      } else if (mcPart->IsSecondaryFromMaterial()) {
+        this->SetParticleOrigin(AliFemtoDreamBasePart::kMaterial);
+      } else {
+        this->SetParticleOrigin(AliFemtoDreamBasePart::kUnknown);
+      }
+    }
+  } else {
+    this->fIsSet =false; //if we don't have MC Information, don't use that track
+  }
+}
+
+float AliFemtoDreamTrack::GetBeta(AliAODTrack *track) {
+  float beta = -999;
+  double integratedTimes[9] = {-1.0,-1.0,-1.0,-1.0,-1.0, -1.0, -1.0, -1.0, -1.0};
+
+  track->GetIntegratedTimes(integratedTimes);
+
+  const float c = 2.99792457999999984e-02;
+  float p = track->P();
+  float l = integratedTimes[0]*c;
+
+  float trackT0 = fPIDResponse->GetTOFResponse().GetStartTime(p);
+
+  float timeTOF = track->GetTOFsignal()- trackT0;
+  if(timeTOF > 0){
+    beta  = l/timeTOF/c;
+  }
+  return beta;
+}
+
+bool AliFemtoDreamTrack::CheckGlobalTrack(const Int_t TrackID) {
+  //This method was inherited from H. Beck analysis
+  //Checks if to the corresponding track a global track exists
+  //This is especially useful if one has TPC only tracks and needs the PID information
+  bool isGlobal = true;
+  if (TMath::Abs(TrackID)<fTrackBufferSize) {
+    if (!(fGTI[-TrackID-1])) {
+      isGlobal = false;
+    }
+  }
+  return isGlobal;
+}
+void AliFemtoDreamTrack::Reset() {
+  if (!fIsReset) {
+    fstatusTPC=AliPIDResponse::kDetNoParams;
+    fstatusTOF=AliPIDResponse::kDetNoParams;
+    fFilterMap=0;
+    fdcaXY=-99;
+    fdcaZ=-99;
+    fdcaXYProp=-99;
+    fdcaZProp=-99;
+    fNClsTPC=0;
+    fTPCCrossedRows=0;
+    fRatioCR=0;
+    fnoSharedClst=0;
+    fTPCClsS=0;
+    fSharedClsITSLayer.clear();
+    fHasSharedClsITSLayer=false;
+    fdEdxTPC=-999;
+    fbetaTOF=1.1;
+    for (int i=0;i<5;++i) {
+      fnSigmaTPC[i]=99;
+      fnSigmaTOF[i]=99;
+    }
+    fHasITSHit=false;
+    fITSHit.clear();
+    fTOFTiming=false;
+    fTPCRefit=false;
+    fP.SetXYZ(0,0,0);
+    fMCP.SetXYZ(0,0,0);
+    fPt=0;
+    fMCPt=0;
+    fMCPt=0;
+    fP_TPC=0;
+    fEta.clear();
+    fTheta.clear();
+    fMCTheta.clear();
+    fPhi.clear();
+    fMCPhi.clear();
+    fIDTracks.clear();
+    fCharge.clear();
+    fCPA=0;
+    fOrigin=AliFemtoDreamBasePart::kUnknown;
+    //we don't want to reset the fPDGCode
+    fMCPDGCode=0;
+    fPDGMotherWeak=0;
+    //we don't want to reset isMC
+    fUse=false;
+    fIsSet=true;
+    fIsReset=true;
+  }
+}

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrack.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrack.h
@@ -1,0 +1,83 @@
+/*
+ * AliFemtoDreamTrack.h
+ *
+ *  Created on: Nov 14, 2017
+ *      Author: gu74req
+ */
+
+#ifndef ALIFEMTODREAMTRACK_H_
+#define ALIFEMTODREAMTRACK_H_
+
+#include <vector>
+#include "AliFemtoDreamBasePart.h"
+#include "AliPIDResponse.h"
+class AliFemtoDreamTrack : public AliFemtoDreamBasePart {
+ public:
+  AliFemtoDreamTrack();
+  virtual ~AliFemtoDreamTrack();
+  void SetTrack(AliAODTrack *track);
+  UInt_t GetilterMap() const {return fFilterMap;};
+  bool TestFilterBit(UInt_t filterBit)
+  {return (bool) ((filterBit & fFilterMap) != 0);}
+
+  double GetDCAXY() const {  return fdcaXY;};
+  double GetDCAXYProp() const {return fdcaXYProp;};
+  double GetDCAZ() const {return fdcaZ;};
+  double GetDCAZProp() const {return fdcaZProp;};
+
+  //Quality Varaibles of the track
+  double GetNClsTPC() const {return fNClsTPC;};
+  float GetTPCCrossedRows() const {return fTPCCrossedRows;};
+  float GetRatioCr() const {return fRatioCR;};
+  bool isnoSharedClst() const {return fnoSharedClst;};
+  double GetTPCClsC() const {return fTPCClsS;};
+  bool GetSharedClusterITS(int i)const{return fSharedClsITSLayer.at(i);};
+  bool GetHasSharedClsITS()const{return fHasSharedClsITSLayer;};
+  bool GetHasITSHit() const {return fHasITSHit;};
+  bool GetITSHit(int i) const {return fITSHit.at(i);};
+  bool GetTOFTimingReuqirement() const {return fTOFTiming;};
+  bool GetHasTPCRefit()const{return fTPCRefit;};
+  //PID Getters
+  AliPIDResponse::EDetPidStatus   GetstatusTOF() const {return fstatusTOF;};
+  AliPIDResponse::EDetPidStatus   GetstatusTPC() const {return fstatusTPC;};
+  double GetdEdxTPC() const {return fdEdxTPC;};
+  double GetbetaTOF() const {return fbetaTOF;};
+  double GetnSigmaTPC(Int_t i) const {return fnSigmaTPC[i];};
+  double GetnSigmaTOF(Int_t i) const {return fnSigmaTOF[i];};
+  TString ClassName(){return "TrackCuts";};
+ private:
+  void Reset();
+  float GetBeta(AliAODTrack *track);
+  bool CheckGlobalTrack(const Int_t TrackID);
+  void SetTrackingInformation();
+  void SetPIDInformation();
+  void SetMCInformation();
+  AliPIDResponse *fPIDResponse;
+  AliPIDResponse::EDetPidStatus fstatusTPC;
+  AliPIDResponse::EDetPidStatus fstatusTOF;
+  UInt_t fFilterMap;
+  double fdcaXY;
+  double fdcaZ;
+  double fdcaXYProp;
+  double fdcaZProp;
+  double fNClsTPC;
+  double fTPCCrossedRows;
+  double fRatioCR;
+  double fnoSharedClst;
+  double fTPCClsS;
+  std::vector<bool> fSharedClsITSLayer;
+  bool fHasSharedClsITSLayer;
+  double fdEdxTPC;
+  double fbetaTOF;
+  bool fHasITSHit;
+  std::vector<bool> fITSHit;
+  bool fTOFTiming;
+  bool fTPCRefit;
+  AliAODTrack *fTrack;
+  AliAODTrack *fGlobalTrack;
+  double fnSigmaTPC[5];
+  double fnSigmaTOF[5];
+  ClassDef(AliFemtoDreamTrack, 1)
+};
+
+#endif /* ALIFEMTODREAMTRACK_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackCuts.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackCuts.cxx
@@ -1,0 +1,741 @@
+/*
+ * AliFemtoDreamTrackCuts.cxx
+ *
+ *  Created on: Nov 14, 2017
+ *      Author: gu74req
+ */
+
+#include "AliFemtoDreamTrackCuts.h"
+#include "TMath.h"
+#include <iostream>
+ClassImp(AliFemtoDreamTrackCuts)
+AliFemtoDreamTrackCuts::AliFemtoDreamTrackCuts()
+:fMCHists(0)
+,fHists(0)
+,fMCData(false)
+,fDCAPlots(false)
+,fCombSigma(false)
+,fContribSplitting(false)
+,fFillQALater(false)
+,fCheckFilterBit(false)
+,fCheckPileUpITS(false)
+,fCheckPileUpTOF(false)
+,fCheckPileUp(false)
+,fFilterBit(0)
+,fpTmin(0.)
+,fpTmax(0.)
+,fcutPt(false)
+,fetamin(0.)
+,fetamax(0.)
+,fcutEta(false)
+,fcutCharge(false)
+,fCharge(0)
+,fnTPCCls(0)
+,fcutnTPCCls(false)
+,fDCAProp(false)
+,fDCAToVertexXY(0)
+,fCutDCAToVtxXY(false)
+,fDCAToVertexZ(0)
+,fCutDCAToVtxZ(false)
+,fCutSharedCls(false)
+,fCheckTPCRefit(false)
+,fCutTPCCrossedRows(false)
+,fCutPID(false)
+,fCutHighPtSig(false)
+,fParticleID(AliPID::kUnknown)
+,fNSigValue(3.)
+,fPIDPTPCThreshold(0)
+,fRejectPions(false)
+{}
+
+AliFemtoDreamTrackCuts::~AliFemtoDreamTrackCuts() {
+  if (fMCHists) {
+    delete fMCHists;
+  }
+  if (fHists) {
+    delete fHists;
+  }
+}
+
+bool AliFemtoDreamTrackCuts::isSelected(AliFemtoDreamTrack *Track) {
+  if (!Track) {
+    AliFatal("No Input Track recieved");
+  }
+  bool pass=true;
+  if (!Track->IsSet()) {
+    pass=false;
+  } else {
+    fHists->FillTrackCounter(0);
+  }
+  if (pass) {
+    if (!TrackingCuts(Track)) {
+      pass=false;
+    }
+  }
+  if (pass) {
+    if (!PIDAODCuts(Track)) {
+      pass=false;
+    } else {
+      fHists->FillTrackCounter(19);
+    }
+  }
+  if (pass) {
+    if (!DCACuts(Track)) {
+      pass=false;
+    }
+  }
+  Track->SetUse(pass);
+  if (!fFillQALater) {
+    BookQA(Track);
+    if (fMCData) {
+      BookMC(Track);
+    }
+  }
+  return pass;
+}
+
+bool AliFemtoDreamTrackCuts::TrackingCuts(AliFemtoDreamTrack *Track) {
+  bool pass=true;
+  std::vector<double> eta=Track->GetEta();
+  std::vector<int> charge=Track->GetCharge();
+  if (fCheckFilterBit) {
+    if (!Track->TestFilterBit(fFilterBit)) {
+      //if there is Filterbit -1 .. see Prong cuts! Daughters don't check for FB
+      pass=false;
+    } else {
+      fHists->FillTrackCounter(1);
+    }
+  }
+  if (pass && fcutPt) {
+    if (Track->GetPt()<fpTmin||Track->GetPt()>fpTmax) {
+      pass=false;
+    } else {
+      fHists->FillTrackCounter(2);
+    }
+  }
+  if (pass && fcutEta) {
+    if (eta[0]< fetamin||eta[0]>fetamax) {
+      pass=false;
+    } else {
+      fHists->FillTrackCounter(3);
+    }
+  }
+  if (pass && fcutCharge) {
+    if (!(charge[0]==fCharge)) {
+      pass=false;
+    } else {
+      fHists->FillTrackCounter(4);
+    }
+  }
+  if (pass&&fCheckPileUpITS) {
+    if (!Track->GetHasITSHit()) {
+      pass=false;
+    } else {
+      fHists->FillTrackCounter(5);
+    }
+  }
+  if (pass&&fCheckPileUpTOF) {
+    if (!Track->GetTOFTimingReuqirement()) {
+      pass=false;
+    } else {
+      fHists->FillTrackCounter(6);
+    }
+  }
+  if (pass&&fCheckPileUp) {
+    if (!(Track->GetTOFTimingReuqirement()||Track->GetHasITSHit())) {
+      pass=false;
+    } else {
+      fHists->FillTrackCounter(7);
+    }
+  }
+  if (pass && fcutnTPCCls) {
+    if (Track->GetNClsTPC()<fnTPCCls) {
+      pass=false;
+    } else {
+      fHists->FillTrackCounter(8);
+    }
+  }
+  if (pass && fCutSharedCls) {
+    if (!Track->isnoSharedClst()) {
+      pass=false;
+    } else {
+      fHists->FillTrackCounter(9);
+    }
+  }
+  if (pass && fCheckTPCRefit) {
+    if (!Track->GetHasTPCRefit()) {
+      pass=false;
+    } else {
+      fHists->FillTrackCounter(10);
+    }
+  }
+  if (pass && fCutTPCCrossedRows) {
+    if (Track->GetTPCCrossedRows()<70) {
+      pass=false;
+    } else {
+      fHists->FillTrackCounter(11);
+    }
+    if (pass) {
+      if (Track->GetRatioCr()<0.83) {
+        pass=false;
+      } else {
+        fHists->FillTrackCounter(12);
+      }
+    }
+  }
+  return pass;
+}
+
+bool AliFemtoDreamTrackCuts::PIDAODCuts(AliFemtoDreamTrack *Track) {
+  bool pass=true;
+  //PID Method with an nSigma cut, just use the TPC below threshold,
+  //and above TPC and TOF Combined
+  //there must be TPC & TOF signal (TOF for P>0.75 GeV/c)
+  bool TPCisthere=false;
+  bool TOFisthere=false;
+
+  if (Track->GetstatusTPC()==AliPIDResponse::kDetPidOk) {
+    TPCisthere=true;
+  }
+  if (Track->GetstatusTOF()==AliPIDResponse::kDetPidOk) {
+    TOFisthere=true;
+  }
+  //Below a threshold where the bands are well seperated in the TPC use only
+  //TPC for PID, since the TOF has only limited matching efficiency. Above
+  //threshold use both detectors and perform a purity check, if another
+  //particle species doesn't have a smaller sigma value
+
+  if (Track->GetMomTPC()<fPIDPTPCThreshold) {
+    if (!TPCisthere) {
+      pass=false;
+    } else {
+      fHists->FillTrackCounter(13);
+      if (fRejectPions&&TOFisthere) {
+        double nSigTOF=(Track->GetnSigmaTOF((int)(AliPID::kPion)));
+        if (TMath::Abs(nSigTOF)<fNSigValue) {
+          if (fParticleID==AliPID::kPion) {
+            AliWarning("Sure you want to use this method? Propably want to set"
+                " SetRejLowPtPionsTOF(kFALSE), since you are selecting Pions");
+          }
+          //if the particle is a Pion according to the TOF, reject it!
+          pass=false;
+        } else {
+          fHists->FillTrackCounter(14);
+        }
+      }
+      if (pass) {
+        double nSigTPC=(Track->GetnSigmaTPC((int)(fParticleID)));
+        if (!(TMath::Abs(nSigTPC)<fNSigValue)) {
+          pass=false;
+        } else {
+          fHists->FillTrackCounter(15);
+        }
+      }
+    }
+  } else {
+    if (!(TPCisthere&&TOFisthere)) {
+      pass=false;
+    } else {
+      fHists->FillTrackCounter(16);
+      double nSigTPC=(Track->GetnSigmaTPC((int)(fParticleID)));
+      double nSigTOF=(Track->GetnSigmaTOF((int)(fParticleID)));
+      double nSigComb=TMath::Sqrt(nSigTPC*nSigTPC + nSigTOF*nSigTOF);
+      if (!(nSigComb<fNSigValue)) {
+        pass=false;
+      } else {
+        fHists->FillTrackCounter(17);
+        if (fCutHighPtSig) {
+          if (!SmallestNSig(Track)) {
+            pass=false;
+          } else {
+            fHists->FillTrackCounter(18);
+          }
+        }
+      }
+    }
+  }
+  return pass;
+}
+
+bool AliFemtoDreamTrackCuts::SmallestNSig(AliFemtoDreamTrack *Track) {
+  bool pass=true;
+  //check before if TPC and TOF PID are available
+  //This should just be for PID of high pT particles
+  AliPID::EParticleType type[5]={AliPID::kElectron,AliPID::kMuon,AliPID::kPion,
+      AliPID::kKaon,AliPID::kProton};
+  double nSigmaComb[5];
+  //Form the combination:
+  for (int i=0; i<5; ++i) {
+    nSigmaComb[i]=TMath::Sqrt(pow((Track->GetnSigmaTPC(i)),2.)+
+                              pow((Track->GetnSigmaTOF(i)),2.));
+  }
+  int index=0;
+  for (int i=0; i<5; ++i) {
+    if (nSigmaComb[index]>nSigmaComb[i]) {
+      index=i;
+    }
+  }
+  if (!(type[index]==fParticleID)) {
+    pass=false;
+  }
+  return pass;
+}
+bool AliFemtoDreamTrackCuts::DCACuts(AliFemtoDreamTrack *Track) {
+  bool pass=true;
+
+  if (fCutDCAToVtxZ) {
+    if (fDCAProp) {
+      if (!(TMath::Abs(Track->GetDCAZProp())<fDCAToVertexZ)) {
+        pass=false;
+      } else {
+        fHists->FillTrackCounter(20);
+      }
+    } else {
+      if (!(TMath::Abs(Track->GetDCAZ())<fDCAToVertexZ)) {
+        pass=false;
+      } else {
+        fHists->FillTrackCounter(20);
+      }
+    }
+  }
+  if (pass&&fDCAPlots) {
+    if (fDCAProp) {
+      fHists->FillDCAXYPtBins(Track->GetPt(),Track->GetDCAXYProp());
+    } else {
+      fHists->FillDCAXYPtBins(Track->GetPt(),Track->GetDCAXY());
+    }
+    if (fMCData) {
+      if (fDCAPlots) {
+        if (fDCAProp) {
+          fMCHists->FillMCDCAXYPtBins(Track->GetParticleOrigin(),
+                                      Track->GetMotherWeak(),
+                                      Track->GetPt(),
+                                      Track->GetDCAXYProp());
+        } else {
+          fMCHists->FillMCDCAXYPtBins(Track->GetParticleOrigin(),
+                                      Track->GetMotherWeak(),
+                                      Track->GetPt(),
+                                      Track->GetDCAXY());
+        }
+      }
+    }
+  }
+  if (pass&&fCutDCAToVtxXY) {
+    if (fDCAProp) {
+      if (!(TMath::Abs(Track->GetDCAXYProp())<fDCAToVertexXY)) {
+        pass=false;
+      } else {
+        fHists->FillTrackCounter(21);
+      }
+    } else {
+      if (!(TMath::Abs(Track->GetDCAXY())<fDCAToVertexXY)) {
+        pass=false;
+      } else {
+        fHists->FillTrackCounter(21);
+      }
+    }
+  }
+  return pass;
+}
+void AliFemtoDreamTrackCuts::Init() {
+  fHists=new AliFemtoDreamTrackHist(fDCAPlots,fCombSigma);
+  if (fMCData) {
+    fMCHists=new AliFemtoDreamTrackMCHist(fContribSplitting,fDCAPlots);
+  }
+  BookTrackCuts();
+}
+
+void AliFemtoDreamTrackCuts::BookQA(AliFemtoDreamTrack *Track) {
+  std::vector<double> eta=Track->GetEta();
+  std::vector<double> phi=Track->GetPhi();
+  double pT = Track->GetPt();
+  double p = Track->GetMomTPC();
+  for (int i=0;i<2;++i) {
+    if (i==0||(i==1&&Track->UseParticle())) {
+      fHists->FilletaCut(i,eta.at(0));
+      fHists->FillphiCut(i,phi.at(0));
+      fHists->FillpTCut(i,pT);
+      fHists->FillpTPCCut(i,p);
+      fHists->FillTPCclsCut(i,Track->GetNClsTPC());
+      if (fDCAProp) {
+        fHists->FillDCAxyCut(i,pT,Track->GetDCAXYProp());
+        fHists->FillDCAzCut(i,pT,Track->GetDCAZProp());
+      } else {
+        fHists->FillDCAxyCut(i,pT,Track->GetDCAXY());
+        fHists->FillDCAzCut(i,pT,Track->GetDCAZ());
+      }
+      fHists->FillTPCCrossedRowCut(i,Track->GetTPCCrossedRows());
+      fHists->FillTPCRatioCut(i,Track->GetRatioCr());
+      fHists->FillTPCClsS(i,Track->GetTPCClsC());
+      for (int j=0;j<6;++j) {
+        if (Track->GetITSHit(j)) {
+          fHists->FillTPCClsCPileUp(i,j,Track->GetTPCClsC());
+        } else if (Track->GetHasITSHit()||Track->GetTOFTimingReuqirement()){
+          fHists->FillTPCClsCPileUp(i,j+7,Track->GetTPCClsC());
+        }
+      }
+      if (Track->GetTOFTimingReuqirement()) {
+        fHists->FillTPCClsCPileUp(i,6,Track->GetTPCClsC());
+      } else if (Track->GetHasITSHit()) {
+        fHists->FillTPCClsCPileUp(i,13,Track->GetTPCClsC());
+      } else {
+        fHists->FillTPCClsCPileUp(i,14,Track->GetTPCClsC());
+      }
+
+      for (int j=0;j<6;++j) {
+        if (Track->GetSharedClusterITS(j)) {
+          fHists->FillHasSharedClsITS(i,j+1,0);
+        } else {
+          fHists->FillHasSharedClsITS(i,j+1,1);
+        }
+        for (int k=0;k<6;++k) {
+          if (Track->GetITSHit(k)) {
+            if (Track->GetSharedClusterITS(j)) {
+              fHists->FillITSSharedPileUp(i,k,j);
+            } else {
+              fHists->FillITSSharedPileUp(i,k,j+6);
+            }
+          } else  if (Track->GetHasITSHit()||Track->GetTOFTimingReuqirement()) {
+            if (Track->GetSharedClusterITS(j)) {
+              fHists->FillITSSharedPileUp(i,k+7,j);
+            } else {
+              fHists->FillITSSharedPileUp(i,k+7,j+6);
+            }
+          }
+        }
+        if (Track->GetTOFTimingReuqirement()) {
+          if (Track->GetSharedClusterITS(j)) {
+            fHists->FillITSSharedPileUp(i,6,j);
+          } else {
+            fHists->FillITSSharedPileUp(i,6,j+6);
+          }
+        } else if (Track->GetHasITSHit()) {
+          if (Track->GetSharedClusterITS(j)) {
+            fHists->FillITSSharedPileUp(i,13,j);
+          } else {
+            fHists->FillITSSharedPileUp(i,13,j+6);
+          }
+        } else {
+          if (Track->GetSharedClusterITS(j)) {
+            fHists->FillITSSharedPileUp(i,14,j);
+          } else {
+            fHists->FillITSSharedPileUp(i,14,j+6);
+          }
+        }
+      }
+
+      fHists->FillTPCdedx(i,p,Track->GetdEdxTPC());
+      fHists->FillTOFbeta(i,p,Track->GetbetaTOF());
+      fHists->FillNSigTPC(i,p,(Track->GetnSigmaTPC(fParticleID)));
+      fHists->FillNSigTOF(i,p,(Track->GetnSigmaTOF(fParticleID)));
+      fHists->FillTPCStatus(i,Track->GetstatusTPC());
+      fHists->FillTOFStatus(i,Track->GetstatusTOF());
+      //Fill These Before
+      if (i==0&&fCombSigma) {
+        fHists->FillNSigComb(pT,Track->GetnSigmaTPC(fParticleID),
+                             Track->GetnSigmaTOF(fParticleID));
+      }
+    }
+  }
+  return;
+}
+
+void AliFemtoDreamTrackCuts::BookMC(AliFemtoDreamTrack *Track) {
+  Int_t PDGcode[5] = {11,13,211,321,2212};
+  if (fpTmin<Track->GetPt()&&Track->GetPt()<fpTmax) {
+    if (fetamin<Track->GetEta().at(0)&&Track->GetEta().at(0)<fetamax) {
+      if(!fcutCharge){
+        if(TMath::Abs(Track->GetMCPDGCode())==PDGcode[fParticleID]){
+          fMCHists->FillMCGen(Track->GetPt());
+        }
+      }else{
+        Int_t sign = (Int_t)fCharge/TMath::Abs(fCharge);
+        if(Track->GetMCPDGCode() == sign*PDGcode[fParticleID]){
+          fMCHists->FillMCGen(Track->GetPt());
+        }
+      }
+    }
+  }
+  if (Track->UseParticle()) {
+    double pT = Track->GetPt();
+    int PDGcode[5] = {11,13,211,321,2212};
+    //Fill Identified
+    fMCHists->FillMCIdent(pT);
+    if (!fcutCharge) {
+      if (TMath::Abs(Track->GetMCPDGCode())==TMath::Abs(PDGcode[fParticleID])) {
+        fMCHists->FillMCCorr(pT);
+      } else {
+        Track->SetParticleOrigin(AliFemtoDreamBasePart::kContamination);
+      }
+    } else {
+      Int_t sign = (Int_t)fCharge/TMath::Abs(fCharge);
+      if (Track->GetMCPDGCode() == sign*PDGcode[fParticleID]) {
+        fMCHists->FillMCCorr(pT);
+      } else {
+        Track->SetParticleOrigin(AliFemtoDreamBasePart::kContamination);
+      }
+    }
+    if (fContribSplitting) {
+      FillMCContributions(Track);
+    }
+  }
+}
+
+void AliFemtoDreamTrackCuts::FillMCContributions(
+    AliFemtoDreamTrack *Track)
+{
+  double pT=Track->GetPt();
+  AliFemtoDreamBasePart::PartOrigin org=Track->GetParticleOrigin();
+  Int_t iFill = -1;
+  switch(org) {
+    case AliFemtoDreamBasePart::kPhysPrimary:
+      fMCHists->FillMCPrimary(pT);
+      iFill = 0;
+      break;
+    case AliFemtoDreamBasePart::kWeak:
+      fMCHists->FillMCFeeddown(pT,TMath::Abs(Track->GetMotherWeak()));
+      iFill = 1;
+      break;
+    case AliFemtoDreamBasePart::kMaterial:
+      fMCHists->FillMCMaterial(pT);
+      iFill = 2;
+      break;
+    case AliFemtoDreamBasePart::kContamination:
+      fMCHists->FillMCCont(pT);
+      iFill = 3;
+      break;
+    default:
+      AliFatal("Type Not implemented");
+      break;
+  }
+  if (iFill >= 0 && iFill < 4) {
+    std::vector<double> eta=Track->GetEta();
+    std::vector<double> phi=Track->GetPhi();
+    fMCHists->FillMCpTPCCut(iFill,Track->GetMomTPC());
+    fMCHists->FillMCetaCut(iFill,eta[0]);
+    fMCHists->FillMCphiCut(iFill,phi[0]);
+    fMCHists->FillMCTPCclsCut(iFill,pT,Track->GetNClsTPC());
+    if (fDCAProp) {
+      fMCHists->FillMCDCAxyCut(iFill,pT,Track->GetDCAXYProp());
+      fMCHists->FillMCDCAzCut(iFill,pT,Track->GetDCAZProp());
+    } else {
+      fMCHists->FillMCDCAxyCut(iFill,pT,Track->GetDCAXY());
+      fMCHists->FillMCDCAzCut(iFill,pT,Track->GetDCAZ());
+    }
+    fMCHists->FillMCTPCCrossedRowCut(iFill,pT,Track->GetTPCCrossedRows());
+    fMCHists->FillMCTPCRatioCut(iFill,pT,Track->GetRatioCr());
+    fMCHists->FillMCTPCdedx(iFill,pT,Track->GetdEdxTPC());
+    fMCHists->FillMCTOFbeta(iFill,pT,Track->GetbetaTOF());
+    fMCHists->FillMCNSigTPC(iFill,pT,Track->GetnSigmaTPC(fParticleID));
+    fMCHists->FillMCNSigTOF(iFill,pT,Track->GetnSigmaTOF(fParticleID));
+  } else {
+    TString errMSG =  Form("iFill = %d", iFill);
+    AliFatal(errMSG.Data());
+  }
+  return;
+}
+
+void AliFemtoDreamTrackCuts::BookTrackCuts() {
+  if (!fHists) {
+    AliFatal("AliFemtoPPbpbLamSpTrackCuts::BookTrackCuts No Histograms to work with");
+  }
+  if (fcutPt) {
+    fHists->FillConfig(0, fpTmin);
+    fHists->FillConfig(1, fpTmax);
+  }
+  if (fcutEta) {
+    fHists->FillConfig(2, fetamin);
+    fHists->FillConfig(3, fetamax);
+  }
+  if (fcutCharge) {
+    fHists->FillConfig(4, fCharge);
+  }
+
+  if (fcutnTPCCls) {
+    fHists->FillConfig(5, fnTPCCls);
+  }
+
+  if (fCheckFilterBit) {
+    fHists->FillConfig(6, fFilterBit);
+  } else {
+    fHists->FillConfig(6, -1);
+  }
+
+  if (fMCData) {
+    fHists->FillConfig(7, 1);
+  }
+  if (fCutDCAToVtxXY) {
+    fHists->FillConfig(8, fDCAToVertexXY);
+  }
+  if (fCutDCAToVtxZ) {
+    fHists->FillConfig(9, fDCAToVertexZ);
+  }
+  if (fCutSharedCls) {
+    fHists->FillConfig(10, 1);
+  }
+  if (fCutTPCCrossedRows) {
+    fHists->FillConfig(11, 1);
+  } else {
+    fHists->FillConfig(11, 0);
+  }
+  if (fCutPID) {
+    fHists->FillConfig(12, fPIDPTPCThreshold);
+    fHists->FillConfig(13, fNSigValue);
+    if (fRejectPions) {
+      fHists->FillConfig(14, 1);
+    } else {
+      fHists->FillConfig(14, 0);
+    }
+    if (fCutHighPtSig) {
+      fHists->FillConfig(15, 1);
+    } else {
+      fHists->FillConfig(15,0);
+    }
+  } else {
+    fHists->FillConfig(12, 0);
+    fHists->FillConfig(13, 0);
+    fHists->FillConfig(14, 0);
+    fHists->FillConfig(15, 0);
+  }
+  if (fCheckPileUpITS) {
+    fHists->FillConfig(16,1);
+  }
+  if (fCheckPileUpTOF) {
+    fHists->FillConfig(17,1);
+  }
+  if (fCheckPileUp) {
+    fHists->FillConfig(18,1);
+  }
+  if (fCheckTPCRefit) {
+    fHists->FillConfig(19,1);
+  }
+}
+
+
+AliFemtoDreamTrackCuts* AliFemtoDreamTrackCuts::PrimProtonCuts(
+    bool isMC,bool DCAPlots,bool CombSigma,bool ContribSplitting)
+{
+  AliFemtoDreamTrackCuts *trackCuts = new AliFemtoDreamTrackCuts();
+  //you can leave DCA cut active, this will still be filled
+  //over the whole DCA_xy range
+  trackCuts->SetPlotDCADist(DCAPlots);
+  trackCuts->SetPlotCombSigma(CombSigma);
+  trackCuts->SetPlotContrib(ContribSplitting);
+  trackCuts->SetIsMonteCarlo(isMC);
+
+  trackCuts->SetFilterBit(128);
+  trackCuts->SetPtRange(0.5, 4.05);
+  trackCuts->SetEtaRange(-0.8, 0.8);
+  trackCuts->SetNClsTPC(80);
+  trackCuts->SetDCAReCalculation(true);//Get the dca from the PropagateToVetex
+  trackCuts->SetDCAVtxZ(0.2);
+  trackCuts->SetDCAVtxXY(0.1);
+  trackCuts->SetCutSharedCls(true);
+  trackCuts->SetCutTPCCrossedRows(true);
+  trackCuts->SetPID(AliPID::kProton, 0.75);
+  trackCuts->SetRejLowPtPionsTOF(true);
+  trackCuts->SetCutSmallestSig(true);
+
+  return trackCuts;
+}
+
+AliFemtoDreamTrackCuts* AliFemtoDreamTrackCuts::DecayProtonCuts(
+    bool isMC,bool ContribSplitting) {
+  AliFemtoDreamTrackCuts *trackCuts = new AliFemtoDreamTrackCuts();
+  trackCuts->SetPlotDCADist(false);
+  trackCuts->SetPlotCombSigma(false);
+  trackCuts->SetPlotContrib(ContribSplitting);
+  trackCuts->SetIsMonteCarlo(isMC);
+  trackCuts->SetFillQALater(true);
+
+  trackCuts->SetCheckPileUp(true);
+  trackCuts->SetCheckFilterBit(false);
+  trackCuts->SetEtaRange(-0.8, 0.8);
+  trackCuts->SetNClsTPC(70);
+  trackCuts->SetDCAReCalculation(true);
+  trackCuts->SetCutCharge(1);
+  trackCuts->SetPID(AliPID::kProton, 999.,5);
+  return trackCuts;
+}
+
+AliFemtoDreamTrackCuts* AliFemtoDreamTrackCuts::DecayPionCuts(
+    bool isMC,bool ContribSplitting) {
+  AliFemtoDreamTrackCuts *trackCuts = new AliFemtoDreamTrackCuts();
+  trackCuts->SetPlotDCADist(false);
+  trackCuts->SetPlotCombSigma(false);
+  trackCuts->SetPlotContrib(ContribSplitting);
+  trackCuts->SetIsMonteCarlo(isMC);
+  trackCuts->SetFillQALater(true);
+
+  trackCuts->SetCheckPileUp(true);
+  trackCuts->SetCheckFilterBit(kFALSE);
+  trackCuts->SetEtaRange(-0.8, 0.8);
+  trackCuts->SetNClsTPC(70);
+  trackCuts->SetDCAReCalculation(kTRUE);
+  trackCuts->SetCutCharge(-1);
+  trackCuts->SetPID(AliPID::kPion, 999.,5);
+  return trackCuts;
+}
+
+AliFemtoDreamTrackCuts* AliFemtoDreamTrackCuts::Xiv0PionCuts(
+    bool isMC,bool ContribSplitting) {
+  AliFemtoDreamTrackCuts *trackCuts = new AliFemtoDreamTrackCuts();
+  trackCuts->SetPlotDCADist(false);
+  trackCuts->SetPlotCombSigma(false);
+  trackCuts->SetCheckPileUp(false);
+  trackCuts->SetPlotContrib(ContribSplitting);
+  trackCuts->SetIsMonteCarlo(isMC);
+  trackCuts->SetFillQALater(true);
+
+  trackCuts->SetCheckFilterBit(kFALSE);
+  trackCuts->SetEtaRange(-0.8, 0.8);
+  trackCuts->SetPtRange(0.3,999);
+  trackCuts->SetCutTPCCrossedRows(true);
+  trackCuts->SetDCAReCalculation(kTRUE);
+  trackCuts->SetCutCharge(-1);
+  trackCuts->SetCheckTPCRefit(true);
+  trackCuts->SetPID(AliPID::kPion, 999.,4);
+  return trackCuts;
+}
+
+AliFemtoDreamTrackCuts* AliFemtoDreamTrackCuts::Xiv0ProtonCuts(
+    bool isMC,bool ContribSplitting) {
+  AliFemtoDreamTrackCuts *trackCuts = new AliFemtoDreamTrackCuts();
+  trackCuts->SetPlotDCADist(false);
+  trackCuts->SetPlotCombSigma(false);
+  trackCuts->SetCheckPileUp(false);
+  trackCuts->SetPlotContrib(ContribSplitting);
+  trackCuts->SetIsMonteCarlo(isMC);
+  trackCuts->SetFillQALater(true);
+
+  trackCuts->SetCheckFilterBit(kFALSE);
+  trackCuts->SetEtaRange(-0.8, 0.8);
+  trackCuts->SetPtRange(0.3,999);
+  trackCuts->SetCutTPCCrossedRows(true);
+  trackCuts->SetDCAReCalculation(kTRUE);
+  trackCuts->SetCutCharge(1);
+  trackCuts->SetCheckTPCRefit(true);
+  trackCuts->SetPID(AliPID::kProton, 999.,4);
+  return trackCuts;
+}
+
+AliFemtoDreamTrackCuts* AliFemtoDreamTrackCuts::XiBachPionCuts(
+    bool isMC,bool ContribSplitting) {
+  AliFemtoDreamTrackCuts *trackCuts = new AliFemtoDreamTrackCuts();
+  trackCuts->SetPlotDCADist(false);
+  trackCuts->SetPlotCombSigma(false);
+  trackCuts->SetCheckPileUp(false);
+  trackCuts->SetPlotContrib(ContribSplitting);
+  trackCuts->SetIsMonteCarlo(isMC);
+  trackCuts->SetFillQALater(true);
+
+  trackCuts->SetCheckFilterBit(kFALSE);
+  trackCuts->SetEtaRange(-0.8, 0.8);
+  trackCuts->SetPtRange(0.3,999);
+  trackCuts->SetCutTPCCrossedRows(true);
+  trackCuts->SetDCAReCalculation(kTRUE);
+  trackCuts->SetCutCharge(-1);
+  trackCuts->SetCheckTPCRefit(true);
+  trackCuts->SetPID(AliPID::kPion, 999.,4);
+  return trackCuts;
+}

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackCuts.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackCuts.cxx
@@ -442,6 +442,7 @@ void AliFemtoDreamTrackCuts::BookQA(AliFemtoDreamTrack *Track) {
 
 void AliFemtoDreamTrackCuts::BookMC(AliFemtoDreamTrack *Track) {
   Int_t PDGcode[5] = {11,13,211,321,2212};
+  //this is not the correct way to do it, since there might be double counting
   if (fpTmin<Track->GetPt()&&Track->GetPt()<fpTmax) {
     if (fetamin<Track->GetEta().at(0)&&Track->GetEta().at(0)<fetamax) {
       if(!fcutCharge){

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackCuts.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackCuts.h
@@ -1,0 +1,123 @@
+/*
+ * AliFemtoDreamTrackCuts.h
+ *
+ *  Created on: Nov 14, 2017
+ *      Author: gu74req
+ */
+
+#ifndef ALIFEMTODREAMTRACKCUTS_H_
+#define ALIFEMTODREAMTRACKCUTS_H_
+#include "Rtypes.h"
+#include "AliFemtoDreamTrack.h"
+#include "AliFemtoDreamTrackMCHist.h"
+#include "AliFemtoDreamTrackHist.h"
+
+class AliFemtoDreamTrackCuts {
+ public:
+  AliFemtoDreamTrackCuts();
+  virtual ~AliFemtoDreamTrackCuts();
+  static AliFemtoDreamTrackCuts *PrimProtonCuts(bool isMC,bool DCAPlots,
+                                                bool CombSigma,
+                                                bool ContribSplitting);
+  static AliFemtoDreamTrackCuts *DecayProtonCuts(bool isMC,
+                                                 bool ContribSplitting);
+  static AliFemtoDreamTrackCuts *DecayPionCuts(bool isMC,
+                                               bool ContribSplitting);
+  static AliFemtoDreamTrackCuts *Xiv0PionCuts(bool isMC,
+                                               bool ContribSplitting);
+  static AliFemtoDreamTrackCuts *Xiv0ProtonCuts(bool isMC,
+                                               bool ContribSplitting);
+  static AliFemtoDreamTrackCuts *XiBachPionCuts(bool isMC,
+                                               bool ContribSplitting);
+//  static AliFemtoDreamTrackCuts *OmegaKaonCuts(bool isMC,
+//                                               bool ContribSplitting);
+
+  //Setters for Plots
+  void SetPlotDCADist(bool plot) {fDCAPlots=plot;};
+  void SetPlotCombSigma(bool plot) {fCombSigma=plot;};
+  void SetPlotContrib(bool plot) {fContribSplitting=plot;};
+  void SetIsMonteCarlo(bool isMC) {fMCData=isMC;};
+  void SetFillQALater(bool FillLater){fFillQALater=FillLater;};
+  bool GetIsMonteCarlo() {return fMCData;};
+  //Setters for the Track Cuts
+  void SetCheckFilterBit(bool check){fCheckFilterBit = check;};
+  void SetFilterBit(UInt_t FilterBit){fFilterBit = FilterBit; fCheckFilterBit = kTRUE;};
+  void SetPtRange(double pmin, double pmax){fpTmin = pmin; fpTmax = pmax; fcutPt = kTRUE;};
+  void SetEtaRange(double etamin, double etamax){fetamin=etamin; fetamax=etamax; fcutEta = kTRUE;};
+  double GetEtaMin() {return fetamin;}
+  double GetEtaMax() {return fetamax;}
+  void SetCutCharge(int charge){fcutCharge = kTRUE; fCharge = charge;};
+  void SetCheckPileUpITS(bool check){fCheckPileUpITS=check;};
+  void SetCheckPileUpTOF(bool check){fCheckPileUpTOF=check;};
+  void SetCheckPileUp(bool check){fCheckPileUp=check;};
+  void SetNClsTPC(int nCls){fnTPCCls = nCls; fcutnTPCCls = kTRUE;};
+  void SetDCAReCalculation(bool which){fDCAProp = which;};
+  void SetDCAVtxXY(double dcaXY){fDCAToVertexXY = dcaXY; fCutDCAToVtxXY = kTRUE;};
+  void SetCutDCAVtxXY(bool cutdcaXY){fCutDCAToVtxXY = cutdcaXY;};
+  void SetDCAVtxZ(double dcaZ){fDCAToVertexZ = dcaZ; fCutDCAToVtxZ = kTRUE;};
+  void SetCutDCAVtxZ(bool cutdcaZ){fCutDCAToVtxZ = cutdcaZ;};
+  void SetCutSharedCls(bool cutit){fCutSharedCls = cutit;};
+  void SetCheckTPCRefit(bool cutit){fCheckTPCRefit=cutit;};
+  void SetCutTPCCrossedRows(bool cutit){fCutTPCCrossedRows = cutit;};
+  void SetPID(AliPID::EParticleType pid, double pTPChresh, double sigVal = 3.)
+  {fParticleID = pid; fPIDPTPCThreshold = pTPChresh; fNSigValue = sigVal; fCutPID = kTRUE;};
+  void SetRejLowPtPionsTOF(bool use){fRejectPions = use;};
+  void SetCutSmallestSig(bool cutit){fCutHighPtSig = cutit;};
+  //selection Methods
+  bool isSelected(AliFemtoDreamTrack *Track);
+  void BookQA(AliFemtoDreamTrack *Track);
+  void BookMC(AliFemtoDreamTrack *Track);
+//  void FillSharedClusterQA(AliFemtoDreamTrack *Track);
+  //Histogram things
+  void Init();
+  TList *GetQAHists() {return fHists->GetHistList();};
+  TList *GetMCQAHists() {return fMCHists->GetHistList();};
+  TString ClassName() {return "AliFemtoDreamTrackCuts";};
+  void SetName(TString name){fHists->SetName(name.Data());};
+ private:
+  bool TrackingCuts(AliFemtoDreamTrack *Track);
+  bool PIDAODCuts(AliFemtoDreamTrack *Track);
+  bool SmallestNSig(AliFemtoDreamTrack *Track);
+  bool DCACuts(AliFemtoDreamTrack *Track);
+  void BookTrackCuts();
+  void FillMCContributions(AliFemtoDreamTrack *Track);
+  AliFemtoDreamTrackMCHist *fMCHists; //!
+  AliFemtoDreamTrackHist *fHists;     //!
+  bool fMCData;                       //
+  bool fDCAPlots;                     //
+  bool fCombSigma;                    //
+  bool fContribSplitting;             //
+  bool fFillQALater;                  //
+  bool fCheckFilterBit;               //
+  bool fCheckPileUpITS;               //
+  bool fCheckPileUpTOF;               //
+  bool fCheckPileUp;                  //  Should only be used for Daughters of v0s
+  UInt_t fFilterBit;                  //
+  double fpTmin;                      //
+  double fpTmax;                      //
+  bool fcutPt;                        //
+  double fetamin;                     //
+  double fetamax;                     //
+  bool fcutEta;                       //
+  bool fcutCharge;                    //
+  int fCharge;                        //
+  int fnTPCCls;                       //
+  bool fcutnTPCCls;                   //
+  bool fDCAProp;                      //  kTRUE means that the DCA gets recalculated by PropagateToDCA, kFALSE just uses the info stored in the AOD
+  double fDCAToVertexXY;              //
+  bool fCutDCAToVtxXY;                //
+  double fDCAToVertexZ;               //
+  bool fCutDCAToVtxZ;                 //
+  bool fCutSharedCls;                 //
+  bool fCheckTPCRefit;                //
+  bool fCutTPCCrossedRows;            //
+  bool fCutPID;                       //
+  bool fCutHighPtSig;                 // Reject tracks which have a lower Sigma for other particles (implemented for electrons, pion, kaons and protons)
+  AliPID::EParticleType fParticleID;  //
+  double fNSigValue;                  // defaults to 3
+  double fPIDPTPCThreshold;           // defaults to 0
+  bool fRejectPions;                  // Supress Pions at low pT with the TOF, if information is available
+  ClassDef(AliFemtoDreamTrackCuts,1);
+};
+
+#endif /* ALIFEMTODREAMTRACKCUTS_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackHist.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackHist.cxx
@@ -1,0 +1,317 @@
+/*
+ * AliFemtoDreamTrackHist.cxx
+ *
+ *  Created on: Nov 14, 2017
+ *      Author: gu74req
+ */
+
+#include "AliFemtoDreamTrackHist.h"
+#include "TMath.h"
+ClassImp(AliFemtoDreamTrackHist)
+AliFemtoDreamTrackHist::AliFemtoDreamTrackHist()
+:fHistList(0)
+,fConfig(0)
+,fCutCounter(0)
+,fDCAXYPtBins(0)
+,fNSigCom(0)
+{
+  for (int i=0;i<2;++i) {
+    fTrackCutQA[i]=0;
+    fpTDist[i]=0;
+    fpTPCDist[i]=0;
+    fetaDist[i]=0;
+    fphiDist[i]=0;
+    fTPCCls[i]=0;
+    fTPCClsS[i]=0;
+    fShrdClsITS[i]=0;
+    fDCAxy[i]=0;
+    fDCAz[i]=0;
+    fTPCCrossedRows[i]=0;
+    fTPCRatio[i]=0;
+    fTPCdedx[i]=0;
+    fTOFbeta[i]=0;
+    fNSigTPC[i]=0;
+    fNSigTOF[i]=0;
+    fTPCStatus[i]=0;
+    fTOFStatus[i]=0;
+    fTPCClsCPiluUp[i]=0;
+    fITShrdClsPileUp[i]=0;
+  }
+}
+AliFemtoDreamTrackHist::AliFemtoDreamTrackHist(bool DCADist,bool CombSig) {
+  TString sName[2] = {"before", "after"};
+  double ptmin = 0;
+  double ptmax = 5;
+  int ptBins = 100;
+  int twoDBins = 400;
+  fHistList = new TList();
+  fHistList->SetName("TrackCuts");
+  fHistList->SetOwner();
+
+  fConfig = new TProfile("TrackCutConfig", "Track Cut Config", 21, 0, 21);
+  fConfig->SetStats(0);
+  fConfig->GetXaxis()->SetBinLabel(1, "pT_{min}");
+  fConfig->GetXaxis()->SetBinLabel(2, "pT_{max}");
+  fConfig->GetXaxis()->SetBinLabel(3, "#eta_{min}");
+  fConfig->GetXaxis()->SetBinLabel(4, "#eta_{max}");
+  fConfig->GetXaxis()->SetBinLabel(5, "Charge");
+  fConfig->GetXaxis()->SetBinLabel(6, "ClsTPC_{min}");
+  fConfig->GetXaxis()->SetBinLabel(7, "Filter Bit");
+  fConfig->GetXaxis()->SetBinLabel(8, "Is MC");
+  fConfig->GetXaxis()->SetBinLabel(9, "DCA_{xy}");
+  fConfig->GetXaxis()->SetBinLabel(10, "DCA_{z}");
+  fConfig->GetXaxis()->SetBinLabel(11, "Shared Cls");
+  fConfig->GetXaxis()->SetBinLabel(12, "TPC Crossed Rows");
+  fConfig->GetXaxis()->SetBinLabel(13, "PID Mom Thresh");
+  fConfig->GetXaxis()->SetBinLabel(14, "PID nsig");
+  fConfig->GetXaxis()->SetBinLabel(15, "Reject Pions");
+  fConfig->GetXaxis()->SetBinLabel(16, "Smallest Sig");
+  fConfig->GetXaxis()->SetBinLabel(17, "ITS Hit");
+  fConfig->GetXaxis()->SetBinLabel(18, "TOF Timing");
+  fConfig->GetXaxis()->SetBinLabel(19, "Pile Up Rej");
+  fConfig->GetXaxis()->SetBinLabel(20, "TPC Refit");
+
+  fHistList->Add(fConfig);
+
+  fCutCounter = new TH1F("CutCounter", "Cut Counter", 22, 0, 22);
+  fCutCounter->GetXaxis()->SetBinLabel(1, "Input");
+  fCutCounter->GetXaxis()->SetBinLabel(2, "Filter Bit");
+  fCutCounter->GetXaxis()->SetBinLabel(3, "p_{T} Cut");
+  fCutCounter->GetXaxis()->SetBinLabel(4, "#eta Cut");
+  fCutCounter->GetXaxis()->SetBinLabel(5, "Charge");
+  fCutCounter->GetXaxis()->SetBinLabel(6, "PileUpITS");
+  fCutCounter->GetXaxis()->SetBinLabel(7, "PileUpTOF");
+  fCutCounter->GetXaxis()->SetBinLabel(8, "PileUp");
+  fCutCounter->GetXaxis()->SetBinLabel(9, "nClsTPC");
+  fCutCounter->GetXaxis()->SetBinLabel(10, "Shared Cls");
+  fCutCounter->GetXaxis()->SetBinLabel(11, "TPC Refit");
+  fCutCounter->GetXaxis()->SetBinLabel(12, "TPC Crossed Rows");
+  fCutCounter->GetXaxis()->SetBinLabel(13, "TPC Row Ratio");
+  fCutCounter->GetXaxis()->SetBinLabel(14, "TPC OK");
+  fCutCounter->GetXaxis()->SetBinLabel(15, "Reject Pions");
+  fCutCounter->GetXaxis()->SetBinLabel(16, "TPC PID");
+  fCutCounter->GetXaxis()->SetBinLabel(17, "TPC TOF OK");
+  fCutCounter->GetXaxis()->SetBinLabel(18, "TPC TOF PID");
+  fCutCounter->GetXaxis()->SetBinLabel(19, "Smallest Sig");
+  fCutCounter->GetXaxis()->SetBinLabel(20, "Passes PID");
+  fCutCounter->GetXaxis()->SetBinLabel(21, "DCA_{Z}");
+  fCutCounter->GetXaxis()->SetBinLabel(22, "DCA_{XY}");
+
+  fHistList->Add(fCutCounter);
+
+  for (int i = 0;i<2;++i) {
+    fTrackCutQA[i] = new TList();
+    fTrackCutQA[i]->SetName(sName[i].Data());
+    fTrackCutQA[i]->SetOwner();
+    fHistList->Add(fTrackCutQA[i]);
+
+    TString ptName=Form("pTDist_%s", sName[i].Data());
+    fpTDist[i] = new TH1F(ptName.Data(), ptName.Data(), ptBins, ptmin, ptmax);
+    fpTDist[i]->Sumw2();
+    fpTDist[i]->GetXaxis()->SetTitle("p_{T}");
+    fTrackCutQA[i]->Add(fpTDist[i]);
+
+    TString pTPCName=Form("pTPCDist_%s", sName[i].Data());
+    fpTPCDist[i] = new TH1F(pTPCName.Data(), pTPCName.Data(), ptBins, ptmin, ptmax);
+    fpTPCDist[i]->Sumw2();
+    fpTPCDist[i]->GetXaxis()->SetTitle("p_{TPC}");
+    fTrackCutQA[i]->Add(fpTPCDist[i]);
+
+    TString etaName = Form("EtaDist_%s", sName[i].Data());
+    fetaDist[i] = new TH1F(etaName.Data(), etaName.Data(), 200, -10., 10.);
+    fetaDist[i]->Sumw2();
+    fetaDist[i]->GetXaxis()->SetTitle("#eta");
+    fTrackCutQA[i]->Add(fetaDist[i]);
+
+    TString phiName = Form("phiDist_%s", sName[i].Data());
+    fphiDist[i] = new TH1F(phiName.Data(), phiName.Data(), 200, 0., 2*TMath::Pi());
+    fphiDist[i]->Sumw2();
+    fphiDist[i]->GetXaxis()->SetTitle("#phi");
+    fTrackCutQA[i]->Add(fphiDist[i]);
+
+    TString TPCName = Form("TPCCls_%s", sName[i].Data());
+    fTPCCls[i] = new TH1F(TPCName.Data(), TPCName.Data(), 100, 0, 200.);
+    fTPCCls[i]->Sumw2();
+    fTPCCls[i]->GetXaxis()->SetTitle("# cls TPC");
+    fTrackCutQA[i]->Add(fTPCCls[i]);
+
+    TString DCAXYName = Form("DCAXY_%s", sName[i].Data());
+    fDCAxy[i] = new TH2F(DCAXYName.Data(), DCAXYName.Data(), ptBins, ptmin, ptmax, 2.5*twoDBins, -5., 5.);
+    fDCAxy[i]->Sumw2();
+    fDCAxy[i]->GetXaxis()->SetTitle("p_{T}");
+    fDCAxy[i]->GetYaxis()->SetTitle("DCA_{xy}");
+
+    fTrackCutQA[i]->Add(fDCAxy[i]);
+
+    TString DCAZName = Form("DCAZ_%s", sName[i].Data());
+    fDCAz[i] = new TH2F(DCAZName.Data(), DCAZName.Data(), ptBins, ptmin, ptmax, 2.5*twoDBins, -5., 5.);
+    fDCAz[i]->Sumw2();
+    fDCAz[i]->GetXaxis()->SetTitle("p_{T}");
+    fDCAz[i]->GetYaxis()->SetTitle("DCA_{z}");
+    fTrackCutQA[i]->Add(fDCAz[i]);
+
+    TString TPCCRName = Form("CrossedRows_%s", sName[i].Data());
+    fTPCCrossedRows[i] = new TH1F(TPCCRName.Data(), TPCCRName.Data(), 100, 0, 200.);
+    fTPCCrossedRows[i]->Sumw2();
+    fTPCCrossedRows[i]->GetXaxis()->SetTitle("# of crossed Rows");
+    fTrackCutQA[i]->Add(fTPCCrossedRows[i]);
+
+    TString TPCratioName = Form("TPCRatio_%s", sName[i].Data());
+    fTPCRatio[i] = new TH1F(TPCratioName.Data(), TPCratioName.Data(), 100, 0., 2.);
+    fTPCRatio[i]->Sumw2();
+    fTPCRatio[i]->GetXaxis()->SetTitle("Ratio");
+    fTrackCutQA[i]->Add(fTPCRatio[i]);
+
+    TString TPCClsSName=Form("TPCClsS_%s",sName[i].Data());
+    fTPCClsS[i]=new TH1F(TPCClsSName.Data(),TPCClsSName.Data(),200,0,200);
+    fTPCClsS[i]->Sumw2();
+    fTPCClsS[i]->GetXaxis()->SetTitle("TPC Cls S");
+    fTrackCutQA[i]->Add(fTPCClsS[i]);
+
+    TString ShrdClsITSName=Form("SharedClsITS_%s",sName[i].Data());
+    fShrdClsITS[i]=new TH2F(ShrdClsITSName.Data(),ShrdClsITSName.Data(),
+                            6,1,7,2,0,2);
+    fShrdClsITS[i]->Sumw2();
+    fShrdClsITS[i]->GetXaxis()->SetTitle("ITS Layer");
+    fShrdClsITS[i]->GetYaxis()->SetBinLabel(1,"Has shared Cls");
+    fShrdClsITS[i]->GetYaxis()->SetBinLabel(2,"Has no Shard Cls");
+    fTrackCutQA[i]->Add(fShrdClsITS[i]);
+
+    TString TPCdedxName = Form("TPCdedx_%s", sName[i].Data());
+    fTPCdedx[i] = new TH2F(TPCdedxName.Data(), TPCdedxName.Data(), ptBins, ptmin, ptmax, 2*twoDBins, 0., 400);
+    fTPCdedx[i]->Sumw2();
+    fTPCdedx[i]->GetXaxis()->SetTitle("p_{TPC}");
+    fTPCdedx[i]->GetYaxis()->SetTitle("dEdx (arb. Units)");
+
+    fTrackCutQA[i]->Add(fTPCdedx[i]);
+
+    TString TOFbetaName = Form("TOFbeta_%s", sName[i].Data());
+    fTOFbeta[i] = new TH2F(TOFbetaName.Data(), TOFbetaName.Data(), ptBins, ptmin, ptmax, 3.5*twoDBins, 0.4, 1.1);
+    fTOFbeta[i]->Sumw2();
+    fTOFbeta[i]->GetXaxis()->SetTitle("p_{TPC}");
+    fTOFbeta[i]->GetYaxis()->SetTitle("#beta_{TOF}");
+
+    fTrackCutQA[i]->Add(fTOFbeta[i]);
+
+    TString NSigTPCName = Form("NSigTPC_%s", sName[i].Data());
+    fNSigTPC[i] = new TH2F(NSigTPCName.Data(), NSigTPCName.Data(), ptBins, ptmin, ptmax, 3.*twoDBins, -60., 60.);
+    fNSigTPC[i]->Sumw2();
+    fNSigTPC[i]->GetXaxis()->SetTitle("p_{TPC}");
+    fNSigTPC[i]->GetYaxis()->SetTitle("n#sigma_{TPC}");
+
+    fTrackCutQA[i]->Add(fNSigTPC[i]);
+
+    TString NSigTOFName = Form("NSigTOF_%s", sName[i].Data());
+    fNSigTOF[i] = new TH2F(NSigTOFName.Data(), NSigTOFName.Data(), ptBins, ptmin, ptmax, 3.*twoDBins, -60., 60.);
+    fNSigTOF[i]->Sumw2();
+    fNSigTOF[i]->GetXaxis()->SetTitle("p_{TPC}");
+    fNSigTOF[i]->GetYaxis()->SetTitle("n#sigma_{TOF}");
+
+    fTrackCutQA[i]->Add(fNSigTOF[i]);
+
+    TString TPCstatusname = Form("TPCStatus_%s",sName[i].Data());
+    fTPCStatus[i] = new TH1F(TPCstatusname.Data(),TPCstatusname.Data(),4,0,4);
+    fTPCStatus[i]->GetXaxis()->SetBinLabel(1, "kDetNoSignal");
+    fTPCStatus[i]->GetXaxis()->SetBinLabel(2, "kDetPidOk");
+    fTPCStatus[i]->GetXaxis()->SetBinLabel(3, "kDetMismatch");
+    fTPCStatus[i]->GetXaxis()->SetBinLabel(4, "kDetNoParams");
+
+    fTrackCutQA[i]->Add(fTPCStatus[i]);
+
+    TString TOFstatusname = Form("TOFStatus_%s",sName[i].Data());
+    fTOFStatus[i] = new TH1F(TOFstatusname.Data(),TOFstatusname.Data(),4,0,4);
+    fTOFStatus[i]->GetXaxis()->SetBinLabel(1, "kDetNoSignal");
+    fTOFStatus[i]->GetXaxis()->SetBinLabel(2, "kDetPidOk");
+    fTOFStatus[i]->GetXaxis()->SetBinLabel(3, "kDetMismatch");
+    fTOFStatus[i]->GetXaxis()->SetBinLabel(4, "kDetNoParams");
+
+    fTrackCutQA[i]->Add(fTOFStatus[i]);
+
+    TString TPCClsCPileUpName=Form("TPCClsCPileUp_%s",sName[i].Data());
+    fTPCClsCPiluUp[i]=new TH2F(TPCClsCPileUpName.Data(),
+                               TPCClsCPileUpName.Data(),
+                               15,0,15,200,0,200);
+    fTPCClsCPiluUp[i]->Sumw2();
+    fTPCClsCPiluUp[i]->GetXaxis()->SetBinLabel(1,"Hit ITS Layer 1");
+    fTPCClsCPiluUp[i]->GetXaxis()->SetBinLabel(2,"Hit ITS Layer 2");
+    fTPCClsCPiluUp[i]->GetXaxis()->SetBinLabel(3,"Hit ITS Layer 3");
+    fTPCClsCPiluUp[i]->GetXaxis()->SetBinLabel(4,"Hit ITS Layer 4");
+    fTPCClsCPiluUp[i]->GetXaxis()->SetBinLabel(5,"Hit ITS Layer 5");
+    fTPCClsCPiluUp[i]->GetXaxis()->SetBinLabel(6,"Hit ITS Layer 6");
+    fTPCClsCPiluUp[i]->GetXaxis()->SetBinLabel(7,"TOF Bunch.Xing");
+    fTPCClsCPiluUp[i]->GetXaxis()->SetBinLabel(8,"no Hit ITS Layer 1");
+    fTPCClsCPiluUp[i]->GetXaxis()->SetBinLabel(9,"no Hit ITS Layer 2");
+    fTPCClsCPiluUp[i]->GetXaxis()->SetBinLabel(10,"no Hit ITS Layer 3");
+    fTPCClsCPiluUp[i]->GetXaxis()->SetBinLabel(11,"no Hit ITS Layer 4");
+    fTPCClsCPiluUp[i]->GetXaxis()->SetBinLabel(12,"no Hit ITS Layer 5");
+    fTPCClsCPiluUp[i]->GetXaxis()->SetBinLabel(13,"no Hit ITS Layer 6");
+    fTPCClsCPiluUp[i]->GetXaxis()->SetBinLabel(14,"no TOF Bunch.Xing");
+    fTPCClsCPiluUp[i]->GetXaxis()->SetBinLabel(15,"all ITS-TOF Req false");
+    fTrackCutQA[i]->Add(fTPCClsCPiluUp[i]);
+
+    TString ITSShrdClsPileUpName=Form("ITSShrdClsPileUp_%s",sName[i].Data());
+    fITShrdClsPileUp[i]=new TH2F(ITSShrdClsPileUpName.Data(),
+                                 ITSShrdClsPileUpName.Data(),
+                                 15,0,15,12,0,12);
+    fITShrdClsPileUp[i]->Sumw2();
+    fITShrdClsPileUp[i]->GetXaxis()->SetBinLabel(1,"Hit ITS Layer 1");
+    fITShrdClsPileUp[i]->GetXaxis()->SetBinLabel(2,"Hit ITS Layer 2");
+    fITShrdClsPileUp[i]->GetXaxis()->SetBinLabel(3,"Hit ITS Layer 3");
+    fITShrdClsPileUp[i]->GetXaxis()->SetBinLabel(4,"Hit ITS Layer 4");
+    fITShrdClsPileUp[i]->GetXaxis()->SetBinLabel(5,"Hit ITS Layer 5");
+    fITShrdClsPileUp[i]->GetXaxis()->SetBinLabel(6,"Hit ITS Layer 6");
+    fITShrdClsPileUp[i]->GetXaxis()->SetBinLabel(7,"TOF Bunch.Xing");
+    fITShrdClsPileUp[i]->GetXaxis()->SetBinLabel(8,"no Hit ITS Layer 1");
+    fITShrdClsPileUp[i]->GetXaxis()->SetBinLabel(9,"no Hit ITS Layer 2");
+    fITShrdClsPileUp[i]->GetXaxis()->SetBinLabel(10,"no Hit ITS Layer 3");
+    fITShrdClsPileUp[i]->GetXaxis()->SetBinLabel(11,"no Hit ITS Layer 4");
+    fITShrdClsPileUp[i]->GetXaxis()->SetBinLabel(12,"no Hit ITS Layer 5");
+    fITShrdClsPileUp[i]->GetXaxis()->SetBinLabel(13,"no Hit ITS Layer 6");
+    fITShrdClsPileUp[i]->GetXaxis()->SetBinLabel(14,"no Hit TOF Bunch.Xing");
+    fITShrdClsPileUp[i]->GetXaxis()->SetBinLabel(15,"all Hit ITS-TOF Req false");
+
+    fITShrdClsPileUp[i]->GetYaxis()->SetBinLabel(1,"Has shared Cls Layer 1");
+    fITShrdClsPileUp[i]->GetYaxis()->SetBinLabel(2,"Has shared Cls Layer 2");
+    fITShrdClsPileUp[i]->GetYaxis()->SetBinLabel(3,"Has shared Cls Layer 3");
+    fITShrdClsPileUp[i]->GetYaxis()->SetBinLabel(4,"Has shared Cls Layer 4");
+    fITShrdClsPileUp[i]->GetYaxis()->SetBinLabel(5,"Has shared Cls Layer 5");
+    fITShrdClsPileUp[i]->GetYaxis()->SetBinLabel(6,"Has shared Cls Layer 6");
+    fITShrdClsPileUp[i]->GetYaxis()->SetBinLabel(7,"Has no Shard Cls 1");
+    fITShrdClsPileUp[i]->GetYaxis()->SetBinLabel(8,"Has no Shard Cls 2");
+    fITShrdClsPileUp[i]->GetYaxis()->SetBinLabel(9,"Has no Shard Cls 3");
+    fITShrdClsPileUp[i]->GetYaxis()->SetBinLabel(10,"Has no Shard Cls 4");
+    fITShrdClsPileUp[i]->GetYaxis()->SetBinLabel(11,"Has no Shard Cls 5");
+    fITShrdClsPileUp[i]->GetYaxis()->SetBinLabel(12,"Has no Shard Cls 6");
+    fTrackCutQA[i]->Add(fITShrdClsPileUp[i]);
+  }
+  if (CombSig) {
+    fNSigCom = new TH3F("NSigComb","NSigComb",14,0.5,4.0,300,-30,30,300,-30,30);
+    fHistList->Add(fNSigCom);
+    fNSigCom->Sumw2();
+  } else {
+    fNSigCom=0;
+  }
+  if (DCADist) {
+    TString dcaPtBinName = Form("DCAXYPtBinningTot");
+    fDCAXYPtBins = new TH2F(dcaPtBinName.Data(), dcaPtBinName.Data(),20,0.5,4.05,500,-5,5);
+    fDCAXYPtBins->Sumw2();
+    fDCAXYPtBins->GetXaxis()->SetTitle("P#_{T}");
+    fDCAXYPtBins->GetYaxis()->SetTitle("dca_{XY}");
+    fHistList->Add(fDCAXYPtBins);
+  } else {
+    fDCAXYPtBins=0;
+  }
+}
+AliFemtoDreamTrackHist::~AliFemtoDreamTrackHist() {
+  delete fHistList;
+}
+
+void AliFemtoDreamTrackHist::FillNSigComb(
+    double pT,double nSigTPC,double nSigTOF)
+{
+  fNSigCom->Fill(pT,nSigTPC,nSigTOF);
+}
+
+void AliFemtoDreamTrackHist::FillDCAXYPtBins(double pT,double dcaxy) {
+  fDCAXYPtBins->Fill(pT,dcaxy);
+}

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackHist.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackHist.h
@@ -1,0 +1,97 @@
+/*
+ * AliFemtoDreamTrackHist.h
+ *
+ *  Created on: Nov 14, 2017
+ *      Author: gu74req
+ */
+
+#ifndef ALIFEMTODREAMTRACKHIST_H_
+#define ALIFEMTODREAMTRACKHIST_H_
+#include "AliPIDResponse.h"
+#include "Rtypes.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TH3F.h"
+#include "TList.h"
+#include "TProfile.h"
+
+class AliFemtoDreamTrackHist {
+ public:
+  AliFemtoDreamTrackHist();
+  AliFemtoDreamTrackHist(bool DCADist,bool CombSig);
+  virtual ~AliFemtoDreamTrackHist();
+  void FillConfig(int iBin, double val){fConfig->Fill(iBin, val);};
+  void FillTrackCounter(int iBin){fCutCounter->Fill(iBin);};
+  void FillpTCut(int i, double pT){fpTDist[i]->Fill(pT);};
+  void FillpTPCCut(int i, double pTPC){fpTPCDist[i]->Fill(pTPC);};
+  void FilletaCut(int i, double eta){fetaDist[i]->Fill(eta);};
+  void FillphiCut(int i, double phi){fphiDist[i]->Fill(phi);};
+  void FillTPCclsCut(int i, double nCls){fTPCCls[i]->Fill(nCls);};
+  void FillDCAxyCut(int i, double pT, double dcaxy){
+    fDCAxy[i]->Fill(pT, dcaxy);};
+  void FillDCAzCut(int i, double pT, double dcaz){fDCAz[i]->Fill(pT, dcaz);};
+  void FillTPCCrossedRowCut(int i, float Crossed){
+    fTPCCrossedRows[i]->Fill(Crossed);
+  };
+  void FillTPCRatioCut(int i, float ratio){fTPCRatio[i]->Fill(ratio);};
+  void FillTPCClsS(int i, double TPCClsS){fTPCClsS[i]->Fill(TPCClsS);};
+  void FillHasSharedClsITS(int i,int layer,int yesno){
+    fShrdClsITS[i]->Fill(layer,yesno);};
+  void FillTPCdedx(int i, double mom, double dedx){
+    fTPCdedx[i]->Fill(mom,dedx);
+  };
+  void FillTOFbeta(int i, double mom, double beta){
+    fTOFbeta[i]->Fill(mom,beta);
+  };
+  void FillNSigTPC(int i, double mom, double nSigTPC){
+    fNSigTPC[i]->Fill(mom, nSigTPC);
+  };
+  void FillNSigTOF(int i, double mom, double nSigTOF){
+    fNSigTOF[i]->Fill(mom, nSigTOF);
+  };
+  void FillTPCStatus(int i, AliPIDResponse::EDetPidStatus statusTPC){
+    fTPCStatus[i]->Fill(statusTPC);
+  };
+  void FillTOFStatus(int i, AliPIDResponse::EDetPidStatus statusTOF){
+    fTOFStatus[i]->Fill(statusTOF);
+  };
+  void FillNSigComb(double pT, double nSigTPC, double nSigTOF);
+  void FillDCAXYPtBins(double pT, double dcaxy);
+  void FillTPCClsCPileUp(int i,int iCrit,double TPCClsC){
+    fTPCClsCPiluUp[i]->Fill(iCrit,TPCClsC);
+  }
+  void FillITSSharedPileUp(int i,int iCrit,int yesno){
+    fITShrdClsPileUp[i]->Fill(iCrit,yesno);
+  }
+  void SetName(TString name){fHistList->SetName(name.Data());};
+  TList *GetHistList(){return fHistList;};
+ private:
+  TList *fHistList;         //!
+  TList *fTrackCutQA[2];    //!
+  TProfile *fConfig;        //!
+  TH1F *fCutCounter;        //!
+  TH1F *fpTDist[2];         //!
+  TH1F *fpTPCDist[2];       //!
+  TH1F *fetaDist[2];        //!
+  TH1F *fphiDist[2];        //!
+  TH1F *fTPCCls[2];         //!
+  TH2F *fShrdClsITS[2];     //!
+  TH2F *fDCAxy[2];          //!
+  TH2F *fDCAz[2];           //!
+  TH2F *fDCAXYPtBins;       //!
+  TH1F *fTPCCrossedRows[2]; //!
+  TH1F *fTPCRatio[2];       //!
+  TH1F *fTPCClsS[2];        //!
+  TH2F *fTPCdedx[2];        //!
+  TH2F *fTOFbeta[2];        //!
+  TH2F *fNSigTPC[2];        //!
+  TH2F *fNSigTOF[2];        //!
+  TH1F *fTPCStatus[2];      //!
+  TH1F *fTOFStatus[2];      //!
+  TH3F *fNSigCom;           //!
+  TH2F *fTPCClsCPiluUp[2];  //!
+  TH2F *fITShrdClsPileUp[2];//!
+  ClassDef(AliFemtoDreamTrackHist,1);
+};
+
+#endif /* ALIFEMTODREAMTRACKHIST_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackMCHist.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackMCHist.cxx
@@ -1,0 +1,290 @@
+/*
+ * AliFemtoDreamTrackMCHist.cxx
+ *
+ *  Created on: Nov 14,2017
+ *      Author: gu74req
+ */
+
+#include "AliFemtoDreamTrackMCHist.h"
+#include "AliLog.h"
+AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist()
+:fpTmin(0.5)
+,fpTmax(4.05)
+,fpTbins(20)
+,fDoSplitting(false)
+,fDoDCAPlots(false)
+,fMCList(0)
+,fDCAPlots(0)
+,fMCCorrPt(0)
+,fMCIdentPt(0)
+,fMCGenPt(0)
+,fMCContPt(0)
+,fMCUnknownPt(0)
+,fMCPrimaryPt(0)
+,fMCMaterialPt(0)
+,fMCFeeddownWeakPt(0)
+,fMCPrimDCAXYPtBins(0)
+,fMCMaterialDCAXYPtBins(0)
+,fMCSecondaryDCAXYPtBins(0)
+,fMCSecLambdaDCAXYPtBins(0)
+,fMCSecSigmaDCAXYPtBins(0)
+{
+  for (int i=0;i<4;++i) {
+    fMCQAPlots[i]=0;
+    fMCpTPCDist[i]=0;
+    fMCetaDist[i]=0;
+    fMCphiDist[i]=0;
+    fMCTPCCls[i]=0;
+    fMCDCAxy[i]=0;
+    fMCDCAz[i]=0;
+    fMCTPCCrossedRows[i]=0;
+    fMCTPCRatio[i]=0;
+    fMCTPCdedx[i]=0;
+    fMCTOFbeta[i]=0;
+    fMCNSigTPC[i]=0;
+    fMCNSigTOF[i]=0;
+  }
+}
+
+AliFemtoDreamTrackMCHist::~AliFemtoDreamTrackMCHist()
+{
+  if (fMCList) {
+    delete fMCList;
+  }
+}
+
+AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,bool DCADist)
+:fpTmin(0.5)
+,fpTmax(4.05)
+,fpTbins(20)
+,fDoSplitting(contribSplitting)
+,fDoDCAPlots(DCADist)
+{
+  double ptmin=0;
+  double ptmax=5;
+  double ptBins=200;
+  double twoDBins=400;
+  fMCList=new TList();
+  fMCList->SetName("MonteCarlo");
+  fMCList->SetOwner();
+
+  fMCCorrPt=new TH1F("CorrParPt","Correct Particles Pt",ptBins,ptmin,ptmax);
+  fMCCorrPt->Sumw2();
+  fMCCorrPt->GetXaxis()->SetTitle("p_{T}");
+  fMCList->Add(fMCCorrPt);
+
+  fMCIdentPt=new TH1F("IdentPartPt","Ident Particles Pt",ptBins,ptmin,ptmax);
+  fMCIdentPt->Sumw2();
+  fMCIdentPt->GetXaxis()->SetTitle("p_{T}");
+  fMCList->Add(fMCIdentPt);
+
+  fMCGenPt=new TH1F("GenPartPt","Gen Particles Pt",ptBins,ptmin,ptmax);
+  fMCGenPt->Sumw2();
+  fMCGenPt->GetXaxis()->SetTitle("p_{T}");
+  fMCList->Add(fMCGenPt);
+
+  fMCContPt=new TH1F("ContPt","ContPt",ptBins,ptmin,ptmax);
+  fMCContPt->Sumw2();
+  fMCContPt->GetXaxis()->SetTitle("p_{T}");
+  fMCList->Add(fMCContPt);
+
+  fMCUnknownPt=new TH1F("UnknPt","UnknPt",ptBins,ptmin,ptmax);
+  fMCUnknownPt->Sumw2();
+  fMCUnknownPt->GetXaxis()->SetTitle("p_{T}");
+  fMCList->Add(fMCUnknownPt);
+
+  fMCPrimaryPt=new TH1F("PrimaryPt","PrimaryPt",ptBins,ptmin,ptmax);
+  fMCPrimaryPt->Sumw2();
+  fMCPrimaryPt->GetXaxis()->SetTitle("p_{T}");
+  fMCList->Add(fMCPrimaryPt);
+
+  fMCMaterialPt=new TH1F("MatPt","MatPT",ptBins,ptmin,ptmax);
+  fMCMaterialPt->Sumw2();
+  fMCMaterialPt->GetXaxis()->SetTitle("p_{T}");
+  fMCList->Add(fMCMaterialPt);
+
+  fMCFeeddownWeakPt=new TH2F("FeeddownPt","Feeddown Pt",ptBins,ptmin,ptmax,
+                             213,3121,3334);
+  fMCFeeddownWeakPt->Sumw2();
+  fMCFeeddownWeakPt->GetXaxis()->SetTitle("p_{T}");
+  fMCList->Add(fMCFeeddownWeakPt);
+
+  if (contribSplitting) {
+    TString MCModes[4]={"Primary","Secondary","Material","Contamination"};
+    for (int i=0;i<4;++i) {
+      fMCQAPlots[i]=new TList();
+      fMCQAPlots[i]->SetName(MCModes[i].Data());
+      fMCQAPlots[i]->SetOwner();
+      fMCList->Add(fMCQAPlots[i]);
+
+      TString MCpTPCName=Form("MCpTPCDist%s",MCModes[i].Data());
+      TString MCetaName=Form("MCEtaDist%s",MCModes[i].Data());
+      TString MCphiName=Form("MCphiDist%s",MCModes[i].Data());
+      TString MCTPCName=Form("MCTPCCls%s",MCModes[i].Data());
+      TString MCDCAXYName=Form("MCMCDCAXY%s",MCModes[i].Data());
+      TString MCDCAZName=Form("MCDCAZ%s",MCModes[i].Data());
+      TString MCTPCCRName=Form("MCCrossedRows%s",MCModes[i].Data());
+      TString MCTPCratioName=Form("MCTPCRatio%s",MCModes[i].Data());
+      TString MCTPCdedxName=Form("MCTPCdedx%s",MCModes[i].Data());
+      TString MCTOFbetaName=Form("MCTOFbeta%s",MCModes[i].Data());
+      TString MCNSigTPCName=Form("MCNSigTPC%s",MCModes[i].Data());
+      TString MCNSigTOFName=Form("MCNSigTOF%s",MCModes[i].Data());
+
+      fMCpTPCDist[i]=new TH1F(MCpTPCName.Data(),MCpTPCName.Data(),ptBins,
+                              ptmin,ptmax);
+      fMCpTPCDist[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCpTPCDist[i]);
+
+      fMCetaDist[i]=new TH1F(MCetaName.Data(),MCetaName.Data(),200,-10.,10.);
+      fMCetaDist[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCetaDist[i]);
+
+      fMCphiDist[i]=new TH1F(MCphiName.Data(),MCphiName.Data(),200,0.,
+                             2*TMath::Pi());
+      fMCphiDist[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCphiDist[i]);
+
+      fMCTPCCls[i]=new TH2F(MCTPCName.Data(),MCTPCName.Data(),ptBins,ptmin,
+                            ptmax,100,0,200.);
+      fMCTPCCls[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCTPCCls[i]);
+
+      fMCDCAxy[i]=new TH2F(MCDCAXYName.Data(),MCDCAXYName.Data(),ptBins,ptmin,
+                           ptmax,2.5*twoDBins,-5.,5.);
+      fMCDCAxy[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCDCAxy[i]);
+
+      fMCDCAz[i]=new TH2F(MCDCAZName.Data(),MCDCAZName.Data(),ptBins,ptmin,
+                          ptmax,2.5*twoDBins,-5.,5.);
+      fMCDCAz[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCDCAz[i]);
+
+      fMCTPCCrossedRows[i]=new TH2F(MCTPCCRName.Data(),MCTPCCRName.Data(),
+                                    ptBins,ptmin,ptmax,100,0,200.);
+      fMCTPCCrossedRows[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCTPCCrossedRows[i]);
+
+      fMCTPCRatio[i]=new TH2F(MCTPCratioName.Data(),MCTPCratioName.Data(),
+                              ptBins,ptmin,ptmax,100,0.,2.);
+      fMCTPCRatio[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCTPCRatio[i]);
+      fMCTPCdedx[i]=new TH2F(MCTPCdedxName.Data(),MCTPCdedxName.Data(),
+                             ptBins,ptmin,ptmax,2*twoDBins,0.,400);
+      fMCTPCdedx[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCTPCdedx[i]);
+      fMCTOFbeta[i]=new TH2F(MCTOFbetaName.Data(),MCTOFbetaName.Data(),
+                             ptBins,ptmin,ptmax,3.5*twoDBins,0.4,1.1);
+      fMCTOFbeta[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCTOFbeta[i]);
+      fMCNSigTPC[i]=new TH2F(MCNSigTPCName.Data(),MCNSigTPCName.Data(),
+                             ptBins,ptmin,ptmax,twoDBins,-20.,20.);
+      fMCNSigTPC[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCNSigTPC[i]);
+      fMCNSigTOF[i]=new TH2F(MCNSigTOFName.Data(),MCNSigTOFName.Data(),
+                             ptBins,ptmin,ptmax,twoDBins,-20.,20.);
+      fMCNSigTOF[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCNSigTOF[i]);
+    }
+  } else {
+    for (int i=0;i<4;++i) {
+      fMCQAPlots[i]=0;
+      fMCpTPCDist[i]=0;
+      fMCetaDist[i]=0;
+      fMCphiDist[i]=0;
+      fMCTPCCls[i]=0;
+      fMCDCAxy[i]=0;
+      fMCDCAz[i]=0;
+      fMCTPCCrossedRows[i]=0;
+      fMCTPCRatio[i]=0;
+      fMCTPCdedx[i]=0;
+      fMCTOFbeta[i]=0;
+      fMCNSigTPC[i]=0;
+      fMCNSigTOF[i]=0;
+    }
+  }
+
+  if (DCADist) {
+    fDCAPlots=new TList();
+    fDCAPlots->SetName("DCAPtBinning");
+    fDCAPlots->SetOwner();
+    fMCList->Add(fDCAPlots);
+    TString MCPridcaPtBinName=Form("DCAPtBinningPri");
+    TString MCMatdcaPtBinName=Form("DCAPtBinningMat");
+    TString MCSecdcaPtBinName=Form("DCAPtBinningSec");
+    TString MCSecLamdcaPtBinName=Form("DCAPtBinningSecLam");
+    TString MCSecSigdcaPtBinName=Form("DCAPtBinningSecSig");
+
+    fMCPrimDCAXYPtBins=new TH2F(MCPridcaPtBinName.Data(),
+                                MCPridcaPtBinName.Data(),fpTbins,fpTmin,fpTmax
+                                ,500,-5,5);
+    fMCPrimDCAXYPtBins->Sumw2();
+    fMCPrimDCAXYPtBins->GetXaxis()->SetTitle("dca_{XY}");
+    fMCPrimDCAXYPtBins->GetYaxis()->SetTitle("dca_{Z}");
+    fDCAPlots->Add(fMCPrimDCAXYPtBins);
+
+    fMCMaterialDCAXYPtBins=new TH2F(MCMatdcaPtBinName.Data(),
+                                    MCMatdcaPtBinName.Data(),fpTbins,fpTmin,
+                                    fpTmax,500,-5,5);
+    fMCMaterialDCAXYPtBins->Sumw2();
+    fMCMaterialDCAXYPtBins->GetXaxis()->SetTitle("dca_{XY}");
+    fMCMaterialDCAXYPtBins->GetYaxis()->SetTitle("dca_{Z}");
+    fDCAPlots->Add(fMCMaterialDCAXYPtBins);
+
+    fMCSecondaryDCAXYPtBins=new TH2F(MCSecdcaPtBinName.Data(),
+                                     MCSecdcaPtBinName.Data(),fpTbins,fpTmin,
+                                     fpTmax,500,-5,5);
+    fMCSecondaryDCAXYPtBins->Sumw2();
+    fMCSecondaryDCAXYPtBins->GetXaxis()->SetTitle("dca_{XY}");
+    fMCSecondaryDCAXYPtBins->GetYaxis()->SetTitle("dca_{Z}");
+    fDCAPlots->Add(fMCSecondaryDCAXYPtBins);
+
+    fMCSecLambdaDCAXYPtBins=new TH2F(MCSecLamdcaPtBinName.Data(),
+                                     MCSecLamdcaPtBinName.Data(),fpTbins,
+                                     fpTmin,fpTmax,500,-5,5);
+    fMCSecLambdaDCAXYPtBins->Sumw2();
+    fMCSecLambdaDCAXYPtBins->GetXaxis()->SetTitle("dca_{XY}");
+    fMCSecLambdaDCAXYPtBins->GetYaxis()->SetTitle("dca_{Z}");
+    fDCAPlots->Add(fMCSecLambdaDCAXYPtBins);
+
+    fMCSecSigmaDCAXYPtBins=new TH2F(MCSecSigdcaPtBinName.Data(),
+                                    MCSecSigdcaPtBinName.Data(),
+                                    fpTbins,fpTmin,fpTmax,500,-5,5);
+    fMCSecSigmaDCAXYPtBins->Sumw2();
+    fMCSecSigmaDCAXYPtBins->GetXaxis()->SetTitle("dca_{XY}");
+    fMCSecSigmaDCAXYPtBins->GetYaxis()->SetTitle("dca_{Z}");
+    fDCAPlots->Add(fMCSecSigmaDCAXYPtBins);
+  } else {
+    fDCAPlots=0;
+    fMCPrimDCAXYPtBins=0;
+    fMCMaterialDCAXYPtBins=0;
+    fMCSecondaryDCAXYPtBins=0;
+    fMCSecLambdaDCAXYPtBins=0;
+    fMCSecSigmaDCAXYPtBins=0;
+  }
+}
+void AliFemtoDreamTrackMCHist::FillMCDCAXYPtBins(
+    AliFemtoDreamBasePart::PartOrigin org,int PDGCodeMoth,
+    double pT,double dcaxy)
+{
+  if (!fDoDCAPlots) {
+    AliFatal("FullBooking not set for SPCutHistograms! Cannot use this method");
+  }
+  if (org==AliFemtoDreamBasePart::kPhysPrimary) {
+    fMCPrimDCAXYPtBins->Fill(pT,dcaxy);
+  } else if (org==AliFemtoDreamBasePart::kWeak) {
+    fMCSecondaryDCAXYPtBins->Fill(pT,dcaxy);
+    if (TMath::Abs(PDGCodeMoth)==3222) {
+      fMCSecSigmaDCAXYPtBins->Fill(pT,dcaxy);
+    } else if (TMath::Abs(PDGCodeMoth)==3122) {
+      fMCSecLambdaDCAXYPtBins->Fill(pT,dcaxy);
+    } else {
+      TString ErrHistSP=Form("Feeddown for %d not implemented",PDGCodeMoth);
+      AliWarning(ErrHistSP.Data());
+    }
+  } else if (org==AliFemtoDreamBasePart::kMaterial) {
+    fMCMaterialDCAXYPtBins->Fill(pT,dcaxy);
+  } else {
+    AliFatal("Particle Origin not implemented");
+  }
+  return;
+}

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackMCHist.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackMCHist.cxx
@@ -83,33 +83,34 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,bool DC
   fMCGenPt->GetXaxis()->SetTitle("p_{T}");
   fMCList->Add(fMCGenPt);
 
-  fMCContPt=new TH1F("ContPt","ContPt",ptBins,ptmin,ptmax);
-  fMCContPt->Sumw2();
-  fMCContPt->GetXaxis()->SetTitle("p_{T}");
-  fMCList->Add(fMCContPt);
-
-  fMCUnknownPt=new TH1F("UnknPt","UnknPt",ptBins,ptmin,ptmax);
-  fMCUnknownPt->Sumw2();
-  fMCUnknownPt->GetXaxis()->SetTitle("p_{T}");
-  fMCList->Add(fMCUnknownPt);
-
-  fMCPrimaryPt=new TH1F("PrimaryPt","PrimaryPt",ptBins,ptmin,ptmax);
-  fMCPrimaryPt->Sumw2();
-  fMCPrimaryPt->GetXaxis()->SetTitle("p_{T}");
-  fMCList->Add(fMCPrimaryPt);
-
-  fMCMaterialPt=new TH1F("MatPt","MatPT",ptBins,ptmin,ptmax);
-  fMCMaterialPt->Sumw2();
-  fMCMaterialPt->GetXaxis()->SetTitle("p_{T}");
-  fMCList->Add(fMCMaterialPt);
-
-  fMCFeeddownWeakPt=new TH2F("FeeddownPt","Feeddown Pt",ptBins,ptmin,ptmax,
-                             213,3121,3334);
-  fMCFeeddownWeakPt->Sumw2();
-  fMCFeeddownWeakPt->GetXaxis()->SetTitle("p_{T}");
-  fMCList->Add(fMCFeeddownWeakPt);
 
   if (contribSplitting) {
+    fMCContPt=new TH1F("ContPt","ContPt",ptBins,ptmin,ptmax);
+    fMCContPt->Sumw2();
+    fMCContPt->GetXaxis()->SetTitle("p_{T}");
+    fMCList->Add(fMCContPt);
+
+    fMCUnknownPt=new TH1F("UnknPt","UnknPt",ptBins,ptmin,ptmax);
+    fMCUnknownPt->Sumw2();
+    fMCUnknownPt->GetXaxis()->SetTitle("p_{T}");
+    fMCList->Add(fMCUnknownPt);
+
+    fMCPrimaryPt=new TH1F("PrimaryPt","PrimaryPt",ptBins,ptmin,ptmax);
+    fMCPrimaryPt->Sumw2();
+    fMCPrimaryPt->GetXaxis()->SetTitle("p_{T}");
+    fMCList->Add(fMCPrimaryPt);
+
+    fMCMaterialPt=new TH1F("MatPt","MatPT",ptBins,ptmin,ptmax);
+    fMCMaterialPt->Sumw2();
+    fMCMaterialPt->GetXaxis()->SetTitle("p_{T}");
+    fMCList->Add(fMCMaterialPt);
+
+    fMCFeeddownWeakPt=new TH2F("FeeddownPt","Feeddown Pt",ptBins,ptmin,ptmax,
+                               213,3121,3334);
+    fMCFeeddownWeakPt->Sumw2();
+    fMCFeeddownWeakPt->GetXaxis()->SetTitle("p_{T}");
+    fMCList->Add(fMCFeeddownWeakPt);
+
     TString MCModes[4]={"Primary","Secondary","Material","Contamination"};
     for (int i=0;i<4;++i) {
       fMCQAPlots[i]=new TList();
@@ -186,6 +187,11 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,bool DC
       fMCQAPlots[i]->Add(fMCNSigTOF[i]);
     }
   } else {
+    fMCContPt=0;
+    fMCUnknownPt=0;
+    fMCPrimaryPt=0;
+    fMCMaterialPt=0;
+    fMCFeeddownWeakPt=0;
     for (int i=0;i<4;++i) {
       fMCQAPlots[i]=0;
       fMCpTPCDist[i]=0;

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackMCHist.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackMCHist.h
@@ -1,0 +1,107 @@
+/*
+ * AliFemtoDreamTrackMCHist.h
+ *
+ *  Created on: Nov 14, 2017
+ *      Author: gu74req
+ */
+
+#ifndef ALIFEMTODREAMTRACKMCHIST_H_
+#define ALIFEMTODREAMTRACKMCHIST_H_
+#include "AliFemtoDreamBasePart.h"
+#include "Rtypes.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TList.h"
+#include "TString.h"
+
+class AliFemtoDreamTrackMCHist {
+ public:
+  AliFemtoDreamTrackMCHist();
+  AliFemtoDreamTrackMCHist(bool contribSplitting,bool DCADist);
+  virtual ~AliFemtoDreamTrackMCHist();
+  void FillMCDCAXYPtBins(AliFemtoDreamBasePart::PartOrigin org,
+                         int PDGCodeMoth,double pT,double dcaxy);
+  void FillMCCorr(double pT){fMCCorrPt->Fill(pT);};
+  void FillMCIdent(double pT){fMCIdentPt->Fill(pT);};
+  void FillMCGen(double pT){fMCGenPt->Fill(pT);};
+  void FillMCCont(double pT){fMCContPt->Fill(pT);};
+  void FillMCUnkn(double pT){fMCUnknownPt->Fill(pT);};
+  void FillMCPrimary(double pT){fMCPrimaryPt->Fill(pT);};
+  void FillMCMaterial(double pT){fMCMaterialPt->Fill(pT);};
+  void FillMCFeeddown(double pT, double pdg){
+    fMCFeeddownWeakPt->Fill(pT, pdg);
+  };
+  void FillMCpTPCCut(int i, double pTPC){fMCpTPCDist[i]->Fill(pTPC);};
+  void FillMCetaCut(int i, double eta){fMCetaDist[i]->Fill(eta);};
+  void FillMCphiCut(int i, double phi){fMCphiDist[i]->Fill(phi);};
+  void FillMCTPCclsCut(int i, double pT, double nCls){
+    fMCTPCCls[i]->Fill(pT, nCls);
+  };
+  void FillMCDCAxyCut(int i, double pT, double dcaxy){
+    fMCDCAxy[i]->Fill(pT, dcaxy);
+  };
+  void FillMCDCAzCut(int i, double pT, double dcaz){
+    fMCDCAz[i]->Fill(pT, dcaz);
+  };
+  void FillMCTPCCrossedRowCut(int i, double pT, float Crossed){
+    fMCTPCCrossedRows[i]->Fill(pT,Crossed);};
+  void FillMCTPCRatioCut(int i, double pT, float ratio){
+    fMCTPCRatio[i]->Fill(pT,ratio);};
+  void FillMCTPCdedx(int i, double mom, double dedx){
+    fMCTPCdedx[i]->Fill(mom,dedx);
+  };
+  void FillMCTOFbeta(int i, double mom, double beta){
+    fMCTOFbeta[i]->Fill(mom,beta);
+  };
+  void FillMCNSigTPC(int i, double mom, double nSigTPC){
+    fMCNSigTPC[i]->Fill(mom, nSigTPC);
+  };
+  void FillMCNSigTOF(int i, double mom, double nSigTOF){
+    fMCNSigTOF[i]->Fill(mom, nSigTOF);
+  };
+  TList *GetHistList() const {return fMCList;};
+  TString ClassName() {return "AliFemtoDreamTrackMCHist";};
+ private:
+  double fpTmin;                  //!
+  double fpTmax;                  //!
+  double fpTbins;                 //!
+  bool fDoSplitting;              //!
+  bool fDoDCAPlots;               //!
+
+  TList *fMCList;                 //!
+  TList *fMCQAPlots[4];           //!
+  TList *fDCAPlots;               //!
+  TH1F *fMCCorrPt;                //!
+  TH1F *fMCIdentPt;               //!
+  TH1F *fMCGenPt;                 //!
+  TH1F *fMCContPt;                //!
+  TH1F *fMCUnknownPt;             //!
+
+  TH1F *fMCPrimaryPt;             //!
+  TH1F *fMCMaterialPt;            //!
+  TH2F *fMCFeeddownWeakPt;        //!
+
+  TH2F *fMCPrimDCAXYPtBins;       //!
+  TH2F *fMCMaterialDCAXYPtBins;   //!
+  TH2F *fMCSecondaryDCAXYPtBins;  //!
+  TH2F *fMCSecLambdaDCAXYPtBins;  //!
+  TH2F *fMCSecSigmaDCAXYPtBins;   //!
+
+  TH1F *fMCpTPCDist[4];           //!
+  TH1F *fMCetaDist[4];            //!
+  TH1F *fMCphiDist[4];            //!
+  TH2F *fMCTPCCls[4];             //!
+  TH2F *fMCDCAxy[4];              //!
+  TH2F *fMCDCAz[4];               //!
+
+  TH2F *fMCTPCCrossedRows[4];     //!
+  TH2F *fMCTPCRatio[4];           //!
+
+  TH2F *fMCTPCdedx[4];            //!
+  TH2F *fMCTOFbeta[4];            //!
+  TH2F *fMCNSigTPC[4];            //!
+  TH2F *fMCNSigTOF[4];            //!
+  ClassDef(AliFemtoDreamTrackMCHist,1);
+};
+
+#endif /* ALIFEMTODREAMTRACKMCHIST_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackMCHist.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackMCHist.h
@@ -76,7 +76,6 @@ class AliFemtoDreamTrackMCHist {
   TH1F *fMCGenPt;                 //!
   TH1F *fMCContPt;                //!
   TH1F *fMCUnknownPt;             //!
-
   TH1F *fMCPrimaryPt;             //!
   TH1F *fMCMaterialPt;            //!
   TH2F *fMCFeeddownWeakPt;        //!

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamZVtxMultContainer.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamZVtxMultContainer.cxx
@@ -1,0 +1,172 @@
+/*
+ * AliFemtoPPbpbLamZVtxMultContainer.cxx
+ *
+ *  Created on: Aug 30, 2017
+ *      Author: gu74req
+ */
+//#include "AliLog.h"
+#include <iostream>
+#include "AliFemtoDreamZVtxMultContainer.h"
+#include "TLorentzVector.h"
+#include "TDatabasePDG.h"
+ClassImp(AliFemtoDreamPartContainer)
+AliFemtoDreamZVtxMultContainer::AliFemtoDreamZVtxMultContainer()
+:fPartContainer(0),
+ fPDGParticleSpecies(0)
+{
+
+}
+
+AliFemtoDreamZVtxMultContainer::AliFemtoDreamZVtxMultContainer(
+    AliFemtoDreamCollConfig *conf)
+:fPartContainer(conf->GetNParticles(),
+                AliFemtoDreamPartContainer(conf->GetMixingDepth()))
+,fPDGParticleSpecies(conf->GetPDGCodes())
+{
+  std::cout<<"Number of Particles: "<<conf->GetNParticles()<<
+      "MixingDepth: "<<conf->GetMixingDepth()<<std::endl;
+}
+
+AliFemtoDreamZVtxMultContainer::~AliFemtoDreamZVtxMultContainer() {
+  // TODO Auto-generated destructor stub
+}
+
+void AliFemtoDreamZVtxMultContainer::SetEvent(
+    std::vector<std::vector<AliFemtoDreamBasePart>> &Particles)
+{
+  //This method sets the particles of an event only in the case, that
+  //more than one particle was identified, to avoid empty events.
+  //  if (Particles->size()!=fParticleSpecies){
+  //    TString errMessage = Form("Number of Input Particlese (%d) doese not"
+  //        "correspond to the Number of particles Set (%d)",Particles->size(),
+  //        fParticleSpecies);
+  //    AliFatal(errMessage.Data());
+  //  } else {
+  std::vector<std::vector<AliFemtoDreamBasePart>>::iterator itInput=
+      Particles.begin();
+  std::vector<AliFemtoDreamPartContainer>::iterator itContainer=
+      fPartContainer.begin();
+  while (itContainer!=fPartContainer.end()) {
+    if (itInput->size()>0) {
+      itContainer->SetEvent(*itInput);
+    }
+    ++itInput;
+    ++itContainer;
+  }
+  //  }
+}
+void AliFemtoDreamZVtxMultContainer::PairParticlesSE(
+    std::vector<std::vector<AliFemtoDreamBasePart>> &Particles,
+    AliFemtoDreamCorrHists *ResultsHist)
+{
+  double RelativeK = 0;
+  int _intSpec1 = 0;
+  int HistCounter=0;
+  //First loop over all the different Species
+ auto itPDGPar1 = fPDGParticleSpecies.begin();
+  for (auto itSpec1=Particles.begin();itSpec1!=Particles.end();++itSpec1) {
+    auto itPDGPar2 = fPDGParticleSpecies.begin();
+    itPDGPar2+=itSpec1-Particles.begin();
+    int _intSpec2 = itSpec1-Particles.begin();
+    for (auto itSpec2=itSpec1;itSpec2!=Particles.end();++itSpec2) {
+      ResultsHist->FillPartnersSE(HistCounter,itSpec1->size(),itSpec2->size());
+      //Now loop over the actual Particles and correlate them
+      for (auto itPart1=itSpec1->begin();itPart1!=itSpec1->end();++itPart1) {
+        std::vector<AliFemtoDreamBasePart>::iterator itPart2;
+        if (itSpec1==itSpec2) {
+          itPart2=itPart1+1;
+        } else {
+          itPart2=itSpec2->begin();
+        }
+        while (itPart2!=itSpec2->end()) {
+          RelativeK=RelativePairMomentum(itPart1->GetMomentum(),*itPDGPar1,
+                                         itPart2->GetMomentum(),
+                                         *itPDGPar2);
+          ResultsHist->FillSameEventDist(HistCounter,RelativeK);
+          ++itPart2;
+        }
+      }
+      ++HistCounter;
+      _intSpec2++;
+      itPDGPar2++;
+    }
+    _intSpec1++;
+    itPDGPar1++;
+  }
+}
+
+void AliFemtoDreamZVtxMultContainer::PairParticlesME(
+    std::vector<std::vector<AliFemtoDreamBasePart>> &Particles,
+    AliFemtoDreamCorrHists *ResultsHist)
+{
+  double RelativeK = 0;
+  int _intSpec1 = 0;
+  int HistCounter=0;
+  auto itPDGPar1 = fPDGParticleSpecies.begin();
+  //First loop over all the different Species
+  for (auto itSpec1=Particles.begin();itSpec1!=Particles.end();++itSpec1) {
+    //We dont want to correlate the particles twice. Mixed Event Dist. of
+    //Particle1 + Particle2 == Particle2 + Particle 1
+    int SkipPart=itSpec1-Particles.begin();
+    int _intSpec2 = SkipPart;
+    auto itPDGPar2 = fPDGParticleSpecies.begin()+
+        SkipPart;
+    for (auto itSpec2=fPartContainer.begin()+SkipPart;
+        itSpec2!=fPartContainer.end();++itSpec2) {
+      for(int iDepth=0;iDepth<(int)itSpec2->GetMixingDepth();++iDepth){
+        std::vector<AliFemtoDreamBasePart> ParticlesOfEvent=
+            itSpec2->GetEvent(iDepth);
+        ResultsHist->FillPartnersME(
+            HistCounter,itSpec1->size(),ParticlesOfEvent.size());
+        for (auto itPart1=itSpec1->begin();itPart1!=itSpec1->end();++itPart1) {
+          for(auto itPart2=ParticlesOfEvent.begin();
+              itPart2!=ParticlesOfEvent.end();++itPart2) {
+            RelativeK=RelativePairMomentum(itPart1->GetMomentum(),*itPDGPar1,
+                                           itPart2->GetMomentum(),*itPDGPar2);
+            ResultsHist->FillMixedEventDist(HistCounter,RelativeK);
+          }
+        }
+      }
+      ++HistCounter;
+      ++_intSpec2;
+      ++itPDGPar2;
+    }
+    ++_intSpec1;
+    ++itPDGPar1;
+  }
+}
+double AliFemtoDreamZVtxMultContainer::RelativePairMomentum(TVector3 Part1Momentum,
+                                                            int PDGPart1,
+                                                            TVector3 Part2Momentum,
+                                                            int PDGPart2)
+{
+    if(PDGPart1 == 0 || PDGPart2== 0){
+      AliError("Invalid PDG Code");
+    }
+  double results = 0.;
+  TLorentzVector SPtrack,TPProng,trackSum,SPtrackCMS,TPProngCMS;
+  //Even if the Daughter tracks were switched up during PID doesn't play a role here cause we are
+  //only looking at the mother mass
+  SPtrack.SetXYZM(Part1Momentum.X(), Part1Momentum.Y(),Part1Momentum.Z(),
+                  TDatabasePDG::Instance()->GetParticle(PDGPart1)->Mass());
+  TPProng.SetXYZM(Part2Momentum.X(), Part2Momentum.Y(),Part2Momentum.Z(),
+                  TDatabasePDG::Instance()->GetParticle(PDGPart2)->Mass());
+  trackSum = SPtrack + TPProng;
+
+  double beta = trackSum.Beta();
+  double betax = beta*cos(trackSum.Phi())*sin(trackSum.Theta());
+  double betay = beta*sin(trackSum.Phi())*sin(trackSum.Theta());
+  double betaz = beta*cos(trackSum.Theta());
+
+  SPtrackCMS = SPtrack;
+  TPProngCMS = TPProng;
+
+  SPtrackCMS.Boost(-betax,-betay,-betaz);
+  TPProngCMS.Boost(-betax,-betay,-betaz);
+
+  TLorentzVector trackRelK;
+
+  trackRelK = SPtrackCMS - TPProngCMS;
+  results = 0.5*trackRelK.P();
+  return results;
+}

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamZVtxMultContainer.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamZVtxMultContainer.h
@@ -1,0 +1,39 @@
+/*
+ * AliFemtoPPbpbLamZVtxMultContainer.h
+ *
+ *  Created on: Aug 30, 2017
+ *      Author: gu74req
+ */
+
+#ifndef ALIFEMTODREAMZVTXMULTCONTAINER_H_
+#define ALIFEMTODREAMZVTXMULTCONTAINER_H_
+#include <vector>
+#include "Rtypes.h"
+
+#include "AliFemtoDreamCollConfig.h"
+#include "AliFemtoDreamCorrHists.h"
+#include "AliFemtoDreamPartContainer.h"
+//Class containing the array buffer of the different particle species for one
+//Multiplicity bin
+class AliFemtoDreamZVtxMultContainer {
+ public:
+  AliFemtoDreamZVtxMultContainer();
+  AliFemtoDreamZVtxMultContainer(AliFemtoDreamCollConfig *conf);
+  virtual ~AliFemtoDreamZVtxMultContainer();
+  void PairParticlesSE(
+      std::vector<std::vector<AliFemtoDreamBasePart>> &Particles,
+      AliFemtoDreamCorrHists *ResultsHist);
+  void PairParticlesME(
+      std::vector<std::vector<AliFemtoDreamBasePart>> &Particles,
+      AliFemtoDreamCorrHists *ResultsHist);
+  void SetEvent(std::vector<std::vector<AliFemtoDreamBasePart>> &Particles);
+  TString ClassName() {return "zVtxMult Container";};
+ private:
+  double RelativePairMomentum(TVector3 Part1Momentum,int PDGPart1,
+                              TVector3 Part2Momentum,int PDGPart2);
+  std::vector<AliFemtoDreamPartContainer> fPartContainer;
+  std::vector<int> fPDGParticleSpecies;
+  ClassDef(AliFemtoDreamZVtxMultContainer,1);
+};
+
+#endif /* ALIFEMTODREAMZVTXMULTCONTAINER_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.cxx
@@ -1,0 +1,223 @@
+/*
+ * AliFemtoDreamv0.cxx
+ *
+ *  Created on: Dec 12, 2017
+ *      Author: gu74req
+ */
+
+#include <vector>
+#include "AliAODMCParticle.h"
+#include "AliFemtoDreamv0.h"
+#include "TClonesArray.h"
+
+ClassImp(AliFemtoDreamv0)
+AliFemtoDreamv0::AliFemtoDreamv0()
+:AliFemtoDreamBasePart()
+,fOnlinev0(false)
+,fHasDaughter(false)
+,fpDaug(new AliFemtoDreamTrack())
+,fnDaug(new AliFemtoDreamTrack())
+,fv0Mass(0)
+,fdcav0Daug(0)
+,fdcaPrim(0)
+,fdcaPrimPos(0)
+,fdcaPrimNeg(0)
+,flenDecay(0)
+,fTransRadius(0)
+{
+  for (int i=0;i<3;++i) {
+    fv0Vtx[i]=0;
+  }
+}
+
+AliFemtoDreamv0::~AliFemtoDreamv0() {
+  if (fpDaug) {
+    delete fpDaug;
+  }
+  if (fnDaug) {
+    delete fnDaug;
+  }
+}
+
+void AliFemtoDreamv0::Setv0(AliAODEvent *evt,AliAODv0* v0) {
+  if (!fGTI) {
+    AliFatal("no GTI Array set");
+  }
+  if (!v0) {
+    AliFatal("SetProng No v0 to work with");
+  }
+  Reset();
+  if (v0->GetNProngs()==2&&v0->GetNDaughters()==2) {
+    fIsReset=false;
+    if (v0->GetOnFlyStatus()) {
+      this->fOnlinev0=true;
+    } else {
+      this->fOnlinev0=false;
+    }
+    this->SetMotherInfo(evt,v0);
+    if (fIsMC) {
+      this->SetMCMotherInfo(evt,v0);
+    }
+    this->SetDaughter(v0);
+  } else {
+    this->SetUse(false);
+  }
+}
+
+void AliFemtoDreamv0::SetDaughter(AliAODv0 *v0) {
+  if (v0->GetPosID()>=fTrackBufferSize||v0->GetNegID()>=fTrackBufferSize) {
+    AliFatal("fGTI too small");
+  } else {
+    fpDaug->SetGlobalTrackInfo(fGTI,fTrackBufferSize);
+    fnDaug->SetGlobalTrackInfo(fGTI,fTrackBufferSize);
+    if (fGTI[v0->GetPosID()]&&fGTI[v0->GetNegID()]) {
+      if (fGTI[v0->GetPosID()]->Charge() > 0 && fGTI[v0->GetNegID()]->Charge() < 0) {
+        fnDaug->SetTrack(fGTI[v0->GetNegID()]);
+        fpDaug->SetTrack(fGTI[v0->GetPosID()]);
+        this->SetDaughterInfo(v0);
+        this->fHasDaughter=true;
+      } else if(fGTI[v0->GetPosID()]->Charge() < 0 && fGTI[v0->GetNegID()]->Charge() > 0) {
+        fnDaug->SetTrack(fGTI[v0->GetPosID()]);
+        fpDaug->SetTrack(fGTI[v0->GetNegID()]);
+        this->SetDaughterInfo(v0);
+        this->fHasDaughter=true;
+      } else {
+        this->fHasDaughter=false;
+      }
+    } else {
+      this->fHasDaughter=false;
+    }
+  }
+}
+
+void AliFemtoDreamv0::SetDaughterInfo(AliAODv0 *v0) {
+  this->SetEta(fnDaug->GetEta().at(0));
+  this->SetEta(fpDaug->GetEta().at(0));
+
+  this->SetTheta(fnDaug->GetTheta().at(0));
+  this->SetTheta(fpDaug->GetTheta().at(0));
+
+  this->SetPhi(fnDaug->GetPhi().at(0));
+  this->SetPhi(fpDaug->GetPhi().at(0));
+
+  this->SetIDTracks(fnDaug->GetIDTracks().at(0));
+  this->SetIDTracks(fpDaug->GetIDTracks().at(0));
+
+  this->SetCharge(fnDaug->GetCharge().at(0));
+  this->SetCharge(fpDaug->GetCharge().at(0));
+  //here we have to set the momentum from the v0. The Momentum of the Global
+  //track is different to the one of the daughter track and is also
+  //used in the official v0 class for the invarian mass
+  //calculation.
+  fnDaug->SetMomentum(v0->PxProng(1), v0->PyProng(1), v0->PzProng(1));
+  fpDaug->SetMomentum(v0->PxProng(0), v0->PyProng(0), v0->PzProng(0));
+
+  if(fIsMC) {
+    this->SetMCTheta(fnDaug->GetMCTheta().at(0));
+    this->SetMCTheta(fpDaug->GetMCTheta().at(0));
+    this->SetMCPhi(fnDaug->GetMCPhi().at(0));
+    this->SetMCPhi(fpDaug->GetMCPhi().at(0));
+  }
+}
+
+void AliFemtoDreamv0::SetMotherInfo(AliAODEvent *evt,AliAODv0 *v0) {
+  this->SetCharge(v0->GetCharge());
+  this->SetPt(v0->Pt());
+  this->SetMomentum(v0->Px(),v0->Py(),v0->Pz());
+  this->SetEta(v0->Eta());
+  this->SetPhi(v0->Phi());
+  this->SetTheta(v0->Theta());
+  double xvP = evt->GetPrimaryVertex()->GetX();
+  double yvP = evt->GetPrimaryVertex()->GetY();
+  double zvP = evt->GetPrimaryVertex()->GetZ();
+  double vecTarget[3]={xvP,yvP,zvP};
+  v0->GetXYZ(fv0Vtx);
+  this->fdcav0Daug=v0->DcaV0Daughters();
+  this->fdcaPrim=v0->DcaV0ToPrimVertex();
+  this->fdcaPrimPos=v0->DcaPosToPrimVertex();
+  this->fdcaPrimNeg=v0->DcaNegToPrimVertex();
+  this->flenDecay=v0->DecayLengthV0(vecTarget);
+  this->fCPA=v0->CosPointingAngle(vecTarget);
+  this->fTransRadius=v0->DecayLengthXY(vecTarget);
+}
+
+void AliFemtoDreamv0::SetMCMotherInfo(AliAODEvent *evt,AliAODv0 *v0) {
+  TClonesArray *mcarray = dynamic_cast<TClonesArray*>(
+      evt->FindListObject(AliAODMCParticle::StdBranchName()));
+  if (!mcarray) {
+    AliFatal("No MC Array found");
+  }
+  int PDGDaug[2];
+  PDGDaug[0]=TMath::Abs(fpDaug->GetPDGCode());
+  PDGDaug[1]=TMath::Abs(fnDaug->GetPDGCode());
+  int label=v0->MatchToMC(TMath::Abs(fPDGCode),mcarray,2,PDGDaug);
+  if (label<0) {
+    //label will be -1 if there was not 'real' candidate for matching,
+    //therefore we have the case of a contamination/background v0
+    this->SetParticleOrigin(AliFemtoDreamBasePart::kContamination);
+  } else {
+    AliAODMCParticle* mcPart=(AliAODMCParticle*)mcarray->At(label);
+    if (!mcPart) {
+      this->SetUse(false);
+    } else {
+      this->SetMCPDGCode(mcPart->GetPdgCode());
+      double mcMom[3]={0.,0.,0.};
+      mcPart->PxPyPz(mcMom);
+      this->SetMCMomentum(mcMom[0],mcMom[1],mcMom[2]);
+      this->SetMCPt(mcPart->Pt());
+      this->SetMCPhi(mcPart->Phi());
+      this->SetMCTheta(mcPart->Theta());
+      if (mcPart->IsPhysicalPrimary()&&!(mcPart->IsSecondaryFromWeakDecay())) {
+        this->SetParticleOrigin(AliFemtoDreamBasePart::kPhysPrimary);
+      } else if (mcPart->IsSecondaryFromWeakDecay()&&
+          !(mcPart->IsSecondaryFromMaterial())) {
+        this->SetParticleOrigin(AliFemtoDreamBasePart::kWeak);
+        this->SetPDGMotherWeak(((AliAODMCParticle*)mcarray->At(
+            mcPart->GetMother()))->PdgCode());
+      } else if (mcPart->IsSecondaryFromMaterial()) {
+        this->SetParticleOrigin(AliFemtoDreamBasePart::kMaterial);
+      } else {
+        this->SetParticleOrigin(AliFemtoDreamBasePart::kUnknown);
+      }
+    }
+  }
+}
+void AliFemtoDreamv0::Reset() {
+  if (!fIsReset) {
+    fOnlinev0=false;
+    fHasDaughter=false;
+    //daughters don't need to be reset, are reset while setting a new track
+    fv0Mass=0;
+    fv0Vtx[0]=99;
+    fv0Vtx[1]=99;
+    fv0Vtx[2]=99;
+    fdcav0Daug=99;
+    fdcaPrim=0;
+    fdcaPrimPos=0;
+    fdcaPrimNeg=0;
+    flenDecay=0;
+    fTransRadius=0;
+    fP.SetXYZ(0,0,0);
+    fMCP.SetXYZ(0,0,0);
+    fPt=0;
+    fMCPt=0;
+    fMCPt=0;
+    fP_TPC=0;
+    fEta.clear();
+    fTheta.clear();
+    fMCTheta.clear();
+    fPhi.clear();
+    fMCPhi.clear();
+    fIDTracks.clear();
+    fCharge.clear();
+    fCPA=0;
+    fOrigin=AliFemtoDreamBasePart::kUnknown;
+    //we don't want to reset the fPDGCode
+    fMCPDGCode=0;
+    fPDGMotherWeak=0;
+    //we don't want to reset isMC
+    fUse=false;
+    fIsSet=true;
+    fIsReset=true;
+  }
+}

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.cxx
@@ -113,10 +113,14 @@ void AliFemtoDreamv0::SetDaughterInfo(AliAODv0 *v0) {
   fpDaug->SetMomentum(v0->PxProng(0), v0->PyProng(0), v0->PzProng(0));
 
   if(fIsMC) {
-    this->SetMCTheta(fnDaug->GetMCTheta().at(0));
-    this->SetMCTheta(fpDaug->GetMCTheta().at(0));
-    this->SetMCPhi(fnDaug->GetMCPhi().at(0));
-    this->SetMCPhi(fpDaug->GetMCPhi().at(0));
+    if (fnDaug->IsSet()) {
+      this->SetMCTheta(fnDaug->GetMCTheta().at(0));
+      this->SetMCPhi(fnDaug->GetMCPhi().at(0));
+    }
+    if (fpDaug->IsSet()) {
+      this->SetMCTheta(fpDaug->GetMCTheta().at(0));
+      this->SetMCPhi(fpDaug->GetMCPhi().at(0));
+    }
   }
 }
 

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.h
@@ -1,0 +1,60 @@
+/*
+ * AliFemtoDreamv0.h
+ *
+ *  Created on: Dec 12, 2017
+ *      Author: gu74req
+ */
+
+#ifndef ALIFEMTODREAMV0_H_
+#define ALIFEMTODREAMV0_H_
+#include "Rtypes.h"
+#include "AliFemtoDreamBasePart.h"
+#include "AliFemtoDreamTrack.h"
+#include "AliAODEvent.h"
+#include "AliAODv0.h"
+
+class AliFemtoDreamv0 : public AliFemtoDreamBasePart {
+ public:
+  AliFemtoDreamv0();
+  virtual ~AliFemtoDreamv0();
+  void Setv0(AliAODEvent *evt,AliAODv0 *v0);
+  bool GetOnlinev0() const {return fOnlinev0;};
+  bool GetHasDaughters() const {return fHasDaughter;};
+  AliFemtoDreamTrack* GetPosDaughter() const {return fpDaug;};
+  void SetPDGDaughterPos(int PDGCode) {fpDaug->SetPDGCode(PDGCode);};
+  AliFemtoDreamTrack* GetNegDaughter() const {return fnDaug;};
+  void SetPDGDaughterNeg(int PDGCode) {fnDaug->SetPDGCode(PDGCode);};
+  double Getv0Mass() const {return fv0Mass;};
+  void Setv0Mass(double mass){fv0Mass=mass;};
+  double GetDCAv0Vtx(int i)const {
+    if(i>-1 && i<3){return fv0Vtx[i];}else{return 0.;};
+  };
+  double GetDaugDCA() const {return fdcav0Daug;};
+  double GetDCAPrimVtx() const {return fdcaPrim;};
+  double GetDCADaugPosVtx() const {return fdcaPrimPos;};
+  double GetDCADaugNegVtx() const {return fdcaPrimNeg;};
+  double GetDecayLength() const {return flenDecay;};
+  double GetTransverseRadius() const {return fTransRadius;};
+  TString ClassName(){return "v0Class";};
+ private:
+  void Reset();
+  void SetDaughter(AliAODv0 *v0);
+  void SetDaughterInfo(AliAODv0 *v0);
+  void SetMotherInfo(AliAODEvent *evt,AliAODv0 *v0);
+  void SetMCMotherInfo(AliAODEvent *evt,AliAODv0 *v0);
+  bool fOnlinev0;
+  bool fHasDaughter;
+  AliFemtoDreamTrack *fpDaug;
+  AliFemtoDreamTrack *fnDaug;
+  double fv0Mass;
+  double fv0Vtx[3];   // Decay Vertex in xyz
+  double fdcav0Daug;  // Daugther to Daughter DCA
+  double fdcaPrim;
+  double fdcaPrimPos; // rphi impact params w.r.t. Primary Vtx [cm]
+  double fdcaPrimNeg; // rphi impact params w.r.t. Primary Vtx [cm]
+  double flenDecay;   // Decay Length
+  double fTransRadius;// Decay Length in xy
+  ClassDef(AliFemtoDreamv0,1)
+};
+
+#endif /* ALIFEMTODREAMV0_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0Cuts.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0Cuts.cxx
@@ -7,6 +7,7 @@
 
 #include "AliFemtoDreamv0Cuts.h"
 #include "TDatabasePDG.h"
+#include <iostream>
 ClassImp(AliFemtoDreamv0Cuts)
 AliFemtoDreamv0Cuts::AliFemtoDreamv0Cuts()
 :fHistList()
@@ -53,9 +54,9 @@ AliFemtoDreamv0Cuts::~AliFemtoDreamv0Cuts() {
   if (fHist) {
     delete fHist;
   }
-  if (fMCHist) {
-    delete fMCHist;
-  }
+//  if (fMCHist) {
+//    delete fMCHist;
+//  }
 }
 AliFemtoDreamv0Cuts* AliFemtoDreamv0Cuts::LambdaCuts(
     bool isMC,bool CPAPlots,bool SplitContrib) {
@@ -323,27 +324,29 @@ void AliFemtoDreamv0Cuts::BookQA(AliFemtoDreamv0 *v0) {
 
 void AliFemtoDreamv0Cuts::BookMC(AliFemtoDreamv0 *v0) {
   double pT=v0->GetPt();
-  double etaNegDaug=v0->GetEta().at(1);
-  double etaPosDaug=v0->GetEta().at(2);
-  if (v0->GetMCPDGCode()==fPDGv0) {
-    if (fpTmin<pT&&pT<fpTmax) {
-      if (fPosCuts->GetEtaMin()<etaPosDaug&&etaPosDaug<fPosCuts->GetEtaMax()) {
-        if (fNegCuts->GetEtaMin()<etaNegDaug&&etaNegDaug<fNegCuts->GetEtaMax()) {
-          fMCHist->FillMCGen(pT);
+  if (v0->GetHasDaughters()) {
+    double etaNegDaug=v0->GetEta().at(1);
+    double etaPosDaug=v0->GetEta().at(2);
+    if (v0->GetMCPDGCode()==fPDGv0) {
+      if (fpTmin<pT&&pT<fpTmax) {
+        if (fPosCuts->GetEtaMin()<etaPosDaug&&etaPosDaug<fPosCuts->GetEtaMax()) {
+          if (fNegCuts->GetEtaMin()<etaNegDaug&&etaNegDaug<fNegCuts->GetEtaMax()) {
+            fMCHist->FillMCGen(pT);
+          }
         }
       }
     }
   }
   if (v0->UseParticle()) {
     fMCHist->FillMCIdent(pT);
-    if (TMath::Abs(v0->GetMCPDGCode())==TMath::Abs(fPDGv0)) {
+    if (v0->GetMCPDGCode()==fPDGv0) {
       fMCHist->FillMCCorr(pT);
     } else {
       v0->SetParticleOrigin(AliFemtoDreamBasePart::kContamination);
     }
-    if (fContribSplitting) {
-      FillMCContributions(v0);
-    }
+//    if (fContribSplitting) {
+//      FillMCContributions(v0);
+//    }
   }
 }
 
@@ -371,18 +374,22 @@ void AliFemtoDreamv0Cuts::FillMCContributions(AliFemtoDreamv0 *v0) {
       AliFatal("Type Not implemented");
       break;
   }
-  fMCHist->FillMCpT(iFill,pT);
-  fMCHist->FillMCEta(iFill,v0->GetEta().at(0));
-  fMCHist->FillMCPhi(iFill,v0->GetPhi().at(0));
-  fMCHist->FillMCDCAVtxX(iFill,pT,v0->GetDCAv0Vtx(0));
-  fMCHist->FillMCDCAVtxY(iFill,pT,v0->GetDCAv0Vtx(1));
-  fMCHist->FillMCDCAVtxZ(iFill,pT,v0->GetDCAv0Vtx(2));
-  fMCHist->FillMCTransverseRadius(iFill,pT,v0->GetTransverseRadius());
-  fMCHist->FillMCDCAPosDaugPrimVtx(iFill,pT,v0->GetDCADaugPosVtx());
-  fMCHist->FillMCDCANegDaugPrimVtx(iFill,pT,v0->GetDCADaugNegVtx());
-  fMCHist->FillMCDCADaugVtx(iFill,pT,v0->GetDaugDCA());
-  fMCHist->FillMCCosPoint(iFill,pT,v0->GetCPA());
-  fMCHist->FillMCInvMass(iFill,v0->Getv0Mass());
+  if (iFill!=-1) {
+    fMCHist->FillMCpT(iFill,pT);
+    fMCHist->FillMCEta(iFill,v0->GetEta().at(0));
+    fMCHist->FillMCPhi(iFill,v0->GetPhi().at(0));
+    fMCHist->FillMCDCAVtxX(iFill,pT,v0->GetDCAv0Vtx(0));
+    fMCHist->FillMCDCAVtxY(iFill,pT,v0->GetDCAv0Vtx(1));
+    fMCHist->FillMCDCAVtxZ(iFill,pT,v0->GetDCAv0Vtx(2));
+    fMCHist->FillMCTransverseRadius(iFill,pT,v0->GetTransverseRadius());
+    fMCHist->FillMCDCAPosDaugPrimVtx(iFill,pT,v0->GetDCADaugPosVtx());
+    fMCHist->FillMCDCANegDaugPrimVtx(iFill,pT,v0->GetDCADaugNegVtx());
+    fMCHist->FillMCDCADaugVtx(iFill,pT,v0->GetDaugDCA());
+    fMCHist->FillMCCosPoint(iFill,pT,v0->GetCPA());
+    fMCHist->FillMCInvMass(iFill,v0->Getv0Mass());
+  } else {
+    std::cout << "this should not happen \n";
+  }
 }
 void AliFemtoDreamv0Cuts::BookTrackCuts() {
   if (!fHist) {

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0Cuts.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0Cuts.cxx
@@ -1,0 +1,454 @@
+/*
+ * AliFemtoDreamv0Cuts.cxx
+ *
+ *  Created on: Dec 12, 2017
+ *      Author: gu74req
+ */
+
+#include "AliFemtoDreamv0Cuts.h"
+#include "TDatabasePDG.h"
+ClassImp(AliFemtoDreamv0Cuts)
+AliFemtoDreamv0Cuts::AliFemtoDreamv0Cuts()
+:fHistList()
+,fMCHist(0)
+,fHist(0)
+,fPosCuts(0)
+,fNegCuts(0)
+,fMCData(false)
+,fCPAPlots(false)
+,fContribSplitting(false)
+,fCutOnFlyStatus(false)
+,fOnFlyStatus(false)
+,fCutCharge(false)
+,fCharge(0)
+,fCutPt(false)
+,fpTmin(0)
+,fpTmax(0)
+,fKaonRejection(false)
+,fKaonRejLow(0)
+,fKaonRejUp(0)
+,fCutDecayVtxXYZ(false)
+,fMaxDecayVtxXYZ(0)
+,fCutTransRadius(false)
+,fMinTransRadius(0)
+,fMaxTransRadius(0)
+,fCutMinDCADaugPrimVtx(false)
+,fMinDCADaugToPrimVtx(0)
+,fCutMaxDCADaugToDecayVtx(false)
+,fMaxDCADaugToDecayVtx(0)
+,fCutCPA(false)
+,fMinCPA(0)
+,fCutInvMass(false)
+,fInvMassCutWidth(0)
+,fAxisMinMass(0)
+,fAxisMaxMass(1)
+,fNumberXBins(1)
+,fPDGv0(0)
+,fPDGDaugP(0)
+,fPDGDaugN(0)
+{
+}
+
+AliFemtoDreamv0Cuts::~AliFemtoDreamv0Cuts() {
+  if (fHist) {
+    delete fHist;
+  }
+  if (fMCHist) {
+    delete fMCHist;
+  }
+}
+AliFemtoDreamv0Cuts* AliFemtoDreamv0Cuts::LambdaCuts(
+    bool isMC,bool CPAPlots,bool SplitContrib) {
+  AliFemtoDreamv0Cuts *LambdaCuts = new AliFemtoDreamv0Cuts();
+  LambdaCuts->SetIsMonteCarlo(isMC);
+  LambdaCuts->SetPlotCPADist(CPAPlots);
+  LambdaCuts->SetPlotContrib(SplitContrib);
+
+  LambdaCuts->SetCheckOnFlyStatus(false); //online = kTRUE, offline = kFALSE
+  LambdaCuts->SetCutCharge(0);
+  LambdaCuts->SetPtRange(0.3,999.);
+  LambdaCuts->SetKaonRejection(0.48,0.515);
+  LambdaCuts->SetCutMaxDecayVtx(100);
+  LambdaCuts->SetCutTransverseRadius(0.2, 100);
+  LambdaCuts->SetCutDCADaugToPrimVtx(0.05);
+  LambdaCuts->SetCutDCADaugTov0Vtx(1.5);
+  LambdaCuts->SetCutCPA(0.99);
+  LambdaCuts->SetCutInvMass(0.004);
+  LambdaCuts->SetAxisInvMassPlots(400,1.0, 1.2);
+
+  return LambdaCuts;
+}
+
+bool AliFemtoDreamv0Cuts::isSelected(AliFemtoDreamv0 *v0) {
+  bool pass=true;
+
+  if (!v0->IsSet()) {
+    pass=false;
+  } else {
+    fHist->FillTrackCounter(0);
+  }
+  if (pass) {
+    if (!DaughtersPassCuts(v0)) {
+      pass=false;
+    }
+  }
+  if (pass) {
+    if (!MotherPassCuts(v0)) {
+      pass=false;
+    }
+  }
+  if (pass) {
+    if (fKaonRejection&&!RejectAsKaon(v0)) {
+      pass=false;
+    }
+  }
+  if (pass) {
+    if (!CPAandMassCuts(v0)) {
+      pass=false;
+    }
+  }
+  v0->SetUse(pass);
+  BookQA(v0);
+  if (fMCData) {
+    BookMC(v0);
+  }
+  return pass;
+}
+
+bool AliFemtoDreamv0Cuts::DaughtersPassCuts(AliFemtoDreamv0 *v0) {
+  bool pass=true;
+  bool passD1=true;
+  bool passD2=true;
+  if (!v0->GetHasDaughters()) {
+    pass=false;
+  } else {
+    fHist->FillTrackCounter(1);
+  }
+  if (pass) {
+    if (v0->GetCharge().at(1)<0&&v0->GetCharge().at(2)>0) {
+      //at 1: Negative daughter, at 2: Positive Daughter should be the way it
+      //was set, but sometimes it it stored in the wrong way
+      fHist->FillTrackCounter(13);
+      v0->Setv0Mass(CalculateInvMass(v0,fPDGDaugP,fPDGDaugN));
+      passD1=fNegCuts->isSelected(v0->GetNegDaughter());
+      passD2=fPosCuts->isSelected(v0->GetPosDaughter());
+      if (passD1&&passD2) {
+        fHist->FillTrackCounter(14);
+      }
+    } else {
+      fHist->FillTrackCounter(15);
+      v0->Setv0Mass(CalculateInvMass(v0,fPDGDaugN,fPDGDaugP));
+      passD1=fPosCuts->isSelected(v0->GetNegDaughter());
+      passD2=fNegCuts->isSelected(v0->GetPosDaughter());
+      if (passD1&&passD2) {
+        fHist->FillTrackCounter(16);
+      }
+    }
+    if (!(passD1&&passD2)) {
+      pass=false;
+    } else {
+      fHist->FillTrackCounter(2);
+    }
+  }
+  pass=passD1&&passD2;
+  return pass;
+}
+bool AliFemtoDreamv0Cuts::MotherPassCuts(AliFemtoDreamv0 *v0) {
+  //all topological and kinematic cuts on the mother except for the CPA, this
+  //will be filled later, in case also the CPA distributions are required.
+  //Special CPA checks impelemented in the RejKaons later, to still ensure
+  //proper Invariant Mass Plots.
+  bool pass=true;
+  if (fCutOnFlyStatus) {
+    if (!(v0->GetOnlinev0()==fOnFlyStatus)) {
+      pass=false;
+    } else {
+      fHist->FillTrackCounter(3);
+    }
+  }
+  if (pass&&fCutCharge) {
+    if (v0->GetCharge().at(0)!=fCharge) {
+      pass=false;
+    } else {
+      fHist->FillTrackCounter(4);
+    }
+  }
+  if (pass&&fCutPt) {
+    if ((v0->GetPt()<fpTmin)||(v0->GetPt()>fpTmax)) {
+      pass=false;
+    } else {
+      fHist->FillTrackCounter(5);
+    }
+  }
+  if (pass&&fCutDecayVtxXYZ) {
+    if ((v0->GetDCAv0Vtx(0)>fMaxDecayVtxXYZ)||
+        (v0->GetDCAv0Vtx(1)>fMaxDecayVtxXYZ)||
+        (v0->GetDCAv0Vtx(2)>fMaxDecayVtxXYZ)) {
+      pass=false;
+    } else {
+      fHist->FillTrackCounter(6);
+    }
+  }
+  if (pass&&fCutTransRadius) {
+    if ((v0->GetTransverseRadius()<fMinTransRadius)||
+        (v0->GetTransverseRadius()>fMaxTransRadius)) {
+      pass=false;
+    } else {
+      fHist->FillTrackCounter(7);
+    }
+  }
+  if (pass&&fCutMinDCADaugPrimVtx) {
+    if ((v0->GetDCADaugPosVtx()<fMinDCADaugToPrimVtx)||
+        (v0->GetDCADaugNegVtx()<fMinDCADaugToPrimVtx)) {
+      pass=false;
+    } else {
+      fHist->FillTrackCounter(8);
+    }
+  }
+  if (pass&&fCutMaxDCADaugToDecayVtx) {
+    if (v0->GetDaugDCA()>fMaxDCADaugToDecayVtx) {
+      pass=false;
+    } else {
+      fHist->FillTrackCounter(9);
+    }
+  }
+  return pass;
+}
+
+bool AliFemtoDreamv0Cuts::RejectAsKaon(AliFemtoDreamv0 *v0) {
+  bool pass=true;
+  bool cpaPass=true;
+  if (v0->GetCPA()<fMinCPA) {
+    cpaPass=false;
+  }
+  double massKaon=CalculateInvMass(v0,211,211);
+  if (cpaPass) {
+    fHist->FillInvMassBefKaonRej(v0->Getv0Mass());
+    fHist->FillInvMassKaon(massKaon);
+  }
+  if (fKaonRejLow<massKaon&&massKaon<fKaonRejUp) {
+    pass=false;
+  } else {
+    fHist->FillTrackCounter(10);
+  }
+  return pass;
+}
+
+bool AliFemtoDreamv0Cuts::CPAandMassCuts(AliFemtoDreamv0 *v0) {
+  //here we cut mass and cpa to fill the cpa distribution properly
+  bool cpaPass=true;
+  bool massPass=true;
+  if (fCutCPA&&(v0->GetCPA()<fMinCPA)) {
+    cpaPass=false;
+  }
+  if (fCutInvMass) {
+    double massv0=TDatabasePDG::Instance()->GetParticle(fPDGv0)->Mass();
+    if ((v0->Getv0Mass()<massv0-fInvMassCutWidth)||
+        (massv0+fInvMassCutWidth<v0->Getv0Mass())) {
+      massPass=false;
+    }
+  }
+  //now with this information fill the histograms
+  if (cpaPass) {
+    fHist->FillInvMassPtBins(v0->GetPt(),v0->Getv0Mass());
+    fHist->Fillv0MassDist(v0->Getv0Mass());
+  }
+  if (massPass&&fCPAPlots) {
+    fHist->FillCPAPtBins(v0->GetPt(),v0->GetCPA());
+    if (fMCData) {
+      fMCHist->FillMCCPAPtBins(
+          v0->GetParticleOrigin(),v0->GetPt(),v0->GetCPA());
+    }
+  }
+  if (massPass) {
+    fHist->FillTrackCounter(11);
+  }
+  if (massPass && cpaPass) {
+    fHist->FillTrackCounter(12);
+  }
+  bool pass=massPass&&cpaPass;
+  return pass;
+}
+void AliFemtoDreamv0Cuts::Init() {
+  fHist=new AliFemtoDreamv0Hist(fNumberXBins,fAxisMinMass,fAxisMaxMass,
+                                fCPAPlots);
+  BookTrackCuts();
+  if (fMCData) {
+    fMCHist=new AliFemtoDreamv0MCHist(fNumberXBins,fAxisMinMass,fAxisMaxMass,
+                                      fContribSplitting,fCPAPlots);
+  }
+  fPosCuts->Init();
+  fNegCuts->Init();
+  fHistList = new TList();
+  fHistList->SetOwner();
+  fHistList->SetName("v0Cuts");
+  fHistList->Add(fHist->GetHistList());
+  fPosCuts->SetName("PosCuts");
+  fHistList->Add(fPosCuts->GetQAHists());
+  fNegCuts->SetName("NegCuts");
+  fHistList->Add(fNegCuts->GetQAHists());
+}
+
+
+void AliFemtoDreamv0Cuts::BookQA(AliFemtoDreamv0 *v0) {
+  for (int i=0;i<2;++i) {
+    if (i==0||(i==1&&v0->UseParticle())) {
+      if (!v0->GetOnlinev0()) {
+        fHist->FillOnFlyStatus(i,1);
+      } else if (v0->GetOnlinev0()) {
+        fHist->FillOnFlyStatus(i,0);
+      }
+      fHist->FillpTCut(i,v0->GetPt());
+      fHist->FillEtaCut(i,v0->GetEta().at(0));
+      fHist->Fillv0DecayVtxXCut(i,v0->GetDCAv0Vtx(0));
+      fHist->Fillv0DecayVtxYCut(i,v0->GetDCAv0Vtx(1));
+      fHist->Fillv0DecayVtxZCut(i,v0->GetDCAv0Vtx(2));
+      fHist->FillTransverRadiusCut(i,v0->GetTransverseRadius());
+      fHist->FillDCAPosDaugToPrimVtxCut(i,v0->GetDCADaugPosVtx());
+      fHist->FillDCANegDaugToPrimVtxCut(i,v0->GetDCADaugNegVtx());
+      fHist->FillDCADaugTov0VtxCut(i,v0->GetDaugDCA());
+      fHist->FillCPACut(i,v0->GetCPA());
+      fHist->FillInvMass(i,v0->Getv0Mass());
+    }
+  }
+  v0->GetPosDaughter()->SetUse(v0->UseParticle());
+  v0->GetNegDaughter()->SetUse(v0->UseParticle());
+  if (fMCData) {
+    v0->GetPosDaughter()->SetParticleOrigin(v0->GetParticleOrigin());
+    v0->GetNegDaughter()->SetParticleOrigin(v0->GetParticleOrigin());
+  }
+  fPosCuts->BookQA(v0->GetPosDaughter());
+  fNegCuts->BookQA(v0->GetNegDaughter());
+}
+
+void AliFemtoDreamv0Cuts::BookMC(AliFemtoDreamv0 *v0) {
+  double pT=v0->GetPt();
+  double etaNegDaug=v0->GetEta().at(1);
+  double etaPosDaug=v0->GetEta().at(2);
+  if (v0->GetMCPDGCode()==fPDGv0) {
+    if (fpTmin<pT&&pT<fpTmax) {
+      if (fPosCuts->GetEtaMin()<etaPosDaug&&etaPosDaug<fPosCuts->GetEtaMax()) {
+        if (fNegCuts->GetEtaMin()<etaNegDaug&&etaNegDaug<fNegCuts->GetEtaMax()) {
+          fMCHist->FillMCGen(pT);
+        }
+      }
+    }
+  }
+  if (v0->UseParticle()) {
+    fMCHist->FillMCIdent(pT);
+    if (TMath::Abs(v0->GetMCPDGCode())==TMath::Abs(fPDGv0)) {
+      fMCHist->FillMCCorr(pT);
+    } else {
+      v0->SetParticleOrigin(AliFemtoDreamBasePart::kContamination);
+    }
+    if (fContribSplitting) {
+      FillMCContributions(v0);
+    }
+  }
+}
+
+void AliFemtoDreamv0Cuts::FillMCContributions(AliFemtoDreamv0 *v0) {
+  Double_t pT = v0->GetPt();
+  Int_t iFill = -1;
+  switch(v0->GetParticleOrigin()){
+    case AliFemtoDreamBasePart::kPhysPrimary:
+      fMCHist->FillMCPrimary(pT);
+      iFill = 0;
+      break;
+    case AliFemtoDreamBasePart::kWeak:
+      fMCHist->FillMCFeeddown(pT, TMath::Abs(v0->GetMotherWeak()));
+      iFill = 1;
+      break;
+    case AliFemtoDreamBasePart::kMaterial:
+      fMCHist->FillMCMaterial(pT);
+      iFill = 2;
+      break;
+    case AliFemtoDreamBasePart::kContamination:
+      fMCHist->FillMCCont(pT);
+      iFill = 3;
+      break;
+    default:
+      AliFatal("Type Not implemented");
+      break;
+  }
+  fMCHist->FillMCpT(iFill,pT);
+  fMCHist->FillMCEta(iFill,v0->GetEta().at(0));
+  fMCHist->FillMCPhi(iFill,v0->GetPhi().at(0));
+  fMCHist->FillMCDCAVtxX(iFill,pT,v0->GetDCAv0Vtx(0));
+  fMCHist->FillMCDCAVtxY(iFill,pT,v0->GetDCAv0Vtx(1));
+  fMCHist->FillMCDCAVtxZ(iFill,pT,v0->GetDCAv0Vtx(2));
+  fMCHist->FillMCTransverseRadius(iFill,pT,v0->GetTransverseRadius());
+  fMCHist->FillMCDCAPosDaugPrimVtx(iFill,pT,v0->GetDCADaugPosVtx());
+  fMCHist->FillMCDCANegDaugPrimVtx(iFill,pT,v0->GetDCADaugNegVtx());
+  fMCHist->FillMCDCADaugVtx(iFill,pT,v0->GetDaugDCA());
+  fMCHist->FillMCCosPoint(iFill,pT,v0->GetCPA());
+  fMCHist->FillMCInvMass(iFill,v0->Getv0Mass());
+}
+void AliFemtoDreamv0Cuts::BookTrackCuts() {
+  if (!fHist) {
+    AliFatal("No Histograms available");
+  }
+  if (fCutOnFlyStatus) {
+    fHist->FillConfig(0,1);
+  }
+  if (fCutCharge) {
+    fHist->FillConfig(1,fCharge);
+  }
+  if (fCutPt) {
+    fHist->FillConfig(2,fpTmin);
+    fHist->FillConfig(3,fpTmax);
+  }
+  if (fKaonRejection) {
+    fHist->FillConfig(4,1);
+  }
+  if (fCutDecayVtxXYZ) {
+    fHist->FillConfig(5,fMaxDecayVtxXYZ);
+  }
+  if (fCutTransRadius) {
+    fHist->FillConfig(6,fMinTransRadius);
+    fHist->FillConfig(7,fMaxTransRadius);
+  }
+  if (fCutMinDCADaugPrimVtx) {
+    fHist->FillConfig(8,fMinDCADaugToPrimVtx);
+  }
+  if (fCutMaxDCADaugToDecayVtx) {
+    fHist->FillConfig(9,fMaxDCADaugToDecayVtx);
+  }
+  if (fCutInvMass) {
+    fHist->FillConfig(10,fInvMassCutWidth);
+  }
+  if (fCutCPA) {
+    fHist->FillConfig(11,fMinCPA);
+  }
+}
+
+double AliFemtoDreamv0Cuts::CalculateInvMass(AliFemtoDreamv0 *v0,
+                                             int PDGPosDaug,int PDGNegDaug) {
+  Double_t invMass = 0;
+  double massDP=TDatabasePDG::Instance()->GetParticle(PDGPosDaug)->Mass();
+  double massDN=TDatabasePDG::Instance()->GetParticle(PDGNegDaug)->Mass();
+
+  double EDaugP=TMath::Sqrt(
+      massDP*massDP +
+      v0->GetPosDaughter()->GetMomentum().X()*v0->GetPosDaughter()->GetMomentum().X()+
+      v0->GetPosDaughter()->GetMomentum().Y()*v0->GetPosDaughter()->GetMomentum().Y()+
+      v0->GetPosDaughter()->GetMomentum().Z()*v0->GetPosDaughter()->GetMomentum().Z());
+  double EDaugN=TMath::Sqrt(
+      massDN*massDN +
+      v0->GetNegDaughter()->GetMomentum().X()*v0->GetNegDaughter()->GetMomentum().X()+
+      v0->GetNegDaughter()->GetMomentum().Y()*v0->GetNegDaughter()->GetMomentum().Y()+
+      v0->GetNegDaughter()->GetMomentum().Z()*v0->GetNegDaughter()->GetMomentum().Z());
+
+  double energysum=EDaugP+EDaugN;
+  double pSum2=
+      (v0->GetNegDaughter()->GetMomentum().X()+v0->GetPosDaughter()->GetMomentum().X())*
+      (v0->GetNegDaughter()->GetMomentum().X()+v0->GetPosDaughter()->GetMomentum().X())+
+
+      (v0->GetNegDaughter()->GetMomentum().Y()+v0->GetPosDaughter()->GetMomentum().Y())*
+      (v0->GetNegDaughter()->GetMomentum().Y()+v0->GetPosDaughter()->GetMomentum().Y())+
+
+      (v0->GetNegDaughter()->GetMomentum().Z()+v0->GetPosDaughter()->GetMomentum().Z())*
+      (v0->GetNegDaughter()->GetMomentum().Z()+v0->GetPosDaughter()->GetMomentum().Z());
+  invMass = TMath::Sqrt(energysum*energysum - pSum2);
+  return invMass;
+}

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0Cuts.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0Cuts.h
@@ -1,0 +1,126 @@
+/*
+ * AliFemtoDreamv0Cuts.h
+ *
+ *  Created on: Dec 12, 2017
+ *      Author: gu74req
+ */
+
+#ifndef ALIFEMTODREAMV0CUTS_H_
+#define ALIFEMTODREAMV0CUTS_H_
+#include "Rtypes.h"
+#include "AliFemtoDreamTrackCuts.h"
+#include "AliFemtoDreamv0MCHist.h"
+#include "AliFemtoDreamv0Hist.h"
+#include "AliFemtoDreamv0.h"
+class AliFemtoDreamv0Cuts {
+ public:
+  AliFemtoDreamv0Cuts();
+  virtual ~AliFemtoDreamv0Cuts();
+  static AliFemtoDreamv0Cuts* LambdaCuts(bool isMC,bool CPAPlots,
+                                         bool SplitContrib);
+  //Setters for plots
+  void SetIsMonteCarlo(bool isMC){fMCData=isMC;};
+  bool GetIsMonteCarlo(){return fMCData;};
+  void SetPlotCPADist(bool plot) {fCPAPlots=plot;};
+  void SetPlotContrib(bool plot) {fContribSplitting=plot;};
+  void SetAxisInvMassPlots(int nBins,double minMass,double maxMass) {
+    fNumberXBins=nBins;fAxisMinMass=minMass;fAxisMaxMass=maxMass;
+  }
+  //Setters for the daughter track cuts
+  void SetPosDaugterTrackCuts(AliFemtoDreamTrackCuts *cuts){fPosCuts=cuts;};
+  void SetNegDaugterTrackCuts(AliFemtoDreamTrackCuts *cuts){fNegCuts=cuts;};
+  //Setters for PDG Codes of the daughters+v0
+  void SetPDGCodev0(int pdgCode) {fPDGv0=pdgCode;};
+  int GetPDGv0() const {return fPDGv0;};
+  void SetPDGCodePosDaug(int pdgCode) {fPDGDaugP=pdgCode;};
+  int GetPDGPosDaug() const {return fPDGDaugP;};
+  void SetPDGCodeNegDaug(int pdgCode) {fPDGDaugN=pdgCode;};
+  int GetPDGNegDaug() const {return fPDGDaugN;};
+  //Setters v0 cuts
+  void SetCheckOnFlyStatus(bool val) {fOnFlyStatus=val;fCutOnFlyStatus=true;};
+  void SetCutCharge(int charge) {fCutCharge=true;fCharge=charge;};
+  void SetPtRange(double pmin,double pmax) {
+    fpTmin=pmin;fpTmax=pmax;fCutPt=true;
+  }
+  void SetKaonRejection(double MassLow,double MassUp) {
+    fKaonRejection=true;fKaonRejLow=MassLow;fKaonRejUp=MassUp;
+  };
+  void SetCutMaxDecayVtx(double maxDecayVtx)  {
+    fCutDecayVtxXYZ=true;fMaxDecayVtxXYZ=maxDecayVtx;
+  };
+  void SetCutTransverseRadius(double minRadius,double maxRadius) {
+    fMinTransRadius=minRadius;fMaxTransRadius=maxRadius;fCutTransRadius=true;
+  }
+  void SetCutDCADaugToPrimVtx(double minDCA) {
+    fMinDCADaugToPrimVtx=minDCA;fCutMinDCADaugPrimVtx=true;
+  };
+  void SetCutDCADaugTov0Vtx(double maxDCA) {
+    fMaxDCADaugToDecayVtx=maxDCA;fCutMaxDCADaugToDecayVtx=true;
+  }
+  void SetCutCPA(double cpa) {fMinCPA=cpa;fCutCPA=true;};
+  void SetCutInvMass(double width){fInvMassCutWidth=width;fCutInvMass=true;};
+  void Init();
+  TList *GetQAHists() {return fHistList;};
+//  TList *GetQAHistsPosDaug() {return fPosCuts->GetQAHists();};
+//  TList *GetQAHistsNegDaug() {return fNegCuts->GetQAHists();};
+  TList *GetMCQAHists() {return fMCHist->GetHistList();};
+//  TList *GetMCQAHistsPosDaug() {return fPosCuts->GetMCQAHists();};
+//  TList *GetMCQAHistsNegDaug() {return fNegCuts->GetMCQAHists();};
+  bool isSelected(AliFemtoDreamv0 *v0);
+  TString ClassName(){return "v0Cuts";};
+ private:
+  bool RejectAsKaon(AliFemtoDreamv0 *v0);
+  bool DaughtersPassCuts(AliFemtoDreamv0 *v0);
+  bool MotherPassCuts(AliFemtoDreamv0 *v0);
+  bool CPAandMassCuts(AliFemtoDreamv0 *v0);
+  void BookQA(AliFemtoDreamv0 *v0);
+  void BookMC(AliFemtoDreamv0 *v0);
+  void BookTrackCuts();
+  void FillMCContributions(AliFemtoDreamv0 *v0);
+  double CalculateInvMass(AliFemtoDreamv0 *v0,int PDGPosDaug,int PDGNegDaug);
+  TList *fHistList;                   //!
+  AliFemtoDreamv0MCHist *fMCHist;     //!
+  AliFemtoDreamv0Hist *fHist;         //!
+  //Here the cut values for the Daughters are stored
+  AliFemtoDreamTrackCuts *fPosCuts;   //
+  AliFemtoDreamTrackCuts *fNegCuts;   //
+  //These are all the cuts directly linked to the v0
+  bool fMCData;                       //
+  bool fCPAPlots;                     //
+  bool fContribSplitting;             //
+  bool fCutOnFlyStatus;               //
+  bool fOnFlyStatus;                  //
+  bool fCutCharge;                    //
+  int fCharge;                        //
+  bool fCutPt;                        //
+  double fpTmin;                      //
+  double fpTmax;                      //
+  bool fKaonRejection;                //
+  double fKaonRejLow;                 //
+  double fKaonRejUp;                  //
+  bool fCutDecayVtxXYZ;               //
+  double fMaxDecayVtxXYZ;             //
+  bool fCutTransRadius;               //
+  double fMinTransRadius;             //
+  double fMaxTransRadius;             //
+  bool fCutMinDCADaugPrimVtx;         //
+  double fMinDCADaugToPrimVtx;        //
+  bool fCutMaxDCADaugToDecayVtx;      //
+  double fMaxDCADaugToDecayVtx;       //
+  bool fCutCPA;                       //
+  double fMinCPA;                     //
+  bool fCutInvMass;                   //
+  double fInvMassCutWidth;            //
+  //Range for the axis of the hists
+  double fAxisMinMass;                //
+  double fAxisMaxMass;                //
+  int fNumberXBins;                   //
+  //PDG Codes of the Mother and the Daughter needed for Inv Mass Calc. and
+  //matching in the MC Sample
+  int fPDGv0;
+  int fPDGDaugP;
+  int fPDGDaugN;
+  ClassDef(AliFemtoDreamv0Cuts,1)
+};
+
+#endif /* ALIFEMTODREAMV0CUTS_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0Hist.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0Hist.cxx
@@ -1,0 +1,216 @@
+/*
+ * AliFemtoDreamv0Hist.cxx
+ *
+ *  Created on: Dec 12, 2017
+ *      Author: gu74req
+ */
+
+#include "AliFemtoDreamv0Hist.h"
+#include "TMath.h"
+ClassImp(AliFemtoDreamv0Hist)
+AliFemtoDreamv0Hist::AliFemtoDreamv0Hist()
+:fHistList(0)
+,fConfig(0)
+,fCutCounter(0)
+,fInvMassBefKaonRej(0)
+,fInvMassKaon(0)
+,fInvMassBefSelection(0)
+,fInvMassPt(0)
+,fCPAPtBins(0)
+{
+  for (int i=0;i<2;++i) {
+    fv0CutQA[i]=0;
+    fOnFly[i]=0;
+    fpTDist[i]=0;
+    fetaDist[i]=0;
+    fDecayVtxv0X[i]=0;
+    fDecayVtxv0Y[i]=0;
+    fDecayVtxv0Z[i]=0;
+    fTransRadius[i]=0;
+    fDCAPosDaugToPrimVtx[i]=0;
+    fDCANegDaugToPrimVtx[i]=0;
+    fDCADaugToVtx[i]=0;
+    fCPA[i]=0;
+    fInvMass[i]=0;
+  }
+}
+
+AliFemtoDreamv0Hist::AliFemtoDreamv0Hist(int MassNBins,double MassMin,
+                                         double MassMax,bool CPAPlots) {
+  TString sName[2]={"before","after"};
+
+  fHistList=new TList();
+  fHistList->SetName("v0Cuts");
+  fHistList->SetOwner();
+
+  fConfig = new TProfile("TrackCutConfig", "Track Cut Config", 20, 0, 20);
+  fConfig->SetStats(0);
+  fConfig->GetXaxis()->SetBinLabel(1, "OnFly Status");
+  fConfig->GetXaxis()->SetBinLabel(2, "Charge");
+  fConfig->GetXaxis()->SetBinLabel(3, "p_{T, Min}");
+  fConfig->GetXaxis()->SetBinLabel(4, "p_{T, Max}");
+  fConfig->GetXaxis()->SetBinLabel(5, "K0 Rejection");
+  fConfig->GetXaxis()->SetBinLabel(6, "Max Decay Vertex XYZ");
+  fConfig->GetXaxis()->SetBinLabel(7, "Min Transverse Radius");
+  fConfig->GetXaxis()->SetBinLabel(8, "Max Transverse Radius");
+  fConfig->GetXaxis()->SetBinLabel(9, "Min DCA to PV of Daug");
+  fConfig->GetXaxis()->SetBinLabel(10,"Max Distance Daug to Vertex");
+  fConfig->GetXaxis()->SetBinLabel(11,"Inv Mass Cut");
+  fConfig->GetXaxis()->SetBinLabel(12,"Min Cos Pointing Angle");
+
+  fHistList->Add(fConfig);
+
+  fCutCounter = new TH1F("CutCounter", "Cut Counter", 20, 0, 20);
+  fCutCounter->GetXaxis()->SetBinLabel(1, "Input");
+  fCutCounter->GetXaxis()->SetBinLabel(2, "Has Daug");
+  fCutCounter->GetXaxis()->SetBinLabel(3, "Daugters pass Cuts");
+  fCutCounter->GetXaxis()->SetBinLabel(4, "On Fly Status");
+  fCutCounter->GetXaxis()->SetBinLabel(5, "Charge");
+  fCutCounter->GetXaxis()->SetBinLabel(6, "p_{T}");
+  fCutCounter->GetXaxis()->SetBinLabel(7, "v0 DCA PV");
+  fCutCounter->GetXaxis()->SetBinLabel(8, "Transverse Radius");
+  fCutCounter->GetXaxis()->SetBinLabel(9, "Daug PV");
+  fCutCounter->GetXaxis()->SetBinLabel(10, "Daug Vtx");
+  fCutCounter->GetXaxis()->SetBinLabel(11, "K0 Rejection");
+  fCutCounter->GetXaxis()->SetBinLabel(12, "Inv Mass Cut");
+  fCutCounter->GetXaxis()->SetBinLabel(13, "Cos Pointing Angle");
+  fCutCounter->GetXaxis()->SetBinLabel(14, "D1&D2 right");
+  fCutCounter->GetXaxis()->SetBinLabel(15, "D1&D2 pass cuts");
+  fCutCounter->GetXaxis()->SetBinLabel(16, "D1&D2 wrong");
+  fCutCounter->GetXaxis()->SetBinLabel(16, "D1&D2 pass cuts");
+
+  fHistList->Add(fCutCounter);
+
+  fInvMassBefKaonRej = new TH1F("InvMassBefK0Rej","InvMassBefK0Rej",
+                                MassNBins,MassMin,MassMax);
+  fInvMassBefKaonRej->Sumw2();
+  fInvMassBefKaonRej->GetXaxis()->SetName("m_{Pair}");
+  fHistList->Add(fInvMassBefKaonRej);
+
+  fInvMassKaon = new TH1F("InvMassKaon","InvMassKaon",400,0.4,0.6);
+  fInvMassKaon->Sumw2();
+  fInvMassKaon->GetXaxis()->SetName("m_{Pair}");
+  fHistList->Add(fInvMassKaon);
+
+  fInvMassBefSelection = new TH1F("InvMasswithCuts","InvMasswithCuts",MassNBins,MassMin,MassMax);
+  fInvMassBefSelection->Sumw2();
+  fInvMassBefSelection->GetXaxis()->SetName("m_{Pair}");
+  fHistList->Add(fInvMassBefSelection);
+
+  fInvMassPt=new TH2F("InvMassPt","Invariant Mass in Pt Bins",
+                      8,0.3,4.3,MassNBins,MassMin,MassMax);
+  fInvMassPt->Sumw2();
+  fInvMassPt->GetXaxis()->SetTitle("P_{T}");
+  fInvMassPt->GetYaxis()->SetTitle("m_{Pair}");
+  fHistList->Add(fInvMassPt);
+
+  for(int i=0;i<2;++i){
+    fv0CutQA[i] = new TList();
+    fv0CutQA[i]->SetName(sName[i].Data());
+    fv0CutQA[i]->SetOwner();
+    fHistList->Add(fv0CutQA[i]);
+
+    TString OnFlyName = Form("OnFly_%s",sName[i].Data());
+    fOnFly[i] = new TH1F(OnFlyName.Data(),OnFlyName.Data(), 2, 0, 2.);
+    fOnFly[i]->Sumw2();
+    fOnFly[i]->GetXaxis()->SetBinLabel(1,"Online");
+    fOnFly[i]->GetXaxis()->SetBinLabel(2,"Offline");
+    fv0CutQA[i]->Add(fOnFly[i]);
+
+    TString ptname = Form("pTDist_%s",sName[i].Data());
+    fpTDist[i] = new TH1F(ptname.Data(),ptname.Data(),100,0,10.);
+    fpTDist[i]->Sumw2();
+    fpTDist[i]->GetXaxis()->SetTitle("P_{T}");
+    fv0CutQA[i]->Add(fpTDist[i]);
+
+    TString etaname = Form("EtaDist_%s",sName[i].Data());
+    fetaDist[i] = new TH1F(etaname.Data(),etaname.Data(),200,-10.,10.);
+    fetaDist[i]->Sumw2();
+    fetaDist[i]->GetXaxis()->SetTitle("#eta");
+    fv0CutQA[i]->Add(fetaDist[i]);
+
+    TString phiname = Form("PhiDist_%s",sName[i].Data());
+    fPhiDist[i] = new TH1F(phiname.Data(),phiname.Data(),100,0.,2*TMath::Pi());
+    fPhiDist[i]->Sumw2();
+    fPhiDist[i]->GetXaxis()->SetTitle("#phi");
+    fv0CutQA[i]->Add(fPhiDist[i]);
+
+    TString decayVtxXname = Form("DecayVtxXPV_%s",sName[i].Data());
+    fDecayVtxv0X[i] = new TH1F(decayVtxXname.Data(),decayVtxXname.Data(),
+                               400,0.,200);
+    fDecayVtxv0X[i]->Sumw2();
+    fDecayVtxv0X[i]->GetXaxis()->SetTitle("Decay Vtx To PV X");
+    fv0CutQA[i]->Add(fDecayVtxv0X[i]);
+
+    TString decayVtxYname = Form("DecayVtxYPV_%s",sName[i].Data());
+    fDecayVtxv0Y[i] = new TH1F(decayVtxYname.Data(),decayVtxYname.Data(),
+                               400,0.,200);
+    fDecayVtxv0Y[i]->Sumw2();
+    fDecayVtxv0Y[i]->GetXaxis()->SetTitle("Decay Vtx To PV Y");
+    fv0CutQA[i]->Add(fDecayVtxv0Y[i]);
+
+    TString decayVtxZname = Form("DecayVtxZPV_%s",sName[i].Data());
+    fDecayVtxv0Z[i] = new TH1F(decayVtxZname.Data(),
+                               decayVtxZname.Data(),400,0.,200);
+    fDecayVtxv0Z[i]->Sumw2();
+    fDecayVtxv0Z[i]->GetXaxis()->SetTitle("Decay Vtx To PV Z");
+    fv0CutQA[i]->Add(fDecayVtxv0Z[i]);
+
+    TString transverseRadname = Form("TransverseRadius_%s",sName[i].Data());
+    fTransRadius[i] = new TH1F(transverseRadname.Data(),
+                               transverseRadname.Data(),750,0,150);
+    fTransRadius[i]->Sumw2();
+    fTransRadius[i]->GetXaxis()->SetTitle("Transverse Radius");
+    fv0CutQA[i]->Add(fTransRadius[i]);
+
+    TString DCADauPVPname = Form("DCADauPToPV_%s",sName[i].Data());
+    fDCAPosDaugToPrimVtx[i] = new TH1F(DCADauPVPname.Data(),
+                                       DCADauPVPname.Data(),500,0,100);
+    fDCAPosDaugToPrimVtx[i]->Sumw2();
+    fDCAPosDaugToPrimVtx[i]->GetXaxis()->SetTitle("DCADaugther P to PV");
+    fv0CutQA[i]->Add(fDCAPosDaugToPrimVtx[i]);
+
+    TString DCADauPVNname = Form("DCADauNToPV_%s", sName[i].Data());
+    fDCANegDaugToPrimVtx[i] = new TH1F(DCADauPVNname.Data(),
+                                       DCADauPVNname.Data(),500,0,100);
+    fDCANegDaugToPrimVtx[i]->Sumw2();
+    fDCANegDaugToPrimVtx[i]->GetXaxis()->SetTitle("DCADaugther N to PV");
+    fv0CutQA[i]->Add(fDCANegDaugToPrimVtx[i]);
+
+    TString DCADaugVtxname = Form("DCADauToVtx_%s", sName[i].Data());
+    fDCADaugToVtx[i] = new TH1F(DCADaugVtxname.Data(),DCADaugVtxname.Data(),
+                                100,0,10);
+    fDCADaugToVtx[i]->Sumw2();
+    fDCADaugToVtx[i]->GetXaxis()->SetTitle("DCA Daug to Vtx");
+    fv0CutQA[i]->Add(fDCADaugToVtx[i]);
+
+    TString cosPointName = Form("PointingAngle_%s", sName[i].Data());
+    fCPA[i] = new TH1F(cosPointName.Data(),cosPointName.Data(),500,0.8,1.001);
+    fCPA[i]->Sumw2();
+    fCPA[i]->GetXaxis()->SetTitle("Cos Pointing Angle");
+    fv0CutQA[i]->Add(fCPA[i]);
+
+    TString invMassName = Form("InvariantMass_%s", sName[i].Data());
+    fInvMass[i] = new TH1F(invMassName.Data(),invMassName.Data(),
+                           MassNBins,MassMin,MassMax);
+    fInvMass[i]->Sumw2();
+    fInvMass[i]->GetXaxis()->SetTitle("m_{Pair}");
+    fv0CutQA[i]->Add(fInvMass[i]);
+  }
+
+  if (CPAPlots) {
+      fCPAPtBins=new TH2F("CPAPtBinsTot","CPAPtBinsTot",
+                          8,0.3,4.3,1000,0.90,1.);
+      fCPAPtBins->Sumw2();
+      fCPAPtBins->GetXaxis()->SetTitle("P_{T}");
+      fCPAPtBins->GetYaxis()->SetTitle("CPA");
+      fHistList->Add(fCPAPtBins);
+  } else {
+      fCPAPtBins=0;
+  }
+}
+
+AliFemtoDreamv0Hist::~AliFemtoDreamv0Hist() {
+  delete fHistList;
+}
+

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0Hist.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0Hist.h
@@ -1,0 +1,73 @@
+/*
+ * AliFemtoDreamv0Hist.h
+ *
+ *  Created on: Dec 12, 2017
+ *      Author: gu74req
+ */
+
+#ifndef ALIFEMTODREAMV0HIST_H_
+#define ALIFEMTODREAMV0HIST_H_
+#include "Rtypes.h"
+#include "TList.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TProfile.h"
+
+class AliFemtoDreamv0Hist {
+ public:
+  AliFemtoDreamv0Hist();
+  AliFemtoDreamv0Hist(
+      int MassNBins,double MassMin,double MassMax,bool CPAPlots);
+  virtual ~AliFemtoDreamv0Hist();
+  void FillConfig(int iBin,double val){fConfig->Fill(iBin,val);};
+  void FillTrackCounter(int iBin){fCutCounter->Fill(iBin);};
+  void FillOnFlyStatus(int i,double val){fOnFly[i]->Fill(val);};
+  void FillpTCut(int i,double pT){fpTDist[i]->Fill(pT);};
+  void FillPhi(int i,double phi){fPhiDist[i]->Fill(phi);};
+  void FillEtaCut(int i,double eta){fetaDist[i]->Fill(eta);};
+  void Fillv0DecayVtxXCut(int i,double vtx){fDecayVtxv0X[i]->Fill(vtx);};
+  void Fillv0DecayVtxYCut(int i,double vtx){fDecayVtxv0Y[i]->Fill(vtx);};
+  void Fillv0DecayVtxZCut(int i,double vtx){fDecayVtxv0Z[i]->Fill(vtx);};
+  void FillTransverRadiusCut(int i,double rad){fTransRadius[i]->Fill(rad);};
+  void FillDCAPosDaugToPrimVtxCut(int i,double dca){
+    fDCAPosDaugToPrimVtx[i]->Fill(dca);
+  };
+  void FillDCANegDaugToPrimVtxCut(int i,double dca){
+    fDCANegDaugToPrimVtx[i]->Fill(dca);
+  };
+  void FillDCADaugTov0VtxCut(int i, double dca){fDCADaugToVtx[i]->Fill(dca);};
+  void FillCPACut(int i,double cpa){fCPA[i]->Fill(cpa);};
+  void FillInvMass(int i,double mass){fInvMass[i]->Fill(mass);};
+  void FillInvMassBefKaonRej(double mass){fInvMassBefKaonRej->Fill(mass);};
+  void FillInvMassKaon(double mass){fInvMassKaon->Fill(mass);};
+  void Fillv0MassDist(double mass){fInvMassBefSelection->Fill(mass);};
+  void FillInvMassPtBins(double pT,double mass){fInvMassPt->Fill(pT,mass);};
+  void FillCPAPtBins(double pT,double cpa){fCPAPtBins->Fill(pT,cpa);};
+  TList *GetHistList(){return fHistList;};
+ private:
+  TList *fHistList;
+  TList *fv0CutQA[2];
+  TProfile *fConfig;
+  TH1F *fCutCounter;
+  TH1F *fOnFly[2];
+  TH1F *fpTDist[2];
+  TH1F *fPhiDist[2];
+  TH1F *fetaDist[2];
+  TH1F *fDecayVtxv0X[2];
+  TH1F *fDecayVtxv0Y[2];
+  TH1F *fDecayVtxv0Z[2];
+  TH1F *fTransRadius[2];
+  TH1F *fDCAPosDaugToPrimVtx[2];
+  TH1F *fDCANegDaugToPrimVtx[2];
+  TH1F *fDCADaugToVtx[2];
+  TH1F *fCPA[2];
+  TH1F *fInvMass[2];
+  TH1F *fInvMassBefKaonRej;
+  TH1F *fInvMassKaon;
+  TH1F *fInvMassBefSelection;
+  TH2F *fInvMassPt;
+  TH2F *fCPAPtBins;
+  ClassDef(AliFemtoDreamv0Hist,1)
+};
+
+#endif /* ALIFEMTODREAMV0HIST_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0MCHist.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0MCHist.cxx
@@ -93,7 +93,6 @@ AliFemtoDreamv0MCHist::AliFemtoDreamv0MCHist(
   fMCFeeddownWeakPt->Sumw2();
   fMCFeeddownWeakPt->GetXaxis()->SetTitle("p_{T}");
   fMCList->Add(fMCFeeddownWeakPt);
-
   if (contribSplitting) {
     TString MCModes[4] = {"Primary","Secondary","Material","Contamination"};
     for (int i=0;i<4;++i) {

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0MCHist.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0MCHist.cxx
@@ -1,0 +1,271 @@
+/*
+ * AliFemtoDreamv0MCHist.cxx
+ *
+ *  Created on: Dec 12,2017
+ *      Author: gu74req
+ */
+
+#include "AliFemtoDreamv0MCHist.h"
+#include "AliFemtoDreamBasePart.h"
+ClassImp(AliFemtoDreamv0MCHist)
+AliFemtoDreamv0MCHist::AliFemtoDreamv0MCHist()
+:fMCList(0)
+,fCPAPlots(0)
+,fMCCorrPt(0)
+,fMCIdentPt(0)
+,fMCGenPt(0)
+,fMCContPt(0)
+,fMCUnknownPt(0)
+,fMCPrimaryPt(0)
+,fMCMaterialPt(0)
+,fMCFeeddownWeakPt(0)
+,fMCPrimCPAPtBins(0)
+,fMCMaterialCPAPtBins(0)
+,fMCSecondaryCPAPtBins(0)
+,fMCContCPAPtBins(0)
+{
+  for (int i=0;i<4;++i) {
+    fMCQAPlots[i] = 0;
+    fMCpTDist[i] = 0;
+    fMCetaDist[i] = 0;
+    fMCphiDist[i] = 0;
+    fMCDecayVtxv0X[i] = 0;
+    fMCDecayVtxv0Y[i] = 0;
+    fMCDecayVtxv0Z[i] = 0;
+    fMCTransverseRadius[i] = 0;
+    fMCDCAPosDaugToPV[i] = 0;
+    fMCDCANegDaugToPV[i] = 0;
+    fMCDCADaugToVtx[i] = 0;
+    fMCCosPointing[i] = 0;
+    fMCInvMass[i] = 0;
+  }
+}
+
+AliFemtoDreamv0MCHist::AliFemtoDreamv0MCHist(
+    int MassNBins,double MassMin,double MassMax,bool contribSplitting,
+    bool CPADist)
+{
+  double ptmin=0.;
+  double ptmax=5.;
+  int ptBins=50;
+
+  fMCList=new TList();
+  fMCList->SetName("v0MonteCarlo");
+  fMCList->SetOwner();
+
+  fMCCorrPt = new TH1F("CorrParPt","Correct Particles Pt",ptBins,ptmin,ptmax);
+  fMCCorrPt->Sumw2();
+  fMCCorrPt->GetXaxis()->SetTitle("p_{T}");
+  fMCList->Add(fMCCorrPt);
+
+  fMCIdentPt = new TH1F("IdentPartPt","Ident Particles Pt",ptBins,ptmin,ptmax);
+  fMCIdentPt->Sumw2();
+  fMCIdentPt->GetXaxis()->SetTitle("p_{T}");
+  fMCList->Add(fMCIdentPt);
+
+  fMCGenPt = new TH1F("GenPartPt","Gen Particles Pt",ptBins,ptmin,ptmax);
+  fMCGenPt->Sumw2();
+  fMCGenPt->GetXaxis()->SetTitle("p_{T}");
+  fMCList->Add(fMCGenPt);
+
+  fMCContPt = new TH1F("ContPt","ContPt",ptBins,ptmin,ptmax);
+  fMCContPt->Sumw2();
+  fMCContPt->GetXaxis()->SetTitle("p_{T}");
+  fMCList->Add(fMCContPt);
+
+  fMCUnknownPt = new TH1F("UnknPt","UnknPt",ptBins,ptmin,ptmax);
+  fMCUnknownPt->Sumw2();
+  fMCUnknownPt->GetXaxis()->SetTitle("p_{T}");
+  fMCList->Add(fMCUnknownPt);
+
+  fMCPrimaryPt = new TH1F("PrimaryPt","PrimaryPt",ptBins,ptmin,ptmax);
+  fMCPrimaryPt->Sumw2();
+  fMCPrimaryPt->GetXaxis()->SetTitle("p_{T}");
+  fMCList->Add(fMCPrimaryPt);
+
+  fMCMaterialPt = new TH1F("MatPt","MatPT",ptBins,ptmin,ptmax);
+  fMCMaterialPt->Sumw2();
+  fMCMaterialPt->GetXaxis()->SetTitle("p_{T}");
+  fMCList->Add(fMCMaterialPt);
+
+  fMCFeeddownWeakPt = new TH2F(
+      "FeeddownPt","Feeddown Pt",ptBins,ptmin,ptmax,213,3121,3334);
+  fMCFeeddownWeakPt->Sumw2();
+  fMCFeeddownWeakPt->GetXaxis()->SetTitle("p_{T}");
+  fMCList->Add(fMCFeeddownWeakPt);
+
+  if (contribSplitting) {
+    TString MCModes[4] = {"Primary","Secondary","Material","Contamination"};
+    for (int i=0;i<4;++i) {
+      fMCQAPlots[i] = new TList();
+      fMCQAPlots[i]->SetOwner();
+      fMCQAPlots[i]->SetName(MCModes[i].Data());
+      fMCList->Add(fMCQAPlots[i]);
+
+      TString MCPtDist = Form("MCPt%s",MCModes[i].Data());
+      fMCpTDist[i] = new TH1F(MCPtDist.Data(),MCPtDist.Data(),
+                              ptBins,ptmin,ptmax);
+      fMCpTDist[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCpTDist[i]);
+
+      TString MCEtaDist = Form("MCEta%s",MCModes[i].Data());
+      fMCetaDist[i] = new TH1F(MCEtaDist.Data(),MCEtaDist.Data(),
+                               200,-10.,10.);
+      fMCetaDist[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCetaDist[i]);
+
+      TString MCPhiDist = Form("MCPhi%s",MCModes[i].Data());
+      fMCphiDist[i] = new TH1F(MCPhiDist.Data(),MCPhiDist.Data(),
+                               100,0.,2*TMath::Pi());
+      fMCphiDist[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCphiDist[i]);
+
+      TString MCDecayVtxv0XDist = Form("MCDecayVtxXPV%s",MCModes[i].Data());
+      fMCDecayVtxv0X[i] = new TH2F(
+          MCDecayVtxv0XDist.Data(),MCDecayVtxv0XDist.Data(),
+          ptBins,ptmin,ptmax,400,0,200);
+      fMCDecayVtxv0X[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCDecayVtxv0X[i]);
+
+      TString MCDecayVtxv0YDist = Form("MCDecayVtxYPV%s",MCModes[i].Data());
+      fMCDecayVtxv0Y[i] = new TH2F(
+          MCDecayVtxv0YDist.Data(),MCDecayVtxv0YDist.Data(),
+          ptBins,ptmin,ptmax,400,0,200);
+      fMCDecayVtxv0Y[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCDecayVtxv0Y[i]);
+
+      TString MCDecayVtxv0ZDist = Form("MCDecayVtxZPV%s",MCModes[i].Data());
+      fMCDecayVtxv0Z[i] = new TH2F(
+          MCDecayVtxv0ZDist.Data(),MCDecayVtxv0ZDist.Data(),
+          ptBins,ptmin,ptmax,400,0,200);
+      fMCDecayVtxv0Z[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCDecayVtxv0Z[i]);
+
+      TString MCTransverseRadius =
+          Form("MCTransverseRadius%s",MCModes[i].Data());
+      fMCTransverseRadius[i] = new TH2F(
+          MCTransverseRadius.Data(),MCTransverseRadius.Data(),
+          ptBins,ptmin,ptmax,750,0,150);
+      fMCTransverseRadius[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCTransverseRadius[i]);
+
+      TString MCDCADaugPVP = Form("MCDCADauPToPV%s",MCModes[i].Data());
+      fMCDCAPosDaugToPV[i] = new TH2F(MCDCADaugPVP.Data(),MCDCADaugPVP.Data(),
+                                      ptBins,ptmin,ptmax,500,0,100);
+      fMCDCAPosDaugToPV[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCDCAPosDaugToPV[i]);
+
+      TString MCDCADaugPVN = Form("MCDCADauNToPV%s",MCModes[i].Data());
+      fMCDCANegDaugToPV[i] = new TH2F(MCDCADaugPVN.Data(),MCDCADaugPVN.Data(),
+                                      ptBins,ptmin,ptmax,500,0,100);
+      fMCDCANegDaugToPV[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCDCANegDaugToPV[i]);
+
+      TString MCDCADaugToVTX = Form("MCDCADauToVtx%s",MCModes[i].Data());
+      fMCDCADaugToVtx[i] = new TH2F(
+          MCDCADaugToVTX.Data(),MCDCADaugToVTX.Data(),
+          ptBins,ptmin,ptmax,100,0,10);
+      fMCDCADaugToVtx[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCDCADaugToVtx[i]);
+
+      TString MCCosPointing = Form("MCPointingAngle%s",MCModes[i].Data());
+      fMCCosPointing[i] = new TH2F(
+          MCCosPointing.Data(),MCCosPointing.Data(),
+          ptBins,ptmin,ptmax,400,0.85,1.001);;
+      fMCCosPointing[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCCosPointing[i]);
+
+      TString MCInvMass = Form("MCInvMass%s",MCModes[i].Data());
+      fMCInvMass[i] = new TH1F(MCInvMass.Data(),MCInvMass.Data(),
+                               MassNBins,MassMin,MassMax);
+      fMCInvMass[i]->Sumw2();
+      fMCQAPlots[i]->Add(fMCInvMass[i]);
+    }
+  } else {
+    for (int i=0;i<4;++i) {
+      fMCQAPlots[i] = 0;
+      fMCpTDist[i] = 0;
+      fMCetaDist[i] = 0;
+      fMCphiDist[i] = 0;
+      fMCDecayVtxv0X[i] = 0;
+      fMCDecayVtxv0Y[i] = 0;
+      fMCDecayVtxv0Z[i] = 0;
+      fMCTransverseRadius[i] = 0;
+      fMCDCAPosDaugToPV[i] = 0;
+      fMCDCANegDaugToPV[i] = 0;
+      fMCDCADaugToVtx[i] = 0;
+      fMCCosPointing[i] = 0;
+      fMCInvMass[i] = 0;
+    }
+  }
+
+  if (CPADist) {
+    fCPAPlots=new TList();
+    fCPAPlots->SetName("CPAPtBinning");
+    fCPAPlots->SetOwner();
+    fMCList->Add(fCPAPlots);
+    TString MCPricpaPtBinName = Form("CPAPtBinningPri");
+    TString MCMatcpaPtBinName = Form("CPAPtBinningMat");
+    TString MCSeccpaPtBinName = Form("CPAPtBinningSec");
+    TString MCConcpaPtBinName = Form("CPAPtBinningCont");
+
+    fMCPrimCPAPtBins = new TH2F(
+        MCPricpaPtBinName.Data(),MCPricpaPtBinName.Data(),
+        8,0.3,4.3,1000,0.90,1.);
+    fMCPrimCPAPtBins->Sumw2();
+    fMCPrimCPAPtBins->GetXaxis()->SetTitle("P_{T}");
+    fMCPrimCPAPtBins->GetYaxis()->SetTitle("CPA");
+    fCPAPlots->Add(fMCPrimCPAPtBins);
+
+    fMCMaterialCPAPtBins = new TH2F(
+        MCMatcpaPtBinName.Data(),MCMatcpaPtBinName.Data(),
+        8,0.3,4.3,1000,0.90,1.);
+    fMCMaterialCPAPtBins->Sumw2();
+    fMCMaterialCPAPtBins->GetXaxis()->SetTitle("P_{T}");
+    fMCMaterialCPAPtBins->GetYaxis()->SetTitle("CPA");
+    fCPAPlots->Add(fMCMaterialCPAPtBins);
+
+    fMCSecondaryCPAPtBins = new TH2F(
+        MCSeccpaPtBinName.Data(),MCSeccpaPtBinName.Data(),
+        8,0.3,4.3,1000,0.90,1.);
+    fMCSecondaryCPAPtBins->Sumw2();
+    fMCSecondaryCPAPtBins->GetXaxis()->SetTitle("P_{T}");
+    fMCSecondaryCPAPtBins->GetYaxis()->SetTitle("CPA");
+    fCPAPlots->Add(fMCSecondaryCPAPtBins);
+
+    fMCContCPAPtBins = new TH2F(
+        MCConcpaPtBinName.Data(),MCConcpaPtBinName.Data(),
+        8,0.3,4.3,1000,0.90,1.);
+    fMCContCPAPtBins->Sumw2();
+    fMCContCPAPtBins->GetXaxis()->SetTitle("P_{T}");
+    fMCContCPAPtBins->GetYaxis()->SetTitle("CPA");
+    fCPAPlots->Add(fMCContCPAPtBins);
+  } else {
+    fCPAPlots=0;
+    fMCPrimCPAPtBins=0;
+    fMCMaterialCPAPtBins=0;
+    fMCSecondaryCPAPtBins=0;
+    fMCContCPAPtBins=0;
+  }
+}
+
+AliFemtoDreamv0MCHist::~AliFemtoDreamv0MCHist() {
+  if (fMCList) {
+    delete fMCList;
+  }
+}
+
+void AliFemtoDreamv0MCHist::FillMCCPAPtBins(
+    AliFemtoDreamBasePart::PartOrigin org,double pT,double cpa) {
+  if (org==AliFemtoDreamBasePart::kPhysPrimary) {
+    fMCPrimCPAPtBins->Fill(pT,cpa);
+  } else if(org == AliFemtoDreamBasePart::kWeak) {
+    fMCSecondaryCPAPtBins->Fill(pT,cpa);
+  } else if(org == AliFemtoDreamBasePart::kMaterial) {
+    fMCMaterialCPAPtBins->Fill(pT,cpa);
+  } else if(org == AliFemtoDreamBasePart::kContamination) {
+    fMCContCPAPtBins->Fill(pT,cpa);
+  } else {
+    AliFatal("Particle Origin not implemented");
+  }
+}

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0MCHist.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0MCHist.h
@@ -1,0 +1,91 @@
+/*
+ * AliFemtoDreamv0MCHist.h
+ *
+ *  Created on: Dec 12, 2017
+ *      Author: gu74req
+ */
+
+#ifndef ALIFEMTODREAMV0MCHIST_H_
+#define ALIFEMTODREAMV0MCHIST_H_
+#include "Rtypes.h"
+#include "TList.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "AliFemtoDreamBasePart.h"
+class AliFemtoDreamv0MCHist {
+ public:
+  AliFemtoDreamv0MCHist();
+  AliFemtoDreamv0MCHist(
+      int MassNBins,double MassMin,double MassMax,bool contribSplitting,
+      bool CPADist);
+  virtual ~AliFemtoDreamv0MCHist();
+  void FillMCCorr(double pT){fMCCorrPt->Fill(pT);};
+  void FillMCIdent(double pT){fMCIdentPt->Fill(pT);};
+  void FillMCGen(double pT){fMCGenPt->Fill(pT);};
+  void FillMCCont(double pT){fMCContPt->Fill(pT);};
+  void FillMCUnkn(double pT){fMCUnknownPt->Fill(pT);};
+  void FillMCPrimary(double pT){fMCPrimaryPt->Fill(pT);};
+  void FillMCMaterial(double pT){fMCMaterialPt->Fill(pT);};
+  void FillMCFeeddown(double pT, double pdg){
+    fMCFeeddownWeakPt->Fill(pT, pdg);
+  };
+  void FillMCpT(int i, double val){fMCpTDist[i]->Fill(val);};
+  void FillMCEta(int i, double val){fMCetaDist[i]->Fill(val);};
+  void FillMCPhi(int i, double val){fMCphiDist[i]->Fill(val);};
+  void FillMCDCAVtxX(int i, double pT, double val){
+    fMCDecayVtxv0X[i]->Fill(pT, val);
+  };
+  void FillMCDCAVtxY(int i, double pT, double val){
+    fMCDecayVtxv0Y[i]->Fill(pT, val);};
+  void FillMCDCAVtxZ(int i, double pT, double val){
+    fMCDecayVtxv0Z[i]->Fill(pT, val);};
+  void FillMCTransverseRadius(int i, double pT, double val){
+    fMCTransverseRadius[i]->Fill(pT, val);
+  };
+  void FillMCDCAPosDaugPrimVtx(int i, double pT, double val){
+    fMCDCAPosDaugToPV[i]->Fill(pT, val);};
+  void FillMCDCANegDaugPrimVtx(int i, double pT, double val){
+    fMCDCANegDaugToPV[i]->Fill(pT, val);};
+  void FillMCDCADaugVtx(int i, double pT, double val){
+    fMCDCADaugToVtx[i]->Fill(pT, val);};
+  void FillMCCosPoint(int i, double pT, double val){
+    fMCCosPointing[i]->Fill(pT, val);};
+  void FillMCInvMass(int i, double massVal){
+    fMCInvMass[i]->Fill(massVal);};
+  void FillMCCPAPtBins(
+      AliFemtoDreamBasePart::PartOrigin org, double pT,double cpa);
+  TList *GetHistList(){return fMCList;};
+  TString ClassName() {return "AliFemtoDreamv0MCHist";};
+ private:
+  TList *fMCList;
+  TList *fCPAPlots;
+  TList *fMCQAPlots[4];
+  TH1F *fMCCorrPt;
+  TH1F *fMCIdentPt;
+  TH1F *fMCGenPt;
+  TH1F *fMCContPt;
+  TH1F *fMCUnknownPt;
+  TH1F *fMCPrimaryPt;
+  TH1F *fMCMaterialPt;
+  TH2F *fMCFeeddownWeakPt;
+  TH1F *fMCpTDist[4];
+  TH1F *fMCetaDist[4];
+  TH1F *fMCphiDist[4];
+  TH2F *fMCDecayVtxv0X[4];
+  TH2F *fMCDecayVtxv0Y[4];
+  TH2F *fMCDecayVtxv0Z[4];
+  TH2F *fMCTransverseRadius[4];
+  TH2F *fMCDCAPosDaugToPV[4];
+  TH2F *fMCDCANegDaugToPV[4];
+  TH2F *fMCDCADaugToVtx[4];
+  TH2F *fMCCosPointing[4];
+  TH1F *fMCInvMass[4];
+  TH2F *fMCPrimCPAPtBins;
+  TH2F *fMCMaterialCPAPtBins;
+  TH2F *fMCSecondaryCPAPtBins;
+  TH2F *fMCContCPAPtBins;
+
+  ClassDef(AliFemtoDreamv0MCHist,1)
+};
+
+#endif /* ALIFEMTODREAMV0MCHIST_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/CMakeLists.txt
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/CMakeLists.txt
@@ -1,0 +1,123 @@
+# **************************************************************************
+# * Copyright(c) 1998-2014, ALICE Experiment at CERN, All rights reserved. *
+# *                                                                        *
+# * Author: The ALICE Off-line Project.                                    *
+# * Contributors are mentioned in the code where appropriate.              *
+# *                                                                        *
+# * Permission to use, copy, modify and distribute this software and its   *
+# * documentation strictly for non-commercial purposes is hereby granted   *
+# * without fee, provided that the above copyright notice appears in all   *
+# * copies and that both the copyright notice and this permission notice   *
+# * appear in the supporting documentation. The authors make no claims     *
+# * about the suitability of this software for any purpose. It is          *
+# * provided "as is" without express or implied warranty.                  *
+# **************************************************************************/
+
+#Module
+set(MODULE PWGCFFemtoDream)
+add_definitions(-D_MODULE_="${MODULE}")
+
+# Module include folder
+include_directories(${AliPhysics_SOURCE_DIR}/PWGCF/FEMTOSCOPY/FemtoDream)
+
+# Additional includes - alphabetical order except ROOT
+include_directories(${ROOT_INCLUDE_DIRS}
+                    ${AliPhysics_SOURCE_DIR}/OADB
+	)
+		  
+
+# Sources - alphabetical order
+set(SRCS
+  AliFemtoDreamEvent.cxx  
+  AliFemtoDreamEventHist.cxx
+  AliFemtoDreamEventCuts.cxx
+  AliFemtoDreamBasePart.cxx
+  AliFemtoDreamTrack.cxx
+  AliFemtoDreamTrackHist.cxx
+  AliFemtoDreamTrackMCHist.cxx 
+  AliFemtoDreamTrackCuts.cxx
+  AliFemtoDreamv0.cxx
+  AliFemtoDreamv0Hist.cxx
+  AliFemtoDreamv0MCHist.cxx
+  AliFemtoDreamv0Cuts.cxx
+  AliFemtoDreamCascade.cxx
+  AliFemtoDreamCascadeHist.cxx
+  AliFemtoDreamCascadeCuts.cxx
+  AliFemtoDreamPairCleanerHists.cxx
+  AliFemtoDreamPairCleaner.cxx 
+  AliFemtoDreamCollConfig.cxx 
+  AliFemtoDreamCorrHists.cxx 
+  AliFemtoDreamPartContainer.cxx 
+  AliFemtoDreamZVtxMultContainer.cxx 
+  AliFemtoDreamPartCollection.cxx 
+  AliFemtoDreamAnalysis.cxx 
+  AliAnalysisTaskFemtoDream.cxx
+  )
+
+
+# Headers from sources
+string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
+
+# Generate the dictionary
+# It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
+get_directory_property(incdirs INCLUDE_DIRECTORIES)
+generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+
+set(ROOT_DEPENDENCIES Core EG GenVector Geom Gpad Hist MathCore Matrix Net Physics RIO Tree)
+set(ALIROOT_DEPENDENCIES ANALYSIS ANALYSISalice AOD)
+
+# Generate the ROOT map
+# Dependecies
+set(LIBDEPS ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES})
+generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
+
+# Generate a PARfile target for this library
+add_target_parfile(${MODULE} "${SRCS}" "${HDRS}" "${MODULE}LinkDef.h" "${LIBDEPS}")
+
+# Create an object to be reused in case of static libraries
+# Otherwise the sources will be compiled twice
+add_library(${MODULE}-object OBJECT ${SRCS} G__${MODULE}.cxx)
+
+# Add a library to the project using the object
+add_library_tested(${MODULE} SHARED $<TARGET_OBJECTS:${MODULE}-object>)
+
+target_link_libraries(${MODULE} ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES})
+
+# Setting the correct headers for the object as gathered from the dependencies
+target_include_directories(${MODULE}-object PUBLIC $<TARGET_PROPERTY:${MODULE},INCLUDE_DIRECTORIES>)
+set_target_properties(${MODULE}-object PROPERTIES COMPILE_DEFINITIONS $<TARGET_PROPERTY:${MODULE},COMPILE_DEFINITIONS>)
+
+# Public include folders that will be propagated to the dependecies
+target_include_directories(${MODULE} PUBLIC ${incdirs})
+
+set(MODULE_COMPILE_FLAGS)
+set(MODULE_LINK_FLAGS)
+
+if(DATE_FOUND)
+    set(MODULE_COMPILE_FLAGS "${DATE_CFLAGS}")
+    set(MODULE_LINK_FLAGS "${DATE_LDFLAGS} ${DATE_LIBS}")
+endif(DATE_FOUND)
+
+# Additional compilation and linking flags
+set(MODULE_COMPILE_FLAGS " ${MODULE_COMPILE_FLAGS}")
+
+# System dependent: Modify the way the library is build
+if(${CMAKE_SYSTEM} MATCHES Darwin)
+    set(MODULE_LINK_FLAGS "-undefined dynamic_lookup ${MODULE_LINK_FLAGS}")
+endif(${CMAKE_SYSTEM} MATCHES Darwin)
+
+# Setting compilation flags for the object
+set_target_properties(${MODULE}-object PROPERTIES COMPILE_FLAGS "${MODULE_COMPILE_FLAGS}")
+# Setting the linking flags for the library
+set_target_properties(${MODULE} PROPERTIES LINK_FLAGS "${MODULE_LINK_FLAGS}")
+
+
+# generate_par("Hyperon")
+
+# Installation
+install(TARGETS ${MODULE}
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib)
+
+install(FILES ${HDRS} DESTINATION include)
+

--- a/PWGCF/FEMTOSCOPY/FemtoDream/PWGCFFemtoDreamLinkDef.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/PWGCFFemtoDreamLinkDef.h
@@ -1,0 +1,34 @@
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+
+#pragma link C++ class AliFemtoDreamEvent+;  
+#pragma link C++ class AliFemtoDreamEventHist+;
+#pragma link C++ class AliFemtoDreamEventCuts+;
+#pragma link C++ class AliFemtoDreamBasePart+;    
+#pragma link C++ class AliFemtoDreamTrack+;
+#pragma link C++ class AliFemtoDreamTrackHist+;
+#pragma link C++ class AliFemtoDreamTrackMCHist+;
+#pragma link C++ class AliFemtoDreamTrackCuts+;
+#pragma link C++ class AliFemtoDreamv0+;
+#pragma link C++ class AliFemtoDreamv0Hist+;
+#pragma link C++ class AliFemtoDreamv0MCHist+;
+#pragma link C++ class AliFemtoDreamv0Cuts+;
+#pragma link C++ class AliFemtoDreamCascade+;
+#pragma link C++ class AliFemtoDreamCascadeHist+;
+#pragma link C++ class AliFemtoDreamCascadeCuts+;
+#pragma link C++ class AliFemtoDreamPairCleanerHists+;
+#pragma link C++ class AliFemtoDreamPairCleaner+;
+#pragma link C++ class AliFemtoDreamCollConfig+;
+#pragma link C++ class AliFemtoDreamCorrHists+;
+#pragma link C++ class AliFemtoDreamPartContainer+;
+#pragma link C++ class AliFemtoDreamZVtxMultContainer+;
+#pragma link C++ class AliFemtoDreamPartCollection+;
+#pragma link C++ class AliFemtoDreamAnalysis+;
+#pragma link C++ class AliAnalysisTaskFemtoDream+;
+
+#endif
+

--- a/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AddTaskPLFemto.C
+++ b/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AddTaskPLFemto.C
@@ -1,0 +1,111 @@
+
+//const Bool_t anaType   = 1;//0 HD; 1 UU;
+const Bool_t OnlineSearchV0 = kFALSE; // True=online, false=offline
+const TString whichV0 = "Lambda"; //Lambda or Kaon
+const TString whichV0region = "signal";//signal or sideband region
+const TString whichMixing = "Tracklets"; //V0M or #Tracklets
+//const int whichfilterbit = 96;
+const int whichfilterbit = 128;
+
+AliAnalysisTaskPLFemto *AliAnalysisTaskPLFemto(Int_t system=0/*0=pp,1=PbPb*/,
+					       
+					       Bool_t theMCon=kFALSE)
+  
+{
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+
+  if (!mgr) 
+    {
+      ::Error("AddTaskPLFemtoSpectra", "No analysis manager to connect to.");
+      return NULL;
+    }  
+  
+  //AliVEventHandler *inputEvents = 0;
+  
+  // Event handlers:
+  /*
+  if(!theMCon)
+    {
+      inputEvents = new AliAODInputHandler();
+      mgr->SetInputEventHandler(inputEvents);
+    }
+  else //Monte Carlo
+    {
+      inputEvents = new AliMCEventHandler();
+      mgr->SetMCtruthEventHandler(inputEvents);
+    }
+  */
+  //CREATE THE TASK
+
+  printf("CREATE TASK\n");
+  // create the task
+
+  AliAnalysisTaskPLFemto *task = new AliAnalysisTaskPLFemto("AliAnalysisPLFemto",OnlineSearchV0,whichV0,whichV0region,whichfilterbit);//calls the constructor of the class
+  task->SelectCollisionCandidates(AliVEvent::kMB);
+  //task->SelectCollisionCandidates(AliVEvent::kINT7+AliVEvent::kMB);
+  //task->SelectCollisionCandidates(AliVEvent::kINT7+AliVEvent::kMB+AliVEvent::kINT8);
+  //AliAnalysisTaskPLFemto *task = new AliAnalysisTaskPLFemto("AliAnalysisPLFemto");//calls the constructor of the class
+
+  task->SetMC(theMCon);
+  task->SetDebugLevel(0);
+  mgr->AddTask(task);
+
+
+
+  // Create and connect containers for input/output
+  
+  //usercomment = "_" + usercomment;  
+
+  TString outputfile = AliAnalysisManager::GetCommonFileName();
+
+  outputfile += ":PWGCF_PLFemto";
+  //outputfile += usercomment;
+  
+
+  // ------ input data ------
+  TString input = "infemto";
+  //input += usercomment;
+  TString output1 = "Evtinfo";
+  //output1 += usercomment;
+  TString output2 = "SPdir";//directory for single particle quantities
+  //output2 += usercomment;
+  TString output3 = "PIDdir";//directory for PID quantities
+  //output3 += usercomment;
+  TString output4 = "TPdir";//directory for two particle quantities
+  //output4 += usercomment;
+  //TString output5 = "MC_dir";//directory for purely Monte Carlo output (doesn't work at the moment)
+  //output5 += usercomment;
+
+  //AliAnalysisDataContainer *cinput0  = mgr->GetCommonInputContainer();
+
+  AliAnalysisDataContainer *cinput0  =  mgr->CreateContainer(input,TChain::Class(),AliAnalysisManager::kInputContainer);
+
+ // ----- output data -----
+
+  AliAnalysisDataContainer *coutput1 = mgr->CreateContainer(output1,TList::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
+
+  AliAnalysisDataContainer *coutput2 = mgr->CreateContainer(output2,TList::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
+
+  AliAnalysisDataContainer *coutput3 = mgr->CreateContainer(output3,TList::Class(),AliAnalysisManager::kOutputContainer, outputfile.Data());
+
+  AliAnalysisDataContainer *coutput4 = mgr->CreateContainer(output4,TList::Class(),AliAnalysisManager::kOutputContainer, outputfile.Data());
+  
+  
+    
+  mgr->ConnectInput(task,0,mgr->GetCommonInputContainer());
+  
+  mgr->ConnectOutput(task,1,coutput1);
+
+  mgr->ConnectOutput(task,2,coutput2);
+
+  mgr->ConnectOutput(task,3,coutput3);
+  
+  mgr->ConnectOutput(task,4,coutput4);
+
+
+  
+  return task;
+}
+
+
+

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoDream.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoDream.C
@@ -1,0 +1,270 @@
+#ifndef ADDTASKFEMTODREAM_C
+#define ADDTASKFEMTODREAM_C
+#include "AliFemtoDreamEventCuts.h"
+#include "AliFemtoDreamTrackCuts.h"
+#include "AliAnalysisTaskFemtoDream.h"
+#include "TROOT.h"
+
+void AddTaskFemtoDream(bool isMC, TString CentEst) {
+  gROOT->ProcessLine(".include $ALICE_ROOT/include");
+  gROOT->ProcessLine(".include $ALICE_PHYSICS/include");
+  gROOT->ProcessLine(".include $ROOTSYS/include");
+
+  // the manager is static, so get the existing manager via the static method
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+
+  if (!mgr)
+  {
+    printf("No analysis manager to connect to!\n");
+    return;
+  }
+  // just to see if all went well, check if the input event handler has been
+  // connected
+  if (!mgr->GetInputEventHandler()) {
+    printf("This task requires an input event handler!\n");
+    return;
+  }
+  AliFemtoDreamEventCuts *evtCuts=
+      AliFemtoDreamEventCuts::StandardCutsRun1();
+  bool DCAPlots=false;
+  bool CPAPlots=false;
+  bool CombSigma=false;
+  bool ContributionSplitting=false;
+  bool ContributionSplittingDaug=false;
+
+  //Track Cuts
+  AliFemtoDreamTrackCuts *TrackCuts=
+      AliFemtoDreamTrackCuts::PrimProtonCuts(
+          isMC,DCAPlots,CombSigma,ContributionSplitting);
+  TrackCuts->SetCutCharge(1);
+  AliFemtoDreamTrackCuts *AntiTrackCuts=
+      AliFemtoDreamTrackCuts::PrimProtonCuts(
+          isMC,DCAPlots,CombSigma,ContributionSplitting);
+  AntiTrackCuts->SetCutCharge(-1);
+
+  //Lambda Cuts
+  AliFemtoDreamv0Cuts *v0Cuts=
+      AliFemtoDreamv0Cuts::LambdaCuts(isMC,CPAPlots,ContributionSplitting);
+  AliFemtoDreamTrackCuts *Posv0Daug=AliFemtoDreamTrackCuts::DecayProtonCuts(
+      isMC,ContributionSplittingDaug);
+  AliFemtoDreamTrackCuts *Negv0Daug=AliFemtoDreamTrackCuts::DecayPionCuts(
+      isMC,ContributionSplittingDaug);
+  v0Cuts->SetPosDaugterTrackCuts(Posv0Daug);
+  v0Cuts->SetNegDaugterTrackCuts(Negv0Daug);
+  v0Cuts->SetPDGCodePosDaug(2212);//Proton
+  v0Cuts->SetPDGCodeNegDaug(211);//Pion
+  v0Cuts->SetPDGCodev0(3122);//Lambda
+  AliFemtoDreamv0Cuts *Antiv0Cuts=
+      AliFemtoDreamv0Cuts::LambdaCuts(isMC,CPAPlots,ContributionSplitting);
+  AliFemtoDreamTrackCuts *PosAntiv0Daug=AliFemtoDreamTrackCuts::DecayPionCuts(
+      isMC,ContributionSplittingDaug);
+  PosAntiv0Daug->SetCutCharge(1);
+  AliFemtoDreamTrackCuts *NegAntiv0Daug=AliFemtoDreamTrackCuts::DecayProtonCuts(
+      isMC,ContributionSplittingDaug);
+  NegAntiv0Daug->SetCutCharge(-1);
+  Antiv0Cuts->SetPosDaugterTrackCuts(PosAntiv0Daug);
+  Antiv0Cuts->SetNegDaugterTrackCuts(NegAntiv0Daug);
+  Antiv0Cuts->SetPDGCodePosDaug(211);//Pion
+  Antiv0Cuts->SetPDGCodeNegDaug(2212);//Proton
+  Antiv0Cuts->SetPDGCodev0(3122);//Lambda
+
+  //Cascade Cuts
+  AliFemtoDreamCascadeCuts *CascadeCuts=
+      AliFemtoDreamCascadeCuts::XiCuts(false);
+  CascadeCuts->SetXiCharge(-1);
+  AliFemtoDreamTrackCuts *XiNegCuts=
+      AliFemtoDreamTrackCuts::Xiv0PionCuts(false,false);
+  AliFemtoDreamTrackCuts *XiPosCuts=
+      AliFemtoDreamTrackCuts::Xiv0ProtonCuts(false,false);
+  AliFemtoDreamTrackCuts *XiBachCuts=
+      AliFemtoDreamTrackCuts::XiBachPionCuts(false,false);
+  AliFemtoDreamCascadeCuts *AntiCascadeCuts=
+      AliFemtoDreamCascadeCuts::XiCuts(false);
+  CascadeCuts->Setv0Negcuts(XiNegCuts);
+  CascadeCuts->Setv0PosCuts(XiPosCuts);
+  CascadeCuts->SetBachCuts(XiBachCuts);
+  AntiCascadeCuts->SetXiCharge(1);
+
+  AliFemtoDreamTrackCuts *AntiXiNegCuts=
+      AliFemtoDreamTrackCuts::Xiv0ProtonCuts(false,false);
+  AntiXiNegCuts->SetCutCharge(-1);
+  AliFemtoDreamTrackCuts *AntiXiPosCuts=
+      AliFemtoDreamTrackCuts::Xiv0PionCuts(false,false);
+  AntiXiPosCuts->SetCutCharge(1);
+  AliFemtoDreamTrackCuts *AntiXiBachCuts=
+      AliFemtoDreamTrackCuts::XiBachPionCuts(false,false);
+  AntiCascadeCuts->Setv0Negcuts(AntiXiNegCuts);
+  AntiCascadeCuts->Setv0PosCuts(AntiXiPosCuts);
+  AntiCascadeCuts->SetBachCuts(AntiXiBachCuts);
+  AntiXiBachCuts->SetCutCharge(1);
+
+  std::vector<int> PDGParticles ={2212,2212,3122,3122};
+  std::vector<double> ZVtxBins = {-10,-8,-6,-4,-2,0,2,4,6,8,10};
+  std::vector<int> MultBins = {0,4,8,12,16,20,24,28,32,36,40,44,48,52,56,60,64,80};
+  std::vector<int> NBins={750,750,150,150,750,150,150,150,150,150};
+  std::vector<double> kMin={0.,0.,0.,0.,0.,0.,0.,0.,0.,0.};
+  std::vector<double> kMax={3.,3.,3.,3.,3.,3.,3.,3.,3.,3.};
+  AliFemtoDreamCollConfig *config=new AliFemtoDreamCollConfig("Femto","Femto");
+  config->SetZBins(ZVtxBins);
+  config->SetMultBins(MultBins);
+  config->SetPDGCodes(PDGParticles);
+  config->SetNBinsHist(NBins);
+  config->SetMinKRel(kMin);
+  config->SetMaxKRel(kMax);
+  config->SetMixingDepth(10);
+
+  AliAnalysisTaskFemtoDream *task=new AliAnalysisTaskFemtoDream("FemtoDream",isMC);
+  if(CentEst == "kInt7"){
+    task->SelectCollisionCandidates(AliVEvent::kINT7);
+    task->SetMVPileUp(kTRUE);
+  }else if(CentEst == "kMB"){
+    task->SelectCollisionCandidates(AliVEvent::kMB);
+    task->SetMVPileUp(kFALSE);
+  }else{
+    std::cout << "=====================================================================" << std::endl;
+    std::cout << "=====================================================================" << std::endl;
+    std::cout << "Centrality Estimator not set, fix it else your Results will be empty!" << std::endl;
+    std::cout << "=====================================================================" << std::endl;
+    std::cout << "=====================================================================" << std::endl;
+  }
+  task->SetDebugLevel(0);
+  task->SetEvtCutQA(true);
+  task->SetTrackBufferSize(2500);
+  task->SetEventCuts(evtCuts);
+  task->SetTrackCuts(TrackCuts);
+  task->SetAntiTrackCuts(AntiTrackCuts);
+  task->Setv0Cuts(v0Cuts);
+  task->SetAntiv0Cuts(Antiv0Cuts);
+  task->SetCascadeCuts(CascadeCuts);
+  task->SetAntiCascadeCuts(AntiCascadeCuts);
+  task->SetCollectionConfig(config);
+  mgr->AddTask(task);
+//  TString QAOutput="AnalysisQA.root";
+//  TString TrackOutput="AnalysisQATracks.root";
+//  TString v0Output="AnalysisQAv0.root";
+//  TString CascadeOutput="AnalysisQACascade.root";
+
+  TString file = AliAnalysisManager::GetCommonFileName();
+
+  AliAnalysisDataContainer *cinput = mgr->GetCommonInputContainer();
+
+  mgr->ConnectInput(task, 0, cinput);
+
+  AliAnalysisDataContainer *coutputQA;
+  TString QAName = Form("QA");
+  coutputQA = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      QAName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), QAName.Data()));
+  mgr->ConnectOutput(task, 1, coutputQA);
+
+  AliAnalysisDataContainer *coutputEvtCuts;
+  TString EvtCutsName = Form("EvtCuts");
+  coutputEvtCuts = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      EvtCutsName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), EvtCutsName.Data()));
+  mgr->ConnectOutput(task, 2, coutputEvtCuts);
+
+  AliAnalysisDataContainer *couputTrkCuts;
+  TString TrackCutsName = Form("TrackCuts");
+  couputTrkCuts = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      TrackCutsName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), TrackCutsName.Data()));
+  mgr->ConnectOutput(task, 3, couputTrkCuts);
+
+  AliAnalysisDataContainer *coutputAntiTrkCuts;
+  TString AntiTrackCutsName = Form("AntiTrackCuts");
+  coutputAntiTrkCuts = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      AntiTrackCutsName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), AntiTrackCutsName.Data()));
+  mgr->ConnectOutput(task, 4, coutputAntiTrkCuts);
+
+  AliAnalysisDataContainer *coutputv0Cuts;
+  TString v0CutsName = Form("v0Cuts");
+  coutputv0Cuts = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      v0CutsName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), v0CutsName.Data()));
+  mgr->ConnectOutput(task, 5, coutputv0Cuts);
+
+  AliAnalysisDataContainer *coutputAntiv0Cuts;
+  TString Antiv0CutsName = Form("Antiv0Cuts");
+  coutputAntiv0Cuts = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      Antiv0CutsName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), Antiv0CutsName.Data()));
+  mgr->ConnectOutput(task, 6, coutputAntiv0Cuts);
+
+  AliAnalysisDataContainer *coutputCascadeCuts;
+  TString CascadeCutsName = Form("CascadeCuts");
+  coutputCascadeCuts = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      CascadeCutsName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), CascadeCutsName.Data()));
+  mgr->ConnectOutput(task, 7, coutputCascadeCuts);
+
+  AliAnalysisDataContainer *coutputAntiCascadeCuts;
+  TString AntiCascadeCutsName = Form("AntiCascadeCuts");
+  coutputAntiCascadeCuts = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      AntiCascadeCutsName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), AntiCascadeCutsName.Data()));
+  mgr->ConnectOutput(task, 8, coutputAntiCascadeCuts);
+
+  AliAnalysisDataContainer *coutputResults;
+  TString ResultsName = Form("Results");
+  coutputResults = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      ResultsName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), ResultsName.Data()));
+  mgr->ConnectOutput(task, 9, coutputResults);
+
+  AliAnalysisDataContainer *coutputResultQA;
+  TString ResultQAName = Form("ResultQA");
+  coutputResultQA = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+      ResultQAName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), ResultQAName.Data()));
+  mgr->ConnectOutput(task, 10, coutputResultQA);
+  if (isMC) {
+    AliAnalysisDataContainer *coutputTrkCutsMC;
+    TString TrkCutsMCName = Form("TrkCutsMC");
+    coutputTrkCutsMC = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+        TrkCutsMCName.Data(), TList::Class(),
+        AliAnalysisManager::kOutputContainer,
+        Form("%s:%s", file.Data(), TrkCutsMCName.Data()));
+    mgr->ConnectOutput(task, 11, coutputTrkCutsMC);
+
+    AliAnalysisDataContainer *coutputAntiTrkCutsMC;
+    TString AntiTrkCutsMCName = Form("AntiTrkCutsMC");
+    coutputAntiTrkCutsMC = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+        AntiTrkCutsMCName.Data(), TList::Class(),
+        AliAnalysisManager::kOutputContainer,
+        Form("%s:%s", file.Data(), AntiTrkCutsMCName.Data()));
+    mgr->ConnectOutput(task, 12, coutputAntiTrkCutsMC);
+
+    AliAnalysisDataContainer *coutputv0CutsMC;
+    TString v0CutsMCName = Form("v0CutsMC");
+    coutputv0CutsMC = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+        v0CutsMCName.Data(), TList::Class(),
+        AliAnalysisManager::kOutputContainer,
+        Form("%s:%s", file.Data(), v0CutsMCName.Data()));
+    mgr->ConnectOutput(task, 13, coutputv0CutsMC);
+
+    AliAnalysisDataContainer *coutputAntiv0CutsMC;
+    TString Antiv0CutsMCName = Form("Antiv0CutsMC");
+    coutputAntiv0CutsMC = mgr->CreateContainer(//@suppress("Invalid arguments") it works ffs
+        Antiv0CutsMCName.Data(), TList::Class(),
+        AliAnalysisManager::kOutputContainer,
+        Form("%s:%s", file.Data(), Antiv0CutsMCName.Data()));
+    mgr->ConnectOutput(task, 14, coutputAntiv0CutsMC);
+  }
+  if (!mgr->InitAnalysis()) {
+    return;
+  }
+  return;
+}
+#endif


### PR DESCRIPTION
Femtoscopy analysis design to select charged tracks (Protons, Pions, Kaons), two particle v0 Decays (e.g. Lambdas) and Cascades (e.g. Xis), which get buffered and are then used to calculate the Same Event and Mixed Event statistics for the calculation of the correlation function. This analysis will be used to analyse Run2 p-p and pPb Data and is therefore build in a modular way. 

The particles are selected by the corresponding cut object, which each contains a class for data output and Monte Carlo output. Additionally classes to configure the behavior of the event mixing, to handle the output of the particle pairing, and at last to store the particles. 

Additionally included in this commit is the steering macro for the analysis task of Oliver Arnold (PLamAnalysisPP) since it was requested from the Analysis Review Committee.  