### PR TITLE
Filtering task: load local OCDB at the right time

### DIFF
--- a/PWGPP/AliTaskCDBconnect.cxx
+++ b/PWGPP/AliTaskCDBconnect.cxx
@@ -20,6 +20,7 @@
 #include <TRegexp.h>
 #include <TGeoGlobalMagField.h>
 #include "TGeoManager.h"
+#include <TInterpreter.h>
  
 #include "AliAnalysisManager.h"
 #include "AliGeomManager.h"
@@ -136,6 +137,10 @@ void AliTaskCDBconnect::InitGRP()
   if (cdb->GetRun()!=fRun) {    
     fLock = cdb->SetLock(kFALSE,fLock);
     cdb->SetRun(fRun);
+    if (gSystem->AccessPathName("localOCDBaccessConfig.C", kFileExists)==0) {
+      // If we are using a specific storage override, this is the place to load it
+      gInterpreter->ProcessLine("localOCDBaccessConfig()");
+    }
     fLock = cdb->SetLock(kTRUE,fLock);
   }
   if (gSystem->AccessPathName("OCDB.root",kFileExists)==0) cdb->SetSnapshotMode("OCDB.root"); 

--- a/PWGPP/macros/main_runFilteringTask.C
+++ b/PWGPP/macros/main_runFilteringTask.C
@@ -45,10 +45,6 @@ void main_runFilteringTask( const char* esdList,
 
     AddTaskCDBconnect(ocdb);
 
-    if (gSystem->AccessPathName("localOCDBaccessConfig.C", kFileExists)==0) {
-      gInterpreter->ProcessLine("localOCDBaccessConfig()");
-    }
-
     // Create input chain
     //gROOT->LoadMacro("$ALICE_PHYSICS/PWGUD/macros/CreateESDChain.C");
     //TChain* chain = CreateESDChain(esdList, nFiles,firstFile);


### PR DESCRIPTION
localOCDBaccessConfig.C should be executed after both an OCDB default storage
and run number are set