### PR TITLE
JetPerformance: allow to use jettagger for geometrical matching

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetPerformance.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetPerformance.h
@@ -119,8 +119,6 @@ class AliAnalysisTaskEmcalJetPerformance : public AliAnalysisTaskEmcalJet {
   void SetComputeMBDownscaling(Bool_t b)                    { fComputeMBDownscaling = b; }
   void SetTrackMatchingDeltaEtaMax(Double_t deta)           { fTrackMatchingDeltaEtaMax = deta; }
   void SetTrackMatchingDeltaPhiMax(Double_t dphi)           { fTrackMatchingDeltaPhiMax = dphi; }
-  void SetMinimumSharedMomentumFraction(double d)           { fMinSharedMomentumFraction = d; }
-  void SetMaximumMatchedJetDistance(double d)               { fMaxMatchedJetDistance = d; }
   void SetUseResponseMaker(Bool_t b)                        { fUseResponseMaker = b; }
   void SetPlotDCal(Bool_t b)                                { fPlotDCal = b; }
 
@@ -156,9 +154,6 @@ class AliAnalysisTaskEmcalJetPerformance : public AliAnalysisTaskEmcalJet {
   Double_t                    GetJetType(const AliEmcalJet* jet);
   ContributorType             GetContributorType(const AliVCluster* clus, const AliMCEvent* mcevent, Int_t label);
   Bool_t                      IsHadron(const ContributorType contributor);
-  
-  // Jet matching functions (for embedding)
-  const AliEmcalJet*          GetMatchedPartLevelJet(const AliJetContainer * jets, const AliEmcalJet * jet, const std::string & histName);
   
   // Analysis parameters
   Bool_t                      fPlotJetHistograms;                   ///< Set whether to enable inclusive jet histograms
@@ -196,8 +191,6 @@ class AliAnalysisTaskEmcalJetPerformance : public AliAnalysisTaskEmcalJet {
   
   // Embedding parameters
   AliEmcalEmbeddingQA         fEmbeddingQA;                         //!<! QA hists for embedding (will only be added if embedding)
-  Double_t                    fMinSharedMomentumFraction;           ///< Minimum shared momentum (pp det-level track pT in combined jet) / (pp det-level track pT)
-  Double_t                    fMaxMatchedJetDistance;               ///< Maximum distance between two matched jets
   Bool_t                      fUseResponseMaker;                    ///< Flag to use Response Maker rather than JetTagger
   AliJetContainer*            fMCJetContainer;                      //!<!Pointer to jet container of truth-level jets
   
@@ -218,7 +211,7 @@ class AliAnalysisTaskEmcalJetPerformance : public AliAnalysisTaskEmcalJet {
   AliAnalysisTaskEmcalJetPerformance &operator=(const AliAnalysisTaskEmcalJetPerformance&); // not implemented
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskEmcalJetPerformance, 13);
+  ClassDef(AliAnalysisTaskEmcalJetPerformance, 14);
   /// \endcond
 };
 #endif


### PR DESCRIPTION
(without mc fraction requirement)

Update to my user task.