### PR TITLE
Update Run1 Proton-Lambda femto analysis code for Run2 analysis

### DIFF
--- a/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AddTaskPLFemto.C
+++ b/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AddTaskPLFemto.C
@@ -1,16 +1,15 @@
 
 //const Bool_t anaType   = 1;//0 HD; 1 UU;
-const Bool_t OnlineSearchV0 = kFALSE; // True=online, false=offline
-const TString whichV0 = "Lambda"; //Lambda or Kaon
-const TString whichV0region = "signal";//signal or sideband region
-const TString whichMixing = "Tracklets"; //V0M or #Tracklets
+//const Bool_t OnlineSearchV0 = kFALSE; // True=online, false=offline
+//const TString whichV0 = "Lambda"; //Lambda or Kaon
+//const TString whichV0region = "signal";//signal or sideband region
+//const TString whichMixing = "Tracklets"; //V0M or #Tracklets
 //const int whichfilterbit = 96;
-const int whichfilterbit = 128;
+//const int whichfilterbit = 128;
 
 AliAnalysisTaskPLFemto *AliAnalysisTaskPLFemto(Int_t system=0/*0=pp,1=PbPb*/,
-					       
-					       Bool_t theMCon=kFALSE)
-  
+					       Bool_t theMCon=kFALSE,Bool_t OnlineSearchV0=kFALSE,
+					       TString whichV0="Lambda",TString whichV0region="signal")
 {
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
 
@@ -19,48 +18,46 @@ AliAnalysisTaskPLFemto *AliAnalysisTaskPLFemto(Int_t system=0/*0=pp,1=PbPb*/,
       ::Error("AddTaskPLFemtoSpectra", "No analysis manager to connect to.");
       return NULL;
     }  
-  
-  //AliVEventHandler *inputEvents = 0;
-  
-  // Event handlers:
-  /*
-  if(!theMCon)
-    {
-      inputEvents = new AliAODInputHandler();
-      mgr->SetInputEventHandler(inputEvents);
-    }
-  else //Monte Carlo
-    {
-      inputEvents = new AliMCEventHandler();
-      mgr->SetMCtruthEventHandler(inputEvents);
-    }
-  */
-  //CREATE THE TASK
+
+
+  //Specify cut values for systematic checks:
+  //Default
+  AliFemtoCutValues::systematics DefaultValues = AliFemtoCutValues::kDefault;
+  //Pt threshold for protons varied by 20% down:
+  AliFemtoCutValues::systematics ProtonPtValueDown = AliFemtoCutValues::kProtonVariationLowerPtThresholdDown;
+  //Pt threshold for protons varied by 20% up:
+  AliFemtoCutValues::systematics ProtonPtValueUp = AliFemtoCutValues::kProtonVariationLowerPtThresholdUp;
+
+
 
   printf("CREATE TASK\n");
   // create the task
 
-  AliAnalysisTaskPLFemto *task = new AliAnalysisTaskPLFemto("AliAnalysisPLFemto",OnlineSearchV0,whichV0,whichV0region,whichfilterbit);//calls the constructor of the class
+  //AliAnalysisTaskPLFemto *task[2];
+
+  AliAnalysisTaskPLFemto *task = new AliAnalysisTaskPLFemto("AliAnalysisPLFemto",OnlineSearchV0,whichV0,whichV0region);//calls the constructor of the class
   task->SelectCollisionCandidates(AliVEvent::kMB);
   //task->SelectCollisionCandidates(AliVEvent::kINT7+AliVEvent::kMB);
   //task->SelectCollisionCandidates(AliVEvent::kINT7+AliVEvent::kMB+AliVEvent::kINT8);
-  //AliAnalysisTaskPLFemto *task = new AliAnalysisTaskPLFemto("AliAnalysisPLFemto");//calls the constructor of the class
 
-  task->SetMC(theMCon);
+  task->SetSystematics(DefaultValues);
+  //task->SetSystematics(PtProtonLowValue);
+  //task->SetSystematics(kDefault);
+  //task->SetTrackCuts(DefaultValues);
+  //task->SetCuts(cutVariationPtProtonLow);
   task->SetDebugLevel(0);
+  task->SetMC(theMCon);
+
   mgr->AddTask(task);
 
 
 
   // Create and connect containers for input/output
-  
-  //usercomment = "_" + usercomment;  
 
   TString outputfile = AliAnalysisManager::GetCommonFileName();
-
   outputfile += ":PWGCF_PLFemto";
   //outputfile += usercomment;
-  
+
 
   // ------ input data ------
   TString input = "infemto";
@@ -73,8 +70,6 @@ AliAnalysisTaskPLFemto *AliAnalysisTaskPLFemto(Int_t system=0/*0=pp,1=PbPb*/,
   //output3 += usercomment;
   TString output4 = "TPdir";//directory for two particle quantities
   //output4 += usercomment;
-  //TString output5 = "MC_dir";//directory for purely Monte Carlo output (doesn't work at the moment)
-  //output5 += usercomment;
 
   //AliAnalysisDataContainer *cinput0  = mgr->GetCommonInputContainer();
 
@@ -83,27 +78,19 @@ AliAnalysisTaskPLFemto *AliAnalysisTaskPLFemto(Int_t system=0/*0=pp,1=PbPb*/,
  // ----- output data -----
 
   AliAnalysisDataContainer *coutput1 = mgr->CreateContainer(output1,TList::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
-
   AliAnalysisDataContainer *coutput2 = mgr->CreateContainer(output2,TList::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
-
   AliAnalysisDataContainer *coutput3 = mgr->CreateContainer(output3,TList::Class(),AliAnalysisManager::kOutputContainer, outputfile.Data());
-
   AliAnalysisDataContainer *coutput4 = mgr->CreateContainer(output4,TList::Class(),AliAnalysisManager::kOutputContainer, outputfile.Data());
-  
-  
-    
+
   mgr->ConnectInput(task,0,mgr->GetCommonInputContainer());
-  
+
   mgr->ConnectOutput(task,1,coutput1);
-
   mgr->ConnectOutput(task,2,coutput2);
-
   mgr->ConnectOutput(task,3,coutput3);
-  
   mgr->ConnectOutput(task,4,coutput4);
 
 
-  
+
   return task;
 }
 

--- a/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliAnalysisTaskPLFemto.cxx
+++ b/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliAnalysisTaskPLFemto.cxx
@@ -37,7 +37,6 @@
 #include "AliAODRecoDecay.h"
 #include "AliESDtrack.h"
 #include "AliAODMCParticle.h"
-//#include "AliNormalizationCounter.h"
 #include "AliAODEvent.h"
 #include "AliAnalysisTaskPLFemto.h"
 #include "AliInputEventHandler.h"
@@ -46,26 +45,29 @@
 #include "AliFemtoLambdaParticle.h"
 #include "AliFemtoProtonParticle.h"
 #include "AliPPVsMultUtils.h"
-//#include "AliAODv0.h"
+#include "AliAODTracklets.h"
+#include "AliMultSelection.h"
 
-#ifdef __ROOT__
+#include "TVector2.h"
+
 ClassImp(AliAnalysisTaskPLFemto)
-#endif
+
 Double_t TPCradii[9] = {85.,105.,125.,145.,165.,185.,205.,225.,245.};//must be global to be used on grid
 //__________________________________________________________________________
 AliAnalysisTaskPLFemto::AliAnalysisTaskPLFemto():
   AliAnalysisTaskSE(),
-  fEvents(0),
+  fAliEventCuts(),
+  fTrigger(AliVEvent::kMB),
+  fIsRun1(true),
+  fV0PercentileMax(100),
   fUseMCInfo(kFALSE),
-  fOnlineV0(kTRUE),
+  fOnlineV0(kFALSE),
   fOutput(0),
   fOutputSP(0),
   fOutputTP(0),
   fOutputPID(0),
   fAODMCEvent(0),
   fCEvents(0),
-  fTPCradii(0),
-  fSphericityvalue(-9999.),
   fwhichV0("Lambda"),
   fwhichAntiV0("Anti-"+fwhichV0),
   fwhichV0region("signal"),
@@ -74,11 +76,11 @@ AliAnalysisTaskPLFemto::AliAnalysisTaskPLFemto():
   fProtonCounter(0),
   fAntiProtonCounter(0),
   fXiCounter(0),
+  fTPCradii(0),
   fEventNumber(0),
-  fWhichfilterbit(128),
   fPIDResponse(0),
   fGTI(0),
-  fTrackBuffSize(1000),
+  fTrackBuffSize(10000),
   fEC(new AliFemtoLambdaEventCollection2 **[kZVertexBins]),
   fEvt(0),
   fV0cand(new AliFemtoLambdaParticle[kV0TrackLimit]),
@@ -86,9 +88,11 @@ AliAnalysisTaskPLFemto::AliAnalysisTaskPLFemto():
   fProtoncand(new AliFemtoProtonParticle[kProtonTrackLimit]),
   fAntiProtoncand(new AliFemtoProtonParticle[kProtonTrackLimit]),
   fXicand(new AliFemtoXiParticle[kXiTrackLimit]),
-  fCuts(new AliFemtoCutValues()),
-  fAnaUtils(new AliAnalysisUtils())
+  fCuts(new AliFemtoCutValues(AliFemtoCutValues::kDefault)),
+  fAnaUtils(new AliAnalysisUtils()),
+  fcutType(AliFemtoCutValues::kDefault)
 {
+  Info("AliAnalysisTaskPLFemto","Calling default Constructor");
   //
   // Constructor. Initialization of Inputs and Outputs
   //
@@ -96,8 +100,6 @@ AliAnalysisTaskPLFemto::AliAnalysisTaskPLFemto():
   fTPCradii = TPCradii;
 
   for(Int_t i=0; i<3;i++) fPrimVertex[i] = -9999.;
-
-  Info("AliAnalysisTaskPLFemto","Calling default Constructor");
 
   for(UChar_t iZBin=0;iZBin<kZVertexBins;iZBin++)
     {
@@ -109,12 +111,17 @@ AliAnalysisTaskPLFemto::AliAnalysisTaskPLFemto():
 	}
     }
 
+  fCuts->SetCutVariation(fcutType);
+  fWhichfilterbit = fCuts->GetFilterBit();
   fAnaUtils->SetMinPlpContribSPD(3);
 }
 //___________________________________________________________________________
-AliAnalysisTaskPLFemto::AliAnalysisTaskPLFemto(const Char_t* name,Bool_t OnlineCase,TString whichV0,TString whichV0region,const int whichfilterbit) :
+AliAnalysisTaskPLFemto::AliAnalysisTaskPLFemto(const Char_t* name,Bool_t OnlineCase,TString whichV0,TString whichV0region) :
   AliAnalysisTaskSE(name),
-  fEvents(0),
+  fAliEventCuts(),
+  fTrigger(AliVEvent::kMB),
+  fIsRun1(true),
+  fV0PercentileMax(100),
   fUseMCInfo(kFALSE),
   fOnlineV0(OnlineCase),
   fOutput(0),
@@ -123,8 +130,6 @@ AliAnalysisTaskPLFemto::AliAnalysisTaskPLFemto(const Char_t* name,Bool_t OnlineC
   fOutputPID(0),
   fAODMCEvent(0),
   fCEvents(0),
-  fTPCradii(0),
-  fSphericityvalue(-9999.),
   fwhichV0(whichV0),
   fwhichAntiV0("Anti-"+whichV0),
   fwhichV0region(whichV0region),
@@ -133,11 +138,11 @@ AliAnalysisTaskPLFemto::AliAnalysisTaskPLFemto(const Char_t* name,Bool_t OnlineC
   fProtonCounter(0),
   fAntiProtonCounter(0),
   fXiCounter(0),
+  fTPCradii(0),
   fEventNumber(0),
-  fWhichfilterbit(whichfilterbit),
   fPIDResponse(0),
   fGTI(0),
-  fTrackBuffSize(1000),
+  fTrackBuffSize(10000),
   fEC(new AliFemtoLambdaEventCollection2 **[kZVertexBins]),
   fEvt(0),
   fV0cand(new AliFemtoLambdaParticle[kV0TrackLimit]),
@@ -145,10 +150,10 @@ AliAnalysisTaskPLFemto::AliAnalysisTaskPLFemto(const Char_t* name,Bool_t OnlineC
   fProtoncand(new AliFemtoProtonParticle[kProtonTrackLimit]),
   fAntiProtoncand(new AliFemtoProtonParticle[kProtonTrackLimit]),
   fXicand(new AliFemtoXiParticle[kXiTrackLimit]),
-  fCuts(new AliFemtoCutValues()),
-  fAnaUtils(new AliAnalysisUtils())
+  fCuts(new AliFemtoCutValues(AliFemtoCutValues::kDefault)),
+  fAnaUtils(new AliAnalysisUtils()),
+  fcutType(AliFemtoCutValues::kDefault)
 {
-
   Info("AliAnalysisTaskPLFemto","Calling extended Constructor");
 
   fTPCradii = TPCradii;
@@ -169,8 +174,11 @@ AliAnalysisTaskPLFemto::AliAnalysisTaskPLFemto(const Char_t* name,Bool_t OnlineC
   DefineOutput(2,TList::Class());
   DefineOutput(3,TList::Class());
   DefineOutput(4,TList::Class());
+  DefineOutput(5,TList::Class());
 
   fAnaUtils->SetMinPlpContribSPD(3);
+  fCuts->SetCutVariation(fcutType);
+  fWhichfilterbit = fCuts->GetFilterBit();
 }
 
 //___________________________________________________________________________
@@ -186,9 +194,7 @@ AliAnalysisTaskPLFemto::~AliAnalysisTaskPLFemto() {
   delete fOutputPID;
   delete fCEvents;
 
-  if (fGTI)
-    delete[] fGTI;
-  fGTI=0;
+  if (fGTI) { delete[] fGTI; fGTI=NULL;}
 
   if(fEC)
     {
@@ -205,14 +211,13 @@ AliAnalysisTaskPLFemto::~AliAnalysisTaskPLFemto() {
       delete[] fEC; fEC = NULL;
     }
 
-  if(fEC){ delete fEC; fEC = NULL;}
   if(fV0cand) delete[] fV0cand;
   if(fAntiV0cand) delete[] fAntiV0cand;
   if(fProtoncand) delete[] fProtoncand;
   if(fAntiProtoncand) delete[] fAntiProtoncand;
   if(fXicand) delete[] fXicand;
-  if(fCuts) delete fCuts;
-  if(fPIDResponse) delete fPIDResponse;
+  if(fCuts){ delete fCuts; fCuts = NULL;}
+  if(fPIDResponse){ delete fPIDResponse; fPIDResponse = NULL;}
 
   // TODO: Uncomment this line when the AliAnalysisUtils destructor is fixed
   // if(fAnaUtils) delete fAnaUtils;
@@ -225,7 +230,7 @@ void AliAnalysisTaskPLFemto::Init()
   //
   return;
 }
-Bool_t AliAnalysisTaskPLFemto::GoodTPCFitMapSharedMap(const AliAODTrack *pTrack, const AliAODTrack *nTrack)
+Bool_t AliAnalysisTaskPLFemto::GoodTPCFitMapSharedMap(const AliAODTrack *pTrack,const AliAODTrack *nTrack)
 {
   //This method was inherited form H. Beck analysis
 
@@ -399,7 +404,7 @@ void AliAnalysisTaskPLFemto::StoreGlobalTrackReference(AliAODTrack *track)
   //   //    return;
   // }
 
-  // Check that the id is positive
+  // Check that the id is positive (global track)
   if(track->GetID()<0)
     {
       //    printf("Warning: track has negative ID: %d\n",track->GetID());
@@ -422,6 +427,11 @@ void AliAnalysisTaskPLFemto::StoreGlobalTrackReference(AliAODTrack *track)
       if( (!track->GetFilterMap()) &&
 	  (!track->GetTPCNcls())   )
 	return;
+
+      if(!track->GetTPCNcls())
+	{
+	  std::cout << "TPC cluster" << track->GetTPCNcls() << std::endl;
+	}
 
     // Imagine the other way around,
     // the zero map zero clusters track
@@ -447,71 +457,67 @@ void AliAnalysisTaskPLFemto::StoreGlobalTrackReference(AliAODTrack *track)
   // 	   ,track->GetTPCNcls());
   // }
 
-  // Assign the pointer
+  //if(track->GetTPCNcls() <= 0) std::cout << "no tpc cluster" << std::endl;
+  //if(fGTI[track->GetID()] >= 0) std::cout << "two tracks same ID " << std::endl;
+
+
+  // Assign the pointer (ID of global track)
   (fGTI[track->GetID()]) = track;
 }
 //_________________________________________________________________
-Double_t *AliAnalysisTaskPLFemto::DCAxy(const AliAODTrack *track, const AliVEvent *evt)
+void AliAnalysisTaskPLFemto::DCAxy(const AliAODTrack *track, const AliVEvent *evt,Double_t *dcaxy)
 {
-  Double_t *DCAVals = new Double_t[2];
-  Double_t *errorVals = new Double_t[2];
+  //standard "error" values:
+  dcaxy[0] = -9999.;
+  dcaxy[1] = -9999.;
 
-  errorVals[0] = -9999.;
-  errorVals[1] = -9999.;
-
-
-  if(!track)
-    {
-      printf("Pointer to track is zero!\n");
-      return errorVals;
-    }
+  if(!track) return;
 
   // Create an external parameter from the AODtrack
   AliExternalTrackParam etp;
   etp.CopyFromVTrack(track);
 
   Double_t covar[3]={0.,0.,0.};
-  if(!etp.PropagateToDCA(evt->GetPrimaryVertex(),evt->GetMagneticField(),10.,DCAVals,covar)) return errorVals;
-
-  // return the DCAxy
-  delete[] errorVals;
-  return DCAVals;
+  if(!etp.PropagateToDCA(evt->GetPrimaryVertex(),evt->GetMagneticField(),10.,dcaxy,covar))
+    {
+      dcaxy[0] = -9999.;
+      dcaxy[1] = -9999.;
+      return;
+    }
 }
 //_________________________________________________________________
 Bool_t AliAnalysisTaskPLFemto::GoodDCA(const AliAODTrack *AODtrack,const AliAODEvent *aodEvent,Int_t type)
 {
   TString fillthis = "";
-  Double_t *xyz = new Double_t[2];
+  Double_t dcaxyz[2];
 
-  if(fWhichfilterbit == 128) xyz = DCAxy(fGTI[-AODtrack->GetID()-1],fInputEvent);
-  else xyz = DCAxy(AODtrack,fInputEvent);
+  if(fWhichfilterbit == 128) DCAxy(fGTI[-AODtrack->GetID()-1],fInputEvent,dcaxyz);
+  else DCAxy(AODtrack,fInputEvent,dcaxyz);
 
   if(type == 4) //proton
     {
       fillthis = "fProtonDCAxyDCAz";
-      ((TH2F*)(fOutputSP->FindObject(fillthis)))->Fill(xyz[0],xyz[1]);
+      ((TH2F*)(fOutputSP->FindObject(fillthis)))->Fill(dcaxyz[0],dcaxyz[1]);
 
       fillthis = "fProtonDCAxy";
-      ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(xyz[0]);
+      ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(dcaxyz[0]);
 
-      if(fabs(xyz[1])<fCuts->GetProtonDCAzCut())//check the influence of z cut on DCAxy
+      if(fabs(dcaxyz[1])<fCuts->GetProtonDCAzCut())//check the influence of z cut on DCAxy
 	{
 	  fillthis = "fProtonDCAxyCutz";
-	  ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(xyz[0]);
+	  ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(dcaxyz[0]);
 	}
 
       fillthis = "fProtonDCAz";
-      ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(xyz[1]);
-
+      ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(dcaxyz[1]);
 
       //Find the pt bin for pt dependent DCA analysis:
       int ptbin = fCuts->FindProtonPtBinDCA(AODtrack->Pt());
-
       if(!fUseMCInfo && ptbin != -9999)
 	{
 	  fillthis = "fProtonDCAxyDCAzPt";
 	  fillthis += ptbin;
-	  ((TH2F*)(fOutputSP->FindObject(fillthis)))->Fill(xyz[0],xyz[1]);//total amount of protons in exp.
+	  ((TH2F*)(fOutputSP->FindObject(fillthis)))->Fill(dcaxyz[0],dcaxyz[1]);//total amount of protons in exp.
 	}
       else if(fUseMCInfo && ptbin != -9999)
 	{
@@ -526,10 +532,10 @@ Bool_t AliAnalysisTaskPLFemto::GoodDCA(const AliAODTrack *AODtrack,const AliAODE
 	  fillthis += 0;
 	  fillthis += "PtBin";
 	  fillthis += ptbin;
-	  ((TH2F*)(fOutputSP->FindObject(fillthis)))->Fill(xyz[0],xyz[1]);//total amount of protons
+	  ((TH2F*)(fOutputSP->FindObject(fillthis)))->Fill(dcaxyz[0],dcaxyz[1]);//total amount of protons
 
 	  //check the DCA of the proton in Monte Carlo
-	  if(mcproton->GetPdgCode() == 2212) //be shure it is a proton
+	  //if(mcproton->GetPdgCode() == 2212) //be shure it is a proton
 	    {
 	      if(mcproton->IsPhysicalPrimary() && !mcproton->IsSecondaryFromWeakDecay())
 		{
@@ -537,7 +543,7 @@ Bool_t AliAnalysisTaskPLFemto::GoodDCA(const AliAODTrack *AODtrack,const AliAODE
 		  fillthis += 1;
 		  fillthis += "PtBin";
 		  fillthis += ptbin;
-		  ((TH2F*)(fOutputSP->FindObject(fillthis)))->Fill(xyz[0],xyz[1]);//primary protons
+		  ((TH2F*)(fOutputSP->FindObject(fillthis)))->Fill(dcaxyz[0],dcaxyz[1]);//primary protons
 		}
 	      else if(mcproton->IsSecondaryFromWeakDecay() && !mcproton->IsSecondaryFromMaterial())
 		{
@@ -545,7 +551,27 @@ Bool_t AliAnalysisTaskPLFemto::GoodDCA(const AliAODTrack *AODtrack,const AliAODE
 		  fillthis += 2;
 		  fillthis += "PtBin";
 		  fillthis += ptbin;
-		  ((TH2F*)(fOutputSP->FindObject(fillthis)))->Fill(xyz[0],xyz[1]);//secondary protons
+		  ((TH2F*)(fOutputSP->FindObject(fillthis)))->Fill(dcaxyz[0],dcaxyz[1]);//secondary protons
+
+
+		  AliAODMCParticle* mcprotonMother = (AliAODMCParticle*)mcarray->At(mcproton->GetMother());
+		  int PDGcode = mcprotonMother->GetPdgCode();
+
+		  //check DCA of Lambda hyperon:
+		  if(PDGcode == 3122)
+		    {
+		      fillthis = "fProtonDCAxyDCAzMCPtBinLambda";
+		      fillthis += "PtBin";
+		      fillthis += ptbin;
+		      ((TH2F*)(fOutputSP->FindObject(fillthis)))->Fill(dcaxyz[0],dcaxyz[1]);//secondary protons
+		    }
+		  if(PDGcode == 3222)
+		    {
+		      fillthis = "fProtonDCAxyDCAzMCPtBinSigma";
+		      fillthis += "PtBin";
+		      fillthis += ptbin;
+		      ((TH2F*)(fOutputSP->FindObject(fillthis)))->Fill(dcaxyz[0],dcaxyz[1]);//secondary protons
+		    }
 		}
 	      else if(mcproton->IsSecondaryFromMaterial())
 		{
@@ -553,53 +579,52 @@ Bool_t AliAnalysisTaskPLFemto::GoodDCA(const AliAODTrack *AODtrack,const AliAODE
 		  fillthis += 3;
 		  fillthis += "PtBin";
 		  fillthis += ptbin;
-		  ((TH2F*)(fOutputSP->FindObject(fillthis)))->Fill(xyz[0],xyz[1]);//material protons
+		  ((TH2F*)(fOutputSP->FindObject(fillthis)))->Fill(dcaxyz[0],dcaxyz[1]);//material protons
 		}
 	    }
+	    /*
 	  else //background
 	    {
 	      fillthis = "fProtonDCAxyDCAzMCCase";
 	      fillthis += 4;
 	      fillthis += "PtBin";
 	      fillthis += ptbin;
-	      ((TH2F*)(fOutputSP->FindObject(fillthis)))->Fill(xyz[0],xyz[1]);//total amount of protons
+	      ((TH2F*)(fOutputSP->FindObject(fillthis)))->Fill(dcaxyz[0],dcaxyz[1]);//total amount of protons
 	    }
+	    */
 	}
     }
   else if(type == -4) //antiproton
     {
       fillthis = "fAntiProtonDCAxyDCAz";
-      ((TH2F*)(fOutputSP->FindObject(fillthis)))->Fill(xyz[0],xyz[1]);
+      ((TH2F*)(fOutputSP->FindObject(fillthis)))->Fill(dcaxyz[0],dcaxyz[1]);
 
       fillthis = "fAntiProtonDCAxy";
-      ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(xyz[0]);
+      ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(dcaxyz[0]);
 
-      if(fabs(xyz[1])<fCuts->GetProtonDCAzCut())//check the influence of z cut on DCAxy
+      if(fabs(dcaxyz[1])<fCuts->GetProtonDCAzCut())//check the influence of z cut on DCAxy
 	{
 	  fillthis = "fAntiProtonDCAxyCutz";
-	  ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(xyz[0]);
+	  ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(dcaxyz[0]);
 	}
 
       fillthis = "fAntiProtonDCAz";
-      ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(xyz[1]);
+      ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(dcaxyz[1]);
     }
 
-  if(fabs(xyz[0]) < fCuts->GetProtonDCAxyCut())//first cut on xy-value
+  if(fabs(dcaxyz[0]) < fCuts->GetProtonDCAxyCut())//first cut on xy-value
     {
-      if(fabs(xyz[1]) < fCuts->GetProtonDCAzCut())//then on z-value
+      if(fabs(dcaxyz[1]) < fCuts->GetProtonDCAzCut())//then on z-value
 	{
-	  delete[] xyz;
 	  return kTRUE;
 	}
       else
 	{
-	  delete[] xyz;
 	  return kFALSE;
 	}
     }
   else
     {
-      delete[] xyz;
       return kFALSE;
     }
 }
@@ -618,8 +643,37 @@ Int_t AliAnalysisTaskPLFemto::GetNumberOfTrackletsInEtaRange(AliAODEvent* ev,Dou
     }
   TString fillthis = "fNTracklets";
   ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(count);
-
+  /*
+  AliAODHeader *header = dynamic_cast<AliAODHeader*>(ev->GetHeader());
+  if(header)
+    {
+      count = header->GetRefMultiplicityComb08();
+    }
+  */
   return count;
+}
+//________________________________________________________________________________________________
+void AliAnalysisTaskPLFemto::GetNumberOfTPCtracksInEtaRange(AliAODEvent* aodEvent,Double_t mineta,Double_t maxeta)
+{
+
+  Int_t count = 0;
+  for(Int_t iTrack=0;iTrack<aodEvent->GetNumberOfTracks();iTrack++)
+    {
+      AliAODTrack *track = dynamic_cast<AliAODTrack*>(aodEvent->GetTrack(iTrack));
+      if(!track)
+	{
+	  AliFatal("Not a standard AOD");
+	  continue;
+	}
+
+      if(!track->TestFilterBit(128)) continue;
+
+      Double_t eta=track->Eta();
+      if(eta>mineta && eta<maxeta) count++;
+    }
+  TString fillthis = "fNTPCTracks";
+  if(count>0)((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(count);
+
 }
 //________________________________________________________________________________________________
 Bool_t AliAnalysisTaskPLFemto::PileUpRejection(AliAODEvent* ev)
@@ -647,9 +701,9 @@ Int_t *AliAnalysisTaskPLFemto::MultiplicityBinFinderzVertexBinFinder(AliAODEvent
 {
   Int_t *MixingBins = new Int_t[2];
 
-
-  Float_t multipl = GetNumberOfTrackletsInEtaRange(aodEvent,-0.8,0.8);//this is the multiplicty calculated with tracklets
-  if(multipl <= 0.) //multiplicity estimation fails
+  Int_t multipl = GetNumberOfTrackletsInEtaRange(aodEvent,-0.8,0.8);//this is the multiplicty calculated with tracklets, (bug, before it was float)
+  GetNumberOfTPCtracksInEtaRange(aodEvent,-0.8,0.8);
+  if(multipl <= 0) //multiplicity estimation fails
     {
       MixingBins[0] = -9999;
       MixingBins[1] = -9999;
@@ -674,22 +728,33 @@ Int_t *AliAnalysisTaskPLFemto::MultiplicityBinFinderzVertexBinFinder(AliAODEvent
 
   if(multBin+1 > kMultiplicityBins) std::cout << "Change the Multiplicity maximum" << std::endl;
 
-  Double_t deltaZ = (kZVertexStop - kZVertexStart)/(Double_t)kZVertexBins;
+  Double_t deltaZ = (fCuts->GetEvtzVertexUp() - fCuts->GetEvtzVertexLow())/(Double_t)kZVertexBins;
 
   Int_t zVertexBin = 0;
   for(Int_t i=0;i<kZVertexBins;i++)
     {
-      if((kZVertexStart + i*deltaZ)<zVertex && zVertex<(kZVertexStart + (i+1)*deltaZ))
+      if((fCuts->GetEvtzVertexLow() + i*deltaZ)<zVertex && zVertex<(fCuts->GetEvtzVertexLow() + (i+1)*deltaZ))
 	{
 	  zVertexBin = i;
 	  break;
 	}
     }
 
-
-
   MixingBins[0] = zVertexBin;
   MixingBins[1] = multBin;
+
+  //check filling of reference multiplicity:
+
+  AliAODHeader *header = dynamic_cast<AliAODHeader*>(aodEvent->GetHeader());
+  if(header)
+    {
+      Double_t RefMultiplicity08 = header->GetRefMultiplicityComb08();
+      TString fillthis = "fRefMultiplicity08";
+      ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(RefMultiplicity08);
+
+      fillthis = "fNTrackletsRefMultiplicity";
+      ((TH2F*)(fOutputSP->FindObject(fillthis)))->Fill(multipl,RefMultiplicity08);
+    }
 
   return MixingBins;
 }
@@ -704,7 +769,6 @@ Double_t AliAnalysisTaskPLFemto::CalcSphericityEvent(AliAODEvent *aodEvent)
 
   Int_t numOfTracks = aodEvent->GetNumberOfTracks();
   if(numOfTracks<3) return -9999.;//if already at this point not enough tracks are in the event -> return
-
 
   Int_t nTracks = 0;
   for(Int_t iTrack=0;iTrack<numOfTracks;iTrack++)
@@ -822,7 +886,7 @@ Bool_t AliAnalysisTaskPLFemto::SingleParticleQualityCuts(const AliAODTrack *aodt
   Double_t pt = aodtrack->Pt();
   Double_t ch = aodtrack->Charge();
 
-  if(ch>0)//protons
+  if(ch>0.)//protons
     {
       if(fabs(eta) > fCuts->GetProtonEtaRange()) return kFALSE; //should lie within the ALICE acceptance
       if(pt < fCuts->GetProtonPIDthrPtLow()) return kFALSE;
@@ -834,7 +898,7 @@ Bool_t AliAnalysisTaskPLFemto::SingleParticleQualityCuts(const AliAODTrack *aodt
       if(!(SelectPID(aodtrack,aodEvent,4))) return kFALSE; //select protons
       if(!GoodDCA(aodtrack,aodEvent,4)) return kFALSE; //to increase the probability for primaries
     }
-  else
+  else//anti-protons
     {
       if(fabs(eta) > fCuts->GetProtonEtaRange()) return kFALSE; //should lie within the ALICE acceptance
       if(pt < fCuts->GetProtonPIDthrPtLow()) return kFALSE;
@@ -853,12 +917,17 @@ Bool_t AliAnalysisTaskPLFemto::SingleParticleQualityCuts(const AliAODTrack *aodt
 //________________________________________________________________________
 Bool_t AliAnalysisTaskPLFemto::SingleParticleQualityCuts(const AliAODv0 *v0)
 {
+
   AliAODTrack *posTrack = fGTI[v0->GetPosID()];
   AliAODTrack *negTrack = fGTI[v0->GetNegID()];
   Double_t poseta = posTrack->Eta();
   Double_t negeta = negTrack->Eta();
   Double_t posTPCcls = posTrack->GetTPCNcls();
   Double_t negTPCcls = negTrack->GetTPCNcls();
+
+  //needed?
+  //Double_t fracSharedClustersPos = Double_t(daughterTrackPos->GetTPCnclsS()) / Double_t(daughterTrackPos->GetTPCncls());
+  //Double_t fracSharedClustersNeg = Double_t(daughterTrackNeg->GetTPCnclsS()) / Double_t(daughterTrackNeg->GetTPCncls());
 
   if(v0->GetNDaughters() != 2) return kFALSE;
   if(v0->GetNProngs() != 2) return kFALSE;
@@ -868,6 +937,16 @@ Bool_t AliAnalysisTaskPLFemto::SingleParticleQualityCuts(const AliAODv0 *v0)
   if(fabs(poseta) > fCuts->GetV0EtaRange()) return kFALSE;
   if(fabs(negeta) > fCuts->GetV0EtaRange()) return kFALSE;
   if(v0->Pt() < fCuts->GetV0PIDthrPtLow()) return kFALSE; //below it just enhances background
+
+  // Pile-up rejection cut for RUN2
+  if (!fIsRun1 && !posTrack->HasPointOnITSLayer(0) &&
+      !posTrack->HasPointOnITSLayer(1) && !posTrack->HasPointOnITSLayer(4) &&
+      !posTrack->HasPointOnITSLayer(5) && !(posTrack->GetTOFBunchCrossing() == 0)) return kFALSE;
+
+  if (!fIsRun1 && !negTrack->HasPointOnITSLayer(0) &&
+      !negTrack->HasPointOnITSLayer(1) && !negTrack->HasPointOnITSLayer(4) &&
+      !negTrack->HasPointOnITSLayer(5) && !(negTrack->GetTOFBunchCrossing() == 0)) return kFALSE;
+
 
   return kTRUE;
 }
@@ -895,17 +974,24 @@ void AliAnalysisTaskPLFemto::ProtonSelector(AliAODEvent *aodEvent)
       if(!track->TestFilterBit(fWhichfilterbit)) continue;
       if(fWhichfilterbit == 128 && !CheckGlobalTrack(track)) continue; //Does a global track exist for the TPC only track?
 
-
       //to select only good track conditions (very strict):
       //does only work with filterbit(128) commented out?
       //if((!(track->GetStatus() & AliESDtrack::kITSrefit) || (!(track->GetStatus() & AliESDtrack::kTPCrefit)))) continue;
       //if(!(track->GetStatus()&AliESDtrack::kTPCrefit)) continue;
 
+
       Double_t charge = track->Charge();
       if(charge>0.)
 	{
 	  if(fProtonCounter > kProtonTrackLimit) continue;
+
 	  if(!SingleParticleQualityCuts(track,aodEvent)) continue;//Define additional quality criteria
+
+	  AliAODTrack *globaltrack = fGTI[-track->GetID()-1];
+
+	  fillthis = "fHistTrackFilterMap";
+	  ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(globaltrack->GetFilterMap());
+
 
 	  //fill proton parameters:
 	  //____________________________________________
@@ -914,12 +1000,15 @@ void AliAnalysisTaskPLFemto::ProtonSelector(AliAODEvent *aodEvent)
 	  if(fWhichfilterbit == 128) fProtoncand[fProtonCounter].fID = (fGTI[-track->GetID()-1])->GetID();
 	  else fProtoncand[fProtonCounter].fID = track->GetID();
 	  fProtoncand[fProtonCounter].fEta = track->Eta();
-	  GetGlobalPositionAtGlobalRadiiThroughTPC(track,aodEvent->GetMagneticField(),fProtoncand[fProtonCounter].fPrimPosTPC,fPrimVertex);
+	  fProtoncand[fProtonCounter].fProtonTag = kTRUE;
+	  //
+	  //GetGlobalPositionAtGlobalRadiiThroughTPC(track,aodEvent->GetMagneticField(),fProtoncand[fProtonCounter].fPrimPosTPC,fPrimVertex);
 
 	  //calculate phi* to check for possible merging/splitting effects:
 	  for(int radius=0;radius<9;radius++)
 	    {
 	      fProtoncand[fProtonCounter].fPhistar[radius] = PhiS(track,aodEvent->GetMagneticField(),fTPCradii[radius]);
+	      fProtoncand[fProtonCounter].fPositionTPC[radius] = GetGlobalPositionAtGlobalRadiiThroughTPC(track,aodEvent->GetMagneticField(),fTPCradii[radius],fPrimVertex);
 	    }
 
 	  fillthis = "fNProtonsTot";
@@ -942,9 +1031,9 @@ void AliAnalysisTaskPLFemto::ProtonSelector(AliAODEvent *aodEvent)
 
 	      //Monte Carlo functions:
 	      GetProtonOrigin(track,aodEvent,4);//evaluated with all the cuts applied
-	      double protontruth[3] = {-9999,-9999.,-9999.};
-	      double protontruth_mother[3] = {-9999,-9999.,-9999.};
-	      double protontruth_motherParton[3] = {-9999,-9999.,-9999.};
+	      double protontruth[3] = {-9999.,-9999.,-9999.};
+	      double protontruth_mother[3] = {-9999.,-9999.,-9999.};
+	      double protontruth_motherParton[3] = {-9999.,-9999.,-9999.};
 	      int PDGcodes[3] = {-9999,-9999,-9999};
 	      GetMCMomentum(track,protontruth,protontruth_mother,protontruth_motherParton,PDGcodes,aodEvent,4);
 	      fProtoncand[fProtonCounter].fMomentumMC.SetXYZ(protontruth[0],protontruth[1],protontruth[2]);
@@ -983,15 +1072,24 @@ void AliAnalysisTaskPLFemto::ProtonSelector(AliAODEvent *aodEvent)
 	  fAntiProtoncand[fAntiProtonCounter].fMomentum.SetXYZ(track->Px(),track->Py(),track->Pz());
 	  if(fWhichfilterbit == 128) fAntiProtoncand[fAntiProtonCounter].fID = (fGTI[-track->GetID()-1])->GetID();
 	  else fAntiProtoncand[fAntiProtonCounter].fID = track->GetID();
+	  fAntiProtoncand[fAntiProtonCounter].fProtonTag = kTRUE;
 	  fAntiProtoncand[fAntiProtonCounter].fEta = track->Eta();
+
+	  //calculate phi* to check for possible merging/splitting effects:
+	  for(int radius=0;radius<9;radius++)
+	    {
+	      fAntiProtoncand[fAntiProtonCounter].fPhistar[radius] = PhiS(track,aodEvent->GetMagneticField(),fTPCradii[radius]);
+	      fAntiProtoncand[fAntiProtonCounter].fPositionTPC[radius] = GetGlobalPositionAtGlobalRadiiThroughTPC(track,aodEvent->GetMagneticField(),fTPCradii[radius],fPrimVertex);
+	    }
+
 
 	  if(fUseMCInfo)
 	    {
 	      //Monte Carlo functions:
 	      GetProtonOrigin(track,aodEvent,-4);//evaluated with all the cuts applied
-	      double antiprotontruth[3] = {-9999,-9999.,-9999.};
-	      double antiprotontruth_mother[3] = {-9999,-9999.,-9999.};
-	      double antiprotontruth_motherParton[3] = {-9999,-9999.,-9999.};
+	      double antiprotontruth[3] = {-9999.,-9999.,-9999.};
+	      double antiprotontruth_mother[3] = {-9999.,-9999.,-9999.};
+	      double antiprotontruth_motherParton[3] = {-9999.,-9999.,-9999.};
 	      int PDGcodes[3] = {-9999,-9999,-9999};
 	      GetMCMomentum(track,antiprotontruth,antiprotontruth_mother,antiprotontruth_motherParton,PDGcodes,aodEvent,-4);
 	      fAntiProtoncand[fAntiProtonCounter].fMomentumMC.SetXYZ(antiprotontruth[0],antiprotontruth[1],antiprotontruth[2]);
@@ -1065,9 +1163,16 @@ void AliAnalysisTaskPLFemto::V0Selector(AliAODEvent *aodEvent)
       AliAODTrack *pTrack = fGTI[v0->GetPosID()];
       AliAODTrack *nTrack = fGTI[v0->GetNegID()];
 
-
       if((!pTrack) || (!nTrack)) continue;
       if(!SingleParticleQualityCuts(v0)) continue;
+
+      //Probably better to do it in this way (no real difference to the method below):
+      //if(!SelectV0PID(v0,fwhichV0) && !SelectV0PID(v0,fwhichAntiV0)) continue;
+
+
+      //FillV0Selection(v0,aodEvent,fwhichV0);
+      //FillV0Selection(v0,aodEvent,fwhichAntiV0);
+
 
       if(SelectV0PID(v0,fwhichV0))//V0 selection
 	{
@@ -1103,24 +1208,28 @@ void AliAnalysisTaskPLFemto::XiSelector(AliAODEvent *aodEvent)
       Double_t pointXi = Xi->CosPointingAngleXi(xvP,yvP,zvP);
       if(!Xi) continue;
 
-      if(Xi->ChargeXi() > 0)
+
+
+      if(Xi->ChargeXi() > 0)//Xip
 	{
 	}
-      else if(Xi->ChargeXi() < 0)
+      else if(Xi->ChargeXi() < 0)//Xim
 	{
 	  Double_t massXi = Xi->MassXi();
 
-	  AliAODTrack* pTrack = fGTI[Xi->GetPosID()];
-	  AliAODTrack* nTrack1 = fGTI[Xi->GetBachID()];
-	  AliAODTrack* nTrack2 = fGTI[Xi->GetNegID()];
+	  AliAODTrack *nTrack2=dynamic_cast<AliAODTrack*>(Xi->GetDaughter(1));
+	  AliAODTrack *pTrack=dynamic_cast<AliAODTrack*>(Xi->GetDaughter(0));
+	  AliAODTrack *nTrack1=dynamic_cast<AliAODTrack*>(Xi->GetDecayVertexXi()->GetDaughter(0));
 
-	  if((pTrack->GetID() == nTrack1->GetID()) || (pTrack->GetID() == nTrack2->GetID()) || (nTrack1->GetID() == nTrack2->GetID())) continue;
+	  if(!pTrack || !nTrack1 || !nTrack2 ) continue;
+
+	  if((pTrack->GetID() == nTrack1->GetID()) || (pTrack->GetID() == nTrack2->GetID()) || (nTrack1->GetID() == nTrack2->GetID())) continue;//this would be weird
 
 	  Int_t posTPCcluster = pTrack->GetTPCNcls();
 	  Int_t negTPCcluster1 = nTrack1->GetTPCNcls();
 	  Int_t negTPCcluster2 = nTrack2->GetTPCNcls();
 
-
+	  //This selections throw out tracking effects seen in the invariant mass of the Xis
 	  if(posTPCcluster < 70) continue;
 	  if(negTPCcluster1 < 70) continue;
 	  if(negTPCcluster2 < 70) continue;
@@ -1148,7 +1257,7 @@ void AliAnalysisTaskPLFemto::XiSelector(AliAODEvent *aodEvent)
 	  fillthis = "fXiInvMassLambda";
 	  ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(MassV0);
 
-	  if(!(MassV0>(fCuts->GetHadronMasses(3122)-fCuts->GetV0PID_width()) && MassV0<(fCuts->GetHadronMasses(3122)+fCuts->GetV0PID_width()))) continue;
+	  if(!(MassV0>(fCuts->GetHadronMasses(3122)-fCuts->GetV0PIDWidth()) && MassV0<(fCuts->GetHadronMasses(3122)+fCuts->GetV0PIDWidth()))) continue;
 	  fillthis = "fXiInvMasswCuts";
 	  ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(massXi);
 
@@ -1176,9 +1285,6 @@ void AliAnalysisTaskPLFemto::FIFOShifter(Int_t zBin,Int_t MultBin)
   //the objects fV0cand and fProtoncand are not deleted: they may have information from the last event for i>fV0Counter stored
   fEC[zBin][MultBin]->FIFOShift();
   (fEvt) = fEC[zBin][MultBin]->fEvt;
-  (fEvt)->fFillStatus = 1;
-  (fEvt)->fMultBin = MultBin;
-  (fEvt)->fSphericity = fSphericityvalue;
   (fEvt)->fEventNumber = fEventNumber;
   fEC[zBin][MultBin]->fNumEvents++;
 }
@@ -1259,6 +1365,9 @@ void AliAnalysisTaskPLFemto::TrackCleaner()
 	      fV0cand[i].fV0tag = kFALSE;
 	      fillthis = "fNV0protonSharedTracks";
 	      ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(1);
+
+	      //Test what happens if also the proton is rejected:
+	      //fProtoncand[j].fProtonTag = kFALSE;
 	    }
 	}
     }
@@ -1277,6 +1386,9 @@ void AliAnalysisTaskPLFemto::TrackCleaner()
 	      fAntiV0cand[i].fV0tag = kFALSE;
 	      fillthis = "fNAntiV0protonSharedTracks";
 	      ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(1);
+
+	      //Test what happens if also the Antiproton is rejected:
+	      //fAntiProtoncand[j].fProtonTag = kFALSE;
 	    }
 	}
     }
@@ -1309,12 +1421,50 @@ void AliAnalysisTaskPLFemto::TrackCleaner()
 	    }
 	}
     }
+
+  nDoubleShare = 0;
+  //Check that Xis don't share tracks
+  if(fXiCounter>1)
+    {
+      //A procedure that controls that we have different V0s:
+      for(Int_t i=0;i<fXiCounter;i++)
+	{
+	  if(!fXicand[i].fXitag) continue; //already tagged as bad, must not be tested
+	  for(Int_t j=i+1;j<fXiCounter;j++)
+	    {
+	      if(!fXicand[j].fXitag) continue; //already tagged as bad, must not be tested
+
+	      if((fXicand[i].fDaughterID1 == fXicand[j].fDaughterID2) || (fXicand[i].fDaughterID2 == fXicand[j].fDaughterID1) //crossing, should be excluded already at PID level
+		 || (fXicand[i].fDaughterID1 == fXicand[j].fDaughterID1) || (fXicand[i].fDaughterID2 == fXicand[j].fDaughterID2)//same
+		 || (fXicand[i].fBachID == fXicand[j].fBachID)//check that bachelor IDs are different
+		 || (fXicand[i].fBachID == fXicand[j].fDaughterID1) || (fXicand[i].fBachID == fXicand[j].fDaughterID2) //check that bacherlor IDs from Xi1 and daughter from Xi2 are different
+		 || (fXicand[i].fDaughterID1 == fXicand[j].fBachID) || (fXicand[i].fDaughterID2 == fXicand[j].fBachID))//check that bacherlor IDs from Xi2 and daughter from Xi1 are different
+		{
+		  nDoubleShare++;
+		  if(fXicand[i].fPointing > fXicand[j].fPointing) fXicand[j].fXitag = kFALSE;//V0_i is "more primary" than V0_j
+		  else fXicand[i].fXitag = kFALSE;
+		}
+	    }
+	}
+    }
+
+  if(nDoubleShare>0)
+    {
+      fillthis = "fNXimTrackSharing";
+      ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(nDoubleShare);
+    }
+
+
 }
 //________________________________________________________________________
-Int_t *AliAnalysisTaskPLFemto::BufferFiller()
+void AliAnalysisTaskPLFemto::BufferFiller(Int_t zBin,Int_t multBin,Int_t *NumberOfParticles)
 {
+  fSEPairAnalysisDecider[kProton] = kFALSE;
+  fSEPairAnalysisDecider[kAntiProton] = kFALSE;
+  fSEPairAnalysisDecider[kV0] = kFALSE;
+  fSEPairAnalysisDecider[kAntiV0] = kFALSE;
+
   TString fillthis = "";
-  Int_t *NumberOfParticles = new Int_t[2];
 
   //Fill V0 candidates in EventCollection:
   Int_t tempV0Counter = 0;
@@ -1333,8 +1483,31 @@ Int_t *AliAnalysisTaskPLFemto::BufferFiller()
 	      ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(3); //fill only unique candidates
 	    }
 	  tempV0Counter++;
+
+	  fLambdaTrackVector.push_back(fV0cand[i]);
+
+
+	  fillthis = "fInvMassLambdaKept";
+	  ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(fV0cand[i].fMass);
+	}
+      else
+	{
+	  fillthis = "fInvMassLambdaRejected";
+	  ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(fV0cand[i].fMass);
 	}
     }
+
+
+  //If it is not empty put it into Mixing Buffer:
+  if(fLambdaTrackVector.size()>0)
+    {
+      fSEPairAnalysisDecider[kV0] = kTRUE;
+      fLambdaEvtBuffer[zBin][multBin].push_front(fLambdaTrackVector);
+    }
+  //If Buffer is larger than mixing depth, kick out the last element:
+  if(fLambdaEvtBuffer[zBin][multBin].size() > kEventsToMix) fLambdaEvtBuffer[zBin][multBin].pop_back();
+  fLambdaTrackVector.clear();
+
 
   Int_t tempAntiV0Counter = 0;
   for(int i=0;i<fAntiV0Counter;i++)
@@ -1352,8 +1525,21 @@ Int_t *AliAnalysisTaskPLFemto::BufferFiller()
 	      ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(3); //fill only unique candidates
 	    }
 	  tempAntiV0Counter++;
+
+	  fAntiLambdaTrackVector.push_back(fAntiV0cand[i]);
 	}
     }
+
+
+  //If it is not empty put it into Mixing Buffer:
+  if(fAntiLambdaTrackVector.size()>0)
+    {
+      fSEPairAnalysisDecider[kAntiV0] = kTRUE;
+      fAntiLambdaEvtBuffer[zBin][multBin].push_front(fAntiLambdaTrackVector);
+    }
+  //If Buffer is larger than mixing depth, kick out the last element:
+  if(fAntiLambdaEvtBuffer[zBin][multBin].size() > kEventsToMix) fAntiLambdaEvtBuffer[zBin][multBin].pop_back();
+  fAntiLambdaTrackVector.clear();
 
 
   //Fill Proton candidates in EventCollection:
@@ -1361,18 +1547,49 @@ Int_t *AliAnalysisTaskPLFemto::BufferFiller()
   for(Int_t i=0;i<fProtonCounter;i++)
     {
       //at this point you can include some cuts
-      (fEvt)->fProtonParticle[i] = fProtoncand[i];
-      tempProtonCounter++;
+      //if(fProtoncand[i].fProtonTag)
+	{
+	  (fEvt)->fProtonParticle[i] = fProtoncand[i];
+	  tempProtonCounter++;
+	  //Put protons in proton array:
+	  fProtonTrackVector.push_back(fProtoncand[i]);
+	}
     }
+
+  //If it is not empty put it into Mixing Buffer:
+  if(fProtonTrackVector.size()>0)
+    {
+      fSEPairAnalysisDecider[kProton] = kTRUE;
+      fProtonEvtBuffer[zBin][multBin].push_front(fProtonTrackVector);
+    }
+  //If Buffer is larger than mixing depth, kick out the last element:
+  if(fProtonEvtBuffer[zBin][multBin].size() > kEventsToMix) fProtonEvtBuffer[zBin][multBin].pop_back();
+  fProtonTrackVector.clear();
 
 
   //Fill Anti-Proton candidates in EventCollection:
   Int_t tempAntiProtonCounter = 0;
   for(Int_t i=0;i<fAntiProtonCounter;i++)
     {
-      (fEvt)->fAntiProtonParticle[i] = fAntiProtoncand[i];
-      tempAntiProtonCounter++;
+      //if(fAntiProtoncand[i].fProtonTag)
+	{
+	  (fEvt)->fAntiProtonParticle[i] = fAntiProtoncand[i];
+	  tempAntiProtonCounter++;
+	  //Put protons in proton array:
+	  fAntiProtonTrackVector.push_back(fAntiProtoncand[i]);
+	}
     }
+
+  //If it is not empty put it into Mixing Buffer:
+  if(fAntiProtonTrackVector.size()>0)
+    {
+      fSEPairAnalysisDecider[kAntiProton] = kTRUE;
+      fAntiProtonEvtBuffer[zBin][multBin].push_front(fAntiProtonTrackVector);
+    }
+  //If Buffer is larger than mixing depth, kick out the last element:
+  if(fAntiProtonEvtBuffer[zBin][multBin].size() > kEventsToMix) fAntiProtonEvtBuffer[zBin][multBin].pop_back();
+  fAntiProtonTrackVector.clear();
+
 
   Int_t tempXiCounter = 0;
   for(int i=0;i<fXiCounter;i++)
@@ -1384,8 +1601,6 @@ Int_t *AliAnalysisTaskPLFemto::BufferFiller()
 	}
     }
 
-
-
   (fEvt)->fNumV0s = tempV0Counter;
   (fEvt)->fNumAntiV0s = tempAntiV0Counter;
   (fEvt)->fNumProtons = tempProtonCounter;
@@ -1394,29 +1609,37 @@ Int_t *AliAnalysisTaskPLFemto::BufferFiller()
 
   NumberOfParticles[0] = tempV0Counter;
   NumberOfParticles[1] = tempProtonCounter;
-
-  return NumberOfParticles;
 }
 //________________________________________________________________________
-void AliAnalysisTaskPLFemto::ParticlePairer()
+void AliAnalysisTaskPLFemto::ParticlePairer(Int_t zBin,Int_t multBin)
 {
+  //In this function two different event mixing procedures are performed.
+  //The "standard" one which includes sometimes a buffering of emtpy evts
+  //A second one where empty events are avoided
+  //The one where empty events are avoided fills histograms with using the QA enums
+
   Int_t NPairs = 0;
   //Loop for p-V0:
-  for(int i=0; i<(fEvt)->fNumV0s;i++)
+  for(unsigned int i=0; i<(fLambdaEvtBuffer[zBin][multBin].front()).size();i++)//get same event size
     {
-      for(int evnum=0; evnum<kEventsToMix+1; evnum++)
+      if(!fSEPairAnalysisDecider[kV0]) break;
+
+      for(unsigned int evnum=0; evnum<fProtonEvtBuffer[zBin][multBin].size(); evnum++)
 	{
-	  for(int j=0; j<(fEvt+evnum)->fNumProtons;j++)
+	  if(evnum == 0) NPairs++;
+	  if(evnum == 0 && !(fSEPairAnalysisDecider[kProton] && fSEPairAnalysisDecider[kV0])) continue;//this ensures that same event correlations is only performed if a proton and V0 is in same event
+
+	  for(unsigned int j=0;j<(fProtonEvtBuffer[zBin][multBin].at(evnum)).size();j++)
 	    {
-	      if(evnum == 0) NPairs++;
-	      PairAnalysis((fEvt)->fLambdaParticle[i],(fEvt+evnum)->fProtonParticle[j],evnum,kProtonV0);
-	    }//Proton Loop
+	      PairAnalysis((fLambdaEvtBuffer[zBin][multBin].front()).at(i),(fProtonEvtBuffer[zBin][multBin].at(evnum)).at(j),evnum,kProtonV0);
+	    }//ProtonA Loop
 	}//event Loop
-    }//V0 Loop
+    }//ProtonB Loop
+
 
   TString fillthis = "fNProtonLambdaPairs";
   if(NPairs !=0) ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(NPairs);
-
+  /*
   //Loop for p-AntiV0
   for(int i=0; i<(fEvt)->fNumAntiV0s;i++)
     {
@@ -1441,82 +1664,72 @@ void AliAnalysisTaskPLFemto::ParticlePairer()
 	    }//AntiProton Loop
 	}//event Loop
     }//V0 Loop
-
-
-  //Loop for Antip-AntiV0
-  for(int i=0; i<(fEvt)->fNumAntiV0s;i++)
-    {
-      for(int evnum=0; evnum<kEventsToMix+1; evnum++)
-	{
-	  for(int j=0; j<(fEvt+evnum)->fNumAntiProtons;j++)
-	    {
-	      PairAnalysis((fEvt)->fAntiLambdaParticle[i],(fEvt+evnum)->fAntiProtonParticle[j],evnum,kAntiProtonAntiV0);
-	    }//Proton Loop
-	}//event Loop
-    }//V0 Loop
-
-  /*
-  for(int i=0; i<(fEvt)->fNumV0s;i++)
-    {
-      for(int evnum=0; evnum<kEventsToMix+1; evnum++)
-	{
-	  int secevent = 0;
-	  if(evnum>0) secevent=evnum+1;//for mixed event take always different events and avoid combinations like 1-2-3, 1-3-2, which leads to double counting
-	  for(int evnum2 = secevent; evnum2<kEventsToMix+1; evnum2++)
-	    {
-	      for(int j=0; j<(fEvt+evnum)->fNumProtons;j++)
-		{
-		  int startevent = 0;
-		  if(evnum==0 && evnum2 == 0) startevent = j+1;
-		  for(int k=startevent; k<(fEvt+evnum2)->fNumProtons;k++)
-		    {
-		      TripleAnalysis((fEvt)->fLambdaParticle[i],(fEvt+evnum)->fProtonParticle[j],(fEvt+evnum2)->fProtonParticle[k],evnum+evnum2,kProtonProtonV0);
-		    }
-		}
-	    }
-	}
-    }
   */
 
-  //Loop for p-p
-  for(int i=0; i<(fEvt)->fNumProtons;i++)
+  //Loop for Antip-AntiV0
+  for(unsigned int i=0; i<(fAntiLambdaEvtBuffer[zBin][multBin].front()).size();i++)//get same event size
     {
-      for(int evnum=0; evnum<kEventsToMix+1; evnum++)
-	{
-	  int startbin = 0;
-	  if(evnum==0)
-	    {
-	      startbin=i+1;
-	      if((fEvt)->fProtonParticle[i].fID == (fEvt+evnum)->fProtonParticle[startbin].fID) continue;
-	    }
+      if(!fSEPairAnalysisDecider[kAntiV0]) break;
 
-	  for(int j=startbin;j<(fEvt+evnum)->fNumProtons;j++)
+      for(unsigned int evnum=0; evnum<fAntiProtonEvtBuffer[zBin][multBin].size(); evnum++)
+	{
+
+	  if(evnum == 0 && !(fSEPairAnalysisDecider[kAntiProton] && fSEPairAnalysisDecider[kAntiV0])) continue;//this ensures that same event correlations is only performed if a proton and V0 is in same event
+
+	  for(unsigned int j=0;j<(fAntiProtonEvtBuffer[zBin][multBin].at(evnum)).size();j++)
 	    {
-	      PairAnalysis((fEvt)->fProtonParticle[i],(fEvt+evnum)->fProtonParticle[j],evnum,kProtonProton);
+	      PairAnalysis((fAntiLambdaEvtBuffer[zBin][multBin].front()).at(i),(fAntiProtonEvtBuffer[zBin][multBin].at(evnum)).at(j),evnum,kAntiProtonAntiV0);
 	    }//ProtonA Loop
 	}//event Loop
     }//ProtonB Loop
 
-  //Loop for Antip-Antip
-  for(int i=0; i<(fEvt)->fNumAntiProtons;i++)
+
+  //Loop for p-p
+  if(fSEPairAnalysisDecider[kProton])
     {
-      for(int evnum=0; evnum<kEventsToMix+1; evnum++)
+      //Check second option
+      for(unsigned int i=0; i<(fProtonEvtBuffer[zBin][multBin].front()).size();i++)//get same event size
 	{
-	  int startbin = 0;
-	  if(evnum==0)
+	  for(unsigned int evnum=0; evnum<fProtonEvtBuffer[zBin][multBin].size(); evnum++)
 	    {
-	      startbin=i+1;
-	      if((fEvt)->fAntiProtonParticle[i].fID == (fEvt+evnum)->fAntiProtonParticle[startbin].fID) continue;
-	    }
+	      int startbin = 0;
+	      if(evnum==0)
+		{
+		  startbin=i+1;
+		  //if((fProtonEvtBuffer.front()).at(i).fID == (fProtonEvtBuffer.at(evnum)).at(startbin).fID) continue;
+		}
+	      for(unsigned int j=startbin;j<(fProtonEvtBuffer[zBin][multBin].at(evnum)).size();j++)
+		{
+		  PairAnalysis((fProtonEvtBuffer[zBin][multBin].front()).at(i),(fProtonEvtBuffer[zBin][multBin].at(evnum)).at(j),evnum,kProtonProton);
+		}//ProtonA Loop
+	    }//event Loop
+	}//ProtonB Loop
+    }
 
-	  for(int j=startbin; j<(fEvt+evnum)->fNumAntiProtons;j++)
+
+  //Loop for Antip-Antip
+  if(fSEPairAnalysisDecider[kAntiProton])
+    {
+      //Check second option
+      for(unsigned int i=0; i<(fAntiProtonEvtBuffer[zBin][multBin].front()).size();i++)//get same event size
+	{
+	  for(unsigned int evnum=0; evnum<fAntiProtonEvtBuffer[zBin][multBin].size(); evnum++)
 	    {
-	      PairAnalysis((fEvt)->fAntiProtonParticle[i],(fEvt+evnum)->fAntiProtonParticle[j],evnum,kAntiProtonAntiProton);
-	    }//AntiProtonA Loop
-	}//event Loop
-    }//AntiProtonB Loop
+	      int startbin = 0;
+	      if(evnum==0)
+		{
+		  startbin=i+1;
+		  //if((fProtonEvtBuffer.front()).at(i).fID == (fProtonEvtBuffer.at(evnum)).at(startbin).fID) continue;
+		}
+	      for(unsigned int j=startbin;j<(fAntiProtonEvtBuffer[zBin][multBin].at(evnum)).size();j++)
+		{
+		  PairAnalysis((fAntiProtonEvtBuffer[zBin][multBin].front()).at(i),(fAntiProtonEvtBuffer[zBin][multBin].at(evnum)).at(j),evnum,kAntiProtonAntiProton);
+		}//ProtonA Loop
+	    }//event Loop
+	}//ProtonB Loop
+    }
 
-
+  /*
   //Loop for Antip-p
   for(int i=0; i<(fEvt)->fNumProtons;i++)
     {
@@ -1558,32 +1771,6 @@ void AliAnalysisTaskPLFemto::ParticlePairer()
 	}//event Loop
     }//Xi Loop
 
-
-  /*
-  for(int i=0; i<(fEvt)->fNumProtons;i++)
-    {
-      for(int evnum=0; evnum<kEventsToMix+1; evnum++)
-	{
-	  int secevent = 0;
-	  if(evnum>0) secevent=evnum+1;//for mixed event take always different events and avoid combinations like 1-2-3, 1-3-2, which leads to double counting
-	  for(int evnum2 = secevent; evnum2<kEventsToMix+1; evnum2++)
-	    {
-	      int startparticle1 = 0;
-	      if(evnum==0 && evnum2 == 0) startparticle1 = i+1;
-	      for(int j=startparticle1; j<(fEvt+evnum)->fNumProtons;j++)
-		{
-		  int startparticle2 = 0;
-		  if(evnum==0 && evnum2 == 0) startparticle2 = j+1;
-		  for(int k=startparticle2; k<(fEvt+evnum2)->fNumProtons;k++)
-		    {
-		      TripleAnalysis((fEvt)->fProtonParticle[i],(fEvt+evnum)->fProtonParticle[j],(fEvt+evnum2)->fProtonParticle[k],evnum+evnum2,kProtonProtonProton);
-		    }
-		}
-	    }
-	}
-    }
-  */
-
   //Loop for V0-V0
   for(int i=0; i<(fEvt)->fNumV0s;i++)
     {
@@ -1597,23 +1784,45 @@ void AliAnalysisTaskPLFemto::ParticlePairer()
 	    }//Proton Loop
 	}//event Loop
     }//V0 Loop
