### PR TITLE
Remove c++11 keywords from header, fix add macro

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergyScale.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergyScale.cxx
@@ -43,6 +43,16 @@ ClassImp(EmcalTriggerJets::AliAnalysisTaskEmcalJetEnergyScale)
 
 using namespace EmcalTriggerJets;
 
+AliAnalysisTaskEmcalJetEnergyScale::AliAnalysisTaskEmcalJetEnergyScale():
+  AliAnalysisTaskEmcalJet(),
+  fHistos(nullptr),
+  fNameDetectorJets(),
+  fNameParticleJets(),
+  fTriggerSelectionString(),
+  fNameTriggerDecisionContainer("EmcalTriggerDecision")
+{
+}
+
 AliAnalysisTaskEmcalJetEnergyScale::AliAnalysisTaskEmcalJetEnergyScale(const char *name):
   AliAnalysisTaskEmcalJet(name, true),
   fHistos(nullptr),

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergyScale.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergyScale.h
@@ -45,14 +45,7 @@ namespace EmcalTriggerJets {
 
 class AliAnalysisTaskEmcalJetEnergyScale : public AliAnalysisTaskEmcalJet {
 public:
-#ifdef USECXX11HEADERS
-  AliAnalysisTaskEmcalJetEnergyScale() = default;
-  AliAnalysisTaskEmcalJetEnergyScale(const AliAnalysisTaskEmcalJetEnergyScale &) = delete;
-  AliAnalysisTaskEmcalJetEnergyScale &operator=(const AliAnalysisTaskEmcalJetEnergyScale &) = delete;
-#else
-  // Only needed for rootcint - no implementation necessary
   AliAnalysisTaskEmcalJetEnergyScale();
-#endif
   AliAnalysisTaskEmcalJetEnergyScale(const char *name);
   virtual ~AliAnalysisTaskEmcalJetEnergyScale();
 
@@ -79,10 +72,8 @@ private:
   TString                     fTriggerSelectionString;        ///< Trigger selection string
   TString                     fNameTriggerDecisionContainer;  ///< Global trigger decision container
 
-#ifndef USECXX11HEADERS
   AliAnalysisTaskEmcalJetEnergyScale(const AliAnalysisTaskEmcalJetEnergyScale &);
   AliAnalysisTaskEmcalJetEnergyScale &operator=(const AliAnalysisTaskEmcalJetEnergyScale &);
-#endif
 
   ClassDef(AliAnalysisTaskEmcalJetEnergyScale, 1);
 };

--- a/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJetEnergyScale.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJetEnergyScale.C
@@ -1,7 +1,3 @@
-#ifndef __CINT__
-#include "AliAnalysisTaskEmcalJetEnergyScale.h"
-#endif
-
 EmcalTriggerJets::AliAnalysisTaskEmcalJetEnergyScale *AddTaskEmcalJetEnergyScale(AliJetContainer::EJetType_t jettype, double jetradius, Bool_t useDCAL, const char *trigger){
-  return EmcalTriggerJets::AliAnalysisTaskEmcalJetEnergyScale(jettype, jetradius, useDCAL, trigger);
+  return EmcalTriggerJets::AliAnalysisTaskEmcalJetEnergyScale::AddTaskJetEnergyScale(jettype, jetradius, useDCAL, trigger);
 }


### PR DESCRIPTION
As observed in a different task ROOT5 has problems with
with c++11 keywords default and delete in function
specification even when circumventing for ROOTCINT.
Therefore c++11 part is removed (temporarily).

Furthermore CINT seems to have problems with the macro
interpretation in case the macro doesn't end with an empty
line. Therefore an empty line is added at the end of the
add macro.