### PR TITLE
change xTalk parameters for SM10 and SM11, they behave quite like SM1

### DIFF
--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -95,8 +95,8 @@ CellEmulateCrosstalk:                               # Component to emulate cross
                  7 : [1.20e-02, 1.20e-02, 1.20e-02, 0], 
                  8 : [0.80e-02, 0.80e-02, 0.80e-02, 0],  
                  9 : [0.80e-02, 0.80e-02, 0.80e-02, 0], 
-                 10: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
-                 11: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
+                 10: [1.20e-02, 1.20e-02, 1.20e-02, 0], 
+                 11: [1.20e-02, 1.20e-02, 1.20e-02, 0], 
                  12: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
                  13: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
                  14: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
@@ -116,7 +116,7 @@ CellEmulateCrosstalk:                               # Component to emulate cross
     inducedEnergyLossMinimumFraction:               # Minimum induced energy fraction when linear dependency is set
         enabled: true                               # Enable setting these values
         values: {0 : [3.5e-3], 1 : [5.0e-3], 2 : [4.5e-3], 3 : [6.0e-3], 4 : [3.5e-3], 5 : [3.5e-3], 6 : [3.5e-3], 7 : [6.0e-3], 8 : [3.5e-3], 9 : [3.5e-3], 
-                 10: [3.5e-3], 11: [3.5e-3], 12: [3.5e-3], 13: [3.5e-3], 14: [3.5e-3], 15: [3.5e-3], 16: [3.5e-3], 17: [3.5e-3], 18: [3.5e-3], 19: [3.5e-3], 
+                 10: [5.0e-3], 11: [5.0e-3], 12: [3.5e-3], 13: [3.5e-3], 14: [3.5e-3], 15: [3.5e-3], 16: [3.5e-3], 17: [3.5e-3], 18: [3.5e-3], 19: [3.5e-3], 
                  20: [3.5e-3], 21: [3.5e-3]} 
        #values: {"all" : [0.008]}                   # Values are [minimum fraction]
     inducedEnergyLossMaximumFraction:               # Maximum induced energy fraction when linear dependency is set

--- a/PWGGA/CaloTrackCorrelations/yaml/EMCalCorrConfig_MC_Run1_ClV1_xTalk.yaml
+++ b/PWGGA/CaloTrackCorrelations/yaml/EMCalCorrConfig_MC_Run1_ClV1_xTalk.yaml
@@ -59,8 +59,8 @@ CellEmulateCrosstalk:                               # Component to emulate cross
                  7 : [1.20e-02, 1.20e-02, 1.20e-02, 0], 
                  8 : [0.80e-02, 0.80e-02, 0.80e-02, 0],  
                  9 : [0.80e-02, 0.80e-02, 0.80e-02, 0], 
-                 10: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
-                 11: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
+                 10: [1.20e-02, 1.20e-02, 1.20e-02, 0], 
+                 11: [1.20e-02, 1.20e-02, 1.20e-02, 0], 
                  12: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
                  13: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
                  14: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
@@ -80,7 +80,7 @@ CellEmulateCrosstalk:                               # Component to emulate cross
     inducedEnergyLossMinimumFraction:               # Minimum induced energy fraction when linear dependency is set
         enabled: true                               # Enable setting these values
         values: {0 : [3.5e-3], 1 : [5.0e-3], 2 : [4.5e-3], 3 : [6.0e-3], 4 : [3.5e-3], 5 : [3.5e-3], 6 : [3.5e-3], 7 : [6.0e-3], 8 : [3.5e-3], 9 : [3.5e-3], 
-                 10: [3.5e-3], 11: [3.5e-3], 12: [3.5e-3], 13: [3.5e-3], 14: [3.5e-3], 15: [3.5e-3], 16: [3.5e-3], 17: [3.5e-3], 18: [3.5e-3], 19: [3.5e-3], 
+                 10: [5.0e-3], 11: [5.0e-3], 12: [3.5e-3], 13: [3.5e-3], 14: [3.5e-3], 15: [3.5e-3], 16: [3.5e-3], 17: [3.5e-3], 18: [3.5e-3], 19: [3.5e-3], 
                  20: [3.5e-3], 21: [3.5e-3]} 
        #values: {"all" : [0.008]}                   # Values are [minimum fraction]
     inducedEnergyLossMaximumFraction:               # Maximum induced energy fraction when linear dependency is set

