### PR TITLE
Automatic pthard scaling: Do not scale further QA histograms

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalList.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalList.cxx
@@ -100,7 +100,8 @@ void AliEmcalList::ScaleAllHistograms(TCollection *hlist, Double_t scalingFactor
 
     // Don't scale profiles and histograms used for scaling
     TString histogram_class (listObject->ClassName());
-    if (!strcmp(listObject->GetName(), "fHistXsection") || !strcmp(listObject->GetName(), "fHistTrials"))
+    TString histogram_name (listObject->GetName());
+    if (histogram_name.Contains("fHistXsection") || histogram_name.Contains("fHistTrials") || histogram_name.Contains("fHistEvents"))
     {
       AliInfo(Form("Histogram %s will not be scaled, because a scaling histogram", listObject->GetName()));
       continue;


### PR DESCRIPTION
In the automatic scaling, do not scale the following histograms:
fHistTrials, fHistXsection, fHistEvents, fHistTrialsAfterSel, fHistXsectionAfterSel, fHistEventsAfterSel.
They might be needed for QA purposes.