### PR TITLE
TTreeMaker to now uses Dielectron Cut Libraries

### DIFF
--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskSimpleTreeMaker.cxx
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskSimpleTreeMaker.cxx
@@ -12,7 +12,7 @@
 *                                                                                 *
 *The default track cuts are relatively loose, and the PID selects out electrons   *
 *within +-4 nSigma in the TPC. This value, as well as cuts on the other detector  *
-*response values, can be turned on and off via their relavent setter function.    *
+*response values, can be turned on and off via their relavent setter functions.   *
 *                                                                                 *
 *The GRID PID number for each job is stored with each event along with a simple   *
 *event counter ID, so that after merging each event still has a unique label.     *
@@ -20,11 +20,7 @@
 *By default, the class will return a TTree focused on selecting electrons from    *
 *primary decays. There are setter functions which can be used to instead create a *
 *TTree filled with tracks originating from V0 decays. In this case the DCA cuts   *
-*are removed.  There is a futher option to create a TTree which contains all      *
-*generated particles, and, if reconstructed, their corresponding reconstructed    *
-*track features.                                                                  *
-*TODO: Speed up the creation of the generator TTree (very slow with multiple      *
-*loops over the same particles).                                                  *
+*are removed.                                                                     *
 **********************************************************************************/
 #include "Riostream.h"
 #include "TChain.h"
@@ -86,6 +82,14 @@ AliAnalysisTaskSimpleTreeMaker::AliAnalysisTaskSimpleTreeMaker():
     fESDtrackCuts(0),
     fPIDResponse(0),
     fTree(0x0),
+		eventCuts(0),
+		eventFilter(0),
+		trackCuts(0),
+		trackFilter(0),
+		pidCuts(0),
+		cuts(0),
+		filter(0),
+		varManager(0),
 		primaryVertex{0,0,0},
 		multiplicityV0A(0),
 		multiplicityV0C(0),
@@ -156,11 +160,13 @@ AliAnalysisTaskSimpleTreeMaker::AliAnalysisTaskSimpleTreeMaker():
     fHasSDD(kTRUE),
     fIsV0tree(kFALSE),
     fArmPlot(0),
-		fIsEffTree(kFALSE),
     fIsAOD(kTRUE),
     fFilterBit(16),
     fIsGRIDanalysis(kTRUE),
-    fGridPID(-1)
+    fGridPID(-1),
+		fUseTPCcorr(kFALSE),
+		fWidth(0),
+		fMean(0)
 {
 
 }
@@ -171,6 +177,14 @@ AliAnalysisTaskSimpleTreeMaker::AliAnalysisTaskSimpleTreeMaker(const char *name)
    	fESDtrackCuts(0),
     fPIDResponse(0),
     fTree(0),
+		eventCuts(0),
+		eventFilter(0),
+		trackCuts(0),
+		trackFilter(0),
+		pidCuts(0),
+		cuts(0),
+		filter(0),
+		varManager(0),
 		primaryVertex{0,0,0},
 		multiplicityV0A(0),
 		multiplicityV0C(0),
@@ -241,17 +255,19 @@ AliAnalysisTaskSimpleTreeMaker::AliAnalysisTaskSimpleTreeMaker(const char *name)
     fHasSDD(kTRUE),
     fIsV0tree(kFALSE),
     fArmPlot(0),
-		fIsEffTree(kFALSE),
     fIsAOD(kTRUE),
     fFilterBit(16),
     fIsGRIDanalysis(kTRUE),
