### PR TITLE
Create the AliMCAnalysisUtils only once for all sub-tasks

### DIFF
--- a/PWG/CaloTrackCorrBase/AliAnaCaloTrackCorrBaseClass.cxx
+++ b/PWG/CaloTrackCorrBase/AliAnaCaloTrackCorrBaseClass.cxx
@@ -64,7 +64,7 @@ fOutputAODName(""),           fOutputAODClassName(""),
 fAODObjArrayName(""),         fAddToHistogramsName(""),
 fCaloPID(0x0),                fCaloUtils(0x0),
 fFidCut(0x0),                 fHisto(0x0),
-fIC(0x0),                     fMCUtils(0x0),                
+fIC(0x0),                                    
 fNMS(0x0),                    fReader(0x0),
 fStudyClusterOverlapsPerGenerator(0),
 fNCocktailGenNames(0)
@@ -83,7 +83,6 @@ AliAnaCaloTrackCorrBaseClass::~AliAnaCaloTrackCorrBaseClass()
   delete fCaloPID ; 
   delete fFidCut  ;  
   delete fIC      ;      
-  delete fMCUtils ; 
   delete fNMS     ;     
   delete fHisto   ;    
 }
@@ -683,16 +682,13 @@ void AliAnaCaloTrackCorrBaseClass::InitDebug()
   if( fDebug >= 0 )
     (AliAnalysisManager::GetAnalysisManager())->AddClassDebug(this->ClassName(),fDebug);
   
-  if( GetMCAnalysisUtils()->GetDebug() >= 0 )
-    (AliAnalysisManager::GetAnalysisManager())->AddClassDebug(GetMCAnalysisUtils()->ClassName(),GetMCAnalysisUtils()->GetDebug());
-  
   if( GetIsolationCut()->GetDebug() >= 0 )
     (AliAnalysisManager::GetAnalysisManager())->AddClassDebug(GetIsolationCut()->ClassName(),GetIsolationCut()->GetDebug());
 
   if( GetNeutralMesonSelection()->GetDebug() >= 0 )
     (AliAnalysisManager::GetAnalysisManager())->AddClassDebug(GetNeutralMesonSelection()->ClassName(),GetNeutralMesonSelection()->GetDebug());
     
-  //printf("Debug levels: Ana %d, MC %d, Iso %d\n",fDebug,GetMCAnalysisUtils()->GetDebug(),GetIsolationCut()->GetDebug());
+  //printf("Debug levels: Ana %d, Neutral Sel %d, Iso %d\n",fDebug,GetNeutralMesonSelection()->GetDebug(),GetIsolationCut()->GetDebug());
 }
 
 //_________________________________________________

--- a/PWG/CaloTrackCorrBase/AliAnaCaloTrackCorrBaseClass.h
+++ b/PWG/CaloTrackCorrBase/AliAnaCaloTrackCorrBaseClass.h
@@ -172,8 +172,7 @@ public:
   virtual void           SetCalorimeter(Int_t calo) ;
 
   virtual Bool_t         IsDataMC()                        const { return fDataMC                ; }
-  virtual void           SwitchOnDataMC()                        { fDataMC = kTRUE ;
-                                                                   if(!fMCUtils) fMCUtils = new AliMCAnalysisUtils() ; }
+  virtual void           SwitchOnDataMC()                        { fDataMC = kTRUE               ; }
   virtual void           SwitchOffDataMC()                       { fDataMC = kFALSE              ; }
   
   virtual Bool_t         IsFiducialCutOn()                 const { return fCheckFidCut           ; }
@@ -335,7 +334,7 @@ public:
   
   virtual AliIsolationCut          * GetIsolationCut()           { if(!fIC)      fIC      = new AliIsolationCut();          return  fIC      ; }
   
-  virtual AliMCAnalysisUtils       * GetMCAnalysisUtils()        { if(!fMCUtils) fMCUtils = new AliMCAnalysisUtils();       return  fMCUtils ; }
+  virtual AliMCAnalysisUtils       * GetMCAnalysisUtils()        { return GetReader()->GetMCAnalysisUtils() ; }
   
   virtual AliNeutralMesonSelection * GetNeutralMesonSelection()  { if(!fNMS)     fNMS     = new AliNeutralMesonSelection(); return  fNMS     ; }
   
