### PR TITLE
Event weight information in the output

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.cxx
@@ -20,6 +20,7 @@
 #include <TList.h>
 #include <TObject.h>
 #include <TH1F.h>
+#include <TH2F.h>
 #include <TProfile.h>
 #include <TSystem.h>
 #include <TFile.h>
@@ -122,27 +123,7 @@ AliAnalysisTaskEmcalLight::AliAnalysisTaskEmcalLight() :
   fEventWeight(1),
   fGeneratorName(),
   fOutput(0),
-  fHistTrialsVsPtHardNoSel(0),
-  fHistEventsVsPtHardNoSel(0),
-  fHistXsectionVsPtHardNoSel(0),
-  fHistEventWeightsNoSel(0),
-  fHistTriggerClassesNoSel(0),
-  fHistZVertexNoSel(0),
-  fHistCentralityNoSel(0),
-  fHistEventPlaneNoSel(0),
-  fHistTrialsVsPtHard(0),
-  fHistEventsVsPtHard(0),
-  fHistXsectionVsPtHard(0),
-  fHistEventWeights(0),
-  fHistTriggerClasses(0),
-  fHistZVertex(0),
-  fHistCentrality(0),
-  fHistEventPlane(0),
-  fHistEventCount(0),
-  fHistEventRejection(0),
-  fHistTrials(0),
-  fHistEvents(0),
-  fHistXsection(0)
+  fHistograms()
 {
   fVertex[0] = 0;
   fVertex[1] = 0;
@@ -196,8 +177,8 @@ AliAnalysisTaskEmcalLight::AliAnalysisTaskEmcalLight(const char *name, Bool_t hi
   fSwitchOffLHC15oFaultyBranches(kFALSE),
   fEventSelectionAfterRun(kFALSE),
   fSelectGeneratorName(),
-  fMinimumEventWeight(0),
-  fMaximumEventWeight(100),
+  fMinimumEventWeight(1e-6),
+  fMaximumEventWeight(1e6),
   fInhibit(kFALSE),
   fLocalInitialized(kFALSE),
   fDataType(kAOD),
@@ -223,27 +204,7 @@ AliAnalysisTaskEmcalLight::AliAnalysisTaskEmcalLight(const char *name, Bool_t hi
   fEventWeight(1),
   fGeneratorName(),
   fOutput(0),
-  fHistTrialsVsPtHardNoSel(0),
-  fHistEventsVsPtHardNoSel(0),
-  fHistXsectionVsPtHardNoSel(0),
-  fHistEventWeightsNoSel(0),
-  fHistTriggerClassesNoSel(0),
-  fHistZVertexNoSel(0),
-  fHistCentralityNoSel(0),
-  fHistEventPlaneNoSel(0),
-  fHistTrialsVsPtHard(0),
-  fHistEventsVsPtHard(0),
-  fHistXsectionVsPtHard(0),
-  fHistEventWeights(0),
-  fHistTriggerClasses(0),
-  fHistZVertex(0),
-  fHistCentrality(0),
-  fHistEventPlane(0),
-  fHistEventCount(0),
-  fHistEventRejection(0),
-  fHistTrials(0),
-  fHistEvents(0),
-  fHistXsection(0)
+  fHistograms()
 {
   fVertex[0] = 0;
   fVertex[1] = 0;
@@ -326,135 +287,164 @@ void AliAnalysisTaskEmcalLight::UserCreateOutputObjects()
 
   if (!fGeneralHistograms) return;
 
+  TH1* h = nullptr;
+
   if (fIsPythia) {
     auto weight_bins = GenerateLogFixedBinArray(1000, fMinimumEventWeight, fMaximumEventWeight, true);
 
-    fHistEventsVsPtHard = new TH1F("fHistEventsVsPtHard", "fHistEventsVsPtHard", 1000, 0, 1000);
-    fHistEventsVsPtHard->GetXaxis()->SetTitle("#it{p}_{T,hard} (GeV/#it{c})");
-    fHistEventsVsPtHard->GetYaxis()->SetTitle("events");
-    fOutput->Add(fHistEventsVsPtHard);
+    h = new TH1F("fHistEventsVsPtHard", "fHistEventsVsPtHard", 1000, 0, 1000);
+    h->GetXaxis()->SetTitle("#it{p}_{T,hard} (GeV/#it{c})");
+    h->GetYaxis()->SetTitle("events");
+    fOutput->Add(h);
+    fHistograms["fHistEventsVsPtHard"] = h;
 
-    fHistTrialsVsPtHard = new TH1F("fHistTrialsVsPtHard", "fHistTrialsVsPtHard", 1000, 0, 1000);
-    fHistTrialsVsPtHard->GetXaxis()->SetTitle("#it{p}_{T,hard} (GeV/#it{c})");
-    fHistTrialsVsPtHard->GetYaxis()->SetTitle("trials");
-    fOutput->Add(fHistTrialsVsPtHard);
+    h = new TH1F("fHistTrialsVsPtHard", "fHistTrialsVsPtHard", 1000, 0, 1000);
+    h->GetXaxis()->SetTitle("#it{p}_{T,hard} (GeV/#it{c})");
+    h->GetYaxis()->SetTitle("trials");
+    fOutput->Add(h);
+    fHistograms["fHistTrialsVsPtHard"] = h;
 
-    fHistXsectionVsPtHard = new TProfile("fHistXsectionVsPtHard", "fHistXsectionVsPtHard", 1000, 0, 1000);
-    fHistXsectionVsPtHard->GetXaxis()->SetTitle("#it{p}_{T,hard} (GeV/#it{c})");
-    fHistXsectionVsPtHard->GetYaxis()->SetTitle("xsection");
-    fOutput->Add(fHistXsectionVsPtHard);
+    h = new TProfile("fHistXsectionVsPtHard", "fHistXsectionVsPtHard", 1000, 0, 1000);
+    h->GetXaxis()->SetTitle("#it{p}_{T,hard} (GeV/#it{c})");
+    h->GetYaxis()->SetTitle("xsection");
+    fOutput->Add(h);
+    fHistograms["fHistXsectionVsPtHard"] = h;
 
-    fHistEventWeights = new TH1F("fHistEventWeights", "fHistEventWeights", 1000, &weight_bins[0]);
-    fHistEventWeights->GetXaxis()->SetTitle("weight");
-    fHistEventWeights->GetYaxis()->SetTitle("events");
-    fOutput->Add(fHistEventWeights);
+    h = new TH1F("fHistEventWeights", "fHistEventWeights", 1000, &weight_bins[0]);
+    h->GetXaxis()->SetTitle("weight");
+    h->GetYaxis()->SetTitle("events");
+    fOutput->Add(h);
+    fHistograms["fHistEventWeights"] = h;
 
-    fHistEventsVsPtHardNoSel = new TH1F("fHistEventsVsPtHardNoSel", "fHistEventsVsPtHardNoSel", 1000, 0, 1000);
-    fHistEventsVsPtHardNoSel->GetXaxis()->SetTitle("#it{p}_{T,hard} (GeV/#it{c})");
-    fHistEventsVsPtHardNoSel->GetYaxis()->SetTitle("events");
-    fOutput->Add(fHistEventsVsPtHardNoSel);
+    h = new TH2F("fHistEventWeightsVsPtHard", "fHistEventWeightsVsPtHard", 1000, 0, 1000, 1000, &weight_bins[0]);
+    h->GetXaxis()->SetTitle("#it{p}_{T,hard} (GeV/#it{c})");
+    h->GetYaxis()->SetTitle("event weight");
+    fOutput->Add(h);
+    fHistograms["fHistEventWeightsVsPtHard"] = h;
 
-    fHistTrialsVsPtHardNoSel = new TH1F("fHistTrialsVsPtHardNoSel", "fHistTrialsVsPtHardNoSel", 1000, 0, 1000);
-    fHistTrialsVsPtHardNoSel->GetXaxis()->SetTitle("#it{p}_{T,hard} (GeV/#it{c})");
-    fHistTrialsVsPtHardNoSel->GetYaxis()->SetTitle("trials");
-    fOutput->Add(fHistTrialsVsPtHardNoSel);
+    h = new TH1F("fHistEventsVsPtHardNoSel", "fHistEventsVsPtHardNoSel", 1000, 0, 1000);
+    h->GetXaxis()->SetTitle("#it{p}_{T,hard} (GeV/#it{c})");
+    h->GetYaxis()->SetTitle("events");
+    fOutput->Add(h);
+    fHistograms["fHistEventsVsPtHardNoSel"] = h;
 
-    fHistXsectionVsPtHardNoSel = new TProfile("fHistXsectionVsPtHardNoSel", "fHistXsectionVsPtHardNoSel", 1000, 0, 1000);
-    fHistXsectionVsPtHardNoSel->GetXaxis()->SetTitle("#it{p}_{T,hard} (GeV/#it{c})");
-    fHistXsectionVsPtHardNoSel->GetYaxis()->SetTitle("xsection");
-    fOutput->Add(fHistXsectionVsPtHardNoSel);
+    h = new TH1F("fHistTrialsVsPtHardNoSel", "fHistTrialsVsPtHardNoSel", 1000, 0, 1000);
+    h->GetXaxis()->SetTitle("#it{p}_{T,hard} (GeV/#it{c})");
+    h->GetYaxis()->SetTitle("trials");
+    fOutput->Add(h);
+    fHistograms["fHistTrialsVsPtHardNoSel"] = h;
 
-    fHistEventWeightsNoSel = new TH1F("fHistEventWeightsNoSel", "fHistEventWeightsNoSel", 1000, &weight_bins[0]);
-    fHistEventWeightsNoSel->GetXaxis()->SetTitle("weight");
-    fHistEventWeightsNoSel->GetYaxis()->SetTitle("events");
-    fOutput->Add(fHistEventWeightsNoSel);
+    h = new TProfile("fHistXsectionVsPtHardNoSel", "fHistXsectionVsPtHardNoSel", 1000, 0, 1000);
+    h->GetXaxis()->SetTitle("#it{p}_{T,hard} (GeV/#it{c})");
+    h->GetYaxis()->SetTitle("xsection");
+    fOutput->Add(h);
+    fHistograms["fHistXsectionVsPtHardNoSel"] = h;
 
-    fHistTrials = new TH1F("fHistTrials", "fHistTrials", 50, 0, 50);
-    fHistTrials->GetXaxis()->SetTitle("#it{p}_{T,hard} bin");
-    fHistTrials->GetYaxis()->SetTitle("trials");
-    fOutput->Add(fHistTrials);
+    h = new TH1F("fHistEventWeightsNoSel", "fHistEventWeightsNoSel", 1000, &weight_bins[0]);
+    h->GetXaxis()->SetTitle("weight");
+    h->GetYaxis()->SetTitle("events");
+    fOutput->Add(h);
+    fHistograms["fHistEventWeightsNoSel"] = h;
 
-    fHistEvents = new TH1F("fHistEvents", "fHistEvents", 50, 0, 50);
-    fHistEvents->GetXaxis()->SetTitle("#it{p}_{T,hard} bin");
-    fHistEvents->GetYaxis()->SetTitle("total events");
-    fOutput->Add(fHistEvents);
+    h = new TH1F("fHistTrials", "fHistTrials", 50, 0, 50);
+    h->GetXaxis()->SetTitle("#it{p}_{T,hard} bin");
+    h->GetYaxis()->SetTitle("trials");
+    fOutput->Add(h);
+    fHistograms["fHistTrialsExternalFile"] = h;
 
-    fHistXsection = new TProfile("fHistXsection", "fHistXsection", 50, 0, 50);
-    fHistXsection->GetXaxis()->SetTitle("#it{p}_{T,hard} bin");
-    fHistXsection->GetYaxis()->SetTitle("xsection");
-    fOutput->Add(fHistXsection);
+    h = new TH1F("fHistEvents", "fHistEvents", 50, 0, 50);
+    h->GetXaxis()->SetTitle("#it{p}_{T,hard} bin");
+    h->GetYaxis()->SetTitle("total events");
+    fOutput->Add(h);
+    fHistograms["fHistEventsExternalFile"] = h;
+
+    h = new TProfile("fHistXsection", "fHistXsection", 50, 0, 50);
+    h->GetXaxis()->SetTitle("#it{p}_{T,hard} bin");
+    h->GetYaxis()->SetTitle("xsection");
+    fOutput->Add(h);
+    fHistograms["fHistXsection"] = h;
   }
 
-  fHistZVertex = new TH1F("fHistZVertex","Z vertex position", 60, -30, 30);
-  fHistZVertex->GetXaxis()->SetTitle("V_{#it{z}}");
-  fHistZVertex->GetYaxis()->SetTitle("counts");
-  fOutput->Add(fHistZVertex);
+  h = new TH1F("fHistZVertex","Z vertex position", 60, -30, 30);
+  h->GetXaxis()->SetTitle("V_{#it{z}}");
+  h->GetYaxis()->SetTitle("counts");
+  fOutput->Add(h);
+  fHistograms["fHistZVertex"] = h;
 
-  fHistZVertexNoSel = new TH1F("fHistZVertexNoSel","Z vertex position (no event selection)", 60, -30, 30);
-  fHistZVertexNoSel->GetXaxis()->SetTitle("V_{#it{z}}");
-  fHistZVertexNoSel->GetYaxis()->SetTitle("counts");
-  fOutput->Add(fHistZVertexNoSel);
+  h = new TH1F("fHistZVertexNoSel","Z vertex position (no event selection)", 60, -30, 30);
+  h->GetXaxis()->SetTitle("V_{#it{z}}");
+  h->GetYaxis()->SetTitle("counts");
+  fOutput->Add(h);
+  fHistograms["fHistZVertexNoSel"] = h;
 
   if (fCentralityEstimation != kNoCentrality) {
-    fHistCentrality = new TH1F("fHistCentrality","Event centrality distribution", 100, 0, 100);
-    fHistCentrality->GetXaxis()->SetTitle("Centrality (%)");
-    fHistCentrality->GetYaxis()->SetTitle("counts");
-    fOutput->Add(fHistCentrality);
+    h = new TH1F("fHistCentrality","Event centrality distribution", 100, 0, 100);
+    h->GetXaxis()->SetTitle("Centrality (%)");
+    h->GetYaxis()->SetTitle("counts");
+    fOutput->Add(h);
+    fHistograms["fHistCentrality"] = h;
 
-    fHistCentralityNoSel = new TH1F("fHistCentralityNoSel","Event centrality distribution (no event selection)", 100, 0, 100);
-    fHistCentralityNoSel->GetXaxis()->SetTitle("Centrality (%)");
-    fHistCentralityNoSel->GetYaxis()->SetTitle("counts");
-    fOutput->Add(fHistCentralityNoSel);
+    h = new TH1F("fHistCentralityNoSel","Event centrality distribution (no event selection)", 100, 0, 100);
+    h->GetXaxis()->SetTitle("Centrality (%)");
+    h->GetYaxis()->SetTitle("counts");
+    fOutput->Add(h);
+    fHistograms["fHistCentralityNoSel"] = h;
   }
 
   if (fForceBeamType != kpp) {
-    fHistEventPlane = new TH1F("fHistEventPlane","Event plane", 120, -TMath::Pi(), TMath::Pi());
-    fHistEventPlane->GetXaxis()->SetTitle("event plane");
-    fHistEventPlane->GetYaxis()->SetTitle("counts");
-    fOutput->Add(fHistEventPlane);
+    h = new TH1F("fHistEventPlane","Event plane", 120, -TMath::Pi(), TMath::Pi());
+    h->GetXaxis()->SetTitle("event plane");
+    h->GetYaxis()->SetTitle("counts");
+    fOutput->Add(h);
+    fHistograms["fHistEventPlane"] = h;
 
-    fHistEventPlaneNoSel = new TH1F("fHistEventPlaneNoSel","Event plane (no event selection)", 120, -TMath::Pi(), TMath::Pi());
-    fHistEventPlaneNoSel->GetXaxis()->SetTitle("event plane");
-    fHistEventPlaneNoSel->GetYaxis()->SetTitle("counts");
-    fOutput->Add(fHistEventPlaneNoSel);
+    h = new TH1F("fHistEventPlaneNoSel","Event plane (no event selection)", 120, -TMath::Pi(), TMath::Pi());
+    h->GetXaxis()->SetTitle("event plane");
+    h->GetYaxis()->SetTitle("counts");
+    fOutput->Add(h);
+    fHistograms["fHistEventPlaneNoSel"] = h;
   }
 
-  fHistEventRejection = new TH1F("fHistEventRejection","Reasons to reject event",30,0,30);
+  h = new TH1F("fHistEventRejection","Reasons to reject event",30,0,30);
 #if ROOT_VERSION_CODE < ROOT_VERSION(6,4,2)
-  fHistEventRejection->SetBit(TH1::kCanRebin);
+  h->SetBit(TH1::kCanRebin);
 #else
-  fHistEventRejection->SetCanExtend(TH1::kAllAxes);
+  h->SetCanExtend(TH1::kAllAxes);
 #endif
   std::array<std::string, 10> labels = {"PhysSel", "Evt Gen Name", "Trg class (acc)", "Trg class (rej)", "Cent", "vertex contr.", "Vz", "VzSPD", "SelPtHardBin", "MCOutlier"};
   int i = 1;
   for (auto label : labels) {
-    fHistEventRejection->GetXaxis()->SetBinLabel(i, label.c_str());
+    h->GetXaxis()->SetBinLabel(i, label.c_str());
     i++;
   }
-  fHistEventRejection->GetYaxis()->SetTitle("counts");
-  fOutput->Add(fHistEventRejection);
+  h->GetYaxis()->SetTitle("counts");
+  fOutput->Add(h);
+  fHistograms["fHistEventRejection"] = h;
 
-  fHistTriggerClasses = new TH1F("fHistTriggerClasses","fHistTriggerClasses",3,0,3);
+  h = new TH1F("fHistTriggerClasses","fHistTriggerClasses",3,0,3);
 #if ROOT_VERSION_CODE < ROOT_VERSION(6,4,2)
-  fHistTriggerClasses->SetBit(TH1::kCanRebin);
+  h->SetBit(TH1::kCanRebin);
 #else
-  fHistTriggerClasses->SetCanExtend(TH1::kAllAxes);
+  h->SetCanExtend(TH1::kAllAxes);
 #endif
-  fOutput->Add(fHistTriggerClasses);
+  fOutput->Add(h);
+  fHistograms["fHistTriggerClasses"] = h;
 
-  fHistTriggerClassesNoSel = new TH1F("fHistTriggerClassesNoSel","fHistTriggerClassesNoSel",3,0,3);
+  h = new TH1F("fHistTriggerClassesNoSel","fHistTriggerClassesNoSel",3,0,3);
 #if ROOT_VERSION_CODE < ROOT_VERSION(6,4,2)
-  fHistTriggerClassesNoSel->SetBit(TH1::kCanRebin);
+  h->SetBit(TH1::kCanRebin);
 #else
-  fHistTriggerClassesNoSel->SetCanExtend(TH1::kAllAxes);
+  h->SetCanExtend(TH1::kAllAxes);
 #endif
-  fOutput->Add(fHistTriggerClassesNoSel);
+  fOutput->Add(h);
+  fHistograms["fHistTriggerClassesNoSel"] = h;
 
-  fHistEventCount = new TH1F("fHistEventCount","fHistEventCount",2,0,2);
-  fHistEventCount->GetXaxis()->SetBinLabel(1,"Accepted");
-  fHistEventCount->GetXaxis()->SetBinLabel(2,"Rejected");
-  fHistEventCount->GetYaxis()->SetTitle("counts");
-  fOutput->Add(fHistEventCount);
+  h = new TH1F("fHistEventCount","fHistEventCount",2,0,2);
+  h->GetXaxis()->SetBinLabel(1,"Accepted");
+  h->GetXaxis()->SetBinLabel(2,"Rejected");
+  h->GetYaxis()->SetTitle("counts");
+  fOutput->Add(h);
+  fHistograms["fHistEventCount"] = h;
 
   PostData(1, fOutput);
 }
@@ -477,34 +467,42 @@ Bool_t AliAnalysisTaskEmcalLight::FillGeneralHistograms(Bool_t eventSelected)
 {
   if (eventSelected) {
     if (fIsPythia) {
-      fHistEventsVsPtHard->Fill(fPtHard, 1);
-      fHistTrialsVsPtHard->Fill(fPtHard, fNTrials);
-      fHistXsectionVsPtHard->Fill(fPtHard, fXsection);
-      fHistEventWeights->Fill(fEventWeight, 1);
+      GetGeneralTH1("fHistEventsVsPtHard")->Fill(fPtHard, 1);
+      GetGeneralTH1("fHistTrialsVsPtHard")->Fill(fPtHard, fNTrials);
+      GetGeneralTProfile("fHistXsectionVsPtHard")->Fill(fPtHard, fXsection);
+      GetGeneralTH1("fHistEventWeights")->Fill(fEventWeight, 1);
+      GetGeneralTH2("fHistEventWeightsVsPtHard")->Fill(fPtHard, fEventWeight);
     }
 
-    fHistZVertex->Fill(fVertex[2]);
+    GetGeneralTH1("fHistZVertex")->Fill(fVertex[2]);
 
-    if (fHistCentrality) fHistCentrality->Fill(fCent);
-    if (fHistEventPlane) fHistEventPlane->Fill(fEPV0);
+    TH1* hCent = GetGeneralTH1("fHistCentrality");
+    if (hCent) hCent->Fill(fCent);
 
+    TH1* hEventPlane = GetGeneralTH1("fHistEventPlane");
+    if (hEventPlane) hEventPlane->Fill(fEPV0);
 
-    for (auto fired_trg : fFiredTriggerClasses) fHistTriggerClasses->Fill(fired_trg.c_str(), 1);
+    TH1* hTriggerClasses = GetGeneralTH1("fHistTriggerClasses");
+    for (auto fired_trg : fFiredTriggerClasses) hTriggerClasses->Fill(fired_trg.c_str(), 1);
   }
   else {
     if (fIsPythia) {
-      fHistEventsVsPtHardNoSel->Fill(fPtHard, 1);
-      fHistTrialsVsPtHardNoSel->Fill(fPtHard, fNTrials);
-      fHistXsectionVsPtHardNoSel->Fill(fPtHard, fXsection);
-      fHistEventWeightsNoSel->Fill(fEventWeight, 1);
+      GetGeneralTH1("fHistEventsVsPtHardNoSel")->Fill(fPtHard, 1);
+      GetGeneralTH1("fHistTrialsVsPtHardNoSel")->Fill(fPtHard, fNTrials);
+      GetGeneralTProfile("fHistXsectionVsPtHardNoSel")->Fill(fPtHard, fXsection);
+      GetGeneralTH1("fHistEventWeightsNoSel")->Fill(fEventWeight, 1);
     }
 
-    fHistZVertexNoSel->Fill(fVertex[2]);
+    GetGeneralTH1("fHistZVertexNoSel")->Fill(fVertex[2]);
 
-    if (fHistCentralityNoSel) fHistCentralityNoSel->Fill(fCent);
-    if (fHistEventPlaneNoSel) fHistEventPlaneNoSel->Fill(fEPV0);
+    TH1* hCent = GetGeneralTH1("fHistCentralityNoSel");
+    if (hCent) hCent->Fill(fCent);
 
-    for (auto fired_trg : fFiredTriggerClasses) fHistTriggerClassesNoSel->Fill(fired_trg.c_str(), 1);
+    TH1* hEventPlane = GetGeneralTH1("fHistEventPlaneNoSel");
+    if (hEventPlane) hEventPlane->Fill(fEPV0);
+
+    TH1* hTriggerClasses = GetGeneralTH1("fHistTriggerClassesNoSel");
+    for (auto fired_trg : fFiredTriggerClasses) hTriggerClasses->Fill(fired_trg.c_str(), 1);
   }
 
   return kTRUE;
@@ -546,10 +544,10 @@ void AliAnalysisTaskEmcalLight::UserExec(Option_t *option)
 
   if (fGeneralHistograms && fCreateHisto) {
     if (eventSelected) {
-      fHistEventCount->Fill("Accepted",1);
+      GetGeneralTH1("fHistEventCount")->Fill("Accepted",1);
     }
     else {
-      fHistEventCount->Fill("Rejected",1);
+      GetGeneralTH1("fHistEventCount")->Fill("Rejected",1);
     }
 
     FillGeneralHistograms(kFALSE);
@@ -699,9 +697,9 @@ Bool_t AliAnalysisTaskEmcalLight::UserNotify()
 
   if (!res) return kTRUE;
 
-  fHistTrials->Fill(fPtHardBin, trials);
-  fHistXsection->Fill(fPtHardBin, xsection);
-  fHistEvents->Fill(fPtHardBin, nevents);
+  GetGeneralTH1("fHistTrials")->Fill(fPtHardBin, trials);
+  GetGeneralTProfile("fHistXsection")->Fill(fPtHardBin, xsection);
+  GetGeneralTH1("fHistEvents")->Fill(fPtHardBin, nevents);
 
   return kTRUE;
 }
@@ -843,14 +841,16 @@ AliAnalysisTaskEmcalLight::EBeamType_t AliAnalysisTaskEmcalLight::GetBeamType()
  */
 Bool_t AliAnalysisTaskEmcalLight::IsEventSelected()
 {
+  TH1* hEventRejection = GetGeneralTH1("fHistEventRejection");
+
   if (fTriggerSelectionBitMap != 0 && (fFiredTriggerBitMap & fTriggerSelectionBitMap) == 0) {
-    if (fGeneralHistograms) fHistEventRejection->Fill("PhysSel",1);
+    if (fGeneralHistograms) hEventRejection->Fill("PhysSel",1);
     return kFALSE;
   }
 
   if (!fSelectGeneratorName.IsNull() && !fGeneratorName.IsNull()) {
     if (!fGeneratorName.Contains(fSelectGeneratorName)) {
-      if (fGeneralHistograms) fHistEventRejection->Fill("Evt Gen Name",1);
+      if (fGeneralHistograms) hEventRejection->Fill("Evt Gen Name",1);
       return kFALSE;
     }
   }
@@ -868,7 +868,7 @@ Bool_t AliAnalysisTaskEmcalLight::IsEventSelected()
     }
 
     if (!acceptedTrgClassFound) {
-      if (fGeneralHistograms) fHistEventRejection->Fill("Trg class (acc)",1);
+      if (fGeneralHistograms) hEventRejection->Fill("Trg class (acc)",1);
       return kFALSE;
     }
   }
@@ -877,7 +877,7 @@ Bool_t AliAnalysisTaskEmcalLight::IsEventSelected()
     for (auto rej_trg : fRejectedTriggerClasses) {
       for (auto fired_trg : fFiredTriggerClasses) {
         if (fired_trg.find(rej_trg) != std::string::npos) {
-          if (fGeneralHistograms) fHistEventRejection->Fill("Trg class (rej)",1);
+          if (fGeneralHistograms) hEventRejection->Fill("Trg class (rej)",1);
           return kFALSE;
         }
       }
@@ -886,19 +886,19 @@ Bool_t AliAnalysisTaskEmcalLight::IsEventSelected()
 
   if (fMinCent < fMaxCent && fMaxCent > 0) {
     if (fCent < fMinCent || fCent > fMaxCent) {
-      if (fGeneralHistograms) fHistEventRejection->Fill("Cent",1);
+      if (fGeneralHistograms) hEventRejection->Fill("Cent",1);
       return kFALSE;
     }
   }
 
   if (fNVertCont < fMinNVertCont) {
-    if (fGeneralHistograms) fHistEventRejection->Fill("vertex contr.",1);
+    if (fGeneralHistograms) hEventRejection->Fill("vertex contr.",1);
     return kFALSE;
   }
 
   if (fMinVz < fMaxVz) {
     if (fVertex[2] < fMinVz || fVertex[2] > fMaxVz) {
-      if (fGeneralHistograms) fHistEventRejection->Fill("Vz",1);
+      if (fGeneralHistograms) hEventRejection->Fill("Vz",1);
       return kFALSE;
     }
   }
@@ -909,30 +909,30 @@ Bool_t AliAnalysisTaskEmcalLight::IsEventSelected()
       Double_t dvertex = TMath::Abs(fVertex[2] - vzSPD);
       //if difference larger than fZvertexDiff
       if (dvertex > fMaxVzDiff) {
-        if (fGeneralHistograms) fHistEventRejection->Fill("VzSPD",1);
+        if (fGeneralHistograms) hEventRejection->Fill("VzSPD",1);
         return kFALSE;
       }
     }
   }
 
   if (fMinPtHard >= 0 && fPtHard < fMinPtHard)  {
-    if (fGeneralHistograms) fHistEventRejection->Fill("SelPtHardBin",1);
+    if (fGeneralHistograms) hEventRejection->Fill("SelPtHardBin",1);
     return kFALSE;
   }
 
   if (fMaxPtHard >= 0 && fPtHard >= fMaxPtHard)  {
-    if (fGeneralHistograms) fHistEventRejection->Fill("SelPtHardBin",1);
+    if (fGeneralHistograms) hEventRejection->Fill("SelPtHardBin",1);
     return kFALSE;
   }
 
   if (fPtHardBin == 0 && fMaxMinimumBiasPtHard >= 0 && fPtHard > fMaxMinimumBiasPtHard) {
-    if (fGeneralHistograms) fHistEventRejection->Fill("SelPtHardBin",1);
+    if (fGeneralHistograms) hEventRejection->Fill("SelPtHardBin",1);
     return kFALSE;
   }
 
   // Reject filter for MC data
   if (!CheckMCOutliers()) {
-    if (fGeneralHistograms) fHistEventRejection->Fill("MCOutlier",1);
+    if (fGeneralHistograms) hEventRejection->Fill("MCOutlier",1);
     return kFALSE;
   }
 
@@ -1086,10 +1086,6 @@ Bool_t AliAnalysisTaskEmcalLight::RetrieveEventObjects()
       fXsection = fPythiaHeader->GetXsection();
       fNTrials = fPythiaHeader->Trials();
       fEventWeight = fPythiaHeader->EventWeight();
-      AliInfoStream() << "Event weight: " << fEventWeight << std::endl;
-      for (auto w : fPythiaHeader->GetEventWeights()) {
-        AliInfoStream() << "Weight " << w.first << ": " << w.second << std::endl;
-      }
     }
   }
 
