### PR TITLE
PWGGA/GammaConv: Fix for trackmatcher when using correction framework

### DIFF
--- a/PWGGA/GammaConv/AliCaloTrackMatcher.cxx
+++ b/PWGGA/GammaConv/AliCaloTrackMatcher.cxx
@@ -206,7 +206,12 @@ void AliCaloTrackMatcher::ProcessEvent(AliVEvent *event){
     nClus = event->GetNumberOfCaloClusters();
   } else {
     arrClusters = dynamic_cast<TClonesArray*>(event->FindListObject(Form("%sClustersBranch",fCorrTaskSetting.Data())));
-    nClus = arrClusters->GetEntries();
+    if(arrClusters){
+      nClus = arrClusters->GetEntries();
+    }else{
+      AliError(Form("Could not find %sClustersBranch despite correction framework being used!",fCorrTaskSetting.Data()));
+      return;
+    }
   }
   Int_t nModules = 0;
   if(fClusterType == 1 || fClusterType == 3) nModules = fGeomEMCAL->GetNumberOfSuperModules();


### PR DESCRIPTION
This fixes a strange situation where for the first event the trackmatcher cannot find the calocluster container.
Running with this fix or alternatively the tender results in the same cluster candidates. Therefore this small addition does not have negative impact on the result.