+  */
+
+  if(fSEPairAnalysisDecider[kV0])
+    {
+      //Check second option
+      for(unsigned int i=0; i<(fLambdaEvtBuffer[zBin][multBin].front()).size();i++)//get same event size
+	{
+	  for(unsigned int evnum=0; evnum<fLambdaEvtBuffer[zBin][multBin].size(); evnum++)
+	    {
+	      int startbin = 0;
+	      if(evnum==0) startbin = i+1;
+	      for(unsigned int j=startbin;j<(fLambdaEvtBuffer[zBin][multBin].at(evnum)).size();j++)
+		{
+		  PairAnalysis((fLambdaEvtBuffer[zBin][multBin].front()).at(i),(fLambdaEvtBuffer[zBin][multBin].at(evnum)).at(j),evnum,kV0V0);
+		}//V0A Loop
+	    }//event Loop
+	}//V0B Loop
+    }
 
 
   //Loop for AntiV0-AntiV0
-  for(int i=0; i<(fEvt)->fNumAntiV0s;i++)
+  if(fSEPairAnalysisDecider[kAntiV0])
     {
-      for(int evnum=0; evnum<kEventsToMix+1; evnum++)
+      //Check second option
+      for(unsigned int i=0; i<(fAntiLambdaEvtBuffer[zBin][multBin].front()).size();i++)//get same event size
 	{
-	  int startbin = 0;
-	  if(evnum==0) startbin=i+1;
-	  for(int j=startbin; j<(fEvt+evnum)->fNumAntiV0s;j++)
+	  for(unsigned int evnum=0; evnum<fAntiLambdaEvtBuffer[zBin][multBin].size(); evnum++)
 	    {
-	      PairAnalysis((fEvt)->fAntiLambdaParticle[i],(fEvt+evnum)->fAntiLambdaParticle[j],evnum,kAntiV0AntiV0);
-	    }//Proton Loop
-	}//event Loop
-    }//V0 Loop
+	      int startbin = 0;
+	      if(evnum==0) startbin = i+1;
+	      for(unsigned int j=startbin;j<(fAntiLambdaEvtBuffer[zBin][multBin].at(evnum)).size();j++)
+		{
+		  PairAnalysis((fAntiLambdaEvtBuffer[zBin][multBin].front()).at(i),(fAntiLambdaEvtBuffer[zBin][multBin].at(evnum)).at(j),evnum,kAntiV0AntiV0);
+		}//V0A Loop
+	    }//event Loop
+	}//V0B Loop
+    }
 
