### PR TITLE
New simple task for trigger correlation

### DIFF
--- a/PWGJE/EMCALJetTasks/CMakeLists.txt
+++ b/PWGJE/EMCALJetTasks/CMakeLists.txt
@@ -122,6 +122,7 @@ set(SRCS
     Tracks/AliAnalysisTaskEmcalOnlinePatchesRef.cxx
     Tracks/AliAnalysisTaskEmcalOfflinePatchesRef.cxx
     Tracks/AliAnalysisTaskEmcalRecalcPatchesRef.cxx
+    Tracks/AliAnalysisTaskEmcalTriggerCorrelation.cxx
     Tracks/AliAnalysisTaskEventSelectionRef.cxx
     Tracks/AliAnalysisTaskEventFilter.cxx
     Tracks/AliAnalysisTaskEtaPhiEfficiency.cxx

--- a/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
+++ b/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
@@ -190,6 +190,7 @@
 #pragma link C++ class EMCalTriggerPtAnalysis::AliAnalysisTaskEGAMonitor+;
 #pragma link C++ class EMCalTriggerPtAnalysis::AliAnalysisTaskEmcalPatchMasking+;
 #pragma link C++ class EMCalTriggerPtAnalysis::AliAnalysisTaskEmcalNoiseTriggers+;
+#pragma link C++ class EMCalTriggerPtAnalysis::AliAnalysisTaskEmcalTriggerCorrelation+;
 #pragma link C++ class EMCalTriggerPtAnalysis::AliAnalysisTaskCountITStracks+;
 #pragma link C++ class AliAnalysisTaskEmcalTriggerTreeWriter+;
 #pragma link C++ class AliAnalysisTaskParticleInJet+;

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerCorrelation.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerCorrelation.cxx
@@ -1,0 +1,65 @@
+/************************************************************************************
+ * Copyright (C) 2018, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <iostream>
+#include <TList.h>
+#include "AliAnalysisManager.h"
+#include "AliAnalysisTaskEmcalTriggerCorrelation.h"
+
+ClassImp(EMCalTriggerPtAnalysis::AliAnalysisTaskEmcalTriggerCorrelation)
+
+using namespace EMCalTriggerPtAnalysis;
+
+AliAnalysisTaskEmcalTriggerCorrelation::AliAnalysisTaskEmcalTriggerCorrelation():
+  AliAnalysisTaskEmcalTriggerBase()
+{
+  SetRequireAnalysisUtils(true);
+}
+
+AliAnalysisTaskEmcalTriggerCorrelation::AliAnalysisTaskEmcalTriggerCorrelation(const char *name):
+  AliAnalysisTaskEmcalTriggerBase(name)
+{
+  SetRequireAnalysisUtils(true);
+}
+
+AliAnalysisTaskEmcalTriggerCorrelation::~AliAnalysisTaskEmcalTriggerCorrelation(){
+
+}
+
+AliAnalysisTaskEmcalTriggerCorrelation *AliAnalysisTaskEmcalTriggerCorrelation::AddTaskTriggerCorrelation(const char *name){
+  auto mgr = AliAnalysisManager::GetAnalysisManager();
+  if(!mgr){
+    std::cerr << "No analysis manager available. Exiting ..." << std::endl;
+    return nullptr;
+  }
+
+  auto task = new AliAnalysisTaskEmcalTriggerCorrelation(name);
+  mgr->AddTask(task);
+
+  mgr->ConnectInput(task, 0, mgr->GetCommonInputContainer());
+  mgr->ConnectOutput(task, 1, mgr->CreateContainer(Form("histosTriggerCorrelation_%s", name), TList::Class(), AliAnalysisManager::kExchangeContainer, Form("%s:TriggerCorrelationQA_%s", mgr->GetCommonFileName(), name)));
+  return task;
+}

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerCorrelation.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerCorrelation.h
@@ -1,0 +1,56 @@
+/************************************************************************************
+ * Copyright (C) 2018, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIANALYSISTASKEMCALTRIGGERCORRELATION_H
+#define ALIANALYSISTASKEMCALTRIGGERCORRELATION_H
+
+#include "AliAnalysisTaskEmcalTriggerBase.h"
+
+namespace EMCalTriggerPtAnalysis {
+
+class AliAnalysisTaskEmcalTriggerCorrelation : public AliAnalysisTaskEmcalTriggerBase {
+public:
+  AliAnalysisTaskEmcalTriggerCorrelation();
+  AliAnalysisTaskEmcalTriggerCorrelation(const char *name);
+  virtual ~AliAnalysisTaskEmcalTriggerCorrelation();
+
+  static AliAnalysisTaskEmcalTriggerCorrelation *AddTaskTriggerCorrelation(const char *name);
+
+protected:
+  virtual void CreateUserHistos() {}
+  virtual void CreateUserObjects() {}
+
+private:
+
+  AliAnalysisTaskEmcalTriggerCorrelation(const AliAnalysisTaskEmcalTriggerCorrelation &);
+  AliAnalysisTaskEmcalTriggerCorrelation &operator=(const AliAnalysisTaskEmcalTriggerCorrelation &);
+
+  ClassDef(AliAnalysisTaskEmcalTriggerCorrelation, 1);
+};
+
+}
+
+#endif

--- a/PWGJE/EMCALJetTasks/macros/AddTaskEmcalTriggerCorrelation.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskEmcalTriggerCorrelation.C
@@ -1,0 +1,3 @@
+EMCalTriggerPtAnalysis::AliAnalysisTaskEmcalTriggerCorrelation *AddTaskEmcalTriggerCorrelation(const char *name){
+  return EMCalTriggerPtAnalysis::AliAnalysisTaskEmcalTriggerCorrelation::AddTaskEmcalTriggerCorrelation(name);
+}


### PR DESCRIPTION
The trigger correlation is already monitored in the base
task AliAnalysisTaskEmcalTriggerBase which is abstract.
This task inherits from AliAnalysisTaskEmcalTriggerBase
and only implements the abstract functions as empty
functions in order to make the task non-abstract.