### PR TITLE
Fixed a compatibility problem with root5 in macro.

### DIFF
--- a/PWGCF/Correlations/macros/jcorran/AddTaskJCDijetTask.C
+++ b/PWGCF/Correlations/macros/jcorran/AddTaskJCDijetTask.C
@@ -1,41 +1,62 @@
 //_____________________________________________________________________
 AliAnalysisTask *AddTaskJCDijetTask(TString taskName,
                                     Bool_t isMC,
-                                    vector<double> centBins  = {0.0, 5.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0},
-                                    double jetCone           = 0.4,
-                                    double particleEtaCut    = 0.8,
-                                    double particlePtCut     = 0.15,
-                                    double leadingJetCut     = 20.0,
-                                    double subleadingJetCut  = 20.0,
-                                    double constituentCut    = 5.0,
-                                    double deltaPhiCut       = 2.0){
-	// Load Custom Configuration and parameters
-	// override values with parameters
+                                    TString centBins        = "0.0 5.0 10.0 20.0 30.0 40.0 50.0 60.0 70.0",
+                                    double jetCone          = 0.4,
+                                    double particleEtaCut   = 0.8,
+                                    double particlePtCut    = 0.15,
+                                    double leadingJetCut    = 20.0,
+                                    double subleadingJetCut = 20.0,
+                                    double constituentCut   = 5.0,
+                                    double deltaPhiCut      = 2.0){
+    // Load Custom Configuration and parameters
+    // override values with parameters
 
-	AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+    AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
 
-	//==== Set up the dijet task ====
-	AliJCDijetTask *dijetTask = new AliJCDijetTask(taskName.Data(),"AOD");
-	dijetTask->SetDebugLevel(5);
-  	dijetTask->SetJCatalystTaskName("JCatalystTask");  // AliJCatalystTask has this name hard coded
-	dijetTask->SetCentralityBins(centBins);
-	dijetTask->SetJetConeSize(jetCone);
-	dijetTask->SetIsMC(isMC);
-	dijetTask->SetCuts(particleEtaCut, particlePtCut, leadingJetCut, subleadingJetCut, constituentCut, deltaPhiCut);
-	cout << dijetTask->GetName() << endl;
+    std::stringstream ss( centBins.Data() );
+    double binBorder;
+    vector<double> vecCentBins;
+    ss >> binBorder;
+    while (!ss.fail()) {
+        vecCentBins.push_back(binBorder);
+        ss >> binBorder;
+    }
+
+    if (vecCentBins.size() < 2) {
+        ::Error("AddTaskJCDijetTask", "Centrality bins are not properly set. Terminating.");
+        return NULL;
+    }
+
+    for (int ivec=0; ivec < vecCentBins.size()-1; ivec++) {
+        if(vecCentBins.at(ivec+1) <= vecCentBins.at(ivec)) {
+            ::Error("AddTaskJCDijetTask", "Centrality bins are not properly set. Terminating.");
+            return NULL;
+        }
+    }
+
+    //==== Set up the dijet task ====
+    AliJCDijetTask *dijetTask = new AliJCDijetTask(taskName.Data(),"AOD");
+    dijetTask->SetDebugLevel(5);
+    dijetTask->SetJCatalystTaskName("JCatalystTask");  // AliJCatalystTask has this name hard coded
+    dijetTask->SetCentralityBins(vecCentBins);
+    dijetTask->SetJetConeSize(jetCone);
+    dijetTask->SetIsMC(isMC);
+    dijetTask->SetCuts(particleEtaCut, particlePtCut, leadingJetCut, subleadingJetCut, constituentCut, deltaPhiCut);
+    cout << dijetTask->GetName() << endl;
 
 
-	mgr->AddTask((AliAnalysisTask*) dijetTask);
+    mgr->AddTask((AliAnalysisTask*) dijetTask);
 
-	// Create containers for input/output
-	AliAnalysisDataContainer *cinput  = mgr->GetCommonInputContainer();
+    // Create containers for input/output
+    AliAnalysisDataContainer *cinput  = mgr->GetCommonInputContainer();
 
 
-	// Connect input/output
-	mgr->ConnectInput(dijetTask, 0, cinput);
-	AliAnalysisDataContainer *jHist = mgr->CreateContainer(Form("%scontainer",dijetTask->GetName()),  TDirectory::Class(), AliAnalysisManager::kOutputContainer, Form("%s:%s",AliAnalysisManager::GetCommonFileName(), dijetTask->GetName()));
-	mgr->ConnectOutput(dijetTask, 1, jHist );
+    // Connect input/output
+    mgr->ConnectInput(dijetTask, 0, cinput);
+    AliAnalysisDataContainer *jHist = mgr->CreateContainer(Form("%scontainer",dijetTask->GetName()),  TDirectory::Class(), AliAnalysisManager::kOutputContainer, Form("%s:%s",AliAnalysisManager::GetCommonFileName(), dijetTask->GetName()));
+    mgr->ConnectOutput(dijetTask, 1, jHist );
 
-	return dijetTask;
+    return dijetTask;
 }
 


### PR DESCRIPTION
Giving a vector as an argument had troubles with root5 so I changed the argument to a TString which is then parsed to a vector. Also added checks for the centrality bin vector so that it is properly set.