### PR TITLE
Fixing memory leaks in QA scripts

### DIFF
--- a/PWGJE/EMCALJetTasks/macros/JetQA/plotPowerpoint.py
+++ b/PWGJE/EMCALJetTasks/macros/JetQA/plotPowerpoint.py
@@ -143,6 +143,8 @@ def plotPowerpoint(runList, plotDir):
       totalRuns=totalRuns+1
       p = tf.add_paragraph()
       p.text = str(run)+" with "+str(nEvents)+" Evts "
+      qaList.Delete()
+      f.Close()
     else:
       print("!!!!!!! Root file for run %s is empty - please check download" % str(run))
   p = tf.add_paragraph()


### PR DESCRIPTION
Added a destructor for the QA histogram list object and closed the QA AnalysisResults file to save memory on large datasets.

@efranzis @jdmulligan 