### PR TITLE
EMCal CorrFW, YAML: Refactor, add string to enum maps

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliClusterContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliClusterContainer.cxx
@@ -30,6 +30,14 @@
 ClassImp(AliClusterContainer);
 /// \endcond
 
+// string to enum map for use with the %YAML config
+const std::map <std::string, AliVCluster::VCluUserDefEnergy_t> AliClusterContainer::fgkClusterEnergyTypeMap = {
+  {"kNonLinCorr", AliVCluster::kNonLinCorr },
+  {"kHadCorr", AliVCluster::kHadCorr },
+  {"kUserDefEnergy1", AliVCluster::kUserDefEnergy1 },
+  {"kUserDefEnergy2", AliVCluster::kUserDefEnergy2 }
+};
+
 // Properly instantiate the object
 AliEmcalContainerIndexMap <TClonesArray, AliVCluster> AliClusterContainer::fgEmcalContainerIndexMap;
 

--- a/PWG/EMCAL/EMCALbase/AliClusterContainer.h
+++ b/PWG/EMCAL/EMCALbase/AliClusterContainer.h
@@ -7,6 +7,7 @@ class TLorentzVector;
 
 class AliVEvent;
 
+#include <map>
 #include <TArrayI.h>
 #include <AliVCluster.h>
 
