### PR TITLE
PWGGA/GammaConv: post calibration related stuffs

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
@@ -77,6 +77,7 @@ AliAnalysisTaskGammaConvV1::AliAnalysisTaskGammaConvV1(): AliAnalysisTaskSE(),
   fMesonDCAList(NULL),
   fTrueList(NULL),
   fMCList(NULL),
+  fGammaTrkQAList(NULL),
   fHeaderNameList(NULL),
   fOutputContainer(0),
   fReaderGammas(NULL),
@@ -259,12 +260,37 @@ AliAnalysisTaskGammaConvV1::AliAnalysisTaskGammaConvV1(): AliAnalysisTaskSE(),
   fIsFromSelectedHeader(kTRUE),
   fIsMC(0),
   fDoTHnSparse(kTRUE),
+  fDoGammaTrkQA(kTRUE),
   fWeightJetJetMC(1),
   fWeightCentrality(NULL),
   fEnableClusterCutsForTrigger(kFALSE),
   fDoMaterialBudgetWeightingOfGammasForTrueMesons(kFALSE),
   tBrokenFiles(NULL),
-  fFileNameBroken(NULL)
+  fFileNameBroken(NULL),
+  sGammaPtEtaPhi(NULL),
+  sGammaAPMassPt(NULL),
+  sGammaCat1CosDCARPt(NULL),
+  sGammaCat2CosDCARPt(NULL),
+  sGammaCat3CosDCARPt(NULL),
+  sGammaXYZR(NULL),
+  sElePtEtaPhi(NULL),
+  sElenSigPEtaR(NULL),
+  sElenSigPiKPrP(NULL),
+  sEleTOFnSigP(NULL),
+  sPosPtEtaPhi(NULL),
+  sPosnSigPEtaR(NULL),
+  sPosnSigPiKPrP(NULL),
+  sPosTOFnSigP(NULL),
+  sCorElenSigPEtaR(NULL),
+  sCorPosnSigPEtaR(NULL),
+  fHistoEleNfindableClsTPC(NULL),
+  fHistoEleClsTPC(NULL),
+  fHistoPosNfindableClsTPC(NULL),
+  fHistoPosClsTPC(NULL),
+  fHistoGammaChi2PsiPair(NULL),  
+  fHistoITSClusterPhi(NULL),
+  fHistoNBunch(NULL)
+
 {
 
 }
@@ -287,6 +313,7 @@ AliAnalysisTaskGammaConvV1::AliAnalysisTaskGammaConvV1(const char *name):
   fMesonDCAList(NULL),
   fTrueList(NULL),
   fMCList(NULL),
+  fGammaTrkQAList(NULL),
   fHeaderNameList(NULL),
   fOutputContainer(0),
   fReaderGammas(NULL),
@@ -469,12 +496,37 @@ AliAnalysisTaskGammaConvV1::AliAnalysisTaskGammaConvV1(const char *name):
   fIsFromSelectedHeader(kTRUE),
   fIsMC(0),
   fDoTHnSparse(kTRUE),
+  fDoGammaTrkQA(kTRUE),
   fWeightJetJetMC(1),
   fWeightCentrality(NULL),
   fEnableClusterCutsForTrigger(kFALSE),
   fDoMaterialBudgetWeightingOfGammasForTrueMesons(kFALSE),
   tBrokenFiles(NULL),
