### PR TITLE
Incoporate fast trigger maker

### DIFF
--- a/PWG/EMCAL/CMakeLists.txt
+++ b/PWG/EMCAL/CMakeLists.txt
@@ -30,6 +30,7 @@ endif(CMAKE_COMPILER_IS_GNUCXX)
 add_subdirectory(EMCALbase)
 add_subdirectory(EMCALtasks)
 add_subdirectory(EMCALtrigger)
+add_subdirectory(EMCALtriggerPart)
 
 # Installing the macros
 install (DIRECTORY macros DESTINATION PWG/EMCAL)

--- a/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerMakerPart.cxx
+++ b/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerMakerPart.cxx
@@ -1,0 +1,299 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include "AliEmcalTriggerMakerPart.h"
+
+ClassImp(PWG::EMCAL::TriggerPart::AliEmcalTriggerMakerPart)
+
+using namespace PWG::EMCAL::TriggerPart;
+
+/**
+ * Constructor, initializing channel maps for EMCAL and DCAL-PHOS
+ */
+AliEmcalTriggerMakerPart::AliEmcalTriggerMakerPart() :
+	TObject(),
+	fJetTrigger(),
+	fGammaTrigger(),
+	fTriggerChannelsEMCAL(48, 64),
+	fTriggerChannelsDCALPHOS(48, 40),
+	fTriggerMapping(),
+	fBadChannelsEMCAL(),
+	fBadChannelsDCALPHOS(),
+	fHasRun(false),
+	fAcceptPHOSPatches(true),
+	fGammaEMCAL(),
+	fGammaDCALPHOS(),
+	fJetEMCAL(),
+	fJetDCALPHOS(),
+	fJetEMCAL8x8(),
+	fJetDCALPHOS8x8()
+{
+	fJetTrigger.SetTriggerSetup(&fTriggerSetup);
+	fGammaTrigger.SetTriggerSetup(&fTriggerSetup);
+}
+
+/**
+ * Destructor
+ */
+AliEmcalTriggerMakerPart::~AliEmcalTriggerMakerPart() {
+}
+
+/**
+ * Reset channel maps
+ */
+void AliEmcalTriggerMakerPart::Reset() {
+	fTriggerChannelsEMCAL.Reset();
+	fTriggerChannelsDCALPHOS.Reset();
+	fGammaEMCAL.clear();
+	fGammaDCALPHOS.clear();
+	fJetEMCAL.clear();
+	fJetDCALPHOS.clear();
+	fJetEMCAL8x8.clear();
+	fJetDCALPHOS8x8.clear();
+	fHasRun = false;
+}
+
+/**
+ * Main function to reconstruct trigger patches in the EMCAL and in the DCAL-PHOS.
+ * Patches are found using the trigger channels map, which has to be filled from outside.
+ * The order in the output list is:
+ * #- EMCAL gamma
+ * #- DCAL-PHOS gamma
+ * #- EMCAL jet
+ * #- DCAL-PHOS jet
+ * @return vector with all trigger patches.
+ */
+
+void AliEmcalTriggerMakerPart::FindPatches() {
+
+	fGammaEMCAL     = fGammaTrigger.FindPatches 	(	&fTriggerChannelsEMCAL		);
+	fGammaDCALPHOS  = fGammaTrigger.FindPatches 	(	&fTriggerChannelsDCALPHOS	);
+	fJetEMCAL       = fJetTrigger.  FindPatches 	(	&fTriggerChannelsEMCAL		);
+	fJetDCALPHOS    = fJetTrigger.  FindPatches 	(	&fTriggerChannelsDCALPHOS	);
+	fJetEMCAL8x8    = fJetTrigger.  FindPatches8x8	(	&fTriggerChannelsEMCAL		);
+	fJetDCALPHOS8x8 = fJetTrigger.  FindPatches8x8	(	&fTriggerChannelsDCALPHOS	);
+
+	fHasRun = true;
+}
+
+std::vector<AliEmcalTriggerPartRawPatch> AliEmcalTriggerMakerPart::GetPatches(const int what) {
+	if (fHasRun == false)
+		FindPatches();
+
+	std::vector<AliEmcalTriggerPartRawPatch> result;
+
+	if (what == AliEmcalTriggerPartRawPatch::kAny || what == AliEmcalTriggerPartRawPatch::kEMCALpatchGA ) {
+		for (std::vector<AliEmcalTriggerPartRawPatch>::iterator patchiter = fGammaEMCAL.begin(); patchiter != fGammaEMCAL.end(); patchiter++) {
+			patchiter->SetPatchType(AliEmcalTriggerPartRawPatch::kEMCALpatch);
+			result.push_back(*patchiter);
+		}
+	}
+
+	if (what == AliEmcalTriggerPartRawPatch::kAny || what == AliEmcalTriggerPartRawPatch::kDCALpatchGA ) {
+		for (std::vector<AliEmcalTriggerPartRawPatch>::iterator patchiter = fGammaDCALPHOS.begin(); patchiter != fGammaDCALPHOS.end(); patchiter++) {
+			if(!fAcceptPHOSPatches && IsPHOSPatch(patchiter->GetColStart(), patchiter->GetRowStart(), 2)) continue;
+			patchiter->SetPatchType(AliEmcalTriggerPartRawPatch::kDCALPHOSpatch);
+			result.push_back(*patchiter);
+		}
+	}
+
+	if (what == AliEmcalTriggerPartRawPatch::kAny || what == AliEmcalTriggerPartRawPatch::kEMCALpatchJE ) {
+		for (std::vector<AliEmcalTriggerPartRawPatch>::iterator patchiter = fJetEMCAL.begin(); patchiter != fJetEMCAL.end(); patchiter++) {
+			patchiter->SetPatchType(AliEmcalTriggerPartRawPatch::kEMCALpatch);
+			result.push_back(*patchiter);
+		}
+	}
+
+	if (what == AliEmcalTriggerPartRawPatch::kAny || what == AliEmcalTriggerPartRawPatch::kDCALpatchJE ) {
+		for (std::vector<AliEmcalTriggerPartRawPatch>::iterator patchiter = fJetDCALPHOS.begin(); patchiter != fJetDCALPHOS.end(); patchiter++) {
+			if(!fAcceptPHOSPatches && IsPHOSPatch(patchiter->GetColStart(), patchiter->GetRowStart(), 16)) continue;
+			patchiter->SetPatchType(AliEmcalTriggerPartRawPatch::kDCALPHOSpatch);
+			result.push_back(*patchiter);
+		}
+	}
+
+	if (what == AliEmcalTriggerPartRawPatch::kAny || what == AliEmcalTriggerPartRawPatch::kEMCALpatchJE8x8 ) {
+		for (std::vector<AliEmcalTriggerPartRawPatch>::iterator patchiter = fJetEMCAL8x8.begin(); patchiter != fJetEMCAL8x8.end(); patchiter++) {
+			patchiter->SetPatchType(AliEmcalTriggerPartRawPatch::kEMCALpatch);
+			result.push_back(*patchiter);
+		}
+	}
+
+	if (what == AliEmcalTriggerPartRawPatch::kAny || what == AliEmcalTriggerPartRawPatch::kDCALpatchJE8x8 ) {
+		for (std::vector<AliEmcalTriggerPartRawPatch>::iterator patchiter = fJetDCALPHOS8x8.begin(); patchiter != fJetDCALPHOS8x8.end(); patchiter++) {
+			if(!fAcceptPHOSPatches && IsPHOSPatch(patchiter->GetColStart(), patchiter->GetRowStart(), 8)) continue;
+			patchiter->SetPatchType(AliEmcalTriggerPartRawPatch::kDCALPHOSpatch);
+			result.push_back(*patchiter);
+		}
+	}
+
+	return result;
+}
+
+bool AliEmcalTriggerMakerPart::IsPHOSPatch(int col, int row, int size){
+	return (col >= kMinEtaPHOS) && (col+size <kMaxEtaPHOS) && (row >= kMinRowPHOS) && (row+size < kMaxRowPHOS);
+}
+
+AliEmcalTriggerPartRawPatch AliEmcalTriggerMakerPart::GetMaxGammaEMCAL()
+{
+	if (fHasRun == false)
+		FindPatches();
+	if (fGammaEMCAL.empty())
+		return AliEmcalTriggerPartRawPatch();
+	else
+		return fGammaEMCAL.back();
+}
+
+AliEmcalTriggerPartRawPatch AliEmcalTriggerMakerPart::GetMaxGammaDCALPHOS()
+{
+	if (fHasRun == false)
+		FindPatches();
+	if (fGammaDCALPHOS.empty())
+		return AliEmcalTriggerPartRawPatch();
+	else
+		return fGammaDCALPHOS.back();
+}
+
+AliEmcalTriggerPartRawPatch AliEmcalTriggerMakerPart::GetMaxJetEMCAL()
+{
+	if (fHasRun == false)
+		FindPatches();
+	if (fJetEMCAL.empty())
+		return AliEmcalTriggerPartRawPatch();
+	else
+		return fJetEMCAL.back();
+}
+
+AliEmcalTriggerPartRawPatch AliEmcalTriggerMakerPart::GetMaxJetDCALPHOS()
+{
+	if (fHasRun == false)
+		FindPatches();
+	if (fJetDCALPHOS.empty())
+		return AliEmcalTriggerPartRawPatch();
+	else
+		return fJetDCALPHOS.back();
+}
+
+AliEmcalTriggerPartRawPatch AliEmcalTriggerMakerPart::GetMaxJetEMCAL8x8()
+{
+	if (fHasRun == false)
+		FindPatches();
+	if (fJetEMCAL8x8.empty())
+		return AliEmcalTriggerPartRawPatch();
+	else
+		return fJetEMCAL8x8.back();
+}
+
+AliEmcalTriggerPartRawPatch AliEmcalTriggerMakerPart::GetMaxJetDCALPHOS8x8()
+{
+	if (fHasRun == false)
+		FindPatches();
+	if (fJetDCALPHOS8x8.empty())
+		return AliEmcalTriggerPartRawPatch();
+	else
+		return fJetDCALPHOS8x8.back();
+}
+
+double AliEmcalTriggerMakerPart::GetMedian(std::vector<AliEmcalTriggerPartRawPatch> v)
+{
+	double median = 0;
+	size_t size = v.size();
+
+	if (size > 0)
+	{
+		size_t halfsize = v.size() / 2;
+		if (size % 2 == 0)
+		{
+			median = (v[halfsize - 1].GetADC() + v[halfsize].GetADC()) / 2;
+		}
+		else
+		{
+			median = v[halfsize].GetADC();
+		}
+	}
+	return median;
+}
+
+double AliEmcalTriggerMakerPart::GetMedianGammaEMCAL()
+{
+	if (fHasRun == false)
+		FindPatches();
+	return GetMedian(fGammaEMCAL);
+}
+
+double AliEmcalTriggerMakerPart::GetMedianGammaDCALPHOS()
+{
+	if (fHasRun == false)
+		FindPatches();
+	return GetMedian(fGammaDCALPHOS);
+}
+
+double AliEmcalTriggerMakerPart::GetMedianJetEMCAL()
+{
+	if (fHasRun == false)
+		FindPatches();
+	return GetMedian(fJetEMCAL);
+}
+
+double AliEmcalTriggerMakerPart::GetMedianJetDCALPHOS()
+{
+	if (fHasRun == false)
+		FindPatches();
+	return GetMedian(fJetDCALPHOS);
+}
+
+double AliEmcalTriggerMakerPart::GetMedianJetEMCAL8x8()
+{
+	if (fHasRun == false)
+		FindPatches();
+	return GetMedian(fJetEMCAL8x8);
+}
+
+double AliEmcalTriggerMakerPart::GetMedianJetDCALPHOS8x8()
+{
+	if (fHasRun == false)
+		FindPatches();
+	return GetMedian(fJetDCALPHOS8x8);
+}
+
+/**
+ * Fill trigger channel map depending on where the particle hits the detector in the EMCAL DCAL-PHOS surface. Adds the charge
+ * to the already existing charge. Doesn't do anything if the particle is outside of the detector acceptance of either of the
+ * tow subsystems.
+ * @param eta Track/Particle eta
+ * @param phi Track/Particle phi
+ * @param energy Track/Particle energy
+ */
+void AliEmcalTriggerMakerPart::FillChannelMap(double eta, double phi, double energy) {
+	AliEmcalTriggerPartChannel position = fTriggerMapping.GetPositionFromEtaPhi(eta, phi);
+	if (position.IsEMCAL()) {
+		if (!fBadChannelsEMCAL.HasChannel(position.GetCol(), position.GetRow()))
+			fTriggerChannelsEMCAL.AddADC(position.GetCol(), position.GetRow(), energy);
+	} else if (position.IsDCALPHOS()) {
+		if (!fBadChannelsDCALPHOS.HasChannel(position.GetCol(), position.GetRow()))
+			fTriggerChannelsDCALPHOS.AddADC(position.GetCol(), position.GetRow(), energy);
+	}
+}

