### PR TITLE
PWGCF: AliFemtoEventCut - Standarized `Clone` method

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBasicEventCut.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoBasicEventCut.h
@@ -16,9 +16,9 @@ class AliFemtoBasicEventCut : public AliFemtoEventCut {
 public:
 
   AliFemtoBasicEventCut(); ///< Default Constructor
-  AliFemtoBasicEventCut(AliFemtoBasicEventCut& c);  ///< Copy Constructor
+  AliFemtoBasicEventCut(const AliFemtoBasicEventCut& c);  ///< Copy Constructor
   virtual ~AliFemtoBasicEventCut(); ///< Destructor
-  AliFemtoBasicEventCut& operator=(AliFemtoBasicEventCut& c);  ///< Assignment Operator
+  AliFemtoBasicEventCut& operator=(const AliFemtoBasicEventCut& c);  ///< Assignment Operator
 
   void SetEventMult(const int& lo,const int& hi);     ///< Set min and max acceptable event multiplicity
   void SetVertZPos(const float& lo, const float& hi); ///< Set min and max acceptable vertex z-coordinate
@@ -36,7 +36,7 @@ public:
   virtual AliFemtoString Report();
   virtual bool Pass(const AliFemtoEvent* event);
 
-  AliFemtoBasicEventCut* Clone();
+  virtual AliFemtoEventCut* Clone() const;
 
 private:   // here are the quantities I want to cut on...
 
@@ -89,13 +89,13 @@ inline void AliFemtoBasicEventCut::SetTriggerSelection(int trig)
   fSelectTrigger = trig;
 }
 
-inline AliFemtoBasicEventCut* AliFemtoBasicEventCut::Clone()
+inline AliFemtoEventCut* AliFemtoBasicEventCut::Clone() const
 {
   AliFemtoBasicEventCut* c = new AliFemtoBasicEventCut(*this);
   return c;
 }
 
-inline AliFemtoBasicEventCut::AliFemtoBasicEventCut(AliFemtoBasicEventCut& c):
+inline AliFemtoBasicEventCut::AliFemtoBasicEventCut(const AliFemtoBasicEventCut& c):
   AliFemtoEventCut(c),
   fAcceptBadVertex(c.fAcceptBadVertex),
   fNEventsPassed(0),
@@ -111,7 +111,7 @@ inline AliFemtoBasicEventCut::AliFemtoBasicEventCut(AliFemtoBasicEventCut& c):
   fPsiEP[1] = c.fPsiEP[1];
 }
 
