### PR TITLE
Update leading hadron calculation and docs

### DIFF
--- a/PWG/JETFW/AliJetContainer.cxx
+++ b/PWG/JETFW/AliJetContainer.cxx
@@ -633,9 +633,11 @@ Double_t AliJetContainer::GetLeadingHadronPt(const AliEmcalJet *jet) const
  * Retrieve the 4-momentum of leading hadron of the jet.
  * The mass hypothesis is always set to the pion mass (0.139 GeV/c^2).
  * NOTE: The cluster energy used to calculate the momentum will always be
- *       the _raw_ energy because the cluster container is not used. Amongst
- *       other possible alternatives, the user could use the neutral energy
- *       calculated at jet finding via AliEmcalJet::MaxNeutralEnergy() (for example).
+ *       the _raw_ energy because the cluster container is not used. There are a
+ *       number of possible alternative approaches to use the user selected energy
+ *       (such as the hadronic corrected energy). One possible alternative which
+ *       uses the cluster energy selected during jet finding is to access the
+ *       leading AliEmcalClusterJetConstituent.
  * @param[out] mom Reference to a TLorentzVector object where the result is returned
  * @param[in] jet Pointer to a AliEmcalJet object
  */

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHPerformance.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHPerformance.cxx
@@ -364,6 +364,9 @@ void AliAnalysisTaskEmcalJetHPerformance::CreateResponseMatrix()
       AliDebugStream(4) << "Rejecting jet due to momentum fraction of " << sharedFraction << ", smaller than the minimum.\n";
       continue;
     }
+    else {
+      AliDebugStream(4) << "Jet passed momentum fraction cut with value of " << sharedFraction << "\n";
+    }
 
     // Apply additional selection to jet 2
     // TODO: Should we apply acceptance criteria to jet 2 here?

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHUtils.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHUtils.cxx
@@ -42,17 +42,10 @@ double AliAnalysisTaskEmcalJetHUtils::GetLeadingHadronPt(AliEmcalJet * jet, AliA
   double maxClusterPt = 0;
 
   if (leadingHadronType == kCharged || leadingHadronType == kBoth) {
-    auto particleConstituents = jet->GetParticleConstituents();
-    for (auto particle : particleConstituents) {
-      if (particle.Pt() > maxTrackPt) {
-        maxTrackPt  = particle.Pt();
-      }
-    }
-    // Swtich to this method once it is fixed in AliEmcalJet
-    /*auto particle = jet->GetLeadingParticleConstituent();
+    auto particle = jet->GetLeadingParticleConstituent();
     if (particle) {
       maxTrackPt = particle->Pt();
-    }*/
+    }
   }
   if (leadingHadronType == kNeutral || leadingHadronType == kBoth) {
     // NOTE: We don't want to use jet->MaxNeutralPt() because this uses energy
@@ -60,22 +53,12 @@ double AliAnalysisTaskEmcalJetHUtils::GetLeadingHadronPt(AliEmcalJet * jet, AliA
     //       strictly wrong, it can be rather misleading to have a leading neutral
     //       particle value when we are really interested in the cluster pt that is
     //       only meaningful at detector level.
-    auto clusterConstituents = jet->GetClusterConstituents();
-    for (auto cluster : clusterConstituents) {
-      AliDebugGeneralStream("AliAnalysisTaskEmcalJetHUtils", 4) << "global index " << cluster.GetGlobalIndex() << ", E(): " << cluster.E() << ", pt(): " << cluster.Pt() << "\n";
-      if (cluster.Pt() > maxClusterPt) {
-        maxClusterPt = cluster.Pt();
-      }
-    }
-    AliDebugGeneralStream("AliAnalysisTaskEmcalJetHUtils", 4) << "N clusters: " << clusterConstituents.size() << ", Max cluster pt: " << maxClusterPt << "\n";
-
-    // Swtich to this method once it is fixed in AliEmcalJet
-    /*auto cluster = jet->GetLeadingClusterConstituent();
+    auto cluster = jet->GetLeadingClusterConstituent();
     if (cluster) {
       // Uses the energy definition that was used when the constituent was created
       // to calculate the Pt(). Usually, this would be the hadronic corrected energy
       maxClusterPt = cluster->Pt();
-    }*/
+    }
   }
 
   // The max value will be 0 unless it was filled. Thus, it will only be greater if


### PR DESCRIPTION
Update method committed in #4499 since the standard method was fixed
in #4522. Also update docs in the jet container to better describe
various options to retrieve the leading hadron momentum.

Thanks @mfasDa for the fix!