### PR TITLE
Added configuration to CF for D0, D+ and D*+ ESE analysis

### DIFF
--- a/PWGHF/vertexingHF/AliCFTaskVertexingHF.cxx
+++ b/PWGHF/vertexingHF/AliCFTaskVertexingHF.cxx
@@ -364,6 +364,9 @@ void AliCFTaskVertexingHF::Init()
     case kFalcon:// super fast configuration: only pt_candidate, y, centrality
       fNvar = 4;
       break;
+    case kESE:// configuration with variables for ESE analysis (pt,y,centrality,mult,q2)
+      fNvar = 6;
+      break;
     }
     fPartName="D0";
     fDauNames="K+pi";
@@ -381,6 +384,9 @@ void AliCFTaskVertexingHF::Init()
       break;
     case kFalcon:// super fast configuration: only pt_candidate, y, centrality
       fNvar = 4;
+      break;
+    case kESE:// configuration with variables for ESE analysis (pt,y,centrality,mult,q2)
+      fNvar = 6;
       break;
     }
     fPartName="Dstar";
@@ -417,6 +423,9 @@ void AliCFTaskVertexingHF::Init()
       break;
     case kFalcon:// super fast configuration: only pt_candidate, y, centrality
       fNvar = 4;
+      break;
+    case kESE:// configuration with variables for ESE analysis (pt,y,centrality,mult,q2)
+      fNvar = 6;
       break;
     }
     fPartName="Dplus";
@@ -742,7 +751,7 @@ void AliCFTaskVertexingHF::UserExec(Option_t *)
   Int_t nTrackletsEta16 = static_cast<Int_t>(AliVertexingHFUtils::GetNumberOfTrackletsInEtaRange(aodEvent,-1.6,1.6));
   nTracklets = (Double_t)nTrackletsEta10;
   if(fMultiplicityEstimator==kNtrk10to16) { nTracklets = (Double_t)(nTrackletsEta16 - nTrackletsEta10); }
-
+  
   // Apply the Ntracklets z-vtx data driven correction
   if(fZvtxCorrectedNtrkEstimator) {
     TProfile* estimatorAvg = GetEstimatorHistogram(aodEvent);
@@ -844,6 +853,16 @@ void AliCFTaskVertexingHF::UserExec(Option_t *)
   if(fMultiplicityEstimator==kVZERO) { multiplicity = vzeroMult; }
 
   cfVtxHF->SetMultiplicity(multiplicity);
+  
+  Double_t q2=0;
+  if(fConfiguration==kESE) {
+    //set q2 in case of kESE configuration
+    q2=ComputeTPCq2(aodEvent,-0.8,0.8,0.2,5.);
+    cfVtxHF->Setq2Value(q2);
+
+    //set track array in case of kESE configuration
+    cfVtxHF->SetTrackArray(aodEvent->GetTracks());
+  }
 
   //  printf("Multiplicity estimator %d, value %2.2f\n",fMultiplicityEstimator,multiplicity);
 
@@ -1367,6 +1386,21 @@ void AliCFTaskVertexingHF::Terminate(Option_t*)
       h[2][iC] =   *(cont->ShowProjection(iC,4));
     }
   }
+  else if(fConfiguration == kESE){
+    //h = new TH1D[3][12];
+    nvarToPlot = 6;
+    for (Int_t ih = 0; ih<3; ih++){
+      h[ih] = new TH1D[nvarToPlot];
+    }
+    for(Int_t iC=0;iC<nvarToPlot; iC++){
+      // MC-level
+      h[0][iC] =   *(cont->ShowProjection(iC,0));
+      // MC-Acceptance level
+      h[1][iC] =   *(cont->ShowProjection(iC,1));
+      // Reco-level
+      h[2][iC] =   *(cont->ShowProjection(iC,4));
+    }
+  }
   TString* titles;
   //Int_t nvarToPlot = 0;
   if (fConfiguration == kSnail){
@@ -1461,6 +1495,16 @@ void AliCFTaskVertexingHF::Terminate(Option_t*)
       titles[2]="centrality";
       titles[3]="multiplicity";
     }
