### PR TITLE
Setter for tpconly added

### DIFF
--- a/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.h
+++ b/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.h
@@ -70,6 +70,7 @@ class AliAnalysisTrackingUncertaintiesAOT : public AliAnalysisTaskSE {
   void           SetMaxCentrality(Double_t val) {fmaxCent = val;}
   void           SetUseCentrality(AliAnalysisTrackingUncertaintiesAOT::ECentrality flag);
   void           SetDCAzOn(Bool_t flag = kTRUE) {fDCAz = flag;}
+  void           SetTPConly(Bool_t tpconly = kTRUE) {fTPConlyFIT = tpconly;}
 
   ULong64_t GetTriggerMask() {return fTriggerMask;}
   ULong64_t GetSpecie() {return fspecie;}

--- a/PWGPP/macros/AddTaskTrackingUncertAOT.C
+++ b/PWGPP/macros/AddTaskTrackingUncertAOT.C
@@ -18,7 +18,7 @@ AliAnalysisTask *AddTaskTrackingUncertAOT(Bool_t readMC = kFALSE,
                                           AliESDtrackCuts::ITSClusterRequirement spdReq=AliESDtrackCuts::kAny,
                                           Bool_t useGenPt = kFALSE,
                                           Bool_t DCAzOn= kFALSE,
-                                          Bool_t fTPConlyFIT=kFALSE) {
+                                          Bool_t fTPConlyFIT=kTRUE) {
 
     
   //
@@ -53,6 +53,8 @@ AliAnalysisTask *AddTaskTrackingUncertAOT(Bool_t readMC = kFALSE,
   task->SetTriggerClass(trigClass.Data());
   task->SetTriggerMask(trigMask);
 
+
+  task->SetTPConly(fTPConlyFIT);
   task->SetSpecie(specie);
   task->SetMaxDCAxy(MaxDCAxy);
   task->SetMaxDCAz(MaxDCAz);


### PR DESCRIPTION
A Set method has been added in .h and AddTask to use TPConly tracks for DCA distributions