### PR TITLE
TPC post calibration for TTreeMaker and Dielectron config implemented

### DIFF
--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskSimpleTreeMaker.h
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskSimpleTreeMaker.h
@@ -42,13 +42,12 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 		void SetupTrackCuts(AliDielectronCutGroup* finalTrackCuts);
 		void SetupEventCuts(AliDielectronEventCuts* finalEventCuts);
 	
-		//PID calibration function to set correct the width and mean of detector
-		//response (I.e each bang should be unit guassian)
+		//PID calibration function to correct the width and mean of detector
+		//response (I.e should be unit guassian)
 		void SetCorrWidthMean(TH3D* width, TH3D* mean){
 			fMean  = mean;
 			fWidth = width;
 		};
-
 
 		void SetCentralityPercentileRange(Double_t min, Double_t max){
 				fCentralityPercentileMin = min;
@@ -154,6 +153,10 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 			hasMC = answer;
 		}
 
+		void SetUseCorr(Bool_t answer){
+			fUseTPCcorr = answer;
+		}
+
 		Bool_t GetDCA(const AliVEvent* event, const AliAODTrack* track, Double_t* d0z0, Double_t* covd0z0);
 
   private:
@@ -178,11 +181,11 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 		AliDielectronEventCuts* eventCuts;
 		AliAnalysisFilter* eventFilter;
 		
-		AliDielectronVarCuts* trackCuts;
-		AliDielectronTrackCuts *trackFilter;
+		AliDielectronVarCuts* varCuts;
+		AliDielectronTrackCuts *trackCuts;
 		AliDielectronPID *pidCuts;
 		AliDielectronCutGroup* cuts;
-		AliAnalysisFilter* filter; 
+		AliAnalysisFilter* trackFilter; 
 
 		//Class needed to use PID within the Dielectron Framework
 		AliDielectronVarManager* varManager;
@@ -214,6 +217,7 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 		Int_t charge;
 		Double_t EnSigmaITS;
 		Double_t EnSigmaTPC;
+		Double_t EnSigmaTPCcorr;
 		Double_t EnSigmaTOF;
 		Double_t PnSigmaTPC;
 		Double_t PnSigmaITS;

--- a/PWGDQ/dielectron/macrosLMEE/AddTask_acapon.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTask_acapon.C
@@ -1,4 +1,4 @@
-AliAnalysisTask *AddTask_acapon(TString outputFileName = "AnalysisResult.root", Bool_t SDDstatus = kFALSE, Bool_t getFromAlien = kFALSE, Bool_t doPairing = kTRUE, Bool_t doMixing = kTRUE){
+AliAnalysisTask *AddTask_acapon(TString outputFileName = "AnalysisResult.root", Bool_t SDDstatus = kFALSE, Bool_t getFromAlien = kFALSE, Bool_t doPairing = kTRUE, Bool_t doMixing = kTRUE, Bool_t useTPCcorr = kFALSE){
   
     //get the current analysis manager
     AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
@@ -51,12 +51,13 @@ AliAnalysisTask *AddTask_acapon(TString outputFileName = "AnalysisResult.root", 
 
     //create task and add it to the manager
     AliAnalysisTaskMultiDielectron *task = new AliAnalysisTaskMultiDielectron("DielectronTask");
-    //if (!hasMC) 
+		if(!task){
+			::Error("AddTask_acapon", "MultiDielectron trask not created");
+			return 0x0;
+		}
 
-    //task->UsePhysicsSelection();
-
-    //Add event filter
-    Int_t triggerNames=(AliVEvent::kINT7);
+		//Add event filter
+    Int_t triggerNames = (AliVEvent::kINT7);
     task->SetEventFilter(cutlib->GetEventCuts(LMEECutLib::kAllSpecies));
     task->SelectCollisionCandidates(triggerNames);
     task->SetTriggerMask(triggerNames);
@@ -69,7 +70,7 @@ AliAnalysisTask *AddTask_acapon(TString outputFileName = "AnalysisResult.root", 
     //add dielectron analysis with different cuts to the task
     for (Int_t i=0; i<nDie; ++i){ //nDie defined in config file
         //MB
-        AliDielectron *diel_low = Config_acapon(arrNames->At(i)->GetName(), hasMC, bESDANA, SDDstatus, doPairing, doMixing);
+        AliDielectron *diel_low = Config_acapon(arrNames->At(i)->GetName(), hasMC, bESDANA, SDDstatus, doPairing, doMixing, useTPCcorr);
         if(!diel_low){ continue; }
         task->AddDielectron(diel_low);
         printf("successfully added AliDielectron: %s\n",diel_low->GetName());

--- a/PWGDQ/dielectron/macrosLMEE/Config_acapon.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_acapon.C
@@ -19,7 +19,9 @@ Int_t selectedCuts = -1;
 Int_t selectedPID = -1;
 Bool_t pairCuts = kTRUE;
 
-AliDielectron* Config_acapon(TString cutDefinition, Bool_t hasMC=kFALSE, Bool_t isESD=kFALSE, Bool_t SDDstatus =kFALSE, Bool_t doPairing = kTRUE, Bool_t doMixing = kTRUE)
+AliDielectron* Config_acapon(TString cutDefinition, Bool_t hasMC = kFALSE, Bool_t isESD = kFALSE,
+                             Bool_t SDDstatus = kFALSE, Bool_t doPairing = kTRUE,
+                             Bool_t doMixing = kTRUE, Bool_t setTPCcorr = kFALSE)
 {
 
     //Setup the instance of AliDielectron
@@ -29,9 +31,14 @@ AliDielectron* Config_acapon(TString cutDefinition, Bool_t hasMC=kFALSE, Bool_t 
     TString name = cutDefinition;
 
     //Init AliDielectron
-    AliDielectron *die = new AliDielectron(Form("%s",name.Data()), Form("AliDielectron with cuts: %s",name.Data()));
-    //die->SetHasMC(hasMC);
-    MCenabled=hasMC;
+    AliDielectron* die = new AliDielectron(Form("%s",name.Data()), Form("AliDielectron with cuts: %s",name.Data()));
+		//die->SetHasMC(hasMC);
+		if(setTPCcorr){
+			LMcutlib->SetEtaCorrectionTPC(die, AliDielectronVarManager::kP,
+                                      AliDielectronVarManager::kEta,
+                                      AliDielectronVarManager::kRefMultTPConly, kFALSE);
+		}
+    MCenabled = hasMC;
 
     // deactivate pairing to check track cuts or run with loose pid cuts:
     if(!doPairing){


### PR DESCRIPTION
The ability to use the TPC post calibration is now implemented for both the SimpleTreeMaker, as
well as for the attached Config file. 
All necessary AddTask files were also updated to accommodate the changes.