@@ -32,6 +33,9 @@ typedef EMCALIterableContainer::AliEmcalIterableContainerT<AliVCluster, EMCALIte
 class AliClusterContainer : public AliEmcalContainer {
  public:
   typedef enum AliVCluster::VCluUserDefEnergy_t VCluUserDefEnergy_t;
+
+  /// Relates string to the cluster energy enumeration for %YAML configuration
+  static const std::map <std::string, VCluUserDefEnergy_t> fgkClusterEnergyTypeMap; //!<!
 
   AliClusterContainer();
   AliClusterContainer(const char *name); 

--- a/PWG/EMCAL/EMCALbase/AliEmcalContainerUtils.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalContainerUtils.cxx
@@ -13,6 +13,76 @@
 
 #include "AliAnalysisTaskEmcalEmbeddingHelper.h"
 
+// string to enum map for use with the %YAML config
+const std::map <std::string, AliVEvent::EOfflineTriggerTypes> AliEmcalContainerUtils::fgkPhysicsSelectionMap = {
+  {"kMB", AliVEvent::kMB},
+  {"kINT1", AliVEvent::kINT1},
+  {"kINT7", AliVEvent::kINT7},
+  {"kMUON", AliVEvent::kMUON},
+  {"kHighMult", AliVEvent::kHighMult},
+  {"kHighMultSPD", AliVEvent::kHighMultSPD},
+  {"kEMC1", AliVEvent::kEMC1},
+  {"kCINT5", AliVEvent::kCINT5},
+  {"kINT5", AliVEvent::kINT5},
+  {"kCMUS5", AliVEvent::kCMUS5},
+  {"kMUSPB", AliVEvent::kMUSPB},
+  {"kINT7inMUON", AliVEvent::kINT7inMUON},
+  {"kMuonSingleHighPt7", AliVEvent::kMuonSingleHighPt7},
+  {"kMUSH7", AliVEvent::kMUSH7},
+  {"kMUSHPB", AliVEvent::kMUSHPB},
+  {"kMuonLikeLowPt7", AliVEvent::kMuonLikeLowPt7},
+  {"kMUL7", AliVEvent::kMUL7},
+  {"kMuonLikePB", AliVEvent::kMuonLikePB},
+  {"kMuonUnlikeLowPt7", AliVEvent::kMuonUnlikeLowPt7},
+  {"kMUU7", AliVEvent::kMUU7},
+  {"kMuonUnlikePB", AliVEvent::kMuonUnlikePB},
+  {"kEMC7", AliVEvent::kEMC7},
+  {"kEMC8", AliVEvent::kEMC8},
+  {"kMUS7", AliVEvent::kMUS7},
+  {"kMuonSingleLowPt7", AliVEvent::kMuonSingleLowPt7},
+  {"kPHI1", AliVEvent::kPHI1},
+  {"kPHI7", AliVEvent::kPHI7},
+  {"kPHI8", AliVEvent::kPHI8},
+  {"kPHOSPb", AliVEvent::kPHOSPb},
+  {"kEMCEJE", AliVEvent::kEMCEJE},
+  {"kEMCEGA", AliVEvent::kEMCEGA},
+  {"kHighMultV0", AliVEvent::kHighMultV0},
+  {"kCentral", AliVEvent::kCentral},
+  {"kSemiCentral", AliVEvent::kSemiCentral},
+  {"kDG", AliVEvent::kDG},
+  {"kDG5", AliVEvent::kDG5},
+  {"kZED", AliVEvent::kZED},
+  {"kSPI7", AliVEvent::kSPI7},
+  {"kSPI", AliVEvent::kSPI},
+  {"kINT8", AliVEvent::kINT8},
+  {"kMuonSingleLowPt8", AliVEvent::kMuonSingleLowPt8},
+  {"kMuonSingleHighPt8", AliVEvent::kMuonSingleHighPt8},
+  {"kMuonLikeLowPt8", AliVEvent::kMuonLikeLowPt8},
+  {"kMuonUnlikeLowPt8", AliVEvent::kMuonUnlikeLowPt8},
+  {"kMuonUnlikeLowPt0", AliVEvent::kMuonUnlikeLowPt0},
+  {"kUserDefined", AliVEvent::kUserDefined},
+  {"kTRD", AliVEvent::kTRD},
+  {"kMuonCalo", AliVEvent::kMuonCalo},
+  {"kFastOnly", AliVEvent::kFastOnly},
+  {"kAny", AliVEvent::kAny},
+  {"kAnyINT", AliVEvent::kAnyINT}
+};
+
+/**
+ * Determines the physics selection that is retrieved from a YAML configuration. Note that the result is an OR of
+ * all of the individual selections in the input.
+ *
+ * @return The desired trigger selection. Note that a `UInt_t` is what is used for fOfflineTriggerMask, so it's fine to return it here.
+ */
+UInt_t AliEmcalContainerUtils::DeterminePhysicsSelectionFromYAML(const std::vector<std::string> & selections)
+{
+  UInt_t physicsSelection = 0;
+  for (auto sel : selections) {
+    physicsSelection |= fgkPhysicsSelectionMap.at(sel);
+  }
+  return physicsSelection;
+}
+
 /**
  * Determines the "usedefault" pattern using the Analysis Manager to determine the datatype automatically.
  * This will often work fine, but it may not always. Note that the use cause for this function is assumed to

--- a/PWG/EMCAL/EMCALbase/AliEmcalContainerUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalContainerUtils.h
@@ -2,10 +2,11 @@
 #define ALIEMCALCONTAINERUTILS_H
 
 #include <string>
+#include <map>
 
 #include <TObjArray.h>
 
-class AliVEvent;
+#include <AliVEvent.h>
 
 /**
  * @namespace AliEmcalContainerUtils
@@ -47,6 +48,11 @@ class AliEmcalContainerUtils {
     kCluster = 1,                  //!<! Cluster container
     kTrack = 2,                    //!<! Track container
   };
+
+  // YAML Configuration helpers
+  /// Relates string to the physics selection enumeration for %YAML configuration
+  static const std::map <std::string, AliVEvent::EOfflineTriggerTypes> fgkPhysicsSelectionMap; //!<!
+  UInt_t DeterminePhysicsSelectionFromYAML(const std::vector<std::string> & selections);
 
   // Utility functions
   static std::string DetermineUseDefaultName(InputObject_t objType);

--- a/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
@@ -49,6 +49,19 @@ ClassImp(AliTrackContainer);
 
 TString AliTrackContainer::fgDefTrackCutsPeriod = "";
 
+// string to enum map for use with the %YAML config
+const std::map <std::string, AliEmcalTrackSelection::ETrackFilterType_t> AliTrackContainer::fgkTrackFilterTypeMap = {
+  {"kNoTrackFilter", AliEmcalTrackSelection::kNoTrackFilter },
+  {"kCustomTrackFilter", AliEmcalTrackSelection::kCustomTrackFilter },
+  {"kHybridTracks",  AliEmcalTrackSelection::kHybridTracks },
+  {"kTPCOnlyTracks", AliEmcalTrackSelection::kTPCOnlyTracks },
+  {"kITSPureTracks", AliEmcalTrackSelection::kITSPureTracks },
+  {"kHybridTracks2010wNoRefit", AliEmcalTrackSelection::kHybridTracks2010wNoRefit },
+  {"kHybridTracks2010woNoRefit", AliEmcalTrackSelection::kHybridTracks2010woNoRefit },
+  {"kHybridTracks2011wNoRefit", AliEmcalTrackSelection::kHybridTracks2011wNoRefit },
+  {"kHybridTracks2011woNoRefit", AliEmcalTrackSelection::kHybridTracks2011woNoRefit }
+};
+
 /**
  * Default constructor.
  */

--- a/PWG/EMCAL/EMCALbase/AliTrackContainer.h
+++ b/PWG/EMCAL/EMCALbase/AliTrackContainer.h
@@ -32,6 +32,8 @@ class AliVParticle;
 class AliVCuts;
 class AliTLorentzVector;
 
+#include <map>
+
 #include <TArrayC.h>
 
 #include "AliVTrack.h"
@@ -91,6 +93,9 @@ class AliTrackContainer : public AliParticleContainer {
   };
 
   typedef AliEmcalTrackSelection::ETrackFilterType_t ETrackFilterType_t;
+
+  /// Relates string to the track filter enumeration for %YAML configuration
+  static const std::map <std::string, AliEmcalTrackSelection::ETrackFilterType_t> fgkTrackFilterTypeMap; //!<!
 
   /**
    * @enum ETrackType_t

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
@@ -34,20 +34,6 @@ ClassImp(AliEmcalCorrectionTask);
 ClassImp(AliEmcalCorrectionCellContainer);
 /// \endcond
 
-const std::map <std::string, AliVCluster::VCluUserDefEnergy_t> AliEmcalCorrectionTask::fgkClusterEnergyTypeMap = {
-  {"kNonLinCorr", AliVCluster::kNonLinCorr },
-  {"kHadCorr", AliVCluster::kHadCorr },
-  {"kUserDefEnergy1", AliVCluster::kUserDefEnergy1 },
-  {"kUserDefEnergy2", AliVCluster::kUserDefEnergy2 }
-};
-
-const std::map <std::string, AliEmcalTrackSelection::ETrackFilterType_t> AliEmcalCorrectionTask::fgkTrackFilterTypeMap = {
-  {"kNoTrackFilter", AliEmcalTrackSelection::kNoTrackFilter },
-  {"kCustomTrackFilter", AliEmcalTrackSelection::kCustomTrackFilter },
-  {"kHybridTracks",  AliEmcalTrackSelection::kHybridTracks },
-  {"kTPCOnlyTracks", AliEmcalTrackSelection::kTPCOnlyTracks }
-};
-
 /**
  * Default constructor.
  */
@@ -908,7 +894,7 @@ void AliEmcalCorrectionTask::SetupContainer(const AliEmcalContainerUtils::InputO
     /*result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "defaultClusterEnergy", tempString, false);
     if (result) {
       // Need to get the enumeration
-      AliVCluster::VCluUserDefEnergy_t clusterEnergyType = fgkClusterEnergyTypeMap.at(tempString);
+      AliVCluster::VCluUserDefEnergy_t clusterEnergyType = AliClusterContainre::fgkClusterEnergyTypeMap.at(tempString);
       AliDebugStream(2) << clusterContainer->GetName() << ": Setting cluster energy type to " << clusterEnergyType << std::endl;
       clusterContainer->SetDefaultClusterEnergy(clusterEnergyType);
     }*/
@@ -955,8 +941,8 @@ void AliEmcalCorrectionTask::SetupContainer(const AliEmcalContainerUtils::InputO
     result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "trackFilterType", tempString, false);
     if (result) {
       // Need to get the enumeration
-      AliEmcalTrackSelection::ETrackFilterType_t trackFilterType = fgkTrackFilterTypeMap.at(tempString);
-      AliDebugStream(2) << trackContainer->GetName() << ": Setting trackFilterType of " << trackFilterType << std::endl;
+      AliEmcalTrackSelection::ETrackFilterType_t trackFilterType = AliTrackContainer::fgkTrackFilterTypeMap.at(tempString);
+      AliDebugStream(2) << trackContainer->GetName() << ": Setting trackFilterType of " << trackFilterType << " (" << tempString << ")\n";
       trackContainer->SetTrackFilterType(trackFilterType);
     }
 

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
@@ -53,12 +53,6 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
     kpA       = 2  //!<! Proton-Nucleus
   };
 
-  /// Relates string to the cluster energy enumeration for %YAML configuration
-  static const std::map <std::string, AliVCluster::VCluUserDefEnergy_t> fgkClusterEnergyTypeMap; //!<!
-
-  /// Relates string to the track filter enumeration for %YAML configuration
-  static const std::map <std::string, AliEmcalTrackSelection::ETrackFilterType_t> fgkTrackFilterTypeMap; //!<!
-
   AliEmcalCorrectionTask();
   AliEmcalCorrectionTask(const char * name);
   // Implemented using copy-and-swap mechanism
@@ -256,7 +250,7 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
   TList *                     fOutput;                     //!<! Output for histograms
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionTask, 5); // EMCal correction task
+  ClassDef(AliEmcalCorrectionTask, 6); // EMCal correction task
   /// \endcond
 };
 


### PR DESCRIPTION
String to enum maps are used for accessing them in YAML configuration
files. The following maps are refactored to allow for more general use:
- Cluster default energy
- Track selection

Additionally, a map is added for physics selection, allowing easier
configuration of tasks.

I plan to commit this right before the tag, but code review is appreciated!