### PR TITLE
A small bugfix for the task macro.

### DIFF
--- a/PWGCF/Correlations/macros/jcorran/AddTaskJCDijetTask.C
+++ b/PWGCF/Correlations/macros/jcorran/AddTaskJCDijetTask.C
@@ -30,7 +30,7 @@ AliAnalysisTask *AddTaskJCDijetTask(TString taskName,
     double binBorder;
     vector<double> vecCentBins;
     ss >> binBorder;
-    while (ss.good()) {
+    while (!ss.fail()) {
         vecCentBins.push_back(binBorder);
         ss >> binBorder;
     }


### PR DESCRIPTION
The goodbit for stringstream is not true for the last instance of the
list so instead !fail has to be used.