### PR TITLE
PWGHF: Updated strategy for tracking eff systematic for Dstar

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskTrackingSysPropagation.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskTrackingSysPropagation.cxx
@@ -421,24 +421,8 @@ void AliAnalysisTaskTrackingSysPropagation::UserExec(Option_t *){
 	  if (mcLabel < 0) continue;
                     
 	  //soft pion
-	  track = (AliAODTrack*)(((AliAODRecoCascadeHF*)d)->GetBachelor());
-	  if(!track) {
-	    PostData(1,fOutput);
-	    return;
-	  }
-	  Int_t labDau = track->GetLabel();
-	  AliAODMCParticle* p = (AliAODMCParticle*)arrayMC->UncheckedAt(TMath::Abs(labDau));
-	  double ptdau = track->Pt();
-                   
-	  bin = fHistMESyst->FindBin(ptdau);
-	  if(bin > 0 && bin <= nbinsME) syst += fHistMESyst->GetBinContent(bin);
-	  else if(bin > nbinsME) syst += fHistMESyst->GetBinContent(nbinsME);
-	  else if(bin == 0) {
-	    AliError("Check input histo at low pt!");
-	    PostData(1,fOutput);
-	    return;
-	  }
-	  fhPtDauVsD->Fill(ptD,ptdau);
+	  //Update 17/07/18: Soft pion not prolonged from TPC to ITS, so matching should not be applied
+
 	  //D0
 	  AliAODRecoDecayHF2Prong *D0 = ((AliAODRecoCascadeHF*)d)->Get2Prong();
 	  for(Int_t iDau=0; iDau < 2; iDau++){
@@ -448,9 +432,9 @@ void AliAnalysisTaskTrackingSysPropagation::UserExec(Option_t *){
 	      PostData(1,fOutput);
 	      return;
 	    }
-	    labDau = track->GetLabel();
-	    p=(AliAODMCParticle*)arrayMC->UncheckedAt(TMath::Abs(labDau));
-	    ptdau = track->Pt();
+	    Int_t labDau = track->GetLabel();
+	    AliAODMCParticle* p=(AliAODMCParticle*)arrayMC->UncheckedAt(TMath::Abs(labDau));
+	    double ptdau = track->Pt();
                         
 	    bin = fHistMESyst->FindBin(ptdau);
 	    if(bin > 0 && bin <= nbinsME) syst += fHistMESyst->GetBinContent(bin);

--- a/PWGHF/vertexingHF/AliRDHFCuts.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCuts.cxx
@@ -128,7 +128,8 @@ fCutGeoNcrNclLength(130.),
 fCutGeoNcrNclGeom1Pt(1.5),
 fCutGeoNcrNclFractionNcr(0.85),
 fCutGeoNcrNclFractionNcl(0.7),
-fUseV0ANDSelectionOffline(kFALSE)
+fUseV0ANDSelectionOffline(kFALSE),
+fUseTPCtrackCutsOnThisDaughter(kTRUE)
 {
   //
   // Default Constructor
@@ -204,7 +205,8 @@ AliRDHFCuts::AliRDHFCuts(const AliRDHFCuts &source) :
   fCutGeoNcrNclGeom1Pt(source.fCutGeoNcrNclGeom1Pt),
   fCutGeoNcrNclFractionNcr(source.fCutGeoNcrNclFractionNcr),
   fCutGeoNcrNclFractionNcl(source.fCutGeoNcrNclFractionNcl),
-  fUseV0ANDSelectionOffline(source.fUseV0ANDSelectionOffline)
+  fUseV0ANDSelectionOffline(source.fUseV0ANDSelectionOffline),
+  fUseTPCtrackCutsOnThisDaughter(source.fUseTPCtrackCutsOnThisDaughter)
 {
   //
   // Copy constructor
@@ -307,6 +309,7 @@ AliRDHFCuts &AliRDHFCuts::operator=(const AliRDHFCuts &source)
   fCutGeoNcrNclFractionNcr=source.fCutGeoNcrNclFractionNcr;
   fCutGeoNcrNclFractionNcl=source.fCutGeoNcrNclFractionNcl;
   fUseV0ANDSelectionOffline=source.fUseV0ANDSelectionOffline;
+  fUseTPCtrackCutsOnThisDaughter=source.fUseTPCtrackCutsOnThisDaughter;
 
   PrintAll();
 
@@ -861,13 +864,13 @@ Bool_t AliRDHFCuts::IsDaughterSelected(AliAODTrack *track,const AliESDVertex *pr
   }
 
   //appliyng TPC crossed rows pT dependent cut
-  if(f1CutMinNCrossedRowsTPCPtDep){
+  if(f1CutMinNCrossedRowsTPCPtDep && fUseTPCtrackCutsOnThisDaughter){
     Float_t nCrossedRowsTPC = esdTrack.GetTPCCrossedRows();
     if(nCrossedRowsTPC<f1CutMinNCrossedRowsTPCPtDep->Eval(esdTrack.Pt())) return kFALSE;
   }
   
   //appliyng NTPCcls/NTPCcrossedRows cut
-  if(fCutRatioClsOverCrossRowsTPC){
+  if(fCutRatioClsOverCrossRowsTPC && fUseTPCtrackCutsOnThisDaughter){
     Float_t nCrossedRowsTPC = esdTrack.GetTPCCrossedRows();
     Float_t nClustersTPC = esdTrack.GetTPCNcls();
     if(nCrossedRowsTPC!=0){ 
@@ -878,7 +881,7 @@ Bool_t AliRDHFCuts::IsDaughterSelected(AliAODTrack *track,const AliESDVertex *pr
   }
 
   //appliyng TPCsignalN/NTPCcrossedRows cut
-  if(fCutRatioSignalNOverCrossRowsTPC){
+  if(fCutRatioSignalNOverCrossRowsTPC && fUseTPCtrackCutsOnThisDaughter){
     Float_t nCrossedRowsTPC = esdTrack.GetTPCCrossedRows();
     Float_t nTPCsignal = esdTrack.GetTPCsignalN();
     if(nCrossedRowsTPC!=0){

--- a/PWGHF/vertexingHF/AliRDHFCuts.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCuts.cxx
@@ -892,7 +892,7 @@ Bool_t AliRDHFCuts::IsDaughterSelected(AliAODTrack *track,const AliESDVertex *pr
   }
 
   // geometrical cut (note uses track at vertex instead of at TPC inner wall)
-  if(fUseCutGeoNcrNcl && aod){
+  if(fUseCutGeoNcrNcl && aod && fUseTPCtrackCutsOnThisDaughter){
     Float_t nCrossedRowsTPC = esdTrack.GetTPCCrossedRows();
     Float_t lengthInActiveZoneTPC=esdTrack.GetLengthInActiveZone(0,fDeadZoneWidth,220.,aod->GetMagneticField());
     Double_t cutGeoNcrNclLength=fCutGeoNcrNclLength-TMath::Power(TMath::Abs(esdTrack.GetSigned1Pt()),fCutGeoNcrNclGeom1Pt);

--- a/PWGHF/vertexingHF/AliRDHFCuts.h
+++ b/PWGHF/vertexingHF/AliRDHFCuts.h
@@ -242,6 +242,7 @@ class AliRDHFCuts : public AliAnalysisCuts
   void SetMinCrossedRowsTPCPtDep(const char *rows="");
   void SetMinRatioClsOverCrossRowsTPC(Float_t ratio=0.) {fCutRatioClsOverCrossRowsTPC = ratio;}
   void SetMinRatioSignalNOverCrossRowsTPC(Float_t ratio=0.) {fCutRatioSignalNOverCrossRowsTPC = ratio;}
+  void SetUseTPCtrackCutsOnThisDaughter(Bool_t flag=kTRUE) {fUseTPCtrackCutsOnThisDaughter=flag;}
 
   AliAODPidHF* GetPidHF() const {return fPidHF;}
   Float_t *GetPtBinLimits() const {return fPtBinLimits;}
@@ -287,6 +288,7 @@ class AliRDHFCuts : public AliAnalysisCuts
   const char* GetMinCrossedRowsTPCPtDep() const {return fCutMinCrossedRowsTPCPtDep;}
   Float_t GetMinRatioClsOverCrossRowsTPC() const {return fCutRatioClsOverCrossRowsTPC;}
   Float_t GetMinRatioSignalNOverCrossRowsTPC() const {return fCutRatioSignalNOverCrossRowsTPC;}
+  Bool_t GetUseTPCtrackCutsOnThisDaughter() const {return fUseTPCtrackCutsOnThisDaughter;}
   Bool_t IsSelected(TObject *obj) {return IsSelected(obj,AliRDHFCuts::kAll);}
   Bool_t IsSelected(TList *list) {if(!list) return kTRUE; return kFALSE;}
   Int_t  IsEventSelectedInCentrality(AliVEvent *event);
@@ -468,10 +470,10 @@ class AliRDHFCuts : public AliAnalysisCuts
   Double_t fCutGeoNcrNclFractionNcr; /// 4th parameter of GeoNcrNcl cut
   Double_t fCutGeoNcrNclFractionNcl; /// 5th parameter of GeoNcrNcl cut
   Bool_t fUseV0ANDSelectionOffline; ///flag to apply V0AND selection offline
-  
+  Bool_t fUseTPCtrackCutsOnThisDaughter; ///flag to apply TPC track quality cuts on specific D-meson daughter (used for different strategies for soft pion and D0daughters from Dstar decay)
 
   /// \cond CLASSIMP    
-  ClassDef(AliRDHFCuts,41);  /// base class for cuts on AOD reconstructed heavy-flavour decays
+  ClassDef(AliRDHFCuts,42);  /// base class for cuts on AOD reconstructed heavy-flavour decays
   /// \endcond
 };
 

--- a/PWGHF/vertexingHF/AliRDHFCutsDStartoKpipi.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCutsDStartoKpipi.cxx
@@ -52,7 +52,9 @@ AliRDHFCutsDStartoKpipi::AliRDHFCutsDStartoKpipi(const char* name) :
   fTrackCutsSoftPi(0),
   fMaxPtPid(9999.),
   fTPCflag(999.),
-  fCircRadius(0.)
+  fCircRadius(0.),
+  fUseTPCtrackCutsOnD0Daughters(kTRUE),
+  fUseTPCtrackCutsOnSoftPion(kFALSE)
 {
   //
   // Default Constructor
@@ -122,7 +124,9 @@ AliRDHFCutsDStartoKpipi::AliRDHFCutsDStartoKpipi(const AliRDHFCutsDStartoKpipi &
   fTrackCutsSoftPi(0),
   fMaxPtPid(9999.),
   fTPCflag(999.),
-  fCircRadius(0.)
+  fCircRadius(0.),
+  fUseTPCtrackCutsOnD0Daughters(source.fUseTPCtrackCutsOnD0Daughters),
+  fUseTPCtrackCutsOnSoftPion(source.fUseTPCtrackCutsOnSoftPion)
 {
   //
   // Copy constructor
@@ -350,6 +354,12 @@ Int_t AliRDHFCutsDStartoKpipi::IsSelected(TObject* obj,Int_t selectionLevel, Ali
   // selection on daughter tracks 
   if(selectionLevel==AliRDHFCuts::kAll || 
      selectionLevel==AliRDHFCuts::kTracks) {
+
+    if(fUseTPCtrackCutsOnD0Daughters || !fUseTPCtrackCutsOnSoftPion){
+    //if by mistake both flags turned off in cutobject => only apply to D0daughters (default option)
+      SetUseTPCtrackCutsOnThisDaughter(kTRUE);
+    } else { SetUseTPCtrackCutsOnThisDaughter(kFALSE); }
+
     if(!AreDaughtersSelected(dd,aod)) return 0;
     if(fTrackCutsSoftPi) {
       AliAODVertex *vAOD = d->GetPrimaryVtx();
@@ -357,6 +367,10 @@ Int_t AliRDHFCutsDStartoKpipi::IsSelected(TObject* obj,Int_t selectionLevel, Ali
       vAOD->GetXYZ(pos);
       vAOD->GetCovarianceMatrix(cov);
       const AliESDVertex vESD(pos,cov,100.,100);
+
+      if(fUseTPCtrackCutsOnSoftPion){ SetUseTPCtrackCutsOnThisDaughter(kTRUE); }
+      else{ SetUseTPCtrackCutsOnThisDaughter(kFALSE); }
+
       if(!IsDaughterSelected(b,&vESD,fTrackCutsSoftPi,aod)) return 0;
     }
   }

--- a/PWGHF/vertexingHF/AliRDHFCutsDStartoKpipi.h
+++ b/PWGHF/vertexingHF/AliRDHFCutsDStartoKpipi.h
@@ -64,15 +64,22 @@ class AliRDHFCutsDStartoKpipi : public AliRDHFCuts
   Double_t GetCircRadius() { return fCircRadius; }
   void SetCircRadius(Double_t radius) { fCircRadius = radius; }
 
+  void SetUseTPCtrackCutsOnD0Daughters(Bool_t flag=kTRUE) { fUseTPCtrackCutsOnD0Daughters = flag; }
+  void SetUseTPCtrackCutsOnSoftPion(Bool_t flag=kFALSE) { fUseTPCtrackCutsOnSoftPion = flag; }
+  Bool_t GetUseTPCtrackCutsOnD0Daughters() const { return fUseTPCtrackCutsOnD0Daughters; }
+  Bool_t GetUseTPCtrackCutsOnSoftPion() const { return fUseTPCtrackCutsOnSoftPion; }
+
  protected:
 
   AliESDtrackCuts *fTrackCutsSoftPi; /// cuts for soft pion (AOD converted to ESD on the flight!)
   Float_t fMaxPtPid; /// maximum Dstar Pt for using PID
   Float_t fTPCflag;   ///
   Double_t fCircRadius; /// Radius for circular PID nsigma cut
+  Bool_t fUseTPCtrackCutsOnD0Daughters; ///flag to apply TPC track quality cuts on D0 daughter from Dstar decay (used for different strategies for soft pion and D0daughters from Dstar decay) 
+  Bool_t fUseTPCtrackCutsOnSoftPion; ///flag to apply TPC track quality cuts on soft pion from Dstar decay (used for different strategies for soft pion and D0daughters from Dstar decay)
 
   /// \cond CLASSIMP    
-  ClassDef(AliRDHFCutsDStartoKpipi,7);  /// class for cuts on AOD reconstructed D0->Kpipi
+  ClassDef(AliRDHFCutsDStartoKpipi,8);  /// class for cuts on AOD reconstructed D0->Kpipi
   /// \endcond
 };
 


### PR DESCRIPTION
As discussed in the D2H of 10/07/18, the implementation of the new strategies to estimate the tracking efficiency systematic for Dstar.

1) ITS-TPC matching: Deleted the contribution from the soft pion, as it is not prolonged from TPC to ITS.
2) Track quality: Added a flag to be able to estimate the effect of TPC track quality variations separately for the soft pion and the D0 daughters.