+  }
+  else if(fConfiguration == kESE){
+    //nvarToPlot = 4;
+    titles = new TString[nvarToPlot];
+    titles[0]="pT_candidate (GeV/c)";
+    titles[1]="rapidity";
+    titles[2]="centrality";
+    titles[3]="multiplicity";
+    titles[4]="N_{tracks} (#Delta#eta<0.1,#Delta#varphi<0.1)";
+    titles[5]="q_{2}";
   }
 
   Int_t markers[16]={20,24,21,25,27,28,
@@ -2183,3 +2227,37 @@ TProfile* AliCFTaskVertexingHF::GetEstimatorHistogram(const AliVEvent* event){
 
   return fMultEstimatorAvg[period];
 }
+
+//________________________________________________________________________
+Double_t AliCFTaskVertexingHF::ComputeTPCq2(AliAODEvent* aod, Double_t etamin, Double_t etamax, Double_t ptmin, Double_t ptmax) const {
+  /// Compute the q2 for ESE starting from TPC tracks
+  /// TO BE ADDED: use only HIJING tracks
+  
+  Int_t nTracks=aod->GetNumberOfTracks();
+  Double_t nHarmonic=2.;
+  Double_t q2Vec[2] = {0.,0.};
+  Int_t multQvec=0;
+  
+  for(Int_t it=0; it<nTracks; it++){
+    AliAODTrack* track=(AliAODTrack*)aod->GetTrack(it);
+    if(!track) continue;
+    if(track->TestFilterBit(BIT(8))||track->TestFilterBit(BIT(9))) {
+      Double_t pt=track->Pt();
+      Double_t eta=track->Eta();
+      Double_t phi=track->Phi();
+      Double_t qx=TMath::Cos(nHarmonic*phi);
+      Double_t qy=TMath::Sin(nHarmonic*phi);
+      if(eta<etamax && eta>etamin && pt>ptmin && pt<ptmax) {
+        q2Vec[0]+=qx;
+        q2Vec[1]+=qy;
+        multQvec++;
+      }
+    }
+  }
+  
+  Double_t q2 = 0.;
+  if(multQvec>0) q2 = TMath::Sqrt(q2Vec[0]*q2Vec[0]+q2Vec[1]*q2Vec[1])/TMath::Sqrt(multQvec);
+
+  return q2;
+}
+

--- a/PWGHF/vertexingHF/AliCFTaskVertexingHF.h
+++ b/PWGHF/vertexingHF/AliCFTaskVertexingHF.h
@@ -67,7 +67,8 @@ class AliCFTaskVertexingHF: public AliAnalysisTaskSE {
   enum {
     kSnail = 0,    /// slow configuration, all variables
     kCheetah = 1,   /// fast configuration, only a subset of variables
-    kFalcon = 2   /// super fast configuration, only (pt,y,centrality)
+    kFalcon = 2,   /// super fast configuration, only (pt,y,centrality)
+    kESE = 3   /// configuration with variables for ESE analysis (pt,y,centrality,q2,mult)
   };
 
   enum {
@@ -273,6 +274,8 @@ class AliCFTaskVertexingHF: public AliAnalysisTaskSE {
 
   void SetCutOnMomConservation(Float_t cut) {fCutOnMomConservation = cut;}
   Bool_t GetCutOnMomConservation() const {return fCutOnMomConservation;}
+
+  Double_t ComputeTPCq2(AliAODEvent* aod, Double_t etamin, Double_t etamax, Double_t ptmin, Double_t ptmax) const;
 
  protected:
   AliCFManager   *fCFManager;   ///  pointer to the CF manager

--- a/PWGHF/vertexingHF/AliCFVertexingHF.cxx
+++ b/PWGHF/vertexingHF/AliCFVertexingHF.cxx
@@ -61,7 +61,10 @@ AliCFVertexingHF::AliCFVertexingHF() :
 	fFakeSelection(0),
 	fFake(1.), // setting to MC value
 	fRejectIfNoQuark(kFALSE),
-	fMultiplicity(0.),
+  fMultiplicity(0.),
+  fLocalMultiplicity(0),
+  fq2(0.),
+  fTrackArray(0x0),
 	fConfiguration(AliCFTaskVertexingHF::kCheetah) // by default, setting the fast configuration
 {
 	//
@@ -97,6 +100,9 @@ AliCFVertexingHF::AliCFVertexingHF(TClonesArray *mcArray, UShort_t originDselect
 	fFake(1.), // setting to MC value
 	fRejectIfNoQuark(kFALSE),
 	fMultiplicity(0.),
+  fLocalMultiplicity(0),
+  fq2(0.),
+  fTrackArray(0x0),
 	fConfiguration(AliCFTaskVertexingHF::kCheetah) // by default, setting the fast configuration
 {
 	//
@@ -128,7 +134,11 @@ AliCFVertexingHF::~AliCFVertexingHF()
 	if (fEtaAccCut){
 	  	delete [] fEtaAccCut;
 	  	fEtaAccCut = 0x0;
-	}	
+	}
+  if(fTrackArray) {
+    delete fTrackArray;
+    fTrackArray = 0x0;
+  }
 }
 
 //_____________________________________________________
@@ -173,7 +183,11 @@ AliCFVertexingHF& AliCFVertexingHF::operator=(const AliCFVertexingHF& c)
 				fEtaAccCut[iP]=c.fEtaAccCut[iP];
 			}
 		}
-		fMultiplicity=c.fMultiplicity;
+    fMultiplicity=c.fMultiplicity;
+    fLocalMultiplicity=c.fLocalMultiplicity;
+    fq2=c.fq2;
+    delete fTrackArray;
+    fTrackArray = new TClonesArray(*(c.fTrackArray));
 		fConfiguration=c.fConfiguration;
 	}
 	
@@ -203,7 +217,10 @@ AliCFVertexingHF::AliCFVertexingHF(const AliCFVertexingHF &c) :
 	fFakeSelection(c.fFakeSelection),
 	fFake(c.fFake),
 	fRejectIfNoQuark(c.fRejectIfNoQuark),	
-	fMultiplicity(c.fMultiplicity),
+  fMultiplicity(c.fMultiplicity),
+  fLocalMultiplicity(c.fLocalMultiplicity),
+  fq2(c.fq2),
+  fTrackArray(0),
 	fConfiguration(c.fConfiguration)
 {  
   //
@@ -226,6 +243,8 @@ AliCFVertexingHF::AliCFVertexingHF(const AliCFVertexingHF &c) :
     if (c.fPtAccCut) memcpy(fPtAccCut,c.fPtAccCut,fProngs*sizeof(Int_t));
     if (c.fEtaAccCut) memcpy(fEtaAccCut,c.fEtaAccCut,fProngs*sizeof(Int_t));
   }
+  delete fTrackArray;
+  fTrackArray = new TClonesArray(*(c.fTrackArray));
 }
 
 //___________________________________________________________
@@ -1015,4 +1034,25 @@ void AliCFVertexingHF::SetAccCut()
 		}
 	}
 	return;
