### PR TITLE
[EMCAL-180] Monitoring for leading jets and leading constituents

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetConstituentQA.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetConstituentQA.h
@@ -43,13 +43,14 @@ public:
   AliAnalysisTaskEmcalJetConstituentQA(const char *name);
   virtual ~AliAnalysisTaskEmcalJetConstituentQA();
 
-  static AliAnalysisTaskEmcalJetConstituentQA *AddTaskEmcalJetConstituentQA(const char *trigger, bool parmode = kFALSE);
+  static AliAnalysisTaskEmcalJetConstituentQA *AddTaskEmcalJetConstituentQA(const char *trigger, AliJetContainer::EJetType_t jettype, bool parmode = kFALSE);
 
   void SetTriggerSelection(const char *trigger) { fTriggerSelectionString = trigger; } 
   void SetNameTrackContainer(const char *name) { fNameTrackContainer = name; }
   void SetNameClusterContainer(const char *name) { fNameClusterContainer = name; }
   void AddNameJetContainer(const char *name) { fNamesJetContainers.Add(new TObjString(name)); }
   void SetUseTriggerSelection(Bool_t doUse) { fUseTriggerSelection = doUse; }
+  void SetJetType(AliJetContainer::EJetType_t jettype) { fJetType = jettype; }
 
 protected:
   virtual void UserCreateOutputObjects();
@@ -58,6 +59,7 @@ protected:
 private:
   THistManager                  *fHistos;                   ///< Histogram manager
 
+  AliJetContainer::EJetType_t   fJetType;                   ///< Jet type
   TString                       fNameTrackContainer;        ///< Name of the track container
   TString                       fNameClusterContainer;      ///< Name of the cluster container
   TObjArray                     fNamesJetContainers;        ///< Names of the connected jet container

--- a/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJetConstituentQA.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJetConstituentQA.C
@@ -1,3 +1,3 @@
-EmcalTriggerJets::AliAnalysisTaskEmcalJetConstituentQA *AddTaskEmcalJetConstituentQA(bool part, const char *trigger) {
-  return EmcalTriggerJets::AliAnalysisTaskEmcalJetConstituentQA::AddTaskEmcalJetConstituentQA(trigger, part);
+EmcalTriggerJets::AliAnalysisTaskEmcalJetConstituentQA *AddTaskEmcalJetConstituentQA(AliJetContainer::EJetType_t jettype, bool part, const char *trigger) {
+  return EmcalTriggerJets::AliAnalysisTaskEmcalJetConstituentQA::AddTaskEmcalJetConstituentQA(trigger, jettype, part);
 }


### PR DESCRIPTION
Monitoring for leading jets
- THnSparse with Lorentz vector
- Leading cluster
- Leading track

Monitoring for leading constituents
- pt(jet)
- NEF(jet)
- pt(const)
- z(const)
- DR(jet,const)

In addition add support for charged and neutral jets