### PR TITLE
EMCal CorrFW: Fix additional dictionary warning

### DIFF
--- a/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
+++ b/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
@@ -47,6 +47,7 @@
 #pragma link C++ class  AliEmcalCorrectionClusterTrackMatcher+;
 #pragma link C++ class  AliEmcalCorrectionClusterHadronicCorrection+;
 #pragma link C++ class  std::map<AliVTrack *,AliParticleContainer *>+;
+#pragma link C++ class  std::pair<AliVTrack *,AliParticleContainer *>+;
 #pragma link C++ class  AliEmcalCorrectionPHOSCorrections+;
 #pragma link C++ class  AliAnalysisTaskEmcalOccupancy+;
 


### PR DESCRIPTION
Add dictionary entry for pair of AOD track and particle container.
Introduced in a0e3356 and partially fixed in 8de9429.