@@ -1511,6 +1507,10 @@ std::vector<double> AliAnalysisTaskEmcalLight::GenerateFixedBinArray(int n, doub
  */
 void AliAnalysisTaskEmcalLight::GenerateLogFixedBinArray(int n, double min, double max, std::vector<double>& array, bool last)
 {
+  if (min <= 0 || max < min) {
+    AliErrorClassStream() << "Cannot generate a log scale fixed-bin array with limits " << min << ", " << max << std::endl;
+    return;
+  }
   double binWidth = std::pow(max / min, 1.0 / n);
   double v = min;
   if (last) n++;
@@ -1534,4 +1534,26 @@ std::vector<double> AliAnalysisTaskEmcalLight::GenerateLogFixedBinArray(int n, d
   std::vector<double> array;
   GenerateLogFixedBinArray(n, min, max, array, last);
   return array;
+}
+
+
+TH1* AliAnalysisTaskEmcalLight::GetGeneralTH1(const char* name)
+{
+  auto search = fHistograms.find(name);
+  if (search != fHistograms.end()) {
+    return search->second;
+  }
+  else {
+    return nullptr;
+  }
+}
+
+TH2* AliAnalysisTaskEmcalLight::GetGeneralTH2(const char* name)
+{
+  return static_cast<TH2*>(GetGeneralTH1(name));
+}
+
+TProfile* AliAnalysisTaskEmcalLight::GetGeneralTProfile(const char* name)
+{
+  return static_cast<TProfile*>(GetGeneralTH1(name));
 }

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.cxx
@@ -116,7 +116,7 @@ AliAnalysisTaskEmcalLight::AliAnalysisTaskEmcalLight() :
   fFiredTriggerClasses(),
   fBeamType(kNA),
   fPythiaHeader(0),
-  fPtHardBin(-1),
+  fPtHardBin(0),
   fPtHard(0),
   fNTrials(0),
   fXsection(0),
@@ -197,7 +197,7 @@ AliAnalysisTaskEmcalLight::AliAnalysisTaskEmcalLight(const char *name, Bool_t hi
   fFiredTriggerClasses(),
   fBeamType(kNA),
   fPythiaHeader(0),
-  fPtHardBin(-1),
+  fPtHardBin(0),
   fPtHard(0),
   fNTrials(0),
   fXsection(0),
@@ -304,11 +304,17 @@ void AliAnalysisTaskEmcalLight::UserCreateOutputObjects()
     fOutput->Add(h);
     fHistograms["fHistTrialsVsPtHard"] = h;
 
-    h = new TProfile("fHistXsectionVsPtHard", "fHistXsectionVsPtHard", 1000, 0, 1000);
-    h->GetXaxis()->SetTitle("#it{p}_{T,hard} (GeV/#it{c})");
-    h->GetYaxis()->SetTitle("xsection");
+    h = new TProfile("fHistXsection", "fHistXsection", 50, 0, 50);
+    h->GetXaxis()->SetTitle("#it{p}_{T,hard} bin");
+    h->GetYaxis()->SetTitle("total integrated cross section (mb)");
     fOutput->Add(h);
-    fHistograms["fHistXsectionVsPtHard"] = h;
+    fHistograms["fHistXsection"] = h;
+
+    h = new TH1F("fHistXsectionDistribution", "fHistXsectionDistribution", 1000, &weight_bins[0]);
+    h->GetXaxis()->SetTitle("total integrated cross section (mb)");
+    h->GetYaxis()->SetTitle("events");
+    fOutput->Add(h);
+    fHistograms["fHistXsectionDistribution"] = h;
 
     h = new TH1F("fHistEventWeights", "fHistEventWeights", 1000, &weight_bins[0]);
     h->GetXaxis()->SetTitle("weight");
@@ -334,11 +340,17 @@ void AliAnalysisTaskEmcalLight::UserCreateOutputObjects()
     fOutput->Add(h);
     fHistograms["fHistTrialsVsPtHardNoSel"] = h;
 
-    h = new TProfile("fHistXsectionVsPtHardNoSel", "fHistXsectionVsPtHardNoSel", 1000, 0, 1000);
-    h->GetXaxis()->SetTitle("#it{p}_{T,hard} (GeV/#it{c})");
-    h->GetYaxis()->SetTitle("xsection");
+    h = new TProfile("fHistXsectionNoSel", "fHistXsectionNoSel", 50, 0, 50);
+    h->GetXaxis()->SetTitle("#it{p}_{T,hard} bin");
+    h->GetYaxis()->SetTitle("total integrated cross section (mb)");
     fOutput->Add(h);
-    fHistograms["fHistXsectionVsPtHardNoSel"] = h;
+    fHistograms["fHistXsectionNoSel"] = h;
+
+    h = new TH1F("fHistXsectionDistributionNoSel", "fHistXsectionDistributionNoSel", 1000, &weight_bins[0]);
+    h->GetXaxis()->SetTitle("total integrated cross section (mb)");
+    h->GetYaxis()->SetTitle("events");
+    fOutput->Add(h);
+    fHistograms["fHistXsectionDistributionNoSel"] = h;
 
     h = new TH1F("fHistEventWeightsNoSel", "fHistEventWeightsNoSel", 1000, &weight_bins[0]);
     h->GetXaxis()->SetTitle("weight");
@@ -346,23 +358,29 @@ void AliAnalysisTaskEmcalLight::UserCreateOutputObjects()
     fOutput->Add(h);
     fHistograms["fHistEventWeightsNoSel"] = h;
 
-    h = new TH1F("fHistTrials", "fHistTrials", 50, 0, 50);
+    h = new TH2F("fHistEventWeightsVsPtHardNoSel", "fHistEventWeightsVsPtHardNoSel", 1000, 0, 1000, 1000, &weight_bins[0]);
+    h->GetXaxis()->SetTitle("#it{p}_{T,hard} (GeV/#it{c})");
+    h->GetYaxis()->SetTitle("event weight");
+    fOutput->Add(h);
+    fHistograms["fHistEventWeightsVsPtHardNoSel"] = h;
+
+    h = new TH1F("fHistTrialsExternalFile", "fHistTrialsExternalFile", 50, 0, 50);
     h->GetXaxis()->SetTitle("#it{p}_{T,hard} bin");
     h->GetYaxis()->SetTitle("trials");
     fOutput->Add(h);
     fHistograms["fHistTrialsExternalFile"] = h;
 
-    h = new TH1F("fHistEvents", "fHistEvents", 50, 0, 50);
+    h = new TH1F("fHistEventsExternalFile", "fHistEventsExternalFile", 50, 0, 50);
     h->GetXaxis()->SetTitle("#it{p}_{T,hard} bin");
     h->GetYaxis()->SetTitle("total events");
     fOutput->Add(h);
     fHistograms["fHistEventsExternalFile"] = h;
 
-    h = new TProfile("fHistXsection", "fHistXsection", 50, 0, 50);
+    h = new TProfile("fHistXsectionExternalFile", "fHistXsectionExternalFile", 50, 0, 50);
     h->GetXaxis()->SetTitle("#it{p}_{T,hard} bin");
-    h->GetYaxis()->SetTitle("xsection");
+    h->GetYaxis()->SetTitle("total integrated cross section (mb)");
     fOutput->Add(h);
-    fHistograms["fHistXsection"] = h;
+    fHistograms["fHistXsectionExternalFile"] = h;
   }
 
   h = new TH1F("fHistZVertex","Z vertex position", 60, -30, 30);
@@ -467,11 +485,15 @@ Bool_t AliAnalysisTaskEmcalLight::FillGeneralHistograms(Bool_t eventSelected)
 {
   if (eventSelected) {
     if (fIsPythia) {
-      GetGeneralTH1("fHistEventsVsPtHard")->Fill(fPtHard, 1);
-      GetGeneralTH1("fHistTrialsVsPtHard")->Fill(fPtHard, fNTrials);
-      GetGeneralTProfile("fHistXsectionVsPtHard")->Fill(fPtHard, fXsection);
-      GetGeneralTH1("fHistEventWeights")->Fill(fEventWeight, 1);
-      GetGeneralTH2("fHistEventWeightsVsPtHard")->Fill(fPtHard, fEventWeight);
+      GetGeneralTH1("fHistEventsVsPtHard", true)->Fill(fPtHard);
+      GetGeneralTH1("fHistTrialsVsPtHard", true)->Fill(fPtHard, fNTrials);
+      GetGeneralTH1("fHistEventWeights", true)->Fill(fEventWeight);
+      GetGeneralTH2("fHistEventWeightsVsPtHard", true)->Fill(fPtHard, fEventWeight);
+      GetGeneralTH1("fHistXsectionDistribution", true)->Fill(fXsection);
+
+      TProfile* hXsection = GetGeneralTProfile("fHistXsection", true);
+      hXsection->SetBinEntries(fPtHardBin + 1, hXsection->GetBinEntries(fPtHardBin + 1) + 1);
+      hXsection->SetBinContent(fPtHardBin + 1, fXsection * hXsection->GetBinEntries(fPtHardBin + 1));
     }
 
     GetGeneralTH1("fHistZVertex")->Fill(fVertex[2]);
@@ -487,13 +509,18 @@ Bool_t AliAnalysisTaskEmcalLight::FillGeneralHistograms(Bool_t eventSelected)
   }
   else {
     if (fIsPythia) {
-      GetGeneralTH1("fHistEventsVsPtHardNoSel")->Fill(fPtHard, 1);
-      GetGeneralTH1("fHistTrialsVsPtHardNoSel")->Fill(fPtHard, fNTrials);
-      GetGeneralTProfile("fHistXsectionVsPtHardNoSel")->Fill(fPtHard, fXsection);
-      GetGeneralTH1("fHistEventWeightsNoSel")->Fill(fEventWeight, 1);
+      GetGeneralTH1("fHistEventsVsPtHardNoSel", true)->Fill(fPtHard);
+      GetGeneralTH1("fHistTrialsVsPtHardNoSel", true)->Fill(fPtHard, fNTrials);
+      GetGeneralTH1("fHistEventWeightsNoSel", true)->Fill(fEventWeight);
+      GetGeneralTH2("fHistEventWeightsVsPtHardNoSel", true)->Fill(fPtHard, fEventWeight);
+      GetGeneralTH1("fHistXsectionDistributionNoSel", true)->Fill(fXsection);
+
+      TProfile* hXsection = GetGeneralTProfile("fHistXsectionNoSel", true);
+      hXsection->SetBinEntries(fPtHardBin + 1, hXsection->GetBinEntries(fPtHardBin + 1) + 1);
+      hXsection->SetBinContent(fPtHardBin + 1, fXsection * hXsection->GetBinEntries(fPtHardBin + 1));
     }
 
-    GetGeneralTH1("fHistZVertexNoSel")->Fill(fVertex[2]);
+    GetGeneralTH1("fHistZVertexNoSel", true)->Fill(fVertex[2]);
 
     TH1* hCent = GetGeneralTH1("fHistCentralityNoSel");
     if (hCent) hCent->Fill(fCent);
@@ -501,7 +528,7 @@ Bool_t AliAnalysisTaskEmcalLight::FillGeneralHistograms(Bool_t eventSelected)
     TH1* hEventPlane = GetGeneralTH1("fHistEventPlaneNoSel");
     if (hEventPlane) hEventPlane->Fill(fEPV0);
 
-    TH1* hTriggerClasses = GetGeneralTH1("fHistTriggerClassesNoSel");
+    TH1* hTriggerClasses = GetGeneralTH1("fHistTriggerClassesNoSel", true);
     for (auto fired_trg : fFiredTriggerClasses) hTriggerClasses->Fill(fired_trg.c_str(), 1);
   }
 
@@ -544,10 +571,10 @@ void AliAnalysisTaskEmcalLight::UserExec(Option_t *option)
 
   if (fGeneralHistograms && fCreateHisto) {
     if (eventSelected) {
-      GetGeneralTH1("fHistEventCount")->Fill("Accepted",1);
+      GetGeneralTH1("fHistEventCount", true)->Fill("Accepted",1);
     }
     else {
-      GetGeneralTH1("fHistEventCount")->Fill("Rejected",1);
+      GetGeneralTH1("fHistEventCount", true)->Fill("Rejected",1);
     }
 
     FillGeneralHistograms(kFALSE);
@@ -576,12 +603,12 @@ void AliAnalysisTaskEmcalLight::UserExec(Option_t *option)
  * @param[out] pthard \f$ p_{t} \f$-hard bin, extracted from path name
  * @return True if parameters were obtained successfully, false otherwise
  */
-Bool_t AliAnalysisTaskEmcalLight::PythiaInfoFromFile(const char* currFile, Float_t &fXsec, Float_t &fTrials, Int_t &pthard)
+Bool_t AliAnalysisTaskEmcalLight::PythiaInfoFromFile(const char* currFile, Float_t &xsec, Float_t &trials, Int_t &pthard)
 {
 
   TString file(currFile);
-  fXsec = 0;
-  fTrials = 1;
+  xsec = 0;
+  trials = 1;
 
   if (file.Contains(".zip#")) {
     Ssiz_t pos1 = file.Index("root_archive",12,0,TString::kExact);
@@ -630,8 +657,8 @@ Bool_t AliAnalysisTaskEmcalLight::PythiaInfoFromFile(const char* currFile, Float
         fxsec->Close();
         return kFALSE;
       }
-      fXsec = static_cast<TProfile*>(list->FindObject("h1Xsec"))->GetBinContent(1);
-      fTrials = static_cast<TH1F*>(list->FindObject("h1Trials"))->GetBinContent(1);
+      xsec = static_cast<TProfile*>(list->FindObject("h1Xsec"))->GetBinContent(1);
+      trials = static_cast<TH1F*>(list->FindObject("h1Trials"))->GetBinContent(1);
       fxsec->Close();
     }
   } else { // no tree pyxsec.root
@@ -645,8 +672,8 @@ Bool_t AliAnalysisTaskEmcalLight::PythiaInfoFromFile(const char* currFile, Float
     xtree->SetBranchAddress("xsection",&xsection);
     xtree->SetBranchAddress("ntrials",&ntrials);
     xtree->GetEntry(0);
-    fTrials = ntrials;
-    fXsec = xsection;
+    trials = ntrials;
+    xsec = xsection;
     fxsec->Close();
   }
   return kTRUE;
@@ -693,13 +720,13 @@ Bool_t AliAnalysisTaskEmcalLight::UserNotify()
 
   Bool_t res = PythiaInfoFromFile(curfile->GetName(), xsection, trials, pthardbin);
 
-  fPtHardBin = pthardbin;
+  fPtHardBin = pthardbin >= 0 ? pthardbin : 0;
 
   if (!res) return kTRUE;
 
-  GetGeneralTH1("fHistTrials")->Fill(fPtHardBin, trials);
-  GetGeneralTProfile("fHistXsection")->Fill(fPtHardBin, xsection);
-  GetGeneralTH1("fHistEvents")->Fill(fPtHardBin, nevents);
+  GetGeneralTH1("fHistTrialsExternalFile", true)->Fill(fPtHardBin, trials);
+  GetGeneralTProfile("fHistXsectionExternalFile", true)->Fill(fPtHardBin, xsection);
+  GetGeneralTH1("fHistEventsExternalFile", true)->Fill(fPtHardBin, nevents);
 
   return kTRUE;
 }
@@ -841,7 +868,7 @@ AliAnalysisTaskEmcalLight::EBeamType_t AliAnalysisTaskEmcalLight::GetBeamType()
  */
 Bool_t AliAnalysisTaskEmcalLight::IsEventSelected()
 {
-  TH1* hEventRejection = GetGeneralTH1("fHistEventRejection");
+  TH1* hEventRejection = GetGeneralTH1("fHistEventRejection", true);
 
   if (fTriggerSelectionBitMap != 0 && (fFiredTriggerBitMap & fTriggerSelectionBitMap) == 0) {
     if (fGeneralHistograms) hEventRejection->Fill("PhysSel",1);
@@ -1537,23 +1564,24 @@ std::vector<double> AliAnalysisTaskEmcalLight::GenerateLogFixedBinArray(int n, d
 }
 
 
-TH1* AliAnalysisTaskEmcalLight::GetGeneralTH1(const char* name)
+TH1* AliAnalysisTaskEmcalLight::GetGeneralTH1(const char* name, bool warn)
 {
   auto search = fHistograms.find(name);
   if (search != fHistograms.end()) {
     return search->second;
   }
   else {
+    if (warn) AliErrorStream() << "Could not find histogram '" << name << "'" << std::endl;
     return nullptr;
   }
 }
 
-TH2* AliAnalysisTaskEmcalLight::GetGeneralTH2(const char* name)
+TH2* AliAnalysisTaskEmcalLight::GetGeneralTH2(const char* name, bool warn)
 {
-  return static_cast<TH2*>(GetGeneralTH1(name));
+  return static_cast<TH2*>(GetGeneralTH1(name, warn));
 }
 
-TProfile* AliAnalysisTaskEmcalLight::GetGeneralTProfile(const char* name)
+TProfile* AliAnalysisTaskEmcalLight::GetGeneralTProfile(const char* name, bool warn)
 {
-  return static_cast<TProfile*>(GetGeneralTH1(name));
+  return static_cast<TProfile*>(GetGeneralTH1(name, warn));
 }

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.h
@@ -157,6 +157,7 @@ class AliAnalysisTaskEmcalLight : public AliAnalysisTaskSE {
   void                        SetEventSelectionAfterRun(Bool_t b)                   { fEventSelectionAfterRun = b                         ; }
   void                        SelectGeneratorName(TString gen)                      { fSelectGeneratorName = gen                          ; }
   void                        SetInhibit(Bool_t s)                                  { fInhibit = s                                        ; }
+  void                        SetEventWeightRange(Double_t min, Double_t max)       { fMinimumEventWeight = min; fMaximumEventWeight = max; }
 
   Bool_t IsInhibit() const { return fInhibit; }
 
@@ -201,6 +202,8 @@ class AliAnalysisTaskEmcalLight : public AliAnalysisTaskSE {
   static Double_t             DeltaPhi(Double_t phia, Double_t phib, Double_t rMin = -TMath::Pi()/2, Double_t rMax = 3*TMath::Pi()/2);
   static std::vector<double>  GenerateFixedBinArray(int n, double min, double max, bool last = true);
   static void                 GenerateFixedBinArray(int n, double min, double max, std::vector<double>& array, bool last = true);
+  static std::vector<double>  GenerateLogFixedBinArray(int n, double min, double max, bool last = true);
+  static void                 GenerateLogFixedBinArray(int n, double min, double max, std::vector<double>& array, bool last = true);
   static Double_t             GetParallelFraction(AliVParticle* part1, AliVParticle* part2);
   static Double_t             GetParallelFraction(const TVector3& vect1, AliVParticle* part2);
   static EBeamType_t          BeamTypeFromRunNumber(Int_t runnumber);
@@ -247,6 +250,8 @@ class AliAnalysisTaskEmcalLight : public AliAnalysisTaskSE {
   Bool_t                      fSwitchOffLHC15oFaultyBranches; ///< Switch off faulty tree branches in LHC15o AOD trees
   Bool_t                      fEventSelectionAfterRun;     ///< If kTRUE, the event selection is performed after Run() but before FillHistograms()
   TString                     fSelectGeneratorName;        ///< Selects only events produced by a generator that has a name containing a string
+  Double_t                    fMinimumEventWeight;         ///< Minimum event weight for the related bookkeping histogram
+  Double_t                    fMaximumEventWeight;         ///< Minimum event weight for the related bookkeping histogram
 
   // Service fields
   Bool_t                      fInhibit;                    //!<!inhibit execution of the task
@@ -269,10 +274,11 @@ class AliAnalysisTaskEmcalLight : public AliAnalysisTaskSE {
   std::vector<std::string>    fFiredTriggerClasses;        //!<!trigger classes fired by the current event
   EBeamType_t                 fBeamType;                   //!<!event beam type
   AliGenPythiaEventHeader    *fPythiaHeader;               //!<!event Pythia header
-  Int_t                       fPtHardBin;                  //!<!event pt hard
+  Int_t                       fPtHardBin;                  //!<!event pt hard bin
   Double_t                    fPtHard;                     //!<!event pt hard
   Int_t                       fNTrials;                    //!<!event trials
   Float_t                     fXsection;                   //!<!x-section from pythia header
+  Float_t                     fEventWeight;                //!<!event weight
   TString                     fGeneratorName;              //!<!name of the MC generator used to produce the current event (only AOD)
 
   // Output
@@ -280,6 +286,7 @@ class AliAnalysisTaskEmcalLight : public AliAnalysisTaskSE {
   TH1                        *fHistTrialsVsPtHardNoSel;    //!<!total number of trials per pt hard bin after selection (no event selection)
   TH1                        *fHistEventsVsPtHardNoSel;    //!<!total number of events per pt hard bin after selection (no event selection)
   TProfile                   *fHistXsectionVsPtHardNoSel;  //!<!x section from pythia header (no event selection)
+  TH1                        *fHistEventWeightsNoSel;      //!<!distribution of event weights (no event selection)
   TH1                        *fHistTriggerClassesNoSel;    //!<!number of events in each trigger class (no event selection)
   TH1                        *fHistZVertexNoSel;           //!<!z vertex position (no event selection)
   TH1                        *fHistCentralityNoSel;        //!<!event centrality distribution (no event selection)
@@ -287,6 +294,7 @@ class AliAnalysisTaskEmcalLight : public AliAnalysisTaskSE {
   TH1                        *fHistTrialsVsPtHard;         //!<!total number of trials per pt hard bin after selection
   TH1                        *fHistEventsVsPtHard;         //!<!total number of events per pt hard bin after selection
   TProfile                   *fHistXsectionVsPtHard;       //!<!x section from pythia header
+  TH1                        *fHistEventWeights;           //!<!distribution of event weights
   TH1                        *fHistTriggerClasses;         //!<!number of events in each trigger class
   TH1                        *fHistZVertex;                //!<!z vertex position
   TH1                        *fHistCentrality;             //!<!event centrality distribution

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.h
@@ -283,29 +283,13 @@ class AliAnalysisTaskEmcalLight : public AliAnalysisTaskSE {
 
   // Output
   TList                      *fOutput;                     //!<!output list
-  TH1                        *fHistTrialsVsPtHardNoSel;    //!<!total number of trials per pt hard bin after selection (no event selection)
-  TH1                        *fHistEventsVsPtHardNoSel;    //!<!total number of events per pt hard bin after selection (no event selection)
-  TProfile                   *fHistXsectionVsPtHardNoSel;  //!<!x section from pythia header (no event selection)
-  TH1                        *fHistEventWeightsNoSel;      //!<!distribution of event weights (no event selection)
-  TH1                        *fHistTriggerClassesNoSel;    //!<!number of events in each trigger class (no event selection)
-  TH1                        *fHistZVertexNoSel;           //!<!z vertex position (no event selection)
-  TH1                        *fHistCentralityNoSel;        //!<!event centrality distribution (no event selection)
-  TH1                        *fHistEventPlaneNoSel;        //!<!event plane distribution (no event selection)
-  TH1                        *fHistTrialsVsPtHard;         //!<!total number of trials per pt hard bin after selection
-  TH1                        *fHistEventsVsPtHard;         //!<!total number of events per pt hard bin after selection
-  TProfile                   *fHistXsectionVsPtHard;       //!<!x section from pythia header
-  TH1                        *fHistEventWeights;           //!<!distribution of event weights
-  TH1                        *fHistTriggerClasses;         //!<!number of events in each trigger class
-  TH1                        *fHistZVertex;                //!<!z vertex position
-  TH1                        *fHistCentrality;             //!<!event centrality distribution
-  TH1                        *fHistEventPlane;             //!<!event plane distribution
-  TH1                        *fHistEventCount;             //!<!incoming and selected events
-  TH1                        *fHistEventRejection;         //!<!book keep reasons for rejecting event
-  TH1                        *fHistTrials;                 //!<!trials from pyxsec.root
-  TH1                        *fHistEvents;                 //!<!total number of events per pt hard bin
-  TProfile                   *fHistXsection;               //!<!x section from pyxsec.root
 
  private:
+  std::map<std::string, TH1*> fHistograms;                 //!<!general QA histograms
+  TH1* GetGeneralTH1(const char* name);
+  TH2* GetGeneralTH2(const char* name);
+  TProfile* GetGeneralTProfile(const char* name);
+
   AliAnalysisTaskEmcalLight(const AliAnalysisTaskEmcalLight&);            // not implemented
   AliAnalysisTaskEmcalLight &operator=(const AliAnalysisTaskEmcalLight&); // not implemented
 

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.h
@@ -286,9 +286,9 @@ class AliAnalysisTaskEmcalLight : public AliAnalysisTaskSE {
 
  private:
   std::map<std::string, TH1*> fHistograms;                 //!<!general QA histograms
-  TH1* GetGeneralTH1(const char* name);
-  TH2* GetGeneralTH2(const char* name);
-  TProfile* GetGeneralTProfile(const char* name);
+  TH1* GetGeneralTH1(const char* name, bool warn=false);
+  TH2* GetGeneralTH2(const char* name, bool warn=false);
+  TProfile* GetGeneralTProfile(const char* name, bool warn=false);
 
   AliAnalysisTaskEmcalLight(const AliAnalysisTaskEmcalLight&);            // not implemented
   AliAnalysisTaskEmcalLight &operator=(const AliAnalysisTaskEmcalLight&); // not implemented

--- a/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
+++ b/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
@@ -37,6 +37,7 @@
 #pragma link C++ class AliAnalysisTaskPWGJEQA+;
 #pragma link C++ class AliAnalysisTaskEmcalJetTreeBase+;
 #pragma link C++ class AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPP+;
+#pragma link C++ class AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPPSimulation+;
 #pragma link C++ class AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPbPb+;
 #pragma link C++ class AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetInfoSummaryPP+;
 #pragma link C++ class AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetInfoSummaryPbPb+;
@@ -53,6 +54,8 @@
 #pragma link C++ class AliAnalysisTaskEmcalJetTree<AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetInfoSummaryPbPb, AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPbPb>+;
 #pragma link C++ class AliAnalysisTaskEmcalJetTree<AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetInfoSummaryPbPbCharged, AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPbPb>+;
 #pragma link C++ class AliAnalysisTaskEmcalJetTree<AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetInfoSummaryEmbedding, AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPbPb>+;
+#pragma link C++ class AliAnalysisTaskEmcalJetTree<AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetInfoSummaryPP, AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPPSimulation>+;
+#pragma link C++ class AliAnalysisTaskEmcalJetTree<AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetInfoSummaryPPCharged, AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPPSimulation>+;
 #pragma link C++ class AliNanoAODArrayMaker+;
 
 // user task

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetTree.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetTree.cxx
@@ -29,11 +29,11 @@ ClassImp(AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPbPb);
 ///
 /// \param cent Event centrality
 /// \param ep Event plane
-AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPbPb::AliEmcalJetEventInfoSummaryPbPb(Double_t cent, Double_t ep) :
+AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPbPb::AliEmcalJetEventInfoSummaryPbPb(EventInfo event) :
   fCent(0),
   fEP(0)
 {
-  Set(cent, ep);
+  Set(event);
 }
 
 /// Reset the object
@@ -47,10 +47,44 @@ void AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPbPb::Reset()
 ///
 /// \param cent Event centrality
 /// \param ep Event plane
-void AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPbPb::Set(Double_t cent, Double_t ep)
+void AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPbPb::Set(EventInfo event)
 {
-  fCent = cent;
-  fEP = ep;
+  fCent = event.fCent;
+  fEP = event.fEP;
+}
+
+// Definitions of class AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPPSimulation
+
+/// \cond CLASSIMP
+ClassImp(AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPPSimulation);
+/// \endcond
+
+/// Constructor that sets the object with the provided event information
+///
+/// \param cent Event centrality
+/// \param ep Event plane
+AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPPSimulation::AliEmcalJetEventInfoSummaryPPSimulation(EventInfo event) :
+  fWeight(1),
+  fPtHard(0)
+{
+  Set(event);
+}
+
+/// Reset the object
+void AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPPSimulation::Reset()
+{
+  fWeight = 1;
+  fPtHard = 0;
+}
+
+/// Set the object with the provided event information
+///
+/// \param cent Event centrality
+/// \param ep Event plane
+void AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetEventInfoSummaryPPSimulation::Set(EventInfo event)
+{
+  fWeight = event.fWeight;
+  fPtHard = event.fPtHard;
 }
 
 // Definitions of class AliAnalysisTaskEmcalJetTreeBase::AliEmcalJetInfoSummaryPP
@@ -333,6 +367,14 @@ AliAnalysisTaskEmcalJetTreeBase* AliAnalysisTaskEmcalJetTreeBase::CreateInstance
     ::Info("AliAnalysisTaskEmcalJetTreeBase::CreateInstance", "Created an instance of AliAnalysisTaskEmcalJetTree<AliEmcalJetInfoSummaryPbPbCharged>");
     return new AliAnalysisTaskEmcalJetTree<AliEmcalJetInfoSummaryPbPbCharged, AliEmcalJetEventInfoSummaryPbPb>(name);
     break;
+  case kJetPPSimulation:
+    ::Info("AliAnalysisTaskEmcalJetTreeBase::CreateInstance", "Created an instance of AliAnalysisTaskEmcalJetTree<AliEmcalJetInfoSummaryPP>");
+    return new AliAnalysisTaskEmcalJetTree<AliEmcalJetInfoSummaryPP, AliEmcalJetEventInfoSummaryPPSimulation>(name);
+    break;
+  case kJetPPChargedSimulation:
+    ::Info("AliAnalysisTaskEmcalJetTreeBase::CreateInstance", "Created an instance of AliAnalysisTaskEmcalJetTree<AliEmcalJetInfoSummaryPPCharged>");
+    return new AliAnalysisTaskEmcalJetTree<AliEmcalJetInfoSummaryPPCharged, AliEmcalJetEventInfoSummaryPPSimulation>(name);
+    break;
   default:
     ::Error("AliAnalysisTaskEmcalJetTreeBase::CreateInstance", "Type %d not implemented!", type);
     return 0;
@@ -468,7 +510,7 @@ Bool_t AliAnalysisTaskEmcalJetTree<T, U>::FillHistograms()
     it->second.clear();
   }
 
-  fCurrentEvent->Set(fCent, fEPV0);
+  fCurrentEvent->Set(EventInfo(fCent, fEPV0, fEventWeight, fPtHard));
 
   Bool_t r = AliAnalysisTaskEmcalJetSpectraQA::FillHistograms();
   if (!r) return kFALSE;

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetTree.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetTree.h
@@ -33,7 +33,24 @@ class AliAnalysisTaskEmcalJetTreeBase : public AliAnalysisTaskEmcalJetSpectraQA 
     kJetPbPb,
     kJetEmbedding,
     kJetPPCharged,
-    kJetPbPbCharged
+    kJetPbPbCharged,
+    kJetPPSimulation,
+    kJetPPChargedSimulation
+  };
+
+  /**
+   * \class EventInfo
+   * \brief Event information
+   */
+  class EventInfo {
+  public:
+    EventInfo() : fCent(-1), fEP(-1), fWeight(1), fPtHard(0) {}
+    EventInfo(double cent, double ep, double w, double pt) : fCent(cent), fEP(ep), fWeight(w), fPtHard(pt) {}
+
+    double fCent;
+    double fEP;
+    double fWeight;
+    double fPtHard;
   };
 
   /**
@@ -46,15 +63,41 @@ class AliAnalysisTaskEmcalJetTreeBase : public AliAnalysisTaskEmcalJetSpectraQA 
   class AliEmcalJetEventInfoSummaryPP {
   public:
     AliEmcalJetEventInfoSummaryPP() {;}
-    AliEmcalJetEventInfoSummaryPP(Double_t, Double_t) {;}
+    AliEmcalJetEventInfoSummaryPP(EventInfo) {;}
 
     virtual ~AliEmcalJetEventInfoSummaryPP() {;}
 
     void Reset() {;}
-    void Set(Double_t, Double_t) {;}
+    void Set(EventInfo) {;}
 
     /// \cond CLASSIMP
     ClassDef(AliEmcalJetEventInfoSummaryPP, 1);
+    /// \endcond
+  };
+
+  /**
+   * \class AliEmcalJetEventInfoSummaryPPSimulation
+   * \brief Class that encapsulates event properties in a very compact structure (pp simulation analysis)
+   *
+   * Class that encapsulates event properties in a very compact structure
+   * for pp analysis on simulations (16 bits)
+   */
+  class AliEmcalJetEventInfoSummaryPPSimulation {
+  public:
+    AliEmcalJetEventInfoSummaryPPSimulation() : fWeight(1), fPtHard(0) {;}
+    AliEmcalJetEventInfoSummaryPPSimulation(EventInfo event);
+
+    virtual ~AliEmcalJetEventInfoSummaryPPSimulation() {;}
+
+    void Reset();
+    void Set(EventInfo event);
+
+    /// Centrality of the collision
+    Double32_t  fWeight          ; //[0,0,12]
+    Double32_t  fPtHard          ; //[0,512,10]
+
+    /// \cond CLASSIMP
+    ClassDef(AliEmcalJetEventInfoSummaryPPSimulation, 1);
     /// \endcond
   };
 
@@ -68,16 +111,16 @@ class AliAnalysisTaskEmcalJetTreeBase : public AliAnalysisTaskEmcalJetSpectraQA 
   class AliEmcalJetEventInfoSummaryPbPb {
   public:
     AliEmcalJetEventInfoSummaryPbPb() : fCent(0), fEP(0) {;}
-    AliEmcalJetEventInfoSummaryPbPb(Double_t cent, Double_t ep);
+    AliEmcalJetEventInfoSummaryPbPb(EventInfo event);
 
     virtual ~AliEmcalJetEventInfoSummaryPbPb() {;}
 
     void Reset();
-    void Set(Double_t cent, Double_t ep);
+    void Set(EventInfo event);
 
-    /// Eta of the jet
+    /// Centrality of the collision
     Double32_t  fCent          ; //[-10,118,7]
-    /// Phi of the jet
+    /// Event plane of the collision
     Double32_t  fEP            ; //[0,2*pi,9]
 
     /// \cond CLASSIMP

--- a/PWGJE/FlavourJetTasks/AliAnalysisTaskDmesonJets.cxx
+++ b/PWGJE/FlavourJetTasks/AliAnalysisTaskDmesonJets.cxx
@@ -681,6 +681,626 @@ void AliAnalysisTaskDmesonJets::AliDStarInfoSummary::Reset()
   fDeltaInvMass = 0;
 }
 
+// Definitions of class AliAnalysisTaskDmesonJets::OutputHandler
+
+/// Constructor
+AliAnalysisTaskDmesonJets::OutputHandler::OutputHandler() :
+  fCandidateType(kD0toKpi),
+  fMCMode(kNoMC),
+  fNMassBins(0),
+  fMinMass(0),
+  fMaxMass(0),
+  fJetDefinitions(nullptr),
+  fPtBinWidth(0.5),
+  fMaxPt(100),
+  fD0Extended(kFALSE),
+  fDmesonJets(nullptr),
+  fHistManager(nullptr),
+  fName()
+{
+}
+
+/// Constructor
+AliAnalysisTaskDmesonJets::OutputHandler::OutputHandler(AnalysisEngine* eng) :
+  fCandidateType(eng->fCandidateType),
+  fMCMode(eng->fMCMode),
+  fNMassBins(eng->fNMassBins),
+  fMinMass(eng->fMinMass),
+  fMaxMass(eng->fMaxMass),
+  fJetDefinitions(&eng->fJetDefinitions),
+  fPtBinWidth(eng->fPtBinWidth),
+  fMaxPt(eng->fMaxPt),
+  fD0Extended(eng->fD0Extended),
+  fDmesonJets(&eng->fDmesonJets),
+  fHistManager(eng->fHistManager),
+  fName(eng->GetName())
+{
+}
+
+/// Fills QA histograms. This method is not used by the AliAnalysisTaskDmesonJets task,
+/// but can be used by derived tasks that have a custom implementation to fill the output objects.
+///
+/// \return Always kTRUE
+Bool_t AliAnalysisTaskDmesonJets::OutputHandler::FillOutput(Bool_t applyKinCuts)
+{
+  TString hname;
+
+  TH1* histAncestor = nullptr;
+  TH1* histPrompt = nullptr;
+
+  if (fMCMode == kSignalOnly || fMCMode == kMCTruth) {
+    hname = TString::Format("%s/fHistPrompt", fName.Data());
+    histPrompt = static_cast<TH1*>(fHistManager->FindObject(hname));
+
+    hname = TString::Format("%s/fHistAncestor", fName.Data());
+    histAncestor = static_cast<TH1*>(fHistManager->FindObject(hname));
+  }
+
+  std::map<AliAODMCParticle*, Short_t> partons ; // set of the partons in the shower that produced each D meson
+  for (auto& dmeson_pair : *fDmesonJets) {
+    Int_t accJets = 0;
+    for (UInt_t ij = 0; ij < fJetDefinitions->size(); ij++) {
+      AliJetInfo* jet = dmeson_pair.second.GetJet(fJetDefinitions->at(ij).GetName());
+      if (!jet) continue;
+      if (applyKinCuts && !fJetDefinitions->at(ij).IsJetInAcceptance(*jet)) {
+        hname = TString::Format("%s/%s/fHistRejectedJetPt", fName.Data(), fJetDefinitions->at(ij).GetName());
+        fHistManager->FillTH1(hname, jet->Pt());
+        hname = TString::Format("%s/%s/fHistRejectedJetPhi", fName.Data(), fJetDefinitions->at(ij).GetName());
+        fHistManager->FillTH1(hname, jet->Phi_0_2pi());
+        hname = TString::Format("%s/%s/fHistRejectedJetEta", fName.Data(), fJetDefinitions->at(ij).GetName());
+        fHistManager->FillTH1(hname, jet->Eta());
+        continue;
+      }
+      accJets++;
+    }
+    if (accJets > 0) {
+      if (histPrompt) {
+        if (dmeson_pair.second.fParton) {
+          partons[dmeson_pair.second.fParton] = dmeson_pair.second.fPartonType;
+          UInt_t absPdgParton = TMath::Abs(dmeson_pair.second.fParton->GetPdgCode());
+          if (absPdgParton == 4) {
+            histPrompt->Fill("Prompt", 1);
+          }
+          else if (absPdgParton == 5) {
+            histPrompt->Fill("Non-Prompt", 1);
+          }
+          else {
+            histPrompt->Fill("Unknown", 1);
+          }
+        }
+        else {
+          histPrompt->Fill("Unknown", 1);
+        }
+      }
+
+      if (histAncestor) {
+        if (dmeson_pair.second.fAncestor) {
+          UInt_t absPdgAncestor = TMath::Abs(dmeson_pair.second.fAncestor->GetPdgCode());
+          if (absPdgAncestor == 4) {
+            histAncestor->Fill("Charm", 1);
+          }
+          else if (absPdgAncestor == 5) {
+            histAncestor->Fill("Bottom", 1);
+          }
+          else if (absPdgAncestor == 2212) {
+            histAncestor->Fill("Proton", 1);
+          }
+          else {
+            histAncestor->Fill("Unknown", 1);
+          }
+        }
+        else {
+          histAncestor->Fill("Unknown", 1);
+        }
+      }
+    }
+    else {
+      hname = TString::Format("%s/fHistRejectedDMesonPt", fName.Data());
+      fHistManager->FillTH1(hname, dmeson_pair.second.fD.Pt());
+      hname = TString::Format("%s/fHistRejectedDMesonPhi", fName.Data());
+      fHistManager->FillTH1(hname, dmeson_pair.second.fD.Phi_0_2pi());
+      hname = TString::Format("%s/fHistRejectedDMesonEta", fName.Data());
+      fHistManager->FillTH1(hname, dmeson_pair.second.fD.Eta());
+      if (fMCMode != kMCTruth) {
+        if (fCandidateType == kD0toKpi || fCandidateType == kD0toKpiLikeSign) {
+          hname = TString::Format("%s/fHistRejectedDMesonInvMass", fName.Data());
+          fHistManager->FillTH1(hname, dmeson_pair.second.fD.M());
+        }
+        else if (fCandidateType == kDstartoKpipi) {
+          hname = TString::Format("%s/fHistRejectedDMeson2ProngInvMass", fName.Data());
+          fHistManager->FillTH1(hname, dmeson_pair.second.fInvMass2Prong);
+
+          hname = TString::Format("%s/fHistRejectedDMesonDeltaInvMass", fName.Data());
+          fHistManager->FillTH1(hname, dmeson_pair.second.fD.M() - dmeson_pair.second.fInvMass2Prong);
+        }
+      }
+    }
+  }
+
+  if (fMCMode == kSignalOnly || fMCMode == kMCTruth) {
+    hname = TString::Format("%s/fHistPartonPt", fName.Data());
+    TH1* histPartonPt = static_cast<TH1*>(fHistManager->FindObject(hname));
+    hname = TString::Format("%s/fHistPartonEta", fName.Data());
+    TH1* histPartonEta = static_cast<TH1*>(fHistManager->FindObject(hname));
+    hname = TString::Format("%s/fHistPartonPhi", fName.Data());
+    TH1* histPartonPhi = static_cast<TH1*>(fHistManager->FindObject(hname));
+    hname = TString::Format("%s/fHistPartonType", fName.Data());
+    TH1* histPartonType = static_cast<TH1*>(fHistManager->FindObject(hname));
+
+    for (auto parton : partons) {
+      if (!parton.first) continue;
+      histPartonPt->Fill(parton.first->Pt());
+      histPartonEta->Fill(parton.first->Eta());
+      histPartonPhi->Fill(TVector2::Phi_0_2pi(parton.first->Phi()));
+      histPartonType->Fill(parton.second);
+    }
+  }
+
+  return kTRUE;
+}
+
+// Definitions of class AliAnalysisTaskDmesonJets::OutputHandlerTHnSparse
+
+/// Constructor
+AliAnalysisTaskDmesonJets::OutputHandlerTHnSparse::OutputHandlerTHnSparse() :
+  OutputHandler(),
+  fEnabledAxis(0)
+{
+}
+
+/// Constructor
+AliAnalysisTaskDmesonJets::OutputHandlerTHnSparse::OutputHandlerTHnSparse(AnalysisEngine* eng) :
+  OutputHandler(eng),
+  fEnabledAxis(0)
+{
+}
+
+
+/// Allocate a THnSparse histogram
+///
+/// \param param Analysis parameters used to properly set some of the axis
+void AliAnalysisTaskDmesonJets::OutputHandlerTHnSparse::BuildOutputObject(const char* /*taskName*/)
+{
+  TString hname;
+
+  Int_t nPtBins = TMath::CeilNint(fMaxPt / fPtBinWidth);
+
+  for (auto &jetDef : *fJetDefinitions) {
+
+    AliDebugGeneralStream("AliAnalysisTaskDmesonJets::OutputHandlerTHnSparse::BuildOutputObject", 2) << "Now working on '" << jetDef.GetName() << "'" << std::endl;
+
+    Double_t radius = jetDef.fRadius;
+
+    TString  title[30] = {""};
+    Int_t    nbins[30] = {0 };
+    Double_t min  [30] = {0.};
+    Double_t max  [30] = {0.};
+    Int_t    dim       = 0   ;
+
+    title[dim] = "#it{p}_{T,D} (GeV/#it{c})";
+    nbins[dim] = nPtBins;
+    min[dim] = 0;
+    max[dim] = fMaxPt;
+    dim++;
+
+    if ((fEnabledAxis & kPositionD) != 0) {
+      title[dim] = "#eta_{D}";
+      nbins[dim] = 50;
+      min[dim] = -1;
+      max[dim] = 1;
+      dim++;
+
+      title[dim] = "#phi_{D} (rad)";
+      nbins[dim] = 150;
+      min[dim] = 0;
+      max[dim] = TMath::TwoPi();
+      dim++;
+    }
+
+    if ((fEnabledAxis & kInvMass) != 0 && fCandidateType == kDstartoKpipi) {
+      title[dim] = "#it{M}_{K#pi#pi} (GeV/#it{c}^{2})";
+      nbins[dim] = fNMassBins;
+      min[dim] = fMinMass;
+      max[dim] = fMaxMass;
+      dim++;
+    }
+
+    if (fCandidateType == kD0toKpi || fCandidateType == kD0toKpiLikeSign) {
+      title[dim] = "#it{M}_{K#pi} (GeV/#it{c}^{2})";
+      nbins[dim] = fNMassBins;
+      min[dim] = fMinMass;
+      max[dim] = fMaxMass;
+      dim++;
+    }
+
+    if ((fEnabledAxis & k2ProngInvMass) != 0 && fCandidateType == kDstartoKpipi) {
+      title[dim] = "#it{M}_{K#pi} (GeV/#it{c}^{2})";
+      nbins[dim] = fNMassBins;
+      CalculateMassLimits(fMaxMass - fMinMass, 421, fNMassBins, min[dim], max[dim]);
+      dim++;
+    }
+
+    if (fCandidateType == kDstartoKpipi) {
+      title[dim] = "#it{M}_{K#pi#pi} - #it{M}_{K#pi} (GeV/#it{c}^{2})";
+      nbins[dim] = fNMassBins*6;
+      CalculateMassLimits(0.20, 413, nbins[dim], min[dim], max[dim]);
+
+      // subtract mass of D0
+      Double_t D0mass = TDatabasePDG::Instance()->GetParticle(421)->Mass();
+      min[dim] -= D0mass;
+      max[dim] -= D0mass;
+
+      dim++;
+    }
+
+    if ((fEnabledAxis & kSoftPionPt) != 0 && fCandidateType == kDstartoKpipi) {
+      title[dim] = "#it{p}_{T,#pi} (GeV/#it{c})";
+      nbins[dim] = 100;
+      min[dim] = 0;
+      max[dim] = 25;
+      dim++;
+    }
+
+    title[dim] = "#it{z}_{D}";
+    nbins[dim] = 110;
+    min[dim] = 0;
+    max[dim] = 1.10;
+    dim++;
+
+    if ((fEnabledAxis & kDeltaR) != 0) {
+      title[dim] = "#Delta R_{D-jet}";
+      nbins[dim] = 100;
+      min[dim] = 0;
+      max[dim] = radius * 1.5;
+      dim++;
+    }
+
+    if ((fEnabledAxis & kDeltaEta) != 0) {
+      title[dim] = "#eta_{D} - #eta_{jet}";
+      nbins[dim] = 100;
+      min[dim] = -radius * 1.2;
+      max[dim] = radius * 1.2;
+      dim++;
+    }
+
+    if ((fEnabledAxis & kDeltaPhi) != 0) {
+      title[dim] = "#phi_{D} - #phi_{jet} (rad)";
+      nbins[dim] = 100;
+      min[dim] = -radius * 1.2;
+      max[dim] = radius * 1.2;
+      dim++;
+    }
+
+    title[dim] = "#it{p}_{T,jet} (GeV/#it{c})";
+    nbins[dim] = nPtBins;
+    min[dim] = 0;
+    max[dim] = fMaxPt;
+    dim++;
+
+    if ((fEnabledAxis & kPositionJet) != 0) {
+      title[dim] = "#eta_{jet}";
+      nbins[dim] = 50;
+      min[dim] = -1;
+      max[dim] = 1;
+      dim++;
+
+      title[dim] = "#phi_{jet} (rad)";
+      nbins[dim] = 150;
+      min[dim] = 0;
+      max[dim] = TMath::TwoPi();
+      dim++;
+    }
+
+    if ((fEnabledAxis & kJetConstituents) != 0) {
+      title[dim] = "No. of constituents";
+      nbins[dim] = 50;
+      min[dim] = -0.5;
+      max[dim] = 49.5;
+      dim++;
+    }
+
+    hname = TString::Format("%s/%s/fDmesonJets", fName.Data(), jetDef.GetName());
+    THnSparse* h = fHistManager->CreateTHnSparse(hname,hname,dim,nbins,min,max);
+    for (Int_t j = 0; j < dim; j++) {
+      h->GetAxis(j)->SetTitle(title[j]);
+    }
+  }
+}
+
+/// Checks whether any of the D meson jets is in the acceptance
+///
+/// \param Const reference to a valid AliDmesonJetInfo object
+Bool_t AliAnalysisTaskDmesonJets::OutputHandlerTHnSparse::IsAnyJetInAcceptance(const AliDmesonJetInfo& dMesonJet) const
+{
+  for (UInt_t i = 0; i < fJetDefinitions->size(); i++) {
+    if (fJetDefinitions->at(i).IsJetInAcceptance(dMesonJet, fJetDefinitions->at(i).GetName())) return kTRUE;
+  }
+
+  return kFALSE;
+}
+
+/// Post the output with D meson jets found in the current event
+///
+/// \return kTRUE on success
+Bool_t AliAnalysisTaskDmesonJets::OutputHandlerTHnSparse::FillOutput(Bool_t applyKinCuts)
+{
+  TString hname;
+
+  for (auto& dmeson_pair : *fDmesonJets) {
+    if (!IsAnyJetInAcceptance(dmeson_pair.second)) {
+      hname = TString::Format("%s/fHistRejectedDMesonPt", fName.Data());
+      fHistManager->FillTH1(hname, dmeson_pair.second.fD.Pt());
+      hname = TString::Format("%s/fHistRejectedDMesonPhi", fName.Data());
+      fHistManager->FillTH1(hname, dmeson_pair.second.fD.Phi_0_2pi());
+      hname = TString::Format("%s/fHistRejectedDMesonEta", fName.Data());
+      fHistManager->FillTH1(hname, dmeson_pair.second.fD.Eta());
+    }
+  }
+
+  for (auto &jetDef : *fJetDefinitions) {
+
+    hname = TString::Format("%s/%s/fDmesonJets", fName.Data(), jetDef.GetName());
+    THnSparse* h = static_cast<THnSparse*>(fHistManager->FindObject(hname));
+
+    for (auto& dmeson_pair : *fDmesonJets) {
+      const AliJetInfo* jet = dmeson_pair.second.GetJet(jetDef.GetName());
+      if (!jet) continue;
+      if (!jetDef.IsJetInAcceptance(*jet)) {
+        hname = TString::Format("%s/%s/fHistRejectedJetPt", fName.Data(), jetDef.GetName());
+        fHistManager->FillTH1(hname, jet->Pt());
+        hname = TString::Format("%s/%s/fHistRejectedJetPhi", fName.Data(), jetDef.GetName());
+        fHistManager->FillTH1(hname, jet->Phi_0_2pi());
+        hname = TString::Format("%s/%s/fHistRejectedJetEta", fName.Data(), jetDef.GetName());
+        fHistManager->FillTH1(hname, jet->Eta());
+        continue;
+      }
+      FillHnSparse(h, dmeson_pair.second, jetDef.GetName());
+    }
+  }
+
+  return kTRUE;
+}
+
+/// Fill a THnSparse using information from a AliDmesonJetInfo object
+///
+/// \param h          Valid pointer to a THnSparse object
+/// \param DmesonJet  Const reference to an AliDmesonJetInfo object
+/// \param n          Jet name
+Bool_t AliAnalysisTaskDmesonJets::OutputHandlerTHnSparse::FillHnSparse(THnSparse* h, const AliDmesonJetInfo& DmesonJet, std::string n)
+{
+  // Fill the THnSparse histogram.
+
+  Double_t contents[30] = {0.};
+
+  Double_t z = DmesonJet.GetZ(n);
+  Double_t deltaPhi = 0;
+  Double_t deltaEta = 0;
+  Double_t deltaR = DmesonJet.GetDistance(n, deltaEta, deltaPhi);
+
+  std::map<std::string, AliJetInfo>::const_iterator it = DmesonJet.fJets.find(n);
+  if (it == DmesonJet.fJets.end()) return kFALSE;
+
+  for (Int_t i = 0; i < h->GetNdimensions(); i++) {
+    TString title(h->GetAxis(i)->GetTitle());
+    if      (title=="#it{p}_{T,D} (GeV/#it{c})")                     contents[i] = DmesonJet.fD.Pt();
+    else if (title=="#eta_{D}")                                      contents[i] = DmesonJet.fD.Eta();
+    else if (title=="#phi_{D} (rad)")                                contents[i] = DmesonJet.fD.Phi_0_2pi();
+    else if (title=="#it{M}_{K#pi} (GeV/#it{c}^{2})")                contents[i] = DmesonJet.fInvMass2Prong > 0 ? DmesonJet.fInvMass2Prong : DmesonJet.fD.M();
+    else if (title=="#it{M}_{K#pi#pi} (GeV/#it{c}^{2})")             contents[i] = DmesonJet.fD.M();
+    else if (title=="#it{M}_{K#pi#pi} - #it{M}_{K#pi} (GeV/#it{c}^{2})") contents[i] = DmesonJet.fD.M() - DmesonJet.fInvMass2Prong;
+    else if (title=="#it{p}_{T,#pi} (GeV/#it{c})")                   contents[i] = DmesonJet.fSoftPionPt;
+    else if (title=="#it{z}_{D}")                                    contents[i] = z;
+    else if (title=="#Delta R_{D-jet}")                              contents[i] = deltaR;
+    else if (title=="#eta_{D} - #eta_{jet}")                         contents[i] = deltaEta;
+    else if (title=="#phi_{D} - #phi_{jet} (rad)")                   contents[i] = deltaPhi;
+    else if (title=="#it{p}_{T,jet} (GeV/#it{c})")                   contents[i] = (*it).second.Pt();
+    else if (title=="#eta_{jet}")                                    contents[i] = (*it).second.Eta();
+    else if (title=="#phi_{jet} (rad)")                              contents[i] = (*it).second.Phi_0_2pi();
+    else if (title=="No. of constituents")                           contents[i] = (*it).second.fNConstituents;
+    else {
+      AliWarningGeneralStream("AliAnalysisTaskDmesonJets::OutputHandlerTHnSparse::FillHnSparse") << "Unable to fill dimension '" << title.Data() << "'!" << std::endl;
+    }
+  }
+
+  h->Fill(contents);
+
+  return kTRUE;
+}
+
+// Definitions of class AliAnalysisTaskDmesonJets::OutputHandlerTHnSparse
+
+/// Constructor
+AliAnalysisTaskDmesonJets::OutputHandlerTTree::OutputHandlerTTree() :
+  OutputHandler(),
+  fDataSlotNumber(-1),
+  fTree(0),
+  fCurrentDmesonJetInfo(0),
+  fCurrentJetInfo(0)
+{
+}
+
+/// Constructor
+AliAnalysisTaskDmesonJets::OutputHandlerTTree::OutputHandlerTTree(AnalysisEngine* eng) :
+  OutputHandler(eng),
+  fDataSlotNumber(-1),
+  fTree(0),
+  fCurrentDmesonJetInfo(0),
+  fCurrentJetInfo(0)
+{
+}
+
+/// Builds the tree where the output will be posted
+///
+/// \return Pointer to the new tree
+void AliAnalysisTaskDmesonJets::OutputHandlerTTree::BuildOutputObject(const char* taskName)
+{
+  TString classname;
+  if (fMCMode == kMCTruth) {
+    classname = "AliAnalysisTaskDmesonJets::AliDmesonMCInfoSummary";
+    fCurrentDmesonJetInfo = new AliDmesonMCInfoSummary();
+  }
+  else {
+    switch (fCandidateType) {
+    case kD0toKpi:
+    case kD0toKpiLikeSign:
+      if (fD0Extended) {
+        classname = "AliAnalysisTaskDmesonJets::AliD0ExtendedInfoSummary";
+        fCurrentDmesonJetInfo = new AliD0ExtendedInfoSummary();
+      }
+      else {
+        classname = "AliAnalysisTaskDmesonJets::AliD0InfoSummary";
+        fCurrentDmesonJetInfo = new AliD0InfoSummary();
+      }
+      break;
+    case kDstartoKpipi:
+      classname = "AliAnalysisTaskDmesonJets::AliDStarInfoSummary";
+      fCurrentDmesonJetInfo = new AliDStarInfoSummary();
+      break;
+    }
+  }
+  TString treeName = TString::Format("%s_%s", taskName, fName.Data());
+  fTree = new TTree(treeName, treeName);
+  fTree->Branch("DmesonJet", classname, &fCurrentDmesonJetInfo);
+  fCurrentJetInfo = new AliJetInfoSummary*[fJetDefinitions->size()];
+  for (Int_t i = 0; i < fJetDefinitions->size(); i++) {
+    if (fJetDefinitions->at(i).fRhoName.IsNull()) {
+      fCurrentJetInfo[i] = new AliJetInfoSummary();
+      fTree->Branch(fJetDefinitions->at(i).GetName(), "AliAnalysisTaskDmesonJets::AliJetInfoSummary", &fCurrentJetInfo[i]);
+    }
+    else {
+      fCurrentJetInfo[i] = new AliJetInfoPbPbSummary();
+      fTree->Branch(fJetDefinitions->at(i).GetName(), "AliAnalysisTaskDmesonJets::AliJetInfoPbPbSummary", &fCurrentJetInfo[i]);
+    }
+  }
+}
+
+/// Post the output with D meson jets found in the current event
+///
+/// \return kTRUE on success
+Bool_t AliAnalysisTaskDmesonJets::OutputHandlerTTree::FillOutput(Bool_t applyKinCuts)
+{
+  TString hname;
+
+  std::map<AliAODMCParticle*, Short_t> partons ; //!<! set of the partons in the shower that produced each D meson
+
+  TH1* histAncestor = nullptr;
+  TH1* histPrompt = nullptr;
+
+  if (fMCMode == kSignalOnly || fMCMode == kMCTruth) {
+    hname = TString::Format("%s/fHistPrompt", fName.Data());
+    histPrompt = static_cast<TH1*>(fHistManager->FindObject(hname));
+
+    hname = TString::Format("%s/fHistAncestor", fName.Data());
+    histAncestor = static_cast<TH1*>(fHistManager->FindObject(hname));
+  }
+
+  for (auto& dmeson_pair : *fDmesonJets) {
+    fCurrentDmesonJetInfo->Set(dmeson_pair.second);
+    Int_t accJets = 0;
+    for (UInt_t ij = 0; ij < fJetDefinitions->size(); ij++) {
+      fCurrentJetInfo[ij]->Reset();
+      AliJetInfo* jet = dmeson_pair.second.GetJet(fJetDefinitions->at(ij).GetName());
+      if (!jet) continue;
+      if (applyKinCuts && !fJetDefinitions->at(ij).IsJetInAcceptance(*jet)) {
+        hname = TString::Format("%s/%s/fHistRejectedJetPt", fName.Data(), fJetDefinitions->at(ij).GetName());
+        fHistManager->FillTH1(hname, jet->Pt());
+        hname = TString::Format("%s/%s/fHistRejectedJetPhi", fName.Data(), fJetDefinitions->at(ij).GetName());
+        fHistManager->FillTH1(hname, jet->Phi_0_2pi());
+        hname = TString::Format("%s/%s/fHistRejectedJetEta", fName.Data(), fJetDefinitions->at(ij).GetName());
+        fHistManager->FillTH1(hname, jet->Eta());
+        continue;
+      }
+      fCurrentJetInfo[ij]->Set(dmeson_pair.second, fJetDefinitions->at(ij).GetName());
+      accJets++;
+    }
+    if (accJets > 0) {
+      if (histPrompt) {
+        if (dmeson_pair.second.fParton) {
+          partons[dmeson_pair.second.fParton] = dmeson_pair.second.fPartonType;
+          UInt_t absPdgParton = TMath::Abs(dmeson_pair.second.fParton->GetPdgCode());
+          if (absPdgParton == 4) {
+            histPrompt->Fill("Prompt", 1);
+          }
+          else if (absPdgParton == 5) {
+            histPrompt->Fill("Non-Prompt", 1);
+          }
+          else {
+            histPrompt->Fill("Unknown", 1);
+          }
+        }
+        else {
+          histPrompt->Fill("Unknown", 1);
+        }
+      }
+
+      if (histAncestor) {
+        if (dmeson_pair.second.fAncestor) {
+          UInt_t absPdgAncestor = TMath::Abs(dmeson_pair.second.fAncestor->GetPdgCode());
+          if (absPdgAncestor == 4) {
+            histAncestor->Fill("Charm", 1);
+          }
+          else if (absPdgAncestor == 5) {
+            histAncestor->Fill("Bottom", 1);
+          }
+          else if (absPdgAncestor == 2212) {
+            histAncestor->Fill("Proton", 1);
+          }
+          else {
+            histAncestor->Fill("Unknown", 1);
+          }
+        }
+        else {
+          histAncestor->Fill("Unknown", 1);
+        }
+      }
+
+      fTree->Fill();
+    }
+    else {
+      hname = TString::Format("%s/fHistRejectedDMesonPt", fName.Data());
+      fHistManager->FillTH1(hname, dmeson_pair.second.fD.Pt());
+      hname = TString::Format("%s/fHistRejectedDMesonPhi", fName.Data());
+      fHistManager->FillTH1(hname, dmeson_pair.second.fD.Phi_0_2pi());
+      hname = TString::Format("%s/fHistRejectedDMesonEta", fName.Data());
+      fHistManager->FillTH1(hname, dmeson_pair.second.fD.Eta());
+      if (fMCMode != kMCTruth) {
+        if (fCandidateType == kD0toKpi || fCandidateType == kD0toKpiLikeSign) {
+          hname = TString::Format("%s/fHistRejectedDMesonInvMass", fName.Data());
+          fHistManager->FillTH1(hname, dmeson_pair.second.fD.M());
+        }
+        else if (fCandidateType == kDstartoKpipi) {
+          hname = TString::Format("%s/fHistRejectedDMeson2ProngInvMass", fName.Data());
+          fHistManager->FillTH1(hname, dmeson_pair.second.fInvMass2Prong);
+
+          hname = TString::Format("%s/fHistRejectedDMesonDeltaInvMass", fName.Data());
+          fHistManager->FillTH1(hname, dmeson_pair.second.fD.M() - dmeson_pair.second.fInvMass2Prong);
+        }
+      }
+    }
+  }
+
+  if (fMCMode == kSignalOnly || fMCMode == kMCTruth) {
+    hname = TString::Format("%s/fHistPartonPt", fName.Data());
+    TH1* histPartonPt = static_cast<TH1*>(fHistManager->FindObject(hname));
+    hname = TString::Format("%s/fHistPartonEta", fName.Data());
+    TH1* histPartonEta = static_cast<TH1*>(fHistManager->FindObject(hname));
+    hname = TString::Format("%s/fHistPartonPhi", fName.Data());
+    TH1* histPartonPhi = static_cast<TH1*>(fHistManager->FindObject(hname));
+    hname = TString::Format("%s/fHistPartonType", fName.Data());
+    TH1* histPartonType = static_cast<TH1*>(fHistManager->FindObject(hname));
+
+    for (auto parton : partons) {
+      if (!parton.first) continue;
+      histPartonPt->Fill(parton.first->Pt());
+      histPartonEta->Fill(parton.first->Eta());
+      histPartonPhi->Fill(TVector2::Phi_0_2pi(parton.first->Phi()));
+      histPartonType->Fill(parton.second);
+    }
+  }
+
+  return kTRUE;
+}
+
 // Definitions of class AliAnalysisTaskDmesonJets::AliJetDefinition
 
 /// \cond CLASSIMP
@@ -878,7 +1498,6 @@ ClassImp(AliAnalysisTaskDmesonJets::AnalysisEngine);
 /// This is the default constructor, used for ROOT I/O purposes.
 AliAnalysisTaskDmesonJets::AnalysisEngine::AnalysisEngine() :
   TObject(),
-  fPartons(),
   fCandidateType(kD0toKpi),
   fCandidateName(),
   fCandidatePDG(0),
@@ -897,13 +1516,11 @@ AliAnalysisTaskDmesonJets::AnalysisEngine::AnalysisEngine() :
   fPtBinWidth(0.5),
   fMaxPt(100),
   fD0Extended(kFALSE),
+  fOutputHandler(nullptr),
   fRandomGen(0),
   fTrackEfficiency(0),
   fRejectISR(kFALSE),
-  fDataSlotNumber(-1),
-  fTree(0),
-  fCurrentDmesonJetInfo(0),
-  fCurrentJetInfo(0),
+  fDmesonJets(),
   fCandidateArray(0),
   fMCContainer(),
   fTrackContainers(),
@@ -924,7 +1541,6 @@ AliAnalysisTaskDmesonJets::AnalysisEngine::AnalysisEngine() :
 /// \param range     Range of the mass axis (will be centered around the PDG mass)
 AliAnalysisTaskDmesonJets::AnalysisEngine::AnalysisEngine(ECandidateType_t type, EMCMode_t MCmode, AliRDHFCuts* cuts, Int_t nMassBins, Double_t range) :
   TObject(),
-  fPartons(),
   fCandidateType(type),
   fCandidateName(),
   fCandidatePDG(0),
@@ -943,12 +1559,10 @@ AliAnalysisTaskDmesonJets::AnalysisEngine::AnalysisEngine(ECandidateType_t type,
   fPtBinWidth(0.5),
   fMaxPt(100),
   fD0Extended(kFALSE),
+  fOutputHandler(nullptr),
   fRandomGen(0),
   fTrackEfficiency(0),
-  fDataSlotNumber(-1),
-  fTree(0),
-  fCurrentDmesonJetInfo(0),
-  fCurrentJetInfo(0),
+  fDmesonJets(),
   fCandidateArray(0),
   fMCContainer(),
   fTrackContainers(),
@@ -966,7 +1580,6 @@ AliAnalysisTaskDmesonJets::AnalysisEngine::AnalysisEngine(ECandidateType_t type,
 /// \param source Reference to a valid AnalysisEngine to copy from.
 AliAnalysisTaskDmesonJets::AnalysisEngine::AnalysisEngine(const AliAnalysisTaskDmesonJets::AnalysisEngine &source) :
   TObject(source),
-  fPartons(source.fPartons),
   fCandidateType(source.fCandidateType),
   fCandidateName(source.fCandidateName),
   fCandidatePDG(source.fCandidatePDG),
@@ -987,10 +1600,7 @@ AliAnalysisTaskDmesonJets::AnalysisEngine::AnalysisEngine(const AliAnalysisTaskD
   fD0Extended(source.fD0Extended),
   fRandomGen(source.fRandomGen),
   fTrackEfficiency(source.fTrackEfficiency),
-  fDataSlotNumber(-1),
-  fTree(0),
-  fCurrentDmesonJetInfo(0),
-  fCurrentJetInfo(0),
+  fDmesonJets(),
   fCandidateArray(source.fCandidateArray),
   fMCContainer(source.fMCContainer),
   fTrackContainers(source.fTrackContainers),
@@ -1016,18 +1626,6 @@ AliAnalysisTaskDmesonJets::AnalysisEngine& AliAnalysisTaskDmesonJets::AnalysisEn
 {
   new (this) AnalysisEngine(source);
   return *this;
-}
-
-/// Checks whether any of the D meson jets is in the acceptance
-///
-/// \param Const reference to a valid AliDmesonJetInfo object
-Bool_t AliAnalysisTaskDmesonJets::AnalysisEngine::IsAnyJetInAcceptance(const AliDmesonJetInfo& dMesonJet) const
-{
-  for (UInt_t i = 0; i < fJetDefinitions.size(); i++) {
-    if (fJetDefinitions[i].IsJetInAcceptance(dMesonJet, fJetDefinitions[i].GetName())) return kTRUE;
-  }
-
-  return kFALSE;
 }
 
 /// Initialize the analysis engine
@@ -2027,537 +2625,7 @@ void AliAnalysisTaskDmesonJets::AnalysisEngine::RunParticleLevelAnalysis()
   fHistManager->FillTH1(hname, nAccCharm[0]+nAccCharm[1]); // same as the number of accepted D mesons, since no selection is performed
 }
 
-/// Builds the tree where the output will be posted
-///
-/// \return Pointer to the new tree
-TTree* AliAnalysisTaskDmesonJets::AnalysisEngine::BuildTree(const char* taskName)
-{
-  TString classname;
-  if (fMCMode == kMCTruth) {
-    classname = "AliAnalysisTaskDmesonJets::AliDmesonMCInfoSummary";
-    fCurrentDmesonJetInfo = new AliDmesonMCInfoSummary();
-  }
-  else {
-    switch (fCandidateType) {
-    case kD0toKpi:
-    case kD0toKpiLikeSign:
-      if (fD0Extended) {
-        classname = "AliAnalysisTaskDmesonJets::AliD0ExtendedInfoSummary";
-        fCurrentDmesonJetInfo = new AliD0ExtendedInfoSummary();
-      }
-      else {
-        classname = "AliAnalysisTaskDmesonJets::AliD0InfoSummary";
-        fCurrentDmesonJetInfo = new AliD0InfoSummary();
-      }
-      break;
-    case kDstartoKpipi:
-      classname = "AliAnalysisTaskDmesonJets::AliDStarInfoSummary";
-      fCurrentDmesonJetInfo = new AliDStarInfoSummary();
-      break;
-    }
-  }
-  TString treeName = TString::Format("%s_%s", taskName, GetName());
-  fTree = new TTree(treeName, treeName);
-  fTree->Branch("DmesonJet", classname, &fCurrentDmesonJetInfo);
-  fCurrentJetInfo = new AliJetInfoSummary*[fJetDefinitions.size()];
-  for (Int_t i = 0; i < fJetDefinitions.size(); i++) {
-    if (fJetDefinitions[i].fRhoName.IsNull()) {
-      fCurrentJetInfo[i] = new AliJetInfoSummary();
-      fTree->Branch(fJetDefinitions[i].GetName(), "AliAnalysisTaskDmesonJets::AliJetInfoSummary", &fCurrentJetInfo[i]);
-    }
-    else {
-      fCurrentJetInfo[i] = new AliJetInfoPbPbSummary();
-      fTree->Branch(fJetDefinitions[i].GetName(), "AliAnalysisTaskDmesonJets::AliJetInfoPbPbSummary", &fCurrentJetInfo[i]);
-    }
-  }
 
-  return fTree;
-}
-
-/// Allocate a THnSparse histogram
-///
-/// \param param Analysis parameters used to properly set some of the axis
-void AliAnalysisTaskDmesonJets::AnalysisEngine::BuildHnSparse(UInt_t enabledAxis)
-{
-  TString hname;
-
-  Int_t nPtBins = TMath::CeilNint(fMaxPt / fPtBinWidth);
-
-  for (auto &jetDef : fJetDefinitions) {
-
-    AliDebug(2,Form("Now working on '%s'", jetDef.GetName()));
-
-    Double_t radius = jetDef.fRadius;
-
-    TString  title[30] = {""};
-    Int_t    nbins[30] = {0 };
-    Double_t min  [30] = {0.};
-    Double_t max  [30] = {0.};
-    Int_t    dim       = 0   ;
-
-    title[dim] = "#it{p}_{T,D} (GeV/#it{c})";
-    nbins[dim] = nPtBins;
-    min[dim] = 0;
-    max[dim] = fMaxPt;
-    dim++;
-
-    if ((enabledAxis & kPositionD) != 0) {
-      title[dim] = "#eta_{D}";
-      nbins[dim] = 50;
-      min[dim] = -1;
-      max[dim] = 1;
-      dim++;
-
-      title[dim] = "#phi_{D} (rad)";
-      nbins[dim] = 150;
-      min[dim] = 0;
-      max[dim] = TMath::TwoPi();
-      dim++;
-    }
-
-    if ((enabledAxis & kInvMass) != 0 && fCandidateType == kDstartoKpipi) {
-      title[dim] = "#it{M}_{K#pi#pi} (GeV/#it{c}^{2})";
-      nbins[dim] = fNMassBins;
-      min[dim] = fMinMass;
-      max[dim] = fMaxMass;
-      dim++;
-    }
-
-    if (fCandidateType == kD0toKpi || fCandidateType == kD0toKpiLikeSign) {
-      title[dim] = "#it{M}_{K#pi} (GeV/#it{c}^{2})";
-      nbins[dim] = fNMassBins;
-      min[dim] = fMinMass;
-      max[dim] = fMaxMass;
-      dim++;
-    }
-
-    if ((enabledAxis & k2ProngInvMass) != 0 && fCandidateType == kDstartoKpipi) {
-      title[dim] = "#it{M}_{K#pi} (GeV/#it{c}^{2})";
-      nbins[dim] = fNMassBins;
-      CalculateMassLimits(fMaxMass - fMinMass, 421, fNMassBins, min[dim], max[dim]);
-      dim++;
-    }
-
-    if (fCandidateType == kDstartoKpipi) {
-      title[dim] = "#it{M}_{K#pi#pi} - #it{M}_{K#pi} (GeV/#it{c}^{2})";
-      nbins[dim] = fNMassBins*6;
-      CalculateMassLimits(0.20, 413, nbins[dim], min[dim], max[dim]);
-
-      // subtract mass of D0
-      Double_t D0mass = TDatabasePDG::Instance()->GetParticle(421)->Mass();
-      min[dim] -= D0mass;
-      max[dim] -= D0mass;
-
-      dim++;
-    }
-
-    if ((enabledAxis & kSoftPionPt) != 0 && fCandidateType == kDstartoKpipi) {
-      title[dim] = "#it{p}_{T,#pi} (GeV/#it{c})";
-      nbins[dim] = 100;
-      min[dim] = 0;
-      max[dim] = 25;
-      dim++;
-    }
-
-    title[dim] = "#it{z}_{D}";
-    nbins[dim] = 110;
-    min[dim] = 0;
-    max[dim] = 1.10;
-    dim++;
-
-    if ((enabledAxis & kDeltaR) != 0) {
-      title[dim] = "#Delta R_{D-jet}";
-      nbins[dim] = 100;
-      min[dim] = 0;
-      max[dim] = radius * 1.5;
-      dim++;
-    }
-
-    if ((enabledAxis & kDeltaEta) != 0) {
-      title[dim] = "#eta_{D} - #eta_{jet}";
-      nbins[dim] = 100;
-      min[dim] = -radius * 1.2;
-      max[dim] = radius * 1.2;
-      dim++;
-    }
-
-    if ((enabledAxis & kDeltaPhi) != 0) {
-      title[dim] = "#phi_{D} - #phi_{jet} (rad)";
-      nbins[dim] = 100;
-      min[dim] = -radius * 1.2;
-      max[dim] = radius * 1.2;
-      dim++;
-    }
-
-    title[dim] = "#it{p}_{T,jet} (GeV/#it{c})";
-    nbins[dim] = nPtBins;
-    min[dim] = 0;
-    max[dim] = fMaxPt;
-    dim++;
-
-    if ((enabledAxis & kPositionJet) != 0) {
-      title[dim] = "#eta_{jet}";
-      nbins[dim] = 50;
-      min[dim] = -1;
-      max[dim] = 1;
-      dim++;
-
-      title[dim] = "#phi_{jet} (rad)";
-      nbins[dim] = 150;
-      min[dim] = 0;
-      max[dim] = TMath::TwoPi();
-      dim++;
-    }
-
-    if ((enabledAxis & kJetConstituents) != 0) {
-      title[dim] = "No. of constituents";
-      nbins[dim] = 50;
-      min[dim] = -0.5;
-      max[dim] = 49.5;
-      dim++;
-    }
-
-    hname = TString::Format("%s/%s/fDmesonJets", GetName(), jetDef.GetName());
-    THnSparse* h = fHistManager->CreateTHnSparse(hname,hname,dim,nbins,min,max);
-    for (Int_t j = 0; j < dim; j++) {
-      h->GetAxis(j)->SetTitle(title[j]);
-    }
-  }
-}
-
-/// Post the output with D meson jets found in the current event
-///
-/// \return kTRUE on success
-Bool_t AliAnalysisTaskDmesonJets::AnalysisEngine::FillTree(Bool_t applyKinCuts)
-{
-  TString hname;
-  fPartons.clear();
-
-  TH1* histAncestor = nullptr;
-  TH1* histPrompt = nullptr;
-
-  if (fMCMode == kSignalOnly || fMCMode == kMCTruth) {
-    hname = TString::Format("%s/fHistPrompt", GetName());
-    histPrompt = static_cast<TH1*>(fHistManager->FindObject(hname));
-
-    hname = TString::Format("%s/fHistAncestor", GetName());
-    histAncestor = static_cast<TH1*>(fHistManager->FindObject(hname));
-  }
-
-  for (auto& dmeson_pair : fDmesonJets) {
-    fCurrentDmesonJetInfo->Set(dmeson_pair.second);
-    Int_t accJets = 0;
-    for (UInt_t ij = 0; ij < fJetDefinitions.size(); ij++) {
-      fCurrentJetInfo[ij]->Reset();
-      AliJetInfo* jet = dmeson_pair.second.GetJet(fJetDefinitions[ij].GetName());
-      if (!jet) continue;
-      if (applyKinCuts && !fJetDefinitions[ij].IsJetInAcceptance(*jet)) {
-        hname = TString::Format("%s/%s/fHistRejectedJetPt", GetName(), fJetDefinitions[ij].GetName());
-        fHistManager->FillTH1(hname, jet->Pt());
-        hname = TString::Format("%s/%s/fHistRejectedJetPhi", GetName(), fJetDefinitions[ij].GetName());
-        fHistManager->FillTH1(hname, jet->Phi_0_2pi());
-        hname = TString::Format("%s/%s/fHistRejectedJetEta", GetName(), fJetDefinitions[ij].GetName());
-        fHistManager->FillTH1(hname, jet->Eta());
-        continue;
-      }
-      fCurrentJetInfo[ij]->Set(dmeson_pair.second, fJetDefinitions[ij].GetName());
-      accJets++;
-    }
-    if (accJets > 0) {
-      if (histPrompt) {
-        if (dmeson_pair.second.fParton) {
-          fPartons[dmeson_pair.second.fParton] = dmeson_pair.second.fPartonType;
-          UInt_t absPdgParton = TMath::Abs(dmeson_pair.second.fParton->GetPdgCode());
-          if (absPdgParton == 4) {
-            histPrompt->Fill("Prompt", 1);
-          }
-          else if (absPdgParton == 5) {
-            histPrompt->Fill("Non-Prompt", 1);
-          }
-          else {
-            histPrompt->Fill("Unknown", 1);
-          }
-        }
-        else {
-          histPrompt->Fill("Unknown", 1);
-        }
-      }
-
-      if (histAncestor) {
-        if (dmeson_pair.second.fAncestor) {
-          UInt_t absPdgAncestor = TMath::Abs(dmeson_pair.second.fAncestor->GetPdgCode());
-          if (absPdgAncestor == 4) {
-            histAncestor->Fill("Charm", 1);
-          }
-          else if (absPdgAncestor == 5) {
-            histAncestor->Fill("Bottom", 1);
-          }
-          else if (absPdgAncestor == 2212) {
-            histAncestor->Fill("Proton", 1);
-          }
-          else {
-            histAncestor->Fill("Unknown", 1);
-          }
-        }
-        else {
-          histAncestor->Fill("Unknown", 1);
-        }
-      }
-
-      fTree->Fill();
-    }
-    else {
-      hname = TString::Format("%s/fHistRejectedDMesonPt", GetName());
-      fHistManager->FillTH1(hname, dmeson_pair.second.fD.Pt());
-      hname = TString::Format("%s/fHistRejectedDMesonPhi", GetName());
-      fHistManager->FillTH1(hname, dmeson_pair.second.fD.Phi_0_2pi());
-      hname = TString::Format("%s/fHistRejectedDMesonEta", GetName());
-      fHistManager->FillTH1(hname, dmeson_pair.second.fD.Eta());
-      if (fMCMode != kMCTruth) {
-        if (fCandidateType == kD0toKpi || fCandidateType == kD0toKpiLikeSign) {
-          hname = TString::Format("%s/fHistRejectedDMesonInvMass", GetName());
-          fHistManager->FillTH1(hname, dmeson_pair.second.fD.M());
-        }
-        else if (fCandidateType == kDstartoKpipi) {
-          hname = TString::Format("%s/fHistRejectedDMeson2ProngInvMass", GetName());
-          fHistManager->FillTH1(hname, dmeson_pair.second.fInvMass2Prong);
-
-          hname = TString::Format("%s/fHistRejectedDMesonDeltaInvMass", GetName());
-          fHistManager->FillTH1(hname, dmeson_pair.second.fD.M() - dmeson_pair.second.fInvMass2Prong);
-        }
-      }
-    }
-  }
-
-  if (fMCMode == kSignalOnly || fMCMode == kMCTruth) {
-    hname = TString::Format("%s/fHistPartonPt", GetName());
-    TH1* histPartonPt = static_cast<TH1*>(fHistManager->FindObject(hname));
-    hname = TString::Format("%s/fHistPartonEta", GetName());
-    TH1* histPartonEta = static_cast<TH1*>(fHistManager->FindObject(hname));
-    hname = TString::Format("%s/fHistPartonPhi", GetName());
-    TH1* histPartonPhi = static_cast<TH1*>(fHistManager->FindObject(hname));
-    hname = TString::Format("%s/fHistPartonType", GetName());
-    TH1* histPartonType = static_cast<TH1*>(fHistManager->FindObject(hname));
-
-    for (auto parton : fPartons) {
-      if (!parton.first) continue;
-      histPartonPt->Fill(parton.first->Pt());
-      histPartonEta->Fill(parton.first->Eta());
-      histPartonPhi->Fill(TVector2::Phi_0_2pi(parton.first->Phi()));
-      histPartonType->Fill(parton.second);
-    }
-  }
-
-  return kTRUE;
-}
-
-/// Fills QA histograms. This method is not used by the AliAnalysisTaskDmesonJets task,
-/// but can be used by derived tasks that have a custom implementation to fill the output objects.
-///
-/// \return Always kTRUE
-Bool_t AliAnalysisTaskDmesonJets::AnalysisEngine::FillQA(Bool_t applyKinCuts)
-{
-  TString hname;
-
-  TH1* histAncestor = nullptr;
-  TH1* histPrompt = nullptr;
-
-  if (fMCMode == kSignalOnly || fMCMode == kMCTruth) {
-    hname = TString::Format("%s/fHistPrompt", GetName());
-    histPrompt = static_cast<TH1*>(fHistManager->FindObject(hname));
-
-    hname = TString::Format("%s/fHistAncestor", GetName());
-    histAncestor = static_cast<TH1*>(fHistManager->FindObject(hname));
-  }
-
-  fPartons.clear();
-  for (auto& dmeson_pair : fDmesonJets) {
-    Int_t accJets = 0;
-    for (UInt_t ij = 0; ij < fJetDefinitions.size(); ij++) {
-      AliJetInfo* jet = dmeson_pair.second.GetJet(fJetDefinitions[ij].GetName());
-      if (!jet) continue;
-      if (applyKinCuts && !fJetDefinitions[ij].IsJetInAcceptance(*jet)) {
-        hname = TString::Format("%s/%s/fHistRejectedJetPt", GetName(), fJetDefinitions[ij].GetName());
-        fHistManager->FillTH1(hname, jet->Pt());
-        hname = TString::Format("%s/%s/fHistRejectedJetPhi", GetName(), fJetDefinitions[ij].GetName());
-        fHistManager->FillTH1(hname, jet->Phi_0_2pi());
-        hname = TString::Format("%s/%s/fHistRejectedJetEta", GetName(), fJetDefinitions[ij].GetName());
-        fHistManager->FillTH1(hname, jet->Eta());
-        continue;
-      }
-      accJets++;
-    }
-    if (accJets > 0) {
-      if (histPrompt) {
-        if (dmeson_pair.second.fParton) {
-          fPartons[dmeson_pair.second.fParton] = dmeson_pair.second.fPartonType;
-          UInt_t absPdgParton = TMath::Abs(dmeson_pair.second.fParton->GetPdgCode());
-          if (absPdgParton == 4) {
-            histPrompt->Fill("Prompt", 1);
-          }
-          else if (absPdgParton == 5) {
-            histPrompt->Fill("Non-Prompt", 1);
-          }
-          else {
-            histPrompt->Fill("Unknown", 1);
-          }
-        }
-        else {
-          histPrompt->Fill("Unknown", 1);
-        }
-      }
-
-      if (histAncestor) {
-        if (dmeson_pair.second.fAncestor) {
-          UInt_t absPdgAncestor = TMath::Abs(dmeson_pair.second.fAncestor->GetPdgCode());
-          if (absPdgAncestor == 4) {
-            histAncestor->Fill("Charm", 1);
-          }
-          else if (absPdgAncestor == 5) {
-            histAncestor->Fill("Bottom", 1);
-          }
-          else if (absPdgAncestor == 2212) {
-            histAncestor->Fill("Proton", 1);
-          }
-          else {
-            histAncestor->Fill("Unknown", 1);
-          }
-        }
-        else {
-          histAncestor->Fill("Unknown", 1);
-        }
-      }
-    }
-    else {
-      hname = TString::Format("%s/fHistRejectedDMesonPt", GetName());
-      fHistManager->FillTH1(hname, dmeson_pair.second.fD.Pt());
-      hname = TString::Format("%s/fHistRejectedDMesonPhi", GetName());
-      fHistManager->FillTH1(hname, dmeson_pair.second.fD.Phi_0_2pi());
-      hname = TString::Format("%s/fHistRejectedDMesonEta", GetName());
-      fHistManager->FillTH1(hname, dmeson_pair.second.fD.Eta());
-      if (fMCMode != kMCTruth) {
-        if (fCandidateType == kD0toKpi || fCandidateType == kD0toKpiLikeSign) {
-          hname = TString::Format("%s/fHistRejectedDMesonInvMass", GetName());
-          fHistManager->FillTH1(hname, dmeson_pair.second.fD.M());
-        }
-        else if (fCandidateType == kDstartoKpipi) {
-          hname = TString::Format("%s/fHistRejectedDMeson2ProngInvMass", GetName());
-          fHistManager->FillTH1(hname, dmeson_pair.second.fInvMass2Prong);
-
-          hname = TString::Format("%s/fHistRejectedDMesonDeltaInvMass", GetName());
-          fHistManager->FillTH1(hname, dmeson_pair.second.fD.M() - dmeson_pair.second.fInvMass2Prong);
-        }
-      }
-    }
-  }
-
-  if (fMCMode == kSignalOnly || fMCMode == kMCTruth) {
-    hname = TString::Format("%s/fHistPartonPt", GetName());
-    TH1* histPartonPt = static_cast<TH1*>(fHistManager->FindObject(hname));
-    hname = TString::Format("%s/fHistPartonEta", GetName());
-    TH1* histPartonEta = static_cast<TH1*>(fHistManager->FindObject(hname));
-    hname = TString::Format("%s/fHistPartonPhi", GetName());
-    TH1* histPartonPhi = static_cast<TH1*>(fHistManager->FindObject(hname));
-    hname = TString::Format("%s/fHistPartonType", GetName());
-    TH1* histPartonType = static_cast<TH1*>(fHistManager->FindObject(hname));
-
-    for (auto parton : fPartons) {
-      if (!parton.first) continue;
-      histPartonPt->Fill(parton.first->Pt());
-      histPartonEta->Fill(parton.first->Eta());
-      histPartonPhi->Fill(TVector2::Phi_0_2pi(parton.first->Phi()));
-      histPartonType->Fill(parton.second);
-    }
-  }
-
-  return kTRUE;
-}
-
-/// Post the output with D meson jets found in the current event
-///
-/// \return kTRUE on success
-Bool_t AliAnalysisTaskDmesonJets::AnalysisEngine::FillHnSparse(Bool_t applyKinCuts)
-{
-  TString hname;
-
-  for (auto& dmeson_pair : fDmesonJets) {
-    if (!IsAnyJetInAcceptance(dmeson_pair.second)) {
-      hname = TString::Format("%s/fHistRejectedDMesonPt", GetName());
-      fHistManager->FillTH1(hname, dmeson_pair.second.fD.Pt());
-      hname = TString::Format("%s/fHistRejectedDMesonPhi", GetName());
-      fHistManager->FillTH1(hname, dmeson_pair.second.fD.Phi_0_2pi());
-      hname = TString::Format("%s/fHistRejectedDMesonEta", GetName());
-      fHistManager->FillTH1(hname, dmeson_pair.second.fD.Eta());
-    }
-  }
-
-  for (auto &jetDef : fJetDefinitions) {
-
-    hname = TString::Format("%s/%s/fDmesonJets", GetName(), jetDef.GetName());
-    THnSparse* h = static_cast<THnSparse*>(fHistManager->FindObject(hname));
-
-    for (auto& dmeson_pair : fDmesonJets) {
-      const AliJetInfo* jet = dmeson_pair.second.GetJet(jetDef.GetName());
-      if (!jet) continue;
-      if (!jetDef.IsJetInAcceptance(*jet)) {
-        hname = TString::Format("%s/%s/fHistRejectedJetPt", GetName(), jetDef.GetName());
-        fHistManager->FillTH1(hname, jet->Pt());
-        hname = TString::Format("%s/%s/fHistRejectedJetPhi", GetName(), jetDef.GetName());
-        fHistManager->FillTH1(hname, jet->Phi_0_2pi());
-        hname = TString::Format("%s/%s/fHistRejectedJetEta", GetName(), jetDef.GetName());
-        fHistManager->FillTH1(hname, jet->Eta());
-        continue;
-      }
-      FillHnSparse(h, dmeson_pair.second, jetDef.GetName());
-    }
-  }
-
-  return kTRUE;
-}
-
-/// Fill a THnSparse using information from a AliDmesonJetInfo object
-///
-/// \param h          Valid pointer to a THnSparse object
-/// \param DmesonJet  Const reference to an AliDmesonJetInfo object
-/// \param n          Jet name
-Bool_t AliAnalysisTaskDmesonJets::AnalysisEngine::FillHnSparse(THnSparse* h, const AliDmesonJetInfo& DmesonJet, std::string n)
-{
-  // Fill the THnSparse histogram.
-
-  Double_t contents[30] = {0.};
-
-  Double_t z = DmesonJet.GetZ(n);
-  Double_t deltaPhi = 0;
-  Double_t deltaEta = 0;
-  Double_t deltaR = DmesonJet.GetDistance(n, deltaEta, deltaPhi);
-
-  std::map<std::string, AliJetInfo>::const_iterator it = DmesonJet.fJets.find(n);
-  if (it == DmesonJet.fJets.end()) return kFALSE;
-
-  for (Int_t i = 0; i < h->GetNdimensions(); i++) {
-    TString title(h->GetAxis(i)->GetTitle());
-    if      (title=="#it{p}_{T,D} (GeV/#it{c})")                     contents[i] = DmesonJet.fD.Pt();
-    else if (title=="#eta_{D}")                                      contents[i] = DmesonJet.fD.Eta();
-    else if (title=="#phi_{D} (rad)")                                contents[i] = DmesonJet.fD.Phi_0_2pi();
-    else if (title=="#it{M}_{K#pi} (GeV/#it{c}^{2})")                contents[i] = DmesonJet.fInvMass2Prong > 0 ? DmesonJet.fInvMass2Prong : DmesonJet.fD.M();
-    else if (title=="#it{M}_{K#pi#pi} (GeV/#it{c}^{2})")             contents[i] = DmesonJet.fD.M();
-    else if (title=="#it{M}_{K#pi#pi} - #it{M}_{K#pi} (GeV/#it{c}^{2})") contents[i] = DmesonJet.fD.M() - DmesonJet.fInvMass2Prong;
-    else if (title=="#it{p}_{T,#pi} (GeV/#it{c})")                   contents[i] = DmesonJet.fSoftPionPt;
-    else if (title=="#it{z}_{D}")                                    contents[i] = z;
-    else if (title=="#Delta R_{D-jet}")                              contents[i] = deltaR;
-    else if (title=="#eta_{D} - #eta_{jet}")                         contents[i] = deltaEta;
-    else if (title=="#phi_{D} - #phi_{jet} (rad)")                   contents[i] = deltaPhi;
-    else if (title=="#it{p}_{T,jet} (GeV/#it{c})")                   contents[i] = (*it).second.Pt();
-    else if (title=="#eta_{jet}")                                    contents[i] = (*it).second.Eta();
-    else if (title=="#phi_{jet} (rad)")                              contents[i] = (*it).second.Phi_0_2pi();
-    else if (title=="No. of constituents")                           contents[i] = (*it).second.fNConstituents;
-    else AliWarning(Form("Unable to fill dimension '%s'!",title.Data()));
-  }
-
-  h->Fill(contents);
-
-  return kTRUE;
-}
 
 // Definitions of class AliAnalysisTaskDmesonJets
 
@@ -2974,18 +3042,33 @@ void AliAnalysisTaskDmesonJets::UserCreateOutputObjects()
     }
     switch (fOutputType) {
     case kTreeOutput:
-      param.BuildTree(GetName());
+    {
+      OutputHandlerTTree* tree_handler = new OutputHandlerTTree(&param);
+      param.fOutputHandler = tree_handler;
+      tree_handler->BuildOutputObject(GetName());
       if (treeSlot < fNOutputTrees) {
-        param.AssignDataSlot(treeSlot+2);
+        tree_handler->AssignDataSlot(treeSlot+2);
         treeSlot++;
-        PostDataFromAnalysisEngine(param);
+        PostDataFromAnalysisEngine(tree_handler);
       }
       else {
         AliError(Form("Number of data output slots %d not sufficient. Tree of analysis engine %s will not be posted!", fNOutputTrees, param.GetName()));
       }
+    }
       break;
     case kTHnOutput:
-      param.BuildHnSparse(fEnabledAxis);
+    {
+      OutputHandlerTHnSparse* thnsparse_handler = new OutputHandlerTHnSparse(&param);
+      param.fOutputHandler = thnsparse_handler;
+      thnsparse_handler->SetEnabledAxis(fEnabledAxis);
+      thnsparse_handler->BuildOutputObject(GetName());
+    }
+      break;
+    case kOnlyQAOutput:
+    {
+      OutputHandler* qa_handler = new OutputHandler(&param);
+      param.fOutputHandler = qa_handler;
+    }
       break;
     case kNoOutput:
       break;
@@ -3189,14 +3272,8 @@ Bool_t AliAnalysisTaskDmesonJets::FillHistograms()
 {
   for (auto &param : fAnalysisEngines) {
     if (param.fInhibit) continue;
-
-    if (fOutputType == kTreeOutput) {
-      param.FillTree(fApplyKinematicCuts);
-      PostDataFromAnalysisEngine(param);
-    }
-    else if (fOutputType == kTHnOutput) {
-      param.FillHnSparse(fApplyKinematicCuts);
-    }
+    param.fOutputHandler->FillOutput(fApplyKinematicCuts);
+    PostDataFromAnalysisEngine(param.fOutputHandler);
   }
   if (fMCContainer) FillPartonLevelHistograms();
   return kTRUE;
@@ -3404,11 +3481,11 @@ const char* AliAnalysisTaskDmesonJets::GetHFEventRejectionReasonLabel(UInt_t& bi
 /// \param eng Constant reference to an analysis engine
 ///
 /// \return -1 if unsuccessful, an integer number corresponding to the data slot if successful
-Int_t AliAnalysisTaskDmesonJets::PostDataFromAnalysisEngine(const AnalysisEngine& eng)
+Int_t AliAnalysisTaskDmesonJets::PostDataFromAnalysisEngine(OutputHandler const* handler)
 {
-  if (eng.GetDataSlotNumber() >= 0 && eng.GetTree()) {
-    PostData(eng.GetDataSlotNumber(), eng.GetTree());
-    return eng.GetDataSlotNumber();
+  if (handler->GetDataSlotNumber() >= 0 && handler->GetOutputObject()) {
+    PostData(handler->GetDataSlotNumber(), handler->GetOutputObject());
+    return handler->GetDataSlotNumber();
   }
   else {
     return -1;
@@ -3435,7 +3512,7 @@ AliAnalysisTaskDmesonJets* AliAnalysisTaskDmesonJets::AddTaskDmesonJets(TString 
   // Check the analysis type using the event handlers connected to the analysis manager
   AliVEventHandler* handler = mgr->GetInputEventHandler();
   if (!handler) {
-    ::Error("AddTaskEmcalJetSpectraQA", "This task requires an input event handler");
+    ::Error("AddTaskDmesonJets", "This task requires an input event handler");
     return NULL;
   }
 

--- a/PWGJE/FlavourJetTasks/AliAnalysisTaskDmesonJetsDetectorResponse.cxx
+++ b/PWGJE/FlavourJetTasks/AliAnalysisTaskDmesonJetsDetectorResponse.cxx
@@ -373,7 +373,7 @@ AliAnalysisTaskDmesonJetsDetectorResponse::AliAnalysisTaskDmesonJetsDetectorResp
   fHistManagerResponse(),
   fResponseEngines()
 {
-  fOutputType = kNoOutput;
+  fOutputType = kOnlyQAOutput;
 }
 
 /// This is the standard named constructor.
@@ -384,7 +384,7 @@ AliAnalysisTaskDmesonJetsDetectorResponse::AliAnalysisTaskDmesonJetsDetectorResp
   fHistManagerResponse(TString::Format("%s_QA", name)),
   fResponseEngines()
 {
-  fOutputType = kNoOutput;
+  fOutputType = kOnlyQAOutput;
 }
 
 /// Creates the output containers.
@@ -495,7 +495,7 @@ Bool_t AliAnalysisTaskDmesonJetsDetectorResponse::FillHistograms()
   for (auto &ana : fAnalysisEngines) {
     if (ana.IsInhibit()) continue;
 
-    ana.FillQA(fApplyKinematicCuts);
+    ana.GetOutputHandler()->FillOutput(fApplyKinematicCuts);
   }
 
   if (fMCContainer) FillPartonLevelHistograms();
@@ -508,12 +508,12 @@ Bool_t AliAnalysisTaskDmesonJetsDetectorResponse::FillHistograms()
 /// \param b Output type (none, tree, thn)
 void AliAnalysisTaskDmesonJetsDetectorResponse::SetOutputTypeInternal(EOutputType_t b)
 {
-  if (fOutputType != kNoOutput && fOutputType != kTreeOutput) {
+  if (fOutputType != kOnlyQAOutput && fOutputType != kNoOutput && fOutputType != kTreeOutput) {
     AliWarning("This class only provides a tree output.");
   }
 
-  // Always set it to kNoOutput: base class does not generate any output (other than QA histograms), all the output comes from the derived class
-  fOutputType = kNoOutput;
+  // Always set it to kOnlyQAOutput: base class does not generate any output (other than QA histograms), all the output comes from the derived class
+  fOutputType = kOnlyQAOutput;
 }
 
 /// Post the tree of an response engine in the data slot (if the tree exists and the data slot has been assigned)

--- a/PWGJE/FlavourJetTasks/PWGJEFlavourJetTasksLinkDef.h
+++ b/PWGJE/FlavourJetTasks/PWGJEFlavourJetTasksLinkDef.h
@@ -33,6 +33,14 @@
 #pragma link C++ class AliAnalysisTaskDmesonJets::AliDStarInfoSummary+;
 #pragma link C++ class AliAnalysisTaskDmesonJets::AliJetInfoSummary+;
 #pragma link C++ class AliAnalysisTaskDmesonJets::AliJetInfoPbPbSummary+;
+#pragma link C++ class AliAnalysisTaskDmesonJets::AliEventInfoSummary+;
+#pragma link C++ class std::vector<AliAnalysisTaskDmesonJets::AliDmesonInfoSummary>+;
+#pragma link C++ class std::vector<AliAnalysisTaskDmesonJets::AliDmesonMCInfoSummary>+;
+#pragma link C++ class std::vector<AliAnalysisTaskDmesonJets::AliD0InfoSummary>+;
+#pragma link C++ class std::vector<AliAnalysisTaskDmesonJets::AliD0ExtendedInfoSummary>+;
+#pragma link C++ class std::vector<AliAnalysisTaskDmesonJets::AliDStarInfoSummary>+;
+#pragma link C++ class std::vector<AliAnalysisTaskDmesonJets::AliJetInfoSummary>+;
+#pragma link C++ class std::vector<AliAnalysisTaskDmesonJets::AliJetInfoPbPbSummary>+;
 #pragma link C++ class AliAnalysisTaskDmesonJets::AnalysisEngine+;
 #pragma link C++ class AliAnalysisTaskDmesonJets::AliHFJetDefinition+;
 #pragma link C++ class std::pair<int,AliAnalysisTaskDmesonJets::AliDmesonJetInfo>+;


### PR DESCRIPTION
This PR implements the event weight in the output for 3 tasks:

- The base class AliAnalysisTaskEmcalLight
- The inclusive jet analysis AliAnalysisTaskEmcalJetTree
- The D-meson tagged jet analysis AliAnalysisTaskDmesonJets