--- a/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerMakerPart.h
+++ b/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerMakerPart.h
@@ -1,0 +1,174 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIEMCALTRIGGERMAKERPART_H
+#define ALIEMCALTRIGGERMAKERPART_H
+
+#include <TObject.h>
+
+#include "AliEmcalTriggerPartGammaAlgorithm.h"
+#include "AliEmcalTriggerPartJetAlgorithm.h"
+#include "AliEmcalTriggerPartChannelMap.h"
+#include "AliEmcalTriggerPartBadChannelContainer.h"
+#include "AliEmcalTriggerPartMapping.h"
+#include "AliEmcalTriggerPartSetup.h"
+
+namespace PWG {
+
+namespace EMCAL {
+
+namespace TriggerPart {
+
+class AliEmcalTriggerMakerPart : public TObject {
+public:
+	enum {
+		kMinRowPHOS = 0,
+		kMaxRowPHOS = 35,
+		kMinEtaPHOS = 16,
+		kMaxEtaPHOS = 31
+	};
+	
+	AliEmcalTriggerMakerPart();
+	virtual ~AliEmcalTriggerMakerPart();
+
+	void 																					Reset();
+	void 																					FindPatches();
+	std::vector<AliEmcalTriggerPartRawPatch>			GetPatches(const int what = AliEmcalTriggerPartRawPatch::kAny);
+	AliEmcalTriggerPartRawPatch 									GetMaxGammaEMCAL();
+	AliEmcalTriggerPartRawPatch 									GetMaxGammaDCALPHOS();
+	AliEmcalTriggerPartRawPatch 									GetMaxJetEMCAL();
+	AliEmcalTriggerPartRawPatch 									GetMaxJetDCALPHOS();
+	AliEmcalTriggerPartRawPatch 									GetMaxJetEMCAL8x8();
+	AliEmcalTriggerPartRawPatch 									GetMaxJetDCALPHOS8x8();
+
+	double 																				GetMedian(std::vector<AliEmcalTriggerPartRawPatch> v);
+
+	double 																				GetMedianGammaEMCAL();
+	double 																				GetMedianGammaDCALPHOS();
+	double 																				GetMedianJetEMCAL();
+	double 																				GetMedianJetDCALPHOS();
+	double 																				GetMedianJetEMCAL8x8();
+	double 																				GetMedianJetDCALPHOS8x8();
+
+	void FillChannelMap(double eta, double phi, double energy);
+
+	/**
+	 * Get the map of the EMCAL trigger channels
+	 * @return Map of the EMCAL trigger channels
+	 */
+	const AliEmcalTriggerPartChannelMap &GetEMCALChannels() const { return fTriggerChannelsEMCAL; }
+
+	/**
+	 * Get the map of the EMCAL trigger channels
+	 * @return Map of the EMCAL trigger channels
+	 */
+	const AliEmcalTriggerPartChannelMap &GetDCALPHOSChannels() const { return fTriggerChannelsDCALPHOS; }
+
+	/**
+	 * Get the mapping between eta and phi on the one side and row and col in the EMCAL / DCAL on the other side
+	 * @return Mapping for EMCAL and DCAL/PHOS trigger channels
+	 */
+	const AliEmcalTriggerPartMapping &GetTriggerChannelMapping() const { return fTriggerMapping; }
+
+											/**
+	 					* Setup trigger patch finders
+	 * @param setup Configuration of 					the trigger patch finders									 */	
+	void SetTriggerSetup(AliEmcalTriggerPartSetup	 &setup) { fTriggerSetup = setup; }
+
+	/*		*
+	 * Accept pa														tches 100% in PHOS
+	 * @param d	o													Accept switch whether we accept or not
+	 */
+	void SetAcceptPHOSPatches(bool doAccept) { fAcceptPHOSPatches = doAccept; }
+
+	/**
+	 * Add bad channel position in EMCAL in row and col to the list of bad channels.
+	 * Bad channels will be ignored when setting the energy
+	 * @param col Column of the bad channel
+	 * @param row Row of the bad channel
+	 */
+	void AddBadChannelEMCAL(int col, int row) { fBadChannelsEMCAL.AddChannel(col, row); }
+
+	/**
+	 * Add bad channel position in EMCAL in row and col to the list of bad channels.
+	 * Bad channels will be ignored when setting the energy
+	 * @param col Column of the bad channel
+	 * @param row Row of the bad channel
+	 */
+	void AddBadChannelDCALPHOS(int col, int row) { fBadChannelsDCALPHOS.AddChannel(col, row); }
+
+	/**
+	 * Get bad channels container
+	 */
+	AliEmcalTriggerPartBadChannelContainer GetBadChannelContainerEMCAL() const
+	{
+		return fBadChannelsEMCAL;
+	}
+
+	/**
+	 * Get bad channels container
+	 */
+	AliEmcalTriggerPartBadChannelContainer GetBadChannelContainerDCALPHOS() const
+	{
+		return fBadChannelsDCALPHOS;
+	}
+
+	/**
+	 * Check whether patch is in PHOS
+	 * @param col
+	 * @param row
+	 * @param size
+	 * @return
+	 */
+	bool IsPHOSPatch(int col, int row, int size);
+
+private:
+	AliEmcalTriggerPartJetAlgorithm								fJetTrigger;								///< Algorithm finding jet patches on a trigger channel map
+	AliEmcalTriggerPartGammaAlgorithm							fGammaTrigger;							///< Algorithm finding gamma patches on a trigger channel map
+	AliEmcalTriggerPartChannelMap									fTriggerChannelsEMCAL;			///< Trigger channels for the EMCAL
+	AliEmcalTriggerPartChannelMap									fTriggerChannelsDCALPHOS;		///< Trigger channels for the combination DCAL-PHOS
+	AliEmcalTriggerPartMapping										fTriggerMapping;						///< Mapping between trigger channels and eta and phi
+	AliEmcalTriggerPartSetup											fTriggerSetup;							///< Setup of the EMCAL / DCAL-PHOS trigger algorithms
+	AliEmcalTriggerPartBadChannelContainer				fBadChannelsEMCAL;					///< Map with bad EMCAL channels
+	AliEmcalTriggerPartBadChannelContainer				fBadChannelsDCALPHOS;				///< Map with bad DCAL-PHOS channels
+	bool																					fHasRun;
+	bool 																					fAcceptPHOSPatches;					///< Accept patches 100% in PHOS
+	std::vector<AliEmcalTriggerPartRawPatch>			fGammaEMCAL;
+	std::vector<AliEmcalTriggerPartRawPatch>			fGammaDCALPHOS;
+	std::vector<AliEmcalTriggerPartRawPatch>			fJetEMCAL;
+	std::vector<AliEmcalTriggerPartRawPatch>			fJetDCALPHOS;
+	std::vector<AliEmcalTriggerPartRawPatch>			fJetEMCAL8x8;
+	std::vector<AliEmcalTriggerPartRawPatch>			fJetDCALPHOS8x8;
+
+	ClassDef(AliEmcalTriggerMakerPart, 1);
+};
+
+}
+}
+}
+
+
+#endif /* SlLImMCALRIGGERMAKERPaARTH */

