### PR TITLE
[EMCAL-204] OADB/EMCAL: Uploaded missing bad channel calibs for LHC18d

### DIFF
--- a/OADB/EMCAL/READMEoadb.txt
+++ b/OADB/EMCAL/READMEoadb.txt
@@ -41,5 +41,6 @@ In addition, a short history of changes to the files in EOS will be listed here:
 - 20180621: Update of EMCALTimeCalib.root and EMCALTimeL1PhaseCalib.root with LHC16o and LHC16p time calibrations
 - 20180622: Update of EMCALBadChannels.root with additional cells for LHC16j and LHC16l and a fix for the LHC16h maps which were not properly added in OADB before
 - 20180706: Update of EMCALBadChannels.root with additional cells for LHC16p and update of EMCALTimeCalib.root with updated calibrations for LHC17o
+- 20180711: Update of EMCALBadChannels.root with new maps for LHC18d
 
 */


### PR DESCRIPTION
The following runs now have new or updated maps:
286129, 286130, 286254, 286261, 286284, 286287, 286288, 286289, 286309, 286310, 286311, 286313, 286314, 286341, 286349, 286350