### PR TITLE
Modified track rotation and mixed event for Ds using pi and phi

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskCombinHF.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskCombinHF.h
@@ -137,6 +137,7 @@ private:
   AliAnalysisTaskCombinHF(const AliAnalysisTaskCombinHF &source);
   AliAnalysisTaskCombinHF& operator=(const AliAnalysisTaskCombinHF& source);
   Double_t ComputeInvMassKK(AliAODTrack* tr1, AliAODTrack* tr2) const;
+  Double_t ComputeInvMassKK(TLorentzVector* tr1, TLorentzVector* tr2) const;
 
   TList   *fOutput; //!<! list send on output slot 0
   TH1F *fHistNEvents;         //!<!hist. for No. of events


### PR DESCRIPTION
Modified track rotation and mixed event for Ds considering it as 2 prong, using phi and pion instead of kaons and pion:

1) for track rotation the pion is rotated and the phi (kaon pair) not
2) for mixed event the pion is taken from an event and the phi (kaon pair) from another one