### PR TITLE
Several implementations (mainly variable CPV)

### DIFF
--- a/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.h
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskEMCALPhotonIsolation.h
@@ -124,6 +124,7 @@ class AliAnalysisTaskEMCALPhotonIsolation: public AliAnalysisTaskEmcal {
   void                         Set2012L1Analysis           ( Bool_t  is2012L1                             ) { f2012EGA = is2012L1;                                      }
   void                         SetANWithNoSameTcard        ( Bool_t  iNoSameTCard                         ) { fANnoSameTcard = iNoSameTCard;                            }
   void                         SetPythiaVersion            ( TString pythiaVersion                        ) { fPythiaVersion = pythiaVersion;                           }
+  void                         SetVariableCPV              ( Bool_t  variable                             ) { fVariableCPV = variable;                           }
   
  protected:
   
@@ -181,6 +182,7 @@ class AliAnalysisTaskEMCALPhotonIsolation: public AliAnalysisTaskEmcal {
   AliAODMCHeader             * fmcHeader;                       ///<
   AliGenDPMjetEventHeader    * fDPMjetHeader;                   ///< DPMjet header for cocktail simulations
   TString                      fPythiaVersion;                  ///< May contain "6" or "8" to determine the Pythia version used
+  Bool_t                       fVariableCPV;                    ///<
   TClonesArray               * fTracksAna;                      ///< Hybrid track array in
   AliStack                   * fStack;                          ///<
   AliEMCALRecoUtils          * fEMCALRecoUtils;                 ///< EMCal utils for cluster rereconstruction.
@@ -276,6 +278,7 @@ class AliAnalysisTaskEMCALPhotonIsolation: public AliAnalysisTaskEmcal {
   TH1F                       * fGenPromptPhotonSel;             //!<!
   TH2F                       * fEtaPhiClus;                     ///<  EMCal Cluster Distribution EtaPhi ---QA
   TH2F                       * fEtaPhiClusAftSel;               ///<  EMCal Cluster Distribution EtaPhi after cluster selection
+  TH3F                       * fPtvsDetavsDphi;                 ///<  Cluster-track matching vs. cluster energy
   TH2F                       * fClusEvsClusT;                   //!<! Cluster Energy vs Cluster Time ---QA
   TH1F                       * fPT;                             //!<! Pt distribution
   TH1F                       * fE;                              //!<! E distribution
@@ -284,6 +287,8 @@ class AliAnalysisTaskEMCALPhotonIsolation: public AliAnalysisTaskEmcal {
   TH2F                       * fNLM2_NC_Acc_noTcard;            //!<! NLM (1,2) distribution for Neutral Clusters in Acceptance w/o NLM=2 in SameT
   TH1F                       * fVz;                             //!<! Vertex Z distribution
   TH1F                       * fEvents;                         //!<! Number of Events
+  TH1F                       * fCutFlowEvents;                  //!<! Effect of each cut on event number
+  TH1F                       * fCutFlowClusters;                //!<! Effect of each cut on candidate cluster number
   TH1F                       * fPtaftTime;                      //!<! E distribution for clusters after Cluster Time cut
   TH1F                       * fPtaftCell;                      //!<! Pt distribution for clusters after NCells cut
   TH1F                       * fPtaftNLM;                       //!<! Pt distribution for clusters after NLM cut


### PR DESCRIPTION
- Adding a function to set a cluster E_T dependent charged-particle veto (CPV) with parametrisation from https://alice-notes.web.cern.ch/node/813 + a histogram with CPV residuals vs. cluster E_T
- Introducing two histograms to follow the event and cluster statistics along cut flow
- Reducing the event number histogram binning to 1 (instead of 1 filled bin + 99 empty bins before)
- Fixing the candidate cluster (eta, phi) map histogram filling