### PR TITLE
Temporarily disable pt-dependent tracking efficiency

### DIFF
--- a/PWGJE/EMCALJetTasks/AliEmcalJetTask.cxx
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetTask.cxx
@@ -73,7 +73,7 @@ AliEmcalJetTask::AliEmcalJetTask() :
   fTrackEfficiency(1.),
   fUtilities(0),
   fTrackEfficiencyOnlyForEmbedding(kFALSE),
-  fTrackEfficiencyFunction(),
+  //fTrackEfficiencyFunction(),
   fApplyArtificialTrackingEfficiency(kFALSE),
   fLocked(0),
   fFillConstituents(kTRUE),
@@ -111,7 +111,7 @@ AliEmcalJetTask::AliEmcalJetTask(const char *name) :
   fTrackEfficiency(1.),
   fUtilities(0),
   fTrackEfficiencyOnlyForEmbedding(kFALSE),
-  fTrackEfficiencyFunction(),
+  //fTrackEfficiencyFunction(),
   fApplyArtificialTrackingEfficiency(kFALSE),
   fLocked(0),
   fFillConstituents(kTRUE),
@@ -255,7 +255,7 @@ Int_t AliEmcalJetTask::FindJets()
       if (fApplyArtificialTrackingEfficiency) {
         if (fTrackEfficiencyOnlyForEmbedding == kFALSE || (fTrackEfficiencyOnlyForEmbedding == kTRUE && tracks->GetIsEmbedding())) {
           
-          Double_t trackEfficiency = fTrackEfficiencyFunction.Eval(it->first.Pt());
+          Double_t trackEfficiency = fTrackEfficiency; //fTrackEfficiencyFunction.Eval(it->first.Pt());
           Double_t rnd = gRandom->Rndm();
           if (trackEfficiency < rnd) {
             AliDebug(2,Form("Track %d rejected due to artificial tracking inefficiency", it.current_index()));
@@ -389,8 +389,8 @@ void AliEmcalJetTask::ExecOnce()
       AliError(Form("%s: fTrackEfficiencyFunction was already loaded! Do not apply multiple artificial track efficiencies.", GetName()));
     }
     
-    fTrackEfficiencyFunction = TF1("trackEfficiencyFunction", "[0]", 0., fMaxBinPt);
-    fTrackEfficiencyFunction.SetParameter(0, fTrackEfficiency);
+    //fTrackEfficiencyFunction = TF1("trackEfficiencyFunction", "[0]", 0., fMaxBinPt);
+    //fTrackEfficiencyFunction.SetParameter(0, fTrackEfficiency);
     fApplyArtificialTrackingEfficiency = kTRUE;
   }
   
@@ -1000,7 +1000,7 @@ void AliEmcalJetTask::LoadTrackEfficiencyFunction(const std::string & path, cons
   }
   
   TF1* trackEffClone = static_cast<TF1*>(trackEff->Clone());
-  fTrackEfficiencyFunction = *trackEffClone;
+  //fTrackEfficiencyFunction = *trackEffClone;
   fApplyArtificialTrackingEfficiency = kTRUE;
   
   file->Close();

--- a/PWGJE/EMCALJetTasks/AliEmcalJetTask.h
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetTask.h
@@ -184,7 +184,7 @@ class AliEmcalJetTask : public AliAnalysisTaskEmcal {
   Double_t               fTrackEfficiency;        ///< artificial tracking inefficiency (0...1)
   TObjArray             *fUtilities;              ///< jet utilities (gen subtractor, constituent subtractor etc.)
   Bool_t                 fTrackEfficiencyOnlyForEmbedding; ///< Apply aritificial tracking inefficiency only for embedded tracks
-  TF1                    fTrackEfficiencyFunction;///< Function that describes the artificial tracking efficiency to be applied on top of the nominal tracking efficiency, as a function of track pT
+  //TF1                    fTrackEfficiencyFunction;///< Function that describes the artificial tracking efficiency to be applied on top of the nominal tracking efficiency, as a function of track pT
   Bool_t                 fApplyArtificialTrackingEfficiency; ///< Flag to apply artificial tracking efficiency
   Bool_t                 fLocked;                 ///< true if lock is set
   Bool_t	          fFillConstituents;		 ///< If true jet consituents will be filled to the AliEmcalJet


### PR DESCRIPTION
In local test it turned out that the double delete introduced in #5541 is due to the tracking efficiency function. I comment out this part for the moment in order to unblock jet trains, leaving it up to @jdmulligan to find a better solution.