### PR TITLE
Possibility to change the multi-vertexer settings

### DIFF
--- a/PWGHF/vertexingHF/AliRDHFCuts.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCuts.cxx
@@ -65,9 +65,10 @@ AliRDHFCuts::AliRDHFCuts(const Char_t* name, const Char_t* title) :
 AliAnalysisCuts(name,title),
 fMinVtxType(3),
 fMinVtxContr(1),
-fMaxVtxRedChi2(5.),
+fMaxVtxRedChi2(1e6),
 fMaxVtxZ(10.),
 fMinSPDMultiplicity(0),
+fMaxVtxChi2PileupMV(5.),
 fMinWDzPileupMV(15.),
 fRejectPlpFromDiffBCMV(kFALSE),
 fTriggerMask(AliVEvent::kAnyINT),
@@ -142,6 +143,7 @@ AliRDHFCuts::AliRDHFCuts(const AliRDHFCuts &source) :
   fMaxVtxRedChi2(source.fMaxVtxRedChi2),
   fMaxVtxZ(source.fMaxVtxZ),
   fMinSPDMultiplicity(source.fMinSPDMultiplicity),
+  fMaxVtxChi2PileupMV(source.fMaxVtxChi2PileupMV),
   fMinWDzPileupMV(source.fMinWDzPileupMV),
   fRejectPlpFromDiffBCMV(source.fRejectPlpFromDiffBCMV),
   fTriggerMask(source.fTriggerMask),
@@ -237,6 +239,7 @@ AliRDHFCuts &AliRDHFCuts::operator=(const AliRDHFCuts &source)
   fMaxVtxRedChi2=source.fMaxVtxRedChi2;
   fMaxVtxZ=source.fMaxVtxZ;
   fMinSPDMultiplicity=source.fMinSPDMultiplicity;
+  fMaxVtxChi2PileupMV=source.fMaxVtxChi2PileupMV;
   fMinWDzPileupMV=source.fMinWDzPileupMV;
   fRejectPlpFromDiffBCMV=source.fRejectPlpFromDiffBCMV;
   fTriggerMask=source.fTriggerMask;