-
+  /*
   //Loop for AntiV0-V0
   for(int i=0; i<(fEvt)->fNumAntiV0s;i++)
     {
@@ -1625,92 +1834,7 @@ void AliAnalysisTaskPLFemto::ParticlePairer()
 	    }//Proton Loop
 	}//event Loop
     }//V0 Loop
-
-
-  //calculate decay matrix for residual correlations:
-  //we take it from another model
-  //CalculateDecayMatrix();
-}
-//________________________________________________________________________
-void AliAnalysisTaskPLFemto::CalculateDecayMatrix()
-{
-  //Calculate decay matrices from monte carlo:
-  if(fUseMCInfo)
-    {
-      Bool_t proton_from_weak = kFALSE;
-      Bool_t lambda_from_weak = kFALSE;
-
-      //This vectors are needed to obtain the matrix:
-      std::vector<AliFemtoProtonParticle> proton_vec;
-      std::vector<AliFemtoProtonParticle> proton_from_weak_vec;
-      std::vector<AliFemtoLambdaParticle> lambda_from_weak_vec;
-
-      //Protons feed down correlations:
-      if((fEvt)->fNumProtons>1)
-	{
-	  for(int i=0;i<(fEvt)->fNumProtons;i++)
-	    {
-	      if((fEvt)->fProtonParticle[i].fPDGCodeMother>0)
-		{
-		  proton_from_weak = kTRUE;
-		  proton_from_weak_vec.push_back((fEvt)->fProtonParticle[i]);
-		}
-	      else
-		{
-		  proton_vec.push_back((fEvt)->fProtonParticle[i]);
-		}
-	    }
-
-	  if(proton_from_weak && proton_from_weak_vec.size() == 1) //Only one feed down proton
-	    {
-	      for(std::vector<AliFemtoProtonParticle>::iterator protonA = proton_vec.begin(); protonA != proton_vec.end(); protonA++)
-		{
-		  for(std::vector<AliFemtoProtonParticle>::iterator protonB = proton_from_weak_vec.begin(); protonB != proton_from_weak_vec.end(); protonB++)//treat this proton as a "weak resonance"
-		    {
-		      //GetDecayMatrix(*protonA,*protonB);
-		    }
-		}
-	    }
-	}
-
-      proton_vec.clear();
-      proton_from_weak_vec.clear();
-
-      //Lambdas feed down correlations:
-      if((fEvt)->fNumProtons>0 && (fEvt)->fNumV0s>0)
-	{
-	  for(int i=0;i<(fEvt)->fNumV0s;i++)
-	    {
-	      if((fEvt)->fLambdaParticle[i].fPDGCodeMother>0)
-		{
-		  lambda_from_weak = kTRUE;
-		  lambda_from_weak_vec.push_back((fEvt)->fLambdaParticle[i]);
-		}
-	    }
-
-	  for(int i=0;i<(fEvt)->fNumProtons;i++)
-	    {
-	      if((fEvt)->fProtonParticle[i].fPDGCodeMother == 0)
-		{
-		  proton_vec.push_back((fEvt)->fProtonParticle[i]);
-		}
-	    }
-
-
-	  if(lambda_from_weak && lambda_from_weak_vec.size() == 1) //Only one feed down V0
-	    {
-	      for(std::vector<AliFemtoProtonParticle>::iterator Proton = proton_vec.begin(); Proton != proton_vec.end(); Proton++)
-		{
-		  for(std::vector<AliFemtoLambdaParticle>::iterator V0 = lambda_from_weak_vec.begin(); V0 != lambda_from_weak_vec.end(); V0++)//treat this V0 as a "weak resonance"
-		    {
-		      //GetDecayMatrix(*Proton,*V0);
-		    }
-		}
-	    }
-	}
-      proton_vec.clear();
-      lambda_from_weak_vec.clear();
-    }
+  */
 }
 //________________________________________________________________________
 Float_t AliAnalysisTaskPLFemto::PhiS(AliAODTrack *track,const Float_t bfield,const Float_t Radius,const Float_t DecVtx[2])
@@ -1781,36 +1905,59 @@ void AliAnalysisTaskPLFemto::UserExec(Option_t *)
     return;
   }
 
-  fEvents++;
+  fCuts->SetCutVariation(fcutType);
+
   TString fillthis = "";
   AliAODEvent* aodEvent = dynamic_cast<AliAODEvent*>(fInputEvent);
   fAODMCEvent = MCEvent(); //return NULL pointer in case of exp event, no problem
 
   fCEvents->Fill(1);
 
-  // the AODs with null vertex pointer didn't pass the PhysSel
-  if(!aodEvent->GetPrimaryVertex() || TMath::Abs(aodEvent->GetMagneticField())<0.001) return;
-  fCEvents->Fill(2);
+  if(fIsRun1) {
+      // the AODs with null vertex pointer didn't pass the PhysSel
+      if(!aodEvent->GetPrimaryVertex() || TMath::Abs(aodEvent->GetMagneticField())<0.001) return;
+      fCEvents->Fill(2);
 
-  // AOD primary vertex
-  AliAODVertex *vtx1 = (AliAODVertex*)aodEvent->GetPrimaryVertex();
-  if(!vtx1) return;
-  if(vtx1->GetNContributors()<2) return;
-  fCEvents->Fill(3);
-  fPrimVertex[0] = vtx1->GetX();
-  fPrimVertex[1] = vtx1->GetY();
-  fPrimVertex[2] = vtx1->GetZ();
+      // AOD primary vertex
+      AliAODVertex *vtx1 = (AliAODVertex*)aodEvent->GetPrimaryVertex();
+      if(!vtx1) return;
+      if(vtx1->GetNContributors()<2) return;
+      fCEvents->Fill(3);
+      fPrimVertex[0] = vtx1->GetX();
+      fPrimVertex[1] = vtx1->GetY();
+      fPrimVertex[2] = vtx1->GetZ();
 
-  fillthis = "fVtxX";
-  ((TH1F*)(fOutput->FindObject(fillthis)))->Fill(fPrimVertex[0]);
-  fillthis = "fVtxY";
-  ((TH1F*)(fOutput->FindObject(fillthis)))->Fill(fPrimVertex[1]);
-  fillthis = "fVtxZ";
-  ((TH1F*)(fOutput->FindObject(fillthis)))->Fill(fPrimVertex[2]);
+      fillthis = "fVtxX";
+      ((TH1F*)(fOutput->FindObject(fillthis)))->Fill(fPrimVertex[0]);
+      fillthis = "fVtxY";
+      ((TH1F*)(fOutput->FindObject(fillthis)))->Fill(fPrimVertex[1]);
+      fillthis = "fVtxZ";
+      ((TH1F*)(fOutput->FindObject(fillthis)))->Fill(fPrimVertex[2]);
 
 
-  if(fPrimVertex[2] < fCuts->GetEvtzVertexLow() || fPrimVertex[2] > fCuts->GetEvtzVertexUp()) return;
-  fCEvents->Fill(4);
+      if(fPrimVertex[2] < fCuts->GetEvtzVertexLow() || fPrimVertex[2] > fCuts->GetEvtzVertexUp()) return;
+      fCEvents->Fill(4);
+    }
+
+  // AliEventCuts for Run2 analysis
+  if(!fIsRun1) {
+      bool isSelected = fAliEventCuts.AcceptEvent(fInputEvent);
+      if(!isSelected) return;
+
+      if(fTrigger == AliVEvent::kHighMultV0 && fV0PercentileMax < 100.f) {
+          Float_t lPercentile = 300;
+          AliMultSelection *MultSelection = 0x0;
+          MultSelection = (AliMultSelection *)fInputEvent->FindListObject("MultSelection");
+          if (!MultSelection) {
+              // If you get this warning (and lPercentiles 300) please check that the
+              // AliMultSelectionTask actually ran (before your task)
+              AliWarning("AliMultSelection object not found!");
+            } else {
+              lPercentile = MultSelection->GetMultiplicityPercentile("V0M");
+            }
+          if (lPercentile > fV0PercentileMax) return;
+        }
+    }
 
   //find the centrality and zBin for mixed event: 0=zBin, 1=MultBin
   Int_t *MixingBins = MultiplicityBinFinderzVertexBinFinder(aodEvent,fPrimVertex[2]);
@@ -1823,12 +1970,13 @@ void AliAnalysisTaskPLFemto::UserExec(Option_t *)
   fillthis = "fNBinsVertexmixing";
   ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(zBin);
 
+  if(fIsRun1) {
+    Bool_t isPileUp = PileUpRejection(aodEvent);
+    if(!aodEvent->IsPileupFromSPD(3,0.8,3.,2.,5.)) fCEvents->Fill(7);
 
-  PileUpRejection(aodEvent);
-  if(!aodEvent->IsPileupFromSPD(3,0.8,3.,2.,5.)) fCEvents->Fill(7);
-
-  if(fAnaUtils->IsPileUpEvent(aodEvent)) return;//pile up rejection
-  fCEvents->Fill(6);
+    if(fAnaUtils->IsPileUpEvent(aodEvent)) return;
+    fCEvents->Fill(6);
+  }
 
   //*******************************(O.Arnold)
   //Set the private pointer array which contains information from global tracks
@@ -1844,22 +1992,27 @@ void AliAnalysisTaskPLFemto::UserExec(Option_t *)
     }
   //*******************************
   fEventNumber++;
-  //Calculate event shape (sphericity):
-  fSphericityvalue = CalcSphericityEvent(aodEvent);
 
-  FIFOShifter(zBin,MultBin);//Put the information into the FIFO
+  //FIFOShifter(zBin,MultBin);//Put the information into the FIFO
   ProtonSelector(aodEvent); //Select primary protons
-
   V0Selector(aodEvent); //Select V0s
   XiSelector(aodEvent); //Select Xis
 
-  if(fProtonCounter>0 && fV0Counter>0) {fCEvents->Fill(8);}
-  if(fAntiProtonCounter>0 && fAntiV0Counter>0) {fCEvents->Fill(9);}
+  //totally empty event for our purposes? then neglect it:
+  if(fProtonCounter == 0 && fV0Counter == 0 && fAntiProtonCounter == 0 && fAntiV0Counter == 0 && fXiCounter == 0) return;
+
+  //if(fProtonCounter == 0) return;
+
+  FIFOShifter(zBin,MultBin);//Put the information into the FIFO
+
+
+  //if(fProtonCounter>0 && fV0Counter>0) {fCEvents->Fill(8);}
+  //if(fAntiProtonCounter>0 && fAntiV0Counter>0) {fCEvents->Fill(9);}
 
   TrackCleaner(); //Check for unique V0s and no track sharing between V0 daughter tracks and primary tracks
-  Int_t *NumberOfParticles = new Int_t[2];
-  NumberOfParticles = BufferFiller();//Fill the candidates to the buffer: 0=V0,1=Proton
-  ParticlePairer(); //at this point the relevant distributions for the CF are built and mixing takes place
+  Int_t NumberOfParticles[2];
+  BufferFiller(zBin,MultBin,NumberOfParticles);//Fill the candidates to the buffer: 0=V0,1=Proton
+  ParticlePairer(zBin,MultBin); //at this point the relevant distributions for the CF are built and mixing takes place
 
   fillthis = "fNProtonsPerevent";
   ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(NumberOfParticles[1]);
@@ -1871,6 +2024,7 @@ void AliAnalysisTaskPLFemto::UserExec(Option_t *)
   PostData(2,fOutputSP);
   PostData(3,fOutputPID);
   PostData(4,fOutputTP);
+  PostData(5,fOutputAliEvent);
 }
 //________________________________________________________________________
 Double_t AliAnalysisTaskPLFemto::Qinv(TLorentzVector trackV0,TLorentzVector trackProton)
@@ -1915,8 +2069,25 @@ Double_t AliAnalysisTaskPLFemto::relKcalc(TLorentzVector track1,TLorentzVector t
   trackRelK = track1cms - track2cms;
   Double_t relK = 0.5*trackRelK.P();
 
-
   return relK;
+}
+//________________________________________________________________________
+Double_t AliAnalysisTaskPLFemto::GetAverageSeparation(const TVector3 globalPositions1st[],const TVector3 globalPositions2nd[])
+{
+  double sumSquare = 0.;
+  int pointUsed = 0;
+
+  for(int RNumber = 0; RNumber < 9; RNumber++)
+    {
+      TVector3 diffVec = globalPositions1st[RNumber] - globalPositions2nd[RNumber];
+      if(globalPositions1st[RNumber].X() == -9999. || globalPositions2nd[RNumber].X() == -9999.) continue;//This happens if the distances deviate too strongly
+
+      sumSquare += diffVec.Mag();
+      pointUsed++;
+    }
+
+  if(pointUsed < 1) return 0.;
+  else return sumSquare / pointUsed;
 }
 //________________________________________________________________________
 void AliAnalysisTaskPLFemto::PairAnalysis(const AliFemtoLambdaParticle &v0,const AliFemtoProtonParticle &proton,Int_t REorME,pairType inputPair)
@@ -1936,16 +2107,29 @@ void AliAnalysisTaskPLFemto::PairAnalysis(const AliFemtoLambdaParticle &v0,const
   double averageMass = 0.5*(fCuts->GetHadronMasses(3122) + fCuts->GetHadronMasses(2212));
   double pairMT = TMath::Sqrt(pow(pairKT,2.) + pow(averageMass,2.));
 
+  double qinv = Qinv(trackV0,trackProton);
+  Double_t avgSepPos = GetAverageSeparation(proton.fPositionTPC,v0.fPositionPosTPC);
+  Double_t avgSepNeg = GetAverageSeparation(proton.fPositionTPC,v0.fPositionNegTPC);
+
+  TString fillthis = "fProtonLambdaDiff";
+  ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(fabs(relK - 0.5*qinv));
+
+  Int_t *MixingBins = MultiplicityBinFinderzVertexBinFinder(static_cast<AliAODEvent*>(fInputEvent),fPrimVertex[2]);
+  Int_t MultBin = MixingBins[1];
 
   if(REorME == 0 && inputPair == kProtonV0)//real event
     {
-      TString fillthis = "fPairkTLp";
+      fillthis = "fPairkTLp";
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(pairKT);
 
       fillthis = "fProtonLambdaMT";
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(pairMT);
 
       fillthis = "fProtonLambdaRelK";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fProtonLambdaRelKMulti_";
+      fillthis += MultBin;
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
 
       fillthis = "fProtonLambdaPosDaughterRelK";
@@ -1962,51 +2146,76 @@ void AliAnalysisTaskPLFemto::PairAnalysis(const AliFemtoLambdaParticle &v0,const
 	  fillthis = "fProtonLambdaMTrelKcut";
 	  ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(pairMT);
 	}
+
+      fillthis = "fProtonLambdaAvgSeparationPP";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPos);
+
+      fillthis = "fProtonLambdaAvgSeparationPPi";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepNeg);
     }
   else if(REorME!=0 && inputPair == kProtonV0)//mixed event
     {
-      TString fillthis = "fProtonLambdaRelKME";
+      fillthis = "fProtonLambdaRelKME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fProtonLambdaRelKMEMulti_";
+      fillthis += MultBin;
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
 
       fillthis = "fProtonLambdaPosDaughterRelKME";
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relKPPdaughter);
 
+      fillthis = "fProtonLambdaAvgSeparationPPME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPos);
+
+      fillthis = "fProtonLambdaAvgSeparationPPiME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepNeg);
+
+
       if(fUseMCInfo) GetMomentumMatrix(v0,proton);//determines the amount of momentum resolution (from mixed event to enlarge statistics)
     }
   else if(REorME == 0 && inputPair == kAntiProtonV0)//real event
     {
-      TString fillthis = "fAntiProtonLambdaRelK";
+      fillthis = "fAntiProtonLambdaRelK";
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
-
-      fillthis = "fAntiProtonAntiLambdaPosDaughterRelK";
-      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relKPPdaughter);
     }
   //else if(REorME != 0 && whichpair_combi=="AntiProton-V0")//mixed event
   else if(REorME != 0 && inputPair == kAntiProtonV0)//mixed event
     {
-      TString fillthis = "fAntiProtonLambdaRelKME";
+      fillthis = "fAntiProtonLambdaRelKME";
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
-
-      fillthis = "fAntiProtonAntiLambdaPosDaughterRelKME";
-      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relKPPdaughter);
     }
   else if(REorME == 0 && inputPair == kProtonAntiV0)//real event
     {
-      TString fillthis = "fProtonAntiLambdaRelK";
+      fillthis = "fProtonAntiLambdaRelK";
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
     }
   else if(REorME != 0 && inputPair == kProtonAntiV0)//mixed event
     {
-      TString fillthis = "fProtonAntiLambdaRelKME";
+      fillthis = "fProtonAntiLambdaRelKME";
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
     }
   else if(REorME == 0 && inputPair == kAntiProtonAntiV0)//real event
     {
-      TString fillthis = "fAntiProtonAntiLambdaRelK";
+      fillthis = "fAntiProtonAntiLambdaRelK";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fAntiProtonAntiLambdaRelKMulti_";
+      fillthis += MultBin;
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
 
       fillthis = "fNPairStatistics";
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(3);
+
+      fillthis = "fAntiProtonAntiLambdaPosDaughterRelK";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relKPPdaughter);
+
+      fillthis = "fAntiProtonAntiLambdaAvgSeparationPP";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPos);
+
+      fillthis = "fAntiProtonAntiLambdaAvgSeparationPPi";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepNeg);
+
 
       if(relK<0.15)
 	{
@@ -2016,8 +2225,21 @@ void AliAnalysisTaskPLFemto::PairAnalysis(const AliFemtoLambdaParticle &v0,const
     }
   else if(REorME != 0 && inputPair == kAntiProtonAntiV0)//mixed event
     {
-      TString fillthis = "fAntiProtonAntiLambdaRelKME";
+      fillthis = "fAntiProtonAntiLambdaRelKME";
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fAntiProtonAntiLambdaRelKMEMulti_";
+      fillthis += MultBin;
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fAntiProtonAntiLambdaPosDaughterRelKME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relKPPdaughter);
+
+      fillthis = "fAntiProtonAntiLambdaAvgSeparationPPME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPos);
+
+      fillthis = "fAntiProtonAntiLambdaAvgSeparationPPiME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepNeg);
     }
 }
 //________________________________________________________________________
@@ -2031,24 +2253,43 @@ void AliAnalysisTaskPLFemto::PairAnalysis(const AliFemtoXiParticle &xi,const Ali
 
   Double_t relK = relKcalc(trackXi,trackProton);
 
+  Int_t *MixingBins = MultiplicityBinFinderzVertexBinFinder(static_cast<AliAODEvent*>(fInputEvent),fPrimVertex[2]);
+  Int_t MultBin = MixingBins[1];
+
   if(REorME == 0 && inputPair == kProtonXi)//real event
     {
       TString fillthis = "fProtonXiRelK";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fProtonXiRelKMulti_";
+      fillthis += MultBin;
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
     }
   else if(REorME!=0 && inputPair == kProtonXi)//mixed event
     {
       TString fillthis = "fProtonXiRelKME";
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fProtonXiRelKMEMulti_";
+      fillthis += MultBin;
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
     }
   else if(REorME == 0 && inputPair == kAntiProtonXi)
     {
       TString fillthis = "fAntiProtonXiRelK";
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fAntiProtonXiRelKMult_";
+      fillthis += MultBin;
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
     }
   else if(REorME != 0 && inputPair == kAntiProtonXi)
     {
       TString fillthis = "fAntiProtonXiRelKME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fAntiProtonXiRelKMEMult";
+      fillthis += MultBin;
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
     }
 }
@@ -2062,35 +2303,108 @@ void AliAnalysisTaskPLFemto::PairAnalysis(const AliFemtoLambdaParticle &v01,cons
 
   Double_t relK = relKcalc(trackV01,trackV02);
 
+  Double_t avgSepPP = GetAverageSeparation(v01.fPositionPosTPC,v02.fPositionPosTPC);
+  Double_t avgSepPPi = GetAverageSeparation(v01.fPositionPosTPC,v02.fPositionNegTPC);
+  Double_t avgSepPiP = GetAverageSeparation(v01.fPositionNegTPC,v02.fPositionPosTPC);
+  Double_t avgSepPiPi = GetAverageSeparation(v01.fPositionNegTPC,v02.fPositionNegTPC);
+
+  Int_t *MixingBins = MultiplicityBinFinderzVertexBinFinder(static_cast<AliAODEvent*>(fInputEvent),fPrimVertex[2]);
+  Int_t MultBin = MixingBins[1];
+
+  TString fillthis = "";
 
   if(REorME == 0 && inputPair == kV0V0)//real event
     {
-      TString fillthis = "fLambdaLambdaRelK";
+      fillthis = "fLambdaLambdaRelK";
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fLambdaLambdaRelKMulti_";
+      fillthis += MultBin;
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fLambdaLambdaAvgSeparationPP";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPP);
+
+      fillthis = "fLambdaLambdaAvgSeparationP1Pi2";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPPi);
+
+      fillthis = "fLambdaLambdaAvgSeparationP2Pi1";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPiP);
+
+      fillthis = "fLambdaLambdaAvgSeparationPiPi";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPiPi);
     }
   else if(REorME != 0 && inputPair == kV0V0)//mixed event
     {
-      TString fillthis = "fLambdaLambdaRelKME";
+      fillthis = "fLambdaLambdaRelKME";
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fLambdaLambdaRelKMEMulti_";
+      fillthis += MultBin;
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fLambdaLambdaAvgSeparationPPME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPP);
+
+      fillthis = "fLambdaLambdaAvgSeparationP1Pi2ME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPPi);
+
+      fillthis = "fLambdaLambdaAvgSeparationP2Pi1ME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPiP);
+
+      fillthis = "fLambdaLambdaAvgSeparationPiPiME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPiPi);
     }
   else if(REorME == 0 && inputPair == kAntiV0AntiV0)//real event
     {
-      TString fillthis = "fAntiLambdaAntiLambdaRelK";
+      fillthis = "fAntiLambdaAntiLambdaRelK";
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fAntiLambdaAntiLambdaRelKMulti_";
+      fillthis += MultBin;
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fAntiLambdaAntiLambdaAvgSeparationPP";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPP);
+
+      fillthis = "fAntiLambdaAntiLambdaAvgSeparationP1Pi2";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPPi);
+
+      fillthis = "fAntiLambdaAntiLambdaAvgSeparationP2Pi1";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPiP);
+
+      fillthis = "fAntiLambdaAntiLambdaAvgSeparationPiPi";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPiPi);
     }
   else if(REorME != 0 && inputPair == kAntiV0AntiV0)//mixed event
     {
-      TString fillthis = "fAntiLambdaAntiLambdaRelKME";
+      fillthis = "fAntiLambdaAntiLambdaRelKME";
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fAntiLambdaAntiLambdaRelKMEMulti_";
+      fillthis += MultBin;
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fAntiLambdaAntiLambdaAvgSeparationPPME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPP);
+
+      fillthis = "fAntiLambdaAntiLambdaAvgSeparationP1Pi2ME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPPi);
+
+      fillthis = "fAntiLambdaAntiLambdaAvgSeparationP2Pi1ME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPiP);
+
+      fillthis = "fAntiLambdaAntiLambdaAvgSeparationPiPiME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSepPiPi);
     }
   else if(REorME == 0 && inputPair == kAntiV0V0)//real event
     {
-      TString fillthis = "fAntiLambdaLambdaRelK";
+      fillthis = "fAntiLambdaLambdaRelK";
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
     }
   else if(REorME != 0 && inputPair == kAntiV0V0)//mixed event
     {
-      TString fillthis = "fAntiLambdaLambdaRelKME";
+      fillthis = "fAntiLambdaLambdaRelKME";
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
     }
 }