--- a/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartAlgorithm.cxx
+++ b/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartAlgorithm.cxx
@@ -1,0 +1,48 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <cstdlib>
+#include "AliEmcalTriggerPartAlgorithm.h"
+
+ClassImp(PWG::EMCAL::TriggerPart::AliEmcalTriggerPartAlgorithm);
+ClassImp(PWG::EMCAL::TriggerPart::AliEmcalTriggerPartRawPatch);
+
+using namespace PWG::EMCAL::TriggerPart;
+
+/**
+ * Constructor
+ */
+AliEmcalTriggerPartAlgorithm::AliEmcalTriggerPartAlgorithm() :
+TObject(),
+fTriggerSetup(NULL)
+{
+}
+
+int AliEmcalTriggerPartRawPatch::GetID() const {
+	// normalize row and col by the index of the subregion
+	int subregionSize  = ((fPatchSize == 16) || (fPatchSize == 8)) ? 4 : 1, neta = 48/subregionSize;
+	return int(fCol)/subregionSize + int(fRow)/subregionSize * neta;
+}

--- a/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartAlgorithm.h
+++ b/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartAlgorithm.h
@@ -1,0 +1,204 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIEMCALTRIGGERPARTALGORITHM_H
+#define ALIEMCALTRIGGERPARTALGORITHM_H
+
+#include <vector>
+#include <TObject.h>
+
+namespace PWG {
+	
+namespace EMCAL {
+
+namespace TriggerPart {
+
+class AliEmcalTriggerPartPatchContainer;
+class AliEmcalTriggerPartChannelMap;
+class AliEmcalTriggerPartSetup;
+
+/**
+ * @class AliEmcalTriggerPartRawPatch
+ * @brief Helper structure for raw patches
+ *
+ * Stores minimal information of reconstructed patches, such as row, column, and
+ * reconstructed amplitude
+ */
+class AliEmcalTriggerPartRawPatch : public TObject{
+	/**
+	 * Default constructor, initializing all values with -1
+	 */
+public:
+	enum EPatchtype_t {
+		kAny,
+		kEMCALpatch,
+		kDCALPHOSpatch,
+		kEMCALpatchGA,
+		kEMCALpatchJE,		
+		kEMCALpatchJE8x8,		
+		kDCALpatchGA,		
+		kDCALpatchJE,				
+		kDCALpatchJE8x8,				
+		kUndefPatch
+	};
+
+	AliEmcalTriggerPartRawPatch():
+		TObject(),
+		fCol(0),
+		fRow(0),
+		fADC(-1.),
+		fTriggerBits(0),
+		fPatchSize(0),
+		fPatchType(kUndefPatch)
+	{}
+	/**
+	 * Constructor, initializing position and amplitude
+	 * @param col Starting col
+	 * @param row Starting row
+	 * @param adc Patch amplitude
+	 */
+	AliEmcalTriggerPartRawPatch(unsigned char col, unsigned char row, double adc, unsigned int triggerBits):
+		TObject(),
+		fCol(col),
+		fRow(row),
+		fADC(adc),
+		fTriggerBits(triggerBits),
+		fPatchSize(0),
+		fPatchType(kUndefPatch)
+	{}
+	/**
+	 * Destructor
+	 */
+	virtual ~AliEmcalTriggerPartRawPatch() {}
+
+	/**
+	 * Comparison operator, comparing to other in terms of ADC value
+	 * @param other Object to compare with
+	 * @return True if this adc is smaller, false otherwise
+	 */
+	bool operator<(const AliEmcalTriggerPartRawPatch & other) const {
+		return fADC < other.fADC;
+	}
+
+	/**
+	 * Set the type of the patch (EMCAL or DCAL-PHOS)
+	 * @param ptype Type of the patch
+	 */
+	void SetPatchType(EPatchtype_t ptype) { fPatchType = ptype; }
+
+	/**
+	 * Set the size of the patch
+	 * @param patchsize
+	 */
+	void SetPatchSize(unsigned char patchsize) { fPatchSize = patchsize; }
+
+	/**
+	 * Get starting row of the patch
+	 * @return starting row
+	 */
+	unsigned char GetRowStart() const { return fRow; }
+	/**
+	 * Get Starting column of the patch
+	 * @return starting column
+	 */
+	unsigned char GetColStart() const { return fCol; }
+	/**
+	 * Get the patch amplitude
+	 * @return the patch amplitude
+	 */
+	double GetADC() const { return fADC; }
+
+	/**
+	 * Get the size of the patch
+	 * @return size of the patch
+	 */
+	unsigned char GetPatchSize() const { return fPatchSize; }
+
+	/**
+	 * Get the trigger bits
+	 */
+	int GetTriggerBits() const { return fTriggerBits; }
+
+	/**
+	 * Check whether patch is of type EMCAL
+	 * @return True if patch is of type EMCAL, false otherwise
+	 */
+	bool IsEMCAL() const { return fPatchType == kEMCALpatch; }
+
+	/**
+	 * Check whether patch is of type DCAL-PHOS
+	 * @return True if patch is of type DCAL-PHOS, false otherwise
+	 */
+	bool IsDCALPHOS() const { return fPatchType == kDCALPHOSpatch; }
+
+	/**
+	 * Get unique ID of the patch, calculated, from col, row and subregion size
+	 * @return Unique ID of the patch;
+	 */
+	int GetID() const;
+
+private:
+	unsigned char        	fCol;           ///< Lower left column in col-row coordinate space
+	unsigned char      		fRow;           ///< Lower left row in col-row coordinate space
+	double      					fADC;           ///< ADC value of the raw patch
+	unsigned int         	fTriggerBits;   ///< Tigger bit settings
+	unsigned char					fPatchSize;	    ///< Patch size
+	EPatchtype_t	  			fPatchType;		 	///< Type of the trigger patch
+
+	ClassDef(AliEmcalTriggerPartRawPatch, 1);
+};
+
+/**
+ * @class AliEmcalTriggerPartAlgorithm
+ * @brief Base class for EMCAL trigger algorithms
+ *
+ * Base class for trigger algorithm implementations for the EMCAL trigger.
+ */
+class AliEmcalTriggerPartAlgorithm : public TObject {
+public:
+	AliEmcalTriggerPartAlgorithm();
+	virtual ~AliEmcalTriggerPartAlgorithm() {}
+
+	virtual std::vector<PWG::EMCAL::TriggerPart::AliEmcalTriggerPartRawPatch> FindPatches(const AliEmcalTriggerPartChannelMap * channels) const = 0;
+	/**
+	 * Set the trigger channel ADC map used to create the trigger patches
+	 * @param inputdata input
+	 */
+	void SetTriggerSetup(AliEmcalTriggerPartSetup *triggersetup) { fTriggerSetup = triggersetup; }
+
+protected:
+	AliEmcalTriggerPartSetup  		              *fTriggerSetup;       ///< Trigger setup data
+
+	ClassDef(AliEmcalTriggerPartAlgorithm, 1);
+};
+
+}
+
+}
+
+}
+
+#endif /* ALIEMCALTRIGGERPARTALGORITHM_H */

--- a/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartBadChannelContainer.cxx
+++ b/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartBadChannelContainer.cxx
@@ -1,0 +1,63 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include "AliEmcalTriggerPartBadChannelContainer.h"
+
+ClassImp(PWG::EMCAL::TriggerPart::AliEmcalTriggerPartBadChannelContainer);
+
+using namespace PWG::EMCAL::TriggerPart;
+
+void AliEmcalTriggerPartBadChannelContainer::AddChannel(int col, int row){
+  if(HasChannel(col, row)) return;
+  fChannels.push_back(TriggerChannelPosition(col, row));
+}
+
+
+bool AliEmcalTriggerPartBadChannelContainer::HasChannel(int col, int row){
+  TriggerChannelPosition test(col, row);
+  bool found(false);
+  for(std::vector<TriggerChannelPosition>::iterator channeliter = fChannels.begin(); channeliter != fChannels.end(); ++channeliter){
+	  if(*channeliter == test){
+		  found = true;
+		  break;
+	  }
+  }
+  return found;
+}
+
+bool AliEmcalTriggerPartBadChannelContainer::TriggerChannelPosition::operator==(const TriggerChannelPosition &other) const {
+  return fCol == other.fCol && fRow == other.fRow;
+}
+
+bool AliEmcalTriggerPartBadChannelContainer::TriggerChannelPosition::operator<(const AliEmcalTriggerPartBadChannelContainer::TriggerChannelPosition &other) const {
+  if(fCol == other.fCol){
+    if(fRow == other.fRow) return 0;
+    else if(fRow < other.fRow) return -1;
+    else return 1;
+  }
+  else if(fCol < other.fCol) return -1;
+  else return 1;
+}

