### PR TITLE
Added features to CF with kESE configuration (D0, D+ and D*+)

### DIFF
--- a/PWGHF/vertexingHF/AliCFTaskVertexingHF.cxx
+++ b/PWGHF/vertexingHF/AliCFTaskVertexingHF.cxx
@@ -857,7 +857,7 @@ void AliCFTaskVertexingHF::UserExec(Option_t *)
   Double_t q2=0;
   if(fConfiguration==kESE) {
     //set q2 in case of kESE configuration
-    q2=ComputeTPCq2(aodEvent,-0.8,0.8,0.2,5.);
+    q2=ComputeTPCq2(aodEvent,mcHeader,-0.8,0.8,0.2,5.);
     cfVtxHF->Setq2Value(q2);
 
     //set track array in case of kESE configuration
@@ -1503,7 +1503,7 @@ void AliCFTaskVertexingHF::Terminate(Option_t*)
     titles[1]="rapidity";
     titles[2]="centrality";
     titles[3]="multiplicity";
-    titles[4]="N_{tracks} (#Delta#eta<0.1,#Delta#varphi<0.1)";
+    titles[4]="N_{tracks} (R<0.4)";
     titles[5]="q_{2}";
   }
 
@@ -2229,9 +2229,8 @@ TProfile* AliCFTaskVertexingHF::GetEstimatorHistogram(const AliVEvent* event){
 }
 
 //________________________________________________________________________
