### PR TITLE
Several changes

### DIFF
--- a/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.h
+++ b/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.h
@@ -110,6 +110,7 @@ public:
      fMCsignalsWritingOptions[fMCsignals.GetEntries()-1] = wOpt;}
   void SetFillHFInfo(Bool_t flag=kTRUE)               {fFillHFInfo = flag;}
   void SetFillTRDMatchedTracks(Bool_t flag1=kTRUE, Bool_t flag2=kFALSE)   {fFillTRDMatchedTracks = flag1; fFillAllTRDMatchedTracks=flag2;}
+  Float_t GetInvPtDevFromBC(Int_t b, Int_t c); // calculates the sagitta value from the online tracks
   void SetWriteEventsWithNoSelectedTracks(Bool_t flag=kTRUE, Double_t scaleDown=0.0, Int_t minSelectedTracks=1)   {
      fWriteEventsWithNoSelectedTracks = flag; 
      fScaleDownEventsWithNoSelectedTracks = scaleDown;
@@ -165,8 +166,10 @@ public:
   Bool_t fFillHFInfo;               // Write HF Process information
   TList   fMCsignals;               // list of AliSignalMC objects to select which particles from the Kinematics stack will be written in the tree
   Int_t   fMCsignalsWritingOptions[kMaxMCsignals];   // writing options for each of the MC signals (either base or full track)     
-  Bool_t fFillTRDMatchedTracks;     // Write global tracks with matched TRD tracks
-  Bool_t fFillAllTRDMatchedTracks;  // if true, fill all global tracks matched in TRD; if false, fill just those global tracks which were selected with the track of V0 filters
+  Bool_t  fFillTRDMatchedTracks;     // Write global tracks with matched TRD tracks
+  Bool_t  fFillAllTRDMatchedTracks;  // if true, fill all global tracks matched in TRD; if false, fill just those global tracks which were selected with the track of V0 filters
+  UChar_t fTRDtrglayerMaskEl;       // layer mask for tracklet requirements
+
 
   AliAnalysisCuts *fEventFilter;      // event filter
   TList            fTrackFilter;      // filter for the hadrons to be correlated with the dielectrons
@@ -220,6 +223,6 @@ public:
   AliAnalysisTaskReducedTreeMaker(const AliAnalysisTaskReducedTreeMaker &c);
   AliAnalysisTaskReducedTreeMaker& operator= (const AliAnalysisTaskReducedTreeMaker &c);
 
-  ClassDef(AliAnalysisTaskReducedTreeMaker, 9); //Analysis Task for creating a reduced event information tree
+  ClassDef(AliAnalysisTaskReducedTreeMaker, 10); //Analysis Task for creating a reduced event information tree
 };
 #endif

--- a/PWGDQ/reducedTree/AliReducedAnalysisTest.cxx
+++ b/PWGDQ/reducedTree/AliReducedAnalysisTest.cxx
@@ -130,6 +130,16 @@ void AliReducedAnalysisTest::Process() {
   //  
   if(!fEvent) return;
   
+  if(fProcessMCInfo) {
+     if(fEventCounter%10000==0) 
+        cout << "Event no. " << fEventCounter << endl;
+  }
+  else {
+     if(fEventCounter%10000==0) 
+        cout << "Event no. " << fEventCounter << endl;
+  }
+  fEventCounter++;
+  
   AliReducedVarManager::SetEvent(fEvent);
   
   AliReducedVarManager::FillEventInfo(fEvent, fValues);

--- a/PWGDQ/reducedTree/AliReducedBaseTrack.cxx
+++ b/PWGDQ/reducedTree/AliReducedBaseTrack.cxx
@@ -53,3 +53,27 @@ AliReducedBaseTrack::~AliReducedBaseTrack()
   // De-Constructor
   //
 }
+
+//_______________________________________________________________________________
+UInt_t AliReducedBaseTrack::GetFirstHalfOfQualityFlags() const {
+   //
+   // Get the first half of the fQualityFlags (bits 0->31)
+   //
+   UInt_t map = 0;
+   for(UShort_t i=0; i<32; ++i) 
+      if(TestQualityFlag(i)) 
+         map |= (UInt_t(1)<<i);
+   return map;   
+}
+
+//_______________________________________________________________________________
+UInt_t AliReducedBaseTrack::GetSecondHalfOfQualityFlags() const {
+   //
+   // Get the second half of the fQualityFlags (bits 32->63)
+   //
+   UInt_t map = 0;
+   for(UShort_t i=0; i<32; ++i) 
+      if(TestQualityFlag(i+32)) 
+         map |= (UInt_t(1)<<i);
+      return map;   
+}