@@ -691,7 +694,7 @@ Bool_t AliRDHFCuts::IsEventSelected(AliVEvent *event) {
   else if(fOptPileup==kRejectMVPileupEvent){
     AliAnalysisUtils utils;
     utils.SetMinPlpContribMV(fMinContrPileup);  // min. multiplicity of the pile-up vertex to consider
-    utils.SetMaxPlpChi2MV(fMaxVtxRedChi2);      // max chi2 per contributor of the pile-up vertex to consider.
+    utils.SetMaxPlpChi2MV(fMaxVtxChi2PileupMV); // max chi2 per contributor of the pile-up vertex to consider.
     utils.SetMinWDistMV(fMinWDzPileupMV);       // minimum weighted distance in Z between 2 vertices (i.e. (zv1-zv2)/sqrt(sigZv1^2+sigZv2^2) )
     utils.SetCheckPlpFromDifferentBCMV(fRejectPlpFromDiffBCMV); // vertex with |BCID|>2 will trigger pile-up (based on TOF)
     Bool_t isPUMV = utils.IsPileUpMV(event);

--- a/PWGHF/vertexingHF/AliRDHFCuts.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCuts.cxx
@@ -65,9 +65,11 @@ AliRDHFCuts::AliRDHFCuts(const Char_t* name, const Char_t* title) :
 AliAnalysisCuts(name,title),
 fMinVtxType(3),
 fMinVtxContr(1),
-fMaxVtxRedChi2(1e6),
+fMaxVtxRedChi2(5.),
 fMaxVtxZ(10.),
 fMinSPDMultiplicity(0),
+fMinWDzPileupMV(15.),
+fRejectPlpFromDiffBCMV(kFALSE),
 fTriggerMask(AliVEvent::kAnyINT),
 fUseOnlyOneTrigger(kFALSE),
 fTrackCuts(0),
@@ -140,6 +142,8 @@ AliRDHFCuts::AliRDHFCuts(const AliRDHFCuts &source) :
   fMaxVtxRedChi2(source.fMaxVtxRedChi2),
   fMaxVtxZ(source.fMaxVtxZ),
   fMinSPDMultiplicity(source.fMinSPDMultiplicity),
+  fMinWDzPileupMV(source.fMinWDzPileupMV),
+  fRejectPlpFromDiffBCMV(source.fRejectPlpFromDiffBCMV),
   fTriggerMask(source.fTriggerMask),
   fUseOnlyOneTrigger(source.fUseOnlyOneTrigger),
   fTriggerClass(),
@@ -233,6 +237,8 @@ AliRDHFCuts &AliRDHFCuts::operator=(const AliRDHFCuts &source)
   fMaxVtxRedChi2=source.fMaxVtxRedChi2;
   fMaxVtxZ=source.fMaxVtxZ;
   fMinSPDMultiplicity=source.fMinSPDMultiplicity;
+  fMinWDzPileupMV=source.fMinWDzPileupMV;
+  fRejectPlpFromDiffBCMV=source.fRejectPlpFromDiffBCMV;
   fTriggerMask=source.fTriggerMask;
   fUseOnlyOneTrigger=source.fUseOnlyOneTrigger;
   fTriggerClass[0]=source.fTriggerClass[0];
@@ -684,6 +690,10 @@ Bool_t AliRDHFCuts::IsEventSelected(AliVEvent *event) {
   }
   else if(fOptPileup==kRejectMVPileupEvent){
     AliAnalysisUtils utils;
+    utils.SetMinPlpContribMV(fMinContrPileup);  // min. multiplicity of the pile-up vertex to consider
+    utils.SetMaxPlpChi2MV(fMaxVtxRedChi2);      // max chi2 per contributor of the pile-up vertex to consider.
+    utils.SetMinWDistMV(fMinWDzPileupMV);       // minimum weighted distance in Z between 2 vertices (i.e. (zv1-zv2)/sqrt(sigZv1^2+sigZv2^2) )
+    utils.SetCheckPlpFromDifferentBCMV(fRejectPlpFromDiffBCMV); // vertex with |BCID|>2 will trigger pile-up (based on TOF)
     Bool_t isPUMV = utils.IsPileUpMV(event);
     if(isPUMV) {
       if(accept) fWhyRejection=1;

--- a/PWGHF/vertexingHF/AliRDHFCuts.h
+++ b/PWGHF/vertexingHF/AliRDHFCuts.h
@@ -223,6 +223,12 @@ class AliRDHFCuts : public AliAnalysisCuts
   void SetOptPileup(Int_t opt=0){
     /// see enum below
     fOptPileup=opt;
+    if (fOptPileup==kRejectMVPileupEvent) {
+      fMinContrPileup=5.;
+      fMaxVtxChi2PileupMV=5.;
+      fMinWDzPileupMV=15.;
+      fRejectPlpFromDiffBCMV=kFALSE;
+    }
   }
   void ConfigurePileupCuts(Int_t minContrib=3, Float_t minDz=0.6){
     fMinContrPileup=minContrib;

--- a/PWGHF/vertexingHF/AliRDHFCuts.h
+++ b/PWGHF/vertexingHF/AliRDHFCuts.h
@@ -60,6 +60,8 @@ class AliRDHFCuts : public AliAnalysisCuts
   void SetMaxVtxRdChi2(Float_t chi2=1e6) {fMaxVtxRedChi2=chi2;}  
   void SetMaxVtxZ(Float_t z=1e6) {fMaxVtxZ=z;}  
   void SetMinSPDMultiplicity(Int_t mult=0) {fMinSPDMultiplicity=mult;}  
+  void SetMinWeightedDzVtxPileupMV(Float_t min=15.) {fMinWDzPileupMV=min;}
+  void SetRejectPlpFromDifferentBCMV(Bool_t ok=kTRUE) {fRejectPlpFromDiffBCMV=ok;}
 
   void SetTriggerMask(ULong64_t mask=0) {fTriggerMask=mask;}
   void SetUseOnlyOneTrigger(Bool_t onlyOne) {fUseOnlyOneTrigger=onlyOne;}
@@ -391,6 +393,8 @@ class AliRDHFCuts : public AliAnalysisCuts
   Float_t fMaxVtxRedChi2; /// maximum chi2/ndf
   Float_t fMaxVtxZ; /// maximum |z| of primary vertex
   Int_t fMinSPDMultiplicity; /// SPD multiplicity
+  Float_t fMinWDzPileupMV; /// minimum weighted distance in Z between 2 vertices (multi-vertexer)
+  Bool_t fRejectPlpFromDiffBCMV; /// flag to reject pileup from different BC (multi-vertexer)
   ULong64_t fTriggerMask; /// trigger mask
   Bool_t fUseOnlyOneTrigger; /// flag to select one trigger only
   TString  fTriggerClass[2]; /// trigger class
@@ -459,7 +463,7 @@ class AliRDHFCuts : public AliAnalysisCuts
   
 
   /// \cond CLASSIMP    
-  ClassDef(AliRDHFCuts,40);  /// base class for cuts on AOD reconstructed heavy-flavour decays
+  ClassDef(AliRDHFCuts,41);  /// base class for cuts on AOD reconstructed heavy-flavour decays
   /// \endcond
 };
 

--- a/PWGHF/vertexingHF/AliRDHFCuts.h
+++ b/PWGHF/vertexingHF/AliRDHFCuts.h
@@ -60,6 +60,7 @@ class AliRDHFCuts : public AliAnalysisCuts
   void SetMaxVtxRdChi2(Float_t chi2=1e6) {fMaxVtxRedChi2=chi2;}  
   void SetMaxVtxZ(Float_t z=1e6) {fMaxVtxZ=z;}  
   void SetMinSPDMultiplicity(Int_t mult=0) {fMinSPDMultiplicity=mult;}  
+  void SetMaxVtxChi2PileupMV(Float_t chi2=5.) {fMaxVtxChi2PileupMV=chi2;}
   void SetMinWeightedDzVtxPileupMV(Float_t min=15.) {fMinWDzPileupMV=min;}
   void SetRejectPlpFromDifferentBCMV(Bool_t ok=kTRUE) {fRejectPlpFromDiffBCMV=ok;}
 
@@ -393,6 +394,7 @@ class AliRDHFCuts : public AliAnalysisCuts
   Float_t fMaxVtxRedChi2; /// maximum chi2/ndf
   Float_t fMaxVtxZ; /// maximum |z| of primary vertex
   Int_t fMinSPDMultiplicity; /// SPD multiplicity
+  Float_t fMaxVtxChi2PileupMV; /// max chi2 per contributor of the pile-up vertex to consider (multi-vertexer).
   Float_t fMinWDzPileupMV; /// minimum weighted distance in Z between 2 vertices (multi-vertexer)
   Bool_t fRejectPlpFromDiffBCMV; /// flag to reject pileup from different BC (multi-vertexer)
   ULong64_t fTriggerMask; /// trigger mask


### PR DESCRIPTION
Possibility to configure the multi-vertexer (MV) in the RDHF cut objects. So far the MV settings were always the same, namely the one tuned for p-Pb 2013 (https://twiki.cern.ch/twiki/bin/view/ALICE/AliDPGtoolsPileup), and could not be changed.

**Important points:**
The default value of the Chi2/ndf data member 'fMaxVtxRedChi2', useful for the MV but not used in D2H framework (_as far as I can see!_), has been changed from 1e6 to 5 (the default MV value).
Could you confirm that the change of the fMaxVtxRedChi2 default value will not affect our analyses? Otherwise an additional data member, dedicated to the MV, could be created.

Cheers,
Julien