### PR TITLE
Add possibility to accept declared as warm/dead/hot channels 

### DIFF
--- a/PWG/CaloTrackCorrBase/AliCalorimeterUtils.cxx
+++ b/PWG/CaloTrackCorrBase/AliCalorimeterUtils.cxx
@@ -1892,10 +1892,10 @@ Bool_t AliCalorimeterUtils::IsMCParticleInCalorimeterAcceptance(Int_t calo, TPar
     Bool_t ok = GetEMCALGeometry()->GetAbsCellIdFromEtaPhi(particle->Eta(),particle->Phi(),absID);
     if(ok)
     {
-      Int_t icol = -1, irow = -1, iRCU = -1;
+      Int_t icol = -1, irow = -1, iRCU = -1, status = 0;
       Int_t nModule = GetModuleNumberCellIndexes(absID,calo, icol, irow, iRCU);
-      Int_t status  = GetEMCALChannelStatus(nModule,icol,irow);
-      if(status > 0) ok = kFALSE;
+      Bool_t bad    = GetEMCALChannelStatus(nModule,icol,irow,status);
+      if( bad ) ok = kFALSE;
     }
 
     return ok ;
@@ -1934,10 +1934,10 @@ Bool_t AliCalorimeterUtils::IsMCParticleInCalorimeterAcceptance(Int_t calo, AliA
     Bool_t ok = GetEMCALGeometry()->GetAbsCellIdFromEtaPhi(particle->Eta(),phi,absID);
     if(ok)
     {
-      Int_t icol = -1, irow = -1, iRCU = -1;
+      Int_t icol = -1, irow = -1, iRCU = -1, status = 0;
       Int_t nModule = GetModuleNumberCellIndexes(absID,calo, icol, irow, iRCU);
-      Int_t status  = GetEMCALChannelStatus(nModule,icol,irow);
-      if(status > 0) ok = kFALSE;
+      Bool_t bad    = GetEMCALChannelStatus(nModule,icol,irow,status);
+      if( bad ) ok = kFALSE;
     }
 
     return ok ;
@@ -1976,10 +1976,10 @@ Bool_t AliCalorimeterUtils::IsMCParticleInCalorimeterAcceptance(Int_t calo, AliV
     Bool_t ok = GetEMCALGeometry()->GetAbsCellIdFromEtaPhi(particle->Eta(),phi,absID);
     if(ok)
     {
-      Int_t icol = -1, irow = -1, iRCU = -1;
+      Int_t icol = -1, irow = -1, iRCU = -1, status = 0;
       Int_t nModule = GetModuleNumberCellIndexes(absID,calo, icol, irow, iRCU);
-      Int_t status  = GetEMCALChannelStatus(nModule,icol,irow);
-      if(status > 0) ok = kFALSE;
+      Bool_t bad    = GetEMCALChannelStatus(nModule,icol,irow,status);
+      if( bad ) ok = kFALSE;
     }
     
     return ok ;
@@ -2018,10 +2018,10 @@ Bool_t AliCalorimeterUtils::IsMCParticleInCalorimeterAcceptance(Int_t calo, Floa
     Bool_t ok = GetEMCALGeometry()->GetAbsCellIdFromEtaPhi(eta,phi,absID);
     if(ok)
     {
-      Int_t icol = -1, irow = -1, iRCU = -1;
+      Int_t icol = -1, irow = -1, iRCU = -1, status = 0;
       Int_t nModule = GetModuleNumberCellIndexes(absID,calo, icol, irow, iRCU);
-      Int_t status  = GetEMCALChannelStatus(nModule,icol,irow);
-      if(status > 0) ok = kFALSE;
+      Bool_t bad    = GetEMCALChannelStatus(nModule,icol,irow,status);
+      if( bad ) ok = kFALSE;
     }
 
     return ok ;

--- a/PWG/CaloTrackCorrBase/AliCalorimeterUtils.h
+++ b/PWG/CaloTrackCorrBase/AliCalorimeterUtils.h
@@ -153,8 +153,8 @@ class AliCalorimeterUtils : public TObject {
   
   void          InitPHOSBadChannelStatusMap () ;
 
-  Int_t         GetEMCALChannelStatus(Int_t iSM , Int_t iCol, Int_t iRow) const { 
-                  return fEMCALRecoUtils->GetEMCALChannelStatus(iSM,iCol,iRow); }//Channel is ok by default
+  Int_t         GetEMCALChannelStatus(Int_t iSM , Int_t iCol, Int_t iRow, Int_t status) const { 
+                  return fEMCALRecoUtils->GetEMCALChannelStatus(iSM, iCol, iRow, status); }//Channel is ok by default
 
   Int_t         GetPHOSChannelStatus (Int_t imod, Int_t iCol, Int_t iRow) const { 
                   if(fPHOSBadChannelMap) return (Int_t) ((TH2I*)fPHOSBadChannelMap->At(imod))->GetBinContent(iCol,iRow); 

--- a/PWG/CaloTrackCorrBase/AliIsolationCut.cxx
+++ b/PWG/CaloTrackCorrBase/AliIsolationCut.cxx
@@ -188,7 +188,7 @@ Float_t AliIsolationCut::GetCellDensity(AliCaloTrackParticleCorrelation * pCandi
     Int_t absId = -999;
     if (eGeom->GetAbsCellIdFromEtaPhi(etaC,phiC,absId))
     {
-      //Get absolute (col,row) of candidate
+      // Get absolute (col,row) of candidate
       Int_t iEta=-1, iPhi=-1, iRCU = -1;
       Int_t nSupMod = cu->GetModuleNumberCellIndexes(absId, pCandidate->GetDetectorTag(), iEta, iPhi, iRCU);
 
@@ -197,7 +197,8 @@ Float_t AliIsolationCut::GetCellDensity(AliCaloTrackParticleCorrelation * pCandi
       Int_t rowC = iPhi + AliEMCALGeoParams::fgkEMCALRows*int(nSupMod/2);
 
       Int_t sqrSize = int(fConeSize/0.0143) ; // Size of cell in radians
-      //loop on cells in a square of side fConeSize to check cells in cone
+      Int_t status = 0;
+      // Loop on cells in a square of side fConeSize to check cells in cone
       for(Int_t icol = colC-sqrSize; icol < colC+sqrSize;icol++)
       {
         for(Int_t irow = rowC-sqrSize; irow < rowC+sqrSize; irow++)
@@ -228,8 +229,8 @@ Float_t AliIsolationCut::GetCellDensity(AliCaloTrackParticleCorrelation * pCandi
             {
               coneCellsBad += 1.;
             }
-            //Count as bad "cells" marked as bad in the DataBase
-            else if (cu->GetEMCALChannelStatus(cellSM,cellEta,cellPhi)==1)
+            // Count as bad "cells" marked as bad in the DataBase
+            else if (cu->GetEMCALChannelStatus(cellSM,cellEta,cellPhi,status)==1)
             {
               coneCellsBad += 1. ;
             }
@@ -284,6 +285,7 @@ void AliIsolationCut::GetCoeffNormBadCell(AliCaloTrackParticleCorrelation * pCan
       Int_t rowC = iPhi + AliEMCALGeoParams::fgkEMCALRows*int(nSupMod/2);
 
       Int_t sqrSize = int(fConeSize/0.0143) ; // Size of cell in radians
+      Int_t status  = 0;
       for(Int_t icol = 0; icol < 2*AliEMCALGeoParams::fgkEMCALCols-1;icol++)
       {
         for(Int_t irow = 0; irow < 5*AliEMCALGeoParams::fgkEMCALRows -1; irow++)
@@ -311,7 +313,7 @@ void AliIsolationCut::GetCoeffNormBadCell(AliCaloTrackParticleCorrelation * pCan
 
           if( (icol < 0 || icol > AliEMCALGeoParams::fgkEMCALCols*2-1 ||
                irow < 0 || irow > AliEMCALGeoParams::fgkEMCALRows*5 - 1) //5*nRows+1/3*nRows //Count as bad "cells" out of EMCAL acceptance
-             || (cu->GetEMCALChannelStatus(cellSM,cellEta,cellPhi)==1))  //Count as bad "cells" marked as bad in the DataBase
+             || (cu->GetEMCALChannelStatus(cellSM,cellEta,cellPhi,status)==1))  //Count as bad "cells" marked as bad in the DataBase
           {
             if     ( Radius(colC, rowC, icol, irow) < sqrSize ) coneBadCellsCoeff    += 1.;
             else if( icol>colC-sqrSize  &&  icol<colC+sqrSize ) phiBandBadCellsCoeff += 1 ;

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
@@ -424,7 +424,10 @@ Bool_t AliEMCALRecoUtils::AcceptCalibrateCell(Int_t absID, Int_t bc,
   if ( IsBadChannelsRemovalSwitchedOn() )
   {
     Bool_t bad = GetEMCALChannelStatus(imod, ieta, iphi,status);
-    if ( status > 0 ) printf("Status %d, bad %d\n",status,bad);
+    
+    if ( status > 0 )
+      AliDebug(1,Form("Channel absId %d, status %d, set as bad %d",absID, status, bad));
+    
     if ( bad ) return kFALSE;
   }
   

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -47,6 +47,7 @@ class AliVCaloCells;
 class AliVEvent;
 #include "AliLog.h"
 class AliMCEvent;
+#include "AliCaloCalibPedestal.h"
 
 // EMCAL includes
 #include "AliEMCALRecoUtilsBase.h"
@@ -259,12 +260,17 @@ public:
                                                            if(!fEMCALBadChannelMap)InitEMCALBadChannelStatusMap() ; }
   TObjArray* GetEMCALBadChannelStatusMapArray()    const { return fEMCALBadChannelMap ; }
   void     InitEMCALBadChannelStatusMap() ;
-  Int_t    GetEMCALChannelStatus(Int_t iSM , Int_t iCol, Int_t iRow) const { 
-    if(fEMCALBadChannelMap) return (Int_t) ((TH2I*)fEMCALBadChannelMap->At(iSM))->GetBinContent(iCol,iRow); 
-    else return 0;}//Channel is ok by default
-  void     SetEMCALChannelStatus(Int_t iSM , Int_t iCol, Int_t iRow, Double_t c = 1) { 
+  void     SetEMCALBadChannelStatusSelection(Bool_t all, Bool_t dead, Bool_t hot, Bool_t warm);
+  void     SetWarmChannelAsGood() 
+           { fBadStatusSelection[0] = kFALSE; fBadStatusSelection[AliCaloCalibPedestal::kWarning] = kFALSE; }
+  void     SetDeadChannelAsGood() 
+           { fBadStatusSelection[0] = kFALSE; fBadStatusSelection[AliCaloCalibPedestal::kDead]    = kFALSE; }
+  void     SetHotChannelAsGood() 
+           { fBadStatusSelection[0] = kFALSE; fBadStatusSelection[AliCaloCalibPedestal::kHot]     = kFALSE; } 
+  Bool_t   GetEMCALChannelStatus(Int_t iSM , Int_t iCol, Int_t iRow, Int_t & status) const ;
+  void     SetEMCALChannelStatus(Int_t iSM , Int_t iCol, Int_t iRow, Double_t status = 1) { 
     if(!fEMCALBadChannelMap)InitEMCALBadChannelStatusMap()               ;
-    ((TH2I*)fEMCALBadChannelMap->At(iSM))->SetBinContent(iCol,iRow,c)    ; }
+    ((TH2I*)fEMCALBadChannelMap->At(iSM))->SetBinContent(iCol,iRow,status)    ; }
   TH2I *   GetEMCALChannelStatusMap(Int_t iSM)     const { return (TH2I*)fEMCALBadChannelMap->At(iSM) ; }
   void     SetEMCALChannelStatusMap(const TObjArray *map);
   void     SetEMCALChannelStatusMap(Int_t iSM , const TH2I* h);
@@ -480,7 +486,12 @@ private:
   Bool_t     fRemoveBadChannels;         ///< Check the channel status provided and remove clusters with bad channels
   Bool_t     fRecalDistToBadChannels;    ///< Calculate distance from highest energy tower of cluster to closes bad channel
   TObjArray* fEMCALBadChannelMap;        ///< Array of histograms with map of bad channels, EMCAL
-
+  Bool_t     fBadStatusSelection[4];     ///< Declare as bad all the types of bad channels or only some. 
+                                         ///<   0- Set all types to bad if true
+                                         ///<   1- Set dead as good if false
+                                         ///<   2- Set hot as good if false
+                                         ///<   3- Set warm as good if false
+  
   // Border cells
   Int_t      fNCellsFromEMCALBorder;     ///< Number of cells from EMCAL border the cell with maximum amplitude has to be.
   Bool_t     fNoEMCALBorderAtEta0;       ///< Do fiducial cut in EMCAL region eta = 0?

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellBadChannel.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellBadChannel.cxx
@@ -49,6 +49,18 @@ Bool_t AliEmcalCorrectionCellBadChannel::Initialize()
 
   fRecoUtils->SetPositionAlgorithm(AliEMCALRecoUtils::kPosTowerGlobal);
 
+  Bool_t dead = kFALSE;
+  GetProperty("acceptDead", dead);
+  if ( dead ) fRecoUtils->SetDeadChannelAsGood();
+
+  Bool_t hot = kFALSE;
+  GetProperty("acceptHot", hot);
+  if ( hot ) fRecoUtils->SetHotChannelAsGood();  
+  
+  Bool_t warm = kFALSE;
+  GetProperty("acceptWarm", warm);
+  if ( warm ) fRecoUtils->SetWarmChannelAsGood();
+  
   return kTRUE;
 }
 

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -56,6 +56,9 @@ CellEnergy:                                         # Cell Energy correction com
 CellBadChannel:                                     # Bad channel removal at the cell level component
     enabled: false                                  # Whether to enable the task
     createHistos: false                             # Whether the task should create output histograms
+    acceptDead: false                               # Declare dead channels as good
+    acceptHot: false                                # Declare hot channels as good
+    acceptWarm: false                               # Declare warm channels as good  
     cellsNames:                                     # Names of the cells input objects which should be attached to the correction
         - defaultCells                              # This object is defined above in the cells section of the input objects
 CellTimeCalib:                                      # Cell Time Calibration component

--- a/PWGGA/CaloTrackCorrelations/AliAnaCalorimeterQA.cxx
+++ b/PWGGA/CaloTrackCorrelations/AliAnaCalorimeterQA.cxx
@@ -432,7 +432,7 @@ void AliAnaCalorimeterQA::CellHistograms(AliVCaloCells *cells)
   Bool_t   highG  = kFALSE;
   Float_t  recalF = 1.;  
   Int_t    bc     = GetReader()->GetInputEvent()->GetBunchCrossNumber();
-  
+  Int_t    status = 0;
   for (Int_t iCell = 0; iCell < cells->GetNumberOfCells(); iCell++)
   {
     if ( cells->GetCellNumber(iCell) < 0 ) continue; // CPV 
@@ -456,7 +456,7 @@ void AliAnaCalorimeterQA::CellHistograms(AliVCaloCells *cells)
     {
       if(GetCalorimeter()==kEMCAL)
       {
-        if(GetCaloUtils()->GetEMCALChannelStatus(nModule,icol,irow)) continue;
+        if(GetCaloUtils()->GetEMCALChannelStatus(nModule,icol,irow,status)) continue;
       }
       else 
       {

--- a/PWGGA/CaloTrackCorrelations/AliAnaRandomTrigger.cxx
+++ b/PWGGA/CaloTrackCorrelations/AliAnaRandomTrigger.cxx
@@ -105,7 +105,9 @@ Bool_t AliAnaRandomTrigger::ExcludeDeadBadRegions(Float_t eta, Float_t phi)
   // Check if the cell or those around are bad
   //-------------------------------------
 
-  if(GetCaloUtils()->GetEMCALChannelStatus(sm,icol, irow) > 0) return kTRUE ; // trigger falls into a bad channel
+  Int_t status = 0;
+  if ( GetCaloUtils()->GetEMCALChannelStatus(sm,icol, irow,status) ) 
+    return kTRUE ; // trigger falls into a bad channel
 
   // Check if close there was a bad channel
 //  for(Int_t i = -1; i <= 1; i++)

--- a/PWGGA/GammaConv/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConv/AliCaloPhotonCuts.cxx
@@ -6408,7 +6408,8 @@ Bool_t AliCaloPhotonCuts::AcceptCellByBadChannelMap(Int_t absID ){
     fGeomEMCAL->GetCellPhiEtaIndexInSModule(imod,iTower,iIphi, iIeta,iphi,ieta);
 
     // Do not include bad channels found in analysis,
-    if (fEMCALRecUtils->GetEMCALChannelStatus(imod, ieta, iphi) == 0 )
+    Int_t status = 0;
+    if (fEMCALRecUtils->GetEMCALChannelStatus(imod, ieta, iphi, status) == 0 )
       return kTRUE;
     else
       return kFALSE;

--- a/PWGPP/EMCAL/AliAnalysisTaskCaloFilter.cxx
+++ b/PWGPP/EMCAL/AliAnalysisTaskCaloFilter.cxx
@@ -471,6 +471,7 @@ void AliAnalysisTaskCaloFilter::FillAODCaloCells()
     aodEMcells.CreateContainer(nEMcell);
     aodEMcells.SetType(AliVCaloCells::kEMCALCell);
     Double_t calibFactor = 1.;   
+    Int_t    status      = 0;
     for (Int_t iCell = 0; iCell < nEMcell; iCell++) 
     { 
       Int_t imod = -1, iphi =-1, ieta=-1,iTower = -1, iIphi = -1, iIeta = -1; 
@@ -482,7 +483,7 @@ void AliAnalysisTaskCaloFilter::FillAODCaloCells()
         calibFactor = fEMCALRecoUtils->GetEMCALChannelRecalibrationFactor(imod,ieta,iphi);
       }
       
-      if(!fEMCALRecoUtils->GetEMCALChannelStatus(imod, ieta, iphi))
+      if(!fEMCALRecoUtils->GetEMCALChannelStatus(imod, ieta, iphi,status))
       { //Channel is not declared as bad
         aodEMcells.SetCell(iCell,
                            eventEMcells.GetCellNumber(iCell),


### PR DESCRIPTION
For calibration analysis it is important to try to understand if some channels declared as bad can be recovered, in particular those declared as "warm". 

With this commit, I changed the method AliEMCALRecoUtils::GetEMCALChannelStatus() that so far returned the status and in most of the code where it is used, if it was non 0 (good channel) this channel was rejected. Now instead, it returns true or false depending on internal conditions to select or not a bad channel depending its status but also the status is recoverable as one of the parameters.

The EMCal correction framework component dealing with bad channels is updated to consider this possibility, in the yaml file one should add the property

      acceptWarm: true

in the part related to bad channels.

In other frames or codes, one should recover the pointer to AliEMCALRecoUtils and do
fRecoUtils->SetWarmChannelAsGood() 

Similar actions for hot or dead are implement, even if it is unlikely its use.

Do not approve immediately in case of comments. I will do it tomorrow.
