### PR TITLE
PWGPP/EMCAL: update of OADB macros including OADBContainer fix

### DIFF
--- a/PWGPP/EMCAL/OADBMacros/CreateEMCAL_OADB_CalibReference.C
+++ b/PWGPP/EMCAL/OADBMacros/CreateEMCAL_OADB_CalibReference.C
@@ -151,27 +151,84 @@ TObjArray *GetArrayEnergy(Int_t run=153323,
   return array;  
 }
 
+
+/*******************************************************************
+ *  NOTE: Sorting function to sort the final OADB file             *
+ *                  by ascending runnumber                         *
+ *******************************************************************/
+void sortOutput(const char *fileNameOADB=""){
+
+    TFile *f                                    = TFile::Open(fileNameOADB);
+    AliOADBContainer *con                       =(AliOADBContainer*)f->Get("AliEMCALRecalib");
+    con->SetName("Old");
+
+    Int_t indexAdd                              = 0;
+    Int_t largerthan                            = 0;
+    Int_t currentvalue                          = 0;
+
+    AliOADBContainer *con2                      = new AliOADBContainer("AliEMCALRecalib");
+    // First entry needs to be added before sorting loop
+//     con2->AddDefaultObject(con->GetObjectByIndex(0));
+    con2->AppendObject(con->GetObjectByIndex(0),con->LowerLimit(0),con->UpperLimit(0));
+//     Int_t lowestRunIndex = con->GetIndexForRun(235716);
+//     con2->AddDefaultObject(con->GetObjectByIndex(lowestRunIndex));
+//     con2->AppendObject(con->GetObjectByIndex(lowestRunIndex),con->LowerLimit(lowestRunIndex),con->UpperLimit(lowestRunIndex));
+    // sorting magic happens here
+    for(int i=1;i<con->GetNumberOfEntries();i++){
+        largerthan                              = con2->UpperLimit(con2->GetNumberOfEntries()-1);
+        currentvalue                            = -1;
+        indexAdd                                = 0;
+        for(int j=0;j<con->GetNumberOfEntries();j++){
+            if(con->UpperLimit(j)<=largerthan) 
+                continue;
+            else if(currentvalue < 0){
+                currentvalue                    = con->UpperLimit(j);
+                indexAdd                        = j;
+            }
+            else if(con->UpperLimit(j)<currentvalue){
+                currentvalue                    = con->UpperLimit(j);
+                indexAdd                        = j;
+            }
+        }
+//         con2->AddDefaultObject(con->GetObjectByIndex(indexAdd));
+        con2->AppendObject(con->GetObjectByIndex(indexAdd),con->LowerLimit(indexAdd),con->UpperLimit(indexAdd));
+    }
+
+    printf("\n\n");
+    Int_t nentries2                             = con2->GetNumberOfEntries();
+    for(int i=0;i<nentries2;i++){
+        printf("\n Entry2 --> %d/%d -->",i,nentries2);
+        printf("%d -- %d --> obj = %p , %s", con2->LowerLimit(i),con2->UpperLimit(i),con2->GetObjectByIndex(i),con2->GetObjectByIndex(i)->GetName());
+    }
+    printf("\n\n");
+
+    con2->WriteToFile("EMCALCalibOnlineRefNEW.root");
+    //gSystem->Exec(Form("rm %s",fileNameOADB));
+
+}
+
 /// 
 /// Create OADB Container for EMCal Calibration reference objects
 /// Main method
 ///
 void CreateEMCAL_OADB_CalibReference()
 {  
-  TObjArray *array12 = GetArrayEnergy(178000,"Run177115_999999999_v2_s0.root","Recalib",1); //last one is division factor
-  TObjArray *array10 = GetArrayEnergy(113461,"Run113461_999999999_v3_s0.root","Recalib",1); 
-  TObjArray *array11 = GetArrayEnergy(153323,"Run144484_999999999_v3_s0.root","Recalib",1);
+//   TObjArray *array12 = GetArrayEnergy(178000,"Run177115_999999999_v2_s0.root","Recalib",1); //last one is division factor
+//   TObjArray *array10 = GetArrayEnergy(113461,"Run113461_999999999_v3_s0.root","Recalib",1); 
+//   TObjArray *array11 = GetArrayEnergy(153323,"Run144484_999999999_v3_s0.root","Recalib",1);
   
   // Creating Container 
-  AliOADBContainer* con = new AliOADBContainer("AliEMCALRecalib");
+//   AliOADBContainer* con = new AliOADBContainer("AliEMCALRecalib");
   
-  con->AddDefaultObject(*&array10);
-  con->AddDefaultObject(*&array11);
-  con->AddDefaultObject(*&array12);
+//   con->AddDefaultObject(*&array10);
+//   con->AddDefaultObject(*&array11);
+//   con->AddDefaultObject(*&array12);
   
   // Appending objects to their specific Run number
-  con->AppendObject(*&array10,113461,139517);
-  con->AppendObject(*&array11,144484,170593);
-  con->AppendObject(*&array12,177115,197692);
-  
-  con->WriteToFile("EMCALCalibOnlineRef.root");
+//   con->AppendObject(*&array10,113461,139517);
+//   con->AppendObject(*&array11,144484,170593);
+//   con->AppendObject(*&array12,177115,197692);
+//     con->WriteToFile("EMCALCalibOnlineRef.root");
+
+  sortOutput("EMCALCalibOnlineRef.root");
 }

--- a/PWGPP/EMCAL/OADBMacros/UpdateEMCAL_OADB_BadChannels.C
+++ b/PWGPP/EMCAL/OADBMacros/UpdateEMCAL_OADB_BadChannels.C
@@ -1,351 +1,417 @@
-///
-/// \file UpdateEMCAL_OADB_BadChannels.C
-/// \ingroup EMCAL_OADB
-/// \brief Update OADB file with bad map.
-///
-/// Read OCDB files with bad map and update the OADB file
-///
-/// \author Marcel Figueredo, <marcel.figueredo@cern.ch>, Sao Paulo
-/// \author Gustavo Conesa Balbastre, <Gustavo.Conesa.Balbastre@cern.ch>, LPSC-CNRS ???
-///
+//!  EMCal bad channel map creation macro
+/*!
+    With this macro, the 2D histogram bad channel maps can be added to OADB/EMCAL/EMCALBadChannels.root.
+*/
 
-#if !defined(__CINT__)
-#include <TH2D.h>
-#include <TFile.h>
-#include <TObjArray.h>
-//#include <TSystem.h>
+#include "TGeoManager.h"
 
