### PR TITLE
[EMCAL-135] OADB/EMCAL: fix of AliOADBContainers and new maps for LHC16hijlqt and LHC17il

### DIFF
--- a/OADB/EMCAL/READMEoadb.txt
+++ b/OADB/EMCAL/READMEoadb.txt
@@ -27,5 +27,7 @@ In addition, a short history of changes to the files in EOS will be listed here:
 - 20180311: Update of EMCALTimeCalib.root and EMCALTimeL1PhaseCalib.root with LHC17o,p,q time calibrations
 - 20180320: Update of EMCALTimeCalib.root and EMCALTimeL1PhaseCalib.root with LHC17j time calibrations
 - 20180403: Update of EMCALBadChannels.root with LHC16f BC maps
+- 20180406: !! Fix for AliOADBContainer deletion problem uploaded, all files recreated for this !!
+- 20180406: Update of EMCALBadChannels.root with new maps for LHC17i,l and additional bad channels for LHC16h,i,j,l,q,t
 
 */


### PR DESCRIPTION
The OADB files for EMCal are now updated on EOS with a fix necessary to remove a memory leak from AliOADBContainer. Details about this can be found on JIRA EMCAL-135 and the PR 4792.

New BC maps for LHC17i,l were added and additional bad channels were added to the BC maps of LHC16hijlqt.