### PR TITLE
Final corrections to Cross Talk emulation component

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEmulateCrosstalk.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEmulateCrosstalk.cxx
@@ -171,7 +171,7 @@ Bool_t AliEmcalCorrectionCellEmulateCrosstalk::Run()
     AliDebug(2, Form("Number of EMCAL cells = %d, returning", fCaloCells->GetNumberOfCells()));
     return kFALSE;
   }
-  
+
   if(fCreateHisto)
     FillCellQA(fCellEnergyDistBefore); // "before" QA
   
@@ -190,7 +190,9 @@ Bool_t AliEmcalCorrectionCellEmulateCrosstalk::Run()
   
   if(fCreateHisto)
     FillCellQA(fCellEnergyDistAfter); // "after" QA
-
+  
+  ResetArrays();
+  
   return kTRUE;
 }
 
@@ -458,6 +460,8 @@ void AliEmcalCorrectionCellEmulateCrosstalk::AddInducedEnergiesToExistingCells()
     
     amp+=fTCardCorrCellsEner[absId];
     
+    //if(fTCardCorrCellsEner[absId] > 0.05) printf("\t absId %d amp %2.2f\n",absId,fTCardCorrCellsEner[absId]);
+
     // Set new amplitude
     fCaloCells->SetCell(icell, absId, amp, time, mclabel, efrac);
   }
@@ -483,11 +487,11 @@ void AliEmcalCorrectionCellEmulateCrosstalk::AddInducedEnergiesToNewCells()
     Int_t     cellNumber = nCells;
     Short_t   absId      = j;
     Float_t   amp        = fTCardCorrCellsEner[j];
-    Double_t  time       = 615.*1e-9;;
+    Double_t  time       = 615.*1e-9;
     Int_t     mclabel    = -1;
     Double_t  efrac      = 0.;
     fCaloCells->SetCell(cellNumber, absId, amp, time, mclabel, efrac);
-    
+        
     nCells++;
   }
   
@@ -530,10 +534,10 @@ Bool_t AliEmcalCorrectionCellEmulateCrosstalk::AcceptCell(Int_t absID)
  */
 void AliEmcalCorrectionCellEmulateCrosstalk::PrintTCardParam()
 {
-  AliInfo(Form("T-Card emulation activated, energy conservation <%d>, randomize E <%d>, induced energy parameters:",
-        fTCardCorrClusEnerConserv,fRandomizeTCard));
-  AliInfo(Form("T-Card emulation super-modules fraction: Min cell E %2.2f Max induced E %2.2f",
-        fTCardCorrMinAmp,fTCardCorrMaxInduced));
+  printf("T-Card emulation activated, energy conservation <%d>, randomize E <%d>, induced energy parameters:\n",
+        fTCardCorrClusEnerConserv,fRandomizeTCard);
+  printf("T-Card emulation super-modules fraction: Min cell E %2.2f Max induced E %2.2f\n",
+        fTCardCorrMinAmp,fTCardCorrMaxInduced);
 
   for(Int_t ism = 0; ism < fgkNsm; ism++)
   {

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEmulateCrosstalk.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEmulateCrosstalk.h
@@ -14,7 +14,7 @@
  *
  * Based on code in AliAnalysisTaskEMCALClusterize.
  *
- * @author Gustavo Conesa Balbastre, LPSC-Grenoble, AliAnalysisTaskEMCALClusterize
+ * @author Gustavo Conesa Balbastre <Gustavo.Conesa.Balbastre@cern.ch>, LPSC-Grenoble, AliAnalysisTaskEMCALClusterize
  * @author Raymond Ehlers <raymond.ehlers@yale.edu>, Yale University, centralize EMCal corrections using components
  * @author James Mulligan <james.mulligan@yale.edu>, Yale University, centralize EMCal corrections using components
  * @date Feb 11 2018

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -66,7 +66,7 @@ CellEmulateCrosstalk:                               # Component to emulate cross
     enabled: false                                  # Whether to enable the task
     createHistos: false                             # Whether the task should create output histograms
     printConfiguration: false                       # Print the configuration after initialization
-    conservEnergy: false                            # Activate cluster energy conservation, not by default
+    conservEnergy: true                             # Activate cluster energy conservation
     randomizeTCardInducedEnergy: false              # Randomize the energy fraction induced by the TCard
     inducedTCardMinimumCellEnergy: 0.01             # Minimum cell energy induced by the TCard
     inducedTCardMaximum: 100                        # Maximum energy induced by the TCard


### PR DESCRIPTION
- Fix major bug, reset of temporal arrays with induced energy per channel at the end of the event
- Minor fixes like double semicolon and printf instead of AliInfo when print parameters is requested
- Add author mail
-Set default value for energy conservation as true