### PR TITLE
PWG/Cocktail: added cocktail feature for wider y range and eta gamma cut

### DIFF
--- a/PWG/Cocktail/macros/AddMCEMCocktailV2.C
+++ b/PWG/Cocktail/macros/AddMCEMCocktailV2.C
@@ -13,7 +13,8 @@ AliGenerator* AddMCEMCocktailV2(  Int_t collisionsSystem      = 200,
                                   Bool_t dynamicalPtRange     = 0,
                                   Bool_t useYWeights          = 0,
                                   TString paramV2FileDir      = "",
-                                  Bool_t toFixEP              =0
+                                  Bool_t toFixEP              = 0,
+                                  Double_t yGenRange          = 1.0
                                 )
 {
   // collisions systems defined:
@@ -45,7 +46,7 @@ AliGenerator* AddMCEMCocktailV2(  Int_t collisionsSystem      = 200,
   gener->SetFixedEventPlane(toFixEP) ;
   gener->SetDynamicalPtRange(dynamicalPtRange);
   gener->SetUseYWeighting(useYWeights);
-  gener->SetYRange(-1.,1.);
+  gener->SetYRange(-yGenRange,yGenRange);
   gener->SetPhiRange(0., 360.);
   gener->SetOrigin(0.,0.,0.); 
   gener->SetSigma(0.,0.,0.);

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCocktailMC.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCocktailMC.cxx
@@ -93,7 +93,8 @@ AliAnalysisTaskGammaCocktailMC::AliAnalysisTaskGammaCocktailMC(): AliAnalysisTas
   fUserInfo(NULL),
   fOutputTree(NULL),
   fIsMC(1),
-  fMaxY(2)
+  fMaxY(2),
+  fMaxEta(0)
 {
 
 }
@@ -138,7 +139,8 @@ AliAnalysisTaskGammaCocktailMC::AliAnalysisTaskGammaCocktailMC(const char *name)
   fUserInfo(NULL),
   fOutputTree(NULL),
   fIsMC(1),
-  fMaxY(2)
+  fMaxY(2),
+  fMaxEta(0)
 {
   // Define output slots here
   DefineOutput(1, TList::Class());
@@ -530,9 +532,14 @@ void AliAnalysisTaskGammaCocktailMC::ProcessMCParticles(){
     if( yPre <= 0 ) continue;
 
     Double_t y = 0.5*TMath::Log(yPre);
-    if (TMath::Abs(y) > fMaxY) continue;
-
+    
     if(particle->GetPdgCode()==22 && hasMother==kTRUE){
+      // additional condition to remove gammas out of eta range
+      if (fMaxEta>0){
+        if (TMath::Abs(particle->Eta()) > fMaxEta) continue;
+      } else {
+        if (TMath::Abs(y) > fMaxY) continue;
+      }
       if(motherIsPrimary && fHasMother[GetParticlePosLocal(motherParticle->GetPdgCode())]){
         fHistPtYGamma->Fill(particle->Pt(), particle->Y(), particle->GetWeight());
         fHistPtPhiGamma->Fill(particle->Pt(), particle->Phi(), particle->GetWeight());
@@ -652,7 +659,8 @@ void AliAnalysisTaskGammaCocktailMC::ProcessMCParticles(){
         }
       }
     }
-
+    // remove particles (not gammas) outside of defined rapidity range
+    if (TMath::Abs(y) > fMaxY) continue;
     if(particle->GetPdgCode()!=22 && particleIsPrimary && fHasMother[GetParticlePosLocal(particle->GetPdgCode())]){
 
       Double_t alpha    = -999;

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCocktailMC.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCocktailMC.h
@@ -26,6 +26,7 @@ class AliAnalysisTaskGammaCocktailMC : public AliAnalysisTaskSE {
     void SetLogBinningXTH1(TH1* histoRebin);
     void SetLogBinningXTH2(TH2* histoRebin);
     void SetMaxY(Double_t maxy){fMaxY = maxy;}
+    void SetMaxEta(Double_t maxeta){fMaxEta = maxeta;}
     void SetLightOutput(Bool_t flag) {fDoLightOutput = flag;}
     void InitializeDecayChannelHist(TH1F* hist, Int_t np);
     void FillPythiaBranchingRatio(TH1F* histo, Int_t np);
@@ -92,12 +93,13 @@ class AliAnalysisTaskGammaCocktailMC : public AliAnalysisTaskSE {
     TTree*                      fOutputTree;
     Int_t                       fIsMC;                          // MC flag
     Double_t                    fMaxY;                          // Max y
+    Double_t                    fMaxEta;                          // Max Eta
 
   private:
     AliAnalysisTaskGammaCocktailMC(const AliAnalysisTaskGammaCocktailMC&);            // Prevent copy-construction
     AliAnalysisTaskGammaCocktailMC &operator=(const AliAnalysisTaskGammaCocktailMC&); // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaCocktailMC, 6);
+    ClassDef(AliAnalysisTaskGammaCocktailMC, 7);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskHadronicCocktailMC.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskHadronicCocktailMC.cxx
@@ -93,7 +93,8 @@ AliAnalysisTaskHadronicCocktailMC::AliAnalysisTaskHadronicCocktailMC(): AliAnaly
   fUserInfo(NULL),
   fOutputTree(NULL),
   fIsMC(1),
-  fMaxY(2)
+  fMaxY(2),
+  fMaxEta(0)
 {
 
 }
@@ -138,7 +139,8 @@ AliAnalysisTaskHadronicCocktailMC::AliAnalysisTaskHadronicCocktailMC(const char 
   fUserInfo(NULL),
   fOutputTree(NULL),
   fIsMC(1),
-  fMaxY(2)
+  fMaxY(2),
+  fMaxEta(0)
 {
   // Define output slots here
   DefineOutput(1, TList::Class());
@@ -515,7 +517,6 @@ void AliAnalysisTaskHadronicCocktailMC::ProcessMCParticles(){
     if( yPre <= 0 ) continue;
 
     Double_t y = 0.5*TMath::Log(yPre);
-    if (TMath::Abs(y) > fMaxY) continue;
 
     Int_t                       PdgAnalyzedParticle = 0;
     if (fAnalyzedMeson==0)      PdgAnalyzedParticle = 111;
@@ -524,6 +525,7 @@ void AliAnalysisTaskHadronicCocktailMC::ProcessMCParticles(){
 
     // pi0/eta/pi+- from source
     if(TMath::Abs(particle->GetPdgCode())==PdgAnalyzedParticle && hasMother==kTRUE){
+      if (TMath::Abs(y) > fMaxY) continue;
       if(motherIsPrimary && fHasMother[GetParticlePosLocal(motherParticle->GetPdgCode())]){
 
         switch(motherParticle->GetPdgCode()){
@@ -680,6 +682,7 @@ void AliAnalysisTaskHadronicCocktailMC::ProcessMCParticles(){
 
     // source
     if(particle->GetPdgCode()!=PdgAnalyzedParticle && particleIsPrimary && fHasMother[GetParticlePosLocal(particle->GetPdgCode())]){
+      if (TMath::Abs(y) > fMaxY) continue;
 
       switch(particle->GetPdgCode()){
         case 221:
@@ -834,6 +837,12 @@ void AliAnalysisTaskHadronicCocktailMC::ProcessMCParticles(){
 
     // gamma from X/pi0 from source
     if (particle->GetPdgCode()==22 && motherHasMother) {
+      // additional condition to remove gammas out of eta range
+      if (fMaxEta>0){
+        if (TMath::Abs(particle->Eta()) > fMaxEta) continue;
+      } else {
+        if (TMath::Abs(y) > fMaxY) continue;
+      }
       if (grandMotherIsPrimary && fHasMother[GetParticlePosLocal(grandMotherParticle->GetPdgCode())]) {
 
         switch(grandMotherParticle->GetPdgCode()){

--- a/PWGGA/GammaConv/AliAnalysisTaskHadronicCocktailMC.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskHadronicCocktailMC.h
@@ -24,6 +24,7 @@ class AliAnalysisTaskHadronicCocktailMC : public AliAnalysisTaskSE {
 
     // setters
     void SetMaxY(Double_t maxy){fMaxY = maxy;}
+    void SetMaxEta(Double_t maxeta){fMaxEta = maxeta;}
     void SetLightOutput(Bool_t flag) {fDoLightOutput = flag;}
     void SetAnalyzedParticle(Int_t flag);
     void SetHasMother(UInt_t selectedMothers);
@@ -95,13 +96,14 @@ class AliAnalysisTaskHadronicCocktailMC : public AliAnalysisTaskSE {
     TTree*                      fOutputTree;
     Int_t                       fIsMC;                            // MC flag
     Double_t                    fMaxY;                            // Max y
+    Double_t                    fMaxEta;                          // Max Eta
 
   
   private:
     AliAnalysisTaskHadronicCocktailMC(const AliAnalysisTaskHadronicCocktailMC&);              // Prevent copy-construction
     AliAnalysisTaskHadronicCocktailMC &operator=(const AliAnalysisTaskHadronicCocktailMC&);   // Prevent assignment
   
-    ClassDef(AliAnalysisTaskHadronicCocktailMC, 8);
+    ClassDef(AliAnalysisTaskHadronicCocktailMC, 9);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_GammaCocktailMC.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCocktailMC.C
@@ -1,7 +1,31 @@
-void AddTask_GammaCocktailMC(Bool_t runLightOutput = kFALSE, TString maxyset = "0.80") {
+void AddTask_GammaCocktailMC(Bool_t runLightOutput = kFALSE, TString maxyetaset = "0.80") {
 
-  Double_t maxy = maxyset.Atof();
-  maxy         /= 100;  // needed to enable subwagon feature on grid
+  TObjArray *rConfigRapandEta = maxyetaset.Tokenize("_");
+  if(rConfigRapandEta->GetEntries()<1){cout << "ERROR: AddTask_GammaCocktailMC during parsing of maxyetaset String '" << maxyetaset.Data() << "'" << endl; return;}
+  TObjString* rmaxyset;
+  TObjString* rmaxetaset;
+  Bool_t fEtaSet = kFALSE;
+  for(Int_t i = 0; i<rConfigRapandEta->GetEntries() ; i++){
+    if(i==0)
+      rmaxyset                = (TObjString*) rConfigRapandEta->At(i);
+    else{
+      rmaxetaset              = (TObjString*) rConfigRapandEta->At(i);
+      fEtaSet                 = kTRUE;
+    }
+  }
+  TString maxyset             = rmaxyset->GetString();
+  Double_t maxy               = maxyset.Atof();
+  maxy                        /= 100;  // needed to enable subwagon feature on grid
+  cout << "running with max y cut of: " << maxy << endl;
+
+  TString maxetaset;
+  Double_t maxeta;
+  if(fEtaSet){
+    maxetaset                 = rmaxetaset->GetString();
+    maxeta                    = maxetaset.Atof();
+    maxeta                    /= 100;  // needed to enable subwagon feature on grid
+    cout << "running with max eta cut of: " << maxeta << endl;
+  }
 
   // ================== GetAnalysisManager ===============================
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
@@ -20,13 +44,15 @@ void AddTask_GammaCocktailMC(Bool_t runLightOutput = kFALSE, TString maxyset = "
   //================================================
   //            find input container
   AliAnalysisTaskGammaCocktailMC *task=NULL;
-  task= new AliAnalysisTaskGammaCocktailMC(Form("GammaCocktailMC_%1.2f",maxy));
+  task= new AliAnalysisTaskGammaCocktailMC(fEtaSet ? Form("GammaCocktailMC_%1.2f_%1.2f",maxy,maxeta) : Form("GammaCocktailMC_%1.2f",maxy));
   task->SetMaxY(maxy);
+  if(fEtaSet)
+    task->SetMaxEta(maxeta);
   task->SetLightOutput(runLightOutput);
   
   //connect containers
   AliAnalysisDataContainer *coutput =
-    mgr->CreateContainer(Form("GammaCocktailMC_%1.2f",maxy), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:GammaCocktailMC",AliAnalysisManager::GetCommonFileName()));
+    mgr->CreateContainer(fEtaSet ? Form("GammaCocktailMC_%1.2f_%1.2f",maxy,maxeta) : Form("GammaCocktailMC_%1.2f",maxy), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:GammaCocktailMC",AliAnalysisManager::GetCommonFileName()));
     
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);

--- a/PWGGA/GammaConv/macros/AddTask_HadronicCocktailMC.C
+++ b/PWGGA/GammaConv/macros/AddTask_HadronicCocktailMC.C
@@ -1,7 +1,31 @@
-void AddTask_HadronicCocktailMC(Int_t particleFlag = 0, Bool_t runLightOutput = kFALSE, TString maxyset = "0.8") {
+void AddTask_HadronicCocktailMC(Int_t particleFlag = 0, Bool_t runLightOutput = kFALSE, TString maxyetaset = "0.80") {
 
-  Double_t maxy = maxyset.Atof();
-  maxy         /= 100;  // needed to enable subwagon feature on grid
+    TObjArray *rConfigRapandEta = maxyetaset.Tokenize("_");
+    if(rConfigRapandEta->GetEntries()<1){cout << "ERROR: AddTask_HadronicCocktailMC during parsing of maxyetaset String '" << maxyetaset.Data() << "'" << endl; return;}
+    TObjString* rmaxyset;
+    TObjString* rmaxetaset;
+    Bool_t fEtaSet = kFALSE;
+    for(Int_t i = 0; i<rConfigRapandEta->GetEntries() ; i++){
+      if(i==0)
+        rmaxyset                = (TObjString*) rConfigRapandEta->At(i);
+      else{
+        rmaxetaset              = (TObjString*) rConfigRapandEta->At(i);
+        fEtaSet                 = kTRUE;
+      }
+    }
+    TString maxyset             = rmaxyset->GetString();
+    Double_t maxy               = maxyset.Atof();
+    maxy                        /= 100;  // needed to enable subwagon feature on grid
+    cout << "running with max y cut of: " << maxy << endl;
+
+    TString maxetaset;
+    Double_t maxeta;
+    if(fEtaSet){
+      maxetaset                 = rmaxetaset->GetString();
+      maxeta                    = maxetaset.Atof();
+      maxeta                    /= 100;  // needed to enable subwagon feature on grid
+      cout << "running with max eta cut of: " << maxeta << endl;
+    }
 
   // ================== GetAnalysisManager ===============================
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
@@ -20,8 +44,10 @@ void AddTask_HadronicCocktailMC(Int_t particleFlag = 0, Bool_t runLightOutput = 
   //================================================
   //            find input container
   AliAnalysisTaskHadronicCocktailMC *task=NULL;
-  task = new AliAnalysisTaskHadronicCocktailMC(Form("HadronicCocktailMC_%1.2f",maxy));
+  task = new AliAnalysisTaskHadronicCocktailMC(fEtaSet ? Form("HadronicCocktailMC_%1.2f_%1.2f",maxy,maxeta) : Form("HadronicCocktailMC_%1.2f",maxy));
   task->SetMaxY(maxy);
+  if(fEtaSet)
+    task->SetMaxEta(maxeta);
   task->SetLightOutput(runLightOutput);
   task->SetAnalyzedParticle(particleFlag);          // switch to run: 0 - pi0, 1 - eta, 2 - pi+-
 
@@ -32,7 +58,7 @@ void AddTask_HadronicCocktailMC(Int_t particleFlag = 0, Bool_t runLightOutput = 
 
   //connect containers
   AliAnalysisDataContainer *coutput =
-  mgr->CreateContainer(Form("HadronicCocktailMC_%s_%1.2f",analyzedParticle.Data(),maxy), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:HadronicCocktailMC",AliAnalysisManager::GetCommonFileName()));
+  mgr->CreateContainer(fEtaSet ? Form("HadronicCocktailMC_%s_%1.2f_%1.2f",analyzedParticle.Data(),maxy,maxeta) : Form("HadronicCocktailMC_%s_%1.2f",analyzedParticle.Data(),maxy), TList::Class(), AliAnalysisManager::kOutputContainer, Form("%s:HadronicCocktailMC",AliAnalysisManager::GetCommonFileName()));
 
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);


### PR DESCRIPTION
Added the possibility to generate the cocktail particles in user defined rapidity range (default is still |y|<1)
Added the possibility to cut differently on photons and hadrons. For this, an eta cut has been added which is applied when it is set via the last argument of the AddTask. 
For example, AddTask_GammaCocktailMC(kFALSE,"80_90"); will apply a cut of  |y|<0.8 on hadrons and |eta|<0.9 on photons. This feature is now implemented for GammaCocktail and HadronicCocktail.
If the same cut on photons and hadrons should be used, then for example "80_80" and "80" would result in the same output.