### PR TITLE
Fix: K*+- set as not a physical primary particle 

### DIFF
--- a/PWGLF/CommonUtils/MConthefly/AliAnalysisTaskSimSpectraLF.cxx
+++ b/PWGLF/CommonUtils/MConthefly/AliAnalysisTaskSimSpectraLF.cxx
@@ -392,7 +392,7 @@ void AliAnalysisTaskSimSpectraLF::ParticleSel(TObject* obj){
   AliMCEvent *event = dynamic_cast<AliMCEvent*>(obj);
   if ( !event ) return;
     
-  Bool_t isPrimary[11] = { kTRUE, kTRUE, kTRUE, kTRUE, kTRUE, kTRUE, kTRUE, kTRUE, kTRUE, kFALSE, kFALSE };
+  Bool_t isPrimary[11] = { kTRUE, kTRUE, kTRUE, kTRUE, kTRUE, kTRUE, kTRUE, kTRUE, kFALSE, kFALSE, kFALSE };
 
   Short_t pidCodeMC = 0;
   Double_t myY = 0.;
@@ -436,9 +436,9 @@ void AliAnalysisTaskSimSpectraLF::ParticleSel(TObject* obj){
 	if (pPDG==3312) MCPartSel[0]	= 5.5;	//	Xi -
 	if (pPDG==3334) MCPartSel[0]	= 6.5;	//	Omega -
 	if (pPDG==3212) MCPartSel[0]	= 7.5;	//	Sigma 0
-	if (pPDG==323)	MCPartSel[0]	= 8.5;	//	K*(892) +-
       }
       else{
+	if (pPDG==323)	MCPartSel[0]	= 8.5;	//	K*(892) +-
 	if (pPDG==333)	MCPartSel[0]	= 9.5;	//	Phi(1020)
 	if (pPDG==313)	MCPartSel[0]	= 10.5;	//	K*(892)
       }

--- a/PWGLF/CommonUtils/MConthefly/AliAnalysisTaskSimSpectraLF.cxx
+++ b/PWGLF/CommonUtils/MConthefly/AliAnalysisTaskSimSpectraLF.cxx
@@ -320,9 +320,10 @@ Bool_t AliAnalysisTaskSimSpectraLF::IsMCParticleInKinematicRange(TObject *obj){
 
   if ( vpart->Pt() < fPtMin || vpart->Pt() > fPtMax ) // set pt cut
     isSelected = kFALSE;
+/*  
   if ( TMath::Abs(vpart->Eta()) > fEta ) // set pseudorapidity cut
     isSelected = kFALSE;
-
+*/
   return isSelected;
 }
 
@@ -350,7 +351,7 @@ void AliAnalysisTaskSimSpectraLF::EventSel(TObject* obj){
 
     Int_t pdgcode = TMath::Abs(mcPart->PdgCode());
     
-    if ( TMath::Abs(mcPart->Eta()) > fEta ) continue;
+     /* if ( TMath::Abs(mcPart->Eta()) > fEta ) continue; */ 
 
     if ( event->IsPhysicalPrimary(i) )
     {
@@ -526,17 +527,17 @@ Short_t AliAnalysisTaskSimSpectraLF::GetPidCode(Int_t pdgCode) const  {
     case 3334:
       pidCode = 6; // Omega-
     break;
-    case 333:
-      pidCode = 7; // phi(1020)
-    break;
-    case 313:
-      pidCode = 8; // K*(892)0
-    break;
     case 3212:
-      pidCode = 9; // Sigma 0
+      pidCode = 7; // Sigma 0
     break;
     case 323:
-    pidCode = 10; // K*(892)+-
+      pidCode = 8; // K*(892)+-
+    break;
+    case 333:
+      pidCode = 9; // phi(1020)
+    break;
+    case 313:
+      pidCode = 10; // K*(892)0
     break;
     default:
       pidCode = 999;  // something else


### PR DESCRIPTION
Before K*+- set as a physical primary particle(which was incorrect). The histogram is not filled up when K*+- set as isPhysPrim. So I changed it as done for phi and K*0 particles.