### PR TITLE
Fix hybrid track selection on ESDs

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalAODHybridTrackCuts.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalAODHybridTrackCuts.cxx
@@ -61,15 +61,14 @@ AliEmcalTrackSelResultPtr AliEmcalAODHybridTrackCuts::IsSelected(TObject *o){
   // Create user object defining the hybrid track type (only in case the object is selected as hybrid track)
   if(selectionresult){
     AliEmcalTrackSelResultHybrid::HybridType_t tracktype = AliEmcalTrackSelResultHybrid::kHybridGlobal;
-    if(fHybridFilterBits[0] > -1 && fHybridFilterBits[1 ] > -1) {
+    if(fHybridFilterBits[0] > -1 && fHybridFilterBits[1] > -1) {
       if(aodtrack->TestFilterBit(BIT(fHybridFilterBits[0]))) tracktype = AliEmcalTrackSelResultHybrid::kHybridGlobal;
       else if(aodtrack->TestFilterBit(BIT(fHybridFilterBits[1]))){
         if(aodtrack->GetStatus() & AliVTrack::kITSrefit) tracktype = AliEmcalTrackSelResultHybrid::kHybridConstrained;
         else tracktype = AliEmcalTrackSelResultHybrid::kHybridConstrainedNoITSrefit;
+      }
     }
-  }
-  result.SetUserInfo(new AliEmcalTrackSelResultHybrid(tracktype));
-
+    result.SetUserInfo(new AliEmcalTrackSelResultHybrid(tracktype));
   }
   return result;
 }

