### PR TITLE
Fix global globals typo

### DIFF
--- a/PWGCF/EBYE/PWGCFebyeLinkDef.h
+++ b/PWGCF/EBYE/PWGCFebyeLinkDef.h
@@ -1,6 +1,6 @@
 #ifdef __CINT__
 
-#pragma link off all glols;
+#pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
 

--- a/PWGCF/FEMTOSCOPY/AliFemto/PWGCFfemtoscopyLinkDef.h
+++ b/PWGCF/FEMTOSCOPY/AliFemto/PWGCFfemtoscopyLinkDef.h
@@ -1,6 +1,6 @@
 #ifdef __CINT__
 
-#pragma link off all glols;
+#pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
 

--- a/PWGCF/FEMTOSCOPY/UNICOR/PWGCFunicorLinkDef.h
+++ b/PWGCF/FEMTOSCOPY/UNICOR/PWGCFunicorLinkDef.h
@@ -1,6 +1,6 @@
 #ifdef __CINT__
 
-#pragma link off all glols;
+#pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
 

--- a/PWGCF/FEMTOSCOPYAOD/PWGCFFEMTOSCOPYAODLinkDef.h
+++ b/PWGCF/FEMTOSCOPYAOD/PWGCFFEMTOSCOPYAODLinkDef.h
@@ -1,6 +1,6 @@
 #ifdef __CINT__
 
-#pragma link off all glols;
+#pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
 

--- a/PWGLF/NUCLEX/PWGLFnuclexLinkDef.h
+++ b/PWGLF/NUCLEX/PWGLFnuclexLinkDef.h
@@ -1,6 +1,6 @@
 #ifdef __CINT__
 
-#pragma link off all glols;
+#pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
 

--- a/PWGLF/QATasks/PWGLFQATasksLinkDef.h
+++ b/PWGLF/QATasks/PWGLFQATasksLinkDef.h
@@ -1,6 +1,6 @@
 #ifdef __CINT__
 
-#pragma link off all glols;
+#pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
 

--- a/PWGLF/STRANGENESS/PWGLFSTRANGENESSLinkDef.h
+++ b/PWGLF/STRANGENESS/PWGLFSTRANGENESSLinkDef.h
@@ -1,6 +1,6 @@
 #ifdef __CINT__
 
-#pragma link off all glols;
+#pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
 

--- a/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrectionsInterface/PWGPPevcharQnInterfaceLinkDef.h
+++ b/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrectionsInterface/PWGPPevcharQnInterfaceLinkDef.h
@@ -1,6 +1,6 @@
 #ifdef __CINT__
 
-#pragma link off all glols;
+#pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
 

--- a/PWGPP/EVCHAR/PWGPPevcharLinkDef.h
+++ b/PWGPP/EVCHAR/PWGPPevcharLinkDef.h
@@ -1,6 +1,6 @@
 #ifdef __CINT__
 
-#pragma link off all glols;
+#pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
 

--- a/PWGPP/MUON/dep/PWGPPMUONdepLinkDef.h
+++ b/PWGPP/MUON/dep/PWGPPMUONdepLinkDef.h
@@ -1,6 +1,6 @@
 #ifdef __CINT__
 
-#pragma link off all glols;
+#pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
 

--- a/PWGPP/MUON/lite/PWGPPMUONliteLinkDef.h
+++ b/PWGPP/MUON/lite/PWGPPMUONliteLinkDef.h
@@ -1,6 +1,6 @@
 #ifdef __CINT__
 
-#pragma link off all glols;
+#pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
 

--- a/PWGPP/PWGPPLinkDef.h
+++ b/PWGPP/PWGPPLinkDef.h
@@ -1,6 +1,6 @@
 #ifdef __CINT__
 
-#pragma link off all glols;
+#pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
 

--- a/PWGPP/pid/PWGPPpidLinkDef.h
+++ b/PWGPP/pid/PWGPPpidLinkDef.h
@@ -1,6 +1,6 @@
 #ifdef __CINT__
 
-#pragma link off all glols;
+#pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
 

--- a/PWGUD/DIFFRACTIVE/PWGUDdiffractiveLinkDef.h
+++ b/PWGUD/DIFFRACTIVE/PWGUDdiffractiveLinkDef.h
@@ -1,6 +1,6 @@
 #ifdef __CINT__
 
-#pragma link off all glols;
+#pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
 

--- a/PWGUD/UPC/PWGUDupcLinkDef.h
+++ b/PWGUD/UPC/PWGUDupcLinkDef.h
@@ -1,6 +1,6 @@
 #ifdef __CINT__
 
-#pragma link off all glols;
+#pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
 


### PR DESCRIPTION
Apparently by copy and pasting from the PWGPPLinkDef many PWG in their
LinkDef have a typo. "glols" is not a supported keyword in the
LinkDef.h, see for reference https://root.cern.ch/root/html534/guides/users-guide/AddingaClass.html