@@ -354,9 +353,7 @@ public:
   virtual void                       SetHistogramRanges(AliHistogramRanges * hr)                    { delete fHisto;   fHisto   = hr      ; }
   
   virtual void                       SetIsolationCut(AliIsolationCut * ic)                          { delete fIC;      fIC      = ic      ; }
-  
-  virtual void                       SetMCAnalysisUtils(AliMCAnalysisUtils * mcutils)               { delete fMCUtils; fMCUtils = mcutils ; }
-  
+    
   virtual void                       SetNeutralMesonSelection(AliNeutralMesonSelection * const nms) { delete fNMS;     fNMS     = nms     ; }
   
   virtual void                       SetReader(AliCaloTrackReader * reader)                         { fReader = reader                    ; }
@@ -435,7 +432,6 @@ private:
   AliFiducialCut           * fFidCut;              ///< Acceptance cuts detector dependent.
   AliHistogramRanges       * fHisto ;              ///< Histogram ranges container.
   AliIsolationCut          * fIC;                  ///< Isolation cut utils. 
-  AliMCAnalysisUtils       * fMCUtils;             ///< MonteCarlo Analysis utils. 
   AliNeutralMesonSelection * fNMS;                 ///< Neutral Meson Selection utities.
   AliCaloTrackReader       * fReader;              ///< Access to ESD/AOD/MC data and other utilities.
 

--- a/PWG/CaloTrackCorrBase/AliAnaCaloTrackCorrMaker.cxx
+++ b/PWG/CaloTrackCorrBase/AliAnaCaloTrackCorrMaker.cxx
@@ -957,37 +957,38 @@ TList *AliAnaCaloTrackCorrMaker::GetOutputContainer()
 void AliAnaCaloTrackCorrMaker::Init()
 {  
   // Activate debug level in maker
-  if( fAnaDebug >= 0 )
+  if ( fAnaDebug >= 0 )
     (AliAnalysisManager::GetAnalysisManager())->AddClassDebug(this->ClassName(),fAnaDebug);
-  
-  //Initialize reader
+
+  // Initialize reader
   GetReader()->Init();
+
   GetReader()->SetCaloUtils(GetCaloUtils()); // pass the calo utils pointer to the reader
 
-  // Activate debug level in reader
-  if( fReader->GetDebug() >= 0 )
-    (AliAnalysisManager::GetAnalysisManager())->AddClassDebug(fReader->ClassName(), fReader->GetDebug());
-  
   // Activate debug level in calo utils
-  if( fCaloUtils->GetDebug() >= 0 )
+  if ( fCaloUtils->GetDebug() >= 0 )
     (AliAnalysisManager::GetAnalysisManager())->AddClassDebug(fCaloUtils->ClassName(), fCaloUtils->GetDebug());
-  
+
   if(!fAnalysisContainer || fAnalysisContainer->GetEntries()==0)
   {
     AliWarning("Analysis job list not initialized");
     return;
   }
-  
+
   for(Int_t iana = 0; iana <  fAnalysisContainer->GetEntries(); iana++)
   {
     AliAnaCaloTrackCorrBaseClass * ana =  ((AliAnaCaloTrackCorrBaseClass *) fAnalysisContainer->At(iana)) ;
     
     ana->SetReader(fReader);       // Set Reader for each analysis
+
     ana->SetCaloUtils(fCaloUtils); // Set CaloUtils for each analysis
-    
+
     ana->Init();
+
     ana->InitDebug();
-  }//Loop on analysis defined
+
+  } // Loop on analysis defined
+
 }
 
 //_____________________________________________

--- a/PWG/CaloTrackCorrBase/AliCaloTrackReader.cxx
+++ b/PWG/CaloTrackCorrBase/AliCaloTrackReader.cxx
@@ -77,7 +77,7 @@ fAODBranchList(0x0),
 fCTSTracks(0x0),             fEMCALClusters(0x0),
 fDCALClusters(0x0),          fPHOSClusters(0x0),
 fEMCALCells(0x0),            fPHOSCells(0x0),
