### PR TITLE
All track types status getters/setters use ULong64_t

### DIFF
--- a/PWG/DevNanoAOD/AliNanoAODTrack.h
+++ b/PWG/DevNanoAOD/AliNanoAODTrack.h
@@ -121,7 +121,7 @@ public:
 
 
   // Bool_t IsOn(Int_t mask) const {return (fFlags&mask)>0;}
-  ULong_t GetStatus() const { AliFatal("Not implemented"); return 0; }
+  ULong64_t GetStatus() const { AliFatal("Not implemented"); return 0; }
   // ULong_t GetFlags() const { return fFlags; }
 
   //  Int_t   GetID() const { return (Int_t)fID; } // FIXME another int (short)

--- a/PWG/EMCAL/EMCALbase/AliPicoTrack.h
+++ b/PWG/EMCAL/EMCALbase/AliPicoTrack.h
@@ -51,7 +51,7 @@ class AliPicoTrack: public AliVTrack {
   Double_t        GetEtaEmc()                 const { return GetTrackEtaOnEMCal(); }
   Double_t        GetPhiEmc()                 const { return GetTrackPhiOnEMCal(); }
   Bool_t          IsEMCAL()                   const { return fEmcal;  }
-  ULong_t         GetStatus()                 const { return 0;       }
+  ULong64_t       GetStatus()                 const { return 0;       }
   Bool_t          GetXYZ(Double_t *v)         const { v[0]=0; v[1]=0; v[2]=0; return 0; }
   using AliVTrack::GetXYZ;
   Double_t        GetBz()                     const { return 0;       }

--- a/PWGCF/Correlations/DPhi/DiHadronPID/AliTrackDiHadronPID.h
+++ b/PWGCF/Correlations/DPhi/DiHadronPID/AliTrackDiHadronPID.h
@@ -55,8 +55,8 @@ public:
 		else return -999.;
 	}
 
-	ULong_t GetFlags() const {return fFlags;}
-	ULong_t GetStatus() const {return GetFlags();}
+	ULong64_t GetFlags() const {return fFlags;}
+	ULong64_t GetStatus() const {return GetFlags();}
 	UInt_t GetFilterMap() const {return fFilterMap;}
 	Bool_t TestFilterMask(UInt_t filterMask) const {return (Bool_t)((filterMask & fFilterMap) == filterMask);}
 
@@ -166,7 +166,7 @@ private:
 	Double_t			fY[3];				// Reconstructed Rapidity for pi,K,p.
 	Double_t			fPhi;				// Reconstructed Phi.
 
-	ULong_t				fFlags;				// Reconstruction Flags.
+	ULong64_t			fFlags;				// Reconstruction Flags.
 	UInt_t				fFilterMap;			// FilterMap.
 
 	Short_t				fID;				// Track ID.
@@ -211,7 +211,7 @@ public:
 private:
 	Int_t				fDebug;				// Debug flag.
 
-	ClassDef(AliTrackDiHadronPID,1);
+	ClassDef(AliTrackDiHadronPID,2);
 
 };
 

