### PR TITLE
removed import statements from addtask macro

### DIFF
--- a/PWGJE/EMCALJetTasks/macros/AddTaskPSHFE.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskPSHFE.C
@@ -1,6 +1,3 @@
-
-#include "AliAnalysisTaskPSHFE.h"
-#include "AliAnalysisManager.h"
     
 AliAnalysisTaskPSHFE* AddTaskPSHFE(const char* taskname, Bool_t trkCutsStrong=kFALSE, Bool_t SSCuts=kFALSE, Bool_t UseNonSignalEvents=kFALSE)
 {


### PR DESCRIPTION
Removed import statements from AddTaskPSHFE so as to run on the lego train without errors.