### PR TITLE
Added alternative logic for D0 from Dstar analysis

### DIFF
--- a/PWGHF/vertexingHF/charmFlow/AliAnalysisTaskSEHFvn.cxx
+++ b/PWGHF/vertexingHF/charmFlow/AliAnalysisTaskSEHFvn.cxx
@@ -84,6 +84,7 @@
 #include "AliQnCorrectionsManager.h"
 #include "AliAnalysisTaskFlowVectorCorrections.h"
 #include "AliVertexingHFUtils.h"
+#include "AliESDtrack.h"
 
 #include "AliAnalysisTaskSEHFvn.h"
 
@@ -144,6 +145,9 @@ AliAnalysisTaskSE(),
   fPercentileq2(kFALSE),
   fEnableCentralityCorrCuts(kFALSE),
   fEnableCentralityMultiplicityCorrStrongCuts(kFALSE),
+  fOptD0FromDstar(0),
+  fUseFiltBit4SoftPion(kFALSE),
+  fCutsSoftPion(0x0),
   fFlowMethod(kEP)
 {
   // Default constructor
@@ -216,6 +220,9 @@ AliAnalysisTaskSEHFvn::AliAnalysisTaskSEHFvn(const char *name,AliRDHFCuts *rdCut
   fPercentileq2(kFALSE),
   fEnableCentralityCorrCuts(kFALSE),
   fEnableCentralityMultiplicityCorrStrongCuts(kFALSE),
+  fOptD0FromDstar(0),
+  fUseFiltBit4SoftPion(kFALSE),
+  fCutsSoftPion(0x0),
   fFlowMethod(kEP)
 {
   // standard constructor
@@ -290,6 +297,18 @@ AliAnalysisTaskSEHFvn::AliAnalysisTaskSEHFvn(const char *name,AliRDHFCuts *rdCut
   fDetV0ConfName[0]  = "VZERO";
   fDetV0ConfName[1]  = "VZEROA";
   fDetV0ConfName[2]  = "VZEROC";
+  
+  if(fDecChannel==kD0toKpiFromDstar && fOptD0FromDstar==1 && !fUseFiltBit4SoftPion) {
+    fCutsSoftPion = new AliESDtrackCuts();
+    fCutsSoftPion->SetRequireSigmaToVertex(kFALSE);
+    //default
+    fCutsSoftPion->SetRequireTPCRefit(kFALSE);
+    fCutsSoftPion->SetRequireITSRefit(kTRUE);
+    fCutsSoftPion->SetMinNClustersITS(3);
+    fCutsSoftPion->SetClusterRequirementITS(AliESDtrackCuts::kSPD,AliESDtrackCuts::kAny);
+    fCutsSoftPion->SetPtRange(0.1,1.e10);
+    fCutsSoftPion->SetEtaRange(-0.8,0.8);
+  }
 }
 
 //________________________________________________________________________
@@ -312,6 +331,9 @@ AliAnalysisTaskSEHFvn::~AliAnalysisTaskSEHFvn()
   if(fq2SmearingHisto) {delete fq2SmearingHisto;}
   for(Int_t i=0; i<6; i++) {
     if(fq2SplinesList[i]) {delete fq2SplinesList[i];}
+  }
+  if(fDecChannel==kD0toKpiFromDstar && fOptD0FromDstar==1 && !fUseFiltBit4SoftPion) {
+    delete fCutsSoftPion;
   }
 }
 //_________________________________________________________________
@@ -663,7 +685,7 @@ void AliAnalysisTaskSEHFvn::UserCreateOutputObjects()
     fOutput->Add(hq2CandVsq2Event);
 
     //histo of number of Dstar built using from the same Dzero (only in case of Dzero<-Dstar analysis)
-    if(fDecChannel==kD0toKpiFromDstar) {
+    if(fDecChannel==kD0toKpiFromDstar && fOptD0FromDstar==0) {
       TH1F* hNumDstarCandFromSameDzeroCand = new TH1F("hNumDstarCandFromSameDzeroCand","Number of Dstar candidates built using same Dzero candidate",101,-0.5,100.5);
       fOutput->Add(hNumDstarCandFromSameDzeroCand);
     }
@@ -741,7 +763,12 @@ void AliAnalysisTaskSEHFvn::UserExec(Option_t */*option*/)
       }
       if(fDecChannel==4){
         absPdgMom=421;
-        arrayProng=(TClonesArray*)aodFromExt->GetList()->FindObject("Dstar");
+        if(fOptD0FromDstar==0) {
+          arrayProng=(TClonesArray*)aodFromExt->GetList()->FindObject("Dstar");
+        }
+        else {
+          arrayProng=(TClonesArray*)aodFromExt->GetList()->FindObject("D0toKpi");
+        }
       }
     }
   } else if(aod){
@@ -763,7 +790,12 @@ void AliAnalysisTaskSEHFvn::UserExec(Option_t */*option*/)
     }
     if(fDecChannel==4){
       absPdgMom=421;
-      arrayProng=(TClonesArray*)aod->GetList()->FindObject("Dstar");
+      if(fOptD0FromDstar==0) {
+        arrayProng=(TClonesArray*)aod->GetList()->FindObject("Dstar");
+      }
+      else {
+        arrayProng=(TClonesArray*)aod->GetList()->FindObject("D0toKpi");
+      }
     }
   }
 
