### PR TITLE
EMCal CorrFW: Fix typo

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterNonLinearity.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterNonLinearity.cxx
@@ -89,11 +89,11 @@ void AliEmcalCorrectionClusterNonLinearity::UserCreateOutputObjects()
   if (fCreateHisto){
     fEnergyDistBefore = new TH1F("hEnergyDistBefore","hEnergyDistBefore;E_{clus} (GeV)",1500,0,150);
     fOutput->Add(fEnergyDistBefore);
-    fEnergyTimeHistBefore = new TH2F("hEnergyTimeDistBefore","hEnergyTimeDistBefore;E_{clus} (GeV);time (ns)",1500,0,150,500,0,1e-6);
+    fEnergyTimeHistBefore = new TH2F("hEnergyTimeDistBefore","hEnergyTimeDistBefore;E_{clus} (GeV);time (s)",1500,0,150,500,0,1e-6);
     fOutput->Add(fEnergyTimeHistBefore);
     fEnergyDistAfter = new TH1F("hEnergyDistAfter","hEnergyDistAfter;E_{clus} (GeV)",1500,0,150);
     fOutput->Add(fEnergyDistAfter);
-    fEnergyTimeHistAfter = new TH2F("hEnergyTimeDistAfter","hEnergyTimeDistAfter;E_{clus} (GeV);time (ns)",1500,0,150,500,0,1e-6);
+    fEnergyTimeHistAfter = new TH2F("hEnergyTimeDistAfter","hEnergyTimeDistAfter;E_{clus} (GeV);time (s)",1500,0,150,500,0,1e-6);
     fOutput->Add(fEnergyTimeHistAfter);
     
     // Take ownership of output list


### PR DESCRIPTION
Typo introduced by 65da1fc95aaf9672ec1e27282875dd881b5a2144. The timing
label was fixed in the cell time calibration component, but missed in
the cluster non-linearity