### PR TITLE
JetPerformance: Let min pT in jet histograms be configurable

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetPerformance.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetPerformance.cxx
@@ -75,6 +75,7 @@ AliAnalysisTaskEmcalJetPerformance::AliAnalysisTaskEmcalJetPerformance() :
   fPlotMatchedJetHistograms(kFALSE),
   fComputeMBDownscaling(kFALSE),
   fPlotDCal(kFALSE),
+  fMinPt(-100),
   fMaxPt(250),
   fNEtaBins(40),
   fNPhiBins(200),
@@ -122,6 +123,7 @@ AliAnalysisTaskEmcalJetPerformance::AliAnalysisTaskEmcalJetPerformance(const cha
   fPlotMatchedJetHistograms(kFALSE),
   fComputeMBDownscaling(kFALSE),
   fPlotDCal(kFALSE),
+  fMinPt(-100),
   fMaxPt(250),
   fNEtaBins(40),
   fNPhiBins(200),
@@ -290,7 +292,9 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateJetHistograms()
   TString histname;
   TString title;
   
-  Int_t nPtBins = TMath::CeilNint(fMaxPt/2);
+  Int_t nPtBins1 = TMath::CeilNint(fMaxPt-fMinPt);
+  Int_t nPtBins2 = TMath::CeilNint((fMaxPt-fMinPt)/2);
+  Int_t nPtBins5 = TMath::CeilNint((fMaxPt-fMinPt)/5);
   
   AliJetContainer* jets = 0;
   TIter nextJetColl(&fJetCollArray);
@@ -300,11 +304,11 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateJetHistograms()
     histname = TString::Format("%s/JetHistograms/hJetRejectionReason", jets->GetArrayName().Data());
     if (fForceBeamType != kpp) {
       title = histname + ";Centrality (%);Rejection reason;#it{p}_{T,corr} (GeV/#it{c});counts";
-      TH3* hist = fHistManager.CreateTH3(histname.Data(), title.Data(), 10, 0, 100, 32, 0, 32, 50, 0, fMaxPt);
+      TH3* hist = fHistManager.CreateTH3(histname.Data(), title.Data(), 10, 0, 100, 32, 0, 32, nPtBins5, fMinPt, fMaxPt);
       SetRejectionReasonLabels(hist->GetYaxis());
     } else {
       title = histname + ";Rejection reason;#it{p}_{T,corr} (GeV/#it{c});counts";
-      TH2* hist = fHistManager.CreateTH2(histname.Data(), title.Data(), 32, 0, 32, 50, 0, fMaxPt);
+      TH2* hist = fHistManager.CreateTH2(histname.Data(), title.Data(), 32, 0, 32, nPtBins5, fMinPt, fMaxPt);
       SetRejectionReasonLabels(hist->GetXaxis());
     }
     
@@ -319,7 +323,7 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateJetHistograms()
     
     // (Centrality, pT, NEF)
     Int_t nbinsx = 20; Int_t minx = 0; Int_t maxx = 100;
-    Int_t nbinsy = fMaxPt; Int_t miny = 0; Int_t maxy = fMaxPt;
+    Int_t nbinsy = nPtBins1; Int_t miny = fMinPt; Int_t maxy = fMaxPt;
     Int_t nbinsz = 50; Int_t minz = 0; Int_t maxz = 1.;
     
     histname = TString::Format("%s/JetHistograms/hNEFVsPtEMCal", jets->GetArrayName().Data());
@@ -348,34 +352,34 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateJetHistograms()
     if (fComputeMBDownscaling) {
       histname = TString::Format("%s/JetHistograms/hPtUpscaledMB", jets->GetArrayName().Data());
       title = histname + ";Centrality (%);#it{p}_{T}^{corr} (GeV/#it{c});type";
-      fHistManager.CreateTH3(histname.Data(), title.Data(), 20, 0, 100, nPtBins, 0, fMaxPt, 2, -0.5, 1.5, "s");
+      fHistManager.CreateTH3(histname.Data(), title.Data(), 20, 0, 100, nPtBins2, fMinPt, fMaxPt, 2, -0.5, 1.5, "s");
     }
     
     // pT-leading vs. pT
     histname = TString::Format("%s/JetHistograms/hPtLeadingVsPt", jets->GetArrayName().Data());
     if (fForceBeamType != kpp) {
       title = histname + ";Centrality (%);#it{p}_{T}^{corr} (GeV/#it{c});#it{p}_{T,particle}^{leading} (GeV/#it{c})";
-      fHistManager.CreateTH3(histname.Data(), title.Data(), 10, 0, 100, nPtBins, 0, fMaxPt, fMaxPt, 0, fMaxPt);
+      fHistManager.CreateTH3(histname.Data(), title.Data(), 10, 0, 100, nPtBins2, fMinPt, fMaxPt, fMaxPt, 0, fMaxPt);
     }
     else {
       title = histname + ";#it{p}_{T}^{corr} (GeV/#it{c});#it{p}_{T,particle}^{leading} (GeV/#it{c})";
-      fHistManager.CreateTH2(histname.Data(), title.Data(), nPtBins, 0, fMaxPt, fMaxPt, 0, fMaxPt);
+      fHistManager.CreateTH2(histname.Data(), title.Data(), nPtBins2, fMinPt, fMaxPt, nPtBins1, fMinPt, fMaxPt);
     }
     
     // A vs. pT
     histname = TString::Format("%s/JetHistograms/hAreaVsPt", jets->GetArrayName().Data());
     if (fForceBeamType != kpp) {
       title = histname + ";Centrality (%);#it{p}_{T}^{corr} (GeV/#it{c});#it{A}_{jet}";
-      fHistManager.CreateTH3(histname.Data(), title.Data(), 10, 0, 100, nPtBins, 0, fMaxPt, 50, 0, 0.5);
+      fHistManager.CreateTH3(histname.Data(), title.Data(), 10, 0, 100, nPtBins2, fMinPt, fMaxPt, 50, 0, 0.5);
     }
     else {
       title = histname + ";#it{p}_{T}^{corr} (GeV/#it{c});#it{A}_{jet}";
-      fHistManager.CreateTH2(histname.Data(), title.Data(), nPtBins, 0, fMaxPt, 50, 0, 0.5);
+      fHistManager.CreateTH2(histname.Data(), title.Data(), nPtBins2, fMinPt, fMaxPt, 50, 0, 0.5);
     }
     
     // (Centrality, pT, z-leading (charged))
     nbinsx = 20; minx = 0; maxx = 100;
-    nbinsy = nPtBins; miny = 0; maxy = fMaxPt;
+    nbinsy = nPtBins2; miny = fMinPt; maxy = fMaxPt;
     nbinsz = 50; minz = 0; maxz = 1.;
     
     histname = TString::Format("%s/JetHistograms/hZLeadingVsPtEMCal", jets->GetArrayName().Data());
@@ -402,7 +406,7 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateJetHistograms()
     
     // (Centrality, pT, z (charged))
     nbinsx = 20; minx = 0; maxx = 100;
-    nbinsy = nPtBins; miny = 0; maxy = fMaxPt;
+    nbinsy = nPtBins2; miny = fMinPt; maxy = fMaxPt;
     nbinsz = 50; minz = 0; maxz = 1.;
     
     histname = TString::Format("%s/JetHistograms/hZVsPtEMCal", jets->GetArrayName().Data());
@@ -429,7 +433,7 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateJetHistograms()
     
     // (Centrality, pT, Nconst)
     nbinsx = 20; minx = 0; maxx = 100;
-    nbinsy = nPtBins; miny = 0; maxy = fMaxPt;
+    nbinsy = nPtBins2; miny = fMinPt; maxy = fMaxPt;
     nbinsz = 50; minz = 0; maxz = fMaxPt;
     
     histname = TString::Format("%s/JetHistograms/hNConstVsPtEMCal", jets->GetArrayName().Data());
@@ -457,7 +461,7 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateJetHistograms()
     // (Centrality, pT) for eta<0 and eta>0
     if (fForceBeamType != kpp) {
       nbinsx = 20; minx = 0; maxx = 100;
-      nbinsy = fMaxPt; miny = 0; maxy = fMaxPt;
+      nbinsy = nPtBins1; miny = fMinPt; maxy = fMaxPt;
       
       histname = TString::Format("%s/JetHistograms/hEtaPosVsPtEMCal", jets->GetArrayName().Data());
       title = histname + ";Centrality (%);#it{p}_{T}^{corr} (GeV/#it{c})";
@@ -471,8 +475,8 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateJetHistograms()
     // (Centrality, jet pT, Enonlincorr - Ehadcorr)
     if (fForceBeamType != kpp) {
       nbinsx = 20; minx = 0; maxx = 100;
-      nbinsy = nPtBins; miny = 0; maxy = fMaxPt;
-      nbinsz = nPtBins; minz = 0; maxz = fMaxPt;
+      nbinsy = nPtBins2; miny = fMinPt; maxy = fMaxPt;
+      nbinsz = nPtBins2; minz = fMinPt; maxz = fMaxPt;
       
       histname = TString::Format("%s/JetHistograms/hDeltaEHadCorr", jets->GetArrayName().Data());
       title = histname + ";Centrality (%);#it{p}_{T}^{corr} (GeV/#it{c});#sum#it{E}_{nonlincorr} - #it{E}_{hadcorr}";
@@ -483,8 +487,8 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateJetHistograms()
     if (fDoTriggerSimulation) {
       histname = TString::Format("%s/JetHistograms/hMedPatchJet", jets->GetArrayName().Data());
       title = histname + ";#it{E}_{patch,med};type;#it{p}_{T}^{corr} (GeV/#it{c});Centrality (%)";
-      Int_t nbins5[4]  = {100, 2, nPtBins, 50};
-      Double_t min5[4] = {0,-0.5, 0, 0};
+      Int_t nbins5[4]  = {100, 2, nPtBins2, 50};
+      Double_t min5[4] = {0,-0.5, fMinPt, 0};
       Double_t max5[4] = {50,1.5, fMaxPt, 100};
       fHistManager.CreateTHnSparse(histname.Data(), title.Data(), 4, nbins5, min5, max5);
     }
@@ -862,7 +866,9 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateTriggerSimHistograms()
 {
   TString histname;
   TString title;
-  Int_t nPtBins = TMath::CeilNint(fMaxPt/2);
+  Int_t nPtBins1 = TMath::CeilNint(fMaxPt-fMinPt);
+  Int_t nPtBins2 = TMath::CeilNint((fMaxPt-fMinPt)/2);
+  Int_t nPtBins5 = TMath::CeilNint((fMaxPt-fMinPt)/5);
   
   //----------------------------------------------
   // Trigger patch histograms
@@ -880,7 +886,7 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateTriggerSimHistograms()
   // patch E vs. centrality
   histname = "TriggerSimHistograms/hPatchE";
   title = histname + ";Centrality (%);#it{E}_{patch} (GeV)";
-  fHistManager.CreateTH2(histname.Data(), title.Data(), 50, 0, 100, nPtBins, 0, fMaxPt);
+  fHistManager.CreateTH2(histname.Data(), title.Data(), 50, 0, 100, nPtBins2, 0, fMaxPt);
   
   // patch median vs. Centrality
   histname = "TriggerSimHistograms/hPatchMedianE";
@@ -896,7 +902,7 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateTriggerSimHistograms()
     // Jet rejection reason
     histname = TString::Format("%s/TriggerSimHistograms/hJetRejectionReason", jets->GetArrayName().Data());
     title = histname + ";Rejection reason;#it{p}_{T,jet} (GeV/#it{c});counts";
-    TH2* hist = fHistManager.CreateTH2(histname.Data(), title.Data(), 32, 0, 32, 50, 0, fMaxPt);
+    TH2* hist = fHistManager.CreateTH2(histname.Data(), title.Data(), 32, 0, 32, nPtBins5, fMinPt, fMaxPt);
     SetRejectionReasonLabels(hist->GetXaxis());
     
     // Rho vs. Centrality
@@ -908,7 +914,7 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateTriggerSimHistograms()
     
     // (Centrality, pT, NEF)
     Int_t nbinsx = 20; Int_t minx = 0; Int_t maxx = 100;
-    Int_t nbinsy = nPtBins; Int_t miny = 0; Int_t maxy = fMaxPt;
+    Int_t nbinsy = nPtBins1; Int_t miny = fMinPt; Int_t maxy = fMaxPt;
     Int_t nbinsz = 50; Int_t minz = 0; Int_t maxz = 1.;
     
     histname = TString::Format("%s/TriggerSimHistograms/hNEFVsPtEMCal", jets->GetArrayName().Data());
@@ -924,16 +930,16 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateTriggerSimHistograms()
     // pT-leading vs. pT
     histname = TString::Format("%s/TriggerSimHistograms/hPtLeadingVsPt", jets->GetArrayName().Data());
     title = histname + ";#it{p}_{T}^{corr} (GeV/#it{c});#it{p}_{T,particle}^{leading} (GeV/#it{c})";
-    fHistManager.CreateTH2(histname.Data(), title.Data(), nPtBins, 0, fMaxPt, nPtBins, 0, fMaxPt);
+    fHistManager.CreateTH2(histname.Data(), title.Data(), nPtBins2, fMinPt, fMaxPt, nPtBins2, fMinPt, fMaxPt);
     
     // A vs. pT
     histname = TString::Format("%s/TriggerSimHistograms/hAreaVsPt", jets->GetArrayName().Data());
     title = histname + ";#it{p}_{T}^{corr} (GeV/#it{c});#it{A}_{jet}";
-    fHistManager.CreateTH2(histname.Data(), title.Data(), nPtBins, 0, fMaxPt, 50, 0, 0.5);
+    fHistManager.CreateTH2(histname.Data(), title.Data(), nPtBins2, fMinPt, fMaxPt, 50, 0, 0.5);
     
     // (Centrality, pT, z-leading (charged))
     nbinsx = 20; minx = 0; maxx = 100;
-    nbinsy = nPtBins; miny = 0; maxy = fMaxPt;
+    nbinsy = nPtBins2; miny = fMinPt; maxy = fMaxPt;
     nbinsz = 50; minz = 0; maxz = 1.;
     
     histname = TString::Format("%s/TriggerSimHistograms/hZLeadingVsPtEMCal", jets->GetArrayName().Data());
@@ -948,7 +954,7 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateTriggerSimHistograms()
     
     // z (charged) vs. pT
     nbinsx = 20; minx = 0; maxx = 100;
-    nbinsy = nPtBins; miny = 0; maxy = fMaxPt;
+    nbinsy = nPtBins2; miny = fMinPt; maxy = fMaxPt;
     nbinsz = 50; minz = 0; maxz = 1.;
     
     histname = TString::Format("%s/TriggerSimHistograms/hZVsPtEMCal", jets->GetArrayName().Data());
@@ -963,7 +969,7 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateTriggerSimHistograms()
     
     // (Centrality, pT, Nconst)
     nbinsx = 20; minx = 0; maxx = 100;
-    nbinsy = nPtBins; miny = 0; maxy = fMaxPt;
+    nbinsy = nPtBins2; miny = fMinPt; maxy = fMaxPt;
     nbinsz = 50; minz = 0; maxz = fMaxPt;
     
     histname = TString::Format("%s/TriggerSimHistograms/hNConstVsPtEMCal", jets->GetArrayName().Data());
@@ -987,12 +993,13 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateMatchedJetHistograms()
 {
   TString histname;
   TString title;
-  Int_t nPtBins = TMath::CeilNint(fMaxPt/2);
+  Int_t nPtBins1 = TMath::CeilNint(fMaxPt-fMinPt);
+  Int_t nPtBinsTruth2 = TMath::CeilNint(fMaxPt/2);
   
   // Response matrix, (centrality, pT-truth, pT-det)
   Int_t nbinsx = 20; Int_t minx = 0; Int_t maxx = 100;
   Int_t nbinsy = fMaxPt; Int_t miny = 0; Int_t maxy = fMaxPt;
-  Int_t nbinsz = fMaxPt; Int_t minz = 0; Int_t maxz = fMaxPt;
+  Int_t nbinsz = nPtBins1; Int_t minz = fMinPt; Int_t maxz = fMaxPt;
   
   histname = "MatchedJetHistograms/hResponseMatrixEMCal";
   if (fForceBeamType != kpp) {
@@ -1018,7 +1025,7 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateMatchedJetHistograms()
   
   // JES shift, (centrality, pT-truth, (pT-det - pT-truth) / pT-truth)
   nbinsx = 20; minx = 0; maxx = 100;
-  nbinsy = nPtBins; miny = 0; maxy = fMaxPt;
+  nbinsy = nPtBinsTruth2; miny = 0; maxy = fMaxPt;
   nbinsz = 250; minz = -5.; maxz = 5.;
   
   histname = "MatchedJetHistograms/hJESshiftEMCal";
@@ -1050,32 +1057,32 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateMatchedJetHistograms()
   
   histname = "MatchedJetHistograms/hNEFVsPt";
   if (fForceBeamType != kpp) {
-    title = histname + ";Centrality (%);#it{p}_{T,corr}^{det} (GeV/#it{c});Calo energy fraction";
+    title = histname + ";Centrality (%);#it{p}_{T}^{truth} (GeV/#it{c});Calo energy fraction";
     fHistManager.CreateTH3(histname.Data(), title.Data(), nbinsx, minx, maxx, nbinsy, miny, maxy, nbinsz, minz, maxz);
   }
   else {
-    title = histname + ";#it{p}_{T,corr}^{det} (GeV/#it{c});Calo energy fraction";
+    title = histname + ";#it{p}_{T}^{truth} (GeV/#it{c});Calo energy fraction";
     fHistManager.CreateTH2(histname.Data(), title.Data(), nbinsy, miny, maxy, nbinsz, minz, maxz);
   }
   
   // z-leading (charged) of det-level matched jets, (centrality, pT-truth, z-leading)
   nbinsx = 20; minx = 0; maxx = 100;
-  nbinsy = nPtBins; miny = 0; maxy = fMaxPt;
+  nbinsy = nPtBinsTruth2; miny = 0; maxy = fMaxPt;
   nbinsz = 50; minz = 0; maxz = 1.;
   
   histname = "MatchedJetHistograms/hZLeadingVsPt";
   if (fForceBeamType != kpp) {
-    title = histname + ";Centrality (%);#it{p}_{T,corr}^{det} (GeV/#it{c});#it{z}_{leading}";
+    title = histname + ";Centrality (%);#it{p}_{T}^{truth} (GeV/#it{c});#it{z}_{leading}";
     fHistManager.CreateTH3(histname.Data(), title.Data(), nbinsx, minx, maxx, nbinsy, miny, maxy, nbinsz, minz, maxz);
   }
   else {
-    title = histname + ";#it{p}_{T,corr}^{det} (GeV/#it{c});#it{z}_{leading}";
+    title = histname + ";#it{p}_{T}^{truth} (GeV/#it{c});#it{z}_{leading}";
     fHistManager.CreateTH2(histname.Data(), title.Data(), nbinsy, miny, maxy, nbinsz, minz, maxz);
   }
   
   // Matching distance, (centrality, pT-truth, R)
   nbinsx = 20; minx = 0; maxx = 100;
-  nbinsy = nPtBins; miny = 0; maxy = fMaxPt;
+  nbinsy = nPtBinsTruth2; miny = 0; maxy = fMaxPt;
   nbinsz = 50; minz = 0; maxz = 1.;
   
   histname = "MatchedJetHistograms/hMatchingDistance";
@@ -1094,15 +1101,15 @@ void AliAnalysisTaskEmcalJetPerformance::AllocateMatchedJetHistograms()
   
   // Jet matching QA (copied from AliAnalysisTaskEmcalJetHCorrelations.cxx)
   if (fForceBeamType != kpp) {
-  histname = "MatchedJetHistograms/fHistJetMatchingQA";
-  title = histname;
-  std::vector<std::string> binLabels = {"noMatch", "matchedJet", "sharedMomentumFraction", "partLevelMatchedJet", "jetDistance", "passedAllCuts"};
-  auto histMatchedJetCuts = fHistManager.CreateTH1(histname.Data(), title.Data(), binLabels.size(), 0, binLabels.size());
-  // Set label names
-  for (unsigned int i = 1; i <= binLabels.size(); i++) {
-    histMatchedJetCuts->GetXaxis()->SetBinLabel(i, binLabels.at(i-1).c_str());
-  }
-  histMatchedJetCuts->GetYaxis()->SetTitle("Number of jets");
+    histname = "MatchedJetHistograms/fHistJetMatchingQA";
+    title = histname;
+    std::vector<std::string> binLabels = {"noMatch", "matchedJet", "sharedMomentumFraction", "partLevelMatchedJet", "jetDistance", "passedAllCuts"};
+    auto histMatchedJetCuts = fHistManager.CreateTH1(histname.Data(), title.Data(), binLabels.size(), 0, binLabels.size());
+    // Set label names
+    for (unsigned int i = 1; i <= binLabels.size(); i++) {
+      histMatchedJetCuts->GetXaxis()->SetBinLabel(i, binLabels.at(i-1).c_str());
+    }
+    histMatchedJetCuts->GetYaxis()->SetTitle("Number of jets");
   }
 
 }

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetPerformance.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetPerformance.h
@@ -106,6 +106,7 @@ class AliAnalysisTaskEmcalJetPerformance : public AliAnalysisTaskEmcalJet {
   void UserCreateOutputObjects()                                                ;
   
   // Setters
+  void SetMinPt(Double_t d)                                 { fMinPt = d; }
   void SetMaxPt(Double_t d)                                 { fMaxPt = d; }
   void SetUseAliEventCuts(Bool_t b)                         { fUseAliEventCuts = b; }
   void SetUseManualEvtCuts(Bool_t input)                    { fUseManualEventCuts = input;}
@@ -170,7 +171,8 @@ class AliAnalysisTaskEmcalJetPerformance : public AliAnalysisTaskEmcalJet {
   Bool_t                      fPlotDCal;                            ///< Set whether to enable several DCal-specific histograms
   
   // Plotting parameters
-  Float_t                     fMaxPt;                               ///< Histogram pt limit
+  Double_t                    fMinPt;                               ///< Histogram min pT limit
+  Double_t                    fMaxPt;                               ///< Histogram max pT limit
   Int_t                       fNEtaBins;                            ///< Number of eta bins
   Int_t                       fNPhiBins;                            ///< Number of phi bins
   Int_t                       fNCentHistBins;                       //!<! number of cent bins
@@ -216,7 +218,7 @@ class AliAnalysisTaskEmcalJetPerformance : public AliAnalysisTaskEmcalJet {
   AliAnalysisTaskEmcalJetPerformance &operator=(const AliAnalysisTaskEmcalJetPerformance&); // not implemented
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskEmcalJetPerformance, 12);
+  ClassDef(AliAnalysisTaskEmcalJetPerformance, 13);
   /// \endcond
 };
 #endif


### PR DESCRIPTION
Update to my user task.

The purpose is to allow the jet pT to go negative due to background fluctuation, since we may want to consider these jets in the unfolding. 