### PR TITLE
Herwig: Automatic matchbox file generation from template with JINJA

### DIFF
--- a/PWG/MCLEGO/Herwig/LHC-MB.tmpl
+++ b/PWG/MCLEGO/Herwig/LHC-MB.tmpl
@@ -1,0 +1,52 @@
+# -*- ThePEG-repository -*-
+
+################################################################################
+# This file contains our best tune to UE data from ATLAS at 7 TeV. More recent
+# tunes and tunes for other centre-of-mass energies as well as more usage
+# instructions can be obtained from this Herwig wiki page:
+# http://projects.hepforge.org/herwig/trac/wiki/MB_UE_tunes
+################################################################################
+
+##################################################
+# Technical parameters for this run
+##################################################
+cd /Herwig/Generators
+set LHCGenerator:NumberOfEvents {{ numberofevents }} 
+set LHCGenerator:RandomNumberGenerator:Seed {{ randomseed }}
+set LHCGenerator:PrintEvent 10
+set LHCGenerator:MaxErrors 1000000
+
+set LHCGenerator:DebugLevel 0
+set LHCGenerator:DumpPeriod -1
+set LHCGenerator:DebugEvent 0
+
+
+##################################################
+# LHC physics parameters (override defaults here) 
+##################################################
+set LHCGenerator:EventHandler:LuminosityFunction:Energy 13000.0
+
+# Intrinsic pT tune extrapolated to LHC energy
+set /Herwig/Shower/Evolver:IntrinsicPtGaussian 2.2*GeV
+
+##################################################
+# Matrix Elements for hadron-hadron collisions 
+##################################################
+cd /Herwig/MatrixElements/
+insert SimpleQCD:MatrixElements[0] MEMinBias
+
+
+# MPI model settings
+set /Herwig/UnderlyingEvent/MPIHandler:IdenticalToUE 0
+cd /Herwig/Generators
+
+# Change to have no pT cuts for MinBias
+set LHCGenerator:EventHandler:Cuts /Herwig/Cuts/MinBiasCuts
+
+insert LHCGenerator:AnalysisHandlers 0 /Herwig/Analysis/HepMCFile
+set /Herwig/Analysis/HepMCFile:Format GenEvent
+set /Herwig/Analysis/HepMCFile:Units GeV_mm
+set /Herwig/Analysis/HepMCFile:Filename output.hepmc
+
+run LHC-MB LHCGenerator
+

--- a/PWG/MCLEGO/Herwig/generate_matchbox_from_template.py
+++ b/PWG/MCLEGO/Herwig/generate_matchbox_from_template.py
@@ -1,0 +1,28 @@
+#! /usr/bin/env python
+
+import os
+import sys
+import jinja2
+
+def render_matchbox(matchbox_template_path, context):
+  path, filename = os.path.split(matchbox_template_path)
+  return jinja2.Environment(
+    loader=jinja2.FileSystemLoader(path or './')
+  ).get_template(filename).render(context)
+
+def generate_matchbox_from_template(templatename):
+  matchboxname = templatename
+  matchboxname = matchboxname.replace(".tmpl", ".in")
+  # decode configuration parameters from environment variables set by AliDPG
+  configparams = {}
+  for k, v in os.environ.items():
+    if "CONFIG" in k:
+      configparams[k] = v
+
+  with open(matchboxname, 'w') as matchboxwriter:
+    rendered = render_matchbox(templatename, configparams)
+    #print(rendered)
+    matchboxwriter.write(rendered)
+
+if __name__ == "__main__":
+  generate_matchbox_from_template(sys.argv[1])  


### PR DESCRIPTION
Matchbox files contain several keys which need to be handled on-
the-fly (number of events, random seed). The easiest solution
to configure matchbox file from static and dynamic settings is
treating Matchbox.in files as JINJA templates with the JINJA
conventions and use a small python script called in gen_herwig.C
to create the Matchbox.in file from the Matchbox.tmpl file.
For configuration settings the python script assumes the AliDPG
naming convention (global variables, starting with CONFIG_).

Attention: The script should be called on the workers. Requires
the python package JINJA to be installed on the grid sides. The
commit here represents only an example at the current stage and
might not work on every grid site.