### PR TITLE
Remove unnecessary dependencies on AliEMCALRecoUtils

### DIFF
--- a/JETAN/JETAN/AliJetReaderHeader.cxx
+++ b/JETAN/JETAN/AliJetReaderHeader.cxx
@@ -23,7 +23,6 @@
 #include <TMath.h>
 
 #include "AliJetReaderHeader.h"
-#include "AliEMCALRecoUtils.h"
 
 ClassImp(AliJetReaderHeader)
 

--- a/JETAN/JETAN/AliJetReaderHeader.h
+++ b/JETAN/JETAN/AliJetReaderHeader.h
@@ -14,8 +14,6 @@
 #include <Riostream.h>  
 #include <TNamed.h>
 #include <TString.h>
-
-class AliEMCALRecoUtils;
  
 class AliJetReaderHeader : public TNamed
 {

--- a/PWGGA/PHOSTasks/PHOS_NeutralMeson/AliAnalysisTaskPHOSNeutralMeson.cxx
+++ b/PWGGA/PHOSTasks/PHOS_NeutralMeson/AliAnalysisTaskPHOSNeutralMeson.cxx
@@ -96,9 +96,6 @@
 #include "AliGenCocktailEventHeader.h"
 #include "AliGenEventHeader.h"
 
-// EMCAL includes
-#include "AliEMCALRecoUtils.h"
-
 using std::cout;
 using std::endl;
 

--- a/PWGHF/hfe/AliAnalysisTaskEHCorrel.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskEHCorrel.cxx
@@ -64,7 +64,6 @@
 #include "AliKFParticle.h"
 #include "AliKFVertex.h"
 #include "AliESDCaloTrigger.h"
-#include "AliEMCALRecoUtils.h"
 #include "AliEMCALGeometry.h"
 #include "AliGeomManager.h"
 #include "stdio.h"

--- a/PWGHF/hfe/AliAnalysisTaskEHCorrel.h
+++ b/PWGHF/hfe/AliAnalysisTaskEHCorrel.h
@@ -20,7 +20,6 @@ class AliMagF;
 class AliESDEvent;
 class AliAODEvent;
 class AliEMCALGeometry;
-class AliEMCALRecoUtils;
 class AliAnalysisFilter;
 class AliESDtrackCuts;
 class AliESDtrack;

--- a/PWGHF/hfe/AliAnalysisTaskEMCalHFEpA.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskEMCalHFEpA.cxx
@@ -90,23 +90,21 @@
 #include "AliVTrack.h"
 #include "AliEventPoolManager.h"
 #include "TObjArray.h"
-	//include to use reader as Lucile does
-#include "AliCaloTrackAODReader.h"
-#include "AliCaloTrackReader.h"
-#include "AliEMCALRecoUtils.h" //to remove exotics
+//include to use reader as Lucile does
+//#include "AliCaloTrackAODReader.h"
+//#include "AliCaloTrackReader.h"
+//#include "AliEMCALRecoUtils.h" //to remove exotics
 #include "AliAODHeader.h"
-#include "AliEMCALGeometry.h"
 
 #include "AliAnalysisUtils.h"
 
 
 
 	// --- ANALYSIS system ---
-#include "AliCalorimeterUtils.h"
+//#include "AliCalorimeterUtils.h"
 #include "AliESDEvent.h"
 #include "AliMCEvent.h"
 #include "AliStack.h"
-	//#include "AliAODPWG4Particle.h"
 #include "AliVCluster.h"
 #include "AliVCaloCells.h"
 #include "AliMixedEvent.h"
@@ -115,8 +113,8 @@
 #include "AliAnalysisManager.h"
 
 	// --- Detector ---
-#include "AliEMCALGeometry.h"
-#include "AliPHOSGeoUtils.h"
+//#include "AliEMCALGeometry.h"
+//#include "AliPHOSGeoUtils.h"
 
 	//______________________________________________________________________
 

--- a/PWGHF/hfe/AliAnalysisTaskEMCalHFEpA.h
+++ b/PWGHF/hfe/AliAnalysisTaskEMCalHFEpA.h
@@ -38,12 +38,12 @@ class AliEventPoolManager;
 class AliEventPool;
 class TObjArray;
 	//Lucile
-class AliCaloTrackAODReader;
-class AliCaloTrackReader;
-	//exotic
-class AliEMCALRecoUtils;
+//class AliCaloTrackAODReader;
+//class AliCaloTrackReader;
+//  //exotic
+//class AliEMCALRecoUtils;
 class AliAODReader;
-class AliCalorimeterUtils;
+//class AliCalorimeterUtils;
 class AliAnalysisUtils;
 
 	// --- ROOT system ---
@@ -57,12 +57,11 @@ class TArrayF;
 	//--- ANALYSIS system ---
 class AliVEvent;
 class AliVTrack;
-class AliAODPWG4Particle;
 class AliAODCaloCluster;
 class AliVCaloCells;
-class AliPHOSGeoUtils;
-class AliEMCALGeometry;
-#include "AliEMCALRecoUtils.h"
+//class AliPHOSGeoUtils;
+//class AliEMCALGeometry;
+//#include "AliEMCALRecoUtils.h"
 
 
 	//______________________________________________________________________

--- a/PWGHF/hfe/AliAnalysisTaskElecHadronCorrel.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskElecHadronCorrel.cxx
@@ -60,7 +60,6 @@
 #include "AliESDCaloCluster.h"
 #include "AliAODCaloCluster.h"
 #include "AliESDCaloTrigger.h"
-#include "AliEMCALRecoUtils.h"
 #include "AliEMCALGeometry.h"
 #include "AliGeomManager.h"
 #include "stdio.h"

--- a/PWGHF/hfe/AliAnalysisTaskElecHadronCorrel.h
+++ b/PWGHF/hfe/AliAnalysisTaskElecHadronCorrel.h
@@ -21,7 +21,6 @@ class AliMagF;
 class AliESDEvent;
 class AliAODEvent;
 class AliEMCALGeometry;
-class AliEMCALRecoUtils;
 class AliAnalysisFilter;
 class AliESDtrackCuts;
 class AliESDtrack;

--- a/PWGHF/hfe/AliAnalysisTaskElecHadronCorrel_Run1.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskElecHadronCorrel_Run1.cxx
@@ -60,7 +60,6 @@
 #include "AliESDCaloCluster.h"
 #include "AliAODCaloCluster.h"
 #include "AliESDCaloTrigger.h"
-#include "AliEMCALRecoUtils.h"
 #include "AliEMCALGeometry.h"
 #include "AliGeomManager.h"
 #include "stdio.h"

--- a/PWGHF/hfe/AliAnalysisTaskElecHadronCorrel_Run1.h
+++ b/PWGHF/hfe/AliAnalysisTaskElecHadronCorrel_Run1.h
@@ -21,7 +21,6 @@ class AliMagF;
 class AliESDEvent;
 class AliAODEvent;
 class AliEMCALGeometry;
-class AliEMCALRecoUtils;
 class AliAnalysisFilter;
 class AliESDtrackCuts;
 class AliESDtrack;

--- a/PWGHF/hfe/AliAnalysisTaskFlowTPCEMCalEP.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskFlowTPCEMCalEP.cxx
@@ -51,7 +51,6 @@
 #include "AliPhysicsSelection.h"
 #include "AliESDCaloCluster.h"
 #include "AliAODCaloCluster.h"
-#include "AliEMCALRecoUtils.h"
 #include "AliEMCALGeometry.h"
 #include "AliGeomManager.h"
 #include "stdio.h"

--- a/PWGHF/hfe/AliAnalysisTaskFlowTPCEMCalEP.h
+++ b/PWGHF/hfe/AliAnalysisTaskFlowTPCEMCalEP.h
@@ -29,7 +29,6 @@ class AliAODMCHeader;
 class AliGenEventHeader;
 class AliVEvent;
 class AliEMCALGeometry;
-class AliEMCALRecoUtils;
 class AliAnalysisFilter;
 class AliESDtrackCuts;
 class AliESDtrack;

--- a/PWGHF/hfe/AliAnalysisTaskFlowTPCEMCalQCSP.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskFlowTPCEMCalQCSP.cxx
@@ -57,7 +57,6 @@
 #include "AliESDCaloCluster.h"
 #include "AliAODCaloCluster.h"
 #include "AliESDCaloTrigger.h"
-#include "AliEMCALRecoUtils.h"
 #include "AliEMCALGeometry.h"
 #include "AliGeomManager.h"
 #include "stdio.h"

--- a/PWGHF/hfe/AliAnalysisTaskFlowTPCEMCalQCSP.h
+++ b/PWGHF/hfe/AliAnalysisTaskFlowTPCEMCalQCSP.h
@@ -21,7 +21,6 @@ class AliMagF;
 class AliESDEvent;
 class AliAODEvent;
 class AliEMCALGeometry;
-class AliEMCALRecoUtils;
 class AliAnalysisFilter;
 class AliESDtrackCuts;
 class AliESDtrack;

--- a/PWGHF/hfe/AliAnalysisTaskHFECal.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskHFECal.cxx
@@ -55,7 +55,6 @@
 #include "AliPhysicsSelection.h"
 #include "AliESDCaloCluster.h"
 #include "AliAODCaloCluster.h"
-#include "AliEMCALRecoUtils.h"
 #include "AliEMCALGeometry.h"
 #include "AliGeomManager.h"
 #include "stdio.h"

--- a/PWGHF/hfe/AliAnalysisTaskHFECal.h
+++ b/PWGHF/hfe/AliAnalysisTaskHFECal.h
@@ -26,7 +26,6 @@ class AliMagF;
 class AliESDEvent;
 class AliAODEvent;
 class AliEMCALGeometry;
-class AliEMCALRecoUtils;
 class AliAnalysisFilter;
 class AliESDtrackCuts;
 class AliESDtrack;

--- a/PWGHF/hfe/AliAnalysisTaskHFEEfficiency.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskHFEEfficiency.cxx
@@ -29,7 +29,6 @@
 #include "TRefArray.h"
 #include "TVector.h"
 #include "AliESDCaloCluster.h"
-#include "AliEMCALRecoUtils.h"
 #include "AliEMCALGeometry.h"
 #include "stdio.h"
 #include "TGeoManager.h"

--- a/PWGHF/hfe/AliAnalysisTaskHFEEfficiency.h
+++ b/PWGHF/hfe/AliAnalysisTaskHFEEfficiency.h
@@ -9,7 +9,6 @@ class TLorentzVector;
 class AliEMCALTrack;
 class AliESDEvent;
 class AliEMCALGeometry;
-class AliEMCALRecoUtils;
 
 class AliHFEcontainer;
 class AliHFEcuts;

--- a/PWGHF/hfe/AliAnalysisTaskHFEMultiplicity.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskHFEMultiplicity.cxx
@@ -72,7 +72,6 @@
 #include "AliKFParticle.h"
 #include "AliKFVertex.h"
 #include "AliESDCaloTrigger.h"
-#include "AliEMCALRecoUtils.h"
 #include "AliEMCALGeometry.h"
 #include "AliGeomManager.h"
 #include "AliCentrality.h"

--- a/PWGHF/hfe/AliAnalysisTaskHFEMultiplicity.h
+++ b/PWGHF/hfe/AliAnalysisTaskHFEMultiplicity.h
@@ -17,7 +17,6 @@ class AliMagF;
 class AliESDEvent;
 class AliAODEvent;
 class AliEMCALGeometry;
-class AliEMCALRecoUtils;
 class AliAnalysisFilter;
 class AliESDtrackCuts;
 class AliESDtrack;

--- a/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.cxx
@@ -92,7 +92,7 @@
 
 
 // --- ANALYSIS system ---
-#include "AliCalorimeterUtils.h"
+//#include "AliCalorimeterUtils.h"
 #include "AliESDEvent.h"
 #include "AliMCEvent.h"
 #include "AliStack.h"

--- a/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.h
+++ b/PWGHF/hfe/AliAnalysisTaskHFEpACorrelation.h
@@ -44,7 +44,7 @@ class AliCaloTrackAODReader;
 class AliCaloTrackReader;
 //exotic
 class AliAODReader;
-class AliCalorimeterUtils;
+//class AliCalorimeterUtils;
 class AliAnalysisUtils;
 
 // --- ROOT system ---

--- a/PWGHF/hfe/AliAnalysisTaskHaHFECorrel.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskHaHFECorrel.cxx
@@ -61,7 +61,6 @@
 #include "AliPhysicsSelection.h"
 #include "AliESDCaloCluster.h"
 #include "AliAODCaloCluster.h"
-#include "AliEMCALRecoUtils.h"
 #include "AliEMCALGeometry.h"
 #include "AliGeomManager.h"
 #include "stdio.h"

--- a/PWGHF/hfe/AliAnalysisTaskHaHFECorrel.h
+++ b/PWGHF/hfe/AliAnalysisTaskHaHFECorrel.h
@@ -29,7 +29,6 @@ class AliAODMCHeader;
 class AliGenEventHeader;
 class AliVEvent;
 class AliEMCALGeometry;
-class AliEMCALRecoUtils;
 class AliAnalysisFilter;
 class AliESDtrackCuts;
 class AliESDtrack;


### PR DESCRIPTION
In view of moving AliEMCALRecoUtils from AliRoot to AliPhysics I spotted that the classes in this commit include AliEMCALRecoUtils but do not use it at all. Please consider approving this since it should not affect at all any of those tasks.