### PR TITLE
[JES] Add lightweight task for jet energy scale

### DIFF
--- a/PWGJE/EMCALJetTasks/CMakeLists.txt
+++ b/PWGJE/EMCALJetTasks/CMakeLists.txt
@@ -135,6 +135,7 @@ set(SRCS
     Tracks/AliAnalysisTaskEmcalTriggerJets.cxx
     Tracks/AliAnalysisTaskEmcalTriggerJetsIDcorr.cxx
     Tracks/AliAnalysisTaskEmcalJetConstituentQA.cxx
+    Tracks/AliAnalysisTaskEmcalJetEnergyScale.cxx
     Tracks/AliAnalysisTaskEmcalTriggerSelectionTest.cxx
     UserTasks/AliAnalysisTaskJetUEStudies.cxx
     UserTasks/AliAnalysisTaskBackFlucRandomCone.cxx

--- a/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
+++ b/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
@@ -208,6 +208,7 @@
 #pragma link C++ class EmcalTriggerJets::AliAnalysisTaskEmcalTriggerJets+;
 #pragma link C++ class EmcalTriggerJets::AliAnalysisTaskEmcalTriggerJetsIDcorr+;
 #pragma link C++ class EmcalTriggerJets::AliAnalysisTaskEmcalJetConstituentQA+;
+#pragma link C++ class EmcalTriggerJets::AliAnalysisTaskEmcalJetEnergyScale+;
 #pragma link C++ class AliAnalysisTaskJetsEvshape+;
 #pragma link C++ class AliJetEmbeddingSelRhoTask+;
 #pragma link C++ class Cumulants+;

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergyScale.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergyScale.cxx
@@ -1,0 +1,189 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <array>
+#include <string>
+#include <sstream>
+#include <THistManager.h>
+#include <TCustomBinning.h>
+#include <TLinearBinning.h>
+
+#include "AliAODInputHandler.h"
+#include "AliAnalysisManager.h"
+#include "AliAnalysisTaskEmcalJetEnergyScale.h"
+#include "AliEmcalTriggerDecisionContainer.h"
+#include "AliEmcalAnalysisFactory.h"
+#include "AliLog.h"
+#include "AliVEventHandler.h"
+
+ClassImp(EmcalTriggerJets::AliAnalysisTaskEmcalJetEnergyScale)
+
+using namespace EmcalTriggerJets;
+
+AliAnalysisTaskEmcalJetEnergyScale::AliAnalysisTaskEmcalJetEnergyScale(const char *name):
+  AliAnalysisTaskEmcalJet(name, true),
+  fHistos(nullptr),
+  fNameDetectorJets(),
+  fNameParticleJets(),
+  fTriggerSelectionString(),
+  fNameTriggerDecisionContainer("EmcalTriggerDecision")
+{
+  DefineOutput(1, TList::Class());
+}
+
+AliAnalysisTaskEmcalJetEnergyScale::~AliAnalysisTaskEmcalJetEnergyScale() {
+  if(fHistos) delete fHistos;
+}
+
+void AliAnalysisTaskEmcalJetEnergyScale::UserCreateOutputObjects(){
+  AliAnalysisTaskEmcal::UserCreateOutputObjects();
+
+  TLinearBinning jetPtBinning(20, 0., 200.), nefbinning(100, 0., 1.), ptdiffbinning(200, -1., 1.);
+
+  const TBinning *diffbinning[3] = {&jetPtBinning, &nefbinning, &ptdiffbinning},
+                 *corrbinning[3] = {&jetPtBinning, &jetPtBinning, &nefbinning};
+
+  fHistos = new THistManager("energyScaleHistos");
+  fHistos->CreateTH1("hEventCounter", "Event counter", 1, 0.5, 1.5);
+  fHistos->CreateTHnSparse("hPtDiff", "pt diff det/part", 3., diffbinning, "s");
+  fHistos->CreateTHnSparse("hPtCorr", "Correlation det pt / part pt", 3., corrbinning, "s");
+  for(auto h : *(fHistos->GetListOfHistograms())) fOutput->Add(h);
+
+  PostData(1, fOutput);
+}
+
+Bool_t AliAnalysisTaskEmcalJetEnergyScale::Run(){
+  if(!fInputHandler->IsEventSelected() & AliVEvent::kINT7) return false;
+  if(IsSelectEmcalTriggers(fTriggerSelectionString.Data())){
+    auto mctrigger = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(fInputEvent->FindListObject(fNameTriggerDecisionContainer));
+    AliDebugStream(1) << "Found trigger decision object: " << (mctrigger ? "yes" : "no") << std::endl;
+    if(!mctrigger){
+      AliErrorStream() <<  "Trigger decision container with name " << fNameTriggerDecisionContainer << " not found in event - not possible to select EMCAL triggers" << std::endl;
+      return false;
+    }
+    if(!mctrigger->IsEventSelected(fTriggerSelectionString)) return false;
+  }
+  fHistos->FillTH1("hEventCounter", 1);
+
+  auto detjets = GetJetContainer(fNameDetectorJets),
+       partjets = GetJetContainer(fNameParticleJets);
+  if(!detjets || !partjets) {
+    AliErrorStream() << "At least one jet container missing, exiting ..." << std::endl;
+    return false;
+  }
+
+  for(auto detjet : detjets->accepted()){
+    auto partjet = detjet->ClosestJet();
+    if(!partjet) continue;
+    double pointCorr[3] = {partjet->Pt(), detjet->Pt(), detjet->NEF()},
+           pointDiff[3] = {partjet->Pt(), (detjet->Pt()-partjet->Pt())/partjet->Pt(), detjet->NEF()};
+    fHistos->FillTHnSparse("hPtDiff", pointDiff);
+    fHistos->FillTHnSparse("hPtCorr", pointCorr);
+  }
+  return true;
+}
+
+bool AliAnalysisTaskEmcalJetEnergyScale::IsSelectEmcalTriggers(const TString &triggerstring) const {
+  const std::array<TString, 8> kEMCALTriggers = {
+    "EJ1", "EJ2", "DJ1", "DJ2", "EG1", "EG2", "DG1", "DG2"
+  };
+  bool isEMCAL = false;
+  for(auto emcaltrg : kEMCALTriggers) {
+    if(triggerstring.Contains(emcaltrg)) {
+      isEMCAL = true;
+      break;
+    }
+  }
+  return isEMCAL;
+}
+
+AliAnalysisTaskEmcalJetEnergyScale *AliAnalysisTaskEmcalJetEnergyScale::AddTaskJetEnergyScale(AliJetContainer::EJetType_t jettype, Double_t jetradius, const char *trigger) {
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if(!mgr){
+    ::Error("EmcalTriggerJets::AliAnalysisTaskEmcalJetEnergyScale::AddTaskJetEnergyScale", "No analysis manager available");
+    return nullptr;
+  } 
+
+  auto inputhandler = mgr->GetInputEventHandler();
+  auto isAOD = inputhandler->IsA() == AliAODInputHandler::Class();
+
+  std::string jettypename;
+  AliJetContainer::JetAcceptanceType acceptance(AliJetContainer::kTPCfid);
+  bool addClusterContainer(false), addTrackContainer(false);
+  switch(jettype){
+    case AliJetContainer::kFullJet:
+        jettypename = "FullJet";
+        acceptance = AliJetContainer::kEMCALfid;
+        addClusterContainer = addTrackContainer = true;
+        break;
+    case AliJetContainer::kChargedJet:
+        jettypename = "ChargedJet";
+        acceptance = AliJetContainer::kTPCfid;
+        addTrackContainer = true;
+        break;
+    case AliJetContainer::kNeutralJet:
+        jettypename = "NeutralJet";
+        acceptance = AliJetContainer::kEMCALfid;
+        addClusterContainer = true;
+        break;
+  };
+
+  std::stringstream taskname, tag;
+  tag << jettypename << "_R" << std::setw(2) << std::setfill('0') << int(jetradius * 10.) << "_" << trigger;
+  taskname << "EnergyScaleTask_" << tag.str();
+  AliAnalysisTaskEmcalJetEnergyScale *energyscaletask = new AliAnalysisTaskEmcalJetEnergyScale(taskname.str().data());
+  mgr->AddTask(energyscaletask);
+
+  auto partcont = energyscaletask->AddMCParticleContainer("mcparticles");
+  partcont->SetMinPt(0.);
+
+  AliClusterContainer *clusters(nullptr);
+  if(addClusterContainer) {
+    clusters = energyscaletask->AddClusterContainer(EMCalTriggerPtAnalysis::AliEmcalAnalysisFactory::ClusterContainerNameFactory(isAOD));
+  }
+  AliTrackContainer *tracks(nullptr);
+  if(addTrackContainer) {
+    tracks = energyscaletask->AddTrackContainer(EMCalTriggerPtAnalysis::AliEmcalAnalysisFactory::TrackContainerNameFactory(isAOD));
+  }
+
+  auto contpartjet = energyscaletask->AddJetContainer(jettype, AliJetContainer::antikt_algorithm, AliJetContainer::E_scheme, jetradius,
+                                                      acceptance, partcont, nullptr, "Jet");
+  contpartjet->SetName("particleLevelJets");
+  energyscaletask->SetNamePartJetContainer("particleLevelJets");
+
+  auto contdetjet = energyscaletask->AddJetContainer(jettype, AliJetContainer::antikt_algorithm, AliJetContainer::E_scheme, jetradius,
+                                                     acceptance, tracks, clusters, "Jet");
+  contdetjet->SetName("detectorLevelJets");
+  energyscaletask->SetNameDetJetContainer("detectorLevelJets");
+
+  std::stringstream outnamebuilder, listnamebuilder;
+  listnamebuilder << "EnergyScaleHists_" << tag.str();
+  outnamebuilder << mgr->GetCommonFileName() << ":EnergyScaleResults_" << tag.str();
+
+  mgr->ConnectInput(energyscaletask, 0, mgr->GetCommonInputContainer());
+  mgr->ConnectOutput(energyscaletask, 1, mgr->CreateContainer(listnamebuilder.str().data(), TList::Class(), AliAnalysisManager::kOutputContainer, outnamebuilder.str().data()));
+  return energyscaletask;
+} 

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergyScale.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergyScale.h
@@ -1,0 +1,96 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIANALYSISTASKEMCALJETENERGYSCALE_H
+#define ALIANALYSISTASKEMCALJETENERGYSCALE_H
+
+#if !(defined __CINT__ || defined __MAKECINT__)
+#if __cplusplus >= 201103L
+// In c++11 mode we will rely on c++11 keywords also in header files 
+// (i.e. final, override, default, delete)
+#define USECXX11HEADERS
+#endif
+#endif
+
+#include <TString.h>
+#include "AliAnalysisTaskEmcalJet.h"
+#include "AliJetContainer.h"
+
+class THistManager;
+
+namespace EmcalTriggerJets {
+
+class AliAnalysisTaskEmcalJetEnergyScale : public AliAnalysisTaskEmcalJet {
+public:
+#ifdef USECXX11HEADERS
+  AliAnalysisTaskEmcalJetEnergyScale() = default;
+  AliAnalysisTaskEmcalJetEnergyScale(const char *name);
+  AliAnalysisTaskEmcalJetEnergyScale(const AliAnalysisTaskEmcalJetEnergyScale &) = delete;
+  AliAnalysisTaskEmcalJetEnergyScale &operator=(const AliAnalysisTaskEmcalJetEnergyScale &) = delete;
+  ~AliAnalysisTaskEmcalJetEnergyScale() override;
+#else
+  AliAnalysisTaskEmcalJetEnergyScale();
+  AliAnalysisTaskEmcalJetEnergyScale(const char *name);
+  virtual ~AliAnalysisTaskEmcalJetEnergyScale();
+#endif
+
+  void SetNameDetJetContainer(const char *name)  { fNameDetectorJets = name; }
+  void SetNamePartJetContainer(const char *name) { fNameParticleJets = name; }
+  void SetTriggerName(const char *name)          { fTriggerSelectionString = name; }
+
+  static AliAnalysisTaskEmcalJetEnergyScale *AddTaskJetEnergyScale(
+    AliJetContainer::EJetType_t       jetType,
+    Double_t                          radius,
+    const char *                      trigger
+  );
+
+protected:
+#ifdef USECXX11HEADERS
+  void UserCreateOutputObjects() final;
+  Bool_t Run() final;
+#else
+  virtual void UserCreateOutputObjects();
+  virtual Bool_t Run(); 
+#endif
+  bool IsSelectEmcalTriggers(const TString &triggerstring) const;
+
+private:
+  THistManager                *fHistos;                       //!<! Histogram collection
+  TString                     fNameDetectorJets;              ///< Name of the data jet container
+  TString                     fNameParticleJets;              ///< Name of the MC jet container
+  TString                     fTriggerSelectionString;        ///< Trigger selection string
+  TString                     fNameTriggerDecisionContainer;  ///< Global trigger decision container
+
+#ifndef USECXX11HEADERS
+  AliAnalysisTaskEmcalJetEnergyScale(const AliAnalysisTaskEmcalJetEnergyScale &);
+  AliAnalysisTaskEmcalJetEnergyScale &operator=(const AliAnalysisTaskEmcalJetEnergyScale &);
+#endif
+
+  ClassDef(AliAnalysisTaskEmcalJetEnergyScale, 1);
+};
+
+}
+#endif // ALIANALYSISTASKEMCALJETENERGYSCALE_H

--- a/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJetEnergyScale.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJetEnergyScale.C
@@ -1,0 +1,7 @@
+#ifndef __CINT__
+#include "AliAnalysisTaskEmcalJetEnergyScale.h"
+#endif
+
+EmcalTriggerJets::AliAnalysisTaskEmcalJetEnergyScale *AddTaskEmcalJetEnergyScale(AliJetContainer::EJetType_t jettype, double jetradius, const char *trigger){
+  return EmcalTriggerJets::AliAnalysisTaskEmcalJetEnergyScale(jettype, jetradius, trigger);
+}


### PR DESCRIPTION
Add lightweight task for jet energy scale filling only two
THnSparses
- correlation between part and det jet pt
- difference between part and det jet pt
Det NEF included in task for NEF cuts.

For configuration the task needs
- Jet type (charged, full, neutral)
- Jet radius
- Trigger (INT7 or EMCAL jet trigger)