### PR TITLE
Allow NULL pointer for MCEvent->GetTrack()/Particle()

### DIFF
--- a/PWGPP/ITS/AliAnalysisTaskITSTrackingCheck.cxx
+++ b/PWGPP/ITS/AliAnalysisTaskITSTrackingCheck.cxx
@@ -60,7 +60,6 @@
 #include "AliGenEventHeader.h" 
 #include "AliAnalysisTaskITSTrackingCheck.h"
 
-
 ClassImp(AliAnalysisTaskITSTrackingCheck)
 AliAnalysisTaskITSTrackingCheck::AliAnalysisTaskITSTrackingCheck() : 
 AliAnalysisTaskSE(), 
@@ -2043,7 +2042,8 @@ void AliAnalysisTaskITSTrackingCheck::UserExec(Option_t *)
     //printf("# generated particles = %d\n",ngenpart);
     dNchdy=0;
     for(Int_t ip=0; ip<ngenpart; ip++) {
-      part = ((AliMCParticle*)mcEvent->GetTrack(ip))->Particle();
+      part = mcEvent->Particle(ip);
+      if (!part) continue;
       // keep only electrons, muons, pions, kaons and protons
       Int_t apdg = TMath::Abs(part->GetPdgCode());
       if(apdg!=11 && apdg!=13 && apdg!=211 && apdg!=321 && apdg!=2212) continue;      
@@ -2238,13 +2238,14 @@ void AliAnalysisTaskITSTrackingCheck::UserExec(Option_t *)
     // check if it is primary
     if(fReadMC && mcEvent) {
       isPrimary = mcEvent->IsPhysicalPrimary(trkLabel);
-      part = ((AliMCParticle*)mcEvent->GetTrack(trkLabel))->Particle();
+      part = mcEvent->Particle(trkLabel);
+      if (!part) continue;
       rProdVtx = TMath::Sqrt((part->Vx()-mcVertex[0])*(part->Vx()-mcVertex[0])+(part->Vy()-mcVertex[1])*(part->Vy()-mcVertex[1]));
       zProdVtx = TMath::Abs(part->Vz()-mcVertex[2]);
       //if(rProdVtx<2.8) isPrimary=kTRUE; // this could be tried
       pdgTrk = TMath::Abs(part->GetPdgCode());
       if(part->GetFirstMother()>=0) {
-	TParticle* mm=((AliMCParticle*)mcEvent->GetTrack(part->GetFirstMother()))->Particle();
+	TParticle* mm = mcEvent->Particle(part->GetFirstMother());
 	if(mm) pdgMoth = TMath::Abs(mm->GetPdgCode());
       }
       if(pdgMoth==310 || pdgMoth==321 || pdgMoth==3122 || pdgMoth==3312) isFromStrange=kTRUE;
@@ -2806,7 +2807,8 @@ void AliAnalysisTaskITSTrackingCheck::UserExec(Option_t *)
     Float_t ptMC=-999.,pdgMC=-999.,d0MC=-999.;
     Double_t d0z0MCv[2]={-999.,-999.},covd0z0MCv[3]={1.,1.,1.};
     if(fReadMC) {
-      part = ((AliMCParticle*)mcEvent->GetTrack(trkLabel))->Particle();
+      part = mcEvent->Particle(trkLabel);
+      if (!part) continue;
       ptMC=part->Pt();
       pdgMC=part->GetPdgCode();
       d0MC=ParticleImpParMC(part,vertexMC,0.1*fESD->GetMagneticField());

--- a/PWGPP/ITS/AliAnalysisTaskITSsaTracks.cxx
+++ b/PWGPP/ITS/AliAnalysisTaskITSsaTracks.cxx
@@ -708,7 +708,8 @@ void AliAnalysisTaskITSsaTracks::UserExec(Option_t *)
     Float_t etagen=-999.;
     Float_t phigen=-999.;
     if(fReadMC){
-      TParticle* part = ((AliMCParticle*)mcEvent->GetTrack(TMath::Abs(trlabel)))->Particle();
+      TParticle* part = mcEvent->Particle(trlabel);
+      if (!part) continue;
       ptgen=part->Pt();
       //     pgen=part->P();
       pxgen=part->Px();
@@ -831,7 +832,8 @@ void AliAnalysisTaskITSsaTracks::UserExec(Option_t *)
     Int_t hadronSpecie=-1;
     if(fReadMC && fUseMCId){
       if(trlabel>=0){
-	TParticle* part = ((AliMCParticle*)mcEvent->GetTrack(trlabel))->Particle();
+	TParticle* part = mcEvent->Particle(trlabel);
+	if (!part) continue;	
 	Int_t pdg=TMath::Abs(part->GetPdgCode());
 	if(pdg==211) hadronSpecie=kPion;
 	else if(pdg==321) hadronSpecie=kKaon;
@@ -883,7 +885,8 @@ void AliAnalysisTaskITSsaTracks::UserExec(Option_t *)
 	
       if(fReadMC){  
 	if(trlabel>=0){
-	  TParticle* part =  ((AliMCParticle*)mcEvent->GetTrack(trlabel))->Particle();
+	  TParticle* part = mcEvent->Particle(trlabel);
+	  if (!part) continue;
 	  ptgen=part->Pt();
 	  Float_t invpttrack=track->OneOverPt();
 	  Float_t invptgen=0.;

--- a/PWGPP/TRD/AliTRDinfoGen.cxx
+++ b/PWGPP/TRD/AliTRDinfoGen.cxx
@@ -643,6 +643,7 @@ void AliTRDinfoGen::UserExec(Option_t *){
     if(HasMCdata()){
       label = esdTrack->GetLabel(); 
       alab = TMath::Abs(label);
+      if (alab>=nTracksMC) continue; // bg track?
       // register the track
       // RS: this check makes no sense for events with embedding
       //      if(alab < UInt_t(nTracksMC)){ 


### PR DESCRIPTION
In case a MC track for dummy label (3151493) was requested, the
AliMCEvent will return 0 pointer. Protection is added for this case