### PR TITLE
Reverse order of retrieving values from config

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
@@ -358,23 +358,23 @@ void AliEmcalCorrectionTask::InitializeConfiguration()
   }
 
   // Setup and initialize configurations
-  // user is added first so that it will be checked first.
-  // User file
-  int returnValue = fYAMLConfig.AddConfiguration(fUserConfigurationFilename, "user");
-  if (returnValue >= 0) {
-    AliInfoStream() << "Using user EMCal corrections configuration located at \"" << fUserConfigurationFilename << "\"\n";
-  }
-  else {
-    AliInfoStream() << "User file at \"" << fUserConfigurationFilename << "\" does not exist! All settings will be from the default file!\n";
-  }
-
+  // default is added first so that it will be checked last.
   // Default file
-  returnValue = fYAMLConfig.AddConfiguration(fDefaultConfigurationFilename, "default");
+  int returnValue = fYAMLConfig.AddConfiguration(fDefaultConfigurationFilename, "default");
   if (returnValue >= 0) {
     AliInfoStream() << "Using default EMCal corrections configuration located at \"" << fDefaultConfigurationFilename << "\"\n";
   }
   else {
     AliFatal(TString::Format("Default file located at \"%s\" does not exist!", fDefaultConfigurationFilename.c_str()));
+  }
+
+  // User file
+  returnValue = fYAMLConfig.AddConfiguration(fUserConfigurationFilename, "user");
+  if (returnValue >= 0) {
+    AliInfoStream() << "Using user EMCal corrections configuration located at \"" << fUserConfigurationFilename << "\"\n";
+  }
+  else {
+    AliInfoStream() << "User file at \"" << fUserConfigurationFilename << "\" does not exist! All settings will be from the default file!\n";
   }
 
   // Initialize


### PR DESCRIPTION
If values are retrieved in the order that the configuration files are
added, then it is impossible to override a value after a file has been
added. Instead, we now look in reverse order of the way they were added,
so a value can be overridden just be adding a new config file.

It's been tested and validated with some unit tests and the EMCal Correction Framework.