### PR TITLE
EMCal CorrFW: Add config for crosstalk task

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEmulateCrosstalk.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEmulateCrosstalk.h
@@ -30,120 +30,15 @@ class AliEmcalCorrectionCellEmulateCrosstalk : public AliEmcalCorrectionComponen
   void UserCreateOutputObjects();
   Bool_t Run();
   
-  /// Constant energy lost by max energy cell in one of T-Card cells, same for all SM
-  /// \param ud energy lost in upper/lower cell, same column
-  /// \param udlr energy lost in upper/lower cell, left or right
-  /// \param lr   energy lost in left or right cell, same row
-  void           SetInducedEnergyLossConstant(Float_t ud, Float_t udlr, Float_t lr, Float_t sec) {
-    for(Int_t ism = 0; ism < 22; ism++) {
-      fTCardCorrInduceEner[0][ism] = ud; fTCardCorrInduceEner[1][ism] = udlr;
-      fTCardCorrInduceEner[2][ism] = lr; fTCardCorrInduceEner[3][ism] = sec ; } }
+  // Print correction paramters
+  void PrintTCardParam();
   
-  /// Fraction of energy lost by max energy cell in one of T-Card cells, same for all SM
-  /// \param ud energy lost in upper/lower cell, same column
-  /// \param udlr energy lost in upper/lower cell, left or right
-  /// \param lr   energy lost in left or right cell, same row
-  void           SetInducedEnergyLossFraction(Float_t ud, Float_t udlr, Float_t lr, Float_t sec) {
-    for(Int_t ism = 0; ism < 22; ism++) {
-      fTCardCorrInduceEnerFrac[0][ism] = ud; fTCardCorrInduceEnerFrac[1][ism] = udlr;
-      fTCardCorrInduceEnerFrac[2][ism] = lr; fTCardCorrInduceEnerFrac[3][ism] = sec ; } }
-  
-  /// Slope parameter of fraction of energy lost by max energy cell in one of T-Card cells, same for all SM
-  /// \param ud energy lost in upper/lower cell, same column
-  /// \param udlr energy lost in upper/lower cell, left or right
-  /// \param lr   energy lost in left or right cell, same row
-  void           SetInducedEnergyLossFractionP1(Float_t ud, Float_t udlr, Float_t lr, Float_t sec) {
-    for(Int_t ism = 0; ism < 22; ism++) {
-      fTCardCorrInduceEnerFracP1[0][ism] = ud; fTCardCorrInduceEnerFracP1[1][ism] = udlr;
-      fTCardCorrInduceEnerFracP1[2][ism] = lr; fTCardCorrInduceEnerFracP1[3][ism] = sec ; } }
-  
-  /// Constant energy lost by max energy cell in one of T-Card cells, per SM
-  /// \param sm super module index
-  /// \param ud energy lost in upper/lower cell, same column
-  /// \param udlr energy lost in upper/lower cell, left or right
-  /// \param lr   energy lost in left or right cell, same row
-  void           SetInducedEnergyLossConstantPerSM(Int_t sm, Float_t ud, Float_t udlr, Float_t lr, Float_t sec) {
-    if ( sm < 22 && sm >= 0 ) {
-      fTCardCorrInduceEner[0][sm] = ud; fTCardCorrInduceEner[1][sm] = udlr;
-      fTCardCorrInduceEner[2][sm] = lr; fTCardCorrInduceEner[3][sm] = sec ; } }
-  
-  /// Fraction of energy lost by max energy cell in one of T-Card cells, per SM
-  /// \param sm super module index
-  /// \param ud energy lost in upper/lower cell, same column
-  /// \param udlr energy lost in upper/lower cell, left or right
-  /// \param lr   energy lost in left or right cell, same row
-  void           SetInducedEnergyLossFractionPerSM(Int_t sm, Float_t ud, Float_t udlr, Float_t lr, Float_t sec) {
-    if ( sm < 22 && sm >= 0 ) {
-      fTCardCorrInduceEnerFrac[0][sm] = ud; fTCardCorrInduceEnerFrac[1][sm] = udlr;
-      fTCardCorrInduceEnerFrac[2][sm] = lr; fTCardCorrInduceEnerFrac[3][sm] = sec ; } }
-  
-  /// Slope parameter of fraction of energy lost by max energy cell in one of T-Card cells, per SM
-  /// \param sm super module index
-  /// \param ud energy lost in upper/lower cell, same column
-  /// \param udlr energy lost in upper/lower cell, left or right
-  /// \param lr   energy lost in left or right cell, same row
-  void           SetInducedEnergyLossFractionP1PerSM(Int_t sm, Float_t ud, Float_t udlr, Float_t lr, Float_t sec) {
-    if ( sm < 22 && sm >= 0 ) {
-      fTCardCorrInduceEnerFracP1[0][sm] = ud; fTCardCorrInduceEnerFracP1[1][sm] = udlr;
-      fTCardCorrInduceEnerFracP1[2][sm] = lr; fTCardCorrInduceEnerFracP1[3][sm] = sec ; } }
-  
-  /// Fraction of energy lost by max energy cell in one of T-Card cells, width of random gaussian, same for all SM
-  /// \param ud energy lost in upper/lower cell, same column
-  /// \param udlr energy lost in upper/lower cell, left or right
-  /// \param lr   energy lost in left or right cell, same row
-  void           SetInducedEnergyLossFractionWidth(Float_t ud, Float_t udlr, Float_t lr, Float_t sec) {
-    for(Int_t ism = 0; ism < 22; ism++) {
-      fTCardCorrInduceEnerFracWidth[0][ism] = ud; fTCardCorrInduceEnerFracWidth[1][ism] = udlr;
-      fTCardCorrInduceEnerFracWidth[2][ism] = lr; fTCardCorrInduceEnerFracWidth[3][ism] = sec ; } }
-  
-  /// Fraction of energy lost by max energy cell in one of T-Card cells, width of random gaussian, per SM
-  /// \param sm super module index
-  /// \param ud energy lost in upper/lower cell, same column
-  /// \param udlr energy lost in upper/lower cell, left or right
-  /// \param lr   energy lost in left or right cell, same row
-  void           SetInducedEnergyLossFractionWidthPerSM(Int_t sm, Float_t ud, Float_t udlr, Float_t lr, Float_t sec) {
-    if ( sm < 22 && sm >= 0 ) {
-      fTCardCorrInduceEnerFracWidth[0][sm] = ud; fTCardCorrInduceEnerFracWidth[1][sm] = udlr;
-      fTCardCorrInduceEnerFracWidth[2][sm] = lr; fTCardCorrInduceEnerFracWidth[3][sm] = sec ; } }
-  
-  /// Maximum induced energy fraction when linear dependency is set, per SM number
-  /// \param max maximum fraction
-  /// \param sm  super-module number
-  void           SetInducedEnergyLossMaximumFractionPerSM(Float_t max, Int_t sm) {
-    if ( sm < 22 && sm >= 0 ) fTCardCorrInduceEnerFracMax[sm] = max ; }
-  
-  /// Minimum induced energy fraction when linear dependency is set, per SM number
-  /// \param min minimum fraction
-  /// \param sm  super-module number
-  void           SetInducedEnergyLossMinimumFractionPerSM(Float_t min, Int_t sm) {
-    if ( sm < 22 && sm >= 0 ) fTCardCorrInduceEnerFracMin[sm] = min ; }
-  
-  /// Maximum induced energy fraction when linear dependency is set, same for all SM
-  /// \param max maximum fraction
-  void           SetInducedEnergyLossMaximumFraction(Float_t max) {
-    for(Int_t ism = 0; ism < 22; ism++) fTCardCorrInduceEnerFracMax[ism] = max ; }
-  
-  /// Minimum induced energy fraction when linear dependency is set, same for all SM
-  /// \param min minimum fraction
-  void           SetInducedEnergyLossMinimumFraction(Float_t min) {
-    for(Int_t ism = 0; ism < 22; ism++) fTCardCorrInduceEnerFracMin[ism] = min ; }
-  
-  /// fraction of times max cell energy correlates with cross cells, different for each super-module
-  /// \param prob probability per event, from 0 to 1
-  /// \param sm   probability assigned to this super-module number
-  void           SetInducedEnergyLossProbabilityPerSM(Float_t prob, Int_t sm) {
-    if ( sm < 22 && sm >= 0 ) fTCardCorrInduceEnerProb[sm] = prob ; }
-  
-  void           SwitchOnRandomizeTCardInducedEnergy()          { fRandomizeTCard = kTRUE   ; }
-  void           SwitchOffRandomizeTCardInducedEnergy()         { fRandomizeTCard = kFALSE  ; }
-  
-  void           SetInducedTCardMinimumCellEnergy(Float_t mi)   { fTCardCorrMinAmp     = mi ; }
-  void           SeInducedTCardMaximum(Float_t ma)              { fTCardCorrMaxInduced = ma ; }
-  
-  void           PrintTCardParam();
-  
-protected:
-  
+ protected:
+
+  // Useful constants
+  static const Int_t fgkNEMCalCells = 17664;       ///< Total number of cells in the calorimeter, 10*48*24 (EMCal) + 4*48*8 (EMCal/DCal 1/3) + 6*32*24 (DCal)
+  static const Int_t fgkNsm = 22;                  ///< Total number of super-modules
+
   // T-Card correlation emulation, do on MC
   void           MakeCellTCardCorrelation();
   void           AddInducedEnergiesToExistingCells();
