### PR TITLE
Implement new virtual trigger selection function

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
@@ -1087,6 +1087,7 @@ Bool_t AliAnalysisTaskEmcal::HasTriggerType(TriggerType trigger)
 
 Bool_t AliAnalysisTaskEmcal::IsEventSelected()
 {
+  AliDebugStream(1) << "Using default event selection" << std::endl;
   if (fOffTrigger != AliVEvent::kAny) {
     UInt_t res = 0;
     const AliESDEvent *eev = dynamic_cast<const AliESDEvent*>(InputEvent());
@@ -1106,6 +1107,7 @@ Bool_t AliAnalysisTaskEmcal::IsEventSelected()
 
   if(!IsTriggerSelected()) {
     if (fGeneralHistograms) fHistEventRejection->Fill("trigger",1);
+    return kFALSE;
   }
 
   if (fTriggerTypeSel != kND) {
@@ -1241,6 +1243,7 @@ Bool_t AliAnalysisTaskEmcal::IsTriggerSelected(){
   // to trigger selection). Users should re-implement
   // this function in case they have certain needs, in
   // particular for EMCAL triggers
+  AliDebugStream(1) << "Using default trigger selection" << std::endl;
   if (!fTrigClass.IsNull()) {
     TString fired = InputEvent()->GetFiredTriggerClasses();
     if (!fired.Contains("-B-")) return kFALSE;

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.cxx
@@ -106,7 +106,6 @@ bool AliAnalysisTaskEmcalJetEnergySpectrum::Run(){
     AliErrorStream() << "Jet container " << fNameJetContainer << " not found" << std::endl;
     return false;
   }
-  if(!TriggerSelection()) return false;
 
   auto trgclusters = GetTriggerClusterIndices(fInputEvent->GetFiredTriggerClasses());
   fHistos->FillTH1("hEventCounter", 1);
@@ -179,7 +178,7 @@ std::vector<AliAnalysisTaskEmcalJetEnergySpectrum::TriggerCluster_t> AliAnalysis
   return result;
 }
 
-bool AliAnalysisTaskEmcalJetEnergySpectrum::TriggerSelection() const {
+bool AliAnalysisTaskEmcalJetEnergySpectrum::IsTriggerSelected() {
   if(!fIsMC){
     // Pure data - do EMCAL trigger selection from selection string
     if(!(fInputHandler->IsEventSelected() & fTriggerSelectionBits)) return false;

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.h
@@ -70,7 +70,7 @@ public:
 protected:
   virtual void UserCreateOutputObjects();
   virtual bool Run();
-  bool TriggerSelection() const;
+  virtual bool IsTriggerSelected();
   std::vector<TriggerCluster_t> GetTriggerClusterIndices(const TString &triggerstring) const;
   bool IsSelectEmcalTriggers(const std::string &triggerstring) const;
 

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.cxx
@@ -98,6 +98,8 @@ AliAnalysisTaskEmcalJetSubstructureTree::AliAnalysisTaskEmcalJetSubstructureTree
     fSDZCut(0.1),
     fSDBetaCut(0),
     fReclusterizer(kCAAlgo),
+    fHasRecEvent(false),
+    fHasTrueEvent(false),
     fTriggerSelectionBits(AliVEvent::kAny),
     fTriggerSelectionString(""),
     fNameTriggerDecisionContainer("EmcalTriggerDecision"),
@@ -130,6 +132,8 @@ AliAnalysisTaskEmcalJetSubstructureTree::AliAnalysisTaskEmcalJetSubstructureTree
     fSDZCut(0.1),
     fSDBetaCut(0),
     fReclusterizer(kCAAlgo),
+    fHasRecEvent(false),
+    fHasTrueEvent(false),
     fTriggerSelectionBits(AliVEvent::kAny),
     fTriggerSelectionString(""),
     fNameTriggerDecisionContainer("EmcalTriggerDecision"),
@@ -278,50 +282,21 @@ bool AliAnalysisTaskEmcalJetSubstructureTree::Run(){
   this->fGlobalTreeParams->fJetRadius = (datajets ? datajets->GetJetRadius() : mcjets->GetJetRadius());
   fGlobalTreeParams->fTriggerClusterIndex = -1;       // Reset trigger cluster index
 
-  // Run trigger selection (not on pure MCgen train)
-  if(datajets){
-    if(!(fInputHandler->IsEventSelected() & fTriggerSelectionBits)) return false;
-    if(!mcjets){
-      // Pure data - do EMCAL trigger selection from selection string
-      if(fTriggerSelectionString.Length()) {
-        if(!fInputEvent->GetFiredTriggerClasses().Contains(fTriggerSelectionString)) return false;
-        if(fTriggerSelectionString.Contains("EJ") && fUseTriggerSelectionForData) {
-          auto trgselresult = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(fInputEvent->FindListObject(fNameTriggerDecisionContainer));
-          AliDebugStream(1) << "Found trigger decision object: " << (trgselresult ? "yes" : "no") << std::endl;
-          if(!trgselresult){
-            AliErrorStream() <<  "Trigger decision container with name " << fNameTriggerDecisionContainer << " not found in event - not possible to select EMCAL triggers" << std::endl;
-            return false;
-          }
-          if(!trgselresult->IsEventSelected(fTriggerSelectionString)) return false;
-        }
-      }
-
-      // decode trigger string in order to determine the trigger clusters
-      std::vector<std::string> clusternames;
-      auto triggerinfos = PWG::EMCAL::Triggerinfo::DecodeTriggerString(fInputEvent->GetFiredTriggerClasses().Data());
-      for(auto t : triggerinfos) {
-        if(std::find(clusternames.begin(), clusternames.end(), t.Triggercluster()) == clusternames.end()) clusternames.emplace_back(t.Triggercluster());
-      }
-      bool isCENT = (std::find(clusternames.begin(), clusternames.end(), "CENT") != clusternames.end()),
-           isCENTNOTRD = (std::find(clusternames.begin(), clusternames.end(), "CENTNOTRD") != clusternames.end()),
-           isCALO = (std::find(clusternames.begin(), clusternames.end(), "CALO") != clusternames.end()),
-           isCALOFAST = (std::find(clusternames.begin(), clusternames.end(), "CALOFAST") != clusternames.end());
-      if(isCENT) fGlobalTreeParams->fTriggerClusterIndex = 0;
-      else if(isCENTNOTRD) fGlobalTreeParams->fTriggerClusterIndex = 1;
-      else if(isCALO) fGlobalTreeParams->fTriggerClusterIndex = 2;
-      else if(isCALOFAST) fGlobalTreeParams->fTriggerClusterIndex = 3;
-    } else {
-      if(IsSelectEmcalTriggers(fTriggerSelectionString.Data())){
-        // Simulation - do EMCAL trigger selection from trigger selection object
-        auto mctrigger = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(fInputEvent->FindListObject(fNameTriggerDecisionContainer));
-        AliDebugStream(1) << "Found trigger decision object: " << (mctrigger ? "yes" : "no") << std::endl;
-        if(!mctrigger){
-          AliErrorStream() <<  "Trigger decision container with name " << fNameTriggerDecisionContainer << " not found in event - not possible to select EMCAL triggers" << std::endl;
-          return false;
-        }
-        if(!mctrigger->IsEventSelected(fTriggerSelectionString)) return false;
-      }
+  if(datajets && !mcjets){
+    // decode trigger string in order to determine the trigger clusters
+    std::vector<std::string> clusternames;
+    auto triggerinfos = PWG::EMCAL::Triggerinfo::DecodeTriggerString(fInputEvent->GetFiredTriggerClasses().Data());
+    for(auto t : triggerinfos) {
+      if(std::find(clusternames.begin(), clusternames.end(), t.Triggercluster()) == clusternames.end()) clusternames.emplace_back(t.Triggercluster());
     }
+    bool isCENT = (std::find(clusternames.begin(), clusternames.end(), "CENT") != clusternames.end()),
+         isCENTNOTRD = (std::find(clusternames.begin(), clusternames.end(), "CENTNOTRD") != clusternames.end()),
+         isCALO = (std::find(clusternames.begin(), clusternames.end(), "CALO") != clusternames.end()),
+         isCALOFAST = (std::find(clusternames.begin(), clusternames.end(), "CALOFAST") != clusternames.end());
+    if(isCENT) fGlobalTreeParams->fTriggerClusterIndex = 0;
+    else if(isCENTNOTRD) fGlobalTreeParams->fTriggerClusterIndex = 1;
+    else if(isCALO) fGlobalTreeParams->fTriggerClusterIndex = 2;
+    else if(isCALOFAST) fGlobalTreeParams->fTriggerClusterIndex = 3;
   }
 
   double weight = 1.;
@@ -427,6 +402,46 @@ bool AliAnalysisTaskEmcalJetSubstructureTree::Run(){
   }
 
   return true;
+}
+
+Bool_t AliAnalysisTaskEmcalJetSubstructureTree::IsTriggerSelected(){
+  AliDebugStream(1) << "Trigger selection called\n";
+  if(!(fHasRecEvent || fHasTrueEvent)){
+    AliErrorStream() << "Impossible combination: Neither rec nor true event available. Rejecting ..." << std::endl;
+    return false;
+  }
+  // Run trigger selection (not on pure MCgen train - pure MCgen train has no rec event, ESD event is fake there)
+  if(fHasRecEvent){
+    if(!(fInputHandler->IsEventSelected() & fTriggerSelectionBits)) return false;
+    if(!fHasTrueEvent){
+      // Pure data - do EMCAL trigger selection from selection string
+      if(fTriggerSelectionString.Length()) {
+        if(!fInputEvent->GetFiredTriggerClasses().Contains(fTriggerSelectionString)) return false;
+        if(fTriggerSelectionString.Contains("EJ") && fUseTriggerSelectionForData) {
+          auto trgselresult = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(fInputEvent->FindListObject(fNameTriggerDecisionContainer));
+          AliDebugStream(1) << "Found trigger decision object: " << (trgselresult ? "yes" : "no") << std::endl;
+          if(!trgselresult){
+            AliErrorStream() <<  "Trigger decision container with name " << fNameTriggerDecisionContainer << " not found in event - not possible to select EMCAL triggers" << std::endl;
+            return false;
+          }
+          if(!trgselresult->IsEventSelected(fTriggerSelectionString)) return false;
+        }
+      }
+    } else {
+      // Simulation - do EMCAL trigger selection from trigger selection object
+      if(!(fInputHandler->IsEventSelected() & AliVEvent::kINT7)) return false;        // Require INT7 trigger - EMCAL triggers will be a subset
+      if(IsSelectEmcalTriggers(fTriggerSelectionString.Data())){
+        auto mctrigger = static_cast<PWG::EMCAL::AliEmcalTriggerDecisionContainer *>(fInputEvent->FindListObject(fNameTriggerDecisionContainer));
+        AliDebugStream(1) << "Found trigger decision object: " << (mctrigger ? "yes" : "no") << std::endl;
+        if(!mctrigger){
+          AliErrorStream() <<  "Trigger decision container with name " << fNameTriggerDecisionContainer << " not found in event - not possible to select EMCAL triggers" << std::endl;
+          return false;
+        }
+        if(!mctrigger->IsEventSelected(fTriggerSelectionString)) return false;
+      }
+    }
+  }
+  return true;      // trigger selected or pure MCgen information
 }
 
 void AliAnalysisTaskEmcalJetSubstructureTree::UserExecOnce() {
@@ -757,6 +772,8 @@ AliAnalysisTaskEmcalJetSubstructureTree *AliAnalysisTaskEmcalJetSubstructureTree
   AliAnalysisTaskEmcalJetSubstructureTree *treemaker = new AliAnalysisTaskEmcalJetSubstructureTree(taskname.str().data());
   mgr->AddTask(treemaker);
   treemaker->SetMakeGeneralHistograms(kTRUE);
+  if(isMC) treemaker->SetHasTrueEvent(true);
+  if(isData) treemaker->SetHasRecEvent(true);
 
   // Adding containers
   if(isMC) {
@@ -782,7 +799,7 @@ AliAnalysisTaskEmcalJetSubstructureTree *AliAnalysisTaskEmcalJetSubstructureTree
       tracks->SetMinPt(0.15);
     }
     AliClusterContainer *clusters(nullptr);
-    if((jettype == AliJetContainer::kFullJet) || (AliJetContainer::kNeutralJet)){
+    if((jettype == AliJetContainer::kFullJet) || (jettype == AliJetContainer::kNeutralJet)){
       std::cout << "Using full or neutral jets ..." << std::endl;
       clusters = treemaker->AddClusterContainer(EMCalTriggerPtAnalysis::AliEmcalAnalysisFactory::ClusterContainerNameFactory(isAOD));
       std::cout << "Cluster container name: " << clusters->GetName() << std::endl;

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.h
@@ -207,6 +207,9 @@ public:
   void SetUseChargedConstituents(Bool_t doUse) { fUseChargedConstituents = doUse; }
   void SetUseNeutralConstituents(Bool_t doUse) { fUseNeutralConstituents = doUse; }
 
+  void SetHasRecEvent(Bool_t hasrec) { fHasRecEvent = hasrec; }
+  void SetHasTrueEvent(Bool_t hastrue) { fHasTrueEvent = hastrue; }
+
 	static AliAnalysisTaskEmcalJetSubstructureTree *AddEmcalJetSubstructureTreeMaker(Bool_t isMC, Bool_t isData, Double_t jetradius, AliJetContainer::EJetType_t jettype, AliJetContainer::ERecoScheme_t recombinationScheme, Bool_t useDCAL, const char *name);
 
 protected:
@@ -214,6 +217,7 @@ protected:
 	virtual bool Run();
 	virtual void RunChanged(Int_t newrun);
   virtual void UserExecOnce();
+  virtual Bool_t IsTriggerSelected();
 
 	AliJetSubstructureData MakeJetSubstructure(const AliEmcalJet &jet, double jetradius, const AliParticleContainer *tracks, const AliClusterContainer *clusters, const AliJetSubstructureSettings &settings) const;
 
@@ -254,6 +258,8 @@ private:
 	Double_t                     fSDBetaCut;                  ///< Soft drop beta cut
 	Reclusterizer_t              fReclusterizer;              ///< Reclusterizer method
 
+  Bool_t                       fHasRecEvent;                ///< Has reconstructed event (for trigger selection)
+  Bool_t                       fHasTrueEvent;               ///< Has Monte-Carlo truth (for trigger selection)
 	UInt_t                       fTriggerSelectionBits;       ///< Trigger selection bits
   TString                      fTriggerSelectionString;     ///< Trigger selection string
   TString                      fNameTriggerDecisionContainer; ///< Global trigger decision container


### PR DESCRIPTION
Implement virtual trigger selection function introduced
in #5879 for AliAnalysisTaskEmcalJetEnergySpectrum
and AliAnalysisTaskEmcalJetSubstructureTree. This is
basically moving code from Run/TriggerSelection to the new function.