### PR TITLE
EMCal CorrFW: Update docs to avoid link to YAML NS

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellCombineCollections.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellCombineCollections.cxx
@@ -44,11 +44,11 @@ AliEmcalCorrectionCellCombineCollections::~AliEmcalCorrectionCellCombineCollecti
 }
 
 /**
- * Initialize all needed variables from the YAML configuration.
+ * Initialize all needed variables from the %YAML configuration.
  *
  * Note that "usedefault" is only applied to the externalCellsBranchName because
  * the "usedefault" name for the combinedCellsBranchName is not well defined.
- * However, just using the default in the default YAML configuration should
+ * However, just using the default in the default %YAML configuration should
  * serve more or less the same purpose.
  *
  */

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterNonLinearity.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterNonLinearity.h
@@ -26,7 +26,7 @@
 
 class AliEmcalCorrectionClusterNonLinearity : public AliEmcalCorrectionComponent {
  public:
-  /// Relates string to the non-linearity function enumeration for YAML configuration
+  /// Relates string to the non-linearity function enumeration for %YAML configuration
   static const std::map <std::string, AliEMCALRecoUtils::NonlinearityFunctions> fgkNonlinearityFunctionMap; //!<!
 
   AliEmcalCorrectionClusterNonLinearity();

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.h
@@ -18,7 +18,7 @@ class TStopwatch;
  *
  * The clusterizer type and the time cuts are to be chosen appropriately for each dataset. Usually the v1 clusterizer is used for pp and the v2 clusterizer is used for PbPb. Sometimes for pp reference runs with the same collision energy as PbPb the v2 clusterizer is employed, but this is analysis dependent. EMCal detector experts are to be contacted for the time cuts.
  *
- * The clusterizer will use as input the cell branch specified in the YAML config, and as output will rewrite the cluster branch specified in the YAML config.
+ * The clusterizer will use as input the cell branch specified in the %YAML config, and as output will rewrite the cluster branch specified in the %YAML config.
  *
  * At this point the energy of the cluster will be available through `cluster->E()` where cluster is the pointer to the AliAODCaloCluster or AliESDCaloCluster object.
  *
@@ -33,7 +33,7 @@ class TStopwatch;
 
 class AliEmcalCorrectionClusterizer : public AliEmcalCorrectionComponent {
  public:
-  /// Relates string to the clusterizer type enumeration for YAML configuration
+  /// Relates string to the clusterizer type enumeration for %YAML configuration
   static const std::map <std::string, AliEMCALRecParam::AliEMCALClusterizerFlag> fgkClusterizerTypeMap; //!<!
 
   AliEmcalCorrectionClusterizer();

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.h
@@ -32,7 +32,7 @@ class AliVEvent;
  * component corresponds to a correction needed for the EMCal. Creation, configuration, and execution
  * of all of the components is handled by AliEmcalCorrectionTask. Each new component is automatically
  * registered through the AliEmcalCorrectionComponentFactory class, and is thus automatically available
- * to execute. Components are configured through a set of YAML configuration files stored in
+ * to execute. Components are configured through a set of %YAML configuration files stored in
  * AliYAMLConfiguration. For more information about the steering, see AliEmcalCorrectionTask.
  *
  * @author Raymond Ehlers <raymond.ehlers@yale.edu>, Yale University
@@ -103,13 +103,13 @@ class AliEmcalCorrectionComponent : public TNamed {
   void SetVertex(Double_t * vertex) { fVertex[0] = vertex[0]; fVertex[1] = vertex[1]; fVertex[2] = vertex[2]; }
   void SetIsESD(Bool_t isESD) {fEsdMode = isESD; }
 
-  /// Set YAML Configuration
+  /// Set %YAML Configuration
   void SetYAMLConfiguration(PWG::Tools::AliYAMLConfiguration config) { fYAMLConfig = config; }
 
   /// Retrieve property
   template<typename T> bool GetProperty(std::string propertyName, T & property, bool requiredProperty = true, std::string correctionName = "");
  protected:
-  PWG::Tools::AliYAMLConfiguration fYAMLConfig;           ///< Contains the YAML configuration used to configure the component
+  PWG::Tools::AliYAMLConfiguration fYAMLConfig;           ///< Contains the %YAML configuration used to configure the component
   Bool_t                  fCreateHisto;                   ///< Flag to make some basic histograms
   Int_t                   fRun;                           //!<! Run number
   TString                 fFilepass;                      ///< Input data pass number
@@ -144,7 +144,7 @@ class AliEmcalCorrectionComponent : public TNamed {
 };
 
 /**
- * Get the requested property from the YAML configuration. This function is generally used by
+ * Get the requested property from the %YAML configuration. This function is generally used by
  * AliEmcalCorrectionComponent derived tasks as a wrapper around the more complicated functions to
  * retrieve properties.
  *
@@ -175,7 +175,7 @@ bool AliEmcalCorrectionComponent::GetProperty(std::string propertyName, T & prop
  * This class maintains a map between the name of the correction component and a function to create the
  * component. This map can be then be used to create each desired component by passing the name in a string.
  * The benefit of this approach is new components can be automatically registered without changing any of the
- * correction classes. Only the YAML configuration needs to be changed!
+ * correction classes. Only the %YAML configuration needs to be changed!
  *
  * The class and associated functions are based on: https://stackoverflow.com/a/582456 , and edited
  * for our purposes.

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
@@ -91,7 +91,7 @@ AliEmcalCorrectionTask::AliEmcalCorrectionTask() :
  *
  * If "_" is included in the name, then all characters after the underscore will
  * be taken as the task suffix (sometimes described as a "specialization") and used
- * to select settings in the YAML configuration file.
+ * to select settings in the %YAML configuration file.
  *
  * @param[in] name Name of the correction task.
  */
@@ -276,7 +276,7 @@ void AliEmcalCorrectionTask::Initialize(bool removeDummyTask)
     AliInfoStream() << "Initializing correction task with suffix \"" << fSuffix << "\"" << std::endl;
   }
 
-  // Initialize YAML configuration
+  // Initialize %YAML configuration
   InitializeConfiguration();
   // Check that the configuration is initialized
   if (fConfigurationInitialized != true)
@@ -348,7 +348,7 @@ void AliEmcalCorrectionTask::RemoveDummyTask() const
 /**
  * Initializes and sets up the user and default configuration files.
  * This includes opening the files and storing the contents of the user and default
- * YAML files into strings so that they can be streamed to the grid.
+ * %YAML files into strings so that they can be streamed to the grid.
  * (yaml-cpp objects do not work properly with ROOT streamers).
  *
  * NOTE: fConfigurationInitialized is set to true if the function is successful.
@@ -395,7 +395,7 @@ void AliEmcalCorrectionTask::InitializeConfiguration()
  * order of which they should be executed.
  *
  * It is recommended to store the result, as it requires a large number of string comparisons and lookups
- * in the YAML configuration, whose associated methods also utilize a number of string comparisons.
+ * in the %YAML configuration, whose associated methods also utilize a number of string comparisons.
  *
  * @param[out] correctionComponents Names of the selected correction components in the order in which they should be executed.
  */
@@ -548,7 +548,7 @@ void AliEmcalCorrectionTask::CheckForUnmatchedUserSettings()
 }
 
 /**
- * Creates, configures, and initializes components based on the configuration described in the YAML files.
+ * Creates, configures, and initializes components based on the configuration described in the %YAML files.
  * Configuration includes making the user and default configuration available to each component, as
  * well as setting up the input clusters and tracks (cells have to be handled during ExecOnce()).
  * Each component's individual initialization is also called.
@@ -570,7 +570,7 @@ void AliEmcalCorrectionTask::InitializeComponents()
     component->SetName(componentName.c_str());
     component->SetTitle(componentName.c_str());
 
-    // Initialize the YAML configurations in each component
+    // Initialize the %YAML configurations in each component
     component->SetYAMLConfiguration(fYAMLConfig);
 
     // configure needed fields for components to properly initialize
@@ -598,7 +598,7 @@ void AliEmcalCorrectionTask::InitializeComponents()
  * input object type. In the case of cells, an EMCal Correction Cell Container is created to handle the
  * relevant information.
  *
- * Normally, when properties are retrieved from the YAML configuration, the entire configuration is considered.
+ * Normally, when properties are retrieved from the %YAML configuration, the entire configuration is considered.
  * However, here we only consider a subset in both the user and default configurations. In particular, the
  * "inputObjects" section is selected and then all properties are drawn from this subset (the shared parameters
  * are also retained so they can be used). Thus, it takes a bit more care to use this task, but it should be
@@ -640,7 +640,7 @@ void AliEmcalCorrectionTask::CreateInputObjects(AliEmcalContainerUtils::InputObj
 
 /**
  * Adds the previously created input objects that are managed by the Correction Task into a correction
- * component based on which input objects are requested in the YAML configuration by the component.
+ * component based on which input objects are requested in the %YAML configuration by the component.
  *
  * @param[in] component The correction component to which the input objects will be added
  * @param[in] inputObjectType The type of input object to add to the component
@@ -763,12 +763,12 @@ void AliEmcalCorrectionTask::SetupContainersFromInputNodes(AliEmcalContainerUtil
 }
 
 /**
- * Setup cell container with information from the YAML configuration nodes corresponding to the selected
+ * Setup cell container with information from the %YAML configuration nodes corresponding to the selected
  * input object.
  *
  * The created cell containers is stored by in the correction task.
  *
- * @param[in] containerName Name of the container to create (as defined in the YAML configuration)
+ * @param[in] containerName Name of the container to create (as defined in the %YAML configuration)
  */
 void AliEmcalCorrectionTask::SetupCellsInfo(std::string containerName)
 {
@@ -809,7 +809,7 @@ void AliEmcalCorrectionTask::SetupCellsInfo(std::string containerName)
  * configured through YAML.
  *
  * @param[in] inputObjectType Type of the input object to configure
- * @param[in] containerName Name of the container to create (as defined in the YAML configuration)
+ * @param[in] containerName Name of the container to create (as defined in the %YAML configuration)
  */
 void AliEmcalCorrectionTask::SetupContainer(const AliEmcalContainerUtils::InputObject_t inputObjectType, const std::string containerName)
 {
@@ -963,7 +963,7 @@ void AliEmcalCorrectionTask::SetupContainer(const AliEmcalContainerUtils::InputO
 
 /**
  * Creates a new AliEmcalContainer derived container based on the requested type and the branch name set in
- * the user and default YAML configuration and requested by a particular correction component. Supports the
+ * the user and default %YAML configuration and requested by a particular correction component. Supports the
  * "usedefault" pattern to simplify setting the proper branch name. Any track input objects are created as 
  * track containers unless the branch is named "mcparticles". If this is problematic for your analysis, the
  * track selection behavior of the track container can be disabled by setting the track selection to
@@ -972,7 +972,7 @@ void AliEmcalCorrectionTask::SetupContainer(const AliEmcalContainerUtils::InputO
  * Note that the created container is adopted and managed by the Correction Task. 
  *
  * @param[in] contType Type of the input object to add
- * @param[in] containerName Name of the container to create (as defined in the YAML configuration)
+ * @param[in] containerName Name of the container to create (as defined in the %YAML configuration)
  *
  * @return The created container
  */
@@ -1023,9 +1023,9 @@ AliEmcalContainer * AliEmcalCorrectionTask::AddContainer(const AliEmcalContainer
 }
 
 /**
- * Reinitializes the YAML configurations if necessary and sets up for output from the correction components.
+ * Reinitializes the %YAML configurations if necessary and sets up for output from the correction components.
  * The reinitialization is necessary if the object is streamed because yaml-cpp objects cannot be streamed.
- * Instead, the YAML configuration is stored in strings and the nodes are recreated here from the string.
+ * Instead, the %YAML configuration is stored in strings and the nodes are recreated here from the string.
  *
  * Note that the number of centrality bins is also set here in the case of a forced beam-type since this is
  * how it was done in AliAnalysisTaskEmcal.
@@ -1038,7 +1038,7 @@ void AliEmcalCorrectionTask::UserCreateOutputObjects()
     AliFatal("YAML configuration must be initialized before running (ie. the AddTask, run macro or wagon)!");
   }
 
-  // YAML Objects cannot be streamed, so we need to reinitialize them here.
+  // %YAML Objects cannot be streamed, so we need to reinitialize them here.
   fYAMLConfig.Reinitialize();
 
   if (fForceBeamType == kpp)
@@ -1364,7 +1364,7 @@ std::ostream & AliEmcalCorrectionTask::PrintConfiguration(std::ostream & in, boo
 }
 
 /**
- * Write the desired YAML configuration to a file.
+ * Write the desired %YAML configuration to a file.
  *
  * @param filename The name of the file to write
  * @param userConfig True to write the user configuration
@@ -1376,17 +1376,17 @@ bool AliEmcalCorrectionTask::WriteConfigurationFile(std::string filename, bool u
 }
 
 /**
- * Compare the passed YAML configuration to the stored YAML configuration. Note that this function
+ * Compare the passed %YAML configuration to the stored %YAML configuration. Note that this function
  * is not const as the passed filename is briefly added and removed to the configuration.
  *
- * @param filename The filename of the YAML configuration to compare
+ * @param filename The filename of the %YAML configuration to compare
  * @param userConfig True to compare against the user configuration
- * @return True when the passed YAML configuration is the same as the stored YAML configuration
+ * @return True when the passed %YAML configuration is the same as the stored %YAML configuration
  */
 bool AliEmcalCorrectionTask::CompareToStoredConfiguration(std::string filename, bool userConfig)
 {
   // Setup
-  // It's important to reinitialize the configuration so the YAML nodes are defined!
+  // It's important to reinitialize the configuration so the %YAML nodes are defined!
   fYAMLConfig.Reinitialize();
   std::string tempConfigName = "tempConfig";
   fYAMLConfig.AddConfiguration(filename, tempConfigName);
@@ -1438,11 +1438,11 @@ void AliEmcalCorrectionTask::CheckForContainerArray(AliEmcalContainer * cont, Al
 }
 
 /**
- * Given the input object type, it return the name of the field in the YAML configuration where information
+ * Given the input object type, it return the name of the field in the %YAML configuration where information
  * about it should be located. 
  *
  * @param inputObjectType The type of the input object
- * @return The name of the field of the requested input object in the YAML configuration file
+ * @return The name of the field of the requested input object in the %YAML configuration file
  */
 std::string AliEmcalCorrectionTask::GetInputFieldNameFromInputObjectType(AliEmcalContainerUtils::InputObject_t inputObjectType)
 {
@@ -1471,7 +1471,7 @@ std::string AliEmcalCorrectionTask::GetInputFieldNameFromInputObjectType(AliEmca
  * large number of possible components
  *
  * @param name Name to search for in the possible names
- * @param possibleComponents Possible names of components that have been retrieved from the YAML file
+ * @param possibleComponents Possible names of components that have been retrieved from the %YAML file
  *
  * @return True name in possible components name
  */
@@ -1555,7 +1555,7 @@ void AliEmcalCorrectionTask::PrintRequestedContainersInformation(AliEmcalContain
 
 /**
  * Utility function for CheckForUnmatchedUserSettings() which returns the names of all of the
- * properties defined in a YAML node. This can then be used to check for consistency in how properties
+ * properties defined in a %YAML node. This can then be used to check for consistency in how properties
  * are defined in the user and default configurations.
  *
  * This function handles the nodes by hand due to the rare requirement to handle the user and default
@@ -1803,7 +1803,7 @@ std::ostream & operator<<(std::ostream & in, const AliEmcalCorrectionTask & myTa
  * Print basic correction task information using the string representation provided by
  * AliEmcalCorrectionTask::toString
  *
- * @param opt If "YAML" is passed, then the YAML configuration is also printed
+ * @param opt If "YAML" is passed, then the %YAML configuration is also printed
  */
 void AliEmcalCorrectionTask::Print(Option_t* opt) const
 {

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
@@ -23,7 +23,7 @@ class AliVEvent;
  * @brief Steering task for the EMCal correction framework
  *
  * This class is the steering class for the cell and cluster level corrections
- * for the EMCal. A YAML configuration file is utilized to determine which
+ * for the EMCal. A %YAML configuration file is utilized to determine which
  * corrections should be run and how they should be configured. The corrections
  * are initialized by calling their Initialize() function. Similar to
  * AliAnalysisTaskEmcal, the relevant event information is loaded, and then
@@ -32,7 +32,7 @@ class AliVEvent;
  * In general, this steering class handles all of the configuration of the
  * corrections, including passing the relevant EMCal containers and event objects.
  *
- * Note: YAML does not play nicely with CINT and dictionary generation, so it is
+ * Note: %YAML does not play nicely with CINT and dictionary generation, so it is
  * hidden using conditional inclusion.
  *
  * @author Raymond Ehlers <raymond.ehlers@yale.edu>, Yale University
@@ -53,10 +53,10 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
     kpA       = 2  //!<! Proton-Nucleus
   };
 
-  /// Relates string to the cluster energy enumeration for YAML configuration
+  /// Relates string to the cluster energy enumeration for %YAML configuration
   static const std::map <std::string, AliVCluster::VCluUserDefEnergy_t> fgkClusterEnergyTypeMap; //!<!
 
-  /// Relates string to the track filter enumeration for YAML configuration
+  /// Relates string to the track filter enumeration for %YAML configuration
   static const std::map <std::string, AliEmcalTrackSelection::ETrackFilterType_t> fgkTrackFilterTypeMap; //!<!
 
   AliEmcalCorrectionTask();
@@ -69,7 +69,7 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
   virtual ~AliEmcalCorrectionTask();
 
   /**
-   * Initializes the Correction Task by initializing the YAML configuration and selected correction components,
+   * Initializes the Correction Task by initializing the %YAML configuration and selected correction components,
    * including setting up the input objects (cells, clusters, and tracks).
    *
    * This function is the main function for initialization and should be called from a run macro!
@@ -81,7 +81,7 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
   void Initialize(bool removeDummyTask = false);
 
   /** @{
-   * @name Functions related to the YAML configuration files.
+   * @name Functions related to the %YAML configuration files.
    */
   /// Set the path to the user configuration filename
   void SetUserConfigurationFilename(std::string name) { fUserConfigurationFilename = name; }
@@ -93,7 +93,7 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
   bool WriteConfigurationFile(std::string filename, bool userConfig = false) const;
   // Compare configurations
   bool CompareToStoredConfiguration(std::string filename, bool userConfig = false);
-  /// Retrieve the YAML configurations for direct access
+  /// Retrieve the %YAML configurations for direct access
   PWG::Tools::AliYAMLConfiguration & GetYAMLConfiguration() { return fYAMLConfig; }
   /** @} */
 
@@ -117,7 +117,7 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
    *
    * \return std::vector of the correction components. Using this vector, the components and their settings
    * can be modified as desired. However, keep in mind that whatever changes are made here will _NOT_ be
-   * reflected in the stored YAML configuration.
+   * reflected in the stored %YAML configuration.
    */
   const std::vector<AliEmcalCorrectionComponent *> & CorrectionComponents() { return fCorrectionComponents; }
   AliEmcalCorrectionComponent * GetCorrectionComponent(const std::string & name) const;
@@ -157,7 +157,7 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
    * EMCal Correction Task AddTask. Should be used by most users, except for those on the LEGO train
    * (see below).
    *
-   * @param[in] suffix Suffix string used to select components in a YAML configuration
+   * @param[in] suffix Suffix string used to select components in a %YAML configuration
    *
    * @return A new EMCal Correction Task added to the analysis manager and ready to configure.
    */
@@ -182,7 +182,7 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
   void SetCellsObjectInCellContainerBasedOnProperties(AliEmcalCorrectionCellContainer * cellContainer);
   // Container utilities
   void CheckForContainerArray(AliEmcalContainer * cont, AliEmcalContainerUtils::InputObject_t objectType);
-  // YAML configuration utilities
+  // %YAML configuration utilities
   std::string GetInputFieldNameFromInputObjectType(AliEmcalContainerUtils::InputObject_t inputObjectType);
   bool CheckPossibleNamesForComponentName(std::string & name, std::set <std::string> & possibleComponents);
   // General utilities
@@ -208,7 +208,7 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
   void CreateInputObjects(AliEmcalContainerUtils::InputObject_t inputObjectType);
   void AddContainersToComponent(AliEmcalCorrectionComponent * component, AliEmcalContainerUtils::InputObject_t inputObjectType, bool checkObjectExists = false);
   
-  // Hidden from CINT since it cannot handle YAML objects well
+  // Hidden from CINT since it cannot handle %YAML objects well
   // Input objects 
   void SetupContainersFromInputNodes(AliEmcalContainerUtils::InputObject_t inputObjectType, std::set <std::string> & requestedContainers);
   // Cells
@@ -218,19 +218,19 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
   AliEmcalContainer * AddContainer(const AliEmcalContainerUtils::InputObject_t contType, const std::string containerName);
 
   // Utilities
-  // YAML node dependent initialization utlitiles
+  // %YAML node dependent initialization utlitiles
   void GetPropertyNamesFromNode(const std::string configurationName, const std::string componentName, std::set <std::string> & propertyNames, const bool nodeRequired);
 
   PWG::Tools::AliYAMLConfiguration fYAMLConfig;            ///< Handles configuration from YAML.
 
   std::string                 fSuffix;                     ///< Suffix of the Correction Task (used to select specialized components)
 
-  std::string                 fUserConfigurationFilename;  //!<! User YAML configruation filename
-  std::string                 fDefaultConfigurationFilename; //!<! Default YAML configuration filename
+  std::string                 fUserConfigurationFilename;  //!<! User %YAML configruation filename
+  std::string                 fDefaultConfigurationFilename; //!<! Default %YAML configuration filename
 
   std::vector <std::string>   fOrderedComponentsToExecute; ///< Ordered set of components to execute
   std::vector <AliEmcalCorrectionComponent *> fCorrectionComponents; ///< Contains the correction components
-  bool                        fConfigurationInitialized;   ///< True if the YAML configuration files are initialized
+  bool                        fConfigurationInitialized;   ///< True if the %YAML configuration files are initialized
 
   bool                        fIsEsd;                      ///< File type
   bool                        fEventInitialized;           ///< If the event is initialized properly

--- a/PWG/EMCAL/READMEemcCorrections.txt
+++ b/PWG/EMCAL/READMEemcCorrections.txt
@@ -6,7 +6,7 @@ The new EMCal correction framework centralizes all of the analysis-level EMCal c
 AliEmcalCorrectionTask. This task coordinates the running of a configurable list of individual "correction components", where a
 correction component means a single correction to be performed: cell-level energy calibration, or cluster-level non-linearity
 correction, or cluster-track matching, etc. The set of corrections to run, as well as their order and their configurable
-parameters, is set in a YAML configuration file. A default config file containing the centralized standard set of parameters is
+parameters, is set in a %YAML configuration file. A default config file containing the centralized standard set of parameters is
 shared by all users, and each user additionally writes their own user config file, overwriting desired variables.
 
 The motivation of this new approach is the following:
@@ -74,14 +74,14 @@ correctionTask->Initialize();
 There are some special procedures for the LEGO train. There will be a centralized EMCal Correction Task wagon which
 contains standard settings such as physics selection, etc. Then the user will create a wagon which calls
 `PWG/EMCAL/macros/ConfigureEmcalCorrectionTaskOnLEGOTrain(std::string suffix)`. This will return an EMCal Correction Task
-for you to configure with your particular YAML configuration file and then initialize.
+for you to configure with your particular %YAML configuration file and then initialize.
 
 To setup this wagon, use the macro listed above. One argument is required: the suffix. This suffix should be some unique
 identifier for your analysis - it could be your name, your analysis, whatever you like. The precise value only matters
 if you are using [specialization](\ref emcCorrectionsSpecialization) - in such a case, your suffix for the configuration
 wagon must match the specialization suffix.
 
-Then in the macro customization of your configuration wagon, you specify your YAML configuration file and initialize
+Then in the macro customization of your configuration wagon, you specify your %YAML configuration file and initialize
 the configuration. It should looks something like the following:
 
 ~~~{.cxx}
@@ -97,10 +97,10 @@ They should not depend on your configuration wagon!
 
 # Configuring Corrections                                       {#configureEMCalCorrections}
 
-The corrections configuration file is specified via a file written in the YAML markup language. YAML is quite
+The corrections configuration file is specified via a file written in the %YAML markup language. %YAML is quite
 readable and is commonly used for configuration files. Although it should be straightforward to read and write,
 more information on its use can be found through the examples available [here](https://en.wikipedia.org/wiki/YAML).
-**All** configuration and options are set through the YAML file, from setting the clusterizer type to the name of
+**All** configuration and options are set through the %YAML file, from setting the clusterizer type to the name of
 the tracks!
 
 The configuration is determined by two files: the base default file (located in ``$ALICE_PHYSICS/PWG/EMCAL/config/``),
@@ -206,7 +206,7 @@ objectName:                         # Used to refer to this object in the YMAL c
 Although it is not required for your task to use EMCal containers, they are used internally in the Correction Task, so it is important to understand a bit about how they work. In particular, any filtering of the collections (such as AOD Track Filtering) is applied for the corrections, but the filtering does not remove anything from the collections!
 In addition, we always write cell/cluster/track corrections in place - it is generally not possible to write out new collections. Thus, it is then the users' responsibility to filter the collection using the information available! One particularly easy way to do so is to use EMCal containers, but it is not required! In the case that the user wants to manually filter, for example, tracks before running the Correction Framework, one can run AOD Track Filtering and then select no additional track filtering using ``kNoTrackFilter``.
 
-The available configuration options are listed below. Direct configuration through the YAML file is limited to a subset of all available configuration options. If you require additional options, please contact the developers - such additions are usually trivial. Alternatively, after calling ``Initialize()``, all containers are available for configuration as usual, so any additional options can be set by hand until implemented by the developers.
+The available configuration options are listed below. Direct configuration through the %YAML file is limited to a subset of all available configuration options. If you require additional options, please contact the developers - such additions are usually trivial. Alternatively, after calling ``Initialize()``, all containers are available for configuration as usual, so any additional options can be set by hand until implemented by the developers.
 
 __Cells__:
 | Property              | Value                             |
@@ -217,7 +217,7 @@ __Cells__:
 __EMCal Containers__:
 | Property              | Value                             |
 | --------------------- | --------------------------------- |
-| Container name        | This is set by the object name in the YAML config |
+| Container name        | This is set by the object name in the %YAML config |
 | branchName            | String selecting the branch name  |
 | embedding             | True if the branch should be taken from an embedded (external) event |
 | minPt                 | Double setting the minimum pT of the container |
@@ -265,7 +265,7 @@ For a survey of the available configuration options and information about the me
 configuration file located in ``$ALICE_PHYSICS/PWG/EMCAL/config/``. This also serves as an example configuration,
 Note that once the Correction Task is initialized using the ``Initialize()`` function, all corrections are
 configured and created. Consequently, any additional configuration can be done manually if desired. However,
-this approach is strongly discouraged. Instead, it is better to change the YAML configuration file so that
+this approach is strongly discouraged. Instead, it is better to change the %YAML configuration file so that
 there is a record of settings.
 
 ### Advanced usage options
@@ -274,7 +274,7 @@ There are a number of useful advanced options to make the Corrections Framework 
 
 #### Shared parameters
 
-Often, a user will want to change some parameters in unison. Say, if a pt cut is changed, it should be changed everywhere. In such a case, it is useful to able to define a variable so that one change will change things everything. This can be accomplished by defining a parameters in the "shared parameters" section of the YAML file. The name of the parameter defined in the shared parameters section can be referenced in other areas of the file by prepending ``sharedParameters:`` to the parameter name. Consider the example below:
+Often, a user will want to change some parameters in unison. Say, if a pt cut is changed, it should be changed everywhere. In such a case, it is useful to able to define a variable so that one change will change things everything. This can be accomplished by defining a parameters in the "shared parameters" section of the %YAML file. The name of the parameter defined in the shared parameters section can be referenced in other areas of the file by prepending ``sharedParameters:`` to the parameter name. Consider the example below:
 
 ~~~
 sharedParameters:
@@ -292,7 +292,7 @@ In the example, any change to ``aMinimumValue`` will be propagated to ``exampleV
 
 Often, a user would like to run two nearly identical corrections. For instance, one could run two clusterizers with the same
 configuration, but perhaps different input cells and output clusters. In such a case, the clusterizer can be "specialized", such that
-each of the two clusterizers will inherit the same settings except for the cells. Consider the following example YAML configuration
+each of the two clusterizers will inherit the same settings except for the cells. Consider the following example %YAML configuration
 file:
 
 ~~~
@@ -332,7 +332,7 @@ while ``Clusterizer_mySpecializedClusterizer`` uses ``anotherCells`` for cells a
 cells branch would have to be created elsewhere, say with ``AliEmcalCopyCollection``). 
 
 To execute these corrections, we must select them in the AddTask of the Correction Task. To do so, set the suffix argument of the AddTask
-to correspond with the specialization suffix that was set in the YAML file. Continuing with the previous example, we would need to add:
+to correspond with the specialization suffix that was set in the %YAML file. Continuing with the previous example, we would need to add:
 
 ~~~{.cxx}
 // The default argument is an empty string, so we don't have to set it here.
@@ -410,7 +410,7 @@ CorrectionTask_example2:
 A practical way to use specialization on the LEGO trains is to implement a correction task wagon with sub wagons for
 each specialization. By naming the sub wagon suffix the same as the specialization name, a specialized correction
 task will be created for each suffix. Each specialized correction task will extract the appropriate components for
-each correction chain from a single YAML file. For an example, see train 2860 on the Jets_EMC_PbPb train. However,
+each correction chain from a single %YAML file. For an example, see train 2860 on the Jets_EMC_PbPb train. However,
 the naming and dependencies of specializations with LEGO train subwagons requires special attention. In a normal run
 macro, the user can always select the order of running correction task specializations. However, in the case of LEGO
 train subwagons, the subwagons will always be run in **alphabetical order**. This can cause the correction tasks to
@@ -499,7 +499,7 @@ virtual Bool_t Run();
 virtual Bool_t UserNotify();
 ~~~
 
-To configure your task in the ``Initialize()`` function with the YAML configuration, you must define the
+To configure your task in the ``Initialize()`` function with the %YAML configuration, you must define the
 object and then get it via the ``GetProperty("propertyName", property)`` function defined in
 ``AliEmcalCorrectionComponent``. For an example, see ``Initialize()`` in any of the correction components.
 
@@ -518,7 +518,7 @@ and then the following to your component implementation file (cxx):
 RegisterCorrectionComponent<AliEmcalCorrectionYourNewComponent> AliEmcalCorrectionYourNewComponent::reg("AliEmcalCorrectionYourNewComponent");
 ```
 
-Lastly, the task needs to be added to the default YAML configuration file. To do so, add the name of the
+Lastly, the task needs to be added to the default %YAML configuration file. To do so, add the name of the
 component (removing "AliEmcalCorrection") to the file, and then set default values for each parameter.
 Be certain to document what each parameter means! In addition to the component configuration, be certain
 to add it into the executionOrder node! Otherwise, your task will never be executed! Note that the order

--- a/PWG/EMCAL/READMEemcCorrectionsChange.txt
+++ b/PWG/EMCAL/READMEemcCorrectionsChange.txt
@@ -60,7 +60,7 @@ The names in ``newBranchName`` determine the name of the new branches. In princi
 
 ### Configure the corrections for side-by-side testing
 
-Before beginning, be certain to read the introduction to YAML and configuring corrections available [here](\ref READMEemcCorrections).
+Before beginning, be certain to read the introduction to %YAML and configuring corrections available [here](\ref READMEemcCorrections).
 
 You can map the current corrections to the new ones with the following table. Note that each new correction is preceded by the name `AliEmcalCorrection`:
 
@@ -75,7 +75,7 @@ You can map the current corrections to the new ones with the following table. No
 | ClusTrackMatcher        | ClusterTrackMatcher       |
 | HadCorr                 | ClusterHadronicCorrection |
 
-Using the table above, we need to make sure that the current and the new corrections are configured the same. Compare the settings in your run macro with those in ``$ALICE_PHYSICS/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml``, known as the default file. In particular, check that each parameter value in the YAML file matches the value for that variable in your run macro (and not the other way around -- it is okay if there is no matching field for every field in the AddTask). The variable names should often be the same. If values are different in the YAML file, then modify the values in **``userTestConfiguration.yaml``**, not in ``AliEmcalCorrectionConfiguration.yaml``! To make the change, write it in yourself or copy the relevant structure of the default file to your user file and modify there. For instance, in the default file, the ``cellE`` parameter in the Clusterizer is to ``0.05``. If I wanted to change that in the user file, you would add:
+Using the table above, we need to make sure that the current and the new corrections are configured the same. Compare the settings in your run macro with those in ``$ALICE_PHYSICS/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml``, known as the default file. In particular, check that each parameter value in the %YAML file matches the value for that variable in your run macro (and not the other way around -- it is okay if there is no matching field for every field in the AddTask). The variable names should often be the same. If values are different in the %YAML file, then modify the values in **``userTestConfiguration.yaml``**, not in ``AliEmcalCorrectionConfiguration.yaml``! To make the change, write it in yourself or copy the relevant structure of the default file to your user file and modify there. For instance, in the default file, the ``cellE`` parameter in the Clusterizer is to ``0.05``. If I wanted to change that in the user file, you would add:
 
 ~~~
 Clusterizer:


### PR DESCRIPTION
The YAML namespace is automatically linked at every mention of YAML,
which is desired, so it is disabled with "YAML" -> "%YAML" (the %
prevents linking)