--- a/PWGDQ/reducedTree/AliReducedBaseTrack.h
+++ b/PWGDQ/reducedTree/AliReducedBaseTrack.h
@@ -36,6 +36,8 @@ class AliReducedBaseTrack : public TObject {
     Bool_t IsCartesian() const {return fIsCartesian;}           
     
     ULong_t GetQualityFlags()             const {return fQualityFlags;}
+    UInt_t  GetFirstHalfOfQualityFlags() const;
+    UInt_t  GetSecondHalfOfQualityFlags() const;
     Bool_t UsedForQvector()               const {return fQualityFlags&(UShort_t(1)<<0);}
     Bool_t TestQualityFlag(UShort_t iflag)  const {return ((iflag<(8*sizeof(ULong_t))) ? fQualityFlags&(ULong_t(1)<<iflag) : kFALSE);}
     Bool_t IsMCTruth()                        const {return (fIsMCTruth ? kTRUE : kFALSE);}

--- a/PWGDQ/reducedTree/AliReducedCompositeCut.cxx
+++ b/PWGDQ/reducedTree/AliReducedCompositeCut.cxx
@@ -1,0 +1,79 @@
+/*
+***********************************************************
+  Implementation of AliReducedCompositeCut class.
+  Contact: iarsene@cern.ch
+  2018/02/06
+  *********************************************************
+*/
+
+#include <iostream>
+using std::cout;
+using std::endl;
+
+#ifndef ALIREDUCEDCOMPOSITECUT_H
+#include "AliReducedCompositeCut.h"
+#endif
+
+ClassImp(AliReducedCompositeCut)
+
+//____________________________________________________________________________
+AliReducedCompositeCut::AliReducedCompositeCut(Bool_t useAND /* = kTRUE */) :
+  AliReducedInfoCut(),
+  fOptionUseAND(useAND)
+{
+  //
+  // default constructor
+  //
+  fCuts.SetOwner(kTRUE);
+}
+
+//____________________________________________________________________________
+AliReducedCompositeCut::AliReducedCompositeCut(const Char_t* name, const Char_t* title, Bool_t useAND /* = kTRUE */) :
+  AliReducedInfoCut(name, title),
+  fOptionUseAND(useAND)
+{
+  //
+  // named constructor
+  //
+   fCuts.SetOwner(kTRUE);
+}
+
+//____________________________________________________________________________
+AliReducedCompositeCut::~AliReducedCompositeCut() {
+  //
+  // destructor
+  //
+}
+
+//____________________________________________________________________________
+Bool_t AliReducedCompositeCut::IsSelected(TObject* obj, Float_t* values) {
+  //
+  // apply cuts
+  //
+  for(Int_t iCut=0; iCut<fCuts.GetEntries(); ++iCut) {
+     AliReducedInfoCut* cut = (AliReducedInfoCut*)fCuts.At(iCut);
+     
+     if(fOptionUseAND && !cut->IsSelected(obj, values)) return kFALSE;
+     if(!fOptionUseAND && cut->IsSelected(obj, values)) return kTRUE;
+  }
+  
+  if(fOptionUseAND) return kTRUE;
+  else return kFALSE;
+}
+
+
+//____________________________________________________________________________
+Bool_t AliReducedCompositeCut::IsSelected(TObject* obj) {
+   //
+   // apply cuts
+   //
+   for(Int_t iCut=0; iCut<fCuts.GetEntries(); ++iCut) {
+      AliReducedInfoCut* cut = (AliReducedInfoCut*)fCuts.At(iCut);
+      
+      if(fOptionUseAND && !cut->IsSelected(obj)) return kFALSE;
+      if(!fOptionUseAND && cut->IsSelected(obj)) return kTRUE;
+   }
+   
+   if(fOptionUseAND) return kTRUE;
+   else return kFALSE;
+}

--- a/PWGDQ/reducedTree/AliReducedCompositeCut.h
+++ b/PWGDQ/reducedTree/AliReducedCompositeCut.h
@@ -1,0 +1,37 @@
+// Class for cutting on ALICE AliReducedVarManager information
+// Author: Ionut-Cristian Arsene (iarsene@cern.ch)
+//   06/02/2018
+
+#ifndef ALIREDUCEDCOMPOSITECUT_H
+#define ALIREDUCEDCOMPOSITECUT_H
+
+#include "AliReducedInfoCut.h"
+#include "TList.h"
+
+//_________________________________________________________________________
+class AliReducedCompositeCut : public AliReducedInfoCut {
+
+public:
+   AliReducedCompositeCut(Bool_t useAND=kTRUE);
+   AliReducedCompositeCut(const Char_t* name, const Char_t* title, Bool_t useAND=kTRUE);
+   virtual ~AliReducedCompositeCut();
+
+   void AddCut(AliReducedInfoCut* cut) {fCuts.Add(cut);};
+   
+   Bool_t GetUseAND() const {return fOptionUseAND;}
+   Int_t    GetNCuts() const {return fCuts.GetEntries();}
+   
+   virtual Bool_t IsSelected(TObject* obj);
+   virtual Bool_t IsSelected(TObject* obj, Float_t* values);
+  
+protected:
+   Bool_t fOptionUseAND;            // true (default): apply AND on all cuts; false: use OR
+   TList   fCuts;                            // list of cuts
+    
+   AliReducedCompositeCut(const AliReducedCompositeCut &c);
+   AliReducedCompositeCut& operator= (const AliReducedCompositeCut &c);
+  
+   ClassDef(AliReducedCompositeCut,1);
+};
+
+#endif

--- a/PWGDQ/reducedTree/AliReducedEventInfo.cxx
+++ b/PWGDQ/reducedTree/AliReducedEventInfo.cxx
@@ -31,6 +31,7 @@ AliReducedEventInfo::AliReducedEventInfo() :
   fL0TriggerInputs(0),
   fL1TriggerInputs(0),
   fL2TriggerInputs(0),
+  fTRDfired(0),
   fBC(0),
   fTimeStamp(0),
   fEventType(0),
@@ -105,6 +106,7 @@ AliReducedEventInfo::AliReducedEventInfo(const Char_t* name, Int_t trackOption /
   fL0TriggerInputs(0),
   fL1TriggerInputs(0),
   fL2TriggerInputs(0),
+  fTRDfired(0),
   fBC(0),
   fTimeStamp(0),
   fEventType(0),
@@ -195,6 +197,7 @@ void AliReducedEventInfo::CopyEventHeader(const AliReducedEventInfo* other) {
    fL0TriggerInputs = other->fL0TriggerInputs;
    fL1TriggerInputs = other->fL1TriggerInputs;
    fL2TriggerInputs = other->fL2TriggerInputs;
+   fTRDfired        = other->fTRDfired;
    fBC = other->fBC;
    fTimeStamp = other->fTimeStamp;
    fEventType = other->fEventType;
@@ -254,6 +257,7 @@ void AliReducedEventInfo::ClearEvent() {
   fL0TriggerInputs=0;
   fL1TriggerInputs=0;
   fL2TriggerInputs=0;
+  fTRDfired=0;
   fIRIntClosestIntMap[0] = 0; fIRIntClosestIntMap[1] = 0;
   fBC = 0;
   fTimeStamp = 0;

--- a/PWGDQ/reducedTree/AliReducedEventInfo.h
+++ b/PWGDQ/reducedTree/AliReducedEventInfo.h
@@ -33,6 +33,7 @@ class AliReducedEventInfo : public AliReducedBaseEvent {
   Bool_t    L1TriggerInput(UShort_t bit)      const {return (bit<8*sizeof(UInt_t) ? (fL1TriggerInputs&(UInt_t(1)<<bit)) : kFALSE);}
   UShort_t  L2TriggerInputs()                 const {return fL2TriggerInputs;}
   Bool_t    L2TriggerInput(UShort_t bit)      const {return (bit<8*sizeof(UShort_t) ? (fL2TriggerInputs&(UShort_t(1)<<bit)) : kFALSE);}
+  UChar_t   TRDfired()                        const {return fTRDfired;}
   UShort_t  BC()                              const {return fBC;}
   UInt_t    TimeStamp()                       const {return fTimeStamp;}
   UInt_t    EventType()                       const {return fEventType;}
@@ -155,6 +156,7 @@ class AliReducedEventInfo : public AliReducedBaseEvent {
   UInt_t    fL0TriggerInputs;       // L0 trigger inputs
   UInt_t    fL1TriggerInputs;       // L1 trigger inputs
   UShort_t  fL2TriggerInputs;       // L2 trigger inputs
+  UChar_t   fTRDfired;              // which TRD trigger fired HQU or HSE
   UShort_t  fBC;                    // bunch crossing
   UInt_t    fTimeStamp;             // time stamp of the event                
   UInt_t    fEventType;             // event type                             
@@ -208,7 +210,7 @@ class AliReducedEventInfo : public AliReducedBaseEvent {
   AliReducedEventInfo& operator= (const AliReducedEventInfo &c);
   AliReducedEventInfo(const AliReducedEventInfo &c);
 
-  ClassDef(AliReducedEventInfo, 6);
+  ClassDef(AliReducedEventInfo, 7);
 };
 
 #endif

--- a/PWGDQ/reducedTree/AliReducedTrackCut.h
+++ b/PWGDQ/reducedTree/AliReducedTrackCut.h
@@ -32,6 +32,16 @@ class AliReducedTrackCut : public AliReducedVarCut {
   void SetTrackFilterBit(Int_t bit) {if(bit>=0 && bit<32) fCutOnTrackFilterMap |= (UInt_t(1)<<bit);}
   void SetUseANDonTrackFilterMap(Bool_t useAND=kTRUE) {fUseANDonTrackFilterMap=useAND;}
   
+  void SetTrackQualityFilterMap(UInt_t map, UInt_t exclusionMap=0, Bool_t useAND=kTRUE) {
+     fCutOnTrackQualityMap = map; fCutOnTrackQualityMapExclude=exclusionMap; fUseANDonTrackQualityMap=useAND;}
+  void SetTrackQualityFilterBit(Int_t bit, Bool_t exclude=kFALSE) {
+     if(bit>=0 && bit<32) {
+        fCutOnTrackQualityMap |= (UInt_t(1)<<bit);
+        if(exclude) fCutOnTrackQualityMapExclude |= (UInt_t(1)<<bit);
+     }
+   }
+  void SetUseANDonTrackQualityFilterMap(Bool_t useAND=kTRUE) {fUseANDonTrackQualityMap=useAND;}
+  
   void SetRejectPureMC(Bool_t reject=kTRUE) {fRejectPureMC=reject;}
   
   void SetMCFilterMap(UInt_t map, Bool_t useAND=kTRUE) {fCutOnMCFilterMap = map; fUseANDonMCFilterMap=useAND;}
@@ -43,6 +53,8 @@ class AliReducedTrackCut : public AliReducedVarCut {
   Bool_t GetRejectTaggedPureGamma() const {return fRejectTaggedPureGamma;}
   UInt_t GetTrackFilterMap() const {return fCutOnTrackFilterMap;}
   Bool_t GetUseANDonTrackFilterMap() const {return fUseANDonTrackFilterMap;}
+  UInt_t GetTrackQualityFilterMap() const {return fCutOnTrackQualityMap;}
+  Bool_t GetUseANDonTrackQualityFilterMap() const {return fUseANDonTrackQualityMap;}
   Bool_t GetRejectPureMC() const {return fRejectPureMC;}
   UInt_t GetMCFilterMap() const {return fCutOnMCFilterMap;}
   Bool_t GetUseANDonMCFilterMap() const {return fUseANDonMCFilterMap;}
@@ -64,6 +76,9 @@ class AliReducedTrackCut : public AliReducedVarCut {
   Bool_t    fRejectKinks;                       // if true, reject kinks
   Bool_t    fRejectTaggedGamma;       // if true, reject tagged gamma conversions
   Bool_t    fRejectTaggedPureGamma;  // if true, reject only the high purity tagged gamma conversions
+  UInt_t    fCutOnTrackQualityMap;      // map encoding requests on the quality of the track (see bits in AliReducedBaseTrack::fQualityFlags)
+  UInt_t    fCutOnTrackQualityMapExclude;    // if bits are enabled, corresponding requests on fCutOnTrackQualityMap are negated
+  Bool_t    fUseANDonTrackQualityMap;   // if false, apply an OR on enabled positions; if true apply AND
   
   // selections on the track filter map 
   UInt_t    fCutOnTrackFilterMap;         // map encoding the various requests on track filters

--- a/PWGDQ/reducedTree/AliReducedTrackInfo.cxx
+++ b/PWGDQ/reducedTree/AliReducedTrackInfo.cxx
@@ -56,6 +56,11 @@ AliReducedTrackInfo::AliReducedTrackInfo() :
   fTRDntracklets(),
   fTRDpid(),
   fTRDpidLQ2D(),
+  fTRDGTUtracklets(0),
+  fTRDGTUlayermask(0),
+  fTRDGTUpt(0.),
+  fTRDGTUsagitta(0.0),
+  fTRDGTUPID(0.),
   fCaloClusterId(-999),
   fTrackParam(),
   fCovMatrix(),
@@ -116,6 +121,11 @@ AliReducedTrackInfo::AliReducedTrackInfo(const AliReducedTrackInfo &c) :
   fTOFmismatchProbab(c.fTOFmismatchProbab),
   fTOFchi2(c.fTOFchi2),
   fTOFdeltaBC(c.fTOFdeltaBC),
+  fTRDGTUtracklets(c.fTRDGTUtracklets),
+  fTRDGTUlayermask(c.fTRDGTUlayermask),
+  fTRDGTUpt(c.fTRDGTUpt),
+  fTRDGTUsagitta(c.fTRDGTUsagitta),
+  fTRDGTUPID(c.fTRDGTUPID),
   fCaloClusterId(c.fCaloClusterId),
   fMCGeneratorIndex(c.fMCGeneratorIndex)
 {

--- a/PWGDQ/reducedTree/AliReducedTrackInfo.h
+++ b/PWGDQ/reducedTree/AliReducedTrackInfo.h
@@ -78,7 +78,15 @@ class AliReducedTrackInfo : public AliReducedBaseTrack {
   Float_t  TRDpid(Int_t specie)       const {return (specie>=0 && specie<=1 ? fTRDpid[specie] : -999.);}
   Float_t  TRDpidLQ1D(Int_t specie)   const {return (specie>=0 && specie<=1 ? fTRDpid[specie] : -999.);}
   Float_t  TRDpidLQ2D(Int_t specie)   const {return (specie>=0 && specie<=1 ? fTRDpidLQ2D[specie] : -999.);}
-  
+
+  // TRD online tracks
+  UChar_t   TRDGTUtracklets()      const {return fTRDGTUtracklets;}
+  UChar_t   TRDGTUlayermask()      const {return fTRDGTUlayermask;}
+  Float_t   TRDGTUpt()             const {return fTRDGTUpt;}
+  Float_t   TRDGTUsagitta()        const {return fTRDGTUsagitta;}
+  UChar_t   TRDGTUPID()            const {return fTRDGTUPID;}
+
+
   Int_t    CaloClusterId() const {return fCaloClusterId;}
   
   Float_t TrackParam(Int_t iPar = 0) {return (iPar>=0 && iPar<6 ? fTrackParam[iPar] : 0.0);}
@@ -148,7 +156,14 @@ class AliReducedTrackInfo : public AliReducedBaseTrack {
   UChar_t fTRDntracklets[2];       // 0 - AliESDtrack::GetTRDntracklets(); 1 - AliESDtrack::GetTRDntrackletsPID()   TODO: use only 1 char
   Float_t fTRDpid[2];              // TRD pid 1D likelihoods, [0]-electron , [1]- pion
   Float_t fTRDpidLQ2D[2];          // TRD pid 2D likelihoods, [0]-electron , [1]- pion
-  
+
+  // TRD online tracks
+  UChar_t  fTRDGTUtracklets;    // TRD online track #tracklets
+  UChar_t  fTRDGTUlayermask;    // TRD online track hit in layer0 yes/no
+  Float_t  fTRDGTUpt;           // TRD online track pT
+  Float_t  fTRDGTUsagitta;      // TRD online track sagitta
+  UChar_t  fTRDGTUPID;          // TRD online track pid
+
   // EMCAL/PHOS
   Int_t  fCaloClusterId;          // ID for the calorimeter cluster (if any)
   
@@ -167,7 +182,7 @@ class AliReducedTrackInfo : public AliReducedBaseTrack {
 
   AliReducedTrackInfo& operator= (const AliReducedTrackInfo &c);
   
-  ClassDef(AliReducedTrackInfo, 5);
+  ClassDef(AliReducedTrackInfo, 6);
 };
 
 //_______________________________________________________________________________

--- a/PWGDQ/reducedTree/AliReducedVarCut.cxx
+++ b/PWGDQ/reducedTree/AliReducedVarCut.cxx
@@ -205,8 +205,6 @@ Bool_t AliReducedVarCut::IsSelected(TObject* obj) {
    //
    // apply cuts
    //
-   if(!obj->InheritsFrom(AliReducedBaseTrack::Class())) return kFALSE;
-   
    //Fill values
    Float_t values[AliReducedVarManager::kNVars];
    if(obj->InheritsFrom(AliReducedBaseEvent::Class())) AliReducedVarManager::FillEventInfo((AliReducedBaseEvent*)obj, values);

--- a/PWGDQ/reducedTree/AliReducedVarManager.cxx
+++ b/PWGDQ/reducedTree/AliReducedVarManager.cxx
@@ -464,6 +464,7 @@ void AliReducedVarManager::FillEventInfo(BASEEVENT* baseEvent, Float_t* values, 
   values[kEventType]            = event->EventType();
   values[kTriggerMask]          = event->TriggerMask();
   values[kINT7Triggered]        = event->TriggerMask() & kINT7 ?1:0;
+  values[kTRDTriggeredType]     = event->TRDfired();
   values[kHighMultV0Triggered]  = event->TriggerMask() & kHighMultV0 ?1:0;
   values[kIsPhysicsSelection]   = (event->IsPhysicsSelection() ? 1.0 : 0.0);
   values[kIsSPDPileup]          = event->IsSPDPileup();
@@ -1348,6 +1349,14 @@ void AliReducedVarManager::FillTrackInfo(BASETRACK* p, Float_t* values) {
   values[kTRDpidProbabilitiesLQ2D+1] = pinfo->TRDpidLQ2D(1);
   values[kTRDntracklets]    = pinfo->TRDntracklets(0);
   values[kTRDntrackletsPID] = pinfo->TRDntracklets(1);
+
+  // TRD GTU online tracks
+  values[kTRDGTUtracklets]   = pinfo->TRDGTUtracklets();
+  values[kTRDGTUlayermask]   = pinfo->TRDGTUlayermask();
+  values[kTRDGTUpt]          = pinfo->TRDGTUpt();
+  values[kTRDGTUsagitta]     = pinfo->TRDGTUsagitta();
+  values[kTRDGTUPID]         = pinfo->TRDGTUPID();
+
 
   if(fgUsedVars[kEMCALmatchedEnergy] || fgUsedVars[kEMCALmatchedEOverP]) {
     values[kEMCALmatchedClusterId] = pinfo->CaloClusterId();
@@ -2339,6 +2348,7 @@ void AliReducedVarManager::SetDefaultVarNames() {
 
 
   fgVariableNames[kINT7Triggered]       = "event was triggered with INT7";       fgVariableUnits[kINT7Triggered]       = "";
+  fgVariableNames[kTRDTriggeredType]    = "event was triggered by TRD ele trigger"; fgVariableUnits[kTRDTriggeredType]       = "";
   fgVariableNames[kHighMultV0Triggered] = "event was triggered with HighMultV0"; fgVariableUnits[kHighMultV0Triggered] = "";
 
   TString vzeroSideNames[3] = {"A","C","AC"};
@@ -2587,6 +2597,12 @@ void AliReducedVarManager::SetDefaultVarNames() {
   fgVariableNames[kTRDpidProbabilitiesLQ1D+1] = "TRD LQ1D pion probability";     fgVariableUnits[kTRDpidProbabilitiesLQ1D+1] = "";
   fgVariableNames[kTRDpidProbabilitiesLQ2D]   = "TRD LQ2D electron probability"; fgVariableUnits[kTRDpidProbabilitiesLQ2D] = "";  
   fgVariableNames[kTRDpidProbabilitiesLQ2D+1] = "TRD LQ2D pion probability";     fgVariableUnits[kTRDpidProbabilitiesLQ2D+1] = "";
+  fgVariableNames[kTRDGTUtracklets]             = "No. TRD GTU tracklets";           fgVariableUnits[kTRDGTUtracklets]        = "";
+  fgVariableNames[kTRDGTUlayermask]             = "No. TRD GTU layer0 cond";         fgVariableUnits[kTRDGTUlayermask]        = "";
+  fgVariableNames[kTRDGTUpt]                    = "No. TRD GTU pt";                  fgVariableUnits[kTRDGTUpt]               = "";
+  fgVariableNames[kTRDGTUsagitta]               = "No. TRD GTU sagitta";             fgVariableUnits[kTRDGTUsagitta]          = "";
+  fgVariableNames[kTRDGTUPID]                   = "No. TRD GTU PID";                 fgVariableUnits[kTRDGTUPID]              = "";
+
   fgVariableNames[kEMCALmatchedEnergy]    = "Calo energy";             fgVariableUnits[kEMCALmatchedEnergy] = "GeV";
   fgVariableNames[kEMCALmatchedClusterId] = "matched Calo cluster id"; fgVariableUnits[kEMCALmatchedClusterId] = "";
   fgVariableNames[kEMCALmatchedEOverP]    = "Calo E/p";                fgVariableUnits[kEMCALmatchedEOverP] = "";  

--- a/PWGDQ/reducedTree/AliReducedVarManager.h
+++ b/PWGDQ/reducedTree/AliReducedVarManager.h
@@ -552,7 +552,14 @@ class AliReducedVarManager : public TObject {
     kDeltaEta,
     kTriggerPt,     // pt of J/psi candidate
     kAssociatedPt,  // pt of associated track
+    // TRD GTU online tracks
+    kTRDGTUtracklets,   // TRD online track #tracklets
+    kTRDGTUlayermask,   // TRD online track hit in layer0 yes/no
+    kTRDGTUpt,          // TRD online track pT
+    kTRDGTUsagitta,     // TRD online track sagitta
+    kTRDGTUPID,         // TRD online track pid
     kTrackingFlags,
+    kTRDTriggeredType,
     kTrackingStatus=kTrackingFlags+kNTrackingFlags,
     kNVars=kTrackingStatus+kNTrackingStatus,     
   };

--- a/PWGDQ/reducedTree/AliResonanceFits.h
+++ b/PWGDQ/reducedTree/AliResonanceFits.h
@@ -196,7 +196,11 @@ class AliResonanceFits : public TObject {
   TH1* GetSignalMC() const {return (fMatchingIsDone ? fSignalMCshape : 0x0);}
   
   Int_t GetBkgMethod() const {return fOptionBkgMethod;}
+  Int_t GetScalingOption() const {return fOptionScale;}
+  Int_t GetMEMatchingMethod() const {return fgOptionMEMatching;}
+  Int_t GetMinuitFitOption() const {return fOptionMinuit;}
   Double_t* GetMassFitRange() const {return fgMassFitRange;}
+  Double_t* GetMassExclusionRange() const {return fgMassExclusionRange;}
   const Double_t* GetFitValues() const {return fFitValues;}
   
   

--- a/PWGDQ/reducedTree/CMakeLists.txt
+++ b/PWGDQ/reducedTree/CMakeLists.txt
@@ -48,6 +48,7 @@ set(SRCS
       AliReducedBaseTrackCut.cxx
       AliReducedBaseTrack.cxx
       AliReducedCaloClusterInfo.cxx
+      AliReducedCompositeCut.cxx
       AliReducedEventCut.cxx
       AliReducedEventInfo.cxx
       AliReducedEventInputHandler.cxx

--- a/PWGDQ/reducedTree/PWGDQreducedTreeLinkDef.h
+++ b/PWGDQ/reducedTree/PWGDQreducedTreeLinkDef.h
@@ -20,6 +20,7 @@
 #pragma link C++ class AliReducedBaseTrackCut+;
 #pragma link C++ class AliReducedBaseTrack+;
 #pragma link C++ class AliReducedCaloClusterInfo+;
+#pragma link C++ class AliReducedCompositeCut+;
 #pragma link C++ class AliReducedEventCut+;
 #pragma link C++ class AliReducedEventInfo+;
 #pragma link C++ class AliReducedEventInputHandler+;


### PR DESCRIPTION
AliReducedCompositeCut: class used to logically combine 2 or more cuts, first commit
AliAnalysisTaskReducedTreeMaker: changes to write TRD online GTU track information (sagita, PID, pt)    (Yvonne)
AliReducedAnalysisTest.cxx: minor change to add an event counter
AliReducedBaseTrack: Added getters for the quality flag map
AliReducedEventInfo: Added data member for TRD triggered events   (Yvonne)
AliReducedTrackCut: Added functionality to cut on the first half of the track quality flags 
AliReducedTrackInfo: Added data members for the TRD GTU track (Yvonne)
AliReducedVarCut: Small bug fix
AliReducedVarManager: Added variables corresponding to the TRD GTU track (Yvonne)
AliResonanceFits: A few getters added needed to access information on options used
CMakeLists.txt, PWGDQreducedTreeLinkDef.h: modified to include the newly added class