### PR TITLE
MC and Embedding functionality added, for inclusive and recoil response

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetCoreEmcal.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetCoreEmcal.h
@@ -30,6 +30,7 @@ class AliAnalysisTaskJetCoreEmcal : public AliAnalysisTaskEmcalJet {
 
 
 	// Setters
+	virtual void		 SetJetShapeType(Int_t type){fJetShapeType=type;}
 	virtual void		 SetCentrality(Float_t cmin, Float_t cmax){fCentMin=cmin; fCentMax=cmax;}
 	virtual void     SetTTLowRef(Float_t ttlow){fTTLowRef=ttlow;}
 	virtual void     SetTTUpRef(Float_t ttup){fTTUpRef=ttup;}
@@ -40,10 +41,15 @@ class AliAnalysisTaskJetCoreEmcal : public AliAnalysisTaskEmcalJet {
 	virtual void     SetJetEtaMin(Float_t eta){fJetEtaMin=eta;}
 	virtual void     SetJetEtaMax(Float_t eta){fJetEtaMax=eta;}
 	virtual void     SetJetHadronDeltaPhi(Float_t delta){fJetHadronDeltaPhi=delta;}
+	virtual void     SetMinFractionSharedPt(Float_t min){fMinFractionSharedPt=min;}
 	virtual void		 SetJetContName(TString cont){fJetContName=cont;}
-
+	virtual void		 SetJetContTrueName(TString cont){fJetContTrueName=cont;}
+	virtual void		 SetJetContPartName(TString cont){fJetContPartName=cont;}
 	virtual void		 SetFillTrackHistograms(Bool_t b){fFillTrackHistograms=b;}
 	virtual void		 SetFillJetHistograms(Bool_t b){fFillJetHistograms=b;}
+	virtual void		 SetFillInclusiveTree(Bool_t b){fFillInclusiveTree=b;}
+	virtual void		 SetFillRecoilTree(Bool_t b){fFillRecoilTree=b;}
+	virtual void		 SetPtHardBin(Int_t bin){fPtHardBin=bin;}
 
 //  static AliAnalysisTaskJetCoreEmcal* AddTaskJetCoreEmcal(
 //      const char *ntracks            = "usedefault",
@@ -55,8 +61,8 @@ class AliAnalysisTaskJetCoreEmcal : public AliAnalysisTaskEmcalJet {
     kMCTrue = 0,   // generated jets only
     kTrueDet =1,  // detector and generated jets  
     kData   = 2,  // raw data 
+    kDetEmbPart = 3,
 //    kDetEmb = 3,  //detector embedded jets
-//    kDetEmbPart = 4,
 //    kPythiaDef = 5,
 //    kDetEmbPartPythia=6,
 //    kGenOnTheFly = 7
@@ -78,6 +84,8 @@ class AliAnalysisTaskJetCoreEmcal : public AliAnalysisTaskEmcalJet {
   void                        DoClusterLoop()                                   ;
   void                        DoCellLoop()                                      ;
   void                        DoJetCoreLoop()                                      ;
+	void												DoMatchingLoop()
+		;
 
 	Int_t												SelectTrigger(TList *list,Double_t minT,Double_t maxT,Int_t &number);
 	Double_t										RelativePhi(Double_t mphi,Double_t vphi);
@@ -87,25 +95,36 @@ class AliAnalysisTaskJetCoreEmcal : public AliAnalysisTaskEmcalJet {
 
 	// flags and selection
 	AliEventCuts fEventCuts; ///< Event cuts
-	Float_t fCentMin; ///<
-	Float_t fCentMax; ///<
-	Float_t fTTLowRef; ///<
-	Float_t fTTUpRef; ///<
-	Float_t fTTLowSig; ///<
-	Float_t fTTUpSig; ///<
-	Int_t fNRPBins;	 ///<
-	Float_t fFrac; ///<
-	Float_t fJetEtaMin; ///<
-	Float_t fJetEtaMax; ///<
-	Float_t fJetHadronDeltaPhi; ///< set 0 > f > pi for selection on jet hadron Dphi
-	TString fJetContName; ///<
-	Bool_t fFillTrackHistograms; ///<
-	Bool_t fFillJetHistograms; ///<
+	Float_t fJetShapeType; ///<
+	Float_t fCentMin; ///< minimum centrality
+	Float_t fCentMax; ///< maximum centrality
+	Float_t fTTLowRef; ///< minimum reference trigger track pt
+	Float_t fTTUpRef; ///< maximum reference trigger track pt
+	Float_t fTTLowSig; ///< minimum signal trigger track pt
+	Float_t fTTUpSig; ///< maximum signal trigger track pt
+	Int_t fNRPBins;	 ///< 
+	Float_t fFrac; ///< fraction of events that are used to fill signal recoil jet population
+	Float_t fJetEtaMin; ///<  minimum jet eta
+	Float_t fJetEtaMax; ///< maximum jet eta
+	Float_t fJetHadronDeltaPhi; ///< max angle from pi (set <0 for no selection)
+	Float_t fMinFractionSharedPt; ///< min fraction of pt between hybrid / detector jets
+	TString fJetContName; ///< Base level jet container name
+	TString fJetContTrueName; ///< True pp (detector) level jet container name
+	TString fJetContPartName; ///< Particle(MC) level jet container name
+	Bool_t fFillTrackHistograms; ///< switch to fill track histograms
+	Bool_t fFillJetHistograms; ///< switch to fill jet histograms
+	Bool_t fFillInclusiveTree; ///< switch to fill embedding tree with inclusive jet info
+	Bool_t fFillRecoilTree; ///< switch to fill embedding tree with recoil jet info
+	Int_t fPtHardBin; ///< pt hard bin if running embedding
 	//
 	TRandom3 *fRandom; ///<
+	Float_t fTreeVarsInclusive[8]; ///<
+	Float_t fTreeVarsRecoil[11]; ///<
 	//histograms to fill
 	TH1I *fHistEvtSelection; //!<!
+	// recoil jet info contained in THnSparse
 	THnSparse *fHJetSpec;  //!<!
+	// recoil histograms
 	TH1D *fh1TrigRef; //!<!
 	TH1D *fh1TrigSig; //!<!
 	TH2F *fh2Ntriggers; //!<!
@@ -113,17 +132,46 @@ class AliAnalysisTaskJetCoreEmcal : public AliAnalysisTaskEmcalJet {
 	TH2F *fh2RPJetsC20; //!<!
 	TH2F *fh2RPTC10; //!<!
 	TH2F *fh2RPTC20; //!<!
-
-	THnSparse *fHJetPhiCorr; //!<!
 	TH2F *fhDphiPtSig; //!<!
 	TH2F *fhDphiPtRef; //!<!
+	// embedding histograms
+	// inclusive jets
+	TH2F *fhPtDetPart; //!<!
+	TH2F *fhPtHybrDet; //!<!
+	TH2F *fhPtHybrPart; //!<!
+	TH2F *fhPtHybrPartCor; //!<!
+	TH2F *fhPhiHybrPartCor; //!<!
+	TH1F *fhPtDet; //!<!
+	TH1F *fhPtDetMatchedToPart; //!<!
+	TH1F *fhResidual; //!<!
+	TH2F *fhPtResidual; //!<!
+	TH1F *fhPhiResidual; //!<!
+	TH2F *fhPhiPhiResidual; //!<!
+	//recoil jets
+	TH2F *fhPtDetPartRecoil; //!<!
+	TH2F *fhPtHybrDetRecoil; //!<!
+	TH2F *fhPtHybrPartRecoil; //!<!
+	TH2F *fhPtHybrPartCorRecoil; //!<!
+	TH2F *fhPhiHybrPartCorRecoil; //!<!
+	TH1F *fhPtDetRecoil; //!<!
+	TH1F *fhPtDetMatchedToPartRecoil; //!<!
+	TH1F *fhResidualRecoil; //!<!
+	TH2F *fhPtResidualRecoil; //!<!
+	TH1F *fhDphiResidualRecoil; //!<!
+	TH2F *fhDphiphiResidualRecoil; //!<!
+	TH2F *fhTTPtDetMatchedToPart; //!<!
+	TH2F *fhTTPhiDetMatchedToPart; //!<!
+	TH2F *fhDPhiHybrPartCorRecoil; //!<!
+	// embedding trees
+	TTree *fTreeEmbInclusive; //!<!
+	TTree *fTreeEmbRecoil; //!<!
 
  private:
   AliAnalysisTaskJetCoreEmcal(const AliAnalysisTaskJetCoreEmcal&)           ; // not implemented
   AliAnalysisTaskJetCoreEmcal &operator=(const AliAnalysisTaskJetCoreEmcal&); // not implemented
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskJetCoreEmcal, 4);
+  ClassDef(AliAnalysisTaskJetCoreEmcal, 5);
   /// \endcond
 };
 #endif

--- a/PWGJE/EMCALJetTasks/macros/AddTaskJetCoreEmcal.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskJetCoreEmcal.C
@@ -1,5 +1,7 @@
 AliAnalysisTaskJetCoreEmcal* AddTaskJetCoreEmcal(
 								 const char *njetsBase,
+								 const char *njetsTrue,
+								 const char *njetsPart,
 						     const Double_t R,
 								 const char *type,
 								 Int_t jetShapeType = AliAnalysisTaskJetCoreEmcal::kData,
@@ -31,32 +33,69 @@ AliAnalysisTaskJetCoreEmcal* AddTaskJetCoreEmcal(
   TString wagonName2 = Form("JetCore_%s_TCTree",njetsBase);
   //Configure jet tagger task
   AliAnalysisTaskJetCoreEmcal *task = new AliAnalysisTaskJetCoreEmcal(wagonName1.Data());
+	task->SetJetContName(njetsBase);
+	if(jetShapeType == AliAnalysisTaskJetCoreEmcal::kDetEmbPart) {
+		task->SetJetContPartName(njetsPart);
+		task->SetJetContTrueName(njetsTrue);
+	}
+	task->SetJetShapeType(jetShapeType);
 	task->SetTTLowRef(kTTminr);
 	task->SetTTUpRef(kTTmaxr);
 	task->SetTTLowSig(kTTmins);
 	task->SetTTUpSig(kTTmaxs);
 
 	TString name = "JetCore";
-	TString trackName = "tracks";
 	TString clusName = "caloClusters";
-  if (trackName == "mcparticles") {
-    task->AddMCParticleContainer(trackName);
-  }
-  else if (trackName == "tracks" || trackName == "Tracks") {
-    task->AddTrackContainer(trackName);
-  }
-  else if (!trackName.IsNull()) {
-    task->AddParticleContainer(trackName);
-  }
+
+	AliParticleContainer *trackCont = 0x0;
+	AliParticleContainer *trackContPartLevel = 0x0;
+	AliParticleContainer *trackContTrueLevel = 0x0;
+
+	if(jetShapeType == AliAnalysisTaskJetCoreEmcal::kMCTrue) {
+		trackCont = task->AddMCParticleContainer("mcparticles");
+	}
+	else if (jetShapeType == AliAnalysisTaskJetCoreEmcal::kData) {
+		trackCont = task->AddTrackContainer("tracks");
+	}
+	else if (jetShapeType == AliAnalysisTaskJetCoreEmcal::kDetEmbPart) {
+		trackCont = task->AddTrackContainer("tracks");
+    trackContTrueLevel = task->AddTrackContainer("tracks");
+    trackContPartLevel = task->AddMCParticleContainer("mcparticles");
+	}
   task->AddClusterContainer(clusName);
 
   // connect jet container 
   TString sRhoChName = "Rho";
   TString typeStr = TString(type);
-  AliJetContainer* jetContBase = task->AddJetContainer(njetsBase,typeStr,R);
-  // for Pb-Pb
-  jetContBase->SetRhoName(sRhoChName);
-  jetContBase->SetPercAreaCut(0.0);
+  AliJetContainer* jetContBase = 0x0;
+  AliJetContainer* jetContTrue = 0x0;
+  AliJetContainer* jetContPart = 0x0;
+	if(jetShapeType == AliAnalysisTaskJetCoreEmcal::kData ||
+			jetShapeType == AliAnalysisTaskJetCoreEmcal::kMCTrue) { 
+
+		jetContBase = task->AddJetContainer(njetsBase,typeStr,R);
+		jetContBase->ConnectParticleContainer(trackCont);
+		jetContBase->SetRhoName(sRhoChName);
+		jetContBase->SetPercAreaCut(0.0);
+	}
+	if(jetShapeType == AliAnalysisTaskJetCoreEmcal::kDetEmbPart) {
+
+		jetContBase = task->AddJetContainer(njetsBase,typeStr,R);
+		jetContBase->ConnectParticleContainer(trackCont);
+		jetContBase->SetRhoName(sRhoChName);
+		jetContBase->SetPercAreaCut(0.0);
+
+		jetContTrue = task->AddJetContainer(njetsTrue,typeStr,R);
+		jetContTrue->SetRhoName(sRhoChName);
+		jetContTrue->ConnectParticleContainer(trackContTrueLevel);
+		jetContTrue->SetPercAreaCut(0.0); 
+
+		jetContPart = task->AddJetContainer(njetsPart,typeStr,R);
+		jetContPart->SetRhoName(sRhoChName);
+		jetContPart->ConnectParticleContainer(trackContPartLevel);
+		jetContPart->SetIsParticleLevel(kTRUE);
+		jetContPart->SetPercAreaCut(0.0);
+	}
 
   //-------------------------------------------------------
   // Final settings, pass to manager and set the containers
@@ -67,14 +106,30 @@ AliAnalysisTaskJetCoreEmcal* AddTaskJetCoreEmcal(
   // Create containers for input/output
   AliAnalysisDataContainer *cinput1  = mgr->GetCommonInputContainer()  ;
   TString contname(name);
+  TString contname1(name);
+  TString contname2(name);
+  TString contname3(name);
 	contname += Form("_%s",TString(listName).Data());
 	contname += Form("_%02d",Int_t(R*10+0.001));
-  contname += "_histos";
-  AliAnalysisDataContainer *coutput1 = mgr->CreateContainer(contname.Data(),
-      TList::Class(),AliAnalysisManager::kOutputContainer,
-      Form("%s", AliAnalysisManager::GetCommonFileName()));
-  mgr->ConnectInput  (task, 0,  cinput1 );
-  mgr->ConnectOutput (task, 1, coutput1 );
+  contname1 = contname;
+  contname2 = contname;
+  contname3 = contname;
+  contname1 += "_histos";
+  contname2 += "_embTreeInclusive";
+  contname3 += "_embTreeRecoil";
+	AliAnalysisDataContainer *coutput1 = mgr->CreateContainer(contname1.Data(),
+			TList::Class(),AliAnalysisManager::kOutputContainer,
+			Form("%s", AliAnalysisManager::GetCommonFileName()));
+	mgr->ConnectInput  (task, 0,  cinput1 );
+	mgr->ConnectOutput (task, 1, coutput1 );
+	AliAnalysisDataContainer *coutput2 = mgr->CreateContainer(contname2.Data(),
+			TTree::Class(),AliAnalysisManager::kOutputContainer,
+			Form("%s", AliAnalysisManager::GetCommonFileName()));
+	mgr->ConnectOutput (task, 2, coutput2 );
+	AliAnalysisDataContainer *coutput3 = mgr->CreateContainer(contname3.Data(),
+			TTree::Class(),AliAnalysisManager::kOutputContainer,
+			Form("%s", AliAnalysisManager::GetCommonFileName()));
+	mgr->ConnectOutput (task, 3, coutput3 );
 
   return task;
 


### PR DESCRIPTION
MC and embedding functionality. Running with the embedding framework allows to match detector level embedded and true jets, and fill response (histograms and trees) for both recoil and inclusive jets. Aim is to 2d unfold the pT/DeltaPhi distribution