### PR TITLE
Fix pool size in correlation task

### DIFF
--- a/PWGCF/Correlations/DPhi/AliAnalysisTaskPhiCorrelations.cxx
+++ b/PWGCF/Correlations/DPhi/AliAnalysisTaskPhiCorrelations.cxx
@@ -434,7 +434,7 @@ void  AliAnalysisTaskPhiCorrelations::CreateOutputObjects()
   AddSettingsTree();
 
   // event mixing
-  Int_t poolsize   = 1000;  // Maximum number of events, ignored in the present implemention of AliEventPoolManager
+  Int_t poolsize   = -1;  // Maximum number of events, -1 means no limit
    
   const Int_t kNZvtxBins  = 10+(1+10)*4;
   // bins for further buffers are shifted by 100 cm


### PR DESCRIPTION
This commit is to fix a change in behavior that was introduced with commit 4403510 (https://github.com/alisw/AliRoot/commit/4403510cda26490ba19991968de7b3206c84743b#diff-34966647f689d13061df3e7a1dc2b3a3)

With the above mentioned commit, AliEventPoolManager has a built-in event limiting feature.
To restore the original (desired) behavior, the AliEventPoolManager needs to be initialized with a poolsize of -1.