-}		
+}
+
+//___________________________________________________________
+Int_t AliCFVertexingHF::ComputeLocalMultiplicity(Double_t etaD, Double_t phiD, Double_t deltaEta, Double_t deltaPhi) const {
+  
+  Int_t mult=0;
+  if(!fTrackArray) {
+    AliWarning("Track array not found, local multiplicity not computed\n");
+    return 0;
+  }
+  for(Int_t it=0; it<fTrackArray->GetEntriesFast(); it++) {
+    AliAODTrack* track=(AliAODTrack*)fTrackArray->UncheckedAt(it);
+    if(!track) continue;
+    if(!track->TestFilterBit(BIT(8)) && !track->TestFilterBit(BIT(9))) continue;
+    Double_t eta=track->Eta();
+    Double_t phi=track->Phi();
+    if(TMath::Abs(eta-etaD)<deltaEta && TMath::Abs(phi-phiD)<deltaPhi) mult++;
+  }
+  
+  return mult;
+}
+

--- a/PWGHF/vertexingHF/AliCFVertexingHF.h
+++ b/PWGHF/vertexingHF/AliCFVertexingHF.h
@@ -116,11 +116,14 @@ class AliCFVertexingHF : public TObject {
 	void SetRejectCandidateIfNotFromQuark(Bool_t opt){fRejectIfNoQuark=opt;}
 
 	void SetMultiplicity(Double_t multiplicity) {fMultiplicity = multiplicity;}
-	void SetConfiguration(Int_t configuration) {fConfiguration = configuration;}
+  void Setq2Value(Double_t q2) {fq2 = q2;}
+  void SetTrackArray(TClonesArray* trkarray) {fTrackArray = trkarray;}
+  void SetConfiguration(Int_t configuration) {fConfiguration = configuration;}
+
+  Int_t ComputeLocalMultiplicity(Double_t etaD, Double_t phiD, Double_t deltaEta, Double_t deltaPhi) const;
 
 	protected:
-	
-	TClonesArray      *fmcArray;               /// mcArray candidate
+  TClonesArray      *fmcArray;               /// mcArray candidate
 	AliAODRecoDecayHF *fRecoCandidate;         /// Reconstructed HF candidate
 	AliAODMCParticle  *fmcPartCandidate;
 	Int_t fNDaughters;
@@ -143,11 +146,14 @@ class AliCFVertexingHF : public TObject {
 	Int_t fFakeSelection; /// fakes selection: 0 --> all, 1 --> non-fake, 2 --> fake
 	Float_t fFake;              /// variable to indicate whether the D0 was a fake or not: 0 --> fake, 1 --> MC, 2 --> non-fake
 	Bool_t fRejectIfNoQuark;  /// flag to remove events not geenrated with PYTHIA
-	Double_t fMultiplicity;    /// multiplicity of the event
-	Int_t fConfiguration;    /// configuration (slow / fast) of the CF --> different variables will be allocated (all / reduced number)
+  Double_t fMultiplicity;    /// multiplicity of the event
+  Int_t fLocalMultiplicity;    /// multiplicity of the event
+  Double_t fq2; /// magnitude of the reduced flow vector (computed using TPC tracks)
+  TClonesArray      *fTrackArray;               /// array of tracks
+  Int_t fConfiguration;    /// configuration (slow / fast) of the CF --> different variables will be allocated (all / reduced number)
 
     /// \cond CLASSIMP    
-	ClassDef(AliCFVertexingHF, 7);
+	ClassDef(AliCFVertexingHF, 8);
     /// \endcond
 };
 

--- a/PWGHF/vertexingHF/AliCFVertexingHF2Prong.cxx
+++ b/PWGHF/vertexingHF/AliCFVertexingHF2Prong.cxx
@@ -198,6 +198,11 @@ Bool_t AliCFVertexingHF2Prong::GetGeneratedValuesFromMCParticle(Double_t* vector
 		pTK = mcPartDaughter0->Pt();
 	}
 	
+  if(fConfiguration == AliCFTaskVertexingHF::kESE) {
+    AliAODRecoDecayHF2Prong *d0toKpi = (AliAODRecoDecayHF2Prong*)fRecoCandidate;
+    fLocalMultiplicity = ComputeLocalMultiplicity(d0toKpi->Eta(), d0toKpi->Phi(), 0.1, 0.1);
+  }
+  
 	switch (fConfiguration){
 	case AliCFTaskVertexingHF::kSnail:
 		vectorMC[0] = fmcPartCandidate->Pt();
@@ -233,6 +238,14 @@ Bool_t AliCFVertexingHF2Prong::GetGeneratedValuesFromMCParticle(Double_t* vector
 		vectorMC[2] = fCentValue;   // dummy value for dca, meaningless in MC
 		vectorMC[3] = fMultiplicity;   // dummy value for dca, meaningless in MC
 		break;
+  case AliCFTaskVertexingHF::kESE:
+    vectorMC[0] = fmcPartCandidate->Pt();
+    vectorMC[1] = fmcPartCandidate->Y() ;
+    vectorMC[2] = fCentValue;   // centrality
+    vectorMC[3] = fMultiplicity;   // multiplicity (diff estimators can be used)
+    vectorMC[4] = fLocalMultiplicity;   // local multiplicity (Ntracks in DeltaEta<0.1 and DeltaPhi<0.1)
+    vectorMC[5] = fq2;   // magnitude of reduced flow vector (computed using TPC tracks)
+    break;
 	}
 	delete decay;
 	bGenValues = kTRUE;
@@ -322,6 +335,14 @@ Bool_t AliCFVertexingHF2Prong::GetRecoValuesFromCandidate(Double_t *vectorReco) 
 		vectorReco[2] = fCentValue;   
 		vectorReco[3] = fMultiplicity;   
 		break;
+  case AliCFTaskVertexingHF::kESE:
+    vectorReco[0] = pt;
+    vectorReco[1] = rapidity;
+    vectorReco[2] = fCentValue;   // centrality
+    vectorReco[3] = fMultiplicity;   // multiplicity (diff estimators can be used)
+    vectorReco[4] = fLocalMultiplicity;   // local multiplicity (Ntracks in DeltaEta<0.1 and DeltaPhi<0.1)
+    vectorReco[5] = fq2;   // magnitude of reduced flow vector (computed using TPC tracks)
+    break;
 	}
 
 	bFillRecoValues = kTRUE;

--- a/PWGHF/vertexingHF/AliCFVertexingHF3Prong.cxx
+++ b/PWGHF/vertexingHF/AliCFVertexingHF3Prong.cxx
@@ -336,6 +336,11 @@ Bool_t AliCFVertexingHF3Prong::GetGeneratedValuesFromMCParticle(Double_t* vector
 	AliAODRecoDecayHF* decay = new AliAODRecoDecayHF(vertD,vertDec,nprongs,charge,px,py,pz,d0);
 	Double_t cT = decay->Ct(pdgCand);
 	
+  if(fConfiguration == AliCFTaskVertexingHF::kESE) {
+    AliAODRecoDecayHF3Prong *decay3 = (AliAODRecoDecayHF3Prong*)fRecoCandidate;
+    fLocalMultiplicity = ComputeLocalMultiplicity(decay3->Eta(), decay3->Phi(), 0.1, 0.1);
+  }
+
 	switch (fConfiguration){
 	case AliCFTaskVertexingHF::kSnail:
 		vectorMC[0] = fmcPartCandidate->Pt();
@@ -374,12 +379,20 @@ Bool_t AliCFVertexingHF3Prong::GetGeneratedValuesFromMCParticle(Double_t* vector
 		vectorMC[6] = 1. ;  // fake: always filling with 1 at MC level 
 		vectorMC[7] = fMultiplicity;   // dummy value for d0pi, meaningless in MC, in micron
 		break;
-	case AliCFTaskVertexingHF::kFalcon:
-		vectorMC[0] = fmcPartCandidate->Pt();
-		vectorMC[1] = fmcPartCandidate->Y() ;
-		vectorMC[2] = fCentValue;   // dummy value for dca, meaningless in MC
-		vectorMC[3] = fMultiplicity;   // dummy value for d0pi, meaningless in MC, in micron
-		break;
+  case AliCFTaskVertexingHF::kFalcon:
+    vectorMC[0] = fmcPartCandidate->Pt();
+    vectorMC[1] = fmcPartCandidate->Y() ;
+    vectorMC[2] = fCentValue;   // dummy value for dca, meaningless in MC
+    vectorMC[3] = fMultiplicity;   // dummy value for d0pi, meaningless in MC, in micron
+    break;
+  case AliCFTaskVertexingHF::kESE:
+    vectorMC[0] = fmcPartCandidate->Pt();
+    vectorMC[1] = fmcPartCandidate->Y() ;
+    vectorMC[2] = fCentValue;   // centrality
+    vectorMC[3] = fMultiplicity;   // multiplicity (diff estimators can be used)
+    vectorMC[4] = fLocalMultiplicity;   // local multiplicity (Ntracks in DeltaEta<0.1 and DeltaPhi<0.1)
+    vectorMC[5] = fq2;   // magnitude of reduced flow vector (computed using TPC tracks)
+    break;
 	}
 	delete decay;	
 	bGenValues = kTRUE;
@@ -496,6 +509,14 @@ Bool_t AliCFVertexingHF3Prong::GetRecoValuesFromCandidate(Double_t *vectorReco) 
 		vectorReco[2] = fCentValue;   
 		vectorReco[3] = fMultiplicity;  
 		break;
+  case AliCFTaskVertexingHF::kESE:
+    vectorReco[0] = pt;
+    vectorReco[1] = rapidity;
+    vectorReco[2] = fCentValue;   // centrality
+    vectorReco[3] = fMultiplicity;   // multiplicity (diff estimators can be used)
+    vectorReco[4] = fLocalMultiplicity;   // local multiplicity (Ntracks in DeltaEta<0.1 and DeltaPhi<0.1)
+    vectorReco[5] = fq2;   // magnitude of reduced flow vector (computed using TPC tracks)
+    break;
 	}
 
 	bFillRecoValues = kTRUE;

--- a/PWGHF/vertexingHF/AliCFVertexingHFCascade.cxx
+++ b/PWGHF/vertexingHF/AliCFVertexingHFCascade.cxx
@@ -285,6 +285,11 @@ Bool_t AliCFVertexingHFCascade::GetGeneratedValuesFromMCParticle(Double_t* vecto
 
   AliDebug(3, Form("The candidate has pt = %f, y = %f", fmcPartCandidate->Pt(), fmcPartCandidate->Y()));
 
+  if(fConfiguration == AliCFTaskVertexingHF::kESE) {
+    AliAODRecoCascadeHF* cascade = (AliAODRecoCascadeHF*)fRecoCandidate;
+    fLocalMultiplicity = ComputeLocalMultiplicity(cascade->Eta(), cascade->Phi(), 0.1, 0.1);
+  }
+
   switch (fConfiguration){
   case AliCFTaskVertexingHF::kSnail:
     vectorMC[0] = fmcPartCandidate->Pt();
@@ -319,6 +324,14 @@ Bool_t AliCFVertexingHFCascade::GetGeneratedValuesFromMCParticle(Double_t* vecto
     vectorMC[1] = fmcPartCandidate->Y() ;
     vectorMC[2] = fCentValue;   // dummy value for dca, meaningless in MC
     vectorMC[3] = fMultiplicity;   // dummy value for d0pi, meaningless in MC, in micron
+    break;
+  case AliCFTaskVertexingHF::kESE:
+    vectorMC[0] = fmcPartCandidate->Pt();
+    vectorMC[1] = fmcPartCandidate->Y() ;
+    vectorMC[2] = fCentValue;   // centrality
+    vectorMC[3] = fMultiplicity;   // multiplicity (diff estimators can be used)
+    vectorMC[4] = fLocalMultiplicity;   // local multiplicity (Ntracks in DeltaEta<0.1 and DeltaPhi<0.1)
+    vectorMC[5] = fq2;   // magnitude of reduced flow vector (computed using TPC tracks)
     break;
   }
 
@@ -418,6 +431,14 @@ Bool_t AliCFVertexingHFCascade::GetRecoValuesFromCandidate(Double_t *vectorReco)
     vectorReco[1] = rapidity;
     vectorReco[2] = fCentValue;
     vectorReco[3] = fMultiplicity; 
+    break;
+  case AliCFTaskVertexingHF::kESE:
+    vectorReco[0] = pt;
+    vectorReco[1] = rapidity;
+    vectorReco[2] = fCentValue;   // centrality
+    vectorReco[3] = fMultiplicity;   // multiplicity (diff estimators can be used)
+    vectorReco[4] = fLocalMultiplicity;   // local multiplicity (Ntracks in DeltaEta<0.1 and DeltaPhi<0.1)
+    vectorReco[5] = fq2;   // magnitude of reduced flow vector (computed using TPC tracks)
     break;
   }
 

--- a/PWGHF/vertexingHF/macros/AddTaskCFVertexingHF.C
+++ b/PWGHF/vertexingHF/macros/AddTaskCFVertexingHF.C
@@ -72,9 +72,12 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF(const char* cutFile = "./D0toKpiCuts.
 	else if (configuration == AliCFTaskVertexingHF::kCheetah){
 		printf("The configuration is set to be FAST --> using only pt, y, ct, phi, zvtx, centrality, fake, multiplicity to fill the CF\n");
 	}
-	else if (configuration == AliCFTaskVertexingHF::kFalcon){
-		printf("The configuration is set to be FAST --> using only pt, y, centrality, multiplicity to fill the CF\n");
-	}
+  else if (configuration == AliCFTaskVertexingHF::kFalcon){
+    printf("The configuration is set to be FAST --> using only pt, y, centrality, multiplicity to fill the CF\n");
+  }
+  else if (configuration == AliCFTaskVertexingHF::kESE){
+    printf("The configuration is set to be for ESE analysis --> using pt, y, centrality, multiplicity, local multiplicity and q2 to fill the CF\n");
+  }
 	else{
 		printf("The configuration is not defined! returning\n");
 		return;
@@ -562,6 +565,63 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF(const char* cutFile = "./D0toKpiCuts.
 		container -> SetVarTitle(icentSuperFast, "centrality");
 		container -> SetVarTitle(imultSuperFast, "multiplicity");
 	}
+  else if (configuration == AliCFTaskVertexingHF::kESE){
+    //arrays for the number of bins in each dimension
+    const Int_t nvar = 6;
+    
+    const UInt_t ipTESE = 0;
+    const UInt_t iyESE = 1;
+    const UInt_t icentESE = 2;
+    const UInt_t imultESE = 3;
+    const UInt_t ilocalmultESE = 4;
+    const UInt_t iq2ESE = 5;
+    
+    Int_t iBinESE[nvarESE];
+    iBinESE[ipTESE] = iBin[ipT];
+    iBinESE[iyESE] = iBin[iy];
+    iBinESE[icentESE] = 100;
+    iBinESE[imultESE] = 100;
+    iBinESE[ilocalmultESE] = 20;
+    iBinESE[iq2ESE] = 250;
+    
+    Double_t binLimcentESE[iBinESE[icentESE]+1];
+    for(Int_t iCent=0; iCent<iBinESE[icentESE]+1; iCent++) {
+      binLimcentESE[iCent] = iCent;
+    }
+    Double_t binLimmultESE[iBinESE[imultESE]+1];
+    for(Int_t iMult=0; iMult<iBinESE[imultESE]+1; iMult++) {
+      binLimmultESE[iMult] = -0.5+iMult*5000/iBinESE[imultESE];
+    }
+    Double_t binLimlocalmultESE[iBinESE[ilocalmultESE]+1];
+    for(Int_t iLocalMult=0; iLocalMult<iBinESE[ilocalmultESE]+1; iLocalMult++) {
+      binLimlocalmultESE[iLocalMult] = -0.5+iLocalMult*100/iBinESE[ilocalmultESE];
+    }
+    Double_t binLimq2ESE[iBinESE[iq2ESE]+1];
+    for(Int_t iq2=0; iq2<iBinESE[iq2ESE]+1; iq2++) {
+      binLimq2ESE[iq2] = iq2*5/iBinESE[iq2ESE];
+    }
+    
+    container = new AliCFContainer(nameContainer,"container for tracks",nstep,nvar,iBinESE);
+    printf("pt\n");
+    container -> SetBinLimits(ipTESE,binLimpT);
+    printf("y\n");
+    container -> SetBinLimits(iyESE,binLimy);
+    printf("centrality\n");
+    container -> SetBinLimits(icentESE,binLimcentESE);
+    printf("multiplicity\n");
+    container -> SetBinLimits(imultESE,binLimmultESE);
+    printf("local multiplicity\n");
+    container -> SetBinLimits(ilocalmultESE,binLimlocalmultESE);
+    printf("q2\n");
+    container -> SetBinLimits(iq2ESE,binLimq2ESE);
+    
+    container -> SetVarTitle(ipTESE,"pt");
+    container -> SetVarTitle(iyESE,"y");
+    container -> SetVarTitle(icentESE, "centrality");
+    container -> SetVarTitle(imultESE, "multiplicity");
+    container -> SetVarTitle(ilocalmultESE, "local multiplicity");
+    container -> SetVarTitle(iq2ESE, "q2");
+  }
 
 	container -> SetStepTitle(0, "MCLimAcc");
 	container -> SetStepTitle(1, "MC");

--- a/PWGHF/vertexingHF/macros/AddTaskCFVertexingHF3Prong.C
+++ b/PWGHF/vertexingHF/macros/AddTaskCFVertexingHF3Prong.C
@@ -526,6 +526,63 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3Prong(TString suffixName="", const ch
 		container -> SetVarTitle(icentSuperFast, "centrality");
 		container -> SetVarTitle(imultSuperFast, "multiplicity");
 	}
+  else if (configuration == AliCFTaskVertexingHF::kESE){
+    //arrays for the number of bins in each dimension
+    const Int_t nvar = 6;
+    
+    const UInt_t ipTESE = 0;
+    const UInt_t iyESE = 1;
+    const UInt_t icentESE = 2;
+    const UInt_t imultESE = 3;
+    const UInt_t ilocalmultESE = 4;
+    const UInt_t iq2ESE = 5;
+
+    Int_t iBinESE[nvarESE];
+    iBinESE[ipTESE] = iBin[ipT];
+    iBinESE[iyESE] = iBin[iy];
+    iBinESE[icentESE] = 100;
+    iBinESE[imultESE] = 100;
+    iBinESE[ilocalmultESE] = 20;
+    iBinESE[iq2ESE] = 250;
+
+    Double_t binLimcentESE[iBinESE[icentESE]+1];
+    for(Int_t iCent=0; iCent<iBinESE[icentESE]+1; iCent++) {
+      binLimcentESE[iCent] = iCent;
+    }
+    Double_t binLimmultESE[iBinESE[imultESE]+1];
+    for(Int_t iMult=0; iMult<iBinESE[imultESE]+1; iMult++) {
+      binLimmultESE[iMult] = -0.5+iMult*5000/iBinESE[imultESE];
+    }
+    Double_t binLimlocalmultESE[iBinESE[ilocalmultESE]+1];
+    for(Int_t iLocalMult=0; iLocalMult<iBinESE[ilocalmultESE]+1; iLocalMult++) {
+      binLimlocalmultESE[iLocalMult] = -0.5+iLocalMult*100/iBinESE[ilocalmultESE];
+    }
+    Double_t binLimq2ESE[iBinESE[iq2ESE]+1];
+    for(Int_t iq2=0; iq2<iBinESE[iq2ESE]+1; iq2++) {
+      binLimq2ESE[iq2] = iq2*5/iBinESE[iq2ESE];
+    }
+
+    container = new AliCFContainer(nameContainer,"container for tracks",nstep,nvar,iBinESE);
+    printf("pt\n");
+    container -> SetBinLimits(ipTESE,binLimpT);
+    printf("y\n");
+    container -> SetBinLimits(iyESE,binLimy);
+    printf("centrality\n");
+    container -> SetBinLimits(icentESE,binLimcentESE);
+    printf("multiplicity\n");
+    container -> SetBinLimits(imultESE,binLimmultESE);
+    printf("local multiplicity\n");
+    container -> SetBinLimits(ilocalmultESE,binLimlocalmultESE);
+    printf("q2\n");
+    container -> SetBinLimits(iq2ESE,binLimq2ESE);
+
+    container -> SetVarTitle(ipTESE,"pt");
+    container -> SetVarTitle(iyESE,"y");
+    container -> SetVarTitle(icentESE, "centrality");
+    container -> SetVarTitle(imultESE, "multiplicity");
+    container -> SetVarTitle(ilocalmultESE, "local multiplicity");
+    container -> SetVarTitle(iq2ESE, "q2");
+  }
 
 	//return container;
 

--- a/PWGHF/vertexingHF/macros/AddTaskCFVertexingHFCascade.C
+++ b/PWGHF/vertexingHF/macros/AddTaskCFVertexingHFCascade.C
@@ -63,6 +63,9 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFCascade(const char* cutFile = "DStarto
 	else if (configuration == AliCFTaskVertexingHF::kFalcon){
 		printf("The configuration is set to be FAST --> using only pt, y, centrality, multiplicity to fill the CF\n");
 	}
+  else if (configuration == AliCFTaskVertexingHF::kESE){
+    printf("The configuration is set to be for ESE analysis --> using pt, y, centrality, multiplicity, local multiplicity and q2 to fill the CF\n");
+  }
 	else{
 		printf("The configuration is not defined! returning\n");
 		return;
@@ -473,7 +476,65 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFCascade(const char* cutFile = "DStarto
 		container -> SetVarTitle(icentSuperFast, "centrality");
 		container -> SetVarTitle(imultSuperFast, "multiplicity");
 	}
+  else if (configuration == AliCFTaskVertexingHF::kESE){
+    //arrays for the number of bins in each dimension
+    const Int_t nvar = 6;
+    
+    const UInt_t ipTESE = 0;
+    const UInt_t iyESE = 1;
+    const UInt_t icentESE = 2;
+    const UInt_t imultESE = 3;
+    const UInt_t ilocalmultESE = 4;
+    const UInt_t iq2ESE = 5;
+    
+    Int_t iBinESE[nvarESE];
+    iBinESE[ipTESE] = iBin[ipT];
+    iBinESE[iyESE] = iBin[iy];
+    iBinESE[icentESE] = 100;
+    iBinESE[imultESE] = 100;
+    iBinESE[ilocalmultESE] = 20;
+    iBinESE[iq2ESE] = 250;
+    
+    Double_t binLimcentESE[iBinESE[icentESE]+1];
+    for(Int_t iCent=0; iCent<iBinESE[icentESE]+1; iCent++) {
+      binLimcentESE[iCent] = iCent;
+    }
+    Double_t binLimmultESE[iBinESE[imultESE]+1];
+    for(Int_t iMult=0; iMult<iBinESE[imultESE]+1; iMult++) {
+      binLimmultESE[iMult] = -0.5+iMult*5000/iBinESE[imultESE];
+    }
+    Double_t binLimlocalmultESE[iBinESE[ilocalmultESE]+1];
+    for(Int_t iLocalMult=0; iLocalMult<iBinESE[ilocalmultESE]+1; iLocalMult++) {
+      binLimlocalmultESE[iLocalMult] = -0.5+iLocalMult*100/iBinESE[ilocalmultESE];
+    }
+    Double_t binLimq2ESE[iBinESE[iq2ESE]+1];
+    for(Int_t iq2=0; iq2<iBinESE[iq2ESE]+1; iq2++) {
+      binLimq2ESE[iq2] = iq2*5/iBinESE[iq2ESE];
+    }
+    
+    container = new AliCFContainer(nameContainer,"container for tracks",nstep,nvar,iBinESE);
+    printf("pt\n");
+    container -> SetBinLimits(ipTESE,binLimpT);
+    printf("y\n");
+    container -> SetBinLimits(iyESE,binLimy);
+    printf("centrality\n");
+    container -> SetBinLimits(icentESE,binLimcentESE);
+    printf("multiplicity\n");
+    container -> SetBinLimits(imultESE,binLimmultESE);
+    printf("local multiplicity\n");
+    container -> SetBinLimits(ilocalmultESE,binLimlocalmultESE);
+    printf("q2\n");
+    container -> SetBinLimits(iq2ESE,binLimq2ESE);
+    
+    container -> SetVarTitle(ipTESE,"pt");
+    container -> SetVarTitle(iyESE,"y");
+    container -> SetVarTitle(icentESE, "centrality");
+    container -> SetVarTitle(imultESE, "multiplicity");
+    container -> SetVarTitle(ilocalmultESE, "local multiplicity");
+    container -> SetVarTitle(iq2ESE, "q2");
+  }
 
+  
 	container -> SetStepTitle(0, "MCLimAcc");
 	container -> SetStepTitle(1, "MC");
         container -> SetStepTitle(2, "MCAcc");


### PR DESCRIPTION
Added configuration to CF for D0, D+ and D*+ for the ESE analysis, with pt, y, centrality, multiplicity, local multiplicity and q2 axes. The local multiplicity is defined as the number of tracks passing FilterBit 8||9 with DeltaEta<0.1 and DeltaPhi<0.1 wrt the D meson. The q2 is computed using TPC tracks with 0.2<pt<5 GeV/c, |eta|<0.8 and FilterBit 8||9.