### PR TITLE
Fix for proper tref handling

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliAodSkimTask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliAodSkimTask.cxx
@@ -20,13 +20,19 @@
 using namespace std;
 ClassImp(AliAodSkimTask)
 
-AliAodSkimTask::AliAodSkimTask() : AliAnalysisTaskSE(), fClusMinE(-1), fCutMC(1), fTrials(0), fPyxsec(0), fPytrials(0), 
-                                   fPypthardbin(0), fAOD(0), fAODMcHeader(0), fOutputList(0)
+AliAodSkimTask::AliAodSkimTask() : 
+  AliAnalysisTaskSE(), fClusMinE(-1), fCutMC(1), fYCutMC(0.7),
+  fDoCopyHeader(1),  fDoCopyVZERO(1),  fDoCopyTZERO(1),  fDoCopyVertices(1),  fDoCopyTOF(1), fDoCopyTracks(1), 
+  fDoCopyTrigger(1), fDoCopyPTrigger(0), fDoCopyCells(1), fDoCopyPCells(0), fDoCopyClusters(1), fDoCopyMC(1), fDoCopyMCHeader(1),
+  fTrials(0), fPyxsec(0), fPytrials(0), fPypthardbin(0), fAOD(0), fAODMcHeader(0), fOutputList(0)
 {
 }
 
