### PR TITLE
new PID parametrization for low magnetic field configuration

### DIFF
--- a/PWGLF/SPECTRA/PiKaPr/ITSsa/AliAnalysisTaskSEITSsaSpectra.cxx
+++ b/PWGLF/SPECTRA/PiKaPr/ITSsa/AliAnalysisTaskSEITSsaSpectra.cxx
@@ -126,6 +126,7 @@ ClassImp(AliAnalysisTaskSEITSsaSpectra)
     fPidMethod(kMeanCut),
     fUseDefaultPriors(kTRUE),
     fIsMC(kFALSE),
+    fIsNominalBfield(kTRUE),
     fFillNtuple(kFALSE),
     fFillIntDistHist(kFALSE),
     fRandGener(0x0),
@@ -1666,6 +1667,131 @@ void AliAnalysisTaskSEITSsaSpectra::PostAllData()
 //
 //
 //________________________________________________________________________
+double AliAnalysisTaskSEITSsaSpectra::BetheITSsaHybrid(double p, double mass) const
+{
+  //
+  // returns AliExternalTrackParam::BetheBloch normalized to
+  // fgMIP at the minimum. The PHOBOS parameterization is used for beta*gamma>0.76.
+  // For beta*gamma<0.76 a polinomial function is used
+
+  Double_t fBBsaHybrid[10];
+  Double_t fBBsaElectron[6];
+
+  if(!fIsMC) {//DATA
+    if(fIsNominalBfield || (mass>0.130 && mass<0.140) || (mass>0.0005 && mass<0.00052)){//pions&elect want always the same parametrization
+      fBBsaHybrid[0]=1.43505E7;  //PHOBOS+Polinomial parameterization
+      fBBsaHybrid[1]=49.3402;
+      fBBsaHybrid[2]=1.77741E-7;
+      fBBsaHybrid[3]=1.77741E-7;
+      fBBsaHybrid[4]=1.01311E-7;
+      fBBsaHybrid[5] = -2.; //exponent of beta in the PHOBOS
+      fBBsaHybrid[6]=77.2777;
+      fBBsaHybrid[7]=33.4099;
+      fBBsaHybrid[8]=46.0089;
+      fBBsaHybrid[9]=-2.26583;
+      fBBsaElectron[0]=4.05799E6;  //electrons in the ITS
+      fBBsaElectron[1]=38.5713;
+      fBBsaElectron[2]=1.46462E-7;
+      fBBsaElectron[3]=1.46462E-7;
+      fBBsaElectron[4]=4.40284E-7;
+      fBBsaElectron[5]=-2.;
+    }
+    else{
+      fBBsaHybrid[0]=2.6110e6;//E0  //PHOBOS+Polinomial parameterization
+      fBBsaHybrid[1]=202.672877;//b
+      fBBsaHybrid[2]=-1.6881e-4;//a
+      fBBsaHybrid[3]=1.9541e-4;//c
+      fBBsaHybrid[4]=9.4432e-9;//d
+      fBBsaHybrid[5]=-1.54;
+      fBBsaHybrid[6]=0.;//p0
+      fBBsaHybrid[7]=0.;//p1
+      fBBsaHybrid[8]=0.;//p2
+      fBBsaHybrid[9]=0.;//p3
+
+      fBBsaElectron[0]=79.856480;//E0 //electrons in the ITS
+      fBBsaElectron[1]=64.838062;//b
+      fBBsaElectron[2]=1.1440e-1;//a
+      fBBsaElectron[3]=-8.6559e-3;//c
+      fBBsaElectron[4]=-5.5526e-4;//d
+      fBBsaElectron[5]=-1.54;//exp
+    }
+
+  } else {//MC
+
+    if(fIsNominalBfield || (mass>0.130 && mass<0.140) || (mass>0.0005 && mass<0.00052)){
+      fBBsaHybrid[0]=1.05381E7; //PHOBOS+Polinomial parameterization
+      fBBsaHybrid[1]=89.3933;
+      fBBsaHybrid[2]=2.4831E-7;
+      fBBsaHybrid[3]=2.4831E-7;
+      fBBsaHybrid[4]=7.80591E-8;
+      fBBsaHybrid[5]=-2.;
+      fBBsaHybrid[6]=62.9214;
+      fBBsaHybrid[7]=32.347;
+      fBBsaHybrid[8]=58.7661;
+      fBBsaHybrid[9]=-3.39869;
+      fBBsaElectron[0]=2.26807E6; //electrons in the ITS
+      fBBsaElectron[1]=99.985;
+      fBBsaElectron[2]=0.000714841;
+      fBBsaElectron[3]=0.000259585;
+      fBBsaElectron[4]=1.39412E-7;
+      fBBsaElectron[5]=-2.;
+    }
+    else{//low B field
+      fBBsaHybrid[0]=1.5173e6;//E0  //PHOBOS+Polinomial parameterization
+      fBBsaHybrid[1]=242.170459;//b
+      fBBsaHybrid[2]=-2.2914e-4;//a
+      fBBsaHybrid[3]=2.4990e-4;//c
+      fBBsaHybrid[4]=-2.4902e-8;//d
+      fBBsaHybrid[5]=-1.58;//exp of beta
+      fBBsaHybrid[6]=0.;//p0
+      fBBsaHybrid[7]=0.;//p1
+      fBBsaHybrid[8]=0.;//p2
+      fBBsaHybrid[9]=0.;//p3
+
+
+      fBBsaElectron[0]=80.981442;//E0 //electrons in the ITS
+      fBBsaElectron[1]=61.698532;//b
+      fBBsaElectron[2]=1.1459e-1;//a
+      fBBsaElectron[3]=-9.3479e-3;//c
+      fBBsaElectron[4]=-4.8142e-4;//d
+      fBBsaElectron[5]=-1.58;//exp of beta
+    }
+
+}
+
+  Double_t bg=p/mass;
+  Double_t beta = bg/TMath::Sqrt(1.+ bg*bg);
+  Double_t gamma=bg/beta;
+  Double_t bb=1.;
+
+  Double_t betagcut = fIsNominalBfield? 0.76 : 1e-20;
+
+  Double_t par[10];
+  //parameters for pi, K, p
+  for(Int_t ip=0; ip<10;ip++) par[ip]=fBBsaHybrid[ip];
+    //if it is an electron the PHOBOS part of the parameterization is tuned for e
+    //in the range used for identification beta*gamma is >0.76 for electrons
+    //To be used only between 100 and 160 MeV/c
+    if(mass>0.0005 && mass<0.00052) for(Int_t ip=0; ip<6; ip++) par[ip]=fBBsaElectron[ip];
+
+      if(gamma>=0. && beta>0. && bg>0.1){
+        if(bg>betagcut){//PHOBOS
+          Double_t eff=1.0;
+          if(bg<par[2])
+           eff=(bg-par[3])*(bg-par[3])+par[4];
+          else
+           eff=(par[2]-par[3])*(par[2]-par[3])+par[4];
+          bb=(par[1]+2.0*TMath::Log(gamma)-beta*beta)*(par[0]/(TMath::Power(beta, -par[5])))*eff;
+        }else{//Polinomial
+          bb=par[6] + par[7]/bg + par[8]/(bg*bg) + par[9]/(bg*bg*bg);
+        }
+      }
+  return bb;
+}
+
+//
+//
+//________________________________________________________________________
 int AliAnalysisTaskSEITSsaSpectra::GetTrackPid(AliESDtrack *track, double *logdiff) const
 {
   AliPID::EParticleType iType[4] = { AliPID::kPion, AliPID::kKaon, AliPID::kProton, AliPID::kDeuteron };
@@ -1684,7 +1810,8 @@ int AliAnalysisTaskSEITSsaSpectra::GetTrackPid(AliESDtrack *track, double *logdi
   double bbtheo[4];
   for (int i = 0; i < 4; i++) {
     float mass = AliPID::ParticleMass(iType[i]);
-    bbtheo[i] = fITSPIDResponse->BetheITSsaHybrid(p, mass);
+    //bbtheo[i] = fITSPIDResponse->BetheITSsaHybrid(p, mass);
+    bbtheo[i] = BetheITSsaHybrid(p, mass);
     logdiff[i] = TMath::Log(dedx) - TMath::Log(bbtheo[i]);
   }
 

--- a/PWGLF/SPECTRA/PiKaPr/ITSsa/AliAnalysisTaskSEITSsaSpectra.h
+++ b/PWGLF/SPECTRA/PiKaPr/ITSsa/AliAnalysisTaskSEITSsaSpectra.h
@@ -165,6 +165,7 @@ class AliAnalysisTaskSEITSsaSpectra : public AliAnalysisTaskSE
   void SetPidTech(int tech) { fPidMethod = static_cast<EPID_Type>(tech); }
   void SetUseDefaultPriors(bool flag = kTRUE) { fUseDefaultPriors = flag; }
   void SetITSPidParams(AliITSPidParams *pidParams) { fITSPidParams = pidParams; }
+  void SetIsNominalBfield(bool flag = kTRUE) {fIsNominalBfield = flag;}
   void SetIsMC(bool flag = kTRUE) { fIsMC = flag; }
   void SetFillNtuple(bool flag = kTRUE) { fFillNtuple = flag; }
   void SetFillIntDistHist() { fFillIntDistHist = kTRUE; }
@@ -204,6 +205,7 @@ class AliAnalysisTaskSEITSsaSpectra : public AliAnalysisTaskSE
   void CreateDCAcutFunctions();
   void PostAllData();
 
+  double BetheITSsaHybrid(double p, double mass) const;
   int GetTrackPid(AliESDtrack *track, double *logdiff) const;
   int GetMostProbable(const double *pDens, const double *priors) const;
   void GetPriors(const AliVTrack *track, double *priors) const;
@@ -371,6 +373,7 @@ class AliAnalysisTaskSEITSsaSpectra : public AliAnalysisTaskSE
 
   bool fUseDefaultPriors; // flag to use default(equal) priors
   bool fIsMC;             // flag to switch on the MC analysis for the efficiency estimation
+  bool fIsNominalBfield;  // flag to select the magnetic field (nominal = 0.5 T)
   bool fFillNtuple;       // flag to fill ntuples
   bool fFillIntDistHist;  // flag to fill histogram with information for statistic pid analysis
 


### PR DESCRIPTION
PID parametrization for low magnetic field configuration. New parameters for PHOBOS parametrization. Pions and electrons use the old parametrization for nominal field.