### PR TITLE
[EMCAL-56, EMCAL-180] Exclude/Require trigger coincidence

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalClustersRef.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalClustersRef.h
@@ -156,6 +156,25 @@ public:
   void SetUseExclusiveTriggers(Bool_t doUse) { fUseExclusiveTriggers = doUse; }
 
   /**
+   * @brief Add trigger for which overlap is required
+   * 
+   * Event is only selected if the trigger fires as well
+   * 
+   * @param[in] trigger Trigger for which overlap is required 
+   */
+  void AddRequiredTriggerOverlap(const char *trigger);
+
+  /**
+   * @brief Add trigger for which overlap is excluded
+   * 
+   * Event is only selected if the trigger does not fire the event in addition
+   * (histos of this trigger will of course be empty)
+   * 
+   * @param[in] trigger Trigger for which overlap is excluded 
+   */
+  void AddExcludedTriggerOverlap(const char *trigger);
+
+  /**
    * @brief Preconfigure task so that it can be used in subwagons
    * @param[in] nClusters Name of the input cluster container
    * @param[in] suffix Suffix of the subwagon
@@ -237,6 +256,8 @@ protected:
   Bool_t                              fUseExclusiveTriggers;      ///< Include exclusive triggers (without lower threshold triggers)
   AliCutValueRange<double>            fClusterTimeRange;          ///< Selected range on cluster time
   std::vector<TriggerCluster_t>       fTriggerClusters;           //!<! Detected trigger clusters for event
+  TObjArray                           fRequiredOverlaps;          ///< Add option to require overlap with certain triggers
+  TObjArray                           fExcludedOverlaps;          ///< Add option to exclude overlap with certain triggers
 
 private:
 

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalRecalcPatchesRef.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalRecalcPatchesRef.cxx
@@ -34,6 +34,7 @@
 #include <THistManager.h>
 #include <TLinearBinning.h>
 #include <TList.h>
+#include <TObjString.h>
 #include <TString.h>
 #include "AliAnalysisManager.h"
 #include "AliEMCALTriggerPatchInfo.h"
@@ -48,7 +49,9 @@ AliAnalysisTaskEmcalRecalcPatchesRef::AliAnalysisTaskEmcalRecalcPatchesRef():
   AliAnalysisTaskEmcalTriggerBase(),
   fEnableSumw2(false),
   fOnlineThresholds(),
-  fSwapPatches(false)
+  fSwapPatches(false),
+  fRequiredOverlaps(),
+  fExcludedOverlaps()
 {
 
 }
@@ -57,7 +60,9 @@ AliAnalysisTaskEmcalRecalcPatchesRef::AliAnalysisTaskEmcalRecalcPatchesRef(const
   AliAnalysisTaskEmcalTriggerBase(name),
   fEnableSumw2(false),
   fOnlineThresholds(),
-  fSwapPatches(false)
+  fSwapPatches(false),
+  fRequiredOverlaps(),
+  fExcludedOverlaps()
 {
   fOnlineThresholds.Set(8);
 }
@@ -99,6 +104,36 @@ void AliAnalysisTaskEmcalRecalcPatchesRef::CreateUserHistos(){
       fHistos->CreateTHnSparse(Form("hAllPatches%c%s%s%s", detector, patchtype, kt.data(), kc.data()), Form("Fired %c%s patches for trigger %s (cluster %s)", detector, patchtype, kt.data(), kc.data()), 3, allpatchbinning, fEnableSumw2 ? "s" : "");
     } 
   }
+}
+
+bool AliAnalysisTaskEmcalRecalcPatchesRef::IsUserEventSelected(){
+  // handle overlaps
+  if(fRequiredOverlaps.GetEntries() || fExcludedOverlaps.GetEntries()){
+    if(fRequiredOverlaps.GetEntries()){
+      Bool_t allFound(true);
+      for(auto t : fRequiredOverlaps){
+        auto trgstr = static_cast<TObjString *>(t)->String();
+        if(std::find_if(fSelectedTriggers.begin(), fSelectedTriggers.end(), [&trgstr](const TString &seltrigger) -> bool { return seltrigger.Contains(trgstr); }) == fSelectedTriggers.end()) {
+          allFound = false;
+          break;
+        }
+      }
+      if(!allFound) return false;
+    }
+
+    if(fExcludedOverlaps.GetEntries()){
+      Bool_t oneFound(false);
+      for(auto t : fExcludedOverlaps){
+        auto trgstr = static_cast<TObjString *>(t)->String();
+        if(std::find_if(fSelectedTriggers.begin(), fSelectedTriggers.end(), [&trgstr](const TString &seltrigger) -> bool { return seltrigger.Contains(trgstr); }) != fSelectedTriggers.end()) {
+          oneFound = true;
+          break;
+        }
+      }
+      if(oneFound) return false;
+    }
+  }
+  return true;
 }
 
 void AliAnalysisTaskEmcalRecalcPatchesRef::UserFillHistosAfterEventSelection(){
@@ -308,6 +343,16 @@ bool AliAnalysisTaskEmcalRecalcPatchesRef::HasOverlap(const AliEMCALTriggerPatch
   if((InRange(testcolmin, refcolmin, refcolmax) && InRange(testrowmin, refrowmin, refrowmax)) ||
      (InRange(testcolmax, refcolmin, refcolmax) && InRange(testrowmax, refrowmin, refrowmax))) return true;
   return false;
+}
+
+void AliAnalysisTaskEmcalRecalcPatchesRef::AddRequiredTriggerOverlap(const char *trigger){
+  if(fRequiredOverlaps.FindObject(trigger)) return;
+  fRequiredOverlaps.Add(new TObjString(trigger));
+}
+
+void AliAnalysisTaskEmcalRecalcPatchesRef::AddExcludedTriggerOverlap(const char *trigger){
+  if(fExcludedOverlaps.FindObject(trigger)) return;
+  fExcludedOverlaps.Add(new TObjString(trigger));
 }
 
 AliAnalysisTaskEmcalRecalcPatchesRef *AliAnalysisTaskEmcalRecalcPatchesRef::AddTaskEmcalRecalcPatches(const char *suffix) {

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalRecalcPatchesRef.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalRecalcPatchesRef.h
@@ -62,11 +62,15 @@ public:
 
   void SetSwapPatches(Bool_t doSwap) { fSwapPatches = doSwap; }
 
+  void AddRequiredTriggerOverlap(const char *trigger);
+  void AddExcludedTriggerOverlap(const char *trigger);
+
   static AliAnalysisTaskEmcalRecalcPatchesRef *AddTaskEmcalRecalcPatches(const char *suffix);
 
 protected:
   virtual void CreateUserObjects() {}
   virtual void CreateUserHistos();
+  virtual bool IsUserEventSelected();
   virtual bool Run();
   virtual void UserFillHistosAfterEventSelection();
   std::vector<const AliEMCALTriggerPatchInfo *> SelectAllPatchesByType(const TClonesArray &patches, EPatchType_t patchtype) const;
@@ -80,6 +84,8 @@ private:
   Bool_t                fEnableSumw2;         ///< Enable sum of weights
   TArrayI               fOnlineThresholds;    ///< Online thresholds
   Bool_t                fSwapPatches;         ///< Look explicitly for the wrong patches
+  TObjArray             fRequiredOverlaps;    ///< Add option to require overlap with certain triggers
+  TObjArray             fExcludedOverlaps;    ///< Add option to exclude overlap with certain triggers
 
   AliAnalysisTaskEmcalRecalcPatchesRef(const AliAnalysisTaskEmcalRecalcPatchesRef &);
   AliAnalysisTaskEmcalRecalcPatchesRef &operator=(const AliAnalysisTaskEmcalRecalcPatchesRef &);


### PR DESCRIPTION
Require or exclude coincidence of a trigger with a certain
list of triggers. Needed in order to check overlap of the
jet trigger with the gamma trigger.