### PR TITLE
[PWGPP-429] Prepare PWGJE tracking QA task for subwagons

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalTrackingQATask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalTrackingQATask.cxx
@@ -1,3 +1,4 @@
+#include <cstring>
 #include <iostream>
 
 #include <THnSparse.h>
@@ -489,7 +490,7 @@ Bool_t AliEmcalTrackingQATask::FillHistograms()
  * @param isMC Whether it is an MC analysis
  * @return Pointer to the newly created object
  */
-AliEmcalTrackingQATask* AliEmcalTrackingQATask::AddTaskTrackingQA(Bool_t isMC)
+AliEmcalTrackingQATask* AliEmcalTrackingQATask::AddTaskTrackingQA(Bool_t isMC, const char *suffix)
 {
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
   if (!mgr) {
@@ -523,6 +524,7 @@ AliEmcalTrackingQATask* AliEmcalTrackingQATask::AddTaskTrackingQA(Bool_t isMC)
 
   // Init the task and do settings
   TString name("AliEmcalTrackingQATask");
+  if(strlen(suffix)) name += TString::Format("_%s", suffix);
   AliInfoClassStream() << "Allocating task." << std::endl;
   AliEmcalTrackingQATask *qaTask = new AliEmcalTrackingQATask(name);
   qaTask->SetVzRange(-10,10);

--- a/PWG/EMCAL/EMCALtasks/AliEmcalTrackingQATask.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalTrackingQATask.h
@@ -34,7 +34,7 @@ class AliEmcalTrackingQATask : public AliAnalysisTaskEmcalLight {
   void                   SetDoSigmaPtOverPtGen(Bool_t s)  {fDoSigmaPtOverPtGen = s; }
   void                   SetDoSeparateTRDrefit(Bool_t s)  {fDoSeparateTRDrefit = s; }
 
-  static AliEmcalTrackingQATask* AddTaskTrackingQA(Bool_t isMC);
+  static AliEmcalTrackingQATask* AddTaskTrackingQA(Bool_t isMC, const char *suffix = "");
 
  protected:
   Bool_t                 FillHistograms()                               ;

--- a/PWG/EMCAL/macros/AddTaskTrackingQA.C
+++ b/PWG/EMCAL/macros/AddTaskTrackingQA.C
@@ -1,4 +1,4 @@
-AliEmcalTrackingQATask* AddTaskTrackingQA(Bool_t isMC)
+AliEmcalTrackingQATask* AddTaskTrackingQA(Bool_t isMC, const char *suffix = "")
 {
-  return AliEmcalTrackingQATask::AddTaskTrackingQA(isMC);
+  return AliEmcalTrackingQATask::AddTaskTrackingQA(isMC, suffix);
 }


### PR DESCRIPTION
This is in particular of relevance for running the tracking
QA task on EMCAL triggered events where one wants
to study the 4 EMCAL triggers in parallel.