--- a/PWGGA/CaloTrackCorrelations/yaml/EMCalCorrConfig_MC_Run1_ClV1_xTalk_ECellCut.yaml
+++ b/PWGGA/CaloTrackCorrelations/yaml/EMCalCorrConfig_MC_Run1_ClV1_xTalk_ECellCut.yaml
@@ -59,8 +59,8 @@ CellEmulateCrosstalk:                               # Component to emulate cross
                  7 : [1.20e-02, 1.20e-02, 1.20e-02, 0], 
                  8 : [0.80e-02, 0.80e-02, 0.80e-02, 0],  
                  9 : [0.80e-02, 0.80e-02, 0.80e-02, 0], 
-                 10: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
-                 11: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
+                 10: [1.20e-02, 1.20e-02, 1.20e-02, 0], 
+                 11: [1.20e-02, 1.20e-02, 1.20e-02, 0], 
                  12: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
                  13: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
                  14: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
@@ -80,7 +80,7 @@ CellEmulateCrosstalk:                               # Component to emulate cross
     inducedEnergyLossMinimumFraction:               # Minimum induced energy fraction when linear dependency is set
         enabled: true                               # Enable setting these values
         values: {0 : [3.5e-3], 1 : [5.0e-3], 2 : [4.5e-3], 3 : [6.0e-3], 4 : [3.5e-3], 5 : [3.5e-3], 6 : [3.5e-3], 7 : [6.0e-3], 8 : [3.5e-3], 9 : [3.5e-3], 
-                 10: [3.5e-3], 11: [3.5e-3], 12: [3.5e-3], 13: [3.5e-3], 14: [3.5e-3], 15: [3.5e-3], 16: [3.5e-3], 17: [3.5e-3], 18: [3.5e-3], 19: [3.5e-3], 
+                 10: [5.0e-3], 11: [5.0e-3], 12: [3.5e-3], 13: [3.5e-3], 14: [3.5e-3], 15: [3.5e-3], 16: [3.5e-3], 17: [3.5e-3], 18: [3.5e-3], 19: [3.5e-3], 
                  20: [3.5e-3], 21: [3.5e-3]} 
        #values: {"all" : [0.008]}                   # Values are [minimum fraction]
     inducedEnergyLossMaximumFraction:               # Maximum induced energy fraction when linear dependency is set

--- a/PWGGA/CaloTrackCorrelations/yaml/EMCalCorrConfig_MC_Run1_ClV1_xTalk_ECellCut_Leak5MeV.yaml
+++ b/PWGGA/CaloTrackCorrelations/yaml/EMCalCorrConfig_MC_Run1_ClV1_xTalk_ECellCut_Leak5MeV.yaml
@@ -59,8 +59,8 @@ CellEmulateCrosstalk:                               # Component to emulate cross
                  7 : [1.20e-02, 1.20e-02, 1.20e-02, 0], 
                  8 : [0.80e-02, 0.80e-02, 0.80e-02, 0],  
                  9 : [0.80e-02, 0.80e-02, 0.80e-02, 0], 
-                 10: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
-                 11: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
+                 10: [1.20e-02, 1.20e-02, 1.20e-02, 0], 
+                 11: [1.20e-02, 1.20e-02, 1.20e-02, 0], 
                  12: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
                  13: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
                  14: [0.80e-02, 0.80e-02, 0.80e-02, 0], 
@@ -80,7 +80,7 @@ CellEmulateCrosstalk:                               # Component to emulate cross
     inducedEnergyLossMinimumFraction:               # Minimum induced energy fraction when linear dependency is set
         enabled: true                               # Enable setting these values
         values: {0 : [3.5e-3], 1 : [5.0e-3], 2 : [4.5e-3], 3 : [6.0e-3], 4 : [3.5e-3], 5 : [3.5e-3], 6 : [3.5e-3], 7 : [6.0e-3], 8 : [3.5e-3], 9 : [3.5e-3], 
-                 10: [3.5e-3], 11: [3.5e-3], 12: [3.5e-3], 13: [3.5e-3], 14: [3.5e-3], 15: [3.5e-3], 16: [3.5e-3], 17: [3.5e-3], 18: [3.5e-3], 19: [3.5e-3], 
+                 10: [5.0e-3], 11: [5.0e-3], 12: [3.5e-3], 13: [3.5e-3], 14: [3.5e-3], 15: [3.5e-3], 16: [3.5e-3], 17: [3.5e-3], 18: [3.5e-3], 19: [3.5e-3], 
                  20: [3.5e-3], 21: [3.5e-3]} 
        #values: {"all" : [0.008]}                   # Values are [minimum fraction]
     inducedEnergyLossMaximumFraction:               # Maximum induced energy fraction when linear dependency is set


### PR DESCRIPTION
After observations in presentation at
[EMCal meeting 21/06/2017](https://indico.cern.ch/event/725637/contributions/3048520/attachments/1671746/2682062/CrossTalkUpdate_Linearity_InvMass_pp7TeV_EMCALMeeting210618.pdf)
slides 38 and 42