-#include "AliCaloCalibPedestal.h"
-#include "AliOADBContainer.h"
-
-#include "AliCDBManager.h"
-#include "AliOADBContainer.h"
-#include "AliCDBStorage.h"
-#include "AliCDBEntry.h"
-#endif
-
-///
-/// Create OADB Container for EMCal Bad Channels
-/// from local or grid OCDB
-///
-/// \param runNum: reference run number
-/// \param localOCDB: 0 local; 1 grid
-///
-TObjArray GetHistoObject( Int_t runNum, Bool_t localOCDB=0)
+/*******************************************************************
+ *  NOTE: Main function which needs to be adjusted for new BC maps *
+ *******************************************************************/
+void UpdateEMCAL_OADB_BadChannels(const char *fileNameOADBAli="$ALICE_DATA/OADB/EMCAL/EMCALBadChannels.root")
 {
-	Int_t i;
-	char buf[100];
+    gSystem->Load("libOADB");  
+    gSystem->Load("libEMCALbase");
+    gSystem->Load("libEMCALUtils");
+    gSystem->Load("libEMCALrec");
 
-	TH2D *histo;
+    // create working copy of OADB file from EOS
+    const char *fileNameOADB                ="EMCALBadChannels_temp.root";
+    gSystem->Exec(Form("cp %s %s",fileNameOADBAli,fileNameOADB));
 
-	TFile *outFile;
-	
-	AliCDBManager *man;
-	AliCDBStorage *stor;
-	AliCaloCalibPedestal *ped;
+    // update OADB file with dead, bad and warm cells
+    // last parameter:
+    //      0: write new map for given run range
+    //      1: update existing map for given run range
+    //      2: same as 1 but also save over/underhead parts (special setting, not for normal use!)
 
-	// created the OCDB manager
-	man = AliCDBManager::Instance();
-	if(localOCDB) 
-    stor = man->GetStorage("local://$HOME/OADB/OCDB/"); //if you download the OCDB files locally.
-	else 
-  {  
-	  man->SetDefaultStorage("raw://");
-	  man->SetRun(runNum);
-	  stor = man->GetDefaultStorage();
-	}
-	
-  ped = (AliCaloCalibPedestal*)(stor->Get("EMCAL/Calib/Pedestals", runNum)->GetObject());
+    // LHC16f - 20180403
+    updateFile(fileNameOADB,"BadChannelsLHC16f","LHC16f/LHC16f_INT7_OADBFile_Dead_V0.txt","LHC16f/LHC16f_INT7_OADBFile_Bad_V0.txt","LHC16f/LHC16f_INT7_OADBFile_Warm_V0.txt",253614,253979,0);
 
-	// get the array of histos
-	TObjArray map = ped->GetDeadMap();
-	for(int i = 0; i < map.GetEntries(); i++ )
-  {
-		histo = (TH2D*)(map[i]);
-		printf("\n !!! EMCALBadChannelMap_Mod%d",i );
-		histo->SetName ( Form("EMCALBadChannelMap_Mod%d", i ));
-		histo->SetTitle( Form("EMCALBadChannelMap_Mod%d", i ));
-	}
+    // LHC16h - 20180405 - Additional bad cells
+    updateFile(fileNameOADB,"BadChannelsLHC16h_V1_add","LHC16hijl/empty.txt","LHC16hijl/16h_block1.txt","LHC16hijl/empty.txt",254381,254654,1);
+    updateFile(fileNameOADB,"BadChannelsLHC16h_V2_add","LHC16hijl/empty.txt","LHC16hijl/16h_block2.txt","LHC16hijl/empty.txt",254655,255467,1);
 
-	return map;
+    // LHC16i - 20180405 - Additional bad cells
+    updateFile(fileNameOADB,"BadChannelsLHC16i_V1_add","LHC16hijl/empty.txt","LHC16hijl/16i_block1.txt","LHC16hijl/empty.txt",255515,255583,1);
+    updateFile(fileNameOADB,"BadChannelsLHC16i_V2_add","LHC16hijl/empty.txt","LHC16hijl/16i_block2.txt","LHC16hijl/empty.txt",255591,255618,1);
+
+    // LHC16j - 20180405 - Additional bad cells
+    updateFile(fileNameOADB,"BadChannelsLHC16j_V1_add","LHC16hijl/empty.txt","LHC16hijl/16j_block1.txt","LHC16hijl/empty.txt",256147,256281,1);
+    updateFile(fileNameOADB,"BadChannelsLHC16j_V2_add","LHC16hijl/empty.txt","LHC16hijl/16j_block2.txt","LHC16hijl/empty.txt",256282,256420,1);
+
+    // LHC16l - 20180405 - Additional bad cells
+    updateFile(fileNameOADB,"BadChannelsLHC16l_V1_add","LHC16hijl/empty.txt","LHC16hijl/16l_block1.txt","LHC16hijl/empty.txt",258883,258964,1);
+    updateFile(fileNameOADB,"BadChannelsLHC16l_V2_add","LHC16hijl/empty.txt","LHC16hijl/16l_block2.txt","LHC16hijl/empty.txt",259086,259396,1);
+    updateFile(fileNameOADB,"BadChannelsLHC16l_V3_add","LHC16hijl/empty.txt","LHC16hijl/16l_block3.txt","LHC16hijl/empty.txt",259469,260014,1);
+
+    // LHC16o - 20180205
+    updateFile(fileNameOADB,"BadChannelsLHC16o_V1","LHC16op/LHC16o_INT7_OADBFile_Dead_V1.txt","LHC16op/LHC16o_INT7_OADBFile_Bad_V1.txt","LHC16op/LHC16o_INT7_OADBFile_Warm_V1.txt",262395,262532,0);
+    updateFile(fileNameOADB,"BadChannelsLHC16o_V2","LHC16op/LHC16o_INT7_OADBFile_Dead_V2.txt","LHC16op/LHC16o_INT7_OADBFile_Bad_V2.txt","LHC16op/LHC16o_INT7_OADBFile_Warm_V2.txt",262533,262858,0);
+    updateFile(fileNameOADB,"BadChannelsLHC16o_V3","LHC16op/LHC16o_INT7_OADBFile_Dead_V3.txt","LHC16op/LHC16o_INT7_OADBFile_Bad_V3.txt","LHC16op/LHC16o_INT7_OADBFile_Warm_V3.txt",263331,263744,0);
+    updateFile(fileNameOADB,"BadChannelsLHC16o_V4","LHC16op/LHC16o_INT7_OADBFile_Dead_V4.txt","LHC16op/LHC16o_INT7_OADBFile_Bad_V4.txt","LHC16op/LHC16o_INT7_OADBFile_Warm_V4.txt",263784,264035,0);
+
+    // LHC16p - 20180205
+    updateFile(fileNameOADB,"BadChannelsLHC16p_V1","LHC16op/LHC16p_INT7_OADBFile_Dead_V1.txt","LHC16op/LHC16p_INT7_OADBFile_Bad_V1.txt","LHC16op/LHC16p_INT7_OADBFile_Warm_V1.txt",264076,264164,0);
+    updateFile(fileNameOADB,"BadChannelsLHC16p_V2","LHC16op/LHC16p_INT7_OADBFile_Dead_V2.txt","LHC16op/LHC16p_INT7_OADBFile_Bad_V2.txt","LHC16op/LHC16p_INT7_OADBFile_Warm_V2.txt",264168,264347,0);
+
+    // LHC16q - 20180405 - Additional bad cells
+    updateFile(fileNameOADB,"BadChannelsLHC16q_V1_add","LHC16hijl/empty.txt","LHC16qt/Add_BadCells_LHC16q.txt","LHC16hijl/empty.txt",265305,265525,1);
+
+    // LHC16t - 20180405 - Additional bad cells
+    updateFile(fileNameOADB,"BadChannelsLHC16t_V1_add","LHC16hijl/empty.txt","LHC16qt/Add_BadCells_LHC16t.txt","LHC16hijl/empty.txt",267161,267166,1);
+
+    // LHC17g - 20180308
+    updateFile(fileNameOADB,"BadChannelsLHC17g_V1","LHC17ghjk/17g_block1/LHC17g_INT7_OADBFile_Dead_V1.txt","LHC17ghjk/17g_block1/LHC17g_INT7_OADBFile_Bad_V1.txt","LHC17ghjk/17g_block1/LHC17g_INT7_OADBFile_Warm_V1.txt",270882,271287,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17g_V2","LHC17ghjk/17g_block2/LHC17g_INT7_OADBFile_Dead_V2.txt","LHC17ghjk/17g_block2/LHC17g_INT7_OADBFile_Bad_V2.txt","LHC17ghjk/17g_block2/LHC17g_INT7_OADBFile_Warm_V2.txt",271288,271777,0);
+
+    // LHC17h - 20180308
+    updateFile(fileNameOADB,"BadChannelsLHC17h_V1","LHC17ghjk/17h_block1/LHC17h_INT7_OADBFile_Dead_V1.txt","LHC17ghjk/17h_block1/LHC17h_INT7_OADBFile_Bad_V1.txt","LHC17ghjk/17h_block1/LHC17h_INT7_OADBFile_Warm_V1.txt",271868,272074,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17h_V2","LHC17ghjk/17h_block2/LHC17h_INT7_OADBFile_Dead_V2.txt","LHC17ghjk/17h_block2/LHC17h_INT7_OADBFile_Bad_V2.txt","LHC17ghjk/17h_block2/LHC17h_INT7_OADBFile_Warm_V2.txt",272075,272122,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17h_V3","LHC17ghjk/17h_block3/LHC17h_INT7_OADBFile_Dead_V3.txt","LHC17ghjk/17h_block3/LHC17h_INT7_OADBFile_Bad_V3.txt","LHC17ghjk/17h_block3/LHC17h_INT7_OADBFile_Warm_V3.txt",272123,272123,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17h_V4","LHC17ghjk/17h_block4/LHC17h_INT7_OADBFile_Dead_V4.txt","LHC17ghjk/17h_block4/LHC17h_INT7_OADBFile_Bad_V4.txt","LHC17ghjk/17h_block4/LHC17h_INT7_OADBFile_Warm_V4.txt",272124,273101,0);
+
+    // LHC17i - 20180405
+    updateFile(fileNameOADB,"BadChannelsLHC17i_V1","LHC17il/17i_block1/LHC17i_INT7_OADBFile_Dead_V1.txt","LHC17il/17i_block1/LHC17i_INT7_OADBFile_Bad_V1.txt","LHC17il/17i_block1/LHC17i_INT7_OADBFile_Warm_V1.txt",273486,273825,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17i_V2","LHC17il/17i_block2/LHC17i_INT7_OADBFile_Dead_V2.txt","LHC17il/17i_block2/LHC17i_INT7_OADBFile_Bad_V2.txt","LHC17il/17i_block2/LHC17i_INT7_OADBFile_Warm_V2.txt",273826,274283,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17i_V3","LHC17il/17i_block3/LHC17i_INT7_OADBFile_Dead_V3.txt","LHC17il/17i_block3/LHC17i_INT7_OADBFile_Bad_V3.txt","LHC17il/17i_block3/LHC17i_INT7_OADBFile_Warm_V3.txt",274284,274442,0);
+
+    // LHC17j - 20180308
+    updateFile(fileNameOADB,"BadChannelsLHC17j_V1","LHC17ghjk/17j_block1/LHC17j_INT7_OADBFile_Dead_V1.txt","LHC17ghjk/17j_block1/LHC17j_INT7_OADBFile_Bad_V1.txt","LHC17ghjk/17j_block1/LHC17j_INT7_OADBFile_Warm_V1.txt",274591,274671,0);
+
+    // LHC17k - 20180308
+    updateFile(fileNameOADB,"BadChannelsLHC17k_V1","LHC17ghjk/17k_block1/LHC17k_INT7_OADBFile_Dead_V1.txt","LHC17ghjk/17k_block1/LHC17k_INT7_OADBFile_Bad_V1.txt","LHC17ghjk/17k_block1/LHC17k_INT7_OADBFile_Warm_V1.txt",276290,276508,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17k_V2","LHC17ghjk/17k_block2/LHC17k_INT7_OADBFile_Dead_V2.txt","LHC17ghjk/17k_block2/LHC17k_INT7_OADBFile_Bad_V2.txt","LHC17ghjk/17k_block2/LHC17k_INT7_OADBFile_Warm_V2.txt",275515,276289,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17k_V3","LHC17ghjk/17k_block3/LHC17k_INT7_OADBFile_Dead_V3.txt","LHC17ghjk/17k_block3/LHC17k_INT7_OADBFile_Bad_V3.txt","LHC17ghjk/17k_block3/LHC17k_INT7_OADBFile_Warm_V3.txt",275057,275514,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17k_V4","LHC17ghjk/17k_block4/LHC17k_INT7_OADBFile_Dead_V4.txt","LHC17ghjk/17k_block4/LHC17k_INT7_OADBFile_Bad_V4.txt","LHC17ghjk/17k_block4/LHC17k_INT7_OADBFile_Warm_V4.txt",274690,275056,0);
+
+    // LHC17l - 20180405
+    updateFile(fileNameOADB,"BadChannelsLHC17l_V1","LHC17il/17l_block1/LHC17l_INT7_OADBFile_Dead_V1.txt","LHC17il/17l_block1/LHC17l_INT7_OADBFile_Bad_V1.txt","LHC17il/17l_block1/LHC17l_INT7_OADBFile_Warm_V1.txt",276551,277117,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17l_V2","LHC17il/17l_block2/LHC17l_INT7_OADBFile_Dead_V2.txt","LHC17il/17l_block2/LHC17l_INT7_OADBFile_Bad_V2.txt","LHC17il/17l_block2/LHC17l_INT7_OADBFile_Warm_V2.txt",277118,277389,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17l_V3","LHC17il/17l_block3/LHC17l_INT7_OADBFile_Dead_V3.txt","LHC17il/17l_block3/LHC17l_INT7_OADBFile_Bad_V3.txt","LHC17il/17l_block3/LHC17l_INT7_OADBFile_Warm_V3.txt",277390,277721,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17l_V4","LHC17il/17l_block4/LHC17l_INT7_OADBFile_Dead_V4.txt","LHC17il/17l_block4/LHC17l_INT7_OADBFile_Bad_V4.txt","LHC17il/17l_block4/LHC17l_INT7_OADBFile_Warm_V4.txt",277722,278216,0);
+
+    // LHC17m - 20180305
+    updateFile(fileNameOADB,"BadChannelsLHC17m_V1","LHC17m/17m_block1/LHC17m_INT7_OADBFile_Dead_V1.txt","LHC17m/17m_block1/LHC17m_INT7_OADBFile_Bad_V1.txt","LHC17m/17m_block1/LHC17m_INT7_OADBFile_Warm_V1.txt",278818, 279355,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17m_V2","LHC17m/17m_block2/LHC17m_INT7_OADBFile_Dead_V2.txt","LHC17m/17m_block2/LHC17m_INT7_OADBFile_Bad_V2.txt","LHC17m/17m_block2/LHC17m_INT7_OADBFile_Warm_V2.txt",279356, 280140,0);
+
+    // LHC17o - 20180206
+    updateFile(fileNameOADB,"BadChannelsLHC17o_V1","LHC17o/17o_block1/LHC17o_INT7_OADBFile_Dead_V1.txt","LHC17o/17o_block1/LHC17o_INT7_OADBFile_Bad_V1.txt","LHC17o/17o_block1/LHC17o_INT7_OADBFile_Warm_V1.txt",280282, 280403,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17o_V2","LHC17o/17o_block2/LHC17o_INT7_OADBFile_Dead_V2.txt","LHC17o/17o_block2/LHC17o_INT7_OADBFile_Bad_V2.txt","LHC17o/17o_block2/LHC17o_INT7_OADBFile_Warm_V2.txt",280404, 280999,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17o_V3","LHC17o/17o_block3/LHC17o_INT7_OADBFile_Dead_V3.txt","LHC17o/17o_block3/LHC17o_INT7_OADBFile_Bad_V3.txt","LHC17o/17o_block3/LHC17o_INT7_OADBFile_Warm_V3.txt",281000, 281753,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17o_V4","LHC17o/17o_block4/LHC17o_INT7_OADBFile_Dead_V4.txt","LHC17o/17o_block4/LHC17o_INT7_OADBFile_Bad_V4.txt","LHC17o/17o_block4/LHC17o_INT7_OADBFile_Warm_V4.txt",281757, 281961,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17o_V5","LHC17o/17o_block5/LHC17o_INT7_OADBFile_Dead_V5.txt","LHC17o/17o_block5/LHC17o_INT7_OADBFile_Bad_V5.txt","LHC17o/17o_block5/LHC17o_INT7_OADBFile_Warm_V5.txt",281754, 281756,0);
+
+    // LHC17p - 20180206
+    updateFile(fileNameOADB,"BadChannelsLHC17p_V1","LHC17pq/LHC17p_INT7_Bad_Ampl_block1_dead.txt","LHC17pq/LHC17p_INT7_Bad_Ampl_block1_bad.txt","LHC17pq/LHC17p_INT7_Bad_Ampl_block1_warm.txt",282025,282126,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17p_V2","LHC17pq/LHC17p_INT7_Bad_Ampl_block2_dead.txt","LHC17pq/LHC17p_INT7_Bad_Ampl_block2_bad.txt","LHC17pq/LHC17p_INT7_Bad_Ampl_block2_warm.txt",282127,282147,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17p_V3","LHC17pq/LHC17p_INT7_Bad_Ampl_block3_dead.txt","LHC17pq/LHC17p_INT7_Bad_Ampl_block3_bad.txt","LHC17pq/LHC17p_INT7_Bad_Ampl_block3_warm.txt",282148,282314,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17p_V4","LHC17pq/LHC17p_INT7_Bad_Ampl_block4_dead.txt","LHC17pq/LHC17p_INT7_Bad_Ampl_block4_bad.txt","LHC17pq/LHC17p_INT7_Bad_Ampl_block4_warm.txt",282315,282343,0);
+
+    // LHC17q - 20180206
+    updateFile(fileNameOADB,"BadChannelsLHC17q_V1","LHC17pq/LHC17q_INT7_Bad_Ampl_block1_dead.txt","LHC17pq/LHC17q_INT7_Bad_Ampl_block1_bad.txt","LHC17pq/LHC17q_INT7_Bad_Ampl_block1_warm.txt",282365,282366,0);
+    updateFile(fileNameOADB,"BadChannelsLHC17q_V2","LHC17pq/LHC17q_INT7_Bad_Ampl_block2_dead.txt","LHC17pq/LHC17q_INT7_Bad_Ampl_block2_bad.txt","LHC17pq/LHC17q_INT7_Bad_Ampl_block2_warm.txt",282367,282440,0);
+
+
+
+    // the final output will be sorted by runnumber
+    sortOutput(fileNameOADB);
+    // the OADB container is additionally checked for ownership
+    rebuildBadCellContainer("EMCALBadChannelsNEW.root");
 }
 
-///
-/// Main method doing the update
-///
-/// \param fileNameOADB: OADB file name and path
-/// \param localOCDB: 0 local; 1 grid
-///
-void UpdateEMCAL_OADB_BadChannels
-(
- const char *fileNameOADB="$ALICE_PHYSICS/OADB/EMCAL/EMCALBadChannels.root",
- Bool_t localOCDB=1
-)
-{
-  ///   gSystem->Load("libOADB");      
-  
-  //Create OADB container for BadChannels
-  AliOADBContainer *con=new AliOADBContainer("");
-  con->InitFromFile(fileNameOADB,"AliEMCALBadChannels"); 
-  
-  //AliOADBContainer* con = new AliOADBContainer("AliEMCALBadChannels");
-  
-  //! List of brand new arrays
-  //LHC13g
-  TObjArray *array = new TObjArray(12);		
-  array->SetName("BadChannels");
-  // 'AliEMCALOCDBTenderConverter.cxx(176326,"BadChannels2012_12a1.root")
-  char name[30];
-  
-  TObjArray array12a1 = GetHistoObject(176326,localOCDB);// Run176326_176700_v5_s0.root
-  TObjArray array12a2 = GetHistoObject(176701,localOCDB);// Run176701_176714_v5_s0.root
-  TObjArray array12a3 = GetHistoObject(176715,localOCDB);// Run176715_176729_v5_s0.root
-  TObjArray array12a4 = GetHistoObject(176730,localOCDB);// Run176730_176858_v5_s0.root
-  TObjArray array12a5 = GetHistoObject(176859,localOCDB);// Run176859_177295_v5_s0.root
-  
-  TObjArray array12b1 = GetHistoObject(177320,localOCDB);// Run177320_999999999_v2_s0 --> 177381-177383
-  TObjArray array12b2 = GetHistoObject(177384,localOCDB);// Run177384_178220_v5_s0.root
-  TObjArray array12b3 = GetHistoObject(177444,localOCDB);// Run177444_177682_v7_s0.root
-  TObjArray array12b4 = GetHistoObject(177844,localOCDB);// Run177844_177849_v7_s0.root     
-  TObjArray array12b5 = GetHistoObject(178220,localOCDB);// Run177384_178220_v9_s0.root
-  
-  TObjArray array12c1  = GetHistoObject(179569,localOCDB);// 
-  TObjArray array12c2  = GetHistoObject(180000,localOCDB);// 
-  TObjArray array12c3  = GetHistoObject(180127,localOCDB);// 
-  TObjArray array12c4  = GetHistoObject(180134,localOCDB);// 
-  TObjArray array12c5  = GetHistoObject(180195,localOCDB);// 
-  TObjArray array12c6  = GetHistoObject(180201,localOCDB);// 
-  TObjArray array12c7  = GetHistoObject(180289,localOCDB);// 
-  TObjArray array12c8  = GetHistoObject(181617,localOCDB);// 
-  TObjArray array12c9  = GetHistoObject(182106,localOCDB);// 
-  TObjArray array12c10 = GetHistoObject(182624,localOCDB);// 
-  TObjArray array12c11 = GetHistoObject(182730,localOCDB);// 
-  
-  
-  TObjArray array12d1  = GetHistoObject(183913,localOCDB);// 
-  TObjArray array12d2  = GetHistoObject(184482,localOCDB);// 
-  TObjArray array12d3  = GetHistoObject(185456,localOCDB);// 
-  TObjArray array12d4  = GetHistoObject(185909,localOCDB);// 
-  TObjArray array12d5  = GetHistoObject(186036,localOCDB);// 
-  
-  TObjArray array12e  = GetHistoObject(186365,localOCDB);// 
-  
-  TObjArray array12f1  = GetHistoObject(186668,localOCDB);// 
-  TObjArray array12f2  = GetHistoObject(187534,localOCDB);// 
-  TObjArray array12f3  = GetHistoObject(188122,localOCDB);// 
-  
-  TObjArray array12g  = GetHistoObject(188356,localOCDB);// 
-  
-  TObjArray array12h1   = GetHistoObject(189122,localOCDB);// 
-  TObjArray array12h2   = GetHistoObject(189301,localOCDB);//
-  TObjArray array12h3   = GetHistoObject(189518,localOCDB);//
-  TObjArray array12h4   = GetHistoObject(189699,localOCDB);//
-  TObjArray array12h5   = GetHistoObject(190335,localOCDB);//
-  TObjArray array12h6   = GetHistoObject(190393,localOCDB);//
-  
-  TObjArray array12h7   = GetHistoObject(190449,localOCDB);//
-  TObjArray array12h8   = GetHistoObject(190895,localOCDB);//
-  TObjArray array12h9   = GetHistoObject(191022,localOCDB);//
-  TObjArray array12h10  = GetHistoObject(191129,localOCDB);//
-  TObjArray array12h11  = GetHistoObject(191163,localOCDB);//
-  TObjArray array12h12  = GetHistoObject(191449,localOCDB);//
-  TObjArray array12h13  = GetHistoObject(191485,localOCDB);//
-  
-  TObjArray array12i1   = GetHistoObject(192745,localOCDB);//
-  TObjArray array12i1b  = GetHistoObject(193000,localOCDB);//   
-  TObjArray array12i2   = GetHistoObject(193301,localOCDB);//
-  TObjArray array12i3   = GetHistoObject(193750,localOCDB);//
-  
-  
-  
-  con->AddDefaultObject(&array12a1);
-  con->AddDefaultObject(&array12a2);
-  con->AddDefaultObject(&array12a3);
-  con->AddDefaultObject(&array12a4);
-  con->AddDefaultObject(&array12a5);
-  
-  con->AddDefaultObject(&array12b1);
-  con->AddDefaultObject(&array12b2);
-  con->AddDefaultObject(&array12b3);
-  con->AddDefaultObject(&array12b4);
-  con->AddDefaultObject(&array12b5);
-  
-  con->AddDefaultObject(&array12c1);
-  con->AddDefaultObject(&array12c2);
-  con->AddDefaultObject(&array12c3);
-  con->AddDefaultObject(&array12c4);
-  con->AddDefaultObject(&array12c5);
-  con->AddDefaultObject(&array12c6);
-  con->AddDefaultObject(&array12c7);
-  con->AddDefaultObject(&array12c8);
-  con->AddDefaultObject(&array12c9);
-  con->AddDefaultObject(&array12c10);
-  con->AddDefaultObject(&array12c11);
-  
-  con->AddDefaultObject(&array12d1);
-  con->AddDefaultObject(&array12d2);
-  con->AddDefaultObject(&array12d3);
-  con->AddDefaultObject(&array12d4);
-  con->AddDefaultObject(&array12d5);
-  
-  con->AddDefaultObject(&array12e);
-  
-  con->AddDefaultObject(&array12d1);
-  con->AddDefaultObject(&array12d2);
-  con->AddDefaultObject(&array12d3);
-  con->AddDefaultObject(&array12d4);
-  con->AddDefaultObject(&array12d5);
-  
-  con->AddDefaultObject(&array12f1);
-  con->AddDefaultObject(&array12f2);
-  con->AddDefaultObject(&array12f3);
-  
-  con->AddDefaultObject(&array12g); 
-  
-  con->AddDefaultObject(&array12h1);
-  con->AddDefaultObject(&array12h2);
-  con->AddDefaultObject(&array12h3);
-  con->AddDefaultObject(&array12h4);
-  con->AddDefaultObject(&array12h5);    
-  con->AddDefaultObject(&array12h6);    
-  con->AddDefaultObject(&array12h7);    
-  con->AddDefaultObject(&array12h8);    
-  con->AddDefaultObject(&array12h9);    
-  con->AddDefaultObject(&array12h10);    
-  con->AddDefaultObject(&array12h11);    
-  con->AddDefaultObject(&array12h12);    
-  con->AddDefaultObject(&array12h13);    
-  
-  con->AddDefaultObject(&array12i1);
-  con->AddDefaultObject(&array12i1b);
-  con->AddDefaultObject(&array12i2);
-  con->AddDefaultObject(&array12i3);
-  
-  con->UpdateObject(con->GetIndexForRun(176326),&array12a1,176326,176700); // Run176326_176700_v5_s0.root 
-  con->AppendObject(&array12a2,176701,176714); //	Run176701_176714_v5_s0.root
-  con->AppendObject(&array12a3,176715,176729); // Run176715_176729_v4_s0.root
-  con->AppendObject(&array12a4,176730,176858); // Run176730_176858_v5_s0.root
-  con->AppendObject(&array12a5,176859,177295); // Run176869_177295_v5_s0.root
-  
-  
-  con->UpdateObject(con->GetIndexForRun(177383),&array12b1,177320,177383); // Run177320_999999999_v2_s0.root 
-  con->UpdateObject(con->GetIndexForRun(177384),&array12b2,177384,177443); // Run177384_178220_v9_s0.root
-  con->UpdateObject(con->GetIndexForRun(177444),&array12b3,177444,177682); // Run177444_177682_v10_s0.root
-  con->UpdateObject(con->GetIndexForRun(177844),&array12b4,177844,177849); // Run177844_177849_v10_s0.root
-  con->UpdateObject(con->GetIndexForRun(177850),&array12b5,177850,178220); // Run177384_178220_v9_s0.root
-  
-  con->UpdateObject(con->GetIndexForRun(179569),&array12c1 ,179569,179999); // Run176859_177295_v6_s0.root
-  con->AppendObject(&array12c2 ,180000,180126); // Run180000_180126_v4_s0.root
-  con->UpdateObject(con->GetIndexForRun(180127),&array12c3 ,180127,180133); // Run180127_180133_v5_s0.root
-  con->AppendObject(&array12c4 ,180134,180194); // Run180134_180194_v5_s0.root
-  con->UpdateObject(con->GetIndexForRun(180195),&array12c5 ,180195,180200); // Run180195_180200_v5_s0.root
-  con->AppendObject(&array12c6 ,180201,180288); // Run180201_180288_v4_s0.root
-  con->UpdateObject(con->GetIndexForRun(180289),&array12c7 ,180289,181616); // Run180289_181616_v5_s0.root
-  con->AppendObject(&array12c8 ,181617,182105); // Run181617_182105_v5_s0.root
-  con->AppendObject(&array12c9 ,182106,182623); // Run182106_182623_v5_s0.root
-  con->AppendObject(&array12c10,182624,182729); // Run182624_182729_v5_s0.root
-  con->UpdateObject(con->GetIndexForRun(182744),&array12c11,182730,182744); // Run182730_182744_v5_s0.root
-  
-  
-  con->UpdateObject(con->GetIndexForRun(183913),&array12d1,183913,184481); // Run183913_184481_v11_s0.root
-  con->UpdateObject(con->GetIndexForRun(184482),&array12d2,184482,185455); // def Run183913_186320_v10_s0.root 
-  con->UpdateObject(con->GetIndexForRun(185456),&array12d3,185456,185784); // Run185456_185784_v11_s0.root 
-  con->UpdateObject(con->GetIndexForRun(185909),&array12d4,185909,186035); // Run185909_186035_v11_s0.root
-  
-  con->UpdateObject(con->GetIndexForRun(186036),&array12d5,186036,186320); // def Run183913_186320_v10_s0.root  
-  
-  con->UpdateObject(con->GetIndexForRun(186365),&array12e,186365,186602); // Run186365_186602_v4_s0.root 
-  
-  con->UpdateObject(con->GetIndexForRun(186668),&array12f1,186668,187533); // def Run186668_188123_v4_s0.root
-  con->AppendObject(&array12f2,187534,187562); // Run187534_187562_v5_s0.root
-  con->AppendObject(&array12f3,187563,188123); // def Run186668_188123_v4_s0.root
-  
-  con->UpdateObject(con->GetIndexForRun(188356),&array12g,188356,188503);  // Run188356_188503_v5_s0.root
-  
-  con->UpdateObject(con->GetIndexForRun(189122),&array12h1,189122,189246); // Run189122_190392_v4_s0.root
-  con->AppendObject(&array12h2,189301,189494); // Run189301_189494_v5_s0.root
-  con->AppendObject(&array12h3,189518,189698); // Run189518_189698_v5_s0.root
-  con->AppendObject(&array12h4,189699,190334); // Run189699_190334_v5_s0.root
-  con->AppendObject(&array12h5,190335,190392); // Run190335_190392_v5_s0.root
-  con->AppendObject(&array12h6,190393,190425); // Run190393_190425_v5_s0.root
-  con->AppendObject(&array12h7,190449,190894); // def Run190393_192732_v4_s0.root
-  con->AppendObject(&array12h8,190895,190984); // Run190895_190984_v5_s0.root
-  con->AppendObject(&array12h9,191022,191121); // def  Run190393_192732_v4_s0.root
-  con->AppendObject(&array12h10,191129,191159); // Run191129_191159_v5_s0.root
-  con->AppendObject(&array12h11,191163,191448); // def  Run190393_192732_v4_s0.root
-  con->AppendObject(&array12h12,191449,191451); // Run191449_191451_v5_s0.root
-  con->AppendObject(&array12h13,191485,192732); // def  Run190393_192732_v4_s0.root
-  
-  
-  con->UpdateObject(con->GetIndexForRun(192745),&array12i1,192745,192824); //Run192745_193300_v4_s0.root
-  con->UpdateObject(con->GetIndexForRun(193300),&array12i1b,192825,193300); //Run192745_193300_v4_s0.root
-  con->UpdateObject(con->GetIndexForRun(193004),&array12i2,193301,193749); //Run193301_193749_v4_s0.root
-  con->AppendObject(&array12i3,193750,193766); //Run193750_193766_v4_s0.root
-  
-  con->WriteToFile("BetaBadChannels.root");   
+/*******************************************************************
+ *  NOTE: Update function that removes existing BC maps from old   *
+ *          file and adds new BC maps at the end of the file       *
+ *  NOTE: The final file is saved and directly renamed as new      *
+ *      input file for the next loop (this reduces total file size)*
+ *******************************************************************/
+void updateFile(const char *fileNameOADB,TString arrName, TString fileNameDeadCells, TString fileNameBadCells, TString fileNameWarmCells,Int_t lowRun, Int_t highRun, Int_t updateExistingMap = 0){
+    printf("\n\nAdding %s maps to OADB file:\n",arrName.Data());
+
+    AliEMCALGeometry   *fEMCALGeo               = new AliEMCALGeometry();
+    AliEMCALRecoUtils  *fEMCALRecoUtils         = new AliEMCALRecoUtils();
+
+    fEMCALGeo                                   = AliEMCALGeometry::GetInstance("EMCAL_COMPLETE12SMV1_DCAL_8SM");
+    const int nSM=20;
+
+    // load OADB file
+    TFile *f                                    = TFile::Open(fileNameOADB);
+    f->ls();
+    AliOADBContainer *con                       =(AliOADBContainer*)f->Get("AliEMCALBadChannels");
+    con->SetName("Old"); 
+
+    // make the output container
+    AliOADBContainer *con2                      = new AliOADBContainer("AliEMCALBadChannels");
+
+    // List of brand new arrays (including overhead arrays for updateExistingMap == 2)
+    TObjArray arrayAdd(nSM);
+    arrayAdd.SetName(arrName.Data());
+    TObjArray arrayAddOverheadLow(nSM);
+    arrayAddOverheadLow.SetName(Form("%s_OHLow",arrName.Data()));
+    TObjArray arrayAddOverheadHigh(nSM);
+    arrayAddOverheadHigh.SetName(Form("%s_OHHigh",arrName.Data()));
+
+    // load OADB file to have access to existing maps
+    TFile *foadb                                = TFile::Open(fileNameOADB);
+    AliOADBContainer *conAP                     = (AliOADBContainer*)foadb->Get("AliEMCALBadChannels");
+    TObjArray *arrayBClow                       = (TObjArray*)conAP->GetObject(lowRun);
+    TObjArray *arrayBChigh                      = (TObjArray*)conAP->GetObject(highRun);
+
+    TH2I *hBadChannels[nSM];
+    TH2I *hBadChannelsOverhead[nSM];
+    char nameSM[50];
+
+    // initialize histograms in array - either load existing map or create new, empty map
+    for(int i=0;i<nSM;i++){
+        sprintf(nameSM,"EMCALBadChannelMap_Mod%d",i);
+        hBadChannels[i]                              = NULL;
+        hBadChannelsOverhead[i]                      = NULL;
+        if(updateExistingMap){
+            cout << "Initializing " << nameSM << " from current AliPhysics OADB file ... ";
+            if(arrayBClow){
+                hBadChannels[i]                      = (TH2I*)arrayBClow->FindObject(nameSM);
+                if(hBadChannels[i] && updateExistingMap>1)
+                    hBadChannelsOverhead[i]          = (TH2I*)hBadChannels[i]->Clone(nameSM);
+            } else if (arrayBChigh){
+                hBadChannels[i]                      = (TH2I*)arrayBChigh->FindObject(nameSM);
+                if(hBadChannels[i] && updateExistingMap>1)
+                    hBadChannelsOverhead[i]          = (TH2I*)hBadChannels[i]->Clone(nameSM);
+            }
+            if(hBadChannels[i])
+                cout << "and found it!" << endl;
+        }
+        if(!updateExistingMap || !hBadChannels[i]){
+            cout << "File not found! Creating new map for " << nameSM << endl;
+            hBadChannels[i]                          = new TH2I(nameSM,nameSM,48,0,48,24,0,24);
+        }
+    }
+
+    // Read in the list of dead channels from the dead cell file
+    std::vector<TString> vecDeadChannels;
+    if(!readin(fileNameDeadCells, vecDeadChannels,kTRUE,0)) {
+        cout << "No dead Channels could be found in file: " << fileNameDeadCells.Data() << endl;
+    }
+    // Read in the list of bad channels from the bad cell file
+    std::vector<TString> vecBadChannels;
+    if(!readin(fileNameBadCells, vecBadChannels,kTRUE,1)) {
+        cout << "No bad Channels could be found in file: " << fileNameBadCells.Data() << endl;
+    }
+    // Read in the list of warm channels from the warm cell file
+    std::vector<TString> vecWarmChannels;
+    if(!readin(fileNameWarmCells, vecWarmChannels,kTRUE,2)) {
+        cout << "No warm Channels could be found in file: " << fileNameWarmCells.Data() << endl;
+    }
+
+    // Fill the bad channel map with different values depending on dead, bad and warm cells
+    Fill_histo(vecDeadChannels,1,hBadChannels,fEMCALGeo,fEMCALRecoUtils);
+    Fill_histo(vecBadChannels,2,hBadChannels,fEMCALGeo,fEMCALRecoUtils);
+    Fill_histo(vecWarmChannels,3,hBadChannels,fEMCALGeo,fEMCALRecoUtils);
+
+    // add histograms to a new array
+    for (Int_t mod=0;mod<nSM;mod++){
+        arrayAdd.Add(hBadChannels[mod]);
+        if( updateExistingMap>1 && hBadChannelsOverhead[mod]){
+            arrayAddOverheadLow.Add(hBadChannelsOverhead[mod]);
+            arrayAddOverheadHigh.Add(hBadChannelsOverhead[mod]);
+        }
+    }
+
+    // check old OADB file for existing BC maps in given run range and remove that old BC map
+    Int_t replacedContainerLowLimit             = -1;
+    Int_t replacedContainerHighLimit            = -1;
+    for(int i=0;i<con->GetNumberOfEntries();i++){
+        if (lowRun >= con->LowerLimit(i) && lowRun <= con->UpperLimit(i)){
+            printf("\n!!! Not adding index %d for runrange %d--%d as low run limit %d is contained\n", con->GetObjectByIndex(i), con->LowerLimit(i),con->UpperLimit(i),lowRun);
+            replacedContainerLowLimit           = con->LowerLimit(i);
+            replacedContainerHighLimit          = con->UpperLimit(i);
+        } else if (highRun >= con->LowerLimit(i) && highRun <= con->UpperLimit(i)){
+            printf("\n!!! Not adding index %d for runrange %d--%d as high run limit %d is contained\n", con->GetObjectByIndex(i), con->LowerLimit(i),con->UpperLimit(i),highRun);
+            replacedContainerLowLimit           = con->LowerLimit(i);
+            replacedContainerHighLimit          = con->UpperLimit(i);
+        }else{
+            con2->AddDefaultObject(con->GetObjectByIndex(i));
+            con2->AppendObject(con->GetObjectByIndex(i),con->LowerLimit(i),con->UpperLimit(i));
+        }
+    }
+    // add new BC maps at the end of the new OADB file (will be sorted later)
+    if( updateExistingMap>1 && replacedContainerLowLimit>0 && lowRun > replacedContainerLowLimit){
+        con2->AddDefaultObject(&arrayAddOverheadLow);
+        con2->AppendObject(&arrayAddOverheadLow, replacedContainerLowLimit,lowRun-1);
+    }
+    con2->AddDefaultObject(&arrayAdd);
+    con2->AppendObject(&arrayAdd, lowRun,highRun);
+    if(updateExistingMap>1 && replacedContainerHighLimit>0 && highRun < replacedContainerHighLimit){
+        con2->AddDefaultObject(&arrayAddOverheadHigh);
+        con2->AppendObject(&arrayAddOverheadHigh, highRun+1,replacedContainerHighLimit);
+    }
+
+    // temporarilty save BC map file and rename as new input file
+    con2->WriteToFile("tempBC.root");
+    gSystem->Exec(Form("mv tempBC.root %s",fileNameOADB));
+
+    printf("\nMaps have been successfully added!\n\n",arrName.Data());
+
 }
 
-    /*
-179569-179999
-180000-180126
-180127-180133
-180134-180194
-180195-180200
-180201-180288
-180289-181616
-181617-182105
-182106-182623
-182624-182729
-182730-182744
-*/
-  /*
-    Default: 183913-186320
-run 183913-184481
-run185456-185784
-run185909-186035
-186036-186320(def)
-*/
+/*******************************************************************
+ *  NOTE: Function to fill the 2D bad channel histograms           *
+ *             using EMCAL Geo for cellID->Eta/Phi                 *
+ *******************************************************************/
+void Fill_histo(std::vector<TString> vecChannels,Int_t fill=1,TH2I **hBadChannels,AliEMCALGeometry   *fEMCALGeo,AliEMCALRecoUtils  *fEMCALRecoUtils){
+    Int_t nSupMod=-1, nModule=-1, nIphi=-1, nIeta=-1, iphi=-1, ieta=-1;
+    for(Int_t i=0; i<(Int_t) vecChannels.size(); i++){
+        fEMCALGeo->GetCellIndex(vecChannels.at(i).Atoi(),nSupMod,nModule,nIphi,nIeta);
+        fEMCALGeo->GetCellPhiEtaIndexInSModule(nSupMod,nModule,nIphi,nIeta,iphi,ieta);
+        fEMCALRecoUtils->SetEMCALChannelStatus(nSupMod, ieta, iphi);
+        //cout<<endl<<"ID:"<<vecChannels.at(i).Atoi()<<" NSupMod: "<<nSupMod<<" ieta: "<<ieta<<" iphi:"<<iphi<<" fill:"<<fill<<endl; 
+        hBadChannels[nSupMod]->SetBinContent(ieta,iphi,fill);
+    }
+}
 
-/*
- Default: 183913-186320
-run 183913-184481
-184482-185455(def)
-run185456-185784
-run185909-186035
-186036-186320(def)   
-*/
-/*
+/*******************************************************************
+ *  NOTE: Sorting function to sort the final OADB file             *
+ *                  by ascending runnumber                         *
+ *******************************************************************/
+void sortOutput(const char *fileNameOADB=""){
 
-1 file runs186365 to 186602
-LHC12f:
-2 files:
-186668 to 188123
-187534-187562
-LHC12g
-1 file: run 188356 to 188503
-*/
+    TFile *f                                    = TFile::Open(fileNameOADB);
+    f->ls();
+    AliOADBContainer *con                       =(AliOADBContainer*)f->Get("AliEMCALBadChannels");
+    con->SetName("Old"); 
+
+    Int_t indexAdd                              = 0;
+    Int_t largerthan                            = 0;
+    Int_t currentvalue                          = 0;
+
+    AliOADBContainer *con2                      = new AliOADBContainer("AliEMCALBadChannels");
+    con2->SetOwner();
+    // First entry needs to be added before sorting loop
+    con2->AppendObject(con->GetObjectByIndex(0),con->LowerLimit(0),con->UpperLimit(0));
+    TString strTemp                             = "";
+
+    // sorting magic happens here
+    for(int i=1;i<con->GetNumberOfEntries();i++){
+        largerthan                              = con2->UpperLimit(con2->GetNumberOfEntries()-1);
+        currentvalue                            = -1;
+        indexAdd                                = 0;
+        for(int j=0;j<con->GetNumberOfEntries();j++){
+            if(con->UpperLimit(j)<=largerthan) 
+                continue;
+            if(currentvalue < 0){
+                currentvalue                    = con->UpperLimit(j);
+                indexAdd                        = j;
+            }
+            if(con->UpperLimit(j)<currentvalue){
+                currentvalue                    = con->UpperLimit(j);
+                indexAdd                        = j;
+            }
+        }
+        con2->AppendObject(con->GetObjectByIndex(indexAdd),con->LowerLimit(indexAdd),con->UpperLimit(indexAdd));
+    }
+
+    printf("\n\n");
+    Int_t nentries2                             = con2->GetNumberOfEntries();
+    for(int i=0;i<nentries2;i++){
+        printf("\n Entry2 --> %d/%d -->",i,nentries2);
+        printf("%d -- %d --> obj = %p , %s", con2->LowerLimit(i),con2->UpperLimit(i),con2->GetObjectByIndex(i),con2->GetObjectByIndex(i)->GetName());
+    }
+    printf("\n\n");
+
+    con2->WriteToFile("EMCALBadChannelsNEW.root");
+}
+
+/*******************************************************************
+ *  NOTE: Function to read the bad channels from                   *
+ *                  the given input file                           *
+ *******************************************************************/
+Bool_t readin(TString fileRuns, std::vector<TString> &vec, Bool_t output, Int_t cellType)
+{
+    if(output) cout << Form("\nReading from %s...", fileRuns.Data()) << endl;
+    fstream file;
+    TString fVar;
+    Int_t totalN=0;
+    file.open(fileRuns.Data(), ios::in);
+    if(file.good())
+    {
+        file.seekg(0L, ios::beg);
+        if(output){
+            switch(cellType){
+                case 0:
+                    cout << "Read in dead cells: \"";
+                    break;
+                case 1:
+                    cout << "Read in bad cells: \"";
+                    break;
+                case 2:
+                    cout << "Read in warm cells: \"";
+                    break;
+                default:
+                    cout << "Read in cells (no type set): \"";
+            }
+        }
+        while(!file.eof())
+        {
+            file >> fVar;
+            if(fVar.Sizeof()>1)
+            {
+                if(output) cout << fVar.Data() << ", ";
+                vec.push_back(fVar);
+                totalN++;
+            }
+        }
+        if(output) cout << "\"" << endl;
+    }
+    file.close();
+    if(totalN>0){
+        switch(cellType){
+                case 0:
+                    cout << "...done!\n\nIn total " << totalN << " dead cells were read in!\n" << endl;
+                    break;
+                case 1:
+                    cout << "...done!\n\nIn total " << totalN << " bad cells were read in!\n" << endl;
+                    break;
+                case 2:
+                    cout << "...done!\n\nIn total " << totalN << " warm cells were read in!\n" << endl;
+                    break;
+                default:
+                    cout << "...done!\n\nIn total " << totalN << " cells were read in!\n" << endl;
+            }
+        return kTRUE;
+    }
+    else return kFALSE;
+}
 
 
-/*
-LHC12h:
-189122-189392
-189393-192732 (default)
 
-189301-189474
-189518-189698
-189699-190334
-190335-190425
-190449-190894 (def)
-190895-190984
-191022-191121 (def)
-191129-191159
-191163-191448 (def)
-191449-191451
-191485-192732 (def)
+TObjArray *CreatePeriodContainer(TObjArray *inputcont){
+  TObjArray *newcont = new TObjArray(inputcont->GetEntries());
+  newcont->SetName(inputcont->GetName());
+  for(int i = 0; i < inputcont->GetEntries(); i++){
+    newcont->AddAt(inputcont->At(i)->Clone(), i);
+  }
+  return newcont;
+}
 
+/*******************************************************************
+ *                                                                 *
+ *        NOTE: Function required to fix OADB ownership            *
+ *                                                                 *
+ *******************************************************************/
+void rebuildBadCellContainer(const char *fileNameOADB=""){
+  TFile *reader = TFile::Open(fileNameOADB);
+  AliOADBContainer *cont = static_cast<AliOADBContainer *>(reader->Get("AliEMCALBadChannels"));
+  delete reader;
 
-LHC12i
-192745-193300
-193301-193749
-193750-193766
-*/
+  AliOADBContainer *newcont = new AliOADBContainer("AliEMCALBadChannels");
+  for(int irun = 0; irun < cont->GetNumberOfEntries(); irun++){
+    newcont->AppendObject(CreatePeriodContainer(static_cast<TObjArray *>(cont->GetObjArray()->At(irun))), cont->LowerLimit(irun), cont->UpperLimit(irun));
+  }
+
+  newcont->WriteToFile("EMCALBadChannelsOADBfix.root");
+
+  TFile *reader = TFile::Open("EMCALBadChannelsOADBfix.root", "READ");
+    AliOADBContainer *cont = static_cast<AliOADBContainer *>(reader->Get("AliEMCALBadChannels"));
+    delete reader;
+    delete cont;
+}

--- a/PWGPP/EMCAL/OADBMacros/UpdateEMCAL_OADB_RunByRunTimeCalib.C
+++ b/PWGPP/EMCAL/OADBMacros/UpdateEMCAL_OADB_RunByRunTimeCalib.C
@@ -1,52 +1,49 @@
-/// \file UpdateEMCAL_OADB_RunByRunTimeCalib.C
-/// \ingroup EMCAL_OADB
-/// \brief  Update OADB Container for EMCal Run by Run calibration dependent on Time L1 phase 
-///
-/// Histograms with L1Phases are loaded and some TObjArrays are filled with these histograms.
-/// This UpdateEMCAL_OADB_RunByRunTimeCalib.C updates the information of a original OADB file 
-/// and writes the output to EMCALTimeL1PhaseCalib_update.root
-///
-/// ******* Example to Update OADB Container 
-/// ******* for EMCal Run by Run calibration dependent 
-/// ******* on Time L1 phase 
-/// to run it:
-///.x UpdateEMCAL_OADB_RunByRunTimeCalib.C("EMCALTimeL1PhaseCalib.root","CorrectionFiles/ReferenceSM_LHC15i_calib_v2.root","CorrectionFiles/runlist_LHC15i_calib.txt","pass0","EMCALTimeL1PhaseCalib_update.root")
-///.x UpdateEMCAL_OADB_RunByRunTimeCalib.C("EMCALTimeL1PhaseCalib_update.root","CorrectionFiles/ReferenceSM_LHC15j_muon_calo_pass1_v1.root","CorrectionFiles/runlist_LHC15j.txt","pass0","EMCALTimeL1PhaseCalib_update2.root")
-///.x UpdateEMCAL_OADB_RunByRunTimeCalib.C("EMCALTimeL1PhaseCalib_update2.root","CorrectionFiles/ReferenceSM_LHC15n_v1.root","CorrectionFiles/runlist_LHC15n.txt","pass1","EMCALTimeL1PhaseCalib_update3.root")
-///.x UpdateEMCAL_OADB_RunByRunTimeCalib.C("EMCALTimeL1PhaseCalib_update3.root","CorrectionFiles/ReferenceSM_LHC15o_muon_calo_pass1_v1.root","CorrectionFiles/runlist_LHC15o_mcp1.txt","pass1","EMCALTimeL1PhaseCalib_update4.root")
-///.x UpdateEMCAL_OADB_RunByRunTimeCalib.C("EMCALTimeL1PhaseCalib_update4.root","CorrectionFiles/ReferenceSM_LHC15i_calib_muon_calo_pass2_v1.root","CorrectionFiles/runlist_LHC15i_calib.txt","pass1","EMCALTimeL1PhaseCalib_update5.root")
-///.x UpdateEMCAL_OADB_RunByRunTimeCalib.C("EMCALTimeL1PhaseCalib_update5.root","CorrectionFiles/ReferenceSM_LHC15j_calib_muon_calo_pass2_v1.root","CorrectionFiles/runlist_LHC15j_calib.txt","pass1","EMCALTimeL1PhaseCalib_update6.root")
-///.x UpdateEMCAL_OADB_RunByRunTimeCalib.C("EMCALTimeL1PhaseCalib_update6.root","CorrectionFiles/ReferenceSM_LHC15j_mcp2_v1.root","CorrectionFiles/runlist_LHC15j.txt","pass1","EMCALTimeL1PhaseCalib_update7.root")
-///.x UpdateEMCAL_OADB_RunByRunTimeCalib.C("EMCALTimeL1PhaseCalib_update7.root","CorrectionFiles/ReferenceSM_LHC16h_mcp1_pass1_v1.root","CorrectionFiles/runlist_LHC16h.txt","pass1","EMCALTimeL1PhaseCalib_update8.root")
-///.x UpdateEMCAL_OADB_RunByRunTimeCalib.C("EMCALTimeL1PhaseCalib_update8.root","CorrectionFiles/ReferenceSM_LHC16f_mcp1_v1.root","CorrectionFiles/runlist_LHC16f.txt","pass1","EMCALTimeL1PhaseCalib_update9.root")  
-///.x UpdateEMCAL_OADB_RunByRunTimeCalib.C("EMCALTimeL1PhaseCalib_update9.root","CorrectionFiles/ReferenceSM_LHC16g_mcp1_v1.root","CorrectionFiles/runlist_LHC16g.txt","pass1","EMCALTimeL1PhaseCalib_update10.root")  
-///
-///.x UpdateEMCAL_OADB_RunByRunTimeCalib.C("EMCALTimeL1PhaseCalib_update10.root","CorrectionFiles/ReferenceSM_LHC16k_pass1_v2.root","CorrectionFiles/runlist_LHC16k.txt","pass1","EMCALTimeL1PhaseCalib_update11.root")  
-///.x UpdateEMCAL_OADB_RunByRunTimeCalib.C("EMCALTimeL1PhaseCalib_update11.root","CorrectionFiles/ReferenceSM_LHC16l_pass1_v2.root","CorrectionFiles/runlist_LHC16l.txt","pass1","EMCALTimeL1PhaseCalib_update12.root")  
-///.x UpdateEMCAL_OADB_RunByRunTimeCalib.C("EMCALTimeL1PhaseCalib_update12.root","CorrectionFiles/ReferenceSM_LHC16q_mcp1_v1.root","CorrectionFiles/runlist_LHC16q.txt","pass1","EMCALTimeL1PhaseCalib_update13.root")  
-///.x UpdateEMCAL_OADB_RunByRunTimeCalib.C("EMCALTimeL1PhaseCalib_update13.root","CorrectionFiles/ReferenceSM_LHC16r_mcp2_v2.root","CorrectionFiles/runlist_LHC16r.txt","pass1","EMCALTimeL1PhaseCalib_update14.root")  
-///.x UpdateEMCAL_OADB_RunByRunTimeCalib.C("EMCALTimeL1PhaseCalib_update14.root","CorrectionFiles/ReferenceSM_LHC16s_mcp1_v1.root","CorrectionFiles/runlist_LHC16s.txt","pass1","EMCALTimeL1PhaseCalib_update15.root")  
-///.x UpdateEMCAL_OADB_RunByRunTimeCalib.C("EMCALTimeL1PhaseCalib_update15.root","CorrectionFiles/ReferenceSM_LHC16t_mcp1_v1.root","CorrectionFiles/runlist_LHC16t.txt","pass1","EMCALTimeL1PhaseCalib_update16.root")  
-///
-/// \author Adam Matyja, <adam.tomasz.matyja@cern.ch>, IFJ PAN Cracow
-///
+//!  EMCal bad channel map creation macro
+/*!
+    With this macro, the 2D histogram bad channel maps can be added to OADB/EMCAL/EMCALBadChannels.root.
+*/
 
-///
-/// update the root file
-//
-/// \param fileNameOADB: TString, input OADB file
-/// \param filename: TString, input file with constants for given period
-/// \param runlist: TString, list file with runs for calibration
-/// \param passname: TString, pass name
-/// \param output: TString, output filename
-void UpdateEMCAL_OADB_RunByRunTimeCalib(TString fileNameOADB="$ALICE_ROOT/OADB/EMCAL/EMCALTimeL1PhaseCalib.root",
-					TString filename="CorrectionFiles/ReferenceSM_LHC15j_calib_v2.root",
-					TString runlist="CorrectionFiles/runlist_LHC15j_calib.txt",
-					TString passname="pass1", TString output="EMCALTimeL1PhaseCalib_update.root")
+#include "TGeoManager.h"
+
+/*******************************************************************
+ *  NOTE: Main function which needs to be adjusted for new BC maps *
+ *******************************************************************/
+void UpdateEMCAL_OADB_RunByRunTimeCalib(const char *fileNameOADBAli="$ALICE_DATA/OADB/EMCAL/EMCALTimeL1PhaseCalib.root")
 {
-  gSystem->Load("libOADB");  
-  AliOADBContainer *con	= new AliOADBContainer("");
-  con->InitFromFile(fileNameOADB.Data(), "AliEMCALTimeL1PhaseCalib");
+    gSystem->Load("libOADB");  
+    gSystem->Load("libEMCALbase");
+    gSystem->Load("libEMCALUtils");
+    gSystem->Load("libEMCALrec");
+
+    const char *fileNameOADB                ="EMCALTimeL1PhaseCalib_temp.root";
+    gSystem->Exec(Form("cp %s %s",fileNameOADBAli,fileNameOADB));
+
+    // LHC17pq - 20180310
+//      updateFile(fileNameOADB,"TimeCalibL1LHC17o","LHC17opq/LHC17o_mcp1_L1phases.root","LHC17opq/runlist_17o.txt","pass1");
+//      updateFile(fileNameOADB,"TimeCalibL1LHC17p","LHC17opq/LHC17p_mcp1_L1phases.root","LHC17opq/runlist_17p.txt","pass1");
+//      updateFile(fileNameOADB,"TimeCalibL1LHC17q","LHC17opq/LHC17q_mcp1_L1phases.root","LHC17opq/runlist_17q.txt","pass1");
+    // LHC17j - 20180320
+//      updateFile(fileNameOADB,"TimeCalibL1LHC17j","LHC17j/LHC17j_mcp1_L1phases.root","LHC17j/runlist_17j.txt","pass1");
+
+
+    // the final output will be sorted by runnumber
+    sortOutput("EMCALTimeL1PhaseCalib_temp.root");
+    rebuildTimeContainer("EMCALTimeL1PhaseCalib.root");
+
+}
+
+/*******************************************************************
+ *  NOTE: Update function that removes existing BC maps from old   *
+ *          file and adds new BC maps at the end of the file       *
+ *  NOTE: The final file is saved and directly renamed as new      *
+ *      input file for the next loop (this reduces total file size)*
+ *******************************************************************/
+void updateFile(const char *fileNameOADB,TString arrName, TString filename, TString runlist, TString passname){
+    printf("\n\nAdding %s maps to OADB file:\n",arrName.Data());
+
+    gSystem->Load("libOADB");  
+  AliOADBContainer *con    = new AliOADBContainer("");
+  con->InitFromFile(fileNameOADB, "AliEMCALTimeL1PhaseCalib");
 
   //list with run numbers to update
   ifstream fList;
@@ -81,112 +78,141 @@ void UpdateEMCAL_OADB_RunByRunTimeCalib(TString fileNameOADB="$ALICE_ROOT/OADB/E
 
       if(runNumber>200000){//L1 phase is only in LHC15 periods
 
-	tmpRefRun = (TH1C*)referenceFile->Get(Form("h%d",runNumber));
-	if(tmpRefRun==0x0) continue;
+    tmpRefRun = (TH1C*)referenceFile->Get(Form("h%d",runNumber));
+    if(tmpRefRun==0x0) continue;
 
-	//get run (period) array
-	TObjArray *arrayPeriod=NULL;
-	//cout<<"arrayPeriod (null) "<<arrayPeriod<<endl;
-	//arrayPeriod=(TObjArray*)con->GetObject(runNumber,Form("%d",runNumber));
-	arrayPeriod=(TObjArray*)con->GetObject(runNumber);
-	//cout<<"arrayPeriod (still null) "<<arrayPeriod<<endl;
-	if(arrayPeriod==0x0){//not exist in OADB need to be created
-	  arrayPeriod=new TObjArray(1);
-	  arrayPeriod->SetName(Form("%d",runNumber));
-	  firstTime=kTRUE;
-	}
-	//cout<<"arrayPeriod (not null)"<<arrayPeriod<<endl;
+    //get run (period) array
+    TObjArray *arrayPeriod=NULL;
+    arrayPeriod=(TObjArray*)con->GetObject(runNumber);
+    if(arrayPeriod==0x0){//not exist in OADB need to be created
+      arrayPeriod=new TObjArray(1);
+      arrayPeriod->SetName(Form("%d",runNumber));
+      firstTime=kTRUE;
+    }
+    //cout<<"arrayPeriod (not null)"<<arrayPeriod<<endl;
 
-	//create pass array
-	TObjArray *arrayPass=new TObjArray(1);
-	arrayPass->SetName(passname.Data());
+    //create pass array
+    TObjArray *arrayPass=new TObjArray(1);
+    arrayPass->SetName(passname.Data());
 
-//	// Init the histogram
-//	TH1C *h = new TH1C(Form("hh%d",runNumber),"",nSM-1,0,nSM-1);
-//	for(Int_t ism = 0; ism < nSM; ism++) {
-//	  Short_t recalFactor = tmpRefRun->GetBinContent(ism);
-//	  h->SetBinContent(ism,(Short_t)(recalFactor));
-//	}
 
-	//add histogram to pass array
-	//arrayPass->Add(h);
-	arrayPass->Add(tmpRefRun);
-	
-	//add pass array to period
-	arrayPeriod->Add(arrayPass);
+    //add histogram to pass array
+    //arrayPass->Add(h);
+    arrayPass->Add(tmpRefRun);
+    
+    //add pass array to period
+    arrayPeriod->Add(arrayPass);
 
-	//When updating object that has already been created: for instance, adding pass2,3 etc.
-	//Just get the object and add new array. Append of runnumber is already done in this case.
+    //When updating object that has already been created: for instance, adding pass2,3 etc.
+    //Just get the object and add new array. Append of runnumber is already done in this case.
 
-	if(firstTime){
-	  //add arrayperiod to main oadb
-	  con->AddDefaultObject((TObject*)arrayPeriod);
-	  //Establishing run number with the correct objects
-	  con->AppendObject(arrayPeriod,runNumber,runNumber);
-	  firstTime=kFALSE;
-	}
-	
-	nRuns++;
+    if(firstTime){
+      //add arrayperiod to main oadb
+      con->AddDefaultObject((TObject*)arrayPeriod);
+      //Establishing run number with the correct objects
+      con->AppendObject(arrayPeriod,runNumber,runNumber);
+      firstTime=kFALSE;
+    }
+    
+    nRuns++;
       }
     }
   }
   fList.close();
   printf(" *** nRuns ***  %d\n",nRuns);
-  //con->WriteToFile("EMCALTimeL1PhaseCalib_update2.root");   
-  con->WriteToFile(output.Data());   
+  con->WriteToFile("EMCALTimeL1PhaseCalib_temp.root");   
   //con->WriteToFile("EMCALTimeL1PhaseCalib.root");   
-  printf(" written to file %s\n",output.Data());
+  printf(" written to file\n");
 
   tmpRefRun->Delete();
 
   referenceFile->Close();    
 }
 
-/// \param runnumber: Int_t, run number
-/// \param passname: TString, pass name
-///
-void Read(int runnumber=236967,TString passname="pass1" ){
-  //
-  // let's read back the file
-  //
-  AliOADBContainer *cont=new AliOADBContainer("");
-  cont->InitFromFile("EMCALTimeL1PhaseCalib_update.root", "AliEMCALTimeL1PhaseCalib");
-  // 
-  cout<<"_________--------------- dump ---------------------___________"<<endl;
-  cont->Dump();
-  cout<<"_________--------------- list ---------------------___________"<<endl;
-  //cont0.List();
-  cout<<"cont->GetDefaultList()->Print()"<<endl;
-  cont->GetDefaultList()->Print();
 
-  TObjArray *recal=cont->GetObject(runnumber); //GetObject(int runnumber)
-  recal->ls();
+/*******************************************************************
+ *  NOTE: Sorting function to sort the final OADB file             *
+ *                  by ascending runnumber                         *
+ *******************************************************************/
+void sortOutput(const char *fileNameOADB=""){
 
-  TObjArray *recalpass=(TObjArray *)recal->FindObject(passname.Data());
-  if(!recalpass){
-    cout<<" no pass "<<passname.Data() <<endl;
-    return;
+    TFile *f                                    = TFile::Open(fileNameOADB);
+    AliOADBContainer *con                       =(AliOADBContainer*)f->Get("AliEMCALTimeL1PhaseCalib");
+    con->SetName("Old");
+
+    Int_t indexAdd                              = 0;
+    Int_t largerthan                            = 0;
+    Int_t currentvalue                          = 0;
+
+    AliOADBContainer *con2                      = new AliOADBContainer("AliEMCALTimeL1PhaseCalib");
+    // First entry needs to be added before sorting loop
+//     con2->AddDefaultObject(con->GetObjectByIndex(0));
+//     con2->AppendObject(con->GetObjectByIndex(0),con->LowerLimit(0),con->UpperLimit(0));
+    Int_t lowestRunIndex = con->GetIndexForRun(235716);
+//     con2->AddDefaultObject(con->GetObjectByIndex(lowestRunIndex));
+    con2->AppendObject(con->GetObjectByIndex(lowestRunIndex),con->LowerLimit(lowestRunIndex),con->UpperLimit(lowestRunIndex));
+    // sorting magic happens here
+    for(int i=1;i<con->GetNumberOfEntries();i++){
+        largerthan                              = con2->UpperLimit(con2->GetNumberOfEntries()-1);
+        currentvalue                            = -1;
+        indexAdd                                = 0;
+        for(int j=0;j<con->GetNumberOfEntries();j++){
+            if(con->UpperLimit(j)<=largerthan) 
+                continue;
+            else if(currentvalue < 0){
+                currentvalue                    = con->UpperLimit(j);
+                indexAdd                        = j;
+            }
+            else if(con->UpperLimit(j)<currentvalue){
+                currentvalue                    = con->UpperLimit(j);
+                indexAdd                        = j;
+            }
+        }
+//         con2->AddDefaultObject(con->GetObjectByIndex(indexAdd));
+        con2->AppendObject(con->GetObjectByIndex(indexAdd),con->LowerLimit(indexAdd),con->UpperLimit(indexAdd));
+    }
+
+    printf("\n\n");
+    Int_t nentries2                             = con2->GetNumberOfEntries();
+    for(int i=0;i<nentries2;i++){
+        printf("\n Entry2 --> %d/%d -->",i,nentries2);
+        printf("%d -- %d --> obj = %p , %s", con2->LowerLimit(i),con2->UpperLimit(i),con2->GetObjectByIndex(i),con2->GetObjectByIndex(i)->GetName());
+    }
+    printf("\n\n");
+
+    con2->WriteToFile("EMCALTimeL1PhaseCalib.root");
+    gSystem->Exec(Form("rm %s",fileNameOADB));
+
+}
+
+
+TObjArray *CreatePeriodContainer(TObjArray *inputcont){
+  TObjArray *newcont = new TObjArray(inputcont->GetEntries());
+  newcont->SetName(inputcont->GetName());
+  for(int i = 0; i < inputcont->GetEntries(); i++){
+    newcont->AddAt(inputcont->At(i)->Clone(), i);
+  }
+  return newcont;
+}
+
+/*******************************************************************
+ *  NOTE: Function required to fix OADB ownership                  *
+ *                                                                 *
+ *******************************************************************/
+void rebuildTimeContainer(const char *fileNameOADB=""){
+  TFile *reader = TFile::Open(fileNameOADB);
+  AliOADBContainer *cont = static_cast<AliOADBContainer *>(reader->Get("AliEMCALTimeL1PhaseCalib"));
+  delete reader;
+
+  AliOADBContainer *newcont = new AliOADBContainer("AliEMCALTimeL1PhaseCalib");
+  for(int irun = 0; irun < cont->GetNumberOfEntries(); irun++){
+    newcont->AppendObject(CreatePeriodContainer(static_cast<TObjArray *>(cont->GetObjArray()->At(irun))), cont->LowerLimit(irun), cont->UpperLimit(irun));
   }
 
-  TH1C *h=(TH1C *)recalpass->FindObject(Form("h%d",runNumber));
-  if (h) {
-    printf("runNumber %d found\n", runNumber);
-  }
-  else {
-    printf("runNumber %d not found - Error - do not use this run - not calibrated\n", runNumber);
-    return;
-  }
-  h->Print(); // tmp debug  
+  newcont->WriteToFile("EMCALTimeL1PhaseCalibOADBfix.root");
 
-  // Read parameter file line-by-line  
-  // Get number of lines first
-  
-  Int_t nSM = 20;
-  
-  for(Int_t iSM = 0; iSM < nSM; iSM++)
-  {
-    printf("SM %d, content %d\n",iSM,h->GetBinContent(iSM));
-  }
-  
-  h->Draw();
+  TFile *reader = TFile::Open("EMCALTimeL1PhaseCalibOADBfix.root", "READ");
+    AliOADBContainer *cont = static_cast<AliOADBContainer *>(reader->Get("AliEMCALTimeL1PhaseCalib"));
+    delete reader;
+    delete cont;
 }


### PR DESCRIPTION
This PR contains the current macros I use for the creation of the OADB files. The most important addition is the ownership test at the end of each macro.
The BC map macro was rewritten from ground up and is now much more user friendly and powerful.