### PR TITLE
Using AliExternalTrackParam::BetheBlochAleph instead of AliMathBase::…

### DIFF
--- a/PWGCF/EBYE/IdentityMethodEbyeFluctuations/tasks/AliAnalysisTaskEbyeIterPID.cxx
+++ b/PWGCF/EBYE/IdentityMethodEbyeFluctuations/tasks/AliAnalysisTaskEbyeIterPID.cxx
@@ -37,7 +37,7 @@
 #include "TF1.h"
 #include "TFile.h"
 #include "TDatabasePDG.h"
-#include "AliMathBase.h"
+#include "AliExternalTrackParam.h"
 #include "AliAnalysisTaskSE.h"
 #include "AliAnalysisManager.h"
 #include "AliTPCdEdxInfo.h"
@@ -3328,14 +3328,14 @@ void  AliAnalysisTaskEbyeIterPID::SelectCleanSamplesFromV0s(AliESDv0 *v0, AliESD
   Double_t EPullEff  = v0->GetEffMass(0,0)/TMath::Sqrt((5e-03)*(5e-03)+(1.e-04*v0->Pt())*(1.e-04*v0->Pt()));
 
   // 
-  //   tree->SetAlias("dEdx0DProton","AliMathBase::BetheBlochAleph(track0.fIp.P()/massProton)");
-  //   tree->SetAlias("dEdx1DProton","AliMathBase::BetheBlochAleph(track1.fIp.P()/massProton)");
-  //   tree->SetAlias("dEdx0DPion","AliMathBase::BetheBlochAleph(track0.fIp.P()/massPion)");
-  //   tree->SetAlias("dEdx1DPion","AliMathBase::BetheBlochAleph(track1.fIp.P()/massPion)");
-  Double_t dEdx0DProton = AliMathBase::BetheBlochAleph(track0->GetInnerParam()->GetP()/massProton);
-  Double_t dEdx1DProton = AliMathBase::BetheBlochAleph(track1->GetInnerParam()->GetP()/massProton);
-  Double_t dEdx0DPion   = AliMathBase::BetheBlochAleph(track0->GetInnerParam()->GetP()/massPion);
-  Double_t dEdx1DPion   = AliMathBase::BetheBlochAleph(track1->GetInnerParam()->GetP()/massPion);
+  //   tree->SetAlias("dEdx0DProton","AliExternalTrackParam::BetheBlochAleph(track0.fIp.P()/massProton)");
+  //   tree->SetAlias("dEdx1DProton","AliExternalTrackParam::BetheBlochAleph(track1.fIp.P()/massProton)");
+  //   tree->SetAlias("dEdx0DPion","AliExternalTrackParam::BetheBlochAleph(track0.fIp.P()/massPion)");
+  //   tree->SetAlias("dEdx1DPion","AliExternalTrackParam::BetheBlochAleph(track1.fIp.P()/massPion)");
+  Double_t dEdx0DProton = AliExternalTrackParam::BetheBlochAleph(track0->GetInnerParam()->GetP()/massProton);
+  Double_t dEdx1DProton = AliExternalTrackParam::BetheBlochAleph(track1->GetInnerParam()->GetP()/massProton);
+  Double_t dEdx0DPion   = AliExternalTrackParam::BetheBlochAleph(track0->GetInnerParam()->GetP()/massPion);
+  Double_t dEdx1DPion   = AliExternalTrackParam::BetheBlochAleph(track1->GetInnerParam()->GetP()/massPion);
 
   //   tree->SetAlias("K0Like0","exp(-K0Pull^2)*livetimeLikeK0");
   //   tree->SetAlias("LLike0","exp(-LPull^2)*livetimeLikeLambda");

--- a/PWGPP/TPC/AliMCInfo.cxx
+++ b/PWGPP/TPC/AliMCInfo.cxx
@@ -49,7 +49,7 @@ IMPORTANT FOR PROOF FAST PROTOTYPING ANALYSIS
 //ALIROOT includes
 #include "AliTrackReference.h"
 #include "AliMCInfo.h" 
-#include "AliMathBase.h" 
+#include "AliExternalTrackParam.h" 
 #endif
 
 //
@@ -230,7 +230,7 @@ void AliMCInfo::Update()
 			      fTrackRef.Pz()*fTrackRef.Pz());    
       if (p>0.001){
 	Float_t betagama = p /fMass;
-	fPrim = AliMathBase::BetheBlochAleph(betagama);
+	fPrim = AliExternalTrackParam::BetheBlochAleph(betagama);
       }else fPrim=0;
     }
   }else{

--- a/PWGPP/TPC/AliTPCComparisonPID.cxx
+++ b/PWGPP/TPC/AliTPCComparisonPID.cxx
@@ -18,7 +18,7 @@
 #include "AliStack.h"
 #include "AliMCEvent.h"
 #include "AliMCEventHandler.h"
-#include "AliMathBase.h"
+#include "AliExternalTrackParam.h"
 
 #include <AliESD.h>
 #include "AliExternalTrackParam.h"
@@ -289,7 +289,7 @@ void  AliTPCComparisonPID::ProcessMCInfo(){
     Double_t dedx=track->GetTPCsignal();
     Double_t mass = particle->GetMass();
     Double_t bg  =mom/mass;
-    Double_t betheBloch = AliMathBase::BetheBlochAleph(bg);
+    Double_t betheBloch = AliExternalTrackParam::BetheBlochAleph(bg);
     //
     // Fill histos
     //

--- a/PWGPP/TPC/AliTPCtaskPID.cxx
+++ b/PWGPP/TPC/AliTPCtaskPID.cxx
@@ -55,7 +55,7 @@
 #include "AliStack.h"
 #include "AliMCEvent.h"
 #include "AliMCEventHandler.h"
-#include "AliMathBase.h"
+#include "AliExternalTrackParam.h"
 
 #include <AliESD.h>
 #include "AliExternalTrackParam.h"
@@ -339,7 +339,7 @@ void  AliTPCtaskPID::ProcessMCInfo(){
     Double_t dedx=track->GetTPCsignal();
     Double_t mass = particle->GetMass();
     Double_t bg  =mom/mass;
-    Double_t betheBloch = AliMathBase::BetheBlochAleph(bg);
+    Double_t betheBloch = AliExternalTrackParam::BetheBlochAleph(bg);
     //
     // Fill histos
     //


### PR DESCRIPTION
AliMathBase::BetheBlochAleph is just a wrapper that creates useless dependency between STEERBase and STAT, replacing its call by the original method AliExternalTrackParam::BetheBlochAleph.