### PR TITLE
move FindTrackMatching from protected to public

### DIFF
--- a/TENDER/TenderSupplies/AliPHOSTenderSupply.h
+++ b/TENDER/TenderSupplies/AliPHOSTenderSupply.h
@@ -61,7 +61,8 @@ public:
   
   void   InitTender();
   Double_t TestCPV(Double_t dx, Double_t dz, Double_t pt, Int_t charge) ;
-  Int_t   FindTrackMatching(Int_t mod,TVector3 *locpos,Double_t &dx, Double_t &dz, Double_t &pttrack, Int_t &charge); 
+  Int_t   FindTrackMatching(Int_t mod,TVector3 *locpos,Double_t &dx, Double_t &dz, Double_t &pttrack, Int_t &charge);
+  //this returns track index with a minimum distance between a extrapolated track in current and a PHOS cluster where locpos and mod points.
 
 protected:
   AliPHOSTenderSupply(const AliPHOSTenderSupply&c);

--- a/TENDER/TenderSupplies/AliPHOSTenderSupply.h
+++ b/TENDER/TenderSupplies/AliPHOSTenderSupply.h
@@ -61,12 +61,12 @@ public:
   
   void   InitTender();
   Double_t TestCPV(Double_t dx, Double_t dz, Double_t pt, Int_t charge) ;
+  Int_t   FindTrackMatching(Int_t mod,TVector3 *locpos,Double_t &dx, Double_t &dz, Double_t &pttrack, Int_t &charge); 
 
 protected:
   AliPHOSTenderSupply(const AliPHOSTenderSupply&c);
   AliPHOSTenderSupply& operator= (const AliPHOSTenderSupply&c);
   void ProcessAODEvent(TClonesArray * clusters, AliAODCaloCells * cells, TVector3 &vertex) ;
-  Int_t   FindTrackMatching(Int_t mod,TVector3 *locpos,Double_t &dx, Double_t &dz, Double_t &pttrack, Int_t &charge); 
   Double_t CorrectNonlinearity(Double_t en) ;
   Double_t TestCoreLambda(Double_t pt,Double_t l1,Double_t l2) ;
   Double_t TestFullLambda(Double_t pt,Double_t l1,Double_t l2) ;


### PR DESCRIPTION
This will allow to simply track matching procedure in mixed event by external analysis tasks.