### PR TITLE
draft of crosstalk emulation correction component

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEmulateCrosstalk.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEmulateCrosstalk.cxx
@@ -1,0 +1,466 @@
+// AliEmcalCorrectionCellEmulateCrosstalk
+//
+
+#include <TObjArray.h>
+#include <TFile.h>
+
+#include "AliEMCALGeometry.h"
+#include "AliEMCALRecoUtils.h"
+#include "AliAODEvent.h"
+
+#include "AliEmcalCorrectionCellEmulateCrosstalk.h"
+
+/// \cond CLASSIMP
+ClassImp(AliEmcalCorrectionCellEmulateCrosstalk);
+/// \endcond
+
+// Actually registers the class with the base class
+RegisterCorrectionComponent<AliEmcalCorrectionCellEmulateCrosstalk> AliEmcalCorrectionCellEmulateCrosstalk::reg("AliEmcalCorrectionCellEmulateCrosstalk");
+
+/**
+ * Default constructor
+ */
+AliEmcalCorrectionCellEmulateCrosstalk::AliEmcalCorrectionCellEmulateCrosstalk() :
+  AliEmcalCorrectionComponent("AliEmcalCorrectionCellEmulateCrosstalk"),
+  fCellEnergyDistBefore(0),
+  fCellEnergyDistAfter(0),
+  fTCardCorrClusEnerConserv(0),
+  fRandom(0),
+  fRandomizeTCard(1),
+  fTCardCorrMinAmp(0.01),
+  fTCardCorrMaxInduced(100),
+  fPrintOnce(0)
+{
+  for(Int_t i = 0; i < 22;    i++)
+  {
+    fTCardCorrInduceEnerProb   [i] = 0;
+    fTCardCorrInduceEnerFracMax[i] = 100;
+    fTCardCorrInduceEnerFracMin[i] =-100;
+    
+    for(Int_t j = 0; j < 4 ; j++)
+    {
+      fTCardCorrInduceEner         [j][i] =  0 ;
+      fTCardCorrInduceEnerFrac     [j][i] =  0 ;
+      fTCardCorrInduceEnerFracP1   [j][i] =  0 ;
+      fTCardCorrInduceEnerFracWidth[j][i] =  0 ;
+    }
+  }
+  
+  ResetArrays();
+  
+}
+
+/**
+ * Destructor
+ */
+AliEmcalCorrectionCellEmulateCrosstalk::~AliEmcalCorrectionCellEmulateCrosstalk()
+{
+}
+
+/**
+ * Initialize and configure the component.
+ */
+Bool_t AliEmcalCorrectionCellEmulateCrosstalk::Initialize()
+{
+  // Initialization
+  AliEmcalCorrectionComponent::Initialize();
+  
+  AliWarning("Init EMCAL crosstalk emulation");
+  
+  GetProperty("createHistos", fCreateHisto);
+  GetProperty("conservEnergy", fTCardCorrClusEnerConserv);
+  
+  if (!fRecoUtils) {
+    fRecoUtils  = new AliEMCALRecoUtils;
+  }
+
+  return kTRUE;
+}
+
+/**
+ * Create run-independent objects for output. Called before running over events.
+ */
+void AliEmcalCorrectionCellEmulateCrosstalk::UserCreateOutputObjects()
+{   
+  AliEmcalCorrectionComponent::UserCreateOutputObjects();
+
+  if (fCreateHisto){
+    fCellEnergyDistBefore = new TH1F("hCellEnergyDistBefore","hCellEnergyDistBefore;E_{cell} (GeV)",1000,0,10);
+    fOutput->Add(fCellEnergyDistBefore);
+    fCellEnergyDistAfter = new TH1F("hCellEnergyDistAfter","hCellEnergyDistAfter;E_{cell} (GeV)",1000,0,10);
+    fOutput->Add(fCellEnergyDistAfter);
+  }
+}
+
+/**
+ * Called for each event to process the event data.
+ */
+Bool_t AliEmcalCorrectionCellEmulateCrosstalk::Run()
+{
+  AliEmcalCorrectionComponent::Run();
+  
+  if (!fEventManager.InputEvent()) {
+    AliError("Event ptr = 0, returning");
+    return kFALSE;
+  }
+  
+  // START PROCESSING ---------------------------------------------------------
+  // Test if cells present
+  if (fCaloCells->GetNumberOfCells()<=0)
+  {
+    AliDebug(2, Form("Number of EMCAL cells = %d, returning", fCaloCells->GetNumberOfCells()));
+    return kFALSE;
+  }
+  
+  if(fCreateHisto)
+    FillCellQA(fCellEnergyDistBefore); // "before" QA
+  
+  // CELL CROSSTALK EMULATION -------------------------------------------------------
+  
+  // Compute the induced cell energies by T-Card correlation emulation, ONLY MC
+  MakeCellTCardCorrelation();
+  
+  // Add to existing cells the found induced energies in MakeCellTCardCorrelation() if new signal is larger than 10 MeV.
+  AddInducedEnergiesToExistingCells();
+  
+  // Add new cells with found induced energies in MakeCellTCardCorrelation() if new signal is larger than 10 MeV.
+  AddInducedEnergiesToNewCells();
+  
+  // -------------------------------------------------------
+  
+  if(fCreateHisto)
+    FillCellQA(fCellEnergyDistAfter); // "after" QA
+
+  return kTRUE;
+}
+
+/**
+ * Recover each cell amplitude and absId and induce energy
+ * in cells in cross of the same T-Card
+ */
+void AliEmcalCorrectionCellEmulateCrosstalk::MakeCellTCardCorrelation()
+{
+  Int_t    id     = -1;
+  Float_t  amp    = -1;
+  
+  // Loop on all cells with signal
+  for (Int_t icell = 0; icell < fCaloCells->GetNumberOfCells(); icell++)
+  {
+    id  = fCaloCells->GetCellNumber(icell);
+    amp = fCaloCells->GetAmplitude (icell); // fCaloCells->GetCellAmplitude(id);
+    
+    if ( amp <= fTCardCorrMinAmp ) continue ;
+    
+    //
+    // First get the SM, col-row of this tower
+    Int_t imod = -1, iphi =-1, ieta=-1,iTower = -1, iIphi = -1, iIeta = -1;
+    fGeom->GetCellIndex(id,imod,iTower,iIphi,iIeta);
+    fGeom->GetCellPhiEtaIndexInSModule(imod,iTower,iIphi, iIeta,iphi,ieta);
+    
+    //
+    // Determine randomly if we want to create a correlation for this cell,
+    // depending the SM number of the cell
+    Float_t rand = fRandom.Uniform(0, 1);
+    
+    if ( rand > fTCardCorrInduceEnerProb[imod] ) continue;
+    
+    AliDebug(1,Form("Reference cell absId %d, iEta %d, iPhi %d, amp %2.3f",id,ieta,iphi,amp));
+    
+    //
+    // Get the absId of the cells in the cross and same T-Card
+    Int_t absIDup = -1;
+    Int_t absIDdo = -1;
+    Int_t absIDlr  = -1;
+    Int_t absIDuplr = -1;
+    Int_t absIDdolr = -1;
+    
+    Int_t absIDup2 = -1;
+    Int_t absIDup2lr = -1;
+    Int_t absIDdo2 = -1;
+    Int_t absIDdo2lr = -1;
+    
+    // Only 2 columns in the T-Card, +1 for even and -1 for odd with respect reference cell
+    Int_t colShift = 0;
+    if (  (ieta%2) && ieta <= AliEMCALGeoParams::fgkEMCALCols-1 ) colShift = -1;
+    if ( !(ieta%2) && ieta >= 0 )                                 colShift = +1;
+    
+    absIDlr = fGeom->GetAbsCellIdFromCellIndexes(imod, iphi, ieta+colShift);
+    
+    // Check up / down cells from reference cell not out of SM and in same T-Card
+    if (  iphi < AliEMCALGeoParams::fgkEMCALRows-1 )
+    {
+      absIDup   = fGeom->GetAbsCellIdFromCellIndexes(imod, iphi+1, ieta);
+      absIDuplr = fGeom->GetAbsCellIdFromCellIndexes(imod, iphi+1, ieta+colShift);
+    }
+    
+    if (  iphi > 0 )
+    {
+      absIDdo   = fGeom->GetAbsCellIdFromCellIndexes(imod, iphi-1, ieta);
+      absIDdolr = fGeom->GetAbsCellIdFromCellIndexes(imod, iphi-1, ieta+colShift);
+    }
+    
+    // Check 2 up / 2 down cells from reference cell not out of SM
+    if (  iphi < AliEMCALGeoParams::fgkEMCALRows-2 )
+    {
+      absIDup2   = fGeom->GetAbsCellIdFromCellIndexes(imod, iphi+2, ieta);
+      absIDup2lr = fGeom->GetAbsCellIdFromCellIndexes(imod, iphi+2, ieta+colShift);
+    }
+    
+    if (  iphi > 1 )
+    {
+      absIDdo2   = fGeom->GetAbsCellIdFromCellIndexes(imod, iphi-2, ieta);
+      absIDdo2lr = fGeom->GetAbsCellIdFromCellIndexes(imod, iphi-2, ieta+colShift);
+    }
+    
+    // In same T-Card?
+    if ( TMath::FloorNint(iphi/8) != TMath::FloorNint((iphi+1)/8) ) { absIDup  = -1 ; absIDuplr  = -1 ; }
+    if ( TMath::FloorNint(iphi/8) != TMath::FloorNint((iphi-1)/8) ) { absIDdo  = -1 ; absIDdolr  = -1 ; }
+    if ( TMath::FloorNint(iphi/8) != TMath::FloorNint((iphi+2)/8) ) { absIDup2 = -1 ; absIDup2lr = -1 ; }
+    if ( TMath::FloorNint(iphi/8) != TMath::FloorNint((iphi-2)/8) ) { absIDdo2 = -1 ; absIDdo2lr = -1 ; }
+    
+    //
+    // Check if they are not declared bad or exist
+    Bool_t okup   = AcceptCell(absIDup   );
+    Bool_t okdo   = AcceptCell(absIDdo   );
+    Bool_t oklr   = AcceptCell(absIDlr   );
+    Bool_t okuplr = AcceptCell(absIDuplr );
+    Bool_t okdolr = AcceptCell(absIDdolr );
+    Bool_t okup2  = AcceptCell(absIDup2  );
+    Bool_t okdo2  = AcceptCell(absIDdo2  );
+    Bool_t okup2lr= AcceptCell(absIDup2lr);
+    Bool_t okdo2lr= AcceptCell(absIDdo2lr);
+    
+    AliDebug(1,Form("Same T-Card cells:\n \t up %d (%d), down %d (%d), left-right %d (%d), up-lr %d (%d), down-lr %d (%d)\n"
+                    "\t up2 %d (%d), down2 %d (%d), up2-lr %d (%d), down2-lr %d (%d)",
+                    absIDup ,okup ,absIDdo ,okdo ,absIDlr,oklr,absIDuplr ,okuplr ,absIDdolr ,okdolr ,
+                    absIDup2,okup2,absIDdo2,okdo2,             absIDup2lr,okup2lr,absIDdo2lr,okdo2lr));
+    
+    //
+    // Generate some energy for the nearby cells in same TCard , depending on this cell energy
+    // Check if originally the tower had no or little energy, in which case tag it as new
+    Float_t fracupdown     = fTCardCorrInduceEnerFrac[0][imod]+amp*fTCardCorrInduceEnerFracP1[0][imod];
+    Float_t fracupdownleri = fTCardCorrInduceEnerFrac[1][imod]+amp*fTCardCorrInduceEnerFracP1[1][imod];
+    Float_t fracleri       = fTCardCorrInduceEnerFrac[2][imod]+amp*fTCardCorrInduceEnerFracP1[2][imod];
+    Float_t frac2nd        = fTCardCorrInduceEnerFrac[3][imod]+amp*fTCardCorrInduceEnerFracP1[3][imod];
+    
+    AliDebug(1,Form("Fraction for SM %d (min %2.3f, max %2.3f):\n"
+                    "\t up-down   : c %2.3e, p1 %2.3e, p2 %2.4e, sig %2.3e, fraction %2.3f\n"
+                    "\t up-down-lr: c %2.3e, p1 %2.3e, p2 %2.4e, sig %2.3e, fraction %2.3f\n"
+                    "\t left-right: c %2.3e, p1 %2.3e, p2 %2.4e, sig %2.3e, fraction %2.3f\n"
+                    "\t 2nd row   : c %2.3e, p1 %2.3e, p2 %2.4e, sig %2.3e, fraction %2.3f",
+                    imod, fTCardCorrInduceEnerFracMin[imod], fTCardCorrInduceEnerFracMax[imod],
+                    fTCardCorrInduceEner[0][imod],fTCardCorrInduceEnerFrac[0][imod],fTCardCorrInduceEnerFracP1[0][imod],fTCardCorrInduceEnerFracWidth[0][imod],fracupdown,
+                    fTCardCorrInduceEner[1][imod],fTCardCorrInduceEnerFrac[1][imod],fTCardCorrInduceEnerFracP1[1][imod],fTCardCorrInduceEnerFracWidth[1][imod],fracupdownleri,
+                    fTCardCorrInduceEner[2][imod],fTCardCorrInduceEnerFrac[2][imod],fTCardCorrInduceEnerFracP1[2][imod],fTCardCorrInduceEnerFracWidth[2][imod],fracleri,
+                    fTCardCorrInduceEner[3][imod],fTCardCorrInduceEnerFrac[3][imod],fTCardCorrInduceEnerFracP1[3][imod],fTCardCorrInduceEnerFracWidth[3][imod],frac2nd));
+    
+    if( fracupdown     < fTCardCorrInduceEnerFracMin[imod] ) fracupdown     = fTCardCorrInduceEnerFracMin[imod];
+    if( fracupdown     > fTCardCorrInduceEnerFracMax[imod] ) fracupdown     = fTCardCorrInduceEnerFracMax[imod];
+    if( fracupdownleri < fTCardCorrInduceEnerFracMin[imod] ) fracupdownleri = fTCardCorrInduceEnerFracMin[imod];
+    if( fracupdownleri > fTCardCorrInduceEnerFracMax[imod] ) fracupdownleri = fTCardCorrInduceEnerFracMax[imod];
+    if( fracleri       < fTCardCorrInduceEnerFracMin[imod] ) fracleri       = fTCardCorrInduceEnerFracMin[imod];
+    if( fracleri       > fTCardCorrInduceEnerFracMax[imod] ) fracleri       = fTCardCorrInduceEnerFracMax[imod];
+    if( frac2nd        < fTCardCorrInduceEnerFracMin[imod] ) frac2nd        = fTCardCorrInduceEnerFracMin[imod];
+    if( frac2nd        > fTCardCorrInduceEnerFracMax[imod] ) frac2nd        = fTCardCorrInduceEnerFracMax[imod];
+    
+    // Randomize the induced fraction, if requested
+    if(fRandomizeTCard)
+    {
+      fracupdown     = fRandom.Gaus(fracupdown    ,fTCardCorrInduceEnerFracWidth[0][imod]);
+      fracupdownleri = fRandom.Gaus(fracupdownleri,fTCardCorrInduceEnerFracWidth[1][imod]);
+      fracleri       = fRandom.Gaus(fracleri      ,fTCardCorrInduceEnerFracWidth[2][imod]);
+      frac2nd        = fRandom.Gaus(frac2nd       ,fTCardCorrInduceEnerFracWidth[3][imod]);
+      
+      AliDebug(1,Form("Randomized fraction: up-down %2.3f; up-down-left-right %2.3f; left-right %2.3f; 2nd row %2.3f",
+                      fracupdown,fracupdownleri,fracleri,frac2nd));
+    }
+    
+    // Calculate induced energy
+    Float_t indEupdown     = fTCardCorrInduceEner[0][imod]+amp*fracupdown;
+    Float_t indEupdownleri = fTCardCorrInduceEner[1][imod]+amp*fracupdownleri;
+    Float_t indEleri       = fTCardCorrInduceEner[2][imod]+amp*fracleri;
+    Float_t indE2nd        = fTCardCorrInduceEner[3][imod]+amp*frac2nd;
+    
+    AliDebug(1,Form("Induced energy: up-down %2.3f; up-down-left-right %2.3f; left-right %2.3f; 2nd row %2.3f",
+                    indEupdown,indEupdownleri,indEleri,indE2nd));
+    
+    // Check if we induce too much energy, in such case use a constant value
+    if ( fTCardCorrMaxInduced < indE2nd        ) indE2nd        = fTCardCorrMaxInduced;
+    if ( fTCardCorrMaxInduced < indEupdownleri ) indEupdownleri = fTCardCorrMaxInduced;
+    if ( fTCardCorrMaxInduced < indEupdown     ) indEupdown     = fTCardCorrMaxInduced;
+    if ( fTCardCorrMaxInduced < indEleri       ) indEleri       = fTCardCorrMaxInduced;
+    
+    AliDebug(1,Form("Induced energy, saturated?: up-down %2.3f; up-down-left-right %2.3f; left-right %2.3f; 2nd row %2.3f",
+                    indEupdown,indEupdownleri,indEleri,indE2nd));
+    
+    //
+    // Add the induced energy, check if cell existed
+    if ( okup )
+    {
+      fTCardCorrCellsEner[absIDup] += indEupdown;
+      
+      if ( fCaloCells->GetCellAmplitude(absIDup) < 0.01 ) fTCardCorrCellsNew[absIDup] = kTRUE;
+    }
+    
+    if ( okdo )
+    {
+      fTCardCorrCellsEner[absIDdo] += indEupdown;
+      
+      if ( fCaloCells->GetCellAmplitude(absIDdo) < 0.01 ) fTCardCorrCellsNew[absIDdo] = kTRUE;
+    }
+    
+    if ( oklr )
+    {
+      fTCardCorrCellsEner[absIDlr] += indEleri;
+      
+      if ( fCaloCells->GetCellAmplitude(absIDlr) < 0.01 ) fTCardCorrCellsNew[absIDlr]  = kTRUE;
+    }
+    
+    if ( okuplr )
+    {
+      fTCardCorrCellsEner[absIDuplr] += indEupdownleri;
+      
+      if ( fCaloCells->GetCellAmplitude(absIDuplr ) < 0.01 ) fTCardCorrCellsNew[absIDuplr]  = kTRUE;
+    }
+    
+    if ( okdolr )
+    {
+      fTCardCorrCellsEner[absIDdolr] += indEupdownleri;
+      
+      if ( fCaloCells->GetCellAmplitude(absIDdolr ) < 0.01 ) fTCardCorrCellsNew[absIDdolr]  = kTRUE;
+    }
+    
+    if ( okup2 )
+    {
+      fTCardCorrCellsEner[absIDup2] += indE2nd;
+      
+      if ( fCaloCells->GetCellAmplitude(absIDup2) < 0.01 ) fTCardCorrCellsNew[absIDup2] = kTRUE;
+    }
+    
+    if ( okup2lr )
+    {
+      fTCardCorrCellsEner[absIDup2lr] += indE2nd;
+      
+      if ( fCaloCells->GetCellAmplitude(absIDup2lr) < 0.01 ) fTCardCorrCellsNew[absIDup2lr] = kTRUE;
+    }
+    
+    if ( okdo2 )
+    {
+      fTCardCorrCellsEner[absIDdo2] += indE2nd;
+      
+      if ( fCaloCells->GetCellAmplitude(absIDdo2) < 0.01 ) fTCardCorrCellsNew[absIDdo2] = kTRUE;
+    }
+    
+    if ( okdo2lr )
+    {
+      fTCardCorrCellsEner[absIDdo2lr] += indE2nd;
+      
+      if ( fCaloCells->GetCellAmplitude(absIDdo2lr) < 0.01 ) fTCardCorrCellsNew[absIDdo2lr] = kTRUE;
+    }
+    
+    //
+    // Subtract the added energy to main cell, if energy conservation is requested
+    if ( fTCardCorrClusEnerConserv )
+    {
+      if ( oklr    ) fTCardCorrCellsEner[id] -= indEleri;
+      if ( okuplr  ) fTCardCorrCellsEner[id] -= indEupdownleri;
+      if ( okdolr  ) fTCardCorrCellsEner[id] -= indEupdownleri;
+      if ( okup    ) fTCardCorrCellsEner[id] -= indEupdown;
+      if ( okdo    ) fTCardCorrCellsEner[id] -= indEupdown;
+      if ( okup2   ) fTCardCorrCellsEner[id] -= indE2nd;
+      if ( okup2lr ) fTCardCorrCellsEner[id] -= indE2nd;
+      if ( okdo2   ) fTCardCorrCellsEner[id] -= indE2nd;
+      if ( okdo2lr ) fTCardCorrCellsEner[id] -= indE2nd;
+    } // conserve energy
+    
+  } // cell loop
+  
+}
+
+/**
+ * Add to existing cells the found induced energies in MakeCellTCardCorrelation() if new signal is larger than 10 MeV.
+ */
+void AliEmcalCorrectionCellEmulateCrosstalk::AddInducedEnergiesToExistingCells()
+{
+  Short_t   absId   = -1;
+  Double_t  amp     = -1;
+  Double_t  time    = -1;
+  Int_t     mclabel = -1;
+  Double_t  efrac   = 0.;
+  
+  for (Int_t icell = 0; icell < fCaloCells->GetNumberOfCells(); icell++)
+  {
+    
+    // Get cell
+    fCaloCells->GetCell(icell, absId, amp, time, mclabel, efrac);
+    
+    if(amp <= 0.01) continue ; // accept if > 10 MeV
+    
+    amp+=fTCardCorrCellsEner[absId];
+    
+    // Set new amplitude
+    fCaloCells->SetCell(icell, absId, amp, time, mclabel, efrac);
+  }
+  
+}
+  
+/**
+ * Add news cells if the found induced energies in MakeCellTCardCorrelation() is larger than 10 MeV.
+ */
+void AliEmcalCorrectionCellEmulateCrosstalk::AddInducedEnergiesToNewCells()
+{
+  Int_t nCells = fCaloCells->GetNumberOfCells();
+  
+  for(Int_t j = 0; j < fgkNEMCalCells; j++)
+  {
+    // Newly created?
+    if ( !fTCardCorrCellsNew[j] ) continue;
+    
+    // Accept only if at least 10 MeV
+    if (  fTCardCorrCellsEner[j] < 0.01 ) continue;
+    
+    // Add new cell
+    Int_t     cellNumber = nCells;
+    Short_t   absId      = j;
+    Float_t   amp        = fTCardCorrCellsEner[j];
+    Double_t  time       = 615.*1e-9;;
+    Int_t     mclabel    = -1;
+    Double_t  efrac      = 0.;
+    fCaloCells->SetCell(cellNumber, absId, amp, time, mclabel, efrac);
+    
+    nCells++;
+  }
+  
+}
+
+/**
+ * Reset arrays containing information for all possible cells.
+ */
+void AliEmcalCorrectionCellEmulateCrosstalk::ResetArrays()
+{
+  for(Int_t j = 0; j < fgkNEMCalCells; j++)
+  {
+    fTCardCorrCellsEner[j] = 0.;
+    fTCardCorrCellsNew [j] = kFALSE;
+  }
+}
+
+/**
+ * Reject cell if acceptance criteria not passed:
+ *   * correct cell number
+ *
+ * \param absID: absolute cell ID number
+ *
+ * \return bool quality of cell, exists or not
+ */
+Bool_t AliEmcalCorrectionCellEmulateCrosstalk::AcceptCell(Int_t absID)
+{
+  if ( absID < 0 || absID >= 24*48*fGeom->GetNumberOfSuperModules() )
+    return kFALSE;
+  
+  Int_t imod = -1,iTower = -1, iIphi = -1, iIeta = -1;
+  if (!fGeom->GetCellIndex(absID,imod,iTower,iIphi,iIeta))
+    return kFALSE;
+
+  return kTRUE;
+}

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEmulateCrosstalk.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEmulateCrosstalk.h
@@ -1,0 +1,194 @@
+#ifndef ALIEMCALCORRECTIONCELLEMULATECROSSTALK_H
+#define ALIEMCALCORRECTIONCELLEMULATECROSSTALK_H
+
+#include <TRandom3.h>
+
+#include "AliEmcalCorrectionComponent.h"
+
+/**
+ * @class AliEmcalCorrectionCellEmulateCrosstalk
+ * @ingroup EMCALCOREFW
+ * @brief Correction component to emulate cell-level crosstalk in the EMCal correction framework.
+ *
+ * Performs energy smearing of cells to mimic T-card crosstalk. The original cell information in the event **will be overwritten**.
+ *
+ * Based on code in AliAnalysisTaskEMCALClusterize.
+ *
+ * @author Gustavo Conesa Balbastre, LPSC-Grenoble, AliAnalysisTaskEMCALClusterize
+ * @author Raymond Ehlers <raymond.ehlers@yale.edu>, Yale University, centralize EMCal corrections using components
+ * @author James Mulligan <james.mulligan@yale.edu>, Yale University, centralize EMCal corrections using components
+ * @date Feb 11 2018
+ */
+
+class AliEmcalCorrectionCellEmulateCrosstalk : public AliEmcalCorrectionComponent {
+ public:
+  AliEmcalCorrectionCellEmulateCrosstalk();
+  virtual ~AliEmcalCorrectionCellEmulateCrosstalk();
+
+  // Sets up and runs the task
+  Bool_t Initialize();
+  void UserCreateOutputObjects();
+  Bool_t Run();
+  
+  /// Constant energy lost by max energy cell in one of T-Card cells, same for all SM
+  /// \param ud energy lost in upper/lower cell, same column
+  /// \param udlr energy lost in upper/lower cell, left or right
+  /// \param lr   energy lost in left or right cell, same row
+  void           SetInducedEnergyLossConstant(Float_t ud, Float_t udlr, Float_t lr, Float_t sec) {
+    for(Int_t ism = 0; ism < 22; ism++) {
+      fTCardCorrInduceEner[0][ism] = ud; fTCardCorrInduceEner[1][ism] = udlr;
+      fTCardCorrInduceEner[2][ism] = lr; fTCardCorrInduceEner[3][ism] = sec ; } }
+  
+  /// Fraction of energy lost by max energy cell in one of T-Card cells, same for all SM
+  /// \param ud energy lost in upper/lower cell, same column
+  /// \param udlr energy lost in upper/lower cell, left or right
+  /// \param lr   energy lost in left or right cell, same row
+  void           SetInducedEnergyLossFraction(Float_t ud, Float_t udlr, Float_t lr, Float_t sec) {
+    for(Int_t ism = 0; ism < 22; ism++) {
+      fTCardCorrInduceEnerFrac[0][ism] = ud; fTCardCorrInduceEnerFrac[1][ism] = udlr;
+      fTCardCorrInduceEnerFrac[2][ism] = lr; fTCardCorrInduceEnerFrac[3][ism] = sec ; } }
+  
+  /// Slope parameter of fraction of energy lost by max energy cell in one of T-Card cells, same for all SM
+  /// \param ud energy lost in upper/lower cell, same column
+  /// \param udlr energy lost in upper/lower cell, left or right
+  /// \param lr   energy lost in left or right cell, same row
+  void           SetInducedEnergyLossFractionP1(Float_t ud, Float_t udlr, Float_t lr, Float_t sec) {
+    for(Int_t ism = 0; ism < 22; ism++) {
+      fTCardCorrInduceEnerFracP1[0][ism] = ud; fTCardCorrInduceEnerFracP1[1][ism] = udlr;
+      fTCardCorrInduceEnerFracP1[2][ism] = lr; fTCardCorrInduceEnerFracP1[3][ism] = sec ; } }
+  
+  /// Constant energy lost by max energy cell in one of T-Card cells, per SM
+  /// \param sm super module index
+  /// \param ud energy lost in upper/lower cell, same column
+  /// \param udlr energy lost in upper/lower cell, left or right
+  /// \param lr   energy lost in left or right cell, same row
+  void           SetInducedEnergyLossConstantPerSM(Int_t sm, Float_t ud, Float_t udlr, Float_t lr, Float_t sec) {
+    if ( sm < 22 && sm >= 0 ) {
+      fTCardCorrInduceEner[0][sm] = ud; fTCardCorrInduceEner[1][sm] = udlr;
+      fTCardCorrInduceEner[2][sm] = lr; fTCardCorrInduceEner[3][sm] = sec ; } }
+  
+  /// Fraction of energy lost by max energy cell in one of T-Card cells, per SM
+  /// \param sm super module index
+  /// \param ud energy lost in upper/lower cell, same column
+  /// \param udlr energy lost in upper/lower cell, left or right
+  /// \param lr   energy lost in left or right cell, same row
+  void           SetInducedEnergyLossFractionPerSM(Int_t sm, Float_t ud, Float_t udlr, Float_t lr, Float_t sec) {
+    if ( sm < 22 && sm >= 0 ) {
+      fTCardCorrInduceEnerFrac[0][sm] = ud; fTCardCorrInduceEnerFrac[1][sm] = udlr;
+      fTCardCorrInduceEnerFrac[2][sm] = lr; fTCardCorrInduceEnerFrac[3][sm] = sec ; } }
+  
+  /// Slope parameter of fraction of energy lost by max energy cell in one of T-Card cells, per SM
+  /// \param sm super module index
+  /// \param ud energy lost in upper/lower cell, same column
+  /// \param udlr energy lost in upper/lower cell, left or right
+  /// \param lr   energy lost in left or right cell, same row
+  void           SetInducedEnergyLossFractionP1PerSM(Int_t sm, Float_t ud, Float_t udlr, Float_t lr, Float_t sec) {
+    if ( sm < 22 && sm >= 0 ) {
+      fTCardCorrInduceEnerFracP1[0][sm] = ud; fTCardCorrInduceEnerFracP1[1][sm] = udlr;
+      fTCardCorrInduceEnerFracP1[2][sm] = lr; fTCardCorrInduceEnerFracP1[3][sm] = sec ; } }
+  
+  /// Fraction of energy lost by max energy cell in one of T-Card cells, width of random gaussian, same for all SM
+  /// \param ud energy lost in upper/lower cell, same column
+  /// \param udlr energy lost in upper/lower cell, left or right
+  /// \param lr   energy lost in left or right cell, same row
+  void           SetInducedEnergyLossFractionWidth(Float_t ud, Float_t udlr, Float_t lr, Float_t sec) {
+    for(Int_t ism = 0; ism < 22; ism++) {
+      fTCardCorrInduceEnerFracWidth[0][ism] = ud; fTCardCorrInduceEnerFracWidth[1][ism] = udlr;
+      fTCardCorrInduceEnerFracWidth[2][ism] = lr; fTCardCorrInduceEnerFracWidth[3][ism] = sec ; } }
+  
+  /// Fraction of energy lost by max energy cell in one of T-Card cells, width of random gaussian, per SM
+  /// \param sm super module index
+  /// \param ud energy lost in upper/lower cell, same column
+  /// \param udlr energy lost in upper/lower cell, left or right
+  /// \param lr   energy lost in left or right cell, same row
+  void           SetInducedEnergyLossFractionWidthPerSM(Int_t sm, Float_t ud, Float_t udlr, Float_t lr, Float_t sec) {
+    if ( sm < 22 && sm >= 0 ) {
+      fTCardCorrInduceEnerFracWidth[0][sm] = ud; fTCardCorrInduceEnerFracWidth[1][sm] = udlr;
+      fTCardCorrInduceEnerFracWidth[2][sm] = lr; fTCardCorrInduceEnerFracWidth[3][sm] = sec ; } }
+  
+  /// Maximum induced energy fraction when linear dependency is set, per SM number
+  /// \param max maximum fraction
+  /// \param sm  super-module number
+  void           SetInducedEnergyLossMaximumFractionPerSM(Float_t max, Int_t sm) {
+    if ( sm < 22 && sm >= 0 ) fTCardCorrInduceEnerFracMax[sm] = max ; }
+  
+  /// Minimum induced energy fraction when linear dependency is set, per SM number
+  /// \param min minimum fraction
+  /// \param sm  super-module number
+  void           SetInducedEnergyLossMinimumFractionPerSM(Float_t min, Int_t sm) {
+    if ( sm < 22 && sm >= 0 ) fTCardCorrInduceEnerFracMin[sm] = min ; }
+  
+  /// Maximum induced energy fraction when linear dependency is set, same for all SM
+  /// \param max maximum fraction
+  void           SetInducedEnergyLossMaximumFraction(Float_t max) {
+    for(Int_t ism = 0; ism < 22; ism++) fTCardCorrInduceEnerFracMax[ism] = max ; }
+  
+  /// Minimum induced energy fraction when linear dependency is set, same for all SM
+  /// \param min minimum fraction
+  void           SetInducedEnergyLossMinimumFraction(Float_t min) {
+    for(Int_t ism = 0; ism < 22; ism++) fTCardCorrInduceEnerFracMin[ism] = min ; }
+  
+  /// fraction of times max cell energy correlates with cross cells, different for each super-module
+  /// \param prob probability per event, from 0 to 1
+  /// \param sm   probability assigned to this super-module number
+  void           SetInducedEnergyLossProbabilityPerSM(Float_t prob, Int_t sm) {
+    if ( sm < 22 && sm >= 0 ) fTCardCorrInduceEnerProb[sm] = prob ; }
+  
+  void           SwitchOnRandomizeTCardInducedEnergy()          { fRandomizeTCard = kTRUE   ; }
+  void           SwitchOffRandomizeTCardInducedEnergy()         { fRandomizeTCard = kFALSE  ; }
+  
+  void           SetInducedTCardMinimumCellEnergy(Float_t mi)   { fTCardCorrMinAmp     = mi ; }
+  void           SeInducedTCardMaximum(Float_t ma)              { fTCardCorrMaxInduced = ma ; }
+  
+  void           PrintTCardParam();
+  
+protected:
+  
+  // T-Card correlation emulation, do on MC
+  void           MakeCellTCardCorrelation();
+  void           AddInducedEnergiesToExistingCells();
+  void           AddInducedEnergiesToNewCells();
+  
+  virtual void   ResetArrays();
+  Bool_t         AcceptCell(Int_t absID);
+  
+  TH1F* fCellEnergyDistBefore;        //!<! cell energy distribution, before energy smearing
+  TH1F* fCellEnergyDistAfter;         //!<! cell energy distribution, after energy smearing
+  
+  static const Int_t fgkNEMCalCells = 17664;       ///< Total number of cells in the calorimeter, 10*48*24 (EMCal) + 4*48*8 (EMCal/DCal 1/3) + 6*32*24 (DCal)
+  
+  // T-Card correlation emulation, do on MC
+  Bool_t                fTCardCorrClusEnerConserv; ///< When making correlation, subtract from the reference cell the induced energy on the neighbour cells
+  Float_t               fTCardCorrCellsEner[fgkNEMCalCells]; ///<  Array with induced cell energy in T-Card neighbour cells
+  Bool_t                fTCardCorrCellsNew [fgkNEMCalCells]; ///<  Array with induced cell energy in T-Card neighbour cells, that before had no signal
+  
+  Float_t               fTCardCorrInduceEner         [4 ][22]; ///< Induced energy loss gauss constant on 0-same row, diff col, 1-up/down cells left/right col 2-left/righ col, and 2nd row cells, param 0
+  Float_t               fTCardCorrInduceEnerFrac     [4 ][22]; ///< Induced energy loss gauss fraction param0 on 0-same row, diff col, 1-up/down cells left/right col 2-left/righ col, and 2nd row cells, param 0
+  Float_t               fTCardCorrInduceEnerFracP1   [4 ][22]; ///< Induced energy loss gauss fraction param1 on 0-same row, diff col, 1-up/down cells left/right col 2-left/righ col, and 2nd row cells, param1
+  Float_t               fTCardCorrInduceEnerFracWidth[4 ][22]; ///< Induced energy loss gauss witdth on 0-same row, diff col, 1-up/down cells left/right col 2-left/righ col, and 2nd row cells
+  Float_t               fTCardCorrInduceEnerFracMax[22];   ///< In case fTCardCorrInduceEnerFracP1  is non null, restrict the maximum fraction of induced energy per SM
+  Float_t               fTCardCorrInduceEnerFracMin[22];   ///< In case fTCardCorrInduceEnerFracP1  is non null, restrict the minimum fraction of induced energy per SM
+  Float_t               fTCardCorrInduceEnerProb[22];      ///< Probability to induce energy loss per SM
+  
+  TRandom3              fRandom   ;                ///<  Random generator
+  Bool_t                fRandomizeTCard ;          ///<  Use random induced energy
+  
+  Float_t               fTCardCorrMinAmp;          ///<  Minimum cell energy to induce signal on adjacent cells
+  Float_t               fTCardCorrMaxInduced;      ///<  Maximum induced energy signal on adjacent cells
+  
+  Bool_t                fPrintOnce;                ///< Print once analysis parameters
+  
+private:
+  
+  AliEmcalCorrectionCellEmulateCrosstalk(const AliEmcalCorrectionCellEmulateCrosstalk &);               // Not implemented
+  AliEmcalCorrectionCellEmulateCrosstalk &operator=(const AliEmcalCorrectionCellEmulateCrosstalk &);    // Not implemented
+
+  // Allows the registration of the class so that it is availble to be used by the correction task.
+  static RegisterCorrectionComponent<AliEmcalCorrectionCellEmulateCrosstalk> reg;
+
+  /// \cond CLASSIMP
+  ClassDef(AliEmcalCorrectionCellEmulateCrosstalk, 1); // EMCal cell crosstalk emulation correction component
+  /// \endcond
+};
+
+#endif /* ALIEMCALCORRECTIONCellEmulateCrosstalk_H */