@@ -151,27 +46,33 @@ protected:
   
   virtual void   ResetArrays();
   Bool_t         AcceptCell(Int_t absID);
+
+  // Initialize array parameters.
+  #if !(defined(__CINT__) || defined(__MAKECINT__))
+  template <typename T>
+  void RetrieveAndSetProperties(const T & properties);
+  #endif
+  void SetProperty(Float_t val[][fgkNsm], std::vector<double> & property, unsigned int iSM, const std::string & name);
+  void SetProperty(Float_t val[fgkNsm], std::vector<double> & property, unsigned int iSM, const std::string & name);
   
   TH1F* fCellEnergyDistBefore;        //!<! cell energy distribution, before energy smearing
   TH1F* fCellEnergyDistAfter;         //!<! cell energy distribution, after energy smearing
-  
-  static const Int_t fgkNEMCalCells = 17664;       ///< Total number of cells in the calorimeter, 10*48*24 (EMCal) + 4*48*8 (EMCal/DCal 1/3) + 6*32*24 (DCal)
   
   // T-Card correlation emulation, do on MC
   Bool_t                fTCardCorrClusEnerConserv; ///< When making correlation, subtract from the reference cell the induced energy on the neighbour cells
   Float_t               fTCardCorrCellsEner[fgkNEMCalCells]; ///<  Array with induced cell energy in T-Card neighbour cells
   Bool_t                fTCardCorrCellsNew [fgkNEMCalCells]; ///<  Array with induced cell energy in T-Card neighbour cells, that before had no signal
   