@@ -1114,17 +1146,17 @@ void AliAnalysisTaskSEHFvn::UserExec(Option_t */*option*/)
   std::vector<Int_t> isSelectedCand;
 
   Int_t nSelCandInMassRange=0;
-  std::vector<Int_t> dzerodaulab1; //vector of labels of D0 daugheter 1 necessary if kD0toKpiFromDstar is used
-  std::vector<Int_t> dzerodaulab2; //vector of labels of D0 daugheter 2 necessary if kD0toKpiFromDstar is used
+  std::vector<Int_t> dzerodaulab1; //vector of labels of D0 daugheter 1 necessary if kD0toKpiFromDstar is used with fOptD0FromDstar==0
+  std::vector<Int_t> dzerodaulab2; //vector of labels of D0 daugheter 2 necessary if kD0toKpiFromDstar is used with fOptD0FromDstar==0
   Int_t nD0usedfordiffDstar=0;
   //Loop on D candidates
   for (Int_t iCand = 0; iCand < nCand; iCand++) {
     Bool_t isD0new = kTRUE;
-    if(fDecChannel!=4) {
+    if(!(fDecChannel==4 && fOptD0FromDstar==0)) {
       d=(AliAODRecoDecayHF*)arrayProng->UncheckedAt(iCand);
       Bool_t isSelBit=kTRUE;
       if(fDecChannel==0) isSelBit=d->HasSelectionBit(AliRDHFCuts::kDplusCuts);
-      if(fDecChannel==1) isSelBit=d->HasSelectionBit(AliRDHFCuts::kD0toKpiCuts);
+      if(fDecChannel==1 || fDecChannel==4) isSelBit=d->HasSelectionBit(AliRDHFCuts::kD0toKpiCuts);
       if(fDecChannel==2) isSelBit=kTRUE;
       if(fDecChannel==3) isSelBit=d->HasSelectionBit(AliRDHFCuts::kDsCuts);
       if(!isSelBit)continue;
@@ -1132,14 +1164,14 @@ void AliAnalysisTaskSEHFvn::UserExec(Option_t */*option*/)
       if(fDecChannel==0 || fDecChannel==3) {
         if(!vHF->FillRecoCand(aod,(AliAODRecoDecayHF3Prong*)d))continue;
       }
-      else if(fDecChannel == 1) {
+      else if(fDecChannel == 1 || fDecChannel==4) {
         if(!vHF->FillRecoCand(aod,(AliAODRecoDecayHF2Prong*)d))continue;
       }
       else if(fDecChannel == 2) {
         if(!vHF->FillRecoCasc(aod,((AliAODRecoCascadeHF*)d),kTRUE))continue;
       }
     }
-    else if (fDecChannel == 4) {
+    else if (fDecChannel == 4 && fOptD0FromDstar==0) {
       //Get the D* candidate, see if it is in the mass range and if it is the case assign the D0 daughter to d
       AliAODRecoDecayHF* dstar=(AliAODRecoDecayHF*)arrayProng->UncheckedAt(iCand);
       if(!vHF->FillRecoCasc(aod,((AliAODRecoCascadeHF*)dstar),kTRUE))continue;
@@ -1178,9 +1210,76 @@ void AliAnalysisTaskSEHFvn::UserExec(Option_t */*option*/)
       Int_t isDsPhipiKK = isSelected&8;
       if(!isDsPhiKKpi & !isDsPhipiKK) continue;
     }
-    if(fDecChannel==4 && !isD0new) {
+    if(fDecChannel==4 && fOptD0FromDstar==0 && !isD0new) {
       nD0usedfordiffDstar++;
       continue; //if D0 candidate already used for previous Dstar candidates, continue (the same D0 candidate can build many D* candidates)
+    }
+    if(fDecChannel==4 && fOptD0FromDstar==1) {
+      
+      Double_t deltamassPDG=(TDatabasePDG::Instance()->GetParticle(413)->Mass())-(TDatabasePDG::Instance()->GetParticle(421)->Mass());
+      Int_t isD0fromDstar=kFALSE;
+      Double_t invmassD0=-1;
+
+      if(isSelected==1) {
+        Int_t pdgdaughtersD0[2]={211,321};//pi+,K-
+        invmassD0 = d->InvMass(2,(UInt_t*)pdgdaughtersD0); //D0
+      }
+      else if(isSelected==2) {
+        Int_t pdgdaughtersD0bar[2]={321,211};//K+,pi-
+        invmassD0 = d->InvMass(2,(UInt_t*)pdgdaughtersD0bar); //D0bar
+      }
+      
+      AliAODTrack* dautrack1 = (AliAODTrack*)d->GetDaughter(0);
+      AliAODTrack* dautrack2 = (AliAODTrack*)d->GetDaughter(1);
+      Double_t mpion=TDatabasePDG::Instance()->GetParticle(211)->Mass();
+      Double_t mkaon=TDatabasePDG::Instance()->GetParticle(321)->Mass();
+
+      AliAODVertex *vAOD = d->GetPrimaryVtx();
+      Double_t pos[3],cov[6];
+      vAOD->GetXYZ(pos);
+      vAOD->GetCovarianceMatrix(cov);
+      const AliESDVertex vESD(pos,cov,100.,100);
+
+      for(Int_t iTrk=0; iTrk<aod->GetNumberOfTracks(); iTrk++) {
+        //check whether D0/D0bar comes from a Dstar, combining it with soft pions
+        AliAODTrack* track=(AliAODTrack*)aod->GetTrack(iTrk);
+        Short_t charge = track->Charge();
+        //wrong charge sign --> continue
+        if(isSelected==1 && charge<0) continue;
+        if(isSelected==2 && charge>0) continue;
+        
+        //track does not pass soft pion selections --> continue
+        if(!IsSoftPionSelected(track,&vESD)) continue;
+        
+        if(isSelected==3 && charge>0) {
+          Int_t pdgdaughtersD0[2]={211,321};//pi+,K-
+          invmassD0 = d->InvMass(2,(UInt_t*)pdgdaughtersD0); //D0
+        }
+        else if(isSelected==3 && charge<0) {
+          Int_t pdgdaughtersD0bar[2]={321,211};//K+,pi-
+          invmassD0 = d->InvMass(2,(UInt_t*)pdgdaughtersD0bar); //D0bar
+        }
+        
+        //compute invariant mass of D0 + soft pion
+        Double_t energysum = 0;
+        if(charge>0) {
+          energysum = track->E(mpion)+dautrack1->E(mpion)+dautrack2->E(mkaon);
+        }
+        else if(charge<0) {
+          energysum = track->E(mpion)+dautrack1->E(mkaon)+dautrack2->E(mpion);
+        }
+        Double_t psum2 = (track->Px()+dautrack1->Px()+dautrack2->Px())*(track->Px()+dautrack1->Px()+dautrack2->Px())+(track->Py()+dautrack1->Py()+dautrack2->Py())*(track->Py()+dautrack1->Py()+dautrack2->Py())+(track->Pz()+dautrack1->Pz()+dautrack2->Pz())*(track->Pz()+dautrack1->Pz()+dautrack2->Pz());
+        Double_t invmassDstar = TMath::Sqrt(energysum*energysum-psum2);
+        
+        Double_t deltainvmassKpipi = invmassDstar-invmassD0;
+        
+        Double_t sigma = 0.0008;
+        if(deltainvmassKpipi<deltamassPDG+3*sigma && deltainvmassKpipi>deltamassPDG+3*sigma) {
+          isD0fromDstar=kTRUE;
+          break;
+        }
+      }
+      if(!isD0fromDstar) continue;
     }
     isSelectedCand.push_back(isSelected);
     
@@ -1605,7 +1704,7 @@ void AliAnalysisTaskSEHFvn::UserExec(Option_t */*option*/)
     }
 
     //fill histo for number of Dstar built using the same Dzero (only in case of Dzero from Dstar analysis)
-    if(fDecChannel==kD0toKpiFromDstar) {
+    if(fDecChannel==kD0toKpiFromDstar && fOptD0FromDstar==0) {
       ((TH1F*)fOutput->FindObject("hNumDstarCandFromSameDzeroCand"))->Fill(nD0usedfordiffDstar);
     }
     
@@ -3002,6 +3101,30 @@ void AliAnalysisTaskSEHFvn::RemoveTracksInDeltaEtaFromOnTheFlyTPCq2(AliAODEvent*
       M--;
     }
   }
+}
+
+//________________________________________________________________________
+Bool_t AliAnalysisTaskSEHFvn::IsSoftPionSelected(AliAODTrack* track, const AliESDVertex* primary)
+{
+  //track cuts
+  if(fUseFiltBit4SoftPion) {
+    if(!track->TestFilterBit(4)) return kFALSE;
+  }
+  else {
+    // convert to ESD track here
+    AliESDtrack esdTrack(track);
+    // set the TPC cluster info
+    esdTrack.SetTPCClusterMap(track->GetTPCClusterMap());
+    esdTrack.SetTPCSharedMap(track->GetTPCSharedMap());
+    esdTrack.SetTPCPointsF(track->GetTPCNclsF());
+    // needed to calculate the impact parameters
+    esdTrack.RelateToVertex(primary,0.,3.);
+    
+    //applying ESDtrackCut
+    if(!fCutsSoftPion->IsSelected(&esdTrack)) return kFALSE;
+  }
+  
+  return kTRUE;
 }
 
 //________________________________________________________________________

--- a/PWGHF/vertexingHF/charmFlow/AliAnalysisTaskSEHFvn.h
+++ b/PWGHF/vertexingHF/charmFlow/AliAnalysisTaskSEHFvn.h
@@ -20,6 +20,9 @@
 #include "AliHFAfterBurner.h"
 #include "AliQnCorrectionsQnVector.h"
 #include "AliEventCuts.h"
+#include "AliAODTrack.h"
+#include "AliESDtrackCuts.h"
+#include "AliESDVertex.h"
 
 class TH1F;
 class TH2F;
@@ -149,6 +152,13 @@ class AliAnalysisTaskSEHFvn : public AliAnalysisTaskSE
     return fEventCuts;
   }
   
+  //options for kD0toKpiFromDstar
+  void SetOptD0FromDstar(Int_t option=0, Bool_t useFilterBit4softPion=kFALSE) {
+    fOptD0FromDstar=option;
+    fUseFiltBit4SoftPion=useFilterBit4softPion;
+  }
+  Bool_t IsSoftPionSelected(AliAODTrack* track,const AliESDVertex* primary);
+
   // Implementation of interface methods
   virtual void UserCreateOutputObjects();
   virtual void LocalInit();// {Init();}
@@ -237,10 +247,13 @@ class AliAnalysisTaskSEHFvn : public AliAnalysisTaskSE
   Bool_t fEnableCentralityCorrCuts; //enable V0M - CL0 centrality correlation cuts
   Bool_t fEnableCentralityMultiplicityCorrStrongCuts; //enable centrality vs. multiplicity correlation cuts
   AliEventCuts fEventCuts; //Event cut object for centrality correlation event cuts
-
+  Int_t fOptD0FromDstar; //option for D0 from Dstar analysis (0: starting from Dstar, 1: strarting from Dzero)
+  Bool_t fUseFiltBit4SoftPion; //flag to enable filterbit 4 for soft pion in D0 from Dstar analysis
+  AliESDtrackCuts *fCutsSoftPion; //track cuts for soft pions used in case of D0 from Dstar analysis (option 1)
+  
   AliAnalysisTaskSEHFvn::FlowMethod fFlowMethod;
 
-  ClassDef(AliAnalysisTaskSEHFvn,17); // AliAnalysisTaskSE for the HF v2 analysis
+  ClassDef(AliAnalysisTaskSEHFvn,18); // AliAnalysisTaskSE for the HF v2 analysis
 };
 
 #endif

--- a/PWGHF/vertexingHF/charmFlow/AliAnalysisTaskSEHFvn.h
+++ b/PWGHF/vertexingHF/charmFlow/AliAnalysisTaskSEHFvn.h
@@ -22,7 +22,6 @@
 #include "AliEventCuts.h"
 #include "AliAODTrack.h"
 #include "AliESDtrackCuts.h"
-#include "AliESDVertex.h"
 
 class TH1F;
 class TH2F;
@@ -157,7 +156,7 @@ class AliAnalysisTaskSEHFvn : public AliAnalysisTaskSE
     fOptD0FromDstar=option;
     fUseFiltBit4SoftPion=useFilterBit4softPion;
   }
-  Bool_t IsSoftPionSelected(AliAODTrack* track,const AliESDVertex* primary);
+  Bool_t IsSoftPionSelected(AliAODTrack* track);
 
   // Implementation of interface methods
   virtual void UserCreateOutputObjects();


### PR DESCRIPTION
Added possibility to select D0 from Dstart, starting from D0 candidates and combining them with soft pions. Soft pions can be selected using standard selections for soft pions (3 points in ITS, pt > 0.1 GeV/c, ITS refit, SPD kAny) or requiring the TPC (filterbit 4). 