### PR TITLE
Revert moving to namespace EMCAL because of a problem with constants …

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalESDTrackCutsGenerator.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalESDTrackCutsGenerator.h
@@ -39,12 +39,12 @@
 
 class AliESDtrackCuts;
 class TString;
+class AliEmcalTrackSelection;
 
 namespace PWG {
 
 namespace EMCAL{
 
-class AliEmcalTrackSelection;
 
 class AliEmcalESDTrackCutsGenerator {
 public:

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.cxx
@@ -37,8 +37,8 @@
 #include "iostream"
 
 /// \cond CLASSIMP
-ClassImp(PWG::EMCAL::AliEmcalManagedObject)
-ClassImp(PWG::EMCAL::AliEmcalTrackSelection)
+ClassImp(AliEmcalManagedObject)
+ClassImp(AliEmcalTrackSelection)
 /// \endcond
 
 using namespace PWG::EMCAL;

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.h
@@ -43,6 +43,9 @@ namespace EMCAL {
 
 class AliEmcalCutBase;
 
+}
+}
+
 /**
  * @class AliEmcalManagedObject
  * @brief Smart pointer implementation for objects inheriting from TObject
@@ -350,8 +353,5 @@ protected:
 
 	/// \endcond
 };
-
-}
-}
 
 #endif /* ALIEMCALTRACKSELECTION_H_ */

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.cxx
@@ -45,7 +45,7 @@
 #include "AliPicoTrack.h"
 
 /// \cond CLASSIMP
-ClassImp(PWG::EMCAL::AliEmcalTrackSelectionAOD)
+ClassImp(AliEmcalTrackSelectionAOD)
 ClassImp(PWG::EMCAL::TestAliEmcalTrackSelectionAOD)
 /// \endcond
 

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.h
@@ -33,10 +33,6 @@
 class AliVCuts;
 class AliVTrack;
 
-namespace PWG {
-
-namespace EMCAL{
-
 class AliEmcalTrackSelResultHybrid;
 
 /**
@@ -133,6 +129,10 @@ private:
 	ClassDef(AliEmcalTrackSelectionAOD, 2);
 	/// \endcond
 };
+
+namespace PWG {
+
+namespace EMCAL{
 
 /**
  * @class TestAliEmcalTrackSelectionAOD

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionESD.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionESD.cxx
@@ -44,7 +44,7 @@
 #include "AliVCuts.h"
 
 /// \cond CLASSIMP
-ClassImp(PWG::EMCAL::AliEmcalTrackSelectionESD)
+ClassImp(AliEmcalTrackSelectionESD)
 /// \endcond
 
 using namespace PWG::EMCAL;

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionESD.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionESD.h
@@ -34,10 +34,6 @@ class TList;
 class AliVCuts;
 class AliVTrack;
 
-namespace PWG {
-
-namespace EMCAL {
-
 /**
  * @class AliEmcalTrackSelectionESD
  * @brief Implementation of virtual track selection for ESDs
@@ -101,9 +97,5 @@ public:
 	ClassDef(AliEmcalTrackSelectionESD,1);
 	/// \endcond
 };
-
-}
-
-}
 
 #endif /* ALIEMCALPTTASKTRACKSELECTIONESD_H_ */

--- a/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
@@ -54,7 +54,7 @@ TString AliTrackContainer::fgDefTrackCutsPeriod = "";
  */
 AliTrackContainer::AliTrackContainer():
   AliParticleContainer(),
-  fTrackFilterType(PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks),
+  fTrackFilterType(AliEmcalTrackSelection::kHybridTracks),
   fListOfCuts(0),
   fSelectionModeAny(kFALSE),
   fITSHybridTrackDistinction(kFALSE),
@@ -76,7 +76,7 @@ AliTrackContainer::AliTrackContainer():
  */
 AliTrackContainer::AliTrackContainer(const char *name, const char *period):
   AliParticleContainer(name),
-  fTrackFilterType(PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks),
+  fTrackFilterType(AliEmcalTrackSelection::kHybridTracks),
   fListOfCuts(0),
   fSelectionModeAny(kFALSE),
   fITSHybridTrackDistinction(kFALSE),
@@ -106,23 +106,23 @@ void AliTrackContainer::SetArray(const AliVEvent *event)
 {
   AliParticleContainer::SetArray(event);
 
-  if (fTrackFilterType == PWG::EMCAL::AliEmcalTrackSelection::kNoTrackFilter) {
+  if (fTrackFilterType == AliEmcalTrackSelection::kNoTrackFilter) {
     if (fEmcalTrackSelection) delete fEmcalTrackSelection;
     fEmcalTrackSelection = 0;
   }
   else {
-    if (fTrackFilterType == PWG::EMCAL::AliEmcalTrackSelection::kCustomTrackFilter) {
+    if (fTrackFilterType == AliEmcalTrackSelection::kCustomTrackFilter) {
 
       AliInfo("Using custom track cuts");
 
       if (fLoadedClass) {
         if (fLoadedClass->InheritsFrom("AliAODTrack")) {
           AliInfo(Form("Objects are of type %s: AOD track selection will be done.", fLoadedClass->GetName()));
-          fEmcalTrackSelection = new PWG::EMCAL::AliEmcalTrackSelectionAOD(0, fAODFilterBits);
+          fEmcalTrackSelection = new AliEmcalTrackSelectionAOD(0, fAODFilterBits);
         }
         else if (fLoadedClass->InheritsFrom("AliESDtrack")) {
           AliInfo(Form("Objects are of type %s: ESD track selection will be done.", fLoadedClass->GetName()));
-          fEmcalTrackSelection = new PWG::EMCAL::AliEmcalTrackSelectionESD(0);
+          fEmcalTrackSelection = new AliEmcalTrackSelectionESD(0);
         }
         else {
           AliWarning(Form("Objects are of type %s: no track filtering will be done!!", fLoadedClass->GetName()));
@@ -150,11 +150,11 @@ void AliTrackContainer::SetArray(const AliVEvent *event)
 
       if (fLoadedClass->InheritsFrom("AliAODTrack")) {
         AliInfo(Form("Objects are of type %s: AOD track selection will be done.", fLoadedClass->GetName()));
-        fEmcalTrackSelection = new PWG::EMCAL::AliEmcalTrackSelectionAOD(fTrackFilterType, fTrackCutsPeriod);
+        fEmcalTrackSelection = new AliEmcalTrackSelectionAOD(fTrackFilterType, fTrackCutsPeriod);
       }
       else if (fLoadedClass->InheritsFrom("AliESDtrack")) {
         AliInfo(Form("Objects are of type %s: ESD track selection will be done.", fLoadedClass->GetName()));
-        fEmcalTrackSelection = new PWG::EMCAL::AliEmcalTrackSelectionESD(fTrackFilterType, fTrackCutsPeriod);
+        fEmcalTrackSelection = new AliEmcalTrackSelectionESD(fTrackFilterType, fTrackCutsPeriod);
       }
       else {
         AliWarning(Form("Objects are of type %s: no track filtering will be done!!", fLoadedClass->GetName()));
@@ -603,11 +603,11 @@ AliVCuts* AliTrackContainer::GetTrackCuts(Int_t icut)
 }
 
 bool AliTrackContainer::IsHybridTrackSelection() const {
-  return (fTrackFilterType == PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks) ||
-         (fTrackFilterType == PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks2010wNoRefit) ||
-         (fTrackFilterType == PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks2010woNoRefit) ||
-         (fTrackFilterType == PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks2011wNoRefit) ||
-         (fTrackFilterType == PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks2011woNoRefit);
+  return (fTrackFilterType == AliEmcalTrackSelection::kHybridTracks) ||
+         (fTrackFilterType == AliEmcalTrackSelection::kHybridTracks2010wNoRefit) ||
+         (fTrackFilterType == AliEmcalTrackSelection::kHybridTracks2010woNoRefit) ||
+         (fTrackFilterType == AliEmcalTrackSelection::kHybridTracks2011wNoRefit) ||
+         (fTrackFilterType == AliEmcalTrackSelection::kHybridTracks2011woNoRefit);
 }
 
 PWG::EMCAL::AliEmcalTrackSelResultHybrid::HybridType_t AliTrackContainer::GetHybridDefinition(const PWG::EMCAL::AliEmcalTrackSelResultPtr &selectionResult) const {

--- a/PWG/EMCAL/EMCALbase/AliTrackContainer.h
+++ b/PWG/EMCAL/EMCALbase/AliTrackContainer.h
@@ -90,7 +90,7 @@ class AliTrackContainer : public AliParticleContainer {
     /// @endcond
   };
 
-  typedef PWG::EMCAL::AliEmcalTrackSelection::ETrackFilterType_t ETrackFilterType_t;
+  typedef AliEmcalTrackSelection::ETrackFilterType_t ETrackFilterType_t;
 
   /**
    * @enum ETrackType_t
@@ -139,7 +139,7 @@ class AliTrackContainer : public AliParticleContainer {
   void                        SetArray(const AliVEvent *event);
 
   void                        SetTrackFilterType(ETrackFilterType_t f)          { fTrackFilterType = f; }
-  void                        SetFilterHybridTracks(Bool_t f)                   { if (f) fTrackFilterType = PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks; else fTrackFilterType = PWG::EMCAL::AliEmcalTrackSelection::kNoTrackFilter; }   // legacy method
+  void                        SetFilterHybridTracks(Bool_t f)                   { if (f) fTrackFilterType = AliEmcalTrackSelection::kHybridTracks; else fTrackFilterType = AliEmcalTrackSelection::kNoTrackFilter; }   // legacy method
   void                        SetITSHybridTrackDistinction(Bool_t doUse)        { fITSHybridTrackDistinction = doUse; }
 
   void                        SetTrackCutsPeriod(const char* period)            { fTrackCutsPeriod = period; }
@@ -197,7 +197,7 @@ class AliTrackContainer : public AliParticleContainer {
   Bool_t                      fITSHybridTrackDistinction;     ///< Distinct hybrid tracks via SPD information
   UInt_t                      fAODFilterBits;                 ///< track filter bits
   TString                     fTrackCutsPeriod;               ///< period string used to generate track cuts
-  PWG::EMCAL::AliEmcalTrackSelection     *fEmcalTrackSelection;  //!<! track selection object
+  AliEmcalTrackSelection     *fEmcalTrackSelection;  //!<! track selection object
   TrackOwnerHandler           fFilteredTracks;                //!<! tracks filtered using fEmcalTrackSelection
   TArrayC                     fTrackTypes;                    //!<! track types
 

--- a/PWG/EMCAL/EMCALbase/PWGEMCALbaseLinkDef.h
+++ b/PWG/EMCAL/EMCALbase/PWGEMCALbaseLinkDef.h
@@ -14,6 +14,10 @@
 #pragma link C++ class AliEmcalParticle+;
 #pragma link C++ class AliEmcalPhysicsSelection+;
 #pragma link C++ class AliEmcalPythiaInfo+;
+#pragma link C++ class AliEmcalManagedObject+;
+#pragma link C++ class AliEmcalTrackSelection+;
+#pragma link C++ class AliEmcalTrackSelectionESD+;
+#pragma link C++ class AliEmcalTrackSelectionAOD+;
 #pragma link C++ class AliParticleContainer+;
 #pragma link C++ class AliPicoTrack+;
 #pragma link C++ class AliMCParticleContainer+;
@@ -28,10 +32,6 @@
 #pragma link C++ namespace PWG;
 #pragma link C++ namespace PWG::EMCAL;
 #pragma link C++ class PWG::EMCAL::AliEmcalDownscaleFactorsOCDB+;
-#pragma link C++ class PWG::EMCAL::AliEmcalManagedObject+;
-#pragma link C++ class PWG::EMCAL::AliEmcalTrackSelection+;
-#pragma link C++ class PWG::EMCAL::AliEmcalTrackSelectionESD+;
-#pragma link C++ class PWG::EMCAL::AliEmcalTrackSelectionAOD+;
 #pragma link C++ class PWG::EMCAL::AliEmcalTrackSelResultPtr+;
 #pragma link C++ class PWG::EMCAL::AliEmcalTrackSelResultUserPtr+;
 #pragma link C++ class PWG::EMCAL::AliEmcalTrackSelResultUserStorage+;

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
@@ -41,11 +41,11 @@ const std::map <std::string, AliVCluster::VCluUserDefEnergy_t> AliEmcalCorrectio
   {"kUserDefEnergy2", AliVCluster::kUserDefEnergy2 }
 };
 
-const std::map <std::string, PWG::EMCAL::AliEmcalTrackSelection::ETrackFilterType_t> AliEmcalCorrectionTask::fgkTrackFilterTypeMap = {
-  {"kNoTrackFilter", PWG::EMCAL::AliEmcalTrackSelection::kNoTrackFilter },
-  {"kCustomTrackFilter", PWG::EMCAL::AliEmcalTrackSelection::kCustomTrackFilter },
-  {"kHybridTracks",  PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks },
-  {"kTPCOnlyTracks", PWG::EMCAL::AliEmcalTrackSelection::kTPCOnlyTracks }
+const std::map <std::string, AliEmcalTrackSelection::ETrackFilterType_t> AliEmcalCorrectionTask::fgkTrackFilterTypeMap = {
+  {"kNoTrackFilter", AliEmcalTrackSelection::kNoTrackFilter },
+  {"kCustomTrackFilter", AliEmcalTrackSelection::kCustomTrackFilter },
+  {"kHybridTracks",  AliEmcalTrackSelection::kHybridTracks },
+  {"kTPCOnlyTracks", AliEmcalTrackSelection::kTPCOnlyTracks }
 };
 
 /**
@@ -955,7 +955,7 @@ void AliEmcalCorrectionTask::SetupContainer(const AliEmcalContainerUtils::InputO
     result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "trackFilterType", tempString, false);
     if (result) {
       // Need to get the enumeration
-      PWG::EMCAL::AliEmcalTrackSelection::ETrackFilterType_t trackFilterType = fgkTrackFilterTypeMap.at(tempString);
+      AliEmcalTrackSelection::ETrackFilterType_t trackFilterType = fgkTrackFilterTypeMap.at(tempString);
       AliDebugStream(2) << trackContainer->GetName() << ": Setting trackFilterType of " << trackFilterType << std::endl;
       trackContainer->SetTrackFilterType(trackFilterType);
     }

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
@@ -57,7 +57,7 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
   static const std::map <std::string, AliVCluster::VCluUserDefEnergy_t> fgkClusterEnergyTypeMap; //!<!
 
   /// Relates string to the track filter enumeration for %YAML configuration
-  static const std::map <std::string, PWG::EMCAL::AliEmcalTrackSelection::ETrackFilterType_t> fgkTrackFilterTypeMap; //!<!
+  static const std::map <std::string, AliEmcalTrackSelection::ETrackFilterType_t> fgkTrackFilterTypeMap; //!<!
 
   AliEmcalCorrectionTask();
   AliEmcalCorrectionTask(const char * name);

--- a/PWG/EMCAL/macros/AddTaskEmcalTestIterators.C
+++ b/PWG/EMCAL/macros/AddTaskEmcalTestIterators.C
@@ -39,7 +39,7 @@ AliAnalysisTaskEmcalIteratorTest *AddTaskEmcalTestIterators(
   testtask->SetTrackContainerName(nameTrackContainer);
   trackcont->SetEtaLimits(-0.5, 0.5);
   trackcont->SetMinPt(0.8);
-  trackcont->SetTrackFilterType(PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks);
+  trackcont->SetTrackFilterType(AliEmcalTrackSelection::kHybridTracks);
   trackcont->SetTrackCutsPeriod(period.Data());
 
   TString filename = mgr->GetCommonFileName();

--- a/PWGGA/EMCALTasks/AliAnalysisTaskEMCALClusterTurnOn.cxx
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskEMCALClusterTurnOn.cxx
@@ -508,7 +508,7 @@ Bool_t AliAnalysisTaskEMCALClusterTurnOn::Run()
     return kFALSE;
   }
   
-  if(tracks->GetTrackFilterType()!= PWG::EMCAL::AliEmcalTrackSelection::kTPCOnlyTracks){
+  if(tracks->GetTrackFilterType()!= AliEmcalTrackSelection::kTPCOnlyTracks){
     AliWarning(Form("CT matching NOT performed with TPCOnly Tracks"));
     AliWarning(Form("You better be sure of what you are doing"));
   }
@@ -522,7 +522,7 @@ Bool_t AliAnalysisTaskEMCALClusterTurnOn::Run()
     //  Printf("FilterType of the tracks for Analysis: %d \t(should be %d)", tracksANA->GetTrackFilterType(),AliEmcalTrackSelection::kHybridTracks);
   
     //    AliError(Form("\n\n\n\nGO CHECK the Settings!!!! Is Isolation calculated with filteredTracks?\n\n\n\n"));
-  if(tracksANA->GetTrackFilterType()!= PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks){
+  if(tracksANA->GetTrackFilterType()!= AliEmcalTrackSelection::kHybridTracks){
     AliWarning(Form("Isolation NOT calculated with HybridTracks"));
     AliWarning(Form("You better be sure of what you are doing"));
   }
@@ -974,7 +974,7 @@ Bool_t AliAnalysisTaskEMCALClusterTurnOn::ClustTrackMatching(AliVCluster *clust)
   clust->GetMomentum(vecClust,fVertex);
   
   Int_t nbMObj = clust -> GetNTracksMatched();
-  if(tracks->GetTrackFilterType()!=PWG::EMCAL::AliEmcalTrackSelection::kTPCOnlyTracks)  AliError(Form("NO TPC only tracks"));
+  if(tracks->GetTrackFilterType()!=AliEmcalTrackSelection::kTPCOnlyTracks)  AliError(Form("NO TPC only tracks"));
   
   
   if (nbMObj == 0) return kFALSE;

--- a/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.cxx
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.cxx
@@ -1308,7 +1308,7 @@ Bool_t AliAnalysisTaskEMCALPhotonIsolation::Run()
     return kFALSE;
   }
 
-  if(tracks->GetTrackFilterType() != PWG::EMCAL::AliEmcalTrackSelection::kTPCOnlyTracks){
+  if(tracks->GetTrackFilterType() != AliEmcalTrackSelection::kTPCOnlyTracks){
     AliWarning(Form("CT matching NOT performed with TPCOnly tracks"));
     AliWarning(Form("You better be sure of what you are doing"));
   }
@@ -1321,7 +1321,7 @@ Bool_t AliAnalysisTaskEMCALPhotonIsolation::Run()
 
   // AliWarning(Form("FilterType of the tracks for Analysis: %d \t(should be %d)", tracksANA->GetTrackFilterType(),AliEmcalTrackSelection::kHybridTracks));
 
-  if(tracksANA->GetTrackFilterType() != PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks){
+  if(tracksANA->GetTrackFilterType() != AliEmcalTrackSelection::kHybridTracks){
     AliWarning(Form("Isolation NOT calculated with HybridTracks"));
     AliWarning(Form("You better be sure of what you are doing"));
   }
@@ -1591,7 +1591,7 @@ Bool_t AliAnalysisTaskEMCALPhotonIsolation::ClustTrackMatching(AliVCluster *clus
     // Check if the cluster matches a track
 
   AliTrackContainer* tracks = GetTrackContainer("tpconlyMatch");
-  if(tracks->GetTrackFilterType() != PWG::EMCAL::AliEmcalTrackSelection::kTPCOnlyTracks)
+  if(tracks->GetTrackFilterType() != AliEmcalTrackSelection::kTPCOnlyTracks)
     AliError(Form("No TPC only tracks"));
 
   TLorentzVector vecClust;
@@ -2379,7 +2379,7 @@ void AliAnalysisTaskEMCALPhotonIsolation::EtIsoClusEtaBand(TLorentzVector c, Dou
     return;
   }
 
-  if(tracksAna->GetTrackFilterType() != PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks)
+  if(tracksAna->GetTrackFilterType() != AliEmcalTrackSelection::kHybridTracks)
     AliError(Form("NOT Hybrid Tracks"));
 
   tracksAna->ResetCurrentID();

--- a/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPi0GammaCorr.cxx
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPi0GammaCorr.cxx
@@ -706,7 +706,7 @@ Float_t AliAnalysisTaskEMCALPi0GammaCorr::ClustTrackMatching(AliVCluster *clust,
     AliError(Form("Could not retrieve tracks !"));
   }
 
-  if(tracks->GetTrackFilterType()!=PWG::EMCAL::AliEmcalTrackSelection::kTPCOnlyTracks)  AliError(Form("NO TPC only tracks"));
+  if(tracks->GetTrackFilterType()!=AliEmcalTrackSelection::kTPCOnlyTracks)  AliError(Form("NO TPC only tracks"));
   AliVTrack* mt = 0;
   TLorentzVector vecClust;
   clust->GetMomentum(vecClust,fVertex);

--- a/PWGGA/EMCALTasks/AliAnalysisTaskEMCALTrackIsolation.cxx
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskEMCALTrackIsolation.cxx
@@ -531,7 +531,7 @@ Bool_t AliAnalysisTaskEMCALTrackIsolation::Run()
     //  //Printf("FilterType of the tracks for Analysis: %d \t(should be %d)", tracksANA->GetTrackFilterType(),AliEmcalTrackSelection::kHybridTracks);
   
     //    AliError(Form("\n\n\n\nGO CHECK the Settings!!!! Is Isolation calculated with filteredTracks?\n\n\n\n"));
-  if(tracksANA->GetTrackFilterType()!= PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks){
+  if(tracksANA->GetTrackFilterType()!= AliEmcalTrackSelection::kHybridTracks){
     AliWarning(Form("Isolation NOT calculated with HybridTracks"));
     AliWarning(Form("You better be sure of what you are doing"));
   }

--- a/PWGGA/EMCALTasks/macros/AddTaskEMCALClusterTurnOn.C
+++ b/PWGGA/EMCALTasks/macros/AddTaskEMCALClusterTurnOn.C
@@ -137,7 +137,7 @@ AliAnalysisTaskEMCALClusterTurnOn* AddTaskEMCALClusterTurnOn(
   if(!trackCont)
     Printf("Error with TPCOnly!!");
   trackCont->SetName("tpconlyMatch");
-  trackCont->SetTrackFilterType(PWG::EMCAL::AliEmcalTrackSelection::kTPCOnlyTracks);
+  trackCont->SetTrackFilterType(AliEmcalTrackSelection::kTPCOnlyTracks);
     // clusters to be used in the analysis already filtered
   AliClusterContainer *clusterCont = task->AddClusterContainer(nclusters);
   

--- a/PWGGA/EMCALTasks/macros/AddTaskEMCALPhotonIsolation.C
+++ b/PWGGA/EMCALTasks/macros/AddTaskEMCALPhotonIsolation.C
@@ -262,7 +262,7 @@ AliAnalysisTaskEMCALPhotonIsolation* AddTaskEMCALPhotonIsolation(
   AliTrackContainer *trackCont = task->AddTrackContainer(trackName);
   if(!trackCont) Printf("Error with TPC-Only Tracks!!");
   trackCont->SetName("tpconlyMatch");
-  trackCont->SetTrackFilterType(PWG::EMCAL::AliEmcalTrackSelection::kTPCOnlyTracks);
+  trackCont->SetTrackFilterType(AliEmcalTrackSelection::kTPCOnlyTracks);
   
   // Tracks to be used in the analysis (Hybrid Tracks)
   AliTrackContainer * tracksForAnalysis = task->AddTrackContainer(trackName);

--- a/PWGGA/EMCALTasks/macros/AddTaskEMCALPi0GammaCorr.C
+++ b/PWGGA/EMCALTasks/macros/AddTaskEMCALPi0GammaCorr.C
@@ -43,12 +43,12 @@ AliAnalysisTaskEMCALPi0GammaCorr* AddTaskEMCALPi0GammaCorr(Bool_t isMC=kFALSE)
   AliTrackContainer* trackContMatching = AnalysisTask->AddTrackContainer("usedefault");
   if(!trackContMatching) ::Error("AddTask", "Track container not found" ) ;
   trackContMatching->SetName("ForMatching");
-  trackContMatching->SetTrackFilterType(PWG::EMCAL::AliEmcalTrackSelection::kTPCOnlyTracks);  
+  trackContMatching->SetTrackFilterType(AliEmcalTrackSelection::kTPCOnlyTracks);  
 
 
   AliTrackContainer* trackITSOnly  = AnalysisTask->AddTrackContainer("usedefault");
   trackITSOnly->SetName("ITSOnly");
-  trackITSOnly->SetTrackFilterType(PWG::EMCAL::AliEmcalTrackSelection::kCustomTrackFilter);
+  trackITSOnly->SetTrackFilterType(AliEmcalTrackSelection::kCustomTrackFilter);
   AliESDtrackCuts* myCuts = AliESDtrackCuts::GetStandardITSPureSATrackCuts2010();
   trackITSOnly->AddTrackCuts(myCuts);
   

--- a/PWGHF/jetsHF/macros/AddTaskBJetTC.C
+++ b/PWGHF/jetsHF/macros/AddTaskBJetTC.C
@@ -122,7 +122,7 @@ AliAnalysisTaskBJetTC* AddTaskBJetTC(
 	jetTask->DoPtRelAnalysis(DoPtRelAna);
 			
 	AliTrackContainer *trackCont  = jetTask->AddTrackContainer(ntracks);
-	trackCont->SetTrackFilterType(PWG::EMCAL::AliEmcalTrackSelection::kCustomTrackFilter);
+	trackCont->SetTrackFilterType(AliEmcalTrackSelection::kCustomTrackFilter);
 	trackCont->SetAODFilterBits((1<<4)|(1<<9));
 
 	AliClusterContainer *clusterCont = jetTask->AddClusterContainer(nclusters);

--- a/PWGJE/EMCALJetTasks/AliAnalysisTaskEmcalJetQA.cxx
+++ b/PWGJE/EMCALJetTasks/AliAnalysisTaskEmcalJetQA.cxx
@@ -882,7 +882,7 @@ void AliAnalysisTaskEmcalJetQA::DoTrackLoop()
         AliTrackContainer* tracks = dynamic_cast<AliTrackContainer*>(particles);
         if (tracks) {
           // Track type (hybrid)
-          if (tracks->GetTrackFilterType() == PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks) {
+          if (tracks->GetTrackFilterType() == AliEmcalTrackSelection::kHybridTracks) {
             type = tracks->GetTrackType(it.current_index());
           }
         }

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskChargedParticlesMCTriggerMimic.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskChargedParticlesMCTriggerMimic.h
@@ -17,15 +17,7 @@ class AliGenPythiaEventHeader;
 class AliMCEvent;
 class AliVParticle;
 
-namespace PWG{
-
-namespace EMCAL {
-
 class AliEmcalTrackSelection;
-
-}
-
-}
 
 namespace EMCalTriggerPtAnalysis {
 
@@ -86,7 +78,7 @@ public:
   void                        SetBeamDirection(BeamDirection_t beamdir) { fEtaSign = static_cast<Double_t>(beamdir); }
 
   void                        SetAnalysisUtil(AliAnalysisUtils *util) { fAliAnalysisUtils = util; }
-  void                        SetEmcalTrackSelection(PWG::EMCAL::AliEmcalTrackSelection * sel) { fTrackCuts = sel; }
+  void                        SetEmcalTrackSelection(AliEmcalTrackSelection * sel) { fTrackCuts = sel; }
   void                        SetEtaLabCut(double etamin, double etamax) { fEtaLabCut.SetLimits(etamin, etamax); }
   void                        SetEtaCMSCut(double etamin, double etamax) { fEtaCmsCut.SetLimits(etamin, etamax); }
   void                        SetTrackPhiCut(double phimin, double phimax) { fPhiCut.SetLimits(phimin, phimax); }
@@ -124,7 +116,7 @@ private:
   AliAnalysisTaskChargedParticlesMCTriggerMimic &operator=(const AliAnalysisTaskChargedParticlesMCTriggerMimic &);
 
 
-  PWG::EMCAL::AliEmcalTrackSelection    *fTrackCuts;                ///< Standard track selection
+  AliEmcalTrackSelection    *fTrackCuts;                ///< Standard track selection
   THistManager                          *fHistos;                   ///< Histogram manager
   const AliEMCalTriggerWeightHandler    *fWeightHandler;            ///< Weight handler (optional)
 

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskChargedParticlesRef.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskChargedParticlesRef.h
@@ -10,15 +10,7 @@
 #include <TString.h>
 
 class THistManager;
-
-namespace PWG {
-
-namespace EMCAL {
-
 class AliEmcalTrackSelection;
-}
-
-}
 
 namespace EMCalTriggerPtAnalysis {
 
@@ -117,7 +109,7 @@ public:
    * Assumes that the track selection object is already fully configured
    * @param[in] sel Virtual track selection
    */
-  void SetEMCALTrackSelection(PWG::EMCAL::AliEmcalTrackSelection *sel) { fTrackCuts = sel; }
+  void SetEMCALTrackSelection(AliEmcalTrackSelection *sel) { fTrackCuts = sel; }
 
   /**
    * @brief Define cut on \f$ \eta_{lab} \f$ used to select tracks
@@ -256,7 +248,7 @@ protected:
    */
   bool IsExoticsTrigger(const TString &trg);
 
-  PWG::EMCAL::AliEmcalTrackSelection *fTrackCuts;                ///< Standard track selection
+  AliEmcalTrackSelection *fTrackCuts;                ///< Standard track selection
 
   Double_t                        fYshift;                    ///< Rapidity shift
   Double_t                        fEtaSign;                   ///< Sign of the eta distribution (swaps when beam directions swap): p-Pb: +1, Pb-p: -1

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskChargedParticlesRefMC.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskChargedParticlesRefMC.h
@@ -21,16 +21,7 @@ class AliESDtrack;
 class AliGenPythiaEventHeader;
 class AliVParticle;
 class AliMCEvent;
-
-namespace PWG {
-
-namespace EMCAL {
-
 class AliEmcalTrackSelection;
-
-}
-
-}
 
 namespace EMCalTriggerPtAnalysis {
 
@@ -117,7 +108,7 @@ public:
    * Assumes that the track selection object is already fully configured
    * @param[in] sel Virtual track selection
    */
-  void SetEMCALTrackSelection(PWG::EMCAL::AliEmcalTrackSelection *sel) { fTrackCuts = sel; }
+  void SetEMCALTrackSelection(AliEmcalTrackSelection *sel) { fTrackCuts = sel; }
 
   /**
    * Define kinematic cut to particles and tracks on \f$ \eta \f$ in the lab frame. By default
@@ -361,7 +352,7 @@ private:
   AliAnalysisTaskChargedParticlesRefMC(const AliAnalysisTaskChargedParticlesRefMC &);
   AliAnalysisTaskChargedParticlesRefMC &operator=(const AliAnalysisTaskChargedParticlesRefMC &);
 
-  PWG::EMCAL::AliEmcalTrackSelection    *fTrackCuts;                ///< Standard track selection
+  AliEmcalTrackSelection    *fTrackCuts;                ///< Standard track selection
   AliEmcalTriggerOfflineSelection       *fTriggerSelection;         ///< Offline trigger selection
   THistManager                          *fHistos;                   ///< Histogram manager
   const AliEMCalTriggerWeightHandler    *fWeightHandler;            ///< Weight handler (optional)

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalClusterMatched.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalClusterMatched.cxx
@@ -165,19 +165,19 @@ bool AliAnalysisTaskEmcalClusterMatched::Run(){
 
 void AliAnalysisTaskEmcalClusterMatched::InitializeTrackSelections(bool isAOD){
   if(isAOD){
-    PWG::EMCAL::AliEmcalTrackSelectionAOD *globalAOD = new PWG::EMCAL::AliEmcalTrackSelectionAOD;
+    AliEmcalTrackSelectionAOD *globalAOD = new AliEmcalTrackSelectionAOD;
     globalAOD->AddFilterBit(AliAODTrack::kTrkGlobal);
     fTrackSelectionGlobal = globalAOD;
 
-    PWG::EMCAL::AliEmcalTrackSelectionAOD *tpcOnlyAOD = new PWG::EMCAL::AliEmcalTrackSelectionAOD;
+    AliEmcalTrackSelectionAOD *tpcOnlyAOD = new AliEmcalTrackSelectionAOD;
     tpcOnlyAOD->AddFilterBit(AliAODTrack::kTrkTPCOnly);
     fTrackSelectionTPConly = tpcOnlyAOD;
   } else {
-    PWG::EMCAL::AliEmcalTrackSelectionESD *globalESD = new PWG::EMCAL::AliEmcalTrackSelectionESD;
+    AliEmcalTrackSelectionESD *globalESD = new AliEmcalTrackSelectionESD;
     globalESD->AddTrackCuts(AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(true, 1));
     fTrackSelectionGlobal = globalESD;
 
-    PWG::EMCAL::AliEmcalTrackSelectionESD *tpcOnlyESD = new PWG::EMCAL::AliEmcalTrackSelectionESD;
+    AliEmcalTrackSelectionESD *tpcOnlyESD = new AliEmcalTrackSelectionESD;
     tpcOnlyESD->AddTrackCuts(AliESDtrackCuts::GetStandardTPCOnlyTrackCuts());
     fTrackSelectionTPConly = tpcOnlyESD;
   }

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalClusterMatched.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalClusterMatched.h
@@ -8,16 +8,7 @@
 #include <TCustomBinning.h>
 #include <TString.h>
 
-namespace PWG{
-
-namespace EMCAL {
-
 class AliEmcalTrackSelection;
-
-}
-
-}
-
 
 namespace EMCalTriggerPtAnalysis {
 
@@ -125,8 +116,8 @@ private:
   AliAnalysisTaskEmcalClusterMatched(const AliAnalysisTaskEmcalClusterMatched &);
   AliAnalysisTaskEmcalClusterMatched &operator=(const AliAnalysisTaskEmcalClusterMatched &);
 
-  PWG::EMCAL::AliEmcalTrackSelection       *fTrackSelectionGlobal;                  ///< Global track cuts (strong condition)
-  PWG::EMCAL::AliEmcalTrackSelection       *fTrackSelectionTPConly;                 ///< TPC-only track cuts (weak condition)
+  AliEmcalTrackSelection       *fTrackSelectionGlobal;                  ///< Global track cuts (strong condition)
+  AliEmcalTrackSelection       *fTrackSelectionTPConly;                 ///< TPC-only track cuts (weak condition)
   AliCutValueRange<double>                  fTimeCut;                               ///< Cut on cluster time
   Bool_t                                    fEnableSumw2;                           ///< Enable Sumw2
 

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerMultiplicity.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerMultiplicity.h
@@ -5,15 +5,7 @@
 
 #include "AliAnalysisTaskEmcalTriggerBase.h"
 
-namespace PWG{
-
-namespace EMCAL{
-
 class AliEmcalTrackSelection;
-
-}
-
-}
 
 namespace EMCalTriggerPtAnalysis {
 
@@ -68,7 +60,7 @@ public:
    * track multiplicity
    * @param[in] sel Track selection object
    */
-  void SetEmcalTrackSelection(PWG::EMCAL::AliEmcalTrackSelection *sel) { fTrackSel = sel; }
+  void SetEmcalTrackSelection(AliEmcalTrackSelection *sel) { fTrackSel = sel; }
 
 
   /**
@@ -105,7 +97,7 @@ protected:
   virtual bool Run();
 
 private:
-  PWG::EMCAL::AliEmcalTrackSelection     *fTrackSel;         ///< EMCAL virtual track selection
+  AliEmcalTrackSelection     *fTrackSel;         ///< EMCAL virtual track selection
   Bool_t                                  fEnableSumw2;       ///< Setter for enabling Sumw2
 
   AliAnalysisTaskEmcalTriggerMultiplicity(const AliAnalysisTaskEmcalTriggerMultiplicity &);

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskParticleInJet.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskParticleInJet.h
@@ -17,16 +17,7 @@ class THistManager;
 
 class AliVParticle;
 class AliVTrack;
-
-namespace PWG {
-
-namespace EMCAL {
-
 class AliEmcalTrackSelection;
-
-}
-
-}
 
 class AliAnalysisTaskParticleInJet: public AliAnalysisTaskEmcalJet {
 public:
@@ -34,7 +25,7 @@ public:
   AliAnalysisTaskParticleInJet(const char *name);
   virtual ~AliAnalysisTaskParticleInJet();
 
-  void SetTrackSelection(PWG::EMCAL::AliEmcalTrackSelection *sel)     { fTrackSelection = sel; }
+  void SetTrackSelection(AliEmcalTrackSelection *sel)     { fTrackSelection = sel; }
   void SetParticleContainerNameRec(TString name)          { fParticleContainerNameRec = name; }
   void SetParticleContainerNameMC(TString name)           { fParticleContainerNameMC = name;}
   void SetJetContainerNameRec(TString name)               { fJetContainerNameRec = name; }
@@ -54,7 +45,7 @@ private:
   void CreateLinearBinning(TArrayD& binning, int nbins, double min, double max) const;
 
   THistManager                    *fHistMgr;
-  PWG::EMCAL::AliEmcalTrackSelection          *fTrackSelection;
+  AliEmcalTrackSelection          *fTrackSelection;
 
   // Container names
   TString                         fParticleContainerNameRec;

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskPtEMCalTrigger.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskPtEMCalTrigger.cxx
@@ -295,8 +295,8 @@ namespace EMCalTriggerPtAnalysis {
     fOutput->Add(fHistos->GetListOfHistograms());
     if(fListTrackCuts && fListTrackCuts->GetEntries()){
       TIter cutIter(fListTrackCuts);
-      PWG::EMCAL::AliEmcalTrackSelection *cutObject(NULL);
-      while((cutObject = dynamic_cast<PWG::EMCAL::AliEmcalTrackSelection *>(cutIter()))){
+      AliEmcalTrackSelection *cutObject(NULL);
+      while((cutObject = dynamic_cast<AliEmcalTrackSelection *>(cutIter()))){
         PWG::EMCAL::AliEmcalVCutsWrapper *trackcuts = dynamic_cast<PWG::EMCAL::AliEmcalVCutsWrapper *>(cutObject->GetTrackCuts(0));
         if(trackcuts){
           PWG::EMCAL::AliEmcalESDtrackCutsWrapper *esdcuts = dynamic_cast<PWG::EMCAL::AliEmcalESDtrackCutsWrapper *>(trackcuts->GetCutObject());
@@ -522,7 +522,7 @@ namespace EMCalTriggerPtAnalysis {
     // found in a jet, and check for different cone radii around a jet
     if(fListTrackCuts && fListTrackCuts->GetEntries()){
       for(int icut = 0; icut < fListTrackCuts->GetEntries(); icut++){
-        PWG::EMCAL::AliEmcalTrackSelection *trackSelection = static_cast<PWG::EMCAL::AliEmcalTrackSelection *>(fListTrackCuts->At(icut));
+        AliEmcalTrackSelection *trackSelection = static_cast<AliEmcalTrackSelection *>(fListTrackCuts->At(icut));
         TIter trackIter(trackSelection->GetAcceptedTracks(fTracks));
         while((track = dynamic_cast<AliVTrack *>(trackIter()))){
           if(fMCEvent && !IsTrueTrack(track)) continue;   // Reject fake tracks in case of MC
@@ -846,7 +846,7 @@ namespace EMCalTriggerPtAnalysis {
    * @param trackCuts Object of type AliESDtrackCuts
    */
   void AliAnalysisTaskPtEMCalTrigger::AddESDTrackCuts(AliESDtrackCuts* trackCuts) {
-    fListTrackCuts->AddLast(new PWG::EMCAL::AliEmcalTrackSelectionESD(trackCuts));
+    fListTrackCuts->AddLast(new AliEmcalTrackSelectionESD(trackCuts));
   }
 
   /**
@@ -855,7 +855,7 @@ namespace EMCalTriggerPtAnalysis {
    * @param trackCuts Object of type AliESDtrackCuts
    */
   void AliAnalysisTaskPtEMCalTrigger::AddCutsForAOD(AliESDtrackCuts* trackCuts, UInt_t filterbits) {
-    fListTrackCuts->AddLast(new PWG::EMCAL::AliEmcalTrackSelectionAOD(trackCuts, filterbits));
+    fListTrackCuts->AddLast(new AliEmcalTrackSelectionAOD(trackCuts, filterbits));
   }
 
 

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskPtEfficiencyJets.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskPtEfficiencyJets.h
@@ -13,15 +13,7 @@ class AliVParticle;
 class AliVTrack;
 class TNtuple;
 
-namespace PWG {
-
-namespace EMCAL {
-
 class AliEmcalTrackSelection;
-
-}
-
-}
 
 namespace EMCalTriggerPtAnalysis {
 
@@ -36,7 +28,7 @@ public:
   virtual Bool_t Run();
 
   void SetMCJetContainer(const char *name) { fMCJetContainer = name; }
-  void SetTrackCuts(PWG::EMCAL::AliEmcalTrackSelection *cuts) { fTrackCuts = cuts; }
+  void SetTrackCuts(AliEmcalTrackSelection *cuts) { fTrackCuts = cuts; }
 
 protected:
   AliVTrack *FindAssociatedTrack(AliVParticle *trueParticle);
@@ -49,7 +41,7 @@ private:
 
   AliAnalysisUtils                    *fAnalysisUtils;
   TString                             fMCJetContainer;
-  PWG::EMCAL::AliEmcalTrackSelection  *fTrackCuts;
+  AliEmcalTrackSelection  *fTrackCuts;
   TNtuple                             *fTrackNtuple;
 
   ClassDef(AliAnalysisTaskPtEfficiencyJets, 1);

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskTrackDensity.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskTrackDensity.h
@@ -17,16 +17,7 @@
 class AliEmcalJet;
 class AliParticleContainer;
 class AliVEvent;
-
-namespace PWG {
-
-namespace EMCAL {
-
 class AliEmcalTrackSelection;
-
-}
-
-}
 
 namespace EMCalTriggerPtAnalysis {
 
@@ -43,7 +34,7 @@ public:
 
   void SetMCJetContainer(TString contname) { fMCJetContainerName = contname; }
   void SetMCParticleContainer(TString contname) { fMCParticleContainerName = contname; }
-  void SetTrackSelection(PWG::EMCAL::AliEmcalTrackSelection *trackSelection) { fTrackSelection = trackSelection; }
+  void SetTrackSelection(AliEmcalTrackSelection *trackSelection) { fTrackSelection = trackSelection; }
 
 protected:
 
@@ -56,7 +47,7 @@ protected:
 
 private:
   THistManager                *fHistos;                     //!<! Histogram manager
-  PWG::EMCAL::AliEmcalTrackSelection      *fTrackSelection;             /// EMCAL track selection
+  AliEmcalTrackSelection      *fTrackSelection;             /// EMCAL track selection
 
   TString                     fMCJetContainerName;          /// Name of the MC jet container
   TString                     fMCParticleContainerName;     /// Name of the MC particle container

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskTrackDensityData.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskTrackDensityData.h
@@ -15,15 +15,7 @@ class AliEmcalJet;
 class AliParticleContainer;
 class THistManager;
 
-namespace PWG {
-
-namespace EMCAL {
-
 class AliEmcalTrackSelection;
-
-}
-
-}
 
 namespace EMCalTriggerPtAnalysis {
 
@@ -35,7 +27,7 @@ public:
   AliAnalysisTaskTrackDensityData(const char *name);
   virtual ~AliAnalysisTaskTrackDensityData();
 
-  void SetEmcalTrackSelection(PWG::EMCAL::AliEmcalTrackSelection *sel) { fTrackSelection = sel; }
+  void SetEmcalTrackSelection(AliEmcalTrackSelection *sel) { fTrackSelection = sel; }
   void SetNameJetContainer(TString name) { fNameJetContainer = name; }
   void SetNameTrackContainer(TString name) { fNameTrackContainer = name; }
 
@@ -50,7 +42,7 @@ protected:
 
 private:
   THistManager                          *fHistos;                 //!<!
-  PWG::EMCAL::AliEmcalTrackSelection    *fTrackSelection;         /// EMCAL track selection
+  AliEmcalTrackSelection    *fTrackSelection;         /// EMCAL track selection
   AliEMCalTriggerBinningComponent       *fBinHandler;             /// Binning handler
 
   TString                               fNameJetContainer;        /// name of the jet container

--- a/PWGJE/EMCALJetTasks/Tracks/AliEMCalTriggerRecJetAnalysisComponent.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliEMCalTriggerRecJetAnalysisComponent.h
@@ -20,15 +20,7 @@ class AliEmcalJet;
 class AliMCEvnet;
 class AliVParticle;
 
-namespace PWG{
-
-namespace EMCAL{
-
 class AliEmcalTrackSelection;
-
-}
-
-}
 
 namespace EMCalTriggerPtAnalysis {
 
@@ -61,7 +53,7 @@ public:
    * Set quality cuts used to select reconstructed tracks.
    * \param trackcuts Track selection cuts used in this analysis component.
    */
-  void SetSingleTrackCuts(PWG::EMCAL::AliEmcalTrackSelection * trackcuts) { fTrackSelection = trackcuts; }
+  void SetSingleTrackCuts(AliEmcalTrackSelection * trackcuts) { fTrackSelection = trackcuts; }
 
   /**
    * Defines whether we swap the sign of \f$ eta\f$.
@@ -74,7 +66,7 @@ protected:
   void FillHistogram(const TString &histname, const AliVParticle *track, const AliEmcalJet *jet, double vz, double weight);
   void FillJetHistogram(const TString &histname, const AliEmcalJet *recjet, double vz, double weight);
   void FillTrackHistogramCentrality(const TString &histname, const AliVTrack * const trk, const AliEmcalJet *jet, double centpercent, double weight);
-  PWG::EMCAL::AliEmcalTrackSelection  *fTrackSelection;         ///< Track selection cuts used in the analysis
+  AliEmcalTrackSelection  *fTrackSelection;         ///< Track selection cuts used in the analysis
   Double_t                          fMinimumJetPt;            ///< Minimum jet \f$ p_{t} \f$
   Bool_t                            fRequestMCtrue;           ///< Request MC true track
   Bool_t                            fSwapEta;                 ///< Swap eta sign on request

--- a/PWGJE/EMCALJetTasks/Tracks/AliEMCalTriggerRecTrackAnalysisComponent.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliEMCalTriggerRecTrackAnalysisComponent.h
@@ -17,16 +17,7 @@ class TString;
 class AliVParticle;
 class AliVTrack;
 class AliMCEvent;
-
-namespace PWG {
-
-namespace EMCAL {
-
 class AliEmcalTrackSelection;
-
-}
-
-}
 
 namespace EMCalTriggerPtAnalysis {
 
@@ -80,7 +71,7 @@ public:
    *
    * \param trackSel The (virtual) track selection applied in the analysis
    */
-  void SetTrackSelection(PWG::EMCAL::AliEmcalTrackSelection *trackSel) { fTrackSelection = trackSel; }
+  void SetTrackSelection(AliEmcalTrackSelection *trackSel) { fTrackSelection = trackSel; }
 
 protected:
   const AliVParticle *IsMCTrueTrack(const AliVTrack *const trk, const AliMCEvent *evnt) const;
@@ -89,7 +80,7 @@ protected:
   void MatchTriggerPatches(const AliVTrack *rectrack, const TClonesArray *inputpatches, TList &outputpatches) const;
   Bool_t HasMatchedPatchOfType(TString triggertype, const TList & patches) const;
 
-  PWG::EMCAL::AliEmcalTrackSelection *fTrackSelection;         ///< Track selection cuts used in the analysis
+  AliEmcalTrackSelection *fTrackSelection;         ///< Track selection cuts used in the analysis
   Bool_t                            fSwapEta;                 ///< Swap eta sign
   Bool_t                            fRequestMCtrue;           ///< Request MC true track
   Bool_t                            fDoMatchPatches;          ///< Request matching with trigger patches

--- a/PWGJE/EMCALJetTasks/Tracks/AliEmcalAnalysisFactory.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliEmcalAnalysisFactory.cxx
@@ -49,8 +49,8 @@
 
 namespace EMCalTriggerPtAnalysis {
 
-PWG::EMCAL::AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cutstring, Bool_t aod){
-  PWG::EMCAL::AliEmcalTrackSelection *result = NULL;
+AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TString cutstring, Bool_t aod){
+  AliEmcalTrackSelection *result = NULL;
   std::unique_ptr<TObjArray> cuts(cutstring.Tokenize(","));
   std::cout << "Creating track cuts for " << (aod ? "AODs" : "ESDs") << std::endl;
   TObjArray trackcuts;
@@ -248,10 +248,10 @@ PWG::EMCAL::AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TS
         trackcuts.Add(geocuts);
       }
     }
-    result = new PWG::EMCAL::AliEmcalTrackSelectionESD;
+    result = new AliEmcalTrackSelectionESD;
     result->AddTrackCuts(&trackcuts);
   } else {
-    PWG::EMCAL::AliEmcalTrackSelectionAOD *aodsel = new PWG::EMCAL::AliEmcalTrackSelectionAOD;
+    AliEmcalTrackSelectionAOD *aodsel = new AliEmcalTrackSelectionAOD;
     result = aodsel;
     // C++11 Lambda: Do not create multiple extra cut objects in case of AODs. If extra cut object does already exist -
     // specify new cut in the same object.
@@ -277,19 +277,19 @@ PWG::EMCAL::AliEmcalTrackSelection *AliEmcalAnalysisFactory::TrackCutsFactory(TS
         extracuts->SetMinTPCCrossedRows(120);
       }
       if(cut == "hybrid"){
-        aodsel->GenerateTrackCuts(PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks, AliTrackContainer::GetDefTrackCutsPeriod());
+        aodsel->GenerateTrackCuts(AliEmcalTrackSelection::kHybridTracks, AliTrackContainer::GetDefTrackCutsPeriod());
       }
       if(cut == "hybrid2010_wNoRefit"){
-        aodsel->GenerateTrackCuts(PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks2010wNoRefit, AliTrackContainer::GetDefTrackCutsPeriod());
+        aodsel->GenerateTrackCuts(AliEmcalTrackSelection::kHybridTracks2010wNoRefit, AliTrackContainer::GetDefTrackCutsPeriod());
       }
       if(cut == "hybrid2010_woNoRefit"){
-        aodsel->GenerateTrackCuts(PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks2010woNoRefit, AliTrackContainer::GetDefTrackCutsPeriod());
+        aodsel->GenerateTrackCuts(AliEmcalTrackSelection::kHybridTracks2010woNoRefit, AliTrackContainer::GetDefTrackCutsPeriod());
       }
       if(cut == "hybrid2011_wNoRefit"){
-        aodsel->GenerateTrackCuts(PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks2011wNoRefit, AliTrackContainer::GetDefTrackCutsPeriod());
+        aodsel->GenerateTrackCuts(AliEmcalTrackSelection::kHybridTracks2011wNoRefit, AliTrackContainer::GetDefTrackCutsPeriod());
       }
       if(cut == "hybrid2011_woNoRefit"){
-        aodsel->GenerateTrackCuts(PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks2011woNoRefit, AliTrackContainer::GetDefTrackCutsPeriod());
+        aodsel->GenerateTrackCuts(AliEmcalTrackSelection::kHybridTracks2011woNoRefit, AliTrackContainer::GetDefTrackCutsPeriod());
       }
       if(cut == "geo"){
         AliEMCalTriggerExtraCuts *extracuts = FindTrackCuts(trackcuts);

--- a/PWGJE/EMCALJetTasks/Tracks/AliEmcalAnalysisFactory.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliEmcalAnalysisFactory.h
@@ -31,16 +31,8 @@
 #include "AliEmcalTriggerOfflineSelection.h"
 
 class AliESDtrackCuts;
-
-namespace PWG{
-
-namespace EMCAL {
-
 class AliEmcalTrackSelection;
 
-}
-
-}
 
 namespace EMCalTriggerPtAnalysis {
 
@@ -101,7 +93,7 @@ public:
    * @param isAOD Switch whether to create cuts for ESDs or AODs
    * @return Fully configured EMCAL track selection
    */
-  static PWG::EMCAL::AliEmcalTrackSelection *TrackCutsFactory(TString name, Bool_t isAOD);
+  static AliEmcalTrackSelection *TrackCutsFactory(TString name, Bool_t isAOD);
 
   /**
    * @brief Configures EMCAL trigger offline selection used to restrict EMCAL triggered sample

--- a/PWGJE/EMCALJetTasks/Tracks/AliReducedHighPtEventCreator.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliReducedHighPtEventCreator.cxx
@@ -309,7 +309,7 @@ Bool_t AliReducedHighPtEventCreator::Run() {
  * \param sel The track selection
  * \param cutindex The index of the track selection
  */
-void AliReducedHighPtEventCreator::AddVirtualTrackSelection(PWG::EMCAL::AliEmcalTrackSelection* sel, int cutindex) {
+void AliReducedHighPtEventCreator::AddVirtualTrackSelection(AliEmcalTrackSelection* sel, int cutindex) {
   fTrackSelections->Add(new AliReducedTrackSelectionContainer(cutindex, sel));
 }
 
@@ -490,7 +490,7 @@ AliReducedTrackSelectionContainer::AliReducedTrackSelectionContainer():
  * \param index Cut index
  * \param sel Track selection object
  */
-AliReducedTrackSelectionContainer::AliReducedTrackSelectionContainer(Int_t index, PWG::EMCAL::AliEmcalTrackSelection* sel):
+AliReducedTrackSelectionContainer::AliReducedTrackSelectionContainer(Int_t index, AliEmcalTrackSelection* sel):
   fIndex(index),
   fTrackSelection(sel)
 {

--- a/PWGJE/EMCALJetTasks/Tracks/AliReducedHighPtEventCreator.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliReducedHighPtEventCreator.h
@@ -21,16 +21,7 @@ class TObjArray;
 class AliVCluster;
 class AliVEvent;
 class AliVParticle;
-
-namespace PWG{
-
-namespace EMCAL{
-
 class AliEmcalTrackSelection;
-
-}
-
-}
 
 namespace HighPtTracks {
 
@@ -44,7 +35,7 @@ class AliReducedPatchContainer;
 class AliReducedTrackSelectionContainer : public TObject{
 public:
   AliReducedTrackSelectionContainer();
-  AliReducedTrackSelectionContainer(Int_t index, PWG::EMCAL::AliEmcalTrackSelection * sel);
+  AliReducedTrackSelectionContainer(Int_t index, AliEmcalTrackSelection * sel);
   virtual ~AliReducedTrackSelectionContainer();
 
   /**
@@ -56,7 +47,7 @@ public:
    * Set the underlying track selection
    * \param trackSelection Underlying track selection
    */
-  void SetTrackSelection(PWG::EMCAL::AliEmcalTrackSelection *trackSelection) { fTrackSelection = trackSelection;}
+  void SetTrackSelection(AliEmcalTrackSelection *trackSelection) { fTrackSelection = trackSelection;}
 
   /**
    * Get the index of the track selection
@@ -67,11 +58,11 @@ public:
    * Get the underlying track selection
    * \return underlying track selection
    */
-  PWG::EMCAL::AliEmcalTrackSelection *GetTrackSelection() const { return fTrackSelection; }
+  AliEmcalTrackSelection *GetTrackSelection() const { return fTrackSelection; }
 
 protected:
   Int_t                                                           fIndex;               ///< Index of the cut
-  PWG::EMCAL::AliEmcalTrackSelection                             *fTrackSelection;     ///< Virtual track selection
+  AliEmcalTrackSelection                             *fTrackSelection;     ///< Virtual track selection
 
 private:
   AliReducedTrackSelectionContainer(AliReducedTrackSelectionContainer &);
@@ -95,7 +86,7 @@ public:
   virtual void UserCreateOutputObjects();
   virtual Bool_t Run();
 
-  void AddVirtualTrackSelection(PWG::EMCAL::AliEmcalTrackSelection * sel, Int_t index);
+  void AddVirtualTrackSelection(AliEmcalTrackSelection * sel, Int_t index);
   /**
    * Define if trigger thresholds are swapped
    * \param doswap if true then thresholds are swapped

--- a/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJetHadEPpid.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJetHadEPpid.C
@@ -123,9 +123,9 @@ AliAnalysisTaskEmcalJetHadEPpid* AddTaskEmcalJetHadEPpid(
   // turns quality cuts off
   if(turnQualityCutsOFF) { 
     trackCont->SetFilterHybridTracks(kFALSE);
-    trackCont->SetTrackFilterType(PWG::EMCAL::AliEmcalTrackSelection::kNoTrackFilter);       // turn OFF filter
-    //trackCont->SetTrackFilterType(PWG::EMCAL::AliEmcalTrackSelection::kTPCOnlyTracks);     // use TPC only tracks
-    //trackCont->SetTrackFilterType(PWG::EMCAL::AliEmcalTrackSelection::kCustomTrackFilter); // used for custom filter
+    trackCont->SetTrackFilterType(AliEmcalTrackSelection::kNoTrackFilter);       // turn OFF filter
+    //trackCont->SetTrackFilterType(AliEmcalTrackSelection::kTPCOnlyTracks);     // use TPC only tracks
+    //trackCont->SetTrackFilterType(AliEmcalTrackSelection::kCustomTrackFilter); // used for custom filter
   }
 
   // custom filter bit for tracks done here - Need to customize still

--- a/PWGJE/EMCALJetTasks/macros/AddTaskParticleInJet.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskParticleInJet.C
@@ -1,4 +1,4 @@
-PWG::EMCAL::AliEmcalTrackSelection *TrackSelectionFactory(Bool_t isAOD);
+AliEmcalTrackSelection *TrackSelectionFactory(Bool_t isAOD);
 
 AliAnalysisTaskParticleInJet *AddTaskParticleInJet(
     Bool_t isMC,
@@ -40,16 +40,16 @@ AliAnalysisTaskParticleInJet *AddTaskParticleInJet(
   return jettask;
 }
 
-PWG::EMCAL::AliEmcalTrackSelection *TrackSelectionFactory(Bool_t isAOD){
-  PWG::EMCAL::AliEmcalTrackSelection *result = 0;
+AliEmcalTrackSelection *TrackSelectionFactory(Bool_t isAOD){
+  AliEmcalTrackSelection *result = 0;
   if(isAOD){
-    PWG::EMCAL::AliEmcalTrackSelectionAOD *aodcuts = new PWG::EMCAL::AliEmcalTrackSelectionAOD();
+    AliEmcalTrackSelectionAOD *aodcuts = new AliEmcalTrackSelectionAOD();
     aodcuts->AddFilterBit(AliAODTrack::kTrkGlobal);
     EMCalTriggerPtAnalysis::AliEMCalTriggerExtraCuts *extracuts = new EMCalTriggerPtAnalysis::AliEMCalTriggerExtraCuts;
     extracuts->SetMinTPCCrossedRows(120);
     result = aodcuts;
   } else {
-    result = new PWG::EMCAL::AliEmcalTrackSelectionESD();
+    result = new AliEmcalTrackSelectionESD();
     AliESDtrackCuts *cuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(kTRUE, 0);
 	  cuts->SetName("Standard Track cuts");
 	  cuts->SetMinNCrossedRowsTPC(120);

--- a/PWGJE/EMCALJetTasks/macros/AddTaskPtEMCalTriggerV1.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskPtEMCalTriggerV1.C
@@ -41,17 +41,17 @@
 #endif
 
 void AddClusterComponent(EMCalTriggerPtAnalysis::AliEMCalTriggerTaskGroup *group);
-void AddTrackComponent(EMCalTriggerPtAnalysis::AliEMCalTriggerTaskGroup *group, PWG::EMCAL::AliEmcalTrackSelection *trackcuts, bool isMC, bool isSwapEta);
+void AddTrackComponent(EMCalTriggerPtAnalysis::AliEMCalTriggerTaskGroup *group, AliEmcalTrackSelection *trackcuts, bool isMC, bool isSwapEta);
 void AddMCParticleComponent(EMCalTriggerPtAnalysis::AliEMCalTriggerTaskGroup *group);
 void AddEventCounterComponent(EMCalTriggerPtAnalysis::AliEMCalTriggerTaskGroup *group);
 void AddMCJetComponent(EMCalTriggerPtAnalysis::AliEMCalTriggerTaskGroup *group, double minJetPt);
-void AddRecJetComponent(EMCalTriggerPtAnalysis::AliEMCalTriggerTaskGroup *group, PWG::EMCAL::AliEmcalTrackSelection *trackcuts, double minJetPt, bool isMC, bool isSwapEta);
+void AddRecJetComponent(EMCalTriggerPtAnalysis::AliEMCalTriggerTaskGroup *group, AliEmcalTrackSelection *trackcuts, double minJetPt, bool isMC, bool isSwapEta);
 void CreateJetPtBinning(EMCalTriggerPtAnalysis::AliAnalysisTaskPtEMCalTriggerV1 *task);
 void CreateTriggerClassespPb2013(EMCalTriggerPtAnalysis::AliAnalysisTaskPtEMCalTriggerV1 *task, bool isMC);
 void CreateTriggerClassespp2012(EMCalTriggerPtAnalysis::AliAnalysisTaskPtEMCalTriggerV1 *task, bool isMC);
-PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCuts(bool isAOD);
-PWG::EMCAL::AliEmcalTrackSelection *CreateHybridTrackCuts(bool isAOD);
-PWG::EMCAL::AliEmcalTrackSelection *TrackCutsFactory(const char *trackCutsName, bool isAOD);
+AliEmcalTrackSelection *CreateDefaultTrackCuts(bool isAOD);
+AliEmcalTrackSelection *CreateHybridTrackCuts(bool isAOD);
+AliEmcalTrackSelection *TrackCutsFactory(const char *trackCutsName, bool isAOD);
 
 /**
  * \brief Configuring the analysis of high-p_{t} tracks in triggered events and adds it to the analysis train
@@ -292,7 +292,7 @@ void AddClusterComponent(EMCalTriggerPtAnalysis::AliEMCalTriggerTaskGroup *group
  * \param isMC True if MC information is available.
  * \param isSwapEta True if the \f$ \eta \f$ sign is swapped
  */
-void AddTrackComponent(EMCalTriggerPtAnalysis::AliEMCalTriggerTaskGroup *group, PWG::EMCAL::AliEmcalTrackSelection * trackcuts, bool isMC, bool isSwapEta){
+void AddTrackComponent(EMCalTriggerPtAnalysis::AliEMCalTriggerTaskGroup *group, AliEmcalTrackSelection * trackcuts, bool isMC, bool isSwapEta){
   EMCalTriggerPtAnalysis::AliEMCalTriggerRecTrackAnalysisComponent *trackanalysis = new EMCalTriggerPtAnalysis::AliEMCalTriggerRecTrackAnalysisComponent("trackAnalysisStandard");
   group->AddAnalysisComponent(trackanalysis);
   // Create charged hadrons pPb standard track cuts
@@ -354,7 +354,7 @@ void AddMCJetComponent(EMCalTriggerPtAnalysis::AliEMCalTriggerTaskGroup *group, 
  * \param isMC True if MC information is available.
  * \param isSwapEta True if the \f$ \eta \f$ sign is swapped
  */
-void AddRecJetComponent(EMCalTriggerPtAnalysis::AliEMCalTriggerTaskGroup *group, PWG::EMCAL::AliEmcalTrackSelection *trackcuts, double minJetPt, bool isMC, bool isSwapEta){
+void AddRecJetComponent(EMCalTriggerPtAnalysis::AliEMCalTriggerTaskGroup *group, AliEmcalTrackSelection *trackcuts, double minJetPt, bool isMC, bool isSwapEta){
   EMCalTriggerPtAnalysis::AliEMCalTriggerRecJetAnalysisComponent *jetana = new EMCalTriggerPtAnalysis::AliEMCalTriggerRecJetAnalysisComponent(Form("RecJetAna%f", minJetPt));
   jetana->SetMinimumJetPt(minJetPt);
   jetana->SetSingleTrackCuts(trackcuts);
@@ -496,10 +496,10 @@ void CreateTriggerClassespp2012(EMCalTriggerPtAnalysis::AliAnalysisTaskPtEMCalTr
  * \param isAOD True in case the analysis is performed on AOD tracks
  * \return A virtual track selection using the hybrid track selection cuts
  */
-PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCuts(bool isAOD){
-  PWG::EMCAL::AliEmcalTrackSelection * trackSelection(NULL);
+AliEmcalTrackSelection *CreateDefaultTrackCuts(bool isAOD){
+  AliEmcalTrackSelection * trackSelection(NULL);
   if(isAOD){
-	  PWG::EMCAL::AliEmcalTrackSelectionAOD *aodsel = new AliEmcalTrackSelectionAOD;
+	  AliEmcalTrackSelectionAOD *aodsel = new AliEmcalTrackSelectionAOD;
 	  aodsel->AddFilterBit(AliAODTrack::kTrkGlobal);
 	  EMCalTriggerPtAnalysis::AliEMCalTriggerExtraCuts *extraCuts = new EMCalTriggerPtAnalysis::AliEMCalTriggerExtraCuts();
 	  extraCuts->SetMinTPCCrossedRows(120);
@@ -511,7 +511,7 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCuts(bool isAOD){
 	  standardTrackCuts->SetName("Standard Track cuts");
 	  standardTrackCuts->SetMinNCrossedRowsTPC(120);
 	  standardTrackCuts->SetMaxDCAToVertexXYPtDep("0.0182+0.0350/pt^1.01");
-	  trackSelection = new PWG::EMCAL::AliEmcalTrackSelectionESD(standardTrackCuts);
+	  trackSelection = new AliEmcalTrackSelectionESD(standardTrackCuts);
 	  //EMCalTriggerPtAnalysis::AliEMCalTriggerExtraCuts *extraCuts = new EMCalTriggerPtAnalysis::AliEMCalTriggerExtraCuts();
 	  //extraCuts->SetMinTPCTrackLengthCut();
 	  //trackSelection->AddTrackCuts(extraCuts);
@@ -530,11 +530,11 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCuts(bool isAOD){
  * \param isAOD True in case the analysis is performed on AOD tracks
  * \return A virtual track selection using the hybrid track selection cuts
  */
-PWG::EMCAL::AliEmcalTrackSelection *CreateHybridTrackCuts(bool isAOD){
-  PWG::EMCAL::AliEmcalTrackSelection * trackSelection(NULL);
+AliEmcalTrackSelection *CreateHybridTrackCuts(bool isAOD){
+  AliEmcalTrackSelection * trackSelection(NULL);
   if(isAOD){
 	  // Purely use filter bits
-	  PWG::EMCAL::AliEmcalTrackSelectionAOD *aodsel = new PWG::EMCAL::AliEmcalTrackSelectionAOD;
+	  AliEmcalTrackSelectionAOD *aodsel = new AliEmcalTrackSelectionAOD;
 	  aodsel->AddFilterBit(256);
 	  aodsel->AddFilterBit(512);
 	  trackSelection = aodsel;
@@ -546,7 +546,7 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateHybridTrackCuts(bool isAOD){
 	  hybridTrackCuts->SetDCAToVertex2D(kTRUE);
 	  hybridTrackCuts->SetMaxChi2TPCConstrainedGlobal(36);
 	  hybridTrackCuts->SetMaxFractionSharedTPCClusters(0.4);
-	  trackSelection = new PWG::EMCAL::AliEmcalTrackSelectionESD(hybridTrackCuts);
+	  trackSelection = new AliEmcalTrackSelectionESD(hybridTrackCuts);
   }
   return trackSelection;
 }
@@ -564,7 +564,7 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateHybridTrackCuts(bool isAOD){
  * \param isAOD True in case the analysis is performed on AOD tracks
  * \return A virtual track selection object (NULL for invalid track cut names)
  */
-PWG::EMCAL::AliEmcalTrackSelection *TrackCutsFactory(const char* trackCutsName, bool isAOD) {
+AliEmcalTrackSelection *TrackCutsFactory(const char* trackCutsName, bool isAOD) {
   if(!strcmp(trackCutsName, "standard")) return CreateDefaultTrackCuts(isAOD);
   else if(!strcmp(trackCutsName, "hybrid")) return CreateHybridTrackCuts(isAOD);
   return NULL;

--- a/PWGJE/EMCALJetTasks/macros/AddTaskTrackDensityData.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskTrackDensityData.C
@@ -23,7 +23,7 @@ EMCalTriggerPtAnalysis::AliAnalysisTaskTrackDensityData *AddTaskTrackDensityData
   trackcont->SetName("trackcontainer");
   trackcont->SetEtaLimits(-0.8, 0.8);
   trackcont->SetTrackCutsPeriod(period);
-  trackcont->SetTrackFilterType(PWG::EMCAL::AliEmcalTrackSelection::kHybridTracks);
+  trackcont->SetTrackFilterType(AliEmcalTrackSelection::kHybridTracks);
   densitytask->SetNameTrackContainer("trackcontainer");
 
   AliJetContainer *jetcont = densitytask->AddJetContainer(jetcontainername, AliEmcalJet::kTPC, 0.4);

--- a/PWGJE/EMCALJetTasks/macros/AddTaskTrackingEffTrackInJet.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskTrackingEffTrackInJet.C
@@ -35,7 +35,7 @@ EMCalTriggerPtAnalysis::AliAnalysisTaskPtEfficiencyJets *AddTaskTrackingEffTrack
   standardTrackCuts->SetName("Standard Track cuts");
   standardTrackCuts->SetMinNCrossedRowsTPC(120);
   standardTrackCuts->SetMaxDCAToVertexXYPtDep("0.0182+0.0350/pt^1.01");
-  analysis->SetTrackCuts(new PWG::EMCAL::AliEmcalTrackSelectionESD(standardTrackCuts));
+  analysis->SetTrackCuts(new AliEmcalTrackSelectionESD(standardTrackCuts));
 
   // connect containers
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();

--- a/PWGJE/EMCALJetTasks/macros/ReducedEventCutVariation.C
+++ b/PWGJE/EMCALJetTasks/macros/ReducedEventCutVariation.C
@@ -15,15 +15,15 @@
 #include "AliReducedHighPtEventCreator.h"
 #endif
 
-PWG::EMCAL::AliEmcalTrackSelection *CreateHybridTrackCuts(bool isAOD);
-PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCuts(bool isAOD);
-PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeCrossRows(bool isAOD, int minCrossedRows);
-PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeFiducialAreaCut(bool isAOD );
-PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeDCAZ(bool isAOD, Double_t dcaZ);
-PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeDCAR(bool isAOD, TString model);
-PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeGoldenCut(bool isAOD, Float_t chi2cut);
-PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeChi2ITS(bool isAOD, Float_t chi2cut);
-PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeChi2TPC(bool isAOD, Float_t chi2cut);
+AliEmcalTrackSelection *CreateHybridTrackCuts(bool isAOD);
+AliEmcalTrackSelection *CreateDefaultTrackCuts(bool isAOD);
+AliEmcalTrackSelection *CreateDefaultTrackCutsChangeCrossRows(bool isAOD, int minCrossedRows);
+AliEmcalTrackSelection *CreateDefaultTrackCutsChangeFiducialAreaCut(bool isAOD );
+AliEmcalTrackSelection *CreateDefaultTrackCutsChangeDCAZ(bool isAOD, Double_t dcaZ);
+AliEmcalTrackSelection *CreateDefaultTrackCutsChangeDCAR(bool isAOD, TString model);
+AliEmcalTrackSelection *CreateDefaultTrackCutsChangeGoldenCut(bool isAOD, Float_t chi2cut);
+AliEmcalTrackSelection *CreateDefaultTrackCutsChangeChi2ITS(bool isAOD, Float_t chi2cut);
+AliEmcalTrackSelection *CreateDefaultTrackCutsChangeChi2TPC(bool isAOD, Float_t chi2cut);
 
 /**
  * Initialize cut variations in the tree creator task. Selected sample is always a subset of the hybrid track sample -
@@ -32,7 +32,7 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeChi2TPC(bool isA
  * \param isAOD Flag for AOD
  */
 void ReducedEventCutVariation(HighPtTracks::AliReducedHighPtEventCreator *task,  Bool_t isAOD){
-  PWG::EMCAL::AliEmcalTrackSelection *trackcuts;
+  AliEmcalTrackSelection *trackcuts;
   if((trackcuts = CreateDefaultTrackCuts(isAOD))) task->AddVirtualTrackSelection(trackcuts, 0);
   if((trackcuts = CreateHybridTrackCuts(isAOD))) task->AddVirtualTrackSelection(trackcuts, 1);
   if((trackcuts = CreateDefaultTrackCutsChangeFiducialAreaCut(isAOD))) task->AddVirtualTrackSelection(trackcuts, 2);
@@ -59,11 +59,11 @@ void ReducedEventCutVariation(HighPtTracks::AliReducedHighPtEventCreator *task, 
  * \param isAOD Flag for AOD
  * \return virtual track selection
  */
-PWG::EMCAL::AliEmcalTrackSelection *CreateHybridTrackCuts(bool isAOD){
-  PWG::EMCAL::AliEmcalTrackSelection * trackSelection(NULL);
+AliEmcalTrackSelection *CreateHybridTrackCuts(bool isAOD){
+  AliEmcalTrackSelection * trackSelection(NULL);
   if(isAOD){
     // Purely use filter bits
-    PWG::EMCAL::AliEmcalTrackSelectionAOD *aodsel = new PWG::EMCAL::AliEmcalTrackSelectionAOD();
+    AliEmcalTrackSelectionAOD *aodsel = new AliEmcalTrackSelectionAOD();
     aodsel->AddFilterBit(256);
     aodsel->AddFilterBit(512);
     trackSelection = aodsel;
@@ -75,7 +75,7 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateHybridTrackCuts(bool isAOD){
     hybridTrackCuts->SetDCAToVertex2D(kTRUE);
     hybridTrackCuts->SetMaxChi2TPCConstrainedGlobal(36);
     hybridTrackCuts->SetMaxFractionSharedTPCClusters(0.4);
-    trackSelection = new PWG::EMCAL::AliEmcalTrackSelectionESD(hybridTrackCuts);
+    trackSelection = new AliEmcalTrackSelectionESD(hybridTrackCuts);
   }
   return trackSelection;
 }
@@ -85,10 +85,10 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateHybridTrackCuts(bool isAOD){
  * \param isAOD Flag for AOD
  * \return virtual track selection
  */
-PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCuts(bool isAOD){
-  PWG::EMCAL::AliEmcalTrackSelection * trackSelection(NULL);
+AliEmcalTrackSelection *CreateDefaultTrackCuts(bool isAOD){
+  AliEmcalTrackSelection * trackSelection(NULL);
   if(isAOD){
-    PWG::EMCAL::AliEmcalTrackSelectionAOD *aodsel = new PWG::EMCAL::AliEmcalTrackSelectionAOD();
+    AliEmcalTrackSelectionAOD *aodsel = new AliEmcalTrackSelectionAOD();
     aodsel->AddFilterBit(AliAODTrack::kTrkGlobal);
     EMCalTriggerPtAnalysis::AliEMCalTriggerExtraCuts *extraCuts = new EMCalTriggerPtAnalysis::AliEMCalTriggerExtraCuts();
     extraCuts->SetMinTPCCrossedRows(120);
@@ -99,7 +99,7 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCuts(bool isAOD){
     standardTrackCuts->SetName("Standard Track cuts");
     standardTrackCuts->SetMinNCrossedRowsTPC(120);
     standardTrackCuts->SetMaxDCAToVertexXYPtDep("0.0182+0.0350/pt^1.01");
-    trackSelection = new PWG::EMCAL::AliEmcalTrackSelectionESD(standardTrackCuts);
+    trackSelection = new AliEmcalTrackSelectionESD(standardTrackCuts);
   }
   return trackSelection;
 }
@@ -109,10 +109,10 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCuts(bool isAOD){
  * \param isAOD Flag for AOD
  * \return virtual track selection
  */
-PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeCrossRows(bool isAOD, int minCrossedRows){
-  PWG::EMCAL::AliEmcalTrackSelection * trackSelection(NULL);
+AliEmcalTrackSelection *CreateDefaultTrackCutsChangeCrossRows(bool isAOD, int minCrossedRows){
+  AliEmcalTrackSelection * trackSelection(NULL);
   if(isAOD){
-    AliEmcalTrackSelectionAOD *aodsel = new PWG::EMCAL::AliEmcalTrackSelectionAOD();
+    AliEmcalTrackSelectionAOD *aodsel = new AliEmcalTrackSelectionAOD();
     aodsel->AddFilterBit(AliAODTrack::kTrkGlobal);
     EMCalTriggerPtAnalysis::AliEMCalTriggerExtraCuts *extraCuts = new EMCalTriggerPtAnalysis::AliEMCalTriggerExtraCuts();
     extraCuts->SetMinTPCCrossedRows(minCrossedRows);
@@ -123,7 +123,7 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeCrossRows(bool i
     standardTrackCuts->SetName("Standard Track cuts");
     standardTrackCuts->SetMinNCrossedRowsTPC(minCrossedRows);
     standardTrackCuts->SetMaxDCAToVertexXYPtDep("0.0182+0.0350/pt^1.01");
-    trackSelection = new PWG::EMCAL::AliEmcalTrackSelectionESD(standardTrackCuts);
+    trackSelection = new AliEmcalTrackSelectionESD(standardTrackCuts);
   }
   return trackSelection;
 }
@@ -133,10 +133,10 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeCrossRows(bool i
  * \param isAOD Flag for AOD
  * \return virtual track selection
  */
-PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeFiducialAreaCut(bool isAOD ){
-  PWG::EMCAL::AliEmcalTrackSelection * trackSelection(NULL);
+AliEmcalTrackSelection *CreateDefaultTrackCutsChangeFiducialAreaCut(bool isAOD ){
+  AliEmcalTrackSelection * trackSelection(NULL);
   if(isAOD){
-    PWG::EMCAL::AliEmcalTrackSelectionAOD *aodsel = new PWG::EMCAL::AliEmcalTrackSelectionAOD();
+    AliEmcalTrackSelectionAOD *aodsel = new AliEmcalTrackSelectionAOD();
     aodsel->AddFilterBit(AliAODTrack::kTrkGlobal);
     EMCalTriggerPtAnalysis::AliEMCalTriggerExtraCuts *extraCuts = new EMCalTriggerPtAnalysis::AliEMCalTriggerExtraCuts();
     extraCuts->SetMinTPCCrossedRows(120);
@@ -148,7 +148,7 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeFiducialAreaCut(
     standardTrackCuts->SetName("Standard Track cuts");
     standardTrackCuts->SetMinNCrossedRowsTPC(120);
     standardTrackCuts->SetMaxDCAToVertexXYPtDep("0.0182+0.0350/pt^1.01");
-    trackSelection = new PWG::EMCAL::AliEmcalTrackSelectionESD(standardTrackCuts);
+    trackSelection = new AliEmcalTrackSelectionESD(standardTrackCuts);
     EMCalTriggerPtAnalysis::AliEMCalTriggerExtraCuts *extraCuts = new EMCalTriggerPtAnalysis::AliEMCalTriggerExtraCuts();
     extraCuts->SetMinTPCTrackLengthCut();
     trackSelection->AddTrackCuts(extraCuts);
@@ -161,8 +161,8 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeFiducialAreaCut(
  * \param isAOD Flag for AOD
  * \return virtual track selection
  */
-PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeDCAZ(bool isAOD, Double_t dcaZ){
-  PWG::EMCAL::AliEmcalTrackSelection * trackSelection(NULL);
+AliEmcalTrackSelection *CreateDefaultTrackCutsChangeDCAZ(bool isAOD, Double_t dcaZ){
+  AliEmcalTrackSelection * trackSelection(NULL);
   if(isAOD){
     return NULL;
   } else {
@@ -171,7 +171,7 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeDCAZ(bool isAOD,
     standardTrackCuts->SetMinNCrossedRowsTPC(120);
     standardTrackCuts->SetMaxDCAToVertexZ(dcaZ);
     standardTrackCuts->SetMaxDCAToVertexXYPtDep("0.0182+0.0350/pt^1.01");
-    trackSelection = new PWG::EMCAL::AliEmcalTrackSelectionESD(standardTrackCuts);
+    trackSelection = new AliEmcalTrackSelectionESD(standardTrackCuts);
   }
   return trackSelection;
 }
@@ -181,8 +181,8 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeDCAZ(bool isAOD,
  * \param isAOD Flag for AOD
  * \return virtual track selection
  */
-PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeDCAR(bool isAOD, TString model){
-  PWG::EMCAL::AliEmcalTrackSelection * trackSelection(NULL);
+AliEmcalTrackSelection *CreateDefaultTrackCutsChangeDCAR(bool isAOD, TString model){
+  AliEmcalTrackSelection * trackSelection(NULL);
   if(isAOD){
     return NULL;
   } else {
@@ -190,7 +190,7 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeDCAR(bool isAOD,
     standardTrackCuts->SetName("Standard Track cuts");
     standardTrackCuts->SetMinNCrossedRowsTPC(120);
     standardTrackCuts->SetMaxDCAToVertexXYPtDep(model.Data());
-    trackSelection = new PWG::EMCAL::AliEmcalTrackSelectionESD(standardTrackCuts);
+    trackSelection = new AliEmcalTrackSelectionESD(standardTrackCuts);
   }
   return trackSelection;
 }
@@ -200,8 +200,8 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeDCAR(bool isAOD,
  * \param isAOD Flag for AOD
  * \return virtual track selection
  */
-PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeGoldenCut(bool isAOD, Float_t chi2cut){
-  PWG::EMCAL::AliEmcalTrackSelection * trackSelection(NULL);
+AliEmcalTrackSelection *CreateDefaultTrackCutsChangeGoldenCut(bool isAOD, Float_t chi2cut){
+  AliEmcalTrackSelection * trackSelection(NULL);
   if(isAOD){
     return NULL;
   } else {
@@ -210,7 +210,7 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeGoldenCut(bool i
     standardTrackCuts->SetMinNCrossedRowsTPC(120);
     standardTrackCuts->SetMaxDCAToVertexXYPtDep("0.0182+0.0350/pt^1.01");
     standardTrackCuts->SetMaxChi2TPCConstrainedGlobal(chi2cut);
-    trackSelection = new PWG::EMCAL::AliEmcalTrackSelectionESD(standardTrackCuts);
+    trackSelection = new AliEmcalTrackSelectionESD(standardTrackCuts);
   }
   return trackSelection;
 }
@@ -220,8 +220,8 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeGoldenCut(bool i
  * \param isAOD Flag for AOD
  * \return virtual track selection
  */
-PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeChi2ITS(bool isAOD, Float_t chi2cut){
-  PWG::EMCAL::AliEmcalTrackSelection * trackSelection(NULL);
+AliEmcalTrackSelection *CreateDefaultTrackCutsChangeChi2ITS(bool isAOD, Float_t chi2cut){
+  AliEmcalTrackSelection * trackSelection(NULL);
   if(isAOD){
     return NULL;
   } else {
@@ -230,7 +230,7 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeChi2ITS(bool isA
     standardTrackCuts->SetMinNCrossedRowsTPC(120);
     standardTrackCuts->SetMaxDCAToVertexXYPtDep("0.0182+0.0350/pt^1.01");
     standardTrackCuts->SetMaxChi2PerClusterITS(chi2cut);
-    trackSelection = new PWG::EMCAL::AliEmcalTrackSelectionESD(standardTrackCuts);
+    trackSelection = new AliEmcalTrackSelectionESD(standardTrackCuts);
   }
   return trackSelection;
 }
@@ -240,8 +240,8 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeChi2ITS(bool isA
  * \param isAOD Flag for AOD
  * \return virtual track selection
  */
-PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeChi2TPC(bool isAOD, Float_t chi2cut){
-  PWG::EMCAL::AliEmcalTrackSelection * trackSelection(NULL);
+AliEmcalTrackSelection *CreateDefaultTrackCutsChangeChi2TPC(bool isAOD, Float_t chi2cut){
+  AliEmcalTrackSelection * trackSelection(NULL);
   if(isAOD){
     return NULL;
   } else {
@@ -250,7 +250,7 @@ PWG::EMCAL::AliEmcalTrackSelection *CreateDefaultTrackCutsChangeChi2TPC(bool isA
     standardTrackCuts->SetMinNCrossedRowsTPC(120);
     standardTrackCuts->SetMaxDCAToVertexXYPtDep("0.0182+0.0350/pt^1.01");
     standardTrackCuts->SetMaxChi2PerClusterTPC(chi2cut);
-    trackSelection = new PWG::EMCAL::AliEmcalTrackSelectionESD(standardTrackCuts);
+    trackSelection = new AliEmcalTrackSelectionESD(standardTrackCuts);
   }
   return trackSelection;
 }

--- a/PWGPP/EMCAL/macros/AddTaskEMCALAlig.C
+++ b/PWGPP/EMCAL/macros/AddTaskEMCALAlig.C
@@ -162,7 +162,7 @@ AliAnalysisTaskEMCALAlig* AddTaskEMCALAlig(
     
     //Track cuts
     sampleTask->GetParticleContainer(0)->SetParticlePtCut(1.2);
-    sampleTask->GetTrackContainer(0)->SetTrackFilterType(PWG::EMCAL::AliEmcalTrackSelection::kCustomTrackFilter);
+    sampleTask->GetTrackContainer(0)->SetTrackFilterType(AliEmcalTrackSelection::kCustomTrackFilter);
     sampleTask->GetTrackContainer(0)->SetAODFilterBits(AliAODTrack::kTrkGlobalNoDCA);
     sampleTask->GetTrackContainer(0)->SetEtaLimits(-0.7, 0.7);
     


### PR DESCRIPTION
…used in macros appearing in some cases under ROOT5