### PR TITLE
[EMCAL-51] Fix mapping for small supermodules in run2

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.cxx
@@ -388,7 +388,7 @@ void AliEmcalTriggerMakerTask::InitializeFastORMaskingFromOCDB(){
       for(unsigned int ibit = 0; ibit < 16; ibit ++){
         if((truconf->GetMaskReg(ifield) >> ibit) & 0x1){
           try{
-            fGeom->GetTriggerMapping()->GetAbsFastORIndexFromTRU(RemapTRUIndex(itru), (ic =  GetMaskHandler()(ifield, ibit)), fastOrAbsID);
+            fGeom->GetTriggerMapping()->GetAbsFastORIndexFromTRU(RemapTRUIndex(itru), (ic =  GetMaskHandler(itru)(ifield, ibit)), fastOrAbsID);
             AliDebugStream(1) << GetName() << "Channel " << ic  << " in TRU " << itru << " ( abs fastor " << fastOrAbsID << ") masked." << std::endl;
             fTriggerMaker->AddFastORBadChannel(fastOrAbsID);
           } catch (int exept){
@@ -415,8 +415,9 @@ void AliEmcalTriggerMakerTask::InitializeFastORMaskingFromOADB(){
 }
 
 
-std::function<int (unsigned int, unsigned int)> AliEmcalTriggerMakerTask::GetMaskHandler() const {
-  if(fGeom->GetTriggerMappingVersion() == 2){
+std::function<int (unsigned int, unsigned int)> AliEmcalTriggerMakerTask::GetMaskHandler(int itru) const {
+  bool isTRUsmallSM = ((itru >= 30 && itru < 31) || (itru >= 44 && itru < 45)) ;
+  if(fGeom->GetTriggerMappingVersion() == 2 && !isTRUsmallSM){
     // Run 2 - complicated TRU layout in 6 subregions
     return [] (unsigned int ifield, unsigned int ibit) -> int {
       if(ifield >= 6 || ibit >= 16) throw kInvalidChannelException;

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.h
@@ -212,11 +212,22 @@ protected:
 
 #if !(defined(__CINT__) || defined(__MAKECINT__))
   /**
+   * @brief Create functor handling the conversion between reg mask and channel
+   * 
    * Closure producing a handler converting a set of mask / bit number into a channel
    * ID. In case the mask / bit number is invalid the function will return -1
    * @return function that converts a set of mask / bit number into a channel ID
+   * 
+   * The handling is different for LHC run1 and LHC run2 due to different TRU geometry:
+   * - In run1 a linear indexing was applied
+   * - In run2 the indexing is not linear for the TRUs in the full and DCAL supermodules,
+   *   while it follows the linear indexing for the 1/3rd supermodules
+   * Due to run2 definitions the handlers are created based on the index of the TRU
+   * using L0 convention.
+   * 
+   * @param[in] itru Index of the TRU (L0 convention, without remapping)
    */
-  std::function<int (unsigned int, unsigned int)> GetMaskHandler() const;
+  std::function<int (unsigned int, unsigned int)> GetMaskHandler(int itru) const;
 #endif
 
  /**


### PR DESCRIPTION
TRUs in the small supermodules still follow the linear
mapping between channels and bits in reg mask, used
in run1 and not the mapping used for the TRUs  in the
other supermodules (EMCAL full or DCAL 2/3rd). The mask
handler is created accordingly based on the TRU index
based on the L0 convention.