### PR TITLE
Fixed a compilation error related to Fastjet.

### DIFF
--- a/PWGCF/Correlations/JCORRAN/Pro/PWGCFCorrelationsJCORRANProLinkDef.h
+++ b/PWGCF/Correlations/JCORRAN/Pro/PWGCFCorrelationsJCORRANProLinkDef.h
@@ -14,6 +14,10 @@
 #pragma link C++ class AliJJetJtAnalysis+;
 #pragma link C++ class AliJJetAnalysis+;
 #pragma link C++ class AliBSDiJetTask+;
+
+#ifdef HAVE_FASTJET
 #pragma link C++ class AliJCDijetTask+;
 #pragma link C++ class AliJCDijetHistos+;
+#endif
+
 #endif /* __CINT__ */


### PR DESCRIPTION
A compilation error occurs when building with root5 but without the Fastjet package. This fix solves the problem.