-Double_t AliCFTaskVertexingHF::ComputeTPCq2(AliAODEvent* aod, Double_t etamin, Double_t etamax, Double_t ptmin, Double_t ptmax) const {
+Double_t AliCFTaskVertexingHF::ComputeTPCq2(AliAODEvent* aod, AliAODMCHeader* mcHeader, Double_t etamin, Double_t etamax, Double_t ptmin, Double_t ptmax) const {
   /// Compute the q2 for ESE starting from TPC tracks
-  /// TO BE ADDED: use only HIJING tracks
   
   Int_t nTracks=aod->GetNumberOfTracks();
   Double_t nHarmonic=2.;
@@ -2241,16 +2240,19 @@ Double_t AliCFTaskVertexingHF::ComputeTPCq2(AliAODEvent* aod, Double_t etamin, D
   for(Int_t it=0; it<nTracks; it++){
     AliAODTrack* track=(AliAODTrack*)aod->GetTrack(it);
     if(!track) continue;
-    if(track->TestFilterBit(BIT(8))||track->TestFilterBit(BIT(9))) {
-      Double_t pt=track->Pt();
-      Double_t eta=track->Eta();
-      Double_t phi=track->Phi();
-      Double_t qx=TMath::Cos(nHarmonic*phi);
-      Double_t qy=TMath::Sin(nHarmonic*phi);
-      if(eta<etamax && eta>etamin && pt>ptmin && pt<ptmax) {
-        q2Vec[0]+=qx;
-        q2Vec[1]+=qy;
-        multQvec++;
+    TString genname = AliVertexingHFUtils::GetGenerator(track->GetLabel(),mcHeader);
+    if(genname.Contains("Hijing")) {
+      if(track->TestFilterBit(BIT(8))||track->TestFilterBit(BIT(9))) {
+        Double_t pt=track->Pt();
+        Double_t eta=track->Eta();
+        Double_t phi=track->Phi();
+        Double_t qx=TMath::Cos(nHarmonic*phi);
+        Double_t qy=TMath::Sin(nHarmonic*phi);
+        if(eta<etamax && eta>etamin && pt>ptmin && pt<ptmax) {
+          q2Vec[0]+=qx;
+          q2Vec[1]+=qy;
+          multQvec++;
+        }
       }
     }
   }

--- a/PWGHF/vertexingHF/AliCFTaskVertexingHF.h
+++ b/PWGHF/vertexingHF/AliCFTaskVertexingHF.h
@@ -275,7 +275,7 @@ class AliCFTaskVertexingHF: public AliAnalysisTaskSE {
   void SetCutOnMomConservation(Float_t cut) {fCutOnMomConservation = cut;}
   Bool_t GetCutOnMomConservation() const {return fCutOnMomConservation;}
 
-  Double_t ComputeTPCq2(AliAODEvent* aod, Double_t etamin, Double_t etamax, Double_t ptmin, Double_t ptmax) const;
+  Double_t ComputeTPCq2(AliAODEvent* aod, AliAODMCHeader* mcHeader, Double_t etamin, Double_t etamax, Double_t ptmin, Double_t ptmax) const;
 
  protected:
   AliCFManager   *fCFManager;   ///  pointer to the CF manager

--- a/PWGHF/vertexingHF/AliCFVertexingHF.cxx
+++ b/PWGHF/vertexingHF/AliCFVertexingHF.cxx
@@ -135,10 +135,7 @@ AliCFVertexingHF::~AliCFVertexingHF()
 	  	delete [] fEtaAccCut;
 	  	fEtaAccCut = 0x0;
 	}
-  if(fTrackArray) {
-    delete fTrackArray;
-    fTrackArray = 0x0;
-  }
+  if(fTrackArray) fTrackArray = 0x0;
 }
 
 //_____________________________________________________
@@ -1037,7 +1034,7 @@ void AliCFVertexingHF::SetAccCut()
 }
 
 //___________________________________________________________
-Int_t AliCFVertexingHF::ComputeLocalMultiplicity(Double_t etaD, Double_t phiD, Double_t deltaEta, Double_t deltaPhi) const {
+Int_t AliCFVertexingHF::ComputeLocalMultiplicity(Double_t etaD, Double_t phiD, Double_t R) const {
   
   Int_t mult=0;
   if(!fTrackArray) {
@@ -1050,7 +1047,7 @@ Int_t AliCFVertexingHF::ComputeLocalMultiplicity(Double_t etaD, Double_t phiD, D
     if(!track->TestFilterBit(BIT(8)) && !track->TestFilterBit(BIT(9))) continue;
     Double_t eta=track->Eta();
     Double_t phi=track->Phi();
-    if(TMath::Abs(eta-etaD)<deltaEta && TMath::Abs(phi-phiD)<deltaPhi) mult++;
+    if(TMath::Sqrt((eta-etaD)*(eta-etaD)+(phi-phiD)*(phi-phiD))<R) mult++;
   }
   
   return mult;

--- a/PWGHF/vertexingHF/AliCFVertexingHF.h
+++ b/PWGHF/vertexingHF/AliCFVertexingHF.h
@@ -117,10 +117,17 @@ class AliCFVertexingHF : public TObject {
 
 	void SetMultiplicity(Double_t multiplicity) {fMultiplicity = multiplicity;}
   void Setq2Value(Double_t q2) {fq2 = q2;}
-  void SetTrackArray(TClonesArray* trkarray) {fTrackArray = trkarray;}
+  void SetTrackArray(TClonesArray* trkarray) {
+    if(fTrackArray) {
+      delete fTrackArray;
+      fTrackArray=0x0;
+    }
+    fTrackArray = trkarray;
+    fTrackArray->SetOwner();
+  }
   void SetConfiguration(Int_t configuration) {fConfiguration = configuration;}
 
-  Int_t ComputeLocalMultiplicity(Double_t etaD, Double_t phiD, Double_t deltaEta, Double_t deltaPhi) const;
+  Int_t ComputeLocalMultiplicity(Double_t etaD, Double_t phiD, Double_t R) const;
 
 	protected:
   TClonesArray      *fmcArray;               /// mcArray candidate

--- a/PWGHF/vertexingHF/AliCFVertexingHF2Prong.cxx
+++ b/PWGHF/vertexingHF/AliCFVertexingHF2Prong.cxx
@@ -199,8 +199,7 @@ Bool_t AliCFVertexingHF2Prong::GetGeneratedValuesFromMCParticle(Double_t* vector
 	}
 	
   if(fConfiguration == AliCFTaskVertexingHF::kESE) {
-    AliAODRecoDecayHF2Prong *d0toKpi = (AliAODRecoDecayHF2Prong*)fRecoCandidate;
-    fLocalMultiplicity = ComputeLocalMultiplicity(d0toKpi->Eta(), d0toKpi->Phi(), 0.1, 0.1);
+    fLocalMultiplicity = ComputeLocalMultiplicity(decay->Eta(), decay->Phi(), 0.4);
   }
   
 	switch (fConfiguration){
@@ -243,7 +242,7 @@ Bool_t AliCFVertexingHF2Prong::GetGeneratedValuesFromMCParticle(Double_t* vector
     vectorMC[1] = fmcPartCandidate->Y() ;
     vectorMC[2] = fCentValue;   // centrality
     vectorMC[3] = fMultiplicity;   // multiplicity (diff estimators can be used)
-    vectorMC[4] = fLocalMultiplicity;   // local multiplicity (Ntracks in DeltaEta<0.1 and DeltaPhi<0.1)
+    vectorMC[4] = fLocalMultiplicity;   // local multiplicity (Ntracks in R<0.4)
     vectorMC[5] = fq2;   // magnitude of reduced flow vector (computed using TPC tracks)
     break;
 	}

--- a/PWGHF/vertexingHF/AliCFVertexingHF3Prong.cxx
+++ b/PWGHF/vertexingHF/AliCFVertexingHF3Prong.cxx
@@ -337,8 +337,7 @@ Bool_t AliCFVertexingHF3Prong::GetGeneratedValuesFromMCParticle(Double_t* vector
 	Double_t cT = decay->Ct(pdgCand);
 	
   if(fConfiguration == AliCFTaskVertexingHF::kESE) {
-    AliAODRecoDecayHF3Prong *decay3 = (AliAODRecoDecayHF3Prong*)fRecoCandidate;
-    fLocalMultiplicity = ComputeLocalMultiplicity(decay3->Eta(), decay3->Phi(), 0.1, 0.1);
+    fLocalMultiplicity = ComputeLocalMultiplicity(decay->Eta(), decay->Phi(), 0.4);
   }
 
 	switch (fConfiguration){
@@ -390,7 +389,7 @@ Bool_t AliCFVertexingHF3Prong::GetGeneratedValuesFromMCParticle(Double_t* vector
     vectorMC[1] = fmcPartCandidate->Y() ;
     vectorMC[2] = fCentValue;   // centrality
     vectorMC[3] = fMultiplicity;   // multiplicity (diff estimators can be used)
-    vectorMC[4] = fLocalMultiplicity;   // local multiplicity (Ntracks in DeltaEta<0.1 and DeltaPhi<0.1)
+    vectorMC[4] = fLocalMultiplicity;   // local multiplicity (Ntracks in R<0.4)
     vectorMC[5] = fq2;   // magnitude of reduced flow vector (computed using TPC tracks)
     break;
 	}

--- a/PWGHF/vertexingHF/AliCFVertexingHFCascade.cxx
+++ b/PWGHF/vertexingHF/AliCFVertexingHFCascade.cxx
@@ -286,8 +286,7 @@ Bool_t AliCFVertexingHFCascade::GetGeneratedValuesFromMCParticle(Double_t* vecto
   AliDebug(3, Form("The candidate has pt = %f, y = %f", fmcPartCandidate->Pt(), fmcPartCandidate->Y()));
 
   if(fConfiguration == AliCFTaskVertexingHF::kESE) {
-    AliAODRecoCascadeHF* cascade = (AliAODRecoCascadeHF*)fRecoCandidate;
-    fLocalMultiplicity = ComputeLocalMultiplicity(cascade->Eta(), cascade->Phi(), 0.1, 0.1);
+    fLocalMultiplicity = ComputeLocalMultiplicity(decay->Eta(), decay->Phi(), 0.4);
   }
 
   switch (fConfiguration){
@@ -330,7 +329,7 @@ Bool_t AliCFVertexingHFCascade::GetGeneratedValuesFromMCParticle(Double_t* vecto
     vectorMC[1] = fmcPartCandidate->Y() ;
     vectorMC[2] = fCentValue;   // centrality
     vectorMC[3] = fMultiplicity;   // multiplicity (diff estimators can be used)
-    vectorMC[4] = fLocalMultiplicity;   // local multiplicity (Ntracks in DeltaEta<0.1 and DeltaPhi<0.1)
+    vectorMC[4] = fLocalMultiplicity;   // local multiplicity (Ntracks in R<0.4)
     vectorMC[5] = fq2;   // magnitude of reduced flow vector (computed using TPC tracks)
     break;
   }

--- a/PWGHF/vertexingHF/macros/AddTaskCFVertexingHF.C
+++ b/PWGHF/vertexingHF/macros/AddTaskCFVertexingHF.C
@@ -576,13 +576,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF(const char* cutFile = "./D0toKpiCuts.
     const UInt_t ilocalmultESE = 4;
     const UInt_t iq2ESE = 5;
     
-    Int_t iBinESE[nvarESE];
-    iBinESE[ipTESE] = iBin[ipT];
-    iBinESE[iyESE] = iBin[iy];
-    iBinESE[icentESE] = 100;
-    iBinESE[imultESE] = 100;
-    iBinESE[ilocalmultESE] = 20;
-    iBinESE[iq2ESE] = 250;
+    const Int_t iBinESE[nvarESE] = {iBin[ipT],iBin[iy],100,100,100,250};
     
     Double_t binLimcentESE[iBinESE[icentESE]+1];
     for(Int_t iCent=0; iCent<iBinESE[icentESE]+1; iCent++) {

--- a/PWGHF/vertexingHF/macros/AddTaskCFVertexingHF3Prong.C
+++ b/PWGHF/vertexingHF/macros/AddTaskCFVertexingHF3Prong.C
@@ -57,9 +57,12 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3Prong(TString suffixName="", const ch
 	else if (configuration == AliCFTaskVertexingHF::kCheetah){
 		printf("The configuration is set to be FAST --> using only pt, y, ct, phi, zvtx, centrality, fake, multiplicity to fill the CF\n");
 	}
-	else if (configuration == AliCFTaskVertexingHF::kFalcon){
-		printf("The configuration is set to be FAST --> using only pt, y, centrality, multiplicity to fill the CF\n");
-	}
+  else if (configuration == AliCFTaskVertexingHF::kFalcon){
+    printf("The configuration is set to be FAST --> using only pt, y, centrality, multiplicity to fill the CF\n");
+  }
+  else if (configuration == AliCFTaskVertexingHF::kESE){
+    printf("The configuration is set to be for ESE analysis --> using pt, y, centrality, multiplicity, local multiplicity and q2 to fill the CF\n");
+  }
 	else{
 		printf("The configuration is not defined! returning\n");
 		return;
@@ -537,13 +540,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3Prong(TString suffixName="", const ch
     const UInt_t ilocalmultESE = 4;
     const UInt_t iq2ESE = 5;
 
-    Int_t iBinESE[nvarESE];
-    iBinESE[ipTESE] = iBin[ipT];
-    iBinESE[iyESE] = iBin[iy];
-    iBinESE[icentESE] = 100;
-    iBinESE[imultESE] = 100;
-    iBinESE[ilocalmultESE] = 20;
-    iBinESE[iq2ESE] = 250;
+    const Int_t iBinESE[nvarESE] = {iBin[ipT],iBin[iy],100,100,100,250};
 
     Double_t binLimcentESE[iBinESE[icentESE]+1];
     for(Int_t iCent=0; iCent<iBinESE[icentESE]+1; iCent++) {

--- a/PWGHF/vertexingHF/macros/AddTaskCFVertexingHFCascade.C
+++ b/PWGHF/vertexingHF/macros/AddTaskCFVertexingHFCascade.C
@@ -487,14 +487,8 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFCascade(const char* cutFile = "DStarto
     const UInt_t ilocalmultESE = 4;
     const UInt_t iq2ESE = 5;
     
-    Int_t iBinESE[nvarESE];
-    iBinESE[ipTESE] = iBin[ipT];
-    iBinESE[iyESE] = iBin[iy];
-    iBinESE[icentESE] = 100;
-    iBinESE[imultESE] = 100;
-    iBinESE[ilocalmultESE] = 20;
-    iBinESE[iq2ESE] = 250;
-    
+    const Int_t iBinESE[nvarESE] = {iBin[ipT],iBin[iy],100,100,100,250};
+
     Double_t binLimcentESE[iBinESE[icentESE]+1];
     for(Int_t iCent=0; iCent<iBinESE[icentESE]+1; iCent++) {
       binLimcentESE[iCent] = iCent;


### PR DESCRIPTION
1) only HIJING tracks are used to compute q2 (to avoid autocorrelations with D-meson daughters)
2) local multiplicity definition changed to Ntracks in R<0.4 wrt the D meson
3) slightly modified axis dimensions