### PR TITLE
Global Track Array Changes and Minimal Booking

### DIFF
--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.cxx
@@ -29,14 +29,6 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists()
 
 AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(
     AliFemtoDreamCollConfig *conf,bool MinimalBooking) {
-  fResults=new TList();
-  fResults->SetName("Results");
-  fResults->SetOwner();
-  if (!fMinimalBooking) {
-    fQA=new TList();
-    fQA->SetName("PairQA");
-    fQA->SetOwner();
-  }
   fMinimalBooking=MinimalBooking;
   fMomentumResolution=conf->GetDoMomResolution();
   fDoMultBinning=conf->GetDoMultBinning();
@@ -53,7 +45,7 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(
   if (nHists!=(int)NBinsHist.size() || nHists!=(int)kRelMin.size() ||
       nHists!=(int)kRelMax.size()) {
     //Todo: Replace by AliFatal!
-    std::cout<<"something went horribly wrong!"<<std::endl;
+    std::cout<<"Initialzing the bin sizes, something went horribly wrong!"<<std::endl;
   }
   //The way the histograms are assigned later is going to be for example for
   //4 different particle species X1,X2,X3,X4:
@@ -66,13 +58,27 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(
   //in the AliFemtoDreamPartCollection::SetEvent Method, X2 to the second and
   //so on.
   //in case we only book the most basic things we don't need this
+  fResults=new TList();
+  fResults->SetName("Results");
+  fResults->SetOwner();
+
   if (!fMinimalBooking) {
+    fQA=new TList();
+    fQA->SetName("PairQA");
+    fQA->SetOwner();
+
     fPairQA=new TList*[nHists];
     fPairCounterSE=new TH2F*[nHists];
     fPairCounterME=new TH2F*[nHists];
     if (fMomentumResolution) {
       fMomResolution=new TH2F*[nHists];
     }
+  } else {
+    fQA=0;
+    fPairQA=0;
+    fPairCounterSE=0;
+    fPairCounterME=0;
+    fMomResolution=0;
   }
   //we always want to do this, regardless of the booking type!
   fPairs=new TList*[nHists];

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrack.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrack.cxx
@@ -60,7 +60,9 @@ void AliFemtoDreamTrack::SetTrack(AliAODTrack *track) {
       AliFatal("AliFemtoSPTrack::SetTrack No fGTI Set");
       fGlobalTrack=NULL;
     }else if(-trackID-1 >= fTrackBufferSize){
-      AliFatal("Buffer Size too small");
+//      AliFatal("Buffer Size too small");
+      this->fIsSet=false;
+      fIsReset=false;
       fGlobalTrack=NULL;
     }else if(!CheckGlobalTrack(trackID)){
       fGlobalTrack=NULL;

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.cxx
@@ -66,7 +66,9 @@ void AliFemtoDreamv0::Setv0(AliAODEvent *evt,AliAODv0* v0) {
 
 void AliFemtoDreamv0::SetDaughter(AliAODv0 *v0) {
   if (v0->GetPosID()>=fTrackBufferSize||v0->GetNegID()>=fTrackBufferSize) {
-    AliFatal("fGTI too small");
+    std::cout<<"fGTI too small, no Global Tracks to work with, PosID:  "
+        << v0->GetPosID() << " and NegID: " << v0->GetNegID() << std::endl;
+    this->fHasDaughter=false;
   } else {
     fpDaug->SetGlobalTrackInfo(fGTI,fTrackBufferSize);
     fnDaug->SetGlobalTrackInfo(fGTI,fTrackBufferSize);

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoContributionSplitting.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoContributionSplitting.C
@@ -299,7 +299,7 @@ AliAnalysisTaskSE* AddTaskFemtoContributionSplitting(TString CentEst="kInt7")
   }
   task->SetDebugLevel(0);
   task->SetEvtCutQA(true);
-  task->SetTrackBufferSize(2500);
+  task->SetTrackBufferSize(10000);
   task->SetEventCuts(evtCuts);
   task->SetTrackCuts(TrackCuts);
   task->SetAntiTrackCuts(AntiTrackCuts);

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoDream.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoDream.C
@@ -301,7 +301,7 @@ AliAnalysisTaskSE* AddTaskFemtoDream(
 	}
 	task->SetDebugLevel(0);
 	task->SetEvtCutQA(true);
-	task->SetTrackBufferSize(2500);
+	task->SetTrackBufferSize(10000);
 	task->SetEventCuts(evtCuts);
 	task->SetTrackCuts(TrackCuts);
 	task->SetAntiTrackCuts(AntiTrackCuts);

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoDreamSysVar.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoDreamSysVar.C
@@ -412,7 +412,7 @@ AliAnalysisTaskSE* AddTaskFemtoDreamSysVar(
   }
   task->SetDebugLevel(0);
   task->SetEvtCutQA(false);
-  task->SetTrackBufferSize(2500);
+  task->SetTrackBufferSize(10000);
   task->SetEventCuts(evtCuts);
   task->SetTrackCuts(TrackCuts);
   task->SetAntiTrackCuts(AntiTrackCuts);


### PR DESCRIPTION
Wrong order of initialization in the CorrHists caused undefined behaviour. Improvement of the handeling of the too small global track array size, only a warning will be thrown and the task will still run. The track and v0 candidates are rejected then. 