### PR TITLE
Fixing output name

### DIFF
--- a/PWGPP/TOF/AddTaskTOFqaID.C
+++ b/PWGPP/TOF/AddTaskTOFqaID.C
@@ -109,12 +109,20 @@ AliAnalysisTaskTOFqaID * AddTaskTOFqaID(Bool_t  flagEnableAdvancedCheck = kFALSE
 
   // Create containers for input/output
   AliAnalysisDataContainer* cInputTOFqa = mgr->CreateContainer("cInputTOFqa", TChain::Class(), AliAnalysisManager::kInputContainer);
-  AliAnalysisDataContainer* cGeneralTOFqa = mgr->CreateContainer(Form("base_%s%s", partName.Data(), cutName.Data()), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s%s:TOF", mgr->GetCommonFileName(), partName.Data()));
-  AliAnalysisDataContainer* cTimeZeroTOFqa = mgr->CreateContainer(Form("timeZero_%s%s", partName.Data(), cutName.Data()), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s%s:TOF", mgr->GetCommonFileName(), partName.Data()));
-  AliAnalysisDataContainer* cPIDTOFqa = mgr->CreateContainer(Form("pid_%s%s", partName.Data(), cutName.Data()), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s%s:TOF", mgr->GetCommonFileName(), partName.Data()));
-  AliAnalysisDataContainer* cTRDcheckTOFqa = mgr->CreateContainer(Form("trd_%s%s", partName.Data(), cutName.Data()), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s%s:TOF", mgr->GetCommonFileName(), partName.Data()));
-  AliAnalysisDataContainer* cTriggerTOFqa = mgr->CreateContainer(Form("trigger_%s%s", partName.Data(), cutName.Data()), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s%s:TOF", mgr->GetCommonFileName(), partName.Data()));
+  AliAnalysisDataContainer* cGeneralTOFqa = mgr->CreateContainer(Form("base_%s%s", partName.Data(), cutName.Data()), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:TOF", mgr->GetCommonFileName()));
+  AliAnalysisDataContainer* cTimeZeroTOFqa = mgr->CreateContainer(Form("timeZero_%s%s", partName.Data(), cutName.Data()), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:TOF", mgr->GetCommonFileName()));
+  AliAnalysisDataContainer* cPIDTOFqa = mgr->CreateContainer(Form("pid_%s%s", partName.Data(), cutName.Data()), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:TOF", mgr->GetCommonFileName()));
+  AliAnalysisDataContainer* cTRDcheckTOFqa = mgr->CreateContainer(Form("trd_%s%s", partName.Data(), cutName.Data()), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:TOF", mgr->GetCommonFileName()));
+  AliAnalysisDataContainer* cTriggerTOFqa = mgr->CreateContainer(Form("trigger_%s%s", partName.Data(), cutName.Data()), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:TOF", mgr->GetCommonFileName()));
 
+  /*
+    AliAnalysisDataContainer* cGeneralTOFqa = mgr->CreateContainer(Form("base_%s%s", partName.Data(), cutName.Data()), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:TOF%s", mgr->GetCommonFileName(), partName.Data()));
+  AliAnalysisDataContainer* cTimeZeroTOFqa = mgr->CreateContainer(Form("timeZero_%s%s", partName.Data(), cutName.Data()), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:TOF%s", mgr->GetCommonFileName(), partName.Data()));
+  AliAnalysisDataContainer* cPIDTOFqa = mgr->CreateContainer(Form("pid_%s%s", partName.Data(), cutName.Data()), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:TOF%s", mgr->GetCommonFileName(), partName.Data()));
+  AliAnalysisDataContainer* cTRDcheckTOFqa = mgr->CreateContainer(Form("trd_%s%s", partName.Data(), cutName.Data()), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:TOF%s", mgr->GetCommonFileName(), partName.Data()));
+  AliAnalysisDataContainer* cTriggerTOFqa = mgr->CreateContainer(Form("trigger_%s%s", partName.Data(), cutName.Data()), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:TOF%s", mgr->GetCommonFileName(), partName.Data()));
+  */
+  
   // Attach i/o
   mgr->ConnectInput(task, 0, mgr->GetCommonInputContainer());
   mgr->ConnectOutput(task, 1, cGeneralTOFqa);


### PR DESCRIPTION
Hello,
There was a mistake in building the name of the output. This is from the attempt to fix the previous version of the macro.
@njacazio , @fbellini : can you check how you wanted to use the "partName"? I have a proposal commented out in the macro, which I am not committing as I might then break the post-processing. Please, change if needed, now the output will be called as before.

Chiara