### PR TITLE
New cuts for phi analysis in XeXe and updated macros

### DIFF
--- a/PWGLF/RESONANCES/AliRsnCutSetDaughterParticle.cxx
+++ b/PWGLF/RESONANCES/AliRsnCutSetDaughterParticle.cxx
@@ -1181,6 +1181,119 @@ void AliRsnCutSetDaughterParticle::Init()
 	SetCutScheme( Form("%s&((%s&%s)|((!%s)&%s))",fCutQuality->GetName(), iCutTPCTOFNSigma->GetName(), iCutTOFNSigma->GetName(), iCutTOFMatch->GetName(), iCutTPCNSigma->GetName()) ) ;
 	break;
 
+
+    case AliRsnCutSetDaughterParticle::kTPCTOFvetoPhiXeXe:
+
+      /* PID for Kaon selection for Xe-Xe 2017
+	 if TOF, 
+	 - Nsigma cut on TOF
+	 - 5sigma mismatch rejection with TPC
+
+	 otherwise TPC only:
+	 - 6 sigma, p < 0.3 GeV/c
+	 - 4 sigma, 0.3 < p < 0.4 GeV/c
+	 - nsigma, p > 0.4 GeV/c
+      */
+      iCutTPCTOFNSigma->SinglePIDRange(5.0);
+      
+      /*set pt-independent TOF cut*/
+      iCutTOFNSigma->SinglePIDRange(fNsigmaTOF);
+
+      /*set pt-dependent tpc cut*/
+      iCutTPCNSigma->AddPIDRange(6.,0.0,0.3);
+      iCutTPCNSigma->AddPIDRange(4.,0.3,0.4);
+      iCutTPCNSigma->AddPIDRange(fNsigmaTPC,0.4,1.e20);
+      
+	
+      AddCut(fCutQuality);
+      AddCut(iCutTPCNSigma);
+      AddCut(iCutTOFMatch);
+      AddCut(iCutTOFNSigma);
+      AddCut(iCutTPCTOFNSigma);
+	
+      // scheme:
+      // quality & [ ( TPConly ) || ( TOFmatch & TOF & TPCTOF ) ]
+      SetCutScheme( Form("%s&((%s)|(%s&%s&%s))", fCutQuality->GetName(), iCutTPCNSigma->GetName(), iCutTOFMatch->GetName(), iCutTOFNSigma->GetName(), iCutTPCTOFNSigma->GetName()) ) ;
+      
+      break;
+
+    case AliRsnCutSetDaughterParticle::kTPCTOFPhiXeXe:
+
+      /* PID for Kaon selection for Xe-Xe 2017
+	 if TOF, use TOF & TPC
+	 else use TPC only
+	 
+	 TOF cut
+	 - Nsigma cut on TOF
+	 
+	 TPC only:
+	 - 6 sigma, p < 0.3 GeV/c
+	 - 4 sigma, 0.3 < p < 0.4 GeV/c
+	 - nsigma, p > 0.4 GeV/c
+      */
+      
+      /*set pt-independent TOF cut*/
+      iCutTOFNSigma->SinglePIDRange(fNsigmaTOF);
+      
+      /*set pt-dependent tpc cut*/
+      iCutTPCNSigma->AddPIDRange(6.,0.0,0.3);
+      iCutTPCNSigma->AddPIDRange(4.,0.3,0.4);
+      iCutTPCNSigma->AddPIDRange(fNsigmaTPC,0.4,1.e20);
+	
+      AddCut(fCutQuality);
+      AddCut(iCutTPCNSigma);
+      AddCut(iCutTOFMatch);
+      AddCut(iCutTOFNSigma);
+      
+      // scheme:
+      // quality & [ ( TPConly ) || ( TOFmatch & TOF & TPConly ) ]
+      SetCutScheme( Form("%s&((%s)|(%s&%s&%s))", fCutQuality->GetName(), iCutTPCNSigma->GetName(), iCutTOFMatch->GetName(), iCutTOFNSigma->GetName(), iCutTPCNSigma->GetName()) ) ;
+      
+      break;
+
+    case AliRsnCutSetDaughterParticle::kTPCTOFvetoElRejPhiXeXe:
+
+      /* PID for Kaon selection for Xe-Xe 2017
+	 if TOF, 
+	 - Nsigma cut on TOF
+	 - 5sigma mismatch rejection with TPC
+
+	 otherwise TPC only:
+	 - 6 sigma, p < 0.3 GeV/c
+	 - 4 sigma, 0.3 < p < 0.4 GeV/c
+	 - nsigma, p > 0.4 GeV/c
+
+	 Electron rejection cut
+	 
+      */
+
+      // Set electron rejection cut - 3sigma TPC
+      iCutTPCNSigmaElectronRejection->SinglePIDRange(3.0);
+      
+      // Set mismatch rejection cut - 5sigma TPC
+      iCutTPCTOFNSigma->SinglePIDRange(5.0);
+      
+      /*set pt-independent TOF cut*/
+      iCutTOFNSigma->SinglePIDRange(fNsigmaTOF);
+      
+      /*set pt-dependent tpc cut*/
+      iCutTPCNSigma->AddPIDRange(6.,0.0,0.3);
+      iCutTPCNSigma->AddPIDRange(4.,0.3,0.4);
+      iCutTPCNSigma->AddPIDRange(fNsigmaTPC,0.4,1.e20);
+      
+	
+      AddCut(fCutQuality);
+      AddCut(iCutTPCNSigma);
+      AddCut(iCutTPCNSigmaElectronRejection);
+      AddCut(iCutTOFMatch);
+      AddCut(iCutTOFNSigma);
+      AddCut(iCutTPCTOFNSigma);
+	
+      // scheme:
+      // quality & electronRejection & [ ( TPConly ) || ( TOFmatch & TOF & TPCTOF ) ]
+      SetCutScheme( Form("(%s)&(!%s)&((%s)|(%s&%s&%s))", fCutQuality->GetName(), iCutTPCNSigmaElectronRejection->GetName(), iCutTPCNSigma->GetName(), iCutTOFMatch->GetName(), iCutTOFNSigma->GetName(), iCutTPCTOFNSigma->GetName()) ) ;
+      
+      break;
       
     default :
       break;

