### PR TITLE
introduce new cuts to restrict or open the induced energy leaks

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEmulateCrosstalk.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEmulateCrosstalk.h
@@ -41,6 +41,10 @@ class AliEmcalCorrectionCellEmulateCrosstalk : public AliEmcalCorrectionComponen
 
   // T-Card correlation emulation, do on MC
   void           MakeCellTCardCorrelation();
+  void           CalculateInducedEnergyInTCardCell(Int_t absId, Int_t absIdRef, 
+                                                   Int_t sm, Float_t ampRef, 
+                                                   Int_t cellCase) ;
+
   void           AddInducedEnergiesToExistingCells();
   void           AddInducedEnergiesToNewCells();
   
@@ -75,6 +79,8 @@ class AliEmcalCorrectionCellEmulateCrosstalk : public AliEmcalCorrectionComponen
   Bool_t                fRandomizeTCard;           ///<  Use random induced energy
   
   Float_t               fTCardCorrMinAmp;          ///<  Minimum cell energy to induce signal on adjacent cells
+  Float_t               fTCardCorrMinInduced;      ///<  Minimum induced energy signal on adjacent cells, sum of induced plus original energy, use same as cell energy clusterization cut
+  Float_t               fTCardCorrMaxInducedELeak; ///<  Maximum value of induced energy signal that is always leaked, ~5-10 MeV
   Float_t               fTCardCorrMaxInduced;      ///<  Maximum induced energy signal on adjacent cells
   
   Bool_t                fPrintOnce;                ///< Print once analysis parameters
@@ -91,7 +97,7 @@ private:
   static RegisterCorrectionComponent<AliEmcalCorrectionCellEmulateCrosstalk> reg;
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionCellEmulateCrosstalk, 2); // EMCal cell crosstalk emulation correction component
+  ClassDef(AliEmcalCorrectionCellEmulateCrosstalk, 3); // EMCal cell crosstalk emulation correction component
   /// \endcond
 };
 

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -71,6 +71,8 @@ CellEmulateCrosstalk:                               # Component to emulate cross
     randomizeTCardInducedEnergy: true               # Randomize the energy fraction induced by the TCard
     inducedTCardMinimumCellEnergy: 0.01             # Minimum cell energy induced by the TCard
     inducedTCardMaximum: 100                        # Maximum energy induced by the TCard
+    inducedTCardMinimum: 0.05                       # Minimum energy induced by the TCard + cell energy, IMPORTANT use the same value as the clusterization cell E threshold or not too far from it
+    inducedTCardMaximumELeak: 0                     # Maximum energy that is going to be leaked independently of what is set with inducedTCardMinimum
     # Note on using the following section:
     # Each setting can be enabled or disabled. If disabled, the settings will _not_ be applied
     # The values are formatted as a map, with the keys as either "all", correspoding to all SMs

--- a/PWGGA/CaloTrackCorrelations/yaml/EMCalCorrConfig_MC_Run1_ClV1_xTalk_ECellCut.yaml
+++ b/PWGGA/CaloTrackCorrelations/yaml/EMCalCorrConfig_MC_Run1_ClV1_xTalk_ECellCut.yaml
@@ -1,4 +1,4 @@
-configurationName: "EMCal MC Correction Cluster V1 Run1 with cross talk emulation"
+configurationName: "EMCal MC Correction Cluster V1 Run1 with cross talk emulation, 100 MeV induced cut"
 pass: "pass1"
 CellEnergy:
     enabled: false
@@ -41,7 +41,7 @@ CellEmulateCrosstalk:                               # Component to emulate cross
     randomizeTCardInducedEnergy: true               # Randomize the energy fraction induced by the TCard
     inducedTCardMinimumCellEnergy: 0.01             # Minimum cell energy induced by the TCard
     inducedTCardMaximum: 100                        # Maximum energy induced by the TCard
-    inducedTCardMinimum: 0.0                        # Minimum energy induced by the TCard + cell energy, IMPORTANT use the same value as the clusterization cell E threshold or not too far from it
+    inducedTCardMinimum: 0.1                        # Minimum energy induced by the TCard + cell energy, IMPORTANT use the same value as the clusterization cell E threshold or not too far from it
     inducedTCardMaximumELeak: 0                     # Maximum energy that is going to be leaked independently of what is set with inducedTCardMinimum    
     inducedEnergyLossConstant:                      # Constant energy lost by max energy cell in one of T-Card cells
         enabled: false                              # Enable setting these values

--- a/PWGGA/CaloTrackCorrelations/yaml/EMCalCorrConfig_MC_Run1_ClV1_xTalk_ECellCut_Leak5MeV.yaml
+++ b/PWGGA/CaloTrackCorrelations/yaml/EMCalCorrConfig_MC_Run1_ClV1_xTalk_ECellCut_Leak5MeV.yaml
@@ -1,4 +1,4 @@
-configurationName: "EMCal MC Correction Cluster V1 Run1 with cross talk emulation"
+configurationName: "EMCal MC Correction Cluster V1 Run1 with cross talk emulation, 100 MeV induced cut and 5 MeV leak"
 pass: "pass1"
 CellEnergy:
     enabled: false
@@ -41,8 +41,8 @@ CellEmulateCrosstalk:                               # Component to emulate cross
     randomizeTCardInducedEnergy: true               # Randomize the energy fraction induced by the TCard
     inducedTCardMinimumCellEnergy: 0.01             # Minimum cell energy induced by the TCard
     inducedTCardMaximum: 100                        # Maximum energy induced by the TCard
-    inducedTCardMinimum: 0.0                        # Minimum energy induced by the TCard + cell energy, IMPORTANT use the same value as the clusterization cell E threshold or not too far from it
-    inducedTCardMaximumELeak: 0                     # Maximum energy that is going to be leaked independently of what is set with inducedTCardMinimum    
+    inducedTCardMinimum: 0.1                        # Minimum energy induced by the TCard + cell energy, IMPORTANT use the same value as the clusterization cell E threshold or not too far from it
+    inducedTCardMaximumELeak: 0.005                 # Maximum energy that is going to be leaked independently of what is set with inducedTCardMinimum    
     inducedEnergyLossConstant:                      # Constant energy lost by max energy cell in one of T-Card cells
         enabled: false                              # Enable setting these values
         values: {"all" : [0.02, 0.02, 0.02, 0]}     # Values are energy lost in [ upper/lower cell in same column, upper/lower cell in left or right, left or right cell in same row, 2nd row upper/lower cells]


### PR DESCRIPTION
set as default the limit on the induced leak at 50 MeV, like the default clusterization cut.
If one uses higher clusterization cuts, it has to be changed.

The calculation of the induced energy has been simplified, all is done by a single method for each of the correlated cells instead of replicating the lines for each correlated cell.

Update also the yaml files for the new cuts. In the PWGGA/CaloTrackCorrelations/yaml directory 3 yaml files with the cases: same as before, with the limit at the clusterization cell E cut, and adding the low energy leaks. For the particular case of V1 clusters and 100 MeV cell energy cut.
