### PR TITLE
EMCal CorrFW: Fix dictionary warning

### DIFF
--- a/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
+++ b/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
@@ -44,6 +44,7 @@
 #pragma link C++ class  AliEmcalCorrectionClusterExotics+;
 #pragma link C++ class  AliEmcalCorrectionClusterTrackMatcher+;
 #pragma link C++ class  AliEmcalCorrectionClusterHadronicCorrection+;
+#pragma link C++ class  std::map<AliVTrack *,AliParticleContainer *>+;
 #pragma link C++ class  AliEmcalCorrectionPHOSCorrections+;
 #pragma link C++ class  AliAnalysisTaskEmcalOccupancy+;
 


### PR DESCRIPTION
Add dictionary entry for AOD track to particle container map introduced
in a0e3356