### PR TITLE
Fix compilation error

### DIFF
--- a/PWGCF/Correlations/JCORRAN/Pro/AliBSDiJetTask.cxx
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliBSDiJetTask.cxx
@@ -491,7 +491,7 @@ Bool_t AliBSDiJetTask::Run(){
  
 	TLorentzVector1D RecJets; 
 	Bool_t gooddijet = this -> MeasureJets(jetContainer, RecJets, false);
-	std::sort(RecJets.begin(), RecJets.end(), [&](const TLorentzVector& x, TLorentzVector& y) { return x.Pt() > y.Pt() ;});
+	std::sort(RecJets.begin(), RecJets.end(), [&](const TLorentzVector& x, const TLorentzVector& y) { return x.Pt() > y.Pt() ;});
 	for (auto j : RecJets){
 			//cout<<"corrected rec jet eta phi  pt  = "<< j.Eta()<<"     "<<TVector2::Phi_0_2pi(j.Phi())<<"     " <<j.Pt() <<endl;
 	}
@@ -507,7 +507,7 @@ Bool_t AliBSDiJetTask::Run(){
 			//cout<<"True jet eta phi  pt  = "<< j.Eta()<<"     "<<TVector2::Phi_0_2pi(j.Phi())<<"     " <<j.Pt() <<endl;
 		}
 		if (!gooddijetkine) return false;
-		std::sort(TrueJets.begin(), TrueJets.end(), [&](const TLorentzVector& x, TLorentzVector& y) { return x.Pt() > y.Pt(); });
+		std::sort(TrueJets.begin(), TrueJets.end(), [&](const TLorentzVector& x, const TLorentzVector& y) { return x.Pt() > y.Pt(); });
 	}
 
 	//cout<<"pjet size : "<<TrueJets.size()<<endl;


### PR DESCRIPTION
Hi,

this PR is needed to avoind that the AliPhyssics compilation fails in AliBSDiJetTask.cxx after this commit:
https://github.com/alisw/AliPhysics/commit/b024292e81927dae2cfdc988415dc023b30a0f41

I just added const in front of the TLorentzVectors passed to std::sort, to prevent this compilation error:
/home/prino/AliSoft/sw/SOURCES/AliPhysics/0/0/PWGCF/Correlations/JCORRAN/Pro/AliBSDiJetTask.cxx:510:93: note:   no known conversion for argument 2 from ‘const TLorentzVector’ to ‘TLorentzVector&’

Best regards, Francesco