### PR TITLE
Change access specifier to access AliCaloCellsQA field in derived classes

### DIFF
--- a/PWGGA/PHOSTasks/CaloCellQA/AliAnalysisTaskCaloCellsQA.h
+++ b/PWGGA/PHOSTasks/CaloCellQA/AliAnalysisTaskCaloCellsQA.h
@@ -50,7 +50,7 @@ private:
   AliAnalysisTaskCaloCellsQA(const AliAnalysisTaskCaloCellsQA &);
   AliAnalysisTaskCaloCellsQA & operator = (const AliAnalysisTaskCaloCellsQA &);
 
-private:
+protected:
   Bool_t           fkAvoidPileup;     // flag not to process pileup events
   AliCaloCellsQA*  fCellsQA;          // analysis instance
   TString          fOutfile;          // output file name


### PR DESCRIPTION
Now it's impossible to update `AliCaloCellsQA` without copying the existing code. The `private` hides the variables so they can't be accessed in derived (child) classes. 