### PR TITLE
[EMCAL-174] Support for no-INT events on patch side

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
@@ -246,7 +246,11 @@ void AliEmcalTriggerMakerTask::ExecOnce(){
  * @return True
  */
 Bool_t AliEmcalTriggerMakerTask::Run(){
-  if(!fTriggerMaker->IsConfigured()) return false;    // only run trigger maker in case it is configured
+  if(!fTriggerMaker->IsConfigured()){
+    AliErrorStream() << "Trigger maker not configured" << std::endl;
+    return false;    // only run trigger maker in case it is configured
+  }
+  AliDebugStream(1) << "Looking for trigger patches ..." << std::endl;
   fCaloTriggersOut->Delete(); // Needed to avoid memory leak
   // prepare trigger maker
   fTriggerMaker->Reset();

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.h
@@ -112,6 +112,16 @@ public:
   virtual Bool_t    Run();
 
   /**
+   * @brief Perfrom Event Selection
+   * 
+   * As the trigger maker is a correction task it should run on
+   * any event, no matter whether the event is a good physics event
+   * or not. Therefor it overrides the event selection implemented
+   * in AliAnalysisTaskEmcal.
+   */
+  virtual Bool_t    IsEventSelected() { return true; }
+
+  /**
    * @brief Set range for L0 time
    * @param[in] min Minimum L0 time (default is 7)
    * @param[in] max Maximum L0 time (default is 10)

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalRecalcPatchesRef.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalRecalcPatchesRef.cxx
@@ -136,6 +136,7 @@ bool AliAnalysisTaskEmcalRecalcPatchesRef::Run(){
   if(!fSelectedTriggers.size()) return false;       // no trigger selected
   AliDebugStream(1) << "Found triggers" << std::endl;
   for(auto t : fSelectedTriggers) AliDebugStream(1) << t << std::endl;
+  AliDebugStream(1) << "Trigger patch container has " << fTriggerPatchInfo->GetEntries() << " patches" << std::endl;
 
   // Decode trigger clusters
   const auto selclusters = GetAcceptedTriggerClusters(fInputEvent->GetFiredTriggerClasses().Data());
@@ -163,6 +164,13 @@ bool AliAnalysisTaskEmcalRecalcPatchesRef::Run(){
     } 
   }
 
+  AliDebugStream(1) << "Processing triggers" << std::endl;
+  for(auto t : handledtriggers) AliDebugStream(1) << t << std::endl;
+  if(!handledtriggers.size()){
+    AliDebugStream(1) << "No supported trigger class found " << std::endl;
+    return false;
+  }
+
   std::vector<const AliEMCALTriggerPatchInfo *> EGApatches, DGApatches, EJEpatches, DJEpatches;
   if(isMB || isEG) EGApatches = SelectAllPatchesByType(*fTriggerPatchInfo, kEGApatches);
   if(isMB || isDG) DGApatches = SelectAllPatchesByType(*fTriggerPatchInfo, kDGApatches);
@@ -182,6 +190,7 @@ bool AliAnalysisTaskEmcalRecalcPatchesRef::Run(){
       std::vector<const AliEMCALTriggerPatchInfo *> &patchhandler = (detector == 'E' ? (t[1] == 'G' ? EGApatches : EJEpatches) : (t[1] == 'G' ? DGApatches : DJEpatches)); 
       auto firedpatches = SelectFiredPatchesByTrigger(*fTriggerPatchInfo, kPatchIndex.find(t.Data())->second);
       auto patchareas = GetNumberNonOverlappingPatchAreas(firedpatches);
+      AliDebugStream(3) << "Trigger " << t << ", patches " << patchhandler.size() << ", firing " << firedpatches.size() << std::endl;
       for(auto p : patchhandler){
         double point[3] = {static_cast<double>(p->GetADCAmp()), static_cast<double>(firedpatches.size()), static_cast<double>(patchareas)};
         for(const auto &kc : selclusters) {
@@ -200,6 +209,7 @@ bool AliAnalysisTaskEmcalRecalcPatchesRef::Run(){
 }
 
 std::vector<const AliEMCALTriggerPatchInfo *> AliAnalysisTaskEmcalRecalcPatchesRef::SelectAllPatchesByType(const TClonesArray &list, EPatchType_t patchtype) const {
+  AliDebugStream(2) << "Selecting all patches for trigger " << static_cast<int>(patchtype) << std::endl;
   std::vector<const AliEMCALTriggerPatchInfo *> result;
   for(auto p : list){
     AliEMCALTriggerPatchInfo *patch = static_cast<AliEMCALTriggerPatchInfo *>(p);
@@ -213,6 +223,7 @@ std::vector<const AliEMCALTriggerPatchInfo *> AliAnalysisTaskEmcalRecalcPatchesR
     };
     if(selected) result.emplace_back(patch);
   }
+  AliDebugStream(2) << "In: " << list.GetEntries() << ", out: " << result.size() << std::endl;
   return result;
 }
 

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerBase.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerBase.cxx
@@ -303,7 +303,7 @@ void AliAnalysisTaskEmcalTriggerBase::TriggerSelection(){
     // Apply cut on the trigger string - this basically discriminates high- and low-threshold
     // triggers
     const std::array<TString, AliEmcalTriggerOfflineSelection::kTrgn> kSelectTriggerStrings = {
-    		"CEMC7-|CEMC8-|C0EMC-", "EG1|EGA", "EG2", "EJ1|EJE", "EJ2", "CDMC7-|CDMC8-|CDMC0-", "DG1", "DG2", "DJ1", "DJ2"
+    		"CEMC7-|CEMC8-|C0EMC-", "EG1|EGA", "EG2", "EJ1|EJE", "EJ2", "CDMC7-|CDMC8-|C0DMC-", "DG1", "DG2", "DJ1", "DJ2"
     };
     if(triggerstring.Contains("EMC")) AliDebugStream(1) << GetName() << ": Trigger string " << triggerstring << std::endl;
     bool isT0trigger = triggerstring.Contains("INT8") || triggerstring.Contains("TVX") || triggerstring.Contains("EMC8") || triggerstring.Contains("DMC8"),


### PR DESCRIPTION
- Do not perform event selection in the trigger maker
  as it is a service task
- Fix DCAL L0 trigger string in trigger base task
- Adopt recalc patch task to handle no INT triggers
- A few AliDebugs