### PR TITLE
Version with new 0nX0n selection (Ezdc < 1500)

### DIFF
--- a/PWGUD/UPC/AliAnalysisTaskUpcEtaC.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUpcEtaC.cxx
@@ -1374,8 +1374,8 @@ void AliAnalysisTaskUpcEtaC::RunAODhist()
   fHistNeventsEtaC3PiPiChannel->Fill(4);
   fHistNeventsEtaC4KaonChannel->Fill(4);
 
-  if( fZNAenergy > 11500 || fZNCenergy > 11500) return; // was 8200
-  if( fZNAenergy <= 1500 || fZNCenergy <= 1500) return;
+  //  if( fZNAenergy > 11500 || fZNCenergy > 11500) return; // was 8200
+  if( fZNAenergy > 1500 || fZNCenergy > 1500) return; //>1500 for 0n0n or <= 1500 for XnXn
 
   fHistNeventsEtaCK0sChannel->Fill(5);
   fHistNeventsEtaC->Fill(5); 


### PR DESCRIPTION
New version for ZDC study using 1500 as the ZDC energy threshold for 0n. In this version ZDCAenergy <1500 and ZDCCenergy < 1500 to select 0n0n.