-  Float_t               fTCardCorrInduceEner         [4 ][22]; ///< Induced energy loss gauss constant on 0-same row, diff col, 1-up/down cells left/right col 2-left/righ col, and 2nd row cells, param 0
-  Float_t               fTCardCorrInduceEnerFrac     [4 ][22]; ///< Induced energy loss gauss fraction param0 on 0-same row, diff col, 1-up/down cells left/right col 2-left/righ col, and 2nd row cells, param 0
-  Float_t               fTCardCorrInduceEnerFracP1   [4 ][22]; ///< Induced energy loss gauss fraction param1 on 0-same row, diff col, 1-up/down cells left/right col 2-left/righ col, and 2nd row cells, param1
-  Float_t               fTCardCorrInduceEnerFracWidth[4 ][22]; ///< Induced energy loss gauss witdth on 0-same row, diff col, 1-up/down cells left/right col 2-left/righ col, and 2nd row cells
-  Float_t               fTCardCorrInduceEnerFracMax[22];   ///< In case fTCardCorrInduceEnerFracP1  is non null, restrict the maximum fraction of induced energy per SM
-  Float_t               fTCardCorrInduceEnerFracMin[22];   ///< In case fTCardCorrInduceEnerFracP1  is non null, restrict the minimum fraction of induced energy per SM
-  Float_t               fTCardCorrInduceEnerProb[22];      ///< Probability to induce energy loss per SM
+  Float_t               fTCardCorrInduceEner         [4][fgkNsm]; ///< Induced energy loss gauss constant on 0-same row, diff col, 1-up/down cells left/right col 2-left/righ col, and 2nd row cells, param 0
+  Float_t               fTCardCorrInduceEnerFrac     [4][fgkNsm]; ///< Induced energy loss gauss fraction param0 on 0-same row, diff col, 1-up/down cells left/right col 2-left/righ col, and 2nd row cells, param 0
+  Float_t               fTCardCorrInduceEnerFracP1   [4][fgkNsm]; ///< Induced energy loss gauss fraction param1 on 0-same row, diff col, 1-up/down cells left/right col 2-left/righ col, and 2nd row cells, param1
+  Float_t               fTCardCorrInduceEnerFracWidth[4][fgkNsm]; ///< Induced energy loss gauss witdth on 0-same row, diff col, 1-up/down cells left/right col 2-left/righ col, and 2nd row cells
+  Float_t               fTCardCorrInduceEnerFracMax[fgkNsm];   ///< In case fTCardCorrInduceEnerFracP1  is non null, restrict the maximum fraction of induced energy per SM
+  Float_t               fTCardCorrInduceEnerFracMin[fgkNsm];   ///< In case fTCardCorrInduceEnerFracP1  is non null, restrict the minimum fraction of induced energy per SM
+  Float_t               fTCardCorrInduceEnerProb[fgkNsm];      ///< Probability to induce energy loss per SM
   
