### PR TITLE
[WIP] Modular jet substructure tree

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.cxx
@@ -82,6 +82,15 @@ namespace EmcalTriggerJets {
 AliAnalysisTaskEmcalJetSubstructureTree::AliAnalysisTaskEmcalJetSubstructureTree() :
     AliAnalysisTaskEmcalJet(),
     fJetSubstructureTree(nullptr),
+    fGlobalTreeParams(nullptr),
+    fSoftDropMeasured(nullptr),
+    fSoftDropTrue(nullptr),
+    fNSubMeasured(nullptr),
+    fNSubTrue(nullptr),
+    fKineRec(nullptr),
+    fKineSim(nullptr),
+    fJetStructureMeasured(nullptr),
+    fJetStructureTrue(nullptr),
     fQAHistos(nullptr),
     fLumiMonitor(nullptr),
     fSDZCut(0.1),
@@ -95,19 +104,25 @@ AliAnalysisTaskEmcalJetSubstructureTree::AliAnalysisTaskEmcalJetSubstructureTree
     fUseChargedConstituents(true),
     fUseNeutralConstituents(true),
     fFillPart(true),
-    fFillAcceptance(true),
     fFillRho(true),
-    fFillMass(true),
     fFillSoftDrop(true),
     fFillNSub(true),
     fFillStructGlob(true)
 {
-  memset(fJetTreeData, 0, sizeof(Double_t) * kTNVar);
 }
 
 AliAnalysisTaskEmcalJetSubstructureTree::AliAnalysisTaskEmcalJetSubstructureTree(const char *name) :
     AliAnalysisTaskEmcalJet(name, kTRUE),
     fJetSubstructureTree(nullptr),
+    fGlobalTreeParams(nullptr),
+    fSoftDropMeasured(nullptr),
+    fSoftDropTrue(nullptr),
+    fNSubMeasured(nullptr),
+    fNSubTrue(nullptr),
+    fKineRec(nullptr),
+    fKineSim(nullptr),
+    fJetStructureMeasured(nullptr),
+    fJetStructureTrue(nullptr),
     fQAHistos(nullptr),
     fLumiMonitor(nullptr),
     fSDZCut(0.1),
@@ -121,19 +136,24 @@ AliAnalysisTaskEmcalJetSubstructureTree::AliAnalysisTaskEmcalJetSubstructureTree
     fUseChargedConstituents(true),
     fUseNeutralConstituents(true),
     fFillPart(true),
-    fFillAcceptance(true),
     fFillRho(true),
-    fFillMass(true),
     fFillSoftDrop(true),
     fFillNSub(true),
     fFillStructGlob(true)
 {
-  memset(fJetTreeData, 0, sizeof(Double_t) * kTNVar);
   DefineOutput(2, TTree::Class());
 }
 
-AliAnalysisTaskEmcalJetSubstructureTree::~AliAnalysisTaskEmcalJetSubstructureTree() {
-
+AliAnalysisTaskEmcalJetSubstructureTree::~AliAnalysisTaskEmcalJetSubstructureTree() { 
+  if(fGlobalTreeParams) delete fGlobalTreeParams;
+  if(fSoftDropMeasured) delete fSoftDropMeasured;
+  if(fSoftDropTrue) delete fSoftDropTrue;
+  if(fNSubMeasured) delete fNSubMeasured;
+  if(fNSubTrue) delete fNSubTrue;
+  if(fKineRec) delete fKineRec;
+  if(fKineSim) delete fKineSim;
+  if(fJetStructureMeasured) delete fJetStructureMeasured;
+  if(fJetStructureTrue) delete fJetStructureTrue;
 }
 
 void AliAnalysisTaskEmcalJetSubstructureTree::UserCreateOutputObjects() {
@@ -168,36 +188,43 @@ void AliAnalysisTaskEmcalJetSubstructureTree::UserCreateOutputObjects() {
   OpenFile(2);
   std::string treename = this->GetOutputSlot(2)->GetContainer()->GetName();
   fJetSubstructureTree = new TTree(treename.data(), "Tree with jet substructure information");
-  std::vector<std::string> varnames = {
-    "Radius", "EventWeight", "PtJetRec", "PtJetSim", "EJetRec",
-    "EJetSim", "EtaRec", "EtaSim", "PhiRec", "PhiSim",
-    "RhoPtRec", "RhoPtSim", "RhoMassRec", "RhoMassSim", "AreaRec",
-    "AreaSim", "NEFRec", "NEFSim", "MassRec", "MassSim",
-    "ZgMeasured", "ZgTrue", "RgMeasured", "RgTrue", "MgMeasured",
-    "MgTrue", "PtgMeasured", "PtgTrue", "MugMeasured", "MugTrue", "DeltaRgMeasured", "DeltaRgTrue",
-    "OneSubjettinessMeasured", "OneSubjettinessTrue", "TwoSubjettinessMeasured", "TwoSubjettinessTrue", "AngularityMeasured",
-    "AngularityTrue", "PtDMeasured", "PtDTrue", "NCharged", "NNeutral",
-    "NConstTrue", "NDroppedMeasured", "NDroppedTrue" };
 
-  for(int ib = 0; ib < kTNVar; ib++){
-    LinkOutputBranch(varnames[ib], fJetTreeData + ib);
+  fGlobalTreeParams = new AliJetTreeGlobalParameters;
+  fGlobalTreeParams->LinkJetTreeBranches(fJetSubstructureTree, fFillRho);
+  fKineRec = new AliJetKineParameters;
+  fKineRec->LinkJetTreeBranches(fJetSubstructureTree, "Rec");
+  if(fFillPart) {
+    fKineSim = new AliJetKineParameters;
+    fKineSim->LinkJetTreeBranches(fJetSubstructureTree, "Sim");
   }
+  if(fFillSoftDrop) {
+    fSoftDropMeasured = new AliSoftDropParameters;
+    fSoftDropMeasured->LinkJetTreeBranches(fJetSubstructureTree, "Measured");
+    if(fFillPart) {
+      fSoftDropTrue = new AliSoftDropParameters;
+      fSoftDropTrue->LinkJetTreeBranches(fJetSubstructureTree, "True");
+    }
+  }
+  if(fFillNSub) {
+    fNSubMeasured = new AliNSubjettinessParameters;
+    fNSubMeasured->LinkJetTreeBranches(fJetSubstructureTree, "Measured");
+    if(fFillPart) {
+      fNSubTrue = new AliNSubjettinessParameters;
+      fNSubTrue->LinkJetTreeBranches(fJetSubstructureTree, "True");
+    }
+  }
+
+  if(fFillStructGlob){
+    fJetStructureMeasured = new AliJetStructureParameters;
+    fJetStructureMeasured->LinkJetTreeBranches(fJetSubstructureTree, "Measured");
+    if(fFillPart){
+      fJetStructureTrue = new AliJetStructureParameters;
+      fJetStructureTrue->LinkJetTreeBranches(fJetSubstructureTree, "True");
+    } 
+  }
+
   PostData(1, fOutput);
   PostData(2, fJetSubstructureTree);
-}
-
-void AliAnalysisTaskEmcalJetSubstructureTree::LinkOutputBranch(const std::string &branchname, Double_t *datalocation) {
-  // Check whether branch is rejected
-  if(!fFillPart && IsPartBranch(branchname)) return;
-  if(!fFillAcceptance && IsAcceptanceBranch(branchname)) return;
-  if(!fFillRho && IsRhoBranch(branchname)) return;
-  if(!fFillMass && IsMassBranch(branchname)) return;
-  if(!fFillSoftDrop && IsSoftdropBranch(branchname)) return;
-  if(!fFillNSub && IsNSubjettinessBranch(branchname)) return;
-  if(!fFillStructGlob && IsStructbranch(branchname)) return;
-
-  std::cout << "Adding branch " << branchname << std::endl;
-  fJetSubstructureTree->Branch(branchname.data(), datalocation, Form("%s/D", branchname.data()));  
 }
 
 void AliAnalysisTaskEmcalJetSubstructureTree::RunChanged(Int_t newrun) {
@@ -222,18 +249,28 @@ bool AliAnalysisTaskEmcalJetSubstructureTree::Run(){
   if(datajets) rhoTagData << "R" << std::setw(2) << std::setfill('0') << static_cast<Int_t>(datajets->GetJetRadius() * 10.);
   if(mcjets) rhoTagMC << "R" << std::setw(2) << std::setfill('0') << static_cast<Int_t>(mcjets->GetJetRadius() * 10.);
 
-  std::string rhoSparseData = "RhoSparse_Full_" + rhoTagData.str(), rhoSparseMC = "RhoSparse_Full_" + rhoTagMC.str(), 
-              rhoMassData = "RhoMassSparse_Full_" + rhoTagData.str(), rhoMassMC = "RhoMassSparse_Full_" + rhoTagMC.str();
-  AliRhoParameter *rhoPtRec = GetRhoFromEvent(rhoSparseData.data()),
-                  *rhoMassRec = GetRhoFromEvent(rhoMassData.data()),
-                  *rhoPtSim = GetRhoFromEvent(rhoSparseMC.data()),
-                  *rhoMassSim = GetRhoFromEvent(rhoMassMC.data());
-  AliDebugStream(2) << "Found rho parameter for reconstructed pt:    " << (rhoPtRec ? "yes" : "no") << ", value: " << (rhoPtRec ? rhoPtRec->GetVal() : 0.) << std::endl;
-  AliDebugStream(2) << "Found rho parameter for sim pt:              " << (rhoPtSim ? "yes" : "no") << ", value: " << (rhoPtSim ? rhoPtSim->GetVal() : 0.) << std::endl;
-  AliDebugStream(2) << "Found rho parameter for reconstructed Mass:  " << (rhoMassRec ? "yes" : "no") << ", value: " << (rhoMassRec ? rhoMassRec->GetVal() : 0.) << std::endl;
-  AliDebugStream(2) << "Found rho parameter for sim Mass:            " << (rhoMassSim ? "yes" : "no") << ", value: " << (rhoMassSim ? rhoMassSim->GetVal() : 0.) << std::endl;
+  if(fFillRho){
+    std::string rhoSparseData = "RhoSparse_Full_" + rhoTagData.str(), rhoSparseMC = "RhoSparse_Full_" + rhoTagMC.str(), 
+                rhoMassData = "RhoMassSparse_Full_" + rhoTagData.str(), rhoMassMC = "RhoMassSparse_Full_" + rhoTagMC.str();
+    AliRhoParameter *rhoPtRec = GetRhoFromEvent(rhoSparseData.data()),
+                    *rhoMassRec = GetRhoFromEvent(rhoMassData.data()),
+                    *rhoPtSim = GetRhoFromEvent(rhoSparseMC.data()),
+                    *rhoMassSim = GetRhoFromEvent(rhoMassMC.data());
+    AliDebugStream(2) << "Found rho parameter for reconstructed pt:    " << (rhoPtRec ? "yes" : "no") << ", value: " << (rhoPtRec ? rhoPtRec->GetVal() : 0.) << std::endl;
+    AliDebugStream(2) << "Found rho parameter for sim pt:              " << (rhoPtSim ? "yes" : "no") << ", value: " << (rhoPtSim ? rhoPtSim->GetVal() : 0.) << std::endl;
+    AliDebugStream(2) << "Found rho parameter for reconstructed Mass:  " << (rhoMassRec ? "yes" : "no") << ", value: " << (rhoMassRec ? rhoMassRec->GetVal() : 0.) << std::endl;
+    AliDebugStream(2) << "Found rho parameter for sim Mass:            " << (rhoMassSim ? "yes" : "no") << ", value: " << (rhoMassSim ? rhoMassSim->GetVal() : 0.) << std::endl;
+    Double_t rhopars[4] = {
+                            rhoPtRec ? rhoPtRec->GetVal() : 0., 
+                            rhoPtSim ? rhoPtSim->GetVal() : 0., 
+                            rhoMassRec ? rhoMassRec->GetVal() : 0., 
+                            rhoMassSim ? rhoMassSim->GetVal() : 0.
+                          };
+    memcpy(this->fGlobalTreeParams->fRhoParamters, rhopars, sizeof(Double_t) * 4);
+  }
 
   AliDebugStream(1) << "Inspecting jet radius " << (datajets ? datajets->GetJetRadius() : mcjets->GetJetRadius()) << std::endl;
+  this->fGlobalTreeParams->fJetRadius = (datajets ? datajets->GetJetRadius() : mcjets->GetJetRadius());
 
   // Run trigger selection (not on pure MCgen train)
   if(datajets){
@@ -275,16 +312,11 @@ bool AliAnalysisTaskEmcalJetSubstructureTree::Run(){
     weight = 1./AliEmcalDownscaleFactorsOCDB::Instance()->GetDownscaleFactorForTriggerClass(triggerstring);
   }
   AliDebugStream(1) << "Using downscale weight " << weight << std::endl;
+  this->fGlobalTreeParams->fEventWeight = weight;
 
 
   // Count events (for spectrum analysis)
   fQAHistos->FillTH1("hEventCounter", 1);
-
-  Double_t rhoparameters[4]; memset(rhoparameters, 0, sizeof(Double_t) * 4);
-  if(rhoPtRec) rhoparameters[0] = rhoPtRec->GetVal();
-  if(rhoPtSim) rhoparameters[1] = rhoPtSim->GetVal();
-  if(rhoMassRec) rhoparameters[2] = rhoMassRec->GetVal();
-  if(rhoMassSim) rhoparameters[3] = rhoMassSim->GetVal();
 
   AliSoftdropDefinition softdropSettings;
   softdropSettings.fBeta = fSDBetaCut;
@@ -320,9 +352,15 @@ bool AliAnalysisTaskEmcalJetSubstructureTree::Run(){
           DoConstituentQA(jet, tracks, clusters);
           AliJetSubstructureData structureData =  MakeJetSubstructure(*jet, datajets->GetJetRadius() * 2., tracks, clusters, {softdropSettings, nsubjettinessSettings}),
                                  structureMC = fFillPart ? MakeJetSubstructure(*associatedJet, mcjets->GetJetRadius() * 2, particles, nullptr, {softdropSettings, nsubjettinessSettings}) : AliJetSubstructureData();
-          Double_t angularity[2] = {fFillStructGlob ? MakeAngularity(*jet, tracks, clusters) : 0., (fFillStructGlob && fFillPart) ? MakeAngularity(*associatedJet, particles, nullptr) : 0.},
-                   ptd[2] = {fFillStructGlob ? MakePtD(*jet, tracks, clusters) : 0., (fFillStructGlob && fFillPart) ? MakePtD(*associatedJet, particles, nullptr) : 0};
-          FillTree(datajets->GetJetRadius(), weight, jet, associatedJet, &(structureData.fSoftDrop), &(structureMC.fSoftDrop), &(structureData.fNsubjettiness), &(structureMC.fNsubjettiness), angularity, ptd, rhoparameters);
+          if(fKineRec) *fKineRec = MakeJetKineParameters(*jet);
+          if(fKineSim) *fKineSim = MakeJetKineParameters(*associatedJet);
+          if(fSoftDropMeasured) *fSoftDropMeasured = structureData.fSoftDrop;
+          if(fSoftDropTrue) *fSoftDropTrue = structureMC.fSoftDrop;
+          if(fNSubMeasured) *fNSubMeasured = structureData.fNsubjettiness;
+          if(fNSubTrue) *fNSubTrue = structureMC.fNsubjettiness;
+          if(fJetStructureMeasured) *fJetStructureMeasured = {MakeAngularity(*jet, tracks, clusters), MakePtD(*jet, tracks, clusters)};
+          if(fJetStructureTrue) *fJetStructureTrue = {MakeAngularity(*associatedJet, particles, nullptr), MakePtD(*associatedJet, particles, nullptr)};
+          fJetSubstructureTree->Fill();
         } catch(ReclusterizerException &e) {
           AliErrorStream() << "Error in reclusterization - skipping jet" << std::endl;
         } catch(SubstructureException &e) {
@@ -333,9 +371,11 @@ bool AliAnalysisTaskEmcalJetSubstructureTree::Run(){
         try {
           DoConstituentQA(jet, tracks, clusters);
           AliJetSubstructureData structure = MakeJetSubstructure(*jet, 0.4, tracks, clusters, {softdropSettings, nsubjettinessSettings});
-          Double_t angularity[2] = {fFillStructGlob ? MakeAngularity(*jet, tracks, clusters): 0., 0.},
-                   ptd[2] = {fFillStructGlob ? MakePtD(*jet, tracks, clusters) : 0., 0.};
-          FillTree(datajets->GetJetRadius(), weight, jet, nullptr, &(structure.fSoftDrop), nullptr, &(structure.fNsubjettiness), nullptr, angularity, ptd, rhoparameters);
+          if(fKineRec) *fKineRec = MakeJetKineParameters(*jet);
+          if(fSoftDropMeasured) *fSoftDropMeasured = structure.fSoftDrop;
+          if(fNSubMeasured) *fNSubMeasured = structure.fNsubjettiness;
+          if(fJetStructureMeasured) *fJetStructureMeasured = {MakeAngularity(*jet, tracks, clusters), MakePtD(*jet, tracks, clusters)};
+          fJetSubstructureTree->Fill();
         } catch(ReclusterizerException &e) {
           AliErrorStream() << "Error in reclusterization - skipping jet" << std::endl;
         } catch(SubstructureException &e) {
@@ -351,9 +391,11 @@ bool AliAnalysisTaskEmcalJetSubstructureTree::Run(){
         AliEmcalJet *mcjet = static_cast<AliEmcalJet *>(j);
         try {
           AliJetSubstructureData structure = MakeJetSubstructure(*mcjet, mcjets->GetJetRadius() * 2., particles, nullptr,{softdropSettings, nsubjettinessSettings});
-          Double_t angularity[2] = {0., MakeAngularity(*mcjet, particles, nullptr)},
-                   ptd[2] = {0., MakePtD(*mcjet, particles, nullptr)};
-          FillTree(mcjets->GetJetRadius(), weight, nullptr, mcjet, nullptr, &(structure.fSoftDrop), nullptr, &(structure.fNsubjettiness), angularity, ptd, rhoparameters);
+          if(this->fKineSim) *fKineSim = MakeJetKineParameters(*mcjet);
+          if(fSoftDropTrue) *fSoftDropTrue = structure.fSoftDrop;
+          if(fNSubTrue) *fNSubTrue = structure.fNsubjettiness;
+          if(fJetStructureTrue) *fJetStructureTrue = {MakeAngularity(*mcjet, particles, nullptr), MakePtD(*mcjet, particles, nullptr)};
+          fJetSubstructureTree->Fill();
         } catch (ReclusterizerException &e) {
           AliErrorStream() << "Error in reclusterization - skipping jet" << std::endl;
         } catch (SubstructureException &e) {
@@ -391,97 +433,6 @@ void AliAnalysisTaskEmcalJetSubstructureTree::UserExecOnce() {
   }
 }
 
-void AliAnalysisTaskEmcalJetSubstructureTree::FillTree(double r, double weight,
-                                                       const AliEmcalJet *datajet, const AliEmcalJet *mcjet,
-                                                       AliSoftDropParameters *dataSoftdrop, AliSoftDropParameters *mcSoftdrop,
-                                                       AliNSubjettinessParameters *dataSubjettiness, AliNSubjettinessParameters *mcSubjettiness,
-                                                       Double_t *angularity, Double_t *ptd, Double_t *rhoparameters){
-
-  memset(fJetTreeData,0, sizeof(Double_t) * kTNVar);
-  fJetTreeData[kTRadius] = r;
-  fJetTreeData[kTWeight] = weight;
-  if(fFillRho){
-    fJetTreeData[kTRhoPtRec] = rhoparameters[0]; 
-    if(fFillMass) fJetTreeData[kTRhoMassRec] = rhoparameters[2]; 
-    if(fFillPart){
-      fJetTreeData[kTRhoPtSim] = rhoparameters[1]; 
-      if(fFillMass) fJetTreeData[kTRhoMassSim] = rhoparameters[3]; 
-    }
-  }
-  if(datajet) {
-    fJetTreeData[kTPtJetRec] = TMath::Abs(datajet->Pt());
-    fJetTreeData[kTNCharged] = fUseChargedConstituents ? datajet->GetNumberOfTracks() : 0.;
-    fJetTreeData[kTNNeutral] = fUseNeutralConstituents ? datajet->GetNumberOfClusters() : 0.;
-    fJetTreeData[kTAreaRec] = datajet->Area();
-    fJetTreeData[kTNEFRec] = datajet->NEF();
-    if(fFillMass) fJetTreeData[kTMassRec] = datajet->M();
-    fJetTreeData[kTEJetRec] = datajet->E();
-    if(fFillAcceptance) {
-      fJetTreeData[kTEtaRec] = datajet->Eta();
-      fJetTreeData[kTPhiRec] = datajet->Phi();
-    }
-  }
-
-  if(fFillPart && mcjet){
-    fJetTreeData[kTPtJetSim] = TMath::Abs(mcjet->Pt());
-    fJetTreeData[kTNConstTrue] = mcjet->GetNumberOfConstituents();
-    fJetTreeData[kTAreaSim] = mcjet->Area();
-    fJetTreeData[kTNEFSim] = mcjet->NEF();
-    if(fFillMass) fJetTreeData[kTMassSim] = mcjet->M();
-    fJetTreeData[kTEJetSim] = mcjet->E();
-    if(fFillAcceptance){
-      fJetTreeData[kTEtaSim] = mcjet->Eta();
-      fJetTreeData[kTPhiSim] = mcjet->Phi();
-    }
-  }
-
-  if(fFillSoftDrop){
-    if(dataSoftdrop) {
-      fJetTreeData[kTZgMeasured] = dataSoftdrop->fZg;
-      fJetTreeData[kTRgMeasured] = dataSoftdrop->fRg;
-      fJetTreeData[kTMgMeasured] = dataSoftdrop->fMg;
-      fJetTreeData[kTPtgMeasured] = dataSoftdrop->fPtg;
-      fJetTreeData[kTMugMeasured] = dataSoftdrop->fMug;
-      fJetTreeData[kTDeltaRgMeasured] = mcSoftdrop->fDeltaR;
-      fJetTreeData[kTNDroppedMeasured] = dataSoftdrop->fNDropped;
-    }
-
-    if(fFillPart && mcSoftdrop) {
-      fJetTreeData[kTZgTrue] = mcSoftdrop->fZg;
-      fJetTreeData[kTRgTrue] = mcSoftdrop->fRg;
-      fJetTreeData[kTMgTrue] = mcSoftdrop->fMg;
-      fJetTreeData[kTPtgTrue] = mcSoftdrop->fPtg;
-      fJetTreeData[kTMugTrue] = mcSoftdrop->fMug;
-      fJetTreeData[kTDeltaRgTrue] = mcSoftdrop->fDeltaR;
-      fJetTreeData[kTNDroppedTrue] = mcSoftdrop->fNDropped;
-    }
-  }
-
-  if(fFillNSub){
-    if(dataSubjettiness) {
-      fJetTreeData[kTOneNSubjettinessMeasured] = dataSubjettiness->fOneSubjettiness;
-      fJetTreeData[kTTwoNSubjettinessMeasured] = dataSubjettiness->fTwoSubjettiness;
-    }
-
-    if(fFillPart && mcSubjettiness) {
-      fJetTreeData[kTOneNSubjettinessTrue] = mcSubjettiness->fOneSubjettiness;
-      fJetTreeData[kTTwoNSubjettinessTrue] = mcSubjettiness->fTwoSubjettiness;
-    } 
-  }
-
-  if(fFillStructGlob){
-    fJetTreeData[kTAngularityMeasured] = angularity[0];
-    fJetTreeData[kTPtDMeasured] = ptd[0];
-
-    if(fFillPart){
-      fJetTreeData[kTAngularityTrue] = angularity[1];
-      fJetTreeData[kTPtDTrue] = ptd[1];
-    }
-  }
-
-  fJetSubstructureTree->Fill();
-}
-
 void AliAnalysisTaskEmcalJetSubstructureTree::FillLuminosity() {
   if(fLumiMonitor && fUseDownscaleWeight){
     AliEmcalDownscaleFactorsOCDB *downscalefactors = AliEmcalDownscaleFactorsOCDB::Instance();
@@ -499,6 +450,20 @@ void AliAnalysisTaskEmcalJetSubstructureTree::FillLuminosity() {
       }
     }
   }
+}
+
+AliJetKineParameters AliAnalysisTaskEmcalJetSubstructureTree::MakeJetKineParameters(const AliEmcalJet &jet) const {
+  AliJetKineParameters result;
+  result.fPt = TMath::Abs(jet.Pt());
+  result.fE = jet.E();
+  result.fEta = jet.Eta();
+  result.fPhi = jet.Phi();
+  result.fArea = jet.Area();
+  result.fMass = jet.M();
+  result.fNEF = jet.NEF();
+  result.fNCharged = jet.GetNumberOfTracks();
+  result.fNNeutral = jet.GetNumberOfClusters();
+  return result;
 }
 
 AliJetSubstructureData AliAnalysisTaskEmcalJetSubstructureTree::MakeJetSubstructure(const AliEmcalJet &jet, double jetradius, const AliParticleContainer *tracks, const AliClusterContainer *clusters, const AliJetSubstructureSettings &settings) const {
@@ -757,34 +722,6 @@ bool AliAnalysisTaskEmcalJetSubstructureTree::IsSelectEmcalTriggers(const std::s
   return isEMCAL;
 }
 
-bool AliAnalysisTaskEmcalJetSubstructureTree::IsPartBranch(const std::string &branchname) const{
-  return (branchname.find("Sim") != std::string::npos) || (branchname.find("True") != std::string::npos);
-}
-
-bool AliAnalysisTaskEmcalJetSubstructureTree::IsAcceptanceBranch(const std::string &branchname) const {
-  return (branchname.find("Eta") != std::string::npos) || (branchname.find("Phi") != std::string::npos);
-}
-
-bool AliAnalysisTaskEmcalJetSubstructureTree::IsRhoBranch(const std::string &branchname) const{
-  return (branchname.find("Rho") != std::string::npos);
-}
-
-bool AliAnalysisTaskEmcalJetSubstructureTree::IsMassBranch(const std::string &branchname) const{
-  return (branchname.find("Mass") != std::string::npos);     // also disable rho mass branch
-}
-
-bool AliAnalysisTaskEmcalJetSubstructureTree::IsSoftdropBranch(const std::string &branchname) const{
-  return (branchname.find("gMeasured") != std::string::npos) || (branchname.find("gTrue") != std::string::npos) || (branchname.find("NDropped") != std::string::npos);
-}
-
-bool AliAnalysisTaskEmcalJetSubstructureTree::IsNSubjettinessBranch(const std::string &branchname) const{
-  return (branchname.find("Subjettiness") != std::string::npos);
-}
-
-bool AliAnalysisTaskEmcalJetSubstructureTree::IsStructbranch(const std::string &branchname) const{
-  return (branchname.find("Angularity") != std::string::npos) || (branchname.find("PtD") != std::string::npos);
-}
-
 AliAnalysisTaskEmcalJetSubstructureTree *AliAnalysisTaskEmcalJetSubstructureTree::AddEmcalJetSubstructureTreeMaker(Bool_t isMC, Bool_t isData, Double_t jetradius, AliJetContainer::EJetType_t jettype, AliJetContainer::ERecoScheme_t recombinationScheme, const char *trigger){
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
 
@@ -894,4 +831,51 @@ bool Triggerinfo::IsTriggerClass(const std::string &triggerclass) const {
   return fTriggerClass.substr(1) == triggerclass; // remove C from trigger class part
 }
 
+void AliSoftDropParameters::LinkJetTreeBranches(TTree *jettree, const char *tag) {
+  LinkBranch(jettree, &fZg, Form("Zg%s", tag), "D");
+  LinkBranch(jettree, &fRg, Form("Rg%s", tag), "D");
+  LinkBranch(jettree, &fMg, Form("Mg%s", tag), "D");
+  LinkBranch(jettree, &fPtg, Form("Ptg%s", tag), "D");
+  LinkBranch(jettree, &fMug, Form("Mug%s", tag), "D");
+  LinkBranch(jettree, &fDeltaR, Form("DeltaRg%s", tag), "D");
+  LinkBranch(jettree, &fNDropped, Form("NDropped%s", tag), "I");
+};
+
+void AliNSubjettinessParameters::LinkJetTreeBranches(TTree *jettree, const char *tag) {
+  LinkBranch(jettree, &fOneSubjettiness, Form("OneSubjettiness%s", tag), "D");
+  LinkBranch(jettree, &fTwoSubjettiness, Form("TwoSubjettiness%s", tag), "D");
+}
+
+void AliJetStructureParameters::LinkJetTreeBranches(TTree *jettree, const char *tag){
+  LinkBranch(jettree, &fAngularity, Form("Angularity%s", tag), "D");
+  LinkBranch(jettree, &fPtD, Form("PtD%s", tag), "D");
+}
+
+void AliJetKineParameters::LinkJetTreeBranches(TTree *jettree, const char *tag){
+  LinkBranch(jettree, &fPt, Form("PtJet%s", tag), "D");
+  LinkBranch(jettree, &fE, Form("EJet%s", tag), "D");
+  LinkBranch(jettree, &fEta, Form("Eta%s", tag), "D");
+  LinkBranch(jettree, &fPhi, Form("Phi%s", tag), "D");
+  LinkBranch(jettree, &fArea, Form("Area%s", tag), "D");
+  LinkBranch(jettree, &fMass, Form("Mass%s", tag), "D");
+  LinkBranch(jettree, &fNEF, Form("NEFt%s", tag), "D");
+  LinkBranch(jettree, &fPt, Form("PtJet%s", tag), "D");
+  LinkBranch(jettree, &fNCharged, Form("NCharged%s", tag), "I");
+  LinkBranch(jettree, &fNNeutral, Form("NNeutral%s", tag), "I");
+}
+
+void AliJetTreeGlobalParameters::LinkJetTreeBranches(TTree *jettree, bool fillRho) {
+  LinkBranch(jettree, &fJetRadius, "Radius", "D");
+  LinkBranch(jettree, &fEventWeight, "EventWeight", "D");
+  if(fillRho) {
+    std::string varnames[] = {"RhoPtRec", "RhoPtSim", "RhoMassRec", "RhoMassSim"};
+    for(int i = 0; i < 4; i++){
+      LinkBranch(jettree, fRhoParamters + i, varnames[i].data(), "D");
+    }
+  }
+}
+
+void LinkBranch(TTree *jettree, void *data, const char *branchname, const char *type) {
+  jettree->Branch(branchname, data, Form("%s/%s", branchname, type));
+}
 } /* namespace EmcalTriggerJets */

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.h
@@ -53,6 +53,8 @@ namespace EmcalTriggerJets {
 struct AliNSubjettinessParameters {
   Double_t fOneSubjettiness;      ///< 1-subjettiness
   Double_t fTwoSubjettiness;      ///< 2-subjettiness
+
+  void LinkJetTreeBranches(TTree *jettree, const char *tag);
 };
 
 /**
@@ -78,6 +80,8 @@ struct AliSoftDropParameters {
   Double_t fDeltaR;         ///< Delta_r of the branches at the last splitting
   Double_t fMug;            ///< Mass Drop parameter
   Int_t fNDropped;          ///< Number of dropped subjets
+
+  void LinkJetTreeBranches(TTree *jettree, const char *tag);
 };
 
 /**
@@ -99,6 +103,45 @@ struct AliJetSubstructureSettings {
 struct AliJetSubstructureData {
   AliSoftDropParameters fSoftDrop;
   AliNSubjettinessParameters fNsubjettiness;
+};
+
+/**
+ * @struct AliJetKineParameters
+ * @brief Jet kinematic parameters
+ * @ingroup PWGJETASKS
+ */
+struct AliJetKineParameters {
+  Double_t fPt;                              ///< Jet Pt
+  Double_t fE;                               ///< Jet Energy
+  Double_t fMass;                            ///< Jet Mass
+  Double_t fEta;                             ///< Jet Eta 
+  Double_t fPhi;                             ///< Jet Phi
+  Double_t fArea;                            ///< Jet Area
+  Double_t fNEF;                             ///< Jet Neutral Energy Fraction
+  Int_t    fNCharged;                        ///< Number of charged constituents
+  Int_t    fNNeutral;                        ///< Number of neutral constituents
+
+  void LinkJetTreeBranches(TTree *jettree, const char *tag);
+};
+
+/**
+ * @struct AliJetStructureParameters
+ * @brief Global jet substructure paramters
+ * @ingroup PWGJETASKS
+ */
+struct AliJetStructureParameters {
+  Double_t fAngularity;                       ///< Angularity
+  Double_t fPtD;                              ///< Pt dispersion
+
+  void LinkJetTreeBranches(TTree *jettree, const char *tag);
+};
+
+struct AliJetTreeGlobalParameters {
+  Double_t fJetRadius;
+  Double_t fEventWeight;
+  Double_t fRhoParamters[4];
+
+  void LinkJetTreeBranches(TTree *jettree, bool fillRho);
 };
 
 struct Triggerinfo {
@@ -145,54 +188,6 @@ public:
     kKTAlgo = 1,
     kAKTAlgo = 2
   };
-  enum JetTreeEntry {
-    kTRadius = 0,
-    kTWeight = 1,
-    kTPtJetRec = 2,
-    kTPtJetSim = 3,
-    kTEJetRec = 4,
-    kTEJetSim = 5,
-    kTEtaRec = 6,
-    kTEtaSim = 7,
-    kTPhiRec = 8,
-    kTPhiSim = 9,
-    kTRhoPtRec = 10,
-    kTRhoPtSim = 11,
-    kTRhoMassRec = 12,
-    kTRhoMassSim = 13,
-    kTAreaRec = 14,
-    kTAreaSim = 15,
-    kTNEFRec = 16,
-    kTNEFSim = 17,
-    kTMassRec = 18,
-    kTMassSim = 19,
-    kTZgMeasured = 20,
-    kTZgTrue = 21,
-    kTRgMeasured = 22,
-    kTRgTrue = 23,
-    kTMgMeasured = 24,
-    kTMgTrue = 25,
-    kTPtgMeasured = 26,
-    kTPtgTrue = 27,
-    kTMugMeasured = 28,
-    kTMugTrue = 29,
-    kTDeltaRgMeasured = 30,
-    kTDeltaRgTrue = 31,
-    kTOneNSubjettinessMeasured = 32,
-    kTOneNSubjettinessTrue = 33,
-    kTTwoNSubjettinessMeasured = 34,
-    kTTwoNSubjettinessTrue = 35,
-    kTAngularityMeasured = 36,
-    kTAngularityTrue = 37,
-    kTPtDMeasured = 38,
-    kTPtDTrue = 39,
-    kTNCharged = 40,
-    kTNNeutral = 41,
-    kTNConstTrue = 42,
-    kTNDroppedMeasured = 43,
-    kTNDroppedTrue = 44,
-    kTNVar = 45
-  };
 
 	AliAnalysisTaskEmcalJetSubstructureTree();
 	AliAnalysisTaskEmcalJetSubstructureTree(const char *name);
@@ -211,9 +206,7 @@ public:
 	}
 
   void SetFillPartLevelBranches(Bool_t doFill) { fFillPart = doFill; }
-  void SetFillAcceptance(Bool_t doFill) { fFillAcceptance = doFill; }
   void SetFillRhoBranches(Bool_t doFill) { fFillRho = doFill; }
-  void SetFillMassBranches(Bool_t doFill) { fFillMass = doFill; }
   void SetFillSoftdropBranches(Bool_t doFill) { fFillSoftDrop = doFill; }
   void SetFillNSubjettinessBranches(Bool_t doFill) { fFillNSub = doFill; }
   void SetFillSubstructureBranches(Bool_t doFill) { fFillStructGlob = doFill; }
@@ -234,36 +227,34 @@ protected:
 	AliSoftDropParameters MakeSoftDropParameters(const fastjet::PseudoJet &jet, const AliSoftdropDefinition &cut) const;
 
 	AliNSubjettinessParameters MakeNsubjettinessParameters(const fastjet::PseudoJet &jet, const AliNSubjettinessDefinition &cut) const;
+  
+  AliJetKineParameters MakeJetKineParameters(const AliEmcalJet &jet) const;
 
 	Double_t MakeAngularity(const AliEmcalJet &jet, const AliParticleContainer *tracks, const AliClusterContainer *clusters) const;
 
 	Double_t MakePtD(const AliEmcalJet &jet, const AliParticleContainer *const particles, const AliClusterContainer *const clusters) const;
 
-	void FillTree(double r, double weight, const AliEmcalJet *datajet, const AliEmcalJet *mcjet, AliSoftDropParameters *dataSoftdrop, AliSoftDropParameters *mcsoftdrop, AliNSubjettinessParameters *dataSubjettiness, AliNSubjettinessParameters *mcSubjettiness, Double_t *angularity, Double_t *ptd, Double_t *rhoparameters);
-
   void FillLuminosity();
 
 	void DoConstituentQA(const AliEmcalJet *jet, const AliParticleContainer *tracks, const AliClusterContainer *clusters);
-
-  void LinkOutputBranch(const std::string &branchname, Double_t *datalocation);
 
   std::vector<Triggerinfo> DecodeTriggerString(const std::string &triggerstring) const;
   std::string MatchTrigger(const std::string &triggerclass) const;
   bool IsSelectEmcalTriggers(const std::string &triggerstring) const;
 
-  bool IsPartBranch(const std::string &branchname) const;
-  bool IsAcceptanceBranch(const std::string &branchname) const;
-  bool IsRhoBranch(const std::string &branchname) const;
-  bool IsMassBranch(const std::string &branchname) const;
-  bool IsSoftdropBranch(const std::string &branchname) const;
-  bool IsNSubjettinessBranch(const std::string &branchname) const;
-  bool IsStructbranch(const std::string &branchname) const;
-
   bool SelectJet(const AliEmcalJet &jet, const AliParticleContainer *particles) const;
 
 private:
 	TTree                       *fJetSubstructureTree;        //!<! Tree with jet substructure information
-	Double_t                     fJetTreeData[kTNVar];        ///< Variable storage for the jet tree
+  AliJetTreeGlobalParameters  *fGlobalTreeParams;           //!<! Global jet tree parameters (same for all jets in event)
+  AliSoftDropParameters       *fSoftDropMeasured;           //!<! Data field for measured soft drop parameters in jet tree
+  AliSoftDropParameters       *fSoftDropTrue;               //!<! Data field for true soft drop parameters in jet tree
+  AliNSubjettinessParameters  *fNSubMeasured;               //!<! Data field for measured n-subjettiness parameters in jet tree
+  AliNSubjettinessParameters  *fNSubTrue;                   //!<! Data field for true n-subjettiness parameters in jet tree
+  AliJetKineParameters        *fKineRec;                    //!<! Detector level jet kinematics
+  AliJetKineParameters        *fKineSim;                    //!<! Particle level jet kinematics
+  AliJetStructureParameters   *fJetStructureMeasured;       //!<! Measured jet substructure parameters
+  AliJetStructureParameters   *fJetStructureTrue;           //!<! True jet substructure paramteres
 	THistManager                *fQAHistos;                   //!<! QA histos
   TH1                         *fLumiMonitor;                //!<! Luminosity monitor
 
@@ -281,9 +272,7 @@ private:
 
   // Fill levels for tree (save disk space when information is not needed)
   Bool_t                       fFillPart;                   ///< Fill particle level information
-  Bool_t                       fFillAcceptance;             ///< Fill acceptance (eta-phi)
   Bool_t                       fFillRho;                    ///< Fill rho parameters
-  Bool_t                       fFillMass;                   ///< Fill jet mass
   Bool_t                       fFillSoftDrop;               ///< Fill soft drop parameters
   Bool_t                       fFillNSub;                   ///< Fill N-subjettiness
   Bool_t                       fFillStructGlob;             ///< Fill other substructure variables
@@ -292,6 +281,16 @@ private:
 	ClassDef(AliAnalysisTaskEmcalJetSubstructureTree, 1);
 	/// \endcond
 };
+
+/**
+ * @brief Helper function linking struct members to branches in the jet substructure tree
+ * 
+ * @param jettree Jet tree to be linked
+ * @param data Data field to be linked
+ * @param branchname Name of the branch in the jet tree
+ * @param type Variable data type
+ */
+void LinkBranch(TTree *jettree, void *data, const char *branchname, const char *type);
 
 } /* namespace EmcalTriggerJets */
 


### PR DESCRIPTION
**Work in progress - don't merge**
Flat array no longer used. Instead the data is organized
in structures (partially using the structures used as
return data for the SoftDrop/N-subjettiness). Each
structure has a function LinJetTreeBranch to link its
variables to a branch in the output tree. The structures
are dynamic data members of the class, allocated in
UserCreateOutputObjects and deleted in the constructor.