--- a/PWGLF/RESONANCES/AliRsnCutSetDaughterParticle.h
+++ b/PWGLF/RESONANCES/AliRsnCutSetDaughterParticle.h
@@ -68,6 +68,9 @@ public:
     kTPCTOFpidTunedPbPbTOFneed, // Pb-Pb cuts tuned for Pb-Pb 2010/2011 (TOF needed)
     kTOFTPCpidKstar,         //cuts for Kstar
     kTOFTPCpidDelta,         //cuts for Delta
+    kTPCTOFvetoPhiXeXe,      // Pb-Pb cuts tuned for Xe-Xe 2017 with TOF veto & mismatch rejection
+    kTPCTOFvetoElRejPhiXeXe, // Pb-Pb cuts tuned for Xe-Xe 2017 with electron rejection
+    kTPCTOFPhiXeXe,          // Pb-Pb cuts tuned for Xe-Xe 2017 with TOF veto & strict TPC
     kNDaughterCuts
   };
 

--- a/PWGLF/RESONANCES/macros/mini/AddTaskPhiXeXe.C
+++ b/PWGLF/RESONANCES/macros/mini/AddTaskPhiXeXe.C
@@ -1,28 +1,63 @@
-/***************************************************************************
-// fbellini@cern.ch - created on 12 Nov 2017
+/*********************************************
+fbellini@cern.ch - created on 20 Nov 2017
+Macro to add task for phi analysis in XeXe
+*********************************************/
 
-// General macro to configure the RSN analysis task.
-// It calls all configs desired by the user, by means
-// of the boolean switches defined in the first lines.
-// ---
-// Inputs:
-//  1) flag to know if running on MC or data
-//  2) path where all configs are stored
-// ---
-// Returns:
-//  kTRUE  --> initialization successful
-//  kFALSE --> initialization failed (some config gave errors)
-//
-****************************************************************************/
+#if !defined (__CINT__) || defined (__CLING__)
+#include "ConfigPhiXeXe.C"
+#endif
 