-  TRandom3              fRandom   ;                ///<  Random generator
-  Bool_t                fRandomizeTCard ;          ///<  Use random induced energy
+  TRandom3              fRandom;                   ///<  Random generator
+  Bool_t                fRandomizeTCard;           ///<  Use random induced energy
   
   Float_t               fTCardCorrMinAmp;          ///<  Minimum cell energy to induce signal on adjacent cells
   Float_t               fTCardCorrMaxInduced;      ///<  Maximum induced energy signal on adjacent cells
@@ -190,5 +91,55 @@ private:
   ClassDef(AliEmcalCorrectionCellEmulateCrosstalk, 1); // EMCal cell crosstalk emulation correction component
   /// \endcond
 };
+
+#if !(defined(__CINT__) || defined(__MAKECINT__))
+/**
+ * Assigns array properties defined in the YAML config to initialize array class members.
+ * Can handle any map for which there is an appropirately defined SetProperty(...).
+ *
+ * NOTE: This function needs to be hidden from CINT because it uses templates.
+ *
+ * @param[in] properties YAML to class members map
+ */
+template <typename T>
+void AliEmcalCorrectionCellEmulateCrosstalk::RetrieveAndSetProperties(const T & properties)
+{
+  std::string taskName = GetName();
+  std::map <std::string, std::vector<double>> values;
+
+  for (auto& val : properties) {
+    AliDebugStream(1) << "Processing value " << val.first << "\n";
+    bool enabled = false;
+    fYAMLConfig.GetProperty({taskName, val.first, "enabled"}, enabled, true);
+    if (enabled) {
+      AliDebugStream(1) << val.first << " enabled.\n";
+      fYAMLConfig.GetProperty({taskName, val.first, "values"}, values, true);
+      // "all"" is prioritized over any individual SM values
+      auto property = values.find("all");
+      if (property != values.end()) {
+        // Set same value in all SMs
+        AliDebugStream(1) << "Retrieving all SM settings for property " << val.first << "\n";
+        for (unsigned int iSM = 0; iSM < fgkNsm; iSM++) {
+          SetProperty(val.second, property->second, iSM, val.first);
+        }
+      }
+      else {
+        // Handle per SM values
+        AliDebugStream(1) << "Retrieving per SM settings for property " << val.first << "\n";
+        for (auto && property : values) {
+          unsigned int iSM = std::stoul(property.first);
+          // iSM must be >= 0 because it is unsigned
+          if (iSM < fgkNsm) {
+            SetProperty(val.second, property.second, iSM, val.first);
+          }
+          else {
+            AliWarningStream() << "SM " << iSM << " requested for property " << val.first << " is out of range. Please check your configuration!\n";
+          }
+        }
+      }
+    }
+  }
+}
+#endif
 
 #endif /* ALIEMCALCORRECTIONCellEmulateCrosstalk_H */

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -65,7 +65,38 @@ CellTimeCalib:                                      # Cell Time Calibration comp
 CellEmulateCrosstalk:                               # Component to emulate crosstalk
     enabled: false                                  # Whether to enable the task
     createHistos: false                             # Whether the task should create output histograms
