### PR TITLE
PWGDQ VarManager small fix in labeling of vars

### DIFF
--- a/PWGDQ/dielectron/core/AliDielectronVarManager.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronVarManager.cxx
@@ -564,7 +564,7 @@ const char* AliDielectronVarManager::fgkParticleNames[AliDielectronVarManager::k
   // {"QnFMDAx_FMDCxCorrH2",       "FMDA^{Qn}_{x} * FMDC^{Qn}_{x}",               ""},
   // {"QnFMDAx_FMDCyCorrH2",       "FMDA^{Qn}_{x} * FMDC^{Qn}_{y}",               ""},
   // {"QnFMDAy_FMDCxCorrH2",       "FMDA^{Qn}_{y} * FMDC^{Qn}_{x}",               ""},
-  // {"QnFMDAy_FMDCyCorrH2",       "FMDA^{Qn}_{y} * FMDC^{Qn}_{y}",               ""},
+  {"QnFMDAy_FMDCyCorrH2",       "FMDA^{Qn}_{y} * FMDC^{Qn}_{y}",               ""},
 // Flow estimators for measured Jpsi
 // Eventplane Fourier calculation
   {"QnDeltaPhiTPCrpH2",         "#phi^{pair}-#Psi^{TPC}",                     ""},

--- a/PWGDQ/dielectron/core/AliDielectronVarManager.h
+++ b/PWGDQ/dielectron/core/AliDielectronVarManager.h
@@ -2593,8 +2593,8 @@ inline void AliDielectronVarManager::FillVarVEvent(const AliVEvent *event, Doubl
 
   // v2 calculation variables with eventplane estimators from run1 commented out to reduce the memory usage
   // ep angle interval [todo, fill]
-  AliEventplane *ep = const_cast<AliVEvent*>(event)->GetEventplane();
-  if(ep) {
+  // AliEventplane *ep = const_cast<AliVEvent*>(event)->GetEventplane();
+  // if(ep) {
   //   // TPC event plane quantities (uncorrected)
   //   TVector2 *qstd  = ep->GetQVector();  // This is the "standard" Q-Vector for TPC
   //   TVector2 *qsub1 = ep->GetQsub1();    // random subevent plane
@@ -2752,7 +2752,7 @@ inline void AliDielectronVarManager::FillVarVEvent(const AliVEvent *event, Doubl
   //   values[AliDielectronVarManager::kZDCArpH1] = 999;
   //   values[AliDielectronVarManager::kZDCCrpH1] = 999;
   //   values[AliDielectronVarManager::kZDCACrpH1] = 999;
-  }
+  // }
 
 
 


### PR DESCRIPTION
A shift in the labeling was introduce due to one label to much commented out. This push fixes it