### PR TITLE
[PWGPP-429] Adapt new hybrid track selection for TRD test in EMCAL fr…

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalAODHybridTrackCuts.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalAODHybridTrackCuts.cxx
@@ -64,7 +64,7 @@ AliEmcalTrackSelResultPtr AliEmcalAODHybridTrackCuts::IsSelected(TObject *o){
     if(fHybridFilterBits[0] > -1 && fHybridFilterBits[1] > -1) {
       if(aodtrack->TestFilterBit(BIT(fHybridFilterBits[0]))) tracktype = AliEmcalTrackSelResultHybrid::kHybridGlobal;
       else if(aodtrack->TestFilterBit(BIT(fHybridFilterBits[1]))){
-        if(aodtrack->GetStatus() & AliVTrack::kITSrefit) tracktype = AliEmcalTrackSelResultHybrid::kHybridConstrained;
+        if(aodtrack->GetStatus() & AliVTrack::kITSrefit) tracktype = AliEmcalTrackSelResultHybrid::kHybridConstrainedTrue; // no module map -> set all complementary hybrid tracks to true complementary hybrid tracks
         else tracktype = AliEmcalTrackSelResultHybrid::kHybridConstrainedNoITSrefit;
       }
     }
@@ -143,7 +143,7 @@ bool TestAliEmcalAODHybridTrackCuts::TestDef2010wRefit() const {
       AliErrorStream() << "Hybrid track information not found for track CAT2" << std::endl;
       nfailure++;          // no hybrid track type found - failure
     } else {
-      if(tracktype->GetHybridTrackType() != AliEmcalTrackSelResultHybrid::kHybridConstrained){
+      if(tracktype->IsHybridTrackConstrained()){
         AliErrorStream() << "Track not selected as hybrid track CAT2: " << int(tracktype->GetHybridTrackType()) << std::endl;
         nfailure++; // wrong hybrid track type
       }
@@ -216,7 +216,7 @@ bool TestAliEmcalAODHybridTrackCuts::TestDef2010woRefit() const {
       AliErrorStream() << "Hybrid track information not found for track CAT2" << std::endl;
       nfailure++;          // no hybrid track type found - failure
     } else {
-      if(tracktype->GetHybridTrackType() != AliEmcalTrackSelResultHybrid::kHybridConstrained){
+      if(tracktype->IsHybridTrackConstrained()){
         AliErrorStream() << "Track not selected as hybrid track CAT2: " << int(tracktype->GetHybridTrackType()) << std::endl;
         nfailure++; // wrong hybrid track type
       }
@@ -277,7 +277,7 @@ bool TestAliEmcalAODHybridTrackCuts::TestDef2011() const {
       AliErrorStream() << "Hybrid track information not found for track CAT2" << std::endl;
       nfailure++;
     } else {
-      if(tracktype->GetHybridTrackType() != AliEmcalTrackSelResultHybrid::kHybridConstrained){
+      if(tracktype->IsHybridTrackConstrained()){
         AliErrorStream() << "Track not selected as hybrid track CAT2: " << int(tracktype->GetHybridTrackType()) << std::endl;
         nfailure++;
       }

--- a/PWG/EMCAL/EMCALbase/AliEmcalESDHybridTrackCuts.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalESDHybridTrackCuts.cxx
@@ -85,7 +85,9 @@ AliEmcalTrackSelResultPtr AliEmcalESDHybridTrackCuts::IsSelected(TObject *o){
     if(fHybridTrackCutsGlobal && fHybridTrackCutsGlobal->AcceptTrack(esdtrack)){
       // Temporary hack for TPC+TRD number of cluster cut which is not yet available in AliESDtrackCuts
       bool isSelected = true;
-      if(fRequireTPCTRDClusters && (GetTPCTRDNumberOfClusters(esdtrack) < fMinClustersTPCTRD)) isSelected = false;
+      auto tracklength = GetTPCTRDNumberOfClusters(esdtrack);
+      AliDebugStream(3) << "Global: Combined track length: " << tracklength << "(" << esdtrack->GetTPCCrossedRows() << "/" << static_cast<Int_t>(esdtrack->GetTRDncls()) << ")" << std::endl;
+      if(fRequireTPCTRDClusters && (tracklength < fMinClustersTPCTRD)) isSelected = false;
       if(isSelected){
         AliDebugStream(2) << "Track selected as global hybrid track" << std::endl;
         tracktype = AliEmcalTrackSelResultHybrid::kHybridGlobal;
@@ -94,7 +96,9 @@ AliEmcalTrackSelResultPtr AliEmcalESDHybridTrackCuts::IsSelected(TObject *o){
       if(fHybridTrackCutsConstrained && fHybridTrackCutsConstrained->AcceptTrack(esdtrack)){
         // Temporary hack for TPC+TRD number of cluster cut which is not yet available in AliESDtrackCuts
         bool isSelected = true;
-        if(fRequireTPCTRDClusters && (GetTPCTRDNumberOfClusters(esdtrack) < fMinClustersTPCTRD)) isSelected = false;
+        auto tracklength = GetTPCTRDNumberOfClusters(esdtrack);
+        AliDebugStream(3) << "Constrained: Combined track length: " << tracklength << "(" << esdtrack->GetTPCCrossedRows() << "/" << static_cast<Int_t>(esdtrack->GetTRDncls()) << ")" << std::endl;
+        if(fRequireTPCTRDClusters && (tracklength < fMinClustersTPCTRD)) isSelected = false;
         if(isSelected){
           AliDebugStream(2) << "Track selected as constrained hybrid track" << std::endl;
           if(IsActiveITSModule(esdtrack, 0) || IsActiveITSModule(esdtrack, 1)) tracktype = AliEmcalTrackSelResultHybrid::kHybridConstrainedFake;
@@ -221,6 +225,7 @@ void AliEmcalESDHybridTrackCuts::InitHybridTracks2011() {
 }
 
 void AliEmcalESDHybridTrackCuts::InitHybridTracks2018TRD(){
+  std::cout << "Initialiing hybrid tracks based on the 2018 definition" <<std::endl;
   InitHybridTracks2011();
 
   // Deactivate TPC crossed rows cut

--- a/PWG/EMCAL/EMCALbase/AliEmcalESDHybridTrackCuts.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalESDHybridTrackCuts.cxx
@@ -97,7 +97,8 @@ AliEmcalTrackSelResultPtr AliEmcalESDHybridTrackCuts::IsSelected(TObject *o){
         if(fRequireTPCTRDClusters && (GetTPCTRDNumberOfClusters(esdtrack) < fMinClustersTPCTRD)) isSelected = false;
         if(isSelected){
           AliDebugStream(2) << "Track selected as constrained hybrid track" << std::endl;
-          tracktype = AliEmcalTrackSelResultHybrid::kHybridConstrained;
+          if(IsActiveITSModule(esdtrack, 0) || IsActiveITSModule(esdtrack, 1)) tracktype = AliEmcalTrackSelResultHybrid::kHybridConstrainedFake;
+          else tracktype = AliEmcalTrackSelResultHybrid::kHybridConstrainedTrue;
         }
       } else if(fHybridTrackCutsNoItsRefit && fHybridTrackCutsNoItsRefit->AcceptTrack(esdtrack)) {
         // Temporary hack for TPC+TRD number of cluster cut which is not yet available in AliESDtrackCuts
@@ -133,6 +134,18 @@ void AliEmcalESDHybridTrackCuts::Init(){
 
 Int_t AliEmcalESDHybridTrackCuts::GetTPCTRDNumberOfClusters(const AliVTrack *const trk) const {
   return static_cast<Int_t>(trk->GetTPCCrossedRows()) + static_cast<Int_t>(trk->GetTRDncls());
+}
+
+Bool_t AliEmcalESDHybridTrackCuts::IsActiveITSModule(const AliESDtrack *const trk, int layer) const {
+  int det, status;
+  Float_t xloc, zloc;
+  trk->GetITSModuleIndexInfo(layer, det, status, xloc, zloc);
+  // dead status:
+  // - dead (2)
+  // - skipped (3)
+  // - outinz (4)
+  // - holeinz (7)
+  return !(status == 2 || status == 3 || status == 4 || status == 7);
 }
 
 void AliEmcalESDHybridTrackCuts::InitHybridTracks2010() {

--- a/PWG/EMCAL/EMCALbase/AliEmcalESDHybridTrackCuts.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalESDHybridTrackCuts.cxx
@@ -48,7 +48,9 @@ AliEmcalESDHybridTrackCuts::AliEmcalESDHybridTrackCuts():
   fHybridTrackDefinition(kDef2010),
   fHybridTrackCutsGlobal(nullptr),
   fHybridTrackCutsConstrained(nullptr),
-  fHybridTrackCutsNoItsRefit(nullptr)
+  fHybridTrackCutsNoItsRefit(nullptr),
+  fRequireTPCTRDClusters(false),
+  fMinClustersTPCTRD(0)
 {
 
 }
@@ -59,7 +61,9 @@ AliEmcalESDHybridTrackCuts::AliEmcalESDHybridTrackCuts(const char *name, HybridD
   fHybridTrackDefinition(hybriddef),
   fHybridTrackCutsGlobal(nullptr),
   fHybridTrackCutsConstrained(nullptr),
-  fHybridTrackCutsNoItsRefit(nullptr)
+  fHybridTrackCutsNoItsRefit(nullptr),
+  fRequireTPCTRDClusters(false),
+  fMinClustersTPCTRD(0)
 {
 
 }
@@ -79,15 +83,30 @@ AliEmcalTrackSelResultPtr AliEmcalESDHybridTrackCuts::IsSelected(TObject *o){
   if(auto esdtrack = dynamic_cast<AliESDtrack *>(o)) {
     AliEmcalTrackSelResultHybrid::HybridType_t tracktype = AliEmcalTrackSelResultHybrid::kUndefined;
     if(fHybridTrackCutsGlobal && fHybridTrackCutsGlobal->AcceptTrack(esdtrack)){
-      AliDebugStream(2) << "Track selected as global hybrid track" << std::endl;
-      tracktype = AliEmcalTrackSelResultHybrid::kHybridGlobal;
+      // Temporary hack for TPC+TRD number of cluster cut which is not yet available in AliESDtrackCuts
+      bool isSelected = true;
+      if(fRequireTPCTRDClusters && (GetTPCTRDNumberOfClusters(esdtrack) < fMinClustersTPCTRD)) isSelected = false;
+      if(isSelected){
+        AliDebugStream(2) << "Track selected as global hybrid track" << std::endl;
+        tracktype = AliEmcalTrackSelResultHybrid::kHybridGlobal;
+      }
     } else {
       if(fHybridTrackCutsConstrained && fHybridTrackCutsConstrained->AcceptTrack(esdtrack)){
-        AliDebugStream(2) << "Track selected as constrained hybrid track" << std::endl;
-        tracktype = AliEmcalTrackSelResultHybrid::kHybridConstrained;
+        // Temporary hack for TPC+TRD number of cluster cut which is not yet available in AliESDtrackCuts
+        bool isSelected = true;
+        if(fRequireTPCTRDClusters && (GetTPCTRDNumberOfClusters(esdtrack) < fMinClustersTPCTRD)) isSelected = false;
+        if(isSelected){
+          AliDebugStream(2) << "Track selected as constrained hybrid track" << std::endl;
+          tracktype = AliEmcalTrackSelResultHybrid::kHybridConstrained;
+        }
       } else if(fHybridTrackCutsNoItsRefit && fHybridTrackCutsNoItsRefit->AcceptTrack(esdtrack)) {
-        AliDebugStream(2) << "Track selected as non-refit hybrid track" << std::endl;
-        tracktype = AliEmcalTrackSelResultHybrid::kHybridConstrainedNoITSrefit;
+        // Temporary hack for TPC+TRD number of cluster cut which is not yet available in AliESDtrackCuts
+        bool isSelected = true;
+        if(fRequireTPCTRDClusters && (GetTPCTRDNumberOfClusters(esdtrack) < fMinClustersTPCTRD)) isSelected = false;
+        if(isSelected){
+          AliDebugStream(2) << "Track selected as non-refit hybrid track" << std::endl;
+          tracktype = AliEmcalTrackSelResultHybrid::kHybridConstrainedNoITSrefit;
+        }
       } else {
         AliDebugStream(2) << "Track not selected as hybrid track" << std::endl;
       }
@@ -105,10 +124,15 @@ void AliEmcalESDHybridTrackCuts::Init(){
   switch(fHybridTrackDefinition){
   case kDef2010: InitHybridTracks2010(); break;
   case kDef2011: InitHybridTracks2011(); break;
+  case kDef2018TRD: InitHybridTracks2018TRD(); break;
   default:
     AliErrorStream() << "No matching initialization found for requested hybrid track definition" <<std::endl;
   };
   fLocalInitialized = true;
+}
+
+Int_t AliEmcalESDHybridTrackCuts::GetTPCTRDNumberOfClusters(const AliVTrack *const trk) const {
+  return static_cast<Int_t>(trk->GetTPCCrossedRows()) + static_cast<Int_t>(trk->GetTRDncls());
 }
 
 void AliEmcalESDHybridTrackCuts::InitHybridTracks2010() {
@@ -181,4 +205,17 @@ void AliEmcalESDHybridTrackCuts::InitHybridTracks2011() {
     fHybridTrackCutsNoItsRefit = new AliESDtrackCuts(*fHybridTrackCutsConstrained);
     fHybridTrackCutsNoItsRefit->SetRequireITSRefit(kFALSE);
   }
+}
+
+void AliEmcalESDHybridTrackCuts::InitHybridTracks2018TRD(){
+  InitHybridTracks2011();
+
+  // Deactivate TPC crossed rows cut
+  if(fHybridTrackCutsGlobal) fHybridTrackCutsGlobal->SetMinNCrossedRowsTPC(30);
+  if(fHybridTrackCutsConstrained) fHybridTrackCutsConstrained->SetMinNCrossedRowsTPC(30);
+  if(fHybridTrackCutsNoItsRefit) fHybridTrackCutsNoItsRefit->SetMinNCrossedRowsTPC(30);
+
+  // Set min. number of TPC+TRD clusters cut
+  fRequireTPCTRDClusters = true;
+  fMinClustersTPCTRD = 120;
 }

--- a/PWG/EMCAL/EMCALbase/AliEmcalESDHybridTrackCuts.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalESDHybridTrackCuts.h
@@ -30,6 +30,7 @@
 #include "AliEmcalCutBase.h"
 
 class AliESDtrackCuts;
+class AliESDtrack;
 class AliVTrack;
 
 namespace PWG {
@@ -111,6 +112,15 @@ public:
    * @return Number of TPC + TRD space points
    */
   Int_t  GetTPCTRDNumberOfClusters(const AliVTrack *const trk) const;
+
+  /**
+   * @brief Check if ITS module in the layer is considerd as active
+   * 
+   * @param trk Track to check 
+   * @param layer Layer to check
+   * @return True if the module in the layer is considered as active, false otherwise
+   */
+  Bool_t IsActiveITSModule(const AliESDtrack *const trk, int layer) const;
 
 protected:
 

--- a/PWG/EMCAL/EMCALbase/AliEmcalESDHybridTrackCuts.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalESDHybridTrackCuts.h
@@ -30,6 +30,7 @@
 #include "AliEmcalCutBase.h"
 
 class AliESDtrackCuts;
+class AliVTrack;
 
 namespace PWG {
 
@@ -55,8 +56,9 @@ public:
    * @brief Definition of various hybrid track selections
    */
   enum HybridDefinition_t {
-    kDef2010,   //!< Definition used for 2010 pass1-2 and LHC11a
-    kDef2011    //!< Definition used since 2011 (LHC11h)
+    kDef2010,     //!< Definition used for 2010 pass1-2 and LHC11a
+    kDef2011,     //!< Definition used since 2011 (LHC11h)
+    kDef2018TRD   //!< Definition for the 2018 TRD reconstruction test
   };
 
   /**
@@ -98,7 +100,17 @@ public:
    * 
    * @param doUse If true non-ITS refit tracks will be used (independent of the hybrid track definition)
    */
-  void SetUseNoITSrefitTracks(bool doUse) { fSelectNonRefitTracks = doUse; }
+  void SetUseNoITSrefitTracks(bool doUse) { fSelectNonRefitTracks = doUse; }  
+
+  /**
+   * @brief Get the combined number of TPC crossed rows + TRD clusters
+   * 
+   * Only to be used for productions that include TRD refit in tracking!
+   * 
+   * @param trk Track for which to obtain the combined number of space points
+   * @return Number of TPC + TRD space points
+   */
+  Int_t  GetTPCTRDNumberOfClusters(const AliVTrack *const trk) const;
 
 protected:
 
@@ -128,7 +140,18 @@ protected:
    * - Constrained tracks with SPD requirement
    * - Complementary tracks (no SPD, no refit) - optional
    */
+
   void InitHybridTracks2011();
+
+  /**
+   * @brief Initialize hybrid track selection used for the TRD tracking test
+   * 
+   * Cuts same as for hybrid tracks 2011, but instead
+   * - No cut on the number of TPC crossed rows, instead cut on the combined
+   *   number of TPC + TRD space points, both for global and complementary
+   *   hybrid tracks
+   */
+  void InitHybridTracks2018TRD();
 
 private:
   bool                  fLocalInitialized;                  ///< Local init status flag steering lazy initialization
@@ -137,6 +160,9 @@ private:
   AliESDtrackCuts       *fHybridTrackCutsGlobal;            ///< Track cuts for global hybrid tracks
   AliESDtrackCuts       *fHybridTrackCutsConstrained;       ///< Track cuts for constrained hybrid tracks
   AliESDtrackCuts       *fHybridTrackCutsNoItsRefit;        ///< Track cuts for complementary hybrid tracks (constrained without ITSrefit)
+
+  Bool_t                fRequireTPCTRDClusters;             ///< Require TPC and TRD combined number of clusters
+  Int_t                 fMinClustersTPCTRD;                 ///< Minimum number of TPC+TRD combined clusters
 
   /// \cond CLASSIMP
   ClassDef(AliEmcalESDHybridTrackCuts, 1);

--- a/PWG/EMCAL/EMCALbase/AliEmcalESDTrackCutsGenerator.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalESDTrackCutsGenerator.cxx
@@ -543,7 +543,7 @@ AliEmcalESDTrackCutsGenerator::EDataSet_t AliEmcalESDTrackCutsGenerator::SteerDa
     dataSet = kLHC11h;
   } else if (strPeriod == "lhc16t") {
     dataSet = kLHC11h;
-  } else if (strPeriod == "lhc17o_TRD") {
+  } else if (strPeriod == "lhc17o_trd") {
     dataSet = kLHC17o_TRD;
   } else if (strPeriod == "lhc12a15f") {
     dataSet = kLHC11h;

--- a/PWG/EMCAL/EMCALbase/AliEmcalESDTrackCutsGenerator.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalESDTrackCutsGenerator.cxx
@@ -543,6 +543,8 @@ AliEmcalESDTrackCutsGenerator::EDataSet_t AliEmcalESDTrackCutsGenerator::SteerDa
     dataSet = kLHC11h;
   } else if (strPeriod == "lhc16t") {
     dataSet = kLHC11h;
+  } else if (strPeriod == "lhc17o_TRD") {
+    dataSet = kLHC17o_TRD;
   } else if (strPeriod == "lhc12a15f") {
     dataSet = kLHC11h;
   } else if (strPeriod == "lhc13b4") {
@@ -594,6 +596,13 @@ void AliEmcalESDTrackCutsGenerator::AddHybridTrackCuts(AliEmcalTrackSelection* t
     auto hybridcuts2010 = new AliEmcalESDHybridTrackCuts("hybridcuts2010wSPD", AliEmcalESDHybridTrackCuts::kDef2010);
     hybridcuts2010->SetUseNoITSrefitTracks(kTRUE);
     trkSel->AddTrackCuts(hybridcuts2010);
+    break;
+  }
+  case kLHC17o_TRD:
+  {
+    auto hybridcuts2018TRD = new AliEmcalESDHybridTrackCuts("hybridcuts2018TRD", AliEmcalESDHybridTrackCuts::kDef2018TRD);
+    hybridcuts2018TRD->SetUseNoITSrefitTracks(kFALSE);
+    trkSel->AddTrackCuts(hybridcuts2018TRD);
     break;
   }
   default:

--- a/PWG/EMCAL/EMCALbase/AliEmcalESDTrackCutsGenerator.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalESDTrackCutsGenerator.h
@@ -55,7 +55,8 @@ public:
     kLHC11a    = 3,
     kLHC11c    = 4,
     kLHC11d    = 5,
-    kLHC11h    = 6
+    kLHC11h    = 6,
+    kLHC17o_TRD = 7
   };
 
   enum EStdCutMode_t {

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultHybrid.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultHybrid.h
@@ -33,20 +33,114 @@ namespace PWG {
 
 namespace EMCAL {
 
+/**
+ * @class AliEmcalTrackSelResultHybrid
+ * @brief Selection result of the hybrid track selection
+ * @ingroup EMCALCOREFW
+ * @author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+ * @since Dec 21, 2017
+ * 
+ * The object stores the type of the hybrid track determined by the AliEmcalESD/AODHybridTrackCuts.
+ * For the various hybrid track types see @ref HybridType_t. The object is produced by the
+ * hybrid track cuts object for each track and added as optional payload to the resulting
+ * AliEmcalTrackSelResultPtr. Users can obtain the payload object from the AliEmcalTrackSelResultPtr
+ * and obtain the hybrid track type by one of the various getters.
+ */
 class AliEmcalTrackSelResultHybrid : public TObject {
 public:
+  /**
+   * @enum HybridType_t
+   * @brief Various types of hybrid tracks
+   * 
+   * | CAT  | Hybrid track type         | Properties                                                                    |
+   * |------|---------------------------|-------------------------------------------------------------------------------|
+   * |  0   | kUndefined                | Not a hybrid track                                                            |
+   * |  I   | kHybridGlobal             | Global hybrid track (with SPD any condition). No vertex constraint            |
+   * |  IIa | kHybridConstrainedTrue    | No SPD cluster, no alive SPD module, probably primary. With vertex constraint |
+   * |  IIb | kHybridConstrainedFake    | No SPD cluster but alive SPD module, probably secondary. No vertex constraint |
+   * |  III | kHybridConstrainedNoRefit | Constrained track failing in refit, treated as primary particle               |
+   */
   enum HybridType_t {
-    kUndefined,
-    kHybridGlobal,
-    kHybridConstrained,
-    kHybridConstrainedNoITSrefit
+    kUndefined,                               ///< Undefined - no hybrid track
+    kHybridGlobal,                            ///< Global hybrid track                                      (type I)
+    kHybridConstrainedTrue,                   ///< Complementary hybrid track without alive SPD module      (type IIa)
+    kHybridConstrainedFake,                   ///< Complementary hybrid track with alive SPD module         (type IIb)
+    kHybridConstrainedNoITSrefit              ///< Complementary hybrid track without ITS refit             (type III)
   };
+
+  /**
+   * @brief Dumy constructor
+   */
+
   AliEmcalTrackSelResultHybrid();
+
+  /**
+   * @brief Constructor with track type
+   * 
+   * For track types see @ref HybridType_t
+   */
   AliEmcalTrackSelResultHybrid(HybridType_t tracktype);
+
+  /**
+   * @brief Destructor
+   */
   virtual ~AliEmcalTrackSelResultHybrid() {}
 
+  /**
+   * @brief Set the type of the hybrid track
+   * 
+   * For track types see @ref HybridType_t
+   * @param tracktype Type of the hybrid track
+   */
   void SetHybridTrackType(HybridType_t tracktype) { fHybridTrackType = tracktype; }
+
+  /**
+   * @brief Get the type of the hybrid track
+   * 
+   * For track types see @ref HybridType_t
+   * @return Type of the hybrid track
+   */
   HybridType_t GetHybridTrackType() const { return fHybridTrackType; }
+
+  /**
+   * @brief Check whether track is selected as hybrid track
+   * @return True if the track is selected as hybrid track, false otherwise
+   */
+  Bool_t IsHybridTrack() const { return fHybridTrackType != kUndefined; }
+
+  /**
+   * @brief Check whether track is selected as global hybrid track
+   * @return True if the track is selected as global hybrid track, false otherwise
+   */
+  Bool_t IsHybridTrackGlobal() const { return fHybridTrackType == kHybridGlobal; }
+
+  /**
+   * @brief Check whether track is selected as any complementary (true or fake) hybrid track
+   * @return True if the track is selected as complementary hybrid track, false otherwise
+   */
+  Bool_t IsHybridTrackConstrained() const { return fHybridTrackType == kHybridConstrainedTrue || fHybridTrackType == kHybridConstrainedFake; }
+
+  /**
+   * @brief Check whether track is selected as true complementary hybrid track
+   * 
+   * For true complementary hybrid tracks both SPD modules were off
+   * @return True if the track is selected as true complementary hybrid track, false otherwise
+   */
+  Bool_t IsHybridTrackConstrainedTrue() const { return fHybridTrackType == kHybridConstrainedTrue; } 
+
+  /**
+   * @brief Check whether track is selected as fake complementary hybrid track
+   * 
+   * For fake complementary hybrid tracks at least one SPD module was active
+   * @return True if the track is selected as fake complementary hybrid track, false otherwise
+   */
+  Bool_t IsHybridTrackConstrainedFake() const { return fHybridTrackType == kHybridConstrainedFake; }
+
+  /**
+   * @brief Check whether track is selected as non-refit complementary hybrid track
+   * @return True if the track is selected as non-refit complementary hybrid track, false otherwise
+   */
+  Bool_t IsHybridTrackNonRefit() const { return fHybridTrackType == kHybridConstrainedNoITSrefit; }
 
 private:
   HybridType_t                  fHybridTrackType;           ///< Hybrid track type

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.h
@@ -184,7 +184,8 @@ public:
 		kHybridTracks2010wNoRefit,	///< Hybrid tracks using the 2010 definition including NoITSrefit tracks (ESD-only)
 		kHybridTracks2010woNoRefit,	///< Hybrid tracks using the 2010 definition excluding NoITSrefit tracks (ESD-only)
 		kHybridTracks2011wNoRefit,	///< Hybrid tracks using the 2011 definition including NoITSrefit tracks (ESD-only)
-		kHybridTracks2011woNoRefit 	///< Hybrid tracks using the 2011 definition excluding NoITSrefit tracks (ESD-only)
+		kHybridTracks2011woNoRefit,	///< Hybrid tracks using the 2011 definition excluding NoITSrefit tracks (ESD-only)
+		kHybridTracks2018TRD				///< Hybrid tracks using the 2018 TRD test definition
   };
 
   /**

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.cxx
@@ -335,7 +335,7 @@ bool TestAliEmcalTrackSelectionAOD::TestHybridDef2010wRefit() const {
       AliErrorStream() << "No hybrid selection result found for CAT2 hybrid track" << std::endl;
       nfailure++;
     } else {
-      if(hybridcat->GetHybridTrackType() != AliEmcalTrackSelResultHybrid::kHybridConstrained) {
+      if(hybridcat->IsHybridTrackConstrained()) {
         AliErrorStream() << "Incorrect hybrid track type for CAT2 hybrid track: " << hybridcat->GetHybridTrackType() << std::endl;
         nfailure++;
       }
@@ -408,7 +408,7 @@ bool TestAliEmcalTrackSelectionAOD::TestHybridDef2010woRefit() const {
       AliErrorStream() << "No hybrid selection result found for CAT2 hybrid track" << std::endl;
       nfailure++;
     } else {
-      if(hybridcat->GetHybridTrackType() != AliEmcalTrackSelResultHybrid::kHybridConstrained) {
+      if(hybridcat->IsHybridTrackConstrained()) {
         AliErrorStream() << "Incorrect hybrid track type for CAT2 hybrid track: " << hybridcat->GetHybridTrackType() << std::endl;
         nfailure++;
       }
@@ -469,7 +469,7 @@ bool TestAliEmcalTrackSelectionAOD::TestHybridDef2011() const {
       AliErrorStream() << "No hybrid selection result found for CAT2 hybrid track" << std::endl;
       nfailure++;
     } else {
-      if(hybridcat->GetHybridTrackType() != AliEmcalTrackSelResultHybrid::kHybridConstrained) {
+      if(hybridcat->IsHybridTrackConstrained()) {
         AliErrorStream() << "Incorrect hybrid track type for CAT2 hybrid track: " << hybridcat->GetHybridTrackType() << std::endl;
         nfailure++;
       }

--- a/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
@@ -199,7 +199,7 @@ void AliTrackContainer::NextEvent(const AliVEvent * event)
       trackarray->Clear();
     }
 
-    int naccepted(0), nrejected(0), nhybridTracks1(0), nhybridTracks2(0), nhybridTracks3(0);
+    int naccepted(0), nrejected(0), nhybridTracks1(0), nhybridTracks2a(0), nhybridTracks2b(0), nhybridTracks3(0);
     Int_t i = 0;
     for(auto accresult : *acceptedTracks) {
       if (i >= fTrackTypes.GetSize()) fTrackTypes.Set((i+1)*2);
@@ -219,9 +219,13 @@ void AliTrackContainer::NextEvent(const AliVEvent * event)
               fTrackTypes[i] = kHybridGlobal;
               nhybridTracks1++;
               break;
-            case PWG::EMCAL::AliEmcalTrackSelResultHybrid::kHybridConstrained:
-              fTrackTypes[i] = kHybridConstrained;
-              nhybridTracks2++;
+            case PWG::EMCAL::AliEmcalTrackSelResultHybrid::kHybridConstrainedTrue:
+              fTrackTypes[i] = kHybridConstrainedTrue;
+              nhybridTracks2a++;
+              break;
+            case PWG::EMCAL::AliEmcalTrackSelResultHybrid::kHybridConstrainedFake:
+              fTrackTypes[i] = kHybridConstrainedFake;
+              nhybridTracks2b++;
               break;
             case PWG::EMCAL::AliEmcalTrackSelResultHybrid::kHybridConstrainedNoITSrefit:
               fTrackTypes[i] = kHybridConstrainedNoITSrefit;
@@ -235,7 +239,7 @@ void AliTrackContainer::NextEvent(const AliVEvent * event)
       }
      i++;
     }
-    AliDebugStream(1) << "Accepted: " << naccepted << ", Rejected: " << nrejected << ", hybrid: (" << nhybridTracks1 << " | " << nhybridTracks2 << " | " << nhybridTracks3 << ")" << std::endl;
+    AliDebugStream(1) << "Accepted: " << naccepted << ", Rejected: " << nrejected << ", hybrid: (" << nhybridTracks1 << " | [" << nhybridTracks2a << " | " << nhybridTracks2b  << "] | " << nhybridTracks3 << ")" << std::endl;
   }
   else {
     fFilteredTracks.SetOwner(false);
@@ -345,7 +349,7 @@ Bool_t AliTrackContainer::GetMomentumFromTrack(TLorentzVector &mom, const AliVTr
     Bool_t useConstrainedParams = kFALSE;
     if (fLoadedClass->InheritsFrom("AliESDtrack") && IsHybridTrackSelection()) {
       Char_t trackType = GetTrackType(track);
-      if (trackType == kHybridConstrained || trackType == kHybridConstrainedNoITSrefit) {
+      if (trackType == kHybridConstrainedTrue || trackType == kHybridConstrainedNoITSrefit) {
         AliDebugStream(2) << "Found a constrained track" << std::endl;
         useConstrainedParams = kTRUE;
       }
@@ -397,7 +401,7 @@ Bool_t AliTrackContainer::GetMomentum(TLorentzVector &mom, Int_t i) const
     if (mass < 0) mass = vp->M();
 
     if (fLoadedClass->InheritsFrom("AliESDtrack") && IsHybridTrackSelection() &&
-        (fTrackTypes[i] == kHybridConstrained || fTrackTypes[i] == kHybridConstrainedNoITSrefit)) {
+        (fTrackTypes[i] == kHybridConstrainedTrue || fTrackTypes[i] == kHybridConstrainedNoITSrefit)) {
       AliDebugStream(2) << "Found a constrained track" << std::endl;
       AliESDtrack *track = static_cast<AliESDtrack*>(vp);
       mom.SetPtEtaPhiM(track->GetConstrainedParam()->Pt(), track->GetConstrainedParam()->Eta(), track->GetConstrainedParam()->Phi(), mass);
@@ -431,7 +435,7 @@ Bool_t AliTrackContainer::GetNextMomentum(TLorentzVector &mom)
     if (mass < 0) mass = vp->M();
 
     if (fLoadedClass->InheritsFrom("AliESDtrack") && IsHybridTrackSelection() &&
-        (fTrackTypes[fCurrentID] == kHybridConstrained || fTrackTypes[fCurrentID] == kHybridConstrainedNoITSrefit)) {
+        (fTrackTypes[fCurrentID] == kHybridConstrainedTrue || fTrackTypes[fCurrentID] == kHybridConstrainedNoITSrefit)) {
       AliDebugStream(2) << "Found a constrained track" << std::endl; 
       AliESDtrack *track = static_cast<AliESDtrack*>(vp);
       mom.SetPtEtaPhiM(track->GetConstrainedParam()->Pt(), track->GetConstrainedParam()->Eta(), track->GetConstrainedParam()->Phi(), mass);
@@ -468,7 +472,7 @@ Bool_t AliTrackContainer::GetAcceptMomentum(TLorentzVector &mom, Int_t i) const
     if (mass < 0) mass = vp->M();
 
     if (fLoadedClass->InheritsFrom("AliESDtrack") && IsHybridTrackSelection() &&
-        (fTrackTypes[i] == kHybridConstrained || fTrackTypes[i] == kHybridConstrainedNoITSrefit)) {
+        (fTrackTypes[i] == kHybridConstrainedTrue || fTrackTypes[i] == kHybridConstrainedNoITSrefit)) {
       AliDebugStream(2) << "Found a constrained track" << std::endl;
       AliESDtrack *track = static_cast<AliESDtrack*>(vp);
       mom.SetPtEtaPhiM(track->GetConstrainedParam()->Pt(), track->GetConstrainedParam()->Eta(), track->GetConstrainedParam()->Phi(), mass);
@@ -503,7 +507,7 @@ Bool_t AliTrackContainer::GetNextAcceptMomentum(TLorentzVector &mom)
     if (mass < 0) mass = vp->M();
 
     if (fLoadedClass->InheritsFrom("AliESDtrack") && IsHybridTrackSelection() &&
-        (fTrackTypes[fCurrentID] == kHybridConstrained || fTrackTypes[fCurrentID] == kHybridConstrainedNoITSrefit)) {
+        (fTrackTypes[fCurrentID] == kHybridConstrainedTrue || fTrackTypes[fCurrentID] == kHybridConstrainedNoITSrefit)) {
       AliDebugStream(2) << "Found a constrained track" << std::endl;
       AliESDtrack *track = static_cast<AliESDtrack*>(vp);
       mom.SetPtEtaPhiM(track->GetConstrainedParam()->Pt(), track->GetConstrainedParam()->Eta(), track->GetConstrainedParam()->Phi(), mass);
@@ -620,7 +624,8 @@ bool AliTrackContainer::IsHybridTrackSelection() const {
          (fTrackFilterType == AliEmcalTrackSelection::kHybridTracks2010wNoRefit) ||
          (fTrackFilterType == AliEmcalTrackSelection::kHybridTracks2010woNoRefit) ||
          (fTrackFilterType == AliEmcalTrackSelection::kHybridTracks2011wNoRefit) ||
-         (fTrackFilterType == AliEmcalTrackSelection::kHybridTracks2011woNoRefit);
+         (fTrackFilterType == AliEmcalTrackSelection::kHybridTracks2011woNoRefit) ||
+         (fTrackFilterType == AliEmcalTrackSelection::kHybridTracks2018TRD);
 }
 
 PWG::EMCAL::AliEmcalTrackSelResultHybrid::HybridType_t AliTrackContainer::GetHybridDefinition(const PWG::EMCAL::AliEmcalTrackSelResultPtr &selectionResult) const {

--- a/PWG/EMCAL/EMCALbase/AliTrackContainer.h
+++ b/PWG/EMCAL/EMCALbase/AliTrackContainer.h
@@ -105,8 +105,9 @@ class AliTrackContainer : public AliParticleContainer {
     kRejected = -1,                  ///< Track rejected
     kUndefined = 0,                  ///< Track status undefined
     kHybridGlobal = 0,               ///< Track selected under the global hybrid track cuts
-    kHybridConstrained = 1,          ///< Track selected under the constrained hybrid track cuts
-    kHybridConstrainedNoITSrefit = 2,///< Track selected under the constrained hybrid track cuts without ITS refit
+    kHybridConstrainedTrue = 1,      ///< Track selected under the constrained hybrid track cuts (true constrained)
+    kHybridConstrainedFake = 2,      ///< Track selected under the constrained hybrid track cuts (fake constrained)
+    kHybridConstrainedNoITSrefit = 3,///< Track selected under the constrained hybrid track cuts without ITS refit
   };
 
   AliTrackContainer();

--- a/PWG/EMCAL/EMCALtasks/AliEmcalTrackingQATask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalTrackingQATask.cxx
@@ -295,6 +295,7 @@ void AliEmcalTrackingQATask::AllocateMatchedParticlesTHnSparse()
 void AliEmcalTrackingQATask::FillDetectorLevelTHnSparse(Double_t cent, Double_t trackEta, Double_t trackPhi, Double_t trackPt, 
     Double_t sigma1OverPt, Int_t mcGen, Byte_t trackType)
 {
+  AliDebugStream(10) << "Filling detector level THnSparse" << std::endl;
   std::vector<Double_t> contents(fTracks->GetNdimensions());
 
   for (Int_t i = 0; i < fTracks->GetNdimensions(); i++) {
@@ -392,10 +393,12 @@ void AliEmcalTrackingQATask::FillMatchedParticlesTHnSparse(Double_t cent, Double
  */
 Bool_t AliEmcalTrackingQATask::FillHistograms()
 {
+  AliDebugStream(1) << "Called: Tracks [" << fDetectorLevel->GetNTracks() << "], Accepted [" << fDetectorLevel->GetNAcceptedTracks() << "]\n";
   auto iterable = fDetectorLevel->accepted_momentum();
   for (auto trackIterator = iterable.begin(); trackIterator != iterable.end(); trackIterator++) {
     auto track = trackIterator->second;
     Byte_t type = fDetectorLevel->GetTrackType(track);
+    AliDebugStream(2) << "Next track of type " << static_cast<Int_t>(type) << std::endl;
     Byte_t ntracklets = 0;
     if (type <= 3) {
       Double_t sigma = 0;

--- a/PWG/EMCAL/EMCALtasks/AliEmcalTrackingQATask.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalTrackingQATask.h
@@ -32,6 +32,7 @@ class AliEmcalTrackingQATask : public AliAnalysisTaskEmcalLight {
   void                   UserCreateOutputObjects();
   void                   SetDoSigma1OverPt(Bool_t s)      {fDoSigma1OverPt     = s; }
   void                   SetDoSigmaPtOverPtGen(Bool_t s)  {fDoSigmaPtOverPtGen = s; }
+  void                   SetDoSeparateTRDrefit(Bool_t s)  {fDoSeparateTRDrefit = s; }
 
   static AliEmcalTrackingQATask* AddTaskTrackingQA(Bool_t isMC);
 
@@ -54,6 +55,7 @@ class AliEmcalTrackingQATask : public AliAnalysisTaskEmcalLight {
   // Task configuration
   Bool_t                  fDoSigma1OverPt        ; ///<  add sigma(1/pt), if false add sigma(pt)/pt instead
   Bool_t                  fDoSigmaPtOverPtGen    ; ///<  MC: if true do sigma((ptgen - ptdet) / ptgen), otherwise do sigma((ptgen - ptdet) / ptdet)
+  Bool_t                  fDoSeparateTRDrefit    ; ///<  Separate tracks into tracks with TRD refit and 4 tracklets (gold) or not (sub-gold)
 
   // Service fields (non-streamed)
   Bool_t                  fIsEsd                 ; //!<! whether it is ESD data


### PR DESCRIPTION
…amework

Hybrid track selection can be done only on ESDs, therefore
only ESD hybrid track selection is modified. Track cuts
are the same as in the 2011 definition, except
- Number of TPC crossed rows cut reduced to 30
- Cut on the number of TPC + TRD clusters set to at least
  120
Since the cut on the combined number of crossed rows +
TPC number of clusters is not yet available in the
AliESDtrackCuts the cut is implemented as a temporary
hack directly in AliEmcalESDHybridTrackCuts. The cut
is applied for both global and complementary hybrid
tracks. The cut is connected with the flag kDef2018TRD.