### PR TITLE
[Hotfix] Fix auto-configuration for periods

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerSelection.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerSelection.cxx
@@ -107,7 +107,7 @@ void AliAnalysisTaskEmcalTriggerSelection::MakeQA(const AliEmcalTriggerDecisionC
 }
 
 void AliAnalysisTaskEmcalTriggerSelection::AutoConfigure(const char *period) {
-  if(Is2012PP(period)) ConfigurePP2016();
+  if(Is2012PP(period)) ConfigurePP2012();
   if(Is2016PP(period)) ConfigurePP2016();
   if(Is2012MCPP(period)) ConfigureMCPP2012();
   if(Is2016MCPP(period)) ConfigureMCPP2016();
@@ -134,7 +134,7 @@ Bool_t AliAnalysisTaskEmcalTriggerSelection::Is2016PP(const char *dataset) const
       if(subperiod > 'g' && subperiod < 'q') return true;
     }
     if(datasetstring.Contains("lhc17")) {
-      if((subperiod > 'c' && subperiod < 'n') || (subperiod == 'o') | (subperiod < 'r')) return true;
+      if((subperiod > 'c' && subperiod < 'n') || (subperiod == 'o') || (subperiod < 'r')) return true;
     }
     if(datasetstring.Contains("lhc18")) {
       // 2018 runs will follow when taken

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalClustersRef.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalClustersRef.cxx
@@ -198,14 +198,22 @@ bool AliAnalysisTaskEmcalClustersRef::Run(){
   int energycomp = -1;
   // get fired trigger patches from the trigger selection task
   if(auto trgsel = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(fInputEvent->FindListObject("EmcalTriggerDecision"))){
+    /*
+    for(auto t : *(trgsel->GetListOfTriggerDecisions())){
+      auto dec  = static_cast<PWG::EMCAL::AliEmcalTriggerDecision *>(t);
+      std::cout << "Found trigger decision " << dec->GetName() << std::endl;
+    }
+    */
     for(auto t : l1triggers){
       auto decision = trgsel->FindTriggerDecision(t.Data());
-      patchhandlers[t] = decision->GetAcceptedPatches();
-      if(energycomp < 0) {
-        switch(decision->GetSelectionCuts()->GetSelectionMethod()){
-          case PWG::EMCAL::AliEmcalTriggerSelectionCuts::kADC: energycomp = 0; break;
-          case PWG::EMCAL::AliEmcalTriggerSelectionCuts::kEnergyOffline: energycomp = 1; break;
-          case PWG::EMCAL::AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared: energycomp = 2; break;
+      if(decision){
+        patchhandlers[t] = decision->GetAcceptedPatches();
+        if(energycomp < 0) {
+          switch(decision->GetSelectionCuts()->GetSelectionMethod()){
+            case PWG::EMCAL::AliEmcalTriggerSelectionCuts::kADC: energycomp = 0; break;
+            case PWG::EMCAL::AliEmcalTriggerSelectionCuts::kEnergyOffline: energycomp = 1; break;
+            case PWG::EMCAL::AliEmcalTriggerSelectionCuts::kEnergyOfflineSmeared: energycomp = 2; break;
+          }
         }
       }
     }


### PR DESCRIPTION
Small bugs (improper call of config function for periods)
prevented configuration of the matching period after the
recent update for pp 2012 and 2017/18.

In addition further cross check for for availability of
trigger decision objects in cluster task