-  fFileNameBroken(NULL)
+  fFileNameBroken(NULL),
+  sGammaPtEtaPhi(NULL),
+  sGammaAPMassPt(NULL),
+  sGammaCat1CosDCARPt(NULL),
+  sGammaCat2CosDCARPt(NULL),
+  sGammaCat3CosDCARPt(NULL),
+  sGammaXYZR(NULL),
+  sElePtEtaPhi(NULL),
+  sElenSigPEtaR(NULL),
+  sElenSigPiKPrP(NULL),
+  sEleTOFnSigP(NULL),
+  sPosPtEtaPhi(NULL),
+  sPosnSigPEtaR(NULL),
+  sPosnSigPiKPrP(NULL),
+  sPosTOFnSigP(NULL),
+  sCorElenSigPEtaR(NULL),
+  sCorPosnSigPEtaR(NULL),
+  fHistoEleNfindableClsTPC(NULL),
+  fHistoEleClsTPC(NULL),
+  fHistoPosNfindableClsTPC(NULL),
+  fHistoPosClsTPC(NULL),
+  fHistoGammaChi2PsiPair(NULL),  
+  fHistoITSClusterPhi(NULL),
+  fHistoNBunch(NULL)
+
 {
   // Define output slots here
   DefineOutput(1, TList::Class());
@@ -817,6 +869,10 @@ void AliAnalysisTaskGammaConvV1::UserCreateOutputObjects(){
     fMotherList             = new TList*[fnCuts];
   }
 
+  if(fDoGammaTrkQA){
+    fGammaTrkQAList         = new TList*[fnCuts];
+  }
+  
   fHistoNEvents             = new TH1F*[fnCuts];
   if (fIsMC > 1){
     fHistoNEventsWOWeight   = new TH1F*[fnCuts];
@@ -883,8 +939,35 @@ void AliAnalysisTaskGammaConvV1::UserCreateOutputObjects(){
     fHistoCaloGammaPt           = new TH1F*[fnCuts];
     fHistoCaloGammaE            = new TH1F*[fnCuts];
   }
+  if(fDoGammaTrkQA){
+   
+    sGammaPtEtaPhi         = new THnSparse*[fnCuts];
+    sGammaAPMassPt         = new THnSparse*[fnCuts];
+    sGammaCat1CosDCARPt    = new THnSparse*[fnCuts];
+    sGammaCat2CosDCARPt    = new THnSparse*[fnCuts];
+    sGammaCat3CosDCARPt    = new THnSparse*[fnCuts];
+    sGammaXYZR             = new THnSparse*[fnCuts];
+    sElePtEtaPhi           = new THnSparse*[fnCuts];
+    sElenSigPEtaR          = new THnSparse*[fnCuts];
+    sElenSigPiKPrP         = new THnSparse*[fnCuts];
+    sEleTOFnSigP           = new THnSparse*[fnCuts];
+    sPosPtEtaPhi           = new THnSparse*[fnCuts];
+    sPosnSigPEtaR          = new THnSparse*[fnCuts];
+    sPosnSigPiKPrP         = new THnSparse*[fnCuts];
+    sPosTOFnSigP           = new THnSparse*[fnCuts];
+    sCorElenSigPEtaR       = new THnSparse*[fnCuts];
+    sCorPosnSigPEtaR       = new THnSparse*[fnCuts];
+    fHistoEleNfindableClsTPC = new TH1F*[fnCuts];
+    fHistoEleClsTPC          = new TH1F*[fnCuts];
+    fHistoPosNfindableClsTPC = new TH1F*[fnCuts];
+    fHistoPosClsTPC          = new TH1F*[fnCuts];
+    fHistoGammaChi2PsiPair   = new TH2F*[fnCuts];
+    fHistoITSClusterPhi      = new TH2F*[fnCuts];
+    fHistoNBunch             = new TH1F*[fnCuts];
+  }
 
 
+  
   for(Int_t iCut = 0; iCut<fnCuts;iCut++){
 
     TString cutstringEvent      = ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetCutNumber();
@@ -1175,6 +1258,122 @@ void AliAnalysisTaskGammaConvV1::UserCreateOutputObjects(){
     }
 
 
+    if(fDoGammaTrkQA){
+      fGammaTrkQAList[iCut] = new TList();
+      fGammaTrkQAList[iCut]->SetName("GammaTrkQA");
+      fGammaTrkQAList[iCut]->SetOwner(kTRUE);
+      fCutFolder[iCut]->Add(fGammaTrkQAList[iCut]);
+            
+      fHistoGammaChi2PsiPair[iCut] = new TH2F("Gamma_Chi2PsiPair","",60,0,30,100,-0.2,0.2); 
+      fGammaTrkQAList[iCut]->Add(fHistoGammaChi2PsiPair[iCut]);
+      fHistoITSClusterPhi[iCut] = new TH2F("ITSClusterPhi","",72,0,2*TMath::Pi(),5,-0.5,4.5); 
+      fGammaTrkQAList[iCut]->Add(fHistoITSClusterPhi[iCut]);
+      
+      //_______________________Pt___Eta____Phi__________
+      Int_t bins_base[3] =    {250, 180,   360};//pt,eta,phi
+      Double_t xmin_base[3] = {0., -0.9,   0.};
+      Double_t xmax_base[3] = {25., 0.9,   2*TMath::Pi()};
+      sGammaPtEtaPhi[iCut] = new THnSparseF("Gamma_PtEtaPhi","",3,bins_base,xmin_base,xmax_base);
+      sGammaPtEtaPhi[iCut]->Sumw2();
+      fGammaTrkQAList[iCut]->Add(sGammaPtEtaPhi[iCut]);
+      
+      //___________________________Arm__Pod__Mass__Pt____
+      Int_t bins_base_cut[4]    = {200, 100,  200, 250};//Arm,Pod,Mass,Pt
+      Double_t xmin_base_cut[4] = {-1.0, 0.,   0.,   0.};
+      Double_t xmax_base_cut[4] = { 1.0,0.1,  0.2,  25.};
+      sGammaAPMassPt[iCut] = new THnSparseF("Gamma_APMassPt","",4,bins_base_cut,xmin_base_cut,xmax_base_cut);
+      sGammaAPMassPt[iCut]->Sumw2();
+      fGammaTrkQAList[iCut]->Add(sGammaAPMassPt[iCut]);
+      
+      //________________________________CosPA___DCAz___R____Pt___
+      Int_t bins_base_cut2_cat[4]    = {250,   160,   360, 250};//cat,CosPA,DCAz,Pt
+      Double_t xmin_base_cut2_cat[4] = {0.995,    -8,    0, 0.};
+      Double_t xmax_base_cut2_cat[4] = {    1.,    8, 180, 25.};
+      //cat1
+      sGammaCat1CosDCARPt[iCut] = new THnSparseF("Gamma_Cat1CosDCARPt","",4,bins_base_cut2_cat,xmin_base_cut2_cat,xmax_base_cut2_cat);
+      sGammaCat1CosDCARPt[iCut]->Sumw2();
+      fGammaTrkQAList[iCut]->Add(sGammaCat1CosDCARPt[iCut]);
+      //cat2
+      sGammaCat2CosDCARPt[iCut] = new THnSparseF("Gamma_Cat2CosDCARPt","",4,bins_base_cut2_cat,xmin_base_cut2_cat,xmax_base_cut2_cat);
+      sGammaCat2CosDCARPt[iCut]->Sumw2();
+      fGammaTrkQAList[iCut]->Add(sGammaCat2CosDCARPt[iCut]);       
+      //cat3
+      sGammaCat3CosDCARPt[iCut] = new THnSparseF("Gamma_Cat3CosDCARPt","",4,bins_base_cut2_cat,xmin_base_cut2_cat,xmax_base_cut2_cat);
+      sGammaCat3CosDCARPt[iCut]->Sumw2();
+      fGammaTrkQAList[iCut]->Add(sGammaCat3CosDCARPt[iCut]);
+      
+      //______________________________X_____Y_____Z____R___
+      Int_t bins_base_conv[4]    = { 240,  240,  300, 360};//XYZR
+      Double_t xmin_base_conv[4] = {-120, -120, -150, 0.};
+      Double_t xmax_base_conv[4] = { 120,  120,  150, 180};
+      sGammaXYZR[iCut] = new THnSparseF("Gamma_ConvXYZR","",4,bins_base_conv,xmin_base_conv,xmax_base_conv);
+      sGammaXYZR[iCut]->Sumw2();
+      fGammaTrkQAList[iCut]->Add(sGammaXYZR[iCut]);
+      
+      //___________________ElePos_____Pt_____Eta___Phi_________
+      Int_t bins_base_ele[3]    = {250, 180,   360};//pt,eta,phi
+      Double_t xmin_base_ele[3] = {0., -0.9,   0.};
+      Double_t xmax_base_ele[3] = {25., 0.9,   2*TMath::Pi()};
+      sElePtEtaPhi[iCut] = new THnSparseF("Ele_PtEtaPhi","",3,bins_base_ele,xmin_base_ele,xmax_base_ele);
+      sElePtEtaPhi[iCut]->Sumw2();
+      fGammaTrkQAList[iCut]->Add(sElePtEtaPhi[iCut]);
+      sPosPtEtaPhi[iCut] = new THnSparseF("Pos_PtEtaPhi","",3,bins_base_ele,xmin_base_ele,xmax_base_ele);
+      sPosPtEtaPhi[iCut]->Sumw2();
+      fGammaTrkQAList[iCut]->Add(sPosPtEtaPhi[iCut]);
+      
+      //___________________ElePos______nSig_P_Eta_R_________
+      Int_t bins_base_ele_PID[4]    = {100, 250,  180,   180};//nSigma, P, Eta, R
+      Double_t xmin_base_ele_PID[4] = { -5,  0., -0.9,    0.};
+      Double_t xmax_base_ele_PID[4] = {  5, 25.,  0.9,   180};
+      sElenSigPEtaR[iCut] = new THnSparseF("Ele_nSigPEtaR","",4,bins_base_ele_PID,xmin_base_ele_PID,xmax_base_ele_PID);
+      sElenSigPEtaR[iCut]->Sumw2();
+      fGammaTrkQAList[iCut]->Add(sElenSigPEtaR[iCut]);
+      sPosnSigPEtaR[iCut] = new THnSparseF("Pos_nSigPEtaR","",4,bins_base_ele_PID,xmin_base_ele_PID,xmax_base_ele_PID);
+      sPosnSigPEtaR[iCut]->Sumw2();
+      fGammaTrkQAList[iCut]->Add(sPosnSigPEtaR[iCut]);
+      sCorElenSigPEtaR[iCut] = new THnSparseF("CorEle_nSigPEtaR","",4,bins_base_ele_PID,xmin_base_ele_PID,xmax_base_ele_PID);
+      sCorElenSigPEtaR[iCut]->Sumw2();
+      fGammaTrkQAList[iCut]->Add(sCorElenSigPEtaR[iCut]);
+      sCorPosnSigPEtaR[iCut] = new THnSparseF("CorPos_nSigPEtaR","",4,bins_base_ele_PID,xmin_base_ele_PID,xmax_base_ele_PID);
+      sCorPosnSigPEtaR[iCut]->Sumw2();
+      fGammaTrkQAList[iCut]->Add(sCorPosnSigPEtaR[iCut]);
+      
+      //___________________ElePos___nSig___Pi______K_____Pr_____P_________
+      Int_t bins_base_ele_PID_PiKPr[4]    = {150,    150,  150,    100};//nSigma, P, Eta, R
+      Double_t xmin_base_ele_PID_PiKPr[4] = { -15,  -15., -15.,   0.05};
+      Double_t xmax_base_ele_PID_PiKPr[4] = {  15,   15.,  15,      20};
+      sElenSigPiKPrP[iCut] = new THnSparseF("Ele_nSigPiKPrP","",4,bins_base_ele_PID_PiKPr,xmin_base_ele_PID_PiKPr,xmax_base_ele_PID_PiKPr);
+      sElenSigPiKPrP[iCut]->Sumw2();
+      fGammaTrkQAList[iCut]->Add(sElenSigPiKPrP[iCut]);
+      sPosnSigPiKPrP[iCut] = new THnSparseF("Pos_nSigPiKPrP","",4,bins_base_ele_PID_PiKPr,xmin_base_ele_PID_PiKPr,xmax_base_ele_PID_PiKPr);
+      sPosnSigPiKPrP[iCut]->Sumw2();
+      fGammaTrkQAList[iCut]->Add(sPosnSigPiKPrP[iCut]);
+      
+      //elepos_cls
+      fHistoEleNfindableClsTPC[iCut] = new TH1F("Ele_findableClusterTPC","",100,0,1);
+      fGammaTrkQAList[iCut]->Add(fHistoEleNfindableClsTPC[iCut] );
+      fHistoEleClsTPC[iCut] = new TH1F("Ele_ClusterTPC","",200,0,200);
+      fGammaTrkQAList[iCut]->Add(fHistoEleClsTPC[iCut]);
+      fHistoPosNfindableClsTPC[iCut] = new TH1F("Pos_findableClusterTPC","",100,0,1);
+      fGammaTrkQAList[iCut]->Add(fHistoPosNfindableClsTPC[iCut] );
+      fHistoPosClsTPC[iCut] = new TH1F("Pos_ClusterTPC","",200,0,200);
+      fGammaTrkQAList[iCut]->Add(fHistoPosClsTPC[iCut]);
+      
+      //___________________ElePos_______________TOF____nSig____P_________
+      Int_t bins_base_ele_PID_TOF[3]    = {600,     100,   100};//TOF, nSig, P
+      Double_t xmin_base_ele_PID_TOF[3] = {-1000,   -5.,  0.05};
+      Double_t xmax_base_ele_PID_TOF[3] = {29000,    5.,    20};
+      sEleTOFnSigP[iCut] = new THnSparseF("Ele_TOFnSigP","",3,bins_base_ele_PID_TOF,xmin_base_ele_PID_TOF,xmax_base_ele_PID_TOF);
+      sEleTOFnSigP[iCut]->Sumw2();
+      fGammaTrkQAList[iCut]->Add(sEleTOFnSigP[iCut]);
+      sPosTOFnSigP[iCut] = new THnSparseF("Pos_TOFnSigP","",3,bins_base_ele_PID_TOF,xmin_base_ele_PID_TOF,xmax_base_ele_PID_TOF);
+      sPosTOFnSigP[iCut]->Sumw2();
+      fGammaTrkQAList[iCut]->Add(sPosTOFnSigP[iCut]);
+      
+      fHistoNBunch[iCut] = new TH1F("NBunch","NBunch",4000,-0.5,3999.5);
+      fGammaTrkQAList[iCut]->Add(fHistoNBunch[iCut]);
+    }
+    
   }
   if(fDoMesonAnalysis){
     InitBack(); // Init Background Handler
@@ -2063,6 +2262,9 @@ void AliAnalysisTaskGammaConvV1::ProcessPhotonCandidates()
 
 
     if(!((AliConversionPhotonCuts*)fCutArray->At(fiCut))->PhotonIsSelected(PhotonCandidate,fInputEvent)) continue;
+
+    PhotonCandidatesQA(PhotonCandidate);//added to create correction map
+    
     if(!((AliConversionPhotonCuts*)fCutArray->At(fiCut))->InPlaneOutOfPlaneCut(PhotonCandidate->GetPhotonPhi(),fEventPlaneAngle)) continue;
     if(!((AliConversionPhotonCuts*)fCutArray->At(fiCut))->UseElecSharingCut() &&
       !((AliConversionPhotonCuts*)fCutArray->At(fiCut))->UseToCloseV0sCut()){
@@ -4337,4 +4539,182 @@ void AliAnalysisTaskGammaConvV1::ProcessClusters(){
     delete clus;
     delete tmpvec;
   }
+}
+//________________________________________________________________________
+void AliAnalysisTaskGammaConvV1::PhotonCandidatesQA(AliAODConversionPhoton *gamma)
+{
+
+  AliPIDResponse* fPIDResponse = ((AliConversionPhotonCuts*)fV0Reader->GetConversionCuts())->GetPIDResponse();
+  //  cout << gamma->GetPhotonPt() << endl;
+  Double_t cont[3];
+  cont[0]=gamma->GetPhotonPt();
+  cont[1]=gamma->Eta();
+  cont[2]=gamma->Phi();
+  sGammaPtEtaPhi[fiCut]->Fill(cont);
+
+  fHistoGammaChi2PsiPair[fiCut]->Fill(gamma->GetChi2perNDF(),gamma->GetPsiPair());
+  
+  Double_t cont_cutvar[4];
+  cont_cutvar[0]=gamma->GetArmenterosAlpha();
+  cont_cutvar[1]=gamma->GetArmenterosQt();
+  cont_cutvar[2]=gamma->GetInvMassPair();
+  cont_cutvar[3]=gamma->GetPhotonPt();
+  sGammaAPMassPt[fiCut]->Fill(cont_cutvar);
+
+  Int_t Qual = gamma->GetPhotonQuality();
+  Double_t cont_cutvar2[4];
+  cont_cutvar2[0]=((AliConversionPhotonCuts*)fCutArray->At(fiCut))->GetCosineOfPointingAngle(gamma,fInputEvent);
+  cont_cutvar2[1]=gamma->GetDCAzToPrimVtx();
+  cont_cutvar2[2]=gamma->GetConversionRadius();
+  cont_cutvar2[3]=gamma->GetPhotonPt();
+    
+  if(Qual==1){
+    sGammaCat1CosDCARPt[fiCut]->Fill(cont_cutvar2);
+  }else if(Qual==2){
+    sGammaCat2CosDCARPt[fiCut]->Fill(cont_cutvar2);
+  }else if(Qual==3){
+    sGammaCat3CosDCARPt[fiCut]->Fill(cont_cutvar2);
+  }
+
+  Double_t cont_convvar[4];
+  cont_convvar[0]=gamma->GetConversionX();
+  cont_convvar[1]=gamma->GetConversionY();
+  cont_convvar[2]=gamma->GetConversionZ();
+  cont_convvar[3]=gamma->GetConversionRadius();
+  sGammaXYZR[fiCut]->Fill(cont_convvar);
+  
+  AliVTrack* negTrack = ((AliConversionPhotonCuts*)fCutArray->At(fiCut))->GetTrack(fInputEvent, gamma->GetTrackLabelNegative());
+  AliVTrack* posTrack = ((AliConversionPhotonCuts*)fCutArray->At(fiCut))->GetTrack(fInputEvent, gamma->GetTrackLabelPositive());
+  if(!negTrack||!posTrack)return;
+  Int_t nPosClusterITS = 0;
+  Int_t nNegClusterITS = 0;
+  for(Int_t itsLayer = 0; itsLayer<6;itsLayer++){
+    if(TESTBIT(negTrack->GetITSClusterMap(),itsLayer)){
+      nNegClusterITS++;
+    }
+    if(TESTBIT(posTrack->GetITSClusterMap(),itsLayer)){
+      nPosClusterITS++;
+    }
+  }
+
+  fHistoITSClusterPhi[fiCut]->Fill(negTrack->Phi(),nNegClusterITS);
+  fHistoITSClusterPhi[fiCut]->Fill(posTrack->Phi(),nPosClusterITS);
+
+  Double_t cont_ele[3];
+  cont_ele[0] = negTrack->Pt(); 
+  cont_ele[1] = negTrack->Eta();
+  cont_ele[2] = negTrack->Phi();
+  sElePtEtaPhi[fiCut]->Fill(cont_ele);
+
+  Double_t cont_pos[3];
+  cont_pos[0] = posTrack->Pt();
+  cont_pos[1] = posTrack->Eta();
+  cont_pos[2] = posTrack->Phi();
+  sPosPtEtaPhi[fiCut]->Fill(cont_pos);
+
+  
+  fHistoEleClsTPC[fiCut]->Fill(negTrack->GetNcls(1));
+  fHistoPosClsTPC[fiCut]->Fill(posTrack->GetNcls(1));
+
+  fHistoEleNfindableClsTPC[fiCut]->Fill((Float_t)negTrack->GetTPCClusterInfo(2,0,((AliConversionPhotonCuts*)fCutArray->At(fiCut))->GetFirstTPCRow(gamma->GetConversionRadius())));
+  fHistoPosNfindableClsTPC[fiCut]->Fill((Float_t)posTrack->GetTPCClusterInfo(2,0,((AliConversionPhotonCuts*)fCutArray->At(fiCut))->GetFirstTPCRow(gamma->GetConversionRadius())));
+
+  Double_t cont_ele_PID[4];
+  cont_ele_PID[0] = fPIDResponse->NumberOfSigmasTPC(negTrack, AliPID::kElectron);
+  cont_ele_PID[1] = negTrack->P();
+  cont_ele_PID[2] = negTrack->Eta(); 
+  cont_ele_PID[3] = gamma->GetConversionRadius();
+  sElenSigPEtaR[fiCut]->Fill(cont_ele_PID);
+
+  Double_t cont_pos_PID[4];
+  cont_pos_PID[0] = fPIDResponse->NumberOfSigmasTPC(posTrack, AliPID::kElectron);
+  cont_pos_PID[1] = posTrack->P();
+  cont_pos_PID[2] = posTrack->Eta(); 
+  cont_pos_PID[3] = gamma->GetConversionRadius();
+  sPosnSigPEtaR[fiCut]->Fill(cont_pos_PID);
+
+  Double_t cont_ele_PID_PiKPr[4];
+  cont_ele_PID_PiKPr[0] =fPIDResponse->NumberOfSigmasTPC(negTrack, AliPID::kPion);
+  cont_ele_PID_PiKPr[1] =fPIDResponse->NumberOfSigmasTPC(negTrack, AliPID::kKaon);
+  cont_ele_PID_PiKPr[2] =fPIDResponse->NumberOfSigmasTPC(negTrack, AliPID::kProton);
+  cont_ele_PID_PiKPr[3] =negTrack->P();
+  sElenSigPiKPrP[fiCut]->Fill(cont_ele_PID_PiKPr);
+
+  Double_t cont_pos_PID_PiKPr[4];
+  cont_pos_PID_PiKPr[0] =fPIDResponse->NumberOfSigmasTPC(posTrack, AliPID::kPion);
+  cont_pos_PID_PiKPr[1] =fPIDResponse->NumberOfSigmasTPC(posTrack, AliPID::kKaon);
+  cont_pos_PID_PiKPr[2] =fPIDResponse->NumberOfSigmasTPC(posTrack, AliPID::kProton);
+  cont_pos_PID_PiKPr[3] =posTrack->P();
+  sPosnSigPiKPrP[fiCut]->Fill(cont_pos_PID_PiKPr);
+
+  // Double_t CentrnSig[2] ={-1,-1};
+  // Double_t P[2]         ={-1,-1};
+  // Double_t Eta[2]       ={-1,-1};
+  // Double_t R         =-1;
+  // CentrnSig[0]=fPIDResponse->NumberOfSigmasTPC(negTrack,AliPID::kElectron);
+  // CentrnSig[1]=fPIDResponse->NumberOfSigmasTPC(posTrack,AliPID::kElectron);
+  // P[0]        =negTrack->P();
+  // P[1]        =posTrack->P();
+  // Eta[0]      =negTrack->Eta();
+  // Eta[1]      =posTrack->Eta();
+  // R           =gamma->GetConversionRadius();
+  // cout << "\x1b[32m     "<< ((AliConversionPhotonCuts*)fCutArray->At(fiCut))->GetCorrectednSigmaN(CentrnSig[0],P[0],Eta[0],R) << " \x1b[39m" <<endl;
+  // cout << "\x1b[33m     "<< ((AliConversionPhotonCuts*)fCutArray->At(fiCut))->GetCorrectednSigmaP(CentrnSig[1],P[1],Eta[1],R) << " \x1b[39m" <<endl; 
+
+  /*   for the moment comment out
+  Double_t cont_ele_corPID[4];
+  cont_ele_corPID[0] = ((AliConversionPhotonCuts*)fCutArray->At(fiCut))->GetCorrectednSigmaN(fPIDResponse->NumberOfSigmasTPC(negTrack,AliPID::kElectron),negTrack->P(),negTrack->Eta(),gamma->GetConversionRadius());
+  cont_ele_corPID[1] = negTrack->P();
+  cont_ele_corPID[2] = negTrack->Eta(); 
+  cont_ele_corPID[3] = gamma->GetConversionRadius();
+  sCorElenSigPEtaR[fiCut]->Fill(cont_ele_corPID);
+
+  Double_t cont_pos_corPID[4];
+  cont_pos_corPID[0] = ((AliConversionPhotonCuts*)fCutArray->At(fiCut))->GetCorrectednSigmaP(fPIDResponse->NumberOfSigmasTPC(posTrack,AliPID::kElectron),posTrack->P(),posTrack->Eta(),gamma->GetConversionRadius());
+  cont_pos_corPID[1] = posTrack->P();
+  cont_pos_corPID[2] = posTrack->Eta(); 
+  cont_pos_corPID[3] = gamma->GetConversionRadius();
+  sCorPosnSigPEtaR[fiCut]->Fill(cont_pos_corPID);
+  */
+  
+  //____________________________TOF dEdx____________________________
+  Bool_t nTOFisthere = kFALSE;
+  //  Bool_t nTOFNoSignal = kFALSE;
+  //  Bool_t nTOFMismatch = kFALSE;
+
+  AliPIDResponse::EDetPidStatus statusnTOF = fPIDResponse->CheckPIDStatus(AliPIDResponse::kTOF,negTrack);
+  if(statusnTOF == AliPIDResponse::kDetPidOk) nTOFisthere = kTRUE;
+  //  if(statusnTOF == AliPIDResponse::kDetNoSignal) nTOFNoSignal = kTRUE;
+  //  if(statusnTOF == AliPIDResponse::kDetMismatch) nTOFMismatch = kTRUE;
+
+  //  if((negTrack->GetStatus() & AliESDtrack::kTOFfPID)==0 && !(negTrack->GetStatus() & AliESDtrack::kTOFmismatch)){
+  if(nTOFisthere){
+    Double_t timesNeg[9];
+    negTrack->GetIntegratedTimes(timesNeg,9);
+    Double_t dTneg = negTrack->GetTOFsignal() - fPIDResponse->GetTOFResponse().GetStartTime(negTrack->P()) - timesNeg[0];
+    Double_t cont_ele_TOF[2];
+    cont_ele_TOF[0] = dTneg;
+    cont_ele_TOF[1] = fPIDResponse->NumberOfSigmasTOF(negTrack, AliPID::kElectron);
+    sEleTOFnSigP[fiCut]->Fill(cont_ele_TOF);   
+  }
+
+  Bool_t pTOFisthere = kFALSE;
+  //  Bool_t pTOFNoSignal = kFALSE;
+  //  Bool_t pTOFMismatch = kFALSE;
+  AliPIDResponse::EDetPidStatus statuspTOF = fPIDResponse->CheckPIDStatus(AliPIDResponse::kTOF,posTrack);
+  if(statuspTOF == AliPIDResponse::kDetPidOk) pTOFisthere = kTRUE;
+  //  if(statuspTOF == AliPIDResponse::kDetNoSignal) pTOFNoSignal = kTRUE;
+  //  if(statuspTOF == AliPIDResponse::kDetMismatch) pTOFMismatch = kTRUE;
+
+  //  if((posTrack->GetStatus() & AliESDtrack::kTOFfPID)==0 && !(posTrack->GetStatus() & AliESDtrack::kTOFmismatch)){
+  if(pTOFisthere){
+    Double_t timesPos[9];
+    posTrack->GetIntegratedTimes(timesPos,9);
+    Double_t dTpos = posTrack->GetTOFsignal() - fPIDResponse->GetTOFResponse().GetStartTime(posTrack->P()) - timesPos[0];
+    Double_t cont_pos_TOF[2];
+    cont_pos_TOF[0] = dTpos;
+    cont_pos_TOF[1] = fPIDResponse->NumberOfSigmasTOF(posTrack, AliPID::kElectron);
+    sPosTOFnSigP[fiCut]->Fill(cont_pos_TOF);   
+  }
+  
 }

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
@@ -42,6 +42,7 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     void SetDoChargedPrimary(Bool_t flag)                         { fDoChargedPrimary           = flag    ;}
     void SetDoPlotVsCentrality(Bool_t flag)                       { fDoPlotVsCentrality         = flag    ;}
     void SetDoTHnSparse(Bool_t flag)                              { fDoTHnSparse                = flag    ;}
+    void SetDoGammaTrkQA(Bool_t flag)                             { fDoGammaTrkQA               = flag    ;}
     void SetDoCentFlattening(Int_t flag)                          { fDoCentralityFlat           = flag    ;}
     void ProcessPhotonCandidates();
     void ProcessClusters();
@@ -83,8 +84,10 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     Bool_t CheckVectorForDoubleCount(vector<Int_t> &vec, Int_t tobechecked);
     void FillMultipleCountMap(map<Int_t,Int_t> &ma, Int_t tobechecked);
     void FillMultipleCountHistoAndClear(map<Int_t,Int_t> &ma, TH1F* hist);
-    
-  protected:
+
+    void PhotonCandidatesQA(AliAODConversionPhoton *gamma);
+
+ protected:
     AliV0ReaderV1*                    fV0Reader;                                  //
     TString                           fV0ReaderName;
     Bool_t                            fDoLightOutput;                             // switch for running light output, kFALSE -> normal mode, kTRUE -> light mode
@@ -100,6 +103,7 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     TList**                           fMesonDCAList;                              //
     TList**                           fTrueList;                                  //
     TList**                           fMCList;                                    //
+    TList**                           fGammaTrkQAList;                            //
     TList**                           fHeaderNameList;                            //
     TList*                            fOutputContainer;                           //
     TClonesArray*                     fReaderGammas;                              //
@@ -296,6 +300,7 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     Bool_t                            fIsFromSelectedHeader;                      //
     Int_t                             fIsMC;                                      //
     Bool_t                            fDoTHnSparse;                               // flag for using THnSparses for background estimation
+    Bool_t                            fDoGammaTrkQA;                               // flag for using THnSparses for background estimation
     Double_t                          fWeightJetJetMC;                            // weight for Jet-Jet MC
     Double_t*                         fWeightCentrality;                          //[fnCuts], weight for centrality flattening
     Bool_t                            fEnableClusterCutsForTrigger;               //enables ClusterCuts for Trigger
@@ -303,6 +308,33 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     TTree*                            tBrokenFiles;                               // tree for keeping track of broken files
     TObjString*                       fFileNameBroken;                            // string object for broken file name
 
+    THnSparse**                       sGammaPtEtaPhi;                 //!
+    THnSparse**                       sGammaAPMassPt;                 //!
+    THnSparse**                       sGammaCat1CosDCARPt;            //!
+    THnSparse**                       sGammaCat2CosDCARPt;            //!
+    THnSparse**                       sGammaCat3CosDCARPt;            //!
+    THnSparse**                       sGammaXYZR;                     //!   
+    THnSparse**                       sElePtEtaPhi;                   //! track e-
+    THnSparse**                       sElenSigPEtaR;                  //! track e-
+    THnSparse**                       sElenSigPiKPrP;                 //! track e-
+    THnSparse**                       sEleTOFnSigP;                   //! track e-
+    THnSparse**                       sPosPtEtaPhi;                   //! track e+
+    THnSparse**                       sPosnSigPEtaR;                  //! track e+
+    THnSparse**                       sPosnSigPiKPrP;                 //! track e+
+    THnSparse**                       sPosTOFnSigP;                   //! track e+
+
+    THnSparse**                       sCorElenSigPEtaR;               //! track e-
+    THnSparse**                       sCorPosnSigPEtaR;               //! track e+
+
+    TH1F**                            fHistoEleNfindableClsTPC;       //! track e-
+    TH1F**                            fHistoEleClsTPC;                //! track e-
+    TH1F**                            fHistoPosNfindableClsTPC;       //! track e+
+    TH1F**                            fHistoPosClsTPC;                //! track e+
+    TH2F**                            fHistoGammaChi2PsiPair;         //!
+    TH2F**                            fHistoITSClusterPhi;            //! track e+e-
+    TH1F**                            fHistoNBunch;                   //!
+
+    
   private:
 
     AliAnalysisTaskGammaConvV1(const AliAnalysisTaskGammaConvV1&); // Prevent copy-construction

--- a/PWGGA/GammaConv/AliConversionPhotonCuts.cxx
+++ b/PWGGA/GammaConv/AliConversionPhotonCuts.cxx
@@ -1025,6 +1025,75 @@ Bool_t AliConversionPhotonCuts::PhotonIsSelected(AliConversionPhotonBase *photon
   FillPhotonCutIndex(kPhotonOut);
   return kTRUE;
 }
+///________________________________________________________________________
+Bool_t AliConversionPhotonCuts::PhotonIsSelected2(AliAODConversionPhoton *photon, AliVEvent * event){
+  //Selection of Reconstructed Photons
+
+  FillPhotonCutIndex(kPhotonIn);
+
+  if(event->IsA()==AliESDEvent::Class()) {
+    if(!SelectV0Finder( ( ((AliESDEvent*)event)->GetV0(photon->GetV0Index()))->GetOnFlyStatus() ) ){
+      FillPhotonCutIndex(kOnFly);
+      return kFALSE;
+    }
+  }
+
+  // Get Tracks
+  AliVTrack * negTrack = GetTrack(event, photon->GetTrackLabelNegative());
+  AliVTrack * posTrack = GetTrack(event, photon->GetTrackLabelPositive());
+
+  if(!negTrack || !posTrack) {
+    FillPhotonCutIndex(kNoTracks);
+    return kFALSE;
+  }
+
+  // check if V0 from AliAODGammaConversion.root is actually contained in AOD by checking if V0 exists with same tracks
+  if(event->IsA()==AliAODEvent::Class() && fPreSelCut && ( fIsHeavyIon != 1 || (fIsHeavyIon == 1 && fProcessAODCheck) )) {
+    AliAODEvent* aodEvent = dynamic_cast<AliAODEvent*>(event);
+
+    Bool_t bFound = kFALSE;
+    Int_t v0PosID = posTrack->GetID();
+    Int_t v0NegID = negTrack->GetID();
+    AliAODv0* v0 = NULL;
+    for(Int_t iV=0; iV<aodEvent->GetNumberOfV0s(); iV++){
+      v0 = aodEvent->GetV0(iV);
+      if(!v0) continue;
+      if( (v0PosID == v0->GetPosID() && v0NegID == v0->GetNegID()) || (v0PosID == v0->GetNegID() && v0NegID == v0->GetPosID()) ){
+        bFound = kTRUE;
+        break;
+      }
+    }
+    if(!bFound){
+      FillPhotonCutIndex(kNoV0);
+      return kFALSE;
+    }
+  }
+
+  photon->DeterminePhotonQuality(negTrack,posTrack);
+  // Track Cuts
+  if(!TracksAreSelected(negTrack, posTrack)){
+    FillPhotonCutIndex(kTrackCuts);
+    return kFALSE;
+  }
+  if (fHistoEtaDistV0s)fHistoEtaDistV0s->Fill(photon->GetPhotonEta());
+  // dEdx Cuts
+
+  if(!KappaCuts(photon, event) || !dEdxCuts2(negTrack,photon) || !dEdxCuts2(posTrack,photon)) {
+    FillPhotonCutIndex(kdEdxCuts);
+    return kFALSE;
+  }
+
+  if (fHistoEtaDistV0sAfterdEdxCuts)fHistoEtaDistV0sAfterdEdxCuts->Fill(photon->GetPhotonEta());
+  // Photon Cuts
+  if(!PhotonCuts(photon,event)){
+    FillPhotonCutIndex(kPhotonCuts);
+    return kFALSE;
+  }
+
+  // Photon passed cuts
+  FillPhotonCutIndex(kPhotonOut);
+  return kTRUE;
+}
 
 ///________________________________________________________________________
 Bool_t AliConversionPhotonCuts::ArmenterosQtCut(AliConversionPhotonBase *photon){   // Armenteros Qt Cut
@@ -1261,6 +1330,37 @@ Float_t AliConversionPhotonCuts::GetKappaTPC(AliConversionPhotonBase *gamma, Ali
 
 }
 ///________________________________________________________________________
+Float_t AliConversionPhotonCuts::GetKappaTPC2(AliAODConversionPhoton *gamma, AliVEvent * event){
+
+  if(!fPIDResponse){InitPIDResponse();}// Try to reinitialize PID Response
+  if(!fPIDResponse){AliError("No PID Response"); return kTRUE;}// if still missing fatal error
+
+  AliVTrack * negTrack = GetTrack(event, gamma->GetTrackLabelNegative());
+  AliVTrack * posTrack = GetTrack(event, gamma->GetTrackLabelPositive());
+
+  Double_t CentrnSig[2] ={-1,-1};//negative, positive
+  Double_t P[2]         ={-1,-1};
+  Double_t Eta[2]       ={-1,-1};
+  Double_t R            =-1;
+
+  CentrnSig[0]=fPIDResponse->NumberOfSigmasTPC(negTrack,AliPID::kElectron);
+  CentrnSig[1]=fPIDResponse->NumberOfSigmasTPC(posTrack,AliPID::kElectron);
+  P[0]        =negTrack->P();
+  P[1]        =posTrack->P();
+  Eta[0]      =negTrack->Eta();
+  Eta[1]      =posTrack->Eta();
+  R           =gamma->GetConversionRadius();
+
+  Float_t KappaPlus, KappaMinus, Kappa;
+  KappaMinus = GetCorrectedTPCResponseN(CentrnSig[0],P[0],Eta[0],R);
+  KappaPlus = GetCorrectedTPCResponseP(CentrnSig[1],P[1],Eta[1],R);
+  Kappa = ( TMath::Abs(KappaMinus) + TMath::Abs(KappaPlus) ) / 2.0 + 2.0*(KappaMinus+KappaPlus);
+
+  return Kappa;
+
+}
+
+///________________________________________________________________________
 Bool_t AliConversionPhotonCuts::dEdxCuts(AliVTrack *fCurrentTrack){
   // Electron Identification Cuts for Photon reconstruction
   if(!fPIDResponse){InitPIDResponse();}// Try to reinitialize PID Response
@@ -1404,7 +1504,176 @@ Bool_t AliConversionPhotonCuts::dEdxCuts(AliVTrack *fCurrentTrack){
 
   return kTRUE;
 }
+///________________________________________________________________________
+Bool_t AliConversionPhotonCuts::dEdxCuts2(AliVTrack *fCurrentTrack,AliAODConversionPhoton* photon){
+  // Electron Identification Cuts for Photon reconstruction
+  if(!fPIDResponse){InitPIDResponse();}// Try to reinitialize PID Response
+  if(!fPIDResponse){AliError("No PID Response"); return kTRUE;}// if still missing fatal error
 
+  Double_t Charge    = fCurrentTrack->Charge();
+  Double_t CentrnSig =fPIDResponse->NumberOfSigmasTPC(fCurrentTrack,AliPID::kElectron);
+  Double_t P         =fCurrentTrack->P();
+  Double_t Eta       =fCurrentTrack->Eta();
+  Double_t R         =photon->GetConversionRadius();
+
+  Int_t cutIndex=0;
+  if(fHistodEdxCuts)fHistodEdxCuts->Fill(cutIndex,fCurrentTrack->Pt());
+  if(fHistoTPCdEdxSigbefore)fHistoTPCdEdxSigbefore->Fill(fCurrentTrack->P(),fPIDResponse->NumberOfSigmasTPC(fCurrentTrack, AliPID::kElectron));
+  if(fHistoTPCdEdxbefore)fHistoTPCdEdxbefore->Fill(fCurrentTrack->P(),fCurrentTrack->GetTPCsignal());
+  cutIndex++;
+  if(fDodEdxSigmaCut == kTRUE && !fSwitchToKappa){
+    // TPC Electron Line
+    if(Charge<0){
+      if( GetCorrectedTPCResponseN(CentrnSig,P,Eta,R)<fPIDnSigmaBelowElectronLine || GetCorrectedTPCResponseN(CentrnSig,P,Eta,R)>fPIDnSigmaAboveElectronLine ){
+	if(fHistodEdxCuts)fHistodEdxCuts->Fill(cutIndex,fCurrentTrack->Pt());
+	return kFALSE;
+      }
+    }else if(Charge>0){
+      if( GetCorrectedTPCResponseP(CentrnSig,P,Eta,R)<fPIDnSigmaBelowElectronLine || GetCorrectedTPCResponseP(CentrnSig,P,Eta,R)>fPIDnSigmaAboveElectronLine ){
+	if(fHistodEdxCuts)fHistodEdxCuts->Fill(cutIndex,fCurrentTrack->Pt());
+	return kFALSE;
+      }
+    }
+    cutIndex++;
+
+    // TPC Pion Line
+    if( fCurrentTrack->P()>fPIDMinPnSigmaAbovePionLine && fCurrentTrack->P()<fPIDMaxPnSigmaAbovePionLine ){
+      if(Charge<0){
+	if( GetCorrectedTPCResponseN(CentrnSig,P,Eta,R)>fPIDnSigmaBelowElectronLine && GetCorrectedTPCResponseN(CentrnSig,P,Eta,R)<fPIDnSigmaAboveElectronLine&&
+	    fPIDResponse->NumberOfSigmasTPC(fCurrentTrack,AliPID::kPion)<fPIDnSigmaAbovePionLine){
+	  if(fHistodEdxCuts)fHistodEdxCuts->Fill(cutIndex,fCurrentTrack->Pt());
+	  return kFALSE;
+	}
+      }else if(Charge>0){
+	if( GetCorrectedTPCResponseP(CentrnSig,P,Eta,R)>fPIDnSigmaBelowElectronLine && GetCorrectedTPCResponseP(CentrnSig,P,Eta,R)<fPIDnSigmaAboveElectronLine&&
+	    fPIDResponse->NumberOfSigmasTPC(fCurrentTrack,AliPID::kPion)<fPIDnSigmaAbovePionLine){
+	  if(fHistodEdxCuts)fHistodEdxCuts->Fill(cutIndex,fCurrentTrack->Pt());
+	  return kFALSE;
+	}
+      }
+      cutIndex++;
+    }
+    // High Pt Pion rej
+    if( fCurrentTrack->P()>fPIDMaxPnSigmaAbovePionLine ){
+      if(Charge<0){
+	if( GetCorrectedTPCResponseN(CentrnSig,P,Eta,R)>fPIDnSigmaBelowElectronLine &&
+	    GetCorrectedTPCResponseN(CentrnSig,P,Eta,R)<fPIDnSigmaAboveElectronLine &&
+	    fPIDResponse->NumberOfSigmasTPC(fCurrentTrack,AliPID::kPion)<fPIDnSigmaAbovePionLineHighPt){
+	  if(fHistodEdxCuts)fHistodEdxCuts->Fill(cutIndex,fCurrentTrack->Pt());
+	  return kFALSE;
+	}
+      }else if(Charge>0){
+	if( GetCorrectedTPCResponseP(CentrnSig,P,Eta,R)>fPIDnSigmaBelowElectronLine &&
+	    GetCorrectedTPCResponseP(CentrnSig,P,Eta,R)<fPIDnSigmaAboveElectronLine &&
+	    fPIDResponse->NumberOfSigmasTPC(fCurrentTrack,AliPID::kPion)<fPIDnSigmaAbovePionLineHighPt){
+	  if(fHistodEdxCuts)fHistodEdxCuts->Fill(cutIndex,fCurrentTrack->Pt());
+	  return kFALSE;
+	}
+      }
+    }
+    cutIndex++;
+  }
+  else{cutIndex+=3;}
+
+  if(fDoKaonRejectionLowP == kTRUE && !fSwitchToKappa){
+    if(fCurrentTrack->P()<fPIDMinPKaonRejectionLowP ){
+      if( TMath::Abs(fPIDResponse->NumberOfSigmasTPC(fCurrentTrack,AliPID::kKaon))<fPIDnSigmaAtLowPAroundKaonLine){
+
+	if(fHistodEdxCuts)fHistodEdxCuts->Fill(cutIndex,fCurrentTrack->Pt());
+        return kFALSE;
+      }
+    }
+  }
+  cutIndex++;
+
+  if(fDoProtonRejectionLowP == kTRUE && !fSwitchToKappa){
+    if( fCurrentTrack->P()<fPIDMinPProtonRejectionLowP ){
+      if( TMath::Abs(fPIDResponse->NumberOfSigmasTPC(fCurrentTrack,AliPID::kProton))<fPIDnSigmaAtLowPAroundProtonLine){
+
+	if(fHistodEdxCuts)fHistodEdxCuts->Fill(cutIndex,fCurrentTrack->Pt());
+        return kFALSE;
+      }
+    }
+  }
+  cutIndex++;
+
+  if(fDoPionRejectionLowP == kTRUE && !fSwitchToKappa){
+    if( fCurrentTrack->P()<fPIDMinPPionRejectionLowP ){
+      if( TMath::Abs(fPIDResponse->NumberOfSigmasTPC(fCurrentTrack,AliPID::kPion))<fPIDnSigmaAtLowPAroundPionLine){
+
+	if(fHistodEdxCuts)fHistodEdxCuts->Fill(cutIndex,fCurrentTrack->Pt());
+        return kFALSE;
+      }
+    }
+  }
+  cutIndex++;
+
+  
+  // cout<<"Start"<<endl;
+  // AliPIDResponse::EDetPidStatus status=fPIDResponse->CheckPIDStatus(AliPIDResponse::kTOF,fCurrentTrack);
+
+  // if( ( (status & AliVTrack::kTOFout) == AliVTrack::kTOFout ) && ( (status & AliVTrack::kTIME) == AliVTrack::kTIME ))
+  //    {cout<<"TOF DA"<<endl;}
+  // if(status == AliPIDResponse::kDetPidOk){
+  //    Float_t probMis = fPIDResponse->GetTOFMismatchProbability(fCurrentTrack);
+  //    cout<<"--> "<<probMis<<endl;
+  //    if(probMis > 0.01){
+
+  //    }
+  // }
+
+  if((fCurrentTrack->GetStatus() & AliESDtrack::kTOFpid ) && !(fCurrentTrack->GetStatus() & AliESDtrack::kTOFmismatch)){
+    if(fHistoTOFbefore){
+      Double_t t0 = fPIDResponse->GetTOFResponse().GetStartTime(fCurrentTrack->P());
+      Double_t  times[AliPID::kSPECIESC];
+      fCurrentTrack->GetIntegratedTimes(times,AliPID::kSPECIESC);
+      Double_t TOFsignal = fCurrentTrack->GetTOFsignal();
+      Double_t dT = TOFsignal - t0 - times[0];
+      fHistoTOFbefore->Fill(fCurrentTrack->P(),dT);
+    }
+    if(fHistoTOFSigbefore) fHistoTOFSigbefore->Fill(fCurrentTrack->P(),fPIDResponse->NumberOfSigmasTOF(fCurrentTrack, AliPID::kElectron));
+    if(fUseTOFpid){
+      if(fPIDResponse->NumberOfSigmasTOF(fCurrentTrack, AliPID::kElectron)>fTofPIDnSigmaAboveElectronLine ||
+	 fPIDResponse->NumberOfSigmasTOF(fCurrentTrack, AliPID::kElectron)<fTofPIDnSigmaBelowElectronLine ){
+	if(fHistodEdxCuts)fHistodEdxCuts->Fill(cutIndex,fCurrentTrack->Pt());
+        return kFALSE;
+      }
+    }
+    if(fHistoTOFSigafter)fHistoTOFSigafter->Fill(fCurrentTrack->P(),fPIDResponse->NumberOfSigmasTOF(fCurrentTrack, AliPID::kElectron));
+  }
+  cutIndex++;
+
+  if((fCurrentTrack->GetStatus() & AliESDtrack::kITSpid)){
+    if(fHistoITSSigbefore) fHistoITSSigbefore->Fill(fCurrentTrack->P(),fPIDResponse->NumberOfSigmasITS(fCurrentTrack, AliPID::kElectron));
+    if(fUseITSpid){
+      if(fCurrentTrack->Pt()<=fMaxPtPIDITS){
+        if(fPIDResponse->NumberOfSigmasITS(fCurrentTrack, AliPID::kElectron)>fITSPIDnSigmaAboveElectronLine || fPIDResponse->NumberOfSigmasITS(fCurrentTrack, AliPID::kElectron)<fITSPIDnSigmaBelowElectronLine ){
+	        if(fHistodEdxCuts)fHistodEdxCuts->Fill(cutIndex,fCurrentTrack->Pt());
+          return kFALSE;
+        }
+      }
+    }
+    if(fHistoITSSigafter)fHistoITSSigafter->Fill(fCurrentTrack->P(),fPIDResponse->NumberOfSigmasITS(fCurrentTrack, AliPID::kElectron));
+  }
+
+  cutIndex++;
+
+  // Apply TRD PID
+  if(fDoTRDPID){
+    if(!fPIDResponse->IdentifiedAsElectronTRD(fCurrentTrack,fPIDTRDEfficiency)){
+      if(fHistodEdxCuts)fHistodEdxCuts->Fill(cutIndex,fCurrentTrack->Pt());
+      return kFALSE;
+    }
+  }
+  cutIndex++;
+
+  if(fHistodEdxCuts)fHistodEdxCuts->Fill(cutIndex,fCurrentTrack->Pt());
+  if(fHistoTPCdEdxSigafter)fHistoTPCdEdxSigafter->Fill(fCurrentTrack->P(),fPIDResponse->NumberOfSigmasTPC(fCurrentTrack, AliPID::kElectron));
+  if(fHistoTPCdEdxafter)fHistoTPCdEdxafter->Fill(fCurrentTrack->P(),fCurrentTrack->GetTPCsignal());
+
+  return kTRUE;
+}
+///________________________________________________________________________
 Bool_t AliConversionPhotonCuts::KappaCuts(AliConversionPhotonBase * photon,AliVEvent *event) {
   // abort if Kappa selection not enabled
   if (!fSwitchToKappa) return kTRUE;
@@ -3678,4 +3947,129 @@ Float_t AliConversionPhotonCuts::GetMaterialBudgetCorrectingWeightForTrueGamma(A
         weight = fProfileContainingMaterialBudgetWeights->GetBinContent(bin);
     }
     return weight;
+}
+///________________________________________________________________________
+Bool_t AliConversionPhotonCuts::InitializePostCalibration(TString filename) {
+
+  AliInfo("Entering loading of correction map for post calibration");
+
+  TFile *file = TFile::Open(filename.Data());
+  if(!file){
+    AliError(Form("file for post calibration %s not found",filename.Data()));
+    return kFALSE;
+  }else{
+    AliInfo(Form("found %s ",filename.Data()));
+  }
+  fHistoEleMapMean  = new TH2F*[3];
+  fHistoEleMapWidth = new TH2F*[3];
+  fHistoPosMapMean  = new TH2F*[3];
+  fHistoPosMapWidth = new TH2F*[3];
+  
+  for(Int_t i=0;i<3;i++){
+    fHistoEleMapMean[i]  = (TH2F*)file->Get(Form("Ele_R%d_mean",i+1));
+    fHistoEleMapWidth[i] = (TH2F*)file->Get(Form("Ele_R%d_width",i+1));
+    fHistoPosMapMean[i]  = (TH2F*)file->Get(Form("Pos_R%d_mean",i+1));
+    fHistoPosMapWidth[i] = (TH2F*)file->Get(Form("Pos_R%d_width",i+1));
+  }
+  for(Int_t i=0;i<3;i++){
+    fHistoEleMapMean[i]  ->SetDirectory(0);
+    fHistoEleMapWidth[i] ->SetDirectory(0);
+    fHistoPosMapMean[i]  ->SetDirectory(0);
+    fHistoPosMapWidth[i] ->SetDirectory(0);
+  }
+  file->Close();
+  delete file;
+
+  return kTRUE;
+}
+//_________________________________________________________________________
+Double_t AliConversionPhotonCuts::GetCorrectedTPCResponseN(Double_t nsig,Double_t P,Double_t Eta,Double_t R){
+
+
+  Double_t CornSig = nsig;
+  Double_t mean          = 1;
+  Double_t width         = 1;
+  //X axis 12 Y axis 18  ... common for all R slice
+  if (fHistoEleMapMean[0] == NULL || fHistoEleMapWidth[0] == NULL || fHistoEleMapMean[1] == NULL || fHistoEleMapWidth[1] == NULL || fHistoEleMapMean[2] == NULL || fHistoEleMapWidth[2] == NULL ){
+    return CornSig;// do nothing if correction map is not avaible
+  }
+
+  Int_t BinP = fHistoEleMapMean[0]->GetXaxis()->FindBin(P);
+  Int_t BinEta = fHistoEleMapMean[0]->GetYaxis()->FindBin(Eta);
+
+  if( R > 0. && R < 30.){//0,30,70,180 cm
+    if(P>0. && P<10){
+      mean = fHistoEleMapMean[0]->GetBinContent(BinP,BinEta);
+      width = fHistoEleMapWidth[0]->GetBinContent(BinP,BinEta);
+    }else if(P>10){// use bin edge value
+      mean = fHistoEleMapMean[0]->GetBinContent(12,BinEta);;
+      width = fHistoEleMapWidth[0]->GetBinContent(12,BinEta);
+    }
+  }else if( R >= 30. && R < 70.){
+    if(P>0. && P<10){
+      mean = fHistoEleMapMean[1]->GetBinContent(BinP,BinEta);
+      width = fHistoEleMapWidth[1]->GetBinContent(BinP,BinEta);
+    }else if(P>10){// use bin edge value
+      mean = fHistoEleMapMean[1]->GetBinContent(12,BinEta);
+      width = fHistoEleMapWidth[1]->GetBinContent(12,BinEta);
+    }
+  }else if( R >= 70. && R < 180.){
+    if(P>0. && P<10){
+      mean = fHistoEleMapMean[2]->GetBinContent(BinP,BinEta);
+      width = fHistoEleMapWidth[2]->GetBinContent(BinP,BinEta);
+    }else if(P>10){// use bin edge value
+      mean = fHistoEleMapMean[2]->GetBinContent(12,BinEta);
+      width = fHistoEleMapWidth[2]->GetBinContent(12,BinEta);
+    }
+  }else{
+    mean = 0.;
+    width = 0.;
+  }
+  CornSig = (nsig - mean) / width;
+  return CornSig;
+}
+//_________________________________________________________________________
+Double_t AliConversionPhotonCuts::GetCorrectedTPCResponseP(Double_t nsig,Double_t P,Double_t Eta,Double_t R){
+
+  Double_t CornSig = nsig;
+  Double_t mean          = 1;
+  Double_t width         = 1;
+  //X axis 12 Y axis 18  ... common for all R slice
+  if (fHistoPosMapMean[0] == NULL || fHistoPosMapWidth[0] == NULL || fHistoPosMapMean[1] == NULL || fHistoPosMapWidth[1] == NULL || fHistoPosMapMean[2] == NULL || fHistoPosMapWidth[2] == NULL ){
+    return CornSig;// do nothing if correction map is not avaible
+  }
+
+  Int_t BinP = fHistoPosMapMean[0]->GetXaxis()->FindBin(P);
+  Int_t BinEta = fHistoPosMapMean[0]->GetYaxis()->FindBin(Eta);
+
+  if( R > 0. && R < 30.){//0,30,70,180 cm
+    if(P>0. && P<10){
+      mean = fHistoPosMapMean[0]->GetBinContent(BinP,BinEta);
+      width = fHistoPosMapWidth[0]->GetBinContent(BinP,BinEta);
+    }else if(P>10){// use bin edge value
+      mean = fHistoPosMapMean[0]->GetBinContent(12,BinEta);;
+      width = fHistoPosMapWidth[0]->GetBinContent(12,BinEta);
+    }
+  }else if( R >= 30. && R < 70.){
+    if(P>0. && P<10){
+      mean = fHistoPosMapMean[1]->GetBinContent(BinP,BinEta);
+      width = fHistoPosMapWidth[1]->GetBinContent(BinP,BinEta);
+    }else if(P>10){// use bin edge value
+      mean = fHistoPosMapMean[1]->GetBinContent(12,BinEta);
+      width = fHistoPosMapWidth[1]->GetBinContent(12,BinEta);
+    }
+  }else if( R >= 70. && R < 180.){
+    if(P>0. && P<10){
+      mean = fHistoPosMapMean[2]->GetBinContent(BinP,BinEta);
+      width = fHistoPosMapWidth[2]->GetBinContent(BinP,BinEta);
+    }else if(P>10){// use bin edge value
+      mean = fHistoPosMapMean[2]->GetBinContent(12,BinEta);
+      width = fHistoPosMapWidth[2]->GetBinContent(12,BinEta);
+    }
+  }else{
+    mean = 0.;
+    width = 0.;
+  }
+  CornSig = (nsig - mean) / width;
+  return CornSig;
 }

--- a/PWGGA/GammaConv/AliConversionPhotonCuts.h
+++ b/PWGGA/GammaConv/AliConversionPhotonCuts.h
@@ -152,9 +152,10 @@ class AliConversionPhotonCuts : public AliAnalysisCuts {
     TString GetCutNumber();
 
     Float_t GetKappaTPC(AliConversionPhotonBase *gamma, AliVEvent *event);
-
+    Float_t GetKappaTPC2(AliAODConversionPhoton *gamma, AliVEvent *event);
     // Cut Selection
     Bool_t PhotonIsSelected(AliConversionPhotonBase * photon, AliVEvent  * event);
+    Bool_t PhotonIsSelected2(AliAODConversionPhoton * photon, AliVEvent  * event);
     Bool_t PhotonIsSelectedMC(TParticle *particle,AliMCEvent *mcEvent,Bool_t checkForConvertedGamma=kTRUE);
     Bool_t PhotonIsSelectedAODMC(AliAODMCParticle *particle,TClonesArray *aodmcArray,Bool_t checkForConvertedGamma=kTRUE);
     //Bool_t ElectronIsSelectedMC(TParticle *particle,AliMCEvent *mcEvent);
@@ -186,6 +187,7 @@ class AliConversionPhotonCuts : public AliAnalysisCuts {
     Bool_t AcceptanceCut(TParticle *particle, TParticle * ePos,TParticle* eNeg);
     Bool_t PhiSectorCut(AliConversionPhotonBase * photon);
     Bool_t dEdxCuts(AliVTrack * track);
+    Bool_t dEdxCuts2(AliVTrack * track,AliAODConversionPhoton * photon);
     Bool_t KappaCuts(AliConversionPhotonBase * photon,AliVEvent *event);
     Bool_t ArmenterosQtCut(AliConversionPhotonBase *photon);
     Bool_t AsymmetryCut(AliConversionPhotonBase *photon,AliVEvent *event);
@@ -250,6 +252,9 @@ class AliConversionPhotonCuts : public AliAnalysisCuts {
     Float_t GetMaterialBudgetCorrectingWeightForTrueGamma(AliAODConversionPhoton* gamma);
 
     Int_t GetV0FinderSameSign(){return fUseOnFlyV0FinderSameSign;}
+    Bool_t   InitializePostCalibration(TString filename);
+    Double_t GetCorrectedTPCResponseN(Double_t nsig,Double_t P,Double_t Eta,Double_t R);
+    Double_t GetCorrectedTPCResponseP(Double_t nsig,Double_t P,Double_t Eta,Double_t R);
 
   protected:
     TList*            fHistograms;                          ///< List of QA histograms
@@ -383,10 +388,13 @@ class AliConversionPhotonCuts : public AliAnalysisCuts {
     Bool_t            fProcessAODCheck;                     ///< Flag for processing check for AOD to be contained in AliAODs.root and AliAODGammaConversion.root
     Bool_t            fMaterialBudgetWeightsInitialized;    ///< weights for conversions photons due due deviating material budget in MC compared to data
     TProfile*         fProfileContainingMaterialBudgetWeights;
-
+    TH2F**            fHistoEleMapMean;
+    TH2F**            fHistoEleMapWidth;
+    TH2F**            fHistoPosMapMean;
+    TH2F**            fHistoPosMapWidth;
   private:
     /// \cond CLASSIMP
-    ClassDef(AliConversionPhotonCuts,16)
+    ClassDef(AliConversionPhotonCuts,17)
     /// \endcond
 };
 


### PR DESCRIPTION
[AliConversionPhotonCuts.cxx ]
for e+e- post calibration functions to get corrected TPC response were added. (but they are not used in analysis tasks so far &  it wouldn't affect them.

[ AliAnalysisTaskGammaConvV1.cxx]
to create nsigma correction map, histograms:  e+e-'s nsigma vs [p,eta,R] were added. also other related QA histograms included.   
*soon flag to switch off them, will be implemented. 