--- a/PWG/EMCAL/EMCALbase/AliEmcalESDHybridTrackCuts.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalESDHybridTrackCuts.cxx
@@ -73,15 +73,28 @@ AliEmcalESDHybridTrackCuts::~AliEmcalESDHybridTrackCuts(){
 AliEmcalTrackSelResultPtr AliEmcalESDHybridTrackCuts::IsSelected(TObject *o){
   AliDebugStream(1) << "AliEmcalESDHybridTrackCuts::IsSelected(): Called" << std::endl;
   if(!fLocalInitialized) Init();
+  AliDebugStream(1) << "Global cuts:      " << (fHybridTrackCutsGlobal ? "yes" : "no") << std::endl;
+  AliDebugStream(1) << "Constrained cuts: " << (fHybridTrackCutsConstrained ? "yes" : "no") << std::endl;
+  AliDebugStream(1) << "Non-refit cuts:   " << (fHybridTrackCutsNoItsRefit ? "yes" : "no") << std::endl;
   if(auto esdtrack = dynamic_cast<AliESDtrack *>(o)) {
     AliEmcalTrackSelResultHybrid::HybridType_t tracktype = AliEmcalTrackSelResultHybrid::kUndefined;
-    if(fHybridTrackCutsGlobal && fHybridTrackCutsGlobal->AcceptTrack(esdtrack)) tracktype = AliEmcalTrackSelResultHybrid::kHybridGlobal;
-    else
-    {
-      if(fHybridTrackCutsConstrained && fHybridTrackCutsConstrained->AcceptTrack(esdtrack)) tracktype = AliEmcalTrackSelResultHybrid::kHybridConstrained;
-      else if(fHybridTrackCutsNoItsRefit && fHybridTrackCutsNoItsRefit->AcceptTrack(esdtrack)) tracktype = AliEmcalTrackSelResultHybrid::kHybridConstrainedNoITSrefit;
+    if(fHybridTrackCutsGlobal && fHybridTrackCutsGlobal->AcceptTrack(esdtrack)){
+      AliDebugStream(2) << "Track selected as global hybrid track" << std::endl;
+      tracktype = AliEmcalTrackSelResultHybrid::kHybridGlobal;
+    } else {
+      if(fHybridTrackCutsConstrained && fHybridTrackCutsConstrained->AcceptTrack(esdtrack)){
+        AliDebugStream(2) << "Track selected as constrained hybrid track" << std::endl;
+        tracktype = AliEmcalTrackSelResultHybrid::kHybridConstrained;
+      } else if(fHybridTrackCutsNoItsRefit && fHybridTrackCutsNoItsRefit->AcceptTrack(esdtrack)) {
+        AliDebugStream(2) << "Track selected as non-refit hybrid track" << std::endl;
+        tracktype = AliEmcalTrackSelResultHybrid::kHybridConstrainedNoITSrefit;
+      } else {
+        AliDebugStream(2) << "Track not selected as hybrid track" << std::endl;
+      }
     }
     AliEmcalTrackSelResultPtr result(esdtrack, tracktype != AliEmcalTrackSelResultHybrid::kUndefined);
+    if(result) result.SetUserInfo(new AliEmcalTrackSelResultHybrid(tracktype));
+    
     return result;
   }
   AliErrorStream() << "No ESD track" << std::endl;

--- a/PWG/EMCAL/EMCALbase/AliEmcalESDTrackCutsGenerator.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalESDTrackCutsGenerator.cxx
@@ -1,27 +1,42 @@
-/**************************************************************************
- * Copyright(c) 1998-2016, ALICE Experiment at CERN, All rights reserved. *
- *                                                                        *
- * Author: The ALICE Off-line Project.                                    *
- * Contributors are mentioned in the code where appropriate.              *
- *                                                                        *
- * Permission to use, copy, modify and distribute this software and its   *
- * documentation strictly for non-commercial purposes is hereby granted   *
- * without fee, provided that the above copyright notice appears in all   *
- * copies and that both the copyright notice and this permission notice   *
- * appear in the supporting documentation. The authors make no claims     *
- * about the suitability of this software for any purpose. It is          *
- * provided "as is" without express or implied warranty.                  *
- **************************************************************************/
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 
 #include <TString.h>
 #include <TFormula.h>
 
+#include "AliEmcalESDHybridTrackCuts.h"
 #include "AliEmcalTrackSelection.h"
 #include "AliEmcalESDTrackCutsGenerator.h"
 
 #include "AliESDtrackCuts.h"
 
 #include "TError.h"
+
+using namespace PWG::EMCAL;
 
 const Int_t AliEmcalESDTrackCutsGenerator::fgkAddCutFactor = 10000;
 
@@ -562,11 +577,9 @@ void AliEmcalESDTrackCutsGenerator::AddHybridTrackCuts(AliEmcalTrackSelection* t
   case kLHC11d:
   case kLHC11h:
   {
-    AliESDtrackCuts *cutsp = CreateTrackCutsPWGJE(kGlobalTracks2011NoSPD, kSPDAny);
-    trkSel->AddTrackCuts(cutsp);
-    AliESDtrackCuts *hybsp = CreateTrackCutsPWGJE(kGlobalTracks2011NoSPD, kSPDOff);
-    trkSel->AddTrackCuts(hybsp);
-
+    auto hybridcuts2011 = new AliEmcalESDHybridTrackCuts("hybridcuts2011NoSPD", AliEmcalESDHybridTrackCuts::kDef2011);
+    hybridcuts2011->SetUseNoITSrefitTracks(kFALSE);
+    trkSel->AddTrackCuts(hybridcuts2011);
     break;
   }
   case kLHC10h:
@@ -574,10 +587,9 @@ void AliEmcalESDTrackCutsGenerator::AddHybridTrackCuts(AliEmcalTrackSelection* t
   case kLHC10bcde:
   {
     /* hybrid track cuts*/
-    AliESDtrackCuts *cutsp = CreateTrackCutsPWGJE(kGlobalTracksNClsPtDepNoSPDNoPtCut, kSPDAny);
-    trkSel->AddTrackCuts(cutsp);
-    AliESDtrackCuts *hybsp = CreateTrackCutsPWGJE(kGlobalTracksNClsPtDepNoSPDNoPtCut, kSPDOff, kNoITSRefit);
-    trkSel->AddTrackCuts(hybsp);
+    auto hybridcuts2010 = new AliEmcalESDHybridTrackCuts("hybridcuts2010wSPD", AliEmcalESDHybridTrackCuts::kDef2010);
+    hybridcuts2010->SetUseNoITSrefitTracks(kTRUE);
+    trkSel->AddTrackCuts(hybridcuts2010);
     break;
   }
   default:

--- a/PWG/EMCAL/EMCALbase/AliEmcalESDTrackCutsGenerator.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalESDTrackCutsGenerator.h
@@ -1,3 +1,29 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
 /**
  * \file AliEmcalESDTrackCutsGenerator.h
  * \brief Declaration of class AliEmcalESDTrackCutsGenerator
@@ -10,12 +36,15 @@
  */
 #ifndef ALIEMCALESDTRACKCUTSGENERATOR_H
 #define ALIEMCALESDTRACKCUTSGENERATOR_H
-/* Copyright(c) 1998-2015, ALICE Experiment at CERN, All rights reserved. *
- * See cxx source for full Copyright notice                               */
 
 class AliESDtrackCuts;
 class AliEmcalTrackSelection;
 class TString;
+
+
+namespace PWG {
+
+namespace EMCAL{
 
 class AliEmcalESDTrackCutsGenerator {
 public:
@@ -66,5 +95,9 @@ public:
   static void AddTPCOnlyTrackCuts(AliEmcalTrackSelection* trkSel, TString period) { AddTPCOnlyTrackCuts(trkSel, SteerDataSetFromString(period)); }
   static void AddTPCOnlyTrackCuts(AliEmcalTrackSelection* trkSel, EDataSet_t period);
 };
+
+}
+
+}
 
 #endif /* ALIEMCALESDTRACKCUTSGENERATOR_H */

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionESD.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionESD.cxx
@@ -72,11 +72,12 @@ void AliEmcalTrackSelectionESD::GenerateTrackCuts(ETrackFilterType_t type, const
 
   switch (type) {
   case kHybridTracks:
-    AliEmcalESDTrackCutsGenerator::AddHybridTrackCuts(this, period);
+    AliDebugStream(1) << "Generate std hybrid track cuts" << std::endl;
+    PWG::EMCAL::AliEmcalESDTrackCutsGenerator::AddHybridTrackCuts(this, period);
     break;
 
   case kTPCOnlyTracks:
-    AliEmcalESDTrackCutsGenerator::AddTPCOnlyTrackCuts(this, period);
+    PWG::EMCAL::AliEmcalESDTrackCutsGenerator::AddTPCOnlyTrackCuts(this, period);
     break;
 
   case kITSPureTracks:
@@ -85,6 +86,7 @@ void AliEmcalTrackSelectionESD::GenerateTrackCuts(ETrackFilterType_t type, const
 
   case kHybridTracks2010wNoRefit:
   {
+    AliDebugStream(1) << "Generate 2010 hybrid track cuts wNoRefit" << std::endl;
     auto hybridcuts = new AliEmcalESDHybridTrackCuts("hybrid_2010_wNoRefit", AliEmcalESDHybridTrackCuts::kDef2010);
     hybridcuts->SetUseNoITSrefitTracks(kTRUE);
     AddTrackCuts(hybridcuts);
@@ -93,7 +95,8 @@ void AliEmcalTrackSelectionESD::GenerateTrackCuts(ETrackFilterType_t type, const
 
   case kHybridTracks2010woNoRefit:
   {
-    auto hybridcuts = new AliEmcalESDHybridTrackCuts("hybrid_2010_wNoRefit", AliEmcalESDHybridTrackCuts::kDef2010);
+    AliDebugStream(1) << "Generate 2010 hybrid track cuts woNoRefit" << std::endl;
+    auto hybridcuts = new AliEmcalESDHybridTrackCuts("hybrid_2010_woNoRefit", AliEmcalESDHybridTrackCuts::kDef2010);
     hybridcuts->SetUseNoITSrefitTracks(kFALSE);
     AddTrackCuts(hybridcuts);
     break;
@@ -101,7 +104,8 @@ void AliEmcalTrackSelectionESD::GenerateTrackCuts(ETrackFilterType_t type, const
 
   case kHybridTracks2011wNoRefit:
   {
-    auto hybridcuts = new AliEmcalESDHybridTrackCuts("hybrid_2010_wNoRefit", AliEmcalESDHybridTrackCuts::kDef2011);
+    AliDebugStream(1) << "Generate 2011 hybrid track cuts wNoRefit" << std::endl;
+    auto hybridcuts = new AliEmcalESDHybridTrackCuts("hybrid_2011_wNoRefit", AliEmcalESDHybridTrackCuts::kDef2011);
     hybridcuts->SetUseNoITSrefitTracks(kTRUE);
     AddTrackCuts(hybridcuts);
     break;
@@ -109,7 +113,8 @@ void AliEmcalTrackSelectionESD::GenerateTrackCuts(ETrackFilterType_t type, const
 
   case kHybridTracks2011woNoRefit:
   {
-    auto hybridcuts = new AliEmcalESDHybridTrackCuts("hybrid_2010_wNoRefit", AliEmcalESDHybridTrackCuts::kDef2011);
+    AliDebugStream(1) << "Generate 2011 hybrid track cuts woNoRefit" << std::endl;
+    auto hybridcuts = new AliEmcalESDHybridTrackCuts("hybrid_2011_woNoRefit", AliEmcalESDHybridTrackCuts::kDef2011);
     hybridcuts->SetUseNoITSrefitTracks(kFALSE);
     AddTrackCuts(hybridcuts);
     break;
@@ -141,14 +146,14 @@ PWG::EMCAL::AliEmcalTrackSelResultPtr AliEmcalTrackSelectionESD::IsTrackAccepted
   trackbitmap.ResetAllBits();
   UInt_t cutcounter = 0;
   AliDebugStream(2) << "Found cut array with " << fListOfCuts->GetEntries() << " cuts\n" << std::endl;
-  TObjArray selectionStatus;
-  selectionStatus.SetOwner(false);
+  TClonesArray selectionStatus("PWG::EMCAL::AliEmcalTrackSelResultPtr", fListOfCuts->GetEntries());
+  selectionStatus.SetOwner(kTRUE);
   for(auto cutIter : *fListOfCuts){
     AliDebugStream(3) << "executing nect cut: " << static_cast<AliVCuts *>(static_cast<AliEmcalManagedObject *>(cutIter)->GetObject())->GetName() << std::endl;
     PWG::EMCAL::AliEmcalCutBase *mycuts = static_cast<PWG::EMCAL::AliEmcalCutBase *>(static_cast<AliEmcalManagedObject *>(cutIter)->GetObject());
     PWG::EMCAL::AliEmcalTrackSelResultPtr selresult = mycuts->IsSelected(esdt);
-    selectionStatus.Add(&selresult);
     if(selresult) trackbitmap.SetBitNumber(cutcounter);
+    new(selectionStatus[selectionStatus.GetEntries()]) PWG::EMCAL::AliEmcalTrackSelResultPtr(selresult);
     cutcounter++;
   }
   // In case of ANY at least one bit has to be set, while in case of ALL all bits have to be set

--- a/PWG/EMCAL/EMCALbase/PWGEMCALbaseLinkDef.h
+++ b/PWG/EMCAL/EMCALbase/PWGEMCALbaseLinkDef.h
@@ -12,7 +12,6 @@
 #pragma link C++ class AliEmcalContainer+;
 #pragma link C++ class AliEmcalContainerUtils+;
 #pragma link C++ class AliEmcalDownscaleFactorsOCDB+;
-#pragma link C++ class AliEmcalESDTrackCutsGenerator+;
 #pragma link C++ class AliEmcalParticle+;
 #pragma link C++ class AliEmcalPhysicsSelection+;
 #pragma link C++ class AliEmcalPythiaInfo+;
@@ -44,6 +43,7 @@
 #pragma link C++ class PWG::EMCAL::AliEmcalAODHybridTrackCuts+;
 #pragma link C++ class PWG::EMCAL::AliEmcalAODTPCOnlyTrackCuts+;
 #pragma link C++ class PWG::EMCAL::AliEmcalESDHybridTrackCuts+;
+#pragma link C++ class PWG::EMCAL::AliEmcalESDTrackCutsGenerator+;
 #pragma link C++ class PWG::EMCAL::AliEmcalESDtrackCutsWrapper+;
 #pragma link C++ class PWG::EMCAL::TestAliEmcalTrackSelResultPtr+;
 #pragma link C++ class PWG::EMCAL::TestAliEmcalAODHybridTrackCuts+;


### PR DESCRIPTION
Hybrid tracks were selected but the payload
defining the hybrid track type was not attached
to the track selection result ptr. In this case
the track container is not able to distinguish
the hybrid track type and will reject all tracks.
The hybrid type is now attached in case the track
was selected as hybrid track.

The track cuts generator was up to now not using the
new hybrid cuts wrapper but instead defined hybrid
cuts as set of ESD cuts. Also in this case the payload
defining the hybrid track type was missing and the
distinction in the track container was imposible. The
different hybrid track types are however already
implemented, and selecting one of the types gives the
expected result. The track cuts generator was modified
to ues the hybrid cuts wrapper with the proper hybrid
definition for the period provided so users don't
need to select the hybrid track type by hand.

In addition:
- Indentation fix in AliEmcalAODHybridTrackCuts
- Some AliDebugStreams for debugging purpose
- Move track cuts generator to the namespace
  PWG::EMCAL (will be done step-by-step also with
  other classes in the EMCAL core framework)