### PR TITLE
Remove absolute values on pdg labels

### DIFF
--- a/PWGGA/PHOSTasks/CMakeLists.txt
+++ b/PWGGA/PHOSTasks/CMakeLists.txt
@@ -94,7 +94,7 @@ set(SRCS
     PHOS_LHC16_pp/AliPP13PhotonSpectrumSelection.cxx
     PHOS_LHC16_pp/AliPP13PhotonTimecutStudySelection.cxx
     PHOS_LHC16_pp/AliPP13PhysPhotonSelection.cxx
-    PHOS_LHC16_pp/AliPP13PionToKaonRatioMC.cxx
+    PHOS_LHC16_pp/AliPP13KaonToPionRatioMC.cxx
     PHOS_LHC16_pp/AliPP13PhysPhotonSelectionMC.cxx
     PHOS_LHC16_pp/AliPP13PythiaInfoSelection.cxx
     PHOS_LHC16_pp/AliPP13QualityPhotonSelection.cxx

--- a/PWGGA/PHOSTasks/PHOS_LHC16_pp/AliPP13KaonToPionRatioMC.cxx
+++ b/PWGGA/PHOSTasks/PHOS_LHC16_pp/AliPP13KaonToPionRatioMC.cxx
@@ -2,7 +2,7 @@
 // #include "iterator"
 
 // --- Custom header files ---
-#include "AliPP13PionToKaonRatioMC.h"
+#include "AliPP13KaonToPionRatioMC.h"
 
 // --- ROOT system ---
 #include <TParticle.h>
@@ -22,11 +22,11 @@
 using namespace std;
 
 
-ClassImp(AliPP13PionToKaonRatioMC);
+ClassImp(AliPP13KaonToPionRatioMC);
 
 
 //________________________________________________________________
-void AliPP13PionToKaonRatioMC::InitSelectionHistograms()
+void AliPP13KaonToPionRatioMC::InitSelectionHistograms()
 {
 	for (EnumNames::iterator i = fPartNames.begin(); i != fPartNames.end(); ++i)
 	{
@@ -46,7 +46,7 @@ void AliPP13PionToKaonRatioMC::InitSelectionHistograms()
 }
 
 
-void AliPP13PionToKaonRatioMC::ConsiderGeneratedParticles(const EventFlags & flags)
+void AliPP13KaonToPionRatioMC::ConsiderGeneratedParticles(const EventFlags & flags)
 {
 	if (!flags.fMcParticles)
 		return;
@@ -54,7 +54,7 @@ void AliPP13PionToKaonRatioMC::ConsiderGeneratedParticles(const EventFlags & fla
 	for (Int_t i = 0; i < flags.fMcParticles->GetEntriesFast(); i++)
 	{
 		AliAODMCParticle * particle = ( AliAODMCParticle *) flags.fMcParticles->At(i);
-		Int_t code = TMath::Abs(particle->GetPdgCode());
+		Int_t code = particle->GetPdgCode();
 
 		// NB: replace this condition by find, if the number of particles will grow
 		//
@@ -71,7 +71,7 @@ void AliPP13PionToKaonRatioMC::ConsiderGeneratedParticles(const EventFlags & fla
 
 
 //________________________________________________________________
-Bool_t AliPP13PionToKaonRatioMC::IsPrimary(const AliAODMCParticle * particle) const
+Bool_t AliPP13KaonToPionRatioMC::IsPrimary(const AliAODMCParticle * particle) const
 {
 	// Look what particle left vertex (e.g. with vertex with radius <1 cm)
 	Double_t rcut = 1.;

--- a/PWGGA/PHOSTasks/PHOS_LHC16_pp/AliPP13KaonToPionRatioMC.h
+++ b/PWGGA/PHOSTasks/PHOS_LHC16_pp/AliPP13KaonToPionRatioMC.h
@@ -1,5 +1,5 @@
-#ifndef ALIPP13PION2KAONRATIOMC_H
-#define ALIPP13PION2KAONRATIOMC_H
+#ifndef ALIPP13KAONTOPIONRATIOMC_H
+#define ALIPP13KAONTOPIONRATIOMC_H
 
 
 #include <map>
@@ -28,7 +28,7 @@
 // TODO: Split this class to have separate efficiency and contamination estimators
 //
 
-class AliPP13PionToKaonRatioMC: public AliPP13PhysPhotonSelectionMC
+class AliPP13KaonToPionRatioMC: public AliPP13PhysPhotonSelectionMC
 {
 public:
 	enum Modes {kGenerated = 0, kReconstructed = 1, kNhists = 2};
@@ -41,7 +41,7 @@ public:
 	};
 
 
-	AliPP13PionToKaonRatioMC():
+	AliPP13KaonToPionRatioMC():
 		AliPP13PhysPhotonSelectionMC(),
 		fPrimary(),
 		fAll()
@@ -52,7 +52,7 @@ public:
 		fPartNames[kKminus] = "K^{-}";
 	}
 
-	AliPP13PionToKaonRatioMC(const char * name, const char * title,
+	AliPP13KaonToPionRatioMC(const char * name, const char * title,
 			AliPP13ClusterCuts cuts, AliPP13SelectionWeights * w):
 		AliPP13PhysPhotonSelectionMC(name, title, cuts, w),
 		fPrimary(),
@@ -81,8 +81,8 @@ protected:
 	}
 
 	virtual Bool_t IsPrimary(const AliAODMCParticle * particle) const;
-	AliPP13PionToKaonRatioMC(const AliPP13PionToKaonRatioMC &);
-	AliPP13PionToKaonRatioMC & operator = (const AliPP13PionToKaonRatioMC &);
+	AliPP13KaonToPionRatioMC(const AliPP13KaonToPionRatioMC &);
+	AliPP13KaonToPionRatioMC & operator = (const AliPP13KaonToPionRatioMC &);
 
 	typedef std::map<Int_t, TString> EnumNames;
 	EnumNames fPartNames;
@@ -92,6 +92,6 @@ protected:
 	EnumHists fAll;          //!
 
 	// Parameters of weighed MC parametrization
-	ClassDef(AliPP13PionToKaonRatioMC, 2)
+	ClassDef(AliPP13KaonToPionRatioMC, 2)
 };
 #endif

--- a/PWGGA/PHOSTasks/PHOS_LHC16_pp/macros/AddAnalysisTaskPP.C
+++ b/PWGGA/PHOSTasks/PHOS_LHC16_pp/macros/AddAnalysisTaskPP.C
@@ -69,7 +69,7 @@ AliAnalysisTaskPP13 * AddAnalysisTaskPP(
 
 		selections->Add(new AliPP13NonlinearityScanSelection("PhysNonlinScan", "Physics efficiency for neutral particles", cuts_pi0, &mc_weights));
 		selections->Add(new AliPP13MesonSelectionMC("MCStudy", "MC Selection with timing cut", cuts_pi0, &mc_weights));
-		selections->Add(new AliPP13PionToKaonRatioMC("PionToKaonRatio", "MC Selection for pion/kaon ratio", cuts_pi0, &mc_weights));
+		selections->Add(new AliPP13KaonToPionRatioMC("KaonToPionRatio", "MC Selection for pion/kaon ratio", cuts_pi0, &mc_weights));
 
 		delete & mc_weights;
 		delete & mc_weights_only;

--- a/PWGGA/PHOSTasks/PWGGAPHOSTasksLinkDef.h
+++ b/PWGGA/PHOSTasks/PWGGAPHOSTasksLinkDef.h
@@ -126,7 +126,7 @@
 #pragma link C++ class AliPP13PhysPhotonSelectionMC+;
 #pragma link C++ class AliPP13NonlinearityScanSelection+;
 #pragma link C++ class AliPP13NonlinearitySelection+;
-#pragma link C++ class AliPP13PionToKaonRatioMC+;
+#pragma link C++ class AliPP13KaonToPionRatioMC+;
 #pragma link C++ class AliPP13MixingSample+;
 #pragma link C++ class AliAnalysisTaskPP13+;
 


### PR DESCRIPTION
It also fixes typos in class names for PHOS neutral mesons analysis @ 13 TeV