### PR TITLE
Allow minimum shared momentum fraction

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.cxx
@@ -72,6 +72,7 @@ AliAnalysisTaskEmcalJetHCorrelations::AliAnalysisTaskEmcalJetHCorrelations() :
   fJESCorrectionHist(nullptr),
   fDoLessSparseAxes(kFALSE), fDoWiderTrackBin(kFALSE),
   fRequireMatchedJetWhenEmbedding(kTRUE),
+  fMinSharedMomentumFraction(0.),
   fHistTrackPt(nullptr),
   fHistJetEtaPhi(nullptr),
   fHistJetHEtaPhi(nullptr),
@@ -101,6 +102,7 @@ AliAnalysisTaskEmcalJetHCorrelations::AliAnalysisTaskEmcalJetHCorrelations(const
   fJESCorrectionHist(nullptr),
   fDoLessSparseAxes(kFALSE), fDoWiderTrackBin(kFALSE),
   fRequireMatchedJetWhenEmbedding(kTRUE),
+  fMinSharedMomentumFraction(0.),
   fHistTrackPt(nullptr),
   fHistJetEtaPhi(nullptr),
   fHistJetHEtaPhi(nullptr),
@@ -494,6 +496,16 @@ Bool_t AliAnalysisTaskEmcalJetHCorrelations::Run()
           if (fIsEmbedded && fRequireMatchedJetWhenEmbedding) {
             if (jet->MatchedJet()) {
               AliDebugStream(4) << "Jet is matched!\nJet: " << jet->toString().Data() << "\n";
+              // Check shared momentum fraction
+              // We explicitly want to use indices instead of geometric matching
+              double sharedFraction = jets->GetFractionSharedPt(jet, nullptr);
+              if (sharedFraction < fMinSharedMomentumFraction) {
+                AliDebugStream(4) << "Jet is rejected due to shared momentum fraction of " << sharedFraction << ", which is smaller than the min momentum fraction of " << fMinSharedMomentumFraction << "\n";
+                continue;
+              }
+              else {
+                AliDebugStream(4) << "Passed shared momentum fraction with value of " << sharedFraction << "\n";
+              }
             }
             else {
               AliDebugStream(5) << "Rejected jet because it was not matched to a external event jet.\n";

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.h
@@ -73,6 +73,9 @@ class AliAnalysisTaskEmcalJetHCorrelations : public AliAnalysisTaskEmcalJet {
   /// Require jet to be matched when embedding
   Bool_t                  GetRequireMatchedJetWhenEmbedding() const   { return fRequireMatchedJetWhenEmbedding; }
   void                    SetRequireMatchedJetWhenEmbedding(Bool_t b) { fRequireMatchedJetWhenEmbedding = b; }
+  /// Mimimum shared momentum fraction for matched jet
+  double                  GetMinimumSharedMomentumFraction() const    { return fMinSharedMomentumFraction; }
+  void                    SetMinimumSharedMomentumFraction(double d)  { fMinSharedMomentumFraction = d; }
 
   // Mixed events
   virtual void            SetEventMixing(Bool_t enable)              { fDoEventMixing = enable;}
@@ -208,6 +211,7 @@ class AliAnalysisTaskEmcalJetHCorrelations : public AliAnalysisTaskEmcalJet {
   Bool_t                 fDoLessSparseAxes;        ///< True if there should be fewer THnSparse axes
   Bool_t                 fDoWiderTrackBin;         ///< True if the track pt bins in the THnSparse should be wider
   Bool_t                 fRequireMatchedJetWhenEmbedding; ///< True if jets are required to be matched (ie. jet->MatchedJet() != nullptr)
+  Double_t               fMinSharedMomentumFraction; ///< Minimum shared momentum with matched jet
 
   // Histograms
   TH1                   *fHistTrackPt;             //!<! Track pt spectrum


### PR DESCRIPTION
The requirement of a minimum amount of shared momentum fraction
is in addition to already requiring jets to match geometrically

NOTE: This first iteration will currently only work with
embedding real pp data.