-inline AliFemtoBasicEventCut& AliFemtoBasicEventCut::operator=(AliFemtoBasicEventCut& c)
+inline AliFemtoBasicEventCut& AliFemtoBasicEventCut::operator=(const AliFemtoBasicEventCut& c)
 {
   if (this != &c) {
     AliFemtoEventCut::operator=(c);

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventCut.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventCut.h
@@ -64,7 +64,7 @@ public:
   virtual TList* AppendSettings(TList*, const TString& prefix="") const;
 
   virtual AliFemtoString Report() = 0; ///< A user-written method to return a string describing cuts
-  virtual AliFemtoEventCut* Clone();   ///< Returns NULL - users should overload.
+  virtual AliFemtoEventCut* Clone() const;   ///< Returns NULL - users should overload.
 
   /// Returns the analysis this cut belongs to
   AliFemtoAnalysis* HbtAnalysis();
@@ -119,7 +119,7 @@ inline void AliFemtoEventCut::SetAnalysis(AliFemtoAnalysis* analysis)
   fyAnalysis = analysis;
 }
 
-inline AliFemtoEventCut* AliFemtoEventCut::Clone()
+inline AliFemtoEventCut* AliFemtoEventCut::Clone() const
 {
   return NULL;
 }

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventCutEstimators.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventCutEstimators.cxx
@@ -50,7 +50,7 @@ AliFemtoEventCutEstimators::~AliFemtoEventCutEstimators(){
   // Default destructor
 }
 //------------------------------
-AliFemtoEventCutEstimators& AliFemtoEventCutEstimators::operator=(AliFemtoEventCutEstimators& c)
+AliFemtoEventCutEstimators& AliFemtoEventCutEstimators::operator=(const AliFemtoEventCutEstimators& c)
 {
   if (this != &c) {
     AliFemtoEventCut::operator=(c);

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventCutEstimators.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoEventCutEstimators.h
@@ -8,11 +8,6 @@
 #ifndef ALIFEMTOEVENTCUTESTIMATORS_H
 #define ALIFEMTOEVENTCUTESTIMATORS_H
 
-// do I need these lines ?
-//#ifndef StMaker_H
-//#include "StMaker.h"
-//#endif
-
 #include "AliFemtoEventCut.h"
 #include "AliFemtoEventReaderESDChain.h"
 
@@ -21,9 +16,9 @@ class AliFemtoEventCutEstimators : public AliFemtoEventCut {
 public:
 
   AliFemtoEventCutEstimators();
-  AliFemtoEventCutEstimators(AliFemtoEventCutEstimators& c);
+  AliFemtoEventCutEstimators(const AliFemtoEventCutEstimators& c);
   virtual ~AliFemtoEventCutEstimators();
-  AliFemtoEventCutEstimators& operator=(AliFemtoEventCutEstimators& c);
+  AliFemtoEventCutEstimators& operator=(const AliFemtoEventCutEstimators& c);
 
   void SetMultEst1Range(const unsigned short &lo, const unsigned short &hi);
   void SetMultEst2Range(const unsigned short &lo, const unsigned short &hi);
@@ -41,7 +36,7 @@ public:
   virtual AliFemtoString Report();
   virtual bool Pass(const AliFemtoEvent* event);
 
-  AliFemtoEventCutEstimators* Clone();
+  virtual AliFemtoEventCut* Clone() const;
 
   void SetVerboseMode(bool aVerbose);
 
@@ -86,10 +81,10 @@ inline void AliFemtoEventCutEstimators::SetCentEst4Range(const float& lo, const 
 inline void AliFemtoEventCutEstimators::SetVertZPos(const float& lo, const float& hi){fVertZPos[0]=lo; fVertZPos[1]=hi;}
 inline int  AliFemtoEventCutEstimators::NEventsPassed() const {return fNEventsPassed;}
 inline int  AliFemtoEventCutEstimators::NEventsFailed() const {return fNEventsFailed;}
-inline AliFemtoEventCutEstimators* AliFemtoEventCutEstimators::Clone() { AliFemtoEventCutEstimators* c = new AliFemtoEventCutEstimators(*this); return c;}
+inline AliFemtoEventCut* AliFemtoEventCutEstimators::Clone() const { AliFemtoEventCutEstimators* c = new AliFemtoEventCutEstimators(*this); return c;}
 inline void AliFemtoEventCutEstimators::SetVerboseMode(bool aVerbose) {fVerbose = aVerbose;}
 
-inline AliFemtoEventCutEstimators::AliFemtoEventCutEstimators(AliFemtoEventCutEstimators& c) : 
+inline AliFemtoEventCutEstimators::AliFemtoEventCutEstimators(const AliFemtoEventCutEstimators& c):
   AliFemtoEventCut(c), 
   fVerbose(c.fVerbose),
   fUseMultEst1(c.fUseMultEst1), fUseMultEst2(c.fUseMultEst2), fUseMultEst3(c.fUseMultEst3), 

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSphericityEventCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSphericityEventCut.cxx
@@ -42,7 +42,7 @@ AliFemtoSphericityEventCut::~AliFemtoSphericityEventCut(){
   // Default destructor
 }
 //------------------------------
-bool AliFemtoSphericityEventCut::Pass(const AliFemtoEvent* event){  
+bool AliFemtoSphericityEventCut::Pass(const AliFemtoEvent* event){
 
   // Pass events if they fall within the multiplicity, z-vertex position range
   // and transverse sphericity. Fail otherwise

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSphericityEventCut.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSphericityEventCut.h
@@ -14,12 +14,12 @@ class AliFemtoSphericityEventCut : public AliFemtoEventCut {
 public:
 
   AliFemtoSphericityEventCut();
-  AliFemtoSphericityEventCut(AliFemtoSphericityEventCut& c);
+  AliFemtoSphericityEventCut(const AliFemtoSphericityEventCut& c);
   virtual ~AliFemtoSphericityEventCut();
-  AliFemtoSphericityEventCut& operator=(AliFemtoSphericityEventCut& c);
+  AliFemtoSphericityEventCut& operator=(const AliFemtoSphericityEventCut& c);
 
-  void SetEventMult(const int& lo,const int& hi);
-  void SetVertZPos(const float& lo, const float& hi);
+  void SetEventMult(const int lo,const int hi);
+  void SetVertZPos(const float lo, const float hi);
   void SetAcceptBadVertex(bool b);
   int NEventsPassed() const;
   int NEventsFailed() const;
@@ -29,12 +29,12 @@ public:
   void SetStMax(double stMax );
   void SetTriggerSelection(int trig);
 
-  void SetEPVZERO(const float& lo, const float& hi);
+  void SetEPVZERO(const float lo, const float hi);
 
   virtual AliFemtoString Report();
   virtual bool Pass(const AliFemtoEvent* event);
 
-  AliFemtoSphericityEventCut* Clone();
+  virtual AliFemtoEventCut* Clone() const;
 
 private:   // here are the quantities I want to cut on...
 
@@ -57,28 +57,35 @@ private:   // here are the quantities I want to cut on...
 
 };
 
-inline void AliFemtoSphericityEventCut::SetEventMult(const int& lo, const int& hi){fEventMult[0]=lo; fEventMult[1]=hi;}
-inline void AliFemtoSphericityEventCut::SetVertZPos(const float& lo, const float& hi){fVertZPos[0]=lo; fVertZPos[1]=hi;}
-inline void AliFemtoSphericityEventCut::SetEPVZERO(const float& lo, const float& hi){fPsiEP[0]=lo; fPsiEP[1]=hi;}
+inline void AliFemtoSphericityEventCut::SetEventMult(const int lo, const int hi){fEventMult[0]=lo; fEventMult[1]=hi;}
+inline void AliFemtoSphericityEventCut::SetVertZPos(const float lo, const float hi){fVertZPos[0]=lo; fVertZPos[1]=hi;}
+inline void AliFemtoSphericityEventCut::SetEPVZERO(const float lo, const float hi){fPsiEP[0]=lo; fPsiEP[1]=hi;}
 inline int  AliFemtoSphericityEventCut::NEventsPassed() const {return fNEventsPassed;}
 inline int  AliFemtoSphericityEventCut::NEventsFailed() const {return fNEventsFailed;}
-inline void  AliFemtoSphericityEventCut::SetStMin(double stMin ) {fStCutMin=stMin;}
-inline void  AliFemtoSphericityEventCut::SetStMax(double stMax ) {fStCutMax=stMax;}
+inline void  AliFemtoSphericityEventCut::SetStMin(double stMin) {fStCutMin=stMin;}
+inline void  AliFemtoSphericityEventCut::SetStMax(double stMax) {fStCutMax=stMax;}
 inline void AliFemtoSphericityEventCut::SetTriggerSelection(int trig) { fSelectTrigger = trig; }
-inline AliFemtoSphericityEventCut* AliFemtoSphericityEventCut::Clone() { AliFemtoSphericityEventCut* c = new AliFemtoSphericityEventCut(*this); return c;}
-inline AliFemtoSphericityEventCut::AliFemtoSphericityEventCut(AliFemtoSphericityEventCut& c) : AliFemtoEventCut(c), fAcceptBadVertex(false), fNEventsPassed(0), fNEventsFailed(0), fAcceptOnlyPhysics(false),fStCutMin(0),fStCutMax(1),  fSelectTrigger(0) {
+inline AliFemtoEventCut* AliFemtoSphericityEventCut::Clone() const { AliFemtoSphericityEventCut* c = new AliFemtoSphericityEventCut(*this); return c;}
+inline AliFemtoSphericityEventCut::AliFemtoSphericityEventCut(const AliFemtoSphericityEventCut& c):
+  AliFemtoEventCut(c),
+  fAcceptBadVertex(c.fAcceptBadVertex),
+  fNEventsPassed(0),
+  fNEventsFailed(0),
+  fAcceptOnlyPhysics(c.fAcceptOnlyPhysics),
+  fStCutMin(c.fStCutMin),
+  fStCutMax(c.fStCutMax),
+  fSelectTrigger(c.fSelectTrigger)
+{
   fEventMult[0] = c.fEventMult[0];
   fEventMult[1] = c.fEventMult[1];
   fVertZPos[0] = c.fVertZPos[0];
   fVertZPos[1] = c.fVertZPos[1];
   fPsiEP[0] = c.fPsiEP[0];
   fPsiEP[1] = c.fPsiEP[1];
-  fStCutMin = c.fStCutMin;
-  fStCutMax = c.fStCutMax;
-
 }
 
-inline AliFemtoSphericityEventCut& AliFemtoSphericityEventCut::operator=(AliFemtoSphericityEventCut& c) {   
+inline AliFemtoSphericityEventCut& AliFemtoSphericityEventCut::operator=(const AliFemtoSphericityEventCut& c)
+{
   if (this != &c) {
     AliFemtoEventCut::operator=(c);
     fEventMult[0] = c.fEventMult[0];
@@ -87,8 +94,13 @@ inline AliFemtoSphericityEventCut& AliFemtoSphericityEventCut::operator=(AliFemt
     fVertZPos[1] = c.fVertZPos[1];
     fPsiEP[0] = c.fPsiEP[0];
     fPsiEP[1] = c.fPsiEP[1];
+    fAcceptBadVertex = c.fAcceptBadVertex;
+    // fNEventsPassed = c.fNEventsPassed;
+    // fNEventsFailed = c.fNEventsFailed;
+    fAcceptOnlyPhysics = c.fAcceptOnlyPhysics;
     fStCutMin = c.fStCutMin;
     fStCutMax = c.fStCutMax;
+    fSelectTrigger = c.fSelectTrigger;
   }
 
   return *this;

--- a/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSpherocityEventCut.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/AliFemtoSpherocityEventCut.h
@@ -14,9 +14,9 @@ class AliFemtoSpherocityEventCut : public AliFemtoEventCut {
 public:
 
   AliFemtoSpherocityEventCut();
-  AliFemtoSpherocityEventCut(AliFemtoSpherocityEventCut& c);
+  AliFemtoSpherocityEventCut(const AliFemtoSpherocityEventCut& c);
   virtual ~AliFemtoSpherocityEventCut();
-  AliFemtoSpherocityEventCut& operator=(AliFemtoSpherocityEventCut& c);
+  AliFemtoSpherocityEventCut& operator=(const AliFemtoSpherocityEventCut& c);
 
   void SetEventMult(const int& lo,const int& hi);
   void SetVertZPos(const float& lo, const float& hi);
@@ -34,20 +34,20 @@ public:
   virtual AliFemtoString Report();
   virtual bool Pass(const AliFemtoEvent* event);
 
-  AliFemtoSpherocityEventCut* Clone();
+  virtual AliFemtoEventCut* Clone() const;
 
 private:   // here are the quantities I want to cut on...
 
-  int fEventMult[2];      // range of multiplicity
-  float fVertZPos[2];     // range of z-position of vertex
-  float fPsiEP[2];     // range of vzero ep angle
-  bool fAcceptBadVertex;  // Set to true to accept events with bad vertex
-  long fNEventsPassed;    // Number of events checked by this cut that passed
-  long fNEventsFailed;    // Number of events checked by this cut that failed
-  bool fAcceptOnlyPhysics;// Accept only physics events
-  double fSoCutMin;       // transverse sphericity minimum
-  double fSoCutMax;       // transverse sphericity maximum
-  int  fSelectTrigger;    // If set, only given trigger will be selected
+  int fEventMult[2];       ///< range of multiplicity
+  float fVertZPos[2];      ///< range of z-position of vertex
+  float fPsiEP[2];         ///< range of vzero ep angle
+  bool fAcceptBadVertex;   ///< Set to true to accept events with bad vertex
+  long fNEventsPassed;     ///< Number of events checked by this cut that passed
+  long fNEventsFailed;     ///< Number of events checked by this cut that failed
+  bool fAcceptOnlyPhysics; ///< Accept only physics events
+  double fSoCutMin;        ///< transverse sphericity minimum
+  double fSoCutMax;        ///< transverse sphericity maximum
+  int  fSelectTrigger;     ///< If set, only given trigger will be selected
 
 #ifdef __ROOT__
   /// \cond CLASSIMP
@@ -62,11 +62,20 @@ inline void AliFemtoSpherocityEventCut::SetVertZPos(const float& lo, const float
 inline void AliFemtoSpherocityEventCut::SetEPVZERO(const float& lo, const float& hi){fPsiEP[0]=lo; fPsiEP[1]=hi;}
 inline int  AliFemtoSpherocityEventCut::NEventsPassed() const {return fNEventsPassed;}
 inline int  AliFemtoSpherocityEventCut::NEventsFailed() const {return fNEventsFailed;}
-inline void  AliFemtoSpherocityEventCut::SetSoMin(double soMin ) {fSoCutMin=soMin;}
-inline void  AliFemtoSpherocityEventCut::SetSoMax(double soMax ) {fSoCutMax=soMax;}
+inline void AliFemtoSpherocityEventCut::SetSoMin(double soMin) {fSoCutMin=soMin;}
+inline void AliFemtoSpherocityEventCut::SetSoMax(double soMax) {fSoCutMax=soMax;}
 inline void AliFemtoSpherocityEventCut::SetTriggerSelection(int trig) { fSelectTrigger = trig; }
-inline AliFemtoSpherocityEventCut* AliFemtoSpherocityEventCut::Clone() { AliFemtoSpherocityEventCut* c = new AliFemtoSpherocityEventCut(*this); return c;}
-inline AliFemtoSpherocityEventCut::AliFemtoSpherocityEventCut(AliFemtoSpherocityEventCut& c) : AliFemtoEventCut(c), fAcceptBadVertex(false), fNEventsPassed(0), fNEventsFailed(0), fAcceptOnlyPhysics(false), fSoCutMin(0), fSoCutMax(1), fSelectTrigger(0) {
+inline AliFemtoEventCut* AliFemtoSpherocityEventCut::Clone() const { AliFemtoSpherocityEventCut* c = new AliFemtoSpherocityEventCut(*this); return c;}
+inline AliFemtoSpherocityEventCut::AliFemtoSpherocityEventCut(const AliFemtoSpherocityEventCut& c):
+  AliFemtoEventCut(c),
+  fAcceptBadVertex(c.fAcceptBadVertex),
+  fNEventsPassed(0),
+  fNEventsFailed(0),
+  fAcceptOnlyPhysics(c.fAcceptOnlyPhysics),
+  fSoCutMin(c.fSoCutMin),
+  fSoCutMax(c.fSoCutMax),
+  fSelectTrigger(c.fSelectTrigger)
+{
   fEventMult[0] = c.fEventMult[0];
   fEventMult[1] = c.fEventMult[1];
   fVertZPos[0] = c.fVertZPos[0];
@@ -75,7 +84,7 @@ inline AliFemtoSpherocityEventCut::AliFemtoSpherocityEventCut(AliFemtoSpherocity
   fPsiEP[1] = c.fPsiEP[1];
 }
 
-inline AliFemtoSpherocityEventCut& AliFemtoSpherocityEventCut::operator=(AliFemtoSpherocityEventCut& c) {
+inline AliFemtoSpherocityEventCut& AliFemtoSpherocityEventCut::operator=(const AliFemtoSpherocityEventCut& c) {
   if (this != &c) {
     AliFemtoEventCut::operator=(c);
     fEventMult[0] = c.fEventMult[0];
@@ -84,6 +93,14 @@ inline AliFemtoSpherocityEventCut& AliFemtoSpherocityEventCut::operator=(AliFemt
     fVertZPos[1] = c.fVertZPos[1];
     fPsiEP[0] = c.fPsiEP[0];
     fPsiEP[1] = c.fPsiEP[1];
+
+    fAcceptBadVertex = c.fAcceptBadVertex;
+    fNEventsPassed = 0;
+    fNEventsFailed = 0;
+    fAcceptOnlyPhysics = c.fAcceptOnlyPhysics;
+    fSoCutMin = c.fSoCutMin;
+    fSoCutMax = c.fSoCutMax;
+    fSelectTrigger = c.fSelectTrigger;
   }
 
   return *this;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoEventCutCentrality.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoEventCutCentrality.h
@@ -96,7 +96,7 @@ public:
   bool PassEventPlane(const AliFemtoEvent* event) const;
   bool PassTrigger(const AliFemtoEvent* event) const;
 
-  AliFemtoEventCut* Clone() const;
+  virtual AliFemtoEventCut* Clone() const;
 
   /// Return the centrality of the event based on whatever algorithm is
   /// selected by the CentralityType member.

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoQAEventCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoQAEventCut.cxx
@@ -1,85 +1,85 @@
-////////////////////////////////////////////////////////////////////////////////
-//                                                                            //
-// AliFemtoQAEventCut - the basic cut to check QA for event cuts.             //
-// Only cuts on event multiplicity and z-vertex position                      //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
+///
+/// \file AliFemtoUser/AliFemtoQAEventCut.cxx
+///
 
 #include "AliFemtoQAEventCut.h"
-//#include <cstdio>
+#include <TString.h>
 
 #ifdef __ROOT__
-ClassImp(AliFemtoQAEventCut)
+  ClassImp(AliFemtoQAEventCut)
 #endif
 
-AliFemtoQAEventCut::AliFemtoQAEventCut() :
-  AliFemtoEventCut(),
-  fEventMult(),
-  fVertZPos(),
-  fAcceptBadVertex(false), 
-  fNEventsPassed(0), 
-  fNEventsFailed(0),
-  fHighOrLowSwitch(0), 
-  fEventMultQASwitch(kFALSE), 
-  fEventZPosQASwitch(kFALSE)
-{
-  // Default constructor
-  fEventMult[0] = 0;
-  fEventMult[1] = 100000;
-  fVertZPos[0] = -100.0;
-  fVertZPos[1] = 100.0;
-  
-  fHighOrLowSwitch = 1;
-  fEventMultQASwitch = false;
-  fEventZPosQASwitch = false;
-  fEventMultQAExclusionZone[0] = 0;
-  fEventMultQAExclusionZone[1] = 100000;
-  fEventZPosQAExclusionZone[0] = -100.0;
-  fEventZPosQAExclusionZone[1] = 100.0;
+  AliFemtoQAEventCut::AliFemtoQAEventCut() :
+    AliFemtoEventCut(),
+    fEventMult(),
+    fVertZPos(),
+    fAcceptBadVertex(false),
+    fNEventsPassed(0),
+    fNEventsFailed(0),
+    fHighOrLowSwitch(0),
+    fEventMultQASwitch(kFALSE),
+    fEventZPosQASwitch(kFALSE)
+  {
+    // Default constructor
+    fEventMult[0] = 0;
+    fEventMult[1] = 100000;
+    fVertZPos[0] = -100.0;
+    fVertZPos[1] = 100.0;
 
-} 
-//------------------------------
-AliFemtoQAEventCut::~AliFemtoQAEventCut(){
-  // Default destructor
-}
-//------------------------------
-AliFemtoQAEventCut& AliFemtoQAEventCut::operator=(AliFemtoQAEventCut& c)
-{
-  if (this != &c) {
-    fEventMult[0] = c.fEventMult[0];
-    fEventMult[1] = c.fEventMult[1];
-    fVertZPos[0] = c.fVertZPos[0];
-    fVertZPos[1] = c.fVertZPos[1];
-    
-    fHighOrLowSwitch = c.fHighOrLowSwitch;
-    fEventMultQASwitch = c.fEventMultQASwitch;
-    fEventZPosQASwitch = c.fEventZPosQASwitch;
-    fEventMultQAExclusionZone[0] = c.fEventMultQAExclusionZone[0];
-    fEventMultQAExclusionZone[1] = c.fEventMultQAExclusionZone[1];
-    fEventZPosQAExclusionZone[0] = c.fEventZPosQAExclusionZone[0];
-    fEventZPosQAExclusionZone[1] = c.fEventZPosQAExclusionZone[1];
+    fHighOrLowSwitch = 1;
+    fEventMultQASwitch = false;
+    fEventZPosQASwitch = false;
+    fEventMultQAExclusionZone[0] = 0;
+    fEventMultQAExclusionZone[1] = 100000;
+    fEventZPosQAExclusionZone[0] = -100.0;
+    fEventZPosQAExclusionZone[1] = 100.0;
+
   }
+  //------------------------------
+  AliFemtoQAEventCut::~AliFemtoQAEventCut(){
+    // Default destructor
+  }
+  //------------------------------
+  AliFemtoQAEventCut& AliFemtoQAEventCut::operator=(const AliFemtoQAEventCut& c)
+  {
+    if (this != &c) {
+      AliFemtoEventCut::operator=(c);
 
-  return *this;
-}
-//------------------------------
-bool AliFemtoQAEventCut::Pass(const AliFemtoEvent* event){
-  // Pass events if they fall within the multiplicity and z-vertex
-  // position range. If QA cutting on quantity, pass if outside 
-  // exclusion zone between low and high cut values. Fail otherwise.
-  int mult =  event->NumberOfTracks();
+      fEventMult[0] = c.fEventMult[0];
+      fEventMult[1] = c.fEventMult[1];
+      fVertZPos[0] = c.fVertZPos[0];
+      fVertZPos[1] = c.fVertZPos[1];
+
+      fHighOrLowSwitch = c.fHighOrLowSwitch;
+      fEventMultQASwitch = c.fEventMultQASwitch;
+      fEventZPosQASwitch = c.fEventZPosQASwitch;
+      fEventMultQAExclusionZone[0] = c.fEventMultQAExclusionZone[0];
+      fEventMultQAExclusionZone[1] = c.fEventMultQAExclusionZone[1];
+      fEventZPosQAExclusionZone[0] = c.fEventZPosQAExclusionZone[0];
+      fEventZPosQAExclusionZone[1] = c.fEventZPosQAExclusionZone[1];
+    }
+
+    return *this;
+  }
+  //------------------------------
+  bool AliFemtoQAEventCut::Pass(const AliFemtoEvent* event)
+  {
+    // Pass events if they fall within the multiplicity and z-vertex
+    // position range. If QA cutting on quantity, pass if outside
+    // exclusion zone between low and high cut values. Fail otherwise.
+    int mult =  event->NumberOfTracks();
   double vertexZPos = event->PrimVertPos().z();
   cout << "AliFemtoQAEventCut:: mult:       " << fEventMult[0] << " < " << mult << " < " << fEventMult[1] << endl;
   cout << "AliFemtoQAEventCut:: VertexZPos: " << fVertZPos[0] << " < " << vertexZPos << " < " << fVertZPos[1] << endl;
-  
+
   bool goodEvent;
-  
+
   if (fEventMultQASwitch) {
     goodEvent =
       ( (((mult < fEventMultQAExclusionZone[0]) && (fHighOrLowSwitch > 0))  ||
 	 ((mult > fEventMultQAExclusionZone[1]) && (fHighOrLowSwitch < 0))) &&
-      (mult > fEventMult[0]) && 
-      (mult < fEventMult[1]) && 
+      (mult > fEventMult[0]) &&
+      (mult < fEventMult[1]) &&
       (vertexZPos > fVertZPos[0]) &&
       (vertexZPos < fVertZPos[1]) &&
       (fAcceptBadVertex || (event->PrimVertCov()[4] > -1000.0)));
@@ -88,40 +88,37 @@ bool AliFemtoQAEventCut::Pass(const AliFemtoEvent* event){
     goodEvent =
       ((((vertexZPos < fEventZPosQAExclusionZone[0]) && (fHighOrLowSwitch > 0))  ||
 	((vertexZPos > fEventZPosQAExclusionZone[1]) && (fHighOrLowSwitch < 0))) &&
-      (mult > fEventMult[0]) && 
-      (mult < fEventMult[1]) && 
+      (mult > fEventMult[0]) &&
+      (mult < fEventMult[1]) &&
       (vertexZPos > fVertZPos[0]) &&
       (vertexZPos < fVertZPos[1]) &&
       (fAcceptBadVertex || (event->PrimVertCov()[4] > -1000.0)));
   }
   else {
   goodEvent =
-    ((mult > fEventMult[0]) && 
-     (mult < fEventMult[1]) && 
+    ((mult > fEventMult[0]) &&
+     (mult < fEventMult[1]) &&
      (vertexZPos > fVertZPos[0]) &&
      (vertexZPos < fVertZPos[1]) &&
      (fAcceptBadVertex || (event->PrimVertCov()[4] > -1000.0)));
   }
-  
+
   if (goodEvent) fHighOrLowSwitch *= -1;
   goodEvent ? fNEventsPassed++ : fNEventsFailed++ ;
   //cout << "AliFemtoQAEventCut:: return : " << goodEvent << endl;
   return (goodEvent);
 }
 //------------------------------
-AliFemtoString AliFemtoQAEventCut::Report(){
+AliFemtoString AliFemtoQAEventCut::Report()
+{
   // Prepare report
-  string stemp;
-  char ctemp[100];
-  snprintf(ctemp , 100, "\nMultiplicity:\t %d-%d",fEventMult[0],fEventMult[1]);
-  stemp = ctemp;
-  snprintf(ctemp , 100, "\nVertex Z-position:\t %E-%E",fVertZPos[0],fVertZPos[1]);
-  stemp += ctemp;
-  snprintf(ctemp , 100, "\nNumber of events which passed:\t%ld  Number which failed:\t%ld",fNEventsPassed,fNEventsFailed);
-  stemp += ctemp;
-  AliFemtoString returnThis = stemp;
-  return returnThis;
+  TString report;
+  report += TString::Format("\nMultiplicity:\t %d-%d",fEventMult[0],fEventMult[1])
+          + TString::Format("\nVertex Z-position:\t %E-%E",fVertZPos[0],fVertZPos[1])
+          + TString::Format("\nNumber of events which passed:\t%ld  Number which failed:\t%ld\n",fNEventsPassed,fNEventsFailed);
+  return AliFemtoString(report.Data());
 }
+
 void AliFemtoQAEventCut::SetAcceptBadVertex(bool b)
 {
   fAcceptBadVertex = b;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoQAEventCut.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoQAEventCut.h
@@ -1,28 +1,24 @@
-////////////////////////////////////////////////////////////////////////////////
-//                                                                            //
-// AliFemtoQAEventCut - the basic cut to check QA for event cuts.             //
-// Only cuts on event multiplicity and z-vertex position                      //
-//                                                                            //
-////////////////////////////////////////////////////////////////////////////////
+///
+/// \file AliFemtoUser/AliFemtoQAEventCut.h
+///
 
 #ifndef ALIFEMTOQAEVENTCUT_H
 #define ALIFEMTOQAEVENTCUT_H
 
-// do I need these lines ?
-//#ifndef StMaker_H
-//#include "StMaker.h"
-//#endif
-
 #include "AliFemtoEventCut.h"
 
+/// \class AliFemtoQAEventCut
+/// \brief The basic cut to check QA for event cuts
+///
+/// Only cuts on event multiplicity and z-vertex position
+///
 class AliFemtoQAEventCut : public AliFemtoEventCut {
-
 public:
 
   AliFemtoQAEventCut();
-  AliFemtoQAEventCut(AliFemtoQAEventCut& c);
+  AliFemtoQAEventCut(const AliFemtoQAEventCut& c);
   virtual ~AliFemtoQAEventCut();
-  AliFemtoQAEventCut& operator=(AliFemtoQAEventCut& c);
+  AliFemtoQAEventCut& operator=(const AliFemtoQAEventCut& c);
 
 
   void SetEventMult(const int& lo,const int& hi);
@@ -39,7 +35,7 @@ public:
   virtual AliFemtoString Report();
   virtual bool Pass(const AliFemtoEvent* event);
 
-  AliFemtoQAEventCut* Clone();
+  virtual AliFemtoEventCut* Clone() const;
 
 private:   // here are the quantities I want to cut on...
 
@@ -69,16 +65,21 @@ inline void AliFemtoQAEventCut::SetEventZPosQASwitch(const bool Switch) { fEvent
 inline void AliFemtoQAEventCut::SetEventZPosQAExclusionZone(const float& lo, const float& hi)  { fEventZPosQAExclusionZone[0]=lo; fEventZPosQAExclusionZone[1]=hi; }
 inline int  AliFemtoQAEventCut::NEventsPassed() const {return fNEventsPassed;}
 inline int  AliFemtoQAEventCut::NEventsFailed() const {return fNEventsFailed;}
-inline AliFemtoQAEventCut* AliFemtoQAEventCut::Clone() { AliFemtoQAEventCut* c = new AliFemtoQAEventCut(*this); return c;}
-inline AliFemtoQAEventCut::AliFemtoQAEventCut(AliFemtoQAEventCut& c) : AliFemtoEventCut(c), fAcceptBadVertex(kFALSE), fNEventsPassed(0), fNEventsFailed(0), fHighOrLowSwitch(0), fEventMultQASwitch(kFALSE), fEventZPosQASwitch(kFALSE) {
+inline AliFemtoEventCut* AliFemtoQAEventCut::Clone() const { AliFemtoQAEventCut* c = new AliFemtoQAEventCut(*this); return c;}
+inline AliFemtoQAEventCut::AliFemtoQAEventCut(const AliFemtoQAEventCut& c) :
+  AliFemtoEventCut(c),
+  fAcceptBadVertex(c.fAcceptBadVertex),
+  fNEventsPassed(0),
+  fNEventsFailed(0),
+  fHighOrLowSwitch(c.fHighOrLowSwitch),
+  fEventMultQASwitch(c.fEventMultQASwitch),
+  fEventZPosQASwitch(c.fEventZPosQASwitch)
+{
   fEventMult[0] = c.fEventMult[0];
   fEventMult[1] = c.fEventMult[1];
   fVertZPos[0] = c.fVertZPos[0];
   fVertZPos[1] = c.fVertZPos[1];
   
-  fHighOrLowSwitch = c.fHighOrLowSwitch;
-  fEventMultQASwitch = c.fEventMultQASwitch;
-  fEventZPosQASwitch = c.fEventZPosQASwitch;
   fEventMultQAExclusionZone[0] = c.fEventMultQAExclusionZone[0];
   fEventMultQAExclusionZone[1] = c.fEventMultQAExclusionZone[1];
   fEventZPosQAExclusionZone[0] = c.fEventZPosQAExclusionZone[0];


### PR DESCRIPTION
* Copy-constructors take a *constant* reference to the original object
* The `Clone()` method is marked virtual and constant and returns a standard `AliFemtoEventCut` pointer rather than the subclass
* Trailing whitespace remove automatically