--- a/PWGCF/Correlations/JCORRAN/Base/AliJBaseTrack.h
+++ b/PWGCF/Correlations/JCORRAN/Base/AliJBaseTrack.h
@@ -46,7 +46,7 @@ class AliJBaseTrack : public TLorentzVector {
         Int_t         GetID()           const { return fID;}
         Int_t         GetLabel()        const { return fLabel; }
         Short_t       GetParticleType() const { return fParticleType;}
-        ULong_t       GetStatus()       const { return fStatus; }
+        ULong64_t     GetStatus()       const { return fStatus; }
         Short_t       GetCharge()       const { return fCharge; } 
         UInt_t        GetFlags()        const { return fFlags; }
         Bool_t        GetIsIsolated()   const { return IsTrue(kIsIsolated);}
@@ -64,7 +64,7 @@ class AliJBaseTrack : public TLorentzVector {
         void SetID      (const int id){fID=id;}
         void SetLabel   (const Int_t label ){ fLabel=label; }
         void SetParticleType(const Short_t ptype){ fParticleType=ptype; }
-        void SetStatus  (const ULong_t status){ fStatus=status; }
+        void SetStatus  (const ULong64_t status){ fStatus=status; }
         void SetCharge  (const Char_t charge){ fCharge=charge; }
         void SetFlags   (const UInt_t bits ){ fFlags=bits; }        //MC, is primary flag
         void SetIsIsolated(Bool_t tf){ SetFlag( kIsIsolated, tf); }
@@ -93,7 +93,7 @@ class AliJBaseTrack : public TLorentzVector {
         Int_t         fLabel;         // Unique track label for MC-Data relation
         Short_t       fParticleType;  // ParticleType 
         Char_t        fCharge;        // track charge for real data
-        ULong_t       fStatus;        // reconstruction status flags or MC status 
+        ULong64_t     fStatus;        // reconstruction status flags or MC status 
         UInt_t        fFlags;         // store series of any boolen value.
 
         Int_t         fTriggID, fAssocID; //!   //id of trigger and assoc particle 
@@ -101,7 +101,7 @@ class AliJBaseTrack : public TLorentzVector {
         Int_t         fMCIndex;           //!   //index of corresp. MC track
         Double_t      fWeight;            //!   //particle weight
 
-        ClassDef(AliJBaseTrack,1)
+        ClassDef(AliJBaseTrack,2)
 };
 
 #endif

--- a/PWGCF/Correlations/ThreePart/AliFilteredTrack.h
+++ b/PWGCF/Correlations/ThreePart/AliFilteredTrack.h
@@ -109,7 +109,7 @@ class AliFilteredTrack : public AliVTrack {
   virtual const Double_t* PID() const {return NULL;}
   virtual Int_t GetID() const {return -1;}
   virtual UChar_t GetITSClusterMap() const {return 0;}
-  virtual ULong_t GetStatus() const {return 0;}
+  virtual ULong64_t GetStatus() const {return 0;}
   virtual Bool_t GetXYZ(Double_t*) const {return kFALSE;}
   virtual Bool_t GetCovarianceXYZPxPyPz(Double_t*) const {return kFALSE;}
   virtual Bool_t PropagateToDCA(const AliVVertex*, Double_t, Double_t, Double_t*, Double_t*) {return kFALSE;}

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoESDTrackCut.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoESDTrackCut.h
@@ -40,7 +40,7 @@ public:
   void SetPidProbProton(const float& lo, const float& hi);
   void SetPidProbMuon(const float& lo, const float& hi);
   void SetLabel(const bool& flag);
-  void SetStatus(const long& w);
+  void SetStatus(const ULong64_t w);
   void SetminTPCclsF(const short& s);
   void SetminTPCncls(const short& s);
   void SetminITScls(const int& s);
@@ -80,7 +80,7 @@ public:
   std::pair<float, float> GetProbProton() const { return std::make_pair(fPidProbProton[0], fPidProbProton[1]); }
   std::pair<float, float> GetProbMuon() const { return std::make_pair(fPidProbMuon[0], fPidProbMuon[1]); }
   bool GetLabel() const { return fLabel; }
-  long GetStatus() const { return fStatus; }
+  ULong64_t GetStatus() const { return fStatus; }
   int GetPIDmethod() const { return fPIDMethod; }
 
   int GetMinFindableClustersTPC() const { return fminTPCclsF; }
@@ -127,7 +127,7 @@ protected:   // here are the quantities I want to cut on...
 
   AliESDtrackCuts::ITSClusterRequirement fCutClusterRequirementITS[3];  ///< detailed ITS cluster requirements for (SPD, SDD, SSD) - from AliESDtrackcuts!
   bool              fLabel;              ///< if true label<0 will not pass throught
-  long              fStatus;             ///< staus flag
+  ULong64_t         fStatus;             ///< staus flag
   ReadPIDMethodType fPIDMethod;          ///< which PID mehod to use. 0 - nsgima, 1 - contour
   Bool_t            fNsigmaTPCTOF;       ///< true if squared nsigma from TPC and TOF, false if separately from TPC and TOF
   Bool_t            fNsigmaTPConly;      ///< true if nsigma from TPC only
@@ -186,7 +186,7 @@ protected:   // here are the quantities I want to cut on...
 
 #ifdef __ROOT__
   /// \cond CLASSIMP
-  ClassDef(AliFemtoESDTrackCut, 1);
+  ClassDef(AliFemtoESDTrackCut, 2);
   /// \endcond
 #endif
 };
@@ -203,7 +203,7 @@ inline void AliFemtoESDTrackCut::SetPidProbProton
 (const float& lo,const float& hi){fPidProbProton[0]=lo; fPidProbProton[1]=hi;}
 inline void AliFemtoESDTrackCut::SetPidProbMuon(const float& lo,const float& hi){fPidProbMuon[0]=lo; fPidProbMuon[1]=hi;}
 inline void AliFemtoESDTrackCut::SetLabel(const bool& flag){fLabel=flag;}
-inline void AliFemtoESDTrackCut::SetStatus(const long& status){fStatus=status;}
+inline void AliFemtoESDTrackCut::SetStatus(const ULong64_t status){fStatus=status;}
 inline void AliFemtoESDTrackCut::SetminTPCclsF(const short& minTPCclsF){fminTPCclsF=minTPCclsF;}
 inline void AliFemtoESDTrackCut::SetminTPCncls(const short& s){fminTPCncls=s;}
 inline void AliFemtoESDTrackCut::SetminITScls(const int& minITScls){fminITScls=minITScls;}

--- a/PWGHF/correlationHF/AliAnalysisTaskSEHFCJqa.cxx
+++ b/PWGHF/correlationHF/AliAnalysisTaskSEHFCJqa.cxx
@@ -537,7 +537,7 @@ Bool_t AliAnalysisTaskSEHFCJqa::FillTrackHistosAndSelectTrack(AliAODTrack *aodtr
 
   // check refit status
   Int_t refit=-1;
-  UInt_t status = esdtrack.GetStatus();
+  ULong64_t status = esdtrack.GetStatus();
   if(status&AliESDtrack::kTPCrefit)refit+=1;
   if(status&AliESDtrack::kITSrefit)refit+=2;
   point[11]=refit;

--- a/PWGHF/jetsHF/AliAnalysisTaskEmcalHFCJQA.cxx
+++ b/PWGHF/jetsHF/AliAnalysisTaskEmcalHFCJQA.cxx
@@ -1028,7 +1028,7 @@ Bool_t AliAnalysisTaskEmcalHFCJQA::FillTrackHistosAndSelectTrack(AliAODTrack *ao
 
   // check refit status
   Int_t refit=-1;
-  UInt_t status = esdtrack.GetStatus();
+  ULong64_t status = esdtrack.GetStatus();
   if(status&AliESDtrack::kTPCrefit)refit+=1;
   if(status&AliESDtrack::kITSrefit)refit+=2;
   point[11]=refit;

--- a/PWGLF/SPECTRA/PiKaPr/TOF/PbPb276/libs/AliAnalysisTrack.h
+++ b/PWGLF/SPECTRA/PiKaPr/TOF/PbPb276/libs/AliAnalysisTrack.h
@@ -34,7 +34,7 @@ public TObject
   Float_t GetPhi() const {return fPhi;}; // get phi
   Float_t GetY(Float_t mass) const; // get Y
   Double_t GetSign() const {return fSign;}; // get sign
-  ULong_t GetStatus() const {return fStatus;}; // get status
+  ULong64_t GetStatus() const {return fStatus;}; // get status
   Int_t GetLabel() const {return fLabel;}; // get label
   Float_t GetImpactParameter(Int_t i) const {return fImpactParameter[i];}; // get impact parameter
   Float_t GetImpactParameterCov(Int_t i) const {return fImpactParameterCov[i];}; // get impact parameter covariance
@@ -143,7 +143,7 @@ public TObject
   Float_t fEta; // eta
   Float_t fPhi; // phi
   Double_t fSign; // sign
-  ULong_t fStatus; // status
+  ULong64_t fStatus; // status
   Int_t fLabel; // label
   Float_t fImpactParameter[2]; // impact parameters 
   Float_t fImpactParameterCov[3]; // impact parameters covariance
@@ -206,7 +206,7 @@ public TObject
 
   Float_t fTimeZeroSigma; //!
 
-  ClassDef(AliAnalysisTrack, 9);
+  ClassDef(AliAnalysisTrack, 10);
 };
 
 #endif /* ALIANALYSISTRACK_H */

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFfits/AliAnalysisPIDTrack.h
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFfits/AliAnalysisPIDTrack.h
@@ -36,7 +36,7 @@ public TObject
   Float_t GetPhi() const {return fPhi;}; // get phi
   Float_t GetY(Float_t mass) const; // get Y
   Double_t GetSign() const {return fSign;}; // get sign
-  ULong_t GetStatus() const {return fStatus;}; // get status
+  ULong64_t GetStatus() const {return fStatus;}; // get status
   Int_t GetLabel() const {return fLabel;}; // get label
   Float_t GetImpactParameter(Int_t i) const {return fImpactParameter[i];}; // get impact parameter
   //Float_t GetImpactParameterCov(Int_t i) const {return fImpactParameterCov[i];}; // get impact parameter covariance
@@ -164,7 +164,7 @@ public TObject
   Float_t fEta; // eta
   Float_t fPhi; // phi
   Double_t fSign; // sign
-  ULong_t fStatus; // status
+  ULong64_t fStatus; // status
   Int_t fLabel; // label
   Float_t fImpactParameter[2]; // impact parameters 
   //Float_t fImpactParameterCov[3]; // impact parameters covariance
@@ -240,7 +240,7 @@ public TObject
 
   Float_t fTimeZeroSigma; //!
 
-  ClassDef(AliAnalysisPIDTrack, 4);
+  ClassDef(AliAnalysisPIDTrack, 5);
 };
 
 #endif /* ALIANALYSISPIDTRACK_H */


### PR DESCRIPTION
Since the bit mask of AliESDtrack needs to use >32 bits, all getters and setters of Alice track type
(starting from AliVParticle) status (GetStatus, SetStatus) are returning/acceptring ULong64_t instead
of ULong_t