### PR TITLE
[EMCAL-135] Disable temperature recalib due to memory leak

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
@@ -221,6 +221,21 @@ Int_t AliEmcalCorrectionCellEnergy::InitRunDepRecalib()
 {
   if (!fEventManager.InputEvent())
     return 0;
+
+  // MF Disable temperature calibration for run2 for the moment
+  // A memory leak in the AliOADBContainer was observed when the 
+  // container is deleted. As consequence when processing multiple
+  // runs the correction task leaks ~100 MB per run included in the 
+  // job, where 70% of the memory leak comes from the temperature
+  // calibration. Untill a fix is provided the temperature calibration
+  // has to be disabled for run2 runs. Disabling has to be done before
+  // opening the OADB container
+  // 
+  // For more information see https://alice.its.cern.ch/jira/browse/EMCAL-135
+  if(fEventManager.InputEvent()->GetRunNumber() > 197692){
+    AliError("Temperature recalibration disabled for run2");
+    return 0;
+  }
   
   AliInfo("Initialising recalibration factors");
   

--- a/TENDER/TenderSupplies/AliEMCALTenderSupply.cxx
+++ b/TENDER/TenderSupplies/AliEMCALTenderSupply.cxx
@@ -1180,6 +1180,21 @@ Int_t AliEMCALTenderSupply::InitRunDepRecalib()
   
   if (!event) 
     return 0;
+
+  // MF Disable temperature calibration for run2 for the moment
+  // A memory leak in the AliOADBContainer was observed when the 
+  // container is deleted. As consequence when processing multiple
+  // runs the correction task leaks ~100 MB per run included in the 
+  // job, where 70% of the memory leak comes from the temperature
+  // calibration. Untill a fix is provided the temperature calibration
+  // has to be disabled for run2 runs. Disabling has to be done before
+  // opening the OADB container
+  // 
+  // For more information see https://alice.its.cern.ch/jira/browse/EMCAL-135
+  if(event->GetRunNumber() > 197692){
+    AliError("Temperature recalibration disabled for run2");
+    return 0;
+  }
   
   if (fDebugLevel>0) 
     AliInfo("Initialising recalibration factors");


### PR DESCRIPTION
It has been observed that the tender and the correction framework
leak ~100 MB once a run is changed, leading to problems for jobs
processing multiple runs. 70% of the leaking is produced from
loading of the temperature recalibration. As the temperature
recalibration is not used in run2 initializing the recalibration
factors is disabled in order to prevent opening the OADB file untill
the memory leak in the OADB container is fixed.