### PR TITLE
EMCal CorrFW: Move create histo init to base class

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellBadChannel.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellBadChannel.cxx
@@ -43,8 +43,6 @@ Bool_t AliEmcalCorrectionCellBadChannel::Initialize()
   
   AliWarning("Init EMCAL cell bad channel removal");
   
-  GetProperty("createHistos", fCreateHisto);
-
   // init reco utils
   if (!fRecoUtils)
     fRecoUtils  = new AliEMCALRecoUtils;

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEmulateCrosstalk.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEmulateCrosstalk.cxx
@@ -67,7 +67,6 @@ Bool_t AliEmcalCorrectionCellEmulateCrosstalk::Initialize()
   
   AliWarning("Init EMCAL crosstalk emulation");
   
-  GetProperty("createHistos", fCreateHisto);
   GetProperty("conservEnergy", fTCardCorrClusEnerConserv);
   
   if (!fRecoUtils) {

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
@@ -46,8 +46,6 @@ Bool_t AliEmcalCorrectionCellEnergy::Initialize()
   
   AliWarning("Init EMCAL cell recalibration");
   
-  GetProperty("createHistos", fCreateHisto);
-
   if(fFilepass.Contains("LHC14a1a")) fUseAutomaticRecalib = kTRUE;
   
   if (!fRecoUtils)

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellTimeCalib.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellTimeCalib.cxx
@@ -47,8 +47,6 @@ Bool_t AliEmcalCorrectionCellTimeCalib::Initialize()
   
   AliWarning("Init EMCAL time calibration");
   
-  GetProperty("createHistos", fCreateHisto);
-  
   fCalibrateTime = kTRUE;
 
   // init reco utils

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterExotics.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterExotics.cxx
@@ -45,8 +45,6 @@ Bool_t AliEmcalCorrectionClusterExotics::Initialize()
   // Initialization
   AliEmcalCorrectionComponent::Initialize();
   
-  GetProperty("createHistos", fCreateHisto);
-  
   Float_t fExoticMinCellAmplitude = 4.;
   GetProperty("fExoticMinCellAmplitude", fExoticMinCellAmplitude);
   Float_t fMaxFcross = 0.97;

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterHadronicCorrection.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterHadronicCorrection.cxx
@@ -91,7 +91,6 @@ Bool_t AliEmcalCorrectionClusterHadronicCorrection::Initialize()
   // Initialization
   AliEmcalCorrectionComponent::Initialize();
   
-  GetProperty("createHistos", fCreateHisto);
   GetProperty("phiMatch", fPhiMatch);
   GetProperty("etaMatch", fEtaMatch);
   GetProperty("hadCorr", fHadCorr);

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterNonLinearity.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterNonLinearity.cxx
@@ -59,8 +59,6 @@ Bool_t AliEmcalCorrectionClusterNonLinearity::Initialize()
   // Initialization
   AliEmcalCorrectionComponent::Initialize();
   
-  GetProperty("createHistos", fCreateHisto);
-
   std::string nonLinFunctStr = "";
   GetProperty("nonLinFunct", nonLinFunctStr);
   UInt_t nonLinFunct = fgkNonlinearityFunctionMap.at(nonLinFunctStr);

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterTrackMatcher.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterTrackMatcher.cxx
@@ -75,7 +75,6 @@ Bool_t AliEmcalCorrectionClusterTrackMatcher::Initialize()
   // Initialization
   AliEmcalCorrectionComponent::Initialize();
   
-  GetProperty("createHistos", fCreateHisto);
   GetProperty("usePIDmass", fUsePIDmass);
   GetProperty("useDCA", fUseDCA);
   GetProperty("maxDist", fMaxDistance);

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.cxx
@@ -116,6 +116,9 @@ Bool_t AliEmcalCorrectionComponent::Initialize()
     }
   }
 
+  // Handle create histos, as this is universal for every component
+  GetProperty("createHistos", fCreateHisto);
+
   return kTRUE;
 }
 


### PR DESCRIPTION
This field is present for every component, so it should be handled in
the base class initialization instead of in each component

cc: @jdmulligan 