### PR TITLE
Added branches to store TOF signal for the daughter tracks

### DIFF
--- a/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrEffStudy.cxx
+++ b/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrEffStudy.cxx
@@ -194,6 +194,8 @@ fTreeVariablePIDPositive(0),
 fTreeVariablePIDNegative(0),
 fTreeVariablePtMC(0),
 fTreeVariableRapMC(0),
+fTreeVariableNegTOFSignal(99999), 
+fTreeVariablePosTOFSignal(99999),
 fTreeVariablePosAlpha(0),
 fTreeVariablePosSigmaY2(0),
 fTreeVariablePosSigmaZ2(0),
@@ -269,6 +271,10 @@ fTreeCascVarPIDBachelor(0),
 fTreeCascVarPID(0),
 fTreeCascVarPtMC(0),
 fTreeCascVarRapMC(0),
+
+fTreeCascVarNegTOFSignal(99999),
+fTreeCascVarPosTOFSignal(99999),
+fTreeCascVarBachTOFSignal(99999),
 
 fTreeCascVarPosDistanceToTrueDecayPt(0),
 fTreeCascVarNegDistanceToTrueDecayPt(0),
@@ -417,6 +423,8 @@ fTreeVariablePIDPositive(0),
 fTreeVariablePIDNegative(0),
 fTreeVariablePtMC(0),
 fTreeVariableRapMC(0),
+fTreeVariableNegTOFSignal(99999), 
+fTreeVariablePosTOFSignal(99999),
 fTreeVariablePosAlpha(0),
 fTreeVariablePosSigmaY2(0),
 fTreeVariablePosSigmaZ2(0),
@@ -486,6 +494,10 @@ fTreeCascVarPIDBachelor(0),
 fTreeCascVarPID(0),
 fTreeCascVarPtMC(0),
 fTreeCascVarRapMC(0),
+
+fTreeCascVarNegTOFSignal(99999),
+fTreeCascVarPosTOFSignal(99999),
+fTreeCascVarBachTOFSignal(99999),
 
 fTreeCascVarPosDistanceToTrueDecayPt(0),
 fTreeCascVarNegDistanceToTrueDecayPt(0),
@@ -698,6 +710,8 @@ void AliAnalysisTaskStrEffStudy::UserCreateOutputObjects()
     fTreeV0->Branch("fTreeVariablePIDNegative",&fTreeVariablePIDNegative,"fTreeVariablePIDNegative/I");
     fTreeV0->Branch("fTreeVariablePtMC",&fTreeVariablePtMC,"fTreeVariablePtMC/F");
     fTreeV0->Branch("fTreeVariableRapMC",&fTreeVariableRapMC,"fTreeVariableRapMC/F");
+    fTreeV0->Branch("fTreeVariableNegTOFSignal",&fTreeVariableNegTOFSignal,"fTreeVariableNegTOFSignal/F");
+    fTreeV0->Branch("fTreeVariablePosTOFSignal",&fTreeVariablePosTOFSignal,"fTreeVariablePosTOFSignal/F");
     
     //Uncertainties
     fTreeV0->Branch("fTreeVariablePosAlpha",&fTreeVariablePosAlpha,"fTreeVariablePosAlpha/F");
@@ -789,6 +803,11 @@ void AliAnalysisTaskStrEffStudy::UserCreateOutputObjects()
     fTreeCascade->Branch("fTreeCascVarPID",&fTreeCascVarPID,"fTreeCascVarPID/I");
     fTreeCascade->Branch("fTreeCascVarPtMC",&fTreeCascVarPtMC,"fTreeCascVarPtMC/F");
     fTreeCascade->Branch("fTreeCascVarRapMC",&fTreeCascVarRapMC,"fTreeCascVarRapMC/F");