--- a/PWG/EMCAL/EMCALtasks/CMakeLists.txt
+++ b/PWG/EMCAL/EMCALtasks/CMakeLists.txt
@@ -70,6 +70,7 @@ set(SRCS
   AliEmcalCorrectionCellBadChannel.cxx
   AliEmcalCorrectionCellEnergy.cxx
   AliEmcalCorrectionCellTimeCalib.cxx
+  AliEmcalCorrectionCellEmulateCrosstalk.cxx
   AliEmcalCorrectionCellCombineCollections.cxx
   AliEmcalCorrectionClusterizer.cxx
   AliEmcalCorrectionClusterNonLinearity.cxx

--- a/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
+++ b/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
@@ -38,6 +38,7 @@
 #pragma link C++ class  AliEmcalCorrectionCellBadChannel+;
 #pragma link C++ class  AliEmcalCorrectionCellEnergy+;
 #pragma link C++ class  AliEmcalCorrectionCellTimeCalib+;
+#pragma link C++ class  AliEmcalCorrectionCellEmulateCrosstalk+;
 #pragma link C++ class  AliEmcalCorrectionCellCombineCollections+;
 #pragma link C++ class  AliEmcalCorrectionClusterizer+;
 #pragma link C++ class  AliEmcalCorrectionClusterNonLinearity+;

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -62,6 +62,12 @@ CellTimeCalib:                                      # Cell Time Calibration comp
     createHistos: false                             # Whether the task should create output histograms
     cellsNames:                                     # Names of the cells input objects which should be attached to the correction
         - defaultCells                              # This object is defined above in the cells section of the input objects
+CellEmulateCrosstalk:                               # Component to emulate crosstalk
+    enabled: false                                  # Whether to enable the task
+    createHistos: false                             # Whether the task should create output histograms
+    conservEnergy: false                            # Activate cluster energy conservation, not by default
+    cellsNames:                                     # Names of the cells input objects which should be attached to the correction
+        - defaultCells                              # This object is defined above in the cells section of the input objects
 CellCombineCollections:                             # Utility task to combine two cells collections into a single collection.
                                                     # It is useful for embedding, but little else.
                                                     # The combined needs to be done here to enable different cell corrections for the different cell collections (for example, MC may need different corrections than data.)
@@ -165,6 +171,7 @@ executionOrder:
     - CellEnergy
     - CellBadChannel
     - CellTimeCalib
+    - CellEmulateCrosstalk
     - CellCombineCollections
     - Clusterizer
     - ClusterExotics


### PR DESCRIPTION
Please do not approve yet.

@gconesab, @raymondEhlers: Here is an initial draft of the crosstalk emulation correction component. I didn't test it at all besides that it compiles and doesn't crash while running. That being said, the component is integrated into the correction framework and will run if you enable it in your user yaml file (see available configuration options and defaults in AliEmcalCorrectionConfiguration.yaml). The main function is Run().

 A few notes:

- I removed all of the code about digits, and attempted to directly write new cells. I added two new functions AddInducedEnergiesToExistingCells() and AddInducedEnergiesToNewCells() to do this. Gustavo, I am not super familiar with how your code works, so please take a look here to see if it has the right idea. You should also check carefully the details, since I included only a fairly minimal amount of code from AliAnalysisTaskEMCALClusterize. But the draft should at least give a good starting point... 

- I placed the component to execute after the cell calibrations, but before clusterization.