### PR TITLE
PWGCF: PionPionAnalysis - Correct check for string "emptiness"

### DIFF
--- a/PWGCF/FEMTOSCOPY/macros/Train/PionPionFemto/AddTaskPionPion.C
+++ b/PWGCF/FEMTOSCOPY/macros/Train/PionPionFemto/AddTaskPionPion.C
@@ -97,7 +97,7 @@ AliAnalysisTaskFemto* AddTaskPionPion(TString configuration,
   macro.ReplaceAll("%%", AUTO_DIRECTORY);
 
   // Dealing with subwagons
-  if (subwagon_suffix) {
+  if (!subwagon_suffix.IsWhitespace()) {
     subwagon_type.ToLower();
 
     if (subwagon_type == "centrality") {


### PR DESCRIPTION
instead of implicitly casting to bool, this uses the IsWhitespace to check if there is content in a parameter