### PR TITLE
Keep V0C, V0A enums at end of list for back compatibility

### DIFF
--- a/PWG/FLOW/Tasks/AliFlowEventCuts.h
+++ b/PWG/FLOW/Tasks/AliFlowEventCuts.h
@@ -27,7 +27,7 @@ class AliMultSelection;
 class AliFlowEventCuts : public AliFlowEventSimpleCuts {
 
  public:
-  enum refMultMethod { kTPConly, kSPDtracklets, kVZERO, kV0=kVZERO, kV0M=kVZERO, kV0C, kV0A, kSPD1clusters, kZDC };
+  enum refMultMethod { kTPConly, kSPDtracklets, kVZERO, kV0=kVZERO, kV0M=kVZERO, kSPD1clusters, kZDC, kV0C, kV0A};
 
   AliFlowEventCuts();
   AliFlowEventCuts(const char* name, const char* title = "AliFlowEventCuts");


### PR DESCRIPTION
Keep V0C, V0A enums at end of list for back compatibility