### PR TITLE
Improvements to jet-hadron correlations and performance tasks

### DIFF
--- a/PWG/JETFW/AliJetContainer.cxx
+++ b/PWG/JETFW/AliJetContainer.cxx
@@ -632,6 +632,10 @@ Double_t AliJetContainer::GetLeadingHadronPt(const AliEmcalJet *jet) const
 /**
  * Retrieve the 4-momentum of leading hadron of the jet.
  * The mass hypothesis is always set to the pion mass (0.139 GeV/c^2).
+ * NOTE: The cluster energy used to calculate the momentum will always be
+ *       the _raw_ energy because the cluster container is not used. Amongst
+ *       other possible alternatives, the user could use the neutral energy
+ *       calculated at jet finding via AliEmcalJet::MaxNeutralEnergy() (for example).
  * @param[out] mom Reference to a TLorentzVector object where the result is returned
  * @param[in] jet Pointer to a AliEmcalJet object
  */

--- a/PWGJE/EMCALJetTasks/CMakeLists.txt
+++ b/PWGJE/EMCALJetTasks/CMakeLists.txt
@@ -160,7 +160,7 @@ set(SRCS
     UserTasks/AliAnalysisTaskEmcalJetCDF.cxx
     UserTasks/AliAnalysisTaskEmcalJetHadCorQA.cxx
     UserTasks/AliAnalysisTaskEmcalJetHadEPpid.cxx
-    UserTasks/AliAnalysisTaskEmcalJetHBase.cxx
+    UserTasks/AliAnalysisTaskEmcalJetHUtils.cxx
     UserTasks/AliAnalysisTaskEmcalJetHPerformance.cxx
     UserTasks/AliAnalysisTaskEmcalJetHCorrelations.cxx
     UserTasks/AliAnalysisTaskEmcalJetMassBkg.cxx

--- a/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
+++ b/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
@@ -76,7 +76,6 @@
 #pragma link C++ class AliAnalysisTaskEmcalHighMultTrigger+;
 #pragma link C++ namespace EmcalHJetMassAnalysis+;
 #pragma link C++ class EmcalHJetMassAnalysis::AliAnalysisTaskEmcalHJetMass+;
-#pragma link C++ class AliAnalysisTaskEmcalJetHCorrelations+;
 #pragma link C++ class AliAnalysisTaskEmcalJetCDF+;
 #pragma link C++ namespace NS_AliAnalysisTaskEmcalJetCDF+;
 #pragma link C++ class AliAnalysisTaskEmcalJetHadCorQA+;
@@ -217,6 +216,7 @@
 #pragma link C++ namespace PWGJE::EMCALJetTasks;
 #pragma link C++ class PWGJE::EMCALJetTasks::AliEmcalJetTaggerTaskFast+;
 #pragma link C++ class PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHPerformance+;
+#pragma link C++ class PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHCorrelations+;
 #pragma link C++ namespace PWGJE::EMCALJetTasks::Test;
 #pragma link C++ class PWGJE::EMCALJetTasks::Test::AliAnalysisTaskEmcalTriggerSelectionTest+;
 

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHBase.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHBase.cxx
@@ -8,8 +8,46 @@
 
 #include <AliLog.h>
 
+#include "AliEmcalJetTask.h"
+
 namespace PWGJE {
 namespace EMCALJetTasks {
+
+const std::map<std::string, AliAnalysisTaskEmcalJetHBase::ELeadingHadronBiasType_t> AliAnalysisTaskEmcalJetHBase::fgkLeadingHadronBiasMap = {
+  { "kCharged", AliAnalysisTaskEmcalJetHBase::kCharged},
+  { "kNeutral", AliAnalysisTaskEmcalJetHBase::kNeutral},
+  { "kBoth", AliAnalysisTaskEmcalJetHBase::kBoth}
+};
+
+/**
+ * Determine leading hadron pt in a jet. This is inspired by AliJetContainer::GetLeadingHadronMomentum(), but
+ * that particular function is avoided because the cluster energy retrieved is always the raw E while the
+ * cluster energy used in creating the jet would be preferred. One could create a cluster container and go
+ * through all of those steps, but there is a simpler approach: the leading charged and neutral momenta
+ * are stored in AliEmcalJet while performing jet finding.
+ *
+ * @param[in] jet Jet from which the leading hadron pt should be extracted
+ * @param[in] leadingHadronType Type of leading hadron pt to retrieve
+ *
+ * @return Value of the leading hadron pt
+ */
+double AliAnalysisTaskEmcalJetHBase::GetLeadingHadronPt(AliEmcalJet * jet, AliAnalysisTaskEmcalJetHBase::ELeadingHadronBiasType_t leadingHadronType)
+{
+  double maxTrackPt = 0;
+  double maxClusterPt = 0;
+
+  if (leadingHadronType == kCharged || leadingHadronType == kBoth) {
+    maxTrackPt = jet->MaxChargedPt();
+  }
+  if (leadingHadronType == kNeutral || leadingHadronType == kBoth) {
+    maxClusterPt = jet->MaxNeutralPt();
+  }
+
+  // The max value will be 0 unless it was filled. Thus, it will only be greater if
+  // it was requested.
+  return (maxTrackPt > maxClusterPt) ? maxTrackPt : maxClusterPt;
+}
+
 
 /**
  * Function to calculate angle between jet and EP in the 1st quadrant (0,Pi/2).

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHBase.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHBase.h
@@ -11,11 +11,28 @@
  * @date 23 Feb 2018
  */
 
+#include <string>
+#include <map>
+
+class AliEmcalJet;
+
 namespace PWGJE {
 namespace EMCALJetTasks {
 
 class AliAnalysisTaskEmcalJetHBase {
  public:
+  /**
+   * @enum ELeadingHadronBiasType_t
+   * @brief Determine the jet leading hadron bias type
+   */
+  enum ELeadingHadronBiasType_t {
+    kCharged = 0,   //!<! Charged hadron bias
+    kNeutral = 1,   //!<! Neutral hadron bias
+    kBoth = 2       //!<! Leading is from the leader of both
+  };
+  static const std::map<std::string, ELeadingHadronBiasType_t> fgkLeadingHadronBiasMap; //!<! Map from name to leading hadron bias used with the YAML config
+  static double GetLeadingHadronPt(AliEmcalJet * jet, ELeadingHadronBiasType_t leadingHadronType);
+
   static double RelativeEPAngle(double jetAngle, double epAngle);
 };
 

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.cxx
@@ -33,9 +33,10 @@
 #include "AliAnalysisTaskEmcalEmbeddingHelper.h"
 #include "AliAnalysisTaskEmcalJetHBase.h"
 
-/// \cond CLASSIMP
-ClassImp(AliAnalysisTaskEmcalJetHCorrelations);
-/// \endcond
+ClassImp(PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHCorrelations);
+
+namespace PWGJE {
+namespace EMCALJetTasks {
 
 // 0-10% centrality: Semi-Good Runs
 Double_t AliAnalysisTaskEmcalJetHCorrelations::p0_10SG[17] = {0.906767, 0.0754127, 1.11638, -0.0233078, 0.795454, 0.00935385, -0.000327857, 1.08903, 0.0107272, 0.443252, -0.143411, 0.965822, 0.359156, -0.581221, 1.0739, 0.00632828, 0.706356};
@@ -1528,3 +1529,6 @@ AliParticleContainer * AliAnalysisTaskEmcalJetHCorrelations::CreateParticleOrTra
 
   return partCont;
 }
+
+} /* namespace EMCALJetTasks */
+} /* namespace PWGJE */

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.cxx
@@ -31,7 +31,7 @@
 #include "AliTrackContainer.h"
 #include "AliJetContainer.h"
 #include "AliAnalysisTaskEmcalEmbeddingHelper.h"
-#include "AliAnalysisTaskEmcalJetHBase.h"
+#include "AliAnalysisTaskEmcalJetHUtils.h"
 
 ClassImp(PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHCorrelations);
 
@@ -380,7 +380,7 @@ Bool_t AliAnalysisTaskEmcalJetHCorrelations::Run()
     leadJet = kFALSE;
     if (jet == leadingJet) leadJet = kTRUE;
     biasedJet = BiasedJet(jet);
-    epAngle = PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHBase::RelativeEPAngle(jet->Phi(), fEPV0);
+    epAngle = PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHUtils::RelativeEPAngle(jet->Phi(), fEPV0);
 
     // Fill jet properties
     fHistJetEtaPhi->Fill(jet->Eta(), jet->Phi());
@@ -511,7 +511,7 @@ Bool_t AliAnalysisTaskEmcalJetHCorrelations::Run()
           leadJet = kFALSE;
           if (jet == leadingJet) { leadJet = kTRUE; }
           biasedJet = BiasedJet(jet);
-          epAngle = PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHBase::RelativeEPAngle(jet->Phi(), fEPV0);
+          epAngle = PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHUtils::RelativeEPAngle(jet->Phi(), fEPV0);
 
           // Make sure event contains a biased jet above our threshold (reduce stats of sparse)
           if (jet->Pt() < 15 || biasedJet == kFALSE) continue;

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.h
@@ -33,6 +33,9 @@ class AliParticleContainer;
 
 #include "AliAnalysisTaskEmcalJet.h"
 
+namespace PWGJE {
+namespace EMCALJetTasks {
+
 class AliAnalysisTaskEmcalJetHCorrelations : public AliAnalysisTaskEmcalJet {
  public:
   /**
@@ -247,8 +250,10 @@ class AliAnalysisTaskEmcalJetHCorrelations : public AliAnalysisTaskEmcalJet {
   AliAnalysisTaskEmcalJetHCorrelations(const AliAnalysisTaskEmcalJetHCorrelations&); // not implemented
   AliAnalysisTaskEmcalJetHCorrelations& operator=(const AliAnalysisTaskEmcalJetHCorrelations&); // not implemented
 
-  /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskEmcalJetHCorrelations, 15);
-  /// \endcond
+  ClassDef(AliAnalysisTaskEmcalJetHCorrelations, 16);
 };
+
+} /* namespace EMCALJetTasks */
+} /* namespace PWGJE */
+
 #endif

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHPerformance.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHPerformance.cxx
@@ -3,7 +3,7 @@
  */
 
 #include "AliAnalysisTaskEmcalJetHPerformance.h"
-#include "AliAnalysisTaskEmcalJetHBase.h"
+#include "AliAnalysisTaskEmcalJetHUtils.h"
 
 #include <map>
 #include <vector>
@@ -42,7 +42,7 @@ AliAnalysisTaskEmcalJetHPerformance::AliAnalysisTaskEmcalJetHPerformance():
   fResponseMatrixFillMap(),
   fResponseFromThreeJetCollections(true),
   fMinFractionShared(0.),
-  fLeadingHadronBiasType(AliAnalysisTaskEmcalJetHBase::kCharged)
+  fLeadingHadronBiasType(AliAnalysisTaskEmcalJetHUtils::kCharged)
 {
 }
 
@@ -59,7 +59,7 @@ AliAnalysisTaskEmcalJetHPerformance::AliAnalysisTaskEmcalJetHPerformance(const c
   fResponseMatrixFillMap(),
   fResponseFromThreeJetCollections(true),
   fMinFractionShared(0.),
-  fLeadingHadronBiasType(AliAnalysisTaskEmcalJetHBase::kCharged)
+  fLeadingHadronBiasType(AliAnalysisTaskEmcalJetHUtils::kCharged)
 {
 }
 
@@ -112,7 +112,7 @@ void AliAnalysisTaskEmcalJetHPerformance::RetrieveTaskPropertiesFromYAMLConfig()
   bool res = fYAMLConfig.GetProperty({baseName, "leadingHadronBiasType"}, hadronBiasStr, false);
   // Only attempt to set the property if it is retrieved successfully
   if (res) {
-    fLeadingHadronBiasType = AliAnalysisTaskEmcalJetHBase::fgkLeadingHadronBiasMap.at(hadronBiasStr);
+    fLeadingHadronBiasType = AliAnalysisTaskEmcalJetHUtils::fgkLeadingHadronBiasMap.at(hadronBiasStr);
   }
 
   // Base class options
@@ -416,9 +416,9 @@ void AliAnalysisTaskEmcalJetHPerformance::FillResponseMatrix(AliEmcalJet * jet1,
     else if (title == "distance")
       values.emaplce_back(jet2->ClosestJetDistance());
     else if (title == "#theta_{jet,1}^{EP}")
-      values.emaplce_back(AliAnalysisTaskEmcalJetHBase::RelativeEPAngle(jet1->Phi(), fEPV0));
+      values.emaplce_back(AliAnalysisTaskEmcalJetHUtils::RelativeEPAngle(jet1->Phi(), fEPV0));
     else if (title == "#theta_{jet,2}^{EP}")
-      values.emaplce_back(AliAnalysisTaskEmcalJetHBase::RelativeEPAngle(jet2->Phi(), fEPV0));
+      values.emaplce_back(AliAnalysisTaskEmcalJetHUtils::RelativeEPAngle(jet2->Phi(), fEPV0));
     else if (title == "p_{T,particle,1}^{leading} (GeV/c)")
       values.emplace_back(GetLeadingHadronPt(jets1, jet1));
     else if (title == "p_{T,particle,2}^{leading} (GeV/c)")
@@ -444,8 +444,8 @@ AliAnalysisTaskEmcalJetHPerformance::AliRMJet AliAnalysisTaskEmcalJetHPerformanc
   rmJet.fArea = jet->Area();
   rmJet.fPhi = jet->Phi();
   rmJet.fDistance = jet->ClosestJetDistance();
-  rmJet.fRelativeEPAngle = AliAnalysisTaskEmcalJetHBase::RelativeEPAngle(jet->Phi(), fEPV0);
-  rmJet.fLeadingHadronPt = AliAnalysisTaskEmcalJetHBase::GetLeadingHadronPt(jet, fLeadingHadronBiasType);
+  rmJet.fRelativeEPAngle = AliAnalysisTaskEmcalJetHUtils::RelativeEPAngle(jet->Phi(), fEPV0);
+  rmJet.fLeadingHadronPt = AliAnalysisTaskEmcalJetHUtils::GetLeadingHadronPt(jet, fLeadingHadronBiasType);
 
   return rmJet;
 }

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHPerformance.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHPerformance.h
@@ -17,6 +17,7 @@ class AliEmcalJet;
 #include "AliYAMLConfiguration.h"
 #include "AliAnalysisTaskEmcalJet.h"
 #include "AliEmcalEmbeddingQA.h"
+#include "AliAnalysisTaskEmcalJetHBase.h"
 
 // operator<< has to be forward declared carefully to stay in the global namespace so that it works with CINT.
 // For generally how to keep the operator in the global namespace, See: https://stackoverflow.com/a/38801633
@@ -33,12 +34,12 @@ class AliAnalysisTaskEmcalJetHPerformance : public AliAnalysisTaskEmcalJet {
    * Wrapper to contain the properties for a jet to simplify filling the response matrix histogram
    */
   struct AliRMJet {
-    double fPt;
-    double fArea;
-    double fPhi;
-    double fRelativeEPAngle;
-    double fLeadingHadronPt;
-    double fDistance;
+    double fPt;                 //!<! Jet pt
+    double fArea;               //!<! Jet area
+    double fPhi;                //!<! jet phi
+    double fRelativeEPAngle;    //!<! Angle relative to the event plane
+    double fLeadingHadronPt;    //!<! Leading hadron pt
+    double fDistance;           //!<! Distance to the matched jet
   };
 
   AliAnalysisTaskEmcalJetHPerformance();
@@ -76,8 +77,8 @@ class AliAnalysisTaskEmcalJetHPerformance : public AliAnalysisTaskEmcalJet {
   // Response matrix functions
   void SetupResponseMatrixHists();
   void CreateResponseMatrix();
-  void FillResponseMatrix(AliEmcalJet * jet1, AliEmcalJet * jet2, AliJetContainer * jets1, AliJetContainer * jets2);
-  AliRMJet CreateAliRMJet(AliEmcalJet * jet, AliJetContainer * jetCont) const;
+  void FillResponseMatrix(AliEmcalJet * jet1, AliEmcalJet * jet2);
+  AliRMJet CreateAliRMJet(AliEmcalJet * jet) const;
 
   // Basic configuration
   PWG::Tools::AliYAMLConfiguration fYAMLConfig; ///< YAML configuration file
@@ -102,6 +103,7 @@ class AliAnalysisTaskEmcalJetHPerformance : public AliAnalysisTaskEmcalJet {
   #endif
   bool fResponseFromThreeJetCollections; ///<  If true, the det level jets in collection 2 are only an intermediate step. They are used to get part level jets to match to hybrid jets
   double fMinFractionShared;             ///<  Minimum fraction of shared jet pt required for matching a hybrid jet to detector level
+  AliAnalysisTaskEmcalJetHBase::ELeadingHadronBiasType_t fLeadingHadronBiasType; ///<  Leading hadron in jet bias type (either charged, neutral, or both)
 
   ClassDef(AliAnalysisTaskEmcalJetHPerformance, 1);
 };

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHPerformance.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHPerformance.h
@@ -17,7 +17,7 @@ class AliEmcalJet;
 #include "AliYAMLConfiguration.h"
 #include "AliAnalysisTaskEmcalJet.h"
 #include "AliEmcalEmbeddingQA.h"
-#include "AliAnalysisTaskEmcalJetHBase.h"
+#include "AliAnalysisTaskEmcalJetHUtils.h"
 
 // operator<< has to be forward declared carefully to stay in the global namespace so that it works with CINT.
 // For generally how to keep the operator in the global namespace, See: https://stackoverflow.com/a/38801633
@@ -103,7 +103,7 @@ class AliAnalysisTaskEmcalJetHPerformance : public AliAnalysisTaskEmcalJet {
   #endif
   bool fResponseFromThreeJetCollections; ///<  If true, the det level jets in collection 2 are only an intermediate step. They are used to get part level jets to match to hybrid jets
   double fMinFractionShared;             ///<  Minimum fraction of shared jet pt required for matching a hybrid jet to detector level
-  AliAnalysisTaskEmcalJetHBase::ELeadingHadronBiasType_t fLeadingHadronBiasType; ///<  Leading hadron in jet bias type (either charged, neutral, or both)
+  AliAnalysisTaskEmcalJetHUtils::ELeadingHadronBiasType_t fLeadingHadronBiasType; ///<  Leading hadron in jet bias type (either charged, neutral, or both)
 
   ClassDef(AliAnalysisTaskEmcalJetHPerformance, 1);
 };

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHUtils.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHUtils.cxx
@@ -1,8 +1,8 @@
 //
-// Base class for Jet-Hadron correlation analysis
+// Utilities class for Jet-Hadron correlation analysis
 //
 
-#include "AliAnalysisTaskEmcalJetHBase.h"
+#include "AliAnalysisTaskEmcalJetHUtils.h"
 
 #include <TMath.h>
 
@@ -13,10 +13,10 @@
 namespace PWGJE {
 namespace EMCALJetTasks {
 
-const std::map<std::string, AliAnalysisTaskEmcalJetHBase::ELeadingHadronBiasType_t> AliAnalysisTaskEmcalJetHBase::fgkLeadingHadronBiasMap = {
-  { "kCharged", AliAnalysisTaskEmcalJetHBase::kCharged},
-  { "kNeutral", AliAnalysisTaskEmcalJetHBase::kNeutral},
-  { "kBoth", AliAnalysisTaskEmcalJetHBase::kBoth}
+const std::map<std::string, AliAnalysisTaskEmcalJetHUtils::ELeadingHadronBiasType_t> AliAnalysisTaskEmcalJetHUtils::fgkLeadingHadronBiasMap = {
+  { "kCharged", AliAnalysisTaskEmcalJetHUtils::kCharged},
+  { "kNeutral", AliAnalysisTaskEmcalJetHUtils::kNeutral},
+  { "kBoth", AliAnalysisTaskEmcalJetHUtils::kBoth}
 };
 
 /**
@@ -31,7 +31,7 @@ const std::map<std::string, AliAnalysisTaskEmcalJetHBase::ELeadingHadronBiasType
  *
  * @return Value of the leading hadron pt
  */
-double AliAnalysisTaskEmcalJetHBase::GetLeadingHadronPt(AliEmcalJet * jet, AliAnalysisTaskEmcalJetHBase::ELeadingHadronBiasType_t leadingHadronType)
+double AliAnalysisTaskEmcalJetHUtils::GetLeadingHadronPt(AliEmcalJet * jet, AliAnalysisTaskEmcalJetHUtils::ELeadingHadronBiasType_t leadingHadronType)
 {
   double maxTrackPt = 0;
   double maxClusterPt = 0;
@@ -58,7 +58,7 @@ double AliAnalysisTaskEmcalJetHBase::GetLeadingHadronPt(AliEmcalJet * jet, AliAn
  *
  * @return Angle between jet and EP in the 1st quadrant (0,Pi/2)
  */
-double AliAnalysisTaskEmcalJetHBase::RelativeEPAngle(double jetAngle, double epAngle)
+double AliAnalysisTaskEmcalJetHUtils::RelativeEPAngle(double jetAngle, double epAngle)
 {
   double dphi = (epAngle - jetAngle);
 
@@ -79,7 +79,7 @@ double AliAnalysisTaskEmcalJetHBase::RelativeEPAngle(double jetAngle, double epA
 
   // Warn if we are not in the proper range
   if ( dphi < 0 || dphi > TMath::Pi()/2 ) {
-    AliWarningGeneralStream("AliAnalysisTaskEmcalJetHBase") << ": dPHI not in range [0, 0.5*Pi]!\n";
+    AliWarningGeneralStream("AliAnalysisTaskEmcalJetHUtils") << ": dPHI not in range [0, 0.5*Pi]!\n";
   }
 
   return dphi;   // dphi in [0, Pi/2]

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHUtils.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHUtils.h
@@ -1,9 +1,9 @@
-#ifndef ALIANALYSISTASKEMCALJETHBASE_H
-#define ALIANALYSISTASKEMCALJETHBASE_H
+#ifndef ALIANALYSISTASKEMCALJETHUTILS_H
+#define ALIANALYSISTASKEMCALJETHUTILS_H
 
 /**
- * @class AliAnalysisTaskEmcalJetHBase
- * @brief Jet-hadron correlations base class
+ * @class AliAnalysisTaskEmcalJetHUtils
+ * @brief Jet-hadron correlations utilities class
  *
  * Contains funtionality that is shared between the various classes
  *
@@ -19,7 +19,7 @@ class AliEmcalJet;
 namespace PWGJE {
 namespace EMCALJetTasks {
 
-class AliAnalysisTaskEmcalJetHBase {
+class AliAnalysisTaskEmcalJetHUtils {
  public:
   /**
    * @enum ELeadingHadronBiasType_t
@@ -39,4 +39,4 @@ class AliAnalysisTaskEmcalJetHBase {
 } /* namespace EMCALJetTasks */
 } /* namespace PWGJE */
 
-#endif /* AliAnalysisTaskEmcalJetHBase.h */
+#endif /* AliAnalysisTaskEmcalJetHUtils.h */

--- a/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJetHCorrelations.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJetHCorrelations.C
@@ -1,4 +1,4 @@
-AliAnalysisTaskEmcalJetHCorrelations* AddTaskEmcalJetHCorrelations(
+PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHCorrelations* AddTaskEmcalJetHCorrelations(
    const char *nTracks              = "usedefault",
    const char *nCaloClusters        = "usedefault",
    // Jet options
@@ -16,14 +16,14 @@ AliAnalysisTaskEmcalJetHCorrelations* AddTaskEmcalJetHCorrelations(
    const Bool_t lessSparseAxes      = 0,
    const Bool_t widerTrackBin       = 0,
    // Corrections
-   const AliAnalysisTaskEmcalJetHCorrelations::ESingleTrackEfficiency_t singleTrackEfficiency = AliAnalysisTaskEmcalJetHCorrelations::kEffDisable,
+   const PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHCorrelations::ESingleTrackEfficiency_t singleTrackEfficiency = PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHCorrelations::kEffDisable,
    const Bool_t embeddingCorrection = kFALSE,
    const char * embeddingCorrectionFilename = "alien:///alice/cern.ch/user/r/rehlersi/embeddingCorrection.root",
    const char * embeddingCorrectionHistName = "embeddingCorrection",
    const char *suffix               = "biased"
 )
 {  
-  AliAnalysisTaskEmcalJetHCorrelations * task = AliAnalysisTaskEmcalJetHCorrelations::AddTaskEmcalJetHCorrelations(
+  PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHCorrelations * task = PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHCorrelations::AddTaskEmcalJetHCorrelations(
                           nTracks, nCaloClusters,
                           trackBias, clusterBias,
                           nTracksMixedEvent, minNTracksMixedEvent, minNEventsMixedEvent,


### PR DESCRIPTION
Includes:
- Move Correlations task to PWGJE::EMCALJetTasks
- Preserve axis order in the Performance task (following the order that they are defined in YAML)
- Performance task bug fixes
- Move to custom retrieval of leading hadron momentum to ensure that the proper cluster momentum is selected
- Add documentation on cluster energy (it only retrieves the raw E()) to leading hadron momentum function in the Jet FW