--- a/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartBadChannelContainer.h
+++ b/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartBadChannelContainer.h
@@ -1,0 +1,167 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIEMCALTRIGGERPARTBADCHANNELCONTAINER_H
+#define ALIEMCALTRIGGERPARTBADCHANNELCONTAINER_H
+
+#include <vector>
+#include <TObject.h>
+
+namespace PWG {
+
+namespace EMCAL {
+
+namespace TriggerPart {
+
+/**
+ * @struct AliEmcalTriggerPartBadChannelContainer
+ * @brief Structure for position of trigger channels
+ *
+ * This structure is a container for trigger channels in col-row space with
+ * a given mask. Channels can only be added to the container, or it can be
+ * checked whether the channel is listed in the container.
+ */
+class AliEmcalTriggerPartBadChannelContainer : public TObject {
+public:
+
+  /**
+   * @struct TriggerChannelPosition
+   * @brief 2D position of a trigger channel on the EMCAL surface
+   *
+   * This class represents the position of a trigger channel in a 2D coordinate
+   * system consisting of column and row.
+   */
+  class TriggerChannelPosition {
+  public:
+
+    /**
+     * Dummy (I/O) constructor, not to be used
+     */
+    TriggerChannelPosition(): fCol(-1), fRow(-1) { }
+
+    /**
+     * Main constuctor, setting the position in column and row
+     * @param col Column of the trigger channel
+     * @param row Row of the trigger channel
+     */
+    TriggerChannelPosition(int col, int row): fCol(col), fRow(row) { }
+
+    /**
+     * Destructor, nothing to do
+     */
+    virtual ~TriggerChannelPosition() {}
+
+    /**
+     * Get the column of the channel
+     * @return  The column of the channel
+     */
+    int GetCol() const { return fCol; }
+
+    /**
+     * Get the row of the channel
+     * @return The row of the channel
+     */
+    int GetRow() const { return fRow; }
+
+    /**
+     * Set the colummn of the channel
+     * \param col The column of the channel
+     */
+    void SetCol(int col) { fCol = col; }
+
+    /**
+     * Set the row of the channel
+     * @param row The row of the channel
+     */
+    void SetRow(int row) { fRow = row; }
+
+    /**
+     * Check if the object is equal to object ref. Object can only be equal if ref is of
+     * the same type (AliEmcalTrigger channel position). If this is the case, col and row
+     * of the two objects have to match.
+     * @param ref The object to check
+     * @return True if objects are equal, false otherwise
+     */
+    bool operator==(const TriggerChannelPosition &ref) const;
+
+    /**
+     * Compare objects. If objects differ, return always greater (+1). Otherwise compare col and
+     * row of the object. Col has priority with respect to row.
+     * @param ref The object ot comparte to
+     * @return 0 if objects are equal, -1 if this object is smaller, +1 if this object is larger.
+     */
+    bool operator<(const TriggerChannelPosition &other) const;
+
+  private:
+    int                     fCol;            ///< Column of the trigger channel
+    int                   fRow;            ///< Row of the trigger channel
+  };
+
+  /**
+   * Constructor
+   */
+  AliEmcalTriggerPartBadChannelContainer(): TObject(), fChannels() {}
+
+  /**
+   * Destructor, cleans up the container
+   */
+  virtual ~AliEmcalTriggerPartBadChannelContainer() {}
+
+  /**
+   * Add a new channel with the postion in column and row to the container, In case the channel
+   * is already listed in the trigger channel container we don't add it again.
+   * @param col Column of the channel
+   * @param row Row of the channel
+   */
+  void AddChannel(int col, int row);
+
+  /**
+   * Check whether channel with the position (col, row) is listed in the trigger channel container
+   * @param col Column of the channel
+   * @param row Row of the channel
+   * @return True if the channel is listed, false otherwise
+   */
+  bool HasChannel(int col, int row);
+
+  /**
+   * Get Channels
+   */
+  std::vector<PWG::EMCAL::TriggerPart::AliEmcalTriggerPartBadChannelContainer::TriggerChannelPosition> GetChannels() const
+  {
+    return fChannels;
+  }
+
+private:
+  std::vector<PWG::EMCAL::TriggerPart::AliEmcalTriggerPartBadChannelContainer::TriggerChannelPosition>             fChannels;      ///< Container for listed channels
+
+  ClassDef(AliEmcalTriggerPartBadChannelContainer, 1);
+};
+
+}
+}
+}
+
+#endif

--- a/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartBitConfig.cxx
+++ b/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartBitConfig.cxx
@@ -1,0 +1,103 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include "AliEmcalTriggerPartBitConfig.h"
+
+ClassImp(PWG::EMCAL::TriggerPart::AliEmcalTriggerPartBitConfig);
+ClassImp(PWG::EMCAL::TriggerPart::AliEmcalTriggerPartBitConfigOld);
+ClassImp(PWG::EMCAL::TriggerPart::AliEmcalTriggerPartBitConfigNew);
+
+using namespace PWG::EMCAL::TriggerPart;
+
+/**
+ * Dummy constructor for the configuraiton base classes, not to be callled
+ */
+AliEmcalTriggerPartBitConfig::AliEmcalTriggerPartBitConfig():
+TObject(),
+fL0Bit(-1),
+fJHighBit(-1),
+fJLowBit(-1),
+fGHighBit(-1),
+fGLowBit(-1),
+fTriggerTypesEnd(-1)
+{
+}
+
+/**
+ * Constructor initialising the configurations. Used by the inheriting classes
+ * @param l0bit	Bit for Level0 (not used here)
+ * @param jhighbit Bit for Jet High (EJ1)
+ * @param jlowbit Bit for Jet Low (EJ2)
+ * @param ghighbit Bit for Gamma High (EG1)
+ * @param glowbit Bit for Gamma Low (EG2)
+ * @param mcoffset Monte Carlo offset bit (not used here)
+ */
+AliEmcalTriggerPartBitConfig::AliEmcalTriggerPartBitConfig(
+		int l0bit,
+		int jhighbit,
+		int jlowbit,
+		int ghighbit,
+		int glowbit,
+		int mcoffset):
+			TObject(),
+			fL0Bit(l0bit),
+			fJHighBit(jhighbit),
+			fJLowBit(jlowbit),
+			fGHighBit(ghighbit),
+			fGLowBit(glowbit),
+			fTriggerTypesEnd(mcoffset)
+{
+}
+
+/**
+ * Initialise from other object
+ * @param ref Reference used to initialize this object
+ */
+void AliEmcalTriggerPartBitConfig::Initialise(const AliEmcalTriggerPartBitConfig& ref) {
+	fL0Bit = ref.GetLevel0Bit();
+	fJHighBit = ref.GetJetHighBit();
+	fJLowBit = ref.GetJetLowBit();
+	fGHighBit = ref.GetGammaHighBit();
+	fGLowBit = ref.GetGammaLowBit();
+	fTriggerTypesEnd = ref.GetTriggerTypesEnd();
+}
+
+/**
+ * Settings for the 2-bit configuration
+ */
+AliEmcalTriggerPartBitConfigOld::AliEmcalTriggerPartBitConfigOld():
+    		AliEmcalTriggerPartBitConfig(0,2,2,1,1,3)
+{
+}
+
+/**
+ * Settings for the 4-bit configuration
+ */
+AliEmcalTriggerPartBitConfigNew::AliEmcalTriggerPartBitConfigNew():
+    		AliEmcalTriggerPartBitConfig(0,3,4,1,2,5)
+{
+}
+

--- a/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartBitConfig.h
+++ b/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartBitConfig.h
@@ -1,0 +1,107 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIEMCALTRIGGERPARTBITCONFIG_H
+#define ALIEMCALTRIGGERPARTBITCONFIG_H
+
+#include <exception>
+#include <sstream>
+#include <string>
+#include <TObject.h>
+
+namespace PWG {
+
+namespace EMCAL {
+
+namespace TriggerPart {
+
+class AliEmcalTriggerPartBitConfig : public TObject {
+public:
+	class InvalidConfigurationException : public std::exception{
+	public:
+		InvalidConfigurationException(std::string bitname):
+			fMessage("")
+		{
+			std::stringstream msgbuilder;
+			msgbuilder << "Invalid trigger configuration: " << bitname << " bit < 0";
+			fMessage = msgbuilder.str();
+		}
+		virtual ~InvalidConfigurationException() throw() {}
+
+		const char *what() const throw() {
+			return fMessage.c_str();
+		}
+
+	private:
+		std::string 				fMessage;
+	};
+
+	AliEmcalTriggerPartBitConfig();
+	AliEmcalTriggerPartBitConfig(int l0bit, int j1bit, int j2bit, int g1bit, int g2bit, int mcoffset);
+	virtual ~AliEmcalTriggerPartBitConfig() {}
+
+	void Initialise(const AliEmcalTriggerPartBitConfig &ref);
+
+	int GetLevel0Bit() const { if(fL0Bit < 0) throw InvalidConfigurationException("Level0"); return fL0Bit; }
+	int GetJetHighBit() const { if(fJHighBit < 0) throw InvalidConfigurationException("JetHigh"); return fJHighBit; }
+	int GetJetLowBit() const { if(fJLowBit < 0) throw InvalidConfigurationException("JetLow"); return fJLowBit; }
+	int GetGammaHighBit() const { if(fGHighBit < 0) throw InvalidConfigurationException("GammaHigh"); return fGHighBit; }
+	int GetGammaLowBit() const { if(fGLowBit < 0) throw InvalidConfigurationException("GammaLow"); return fGLowBit; }
+	int GetTriggerTypesEnd() const {if(fTriggerTypesEnd < 0) throw InvalidConfigurationException("MCOffset"); return fTriggerTypesEnd; }
+
+protected:
+	int fL0Bit;      			///< Level0 bit
+	int fJHighBit;   			///< Jet High bit
+	int fJLowBit;    			///< Jet Low bit
+	int fGHighBit;   			///< Gamma High bit
+	int fGLowBit;    			///< Gamma Low bit
+	int fTriggerTypesEnd;   	///< Monte-Carlo offset
+
+	ClassDef(AliEmcalTriggerPartBitConfig, 1);
+};
+
+class AliEmcalTriggerPartBitConfigOld : public AliEmcalTriggerPartBitConfig{
+public:
+	AliEmcalTriggerPartBitConfigOld();
+	virtual ~AliEmcalTriggerPartBitConfigOld() {}
+
+	ClassDef(AliEmcalTriggerPartBitConfigOld, 1);
+};
+
+class AliEmcalTriggerPartBitConfigNew : public AliEmcalTriggerPartBitConfig{
+public:
+	AliEmcalTriggerPartBitConfigNew();
+	virtual ~AliEmcalTriggerPartBitConfigNew() {}
+
+	ClassDef(AliEmcalTriggerPartBitConfigNew, 1);
+};
+
+}
+}
+}
+
+
+#endif /* ALIEMCALTRIGGERPARTBITCONFIG_H */