@@ -2111,9 +2425,28 @@ void AliAnalysisTaskPLFemto::PairAnalysis(const AliFemtoProtonParticle &protonA,
   Double_t pairKT = 0.5*trackSum.Pt();
   Double_t pairMT = TMath::Sqrt(pow(pairKT,2.) + pow(fCuts->GetHadronMasses(2212),2.));
 
+  Double_t e1Timese2 = trackProtonA.E() * trackProtonB.E();
+  Double_t e1Pluse2 = trackProtonA.E() + trackProtonB.E();
+  Double_t p1zTimesp2z = trackProtonA.Pz() * trackProtonB.Pz();
+
+  Double_t avgSep = GetAverageSeparation(protonA.fPositionTPC,protonB.fPositionTPC);
+
+  TVector2 tPt1;
+  TVector2 tPt2;
+  tPt1.Set(trackProtonA.Px(),trackProtonA.Py());
+  tPt2.Set(trackProtonB.Px(),trackProtonB.Py());
+  double pt1Dotpt2 = tPt1*tPt2;
+
+  Int_t *MixingBins = MultiplicityBinFinderzVertexBinFinder(static_cast<AliAODEvent*>(fInputEvent),fPrimVertex[2]);
+  Int_t MultBin = MixingBins[1];
+
   if(REorME == 0 && inputPair == kProtonProton)//real event
     {
       fillthis = "fProtonProtonRelK";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fProtonProtonRelKMulti_";
+      fillthis += MultBin;
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
 
       fillthis = "fPairkTpp";
@@ -2136,20 +2469,66 @@ void AliAnalysisTaskPLFemto::PairAnalysis(const AliFemtoProtonParticle &protonA,
 
 
       //check for splitting/merging in angle space
+
       for(int radius=0; radius<9; radius++)
 	{
 	  Double_t deltaEta = protonA.fEta - protonB.fEta;
+
 	  Double_t deltaPhistar = protonA.fPhistar[radius] - protonB.fPhistar[radius];
+
 
 	  fillthis = "fDeltaEtaDeltaPhiTPCradpp";
 	  fillthis += radius;
 	  ((TH2F*)(fOutputTP->FindObject(fillthis)))->Fill(TMath::Abs(deltaEta),TMath::Abs(deltaPhistar));
 	}
+
+      //Fill only with certain separation
+      if(avgSep > 4.)//cm
+	{
+	  fillthis = "fProtonProtonRelKw2TC";
+	  ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+	}
+
+
+      fillthis = "fProtonProtonAvgSeparation";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSep);
+
+      fillthis = "fProtonProtonAvgSeparationVsRelK";
+      ((TH2F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSep,relK);
+
+      fillthis = "fProtonPtCorrelationRE";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(trackProtonA.Pt(),trackProtonB.Pt());
+
+      fillthis = "fProtonEtaCorrelationRE";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(trackProtonA.PseudoRapidity(),trackProtonB.PseudoRapidity());
+
+      fillthis = "fProtonEnCorrelationRE";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(trackProtonA.E(),trackProtonB.E());
+
+      fillthis = "fProtonPhiCorrelationRE";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(trackProtonA.Phi(),trackProtonB.Phi());
     }
   else if(REorME!=0 && inputPair == kProtonProton)//mixed event
     {
       fillthis = "fProtonProtonRelKME";
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fProtonProtonRelKMEMulti_";
+      fillthis += MultBin;
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      //EMCIC histos:
+      fillthis = "fProtonProtonRelKEnMultME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK,e1Timese2);
+
+      fillthis = "fProtonProtonRelKEnSumME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK,e1Pluse2);
+
+      fillthis = "fProtonProtonRelKPzMultME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK,p1zTimesp2z);
+
+      fillthis = "fProtonProtonRelKPtMultME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK,pt1Dotpt2);
 
       if(fUseMCInfo) GetMomentumMatrix(protonA,protonB);//Determine the momentum resolution (from mixed event to enlarge statistics)
 
@@ -2164,10 +2543,39 @@ void AliAnalysisTaskPLFemto::PairAnalysis(const AliFemtoProtonParticle &protonA,
 	  fillthis += radius;
 	  ((TH2F*)(fOutputTP->FindObject(fillthis)))->Fill(TMath::Abs(deltaEta),TMath::Abs(deltaPhistar));
 	}
+
+      //Fill p-p correlations with a certain track separation:
+      if(avgSep > 4.)//cm
+	{
+	  fillthis = "fProtonProtonRelKw2TCME";
+	  ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+	}
+
+      fillthis = "fProtonProtonAvgSeparationME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSep);
+
+      fillthis = "fProtonProtonAvgSeparationVsRelKME";
+      ((TH2F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSep,relK);
+
+      fillthis = "fProtonPtCorrelationME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(trackProtonA.Pt(),trackProtonB.Pt());
+
+      fillthis = "fProtonEtaCorrelationME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(trackProtonA.PseudoRapidity(),trackProtonB.PseudoRapidity());
+
+      fillthis = "fProtonEnCorrelationME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(trackProtonA.E(),trackProtonB.E());
+
+      fillthis = "fProtonPhiCorrelationME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(trackProtonA.Phi(),trackProtonB.Phi());
     }
   else if(REorME==0 && inputPair == kAntiProtonAntiProton)//same event
     {
       fillthis = "fAntiProtonAntiProtonRelK";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fAntiProtonAntiProtonRelKMulti_";
+      fillthis += MultBin;
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
 
       fillthis = "fPairkTApAp";
@@ -2181,11 +2589,36 @@ void AliAnalysisTaskPLFemto::PairAnalysis(const AliFemtoProtonParticle &protonA,
 	  fillthis = "fNPairStatistics";
 	  ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(9);
 	}
+
+      fillthis = "fAntiProtonAntiProtonAvgSeparation";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSep);
+
+      //Fill only with certain separation
+      if(avgSep > 4.)//cm
+	{
+	  fillthis = "fAntiProtonAntiProtonRelKw2TC";
+	  ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+	}
+
     }
   else if(REorME!=0 && inputPair == kAntiProtonAntiProton)//mixed event
     {
       fillthis = "fAntiProtonAntiProtonRelKME";
       ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fAntiProtonAntiProtonRelKMEMulti_";
+      fillthis += MultBin;
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+
+      fillthis = "fAntiProtonAntiProtonAvgSeparationME";
+      ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(avgSep);
+
+      //Fill only with certain separation
+      if(avgSep > 4.)//cm
+	{
+	  fillthis = "fAntiProtonAntiProtonRelKw2TCME";
+	  ((TH1F*)(fOutputTP->FindObject(fillthis)))->Fill(relK);
+	}
     }
   else if(REorME==0 && inputPair == kAntiProtonProton)//same event
     {
@@ -2399,7 +2832,7 @@ Bool_t AliAnalysisTaskPLFemto::V0TopologicalSelection(AliAODv0 *v0,AliAODEvent *
 
       fillthis = "fLambdaCPAPtBin";
       fillthis += ptbin;
-      if(MassV0>(fCuts->GetHadronMasses(3122)-fCuts->GetV0PID_width()) && MassV0<(fCuts->GetHadronMasses(3122)+fCuts->GetV0PID_width()) && ParOrAPar == fwhichV0)
+      if(MassV0>(fCuts->GetHadronMasses(3122)-fCuts->GetV0PIDWidth()) && MassV0<(fCuts->GetHadronMasses(3122)+fCuts->GetV0PIDWidth()) && ParOrAPar == fwhichV0)
 	{
 	  ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(point);//Fill pointing angle only for Lambda candidates
 	}
@@ -2445,7 +2878,7 @@ Bool_t AliAnalysisTaskPLFemto::V0TopologicalSelection(AliAODv0 *v0,AliAODEvent *
 	      fillthis = "fLambdaCPABkgPtBin";
 	      fillthis += ptbin;
 	      //background in the mass range of the lambda is interesting for us:
-	      if(MassV0>(fCuts->GetHadronMasses(3122)-fCuts->GetV0PID_width()) && MassV0<(fCuts->GetHadronMasses(3122)+fCuts->GetV0PID_width()) && ParOrAPar == fwhichV0)
+	      if(MassV0>(fCuts->GetHadronMasses(3122)-fCuts->GetV0PIDWidth()) && MassV0<(fCuts->GetHadronMasses(3122)+fCuts->GetV0PIDWidth()) && ParOrAPar == fwhichV0)
 		{
 		  ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(point);//Fill background only in the selection region
 		}
@@ -2465,6 +2898,7 @@ inline void AliAnalysisTaskPLFemto::FillV0Selection(AliAODv0 *v0,AliAODEvent* ao
   Double_t MassV0 = 0.;
 
   TString fillthis = "";
+
 
   if(ParOrAPar == fwhichV0)
     {
@@ -2587,8 +3021,8 @@ inline void AliAnalysisTaskPLFemto::FillV0Selection(AliAODv0 *v0,AliAODEvent* ao
 	}
       else if(fwhichV0region == "signal")
 	{
-	  if(MassV0>(fCuts->GetHadronMasses(3122)-fCuts->GetV0PID_width()) && MassV0<(fCuts->GetHadronMasses(3122)+fCuts->GetV0PID_width()) && ParOrAPar == fwhichV0) which_V0_region = kTRUE;
-	  else if(MassV0>(fCuts->GetHadronMasses(3122)-fCuts->GetV0PID_width()) && MassV0<(fCuts->GetHadronMasses(3122)+fCuts->GetV0PID_width()) && ParOrAPar == fwhichAntiV0) which_AntiV0_region = kTRUE;
+	  if(MassV0>(fCuts->GetHadronMasses(3122)-fCuts->GetV0PIDWidth()) && MassV0<(fCuts->GetHadronMasses(3122)+fCuts->GetV0PIDWidth()) && ParOrAPar == fwhichV0) which_V0_region = kTRUE;
+	  else if(MassV0>(fCuts->GetHadronMasses(3122)-fCuts->GetV0PIDWidth()) && MassV0<(fCuts->GetHadronMasses(3122)+fCuts->GetV0PIDWidth()) && ParOrAPar == fwhichAntiV0) which_AntiV0_region = kTRUE;
 	}
 
 
@@ -2606,6 +3040,12 @@ inline void AliAnalysisTaskPLFemto::FillV0Selection(AliAODv0 *v0,AliAODEvent* ao
 	  fillthis = "fInvMassLambdawCutsAfterMassCut";
 	  ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(MassV0);
 
+	  fillthis = "fLambdaPosDaughPt";
+	  ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(pTrack->Pt());
+
+	  fillthis = "fLambdaNegDaughPt";
+	  ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(nTrack->Pt());
+
 	  if(fV0Counter > kV0TrackLimit) return;
 	  if(pTrack->GetID() == nTrack->GetID()) return; //should never happen
 	  fV0cand[fV0Counter].fPt = v0->Pt();
@@ -2618,14 +3058,34 @@ inline void AliAnalysisTaskPLFemto::FillV0Selection(AliAODv0 *v0,AliAODEvent* ao
 	  fV0cand[fV0Counter].fDaughterID2 = nTrack->GetID();
 	  fV0cand[fV0Counter].fMomentumPosDaughter.SetXYZ(pTrack->Px(),pTrack->Py(),pTrack->Pz());
 	  fV0cand[fV0Counter].fMomentumNegDaughter.SetXYZ(nTrack->Px(),nTrack->Py(),nTrack->Pz());
-	  GetGlobalPositionAtGlobalRadiiThroughTPC(pTrack,aodEvent->GetMagneticField(),fV0cand[fV0Counter].fPosDaughPosTPC,fPrimVertex);
-	  GetGlobalPositionAtGlobalRadiiThroughTPC(nTrack,aodEvent->GetMagneticField(),fV0cand[fV0Counter].fNegDaughPosTPC,fPrimVertex);
+	  //GetGlobalPositionAtGlobalRadiiThroughTPC(pTrack,aodEvent->GetMagneticField(),fV0cand[fV0Counter].fPositionPosTPC,fPrimVertex);
+	  //GetGlobalPositionAtGlobalRadiiThroughTPC(nTrack,aodEvent->GetMagneticField(),fV0cand[fV0Counter].fPositionNegTPC,fPrimVertex);
+
+	  for(int radius=0;radius<9;radius++)
+	    {
+	      fV0cand[fV0Counter].fPositionPosTPC[radius] = GetGlobalPositionAtGlobalRadiiThroughTPC(pTrack,aodEvent->GetMagneticField(),fTPCradii[radius],fPrimVertex);
+	      fV0cand[fV0Counter].fPositionNegTPC[radius] = GetGlobalPositionAtGlobalRadiiThroughTPC(nTrack,aodEvent->GetMagneticField(),fTPCradii[radius],fPrimVertex);
+	    }
+
+
 
 	  if(fUseMCInfo)// if monte carlo
 	    {
 	      if(CheckMCPID(v0,aodEvent,3122)) fV0cand[fV0Counter].fReal = kTRUE;
 	      else fV0cand[fV0Counter].fReal = kFALSE;
 
+	      /*
+	      if(fV0cand[fV0Counter].fReal)
+		{
+		  fillthis = "fLambdaSignalBkg";
+		  ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(1);
+		}
+	      else
+		{
+		  fillthis = "fLambdaSignalBkg";
+		  ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(2);
+		}
+	      */
 	      GetV0Origin(v0,aodEvent);//evaluated with all the cuts applied
 	      double v0MCmom[3] = {-9999.,-9999.,-9999.};
 	      double v0MCmom_mother[4] = {-9999.,-9999.,-9999.,-9999.};
@@ -2669,6 +3129,13 @@ inline void AliAnalysisTaskPLFemto::FillV0Selection(AliAODv0 *v0,AliAODEvent* ao
 	  fillthis = "fNAntiLambdasTot";
 	  ((TH1F*)(fOutputSP->FindObject(fillthis)))->Fill(1); //fill only unique candidates
 
+
+	  for(int radius=0;radius<9;radius++)
+	    {
+	      fAntiV0cand[fAntiV0Counter].fPositionPosTPC[radius] = GetGlobalPositionAtGlobalRadiiThroughTPC(pTrack,aodEvent->GetMagneticField(),fTPCradii[radius],fPrimVertex);
+	      fAntiV0cand[fAntiV0Counter].fPositionNegTPC[radius] = GetGlobalPositionAtGlobalRadiiThroughTPC(nTrack,aodEvent->GetMagneticField(),fTPCradii[radius],fPrimVertex);
+	    }
+
 	  fAntiV0Counter++;//This is a Anti-V0 (Anti-Lambda) candidate
 	}
       //_____________________________________________________
@@ -2686,7 +3153,7 @@ void AliAnalysisTaskPLFemto::Terminate(Option_t*)
   AliAnalysisTaskSE::Terminate();
 
   fOutput = dynamic_cast<TList*> (GetOutputData(1));
-  if (!fOutput) {
+  if (!fOutput) {     
     printf("ERROR: fOutput not available\n");
     return;
   }
@@ -2726,6 +3193,15 @@ void AliAnalysisTaskPLFemto::UserCreateOutputObjects()
   fOutput->SetOwner();
   fOutput->SetName("listEvt");
 
+  if(!fIsRun1) {
+      fOutputAliEvent = new TList();
+      fOutputAliEvent->SetOwner();
+      fOutputAliEvent->SetName("listAliEventCuts");
+      fAliEventCuts.SetManualMode();
+      fAliEventCuts.fTriggerMask = fTrigger;
+      fAliEventCuts.AddQAplotsToList(fOutputAliEvent);
+    }
+
   fOutputPID = new TList();
   fOutputPID->SetOwner();
   fOutputPID->SetName("listPID");
@@ -2752,10 +3228,12 @@ void AliAnalysisTaskPLFemto::UserCreateOutputObjects()
   fPIDResponse = inputHandler->GetPIDResponse();
   if(!fPIDResponse){AliError("Couldn't get the PID response task!");}
 
+
   PostData(1,fOutput);
   PostData(2,fOutputSP);
   PostData(3,fOutputPID);
   PostData(4,fOutputTP);
+  PostData(5,fOutputAliEvent);
 
   return;
 }
@@ -2861,6 +3339,11 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
   TH1F* fInvMassLambdawCutsAfterSelection = new TH1F("fInvMassLambdawCutsAfterSelection","Invariant mass of Lambda(p #pi) (GeV/c) with topological cuts and after proton selection",400,invMassLow,invMassUp);
   TH1F* fInvMassLambdawCutsAfterMassCut = new TH1F("fInvMassLambdawCutsAfterMassCut","Invariant mass of Lambda(p #pi) (GeV/c) with vertex cuts and Mass cut of 4 MeV/c²",400,invMassLow,invMassUp);
 
+  //TH1F* fLambdaSignalBkg = new TH1F("fLambdaSignalBkg","Count true and fake lambda pairs",10,0,10);
+
+  TH1F* fInvMassLambdaRejected = new TH1F("fInvMassLambdaRejected","Invariant mass of Lambda(p #pi) (GeV/c) which were rejected from the sample",400,invMassLow,invMassUp);
+  TH1F* fInvMassLambdaKept = new TH1F("fInvMassLambdaKept","Invariant mass of Lambda(p #pi) (GeV/c) which were kept in the sample",400,invMassLow,invMassUp);
+
   //Differential Analysis in Pt:
   TH1F* fInvMassLambdawCutsPtBin[fCuts->GetV0PtBinsInvMass()];
 
@@ -2872,6 +3355,8 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
       fOutputSP->Add(fInvMassLambdawCutsPtBin[i]);
     }
 
+
+  TH1F* fHistTrackFilterMap = new TH1F("fHistTrackFilterMap","Includes different filter maps for all the corresponding global tracks",4000,0,2000);
 
   TH1F* fInvMassAntiLambdawCuts = new TH1F("fInvMassAntiLambdawCuts","Invariant mass of AntiLambda(a-p a-#pi) (GeV/c) with vertex cuts",400,invMassLow,invMassUp);
   TH1F* fInvMassAntiLambdawoCuts = new TH1F("fInvMassAntiLambdawoCuts","Invariant mass of AntiLambda(a-p a-#pi) (GeV/c) without topological cuts",400,invMassLow,invMassUp);
@@ -2901,6 +3386,8 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
   TH2F* fAntiProtonDCAxyDCAz = new TH2F("fAntiProtonDCAxyDCAz","Distribution of DCAz vs DCAxy",500,-5,5,1000,-20,20);
 
   TH2F* fProtonDCAxyDCAzMCPtBin[5][fCuts->GetPtBinsDCA()];
+  TH2F* fProtonDCAxyDCAzMCPtBinLambda[fCuts->GetPtBinsDCA()];
+  TH2F* fProtonDCAxyDCAzMCPtBinSigma[fCuts->GetPtBinsDCA()];
   TH2F* fProtonDCAxyDCAzPt[fCuts->GetPtBinsDCA()];
 
   for(int ProtonCases = 0; ProtonCases < 5; ProtonCases++)//primary, secondary, ....
@@ -2915,16 +3402,33 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
 	  fProtonDCAxyDCAzMCPtBin[ProtonCases][ptbins] = new TH2F(HistName.Data(),"DCAz vs DCAxy for different pt Bins",500,-5,5,500,-5,5);
 	  fProtonDCAxyDCAzMCPtBin[ProtonCases][ptbins]->Sumw2();
 	  if(fUseMCInfo) fOutputSP->Add(fProtonDCAxyDCAzMCPtBin[ProtonCases][ptbins]);
-	  else if(!fUseMCInfo)
+
+	  if(ProtonCases == 0)
 	    {
-	      if(ProtonCases == 0)
-		{
-		  HistName = "fProtonDCAxyDCAzPt";
-		  HistName += ptbins;
-		  fProtonDCAxyDCAzPt[ptbins] = new TH2F(HistName.Data(),"DCAz vs DCAxy for different pt Bins",500,-5,5,500,-5,5);
-		  fProtonDCAxyDCAzPt[ptbins]->Sumw2();
-		  fOutputSP->Add(fProtonDCAxyDCAzPt[ptbins]);
-		}
+	      HistName = "fProtonDCAxyDCAzMCPtBinLambda";
+	      HistName += "PtBin";
+	      HistName += ptbins;
+
+	      fProtonDCAxyDCAzMCPtBinLambda[ptbins] = new TH2F(HistName.Data(),"DCAz vs DCAxy for different pt Bins for Lambda hyperons",500,-5,5,500,-5,5);
+	      fProtonDCAxyDCAzMCPtBinLambda[ptbins]->Sumw2();
+	      if(fUseMCInfo) fOutputSP->Add(fProtonDCAxyDCAzMCPtBinLambda[ptbins]);
+
+	      HistName = "fProtonDCAxyDCAzMCPtBinSigma";
+	      HistName += "PtBin";
+	      HistName += ptbins;
+
+	      fProtonDCAxyDCAzMCPtBinSigma[ptbins] = new TH2F(HistName.Data(),"DCAz vs DCAxy for different pt Bins for Sigma+ hyperons",500,-5,5,500,-5,5);
+	      fProtonDCAxyDCAzMCPtBinSigma[ptbins]->Sumw2();
+	      if(fUseMCInfo) fOutputSP->Add(fProtonDCAxyDCAzMCPtBinSigma[ptbins]);
+	    }
+
+	  if(ProtonCases == 0)
+	    {
+	      HistName = "fProtonDCAxyDCAzPt";
+	      HistName += ptbins;
+	      fProtonDCAxyDCAzPt[ptbins] = new TH2F(HistName.Data(),"DCAz vs DCAxy for different pt Bins",500,-5,5,500,-5,5);
+	      fProtonDCAxyDCAzPt[ptbins]->Sumw2();
+	      fOutputSP->Add(fProtonDCAxyDCAzPt[ptbins]);
 	    }
 	}
     }
@@ -2972,12 +3476,13 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
 	}
     }
 
-
   TH1F* fLambdaPt = new TH1F("fLambdaPt","Transverse momentum spectrum of V0s",50,0.,10.);
+  TH1F* fLambdaPosDaughPt = new TH1F("fLambdaPosDaughPt","Transverse momentum of positive daughter of V0",500,0.,10.);
+  TH1F* fLambdaNegDaughPt = new TH1F("fLambdaNegDaughPt","Transverse momentum of negative daughter of V0",500,0.,10.);
   TH1F* fLambdaPhi = new TH1F("fLambdaPhi","Phi angle spectrum of V0s",300,-1,2.*TMath::Pi());
   TH1F* fLambdaEta = new TH1F("fLambdaEta","Eta spectrum of V0s",400,-2,2);
   TH1F* fAntiLambdaPt = new TH1F("fAntiLambdaPt","Transverse momentum spectrum of Anti-V0s",50,0.,10.);
-  TH1F* fProtonPt = new TH1F("fProtonPt","Transverse momentum spectrum of protons",50,0.,10.);
+  TH1F* fProtonPt = new TH1F("fProtonPt","Transverse momentum spectrum of protons",400,0.,10.);
   TH1F* fProtonPhi = new TH1F("fProtonPhi","Phi angle spectrum of protons",300,-1,2.*TMath::Pi());
   TH1F* fProtonEta = new TH1F("fProtonEta","Pseudorapidity spectrum of protons",400,-2,2);
 
@@ -3003,6 +3508,9 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
   TH1F* fNBinsMultmixing = new TH1F("fNBinsMultmixing","Bins in multiplicity that are used for event mixing, which bin is often occupied etc.",kMultiplicityBins,0,kMultiplicityBins);
   TH1F* fNBinsVertexmixing = new TH1F("fNBinsVertexmixing","Bins in z-Vertex that are used for event mixing, which bin is often occupied etc.",kZVertexBins,0,kZVertexBins);
   TH1F* fNTracklets = new TH1F("fNTracklets","Number of Tracklets",200,0,200);
+  TH1F* fRefMultiplicity08 = new TH1F("fRefMultiplicity08","Reference multiplicity",200,0,200);
+  TH2F* fNTrackletsRefMultiplicity = new TH2F("fNTrackletsRefMultiplicity","Correlation between tracklets and refmultiplicity",200,0,200,200,0,200);
+  TH1F* fNTPCTracks = new TH1F("fNTPCTracks","Number of TPC tracks",200,0,200);
   TH1F* fNProtonsPerevent = new TH1F("fNProtonsPerevent","Number of protons in an event",200,1,100);
   TH1F* fNLambdasPerevent = new TH1F("fNLambdasPerevent","Number of V0s in an event",20,1,10);
   TH1F* fNProtonsTot = new TH1F("fNProtonsTot","Total number of protons",10,1,10);
@@ -3014,7 +3522,7 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
   TH1F* fNV0protonSharedTracks = new TH1F("fNV0protonSharedTracks","How often share a V0 and a proton the same track?",10,0,10);
   TH1F* fNAntiV0protonSharedTracks = new TH1F("fNAntiV0protonSharedTracks","How often share a Anti-V0 and a proton the same track?",10,0,10);
   TH1F* fNAntiV0AntiprotonSharedTracks = new TH1F("fNAntiV0AntiprotonSharedTracks","How often share a Anti-V0 and a Anti-proton the same track?",10,0,10);
-
+  TH1F* fNXimTrackSharing = new TH1F("fNXimTrackSharing","Number of Xim which shared tracks in an event",20,0,10);
 
   TH1F* fFeeddownProton = new TH1F("fFeeddownProton","1: total number of protons, 2: Primary, 3: from weak decays, 4: from material",10,0,10);
   TH1F* fFeeddownProtonFromWeakPDG = new TH1F("fFeeddownProtonFromWeakPDG","Protons stemming from weak decays",213,3121,3334);
@@ -3038,6 +3546,9 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
   fInvMassMissIDK0s->Sumw2();
   fInvMassMissIDK0swCuts->Sumw2();
 
+  fInvMassLambdaRejected->Sumw2();
+  fInvMassLambdaKept->Sumw2();
+
   fXiInvMasswoCuts->Sumw2();
   fXiInvMasswCuts->Sumw2();
 
@@ -3050,12 +3561,18 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
   fAntiProtonDCAz->Sumw2();
   fAntiProtonDCAxyDCAz->Sumw2();
 
+  fOutputSP->Add(fHistTrackFilterMap);
   fOutputSP->Add(fNBinsMultmixing);
   fOutputSP->Add(fNBinsVertexmixing);
   fOutputSP->Add(fNTracklets);
+  fOutputSP->Add(fRefMultiplicity08);
+  fOutputSP->Add(fNTrackletsRefMultiplicity);
+  fOutputSP->Add(fNTPCTracks);
   fOutputSP->Add(fInvMassLambdawCuts);
   fOutputSP->Add(fInvMassLambdawoCuts);
   fOutputSP->Add(fInvMassLambdawCutsAfterSelection);
+  fOutputSP->Add(fInvMassLambdaRejected);
+  fOutputSP->Add(fInvMassLambdaKept);
 
   fOutputSP->Add(fInvMassLambdawCutsAfterMassCut);
   fOutputSP->Add(fInvMassAntiLambdawCuts);
@@ -3068,6 +3585,8 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
   fOutputSP->Add(fXiInvMassLambda);
 
   fOutputSP->Add(fLambdaPt);
+  fOutputSP->Add(fLambdaPosDaughPt);
+  fOutputSP->Add(fLambdaNegDaughPt);
   fOutputSP->Add(fLambdaPhi);
   fOutputSP->Add(fLambdaEta);
   fOutputSP->Add(fAntiLambdaPt);
@@ -3086,7 +3605,7 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
   fOutputSP->Add(fNV0protonSharedTracks);
   fOutputSP->Add(fNAntiV0protonSharedTracks);
   fOutputSP->Add(fNAntiV0AntiprotonSharedTracks);
-
+  fOutputSP->Add(fNXimTrackSharing);
 
   if(fUseMCInfo)
     {
@@ -3141,19 +3660,45 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
   fOutputSP->Add(fRatioFindableCrossedAntiProton);
 
 
+
+
   //Define two particle histograms:
   //p-lambda
   TH1F* fProtonLambdaRelK = new TH1F("fProtonLambdaRelK","Relative momentum of V0-p RE",150,0.,3.); //first choice was 300 bins
   TH1F* fProtonLambdaRelKME = new TH1F("fProtonLambdaRelKME","Relative momentum of V0-p ME",150,0.,3.);
+  TH1F* fProtonLambdaRelKMulti[13];
+  TH1F* fProtonLambdaRelKMEMulti[13];
+  for(int i=0; i<13; ++i) {
+      fProtonLambdaRelKMulti[i] = new TH1F(Form("fProtonLambdaRelKMulti_%i", i),"Relative momentum of V0-p RE",150,0.,3.); //first choice was 300 bins
+      fProtonLambdaRelKMEMulti[i] = new TH1F(Form("fProtonLambdaRelKMEMulti_%i", i),"Relative momentum of V0-p ME",150,0.,3.);
+    }
+
   TH1F* fProtonLambdaPosDaughterRelK = new TH1F("fProtonLambdaPosDaughterRelK","Relative momentum of daughter proton and primary proton RE",150,0.,3.); //first choice was 300 bins
   TH1F* fProtonLambdaPosDaughterRelKME = new TH1F("fProtonLambdaPosDaughterRelKME","Relative momentum of daughter proton and primary proton ME",150,0.,3.);
   TH1F* fAntiProtonAntiLambdaPosDaughterRelK = new TH1F("fAntiProtonAntiLambdaPosDaughterRelK","Relative momentum of daughter anti-proton and primary anti-proton RE",150,0.,3.); //first choice was 300 bins
   TH1F* fAntiProtonAntiLambdaPosDaughterRelKME = new TH1F("fAntiProtonAntiLambdaPosDaughterRelKME","Relative momentum of daughter anti-proton and primary anti-proton ME",150,0.,3.);
+  TH1F* fProtonLambdaDiff = new TH1F("fProtonLambdaDiff","diff of qinv relk",1000,-0.1,0.1);
+  TH1F* fProtonLambdaAvgSeparationPP = new TH1F("fProtonLambdaAvgSeparationPP","Relative distances of pp_daugh RE",2000,0.,500.);
+  TH1F* fProtonLambdaAvgSeparationPPME = new TH1F("fProtonLambdaAvgSeparationPPME","Relative distances of pp_daugh ME",2000,0.,500.);
+  TH1F* fProtonLambdaAvgSeparationPPi = new TH1F("fProtonLambdaAvgSeparationPPi","Relative distances of ppi_daugh RE",2000,0.,500.);
+  TH1F* fProtonLambdaAvgSeparationPPiME = new TH1F("fProtonLambdaAvgSeparationPPiME","Relative distances of ppi_daugh ME",2000,0.,500.);
 
 
   //Antip-Antilambda
-  TH1F* fAntiProtonAntiLambdaRelK = new TH1F("fAntiProtonAntiLambdaRelK","Relative momentum of Anti-V0-Antip RE",500,0.,3.); //first choice was 300 bins
-  TH1F* fAntiProtonAntiLambdaRelKME = new TH1F("fAntiProtonAntiLambdaRelKME","Relative momentum of Anti-V0-Antip ME",500,0.,3.);
+  TH1F* fAntiProtonAntiLambdaRelK = new TH1F("fAntiProtonAntiLambdaRelK","Relative momentum of Anti-V0-Antip RE",150,0.,3.); //first choice was 300 bins
+  TH1F* fAntiProtonAntiLambdaRelKME = new TH1F("fAntiProtonAntiLambdaRelKME","Relative momentum of Anti-V0-Antip ME",150,0.,3.);
+  TH1F* fAntiProtonAntiLambdaRelKMulti[13];
+  TH1F* fAntiProtonAntiLambdaRelKMEMulti[13];
+  for(int i=0; i<13; ++i) {
+      fAntiProtonAntiLambdaRelKMulti[i] = new TH1F(Form("fAntiProtonAntiLambdaRelKMulti_%i", i), Form("Relative momentum of AntiV0-Antip RE %i", i),150,0.,3.); //first choice was 300 bins
+      fAntiProtonAntiLambdaRelKMEMulti[i] = new TH1F(Form("fAntiProtonAntiLambdaRelKMEMulti_%i", i), Form("Relative momentum of AntiV0-Antip ME %i", i),150,0.,3.);
+    }
+
+  TH1F* fAntiProtonAntiLambdaAvgSeparationPP = new TH1F("fAntiProtonAntiLambdaAvgSeparationPP","Relative distances of pp_daugh RE",2000,0.,500.);
+  TH1F* fAntiProtonAntiLambdaAvgSeparationPPME = new TH1F("fAntiProtonAntiLambdaAvgSeparationPPME","Relative distances of pp_daugh ME",2000,0.,500.);
+  TH1F* fAntiProtonAntiLambdaAvgSeparationPPi = new TH1F("fAntiProtonAntiLambdaAvgSeparationPPi","Relative distances of ppi_daugh RE",2000,0.,500.);
+  TH1F* fAntiProtonAntiLambdaAvgSeparationPPiME = new TH1F("fAntiProtonAntiLambdaAvgSeparationPPiME","Relative distances of ppi_daugh ME",2000,0.,500.);
+
 
   TH1F* fProtonLambdaMT = new TH1F("fProtonLambdaMT","Transverse mass of pL",1000,0.,10.);
   TH1F* fProtonLambdaMTrelKcut = new TH1F("fProtonLambdaMTrelKcut","Transverse mass of pL",1000,0.,10.);
@@ -3167,28 +3712,67 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
   //p-Xi
   TH1F* fProtonXiRelK = new TH1F("fProtonXiRelK","Relative momentum of Xi-p RE",150,0.,3.);
   TH1F* fProtonXiRelKME = new TH1F("fProtonXiRelKME","Relative momentum of Xi-p ME",150,0.,3.);
+  TH1F* fProtonXiRelKMulti[13];
+  TH1F* fProtonXiRelKMEMulti[13];
+  for(int i=0; i<13; ++i) {
+      fProtonXiRelKMulti[i] = new TH1F(Form("fProtonXiRelKMulti_%i", i), Form("Relative momentum of Xi-p RE %i", i),150,0.,3.); //first choice was 300 bins
+      fProtonXiRelKMEMulti[i] = new TH1F(Form("fProtonXiRelKMEMulti_%i", i), Form("Relative momentum of Xi-p ME %i", i),150,0.,3.);
+    }
+
   TH1F* fAntiProtonXiRelK = new TH1F("fAntiProtonXiRelK","Relative momentum of Xi-Antip RE",150,0.,3.);
   TH1F* fAntiProtonXiRelKME = new TH1F("fAntiProtonXiRelKME","Relative momentum of Xi-Antip ME",150,0.,3.);
+  TH1F* fAntiProtonXiRelKMulti[13];
+  TH1F* fAntiProtonXiRelKMEMulti[13];
+  for(int i=0; i<13; ++i) {
+      fAntiProtonXiRelKMulti[i] = new TH1F(Form("fAntiProtonXiRelKMulti_%i", i), Form("Relative momentum of Xi-Antip RE %i", i),150,0.,3.); //first choice was 300 bins
+      fAntiProtonXiRelKMEMulti[i] = new TH1F(Form("fAntiProtonXiRelKMEMulti_%i", i), Form("Relative momentum of Xi-Antip ME %i", i),150,0.,3.);
+    }
 
   //p-p
   TH1F* fProtonProtonRelK = new TH1F("fProtonProtonRelK","Relative momentum of pp RE",750,0.,3.);
   TH1F* fProtonProtonRelKME = new TH1F("fProtonProtonRelKME","Relative momentum of pp ME",750,0.,3.);
+  TH1F* fProtonProtonRelKMulti[13];
+  TH1F* fProtonProtonRelKMEMulti[13];
+  for(int i=0; i<13; ++i) {
+      fProtonProtonRelKMulti[i] = new TH1F(Form("fProtonProtonRelKMulti_%i", i), Form("Relative momentum of pp RE %i", i),150,0.,3.); //first choice was 300 bins
+      fProtonProtonRelKMEMulti[i] = new TH1F(Form("fProtonProtonRelKMEMulti_%i", i), Form("Relative momentum of pp ME %i", i),150,0.,3.);
+    }
+
+  TH1F* fProtonProtonRelKw2TC = new TH1F("fProtonProtonRelKw2TC","Relative momentum of pp RE with two track cuts",750,0.,3.);
+  TH1F* fProtonProtonRelKw2TCME = new TH1F("fProtonProtonRelKw2TCME","Relative momentum of pp with  two track cuts ME",750,0.,3.);
+
+  TH1F* fProtonProtonAvgSeparation = new TH1F("fProtonProtonAvgSeparation","Relative distances of pp RE",2000,0.,500.);
+  TH1F* fProtonProtonAvgSeparationME = new TH1F("fProtonProtonAvgSeparationME","Relative distances of pp ME",2000,0.,500.);
+  TH2F* fProtonProtonAvgSeparationVsRelK = new TH2F("fProtonProtonAvgSeparationVsRelK","Average separation vs. relK",500,0,50,500,0,3);
+  TH2F* fProtonProtonAvgSeparationVsRelKME = new TH2F("fProtonProtonAvgSeparationVsRelKME","Average separation vs. relK",500,0,50,500,0,3);
+
+  //Check also EMCIC histos:
+  TH1F* fProtonProtonRelKEnSumME = new TH1F("fProtonProtonRelKEnSumME","Relative momentum of pp weighted with total energy ME",750,0.,3.);
+  TH1F* fProtonProtonRelKEnMultME = new TH1F("fProtonProtonRelKEnMultME","Relative momentum of pp weighted with multiplied energy ME",750,0.,3.);
+  TH1F* fProtonProtonRelKPzMultME = new TH1F("fProtonProtonRelKPzMultME","Relative momentum of pp weighted with multiplied z-components of momenta ME",750,0.,3.);
+  TH1F* fProtonProtonRelKPtMultME = new TH1F("fProtonProtonRelKPtMultME","Relative momentum of pp weighted with multiplied pt-components of momenta ME",750,0.,3.);
 
   TH1F* fProtonProtonMT = new TH1F("fProtonProtonMT","Transverse mass of pp",1000,0.,10.);
   TH1F* fProtonProtonMTrelKcut = new TH1F("fProtonProtonMTrelKcut","Transverse mass of pp with relative momentum cut",1000,0.,10.);
 
-  //p-p-p
-  TH1F* fProtonProtonProtonRelK = new TH1F("fProtonProtonProtonRelK","Relative momentum of ppp RE",150,0.,3.);
-  TH1F* fProtonProtonProtonRelKME = new TH1F("fProtonProtonProtonRelKME","Relative momentum of ppp ME",150,0.,3.);
-
-  //p-p-V0
-  TH1F* fProtonProtonLambdaRelK = new TH1F("fProtonProtonLambdaRelK","Relative momentum of p-p-Lambda RE",300,0.,6.);
-  TH1F* fProtonProtonLambdaRelKME = new TH1F("fProtonProtonLambdaRelKME","Relative momentum of p-p-Lambda ME",300,0.,6.);
-
-
   //Antip-Antip
   TH1F* fAntiProtonAntiProtonRelK = new TH1F("fAntiProtonAntiProtonRelK","Relative momentum of antip-antip RE",750,0.,3.);
   TH1F* fAntiProtonAntiProtonRelKME = new TH1F("fAntiProtonAntiProtonRelKME","Relative momentum of antip-antip ME",750,0.,3.);
+  TH1F* fAntiProtonAntiProtonRelKMulti[13];
+  TH1F* fAntiProtonAntiProtonRelKMEMulti[13];
+  for(int i=0; i<13; ++i) {
+      fAntiProtonAntiProtonRelKMulti[i] = new TH1F(Form("fAntiProtonAntiProtonRelKMulti_%i", i), Form("Relative momentum of AntipAntip RE %i", i),150,0.,3.); //first choice was 300 bins
+      fAntiProtonAntiProtonRelKMEMulti[i] = new TH1F(Form("fAntiProtonAntiProtonRelKMEMulti_%i", i), Form("Relative momentum of AntipAntip ME %i", i),150,0.,3.);
+    }
+
+  TH1F* fAntiProtonAntiProtonRelKw2TC = new TH1F("fAntiProtonAntiProtonRelKw2TC","Relative momentum of antip-antip RE with two track cuts",750,0.,3.);
+  TH1F* fAntiProtonAntiProtonRelKw2TCME = new TH1F("fAntiProtonAntiProtonRelKw2TCME","Relative momentum of antip-antip ME with two track cuts",750,0.,3.);
+
+
+  TH1F* fAntiProtonAntiProtonAvgSeparation = new TH1F("fAntiProtonAntiProtonAvgSeparation","Relative distances of pp RE",2000,0.,500.);
+  TH1F* fAntiProtonAntiProtonAvgSeparationME = new TH1F("fAntiProtonAntiProtonAvgSeparationME","Relative distances of pp ME",2000,0.,500.);
+
+
 
   //Antip-p
   TH1F* fAntiProtonProtonRelK = new TH1F("fAntiProtonProtonRelK","Relative momentum of antip-p RE",300,0.,3.);
@@ -3197,14 +3781,47 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
   //Lambda-Lambda
   TH1F* fLambdaLambdaRelK = new TH1F("fLambdaLambdaRelK","Relative momentum of V0-V0 RE",150,0.,3.);
   TH1F* fLambdaLambdaRelKME = new TH1F("fLambdaLambdaRelKME","Relative momentum of V0-V0 ME",150,0.,3.);
+  TH1F* fLambdaLambdaRelKMulti[13];
+  TH1F* fLambdaLambdaRelKMEMulti[13];
+  for(int i=0; i<13; ++i) {
+      fLambdaLambdaRelKMulti[i] = new TH1F(Form("fLambdaLambdaRelKMulti_%i", i), Form("Relative momentum of V0-V0 RE %i", i),150,0.,3.); //first choice was 300 bins
+      fLambdaLambdaRelKMEMulti[i] = new TH1F(Form("fLambdaLambdaRelKMEMulti_%i", i), Form("Relative momentum of V0-V0 ME %i", i),150,0.,3.);
+    }
+
+  TH1F* fLambdaLambdaAvgSeparationPP = new TH1F("fLambdaLambdaAvgSeparationPP","Relative distances of p_daugh-p_daugh RE",1000,0.,500.);
+  TH1F* fLambdaLambdaAvgSeparationPPME = new TH1F("fLambdaLambdaAvgSeparationPPME","Relative distances of p_daugh-p_daugh ME",1000,0.,500.);
+  TH1F* fLambdaLambdaAvgSeparationP1Pi2 = new TH1F("fLambdaLambdaAvgSeparationP1Pi2","Relative distances of ppi_daugh RE",1000,0.,500.);
+  TH1F* fLambdaLambdaAvgSeparationP1Pi2ME = new TH1F("fLambdaLambdaAvgSeparationP1Pi2ME","Relative distances of ppi_daugh ME",1000,0.,500.);
+  TH1F* fLambdaLambdaAvgSeparationP2Pi1 = new TH1F("fLambdaLambdaAvgSeparationP2Pi1","Relative distances of ppi_daugh RE",1000,0.,500.);
+  TH1F* fLambdaLambdaAvgSeparationP2Pi1ME = new TH1F("fLambdaLambdaAvgSeparationP2Pi1ME","Relative distances of ppi_daugh ME",1000,0.,500.);
+  TH1F* fLambdaLambdaAvgSeparationPiPi = new TH1F("fLambdaLambdaAvgSeparationPiPi","Relative distances of p_daugh-p_daugh RE",1000,0.,500.);
+  TH1F* fLambdaLambdaAvgSeparationPiPiME = new TH1F("fLambdaLambdaAvgSeparationPiPiME","Relative distances of p_daugh-p_daugh ME",1000,0.,500.);
+
 
   //AntiLambda-Lambda
   TH1F* fAntiLambdaLambdaRelK = new TH1F("fAntiLambdaLambdaRelK","Relative momentum of AntiV0-V0 RE",150,0.,3.);
   TH1F* fAntiLambdaLambdaRelKME = new TH1F("fAntiLambdaLambdaRelKME","Relative momentum of V0-V0 ME",150,0.,3.);
+  TH1F* fAntiLambdaAntiLambdaRelKMulti[13];
+  TH1F* fAntiLambdaAntiLambdaRelKMEMulti[13];
+  for(int i=0; i<13; ++i) {
+      fAntiLambdaAntiLambdaRelKMulti[i] = new TH1F(Form("fAntiLambdaAntiLambdaRelKMulti_%i", i), Form("Relative momentum of AntiV0-AntiV0 RE %i", i),150,0.,3.); //first choice was 300 bins
+      fAntiLambdaAntiLambdaRelKMEMulti[i] = new TH1F(Form("fAntiLambdaAntiLambdaRelKMEMulti_%i", i), Form("Relative momentum of AntiV0-AntiV0 ME %i", i),150,0.,3.);
+    }
 
   //AntiLambda-AntiLambda
   TH1F* fAntiLambdaAntiLambdaRelK = new TH1F("fAntiLambdaAntiLambdaRelK","Relative momentum of AntiV0-AntiV0 RE",150,0.,3.);
   TH1F* fAntiLambdaAntiLambdaRelKME = new TH1F("fAntiLambdaAntiLambdaRelKME","Relative momentum of AntiV0-AntiV0 ME",150,0.,3.);
+
+  TH1F* fAntiLambdaAntiLambdaAvgSeparationPP = new TH1F("fAntiLambdaAntiLambdaAvgSeparationPP","Relative distances of p_daugh-p_daugh RE",1000,0.,500.);
+  TH1F* fAntiLambdaAntiLambdaAvgSeparationPPME = new TH1F("fAntiLambdaAntiLambdaAvgSeparationPPME","Relative distances of p_daugh-p_daugh ME",1000,0.,500.);
+  TH1F* fAntiLambdaAntiLambdaAvgSeparationP1Pi2 = new TH1F("fAntiLambdaAntiLambdaAvgSeparationP1Pi2","Relative distances of ppi_daugh RE",1000,0.,500.);
+  TH1F* fAntiLambdaAntiLambdaAvgSeparationP1Pi2ME = new TH1F("fAntiLambdaAntiLambdaAvgSeparationP1Pi2ME","Relative distances of ppi_daugh ME",1000,0.,500.);
+  TH1F* fAntiLambdaAntiLambdaAvgSeparationP2Pi1 = new TH1F("fAntiLambdaAntiLambdaAvgSeparationP2Pi1","Relative distances of ppi_daugh RE",1000,0.,500.);
+  TH1F* fAntiLambdaAntiLambdaAvgSeparationP2Pi1ME = new TH1F("fAntiLambdaAntiLambdaAvgSeparationP2Pi1ME","Relative distances of ppi_daugh ME",1000,0.,500.);
+  TH1F* fAntiLambdaAntiLambdaAvgSeparationPiPi = new TH1F("fAntiLambdaAntiLambdaAvgSeparationPiPi","Relative distances of p_daugh-p_daugh RE",1000,0.,500.);
+  TH1F* fAntiLambdaAntiLambdaAvgSeparationPiPiME = new TH1F("fAntiLambdaAntiLambdaAvgSeparationPiPiME","Relative distances of p_daugh-p_daugh ME",1000,0.,500.);
+
+
 
   TH1F* fNProtonLambdaPairs = new TH1F("fNProtonLambdaPairs","Number of V0-p pairs in an event",200,0,100);
   TH1F* fNPairStatistics = new TH1F("fNPairStatistics","Number of pairs under certain condition",40,0,10);
@@ -3289,12 +3906,27 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
   TH2F* fPpRelKTrueReco = new TH2F("fPpRelKTrueReco","pp: true momentum vs. reconstructed momentum relK",750,0.,3.,750,0.,3.);
   TH2F* fPpRelKTrueRecoFB = new TH2F("fPpRelKTrueRecoFB","pp: true momentum vs. reconstructed momentum relK",1500,0.,3.,1500,0.,3.);
   TH2F* fPpRelKTrueRecoRotated = new TH2F("fPpRelKTrueRecoRotated","pp: true momentum vs. reconstructed momentum relK in rotated coordinate system",750,0.,3.,1000,-1.,1.);
-  TH2F* fPpPV0RelKRelK = new TH2F("fPpPV0RelKRelK","relative momentum transformation from pV0 -> pp",600,0.,3.,600,0.,3.);
+
+
+  TH2F *fProtonPtCorrelationRE = new TH2F("fProtonPtCorrelationRE","correlation pt1-pt2 in same event",100,0.,5.,100,0.,5.);
+  TH2F *fProtonPtCorrelationME = new TH2F("fProtonPtCorrelationME","correlation pt1-pt2 in mixed event",100,0.,5.,100,0.,5.);
+  TH2F *fProtonEtaCorrelationRE = new TH2F("fProtonEtaCorrelationRE","correlation eta1-eta2 in same event",100,-1.,1.,100,-1.,1.);
+  TH2F *fProtonEtaCorrelationME = new TH2F("fProtonEtaCorrelationME","correlation eta1-eta2 in mixed event",100,-1.,1.,100,-1.,1.);
+  TH2F *fProtonEnCorrelationRE = new TH2F("fProtonEnCorrelationRE","correlation En1-En2 in same event",100,0.,5.,100,0.,5.);
+  TH2F *fProtonEnCorrelationME = new TH2F("fProtonEnCorrelationME","correlation En1-En2 in mixed event",100,0.,5.,100,0.,5.);
+  TH2F *fProtonPhiCorrelationRE = new TH2F("fProtonPhiCorrelationRE","correlation phi1-phi2 in same event",100,-TMath::Pi(),TMath::Pi(),100,-TMath::Pi(),TMath::Pi());
+  TH2F *fProtonPhiCorrelationME = new TH2F("fProtonPhiCorrelationME","correlation phi1-phi2 in mixed event",100,-TMath::Pi(),TMath::Pi(),100,-TMath::Pi(),TMath::Pi());
+
 
   fProtonLambdaMT->Sumw2();
   fProtonLambdaMTrelKcut->Sumw2();
   fProtonLambdaRelK->Sumw2();
   fProtonLambdaRelKME->Sumw2();
+
+  fProtonLambdaAvgSeparationPP->Sumw2();
+  fProtonLambdaAvgSeparationPPME->Sumw2();
+  fProtonLambdaAvgSeparationPPi->Sumw2();
+  fProtonLambdaAvgSeparationPPiME->Sumw2();
   fProtonLambdaPosDaughterRelK->Sumw2();
   fProtonLambdaPosDaughterRelKME->Sumw2();
   fAntiProtonAntiLambdaPosDaughterRelK->Sumw2();
@@ -3305,6 +3937,28 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
   fProtonAntiLambdaRelKME->Sumw2();
   fAntiProtonAntiLambdaRelK->Sumw2();
   fAntiProtonAntiLambdaRelKME->Sumw2();
+  for(int i=0; i<13; ++i) {
+      fProtonLambdaRelKMulti[i]->Sumw2();
+      fProtonLambdaRelKMEMulti[i]->Sumw2();
+      fAntiProtonAntiLambdaRelKMulti[i]->Sumw2();
+      fAntiProtonAntiLambdaRelKMEMulti[i]->Sumw2();
+      fProtonXiRelKMulti[i]->Sumw2();
+      fProtonXiRelKMEMulti[i]->Sumw2();
+      fAntiProtonXiRelKMulti[i]->Sumw2();
+      fAntiProtonXiRelKMEMulti[i]->Sumw2();
+      fProtonProtonRelKMulti[i]->Sumw2();
+      fProtonProtonRelKMEMulti[i]->Sumw2();
+      fAntiProtonAntiProtonRelKMulti[i]->Sumw2();
+      fAntiProtonAntiProtonRelKMEMulti[i]->Sumw2();
+      fLambdaLambdaRelKMulti[i]->Sumw2();
+      fLambdaLambdaRelKMEMulti[i]->Sumw2();
+      fAntiLambdaAntiLambdaRelKMulti[i]->Sumw2();
+      fAntiLambdaAntiLambdaRelKMEMulti[i]->Sumw2();
+    }
+  fAntiProtonAntiLambdaAvgSeparationPP->Sumw2();
+  fAntiProtonAntiLambdaAvgSeparationPPME->Sumw2();
+  fAntiProtonAntiLambdaAvgSeparationPPi->Sumw2();
+  fAntiProtonAntiLambdaAvgSeparationPPiME->Sumw2();
   fProtonXiRelK->Sumw2();
   fProtonXiRelKME->Sumw2();
   fAntiProtonXiRelK->Sumw2();
@@ -3314,33 +3968,77 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
 
   fProtonProtonRelK->Sumw2();
   fProtonProtonRelKME->Sumw2();
-  fProtonProtonLambdaRelK->Sumw2();
-  fProtonProtonLambdaRelKME->Sumw2();
-  fProtonProtonProtonRelK->Sumw2();
-  fProtonProtonProtonRelKME->Sumw2();
+
+  fProtonProtonRelKw2TC->Sumw2();
+  fProtonProtonRelKw2TCME->Sumw2();
+  fProtonProtonAvgSeparation->Sumw2();
+  fProtonProtonAvgSeparationME->Sumw2();
+  fProtonProtonRelKEnSumME->Sumw2();
+  fProtonProtonRelKEnMultME->Sumw2();
+  fProtonProtonRelKPzMultME->Sumw2();
+  fProtonProtonRelKPtMultME->Sumw2();
+
 
   fAntiProtonAntiProtonRelK->Sumw2();
   fAntiProtonAntiProtonRelKME->Sumw2();
+
+  fAntiProtonAntiProtonRelKw2TC->Sumw2();
+  fAntiProtonAntiProtonRelKw2TCME->Sumw2();
+
+  fAntiProtonAntiProtonAvgSeparation->Sumw2();
+  fAntiProtonAntiProtonAvgSeparationME->Sumw2();
   fAntiProtonProtonRelK->Sumw2();
   fAntiProtonProtonRelKME->Sumw2();
 
   fLambdaLambdaRelK->Sumw2();
   fLambdaLambdaRelKME->Sumw2();
+
+  fLambdaLambdaAvgSeparationPP->Sumw2();
+  fLambdaLambdaAvgSeparationPPME->Sumw2();
+  fLambdaLambdaAvgSeparationP1Pi2->Sumw2();
+  fLambdaLambdaAvgSeparationP1Pi2ME->Sumw2();
+  fLambdaLambdaAvgSeparationP2Pi1->Sumw2();
+  fLambdaLambdaAvgSeparationP2Pi1ME->Sumw2();
+  fLambdaLambdaAvgSeparationPiPi->Sumw2();
+  fLambdaLambdaAvgSeparationPiPiME->Sumw2();
+
   fAntiLambdaAntiLambdaRelK->Sumw2();
   fAntiLambdaAntiLambdaRelKME->Sumw2();
+
+  fAntiLambdaAntiLambdaAvgSeparationPP->Sumw2();
+  fAntiLambdaAntiLambdaAvgSeparationPPME->Sumw2();
+  fAntiLambdaAntiLambdaAvgSeparationP1Pi2->Sumw2();
+  fAntiLambdaAntiLambdaAvgSeparationP1Pi2ME->Sumw2();
+  fAntiLambdaAntiLambdaAvgSeparationP2Pi1->Sumw2();
+  fAntiLambdaAntiLambdaAvgSeparationP2Pi1ME->Sumw2();
+  fAntiLambdaAntiLambdaAvgSeparationPiPi->Sumw2();
+  fAntiLambdaAntiLambdaAvgSeparationPiPiME->Sumw2();
+
+
   fAntiLambdaLambdaRelK->Sumw2();
   fAntiLambdaLambdaRelKME->Sumw2();
 
   fOutputTP->Add(fProtonLambdaMT);
   fOutputTP->Add(fProtonLambdaMTrelKcut);
+  fOutputTP->Add(fProtonLambdaDiff);
   fOutputTP->Add(fProtonLambdaRelK);
   fOutputTP->Add(fProtonLambdaRelKME);
+
+  fOutputTP->Add(fProtonLambdaAvgSeparationPP);
+  fOutputTP->Add(fProtonLambdaAvgSeparationPPME);
+  fOutputTP->Add(fProtonLambdaAvgSeparationPPi);
+  fOutputTP->Add(fProtonLambdaAvgSeparationPPiME);
   fOutputTP->Add(fProtonLambdaPosDaughterRelK);
   fOutputTP->Add(fProtonLambdaPosDaughterRelKME);
   fOutputTP->Add(fAntiProtonAntiLambdaPosDaughterRelK);
   fOutputTP->Add(fAntiProtonAntiLambdaPosDaughterRelKME);
   fOutputTP->Add(fAntiProtonAntiLambdaRelK);
   fOutputTP->Add(fAntiProtonAntiLambdaRelKME);
+  fOutputTP->Add(fAntiProtonAntiLambdaAvgSeparationPP);
+  fOutputTP->Add(fAntiProtonAntiLambdaAvgSeparationPPME);
+  fOutputTP->Add(fAntiProtonAntiLambdaAvgSeparationPPi);
+  fOutputTP->Add(fAntiProtonAntiLambdaAvgSeparationPPiME);
+
   fOutputTP->Add(fProtonAntiLambdaRelK);
   fOutputTP->Add(fProtonAntiLambdaRelKME);
   fOutputTP->Add(fAntiProtonLambdaRelK);
@@ -3349,22 +4047,54 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
   fOutputTP->Add(fProtonXiRelKME);
   fOutputTP->Add(fAntiProtonXiRelK);
   fOutputTP->Add(fAntiProtonXiRelKME);
-  fOutputTP->Add(fProtonProtonLambdaRelK);
-  fOutputTP->Add(fProtonProtonLambdaRelKME);
-  fOutputTP->Add(fProtonProtonProtonRelK);
-  fOutputTP->Add(fProtonProtonProtonRelKME);
   fOutputTP->Add(fProtonProtonRelK);
   fOutputTP->Add(fProtonProtonRelKME);
+  fOutputTP->Add(fProtonProtonRelKw2TC);
+  fOutputTP->Add(fProtonProtonRelKw2TCME);
+  fOutputTP->Add(fProtonProtonAvgSeparation);
+  fOutputTP->Add(fProtonProtonAvgSeparationME);
+  fOutputTP->Add(fProtonProtonAvgSeparationVsRelK);
+  fOutputTP->Add(fProtonProtonAvgSeparationVsRelKME);
+  fOutputTP->Add(fProtonProtonRelKEnSumME);
+  fOutputTP->Add(fProtonProtonRelKEnMultME);
+  fOutputTP->Add(fProtonProtonRelKPzMultME);
+  fOutputTP->Add(fProtonProtonRelKPtMultME);
+
   fOutputTP->Add(fProtonProtonMT);
   fOutputTP->Add(fProtonProtonMTrelKcut);
   fOutputTP->Add(fAntiProtonAntiProtonRelK);
   fOutputTP->Add(fAntiProtonAntiProtonRelKME);
+
+  fOutputTP->Add(fAntiProtonAntiProtonRelKw2TC);
+  fOutputTP->Add(fAntiProtonAntiProtonRelKw2TCME);
+  fOutputTP->Add(fAntiProtonAntiProtonAvgSeparation);
+  fOutputTP->Add(fAntiProtonAntiProtonAvgSeparationME);
   fOutputTP->Add(fAntiProtonProtonRelK);
   fOutputTP->Add(fAntiProtonProtonRelKME);
   fOutputTP->Add(fLambdaLambdaRelK);
   fOutputTP->Add(fLambdaLambdaRelKME);
+  fOutputTP->Add(fLambdaLambdaAvgSeparationPP);
+  fOutputTP->Add(fLambdaLambdaAvgSeparationPPME);
+  fOutputTP->Add(fLambdaLambdaAvgSeparationP1Pi2);
+  fOutputTP->Add(fLambdaLambdaAvgSeparationP1Pi2ME);
+  fOutputTP->Add(fLambdaLambdaAvgSeparationP2Pi1);
+  fOutputTP->Add(fLambdaLambdaAvgSeparationP2Pi1ME);
+  fOutputTP->Add(fLambdaLambdaAvgSeparationPiPi);
+  fOutputTP->Add(fLambdaLambdaAvgSeparationPiPiME);
+
   fOutputTP->Add(fAntiLambdaAntiLambdaRelK);
   fOutputTP->Add(fAntiLambdaAntiLambdaRelKME);
+
+  fOutputTP->Add(fAntiLambdaAntiLambdaAvgSeparationPP);
+  fOutputTP->Add(fAntiLambdaAntiLambdaAvgSeparationPPME);
+  fOutputTP->Add(fAntiLambdaAntiLambdaAvgSeparationP1Pi2);
+  fOutputTP->Add(fAntiLambdaAntiLambdaAvgSeparationP1Pi2ME);
+  fOutputTP->Add(fAntiLambdaAntiLambdaAvgSeparationP2Pi1);
+  fOutputTP->Add(fAntiLambdaAntiLambdaAvgSeparationP2Pi1ME);
+  fOutputTP->Add(fAntiLambdaAntiLambdaAvgSeparationPiPi);
+  fOutputTP->Add(fAntiLambdaAntiLambdaAvgSeparationPiPiME);
+
+
   fOutputTP->Add(fAntiLambdaLambdaRelK);
   fOutputTP->Add(fAntiLambdaLambdaRelKME);
 
@@ -3375,6 +4105,25 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
   fOutputTP->Add(fPairkTpp);
   fOutputTP->Add(fPairkTApAp);
   fOutputTP->Add(fPairkTApp);
+
+  for(int i=0; i<13; ++i) {
+      fOutputTP->Add(fProtonLambdaRelKMulti[i]);
+      fOutputTP->Add(fProtonLambdaRelKMEMulti[i]);
+      fOutputTP->Add(fAntiProtonAntiLambdaRelKMulti[i]);
+      fOutputTP->Add(fAntiProtonAntiLambdaRelKMEMulti[i]);
+      fOutputTP->Add(fProtonXiRelKMulti[i]);
+      fOutputTP->Add(fProtonXiRelKMEMulti[i]);
+      fOutputTP->Add(fAntiProtonXiRelKMulti[i]);
+      fOutputTP->Add(fAntiProtonXiRelKMEMulti[i]);
+      fOutputTP->Add(fProtonProtonRelKMulti[i]);
+      fOutputTP->Add(fProtonProtonRelKMEMulti[i]);
+      fOutputTP->Add(fAntiProtonAntiProtonRelKMulti[i]);
+      fOutputTP->Add(fAntiProtonAntiProtonRelKMEMulti[i]);
+      fOutputTP->Add(fLambdaLambdaRelKMulti[i]);
+      fOutputTP->Add(fLambdaLambdaRelKMEMulti[i]);
+      fOutputTP->Add(fAntiLambdaAntiLambdaRelKMulti[i]);
+      fOutputTP->Add(fAntiLambdaAntiLambdaRelKMEMulti[i]);
+    }
 
 
   if(fUseMCInfo)
@@ -3392,8 +4141,17 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
       fOutputTP->Add(fPpRelKTrueReco);
       fOutputTP->Add(fPpRelKTrueRecoFB);
       fOutputTP->Add(fPpRelKTrueRecoRotated);
-      fOutputTP->Add(fPpPV0RelKRelK);
     }
+
+  fOutputTP->Add(fProtonPtCorrelationRE);
+  fOutputTP->Add(fProtonPtCorrelationME);
+  fOutputTP->Add(fProtonEtaCorrelationRE);
+  fOutputTP->Add(fProtonEtaCorrelationME);
+  fOutputTP->Add(fProtonEnCorrelationRE);
+  fOutputTP->Add(fProtonEnCorrelationME);
+  fOutputTP->Add(fProtonPhiCorrelationRE);
+  fOutputTP->Add(fProtonPhiCorrelationME);
+
 
   //Define PID related histograms:
   TH2F* fdEdxVsP = new TH2F("fdEdxVsP","dE/dx of all particles vs momentum",1000,0,7,400,-10,200);
@@ -3403,7 +4161,22 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
 
   TH2F* fNsigmaTOFTPCPtBin[fCuts->GetPtBinsPurity()];
   TH2F* fNsigmaTOFTPCHypothesisIncludedPtBin[fCuts->GetPtBinsPurity()];
-  TH1F* fProtonPurityTOFTPCcombinedMCPtBin[fCuts->GetPtBinsPurity()];
+
+
+  TH1F* fProtonsCorrectlyIdentified = new TH1F("fProtonsCorrectlyIdentified","Particles that were correctly identified as protons",100,fCuts->GetProtonPIDthrPtLow(),fCuts->GetProtonPIDthrPtUp());
+  fProtonsCorrectlyIdentified->Sumw2();
+  TH1F* fProtonsTotallyIdentified = new TH1F("fProtonsTotallyIdentified","All Particles that were identified as protons",100,fCuts->GetProtonPIDthrPtLow(),fCuts->GetProtonPIDthrPtUp());
+  fProtonsTotallyIdentified->Sumw2();
+  TH1F* fProtonsBkgIdentified = new TH1F("fProtonsBkgIdentified","All Particles that were identified as protons",100,fCuts->GetProtonPIDthrPtLow(),fCuts->GetProtonPIDthrPtUp());
+  fProtonsBkgIdentified->Sumw2();
+
+
+  if(fUseMCInfo)
+    {
+      fOutputPID->Add(fProtonsCorrectlyIdentified);
+      fOutputPID->Add(fProtonsTotallyIdentified);
+      fOutputPID->Add(fProtonsBkgIdentified);
+    }
 
   for(Int_t i=0;i<fCuts->GetPtBinsPurity();i++)
     {
@@ -3420,17 +4193,6 @@ void AliAnalysisTaskPLFemto::DefineHistograms(TString whichV0)
       Description += i;
       fNsigmaTOFTPCHypothesisIncludedPtBin[i] = new TH2F(HistName.Data(),Description.Data(),200,-10,10,200,-10,10);
       fOutputPID->Add(fNsigmaTOFTPCHypothesisIncludedPtBin[i]);
-
-      if(fUseMCInfo)
-	{
-	  HistName = "fProtonPurityTOFTPCcombinedMCPtBin";
-	  HistName += i;
-	  Description = "Total: 1, Signal: 2, Background: 3, purity for protons with kaon rejection and n#sigma_{combined}<3 in momentum bin ";
-	  Description += i;
-
-	  fProtonPurityTOFTPCcombinedMCPtBin[i] = new TH1F(HistName.Data(),Description.Data(),4,0,4);
-	  fOutputPID->Add(fProtonPurityTOFTPCcombinedMCPtBin[i]);
-	}
     }
 
   fOutputPID->Add(fdEdxVsP);
@@ -3497,7 +4259,8 @@ Bool_t AliAnalysisTaskPLFemto::SelectPID(const AliAODTrack *track,const AliAODEv
       Double_t nSigmaTOFproton = fPIDResponse->NumberOfSigmasTOF(globaltrack,(AliPID::kProton));
       Double_t nSigmaTPCTOFcombined = TMath::Sqrt(pow(nSigmaTPCproton,2.) + pow(nSigmaTOFproton,2.));
 
-      //if(type == 4 && GoodDCA(track,aodevent,kTRUE,type))
+      if(nSigmaTPCTOFcombined < fCuts->GetProtonnsigma() && TestPIDHypothesis(globaltrack,type)) isparticle = kTRUE;
+
       if(type == 4)
 	{
 	  fillthis = "fProtonNSigmaCombined";
@@ -3505,12 +4268,12 @@ Bool_t AliAnalysisTaskPLFemto::SelectPID(const AliAODTrack *track,const AliAODEv
 	  fillthis = "fTOFSignalVsP";
 	  ((TH2F*)(fOutputPID->FindObject(fillthis)))->Fill(globaltrack->GetTPCmomentum(),corrTOFsignal);
 	}
-      if(nSigmaTPCTOFcombined < fCuts->GetProtonnsigma() && TestPIDHypothesis(globaltrack,type)) isparticle = kTRUE;//full PID for high momentum region
 
 
       //QA the PID differentially as a function of pt
       Int_t ptbin = fCuts->FindProtonPtBinPurity(globaltrack->GetTPCmomentum());
-      //if(ptbin != -9999 && GoodDCA(track,aodevent,kTRUE,type))
+      //Int_t ptbin = fCuts->FindProtonPtBinPurity(track->Pt());
+
       if(ptbin != -9999)
 	{
 	  //investigate this as a function of momentum slices:
@@ -3527,36 +4290,35 @@ Bool_t AliAnalysisTaskPLFemto::SelectPID(const AliAODTrack *track,const AliAODEv
 		  ((TH2F*)(fOutputPID->FindObject(fillthis)))->Fill(nSigmaTPCproton,nSigmaTOFproton);
 		}
 	    }
+	}
+    }
 
 
-	  //Investigate the purity for the selected particles (in Monte Carlo):
-	  if(isparticle)
+  //Investigate the purity for the selected particles (in Monte Carlo):
+  if(isparticle)
+    {
+      if(fUseMCInfo)
+	{
+	  //check with monte carlo the purity:
+	  if(type == 4)
 	    {
-	      if(fUseMCInfo)
-		{
-		  //check with monte carlo the purity:
-		  if(type == 4)
-		    {
-		      fillthis = "fProtonPurityTOFTPCcombinedMCPtBin";
-		      fillthis += ptbin;
-		      ((TH1F*)(fOutputPID->FindObject(fillthis)))->Fill(1);
-		    }
-		  if(type == 4 && mcproton->GetPdgCode() == 2212)
-		    {
-		      fillthis = "fProtonPurityTOFTPCcombinedMCPtBin";
-		      fillthis += ptbin;
-		      ((TH1F*)(fOutputPID->FindObject(fillthis)))->Fill(2);
-		    }
-		  else if(type == 4 && mcproton->GetPdgCode() != 2212)
-		    {
-		      fillthis = "fProtonPurityTOFTPCcombinedMCPtBin";
-		      fillthis += ptbin;
-		      ((TH1F*)(fOutputPID->FindObject(fillthis)))->Fill(3);
-		    }
-		}
+	      fillthis = "fProtonsTotallyIdentified";
+	      ((TH1F*)(fOutputPID->FindObject(fillthis)))->Fill(track->Pt());
+	    }
+	  if(type == 4 && mcproton->GetPdgCode() == 2212)
+	    {
+	      fillthis = "fProtonsCorrectlyIdentified";
+	      ((TH1F*)(fOutputPID->FindObject(fillthis)))->Fill(track->Pt());
+	    }
+	  else if(type == 4 && mcproton->GetPdgCode() != 2212)
+	    {
+	      fillthis = "fProtonsBkgIdentified";
+	      ((TH1F*)(fOutputPID->FindObject(fillthis)))->Fill(track->Pt());
 	    }
 	}
     }
+
+
   return isparticle;
 }
 
@@ -3579,8 +4341,8 @@ Bool_t AliAnalysisTaskPLFemto::TestPIDHypothesis(const AliAODTrack *track,Int_t 
     {
       AliPIDResponse::EDetPidStatus statusTPC = fPIDResponse->CheckPIDStatus(AliPIDResponse::kTPC,track);
       AliPIDResponse::EDetPidStatus statusTOF = fPIDResponse->CheckPIDStatus(AliPIDResponse::kTOF,track);
-      if(!statusTPC) return kTRUE; //TPC signal must be present
-      if(!statusTOF) return kTRUE; //TOF signal must be present
+      if(!statusTPC) return kFALSE; //TPC signal must be present, BUG 30.01.2017: Was kTRUE must be kFALSE but it is anyhow checked before in SelectPID
+      if(!statusTOF) return kFALSE; //TOF signal must be present
 
       Double_t nSigmaProtonTPC = TMath::Abs(fPIDResponse->NumberOfSigmasTPC(track,(AliPID::kProton)));
       Double_t nSigmaKaonTPC = TMath::Abs(fPIDResponse->NumberOfSigmasTPC(track,(AliPID::kKaon)));
@@ -3600,7 +4362,6 @@ Bool_t AliAnalysisTaskPLFemto::TestPIDHypothesis(const AliAODTrack *track,Int_t 
 
       //The other hypothesis fits better:
       if((nSigmaKaonCombined < nSigmaProtonCombined) || (nSigmaPionCombined < nSigmaProtonCombined) || (nSigmaElectronCombined < nSigmaProtonCombined)) keepParticle = kFALSE;
-
     }
 
   return keepParticle;
@@ -3648,17 +4409,130 @@ Bool_t AliAnalysisTaskPLFemto::SelectV0PID(const AliAODv0 *v0,TString ParOrAPar)
 
   if(isProton && isPion) isV0 = kTRUE;
 
+  /*
+  AliAODTrack* daughterTrackPos = (AliAODTrack*)v0->GetDaughter(0);
+  AliAODTrack* daughterTrackNeg = (AliAODTrack*)v0->GetDaughter(1);
+
+  AliAODMCParticle *posTrackMC  = (AliAODMCParticle*)fAODMCEvent->GetTrack(daughterTrackPos->GetLabel());
+  if(!posTrackMC) return kFALSE;
+
+  AliAODMCParticle *negTrackMC  = (AliAODMCParticle*)fAODMCEvent->GetTrack(daughterTrackNeg->GetLabel());
+  if(!negTrackMC) return kFALSE;
+
+
+  if(ParOrAPar == fwhichV0)
+    {
+
+      if(posTrackMC->GetPdgCode() == 2212 && negTrackMC->GetPdgCode()==-211)
+	{
+
+	  std::cout << "particle: " << fwhichV0 << std::endl;
+	  std::cout << "posTrackPDG: "  << posTrackMC->GetPdgCode() << std::endl;
+	  std::cout << "negTrackPDG: "  << negTrackMC->GetPdgCode() << std::endl;
+	  std::cout << "Px: " << daughterTrackPos->Px() << std::endl;
+	  std::cout << "px2: " << pTrack->Px() << std::endl;
+	  std::cout << ".................................." << std::endl;
+	}
+    }
+  else if(ParOrAPar == fwhichAntiV0)
+    {
+      if(posTrackMC->GetPdgCode() == 211 && negTrackMC->GetPdgCode()==-2212)
+	{
+
+	  std::cout << "particle: " << fwhichAntiV0 << std::endl;
+	  std::cout << "posTrackPDG: "  << posTrackMC->GetPdgCode() << std::endl;
+	  std::cout << "negTrackPDG: "  << negTrackMC->GetPdgCode() << std::endl;
+	  std::cout << "Px: " << daughterTrackPos->Px() << std::endl;
+	  std::cout << "px2: " << pTrack->Px() << std::endl;
+	  std::cout << ".................................." << std::endl;
+	}
+    }
+  */
+
   return isV0;
 }
 
 //________________________________________________________________________
-void AliAnalysisTaskPLFemto::GetGlobalPositionAtGlobalRadiiThroughTPC(const AliAODTrack *track, const Float_t bfield,double globalPositionsAtRadii[9][3], double PrimaryVertex[3])
+TVector3 AliAnalysisTaskPLFemto::GetGlobalPositionAtGlobalRadiiThroughTPC(const AliAODTrack *track, const Float_t bfield,double Rwanted,double PrimaryVertex[3])
 {
   // Gets the global position of the track at nine different radii in the TPC
   // track is the track you want to propagate
   // bfield is the magnetic field of your event
   // globalPositionsAtRadii is the array of global positions in the radii and xyz
 
+
+  //Directly from GitHub:  Add method GetXYZatR for fast estimate of track intersection with given X or R
+  //https://gitlab.cern.ch/mkrzewic/AliRoot/commit/c8253dd95447cc9624b1761bef3603d7171d8759
+
+  // This method has 3 modes of behaviour
+  // 1) xyz[3] array is provided but alpSect pointer is 0: calculate the position of track intersection
+  //    with circle of radius xr and fill it in xyz array
+  // 2) alpSect pointer is provided: find alpha of the sector where the track reaches local coordinate xr
+  //    Note that in this case xr is NOT the radius but the local coordinate.
+  //    If the xyz array is provided, it will be filled by track lab coordinates at local X in this sector
+  // 3) Neither alpSect nor xyz pointers are provided: just check if the track reaches radius xr
+
+  //*********************************************
+  //How the method (probably) works:
+
+  //helix is obtained at starting point of track e.g. at DCA or first track points
+  //this track helix is then intersected with a circle centered around the origin
+
+  //*********************************************
+
+  //How to take into account in mixed event hat one has two separated primary vertices?
+  //1) Shift at least along the z-coordinate
+  //2) Shift the whole primary vertex
+
+  //Method 1) does not influence the Rwanted
+
+  //For method 2) there is basically only one possibility left, to change the Rwanted value
+
+  //If we shift the primary vertex to be in the origin of the coordinate system, it is the same as shifting the circle to the primary vertex
+  //But then the track hits not the position it would hit without offset. Well there are always drawbacks
+
+  //If we have a vector R which points from the origin to the intersection point of the track with the radius, and a vector x_0 which contains the primary vertex (x,y), then we have to calculate the shifted vector a = R - x_0
+  //The length of the new vector |a|² is the radius we would obtain if all primary vertices would lie at the origin
+
+
+  //Try to shift only along z, this is the worst direction and easiest to calculate:
+
+  AliExternalTrackParam exParam;
+  exParam.CopyFromVTrack(track);
+  double Position[3] = {-9999.,-9999.,-9999.};
+
+  TVector3 globalPositionsAtRadii;
+  globalPositionsAtRadii.SetXYZ(Position[0],Position[1],Position[2]);
+
+
+  if(!exParam.GetXYZatR(Rwanted,bfield,Position,NULL)) return globalPositionsAtRadii;
+  else
+    {
+      //Shift z-direction:
+      Position[2] -= PrimaryVertex[2];
+
+      globalPositionsAtRadii.SetXYZ(Position[0],Position[1],Position[2]);//set the position to the correct value if the propagation worked
+      return globalPositionsAtRadii;
+    }
+
+
+  /*
+    AliExternalTrackParam exParam[9];//For every track an individual copy
+
+  for(Int_t RNumber = 0; RNumber < 9; RNumber++)
+    {
+    exParam[RNumber].CopyFromVTrack(track);
+
+    double Position[3] = {-9999.,-9999.,-9999.};
+      globalPositionsAtRadii[RNumber].SetXYZ(Position[0],Position[1],Position[2]);//set the position onto unnatural large values to see that something goes wrong
+      if(!exParam[RNumber].GetXYZatR(TPCradii[RNumber],bfield,Position,NULL)) continue;
+      globalPositionsAtRadii[RNumber].SetXYZ(Position[0],Position[1],Position[2]);//set the position to the correct value if the propagation worked
+    }
+  */
+
+  //OLD method:
+
+  /*
   // Initialize the array to something indicating there was no propagation
   for(Int_t i=0;i<9;i++)
     {
@@ -3688,7 +4562,7 @@ void AliAnalysisTaskPLFemto::GetGlobalPositionAtGlobalRadiiThroughTPC(const AliA
 
   // Propagation is done in local x of the track
   for (Float_t x = etp.GetX();x<247.;x+=1.)
-    {
+    { 
       // GetX returns local coordinates
       // Starts at the tracks fX and goes outwards. x = 245 is the outer radial limit
       // of the TPC when the track is straight, i.e. has inifinite pt and doesn't get bent.
@@ -3733,6 +4607,7 @@ void AliAnalysisTaskPLFemto::GetGlobalPositionAtGlobalRadiiThroughTPC(const AliA
 
       if(iR>8) return; //TPC edge reached
     }
+  */
 }
 //________________________________________________________________________
 Double_t AliAnalysisTaskPLFemto::DEtacalc(const double zprime1, const double zprime2, const double radius)
@@ -3755,91 +4630,6 @@ Double_t AliAnalysisTaskPLFemto::DPhicalc(const double dxprime, const double dyp
   double dphi = 2.*TMath::ATan(dist/(2.*radius));
 
   return dphi;
-}
-//________________________________________________________________________
-void AliAnalysisTaskPLFemto::GetAverageSeparation(const double globalPositions1st[9][3],const double globalPositions2nd[9][3],Int_t REorME,TString whichpair,double *average_separation)
-{
-  int numPoints = 0;
-  TString fillthis = "";
-  //Compute the separation of two daughter tracks, averaged over 9 different positions
-  double avgSeparationTotal = 0.;
-  double avgSeparationTransverse = 0.;
-  double avgSeparationZ = 0.;
-
-  for(int RadiusNumber = 0; RadiusNumber <9; RadiusNumber++)
-    {
-      double sumsquareTotal = 0.;
-      double sumsquareTransverse = 0.;
-      double sumsquareZ = 0.;
-
-
-      //Calculate different separations:
-      for(int Component = 0; Component <3; Component++)
-	{
-	  //Check first if all components were calculated properly:
-	  if(globalPositions1st[RadiusNumber][Component] == -9999. || globalPositions2nd[RadiusNumber][Component] == -9999.) continue;
-	  sumsquareTotal += pow(globalPositions1st[RadiusNumber][Component] - globalPositions2nd[RadiusNumber][Component],2);
-	  if(Component<2) sumsquareTransverse += pow(globalPositions1st[RadiusNumber][Component] - globalPositions2nd[RadiusNumber][Component],2);
-	  else sumsquareZ += pow(globalPositions1st[RadiusNumber][Component] - globalPositions2nd[RadiusNumber][Component],2);
-	  numPoints++;
-	}
-      double dxprime = globalPositions1st[RadiusNumber][0] - globalPositions2nd[RadiusNumber][0];
-      double dyprime = globalPositions1st[RadiusNumber][1] - globalPositions2nd[RadiusNumber][1];
-
-      //Calculate Angle observables:
-      double detaS = DEtacalc(globalPositions1st[RadiusNumber][2],globalPositions2nd[RadiusNumber][2],fTPCradii[RadiusNumber]);
-      double dphiS = DPhicalc(dxprime,dyprime,fTPCradii[RadiusNumber]);
-      detaS = TMath::Abs(detaS);
-      dphiS = TMath::Abs(dphiS);
-
-
-      if(REorME == 0 && whichpair=="Proton-V0,pp")
-	{
-	  fillthis = "fDeltaEtaDeltaPhiTPCradLpPrimProtonDaughProton";
-	  fillthis += RadiusNumber;
-	  ((TH2F*)(fOutputTP->FindObject(fillthis)))->Fill(detaS,dphiS);
-	}
-      else if(REorME != 0 && whichpair=="Proton-V0,pp")
-	{
-	  fillthis = "fDeltaEtaDeltaPhiTPCradLpPrimProtonDaughProtonME";
-	  fillthis += RadiusNumber;
-	  ((TH2F*)(fOutputTP->FindObject(fillthis)))->Fill(detaS,dphiS);
-	}
-      else if(REorME == 0 && whichpair=="Proton-V0,ppim")
-	{
-	  fillthis = "fDeltaEtaDeltaPhiTPCradLpPrimProtonDaughPion";
-	  fillthis += RadiusNumber;
-	  ((TH2F*)(fOutputTP->FindObject(fillthis)))->Fill(detaS,dphiS);
-	}
-      else if(REorME != 0 && whichpair=="Proton-V0,ppim")
-	{
-	  fillthis = "fDeltaEtaDeltaPhiTPCradLpPrimProtonDaughPionME";
-	  fillthis += RadiusNumber;
-	  ((TH2F*)(fOutputTP->FindObject(fillthis)))->Fill(detaS,dphiS);
-	}
-
-      avgSeparationTotal += sqrt(sumsquareTotal);
-      avgSeparationTransverse += sqrt(sumsquareTransverse);
-      avgSeparationZ += sqrt(sumsquareZ);
-    }
-
-  if(numPoints != 0)
-    {
-      avgSeparationTotal /= (Double_t)numPoints;
-      avgSeparationTransverse /= (Double_t)numPoints;
-      avgSeparationZ /= (Double_t)numPoints;
-    }
-  else
-    {
-      avgSeparationTotal = -9999.;
-      avgSeparationTransverse = -9999.;
-      avgSeparationZ = -9999.;
-    }
-
-
-  average_separation[0] = avgSeparationTotal;
-  average_separation[1] = avgSeparationTransverse;
-  average_separation[2] = avgSeparationZ;
 }
 //________________________________________________________________________
 Bool_t AliAnalysisTaskPLFemto::CheckIfRealV0(AliAODv0 *v0,AliAODEvent *aodEvent,Int_t PDGmother,Int_t PDGdaugh1, Int_t PDGdaugh2)
@@ -4076,7 +4866,6 @@ void AliAnalysisTaskPLFemto::GetMCMomentum(AliAODTrack *aodtrack,double *Protont
       Double_t ptTrue = mcproton->Pt();
       Double_t ptReco = aodtrack->Pt();
       Double_t ptTruePrime = 1./TMath::Sqrt(2.)*(ptTrue - ptReco);
-      // Double_t ptRecoPrime = 1./TMath::Sqrt(2.)*(ptTrue + ptReco);
 
       Double_t phiTrue = mcproton->Phi();
       Double_t phiReco = aodtrack->Phi();
@@ -4136,7 +4925,6 @@ void AliAnalysisTaskPLFemto::GetMCMomentum(AliAODv0 *v0,double *V0momtruth,doubl
       Double_t ptTrue = MCv0->Pt();
       Double_t ptReco = v0->Pt();
       Double_t ptTruePrime = 1./TMath::Sqrt(2.)*(ptTrue - ptReco);
-      // Double_t ptRecoPrime = 1./TMath::Sqrt(2.)*(ptTrue + ptReco);
 
       Double_t phiTrue = MCv0->Phi();
       Double_t phiReco = v0->Phi();

--- a/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliAnalysisTaskPLFemto.h
+++ b/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliAnalysisTaskPLFemto.h
@@ -20,6 +20,7 @@
 //#include <TH2F.h>
 #include "AliAnalysisTaskSE.h"
 #include <vector>
+#include <deque>
 #include "AliFemtoLambdaEventCollection2.h"
 #include "AliFemtoProtonParticle.h"
 #include "AliFemtoLambdaParticle.h"
@@ -28,7 +29,8 @@
 #include "AliFemtoCutValues.h"
 #include "AliAODv0.h"
 #include "AliAODpidUtil.h"
-//#include "TRandom3.h"
+#include "AliEventCuts.h"
+
 
 //class AliFemtoLambdaEventCollection2;
 //class AliFemtoLambdaEvent;
@@ -36,6 +38,7 @@
 class AliAODEvent;
 class AliAODv0;
 class AliAODMCParticle;
+class AliFemtoCutValues;
 
 class AliAnalysisTaskPLFemto : public AliAnalysisTaskSE
 {
@@ -43,10 +46,8 @@ class AliAnalysisTaskPLFemto : public AliAnalysisTaskSE
   
  public:
   
-
   AliAnalysisTaskPLFemto();
-  //AliAnalysisTaskPLFemto(const Char_t* name,AliRDHFCutsDStartoKpipi* cuts);
-  AliAnalysisTaskPLFemto(const Char_t* name,Bool_t OnlineCase, TString whichV0, TString whichV0region,const int whichfilterbit);
+  AliAnalysisTaskPLFemto(const Char_t* name,Bool_t OnlineCase, TString whichV0, TString whichV0region);
   virtual ~AliAnalysisTaskPLFemto();
 
   // Implementation of interface methods  
@@ -60,43 +61,29 @@ class AliAnalysisTaskPLFemto : public AliAnalysisTaskSE
   enum pairType
   {
     kProtonProton,
+    kProtonProtonQA,
     kProtonProtonProton,
     kAntiProtonAntiProton,
+    kAntiProtonAntiProtonQA,
     kAntiProtonProton,
     kProtonV0,
+    kProtonV0QA,
     kProtonProtonV0,
     kProtonProtonXi,
     kAntiProtonV0,
     kProtonAntiV0,
     kAntiProtonAntiV0,
+    kAntiProtonAntiV0QA,
     kV0V0,
+    kV0V0QA,
     kAntiV0AntiV0,
+    kAntiV0AntiV0QA,
     kAntiV0V0,
     kProtonXi,
     kAntiProtonXi
   };
 
-
-  
-  Bool_t SelectPID(const AliAODTrack *track,const AliAODEvent *aodevent, Int_t type);
-  Bool_t SelectV0PID(const AliAODv0 *v0,TString ParOrAPar);
-  Bool_t GoodTPCFitMapSharedMap(const AliAODTrack *track);
-  Bool_t GoodTPCFitMapSharedMap(const AliAODTrack *pTrack,const AliAODTrack *nTrack);
-  Bool_t AcceptTrack(const AliAODTrack *track,int type);
-  //Bool_t GetMC() const {return fUseMCInfo;}
-  Bool_t GoodDCA(const AliAODTrack *track,const AliAODEvent *aodEvent,Int_t type);
-  Bool_t SingleParticleQualityCuts(const AliAODTrack *aodtrack,const AliAODEvent *aodEvent);
-  Bool_t SingleParticleQualityCuts(const AliAODv0 *v0);
-  Bool_t TestPIDHypothesis(const AliAODTrack *track,Int_t type);
-  Bool_t ClosePairRejecter(Float_t deltaPhiS,Float_t deltaEta);
-  Bool_t CheckIfRealV0(AliAODv0 *v0,AliAODEvent *aodEvent,Int_t PDGmother,Int_t PDGdaugh1, Int_t PDGdaugh2);
-  Bool_t V0TopologicalSelection(AliAODv0 *v0,AliAODEvent *aodevent,TString ParOrAPar);
-  Bool_t PileUpRejection(AliAODEvent* ev);
-  Bool_t CheckMCPID(AliAODEvent *aodEvent, AliAODTrack* aodtrack,int pdg);
-  Bool_t CheckMCPID(AliAODv0 *v0,AliAODEvent* aodEvent,int pdg);
-
   void DefineHistograms(TString whichV0);
-
   void FillV0Selection(AliAODv0 *v0,AliAODEvent* aodEvent,TString ParOrAPar);
   void SetMC(Bool_t theMCon) {fUseMCInfo = theMCon;}
   void ResetGlobalTrackReference();
@@ -112,62 +99,92 @@ class AliAnalysisTaskPLFemto : public AliAnalysisTaskSE
   void XiSelector(AliAODEvent *aodEvent);
   void FIFOShifter(Int_t zBin,Int_t MultBin);
   void TrackCleaner();
-  void ParticlePairer();
-  void GetGlobalPositionAtGlobalRadiiThroughTPC(const AliAODTrack *track, const Float_t bfield,double globalPositionsAtRadii[9][3], double PrimaryVertex[3]);
+  void ParticlePairer(Int_t zBin,Int_t multBin);
   void GetV0Origin(AliAODv0 *v0,AliAODEvent *aodEvent);
-  void GetProtonOrigin(AliAODTrack *proton,AliAODEvent *aodEvent,Int_t type);
+  void GetProtonOrigin(AliAODTrack *AODtrack,AliAODEvent *aodEvent,Int_t type);
   void GetMomentumMatrix(const AliFemtoLambdaParticle &v0,const AliFemtoProtonParticle &proton);
-  void GetMomentumMatrix(const AliFemtoProtonParticle &protonA,const AliFemtoProtonParticle &protonB);
-  void GetMCMomentum(AliAODTrack *aodTrack,double *Protontruth,double *ProtontruthMother,double *ProtontruthMotherParton,int *PDGcodes,AliAODEvent *aodEvent,Int_t type);
+  void GetMomentumMatrix(const AliFemtoProtonParticle &proton1,const AliFemtoProtonParticle &proton2);
+  void GetMCMomentum(AliAODTrack *aodtrack,double *Protontruth,double *ProtontruthMother,double *ProtontruthMotherParton,int *PDGcodes,AliAODEvent *aodEvent, Int_t type);
   void GetMCMomentum(AliAODv0 *v0,double *V0momtruth,double *V0momtruthMother,AliAODEvent *aodEvent);
-  void GetAverageSeparation(const double globalPositions1st[9][3],const double globalPositions2nd[9][3],Int_t REorME,TString whichpair,double *averageSeparation);
-  void CalculateDecayMatrix();
+  void GetNumberOfTPCtracksInEtaRange(AliAODEvent* aodEvent,Double_t mineta,Double_t maxeta);
+  void DCAxy(const AliAODTrack *track, const AliVEvent *evt,Double_t *dcaxy);
+  void BufferFiller(Int_t zBin,Int_t multBin,Int_t *NumberOfParticles);
   
-  Int_t *BufferFiller();
+  TVector3 GetGlobalPositionAtGlobalRadiiThroughTPC(const AliAODTrack *track, const Float_t bfield,double Rwanted,double PrimaryVertex[3]);
+  
+  void SetRun1(bool run1) { fIsRun1 = run1; }
+  Bool_t SelectPID(const AliAODTrack *track,const AliAODEvent *aodevent,Int_t type);
+  Bool_t SelectV0PID(const AliAODv0 *v0,TString ParOrAPar);
+  Bool_t GoodTPCFitMapSharedMap(const AliAODTrack *track);
+  Bool_t GoodTPCFitMapSharedMap(const AliAODTrack *pTrack,const AliAODTrack *nTrack);
+  Bool_t AcceptTrack(const AliAODTrack *track,int type);
+  Bool_t GoodDCA(const AliAODTrack *AODtrack,const AliAODEvent *aodEvent,Int_t type);
+  Bool_t SingleParticleQualityCuts(const AliAODTrack *aodtrack,const AliAODEvent *aodEvent);
+  Bool_t SingleParticleQualityCuts(const AliAODv0 *v0);
+  Bool_t TestPIDHypothesis(const AliAODTrack *track,Int_t type);
+  Bool_t ClosePairRejecter(Float_t deltaPhiS,Float_t deltaEta);
+  Bool_t CheckIfRealV0(AliAODv0 *v0,AliAODEvent *aodEvent,Int_t PDGmother,Int_t PDGdaugh1, Int_t PDGdaugh2);
+  Bool_t V0TopologicalSelection(AliAODv0 *v0,AliAODEvent *aodevent,TString ParOrAPar);
+  Bool_t PileUpRejection(AliAODEvent* ev);
+  Bool_t CheckMCPID(AliAODEvent *aodEvent, AliAODTrack* aodtrack,int pdg);
+  Bool_t CheckMCPID(AliAODv0 *v0,AliAODEvent* aodEvent,int pdg);
+
   Int_t GetNumberOfTrackletsInEtaRange(AliAODEvent* ev,Double_t mineta,Double_t maxeta);
-  
+
   Float_t PhiS(AliAODTrack *track,const Float_t bfield,const Float_t radius,const Float_t decVtx[2]);
   Float_t PhiS(AliAODTrack *track,const Float_t bfield,const Float_t radius);
   Float_t EtaS(const Float_t zVertex, const Float_t radius);
-  Double_t *DCAxy(const AliAODTrack *track, const AliVEvent *evt);
-  Double_t Qinv(TLorentzVector v0,TLorentzVector proton);
+
+  Double_t Qinv(TLorentzVector trackV0,TLorentzVector trackProton);
   Double_t relKcalc(TLorentzVector track1,TLorentzVector track2);
   Double_t LpCorrfunc(Double_t relk,Double_t source);
   Double_t ppCorrfunc(Double_t relk,Double_t source);
+  Double_t GetAverageSeparation(const TVector3 globalPositions1st[],const TVector3 globalPositions2nd[]);
 
-    
+  void SetSystematics(AliFemtoCutValues::systematics cutType){fcutType = cutType;}
+
+  AliEventCuts fAliEventCuts;
+  void SetTrigger(UInt_t trigger) { fTrigger = trigger; }
+  UInt_t GetTrigger() const { return fTrigger; }
+  void SetV0Percentile(float v0perc) { fV0PercentileMax = v0perc; }
+
  private:
   
   AliAnalysisTaskPLFemto(const AliAnalysisTaskPLFemto &source);
   AliAnalysisTaskPLFemto& operator=(const AliAnalysisTaskPLFemto& source); 
   
-  Int_t  fEvents;                //  n. of events
+  UInt_t fTrigger;
+  bool fIsRun1;
+  float fV0PercentileMax;
   Bool_t fUseMCInfo;             //  Use MC info
   Bool_t fOnlineV0;
   TList *fOutput;               //!  User output
+  TList *fOutputAliEvent;       //! User output AliEventCuts
   TList *fOutputSP;             //!  User output2
   TList *fOutputTP;             //!  User output4
   TList *fOutputPID;            //!  User output3
   AliMCEvent* fAODMCEvent; //!
   TH1F *fCEvents;          //!
 
-  Double_t *fTPCradii; //!
-  Double_t fSphericityvalue;
-  Double_t fPrimVertex[3];
-    
+
   TString fwhichV0,fwhichAntiV0,fwhichV0region;
   Int_t fV0Counter;
   Int_t fAntiV0Counter;
   Int_t fProtonCounter;
   Int_t fAntiProtonCounter;
   Int_t fXiCounter;
-  
+
   Int_t fEventNumber;
   int fWhichfilterbit;
   //PID:
-  AliPIDResponse  *fPIDResponse; //! PID response object
-  //AliTPCPIDResponse *fTPCResponse;
   
+  Double_t *fTPCradii; //!
+  Double_t fPrimVertex[3];
+
+  AliFemtoCutValues::systematics fcutType;
+
+  AliPIDResponse  *fPIDResponse; //! PID response object
+
   //for tracking mixed events etc.
   AliAODTrack     **fGTI;                  //! Array of pointers which stores global track infos
   const UShort_t  fTrackBuffSize;          //! Size fo the above arra
@@ -187,7 +204,7 @@ class AliAnalysisTaskPLFemto : public AliAnalysisTaskSE
   Bool_t CheckGlobalTrack(const AliAODTrack *track);
   Int_t *MultiplicityBinFinderzVertexBinFinder(AliAODEvent *aodEvent,Double_t zVertex);
   Float_t GetCorrectedTOFSignal(const AliVTrack *track,const AliAODEvent *aodevent); //!
-  
+
   Double_t CalcSphericityEvent(AliAODEvent *AODevent);
   Double_t DEtacalc(const double zprime1, const double zprime2, const double radius);
   Double_t DPhicalc(const double dxprime, const double dyprime, const double radius);
@@ -196,17 +213,38 @@ class AliAnalysisTaskPLFemto : public AliAnalysisTaskSE
   {
     kZVertexBins = 10,//10
     kEventsToMix =  10,//15
-    kV0TrackLimit   = 100,              //maximum number of v0s, array size
+    kV0TrackLimit   = 100, //maximum number of v0s, array size
     kProtonTrackLimit = 100, //maximum number of protons in array
     kXiTrackLimit = 100, //maximum number of Xis in array
-    kZVertexStart = -10,
-    kZVertexStop = 10,
     kMultiplicityBins = 13,//5
   };
-  
-#ifdef __ROOT__
-  ClassDef(AliAnalysisTaskPLFemto,1);
-#endif
+
+
+  //Check buffer with deque (mainly to avoid empty evt mixing):
+
+  enum
+  {
+    kProton,
+    kAntiProton,
+    kV0,
+    kAntiV0
+  };
+
+  Bool_t fSEPairAnalysisDecider[4];
+
+  //every particle has its own vector
+  std::vector<AliFemtoProtonParticle> fProtonTrackVector;
+  std::vector<AliFemtoProtonParticle> fAntiProtonTrackVector;
+  std::vector<AliFemtoLambdaParticle> fLambdaTrackVector;
+  std::vector<AliFemtoLambdaParticle> fAntiLambdaTrackVector;
+
+  //every particle has also its own buffer
+  std::deque< std::vector< AliFemtoProtonParticle > > fProtonEvtBuffer[kZVertexBins][kMultiplicityBins];
+  std::deque< std::vector< AliFemtoProtonParticle > > fAntiProtonEvtBuffer[kZVertexBins][kMultiplicityBins];
+  std::deque< std::vector< AliFemtoLambdaParticle > > fLambdaEvtBuffer[kZVertexBins][kMultiplicityBins];
+  std::deque< std::vector< AliFemtoLambdaParticle > > fAntiLambdaEvtBuffer[kZVertexBins][kMultiplicityBins];
+
+  ClassDef(AliAnalysisTaskPLFemto,2)
 };
 
 #endif

--- a/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoCutValues.cxx
+++ b/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoCutValues.cxx
@@ -17,6 +17,8 @@
 
 #include "AliFemtoCutValues.h"
 
+ClassImp(AliFemtoCutValues)
+
 AliFemtoCutValues::AliFemtoCutValues() :
   fEvtZvtxLow(-10.),//cm
   fEvtZvtxUp(10.),//cm
@@ -26,7 +28,7 @@ AliFemtoCutValues::AliFemtoCutValues() :
   fV0EtaRange(0.8),
   fAntiCutK0sLow(0.48),//GeV/c*2
   fAntiCutK0sUp(0.515),//GeV/c*2
-  fV0Nsigma(5.),
+  fV0Nsigma(5.),//5
   fV0Pointing(0.99),
   fV0RxyLow(0.2),//cm
   fV0RxyUp(100.),//cm
@@ -39,16 +41,55 @@ AliFemtoCutValues::AliFemtoCutValues() :
   fProtonPIDThresholdPtTPCLow(0.5),//GeV/c
   fProtonPIDThresholdPtTOFUp(4.05),//GeV/c
   fProtonPIDTPCTOFSwitch(0.75),//GeV/c
+  fProtonPtBinsDCA(20),
+  fProtonPtBinsPurity(33),
+  fProtonTPCCluster(80),
   fProtonDCAxyCut(0.1),//cm
   fProtonDCAzCut(0.2),//cm
   fProtonEtaRange(0.8),
   fProtonNsigma(3.),
+  fTrackFilterBit(128)
+//fPDGDatabase(new TDatabasePDG())
+{
+  //Default constructor
+  Info("AliFemtoCutValues","Calling default Constructor");
+}
+//_____________________________________________________________________________
+AliFemtoCutValues::AliFemtoCutValues(systematics cutType) :
+  fEvtZvtxLow(-10.),//cm
+  fEvtZvtxUp(10.),//cm
+  fV0PIDThresholdPtTPCLow(0.3),//GeV/c
+  fV0PIDThresholdPtTPCUp(4.3),//GeV/c
+  fV0SelWidth(0.004),//GeV/c*2
+  fV0EtaRange(0.8),
+  fAntiCutK0sLow(0.48),//GeV/c*2
+  fAntiCutK0sUp(0.515),//GeV/c*2
+  fV0Nsigma(5.),//5
+  fV0Pointing(0.99),
+  fV0RxyLow(0.2),//cm
+  fV0RxyUp(100.),//cm
+  fV0Decayvtx(100.),//cm
+  fV0DCAtrackPV(0.05),//cm
+  fV0DCAtracksV0decay(1.5),//cm
+  fV0PtBinsCPA(8),
+  fV0PtBinsInvMass(8),
+  fV0TPCCluster(70),
+  fProtonPIDThresholdPtTPCLow(0.5),//GeV/c
+  fProtonPIDThresholdPtTOFUp(4.05),//GeV/c
+  fProtonPIDTPCTOFSwitch(0.75),//GeV/c
   fProtonPtBinsDCA(20),
   fProtonPtBinsPurity(33),
   fProtonTPCCluster(80),
-  fPDGDatabase(new TDatabasePDG())
+  fProtonDCAxyCut(0.1),//cm
+  fProtonDCAzCut(0.2),//cm
+  fProtonEtaRange(0.8),
+  fProtonNsigma(3.),
+  fTrackFilterBit(128)
+//fPDGDatabase(new TDatabasePDG())
 {
-  //Default constructor
+  if(cutType != kDefault) SetCutVariation(cutType);
+
+  Info("AliFemtoCutValues","Calling extended Constructor");
 }
 //_____________________________________________________________________________
 AliFemtoCutValues::AliFemtoCutValues(const AliFemtoCutValues &obj) :
@@ -73,14 +114,13 @@ AliFemtoCutValues::AliFemtoCutValues(const AliFemtoCutValues &obj) :
   fProtonPIDThresholdPtTPCLow(obj.fProtonPIDThresholdPtTPCLow),
   fProtonPIDThresholdPtTOFUp(obj.fProtonPIDThresholdPtTOFUp),
   fProtonPIDTPCTOFSwitch(obj.fProtonPIDTPCTOFSwitch),
-  fProtonDCAxyCut(obj.fProtonDCAxyCut),
-  fProtonDCAzCut(obj.fProtonDCAzCut),
-  fProtonEtaRange(obj.fProtonEtaRange),
-  fProtonNsigma(obj.fProtonNsigma),
   fProtonPtBinsDCA(obj.fProtonPtBinsDCA),
   fProtonPtBinsPurity(obj.fProtonPtBinsPurity),
   fProtonTPCCluster(obj.fProtonTPCCluster),
-  fPDGDatabase(new TDatabasePDG())
+  fProtonDCAxyCut(obj.fProtonDCAxyCut),
+  fProtonDCAzCut(obj.fProtonDCAzCut),
+  fProtonEtaRange(obj.fProtonEtaRange),
+  fProtonNsigma(obj.fProtonNsigma)
 {
   // copy constructor
 }
@@ -141,12 +181,41 @@ Int_t AliFemtoCutValues::fFindPtBin(Double_t ptVal,Double_t ptLow,Double_t ptUp,
   return ptBin;
 }
 //_____________________________________________________________________________
+void AliFemtoCutValues::SetCutVariation(systematics cutType)
+{
+  //This will update the cut values initialized for default values in the constructor
+
+  if(cutType == kDefault) return;//do nothing
+  //Proton Variations:
+  else if(cutType == kProtonVariationLowerPtThresholdDown) fProtonPIDThresholdPtTPCLow = 0.4;
+  else if(cutType == kProtonVariationLowerPtThresholdUp) fProtonPIDThresholdPtTPCLow = 0.6;
+  else if(cutType == kProtonVariationEtaRangeUp) fProtonEtaRange = 0.9;
+  else if(cutType == kProtonVariationEtaRangeDown) fProtonEtaRange = 0.7;
+  else if(cutType == kProtonVariationNsigmaUp) fProtonNsigma = 4.;
+  else if(cutType == kProtonVariationNsigmaDown) fProtonNsigma = 2.;
+  else if(cutType == kProtonTPCClusterUp) fProtonTPCCluster = 90;
+  else if(cutType == kProtonVariationFilterBitGlobal) fTrackFilterBit = 96;
+  //V0 variations:
+  else if(cutType == kV0VariationLowerPtThresholdDown) fV0PIDThresholdPtTPCLow = 0.24;
+  else if(cutType == kV0VariationLowerPtThresholdUp) fV0PIDThresholdPtTPCLow = 0.36;
+  else if(cutType == kV0VariationCosinePointingUp) fV0Pointing = 0.998;
+  else if(cutType == kV0VariationNsigmaDown) fV0Nsigma = 4.;
+  else if(cutType == kV0VariationTPCClusterUp) fV0TPCCluster = 80;
+  else if(cutType == kV0VariationEtaRangeUp) fV0EtaRange = 0.9;
+  else if(cutType == kV0VariationEtaRangeDown) fV0EtaRange = 0.7;
+  else if(cutType == kV0VariationDCAatV0DecayDown) fV0DCAtracksV0decay = 1.2;
+  else if(cutType == kV0VariationDCADaughtersToPVUp) fV0DCAtrackPV = 0.06;
+  else std::cout << "Unknown variation, default values are used for analysis" << std::endl;
+}
+//_____________________________________________________________________________
 AliFemtoCutValues::~AliFemtoCutValues()
 {
+  /*
   if(fPDGDatabase)
     {
       delete fPDGDatabase;
       fPDGDatabase = 0;
     }
+  */
 }
 //_____________________________________________________________________________

--- a/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoCutValues.h
+++ b/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoCutValues.h
@@ -43,7 +43,7 @@ class AliFemtoCutValues
   Int_t fV0PtBinsCPA; //Number of pt bins to do cosine pointing angle differentially
   Int_t fV0PtBinsInvMass; //Number of pt bins to do invariant mass differentially
   Int_t fV0TPCCluster;
-  
+
   //Protons
   Double_t fProtonPIDThresholdPtTPCLow; //At which pt-value the PID for Protons starts
   Double_t fProtonPIDThresholdPtTOFUp; //At which pt-value the PID for Protons stops
@@ -55,68 +55,96 @@ class AliFemtoCutValues
   Int_t fProtonPtBinsDCA; //Number of pt bins to do DCA plots differentially
   Int_t fProtonPtBinsPurity; //Number of pt bins to do Purity plots differentially
   Int_t fProtonTPCCluster;
+  Int_t fTrackFilterBit;
 
   //functions
   Int_t fFindPtBin(Double_t ptVal,Double_t ptLow,Double_t ptUp,Int_t nBins);
-  
-  
-  TDatabasePDG *fPDGDatabase; //!
-  
+
+
+  TDatabasePDG fPDGDatabase; //!
+
  public:
-  
+
+  enum systematics
+  {
+    kDefault,
+    kProtonVariationLowerPtThresholdUp,
+    kProtonVariationLowerPtThresholdDown,
+    kProtonVariationEtaRangeUp,
+    kProtonVariationEtaRangeDown,
+    kProtonVariationNsigmaUp,
+    kProtonVariationNsigmaDown,
+    kProtonTPCClusterUp,
+    kProtonVariationFilterBitGlobal,
+    kV0VariationLowerPtThresholdDown,
+    kV0VariationLowerPtThresholdUp,
+    kV0VariationCosinePointingUp,
+    kV0VariationNsigmaDown,
+    kV0VariationTPCClusterUp,
+    kV0VariationEtaRangeUp,
+    kV0VariationEtaRangeDown,
+    kV0VariationDCAatV0DecayDown,
+    kV0VariationDCADaughtersToPVUp
+  };
+
   AliFemtoCutValues();
+  AliFemtoCutValues(systematics cutType);
   virtual ~AliFemtoCutValues();
   AliFemtoCutValues(const AliFemtoCutValues &obj);
   AliFemtoCutValues &operator=(const AliFemtoCutValues &obj);
-  
+
   //Int_t fFindPtBin(Double_t ptVal,Double_t ptLow,Double_t ptUp,Int_t nBins);
 
   //Event
-  Double_t GetEvtzVertexLow() {return fEvtZvtxLow;};
-  Double_t GetEvtzVertexUp() {return fEvtZvtxUp;};
+  Double_t GetEvtzVertexLow() {return fEvtZvtxLow;}
+  Double_t GetEvtzVertexUp() {return fEvtZvtxUp;}
 
   //V0s
-  Int_t FindV0PtBinInvMass(Double_t V0pt){return fFindPtBin(V0pt,fV0PIDThresholdPtTPCLow,fV0PIDThresholdPtTPCUp,fV0PtBinsInvMass);};
-  Int_t FindV0PtBinCPA(Double_t V0pt){return fFindPtBin(V0pt,fV0PIDThresholdPtTPCLow,fV0PIDThresholdPtTPCUp,fV0PtBinsCPA);};
+  Int_t FindV0PtBinInvMass(Double_t V0pt){return fFindPtBin(V0pt,fV0PIDThresholdPtTPCLow,fV0PIDThresholdPtTPCUp,fV0PtBinsInvMass);}
+  Int_t FindV0PtBinCPA(Double_t V0pt){return fFindPtBin(V0pt,fV0PIDThresholdPtTPCLow,fV0PIDThresholdPtTPCUp,fV0PtBinsCPA);}
+
+  //Setter
+  void SetCutVariation(systematics cutType);
 
   //Getter
   Int_t GetV0PtBinsCPA(){return fV0PtBinsCPA;}
   Int_t GetV0PtBinsInvMass(){return fV0PtBinsInvMass;}
-  Int_t GetV0TPCCluster(){return fV0TPCCluster;};
+  Int_t GetV0TPCCluster(){return fV0TPCCluster;}
+  Int_t GetFilterBit(){return fTrackFilterBit;}
 
-  Double_t GetV0PID_width(){return fV0SelWidth;}
-  Double_t GetV0PIDthrPtLow(){return fV0PIDThresholdPtTPCLow;};
-  Double_t GetV0PIDthrPtUp(){return fV0PIDThresholdPtTPCUp;};
-  Double_t GetHadronMasses(Int_t Pdgcode) {return fPDGDatabase->GetParticle(Pdgcode)->Mass();};
-  Double_t GetV0EtaRange(){return fV0EtaRange;};
-  Double_t GetK0sAntiCutLow(){return fAntiCutK0sLow;};
-  Double_t GetK0sAntiCutUp(){return fAntiCutK0sUp;};
-  Double_t GetV0nsigma(){return fV0Nsigma;};
-  Double_t GetV0pointing(){return fV0Pointing;};
-  Double_t GetV0rxylow(){return fV0RxyLow;};
-  Double_t GetV0rxyup(){return fV0RxyUp;};
-  Double_t GetV0decayvtxcut(){return fV0Decayvtx;};
-  Double_t GetV0DCAtrPV(){return fV0DCAtrackPV;};
-  Double_t GetV0DCAtracksV0decay(){return fV0DCAtracksV0decay;};
-  
+  Double_t GetV0PIDWidth(){return fV0SelWidth;}
+  Double_t GetV0PIDthrPtLow(){return fV0PIDThresholdPtTPCLow;}
+  Double_t GetV0PIDthrPtUp(){return fV0PIDThresholdPtTPCUp;}
+  Double_t GetHadronMasses(Int_t Pdgcode) {return (fPDGDatabase.GetParticle(Pdgcode))->Mass();}
+  Double_t GetV0EtaRange(){return fV0EtaRange;}
+  Double_t GetK0sAntiCutLow(){return fAntiCutK0sLow;}
+  Double_t GetK0sAntiCutUp(){return fAntiCutK0sUp;}
+  Double_t GetV0nsigma(){return fV0Nsigma;}
+  Double_t GetV0pointing(){return fV0Pointing;}
+  Double_t GetV0rxylow(){return fV0RxyLow;}
+  Double_t GetV0rxyup(){return fV0RxyUp;}
+  Double_t GetV0decayvtxcut(){return fV0Decayvtx;}
+  Double_t GetV0DCAtrPV(){return fV0DCAtrackPV;}
+  Double_t GetV0DCAtracksV0decay(){return fV0DCAtracksV0decay;}
+
   //Protons
-  Int_t FindProtonPtBinDCA(Double_t Protonpt){return fFindPtBin(Protonpt,fProtonPIDThresholdPtTPCLow,fProtonPIDThresholdPtTOFUp,fProtonPtBinsDCA);};
-  Int_t FindProtonPtBinPurity(Double_t Protonpt){return fFindPtBin(Protonpt,fProtonPIDTPCTOFSwitch,fProtonPIDThresholdPtTOFUp,fProtonPtBinsPurity);};
+  Int_t FindProtonPtBinDCA(Double_t Protonpt){return fFindPtBin(Protonpt,fProtonPIDThresholdPtTPCLow,fProtonPIDThresholdPtTOFUp,fProtonPtBinsDCA);}
+  Int_t FindProtonPtBinPurity(Double_t Protonpt){return fFindPtBin(Protonpt,fProtonPIDTPCTOFSwitch,fProtonPIDThresholdPtTOFUp,fProtonPtBinsPurity);}
 
-  Int_t GetProtonTPCCluster(){return fProtonTPCCluster;};
-  
+  Int_t GetProtonTPCCluster(){return fProtonTPCCluster;}
+
   Double_t GetProtonPIDthrPtLow(){return fProtonPIDThresholdPtTPCLow;}
   Double_t GetProtonPIDthrPtUp(){return fProtonPIDThresholdPtTOFUp;}
   Double_t GetProtonPIDTOFTPCSwitch(){return fProtonPIDTPCTOFSwitch;}
   Double_t GetProtonDCAxyCut(){return fProtonDCAxyCut;}
   Double_t GetProtonDCAzCut(){return fProtonDCAzCut;}
   Double_t GetProtonEtaRange(){return fProtonEtaRange;}
-  Double_t GetProtonnsigma(){return fProtonNsigma;};
-  
-  Int_t GetPtBinsPurity(){return fProtonPtBinsPurity;};
-  Int_t GetPtBinsDCA(){return fProtonPtBinsDCA;};
-  
-  //ClassDef(AliFemtoCutValues, 1);
+  Double_t GetProtonnsigma(){return fProtonNsigma;}
+
+  Int_t GetPtBinsPurity(){return fProtonPtBinsPurity;}
+  Int_t GetPtBinsDCA(){return fProtonPtBinsDCA;}
+
+  ClassDef(AliFemtoCutValues, 2)
 };
 
 

--- a/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoLambdaEvent.cxx
+++ b/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoLambdaEvent.cxx
@@ -28,23 +28,15 @@
 
 AliFemtoLambdaEvent::AliFemtoLambdaEvent():
   fEventNumber(0),
-  fFillStatus(0),
   fNumV0s(0),
   fNumAntiV0s(0),
   fNumProtons(0),
   fNumAntiProtons(0),
   fNumXis(0),
-  fNumV0SideBand_left(0),
-  fNumV0SideBand_right(0),
-  fMultBin(-10),
-  fBoostVal(-10),
-  fSphericity(-9999.),
   fLambdaParticle(0x0),
   fAntiLambdaParticle(0x0),
   fProtonParticle(0x0),
   fAntiProtonParticle(0x0),
-  fLambdaSideBand_left(0x0),
-  fLambdaSideBand_right(0x0),
   fXiParticle(0x0)
 {
   //Default constructor
@@ -52,23 +44,15 @@ AliFemtoLambdaEvent::AliFemtoLambdaEvent():
 //_____________________________________________________________________________
 AliFemtoLambdaEvent::AliFemtoLambdaEvent(const AliFemtoLambdaEvent &obj) :
   fEventNumber(obj.fEventNumber),
-  fFillStatus(obj.fFillStatus),
   fNumV0s(obj.fNumV0s),
   fNumAntiV0s(obj.fNumAntiV0s),
   fNumProtons(obj.fNumProtons),
   fNumAntiProtons(obj.fNumAntiProtons),
   fNumXis(obj.fNumXis),
-  fNumV0SideBand_left(obj.fNumV0SideBand_left),
-  fNumV0SideBand_right(obj.fNumV0SideBand_right),
-  fMultBin(obj.fMultBin),
-  fBoostVal(obj.fBoostVal),
-  fSphericity(obj.fSphericity),
   fLambdaParticle(obj.fLambdaParticle),
   fAntiLambdaParticle(obj.fAntiLambdaParticle),
   fProtonParticle(obj.fProtonParticle),
   fAntiProtonParticle(obj.fProtonParticle),
-  fLambdaSideBand_left(obj.fLambdaSideBand_left),
-  fLambdaSideBand_right(obj.fLambdaSideBand_right),
   fXiParticle(obj.fXiParticle)
 {
   //Copy constructor
@@ -80,23 +64,15 @@ AliFemtoLambdaEvent &AliFemtoLambdaEvent::operator=(const AliFemtoLambdaEvent &o
  if(this == &obj) return *this;
 
  fEventNumber = obj.fEventNumber;
- fFillStatus = obj.fFillStatus;
  fNumV0s = obj.fNumV0s;
  fNumAntiV0s = obj.fNumAntiV0s;
  fNumProtons = obj.fNumProtons;
  fNumAntiProtons = obj.fNumAntiProtons;
- fNumV0SideBand_left = obj.fNumV0SideBand_left;
- fNumV0SideBand_right = obj.fNumV0SideBand_right;
  fNumXis = obj.fNumXis;
- fMultBin = obj.fMultBin;
- fBoostVal = obj.fBoostVal;
- fSphericity = obj.fSphericity;
  fLambdaParticle = obj.fLambdaParticle;
  fAntiLambdaParticle = obj.fAntiLambdaParticle;
  fProtonParticle = obj.fProtonParticle;
  fAntiProtonParticle = obj.fAntiProtonParticle;
- fLambdaSideBand_left = obj.fLambdaSideBand_left;
- fLambdaSideBand_right = obj.fLambdaSideBand_right;
  fXiParticle = obj.fXiParticle;
 
  return (*this);
@@ -124,16 +100,6 @@ AliFemtoLambdaEvent::~AliFemtoLambdaEvent()
    {
      delete fAntiProtonParticle;
      fAntiProtonParticle = 0;
-   }
- if(fLambdaSideBand_left)
-   {
-     delete fLambdaSideBand_left;
-     fLambdaSideBand_left = 0;
-   }
- if(fLambdaSideBand_right)
-   {
-     delete fLambdaSideBand_right;
-     fLambdaSideBand_right = 0;
    }
  if(fXiParticle)
    {

--- a/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoLambdaEvent.h
+++ b/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoLambdaEvent.h
@@ -2,8 +2,6 @@
 #define ALIFEMTOLambdaEVENT_H
 //
 
-
-
 #include <iostream>
 #include <string>
 #include "TH1.h"
@@ -30,27 +28,19 @@ class AliFemtoLambdaEvent // like particle_event
   AliFemtoLambdaEvent &operator=(const AliFemtoLambdaEvent &obj);
 
   int fEventNumber;
-  int fFillStatus;     //tells AliFemtoLambdaEventCollection to add event
   int fNumV0s;         //number of collected v0s in event
   int fNumAntiV0s;         //number of collected Anti-v0s in event
   int fNumProtons;     //number of primary protons used for correlations
   int fNumAntiProtons;     //number of primary anti-protons used for correlations
   int fNumXis;
-  int fNumV0SideBand_left; //number of fake V0s on the left side of Lambda peak
-  int fNumV0SideBand_right; //number of fake V0s on the right side of Lambda peak
-  int fMultBin;
-  int fBoostVal;
-  double fSphericity;
+
   AliFemtoLambdaParticle *fLambdaParticle; //class for Lambda parameters needed for CF
   AliFemtoLambdaParticle *fAntiLambdaParticle; //class for Lambda parameters needed for CF
   AliFemtoProtonParticle *fProtonParticle;
   AliFemtoProtonParticle *fAntiProtonParticle;
-  AliFemtoLambdaParticle *fLambdaSideBand_left;
-  AliFemtoLambdaParticle *fLambdaSideBand_right;
   AliFemtoXiParticle *fXiParticle;
-#ifdef __ROOT__
-  ClassDef(AliFemtoLambdaEvent, 1);
-#endif
+
+  ClassDef(AliFemtoLambdaEvent, 2)
 };
 
 #endif

--- a/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoLambdaEventCollection2.cxx
+++ b/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoLambdaEventCollection2.cxx
@@ -24,6 +24,8 @@
 
 #include "AliFemtoLambdaEventCollection2.h"
 
+ClassImp(AliFemtoLambdaEventCollection2)
+
 //_____________________________________________________________________________
 AliFemtoLambdaEventCollection2::AliFemtoLambdaEventCollection2() : 
  fBufferSize(0),
@@ -51,29 +53,22 @@ AliFemtoLambdaEventCollection2::AliFemtoLambdaEventCollection2(short a, int lim)
   for(int ii = 0; ii < fBufferSize; ii++)   //Initialize particle table pointers to NULL
     {
       (fEvt + ii)->fLambdaParticle = 0;
-      (fEvt + ii)->fLambdaSideBand_left = 0;
-      (fEvt + ii)->fLambdaSideBand_right = 0;
       (fEvt + ii)->fAntiLambdaParticle = 0;
       (fEvt + ii)->fProtonParticle = 0;
       (fEvt + ii)->fAntiProtonParticle = 0;
+      (fEvt + ii)->fXiParticle = 0;
       
       (fEvt + ii)->fNumV0s = 0;
       (fEvt + ii)->fNumAntiV0s = 0;
       (fEvt + ii)->fNumProtons = 0;
       (fEvt + ii)->fNumAntiProtons = 0;
-      (fEvt + ii)->fNumAntiProtons = 0;
       (fEvt + ii)->fNumXis = 0;
-      (fEvt + ii)->fNumV0SideBand_left = 0;
-      (fEvt + ii)->fNumV0SideBand_right = 0;
-      (fEvt + ii)->fFillStatus = 0;
       
       (fEvt + ii)->fLambdaParticle = new AliFemtoLambdaParticle[fLimit];
       (fEvt + ii)->fAntiLambdaParticle = new AliFemtoLambdaParticle[fLimit];
       (fEvt + ii)->fProtonParticle = new AliFemtoProtonParticle[fLimit];
       (fEvt + ii)->fAntiProtonParticle = new AliFemtoProtonParticle[fLimit];
       (fEvt + ii)->fXiParticle = new AliFemtoXiParticle[fLimit];
-      (fEvt + ii)->fLambdaSideBand_left = new AliFemtoLambdaParticle[fLimit];
-      (fEvt + ii)->fLambdaSideBand_right = new AliFemtoLambdaParticle[fLimit];;
     }
 }
 //_____________________________________________________________________________
@@ -125,16 +120,6 @@ AliFemtoLambdaEventCollection2::~AliFemtoLambdaEventCollection2()
 	 delete [] (fEvt + i)->fAntiProtonParticle;
 	 (fEvt + i)->fAntiProtonParticle = 0;
        }
-     if((fEvt + i)->fLambdaSideBand_left != 0)
-       {
-	 delete [] (fEvt + i)->fLambdaSideBand_left;
-	 (fEvt + i)->fLambdaSideBand_left = 0;
-       }
-     if((fEvt + i)->fLambdaSideBand_right != 0)
-       {
-	 delete [] (fEvt + i)->fLambdaSideBand_right;
-	 (fEvt + i)->fLambdaSideBand_right = 0;
-       }
      if((fEvt + i)->fXiParticle != 0)
        {
 	 delete [] (fEvt + i)->fXiParticle;
@@ -154,32 +139,20 @@ void AliFemtoLambdaEventCollection2::FIFOShift(){ //Shift elements in FIFO by on
       for(int j=0; j<(fEvt + i-1)->fNumAntiV0s; j++) (fEvt + i)->fAntiLambdaParticle[j] = (fEvt + i-1)->fAntiLambdaParticle[j];
       for(int j=0; j<(fEvt + i-1)->fNumProtons; j++) (fEvt + i)->fProtonParticle[j] = (fEvt + i-1)->fProtonParticle[j];
       for(int j=0; j<(fEvt + i-1)->fNumAntiProtons; j++) (fEvt + i)->fAntiProtonParticle[j] = (fEvt + i-1)->fAntiProtonParticle[j];
-      for(int j=0; j<(fEvt + i-1)->fNumV0SideBand_left; j++) (fEvt + i)->fLambdaSideBand_left[j] = (fEvt + i-1)->fLambdaSideBand_left[j];
-      for(int j=0; j<(fEvt + i-1)->fNumV0SideBand_right; j++) (fEvt + i)->fLambdaSideBand_right[j] = (fEvt + i-1)->fLambdaSideBand_right[j];
       for(int j=0; j<(fEvt + i-1)->fNumXis; j++) (fEvt + i)->fXiParticle[j] = (fEvt + i-1)->fXiParticle[j];
       
-      (fEvt + i)->fFillStatus = (fEvt + i-1)->fFillStatus;
       (fEvt + i)->fNumV0s = (fEvt + i-1)->fNumV0s;
       (fEvt + i)->fNumAntiV0s = (fEvt + i-1)->fNumAntiV0s;
       (fEvt + i)->fNumProtons = (fEvt + i-1)->fNumProtons;
       (fEvt + i)->fNumAntiProtons = (fEvt + i-1)->fNumAntiProtons;
-      (fEvt + i)->fMultBin = (fEvt + i-1)->fMultBin;
-      (fEvt + i)->fBoostVal = (fEvt + i-1)->fBoostVal;
-      (fEvt + i)->fSphericity = (fEvt + i-1)->fSphericity;
-      (fEvt + i)->fNumV0SideBand_left = (fEvt + i-1)->fNumV0SideBand_left;
-      (fEvt + i)->fNumV0SideBand_right = (fEvt + i-1)->fNumV0SideBand_right;
       (fEvt + i)->fNumXis = (fEvt + i-1)->fNumXis;
+      (fEvt + i)->fEventNumber = (fEvt + i-1)->fEventNumber;
     }
 
   (fEvt)->fNumV0s = 0;
   (fEvt)->fNumAntiV0s = 0;
   (fEvt)->fNumProtons = 0;
   (fEvt)->fNumAntiProtons = 0;
-  (fEvt)->fFillStatus = 0;
-  (fEvt)->fMultBin = 0;
-  (fEvt)->fBoostVal = 0;
-  (fEvt)->fSphericity = 0;
-  (fEvt)->fNumV0SideBand_left = 0;
-  (fEvt)->fNumV0SideBand_right = 0;
   (fEvt)->fNumXis = 0;
+  (fEvt)->fEventNumber = 0;
 }

--- a/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoLambdaEventCollection2.h
+++ b/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoLambdaEventCollection2.h
@@ -34,9 +34,7 @@ class AliFemtoLambdaEventCollection2
 
     void FIFOShift();  //remove/add event (first in, first out)
     void SetBufferSize(short a){fBufferSize = a;} //set size of event buffer
-    
-#ifdef __ROOT__
-    ClassDef(AliFemtoLambdaEventCollection2, 1);
-#endif
+
+    ClassDef(AliFemtoLambdaEventCollection2, 2)
 };
 #endif

--- a/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoLambdaParticle.cxx
+++ b/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoLambdaParticle.cxx
@@ -13,10 +13,9 @@
  * about the suitability of this software for any purpose. It is          *
  * provided "as is" without express or implied warranty.                  *
  **************************************************************************/
-
-
 #include "AliFemtoLambdaParticle.h"
 
+ClassImp(AliFemtoLambdaParticle)
 
 AliFemtoLambdaParticle::AliFemtoLambdaParticle() :
   fMomentum(),
@@ -41,27 +40,26 @@ AliFemtoLambdaParticle::AliFemtoLambdaParticle() :
   //Default constructor
 }
 //_____________________________________________________________________________
-/*
-AliFemtoLambdaParticle::AliFemtoLambdaParticle(const AliFemtoLambdaParticle &obj) :
-  fMomentum(),
-  fMomentumMC(),
-  fMomentumMCMother(),
-  fPDGCode(obj.fPDGCode),
-  fPDGCodeMother(obj.fPDGCodeMother),
-  fPt(obj.fPt),
-  fMass(obj.fMass),
-  fDaughterID1(obj.fDaughterID1),
-  fDaughterID2(obj.fDaughterID2),
-  fV0tag(obj.fV0tag),
-  fPointing(obj.fPointing),
-  fPhiPosdaughter(obj.fPhiPosdaughter),
-  fEtaPosdaughter(obj.fEtaPosdaughter),
-  fPhiNegdaughter(obj.fPhiNegdaughter),
-  fEtaNegdaughter(obj.fEtaNegdaughter)
-{
-  // copy constructor
-}
-*/
+//AliFemtoLambdaParticle::AliFemtoLambdaParticle(const AliFemtoLambdaParticle &obj) :
+//  fMomentum(),
+//  fMomentumMC(),
+//  fMomentumMCMother(),
+//  fPDGCode(obj.fPDGCode),
+//  fPDGCodeMother(obj.fPDGCodeMother),
+//  fPt(obj.fPt),
+//  fMass(obj.fMass),
+//  fDaughterID1(obj.fDaughterID1),
+//  fDaughterID2(obj.fDaughterID2),
+//  fV0tag(obj.fV0tag),
+//  fPointing(obj.fPointing),
+//  fPhiPosdaughter(obj.fPhiPosdaughter),
+//  fEtaPosdaughter(obj.fEtaPosdaughter),
+//  fPhiNegdaughter(obj.fPhiNegdaughter),
+//  fEtaNegdaughter(obj.fEtaNegdaughter)
+//{
+//  // copy constructor
+//}
+
 //_____________________________________________________________________________
 AliFemtoLambdaParticle &AliFemtoLambdaParticle::operator=(const AliFemtoLambdaParticle &obj)
 {
@@ -88,13 +86,11 @@ AliFemtoLambdaParticle &AliFemtoLambdaParticle::operator=(const AliFemtoLambdaPa
   fEtaNegdaughter = obj.fEtaNegdaughter;
   fReal = obj.fReal;
 
+
   for(int i=0;i<9;i++)
    {
-     for(int j=0;j<3;j++)
-       {
-	 fPosDaughPosTPC[i][j] = obj.fPosDaughPosTPC[i][j];
-	 fNegDaughPosTPC[i][j] = obj.fNegDaughPosTPC[i][j];
-       }
+     fPositionPosTPC[i] = obj.fPositionPosTPC[i];
+     fPositionNegTPC[i] = obj.fPositionNegTPC[i];
    }
   
   

--- a/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoLambdaParticle.h
+++ b/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoLambdaParticle.h
@@ -26,12 +26,15 @@ class AliFemtoLambdaParticle // Reconstructed Lambdas parameters needed for corr
   
   AliFemtoLambdaParticle();
   virtual ~AliFemtoLambdaParticle();
-  //AliFemtoLambdaParticle(const AliFemtoLambdaParticle &obj);
+//  AliFemtoLambdaParticle(const AliFemtoLambdaParticle &obj);
   AliFemtoLambdaParticle &operator=(const AliFemtoLambdaParticle &obj);
   
   TVector3 fMomentum;  //v0 momentum
   TVector3 fMomentumMC;  //v0 Monte Carlo momentum
   TVector3 fMomentumMCMother;  //v0 Monte Carlo momentum of mother particle
+  TVector3 fPositionPosTPC[9];
+  TVector3 fPositionNegTPC[9];
+
   int fPDGCode;
   int fPDGCodeMother;
   double fPt;           //v0 transverse momentum
@@ -49,11 +52,9 @@ class AliFemtoLambdaParticle // Reconstructed Lambdas parameters needed for corr
   double fEtaPosdaughter;
   double fPhiNegdaughter;
   double fEtaNegdaughter;
-  double fPosDaughPosTPC[9][3];
-  double fNegDaughPosTPC[9][3];
-  
-#ifdef __ROOT__
-  ClassDef(AliFemtoLambdaParticle, 1);
-#endif
+  //double fPosDaughPosTPC[9][3];
+  //double fNegDaughPosTPC[9][3];
+
+  ClassDef(AliFemtoLambdaParticle, 2)
 };
 #endif

--- a/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoProtonParticle.cxx
+++ b/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoProtonParticle.cxx
@@ -16,6 +16,8 @@
 
 #include "AliFemtoProtonParticle.h"
 
+ClassImp(AliFemtoProtonParticle)
+
 AliFemtoProtonParticle::AliFemtoProtonParticle() :
   fMomentum(),
   fMomentumMC(),
@@ -30,28 +32,31 @@ AliFemtoProtonParticle::AliFemtoProtonParticle() :
   fPhi(0),
   fPhistar(),
   fEta(0),
-  fReal(kFALSE)
+  fReal(kFALSE),
+  fProtonTag(kTRUE)
 {
+
+  fMomentum.SetXYZ(0.,0.,0.);
+  fMomentumMC.SetXYZ(0.,0.,0.);
+  fMomentumMCMother.SetXYZ(0.,0.,0.);
+  fMomentumMCMotherParton.SetXYZ(0.,0.,0.);
+
   //Default constructor
 }
 //_____________________________________________________________________________
-/*
-AliFemtoProtonParticle::AliFemtoProtonParticle(const AliFemtoProtonParticle &obj) :
-  fMomentum(),
-  fMomentumMC(),
-  fMomentumMCMother(),
-  fPDGCode(obj.fPDGCode),
-  fPDGCodeMother(obj.fPDGCodeMother),
-  fPt(obj.fPt),
-  fID(obj.fID),
-  fPhi(obj.fPhi),
-  fPhiS(),
-  fEta(obj.fEta),
-  fPrimPosTPC()
-{
-  // copy constructor
-}
-*/
+//AliFemtoProtonParticle::AliFemtoProtonParticle(const AliFemtoProtonParticle &obj) :
+//  fMomentum(),
+//  fMomentumMC(),
+//  fMomentumMCMother(),
+//  fPDGCode(obj.fPDGCode),
+//  fPDGCodeMother(obj.fPDGCodeMother),
+//  fPt(obj.fPt),
+//  fID(obj.fID),
+//  fPhi(obj.fPhi),
+//  fEta(obj.fEta)
+//{
+//  // copy constructor
+//}
 //_____________________________________________________________________________
 AliFemtoProtonParticle &AliFemtoProtonParticle::operator=(const AliFemtoProtonParticle &obj)
 {
@@ -67,22 +72,23 @@ AliFemtoProtonParticle &AliFemtoProtonParticle::operator=(const AliFemtoProtonPa
  fPDGCodePartonMother = obj.fPDGCodePartonMother;
  fPartonMotherLabel = obj.fPartonMotherLabel;
  fReal = obj.fReal;
+ fProtonTag = obj.fProtonTag;
 
  fPt = obj.fPt;
  fID = obj.fID;
  fPhi = obj.fPhi;
  fEta = obj.fEta;
- 
- 
 
  for(int i=0;i<9;i++)//nine different TPC radii, ok its not good to hard code the number
    {
      fPhistar[i] = obj.fPhistar[i];
-
+     fPositionTPC[i] = obj.fPositionTPC[i];
+     /*
      for(int j=0;j<3;j++)
        {
 	 fPrimPosTPC[i][j] = obj.fPrimPosTPC[i][j];
        }
+     */
    }
 
  return (*this);

--- a/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoProtonParticle.h
+++ b/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoProtonParticle.h
@@ -31,14 +31,15 @@ class AliFemtoProtonParticle  // Proton parameters are stored in this class
   
   AliFemtoProtonParticle();
   virtual ~AliFemtoProtonParticle();
-  //AliFemtoProtonParticle(const AliFemtoProtonParticle &obj);
+//  AliFemtoProtonParticle(const AliFemtoProtonParticle &obj);
   AliFemtoProtonParticle &operator=(const AliFemtoProtonParticle &obj);
  
   TVector3 fMomentum;  //proton momentum
   TVector3 fMomentumMC;  //proton monte carlo momentum
   TVector3 fMomentumMCMother;  //momentum of mother particle of proton
   TVector3 fMomentumMCMotherParton;
-  
+  TVector3 fPositionTPC[9];
+
   int fPDGCode;
   int fPDGCodeMother; // PDG code of the weakly decaying mother resonance in the case of feed-down
   int fPDGCodePartonMother; //PDG code of the parton that created the proton
@@ -48,11 +49,11 @@ class AliFemtoProtonParticle  // Proton parameters are stored in this class
   double fPhi;
   double fPhistar[9];
   double fEta;
-  double fPrimPosTPC[9][3];
+  //double fPrimPosTPC[9][3];
   Bool_t fReal;
-#ifdef __ROOT__
-  ClassDef(AliFemtoProtonParticle, 1);
-#endif
+  Bool_t fProtonTag;
+
+  ClassDef(AliFemtoProtonParticle, 2)
 };
 
 

--- a/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoXiParticle.cxx
+++ b/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoXiParticle.cxx
@@ -17,6 +17,7 @@
 
 #include "AliFemtoXiParticle.h"
 
+ClassImp(AliFemtoXiParticle)
 
 AliFemtoXiParticle::AliFemtoXiParticle() :
   fMomentum(),

--- a/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoXiParticle.h
+++ b/PWGCF/FEMTOSCOPY/PLamAnalysisPP/AliFemtoXiParticle.h
@@ -36,9 +36,7 @@ class AliFemtoXiParticle // Reconstructed Lambdas parameters needed for correlat
   short fBachID; //Bachelor ID of Xi candidate
   bool fXitag;
   double fPointing;
-  
-#ifdef __ROOT__
-  ClassDef(AliFemtoXiParticle, 1);
-#endif
+
+  ClassDef(AliFemtoXiParticle, 2)
 };
 #endif

--- a/PWGCF/FEMTOSCOPY/PLamAnalysisPP/CMakeLists.txt
+++ b/PWGCF/FEMTOSCOPY/PLamAnalysisPP/CMakeLists.txt
@@ -23,8 +23,11 @@ include_directories(${AliPhysics_SOURCE_DIR}/PWGCF/FEMTOSCOPY/PLamAnalysisPP)
 # Additional includes - alphabetical order except ROOT
 include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/CORRFW
-		    ${AliPhysics_SOURCE_DIR}/PWG/Tools
-		    ${AliPhysics_SOURCE_DIR}/OADB
+                    ${AliPhysics_SOURCE_DIR}/PWG/Tools
+                    ${AliPhysics_SOURCE_DIR}/PWGGA/PWGGAUtils
+                    ${AliPhysics_SOURCE_DIR}/OADB
+                    ${AliPhysics_SOURCE_DIR}/TENDER/Tender
+                    ${AliPhysics_SOURCE_DIR}/TENDER/TenderSupplies
 		    )
 		  
 
@@ -50,9 +53,12 @@ generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 # Add a shared library
 add_library_tested(${MODULE} SHARED  ${SRCS} G__${MODULE}.cxx)
 
+set(ROOT_DEPENDENCIES Core EG GenVector Geom Gpad Hist MathCore Matrix Net Physics RIO Tree)
+set(ALIROOT_DEPENDENCIES ANALYSIS ANALYSISalice AOD EMCALbase EMCALUtils ESD STEERBase PWGTRD PWGEMCALbase PWGEMCALtrigger PWGflowTasks)
+
 # Generate the ROOT map
 # Dependecies
-set(LIBDEPS ANALYSISalice)
+set(LIBDEPS ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES})
 generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
 
 # Generate a PARfile target for this library

--- a/PWGCF/FEMTOSCOPY/PLamAnalysisPP/PWGCFPLamAnalysisPPLinkDef.h
+++ b/PWGCF/FEMTOSCOPY/PLamAnalysisPP/PWGCFPLamAnalysisPPLinkDef.h
@@ -1,11 +1,15 @@
+#ifdef __CINT__
+
 #pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ AliFemtoCutValues+;
-#pragma link C++ AliFemtoProtonParticle+;
-#pragma link C++ AliFemtoXiParticle+;
-#pragma link C++ AliFemtoLambdaParticle+;
-#pragma link C++ AliFemtoLambdaEvent+;
-#pragma link C++ AliFemtoLambdaEventCollection2+;
-#pragma link C++ AliAnalysisTaskPLFemto+;
+#pragma link C++ class AliFemtoCutValues+;
+#pragma link C++ class AliFemtoProtonParticle+;
+#pragma link C++ class AliFemtoXiParticle+;
+#pragma link C++ class AliFemtoLambdaParticle+;
+#pragma link C++ class AliFemtoLambdaEvent+;
+#pragma link C++ class AliFemtoLambdaEventCollection2+;
+#pragma link C++ class AliAnalysisTaskPLFemto+;
+
+#endif

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskPLFemtoRun2.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskPLFemtoRun2.C
@@ -1,0 +1,118 @@
+#include <stdio.h>
+#include <string.h>
+
+AliAnalysisTaskSE *AddTaskPLFemtoRun2(Int_t system=0/*0=pp,1=PbPb*/,
+					       Bool_t theMCon=kFALSE,Bool_t OnlineSearchV0=kFALSE,
+                 TString whichV0="Lambda",TString whichV0region="signal", TString trigger="kINT7",
+                 bool isRun1=true, const char *cutVariation = "0")
+{
+  TString suffix;
+  suffix.Form("%s", cutVariation);
+
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+
+  if (!mgr) 
+    {
+      ::Error("AddTaskPLFemtoSpectra", "No analysis manager to connect to.");
+      return NULL;
+    }
+
+  if (theMCon) {
+      // IMPORTANT - SET WHEN USING DIFFERENT PASS
+      AliAnalysisTaskPIDResponse *pidResponse =
+          reinterpret_cast<AliAnalysisTaskPIDResponse *>(
+            gInterpreter->ExecuteMacro("$ALICE_ROOT/ANALYSIS/macros/"
+                                       "AddTaskPIDResponse.C (kTRUE, kTRUE, "
+                                       "kTRUE, \"1\")"));
+    } else {
+      AliAnalysisTaskPIDResponse *pidResponse =
+          reinterpret_cast<AliAnalysisTaskPIDResponse *>(
+            gInterpreter->ExecuteMacro(
+              "$ALICE_ROOT/ANALYSIS/macros/AddTaskPIDResponse.C)"));
+    }
+
+  printf("CREATE TASK\n");
+  // create the task
+
+  AliAnalysisTaskPLFemto *task = new AliAnalysisTaskPLFemto(Form("AliAnalysisPLFemto_%s",cutVariation) ,OnlineSearchV0,whichV0,whichV0region);
+  task->SetRun1(isRun1);
+  if(trigger == "kINT7") task->SetTrigger(AliVEvent::kINT7);
+  else if(trigger == "kHighMultV0") task->SetTrigger(AliVEvent::kHighMultV0);
+  else if(trigger == "kMB") task->SetTrigger(AliVEvent::kMB);
+  else {
+      std::cout << "Requested trigger type unknown \n";
+      return nullptr;
+    }
+  task->SelectCollisionCandidates(task->GetTrigger());
+  if (task->GetTrigger() == AliVEvent::kHighMultV0) task->SetV0Percentile(0.1);
+
+  if(suffix == "0") task->SetSystematics(AliFemtoCutValues::kDefault);
+  else if(suffix == "1") task->SetSystematics(AliFemtoCutValues::kProtonVariationLowerPtThresholdDown);
+  else if(suffix == "2") task->SetSystematics(AliFemtoCutValues::kProtonVariationLowerPtThresholdUp);
+  else if(suffix == "3") task->SetSystematics(AliFemtoCutValues::kProtonVariationEtaRangeUp);
+  else if(suffix == "4") task->SetSystematics(AliFemtoCutValues::kProtonVariationEtaRangeDown);
+  else if(suffix == "5") task->SetSystematics(AliFemtoCutValues::kProtonVariationNsigmaUp);
+  else if(suffix == "6") task->SetSystematics(AliFemtoCutValues::kProtonVariationNsigmaDown);
+  else if(suffix == "7") task->SetSystematics(AliFemtoCutValues::kProtonTPCClusterUp);
+  else if(suffix == "8") task->SetSystematics(AliFemtoCutValues::kProtonVariationFilterBitGlobal);
+  else if(suffix == "9") task->SetSystematics(AliFemtoCutValues::kV0VariationLowerPtThresholdDown);
+  else if(suffix == "10") task->SetSystematics(AliFemtoCutValues::kV0VariationLowerPtThresholdUp);
+  else if(suffix == "11") task->SetSystematics(AliFemtoCutValues::kV0VariationCosinePointingUp);
+  else if(suffix == "12") task->SetSystematics(AliFemtoCutValues::kV0VariationNsigmaDown);
+  else if(suffix == "13") task->SetSystematics(AliFemtoCutValues::kV0VariationTPCClusterUp);
+  else if(suffix == "14") task->SetSystematics(AliFemtoCutValues::kV0VariationEtaRangeUp);
+  else if(suffix == "15") task->SetSystematics(AliFemtoCutValues::kV0VariationEtaRangeDown);
+  else if(suffix == "16") task->SetSystematics(AliFemtoCutValues::kV0VariationDCAatV0DecayDown);
+  else if(suffix == "17") task->SetSystematics(AliFemtoCutValues::kV0VariationDCADaughtersToPVUp);
+  else {
+      std::cout << "Unknown cut variation " << suffix << "\n";
+      return nullptr;
+    }
+
+  task->SetDebugLevel(0);
+  task->SetMC(theMCon);
+
+  mgr->AddTask(task);
+
+  // Create and connect containers for input/output
+  TString outputfile = AliAnalysisManager::GetCommonFileName();
+  outputfile += ":PWGCF_PLFemto_";
+  outputfile += suffix;
+
+  // ------ input data ------
+  TString input = "infemto";
+  input += suffix;
+  TString output1 = "Evtinfo_";
+  output1 += suffix;
+  TString outputEvt = "AliEventCuts_";
+  outputEvt += suffix;
+  TString output2 = "SPdir_";//directory for single particle quantities
+  output2 += suffix;
+  TString output3 = "PIDdir_";//directory for PID quantities
+  output3 += suffix;
+  TString output4 = "TPdir_";//directory for two particle quantities
+  output4 += suffix;
+
+  AliAnalysisDataContainer *cinput0  =  mgr->CreateContainer(input,TChain::Class(),AliAnalysisManager::kInputContainer);
+
+ // ----- output data -----
+
+  AliAnalysisDataContainer *coutput1 = mgr->CreateContainer(output1,TList::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
+  AliAnalysisDataContainer *coutput2 = mgr->CreateContainer(output2,TList::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
+  AliAnalysisDataContainer *coutput3 = mgr->CreateContainer(output3,TList::Class(),AliAnalysisManager::kOutputContainer, outputfile.Data());
+  AliAnalysisDataContainer *coutput4 = mgr->CreateContainer(output4,TList::Class(),AliAnalysisManager::kOutputContainer, outputfile.Data());
+  AliAnalysisDataContainer *coutput5 = mgr->CreateContainer(outputEvt,TList::Class(),AliAnalysisManager::kOutputContainer, outputfile.Data());
+
+  mgr->ConnectInput(task,0,mgr->GetCommonInputContainer());
+
+  mgr->ConnectOutput(task,1,coutput1);
+  mgr->ConnectOutput(task,2,coutput2);
+  mgr->ConnectOutput(task,3,coutput3);
+  mgr->ConnectOutput(task,4,coutput4);
+  mgr->ConnectOutput(task,5,coutput5);
+
+  return task;
+}
+
+
+


### PR DESCRIPTION
o Run1 part left intact, can be configured with the SetRun1 flag
o Usage of AliEventCuts for event selection
o Inclusion of high multiplicity events possible
o Multiplicity binning for the correlation function
o Pile-up rejection for the V0 daughters