### PR TITLE
Protect against case of no PID

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetExtractor.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetExtractor.cxx
@@ -522,6 +522,9 @@ void AliAnalysisTaskJetExtractor::AddPIDInformation(AliVParticle* particle, Floa
   // Get AOD value from reco
   recoPID  = aodtrack->GetMostProbablePID();
   AliAODPid* pidObj = aodtrack->GetDetPid();
+  if(!pidObj)
+    return;
+
   sigITS = pidObj->GetITSsignal();
   sigTPC = pidObj->GetTPCsignal();
   sigTOF = pidObj->GetTOFsignal();


### PR DESCRIPTION
Simple protection for the case that AOD PID object does not exist.