--- a/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartChannelMap.cxx
+++ b/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartChannelMap.cxx
@@ -1,0 +1,99 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <cstdlib>
+#include <cstring>
+
+#include "AliEmcalTriggerPartChannelMap.h"
+
+ClassImp(PWG::EMCAL::TriggerPart::AliEmcalTriggerPartChannelMap);
+
+using namespace PWG::EMCAL::TriggerPart;
+
+/**
+ * Constructor, initializing channel map with the dimensions needed
+ * @param ncols Number of columns
+ * @param nrows Number of rows
+ */
+AliEmcalTriggerPartChannelMap::AliEmcalTriggerPartChannelMap(int ncols, int nrows):
+    TObject(),
+    fNADCCols(ncols),
+    fNADCRows(nrows),
+    fADC(NULL)
+{
+  fADC = new double[fNADCCols * fNADCRows];
+  memset(fADC, 0, sizeof(double) * fNADCCols * fNADCRows);
+}
+
+/**
+ * Destructor
+ */
+AliEmcalTriggerPartChannelMap::~AliEmcalTriggerPartChannelMap() {
+  delete[] fADC;
+}
+
+/**
+ * Set ADC value for position (col, row). Checks for boundary.
+ * @param col Column of the position
+ * @param row Row of the position
+ * @param ADC The value to set
+ */
+void AliEmcalTriggerPartChannelMap::SetADC(int col, int row, double adc) {
+  if(row >= fNADCRows || col >= fNADCCols)
+	  throw BoundaryException(row, col, fNADCRows, fNADCCols);
+  fADC[GetIndexInArray(col, row)] = adc;
+}
+
+/**
+ * Add ADC value for position (col, row). Checks for boundary.
+ * @param col Column of the position
+ * @param row Row of the position
+ * @param ADC The value to set
+ */
+void AliEmcalTriggerPartChannelMap::AddADC(int col, int row, double adc) {
+  if(row >= fNADCRows || col >= fNADCCols)
+	  throw BoundaryException(row, col, fNADCRows, fNADCCols);
+  fADC[GetIndexInArray(col, row)] += adc;
+}
+
+/**
+ * Set the ADC values stored in the 2D map again to 0
+ */
+void AliEmcalTriggerPartChannelMap::Reset() {
+  memset(fADC, 0, sizeof(double) * fNADCCols * fNADCRows);
+}
+
+/**
+ * Get ADC value at position (col, row). Checks for boundary.
+ * @param col Column of the position
+ * @param row Row of the position
+ * @return ADC value at the given position
+ */
+double AliEmcalTriggerPartChannelMap::GetADC(int col, int row) const {
+  if(row >= fNADCRows || col >= fNADCCols)
+	  throw BoundaryException(row, col, fNADCRows, fNADCCols);
+  return fADC[GetIndexInArray(col, row)];
+}

--- a/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartChannelMap.h
+++ b/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartChannelMap.h
@@ -1,0 +1,120 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef AliEMCALTRIGGERPARTCHANNELMAP_H
+#define AliEMCALTRIGGERPARTCHANNELMAP_H
+
+#include <exception>
+#include <sstream>
+#include <string>
+#include <TObject.h>
+
+namespace PWG {
+
+namespace EMCAL {
+
+namespace TriggerPart {
+
+class AliEmcalTriggerPartChannelMap : public TObject {
+public:
+	class BoundaryException : public std::exception{
+	public:
+		BoundaryException():
+			exception(),
+			fMessage(""),
+			fRow(),
+			fCol(),
+			fNRow(),
+			fNCol()
+		{
+		}
+		BoundaryException(int row, int col, int nrow, int ncol):
+			exception(),
+			fMessage(""),
+			fRow(row),
+			fCol(col),
+			fNRow(nrow),
+			fNCol(ncol)
+		{
+			std::stringstream msgstream;
+			msgstream << "Boundary exception: row(" << fRow << ", max " << fNRow -1 << "), col(" << fCol << ", max " << fNCol -1 << ")";
+			fMessage = msgstream.str().c_str();
+		}
+		virtual ~BoundaryException() throw() {}
+
+		int GetRow() const throw() { return fRow; }
+		int GetCol() const throw() { return fCol; }
+		int GetNRow() const throw() { return fNRow; }
+		int GetNCol() const throw() { return fNCol; }
+
+		const char *what() const throw(){
+			return fMessage.c_str();
+		}
+	private:
+		std::string 			fMessage;			///< Error message
+		int						fRow;				///< Row of the position
+		int						fCol;				///< Col of the position
+		int						fNRow;				///< Number of rows in the channel map
+		int						fNCol;				///< Number of cols in the channel map
+	};
+
+	AliEmcalTriggerPartChannelMap(int cols, int rows);
+	virtual ~AliEmcalTriggerPartChannelMap();
+
+	void Reset();
+
+	void SetADC(int col, int row, double adc);
+	void AddADC(int col, int row, double adc);
+	double GetADC(int col, int row) const;
+	/**
+	 * Get the number of columns in the map
+	 * @return The number of colums
+	 */
+	int GetNumberOfCols() const { return fNADCCols; }
+	/**
+	 * Get the number of rows in the map
+	 * @return The number of cols
+	 */
+	int GetNumberOfRows() const { return fNADCRows; }
+
+protected:
+
+	inline int GetIndexInArray(int col, int row) const;
+	int                     fNADCCols;      ///< Number of columns
+	int                     fNADCRows;      ///< Number of rows
+	double                  *fADC;          ///< Array of Trigger ADC values
+
+	ClassDef(AliEmcalTriggerPartChannelMap, 1);
+};
+
+int AliEmcalTriggerPartChannelMap::GetIndexInArray(int col, int row) const {
+	return fNADCCols * row + col;
+}
+
+}
+}
+}
+#endif /* AliEMCALTRIGGERPARTCHANNELMAP_H */

--- a/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartGammaAlgorithm.cxx
+++ b/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartGammaAlgorithm.cxx
@@ -1,0 +1,88 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <algorithm>
+#include "AliEmcalTriggerPartGammaAlgorithm.h"
+#include "AliEmcalTriggerPartChannelMap.h"
+#include "AliEmcalTriggerPartSetup.h"
+
+ClassImp(PWG::EMCAL::TriggerPart::AliEmcalTriggerPartGammaAlgorithm);
+
+using namespace PWG::EMCAL::TriggerPart;
+
+/**
+ * Constructor
+ */
+AliEmcalTriggerPartGammaAlgorithm::AliEmcalTriggerPartGammaAlgorithm() :
+AliEmcalTriggerPartAlgorithm()
+{
+}
+
+/**
+ * Destructor
+ */
+AliEmcalTriggerPartGammaAlgorithm::~AliEmcalTriggerPartGammaAlgorithm() {
+}
+
+/**
+ * Gamma trigger algorithm
+ * 1. Loop over all rows (- patchsize) to get the starting position of the patch
+ * 2. Loop over ADC values in the 2x2 window
+ * 3. Sorting of the trigger patches so that the highest energetic patch (main patch is the first)
+ * 4. Fill the output trigger object
+ * @param channes Input channel map
+ * @return vector with trigger patches
+ */
+std::vector<AliEmcalTriggerPartRawPatch> AliEmcalTriggerPartGammaAlgorithm::FindPatches(const AliEmcalTriggerPartChannelMap *channels) const {
+	std::vector<AliEmcalTriggerPartRawPatch> rawpatches;
+
+	double adcsum(0);
+	for(unsigned char irow = 0; irow < channels->GetNumberOfRows() - 1; ++irow){
+		for(unsigned char icol = 0; icol < channels->GetNumberOfCols() - 1; ++icol){
+			// 2x2 window
+			adcsum = 0;
+			for(unsigned char jrow = 0; jrow < 2; jrow++)
+				for(unsigned char jcol = 0; jcol < 2; jcol++)
+					adcsum += channels->GetADC(icol + jcol, irow + jrow);
+
+			// make decision, low and high threshold
+			int triggerBits(0);
+			if(adcsum > fTriggerSetup->GetThresholdGammaHigh()) triggerBits |= 1 << fTriggerSetup->GetTriggerBitConfiguration().GetGammaHighBit();
+			if(adcsum > fTriggerSetup->GetThresholdGammaLow()) triggerBits |= 1 << fTriggerSetup->GetTriggerBitConfiguration().GetGammaLowBit();
+
+			// Set special bit
+			if(triggerBits){
+				AliEmcalTriggerPartRawPatch patch(icol, irow, adcsum, triggerBits);
+				patch.SetPatchSize(2);
+				rawpatches.push_back(patch);
+			}
+		}
+	}
+
+	// sort patches so that the main patch appears first
+	std::sort(rawpatches.begin(), rawpatches.end());
+	return rawpatches;
+}

--- a/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartGammaAlgorithm.h
+++ b/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartGammaAlgorithm.h
@@ -1,0 +1,64 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIEMCALTRIGGERPARTGAMMAALGORITHM_H
+#define ALIEMCALTRIGGERPARTGAMMAALGORITHM_H
+
+#include "AliEmcalTriggerPartAlgorithm.h"
+
+namespace PWG {
+
+namespace EMCAL {
+
+namespace TriggerPart {
+
+class AliEmcalTriggerPartPatchContainer;
+class AliEmcalTriggerPartChannelMap;
+
+/**
+ * @class AliEmcalTriggerPartGammaAlgorithm
+ * @brief Implementation of the EMCAL gamma trigger algorithm using ADC values
+ *
+ * This class implements the EMCAL Level1 algorithm finding gamma patches. The patch
+ * finding algorithm is described and implemented in the function FindPatches.
+ */
+class AliEmcalTriggerPartGammaAlgorithm : public AliEmcalTriggerPartAlgorithm {
+public:
+	AliEmcalTriggerPartGammaAlgorithm();
+	virtual ~AliEmcalTriggerPartGammaAlgorithm();
+
+	std::vector<PWG::EMCAL::TriggerPart::AliEmcalTriggerPartRawPatch> FindPatches(const AliEmcalTriggerPartChannelMap * channels) const;
+
+	ClassDef(AliEmcalTriggerPartGammaAlgorithm, 1);
+};
+
+}
+
+}
+
+}
+
+#endif /* ALIEMCALTRIGGERPARTGAMMAALGORITHM_H */

