### PR TITLE
Including desciption about EMCAL OADB in doxygen

### DIFF
--- a/OADB/EMCAL/READMEoadb.txt
+++ b/OADB/EMCAL/READMEoadb.txt
@@ -1,12 +1,20 @@
+/*! \page READMEoadb Accessing the EMCAL OADB from EOS
+
 The EMCal OADB files have been moved to the EOS directory /eos/experiment/alice/analysis-data/OADB/EMCAL which is accessible via lxplus.
-Analysis tasks can access these files via, for example: AliDataFile::GetFileNameOADB("EMCAL/EMCALTimeL1PhaseCalib.root") which has been implemented into the Tender and the Correction Framework as well as most analysis tasks in AliPhysics.
+Analysis tasks can access these files via, for example: ```AliDataFile::GetFileNameOADB("EMCAL/EMCALTimeL1PhaseCalib.root")``` which has been implemented into the Tender and the Correction Framework as well as most analysis tasks in AliPhysics.
 If you want to have the OADB files locally, you can download them from lxplus via:
+```
 rsync -av --delete cern_user@lxplus.cern.ch:/eos/experiment/alice/analysis-data/ /path/to/my/local/oadb/
+```
 
 In order for local tests to work properly, please add the OADB_PATH global variable to your bashrc or similar.
+```
 OADB_PATH=/path/to/my/local/oadb/OADB
+```
 It is crucial, that the additional /OADB is added to the global variable OADB_PATH. This is necessary as the downloaded directory from EOS contains the subfolder OADB. OADB_PATH must point to this subfolder in order to be able to properly load the files.
 
 In addition, a short history of changes to the files in EOS will be listed here:
 
-20180213: Moved all files to EOS.
+- 20180213: Moved all files to EOS.
+
+*/

--- a/OADB/EMCAL/READMEoadb.txt
+++ b/OADB/EMCAL/READMEoadb.txt
@@ -3,14 +3,14 @@
 The EMCal OADB files have been moved to the EOS directory /eos/experiment/alice/analysis-data/OADB/EMCAL which is accessible via lxplus.
 Analysis tasks can access these files via, for example: ```AliDataFile::GetFileNameOADB("EMCAL/EMCALTimeL1PhaseCalib.root")``` which has been implemented into the Tender and the Correction Framework as well as most analysis tasks in AliPhysics.
 If you want to have the OADB files locally, you can download them from lxplus via:
-```
+~~~{.sh}
 rsync -av --delete cern_user@lxplus.cern.ch:/eos/experiment/alice/analysis-data/ /path/to/my/local/oadb/
-```
+~~~
 
 In order for local tests to work properly, please add the OADB_PATH global variable to your bashrc or similar.
-```
+~~~{.sh}
 OADB_PATH=/path/to/my/local/oadb/OADB
-```
+~~~
 It is crucial, that the additional /OADB is added to the global variable OADB_PATH. This is necessary as the downloaded directory from EOS contains the subfolder OADB. OADB_PATH must point to this subfolder in order to be able to properly load the files.
 
 In addition, a short history of changes to the files in EOS will be listed here:

--- a/PWG/EMCAL/READMEcorefw.txt
+++ b/PWG/EMCAL/READMEcorefw.txt
@@ -68,6 +68,10 @@ Information about the cell and cluster corrections is available at \subpage READ
 
 Information about embedding in the EMCal framework is available at \subpage READMEemcEmbedding.
 
+# Accesing the EMCAL OADB from EOS
+
+Instructions how to access the EMCAL OADB from EOS are available at \subpage READMEoadb
+
 # How to transition from old to new framework
 
 Here you find detailed information which compares old and new framework and tells you the things you have to keep in mind when using the new EMCal framework. Please read \subpage READMEchangefw.  

--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -802,6 +802,7 @@ INPUT                  = @CMAKE_SOURCE_DIR@/doxygen \
                          @CMAKE_SOURCE_DIR@/PWG/FLOW/Tasks \
                          @CMAKE_SOURCE_DIR@/PWG/FLOW/Base \
                          @CMAKE_SOURCE_DIR@/PWG/CaloTrackCorrBase \
+                         @CMAKE_SOURCE_DIR@/OADB/EMCAL \
                          @CMAKE_SOURCE_DIR@/PWG/EMCAL \
                          @CMAKE_SOURCE_DIR@/PWG/EMCAL/EMCALbase \
                          @CMAKE_SOURCE_DIR@/PWG/EMCAL/EMCALtrigger \


### PR DESCRIPTION
Linking doxypage with description about accessing the EMCAL
OADB under the EMCAL core framework.