### PR TITLE
Obtain friendTrack via esdTrack only

### DIFF
--- a/PWGLF/SPECTRA/ChargedHadrons/dNdPt/AlidNdPtTrackDumpTask.cxx
+++ b/PWGLF/SPECTRA/ChargedHadrons/dNdPt/AlidNdPtTrackDumpTask.cxx
@@ -900,7 +900,7 @@ void AlidNdPtTrackDumpTask::ProcessAll(AliESDEvent *const esdEvent, AliMCEvent *
       if(esdFriend && esdFriend->TestSkipBit()==kFALSE) 
       {
         // propagate ITSout to TPC inner wall
-        AliESDfriendTrack *friendTrack = esdFriend->GetTrack(iTrack);
+        const AliESDfriendTrack *friendTrack = track->GetFriendTrack();
 
         if(friendTrack) 
 	{

--- a/PWGPP/AliAnalysisTaskFilteredTree.cxx
+++ b/PWGPP/AliAnalysisTaskFilteredTree.cxx
@@ -416,10 +416,10 @@ void AliAnalysisTaskFilteredTree::ProcessCosmics(AliESDEvent *const event, AliES
     //if (TMath::Abs(dcaTPC[0])<kMaxDelta[0]) continue;
     //if (TMath::Abs(dcaTPC[1])<kMaxDelta[0]*2) continue;
     //    const AliExternalTrackParam * trackIn0 = track0->GetInnerParam();
-    AliESDfriendTrack* friendTrack0=NULL;
+    const AliESDfriendTrack* friendTrack0=NULL;
     if (esdFriend &&!esdFriend->TestSkipBit()){
       if (itrack0<ntracksFriend){
-	friendTrack0 = esdFriend->GetTrack(itrack0);
+	friendTrack0 = track0->GetFriendTrack();
       } //this guy can be NULL
     }
 
@@ -475,16 +475,16 @@ void AliAnalysisTaskFilteredTree::ProcessCosmics(AliESDEvent *const event, AliES
       ULong64_t gid          = ((periodID << 36) | (orbitID << 12) | bunchCrossID); 
       
 
-      AliESDfriendTrack* friendTrack1=NULL;
+      const AliESDfriendTrack* friendTrack1=NULL;
       if (esdFriend &&!esdFriend->TestSkipBit()){
 	if (itrack1<ntracksFriend){
-	  friendTrack1 = esdFriend->GetTrack(itrack1);
+	  friendTrack1 = track1->GetFriendTrack();
 	} //this guy can be NULL
       }
 
       //
-      AliESDfriendTrack *friendTrackStore0=friendTrack0;    // store friend track0 for later processing
-      AliESDfriendTrack *friendTrackStore1=friendTrack1;    // store friend track1 for later processing
+      AliESDfriendTrack *friendTrackStore0=(AliESDfriendTrack*)friendTrack0;    // store friend track0 for later processing
+      AliESDfriendTrack *friendTrackStore1=(AliESDfriendTrack*)friendTrack1;    // store friend track1 for later processing
       if (fFriendDownscaling>=1){  // downscaling number of friend tracks
 	if (gRandom->Rndm()>1./fFriendDownscaling){
 	  friendTrackStore0 = 0;
@@ -766,7 +766,7 @@ void AliAnalysisTaskFilteredTree::ProcessLaser(AliESDEvent *const esdEvent, AliM
       if (track->GetInnerParam()->Pt()<kMinPt) continue;
       Bool_t skipTrack=gRandom->Rndm()>1/(1+TMath::Abs(fFriendDownscaling));
       if (skipTrack) continue;
-      if (esdFriend) {if (!esdFriend->TestSkipBit()) friendTrack = esdFriend->GetTrack(iTrack);} //this guy can be NULL      
+      if (esdFriend) {if (!esdFriend->TestSkipBit()) friendTrack = (AliESDfriendTrack*)track->GetFriendTrack();} //this guy can be NULL      
       (*fTreeSRedirector)<<"Laser"<<
         "gid="<<gid<<                          // global identifier of event
         "fileName.="<<&fCurrentFileName<<              //
@@ -978,7 +978,9 @@ void AliAnalysisTaskFilteredTree::ProcessAll(AliESDEvent *const esdEvent, AliMCE
       AliESDfriendTrack* friendTrack=NULL;
       Int_t numberOfFriendTracks=0;
       if (esdFriend) numberOfFriendTracks=esdFriend->GetNumberOfTracks();
-      if (esdFriend && iTrack<numberOfFriendTracks) {if (!esdFriend->TestSkipBit()) friendTrack = esdFriend->GetTrack(iTrack);} //this guy can be NULL
+      if (esdFriend && iTrack<numberOfFriendTracks) {
+	if (!esdFriend->TestSkipBit()) friendTrack = (AliESDfriendTrack*)track->GetFriendTrack();
+      } //this guy can be NULL
       if(!track) continue;
       if(track->Charge()==0) continue;
       if(!esdTrackCuts->AcceptTrack(track)) continue;
@@ -1967,10 +1969,10 @@ void AliAnalysisTaskFilteredTree::ProcessV0(AliESDEvent *const esdEvent, AliMCEv
         if (!esdFriend->TestSkipBit()){
 	  Int_t ntracksFriend = esdFriend->GetNumberOfTracks();
 	  if (v0->GetIndex(0)<ntracksFriend){
-	    friendTrack0 = esdFriend->GetTrack(v0->GetIndex(0)); //this guy can be NULL
+	    friendTrack0 = (AliESDfriendTrack*)track0->GetFriendTrack(); //this guy can be NULL
 	  }
 	  if (v0->GetIndex(1)<ntracksFriend){
-	    friendTrack1 = esdFriend->GetTrack(v0->GetIndex(1)); //this guy can be NULL
+	    friendTrack1 =  (AliESDfriendTrack*)track1->GetFriendTrack(); //this guy can be NULL
 	  }
         }
       }
@@ -2169,7 +2171,7 @@ void AliAnalysisTaskFilteredTree::ProcessdEdx(AliESDEvent *const esdEvent, AliMC
       if (esdFriend && !esdFriend->TestSkipBit()) {
 	Int_t ntracksFriend = esdFriend->GetNumberOfTracks();
 	if (iTrack<ntracksFriend){
-	  friendTrack = esdFriend->GetTrack(iTrack);
+	  friendTrack = (AliESDfriendTrack*)track->GetFriendTrack();
 	} //this guy can be NULL	
       }
       
@@ -2748,7 +2750,7 @@ void AliAnalysisTaskFilteredTree::ProcessITSTPCmatchOut(AliESDEvent *const esdEv
       vecMomR1(iTrack,4)= trackTPC->GetSigned1Pt();;    
       vecMomR1(iTrack,5)= trackTPC->GetTgl();;    
     }
-    AliESDfriendTrack* friendTrack=esdFriend->GetTrack(iTrack);
+    const AliESDfriendTrack* friendTrack = track->GetFriendTrack();
     if(!friendTrack) continue;
     if (friendTrack->GetITSOut()){
       const AliExternalTrackParam *trackITS=friendTrack->GetITSOut();
@@ -2780,7 +2782,7 @@ void AliAnalysisTaskFilteredTree::ProcessITSTPCmatchOut(AliESDEvent *const esdEv
     AliESDtrack *track0 = esdEvent->GetTrack(iTrack0);   
     if(!track0) continue;
     if (track0->IsOn(AliVTrack::kTPCin)) continue;
-    AliESDfriendTrack* friendTrack0=esdFriend->GetTrack(iTrack0); 
+    const AliESDfriendTrack* friendTrack0 = track0->GetFriendTrack();
     if (!friendTrack0) continue;
     //if (!track0->IsOn(AliVTrack::kITSpureSA)) continue;
     //if (!friendTrack0->GetITSOut()) continue;  // is there flag for ITS standalone?

--- a/PWGPP/AliTrackComparisonESD.cxx
+++ b/PWGPP/AliTrackComparisonESD.cxx
@@ -274,7 +274,7 @@ void AliTrackComparisonESD::Exec(Option_t *) {
       AliESDtrack *track = fESD->GetTrack(itr);
       if(!track || !fESDCuts->AcceptTrack(track)) continue;
 
-      AliESDfriendTrack *friendTrack = fESDfriend->GetTrack(itr);
+      AliESDfriendTrack *friendTrack = (AliESDfriendTrack*)track->GetFriendTrack();
       if(!friendTrack) continue;
       //printf(" --- %d < %d || %p | %p -- %p \n", itr, fESDfriend->GetNumberOfTracks(), track, fESDfriend, friendTrack);
       ProcessTOF(track,friendTrack,vPos);

--- a/PWGPP/TPC/AliMaterialBudget.cxx
+++ b/PWGPP/TPC/AliMaterialBudget.cxx
@@ -692,7 +692,7 @@ void AliMaterialBudget::FindPairs(AliESDEvent * event) {
    const AliExternalTrackParam * trackOut = track->GetOuterParam();
    if (!trackIn) continue;
    if (!trackOut) continue;
-   AliESDfriendTrack *friendTrack = ESDfriend->GetTrack(i);
+   AliESDfriendTrack *friendTrack = (AliESDfriendTrack*)track->GetFriendTrack();
    if (!friendTrack) continue;
    TObject *calibObject;
    AliTPCseed *seed = 0;

--- a/PWGPP/TPC/AliPerformanceRes.cxx
+++ b/PWGPP/TPC/AliPerformanceRes.cxx
@@ -47,6 +47,7 @@
 #include "AliExternalTrackParam.h"
 #include "AliVfriendTrack.h"
 #include "AliVfriendEvent.h"
+#include "AliESDtrack.h"
 #include "AliLog.h" 
 #include "AliMCEvent.h" 
 #include "AliMCParticle.h" 
@@ -978,8 +979,15 @@ void AliPerformanceRes::Exec(AliMCEvent* const mcEvent, AliVEvent *const vEvent,
     else if(GetAnalysisMode() == 2) ProcessConstrained(mcEvent,vTrack,vEvent);
     else if(GetAnalysisMode() == 3) ProcessInnerTPC(mcEvent,vTrack,vEvent);
     else if(GetAnalysisMode() == 4) {
-      if(bUseVfriend && vfriendEvent && vfriendEvent->TestSkipBit()==kFALSE && iTrack<vfriendEvent->GetNumberOfTracks()) {
-	friendTrack=vfriendEvent->GetTrack(iTrack);
+      if(bUseVfriend && vfriendEvent && vfriendEvent->TestSkipBit()==kFALSE) {
+	if (vTrack->IsA()==AliESDtrack::Class()) {
+	  friendTrack = ((AliESDtrack*)vTrack)->GetFriendTrack();
+	}
+	else {
+	  if (iTrack<vfriendEvent->GetNumberOfTracks()) {
+	    friendTrack=vfriendEvent->GetTrack(iTrack);
+	  }
+	}
 	if(!friendTrack) continue;
       }
       ProcessOuterTPC(mcEvent,vTrack,friendTrack,vEvent);

--- a/PWGPP/TPC/AliPerformanceTPC.cxx
+++ b/PWGPP/TPC/AliPerformanceTPC.cxx
@@ -851,56 +851,63 @@ void AliPerformanceTPC::Exec(AliMCEvent* const mcEvent, AliVEvent *const vEvent,
     // if not fUseKinkDaughters don't use tracks with kink index > 0
     if(!fUseKinkDaughters && vTrack->GetKinkIndex(0) > 0) continue;
 
-    if(bUseVfriend && vfriendEvent && vfriendEvent->TestSkipBit()==kFALSE && iTrack<vfriendEvent->GetNumberOfTracks())
-        {
-          const AliVfriendTrack *friendTrack=vfriendEvent->GetTrack(iTrack);
-          if(friendTrack) 
-              {
-                //
-                TObject *calibObject=0;
-                AliTPCseed *seed=0;
-                for (Int_t j=0;(calibObject=friendTrack->GetCalibObject(j));++j) {
-                if ((seed=dynamic_cast<AliTPCseed*>(calibObject))) {
-                break;
-              }
-                }
-                for (Int_t irow=0;irow<159;irow++) {
-                if(!seed) continue;
+    if(bUseVfriend && vfriendEvent && vfriendEvent->TestSkipBit()==kFALSE) {
+      const AliVfriendTrack *friendTrack = 0;
+      if (vTrack->IsA()==AliESDtrack::Class()) {
+	friendTrack = ((AliESDtrack*)vTrack)->GetFriendTrack();
+      }
+      else {
+	if (iTrack<vfriendEvent->GetNumberOfTracks()) {
+	  friendTrack=vfriendEvent->GetTrack(iTrack);
+	}
+      }
+      if(friendTrack) 
+	{
+	  //
+	  TObject *calibObject=0;
+	  AliTPCseed *seed=0;
+	  for (Int_t j=0;(calibObject=friendTrack->GetCalibObject(j));++j) {
+	    if ((seed=dynamic_cast<AliTPCseed*>(calibObject))) {
+	      break;
+	    }
+	  }
+	  for (Int_t irow=0;irow<159;irow++) {
+	    if(!seed) continue;
                   
-                  AliTPCclusterMI *cluster=seed->GetClusterPointer(irow);
-                  if (!cluster) continue;
+	    AliTPCclusterMI *cluster=seed->GetClusterPointer(irow);
+	    if (!cluster) continue;
 
-                     Float_t gclf[3];
-                     cluster->GetGlobalXYZ(gclf);
+	    Float_t gclf[3];
+	    cluster->GetGlobalXYZ(gclf);
 
-                     //Double_t x[3]={cluster->GetRow(),cluster->GetPad(),cluster->GetTimeBin()};
-                     //Int_t i[1]={cluster->GetDetector()};
-                         //transform->Transform(x,i,0,1);
-                     //printf("gx %f gy  %f  gz %f \n", cluster->GetX(), cluster->GetY(),cluster->GetZ());
-                     //printf("gclf[0] %f gclf[1]  %f  gclf[2] %f \n", gclf[0], gclf[1],  gclf[2]);
+	    //Double_t x[3]={cluster->GetRow(),cluster->GetPad(),cluster->GetTimeBin()};
+	    //Int_t i[1]={cluster->GetDetector()};
+	    //transform->Transform(x,i,0,1);
+	    //printf("gx %f gy  %f  gz %f \n", cluster->GetX(), cluster->GetY(),cluster->GetZ());
+	    //printf("gclf[0] %f gclf[1]  %f  gclf[2] %f \n", gclf[0], gclf[1],  gclf[2]);
                  
-                         Int_t TPCside; 
-                     if(gclf[2]>0.) TPCside=0; // A side 
-                     else TPCside=1;
+	    Int_t TPCside; 
+	    if(gclf[2]>0.) TPCside=0; // A side 
+	    else TPCside=1;
 
-                     //
-                         //Double_t vTPCClust1[3] = { gclf[0], gclf[1],  TPCside };
-                         //fTPCClustHisto1->Fill(vTPCClust1);
+	    //
+	    //Double_t vTPCClust1[3] = { gclf[0], gclf[1],  TPCside };
+	    //fTPCClustHisto1->Fill(vTPCClust1);
 
-                         //  
-                     Double_t phi = TMath::ATan2(gclf[1],gclf[0]);
-                     if(phi < 0) phi += 2.*TMath::Pi();
+	    //  
+	    Double_t phi = TMath::ATan2(gclf[1],gclf[0]);
+	    if(phi < 0) phi += 2.*TMath::Pi();
                     
-                  //Float_t pad = cluster->GetPad();
-                  //Int_t detector = cluster->GetDetector();
-                  //Double_t vTPCClust[6] = { irow, phi, TPCside, pad, detector, gclf[2] };
-                  Double_t vTPCClust[3] = { static_cast<Double_t>(irow), phi, static_cast<Double_t>(TPCside) };
-                    if(fUseSparse) fTPCClustHisto->Fill(vTPCClust);
-                    else{
-                        h_tpc_clust_0_1_2->Fill(vTPCClust[0],vTPCClust[1],vTPCClust[2]);
-                    }
-                } //end if(bUseVfriend && vfriendEvent && ...)
-            }
+	    //Float_t pad = cluster->GetPad();
+	    //Int_t detector = cluster->GetDetector();
+	    //Double_t vTPCClust[6] = { irow, phi, TPCside, pad, detector, gclf[2] };
+	    Double_t vTPCClust[3] = { static_cast<Double_t>(irow), phi, static_cast<Double_t>(TPCside) };
+	    if(fUseSparse) fTPCClustHisto->Fill(vTPCClust);
+	    else{
+	      h_tpc_clust_0_1_2->Fill(vTPCClust[0],vTPCClust[1],vTPCClust[2]);
+	    }
+	  } //end if(bUseVfriend && vfriendEvent && ...)
+	}
     }
     if(GetAnalysisMode() == 0) ProcessTPC(mcEvent,vTrack,vEvent,vertStatus);
     else if(GetAnalysisMode() == 1) ProcessTPCITS(mcEvent,vTrack,vEvent,vertStatus);

--- a/PWGPP/TRD/AliTRDinfoGen.cxx
+++ b/PWGPP/TRD/AliTRDinfoGen.cxx
@@ -721,8 +721,8 @@ void AliTRDinfoGen::UserExec(Option_t *){
     }
 
     // read track REC info
-    if (fESDfriend->GetNumberOfTracks() > itrk) {
-      const AliESDfriendTrack* esdFriendTrack = dynamic_cast<const AliESDfriendTrack*>(fESDfriend->GetTrack(itrk));
+    const AliESDfriendTrack* esdFriendTrack = dynamic_cast<const AliESDfriendTrack*>(esdTrack->GetFriendTrack());
+    if (esdFriendTrack) {
       fTrackInfo->SetTPCoutParam(esdFriendTrack->GetTPCOut());
       fTrackInfo->SetITSoutParam(esdFriendTrack->GetITSOut());
       const AliTrackPointArray *tps(NULL);


### PR DESCRIPTION
The friend and esd tracks have no one to one mapping in the offline ESDs, the correct way of
obtaining the friend for given esdTrack is esdTrack->GetFriendTrack().
Direct acces via esdFriendEvent->GetTrack(i) is not guaranteed to return the friend for esdTrack i