### PR TITLE
MCStatus with LCA and EMCal/DCal flag

### DIFF
--- a/PWGGA/EMCALTasks/AliAnalysisTaskGammaHadron.cxx
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskGammaHadron.cxx
@@ -1983,9 +1983,6 @@ void AliAnalysisTaskGammaHadron::FillPi0CandsHist(AliTLorentzVector CaloClusterV
 				if (iMCRootPartClus1 == iMCRootPartClus2) { //The MC Parts still have a common ancestor
 					AliAODMCParticle * pRootPart = fMCParticles->GetMCParticle(iMCRootPartClus1);
 
-					//FIXME delete me
-					if (pRootPart) printf("MHO: Shared Ancestor (height1,height2,pdg) = %2d %2d %d\n",iMCTreeHeight1,iMCTreeHeight2,pRootPart->GetPdgCode());
-
 					if (pRootPart && (221 == pRootPart->GetPdgCode())) MCMatchStatus = 5;
 					else MCMatchStatus = 6;
 				}

--- a/PWGGA/EMCALTasks/AliAnalysisTaskGammaHadron.cxx
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskGammaHadron.cxx
@@ -595,19 +595,18 @@ void AliAnalysisTaskGammaHadron::UserCreateOutputObjects()
     maxThnPi0[dimThnPi0] = 3;
     dimThnPi0++;
 
-    Double_t mcStatusArray[6+1];
+    Double_t mcStatusArray[7+1];
     if (fIsMC) {
       printf("Adding MCStatus to THnSparse\n"); //FIXME
       //..MC Status array: 0 - no Match, 1 - pair matched to pi0, 2 - pair match to eta
-      //  3 for gamma (PCM), 4 for same MC Part, 5 for other common ancestor 
-      ////  3 for gamma (PCM), 4 for shared grandmother (K^0, eta, etc.)
-      ////  3 for misc (2 pi0, 1 pi0, 1 eta, etc)
+      //  3 for gamma (PCM), 4 for same MC Part, 5 for eta common ancestor(not eta -> 2 gamma) 
+			// 6 for other common ancestor 
       titleThnPi0[dimThnPi0] = "MC Match Status";
-      nBinsThnPi0[dimThnPi0] = 6;
+      nBinsThnPi0[dimThnPi0] = 7;
       binEdgesThnPi0[dimThnPi0] = mcStatusArray;
-      GenerateFixedBinArray(6,0,6,mcStatusArray);
+      GenerateFixedBinArray(7,0,7,mcStatusArray);
       minThnPi0[dimThnPi0] = 0;
-      maxThnPi0[dimThnPi0] = 6;
+      maxThnPi0[dimThnPi0] = 7;
       dimThnPi0++;
     }
 
@@ -1982,7 +1981,13 @@ void AliAnalysisTaskGammaHadron::FillPi0CandsHist(AliTLorentzVector CaloClusterV
 				Int_t iMCRootPartClus2 = FindMCRootPart(mcIndex2,&iMCTreeHeight2);
 
 				if (iMCRootPartClus1 == iMCRootPartClus2) { //The MC Parts still have a common ancestor
-					MCMatchStatus = 5;
+					AliAODMCParticle * pRootPart = fMCParticles->GetMCParticle(iMCRootPartClus1);
+
+					//FIXME delete me
+					if (pRootPart) printf("MHO: Shared Ancestor (height1,height2,pdg) = %2d %2d %d\n",iMCTreeHeight1,iMCTreeHeight2,pRootPart->GetPdgCode());
+
+					if (pRootPart && (221 == pRootPart->GetPdgCode())) MCMatchStatus = 5;
+					else MCMatchStatus = 6;
 				}
 
 				if (false) {

--- a/PWGGA/EMCALTasks/AliAnalysisTaskGammaHadron.h
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskGammaHadron.h
@@ -46,6 +46,7 @@ public:
   void                        SetPlotMore(Int_t input)                              { fPlotQA          = input  ; }
   void                        SetEvtTriggerType(UInt_t input)                       { fTriggerType     = input  ; }
   void                        SetTriggerPtCut(Double_t input)                       { fTriggerPtCut    = input; }
+  void                        SetSubDetector(Int_t input)                           { fSubDetector     = input; }
   void                        SetEvtMixType(UInt_t input)                           { fMixingEventType = input  ; }
   void                        SetClEnergyMin(Int_t input)                           { fClEnergyMin     = input;}
   void                        SetOpeningAngleCut(Double_t input)                    { fOpeningAngleCut = input;}
@@ -102,6 +103,7 @@ public:
   //..Functions for MC purposes
   Int_t                       FindMCPartForClus(AliVCluster * caloCluster);
   Int_t                       FindMCRootPart(Int_t iMCIndex, Int_t * iMCTreeHeight);
+  Int_t                       FindMCLowComAnc(Int_t iMCIndex1, Int_t iMCIndex2);
 
 
   //..Delta phi does also exist in AliAnalysisTaskEmcal. It is overwritten here (ask Raymond)
@@ -140,6 +142,7 @@ public:
   Double_t                    fArrayNVertBins[21];       ///< 21=kNvertBins+1
 
   //..cuts
+	Int_t                       fSubDetector;              ///< Whether to use all clusters, ECal only, or DCal only
   Double_t                    fTriggerPtCut;             ///< Cut of 5 GeV/c on Trigger Pt
   Double_t                    fClShapeMin;               ///< Minimum cluster shape
   Double_t                    fClShapeMax;               ///< Maximum cluster shape


### PR DESCRIPTION
Modifies MC Status information to use a better classification method involving the Lowest Common Ancestor of the two clusters.
Also adds flag to select only main EMCal or only DCal.