+    printConfiguration: false                       # Print the configuration after initialization
     conservEnergy: false                            # Activate cluster energy conservation, not by default
+    randomizeTCardInducedEnergy: false              # Randomize the energy fraction induced by the TCard
+    inducedTCardMinimumCellEnergy: 0.01             # Minimum cell energy induced by the TCard
+    inducedTCardMaximum: 100                        # Maximum energy induced by the TCard
+    # Note on using the following section:
+    # Each setting can be enabled or disabled. If disabled, the settings will _not_ be applied
+    # The values are formatted as a map, with the keys as either "all", correspoding to all SMs
+    # or the super module number. The format of the value is specified in the comment after the field.
+    #
+    # NOTE: If you specify "all", it will take precedence over any individual SM values, which will be ignored.
+    inducedEnergyLossConstant:                      # Constant energy lost by max energy cell in one of T-Card cells
+        enabled: false                              # Enable setting these values
+        values: {"all" : [0.02, 0.02, 0.02, 0]}     # Values are energy lost in [ upper/lower cell in same column, upper/lower cell in left or right, left or right cell in same row, ??]
+    inducedEnergyLossFraction:                      # Fraction of energy lost by max energy cell in one of T-Card cells
+        enabled: true                               # Enable setting these values
+        values: {"all" : [0.02, 0.02, 0.02, 0]}     # Values are energy lost in [ upper/lower cell in same column, upper/lower cell in left or right, left or right cell in same row, ??]
+    inducedEnergyLossFractionP1:                    # Slope parameter of fraction of energy lost by max energy cell in one of T-Card cells
+        enabled: true                               # Enable setting these values
+        values: {"all" : [-0.0009, -0.0009, -0.0009, 0]}  # Values are energy lost in [ upper/lower cell in same column, upper/lower cell in left or right, left or right cell in same row, ??]
+    inducedEnergyLossFractionWidth:                 # Fraction of energy lost by max energy cell in one of T-Card cells, width of random gaussian
+        enabled: true                               # Enable setting these values
+        values: {"all" : [0.0, 0.0, 0.0, 0]}        # Values are energy lost in [ upper/lower cell in same column, upper/lower cell in left or right, left or right cell in same row, ??]
+    inducedEnergyLossMinimumFraction:               # Minimum induced energy fraction when linear dependency is set
+        enabled: true                               # Enable setting these values
+        values: {"all" : [0.008]}                   # Values are [minimum fraction]
+    inducedEnergyLossMaximumFraction:               # Maximum induced energy fraction when linear dependency is set
+        enabled: true                               # Enable setting these values
+        values: {"all" : [0.025]}                   # Values are [maximum fraction]
+    inducedEnergyLossProbability:                   # Fraction of times max cell energy correlates with cross cells
+        enabled: true                               # Enable setting these values
+        values: {0 : [0.30], 1: [0.60], 2: [0.50], 3: [1.00], 4: [0.35], 5: [0.25], 6: [0.35], 7: [1.00], 8 : [0.25], 9: [0.25]}  # Values are [probability per event from 0 to 1]
     cellsNames:                                     # Names of the cells input objects which should be attached to the correction
         - defaultCells                              # This object is defined above in the cells section of the input objects
 CellCombineCollections:                             # Utility task to combine two cells collections into a single collection.


### PR DESCRIPTION
As promised in #4178, this PR allows array initialization for the new crosstalk correction. This configuration was a bit more complicated than usual, but a little templates magic makes it work and should be fairly intuitive. I tried to document it and configure it as you have in your .C, but both should be checked more closely. Please let me know if it is unclear.

cc: @gconesab , @jdmulligan 