### PR TITLE
Updated CEPRawBuffers with veto information based on EMCal data

### DIFF
--- a/PWGUD/DIFFRACTIVE/CEPdevel/AliAnalysisTaskCEP.cxx
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/AliAnalysisTaskCEP.cxx
@@ -1082,7 +1082,7 @@ void AliAnalysisTaskCEP::UserExec(Option_t *)
     if (fCEPUtil->checkstatus(fAnalysisStatus,
       AliCEPBase::kBitRawBuffer,AliCEPBase::kBitRawBuffer)) {
       
-      fCEPRawEvent->SetEventVariables(fESDEvent);
+      fCEPRawEvent->SetEventVariables(fESDEvent,TTindices);
       
     }
     

--- a/PWGUD/DIFFRACTIVE/CEPdevel/RawBuffers/CEPRawCaloClusterTrack.cxx
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/RawBuffers/CEPRawCaloClusterTrack.cxx
@@ -22,6 +22,8 @@ CEPRawCaloClusterTrack::CEPRawCaloClusterTrack()
   , fM20(CEPTrackBuffer::kdumval)
   , fM02(CEPTrackBuffer::kdumval)
   , fTime(CEPTrackBuffer::kdumval)
+  , fPhiEtaDistToNearestTrack(999.)
+  , fHasTrackToMatch(kFALSE)
 {
     this->Reset(); 
 }
@@ -39,6 +41,8 @@ void CEPRawCaloClusterTrack::Reset()
     fGlobalPos[0] = -999.;
     fGlobalPos[1] = -999.;
     fGlobalPos[2] = -999.;
+    fPhiEtaDistToNearestTrack = 999.;
+    fHasTrackToMatch = kFALSE;
 }
 
 // ____________________________________________________________________________
@@ -64,7 +68,14 @@ void CEPRawCaloClusterTrack::GetCaloClusterGlobalPosition(Float_t &x, Float_t &y
 }
 
 // ____________________________________________________________________________
