### PR TITLE
Fix ROOT5 issue with pT-depedent artificial tracking efficiency

### DIFF
--- a/PWGJE/EMCALJetTasks/AliEmcalJetTask.cxx
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetTask.cxx
@@ -73,8 +73,9 @@ AliEmcalJetTask::AliEmcalJetTask() :
   fTrackEfficiency(1.),
   fUtilities(0),
   fTrackEfficiencyOnlyForEmbedding(kFALSE),
-  //fTrackEfficiencyFunction(),
+  fTrackEfficiencyFunction(nullptr),
   fApplyArtificialTrackingEfficiency(kFALSE),
+  fRandom(0),
   fLocked(0),
   fFillConstituents(kTRUE),
   fJetsName(),
@@ -111,8 +112,9 @@ AliEmcalJetTask::AliEmcalJetTask(const char *name) :
   fTrackEfficiency(1.),
   fUtilities(0),
   fTrackEfficiencyOnlyForEmbedding(kFALSE),
-  //fTrackEfficiencyFunction(),
+  fTrackEfficiencyFunction(nullptr),
   fApplyArtificialTrackingEfficiency(kFALSE),
+  fRandom(0),
   fLocked(0),
   fFillConstituents(kTRUE),
   fJetsName(),
@@ -254,9 +256,8 @@ Int_t AliEmcalJetTask::FindJets()
       // Apply artificial track inefficiency, if supplied (either constant or pT-dependent)
       if (fApplyArtificialTrackingEfficiency) {
         if (fTrackEfficiencyOnlyForEmbedding == kFALSE || (fTrackEfficiencyOnlyForEmbedding == kTRUE && tracks->GetIsEmbedding())) {
-          
-          Double_t trackEfficiency = fTrackEfficiency; //fTrackEfficiencyFunction.Eval(it->first.Pt());
-          Double_t rnd = gRandom->Rndm();
+          Double_t trackEfficiency = fTrackEfficiencyFunction->Eval(it->first.Pt());
+          Double_t rnd = fRandom.Rndm();
           if (trackEfficiency < rnd) {
             AliDebug(2,Form("Track %d rejected due to artificial tracking inefficiency", it.current_index()));
             continue;
@@ -389,17 +390,14 @@ void AliEmcalJetTask::ExecOnce()
       AliError(Form("%s: fTrackEfficiencyFunction was already loaded! Do not apply multiple artificial track efficiencies.", GetName()));
     }
     
-    //fTrackEfficiencyFunction = TF1("trackEfficiencyFunction", "[0]", 0., fMaxBinPt);
-    //fTrackEfficiencyFunction.SetParameter(0, fTrackEfficiency);
+    fTrackEfficiencyFunction = new TF1("trackEfficiencyFunction", "[0]", 0., fMaxBinPt);
+    fTrackEfficiencyFunction->SetParameter(0, fTrackEfficiency);
     fApplyArtificialTrackingEfficiency = kTRUE;
   }
   
   // If artificial tracking efficiency is enabled (either constant or pT-depdendent), set up random number generator
   if (fApplyArtificialTrackingEfficiency) {
-    if (gRandom) {
-      delete gRandom;
-    }
-    gRandom = new TRandom3(0);
+    fRandom.SetSeed(0);
   }
 
   fJetsName = AliJetContainer::GenerateJetName(fJetType, fJetAlgo, fRecombScheme, fRadius, GetParticleContainer(0), GetClusterContainer(0), fJetsTag);
@@ -999,8 +997,7 @@ void AliEmcalJetTask::LoadTrackEfficiencyFunction(const std::string & path, cons
     return;
   }
   
-  TF1* trackEffClone = static_cast<TF1*>(trackEff->Clone());
-  //fTrackEfficiencyFunction = *trackEffClone;
+  fTrackEfficiencyFunction = static_cast<TF1*>(trackEff->Clone());
   fApplyArtificialTrackingEfficiency = kTRUE;
   
   file->Close();

--- a/PWGJE/EMCALJetTasks/AliEmcalJetTask.h
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetTask.h
@@ -10,6 +10,7 @@ class AliVEvent;
 class AliEmcalJetUtility;
 
 #include "TF1.h"
+#include "TRandom3.h"
 
 #include <AliLog.h>
 
@@ -184,8 +185,9 @@ class AliEmcalJetTask : public AliAnalysisTaskEmcal {
   Double_t               fTrackEfficiency;        ///< artificial tracking inefficiency (0...1)
   TObjArray             *fUtilities;              ///< jet utilities (gen subtractor, constituent subtractor etc.)
   Bool_t                 fTrackEfficiencyOnlyForEmbedding; ///< Apply aritificial tracking inefficiency only for embedded tracks
-  //TF1                    fTrackEfficiencyFunction;///< Function that describes the artificial tracking efficiency to be applied on top of the nominal tracking efficiency, as a function of track pT
+  TF1                   *fTrackEfficiencyFunction;///< Function that describes the artificial tracking efficiency to be applied on top of the nominal tracking efficiency, as a function of track pT
   Bool_t                 fApplyArtificialTrackingEfficiency; ///< Flag to apply artificial tracking efficiency
+  TRandom3               fRandom;                 //!<! Random number generator for artificial tracking efficiency
   Bool_t                 fLocked;                 ///< true if lock is set
   Bool_t	          fFillConstituents;		 ///< If true jet consituents will be filled to the AliEmcalJet
 
@@ -212,7 +214,7 @@ class AliEmcalJetTask : public AliAnalysisTaskEmcal {
   AliEmcalJetTask &operator=(const AliEmcalJetTask&); // not implemented
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalJetTask, 27);
+  ClassDef(AliEmcalJetTask, 28);
   /// \endcond
 };
 #endif


### PR DESCRIPTION
See PR #5541 and #5584. This commit fixes the ROOT5 issue by switching the TF1 back to using pointers. It was tested in both ROOT5 and ROOT6, and verified to agree in all cases. As before the feature is off by default.

The use of gRandom was also discontinued here, as discussed in 5541.