### PR TITLE
OADB/EMCAL: IMPORTANT change to OADB instructions for EOS

### DIFF
--- a/OADB/EMCAL/READMEoadb.txt
+++ b/OADB/EMCAL/READMEoadb.txt
@@ -7,15 +7,14 @@ If you want to have the OADB files locally, you can download them from lxplus vi
 rsync -av --delete cern_user@lxplus.cern.ch:/eos/experiment/alice/analysis-data/ /path/to/my/local/oadb/
 ~~~
 
-In order for local tests to work properly, please add the OADB_PATH global variable to your bashrc or similar.
+In order for local tests to work properly, please add the ALICE_DATA global variable to your bashrc or similar.
 ~~~{.sh}
-OADB_PATH=/path/to/my/local/oadb/OADB
+ALICE_DATA=/path/to/my/local/oadb
 ~~~
-It is crucial, that the additional /OADB is added to the global variable OADB_PATH. This is necessary as the downloaded directory from EOS contains the subfolder OADB. OADB_PATH must point to this subfolder in order to be able to properly load the files.
 
 Furthermore, the "export" command should be used in addition to adding the path to the bashrc. This will make the variable available to all processes:
 ~~~{.sh}
-export OADB_PATH=/path/to/my/local/oadb/OADB
+export ALICE_DATA=/path/to/my/local/oadb
 ~~~
 
 In addition, a short history of changes to the files in EOS will be listed here:


### PR DESCRIPTION
Please use the different global variable to access the OADB files as with OADB_PATH several people ran into problems with the PhysicsSelection.

Please use:
ALICE_DATA=/path/to/my/local/oadb
instead of:
OADB_PATH=/path/to/my/local/oadb/OADB