+
+    //TOF SIGNAL
+    fTreeCascade->Branch("fTreeCascVarNegTOFSignal",&fTreeCascVarNegTOFSignal,"fTreeCascVarNegTOFSignal/F");
+    fTreeCascade->Branch("fTreeCascVarPosTOFSignal",&fTreeCascVarPosTOFSignal,"fTreeCascVarPosTOFSignal/F");
+    fTreeCascade->Branch("fTreeCascVarBachTOFSignal",&fTreeCascVarBachTOFSignal,"fTreeCascVarBachTOFSignal/F");
     
     fTreeCascade->Branch("fTreeCascVarPosDistanceToTrueDecayPt",&fTreeCascVarPosDistanceToTrueDecayPt,"fTreeCascVarPosDistanceToTrueDecayPt/F");
     fTreeCascade->Branch("fTreeCascVarNegDistanceToTrueDecayPt",&fTreeCascVarNegDistanceToTrueDecayPt,"fTreeCascVarNegDistanceToTrueDecayPt/F");
@@ -1422,6 +1441,10 @@ void AliAnalysisTaskStrEffStudy::UserExec(Option_t *)
         //Get Cosine of pointing angle
         Float_t cpa=vertex.GetV0CosineOfPointingAngle(lBestPrimaryVtxPos[0],lBestPrimaryVtxPos[1],lBestPrimaryVtxPos[2]);
         fTreeVariableV0CosineOfPointingAngle = cpa;
+
+        //Get TOF signal
+        fTreeVariableNegTOFSignal = esdTrackNeg->GetTOFsignal() * 1.e-3; // in ns
+        fTreeVariablePosTOFSignal = esdTrackPos->GetTOFsignal() * 1.e-3; // in ns
         
         //Final step: get estimated masses under different mass hypotheses
         vertex.ChangeMassHypothesis(310);
@@ -1721,6 +1744,11 @@ void AliAnalysisTaskStrEffStudy::UserExec(Option_t *)
         //DCA to PV
         fTreeCascVarDCAV0ToPrimVtx = vertex.GetD(lBestPrimaryVtxPos[0],lBestPrimaryVtxPos[1],lBestPrimaryVtxPos[2]);
         fTreeCascVarDCAxyV0ToPrimVtx = vertex.GetD(lBestPrimaryVtxPos[0],lBestPrimaryVtxPos[1]);
+
+        //Get TOF signal
+        fTreeCascVarBachTOFSignal = esdTrackBach->GetTOFsignal() * 1.e-3; // in ns
+        fTreeCascVarNegTOFSignal  = esdTrackNeg->GetTOFsignal() * 1.e-3; // in ns
+        fTreeCascVarPosTOFSignal  = esdTrackPos->GetTOFsignal() * 1.e-3; // in ns
         
         //Final step: get estimated masses under different mass hypotheses
         vertex.ChangeMassHypothesis(3122);

--- a/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrEffStudy.h
+++ b/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrEffStudy.h
@@ -416,6 +416,9 @@ private:
     Int_t fTreeVariablePIDNegative;
     Float_t fTreeVariablePtMC;
     Float_t fTreeVariableRapMC;
+    //TOF info
+    Float_t fTreeVariableNegTOFSignal; //!
+    Float_t fTreeVariablePosTOFSignal; //!
     //Uncertainties
     Float_t fTreeVariablePosAlpha;
     Float_t fTreeVariablePosSigmaY2;
@@ -499,11 +502,17 @@ private:
     Int_t fTreeCascVarPIDPositive;
     Int_t fTreeCascVarPIDNegative;
     Int_t fTreeCascVarPIDBachelor;
+
     //Set tree variables
     Int_t fTreeCascVarPID;
     Float_t fTreeCascVarPtMC;
     Float_t fTreeCascVarRapMC;
     
+    //TOF info
+    Float_t fTreeCascVarNegTOFSignal; //!
+    Float_t fTreeCascVarPosTOFSignal; //!
+    Float_t fTreeCascVarBachTOFSignal; //!
+
     //Super-control vars
     Float_t fTreeCascVarPosDistanceToTrueDecayPt;
     Float_t fTreeCascVarNegDistanceToTrueDecayPt;


### PR DESCRIPTION
Included new branches in the TTrees for V0s and Cascades in order to store the measured TOF signal for the daughter tracks.