### PR TITLE
PWGGA/GammaConv introducing EOverP cut in TM

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMerged.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMerged.cxx
@@ -1481,9 +1481,9 @@ void AliAnalysisTaskGammaCaloMerged::ProcessClusters(){
   ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->FillHistogramsExtendedQA(fInputEvent,fIsMC);
 
   // match tracks to clusters
-  ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->MatchTracksToClusters(fInputEvent);
+  ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->MatchTracksToClusters(fInputEvent, fWeightJetJetMC, kTRUE, fMCEvent);
   // match tracks to clusters also for mergedCutArray
-  ((AliCaloPhotonCuts*)fClusterMergedCutArray->At(fiCut))->MatchTracksToClusters(fInputEvent);
+  ((AliCaloPhotonCuts*)fClusterMergedCutArray->At(fiCut))->MatchTracksToClusters(fInputEvent, fWeightJetJetMC, kTRUE, fMCEvent);
 
   // vertex
   Double_t vertex[3] = {0};

--- a/PWGGA/GammaConv/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConv/AliCaloPhotonCuts.cxx
@@ -136,6 +136,8 @@ AliCaloPhotonCuts::AliCaloPhotonCuts(Int_t isMC, const char *name,const char *ti
   fUsePtDepTrackToCluster(0),
   fFuncPtDepEta(0),
   fFuncPtDepPhi(0),
+  fUseEOverPVetoTM(0),
+  fEOverPMax(0.),
   fExtendedMatchAndQA(0),
   fExoticEnergyFracCluster(0),
   fExoticMinEnergyCell(1),
@@ -244,12 +246,8 @@ AliCaloPhotonCuts::AliCaloPhotonCuts(Int_t isMC, const char *name,const char *ti
   fHistClusterEnergyvsNCellsExotics(NULL),
   fHistClusterEEstarExotics(NULL),
   fHistClusterTMEffiInput(NULL),
-  fHistClusterElecEtaPhiBeforeTM_00_20(NULL),
-  fHistClusterElecEtaPhiBeforeTM_20_50(NULL),
-  fHistClusterElecEtaPhiBeforeTM_50_00(NULL),
-  fHistClusterElecEtaPhiAfterTM_00_20(NULL),
-  fHistClusterElecEtaPhiAfterTM_20_50(NULL),
-  fHistClusterElecEtaPhiAfterTM_50_00(NULL),
+  fHistClusterTrueElecEtaPhiBeforeTM_30_00(NULL),
+  fHistClusterTrueElecEtaPhiAfterTM_30_00(NULL),
   fHistClusterEvsTrackECharged(NULL),
   fHistClusterEvsTrackEChargedLead(NULL),
   fHistClusterEvsTrackENeutral(NULL),
@@ -261,6 +259,11 @@ AliCaloPhotonCuts::AliCaloPhotonCuts(Int_t isMC, const char *name,const char *ti
   fHistClusterENMatchesCharged(NULL),
   fHistClusterEvsTrackEPrimaryButNoElec(NULL),
   fHistClusterEvsTrackSumEPrimaryButNoElec(NULL),
+  fHistClusETruePi0_BeforeTM(NULL),
+  fHistClusETruePi0_Matched(NULL),
+  fHistMatchedTrackPClusE(NULL),
+  fHistMatchedTrackPClusEAfterEOverPVeto(NULL),
+  fHistMatchedTrackPClusETruePi0Clus(NULL),
   fNMaxDCalModules(8),
   fgkDCALCols(32),
   fIsAcceptedForBasic(kFALSE)
@@ -318,6 +321,8 @@ AliCaloPhotonCuts::AliCaloPhotonCuts(const AliCaloPhotonCuts &ref) :
   fUsePtDepTrackToCluster(ref.fUsePtDepTrackToCluster),
   fFuncPtDepEta(ref.fFuncPtDepEta),
   fFuncPtDepPhi(ref.fFuncPtDepPhi),
+  fUseEOverPVetoTM(ref.fUseEOverPVetoTM),
+  fEOverPMax(ref.fEOverPMax),
   fExtendedMatchAndQA(ref.fExtendedMatchAndQA),
   fExoticEnergyFracCluster(ref.fExoticEnergyFracCluster),
   fExoticMinEnergyCell(ref.fExoticMinEnergyCell),
@@ -426,12 +431,8 @@ AliCaloPhotonCuts::AliCaloPhotonCuts(const AliCaloPhotonCuts &ref) :
   fHistClusterEnergyvsNCellsExotics(NULL),
   fHistClusterEEstarExotics(NULL),
   fHistClusterTMEffiInput(NULL),
-  fHistClusterElecEtaPhiBeforeTM_00_20(NULL),
-  fHistClusterElecEtaPhiBeforeTM_20_50(NULL),
-  fHistClusterElecEtaPhiBeforeTM_50_00(NULL),
-  fHistClusterElecEtaPhiAfterTM_00_20(NULL),
-  fHistClusterElecEtaPhiAfterTM_20_50(NULL),
-  fHistClusterElecEtaPhiAfterTM_50_00(NULL),
+  fHistClusterTrueElecEtaPhiBeforeTM_30_00(NULL),
+  fHistClusterTrueElecEtaPhiAfterTM_30_00(NULL),
   fHistClusterEvsTrackECharged(NULL),
   fHistClusterEvsTrackEChargedLead(NULL),
   fHistClusterEvsTrackENeutral(NULL),
@@ -443,6 +444,11 @@ AliCaloPhotonCuts::AliCaloPhotonCuts(const AliCaloPhotonCuts &ref) :
   fHistClusterENMatchesCharged(NULL),
   fHistClusterEvsTrackEPrimaryButNoElec(NULL),
   fHistClusterEvsTrackSumEPrimaryButNoElec(NULL),
+  fHistClusETruePi0_BeforeTM(NULL),
+  fHistClusETruePi0_Matched(NULL),
+  fHistMatchedTrackPClusE(NULL),
+  fHistMatchedTrackPClusEAfterEOverPVeto(NULL),
+  fHistMatchedTrackPClusETruePi0Clus(NULL),
   fNMaxDCalModules(ref.fNMaxDCalModules),
   fgkDCALCols(ref.fgkDCALCols),
   fIsAcceptedForBasic(ref.fIsAcceptedForBasic)
@@ -506,10 +512,12 @@ void AliCaloPhotonCuts::InitCutHistograms(TString name){
 
   Double_t *arrClusEBinning        = new Double_t[400];
   Double_t *arrClusEBinningCoarse  = new Double_t[400];
+  Double_t *arrClusEBinningOnlyHighPt  = new Double_t[400];
   Int_t nBinsClusterE              = 235;
   Int_t nBinsClusterEMod           = 249;
   Int_t nBinsClusterECell          = 119;
   Int_t nBinsClusterECellCoarse    = 109;
+  Int_t nBinsClusterEOnlyHighPt    = 134;
   Double_t maxClusterE             = 400;
   for(Int_t i=0; i<nBinsClusterEMod+1;i++){
     if (i < 1) arrClusEBinning[i]          = 0.3*i;
@@ -534,6 +542,16 @@ void AliCaloPhotonCuts::InitCutHistograms(TString name){
     else if(i<109) arrClusEBinningCoarse[i]       = 40.+5.0*(i-97);
     else if(i<119) arrClusEBinningCoarse[i]       = 100.+10.0*(i-109);
     else arrClusEBinningCoarse[i]                 = 200;
+  }
+  for(Int_t i=0; i<nBinsClusterEOnlyHighPt+1;i++){
+    if(i<25) arrClusEBinningOnlyHighPt[i]         = 10.+0.2*i;
+    else if(i<55) arrClusEBinningOnlyHighPt[i]    = 15.+0.5*(i-25);
+    else if(i<75) arrClusEBinningOnlyHighPt[i]    = 30.+1.0*(i-55);
+    else if(i<100) arrClusEBinningOnlyHighPt[i]   = 50.+2.0*(i-75);
+    else if(i<120) arrClusEBinningOnlyHighPt[i]   = 100.+5.0*(i-100);
+    else if(i<130) arrClusEBinningOnlyHighPt[i]   = 200.+10.0*(i-120);
+    else if(i<134) arrClusEBinningOnlyHighPt[i]   = 300.+25.0*(i-130);
+    else arrClusEBinningOnlyHighPt[i]             = maxClusterE;
   }
 
   // IsPhotonSelected
@@ -1155,7 +1173,7 @@ void AliCaloPhotonCuts::InitCutHistograms(TString name){
       fHistClusterdPhidPtAfterQA->GetYaxis()->SetTitle("p_{T} (GeV/c)");
       fHistograms->Add(fHistClusterdPhidPtAfterQA);
 
-      if(fIsMC > 0){
+      if(fIsMC > 0 && fIsPureCalo == 0){ // these histograms are so far only used in conjunction with PCM, namely in MatchConvPhotonToCluster
         fHistClusterdEtadPtTrueMatched                = new TH2F(Form("dEtaVsPt_TrueMatched %s",GetCutNumber().Data()),"dEtaVsPt_TrueMatched",nEtaBins,EtaRange[0],EtaRange[1],
                                                                   nBinsClusterEMod, arrClusEBinning);
         fHistClusterdEtadPtTrueMatched->GetXaxis()->SetTitle("d#eta_{cl-track}");
@@ -1183,6 +1201,21 @@ void AliCaloPhotonCuts::InitCutHistograms(TString name){
       fHistClusterM20M02AfterQA->GetYaxis()->SetTitle("#sigma_{long}^2");
       fHistograms->Add(fHistClusterM20M02AfterQA);
 
+      if(fUseEOverPVetoTM){
+        // plot trackP vs. clusterE in case of a match
+        fHistMatchedTrackPClusE  = new TH2F(Form("MatchedTrackPClusE %s",GetCutNumber().Data()), "Matched tracks: #it{P}_{track} vs #it{E}_{cl}",
+                                            nBinsClusterEOnlyHighPt, arrClusEBinningOnlyHighPt, nBinsClusterEOnlyHighPt, arrClusEBinningOnlyHighPt);
+        fHistMatchedTrackPClusE->GetXaxis()->SetTitle("E_{cl} (GeV)");
+        fHistMatchedTrackPClusE->GetYaxis()->SetTitle("P_{track} (GeV/c)");
+        fHistograms->Add(fHistMatchedTrackPClusE);
+
+        // plot trackP vs. clusterE in case of a match AFTER EOverP veto has been applied
+        fHistMatchedTrackPClusEAfterEOverPVeto = new TH2F(Form("MatchedTrackPClusEAfterEOverPVeto  %s",GetCutNumber().Data()), "Matched tracks after EOverP veto: #it{P}_{track} vs #it{E}_{cl}",
+                                                        nBinsClusterEOnlyHighPt, arrClusEBinningOnlyHighPt, nBinsClusterEOnlyHighPt, arrClusEBinningOnlyHighPt);
+        fHistMatchedTrackPClusEAfterEOverPVeto ->GetXaxis()->SetTitle("E_{cl} (GeV)");
+        fHistMatchedTrackPClusEAfterEOverPVeto ->GetYaxis()->SetTitle("P_{track} (GeV/c)");
+        fHistograms->Add(fHistMatchedTrackPClusEAfterEOverPVeto);
+      }
       //----------------
       if(fIsMC > 1){
         fHistClusterRBeforeQA->Sumw2();
@@ -1209,6 +1242,10 @@ void AliCaloPhotonCuts::InitCutHistograms(TString name){
         fHistClusterdPhidPtNegTracksTrueMatched->Sumw2();
         fHistClusterM20M02BeforeQA->Sumw2();
         fHistClusterM20M02AfterQA->Sumw2();
+        if(fUseEOverPVetoTM){
+          fHistMatchedTrackPClusE->Sumw2();
+          fHistMatchedTrackPClusEAfterEOverPVeto->Sumw2();
+        }
       }
       //----------------
     }
@@ -1220,31 +1257,16 @@ void AliCaloPhotonCuts::InitCutHistograms(TString name){
     Float_t EmcalEtaBins[nEmcalEtaBins+1] = {-0.66687,-0.653,-0.63913,-0.62526,-0.61139,-0.59752,-0.58365,-0.56978,-0.55591,-0.54204,-0.52817,-0.5143,-0.50043,-0.48656,-0.47269,-0.45882,-0.44495,-0.43108,-0.41721,-0.40334,-0.38947,-0.3756,-0.36173,-0.34786,-0.33399,-0.32012,-0.30625,-0.29238,-0.27851,-0.26464,-0.25077,-0.2369,-0.22303,-0.20916,-0.19529,-0.18142,-0.16755,-0.15368,-0.13981,-0.12594,-0.11207,-0.0982,-0.08433,-0.07046,-0.05659,-0.04272,-0.02885,-0.01498,-0.00111,0.01276,0.02663,0.0405,0.05437,0.06824,0.08211,0.09598,0.10985,0.12372,0.13759,0.15146,0.16533,0.1792,0.19307,0.20694,0.22081,0.23468,0.24855,0.26242,0.27629,0.29016,0.30403,0.3179,0.33177,0.34564,0.35951,0.37338,0.38725,0.40112,0.41499,0.42886,0.44273,0.4566,0.47047,0.48434,0.49821,0.51208,0.52595,0.53982,0.55369,0.56756,0.58143,0.5953,0.60917,0.62304,0.63691,0.65078,0.66465};
     Float_t EmcalPhiBins[nEmcalPhiBins+1] = {1.408,1.4215,1.435,1.4485,1.462,1.4755,1.489,1.5025,1.516,1.5295,1.543,1.5565,1.57,1.5835,1.597,1.6105,1.624,1.6375,1.651,1.6645,1.678,1.6915,1.705,1.7185,1.732,1.758,1.7715,1.785,1.7985,1.812,1.8255,1.839,1.8525,1.866,1.8795,1.893,1.9065,1.92,1.9335,1.947,1.9605,1.974,1.9875,2.001,2.0145,2.028,2.0415,2.055,2.0685,2.082,2.108,2.1215,2.135,2.1485,2.162,2.1755,2.189,2.2025,2.216,2.2295,2.243,2.2565,2.27,2.2835,2.297,2.3105,2.324,2.3375,2.351,2.3645,2.378,2.3915,2.405,2.4185,2.432,2.456,2.4695,2.483,2.4965,2.51,2.5235,2.537,2.5505,2.564,2.5775,2.591,2.6045,2.618,2.6315,2.645,2.6585,2.672,2.6855,2.699,2.7125,2.726,2.7395,2.753,2.7665,2.78,2.804,2.8175,2.831,2.8445,2.858,2.8715,2.885,2.8985,2.912,2.9255,2.939,2.9525,2.966,2.9795,2.993,3.0065,3.02,3.0335,3.047,3.0605,3.074,3.0875,3.101,3.1145,3.128};
 
-    fHistClusterElecEtaPhiBeforeTM_00_20  = new TH2F(Form("ElecEtaPhiBeforeTM_clusterE<20_Histo %s",GetCutNumber().Data()),"ElecEtaPhiBeforeTM_clusterE<20_Histo",nEmcalPhiBins,EmcalPhiBins,nEmcalEtaBins,EmcalEtaBins);
-    fHistClusterElecEtaPhiBeforeTM_00_20->GetXaxis()->SetTitle("#varphi (rad)");
-    fHistClusterElecEtaPhiBeforeTM_00_20->GetYaxis()->SetTitle("#eta");
-    fHistograms->Add(fHistClusterElecEtaPhiBeforeTM_00_20);
-    fHistClusterElecEtaPhiBeforeTM_20_50  = new TH2F(Form("ElecEtaPhiBeforeTM_20<clusterE<50_Histo %s",GetCutNumber().Data()),"ElecEtaPhiBeforeTM_20<clusterE<50_Histo",nEmcalPhiBins,EmcalPhiBins,nEmcalEtaBins,EmcalEtaBins);
-    fHistClusterElecEtaPhiBeforeTM_20_50->GetXaxis()->SetTitle("#varphi (rad)");
-    fHistClusterElecEtaPhiBeforeTM_20_50->GetYaxis()->SetTitle("#eta");
-    fHistograms->Add(fHistClusterElecEtaPhiBeforeTM_20_50);
-    fHistClusterElecEtaPhiBeforeTM_50_00  = new TH2F(Form("ElecEtaPhiBeforeTM_50<clusterE_Histo %s",GetCutNumber().Data()),"ElecEtaPhiBeforeTM_50<clusterE_Histo",nEmcalPhiBins,EmcalPhiBins,nEmcalEtaBins,EmcalEtaBins);
-    fHistClusterElecEtaPhiBeforeTM_50_00->GetXaxis()->SetTitle("#varphi (rad)");
-    fHistClusterElecEtaPhiBeforeTM_50_00->GetYaxis()->SetTitle("#eta");
-    fHistograms->Add(fHistClusterElecEtaPhiBeforeTM_50_00);
+    fHistClusterTrueElecEtaPhiBeforeTM_30_00  = new TH2F(Form("ElecEtaPhiBeforeTM_clusterE>30_Histo %s",GetCutNumber().Data()),"electron clusters before track matching, E_{cl}>30GeV",nEmcalPhiBins,EmcalPhiBins,nEmcalEtaBins,EmcalEtaBins);
+    fHistClusterTrueElecEtaPhiBeforeTM_30_00->GetXaxis()->SetTitle("#varphi (rad)");
+    fHistClusterTrueElecEtaPhiBeforeTM_30_00->GetYaxis()->SetTitle("#eta");
+    fHistograms->Add(fHistClusterTrueElecEtaPhiBeforeTM_30_00);
 
-    fHistClusterElecEtaPhiAfterTM_00_20  = new TH2F(Form("ElecEtaPhiAfterTM_clusterE<20_Histo %s",GetCutNumber().Data()),"ElecEtaPhiAfterTM_clusterE<20_Histo",nEmcalPhiBins,EmcalPhiBins,nEmcalEtaBins,EmcalEtaBins);
-    fHistClusterElecEtaPhiAfterTM_00_20->GetXaxis()->SetTitle("#varphi (rad)");
-    fHistClusterElecEtaPhiAfterTM_00_20->GetYaxis()->SetTitle("#eta");
-    fHistograms->Add(fHistClusterElecEtaPhiAfterTM_00_20);
-    fHistClusterElecEtaPhiAfterTM_20_50  = new TH2F(Form("ElecEtaPhiAfterTM_20<clusterE<50_Histo %s",GetCutNumber().Data()),"ElecEtaPhiAfterTM_20<clusterE<50_Histo",nEmcalPhiBins,EmcalPhiBins,nEmcalEtaBins,EmcalEtaBins);
-    fHistClusterElecEtaPhiAfterTM_20_50->GetXaxis()->SetTitle("#varphi (rad)");
-    fHistClusterElecEtaPhiAfterTM_20_50->GetYaxis()->SetTitle("#eta");
-    fHistograms->Add(fHistClusterElecEtaPhiAfterTM_20_50);
-    fHistClusterElecEtaPhiAfterTM_50_00  = new TH2F(Form("ElecEtaPhiAfterTM_50<clusterE_Histo %s",GetCutNumber().Data()),"ElecEtaPhiAfterTM_50<clusterE_Histo",nEmcalPhiBins,EmcalPhiBins,nEmcalEtaBins,EmcalEtaBins);
-    fHistClusterElecEtaPhiAfterTM_50_00->GetXaxis()->SetTitle("#varphi (rad)");
-    fHistClusterElecEtaPhiAfterTM_50_00->GetYaxis()->SetTitle("#eta");
-    fHistograms->Add(fHistClusterElecEtaPhiAfterTM_50_00);
+
+    fHistClusterTrueElecEtaPhiAfterTM_30_00  = new TH2F(Form("ElecEtaPhiAfterTM_clusterE>30_Histo %s",GetCutNumber().Data()),"electron clusters before track matching, E_{cl}>30GeV",nEmcalPhiBins,EmcalPhiBins,nEmcalEtaBins,EmcalEtaBins);
+    fHistClusterTrueElecEtaPhiAfterTM_30_00->GetXaxis()->SetTitle("#varphi (rad)");
+    fHistClusterTrueElecEtaPhiAfterTM_30_00->GetYaxis()->SetTitle("#eta");
+    fHistograms->Add(fHistClusterTrueElecEtaPhiAfterTM_30_00);
 
     fHistClusterTMEffiInput                       = new TH2F(Form("TMEffiInputHisto %s",GetCutNumber().Data()),"TMEffiInputHisto",nBinsClusterE, arrClusEBinning, 22, -0.5, 21.5);
     fHistClusterTMEffiInput->GetYaxis()->SetBinLabel(1,"All cl");
@@ -1330,14 +1352,32 @@ void AliCaloPhotonCuts::InitCutHistograms(TString name){
     fHistClusterEvsTrackSumEPrimaryButNoElec->GetYaxis()->SetTitle("#sum#it{E}_{tr} (GeV)");
     fHistograms->Add(fHistClusterEvsTrackSumEPrimaryButNoElec);
 
+    if(fUseEOverPVetoTM){
+      fHistClusETruePi0_BeforeTM = new TH1F(Form("ClusETruePi0_BeforeTM %s",GetCutNumber().Data()), "true #pi^{0} clusters before TM",
+                                            nBinsClusterEOnlyHighPt, arrClusEBinningOnlyHighPt);
+      fHistClusETruePi0_BeforeTM->GetXaxis()->SetTitle("#it{E}_{cl} (GeV)");
+      fHistClusETruePi0_BeforeTM->GetYaxis()->SetTitle("weighted counts");
+      fHistograms->Add(fHistClusETruePi0_BeforeTM);
+
+      fHistClusETruePi0_Matched = new TH1F(Form("ClusETruePi0_Matched %s",GetCutNumber().Data()), "matched true #pi^{0} clusters",
+                                           nBinsClusterEOnlyHighPt, arrClusEBinningOnlyHighPt);
+      fHistClusETruePi0_Matched->GetXaxis()->SetTitle("#it{E}_{cl} (GeV)");
+      fHistClusETruePi0_Matched->GetYaxis()->SetTitle("weighted counts");
+      fHistograms->Add(fHistClusETruePi0_Matched);
+
+      // plot trackP vs. clusterE in case of a match with pi0
+      fHistMatchedTrackPClusETruePi0Clus  = new TH2F(Form("MatchedTrackPClusETruePi0Clus %s",GetCutNumber().Data()), "Matched tracks to #pi^{0} clusters: #it{P}_{track} vs #it{E}_{cl}",
+                                                      nBinsClusterEOnlyHighPt, arrClusEBinningOnlyHighPt, nBinsClusterEOnlyHighPt, arrClusEBinningOnlyHighPt);
+      fHistMatchedTrackPClusETruePi0Clus->GetXaxis()->SetTitle("E_{cl} (GeV)");
+      fHistMatchedTrackPClusETruePi0Clus->GetYaxis()->SetTitle("P_{track} (GeV/c)");
+      fHistograms->Add(fHistMatchedTrackPClusETruePi0Clus);
+    }
+
+
     if(fIsMC > 1){
       fHistClusterTMEffiInput->Sumw2();
-      fHistClusterElecEtaPhiBeforeTM_00_20->Sumw2();
-      fHistClusterElecEtaPhiBeforeTM_20_50->Sumw2();
-      fHistClusterElecEtaPhiBeforeTM_50_00->Sumw2();
-      fHistClusterElecEtaPhiAfterTM_00_20->Sumw2();
-      fHistClusterElecEtaPhiAfterTM_20_50->Sumw2();
-      fHistClusterElecEtaPhiAfterTM_50_00->Sumw2();
+      fHistClusterTrueElecEtaPhiBeforeTM_30_00->Sumw2();
+      fHistClusterTrueElecEtaPhiAfterTM_30_00->Sumw2();
       fHistClusterEvsTrackECharged->Sumw2();
       fHistClusterEvsTrackEChargedLead->Sumw2();
       fHistClusterEvsTrackENeutral->Sumw2();
@@ -1349,6 +1389,11 @@ void AliCaloPhotonCuts::InitCutHistograms(TString name){
       fHistClusterENMatchesCharged->Sumw2();
       fHistClusterEvsTrackEPrimaryButNoElec->Sumw2();
       fHistClusterEvsTrackSumEPrimaryButNoElec->Sumw2();
+      if(fUseEOverPVetoTM){
+        fHistMatchedTrackPClusETruePi0Clus->Sumw2();
+        fHistClusETruePi0_BeforeTM->Sumw2();
+        fHistClusETruePi0_Matched->Sumw2();
+      }
     }
   }
 
@@ -1814,8 +1859,10 @@ Bool_t AliCaloPhotonCuts::ClusterQualityCuts(AliVCluster* cluster, AliVEvent *ev
     leadMCLabel         = ((AliAODCaloCluster*)cluster)->GetLabel();
 
   // TM efficiency histograms before TM
-  if (fIsMC && isMC && (fExtendedMatchAndQA == 1 || fExtendedMatchAndQA == 3 || fExtendedMatchAndQA == 5) && fUseDistTrackToCluster){
+  if (fIsMC && isMC && (fExtendedMatchAndQA == 1 || fExtendedMatchAndQA == 3 || fExtendedMatchAndQA == 5) && fUseDistTrackToCluster  && !(fIsPureCalo > 0 && cluster->E() < 10.)){
     classification    = ClassifyClusterForTMEffi(cluster, event, mcEvent, isESD);
+    if(IsClusterPi0(event, mcEvent, cluster))
+      if(fHistClusETruePi0_BeforeTM) fHistClusETruePi0_BeforeTM->Fill(cluster->E(), weight);
     fHistClusterTMEffiInput->Fill(cluster->E(), 0., weight); //All cl
     if (classification == 5 )
       fHistClusterTMEffiInput->Fill(cluster->E(), 1., weight); //Ch cl
@@ -1825,13 +1872,10 @@ Bool_t AliCaloPhotonCuts::ClusterQualityCuts(AliVCluster* cluster, AliVEvent *ev
       fHistClusterTMEffiInput->Fill(cluster->E(), 6., weight); //conv electron cl
     if (classification == 6){
       fHistClusterTMEffiInput->Fill(cluster->E(), 8., weight); // electron cl
-      if (cluster->E() <= 20.)
-        fHistClusterElecEtaPhiBeforeTM_00_20->Fill(phiCluster, etaCluster, weight);
-      if (cluster->E() > 20 && cluster->E() <= 50.)
-        fHistClusterElecEtaPhiBeforeTM_20_50->Fill(phiCluster, etaCluster, weight);
-      if (cluster->E() > 50.)
-        fHistClusterElecEtaPhiBeforeTM_50_00->Fill(phiCluster, etaCluster, weight);
+      if (cluster->E() > 30.)
+        fHistClusterTrueElecEtaPhiBeforeTM_30_00->Fill(phiCluster, etaCluster, weight);
     }
+
     if (classification == 0 || classification == 1)
       fHistClusterTMEffiInput->Fill(cluster->E(), 2., weight); // Ne cl match
     if (classification == 1)
@@ -1854,12 +1898,8 @@ Bool_t AliCaloPhotonCuts::ClusterQualityCuts(AliVCluster* cluster, AliVEvent *ev
 
     // plot electrons that survived the track matching
     if (!CheckClusterForTrackMatch(cluster) && classification == 6){ // electrons that survived the matching
-      if (cluster->E() <= 20.)
-        fHistClusterElecEtaPhiAfterTM_00_20->Fill(phiCluster, etaCluster, weight);
-      if (cluster->E() > 20 && cluster->E() <= 50.)
-        fHistClusterElecEtaPhiAfterTM_20_50->Fill(phiCluster, etaCluster, weight);
-      if (cluster->E() > 50.)
-        fHistClusterElecEtaPhiAfterTM_50_00->Fill(phiCluster, etaCluster, weight);
+      if (cluster->E() > 30.)
+        fHistClusterTrueElecEtaPhiAfterTM_30_00->Fill(phiCluster, etaCluster, weight);
     }
   }
 
@@ -1868,8 +1908,9 @@ Bool_t AliCaloPhotonCuts::ClusterQualityCuts(AliVCluster* cluster, AliVEvent *ev
     if( CheckClusterForTrackMatch(cluster) ){
       if(fHistClusterIdentificationCuts)fHistClusterIdentificationCuts->Fill(cutIndex, cluster->E());//2
       // TM efficiency histos after TM
-      if (fIsMC && isMC && (fExtendedMatchAndQA == 1 || fExtendedMatchAndQA == 3 || fExtendedMatchAndQA == 5)){
-
+      if (fIsMC && isMC && (fExtendedMatchAndQA == 1 || fExtendedMatchAndQA == 3 || fExtendedMatchAndQA == 5)  && !(fIsPureCalo > 0 && cluster->E() < 10.)){ // ignore low energies for merged analysis
+        if(IsClusterPi0(event, mcEvent, cluster))
+          if(fHistClusETruePi0_Matched) fHistClusETruePi0_Matched->Fill(cluster->E(), weight);
         fHistClusterTMEffiInput->Fill(cluster->E(), 9., weight);
         if (classification == 5 )
           fHistClusterTMEffiInput->Fill(cluster->E(), 10., weight); //Ch cl match
@@ -3045,7 +3086,7 @@ Bool_t AliCaloPhotonCuts::MatchConvPhotonToCluster(AliAODConversionPhoton* convP
 }
 
 //________________________________________________________________________
-void AliCaloPhotonCuts::MatchTracksToClusters(AliVEvent* event, Double_t weight, Bool_t isEMCalOnly){
+void AliCaloPhotonCuts::MatchTracksToClusters(AliVEvent* event, Double_t weight, Bool_t isEMCalOnly, AliMCEvent* mcEvent){
   if( !fUseDistTrackToCluster ) return;
   if( (fClusterType == 1 || fClusterType == 3) && !fEMCALInitialized ) InitializeEMCAL(event);
   if( fClusterType == 2 && ( !fPHOSInitialized || (fPHOSCurrentRun != event->GetRunNumber()) ) ) InitializePHOS(event);
@@ -3202,6 +3243,7 @@ void AliCaloPhotonCuts::MatchTracksToClusters(AliVEvent* event, Double_t weight,
 
       Bool_t match_dEta = (TMath::Abs(dEta) < fMaxDistTrackToClusterEta) ? kTRUE : kFALSE;
       Bool_t match_dPhi = kFALSE;
+      Bool_t vetoEOverP = kFALSE;
 
       if( (inTrack->Charge() > 0) && (dPhi > fMinDistTrackToClusterPhi) && (dPhi < fMaxDistTrackToClusterPhi) ) match_dPhi = kTRUE;
       else if( (inTrack->Charge() < 0) && (dPhi < -fMinDistTrackToClusterPhi) && (dPhi > -fMaxDistTrackToClusterPhi) ) match_dPhi = kTRUE;
@@ -3214,9 +3256,24 @@ void AliCaloPhotonCuts::MatchTracksToClusters(AliVEvent* event, Double_t weight,
         else match_dPhi = kFALSE;
       }
 
+      if(fUseEOverPVetoTM && cluster->E()/inTrack->P() > fEOverPMax)
+        vetoEOverP = kTRUE;
+
       if(match_dEta && match_dPhi){
-        fVectorMatchedClusterIDs.push_back(cluster->GetID());
-       // cout << "MATCHED!!!!!!!!!!!!!!!!!!!!!!!!! - " << cluster->GetID() << endl;
+        if(fUseEOverPVetoTM){
+          if(!vetoEOverP){
+            fVectorMatchedClusterIDs.push_back(cluster->GetID());
+            if(fHistMatchedTrackPClusEAfterEOverPVeto) fHistMatchedTrackPClusEAfterEOverPVeto->Fill(inTrack->P(),cluster->E());
+          }
+        }else{
+          fVectorMatchedClusterIDs.push_back(cluster->GetID());
+        }
+        if(fHistMatchedTrackPClusE && fUseEOverPVetoTM) fHistMatchedTrackPClusE->Fill(inTrack->P(),cluster->E());
+        if(fIsMC && (fExtendedMatchAndQA == 1 || fExtendedMatchAndQA == 3 || fExtendedMatchAndQA == 5 ) && fUseEOverPVetoTM){
+          if(IsClusterPi0(event, mcEvent, cluster) && fHistMatchedTrackPClusETruePi0Clus)
+            fHistMatchedTrackPClusETruePi0Clus->Fill(inTrack->P(),cluster->E());
+        }
+
         if(isEMCalOnly){
           if(fHistClusterdEtadPtAfterQA) fHistClusterdEtadPtAfterQA->Fill(dEta,inTrack->Pt());
           if(fHistClusterdPhidPtAfterQA) fHistClusterdPhidPtAfterQA->Fill(dPhi,inTrack->Pt());
@@ -3232,7 +3289,7 @@ void AliCaloPhotonCuts::MatchTracksToClusters(AliVEvent* event, Double_t weight,
           else fHistClusterdEtadPhiNegTracksAfterQA->Fill(dEta, dPhi, weight);
           fHistClusterM20M02AfterQA->Fill(clusM20, clusM02, weight);
         }
-       // cout << "no match" << endl;
+        // cout << "no match" << endl;
       }
       if(arrClustersMatch) delete cluster;
     }
@@ -3920,7 +3977,81 @@ Bool_t AliCaloPhotonCuts::SetTrackMatchingCut(Int_t trackMatching)
 
       fFuncPtDepPhi = new TF1("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
       fFuncPtDepPhi->SetParameters(0.095, 0.015, 1.75);
-        break;
+      break;
+    case 12: // here starts clusterE/trackP veto for TM, taking case 7 as usual TM cuts; cut char 'c'
+      // note: this case does not apply the cut (fEOverPMax = 9e9), but sets fUseEOverPVetoTM = kTRUE, so that reference histos are still produced
+      if (!fUseDistTrackToCluster) fUseDistTrackToCluster=kTRUE;
+      if (!fUseEOverPVetoTM) fUseEOverPVetoTM=kTRUE;
+      fUsePtDepTrackToCluster = kTRUE;
+      fFuncPtDepEta = new TF1("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
+      fFuncPtDepEta->SetParameters(0.04, 0.010, 2.5);
+
+      fFuncPtDepPhi = new TF1("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
+      fFuncPtDepPhi->SetParameters(0.09, 0.015, 2.);
+
+      fEOverPMax = 9e9;
+      break;
+    case 13: // loosest E/P cut; cut char 'd'
+      if (!fUseDistTrackToCluster) fUseDistTrackToCluster=kTRUE;
+      if (!fUseEOverPVetoTM) fUseEOverPVetoTM=kTRUE;
+      fUsePtDepTrackToCluster = kTRUE;
+      fFuncPtDepEta = new TF1("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
+      fFuncPtDepEta->SetParameters(0.04, 0.010, 2.5);
+
+      fFuncPtDepPhi = new TF1("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
+      fFuncPtDepPhi->SetParameters(0.09, 0.015, 2.);
+
+      fEOverPMax = 3.0;
+      break;
+    case 14: // cut char 'e'
+      if (!fUseDistTrackToCluster) fUseDistTrackToCluster=kTRUE;
+      if (!fUseEOverPVetoTM) fUseEOverPVetoTM=kTRUE;
+      fUsePtDepTrackToCluster = kTRUE;
+      fFuncPtDepEta = new TF1("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
+      fFuncPtDepEta->SetParameters(0.04, 0.010, 2.5);
+
+      fFuncPtDepPhi = new TF1("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
+      fFuncPtDepPhi->SetParameters(0.09, 0.015, 2.);
+
+      fEOverPMax = 2.0;
+      break;
+    case 15: // cut char 'f'
+      if (!fUseDistTrackToCluster) fUseDistTrackToCluster=kTRUE;
+      if (!fUseEOverPVetoTM) fUseEOverPVetoTM=kTRUE;
+      fUsePtDepTrackToCluster = kTRUE;
+      fFuncPtDepEta = new TF1("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
+      fFuncPtDepEta->SetParameters(0.04, 0.010, 2.5);
+
+      fFuncPtDepPhi = new TF1("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
+      fFuncPtDepPhi->SetParameters(0.09, 0.015, 2.);
+
+      fEOverPMax = 1.75;
+      break;
+    case 16: // cut char 'g'
+      if (!fUseDistTrackToCluster) fUseDistTrackToCluster=kTRUE;
+      if (!fUseEOverPVetoTM) fUseEOverPVetoTM=kTRUE;
+      fUsePtDepTrackToCluster = kTRUE;
+      fFuncPtDepEta = new TF1("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
+      fFuncPtDepEta->SetParameters(0.04, 0.010, 2.5);
+
+      fFuncPtDepPhi = new TF1("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
+      fFuncPtDepPhi->SetParameters(0.09, 0.015, 2.);
+
+      fEOverPMax = 1.5;
+      break;
+
+    case 17: // hardest E/p cut; cut char 'h'
+      if (!fUseDistTrackToCluster) fUseDistTrackToCluster=kTRUE;
+      if (!fUseEOverPVetoTM) fUseEOverPVetoTM=kTRUE;
+      fUsePtDepTrackToCluster = kTRUE;
+      fFuncPtDepEta = new TF1("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
+      fFuncPtDepEta->SetParameters(0.04, 0.010, 2.5);
+
+      fFuncPtDepPhi = new TF1("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
+      fFuncPtDepPhi->SetParameters(0.09, 0.015, 2.);
+
+      fEOverPMax = 1.25;
+      break;
 
     default:
       AliError(Form("Track Matching Cut not defined %d",trackMatching));
@@ -3981,6 +4112,7 @@ Bool_t AliCaloPhotonCuts::SetTrackMatchingCut(Int_t trackMatching)
         fFuncPtDepPhi = new TF1("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
         fFuncPtDepPhi->SetParameters(0.45, 0.010, 2.0);
         break;
+
 
       default:
         AliError(Form("Track Matching Cut not defined %d",trackMatching));
@@ -6419,4 +6551,69 @@ Bool_t AliCaloPhotonCuts::GetHighestPtMatchedTrackToCluster(AliVEvent* event, Al
   if(!isSucessful) return kFALSE;
   trackLabel = highestPtTrack;
   return kTRUE;
+}
+
+//_______________________________________________________________________________
+Bool_t AliCaloPhotonCuts::IsClusterPi0(AliVEvent *event,  AliMCEvent* mcEvent, AliVCluster *cluster){
+
+  Int_t* mclabelsCluster  = cluster->GetLabels();
+  // check if esd or aod
+  AliESDEvent *esdev = dynamic_cast<AliESDEvent*>(event);
+  AliAODEvent *aodev = 0;
+  if (!esdev) {
+    aodev = dynamic_cast<AliAODEvent*>(event);
+    if (!aodev) {
+      AliError("Task needs AOD or ESD event, returning");
+      return kFALSE;
+    }
+  }
+
+  if(esdev){
+    // check if cluster is from pi0
+    if (cluster->GetNLabels()>0){
+      TParticle* particleLead   = (TParticle*)mcEvent->Particle(mclabelsCluster[0]);
+      if(particleLead->GetPdgCode() == 22 || particleLead->GetPdgCode() == -11 || particleLead->GetPdgCode() == 11){
+        if (particleLead->GetMother(0) > -1){
+          TParticle* motherDummy = mcEvent->Particle(particleLead->GetMother(0));
+//          printf("mother pdg = %d\n",motherDummy->GetPdgCode());
+          if(motherDummy->GetPdgCode() == 111) return kTRUE;
+          if(motherDummy->GetPdgCode() == 22){ // check also conversions
+            UInt_t whileCounter = 0;// to be 100% sure against infinite while loop
+            while(motherDummy->GetMother(0) > -1 && whileCounter++ < 5){
+              motherDummy = mcEvent->Particle(motherDummy->GetMother(0));
+//              printf("grandmother pdg = %d\n",motherDummy->GetPdgCode());
+              if(motherDummy->GetPdgCode() == 111) return kTRUE;
+            }
+          }
+        }
+      }
+    }
+  }else if(aodev){ // same procedure for AODsesdt
+    TClonesArray *AODMCTrackArray = dynamic_cast<TClonesArray*>(event->FindListObject(AliAODMCParticle::StdBranchName()));
+    if (AODMCTrackArray == NULL){
+      AliError("No MC particle list available in AOD");
+      return kFALSE;
+    }
+    // check if cluster is from pi0
+    if (cluster->GetNLabels()>0){
+      AliAODMCParticle* particleLead = static_cast<AliAODMCParticle*>(AODMCTrackArray->At(mclabelsCluster[0]));
+      if(particleLead->GetPdgCode() == 22 || particleLead->GetPdgCode() == -11 || particleLead->GetPdgCode() == 11){
+        if (particleLead->GetMother() > -1){
+          AliAODMCParticle* motherDummy = static_cast<AliAODMCParticle*>(AODMCTrackArray->At(particleLead->GetMother()));
+//          printf("mother pdg = %d\n",motherDummy->GetPdgCode());
+          if(motherDummy->GetPdgCode() == 111) return kTRUE;
+          if(motherDummy->GetPdgCode() == 22){ // check also conversions
+            UInt_t whileCounter = 0;// to be 100% sure against infinite while loop
+            while(motherDummy->GetMother() > -1 && whileCounter++ < 5){
+              motherDummy    = static_cast<AliAODMCParticle*>(AODMCTrackArray->At(motherDummy->GetMother()));
+//              printf("grandmother pdg = %d\n",motherDummy->GetPdgCode());
+              if(motherDummy->GetPdgCode() == 111) return kTRUE;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return kFALSE;
 }

--- a/PWGGA/GammaConv/AliCaloPhotonCuts.h
+++ b/PWGGA/GammaConv/AliCaloPhotonCuts.h
@@ -296,7 +296,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     Bool_t      ClusterQualityCuts(AliVCluster* cluster,AliVEvent *event, AliMCEvent *mcEvent, Int_t isMC, Double_t weight, Long_t clusterID);
 
     Bool_t      MatchConvPhotonToCluster(AliAODConversionPhoton* convPhoton, AliVCluster* cluster, AliVEvent* event, Double_t weight=1.);
-    void        MatchTracksToClusters(AliVEvent* event, Double_t weight=1., Bool_t isEMCalOnly = kTRUE);
+    void        MatchTracksToClusters(AliVEvent* event, Double_t weight=1., Bool_t isEMCalOnly = kTRUE, AliMCEvent *mcEvent = 0x0);
     Bool_t      CheckClusterForTrackMatch(AliVCluster* cluster);
     Int_t       GetNumberOfLocalMaxima(AliVCluster* cluster, AliVEvent * event);
     Int_t       GetNumberOfLocalMaxima(AliVCluster* cluster, AliVEvent * event,  Int_t *absCellIdList, Float_t* maxEList);
@@ -312,6 +312,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     std::vector<Int_t> GetVectorMatchedTracksToCluster(AliVEvent* event, AliVCluster* cluster);
     Bool_t      GetClosestMatchedTrackToCluster(AliVEvent* event, AliVCluster* cluster, Int_t &trackLabel);
     Bool_t      GetHighestPtMatchedTrackToCluster(AliVEvent* event, AliVCluster* cluster, Int_t &trackLabel);
+    Bool_t      IsClusterPi0(AliVEvent *event, AliMCEvent *mcEvent, AliVCluster *cluster);
 
     AliCaloTrackMatcher* GetCaloTrackMatcherInstance()          {return fCaloTrackMatcher;}
 
@@ -421,6 +422,8 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     Bool_t    fUsePtDepTrackToCluster;                  // flag for switching on pT dependent matching parameters
     TF1*      fFuncPtDepEta;                            // TF1 for pT dep cutting in eta
     TF1*      fFuncPtDepPhi;                            // TF1 for pT dep cutting in phi
+    Bool_t    fUseEOverPVetoTM;                         // flag for switching on E/P veto (forbidding tracks to match clusters if clusterE/trackP > someValue
+    Double_t  fEOverPMax;                               // maximum value for E/P of a track to be considered for TM
     Int_t     fExtendedMatchAndQA;                      // switching on ext matching histograms (1) / ext QA_noCell (2) / ext matching + ext QA_noCell (3) / extQA + cell (4) / ext match + extQA + cell (5) or all off (0)
     Double_t  fExoticEnergyFracCluster;                 // exotic energy compared to E_cross cluster cut
     Double_t  fExoticMinEnergyCell;                     // minimum energy of cell to test for exotics
@@ -545,12 +548,8 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
 
     // histograms for track matching efficiency
     TH2F*     fHistClusterTMEffiInput;                  //
-    TH2F*     fHistClusterElecEtaPhiBeforeTM_00_20;     //
-    TH2F*     fHistClusterElecEtaPhiBeforeTM_20_50;     //
-    TH2F*     fHistClusterElecEtaPhiBeforeTM_50_00;     //
-    TH2F*     fHistClusterElecEtaPhiAfterTM_00_20;      //
-    TH2F*     fHistClusterElecEtaPhiAfterTM_20_50;      //
-    TH2F*     fHistClusterElecEtaPhiAfterTM_50_00;      //
+    TH2F*     fHistClusterTrueElecEtaPhiBeforeTM_30_00; // electron clusters before track matching, only for E_clus > 30 GeV
+    TH2F*     fHistClusterTrueElecEtaPhiAfterTM_30_00;  // electron clusters after track matching, only for E_clus > 30 GeV
     TH2F*     fHistClusterEvsTrackECharged;             //
     TH2F*     fHistClusterEvsTrackEChargedLead;         //
     TH2F*     fHistClusterEvsTrackENeutral;             //
@@ -562,6 +561,14 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     TH2F*     fHistClusterENMatchesCharged;             //
     TH2F*     fHistClusterEvsTrackEPrimaryButNoElec;    //
     TH2F*     fHistClusterEvsTrackSumEPrimaryButNoElec; //
+
+    TH1F*     fHistClusETruePi0_BeforeTM;               // for checking the false positives: how much true pi0s are matched away?
+    TH1F*     fHistClusETruePi0_Matched;                //
+
+    // histograms for studying track matching veto with track momentum vs. cluster energy
+    TH2F*     fHistMatchedTrackPClusE;                // track P vs cluster E in case of matching with a cluster
+    TH2F*     fHistMatchedTrackPClusEAfterEOverPVeto; // track P vs cluster E for matched tracks surviving the E/P veto
+    TH2F*     fHistMatchedTrackPClusETruePi0Clus;     // track P vs cluster E in case of matching with a true pi0 cluster
 
     Int_t      fNMaxDCalModules;                        // max number of DCal Modules
     Int_t      fgkDCALCols;                             // Number of columns in DCal

--- a/PWGGA/GammaConv/macros/AddTask_GammaCaloMerged_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCaloMerged_pp.C
@@ -907,6 +907,34 @@ void AddTask_GammaCaloMerged_pp(  Int_t     trainConfig                 = 1,    
     cuts.AddCut("00052113","1111111067032200000","1111111067022210002","0163302200000000"); // EMC7
     cuts.AddCut("00081113","1111111067032200000","1111111067022210002","0163302200000000"); // EMCEGA,
 
+    // use EOverP veto in track matching
+    // INT7
+  } else if (trainConfig == 171){  // default TM with different E/p cuts
+    cuts.AddCut("00010113","111111106c032200000","111111106c022700001","0163300000000000"); // no E/p cut, but reference histograms for variations
+    cuts.AddCut("00010113","111111106d032200000","111111106d022700001","0163300000000000"); // loosest cut: EOverPMax= 3.0
+    cuts.AddCut("00010113","111111106e032200000","111111106e022700001","0163300000000000"); // EOverPMax= 2.0
+  } else if (trainConfig == 172){  // default TM with different E/p cuts
+    cuts.AddCut("00010113","111111106f032200000","111111106f022700001","0163300000000000"); // EOverPMax= 1.75
+    cuts.AddCut("00010113","111111106g032200000","111111106g022700001","0163300000000000"); // EOverPMax= 1.5
+    cuts.AddCut("00010113","111111106h032200000","111111106h022700001","0163300000000000"); // hardest cut: EOverPMax= 1.25
+    // EMC7
+  } else if (trainConfig == 174){  // default TM with different E/p cuts
+    cuts.AddCut("00052113","111111106c032200000","111111106c022700001","0163300000000000"); // no E/p cut, but reference histograms for variations
+    cuts.AddCut("00052113","111111106d032200000","111111106d022700001","0163300000000000"); // loosest cut: EOverPMax= 3.0
+    cuts.AddCut("00052113","111111106e032200000","111111106e022700001","0163300000000000"); // EOverPMax= 2.0
+  } else if (trainConfig == 175){  // default TM with different E/p cuts
+    cuts.AddCut("00052113","111111106f032200000","111111106f022700001","0163300000000000"); // EOverPMax= 1.75
+    cuts.AddCut("00052113","111111106g032200000","111111106g022700001","0163300000000000"); // EOverPMax= 1.5
+    cuts.AddCut("00052113","111111106h032200000","111111106h022700001","0163300000000000"); // hardest cut: EOverPMax= 1.25
+    // EGA
+  } else if (trainConfig == 177){  // default TM with different E/p cuts
+    cuts.AddCut("00081113","111111106c032200000","111111106c022700001","0163300000000000"); // no E/p cut, but reference histograms for variations
+    cuts.AddCut("00081113","111111106d032200000","111111106d022700001","0163300000000000"); // loosest cut: EOverPMax= 3.0
+    cuts.AddCut("00081113","111111106e032200000","111111106e022700001","0163300000000000"); // EOverPMax= 2.0
+  } else if (trainConfig == 178){  // default TM with different E/p cuts
+    cuts.AddCut("00081113","111111106f032200000","111111106f022700001","0163300000000000"); // EOverPMax= 1.75
+    cuts.AddCut("00081113","111111106g032200000","111111106g022700001","0163300000000000"); // EOverPMax= 1.5
+    cuts.AddCut("00081113","111111106h032200000","111111106h022700001","0163300000000000"); // hardest cut: EOverPMax= 1.25
     
   // T0AND cuts
   } else if (trainConfig == 181){  // EMCAL clusters, different triggers with NonLinearity track matching to cluster
@@ -977,8 +1005,6 @@ void AddTask_GammaCaloMerged_pp(  Int_t     trainConfig                 = 1,    
     cuts.AddCut("00052113","1111112067032200000","1111112067022700001","0163300000000000"); // EMC7
     cuts.AddCut("00085113","1111112067032200000","1111112067022700001","0163300000000000"); // EG2
     cuts.AddCut("00083113","1111112067032200000","1111112067022700001","0163300000000000"); // EG1
-
-
     // all the cut variations
   } else {
     Error(Form("GammaCaloMerged_%i",trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");


### PR DESCRIPTION
new: CaloMerged task gives JJ weights & mcEvent to MatchTracksToCluster
     introducing EOverP veto in track matching, so that jets (charged tracks with large E/p) are not matched away
     new histos for data & mc:
         - TH2 trackP vs clusterE for track matches
         - TH2 trackP vs clusterE for track matches after EOverP veto
     for mc only:
         - TH1 true pi0 cluster spectrum before/after track matching
         - TH2 trackP vs clusterE for track matches in case of cluster = true pi0 cluster
     TM cuts ("c",...,"h") for different values of allowed maxEOverP(999.9, 3., 2., 1.75, 1.5, 1.25); took dEta,dPhi cuts from default case "7"
     mEMC addtask: took configs "17x" for EOverP cut studies in 8TeV pp
modified: only one eta-phi map of electron clusters before/after TM, instead of three and now only for high pt, for less memory consumption
          also, dont fill extQA(1,3,5) histograms and dont do MatchTracksToClusters if clusterE < 10 GeV AND fIsPureCalo>0 (= merged analysis)
          omit booking of three histograms if fIsPureCalo != 0, because they are only used in conjunction with PCM