### PR TITLE
Modified V0Reader cut string to be the same in all AddTasks (calo, co…

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_GammaCaloMerged_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCaloMerged_pp.C
@@ -141,7 +141,7 @@ void AddTask_GammaCaloMerged_pp(  Int_t     trainConfig                 = 1,    
   Printf("here \n");
 
   //=========  Set Cutnumber for V0Reader ================================
-  TString cutnumberPhoton           = "00000008400100001500000000";
+  TString cutnumberPhoton           = "00000008400000000100000000";
   TString cutnumberEvent            = "00000003";
   Bool_t doEtaShift                 = kFALSE;
   AliAnalysisDataContainer *cinput  = mgr->GetCommonInputContainer();

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
@@ -148,7 +148,7 @@ void AddTask_GammaCalo_pp(  Int_t     trainConfig                   = 1,        
   Printf("here \n");
 
   //=========  Set Cutnumber for V0Reader ================================
-  TString cutnumberPhoton = "00000008400100001500000000";
+  TString cutnumberPhoton = "00000008400000000100000000";
   TString cutnumberEvent = "00000003";
   Bool_t doEtaShift = kFALSE;
   AliAnalysisDataContainer *cinput = mgr->GetCommonInputContainer();

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
@@ -150,7 +150,7 @@ void AddTask_GammaConvCalo_pp(  Int_t     trainConfig                   = 1,    
   Printf("here \n");
 
   //=========  Set Cutnumber for V0Reader ================================
-  TString cutnumberPhoton = "00000008400100001500000000";
+  TString cutnumberPhoton = "00000008400000000100000000";
   TString cutnumberEvent = "00000003";
   Bool_t doEtaShift = kFALSE;
   AliAnalysisDataContainer *cinput = mgr->GetCommonInputContainer();


### PR DESCRIPTION
…nv, convcalo). This should avoid problems when using wagons from different groups within the same train.