### PR TITLE
[EMCAL-51] Remap TRU index to STU convention

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
@@ -384,7 +384,7 @@ void AliEmcalTriggerMakerTask::InitializeFastORMaskingFromOCDB(){
       for(unsigned int ibit = 0; ibit < 16; ibit ++){
         if((truconf->GetMaskReg(ifield) >> ibit) & 0x1){
           try{
-            fGeom->GetTriggerMapping()->GetAbsFastORIndexFromTRU(itru, (ic =  GetMaskHandler()(ifield, ibit)), fastOrAbsID);
+            fGeom->GetTriggerMapping()->GetAbsFastORIndexFromTRU(RemapTRUIndex(itru), (ic =  GetMaskHandler()(ifield, ibit)), fastOrAbsID);
             AliDebugStream(1) << GetName() << "Channel " << ic  << " in TRU " << itru << " ( abs fastor " << fastOrAbsID << ") masked." << std::endl;
             fTriggerMaker->AddFastORBadChannel(fastOrAbsID);
           } catch (int exept){
@@ -431,6 +431,13 @@ std::function<int (unsigned int, unsigned int)> AliEmcalTriggerMakerTask::GetMas
       return ifield * 16 + ibit;
     };
   }
+}
+
+int AliEmcalTriggerMakerTask::RemapTRUIndex(int itru) const {
+  if(fGeom->GetTriggerMappingVersion() == 2){
+    const int trumapping[46] = {0,1,2,5,4,3,6,7,8,11,10,9,12,13,14,17,16,15,18,19,20,23,22,21,24,25,26,29,28,27,30,31,32,33,37,36,38,39,43,42,44,45,49,48,50,51};
+    return trumapping[itru];
+  } else return itru;
 }
 
 void AliEmcalTriggerMakerTask::FillQAHistos(const TString &patchtype, const AliEMCALTriggerPatchInfo &recpatch){

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.h
@@ -209,6 +209,22 @@ protected:
   std::function<int (unsigned int, unsigned int)> GetMaskHandler() const;
 #endif
 
+ /**
+  * @brief Fix mapping in TRU index
+  * 
+  * In run 2 the index of the TRU is different between
+  * TRU indexing and STU indexing:
+  * - STU indexing: Linear, including PHOS region
+  * - TRU indexing: Out to in in eta (C-side mirrored), no PHOS region
+  * Obviously the mapping uses the STU indexing. This function
+  * remaps the TRU indexing (used in the DCS configuration) to the
+  * STU indexing
+  * 
+  * @param itru TRU index in TRU convention 
+  * @return int TRU index in STU convention
+  */
+  int RemapTRUIndex(int itru) const;
+
   /**
    * @brief Internal QA handler for trigger pathches of given type
    *


### PR DESCRIPTION
Tests indicate that the abs fastor indexing works with
the STU convention while the DCS uses the TRU indexing.
In order to mask FastORs correctly based on the trigger
DCS config from OCDB the TRU indexing needs to be
remapped, otherwise masked FastORs appear in the wrong
position.