-fInputEvent(0x0),            fOutputEvent(0x0),fMC(0x0),
+fInputEvent(0x0),            fOutputEvent(0x0),               fMC(0x0),
 fFillCTS(0),                 fFillEMCAL(0),
 fFillDCAL(0),                fFillPHOS(0),
 fFillEMCALCells(0),          fFillPHOSCells(0),
@@ -97,7 +97,7 @@ fEventTrigEMCALL1Jet1(0),    fEventTrigEMCALL1Jet2(0),
 fBitEGA(0),                  fBitEJE(0),
 
 fEventType(-1),
-fTaskName(""),               fCaloUtils(0x0),
+fTaskName(""),               fCaloUtils(0x0),                 fMCUtils(0x0), 
 fWeightUtils(0x0),           fEventWeight(1),
 fMixedEvent(NULL),           fNMixedEvent(0),                 fVertex(NULL),
 fListMixedTracksEvents(),    fListMixedCaloEvents(),
@@ -223,6 +223,8 @@ void AliCaloTrackReader::DeletePointers()
   
   if ( fWeightUtils ) delete fWeightUtils ;
     
+  if ( fMCUtils     ) delete fMCUtils ; 
+
   //  Pointers not owned, done by the analysis frame
   //  if(fInputEvent)  delete fInputEvent ;
   //  if(fOutputEvent) delete fOutputEvent ;
@@ -1019,9 +1021,19 @@ Int_t AliCaloTrackReader::GetTrackID(AliVTrack* track)
 //_____________________________
 void AliCaloTrackReader::Init()
 {  
+  // Activate debug level in reader
+  if( fDebug >= 0 )
+    (AliAnalysisManager::GetAnalysisManager())->AddClassDebug(this->ClassName(),fDebug);
+  
   // Activate debug level in AliAnaWeights
   if( fWeightUtils->GetDebug() >= 0 )
     (AliAnalysisManager::GetAnalysisManager())->AddClassDebug(fWeightUtils->ClassName(), fWeightUtils->GetDebug());
+  
+  // Activate debug level in AliMCAnalysisUtils
+  if( GetMCAnalysisUtils()->GetDebug() >= 0 )
+  (AliAnalysisManager::GetAnalysisManager())->AddClassDebug(GetMCAnalysisUtils()->ClassName(),GetMCAnalysisUtils()->GetDebug());
+  
+  //printf("Debug levels: Reader %d, Neutral Sel %d, Iso %d\n",fDebug,GetMCAnalysisUtils()->GetDebug(),fWeightUtils->GetDebug());
 }
 
 //_______________________________________
@@ -1151,9 +1163,11 @@ void AliCaloTrackReader::InitParameters()
   fSmearNLMMin = 1;
   fSmearNLMMax = 1;
   
+  fMCUtils     = new AliMCAnalysisUtils() ;
+
   fWeightUtils = new AliAnaWeights() ;
   fEventWeight = 1 ;
-    
+      
   fTrackMultNPtCut = 8;
   fTrackMultPtCut[0] = 0.15; fTrackMultPtCut[1] = 0.5;  fTrackMultPtCut[2] = 1.0; 
   fTrackMultPtCut[3] = 2.0 ; fTrackMultPtCut[4] = 4.0;  fTrackMultPtCut[5] = 6.0;  