-AliAodSkimTask::AliAodSkimTask(const char* name) : AliAnalysisTaskSE(name), fClusMinE(-1), fCutMC(1), fTrials(0), fPyxsec(0), fPytrials(0),
-                                                   fPypthardbin(0), fAOD(0), fAODMcHeader(0), fOutputList(0)
+AliAodSkimTask::AliAodSkimTask(const char* name) : 
+  AliAnalysisTaskSE(name), fClusMinE(-1), fCutMC(1), fYCutMC(0.7),
+  fDoCopyHeader(1),  fDoCopyVZERO(1),  fDoCopyTZERO(1),  fDoCopyVertices(1),  fDoCopyTOF(1), fDoCopyTracks(1), 
+  fDoCopyTrigger(1), fDoCopyPTrigger(0), fDoCopyCells(1), fDoCopyPCells(0), fDoCopyClusters(1), fDoCopyMC(1), fDoCopyMCHeader(1),
+  fTrials(0), fPyxsec(0), fPytrials(0), fPypthardbin(0), fAOD(0), fAODMcHeader(0), fOutputList(0)
 {
   DefineInput(0, TChain::Class());
   DefineOutput(1, TList::Class());
@@ -64,8 +70,15 @@ void AliAodSkimTask::UserExec(Option_t *)
   if (!fAOD)
     return;
 
-  Bool_t store = kFALSE;
+  AliAnalysisManager *man = AliAnalysisManager::GetAnalysisManager();
+  AliAODHandler *oh = (AliAODHandler*)man->GetOutputEventHandler();
+  if (!oh) {
+    AliFatal("No output handler found");
+    return;
+  }
+  oh->SetFillAOD(kFALSE);
 
+  Bool_t store = kFALSE;
   if (fClusMinE>0) {
     TClonesArray *cls  = fAOD->GetCaloClusters();  
     for (Int_t i=0; i<cls->GetEntriesFast(); ++i) {
@@ -87,127 +100,147 @@ void AliAodSkimTask::UserExec(Option_t *)
     fHevs->Fill(0);
     return;
   }
+
   fHevs->Fill(1);
 
-  AliAnalysisManager *man = AliAnalysisManager::GetAnalysisManager();
-  AliAODHandler *oh = (AliAODHandler*)man->GetOutputEventHandler();
-  if (oh)
-    oh->SetFillAOD(kFALSE);
-
-  if (1) {
-    oh->SetFillAOD(kTRUE);
-    AliAODEvent *eout = dynamic_cast<AliAODEvent*>(oh->GetAOD());
-    AliAODEvent *evin = dynamic_cast<AliAODEvent*>(InputEvent());
-    TTree *tout = oh->GetTree();
-    if (tout) {
-      TList *lout = tout->GetUserInfo();
-      if (lout->FindObject("alirootVersion")==0) {
-	TList *lin = AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler()->GetUserInfo();
-	for (Int_t jj=0;jj<lin->GetEntries()-1;++jj) { 
-	  lout->Add(lin->At(jj)->Clone(lin->At(jj)->GetName()));
-	}
+  oh->SetFillAOD(kTRUE);
+  AliAODEvent *eout = dynamic_cast<AliAODEvent*>(oh->GetAOD());
+  AliAODEvent *evin = dynamic_cast<AliAODEvent*>(InputEvent());
+  TTree *tout = oh->GetTree();
+  if (tout) {
+    TList *lout = tout->GetUserInfo();
+    if (lout->FindObject("alirootVersion")==0) {
+      TList *lin = AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler()->GetUserInfo();
+      for (Int_t jj=0;jj<lin->GetEntries()-1;++jj) { 
+	lout->Add(lin->At(jj)->Clone(lin->At(jj)->GetName()));
       }
     }
-	
-    if (1) {
-      AliAODHeader *out = (AliAODHeader*)eout->GetHeader();                      
-      AliAODHeader *in  = (AliAODHeader*)evin->GetHeader();  	    
-      *out = *in;
-      out->SetUniqueID(fTrials);
-    }
-    if (1) {   
-      AliAODVZERO *out = eout->GetVZEROData();	                 
-      AliAODVZERO *in  = evin->GetVZEROData();
-      *out = *in;                  
-    }
-    if (1) {   
-      AliAODTZERO *out = eout->GetTZEROData();	                 
-      AliAODTZERO *in  = evin->GetTZEROData(); 	    
-      *out = *in; 
-    }
-    if (1) {   
-      TClonesArray *out = eout->GetVertices(); 
-      TClonesArray *in  = evin->GetVertices();      
-      for (Int_t i=0;i<in->GetEntriesFast();++i) {
-	AliAODVertex *v = static_cast<AliAODVertex*>(in->At(i));
-	new ((*out)[i]) AliAODVertex(*v);
-      }
-    }
-    if (1) {   
-      AliTOFHeader *out = const_cast<AliTOFHeader*>(eout->GetTOFHeader()); 
-      const AliTOFHeader *in = evin->GetTOFHeader();	    
-      *out = *in;                  
-    }
-    if (1) {
-      TClonesArray *out = eout->GetTracks();	                 
-      TClonesArray *in  = evin->GetTracks();	
-      for (Int_t i=0;i<in->GetEntriesFast();++i) {
-	AliAODTrack *t = static_cast<AliAODTrack*>(in->At(i));
-	new ((*out)[i]) AliAODTrack(*t);
-      }
-    }
-    if (1) { 
-      AliAODCaloTrigger *out = eout->GetCaloTrigger("EMCAL");
-      AliAODCaloTrigger *in  = evin->GetCaloTrigger("EMCAL");
-      *out = *in;
-    }
-    if (1) { 
-      AliAODCaloCells *out = eout->GetEMCALCells();                  
-      AliAODCaloCells *in  = evin->GetEMCALCells();    
-      *out = *in;
-    }
-    if (1) { 
-      TClonesArray *out = eout->GetCaloClusters();	         
-      TClonesArray *in  = evin->GetCaloClusters();  
-      for (Int_t i=0;i<in->GetEntriesFast();++i) {
-	AliAODCaloCluster *c = static_cast<AliAODCaloCluster*>(in->At(i));
-	new ((*out)[i]) AliAODCaloCluster(*c);
-      }
-    }
-
-    if (1) {
-      TClonesArray *out = static_cast<TClonesArray*>(eout->FindListObject(AliAODMCParticle::StdBranchName()));
-      TClonesArray *in  = static_cast<TClonesArray*>(evin->FindListObject(AliAODMCParticle::StdBranchName()));
-      if (in && !out) {
-	fgAODMCParticles = new TClonesArray("AliAODMCParticle",1000);
-	fgAODMCParticles->SetName(AliAODMCParticle::StdBranchName());
-	oh->AddBranch("TClonesArray", &fgAODMCParticles);
-	out = static_cast<TClonesArray*>(eout->FindListObject(AliAODMCParticle::StdBranchName()));
-      } 
-      if (in && out) {
-	if (fCutMC) {
-	  for (Int_t i=0;i<in->GetEntriesFast();++i) {
-	    AliAODMCParticle *mc = static_cast<AliAODMCParticle*>(in->At(i));
-	    if (TMath::Abs(mc->Y())>1.2)
-	      new ((*out)[i]) AliAODMCParticle;
-	    else
-	      new ((*out)[i]) AliAODMCParticle(*mc);
-	  }
-	}
-      }      
-    }
-
-    if (1) {
-      AliAODMCHeader *out = static_cast<AliAODMCHeader*>(eout->FindListObject(AliAODMCHeader::StdBranchName()));
-      AliAODMCHeader *in  = static_cast<AliAODMCHeader*>(evin->FindListObject(AliAODMCHeader::StdBranchName()));
-      if (in && !out) { 
-	fAODMcHeader = new AliAODMCHeader();
-	fAODMcHeader->SetName(AliAODMCHeader::StdBranchName());
-	oh->AddBranch("AliAODMCHeader",&fAODMcHeader); 
-	out = static_cast<AliAODMCHeader*>(eout->FindListObject(AliAODMCHeader::StdBranchName()));
-      } 
-      if (in && out) {
-	*out = *in;
-	if ((in->GetCrossSection()==0) && (fPyxsec>0)) {
-	  out->SetCrossSection(fPyxsec);
-	  out->SetTrials(fPytrials);
-	  out->SetPtHard(fPypthardbin);
-	}
-      }
-    }
-    fTrials = 0;
-    PostData(1, fOutputList);
   }
+
+  if (fDoCopyHeader) {
+    AliAODHeader *out = (AliAODHeader*)eout->GetHeader();                      
+    AliAODHeader *in  = (AliAODHeader*)evin->GetHeader();  	    
+    *out = *in;
+    out->SetUniqueID(fTrials);
+  }
+  if (fDoCopyVZERO) {   
+    AliAODVZERO *out = eout->GetVZEROData();	                 
+    AliAODVZERO *in  = evin->GetVZEROData();
+    *out = *in;                  
+  }
+  if (fDoCopyTZERO) {   
+    AliAODTZERO *out = eout->GetTZEROData();	                 
+    AliAODTZERO *in  = evin->GetTZEROData(); 	    
+    *out = *in; 
+  }
+  if (fDoCopyVertices) {   
+    TClonesArray *out = eout->GetVertices(); 
+    TClonesArray *in  = evin->GetVertices();      
+    if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
+      AliFatal(Form("%s - UserExce: Previous event not deleted. This should not happen!",GetName()));
+    }
+    out->AbsorbObjects(in);
+  }
+  if (fDoCopyTOF) {   
+    AliTOFHeader *out = const_cast<AliTOFHeader*>(eout->GetTOFHeader()); 
+    const AliTOFHeader *in = evin->GetTOFHeader();	    
+    *out = *in;                  
+  }
+  if (fDoCopyTracks) {
+    TClonesArray *out = eout->GetTracks();	                 
+    TClonesArray *in  = evin->GetTracks();	
+    if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
+      AliFatal(Form("%s - UserExce: Previous event not deleted. This should not happen!",GetName()));
+    }
+    out->AbsorbObjects(in);
+  }
+  if (fDoCopyTrigger) { 
+    AliAODCaloTrigger *out = eout->GetCaloTrigger("EMCAL");
+    AliAODCaloTrigger *in  = evin->GetCaloTrigger("EMCAL");
+    *out = *in;
+  }
+  if (fDoCopyPTrigger) { 
+    AliAODCaloTrigger *out = eout->GetCaloTrigger("PHOS");
+    AliAODCaloTrigger *in  = evin->GetCaloTrigger("PHOS");
+    *out = *in;
+  }
+  if (fDoCopyCells) { 
+    AliAODCaloCells *out = eout->GetEMCALCells();                  
+    AliAODCaloCells *in  = evin->GetEMCALCells();    
+      *out = *in;
+  }
+  if (fDoCopyPCells) { 
+    AliAODCaloCells *out = eout->GetPHOSCells();                  
+    AliAODCaloCells *in  = evin->GetPHOSCells();    
+    *out = *in;
+  }
+  if (fDoCopyClusters) { 
+    TClonesArray *out = eout->GetCaloClusters();	         
+    TClonesArray *in  = evin->GetCaloClusters();  
+    if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
+      AliFatal(Form("%s - UserExce: Previous event not deleted. This should not happen!",GetName()));
+    }
+    out->AbsorbObjects(in);
+  }
+  
+  if (fDoCopyMC) {
+    TClonesArray *out = static_cast<TClonesArray*>(eout->FindListObject(AliAODMCParticle::StdBranchName()));
+    TClonesArray *in  = static_cast<TClonesArray*>(evin->FindListObject(AliAODMCParticle::StdBranchName()));
+    if (in && !out) {
+      fgAODMCParticles = new TClonesArray("AliAODMCParticle",2*in->GetEntries());
+      fgAODMCParticles->SetName(AliAODMCParticle::StdBranchName());
+      oh->AddBranch("TClonesArray", &fgAODMCParticles);
+      out = static_cast<TClonesArray*>(eout->FindListObject(AliAODMCParticle::StdBranchName()));
+    }
+    if (in && out) {
+      if (out->GetEntries()>0) { // just checking if the deletion of previous event worked
+	AliFatal(Form("%s - UserExce: Previous event not deleted. This should not happen!",GetName()));
+      }
+      out->AbsorbObjects(in);
+      if (fCutMC) {
+	for (Int_t i=0;i<out->GetEntriesFast();++i) {
+	  AliAODMCParticle *mc = static_cast<AliAODMCParticle*>(in->At(i));
+	  if ((mc==0)&&(i==0)) {
+	    AliError(Form("%s - UserExce: No MC info, skipping this event!",GetName()));
+	    oh->SetFillAOD(kFALSE);
+	    return;
+	  }
+	  if ((mc==0)||(TMath::Abs(mc->Y())>fYCutMC))
+	    new ((*out)[i]) AliAODMCParticle;
+	}
+      }
+    }      
+  }
+
+  if (fDoCopyMCHeader) {
+    AliAODMCHeader *out = static_cast<AliAODMCHeader*>(eout->FindListObject(AliAODMCHeader::StdBranchName()));
+    AliAODMCHeader *in  = static_cast<AliAODMCHeader*>(evin->FindListObject(AliAODMCHeader::StdBranchName()));
+    if (in && !out) { 
+      fAODMcHeader = new AliAODMCHeader();
+      fAODMcHeader->SetName(AliAODMCHeader::StdBranchName());
+      oh->AddBranch("AliAODMCHeader",&fAODMcHeader); 
+      out = static_cast<AliAODMCHeader*>(eout->FindListObject(AliAODMCHeader::StdBranchName()));
+    } 
+    if (in && out) {
+      *out = *in;
+      if ((in->GetCrossSection()==0) && (fPyxsec>0)) {
+	out->SetCrossSection(fPyxsec);
+	out->SetTrials(fPytrials);
+	out->SetPtHard(fPypthardbin);
+      }
+    }
+  }
+
+  if (gDebug>10) { 
+    Int_t  run = eout->GetRunNumber();
+    AliAODVertex *v=(AliAODVertex*)eout->GetVertices()->At(0);
+    Int_t   vzn = v->GetNContributors();
+    Double_t vz = v->GetZ();
+    cout << "debug run " << run << " " << vzn << " " << vz << endl;
+  }
+
+  fTrials = 0;
+  PostData(1, fOutputList);
 }
 
 Bool_t AliAodSkimTask::UserNotify()
@@ -238,7 +271,7 @@ Bool_t AliAodSkimTask::UserNotify()
   gErrorIgnoreLevel=slevel;
 
   if (res) {
-    cout << "AliAodSkimTask " << GetName() << " found " << xsection << " " << trials << " " << pthardbin << " " << nevents << endl;
+    cout << "AliAodSkimTask " << GetName() << " found xsec info: " << xsection << " " << trials << " " << pthardbin << " " << nevents << endl;
     fPyxsec      = xsection;      
     fPytrials    = trials;      
     fPypthardbin = pthardbin;
@@ -249,7 +282,8 @@ Bool_t AliAodSkimTask::UserNotify()
 
 void AliAodSkimTask::Terminate(Option_t *)
 {
-  cout << "AliAodSkimTask " << GetName() << " terminated with accepted fraction of events: " << fHevs->GetBinContent(2)/fHevs->GetEntries() << endl;
+  cout << "AliAodSkimTask " << GetName() << " terminated with accepted fraction of events: " << fHevs->GetBinContent(2)/fHevs->GetEntries() 
+       << " (" << fHevs->GetBinContent(2) << "/" << fHevs->GetEntries() << ")" << endl;
 }
 
 Bool_t AliAodSkimTask::PythiaInfoFromFile(const char* currFile, Float_t &xsec, Float_t &trials, Int_t &pthard)

--- a/PWG/EMCAL/EMCALtasks/AliAodSkimTask.h
+++ b/PWG/EMCAL/EMCALtasks/AliAodSkimTask.h
@@ -1,6 +1,13 @@
 #ifndef AliAodSkimTask_H
 #define AliAodSkimTask_H
 
+/// \class AliAodSkimTask
+/// \brief Use to skim AOD files
+///
+/// Class to skim AOD files with the idea to keep the skimmed file as close as possible to the original AOD.
+///
+/// \author C.Loizides
+
 #include <AliAnalysisTaskSE.h>
 class AliAODMCHeader;
 class TH1F;
@@ -11,26 +18,53 @@ class AliAodSkimTask: public AliAnalysisTaskSE
     AliAodSkimTask();
     AliAodSkimTask(const char *name);
     virtual              ~AliAodSkimTask();
-    void                  SetClusMinE(Double_t v) {fClusMinE=v;}
-    void                  SetCutMC(Bool_t b)      {fCutMC=b;   }
+    void                  SetClusMinE(Double_t v)   {fClusMinE=v;}
+    void                  SetCutMC(Bool_t b)        {fCutMC=b;}
+    void                  SetYCutMC(Double_t v)     {fYCutMC=v;}
+    void                  SetCopyHeader(Bool_t b)   {fDoCopyHeader=b;}
+    void                  SetCopyVZERO(Bool_t b)    {fDoCopyVZERO=b;}
+    void                  SetCopyTZERO(Bool_t b)    {fDoCopyTZERO=b;}
+    void                  SetCopyVertices(Bool_t b) {fDoCopyVertices=b;}
+    void                  SetCopyTOF(Bool_t b)      {fDoCopyTOF=b;}
+    void                  SetCopyTracks(Bool_t b)   {fDoCopyTracks=b;}
+    void                  SetCopyTrigger(Bool_t b)  {fDoCopyTrigger=b;}
+    void                  SetCopyPTrigger(Bool_t b) {fDoCopyPTrigger=b;}
+    void                  SetCopyCells(Bool_t b)    {fDoCopyCells=b;}
+    void                  SetCopyPCells(Bool_t b)   {fDoCopyPCells=b;}
+    void                  SetCopyClusters(Bool_t b) {fDoCopyClusters=b;}
+    void                  SetCopyMC(Bool_t b)       {fDoCopyMC=b;}
+    void                  SetCopyMCHeader(Bool_t b) {fDoCopyMCHeader=b;}
   protected:
     void                  UserCreateOutputObjects();
     void                  UserExec(Option_t* option);
     Bool_t                UserNotify();
     void                  Terminate(Option_t* option);
     Bool_t                PythiaInfoFromFile(const char *currFile, Float_t &xsec, Float_t &trials, Int_t &pthard);
-
-    Double_t              fClusMinE;      //  minimum cluster energy to accept event
-    Bool_t                fCutMC;         //  if true cut MC particles with |Y|>1.2
-    UInt_t                fTrials;        //! events seen since last acceptance 
-    Float_t               fPyxsec;        //! pythia xsection
-    Float_t               fPytrials;      //! pythia trials
-    Int_t                 fPypthardbin;   //! pythia pthard bin
-    AliAODEvent          *fAOD;           //! input event
-    AliAODMCHeader       *fAODMcHeader;   //! MC header
-    TList                *fOutputList;    //! output list
-    TH1F                 *fHevs;          //! events processed/accepted
-    TH1F                 *fHclus;         //! cluster distribution
+    Double_t              fClusMinE;        //  minimum cluster energy to accept event
+    Bool_t                fCutMC;           //  if true cut MC particles with |Y|>fYCutMC
+    Double_t              fYCutMC;          //  cut for MC particles (default = 0.7)
+    Bool_t                fDoCopyHeader;    //  if true copy header
+    Bool_t                fDoCopyVZERO;     //  if true copy VZERO
+    Bool_t                fDoCopyTZERO;     //  if true copy TZERO
+    Bool_t                fDoCopyVertices;  //  if true copy vertices
+    Bool_t                fDoCopyTOF;       //  if true copy TOF
+    Bool_t                fDoCopyTracks;    //  if true copy tracks
+    Bool_t                fDoCopyTrigger;   //  if true copy trigger (EMC)
+    Bool_t                fDoCopyPTrigger;  //  if true copy trigger (PHS)
+    Bool_t                fDoCopyCells;     //  if true copy cells (EMC)
+    Bool_t                fDoCopyPCells;    //  if true copy cells (PHS)
+    Bool_t                fDoCopyClusters;  //  if true copy clusters
+    Bool_t                fDoCopyMC;        //  if true copy MC particles
+    Bool_t                fDoCopyMCHeader;  //  if true copy MC header
+    UInt_t                fTrials;          //! events seen since last acceptance 
+    Float_t               fPyxsec;          //! pythia xsection
+    Float_t               fPytrials;        //! pythia trials
+    Int_t                 fPypthardbin;     //! pythia pthard bin
+    AliAODEvent          *fAOD;             //! input event
+    AliAODMCHeader       *fAODMcHeader;     //! MC header
+    TList                *fOutputList;      //! output list
+    TH1F                 *fHevs;            //! events processed/accepted
+    TH1F                 *fHclus;           //! cluster distribution
     AliAodSkimTask(const AliAodSkimTask&);             // not implemented
     AliAodSkimTask& operator=(const AliAodSkimTask&);  // not implemented
   ClassDef(AliAodSkimTask, 1);


### PR DESCRIPTION
Avoid copying objects that are being referenced via TRef. Instead either clone or move them from one to the other array. The latter was easily achieved use AbsorbObjects member of TClonesArray.
This is work related to EMCAL-142