### PR TITLE
implement pT-dependent artificial track efficiency feature in jet finding

### DIFF
--- a/PWG/EMCAL/READMEemcEmbedding.txt
+++ b/PWG/EMCAL/READMEemcEmbedding.txt
@@ -471,19 +471,27 @@ Note that this alternative approach will **not** work with automatic setup of Al
 
 # Note on jets and jet finding                                                  {#emcEmbeddingJetFinding}
 
-When handling jet finding, a bit more care needs to be applied, especially if apply an artificial tracking
+When handling jet finding, a bit more care needs to be applied, especially if applying an artificial tracking
 efficiency. This is due to the fact that the jet finder keeps track of constituents by index, which can cause
 some ambiguity in which object applies to which container (if you are interested, see the
 [advanced topics](\ref emcEmbeddingAdvancedTopics) for further details). Thus, the recommend approach is as
 follows:
 
-To apply an artificial efficiency to the embedded input objects, it is best to do so via the jet finder:
+To apply an artificial efficiency to the embedded input objects, it is best to do so via the jet finder. There
+are two different approaches available: to apply a constant additional tracking efficiency, or to apply a
+pT-dependent additional tracking efficiency. For the constant case, one should use: 
 
 ~~~{.cxx}
 // Create the finder jet task as usual (called "jetTask")
 // Set the track efficiency as desired
 jetTask->SetTrackEfficiency(0.94);
 // Tell it to apply to embedding only
+jetTask->SetTrackEfficiencyOnlyForEmbedding(kTRUE);
+~~~
+
+For the pT-dependent case, one should define a TF1 parameterizing the additional efficiency (typically PbPb track efficiency / pp track efficiency) in a root file, and in the AddTask customization call:
+~~~{.cxx}
+jetTask->LoadTrackEfficiencyFunction("/path/to/file.root", "tf1name");
 jetTask->SetTrackEfficiencyOnlyForEmbedding(kTRUE);
 ~~~
 
@@ -499,7 +507,7 @@ for (int i = 0; i < jet->GetNumberOfTracks(); ++i) {
 }
 ~~~
 
-Previous functions such as AliEmcalJet::TrackAt(Int_t index, TCloensArray * arr) still work, but with multiple
+Previous functions such as AliEmcalJet::TrackAt(Int_t index, TClonesArray * arr) still work, but with multiple
 containers, it is impossible to disambiguate which object comes from which container without external help
 (this is handled by AliEmcalContainerIndexMap). AliEmcalJet::Track(Int_t index) handles such situations properly
 and is provided as a convenience. And of course the use is still welcome to get the index directly via

--- a/PWGJE/EMCALJetTasks/AliEmcalJetTask.h
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetTask.h
@@ -116,7 +116,7 @@ class AliEmcalJetTask : public AliAnalysisTaskEmcal {
 
   UInt_t                 FindJetAcceptanceType(Double_t eta, Double_t phi, Double_t r);
   
-  void                   LoadTrackEfficiencyFunction(const char* path, const char* name);
+  void                   LoadTrackEfficiencyFunction(const std::string & path, const std::string & name);
 
   Bool_t                 IsLocked() const;
   void                   SelectCollisionCandidates(UInt_t offlineTriggerMask = AliVEvent::kMB);

--- a/PWGJE/EMCALJetTasks/AliEmcalJetTask.h
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetTask.h
@@ -9,6 +9,8 @@ class TObjArray;
 class AliVEvent;
 class AliEmcalJetUtility;
 
+#include "TF1.h"
+
 #include <AliLog.h>
 
 #include "AliAnalysisTaskEmcal.h"
@@ -114,6 +116,7 @@ class AliEmcalJetTask : public AliAnalysisTaskEmcal {
 
   UInt_t                 FindJetAcceptanceType(Double_t eta, Double_t phi, Double_t r);
   
+  void                   LoadTrackEfficiencyFunction(const char* path, const char* name);
 
   Bool_t                 IsLocked() const;
   void                   SelectCollisionCandidates(UInt_t offlineTriggerMask = AliVEvent::kMB);
@@ -180,7 +183,9 @@ class AliEmcalJetTask : public AliAnalysisTaskEmcal {
   Double_t               fGhostArea;              ///< ghost area
   Double_t               fTrackEfficiency;        ///< artificial tracking inefficiency (0...1)
   TObjArray             *fUtilities;              ///< jet utilities (gen subtractor, constituent subtractor etc.)
-  Bool_t                 fTrackEfficiencyOnlyForEmbedding; ///<tituent Apply aritificial tracking inefficiency only for embedded tracks
+  Bool_t                 fTrackEfficiencyOnlyForEmbedding; ///< Apply aritificial tracking inefficiency only for embedded tracks
+  TF1                    fTrackEfficiencyFunction;///< Function that describes the artificial tracking efficiency to be applied on top of the nominal tracking efficiency, as a function of track pT
+  Bool_t                 fApplyArtificialTrackingEfficiency; ///< Flag to apply artificial tracking efficiency
   Bool_t                 fLocked;                 ///< true if lock is set
   Bool_t	          fFillConstituents;		 ///< If true jet consituents will be filled to the AliEmcalJet
 
@@ -207,7 +212,7 @@ class AliEmcalJetTask : public AliAnalysisTaskEmcal {
   AliEmcalJetTask &operator=(const AliEmcalJetTask&); // not implemented
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalJetTask, 26);
+  ClassDef(AliEmcalJetTask, 27);
   /// \endcond
 };
 #endif

--- a/PWGJE/doc/READMEjetfw.txt
+++ b/PWGJE/doc/READMEjetfw.txt
@@ -171,6 +171,11 @@ For example, you can set the geometrical jet acceptance selection you would like
 
 Additionally, since the jet acceptance bits are stored in the jet, you can manipulate them in your analysis using the AliEmcalJet::GetJetAcceptanceType() function. This may be useful when studying jets in the DCal region, since there are several different partially overlapping bits.
 
+## Artificial track efficiency
+
+In some cases it is useful to artificially reduce the tracking efficiency by applying an additional
+tracking efficiency. See [here](\ref emcEmbeddingJetFinding) for details.
+
 ## Utilities (e.g. FJ contribs)
 
 For information on utilities such as ``fastjet`` contrib, see \subpage READMEjetfwUtilities.


### PR DESCRIPTION
Hi @raymondEhlers, All,

Please take a look at my implementation of pT-dependent artificial track efficiency in jet finding. This builds on the previous implementation of a constant artificial track efficiency, e.g. SetTrackEfficiency(0.98) to account for the ~2% reduced efficiency in PbPb compared to pp. The idea with this commit is that the user can now provide a pT-dependent efficiency via a file containing a TF1 by calling the function LoadTrackEfficiencyFunction() in the AddTask customization. The TF1 should be a parameterization of the "additional" track efficiency you want to apply, typically (PbPb track efficiency / pp track efficiency).

I tested that the feature has no effect if disabled (which is default), and that if a constant efficiency is supplied (either via SetTrackEfficiency() or LoadTrackEfficiencyFunction() ) the behavior is the same as before. I tested also a couple cases of toy TF1s that I supplied, and the behavior is as expected. Further testing is always appreciated.

Please share any comments, I propose to leave the PR open for a day or so and then approve.

Best,
James