-void CEPRawCaloClusterTrack::SetCaloClusterVariables(AliESDCaloCluster* ClusterObj, AliESDCaloCells* CaloCells)
+Bool_t CEPRawCaloClusterTrack::IsClusterFromBG(Double_t cutdPhiEta) const
+{
+    if (fHasTrackToMatch && fPhiEtaDistToNearestTrack<cutdPhiEta) return kFALSE;
+    else return kTRUE;
+}
+
+// ____________________________________________________________________________
+void CEPRawCaloClusterTrack::SetCaloClusterVariables(AliESDCaloCluster* ClusterObj, AliESDCaloCells* CaloCells, AliESDEvent* ESDobj, TArrayI* TTindices)
 {
     // Global member variable setter
     this->SetCaloClusterE(ClusterObj->E());
@@ -78,8 +89,8 @@ void CEPRawCaloClusterTrack::SetCaloClusterVariables(AliESDCaloCluster* ClusterO
     Float_t x[3];
     ClusterObj->GetPosition(x);
     this->SetCaloClusterGlobalPosition(x);
-
-    if (ClusterObj->IsEMCAL() && ClusterObj->GetNCells()>0){
+    // get the time in the most energetic cell in the cluster
+    if (ClusterObj->IsEMCAL() && ClusterObj->GetNCells()>0) {
         // variable preperation for easier readability
         Double_t cellAmpl_max, cellAmpl;
         Short_t cellNb, cellNb_max_ampl;
@@ -92,7 +103,52 @@ void CEPRawCaloClusterTrack::SetCaloClusterVariables(AliESDCaloCluster* ClusterO
             if (cellAmpl>=cellAmpl_max) { cellAmpl_max = cellAmpl; cellNb_max_ampl = cellNb; }
         }
         fTime = CaloCells->GetCellTime(cellNb_max_ampl);
-    } else fTime = -999.;
+    
+        // /////////////////////////////////////////////////////////////////////////////
+        // -------------- get the distance to the nearest track ------------------------
+        // contruct the track-TObjArray here
+        TObjArray* track_arr = new TObjArray();
+        track_arr->SetOwner(kTRUE);
+        AliESDtrack* trk = 0x0;
+        for (Int_t kk(0); kk<ESDobj->GetNumberOfTracks(); kk++){
+            trk = (AliESDtrack*) ESDobj->GetTrack(kk); 
+            if (!trk) continue;
+            track_arr->Add(trk);
+        }
+        Double_t dPhiEtaMin = 999.;
+        Float_t x[3];
+        ClusterObj->GetPosition(x);
+        TVector3 v3(x[0], x[1], x[2]);
+        // v3 phi is in the range [-pi,pi) -> map it to [0, 2pi)
+        Double_t cluster_phi = (v3.Phi()>0.) ? v3.Phi() : v3.Phi() + 2.*TMath::Pi();
+        Double_t cluster_eta = v3.Eta();
+        for (Int_t kk(0); kk<TTindices->GetSize(); kk++) {
+            Int_t trkIndex = TTindices->At(kk);
+            AliESDtrack *tmptrk = (AliESDtrack*) track_arr->At(trkIndex);
+            // track position on emcal
+            Double_t trkPhiOnEmc = tmptrk->GetTrackPhiOnEMCal();
+            // Map phi to [0,2pi)
+            trkPhiOnEmc = (trkPhiOnEmc>0.) ? trkPhiOnEmc : trkPhiOnEmc+2.*TMath::Pi();
+            if (trkPhiOnEmc<0.) trkPhiOnEmc=-999.;
+            Double_t trkEtaOnEmc = tmptrk->GetTrackEtaOnEMCal();
+            // no matching if at least one has value -999.
+            if (trkPhiOnEmc==-999. || trkEtaOnEmc==-999.) continue;
+            // in case of track on emcal: calculate distance in phi and eta
+            Double_t dEta = trkEtaOnEmc - cluster_eta;
+            Double_t dPhi = trkPhiOnEmc - cluster_phi;
+            Double_t dPhiEta = TMath::Sqrt( dEta*dEta + dPhi*dPhi );
+
+            dPhiEtaMin = (dPhiEtaMin<dPhiEta) ? dPhiEtaMin : dPhiEta;
+        }
+        fPhiEtaDistToNearestTrack = dPhiEtaMin;
+        fHasTrackToMatch = (dPhiEtaMin==999.) ? kFALSE : kTRUE;
+        // clear tracks
+        if (track_arr) {
+            track_arr->Clear();
+            delete track_arr;
+            track_arr = 0x0;
+        }
+    } 
 }
 
 // ____________________________________________________________________________

--- a/PWGUD/DIFFRACTIVE/CEPdevel/RawBuffers/CEPRawCaloClusterTrack.h
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/RawBuffers/CEPRawCaloClusterTrack.h
@@ -3,6 +3,7 @@
 
 #include "AliESDCaloCluster.h"
 #include "AliESDCaloCells.h"
+#include "AliESDEvent.h"
 
 class CEPRawCaloClusterTrack : public TObject {
 
@@ -26,6 +27,11 @@ class CEPRawCaloClusterTrack : public TObject {
     Double_t        fM20;            /// 2nd moment along the second eigen axis
     /// Time in the higest amplitude cell
     Double_t        fTime;
+    /// Distant in eta-phi space to the nearest track
+    Double_t        fPhiEtaDistToNearestTrack;
+    /// Is there even a possibility to match tracks
+    Bool_t          fHasTrackToMatch;
+
 
   public:
                     CEPRawCaloClusterTrack();
@@ -49,7 +55,10 @@ class CEPRawCaloClusterTrack : public TObject {
 
 
     /// Global Setter
-    void            SetCaloClusterVariables(AliESDCaloCluster* ClusterObj, AliESDCaloCells* CaloCells);
+    void            SetCaloClusterVariables(AliESDCaloCluster* ClusterObj, 
+                                            AliESDCaloCells* CaloCells,
+                                            AliESDEvent* ESDobj,
+                                            TArrayI* TTindices);
 
     /// Accessors
     Float_t         GetCaloClusterE()                 const { return fE;           }
@@ -62,6 +71,15 @@ class CEPRawCaloClusterTrack : public TObject {
     Float_t         GetCaloClusterM20()   const  { return fM20; }
     Float_t         GetCaloClusterM02()   const  { return fM02; }
     Float_t         GetCaloClusterTime()  const  { return fTime; }
+
+    Float_t         GetCaloClusterEtaPhiDistNearTrk() const { return fPhiEtaDistToNearestTrack; }
+    Bool_t          GetCaloClusterHasTrkToMatch() const { return fHasTrackToMatch; }
+    // to test if cluster is bg we check:
+    //  - if (!fHasTrackToMatch)
+    //  or if(fPhiEtaDistToNearestTrack>cutdPhiEta)
+    //  the last part has to be done as many clusters arise from pions but these clusters are
+    //  mostly close to the the pion track
+    Bool_t          IsClusterFromBG(Double_t cutdPhiEta) const;
     
     void            GetCaloClusterGlobalPosition(Float_t &x, Float_t &y, Float_t &z);
 

--- a/PWGUD/DIFFRACTIVE/CEPdevel/RawBuffers/CEPRawEventBuffer.cxx
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/RawBuffers/CEPRawEventBuffer.cxx
@@ -188,7 +188,7 @@ Bool_t CEPRawEventBuffer::RemoveCaloCluster(UInt_t ind)
 }
 
 //______________________________________________________________________________
-void CEPRawEventBuffer::SetEventVariables(AliESDEvent* ESDobj)
+void CEPRawEventBuffer::SetEventVariables(AliESDEvent* ESDobj, TArrayI* TTindices)
 {
     this->Reset();
     // Set event number
@@ -243,7 +243,8 @@ void CEPRawEventBuffer::SetEventVariables(AliESDEvent* ESDobj)
         // get calo cluster from the ESD object
         aliCluster = (AliESDCaloCluster*)ESDobj->GetCaloCluster(i);
         // fill raw calo-cluster buffer
-        caloTrk->SetCaloClusterVariables(aliCluster, (AliESDCaloCells*)ESDobj->GetEMCALCells());
+        caloTrk->SetCaloClusterVariables(aliCluster, (AliESDCaloCells*)ESDobj->GetEMCALCells(),
+                                         ESDobj, TTindices);
         // add track to the 
         AddCaloTrack(caloTrk);
     }

--- a/PWGUD/DIFFRACTIVE/CEPdevel/RawBuffers/CEPRawEventBuffer.h
+++ b/PWGUD/DIFFRACTIVE/CEPdevel/RawBuffers/CEPRawEventBuffer.h
@@ -79,7 +79,7 @@ class CEPRawEventBuffer : public TObject
     void                        SetTotalPHOSTime(Float_t tme)       { fPHOSTotalTime      = tme;  }
         
     /// Global variable setter
-    void                        SetEventVariables(AliESDEvent* ESDobj);
+    void                        SetEventVariables(AliESDEvent* ESDobj, TArrayI* TTindices);
 
     /// Modifiers
     void                        Reset();


### PR DESCRIPTION
CEPRawBuffer was updadet with EMCal informtion which allows to veto on events with a gamma measured in the EMCal and thus to refine the DoubleGap event selection.