### PR TITLE
EMCal Embed: Update jet taggers

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetTagger.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetTagger.cxx
@@ -222,8 +222,8 @@ void AliAnalysisTaskEmcalJetTagger::Init(){
    if(!cont1 || !cont2) AliError("Missing jet container");
    
    // when full azimuth, don't do anything
-   Double_t phiMin1 = cont1->GetJetPhiMin(), phiMax1 = cont1->GetJetPhiMax();
-   Double_t phiMin2 = cont2->GetJetPhiMin(), phiMax2 = cont2->GetJetPhiMax();
+   Double_t phiMin1 = cont1->GetJetPhiMin();
+   Double_t phiMin2 = cont2->GetJetPhiMin();
    Bool_t isZeroTwoPi1 = kFALSE;
    //check only one side of phi, since the upper bound is not well defined
    if(phiMin1 > -1.e-6 && phiMin1 < 1.e-6) isZeroTwoPi1 = kTRUE;
@@ -272,7 +272,7 @@ Bool_t AliAnalysisTaskEmcalJetTagger::FillHistograms()
 
     //fill histo with angle between jet axis and constituents
     for(Int_t icc=0; icc<jet1->GetNumberOfTracks(); icc++) {
-      AliVParticle *vp = static_cast<AliVParticle*>(jet1->TrackAt(icc, jetCont->GetParticleContainer()->GetArray()));//fTracks));
+      AliVParticle *vp = static_cast<AliVParticle*>(jet1->Track(icc));
       if(!vp) continue;
       Double_t dEta = jet1->Eta()-vp->Eta();
       Double_t dPhi = jet1->Phi()-vp->Phi();

--- a/PWGJE/EMCALJetTasks/UserTasks/AliEmcalJetTaggerTaskFast.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliEmcalJetTaggerTaskFast.cxx
@@ -319,7 +319,7 @@ namespace PWGJE {
 
       //fill histo with angle between jet axis and constituents
       for(Int_t icc=0; icc<jet1->GetNumberOfTracks(); icc++) {
-        AliVParticle *vp = static_cast<AliVParticle*>(jet1->TrackAt(icc, jetCont->GetParticleContainer()->GetArray()));//fTracks));
+        AliVParticle *vp = static_cast<AliVParticle*>(jet1->Track(icc));
         if(!vp) continue;
         Double_t dEta = jet1->Eta()-vp->Eta();
         Double_t dPhi = jet1->Phi()-vp->Phi();


### PR DESCRIPTION
The tasks use `AliEmcalJet::TrackAt(int index, TClonesArray * tracks)`,
with the particles accessed via the particle container attached to the
jet container. This will cause harmless warnings (the proper particle
is _always_ returned) as explained in the docs of `AliEmcalJet` and
of the embedding framework. However, the tasks should be updated to
silence these warnings under the new embedding framework.

This update causes no change in functionality.

Two compiler warnings for unused variables are also fixed.

@lcunquei , @mfasDa I'm switching over to these classes to better handle jet matching and cut on the shared momentum fraction. This modification is trivial, but allows the use of these classes without warnings under the new embedding framework. If possible, I'd like to get this into the tag for tomorrow - please let me know what you think!