### PR TITLE
Improve alignment information

### DIFF
--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.h
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALAlig.h
@@ -33,6 +33,11 @@ public:
     Float_t pz;
     Float_t eta_track;
     Float_t phi_track;
+    Float_t x_track;
+    Float_t y_track;
+    Float_t z_track;
+    Float_t zvtx;
+
     
     //cluster properties
     Float_t energy;
@@ -40,98 +45,79 @@ public:
     Float_t M02;
     Float_t eta_cluster;
     Float_t phi_cluster;
-    UShort_t super_module_number;
-    
-    //mathing properties using default matcher
-    Float_t x_resitual_def;
-    Float_t y_resitual_def;
-    Float_t z_resitual_def;
-    Float_t phi_resitual_def;
-    Float_t eta_resitual_def;
-    
+    Float_t x_cluster;
+    Float_t y_cluster;
+    Float_t z_cluster;
+
     //mathing properties using electron mass
-    Float_t x_resitual_e;
-    Float_t y_resitual_e;
-    Float_t z_resitual_e;
-    Float_t phi_resitual_e;
-    Float_t eta_resitual_e;
-    
+    UShort_t super_module_number;
+    Int_t distance_bad_channel;
+    Bool_t is_in_fid_region;
+
     //PID properties
     Float_t n_sigma_electron_TPC;
     
     ElectronForAlignment()
     {
-        //General Track properties
         charge = -9;
         pt = -999;
         pz = -999;
         eta_track = -999;
         phi_track = -999;
-        
-        //cluster properties
+        x_track = -999;
+        y_track = -999;
+        z_track = -999;
+        zvtx = -999;
+
         energy = -999;
         M20 = -999;
         M02 = -999;
         eta_cluster = -999;
         phi_cluster = -999;
+        x_cluster = -999;
+        y_cluster = -999;
+        z_cluster = -999;
         
-        //mathing properties using default matcher
-        x_resitual_def = -999;
-        y_resitual_def = -999;
-        z_resitual_def = -999;
-        phi_resitual_def = -999;
-        eta_resitual_def = -999;
-        
-        //mathing properties using electron mass
-        x_resitual_e = -999;
-        y_resitual_e = -999;
-        z_resitual_e = -999;
-        phi_resitual_e = -999;
-        eta_resitual_e = -999;
-        
+
         super_module_number = 99;
-        //PID properties
+        distance_bad_channel = -99;
+        is_in_fid_region = kFALSE;
+
         n_sigma_electron_TPC = -999;
     }
     
     void Reset()
     {
-        //General Track properties
-        charge = -9;
+               charge = -9;
         pt = -999;
         pz = -999;
         eta_track = -999;
         phi_track = -999;
-        
-        //cluster properties
+        x_track = -999;
+        y_track = -999;
+        z_track = -999;
+        zvtx = -999;
+
+
         energy = -999;
         M20 = -999;
         M02 = -999;
         eta_cluster = -999;
         phi_cluster = -999;
+        x_cluster = -999;
+        y_cluster = -999;
+        z_cluster = -999;
         
-        //mathing properties using default matcher
-        x_resitual_def = -999;
-        y_resitual_def = -999;
-        z_resitual_def = -999;
-        phi_resitual_def = -999;
-        eta_resitual_def = -999;
-        
-        //mathing properties using electron mass
-        x_resitual_e = -999;
-        y_resitual_e = -999;
-        z_resitual_e = -999;
-        phi_resitual_e = -999;
-        eta_resitual_e = -999;
-        
+
         super_module_number = 99;
-        //PID properties
+        distance_bad_channel = -99;
+        is_in_fid_region = kFALSE;
         n_sigma_electron_TPC = -999;
     }
     
     //Default Initializer
     
-    ClassDef(ElectronForAlignment, 2);
+    ClassDef(ElectronForAlignment, 3);
     
 };
 


### PR DESCRIPTION
In this commit I have changed:

- The propagation of the tracks is done by AliTrackerBase instead of AliEMCALRecoUtils. With this change I hope to achieve better precision on the edges of the EMCAL.
- Now the tree saves only XYZ positions of the track using the method above and the XYZ positions of the cluster. This saves space and may allow a more complete study. The phi and eta can of course be calculated straightforward.
- The default matcher is removed (saves a bit of space), since it is clearly not good enough for this study.
- The trees now have informations about the Z of the primary vertex
- A flag (is_in_fid_region) that looks if the cluster is or not in the edge was added.
- Check the distance to the bad channels and saves it to the tree (@gconesab can check if the implementation is ok for the last two)
- Changed the method to get the Energy from GetNonLinCorrEnergy() to E() (suggested by electrons experts) 

Please let me know in case you think I should add more variables or if I missed something from the discussion last week.