--- a/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartJetAlgorithm.cxx
+++ b/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartJetAlgorithm.cxx
@@ -1,0 +1,119 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <algorithm>
+#include "AliEmcalTriggerPartChannelMap.h"
+#include "AliEmcalTriggerPartJetAlgorithm.h"
+#include "AliEmcalTriggerPartSetup.h"
+
+ClassImp(PWG::EMCAL::TriggerPart::AliEmcalTriggerPartJetAlgorithm);
+
+using namespace PWG::EMCAL::TriggerPart;
+
+/**
+ * Constructor
+ */
+AliEmcalTriggerPartJetAlgorithm::AliEmcalTriggerPartJetAlgorithm():
+  AliEmcalTriggerPartAlgorithm()
+{
+}
+
+/**
+ * Destructor
+ */
+AliEmcalTriggerPartJetAlgorithm::~AliEmcalTriggerPartJetAlgorithm() {
+}
+
+/**
+ * Gamma trigger algorithm
+ * 1. Loop over all rows (- patchsize) to get the starting position of the patch
+ * 2. Loop over ADC values in the 16x16 window
+ * 3. Sorting of the trigger patches so that the highest energetic patch (main patch is the first)
+ * 4. Fill the output trigger object
+ * @param channes Input channel map
+ * @return vector with trigger patches
+ */
+std::vector<AliEmcalTriggerPartRawPatch> AliEmcalTriggerPartJetAlgorithm::FindPatches(const AliEmcalTriggerPartChannelMap *channels) const {
+	std::vector<AliEmcalTriggerPartRawPatch> rawpatches;
+
+	double adcsum(0);
+	for(unsigned char irow = 0; irow < channels->GetNumberOfRows() - 15; irow+=4){
+		for(unsigned char icol = 0; icol < channels->GetNumberOfCols() - 15; icol+=4){
+			// 16x16 window
+			adcsum = 0;
+			for(unsigned char jrow = 0; jrow < 16; jrow++)
+				for(unsigned char jcol = 0; jcol < 16; jcol++)
+					adcsum += channels->GetADC(icol + jcol, irow + jrow);
+
+			// make decision, low and high threshold
+			int triggerBits(0);
+			if(adcsum > fTriggerSetup->GetThresholdJetHigh()) triggerBits |= 1 << fTriggerSetup->GetTriggerBitConfiguration().GetJetHighBit();
+			if(adcsum > fTriggerSetup->GetThresholdJetLow()) triggerBits |= 1 << fTriggerSetup->GetTriggerBitConfiguration().GetJetLowBit();
+
+			// Set special bit
+			if(triggerBits){
+				AliEmcalTriggerPartRawPatch patch(icol, irow, adcsum, triggerBits);
+				patch.SetPatchSize(16);
+				rawpatches.push_back(patch);
+			}
+		}
+	}
+
+	// sort patches so that the main patch appears first
+	std::sort(rawpatches.begin(), rawpatches.end());
+	return rawpatches;
+}
+
+std::vector<AliEmcalTriggerPartRawPatch> AliEmcalTriggerPartJetAlgorithm::FindPatches8x8(const AliEmcalTriggerPartChannelMap *channels) const {
+	std::vector<AliEmcalTriggerPartRawPatch> rawpatches;
+
+	double adcsum(0);
+	for(unsigned char irow = 0; irow < channels->GetNumberOfRows() - 8-1; irow+=4){
+		for(unsigned char icol = 0; icol < channels->GetNumberOfCols() - 8-1; icol+=4){
+			// 8x8 window
+			adcsum = 0;
+			for(unsigned char jrow = 0; jrow < 8; jrow++)
+				for(unsigned char jcol = 0; jcol < 8; jcol++)
+					adcsum += channels->GetADC(icol + jcol, irow + jrow);
+
+			// make decision, low and high threshold
+			int triggerBits(0);
+			if(adcsum > fTriggerSetup->GetThresholdJetHigh()) triggerBits |= 1 << fTriggerSetup->GetTriggerBitConfiguration().GetJetHighBit();
+			if(adcsum > fTriggerSetup->GetThresholdJetLow()) triggerBits |= 1 << fTriggerSetup->GetTriggerBitConfiguration().GetJetLowBit();
+
+			// Set special bit
+			if(triggerBits){
+				AliEmcalTriggerPartRawPatch patch(icol, irow, adcsum, triggerBits);
+				patch.SetPatchSize(8);
+				rawpatches.push_back(patch);
+			}
+		}
+	}
+
+	// sort patches so that the main patch appears first
+	std::sort(rawpatches.begin(), rawpatches.end());
+	return rawpatches;
+}

--- a/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartJetAlgorithm.h
+++ b/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartJetAlgorithm.h
@@ -1,0 +1,55 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIEMCALTRIGGERPARTJETALGORITHM_H
+#define ALIEMCALTRIGGERPARTJETALGORITHM_H
+
+#include "AliEmcalTriggerPartAlgorithm.h"
+
+namespace PWG {
+
+namespace EMCAL {
+
+namespace TriggerPart {
+
+class AliEmcalTriggerPartPatchContainer;
+
+class AliEmcalTriggerPartJetAlgorithm: public AliEmcalTriggerPartAlgorithm {
+public:
+	AliEmcalTriggerPartJetAlgorithm();
+	virtual ~AliEmcalTriggerPartJetAlgorithm();
+
+	std::vector<PWG::EMCAL::TriggerPart::AliEmcalTriggerPartRawPatch> FindPatches(const AliEmcalTriggerPartChannelMap * channels) const;
+	std::vector<PWG::EMCAL::TriggerPart::AliEmcalTriggerPartRawPatch> FindPatches8x8(const AliEmcalTriggerPartChannelMap *channels) const;
+
+	ClassDef(AliEmcalTriggerPartJetAlgorithm, 1);
+};
+
+}
+}
+}
+
+#endif /* ALIEMCALTRIGGERPARTJETALGORITHM_H */

