### PR TITLE
[EMCAL-205] OADB/EMCAL: Upload of runwise bad channel maps for LHC18d

### DIFF
--- a/OADB/EMCAL/READMEoadb.txt
+++ b/OADB/EMCAL/READMEoadb.txt
@@ -35,6 +35,8 @@ In addition, a short history of changes to the files in EOS will be listed here:
 - 20180530: Update of EMCALTimeCalib.root with updated LHC17m and LHC17k time calibrations
 - 20180531: Update of EMCALTimeL1PhaseCalib.root with two missing runs from LHC16kv time calibration
 - 20180606: Update of EMCALBadChannels.root with new maps for LHC17c,f
-- 20180320: Update of EMCALTimeCalib.root and EMCALTimeL1PhaseCalib.root with LHC17l time calibrations, as well as final calibrations for LHC16i and LHC16j
-- 20180320: Update of EMCALTimeCalib.root and EMCALTimeL1PhaseCalib.root with increased run range for LHC17l
+- 20180612: Update of EMCALTimeCalib.root and EMCALTimeL1PhaseCalib.root with LHC17l time calibrations, as well as final calibrations for LHC16i and LHC16j
+- 20180615: Update of EMCALTimeCalib.root and EMCALTimeL1PhaseCalib.root with increased run range for LHC17l
+- 20180618: Update of EMCALBadChannels.root with runwise maps for LHC18d (except for runs 286129 286350 286341 286313)
+
 */


### PR DESCRIPTION
The following runs are now covered by individual bc maps:
285978, 285979, 285980, 286014, 286018, 286025, 286026, 286027, 286030, 286064, 286124, 286127, 286129, 286130, 286154, 286157, 286159, 286198, 286201, 286202, 286203, 286229, 286230, 286231, 286254, 286255, 286256, 286257, 286258, 286261, 286263, 286282, 286284, 286287, 286288, 286289, 286308, 286309, 286310, 286311, 286312, 286313, 286314, 286336, 286337, 286340, 286341, 286345, 286348, 286349, 286350