-    fGridPID(-1)
+    fGridPID(0),
+		fUseTPCcorr(kFALSE),
+		fWidth(0),
+		fMean(0)
 
 {
-    if(!fIsV0tree && !fIsEffTree){
+    if(!fIsV0tree){
         fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(kFALSE,1);
     }
-    else if(fIsV0tree && !fIsEffTree){
+    else{
         fESDtrackCuts = AliESDtrackCuts::GetStandardV0DaughterCuts();
     }
 
@@ -264,13 +280,18 @@ AliAnalysisTaskSimpleTreeMaker::AliAnalysisTaskSimpleTreeMaker(const char *name)
 
 //________________________________________________________________________
 
-//~ AliAnalysisTaskSimpleTreeMaker::~AliAnalysisTaskSimpleTreeMaker() {
+AliAnalysisTaskSimpleTreeMaker::~AliAnalysisTaskSimpleTreeMaker(){
 
-  //~ // Destructor
+  delete eventCuts;
+  delete eventFilter;
+  
+  delete trackCuts;
+  delete trackFilter;
+  delete pidCuts;
+  delete cuts;
+  delete filter; 
 
-  //~ // ... not implemented
-
-//~ }
+}
 
 
 //________________________________________________________________________
@@ -480,9 +501,19 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 
 	AliVParticle* mcTrack = 0x0;
 	AliVParticle* motherMCtrack = 0x0;
+	
+	//Setup TPC correction maps
+	if(fUseTPCcorr){
+		AliDielectronPID::SetCentroidCorrFunction( (TH1*)fMean->Clone() );
+		AliDielectronPID::SetWidthCorrFunction( (TH1*)fWidth->Clone() );
+		::Info("AliAnalysisTaskSimpleTreeMaker::UserExec","Setting Correction Histos");
+	}
+
+	//Needed by the dielectron framework
+  varManager->SetPIDResponse(fPIDResponse);
 
 	//Loop over tracks for event
-	if(!fIsV0tree && !fIsEffTree){
+	if(!fIsV0tree){
 		for(Int_t iTrack = 0; iTrack < eventTracks; iTrack++){ 
 
 			AliVTrack* track = dynamic_cast<AliVTrack*>(event->GetTrack(iTrack));
@@ -494,16 +525,16 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 			fQAhist->Fill("Tracks_all",1);
 
 			//Set MC features to dummy values
-			mcEta     = -99;
-			mcPhi     = -99;
-			mcPt      = -99;
-			mcVert[0] = {-99};
-			mcVert[1] = {-99};
-			mcVert[2] = {-99};
-			iPdg         = -9999;
-			iPdgMother   = -9999;
-			HasMother   = kFALSE; 
-			motherLabel  = -9999; //Needed to determine whether tracks have same mother
+			mcEta       = -99;
+			mcPhi       = -99;
+			mcPt        = -99;
+			mcVert[0]   = {-99};
+			mcVert[1]   = {-99};
+			mcVert[2]   = {-99};
+			iPdg        = -9999;
+			iPdgMother  = -9999;
+			HasMother   = kFALSE;
+			motherLabel = -9999; //Needed to determine whether tracks have same mother
 			//Bool_t IsEnhanced = kFALSE;
 
 			//Get MC information
@@ -567,7 +598,6 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 				}*/
       }
 
-
 			//Apply global track filter
 			if(!fIsAOD){
 				if(!(fESDtrackCuts->AcceptTrack(dynamic_cast<const AliESDtrack*>(track)))){ 
@@ -575,28 +605,47 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 				}
 			}
 			else{
-				if(!((dynamic_cast<AliAODTrack*>(track)))->TestFilterBit(fFilterBit)){
+				UInt_t selectedMask = (1<<filter->GetCuts()->GetEntries())-1;
+				if( selectedMask != (filter->IsSelected((AliVParticle*)track)) ){
 						continue;
 				}
 			}
 
-			//Apply some track cuts 
-			pt = track->Pt();
-			if( pt < fPtMin || pt >= fPtMax ){ continue;}
-			eta  = track->Eta();
-			if( eta < fEtaMin || eta >= fEtaMax ){ continue;} 
-			phi  = track->Phi();
+			fQAhist->Fill("Tracks_Cuts", 1);
+			
+			pt  = track->Pt();
+			eta = track->Eta();
+			phi = track->Phi();
 
-			fQAhist->Fill("Tracks_KineCuts", 1);
+			//Get PID response of track without TPC calibration
+			EnSigmaTPC = fPIDResponse->NumberOfSigmasTPC(track,(AliPID::EParticleType)AliPID::kElectron);
+			if(fUseTPCcorr){
+				EnSigmaTPC -= AliDielectronPID::GetCntrdCorr(track);
+				EnSigmaTPC /= AliDielectronPID::GetWdthCorr(track);
+			}
+				
+			EnSigmaITS = -999;
+			if(fHasSDD){
+				EnSigmaITS = fPIDResponse->NumberOfSigmasITS(track,(AliPID::EParticleType)AliPID::kElectron);
+			}
+			EnSigmaTOF = fPIDResponse->NumberOfSigmasTOF(track,(AliPID::EParticleType)AliPID::kElectron);
+
+			PnSigmaTPC = fPIDResponse->NumberOfSigmasTPC(track,(AliPID::EParticleType)AliPID::kPion);
+		
+			//Get rest of nSigma values for pion and kaon
+			PnSigmaITS = fPIDResponse->NumberOfSigmasITS(track,(AliPID::EParticleType)AliPID::kPion);
+			PnSigmaTOF = fPIDResponse->NumberOfSigmasTOF(track,(AliPID::EParticleType)AliPID::kPion);
+
+			KnSigmaITS = fPIDResponse->NumberOfSigmasITS(track,(AliPID::EParticleType)AliPID::kKaon);
+			KnSigmaTPC = fPIDResponse->NumberOfSigmasTPC(track,(AliPID::EParticleType)AliPID::kKaon);
+			KnSigmaTOF = fPIDResponse->NumberOfSigmasTOF(track,(AliPID::EParticleType)AliPID::kKaon);
 
 			//Get TPC information
 			//kNclsTPC
 			nTPCclusters = track->GetTPCNcls(); 
-			if(nTPCclusters < 70){ continue;}
 			
 			//kNFclsTPCr
 			nTPCcrossed = track->GetTPCClusterInfo(2,1);
-			if(nTPCcrossed < 60){ continue;}
 
 			fTPCcrossOverFind = 0;
 			nTPCfindable = track->GetTPCNclsF();
@@ -604,8 +653,6 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 			if(nTPCfindable > 0){
 				fTPCcrossOverFind = nTPCcrossed/nTPCfindable;
 			}
-
-			if(fTPCcrossOverFind < 0.3 || fTPCcrossOverFind >= 1.1){ continue;}
 
 			tpcSharedMap = 0;
 			if(fIsAOD){
@@ -623,10 +670,6 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 
 			chi2TPC = track->GetTPCchi2(); //Function only implemented in ESDs. Returns dumym value for AODs
 			
-			//Check for refits 
-			if((track->GetStatus() & AliVTrack::kITSrefit) <= 0){ continue;}
-			if((track->GetStatus() & AliVTrack::kTPCrefit) <= 0){ continue;}
-
 			//DCA values
 			Float_t  DCAesd[2] = {0.0, 0.0};
 			Double_t DCAaod[2] = {0.0, 0.0};
@@ -648,26 +691,10 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 				DCA[1] = static_cast<Double_t>(DCAaod[1]);
 			}
 
-			//DCAxy cut
-			//kImpactParXY
-			if(DCA[0] < -3.0 || DCA[0] >= 3.0){ continue;}
-			//DCAz cut
-			//kImpactParZ
-			if(DCA[1] < -4.0 || DCA[1] >= 4.0){ continue;}
-
 			//Get ITS information
 			//kNclsITS
 			nITS = track->GetNcls(0);
-
-			if(fHasSDD){
-				if(nITS < 3){ continue;}
-			}else{
-				if(nITS < 1){ continue;}
-			}
-			
 			chi2ITS = track->GetITSchi2();
-			//kITSchi2Cl
-			if((chi2ITS/nITS) >= 36){ continue;} 
 			
 			fITSshared = 0.;
 			for(Int_t d = 0; d < 6; d++){
@@ -681,49 +708,10 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 				SPDfirst = (dynamic_cast<AliESDtrack*>(track))->HasPointOnITSLayer(0);
 			}
 
-			fQAhist->Fill("Tracks_TrackCuts", 1);
-
-
-			//Get electron nSigma in TPC for cut (inclusive cut)
-			EnSigmaTPC = fPIDResponse->NumberOfSigmasTPC(track,(AliPID::EParticleType)AliPID::kElectron);
-			if( EnSigmaTPC >= fESigTPCMax || EnSigmaTPC < fESigTPCMin) { continue;}
-				
-			EnSigmaITS = -999;
-			if(fHasSDD){
-				//Get rest of electron nSigma values and apply cuts if requested (inclusive cuts)
-				EnSigmaITS = fPIDResponse->NumberOfSigmasITS(track,(AliPID::EParticleType)AliPID::kElectron);
-				if(fPIDcutITS){
-					if(EnSigmaITS < fESigITSMin || EnSigmaITS > fESigITSMax){ continue;}
-				}
-			}
-
-			EnSigmaTOF = fPIDResponse->NumberOfSigmasTOF(track,(AliPID::EParticleType)AliPID::kElectron);
-			if(fPIDcutTOF){
-				if(EnSigmaTOF < fESigTOFMin || EnSigmaTOF > fESigTOFMax){ continue;}
-			}
-
-			//Get pion nSigma for TPC and apply cut if requested (exclusive cut)
-			PnSigmaTPC = fPIDResponse->NumberOfSigmasTPC(track,(AliPID::EParticleType)AliPID::kPion);
-			if(fPionPIDcutTPC){
-				if(PnSigmaTPC > fPSigTPCMin && PnSigmaTPC < fPSigTPCMax){ continue;}
-			}
-		
-			fQAhist->Fill("Tracks_PIDcuts",1); 
-
-			//Get rest of nSigma values for pion and kaon
-			PnSigmaITS = fPIDResponse->NumberOfSigmasITS(track,(AliPID::EParticleType)AliPID::kPion);
-			PnSigmaTOF = fPIDResponse->NumberOfSigmasTOF(track,(AliPID::EParticleType)AliPID::kPion);
-
-			KnSigmaITS = fPIDResponse->NumberOfSigmasITS(track,(AliPID::EParticleType)AliPID::kKaon);
-			KnSigmaTPC = fPIDResponse->NumberOfSigmasTPC(track,(AliPID::EParticleType)AliPID::kKaon);
-			KnSigmaTOF = fPIDResponse->NumberOfSigmasTOF(track,(AliPID::EParticleType)AliPID::kKaon);
-
-
 			//Get ITS and TPC signals
 			ITSsignal = track->GetITSsignal();
 			TPCsignal = track->GetTPCsignal();
 			TOFsignal = track->GetTOFsignal();
-           
 
 			Int_t fCutMaxChi2TPCConstrainedVsGlobalVertexType = fESDtrackCuts->kVertexTracks | fESDtrackCuts->kVertexSPD;
 
@@ -757,7 +745,7 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 			fTree->Fill();
     } //End loop over tracks
   }//End of "normal" TTree creation
-  else if(fIsV0tree && !fIsEffTree){
+  else if(fIsV0tree){
 		for(Int_t iV0 = 0; iV0 < numV0s; iV0++){
 
 			AliESDv0* V0vertex = esdEvent->GetV0(iV0);
@@ -1110,289 +1098,6 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 			fTree->Fill();
 		}//End loop over v0's for this event
   }//End V0 code
-	else if(!fIsV0tree && fIsEffTree){
-
-		//Vars used to keep track of particle labels 
-		std::vector<std::vector<Int_t>> particleList; //List of all generated particle
-		std::vector<Int_t> recoInfo(3,0); //Flags for each track: electron, recod, reco. track number
-		std::vector<Int_t> labels; //List of generated electrons (generator track labels))
-
-		
-		//First loop over all MC particles and get list of electrons
-		for(Int_t iMCtrack = 0; iMCtrack < mcEvent->GetNumberOfTracks(); iMCtrack++){
-
-			if(fIsAOD){
-				mcTrack = dynamic_cast<AliAODMCParticle*>(mcEvent->GetTrack(iMCtrack));
-			}else{
-				mcTrack = dynamic_cast<AliMCParticle*>(mcEvent->GetTrack(iMCtrack));
-			}
-			if(!mcTrack){
-				AliWarning(Form("Could not retreive MC particle %d", iMCtrack));
-				continue;
-			}
-  
-			//Check if MC particle is electron. If not, skip to next track
-			if(TMath::Abs(mcTrack->PdgCode()) != 11){
-				recoInfo[0] = 0;
-			}
-			else{
-				recoInfo[0] = 1;
-				labels.push_back(iMCtrack);
-			}
-			particleList.push_back(recoInfo);
-		}//End loop over MC tracks
- 
-		//Next loop over reconstructed tracks and store which tracks were
-		//reconstructed
-		for(Int_t iTracks = 0; iTracks < event->GetNumberOfTracks(); iTracks++){
-			
-			AliVTrack* recoTrack = dynamic_cast<AliVTrack*>(event->GetTrack(iTracks));
-      if(!recoTrack){
-	      AliError(Form("Could not receive reconstructed track %d", iTracks));
-	      continue;
-      } 
-			//Check if electron
-			//GetLabel returns MC track number
-			//Take absolute value as some tracks recieve a negative value due to poor
-			//quality of track (not important for this step)
-      if(particleList[TMath::Abs(recoTrack->GetLabel())][0] == 0){
-				continue;     
-			}
-			//Store flag for reconstruction and reconstruction track number
-      particleList[TMath::Abs(recoTrack->GetLabel())][1] = 1;
-      particleList[TMath::Abs(recoTrack->GetLabel())][2] = iTracks;
-		}
-
-		//Finally, loop over generated electrons
-		for(UInt_t iTrack = 0; iTrack < labels.size(); iTrack++){
-			Int_t elecLabel = labels[iTrack];
-
-			fQAhist->Fill("Tracks_all", 1);
-			if(fIsAOD){
-				mcTrack = dynamic_cast<AliAODMCParticle*>(mcEvent->GetTrack(elecLabel));
-			}else{
-				mcTrack = dynamic_cast<AliMCParticle*>(mcEvent->GetTrack(elecLabel));
-			}
-			if(!mcTrack){
-				Printf("Could not get MC track!");
-				AliWarning(Form("Could not retreive MC particle %d", elecLabel));
-				continue;
-			}
-  
-			//Check if MC particle is electron. If not, issue error and exit
-			if(TMath::Abs(mcTrack->PdgCode()) != 11){
-				Printf("Second loop over non-electron. Shouldn't happen. Disregard all results and check code");
-				return;
-			}
-			
-			fQAhist->Fill("Tracks_MCcheck", 1);
-			//Apply kine cuts (to MC)
-			pt   = mcTrack->Pt();
-			if( pt < fPtMin || pt > fPtMax ){ continue;}
-			eta  = mcTrack->Eta();
-			if( eta < fEtaMin || eta > fEtaMax ){ continue;} 
-			fQAhist->Fill("Tracks_KineCuts", 1);
-			phi  = mcTrack->Phi();
-			
-			//Get MC information
-			//Declare MC variables
-			mcEta       = -99;
-			mcPhi       = -99;
-			mcPt        = -99;
-			mcVert[0]   = {-99};
-			mcVert[1]   = {-99};
-			mcVert[2]   = {-99};
-			iPdg        = -9999;
-			iPdgMother  = -9999;
-			HasMother   = kFALSE;
-			motherLabel = -9999;
-
-			iPdg  = mcTrack->PdgCode();
-			mcEta = mcTrack->Eta();
-			mcPhi = mcTrack->Phi();
-			mcPt  = mcTrack->Pt();
-			mcTrack->XvYvZv(mcVert);
-
-			//Check for mother particle
-			//If not found, dummy MC initialisation values will be written
-			Int_t gMotherIndex = mcTrack->GetMother();
-			if(!(gMotherIndex < 0)){
-				if(fIsAOD){
-					motherMCtrack = dynamic_cast<AliAODMCParticle*>((mcEvent->GetTrack(gMotherIndex)));
-				}else{
-					motherMCtrack = dynamic_cast<AliMCParticle*>((mcEvent->GetTrack(gMotherIndex)));
-				}
-				HasMother   = kTRUE;
-				iPdgMother  = motherMCtrack->PdgCode();
-				motherLabel = TMath::Abs(motherMCtrack->GetLabel());
-			}
-		
-			//If reconstructed, get track properties.
-			//Otherwise branches will be filled with dummy variables.
-			if(particleList[elecLabel][1] == 1){
-
-				//Get reconstructed track
-				AliVTrack* track = dynamic_cast<AliVTrack*>(event->GetTrack(particleList[elecLabel][2]));
-				if(!track){
-					Printf("Could not retrieve reconstructed track %d", particleList[elecLabel][2]);
-					continue;
-				}
-
-				nTPCclusters      = track->GetTPCNcls();
-				nTPCcrossed       = track->GetTPCClusterInfo(2,1);
-				fTPCcrossOverFind = 0;
-				nTPCfindable      = track->GetTPCNclsF();
-				if(nTPCfindable > 0){
-					fTPCcrossOverFind = nTPCcrossed/nTPCfindable;
-				}
-				tpcSharedMap = 0;
-				if(fIsAOD){
-					tpcSharedMap = (dynamic_cast<AliAODTrack*>(track))->GetTPCSharedMap();
-				}else{
-					tpcSharedMap = (dynamic_cast<AliESDtrack*>(track))->GetTPCSharedMap();
-				}
-
-				nTPCshared = -1;
-				if(fIsAOD){
-					nTPCshared = tpcSharedMap.CountBits(0) - tpcSharedMap.CountBits(159);
-				}else{
-					nTPCshared = (dynamic_cast<AliESDtrack*>(track))->GetTPCnclsS();
-				}
-
-				//chi2TPC = track->GetTPCchi2(); //Function only implemented in ESDs. Returns dummy value for AODs
-
-				//DCA values
-				Float_t DCAesd[2]  = {0.0,0.0};
-				Double_t DCAaod[2] = {0.0,0.0};
-				Double_t DCAcov[2] = {0.0, 0.0};
-				if(!fIsAOD){
-					track->GetImpactParameters( &DCAesd[0], &DCAesd[1]);
-				}
-				else{
-					GetDCA(const_cast<const AliVEvent*>(event), dynamic_cast<const AliAODTrack*>(track), DCAaod, DCAcov);
-				}
-				//Final DCA values stored here 
-				if(!fIsAOD){
-					DCA[0] = static_cast<Double_t>(DCAesd[0]);
-					DCA[1] = static_cast<Double_t>(DCAesd[1]);
-				}
-				else{
-					DCA[0] = static_cast<Double_t>(DCAaod[0]);
-					DCA[1] = static_cast<Double_t>(DCAaod[1]);
-				}
-
-				//Get ITS values
-				nITS = track->GetNcls(0);;
-				chi2ITS = track->GetITSchi2();
-				fITSshared = 0.;
-				for(Int_t d = 0; d < 6; d++){
-					fITSshared += static_cast<Double_t>(track->HasSharedPointOnITSLayer(d));
-				}
-				fITSshared /= nITS;
-				SPDfirst = kFALSE;
-				if(fIsAOD){
-					SPDfirst = (dynamic_cast<AliAODTrack*>(track))->HasPointOnITSLayer(0);
-				}else{
-					SPDfirst = (dynamic_cast<AliESDtrack*>(track))->HasPointOnITSLayer(0);
-				}
-
-				//Get electron nSigma in TPC for cut (inclusive cut)
-				EnSigmaTPC = fPIDResponse->NumberOfSigmasTPC(track,(AliPID::EParticleType)AliPID::kElectron);
-					
-				EnSigmaITS = -999;
-				if(fHasSDD){
-					//Get rest of electron nSigma values and apply cuts if requested (inclusive cuts)
-					EnSigmaITS = fPIDResponse->NumberOfSigmasITS(track,(AliPID::EParticleType)AliPID::kElectron);
-				}
-
-				EnSigmaTOF = fPIDResponse->NumberOfSigmasTOF(track,(AliPID::EParticleType)AliPID::kElectron);
-
-				//Get pion nSigma for TPC and apply cut if requested (exclusive cut)
-				PnSigmaTPC = fPIDResponse->NumberOfSigmasTPC(track,(AliPID::EParticleType)AliPID::kPion);
-			
-				//Get rest of nSigma values for pion and kaon
-				/* PnSigmaITS = fPIDResponse->NumberOfSigmasITS(track,(AliPID::EParticleType)AliPID::kPion); */
-				/* PnSigmaTOF = fPIDResponse->NumberOfSigmasTOF(track,(AliPID::EParticleType)AliPID::kPion); */
-				/* KnSigmaITS = fPIDResponse->NumberOfSigmasITS(track,(AliPID::EParticleType)AliPID::kKaon); */
-				/* KnSigmaTPC = fPIDResponse->NumberOfSigmasTPC(track,(AliPID::EParticleType)AliPID::kKaon); */
-				/* KnSigmaTOF = fPIDResponse->NumberOfSigmasTOF(track,(AliPID::EParticleType)AliPID::kKaon); */
-
-				//Get raw signals
-				ITSsignal = track->GetITSsignal();
-				TPCsignal = track->GetTPCsignal();
-				TOFsignal = track->GetTOFsignal();
-						 
-				Int_t fCutMaxChi2TPCConstrainedVsGlobalVertexType = fESDtrackCuts->kVertexTracks | fESDtrackCuts->kVertexSPD;
-
-				const AliVVertex* vertex = 0;
-
-				if(fCutMaxChi2TPCConstrainedVsGlobalVertexType & fESDtrackCuts->kVertexTracks){
-					vertex = track->GetEvent()->GetPrimaryVertexTracks();
-				}
-
-				if((!vertex || !vertex->GetStatus()) && fCutMaxChi2TPCConstrainedVsGlobalVertexType & fESDtrackCuts->kVertexSPD){
-					vertex = track->GetEvent()->GetPrimaryVertexSPD();
-				}
-
-				if((!vertex || !vertex->GetStatus()) && fCutMaxChi2TPCConstrainedVsGlobalVertexType & fESDtrackCuts->kVertexTPC){
-					vertex = track->GetEvent()->GetPrimaryVertexTPC();
-				}
-			
-				/* //Get golden Chi2 */
-				/* Double_t goldenChi2 = -1; */
-				/* if(vertex->GetStatus()){ */
-				/* 	if(fIsAOD){ */
-				/* 		goldenChi2 = dynamic_cast<AliAODTrack*>(track)->GetChi2TPCConstrainedVsGlobal(); */
-				/* 	} */
-				/* 	else{ */
-				/* 		goldenChi2 = dynamic_cast<AliESDtrack*>(track)->GetChi2TPCConstrainedVsGlobal(dynamic_cast<const AliESDVertex*>(vertex)); */
-				/* 	} */
-				/* } */
-
-				charge = -998;
-				charge = track->Charge();
-
-				fTree->Fill();
-			}
-			else{
-				//If not reconstructed
-				//Reconstructed branches get dummy values
-				//MC branches get correct values (generated values)
-				pt                = -9999;
-				eta               = -9999;
-				phi               = -9999;
-				nTPCclusters      = -9999;
-				nTPCcrossed       = -9999;
-				nTPCfindable      = -9999;
-				fTPCcrossOverFind = -9999;
-				tpcSharedMap      = -9999;
-				nTPCshared        = -9999;
-				DCA[0]            = -9999;
-				DCA[1]            = -9999;
-				nITS              = -9999;
-				chi2ITS           = -9999;
-				fITSshared        = -9999;
-				SPDfirst          = kFALSE;
-				EnSigmaTPC        = -9999;
-				EnSigmaITS        = -9999;
-				EnSigmaTOF        = -9999;
-				PnSigmaTPC        = -9999;
-				PnSigmaITS        = -9999;
-				PnSigmaTOF        = -9999;
-				KnSigmaITS        = -9999;
-				KnSigmaTPC        = -9999;
-				KnSigmaTOF        = -9999;
-				ITSsignal         = -9999;
-				TPCsignal         = -9999;
-				TOFsignal         = -9999;
-				goldenChi2        = -9999;
-				charge            = -9999;
-
-				fTree->Fill();
-			}
-
-		}//End loop over tracks
-	}//End efficiency loop
 
 }
 
@@ -1424,13 +1129,10 @@ void AliAnalysisTaskSimpleTreeMaker::Terminate(Option_t *){
 Int_t AliAnalysisTaskSimpleTreeMaker::IsEventAccepted(AliVEvent *event){
     
     if(!fIsV0tree){
-			if(TMath::Abs(event->GetPrimaryVertexSPD()->GetZ()) < 10){
-				if(event->GetPrimaryVertexSPD()->GetNContributors() >0){ 
-						return 1; 
-				}
-				else{ 
-					return 0;
-				}   
+			UInt_t selectedMask = (1<<eventFilter->GetCuts()->GetEntries())-1;
+			varManager->SetEvent(event);
+			if(selectedMask == (eventFilter->IsSelected(event))){
+				return 1;
 			}
     }
     else{
@@ -1500,4 +1202,20 @@ Bool_t AliAnalysisTaskSimpleTreeMaker::GetDCA(const AliVEvent* event, const AliA
     d0z0[1] = -999.;
   }
   return ok;
+}
+
+//
+void AliAnalysisTaskSimpleTreeMaker::SetupTrackCuts(AliDielectronCutGroup* cuts){
+
+	//Initialise track cut object and add to DielectronCutGroup
+	//Track cuts include kinematic cuts, track cuts and PID cuts
+	filter = new AliAnalysisFilter("filter", "filter");
+	filter->AddCuts(cuts);
+}
+
+void AliAnalysisTaskSimpleTreeMaker::SetupEventCuts(AliDielectronEventCuts* cuts){
+
+	//Initiliase the event filter object and add event cuts
+	eventFilter = new AliAnalysisFilter("eventFilter", "eventFilter");
+	eventFilter->AddCuts(cuts);
 }

--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskSimpleTreeMaker.h
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskSimpleTreeMaker.h
@@ -7,10 +7,12 @@ class TH3D;
 class AliESDtrackCuts;
 
 #include "AliAnalysisTaskSE.h"
-#include "AliPIDResponse.h"
-#include "TFile.h"
-#include "TTreeStream.h"
-#include "AliAnalysisTaskSE.h"
+#include "AliDielectronVarCuts.h"
+#include "AliDielectronTrackCuts.h"
+#include "AliDielectronCutGroup.h"
+#include "AliDielectronPID.h"
+#include "AliAnalysisFilter.h"
+#include "AliDielectronEventCuts.h"
 #ifndef ALIANALYSISTASKSE_H
 #endif
 
@@ -27,239 +29,239 @@ class AliESDtrackCuts;
 
 class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 
-    public:
-        AliAnalysisTaskSimpleTreeMaker(const char *name);
-        AliAnalysisTaskSimpleTreeMaker();
-        virtual ~AliAnalysisTaskSimpleTreeMaker(){} 
+  public:
+		AliAnalysisTaskSimpleTreeMaker(const char *name);
+		AliAnalysisTaskSimpleTreeMaker();
+		virtual ~AliAnalysisTaskSimpleTreeMaker(){} 
 
-        virtual void   UserCreateOutputObjects();
-        virtual void   UserExec(Option_t *option);
-        virtual void   FinishTaskOutput();
-        virtual void   Terminate(Option_t *);
-        //~ 
+		virtual void   UserCreateOutputObjects();
+		virtual void   UserExec(Option_t *option);
+		virtual void   FinishTaskOutput();
+		virtual void   Terminate(Option_t *);
+		//~ 
+	
+		void SetCentralityPercentileRange(Double_t min, Double_t max){
+				fCentralityPercentileMin = min;
+				fCentralityPercentileMax = max;
+		}
 
-        void SetCentralityPercentileRange(Double_t min, Double_t max){
-            fCentralityPercentileMin = min;
-            fCentralityPercentileMax = max;
-        }
+		void SetPtRange(Double_t min, Double_t max){
+				fPtMin = min;
+				fPtMax = max;
+		}
 
-        void SetPtRange(Double_t min, Double_t max){
-            fPtMin = min;
-            fPtMax = max;
-        }
+		void SetEtaRange(Double_t min, Double_t max){
+				fEtaMin = min;
+				fEtaMax = max;
+		}
 
-        void SetEtaRange(Double_t min, Double_t max){
-            fEtaMin = min;
-            fEtaMax = max;
-        }
+		//Set inclusive electron PID cuts
+		void SetESigRangeITS(Double_t min, Double_t max){
+				fPIDcutITS = kTRUE;
+				fESigITSMin = min;
+				fESigITSMax = max;
+		}
 
-        //Set inclusive electron PID cuts
-        void SetESigRangeITS(Double_t min, Double_t max){
-            fPIDcutITS = kTRUE;
-            fESigITSMin = min;
-            fESigITSMax = max;
-        }
+		void SetESigRangeTPC(Double_t min, Double_t max){
+				fESigTPCMin = min;
+				fESigTPCMax = max;
+		}
 
-        void SetESigRangeTPC(Double_t min, Double_t max){
-            fESigTPCMin = min;
-            fESigTPCMax = max;
-        }
+		void SetESigRangeTOF(Double_t min, Double_t max){
+				fPIDcutTOF = kTRUE;
+				fESigTOFMin = min;
+				fESigTOFMax = max;
+		}
 
-        void SetESigRangeTOF(Double_t min, Double_t max){
-            fPIDcutTOF = kTRUE;
-            fESigTOFMin = min;
-            fESigTOFMax = max;
-        }
+		//Set pion PID exclusion cut
+		void SetPSigRangeTPC(Double_t min, Double_t max){
+				fPionPIDcutTPC = kTRUE;
+				fPSigTPCMin = min;
+				fPSigTPCMax = max;
+		}
 
-        //Set pion PID exclusion cut
-        void SetPSigRangeTPC(Double_t min, Double_t max){
-            fPionPIDcutTPC = kTRUE;
-            fPSigTPCMin = min;
-            fPSigTPCMax = max;
-        }
+		void SetMC(Bool_t answer){ hasMC = answer; }
 
-        void SetMC(Bool_t answer){ hasMC = answer; }
+		//Track cut setters. StandardITSTPC2011 cuts used if nothing specified
+		void SetTPCminClusters(Int_t number){
+				fESDtrackCuts->SetMinNClustersTPC(number);
+		}
 
-        //Track cut setters. StandardITSTPC2011 cuts used if nothing specified
-        void SetTPCminClusters(Int_t number){
-            fESDtrackCuts->SetMinNClustersTPC(number);
-        }
+		void SetTPCminCrossedRows(Int_t number){
+				fESDtrackCuts->SetMinNCrossedRowsTPC(number);
+		}
 
-        void SetTPCminCrossedRows(Int_t number){
-            fESDtrackCuts->SetMinNCrossedRowsTPC(number);
-        }
+		void SetTPCRatio(Double_t number){
+				fESDtrackCuts->SetMinRatioCrossedRowsOverFindableClustersTPC(number);
+		}
 
-        void SetTPCRatio(Double_t number){
-            fESDtrackCuts->SetMinRatioCrossedRowsOverFindableClustersTPC(number);
-        }
+		void SetTPCChi2PerCluster(Float_t number){
+				fESDtrackCuts->SetMaxChi2PerClusterTPC(number);
+		}
 
-        void SetTPCChi2PerCluster(Float_t number){
-            fESDtrackCuts->SetMaxChi2PerClusterTPC(number);
-        }
+		void SetITSclusterRequirements(AliESDtrackCuts::Detector detector, AliESDtrackCuts::ITSClusterRequirement requirement){
+				fESDtrackCuts->SetClusterRequirementITS(detector, requirement);
+		}
 
-        void SetITSclusterRequirements(AliESDtrackCuts::Detector detector, AliESDtrackCuts::ITSClusterRequirement requirement){
-            fESDtrackCuts->SetClusterRequirementITS(detector, requirement);
-        }
+		void SetITSChi2PerCluster(Float_t number){
+				fESDtrackCuts->SetMaxChi2PerClusterITS(number);
+		}
 
-        void SetITSChi2PerCluster(Float_t number){
-            fESDtrackCuts->SetMaxChi2PerClusterITS(number);
-        }
+		void SetMaxDCAxy(Float_t number){
+				fESDtrackCuts->SetMaxDCAToVertexXY(number);
+		}
 
-        void SetMaxDCAxy(Float_t number){
-            fESDtrackCuts->SetMaxDCAToVertexXY(number);
-        }
+		void SetMaxDCAPtDep(const char* dist){
+				fESDtrackCuts->SetMaxDCAToVertexXYPtDep(dist);
+		}
 
-        void SetMaxDCAPtDep(const char* dist){
-            fESDtrackCuts->SetMaxDCAToVertexXYPtDep(dist);
-        }
+		void SetMaxDCAz(Double_t number){
+				fESDtrackCuts->SetMaxDCAToVertexZ(number);
+		 }
 
-        void SetMaxDCAz(Double_t number){
-            fESDtrackCuts->SetMaxDCAToVertexZ(number);
-         }
+		void SetTPCconstrainedGlobalChi2(Double_t number){
+				fESDtrackCuts->SetMaxChi2TPCConstrainedGlobal(number);
+		}
 
-        void SetTPCconstrainedGlobalChi2(Double_t number){
-            fESDtrackCuts->SetMaxChi2TPCConstrainedGlobal(number);
-        }
+		void SetGridPID(std::string string){
+				fGridPID = std::stoi(string);
+		}
+		void GRIDanalysis(Bool_t answer){
+				fIsGRIDanalysis = answer;
+		}
+		void createV0tree(Bool_t answer){
+				fIsV0tree = answer;
+		}
+		void setSDDstatus(Bool_t answer){
+				fHasSDD = answer;
+		}
+		void createGenTree(Bool_t answer){
+			fIsEffTree = answer;
+		}
+		Bool_t isV0daughterAccepted(AliVTrack* track);
 
-        void SetGridPID(std::string string){
-            fGridPID = std::stoi(string);
-        }
-        void GRIDanalysis(Bool_t answer){
-            fIsGRIDanalysis = answer;
-        }
-        void createV0tree(Bool_t answer){
-            fIsV0tree = answer;
-        }
-        void setSDDstatus(Bool_t answer){
-            fHasSDD = answer;
-        }
-				void createGenTree(Bool_t answer){
-					fIsEffTree = answer;
-				}
-        Bool_t isV0daughterAccepted(AliVTrack* track);
+		void setFilterBitSelection(Int_t filterBit){
+				fFilterBit = filterBit;
+		}
+		void analyseMC(Bool_t answer){
+			hasMC = answer;
+		}
 
-        void setFilterBitSelection(Int_t filterBit){
-            fFilterBit = filterBit;
-        }
-				void analyseMC(Bool_t answer){
-					hasMC = answer;
-				}
+		Bool_t GetDCA(const AliVEvent* event, const AliAODTrack* track, Double_t* d0z0, Double_t* covd0z0);
 
-        Bool_t GetDCA(const AliVEvent* event, const AliAODTrack* track, Double_t* d0z0, Double_t* covd0z0);
-
-    private:
+  private:
  
-        Int_t IsEventAccepted(AliVEvent* event);
-        //Int_t GetAcceptedTracks(AliVEvent *event, Double_t gCentrality);
-      
-        AliAnalysisTaskSimpleTreeMaker(const AliAnalysisTaskSimpleTreeMaker&); // not implemented
+		Int_t IsEventAccepted(AliVEvent* event);
+		//Int_t GetAcceptedTracks(AliVEvent *event, Double_t gCentrality);
+	
+		AliAnalysisTaskSimpleTreeMaker(const AliAnalysisTaskSimpleTreeMaker&); // not implemented
 
-        AliAnalysisTaskSimpleTreeMaker& operator=(const AliAnalysisTaskSimpleTreeMaker&); // not implemented
+		AliAnalysisTaskSimpleTreeMaker& operator=(const AliAnalysisTaskSimpleTreeMaker&); // not implemented
 
-				Bool_t hasMC;
+		Bool_t hasMC;
 
-        AliESDtrackCuts* fESDtrackCuts; // ESD track cuts object
+		AliESDtrackCuts* fESDtrackCuts; // ESD track cuts object
 
-        AliPIDResponse* fPIDResponse; //! PID response object
+		AliPIDResponse* fPIDResponse; //! PID response object
 
-        TTree* fTree;
+		TTree* fTree;
 
-				//TTree branch variables
-				//Event variables
-				Double_t primaryVertex[3];
-				Double_t multiplicityV0A;
-				Double_t multiplicityV0C;
-				Double_t multiplicityCL1;
-				Int_t runNumber;
-				Int_t event;
-				//Reconstructed
-				Double_t pt;
-				Double_t eta;
-				Double_t phi;
-				Double_t nTPCclusters;
-				Double_t nTPCcrossed;
-				Double_t fTPCcrossOverFind;
-				Double_t nTPCfindable;
-				TBits tpcSharedMap;
-				Double_t nTPCshared;
-				Double_t chi2TPC;
-				Double_t DCA[2];
-				Int_t nITS;
-				Double_t chi2ITS;
-				Double_t fITSshared;
-				Bool_t SPDfirst;
-				Int_t charge;
-				Double_t EnSigmaITS;
-				Double_t EnSigmaTPC;
-				Double_t EnSigmaTOF;
-				Double_t PnSigmaTPC;
-				Double_t PnSigmaITS;
-				Double_t PnSigmaTOF;
-				Double_t KnSigmaITS;
-				Double_t KnSigmaTPC;
-				Double_t KnSigmaTOF;
-				Double_t ITSsignal;
-				Double_t TPCsignal;
-				Double_t TOFsignal;
-				Double_t goldenChi2;
-				//MC 
-				Double_t mcEta;
-				Double_t mcPhi;
-				Double_t mcPt;
-				Double_t mcVert[3];
-				Int_t iPdg;
-				Int_t iPdgMother;
-				Bool_t HasMother;
-				Int_t motherLabel;
-				//V0 features
-				Double_t pointingAngle;
-				Double_t daughtersDCA;
-				Double_t decayLength;
-				Double_t v0mass;
-				Double_t ptArm;
-				Double_t alpha;
+		//TTree branch variables
+		//Event variables
+		Double_t primaryVertex[3];
+		Double_t multiplicityV0A;
+		Double_t multiplicityV0C;
+		Double_t multiplicityCL1;
+		Int_t runNumber;
+		Int_t event;
+		//Reconstructed
+		Double_t pt;
+		Double_t eta;
+		Double_t phi;
+		Double_t nTPCclusters;
+		Double_t nTPCcrossed;
+		Double_t fTPCcrossOverFind;
+		Double_t nTPCfindable;
+		TBits tpcSharedMap;
+		Double_t nTPCshared;
+		Double_t chi2TPC;
+		Double_t DCA[2];
+		Int_t nITS;
+		Double_t chi2ITS;
+		Double_t fITSshared;
+		Bool_t SPDfirst;
+		Int_t charge;
+		Double_t EnSigmaITS;
+		Double_t EnSigmaTPC;
+		Double_t EnSigmaTOF;
+		Double_t PnSigmaTPC;
+		Double_t PnSigmaITS;
+		Double_t PnSigmaTOF;
+		Double_t KnSigmaITS;
+		Double_t KnSigmaTPC;
+		Double_t KnSigmaTOF;
+		Double_t ITSsignal;
+		Double_t TPCsignal;
+		Double_t TOFsignal;
+		Double_t goldenChi2;
+		//MC 
+		Double_t mcEta;
+		Double_t mcPhi;
+		Double_t mcPt;
+		Double_t mcVert[3];
+		Int_t iPdg;
+		Int_t iPdgMother;
+		Bool_t HasMother;
+		Int_t motherLabel;
+		//V0 features
+		Double_t pointingAngle;
+		Double_t daughtersDCA;
+		Double_t decayLength;
+		Double_t v0mass;
+		Double_t ptArm;
+		Double_t alpha;
 
-        TH1F* fQAhist;
-        Double_t fCentralityPercentileMin;// minimum centrality threshold (default = 0)
-        Double_t fCentralityPercentileMax;// maximum centrality threshold (default = 80)
+		TH1F* fQAhist;
+		Double_t fCentralityPercentileMin;// minimum centrality threshold (default = 0)
+		Double_t fCentralityPercentileMax;// maximum centrality threshold (default = 80)
 
-        Double_t fPtMin;// minimum pT threshold (default = 0)
-        Double_t fPtMax;// maximum pT threshold (default = 10)
-        Double_t fEtaMin;// minimum eta threshold (default = -0.8)
-        Double_t fEtaMax;// maximum eta threshold (default = 0.8)
+		Double_t fPtMin;// minimum pT threshold (default = 0)
+		Double_t fPtMax;// maximum pT threshold (default = 10)
+		Double_t fEtaMin;// minimum eta threshold (default = -0.8)
+		Double_t fEtaMax;// maximum eta threshold (default = 0.8)
 
-        //Values and flags for PID cuts in ITS and TOF
-        Double_t fESigITSMin;
-        Double_t fESigITSMax;
-				Double_t fESigTPCMin; 
-        Double_t fESigTPCMax; 
-        Double_t fESigTOFMin;
-        Double_t fESigTOFMax;
-        
-        Bool_t fPIDcutITS;
-        Bool_t fPIDcutTOF;
-        
-        //Values and flag for pion PID cuts in TPC
-        Bool_t fPionPIDcutTPC;
-        Double_t fPSigTPCMin;
-        Double_t fPSigTPCMax;
-        
-        Bool_t fHasSDD;
+		//Values and flags for PID cuts in ITS and TOF
+		Double_t fESigITSMin;
+		Double_t fESigITSMax;
+		Double_t fESigTPCMin; 
+		Double_t fESigTPCMax; 
+		Double_t fESigTOFMin;
+		Double_t fESigTOFMax;
+		
+		Bool_t fPIDcutITS;
+		Bool_t fPIDcutTOF;
+		
+		//Values and flag for pion PID cuts in TPC
+		Bool_t fPionPIDcutTPC;
+		Double_t fPSigTPCMin;
+		Double_t fPSigTPCMax;
+		
+		Bool_t fHasSDD;
 
-        Bool_t fIsV0tree;
-        TH2F* fArmPlot;
+		Bool_t fIsV0tree;
+		TH2F* fArmPlot;
 
-				//Efficiency calculation flags
-				Bool_t fIsEffTree;
+		//Efficiency calculation flags
+		Bool_t fIsEffTree;
 
-        Bool_t fIsAOD;
-        Int_t fFilterBit;
-        
-        //Grid PID
-        Bool_t fIsGRIDanalysis;
-        Int_t fGridPID;
-        
-        ClassDef(AliAnalysisTaskSimpleTreeMaker, 4); //
+		Bool_t fIsAOD;
+		Int_t fFilterBit;
+		
+		//Grid PID
+		Bool_t fIsGRIDanalysis;
+		Int_t fGridPID;
+		
+		ClassDef(AliAnalysisTaskSimpleTreeMaker, 4); //
 
 };
 

--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskSimpleTreeMaker.h
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskSimpleTreeMaker.h
@@ -32,14 +32,24 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
   public:
 		AliAnalysisTaskSimpleTreeMaker(const char *name);
 		AliAnalysisTaskSimpleTreeMaker();
-		virtual ~AliAnalysisTaskSimpleTreeMaker(){} 
+		~AliAnalysisTaskSimpleTreeMaker();
 
 		virtual void   UserCreateOutputObjects();
 		virtual void   UserExec(Option_t *option);
 		virtual void   FinishTaskOutput();
 		virtual void   Terminate(Option_t *);
-		//~ 
+
+		void SetupTrackCuts(AliDielectronCutGroup* finalTrackCuts);
+		void SetupEventCuts(AliDielectronEventCuts* finalEventCuts);
 	
+		//PID calibration function to set correct the width and mean of detector
+		//response (I.e each bang should be unit guassian)
+		void SetCorrWidthMean(TH3D* width, TH3D* mean){
+			fMean  = mean;
+			fWidth = width;
+		};
+
+
 		void SetCentralityPercentileRange(Double_t min, Double_t max){
 				fCentralityPercentileMin = min;
 				fCentralityPercentileMax = max;
@@ -135,9 +145,6 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 		void setSDDstatus(Bool_t answer){
 				fHasSDD = answer;
 		}
-		void createGenTree(Bool_t answer){
-			fIsEffTree = answer;
-		}
 		Bool_t isV0daughterAccepted(AliVTrack* track);
 
 		void setFilterBitSelection(Int_t filterBit){
@@ -165,6 +172,20 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 		AliPIDResponse* fPIDResponse; //! PID response object
 
 		TTree* fTree;
+	
+		//Dielectron cut classes needed to source cuts from LMEE cut libraries
+		//The desired cut library should be specified in the AddTask
+		AliDielectronEventCuts* eventCuts;
+		AliAnalysisFilter* eventFilter;
+		
+		AliDielectronVarCuts* trackCuts;
+		AliDielectronTrackCuts *trackFilter;
+		AliDielectronPID *pidCuts;
+		AliDielectronCutGroup* cuts;
+		AliAnalysisFilter* filter; 
+
+		//Class needed to use PID within the Dielectron Framework
+		AliDielectronVarManager* varManager;
 
 		//TTree branch variables
 		//Event variables
@@ -251,16 +272,16 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 		Bool_t fIsV0tree;
 		TH2F* fArmPlot;
 
-		//Efficiency calculation flags
-		Bool_t fIsEffTree;
-
 		Bool_t fIsAOD;
 		Int_t fFilterBit;
 		
 		//Grid PID
 		Bool_t fIsGRIDanalysis;
 		Int_t fGridPID;
-		
+				
+		Bool_t fUseTPCcorr;
+		TH3D* fWidth;
+		TH3D* fMean;
 		ClassDef(AliAnalysisTaskSimpleTreeMaker, 4); //
 
 };

--- a/PWGDQ/dielectron/macrosLMEE/Config_acapon.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_acapon.C
@@ -15,6 +15,7 @@ TObjArray *arrNames = names.Tokenize(";");
 const Int_t nDie = arrNames->GetEntries();
 Bool_t MCenabled = kTRUE; //Needed for LMEEcutlib
 Bool_t isQAtask =  kTRUE;
+Int_t selectedCuts = -1;
 Int_t selectedPID = -1;
 Bool_t pairCuts = kTRUE;
 
@@ -42,67 +43,61 @@ AliDielectron* Config_acapon(TString cutDefinition, Bool_t hasMC=kFALSE, Bool_t 
     cout << "cutDefinition = " << cutDefinition << endl;
     // Setup Analysis Selection
     if(cutDefinition == "all"){
-        selectedPID = LMEECutLib::kAllSpecies;
-        die->GetTrackFilter().AddCuts( LMcutlib->GetKineCutsAna(selectedPID) );
-        die->GetTrackFilter().AddCuts( LMcutlib->GetTrackCutsAna(selectedPID) );
-        die->GetTrackFilter().AddCuts( LMcutlib->GetPIDCutsAna(selectedPID) );
+        selectedCuts = LMEECutLib::kAllSpecies;
+				selectedPID = LMEECutLib::kAllSpecies;
+        die->GetTrackFilter().AddCuts( LMcutlib->GetTrackCutsAna(selectedCuts, selectedPID) );
         if(pairCuts){
-            //die->GetPairPreFilter().AddCuts( LMcutlib->GetPairCutsPre(selectedPID) );
-            die->GetPairFilter().AddCuts( LMcutlib->GetPairCutsAna(selectedPID) );
+            //die->GetPairPreFilter().AddCuts( LMcutlib->GetPairCutsPre(selectedCuts) );
+            die->GetPairFilter().AddCuts( LMcutlib->GetPairCutsAna(selectedCuts) );
         }
     }
     else if(cutDefinition == "electrons"){
-        selectedPID = LMEECutLib::kElectrons;
-        die->GetTrackFilter().AddCuts( LMcutlib->GetKineCutsAna(selectedPID) );
-        die->GetTrackFilter().AddCuts( LMcutlib->GetTrackCutsAna(selectedPID) );
-        die->GetTrackFilter().AddCuts( LMcutlib->GetPIDCutsAna(selectedPID) );
+        selectedCuts = LMEECutLib::kElectrons;
+				selectedPID = LMEECutLib::kAllSpecies;
+        die->GetTrackFilter().AddCuts( LMcutlib->GetTrackCutsAna(selectedCuts, selectedPID) );
         if(pairCuts){
-            //die->GetPairPreFilter().AddCuts( LMcutlib->GetPairCutsPre(selectedPID) );
-            die->GetPairFilter().AddCuts( LMcutlib->GetPairCutsAna(selectedPID) );
+            //die->GetPairPreFilter().AddCuts( LMcutlib->GetPairCutsPre(selectedCuts) );
+            die->GetPairFilter().AddCuts( LMcutlib->GetPairCutsAna(selectedCuts) );
         }
     }
     else if(cutDefinition == "highMult"){
-        selectedPID = LMEECutLib::kHighMult;
-        die->GetEventFilter().AddCuts( LMcutlib->GetCentralityCuts(selectedPID) );
-        die->GetTrackFilter().AddCuts( LMcutlib->GetKineCutsAna(selectedPID) );
-        die->GetTrackFilter().AddCuts( LMcutlib->GetTrackCutsAna(selectedPID) );
-        die->GetTrackFilter().AddCuts( LMcutlib->GetPIDCutsAna(selectedPID) );
+        selectedCuts = LMEECutLib::kHighMult;
+				selectedPID = LMEECutLib::kAllSpecies;
+        die->GetEventFilter().AddCuts( LMcutlib->GetCentralityCuts(selectedCuts) );
+        die->GetTrackFilter().AddCuts( LMcutlib->GetTrackCutsAna(selectedCuts, selectedPID) );
         if(pairCuts){
-            //die->GetPairPreFilter().AddCuts( LMcutlib->GetPairCutsPre(selectedPID) );
-            die->GetPairFilter().AddCuts( LMcutlib->GetPairCutsAna(selectedPID) );
+            //die->GetPairPreFilter().AddCuts( LMcutlib->GetPairCutsPre(selectedCuts) );
+            die->GetPairFilter().AddCuts( LMcutlib->GetPairCutsAna(selectedCuts) );
         }
     }
     else if(cutDefinition == "midMult"){
-        selectedPID = LMEECutLib::kMidMult;
-        die->GetEventFilter().AddCuts( LMcutlib->GetCentralityCuts(selectedPID) );
-        die->GetTrackFilter().AddCuts( LMcutlib->GetKineCutsAna(selectedPID) );
-        die->GetTrackFilter().AddCuts( LMcutlib->GetTrackCutsAna(selectedPID) );
-        die->GetTrackFilter().AddCuts( LMcutlib->GetPIDCutsAna(selectedPID) );
+        selectedCuts = LMEECutLib::kMidMult;
+				selectedPID = LMEECutLib::kAllSpecies;
+        die->GetEventFilter().AddCuts( LMcutlib->GetCentralityCuts(selectedCuts) );
+        die->GetTrackFilter().AddCuts( LMcutlib->GetTrackCutsAna(selectedCuts, selectedPID) );
         if(pairCuts){
-            //die->GetPairPreFilter().AddCuts( LMcutlib->GetPairCutsPre(selectedPID) );
-            die->GetPairFilter().AddCuts( LMcutlib->GetPairCutsAna(selectedPID) );
+            //die->GetPairPreFilter().AddCuts( LMcutlib->GetPairCutsPre(selectedCuts) );
+            die->GetPairFilter().AddCuts( LMcutlib->GetPairCutsAna(selectedCuts) );
         }
     }
     else if(cutDefinition == "lowMult"){
-        selectedPID = LMEECutLib::kLowMult;
-        die->GetEventFilter().AddCuts( LMcutlib->GetCentralityCuts(selectedPID) );
-        die->GetTrackFilter().AddCuts( LMcutlib->GetKineCutsAna(selectedPID) );
-        die->GetTrackFilter().AddCuts( LMcutlib->GetTrackCutsAna(selectedPID) );
-        die->GetTrackFilter().AddCuts( LMcutlib->GetPIDCutsAna(selectedPID) );
+        selectedCuts = LMEECutLib::kLowMult;
+				selectedPID = LMEECutLib::kAllSpecies;
+        die->GetEventFilter().AddCuts( LMcutlib->GetCentralityCuts(selectedCuts) );
+        die->GetTrackFilter().AddCuts( LMcutlib->GetTrackCutsAna(selectedCuts, selectedPID) );
         if(pairCuts){
-            //die->GetPairPreFilter().AddCuts( LMcutlib->GetPairCutsPre(selectedPID) );
-            die->GetPairFilter().AddCuts( LMcutlib->GetPairCutsAna(selectedPID) );
+            //die->GetPairPreFilter().AddCuts( LMcutlib->GetPairCutsPre(selectedCuts) );
+            die->GetPairFilter().AddCuts( LMcutlib->GetPairCutsAna(selectedCuts) );
         }
     }
     else if(cutDefinition == "TTreeCuts"){
-        selectedPID = LMEECutLib::kTTreeCuts;
-        //die->GetEventFilter().AddCuts( LMcutlib->GetCentralityCuts(selectedPID) );
-        die->GetTrackFilter().AddCuts( LMcutlib->GetKineCutsAna(selectedPID) );
-        die->GetTrackFilter().AddCuts( LMcutlib->GetTrackCutsAna(selectedPID) );
-        die->GetTrackFilter().AddCuts( LMcutlib->GetPIDCutsAna(selectedPID) );
+        selectedCuts = LMEECutLib::kTTreeCuts;
+				selectedPID = LMEECutLib::kAllSpecies;
+        //die->GetEventFilter().AddCuts( LMcutlib->GetCentralityCuts(selectedCuts) );
+        die->GetTrackFilter().AddCuts( LMcutlib->GetTrackCutsAna(selectedCuts, selectedPID) );
         if(pairCuts){
-            //die->GetPairPreFilter().AddCuts( LMcutlib->GetPairCutsPre(selectedPID) );
-            die->GetPairFilter().AddCuts( LMcutlib->GetPairCutsAna(selectedPID) );
+            //die->GetPairPreFilter().AddCuts( LMcutlib->GetPairCutsPre(selectedCuts) );
+            die->GetPairFilter().AddCuts( LMcutlib->GetPairCutsAna(selectedCuts) );
         }
     }
     
@@ -117,7 +112,7 @@ AliDielectron* Config_acapon(TString cutDefinition, Bool_t hasMC=kFALSE, Bool_t 
 
     AliDielectronMixingHandler* mix = 0x0;
     if(doMixing){
-        mix = LMcutlib->GetMixingHandler(selectedPID);
+        mix = LMcutlib->GetMixingHandler(selectedCuts);
         die->SetMixingHandler(mix);
     }
 


### PR DESCRIPTION
SimpleTreeMaker class updated to use LMEEcutLib files when implementing cuts.
Additional changes: 
-One now specifies both the desired track and PID cuts when calling GetTrackCuts(trackCuts, PIDcuts).  This function now implements or loads all necessary track+PID cuts, so only one function call is needed in the AddTask.
- The generator TTreeMaker implementation has been removed (redundant)
- Minor formatting and spelling corrections