### PR TITLE
Added macros used for the Jpsi Raa analysis of the 2017 Xe-Xe data

### DIFF
--- a/PWGDQ/reducedTree/macros/attic/XeXe2017/AddTask_iarsene_dst.C
+++ b/PWGDQ/reducedTree/macros/attic/XeXe2017/AddTask_iarsene_dst.C
@@ -1,0 +1,640 @@
+void AddFMDTask();
+
+//__________________________________________________________________________________________
+AliAnalysisTask *AddTask_iarsene_dst(Int_t reducedEventType=-1, Bool_t writeTree=kTRUE, TString prod="LHC10h"){
+  //get the current analysis manager
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    Error("AddTask_iarsene_dst", "No analysis manager found.");
+    return 0;
+  }
+
+  //Do we have an MC handler?
+  Bool_t hasMC=(AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler()!=0x0);
+  Bool_t isAOD=mgr->GetInputEventHandler()->IsA()==AliAODInputHandler::Class();
+  
+  Int_t collSystem = 0;
+  if(!prod.CompareTo("LHC10h")) collSystem = 1;    // minimum bias Pb-Pb
+  if(!prod.CompareTo("LHC11h")) collSystem = 2;    // centrality triggered Pb-Pb
+  if(!prod.CompareTo("LHC15o")) collSystem = 3;    // minimum bias Pb-Pb
+  if(!prod.CompareTo("LHC10b") || !prod.CompareTo("LHC10c") || !prod.CompareTo("LHC10d") || 
+     !prod.CompareTo("LHC10e") || !prod.CompareTo("LHC10f")) collSystem = 4;   // minimum bias pp
+  if(!prod.CompareTo("LHC13b") || !prod.CompareTo("LHC13c")) collSystem = 5;   // minimum bias p-Pb   
+  if(!prod.CompareTo("LHC16l")) collSystem = 6;    // minimum bias pp and Pb-Pb
+  if(!prod.CompareTo("LHC16q") || !prod.CompareTo("LHC16r") || !prod.CompareTo("LHC16s") || !prod.CompareTo("LHC16t")) collSystem = 7;    // triggered p-Pb (2016 data)
+  if(!prod.CompareTo("LHC17n")) collSystem = 8;
+  
+  if(!collSystem && !hasMC) {
+     collSystem = 1;
+     printf("WARNING: In AddTask_iarsene_dst(), no proper production name specified, or not supported! \n");
+     printf("                 Using collSystem=1 (min bias 2010 Pb-Pb) as default \n");
+  }
+  
+  //create task and add it to the manager
+  AliAnalysisTaskReducedTreeMaker *task=new AliAnalysisTaskReducedTreeMaker("DSTTreeMaker", kTRUE);
+  if(collSystem==1) task->SetTriggerMask(AliVEvent::kMB);
+  if(collSystem==2)
+    task->SetTriggerMask(AliVEvent::kMB+AliVEvent::kCentral+AliVEvent::kSemiCentral);
+  if(collSystem==3) task->SetTriggerMask(AliVEvent::kINT7);
+  if(collSystem==4) task->SetTriggerMask(AliVEvent::kMB);
+  if(collSystem==5) task->SetTriggerMask(AliVEvent::kINT7);
+  if(collSystem==6) task->SetTriggerMask(AliVEvent::kMB+AliVEvent::kINT7+AliVEvent::kHighMultSPD+AliVEvent::kHighMultV0);
+  if(collSystem==7) task->SetTriggerMask(AliVEvent::kINT7+AliVEvent::kTRD);
+  if(collSystem==8) task->SetTriggerMask(AliVEvent::kINT7);
+  
+  //if(collSystem==4)
+  //  task->SetRejectPileup();
+    
+  task->UsePhysicsSelection(kFALSE);
+  task->SetUseAnalysisUtils(kTRUE);
+  
+  task->SetFillV0Info(kTRUE);
+  task->SetFillGammaConversions(kFALSE);
+  task->SetFillK0s(kFALSE);
+  task->SetFillLambda(kFALSE);
+  task->SetFillALambda(kFALSE);
+  task->SetFillCaloClusterInfo(kFALSE);
+  //task->SetFillDielectronInfo(kFALSE);
+  //task->SetFillFriendInfo(kFALSE);
+  
+  task->SetEventFilter(CreateEventFilter(isAOD));
+  //task->SetTrackFilter(CreateGlobalTrackFilter(isAOD));
+  CreateTrackFilters(task, isAOD);
+  
+  //  task->SetFlowTrackFilter(CreateFlowTrackFilter(isAOD));
+  //task->SetK0sPionCuts(CreateK0sPionCuts(isAOD));
+  //task->SetLambdaProtonCuts(CreateLambdaProtonCuts(isAOD));
+  //task->SetLambdaPionCuts(CreateLambdaPionCuts(isAOD));
+  //task->SetGammaElectronCuts(CreateGammaConvElectronCuts(isAOD));
+  //task->SetK0sMassRange(0.44,0.55);
+  //task->SetLambdaMassRange(1.090,1.14);
+  //task->SetGammaConvMassRange(0.0,0.1);
+  //task->SetV0OpenCuts(CreateV0OpenCuts(AliESDv0KineCuts::kPurity, AliESDv0KineCuts::kPbPb));
+  //task->SetV0StrongCuts(CreateV0StrongCuts(AliESDv0KineCuts::kPurity, AliESDv0KineCuts::kPbPb));
+  //task->SetFillFMDInfo(); AddFMDTask();
+  if(hasMC) {
+     task->SetFillMCInfo(kTRUE);
+     AddMCSignals(task);
+  }
+  //task->SetFillEventPlaneInfo(kTRUE);
+
+  //task->SetTreeWritingOption(AliAnalysisTaskReducedTreeMaker::kFullEventsWithFullTracks);
+  //task->SetTreeWritingOption(AliAnalysisTaskReducedTreeMaker::kBaseEventsWithBaseTracks);
+  if(reducedEventType!=-1)
+    task->SetTreeWritingOption(reducedEventType);
+  task->SetWriteTree(writeTree);
+  //task->SetWriteEventsWithNoSelectedTracks(kFALSE);
+  
+  SetInactiveBranches(task);
+  
+  mgr->AddTask(task);
+    
+  AliAnalysisDataContainer *cReducedTree = 0x0;
+  AliAnalysisDataContainer *cEventStatsInfo = 0x0;
+  AliAnalysisDataContainer *cTrackStatsInfo = 0x0;
+  AliAnalysisDataContainer *cMCStatsInfo = 0x0;
+  if(task->WriteTree()) {
+    cReducedTree = mgr->CreateContainer("dstTree", TTree::Class(),
+                                          AliAnalysisManager::kOutputContainer, "dstTree.root");
+    cEventStatsInfo = mgr->CreateContainer("EventStats", TH2I::Class(),
+       AliAnalysisManager::kOutputContainer, "dstTree.root");
+    cTrackStatsInfo = mgr->CreateContainer("TrackStats", TH2I::Class(),
+                                           AliAnalysisManager::kOutputContainer, "dstTree.root");
+    cMCStatsInfo = mgr->CreateContainer("MCStats", TH2I::Class(),
+                                           AliAnalysisManager::kOutputContainer, "dstTree.root");
+  }
+  
+  AliAnalysisDataContainer *cReducedEvent =
+  mgr->CreateContainer("ReducedEventDQ",
+                         AliReducedBaseEvent::Class(),
+                         AliAnalysisManager::kExchangeContainer,
+                         "reducedEvent");
+  
+  mgr->ConnectInput(task,  0, mgr->GetCommonInputContainer());
+  mgr->ConnectOutput(task, 1, cReducedEvent);
+  if(task->WriteTree()) {
+     mgr->ConnectOutput(task, 2, cReducedTree);
+     mgr->ConnectOutput(task, 3, cEventStatsInfo);
+     mgr->ConnectOutput(task, 4, cTrackStatsInfo);
+     if(hasMC) mgr->ConnectOutput(task, 5, cMCStatsInfo);
+  }
+  
+  return task;
+}
+
+//_______________________________________________________________________________________________
+void AddMCSignals(AliAnalysisTaskReducedTreeMaker* task) {
+   //
+   // Add the MC signals to be filtered
+   //
+   AliSignalMC* jpsiInclusive=new AliSignalMC("JpsiInclusive", "",1,1);
+   jpsiInclusive->SetPDGcode(0, 0, 443, kFALSE);
+   task->AddMCsignal(jpsiInclusive, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   
+   AliSignalMC* jpsiFromB=new AliSignalMC("JpsiNonPrompt","",1,2);
+   jpsiFromB->SetPDGcode(0, 0, 443, kFALSE);
+   jpsiFromB->SetPDGcode(0, 1, 500, kTRUE);
+   task->AddMCsignal(jpsiFromB, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   
+   AliSignalMC* jpsiPrompt=new AliSignalMC("JpsiPrompt","",1,2);
+   jpsiPrompt->SetPDGcode(0, 0, 443, kFALSE);
+   jpsiPrompt->SetPDGcode(0, 1, 500, kTRUE, kTRUE);
+   task->AddMCsignal(jpsiPrompt, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   
+   AliSignalMC* jpsiInclusiveRadiative=new AliSignalMC("JpsiInclusiveRadiative","",1,1);
+   jpsiInclusiveRadiative->SetPDGcode(0, 0, 443, kFALSE);
+   jpsiInclusiveRadiative->SetSourceBit(0, 0, AliSignalMC::kRadiativeDecay);
+   task->AddMCsignal(jpsiInclusiveRadiative, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   
+   AliSignalMC* jpsiInclusiveNonRadiative=new AliSignalMC("JpsiInclusiveNonRadiative","",1,1);
+   jpsiInclusiveNonRadiative->SetPDGcode(0, 0, 443, kFALSE);
+   jpsiInclusiveNonRadiative->SetSourceBit(0, 0, AliSignalMC::kRadiativeDecay, kTRUE);
+   task->AddMCsignal(jpsiInclusiveNonRadiative, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   
+   AliSignalMC* electronFromJpsi=new AliSignalMC("electronFromJpsiInclusive","",1,2);
+   electronFromJpsi->SetPDGcode(0, 0, 11, kTRUE);
+   electronFromJpsi->SetPDGcode(0, 1, 443);
+   task->AddMCsignal(electronFromJpsi, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   
+   AliSignalMC* electronFromJpsiNonPrompt=new AliSignalMC("electronFromJpsiNonPrompt","",1,3);
+   electronFromJpsiNonPrompt->SetPDGcode(0, 0, 11, kTRUE);
+   electronFromJpsiNonPrompt->SetPDGcode(0, 1, 443);
+   electronFromJpsiNonPrompt->SetPDGcode(0, 2, 500, kTRUE);      //
+   task->AddMCsignal(electronFromJpsiNonPrompt, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   
+   AliSignalMC* electronFromJpsiPrompt=new AliSignalMC("electronFromJpsiPrompt","", 1,3);
+   electronFromJpsiPrompt->SetPDGcode(0, 0, 11, kTRUE);
+   electronFromJpsiPrompt->SetPDGcode(0, 1, 443);
+   electronFromJpsiPrompt->SetPDGcode(0, 2, 500, kTRUE, kTRUE);    //
+   task->AddMCsignal(electronFromJpsiPrompt, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   
+   AliSignalMC* electronFromJpsiRadiative=new AliSignalMC("electronFromJpsiRadiative","",1,2);
+   electronFromJpsiRadiative->SetPDGcode(0, 0, 11, kTRUE);
+   electronFromJpsiRadiative->SetPDGcode(0, 1, 443);
+   electronFromJpsiRadiative->SetSourceBit(0, 1, AliSignalMC::kRadiativeDecay);
+   task->AddMCsignal(electronFromJpsiRadiative, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   
+   AliSignalMC* electronFromJpsiNonRadiative=new AliSignalMC("electronFromJpsiNonRadiative","",1,2);
+   electronFromJpsiNonRadiative->SetPDGcode(0, 0, 11, kTRUE);
+   electronFromJpsiNonRadiative->SetPDGcode(0, 1, 443);
+   electronFromJpsiNonRadiative->SetSourceBit(0, 1, AliSignalMC::kRadiativeDecay, kTRUE);
+   task->AddMCsignal(electronFromJpsiNonRadiative, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+   
+   AliSignalMC* photonFromJpsiDecay=new AliSignalMC("photonFromJpsiDecay","",1,2);
+   photonFromJpsiDecay->SetPDGcode(0, 0, 22);
+   photonFromJpsiDecay->SetPDGcode(0, 1, 443);
+   task->AddMCsignal(photonFromJpsiDecay, AliAnalysisTaskReducedTreeMaker::kFullTrack);
+}
+
+//_______________________________________________________________________________________________
+void SetInactiveBranches(AliAnalysisTaskReducedTreeMaker* task) {
+   //
+   // Set inactive branches
+   //
+   // You can define the active branches of the tree, all other branches will be set to inactive
+   //task->SetTreeActiveBranch("Event");
+   //task->SetTreeActiveBranch("fRunNo");
+   // Alternatively, you can define the inactive branches of the tree, all other branches will be set to active
+
+   
+   //task->SetTreeInactiveBranch("fEventTag");
+   //task->SetTreeInactiveBranch("fRunNo");
+   //task->SetTreeInactiveBranch("fVtx*");
+   //task->SetTreeInactiveBranch("fNVtxContributors");
+   //task->SetTreeInactiveBranch("fCentrality*");
+   //task->SetTreeInactiveBranch("fCentQuality");
+   //task->SetTreeInactiveBranch("fNtracks*");
+   //task->SetTreeInactiveBranch("fNV0candidates*");
+   //task->SetTreeInactiveBranch("fTracks.*");
+   task->SetTreeInactiveBranch("fCandidates.*");
+   task->SetTreeInactiveBranch("fEventNumberInFile");
+   task->SetTreeInactiveBranch("fL0TriggerInputs");
+   task->SetTreeInactiveBranch("fL1TriggerInputs");
+   task->SetTreeInactiveBranch("fL2TriggerInputs");
+   //task->SetTreeInactiveBranch("fBC");
+   task->SetTreeInactiveBranch("fTimeStamp");
+   task->SetTreeInactiveBranch("fEventType");
+   //task->SetTreeInactiveBranch("fTriggerMask");
+   task->SetTreeInactiveBranch("fMultiplicityEstimators*");
+   task->SetTreeInactiveBranch("fMultiplicityEstimatorPercentiles*");
+   //task->SetTreeInactiveBranch("fIsPhysicsSelection");
+   task->SetTreeInactiveBranch("fIsSPDPileup");
+   task->SetTreeInactiveBranch("fIsSPDPileupMultBins");
+   task->SetTreeInactiveBranch("fIRIntClosestIntMap*");
+   task->SetTreeInactiveBranch("fVtxTPC*");
+   task->SetTreeInactiveBranch("fNVtxTPCContributors");
+   task->SetTreeInactiveBranch("fVtxSPD*");
+   task->SetTreeInactiveBranch("fNVtxSPDContributors");
+   task->SetTreeInactiveBranch("fNpileupSPD");
+   task->SetTreeInactiveBranch("fNpileupTracks");
+   //task->SetTreeInactiveBranch("fNTPCclusters");
+   task->SetTreeInactiveBranch("fNPMDtracks");
+   task->SetTreeInactiveBranch("fNTRDtracks");
+   task->SetTreeInactiveBranch("fNTRDtracklets");
+   //task->SetTreeInactiveBranch("fSPDntracklets");
+   task->SetTreeInactiveBranch("fSPDntrackletsEta*");
+   //task->SetTreeInactiveBranch("fSPDFiredChips*");
+   task->SetTreeInactiveBranch("fITSClusters*");
+   task->SetTreeInactiveBranch("fSPDnSingle");
+   //task->SetTreeInactiveBranch("fNtracksPerTrackingFlag*");
+   task->SetTreeInactiveBranch("fVZEROMult*");
+   //task->SetTreeInactiveBranch("fVZEROTotalMult*");
+   task->SetTreeInactiveBranch("fZDCnEnergy*");
+   task->SetTreeInactiveBranch("fZDCpEnergy*");
+   //task->SetTreeInactiveBranch("fZDCnTotalEnergy*");
+   //task->SetTreeInactiveBranch("fZDCpTotalEnergy*");
+   task->SetTreeInactiveBranch("fT0amplitude*");
+   task->SetTreeInactiveBranch("fT0TOF*");
+   task->SetTreeInactiveBranch("fT0TOFbest*");
+   task->SetTreeInactiveBranch("fT0zVertex");
+   task->SetTreeInactiveBranch("fT0start");
+   //task->SetTreeInactiveBranch("fT0pileup");
+   //task->SetTreeInactiveBranch("fT0sattelite");
+   //task->SetTreeInactiveBranch("fNCaloClusters");
+   //task->SetTreeInactiveBranch("fCaloClusters.*");
+   //task->SetTreeInactiveBranch("fFMD.*");
+   //task->SetTreeInactiveBranch("fEventPlane.*");
+   
+   //task->SetTreeInactiveBranch("fTracks2.*");
+   //task->SetTreeInactiveBranch("fTracks.fP*");
+   //task->SetTreeInactiveBranch("fTracks.fIsCartesian");
+   //task->SetTreeInactiveBranch("fTracks.fCharge");
+   //task->SetTreeInactiveBranch("fTracks.fFlags");
+   //task->SetTreeInactiveBranch("fTracks.fQualityFlags");
+   //task->SetTreeInactiveBranch("fTracks.fTrackId");
+   //task->SetTreeInactiveBranch("fTracks.fStatus");
+   task->SetTreeInactiveBranch("fTracks.fTPCPhi");
+   task->SetTreeInactiveBranch("fTracks.fTPCPt");
+   task->SetTreeInactiveBranch("fTracks.fTPCEta");
+   //task->SetTreeInactiveBranch("fTracks.fMomentumInner");
+   //task->SetTreeInactiveBranch("fTracks.fDCA*");
+   task->SetTreeInactiveBranch("fTracks.fTPCDCA*");
+   task->SetTreeInactiveBranch("fTracks.fTrackLength");
+   task->SetTreeInactiveBranch("fTracks.fMassForTracking");
+   //task->SetTreeInactiveBranch("fTracks.fChi2TPCConstrainedVsGlobal");
+   task->SetTreeInactiveBranch("fTracks.fHelixCenter*");
+   task->SetTreeInactiveBranch("fTracks.fHelixRadius");
+   //task->SetTreeInactiveBranch("fTracks.fITSclusterMap");
+   //task->SetTreeInactiveBranch("fTracks.fITSSharedClusterMap");
+   task->SetTreeInactiveBranch("fTracks.fITSsignal");
+   task->SetTreeInactiveBranch("fTracks.fITSnSig*");
+   //task->SetTreeInactiveBranch("fTracks.fITSchi2");
+   //task->SetTreeInactiveBranch("fTracks.fTPCNcls");
+   //task->SetTreeInactiveBranch("fTracks.fTPCCrossedRows");
+   //task->SetTreeInactiveBranch("fTracks.fTPCNclsF");
+   //task->SetTreeInactiveBranch("fTracks.fTPCNclsShared");
+   //task->SetTreeInactiveBranch("fTracks.fTPCClusterMap");
+   //task->SetTreeInactiveBranch("fTracks.fTPCsignal");
+   //task->SetTreeInactiveBranch("fTracks.fTPCsignalN");
+   //task->SetTreeInactiveBranch("fTracks.fTPCnSig*");
+   //task->SetTreeInactiveBranch("fTracks.fTPCchi2");
+   task->SetTreeInactiveBranch("fTracks.fTPCActiveLength");
+   task->SetTreeInactiveBranch("fTracks.fTPCGeomLength");
+   //task->SetTreeInactiveBranch("fTracks.fTOFbeta");
+   task->SetTreeInactiveBranch("fTracks.fTOFtime");
+   task->SetTreeInactiveBranch("fTracks.fTOFdx");
+   task->SetTreeInactiveBranch("fTracks.fTOFdz");
+   task->SetTreeInactiveBranch("fTracks.fTOFmismatchProbab");
+   task->SetTreeInactiveBranch("fTracks.fTOFchi2");
+   task->SetTreeInactiveBranch("fTracks.fTOFnSig*");
+   task->SetTreeInactiveBranch("fTracks.fTOFdeltaBC");
+   task->SetTreeInactiveBranch("fTracks.fTRDntracklets*");
+   task->SetTreeInactiveBranch("fTracks.fTRDpid*");
+   task->SetTreeInactiveBranch("fTracks.fTRDpidLQ2D*");
+   task->SetTreeInactiveBranch("fTracks.fCaloClusterId");
+   //task->SetTreeInactiveBranch("fTracks.fMCMom*");
+   //task->SetTreeInactiveBranch("fTracks.fMCFreezeout*");
+   //task->SetTreeInactiveBranch("fTracks.fMCLabels*");
+   //task->SetTreeInactiveBranch("fTracks.fMCPdg*");
+   //task->SetTreeInactiveBranch("fTracks.fMCGeneratorIndex");
+  
+   //task->SetTreeInactiveBranch("fCandidates.fP*");
+   //task->SetTreeInactiveBranch("fCandidates.fIsCartesian");
+   //task->SetTreeInactiveBranch("fCandidates.fCharge");
+   //task->SetTreeInactiveBranch("fCandidates.fFlags");
+   //task->SetTreeInactiveBranch("fCandidates.fQualityFlags");
+   //task->SetTreeInactiveBranch("fCandidates.fCandidateId");
+   //task->SetTreeInactiveBranch("fCandidates.fPairType");
+   //task->SetTreeInactiveBranch("fCandidates.fLegIds*");
+   //task->SetTreeInactiveBranch("fCandidates.fMass*");
+   //task->SetTreeInactiveBranch("fCandidates.fLxy");
+   //task->SetTreeInactiveBranch("fCandidates.fPointingAngle");
+   //task->SetTreeInactiveBranch("fCandidates.fChisquare");
+   
+}
+
+
+//_______________________________________________________________________________________________
+AliAnalysisCuts* CreateEventFilter(Bool_t isAOD) {
+  //
+  // Event wise cuts
+  //
+  AliDielectronEventCuts *eventCuts=new AliDielectronEventCuts("eventCuts","Vertex Track && |vtxZ|<10 && ncontrib>0");
+  if(isAOD) eventCuts->SetVertexType(AliDielectronEventCuts::kVtxAny);
+  eventCuts->SetRequireVertex();
+  eventCuts->SetMinVtxContributors(1);
+  eventCuts->SetVertexZ(-10.,10.);
+  return eventCuts;
+}
+
+
+//______________________________________________________________________________________
+void CreateTrackFilters(AliAnalysisTaskReducedTreeMaker* task, Bool_t isAOD) {
+   //
+   // add track filters
+   //
+   AliDielectronCutGroup* basicCut = new AliDielectronCutGroup("basicCut","J/psi candidate electron (basic cut)",AliDielectronCutGroup::kCompAND);
+   AliDielectronVarCuts *basicVarCuts = new AliDielectronVarCuts("basicVarCuts","basic var track cuts");
+   basicVarCuts->AddCut(AliDielectronVarManager::kImpactParXY,-1.0,1.0);
+   basicVarCuts->AddCut(AliDielectronVarManager::kImpactParZ,-3.0,3.0);
+   basicVarCuts->AddCut(AliDielectronVarManager::kEta,-0.9,0.9);
+   basicVarCuts->AddCut(AliDielectronVarManager::kPt,0.8,1.0e+30);
+   basicVarCuts->AddCut(AliDielectronVarManager::kNclsTPC,70.0,161.0);   
+   basicVarCuts->AddCut(AliDielectronVarManager::kTPCnSigmaEle, -4.0, 4.0);
+   basicVarCuts->AddCut(AliDielectronVarManager::kTPCnSigmaPro, -3.0, 2.0, kTRUE);
+   basicVarCuts->AddCut(AliDielectronVarManager::kTPCnSigmaPio, -3.0, 2.0, kTRUE);
+   basicVarCuts->AddCut(AliDielectronVarManager::kTPCnSigmaKao, -3.0, 3.0, kTRUE);
+//   basicVarCuts->AddCut(AliDielectronVarManager::kTPCchi2Cl, 0.0, 10.0);
+//   basicVarCuts->AddCut(AliDielectronVarManager::kITSchi2Cl, 0.0, 100.);
+//   basicVarCuts->AddCut(AliDielectronVarManager::kTPCclsSegments, 5., 9.);
+//   basicVarCuts->AddCut(AliDielectronVarManager::kNclsSFracTPC, 0.6, 2.0, kTRUE);
+//   basicVarCuts->AddCut(AliDielectronVarManager::kNFclsTPCfCross, 0.5, 2.0);
+//   basicVarCuts->AddCut(AliDielectronVarManager::kChi2TPCConstrainedVsGlobal, 100., 1.0e+10, kTRUE);
+   basicCut->AddCut(basicVarCuts);
+   AliDielectronTrackCuts* basicTrackCuts = new AliDielectronTrackCuts("basicTrackCuts","basic track cuts");
+   basicTrackCuts->SetRequireITSRefit(kTRUE);
+   basicTrackCuts->SetRequireTPCRefit(kTRUE);
+   if(isAOD) basicTrackCuts->SetAODFilterBit(AliDielectronTrackCuts::kTPCqual);
+   basicCut->AddCut(basicTrackCuts);
+   task->AddTrackFilter(basicCut, kFALSE);   // basic cut, no SPD requirements
+   
+   AliDielectronCutGroup* prefilterCut = new AliDielectronCutGroup("prefilterCut","basic electron cut to be used for prefilter",AliDielectronCutGroup::kCompAND);
+   AliDielectronVarCuts *prefilterVarCuts = new AliDielectronVarCuts("prefilterVarCuts","prefilter var track cuts");
+   prefilterVarCuts->AddCut(AliDielectronVarManager::kImpactParXY,-3.0,3.0);
+   prefilterVarCuts->AddCut(AliDielectronVarManager::kImpactParZ,-10.0,10.0);
+   prefilterVarCuts->AddCut(AliDielectronVarManager::kEta,-0.9,0.9);
+   prefilterVarCuts->AddCut(AliDielectronVarManager::kPt,0.5,1.0e+30);
+   prefilterVarCuts->AddCut(AliDielectronVarManager::kNclsTPC,50.0,161.0);   
+   prefilterVarCuts->AddCut(AliDielectronVarManager::kTPCnSigmaEle, -4.0, 4.0);
+   prefilterVarCuts->AddCut(AliDielectronVarManager::kTPCnSigmaPro, -3.0, 2.0, kTRUE);
+   prefilterVarCuts->AddCut(AliDielectronVarManager::kTPCnSigmaPio, -3.0, 2.0, kTRUE);
+   prefilterVarCuts->AddCut(AliDielectronVarManager::kTPCnSigmaKao, -3.0, 3.0, kTRUE);
+//   prefilterVarCuts->AddCut(AliDielectronVarManager::kTPCchi2Cl, 0.0, 10.0);
+//   prefilterVarCuts->AddCut(AliDielectronVarManager::kITSchi2Cl, 0.0, 100.);
+//   prefilterVarCuts->AddCut(AliDielectronVarManager::kTPCclsSegments, 4., 9.);
+   //prefilterVarCuts->AddCut(AliDielectronVarManager::kNclsSFracTPC, 0.6, 2.0, kTRUE);
+   //prefilterVarCuts->AddCut(AliDielectronVarManager::kNFclsTPCfCross, 0.5, 2.0);
+   //prefilterVarCuts->AddCut(AliDielectronVarManager::kChi2TPCConstrainedVsGlobal, 100., 1.0e+10, kTRUE);
+   prefilterCut->AddCut(prefilterVarCuts);
+   AliDielectronTrackCuts* prefilterTrackCuts = new AliDielectronTrackCuts("prefilterTrackCuts","prefilter track cuts");
+   //prefilterTrackCuts->SetRequireITSRefit(kTRUE);
+   prefilterTrackCuts->SetRequireTPCRefit(kTRUE);
+   if(isAOD) prefilterTrackCuts->SetAODFilterBit(AliDielectronTrackCuts::kTPCqual);
+   prefilterCut->AddCut(prefilterTrackCuts);
+   task->AddTrackFilter(prefilterCut, kFALSE);   // prefilter electron cut
+}
+
+
+//_________________________________________________________________________________________________________________
+void AddFMDTask(){
+
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+
+  gSystem->Load("libPWGLFforward2");  // for FMD
+
+  // Create the FMD task and add it to the manager
+  //===========================================================================
+
+
+  //--- AOD output handler -----------------------------------------
+  AliAODHandler* ret = new AliAODHandler();
+  //ret->SetFillAOD(kTRUE);
+  ret->SetOutputFileName("AliAOD.pass2.root");
+  mgr->SetOutputEventHandler(ret);
+  ////AliVEventHandler*  outputHandlernew AliAODInputHandler();
+  //
+
+
+  //gROOT->LoadClass("AliAODForwardMult", "libPWGLFforward2");
+  gSystem->Load("libESDfilter.so");
+  gROOT->LoadMacro("$ALICE_ROOT/ANALYSIS/ESDfilter/macros/AddTaskESDFilter.C");
+  AliAnalysisTaskESDfilter *esdfilter = AddTaskESDFilter(kTRUE, kFALSE, kFALSE, kFALSE, kFALSE, kTRUE);
+  //AliAnalysisTaskESDfilter *esdfilter = AddTaskESDFilter();
+
+  // Create ONLY the output containers for the data produced by the task.
+  // Get and connect other common input/output containers via the manager as below
+  //==============================================================================
+  mgr->ConnectInput  (esdfilter,  0, mgr->GetCommonInputContainer());
+  mgr->ConnectOutput (esdfilter,  0, mgr->GetCommonOutputContainer());
+
+  gROOT->LoadMacro("$ALICE_PHYSICS/PWGLF/FORWARD/analysis2/AddTaskForwardMult.C");
+
+  Bool_t   mc  = false; // false: real data, true: simulated data
+  ULong_t run = 0; // 0: get from data???
+  UShort_t sys = 0; // 0: get from data, 1: pp, 2: AA 
+  UShort_t sNN = 0; // 0: get from data, otherwise center of mass energy (per nucleon pair)
+  Short_t  fld = 0; // 0: get from data, otherwise L3 field in kG
+  //AliAnalysisTask *taskFmd  = AddTaskForwardMult(mc, sys, sNN, fld);
+  //const Char_t* config = "$ALICE_PHYSICS/PWGDQ/dielectron/ReducedTreeMaker/ForwardAODConfig2.C";
+  const Char_t* config = "ForwardAODConfig2.C";  // to be changed to the above line when config is committed
+  AliAnalysisTask *taskFmd  = AddTaskForwardMult(mc, run, sys, sNN, fld, config);
+
+
+
+  // --- Make the output container and connect it --------------------
+  AliAnalysisDataContainer* histOut = 
+    mgr->CreateContainer("Forward", TList::Class(), 
+        AliAnalysisManager::kExchangeContainer,
+        "Forward");
+  //AliAnalysisManager::GetCommonFileName());
+  AliAnalysisDataContainer *output = 
+    mgr->CreateContainer("ForwardResults", TList::Class(), 
+        AliAnalysisManager::kParamContainer, 
+        "ForwardResults");
+  //AliAnalysisManager::GetCommonFileName());
+
+  mgr->ConnectInput(taskFmd, 0, mgr->GetCommonInputContainer());
+  mgr->ConnectOutput(taskFmd, 1, histOut);
+  //mgr->ConnectOutput(taskFmd, 2, output);
+  mgr->AddTask(taskFmd);
+}
+
+//_______________________________________________________________________________________________
+AliAnalysisCuts* CreateFlowTrackFilter(Bool_t isAOD) {
+  //
+  // Cuts for tracks to be used for the event plane q-vector
+  // These cuts are applied aditionally to the global track cuts
+  //
+  if(!isAOD) {
+    AliESDtrackCuts *esdTrackCuts = new AliESDtrackCuts;
+    esdTrackCuts->SetPtRange(0.2,2.0);
+    esdTrackCuts->SetEtaRange(-0.8, 0.8);
+    esdTrackCuts->SetMinNClustersTPC(70);
+    return esdTrackCuts;
+  }
+  else return 0;
+}
+
+
+//_______________________________________________________________________________________________
+AliAnalysisCuts* CreateK0sPionCuts(Bool_t isAOD) {
+  //
+  // Cuts on the K0s pions (tracking cuts, pid cuts, ...) 
+  //
+  if(!isAOD) {
+    AliESDtrackCuts *pionCuts = new AliESDtrackCuts;
+    pionCuts->SetPtRange(0.15,100.0);
+    pionCuts->SetEtaRange(-1.6,1.6);
+    pionCuts->SetRequireTPCRefit(kTRUE);
+    pionCuts->SetMinNClustersTPC(50);
+    return pionCuts;
+  }
+  else return 0;
+}
+
+//_______________________________________________________________________________________________
+AliAnalysisCuts* CreateLambdaPionCuts(Bool_t isAOD) {
+  //
+  // Cuts on the Lambda pions (tracking cuts, pid cuts, ...) 
+  //
+  if(!isAOD) {
+    AliESDtrackCuts *pionCuts = new AliESDtrackCuts;
+    pionCuts->SetPtRange(0.15,100.0);
+    pionCuts->SetEtaRange(-1.6,1.6);
+    pionCuts->SetRequireTPCRefit(kTRUE);
+    pionCuts->SetMinNClustersTPC(50);
+    return pionCuts;
+  }
+  else return 0;
+}
+
+
+//_______________________________________________________________________________________________
+AliAnalysisCuts* CreateLambdaProtonCuts(Bool_t isAOD) {
+  //
+  // Cuts on the Lambda protons (tracking cuts, pid cuts, ...) 
+  //
+  if(!isAOD) {
+    AliESDtrackCuts *protonCuts = new AliESDtrackCuts;
+    protonCuts->SetPtRange(0.15,100.0);
+    protonCuts->SetEtaRange(-1.6,1.6);
+    protonCuts->SetRequireTPCRefit(kTRUE);
+    protonCuts->SetMinNClustersTPC(50);
+    return protonCuts;
+  }
+  else return 0;
+}
+
+
+//______________________________________________________________________________________
+AliAnalysisCuts* CreateGammaConvElectronCuts(Bool_t isAOD) {
+  //
+  // Cuts for the selection of electrons from gamma conversions
+  //
+  if(!isAOD) {
+    AliESDtrackCuts* electronCuts = new AliESDtrackCuts;
+    electronCuts->SetPtRange(0.7,100.0);
+    electronCuts->SetEtaRange(-0.9,0.9);
+    electronCuts->SetRequireTPCRefit(kTRUE);
+    electronCuts->SetMinNClustersTPC(70);
+    return electronCuts;
+  }
+}
+
+//______________________________________________________________________________________
+AliESDv0KineCuts* CreateV0StrongCuts(Int_t mode, Int_t type) {
+  //
+  // cuts for the selection of gamma conversions
+  //
+  AliESDv0KineCuts* cuts = new AliESDv0KineCuts();
+  cuts->SetMode(mode, type);
+  
+  // leg cuts
+  cuts->SetNTPCclusters(50);
+  cuts->SetTPCrefit(kTRUE);
+  cuts->SetTPCchi2perCls(4.0);
+  cuts->SetTPCclusterratio(0.6);
+  cuts->SetNoKinks(kTRUE);
+  // gamma cuts                                                                                                                      
+  cuts->SetGammaCutChi2NDF(10.0);
+  Float_t cosPoint[2] = {0.0, 0.02};
+  cuts->SetGammaCutCosPoint(cosPoint);
+  Float_t cutDCA[2] = {0.0, 0.25};
+  cuts->SetGammaCutDCA(cutDCA);
+  Float_t vtxR[2] = {3.0, 90.0};
+  cuts->SetGammaCutVertexR(vtxR);
+  Float_t psiPairCut[2]={0.0,0.05};
+  cuts->SetGammaCutPsiPair(psiPairCut);
+  cuts->SetGammaCutInvMass(0.05);
+  // K0s cuts
+  cuts->SetK0CutChi2NDF(10.0);
+  Float_t cosPointK0s[2] = {0.0, 0.02};
+  cuts->SetK0CutCosPoint(cosPointK0s);
+  Float_t cutDCAK0s[2] = {0.0, 0.2};
+  cuts->SetK0CutDCA(cutDCAK0s);
+  Float_t vtxRK0s[2] = {2.0, 30.0};
+  cuts->SetK0CutVertexR(vtxRK0s);
+  Float_t k0sInvMass[2] = {0.486, 0.508};
+  cuts->SetK0CutInvMass(k0sInvMass);
+  // Lambda and anti-Lambda cuts
+  cuts->SetLambdaCutChi2NDF(10.0);
+  Float_t cosPointLambda[2] = {0.0, 0.02};
+  cuts->SetLambdaCutCosPoint(cosPointLambda);
+  Float_t cutDCALambda[2] = {0.0, 0.2};
+  cuts->SetLambdaCutDCA(cutDCALambda);
+  Float_t vtxRLambda[2] = {2.0, 40.0};
+  cuts->SetLambdaCutVertexR(vtxRLambda);
+  Float_t lambdaInvMass[2] = {1.11, 1.12};
+  cuts->SetLambdaCutInvMass(lambdaInvMass);
+  
+  return cuts;
+}
+
+//______________________________________________________________________________________
+AliESDv0KineCuts* CreateV0OpenCuts(Int_t mode, Int_t type) {
+  //
+  // cuts for the selection of gamma conversions
+  //
+  AliESDv0KineCuts* cuts = new AliESDv0KineCuts();
+  cuts->SetMode(mode, type);
+  
+  // leg cuts
+  cuts->SetNTPCclusters(50);
+  cuts->SetTPCrefit(kTRUE);
+  cuts->SetTPCchi2perCls(4.0);
+  cuts->SetTPCclusterratio(0.6);
+  cuts->SetNoKinks(kTRUE);
+  // gamma cuts                                                                                                                      
+  cuts->SetGammaCutChi2NDF(10.0);
+  Float_t cosPoint[2] = {0.0, 0.05};  //  Float_t cosPoint[2] = {0.0, 0.02};
+  cuts->SetGammaCutCosPoint(cosPoint);
+  Float_t cutDCA[2] = {0.0, 1.0};  //  Float_t cutDCA[2] = {0.0, 0.25};
+  cuts->SetGammaCutDCA(cutDCA);
+  Float_t vtxR[2] = {3.0, 90.0};
+  cuts->SetGammaCutVertexR(vtxR);
+  Float_t psiPairCut[2]={0.0,0.20};  //Float_t psiPairCut[2]={0.0,0.05};
+  cuts->SetGammaCutPsiPair(psiPairCut);
+  cuts->SetGammaCutInvMass(0.1); //  cuts->SetGammaCutInvMass(0.05);
+  // K0s cuts
+  cuts->SetK0CutChi2NDF(10.0);
+  Float_t cosPointK0s[2] = {0.0, 0.1};  //  Float_t cosPointK0s[2] = {0.0, 0.02};
+  cuts->SetK0CutCosPoint(cosPointK0s);
+  Float_t cutDCAK0s[2] = {0.0, 1.0};  //  Float_t cutDCAK0s[2] = {0.0, 0.2};
+  cuts->SetK0CutDCA(cutDCAK0s);
+  Float_t vtxRK0s[2] = {2.0, 90.0};  //  Float_t vtxRK0s[2] = {2.0, 30.0};
+  cuts->SetK0CutVertexR(vtxRK0s);
+  Float_t k0sInvMass[2] = {0.44, 0.55};  //  Float_t k0sInvMass[2] = {0.486, 0.508};
+  cuts->SetK0CutInvMass(k0sInvMass);
+  // Lambda and anti-Lambda cuts
+  cuts->SetLambdaCutChi2NDF(10.0);
+  Float_t cosPointLambda[2] = {0.0, 0.1};  //  Float_t cosPointLambda[2] = {0.0, 0.02};
+  cuts->SetLambdaCutCosPoint(cosPointLambda);
+  Float_t cutDCALambda[2] = {0.0, 1.0};  //  Float_t cutDCALambda[2] = {0.0, 0.2};
+  cuts->SetLambdaCutDCA(cutDCALambda);
+  Float_t vtxRLambda[2] = {2.0, 90.0};  //  Float_t vtxRLambda[2] = {2.0, 40.0};
+  cuts->SetLambdaCutVertexR(vtxRLambda);
+  Float_t lambdaInvMass[2] = {1.09, 1.14};  //  Float_t lambdaInvMass[2] = {1.11, 1.12};
+  cuts->SetLambdaCutInvMass(lambdaInvMass);
+  
+  return cuts;
+}

--- a/PWGDQ/reducedTree/macros/attic/XeXe2017/AddTask_iarsene_jpsi2ee_XeXe.C
+++ b/PWGDQ/reducedTree/macros/attic/XeXe2017/AddTask_iarsene_jpsi2ee_XeXe.C
@@ -1,0 +1,1095 @@
+//void Setup(AliReducedAnalysisJpsi2ee* processor, TString prod="LHC10h");
+//AliHistogramManager* SetupHistogramManager(TString prod="LHC10h");
+//void DefineHistograms(AliHistogramManager* man, TString prod="LHC10h");
+
+enum TrackFilters {
+   kBasicCut=0,
+   kPrefilterCut,
+   kNTrackFilters
+};
+
+enum MCFilters {
+   kJpsiInclusive=0,
+   kJpsiNonPrompt,
+   kJpsiPrompt,
+   kJpsiRadiative,
+   kJpsiNonRadiative,
+   kJpsiDecayElectron,
+   kJpsiNonPromptDecayElectron,
+   kJpsiPromptDecayElectron,
+   kJpsiRadiativeDecayElectron,
+   kJpsiNonRadiativeDecayElectron,
+   kJpsiDecayPhoton
+};
+
+enum TrackQualityFilterBits {       // as in AliReducedBaseTrack::fQualityFlags
+   kTPCEventPlaneContributor = 0,
+   kPhotonConversionV0Leg, 
+   kK0sV0Leg,
+   kLambdaV0Leg,
+   kAntiLambdaV0Leg,
+   kKink0PositiveIndex,
+   kKink1PositiveIndex,
+   kKink2PositiveIndex,
+   kPurePhotonConversionV0Leg,
+   kPureK0sV0Leg, 
+   kPureLambdaV0Leg,
+   kAntiLambdaV0Leg, 
+   kKink0NegativeIndex, 
+   kKink1NegativeIndex,
+   kKink2NegativeIndex,
+   kAODbits=15,
+   kTRDmatch=26
+};
+
+// run list string used for run IDs in the VarManager
+const Int_t gkNRuns = 2;
+TString gRunList = "280234;280235";
+
+// centrality binning used for event mixing and main pair histograms
+const Int_t gkNCentBins = 15;
+Double_t gCentLims[gkNCentBins] = {
+   0.0, 2.5, 5.0, 7.5, 10., 
+   15.0, 20., 25., 30., 40., 
+   50.0,  60.0, 70.0, 80., 90.0
+};
+
+// pt binning
+const Int_t gkNPtBins = 12;
+Double_t gPtLims[gkNPtBins] = {
+   0.0, 0.50, 1.0, 1.5, 2.0, 
+   2.5, 3.0, 4.0, 5.0, 7.0,
+   10., 20.0
+};
+
+// vertex-z binning
+const Int_t gkNVtxZBins = 7;
+Double_t gVtxZLims[gkNVtxZBins] = {
+   -10.0, -7.0, -3.0, 0.0, 3.0, 7.0, 10.0
+};
+
+// mass binning
+const Int_t gkNMassBins = 91;
+Double_t gMassBins[gkNMassBins] = {0.};
+
+
+//__________________________________________________________________________________________
+AliAnalysisTask* AddTask_iarsene_jpsi2ee_XeXe(Bool_t isAliRoot=kTRUE, Int_t runMode=1, TString prod="LHC10h"){    
+   //
+   // isAliRoot=kTRUE for ESD/AOD analysis in AliROOT, kFALSE for root analysis on reduced trees
+   // runMode=1 (AliAnalysisTaskReducedEventProcessor::kUseOnTheFlyReducedEvents)
+   //               =2 (AliAnalysisTaskReducedEventProcessor::kUseEventsFromTree)
+   //
+   //get the current analysis manager
+
+  printf("INFO on AddTask_iarsene_jpsi2ee(): (isAliRoot, runMode) :: (%d,%d) \n", isAliRoot, runMode);
+
+  AliReducedAnalysisJpsi2ee* jpsi2eeAnalysis = new AliReducedAnalysisJpsi2ee("Jpsi2eeAnalysis","Jpsi->ee analysis");
+  jpsi2eeAnalysis->Init();
+  //jpsi2eeAnalysis->SetLoopOverTracks(kFALSE);
+  //jpsi2eeAnalysis->SetRunEventMixing(kFALSE);
+  //jpsi2eeAnalysis->SetRunPairing(kFALSE);
+  jpsi2eeAnalysis->SetRunOverMC(kTRUE);
+  //jpsi2eeAnalysis->SetRunLikeSignPairing(kFALSE);
+  //jpsi2eeAnalysis->SetRunPrefilter(kFALSE);
+  Setup(jpsi2eeAnalysis, prod);
+  // initialize an AliAnalysisTask which will wrapp the AliReducedAnalysisJpsi2ee such that it can be run in an aliroot analysis train (e.g. LEGO, local analysis etc)
+  AliAnalysisTaskReducedEventProcessor* task = new AliAnalysisTaskReducedEventProcessor("ReducedEventAnalysisManager", runMode);
+  task->AddTask(jpsi2eeAnalysis);
+  
+  if(isAliRoot){
+     AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+     if (!mgr) {
+        Error("AddTask_iarsene_dst", "No analysis manager found.");
+        return 0;
+     }
+     
+     AliAnalysisDataContainer* cReducedEvent = NULL;
+     if(runMode==AliAnalysisTaskReducedEventProcessor::kUseOnTheFlyReducedEvents) {
+       printf("INFO on AddTask_iarsene_jpsi2ee(): use on the fly events ");
+       cReducedEvent = (AliAnalysisDataContainer*)mgr->GetContainers()->FindObject("ReducedEventDQ");
+       if(!cReducedEvent) {
+         printf("ERROR: In AddTask_iarsene_jpsi2ee(), couldn't find exchange container with ReducedEvent! ");
+         printf("             You need to use AddTask_iarsene_dst() in the on-the-fly reduced events mode!");
+         return 0x0;
+       }
+     }
+            
+     mgr->AddTask(task);
+      
+     if(runMode==AliAnalysisTaskReducedEventProcessor::kUseEventsFromTree) 
+        mgr->ConnectInput(task,  0, mgr->GetCommonInputContainer());
+      
+     if(runMode==AliAnalysisTaskReducedEventProcessor::kUseOnTheFlyReducedEvents) 
+       mgr->ConnectInput(task, 0, cReducedEvent);
+  
+     TString outputFilename = "AnalysisHistograms_jpsi2ee_XeXe.root";
+     if(jpsi2eeAnalysis->GetRunOverMC()) outputFilename = "AnalysisHistograms_jpsi2ee_XeXe_MC.root";
+     AliAnalysisDataContainer *cOutputHist = mgr->CreateContainer("jpsi2eeHistos", THashList::Class(),
+                                                                  AliAnalysisManager::kOutputContainer, outputFilename.Data());
+     mgr->ConnectOutput(task, 1, cOutputHist );
+  }
+  else {
+    // nothing at the moment   
+  }
+  
+  return task;
+}
+
+
+//_________________________________________________________________
+void Setup(AliReducedAnalysisJpsi2ee* processor, TString prod /*="LHC10h"*/) {
+  //
+  // Configure the analysis task
+  // Setup histograms, handlers, cuts, etc.
+  //
+   Bool_t isMC = processor->GetRunOverMC();
+   
+  if(!processor->GetRunOverMC()) {
+      //TFile* corrFile = TFile::Open("/home/iarsene/work/ALICE/XeXe2017/tpcPostcalibrationMaps_cent0_30.root");
+      TFile* corrFile = TFile::Open("/home/iarsene/work/ALICE/XeXe2017/tpcPostcalibrationMaps_cent30_90.root");
+      AliReducedVarManager::SetTPCelectronCorrectionMaps((TH2F*)corrFile->Get("Mean"), (TH2F*)corrFile->Get("Width"), 
+                                                         AliReducedVarManager::kEta, AliReducedVarManager::kCentVZERO);
+      corrFile->Close();   
+  }
+   
+  // Set event cuts
+  AliReducedEventCut* evCut1 = new AliReducedEventCut("Centrality","Centrality selection");
+  evCut1->AddCut(AliReducedVarManager::kCentVZERO, 0., 90.);
+  evCut1->AddCut(AliReducedVarManager::kVtxZ, -10.0, 10.0);
+  if(!isMC)  evCut1->AddCut(AliReducedVarManager::kIsPhysicsSelection, 0.1, 2.);   // request physics selection
+  evCut1->EnableVertexDistanceCut();
+  TF1* cutCorrTPCoutVZEROmult = new TF1("cutCorrTPCoutVZEROmult", "[0]+[1]*x+[2]*x*x", 0., 1.e+5);
+  cutCorrTPCoutVZEROmult->SetParameters(-1000., 2.8, 1.2e-5);
+  if(prod.Contains("LHC17n") && !processor->GetRunOverMC()) 
+     evCut1->AddCut(AliReducedVarManager::kVZEROTotalMult, cutCorrTPCoutVZEROmult, 99999., kFALSE, AliReducedVarManager::kNTracksPerTrackingStatus+AliReducedVarManager::kTPCout, 0., 99998.);
+    
+  processor->AddEventCut(evCut1);
+  
+  // define some generic track cuts 
+  AliReducedTrackCut* spdAny = new AliReducedTrackCut("spdAny","");
+  spdAny->SetRequestSPDany();
+  AliReducedTrackCut* spdFirst = new AliReducedTrackCut("spdFirst","");
+  spdFirst->SetRequestSPDfirst();
+  AliReducedTrackCut* conversionElectron = new AliReducedTrackCut("conversionElectron","");
+  conversionElectron->SetTrackQualityFilterBit(kPhotonConversionV0Leg, kFALSE);
+  
+  SetupTrackingSystematicsCuts(processor, "prot36_pion34", kFALSE, 3.0, 3.6, 3.4);
+  //SetupTrackingSystematicsCuts(processor, "prot30_pion30", kTRUE, 3.0, 3.0, 3.0);
+  SetupTrackingSystematicsCuts(processor, "prot40_pion36", kFALSE, 3.0, 4.0, 3.6);
+  
+  //SetupPIDSystematicsCuts(processor, kTRUE);   // kFALSE -> use SPDfirst
+  
+  //SetupPIDSystematicsCutsSingleLeg(processor, kTRUE);       // calibrated electron band
+  //SetupPIDSystematicsCutsSingleLeg(processor, kFALSE);      // uncalibrated
+  
+  
+  // set track prefilter cuts
+  AliReducedTrackCut* prefTrackCut1 = new AliReducedTrackCut("prefCutPt09","prefilter P selection");
+  prefTrackCut1->SetTrackFilterBit(kPrefilterCut);
+  prefTrackCut1->AddCut(AliReducedVarManager::kPt, 0.8,100.0);
+  //prefTrackCut1->SetRequestTPCrefit();
+  prefTrackCut1->SetRequestITSrefit();
+  processor->AddPrefilterTrackCut(prefTrackCut1);  
+  
+  // MC truth info for reconstructed electron candidates
+  AliReducedTrackCut* trueElectron = new AliReducedTrackCut("TrueElectron", "reconstructed electrons with MC truth");
+  trueElectron->SetMCFilterBit(kJpsiDecayElectron);
+  processor->AddLegCandidateMCcut(trueElectron);  
+  
+  AliReducedTrackCut* trueElectronNonPrompt = new AliReducedTrackCut("TrueElectronNonPrompt", "reconstructed electrons with MC truth");
+  trueElectronNonPrompt->SetMCFilterBit(kJpsiNonPromptDecayElectron);
+  processor->AddLegCandidateMCcut(trueElectronNonPrompt);
+
+  AliReducedTrackCut* trueElectronPrompt = new AliReducedTrackCut("TrueElectronPrompt", "reconstructed electrons with MC truth");
+  trueElectronPrompt->SetMCFilterBit(kJpsiPromptDecayElectron);
+  processor->AddLegCandidateMCcut(trueElectronPrompt);    
+  
+  // MC truth selections(s) for the J/psi mother and electron daughters
+  AliReducedTrackCut* mcTruthJpsi = new AliReducedTrackCut("mcTruthJpsi", "Pure MC truth J/psi");
+  mcTruthJpsi->SetMCFilterBit(kJpsiInclusive);
+  mcTruthJpsi->AddCut(AliReducedVarManager::kRap, -0.9, 0.9);
+  AliReducedTrackCut* mcTruthJpsiElectron = new AliReducedTrackCut("mcTruthJpsiElectron", "Pure MC truth electron from J/psi");
+  mcTruthJpsiElectron->SetMCFilterBit(kJpsiDecayElectron);
+  mcTruthJpsiElectron->AddCut(AliReducedVarManager::kEta, -0.9, 0.9);
+  mcTruthJpsiElectron->AddCut(AliReducedVarManager::kPt, 1.0, 100.0);
+  processor->AddJpsiMotherMCCut(mcTruthJpsi, mcTruthJpsiElectron);  
+  
+  AliReducedTrackCut* mcTruthJpsiNonPrompt = new AliReducedTrackCut("mcTruthJpsiNonPrompt", "Pure MC truth J/psi");
+  mcTruthJpsiNonPrompt->SetMCFilterBit(kJpsiNonPrompt);
+  mcTruthJpsiNonPrompt->AddCut(AliReducedVarManager::kRap, -0.9, 0.9);
+  AliReducedTrackCut* mcTruthJpsiElectronNonPrompt = new AliReducedTrackCut("mcTruthJpsiElectronNonPrompt", "Pure MC truth electron from J/psi");
+  mcTruthJpsiElectronNonPrompt->SetMCFilterBit(kJpsiNonPromptDecayElectron);
+  mcTruthJpsiElectronNonPrompt->AddCut(AliReducedVarManager::kEta, -0.9, 0.9);
+  mcTruthJpsiElectronNonPrompt->AddCut(AliReducedVarManager::kPt, 1.0, 100.0);
+  processor->AddJpsiMotherMCCut(mcTruthJpsiNonPrompt, mcTruthJpsiElectronNonPrompt);
+
+  AliReducedTrackCut* mcTruthJpsiPrompt = new AliReducedTrackCut("mcTruthJpsiPrompt", "Pure MC truth J/psi");
+  mcTruthJpsiPrompt->SetMCFilterBit(kJpsiPrompt);
+  mcTruthJpsiPrompt->AddCut(AliReducedVarManager::kRap, -0.9, 0.9);
+  AliReducedTrackCut* mcTruthJpsiElectronPrompt = new AliReducedTrackCut("mcTruthJpsiElectronPrompt", "Pure MC truth electron from J/psi");
+  mcTruthJpsiElectronPrompt->SetMCFilterBit(kJpsiPromptDecayElectron);
+  mcTruthJpsiElectronPrompt->AddCut(AliReducedVarManager::kEta, -0.9, 0.9);
+  mcTruthJpsiElectronPrompt->AddCut(AliReducedVarManager::kPt, 1.0, 100.0);
+  processor->AddJpsiMotherMCCut(mcTruthJpsiPrompt, mcTruthJpsiElectronPrompt);    
+  
+  // set pair prefilter cuts
+  AliReducedVarCut* prefPairCut = new AliReducedVarCut("prefCutM50MeV","prefilter pair cuts");
+  prefPairCut->AddCut(AliReducedVarManager::kMass, 0.0, 0.05, kTRUE);
+  processor->AddPrefilterPairCut(prefPairCut);
+  
+  // Set pair cuts
+  AliReducedTrackCut* pairCut1 = new AliReducedTrackCut("Ptpair","Pt pair selection");
+  pairCut1->AddCut(AliReducedVarManager::kPt, 0.0,100.0);
+  pairCut1->AddCut(AliReducedVarManager::kRap, -0.9,0.9);
+  processor->AddPairCut(pairCut1);
+    
+  SetupHistogramManager(processor, prod);
+  SetupMixingHandler(processor);
+}
+
+
+//__________________________________________________________________________________________
+void SetupTrackingSystematicsCuts(AliReducedAnalysisJpsi2ee* processor, const Char_t* settingName, Bool_t useSPDany, Double_t eleCut, Double_t protCut, Double_t pionCut) {
+   //
+   // add tracking systematic cuts
+   //
+   Bool_t isMC = processor->GetRunOverMC();
+   
+   AliReducedTrackCut* commonVarCuts = new AliReducedTrackCut();
+   commonVarCuts->SetTrackFilterBit(kBasicCut);
+   commonVarCuts->AddCut(AliReducedVarManager::kPt, 1.0, 100.0);  
+   commonVarCuts->SetRejectKinks();
+   commonVarCuts->AddCut(AliReducedVarManager::kTPCncls, 70., 161.);   
+   if(isMC)   commonVarCuts->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, -1.0*eleCut, eleCut);
+   else      commonVarCuts->AddCut(AliReducedVarManager::kTPCnSigCorrected+AliReducedVarManager::kElectron, -1.0*eleCut, eleCut);
+   commonVarCuts->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kProton, protCut, 30000.0);
+   commonVarCuts->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kPion, pionCut, 30000.0);
+   
+   AliReducedTrackCut* spdAny = new AliReducedTrackCut("spdAny","");
+   spdAny->SetRequestSPDany();
+   AliReducedTrackCut* spdFirst = new AliReducedTrackCut("spdFirst","");
+   spdFirst->SetRequestSPDfirst();
+   
+   // add track cuts to the jpsi2ee task
+   AliReducedCompositeCut* spdAnyCut = new AliReducedCompositeCut(Form("%s_spdAny", settingName), "", kTRUE);
+   spdAnyCut->AddCut(commonVarCuts);
+   spdAnyCut->AddCut(spdAny);
+   AliReducedVarCut* itsExtraCuts = new AliReducedTrackCut();
+   itsExtraCuts->AddCut(AliReducedVarManager::kITSchi2, 0., 15.);
+   //itsExtraCuts->AddCut(AliReducedVarManager::kTPCchi2, 0., 4.);
+   itsExtraCuts->AddCut(AliReducedVarManager::kTPCNclusBitsFired, 6., 9.);
+   spdAnyCut->AddCut(itsExtraCuts);
+   processor->AddTrackCut(spdAnyCut);   
+   
+   AliReducedCompositeCut* spdFirstCut = new AliReducedCompositeCut(Form("%s_spdFirst", settingName), "", kTRUE);
+   spdFirstCut->AddCut(commonVarCuts);
+   spdFirstCut->AddCut(itsExtraCuts);
+   spdFirstCut->AddCut(spdFirst);
+   processor->AddTrackCut(spdFirstCut);
+   
+   AliReducedCompositeCut* itsCls3 = new AliReducedCompositeCut(Form("%s_itsCls3", settingName), "", kTRUE);
+   itsCls3->AddCut(commonVarCuts);
+   itsCls3->AddCut(itsExtraCuts);
+   AliReducedTrackCut* itsCls3ExtraCut = new AliReducedTrackCut();
+   itsCls3ExtraCut->AddCut(AliReducedVarManager::kITSncls, 2.9, 6.1);
+   itsCls3->AddCut(itsCls3ExtraCut);
+   processor->AddTrackCut(itsCls3);
+   
+   AliReducedCompositeCut* itsCls4 = new AliReducedCompositeCut(Form("%s_itsCls4", settingName), "", kTRUE);
+   itsCls4->AddCut(commonVarCuts);
+   itsCls4->AddCut(itsExtraCuts);
+   AliReducedTrackCut* itsCls4ExtraCut = new AliReducedTrackCut();
+   itsCls4ExtraCut->AddCut(AliReducedVarManager::kITSncls, 3.9, 6.1);
+   itsCls4->AddCut(itsCls4ExtraCut);
+   processor->AddTrackCut(itsCls4);
+   
+   AliReducedCompositeCut* itsCls5 = new AliReducedCompositeCut(Form("%s_itsCls5", settingName), "", kTRUE);
+   itsCls5->AddCut(commonVarCuts);
+   itsCls5->AddCut(itsExtraCuts);
+   AliReducedTrackCut* itsCls5ExtraCut = new AliReducedTrackCut();
+   itsCls5ExtraCut->AddCut(AliReducedVarManager::kITSncls, 4.9, 6.1);
+   itsCls5->AddCut(itsCls5ExtraCut);
+   //processor->AddTrackCut(itsCls5);
+   
+   AliReducedCompositeCut* itsChi2_11 = new AliReducedCompositeCut(Form("%s_itsChi2_11", settingName), "", kTRUE);
+   itsChi2_11->AddCut(commonVarCuts);
+   AliReducedTrackCut* itsChi2CommonExtraCuts = new AliReducedTrackCut();
+   if(useSPDany)  itsChi2CommonExtraCuts->SetRequestSPDany();
+   else                 itsChi2CommonExtraCuts->SetRequestSPDfirst();
+   itsChi2CommonExtraCuts->AddCut(AliReducedVarManager::kTPCchi2, 0., 4.);
+   itsChi2CommonExtraCuts->AddCut(AliReducedVarManager::kTPCNclusBitsFired, 6., 9.);
+   itsChi2_11->AddCut(itsChi2CommonExtraCuts);
+   AliReducedTrackCut* itsChi2_11_cut = new AliReducedTrackCut();
+   itsChi2_11_cut->AddCut(AliReducedVarManager::kITSchi2, 0., 11.);
+   itsChi2_11->AddCut(itsChi2_11_cut);
+   processor->AddTrackCut(itsChi2_11);
+   
+   AliReducedCompositeCut* itsChi2_9 = new AliReducedCompositeCut(Form("%s_itsChi2_9", settingName), "", kTRUE);
+   itsChi2_9->AddCut(commonVarCuts);
+   itsChi2_9->AddCut(itsChi2CommonExtraCuts);
+   AliReducedTrackCut* itsChi2_9_cut = new AliReducedTrackCut();
+   itsChi2_9_cut->AddCut(AliReducedVarManager::kITSchi2, 0., 9.);
+   itsChi2_9->AddCut(itsChi2_9_cut);
+   processor->AddTrackCut(itsChi2_9);
+   
+   AliReducedCompositeCut* itsChi2_7 = new AliReducedCompositeCut(Form("%s_itsChi2_7", settingName), "", kTRUE);
+   itsChi2_7->AddCut(commonVarCuts);
+   itsChi2_7->AddCut(itsChi2CommonExtraCuts);
+   AliReducedTrackCut* itsChi2_7_cut = new AliReducedTrackCut();
+   itsChi2_7_cut->AddCut(AliReducedVarManager::kITSchi2, 0., 7.);
+   itsChi2_7->AddCut(itsChi2_7_cut);
+   processor->AddTrackCut(itsChi2_7);
+   
+   AliReducedCompositeCut* itsChi2_13 = new AliReducedCompositeCut(Form("%s_itsChi2_13", settingName), "", kTRUE);
+   itsChi2_13->AddCut(commonVarCuts);
+   itsChi2_13->AddCut(itsChi2CommonExtraCuts);
+   AliReducedTrackCut* itsChi2_13_cut = new AliReducedTrackCut();
+   itsChi2_13_cut->AddCut(AliReducedVarManager::kITSchi2, 0., 13.);
+   itsChi2_13->AddCut(itsChi2_13_cut);
+   processor->AddTrackCut(itsChi2_13);
+   
+   AliReducedCompositeCut* itsChi2_17 = new AliReducedCompositeCut(Form("%s_itsChi2_17", settingName), "", kTRUE);
+   itsChi2_17->AddCut(commonVarCuts);
+   itsChi2_17->AddCut(itsChi2CommonExtraCuts);
+   AliReducedTrackCut* itsChi2_17_cut = new AliReducedTrackCut();
+   itsChi2_17_cut->AddCut(AliReducedVarManager::kITSchi2, 0., 17.);
+   itsChi2_17->AddCut(itsChi2_17_cut);
+   processor->AddTrackCut(itsChi2_17);
+   
+   AliReducedCompositeCut* itsChi2_19 = new AliReducedCompositeCut(Form("%s_itsChi2_19", settingName), "", kTRUE);
+   itsChi2_19->AddCut(commonVarCuts);
+   itsChi2_19->AddCut(itsChi2CommonExtraCuts);
+   AliReducedTrackCut* itsChi2_19_cut = new AliReducedTrackCut();
+   itsChi2_19_cut->AddCut(AliReducedVarManager::kITSchi2, 0., 19.);
+   itsChi2_19->AddCut(itsChi2_19_cut);
+   processor->AddTrackCut(itsChi2_19);
+   
+   AliReducedCompositeCut* tpcChi2_60 = new AliReducedCompositeCut(Form("%s_tpcChi2_60", settingName), "", kTRUE);
+   tpcChi2_60->AddCut(commonVarCuts);
+   AliReducedTrackCut* tpcChi2CommonExtraCuts = new AliReducedTrackCut();
+   if(useSPDany) tpcChi2CommonExtraCuts->SetRequestSPDany();
+   else                tpcChi2CommonExtraCuts->SetRequestSPDfirst();
+   tpcChi2CommonExtraCuts->AddCut(AliReducedVarManager::kITSchi2, 0., 15.);
+   tpcChi2CommonExtraCuts->AddCut(AliReducedVarManager::kTPCNclusBitsFired, 6., 9.);
+   tpcChi2_60->AddCut(tpcChi2CommonExtraCuts);
+   AliReducedTrackCut* tpcChi2_60_cut = new AliReducedTrackCut();
+   tpcChi2_60_cut->AddCut(AliReducedVarManager::kTPCchi2, 0., 6.);
+   tpcChi2_60->AddCut(tpcChi2_60_cut);
+   processor->AddTrackCut(tpcChi2_60);
+   
+   AliReducedCompositeCut* tpcChi2_50 = new AliReducedCompositeCut(Form("%s_tpcChi2_50", settingName), "", kTRUE);
+   tpcChi2_50->AddCut(commonVarCuts);
+   tpcChi2_50->AddCut(tpcChi2CommonExtraCuts);
+   AliReducedTrackCut* tpcChi2_50_cut = new AliReducedTrackCut();
+   tpcChi2_50_cut->AddCut(AliReducedVarManager::kTPCchi2, 0., 5.0);
+   tpcChi2_50->AddCut(tpcChi2_50_cut);
+   processor->AddTrackCut(tpcChi2_50);
+   
+   AliReducedCompositeCut* tpcChi2_35 = new AliReducedCompositeCut(Form("%s_tpcChi2_35", settingName), "", kTRUE);
+   tpcChi2_35->AddCut(commonVarCuts);
+   tpcChi2_35->AddCut(tpcChi2CommonExtraCuts);
+   AliReducedTrackCut* tpcChi2_35_cut = new AliReducedTrackCut();
+   tpcChi2_35_cut->AddCut(AliReducedVarManager::kTPCchi2, 0., 3.5);
+   tpcChi2_35->AddCut(tpcChi2_35_cut);
+   processor->AddTrackCut(tpcChi2_35);
+   
+   AliReducedCompositeCut* tpcChi2_30 = new AliReducedCompositeCut(Form("%s_tpcChi2_30", settingName), "", kTRUE);
+   tpcChi2_30->AddCut(commonVarCuts);
+   tpcChi2_30->AddCut(tpcChi2CommonExtraCuts);
+   AliReducedTrackCut* tpcChi2_30_cut = new AliReducedTrackCut();
+   tpcChi2_30_cut->AddCut(AliReducedVarManager::kTPCchi2, 0., 3.0);
+   tpcChi2_30->AddCut(tpcChi2_30_cut);
+   processor->AddTrackCut(tpcChi2_30);
+   
+   AliReducedCompositeCut* tpcChi2_25 = new AliReducedCompositeCut(Form("%s_tpcChi2_25", settingName), "", kTRUE);
+   tpcChi2_25->AddCut(commonVarCuts);
+   tpcChi2_25->AddCut(tpcChi2CommonExtraCuts);
+   AliReducedTrackCut* tpcChi2_25_cut = new AliReducedTrackCut();
+   tpcChi2_25_cut->AddCut(AliReducedVarManager::kTPCchi2, 0., 2.5);
+   tpcChi2_25->AddCut(tpcChi2_25_cut);
+   processor->AddTrackCut(tpcChi2_25);
+   
+   AliReducedCompositeCut* tpcSegm4 = new AliReducedCompositeCut(Form("%s_tpcSegm4", settingName), "", kTRUE);
+   tpcSegm4->AddCut(commonVarCuts);
+   AliReducedTrackCut* tpcSegmCommonExtraCuts = new AliReducedTrackCut();
+   if(useSPDany) tpcSegmCommonExtraCuts->SetRequestSPDany();
+   else                tpcSegmCommonExtraCuts->SetRequestSPDfirst();
+   tpcSegmCommonExtraCuts->AddCut(AliReducedVarManager::kITSchi2, 0., 15.);
+   tpcSegmCommonExtraCuts->AddCut(AliReducedVarManager::kTPCchi2, 0., 4.);
+   tpcSegm4->AddCut(tpcSegmCommonExtraCuts);
+   AliReducedTrackCut* tpcSegm4_cut = new AliReducedTrackCut();
+   tpcSegm4_cut->AddCut(AliReducedVarManager::kTPCNclusBitsFired, 4., 9.);
+   tpcSegm4->AddCut(tpcSegm4_cut);
+   processor->AddTrackCut(tpcSegm4);
+   
+   AliReducedCompositeCut* tpcSegm5 = new AliReducedCompositeCut(Form("%s_tpcSegm5", settingName), "", kTRUE);
+   tpcSegm5->AddCut(commonVarCuts);
+   tpcSegm5->AddCut(tpcSegmCommonExtraCuts);
+   AliReducedTrackCut* tpcSegm5_cut = new AliReducedTrackCut();
+   tpcSegm5_cut->AddCut(AliReducedVarManager::kTPCNclusBitsFired, 5., 9.);
+   tpcSegm5->AddCut(tpcSegm5_cut);
+   processor->AddTrackCut(tpcSegm5);
+   
+   AliReducedCompositeCut* tpcSegm7 = new AliReducedCompositeCut(Form("%s_tpcSegm7", settingName), "", kTRUE);
+   tpcSegm7->AddCut(commonVarCuts);
+   tpcSegm7->AddCut(tpcSegmCommonExtraCuts);
+   AliReducedTrackCut* tpcSegm7_cut = new AliReducedTrackCut();
+   tpcSegm7_cut->AddCut(AliReducedVarManager::kTPCNclusBitsFired, 7., 9.);
+   tpcSegm7->AddCut(tpcSegm7_cut);
+   processor->AddTrackCut(tpcSegm7);
+   
+   AliReducedCompositeCut* tpcCls90 = new AliReducedCompositeCut(Form("%s_tpcCls90", settingName), "", kTRUE);
+   tpcCls90->AddCut(commonVarCuts);
+   AliReducedTrackCut* tpcClsCommonExtraCuts = new AliReducedTrackCut();
+   if(useSPDany) tpcClsCommonExtraCuts->SetRequestSPDany();
+   else                tpcClsCommonExtraCuts->SetRequestSPDfirst();
+   tpcClsCommonExtraCuts->AddCut(AliReducedVarManager::kITSchi2, 0., 15.);
+   tpcClsCommonExtraCuts->AddCut(AliReducedVarManager::kTPCchi2, 0., 4.);
+   tpcClsCommonExtraCuts->AddCut(AliReducedVarManager::kTPCNclusBitsFired, 6., 9.);
+   tpcCls90->AddCut(tpcClsCommonExtraCuts);
+   AliReducedTrackCut* tpcCls90_cut = new AliReducedTrackCut();
+   tpcCls90_cut->AddCut(AliReducedVarManager::kTPCncls, 90.,160.0);
+   tpcCls90->AddCut(tpcCls90_cut);
+   processor->AddTrackCut(tpcCls90);
+   
+   AliReducedCompositeCut* tpcCls100 = new AliReducedCompositeCut(Form("%s_tpcCls100", settingName), "", kTRUE);
+   tpcCls100->AddCut(commonVarCuts);
+   tpcCls100->AddCut(tpcClsCommonExtraCuts);
+   AliReducedTrackCut* tpcCls100_cut = new AliReducedTrackCut();
+   tpcCls100_cut->AddCut(AliReducedVarManager::kTPCncls, 100.,160.0);
+   tpcCls100->AddCut(tpcCls100_cut);
+   processor->AddTrackCut(tpcCls100);
+   
+   AliReducedCompositeCut* tpcCls110 = new AliReducedCompositeCut(Form("%s_tpcCls110", settingName), "", kTRUE);
+   tpcCls110->AddCut(commonVarCuts);
+   tpcCls110->AddCut(tpcClsCommonExtraCuts);
+   AliReducedTrackCut* tpcCls110_cut = new AliReducedTrackCut();
+   tpcCls110_cut->AddCut(AliReducedVarManager::kTPCncls, 110.,160.0);
+   tpcCls110->AddCut(tpcCls110_cut);
+   processor->AddTrackCut(tpcCls110);
+   
+   AliReducedCompositeCut* tpcCls115 = new AliReducedCompositeCut(Form("%s_tpcCls115", settingName), "", kTRUE);
+   tpcCls115->AddCut(commonVarCuts);
+   tpcCls115->AddCut(tpcClsCommonExtraCuts);
+   AliReducedTrackCut* tpcCls115_cut = new AliReducedTrackCut();
+   tpcCls115_cut->AddCut(AliReducedVarManager::kTPCncls, 115.,160.0);
+   tpcCls115->AddCut(tpcCls115_cut);
+   processor->AddTrackCut(tpcCls115);
+   
+   AliReducedCompositeCut* tpcCls120 = new AliReducedCompositeCut(Form("%s_tpcCls120", settingName), "", kTRUE);
+   tpcCls120->AddCut(commonVarCuts);
+   tpcCls120->AddCut(tpcClsCommonExtraCuts);
+   AliReducedTrackCut* tpcCls120_cut = new AliReducedTrackCut();
+   tpcCls120_cut->AddCut(AliReducedVarManager::kTPCncls, 120.,160.0);
+   tpcCls120->AddCut(tpcCls120_cut);
+   processor->AddTrackCut(tpcCls120);
+   
+   AliReducedCompositeCut* tpcCls125 = new AliReducedCompositeCut(Form("%s_tpcCls125", settingName), "", kTRUE);
+   tpcCls125->AddCut(commonVarCuts);
+   tpcCls125->AddCut(tpcClsCommonExtraCuts);
+   AliReducedTrackCut* tpcCls125_cut = new AliReducedTrackCut();
+   tpcCls125_cut->AddCut(AliReducedVarManager::kTPCncls, 125.,160.0);
+   tpcCls125->AddCut(tpcCls125_cut);
+   //processor->AddTrackCut(tpcCls125);
+   
+   AliReducedCompositeCut* tpcCls130 = new AliReducedCompositeCut(Form("%s_tpcCls130", settingName), "", kTRUE);
+   tpcCls130->AddCut(commonVarCuts);
+   tpcCls130->AddCut(tpcClsCommonExtraCuts);
+   AliReducedTrackCut* tpcCls130_cut = new AliReducedTrackCut();
+   tpcCls130_cut->AddCut(AliReducedVarManager::kTPCncls, 130.,160.0);
+   tpcCls130->AddCut(tpcCls130_cut);
+   //processor->AddTrackCut(tpcCls130);
+}
+
+
+//__________________________________________________________________________________________
+void SetupPIDSystematicsCuts(AliReducedAnalysisJpsi2ee* task, Bool_t useSPDany) {
+   //
+   // add pid systematics cuts
+   //
+   AliReducedTrackCut* commonVarCuts = new AliReducedTrackCut("commonVarCuts","");
+   commonVarCuts->SetTrackFilterBit(kBasicCut);
+   commonVarCuts->AddCut(AliReducedVarManager::kPt, 1.0, 100.0);  
+   commonVarCuts->SetRejectKinks();
+   commonVarCuts->AddCut(AliReducedVarManager::kTPCncls, 70., 161.);
+   commonVarCuts->AddCut(AliReducedVarManager::kITSchi2, 0., 15.);
+   commonVarCuts->AddCut(AliReducedVarManager::kTPCchi2, 0., 4.0);
+   commonVarCuts->AddCut(AliReducedVarManager::kTPCNclusBitsFired, 6., 9.);
+   if(useSPDany) commonVarCuts->SetRequestSPDany();
+   else                commonVarCuts->SetRequestSPDfirst();
+   
+   Double_t eleCuts[3] = {3.0, 2.8, 2.6};
+   Double_t protCuts[4] = {3.6, 3.8, 4.0, 4.2};
+   Double_t pionCuts[5] = {3.2, 3.4, 3.6, 3.8, 4.0};
+   for(Int_t iele=0; iele<3; ++iele) {
+      for(Int_t ipro=0; ipro<4; ++ipro) {
+         for(Int_t ipio=0; ipio<5; ++ipio) {
+            
+            AliReducedCompositeCut* cut = new AliReducedCompositeCut(Form("electron%.0f_prot%.0f_pion%.0f", 
+                                                                          eleCuts[iele]*10, protCuts[ipro]*10, pionCuts[ipio]*10), "", kTRUE);
+            cut->AddCut(commonVarCuts);
+            AliReducedTrackCut* varCut = new AliReducedTrackCut(Form("electron%.0f_prot%.0f_pion%.0f_varCut", 
+                                                                     eleCuts[iele]*10, protCuts[ipro]*10, pionCuts[ipio]*10), "");
+            if(task->GetRunOverMC())
+               varCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, -1.0*eleCuts[iele], eleCuts[iele]);
+            else
+               varCut->AddCut(AliReducedVarManager::kTPCnSigCorrected+AliReducedVarManager::kElectron, -1.0*eleCuts[iele], eleCuts[iele]);
+            
+            varCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kProton, protCuts[ipro], 30000.0);
+            varCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kPion, pionCuts[ipio], 30000.0);
+            cut->AddCut(varCut);
+            
+            task->AddTrackCut(cut);
+         }  // end loop over pion rej settings
+      }  // end loop over proton rej settings
+   }  // end loop over electron inclusion setting
+}
+
+//__________________________________________________________________________________________
+void SetupPIDSystematicsCutsSingleLeg(AliReducedAnalysisJpsi2ee* processor, Bool_t calibrated) {
+   //
+   //
+   //
+   Bool_t isMC = processor->GetRunOverMC();
+   
+   AliReducedTrackCut* conversionElectron = new AliReducedTrackCut("conversionElectron","");
+   conversionElectron->SetTrackQualityFilterBit(kPhotonConversionV0Leg, kFALSE);
+   
+   AliReducedTrackCut* commonVarCuts = new AliReducedTrackCut("commonVarCuts","");
+   commonVarCuts->SetTrackFilterBit(kBasicCut);
+   //commonVarCuts->AddCut(AliReducedVarManager::kPt, 1.0, 100.0);  
+   //commonVarCuts->SetRejectKinks();
+   commonVarCuts->AddCut(AliReducedVarManager::kTPCncls, 70., 161.);
+   //commonVarCuts->AddCut(AliReducedVarManager::kITSchi2, 0., 15.);
+   //commonVarCuts->AddCut(AliReducedVarManager::kTPCchi2, 0., 4.0);
+   commonVarCuts->AddCut(AliReducedVarManager::kTPCNclusBitsFired, 6., 9.);
+   //if(useSPDany) commonVarCuts->SetRequestSPDany();
+   //else                commonVarCuts->SetRequestSPDfirst();
+   
+   AliReducedCompositeCut* basicElectronSelection = new AliReducedCompositeCut("basicElectronCut", "");
+   if(!isMC) basicElectronSelection->AddCut(conversionElectron);
+   basicElectronSelection->AddCut(commonVarCuts);
+   processor->AddTrackCut(basicElectronSelection);
+   
+   AliReducedCompositeCut* electron30 = new AliReducedCompositeCut(Form("electron30%s", (!calibrated ? "_uncalibrated" : "")), "", kTRUE);
+   electron30->AddCut(basicElectronSelection);
+   AliReducedTrackCut* electron30VarCut = new AliReducedTrackCut();
+   if(isMC || !calibrated)  electron30VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, -3.0, 3.0);
+   else       electron30VarCut->AddCut(AliReducedVarManager::kTPCnSigCorrected+AliReducedVarManager::kElectron, -3.0, 3.0);
+   electron30VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kProton, 4.0, 30000.0);
+   electron30VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kPion, 3.6, 30000.0);
+   electron30->AddCut(electron30VarCut);
+   processor->AddTrackCut(electron30);
+   
+   AliReducedCompositeCut* electron28 = new AliReducedCompositeCut(Form("electron28%s", (!calibrated ? "_uncalibrated" : "")), "", kTRUE);
+   electron28->AddCut(basicElectronSelection);
+   AliReducedTrackCut* electron28VarCut = new AliReducedTrackCut();
+   if(isMC || !calibrated)   electron28VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, -2.8, 2.8);
+   else        electron28VarCut->AddCut(AliReducedVarManager::kTPCnSigCorrected+AliReducedVarManager::kElectron, -2.8, 2.8);
+   electron28VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kProton, 4.0, 30000.0);
+   electron28VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kPion, 3.6, 30000.0);
+   electron28->AddCut(electron28VarCut);
+   processor->AddTrackCut(electron28);
+   
+   AliReducedCompositeCut* electron26 = new AliReducedCompositeCut(Form("electron26%s", (!calibrated ? "_uncalibrated" : "")), "", kTRUE);
+   electron26->AddCut(basicElectronSelection);
+   AliReducedTrackCut* electron26VarCut = new AliReducedTrackCut();
+   if(isMC || !calibrated)   electron26VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, -2.6, 2.6);
+   else        electron26VarCut->AddCut(AliReducedVarManager::kTPCnSigCorrected+AliReducedVarManager::kElectron, -2.6, 2.6);
+   electron26VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kProton, 4.0, 30000.0);
+   electron26VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kPion, 3.6, 30000.0);
+   electron26->AddCut(electron26VarCut);
+   processor->AddTrackCut(electron26);
+   
+   AliReducedCompositeCut* proton42 = new AliReducedCompositeCut(Form("proton42%s", (!calibrated ? "_uncalibrated" : "")), "", kTRUE);
+   proton42->AddCut(basicElectronSelection);
+   AliReducedTrackCut* proton42VarCut = new AliReducedTrackCut();
+   if(isMC || !calibrated)   proton42VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, -3.0, 3.0);
+   else        proton42VarCut->AddCut(AliReducedVarManager::kTPCnSigCorrected+AliReducedVarManager::kElectron, -3.0, 3.0);
+   proton42VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kProton, 4.2, 30000.0);
+   proton42VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kPion, 3.6, 30000.0);
+   proton42->AddCut(proton42VarCut);
+   processor->AddTrackCut(proton42);
+   
+   AliReducedCompositeCut* proton40 = new AliReducedCompositeCut(Form("proton40%s", (!calibrated ? "_uncalibrated" : "")), "", kTRUE);
+   proton40->AddCut(basicElectronSelection);
+   AliReducedTrackCut* proton40VarCut = new AliReducedTrackCut();
+   if(isMC || !calibrated)   proton40VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, -3.0, 3.0);
+   else        proton40VarCut->AddCut(AliReducedVarManager::kTPCnSigCorrected+AliReducedVarManager::kElectron, -3.0, 3.0);
+   proton40VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kProton, 4.0, 30000.0);
+   proton40VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kPion, 3.6, 30000.0);
+   proton40->AddCut(proton40VarCut);
+   processor->AddTrackCut(proton40);
+   
+   AliReducedCompositeCut* proton38 = new AliReducedCompositeCut(Form("proton38%s", (!calibrated ? "_uncalibrated" : "")), "", kTRUE);
+   proton38->AddCut(basicElectronSelection);
+   AliReducedTrackCut* proton38VarCut = new AliReducedTrackCut();
+   if(isMC || !calibrated)   proton38VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, -3.0, 3.0);
+   else        proton38VarCut->AddCut(AliReducedVarManager::kTPCnSigCorrected+AliReducedVarManager::kElectron, -3.0, 3.0);
+   proton38VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kProton, 3.8, 30000.0);
+   proton38VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kPion, 3.6, 30000.0);
+   proton38->AddCut(proton38VarCut);
+   processor->AddTrackCut(proton38);
+   
+   AliReducedCompositeCut* proton36 = new AliReducedCompositeCut(Form("proton36%s", (!calibrated ? "_uncalibrated" : "")), "", kTRUE);
+   proton36->AddCut(basicElectronSelection);
+   AliReducedTrackCut* proton36VarCut = new AliReducedTrackCut();
+   if(isMC || !calibrated)   proton36VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, -3.0, 3.0);
+   else        proton36VarCut->AddCut(AliReducedVarManager::kTPCnSigCorrected+AliReducedVarManager::kElectron, -3.0, 3.0);
+   proton36VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kProton, 3.6, 30000.0);
+   proton36VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kPion, 3.6, 30000.0);
+   proton36->AddCut(proton36VarCut);
+   processor->AddTrackCut(proton36);
+   
+   AliReducedCompositeCut* pion40 = new AliReducedCompositeCut(Form("pion40%s", (!calibrated ? "_uncalibrated" : "")), "", kTRUE);
+   pion40->AddCut(basicElectronSelection);
+   AliReducedTrackCut* pion40VarCut = new AliReducedTrackCut();
+   if(isMC || !calibrated)   pion40VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, -3.0, 3.0);
+   else        pion40VarCut->AddCut(AliReducedVarManager::kTPCnSigCorrected+AliReducedVarManager::kElectron, -3.0, 3.0);
+   pion40VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kProton, 4.0, 30000.0);
+   pion40VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kPion, 4.0, 30000.0);
+   pion40->AddCut(pion40VarCut);
+   processor->AddTrackCut(pion40);
+   
+   AliReducedCompositeCut* pion38 = new AliReducedCompositeCut(Form("pion38%s", (!calibrated ? "_uncalibrated" : "")), "", kTRUE);
+   pion38->AddCut(basicElectronSelection);
+   AliReducedTrackCut* pion38VarCut = new AliReducedTrackCut();
+   if(isMC || !calibrated)   pion38VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, -3.0, 3.0);
+   else        pion38VarCut->AddCut(AliReducedVarManager::kTPCnSigCorrected+AliReducedVarManager::kElectron, -3.0, 3.0);
+   pion38VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kProton, 4.0, 30000.0);
+   pion38VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kPion, 3.8, 30000.0);
+   pion38->AddCut(pion38VarCut);
+   processor->AddTrackCut(pion38);
+   
+   AliReducedCompositeCut* pion36 = new AliReducedCompositeCut(Form("pion36%s", (!calibrated ? "_uncalibrated" : "")), "", kTRUE);
+   pion36->AddCut(basicElectronSelection);
+   AliReducedTrackCut* pion36VarCut = new AliReducedTrackCut();
+   if(isMC || !calibrated)   pion36VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, -3.0, 3.0);
+   else        pion36VarCut->AddCut(AliReducedVarManager::kTPCnSigCorrected+AliReducedVarManager::kElectron, -3.0, 3.0);
+   pion36VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kProton, 4.0, 30000.0);
+   pion36VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kPion, 3.6, 30000.0);
+   pion36->AddCut(pion36VarCut);
+   processor->AddTrackCut(pion36);
+   
+   AliReducedCompositeCut* pion34 = new AliReducedCompositeCut(Form("pion34%s", (!calibrated ? "_uncalibrated" : "")), "", kTRUE);
+   pion34->AddCut(basicElectronSelection);
+   AliReducedTrackCut* pion34VarCut = new AliReducedTrackCut();
+   if(isMC || !calibrated)   pion34VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, -3.0, 3.0);
+   else        pion34VarCut->AddCut(AliReducedVarManager::kTPCnSigCorrected+AliReducedVarManager::kElectron, -3.0, 3.0);
+   pion34VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kProton, 4.0, 30000.0);
+   pion34VarCut->AddCut(AliReducedVarManager::kTPCnSig+AliReducedVarManager::kPion, 3.4, 30000.0);
+   pion34->AddCut(pion34VarCut);
+   processor->AddTrackCut(pion34);
+}
+
+
+//_________________________________________________________________
+void SetupMixingHandler(AliReducedAnalysisJpsi2ee* task) {
+   //
+   // setup the mixing handler
+   //
+   AliMixingHandler* handler = task->GetMixingHandler();
+   handler->SetPoolDepth(100);
+   handler->SetMixingThreshold(1.0);
+   handler->SetDownscaleEvents(1);
+   handler->SetDownscaleTracks(1);
+   
+   handler->AddMixingVariable(AliReducedVarManager::kCentVZERO, gkNCentBins, gCentLims);
+   //handler->AddMixingVariable(AliReducedVarManager::kVtxZ, gkNVtxZBins, gVtxZLims);
+}
+
+
+//_________________________________________________________________
+void SetupHistogramManager(AliReducedAnalysisJpsi2ee* task, TString prod /*="LHC10h"*/) {
+  //
+  // setup the histograms manager
+  //
+  AliReducedVarManager::SetDefaultVarNames();
+  
+  DefineHistograms(task, prod);
+  
+  AliReducedVarManager::SetUseVars(task->GetHistogramManager()->GetUsedVars());
+}
+
+
+//_________________________________________________________________
+void DefineHistograms(AliReducedAnalysisJpsi2ee* task, TString prod /*="LHC10h"*/) {
+  //
+  // define histograms
+  // NOTE: The DefineHistograms need to be called after the track cuts are defined because the name of the cuts
+  //           are used in the histogram lists
+   // NOTE: The name of the pair histogram lists for event mixing need to contain "PairMEPP", "PairMEPM", "PairMEMM", in their name, see below.
+   //  TODO: make needed changes such that this becomes less prone to mistakes
+   
+  AliHistogramManager* man = task->GetHistogramManager(); 
+   
+  TString histClasses = "";
+  histClasses += "Event_BeforeCuts;";
+  histClasses += "Event_AfterCuts;";
+  if(!task->GetRunOverMC()) {
+    histClasses += "EventTag_BeforeCuts;";   
+    histClasses += "EventTag_AfterCuts;";   
+    histClasses += "EventTriggers_BeforeCuts;";
+    histClasses += "EventTriggers_AfterCuts;";   
+  }
+  if(task->GetLoopOverTracks())
+    histClasses += "Track_BeforeCuts;";
+  if(!task->GetRunOverMC()) {
+    histClasses += "TrackStatusFlags_BeforeCuts;";
+  }
+  if(task->GetLoopOverTracks()) {
+    histClasses += "TrackITSclusterMap_BeforeCuts;";
+    histClasses += "TrackTPCclusterMap_BeforeCuts;";
+  }
+  if(task->GetRunOverMC()) {
+     for(Int_t mcSel=0; mcSel<task->GetNJpsiMotherMCCuts(); ++mcSel) {
+        histClasses += Form("%s_PureMCTruth_BeforeSelection;", task->GetJpsiMotherMCcutName(mcSel));
+        histClasses += Form("%s_PureMCTruth_AfterSelection;", task->GetJpsiMotherMCcutName(mcSel));
+     }
+  }
+  if(task->GetLoopOverTracks()) {
+    for(Int_t i=0; i<task->GetNTrackCuts(); ++i) {
+      TString cutName = task->GetTrackCutName(i);
+      histClasses += Form("Track_%s;", cutName.Data());
+      if(!task->GetRunOverMC()) {
+        histClasses += Form("TrackStatusFlags_%s;", cutName.Data());
+      }
+      histClasses += Form("TrackITSclusterMap_%s;", cutName.Data());
+      histClasses += Form("TrackTPCclusterMap_%s;", cutName.Data());
+      if(task->GetRunOverMC()) {
+         for(Int_t mcSel=0; mcSel<task->GetNLegCandidateMCcuts(); ++mcSel) {
+            histClasses += Form("Track_%s_%s;", cutName.Data(), task->GetLegCandidateMCcutName(mcSel));
+            histClasses += Form("TrackStatusFlags_%s_%s;", cutName.Data(), task->GetLegCandidateMCcutName(mcSel));
+            histClasses += Form("TrackITSclusterMap_%s_%s;", cutName.Data(), task->GetLegCandidateMCcutName(mcSel));
+            histClasses += Form("TrackTPCclusterMap_%s_%s;", cutName.Data(), task->GetLegCandidateMCcutName(mcSel));
+         }
+      }
+      if(!task->GetRunLikeSignPairing())
+         histClasses += Form("PairSEPM_%s;", cutName.Data());
+      else
+         histClasses += Form("PairSEPP_%s;PairSEPM_%s;PairSEMM_%s;", cutName.Data(), cutName.Data(), cutName.Data());
+      if(!task->GetRunOverMC())
+        histClasses += Form("PairMEPP_%s;PairMEPM_%s;PairMEMM_%s;", cutName.Data(), cutName.Data(), cutName.Data());
+      if(task->GetRunOverMC()) {
+         for(Int_t mcSel=0; mcSel<task->GetNLegCandidateMCcuts(); ++mcSel)
+            histClasses += Form("PairSEPM_%s_%s;", cutName.Data(), task->GetLegCandidateMCcutName(mcSel));
+      }
+    }
+  }
+  
+  AliReducedVarManager::SetRunNumbers(gRunList);
+  
+  const Int_t kNBCBins = 3600;
+  Double_t bcHistRange[2] = {-0.5,3599.5};
+  
+  // set the mass bin limits
+  for(Int_t i=0; i<gkNMassBins;++i) gMassBins[i] = 1.0+i*0.04;
+  
+  TString classesStr(histClasses);
+  TObjArray* arr=classesStr.Tokenize(";");
+  
+  cout << "Histogram classes included in the Histogram Manager" << endl;
+  for(Int_t iclass=0; iclass<arr->GetEntries(); ++iclass) {
+    TString classStr = arr->At(iclass)->GetName();
+    
+    if(classStr.Contains("PureMCTruth_")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       
+       man->AddHistogram(classStr.Data(), "MassMC_Pt_CentVZERO", "", kFALSE, gkNMassBins-1, gMassBins, AliReducedVarManager::kMassMC, gkNPtBins-1, gPtLims, AliReducedVarManager::kPtMC, gkNCentBins-1, gCentLims, AliReducedVarManager::kCentVZERO);
+       
+       man->AddHistogram(classStr.Data(), "MassMC", "MC mass", kFALSE, 200, 0., 5.0, AliReducedVarManager::kMassMC);
+       man->AddHistogram(classStr.Data(), "RapidityMC", "MC rapidity", kFALSE, 48, -1.2, 1.2, AliReducedVarManager::kRapMC);
+       man->AddHistogram(classStr.Data(), "PtMC", "p_{T} MC", kFALSE, 1000, 0., 10.0, AliReducedVarManager::kPtMC);
+       man->AddHistogram(classStr.Data(), "PtMC_coarse", "p_{T} MC", kFALSE, 20, 0., 20.0, AliReducedVarManager::kPtMC);
+       man->AddHistogram(classStr.Data(), "PhiMC", "MC #varphi", kFALSE, 100, 0., 6.3, AliReducedVarManager::kPhiMC);
+       man->AddHistogram(classStr.Data(), "EtaMC", "MC #eta", kFALSE, 100, -1.5, 1.5, AliReducedVarManager::kEtaMC);
+       man->AddHistogram(classStr.Data(), "PtMC_RapMC", "", kFALSE, 100, -1.2, 1.2, AliReducedVarManager::kRapMC, 100, 0., 15., AliReducedVarManager::kPtMC);
+       man->AddHistogram(classStr.Data(), "CosThetaStarCS", "cos(#theta^{*})_{CS}", kFALSE, 22, -1.1, 1.1, AliReducedVarManager::kPairThetaCS);
+       man->AddHistogram(classStr.Data(), "CosThetaStarCS_ptMC", "cos(#theta^{*})_{CS} vs MC pt", kFALSE, 22, -1.1, 1.1, AliReducedVarManager::kPairThetaCS, 50, 0., 1., AliReducedVarManager::kPtMC);
+       man->AddHistogram(classStr.Data(), "CosThetaStarHE", "cos(#theta^{*})_{HE}", kFALSE, 22, -1.1, 1.1, AliReducedVarManager::kPairThetaHE);
+       man->AddHistogram(classStr.Data(), "CosThetaStarHE_ptMC", "cos(#theta^{*})_{HE} vs MC pt", kFALSE, 22, -1.1, 1.1, AliReducedVarManager::kPairThetaHE, 100, 0., 1., AliReducedVarManager::kPtMC);
+       man->AddHistogram(classStr.Data(), "CosThetaStarHE_ptMC_coarse", "cos(#theta^{*})_{HE} vs MC pt", kFALSE, 10, -1.0, 1.0, AliReducedVarManager::kPairThetaHE, 20, 0., 20., AliReducedVarManager::kPtMC);
+       man->AddHistogram(classStr.Data(), "PhiStarCS", "#varphi^{*}_{CS}", kFALSE, 22, -3.3, 3.3, AliReducedVarManager::kPairPhiCS);
+       man->AddHistogram(classStr.Data(), "PhiStarHE", "#varphi^{*}_{HE}", kFALSE, 22, -3.3, 3.3, AliReducedVarManager::kPairPhiHE);
+       
+       continue;
+    }
+    
+    // Event wise histograms
+    if(classStr.Contains("EventTag_")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       TString tagNames = "";
+       tagNames += "AliAnalysisUtils 2013 selection;";
+       tagNames += "AliAnalysisUtils MV pileup;";
+       tagNames += "AliAnalysisUtils MV pileup, no BC check;";
+       tagNames += "AliAnalysisUtils MV pileup, min wght dist 10;";
+       tagNames += "AliAnalysisUtils MV pileup, min wght dist 5;";
+       tagNames += "IsPileupFromSPD(3,0.6,3.,2.,5.);";
+       tagNames += "IsPileupFromSPD(4,0.6,3.,2.,5.);";
+       tagNames += "IsPileupFromSPD(5,0.6,3.,2.,5.);";
+       tagNames += "IsPileupFromSPD(6,0.6,3.,2.,5.);";
+       tagNames += "IsPileupFromSPD(3,0.8,3.,2.,5.);";
+       tagNames += "IsPileupFromSPD(4,0.8,3.,2.,5.);";
+       tagNames += "IsPileupFromSPD(5,0.8,3.,2.,5.);";
+       tagNames += "IsPileupFromSPD(6,0.8,3.,2.,5.);";
+       tagNames += "vtx distance selected;";
+       man->AddHistogram(classStr.Data(), "EventTags", "Event tags", kFALSE,
+                         20, -0.5, 19.5, AliReducedVarManager::kEventTag, 0, 0.0, 0.0, AliReducedVarManager::kNothing, 0, 0.0, 0.0, AliReducedVarManager::kNothing, tagNames.Data());
+       man->AddHistogram(classStr.Data(), "EventTags_CentVZERO", "Event tags vs VZERO centrality", kFALSE,
+                         20, -0.5, 19.5, AliReducedVarManager::kEventTag, 9, 0.0, 90.0, AliReducedVarManager::kCentVZERO, 0, 0.0, 0.0, AliReducedVarManager::kNothing, tagNames.Data());
+       continue;
+    }
+    
+    if(classStr.Contains("EventTriggers_")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       TString triggerNames = "";
+       for(Int_t i=0; i<64; ++i) {triggerNames += AliReducedVarManager::fgkOfflineTriggerNames[i]; triggerNames+=";";}
+       
+       man->AddHistogram(classStr.Data(), "Triggers2", "", kFALSE,
+                         64, -0.5, 63.5, AliReducedVarManager::kOnlineTriggerFired2, 0, 0.0, 0.0, AliReducedVarManager::kNothing, 0, 0.0, 0.0, AliReducedVarManager::kNothing, triggerNames.Data());
+       man->AddHistogram(classStr.Data(), "CentVZERO_Triggers2", "", kFALSE,
+                         64, -0.5, 63.5, AliReducedVarManager::kOnlineTriggerFired2, 9, 0.0, 90.0, AliReducedVarManager::kCentVZERO, 0, 0.0, 0.0, AliReducedVarManager::kNothing, triggerNames.Data());
+       continue;
+    }
+    
+    if(classStr.Contains("Event_")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      man->AddHistogram(classStr.Data(),"RunNo","Run numbers",kFALSE, gkNRuns, -0.5, -0.5+gkNRuns, AliReducedVarManager::kRunID);
+      man->AddHistogram(classStr.Data(),"VtxX","Vtx X",kFALSE,300,-0.4,0.4,AliReducedVarManager::kVtxX);
+      man->AddHistogram(classStr.Data(),"VtxY","Vtx Y",kFALSE,300,-0.4,0.4,AliReducedVarManager::kVtxY);
+      man->AddHistogram(classStr.Data(),"VtxZ","Vtx Z",kFALSE,300,-15.,15.,AliReducedVarManager::kVtxZ);
+      man->AddHistogram(classStr.Data(),"CentVZERO","Centrality(VZERO)",kFALSE, 100, 0.0, 100.0, AliReducedVarManager::kCentVZERO);
+      man->AddHistogram(classStr.Data(),"CentVZERO_VtxZ","Centrality(VZERO) vs vtxZ",kFALSE, 50, 0.0, 100.0, AliReducedVarManager::kCentVZERO,
+         50, -10., 10., AliReducedVarManager::kVtxZ);
+      man->AddHistogram(classStr.Data(),"CentSPD","Centrality(SPD)",kFALSE, 100, 0.0, 100.0, AliReducedVarManager::kCentSPD);
+      man->AddHistogram(classStr.Data(),"CentSPD_VtxZ","Centrality(SPD) vs vtxZ",kFALSE, 50, 0.0, 100.0, AliReducedVarManager::kCentSPD,
+         50, -10., 10., AliReducedVarManager::kVtxZ);
+      man->AddHistogram(classStr.Data(),"CentQuality","Centrality quality",kFALSE, 500, 0., 500., AliReducedVarManager::kCentQuality);
+      man->AddHistogram(classStr.Data(),"SPDntracklets", "SPD #tracklets in |#eta|<1.0", kFALSE, 200, 0., 5000., AliReducedVarManager::kSPDntracklets);
+
+      man->AddHistogram(classStr.Data(),"VZEROmult", "", kFALSE, 500, 0.0, 50000., AliReducedVarManager::kVZEROTotalMult);
+      man->AddHistogram(classStr.Data(),"VZEROmult_VtxContributors", "", kFALSE, 
+		   200, 0.0, 40000., AliReducedVarManager::kVZEROTotalMult, 200, 0.0, 10000., AliReducedVarManager::kNVtxContributors);
+      man->AddHistogram(classStr.Data(),"VZEROmult_SPDntracklets", "", kFALSE, 
+                        200, 0.0, 5000., AliReducedVarManager::kSPDntracklets, 200, 0.0, 40000., AliReducedVarManager::kVZEROTotalMult);
+      man->AddHistogram(classStr.Data(),"IsPhysicsSelection","Physics selection flag",kFALSE,
+                        2,-0.5,1.5,AliReducedVarManager::kIsPhysicsSelection, 0,0.0,0.0,AliReducedVarManager::kNothing, 0,0.0,0.0,AliReducedVarManager::kNothing, "off;on");
+
+      man->AddHistogram(classStr.Data(),"NPosTracksAnalyzed","#positrons per event",kFALSE,100,0.,100.,AliReducedVarManager::kNtracksPosAnalyzed);
+      man->AddHistogram(classStr.Data(),"NNegTracksAnalyzed","#electrons per event",kFALSE,100,0.,100.,AliReducedVarManager::kNtracksNegAnalyzed);
+      man->AddHistogram(classStr.Data(),"NTotalTracksAnalyzed","#leg candidates per event",kFALSE,100,0.,100.,AliReducedVarManager::kNtracksAnalyzed);
+      man->AddHistogram(classStr.Data(),"NTotalPairsAnalyzed","#dielectron candidates per event",kFALSE,100,0.,100.,AliReducedVarManager::kNpairsSelected);
+
+      man->AddHistogram(classStr.Data(),"NTracksTPCout","",kFALSE,1800,0.,30000.,AliReducedVarManager::kNTracksPerTrackingStatus+AliReducedVarManager::kTPCout);
+      man->AddHistogram(classStr.Data(),"NTracksTPCout_VZEROmult","",kFALSE,100,0.,15000.,AliReducedVarManager::kNTracksPerTrackingStatus+AliReducedVarManager::kTPCout, 100, 0., 30000., AliReducedVarManager::kVZEROTotalMult);
+      man->AddHistogram(classStr.Data(),"NTotalTracksAnalyzed_NTracksTPCout_VZEROmult_prof","",kTRUE,20,0.,15000.,AliReducedVarManager::kNTracksPerTrackingStatus+AliReducedVarManager::kTPCout, 20, 0., 30000., AliReducedVarManager::kVZEROTotalMult, 10, 0., 10., AliReducedVarManager::kNtracksAnalyzed);
+      man->AddHistogram(classStr.Data(),"NTotalPairsAnalyzed_NTracksTPCout_VZEROmult_prof","",kTRUE,20,0.,15000.,AliReducedVarManager::kNTracksPerTrackingStatus+AliReducedVarManager::kTPCout, 20, 0., 30000., AliReducedVarManager::kVZEROTotalMult, 10, 0., 10., AliReducedVarManager::kNpairsSelected);
+      
+      man->AddHistogram(classStr.Data(),"NTracksAnalyzed_VZEROmult","",kFALSE,100,0.,100.,AliReducedVarManager::kNtracksAnalyzed, 300, 0., 40000., AliReducedVarManager::kVZEROTotalMult);
+      man->AddHistogram(classStr.Data(),"NTracksTPCoutVsVZEROmult","",kFALSE,1000,0.,10.,AliReducedVarManager::kNTracksTPCoutVsVZEROTotalMult);
+      man->AddHistogram(classStr.Data(),"NTracksTPCoutVsVZEROmult_CentVZERO","",kFALSE, 20, 0., 100., AliReducedVarManager::kCentVZERO, 1000,0.,10.,AliReducedVarManager::kNTracksTPCoutVsVZEROTotalMult);
+      man->AddHistogram(classStr.Data(),"NTracksAnalyzed_RunNo_prof","",kTRUE, gkNRuns, -0.5, -0.5 + gkNRuns, AliReducedVarManager::kRunID, 10, 0., 10., AliReducedVarManager::kNtracksAnalyzed);
+      man->AddHistogram(classStr.Data(),"NPairsAnalyzed_RunNo_prof","",kTRUE, gkNRuns, -0.5, -0.5 + gkNRuns, AliReducedVarManager::kRunID, 10, 0., 10., AliReducedVarManager::kNpairsSelected);
+      continue;
+    }  // end if className contains "Event"    
+    
+    // Track histograms
+    if(classStr.Contains("TrackITSclusterMap_")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       man->AddHistogram(classStr.Data(), "ITSlayerHit", "Hits in the ITS layers", kFALSE,
+                         6, 0.5, 6.5, AliReducedVarManager::kITSlayerHit);
+       //man->AddHistogram(classStr.Data(), "ITSlayerHit_Phi", "Hits in the ITS layers vs #varphi", kFALSE,
+         //                180, 0.0, 6.29, AliReducedVarManager::kPhi, 6, 0.5, 6.5, AliReducedVarManager::kITSlayerHit);
+       //man->AddHistogram(classStr.Data(), "ITSlayerHit_Eta", "Hits in the ITS layers vs #eta", kFALSE,
+         //                100, -1.0, 1.0, AliReducedVarManager::kEta, 6, 0.5, 6.5, AliReducedVarManager::kITSlayerHit);
+       continue;
+    }  // end of ITSclusterMap histogram definitions
+    
+    if(classStr.Contains("TrackTPCclusterMap_")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       man->AddHistogram(classStr.Data(), "TPCclusterMap", "TPC cluster map", kFALSE,
+                         8, -0.5, 7.5, AliReducedVarManager::kTPCclusBitFired);
+       //man->AddHistogram(classStr.Data(), "TPCclusterMap_Phi", "TPC cluster map vs #varphi", kFALSE,
+        //                 180, 0.0, 6.29, AliReducedVarManager::kPhi, 8, -0.5, 7.5, AliReducedVarManager::kTPCclusBitFired);
+       //man->AddHistogram(classStr.Data(), "TPCclusterMap_Eta", "TPC cluster map vs #eta", kFALSE,
+         //                100, -1.0, 1.0, AliReducedVarManager::kEta, 8, -0.5, 7.5, AliReducedVarManager::kTPCclusBitFired);
+       //man->AddHistogram(classStr.Data(), "TPCclusterMap_Pt", "TPC cluster map vs p_{T}", kFALSE,
+         //                100, 0.0, 10.0, AliReducedVarManager::kPt, 8, -0.5, 7.5, AliReducedVarManager::kTPCclusBitFired);
+       continue;
+    }  // end of TPCclusterMap histogram definitions
+    
+    TString trkStatusNames = "";
+    for(Int_t iflag=0; iflag<AliReducedVarManager::kNTrackingStatus; ++iflag) {
+       trkStatusNames += AliReducedVarManager::fgkTrackingStatusNames[iflag];
+       trkStatusNames += ";";
+    }
+    if(classStr.Contains("TrackStatusFlags_")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       man->AddHistogram(classStr.Data(), "TrackingFlags", "Tracking flags;;", kFALSE,
+                         AliReducedVarManager::kNTrackingStatus, -0.5, AliReducedVarManager::kNTrackingStatus-0.5, AliReducedVarManager::kTrackingFlag, 
+                         0, 0.0, 0.0, AliReducedVarManager::kNothing, 0, 0.0, 0.0, AliReducedVarManager::kNothing, trkStatusNames.Data());
+       continue;
+    }
+    
+    if(classStr.Contains("Track_")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      //man->AddHistogram(classStr.Data(), "P_Pin", "P vs Pin", kFALSE, 100, 0.0, 10.0, AliReducedVarManager::kP, 100, 0.0, 10.0, AliReducedVarManager::kPin);
+      man->AddHistogram(classStr.Data(), "Pt", "p_{T} distribution", kFALSE, 200, 0.0, 10.0, AliReducedVarManager::kPt);
+      man->AddHistogram(classStr.Data(), "P", "p distribution", kFALSE, 100, 0.0, 10.0, AliReducedVarManager::kP);
+      man->AddHistogram(classStr.Data(), "Pin", "p_{IN} distribution", kFALSE, 200, 0.0, 10.0, AliReducedVarManager::kPin);
+      man->AddHistogram(classStr.Data(), "Eta", "", kFALSE, 100, -1.0, 1.0, AliReducedVarManager::kEta);
+      man->AddHistogram(classStr.Data(), "Eta_Phi", "", kFALSE, 40, -1.0, 1.0, AliReducedVarManager::kEta, 36, 0., 6.29, AliReducedVarManager::kPhi);
+      man->AddHistogram(classStr.Data(), "Eta_P", "", kFALSE, 40, -1.0, 1.0, AliReducedVarManager::kEta, 50, 0., 5.0, AliReducedVarManager::kP);
+      man->AddHistogram(classStr.Data(), "Phi", "", kFALSE, 36, 0.0, 6.29, AliReducedVarManager::kPhi);
+      //man->AddHistogram(classStr.Data(), "DCAxy_Pt", "DCAxy", kFALSE, 100, -2.0, 2.0, AliReducedVarManager::kDcaXY, 50, 0.0, 5.0, AliReducedVarManager::kPt);
+      man->AddHistogram(classStr.Data(), "DCAxy", "DCAxy", kFALSE, 100, -2.5, 2.5, AliReducedVarManager::kDcaXY);
+      man->AddHistogram(classStr.Data(), "DCAz", "DCAz", kFALSE, 100, -5.0, 5.0, AliReducedVarManager::kDcaZ);
+      //man->AddHistogram(classStr.Data(), "DCAz_Pt", "DCAz", kFALSE, 100, -3.0, 3.0, AliReducedVarManager::kDcaZ, 50, 0.0, 5.0, AliReducedVarManager::kPt);
+      
+        man->AddHistogram(classStr.Data(),"ITSncls", "ITS nclusters", kFALSE, 7,-0.5,6.5,AliReducedVarManager::kITSncls);
+        man->AddHistogram(classStr.Data(),"ITSnclsShared", "ITS nclusters shared", kFALSE, 7,-0.5,6.5,AliReducedVarManager::kITSnclsShared);
+        /*man->AddHistogram(classStr.Data(),"Eta_Phi_ITSncls_prof","ITS <nclusters> vs (#eta,#phi)",kTRUE,
+                     36, -0.9, 0.9, AliReducedVarManager::kEta, 90, 0.0, 2.0*TMath::Pi(), AliReducedVarManager::kPhi, 7, -0.5, 6.5, AliReducedVarManager::kITSncls);
+        man->AddHistogram(classStr.Data(),"Eta_Phi_ITSnclsShared_prof","ITS <nclusters-shared> vs (#eta,#phi)",kTRUE,
+                          36, -0.9, 0.9, AliReducedVarManager::kEta, 90, 0.0, 2.0*TMath::Pi(), AliReducedVarManager::kPhi, 7, -0.5, 6.5, AliReducedVarManager::kITSnclsShared);*/
+	man->AddHistogram(classStr.Data(),"ITSchi2", "ITS #chi^{2}", kFALSE, 200,0.0,50.0, AliReducedVarManager::kITSchi2);
+        //man->AddHistogram(classStr.Data(),"ITSchi2_RunID_prof","",kTRUE, gkNRuns, -0.5, -0.5+gkNRuns, AliReducedVarManager::kRunID, 10, 0., 10., AliReducedVarManager::kITSchi2);
+        man->AddHistogram(classStr.Data(),"ITSchi2_ITSncls", "ITS #chi^{2} vs ITS clusters", kFALSE, 100,0.0,20.0, AliReducedVarManager::kITSchi2,7,-0.5,6.5, AliReducedVarManager::kITSncls);
+	man->AddHistogram(classStr.Data(),"Eta_Phi_ITSchi2_prof","ITS <#chi^{2}> vs (#eta,#phi)",kTRUE,
+                     36, -0.9, 0.9, AliReducedVarManager::kEta, 90, 0.0, 2.0*TMath::Pi(), AliReducedVarManager::kPhi, 100, 0.0, 1000, AliReducedVarManager::kITSchi2);        
+        man->AddHistogram(classStr.Data(),"ITSchi2_NTracksTPCout_VZEROmult_prof","",kTRUE,20,0.,15000.,AliReducedVarManager::kNTracksPerTrackingStatus+AliReducedVarManager::kTPCout, 20, 0., 30000., AliReducedVarManager::kVZEROTotalMult, 10, 0., 10., AliReducedVarManager::kITSchi2);
+        man->AddHistogram(classStr.Data(),"Chi2TPCConstrainedVsGlobal","",kFALSE,1000,0.,200.,AliReducedVarManager::kChi2TPCConstrainedVsGlobal);
+        
+        man->AddHistogram(classStr.Data(),"TPCncls","",kFALSE,160,-0.5,159.5,AliReducedVarManager::kTPCncls);
+        //man->AddHistogram(classStr.Data(),"TPCncls_RunID_prof","",kTRUE, gkNRuns, -0.5, -0.5+gkNRuns, AliReducedVarManager::kRunID, 10, 0., 10., AliReducedVarManager::kTPCncls);
+        man->AddHistogram(classStr.Data(),"TPCncls_NTracksTPCout_VZEROmult_prof","",kTRUE,20,0.,10000.,AliReducedVarManager::kNTracksPerTrackingStatus+AliReducedVarManager::kTPCout, 20, 0., 30000., AliReducedVarManager::kVZEROTotalMult, 10, 0., 10., AliReducedVarManager::kTPCncls);
+	man->AddHistogram(classStr.Data(),"TPCcrossedRows","", kFALSE, 160,-0.5,159.5,AliReducedVarManager::kTPCcrossedRows);
+        man->AddHistogram(classStr.Data(),"TPCfindableClusters","", kFALSE, 160,-0.5,159.5,AliReducedVarManager::kTPCnclsF);
+        man->AddHistogram(classStr.Data(),"TPCcrossedRowsOverFindableClusters","", kFALSE, 200,0.0,1.5,AliReducedVarManager::kTPCcrossedRowsOverFindableClusters);
+	man->AddHistogram(classStr.Data(),"TPCnclsShared","",kFALSE, 160,-0.5,159.5,AliReducedVarManager::kTPCnclsShared);
+        man->AddHistogram(classStr.Data(),"TPCnclsSharedRatio","",kFALSE, 200,0.,1.,AliReducedVarManager::kTPCnclsSharedRatio);        
+        
+        man->AddHistogram(classStr.Data(),"TPCchi2","",kFALSE, 200,0.0,10.0,AliReducedVarManager::kTPCchi2);
+        man->AddHistogram(classStr.Data(),"TPCchi2_Pt","",kFALSE, 200,0.0,10.0,AliReducedVarManager::kTPCchi2, 100, 0., 10.0, AliReducedVarManager::kPt);
+        man->AddHistogram(classStr.Data(),"TPCchi2_TPCncls", "TPC #chi^{2} vs TPC clusters", kFALSE, 100,0.0,10.0, AliReducedVarManager::kTPCchi2,160,0.,160., AliReducedVarManager::kTPCncls);
+        man->AddHistogram(classStr.Data(),"TPCchi2_CentVZERO", "TPC #chi^{2} vs CentVZERO", kFALSE, 100,0.0,10.0, AliReducedVarManager::kTPCchi2,20,0.,100., AliReducedVarManager::kCentVZERO);
+        man->AddHistogram(classStr.Data(),"Eta_TPCchi2","TPC #chi^{2} vs #eta",kFALSE,
+                          36, -0.9, 0.9, AliReducedVarManager::kEta, 100, 0.0, 10., AliReducedVarManager::kTPCchi2);
+        man->AddHistogram(classStr.Data(),"TPCsegments","",kFALSE, 9,0.0,9.0,AliReducedVarManager::kTPCNclusBitsFired);
+        
+        /*man->AddHistogram(classStr.Data(),"Eta_Phi_TPCncls_prof","TPC <nclusters> vs (#eta,#phi)",kTRUE,
+                     36, -0.9, 0.9, AliReducedVarManager::kEta, 90, 0.0, 2.0*TMath::Pi(), AliReducedVarManager::kPhi, 160, -0.5, 159.5, AliReducedVarManager::kTPCncls);    
+	man->AddHistogram(classStr.Data(),"Eta_Phi_TPCcrossedRows_prof","TPC <n crossed rows> vs (#eta,#phi)",kTRUE,
+                     36, -0.9, 0.9, AliReducedVarManager::kEta, 90, 0.0, 2.0*TMath::Pi(), AliReducedVarManager::kPhi, 160, -0.5, 159.5, AliReducedVarManager::kTPCcrossedRows);
+	man->AddHistogram(classStr.Data(),"Eta_Phi_TPCnclsF_prof","TPC <nclusters findable> vs (#eta,#phi)",kTRUE,
+                     36, -0.9, 0.9, AliReducedVarManager::kEta, 90, 0.0, 2.0*TMath::Pi(), AliReducedVarManager::kPhi, 160, -0.5, 159.5, AliReducedVarManager::kTPCnclsF);*/
+	man->AddHistogram(classStr.Data(),"Eta_Phi_TPCchi2_prof","TPC <#chi^{2}> vs (#eta,#phi)",kTRUE,
+                     36, -0.9, 0.9, AliReducedVarManager::kEta, 90, 0.0, 2.0*TMath::Pi(), AliReducedVarManager::kPhi, 160, -0.5, 159.5, AliReducedVarManager::kTPCchi2);
+        
+        man->AddHistogram(classStr.Data(),"TPCchi2_NTracksTPCout_VZEROmult_prof","",kTRUE,20,0.,15000.,AliReducedVarManager::kNTracksPerTrackingStatus+AliReducedVarManager::kTPCout, 20, 0., 30000., AliReducedVarManager::kVZEROTotalMult, 10, 0., 10., AliReducedVarManager::kTPCchi2);
+        /*man->AddHistogram(classStr.Data(),"Eta_Phi_TPCchi2","TPC #chi^{2} vs (#eta,#phi)",kFALSE,
+                          36, -0.9, 0.9, AliReducedVarManager::kEta, 90, 0.0, 2.0*TMath::Pi(), AliReducedVarManager::kPhi, 100, 0., 10.0, AliReducedVarManager::kTPCchi2); */
+        man->AddHistogram(classStr.Data(),"TPCsignal_Pin","TPC dE/dx vs. inner param P",kFALSE,
+                     100,0.0,10.0,AliReducedVarManager::kPin,100,49.5,150.5,AliReducedVarManager::kTPCsignal);
+	man->AddHistogram(classStr.Data(),"TPCsignalN","",kFALSE,160,-0.5,159.5,AliReducedVarManager::kTPCsignalN);
+	/*man->AddHistogram(classStr.Data(),"Eta_Phi_TPCsignalN_prof","TPC <nclusters pid> vs (#eta,#phi)",kTRUE,
+                     36, -0.9, 0.9, AliReducedVarManager::kEta, 90, 0.0, 2.0*TMath::Pi(), AliReducedVarManager::kPhi, 160, -0.5, 159.5, AliReducedVarManager::kTPCsignalN);    */
+        man->AddHistogram(classStr.Data(),"TPCnsigElectron_Pin","TPC N_{#sigma} electron vs. inner param P",kFALSE,
+                     100,0.0,10.0,AliReducedVarManager::kPin,100,-5.0,5.0,AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron);
+        man->AddHistogram(classStr.Data(),"TPCnsigElectron_Eta","TPC N_{#sigma} electron vs. #eta",kFALSE,
+                          36,-0.9,0.9,AliReducedVarManager::kEta,100,-5.0,5.0,AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron);
+        man->AddHistogram(classStr.Data(),"TPCnsigElectronCorrected_Pin","TPC N_{#sigma} electron corrected vs. inner param P",kFALSE,
+                          100,0.0,10.0,AliReducedVarManager::kPin,100,-5.0,5.0,AliReducedVarManager::kTPCnSigCorrected+AliReducedVarManager::kElectron);
+        man->AddHistogram(classStr.Data(),"TPCnsigElectronCorrected_Eta","TPC N_{#sigma} electron corrected vs. #eta",kFALSE,
+                          36,-0.9,0.9,AliReducedVarManager::kEta,100,-5.0,5.0,AliReducedVarManager::kTPCnSigCorrected+AliReducedVarManager::kElectron);
+        
+        man->AddHistogram(classStr.Data(),"TPCchi2_vs_TPCnsigElectron_Pin_prof","<TPC chi2> vs TPC N_{#sigma} electron and inner param P",kTRUE,
+                          20,0.0,5.0,AliReducedVarManager::kPin,30,-5.0,5.0,AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, 10, 0., 10., AliReducedVarManager::kTPCchi2);
+        man->AddHistogram(classStr.Data(),"TPCchi2_vs_TPCnsigElectron_Pin","TPC chi2 vs TPC N_{#sigma} electron and inner param P",kFALSE,
+                          20,0.0,5.0,AliReducedVarManager::kPin,30,-5.0,5.0,AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, 80, 0., 8., AliReducedVarManager::kTPCchi2);
+        man->AddHistogram(classStr.Data(),"TPCchi2_vs_TPCnsigElectronCorrected_Pin_prof","<TPC chi2> vs TPC N_{#sigma} electron corrected and inner param P",kTRUE,
+                          20,0.0,5.0,AliReducedVarManager::kPin,30,-5.0,5.0,AliReducedVarManager::kTPCnSigCorrected+AliReducedVarManager::kElectron, 10, 0., 10., AliReducedVarManager::kTPCchi2);
+        
+        //man->AddHistogram(classStr.Data(),"TOFbeta_P","TOF #beta vs P",kFALSE,
+          //           100,0.0,10.0,AliReducedVarManager::kP, 110,0.0,1.1,AliReducedVarManager::kTOFbeta);
+        
+        //man->AddHistogram(classStr.Data(),"TPCchi2_ITSchi2","",kFALSE, 100,0.0,10.0,AliReducedVarManager::kTPCchi2, 100,0.0,40.0,AliReducedVarManager::kITSchi2);
+        //man->AddHistogram(classStr.Data(),"ITSchi2_Chi2TPCconstrainedVsGlobal","",kFALSE, 500,0.0,1000.0,AliReducedVarManager::kChi2TPCConstrainedVsGlobal, 100,0.0,40.0,AliReducedVarManager::kITSchi2);
+        //man->AddHistogram(classStr.Data(),"TPCchi2_Chi2TPCconstrainedVsGlobal","",kFALSE, 500,0.0,1000.0,AliReducedVarManager::kChi2TPCConstrainedVsGlobal, 100,0.0,10.0,AliReducedVarManager::kTPCchi2);
+        
+        if(classStr.Contains("MCTruth")) {
+          man->AddHistogram(classStr.Data(), "PtMC", "p_{T} MC", kFALSE, 150, 0., 15.0, AliReducedVarManager::kPtMC);
+          //man->AddHistogram(classStr.Data(), "PtRec_PtMC", "p_{T} MC vs p_{T} reconstructed", kFALSE, 100, 0., 10.0, AliReducedVarManager::kPtMC, 100, 0., 10.0, AliReducedVarManager::kPt);
+          man->AddHistogram(classStr.Data(), "PhiMC", "#varphi MC", kFALSE, 180, 0., 6.3, AliReducedVarManager::kPhiMC);
+          //man->AddHistogram(classStr.Data(), "PhiRec_PhiMC", "#varphi MC vs #varphi reconstructed", kFALSE, 180, 0., 6.3, AliReducedVarManager::kPhiMC, 180, 0., 6.3, AliReducedVarManager::kPhi);
+          man->AddHistogram(classStr.Data(), "EtaMC", "#eta MC", kFALSE, 100, -1.0, 1.0, AliReducedVarManager::kEtaMC);
+          //man->AddHistogram(classStr.Data(), "EtaRec_EtaMC", "#eta MC vs #eta reconstructed", kFALSE, 100, -1.0, 1.0, AliReducedVarManager::kEtaMC, 100, -1.0, 1.0, AliReducedVarManager::kEta);          
+          //man->AddHistogram(classStr.Data(), "PDGcode0", "PDG code of the track", kFALSE, 12000, -6000., 6000.0, AliReducedVarManager::kPdgMC);
+          //man->AddHistogram(classStr.Data(), "PDGcode1", "PDG code of the track's mother", kFALSE, 12000, -6000., 6000.0, AliReducedVarManager::kPdgMC+1);
+          //man->AddHistogram(classStr.Data(), "PDGcode2", "PDG code of the track's grand-mother", kFALSE, 12000, -6000., 6000.0, AliReducedVarManager::kPdgMC+2);
+          //man->AddHistogram(classStr.Data(), "PDGcode3", "PDG code of the track's grand-grand mother", kFALSE, 12000, -6000., 6000.0, AliReducedVarManager::kPdgMC+3);
+        }
+      continue;
+    }  // end if "TrackQA"
+        
+    //Int_t vars[4] = {AliReducedVarManager::kMass, AliReducedVarManager::kPt, AliReducedVarManager::kCentVZERO, AliReducedVarManager::kVtxZ};
+    Int_t vars[3] = {AliReducedVarManager::kMass, AliReducedVarManager::kPt, AliReducedVarManager::kCentVZERO};   
+    
+    TArrayD pairHistBinLimits[3];
+    pairHistBinLimits[0] = TArrayD(gkNMassBins, gMassBins);
+    pairHistBinLimits[1] = TArrayD(gkNPtBins, gPtLims);
+    pairHistBinLimits[2] = TArrayD(gkNCentBins, gCentLims);
+    //pairHistBinLimits[3] = TArrayD(gkNVtxZBins, gVtxZLims);
+    
+    // Histograms for pairs
+    if(classStr.Contains("Pair")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      man->AddHistogram(classStr.Data(), "PairInvMass", "Differential pair inv. mass", 3, vars, pairHistBinLimits);
+      if(classStr.Contains("PairSE") || classStr.Contains("PairPrefilterSE")) {
+        man->AddHistogram(classStr.Data(), "PairType", "Pair type", kFALSE, 4, -0.5, 3.5, AliReducedVarManager::kPairType);
+	man->AddHistogram(classStr.Data(), "Mass", "Invariant mass", kFALSE, gkNMassBins-1, gMassBins, AliReducedVarManager::kMass);
+        man->AddHistogram(classStr.Data(), "Pt", "", kFALSE, 1000, 0.0, 10.0, AliReducedVarManager::kPt);
+        man->AddHistogram(classStr.Data(), "Pt_coarse", "", kFALSE, 20, 0.0, 20.0, AliReducedVarManager::kPt);
+	man->AddHistogram(classStr.Data(), "Rapidity", "Rapidity", kFALSE, 240, -1.2, 1.2, AliReducedVarManager::kRap);
+	man->AddHistogram(classStr.Data(), "Phi", "Azimuthal distribution", kFALSE, 315, 0.0, 6.3, AliReducedVarManager::kPhi);
+      }   // end if "QA"
+      
+      if(classStr.Contains("MCTruth")) {
+         man->AddHistogram(classStr.Data(), "PtMC", "p_{T} MC", kFALSE, 200, 0., 10.0, AliReducedVarManager::kPtMC);
+         man->AddHistogram(classStr.Data(), "PtMC_coarse", "p_{T} MC", kFALSE, 20, 0., 20.0, AliReducedVarManager::kPtMC);
+         //man->AddHistogram(classStr.Data(), "MassMC_Mass", "Invariant mass, MC vs reconstructed", kFALSE, 150, 2.0, 3.5, AliReducedVarManager::kMass,
+          //  150, 2.0, 3.5, AliReducedVarManager::kMassMC);
+         //man->AddHistogram(classStr.Data(), "PtMC_Pt", "pair pT, MC vs reconstructed", kFALSE, 150, 0.0, 15., AliReducedVarManager::kPt,
+          //                 150, 0.0, 15.0, AliReducedVarManager::kPtMC);
+         man->AddHistogram(classStr.Data(), "PtMC_MassMC", "", kFALSE, 100, 0.0, 1., AliReducedVarManager::kPtMC,
+                           30, 2.7, 3.3, AliReducedVarManager::kMassMC);
+         man->AddHistogram(classStr.Data(), "Pt_Mass", "", kFALSE, 100, 0.0, 1., AliReducedVarManager::kPt,
+                           30, 2.7, 3.3, AliReducedVarManager::kMass);
+         man->AddHistogram(classStr.Data(), "PtMC_Mass", "", kFALSE, 100, 0.0, 1., AliReducedVarManager::kPtMC,
+                           30, 2.7, 3.3, AliReducedVarManager::kMass);
+         man->AddHistogram(classStr.Data(), "Pt_MassMC", "", kFALSE, 100, 0.0, 1., AliReducedVarManager::kPt,
+                           30, 2.7, 3.3, AliReducedVarManager::kMassMC);
+         //man->AddHistogram(classStr.Data(), "PtMC_Pt_lowPtZoom", "pair pT, MC vs reconstructed", kFALSE, 100, 0.0, 0.5, AliReducedVarManager::kPt,
+          //                 100, 0.0, 0.5, AliReducedVarManager::kPtMC);
+         //man->AddHistogram(classStr.Data(), "PtMC_Pt_Mass", "pair pT, MC vs reconstructed, vs mass", kFALSE, 100, 0.0, 0.5, AliReducedVarManager::kPt,
+          //                 100, 0.0, 0.5, AliReducedVarManager::kPtMC, 15, 2.72, 3.32, AliReducedVarManager::kMass);
+         man->AddHistogram(classStr.Data(), "PtMC_Pt_Mass_coarse", "pair pT, MC vs reconstructed, vs mass", kFALSE, 25, 0.0, 0.5, AliReducedVarManager::kPt,
+                           25, 0.0, 0.5, AliReducedVarManager::kPtMC, 15, 2.72, 3.32, AliReducedVarManager::kMass);
+         
+         man->AddHistogram(classStr.Data(), "Mass_Pt_CentVZERO", "", kFALSE, gkNMassBins-1, gMassBins, AliReducedVarManager::kMass, gkNPtBins-1, gPtLims, AliReducedVarManager::kPt, gkNCentBins-1, gCentLims, AliReducedVarManager::kCentVZERO);
+      }
+      
+      continue;
+    }   // end if for Pair classes of histograms
+  }  // end loop over histogram classes
+}

--- a/PWGDQ/reducedTree/macros/attic/XeXe2017/AddTask_iarsene_testTask.C
+++ b/PWGDQ/reducedTree/macros/attic/XeXe2017/AddTask_iarsene_testTask.C
@@ -1,0 +1,786 @@
+void Setup(AliReducedAnalysisTaskSE* processor, TString prod="LHC10h");
+AliHistogramManager* SetupHistogramManager(TString prod="LHC10h");
+void DefineHistograms(AliHistogramManager* man, TString prod="LHC10h");
+
+//__________________________________________________________________________________________
+AliAnalysisTask* AddTask_iarsene_testTask(Bool_t isAliRoot=kTRUE, Int_t runMode=1, TString prod="LHC10h"){    
+   //
+   // isAliRoot=kTRUE for ESD/AOD analysis in AliROOT, kFALSE for root analysis on reduced trees
+   // runMode=1 (AliAnalysisTaskReducedEventProcessor::kUseOnTheFlyReducedEvents)
+   //               =2 (AliAnalysisTaskReducedEventProcessor::kUseEventsFromTree)
+   //
+   //get the current analysis manager
+
+  printf("INFO on AddTask_iarsene_testTask(): (isAliRoot, runMode) :: (%d,%d)", isAliRoot, runMode);
+
+  AliReducedAnalysisTest* testAnalysis = new AliReducedAnalysisTest("TestAnalysis","Test analysis");
+  testAnalysis->Init();
+  testAnalysis->SetProcessMC();
+  Setup(testAnalysis, prod);
+  // initialize an AliAnalysisTask which will wrapp the AliReducedAnalysisTest such that it can be run in an aliroot analysis train (e.g. LEGO, local analysis etc)
+  AliAnalysisTaskReducedEventProcessor* task = new AliAnalysisTaskReducedEventProcessor("ReducedEventAnalysisManager", runMode);
+  task->AddTask(testAnalysis);
+  
+  if(isAliRoot){
+     AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+     if (!mgr) {
+        Error("AddTask_iarsene_dst", "No analysis manager found.");
+        return 0;
+     }
+     
+     AliAnalysisDataContainer* cReducedEvent = NULL;
+     if(runMode==AliAnalysisTaskReducedEventProcessor::kUseOnTheFlyReducedEvents) {
+       printf("INFO on AddTask_iarsene_testTask(): use on the fly events ");
+       cReducedEvent = (AliAnalysisDataContainer*)mgr->GetContainers()->FindObject("ReducedEventDQ");
+       if(!cReducedEvent) {
+         printf("ERROR: In AddTask_iarsene_testTask(), couldn't find exchange container with ReducedEvent! ");
+         printf("             You need to use AddTask_iarsene_dst() in the on-the-fly reduced events mode!");
+         return 0x0;
+       }
+     }
+            
+     mgr->AddTask(task);
+      
+     if(runMode==AliAnalysisTaskReducedEventProcessor::kUseEventsFromTree) 
+        mgr->ConnectInput(task,  0, mgr->GetCommonInputContainer());
+      
+     if(runMode==AliAnalysisTaskReducedEventProcessor::kUseOnTheFlyReducedEvents) 
+       mgr->ConnectInput(task, 0, cReducedEvent);
+  
+     AliAnalysisDataContainer *cOutputHist = mgr->CreateContainer("testHistos", THashList::Class(),
+                                                                  AliAnalysisManager::kOutputContainer, "AnalysisHistograms_testTask.root");
+     mgr->ConnectOutput(task, 1, cOutputHist );
+  }
+  
+  return task;
+}
+
+
+//_________________________________________________________________
+void Setup(AliReducedAnalysisTest* processor, TString prod /*="LHC10h"*/) {
+  //
+  // Configure the event processor
+  // Setup histograms, handlers, cuts, etc.
+  //
+   if(prod.Contains("LHC15o")) {
+      TFile* grpFile = TFile::Open("/home/iarsene/work/ALICE/treeAnalysis/newdst/development/test/grpData_LHC15o_allRuns.root");
+      AliReducedVarManager::SetLHCDataInfo((TH1F*)grpFile->Get("lumiTotal"), (TH1F*)grpFile->Get("intTotal0"), 
+                                           (TH1F*)grpFile->Get("intTotal1"), (TH1I*)grpFile->Get("fillNumber"));
+      AliReducedVarManager::SetGRPDataInfo((TH1I*)grpFile->Get("dipolePolarity"), (TH1I*)grpFile->Get("l3Polarity"), 
+                                           (TH1I*)grpFile->Get("timeStart"), (TH1I*)grpFile->Get("timeStop"));
+      grpFile->Close();
+   }
+  
+  // Set event cuts
+  AliReducedEventCut* evCut1 = new AliReducedEventCut("Centrality","Centrality selection");
+  //evCut1->AddCut(AliReducedVarManager::kCentVZERO, 0., 90.);
+  AliReducedEventCut* evCut2 = new AliReducedEventCut("VertexZ","Vertex selection");
+  evCut2->AddCut(AliReducedVarManager::kVtxZ, -25.0, 25.0);
+  //processor->AddEventCut(evCut1);
+  //evCut2->AddEventTriggerFilter(AliReducedVarManager::kTRD);
+  //evCut2->AddEventL1InputFilter((UInt_t(1)<<10));          // HSE
+  evCut2->AddCut(AliReducedVarManager::kIsPhysicsSelection, 0.1, 2.);   // request physics selection
+  processor->AddEventCut(evCut2);
+  
+  // Set track cuts
+  AliReducedTrackCut* trackCut1 = new AliReducedTrackCut("Pt","Pt selection");
+  trackCut1->AddCut(AliReducedVarManager::kPt, 0.,100.0);
+  trackCut1->AddCut(AliReducedVarManager::kEta, -1.5,1.5);
+  processor->AddTrackCut(trackCut1);  
+  
+  // Set pair cuts
+  AliReducedTrackCut* pairCut1 = new AliReducedTrackCut("Ptpair","Pt pair selection");
+  pairCut1->AddCut(AliReducedVarManager::kPt, 0.0,100.0);
+  //pairCut1->AddCut(AliReducedVarManager::kEta, -1.5,1.5);
+  processor->AddPairCut(pairCut1);
+  
+  // add pure MC filter names
+  if(processor->ProcessMC()) {
+     processor->AddMCBitNames("JpsiInclusive;JpsiNonPrompt;JpsiPrompt;");
+     processor->AddMCBitNames("JpsiInclusiveRadiative;JpsiInclusiveNonRadiative;");
+     processor->AddMCBitNames("electronFromJpsi;electronFromJpsiNonPrompt;electronFromJpsiPrompt;");
+     processor->AddMCBitNames("electronFromJpsiRadiative;electronFromJpsiNonRadiative;photonFromJpsiDecay;");
+  }
+  processor->AddTrackFilterBitNames("basicCuts;prefilterCut;");
+  //processor->AddTrackFilterBitNames("basicCuts;spdAny;spdFirst;tpc100;tpc120;tpcChi2_3;itsChi2_10;");
+  //processor->AddTrackFilterBitNames("eleInclusion_35;eleInclusion_30;protRej_30;protRej_35;protRej_40;");
+  //processor->AddTrackFilterBitNames("pionRej_30;pionRej_35;pionRej_40;basicCutRandom;");
+  
+  SetupHistogramManager(processor, processor->GetHistogramManager(), prod);
+}
+
+
+//_________________________________________________________________
+void SetupHistogramManager(AliReducedAnalysisTest* testTask, AliHistogramManager* man, TString prod /*="LHC10h"*/) {
+  //
+  // setup the histograms manager
+  //
+  AliReducedVarManager::SetDefaultVarNames();
+  
+  DefineHistograms(testTask, man, prod);
+  
+  AliReducedVarManager::SetUseVars(man->GetUsedVars());
+}
+
+
+//_________________________________________________________________
+void DefineHistograms(AliReducedAnalysisTest* testTask, AliHistogramManager* man, TString prod /*="LHC10h"*/) {
+  //
+  // define histograms
+  //
+   // check whether an MC handler is present
+   Bool_t hasMC=(AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler());
+   
+  TString histClasses = "";
+  histClasses += "Event_NoCuts;";        //ok
+  histClasses += "Event_AfterCuts;";     //ok
+  histClasses += "EvtTags;L0TriggerInput;L1TriggerInput;L2TriggerInput;";   //ok
+  histClasses += "L0InputCorrelation;L1InputCorrelation;L2InputCorrelation;";
+  histClasses += "OnlineTriggers_vs_L0TrigInputs;OnlineTriggers_vs_L1TrigInputs;OnlineTriggers_vs_L2TrigInputs;";  //ok
+  histClasses += "ITSclusterMap;TPCclusterMap;";   //ok
+  histClasses += "CaloClusters;";   //ok
+  histClasses += "OnlineTriggers_NoCuts;";  //ok
+  histClasses += "OnlineTriggers_AfterCuts;";    //ok
+  histClasses += "TriggerCorrelation_NoCuts;";
+  histClasses += "TriggerCorrelation_AfterCuts;";
+  histClasses += "TrackQA_GammaLeg;";         //ok
+  histClasses += "TrackQA_PureGammaLeg;";
+  histClasses += "TrackQA_K0sLeg;";
+  histClasses += "TrackQA_PureK0sLeg;";
+  histClasses += "TrackQA_LambdaPosLeg;";
+  histClasses += "TrackQA_PureLambdaPosLeg;";
+  histClasses += "TrackQA_LambdaNegLeg;";
+  histClasses += "TrackQA_PureLambdaNegLeg;";
+  histClasses += "TrackQA_ALambdaPosLeg;";
+  histClasses += "TrackQA_PureALambdaPosLeg;";
+  histClasses += "TrackQA_ALambdaNegLeg;";
+  histClasses += "TrackQA_PureALambdaNegLeg;";
+  histClasses += "TrackQA_AllTracks;";            //ok
+  TString trkBitNames = testTask->GetTrackFilterBitNames();
+  TObjArray* trkBitNamesArr = trkBitNames.Tokenize(";");
+  for(Int_t iflag = 0; iflag<trkBitNamesArr->GetEntries(); ++iflag)
+     histClasses += Form("TrackQA_%s;", trkBitNamesArr->At(iflag)->GetName());
+  histClasses += "TrackingFlags;TrackQualityFlags;PairQualityFlags_Offline;PairQualityFlags_OnTheFly;";   //ok
+  histClasses += "CorrelationQualityFlagsTracks;CorrelationQualityFlagsPairs_Offline;CorrelationQualityFlagsPairs_OnTheFly;";
+  histClasses += "TrackQualityFlags_GammaLeg;TrackQualityFlags_K0sLeg;";
+  histClasses += "PairQA_OfflineGamma;";           // ok
+  histClasses += "PairQA_OfflinePureGamma;";
+  histClasses += "PairQA_OnTheFlyGamma;";
+  histClasses += "PairQA_OnTheFlyPureGamma;";
+  histClasses += "PairQA_OfflineK0s;";
+  histClasses += "PairQA_OfflinePureK0s;";
+  histClasses += "PairQA_OnTheFlyK0s;";
+  histClasses += "PairQA_OnTheFlyPureK0s;";
+  histClasses += "PairQA_OfflineLambda;";
+  histClasses += "PairQA_OfflinePureLambda;";
+  histClasses += "PairQA_OnTheFlyLambda;";
+  histClasses += "PairQA_OnTheFlyPureLambda;";
+  histClasses += "PairQA_OfflineALambda;";
+  histClasses += "PairQA_OfflinePureALambda;";
+  histClasses += "PairQA_OnTheFlyALambda;";
+  histClasses += "PairQA_OnTheFlyPureALambda;";
+  histClasses += "PairQA_Jpsi2EE_PP;PairQA_Jpsi2EE_PM;PairQA_Jpsi2EE_MM;";  
+  histClasses += "PairQA_ADzeroToKplusPiminus_PP;PairQA_ADzeroToKplusPiminus_PM;PairQA_ADzeroToKplusPiminus_MM;";
+  if(testTask->ProcessMC()) {
+    histClasses += "PureMCflags;CorrelationMCflags;";
+    //"PureMCflags;PureMCqa_Signal1;PureMCqa_Signal2;PureMCqa_Signal3;PureMCqa_Signal4;PureMCqa_Signal5;PureMCqa_Signal6;PureMCqa_Signal7;";
+    TObjArray* arrNames = testTask->GetMCBitNames().Tokenize(";"); 
+    for(Int_t iflag=0; iflag<arrNames->GetEntries(); ++iflag) 
+       histClasses += Form("PureMCqa_%s;", arrNames->At(iflag)->GetName());
+  }
+  
+  
+  Int_t runNBins = 0;
+  Double_t runHistRange[2] = {0.0,0.0};
+  
+  // Pb-Pb from 2010 run range is default: LHC10h
+  runNBins = 2500;
+  runHistRange[0] = 137100.;
+  runHistRange[1] = 139600.;
+  
+  // Pb-Pb of 2011
+  if(!prod.CompareTo("LHC11h")) {
+    runNBins = 2700;
+    runHistRange[0] = 167900.;
+    runHistRange[1] = 170600.;
+  }
+  
+  // Pb-Pb of 2015
+  if(!prod.CompareTo("LHC15o")) {
+     runNBins = 2100;
+     runHistRange[0] = 244900.;
+     runHistRange[1] = 247000.;
+  }
+  
+  // p-Pb of 2013
+  if(!prod.CompareTo("LHC13b") || !prod.CompareTo("LHC13c")) {
+    runNBins = 400;
+    runHistRange[0] = 195300.;
+    runHistRange[1] = 195700.;
+  }
+  
+  const Int_t kNBCBins = 3600;
+  Double_t bcHistRange[2] = {-0.5,3599.5};
+  
+  TString classesStr(histClasses);
+  TObjArray* arr=classesStr.Tokenize(";");
+  
+  for(Int_t iclass=0; iclass<arr->GetEntries(); ++iclass) {
+    TString classStr = arr->At(iclass)->GetName();
+    
+    // Event wise histograms
+    if(classStr.Contains("Event")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      man->AddHistogram(classStr.Data(),"RunNo","Run numbers",kFALSE, runNBins, runHistRange[0], runHistRange[1], AliReducedVarManager::kRunNo);
+      man->AddHistogram(classStr.Data(),"VtxX","Vtx X",kFALSE,300,-0.4,0.4,AliReducedVarManager::kVtxX);
+      man->AddHistogram(classStr.Data(),"VtxY","Vtx Y",kFALSE,300,-0.4,0.4,AliReducedVarManager::kVtxY);
+      man->AddHistogram(classStr.Data(),"VtxZ","Vtx Z",kFALSE,300,-15.,15.,AliReducedVarManager::kVtxZ);
+      man->AddHistogram(classStr.Data(),"NVtxContributors","",kFALSE,500,0.,10000.,AliReducedVarManager::kNVtxContributors);      
+      man->AddHistogram(classStr.Data(),"CentVZERO","Centrality(VZERO)",kFALSE, 100, 0.0, 100.0, AliReducedVarManager::kCentVZERO);
+      man->AddHistogram(classStr.Data(),"CentVZEROA","Centrality(VZERO-A)",kFALSE, 100, 0.0, 100.0, AliReducedVarManager::kCentVZEROA);
+      man->AddHistogram(classStr.Data(),"CentVZEROC","Centrality(VZERO-C)",kFALSE, 100, 0.0, 100.0, AliReducedVarManager::kCentVZEROC);
+      man->AddHistogram(classStr.Data(),"CentSPD","Centrality(SPD)",kFALSE, 100, 0.0, 100.0, AliReducedVarManager::kCentSPD);
+      man->AddHistogram(classStr.Data(),"CentTPC","Centrality(TPC)",kFALSE, 100, 0.0, 100.0, AliReducedVarManager::kCentTPC);
+      man->AddHistogram(classStr.Data(),"CentZDC","Centrality(ZDC)",kFALSE, 100, 0.0, 100.0, AliReducedVarManager::kCentZDC);
+      man->AddHistogram(classStr.Data(),"CentZNA","Centrality(ZNA)",kFALSE, 100, 0.0, 100.0, AliReducedVarManager::kCentZNA);
+      man->AddHistogram(classStr.Data(),"CentQuality","Centrality quality",kFALSE, 100, -50.5, 49.5, AliReducedVarManager::kCentQuality);
+      
+      TString multEstimators = "OnlineV0M;OnlineV0A;OnlineV0C;ADM;ADA;ADC;SPDClusters;SPDTracklets;RefMult05;RefMult08";
+      TObjArray* arrEstim=multEstimators.Tokenize(";");
+      
+      for(Int_t i=0;i<10;++i) {
+         TString estimStr = arrEstim->At(i)->GetName();
+         man->AddHistogram(classStr.Data(), Form("MultEstimator_%s", estimStr.Data()), Form("Multiplicity estimator %s", estimStr.Data()), kFALSE, 100, 0.0, 1000, AliReducedVarManager::kMultEstimatorOnlineV0M+i);
+         man->AddHistogram(classStr.Data(), Form("MultEstimatorPercentile_%s", estimStr.Data()), Form("Multiplicity estimator percentile %s", estimStr.Data()), kFALSE, 100, 0.0, 100, AliReducedVarManager::kMultEstimatorPercentileOnlineV0M+i);
+      }
+      
+      man->AddHistogram(classStr.Data(),"NTracksTotal","Number of total tracks per event",kFALSE,500,0.,20000.,AliReducedVarManager::kNtracksTotal);
+      man->AddHistogram(classStr.Data(),"NTracksSelected","Number of selected tracks per event",kFALSE,200,0.,200.,AliReducedVarManager::kNtracksSelected);
+      man->AddHistogram(classStr.Data(),"NV0sTotal","Number of V0 candidates per event",kFALSE,200,0.,30000.,AliReducedVarManager::kNV0total);
+      man->AddHistogram(classStr.Data(),"NV0sSelected","Number of selected V0 candidates per event",kFALSE,200,0.,2000.,AliReducedVarManager::kNV0selected);
+      man->AddHistogram(classStr.Data(),"EventNumberInESDFile","Event number in ESD file",kFALSE, 1000, 0.0, 1000.0, AliReducedVarManager::kEventNumberInFile);
+      man->AddHistogram(classStr.Data(),"BC","Bunch crossing",kFALSE,3500,0.,3500.,AliReducedVarManager::kBC);
+      man->AddHistogram(classStr.Data(),"TimeFromSOR","Events vs time",kFALSE, 450, 0., 450., AliReducedVarManager::kTimeRelativeSOR);
+      man->AddHistogram(classStr.Data(),"EventType","Event type",kFALSE,100,0.,100.,AliReducedVarManager::kEventType);
+      man->AddHistogram(classStr.Data(),"IsPhysicsSelection","Physics selection flag",kFALSE,
+                        2,-0.5,1.5,AliReducedVarManager::kIsPhysicsSelection, 0,0.0,0.0,AliReducedVarManager::kNothing, 0,0.0,0.0,AliReducedVarManager::kNothing, "off;on");
+      man->AddHistogram(classStr.Data(),"IsSPDPileup","Event has pileup (SPD)",kFALSE,
+                        2,-0.5,1.5,AliReducedVarManager::kIsSPDPileup, 0,0.0,0.0,AliReducedVarManager::kNothing, 0,0.0,0.0,AliReducedVarManager::kNothing, "no;yes");
+      man->AddHistogram(classStr.Data(),"IsSPDPileupMultBins","Event has pileup (SPD multiplicity bins)",kFALSE,
+                        2,-0.5,1.5,AliReducedVarManager::kIsSPDPileupMultBins, 0,0.0,0.0,AliReducedVarManager::kNothing, 0,0.0,0.0,AliReducedVarManager::kNothing, "no;yes");
+      man->AddHistogram(classStr.Data(),"IRIntClosestInt1Map","Closest out of bunch interactions Int1",kFALSE,7000,-3500.,3500.,AliReducedVarManager::kIRIntClosestIntMap);
+      man->AddHistogram(classStr.Data(),"IRIntClosestInt2Map","Closest out of bunch interactions Int2",kFALSE,7000,-3500.,3500.,AliReducedVarManager::kIRIntClosestIntMap+1);
+      man->AddHistogram(classStr.Data(),"VtxXtpc","Vtx X (TPC)",kFALSE,300,-1.,1.,AliReducedVarManager::kVtxXtpc);
+      man->AddHistogram(classStr.Data(),"VtxYtpc","Vtx Y (TPC)",kFALSE,300,-1.,1.,AliReducedVarManager::kVtxYtpc);
+      man->AddHistogram(classStr.Data(),"VtxZtpc","Vtx Z (TPC)",kFALSE,300,-15.,15.,AliReducedVarManager::kVtxZtpc);
+      man->AddHistogram(classStr.Data(),"DeltaVtxZ","Z_{global}-Z_{TPC}",kFALSE,300,-1.,1.,AliReducedVarManager::kDeltaVtxZ);
+      man->AddHistogram(classStr.Data(),"NVtxTPCContributors","",kFALSE,500,0.,10000.,AliReducedVarManager::kNVtxTPCContributors);
+      man->AddHistogram(classStr.Data(),"VtxXspd","Vtx X (SPD)",kFALSE,300,-1.,1.,AliReducedVarManager::kVtxXspd);
+      man->AddHistogram(classStr.Data(),"VtxYspd","Vtx Y (SPD)",kFALSE,300,-1.,1.,AliReducedVarManager::kVtxYspd);
+      man->AddHistogram(classStr.Data(),"VtxZspd","Vtx Z (SPD)",kFALSE,300,-15.,15.,AliReducedVarManager::kVtxZspd);
+      man->AddHistogram(classStr.Data(),"DeltaVtxZspd","Z_{global}-Z_{SPD}",kFALSE,300,-1.,1.,AliReducedVarManager::kDeltaVtxZspd);
+      man->AddHistogram(classStr.Data(),"NVtxSPDContributors","",kFALSE,500,0.,10000.,AliReducedVarManager::kNVtxSPDContributors);
+      man->AddHistogram(classStr.Data(),"NSPDpileups","No. SPD pileups",kFALSE,10,0.,10.,AliReducedVarManager::kNSPDpileups);
+      man->AddHistogram(classStr.Data(),"NTrackPileups","No. Track pileups",kFALSE,10,0.,10.,AliReducedVarManager::kNTrackPileups);
+      man->AddHistogram(classStr.Data(),"NTPCclusters","Number of TPC clusters per event",kFALSE,200,0.,100000.,AliReducedVarManager::kNTPCclusters);
+      man->AddHistogram(classStr.Data(),"NPMDtracks","No. PMD tracks",kFALSE,200,0.,200.,AliReducedVarManager::kNPMDtracks);
+      man->AddHistogram(classStr.Data(),"NTRDtracks","No. TRD tracks",kFALSE,200,0.,200.,AliReducedVarManager::kNTRDtracks);
+      man->AddHistogram(classStr.Data(),"NTRDtracklets","No. TRD tracklets",kFALSE,500,0.,50000.,AliReducedVarManager::kNTRDtracklets);
+      man->AddHistogram(classStr.Data(),"SPDntracklets", "SPD #tracklets in |#eta|<1.0", kFALSE, 200, 0., 5000., AliReducedVarManager::kSPDntracklets);
+      for(Int_t i=0; i<32; ++i)
+         man->AddHistogram(classStr.Data(),Form("SPDntracklets_%d",i), "", kFALSE, 100, 0., 300., AliReducedVarManager::kSPDntrackletsEtaBin+i);
+      for(Int_t il=0; il<2; ++il)
+         man->AddHistogram(classStr.Data(), Form("SPDfiredChips_layer%d",il+1), Form("SPD fired chips in layer %d",il+1), 
+                           kFALSE, 200, 0., 600., AliReducedVarManager::kSPDFiredChips+il);
+      for(Int_t il=0; il<6; ++il)
+         man->AddHistogram(classStr.Data(), Form("ITSclusters_layer%d",il+1), Form("ITS clusters in layer %d",il+1), 
+                          kFALSE, 200, 0., 10000., AliReducedVarManager::kITSnClusters+il);
+      man->AddHistogram(classStr.Data(), "SPDnSingleClusters", "SPD single clusters", 
+                          kFALSE, 200, 0., 6000., AliReducedVarManager::kSPDnSingleClusters);	
+      for(Int_t i=0; i<64; ++i)
+         man->AddHistogram(classStr.Data(), Form("VZEROmult_ch%d",i), "", kFALSE, 200, 0.0, 1000.0, AliReducedVarManager::kVZEROChannelMult+i);
+      man->AddHistogram(classStr.Data(),"VZEROAmult", "", kFALSE, 300, 0.0, 20000., AliReducedVarManager::kVZEROATotalMult);
+      man->AddHistogram(classStr.Data(),"VZEROCmult", "", kFALSE, 300, 0.0, 20000., AliReducedVarManager::kVZEROCTotalMult);
+      man->AddHistogram(classStr.Data(),"VZEROmult", "", kFALSE, 300, 0.0, 30000., AliReducedVarManager::kVZEROTotalMult);
+      man->AddHistogram(classStr.Data(),"VZEROAemptyChannels", "", kFALSE, 64, 0.0, 64., AliReducedVarManager::kVZEROAemptyChannels);
+      man->AddHistogram(classStr.Data(),"VZEROCemptyChannels", "", kFALSE, 64, 0.0, 64., AliReducedVarManager::kVZEROCemptyChannels);
+      for(Int_t i=0; i<10; ++i)
+         man->AddHistogram(classStr.Data(), Form("ZDCNenergy_ch%d",i), "", kFALSE, 200, 0.0, (i==0 || i==5 ? 100000.0 : 20000.), AliReducedVarManager::kZDCnEnergyCh+i);
+      for(Int_t i=0; i<10; ++i)
+         man->AddHistogram(classStr.Data(), Form("ZDCPenergy_ch%d",i), "", kFALSE, 200, 0.0, (i==0 || i==5 ? 40000.0 : 20000.), AliReducedVarManager::kZDCpEnergyCh+i);
+      for(Int_t i=0; i<26; ++i)
+         man->AddHistogram(classStr.Data(), Form("TZEROamp_ch%d",i), "", kFALSE, 200, 0.0, 100.0, AliReducedVarManager::kTZEROAmplitudeCh+i);
+      for(Int_t i=0; i<3; ++i)
+         man->AddHistogram(classStr.Data(), Form("TZERO_TOF%d",i), "", kFALSE, 200, -1000.0, 1000.0, AliReducedVarManager::kTZEROTOF+i);
+      for(Int_t i=0; i<3; ++i)
+         man->AddHistogram(classStr.Data(), Form("TZERO_TOFbest%d",i), "", kFALSE, 200, -1000.0, 1000.0, AliReducedVarManager::kTZEROTOFbest+i);
+      man->AddHistogram(classStr.Data(),"TZEROzVtx", "", kFALSE, 300, -15.0, 15., AliReducedVarManager::kTZEROzVtx);
+      man->AddHistogram(classStr.Data(),"TZEROstartTime", "", kFALSE, 1000, -1000.0, 1000., AliReducedVarManager::kTZEROstartTime);
+      man->AddHistogram(classStr.Data(),"TZEROpileup", "TZERO pileup", kFALSE, 2, -0.5, 1.5, AliReducedVarManager::kTZEROpileup);
+      man->AddHistogram(classStr.Data(),"TZEROsatellite", "TZERO satellite", kFALSE, 2, -0.5, 1.5, AliReducedVarManager::kTZEROsatellite);
+
+      continue;
+    }  // end if className contains "Event"    
+    
+    if(classStr.Contains("EvtTags")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      TString tagNames = "";
+      tagNames += "AliAnalysisUtils 2013 selection;";
+      tagNames += "AliAnalysisUtils MV pileup;";
+      tagNames += "AliAnalysisUtils MV pileup, no BC check;";
+      tagNames += "AliAnalysisUtils MV pileup, min wght dist 10;";
+      tagNames += "AliAnalysisUtils MV pileup, min wght dist 5;";
+      tagNames += "IsPileupFromSPD(3,0.6,3.,2.,5.);";
+      tagNames += "IsPileupFromSPD(4,0.6,3.,2.,5.);";
+      tagNames += "IsPileupFromSPD(5,0.6,3.,2.,5.);";
+      tagNames += "IsPileupFromSPD(6,0.6,3.,2.,5.);";
+      tagNames += "IsPileupFromSPD(3,0.8,3.,2.,5.);";
+      tagNames += "IsPileupFromSPD(4,0.8,3.,2.,5.);";
+      tagNames += "IsPileupFromSPD(5,0.8,3.,2.,5.);";
+      tagNames += "IsPileupFromSPD(6,0.8,3.,2.,5.);";
+      tagNames += "vtx distance selected;";
+      man->AddHistogram(classStr.Data(), "EventTags", "Event tags", kFALSE,
+	           64, -0.5, 63.5, AliReducedVarManager::kEventTag, 0, 0.0, 0.0, AliReducedVarManager::kNothing, 0, 0.0, 0.0, AliReducedVarManager::kNothing, tagNames.Data());
+      continue;
+    }
+    if(classStr.Contains("L0TriggerInput")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      TString trigInputs = "";
+      for(Int_t i=0; i<32; ++i) {trigInputs += Form("L0 Input %d", i); trigInputs+=";";}
+      man->AddHistogram(classStr.Data(), "L0TriggerInputs", "L0 trigger inputs", kFALSE,
+	           32, -0.5, 31.5, AliReducedVarManager::kL0TriggerInput, 0, 0.0, 0.0, AliReducedVarManager::kNothing, 0, 0.0, 0.0, AliReducedVarManager::kNothing, trigInputs.Data());
+      continue;
+    }
+    if(classStr.Contains("L0InputCorrelation")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       TString trigInputs = "";
+       for(Int_t i=0; i<32; ++i) {trigInputs += Form("L0 Input %d", i); trigInputs+=";";}
+       man->AddHistogram(classStr.Data(), "L0InputCorrelation", "L0 trigger inputs correlation", kFALSE,
+                         32, -0.5, 31.5, AliReducedVarManager::kL0TriggerInput, 32, -0.5, 31.5, AliReducedVarManager::kL0TriggerInput2, 0, 0.0, 0.0, AliReducedVarManager::kNothing, trigInputs.Data(), trigInputs.Data());
+       continue;
+    }
+    if(classStr.Contains("L1TriggerInput")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      TString trigInputs = "";
+      for(Int_t i=0; i<32; ++i) {trigInputs += Form("L1 Input %d", i); trigInputs+=";";}
+      man->AddHistogram(classStr.Data(), "L1TriggerInputs", "L1 trigger inputs", kFALSE,
+	           32, -0.5, 31.5, AliReducedVarManager::kL1TriggerInput, 0, 0.0, 0.0, AliReducedVarManager::kNothing, 0, 0.0, 0.0, AliReducedVarManager::kNothing, trigInputs.Data());
+      continue;
+    }
+    if(classStr.Contains("L1InputCorrelation")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       TString trigInputs = "";
+       for(Int_t i=0; i<32; ++i) {trigInputs += Form("L1 Input %d", i); trigInputs+=";";}
+       man->AddHistogram(classStr.Data(), "L1InputCorrelation", "L1 trigger inputs correlation", kFALSE,
+                         32, -0.5, 31.5, AliReducedVarManager::kL1TriggerInput, 32, -0.5, 31.5, AliReducedVarManager::kL1TriggerInput2, 0, 0.0, 0.0, AliReducedVarManager::kNothing, trigInputs.Data(), trigInputs.Data());
+       continue;
+    }
+    if(classStr.Contains("L2TriggerInput")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      TString trigInputs = "";
+      for(Int_t i=0; i<16; ++i) {trigInputs += Form("L2 Input %d", i); trigInputs+=";";}
+      man->AddHistogram(classStr.Data(), "L2TriggerInputs", "L2 trigger inputs", kFALSE,
+	           16, -0.5, 15.5, AliReducedVarManager::kL2TriggerInput, 0, 0.0, 0.0, AliReducedVarManager::kNothing, 0, 0.0, 0.0, AliReducedVarManager::kNothing, trigInputs.Data());
+      continue;
+    }
+    if(classStr.Contains("L2InputCorrelation")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       TString trigInputs = "";
+       for(Int_t i=0; i<32; ++i) {trigInputs += Form("L2 Input %d", i); trigInputs+=";";}
+       man->AddHistogram(classStr.Data(), "L2InputCorrelation", "L2 trigger inputs correlation", kFALSE,
+                         32, -0.5, 31.5, AliReducedVarManager::kL2TriggerInput, 32, -0.5, 31.5, AliReducedVarManager::kL2TriggerInput2, 0, 0.0, 0.0, AliReducedVarManager::kNothing, trigInputs.Data(), trigInputs.Data());
+       continue;
+    }
+    
+    // Offline trigger histograms
+    if(classStr.Contains("OnlineTriggers")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      TString triggerNames = "";
+      for(Int_t i=0; i<64; ++i) {triggerNames += AliReducedVarManager::fgkOfflineTriggerNames[i]; triggerNames+=";";}
+      
+      man->AddHistogram(classStr.Data(), "Triggers", "", kFALSE,
+	           64, -0.5, 63.5, AliReducedVarManager::kOnlineTriggerFired, 0, 0.0, 0.0, AliReducedVarManager::kNothing, 0, 0.0, 0.0, AliReducedVarManager::kNothing, triggerNames.Data());
+      man->AddHistogram(classStr.Data(), "CentVZERO_Triggers", "", kFALSE,
+	           64, -0.5, 63.5, AliReducedVarManager::kOnlineTriggerFired, 20, 0.0, 100.0, AliReducedVarManager::kCentVZERO, 0, 0.0, 0.0, AliReducedVarManager::kNothing, triggerNames.Data());
+      continue;
+    }
+    
+    if(classStr.Contains("TriggerCorrelation")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       TString triggerNames = "";
+       for(Int_t i=0; i<64; ++i) {triggerNames += AliReducedVarManager::fgkOfflineTriggerNames[i]; triggerNames+=";";}
+       
+       man->AddHistogram(classStr.Data(), "TriggerCorrelation", "", kFALSE,
+                         32, -0.5, 31.5, AliReducedVarManager::kOnlineTriggerFired, 32, -0.5, 31.5, AliReducedVarManager::kOnlineTriggerFired2, 0, 0.0, 0.0, AliReducedVarManager::kNothing, triggerNames.Data(), triggerNames.Data());
+       continue;
+    }
+    
+    
+    
+    if(classStr.Contains("OnlineTriggers_vs_L0TrigInputs")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      TString triggerNames = "";
+      for(Int_t i=0; i<64; ++i) {triggerNames += AliReducedVarManager::fgkOfflineTriggerNames[i]; triggerNames+=";";}
+      TString trigInputs = "";
+      for(Int_t i=0; i<32; ++i) {trigInputs += Form("L0 Input %d", i); trigInputs+=";";}
+      man->AddHistogram(classStr.Data(), "OnlineTriggers_L0TriggerInputs", "", kFALSE,
+	           64, -0.5, 63.5, AliReducedVarManager::kOnlineTriggerFired2, 32, -0.5, 31.5, AliReducedVarManager::kL0TriggerInput, 0, 0.0, 0.0, AliReducedVarManager::kNothing, 
+		   triggerNames.Data(), trigInputs);
+    }
+    if(classStr.Contains("OnlineTriggers_vs_L1TrigInputs")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      TString triggerNames = "";
+      for(Int_t i=0; i<64; ++i) {triggerNames += AliReducedVarManager::fgkOfflineTriggerNames[i]; triggerNames+=";";}
+      TString trigInputs = "";
+      for(Int_t i=0; i<32; ++i) {trigInputs += Form("L1 Input %d", i); trigInputs+=";";}
+      man->AddHistogram(classStr.Data(), "OnlineTriggers_L1TriggerInputs", "", kFALSE,
+	           64, -0.5, 63.5, AliReducedVarManager::kOnlineTriggerFired2, 32, -0.5, 31.5, AliReducedVarManager::kL1TriggerInput, 0, 0.0, 0.0, AliReducedVarManager::kNothing, 
+		   triggerNames.Data(), trigInputs);
+    }
+    if(classStr.Contains("OnlineTriggers_vs_L2TrigInputs")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      TString triggerNames = "";
+      for(Int_t i=0; i<64; ++i) {triggerNames += AliReducedVarManager::fgkOfflineTriggerNames[i]; triggerNames+=";";}
+      TString trigInputs = "";
+      for(Int_t i=0; i<16; ++i) {trigInputs += Form("L2 Input %d", i); trigInputs+=";";}
+      man->AddHistogram(classStr.Data(), "OnlineTriggers_L2TriggerInputs", "", kFALSE,
+	           64, -0.5, 63.5, AliReducedVarManager::kOfflineTriggerFired2, 16, -0.5, 15.5, AliReducedVarManager::kL2TriggerInput, 0, 0.0, 0.0, AliReducedVarManager::kNothing, 
+		   triggerNames.Data(), trigInputs);
+    }
+        
+    if(classStr.Contains("ITSclusterMap")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      man->AddHistogram(classStr.Data(), "ITSlayerHit", "Hits in the ITS layers", kFALSE,
+                   13, -6.5, 6.5, AliReducedVarManager::kITSlayerHit);
+      man->AddHistogram(classStr.Data(), "ITSlayerHit_Phi", "Hits in the ITS layers vs #varphi", kFALSE,
+                   100, 0.0, 6.29, AliReducedVarManager::kPhi, 13, -6.5, 6.5, AliReducedVarManager::kITSlayerHit);
+      man->AddHistogram(classStr.Data(), "ITSlayerHit_Eta", "Hits in the ITS layers vs #eta", kFALSE,
+                   100, -1.0, 1.0, AliReducedVarManager::kEta, 13, -6.5, 6.5, AliReducedVarManager::kITSlayerHit);
+      man->AddHistogram(classStr.Data(), "ITSlayerHit_DCAxy", "Hits in the ITS layers vs DCA_{xy}", kFALSE,
+                   1000, -0.5, 0.5, AliReducedVarManager::kDcaXY, 13, -6.5, 6.5, AliReducedVarManager::kITSlayerHit);
+      man->AddHistogram(classStr.Data(), "ITSlayerHit_DCAz", "Hits in the ITS layers vs DCA_{z}", kFALSE,
+                   1800, -1.0, 1.0, AliReducedVarManager::kDcaZ, 13, -6.5, 6.5, AliReducedVarManager::kITSlayerHit);
+      continue;
+    }  // end of ITSclusterMap histogram definitions
+    
+    if(classStr.Contains("TPCclusterMap")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      man->AddHistogram(classStr.Data(), "TPCclusterMap", "TPC cluster map", kFALSE,
+                   8, -0.5, 7.5, AliReducedVarManager::kTPCclusBitFired);
+      man->AddHistogram(classStr.Data(), "TPCclusterMap_Phi", "TPC cluster map vs #varphi", kFALSE,
+                   360, 0.0, 6.29, AliReducedVarManager::kPhi, 8, -0.5, 7.5, AliReducedVarManager::kTPCclusBitFired);
+      man->AddHistogram(classStr.Data(), "TPCclusterMap_Eta", "TPC cluster map vs #eta", kFALSE,
+                   100, -1.0, 1.0, AliReducedVarManager::kEta, 8, -0.5, 7.5, AliReducedVarManager::kTPCclusBitFired);
+      man->AddHistogram(classStr.Data(), "TPCclusterMap_Pt", "TPC cluster map vs p_{T}", kFALSE,
+                   100, 0.0, 10.0, AliReducedVarManager::kPt, 8, -0.5, 7.5, AliReducedVarManager::kTPCclusBitFired);
+      continue;
+    }  // end of TPCclusterMap histogram definitions
+    
+    // Calorimeter cluster histograms
+    if(classStr.Contains("CaloClusters")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      man->AddHistogram(classStr.Data(), "Energy", "Cluster energy", kFALSE,
+	           2, 0.5, 2.5, AliReducedVarManager::kEMCALdetector, 500, 0.0, 20.0, AliReducedVarManager::kEMCALclusterEnergy, 0, 0.0, 0.0, AliReducedVarManager::kNothing, "EMCAL;PHOS");
+      man->AddHistogram(classStr.Data(), "Dx", "Cluster dx", kFALSE,
+	           2, 0.5, 2.5, AliReducedVarManager::kEMCALdetector, 600, -300.0, 300.0, AliReducedVarManager::kEMCALclusterDx, 0, 0.0, 0.0, AliReducedVarManager::kNothing, "EMCAL;PHOS");
+      man->AddHistogram(classStr.Data(), "Dz", "Cluster dz", kFALSE,
+	           2, 0.5, 2.5, AliReducedVarManager::kEMCALdetector, 600, -300.0, 300.0, AliReducedVarManager::kEMCALclusterDz, 0, 0.0, 0.0, AliReducedVarManager::kNothing, "EMCAL;PHOS");
+      man->AddHistogram(classStr.Data(), "M20", "Cluster M20", kFALSE,
+	           2, 0.5, 2.5, AliReducedVarManager::kEMCALdetector, 400, -2.0, 200.0, AliReducedVarManager::kEMCALm20, 0, 0.0, 0.0, AliReducedVarManager::kNothing, "EMCAL;PHOS");
+      man->AddHistogram(classStr.Data(), "M02", "Cluster M02", kFALSE,
+	           2, 0.5, 2.5, AliReducedVarManager::kEMCALdetector, 400, -2.0, 200.0, AliReducedVarManager::kEMCALm02, 0, 0.0, 0.0, AliReducedVarManager::kNothing, "EMCAL;PHOS");
+      man->AddHistogram(classStr.Data(), "Dispersion", "Cluster dispersion", kFALSE,
+	           2, 0.5, 2.5, AliReducedVarManager::kEMCALdetector, 400, 0.0, 50.0, AliReducedVarManager::kEMCALdispersion, 0, 0.0, 0.0, AliReducedVarManager::kNothing, "EMCAL;PHOS");
+      man->AddHistogram(classStr.Data(), "M20_M02", "", kFALSE, 400, -2.0, 200., AliReducedVarManager::kEMCALm02, 400, -2.0, 200., AliReducedVarManager::kEMCALm20);
+      
+      man->AddHistogram(classStr.Data(), "CaloClusterEnergy_Run", "Cluster <energy> vs run", kTRUE,
+                   runNBins, runHistRange[0], runHistRange[1], AliReducedVarManager::kRunNo, 2, 0.5, 2.5, AliReducedVarManager::kEMCALdetector, 200, 0.0, 50.0, AliReducedVarManager::kEMCALclusterEnergy, "", "EMCAL;PHOS");
+      man->AddHistogram(classStr.Data(), "CaloClusterDx_Run", "Cluster <dx> vs run", kTRUE,
+                   runNBins, runHistRange[0], runHistRange[1], AliReducedVarManager::kRunNo, 2, 0.5, 2.5, AliReducedVarManager::kEMCALdetector, 200, -300.0, 300.0, AliReducedVarManager::kEMCALclusterDx, "", "EMCAL;PHOS");
+      man->AddHistogram(classStr.Data(), "CaloClusterDz_Run", "Cluster <dz> vs run", kTRUE,
+                   runNBins, runHistRange[0], runHistRange[1], AliReducedVarManager::kRunNo, 2, 0.5, 2.5, AliReducedVarManager::kEMCALdetector, 200, -300.0, 300.0, AliReducedVarManager::kEMCALclusterDz, "", "EMCAL;PHOS");
+    }  // end if "CaloClusters" histograms
+    
+    TString trkStatusNames = "";
+    for(Int_t iflag=0; iflag<AliReducedVarManager::kNTrackingStatus; ++iflag) {
+      trkStatusNames += AliReducedVarManager::fgkTrackingStatusNames[iflag];
+      trkStatusNames += ";";
+    }
+    TString trackQualityFlagNames = "EP;#gamma;K^{0}_{S};#Lambda;#bar{#Lambda};kink0;kink1;kink2;";
+    trackQualityFlagNames += "pure #gamma;pure K^{0}_{S};pure #Lambda;pure #bar{#Lambda};-kink0;-kink1;-kink2;";
+    //trackQualityFlagNames += "bayes e>0.5;bayes #pi>0.5;bayes K>0.5;bayes p>0.5;bayes>0.7;bayes>0.8;bayes>0.9";
+    trackQualityFlagNames += "AOD filter bit 0; AOD filter bit 1; AOD filter bit 2; AOD filter bit 3; AOD filter bit 4;";
+    trackQualityFlagNames += "AOD filter bit 5; AOD filter bit 6; AOD filter bit 7; AOD filter bit 8; AOD filter bit 9; ; TRD match; ; ; ; ; ;";
+    trackQualityFlagNames += trkBitNames.Data();
+    
+    if(classStr.Contains("TrackingFlags")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      man->AddHistogram(classStr.Data(), "TrackingFlags", "Tracking flags;;", kFALSE,
+	                AliReducedVarManager::kNTrackingStatus, -0.5, AliReducedVarManager::kNTrackingStatus-0.5, AliReducedVarManager::kTrackingFlag, 
+			0, 0.0, 0.0, AliReducedVarManager::kNothing, 0, 0.0, 0.0, AliReducedVarManager::kNothing, trkStatusNames.Data());
+      continue;
+    }
+    
+    if(classStr.Contains("TrackQualityFlags")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      man->AddHistogram(classStr.Data(), "TrackQualityFlags", "Track quality flags;;", kFALSE,
+	                64, -0.5, 63.5, AliReducedVarManager::kTrackQualityFlag, 0, 0.0, 0.0, AliReducedVarManager::kNothing, 
+			0, 0.0, 0.0, AliReducedVarManager::kNothing, trackQualityFlagNames.Data());
+      continue;
+    }
+    
+    if(classStr.Contains("CorrelationQualityFlagsTracks")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       man->AddHistogram(classStr.Data(), "CorrelationTrackQualityFlags", "Track quality flags correlation;;", kFALSE,
+                         64, -0.5, 63.5, AliReducedVarManager::kTrackQualityFlag, 64, -0.5, 63.5, AliReducedVarManager::kTrackQualityFlag2, 
+                         0, 0.0, 0.0, AliReducedVarManager::kNothing, trackQualityFlagNames.Data(), trackQualityFlagNames.Data());
+       continue;
+    }
+    
+    
+    TString mcFlagNames = testTask->GetMCBitNames();
+      
+    if(classStr.Contains("PureMCflags")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       man->AddHistogram(classStr.Data(), "MCFlags", "MC flags;;", kFALSE,
+                         32, -0.5, 31.5, AliReducedVarManager::kTrackMCFlag, 0, 0.0, 0.0, AliReducedVarManager::kNothing, 
+                         0, 0.0, 0.0, AliReducedVarManager::kNothing, mcFlagNames.Data());
+       continue;
+    }
+    if(classStr.Contains("CorrelationMCflags")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       man->AddHistogram(classStr.Data(), "CorrelationMCFlags", "MC flags correlation;;", kFALSE,
+                         32, -0.5, 31.5, AliReducedVarManager::kTrackMCFlag, 32, -0.5, 31.5, AliReducedVarManager::kTrackMCFlag2, 
+                         0, 0.0, 0.0, AliReducedVarManager::kNothing, mcFlagNames.Data(), mcFlagNames.Data());
+       continue;
+    }
+    
+    if(classStr.Contains("PureMCqa")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       
+       man->AddHistogram(classStr.Data(), "Pt", "p_{T} distribution", kFALSE, 1000, 0.0, 50.0, AliReducedVarManager::kPt);
+       man->AddHistogram(classStr.Data(), "Eta", "", kFALSE, 1000, -1.5, 1.5, AliReducedVarManager::kEta);
+       man->AddHistogram(classStr.Data(), "Phi", "", kFALSE, 1000, 0.0, 6.3, AliReducedVarManager::kPhi);
+       man->AddHistogram(classStr.Data(), "Charge", "", kFALSE, 2, -1.0, 1.0, AliReducedVarManager::kCharge);
+       continue;
+    }
+    
+    // Track histograms
+    if(classStr.Contains("TrackQA")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      man->AddHistogram(classStr.Data(), "Pt", "p_{T} distribution", kFALSE, 1000, 0.0, 50.0, AliReducedVarManager::kPt);
+      man->AddHistogram(classStr.Data(), "Eta", "", kFALSE, 1000, -1.5, 1.5, AliReducedVarManager::kEta);
+      man->AddHistogram(classStr.Data(), "Phi", "", kFALSE, 1000, 0.0, 6.3, AliReducedVarManager::kPhi);
+      man->AddHistogram(classStr.Data(), "Charge", "", kFALSE, 2, -1.0, 1.0, AliReducedVarManager::kCharge);
+      man->AddHistogram(classStr.Data(), "PtTPC", "p_{T} (TPC) distribution", kFALSE, 1000, 0.0, 50.0, AliReducedVarManager::kPtTPC);
+      man->AddHistogram(classStr.Data(), "EtaTPC", "#eta (TPC)", kFALSE, 1000, -1.5, 1.5, AliReducedVarManager::kEtaTPC);
+      man->AddHistogram(classStr.Data(), "PhiTPC", "#varphi (TPC)", kFALSE, 1000, 0.0, 6.3, AliReducedVarManager::kPhiTPC);
+      man->AddHistogram(classStr.Data(), "Pinner", "p inner param", kFALSE, 1000, 0.0, 50.0, AliReducedVarManager::kPin);
+      man->AddHistogram(classStr.Data(), "DCAxy", "DCAxy", kFALSE, 1000, -10.0, 10.0, AliReducedVarManager::kDcaXY);
+      man->AddHistogram(classStr.Data(), "DCAz", "DCAz", kFALSE, 1000, -10.0, 10.0, AliReducedVarManager::kDcaZ);
+      man->AddHistogram(classStr.Data(), "TrackLength", "Track length", kFALSE, 1000, 0.0, 1000.0, AliReducedVarManager::kTrackLength);
+      man->AddHistogram(classStr.Data(),"MassUsedForTracking","",kFALSE,40,0.,4.,AliReducedVarManager::kMassUsedForTracking);
+      man->AddHistogram(classStr.Data(),"ITSncls", "ITS nclusters", kFALSE, 7,-0.5,6.5,AliReducedVarManager::kITSncls);
+      man->AddHistogram(classStr.Data(),"Eta_Phi_ITSncls_prof","ITS <nclusters> vs (#eta,#phi)",kTRUE,
+                        192, -1.2, 1.2, AliReducedVarManager::kEta, 126, 0.0, 6.3, AliReducedVarManager::kPhi, 7, -0.5, 6.5, AliReducedVarManager::kITSncls);
+      man->AddHistogram(classStr.Data(),"ITSsignal", "ITS dE/dx", kFALSE, 400,0.0,1000.0, AliReducedVarManager::kITSsignal);
+      man->AddHistogram(classStr.Data(),"Eta_Phi_ITSsignal_prof","ITS <dE/dx> vs (#eta,#phi)",kTRUE,
+                        192, -1.2, 1.2, AliReducedVarManager::kEta, 126, 0.0, 6.3, AliReducedVarManager::kPhi, 100, 0.0, 1000, AliReducedVarManager::kITSsignal);
+      man->AddHistogram(classStr.Data(),"ITSchi2", "ITS #chi^{2}", kFALSE, 200,0.0,20.0, AliReducedVarManager::kITSchi2);
+      man->AddHistogram(classStr.Data(),"Eta_Phi_ITSchi2_prof","ITS <#chi^{2}> vs (#eta,#phi)",kTRUE,
+                        192, -1.2, 1.2, AliReducedVarManager::kEta, 126, 0.0, 6.3, AliReducedVarManager::kPhi, 100, 0.0, 1000, AliReducedVarManager::kITSchi2);
+      man->AddHistogram(classStr.Data(),"ITSnclsShared", "ITS nclusters shared", kFALSE, 7,-0.5,6.5,AliReducedVarManager::kITSnclsShared);
+      man->AddHistogram(classStr.Data(),"TPCncls","",kFALSE,160,-0.5,159.5,AliReducedVarManager::kTPCncls);
+      man->AddHistogram(classStr.Data(),"TPCcrossedRows","", kFALSE, 160,-0.5,159.5,AliReducedVarManager::kTPCcrossedRows);
+      man->AddHistogram(classStr.Data(),"TPCnclsF","",kFALSE, 160,-0.5,159.5,AliReducedVarManager::kTPCnclsF);
+      man->AddHistogram(classStr.Data(),"TPCnclsShared","",kFALSE, 160,-0.5,159.5,AliReducedVarManager::kTPCnclsShared);
+      man->AddHistogram(classStr.Data(),"TPCchi2","",kFALSE, 200,0.0,10.0,AliReducedVarManager::kTPCchi2);
+      man->AddHistogram(classStr.Data(),"Eta_Phi_TPCncls_prof","TPC <nclusters> vs (#eta,#phi)",kTRUE,
+                        192, -1.2, 1.2, AliReducedVarManager::kEta, 126, 0.0, 6.3, AliReducedVarManager::kPhi, 160, -0.5, 159.5, AliReducedVarManager::kTPCncls);    
+      man->AddHistogram(classStr.Data(),"Eta_Phi_TPCcrossedRows_prof","TPC <n crossed rows> vs (#eta,#phi)",kTRUE,
+                        192, -1.2, 1.2, AliReducedVarManager::kEta, 126, 0.0, 6.3, AliReducedVarManager::kPhi, 160, -0.5, 159.5, AliReducedVarManager::kTPCcrossedRows);
+      man->AddHistogram(classStr.Data(),"Eta_Phi_TPCnclsF_prof","TPC <nclusters findable> vs (#eta,#phi)",kTRUE,
+                        192, -1.2, 1.2, AliReducedVarManager::kEta, 126, 0.0, 6.3, AliReducedVarManager::kPhi, 160, -0.5, 159.5, AliReducedVarManager::kTPCnclsF);
+      man->AddHistogram(classStr.Data(),"Eta_Phi_TPCchi2_prof","TPC <#chi^{2}> vs (#eta,#phi)",kTRUE,
+                        192, -1.2, 1.2, AliReducedVarManager::kEta, 126, 0.0, 6.3, AliReducedVarManager::kPhi, 160, -0.5, 159.5, AliReducedVarManager::kTPCchi2);
+      man->AddHistogram(classStr.Data(),"TPCsignal_Pin","TPC dE/dx vs. inner param P",kFALSE,
+                        400,0.0,4.0,AliReducedVarManager::kPin,500,-0.5,499.5,AliReducedVarManager::kTPCsignal);
+      man->AddHistogram(classStr.Data(),"TPCsignalN","",kFALSE,160,-0.5,159.5,AliReducedVarManager::kTPCsignalN);
+      man->AddHistogram(classStr.Data(),"Eta_Phi_TPCsignalN_prof","TPC <nclusters pid> vs (#eta,#phi)",kTRUE,
+                        192, -1.2, 1.2, AliReducedVarManager::kEta, 126, 0.0, 6.3, AliReducedVarManager::kPhi, 160, -0.5, 159.5, AliReducedVarManager::kTPCsignalN);    
+      man->AddHistogram(classStr.Data(),"TPCnsigElectron_Pin","TPC N_{#sigma} electron vs. inner param P",kFALSE,
+                        200,0.0,10.0,AliReducedVarManager::kPin,100,-5.0,5.0,AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron);
+      man->AddHistogram(classStr.Data(),"TPCnsigElectron_Eta","TPC N_{#sigma} electron vs. #eta",kFALSE,
+                        100,-1.0,1.0,AliReducedVarManager::kEta,100,-5.0,5.0,AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron);
+      man->AddHistogram(classStr.Data(),"TPCnsigPion_Pin","TPC N_{#sigma} pion vs. inner param P",kFALSE,
+                        200,0.0,10.0,AliReducedVarManager::kPin,100,-5.0,5.0,AliReducedVarManager::kTPCnSig+AliReducedVarManager::kPion);
+      man->AddHistogram(classStr.Data(),"TPCnsigKaon_Pin","TPC N_{#sigma} kaon vs. inner param P",kFALSE,
+                        200,0.0,10.0,AliReducedVarManager::kPin,100,-5.0,5.0,AliReducedVarManager::kTPCnSig+AliReducedVarManager::kKaon);
+      man->AddHistogram(classStr.Data(),"TPCnsigProton_Pin","TPC N_{#sigma} proton vs. inner param P",kFALSE,
+                        200,0.0,10.0,AliReducedVarManager::kPin,100,-5.0,5.0,AliReducedVarManager::kTPCnSig+AliReducedVarManager::kProton);
+      man->AddHistogram(classStr.Data(),"TPCnsigElectron_Run","TPC N_{#sigma} electron vs. run",kTRUE,
+                        runNBins, runHistRange[0], runHistRange[1], AliReducedVarManager::kRunNo,100,-5.0,5.0,AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron);
+      man->AddHistogram(classStr.Data(),"TPCnsigPion_Run","TPC N_{#sigma} pion vs. run",kTRUE,
+                        runNBins, runHistRange[0], runHistRange[1], AliReducedVarManager::kRunNo,100,-5.0,5.0,AliReducedVarManager::kTPCnSig+AliReducedVarManager::kPion);
+      man->AddHistogram(classStr.Data(),"TPCnsigKaon_Run","TPC N_{#sigma} kaon vs. run",kTRUE,
+                        runNBins, runHistRange[0], runHistRange[1], AliReducedVarManager::kRunNo,100,-5.0,5.0,AliReducedVarManager::kTPCnSig+AliReducedVarManager::kKaon);
+      man->AddHistogram(classStr.Data(),"TPCnsigProton_Run","TPC N_{#sigma} proton vs. run",kTRUE,
+                        runNBins, runHistRange[0], runHistRange[1], AliReducedVarManager::kRunNo,100,-5.0,5.0,AliReducedVarManager::kTPCnSig+AliReducedVarManager::kProton);
+      man->AddHistogram(classStr.Data(),"TOFdeltaBC","TOF #delta BC", kFALSE, 7000, -3500.,3500.,AliReducedVarManager::kTOFdeltaBC);
+      man->AddHistogram(classStr.Data(),"TOFtime","TOF time", kFALSE, 500, 0., 1.0e+5,AliReducedVarManager::kTOFtime);
+      man->AddHistogram(classStr.Data(),"TOFdx","TOF dx", kFALSE, 500, -5., 5., AliReducedVarManager::kTOFdx);
+      man->AddHistogram(classStr.Data(),"TOFdz","TOF dz", kFALSE, 500, -5., 5., AliReducedVarManager::kTOFdz);
+      man->AddHistogram(classStr.Data(),"TOFmismatchProbab","TOF mismatch probability", kFALSE, 120, -0.1, 1.1, AliReducedVarManager::kTOFmismatchProbability);
+      man->AddHistogram(classStr.Data(),"TOFchi2","TOF #chi^{2}", kFALSE, 500, -1., 10., AliReducedVarManager::kTOFchi2);
+      man->AddHistogram(classStr.Data(),"TOFbeta_P","TOF #beta vs P",kFALSE,
+                        200,0.0,20.0,AliReducedVarManager::kP, 220,0.0,1.1,AliReducedVarManager::kTOFbeta);
+      man->AddHistogram(classStr.Data(),"TOFnsigElectron_P","TOF N_{#sigma} electron vs. P",kFALSE,
+                        200,0.0,20.0,AliReducedVarManager::kP, 100,-5.0,5.0,AliReducedVarManager::kTOFnSig+AliReducedVarManager::kElectron);
+      man->AddHistogram(classStr.Data(),"TOFnsigPion_P","TOF N_{#sigma} pion vs. P",kFALSE,
+                        200,0.0,20.0,AliReducedVarManager::kP, 100,-5.0,5.0,AliReducedVarManager::kTOFnSig+AliReducedVarManager::kPion);
+      man->AddHistogram(classStr.Data(),"TOFnsigKaon_P","TOF N_{#sigma} kaon vs. P",kFALSE,
+                        200,0.0,20.0,AliReducedVarManager::kP, 100,-5.0,5.0,AliReducedVarManager::kTOFnSig+AliReducedVarManager::kKaon);
+      man->AddHistogram(classStr.Data(),"TOFnsigProton_P","TOF N_{#sigma} proton vs. P",kFALSE,
+                        200,0.0,20.0,AliReducedVarManager::kP, 100,-5.0,5.0,AliReducedVarManager::kTOFnSig+AliReducedVarManager::kProton);
+      man->AddHistogram(classStr.Data(),"TRDntracklets","TRD ntracklets",kFALSE,
+                        7,-0.5,6.5,AliReducedVarManager::kTRDntracklets);
+      man->AddHistogram(classStr.Data(),"TRDntrackletsPID","TRD ntracklets PID",kFALSE,
+                        7,-0.5,6.5,AliReducedVarManager::kTRDntrackletsPID);
+      man->AddHistogram(classStr.Data(),"TRDprobabElectronLQ1D","TRD electron probability LQ1D",kFALSE,
+                        500,0.0,1.0,AliReducedVarManager::kTRDpidProbabilitiesLQ1D);
+      man->AddHistogram(classStr.Data(),"TRDprobabPionLQ1D","TRD pion probability LQ1D",kFALSE,
+                        500,0.0,1.0,AliReducedVarManager::kTRDpidProbabilitiesLQ1D+1);
+      man->AddHistogram(classStr.Data(),"TRDprobabElectronLQ2D","TRD electron probability LQ2D",kFALSE,
+                        500,0.0,1.0,AliReducedVarManager::kTRDpidProbabilitiesLQ2D);
+      man->AddHistogram(classStr.Data(),"TRDprobabPionLQ2D","TRD pion probability LQ2D",kFALSE,
+                        500,0.0,1.0,AliReducedVarManager::kTRDpidProbabilitiesLQ2D+1);
+      man->AddHistogram(classStr.Data(),"Eta_Phi_TRDntracklets_prof","TRD <ntracklets> vs (#eta,#phi)",kTRUE,
+                        192, -1.2, 1.2, AliReducedVarManager::kEta, 126, 0.0, 6.3, AliReducedVarManager::kPhi, 7, -0.5, 6.5, AliReducedVarManager::kTRDntracklets);   
+      man->AddHistogram(classStr.Data(),"Eta_Phi_TRDntrackletsPID_prof","TRD <ntracklets PID> vs (#eta,#phi)",kTRUE,
+                        192, -1.2, 1.2, AliReducedVarManager::kEta, 126, 0.0, 6.3, AliReducedVarManager::kPhi, 7, -0.5, 6.5, AliReducedVarManager::kTRDntrackletsPID);
+      man->AddHistogram(classStr.Data(), "MatchedCaloClusterId", "EMCAL/PHOS matched cluster id", kFALSE,
+                        5000, 0.0, 5000.0, AliReducedVarManager::kEMCALmatchedClusterId);
+      man->AddHistogram(classStr.Data(), "MatchedEnergy", "Energy from the calorimeter matched cluster", kFALSE,
+                        200, 0.0, 50.0, AliReducedVarManager::kEMCALmatchedEnergy);
+      man->AddHistogram(classStr.Data(), "MatchedEOverP", "E/P from the calorimeter matched cluster", kFALSE,
+                        300, 0.0, 1.5, AliReducedVarManager::kEMCALmatchedEOverP);
+      man->AddHistogram(classStr.Data(), "MatchedEOverP_P", "E/P from the calorimeter matched cluster vs P", kFALSE,
+                        10, 0.0, 10.0, AliReducedVarManager::kPin, 300, 0.0, 1.5, AliReducedVarManager::kEMCALmatchedEOverP);
+      man->AddHistogram(classStr.Data(),"MatchedEnergy_Run","Calorimeter matched energy vs run",kTRUE,
+                        runNBins, runHistRange[0], runHistRange[1], AliReducedVarManager::kRunNo, 100, 0.0, 50.0, AliReducedVarManager::kEMCALmatchedEnergy);
+      man->AddHistogram(classStr.Data(),"EMCALmatchedEOverP_Run","Calorimeter matched E/P vs run",kTRUE,
+                        runNBins, runHistRange[0], runHistRange[1], AliReducedVarManager::kRunNo, 100, 0.0, 2.0, AliReducedVarManager::kEMCALmatchedEOverP);
+      man->AddHistogram(classStr.Data(),"EMCALmatchedEnergy_P","Calorimeter matched energy vs momentum",kFALSE,
+                        100, 0.0, 10.0, AliReducedVarManager::kP, 100, 0.0, 10.0, AliReducedVarManager::kEMCALmatchedEnergy);
+      man->AddHistogram(classStr.Data(),"EMCALmatchedEnergy_CentVZERO","Calorimeter matched energy vs centrality VZERO",kTRUE,
+                        20, 0.0, 100.0, AliReducedVarManager::kCentVZERO, 100, 0.0, 10.0, AliReducedVarManager::kEMCALmatchedEnergy);
+      man->AddHistogram(classStr.Data(),"Eta_Phi_MatchedEnergy_prof","EMCAL matched cluster <energy> vs (#eta,#phi)",kTRUE,
+                        192, -1.2, 1.2, AliReducedVarManager::kEta, 126, 0.0, 6.3, AliReducedVarManager::kPhi, 100, 0.0, 10.0, AliReducedVarManager::kEMCALmatchedEnergy);
+      
+      Int_t vars[5] = {AliReducedVarManager::kTPCnSig+AliReducedVarManager::kElectron, AliReducedVarManager::kPin, AliReducedVarManager::kEta, AliReducedVarManager::kCentVZERO, AliReducedVarManager::kPhi};
+      const Int_t kNSigEleBins = 81;
+      Double_t sigEleBins[kNSigEleBins]; for(Int_t i=0; i<kNSigEleBins; i++) sigEleBins[i] = -4.0+0.1*i;
+      const Int_t kNPinBins = 9;
+      Double_t pinBins[kNPinBins] = {0.8, 1.0, 1.5, 2.0, 3.0, 4.0, 5.0, 7.0, 10.0};
+      const Int_t kNEtaBins = 19;
+      Double_t etaBins[kNEtaBins]; for(Int_t i=0; i<kNEtaBins; i++) etaBins[i] = -0.9+0.1*i;
+      const Int_t kNCentBins = 7;
+      Double_t centBins[kNCentBins] = {0.0, 10., 20., 30., 50., 70., 90.};
+      const Int_t kNPhiBins = 19;
+      Double_t phiBins[kNPhiBins]; for(Int_t i=0; i<kNPhiBins; i++) phiBins[i] = 0.0+2.0*TMath::Pi()/18.*i;
+      
+      TArrayD binLims[5];
+      binLims[0] = TArrayD(kNSigEleBins, sigEleBins);
+      binLims[1] = TArrayD(kNPinBins, pinBins);
+      binLims[2] = TArrayD(kNEtaBins, etaBins);
+      binLims[3] = TArrayD(kNCentBins, centBins);
+      binLims[4] = TArrayD(kNPhiBins, phiBins);
+      
+      man->AddHistogram(classStr.Data(), "TPCnSigElectron_multiDim", "TPC n-#sigma_{e} as a function of (p_{IN}, #eta, CentVZERO, phi)", 5, vars, binLims);
+      
+      continue;
+    }  // end if "TrackQA"
+    
+    if(classStr.Contains("PairQualityFlags")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      TString pairQualityFlagNames = " ;K^{0}_{S}#rightarrow#pi^{+}#pi^{-};#Lambda#rightarrow p#pi^{-};#bar{#Lambda}#rightarrow #bar{p}#pi^{+};#gamma#rightarrow e^{+}e^{-};";
+      man->AddHistogram(classStr.Data(), "PairQualityFlags", "Pair quality flags;;", kFALSE,
+	                32, -0.5, 31.5, AliReducedVarManager::kPairQualityFlag, 0, 0.0, 0.0, AliReducedVarManager::kNothing, 0, 0.0, 0.0, AliReducedVarManager::kNothing, pairQualityFlagNames.Data());
+      continue;
+    }
+    if(classStr.Contains("CorrelationQualityFlagsPairs")) {
+       man->AddHistClass(classStr.Data());
+       cout << classStr.Data() << endl;
+       TString pairQualityFlagNames = " ;K^{0}_{S}#rightarrow#pi^{+}#pi^{-};#Lambda#rightarrow p#pi^{-};#bar{#Lambda}#rightarrow #bar{p}#pi^{+};#gamma#rightarrow e^{+}e^{-};";
+       man->AddHistogram(classStr.Data(), "CorrelationPairQualityFlags", "Correlation on pair quality flags;;", kFALSE,
+                         32, -0.5, 31.5, AliReducedVarManager::kPairQualityFlag, 32, -0.5, 31.5, AliReducedVarManager::kPairQualityFlag2, 0, 0.0, 0.0, AliReducedVarManager::kNothing, pairQualityFlagNames.Data(), pairQualityFlagNames.Data());
+       continue;
+    }
+    
+    Double_t massBinWidth = 0.001;     // *GeV/c^2
+    Double_t massRange[2] = {0.0,5.0};
+    Int_t nMassBins = TMath::Nint((massRange[1]-massRange[0])/massBinWidth);
+
+    TString candidateNames = "#gamma#rightarrow e^{+}e^{-};K^{0}_{S}#rightarrow#pi^{+}#pi^{-};";
+    candidateNames += "#Lambda#rightarrow p#pi^{-};#bar{#Lambda}#rightarrow #bar{p}#pi^{+};";
+   
+    // Histograms for pairs
+    if(classStr.Contains("Pair")) {
+      man->AddHistClass(classStr.Data());
+      cout << classStr.Data() << endl;
+      if(classStr.Contains("QA")) {
+	man->AddHistogram(classStr.Data(), "CandidateId", "Candidate id", kFALSE,
+                          5, -0.5, 4.5, AliReducedVarManager::kCandidateId, 0, 0.0, 0.0, AliReducedVarManager::kNothing, 0, 0.0, 0.0, AliReducedVarManager::kNothing, candidateNames.Data());
+        man->AddHistogram(classStr.Data(), "PairType", "Pair type", kFALSE, 4, -0.5, 3.5, AliReducedVarManager::kPairType);
+	man->AddHistogram(classStr.Data(), "PairChi2", "Pair #chi^{2}", kFALSE, 200, 0.0, 50, AliReducedVarManager::kPairChisquare);	
+	man->AddHistogram(classStr.Data(), "Mass", "Invariant mass", kFALSE, nMassBins, massRange[0], massRange[1], AliReducedVarManager::kMass);
+        man->AddHistogram(classStr.Data(), "Mass_V0K0s", "Invariant mass, K^{0}_{s} assumption", kFALSE,
+                     nMassBins, massRange[0], massRange[1], AliReducedVarManager::kMassV0);
+        man->AddHistogram(classStr.Data(), "Mass_V0Lambda", "Invariant mass, #Lambda^{0} assumption", kFALSE,
+                     nMassBins, massRange[0], massRange[1], AliReducedVarManager::kMassV0+1);
+        man->AddHistogram(classStr.Data(), "Mass_V0ALambda", "Invariant mass, #bar{#Lambda^{0}} assumption", kFALSE,
+                     nMassBins, massRange[0], massRange[1], AliReducedVarManager::kMassV0+2);
+        man->AddHistogram(classStr.Data(), "Mass_V0Gamma", "Invariant mass, #gamma conversion assumption", kFALSE,
+                     nMassBins, massRange[0], massRange[1], AliReducedVarManager::kMassV0+3);
+        man->AddHistogram(classStr.Data(), "Pt", "", kFALSE, 1000, 0.0, 10.0, AliReducedVarManager::kPt);
+	man->AddHistogram(classStr.Data(), "Px", "", kFALSE, 1000, 0.0, 10.0, AliReducedVarManager::kPx);
+	man->AddHistogram(classStr.Data(), "Py", "", kFALSE, 1000, 0.0, 10.0, AliReducedVarManager::kPy);
+	man->AddHistogram(classStr.Data(), "Pz", "", kFALSE, 1000, 0.0, 10.0, AliReducedVarManager::kPz);
+	man->AddHistogram(classStr.Data(), "P", "", kFALSE, 1000, 0.0, 10.0, AliReducedVarManager::kP);
+	man->AddHistogram(classStr.Data(), "Rapidity", "Rapidity", kFALSE, 240, -1.2, 1.2, AliReducedVarManager::kRap);
+	man->AddHistogram(classStr.Data(), "Eta", "Pseudo-rapidity #eta", kFALSE, 240, -2.0, 2.0, AliReducedVarManager::kEta);
+	man->AddHistogram(classStr.Data(), "Phi", "Azimuthal distribution", kFALSE, 315, 0.0, 6.3, AliReducedVarManager::kPhi);
+	man->AddHistogram(classStr.Data(), "Theta", "#theta distribution", kFALSE, 1000, 0.0, 3.2, AliReducedVarManager::kTheta);
+	man->AddHistogram(classStr.Data(), "LxyOrR", "L_{xy}/Decay Radius", kFALSE, 1000, -10.0, 10.0, AliReducedVarManager::kPairLxy);
+	man->AddHistogram(classStr.Data(), "OpeningAngle", "Opening angle", kFALSE, 1000, 0.0, 3.2, AliReducedVarManager::kPairOpeningAngle);
+        man->AddHistogram(classStr.Data(), "PointingAngle", "Pointing angle", kFALSE, 1000, 0.0, 3.2, AliReducedVarManager::kPairPointingAngle);
+      }   // end if "QA"
+      
+      continue;
+    }   // end if for Pair classes of histograms
+  }  // end loop over histogram classes
+}

--- a/PWGDQ/reducedTree/macros/attic/XeXe2017/JpsiRaa_XeXe_sigExtr.C
+++ b/PWGDQ/reducedTree/macros/attic/XeXe2017/JpsiRaa_XeXe_sigExtr.C
@@ -1,0 +1,1465 @@
+// TAA values for Xe-Xe:       TAA, rms, sys error
+//  centrality ranges, respectively, 0-20%, 20-90%, 0-90%
+Double_t gTAA_XeXe[3][3] = {              
+   {9.896, 2.9, 0.88},
+   {1.352, 1.5, 0.2},
+   {3.252, 4.0, 0.35}
+};
+
+// Ncoll values for Xe-Xe:       ncoll, rms, sys error
+//  centrality ranges, respectively, 0-20%, 20-90%, 0-90%
+Double_t gNcoll_XeXe[3][3] = {              
+   {676.9, 200., 60.},
+   {92.51, 110., 14.},
+   {222.4, 280., 24.}
+};
+
+// Npart values for Xe-Xe:       npart, rms, sys error
+//  centrality ranges, respectively, 0-20%, 20-90%, 0-90%
+Double_t gNpart_XeXe[3][3] = {              
+   {193., 34., 2.5},
+   {46.42, 39., 2.5},
+   {79.01, 72., 2.5}
+};
+
+// J/psi cross-section at 5.02 TeV obtained via interpolation at mid-y
+// B.R. x d sigma/ dy 
+//Double_t gPPcrossSection5TeVinterpol = 367.0e-9;        // nb
+
+// J/psi cross-section at 5.44 TeV obtained via interpolation at mid-y
+// B.R. x d sigma/ dy 
+Double_t gPPcrossSection5TeVinterpol = 388.6e-9;        // nb, excluding ln+powerlaw
+
+TH1* gOldPointer = 0x0;
+
+AliHistogramManager* gHistManData = 0x0;
+AliHistogramManager* gHistManMC = 0x0;
+AliResonanceFits gFits;
+
+//________________________________________________________________________________________
+void RunSystematics(const Char_t* filename, const Char_t* filenameMC, Int_t centBin=2, const Char_t* outputDir=".", Bool_t savePictures=kFALSE) {
+   //
+   // Run systematics
+   //
+   gHistManData = new AliHistogramManager();
+   gHistManData->InitFile(filename, "jpsi2eeHistos");
+   
+   gHistManMC = new AliHistogramManager();
+   gHistManMC->InitFile(filenameMC, "jpsi2eeHistos");
+   
+   TH1F* eventsVsCent = (TH1F*)gHistManData->GetHistogram("Event_AfterCuts","CentVZERO");
+   
+   //gFits.AddVariable(AliReducedVarManager::kVtxZ, 3);
+   gFits.AddVariable(AliReducedVarManager::kCentVZERO, 2);
+   gFits.AddVariable(AliReducedVarManager::kPt, 1);
+   gFits.AddVariable(AliReducedVarManager::kMass, 0);
+   gFits.SetVarRange(AliReducedVarManager::kMass, 1.5, 4.2);
+   
+   gFits.SetBkgMethod(AliResonanceFits::kBkgMixedEvent);          // kBkgMixedEvent,  kBkgLikeSign, kBkgFitFunction, kBkgMixedEventAndResidualFit
+   gFits.SetMEMatchingMethod(AliResonanceFits::kMatchSEOS);     // kMatchSEOS, kMatchSELS
+   gFits.SetLSmethod(AliResonanceFits::kLSArithmeticMean);       // kLSArithmeticMean, kLSGeometricMean
+   gFits.SetUseRfactorCorrection(kTRUE);
+   gFits.SetMassFitRange(1.5,4.2);
+   gFits.SetMassExclusionRange(2.5,4.2);
+   gFits.SetScaleSummedBkg(kTRUE);
+   //gFits.SetUseSignificantZero(kFALSE);
+   gFits.SetScalingOption(AliResonanceFits::kScaleEntries);   // kScaleEntries, kScaleFit, kScaleWeightedAverage
+   gFits.SetWeightedAveragePower(2.0);                                 // 2 - is default, but it can be modified in some specific situations
+   gFits.SetMinuitFitOption(AliResonanceFits::kMinuitMethodLikelihood);   // kMinuitMethodChi2, kMinuitMethodLikelihood
+   //TF1* fitFunc = new TF1("fitFunc", "pol2/pol3(3)", 1.0, 4.6);
+   //TF1* fitFunc = new TF1("fitFunc", "pol2/pol3(3)", 1.0, 4.6);
+   //TF1* fitFunc = new TF1("fitFunc", "[0]*pol1(1)/x", 0., 5.0);
+   //fitFunc->SetParLimits(1, -1.0e+10, 0.); 
+   //fitFunc->SetParLimits(2, 6., 1.0e+10);
+   //fitFunc->SetParLimits(3, -1.0e+10, 0.);
+   //fitFunc->SetParLimits(4, 0.0, 1.0e+10);
+   
+   //fitFunc->SetParameter(1, 10.); fitFunc->SetParLimits(1, 5., 100.);
+   TF1* fitFunc = new TF1("fitFunc", "pol1", 0., 5.0);
+   //fitFunc->SetParameter(0, 10.); fitFunc->SetParameter(1,-0.1);
+   gFits.SetBkgFitFunction(fitFunc);
+   
+   /*
+   const Int_t kNsettings = 16;
+   const Char_t* settingNames[kNsettings] = {
+      "prot36_pion34_spdAny", "prot36_pion34_spdFirst", "prot36_pion34_itsCls3", "prot36_pion34_itsCls4",
+      "prot36_pion34_itsChi2_19",  "prot36_pion34_itsChi2_17", "prot36_pion34_itsChi2_13", 
+      //"prot36_pion34_itsChi2_11", "prot36_pion34_itsChi2_9", "prot36_pion34_itsChi2_7",
+      "prot36_pion34_tpcChi2_60", "prot36_pion34_tpcChi2_50", "prot36_pion34_tpcChi2_35", 
+      //"prot36_pion34_tpcChi2_30", "prot36_pion34_tpcChi2_25",
+      "prot36_pion34_tpcSegm4", "prot36_pion34_tpcSegm5", "prot36_pion34_tpcSegm7",
+      "prot36_pion34_tpcCls90", "prot36_pion34_tpcCls100", "prot36_pion34_tpcCls110"//, "prot36_pion34_tpcCls115", "prot36_pion34_tpcCls120"
+      
+      
+      "prot40_pion36_spdAny", "prot40_pion36_spdFirst", "prot40_pion36_itsCls3", "prot40_pion36_itsCls4",
+      "prot40_pion36_itsChi2_19",  "prot40_pion36_itsChi2_17", "prot40_pion36_itsChi2_13", 
+      //"prot40_pion36_itsChi2_11", "prot40_pion36_itsChi2_9", "prot40_pion36_itsChi2_7",
+      "prot40_pion36_tpcChi2_60", "prot40_pion36_tpcChi2_50", "prot40_pion36_tpcChi2_35", 
+      //"prot40_pion36_tpcChi2_30", "prot40_pion36_tpcChi2_25",
+      "prot40_pion36_tpcSegm4", "prot40_pion36_tpcSegm5", "prot40_pion36_tpcSegm7",
+      "prot40_pion36_tpcCls90", "prot40_pion36_tpcCls100", "prot40_pion36_tpcCls110"//, "prot40_pion36_tpcCls115", "prot40_pion36_tpcCls120"
+   };
+   const Char_t* settingNamesShort[kNsettings] = {
+      "SPD any", "SPD first", "ITS ncls #geq 3", "ITS ncls #geq 4",
+      "ITS #chi^2 #GT 19",  "ITS #chi^2 #GT 17", "ITS #chi^2 #GT 13", 
+      //"ITS #chi^2 #GT 11", "ITS #chi^2 #GT 9", "ITS #chi^2 #GT 7",
+      "TPC #chi^2 #GT 6", "TPC #chi^2 #GT 5", "TPC #chi^2 #GT 3.5", 
+      //"TPC #chi^2 #GT 3", "TPC #chi^2 #GT 2.5",
+      "TPC nsegm #geq 4", "TPC nsegm #geq 5", "TPC nsegm #geq 7",
+      "TPC ncls #geq 90", "TPC ncls #geq 100", "TPC ncls #geq 110"//, "TPC ncls #geq 115", "TPC ncls #geq 120"
+   };*/
+   
+   
+   
+   const Int_t kNsettings = 48;
+   //const Int_t kNsettings = 42;
+   const Char_t* settingNames[kNsettings] = {
+      "electron30_prot36_pion34", "electron30_prot36_pion36", "electron30_prot36_pion38", "electron30_prot36_pion40",
+      "electron30_prot38_pion34", "electron30_prot38_pion36", "electron30_prot38_pion38", "electron30_prot38_pion40",
+      "electron30_prot40_pion34", "electron30_prot40_pion36", "electron30_prot40_pion38", "electron30_prot40_pion40",
+      "electron30_prot42_pion34", "electron30_prot42_pion36", "electron30_prot42_pion38", "electron30_prot42_pion40",
+      
+      "electron28_prot36_pion34", "electron28_prot36_pion36", "electron28_prot36_pion38", "electron28_prot36_pion40",
+      "electron28_prot38_pion34", "electron28_prot38_pion36", "electron28_prot38_pion38", "electron28_prot38_pion40",
+      "electron28_prot40_pion34", "electron28_prot40_pion36", "electron28_prot40_pion38", "electron28_prot40_pion40",
+      "electron28_prot42_pion34", "electron28_prot42_pion36", "electron28_prot42_pion38", "electron28_prot42_pion40",
+      
+      "electron26_prot36_pion34", "electron26_prot36_pion36", "electron26_prot36_pion38", "electron26_prot36_pion40",
+      "electron26_prot38_pion34", "electron26_prot38_pion36", "electron26_prot38_pion38", "electron26_prot38_pion40",
+      "electron26_prot40_pion34", "electron26_prot40_pion36", "electron26_prot40_pion38", "electron26_prot40_pion40",
+      "electron26_prot42_pion34", "electron26_prot42_pion36", "electron26_prot42_pion38", "electron26_prot42_pion40",
+   };
+   const Char_t* settingNamesShort[kNsettings] = {
+      "|n#sigma(e)|<3, n#sigma(p)>3.6, n#sigma(#pi)>3.4", "|n#sigma(e)|<3, n#sigma(p)>3.6, n#sigma(#pi)>3.6",
+      "|n#sigma(e)|<3, n#sigma(p)>3.6, n#sigma(#pi)>3.8", "|n#sigma(e)|<3, n#sigma(p)>3.6, n#sigma(#pi)>4.0",
+      "|n#sigma(e)|<3, n#sigma(p)>3.8, n#sigma(#pi)>3.4", "|n#sigma(e)|<3, n#sigma(p)>3.8, n#sigma(#pi)>3.6",
+      "|n#sigma(e)|<3, n#sigma(p)>3.8, n#sigma(#pi)>3.8", "|n#sigma(e)|<3, n#sigma(p)>3.8, n#sigma(#pi)>4.0",
+      "|n#sigma(e)|<3, n#sigma(p)>4.0, n#sigma(#pi)>3.4", "|n#sigma(e)|<3, n#sigma(p)>4.0, n#sigma(#pi)>3.6",
+      "|n#sigma(e)|<3, n#sigma(p)>4.0, n#sigma(#pi)>3.8", "|n#sigma(e)|<3, n#sigma(p)>4.0, n#sigma(#pi)>4.0",
+      "|n#sigma(e)|<3, n#sigma(p)>4.2, n#sigma(#pi)>3.4", "|n#sigma(e)|<3, n#sigma(p)>4.2, n#sigma(#pi)>3.6",
+      "|n#sigma(e)|<3, n#sigma(p)>4.2, n#sigma(#pi)>3.8", "|n#sigma(e)|<3, n#sigma(p)>4.2, n#sigma(#pi)>4.0",
+      
+      "|n#sigma(e)|<2.8, n#sigma(p)>3.6, n#sigma(#pi)>3.4", "|n#sigma(e)|<2.8, n#sigma(p)>3.6, n#sigma(#pi)>3.6",
+      "|n#sigma(e)|<2.8, n#sigma(p)>3.6, n#sigma(#pi)>3.8", "|n#sigma(e)|<2.8, n#sigma(p)>3.6, n#sigma(#pi)>4.0",
+      "|n#sigma(e)|<2.8, n#sigma(p)>3.8, n#sigma(#pi)>3.4", "|n#sigma(e)|<2.8, n#sigma(p)>3.8, n#sigma(#pi)>3.6",
+      "|n#sigma(e)|<2.8, n#sigma(p)>3.8, n#sigma(#pi)>3.8", "|n#sigma(e)|<2.8, n#sigma(p)>3.8, n#sigma(#pi)>4.0",
+      "|n#sigma(e)|<2.8, n#sigma(p)>4.0, n#sigma(#pi)>3.4", "|n#sigma(e)|<2.8, n#sigma(p)>4.0, n#sigma(#pi)>3.6",
+      "|n#sigma(e)|<2.8, n#sigma(p)>4.0, n#sigma(#pi)>3.8", "|n#sigma(e)|<2.8, n#sigma(p)>4.0, n#sigma(#pi)>4.0",
+      "|n#sigma(e)|<2.8, n#sigma(p)>4.2, n#sigma(#pi)>3.4", "|n#sigma(e)|<2.8, n#sigma(p)>4.2, n#sigma(#pi)>3.6",
+      "|n#sigma(e)|<2.8, n#sigma(p)>4.2, n#sigma(#pi)>3.8", "|n#sigma(e)|<2.8, n#sigma(p)>4.2, n#sigma(#pi)>4.0",
+      
+      "|n#sigma(e)|<2.6, n#sigma(p)>3.6, n#sigma(#pi)>3.4", "|n#sigma(e)|<2.6, n#sigma(p)>3.6, n#sigma(#pi)>3.6",
+      "|n#sigma(e)|<2.6, n#sigma(p)>3.6, n#sigma(#pi)>3.8", "|n#sigma(e)|<2.6, n#sigma(p)>3.6, n#sigma(#pi)>4.0",
+      "|n#sigma(e)|<2.6, n#sigma(p)>3.8, n#sigma(#pi)>3.4", "|n#sigma(e)|<2.6, n#sigma(p)>3.8, n#sigma(#pi)>3.6",
+      "|n#sigma(e)|<2.6, n#sigma(p)>3.8, n#sigma(#pi)>3.8", "|n#sigma(e)|<2.6, n#sigma(p)>3.8, n#sigma(#pi)>4.0",
+      "|n#sigma(e)|<2.6, n#sigma(p)>4.0, n#sigma(#pi)>3.4", "|n#sigma(e)|<2.6, n#sigma(p)>4.0, n#sigma(#pi)>3.6",
+      "|n#sigma(e)|<2.6, n#sigma(p)>4.0, n#sigma(#pi)>3.8", "|n#sigma(e)|<2.6, n#sigma(p)>4.0, n#sigma(#pi)>4.0",
+      "|n#sigma(e)|<2.6, n#sigma(p)>4.2, n#sigma(#pi)>3.4", "|n#sigma(e)|<2.6, n#sigma(p)>4.2, n#sigma(#pi)>3.6",
+      "|n#sigma(e)|<2.6, n#sigma(p)>4.2, n#sigma(#pi)>3.8", "|n#sigma(e)|<2.6, n#sigma(p)>4.2, n#sigma(#pi)>4.0"
+   };
+   
+   const Int_t kNSigWindowSettings = 15;
+   Double_t sigWindows[kNSigWindowSettings][2] = {
+      {2.92, 3.16}, {2.88, 3.16}, {2.84, 3.16}, {2.80, 3.16}, {2.76, 3.16},
+      {2.92, 3.20}, {2.88, 3.20}, {2.84, 3.20}, {2.80, 3.20}, {2.76, 3.20},
+      {2.92, 3.12}, {2.88, 3.12}, {2.84, 3.12}, {2.80, 3.12}, {2.76, 3.12}
+      //{2.92, 3.08}, {2.88, 3.08}, {2.84, 3.08}, {2.80, 3.08}, {2.76, 3.08} 
+   };
+   const Int_t kNFitRangeSettings = 7;
+   Double_t fitRanges[kNFitRangeSettings][2] = {
+      {1.5, 4.2}, {1.3, 4.4}, {1.1, 4.6}, {1.7, 4.0}, {1.9, 3.8},
+      {1.1, 3.8}, {1.9, 4.6}
+     // {1.0, 4.5}, {1.0, 4.3}, {1.0, 4.1}, {1.0, 3.9},
+     // {1.2, 4.5}, {1.2, 4.3}, {1.2, 4.1}, {1.2, 3.9}
+   };
+   const Int_t kNExclusionRangeSettings = 5;
+   Double_t exclRanges[kNExclusionRangeSettings][2] = {
+      {2.74, 3.2}, {2.62, 3.2}, {2.50, 3.2}, {2.38, 3.2}, {2.26, 3.2}  
+      //{2.5, 3.2}
+   };
+   const Int_t kNTotalSigFitSettings = kNSigWindowSettings+kNFitRangeSettings*kNExclusionRangeSettings-1;  
+   // the "-1" is the double counting of the "standard" case
+   
+   const Char_t* centStrings[3] = {"0_20", "20_90", "0_90"};
+   const Double_t centLims[3][2] = {
+      {0.,20.}, {20.,90.}, {0.,90.}
+   };
+   
+   TH1D* signalHist = new TH1D(Form("signalHist_%s", centStrings[centBin]), Form("Signal counts, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]), kNsettings, -0.5, -0.5+kNsettings);
+   signalHist->GetYaxis()->SetTitle("counts");
+   signalHist->GetXaxis()->LabelsOption("v");
+   TH2D* signalHist2D = new TH2D(Form("signalHist2D_%s", centStrings[centBin]), Form("Signal counts, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]), kNsettings, -0.5, -0.5+kNsettings, kNTotalSigFitSettings, -0.5, -0.5+kNTotalSigFitSettings);
+   signalHist2D->GetZaxis()->SetTitle("counts");
+   signalHist2D->GetXaxis()->LabelsOption("v");
+   
+   TH1D* effHist = new TH1D(Form("effHist_%s", centStrings[centBin]), Form("Efficiency, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]), kNsettings, -0.5, -0.5+kNsettings);
+   effHist->GetYaxis()->SetTitle("acc x eff");
+   effHist->GetXaxis()->LabelsOption("v");
+   TH2D* effHist2D = new TH2D(Form("effHist2D_%s", centStrings[centBin]), Form("Efficiency, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]), kNsettings, -0.5, -0.5+kNsettings, kNTotalSigFitSettings, -0.5, -0.5+kNTotalSigFitSettings);
+   effHist2D->GetZaxis()->SetTitle("acc x eff");
+   effHist2D->GetXaxis()->LabelsOption("v");
+   
+   TH1D* sigFracHist = new TH1D(Form("signalFracHist_%s", centStrings[centBin]), Form("Signal fraction in counting window, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]), kNsettings, -0.5, -0.5+kNsettings);
+   sigFracHist->GetXaxis()->LabelsOption("v");
+   TH2D* sigFracHist2D = new TH2D(Form("signalFracHist2D_%s", centStrings[centBin]), Form("Signal fraction in counting window, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]), kNsettings, -0.5, -0.5+kNsettings, kNTotalSigFitSettings, -0.5, -0.5+kNTotalSigFitSettings);
+   sigFracHist2D->GetXaxis()->LabelsOption("v");
+   
+   TH1D* taaHist = new TH1D(Form("Taa_%s", centStrings[centBin]), "TAA values", kNsettings, -0.5, -0.5+kNsettings);
+   taaHist->GetXaxis()->LabelsOption("v");
+   TH1D* signifHist = new TH1D(Form("signifHist_%s", centStrings[centBin]), Form("Significance, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]), kNsettings, -0.5, -0.5+kNsettings);
+   signifHist->GetYaxis()->SetTitle("Significance");
+   signifHist->GetXaxis()->LabelsOption("v");
+   
+   TH2D* signifHist2D = new TH2D(Form("signifHist2D_%s", centStrings[centBin]), Form("Significance, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]), kNsettings, -0.5, -0.5+kNsettings, kNTotalSigFitSettings, -0.5, -0.5+kNTotalSigFitSettings);
+   signifHist2D->GetZaxis()->SetTitle("Significance");
+   signifHist2D->GetXaxis()->LabelsOption("v");
+   
+   TH1D* sOverBHist = new TH1D(Form("sOverBHist_%s", centStrings[centBin]), Form("S/B, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]), kNsettings, -0.5, -0.5+kNsettings);
+   sOverBHist->GetYaxis()->SetTitle("S/B");
+   sOverBHist->GetXaxis()->LabelsOption("v");
+   TH2D* sOverBHist2D = new TH2D(Form("sOverBHist2D_%s", centStrings[centBin]), Form("S/B, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]), kNsettings, -0.5, -0.5+kNsettings, kNTotalSigFitSettings, -0.5, -0.5+kNTotalSigFitSettings);
+   sOverBHist2D->GetZaxis()->SetTitle("S/B");
+   sOverBHist2D->GetXaxis()->LabelsOption("v");
+   
+   TH1D* chi2Hist = new TH1D(Form("chi2Hist_%s", centStrings[centBin]), Form("#chi^{2}, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]), kNsettings, -0.5, -0.5+kNsettings);
+   chi2Hist->GetYaxis()->SetTitle("#chi^{2}");
+   chi2Hist->GetXaxis()->LabelsOption("v");
+   TH2D* chi2Hist2D = new TH2D(Form("chi2Hist2D_%s", centStrings[centBin]), Form("#chi^{2}, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]), kNsettings, -0.5, -0.5+kNsettings, kNTotalSigFitSettings, -0.5, -0.5+kNTotalSigFitSettings);
+   chi2Hist2D->GetZaxis()->SetTitle("#chi^{2}");
+   chi2Hist2D->GetXaxis()->LabelsOption("v");
+   
+   TH1D* chi2MCHist = new TH1D(Form("chi2MCHist_%s", centStrings[centBin]), Form("#chi^{2} MC, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]), kNsettings, -0.5, -0.5+kNsettings);
+   chi2MCHist->GetYaxis()->SetTitle("#chi^{2} MC");
+   chi2MCHist->GetXaxis()->LabelsOption("v");
+   TH2D* chi2MCHist2D = new TH2D(Form("chi2MCHist2D_%s", centStrings[centBin]), Form("#chi^{2} MC, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]), kNsettings, -0.5, -0.5+kNsettings, kNTotalSigFitSettings, -0.5, -0.5+kNTotalSigFitSettings);
+   chi2MCHist2D->GetZaxis()->SetTitle("#chi^{2} MC");
+   chi2MCHist2D->GetXaxis()->LabelsOption("v");
+   
+   for(Int_t i=1; i<=kNsettings; ++i) {
+      signalHist->GetXaxis()->SetBinLabel(i, settingNamesShort[i-1]);      
+      effHist->GetXaxis()->SetBinLabel(i, settingNamesShort[i-1]);
+      sigFracHist->GetXaxis()->SetBinLabel(i, settingNamesShort[i-1]);
+      signifHist->GetXaxis()->SetBinLabel(i, settingNamesShort[i-1]);      
+      sOverBHist->GetXaxis()->SetBinLabel(i, settingNamesShort[i-1]);      
+      chi2Hist->GetXaxis()->SetBinLabel(i, settingNamesShort[i-1]);      
+      chi2MCHist->GetXaxis()->SetBinLabel(i, settingNamesShort[i-1]);      
+      
+      signalHist2D->GetXaxis()->SetBinLabel(i, settingNamesShort[i-1]); 
+      effHist2D->GetXaxis()->SetBinLabel(i, settingNamesShort[i-1]); 
+      sigFracHist2D->GetXaxis()->SetBinLabel(i, settingNamesShort[i-1]);
+      signifHist2D->GetXaxis()->SetBinLabel(i, settingNamesShort[i-1]);      
+      sOverBHist2D->GetXaxis()->SetBinLabel(i, settingNamesShort[i-1]);      
+      chi2Hist2D->GetXaxis()->SetBinLabel(i, settingNamesShort[i-1]);      
+      chi2MCHist2D->GetXaxis()->SetBinLabel(i, settingNamesShort[i-1]);      
+   }
+   
+   for(Int_t i=0; i<kNSigWindowSettings; ++i) {
+      signalHist2D->GetYaxis()->SetBinLabel(i+1, Form("msig [%.2f - %.2f]", sigWindows[i][0], sigWindows[i][1])); 
+      effHist2D->GetYaxis()->SetBinLabel(i+1, Form("msig [%.2f - %.2f]", sigWindows[i][0], sigWindows[i][1])); 
+      sigFracHist2D->GetYaxis()->SetBinLabel(i+1, Form("msig [%.2f - %.2f]", sigWindows[i][0], sigWindows[i][1])); 
+      signifHist2D->GetYaxis()->SetBinLabel(i+1, Form("msig [%.2f - %.2f]", sigWindows[i][0], sigWindows[i][1])); 
+      sOverBHist2D->GetYaxis()->SetBinLabel(i+1, Form("msig [%.2f - %.2f]", sigWindows[i][0], sigWindows[i][1])); 
+      chi2Hist2D->GetYaxis()->SetBinLabel(i+1, Form("msig [%.2f - %.2f]", sigWindows[i][0], sigWindows[i][1])); 
+      chi2MCHist2D->GetYaxis()->SetBinLabel(i+1, Form("msig [%.2f - %.2f]", sigWindows[i][0], sigWindows[i][1])); 
+   }
+   Int_t idxSigExtr=1;
+   for(Int_t i=0; i<kNFitRangeSettings; ++i) {
+      for(Int_t j=0; j<kNExclusionRangeSettings; ++j) {
+         if(i==0 && j==0) continue;     // skip the standard case which is already included
+         signalHist2D->GetYaxis()->SetBinLabel(kNSigWindowSettings+idxSigExtr, 
+                                               Form("mfit [%.2f - %.2f], mexcl [%.2f - %.2f]", fitRanges[i][0], fitRanges[i][1], exclRanges[j][0], exclRanges[j][1])); 
+         effHist2D->GetYaxis()->SetBinLabel(kNSigWindowSettings+idxSigExtr, 
+                                               Form("mfit [%.2f - %.2f], mexcl [%.2f - %.2f]", fitRanges[i][0], fitRanges[i][1], exclRanges[j][0], exclRanges[j][1])); 
+         sigFracHist2D->GetYaxis()->SetBinLabel(kNSigWindowSettings+idxSigExtr, 
+                                            Form("mfit [%.2f - %.2f], mexcl [%.2f - %.2f]", fitRanges[i][0], fitRanges[i][1], exclRanges[j][0], exclRanges[j][1])); 
+         signifHist2D->GetYaxis()->SetBinLabel(kNSigWindowSettings+idxSigExtr, 
+                                               Form("mfit [%.2f - %.2f], mexcl [%.2f - %.2f]", fitRanges[i][0], fitRanges[i][1], exclRanges[j][0], exclRanges[j][1])); 
+         sOverBHist2D->GetYaxis()->SetBinLabel(kNSigWindowSettings+idxSigExtr, 
+                                               Form("mfit [%.2f - %.2f], mexcl [%.2f - %.2f]", fitRanges[i][0], fitRanges[i][1], exclRanges[j][0], exclRanges[j][1])); 
+         chi2Hist2D->GetYaxis()->SetBinLabel(kNSigWindowSettings+idxSigExtr, 
+                                               Form("mfit [%.2f - %.2f], mexcl [%.2f - %.2f]", fitRanges[i][0], fitRanges[i][1], exclRanges[j][0], exclRanges[j][1])); 
+         chi2MCHist2D->GetYaxis()->SetBinLabel(kNSigWindowSettings+idxSigExtr, 
+                                               Form("mfit [%.2f - %.2f], mexcl [%.2f - %.2f]", fitRanges[i][0], fitRanges[i][1], exclRanges[j][0], exclRanges[j][1])); 
+         idxSigExtr++;
+      }
+   }
+   
+   for(Int_t iSetting=0; iSetting<kNsettings; ++iSetting) {
+   //for(Int_t iSetting=0; iSetting<1; ++iSetting) {
+      cout << "Setting " << settingNames[iSetting] << endl;
+      
+      // standard setting
+      //gFits.SetBkgFitFunction(fitFunc);
+      ExtractSignal(settingNames[iSetting], 2.92, 3.16, centLims[centBin][0], centLims[centBin][1], kTRUE);
+      //gFits.PrintFitValues();
+      Double_t* fitValues = gFits.GetFitValues();
+      signalHist->SetBinContent(iSetting+1, fitValues[AliResonanceFits::kSig]);
+      signalHist->SetBinError(iSetting+1, fitValues[AliResonanceFits::kSigErr]);
+      signalHist2D->SetBinContent(iSetting+1, 1, fitValues[AliResonanceFits::kSig]);
+      signalHist2D->SetBinError(iSetting+1, 1, fitValues[AliResonanceFits::kSigErr]);
+      signifHist->SetBinContent(iSetting+1, fitValues[AliResonanceFits::kSignif]);
+      signifHist2D->SetBinContent(iSetting+1,1, fitValues[AliResonanceFits::kSignif]);
+      sOverBHist->SetBinContent(iSetting+1, fitValues[AliResonanceFits::kSoverB]);
+      sOverBHist2D->SetBinContent(iSetting+1,1, fitValues[AliResonanceFits::kSoverB]);
+      chi2Hist->SetBinContent(iSetting+1, fitValues[AliResonanceFits::kChisqSideBands]);
+      chi2Hist2D->SetBinContent(iSetting+1,1, fitValues[AliResonanceFits::kChisqSideBands]);
+      chi2MCHist->SetBinContent(iSetting+1, fitValues[AliResonanceFits::kChisqMCTotal]);
+      chi2MCHist2D->SetBinContent(iSetting+1,1, fitValues[AliResonanceFits::kChisqMCTotal]);
+      
+      Double_t eff=0.; Double_t effErr=0.; Double_t sigFrac=0.;
+      ComputeEfficiency(settingNames[iSetting], eff, effErr, sigFrac, 2.92, 3.16, centLims[centBin][0], centLims[centBin][1]);
+      effHist->SetBinContent(iSetting+1, eff);
+      effHist->SetBinError(iSetting+1, effErr);
+      effHist2D->SetBinContent(iSetting+1,1, eff);
+      effHist2D->SetBinError(iSetting+1,1, effErr);
+      
+      sigFracHist->SetBinContent(iSetting+1, sigFrac);
+      sigFracHist2D->SetBinContent(iSetting+1,1, sigFrac);
+      
+      taaHist->SetBinContent(iSetting+1, 1000.*gTAA_XeXe[centBin][0]);         // factor 1000 to express this in 1/b
+      taaHist->SetBinError(iSetting+1, 1000.0*gTAA_XeXe[centBin][2]);
+      
+      if(savePictures) {
+         TString pictureBaseName = settingNames[iSetting];
+         pictureBaseName += Form("_%s", centStrings[centBin]);
+         pictureBaseName += "_Sig2.92_3.16";
+         pictureBaseName += Form("_MFit%.2f_%.2f", gFits.GetMassFitRange()[0], gFits.GetMassFitRange()[1]);
+         pictureBaseName += Form("_MExcl%.2f_%.2f", gFits.GetMassExclusionRange()[0], gFits.GetMassExclusionRange()[1]);
+         Draw(&gFits, 2.92, 3.16, kTRUE, outputDir, pictureBaseName.Data());
+      }
+      
+      continue;
+      // mass counting window variations
+      for(Int_t imass=1; imass<kNSigWindowSettings; ++imass) {
+         gFits.ComputeOutputValues(sigWindows[imass][0], sigWindows[imass][1]);
+         fitValues = gFits.GetFitValues();
+         signalHist2D->SetBinContent(iSetting+1, 1+imass, fitValues[AliResonanceFits::kSig]);
+         signalHist2D->SetBinError(iSetting+1, 1+imass, fitValues[AliResonanceFits::kSigErr]);
+         signifHist2D->SetBinContent(iSetting+1,1+imass, fitValues[AliResonanceFits::kSignif]);
+         sOverBHist2D->SetBinContent(iSetting+1,1+imass, fitValues[AliResonanceFits::kSoverB]);
+         chi2Hist2D->SetBinContent(iSetting+1,1+imass, fitValues[AliResonanceFits::kChisqSideBands]);
+         chi2MCHist2D->SetBinContent(iSetting+1,1+imass, fitValues[AliResonanceFits::kChisqMCTotal]);
+         
+         ComputeEfficiency(settingNames[iSetting], eff, effErr, sigFrac, sigWindows[imass][0], sigWindows[imass][1], centLims[centBin][0], centLims[centBin][1]);
+         effHist2D->SetBinContent(iSetting+1,1+imass, eff);
+         effHist2D->SetBinError(iSetting+1,1+imass, effErr);
+         sigFracHist2D->SetBinContent(iSetting+1,1+imass, sigFrac);
+         
+         /*if(savePictures) {
+            TString pictureBaseName = settingNames[iSetting];
+            pictureBaseName += Form("_%s", centStrings[centBin]);
+            pictureBaseName += Form("_Sig%.2f_%.2f", sigWindows[imass][0], sigWindows[imass][1]);
+            pictureBaseName += Form("_MFit%.2f_%.2f", gFits.GetMassFitRange()[0], gFits.GetMassFitRange()[1]);
+            pictureBaseName += Form("_MExcl%.2f_%.2f", gFits.GetMassExclusionRange()[0], gFits.GetMassExclusionRange()[1]);
+            Draw(&gFits, sigWindows[imass][0], sigWindows[imass][1], kTRUE, outputDir, pictureBaseName.Data());
+         }*/          
+      }  // end loop over mass windows
+      
+      // recompute efficiency for the standard counting window
+      ComputeEfficiency(settingNames[iSetting], eff, effErr, sigFrac, 2.92, 3.16, centLims[centBin][0], centLims[centBin][1]);
+      
+      // systematic variations on the mass fit and exclusion windows
+      idxSigExtr=1;
+      for(Int_t ifit=0; ifit<kNFitRangeSettings; ++ifit) {
+         gFits.SetMassFitRange(fitRanges[ifit][0], fitRanges[ifit][1]);
+         gFits.SetBkgFitFunction(fitFunc);
+         for(Int_t iexcl=0; iexcl<kNExclusionRangeSettings; ++iexcl) {
+            if(ifit==0 && iexcl==0) continue;
+            gFits.SetMassExclusionRange(exclRanges[iexcl][0], exclRanges[iexcl][1]);
+            
+            ExtractSignal(settingNames[iSetting], 2.92, 3.16, centLims[centBin][0], centLims[centBin][1], kTRUE);
+            //gFits.PrintFitValues();
+            fitValues = gFits.GetFitValues();
+            signalHist2D->SetBinContent(iSetting+1, kNSigWindowSettings+idxSigExtr, fitValues[AliResonanceFits::kSig]);
+            signalHist2D->SetBinError(iSetting+1, kNSigWindowSettings+idxSigExtr, fitValues[AliResonanceFits::kSigErr]);
+            signifHist2D->SetBinContent(iSetting+1,kNSigWindowSettings+idxSigExtr, fitValues[AliResonanceFits::kSignif]);
+            sOverBHist2D->SetBinContent(iSetting+1,kNSigWindowSettings+idxSigExtr, fitValues[AliResonanceFits::kSoverB]);
+            chi2Hist2D->SetBinContent(iSetting+1,kNSigWindowSettings+idxSigExtr, fitValues[AliResonanceFits::kChisqSideBands]);
+            chi2MCHist2D->SetBinContent(iSetting+1,kNSigWindowSettings+idxSigExtr, fitValues[AliResonanceFits::kChisqMCTotal]);
+            
+            effHist2D->SetBinContent(iSetting+1, kNSigWindowSettings+idxSigExtr, eff);
+            effHist2D->SetBinError(iSetting+1, kNSigWindowSettings+idxSigExtr, effErr);
+            sigFracHist2D->SetBinContent(iSetting+1, kNSigWindowSettings+idxSigExtr, sigFrac);
+            
+            /*if(savePictures) {
+               TString pictureBaseName = settingNames[iSetting];
+               pictureBaseName += Form("_%s", centStrings[centBin]);
+               pictureBaseName += "_Sig2.92_3.16";
+               pictureBaseName += Form("_MFit%.2f_%.2f", gFits.GetMassFitRange()[0], gFits.GetMassFitRange()[1]);
+               pictureBaseName += Form("_MExcl%.2f_%.2f", gFits.GetMassExclusionRange()[0], gFits.GetMassExclusionRange()[1]);
+               Draw(&gFits, 2.92, 3.16, kTRUE, outputDir, pictureBaseName.Data());
+            }*/
+            
+            idxSigExtr++;
+         }
+      }
+      // reset defaults
+      gFits.SetMassFitRange(1.5, 4.2);
+      gFits.SetMassExclusionRange(2.5, 3.2);
+   }   // end loop over settings
+   signalHist->Sumw2();
+   signalHist2D->Sumw2();
+   effHist->Sumw2();
+   effHist2D->Sumw2();
+   taaHist->Sumw2();
+   
+   // Compute corrected J/psi yields in Xe-Xe
+   TH1D* corrYieldHist = (TH1D*) signalHist->Clone(Form("corrYieldHist_%s", centStrings[centBin]));
+   corrYieldHist->SetTitle(Form("Corrected J/#psi yield, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]));
+   corrYieldHist->GetYaxis()->SetTitle("B.R. x dN/dy");
+   corrYieldHist->GetXaxis()->LabelsOption("v");
+   corrYieldHist->Divide(effHist);
+   corrYieldHist->Scale(1./1.8);               // normalize to the delta y interval y<|0.9|
+   
+   TH2D* corrYieldHist2D = (TH2D*) signalHist2D->Clone(Form("corrYieldHist2D_%s", centStrings[centBin]));
+   corrYieldHist2D->SetTitle(Form("Corrected J/#psi yield, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]));
+   corrYieldHist2D->GetYaxis()->SetTitle("B.R. x dN/dy");
+   corrYieldHist2D->GetXaxis()->LabelsOption("v");
+   corrYieldHist2D->Divide(effHist2D);
+   corrYieldHist2D->Scale(1./1.8);               // normalize to the delta y interval y<|0.9|
+   TH2D* corrYieldDistrib2D_sigShape = new TH2D(Form("corrYieldDistrib2D_sigShape_%s", centStrings[centBin]), "", kNsettings, -0.5, -0.5+kNsettings, 50, 0.0, 0.003);
+   corrYieldDistrib2D_sigShape->GetYaxis()->SetTitle("B.R. x dN/dy");
+   corrYieldDistrib2D_sigShape->GetXaxis()->LabelsOption("v");
+   TH2D* corrYieldDistrib2D_bkgMatching = new TH2D(Form("corrYieldDistrib2D_bkgMatching_%s", centStrings[centBin]), "", kNsettings, -0.5, -0.5+kNsettings, 50, 0.0, 0.003);
+   corrYieldDistrib2D_bkgMatching->GetYaxis()->SetTitle("B.R. x dN/dy");
+   corrYieldDistrib2D_bkgMatching->GetXaxis()->LabelsOption("v");
+   TH1D* corrYieldSigExtractionSystematics_sigShape = new TH1D(Form("corrYieldSigExtractionSystematics_sigShape_%s", centStrings[centBin]), "", kNsettings, -0.5, -0.5+kNsettings);
+   corrYieldSigExtractionSystematics_sigShape->GetXaxis()->LabelsOption("v");
+   TH1D* corrYieldSigExtractionSystematics_bkgMatching = new TH1D(Form("corrYieldSigExtractionSystematics_bkgMatching_%s", centStrings[centBin]), "", kNsettings, -0.5, -0.5+kNsettings);
+   corrYieldSigExtractionSystematics_bkgMatching->GetXaxis()->LabelsOption("v");
+   for(Int_t ib=1;ib<=kNsettings;++ib) {
+      corrYieldDistrib2D_sigShape->GetXaxis()->SetBinLabel(ib, settingNames[ib-1]);
+      corrYieldDistrib2D_bkgMatching->GetXaxis()->SetBinLabel(ib, settingNames[ib-1]);
+      corrYieldSigExtractionSystematics_sigShape->GetXaxis()->SetBinLabel(ib, settingNames[ib-1]);
+      corrYieldSigExtractionSystematics_bkgMatching->GetXaxis()->SetBinLabel(ib, settingNames[ib-1]);
+   }
+   
+   // normalize to the number of events
+   Double_t nevents = eventsVsCent->Integral(eventsVsCent->GetXaxis()->FindBin(centLims[centBin][0]+1.0e-6), eventsVsCent->GetXaxis()->FindBin(centLims[centBin][1]-1.0e-6));
+   corrYieldHist->Scale(1.0/nevents);
+   corrYieldHist2D->Scale(1.0/nevents);
+   
+   TH1D* corrYieldDistrib = new TH1D("corrYieldDistrib", "", 50, 0.0, 0.003);
+   corrYieldDistrib->GetXaxis()->SetTitle("B.R. x dN/dy");
+   for(Int_t i=1; i<=corrYieldHist->GetXaxis()->GetNbins(); ++i)
+      corrYieldDistrib->Fill(corrYieldHist->GetBinContent(i));
+   
+   TH1D* absDeviations = (TH1D*) corrYieldHist->Clone(Form("absDeviations_%s", centStrings[centBin]));
+   absDeviations->SetTitle(Form("Corrected yield deviations from standard setting #Delta Y= (Y-Y_{0}), centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]));
+   absDeviations->GetYaxis()->SetTitle("#Delta Y = Y_{0}-Y_{i}");
+   absDeviations->GetXaxis()->LabelsOption("v");
+   
+   TH2D* absDeviations2D = (TH2D*) corrYieldHist2D->Clone(Form("absDeviations2D_%s", centStrings[centBin]));
+   absDeviations2D->SetTitle(Form("Corrected yield deviations from standard setting #Delta Y= (Y-Y_{0}), centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]));
+   absDeviations2D->GetZaxis()->SetTitle("#Delta Y = Y_{0}-Y_{i}");
+   absDeviations2D->GetXaxis()->LabelsOption("v");
+   
+   TH1D* relDeviations = (TH1D*) corrYieldHist->Clone(Form("relDeviations_%s", centStrings[centBin]));
+   relDeviations->SetTitle(Form("Relative yield deviations from standard setting, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]));
+   relDeviations->GetYaxis()->SetTitle("#Delta Y / Y (percents)");
+   relDeviations->GetXaxis()->LabelsOption("v");
+   
+   TH2D* relDeviations2D = (TH2D*) corrYieldHist2D->Clone(Form("relDeviations2D_%s", centStrings[centBin]));
+   relDeviations2D->SetTitle(Form("Relative yield deviations from standard setting, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]));
+   relDeviations2D->GetZaxis()->SetTitle("percents");
+   relDeviations2D->GetXaxis()->LabelsOption("v");
+   
+   TH1D* tempDndyHist1 = new TH1D("tempDndyHist1","", 50, 0.0, 0.003);
+   TH1D* tempDndyHist2 = new TH1D("tempDndyHist2","", 50, 0.0, 0.003);
+   for(Int_t iSetting=0; iSetting<kNsettings; ++iSetting) {
+      cout << "iSetting " << iSetting << endl;
+      
+      absDeviations->SetBinContent(iSetting+1, corrYieldHist->GetBinContent(iSetting+1) - corrYieldHist->GetBinContent(1));
+      absDeviations->SetBinError(iSetting+1, TMath::Sqrt(TMath::Abs(corrYieldHist->GetBinError(iSetting+1)*corrYieldHist->GetBinError(iSetting+1) - 
+                                                                                                            corrYieldHist->GetBinError(1)*corrYieldHist->GetBinError(1))));
+      
+      if(absDeviations->GetBinError(iSetting+1)>1.0e-6) {
+         relDeviations->SetBinContent(iSetting+1, 100.0*absDeviations->GetBinContent(iSetting+1) / corrYieldHist->GetBinContent(1));
+         relDeviations->SetBinError(iSetting+1, 100.0*absDeviations->GetBinError(iSetting+1) / corrYieldHist->GetBinContent(1));
+      }
+      else
+         relDeviations->SetBinContent(iSetting+1, 0.0);
+      
+      for(Int_t iSigSetting=0; iSigSetting<kNTotalSigFitSettings; ++iSigSetting) {
+         absDeviations2D->SetBinContent(iSetting+1, iSigSetting+1, corrYieldHist2D->GetBinContent(iSetting+1,iSigSetting+1)-
+                                                                                                         corrYieldHist2D->GetBinContent(iSetting+1,1));
+         absDeviations2D->SetBinError(iSetting+1, iSigSetting+1, 
+                                      TMath::Sqrt(TMath::Abs(corrYieldHist2D->GetBinError(iSetting+1,iSigSetting+1) * 
+                                                                            corrYieldHist2D->GetBinError(iSetting+1,iSigSetting+1) - 
+                                                                             corrYieldHist2D->GetBinError(iSetting+1,1)*corrYieldHist2D->GetBinError(iSetting+ 1,1))));
+         
+         if(absDeviations2D->GetBinError(iSetting+1, iSigSetting+1)>1.0e-6) {
+            relDeviations2D->SetBinContent(iSetting+1, iSigSetting+1, 
+                                           100.0*absDeviations2D->GetBinContent(iSetting+1, iSigSetting+1) / corrYieldHist->GetBinContent(iSetting+1,1));
+            relDeviations2D->SetBinError(iSetting+1, iSigSetting+1, 
+                                         100.0*absDeviations2D->GetBinError(iSetting+1, iSigSetting+1) / corrYieldHist->GetBinContent(iSetting+1,1));
+         }
+         else
+            relDeviations2D->SetBinContent(iSetting+1, iSigSetting+1, 0.0);
+         
+         if(iSigSetting<kNSigWindowSettings) { 
+            corrYieldDistrib2D_sigShape->Fill(iSetting, corrYieldHist2D->GetBinContent(iSetting+1,iSigSetting+1));
+            tempDndyHist1->Fill(corrYieldHist2D->GetBinContent(iSetting+1,iSigSetting+1));
+         }
+         else {
+            corrYieldDistrib2D_bkgMatching->Fill(iSetting, corrYieldHist2D->GetBinContent(iSetting+1,iSigSetting+1));
+            tempDndyHist2->Fill(corrYieldHist2D->GetBinContent(iSetting+1,iSigSetting+1));
+         }
+      }      // end loop over signal extraction cases
+      
+      corrYieldSigExtractionSystematics_sigShape->SetBinContent(iSetting+1, tempDndyHist1->GetMean());
+      corrYieldSigExtractionSystematics_sigShape->SetBinError(iSetting+1, tempDndyHist1->GetRMS());
+      corrYieldSigExtractionSystematics_bkgMatching->SetBinContent(iSetting+1, tempDndyHist2->GetMean());
+      corrYieldSigExtractionSystematics_bkgMatching->SetBinError(iSetting+1, tempDndyHist2->GetRMS());
+      tempDndyHist1->Reset();
+      tempDndyHist2->Reset();
+   }
+   
+   cout << "aaaaaaaaa 1" << endl;
+   
+   // compute the Raa
+   TH1D* raaHist = (TH1D*) corrYieldHist->Clone(Form("raaHist_%s", centStrings[centBin]));
+   raaHist->SetTitle(Form("J/#psi R_{AA} in Xe-Xe, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]));
+   raaHist->GetYaxis()->SetTitle("J/#psi R_{AA}");
+   raaHist->GetXaxis()->LabelsOption("v");
+   raaHist->Scale(1.0/1000.0/gTAA_XeXe[centBin][0]);
+   raaHist->Scale(1.0/gPPcrossSection5TeVinterpol);
+   
+   TH2D* raaHist2D = (TH2D*) corrYieldHist2D->Clone(Form("raaHist2D_%s", centStrings[centBin]));
+   raaHist2D->SetTitle(Form("J/#psi R_{AA} in Xe-Xe, centrality %.0f - %.0f #%", centLims[centBin][0], centLims[centBin][1]));
+   raaHist2D->GetZaxis()->SetTitle("J/#psi R_{AA}");
+   raaHist2D->GetXaxis()->LabelsOption("v");
+   raaHist2D->Scale(1.0/1000.0/gTAA_XeXe[centBin][0]);
+   raaHist2D->Scale(1.0/gPPcrossSection5TeVinterpol);
+   
+   TH2D* raaDistrib2D_sigShape = new TH2D(Form("raaDistrib2D_sigShape_%s", centStrings[centBin]), "", kNsettings, -0.5, -0.5+kNsettings, 50, 0.0, 2.0);
+   raaDistrib2D_sigShape->GetYaxis()->SetTitle("J/#psi R_{AA}");
+   raaDistrib2D_sigShape->GetXaxis()->LabelsOption("v");
+   TH2D* raaDistrib2D_bkgMatching = new TH2D(Form("raaDistrib2D_bkgMatching_%s", centStrings[centBin]), "", kNsettings, -0.5, -0.5+kNsettings, 50, 0.0, 2.0);
+   raaDistrib2D_bkgMatching->GetYaxis()->SetTitle("dN/dy");
+   raaDistrib2D_bkgMatching->GetXaxis()->LabelsOption("v");
+   TH1D* raaSigExtractionSyst_sigShape = new TH1D(Form("raaSigExtractionSyst_sigShape_%s", centStrings[centBin]), "", kNsettings, -0.5, -0.5+kNsettings);
+   raaSigExtractionSyst_sigShape->GetXaxis()->LabelsOption("v");
+   TH1D* raaSigExtractionSyst_bkgMatching = new TH1D(Form("raaSigExtractionSyst_bkgMatching_%s", centStrings[centBin]), "", kNsettings, -0.5, -0.5+kNsettings);
+   raaSigExtractionSyst_bkgMatching->GetXaxis()->LabelsOption("v");
+   for(Int_t ib=1;ib<=kNsettings;++ib) {
+      raaDistrib2D_sigShape->GetXaxis()->SetBinLabel(ib, settingNames[ib-1]);
+      raaDistrib2D_bkgMatching->GetXaxis()->SetBinLabel(ib, settingNames[ib-1]);
+      raaSigExtractionSyst_sigShape->GetXaxis()->SetBinLabel(ib, settingNames[ib-1]);
+      raaSigExtractionSyst_bkgMatching->GetXaxis()->SetBinLabel(ib, settingNames[ib-1]);
+   }
+   
+   cout << "aaaaaaaaa 2" << endl;
+   
+   TH1D* raaDistrib = new TH1D(Form("raaDistrib_%s", centStrings[centBin]), "", 50, 0.0, 2.0);
+   TH1D* raaErrDistrib = new TH1D(Form("raaErrDistrib_%s", centStrings[centBin]), "", 25, 0., 0.5);
+   TH1D* raaDistribFromMeans_sigShape = new TH1D(Form("raaDistribFromMeans_sigShape_%s", centStrings[centBin]), "", 50, 0.0, 2.0);
+   TH1D* raaDistribFromMeans_bkgMatching = new TH1D(Form("raaDistribFromMeans_bkgMatching_%s", centStrings[centBin]), "", 50, 0.0, 2.0);
+   TH1D* raaDistribSystErr_sigShape = new TH1D(Form("raaDistribSystErr_sigShape_%s", centStrings[centBin]), "", 20, 0., 20.);
+   raaDistribSystErr_sigShape->GetXaxis()->SetTitle("Relative syst uncertainty on J/#psi MC signal shape (percents)");
+   TH1D* raaDistribSystErr_bkgMatching = new TH1D(Form("raaDistribSystErr_bkgMatching_%s", centStrings[centBin]), "", 20, 0., 20.);
+   raaDistribSystErr_bkgMatching->GetXaxis()->SetTitle("Relative syst uncertainty on bkg matching (percents)");
+   
+   TH1D* tempHist1 = new TH1D("tempHist1", "", 50., 0.0, 2.0);
+   TH1D* tempHist2 = new TH1D("tempHist2", "", 50., 0.0, 2.0);
+   for(Int_t iSetting=0; iSetting<kNsettings; ++iSetting) {
+      raaDistrib->Fill(raaHist->GetBinContent(iSetting+1));
+      raaErrDistrib->Fill(raaHist->GetBinError(iSetting+1));
+      
+      continue;
+      for(Int_t iSigSetting=0;iSigSetting<kNTotalSigFitSettings; ++iSigSetting) {
+         if(iSigSetting<kNSigWindowSettings) {
+            raaDistrib2D_sigShape->Fill(iSetting, raaHist2D->GetBinContent(iSetting+1, iSigSetting+1));
+            tempHist1->Fill(raaHist2D->GetBinContent(iSetting+1, iSigSetting+1));
+         }
+         else {
+            raaDistrib2D_bkgMatching->Fill(iSetting, raaHist2D->GetBinContent(iSetting+1, iSigSetting+1));
+            tempHist2->Fill(raaHist2D->GetBinContent(iSetting+1, iSigSetting+1));
+         }
+      }
+      raaSigExtractionSyst_sigShape->SetBinContent(iSetting+1, tempHist1->GetMean());
+      raaSigExtractionSyst_sigShape->SetBinError(iSetting+1, tempHist1->GetRMS());
+      raaSigExtractionSyst_bkgMatching->SetBinContent(iSetting+1, tempHist2->GetMean());
+      raaSigExtractionSyst_bkgMatching->SetBinError(iSetting+1, tempHist2->GetRMS());
+      raaDistribFromMeans_sigShape->Fill(tempHist1->GetMean());
+      raaDistribFromMeans_bkgMatching->Fill(tempHist2->GetMean());
+      raaDistribSystErr_sigShape->Fill(100.0*tempHist1->GetRMS()/tempHist1->GetMean());
+      raaDistribSystErr_bkgMatching->Fill(100.0*tempHist2->GetRMS()/tempHist2->GetMean());
+      tempHist1->Reset();
+      tempHist2->Reset();
+   }
+   
+   cout << "aaaaaaaaa 3" << endl;
+   
+   TFile* save=new TFile(Form("%s/jpsiRAASyst_%s_selectedFinal.root", outputDir, centStrings[centBin]), "RECREATE");
+   signalHist->Write();
+   signalHist2D->Write();
+   signifHist->Write();
+   signifHist2D->Write();
+   sOverBHist->Write();
+   sOverBHist2D->Write();
+   effHist->Write();
+   effHist2D->Write();
+   sigFracHist->Write();
+   sigFracHist2D->Write();
+   taaHist->Write();
+   corrYieldHist->Write();
+   corrYieldDistrib->Write();
+   corrYieldHist2D->Write();
+   corrYieldDistrib2D_sigShape->Write();
+   corrYieldDistrib2D_bkgMatching->Write();
+   corrYieldSigExtractionSystematics_sigShape->Write();
+   corrYieldSigExtractionSystematics_bkgMatching->Write();
+   absDeviations->Write();
+   absDeviations2D->Write();
+   relDeviations->Write();
+   relDeviations2D->Write();
+   raaHist->Write();
+   raaHist2D->Write();
+   raaDistrib->Write();
+   raaErrDistrib->Write();
+   raaDistribFromMeans_sigShape->Write();
+   raaDistribFromMeans_bkgMatching->Write();
+   raaDistrib2D_sigShape->Write();
+   raaDistrib2D_bkgMatching->Write();
+   raaSigExtractionSyst_sigShape->Write();
+   raaSigExtractionSyst_bkgMatching->Write();
+   raaDistribSystErr_sigShape->Write();
+   raaDistribSystErr_bkgMatching->Write();
+   chi2Hist->Write();
+   chi2Hist2D->Write();
+   chi2MCHist->Write();
+   chi2MCHist2D->Write();
+   save->Close();
+}
+
+
+//________________________________________________________________________________________
+void ExtractSignal(const Char_t* setting, Double_t minMass, Double_t maxMass, Double_t minCent, Double_t maxCent, Bool_t savePicture=kFALSE) {
+   //
+   // test signal extraction
+   //
+   THnF* seos = (THnF*)gHistManData->GetHistogram(Form("PairSEPM_%s",setting),"PairInvMass");
+   THnF* meos = (THnF*)gHistManData->GetHistogram(Form("PairMEPM_%s",setting),"PairInvMass");
+   THnF* sels1 = (THnF*)gHistManData->GetHistogram(Form("PairSEPP_%s",setting),"PairInvMass");
+   THnF* sels2 = (THnF*)gHistManData->GetHistogram(Form("PairSEMM_%s",setting),"PairInvMass");
+   THnF* mels1 = (THnF*)gHistManData->GetHistogram(Form("PairMEPP_%s",setting),"PairInvMass");
+   THnF* mels2 = (THnF*)gHistManData->GetHistogram(Form("PairMEMM_%s",setting),"PairInvMass");
+   
+   THnF* seosMC = 0x0;
+   if(savePicture)
+      seosMC = (THnF*)gHistManMC->GetHistogram(Form("PairSEPM_%s_TrueElectron",setting),"PairInvMass");
+   
+   gFits.SetSEOSHistogram(seos);
+   gFits.SetMEOSHistogram(meos);
+   gFits.SetSELSHistograms(sels1, sels2);
+   gFits.SetMELSHistograms(mels1, mels2);
+   if(seosMC) gFits.SetSEOSMCHistogram(seosMC);
+   
+   cout << "minCent / maxCent " << minCent << "   " << maxCent << endl; 
+   gFits.SetVarRange(AliReducedVarManager::kCentVZERO, minCent, maxCent);
+   
+   gFits.Process();
+   gFits.ComputeOutputValues(minMass, maxMass);
+}
+
+//________________________________________________________________________________________
+void ComputeEfficiency(const Char_t* setting, Double_t& eff, Double_t& effErr, Double_t& sigFrac, 
+                                      Double_t minMass, Double_t maxMass, 
+                                      Double_t centMin=0., Double_t centMax=100.,
+                                      Double_t ptMin=0., Double_t ptMax=100.) {
+   //
+   // compute efficiency
+   //
+   cout << "ComputeEff 0" << endl;
+   THnF* nominatorMC = (THnF*)gHistManMC->GetHistogram(Form("PairSEPM_%s_TrueElectron",setting),"PairInvMass");
+   cout << "ComputeEff 0.1" << endl;
+   TH3F* denominatorMC = (TH3F*)gHistManMC->GetHistogram("mcTruthJpsi_PureMCTruth_BeforeSelection","MassMC_Pt_CentVZERO");
+   cout << "ComputeEff 0.2" << endl;
+   nominatorMC->Sumw2();
+   cout << "ComputeEff 0.3" << endl;
+   //denominatorMC->Sumw2();
+   
+   cout << "ComputeEff 1" << endl;
+   
+   nominatorMC->GetAxis(1)->SetRangeUser(ptMin+1.0e-6, ptMax-1.0e-6);
+   denominatorMC->GetYaxis()->SetRangeUser(ptMin+1.0e-6, ptMax-1.0e-6);
+   nominatorMC->GetAxis(2)->SetRangeUser(centMin+1.0e-6, centMax-1.0e-6);
+   denominatorMC->GetZaxis()->SetRangeUser(centMin+1.0e-6, centMax-1.0e-6);
+   
+   Double_t err=0.0;
+   sigFrac = 0.0;
+   /*TH3D* nominatorMCProj3D = nominatorMC->Projection(0,1,2);
+   sigFrac = nominatorMCProj3D->IntegralAndError(nominatorMCProj3D->GetXaxis()->FindBin(minMass+1.0e-6), 
+                                                 nominatorMCProj3D->GetXaxis()->FindBin(maxMass-1.0e-6), 
+                                                 nominatorMCProj3D->GetYaxis()->FindBin(ptMin+1.0e-6), 
+                                                 nominatorMCProj3D->GetYaxis()->FindBin(ptMax-1.0e-6), 
+                                                 nominatorMCProj3D->GetZaxis()->FindBin(centMin+1.0e-6), 
+                                                 nominatorMCProj3D->GetZaxis()->FindBin(centMax-1.0e-6),err);
+   
+   sigFrac /= nominatorMCProj3D->IntegralAndError(1, nominatorMCProj3D->GetXaxis()->GetNbins(), 
+                                            nominatorMCProj3D->GetYaxis()->FindBin(ptMin+1.0e-6), nominatorMCProj3D->GetYaxis()->FindBin(ptMax-1.0e-6), 
+                                            nominatorMCProj3D->GetZaxis()->FindBin(centMin+1.0e-6), nominatorMCProj3D->GetZaxis()->FindBin(centMax-1.0e-6),err);
+   */
+   //nominatorMCProj3D->GetXaxis()->SetRangeUser(minMass+1.0e-6, maxMass-1.0e-6);
+   
+   cout << "ComputeEff 2" << endl;
+   
+   TH1D* nomProjMass = nominatorMC->Projection(0); nomProjMass->SetName("nomProjMass");
+   TH1D* denomProjMass = denominatorMC->ProjectionX("denomProjMass");
+   TH1D* nomProjPt = nominatorMC->Projection(1); nomProjPt->SetName("nomProjPt");
+   TH1D* denomProjPt = denominatorMC->ProjectionY("denomProjPt");
+   TH1D* nomProjCent = nominatorMC->Projection(2); nomProjCent->SetName("nomProjCent");
+   TH1D* denomProjCent = denominatorMC->ProjectionZ("denomProjCent");
+   
+   Double_t nomYieldErr = 0.0;
+   //Double_t nomYield = nomProjPt->IntegralAndError(1, nomProjPt->GetXaxis()->GetNbins(), nomYieldErr);
+   Double_t nomYield = nomProjMass->IntegralAndError(nomProjMass->GetXaxis()->FindBin(minMass+0.001), 
+                                                     nomProjMass->GetXaxis()->FindBin(maxMass-0.001), nomYieldErr);
+   Double_t totalRecYieldErr = 0.0;
+   Double_t totalRecYield = nomProjMass->IntegralAndError(1, nomProjMass->GetXaxis()->GetNbins(), totalRecYieldErr);
+   sigFrac = nomYield / totalRecYield;
+   
+   Double_t denomYieldErr = 0.0;
+   //Double_t denomYield = denomProjPt->IntegralAndError(1, nomProjPt->GetXaxis()->GetNbins(), denomYieldErr);
+   Double_t denomYield = denomProjMass->IntegralAndError(1, denomProjMass->GetXaxis()->GetNbins(), denomYieldErr);
+   
+   // compute approximate binomial error (efficiency ~ 10%)
+   if(denomYield>0.) {
+      effErr = nomYield * (denomYield - nomYield) / denomYield / denomYield / denomYield;
+      effErr = TMath::Sqrt(effErr);
+      eff = nomYield / denomYield;
+   }
+   else {
+      effErr = 0.0;
+      eff = 0.0;
+   }
+   
+   cout << "ComputeEff 3" << endl;
+   
+   delete nomProjMass; delete denomProjMass;
+   delete nomProjPt; delete denomProjPt;
+   delete nomProjCent; delete denomProjCent;
+}
+
+//________________________________________________________________________________________
+void TestResonanceFits(const Char_t* filename, const Char_t* setting, const Char_t* filenameMC="", Bool_t isPreliminaryPlot=kFALSE) {
+   //
+   // test signal extraction
+   //
+   gHistManData=new AliHistogramManager();
+   gHistManData->InitFile(filename,"jpsi2eeHistos");
+   THnF* seos = (THnF*)gHistManData->GetHistogram(Form("PairSEPM_%s",setting),"PairInvMass");
+   THnF* meos = (THnF*)gHistManData->GetHistogram(Form("PairMEPM_%s",setting),"PairInvMass");
+   THnF* sels1 = (THnF*)gHistManData->GetHistogram(Form("PairSEPP_%s",setting),"PairInvMass");
+   THnF* sels2 = (THnF*)gHistManData->GetHistogram(Form("PairSEMM_%s",setting),"PairInvMass");
+   THnF* mels1 = (THnF*)gHistManData->GetHistogram(Form("PairMEPP_%s",setting),"PairInvMass");
+   THnF* mels2 = (THnF*)gHistManData->GetHistogram(Form("PairMEMM_%s",setting),"PairInvMass");
+   
+   THnF* seosMC = 0x0;
+   TH1F* sigShape = 0x0;
+   if(filenameMC[0]!='\0') {
+      gHistManMC = new AliHistogramManager();
+      gHistManMC->InitFile(filenameMC,"jpsi2eeHistos");
+      seosMC = (THnF*)gHistManMC->GetHistogram(Form("PairSEPM_%s_TrueElectron",setting),"PairInvMass");
+   }
+   else {
+      TFile* histFile=TFile::Open("/home/iarsene/work/ALICE/AliResonanceFits_bug/jpsiSignalShape.root");
+      sigShape = (TH1F*)histFile->Get("Mass");
+   }
+   
+   gFits.SetSEOSHistogram(seos);
+   gFits.SetMEOSHistogram(meos);
+   gFits.SetSELSHistograms(sels1, sels2);
+   gFits.SetMELSHistograms(mels1, mels2);
+   if(seosMC) gFits.SetSEOSMCHistogram(seosMC);
+   else gFits.SetSignalMCshape(sigShape);
+   
+   //gFits.AddVariable(AliReducedVarManager::kCentVZERO, 2);
+   //gFits.AddVariable(AliReducedVarManager::kVtxZ, 2);
+   //gFits.SetVarRange(AliReducedVarManager::kCentVZERO, 0., 20.);
+   gFits.AddVariable(AliReducedVarManager::kPt, 1);
+   gFits.AddVariable(AliReducedVarManager::kMass, 0);
+   gFits.SetVarRange(AliReducedVarManager::kMass, 1.0, 5.0);
+   //gFits.SetVarRange(AliReducedVarManager::kPt, 10.0, 30.0);
+   
+   gFits.SetBkgMethod(AliResonanceFits::kBkgMixedEvent);          // kBkgMixedEvent,  kBkgLikeSign, kBkgMixedEventAndResidualFit, kBkgFitFunction
+   gFits.SetMEMatchingMethod(AliResonanceFits::kMatchSEOS);     // kMatchSEOS, kMatchSELS
+   gFits.SetLSmethod(AliResonanceFits::kLSArithmeticMean);    // kLSArithmeticMean, kLSGeometricMean
+   gFits.SetUseRfactorCorrection(kTRUE);
+   gFits.SetMassFitRange(1.5,4.2);
+   gFits.SetMassExclusionRange(2.5, 3.2);
+   gFits.SetScaleSummedBkg(kTRUE);
+   //gFits.SetUseSignificantZero(kFALSE);
+   gFits.SetScalingOption(AliResonanceFits::kScaleEntries);   // kScaleEntries, kScaleFit, kScaleWeightedAverage
+   //gFits.SetWeightedAveragePower(2.0);                    // 2 - is default, but it can be modified in some specific situations
+   //gFits.SetMinuitFitOption(AliResonanceFits::kMinuitMethodLikelihood);   // kMinuitMethodChi2, kMinuitMethodLikelihood
+   //TF1* fitFunc = new TF1("fitFunc", "pol2", 0., 5.0);
+   //gFits.SetResidualFitFunction(fitFunc);
+   //gFits.SetDebugMode(kTRUE);
+   //TF1* fitFunc = new TF1("fitFunc", "([0]*x^2+[1]*x+[2])/([3]*x^3+[4]*x^2+[5]*x+[6])", 1.0, 4.6);
+   //TF1* fitFunc = new TF1("fitFunc", "[0]*(x-[1])*(x-[2])/pol3(3)", 0., 5.0);
+   //TF1* fitFunc = new TF1("fitFunc", "pol2/pol3(3)", 0., 5.0);
+   //fitFunc->SetParameters(1.63610e+04, 7.63652e+04, -1.09040e+04, -3.73453e+02, 1.32915e+03, -7.27885e+02, 1.21654e+02);
+   //fitFunc->SetParameter(0, 0.); fitFunc->SetParLimits(0, -100., 0.);
+   //fitFunc->SetParameter(1, 10.); fitFunc->SetParLimits(1, 5., 100.);
+   TF1* fitFunc = new TF1("fitFunc", "pol1", 0., 5.0);
+   //fitFunc->SetParameter(0, 10.); fitFunc->SetParameter(1,-0.1);
+   gFits.SetBkgFitFunction(fitFunc);
+   
+   gFits.Process();
+   gFits.ComputeOutputValues(2.92, 3.16);
+   gFits.Print();
+   gFits.PrintFitValues();
+   
+   Draw(&gFits, 2.92, 3.16, kTRUE, "testDir/", setting, isPreliminaryPlot);
+   /*
+   Double_t eff=0.0; Double_t sigFrac = 0.0;
+   TH1D* effPt = ComputeEfficiency(0, filenameMC, setting, eff, sigFrac, 2.92, 3.16);
+   cout << "eff = " << eff << endl;
+   cout << "sigFrac = " << sigFrac << endl;
+   
+   TCanvas* c2=new TCanvas();
+   effPt->Draw();
+   */
+}
+
+
+//________________________________________________________________________________________
+TH1D* ComputeEfficiency(Int_t option, const Char_t* filenameMC, const Char_t* setting, Double_t& eff, Double_t& sigFrac, 
+                        Double_t minMass, Double_t maxMass, 
+                        Double_t centMin=0., Double_t centMax=100.,
+                        Double_t ptMin=0., Double_t ptMax=100.) {
+   //
+   // compute efficiency
+   //
+   AliHistogramManager* histMan=new AliHistogramManager();
+   histMan->InitFile(filenameMC,"jpsi2eeHistos");
+   THnF* nominatorMC = (THnF*)histMan->GetHistogram(Form("PairSEPM_%s_TrueElectron",setting),"PairInvMass");
+   TH3F* denominatorMC = (TH3F*)histMan->GetHistogram("mcTruthJpsi_PureMCTruth_BeforeSelection","MassMC_Pt_CentVZERO");
+   nominatorMC->Sumw2();
+   //denominatorMC->Sumw2();
+   
+   /*nominatorMC->GetAxis(1)->SetRangeUser(ptMin+1.0e-6, ptMax-1.0e-6);
+   denominatorMC->GetYaxis()->SetRangeUser(ptMin+1.0e-6, ptMax-1.0e-6);
+   nominatorMC->GetAxis(2)->SetRangeUser(centMin+1.0e-6, centMax-1.0e-6);
+   denominatorMC->GetZaxis()->SetRangeUser(centMin+1.0e-6, centMax-1.0e-6);
+   */
+   
+   Double_t err=0.0;
+   /*sigFrac = nominatorMC->IntegralAndError(nominatorMC->GetXaxis()->FindBin(minMass+1.0e-6), nominatorMC->GetXaxis()->FindBin(maxMass-1.0e-6), nominatorMC->GetYaxis()->FindBin(ptMin+1.0e-6), nominatorMC->GetYaxis()->FindBin(ptMax-1.0e-6), 
+   nominatorMC->GetZaxis()->FindBin(centMin+1.0e-6), nominatorMC->GetZaxis()->FindBin(centMax-1.0e-6),err);
+   
+   sigFrac /= nominatorMC->IntegralAndError(1, nominatorMC->GetXaxis()->GetNbins(), 
+                                            nominatorMC->GetYaxis()->FindBin(ptMin+1.0e-6), nominatorMC->GetYaxis()->FindBin(ptMax-1.0e-6), 
+                                            nominatorMC->GetZaxis()->FindBin(centMin+1.0e-6), nominatorMC->GetZaxis()->FindBin(centMax-1.0e-6),err);
+   */
+   
+   nominatorMC->GetAxis(0)->SetRangeUser(minMass+1.0e-6, maxMass-1.0e-6);
+   
+   TH1D* nomProjMass = nominatorMC->Projection(0); nomProjMass->SetName("nomProjMass");
+   TH1D* denomProjMass = denominatorMC->ProjectionX("denomProjMass");
+   TH1D* nomProjPt = nominatorMC->Projection(1); nomProjPt->SetName("nomProjPt");
+   TH1D* denomProjPt = denominatorMC->ProjectionY("denomProjPt");
+   TH1D* nomProjCent = nominatorMC->Projection(2); nomProjCent->SetName("nomProjCent");
+   TH1D* denomProjCent = denominatorMC->ProjectionZ("denomProjCent");
+   
+   eff = nomProjPt->IntegralAndError(1, nomProjPt->GetXaxis()->GetNbins(), err);
+   eff /= denomProjPt->IntegralAndError(1, nomProjPt->GetXaxis()->GetNbins(), err);
+   
+   nomProjPt->Divide(denomProjPt);
+   nomProjCent->Divide(denomProjCent);
+   if(option==0) return nomProjPt;
+   if(option==1) return nomProjCent;
+}
+
+
+//________________________________________________________________________________________
+void BeutifyTH1(TH1* h, const Char_t* title, Double_t lineWidth, Int_t lineColor,
+                           Int_t markerStyle=1, Int_t markerColor=1) {
+   //
+   // set drawing options for a TH1
+   //
+   if(!h) return;
+   h->SetTitle(title);
+   h->SetLineWidth(lineWidth); h->SetLineColor(lineColor);
+   h->SetMarkerStyle(markerStyle);
+   h->SetMarkerColor(markerColor);
+}
+
+//________________________________________________________________________________________
+void BeutifyTAxis(TAxis* ax, 
+                            const Char_t* title, Bool_t centerTitle, Double_t titleSize, Double_t titleOffset, Int_t titleFont,
+                            Double_t labelSize, Int_t labelFont, Int_t nDivisions) {
+   //
+   // set drawing options for TAxis
+   //
+   if(!ax) return;
+   ax->SetTitle(title);
+   if(centerTitle) ax->CenterTitle();
+   ax->SetTitleSize(titleSize);
+   ax->SetTitleOffset(titleOffset);
+   ax->SetTitleFont(titleFont);
+   ax->SetLabelSize(labelSize);
+   ax->SetLabelFont(labelFont);
+   ax->SetNdivisions(nDivisions);
+}
+
+
+//________________________________________________________________________________________
+void Draw(AliResonanceFits* fits, Double_t massSignalMin, Double_t massSignalMax, 
+          Bool_t savePicture=kFALSE, const Char_t* outputDir=".", const Char_t* pictureName="standard", Bool_t preliminaryPlot=kFALSE) {
+   //
+   // Make signal extraction plot using the AliResonanceFits output
+   //
+   TH1* histSplusB = fits->GetSplusB(); if(!histSplusB) return;
+   TH1* histSig = fits->GetSignal();  if(!histSig) return;
+   TH1* histBkg = fits->GetBkg(); // if(!histBkg) return;
+   TH1* histSplusResidualBkg = fits->GetSplusResidualBkg();
+   TH1* histSigMC = fits->GetSignalMC();
+   TF1* bkgFit = ((fits->GetBkgMethod()==AliResonanceFits::kBkgMixedEventAndResidualFit || 
+                          fits->GetBkgMethod()==AliResonanceFits::kBkgFitFunction) ? fits->GetBkgFitFunction() : 0x0);
+   TF1* globalFit = ((fits->GetBkgMethod()==AliResonanceFits::kBkgMixedEventAndResidualFit || 
+                        fits->GetBkgMethod()==AliResonanceFits::kBkgFitFunction) ? fits->GetGlobalFitFunction() : 0x0);
+   
+   Bool_t histogramsAreUnchanged = kFALSE;
+   if(histSplusB==gOldPointer) histogramsAreUnchanged = kTRUE;
+   else gOldPointer = histSplusB;
+   
+   TLatex* lat=new TLatex();
+   lat->SetNDC();
+   lat->SetTextSize(0.06);
+   lat->SetTextColor(1);
+   
+   TCanvas* oldCanvas = (TCanvas*)gROOT->FindObject("AliResonanceFitsCanvas");
+   if(oldCanvas) delete oldCanvas; 
+   TCanvas* c1=new TCanvas("AliResonanceFitsCanvas", "AliResonanceFits canvas", 980, 1200);
+   c1->SetTopMargin(0.01);
+   c1->SetRightMargin(0.005);
+   c1->SetBottomMargin(0.01);
+   c1->SetLeftMargin(0.005);
+   c1->Divide(1,2,0.0,0.0);
+   
+   // Draw the top pad ================================================
+   TVirtualPad* pad = c1->cd(1);
+   pad->SetTopMargin(0.01);
+   pad->SetRightMargin(0.02);
+   pad->SetBottomMargin(0.0);
+   pad->SetLeftMargin(0.15);
+   pad->SetTicks(1,1);
+   
+   histSplusB->SetStats(kFALSE);
+   if(!histogramsAreUnchanged)
+      histSplusB->GetYaxis()->SetRangeUser(0.01, 1.3*histSplusB->GetMaximum());
+   //histSplusB->GetXaxis()->SetRangeUser(fits->GetMassFitRange()[0]-0.1, fits->GetMassFitRange()[1]+0.1);
+   BeutifyTH1(histSplusB, "", 3.0, 1);
+   BeutifyTAxis(histSplusB->GetXaxis(), "", kFALSE, 0.04, 1., 42, 0.04, 42, 510);
+   BeutifyTAxis(histSplusB->GetYaxis(), Form("entries per %.0f MeV/#it{c}^{2}", 1000.*histSplusB->GetXaxis()->GetBinWidth(1)), kTRUE, 0.08, 0.84, 42, 0.065, 42, 507);
+   histSplusB->DrawClone("EXY");
+   
+   if(histBkg) {
+      histBkg->SetStats(kFALSE);
+      BeutifyTH1(histBkg, "", 2.0, 2);
+      //histBkg->GetXaxis()->SetRangeUser(fits->GetMassFitRange()[0]-0.1, fits->GetMassFitRange()[1]+0.1);
+      histBkg->DrawClone("sameE");
+   }
+   if(bkgFit && globalFit && fits->GetBkgMethod()==AliResonanceFits::kBkgFitFunction) {
+      bkgFit->SetLineColor(4); bkgFit->SetLineWidth(1);
+      globalFit->SetLineColor(6); globalFit->SetLineWidth(1);
+      globalFit->Draw("same");
+      bkgFit->Draw("same");
+   }
+   
+   TBox* boxL = new TBox(fits->GetMassFitRange()[0], histSplusB->GetMaximum()*0.1, fits->GetMassExclusionRange()[0], histSplusB->GetMaximum()*0.15);
+   boxL->SetFillColorAlpha(4, 0.35);
+   //boxL->SetFillStyle(3003);
+   //boxL->Draw();
+   
+   TBox* boxR = new TBox(fits->GetMassExclusionRange()[1], histSplusB->GetMaximum()*0.1, fits->GetMassFitRange()[1], histSplusB->GetMaximum()*0.15);
+   boxR->SetFillColorAlpha(4, 0.35);
+   //boxR->SetFillStyle(3003);
+   //boxR->Draw();
+   
+   TLegend* legend1 = new TLegend(0.18, 0.05, 0.42, 0.23);
+   legend1->SetTextSize(0.06);
+   legend1->SetTextFont(42);
+   legend1->SetFillColor(0);
+   legend1->SetBorderSize(0);
+   legend1->AddEntry(histSplusB, "Same event", "l");
+   if(fits->GetBkgMethod()==AliResonanceFits::kBkgFitFunction) {
+      legend1->AddEntry(globalFit, "Global fit", "l");
+      legend1->AddEntry(bkgFit, "Bkg fit", "l");
+   }
+   else if(fits->GetBkgMethod()==AliResonanceFits::kBkgMixedEventAndResidualFit) {
+      legend1->AddEntry(histBkg, "ME like sign", "l");
+   }
+   else 
+      legend1->AddEntry(histBkg, (fits->GetBkgMethod()==AliResonanceFits::kBkgMixedEvent ? "Mixed event" : "Like sign"), "l");
+   legend1->Draw();
+   
+   TLine line;
+   line.SetLineColor(1);
+   line.SetLineStyle(1);
+   line.SetLineWidth(1.0);
+   line.DrawLine(massSignalMin, 0.0, massSignalMin, histSplusB->GetMaximum()*0.75);
+   line.DrawLine(massSignalMax, 0.0, massSignalMax, histSplusB->GetMaximum()*0.75);
+   lat->SetTextFont(42);
+   lat->SetTextColor(1);
+   lat->SetTextSize(0.060);
+   
+   if(preliminaryPlot) {
+      lat->DrawLatex(0.2, 0.90, "ALICE Preliminary");
+      lat->DrawLatex(0.2, 0.82, "0#minus90% Xe#minusXe #sqrt{#it{s}_{NN}} = 5.44 TeV");
+   }
+   
+   if(!preliminaryPlot && (fits->GetBkgMethod()==AliResonanceFits::kBkgMixedEvent || fits->GetBkgMethod()==AliResonanceFits::kBkgLikeSign))
+      lat->DrawLatex(0.56, 0.82, Form("#chi^{2}/NDF (%.1f, %.1f) = %.2f", fits->GetMassFitRange()[0], fits->GetMassFitRange()[1], fits->GetFitValues()[AliResonanceFits::kChisqSideBands]));
+   //if(fEventVsCent) lat->DrawLatex((noYlabels ? 0.52 : 0.56), 0.72, Form("# events = %.2e", fEventVsCent->Integral(fEventVsCent->GetXaxis()->FindBin(fCentralityRange[0]+0.001), fEventVsCent->GetXaxis()->FindBin(fCentralityRange[1]-0.001))));
+   /*lat->DrawLatex(0.63, 0.66, "Fit ranges:");
+   lat->DrawLatex(0.63, 0.60, Form("%.2f<m_{ee}<%.2f GeV/c^{2}", fFitRange[0], fFitRange[1]));
+   lat->DrawLatex(0.63, 0.54, Form("%.2f<p_{T}<%.2f GeV/c", fPtFitRange[0], fPtFitRange[1]));
+   lat->DrawLatex(0.63, 0.45, "Signal:");
+   lat->DrawLatex(0.63, 0.39, Form("%.2f<m_{ee}<%.2f GeV/c^{2}", fSignalRange[0], fSignalRange[1]));
+   lat->DrawLatex(0.63, 0.33, Form("%.2f<p_{T}<%.2f GeV/c", fPtRange[0], fPtRange[1])); */
+
+   // Draw the bottom pad ================================================
+   pad = c1->cd(2);
+   pad->SetTopMargin(0.0);
+   pad->SetRightMargin(0.02);
+   pad->SetBottomMargin(0.17);
+   pad->SetLeftMargin(0.15);
+   pad->SetTicks(1,1);
+   
+   if(fits->GetBkgMethod()==AliResonanceFits::kBkgMixedEvent ||
+      fits->GetBkgMethod()==AliResonanceFits::kBkgLikeSign ||
+      fits->GetBkgMethod()==AliResonanceFits::kBkgFitFunction) {
+      histSig->SetStats(kFALSE);
+      BeutifyTH1(histSig, "", 2.0, 2, 20, 2);
+      if(!histogramsAreUnchanged)
+         histSig->GetYaxis()->SetRangeUser(histSig->GetMinimum()*1.4, histSig->GetMaximum()*1.8);
+      //histSig->GetXaxis()->SetRangeUser(fits->GetMassFitRange()[0]-0.1, fits->GetMassFitRange()[1]+0.1);
+      BeutifyTAxis(histSig->GetYaxis(), "", kFALSE, 0.08, 1.2, 42, 0.065, 42, 508);
+      BeutifyTAxis(histSig->GetXaxis(), "#it{m}_{e^{#plus}e^{#minus}} (GeV/#it{c}^{2})", kTRUE, 0.08, 0.84, 42, 0.065, 42, 508);
+      histSig->DrawClone("XY");
+      if(histSigMC) {
+         //histSigMC->GetXaxis()->SetRangeUser(fits->GetMassFitRange()[0]-0.1, fits->GetMassFitRange()[1]+0.1);
+         BeutifyTH1(histSigMC, "", 2.0, 1);
+         TH1* histSigMCclone = (TH1*)histSigMC->Clone("histSigMCclone");
+         if(fits->GetBkgMethod()==AliResonanceFits::kBkgFitFunction) 
+            histSigMCclone->Scale(globalFit->GetParameter(0));
+         histSigMCclone->DrawClone("sameHISTC"); //smooth MC shape drawing
+      }
+   }
+   if(fits->GetBkgMethod()==AliResonanceFits::kBkgMixedEventAndResidualFit) {
+      histSplusResidualBkg->SetStats(kFALSE);
+      BeutifyTH1(histSplusResidualBkg, "", 2.0, 2, 20, 2);
+      if(!histogramsAreUnchanged)
+         histSplusResidualBkg->GetYaxis()->SetRangeUser(histSplusResidualBkg->GetMinimum()*1.4, histSplusResidualBkg->GetMaximum()*1.8);
+      BeutifyTAxis(histSplusResidualBkg->GetYaxis(), "", kFALSE, 0.08, 1.2, 42, 0.065, 42, 508);
+      BeutifyTAxis(histSplusResidualBkg->GetXaxis(), "#it{m}_{e^{#plus}e^{#minus}} (GeV/#it{c}^{2})", kTRUE, 0.08, 0.84, 42, 0.065, 42, 508);
+      histSplusResidualBkg->DrawClone("XY");
+      bkgFit->SetLineColor(4); bkgFit->SetLineWidth(2);
+      globalFit->SetLineColor(6); globalFit->SetLineWidth(2);
+      
+      cout << "global fit " << globalFit << "  par0 " << globalFit->GetParameter(0) << endl;
+      globalFit->Draw("same");
+      bkgFit->Draw("same");
+   }
+   
+   line.DrawLine(fits->GetMassFitRange()[0],0.0,fits->GetMassFitRange()[1],0.0);
+   
+   Double_t* fitValues = fits->GetFitValues();
+   
+   line.DrawLine(massSignalMin, histSig->GetMinimum()*0.9, massSignalMin, histSig->GetMaximum()*0.8);
+   line.DrawLine(massSignalMax, histSig->GetMinimum()*0.9, massSignalMax, histSig->GetMaximum()*0.8);
+   lat->DrawLatex(0.18, 0.92, Form("Signal:    %.0f #pm %.0f", fitValues[AliResonanceFits::kSig], fitValues[AliResonanceFits::kSigErr]));
+   lat->DrawLatex(0.18, 0.84, Form("#it{S}/#it{B}:        %.3f #pm %.3f", fitValues[AliResonanceFits::kSoverB], fitValues[AliResonanceFits::kSoverBerr]));
+   if(fits->GetBkgMethod()==AliResonanceFits::kBkgMixedEvent || fits->GetBkgMethod()==AliResonanceFits::kBkgMixedEventAndResidualFit) 
+      lat->DrawLatex(0.18, 0.76, Form("#it{S}/#sqrt{#it{S}+#it{B}}: %.1f", fitValues[AliResonanceFits::kSignif]));
+   if(fits->GetBkgMethod()==AliResonanceFits::kBkgLikeSign) 
+      lat->DrawLatex(0.18, 0.76, Form("#it{S}/#sqrt{#it{S}+2#it{B}}: %.1f", fitValues[AliResonanceFits::kSignif]));
+   if(fits->GetBkgMethod()==AliResonanceFits::kBkgFitFunction) 
+      lat->DrawLatex(0.18, 0.76, Form("#it{S}/#delta_{#it{S}}: %.1f", fitValues[AliResonanceFits::kSignif]));
+   if(histSigMC && !preliminaryPlot) {
+      lat->DrawLatex(0.18, 0.68, Form("#chi^{2}/NDF (%.1f, %.1f) = %.2f", fits->GetMassFitRange()[0], fits->GetMassFitRange()[1], fitValues[AliResonanceFits::kChisqMCTotal]));
+      lat->DrawLatex(0.18, 0.60, Form("Probability = %.2f", fitValues[AliResonanceFits::kFitProbability]));
+      //lat->DrawLatex(0.56, 0.56, Form("MC yield fraction  = %.2f", fitValues[AliResonanceFits::kMCYieldFraction]));
+   }
+   TLegend* legend2 = new TLegend(0.70, 0.83, 0.96, 0.97);
+   legend2->SetFillColor(0);
+   legend2->SetBorderSize(0);
+   legend2->SetTextFont(42);
+   legend2->SetTextSize(0.06);
+   legend2->SetMargin(0.15);
+   if(fits->GetBkgMethod()==AliResonanceFits::kBkgMixedEventAndResidualFit)
+      legend2->AddEntry(histSplusResidualBkg, "Data", "lp");
+   else
+      legend2->AddEntry(histSig, "Data", "lp");
+   if(fits->GetBkgMethod()==AliResonanceFits::kBkgMixedEventAndResidualFit) {
+      legend2->AddEntry(globalFit, "global function", "l");
+      legend2->AddEntry(bkgFit, "bkg function", "l");
+   }
+   else
+      if(histSigMC) legend2->AddEntry(histSigMC, "Monte Carlo", "l");
+   legend2->Draw();  
+   
+   if(savePicture) {
+      TString pictureDetailedName = pictureName;
+      if(fits->GetBkgMethod()==AliResonanceFits::kBkgMixedEvent) pictureDetailedName += "_BkgME";
+      if(fits->GetBkgMethod()==AliResonanceFits::kBkgLikeSign) pictureDetailedName += "_BkgLS";
+      if(fits->GetBkgMethod()==AliResonanceFits::kBkgMixedEventAndResidualFit) pictureDetailedName += "_BkgMEresidual";
+      if(fits->GetBkgMethod()==AliResonanceFits::kBkgFitFunction) pictureDetailedName += "_BkgFit";
+      if(fits->GetScalingOption() == AliResonanceFits::kScaleEntries) pictureDetailedName += "_ScaleEnt";
+      if(fits->GetScalingOption() == AliResonanceFits::kScaleWeightedAverage) pictureDetailedName += "_ScaleWav";
+      if(fits->GetScalingOption() == AliResonanceFits::kScaleFit) pictureDetailedName += "_ScaleFit";
+      if(fits->GetBkgMethod()==AliResonanceFits::kBkgMixedEvent) {
+         if(fits->GetMEMatchingMethod()==AliResonanceFits::kMatchSEOS) pictureDetailedName += "_MatchSEOS";
+         if(fits->GetMEMatchingMethod()==AliResonanceFits::kMatchSELS) pictureDetailedName += "_MatchSELS";
+      }
+      if(fits->GetScalingOption() == AliResonanceFits::kScaleFit) {
+         if(fits->GetMinuitFitOption() == AliResonanceFits::kMinuitMethodChi2) pictureDetailedName += "_FitChi2";
+         if(fits->GetMinuitFitOption() == AliResonanceFits::kMinuitMethodLikelihood) pictureDetailedName += "_FitLikelihood";
+      }
+      
+      c1->SaveAs(Form("%s/%s.png", outputDir, pictureDetailedName.Data()));
+      //c1->SaveAs(Form("%s/%s.eps", outputDir, pictureDetailedName.Data()));
+   }
+}
+
+
+//____________________________________________________________________________________________________
+TList* CheckPIDsystematicsForSetting(const Char_t* setting, const Char_t* refSetting="pid1") {
+   //
+   //
+   //
+   const Int_t kNrebinnedBins = 16;
+   Double_t rebinEdges[kNrebinnedBins+1] = {
+      0.0, 0.5, 1.0, 1.1, 1.2, 
+      1.3, 1.4, 1.5, 1.6, 1.7, 
+      1.8, 2.0, 2.5, 3.0, 4.5, 
+      6.0, 10.0};
+   TH1F* data_p_ref = (TH1F*)gHistManData->GetHistogram(Form("Track_%s", refSetting),"P");
+   data_p_ref->SetName(Form("data_p_ref_%s_%.6f", refSetting, gRandom->Rndm()));
+   TH1F* data_eta_ref = (TH1F*)gHistManData->GetHistogram(Form("Track_%s", refSetting),"Eta");
+   data_eta_ref->SetName(Form("data_eta_ref_%s_%.6f", refSetting, gRandom->Rndm()));
+   TH2F* data_etap_ref = (TH2F*)gHistManData->GetHistogram(Form("Track_%s", refSetting),"Eta_P");
+   data_etap_ref->SetName(Form("data_etap_ref_%s_%.6f", refSetting, gRandom->Rndm()));
+   TH1F* data_p_ref_rebinned = dynamic_cast<TH1F*>(data_p_ref->Rebin(kNrebinnedBins, Form("data_p_ref_%s_rebinned", refSetting), rebinEdges));
+   data_eta_ref->Rebin(2);
+   TH1F* mc_p_ref = (TH1F*)gHistManMC->GetHistogram(Form("Track_%s_TrueElectron", refSetting),"P");
+   mc_p_ref->SetName(Form("mc_p_ref_%s_%.6f", refSetting, gRandom->Rndm()));
+   TH1F* mc_eta_ref = (TH1F*)gHistManMC->GetHistogram(Form("Track_%s_TrueElectron", refSetting),"Eta");
+   mc_eta_ref->SetName(Form("mc_eta_ref_%s_%.6f", refSetting, gRandom->Rndm()));
+   TH2F* mc_etap_ref = (TH2F*)gHistManMC->GetHistogram(Form("Track_%s_TrueElectron", refSetting),"Eta_P");
+   mc_etap_ref->SetName(Form("mc_etap_ref_%s_%.6f", refSetting, gRandom->Rndm()));
+   TH1F* mc_p_ref_rebinned = dynamic_cast<TH1F*>(mc_p_ref->Rebin(kNrebinnedBins, Form("mc_p_ref_%s_rebinned", refSetting), rebinEdges));
+   mc_eta_ref->Rebin(2);
+   
+   TH1F* data_p = (TH1F*)gHistManData->GetHistogram(Form("Track_%s", setting),"P");
+   data_p->SetName(Form("data_p_%s", setting));
+   TH1F* data_eta = (TH1F*)gHistManData->GetHistogram(Form("Track_%s", setting),"Eta");
+   data_eta->SetName(Form("data_eta_%s", setting));
+   TH2F* data_etap = (TH2F*)gHistManData->GetHistogram(Form("Track_%s", setting),"Eta_P");
+   data_etap->SetName(Form("data_etap_%s", setting));
+   TH1F* data_p_rebinned = dynamic_cast<TH1F*>(data_p->Rebin(kNrebinnedBins, Form("data_p_%s_rebinned", refSetting), rebinEdges));
+   data_eta->Rebin(2);
+   
+   TH1F* mc_p = (TH1F*)gHistManMC->GetHistogram(Form("Track_%s_TrueElectron", setting),"P");
+   mc_p->SetName(Form("mc_p_%s", setting));
+   TH1F* mc_eta = (TH1F*)gHistManMC->GetHistogram(Form("Track_%s_TrueElectron", setting),"Eta");
+   mc_eta->SetName(Form("mc_eta_%s", setting));
+   TH2F* mc_etap = (TH2F*)gHistManMC->GetHistogram(Form("Track_%s_TrueElectron", setting),"Eta_P");
+   mc_etap->SetName(Form("mc_etap_%s", setting));
+   TH1F* mc_p_rebinned = dynamic_cast<TH1F*>(mc_p->Rebin(kNrebinnedBins, Form("mc_p_%s_rebinned", refSetting), rebinEdges));
+   mc_eta->Rebin(2);
+   
+   TH1F* data_ratio_p = (TH1F*) data_p_rebinned->Clone(Form("data_ratio_p_%s", setting));
+   BeutifyTH1(data_ratio_p, "", 2, 4);
+   TH1F* mc_ratio_p = (TH1F*) mc_p_rebinned->Clone(Form("mc_ratio_p_%s", setting));
+   BeutifyTH1(mc_ratio_p, "", 2, 2);
+   data_ratio_p->Divide(data_p_rebinned, data_p_ref_rebinned, 1.,1.,"B");
+   mc_ratio_p->Divide(mc_p_rebinned, mc_p_ref_rebinned, 1.,1.,"B");
+   TH2F* data_ratio_etap = (TH2F*) data_etap->Clone(Form("data_ratio_etap_%s", setting));
+   TH2F* mc_ratio_etap = (TH2F*) mc_etap->Clone(Form("mc_ratio_etap_%s", setting));
+   data_ratio_etap->Divide(data_etap, data_etap_ref, 1.,1.,"B");
+   mc_ratio_etap->Divide(mc_etap, mc_etap_ref, 1.,1.,"B");
+   
+   TH1F* dataMC_ratio_p = (TH1F*)data_ratio_p->Clone(Form("dataMC_ratio_p_%s", setting));
+   BeutifyTH1(dataMC_ratio_p, "", 2, 6);
+   dataMC_ratio_p->Divide(mc_ratio_p);
+   TH2F* dataMC_ratio_etap = (TH2F*)data_ratio_etap->Clone(Form("dataMC_ratio_etap_%s", setting));
+   dataMC_ratio_etap->Divide(mc_ratio_etap);
+   
+   TList* returnItems = new TList();
+   returnItems->Add(data_ratio_p); returnItems->Add(mc_ratio_p);
+   returnItems->Add(data_ratio_etap); returnItems->Add(mc_ratio_etap);
+   returnItems->Add(dataMC_ratio_p);
+   returnItems->Add(dataMC_ratio_etap);
+   
+   return returnItems;
+}
+
+
+//____________________________________________________________________________________________________
+void CheckPIDsystematics(const Char_t* dataFilename, const Char_t* mcFilename,
+      const Char_t* settingName, const Char_t* referenceSettingName,
+      const Char_t* outputFilename="pidSyst_SingleEle.root") {
+   //
+   // 
+   //
+   gHistManData = new AliHistogramManager();
+   gHistManData->InitFile(dataFilename, "jpsi2eeHistos");
+   
+   gHistManMC = new AliHistogramManager();
+   gHistManMC->InitFile(mcFilename, "jpsi2eeHistos");
+   
+   //TList* electron28Ratios = CheckPIDsystematicsForSetting("electron28","electron30");
+   //TList* electron26Ratios = CheckPIDsystematicsForSetting("electron26","electron30");
+   //TList* proton42Ratios = CheckPIDsystematicsForSetting("proton42","proton36");
+   //TList* proton40Ratios = CheckPIDsystematicsForSetting("proton40","proton36");
+   //TList* proton38Ratios = CheckPIDsystematicsForSetting("proton38","proton36");
+   //TList* pion40Ratios = CheckPIDsystematicsForSetting("pion40","pion34");
+   //TList* pion38Ratios = CheckPIDsystematicsForSetting("pion38","pion34");
+   //TList* pion36Ratios = CheckPIDsystematicsForSetting("pion36","pion34");
+   //TList* electron28Ratios_uncalibrated = CheckPIDsystematicsForSetting("electron28_uncalibrated","electron30_uncalibrated");
+   //TList* electron26Ratios_uncalibrated = CheckPIDsystematicsForSetting("electron26_uncalibrated","electron30_uncalibrated");
+   //TList* proton42Ratios_uncalibrated = CheckPIDsystematicsForSetting("proton42_uncalibrated","proton36_uncalibrated");
+   //TList* proton40Ratios_uncalibrated = CheckPIDsystematicsForSetting("proton40_uncalibrated","proton36_uncalibrated");
+   //TList* proton38Ratios_uncalibrated = CheckPIDsystematicsForSetting("proton38_uncalibrated","proton36_uncalibrated");
+   //TList* pion40Ratios_uncalibrated = CheckPIDsystematicsForSetting("pion40_uncalibrated","pion34_uncalibrated");
+   //TList* pion38Ratios_uncalibrated = CheckPIDsystematicsForSetting("pion38_uncalibrated","pion34_uncalibrated");
+   //TList* pion36Ratios_uncalibrated = CheckPIDsystematicsForSetting("pion36_uncalibrated","pion34_uncalibrated");
+   TList* histList = CheckPIDsystematicsForSetting(settingName, referenceSettingName);
+   
+   
+   TH1F* ptMC = (TH1F*)gHistManMC->GetHistogram("mcTruthJpsi_PureMCTruth_BeforeSelection", "PtMC");
+   ptMC->SetName("JpsiPtSpectrum");
+   
+   TFile* save=new TFile(outputFilename, "RECREATE");
+   ptMC->Write();
+   //electron28Ratios->Write();
+   //electron26Ratios->Write();
+   //proton42Ratios->Write();
+   //proton40Ratios->Write();
+   //proton38Ratios->Write();
+   //pion40Ratios->Write();
+   //pion38Ratios->Write();
+   //pion36Ratios->Write();
+   //electron28Ratios_uncalibrated->Write();
+   //electron26Ratios_uncalibrated->Write();
+   //proton42Ratios_uncalibrated->Write();
+   //proton40Ratios_uncalibrated->Write();
+   //proton38Ratios_uncalibrated->Write();
+   //pion40Ratios_uncalibrated->Write();
+   //pion38Ratios_uncalibrated->Write();
+   //pion36Ratios_uncalibrated->Write();
+   histList->Write();
+   
+   save->Close();
+}
+
+//____________________________________________________________________________________________________
+void ComputeInputKineSyst(const Char_t* mcFilename, const Char_t* setting) {
+   //
+   // computes the systematic uncertainty on the choice of the input MC kinematics
+   //
+   gHistManMC = new AliHistogramManager();
+   gHistManMC->InitFile(mcFilename, "jpsi2eeHistos");
+   
+   TH1F* jpsiPtSpectrumInputMC_coarse = (TH1F*)gHistManMC->GetHistogram("mcTruthJpsi_PureMCTruth_BeforeSelection", "PtMC_coarse");
+   TH1F* jpsiPtSpectrumInputMC = (TH1F*)gHistManMC->GetHistogram("mcTruthJpsi_PureMCTruth_BeforeSelection", "PtMC");
+   jpsiPtSpectrumInputMC->Rebin(10);
+   //TH3F* jpsiInput3D = (TH3F*)gHistManMC->GetHistogram("mcTruthJpsi_PureMCTruth_BeforeSelection", "MassMC_Pt_CentVZERO");
+   
+   
+   //THnF* selectedJpsi = (THnF*)gHistManMC->GetHistogram(Form("PairSEPM_%s_TrueElectron", setting), "PairInvMass");
+   //selectedJpsi->GetAxis(0)->SetRangeUser(2.9201, 3.159);
+   //TH1D* recYield = (TH1D*)selectedJpsi->Projection(0);
+   TH1F* recYield_coarse = (TH1F*)gHistManMC->GetHistogram(Form("PairSEPM_%s_TrueElectron", setting), "Pt_coarse");
+   TH1F* recYield = (TH1F*)gHistManMC->GetHistogram(Form("PairSEPM_%s_TrueElectron", setting), "Pt");
+   recYield->Rebin(10);
+   
+   TH1F* effPt = (TH1F*)recYield->Clone("effPt");
+   effPt->Divide(recYield, jpsiPtSpectrumInputMC, 1., 1., "B");
+   
+   TH1F* effPt_coarse = (TH1F*)recYield_coarse->Clone("effPt_coarse");
+   effPt_coarse->Divide(recYield_coarse, jpsiPtSpectrumInputMC_coarse, 1., 1., "B");
+   
+   //effPt->Draw();
+   //effPt_coarse->Draw("same");
+   
+   // get the spectra file from the Pb-Pb analysis
+   TFile* fileSpectraTona = TFile::Open("analysisOutputs/StuffForAN/dNdpT_Cent0_20_40_90_24062017.root");
+   TH1D* spectraPbPb0_20 = (TH1D*)fileSpectraTona->Get("totalYieldPt020");
+   TH1D* spectraPbPb20_40 = (TH1D*)fileSpectraTona->Get("totalYieldPt2040");
+   TH1D* spectraPbPb40_90 = (TH1D*)fileSpectraTona->Get("totalYieldPt4090");
+   
+   TFile* fileMUON = TFile::Open("analysisOutputs/StuffForAN/SpectraPbPbFwdY.root");
+   TH1D* spectraJpsi0 = (TH1D*)fileMUON->Get("hPsiAccCor_Cent0");
+   TF1* spectraFit = (TF1*)spectraJpsi0->GetListOfFunctions()->At(0);
+   TH1D* spectraJpsi1 = (TH1D*)fileMUON->Get("hPsiAccCor_Cent1");
+   TH1D* spectraJpsi2 = (TH1D*)fileMUON->Get("hPsiAccCor_Cent2");
+   TH1D* spectraJpsi3 = (TH1D*)fileMUON->Get("hPsiAccCor_Cent3");
+   TH1D* spectraJpsi4 = (TH1D*)fileMUON->Get("hPsiAccCor_Cent4");
+   TH1D* spectraJpsi5 = (TH1D*)fileMUON->Get("hPsiAccCor_Cent5");
+   TH1D* spectraJpsi6 = (TH1D*)fileMUON->Get("hPsiAccCor_Cent6");
+   
+   jpsiPtSpectrumInputMC->Fit(spectraFit, "ME", "Q", 0., 10.);
+   
+   Double_t efff = WeightedAverage(effPt, spectraFit, 0.0, 10.0);
+   cout << "efff = " << efff << endl;
+   return;
+   //jpsiPtSpectrumInputMC->Draw();
+   //spectraFit->Draw("same");
+   //cout << spectraFit->GetExpFormula().Data() << endl;
+   //return;
+   
+   TCanvas* c1=new TCanvas();   
+   
+   spectraPbPb20_40->Fit(spectraFit, "ME","Q",0.,10.);
+   spectraFit->SetLineStyle(3);
+   spectraFit->SetLineColor(4);
+   spectraPbPb0_20->Draw();
+   
+   /*TCanvas* cc = new TCanvas();
+   gMinuit->SetErrorDef(1); // 1 sigmas (2^2)
+   TGraph* g12 = static_cast<TGraph*>(gMinuit->Contour(200,1,2));
+   g12->Draw("al");
+   g12->GetXaxis()->SetTitle("pt0");
+   g12->GetYaxis()->SetTitle("n");
+   cc->Update();*/
+   //return;
+   
+   
+   Double_t meanPar1 = spectraFit->GetParameter(1);
+   Double_t par1Err = spectraFit->GetParError(1);
+   Double_t meanPar2 = spectraFit->GetParameter(2);
+   Double_t par2Err = spectraFit->GetParError(2);
+   Double_t meanPar3 = spectraFit->GetParameter(3);
+   Double_t par3Err = spectraFit->GetParError(3);
+   
+   cout << "spectra fit function :: " << spectraFit->GetExpFormula() << endl;
+   cout << "par1  :: " << meanPar1 << " +/- " << par1Err << endl;
+   cout << "par2  :: " << meanPar2 << " +/- " << par2Err << endl;
+   cout << "par3  :: " << meanPar3 << " +/- " << par3Err << endl;
+   cout << "chi2 / ndf :: " << spectraFit->GetChisquare() << " / " << spectraFit->GetNDF() << " = " << spectraFit->GetChisquare() / spectraFit->GetNDF() << endl;
+   
+   c1->cd();
+   TH1D* hEff = new TH1D("hEff", "efficiency after MC input kine variations", 1000, 0.03, 0.15);
+   TH1D* hInvEff = new TH1D("hInvEff", "1.0/efficiency after MC input kine variations", 1000, 5.0, 15.);
+   spectraJpsi0->SetLineColor(2);
+   spectraJpsi0->SetMarkerColor(2);
+   //spectraJpsi0->Draw();
+   for(Int_t i=0; i<1000;++i) {
+      Double_t par1 = gRandom->Gaus(meanPar1, par1Err);
+      //Double_t par2 = gRandom->Gaus(-0.18 + par1*1.1, 0.3);              // 0-20%
+      Double_t par2 = gRandom->Gaus(0.54 + par1*0.77, 0.2);             // 20-40%
+      //Double_t par2 = gRandom->Gaus(0.65 + par1*0.636, 0.2);             // 40-90%
+      spectraFit->SetParameter(1, par1);
+      spectraFit->SetParameter(2, par2);
+      //spectraFit->SetParameter(1, gRandom->Gaus(meanPar1, par1Err));
+      //spectraFit->SetParameter(2, gRandom->Gaus(meanPar2, par2Err));
+      //spectraFit->SetParameter(3, gRandom->Gaus(meanPar3, par3Err));
+      Double_t eff = WeightedAverage(effPt, spectraFit, 0.0, 10.0);
+      hEff->Fill(eff);
+      hInvEff->Fill(1.0/eff);
+      spectraFit->DrawClone("same");
+   }
+   spectraPbPb20_40->Draw("same");
+      
+   TCanvas* c2=new TCanvas();
+   hEff->Draw();
+   TCanvas* c3=new TCanvas();
+   hInvEff->Draw();
+   TCanvas* c4=new TCanvas();
+   //effTona->Draw();
+   effPt->Draw();
+}
+
+//____________________________________________________________________________
+Double_t WeightedAverage(TH1F* eff, TF1* weight, Float_t ptMin, Float_t ptMax) {
+   //
+   // Takes as arguments the efficiency as a funciton of pt and the input pt spectrum.
+   // Calculates the average efficiency in the pt range ptMin - ptMax
+   //
+   Double_t average = 0.0;
+   Double_t norm = 0.0;
+   for(Int_t i=1; i<=eff->GetXaxis()->GetNbins(); ++i) {
+      Double_t pt=eff->GetXaxis()->GetBinCenter(i);
+      if(pt<ptMin) continue;
+      if(pt>ptMax) continue;
+      average += eff->GetBinContent(i) * weight->Eval(pt) * eff->GetXaxis()->GetBinWidth(i);
+      norm += weight->Eval(pt) * eff->GetXaxis()->GetBinWidth(i);
+   }
+   average /= norm;
+   return average;
+}
+
+//____________________________________________________________________________
+Double_t WeightedAverage(TH2F* eff, TF1* weightPt, TF1* weightPolariz, Float_t ptMin, Float_t ptMax) {
+   //
+   // Takes as arguments a 2-D efficiency as a function of pt and cos(theta*), the pt spectrum and the cos(theta*) distribution
+   // Calculates the average efficiency between ptMin and ptMax
+   //
+   Double_t average = 0.0;
+   Double_t norm = 0.0;
+   for(Int_t ipt=1; ipt<=eff->GetYaxis()->GetNbins(); ++ipt) {
+      Double_t pt=eff->GetYaxis()->GetBinCenter(ipt);
+      if(pt<ptMin) continue;
+      if(pt>ptMax) continue;
+      for(Int_t ict=1; ict<=eff->GetXaxis()->GetNbins(); ++ict) {
+         Double_t cTheta=eff->GetXaxis()->GetBinCenter(ict);
+         average += eff->GetBinContent(ict,ipt) * weightPt->Eval(pt) * weightPolariz->Eval(cTheta);
+         norm += weightPt->Eval(pt) * weightPolariz->Eval(cTheta);
+      }
+   }
+   average /= norm;
+   return average;
+}
+
+
+//________________________________________________________________________________________
+void ConsistencyCheck() {
+   
+   Double_t preliminary2040 = 0.7389;
+   Double_t preliminary2040stat = 0.065564;
+   Double_t preliminary2040syst = 0.05715299;
+   
+   Double_t current2040 = 0.827;
+   Double_t current2040stat = 0.072;
+   Double_t current2040syst = 0.065;
+   
+   Double_t xexe090 = 1.315;
+   Double_t xexe090stat = 0.37;
+   Double_t xexe090syst = 0.122;
+   
+   Double_t xexefwd090 = 0.54;
+   Double_t xexefwd090stat = 0.11;
+   Double_t xexefwd090syst = 0.09;
+   
+   Double_t refsystRel = 0.17;
+   
+   // difference wrt preliminary result: 1.36 sigma
+   // difference wrt updated result: 1.14 sigma
+   // difference wrt XeXe at fwd-y:  1.64 sigma
+   // difference wrt XeXe at fwd-y (shifted to Pb-Pb value):  1.4 sigma
+   
+   TH2F* range = new TH2F("range", "", 10, 0.0, 3.0, 10, 0., 1.);
+   range->Draw();
+   
+   TF1* xexePDFnoRef = new TF1("xexePDFnoRef", "gaus", 0., 3.);
+   xexePDFnoRef->SetParameters(1., xexe090, TMath::Sqrt(xexe090stat*xexe090stat + xexe090syst*xexe090syst));
+   
+   TF1* pbpbPrelPDFnoRef = new TF1("pbpbPrelPDFnoRef", "gaus", 0., 3.);
+   pbpbPrelPDFnoRef->SetParameters(1., preliminary2040, TMath::Sqrt(preliminary2040stat*preliminary2040stat + preliminary2040syst*preliminary2040syst));
+   
+   TH1D* diff = new TH1D("diff", "diff", 600, -2., 4.);
+   for(Int_t i=0; i<1000000; ++i) {
+      diff->Fill(xexePDFnoRef->GetRandom() - pbpbPrelPDFnoRef->GetRandom());
+   }
+   diff->Draw();
+   
+   
+   /*xexePDFnoRef->Draw("same");
+   pbpbPrelPDFnoRef->Draw("same");*/
+}


### PR DESCRIPTION
A new directory was created in PWGDQ/reducedTree/attic which will hold macros used for past analyses.
The directory PWGDQ/reducedTree/attic/XeXe2017/ contains the analysis macros used in the J/psi Raa analysis of the XeXe 2017 data. This directory is referenced in the corresponding analysis note.