--- a/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartMapping.cxx
+++ b/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartMapping.cxx
@@ -1,0 +1,298 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <cstdlib>
+
+#include "AliEmcalTriggerPartMapping.h"
+
+ClassImp(PWG::EMCAL::TriggerPart::AliEmcalTriggerPartMapping);
+ClassImp(PWG::EMCAL::TriggerPart::AliEmcalTriggerPartChannel);
+
+using namespace PWG::EMCAL::TriggerPart;
+
+/**
+ * Constructor, setting EMCAL and DCAL+PHOS dimensions
+ *
+ * Phi Limits:
+ * EMCAL
+ * Sector 0: min(1.40413), max(1.73746), dist(0.333328)
+ * Sector 1: min(1.7532),  max(2.08653), dist(0.333328)
+ * Sector 2: min(2.10226), max(2.43559), dist(0.333328)
+ * Sector 3: min(2.45133), max(2.78466), dist(0.333328)
+ * Sector 4: min(2.8004),  max(3.13372), dist(0.333328)
+ * Sector 5: min(3.14946), max(3.26149), dist(0.112032)
+ *
+ * DCAL + PHOS
+ * Sector 0: min(4.54573), max(4.87905), dist(0.333328)
+ * Sector 1: min(4.89479), max(5.22812), dist(0.333328)
+ * Sector 2: min(5.24386), max(5.57718), dist(0.333328)
+ * Sector 3: min(5.59292), max(5.70495), dist(0.112032)
+ */
+AliEmcalTriggerPartMapping::AliEmcalTriggerPartMapping():
+	TObject(),
+	fPhiLimitsEMCAL(),
+	fPhiLimitsDCALPHOS(),
+	fEtaMin(-0.668305),
+	fEtaMax(0.668305),
+	fEtaSizeFOR()
+{
+	fEtaSizeFOR = (fEtaMax - fEtaMin) / 48;
+	fPhiLimitsEMCAL.push_back(SectorPhi(0, 1.40413, 1.73746, 12));
+	fPhiLimitsEMCAL.push_back(SectorPhi(1, 1.7532, 2.08653, 12));
+	fPhiLimitsEMCAL.push_back(SectorPhi(2, 2.10226, 2.43559, 12));
+	fPhiLimitsEMCAL.push_back(SectorPhi(3, 2.45133, 2.78466, 12));
+	fPhiLimitsEMCAL.push_back(SectorPhi(4, 2.8004, 3.13372, 12));
+	fPhiLimitsEMCAL.push_back(SectorPhi(5, 3.14946, 3.26149, 4));
+
+	fPhiLimitsDCALPHOS.push_back(SectorPhi(0, 4.54573, 4.87905, 12));
+	fPhiLimitsDCALPHOS.push_back(SectorPhi(1, 4.89479, 5.22812, 12));
+	fPhiLimitsDCALPHOS.push_back(SectorPhi(2, 5.24386, 5.57718, 12));
+	fPhiLimitsDCALPHOS.push_back(SectorPhi(3, 5.59292, 5.70495, 4));
+}
+
+/**
+ * Destructor, nothing to do
+ */
+AliEmcalTriggerPartMapping::~AliEmcalTriggerPartMapping() {
+}
+
+/**
+ * Map the position of the trigger channel. Always returns a trigger channel postition (also if outside the EMCAL
+ * or DCAL+PHOS acceptance), which can however be undefined. In case of accessing row or col of an undefined trigger
+ * position an exception is thrown.
+ * @param eta Eta of the particle
+ * @param phi Phi of the particle
+ * @return The trigger channel corresponding to the Eta-Phi position of the particle.
+ */
+AliEmcalTriggerPartChannel AliEmcalTriggerPartMapping::GetPositionFromEtaPhi(double eta, double phi) const{
+	if(IsEMCAL(eta, phi)){
+		return GetPositionFromEtaPhiEMCAL(eta, phi);
+	} else if(IsDCALPHOS(eta, phi)){
+		return GetPositionFromEtaPhiDCALPHOS(eta, phi);
+	}
+	return AliEmcalTriggerPartChannel();
+}
+
+/**
+ * Check whether particle is in the EMCAL trigger active area
+ * @param eta Particle Eta
+ * @param phi Particle Phi
+ * @return True if the particle is in the active area of the EMCAL trigger, false otherwise
+ */
+bool AliEmcalTriggerPartMapping::IsEMCAL(double eta, double phi) const{
+	if(eta < fEtaMin || eta > fEtaMax) return false;
+	bool hasfound(false);
+	for(std::vector<SectorPhi>::const_iterator phiit = fPhiLimitsEMCAL.begin(); phiit != fPhiLimitsEMCAL.end(); ++phiit){
+		if(phiit->IsInSector(phi)){
+			hasfound = true;
+			break;
+		}
+	}
+	return hasfound;
+}
+
+/**
+ * Check whether particle is in the DCAL+PHOS trigger active area
+ * @param eta Particle Eta
+ * @param phi Particle Phi
+ * @return True if the particle is in the active area of the EMCAL trigger, false otherwise
+ */
+bool AliEmcalTriggerPartMapping::IsDCALPHOS(double eta, double phi) const{
+	if(eta < fEtaMin || eta > fEtaMax) return false;
+	bool hasfound(false);
+	for(std::vector<SectorPhi>::const_iterator phiit = fPhiLimitsDCALPHOS.begin(); phiit != fPhiLimitsDCALPHOS.end(); ++phiit){
+		if(phiit->IsInSector(phi)){
+			hasfound = true;
+			break;
+		}
+	}
+	return hasfound;
+}
+
+/**
+ * Map eta and phi to trigger position in EMCAL. Mapping is done in the following way:
+ * - linear model between min and max phi using a constant size in phi of the FastOR
+ * @param eta Particle Eta
+ * @param phi Particle Phi
+ * @return Trigger position in the EMCAL
+ */
+AliEmcalTriggerPartChannel AliEmcalTriggerPartMapping::GetPositionFromEtaPhiEMCAL(double eta, double phi) const{
+	AliEmcalTriggerPartChannel result;
+	int row(-1), col(-1);
+	// first get the row
+	const SectorPhi *emcsec = FindSectorEMCAL(phi);
+	if(!emcsec) 		// dead area
+		return result;
+	if(emcsec->GetSectorID() == 0){
+		row = emcsec->GetRowNumberInSector(phi);
+	} else {
+		int rowsec = emcsec->GetRowNumberInSector(phi);
+		row = 0;
+		for(int isec = 0; isec < 6; isec++){
+			if(isec < emcsec->GetSectorID()) row += fPhiLimitsEMCAL[isec].GetNumberOfRows();
+			else break;
+		}
+		row += rowsec;
+	}
+	// then get the column
+	// assume linear model, mapping from positive to negative eta as obtained from fastor + cell mapping from AliEMCALGeometry
+	for(int coliter = 0; coliter < 48; coliter++){
+		if(eta > fEtaMax - (coliter+1) * fEtaSizeFOR && eta < fEtaMax - coliter * fEtaSizeFOR){
+			col = coliter;
+			break;
+		}
+	}
+
+	if(col >= 0)
+		result.Set(row, col, AliEmcalTriggerPartChannel::kEMCAL);
+	return result;
+}
+
+/**
+ * Map eta and phi to trigger position in EMCAL. Mapping is done in the following way:
+ * - linear model between min and max phi using a constant size in phi of the FastOR
+ * @param eta Particle Eta
+ * @param phi Particle Phi
+ * @return Trigger position in the EMCAL
+ */
+AliEmcalTriggerPartChannel AliEmcalTriggerPartMapping::GetPositionFromEtaPhiDCALPHOS(double eta, double phi) const{
+	AliEmcalTriggerPartChannel result;
+	int row(-1), col(-1);
+	// first get the row
+	// first get the row
+	const SectorPhi *emcsec = FindSectorDCALPHOS(phi);
+	if(!emcsec) 		// dead area
+		return result;
+	if(emcsec->GetSectorID() == 0){
+		row = emcsec->GetRowNumberInSector(phi);
+	} else {
+		int rowsec = emcsec->GetRowNumberInSector(phi);
+		row = 0;
+		for(int isec = 0; isec < 4; isec++){
+			if(isec < emcsec->GetSectorID()) row += fPhiLimitsDCALPHOS[isec].GetNumberOfRows();
+			else break;
+		}
+		row += rowsec;
+	}
+	// then get the column
+	// assume linear model, mapping from positive to negative eta as obtained from fastor + cell mapping from AliEMCALGeometry
+	for(int coliter = 0; coliter < 48; coliter++){
+		if(eta > fEtaMax - (coliter+1) * fEtaSizeFOR && eta < fEtaMax - coliter * fEtaSizeFOR){
+			col = coliter;
+			break;
+		}
+	}
+
+	if(col >= 0)
+		result.Set(row, col, AliEmcalTriggerPartChannel::kDCALPHOS);
+	return result;
+}
+
+/**
+ * Find the sector according to the given phi angle, either in the EMCAL or in the DCAL/PHOS
+ * @param phi Phi of the track/particle
+ * @param isEMCAL Switch whether to test EMCAL or DCAL/PHOS
+ * @return Full sector information (NULL if not found)
+ */
+const AliEmcalTriggerPartMapping::SectorPhi *AliEmcalTriggerPartMapping::FindSector(double phi, bool isEMCAL) const {
+	if(isEMCAL) return FindSectorEMCAL(phi);
+	else return FindSectorDCALPHOS(phi);
+}
+
+/**
+ * Find the sector in the EMCAL for a given phi of the particle/track
+ * @param phi Particle/Track phi
+ * @return Sector information according to the phi (NULL if not found)
+ */
+const AliEmcalTriggerPartMapping::SectorPhi *AliEmcalTriggerPartMapping::FindSectorEMCAL(double phi) const {
+	const SectorPhi *result = NULL;
+	for(std::vector<SectorPhi>::const_iterator secit = fPhiLimitsEMCAL.begin(); secit != fPhiLimitsEMCAL.end(); ++secit){
+		if(secit->IsInSector(phi)){
+			result = &(*secit);
+			break;
+		}
+	}
+	return result;
+}
+
+/**
+ * Find the sector in the DCAL/PHOS for a given phi of the particle/track
+ * @param phi Particle/Track phi
+ * @return Sector information according to the phi (NULL if not found)
+ */
+const AliEmcalTriggerPartMapping::SectorPhi *AliEmcalTriggerPartMapping::FindSectorDCALPHOS(double phi) const {
+	const SectorPhi *result = NULL;
+	for(std::vector<SectorPhi>::const_iterator secit = fPhiLimitsDCALPHOS.begin(); secit != fPhiLimitsDCALPHOS.end(); ++secit){
+		if(secit->IsInSector(phi)){
+			result = &(*secit);
+			break;
+		}
+	}
+	return result;
+}
+
+/**
+ * Dummy constructor for ROOT I/O
+ */
+AliEmcalTriggerPartMapping::SectorPhi::SectorPhi():
+	fSectorID(-1),
+	fMinimum(-100),
+	fMaximum(-100),
+	fNRows(-1)
+{}
+
+/**
+ * Initialize the Sector with mandatory information to map the position into a row number
+ * @param sectorID ID of the sector, starting from 0
+ * @param phiMin Min. phi of the sector
+ * @param phiMax Max. phi of the sector
+ * @param nrow Number of rows in the sector
+ */
+AliEmcalTriggerPartMapping::SectorPhi::SectorPhi(int sectorID, double phiMin, double phiMax, int nrow):
+	fSectorID(sectorID),
+	fMinimum(phiMin),
+	fMaximum(phiMax),
+	fNRows(nrow)
+{}
+
+/**
+ * Calculate row number in sector from the phi of the particle / track
+ * @param phi
+ * @return Row number of the FastOR within the chamber (-1 if not found)
+ */
+int AliEmcalTriggerPartMapping::SectorPhi::GetRowNumberInSector(double phi) const {
+	int rownumber = -1;
+	double phiwidth = (fMaximum - fMinimum) / fNRows;
+	int rowcounter = 0;
+	for(double phiiter = fMinimum; phiiter < fMaximum; phiiter += phiwidth){
+		if(phi > phiiter && phi < phiiter + phiwidth){
+			rownumber = rowcounter;
+			break;
+		}
+		rowcounter++;
+	}
+	return rownumber;
+}

--- a/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartMapping.h
+++ b/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartMapping.h
@@ -1,0 +1,134 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIEMCALTRIGGERPARTMAPPING_H
+#define ALIEMCALTRIGGERPARTMAPPING_H
+
+#include <exception>
+#include <vector>
+#include <TObject.h>
+
+namespace PWG {
+
+namespace EMCAL {
+
+namespace TriggerPart {
+
+class AliEmcalTriggerPartChannel : public TObject {
+public:
+	enum Detector{
+		kEMCAL,
+		kDCALPHOS,
+		kUndefined,
+	};
+	class TriggerChannelException : public std::exception{
+	public:
+		TriggerChannelException() {}
+		virtual ~TriggerChannelException() throw() {}
+		const char *what() const throw() {
+			return "Trigger channel not existing";
+		}
+	};
+
+	AliEmcalTriggerPartChannel():
+		TObject(),
+		fDetector(kUndefined),
+		fRow(0),
+		fCol(0)
+	{}
+	virtual ~AliEmcalTriggerPartChannel() {}
+
+	void Set(int row, int col, Detector det){
+		fRow = row;
+		fCol = col;
+		fDetector = det;
+	}
+
+	int GetRow() const { if(fDetector == kUndefined) throw TriggerChannelException(); return fRow; }
+	int GetCol() const { if(fDetector == kUndefined) throw TriggerChannelException(); return fCol; }
+
+	bool IsEMCAL() const { if(fDetector == kEMCAL) return true; return false; }
+	bool IsDCALPHOS() const { if(fDetector == kDCALPHOS) return true; return false; }
+
+private:
+	Detector		fDetector;
+	int 			fRow;
+	int 			fCol;
+
+	ClassDef(AliEmcalTriggerPartChannel, 1);
+};
+
+class AliEmcalTriggerPartMapping : public TObject {
+public:
+	AliEmcalTriggerPartMapping();
+	virtual ~AliEmcalTriggerPartMapping();
+
+	AliEmcalTriggerPartChannel GetPositionFromEtaPhi(double eta, double phi) const;
+	bool IsEMCAL(double eta, double phi) const;
+	bool IsDCALPHOS(double eta, double phi) const;
+
+	class SectorPhi{
+	public:
+		SectorPhi();
+		SectorPhi(int sectorID, double phiMin, double phiMax, int nrow);
+		~SectorPhi() {}
+
+		int	 		GetSectorID() const { return fSectorID; }
+		int	 		GetNumberOfRows() const { return fNRows; }
+		double	 	GetPhiMin() const { return fMinimum; }
+		double 		GetPhiMax() const { return fMaximum; }
+
+		bool IsInSector(double phi)  const { return phi > fMinimum && phi < fMaximum; }
+		int GetRowNumberInSector(double phi) const;
+
+	private:
+		int 			fSectorID;			///< ID of the sector, starting from 0 (Indices separate for EMCAL and DCAL)
+		double 			fMinimum;			///< Min. phi of the sector (0 - 2 pi)
+		double			fMaximum;			///< Max. phi of the sector (0 - 2 pi)
+		int 			fNRows;  			///< Number of rows in a sector in phi (12 for big supermodules, 4 for small)
+	};
+
+protected:
+	const SectorPhi *FindSector(double phi, bool isEMCAL) const;
+	const SectorPhi *FindSectorEMCAL(double phi) const;
+	const SectorPhi *FindSectorDCALPHOS(double phi) const;
+	AliEmcalTriggerPartChannel GetPositionFromEtaPhiEMCAL(double eta, double phi) const;
+	AliEmcalTriggerPartChannel GetPositionFromEtaPhiDCALPHOS(double eta, double phi) const;
+
+	std::vector<SectorPhi>		fPhiLimitsEMCAL;
+	std::vector<SectorPhi> 		fPhiLimitsDCALPHOS;
+	double						fEtaMin;
+	double						fEtaMax;
+	double						fEtaSizeFOR;
+
+	ClassDef(AliEmcalTriggerPartMapping, 1);
+};
+
+}
+}
+}
+
+#endif /* ALIEMCALTRIGGERPARTMAPPING_H_*/

