### PR TITLE
[EMCAL-180] Apply EMCAL trigger bit selection to all cases

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerBase.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerBase.cxx
@@ -291,11 +291,11 @@ void AliAnalysisTaskEmcalTriggerBase::TriggerSelection(){
 		  AliVEvent::kEMC7|AliVEvent::kEMC8, AliVEvent::kEMCEGA, AliVEvent::kEMCEGA, AliVEvent::kEMCEJE, AliVEvent::kEMCEJE
       };
       for(int iclass = 0; iclass < AliEmcalTriggerOfflineSelection::kTrgn; iclass++){
-        emcalTriggers[iclass] &= bool(selectionstatus & kSelectTriggerBits[iclass]);
-        emc8Triggers[iclass] &= bool(selectionstatus & kSelectTriggerBits[iclass]);
+        if(!(selectionstatus & kSelectTriggerBits[iclass])) {
+          emcNoIntTriggers[iclass] = emc8Triggers[iclass] = emcalTriggers[iclass] = false;
+        }
         if(fRequireL0forL1 && !bool(selectionstatus & (AliVEvent::kEMC7|AliVEvent::kEMC8))) {
-          emcalTriggers[iclass] = false;
-          emc8Triggers[iclass] = false;
+          emcNoIntTriggers[iclass] = emc8Triggers[iclass] = emcalTriggers[iclass] = false;
         }
       }
     }


### PR DESCRIPTION
Instead of separate &= operations use check for the triggerbit
for all INT (INT76, INT8, NoINT) cases