@@ -1452,8 +1466,8 @@ Bool_t AliCaloTrackReader::FillInputEvent(Int_t iEntry, const char * /*curFileNa
     
     // Init it first to 0 to tell the method to recover it.
     fGenPythiaEventHeader = 
-    AliMCAnalysisUtils::GetPythiaEventHeader(GetMC(),fMCGenerEventHeaderToAccept,
-                                             pyGenName,pyProcessName,pyProcess,pyFirstGenPart,pythiaVersion);
+    GetMCAnalysisUtils()->GetPythiaEventHeader(GetMC(),fMCGenerEventHeaderToAccept,
+                                               pyGenName,pyProcessName,pyProcess,pyFirstGenPart,pythiaVersion);
 
     if(fGenPythiaEventHeader)
     {

--- a/PWG/CaloTrackCorrBase/AliCaloTrackReader.h
+++ b/PWG/CaloTrackCorrBase/AliCaloTrackReader.h
@@ -53,6 +53,7 @@ class AliVCluster;
 #include "AliFiducialCut.h"
 class AliCalorimeterUtils;
 #include "AliAnaWeights.h"
+#include "AliMCAnalysisUtils.h"
 
 // Jets
 class AliAODJetEventBackground;
@@ -648,7 +649,11 @@ public:
   
   Float_t               RadToDeg(Float_t rad)        const { rad *= TMath::RadToDeg(); return rad ; }
 
-  
+  virtual AliMCAnalysisUtils * GetMCAnalysisUtils()        { return           fMCUtils ; } 
+  virtual void                 SetMCAnalysisUtils(AliMCAnalysisUtils * mcutils) { 
+                                                             if (  fMCUtils ) delete fMCUtils; 
+                                                             fMCUtils = mcutils ; }
+
   //------------------------------------------------
   // MC analysis specific methods
   //-------------------------------------------------
@@ -872,6 +877,7 @@ public:
   TString          fTaskName;                      ///<  Name of task that executes the analysis.
 	
   AliCalorimeterUtils * fCaloUtils ;               ///<  Pointer to AliCalorimeterUtils.
+  AliMCAnalysisUtils  * fMCUtils;                  ///<  MonteCarlo Analysis utils. Initialized in SetMC()
 
   AliAnaWeights  * fWeightUtils ;                  ///<  Pointer to AliAnaWeights.
   Double_t         fEventWeight ;                  ///<  Weight assigned to the event when filling histograms.
@@ -1007,7 +1013,7 @@ public:
   AliCaloTrackReader & operator = (const AliCaloTrackReader & r) ; 
   
   /// \cond CLASSIMP
-  ClassDef(AliCaloTrackReader,80) ;
+  ClassDef(AliCaloTrackReader,81) ;
   /// \endcond
 
 } ;

--- a/PWGGA/CaloTrackCorrelations/macros/AddTaskCaloTrackCorr.C
+++ b/PWGGA/CaloTrackCorrelations/macros/AddTaskCaloTrackCorr.C
@@ -255,9 +255,6 @@ void ConfigureMC(AliAnaCaloTrackCorrBaseClass* ana)
 {
   if(kSimulation) ana->SwitchOnDataMC() ;//Access MC stack and fill more histograms, AOD MC not implemented yet.
   else            ana->SwitchOffDataMC() ;
-  
-  //Set here generator name, default pythia
-  //ana->GetMCAnalysisUtils()->SetMCGenerator("");
 }  
 
 ///

--- a/PWGGA/CaloTrackCorrelations/macros/AddTaskCaloTrackCorrBase.C
+++ b/PWGGA/CaloTrackCorrelations/macros/AddTaskCaloTrackCorrBase.C
@@ -82,6 +82,9 @@ AliCaloTrackReader * ConfigureReader(TString col,           Bool_t simulation,
     // Event rejection more suitable for gamma-jet simulations, do not use in other
     // reader->SetPtHardAndClusterPtComparison(kTRUE);
     // reader->SetPtHardAndClusterPtFactor(1.5);
+    
+    // Set here generator name, default pythia
+    //reader->GetMCAnalysisUtils()->SetMCGenerator("");
   }
   
   //---------------------------

--- a/PWGGA/CaloTrackCorrelations/macros/AddTaskClusterShape.C
+++ b/PWGGA/CaloTrackCorrelations/macros/AddTaskClusterShape.C
@@ -806,10 +806,7 @@ void SetAnalysisCommonParameters(AliAnaCaloTrackCorrBaseClass* ana,
   //
   if(simulation) ana->SwitchOnDataMC() ;//Access MC stack and fill more histograms, AOD MC not implemented yet.
   else           ana->SwitchOffDataMC() ;
-  
-  //Set here generator name, default pythia
-  //ana->GetMCAnalysisUtils()->SetMCGenerator("");
-  
+
   //
   // Debug
   //

--- a/PWGGA/CaloTrackCorrelations/macros/AddTaskGammaHadronCorrelation.C
+++ b/PWGGA/CaloTrackCorrelations/macros/AddTaskGammaHadronCorrelation.C
@@ -1619,9 +1619,6 @@ void SetAnalysisCommonParameters(AliAnaCaloTrackCorrBaseClass* ana,
   if(simulation) ana->SwitchOnDataMC() ;//Access MC stack and fill more histograms, AOD MC not implemented yet.
   else           ana->SwitchOffDataMC() ;
   
-  //Set here generator name, default pythia
-  //ana->GetMCAnalysisUtils()->SetMCGenerator("");
-  
   //
   // Debug
   //

--- a/PWGGA/CaloTrackCorrelations/macros/AddTaskGammaJetCorrelation.C
+++ b/PWGGA/CaloTrackCorrelations/macros/AddTaskGammaJetCorrelation.C
@@ -799,9 +799,6 @@ void ConfigureMC(AliAnaCaloTrackCorrBaseClass* ana,Bool_t simulation = kFALSE)
 {
   if(simulation) ana->SwitchOnDataMC() ;//Access MC stack and fill more histograms, AOD MC not implemented yet.
   else            ana->SwitchOffDataMC() ;
-
-  //Set here generator name, default pythia
-  //ana->GetMCAnalysisUtils()->SetMCGenerator("");
 }  
 
 ///

--- a/PWGGA/CaloTrackCorrelations/macros/AddTaskIsoPhoton.C
+++ b/PWGGA/CaloTrackCorrelations/macros/AddTaskIsoPhoton.C
@@ -803,9 +803,6 @@ void ConfigureMC(AliAnaCaloTrackCorrBaseClass* ana, Bool_t simu = kFALSE)
 {
   if(simu) ana->SwitchOnDataMC() ;//Access MC stack and fill more histograms, AOD MC not implemented yet.
   else     ana->SwitchOffDataMC() ;
-
-  //Set here generator name, default pythia
-  //ana->GetMCAnalysisUtils()->SetMCGenerator("");
 }
 
 ///

--- a/PWGGA/CaloTrackCorrelations/macros/AddTaskMergedPi0Selection.C
+++ b/PWGGA/CaloTrackCorrelations/macros/AddTaskMergedPi0Selection.C
@@ -757,9 +757,6 @@ void SetAnalysisCommonParameters(AliAnaCaloTrackCorrBaseClass* ana,
   //
   if(simulation) ana->SwitchOnDataMC() ;//Access MC stack and fill more histograms, AOD MC not implemented yet.
   else           ana->SwitchOffDataMC() ;
-  
-  //Set here generator name, default pythia
-  //ana->GetMCAnalysisUtils()->SetMCGenerator("");
 
   //
   // Debug

--- a/PWGGA/CaloTrackCorrelations/macros/AddTaskPi0.C
+++ b/PWGGA/CaloTrackCorrelations/macros/AddTaskPi0.C
@@ -860,9 +860,6 @@ void SetAnalysisCommonParameters(AliAnaCaloTrackCorrBaseClass* ana,
   
   if(col.Contains("PbPb")) ana->SwitchOnFillHighMultiplicityHistograms();
   else                     ana->SwitchOffFillHighMultiplicityHistograms();
-  
-  //Set here generator name, default pythia
-  //ana->GetMCAnalysisUtils()->SetMCGenerator("");
 
   //
   // Debug

--- a/PWGGA/CaloTrackCorrelations/macros/ConfigureCaloTrackCorrAnalysis.C
+++ b/PWGGA/CaloTrackCorrelations/macros/ConfigureCaloTrackCorrAnalysis.C
@@ -182,9 +182,6 @@ void SetAnalysisCommonParameters(AliAnaCaloTrackCorrBaseClass* ana, TString hist
   if(simulation) ana->SwitchOnDataMC() ;//Access MC stack and fill more histograms, AOD MC not implemented yet.
   else           ana->SwitchOffDataMC() ;
   
-  //Set here generator name, default pythia
-  //ana->GetMCAnalysisUtils()->SetMCGenerator("");
-  
   //
   // Debug
   //


### PR DESCRIPTION
Move the initialization of this object from the sub-tasks base class to the reader class so that it can be accessed by all subtasks