--- a/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartSetup.cxx
+++ b/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartSetup.cxx
@@ -1,0 +1,77 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include "AliEmcalTriggerPartSetup.h"
+
+ClassImp(PWG::EMCAL::TriggerPart::AliEmcalTriggerPartSetup);
+
+using namespace PWG::EMCAL::TriggerPart;
+
+/**
+ * Default constructor
+ */
+AliEmcalTriggerPartSetup::AliEmcalTriggerPartSetup() :
+  TObject(),
+  fThresholds(),
+  fTriggerBitConfig()
+{
+  for( int i = 0; i < 4; i++) fThresholds[i] = -1;
+}
+
+/**
+ * Copy constructor
+ * \param p Reference for the copy
+ */
+AliEmcalTriggerPartSetup::AliEmcalTriggerPartSetup(const AliEmcalTriggerPartSetup &p) :
+  fTriggerBitConfig()
+{
+  // Copy constructor.
+  for( int i = 0; i < 4; i++ ) fThresholds[i] = p.fThresholds[i];
+  fTriggerBitConfig.Initialise(p.fTriggerBitConfig);
+}
+
+/**
+ * Assignment operator
+ * @param p Reference for the assignment
+ * @return This object
+ */
+AliEmcalTriggerPartSetup &AliEmcalTriggerPartSetup::operator=(const AliEmcalTriggerPartSetup &p){
+  if (this != &p) {
+    for( int i = 0; i < 4; i++ )
+      fThresholds[i] = p.fThresholds[i];
+    fTriggerBitConfig.Initialise(p.fTriggerBitConfig);
+  }
+
+  return *this;
+}
+
+/**
+ * Cleaning function, resets all arrays to 0
+ */
+void AliEmcalTriggerPartSetup::Clean(){
+  for( int i = 0; i < 4; i++ )
+    fThresholds[i] = -1;
+}

--- a/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartSetup.h
+++ b/PWG/EMCAL/EMCALtriggerPart/AliEmcalTriggerPartSetup.h
@@ -1,0 +1,79 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIEMCALTRIGGERPARTSETUP_H
+#define ALIEMCALTRIGGERPARTSETUP_H
+
+#include <TObject.h>
+#include "AliEmcalTriggerPartBitConfig.h"
+
+namespace PWG {
+
+namespace EMCAL {
+
+namespace TriggerPart {
+
+/**
+ * @class AliEmcalTriggerPartSetup
+ */
+class AliEmcalTriggerPartSetup : public TObject {
+public:
+	AliEmcalTriggerPartSetup();
+	AliEmcalTriggerPartSetup(const AliEmcalTriggerPartSetup &p);
+	AliEmcalTriggerPartSetup &operator=(const AliEmcalTriggerPartSetup &p);
+	/**
+	 * Destructor
+	 */
+	virtual ~AliEmcalTriggerPartSetup() {}
+
+	double GetThresholdJetLow() const { return fThresholds[2]; }
+	double GetThresholdJetHigh() const { return fThresholds[0]; }
+
+	double GetThresholdGammaLow() const { return fThresholds[3]; }
+	double GetThresholdGammaHigh() const { return fThresholds[1]; }
+
+	const AliEmcalTriggerPartBitConfig &GetTriggerBitConfiguration() const { return fTriggerBitConfig; }
+
+	void SetThresholds( double i0, double i1, double i2, double i3 ) {
+		fThresholds[0] = i0; fThresholds[1] = i1; fThresholds[2] = i2; fThresholds[3] = i3;}
+	void SetTriggerBitConfig(const AliEmcalTriggerPartBitConfig &ref){
+		fTriggerBitConfig.Initialise(ref);
+	}
+
+	void Clean();
+
+protected:
+	double                                  fThresholds[4];                 ///< per event L1 online thresholds in ADC counts
+	AliEmcalTriggerPartBitConfig         		fTriggerBitConfig;              ///< Trigger bit configuration
+
+	ClassDef(AliEmcalTriggerPartSetup, 1);
+};
+
+}
+}
+}
+
+#endif

--- a/PWG/EMCAL/EMCALtriggerPart/CMakeLists.txt
+++ b/PWG/EMCAL/EMCALtriggerPart/CMakeLists.txt
@@ -1,0 +1,69 @@
+# **************************************************************************
+# * Copyright(c) 1998-2014, ALICE Experiment at CERN, All rights reserved. *
+# *                                                                        *
+# * Author: The ALICE Off-line Project.                                    *
+# * Contributors are mentioned in the code where appropriate.              *
+# *                                                                        *
+# * Permission to use, copy, modify and distribute this software and its   *
+# * documentation strictly for non-commercial purposes is hereby granted   *
+# * without fee, provided that the above copyright notice appears in all   *
+# * copies and that both the copyright notice and this permission notice   *
+# * appear in the supporting documentation. The authors make no claims     *
+# * about the suitability of this software for any purpose. It is          *
+# * provided "as is" without express or implied warranty.                  *
+# **************************************************************************/
+#Module
+set(MODULE PWGEMCALtriggerPart)
+add_definitions(-D_MODULE_="${MODULE}")
+
+# Module include folder
+include_directories(${AliPhysics_SOURCE_DIR}/PWG/EMCAL/EMCALtriggerPart)
+
+# Sources - alphabetical order
+set(SRCS
+  AliEmcalTriggerMakerPart.cxx
+  AliEmcalTriggerPartAlgorithm.cxx
+  AliEmcalTriggerPartGammaAlgorithm.cxx
+  AliEmcalTriggerPartJetAlgorithm.cxx
+  AliEmcalTriggerPartBadChannelContainer.cxx
+  AliEmcalTriggerPartBitConfig.cxx
+  AliEmcalTriggerPartChannelMap.cxx
+  AliEmcalTriggerPartSetup.cxx
+  AliEmcalTriggerPartMapping.cxx
+  )
+
+# Headers from sources
+string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
+
+# Generate the dictionary
+# It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
+get_directory_property(incdirs INCLUDE_DIRECTORIES)
+generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+
+# Add a shared library
+add_library_tested(${MODULE} SHARED  ${SRCS} ${HDRS} ${MODULE}LinkDef.h G__${MODULE}.cxx)
+
+# Generate the ROOT map
+# Dependecies
+set(LIBDEPS )
+generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
+
+# Generate a PARfile target for this library
+add_target_parfile(${MODULE} "${SRCS}" "${HDRS}" "${MODULE}LinkDef.h" "${LIBDEPS}")
+
+# Linking the library
+target_link_libraries(${MODULE} ${LIBDEPS})
+
+# Public include folders that will be propagated to the dependecies
+target_include_directories(${MODULE} PUBLIC ${incdirs})
+
+# System dependent: Modify the way the library is build
+if(${CMAKE_SYSTEM} MATCHES Darwin)
+    set_target_properties(${MODULE} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+endif(${CMAKE_SYSTEM} MATCHES Darwin)
+
+# Installation
+install(TARGETS ${MODULE} 
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib)
+install(FILES ${HDRS} DESTINATION include)

--- a/PWG/EMCAL/EMCALtriggerPart/PWGEMCALtriggerPartLinkDef.h
+++ b/PWG/EMCAL/EMCALtriggerPart/PWGEMCALtriggerPartLinkDef.h
@@ -1,0 +1,24 @@
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+
+#pragma link C++ namespace PWG;
+#pragma link C++ namespace PWG::EMCAL;
+#pragma link C++ namespace PWG::EMCAL::TriggerPart;
+#pragma link C++ class PWG::EMCAL::TriggerPart::AliEmcalTriggerMakerPart+;
+#pragma link C++ class PWG::EMCAL::TriggerPart::AliEmcalTriggerPartRawPatch+;
+#pragma link C++ class PWG::EMCAL::TriggerPart::AliEmcalTriggerPartAlgorithm+;
+#pragma link C++ class PWG::EMCAL::TriggerPart::AliEmcalTriggerPartGammaAlgorithm+;
+#pragma link C++ class PWG::EMCAL::TriggerPart::AliEmcalTriggerPartJetAlgorithm+;
+#pragma link C++ class PWG::EMCAL::TriggerPart::AliEmcalTriggerPartBadChannelContainer+;
+#pragma link C++ class PWG::EMCAL::TriggerPart::AliEmcalTriggerPartBitConfig+;
+#pragma link C++ class PWG::EMCAL::TriggerPart::AliEmcalTriggerPartBitConfigOld+;
+#pragma link C++ class PWG::EMCAL::TriggerPart::AliEmcalTriggerPartBitConfigNew+;
+#pragma link C++ class PWG::EMCAL::TriggerPart::AliEmcalTriggerPartChannelMap+;
+#pragma link C++ class PWG::EMCAL::TriggerPart::AliEmcalTriggerPartChannel+;
+#pragma link C++ class PWG::EMCAL::TriggerPart::AliEmcalTriggerPartMapping+;
+#pragma link C++ class PWG::EMCAL::TriggerPart::AliEmcalTriggerPartSetup+;
+#endif


### PR DESCRIPTION
Incoporate fast trigger maker from
https://github.com/mfasDa/EmcalTriggerFast, for trigger
studies at particle level. In order to run on the grid the
stand alone c++ program must be part of AliPhysics and
classes must inherit from TObject as most of the
configurations will probably happen in the asynchronous
stage.