### PR TITLE
Tag properly pythia direct photons for version 8 and cocktail MCs with pythia

### DIFF
--- a/PWG/CaloTrackCorrBase/AliMCAnalysisUtils.h
+++ b/PWG/CaloTrackCorrBase/AliMCAnalysisUtils.h
@@ -30,6 +30,7 @@ class TClonesArray;
 //--- AliRoot system ---
 class AliMCEvent;
 class AliGenEventHeader;
+class AliGenPythiaEventHeader;
 
 class AliMCAnalysisUtils : public TObject {
 	
@@ -65,8 +66,9 @@ class AliMCAnalysisUtils : public TObject {
   Int_t   CheckCommonAncestor(Int_t index1, Int_t index2, const AliMCEvent* mcevent, 
 			      Int_t & ancPDG, Int_t & ancStatus, TLorentzVector & momentum, TVector3 & prodVertex) ;
   
-  Int_t   CheckOrigin(Int_t label, const AliMCEvent* mcevent) ;  
-  Int_t   CheckOrigin(const Int_t *labels, Int_t nlabels, const AliMCEvent* mcevent, const TObjArray *arrayCluster = 0x0) ; 
+  Int_t   CheckOrigin(Int_t label, AliMCEvent* mcevent, TString selectHeaderName) ;  
+  Int_t   CheckOrigin(const Int_t *labels, Int_t nlabels, AliMCEvent* mcevent, 
+                      TString selectHeaderName, const TObjArray *arrayCluster = 0x0) ; 
   
   void    CheckOverlapped2GammaDecay(const Int_t *labels, Int_t nlabels, Int_t mesonIndex, const AliMCEvent* mcevent, Int_t & tag); 
   
@@ -77,7 +79,8 @@ class AliMCAnalysisUtils : public TObject {
   TLorentzVector GetMother     (Int_t label,const AliMCEvent* mcevent, Int_t & pdg, Int_t & status, Bool_t & ok, Int_t & momLabel);
   TLorentzVector GetGrandMother(Int_t label,const AliMCEvent* mcevent, Int_t & pdg, Int_t & status, Bool_t & ok, Int_t & grandMomLabel, Int_t & greatMomLabel);
 
-  TLorentzVector GetMotherWithPDG(Int_t label, Int_t pdg,const AliMCEvent* mcevent, Bool_t & ok, Int_t & momLabel);
+  TLorentzVector GetMotherWithPDG     (Int_t label, Int_t pdg,const AliMCEvent* mcevent, Bool_t & ok, Int_t & momLabel);
+  TLorentzVector GetFirstMotherWithPDG(Int_t label, Int_t pdg,const AliMCEvent* mcevent, Bool_t & ok, Int_t & momLabel, Int_t & gparentlabel);
   
   void GetMCDecayAsymmetryAngleForPDG(Int_t label, Int_t pdg,const AliMCEvent* mcevent,
                                       Float_t & asy, Float_t & angle, Bool_t & ok);
@@ -109,6 +112,12 @@ class AliMCAnalysisUtils : public TObject {
     
   // Method to recover MC jets stored in generator
   TList * GetJets(AliMCEvent* mcevent, AliGenEventHeader * mcheader, Int_t eventNumber) ;
+  
+  static AliGenPythiaEventHeader * GetPythiaEventHeader
+  (AliMCEvent* mcevent, TString selecHeaderName,
+   TString & genName, TString & processName, 
+   Int_t   & process, Int_t & firstParticle, 
+   Int_t   & pythiaVersion);
   
   void    SetDebug(Int_t deb)           { fDebug=deb           ; }
   Int_t   GetDebug()              const { return fDebug        ; }	

--- a/PWGGA/CaloTrackCorrelations/AliAnaCalorimeterQA.cxx
+++ b/PWGGA/CaloTrackCorrelations/AliAnaCalorimeterQA.cxx
@@ -1146,7 +1146,8 @@ Bool_t AliAnaCalorimeterQA::ClusterMCHistograms(Bool_t matched,const Int_t * lab
   Int_t charge  = 0;
   
   // Check the origin.
-  Int_t tag = GetMCAnalysisUtils()->CheckOrigin(labels, nLabels, GetMC());
+  Int_t tag = GetMCAnalysisUtils()->CheckOrigin(labels, nLabels, GetMC(),
+                                                GetReader()->GetNameOfMCEventHederGeneratorToAccept());
   
   if ( !GetMCAnalysisUtils()->CheckTagBit(tag, AliMCAnalysisUtils::kMCUnknown) )
   { 

--- a/PWGGA/CaloTrackCorrelations/AliAnaClusterShapeCorrelStudies.cxx
+++ b/PWGGA/CaloTrackCorrelations/AliAnaClusterShapeCorrelStudies.cxx
@@ -2181,7 +2181,8 @@ void AliAnaClusterShapeCorrelStudies::ClusterLoopHistograms()
     Int_t noverlaps =0;
     if ( IsDataMC() && fStudyShape )
     {
-      mcTag = GetMCAnalysisUtils()->CheckOrigin(clus->GetLabels(), clus->GetNLabels(), GetMC());
+      mcTag = GetMCAnalysisUtils()->CheckOrigin(clus->GetLabels(), clus->GetNLabels(), GetMC(),
+                                                GetReader()->GetNameOfMCEventHederGeneratorToAccept());
       
       if      ( GetMCAnalysisUtils()->CheckTagBit(mcTag, AliMCAnalysisUtils::kMCPi0        ) ||
                 GetMCAnalysisUtils()->CheckTagBit(mcTag, AliMCAnalysisUtils::kMCEta        ) ) mcIndex = 0;

--- a/PWGGA/CaloTrackCorrelations/AliAnaElectron.cxx
+++ b/PWGGA/CaloTrackCorrelations/AliAnaElectron.cxx
@@ -1203,7 +1203,8 @@ void  AliAnaElectron::MakeAnalysisFillAOD()
     Int_t tag = -1 ;
     if(IsDataMC())
     {
-      tag = GetMCAnalysisUtils()->CheckOrigin(calo->GetLabels(), calo->GetNLabels(), GetMC());
+      tag = GetMCAnalysisUtils()->CheckOrigin(calo->GetLabels(), calo->GetNLabels(), GetMC(),
+                                              GetReader()->GetNameOfMCEventHederGeneratorToAccept());
       
       AliDebug(1,Form("Origin of candidate, bit map %d",tag));
          

--- a/PWGGA/CaloTrackCorrelations/AliAnaInsideClusterInvariantMass.cxx
+++ b/PWGGA/CaloTrackCorrelations/AliAnaInsideClusterInvariantMass.cxx
@@ -6257,8 +6257,8 @@ TList * AliAnaInsideClusterInvariantMass::GetCreateOutputObjects()
 void AliAnaInsideClusterInvariantMass::GetMCIndex(AliVCluster* cluster,
                                                   Int_t & mcindex, Int_t & tag)
 {
-//tag	= GetMCAnalysisUtils()->CheckOrigin(cluster->GetLabels(), cluster->GetNLabels(), GetReader(), GetCalorimeter());
-  tag	= GetMCAnalysisUtils()->CheckOrigin(cluster->GetLabels(), cluster->GetNLabels(), GetMC());
+  tag	= GetMCAnalysisUtils()->CheckOrigin(cluster->GetLabels(), cluster->GetNLabels(), GetMC(),
+                                          GetReader()->GetNameOfMCEventHederGeneratorToAccept());
   
   if      ( GetMCAnalysisUtils()->CheckTagBit(tag,AliMCAnalysisUtils::kMCPi0) &&
            !GetMCAnalysisUtils()->CheckTagBit(tag,AliMCAnalysisUtils::kMCConversion)) mcindex = kmcPi0;

--- a/PWGGA/CaloTrackCorrelations/AliAnaParticleIsolation.cxx
+++ b/PWGGA/CaloTrackCorrelations/AliAnaParticleIsolation.cxx
@@ -7807,7 +7807,8 @@ void AliAnaParticleIsolation::FillAcceptanceHistograms()
     
     // Get tag of this particle photon from fragmentation, decay, prompt ...
     // Set the origin of the photon.
-    tag = GetMCAnalysisUtils()->CheckOrigin(i, GetMC());
+    tag = GetMCAnalysisUtils()->CheckOrigin(i, GetMC(),
+                                            GetReader()->GetNameOfMCEventHederGeneratorToAccept());
     
     if(pdg == 22 && !GetMCAnalysisUtils()->CheckTagBit(tag,AliMCAnalysisUtils::kMCPhoton))
     {

--- a/PWGGA/CaloTrackCorrelations/AliAnaPhoton.cxx
+++ b/PWGGA/CaloTrackCorrelations/AliAnaPhoton.cxx
@@ -1038,7 +1038,8 @@ void AliAnaPhoton::FillAcceptanceHistograms()
   
     // Get tag of this particle photon from fragmentation, decay, prompt ...
     // Set the origin of the photon.
-    tag = GetMCAnalysisUtils()->CheckOrigin(i, GetMC());
+    tag = GetMCAnalysisUtils()->CheckOrigin(i, GetMC(),
+                                            GetReader()->GetNameOfMCEventHederGeneratorToAccept());
     
     if(!GetMCAnalysisUtils()->CheckTagBit(tag,AliMCAnalysisUtils::kMCPhoton))
     {
@@ -4589,7 +4590,9 @@ void  AliAnaPhoton::MakeAnalysisFillAOD()
     
     if ( IsDataMC() )
     {
-      tag = GetMCAnalysisUtils()->CheckOrigin(calo->GetLabels(),calo->GetNLabels(), GetMC(), pl); // check lost decays
+      tag = GetMCAnalysisUtils()->CheckOrigin(calo->GetLabels(),calo->GetNLabels(), GetMC(), 
+                                              GetReader()->GetNameOfMCEventHederGeneratorToAccept(),
+                                              pl); // check lost decays
           
       AliDebug(1,Form("Origin of candidate, bit map %d",tag));
       

--- a/PWGGA/CaloTrackCorrelations/AliAnaPi0EbE.cxx
+++ b/PWGGA/CaloTrackCorrelations/AliAnaPi0EbE.cxx
@@ -3286,7 +3286,8 @@ void  AliAnaPi0EbE::MakeInvMassInCalorimeterAndCTS()
       if(IsDataMC())
       {
         Int_t	label2 = photon2->GetLabel();
-        if ( label2 >= 0 ) photon2->SetTag(GetMCAnalysisUtils()->CheckOrigin(label2, GetMC()));
+        if ( label2 >= 0 ) photon2->SetTag(GetMCAnalysisUtils()->CheckOrigin(label2, GetMC(),
+                                                                             GetReader()->GetNameOfMCEventHederGeneratorToAccept()));
         
         HasPairSameMCMother(photon1->GetLabel(), photon2->GetLabel(),
                             photon1->GetTag()  , photon2->GetTag(),
@@ -3478,7 +3479,8 @@ void  AliAnaPi0EbE::MakeShowerShapeIdentification()
     Int_t tag	= 0 ;
     if(IsDataMC())
     {
-      tag = GetMCAnalysisUtils()->CheckOrigin(calo->GetLabels(), calo->GetNLabels(), GetMC());
+      tag = GetMCAnalysisUtils()->CheckOrigin(calo->GetLabels(), calo->GetNLabels(), GetMC(),
+                                              GetReader()->GetNameOfMCEventHederGeneratorToAccept());
       AliDebug(1,Form("Origin of candidate %d",tag));
     }
     


### PR DESCRIPTION
Add new method in AliMCAnalysisUtils to get the Pythia event header. It returns also the header name and process and a string dedicated to gamma-jet or jet-jet processes
This new method is used in the reader when checking outlier pT hard events.
In case of cocktail generators where a multiple pythia generator is included, a string to tag the direct photons from a particular pythia event can be set.