+AliRsnMiniAnalysisTask * AddTaskPhiXeXe(Int_t selectTaskConfig = 0, Bool_t isMC = kFALSE, TString multEstimator = "AliMultSelection_V0M");
 AliRsnMiniAnalysisTask * AddTaskPhiXeXe( Bool_t      isMC = kFALSE,
-					 AliRsnCutSetDaughterParticle::ERsnDaughterCutSet cutKaCandidate = AliRsnCutSetDaughterParticle::kFastTPCpidNsigma,
-					 Float_t     nsigmaK = 3.0,
+					 AliRsnCutSetDaughterParticle::ERsnDaughterCutSet cutKaCandidate = AliRsnCutSetDaughterParticle::kTPCpidTOFveto3s,
+					 Float_t     nsigmaTPC = 2.0,
+					 Float_t     nsigmaTOF = 2.0,
 					 Int_t       aodFilterBit = 5,
-					 TString     multEstimator = "AliMultSelection_V0M", 
+					 TString     multEstimator = "AliMultSelection_V0M",  
 					 Int_t       nmix = 5,
 					 Bool_t      enableMonitor = kTRUE,
-					 TString     outNameSuffix = "Xe")
+					 TString     outNameSuffix = "tpc2s_tof3sveto");
+
+AliRsnMiniAnalysisTask * AddTaskPhiXeXe(Int_t selectTaskConfig, Bool_t isMC, TString multEstimator)
+{
+  //Select cuts configuration and returns the corresponding add task
+  AliRsnMiniAnalysisTask * task = 0x0;
+  
+  switch (selectTaskConfig){
+  case 1 :
+    task = (AliRsnMiniAnalysisTask *) AddTaskPhiXeXe(isMC, AliRsnCutSetDaughterParticle::kTPCpidTOFveto3s, 3.0, 3.0, 5, multEstimator.Data(), 5, kTRUE, "tpc3s_tof3sveto");
+    break;
+  case 2 :
+    task = (AliRsnMiniAnalysisTask *) AddTaskPhiXeXe(isMC, AliRsnCutSetDaughterParticle::kTPCpidTOFveto4s, 2.0, 4.0, 5, multEstimator.Data(), 5, kTRUE, "tpc2s_tof4sveto");
+    break;
+  case 3 :
+    task = (AliRsnMiniAnalysisTask *) AddTaskPhiXeXe(isMC, AliRsnCutSetDaughterParticle::kFastTPCpidNsigma, 3.0, 10.0,  5, multEstimator.Data(), 5, kTRUE, "tpc3s");
+    break;
+  case 4 :
+    task = (AliRsnMiniAnalysisTask *) AddTaskPhiXeXe(isMC, AliRsnCutSetDaughterParticle::kFastTOFpidNsigma, 10.0, 3.0, 5, multEstimator.Data(), 5, kTRUE, "tof3s");
+    break;
+  case 5 :
+    task = (AliRsnMiniAnalysisTask *) AddTaskPhiXeXe(isMC, AliRsnCutSetDaughterParticle::kTPCpidphipp2015, 2.0, 10.0, 5, multEstimator.Data(), 5, kTRUE, "tpc2sPtDep");    
+    break;
+  case 6 :
+    task = (AliRsnMiniAnalysisTask *) AddTaskPhiXeXe(isMC, AliRsnCutSetDaughterParticle::kTPCTOFpidphipp2015, 3.0, 3.0, 5, multEstimator.Data(), 5, kTRUE, "tpc3sPtDep_tof3sveto");    
+    break;
+  case 7 :
+    task = (AliRsnMiniAnalysisTask *) AddTaskPhiXeXe(isMC, AliRsnCutSetDaughterParticle::kTPCTOFpidphipp2015, 2.0, 3.0, 5, multEstimator.Data(), 5, kTRUE, "tpc2sPtDep_tof3sveto");    
+    break;
+  case 8 :
+    task = (AliRsnMiniAnalysisTask *) AddTaskPhiXeXe(isMC, AliRsnCutSetDaughterParticle::kTPCTOFpidphipp2015, 2.0, 2.0, 5, multEstimator.Data(), 5, kTRUE, "tpc2sPtDep_tof2sveto");    
+    break;
+  default:
+    task = (AliRsnMiniAnalysisTask *) AddTaskPhiXeXe(isMC, AliRsnCutSetDaughterParticle::kTPCpidTOFveto3s, 2.0, 3.0, 5, multEstimator.Data(), 5, kTRUE, "tpc2s_tof3sveto");
+  }
+
+  return task;
+}
+
+
+AliRsnMiniAnalysisTask * AddTaskPhiXeXe(Bool_t isMC, AliRsnCutSetDaughterParticle::ERsnDaughterCutSet cutKaCandidate, Float_t nsigmaTPC, Float_t nsigmaTOF,
+					Int_t aodFilterBit, TString multEstimator, Int_t nmix, Bool_t enableMonitor, TString outNameSuffix)
 {  
   //-------------------------------------------
   // event cuts
@@ -57,34 +92,30 @@ AliRsnMiniAnalysisTask * AddTaskPhiXeXe( Bool_t      isMC = kFALSE,
    AliRsnMiniAnalysisTask *task = new AliRsnMiniAnalysisTask(taskName.Data(), isMC);
    //task->SelectCollisionCandidates(triggerMask);//AOD
    task->UseESDTriggerMask(triggerMask);//ESD
-   task->UseMultiplicity(multEstimator.Data());
+   task->UseMultiplicity("AliMultSelection_V0M");
    
    // set event mixing options
    task->UseContinuousMix();
-   //task->UseBinnedMix();
    task->SetNMix(nmix);
    task->SetMaxDiffVz(maxDiffVzMix);
    task->SetMaxDiffMult(maxDiffMultMix);
-   task->UseMC(isMC);
-   ::Info("AddTaskPhiXeXe", Form("Event mixing configuration: \n events to mix = %i \n max diff. vtxZ = cm %5.3f \n max diff multi = %5.3f \n", nmix, maxDiffVzMix, maxDiffMultMix));
+   TString message = Form("\nevents to mix = %i \n max diff. vtxZ = cm %5.3f \n max diff multi = %5.3f \n", nmix, maxDiffVzMix, maxDiffMultMix);
+   Printf("AddTaskPhiXeXe :::: Event mixing configuration: %s", message.Data());
    
    mgr->AddTask(task);
 
    //
    // -- EVENT CUTS (same for all configs) ---------------------------------------------------------
-   //  
-   // cut on primary vertex:
-   // - 2nd argument --> |Vz| range
-   // - 3rd argument --> minimum required number of contributors
-   // - 4th argument --> tells if TPC stand-alone vertexes must be accepted
-   
+   //   
    AliRsnCutEventUtils* cutEventUtils = new AliRsnCutEventUtils("cutEventUtils", kTRUE, rejectPileUp);
-   cutEventUtils->SetCheckAcceptedMultSelection(kTRUE);
-   ::Info("AddTaskPhiXeXe", Form(":::::::::::::::::: Centrality estimator: %s", multEstimator.Data()));
+   cutEventUtils->SetRemovePileUppA2013(kFALSE);
+   cutEventUtils->SetCheckAcceptedMultSelection();
+   Printf("AddTaskPhiXeXe :::: Centrality estimator: %s", multEstimator.Data());
    
    AliRsnCutSet* eventCuts = new AliRsnCutSet("eventCuts", AliRsnTarget::kEvent);
    eventCuts->AddCut(cutEventUtils);
    eventCuts->SetCutScheme(Form("%s", cutEventUtils->GetName()));
+
    task->SetEventCuts(eventCuts); 
 
    //
@@ -96,8 +127,8 @@ AliRsnMiniAnalysisTask * AddTaskPhiXeXe( Bool_t      isMC = kFALSE,
    Int_t multID = task->CreateValue(AliRsnMiniValue::kMult, kFALSE);
 
    AliRsnMiniOutput *outVtx = task->CreateOutput("eventVtx", "HIST", "EVENT");
-   outVtx->AddAxis(vtxID, 400, -20.0, 20.0);
-   outVtx->AddAxis(multID, 100, 0.0, 100.0);
+   outVtx->AddAxis(vtxID, 240, -12.0, 12.0);
+   outVtx->AddAxis(multID, 20, 0.0, 100.0);
    
    AliRsnMiniOutput *outMult = task->CreateOutput("eventMult", "HIST", "EVENT");
    outMult->AddAxis(multID, 100, 0.0, 100.0);
@@ -116,15 +147,18 @@ AliRsnMiniAnalysisTask * AddTaskPhiXeXe( Bool_t      isMC = kFALSE,
    // ------------------------------------------------------
    // CONFIG ANALYSIS
    // ------------------------------------------------------
+#if !defined (__CINT__) || defined (__CLING__)
+   ConfigPhiXeXe(task, isMC, outNameSuffix.Data(), cutsPair, aodFilterBit, cutKaCandidate, nsigmaTPC, nsigmaTOF, 15.0, enableMonitor,kTRUE, kFALSE);
+#else
    gROOT->LoadMacro("$ALICE_PHYSICS/PWGLF/RESONANCES/macros/mini/ConfigPhiXeXe.C");
-   if (!ConfigPhiXeXe(task, isMC, "", cutsPair, aodFilterBit, AliRsnCutSetDaughterParticle::kDisableCustom, cutKaCandidate, nsigmaK, enableMonitor)) return 0x0;
-   // Bool_t      useGeoCutsPbPb2015 = kFALSE;
-
+   //gROOT->LoadMacro("./ConfigPhiXeXe.C");
+   ConfigPhiXeXe(task, isMC, outNameSuffix.Data(), cutsPair, aodFilterBit, cutKaCandidate, nsigmaTPC, nsigmaTOF, 15.0, enableMonitor, kTRUE, kFALSE);
+#endif
+   
    //
    // -- CONTAINERS --------------------------------------------------------------------------------
    //
    TString outputFileName = AliAnalysisManager::GetCommonFileName();
-   // outputFileName += ":Rsn";
    Printf("AddTaskPhiXeXe - Set OutputFileName : \n %s\n", outputFileName.Data() );
    
    AliAnalysisDataContainer *output = mgr->CreateContainer(Form("RsnOut_%s",outNameSuffix.Data()), 
@@ -136,3 +170,4 @@ AliRsnMiniAnalysisTask * AddTaskPhiXeXe( Bool_t      isMC = kFALSE,
    
    return task;
 }
+

--- a/PWGLF/RESONANCES/macros/mini/ConfigPhiXeXe.C
+++ b/PWGLF/RESONANCES/macros/mini/ConfigPhiXeXe.C
@@ -1,56 +1,53 @@
 /***************************************************************************
-              fbellini@cern.ch - last modified on 17/02/2014
-
-// *** Configuration script for K*, anti-K* analysis with 2013 pPb runs ***
-// 
-// A configuration script for RSN package needs to define the followings:
-//
-// (1) decay tree of each resonance to be studied, which is needed to select
-//     true pairs and to assign the right mass to all candidate daughters
-// (2) cuts at all levels: single daughters, tracks, events
-// (3) output objects: histograms or trees
+fbellini@cern.ch - last modified on 23/03/2018
+Configuration script forphi analysis with 2017 XeXe runs
 ****************************************************************************/
-Bool_t ConfigPhiXeXe(  
-    AliRsnMiniAnalysisTask *task, 
-    Bool_t                 isMC, 
-    const char             *suffix,
-    AliRsnCutSet           *cutsPair,
-    Int_t                  aodFilterBit = 5,
-    AliRsnCutSetDaughterParticle::ERsnDaughterCutSet cutPid = AliRsnCutSetDaughterParticle::kTPCpidTOFveto3s, // pid cut set
-    Float_t                nsigma = 3.0,          //nsigma of TPC PID cut
-    Bool_t                 enableMonitor = kTRUE,
-    Bool_t                 IsMcTrueOnly = kFALSE,
-    TString                monitorOpt = "NoSIGN",
-    Bool_t                 useMixLS = 0,
-    Bool_t                 checkReflex = 0,
-    AliRsnMiniValue::EType yaxisVar = AliRsnMiniValue::kPt
-)
+#if !defined (__CINT__) || defined (__CLING__)
+#include "AddMonitorOutput.C"
+#endif
+
+Bool_t SetCustomQualityCut(AliRsnCutTrackQuality * trkQualityCut = NULL, Int_t customQualityCutsID = 0, Int_t customFilterBit = 0);
+
+Bool_t ConfigPhiXeXe(AliRsnMiniAnalysisTask *task = 0x0, 
+		     Bool_t                 isMC = kFALSE, 
+		     TString                suffix = "",
+		     AliRsnCutSet           *cutsPair = 0x0,
+		     Int_t                  aodFilterBit = 5,
+		     AliRsnCutSetDaughterParticle::ERsnDaughterCutSet cutPid = AliRsnCutSetDaughterParticle::kTPCpidTOFveto3s, // pid cut set
+		     Float_t                nsigmaTPC = 2.0,          //nsigma of TPC PID cut
+		     Float_t                nsigmaTOF = 3.0,          //nsigma of TOF PID cut
+		     Float_t                ptMax = 15.0,
+		     Bool_t                 enableMonitor = kTRUE,
+		     Bool_t                 useMixLS = kFALSE,
+		     Bool_t                 checkReflex = kFALSE)
 {
-  // manage suffix
-  if (strlen(suffix) > 0) suffix = Form("_%s", suffix);
-  
+
   //use default quality cuts std 2010 with crossed rows TPC
   Bool_t useCrossedRows = 1; 
-  AliRsnCutSetDaughterParticle * cutSetKa = new AliRsnCutSetDaughterParticle("cutKa", cutPid, AliPID::kKaon, nsigma, aodFilterBit, useCrossedRows);
+  AliRsnCutSetDaughterParticle * cutSetKa = new AliRsnCutSetDaughterParticle("cutKa", cutPid, AliPID::kKaon, nsigmaTPC, nsigmaTOF, aodFilterBit, useCrossedRows);
   cutSetKa->SetUse2011StdQualityCuts(kTRUE);
-  Int_t iCutKa = task->AddTrackCuts(cutSetKa);
-
-  //set daughter cuts
-  Int_t iCut1 = iCutKa;
-  Int_t iCut2 = iCutKa;
-
-  //monitor single-track selection based on track quality cuts only
-  AliRsnCutSetDaughterParticle * cutSetQuality = new AliRsnCutSetDaughterParticle("cutQuality", AliRsnCutSetDaughterParticle::kQualityStd2011, AliPID::kPion, 10.0, aodFilterBit, useCrossedRows);
-  Int_t iCutQuality = task->AddTrackCuts(cutSetQuality);
+  Int_t icutKa = task->AddTrackCuts(cutSetKa);
   
-  //QA plots 
+  //set daughter cuts
+  Int_t iCut1 = icutKa;
+  Int_t iCut2 = icutKa;
+  
+  //monitor single-track selection based on track quality cuts only
+  AliRsnCutSetDaughterParticle * cutSetQuality = new AliRsnCutSetDaughterParticle("cutQuality", AliRsnCutSetDaughterParticle::kQualityStd2011, AliPID::kPion, 10.0, 10.0, aodFilterBit, useCrossedRows);
+  Int_t icutQuality = task->AddTrackCuts(cutSetQuality);
+  
+#if defined (__CINT__) || !defined (__CLING__)
+  gROOT->LoadMacro("$ALICE_PHYSICS/PWGLF/RESONANCES/macros/mini/AddMonitorOutput.C");
+  //gROOT->LoadMacro("./AddMonitorOutput.C");
+#endif
+    
+  //QA plots
+  TString monitorOpt = "NoSIGN";
   if (enableMonitor){
-    Printf("======== Cut monitoring enabled");
-    gROOT->LoadMacro("$ALICE_PHYSICS/PWGLF/RESONANCES/macros/mini/AddMonitorOutput.C");
     AddMonitorOutput(isMC, cutSetQuality->GetMonitorOutput(), monitorOpt.Data());
-    AddMonitorOutput(isMC, cutSetKa->GetMonitorOutput(), monitorOpt.Data());
+    AddMonitorOutput(isMC, cutSetKa->GetMonitorOutput(), monitorOpt.Data());    
   }  
-
+  
   
   // -- Values ------------------------------------------------------------------------------------
   /* invariant mass   */ Int_t imID   = task->CreateValue(AliRsnMiniValue::kInvMass, kFALSE);
@@ -65,15 +62,10 @@ Bool_t ConfigPhiXeXe(
   /* 2nd daughter p   */ Int_t sdp    = task->CreateValue(AliRsnMiniValue::kSecondDaughterP, kFALSE);
   /* pair pt res      */ Int_t resPt  = task->CreateValue(AliRsnMiniValue::kPairPtRes, kTRUE);
   /* pair y res       */ Int_t resY   = task->CreateValue(AliRsnMiniValue::kPairYRes, kTRUE);
+
+  const Int_t nptbins = ptMax/0.1;
   
   // -- Create all needed outputs -----------------------------------------------------------------
-  // use an array for more compact writing, which are different on mixing and charges
-  // [0][1] = unlike +-, -+ (Minv, pT, multiplicity)
-  // [2][3] = mixing +-, -+ (Minv, pT, multiplicity)
-  // [4][5] = like ++, -- (Minv, pT, multiplicity)
-  // [6][7] = MC true +-, -+ (Minv, pT, multiplicity)
-  // [8][9] = MC true +-, -+ (Minv, pT, y)
-  // [10][11] = mixing ++, -- (Minv, pT, multiplicity)
   Bool_t  use     [8] = {   !isMC,    !isMC,    !isMC,    !isMC,   isMC,    isMC,   useMixLS, useMixLS};
   TString name    [8] = {"Unlike", "Mixing", "LikePP", "LikeMM", "True", "TrueY", "MixingPP", "MixingMM"};
   TString comp    [8] = {"PAIR"  , "MIX"   , "PAIR"  , "PAIR"  , "TRUE", "TRUE" , "MIX"     , "MIX"};
@@ -84,10 +76,10 @@ Bool_t ConfigPhiXeXe(
   
   /*********************
      Data and MC true
-    *******************/
+  *******************/
   for (Int_t i = 0; i < 8; i++) {
     if (!use[i]) continue;
-    AliRsnMiniOutput *out = task->CreateOutput(Form("%s%s", name[i].Data(), suffix), output.Data(), comp[i].Data());
+    AliRsnMiniOutput *out = task->CreateOutput(Form("%s%s", name[i].Data(), suffix.Data()), output.Data(), comp[i].Data());
     out->SetCutID(0, iCut1);
     out->SetCutID(1, iCut2);
     out->SetDaughter(0, AliRsnDaughter::kKaon);
@@ -99,125 +91,125 @@ Bool_t ConfigPhiXeXe(
     out->SetPairCuts(cutsPair);
     
     // axis X: invmass
-    out->AddAxis(imID, 350, 0.85, 1.2);
+    out->AddAxis(imID, 420, 0.98, 1.4);
+
     // axis Y: transverse momentum of pair as default - else chosen value
-    if (yaxisVar==AliRsnMiniValue::kFirstDaughterPt)
-      out->AddAxis(fdpt, 100, 0.0, 5.0);
-    else
-      if (yaxisVar==AliRsnMiniValue::kSecondDaughterPt)
-	out->AddAxis(sdpt, 100, 0.0, 5.0);
-      else
-	if (yaxisVar==AliRsnMiniValue::kFirstDaughterP)
-	  out->AddAxis(fdp, 100, 0.0, 5.0);
-	else
-	  if (yaxisVar==AliRsnMiniValue::kSecondDaughterP)
-	    out->AddAxis(sdp, 100, 0.0, 5.0);
-	  else 
-	    out->AddAxis(ptID, 100, 0.0, 5.0); //default use mother pt
+    if (i==5) out->AddAxis(yID, 100, -0.5, 0.5);
+    else out->AddAxis(ptID, nptbins, 0.0, ptMax); //default use mother pt
     
     // axis Z: centrality or multiplicity or rapidity
-    if (i==5) {
-      out->AddAxis(yID, 400, -2.0, 2.0);
-    } else {
-      out->AddAxis(centID, 100, 0.0, 100.0);
-    }
+    out->AddAxis(centID, 100, 0.0, 100.0);
   }   
+  
+  if (!isMC) return kTRUE;   
   
   /****************
      MONTECARLO
   ****************/
-  if (isMC){   
+  //Minv resolution, pair's pT and pair's y resolution vs pT vs y
+  //Computed as (Xrec-Xgen)/Xgen, with a MC-true like computation
+  TString nameR[4]    = {"Res", "ResCent", "ResPt", "ResY"};
+  TString compR[4]    = {"TRUE" , "TRUE", "TRUE", "TRUE"};
+  TString outputR[4]  = {"HIST", "HIST","HIST", "HIST"};
+  Int_t   pdgCodeR[4] = {333, 333, 333, 333};
+  Char_t  charge1R[4] = {'+', '+', '+', '+'};
+  Char_t  charge2R[4] = {'-', '-', '-', '-'};
 
-    //Minv resolution, pair's pT and pair's y resolution vs pT vs y
-    //Computed as (Xrec-Xgen)/Xgen, with a MC-true like computation
-    TString nameR[3]    = {"Res", "ResPt", "ResY"};
-    TString compR[3]    = {"TRUE" , "TRUE", "TRUE"};
-    TString outputR[3]  = {"HIST","HIST", "HIST"};
-    Int_t   pdgCodeR[3] = {333,   333, 333};
-    Char_t  charge1R[3] = {'+', '+', '+'};
-    Char_t  charge2R[3] = {'-', '-', '-'};
-
-    for (Int_t j = 0; j < 3; j++) {
-      AliRsnMiniOutput *outR = task->CreateOutput(Form("%s%s", nameR[j].Data(), suffix), outputR[j].Data(), compR[j].Data());
-      outR->SetCutID(0, iCut1);
-      outR->SetCutID(1, iCut2);
-      outR->SetDaughter(0, AliRsnDaughter::kKaon);
-      outR->SetDaughter(1, AliRsnDaughter::kKaon);
-      outR->SetCharge(0, charge1R[j]);
-      outR->SetCharge(1, charge2R[j]);
-      outR->SetMotherPDG(pdgCodeR[j]);
-      outR->SetMotherMass(1.01995);
-      outR->SetPairCuts(cutsPair);
-      // axis X: invmass resolution, pt resolution, y resolution
-      if (j<2) outR->AddAxis(resID, 100, -0.01, 0.01);
-      else if (j<4) outR->AddAxis(resPt, 100, -0.05, 0.05);
-      else outR->AddAxis(resY, 100, -0.5, 0.5);
-      //axis Y: mother pt
-      outR->AddAxis(ptID, 100, 0.0, 5.0); 
-      //axis Z: rapidity
-      outR->AddAxis(yID, 400, -2.0, 2.0);
+  for (Int_t j = 0; j < 4; j++) {
+    AliRsnMiniOutput *outR = task->CreateOutput(Form("%s%s", nameR[j].Data(), suffix.Data()), outputR[j].Data(), compR[j].Data());
+    outR->SetCutID(0, iCut1);
+    outR->SetCutID(1, iCut2);
+    outR->SetDaughter(0, AliRsnDaughter::kKaon);
+    outR->SetDaughter(1, AliRsnDaughter::kKaon);
+    outR->SetCharge(0, charge1R[j]);
+    outR->SetCharge(1, charge2R[j]);
+    outR->SetMotherPDG(pdgCodeR[j]);
+    outR->SetMotherMass(1.01995);
+    outR->SetPairCuts(cutsPair);
+    // axis X: invmass resolution, pt resolution, y resolution
+    switch (j) {
+    case 0:
+      outR->AddAxis(resID, 100, -0.01, 0.01);
+      outR->AddAxis(ptID, nptbins, 0.0, ptMax); 
+      outR->AddAxis(yID, 100, -0.5, 0.5);
+      break;
+    case 1:
+      outR->AddAxis(resID, 100, -0.01, 0.01);
+      outR->AddAxis(ptID, nptbins, 0.0, ptMax); 
+      outR->AddAxis(centID, 100, 0.0, 100.0);
+      break;
+    case 2:
+      outR->AddAxis(resPt, 100, -0.05, 0.05);
+      outR->AddAxis(ptID, nptbins, 0.0, ptMax); 
+      outR->AddAxis(yID, 100, -0.5, 0.5);
+      break;
+    case 3:
+      outR->AddAxis(resY, 100, -0.05, 0.05);
+      outR->AddAxis(ptID, nptbins, 0.0, ptMax); 
+      outR->AddAxis(yID, 100, -0.5, 0.5);
+      break;
+    default:
+      break;
     }
-
-    //get mothers for PDG = 333
-    AliRsnMiniOutput *outm = task->CreateOutput(Form("Mother%s", suffix), "HIST", "MOTHER");
-    outm->SetDaughter(0, AliRsnDaughter::kKaon);
-    outm->SetDaughter(1, AliRsnDaughter::kKaon);
-    outm->SetMotherPDG(333);
-    outm->SetMotherMass(1.01995);
-    outm->SetPairCuts(cutsPair);
-    outm->AddAxis(imID, 350, 0.85, 1.2);
-    outm->AddAxis(ptID, 100, 0.0, 5.0);
-    outm->AddAxis(centID, 100, 0.0, 100.0);
+  }
+  //get mothers for PDG = 333
+  AliRsnMiniOutput *outm = task->CreateOutput(Form("Mother%s", suffix.Data()), "HIST", "MOTHER");
+  outm->SetDaughter(0, AliRsnDaughter::kKaon);
+  outm->SetDaughter(1, AliRsnDaughter::kKaon);
+  outm->SetMotherPDG(333);
+  outm->SetMotherMass(1.01995);
+  outm->SetPairCuts(cutsPair);
+  outm->AddAxis(imID, 420, 0.98, 1.4);
+  outm->AddAxis(ptID, nptbins, 0.0, ptMax);
+  outm->AddAxis(centID, 100, 0.0, 100.0);
       
-    //get mothers for PDG = 333
-    AliRsnMiniOutput *outm2 = task->CreateOutput(Form("MotherY%s", suffix), "HIST", "MOTHER");
-    outm2->SetDaughter(0, AliRsnDaughter::kKaon);
-    outm2->SetDaughter(1, AliRsnDaughter::kKaon);
-    outm2->SetMotherPDG(333);
-    outm2->SetMotherMass(1.01995);
-    outm2->SetPairCuts(cutsPair);
-    outm2->AddAxis(imID, 350, 0.85, 1.2);
-    outm2->AddAxis(ptID, 100, 0.0, 5.0);
-    outm2->AddAxis(yID, 400, -2.0, 2.0);
+  //get mothers for PDG = 333
+  AliRsnMiniOutput *outm2 = task->CreateOutput(Form("MotherY%s", suffix.Data()), "HIST", "MOTHER");
+  outm2->SetDaughter(0, AliRsnDaughter::kKaon);
+  outm2->SetDaughter(1, AliRsnDaughter::kKaon);
+  outm2->SetMotherPDG(333);
+  outm2->SetMotherMass(1.01995);
+  outm2->SetPairCuts(cutsPair);
+  outm2->AddAxis(imID, 420, 0.98, 1.4);
+  outm2->AddAxis(yID, 100, -0.5, 0.5);
+  outm2->AddAxis(centID, 100, 0.0, 100.0);
+	
+  //get phase space of the decay from mothers
+  AliRsnMiniOutput *outps = task->CreateOutput(Form("PhaseSpace%s", suffix.Data()), "HIST", "TRUE");
+  outps->SetDaughter(0, AliRsnDaughter::kKaon);
+  outps->SetDaughter(1, AliRsnDaughter::kKaon);
+  outps->SetCutID(0, iCut1);
+  outps->SetCutID(1, iCut2);
+  outps->SetMotherPDG(333);
+  outps->SetMotherMass(1.01995);
+  outps->SetPairCuts(cutsPair);
+  outps->AddAxis(fdpt, 50, 0.0, 5.0);
+  outps->AddAxis(sdpt, 50, 0.0, 5.0);
+  outps->AddAxis(ptID, nptbins, 0.0, ptMax);
     
-    //get phase space of the decay from mothers
-    AliRsnMiniOutput *outps = task->CreateOutput(Form("PhaseSpace%s", suffix), "HIST", "TRUE");
-    outps->SetDaughter(0, AliRsnDaughter::kKaon);
-    outps->SetDaughter(1, AliRsnDaughter::kKaon);
-    outps->SetCutID(0, iCut1);
-    outps->SetCutID(1, iCut2);
-    outps->SetMotherPDG(333);
-    outps->SetMotherMass(1.01995);
-    outps->SetPairCuts(cutsPair);
-    outps->AddAxis(fdpt, 50, 0.0, 5.0);
-    outps->AddAxis(sdpt, 50, 0.0, 5.0);
-    outps->AddAxis(ptID, 100, 0.0, 10.0);
-    
-    //get reflections
-    //defined as MC-true like computation but checking what happens when 
-    //pions are mis-identified as K and K are mis-identified as pions
-    if (checkReflex) { 
+  //get reflections
+  //defined as MC-true like computation but checking what happens when 
+  //pions are mis-identified as K and K are mis-identified as pions
+  if (checkReflex) { 
+    AliRsnMiniOutput *outreflex = task->CreateOutput(Form("Reflex2pi_%s", suffix.Data()), "HIST", "TRUE");
+    outreflex->SetDaughter(0, AliRsnDaughter::kKaon);
+    outreflex->SetDaughter(1, AliRsnDaughter::kKaon);
+    outreflex->SetCutID(0, iCut1);
+    outreflex->SetCutID(1, iCut2);
+    outreflex->SetMotherPDG(333);
+    outreflex->SetMotherMass(1.01995);
+    outreflex->SetPairCuts(cutsPair);
+    outreflex->AddAxis(imID, 420, 0.98, 1.4);
+    outreflex->AddAxis(ptID, nptbins, 0.0, ptMax);
+    outreflex->AddAxis(centID, 100, 0.0, 100.0);     
+  }//end reflections
 
-      AliRsnMiniOutput *outreflex = task->CreateOutput(Form("Reflex%s", suffix), "HIST", "TRUE");
-      outreflex->SetDaughter(0, AliRsnDaughter::kKaon);
-      outreflex->SetDaughter(1, AliRsnDaughter::kKaon);
-      outreflex->SetCutID(0, iCut1);
-      outreflex->SetCutID(1, iCut2);
-      outreflex->SetMotherPDG(333);
-      outreflex->SetMotherMass(1.01995);
-      outreflex->SetPairCuts(cutsPair);
-      outreflex->AddAxis(imID, 350, 0.85, 1.2);
-      outreflex->AddAxis(ptID, 100, 0.0, 5.0);
-      outreflex->AddAxis(centID, 100, 0.0, 100.0);
-      
-    }//end reflections
-  }//end MC
   
-   return kTRUE;
+  return kTRUE;
 }
 
 //-------------------------------------------------------  
-Bool_t SetCustomQualityCut(AliRsnCutTrackQuality * trkQualityCut, Int_t customQualityCutsID = 0, Int_t customFilterBit = 0)
+Bool_t SetCustomQualityCut(AliRsnCutTrackQuality * trkQualityCut, Int_t customQualityCutsID, Int_t customFilterBit)
 {
   //Sets configuration for track quality object different from std quality cuts.
   //Returns kTRUE if track quality cut object is successfully defined,
@@ -238,9 +230,9 @@ Bool_t SetCustomQualityCut(AliRsnCutTrackQuality * trkQualityCut, Int_t customQu
 
   //filter bit 5:  AliESDtrackCuts::GetStandardITSTPCTrackCuts2011();
 
-   //filter bit 10: standard cuts with tight DCA cut, using cluster cut instead of crossed rows (a la 2010 default)
-   //AliESDtrackCuts* esdTrackCutsH2Cluster = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(kTRUE, 0);
-   */
+  //filter bit 10: standard cuts with tight DCA cut, using cluster cut instead of crossed rows (a la 2010 default)
+  //AliESDtrackCuts* esdTrackCutsH2Cluster = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(kTRUE, 0);
+  */
 
   if ((!trkQualityCut) || (customQualityCutsID<=0) || (customQualityCutsID>=AliRsnCutSetDaughterParticle::kNcustomQualityCuts)){
     Printf("::::: SetCustomQualityCut:: use default quality cuts specified in task configuration.");
@@ -307,7 +299,7 @@ Bool_t SetCustomQualityCut(AliRsnCutTrackQuality * trkQualityCut, Int_t customQu
   trkQualityCut->SetPtRange(0.15, 20.0);
   trkQualityCut->SetEtaRange(-0.8, 0.8);
   
-  Printf(Form("::::: SetCustomQualityCut:: using custom track quality cuts #%i",customQualityCutsID));
+  Printf("::::: SetCustomQualityCut:: using custom track quality cuts %i",customQualityCutsID);
   trkQualityCut->Print();
   return kTRUE;
 }


### PR DESCRIPTION
- Added new PID cuts (TPC-TOF, TPC-TOFveto and TPC-TOFveto + electron rejection)
- Updated macros, including changes for ROOT6
