### PR TITLE
PWGGA/GammaConv: Upload of new AnalysisTask for heavy neutral mesons with three particle decay

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.cxx
@@ -1,0 +1,3709 @@
+/**************************************************************************
+ * Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: Friederike Bock 									              *
+ * Version 1                                                              *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+//
+
+#include <vector>
+#include "TParticle.h"
+#include "TPDGCode.h"
+#include "TMCProcess.h"
+#include "TDatabasePDG.h"
+#include "TList.h"
+#include "TChain.h"
+#include "TDirectory.h"
+#include "TTree.h"
+#include "TH1.h"
+#include "TH1F.h"
+#include "THnSparse.h"
+#include "TH2F.h"
+#include "AliAnalysisManager.h"
+#include "AliESDInputHandler.h"
+#include "AliESDtrack.h"
+#include "AliMCEvent.h"
+#include "AliMCEventHandler.h"
+#include "AliPID.h"
+#include "AliLog.h"
+#include "AliESDtrackCuts.h"
+#include "AliESDpidCuts.h"
+#include "AliMCEvent.h"
+#include "AliESDv0.h"
+#include "AliESDEvent.h"
+#include "AliESDpid.h"
+#include "AliKFParticle.h"
+#include "AliMCEventHandler.h"
+#include "AliKFVertex.h"
+#include "AliTriggerAnalysis.h"
+#include "AliCentrality.h"
+#include "AliMultiplicity.h"
+#include "AliAODEvent.h"
+#include "AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.h"
+#include "AliCaloTrackMatcher.h"
+#include <vector>
+
+ClassImp( AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson )
+
+//-----------------------------------------------------------------------------------------------
+AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson():
+  fV0Reader(NULL),
+  fV0ReaderName("V0ReaderV1"),
+  fPionSelector(NULL),
+  fBGHandlerPiPl(NULL),
+  fBGHandlerPiMi(NULL),
+  fESDEvent(NULL),
+  fMCEvent(NULL),
+  fCutFolder(NULL),
+  fESDList(NULL),
+  fTrueList(NULL),
+  fTrueTreeList(NULL),
+  fMCList(NULL),
+  fOutputContainer(0),
+  fReaderGammas(NULL),
+  fSelectorNegPionIndex(0),
+  fSelectorPosPionIndex(0),
+  fGoodConvGammas(NULL),
+  fClusterCandidates(NULL),
+  fNeutralDecayParticleCandidates(NULL),
+  fNeutralDecayParticleSidebandCandidates(NULL),
+  fPosPionCandidates(NULL),
+  fNegPionCandidates(NULL),
+  fGoodVirtualParticles(NULL),
+  fEventCutArray(NULL),
+  fGammaCutArray(NULL),
+  fClusterCutArray(NULL),
+  fPionCutArray(NULL),
+  fNeutralDecayMesonCutArray(NULL),
+  fMesonCutArray(NULL),
+  fEventCuts(NULL),
+  fConversionCuts(NULL),
+  fClusterCuts(NULL),
+  fTreePiPiSameMother(NULL),
+  fTreePiPiPiSameMother(NULL),
+  fTreeEventInfoHNM(NULL),
+  fCasePiPi(-1),
+  fSamePiPiMotherID(-1),
+  fSamePiPiMotherInvMass(-1),
+  fSamePiPiMotherPt(-1),
+  fSamePiPiPiMotherID(-1),
+  fSamePiPiPiMotherInvMass(-1),
+  fSamePiPiPiMotherPt(-1),
+  fV0MultiplicityHNMEvent(-1),
+  fTrackMultiplicityHNMEvent(-1),
+  fZVertexHNMEvent(-1),
+  fPtHNM(-1),
+  fPDGMassNDM(-1),
+  fPDGCodeNDM(-1),
+  fPDGCodeAnalyzedMeson(-1),
+  fHistoConvGammaPt(NULL),
+  fHistoConvGammaEta(NULL),
+  fHistoClusterGammaPt(NULL),
+  fHistoClusterGammaEta(NULL),
+  fHistoNegPionPt(NULL),
+  fHistoPosPionPt(NULL),
+  fHistoNegPionPhi(NULL),
+  fHistoPosPionPhi(NULL),
+  fHistoNegPionEta(NULL),
+  fHistoPosPionEta(NULL),
+  fHistoNegPionClsTPC(NULL),
+  fHistoPosPionClsTPC(NULL),
+  fHistoPionDCAxy(NULL),
+  fHistoPionDCAz(NULL),
+  fHistoPionTPCdEdxNSigma(NULL),
+  fHistoPionTPCdEdx(NULL),
+  fHistoPionPionInvMassPt(NULL),
+  fHistoGammaGammaInvMassPt(NULL),
+  fHistoMotherInvMassPt(NULL),
+  fHistoMotherInvMassPtRejectedKinematic(NULL),
+  fHistoBackInvMassPtGroup1(NULL),
+  fHistoBackInvMassPtGroup2(NULL),
+  fHistoBackInvMassPtGroup3(NULL),
+  fHistoBackInvMassPtGroup4(NULL),
+  fHistoMotherLikeSignBackInvMassPt(NULL),
+  fHistoAngleHNMesonPiPlPiMi(NULL),
+  fHistoAngleHNMesonNDM(NULL),
+  fHistoAngleHNMesonPiPl(NULL),
+  fHistoAngleHNMesonPiMi(NULL),
+  fHistoAnglePiPlPiMi(NULL),
+  fHistoAngleNDMPiMi(NULL),
+  fHistoAnglePiPlNDM(NULL),
+  fHistoAngleSum(NULL),
+  fHistoTrueAngleSum(NULL),
+  fHistoMotherInvMassSubNDM(NULL),
+  fHistoBackInvMassPtGroup1SubNDM(NULL),
+  fHistoBackInvMassPtGroup2SubNDM(NULL),
+  fHistoBackInvMassPtGroup3SubNDM(NULL),
+  fHistoBackInvMassPtGroup4SubNDM(NULL),
+  fHistoMotherLikeSignBackInvMassSubNDMPt(NULL),
+  fHistoMotherInvMassFixedPzNDM(NULL),
+  fHistoBackInvMassPtGroup1FixedPzNDM(NULL),
+  fHistoBackInvMassPtGroup2FixedPzNDM(NULL),
+  fHistoBackInvMassPtGroup3FixedPzNDM(NULL),
+  fHistoBackInvMassPtGroup4FixedPzNDM(NULL),
+  fHistoMotherLikeSignBackInvMassFixedPzNDMPt(NULL),
+  fHistoMCAllGammaPt(NULL),
+  fHistoMCConvGammaPt(NULL),
+  fHistoMCAllPosPionsPt(NULL),
+  fHistoMCAllNegPionsPt(NULL),
+  fHistoMCGammaFromNeutralMesonPt(NULL),
+  fHistoMCPosPionsFromNeutralMesonPt(NULL),
+  fHistoMCNegPionsFromNeutralMesonPt(NULL),
+  fHistoMCHNMPiPlPiMiNDMPt(NULL),
+  fHistoMCHNMPiPlPiMiNDMInAccPt(NULL),
+  fHistoTrueMotherPiPlPiMiNDMInvMassPt(NULL),
+  fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt(NULL),
+  fHistoTrueMotherGammaGammaInvMassPt(NULL),
+  fHistoTrueMotherGammaGammaFromHNMInvMassPt(NULL),
+  fHistoTrueConvGammaPt(NULL),
+  fHistoTrueConvGammaFromNeutralMesonPt(NULL),
+  fHistoTrueClusterGammaPt(NULL),
+  fHistoTrueClusterGammaFromNeutralMesonPt(NULL),
+  fHistoTruePosPionPt(NULL),
+  fHistoTruePosPionFromNeutralMesonPt(NULL),
+  fHistoTrueNegPionPt(NULL),
+  fHistoTrueNegPionFromNeutralMesonPt(NULL),
+  fHistoTruePionPionInvMassPt(NULL),
+  fHistoTruePionPionFromSameMotherInvMassPt(NULL),
+  fHistoTruePionPionFromHNMInvMassPt(NULL),
+  fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt(NULL),
+  fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt(NULL),
+  fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt(NULL),
+  fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt(NULL),
+  fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt(NULL),
+  fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt(NULL),
+  fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt(NULL),
+  fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt(NULL),
+  fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt(NULL),
+  fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt(NULL),
+  fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt(NULL),
+  fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt(NULL),
+  fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt(NULL),
+  fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt(NULL),
+  fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt(NULL),
+  fHistoTruePiPlPiMiNDMContaminationInvMassPt(NULL),
+  fHistoDoubleCountTruePi0InvMassPt(NULL),
+  fHistoDoubleCountTrueHNMInvMassPt(NULL),
+  fHistoDoubleCountTrueConvGammaRPt(NULL),
+  fVectorDoubleCountTruePi0s(0),
+  fVectorDoubleCountTrueHNMs(0),
+  fVectorDoubleCountTrueConvGammas(0),
+  fHistoNEvents(NULL),
+  fHistoNGoodESDTracks(NULL),
+  fProfileEtaShift(NULL),
+  fHistoSPDClusterTrackletBackground(NULL),
+  fRandom(0),
+  fnCuts(0),
+  fiCut(0),
+  fNumberOfESDTracks(0),
+  fMoveParticleAccordingToVertex(kFALSE),
+  fIsHeavyIon(0),
+  fDoMesonAnalysis(kTRUE),
+  fDoMesonQA(0),
+  fIsFromMBHeader(kTRUE),
+  fIsMC(kFALSE),
+  fSelectedHeavyNeutralMeson(kFALSE),
+  fDoLightOutput(kFALSE),
+  fNDMRecoMode(0),
+  fTolerance(-1)
+{
+
+}
+
+//-----------------------------------------------------------------------------------------------
+AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson( const char* name ):
+  AliAnalysisTaskSE(name),
+  fV0Reader(NULL),
+  fV0ReaderName("V0ReaderV1"),
+  fPionSelector(NULL),
+  fBGHandlerPiPl(NULL),
+  fBGHandlerPiMi(NULL),
+  fESDEvent(NULL),
+  fMCEvent(NULL),
+  fCutFolder(NULL),
+  fESDList(NULL),
+  fTrueList(NULL),
+  fTrueTreeList(NULL),
+  fMCList(NULL),
+  fOutputContainer(0),
+  fReaderGammas(NULL),
+  fSelectorNegPionIndex(0),
+  fSelectorPosPionIndex(0),
+  fGoodConvGammas(NULL),
+  fClusterCandidates(NULL),
+  fNeutralDecayParticleCandidates(NULL),
+  fNeutralDecayParticleSidebandCandidates(NULL),
+  fPosPionCandidates(NULL),
+  fNegPionCandidates(NULL),
+  fGoodVirtualParticles(NULL),
+  fEventCutArray(NULL),
+  fGammaCutArray(NULL),
+  fClusterCutArray(NULL),
+  fPionCutArray(NULL),
+  fNeutralDecayMesonCutArray(NULL),
+  fMesonCutArray(NULL),
+  fEventCuts(NULL),
+  fConversionCuts(NULL),
+  fClusterCuts(NULL),
+  fTreePiPiSameMother(NULL),
+  fTreePiPiPiSameMother(NULL),
+  fTreeEventInfoHNM(NULL),
+  fCasePiPi(-1),
+  fSamePiPiMotherID(-1),
+  fSamePiPiMotherInvMass(-1),
+  fSamePiPiMotherPt(-1),
+  fSamePiPiPiMotherID(-1),
+  fSamePiPiPiMotherInvMass(-1),
+  fSamePiPiPiMotherPt(-1),
+  fV0MultiplicityHNMEvent(-1),
+  fTrackMultiplicityHNMEvent(-1),
+  fZVertexHNMEvent(-1),
+  fPtHNM(-1),
+  fPDGMassNDM(-1),
+  fPDGCodeNDM(-1),
+  fPDGCodeAnalyzedMeson(-1),
+  fHistoConvGammaPt(NULL),
+  fHistoConvGammaEta(NULL),
+  fHistoClusterGammaPt(NULL),
+  fHistoClusterGammaEta(NULL),
+  fHistoNegPionPt(NULL),
+  fHistoPosPionPt(NULL),
+  fHistoNegPionPhi(NULL),
+  fHistoPosPionPhi(NULL),
+  fHistoNegPionEta(NULL),
+  fHistoPosPionEta(NULL),
+  fHistoNegPionClsTPC(NULL),
+  fHistoPosPionClsTPC(NULL),
+  fHistoPionDCAxy(NULL),
+  fHistoPionDCAz(NULL),
+  fHistoPionTPCdEdxNSigma(NULL),
+  fHistoPionTPCdEdx(NULL),
+  fHistoPionPionInvMassPt(NULL),
+  fHistoGammaGammaInvMassPt(NULL),
+  fHistoMotherInvMassPt(NULL),
+  fHistoMotherInvMassPtRejectedKinematic(NULL),
+  fHistoBackInvMassPtGroup1(NULL),
+  fHistoBackInvMassPtGroup2(NULL),
+  fHistoBackInvMassPtGroup3(NULL),
+  fHistoBackInvMassPtGroup4(NULL),
+  fHistoMotherLikeSignBackInvMassPt(NULL),
+  fHistoAngleHNMesonPiPlPiMi(NULL),
+  fHistoAngleHNMesonNDM(NULL),
+  fHistoAngleHNMesonPiPl(NULL),
+  fHistoAngleHNMesonPiMi(NULL),
+  fHistoAnglePiPlPiMi(NULL),
+  fHistoAngleNDMPiMi(NULL),
+  fHistoAnglePiPlNDM(NULL),
+  fHistoAngleSum(NULL),
+  fHistoTrueAngleSum(NULL),
+  fHistoMotherInvMassSubNDM(NULL),
+  fHistoBackInvMassPtGroup1SubNDM(NULL),
+  fHistoBackInvMassPtGroup2SubNDM(NULL),
+  fHistoBackInvMassPtGroup3SubNDM(NULL),
+  fHistoBackInvMassPtGroup4SubNDM(NULL),
+  fHistoMotherLikeSignBackInvMassSubNDMPt(NULL),
+  fHistoMotherInvMassFixedPzNDM(NULL),
+  fHistoBackInvMassPtGroup1FixedPzNDM(NULL),
+  fHistoBackInvMassPtGroup2FixedPzNDM(NULL),
+  fHistoBackInvMassPtGroup3FixedPzNDM(NULL),
+  fHistoBackInvMassPtGroup4FixedPzNDM(NULL),
+  fHistoMotherLikeSignBackInvMassFixedPzNDMPt(NULL),
+  fHistoMCAllGammaPt(NULL),
+  fHistoMCConvGammaPt(NULL),
+  fHistoMCAllPosPionsPt(NULL),
+  fHistoMCAllNegPionsPt(NULL),
+  fHistoMCGammaFromNeutralMesonPt(NULL),
+  fHistoMCPosPionsFromNeutralMesonPt(NULL),
+  fHistoMCNegPionsFromNeutralMesonPt(NULL),
+  fHistoMCHNMPiPlPiMiNDMPt(NULL),
+  fHistoMCHNMPiPlPiMiNDMInAccPt(NULL),
+  fHistoTrueMotherPiPlPiMiNDMInvMassPt(NULL),
+  fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt(NULL),
+  fHistoTrueMotherGammaGammaInvMassPt(NULL),
+  fHistoTrueMotherGammaGammaFromHNMInvMassPt(NULL),
+  fHistoTrueConvGammaPt(NULL),
+  fHistoTrueConvGammaFromNeutralMesonPt(NULL),
+  fHistoTrueClusterGammaPt(NULL),
+  fHistoTrueClusterGammaFromNeutralMesonPt(NULL),
+  fHistoTruePosPionPt(NULL),
+  fHistoTruePosPionFromNeutralMesonPt(NULL),
+  fHistoTrueNegPionPt(NULL),
+  fHistoTrueNegPionFromNeutralMesonPt(NULL),
+  fHistoTruePionPionInvMassPt(NULL),
+  fHistoTruePionPionFromSameMotherInvMassPt(NULL),
+  fHistoTruePionPionFromHNMInvMassPt(NULL),
+  fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt(NULL),
+  fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt(NULL),
+  fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt(NULL),
+  fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt(NULL),
+  fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt(NULL),
+  fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt(NULL),
+  fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt(NULL),
+  fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt(NULL),
+  fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt(NULL),
+  fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt(NULL),
+  fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt(NULL),
+  fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt(NULL),
+  fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt(NULL),
+  fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt(NULL),
+  fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt(NULL),
+  fHistoTruePiPlPiMiNDMContaminationInvMassPt(NULL),
+  fHistoDoubleCountTruePi0InvMassPt(NULL),
+  fHistoDoubleCountTrueHNMInvMassPt(NULL),
+  fHistoDoubleCountTrueConvGammaRPt(NULL),
+  fVectorDoubleCountTruePi0s(0),
+  fVectorDoubleCountTrueHNMs(0),
+  fVectorDoubleCountTrueConvGammas(0),
+  fHistoNEvents(NULL),
+  fHistoNGoodESDTracks(NULL),
+  fProfileEtaShift(NULL),
+  fHistoSPDClusterTrackletBackground(NULL),
+  fRandom(0),
+  fnCuts(0),
+  fiCut(0),
+  fNumberOfESDTracks(0),
+  fMoveParticleAccordingToVertex(kFALSE),
+  fIsHeavyIon(0),
+  fDoMesonAnalysis(kTRUE),
+  fDoMesonQA(0),
+  fIsFromMBHeader(kTRUE),
+  fIsMC(kFALSE),
+  fSelectedHeavyNeutralMeson(kFALSE),
+  fDoLightOutput(kFALSE),
+  fNDMRecoMode(0),
+  fTolerance(-1)
+{
+  DefineOutput(1, TList::Class());
+}
+
+//-----------------------------------------------------------------------------------------------
+AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::~AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson()
+{
+  //
+  // virtual destructor
+  //
+  cout<<"Destructor"<<endl;
+  if(fGoodConvGammas){
+    delete fGoodConvGammas;
+    fGoodConvGammas = 0x0;
+  }
+  if(fClusterCandidates){
+    delete fClusterCandidates;
+    fClusterCandidates = 0x0;
+  }
+
+  if(fNeutralDecayParticleCandidates){
+    delete fNeutralDecayParticleCandidates;
+    fNeutralDecayParticleCandidates = 0x0;
+  }
+
+  if(fNeutralDecayParticleSidebandCandidates){
+    delete fNeutralDecayParticleSidebandCandidates;
+    fNeutralDecayParticleSidebandCandidates = 0x0;
+  }
+
+  if(fPosPionCandidates){
+    delete fPosPionCandidates;
+    fPosPionCandidates = 0x0;
+  }
+
+  if(fNegPionCandidates){
+    delete fNegPionCandidates;
+    fNegPionCandidates = 0x0;
+  }
+
+  if(fGoodVirtualParticles){
+    delete fGoodVirtualParticles;
+    fGoodVirtualParticles = 0x0;
+  }
+
+  if(fBGHandlerPiPl){
+    delete[] fBGHandlerPiPl;
+    fBGHandlerPiPl = 0x0;
+  }
+
+  if(fBGHandlerPiMi){
+    delete[] fBGHandlerPiMi;
+    fBGHandlerPiMi = 0x0;
+  }
+}
+//___________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::InitBack(){
+
+  fBGHandlerPiPl = new AliGammaConversionAODBGHandler*[fnCuts];
+  fBGHandlerPiMi = new AliGammaConversionAODBGHandler*[fnCuts];
+
+  for(Int_t iCut = 0; iCut<fnCuts;iCut++){
+
+    TString cutstringEvent		= ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetCutNumber();
+    TString cutstringPion		= ((AliPrimaryPionCuts*)fPionCutArray->At(iCut))->GetCutNumber();
+    TString cutstringConvGamma = "";
+    if (fNDMRecoMode < 2)  cutstringConvGamma = ((AliConversionPhotonCuts*)fGammaCutArray->At(iCut))->GetCutNumber();
+    TString cutstringCaloGamma = "";
+    if (fNDMRecoMode > 0)  cutstringCaloGamma = ((AliCaloPhotonCuts*)fClusterCutArray->At(iCut))->GetCutNumber();
+    TString cutstringNeutralPion= ((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(iCut))->GetCutNumber();
+    TString cutstringMeson		= ((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->GetCutNumber();
+
+    TString fullCutString = "";
+    if (fNDMRecoMode == 0) fullCutString = Form("%i_%s_%s_%s_%s_%s",fNDMRecoMode,cutstringEvent.Data(),cutstringConvGamma.Data(),cutstringNeutralPion.Data(), cutstringPion.Data(),cutstringMeson.Data());
+    else if (fNDMRecoMode == 1) fullCutString = Form("%i_%s_%s_%s_%s_%s_%s",fNDMRecoMode,cutstringEvent.Data(),cutstringConvGamma.Data(),cutstringCaloGamma.Data(),cutstringNeutralPion.Data(), cutstringPion.Data(),cutstringMeson.Data());
+    else if (fNDMRecoMode == 2) fullCutString = Form("%i_%s_%s_%s_%s_%s",fNDMRecoMode,cutstringEvent.Data(),cutstringCaloGamma.Data(),cutstringNeutralPion.Data(), cutstringPion.Data(),cutstringMeson.Data());
+
+    Int_t collisionSystem = atoi((TString)(((AliConvEventCuts*)fEventCutArray->At(iCut))->GetCutNumber())(0,1));
+    Int_t centMin = atoi((TString)(((AliConvEventCuts*)fEventCutArray->At(iCut))->GetCutNumber())(1,1));
+    Int_t centMax = atoi((TString)(((AliConvEventCuts*)fEventCutArray->At(iCut))->GetCutNumber())(2,1));
+
+    if(collisionSystem == 1 || collisionSystem == 2 ||
+      collisionSystem == 5 || collisionSystem == 8 ||
+      collisionSystem == 9){
+      centMin = centMin*10;
+      centMax = centMax*10;
+    }
+    else if(collisionSystem == 3 || collisionSystem == 6){
+      centMin = centMin*5;
+      centMax = centMax*5;
+    }
+    else if(collisionSystem == 4 || collisionSystem == 7){
+      centMin = ((centMin*5)+45);
+      centMax = ((centMax*5)+45);
+    }
+
+    fBGHandlerPiPl[iCut] = new AliGammaConversionAODBGHandler(	collisionSystem,centMin,centMax,
+                                ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GetNumberOfBGEvents(),
+                                ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->UseTrackMultiplicity(),
+                                4,8,5);
+
+    fBGHandlerPiMi[iCut] = new AliGammaConversionAODBGHandler(	collisionSystem,centMin,centMax,
+                                ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->GetNumberOfBGEvents(),
+                                ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->UseTrackMultiplicity(),
+                                4,8,5);
+  }
+}
+
+//______________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::UserCreateOutputObjects()
+{
+  //
+  // Create ouput objects
+  //
+
+  // Set pT and mass ranges
+  Double_t HistoNMassBins                             = 600;
+  Double_t HistoMassRange[2]                          = {0.4,1.0};
+  Double_t HistoNMassBinsSub                          = 600;
+  Double_t HistoMassRangeSub[2]                       = {0.4,1.0};
+  Double_t HistoNPtBins                               = 250;
+  Double_t HistoPtRange[2]                            = {0.,25.};
+  Double_t HistoNMassBinsDecayMeson                   = 450;
+  Double_t HistoMassRangeNDM[2]                       = {0.0,0.45};
+  Double_t HistoNMassBinsPiPlusPiMinus                = 2000;
+  Double_t HistoMassRangePiPlusPiMinus[2]             = {0.0,2.0};
+  TString NameNeutralMesonAnalyzed                    = "not set";
+  TString NameNeutralMesonAnalyzedLatex               = "not set";
+  TString NameNDM                                     = "not set";
+  TString NameNDMLatex                                = "not set";
+  
+  switch( fSelectedHeavyNeutralMeson ) {
+  case 0: // ETA MESON
+    HistoNMassBins                                    = 400;
+    HistoMassRange[0]                                 = 0.3;
+    HistoMassRange[1]                                 = 0.7;
+    HistoNMassBinsSub                                 = 400;
+    HistoMassRangeSub[0]                              = 0.3;
+    HistoMassRangeSub[1]                              = 0.7;
+    HistoNMassBinsDecayMeson                          = 450;
+    HistoMassRangeNDM[0]                              = 0.0;
+    HistoMassRangeNDM[1]                              = 0.45;
+    NameNeutralMesonAnalyzed                          = "Eta";
+    NameNeutralMesonAnalyzedLatex                     = "#eta";
+    NameNDM                                           = "NeutralPion";
+    NameNDMLatex                                      = "#pi^{0}";
+    fPDGMassNDM                                       = 0.1349766; // hard coded PDG value to keep results reproducable later
+    fPDGCodeNDM                                       = 111; // PDG pi0
+    fPDGCodeAnalyzedMeson                             = 221; // PDG omega
+    break;
+  case 1: // OMEGA MESON
+    HistoNMassBins                                    = 500;
+    HistoMassRange[0]                                 = 0.5;
+    HistoMassRange[1]                                 = 1.0;
+    HistoNMassBinsSub                                 = 500;
+    HistoMassRangeSub[0]                              = 0.5;
+    HistoMassRangeSub[1]                              = 1.0;
+    HistoNMassBinsDecayMeson                          = 450;
+    HistoMassRangeNDM[0]                              = 0.0;
+    HistoMassRangeNDM[1]                              = 0.45;
+    NameNeutralMesonAnalyzed                          = "Omega";
+    NameNeutralMesonAnalyzedLatex                     = "#omega";
+    NameNDM                                           = "NeutralPion";
+    NameNDMLatex                                      = "#pi^{0}";
+    fPDGMassNDM                                       = 0.1349766; // hard coded PDG value to keep results reproducable later
+    fPDGCodeNDM                                       = 111; // PDG pi0
+    fPDGCodeAnalyzedMeson                             = 223; // PDG omega
+    break;
+  case 2: // ETA PRIME MESON
+    HistoNMassBins                                    = 600;
+    HistoMassRange[0]                                 = 0.6;
+    HistoMassRange[1]                                 = 1.2;
+    HistoNMassBinsSub                                 = 600;
+    HistoMassRangeSub[0]                              = 0.6;
+    HistoMassRangeSub[1]                              = 1.2;
+    HistoNMassBinsDecayMeson                          = 450;
+    HistoMassRangeNDM[0]                              = 0.4;
+    HistoMassRangeNDM[1]                              = 0.85;
+    NameNeutralMesonAnalyzed                          = "EtaPrime";
+    NameNeutralMesonAnalyzedLatex                     = "#eta'";
+    NameNDM                                           = "EtaMeson";
+    NameNDMLatex                                      = "#eta";
+    fPDGMassNDM                                       = 0.547862; // hard coded PDG value to keep results reproducable later
+    fPDGCodeNDM                                       = 221; // PDG value eta
+    fPDGCodeAnalyzedMeson                             = 331; // PDG value eta prime
+    break;
+  default:
+    AliError(Form("Heavy neutral meson not correctly selected (only 0,1,2 valid)... selected: %d",fSelectedHeavyNeutralMeson));
+  }
+
+  // Create the output container
+  if(fOutputContainer != NULL){
+    delete fOutputContainer;
+    fOutputContainer            = NULL;
+  }
+  if(fOutputContainer == NULL){
+    fOutputContainer            = new TList();
+    fOutputContainer->SetOwner(kTRUE);
+  }
+
+  fGoodConvGammas               = new TList();
+  fClusterCandidates            = new TList();
+  fClusterCandidates->SetOwner(kTRUE);
+
+  fNeutralDecayParticleCandidates        = new TList();
+  fNeutralDecayParticleCandidates->SetOwner(kTRUE);
+
+  fNeutralDecayParticleSidebandCandidates        = new TList();
+  fNeutralDecayParticleSidebandCandidates->SetOwner(kTRUE);
+
+
+  fPosPionCandidates            = new TList();
+  fPosPionCandidates->SetOwner(kTRUE);
+  fNegPionCandidates            = new TList();
+  fNegPionCandidates->SetOwner(kTRUE);
+  fGoodVirtualParticles         = new TList();
+  fGoodVirtualParticles->SetOwner(kTRUE);
+
+  fCutFolder                    = new TList*[fnCuts];
+  fESDList                      = new TList*[fnCuts];
+  fHistoNEvents                 = new TH1I*[fnCuts];
+  fHistoNGoodESDTracks          = new TH1I*[fnCuts];
+  if(!fDoLightOutput){
+      fProfileEtaShift              = new TProfile*[fnCuts];
+      fHistoSPDClusterTrackletBackground = new TH2F*[fnCuts];
+
+      if (fNDMRecoMode < 2){
+          fHistoConvGammaPt           = new TH1F*[fnCuts];
+          fHistoConvGammaEta          = new TH1F*[fnCuts];
+      }
+      if (fNDMRecoMode > 0){
+          fHistoClusterGammaPt        = new TH1F*[fnCuts];
+          fHistoClusterGammaEta       = new TH1F*[fnCuts];
+      }
+      fHistoNegPionPt               = new TH1F*[fnCuts];
+      fHistoPosPionPt               = new TH1F*[fnCuts];
+      fHistoNegPionPhi              = new TH1F*[fnCuts];
+      fHistoPosPionPhi              = new TH1F*[fnCuts];
+      fHistoPionPionInvMassPt       = new TH2F*[fnCuts];
+
+      if( fDoMesonQA>0 ) {
+          fHistoNegPionEta            = new TH1F*[fnCuts];
+          fHistoPosPionEta            = new TH1F*[fnCuts];
+          fHistoNegPionClsTPC         = new TH2F*[fnCuts];
+          fHistoPosPionClsTPC         = new TH2F*[fnCuts];
+          fHistoPionDCAxy             = new TH2F*[fnCuts];
+          fHistoPionDCAz              = new TH2F*[fnCuts];
+          fHistoPionTPCdEdxNSigma     = new TH2F*[fnCuts];
+          fHistoPionTPCdEdx           = new TH2F*[fnCuts];
+      }
+
+
+      fHistoAngleHNMesonPiPlPiMi    = new TH2F*[fnCuts];
+      fHistoAngleHNMesonNDM      = new TH2F*[fnCuts];
+      fHistoAngleHNMesonPiPl        = new TH2F*[fnCuts];
+      fHistoAngleHNMesonPiMi        = new TH2F*[fnCuts];
+      fHistoAngleNDMPiMi       = new TH2F*[fnCuts];
+      fHistoAnglePiPlPiMi         = new TH2F*[fnCuts];
+      fHistoAnglePiPlNDM       = new TH2F*[fnCuts];
+      fHistoAngleSum              = new TH2F*[fnCuts];
+  }
+
+  fHistoGammaGammaInvMassPt               = new TH2F*[fnCuts];
+  fHistoMotherInvMassPt                   = new TH2F*[fnCuts];
+  fHistoMotherInvMassPtRejectedKinematic  = new TH2F*[fnCuts];
+  fHistoBackInvMassPtGroup1 = new TH2F*[fnCuts];
+  fHistoBackInvMassPtGroup2 = new TH2F*[fnCuts];
+  fHistoBackInvMassPtGroup3  = new TH2F*[fnCuts];
+  fHistoBackInvMassPtGroup4  = new TH2F*[fnCuts];
+
+  fHistoMotherLikeSignBackInvMassPt       = new TH2F*[fnCuts];
+
+  fHistoMotherInvMassSubNDM                               = new TH2F*[fnCuts];
+  fHistoBackInvMassPtGroup1SubNDM = new TH2F*[fnCuts];
+  fHistoBackInvMassPtGroup2SubNDM = new TH2F*[fnCuts];
+  fHistoBackInvMassPtGroup3SubNDM  = new TH2F*[fnCuts];
+  fHistoBackInvMassPtGroup4SubNDM  = new TH2F*[fnCuts];
+
+  fHistoMotherLikeSignBackInvMassSubNDMPt       = new TH2F*[fnCuts];
+
+  fHistoMotherInvMassFixedPzNDM                     = new TH2F*[fnCuts];
+  fHistoBackInvMassPtGroup1FixedPzNDM = new TH2F*[fnCuts];
+  fHistoBackInvMassPtGroup2FixedPzNDM = new TH2F*[fnCuts];
+  fHistoBackInvMassPtGroup3FixedPzNDM  = new TH2F*[fnCuts];
+  fHistoBackInvMassPtGroup4FixedPzNDM  = new TH2F*[fnCuts];
+
+  fHistoMotherLikeSignBackInvMassFixedPzNDMPt       = new TH2F*[fnCuts];
+
+  for(Int_t iCut = 0; iCut<fnCuts;iCut++){
+    TString cutstringEvent        = ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetCutNumber();
+    TString cutstringPion         = ((AliPrimaryPionCuts*)fPionCutArray->At(iCut))->GetCutNumber();
+    TString cutstringConvGamma    = "";
+    if (fNDMRecoMode < 2)
+      cutstringConvGamma          = ((AliConversionPhotonCuts*)fGammaCutArray->At(iCut))->GetCutNumber();
+    TString cutstringCaloGamma    = "";
+    if (fNDMRecoMode > 0)
+      cutstringCaloGamma          = ((AliCaloPhotonCuts*)fClusterCutArray->At(iCut))->GetCutNumber();
+    TString cutstringNeutralPion  = ((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(iCut))->GetCutNumber();
+    TString cutstringMeson        = ((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->GetCutNumber();
+
+    TString fullCutString         = "";
+    if (fNDMRecoMode == 0)
+      fullCutString               = Form("%i_%s_%s_%s_%s_%s",fNDMRecoMode,cutstringEvent.Data(),cutstringConvGamma.Data(),cutstringNeutralPion.Data(), cutstringPion.Data(),cutstringMeson.Data());
+    else if (fNDMRecoMode == 1)
+      fullCutString               = Form("%i_%s_%s_%s_%s_%s_%s",fNDMRecoMode,cutstringEvent.Data(),cutstringConvGamma.Data(),cutstringCaloGamma.Data(),cutstringNeutralPion.Data(), cutstringPion.Data(),cutstringMeson.Data());
+    else if (fNDMRecoMode == 2)
+      fullCutString               = Form("%i_%s_%s_%s_%s_%s",fNDMRecoMode,cutstringEvent.Data(),cutstringCaloGamma.Data(),cutstringNeutralPion.Data(), cutstringPion.Data(),cutstringMeson.Data());
+    TString nameCutFolder         = Form("Cut Number %s", fullCutString.Data());
+    TString nameESDList           = Form("%s ESD histograms", fullCutString.Data());
+
+    fCutFolder[iCut]              = new TList();
+    fCutFolder[iCut]->SetName(nameCutFolder.Data());
+    fCutFolder[iCut]->SetOwner(kTRUE);
+    fOutputContainer->Add(fCutFolder[iCut]);
+
+    fESDList[iCut]                = new TList();
+    fESDList[iCut]->SetName(nameESDList.Data());
+    fESDList[iCut]->SetOwner(kTRUE);
+
+    fHistoNEvents[iCut]           = new TH1I("NEvents","NEvents",14,-0.5,13.5);
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(1,"Accepted");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(2,"Centrality");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(3,"Miss. MC or inc. ev.");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(4,"Trigger");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(5,"Vertex Z");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(6,"Cont. Vertex");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(7,"Pile-Up");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(8,"no SDD");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(9,"no V0AND");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(10,"EMCAL problem");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(12,"SPD hits vs tracklet");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(13,"Out-of-Bunch pileup Past-Future");
+    fHistoNEvents[iCut]->GetXaxis()->SetBinLabel(14,"Pileup V0M-TPCout Tracks");
+    fHistoNEvents[iCut]->GetYaxis()->SetTitle("N_{events}");
+    fESDList[iCut]->Add(fHistoNEvents[iCut]);
+
+    if(fIsHeavyIon>0)
+      fHistoNGoodESDTracks[iCut]  = new TH1I("GoodESDTracks","GoodESDTracks",3000,0,3000);
+    else
+      fHistoNGoodESDTracks[iCut]  = new TH1I("GoodESDTracks","GoodESDTracks",200,0,200);
+    fHistoNGoodESDTracks[iCut]->GetXaxis()->SetTitle("N_{good ESD tracks}");
+    fHistoNGoodESDTracks[iCut]->GetYaxis()->SetTitle("N_{events}");
+    fESDList[iCut]->Add(fHistoNGoodESDTracks[iCut]);
+    if(!fDoLightOutput){
+        fProfileEtaShift[iCut]        = new TProfile("Eta Shift","Eta Shift",1, -0.5,0.5);
+        fESDList[iCut]->Add(fProfileEtaShift[iCut]);
+        fHistoSPDClusterTrackletBackground[iCut] = new TH2F("SPD tracklets vs SPD clusters","SPD tracklets vs SPD clusters",100,0,200,250,0,1000);
+        fHistoSPDClusterTrackletBackground[iCut]->GetXaxis()->SetTitle("N_{SPD tracklets}");
+        fHistoSPDClusterTrackletBackground[iCut]->GetYaxis()->SetTitle("N_{SPD clusters}");
+        fESDList[iCut]->Add(fHistoSPDClusterTrackletBackground[iCut]);
+        if (fNDMRecoMode < 2){
+            fHistoConvGammaPt[iCut]     = new TH1F("ESD_ConvGamma_Pt","ESD_ConvGamma_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+            fHistoConvGammaPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+            fHistoConvGammaPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,conv}");
+            fESDList[iCut]->Add(fHistoConvGammaPt[iCut]);
+            fHistoConvGammaEta[iCut]    = new TH1F("ESD_ConvGamma_Eta","ESD_ConvGamma_Eta",600,-1.5,1.5);
+            fHistoConvGammaEta[iCut]->GetXaxis()->SetTitle("#eta");
+            fHistoConvGammaEta[iCut]->GetYaxis()->SetTitle("N_{#gamma,conv}");
+            fESDList[iCut]->Add(fHistoConvGammaEta[iCut]);
+        }
+        if (fNDMRecoMode > 0){
+            fHistoClusterGammaPt[iCut]  = new TH1F("ESD_ClusterGamma_Pt","ESD_ClusterGamma_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+            fHistoClusterGammaPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+            fHistoClusterGammaPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,cluster}");
+            fESDList[iCut]->Add(fHistoClusterGammaPt[iCut]);
+            fHistoClusterGammaEta[iCut] = new TH1F("ESD_ClusterGamma_Eta","ESD_ClusterGamma_Eta",600,-1.5,1.5);
+            fHistoClusterGammaEta[iCut]->GetXaxis()->SetTitle("#eta");
+            fHistoClusterGammaEta[iCut]->GetYaxis()->SetTitle("N_{#gamma,cluster}");
+            fESDList[iCut]->Add(fHistoClusterGammaEta[iCut]);
+        }
+        fHistoNegPionPt[iCut]         = new TH1F("ESD_PrimaryNegPions_Pt","ESD_PrimaryNegPions_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+        fHistoNegPionPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoNegPionPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
+        fESDList[iCut]->Add(fHistoNegPionPt[iCut]);
+        fHistoPosPionPt[iCut]         = new TH1F("ESD_PrimaryPosPions_Pt","ESD_PrimaryPosPions_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+        fHistoPosPionPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoPosPionPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
+        fESDList[iCut]->Add(fHistoPosPionPt[iCut]);
+        fHistoNegPionPhi[iCut]        = new TH1F("ESD_PrimaryNegPions_Phi","ESD_PrimaryNegPions_Phi",360,0,2*TMath::Pi());
+        fHistoNegPionPhi[iCut]->GetXaxis()->SetTitle("#phi");
+        fHistoNegPionPhi[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
+        fESDList[iCut]->Add(fHistoNegPionPhi[iCut]);
+        fHistoPosPionPhi[iCut]        = new TH1F("ESD_PrimaryPosPions_Phi","ESD_PrimaryPosPions_Phi",360,0,2*TMath::Pi());
+        fHistoPosPionPhi[iCut]->GetXaxis()->SetTitle("#phi");
+        fHistoPosPionPhi[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
+        fESDList[iCut]->Add(fHistoPosPionPhi[iCut]);
+        fHistoPionPionInvMassPt[iCut] = new TH2F("ESD_PiPlusPiNeg_InvMassPt","ESD_PiPlusPiNeg_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+        fHistoPionPionInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+        fHistoPionPionInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+        fESDList[iCut]->Add(fHistoPionPionInvMassPt[iCut]);
+
+        if ( fDoMesonQA>0 ) {
+            fHistoNegPionEta[iCut]        = new TH1F("ESD_PrimaryNegPions_Eta","ESD_PrimaryNegPions_Eta",600,-1.5,1.5);
+            fHistoNegPionEta[iCut]->GetXaxis()->SetTitle("#eta");
+            fHistoNegPionEta[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
+            fESDList[iCut]->Add(fHistoNegPionEta[iCut]);
+            fHistoPosPionEta[iCut]        = new TH1F("ESD_PrimaryPosPions_Eta","ESD_PrimaryPosPions_Eta",600,-1.5,1.5);
+            fHistoPosPionEta[iCut]->GetXaxis()->SetTitle("#eta");
+            fHistoPosPionEta[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
+            fESDList[iCut]->Add(fHistoPosPionEta[iCut]);
+            fHistoNegPionClsTPC[iCut]     = new TH2F("ESD_PrimaryNegPions_ClsTPC","ESD_PrimaryNegPions_ClsTPC",100,0,1,400,0.,10.);
+            fHistoNegPionClsTPC[iCut]->GetXaxis()->SetTitle("N_{findable cls. TPC #pi^{-}}");
+            fHistoNegPionClsTPC[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+            fESDList[iCut]->Add(fHistoNegPionClsTPC[iCut]);
+            fHistoPosPionClsTPC[iCut]     = new TH2F("ESD_PrimaryPosPions_ClsTPC","ESD_PrimaryPosPions_ClsTPC",100,0,1,400,0.,10.);
+            fHistoPosPionClsTPC[iCut]->GetXaxis()->SetTitle("N_{findable cls. TPC #pi^{+}}");
+            fHistoPosPionClsTPC[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+            fESDList[iCut]->Add(fHistoPosPionClsTPC[iCut]);
+            fHistoPionDCAxy[iCut]         = new TH2F("ESD_PrimaryPions_DCAxy","ESD_PrimaryPions_DCAxy",800,-4.0,4.0,400,0.,10.);
+            fHistoPionDCAxy[iCut]->GetXaxis()->SetTitle("DCA_{xy}");
+            fHistoPionDCAxy[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+            fESDList[iCut]->Add(fHistoPionDCAxy[iCut]);
+            fHistoPionDCAz[iCut]          = new TH2F("ESD_PrimaryPions_DCAz","ESD_PrimaryPions_DCAz",800,-4.0,4.0,400,0.,10.);
+            fHistoPionDCAz[iCut]->GetXaxis()->SetTitle("DCA_{z}");
+            fHistoPionDCAz[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+            fESDList[iCut]->Add(fHistoPionDCAz[iCut]);
+            fHistoPionTPCdEdxNSigma[iCut] = new TH2F("ESD_PrimaryPions_TPCdEdx","ESD_PrimaryPions_TPCdEdx",150,0.05,20,400,-10,10);
+            fHistoPionTPCdEdxNSigma[iCut]->GetXaxis()->SetTitle("p (GeV/c)");
+            fHistoPionTPCdEdxNSigma[iCut]->GetYaxis()->SetTitle("#sigma_{PID,TPC}");
+            fESDList[iCut]->Add(fHistoPionTPCdEdxNSigma[iCut]);
+            fHistoPionTPCdEdx[iCut]       = new TH2F("ESD_PrimaryPions_TPCdEdxSignal","ESD_PrimaryPions_TPCdEdxSignal" ,150,0.05,20.0,800,0.0,200);
+            fHistoPionTPCdEdx[iCut]->GetXaxis()->SetTitle("p (GeV/c)");
+            fHistoPionTPCdEdx[iCut]->GetYaxis()->SetTitle("dE/dx signal (au)");
+            fESDList[iCut]->Add(fHistoPionTPCdEdx[iCut]);
+        }
+    fHistoGammaGammaInvMassPt[iCut]               = new TH2F("ESD_GammaGamma_InvMass_Pt","ESD_GammaGamma_InvMass_Pt",HistoNMassBinsDecayMeson,HistoMassRangeNDM[0],HistoMassRangeNDM[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+    fHistoGammaGammaInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#gamma #gamma} (GeV/c^{2})");
+    fHistoGammaGammaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    fESDList[iCut]->Add(fHistoGammaGammaInvMassPt[iCut]);
+  }
+    fHistoMotherInvMassPt[iCut]                   = new TH2F("ESD_Mother_InvMass_Pt","ESD_Mother_InvMass_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+    fHistoMotherInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} (GeV/c^{2})",NameNDMLatex.Data()));
+    fHistoMotherInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    fESDList[iCut]->Add(fHistoMotherInvMassPt[iCut]);
+    fHistoMotherInvMassPtRejectedKinematic[iCut]  = new TH2F("ESD_Mother_InvMass_Pt_KinematicRejected","ESD_Mother_InvMass_Pt_KinematicRejected",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+    fHistoMotherInvMassPtRejectedKinematic[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} (GeV/c^{2})",NameNDMLatex.Data()));
+    fHistoMotherInvMassPtRejectedKinematic[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    fESDList[iCut]->Add(fHistoMotherInvMassPtRejectedKinematic[iCut]);
+
+    fHistoBackInvMassPtGroup1[iCut] = new TH2F("ESD_Background_1_InvMass_Pt","ESD_Background_1_InvMass_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+    fHistoBackInvMassPtGroup2[iCut] = new TH2F("ESD_Background_2_InvMass_Pt","ESD_Background_2_InvMass_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+    fHistoBackInvMassPtGroup3[iCut]  = new TH2F("ESD_Background_3_InvMass_Pt","ESD_Background_3_InvMass_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+    fHistoBackInvMassPtGroup4[iCut]  = new TH2F("ESD_Background_4_InvMass_Pt","ESD_Background_4_InvMass_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+    fHistoBackInvMassPtGroup1[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} (GeV/c^{2})",NameNDMLatex.Data()));
+    fHistoBackInvMassPtGroup1[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    fHistoBackInvMassPtGroup2[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} (GeV/c^{2})",NameNDMLatex.Data()));
+    fHistoBackInvMassPtGroup2[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    fHistoBackInvMassPtGroup3[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} (GeV/c^{2})",NameNDMLatex.Data()));
+    fHistoBackInvMassPtGroup3[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    fHistoBackInvMassPtGroup4[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} (GeV/c^{2})",NameNDMLatex.Data()));
+    fHistoBackInvMassPtGroup4[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    if(!(((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->UseLikeSignMixing())){
+       fESDList[iCut]->Add(fHistoBackInvMassPtGroup1[iCut]);
+        fESDList[iCut]->Add(fHistoBackInvMassPtGroup2[iCut]);
+        fESDList[iCut]->Add(fHistoBackInvMassPtGroup3[iCut]);
+        fESDList[iCut]->Add(fHistoBackInvMassPtGroup4[iCut]);
+    }
+
+    fHistoMotherLikeSignBackInvMassPt[iCut]  = new TH2F("ESD_Background_LikeSign_InvMass_Pt","ESD_Background_LikeSign_InvMass_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+    fHistoMotherLikeSignBackInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{#pm} #pi^{#pm} %s} (GeV/c^{2})",NameNDMLatex.Data()));
+    fHistoMotherLikeSignBackInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    if(((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->UseLikeSignMixing()){
+        fESDList[iCut]->Add(fHistoMotherLikeSignBackInvMassPt[iCut]);
+    }
+    fHistoMotherInvMassSubNDM[iCut]                       = new TH2F("ESD_InvMass_Mother_Sub_InvMass_Neutral_Pt","ESD_InvMass_Mother_Sub_InvMass_Neutral_Pt",HistoNMassBinsSub,HistoMassRangeSub[0],HistoMassRangeSub[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+    fHistoMotherInvMassSubNDM[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} - (M_{%s}-M_{%s},PDG}) (GeV/c^{2})",NameNDMLatex.Data(),NameNDMLatex.Data(),NameNDMLatex.Data()));
+    fHistoMotherInvMassSubNDM[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    fESDList[iCut]->Add(fHistoMotherInvMassSubNDM[iCut]);
+
+    fHistoBackInvMassPtGroup1SubNDM[iCut]   = new TH2F("ESD_Background_1_InvMass_Sub_InvMass_Neutral_Pt","ESD_Background_1_InvMass_Sub_InvMass_Neutral_Pt",
+                                                                     HistoNMassBinsSub,HistoMassRangeSub[0],HistoMassRangeSub[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+    fHistoBackInvMassPtGroup2SubNDM[iCut]   = new TH2F("ESD_Background_2_InvMass_Sub_InvMass_Neutral_Pt","ESD_Background_2_InvMass_Sub_InvMass_Neutral_Pt",
+                                                                     HistoNMassBinsSub,HistoMassRangeSub[0],HistoMassRangeSub[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+    fHistoBackInvMassPtGroup3SubNDM[iCut]    = new TH2F("ESD_Background_3_InvMass_Sub_InvMass_Neutral_Pt","ESD_Background_3_InvMass_Sub_InvMass_Neutral_Pt",
+                                                                     HistoNMassBinsSub,HistoMassRangeSub[0],HistoMassRangeSub[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+    fHistoBackInvMassPtGroup4SubNDM[iCut]    = new TH2F("ESD_Background_4_InvMass_Sub_InvMass_Neutral_Pt","ESD_Background_4_InvMass_Sub_InvMass_Neutral_Pt",
+                                                                     HistoNMassBinsSub,HistoMassRangeSub[0],HistoMassRangeSub[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+
+    fHistoBackInvMassPtGroup1SubNDM[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} - (M_{%s}-M_{%s},PDG}) (GeV/c^{2})",NameNDMLatex.Data(),NameNDMLatex.Data(),NameNDMLatex.Data()));
+    fHistoBackInvMassPtGroup1SubNDM[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    fHistoBackInvMassPtGroup2SubNDM[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} - (M_{%s}-M_{%s},PDG}) (GeV/c^{2})",NameNDMLatex.Data(),NameNDMLatex.Data(),NameNDMLatex.Data()));
+    fHistoBackInvMassPtGroup2SubNDM[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    fHistoBackInvMassPtGroup3SubNDM[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} - (M_{%s}-M_{%s},PDG}) (GeV/c^{2})",NameNDMLatex.Data(),NameNDMLatex.Data(),NameNDMLatex.Data()));
+    fHistoBackInvMassPtGroup3SubNDM[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    fHistoBackInvMassPtGroup4SubNDM[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} - (M_{%s}-M_{%s},PDG}) (GeV/c^{2})",NameNDMLatex.Data(),NameNDMLatex.Data(),NameNDMLatex.Data()));
+    fHistoBackInvMassPtGroup4SubNDM[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    if(!(((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->UseLikeSignMixing())){
+        fESDList[iCut]->Add(fHistoBackInvMassPtGroup4SubNDM[iCut]);
+        fESDList[iCut]->Add(fHistoBackInvMassPtGroup1SubNDM[iCut]);
+        fESDList[iCut]->Add(fHistoBackInvMassPtGroup2SubNDM[iCut]);
+        fESDList[iCut]->Add(fHistoBackInvMassPtGroup3SubNDM[iCut]);
+    }
+    fHistoMotherLikeSignBackInvMassSubNDMPt[iCut]    = new TH2F("ESD_Background_LikeSign_InvMass_Sub_InvMass_Neutral_Pt","ESD_Background_LikeSign_InvMass_Sub_InvMass_Neutral_Pt",
+                                                                HistoNMassBinsSub,HistoMassRangeSub[0],HistoMassRangeSub[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+    fHistoMotherLikeSignBackInvMassSubNDMPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{#pm} #pi^{#pm} %s} - M_{%s} (GeV/c^{2})",NameNDMLatex.Data(),NameNDMLatex.Data()));
+    fHistoMotherLikeSignBackInvMassSubNDMPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    if(((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->UseLikeSignMixing()){
+        fESDList[iCut]->Add(fHistoMotherLikeSignBackInvMassSubNDMPt[iCut]);
+    }
+    fHistoMotherInvMassFixedPzNDM[iCut]                     = new TH2F("ESD_InvMass_Mother_FixedPz_Neutral_Pt","ESD_Mother_InvMass_FixedPz_Neutral_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+    fHistoMotherInvMassFixedPzNDM[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} (GeV/c^{2})",NameNDMLatex.Data()));
+    fHistoMotherInvMassFixedPzNDM[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    fESDList[iCut]->Add(fHistoMotherInvMassFixedPzNDM[iCut]);
+
+    fHistoBackInvMassPtGroup1FixedPzNDM[iCut] = new TH2F("ESD_Background_1_InvMass_FixedPz_Neutral_Pt","ESD_Background_1_InvMass_FixedPz_Neutral_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+    fHistoBackInvMassPtGroup2FixedPzNDM[iCut] = new TH2F("ESD_Background_2_InvMass_FixedPz_Neutral_Pt","ESD_Background_2_InvMass_FixedPz_Neutral_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+    fHistoBackInvMassPtGroup3FixedPzNDM[iCut]  = new TH2F("ESD_Background_3_InvMass_FixedPz_Neutral_Pt","ESD_Background_3_InvMass_FixedPz_Neutral_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+    fHistoBackInvMassPtGroup4FixedPzNDM[iCut]  = new TH2F("ESD_Background_4_InvMass_FixedPz_Neutral_Pt","ESD_Background_4_InvMass_FixedPz_Neutral_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+    fHistoBackInvMassPtGroup1FixedPzNDM[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} (GeV/c^{2})",NameNDMLatex.Data()));
+    fHistoBackInvMassPtGroup1FixedPzNDM[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    fHistoBackInvMassPtGroup2FixedPzNDM[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} (GeV/c^{2})",NameNDMLatex.Data()));
+    fHistoBackInvMassPtGroup2FixedPzNDM[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    fHistoBackInvMassPtGroup3FixedPzNDM[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} (GeV/c^{2})",NameNDMLatex.Data()));
+    fHistoBackInvMassPtGroup3FixedPzNDM[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    fHistoBackInvMassPtGroup4FixedPzNDM[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} (GeV/c^{2})",NameNDMLatex.Data()));
+    fHistoBackInvMassPtGroup4FixedPzNDM[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    if(!(((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->UseLikeSignMixing())){
+        fESDList[iCut]->Add(fHistoBackInvMassPtGroup1FixedPzNDM[iCut]);
+        fESDList[iCut]->Add(fHistoBackInvMassPtGroup2FixedPzNDM[iCut]);
+        fESDList[iCut]->Add(fHistoBackInvMassPtGroup3FixedPzNDM[iCut]);
+        fESDList[iCut]->Add(fHistoBackInvMassPtGroup4FixedPzNDM[iCut]);
+    }
+    fHistoMotherLikeSignBackInvMassFixedPzNDMPt[iCut]  = new TH2F("ESD_Background_LikeSign_InvMass_FixedPz_Neutral_Pt","ESD_Background_LikeSign_InvMass_FixedPz_Neutral_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+    fHistoMotherLikeSignBackInvMassFixedPzNDMPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{#pm} #pi^{#pm} %s} (GeV/c^{2})",NameNDMLatex.Data()));
+    fHistoMotherLikeSignBackInvMassFixedPzNDMPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+    if(((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->UseLikeSignMixing()){
+        fESDList[iCut]->Add(fHistoMotherLikeSignBackInvMassFixedPzNDMPt[iCut]);
+    }
+    if(!fDoLightOutput){
+        fHistoAngleHNMesonPiPlPiMi[iCut]      = new TH2F(Form("ESD_Mother_Angle%sNegPionsPosPions_Pt",NameNeutralMesonAnalyzed.Data()),Form("ESD_Mother_Angle%sNegPionsPosPions_Pt",NameNeutralMesonAnalyzed.Data()),HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
+        fHistoAngleHNMesonPiPlPiMi[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoAngleHNMesonPiPlPiMi[iCut]->GetYaxis()->SetTitle("#angle (meson,#pi^{+}#pi^{-})");
+        fESDList[iCut]->Add(fHistoAngleHNMesonPiPlPiMi[iCut]);
+        fHistoAngleHNMesonPiMi[iCut]          = new TH2F(Form("ESD_Mother_Angle%sNegPions_Pt",NameNeutralMesonAnalyzed.Data()),Form("ESD_Mother_Angle%sNegPions_Pt",NameNeutralMesonAnalyzed.Data()),HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
+        fHistoAngleHNMesonPiMi[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoAngleHNMesonPiMi[iCut]->GetYaxis()->SetTitle("#angle (meson,#pi^{-})");
+        fESDList[iCut]->Add(fHistoAngleHNMesonPiMi[iCut]);
+        fHistoAngleHNMesonPiPl[iCut]          = new TH2F(Form("ESD_Mother_Angle%sPosPions_Pt",NameNeutralMesonAnalyzed.Data()),Form("ESD_Mother_Angle%sPosPions_Pt",NameNeutralMesonAnalyzed.Data()),HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
+        fHistoAngleHNMesonPiPl[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoAngleHNMesonPiPl[iCut]->GetYaxis()->SetTitle("#angle (meson,#pi^{+})");
+        fESDList[iCut]->Add(fHistoAngleHNMesonPiPl[iCut]);
+        fHistoAngleHNMesonNDM[iCut]        = new TH2F(Form("ESD_Mother_Angle%s%s_Pt",NameNeutralMesonAnalyzed.Data(),NameNDM.Data()),Form("ESD_Mother_Angle%s%s_Pt",NameNeutralMesonAnalyzed.Data(),NameNDM.Data()),HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
+        fHistoAngleHNMesonNDM[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoAngleHNMesonNDM[iCut]->GetYaxis()->SetTitle(Form("#angle (meson,%s)",NameNDMLatex.Data()));
+        fESDList[iCut]->Add(fHistoAngleHNMesonNDM[iCut]);
+        fHistoAnglePiPlNDM[iCut]         = new TH2F(Form("ESD_Mother_AnglePosPions%s_Pt",NameNDM.Data()),Form("ESD_Mother_AnglePosPions%s_Pt",NameNDM.Data()),HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
+        fHistoAnglePiPlNDM[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoAnglePiPlNDM[iCut]->GetYaxis()->SetTitle(Form("#angle (#pi^{+},%s)",NameNDMLatex.Data()));
+        fESDList[iCut]->Add(fHistoAnglePiPlNDM[iCut]);
+        fHistoAnglePiPlPiMi[iCut]           = new TH2F("ESD_Mother_AnglePosPionsNegPions_Pt","ESD_Mother_AnglePosPionsNegPions_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
+        fHistoAnglePiPlPiMi[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoAnglePiPlPiMi[iCut]->GetYaxis()->SetTitle("#angle (#pi^{+},#pi^{-})");
+        fESDList[iCut]->Add(fHistoAnglePiPlPiMi[iCut]);
+        fHistoAngleNDMPiMi[iCut]         = new TH2F(Form("ESD_Mother_Angle%sNegPions_Pt",NameNDM.Data()),Form("ESD_Mother_Angle%sNegPions_Pt",NameNDM.Data()),HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
+        fHistoAngleNDMPiMi[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoAngleNDMPiMi[iCut]->GetYaxis()->SetTitle(Form("#angle (%s,#pi^{-})",NameNDMLatex.Data()));
+        fESDList[iCut]->Add(fHistoAngleNDMPiMi[iCut]);
+        fHistoAngleSum[iCut]                = new TH2F("ESD_Mother_AngleSum_Pt","ESD_Mother_AngleSum_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1],720,0,2*TMath::Pi());
+        fHistoAngleSum[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoAngleSum[iCut]->GetYaxis()->SetTitle("#sum #angle");
+        fESDList[iCut]->Add(fHistoAngleSum[iCut]);
+    }
+    if ( fDoMesonQA>0 && (!fDoLightOutput) ) {
+      TAxis *AxisAfter        = fHistoPionTPCdEdxNSigma[iCut]->GetXaxis();
+      Int_t bins              = AxisAfter->GetNbins();
+      Double_t from           = AxisAfter->GetXmin();
+      Double_t to             = AxisAfter->GetXmax();
+      Double_t *newBins       = new Double_t[bins+1];
+      newBins[0]              = from;
+      Double_t factor         = TMath::Power(to/from, 1./bins);
+      for(Int_t i=1; i<=bins; ++i) newBins[i] = factor * newBins[i-1];
+
+      AxisAfter->Set(bins, newBins);
+      AxisAfter               = fHistoPionTPCdEdx[iCut]->GetXaxis();
+      AxisAfter->Set(bins, newBins);
+      delete [] newBins;
+    }
+
+    fCutFolder[iCut]->Add(fESDList[iCut]);
+
+  }
+
+  if( fIsMC ){
+    // MC Histogramms
+    fMCList                                 = new TList*[fnCuts];
+    // True Histogramms
+    fTrueList                               = new TList*[fnCuts];
+    if(!fDoLightOutput){
+        if (fNDMRecoMode < 2){
+            fHistoTrueConvGammaPt                 = new TH1F*[fnCuts];
+            fHistoDoubleCountTrueConvGammaRPt     = new TH2F*[fnCuts];
+            fHistoTrueConvGammaFromNeutralMesonPt = new TH1F*[fnCuts];
+        }
+        if (fNDMRecoMode > 0){
+            fHistoTrueClusterGammaPt                  = new TH1F*[fnCuts];
+            fHistoTrueClusterGammaFromNeutralMesonPt  = new TH1F*[fnCuts];
+        }
+        fHistoTruePosPionPt                     = new TH1F*[fnCuts];
+        fHistoTrueNegPionPt                     = new TH1F*[fnCuts];
+        fHistoTruePosPionFromNeutralMesonPt     = new TH1F*[fnCuts];
+        fHistoTrueNegPionFromNeutralMesonPt     = new TH1F*[fnCuts];
+
+
+        fHistoMCAllGammaPt                      = new TH1F*[fnCuts];
+        if (fNDMRecoMode < 2){
+            fHistoMCConvGammaPt                   = new TH1F*[fnCuts];
+        }
+        fHistoMCAllPosPionsPt                   = new TH1F*[fnCuts];
+        fHistoMCAllNegPionsPt                   = new TH1F*[fnCuts];
+        fHistoMCGammaFromNeutralMesonPt         = new TH1F*[fnCuts];
+        fHistoMCPosPionsFromNeutralMesonPt      = new TH1F*[fnCuts];
+        fHistoMCNegPionsFromNeutralMesonPt      = new TH1F*[fnCuts];
+    }
+    fHistoMCHNMPiPlPiMiNDMPt                     = new TH1F*[fnCuts];
+    fHistoMCHNMPiPlPiMiNDMInAccPt                = new TH1F*[fnCuts];
+    if(!fDoLightOutput){
+        fHistoDoubleCountTruePi0InvMassPt               = new TH2F*[fnCuts];
+        fHistoDoubleCountTrueHNMInvMassPt               = new TH2F*[fnCuts];
+    }
+    fHistoTrueMotherPiPlPiMiNDMInvMassPt         = new TH2F*[fnCuts];
+    fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt      = new TH2F*[fnCuts];
+    if(!fDoLightOutput){
+        fHistoTrueMotherGammaGammaInvMassPt             = new TH2F*[fnCuts];
+        fHistoTrueMotherGammaGammaFromHNMInvMassPt      = new TH2F*[fnCuts];
+        fHistoTrueAngleSum                              = new TH2F*[fnCuts];
+    }
+    if(!fDoLightOutput){
+        if (fDoMesonQA>0){
+            fHistoTruePionPionInvMassPt                               = new TH2F*[fnCuts];
+            fHistoTruePionPionFromSameMotherInvMassPt                 = new TH2F*[fnCuts];
+            fHistoTruePionPionFromHNMInvMassPt                        = new TH2F*[fnCuts];
+
+            fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt              = new TH2F*[fnCuts];
+            fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt            = new TH2F*[fnCuts];
+            fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt              = new TH2F*[fnCuts];
+            fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt         = new TH2F*[fnCuts];
+            fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt              = new TH2F*[fnCuts];
+            fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt              = new TH2F*[fnCuts];
+            fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt            = new TH2F*[fnCuts];
+            fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt          = new TH2F*[fnCuts];
+            fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt            = new TH2F*[fnCuts];
+            fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt            = new TH2F*[fnCuts];
+            fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt            = new TH2F*[fnCuts];
+            fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt          = new TH2F*[fnCuts];
+            fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt            = new TH2F*[fnCuts];
+            fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt            = new TH2F*[fnCuts];
+            fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt       = new TH2F*[fnCuts];
+            fHistoTruePiPlPiMiNDMContaminationInvMassPt            = new TH2F*[fnCuts];
+            if (fDoMesonQA>1){
+                fTrueTreeList                                           = new TList*[fnCuts];
+                fTreePiPiSameMother                                     = new TTree*[fnCuts];
+                fTreePiPiPiSameMother                                   = new TTree*[fnCuts];
+                fTreeEventInfoHNM                                       = new TTree*[fnCuts];
+            }
+        }
+    }
+
+    for(Int_t iCut = 0; iCut<fnCuts;iCut++){
+      TString cutstringEvent            = ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetCutNumber();
+      TString cutstringPion             = ((AliPrimaryPionCuts*)fPionCutArray->At(iCut))->GetCutNumber();
+      TString cutstringConvGamma        = "";
+      if (fNDMRecoMode < 2)
+        cutstringConvGamma              = ((AliConversionPhotonCuts*)fGammaCutArray->At(iCut))->GetCutNumber();
+      TString cutstringCaloGamma        = "";
+      if (fNDMRecoMode > 0)
+        cutstringCaloGamma              = ((AliCaloPhotonCuts*)fClusterCutArray->At(iCut))->GetCutNumber();
+      TString cutstringNeutralPion      = ((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(iCut))->GetCutNumber();
+      TString cutstringMeson            = ((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->GetCutNumber();
+
+      TString fullCutString             = "";
+      if (fNDMRecoMode == 0)
+        fullCutString                   = Form("%i_%s_%s_%s_%s_%s",fNDMRecoMode,cutstringEvent.Data(),cutstringConvGamma.Data(),cutstringNeutralPion.Data(), cutstringPion.Data(),
+                                               cutstringMeson.Data());
+      else if (fNDMRecoMode == 1)
+        fullCutString                   = Form("%i_%s_%s_%s_%s_%s_%s",fNDMRecoMode,cutstringEvent.Data(),cutstringConvGamma.Data(),cutstringCaloGamma.Data(), cutstringNeutralPion.Data(),
+                                               cutstringPion.Data(), cutstringMeson.Data());
+      else if (fNDMRecoMode == 2)
+        fullCutString                   = Form("%i_%s_%s_%s_%s_%s",fNDMRecoMode,cutstringEvent.Data(), cutstringCaloGamma.Data(), cutstringNeutralPion.Data(), cutstringPion.Data(),
+                                               cutstringMeson.Data());
+      TString nameMCList                = Form("%s MC histograms", fullCutString.Data());
+      TString nameTrueRecList           = Form("%s True histograms", fullCutString.Data());
+      TString nameTrueRecTTreeList      = Form("%s True TTrees", fullCutString.Data());
+
+      fMCList[iCut]                     = new TList();
+      fMCList[iCut]->SetName(nameMCList.Data());
+      fMCList[iCut]->SetOwner(kTRUE);
+      fCutFolder[iCut]->Add(fMCList[iCut]);
+
+      if(!fDoLightOutput){
+          fHistoMCAllGammaPt[iCut]          = new TH1F("MC_AllGamma_Pt","MC_AllGamma_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoMCAllGammaPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+          fHistoMCAllGammaPt[iCut]->GetYaxis()->SetTitle("N_{#gamma}");
+          fMCList[iCut]->Add(fHistoMCAllGammaPt[iCut]);
+          if (fNDMRecoMode < 2){
+              fHistoMCConvGammaPt[iCut]       = new TH1F("MC_ConvGamma_Pt","MC_ConvGamma_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoMCConvGammaPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+              fHistoMCConvGammaPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,conv}");
+              fMCList[iCut]->Add(fHistoMCConvGammaPt[iCut]);
+          }
+
+          fHistoMCAllPosPionsPt[iCut]               = new TH1F("MC_AllPosPions_Pt","MC_AllPosPions_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoMCAllPosPionsPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+          fHistoMCAllPosPionsPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
+          fMCList[iCut]->Add(fHistoMCAllPosPionsPt[iCut]);
+          fHistoMCAllNegPionsPt[iCut]               = new TH1F("MC_AllNegPions_Pt","MC_AllNegPions_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoMCAllNegPionsPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+          fHistoMCAllNegPionsPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
+          fMCList[iCut]->Add(fHistoMCAllNegPionsPt[iCut]);
+          fHistoMCGammaFromNeutralMesonPt[iCut]     = new TH1F("MC_GammaFromNeutralMeson_Pt","MC_GammaFromNeutralMeson_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoMCGammaFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+          fHistoMCGammaFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle("N_{#gamma}");
+          fMCList[iCut]->Add(fHistoMCGammaFromNeutralMesonPt[iCut]);
+          fHistoMCPosPionsFromNeutralMesonPt[iCut]  = new TH1F("MC_PosPionsFromNeutralMeson_Pt","MC_PosPionsFromNeutralMeson_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoMCPosPionsFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+          fHistoMCPosPionsFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
+          fMCList[iCut]->Add(fHistoMCPosPionsFromNeutralMesonPt[iCut]);
+          fHistoMCNegPionsFromNeutralMesonPt[iCut]  = new TH1F("MC_NegPionsFromNeutralMeson_Pt","MC_NegPionsFromNeutralMeson_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoMCNegPionsFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+          fHistoMCNegPionsFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
+          fMCList[iCut]->Add(fHistoMCNegPionsFromNeutralMesonPt[iCut]);
+      }
+      fHistoMCHNMPiPlPiMiNDMPt[iCut]         = new TH1F("MC_HNM_Pt","MC_HNM_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+      fHistoMCHNMPiPlPiMiNDMPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+      fHistoMCHNMPiPlPiMiNDMPt[iCut]->GetYaxis()->SetTitle("N_{HNM}");
+      fHistoMCHNMPiPlPiMiNDMPt[iCut]->Sumw2();
+      fMCList[iCut]->Add(fHistoMCHNMPiPlPiMiNDMPt[iCut]);
+
+      fHistoMCHNMPiPlPiMiNDMInAccPt[iCut]    = new TH1F("MC_HNMInAcc_Pt","MC_HNMInAcc_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+      fHistoMCHNMPiPlPiMiNDMInAccPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+      fHistoMCHNMPiPlPiMiNDMInAccPt[iCut]->GetYaxis()->SetTitle("A #times N_{HNM}");
+      fHistoMCHNMPiPlPiMiNDMInAccPt[iCut]->Sumw2();
+      fMCList[iCut]->Add(fHistoMCHNMPiPlPiMiNDMInAccPt[iCut]);
+
+      fTrueList[iCut]                           = new TList();
+      fTrueList[iCut]->SetName(nameTrueRecList.Data());
+      fTrueList[iCut]->SetOwner(kTRUE);
+      fCutFolder[iCut]->Add(fTrueList[iCut]);
+
+      if(!fDoLightOutput){
+          if (fNDMRecoMode < 2){
+              fHistoTrueConvGammaPt[iCut]                 = new TH1F("ESD_TrueConvGamma_Pt","ESD_TrueConvGamma_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTrueConvGammaPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+              fHistoTrueConvGammaPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,conv}");
+              fTrueList[iCut]->Add(fHistoTrueConvGammaPt[iCut]);
+              fHistoDoubleCountTrueConvGammaRPt[iCut]     = new TH2F("ESD_TrueDoubleCountConvGamma_R_Pt","ESD_TrueDoubleCountConvGamma_R_Pt",800,0,200,HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoDoubleCountTrueConvGammaRPt[iCut]->GetXaxis()->SetTitle("R_{conv} (cm)");
+              fHistoDoubleCountTrueConvGammaRPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoDoubleCountTrueConvGammaRPt[iCut]);
+              fHistoTrueConvGammaFromNeutralMesonPt[iCut] = new TH1F("ESD_TrueConvGammaFromNeutralMeson_Pt","ESD_TrueConvGammaFromNeutralMeson_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTrueConvGammaFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+              fHistoTrueConvGammaFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,conv}");
+              fTrueList[iCut]->Add(fHistoTrueConvGammaFromNeutralMesonPt[iCut]);
+          }
+          if (fNDMRecoMode > 0){
+              fHistoTrueClusterGammaPt[iCut]                  = new TH1F("ESD_TrueClusterGamma_Pt","ESD_TrueClusterGamma_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTrueClusterGammaPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+              fHistoTrueClusterGammaPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,cluster}");
+              fTrueList[iCut]->Add(fHistoTrueClusterGammaPt[iCut]);
+              fHistoTrueClusterGammaFromNeutralMesonPt[iCut]  = new TH1F("ESD_TrueClusterGammaFromNeutralMeson_Pt","ESD_TrueClusterGammaFromNeutralMeson_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTrueClusterGammaFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+              fHistoTrueClusterGammaFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,cluster}");
+              fTrueList[iCut]->Add(fHistoTrueClusterGammaFromNeutralMesonPt[iCut]);
+          }
+          fHistoTruePosPionPt[iCut]                       = new TH1F("ESD_TruePosPion_Pt","ESD_TruePosPion_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePosPionPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+          fHistoTruePosPionPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
+          fTrueList[iCut]->Add(fHistoTruePosPionPt[iCut]);
+          fHistoTrueNegPionPt[iCut]                       = new TH1F("ESD_TrueNegPion_Pt","ESD_TrueNegPion_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTrueNegPionPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+          fHistoTrueNegPionPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
+          fTrueList[iCut]->Add(fHistoTrueNegPionPt[iCut]);
+
+          fHistoTrueNegPionFromNeutralMesonPt[iCut]       = new TH1F("ESD_TrueNegPionFromNeutralMeson_Pt","ESD_TrueNegPionFromNeutralMeson_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTrueNegPionFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+          fHistoTrueNegPionFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
+          fTrueList[iCut]->Add(fHistoTrueNegPionFromNeutralMesonPt[iCut]);
+          fHistoTruePosPionFromNeutralMesonPt[iCut]       = new TH1F("ESD_TruePosPionFromNeutralMeson_Pt","ESD_TruePosPionFromNeutralMeson_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePosPionFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+          fHistoTruePosPionFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
+          fTrueList[iCut]->Add(fHistoTruePosPionFromNeutralMesonPt[iCut]);
+
+          fHistoDoubleCountTruePi0InvMassPt[iCut]         = new TH2F("ESD_TrueDoubleCountPi0_InvMass_Pt","ESD_TrueDoubleCountPi0_InvMass_Pt",800,0,0.8,HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoDoubleCountTruePi0InvMassPt[iCut]->GetXaxis()->SetTitle("M_{#gamma #gamma} (GeV/c^{2})");
+          fHistoDoubleCountTruePi0InvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoDoubleCountTruePi0InvMassPt[iCut]);
+          fHistoDoubleCountTrueHNMInvMassPt[iCut]         = new TH2F("ESD_TrueDoubleCountHNM_InvMass_Pt","ESD_TrueDoubleCountHNM_InvMass_Pt",800,0,0.8,HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoDoubleCountTrueHNMInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#eta} (GeV/c^{2})");
+          fHistoDoubleCountTrueHNMInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoDoubleCountTrueHNMInvMassPt[iCut]);
+      }
+      fHistoTrueMotherPiPlPiMiNDMInvMassPt[iCut]       = new TH2F("ESD_TrueMotherPiPlPiMiNDM_InvMass_Pt","ESD_TrueMotherPiPlPiMiNDM_InvMass_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+      fHistoTrueMotherPiPlPiMiNDMInvMassPt[iCut]->Sumw2();
+      fHistoTrueMotherPiPlPiMiNDMInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} (GeV/c^{2})",NameNDMLatex.Data()));
+      fHistoTrueMotherPiPlPiMiNDMInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+      fTrueList[iCut]->Add(fHistoTrueMotherPiPlPiMiNDMInvMassPt[iCut]);
+
+          fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt[iCut]  = new TH2F("ESD_TrueMotherHNMPiPlPiMiNDM_InvMass_Pt","ESD_TrueMotherHNMPiPlPiMiNDM_InvMass_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt[iCut]->Sumw2();
+          fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} (GeV/c^{2})",NameNDMLatex.Data()));
+          fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt[iCut]);
+
+      if(!fDoLightOutput){
+          fHistoTrueMotherGammaGammaInvMassPt[iCut]           = new TH2F("ESD_TrueMotherGG_InvMass_Pt","ESD_TrueMotherGG_InvMass_Pt",HistoNMassBinsDecayMeson,HistoMassRangeNDM[0],HistoMassRangeNDM[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTrueMotherGammaGammaInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#gamma #gamma} (GeV/c^{2})");
+          fHistoTrueMotherGammaGammaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTrueMotherGammaGammaInvMassPt[iCut]);
+          fHistoTrueMotherGammaGammaFromHNMInvMassPt[iCut]    = new TH2F("ESD_TrueMotherGGFromHNM_InvMass_Pt","ESD_TrueMotherGGFromHNM_InvMass_Pt",HistoNMassBinsDecayMeson,HistoMassRangeNDM[0],HistoMassRangeNDM[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTrueMotherGammaGammaFromHNMInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#gamma #gamma} (GeV/c^{2})");
+          fHistoTrueMotherGammaGammaFromHNMInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTrueMotherGammaGammaFromHNMInvMassPt[iCut]);
+          fHistoTrueAngleSum[iCut]                            = new TH2F("ESD_TrueMother_AngleSum_Pt","ESD_TrueMother_AngleSum_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1],720,0,2*TMath::Pi());
+          fHistoTrueAngleSum[iCut]->GetXaxis()->SetTitle("#sum #angle");
+          fHistoTrueAngleSum[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTrueAngleSum[iCut]);
+
+          if (fDoMesonQA>0){
+              fHistoTruePionPionInvMassPt[iCut]                 = new TH2F("ESD_TruePiPlusPiNeg_InvMassPt","ESD_TruePiPlusPiNeg_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTruePionPionInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+              fHistoTruePionPionInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoTruePionPionInvMassPt[iCut]);
+              fHistoTruePionPionFromSameMotherInvMassPt[iCut]   = new TH2F("ESD_TruePiPlusPiNegFromSameMother_InvMassPt","ESD_TruePiPlusPiNegFromSameMother_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTruePionPionFromSameMotherInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+              fHistoTruePionPionFromSameMotherInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoTruePionPionFromSameMotherInvMassPt[iCut]);
+              fHistoTruePionPionFromHNMInvMassPt[iCut]          = new TH2F("ESD_TruePiPlusPiNegFromHNM_InvMassPt","ESD_TruePiPlusPiNegFromHNM_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTruePionPionFromHNMInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+              fHistoTruePionPionFromHNMInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoTruePionPionFromHNMInvMassPt[iCut]);
+
+              fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt[iCut]    = new TH2F("ESD_TruePiPlPiMiSameMotherFromEta_InvMassPt","ESD_TruePiPlPiMiSameMotherFromEta_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+              fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt[iCut]);
+              fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt[iCut]  = new TH2F("ESD_TruePiPlPiMiSameMotherFromOmega_InvMassPt","ESD_TruePiPlPiMiSameMotherFromOmega_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+              fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt[iCut]);
+              fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt[iCut]    = new TH2F("ESD_TruePiPlPiMiSameMotherFromRho_InvMassPt","ESD_TruePiPlPiMiSameMotherFromRho_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+              fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt[iCut]);
+              fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt[iCut] = new TH2F("ESD_TruePiPlPiMiSameMotherFromEtaPrime_InvMassPt","ESD_TruePiPlPiMiSameMotherFromEtaPrime_InvMassPt",
+                                                                                 HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+              fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt[iCut]);
+              fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt[iCut]    = new TH2F("ESD_TruePiPlPiMiSameMotherFromK0s_InvMassPt","ESD_TruePiPlPiMiSameMotherFromK0s_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+              fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt[iCut]);
+              fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt[iCut]    = new TH2F("ESD_TruePiPlPiMiSameMotherFromK0l_InvMassPt","ESD_TruePiPlPiMiSameMotherFromK0l_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+              fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt[iCut]);
+
+              fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt[iCut]  = new TH2F("ESD_TruePiMiPiZeroSameMotherFromEta_InvMassPt","ESD_TruePiMiPiZeroSameMotherFromEta_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{-}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+              fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt[iCut]);
+              fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt[iCut] = new TH2F("ESD_TruePiMiPiZeroSameMotherFromOmega_InvMassPt","ESD_TruePiMiPiZeroSameMotherFromOmega_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{-}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+              fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt[iCut]);
+              fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt[iCut]  = new TH2F("ESD_TruePiMiPiZeroSameMotherFromRho_InvMassPt","ESD_TruePiMiPiZeroSameMotherFromRho_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{-}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+              fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt[iCut]);
+              fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt[iCut]  = new TH2F("ESD_TruePiMiPiZeroSameMotherFromK0l_InvMassPt","ESD_TruePiMiPiZeroSameMotherFromK0l_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{-}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+              fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt[iCut]);
+
+              fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt[iCut]  = new TH2F("ESD_TruePiPlPiZeroSameMotherFromEta_InvMassPt","ESD_TruePiPlPiZeroSameMotherFromEta_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+              fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt[iCut]);
+              fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt[iCut] = new TH2F("ESD_TruePiPlPiZeroSameMotherFromOmega_InvMassPt","ESD_TruePiPlPiZeroSameMotherFromOmega_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+              fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt[iCut]);
+              fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt[iCut]  = new TH2F("ESD_TruePiPlPiZeroSameMotherFromRho_InvMassPt","ESD_TruePiPlPiZeroSameMotherFromRho_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+              fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt[iCut]);
+              fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt[iCut]  = new TH2F("ESD_TruePiPlPiZeroSameMotherFromK0l_InvMassPt","ESD_TruePiPlPiZeroSameMotherFromK0l_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+              fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt[iCut]);
+              fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt[iCut]  = new TH2F("ESD_TruePiPlPiMiNDMPureCombinatorical_InvMassPt","ESD_TruePiPlPiMiNDMPureCombinatorical_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+}#pi^{-}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+              fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt[iCut]);
+              fHistoTruePiPlPiMiNDMContaminationInvMassPt[iCut]  = new TH2F("ESD_TruePiPlPiMiNDMContamination_InvMassPt","ESD_TruePiPlPiMiNDMContamination_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+              fHistoTruePiPlPiMiNDMContaminationInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+}#pi^{-}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+              fHistoTruePiPlPiMiNDMContaminationInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+              fTrueList[iCut]->Add(fHistoTruePiPlPiMiNDMContaminationInvMassPt[iCut]);
+              if(fDoMesonQA>1){
+                  fTrueTreeList[iCut]                               = new TList();
+                  fTrueTreeList[iCut]->SetName(nameTrueRecTTreeList.Data());
+                  fTrueTreeList[iCut]->SetOwner(kTRUE);
+                  fCutFolder[iCut]->Add(fTrueTreeList[iCut]);
+
+                  fTreePiPiSameMother[iCut]                         = new TTree("TreePiPiSameMother","TreePiPiSameMother");
+                  fTreePiPiSameMother[iCut]->Branch("fCasePiPi", &fCasePiPi, "fCasePiPi/S");
+                  fTreePiPiSameMother[iCut]->Branch("fSamePiPiMotherID", &fSamePiPiMotherID, "fSamePiPiMotherID/F");
+                  fTreePiPiSameMother[iCut]->Branch("fSamePiPiMotherInvMass", &fSamePiPiMotherInvMass, "fSamePiPiMotherInvMass/F");
+                  fTreePiPiSameMother[iCut]->Branch("fSamePiPiMotherPt", &fSamePiPiMotherPt, "fSamePiPiMotherPt/F");
+                  fTrueTreeList[iCut]->Add(fTreePiPiSameMother[iCut]);
+
+                  fTreePiPiPiSameMother[iCut]                         = new TTree("TreePiPiPiSameMother","TreePiPiPiSameMother");
+                  fTreePiPiPiSameMother[iCut]->Branch("fSamePiPiPiMotherID", &fSamePiPiPiMotherID, "fSamePiPiPiMotherID/F");
+                  fTreePiPiPiSameMother[iCut]->Branch("fSamePiPiPiMotherInvMass", &fSamePiPiPiMotherInvMass, "fSamePiPiPiMotherInvMass/F");
+                  fTreePiPiPiSameMother[iCut]->Branch("fSamePiPiPiMotherPt", &fSamePiPiPiMotherPt, "fSamePiPiPiMotherPt/F");
+                  fTrueTreeList[iCut]->Add(fTreePiPiPiSameMother[iCut]);
+
+                  fTreeEventInfoHNM[iCut]                         = new TTree("TreeEventInfoHNM","TreeEventInfoHNM");
+                  fTreeEventInfoHNM[iCut]->Branch("fV0MultiplicityHNMEvent", &fV0MultiplicityHNMEvent, "fV0MultiplicityHNMEvent/F");
+                  fTreeEventInfoHNM[iCut]->Branch("fTrackMultiplicityHNMEvent", &fTrackMultiplicityHNMEvent, "fTrackMultiplicityHNMEvent/F");
+                  fTreeEventInfoHNM[iCut]->Branch("fZVertexHNMEvent", &fZVertexHNMEvent, "fZVertexHNMEvent/F");
+                  fTreeEventInfoHNM[iCut]->Branch("fPtHNM", &fPtHNM, "fPtHNM/F");
+                  fTrueTreeList[iCut]->Add(fTreeEventInfoHNM[iCut]);
+              }
+          }
+      }
+    }
+  }
+
+  fVectorDoubleCountTruePi0s.clear();
+  fVectorDoubleCountTrueHNMs.clear();
+  fVectorDoubleCountTrueConvGammas.clear();
+
+  InitBack(); // Init Background Handler
+
+  fV0Reader=(AliV0ReaderV1*)AliAnalysisManager::GetAnalysisManager()->GetTask(fV0ReaderName.Data());
+  if(!fV0Reader){printf("Error: No V0 Reader");return;} // GetV0Reader
+
+  if(fV0Reader){
+    if((AliConvEventCuts*)fV0Reader->GetEventCuts()){
+      if(((AliConvEventCuts*)fV0Reader->GetEventCuts())->GetCutHistograms()){
+        fOutputContainer->Add(((AliConvEventCuts*)fV0Reader->GetEventCuts())->GetCutHistograms());
+      }
+    }
+
+    if((AliConversionPhotonCuts*)fV0Reader->GetConversionCuts()){
+      if(((AliConversionPhotonCuts*)fV0Reader->GetConversionCuts())->GetCutHistograms()){
+        fOutputContainer->Add(((AliConversionPhotonCuts*)fV0Reader->GetConversionCuts())->GetCutHistograms());
+      }
+    }
+
+  }
+
+  for(Int_t iMatcherTask = 0; iMatcherTask < 3; iMatcherTask++){
+    AliCaloTrackMatcher* temp = (AliCaloTrackMatcher*) (AliAnalysisManager::GetAnalysisManager()->GetTask(Form("CaloTrackMatcher_%i",iMatcherTask)));
+    if(temp) fOutputContainer->Add(temp->GetCaloTrackMatcherHistograms());
+  }
+
+  fPionSelector=(AliPrimaryPionSelector*)AliAnalysisManager::GetAnalysisManager()->GetTask("PionSelector");
+  if(!fPionSelector){printf("Error: No PionSelector");return;} // GetV0Reader
+
+  if( fPionSelector && (!fDoLightOutput)){
+    if ( ((AliPrimaryPionCuts*)fPionSelector->GetPrimaryPionCuts())->GetCutHistograms() ){
+      fOutputContainer->Add( ((AliPrimaryPionCuts*)fPionSelector->GetPrimaryPionCuts())->GetCutHistograms() );
+    }
+  }
+
+  for(Int_t iCut = 0; iCut<fnCuts;iCut++){
+    if( fEventCutArray) {
+      if( ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetCutHistograms() ) {
+        fCutFolder[iCut]->Add( ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetCutHistograms());
+      }
+    }
+
+    if( fPionCutArray){
+      if( ((AliPrimaryPionCuts*)fPionCutArray->At(iCut))->GetCutHistograms() ) {
+        fCutFolder[iCut]->Add( ((AliPrimaryPionCuts*)fPionCutArray->At(iCut))->GetCutHistograms() );
+      }
+    }
+    if (fNDMRecoMode < 2){
+      if( fGammaCutArray ) {
+        if( ((AliConversionPhotonCuts*)fGammaCutArray->At(iCut))->GetCutHistograms() ) {
+          fCutFolder[iCut]->Add( ((AliConversionPhotonCuts*)fGammaCutArray->At(iCut))->GetCutHistograms()  );
+        }
+      }
+    }
+    if (fNDMRecoMode > 0){
+      if( fClusterCutArray ) {
+        if( ((AliCaloPhotonCuts*)fClusterCutArray->At(iCut))->GetCutHistograms() ) {
+          fCutFolder[iCut]->Add( ((AliCaloPhotonCuts*)fClusterCutArray->At(iCut))->GetCutHistograms()  );
+        }
+      }
+    }
+    if( fNeutralDecayMesonCutArray ) {
+      if( ((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(iCut))->GetCutHistograms() ) {
+        fCutFolder[iCut]->Add( ((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(iCut))->GetCutHistograms());
+      }
+    }
+    if( fMesonCutArray ) {
+      if( ((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->GetCutHistograms() ) {
+        fCutFolder[iCut]->Add( ((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->GetCutHistograms());
+      }
+    }
+  }
+
+  PostData(1, fOutputContainer);
+
+}
+
+//______________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::UserExec(Option_t *){
+
+  //
+  // Execute analysis for current event
+  //
+
+  fV0Reader=(AliV0ReaderV1*)AliAnalysisManager::GetAnalysisManager()->GetTask(fV0ReaderName.Data());
+  if(!fV0Reader){printf("Error: No V0 Reader");return;} // GetV0Reader
+
+  Int_t eventQuality = ((AliConvEventCuts*)fV0Reader->GetEventCuts())->GetEventQuality();
+  if(InputEvent()->IsIncompleteDAQ()==kTRUE) eventQuality = 2;  // incomplete event
+  if(eventQuality == 2 || eventQuality == 3){// Event Not Accepted due to MC event missing or wrong trigger for V0ReaderV1 or because it is incomplete
+    for(Int_t iCut = 0; iCut<fnCuts; iCut++){
+      fHistoNEvents[iCut]->Fill(eventQuality);
+    }
+    return;
+  }
+
+  fPionSelector=(AliPrimaryPionSelector*)AliAnalysisManager::GetAnalysisManager()->GetTask("PionSelector");
+  if(!fPionSelector){printf("Error: No PionSelector");return;} // GetV0Reader
+
+  if(fIsMC) fMCEvent     =  MCEvent();
+  fESDEvent        = (AliESDEvent*)InputEvent();
+  fReaderGammas    = fV0Reader->GetReconstructedGammas(); // Gammas from default Cut
+  fSelectorNegPionIndex = fPionSelector->GetReconstructedNegPionIndex(); // Electrons from default Cut
+  fSelectorPosPionIndex = fPionSelector->GetReconstructedPosPionIndex(); // Positrons from default Cut
+
+  fNumberOfESDTracks = fV0Reader->GetNumberOfPrimaryTracks();
+  //AddTaskContainers(); //Add conatiner
+
+  for(Int_t iCut = 0; iCut<fnCuts; iCut++){
+    fiCut = iCut;
+
+    Bool_t isRunningEMCALrelAna = kFALSE;
+    if (fNDMRecoMode > 0){
+      if (((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->GetClusterType() == 1) isRunningEMCALrelAna = kTRUE;
+    }
+
+    Int_t eventNotAccepted = ((AliConvEventCuts*)fEventCutArray->At(iCut))->IsEventAcceptedByCut(fV0Reader->GetEventCuts(),fInputEvent,fMCEvent,fIsHeavyIon, isRunningEMCALrelAna);
+
+    if(eventNotAccepted){
+      // 			cout << "event rejected due to wrong trigger: " <<eventNotAccepted << endl;
+      fHistoNEvents[iCut]->Fill(eventNotAccepted); // Check Centrality, PileUp, SDD and V0AND --> Not Accepted => eventQuality = 1
+      continue;
+    }
+
+    if(eventQuality != 0){// Event Not Accepted
+      // 			cout << "event rejected due to: " <<eventQuality << endl;
+      fHistoNEvents[iCut]->Fill(eventQuality);
+      continue;
+    }
+
+    fHistoNEvents[iCut]->Fill(eventQuality);
+    fHistoNGoodESDTracks[iCut]->Fill(fNumberOfESDTracks);
+    if(!fDoLightOutput){
+        fHistoSPDClusterTrackletBackground[iCut]->Fill(fInputEvent->GetMultiplicity()->GetNumberOfTracklets(),(fInputEvent->GetNumberOfITSClusters(0)+fInputEvent->GetNumberOfITSClusters(1)));
+    }
+    if(fMCEvent){ // Process MC Particle
+      if(((AliConvEventCuts*)fEventCutArray->At(iCut))->GetSignalRejection() != 0){
+        ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetNotRejectedParticles(((AliConvEventCuts*)fEventCutArray->At(iCut))->GetSignalRejection(),
+                                            ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetAcceptedHeader(),
+                                            fMCEvent);
+      }
+      ProcessMCParticles();
+    }
+
+    if (fNDMRecoMode < 2){
+      ProcessConversionPhotonCandidates(); // Process this cuts conversion gammas
+    }
+    if (fNDMRecoMode > 0){
+      ProcessCaloPhotonCandidates(); // Process this cuts calo gammas
+    }
+
+    if (fNDMRecoMode == 0 ){
+      ProcessNeutralDecayMesonCandidatesPureConversions(); // Process neutral pion candidates purely from conversions
+    }
+    if (fNDMRecoMode == 1){
+      ProcessNeutralPionCandidatesMixedConvCalo(); // Process neutral pion candidates mixed conv and calo
+    }
+    if (fNDMRecoMode == 2){
+      ProcessNeutralPionCandidatesPureCalo(); // Process neutral pion candidates purely from calo
+    }
+
+    ProcessPionCandidates(); // Process this cuts gammas
+
+    CalculateMesonCandidates();
+    CalculateBackground();
+    UpdateEventByEventData();
+
+    fVectorDoubleCountTruePi0s.clear();
+    fVectorDoubleCountTrueHNMs.clear();
+    fVectorDoubleCountTrueConvGammas.clear();
+
+    fGoodConvGammas->Clear();
+    fClusterCandidates->Clear();
+    fNeutralDecayParticleCandidates->Clear();
+    if(fNeutralDecayParticleSidebandCandidates) fNeutralDecayParticleSidebandCandidates->Clear();
+    fPosPionCandidates->Clear();
+    fNegPionCandidates->Clear();
+    fGoodVirtualParticles->Clear(); // delete this cuts good gammas
+  }
+
+  fSelectorNegPionIndex.clear();
+  fSelectorPosPionIndex.clear();
+
+  PostData( 1, fOutputContainer );
+}
+//________________________________________________________________________
+Bool_t AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::Notify(){
+  for(Int_t iCut = 0; iCut<fnCuts;iCut++){
+    if (((AliConvEventCuts*)fEventCutArray->At(iCut))->GetPeriodEnum() == AliConvEventCuts::kNoPeriod && ((AliConvEventCuts*)fV0Reader->GetEventCuts())->GetPeriodEnum() != AliConvEventCuts::kNoPeriod){
+        ((AliConvEventCuts*)fEventCutArray->At(iCut))->SetPeriodEnumExplicit(((AliConvEventCuts*)fV0Reader->GetEventCuts())->GetPeriodEnum());
+    } else if (((AliConvEventCuts*)fEventCutArray->At(iCut))->GetPeriodEnum() == AliConvEventCuts::kNoPeriod ){
+      ((AliConvEventCuts*)fEventCutArray->At(iCut))->SetPeriodEnum(fV0Reader->GetPeriodName());
+    }
+
+    if( !((AliConvEventCuts*)fEventCutArray->At(iCut))->GetDoEtaShift() ){
+      if(!fDoLightOutput){
+        fProfileEtaShift[iCut]->Fill(0.,0.);
+      }
+      continue; // No Eta Shift requested, continue
+    }
+    if( ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetEtaShift() == 0.0){ // Eta Shift requested but not set, get shift automatically
+      ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetCorrectEtaShiftFromPeriod();
+      ((AliConvEventCuts*)fEventCutArray->At(iCut))->DoEtaShift(kFALSE); // Eta Shift Set, make sure that it is called only once
+      ((AliPrimaryPionCuts*)fPionCutArray->At(iCut))->SetEtaShift( ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetEtaShift() );
+      if(!fDoLightOutput){
+        fProfileEtaShift[iCut]->Fill(0.,(((AliConvEventCuts*)fEventCutArray->At(iCut))->GetEtaShift()));
+      }
+      continue;
+    } else {
+      printf(" Eta t PiPlusPiMinus Gamma Task %s :: Eta Shift Manually Set to %f \n\n",
+      (((AliConvEventCuts*)fEventCutArray->At(iCut))->GetCutNumber()).Data(),((AliConvEventCuts*)fEventCutArray->At(iCut))->GetEtaShift());
+      ((AliConvEventCuts*)fEventCutArray->At(iCut))->DoEtaShift(kFALSE); // Eta Shift Set, make sure that it is called only once
+      ((AliPrimaryPionCuts*)fPionCutArray->At(iCut))->SetEtaShift( ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetEtaShift() );
+      if(!fDoLightOutput){
+        fProfileEtaShift[iCut]->Fill(0.,(((AliConvEventCuts*)fEventCutArray->At(iCut))->GetEtaShift()));
+      }
+    }
+  }
+  return kTRUE;
+}
+
+
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::Terminate(const Option_t *){
+///Grid
+}
+
+
+//________________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessCaloPhotonCandidates()
+{
+
+  Int_t nclus = 0;
+  nclus = fInputEvent->GetNumberOfCaloClusters();
+
+  // 	cout << nclus << endl;
+
+  if(nclus == 0)	return;
+
+  // vertex
+  Double_t vertex[3] = {0};
+  InputEvent()->GetPrimaryVertex()->GetXYZ(vertex);
+
+  // Loop over EMCal clusters
+  for(Long_t i = 0; i < nclus; i++){
+
+    AliVCluster* clus = NULL;
+    if(fInputEvent->IsA()==AliESDEvent::Class()) clus = new AliESDCaloCluster(*(AliESDCaloCluster*)fInputEvent->GetCaloCluster(i));
+    else if(fInputEvent->IsA()==AliAODEvent::Class()) clus = new AliAODCaloCluster(*(AliAODCaloCluster*)fInputEvent->GetCaloCluster(i));
+
+    if (!clus) continue;
+    if(!((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelected(clus,fInputEvent,fMCEvent,fIsMC,1.,i)){ delete clus; continue;}
+    // TLorentzvector with cluster
+    TLorentzVector clusterVector;
+    clus->GetMomentum(clusterVector,vertex);
+
+    TLorentzVector* tmpvec = new TLorentzVector();
+    tmpvec->SetPxPyPzE(clusterVector.Px(),clusterVector.Py(),clusterVector.Pz(),clusterVector.E());
+
+    // convert to AODConversionPhoton
+    AliAODConversionPhoton *PhotonCandidate=new AliAODConversionPhoton(tmpvec);
+    if(!PhotonCandidate){ delete clus; delete tmpvec; continue;}
+
+    // Flag Photon as CaloPhoton
+    PhotonCandidate->SetIsCaloPhoton();
+    PhotonCandidate->SetCaloClusterRef(i);
+    // get MC label
+    if(fIsMC){
+      Int_t* mclabelsCluster = clus->GetLabels();
+      PhotonCandidate->SetNCaloPhotonMCLabels(clus->GetNLabels());
+			// cout << clus->GetNLabels() << endl;
+      if (clus->GetNLabels()>0){
+        for (Int_t k =0; k< (Int_t)clus->GetNLabels(); k++){
+          if (k< 50)PhotonCandidate->SetCaloPhotonMCLabel(k,mclabelsCluster[k]);
+					// Int_t pdgCode = fMCEvent->Particle(mclabelsCluster[k])->GetPdgCode();
+					// cout << "label " << k << "\t" << mclabelsCluster[k] << " pdg code: " << pdgCode << endl;
+        }
+      }
+    }
+
+    fIsFromMBHeader = kTRUE;
+    // test whether largest contribution to cluster orginates in added signals
+    if (fIsMC && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetCaloPhotonMCLabel(0), fMCEvent, fInputEvent) == 0) fIsFromMBHeader = kFALSE;
+
+    if (fIsFromMBHeader && (!fDoLightOutput)){
+      fHistoClusterGammaPt[fiCut]->Fill(PhotonCandidate->Pt());
+      fHistoClusterGammaEta[fiCut]->Fill(PhotonCandidate->Eta());
+    }
+    fClusterCandidates->Add(PhotonCandidate); // if no second loop is required add to events good gammas
+
+    if(fIsMC){
+			// if(fInputEvent->IsA()==AliESDEvent::Class()){
+        ProcessTrueCaloPhotonCandidates(PhotonCandidate);
+			// } else {
+				// ProcessTrueClusterCandidatesAOD(PhotonCandidate);
+			// }
+    }
+
+    delete clus;
+    delete tmpvec;
+  }
+
+}
+
+//________________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessTrueCaloPhotonCandidates(AliAODConversionPhoton *TruePhotonCandidate)
+{
+  TParticle *Photon = NULL;
+  if (!TruePhotonCandidate->GetIsCaloPhoton()) AliFatal("CaloPhotonFlag has not been set task will abort");
+    if (TruePhotonCandidate->GetCaloPhotonMCLabel(0)<0) return;
+	// fHistoTrueNLabelsInClus[fiCut]->Fill(TruePhotonCandidate->GetNCaloPhotonMCLabels());
+
+  const AliVVertex* primVtxMC 	= fMCEvent->GetPrimaryVertex();
+  Double_t mcProdVtxX 	= primVtxMC->GetX();
+  Double_t mcProdVtxY 	= primVtxMC->GetY();
+  Double_t mcProdVtxZ 	= primVtxMC->GetZ();
+
+  if (TruePhotonCandidate->GetNCaloPhotonMCLabels()>0)Photon = fMCEvent->Particle(TruePhotonCandidate->GetCaloPhotonMCLabel(0));
+    else return;
+
+  if(Photon == NULL){
+  //    cout << "no photon" << endl;
+    return;
+  }
+
+	// Int_t pdgCodeParticle = Photon->GetPdgCode();
+  TruePhotonCandidate->SetCaloPhotonMCFlags(fMCEvent, kFALSE);
+
+  // True Photon
+  if(fIsFromMBHeader && (!fDoLightOutput)){
+    Bool_t isPrimary = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryESD( fMCEvent, TruePhotonCandidate->GetCaloPhotonMCLabel(0), mcProdVtxX, mcProdVtxY, mcProdVtxZ);
+    if(isPrimary){
+      if (TruePhotonCandidate->IsLargestComponentPhoton()){
+        fHistoTrueClusterGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt());
+        if (GammaIsNeutralMesonPiPlPiMiNDMDaughter(TruePhotonCandidate->GetCaloPhotonMCLabel(0))){
+          fHistoTrueClusterGammaFromNeutralMesonPt[fiCut]->Fill(TruePhotonCandidate->Pt());
+        }
+      }
+      if (TruePhotonCandidate->IsLargestComponentElectron() && TruePhotonCandidate->IsConversion()){
+          fHistoTrueClusterGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt());
+          if (GammaIsNeutralMesonPiPlPiMiNDMDaughter(TruePhotonCandidate->GetCaloPhotonMCLabel(0))){
+          fHistoTrueClusterGammaFromNeutralMesonPt[fiCut]->Fill(TruePhotonCandidate->Pt());
+        }
+      }
+    }
+  }
+  return;
+}
+
+
+
+//________________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessConversionPhotonCandidates(){
+  Int_t nV0 = 0;
+  TList *GoodGammasStepOne = new TList();
+  TList *GoodGammasStepTwo = new TList();
+  // Loop over Photon Candidates allocated by ReaderV1
+
+  for(Int_t i = 0; i < fReaderGammas->GetEntriesFast(); i++){
+    AliAODConversionPhoton* PhotonCandidate = (AliAODConversionPhoton*) fReaderGammas->At(i);
+    if(!PhotonCandidate) continue;
+
+    fIsFromMBHeader = kTRUE;
+
+    if( fMCEvent && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 0 ){
+      Int_t isPosFromMBHeader
+        = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelPositive(), fMCEvent, fInputEvent);
+      if(isPosFromMBHeader == 0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 3) continue;
+      Int_t isNegFromMBHeader
+        = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelNegative(), fMCEvent,fInputEvent);
+      if(isNegFromMBHeader == 0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 3) continue;
+      if( (isNegFromMBHeader+isPosFromMBHeader) != 4) fIsFromMBHeader = kFALSE;
+    }
+
+    if(!((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelected(PhotonCandidate,fESDEvent)) continue;
+
+    if(!((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->UseElecSharingCut() &&
+      !((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->UseToCloseV0sCut()){ // if no post reader loop is required add to events good gammas
+
+      fGoodConvGammas->Add(PhotonCandidate);
+
+      if(fIsFromMBHeader && (!fDoLightOutput)){
+        fHistoConvGammaPt[fiCut]->Fill(PhotonCandidate->Pt());
+        fHistoConvGammaEta[fiCut]->Fill(PhotonCandidate->Eta());
+      }
+
+      if(fMCEvent){
+        ProcessTrueConversionPhotonCandidates(PhotonCandidate);
+      }
+    } else if(((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->UseElecSharingCut()){ // if Shared Electron cut is enabled, Fill array, add to step one
+      ((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->FillElectonLabelArray(PhotonCandidate,nV0);
+      nV0++;
+      GoodGammasStepOne->Add(PhotonCandidate);
+    } else if(!((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->UseElecSharingCut() &&
+        ((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->UseToCloseV0sCut()){ // shared electron is disabled, step one not needed -> step two
+      GoodGammasStepTwo->Add(PhotonCandidate);
+    }
+  }
+
+
+  if(((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->UseElecSharingCut()){
+    for(Int_t i = 0;i<GoodGammasStepOne->GetEntries();i++){
+      AliAODConversionPhoton *PhotonCandidate= (AliAODConversionPhoton*) GoodGammasStepOne->At(i);
+      if(!PhotonCandidate) continue;
+      fIsFromMBHeader = kTRUE;
+      if(fMCEvent && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 0){
+        Int_t isPosFromMBHeader
+        = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelPositive(), fMCEvent,fInputEvent);
+        Int_t isNegFromMBHeader
+        = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelNegative(), fMCEvent,fInputEvent);
+        if( (isNegFromMBHeader+isPosFromMBHeader) != 4) fIsFromMBHeader = kFALSE;
+      }
+      if(!((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->RejectSharedElectronV0s(PhotonCandidate,i,GoodGammasStepOne->GetEntries())) continue;
+      if(!((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->UseToCloseV0sCut()){ // To Colse v0s cut diabled, step two not needed
+        fGoodConvGammas->Add(PhotonCandidate);
+        if(fIsFromMBHeader && (!fDoLightOutput)){
+          fHistoConvGammaPt[fiCut]->Fill(PhotonCandidate->Pt());
+          fHistoConvGammaEta[fiCut]->Fill(PhotonCandidate->Eta());
+        }
+        if(fMCEvent){
+          ProcessTrueConversionPhotonCandidates(PhotonCandidate);
+        }
+      }
+      else GoodGammasStepTwo->Add(PhotonCandidate); // Close v0s cut enabled -> add to list two
+    }
+  }
+  if(((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->UseToCloseV0sCut()){
+    for(Int_t i = 0;i<GoodGammasStepTwo->GetEntries();i++){
+      AliAODConversionPhoton* PhotonCandidate = (AliAODConversionPhoton*) GoodGammasStepTwo->At(i);
+      if(!PhotonCandidate) continue;
+
+      if(fMCEvent && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 0){
+        Int_t isPosFromMBHeader
+        = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelPositive(), fMCEvent,fInputEvent);
+        Int_t isNegFromMBHeader
+        = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(PhotonCandidate->GetMCLabelNegative(), fMCEvent,fInputEvent);
+        if( (isNegFromMBHeader+isPosFromMBHeader) != 4) fIsFromMBHeader = kFALSE;
+      }
+
+      if(!((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->RejectToCloseV0s(PhotonCandidate,GoodGammasStepTwo,i)) continue;
+      fGoodConvGammas->Add(PhotonCandidate); // Add gamma to current cut TList
+
+      if(fIsFromMBHeader && (!fDoLightOutput)){
+        fHistoConvGammaPt[fiCut]->Fill(PhotonCandidate->Pt()); // Differences to old V0Reader in p_t due to conversion KF->TLorentzVector
+        fHistoConvGammaEta[fiCut]->Fill(PhotonCandidate->Eta());
+      }
+
+      if(fMCEvent){
+        ProcessTrueConversionPhotonCandidates(PhotonCandidate);
+      }
+    }
+  }
+
+  delete GoodGammasStepOne;
+  GoodGammasStepOne = 0x0;
+  delete GoodGammasStepTwo;
+  GoodGammasStepTwo = 0x0;
+}
+
+//________________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessTrueConversionPhotonCandidates(AliAODConversionPhoton *TruePhotonCandidate)
+{
+  // Process True Photons
+  TParticle *posDaughter = TruePhotonCandidate->GetPositiveMCDaughter(fMCEvent);
+  TParticle *negDaughter = TruePhotonCandidate->GetNegativeMCDaughter(fMCEvent);
+
+  const AliVVertex* primVtxMC 	= fMCEvent->GetPrimaryVertex();
+  Double_t mcProdVtxX 	= primVtxMC->GetX();
+  Double_t mcProdVtxY 	= primVtxMC->GetY();
+  Double_t mcProdVtxZ 	= primVtxMC->GetZ();
+
+
+  if(posDaughter == NULL || negDaughter == NULL) return; // One particle does not exist
+  if(posDaughter->GetMother(0) != negDaughter->GetMother(0)){  // Not Same Mother == Combinatorial Bck
+    return;
+  }
+
+  else if (posDaughter->GetMother(0) == -1){
+    return;
+  }
+
+  if(TMath::Abs(posDaughter->GetPdgCode())!=11 || TMath::Abs(negDaughter->GetPdgCode())!=11) return; //One Particle is not electron
+  if(posDaughter->GetPdgCode()==negDaughter->GetPdgCode()) return; // Same Charge
+  if(posDaughter->GetUniqueID() != 5 || negDaughter->GetUniqueID() !=5) return;// check if the daughters come from a conversion
+
+  TParticle *Photon = TruePhotonCandidate->GetMCParticle(fMCEvent);
+  if(Photon->GetPdgCode() != 22) return; // Mother is no Photon
+
+  // True Photon
+
+  if (CheckVectorForDoubleCount(fVectorDoubleCountTrueConvGammas,posDaughter->GetMother(0)) && (!fDoLightOutput)) fHistoDoubleCountTrueConvGammaRPt[fiCut]->Fill(TruePhotonCandidate->GetConversionRadius(),TruePhotonCandidate->Pt());
+
+  Int_t labelGamma = TruePhotonCandidate->GetMCParticleLabel(fMCEvent);
+  Bool_t gammaIsPrimary = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryESD( fMCEvent, labelGamma, mcProdVtxX, mcProdVtxY, mcProdVtxZ);
+  if( gammaIsPrimary ){
+    if( fIsFromMBHeader && (!fDoLightOutput) ){
+      fHistoTrueConvGammaPt[fiCut]->Fill(TruePhotonCandidate->Pt());
+      if (GammaIsNeutralMesonPiPlPiMiNDMDaughter(labelGamma)){
+        fHistoTrueConvGammaFromNeutralMesonPt[fiCut]->Fill(TruePhotonCandidate->Pt());
+      }
+    }
+  }
+}
+
+//________________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessNeutralDecayMesonCandidatesPureConversions(){
+  // Conversion Gammas
+  if(fGoodConvGammas->GetEntries()>1){
+    for(Int_t firstGammaIndex=0;firstGammaIndex<fGoodConvGammas->GetEntries()-1;firstGammaIndex++){
+      AliAODConversionPhoton *gamma0=dynamic_cast<AliAODConversionPhoton*>(fGoodConvGammas->At(firstGammaIndex));
+      if (gamma0==NULL) continue;
+      for(Int_t secondGammaIndex=firstGammaIndex+1;secondGammaIndex<fGoodConvGammas->GetEntries();secondGammaIndex++){
+        AliAODConversionPhoton *gamma1=dynamic_cast<AliAODConversionPhoton*>(fGoodConvGammas->At(secondGammaIndex));
+        //Check for same Electron ID
+        if (gamma1==NULL) continue;
+        if(gamma0->GetTrackLabelPositive() == gamma1->GetTrackLabelPositive() ||
+        gamma0->GetTrackLabelNegative() == gamma1->GetTrackLabelNegative() ||
+        gamma0->GetTrackLabelNegative() == gamma1->GetTrackLabelPositive() ||
+        gamma0->GetTrackLabelPositive() == gamma1->GetTrackLabelNegative() ) continue;
+
+        AliAODConversionMother *NDMcand = new AliAODConversionMother(gamma0,gamma1);
+        NDMcand->SetLabels(firstGammaIndex,secondGammaIndex);
+
+        NDMcand->CalculateDistanceOfClossetApproachToPrimVtx(fInputEvent->GetPrimaryVertex());
+        if((((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->MesonIsSelected(NDMcand,kTRUE,((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift()))){
+          if(!fDoLightOutput){
+              fHistoGammaGammaInvMassPt[fiCut]->Fill(NDMcand->M(),NDMcand->Pt());
+          }
+          if(fIsMC){
+            if(fInputEvent->IsA()==AliESDEvent::Class())
+              ProcessTrueNeutralPionCandidatesPureConversions(NDMcand,gamma0,gamma1);
+            if(fInputEvent->IsA()==AliAODEvent::Class())
+              ProcessTrueNeutralPionCandidatesPureConversionsAOD(NDMcand,gamma0,gamma1);
+          }
+          if (((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(NDMcand, 0)){
+            fNeutralDecayParticleCandidates->Add(NDMcand);
+          } else if((((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->UseSidebandMixing()) &&
+                    (((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(NDMcand, 1))){
+            fNeutralDecayParticleSidebandCandidates->Add(NDMcand);
+          } else if((((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->UseSidebandMixingBothSides()) &&
+                    ((((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(NDMcand, 2)) ||
+                     ((((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(NDMcand, 3))))){
+            fNeutralDecayParticleSidebandCandidates->Add(NDMcand);
+          } else{
+            delete NDMcand;
+            NDMcand=0x0;
+          }
+        }else{
+          delete NDMcand;
+          NDMcand=0x0;
+        }
+      }
+    }
+  }
+}
+
+
+//________________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessNeutralPionCandidatesPureCalo(){
+
+  // Conversion Gammas
+  if(fClusterCandidates->GetEntries()>0){
+
+    // vertex
+    Double_t vertex[3] = {0};
+    InputEvent()->GetPrimaryVertex()->GetXYZ(vertex);
+
+    for(Int_t firstGammaIndex=0;firstGammaIndex<fClusterCandidates->GetEntries();firstGammaIndex++){
+      AliAODConversionPhoton *gamma0=dynamic_cast<AliAODConversionPhoton*>(fClusterCandidates->At(firstGammaIndex));
+      if (gamma0==NULL) continue;
+
+      for(Int_t secondGammaIndex=0;secondGammaIndex<fClusterCandidates->GetEntries();secondGammaIndex++){
+        if (firstGammaIndex == secondGammaIndex) continue;
+        AliAODConversionPhoton *gamma1=dynamic_cast<AliAODConversionPhoton*>(fClusterCandidates->At(secondGammaIndex));
+        if (gamma1==NULL) continue;
+
+        AliAODConversionMother *NDMcand = new AliAODConversionMother(gamma0,gamma1);
+        NDMcand->SetLabels(firstGammaIndex,secondGammaIndex);
+
+        if((((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->MesonIsSelected(NDMcand,kTRUE,((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift()))){
+          if(!fDoLightOutput){
+              fHistoGammaGammaInvMassPt[fiCut]->Fill(NDMcand->M(),NDMcand->Pt());
+          }
+          if(fIsMC){
+            ProcessTrueNeutralPionCandidatesPureCalo(NDMcand,gamma0,gamma1);
+          }
+
+          if (((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(NDMcand, 0)){
+            fNeutralDecayParticleCandidates->Add(NDMcand);
+          } else if((((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->UseSidebandMixing()) &&
+                    (((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(NDMcand, 1))){
+            fNeutralDecayParticleSidebandCandidates->Add(NDMcand);
+          } else if((((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->UseSidebandMixingBothSides()) &&
+                    ((((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(NDMcand, 2)) ||
+                      ((((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(NDMcand, 3))))){
+            fNeutralDecayParticleSidebandCandidates->Add(NDMcand);
+          }else {
+            delete NDMcand;
+            NDMcand=0x0;
+          }
+        } else{
+          delete NDMcand;
+          NDMcand=0x0;
+        }
+      }
+    }
+  }
+}
+
+//______________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessTrueNeutralPionCandidatesPureCalo( AliAODConversionMother *Pi0Candidate, AliAODConversionPhoton *TrueGammaCandidate0, AliAODConversionPhoton *TrueGammaCandidate1)
+{
+  // Process True Mesons
+
+  Bool_t isTrueNDM = kFALSE;
+  Int_t gamma0MCLabel = TrueGammaCandidate0->GetCaloPhotonMCLabel(0); 	// get most probable MC label
+  Int_t gamma0MotherLabel = -1;
+  Int_t motherRealLabel = -1;
+
+  if(gamma0MCLabel != -1){ // Gamma is Combinatorial; MC Particles don't belong to the same Mother
+    TParticle * gammaMC0 = (TParticle*)fMCEvent->Particle(gamma0MCLabel);
+    if (TrueGammaCandidate0->IsLargestComponentPhoton() || TrueGammaCandidate0->IsLargestComponentElectron()){		// largest component is electro magnetic
+      // get mother of interest (pi0 or eta)
+      if (TrueGammaCandidate0->IsLargestComponentPhoton()){														// for photons its the direct mother
+        gamma0MotherLabel=gammaMC0->GetMother(0);
+        motherRealLabel=gammaMC0->GetFirstMother();
+      } else if (TrueGammaCandidate0->IsLargestComponentElectron()){ 												// for electrons its either the direct mother or for conversions the grandmother
+                if (TrueGammaCandidate0->IsConversion() && gammaMC0->GetMother(0)>-1){
+          gamma0MotherLabel=fMCEvent->Particle(gammaMC0->GetMother(0))->GetMother(0);
+          motherRealLabel=fMCEvent->Particle(gammaMC0->GetMother(0))->GetMother(0);
+        } else {
+          gamma0MotherLabel=gammaMC0->GetMother(0);
+          motherRealLabel=gammaMC0->GetMother(0);
+        }
+      }
+    }
+  }
+
+  if (!TrueGammaCandidate1->GetIsCaloPhoton()) AliFatal("CaloPhotonFlag has not been set. Aborting");
+
+  Int_t gamma1MCLabel = TrueGammaCandidate1->GetCaloPhotonMCLabel(0); 	// get most probable MC label
+  Int_t gamma1MotherLabel = -1;
+  // check if
+  if(gamma1MCLabel != -1){ // Gamma is Combinatorial; MC Particles don't belong to the same Mother
+    // Daughters Gamma 1
+    TParticle * gammaMC1 = (TParticle*)fMCEvent->Particle(gamma1MCLabel);
+    if (TrueGammaCandidate1->IsLargestComponentPhoton() || TrueGammaCandidate1->IsLargestComponentElectron()){		// largest component is electro magnetic
+      // get mother of interest (pi0 or eta)
+      if (TrueGammaCandidate1->IsLargestComponentPhoton()){														// for photons its the direct mother
+        gamma1MotherLabel=gammaMC1->GetMother(0);
+      } else if (TrueGammaCandidate1->IsLargestComponentElectron()){ 												// for electrons its either the direct mother or for conversions the grandmother
+                if (TrueGammaCandidate1->IsConversion() && gammaMC1->GetMother(0)>-1) gamma1MotherLabel=fMCEvent->Particle(gammaMC1->GetMother(0))->GetMother(0);
+        else gamma1MotherLabel=gammaMC1->GetMother(0);
+      }
+    }
+  }
+
+  if(gamma0MotherLabel>=0 && gamma0MotherLabel==gamma1MotherLabel){
+    if(((TParticle*)fMCEvent->Particle(gamma1MotherLabel))->GetPdgCode() == fPDGCodeNDM){
+      isTrueNDM=kTRUE;
+      if (CheckVectorForDoubleCount(fVectorDoubleCountTruePi0s,gamma0MotherLabel) && (!fDoLightOutput)) fHistoDoubleCountTruePi0InvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+    }
+  }
+
+  if(isTrueNDM){// True Pion
+    Pi0Candidate->SetTrueMesonValue(1);
+    Pi0Candidate->SetMCLabel(motherRealLabel);
+    if(!fDoLightOutput){
+      fHistoTrueMotherGammaGammaInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+      switch( fSelectedHeavyNeutralMeson ) {
+      case 0: // ETA MESON
+        if( IsEtaPiPlPiMiPiZeroDaughter(motherRealLabel) )
+            fHistoTrueMotherGammaGammaFromHNMInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+        break;
+      case 1: // OMEGA MESON
+        if( IsOmegaPiPlPiMiPiZeroDaughter(motherRealLabel) )
+            fHistoTrueMotherGammaGammaFromHNMInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+        break;
+      case 2: // ETA PRIME MESON
+        if( IsEtaPrimePiPlPiMiEtaDaughter(motherRealLabel) )
+            fHistoTrueMotherGammaGammaFromHNMInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+        break;
+      default:
+        AliError(Form("Heavy neutral meson not correctly selected (only 0,1,2 valid)... selected: %d",fSelectedHeavyNeutralMeson));
+      }
+    }
+  }
+}
+
+
+
+//______________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessTrueNeutralPionCandidatesPureConversions(AliAODConversionMother *Pi0Candidate, AliAODConversionPhoton *TrueGammaCandidate0, AliAODConversionPhoton *TrueGammaCandidate1)
+{
+  // Process True Mesons
+  if(TrueGammaCandidate0->GetV0Index()<fInputEvent->GetNumberOfV0s()){
+    Bool_t isTrueNDM = kFALSE;
+    Bool_t isTruePi0Dalitz = kFALSE;
+    Bool_t gamma0DalitzCand = kFALSE;
+    Bool_t gamma1DalitzCand = kFALSE;
+    Int_t gamma0MCLabel = TrueGammaCandidate0->GetMCParticleLabel(fMCEvent);
+    Int_t gamma0MotherLabel = -1;
+    Int_t motherRealLabel = -1;
+    if(gamma0MCLabel != -1){ // Gamma is Combinatorial; MC Particles don't belong to the same Mother
+      // Daughters Gamma 0
+      TParticle * negativeMC = (TParticle*)TrueGammaCandidate0->GetNegativeMCDaughter(fMCEvent);
+      TParticle * positiveMC = (TParticle*)TrueGammaCandidate0->GetPositiveMCDaughter(fMCEvent);
+      TParticle * gammaMC0 = (TParticle*)fMCEvent->Particle(gamma0MCLabel);
+      if(TMath::Abs(negativeMC->GetPdgCode())==11 && TMath::Abs(positiveMC->GetPdgCode())==11){  // Electrons ...
+        if(negativeMC->GetUniqueID() == 5 && positiveMC->GetUniqueID() ==5){ // ... From Conversion ...
+          if(gammaMC0->GetPdgCode() == 22){ // ... with Gamma Mother
+            gamma0MotherLabel=gammaMC0->GetFirstMother();
+            motherRealLabel=gammaMC0->GetFirstMother();
+          }
+        }
+        if(gammaMC0->GetPdgCode() ==111){ // Dalitz candidate
+          gamma0DalitzCand = kTRUE;
+          gamma0MotherLabel=-111;
+          motherRealLabel=gamma0MCLabel;
+        }
+      }
+    }
+    if(TrueGammaCandidate1->GetV0Index()<fInputEvent->GetNumberOfV0s()){
+      Int_t gamma1MCLabel = TrueGammaCandidate1->GetMCParticleLabel(fMCEvent);
+      Int_t gamma1MotherLabel = -1;
+      if(gamma1MCLabel != -1){ // Gamma is Combinatorial; MC Particles don't belong to the same Mother
+        // Daughters Gamma 1
+        TParticle * negativeMC = (TParticle*)TrueGammaCandidate1->GetNegativeMCDaughter(fMCEvent);
+        TParticle * positiveMC = (TParticle*)TrueGammaCandidate1->GetPositiveMCDaughter(fMCEvent);
+        TParticle * gammaMC1 = (TParticle*)fMCEvent->Particle(gamma1MCLabel);
+        if(TMath::Abs(negativeMC->GetPdgCode())==11 && TMath::Abs(positiveMC->GetPdgCode())==11){  // Electrons ...
+          if(negativeMC->GetUniqueID() == 5 && positiveMC->GetUniqueID() ==5){ // ... From Conversion ...
+            if(gammaMC1->GetPdgCode() == 22){ // ... with Gamma Mother
+              gamma1MotherLabel=gammaMC1->GetFirstMother();
+            }
+          }
+          if(gammaMC1->GetPdgCode() ==111 ){ // Dalitz candidate
+            gamma1DalitzCand = kTRUE;
+            gamma1MotherLabel=-111;
+          }
+        }
+      }
+      if(gamma0MotherLabel>=0 && gamma0MotherLabel==gamma1MotherLabel){
+        if(((TParticle*)fMCEvent->Particle(gamma1MotherLabel))->GetPdgCode() == fPDGCodeNDM){
+          isTrueNDM=kTRUE;
+          if (CheckVectorForDoubleCount(fVectorDoubleCountTruePi0s,gamma0MotherLabel) && (!fDoLightOutput)) fHistoDoubleCountTruePi0InvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+        }
+      }
+
+      //Identify Dalitz candidate
+      if (gamma1DalitzCand || gamma0DalitzCand){
+        if (gamma0DalitzCand && gamma0MCLabel >=0 && gamma0MCLabel==gamma1MotherLabel){
+          if (gamma0MotherLabel == -111) isTruePi0Dalitz = kTRUE;
+        }
+        if (gamma1DalitzCand && gamma1MCLabel >=0 && gamma1MCLabel==gamma0MotherLabel){
+          if (gamma1MotherLabel == -111) isTruePi0Dalitz = kTRUE;
+        }
+      }
+
+
+      if(isTrueNDM || isTruePi0Dalitz){// True Pion
+        Pi0Candidate->SetTrueMesonValue(1);
+        Pi0Candidate->SetMCLabel(motherRealLabel);
+        if(!fDoLightOutput){
+          fHistoTrueMotherGammaGammaInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+          switch( fSelectedHeavyNeutralMeson ) {
+          case 0: // ETA MESON
+            if( IsEtaPiPlPiMiPiZeroDaughter(motherRealLabel) )
+                fHistoTrueMotherGammaGammaFromHNMInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+            break;
+          case 1: // OMEGA MESON
+            if( IsOmegaPiPlPiMiPiZeroDaughter(motherRealLabel) )
+                fHistoTrueMotherGammaGammaFromHNMInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+            break;
+          case 2: // ETA PRIME MESON
+            if( IsEtaPrimePiPlPiMiEtaDaughter(motherRealLabel) )
+                fHistoTrueMotherGammaGammaFromHNMInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+            break;
+          default:
+            AliError(Form("Heavy neutral meson not correctly selected (only 0,1,2 valid)... selected: %d",fSelectedHeavyNeutralMeson));
+          }
+        }
+      }
+    }
+  }
+}
+
+//______________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessTrueNeutralPionCandidatesPureConversionsAOD(AliAODConversionMother *Pi0Candidate, AliAODConversionPhoton *TrueGammaCandidate0, AliAODConversionPhoton *TrueGammaCandidate1)
+{
+
+  // Process True Mesons
+  TClonesArray *AODMCTrackArray = dynamic_cast<TClonesArray*>(fInputEvent->FindListObject(AliAODMCParticle::StdBranchName()));
+  Bool_t isTruePi0 = kFALSE;
+  Bool_t isTruePi0Dalitz = kFALSE;
+  Bool_t gamma0DalitzCand = kFALSE;
+  Bool_t gamma1DalitzCand = kFALSE;
+  Int_t motherRealLabel = -1;
+
+  if (AODMCTrackArray!=NULL && TrueGammaCandidate0 != NULL){
+    AliAODMCParticle *positiveMC = static_cast<AliAODMCParticle*>(AODMCTrackArray->At(TrueGammaCandidate0->GetMCLabelPositive()));
+    AliAODMCParticle *negativeMC = static_cast<AliAODMCParticle*>(AODMCTrackArray->At(TrueGammaCandidate0->GetMCLabelNegative()));
+
+    Int_t gamma0MCLabel = -1;
+    Int_t gamma0MotherLabel = -1;
+    if(!positiveMC||!negativeMC)
+      return;
+
+    if(positiveMC->GetMother()>-1&&(negativeMC->GetMother() == positiveMC->GetMother())){
+      gamma0MCLabel = positiveMC->GetMother();
+    }
+
+    if(gamma0MCLabel != -1){ // Gamma is Combinatorial; MC Particles don't belong to the same Mother
+      // Daughters Gamma 0
+      AliAODMCParticle * gammaMC0 = static_cast<AliAODMCParticle*>(AODMCTrackArray->At(gamma0MCLabel));
+      if(TMath::Abs(negativeMC->GetPdgCode())==11 && TMath::Abs(positiveMC->GetPdgCode())==11){  // Electrons ...
+        if(((positiveMC->GetMCProcessCode())) == 5 && ((negativeMC->GetMCProcessCode())) == 5){ // ... From Conversion ...
+          if(gammaMC0->GetPdgCode() == 22){ // ... with Gamma Mother
+            gamma0MotherLabel=gammaMC0->GetMother();
+            motherRealLabel=gammaMC0->GetMother();
+          }
+        }
+        if(gammaMC0->GetPdgCode() ==111){ // Dalitz candidate
+          gamma0DalitzCand = kTRUE;
+          gamma0MotherLabel=-111;
+          motherRealLabel=gamma0MCLabel;
+        }
+      }
+    }
+    positiveMC = static_cast<AliAODMCParticle*>(AODMCTrackArray->At(TrueGammaCandidate1->GetMCLabelPositive()));
+    negativeMC = static_cast<AliAODMCParticle*>(AODMCTrackArray->At(TrueGammaCandidate1->GetMCLabelNegative()));
+
+    Int_t gamma1MCLabel = -1;
+    Int_t gamma1MotherLabel = -1;
+    if(!positiveMC||!negativeMC)
+      return;
+
+    if(positiveMC->GetMother()>-1&&(negativeMC->GetMother() == positiveMC->GetMother())){
+      gamma1MCLabel = positiveMC->GetMother();
+    }
+    if(gamma1MCLabel != -1){ // Gamma is Combinatorial; MC Particles don't belong to the same Mother
+      // Daughters Gamma 1
+      AliAODMCParticle * gammaMC1 = static_cast<AliAODMCParticle*>(AODMCTrackArray->At(gamma1MCLabel));
+      if(TMath::Abs(negativeMC->GetPdgCode())==11 && TMath::Abs(positiveMC->GetPdgCode())==11){  // Electrons ...
+        if(((positiveMC->GetMCProcessCode())) == 5 && ((negativeMC->GetMCProcessCode())) == 5){ // ... From Conversion ...
+          if(gammaMC1->GetPdgCode() == 22){ // ... with Gamma Mother
+          gamma1MotherLabel=gammaMC1->GetMother();
+          }
+        }
+        if(gammaMC1->GetPdgCode() ==111 ){ // Dalitz candidate
+            gamma1DalitzCand = kTRUE;
+            gamma1MotherLabel=-111;
+        }
+      }
+    }
+    if(gamma0MotherLabel>=0 && gamma0MotherLabel==gamma1MotherLabel){
+      if(static_cast<AliAODMCParticle*>(AODMCTrackArray->At(gamma1MotherLabel))->GetPdgCode() == fPDGCodeNDM){
+        isTruePi0=kTRUE;
+        if (CheckVectorForDoubleCount(fVectorDoubleCountTruePi0s,gamma0MotherLabel) &&(!fDoLightOutput)) fHistoDoubleCountTruePi0InvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+      }
+    }
+
+    //Identify Dalitz candidate
+    if (gamma1DalitzCand || gamma0DalitzCand){
+      if (gamma0DalitzCand && gamma0MCLabel >=0 && gamma0MCLabel==gamma1MotherLabel){
+        if (gamma0MotherLabel == -111) isTruePi0Dalitz = kTRUE;
+      }
+      if (gamma1DalitzCand && gamma1MCLabel >=0 && gamma1MCLabel==gamma0MotherLabel){
+        if (gamma1MotherLabel == -111) isTruePi0Dalitz = kTRUE;
+      }
+    }
+
+    if(isTruePi0 || isTruePi0Dalitz){// True Pion
+      Pi0Candidate->SetTrueMesonValue(1);
+      Pi0Candidate->SetMCLabel(motherRealLabel);
+      if(!fDoLightOutput){
+        fHistoTrueMotherGammaGammaInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+        switch( fSelectedHeavyNeutralMeson ) {
+        case 0: // ETA MESON
+          if( IsEtaPiPlPiMiPiZeroDaughter(motherRealLabel) )
+              fHistoTrueMotherGammaGammaFromHNMInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+          break;
+        case 1: // OMEGA MESON
+          if( IsOmegaPiPlPiMiPiZeroDaughter(motherRealLabel) )
+              fHistoTrueMotherGammaGammaFromHNMInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+          break;
+        case 2: // ETA PRIME MESON
+          if( IsEtaPrimePiPlPiMiEtaDaughter(motherRealLabel) )
+              fHistoTrueMotherGammaGammaFromHNMInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+          break;
+        default:
+          AliError(Form("Heavy neutral meson not correctly selected (only 0,1,2 valid)... selected: %d",fSelectedHeavyNeutralMeson));
+        }
+      }
+    }
+  }
+  return;
+}
+
+
+//________________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessNeutralPionCandidatesMixedConvCalo(){
+
+  // Conversion Gammas
+  if(fGoodConvGammas->GetEntries()>0){
+    // vertex
+    Double_t vertex[3] = {0};
+    InputEvent()->GetPrimaryVertex()->GetXYZ(vertex);
+
+    for(Int_t firstGammaIndex=0;firstGammaIndex<fGoodConvGammas->GetEntries();firstGammaIndex++){
+      AliAODConversionPhoton *gamma0=dynamic_cast<AliAODConversionPhoton*>(fGoodConvGammas->At(firstGammaIndex));
+      if (gamma0==NULL) continue;
+
+      for(Int_t secondGammaIndex=0;secondGammaIndex<fClusterCandidates->GetEntries();secondGammaIndex++){
+        Bool_t matched = kFALSE;
+        AliAODConversionPhoton *gamma1=dynamic_cast<AliAODConversionPhoton*>(fClusterCandidates->At(secondGammaIndex));
+        if (gamma1==NULL) continue;
+
+        if (gamma1->GetIsCaloPhoton()){
+          AliVCluster* cluster = fInputEvent->GetCaloCluster(gamma1->GetCaloClusterRef());
+          matched = ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->MatchConvPhotonToCluster(gamma0,cluster, fInputEvent );
+        }
+
+        AliAODConversionMother *NDMcand = new AliAODConversionMother(gamma0,gamma1);
+        NDMcand->SetLabels(firstGammaIndex,secondGammaIndex);
+
+        if((((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->MesonIsSelected(NDMcand,kTRUE,((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift()))){
+          if (!matched){
+            if(!fDoLightOutput){
+              fHistoGammaGammaInvMassPt[fiCut]->Fill(NDMcand->M(),NDMcand->Pt());
+            }
+            if(fIsMC){
+              ProcessTrueNeutralPionCandidatesMixedConvCalo(NDMcand,gamma0,gamma1);
+            }
+            if (((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(NDMcand, 0)){
+              fNeutralDecayParticleCandidates->Add(NDMcand);
+            } else if((((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->UseSidebandMixing()) &&
+                      (((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(NDMcand, 1))){
+              fNeutralDecayParticleSidebandCandidates->Add(NDMcand);
+            } else if((((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->UseSidebandMixingBothSides()) &&
+                      ((((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(NDMcand, 2)) ||
+                      ((((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->MesonIsSelectedByMassCut(NDMcand, 3))))){
+              fNeutralDecayParticleSidebandCandidates->Add(NDMcand);
+            } else{
+              delete NDMcand;
+              NDMcand=0x0;
+            }
+          }else{
+            delete NDMcand;
+            NDMcand=0x0;
+          }
+        }else{
+          delete NDMcand;
+          NDMcand=0x0;
+        }
+      }
+    }
+  }
+}
+
+//______________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessTrueNeutralPionCandidatesMixedConvCalo( AliAODConversionMother *Pi0Candidate, AliAODConversionPhoton *TrueGammaCandidate0, AliAODConversionPhoton *TrueGammaCandidate1)
+{
+  // Process True Mesons
+  if(TrueGammaCandidate0->GetV0Index()<fInputEvent->GetNumberOfV0s()){
+    Bool_t isTruePi0 = kFALSE;
+    Bool_t isTruePi0Dalitz = kFALSE;
+    Bool_t gamma0DalitzCand = kFALSE;
+
+    Int_t gamma0MCLabel = TrueGammaCandidate0->GetMCParticleLabel(fMCEvent);
+    Int_t gamma0MotherLabel = -1;
+    Int_t motherRealLabel = -1;
+    if(gamma0MCLabel != -1){ // Gamma is Combinatorial; MC Particles don't belong to the same Mother
+      // Daughters Gamma 0
+      TParticle * negativeMC = (TParticle*)TrueGammaCandidate0->GetNegativeMCDaughter(fMCEvent);
+      TParticle * positiveMC = (TParticle*)TrueGammaCandidate0->GetPositiveMCDaughter(fMCEvent);
+      TParticle * gammaMC0 = (TParticle*)fMCEvent->Particle(gamma0MCLabel);
+      if(TMath::Abs(negativeMC->GetPdgCode())==11 && TMath::Abs(positiveMC->GetPdgCode())==11){  // Electrons ...
+        if(negativeMC->GetUniqueID() == 5 && positiveMC->GetUniqueID() ==5){ // ... From Conversion ...
+          if(gammaMC0->GetPdgCode() == 22){ // ... with Gamma Mother
+            gamma0MotherLabel=gammaMC0->GetFirstMother();
+            motherRealLabel=gammaMC0->GetFirstMother();
+          }
+        }
+        if(gammaMC0->GetPdgCode() ==111){ // Dalitz candidate
+          gamma0DalitzCand = kTRUE;
+          gamma0MotherLabel=-111;
+          motherRealLabel=gamma0MCLabel;
+        }
+
+      }
+    }
+
+    if (!TrueGammaCandidate1->GetIsCaloPhoton()) AliFatal("CaloPhotonFlag has not been set. Aborting");
+
+    Int_t gamma1MCLabel = TrueGammaCandidate1->GetCaloPhotonMCLabel(0); 	// get most probable MC label
+    Int_t gamma1MotherLabel = -1;
+    // check if
+
+    if(gamma1MCLabel != -1){ // Gamma is Combinatorial; MC Particles don't belong to the same Mother
+      // Daughters Gamma 1
+      TParticle * gammaMC1 = (TParticle*)fMCEvent->Particle(gamma1MCLabel);
+      if (TrueGammaCandidate1->IsLargestComponentPhoton() || TrueGammaCandidate1->IsLargestComponentElectron()){		// largest component is electro magnetic
+        // get mother of interest (pi0 or eta)
+        if (TrueGammaCandidate1->IsLargestComponentPhoton()){														// for photons its the direct mother
+          gamma1MotherLabel=gammaMC1->GetMother(0);
+        } else if (TrueGammaCandidate1->IsLargestComponentElectron()){ 												// for electrons its either the direct mother or for conversions the grandmother
+                    if (TrueGammaCandidate1->IsConversion() && gammaMC1->GetMother(0)>-1) gamma1MotherLabel=fMCEvent->Particle(gammaMC1->GetMother(0))->GetMother(0);
+          else gamma1MotherLabel=gammaMC1->GetMother(0);
+        }
+      }
+    }
+
+    if(gamma0MotherLabel>=0 && gamma0MotherLabel==gamma1MotherLabel){
+      if(((TParticle*)fMCEvent->Particle(gamma1MotherLabel))->GetPdgCode() == fPDGCodeNDM){
+        isTruePi0=kTRUE;
+        if (CheckVectorForDoubleCount(fVectorDoubleCountTruePi0s,gamma0MotherLabel) && (!fDoLightOutput)) fHistoDoubleCountTruePi0InvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+      }
+    }
+
+    if (gamma0DalitzCand ){
+      if (gamma0DalitzCand && gamma0MCLabel >=0 && gamma0MCLabel==gamma1MotherLabel){
+        if (gamma0MotherLabel == -111) isTruePi0Dalitz = kTRUE;
+      }
+    }
+
+    if(isTruePi0 || isTruePi0Dalitz ){
+      Pi0Candidate->SetTrueMesonValue(1);
+      Pi0Candidate->SetMCLabel(motherRealLabel);
+      if(!fDoLightOutput){
+        fHistoTrueMotherGammaGammaInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+        switch( fSelectedHeavyNeutralMeson ) {
+        case 0: // ETA MESON
+          if( IsEtaPiPlPiMiPiZeroDaughter(motherRealLabel) )
+              fHistoTrueMotherGammaGammaFromHNMInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+          break;
+        case 1: // OMEGA MESON
+          if( IsOmegaPiPlPiMiPiZeroDaughter(motherRealLabel) )
+              fHistoTrueMotherGammaGammaFromHNMInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+          break;
+        case 2: // ETA PRIME MESON
+          if( IsEtaPrimePiPlPiMiEtaDaughter(motherRealLabel) )
+              fHistoTrueMotherGammaGammaFromHNMInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt());
+          break;
+        default:
+          AliError(Form("Heavy neutral meson not correctly selected (only 0,1,2 valid)... selected: %d",fSelectedHeavyNeutralMeson));
+        }
+      }
+    }
+  }
+}
+
+
+
+//________________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessPionCandidates(){
+
+  Double_t magField = fInputEvent->GetMagneticField();
+  if( magField  < 0.0 ){
+    magField =  1.0;
+  } else {
+    magField =  -1.0;
+  }
+
+  vector<Int_t> lGoodNegPionIndexPrev(0);
+  vector<Int_t> lGoodPosPionIndexPrev(0);
+
+    for(UInt_t i = 0; i < fSelectorNegPionIndex.size(); i++){
+    AliESDtrack* negPionCandidate = fESDEvent->GetTrack(fSelectorNegPionIndex[i]);
+    if(! ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelected(negPionCandidate) ) continue;
+    lGoodNegPionIndexPrev.push_back(   fSelectorNegPionIndex[i] );
+
+    TLorentzVector *negPionforHandler = new TLorentzVector();
+    negPionforHandler->SetPxPyPzE(negPionCandidate->Px(), negPionCandidate->Py(), negPionCandidate->Pz(), negPionCandidate->E());
+
+    AliAODConversionPhoton *negPionHandler = new AliAODConversionPhoton(negPionforHandler);
+    delete negPionforHandler;
+
+    fNegPionCandidates->Add(negPionHandler);
+    if(!fDoLightOutput){
+        fHistoNegPionPt[fiCut]->Fill(negPionCandidate->Pt());
+        fHistoNegPionPhi[fiCut]->Fill(negPionCandidate->Phi());
+    }
+
+    if( fMCEvent ) {
+      const AliVVertex* primVtxMC 	= fMCEvent->GetPrimaryVertex();
+      Double_t mcProdVtxX 	= primVtxMC->GetX();
+      Double_t mcProdVtxY 	= primVtxMC->GetY();
+      Double_t mcProdVtxZ 	= primVtxMC->GetZ();
+
+      Int_t labelNegPion = TMath::Abs( negPionCandidate->GetLabel() );
+      Bool_t negPionIsPrimary = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryESD( fMCEvent, labelNegPion, mcProdVtxX, mcProdVtxY, mcProdVtxZ);
+            if( labelNegPion>-1 && labelNegPion < fMCEvent->GetNumberOfTracks() ){
+        TParticle* negPion = fMCEvent->Particle(labelNegPion);
+        if( negPion->GetPdgCode() ==  -211 ){
+          if(!fDoLightOutput){
+            if( negPionIsPrimary ){
+                fHistoTrueNegPionPt[fiCut]->Fill(negPionCandidate->Pt());    //primary negPion
+            }
+            switch( fSelectedHeavyNeutralMeson ) {
+            case 0: // ETA MESON
+              if( IsEtaPiPlPiMiPiZeroDaughter(labelNegPion) && negPionIsPrimary )
+                fHistoTrueNegPionFromNeutralMesonPt[fiCut]->Fill(negPionCandidate->Pt());
+              break;
+            case 1: // OMEGA MESON
+              if( IsOmegaPiPlPiMiPiZeroDaughter(labelNegPion) && negPionIsPrimary)
+                fHistoTrueNegPionFromNeutralMesonPt[fiCut]->Fill(negPionCandidate->Pt());
+              break;
+            case 2: // ETA PRIME MESON
+              if( IsEtaPrimePiPlPiMiEtaDaughter(labelNegPion) &&  negPionIsPrimary)
+                fHistoTrueNegPionFromNeutralMesonPt[fiCut]->Fill(negPionCandidate->Pt());
+              break;
+            default:
+              AliError(Form("Heavy neutral meson not correctly selected (only 0,1,2 valid)... selected: %d",fSelectedHeavyNeutralMeson));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  for(UInt_t i = 0; i < fSelectorPosPionIndex.size(); i++){
+    AliESDtrack* posPionCandidate = fESDEvent->GetTrack( fSelectorPosPionIndex[i] );
+    if(! ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelected(posPionCandidate) ) continue;
+    lGoodPosPionIndexPrev.push_back(   fSelectorPosPionIndex[i]  );
+
+    TLorentzVector *posPionforHandler = new TLorentzVector();
+    posPionforHandler->SetPxPyPzE(posPionCandidate->Px(), posPionCandidate->Py(), posPionCandidate->Pz(), posPionCandidate->E());
+
+    AliAODConversionPhoton *posPionHandler = new AliAODConversionPhoton(posPionforHandler);
+    delete posPionforHandler;
+
+    fPosPionCandidates->Add(posPionHandler);
+    if(!fDoLightOutput){
+        fHistoPosPionPt[fiCut]->Fill( posPionCandidate->Pt() );
+        fHistoPosPionPhi[fiCut]->Fill( posPionCandidate->Phi() );
+    }
+    if( fMCEvent ) {
+      const AliVVertex* primVtxMC 	= fMCEvent->GetPrimaryVertex();
+      Double_t mcProdVtxX 	= primVtxMC->GetX();
+      Double_t mcProdVtxY 	= primVtxMC->GetY();
+      Double_t mcProdVtxZ 	= primVtxMC->GetZ();
+
+      Int_t labelPosPion = TMath::Abs( posPionCandidate->GetLabel() );
+      Bool_t posPionIsPrimary = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryESD( fMCEvent, labelPosPion, mcProdVtxX, mcProdVtxY, mcProdVtxZ);
+            if( labelPosPion>-1 && labelPosPion < fMCEvent->GetNumberOfTracks() ) {
+        TParticle* posPion = fMCEvent->Particle(labelPosPion);
+        if( posPion->GetPdgCode() ==  211 ){
+          if(!fDoLightOutput){
+            if( posPionIsPrimary ){
+              fHistoTruePosPionPt[fiCut]->Fill(posPionCandidate->Pt());
+            }
+            switch( fSelectedHeavyNeutralMeson ) {
+            case 0: // ETA MESON
+              if( IsEtaPiPlPiMiPiZeroDaughter(labelPosPion) && posPionIsPrimary )
+                fHistoTruePosPionFromNeutralMesonPt[fiCut]->Fill(posPionCandidate->Pt());
+              break;
+            case 1: // OMEGA MESON
+              if( IsOmegaPiPlPiMiPiZeroDaughter(labelPosPion) && posPionIsPrimary)
+                fHistoTruePosPionFromNeutralMesonPt[fiCut]->Fill(posPionCandidate->Pt());
+              break;
+            case 2: // ETA PRIME MESON
+              if( IsEtaPrimePiPlPiMiEtaDaughter(labelPosPion) &&  posPionIsPrimary)
+                fHistoTruePosPionFromNeutralMesonPt[fiCut]->Fill(posPionCandidate->Pt());
+              break;
+            default:
+              AliError(Form("Heavy neutral meson not correctly selected (only 0,1,2 valid)... selected: %d",fSelectedHeavyNeutralMeson));
+            }
+          }
+        }
+      }
+    }
+  }
+
+
+  for(UInt_t i = 0; i < lGoodNegPionIndexPrev.size(); i++){
+    AliESDtrack *negPionCandidate = fESDEvent->GetTrack(lGoodNegPionIndexPrev[i]);
+    AliKFParticle negPionCandidateKF( *negPionCandidate->GetConstrainedParam(), 211 );
+
+    for(UInt_t j = 0; j < lGoodPosPionIndexPrev.size(); j++){
+      AliESDtrack *posPionCandidate = fESDEvent->GetTrack(lGoodPosPionIndexPrev[j]);
+      AliKFParticle posPionCandidateKF( *posPionCandidate->GetConstrainedParam(), 211 );
+
+      AliKFConversionPhoton* virtualPhoton = NULL;
+      virtualPhoton = new AliKFConversionPhoton(negPionCandidateKF,posPionCandidateKF);
+      AliKFVertex primaryVertexImproved(*fInputEvent->GetPrimaryVertex());
+			// primaryVertexImproved+=*virtualPhoton;
+      virtualPhoton->SetProductionVertex(primaryVertexImproved);
+      virtualPhoton->SetTrackLabels( lGoodPosPionIndexPrev[j], lGoodNegPionIndexPrev[i]);
+
+      Int_t labeln=0;
+      Int_t labelp=0;
+      Int_t motherlabelp = 0;
+      Int_t motherlabeln = 0;
+      TParticle *fNegativeMCParticle =NULL;
+      TParticle *fPositiveMCParticle =NULL;
+      if( fMCEvent ) {
+        labeln=TMath::Abs(negPionCandidate->GetLabel());
+        labelp=TMath::Abs(posPionCandidate->GetLabel());
+                if(labeln>-1) fNegativeMCParticle = fMCEvent->Particle(labeln);
+                if(labelp>-1) fPositiveMCParticle = fMCEvent->Particle(labelp);
+        // check whether MC particles exist, else abort
+        if (fNegativeMCParticle == NULL || fPositiveMCParticle == NULL) return;
+
+        motherlabeln = fNegativeMCParticle->GetMother(0);
+        motherlabelp = fPositiveMCParticle->GetMother(0);
+        virtualPhoton->SetMCLabelPositive(labelp);
+        virtualPhoton->SetMCLabelNegative(labeln);
+
+      }
+
+      AliAODConversionPhoton *vParticle = new AliAODConversionPhoton(virtualPhoton); //To apply mass 2 pion mass cut
+      if(!fDoLightOutput){
+        if (fMCEvent &&(fDoMesonQA>0)){
+          if (fPositiveMCParticle && fNegativeMCParticle ) {
+            if (((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->DoMassCut()){
+              if (vParticle->GetMass() < ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->GetMassCut()){
+                if(TMath::Abs(fNegativeMCParticle->GetPdgCode())==211 && TMath::Abs(fPositiveMCParticle->GetPdgCode())==211){  // Pions ...
+                  fHistoTruePionPionInvMassPt[fiCut]->Fill(vParticle->GetMass(),vParticle->Pt());
+                  if (motherlabeln == motherlabelp){
+                    fHistoTruePionPionFromSameMotherInvMassPt[fiCut]->Fill(vParticle->GetMass(),vParticle->Pt());
+                    switch( fSelectedHeavyNeutralMeson ) {
+                    case 0: // ETA MESON
+                      if( IsEtaPiPlPiMiPiZeroDaughter(labeln) )
+                      fHistoTruePionPionFromHNMInvMassPt[fiCut]->Fill(vParticle->GetMass(),vParticle->Pt());
+                      break;
+                    case 1: // OMEGA MESON
+                      if( IsOmegaPiPlPiMiPiZeroDaughter(labeln) )
+                      fHistoTruePionPionFromHNMInvMassPt[fiCut]->Fill(vParticle->GetMass(),vParticle->Pt());
+                      break;
+                    case 2: // ETA PRIME MESON
+                      if( IsEtaPrimePiPlPiMiEtaDaughter(labeln) )
+                        fHistoTruePionPionFromHNMInvMassPt[fiCut]->Fill(vParticle->GetMass(),vParticle->Pt());
+                      break;
+                    default:
+                      AliError(Form("Heavy neutral meson not correctly selected (only 0,1,2 valid)... selected: %d",fSelectedHeavyNeutralMeson));
+                    }
+                  }
+                }
+              }
+            } else {
+              if(TMath::Abs(fNegativeMCParticle->GetPdgCode())==211 && TMath::Abs(fPositiveMCParticle->GetPdgCode())==211){  // Pions ...
+                fHistoTruePionPionInvMassPt[fiCut]->Fill(vParticle->GetMass(),vParticle->Pt());
+                if (motherlabeln == motherlabelp){
+                  fHistoTruePionPionFromSameMotherInvMassPt[fiCut]->Fill(vParticle->GetMass(),vParticle->Pt());
+                  switch( fSelectedHeavyNeutralMeson ) {
+                  case 0: // ETA MESON
+                    if( IsEtaPiPlPiMiPiZeroDaughter(labeln) )
+                    fHistoTruePionPionFromHNMInvMassPt[fiCut]->Fill(vParticle->GetMass(),vParticle->Pt());
+                    break;
+                  case 1: // OMEGA MESON
+                    if( IsOmegaPiPlPiMiPiZeroDaughter(labeln) )
+                    fHistoTruePionPionFromHNMInvMassPt[fiCut]->Fill(vParticle->GetMass(),vParticle->Pt());
+                    break;
+                  case 2: // ETA PRIME MESON
+                    if( IsEtaPrimePiPlPiMiEtaDaughter(labeln) )
+                      fHistoTruePionPionFromHNMInvMassPt[fiCut]->Fill(vParticle->GetMass(),vParticle->Pt());
+                    break;
+                  default:
+                    AliError(Form("Heavy neutral meson not correctly selected (only 0,1,2 valid)... selected: %d",fSelectedHeavyNeutralMeson));
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      if (((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->DoMassCut()){
+        if (vParticle->GetMass() < ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->GetMassCut()){
+                    fGoodVirtualParticles->Add( vParticle );
+                    if(!fDoLightOutput){
+                      fHistoPionPionInvMassPt[fiCut]->Fill( vParticle->GetMass(),vParticle->Pt());
+                    }
+        }else{
+          delete vParticle;
+          vParticle=0x0;
+        }
+      } else {
+                fGoodVirtualParticles->Add( vParticle );
+                if(!fDoLightOutput){
+                  fHistoPionPionInvMassPt[fiCut]->Fill( vParticle->GetMass(),vParticle->Pt());
+                }
+      }
+
+      Double_t clsToFPos = -1.0;
+      Double_t clsToFNeg = -1.0;
+
+      Float_t dcaToVertexXYPos = -1.0;
+      Float_t dcaToVertexZPos  = -1.0;
+      Float_t dcaToVertexXYNeg = -1.0;
+      Float_t dcaToVertexZNeg  = -1.0;
+
+      if ( fDoMesonQA>0 ) {
+        clsToFPos = ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->GetNFindableClustersTPC(posPionCandidate);
+        clsToFNeg = ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->GetNFindableClustersTPC(negPionCandidate);
+
+        Float_t bPos[2];
+        Float_t bCovPos[3];
+        posPionCandidate->GetImpactParameters(bPos,bCovPos);
+        if (bCovPos[0]<=0 || bCovPos[2]<=0) {
+          AliDebug(1, "Estimated b resolution lower or equal zero!");
+          bCovPos[0]=0; bCovPos[2]=0;
+        }
+
+        Float_t bNeg[2];
+        Float_t bCovNeg[3];
+        posPionCandidate->GetImpactParameters(bNeg,bCovNeg);
+        if (bCovNeg[0]<=0 || bCovNeg[2]<=0) {
+          AliDebug(1, "Estimated b resolution lower or equal zero!");
+          bCovNeg[0]=0; bCovNeg[2]=0;
+        }
+
+        dcaToVertexXYPos = bPos[0];
+        dcaToVertexZPos  = bPos[1];
+        dcaToVertexXYNeg = bNeg[0];
+        dcaToVertexZNeg  = bNeg[1];
+
+        if(!fDoLightOutput){
+          fHistoNegPionEta[fiCut]->Fill( negPionCandidate->Eta() );
+          fHistoPosPionEta[fiCut]->Fill( posPionCandidate->Eta() );
+
+          fHistoNegPionClsTPC[fiCut]->Fill(clsToFNeg,negPionCandidate->Pt());
+          fHistoPosPionClsTPC[fiCut]->Fill(clsToFPos,posPionCandidate->Pt());
+
+          fHistoPionDCAxy[fiCut]->Fill(  dcaToVertexXYNeg, negPionCandidate->Pt() );
+          fHistoPionDCAz[fiCut]->Fill(   dcaToVertexZNeg,  negPionCandidate->Pt() );
+          fHistoPionDCAxy[fiCut]->Fill(  dcaToVertexXYPos, posPionCandidate->Pt() );
+          fHistoPionDCAz[fiCut]->Fill(   dcaToVertexZPos,  posPionCandidate->Pt() );
+
+          fHistoPionTPCdEdxNSigma[fiCut]->Fill( posPionCandidate->P(),((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->GetPIDResponse()->NumberOfSigmasTPC(posPionCandidate, AliPID::kPion) );
+          fHistoPionTPCdEdxNSigma[fiCut]->Fill( negPionCandidate->P(),((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->GetPIDResponse()->NumberOfSigmasTPC(negPionCandidate, AliPID::kPion) );
+
+          fHistoPionTPCdEdx[fiCut]->Fill( posPionCandidate->P(), TMath::Abs(posPionCandidate->GetTPCsignal()));
+          fHistoPionTPCdEdx[fiCut]->Fill( negPionCandidate->P(), TMath::Abs(negPionCandidate->GetTPCsignal()));
+        }
+      }
+
+      delete virtualPhoton;
+      virtualPhoton=NULL;
+    }
+  }
+}
+
+//_____________________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessMCParticles(){
+
+  // Loop over all primary MC particle
+  const AliVVertex* primVtxMC 	= fMCEvent->GetPrimaryVertex();
+  Double_t mcProdVtxX 	= primVtxMC->GetX();
+  Double_t mcProdVtxY 	= primVtxMC->GetY();
+  Double_t mcProdVtxZ 	= primVtxMC->GetZ();
+
+  for(Int_t i = 0; i < fMCEvent->GetNumberOfTracks(); i++) {
+    if (((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryESD( fMCEvent, i, mcProdVtxX, mcProdVtxY, mcProdVtxZ)){
+
+      TParticle* particle = (TParticle *)fMCEvent->Particle(i);
+      if (!particle) continue;
+
+      Int_t isMCFromMBHeader = -1;
+      if(((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 0){
+        isMCFromMBHeader
+          = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(i, fMCEvent, fInputEvent);
+        if(isMCFromMBHeader == 0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 3) continue;
+      }
+
+      if(!fDoLightOutput){
+        if(((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(i, fMCEvent,fInputEvent)){
+          // find MC photons
+          if (fNDMRecoMode < 2 ){
+            if(((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedMC(particle,fMCEvent,kFALSE)){
+              fHistoMCAllGammaPt[fiCut]->Fill(particle->Pt()); // All MC Gamma
+              if(particle->GetMother(0) >-1){
+                if (fMCEvent->Particle(particle->GetMother(0))->GetPdgCode() ==fPDGCodeNDM){
+                  if (fMCEvent->Particle(particle->GetMother(0))->GetMother(0) > -1){
+                    if ( fMCEvent->Particle((fMCEvent->Particle(particle->GetMother(0)))->GetMother(0))->GetPdgCode() == fPDGCodeAnalyzedMeson ){
+                      if ( fMCEvent->Particle(particle->GetMother(0))->GetNDaughters()==3 )
+                        fHistoMCGammaFromNeutralMesonPt[fiCut]->Fill(particle->Pt()); // All photons from eta or omega via pi0
+                    }
+                  }
+                }
+              }
+            }
+          } else if (fNDMRecoMode == 2){
+            if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedMC(particle,fMCEvent)){
+              fHistoMCAllGammaPt[fiCut]->Fill(particle->Pt()); // All MC Gamma
+              if(particle->GetMother(0) >-1){
+                if (fMCEvent->Particle(particle->GetMother(0))->GetPdgCode() ==fPDGCodeNDM){
+                  if (fMCEvent->Particle(particle->GetMother(0))->GetMother(0) > -1){
+                    if ( fMCEvent->Particle((fMCEvent->Particle(particle->GetMother(0)))->GetMother(0))->GetPdgCode() == fPDGCodeAnalyzedMeson ){
+                      if ( fMCEvent->Particle(particle->GetMother(0))->GetNDaughters()==3 )
+                        fHistoMCGammaFromNeutralMesonPt[fiCut]->Fill(particle->Pt()); // All photons from analyzed meson via pi0 or eta from decay
+                    }
+                  }
+                }
+              }
+            }
+          }
+          if (fNDMRecoMode < 2){
+            if (((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedMC(particle,fMCEvent,kTRUE)){
+              fHistoMCConvGammaPt[fiCut]->Fill(particle->Pt());
+            } // Converted MC Gamma
+          }
+          if(((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(i,fMCEvent)){
+            if( particle->GetPdgCode() == 211){
+              fHistoMCAllPosPionsPt[fiCut]->Fill(particle->Pt()); // All pos pions
+              if(particle->GetMother(0) >-1){
+                if (fMCEvent->Particle(particle->GetMother(0))->GetPdgCode() ==fPDGCodeAnalyzedMeson)
+                  fHistoMCPosPionsFromNeutralMesonPt[fiCut]->Fill(particle->Pt()); // All pos from neutral heavy meson (omega, eta OR eta prime)
+              }
+            }
+            if( particle->GetPdgCode() == -211){
+              fHistoMCAllNegPionsPt[fiCut]->Fill(particle->Pt()); // All neg pions
+              if(particle->GetMother(0) >-1){
+                if (fMCEvent->Particle(particle->GetMother(0))->GetPdgCode() ==fPDGCodeAnalyzedMeson)
+                  fHistoMCNegPionsFromNeutralMesonPt[fiCut]->Fill(particle->Pt()); // All pos from neutral heavy meson (omega, eta OR eta prime)
+              }
+            }
+          }
+        }
+      }
+
+        // \eta -> pi+ pi- \gamma
+        Int_t labelNDM = -1;
+        Int_t labelNegPion = -1;
+        Int_t labelPosPion = -1;
+
+        if( ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelectedMCPiPlPiMiPiZero(particle,fMCEvent,labelNegPion,labelPosPion,labelNDM,((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift()) ||   ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelectedMCPiPlPiMiEta(particle,fMCEvent,labelNegPion,labelPosPion,labelNDM,((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift())){
+          Float_t weighted= 1;
+          if( ((AliPrimaryPionCuts*) fPionCutArray->At(fiCut))->DoWeights() ) {
+            if(((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(i, fMCEvent,fInputEvent)){
+              if (particle->Pt()>0.005){
+                weighted= ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetWeightForMeson(i, fMCEvent,fInputEvent);
+              }
+            }
+          }
+          if(particle->GetPdgCode() == fPDGCodeAnalyzedMeson)fHistoMCHNMPiPlPiMiNDMPt[fiCut]->Fill(particle->Pt(), weighted); 	// All MC eta, omega OR eta prime in respective decay channel
+
+          if(labelNDM>-1){
+            TParticle *particleNDM    = fMCEvent->Particle(labelNDM);
+            if(particleNDM->GetDaughter(0)>-1 && particleNDM->GetDaughter(1)>-1){
+              TParticle *gamma1 = fMCEvent->Particle(particleNDM->GetDaughter(0));
+              TParticle *gamma2 = fMCEvent->Particle(particleNDM->GetDaughter(1));
+              Bool_t kDaughter0IsPrim = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryESD( fMCEvent, particleNDM->GetDaughter(0), mcProdVtxX, mcProdVtxY, mcProdVtxZ);
+              Bool_t kDaughter1IsPrim = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryESD( fMCEvent, particleNDM->GetDaughter(1), mcProdVtxX, mcProdVtxY, mcProdVtxZ);
+              Bool_t kNegPionIsPrim = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryESD( fMCEvent, labelNegPion, mcProdVtxX, mcProdVtxY, mcProdVtxZ);
+              Bool_t kPosPionIsPrim = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryESD( fMCEvent, labelPosPion, mcProdVtxX, mcProdVtxY, mcProdVtxZ);
+
+              if (fNDMRecoMode < 2){
+                if( kDaughter0IsPrim && kDaughter1IsPrim && kNegPionIsPrim && kPosPionIsPrim &&
+                    ((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedMC(gamma1,fMCEvent,kFALSE) &&					// test first daugther of pi0
+                    ((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedMC(gamma2,fMCEvent,kFALSE) &&					// test second daughter of pi0
+                    ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(labelNegPion,fMCEvent) &&								// test negative pion
+                    ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(labelPosPion,fMCEvent) 								// test positive pion
+                ) {
+                  if(particle->GetPdgCode() == fPDGCodeAnalyzedMeson) fHistoMCHNMPiPlPiMiNDMInAccPt[fiCut]->Fill(particle->Pt(), weighted ); 		// MC Eta, omega or eta prime with pi+ pi- pi0 with gamma's and e+e- in acc
+                }
+              } else if (fNDMRecoMode == 2){
+                if( kDaughter0IsPrim && kDaughter1IsPrim && kNegPionIsPrim && kPosPionIsPrim &&
+                    ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedMC(gamma1,fMCEvent) &&					// test first daugther of pi0
+                    ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedMC(gamma2,fMCEvent) &&					// test second daughter of pi0
+                    ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(labelNegPion,fMCEvent) &&								// test negative pion
+                    ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(labelPosPion,fMCEvent) 								// test positive pion
+                ) {
+                  if(particle->GetPdgCode() == fPDGCodeAnalyzedMeson) fHistoMCHNMPiPlPiMiNDMInAccPt[fiCut]->Fill(particle->Pt(), weighted ); 		// MC Eta pi+ pi- pi0 with gamma's and e+e- in acc
+                }
+              }
+            }
+          }
+        }
+    }
+  }
+}
+
+
+//________________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::CalculateMesonCandidates(){
+
+  // Conversion Gammas
+  if( fNeutralDecayParticleCandidates->GetEntries() > 0 && fGoodVirtualParticles->GetEntries() > 0 ){
+    for(Int_t mesonIndex=0; mesonIndex<fNeutralDecayParticleCandidates->GetEntries(); mesonIndex++){
+      AliAODConversionMother *neutralDecayMeson=dynamic_cast<AliAODConversionMother*>(fNeutralDecayParticleCandidates->At(mesonIndex));
+      if (neutralDecayMeson==NULL) continue;
+
+      for(Int_t virtualParticleIndex=0;virtualParticleIndex<fGoodVirtualParticles->GetEntries();virtualParticleIndex++){
+
+                AliAODConversionPhoton *vParticle=dynamic_cast<AliAODConversionPhoton*>(fGoodVirtualParticles->At(virtualParticleIndex));
+        if (vParticle==NULL) continue;
+        //Check for same Electron ID
+
+        AliAODConversionMother *mesoncand = new AliAODConversionMother(neutralDecayMeson,vParticle);
+        mesoncand->SetLabels(mesonIndex,virtualParticleIndex);
+        if( ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(mesoncand,kTRUE,((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift())){
+
+          AliESDtrack *negPionCandidatetmp = (AliESDtrack*) fESDEvent->GetTrack(vParticle->GetTrackLabel(1));
+          if(negPionCandidatetmp==NULL){ delete mesoncand; continue;}
+          AliAODConversionMother *NegPiontmp = new AliAODConversionMother();
+          NegPiontmp->SetPxPyPzE(negPionCandidatetmp->Px(), negPionCandidatetmp->Py(), negPionCandidatetmp->Pz(), negPionCandidatetmp->E());
+
+          AliESDtrack *posPionCandidatetmp = (AliESDtrack*) fESDEvent->GetTrack(vParticle->GetTrackLabel(0));
+          if(posPionCandidatetmp==NULL){ delete NegPiontmp; delete mesoncand; continue;}
+          AliAODConversionMother *PosPiontmp = new AliAODConversionMother();
+          PosPiontmp->SetPxPyPzE(posPionCandidatetmp->Px(), posPionCandidatetmp->Py(), posPionCandidatetmp->Pz(), posPionCandidatetmp->E());
+
+          if(KinematicCut(NegPiontmp, PosPiontmp, neutralDecayMeson, mesoncand)){
+            if(!fDoLightOutput){
+              fHistoAngleHNMesonNDM[fiCut]->Fill(mesoncand->Pt(),neutralDecayMeson->Angle(mesoncand->Vect()));
+              fHistoAngleHNMesonPiPl[fiCut]->Fill(mesoncand->Pt(),PosPiontmp->Angle(mesoncand->Vect()));
+              fHistoAngleHNMesonPiMi[fiCut]->Fill(mesoncand->Pt(),NegPiontmp->Angle(mesoncand->Vect()));
+              fHistoAngleNDMPiMi[fiCut]->Fill(mesoncand->Pt(),NegPiontmp->Angle(neutralDecayMeson->Vect()));
+              fHistoAnglePiPlPiMi[fiCut]->Fill(mesoncand->Pt(),NegPiontmp->Angle(PosPiontmp->Vect()));
+              fHistoAnglePiPlNDM[fiCut]->Fill(mesoncand->Pt(),PosPiontmp->Angle(neutralDecayMeson->Vect()));
+              fHistoAngleHNMesonPiPlPiMi[fiCut]->Fill(mesoncand->Pt(),vParticle->Angle(mesoncand->Vect()));
+              fHistoAngleSum[fiCut]->Fill(mesoncand->Pt(),((PosPiontmp->Angle(mesoncand->Vect()))+(NegPiontmp->Angle(PosPiontmp->Vect()))+(PosPiontmp->Angle(neutralDecayMeson->Vect()))));
+            }
+
+            // Subtract mass of used pi0 candidate and then add PDG mass to get to right range again
+            fHistoMotherInvMassSubNDM[fiCut]->Fill(mesoncand->M()-(neutralDecayMeson->M()-fPDGMassNDM),mesoncand->Pt());
+
+            // Fix Pz of pi0 candidate to match pi0 PDG mass
+            AliAODConversionMother *NDMtmp = new AliAODConversionMother();
+            NDMtmp->SetPxPyPzE(neutralDecayMeson->Px(), neutralDecayMeson->Py(), neutralDecayMeson->Pz(), neutralDecayMeson->Energy());
+            FixPzToMatchPDGInvMassNDM(NDMtmp);
+            AliAODConversionMother *mesontmp = new AliAODConversionMother(NDMtmp,vParticle);
+            fHistoMotherInvMassFixedPzNDM[fiCut]->Fill(mesontmp->M(),mesontmp->Pt());
+            delete NDMtmp;
+            delete mesontmp;
+            fHistoMotherInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt());
+            if(fMCEvent){
+              ProcessTrueMesonCandidates(mesoncand,neutralDecayMeson,vParticle);
+            }
+          }else{
+            if(!fDoLightOutput){
+              fHistoMotherInvMassPtRejectedKinematic[fiCut]->Fill(mesoncand->M(),mesoncand->Pt());
+            }
+          }
+          if(!fDoLightOutput){
+            delete NegPiontmp;
+            delete PosPiontmp;
+          }
+        }
+        delete mesoncand;
+        mesoncand=0x0;
+      }
+    }
+  }
+}
+//________________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::CalculateBackground(){
+
+  /* Event mixing histo explanation
+  *
+  * fHistoBackInvMassPtGroup1 => pi+ and pi- from same event
+  * fHistoBackInvMassPtGroup2 => pi+ and pi0 from same event
+  * fHistoBackInvMassPtGroup3 => pi- and pi0 from same event
+  * fHistoBackInvMassPtGroup4 => no pions from same event
+  */
+
+  // Get multiplicity and zbin from fBGHandler
+  Int_t zbin= fBGHandlerPiMi[fiCut]->GetZBinIndex(fESDEvent->GetPrimaryVertex()->GetZ());
+  Int_t mbin = 0;
+
+  // Multiplicity can be determined either by number of cluster candidates or track mulitiplicity
+  if(((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->UseTrackMultiplicity()){
+    mbin = fBGHandlerPiMi[fiCut]->GetMultiplicityBinIndex(fNumberOfESDTracks);
+  } else {
+    if (fNDMRecoMode < 2) mbin = fBGHandlerPiMi[fiCut]->GetMultiplicityBinIndex(fGoodConvGammas->GetEntries());
+    else mbin = fBGHandlerPiMi[fiCut]->GetMultiplicityBinIndex(fClusterCandidates->GetEntries());
+  }
+
+  AliGammaConversionAODBGHandler::GammaConversionVertex *bgEventVertexPl = NULL;
+  AliGammaConversionAODBGHandler::GammaConversionVertex *bgEventVertexMi = NULL;
+
+  // Get N of Pi0 according to chosen mix mode
+  Int_t NNDMCandidates = 0;
+  if( (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->UseSidebandMixing()) || (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->UseSidebandMixingBothSides())){
+      NNDMCandidates = fNeutralDecayParticleSidebandCandidates->GetEntries();
+   }else{
+      NNDMCandidates = fNeutralDecayParticleCandidates->GetEntries();
+  }
+  // Begin loop over all Pi0 candidates
+ for(Int_t iCurrentNDM=0; iCurrentNDM<NNDMCandidates; iCurrentNDM++){
+     AliAODConversionMother* EventNDMGoodMeson;
+     if( (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->UseSidebandMixing()) ||  (((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->UseSidebandMixingBothSides())){
+         EventNDMGoodMeson = (AliAODConversionMother*)(fNeutralDecayParticleSidebandCandidates->At(iCurrentNDM));
+     }else{
+         EventNDMGoodMeson = (AliAODConversionMother*)(fNeutralDecayParticleCandidates->At(iCurrentNDM));
+     }
+
+  if(!(((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->UseLikeSignMixing())){
+    // Begin loop over BG events for Pi+
+    for(Int_t nEventsInBGPl=0;nEventsInBGPl<fBGHandlerPiPl[fiCut]->GetNBGEvents();nEventsInBGPl++){
+
+      // Store all Pi+ of current event in right binning in vector
+      AliGammaConversionMotherAODVector *EventPiPlMeson = fBGHandlerPiPl[fiCut]->GetBGGoodMesons(zbin,mbin,nEventsInBGPl);
+
+      // Begin loop over BG events for Pi-
+      for(Int_t nEventsInBGMi=0;nEventsInBGMi<fBGHandlerPiMi[fiCut]->GetNBGEvents();nEventsInBGMi++){
+        AliGammaConversionMotherAODVector *EventPiMiMeson = fBGHandlerPiMi[fiCut]->GetBGGoodMesons(zbin,mbin,nEventsInBGMi);
+
+        // If one of the events isn't found skip to next one
+        if((EventPiMiMeson && EventPiPlMeson) == kFALSE) continue;
+
+        // Determine Background event vertex
+        if(fMoveParticleAccordingToVertex == kTRUE){
+          bgEventVertexPl = fBGHandlerPiPl[fiCut]->GetBGEventVertex(zbin,mbin,nEventsInBGPl);
+          bgEventVertexMi = fBGHandlerPiMi[fiCut]->GetBGEventVertex(zbin,mbin,nEventsInBGMi);
+        }
+        // Loop over all Pi+
+        for(UInt_t iCurrentPiPl = 0; iCurrentPiPl<EventPiPlMeson->size();iCurrentPiPl++){
+            AliAODConversionMother EventPiPlGoodMeson= (AliAODConversionMother)(*(EventPiPlMeson->at(iCurrentPiPl)));
+
+            // Move Vertex
+            if(fMoveParticleAccordingToVertex == kTRUE){
+              MoveParticleAccordingToVertex(&EventPiPlGoodMeson, bgEventVertexPl);
+            }
+
+            // Combine Pi+ and Pi0
+            AliAODConversionMother *PiPlNDMBackgroundCandidate = new AliAODConversionMother(EventNDMGoodMeson, &EventPiPlGoodMeson);
+
+            for(UInt_t iCurrentPiMi = 0; iCurrentPiMi<EventPiMiMeson->size();iCurrentPiMi++){
+              AliAODConversionMother EventPiMiGoodMeson = (AliAODConversionMother)(*(EventPiMiMeson->at(iCurrentPiMi)));
+
+              // Move Vertex
+              if(fMoveParticleAccordingToVertex == kTRUE){
+                MoveParticleAccordingToVertex(&EventPiMiGoodMeson, bgEventVertexMi);
+              }
+
+              // Mass cut (pi+pi-)
+              if (((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->DoMassCut()){
+                AliAODConversionMother *backPiPlPiMiCandidate = new AliAODConversionMother(&EventPiPlGoodMeson,&EventPiMiGoodMeson);
+                if (backPiPlPiMiCandidate->M() >= ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->GetMassCut()){
+                  delete backPiPlPiMiCandidate;
+                  backPiPlPiMiCandidate = 0x0;
+                  continue;
+                }
+                delete backPiPlPiMiCandidate;
+                backPiPlPiMiCandidate = 0x0;
+              }
+
+              // Create (final) Candidate
+              AliAODConversionMother *PiPlPiMiNDMBackgroundCandidate = new AliAODConversionMother(PiPlNDMBackgroundCandidate,&EventPiMiGoodMeson);
+
+              // Check if candidate survives meson cut
+              if(  ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(PiPlPiMiNDMBackgroundCandidate,kFALSE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift())){
+
+                // Check if candidate survives kinematic cut
+                if(KinematicCut(&EventPiMiGoodMeson, &EventPiPlGoodMeson,EventNDMGoodMeson,PiPlPiMiNDMBackgroundCandidate)){
+                  // Create temporary mesons to be able to fix pz
+                  AliAODConversionMother *NDMtmp = new AliAODConversionMother();
+                  NDMtmp->SetPxPyPzE(EventNDMGoodMeson->Px(), EventNDMGoodMeson->Py(), EventNDMGoodMeson->Pz(), EventNDMGoodMeson->Energy());
+                  FixPzToMatchPDGInvMassNDM(NDMtmp);
+                  AliAODConversionMother *PiMiNDMtmp = new AliAODConversionMother(&EventPiMiGoodMeson,NDMtmp);
+                  AliAODConversionMother *PiPlPiMiNDMtmp = new AliAODConversionMother(&EventPiPlGoodMeson,PiMiNDMtmp);
+
+                  if (nEventsInBGMi != nEventsInBGPl){
+                    // Pi+ and Pi- don't come from the same event (but different than pi0 event)
+                    // Fill histograms
+                    fHistoBackInvMassPtGroup4[fiCut]->Fill(PiPlPiMiNDMBackgroundCandidate->M(),PiPlPiMiNDMBackgroundCandidate->Pt());
+                    fHistoBackInvMassPtGroup4SubNDM[fiCut]->Fill(PiPlPiMiNDMBackgroundCandidate->M()-(EventNDMGoodMeson->M()-fPDGMassNDM),PiPlPiMiNDMBackgroundCandidate->Pt());
+                    fHistoBackInvMassPtGroup4FixedPzNDM[fiCut]->Fill(PiPlPiMiNDMtmp->M(),PiPlPiMiNDMtmp->Pt());
+
+                  } else if(nEventsInBGMi==nEventsInBGPl){
+                    // Pi+ and Pi- come from the same event (but different than pi0 event)
+                    fHistoBackInvMassPtGroup1[fiCut]->Fill(PiPlPiMiNDMBackgroundCandidate->M(),PiPlPiMiNDMBackgroundCandidate->Pt());
+                    fHistoBackInvMassPtGroup1SubNDM[fiCut]->Fill(PiPlPiMiNDMBackgroundCandidate->M()-(EventNDMGoodMeson->M()-fPDGMassNDM),PiPlPiMiNDMBackgroundCandidate->Pt());
+                    fHistoBackInvMassPtGroup1FixedPzNDM[fiCut]->Fill(PiPlPiMiNDMtmp->M(),PiPlPiMiNDMtmp->Pt());
+                  }
+
+                  delete NDMtmp;
+                  delete PiMiNDMtmp;
+                  delete PiPlPiMiNDMtmp;
+
+                  delete PiPlPiMiNDMBackgroundCandidate;
+                  PiPlPiMiNDMBackgroundCandidate = 0x0;
+                }
+              }
+              if(PiPlPiMiNDMBackgroundCandidate!=0x0){
+                  delete PiPlPiMiNDMBackgroundCandidate;
+                  PiPlPiMiNDMBackgroundCandidate = 0x0;
+              }
+            } // end pi- loop
+            if(PiPlNDMBackgroundCandidate!=0x0){
+                delete PiPlNDMBackgroundCandidate;
+                PiPlNDMBackgroundCandidate = 0x0;
+            }
+        } // end pi+ loop
+      } // end loop over all pi- event
+    } // end loop over pi+ events
+
+    // Loop over all pi+ events(from Handler)
+    for(Int_t nEventsInBGPl=0;nEventsInBGPl<fBGHandlerPiPl[fiCut]->GetNBGEvents();nEventsInBGPl++){
+      // Store all Pi+ of current event in right binning in vector
+      AliGammaConversionMotherAODVector *EventPiPlMeson = fBGHandlerPiPl[fiCut]->GetBGGoodMesons(zbin,mbin,nEventsInBGPl);
+
+      // Determine Vertex
+      if(fMoveParticleAccordingToVertex == kTRUE){
+        bgEventVertexPl = fBGHandlerPiPl[fiCut]->GetBGEventVertex(zbin,mbin,nEventsInBGPl);
+      }
+      // Begin loop over all pi+ in ecent
+      for(UInt_t iCurrentPiPl = 0; iCurrentPiPl<EventPiPlMeson->size();iCurrentPiPl++){
+        AliAODConversionMother EventPiPlGoodMeson= (AliAODConversionMother)(*(EventPiPlMeson->at(iCurrentPiPl)));
+
+        // Move vertex
+        if(fMoveParticleAccordingToVertex == kTRUE){
+          MoveParticleAccordingToVertex(&EventPiPlGoodMeson, bgEventVertexPl);
+        }
+        // Combine Pi+ and Pi0
+        AliAODConversionMother *PiPlNDMBackgroundCandidate = new AliAODConversionMother(EventNDMGoodMeson, &EventPiPlGoodMeson);
+        // Loop over all pi- (from current event)
+        for(Int_t iCurrentPiMi=0; iCurrentPiMi<fNegPionCandidates->GetEntries(); iCurrentPiMi++){
+          AliAODConversionMother EventPiNegGoodMeson = *(AliAODConversionMother*)(fNegPionCandidates->At(iCurrentPiMi));
+
+          // Mass cut on pi+pi-
+          if (((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->DoMassCut()){
+            AliAODConversionMother *backPiPlPiMiCandidate = new AliAODConversionMother(&EventPiPlGoodMeson,&EventPiNegGoodMeson);
+            if (backPiPlPiMiCandidate->M() >= ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->GetMassCut()){
+              delete backPiPlPiMiCandidate;
+              backPiPlPiMiCandidate = 0x0;
+              continue;
+            }
+            delete backPiPlPiMiCandidate;
+            backPiPlPiMiCandidate = 0x0;
+          }
+
+          // Create (final) Candidate
+          AliAODConversionMother *PiPlPiMiNDMBackgroundCandidate = new AliAODConversionMother(PiPlNDMBackgroundCandidate,&EventPiNegGoodMeson);
+
+          // Check if candidate survives meson cut
+          if( ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(PiPlPiMiNDMBackgroundCandidate,kFALSE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift())){
+
+            // Check if candidate survives kinematic cut
+            if(KinematicCut(&EventPiNegGoodMeson, &EventPiPlGoodMeson, EventNDMGoodMeson,PiPlPiMiNDMBackgroundCandidate)){
+
+              // Create temporary mesons to be able to fix pz
+              AliAODConversionMother *NDMtmp = new AliAODConversionMother();
+              NDMtmp->SetPxPyPzE(EventNDMGoodMeson->Px(), EventNDMGoodMeson->Py(), EventNDMGoodMeson->Pz(), EventNDMGoodMeson->Energy());
+              FixPzToMatchPDGInvMassNDM(NDMtmp);
+              AliAODConversionMother *PiMiNDMtmp = new AliAODConversionMother(&EventPiNegGoodMeson,NDMtmp);
+              AliAODConversionMother *PiPlPiMiNDMtmp = new AliAODConversionMother(&EventPiPlGoodMeson,PiMiNDMtmp);
+
+              // Fill histograms (pi- and pi0 from same event)
+              fHistoBackInvMassPtGroup3[fiCut]->Fill(PiPlPiMiNDMBackgroundCandidate->M(),PiPlPiMiNDMBackgroundCandidate->Pt());
+              fHistoBackInvMassPtGroup3SubNDM[fiCut]->Fill(PiPlPiMiNDMBackgroundCandidate->M()-(EventNDMGoodMeson->M()-fPDGMassNDM),PiPlPiMiNDMBackgroundCandidate->Pt());
+              fHistoBackInvMassPtGroup3FixedPzNDM[fiCut]->Fill(PiPlPiMiNDMtmp->M(),PiPlPiMiNDMtmp->Pt());
+
+              delete NDMtmp;
+              delete PiMiNDMtmp;
+              delete PiPlPiMiNDMtmp;
+
+              delete PiPlPiMiNDMBackgroundCandidate;
+              PiPlPiMiNDMBackgroundCandidate = 0x0;
+            }
+          }
+          if(PiPlPiMiNDMBackgroundCandidate!=0x0){
+              delete PiPlPiMiNDMBackgroundCandidate;
+              PiPlPiMiNDMBackgroundCandidate = 0x0;
+          }
+        } // End loop pi- (from current event)
+        if(PiPlNDMBackgroundCandidate!=0x0){
+            delete PiPlNDMBackgroundCandidate;
+            PiPlNDMBackgroundCandidate = 0x0;
+        }
+      } // End loop pi+
+    } // end loop over pi+ events
+
+    // Loop over all pi- events(from Handler)
+    for(Int_t nEventsInBGMi=0;nEventsInBGMi<fBGHandlerPiPl[fiCut]->GetNBGEvents();nEventsInBGMi++){
+      // Store all Pi- of current event in right binning in vector
+      AliGammaConversionMotherAODVector *EventPiMiMeson = fBGHandlerPiMi[fiCut]->GetBGGoodMesons(zbin,mbin,nEventsInBGMi);
+
+      // Determine vertex
+      if(fMoveParticleAccordingToVertex == kTRUE){
+        bgEventVertexMi = fBGHandlerPiMi[fiCut]->GetBGEventVertex(zbin,mbin,nEventsInBGMi);
+      }
+
+      // Begin loop over all pi- in event
+      for(UInt_t iCurrentPiMi = 0; iCurrentPiMi<EventPiMiMeson->size();iCurrentPiMi++){
+        AliAODConversionMother EventPiMiGoodMeson= (AliAODConversionMother)(*(EventPiMiMeson->at(iCurrentPiMi)));
+
+        // move vertex
+        if(fMoveParticleAccordingToVertex == kTRUE){
+          MoveParticleAccordingToVertex(&EventPiMiGoodMeson, bgEventVertexMi);
+        }
+
+
+        // Combine Pi- and Pi0
+        AliAODConversionMother *PiMiNDMBackgroundCandidate = new AliAODConversionMother(EventNDMGoodMeson, &EventPiMiGoodMeson);
+
+        // Loop over all pi+ (from current event)
+        for(Int_t iCurrentPiPl=0; iCurrentPiPl<fPosPionCandidates->GetEntries(); iCurrentPiPl++){
+          AliAODConversionMother EventPiPlGoodMeson = *(AliAODConversionMother*)(fPosPionCandidates->At(iCurrentPiPl));
+
+          // Mass cut on pi+pi-
+          if (((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->DoMassCut()){
+            AliAODConversionMother *backPiPlPiMiCandidate = new AliAODConversionMother(&EventPiPlGoodMeson,&EventPiMiGoodMeson);
+            if (backPiPlPiMiCandidate->M() >= ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->GetMassCut()){
+              delete backPiPlPiMiCandidate;
+              backPiPlPiMiCandidate = 0x0;
+              continue;
+            }
+            delete backPiPlPiMiCandidate;
+            backPiPlPiMiCandidate = 0x0;
+          }
+
+          // Create (final) Candidate
+          AliAODConversionMother *PiPlPiMiNDMBackgroundCandidate = new AliAODConversionMother(PiMiNDMBackgroundCandidate,&EventPiPlGoodMeson);
+
+          // Check if candidate survives meson cut
+          if( ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(PiMiNDMBackgroundCandidate,kFALSE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift())){
+
+            // Check if candidate survives kinematic cut
+            if(KinematicCut(&EventPiMiGoodMeson, &EventPiPlGoodMeson, EventNDMGoodMeson,PiPlPiMiNDMBackgroundCandidate)){
+
+              // Create temporary mesons to be able to fix pz
+              AliAODConversionMother *NDMtmp = new AliAODConversionMother();
+              NDMtmp->SetPxPyPzE(EventNDMGoodMeson->Px(), EventNDMGoodMeson->Py(), EventNDMGoodMeson->Pz(), EventNDMGoodMeson->Energy());
+              FixPzToMatchPDGInvMassNDM(NDMtmp);
+              AliAODConversionMother *PiMiNDMtmp = new AliAODConversionMother(&EventPiMiGoodMeson,NDMtmp);
+              AliAODConversionMother *PiPlPiMiNDMtmp = new AliAODConversionMother(&EventPiPlGoodMeson,PiMiNDMtmp);
+
+              // Fill histograms (pi+ and pi0 from same event)
+              fHistoBackInvMassPtGroup2[fiCut]->Fill(PiPlPiMiNDMBackgroundCandidate->M(),PiPlPiMiNDMBackgroundCandidate->Pt());
+              fHistoBackInvMassPtGroup2SubNDM[fiCut]->Fill(PiPlPiMiNDMBackgroundCandidate->M()-(EventNDMGoodMeson->M()-fPDGMassNDM),PiPlPiMiNDMBackgroundCandidate->Pt());
+              fHistoBackInvMassPtGroup2FixedPzNDM[fiCut]->Fill(PiPlPiMiNDMtmp->M(),PiPlPiMiNDMtmp->Pt());
+
+              delete NDMtmp;
+              delete PiMiNDMtmp;
+              delete PiPlPiMiNDMtmp;
+
+              delete PiPlPiMiNDMBackgroundCandidate;
+              PiPlPiMiNDMBackgroundCandidate = 0x0;
+            }
+          }
+          if(PiPlPiMiNDMBackgroundCandidate!=0x0){
+              delete PiPlPiMiNDMBackgroundCandidate;
+              PiPlPiMiNDMBackgroundCandidate = 0x0;
+          }
+        } // End loop pi+ (from current event)
+        if(PiMiNDMBackgroundCandidate!=0x0){
+            delete PiMiNDMBackgroundCandidate;
+            PiMiNDMBackgroundCandidate = 0x0;
+        }
+      } // End loop pi-
+    } // end loop over pi+ events
+ /*
+  * LikeSign Mixing
+  */
+ } else if( ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->UseLikeSignMixing()){
+     // Loops for Pi0Pi+Pi+ LikeSign mixing
+     for(Int_t iCurrentPiPl=0; iCurrentPiPl<fPosPionCandidates->GetEntries(); iCurrentPiPl++){
+
+         AliAODConversionMother EventPiPlGoodMeson = *(AliAODConversionMother*)(fPosPionCandidates->At(iCurrentPiPl));
+
+          for(Int_t iCurrentPiPl2=0; iCurrentPiPl2<fPosPionCandidates->GetEntries(); iCurrentPiPl2++){
+
+              if(iCurrentPiPl!=iCurrentPiPl2){ // dont mix same particle
+                  AliAODConversionMother EventPiPlGoodMeson2 = *(AliAODConversionMother*)(fPosPionCandidates->At(iCurrentPiPl2));
+
+                  // Combine Pi+ and Pi0
+                  AliAODConversionMother *PiPlNDMBackgroundCandidate = new AliAODConversionMother(&EventPiPlGoodMeson, EventNDMGoodMeson);
+
+                  // Mass cut on pi+pi+
+                  if (((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->DoMassCut()){
+                    AliAODConversionMother *backPiPlPiPlCandidate = new AliAODConversionMother(&EventPiPlGoodMeson,&EventPiPlGoodMeson2);
+                    if (backPiPlPiPlCandidate->M() >= ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->GetMassCut()){
+                      delete backPiPlPiPlCandidate;
+                      backPiPlPiPlCandidate = 0x0;
+                      continue;
+                    }
+                    delete backPiPlPiPlCandidate;
+                    backPiPlPiPlCandidate = 0x0;
+                  }
+
+                  // Create (final) Candidate
+                  AliAODConversionMother *PiPlPiPlNDMBackgroundCandidate = new AliAODConversionMother(PiPlNDMBackgroundCandidate, &EventPiPlGoodMeson2);
+
+                  // Check if candidate survives meson cut
+                  if( ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(PiPlNDMBackgroundCandidate,kFALSE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift())){
+
+                    // Check if candidate survives kinematic cut
+                    if(KinematicCut(&EventPiPlGoodMeson, &EventPiPlGoodMeson2, EventNDMGoodMeson,PiPlPiPlNDMBackgroundCandidate)){
+
+                      // Create temporary mesons to be able to fix pz
+                      AliAODConversionMother *NDMtmp = new AliAODConversionMother();
+                      NDMtmp->SetPxPyPzE(EventNDMGoodMeson->Px(), EventNDMGoodMeson->Py(), EventNDMGoodMeson->Pz(), EventNDMGoodMeson->Energy());
+                      FixPzToMatchPDGInvMassNDM(NDMtmp);
+                      AliAODConversionMother *PiPlNDMtmp = new AliAODConversionMother(&EventPiPlGoodMeson,NDMtmp);
+                      AliAODConversionMother *PiPlPiPlNDMtmp = new AliAODConversionMother(&EventPiPlGoodMeson2,PiPlNDMtmp);
+
+                      // Fill histograms (likesign)
+                      fHistoMotherLikeSignBackInvMassPt[fiCut]->Fill(PiPlPiPlNDMBackgroundCandidate->M(),PiPlPiPlNDMBackgroundCandidate->Pt());
+                      fHistoMotherLikeSignBackInvMassSubNDMPt[fiCut]->Fill(PiPlPiPlNDMBackgroundCandidate->M()-(EventNDMGoodMeson->M()-fPDGMassNDM),PiPlPiPlNDMBackgroundCandidate->Pt());
+                      fHistoMotherLikeSignBackInvMassFixedPzNDMPt[fiCut]->Fill(PiPlPiPlNDMtmp->M(),PiPlPiPlNDMtmp->Pt());
+
+                      delete NDMtmp;
+                      delete PiPlNDMtmp;
+                      delete PiPlPiPlNDMtmp;
+
+                      delete PiPlPiPlNDMBackgroundCandidate;
+                      PiPlPiPlNDMBackgroundCandidate = 0x0;
+                    }
+                  }
+
+
+              }
+          } // end of iCurrentPiPl2
+     }// end of iCurrenPiPl
+
+     // Loops for Pi0Pi-Pi- LikeSign mixing
+     for(Int_t iCurrentPiMi=0; iCurrentPiMi<fNegPionCandidates->GetEntries(); iCurrentPiMi++){
+
+         AliAODConversionMother EventPiMiGoodMeson = *(AliAODConversionMother*)(fNegPionCandidates->At(iCurrentPiMi));
+
+          for(Int_t iCurrentPiMi2=0; iCurrentPiMi2<fNegPionCandidates->GetEntries(); iCurrentPiMi2++){
+
+              if(iCurrentPiMi!=iCurrentPiMi2){ // dont mix same particle
+                  AliAODConversionMother EventPiMiGoodMeson2 = *(AliAODConversionMother*)(fNegPionCandidates->At(iCurrentPiMi2));
+
+                  // Combine Pi- and Pi0
+                  AliAODConversionMother *PiMiNDMBackgroundCandidate = new AliAODConversionMother(&EventPiMiGoodMeson, EventNDMGoodMeson);
+
+                  // Mass cut on pi-pi-
+                  if (((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->DoMassCut()){
+                    AliAODConversionMother *backPiMiPiMiCandidate = new AliAODConversionMother(&EventPiMiGoodMeson,&EventPiMiGoodMeson2);
+                    if (backPiMiPiMiCandidate->M() >= ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->GetMassCut()){
+                      delete backPiMiPiMiCandidate;
+                      backPiMiPiMiCandidate = 0x0;
+                      continue;
+                    }
+                    delete backPiMiPiMiCandidate;
+                    backPiMiPiMiCandidate = 0x0;
+                  }
+
+                  // Create (final) Candidate
+                  AliAODConversionMother *PiMiPiMiNDMBackgroundCandidate = new AliAODConversionMother(PiMiNDMBackgroundCandidate, &EventPiMiGoodMeson2);
+
+                  // Check if candidate survives meson cut
+                  if(((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(PiMiNDMBackgroundCandidate,kFALSE, ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift())){
+
+                    // Check if candidate survives kinematic cut
+                    if(KinematicCut(&EventPiMiGoodMeson, &EventPiMiGoodMeson2, EventNDMGoodMeson,PiMiPiMiNDMBackgroundCandidate)){
+
+                      // Create temporary mesons to be able to fix pz
+                      AliAODConversionMother *NDMtmp = new AliAODConversionMother();
+                      NDMtmp->SetPxPyPzE(EventNDMGoodMeson->Px(), EventNDMGoodMeson->Py(), EventNDMGoodMeson->Pz(), EventNDMGoodMeson->Energy());
+                      FixPzToMatchPDGInvMassNDM(NDMtmp);
+                      AliAODConversionMother *PiMiNDMtmp = new AliAODConversionMother(&EventPiMiGoodMeson,NDMtmp);
+                      AliAODConversionMother *PiMiPiMiNDMtmp = new AliAODConversionMother(&EventPiMiGoodMeson2,PiMiNDMtmp);
+
+                      // Fill histograms (likesign)
+                      fHistoMotherLikeSignBackInvMassPt[fiCut]->Fill(PiMiPiMiNDMBackgroundCandidate->M(),PiMiPiMiNDMBackgroundCandidate->Pt());
+                      fHistoMotherLikeSignBackInvMassSubNDMPt[fiCut]->Fill(PiMiPiMiNDMBackgroundCandidate->M()-(EventNDMGoodMeson->M()-fPDGMassNDM),PiMiPiMiNDMBackgroundCandidate->Pt());
+                      fHistoMotherLikeSignBackInvMassFixedPzNDMPt[fiCut]->Fill(PiMiPiMiNDMtmp->M(),PiMiPiMiNDMtmp->Pt());
+
+                      delete NDMtmp;
+                      delete PiMiNDMtmp;
+                      delete PiMiPiMiNDMtmp;
+
+                      delete PiMiPiMiNDMBackgroundCandidate;
+                      PiMiPiMiNDMBackgroundCandidate = 0x0;
+                    }
+                  }
+
+
+              }
+          } // end of iCurrentPiMi2
+     }// end of iCurrenPiMi
+   } // end of LikeSign if
+ } //end loop pi0 candidates
+}
+
+//______________________________________________________________________
+Bool_t AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::KinematicCut(AliAODConversionMother *negpion, AliAODConversionMother *pospion, AliAODConversionMother *neutpion, AliAODConversionMother *omega){
+
+  if(fTolerance == -1) return kTRUE;
+  if((omega->Pt())<=5.){
+    if( (omega->Angle(pospion->Vect()))    < ((2.78715*(TMath::Exp(-0.589934*(omega->Pt()))+0.0519574))*fTolerance) &&
+        (omega->Angle(negpion->Vect()))    < ((5.94216*(TMath::Exp(-0.444428*(omega->Pt()))-0.0574076))*fTolerance) &&
+        (omega->Angle(neutpion->Vect()))   < ((2.79529*(TMath::Exp(-0.565999*(omega->Pt()))+0.0413576))*fTolerance) &&
+        (pospion->Angle(negpion->Vect()))  < ((3.14446*(TMath::Exp(-0.666433*(omega->Pt()))+0.0964309))*fTolerance) &&
+        (pospion->Angle(neutpion->Vect())) < ((3.08241*(TMath::Exp(-0.650657*(omega->Pt()))+0.0997539))*fTolerance) &&
+        (negpion->Angle(neutpion->Vect())) < ((3.18536*(TMath::Exp(-0.752847*(omega->Pt()))+0.1262780))*fTolerance)
+      ){
+        return kTRUE;
+    }
+  }else{
+    if( (omega->Angle(pospion->Vect()))    < ((0.459270*(TMath::Exp(-0.126007*(omega->Pt()))+0.100475))*fTolerance) &&
+        (omega->Angle(negpion->Vect()))    < ((0.521250*(TMath::Exp(-0.152532*(omega->Pt()))+0.114617))*fTolerance) &&
+        (omega->Angle(neutpion->Vect()))   < ((0.409766*(TMath::Exp(-0.108566*(omega->Pt()))+0.103594))*fTolerance) &&
+        (pospion->Angle(negpion->Vect()))  < ((0.709206*(TMath::Exp(-0.149072*(omega->Pt()))+0.111345))*fTolerance) &&
+        (pospion->Angle(neutpion->Vect())) < ((0.662184*(TMath::Exp(-0.123397*(omega->Pt()))+0.104675))*fTolerance) &&
+        (negpion->Angle(neutpion->Vect())) < ((0.730228*(TMath::Exp(-0.120859*(omega->Pt()))+0.105522))*fTolerance)
+      ){
+        return kTRUE;
+    }
+  }
+  return kFALSE;
+}
+
+
+//______________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessTrueMesonCandidates(AliAODConversionMother *mesoncand, AliAODConversionMother *TrueNeutralDecayMesonCandidate, AliAODConversionPhoton *TrueVirtualParticleCandidate)
+{
+
+  // Process True Mesons
+
+  Bool_t isSameMotherPiPlPiMiNDM   = kFALSE;   // pi+ pi- and pi0 have the same mother
+  Bool_t isSameMotherPiPlPiMi         = kFALSE;   // pi+ and pi- have the same mother
+  Bool_t isSameMotherPiPlNDM       = kFALSE;   // pi+ and pi0 have the same mother
+  Bool_t isSameMotherPiMiNDM       = kFALSE;   // pi- and pi0 have the same mother
+  Bool_t isNoSameMother               = kFALSE;   // none of the pions have the same mother
+  Bool_t isNoPiPiPi                   = kFALSE;   // the decay is not a 3 pion decay
+
+
+  Int_t virtualParticleMCLabel = TrueVirtualParticleCandidate->GetMCParticleLabel(fMCEvent);
+  Int_t virtualParticleMotherLabel = -1;
+  Int_t trueMesonFlag  = TrueNeutralDecayMesonCandidate->GetTrueMesonValue();
+  Int_t NDMMCLabel     = TrueNeutralDecayMesonCandidate->GetMCLabel();
+
+  Float_t weighted= 1;
+
+  if ( !(trueMesonFlag == 1 && NDMMCLabel != -1)){
+      if((fDoMesonQA>0 ) && (!fDoLightOutput)){
+          fHistoTruePiPlPiMiNDMContaminationInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt(),weighted);
+      }
+      return;
+  }
+  Int_t NDMMotherLabel =  fMCEvent->Particle(NDMMCLabel)->GetMother(0);
+
+  TParticle * negativeMC = (TParticle*)TrueVirtualParticleCandidate->GetNegativeMCDaughter(fMCEvent);
+  TParticle * positiveMC = (TParticle*)TrueVirtualParticleCandidate->GetPositiveMCDaughter(fMCEvent);
+
+  Int_t posMotherLabelMC = positiveMC->GetMother(0);
+  Int_t negMotherLabelMC = negativeMC->GetMother(0);
+
+  // Check case present
+  if((TMath::Abs(negativeMC->GetPdgCode())==211) && (TMath::Abs(positiveMC->GetPdgCode())==211) && (fMCEvent->Particle(NDMMCLabel)->GetPdgCode()==fPDGCodeNDM)){
+    // three pion decay
+    if(virtualParticleMCLabel!=-1){
+      // pi+ pi- have same mother
+      virtualParticleMotherLabel  = virtualParticleMCLabel;
+      if(virtualParticleMotherLabel==NDMMotherLabel){
+        // all pions from same mother
+        if(fMCEvent->Particle(NDMMotherLabel)->GetStatusCode()!=21) isSameMotherPiPlPiMiNDM  = kTRUE;
+      } else{
+        // only pi+ pi- from same mother
+        if(fMCEvent->Particle(virtualParticleMotherLabel)->GetStatusCode()!=21) isSameMotherPiPlPiMi = kTRUE;
+      }
+    } else{
+      if(NDMMotherLabel==negMotherLabelMC && negMotherLabelMC != -1){
+        // pi0 and pi- same mother
+        if(fMCEvent->Particle(negMotherLabelMC)->GetStatusCode()!=21) isSameMotherPiMiNDM      = kTRUE;
+      } else if(NDMMotherLabel==posMotherLabelMC && posMotherLabelMC != -1){
+        // pi0 and pi+ same mother
+        if(fMCEvent->Particle(posMotherLabelMC)->GetStatusCode()!=21)  isSameMotherPiPlNDM      = kTRUE;
+      } else{
+        // all pions different mother
+        isNoSameMother              = kTRUE;
+      }
+    }
+  } else{
+    // not a three pion decay
+    isNoPiPiPi = kTRUE;
+  }
+
+  // Do things for each case
+  if(isSameMotherPiPlPiMiNDM){
+    if(fMCEvent->Particle(NDMMotherLabel)->GetPdgCode()                        == fPDGCodeAnalyzedMeson){
+      // eta was found
+      fHistoTrueMotherPiPlPiMiNDMInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt(),weighted);
+      fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt(),weighted);
+      AliAODConversionMother *PosPiontmp = new AliAODConversionMother();
+      PosPiontmp->SetPxPyPzE(positiveMC->Px(), positiveMC->Py(), positiveMC->Pz(), positiveMC->Energy());
+      AliAODConversionMother *NegPiontmp = new AliAODConversionMother();
+      NegPiontmp->SetPxPyPzE(negativeMC->Px(), negativeMC->Py(), negativeMC->Pz(), negativeMC->Energy());
+      if(!fDoLightOutput) fHistoTrueAngleSum[fiCut]->Fill(mesoncand->Pt(),((PosPiontmp->Angle(mesoncand->Vect()))+(NegPiontmp->Angle(PosPiontmp->Vect()))+(PosPiontmp->Angle(TrueNeutralDecayMesonCandidate->Vect()))));
+
+      delete PosPiontmp; PosPiontmp = 0x0;
+      delete NegPiontmp; NegPiontmp = 0x0;
+
+      // Fill tree to get info about event that the eta was found in
+      if(fDoMesonQA>1 && (!fDoLightOutput)){
+         fV0MultiplicityHNMEvent = fMCEvent->GetNumberOfV0s();
+         fTrackMultiplicityHNMEvent = fMCEvent->GetNumberOfTracks();
+         fZVertexHNMEvent = fMCEvent->GetPrimaryVertex()->GetZ();
+         fPtHNM = mesoncand->Pt();
+
+         fTreeEventInfoHNM[fiCut]->Fill();
+      }
+      if (CheckVectorForDoubleCount(fVectorDoubleCountTrueHNMs,NDMMotherLabel) && (!fDoLightOutput)) fHistoDoubleCountTrueHNMInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt());
+    } else{
+      if(fDoMesonQA>1 && (!fDoLightOutput)){
+        // Write "unknown" mother to TTree
+        fSamePiPiPiMotherID       = fMCEvent->Particle(posMotherLabelMC)->GetPdgCode();
+        fSamePiPiPiMotherInvMass  = mesoncand->M();
+        fSamePiPiPiMotherPt       = mesoncand->Pt();
+
+        fTreePiPiPiSameMother[fiCut]->Fill();
+      }
+    }
+  } else if(isSameMotherPiPlPiMi &&  (fDoMesonQA>0 ) && (!fDoLightOutput)){
+    if(fMCEvent->Particle(posMotherLabelMC)->GetPdgCode()                     == 221){
+      // pi+pi- come from eta
+      fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt(),weighted);
+    } else if(fMCEvent->Particle(posMotherLabelMC)->GetPdgCode()              == 223){
+      // pi+pi- come from omega
+      fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt(),weighted);
+    } else if(fMCEvent->Particle(posMotherLabelMC)->GetPdgCode()              == 113){
+      // pi+pi- come from rho0
+      fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt(),weighted);
+    } else if(fMCEvent->Particle(posMotherLabelMC)->GetPdgCode()              == 331){
+      // pi+pi- come from eta prime
+      fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt(),weighted);
+    } else if(fMCEvent->Particle(posMotherLabelMC)->GetPdgCode()              == 310){
+      // pi+pi- come from K0 short
+      fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt(),weighted);
+    } else if(fMCEvent->Particle(posMotherLabelMC)->GetPdgCode()              == 130){
+      // pi+pi- come from K0 short
+      fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt(),weighted);
+    } else{
+      // pi+pi- come from something else
+      if(fDoMesonQA>1 && (!fDoLightOutput)){
+        fCasePiPi = 0;
+        // Write "unknown" mother to TTree
+        fSamePiPiMotherID = fMCEvent->Particle(posMotherLabelMC)->GetPdgCode();
+        fSamePiPiMotherInvMass = mesoncand->M();
+        fSamePiPiMotherPt = mesoncand->Pt();
+
+        fTreePiPiSameMother[fiCut]->Fill();
+      }
+    }
+  } else if(isSameMotherPiMiNDM  &&  (fDoMesonQA>0 ) && (!fDoLightOutput)){
+    if(fMCEvent->Particle(NDMMotherLabel)->GetPdgCode()                       == 221){
+      // pi0pi- come from eta
+      fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt(),weighted);
+    } else if(fMCEvent->Particle(NDMMotherLabel)->GetPdgCode()                == 223){
+      // pi0pi- come from omega
+      fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt(),weighted);
+    } else if(fMCEvent->Particle(NDMMotherLabel)->GetPdgCode()                ==-213){
+      // pi0pi- come from rho-
+      fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt(),weighted);
+    } else if(fMCEvent->Particle(NDMMotherLabel)->GetPdgCode()                == 130){
+      // pi0pi- come from rho-
+      fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt(),weighted);
+    } else{
+      // pi0pi- come from something else
+      if(fDoMesonQA>1){
+        fCasePiPi = 1;
+        // Write "unknown" mother to TTree
+        fSamePiPiMotherID = fMCEvent->Particle(NDMMotherLabel)->GetPdgCode();
+        fSamePiPiMotherInvMass = mesoncand->M();
+        fSamePiPiMotherPt = mesoncand->Pt();
+
+        fTreePiPiSameMother[fiCut]->Fill();
+      }
+    }
+  } else if(isSameMotherPiPlNDM  &&  (fDoMesonQA>0 ) && (!fDoLightOutput)){
+    if(fMCEvent->Particle(posMotherLabelMC)->GetPdgCode()                     == 221){
+      // pi+pi0 come from eta
+      fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt(),weighted);
+    } else if(fMCEvent->Particle(posMotherLabelMC)->GetPdgCode()              == 223){
+      // pi+pi0 come from omega
+      fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt(),weighted);
+    } else if(fMCEvent->Particle(posMotherLabelMC)->GetPdgCode()              == 213) {
+      // pi+pi0 come from rho+
+      fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt(),weighted);
+    } else if(fMCEvent->Particle(posMotherLabelMC)->GetPdgCode()              == 130) {
+      // pi+pi0 come from rho+
+      fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt(),weighted);
+    } else{
+      // pi+pi0 come from something else
+      if(fDoMesonQA>1){
+        fCasePiPi = 2;
+        // Write "unknown" mother to TTree
+        fSamePiPiMotherID = fMCEvent->Particle(NDMMotherLabel)->GetPdgCode();
+        fSamePiPiMotherInvMass = mesoncand->M();
+        fSamePiPiMotherPt = mesoncand->Pt();
+
+        fTreePiPiSameMother[fiCut]->Fill();
+      }
+    }
+  } else if(isNoSameMother  &&  (fDoMesonQA>0 ) && (!fDoLightOutput)){
+    // no same mother purecombinatorical
+    fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt(),weighted);
+  } else if(isNoPiPiPi  &&  (fDoMesonQA>0 ) && (!fDoLightOutput)){
+    // no pi pi pi decay contamination
+    fHistoTruePiPlPiMiNDMContaminationInvMassPt[fiCut]->Fill(mesoncand->M(),mesoncand->Pt(),weighted);
+    // investigate here what was missmatched (?)
+
+  }
+}
+
+
+//________________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::UpdateEventByEventData(){
+  //see header file for documentation
+
+  Int_t method = 1;
+  if( method == 1 ) {
+    if(fPosPionCandidates->GetEntries() >0 && fNegPionCandidates->GetEntries() >0){
+      if(((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->UseTrackMultiplicity()){
+        fBGHandlerPiPl[fiCut]->AddMesonEvent(fPosPionCandidates,fInputEvent->GetPrimaryVertex()->GetX(),fInputEvent->GetPrimaryVertex()->GetY(),fInputEvent->GetPrimaryVertex()->GetZ(),fV0Reader->GetNumberOfPrimaryTracks(),0);
+        fBGHandlerPiMi[fiCut]->AddMesonEvent(fNegPionCandidates,fInputEvent->GetPrimaryVertex()->GetX(),fInputEvent->GetPrimaryVertex()->GetY(),fInputEvent->GetPrimaryVertex()->GetZ(),fV0Reader->GetNumberOfPrimaryTracks(),0);
+      } else { // means we use #V0s for multiplicity
+        if (fNDMRecoMode < 2){
+          fBGHandlerPiPl[fiCut]->AddMesonEvent(fPosPionCandidates,fInputEvent->GetPrimaryVertex()->GetX(),fInputEvent->GetPrimaryVertex()->GetY(),fInputEvent->GetPrimaryVertex()->GetZ(),fGoodConvGammas->GetEntries(),0);
+          fBGHandlerPiMi[fiCut]->AddMesonEvent(fNegPionCandidates,fInputEvent->GetPrimaryVertex()->GetX(),fInputEvent->GetPrimaryVertex()->GetY(),fInputEvent->GetPrimaryVertex()->GetZ(),fGoodConvGammas->GetEntries(),0);
+        }else {
+          fBGHandlerPiPl[fiCut]->AddMesonEvent(fPosPionCandidates,fInputEvent->GetPrimaryVertex()->GetX(),fInputEvent->GetPrimaryVertex()->GetY(),fInputEvent->GetPrimaryVertex()->GetZ(),fClusterCandidates->GetEntries(),0);
+          fBGHandlerPiMi[fiCut]->AddMesonEvent(fNegPionCandidates,fInputEvent->GetPrimaryVertex()->GetX(),fInputEvent->GetPrimaryVertex()->GetY(),fInputEvent->GetPrimaryVertex()->GetZ(),fClusterCandidates->GetEntries(),0);
+        }
+      }
+    }
+  }
+}
+
+//________________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::MoveParticleAccordingToVertex(AliAODConversionMother* particle,const AliGammaConversionAODBGHandler::GammaConversionVertex *vertex){
+  //see header file for documentation
+
+  Double_t dx = vertex->fX - fInputEvent->GetPrimaryVertex()->GetX();
+  Double_t dy = vertex->fY - fInputEvent->GetPrimaryVertex()->GetY();
+  Double_t dz = vertex->fZ - fInputEvent->GetPrimaryVertex()->GetZ();
+
+  Double_t movedPlace[3] = {particle->GetProductionX() - dx,particle->GetProductionY() - dy,particle->GetProductionZ() - dz};
+  particle->SetProductionPoint(movedPlace);
+}
+
+//________________________________________________________________________
+void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::FixPzToMatchPDGInvMassNDM(AliAODConversionMother* particle) {
+
+  Double_t px = particle->Px();
+  Double_t py = particle->Py();
+  Int_t signPz = particle->Pz()<0?-1:1;
+  Double_t energy = particle->Energy();
+  Double_t pz = signPz*TMath::Sqrt(TMath::Abs(pow(fPDGMassNDM,2)-pow(energy,2)+pow(px,2)+pow(py,2)));
+  particle->SetPxPyPzE(px,py,pz,energy);
+
+  return;
+}
+
+//_____________________________________________________________________________________
+Bool_t AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::IsEtaPrimePiPlPiMiEtaDaughter( Int_t label ) const {
+  //
+  // Returns true if the particle comes from eta -> pi+ pi- gamma
+  //
+  if(label<0) return kFALSE;
+  Int_t motherLabel = fMCEvent->Particle( label )->GetMother(0);
+  if( motherLabel < 0 || motherLabel >= fMCEvent->GetNumberOfTracks() ) return kFALSE;
+
+  TParticle* mother = fMCEvent->Particle( motherLabel );
+  if( mother->GetPdgCode() != 331 ) return kFALSE;
+  if( IsPiPlPiMiEtaDecay( mother ) ) return kTRUE;
+  return kFALSE;
+}
+//_____________________________________________________________________________________
+Bool_t AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::IsEtaPiPlPiMiPiZeroDaughter( Int_t label ) const {
+  //
+  // Returns true if the particle comes from eta -> pi+ pi- gamma
+  //
+    if(label<0) return kFALSE;
+  Int_t motherLabel = fMCEvent->Particle( label )->GetMother(0);
+  if( motherLabel < 0 || motherLabel >= fMCEvent->GetNumberOfTracks() ) return kFALSE;
+
+  TParticle* mother = fMCEvent->Particle( motherLabel );
+  if( mother->GetPdgCode() != 221 ) return kFALSE;
+  if( IsPiPlPiMiPiZeroDecay( mother ) ) return kTRUE;
+  return kFALSE;
+}
+
+//_____________________________________________________________________________________
+Bool_t AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::IsOmegaPiPlPiMiPiZeroDaughter( Int_t label ) const {
+  //
+  // Returns true if the particle comes from eta -> pi+ pi- gamma
+  //
+  if(label<0) return kFALSE;
+  Int_t motherLabel = fMCEvent->Particle( label )->GetMother(0);
+  if( motherLabel < 0 || motherLabel >= fMCEvent->GetNumberOfTracks() ) return kFALSE;
+
+  TParticle* mother = fMCEvent->Particle( motherLabel );
+  if( mother->GetPdgCode() != 223 ) return kFALSE;
+  if( IsPiPlPiMiPiZeroDecay( mother ) ) return kTRUE;
+  return kFALSE;
+}
+
+
+//_____________________________________________________________________________
+Bool_t AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::IsPiPlPiMiPiZeroDecay(TParticle *fMCMother) const
+{
+  if( fMCMother->GetNDaughters() != 3 ) return kFALSE;
+  if( !(fMCMother->GetPdgCode() == 221 || fMCMother->GetPdgCode() == 223)  ) return kFALSE;
+
+  TParticle *posPion = 0x0;
+  TParticle *negPion = 0x0;
+  TParticle *neutPion    = 0x0;
+
+  for(Int_t index= fMCMother->GetFirstDaughter();index<= fMCMother->GetLastDaughter();index++){
+    if(index<0) continue;
+    TParticle* temp = (TParticle*)fMCEvent->Particle( index );
+
+    switch( temp->GetPdgCode() ) {
+    case 211:
+      posPion =  temp;
+      break;
+    case -211:
+      negPion =  temp;
+      break;
+    case 111:
+      neutPion = temp;
+      break;
+    }
+  }
+  if( posPion && negPion && neutPion) return kTRUE;
+
+  return kFALSE;
+}
+
+//_____________________________________________________________________________
+Bool_t AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::IsPiPlPiMiEtaDecay(TParticle *fMCMother) const
+{
+  if( fMCMother->GetNDaughters() != 3 ) return kFALSE;
+  if( !(fMCMother->GetPdgCode() == 331)  ) return kFALSE;
+
+  TParticle *posPion = 0x0;
+  TParticle *negPion = 0x0;
+  TParticle *etaMeson    = 0x0;
+
+  for(Int_t index= fMCMother->GetFirstDaughter();index<= fMCMother->GetLastDaughter();index++){
+    if(index<0) continue;
+    TParticle* temp = (TParticle*)fMCEvent->Particle( index );
+
+    switch( temp->GetPdgCode() ) {
+    case 211:
+      posPion =  temp;
+      break;
+    case -211:
+      negPion =  temp;
+      break;
+    case 221:
+      etaMeson = temp;
+      break;
+    }
+  }
+  if( posPion && negPion && etaMeson) return kTRUE;
+
+  return kFALSE;
+}
+
+//_____________________________________________________________________________________
+Bool_t AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::GammaIsNeutralMesonPiPlPiMiNDMDaughter( Int_t label ) const {
+  //
+  // Returns true if the particle comes from eta -> pi+ pi- gamma
+  //
+    if(label<0) return kFALSE;
+  Int_t motherLabel = fMCEvent->Particle( label )->GetMother(0);
+  if( motherLabel < 0 || motherLabel >= fMCEvent->GetNumberOfTracks() ) return kFALSE;
+
+  TParticle* mother = fMCEvent->Particle( motherLabel );
+  if( mother->GetPdgCode() != fPDGCodeNDM ) return kFALSE;
+  Int_t grandMotherLabel = mother->GetMother(0);
+  if( grandMotherLabel < 0 || grandMotherLabel >= fMCEvent->GetNumberOfTracks() ) return kFALSE;
+  TParticle* grandmother = fMCEvent->Particle( grandMotherLabel );
+  
+  switch( fSelectedHeavyNeutralMeson ) {
+  case 0: // ETA MESON
+  case 1: // OMEGA MESON
+    if( IsPiPlPiMiPiZeroDecay( grandmother ) ) return kTRUE;
+    break;
+  case 2: // ETA PRIME MESON
+    if( IsPiPlPiMiEtaDecay( grandmother ) ) return kTRUE;
+    break;
+  default:
+    AliError(Form("Heavy neutral meson not correctly selected (only 0,1,2 valid)... selected: %d",fSelectedHeavyNeutralMeson));
+  }
+  
+  return kFALSE;
+}
+
+//_________________________________________________________________________________
+Bool_t AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::CheckVectorForDoubleCount(vector<Int_t> &vec, Int_t tobechecked)
+{
+  if(tobechecked > -1)
+  {
+    vector<Int_t>::iterator it;
+    it = find (vec.begin(), vec.end(), tobechecked);
+    if (it != vec.end()) return true;
+    else{
+      vec.push_back(tobechecked);
+      return false;
+    }
+  }
+  return false;
+}
+
+

--- a/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.h
@@ -1,0 +1,308 @@
+
+#ifndef AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson_H
+#define AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson_H
+
+/* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
+
+
+#include "AliAnalysisTaskSE.h"
+#include "AliV0ReaderV1.h"
+#include "AliKFConversionPhoton.h"
+#include "AliPrimaryPionSelector.h"
+#include "AliConversionMesonCuts.h"
+#include "AliConvEventCuts.h"
+#include "AliCaloPhotonCuts.h"
+#include "AliGammaConversionAODBGHandler.h"
+#include "TProfile2D.h"
+#include <vector>
+
+class AliESDInputHandler;
+class AliMCEventHandler;
+class AliESDEvent;
+class AliESDtrack;
+class AliESDtrackCuts;
+class AliESDpidCuts;
+class AliTriggerAnalysis;
+
+class AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson: public AliAnalysisTaskSE
+{
+  public:
+
+    AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson();
+    AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson( const char* name );
+    virtual ~AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson();
+
+    virtual void UserExec(Option_t *);
+    virtual void UserCreateOutputObjects();
+    virtual Bool_t Notify();
+    virtual void Terminate(const Option_t *);
+
+    void SetV0ReaderName(TString name){fV0ReaderName=name; return;}
+
+    void SetMoveParticleAccordingToVertex(Bool_t flag){fMoveParticleAccordingToVertex = flag;}
+    void SetIsHeavyIon(Int_t flag){
+      if (flag == 1 || flag ==2 ){
+        fIsHeavyIon = 1;
+      } else {
+        fIsHeavyIon = 0;
+      }
+    }
+
+    void SetIsMC(Bool_t isMC){fIsMC=isMC;}
+    void SetLightOutput(Bool_t flag){fDoLightOutput = flag;}
+    void SetEventCutList(Int_t nCuts, TList *CutArray){
+      fnCuts= nCuts;
+      fEventCutArray = CutArray;
+    }
+    void SetConversionCutList(TList *CutArray){ fGammaCutArray = CutArray;}
+    void SetClusterCutList(TList *CutArray){ fClusterCutArray = CutArray;}
+    void SetPionCutList(TList *CutArray){ fPionCutArray = CutArray;}
+    void SetNeutralPionCutList(TList *CutArray){ fNeutralDecayMesonCutArray = CutArray; }
+    void SetMesonCutList(TList *CutArray){ fMesonCutArray = CutArray; }
+    void SetDoMesonQA(Int_t flag){ fDoMesonQA = flag; }
+    void SetNDMRecoMode(Int_t mode){fNDMRecoMode = mode; }
+    void SetTolerance(Double_t tol){fTolerance=tol;}
+    void SetSelectedHeavyNeutralMeson(Int_t selectMeson){fSelectedHeavyNeutralMeson=selectMeson;}
+
+  private:
+
+    void InitBack();
+
+    // routines for photon selection from conversions
+    void ProcessConversionPhotonCandidates();
+    void ProcessTrueConversionPhotonCandidates(AliAODConversionPhoton*);
+
+    // routines for photon selection from clusters
+    void ProcessCaloPhotonCandidates();
+    void ProcessTrueCaloPhotonCandidates(AliAODConversionPhoton *TruePhotonCandidate);
+
+    void ProcessTrueMesonCandidates(AliAODConversionMother *Pi0Candidate, AliAODConversionMother *TrueNeutralPionCandidate, AliAODConversionPhoton *TrueVirtualGammaCandidate);
+    void MoveParticleAccordingToVertex(AliAODConversionMother* particle,const AliGammaConversionAODBGHandler::GammaConversionVertex *vertex);
+
+    void FixPzToMatchPDGInvMassNDM(AliAODConversionMother* particle);
+
+    // routines for neutral pion candidates from pure conversion
+    void ProcessNeutralDecayMesonCandidatesPureConversions();
+    void ProcessTrueNeutralPionCandidatesPureConversions(AliAODConversionMother *Pi0Candidate, AliAODConversionPhoton *TrueGammaCandidate0, AliAODConversionPhoton *TrueGammaCandidate1);
+    void ProcessTrueNeutralPionCandidatesPureConversionsAOD(AliAODConversionMother *Pi0Candidate, AliAODConversionPhoton *TrueGammaCandidate0, AliAODConversionPhoton *TrueGammaCandidate1);
+
+    // routines for neutral pion candidates from pure calo
+    void ProcessNeutralPionCandidatesPureCalo();
+    void ProcessTrueNeutralPionCandidatesPureCalo(AliAODConversionMother *Pi0Candidate, AliAODConversionPhoton *TrueGammaCandidate0, AliAODConversionPhoton *TrueGammaCandidate1);
+
+    // routines for neutral pion candidates from mixed conv + calo
+    void ProcessNeutralPionCandidatesMixedConvCalo();
+    void ProcessTrueNeutralPionCandidatesMixedConvCalo( AliAODConversionMother *Pi0Candidate, AliAODConversionPhoton *TrueGammaCandidate0, AliAODConversionPhoton *TrueGammaCandidate1);
+
+    void ProcessPionCandidates();
+    void ProcessMCParticles();
+    void CalculateMesonCandidates();
+    void CalculateBackground();
+    void UpdateEventByEventData();
+
+    Bool_t IsPiPlPiMiPiZeroDecay(TParticle *fMCMother) const;
+    Bool_t IsPiPlPiMiEtaDecay(TParticle *fMCMother) const;
+    Bool_t IsEtaPrimePiPlPiMiEtaDaughter( Int_t label ) const;
+    Bool_t IsEtaPiPlPiMiPiZeroDaughter( Int_t label ) const;
+    Bool_t IsOmegaPiPlPiMiPiZeroDaughter( Int_t label ) const;
+    Bool_t GammaIsNeutralMesonPiPlPiMiNDMDaughter( Int_t label ) const;
+
+    Bool_t CheckVectorForDoubleCount(vector<Int_t> &vec, Int_t tobechecked);
+
+    Bool_t KinematicCut(AliAODConversionMother *negpion, AliAODConversionMother *pospion, AliAODConversionMother *neutpion, AliAODConversionMother *omega);
+
+
+    AliV0ReaderV1*                    fV0Reader;                                          // V0Reader for basic conversion photon selection
+    TString                           fV0ReaderName;
+    AliPrimaryPionSelector*           fPionSelector;                                      // primary charged pion selector, basic selection of pi+,pi-
+    AliGammaConversionAODBGHandler**  fBGHandlerPiPl;                                     // BG handler Pos Pion
+    AliGammaConversionAODBGHandler**  fBGHandlerPiMi;                                     // BG handler Neg Pion
+    AliESDEvent*                      fESDEvent;                                          // current event
+    AliMCEvent*                       fMCEvent;                                           // current MC event
+    TList**                           fCutFolder;                                         // list of output folders with main cut name
+    TList**                           fESDList;                                           // list with main output histograms for data
+    TList**                           fTrueList;                                          // list with validated reconstructed MC histograms
+    TList**                           fTrueTreeList;                                      // list containing TTree's for MC True
+    TList**                           fMCList;                                            // list with pure MC histograms
+    TList*                            fOutputContainer;                                   // output container
+    TClonesArray*                     fReaderGammas;                                      // array with photon from fV0Reader
+    vector<Int_t>                     fSelectorNegPionIndex;                              // array with pion indices for negative pions from fPionSelector
+    vector<Int_t>                     fSelectorPosPionIndex;                              // array with pion indices for positive pions from fPionSelector
+    TList*                            fGoodConvGammas;                                    // good conv gammas after selection
+    TList*                            fClusterCandidates;                                 //! good calo gammas after selection
+    TList*                            fNeutralDecayParticleCandidates;                             // good neutral pion candidates
+    TList*                            fNeutralDecayParticleSidebandCandidates;                     // good neutral pion candidates from sideband
+    TList*                            fPosPionCandidates;                                 // good positive pion candidates
+    TList*                            fNegPionCandidates;                                 // good negative pion candidates
+    TList*                            fGoodVirtualParticles;                              // combination of pi+pi- candidates
+    TList*                            fEventCutArray;                                     // array with event cuts
+    TList*                            fGammaCutArray;                                     // array with Conversion Cuts
+    TList*                            fClusterCutArray;                                   // array with Cluster Cuts
+    TList*                            fPionCutArray;                                      // array with charged pion cuts
+    TList*                            fNeutralDecayMesonCutArray;                          // array with neutral pion cuts
+    TList*                            fMesonCutArray;                                     // array with neutral meson cuts
+    AliConvEventCuts*                 fEventCuts;                                         // current event cuts
+    AliConversionPhotonCuts*          fConversionCuts;                                    // current conversion cuts
+    AliCaloPhotonCuts*                fClusterCuts;                                       // current cluster cuts
+
+    // TTrees
+    TTree**                           fTreePiPiSameMother;                                // Tree containing info about the mother of two pions who have the same mother,
+                                                                                          // if ID isn't covered by current implementations
+    TTree**                           fTreePiPiPiSameMother;                              // Tree containing info about the mother of three pions who have the same mother,
+    TTree**                           fTreeEventInfoHNM;                                  // Tree containing information about an event where eta->pi+pi-pi0 was found
+                                                                                          // if ID isn't covered by current implementations
+    Short_t                           fCasePiPi;                                          // 0:PiPlPiMi 1:PiMiPiZero 1:PiPlPiZero
+    Float_t                           fSamePiPiMotherID;                                  // ID of mother of two pions
+    Float_t                           fSamePiPiMotherInvMass;                             // Invariant mass of mother of two pions
+    Float_t                           fSamePiPiMotherPt;                                  // pT of mother of two pions
+    Float_t                           fSamePiPiPiMotherID;                                // ID of mother of two pions
+    Float_t                           fSamePiPiPiMotherInvMass;                           // Invariant mass of mother of two pions
+    Float_t                           fSamePiPiPiMotherPt;                                // pT of mother of two pions
+    Float_t                           fV0MultiplicityHNMEvent;                            // V0 multiplicity of an event where a true Eta was found
+    Float_t                           fTrackMultiplicityHNMEvent;                         // track multiplicity of an event where a true Eta was found
+    Float_t                           fZVertexHNMEvent;                                   // z position of primary vertex of an event where a true Eta was found
+    Float_t                           fPtHNM;                                             // pT of a true Eta
+    Float_t                           fPDGMassNDM;                                        // PDG mass of either pi0 or eta
+    Int_t                             fPDGCodeNDM;                                        // PDG code of either pi0 or eta
+    Int_t                             fPDGCodeAnalyzedMeson;                              // PDG code of the analyzed heavy netural meson
+    // reconstructed particles
+    TH1F**                            fHistoConvGammaPt;                                  // array of histos of conversion photon, pt
+    TH1F**                            fHistoConvGammaEta;                                 // array of histos of conversion photon, eta
+    TH1F**                            fHistoClusterGammaPt;                               // array of histos of Cluster photon, pt
+    TH1F**                            fHistoClusterGammaEta;                              // array of histos of Cluster photon, eta
+    TH1F**                            fHistoNegPionPt;                                    // array of histos of negative pion, pt
+    TH1F**                            fHistoPosPionPt;                                    // array of histos of positive pion, pt
+    TH1F**                            fHistoNegPionPhi;                                   // array of histos of negative pion, phi
+    TH1F**                            fHistoPosPionPhi;                                   // array of histos of positive pion, phi
+    TH1F**                            fHistoNegPionEta;                                   // array of histos of negative pion, eta
+    TH1F**                            fHistoPosPionEta;                                   // array of histos of positive pion, eta
+    TH2F**                            fHistoNegPionClsTPC;                                // array of histos of negative pion, findable tpc cluster, pT
+    TH2F**                            fHistoPosPionClsTPC;                                // array of histos of positive pion, findable tpc cluster, pT
+    TH2F**                            fHistoPionDCAxy;                                    // array of histos of pion, dca_xy, pT
+    TH2F**                            fHistoPionDCAz;                                     // array of histos of pion, dca_z, pT
+    TH2F**                            fHistoPionTPCdEdxNSigma;                            // array of histos of pion, p, TPC nSigma dEdx pion
+    TH2F**                            fHistoPionTPCdEdx;                                  // array of histos of pion, p, TPC dEdx
+    TH2F**                            fHistoPionPionInvMassPt;                            // array of histos of pion pion, invMass, pT_{pi+pi-}
+    TH2F**                            fHistoGammaGammaInvMassPt;                          // array of histos of gamma-gamma, invMass, pT_{gamma gamma}
+    TH2F**                            fHistoMotherInvMassPt;                              // array of histos of pi+pi-pi0 same event, invMass, pT_{pi+pi-pi0}
+    TH2F**                            fHistoMotherInvMassPtRejectedKinematic;             // array of histos of rejected pi+pi-pi0 same event, invMass, pT_{pi+pi-pi0}
+    TH2F**                            fHistoBackInvMassPtGroup1;                          // Event mixing background group 1 (pi+ and pi- from same event)
+    TH2F**                            fHistoBackInvMassPtGroup2;                          // Event mixing background group 2 (pi+ and pi0 from same event)
+    TH2F**                            fHistoBackInvMassPtGroup3;                          // Event mixing background group 3 (pi- and pi0 from same event)
+    TH2F**                            fHistoBackInvMassPtGroup4;                          // Event mixing background group 4 (no pion from same event)
+    TH2F**                            fHistoMotherLikeSignBackInvMassPt;                  // array of histos of pi+pi+pi0 likesign mixed event, invMass, pT_{pi+pi-pi0}
+
+    // angle distributions
+    TH2F**                            fHistoAngleHNMesonPiPlPiMi;                           // angle between combined Pi+ and Pi- and omega
+    TH2F**                            fHistoAngleHNMesonNDM;                             // angle between Pi0 and omega
+    TH2F**                            fHistoAngleHNMesonPiPl;                               // angle between Pi+ and omega
+    TH2F**                            fHistoAngleHNMesonPiMi;                               // angle between Pi- and omega
+    TH2F**                            fHistoAnglePiPlPiMi;                                // angle between Pi+ and Pi-
+    TH2F**                            fHistoAngleNDMPiMi;                              // angle between Pi0 and Pi-
+    TH2F**                            fHistoAnglePiPlNDM;                              // angle between Pi+ and Pi0
+    TH2F**                            fHistoAngleSum;                                     // angle between omega and Pi0 + angle between Pi+ and Pi- + angle between Pi0 and Pi-
+    TH2F**                            fHistoTrueAngleSum;
+
+    TH2F**                            fHistoMotherInvMassSubNDM;                          // invariant mass of (pi+,pi-,pi0) - invariant mass of pi0
+    TH2F**                            fHistoBackInvMassPtGroup1SubNDM;                    // background group 1, invMass-invMass(pi0), pT_{pi+pi-pi0} (pi+ and pi- from same event)
+    TH2F**                            fHistoBackInvMassPtGroup2SubNDM;                    // background group 2, invMass-invMass(pi0), pT_{pi+pi-pi0} (pi+ and pi0 from same event)
+    TH2F**                            fHistoBackInvMassPtGroup3SubNDM;                    // background group 3, invMass-invMass(pi0), pT_{pi+pi-pi0} (pi+ and pi0 from same event)
+    TH2F**                            fHistoBackInvMassPtGroup4SubNDM;                    // background group 4, invMass-invMass(pi0), pT_{pi+pi-pi0} (no pion from same event)
+    TH2F**                            fHistoMotherLikeSignBackInvMassSubNDMPt;            // array of histos of pi+pi+pi0 likesign mixed event, invMass-invMass(pi0), pT_{pi+pi-pi0}
+
+    TH2F**                            fHistoMotherInvMassFixedPzNDM;                      // invariant mass of (pi+,pi-,pi0) - invariant mass of pi0
+    TH2F**                            fHistoBackInvMassPtGroup1FixedPzNDM;                // background group 1 mixed event, invMass, pT_{pi+pi-pi0}, the Pz of the pi0 was fixed such that
+                                                                                          // its invMass matches the PDG value
+    TH2F**                            fHistoBackInvMassPtGroup2FixedPzNDM;                // background group 2 mixed event, invMass, pT_{pi+pi-pi0}, the Pz of the pi0 was fixed such that
+                                                                                          // its invMass matches the PDG value
+    TH2F**                            fHistoBackInvMassPtGroup3FixedPzNDM;                // background group 3 mixed event, invMass, pT_{pi+pi-pi0}, the Pz of the pi0 was fixed such that
+                                                                                          // its invMass matches the PDG value
+    TH2F**                            fHistoBackInvMassPtGroup4FixedPzNDM;                // background group 4 mixed event, invMass, pT_{pi+pi-pi0}, the Pz of the pi0 was fixed such that
+                                                                                          // its invMass matches the PDG value
+    TH2F**                            fHistoMotherLikeSignBackInvMassFixedPzNDMPt;        // array of histos of pi+pi+pi0 likesign mixed event, invMass, pT_{pi+pi+pi0}, the Pz of the pi0 was fixed such that
+                                                                                          // its invMass matches the PDG value
+    // pure MC properties
+    TH1F**                            fHistoMCAllGammaPt;                                 // array of histos of all produced gammas in the specified y range
+    TH1F**                            fHistoMCConvGammaPt;                                // array of histos of all converted gammas in the specified y range
+    TH1F**                            fHistoMCAllPosPionsPt;                              // array of histos with all produced primary positive pions in the specified y range
+    TH1F**                            fHistoMCAllNegPionsPt;                              // array of histos with all produced primary negative pions in the specified y range
+    TH1F**                            fHistoMCGammaFromNeutralMesonPt;                    // array of histos of all produced gammas from omega or eta via pi+pi-pi0 in the specified y range/
+    TH1F**                            fHistoMCPosPionsFromNeutralMesonPt;                 // array of histos of all produced positive pions from omega or eta via pi+pi-pi0 in the specified y range/
+    TH1F**                            fHistoMCNegPionsFromNeutralMesonPt;                 // array of histos of all produced negative pions from omega or eta via pi+pi-pi0 in the specified y range/
+    TH1F**                            fHistoMCHNMPiPlPiMiNDMPt;                        // array of histos of produced etas via pi+pi-pi0 in the specified y range
+    TH1F**                            fHistoMCHNMPiPlPiMiNDMInAccPt;                   // array of histos of produced etas via pi+pi-pi0 in the specified y range,
+                                                                                          // with decay products in respective y, eta ranges
+
+    // reconstructed particles MC validated
+    TH2F**                          fHistoTrueMotherPiPlPiMiNDMInvMassPt;              // histos with reconstructed validated eta or omega, inv mass, pT
+    TH2F**                          fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt;           // histos with reconstructed validated eta, inv mass, pT
+    TH2F**                          fHistoTrueMotherGammaGammaInvMassPt;                  // histos with reconstructed validated pi0, inv mass, pT
+    TH2F**                          fHistoTrueMotherGammaGammaFromHNMInvMassPt;           // histos with reconstructed validated pi0, inv mass, pT
+    TH1F**                          fHistoTrueConvGammaPt;                                // histos with reconstructed validated conv gamma, pT
+    TH1F**                          fHistoTrueConvGammaFromNeutralMesonPt;                // histos with reconstructed validated conv gamma from eta or omega via pi0, pT
+    TH1F**                          fHistoTrueClusterGammaPt;                             // histos with reconstructed validated cluster gamma, pT
+    TH1F**                          fHistoTrueClusterGammaFromNeutralMesonPt;             // histos with reconstructed validated cluster gamma from eta or omega via pi0, pT
+    TH1F**                          fHistoTruePosPionPt;                                  // histos with reconstructed validated positive pion, pT
+    TH1F**                          fHistoTruePosPionFromNeutralMesonPt;                  // histos with reconstructed validated positive pion from eta or omega, pT
+    TH1F**                          fHistoTrueNegPionPt;                                  // histos with reconstructed validated negative pion, pT
+    TH1F**                          fHistoTrueNegPionFromNeutralMesonPt;                  // histos with reconstructed validated negative pion from eta or omega, pT
+    TH2F**                          fHistoTruePionPionInvMassPt;                          // histos with reconstructed validated two pion, invariant mass, pT
+    TH2F**                          fHistoTruePionPionFromSameMotherInvMassPt;            // histos with reconstructed validated two pion from same mother, invariant mass, pT
+    TH2F**                          fHistoTruePionPionFromHNMInvMassPt;                   // histos with reconstructed validated two pion from eta , invariant mass, pT
+
+    TH2F**                          fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt;         // histos with reconstructed validated pi+ pi-  from omega, invariant mass, pT
+    TH2F**                          fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt;       // histos with reconstructed validated pi+ pi-  from eta, invariant mass, pT
+    TH2F**                          fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt;         // histos with reconstructed validated pi+ pi-  from rho0, invariant mass, pT
+    TH2F**                          fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt;    // histos with reconstructed validated pi+ pi-  from etaprime, invariant mass, pT
+    TH2F**                          fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt;         // histos with reconstructed validated pi+ pi-  from K0s, invariant mass, pT
+    TH2F**                          fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt;         // histos with reconstructed validated pi+ pi-  from K0s, invariant mass, pT
+
+    TH2F**                          fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt;       // histos with reconstructed validated pi0 pi-  from omega, invariant mass, pT
+    TH2F**                          fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt;     // histos with reconstructed validated pi0 pi-  from eta, invariant mass, pT
+    TH2F**                          fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt;       // histos with reconstructed validated pi0 pi-  from rho0, invariant mass, pT
+    TH2F**                          fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt;       // histos with reconstructed validated pi0 pi-  from rho0, invariant mass, pT
+
+    TH2F**                          fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt;       // histos with reconstructed validated pi0 pi+  from omega, invariant mass, pT
+    TH2F**                          fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt;     // histos with reconstructed validated pi0 pi+  from eta, invariant mass, pT
+    TH2F**                          fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt;       // histos with reconstructed validated pi0 pi+  from rho0, invariant mass, pT
+    TH2F**                          fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt;       // histos with reconstructed validated pi0 pi+  from K0l, invariant mass, pT
+    TH2F**                          fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt;  // histos with reconstructed validated pi+pi-pi0 that are pure combinatorical (do not share a mother)
+    TH2F**                          fHistoTruePiPlPiMiNDMContaminationInvMassPt;       // histos with reconstructed pi+pi-pi0 that are not actually pions
+
+    TH2F**                          fHistoDoubleCountTruePi0InvMassPt;                    //! array of histos with double counted pi0s, invMass, pT
+    TH2F**                          fHistoDoubleCountTrueHNMInvMassPt;                    //! array of histos with double counted etas, invMass, pT
+    TH2F**                          fHistoDoubleCountTrueConvGammaRPt;                    //! array of histos with double counted photons, R, pT
+    vector<Int_t>                   fVectorDoubleCountTruePi0s;                           //! vector containing labels of validated pi0
+    vector<Int_t>                   fVectorDoubleCountTrueHNMs;                           //! vector containing labels of validated eta
+    vector<Int_t>                   fVectorDoubleCountTrueConvGammas;                     //! vector containing labels of validated photons
+    // Event properties
+    TH1I**                          fHistoNEvents;                                        // histo for event counting
+    TH1I**                          fHistoNGoodESDTracks;                                 // histo number of reconstructed primary tracks
+    TProfile**                      fProfileEtaShift;                                     // profile for eta shift bookkeeping
+    TH2F**                          fHistoSPDClusterTrackletBackground;                   //! array of histos with SPD tracklets vs SPD clusters for background rejection
+
+
+    TRandom3                        fRandom;                                              // random number
+    Int_t                           fnCuts;                                               // number of cuts to be run in parallel
+    Int_t                           fiCut;                                                // current cut
+    Int_t                           fNumberOfESDTracks;                                   // integer with number of primary tracks in this event
+    Bool_t                          fMoveParticleAccordingToVertex;                       // Flag to move parice to the vertex
+    Int_t                           fIsHeavyIon;                                          // Flag for collision system 0: pp, 1: PbPb, 2: pPb
+    Bool_t                          fDoMesonAnalysis;                                     // Flag for switching on meson analysis
+    Int_t                           fDoMesonQA;                                           // Switching for meson QA 0: no QA 1: small QA 2: big QA
+    Bool_t                          fIsFromMBHeader;                                      // Flag for particle whether it belongs to accepted header
+    Bool_t                          fIsMC;                                                // Flag for MC
+    Int_t                           fSelectedHeavyNeutralMeson;                                          // Flag for running eta prime
+    Bool_t                          fDoLightOutput;                                       // Flag to turn on light output
+    Int_t                           fNDMRecoMode;                                     // Flag how neutral pion is reconstructed 0=PCM-PCM, 1=PCM-Calo, 2=Calo-Calo
+    Double_t                        fTolerance;                                           // tolerance in rad for angle cuts
+private:
+    AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson( const AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson& ); // Not implemented
+    AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson& operator=( const AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson& ); // Not implemented
+
+  ClassDef(AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson, 1);
+};
+
+#endif // AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson_H
+

--- a/PWGGA/GammaConv/AliConversionMesonCuts.h
+++ b/PWGGA/GammaConv/AliConversionMesonCuts.h
@@ -113,6 +113,7 @@ class AliConversionMesonCuts : public AliAnalysisCuts {
     Bool_t MesonIsSelectedMCDalitz(TParticle *fMCMother,AliMCEvent *mcEvent, Int_t &labelelectron, Int_t &labelpositron, Int_t &labelgamma,Double_t fRapidityShift=0.);
     Bool_t MesonIsSelectedAODMCDalitz(AliAODMCParticle *MCMother,TClonesArray *AODMCArray, Int_t &labelelectron, Int_t &labelpositron, Int_t &labelgamma,Double_t fRapidityShift=0.);
     Bool_t MesonIsSelectedMCEtaPiPlPiMiGamma(TParticle *fMCMother,AliMCEvent *mcEvent, Int_t &labelNegPion, Int_t &labelPosPion, Int_t &labelGamma, Double_t fRapidityShift=0);
+    Bool_t MesonIsSelectedMCPiPlPiMiEta(TParticle *fMCMother,AliMCEvent *mcEvent, Int_t &labelNegPion, Int_t &labelPosPion, Int_t &labelNeutPion, Double_t fRapidityShift=0);
     Bool_t MesonIsSelectedMCPiPlPiMiPiZero(TParticle *fMCMother,AliMCEvent *mcEvent, Int_t &labelNegPion, Int_t &labelPosPion, Int_t &labelNeutPion, Double_t fRapidityShift=0);
     Bool_t MesonIsSelectedMCPiZeroGamma(TParticle *fMCMother, AliMCEvent *mcEvent, Int_t &labelNeutPion, Int_t &labelGamma, Double_t fRapidityShift=0);
     Bool_t MesonIsSelectedMCChiC(TParticle *fMCMother,AliMCEvent *mcEvent, Int_t &, Int_t &, Int_t &, Double_t fRapidityShift=0. );
@@ -277,7 +278,7 @@ class AliConversionMesonCuts : public AliAnalysisCuts {
   private:
 
     /// \cond CLASSIMP
-    ClassDef(AliConversionMesonCuts,24)
+    ClassDef(AliConversionMesonCuts,25)
     /// \endcond
 };
 

--- a/PWGGA/GammaConv/AliPrimaryPionCuts.cxx
+++ b/PWGGA/GammaConv/AliPrimaryPionCuts.cxx
@@ -1065,18 +1065,22 @@ Bool_t AliPrimaryPionCuts::SetMassCut(Int_t massCut){
 			fDoMassCut = kTRUE;
 			fMassCut = 0.5;
 			break;
-        case 6: // cut at 0.65 GeV/c^2
-            fDoMassCut = kTRUE;
-            fMassCut = 0.65;
-            break;
-        case 7: // cut at 0.7 GeV/c^2
-            fDoMassCut = kTRUE;
-            fMassCut = 0.7;
-            break;
-        case 8: // cut at 0.85 GeV/c^2
-             fDoMassCut = kTRUE;
-             fMassCut = 0.85;
-             break;
+    case 6: // cut at 0.65 GeV/c^2
+        fDoMassCut = kTRUE;
+        fMassCut = 0.65;
+        break;
+    case 7: // cut at 0.7 GeV/c^2
+        fDoMassCut = kTRUE;
+        fMassCut = 0.7;
+        break;
+    case 8: // cut at 0.85 GeV/c^2
+         fDoMassCut = kTRUE;
+         fMassCut = 0.85;
+         break;
+    case 9: // cut at 1.5 GeV/c^2
+         fDoMassCut = kTRUE;
+         fMassCut = 1.5;
+         break;
 		default:
 			cout<<"Warning: MassCut not defined "<<massCut<<endl;
 		return kFALSE;

--- a/PWGGA/GammaConv/CMakeLists.txt
+++ b/PWGGA/GammaConv/CMakeLists.txt
@@ -57,6 +57,7 @@ set(SRCS
     AliAnalysisTaskMaterial.cxx
     AliAnalysisTaskMaterialHistos.cxx
     AliAnalysisTaskNeutralMesonToPiPlPiMiPiZero.cxx
+    AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.cxx
     AliAnalysisTaskOmegaToPiZeroGamma.cxx
     AliAnalysisTaskHeavyNeutralMesonToGG.cxx
     AliAnalysisTaskK0toPi0Pi0.cxx

--- a/PWGGA/GammaConv/PWGGAGammaConvLinkDef.h
+++ b/PWGGA/GammaConv/PWGGAGammaConvLinkDef.h
@@ -56,6 +56,7 @@
 #pragma link C++ class AliPrimaryPionCuts+;
 #pragma link C++ class AliAnalysisTaskEtaToPiPlPiMiGamma+;
 #pragma link C++ class AliAnalysisTaskNeutralMesonToPiPlPiMiPiZero+;
+#pragma link C++ class AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson+;
 #pragma link C++ class AliAnalysisTaskGammaConvCalo+;
 #pragma link C++ class AliAnalysisTaskGammaCalo+;
 #pragma link C++ class AliAnalysisTaskGammaCaloMerged+;

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pp.C
@@ -1,0 +1,432 @@
+/**************************************************************************
+ * Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
+ *                                       *
+ * Author: Friederike Bock, Daniel Mühlheim                     *
+ * Version 1.0                                 *
+ *                                       *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its    *
+ * documentation strictly for non-commercial purposes is hereby granted    *
+ * without fee, provided that the above copyright notice appears in all    *
+ * copies and that both the copyright notice and this permission notice    *
+ * appear in the supporting documentation. The authors make no claims    *
+ * about the suitability of this software for any purpose. It is      *
+ * provided "as is" without express or implied warranty.               *
+ **************************************************************************/
+
+//***************************************************************************************
+//This AddTask is supposed to set up the main task
+//($ALIPHYSICS/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.cxx) for
+//pp together with all supporting classes
+//***************************************************************************************
+
+//***************************************************************************************
+//CutHandler contains all cuts for a certain analysis and trainconfig,
+//it automatically checks length of cutStrings and takes care of the number of added cuts,
+//no specification of the variable 'numberOfCuts' needed anymore.
+//***************************************************************************************
+class CutHandlerNeutralCalo{
+  public:
+    CutHandlerNeutralCalo(Int_t nMax=10){
+      nCuts=0; nMaxCuts=nMax; validCuts = true;
+      eventCutArray = new TString[nMaxCuts]; clusterCutArray = new TString[nMaxCuts]; pionCutArray = new TString[nMaxCuts]; neutralPionCutArray = new TString[nMaxCuts]; mesonCutArray = new TString[nMaxCuts];
+      for(Int_t i=0; i<nMaxCuts; i++) {eventCutArray[i] = ""; clusterCutArray[i] = ""; pionCutArray[i] = ""; neutralPionCutArray[i] = ""; mesonCutArray[i] = "";}
+    }
+
+    void AddCut(TString eventCut, TString clusterCut, TString pionCut, TString neutralPionCut, TString mesonCut){
+      if(nCuts>=nMaxCuts) {cout << "ERROR in CutHandlerNeutralCalo: Exceeded maximum number of cuts!" << endl; validCuts = false; return;}
+      if( eventCut.Length()!=8 || clusterCut.Length()!=19 || pionCut.Length()!=9 || neutralPionCut.Length()!=16 || mesonCut.Length()!=16 ) {cout << "ERROR in CutHandlerNeutralCalo: Incorrect length of cut string!" << endl; validCuts = false; return;}
+      eventCutArray[nCuts]=eventCut; clusterCutArray[nCuts]=clusterCut; pionCutArray[nCuts]=pionCut; neutralPionCutArray[nCuts]=neutralPionCut; mesonCutArray[nCuts]=mesonCut;
+      nCuts++;
+      return;
+    }
+    Bool_t AreValid(){return validCuts;}
+    Int_t GetNCuts(){if(validCuts) return nCuts; else return 0;}
+    TString GetEventCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return eventCutArray[i]; else{cout << "ERROR in CutHandlerNeutralCalo: GetEventCut wrong index i" << endl;return "";}}
+    TString GetClusterCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return clusterCutArray[i]; else {cout << "ERROR in CutHandlerNeutralCalo: GetClusterCut wrong index i" << endl;return "";}}
+    TString GetPionCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return pionCutArray[i]; else {cout << "ERROR in CutHandlerNeutralCalo: GetPionCut wrong index i" << endl;return "";}}
+    TString GetNeutralPionCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return neutralPionCutArray[i]; else {cout << "ERROR in CutHandlerNeutralCalo: GetNeutralPionCut wrong index i" << endl;return "";}}
+    TString GetMesonCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return mesonCutArray[i]; else {cout << "ERROR in CutHandlerNeutralCalo: GetMesonCut wrong index i" << endl;return "";}}
+  private:
+    Bool_t validCuts;
+    Int_t nCuts; Int_t nMaxCuts;
+    TString* eventCutArray;
+    TString* clusterCutArray;
+    TString* pionCutArray;
+    TString* neutralPionCutArray;
+    TString* mesonCutArray;
+};
+
+//***************************************************************************************
+//main function
+//***************************************************************************************
+void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pp(
+    Int_t trainConfig                 = 1,
+    Bool_t isMC                       = kFALSE,                             //run MC
+    Int_t selectHeavyNeutralMeson                  = 0,                          //run eta prime instead of omega
+    Int_t enableQAMesonTask           = 1,                                  //enable QA in AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson
+    TString fileNameInputForWeighting = "MCSpectraInput.root",              // path to file for weigting input
+    Bool_t doWeighting                = kFALSE,                             //enable Weighting
+    TString generatorName             = "HIJING",
+    TString cutnumberAODBranch        = "000000006008400001001500000",
+    Double_t tolerance                = -1,
+    TString periodNameV0Reader        = "",                                 // period Name for V0Reader
+    Int_t runLightOutput              = 0,                                  // run light output option 0: no light output 1: most cut histos stiched off 2: unecessary omega hists turned off as well
+    TString additionalTrainConfig     = "0"                                 // additional counter for trainconfig, this has to be always the last parameter
+  ) {
+
+  //parse additionalTrainConfig flag
+  TObjArray *rAddConfigArr = additionalTrainConfig.Tokenize("_");
+  if(rAddConfigArr->GetEntries()<1){cout << "ERROR during parsing of additionalTrainConfig String '" << additionalTrainConfig.Data() << "'" << endl; return;}
+  TObjString* rAdditionalTrainConfig;
+  for(Int_t i = 0; i<rAddConfigArr->GetEntries() ; i++){
+    if(i==0) rAdditionalTrainConfig = (TObjString*)rAddConfigArr->At(i);
+    else{
+      TObjString* temp = (TObjString*) rAddConfigArr->At(i);
+      TString tempStr = temp->GetString();
+      cout << "INFO: nothing to do, no definition available!" << endl;
+    }
+  }
+  TString sAdditionalTrainConfig = rAdditionalTrainConfig->GetString();
+  if (sAdditionalTrainConfig.Atoi() > 0){
+    trainConfig = trainConfig + sAdditionalTrainConfig.Atoi();
+    cout << "INFO: AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pp running additionalTrainConfig '" << sAdditionalTrainConfig.Atoi() << "', train config: '" << trainConfig << "'" << endl;
+  }
+
+  Int_t isHeavyIon = 0;
+  Int_t neutralPionMode = 2;
+
+  // ================== GetAnalysisManager ===============================
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    Error(Form("AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pp_%i",trainConfig), "No analysis manager found.");
+    return ;
+  }
+
+  // ================== GetInputEventHandler =============================
+  AliVEventHandler *inputHandler=mgr->GetInputEventHandler();
+
+  //========= Add PID Reponse to ANALYSIS manager ====
+  if(!(AliPIDResponse*)mgr->GetTask("PIDResponseTask")){
+    gROOT->LoadMacro("$ALICE_ROOT/ANALYSIS/macros/AddTaskPIDResponse.C");
+    AddTaskPIDResponse(isMC);
+  }
+
+  //=========  Set Cutnumber for V0Reader ================================
+  TString cutnumberPhoton = "06000008400100001500000000";
+  if (  periodNameV0Reader.CompareTo("LHC16f") == 0 || periodNameV0Reader.CompareTo("LHC17g")==0 || periodNameV0Reader.CompareTo("LHC18c")==0 ||
+        periodNameV0Reader.CompareTo("LHC17d1") == 0  || periodNameV0Reader.CompareTo("LHC17d12")==0 ||
+        periodNameV0Reader.CompareTo("LHC17h3")==0 || periodNameV0Reader.CompareTo("LHC17k1")==0 ||
+        periodNameV0Reader.CompareTo("LHC17f8b") == 0 ||
+        periodNameV0Reader.CompareTo("LHC16P1JJLowB") == 0 || periodNameV0Reader.CompareTo("LHC16P1Pyt8LowB") == 0 )
+    cutnumberPhoton         = "00000088400000000100000000";
+
+  TString cutnumberEvent = "00000003";
+  TString PionCuts      = "000000200";            //Electron Cuts
+
+
+  AliAnalysisDataContainer *cinput = mgr->GetCommonInputContainer();
+
+  //========= Add V0 Reader to  ANALYSIS manager if not yet existent =====
+  TString V0ReaderName = Form("V0ReaderV1_%s_%s",cutnumberEvent.Data(),cutnumberPhoton.Data());
+  if( !(AliV0ReaderV1*)mgr->GetTask(V0ReaderName.Data()) ){
+    AliV0ReaderV1 *fV0ReaderV1 = new AliV0ReaderV1(V0ReaderName.Data());
+    if (periodNameV0Reader.CompareTo("") != 0) fV0ReaderV1->SetPeriodName(periodNameV0Reader);
+    fV0ReaderV1->SetUseOwnXYZCalculation(kTRUE);
+    fV0ReaderV1->SetCreateAODs(kFALSE);// AOD Output
+    fV0ReaderV1->SetUseAODConversionPhoton(kTRUE);
+
+    if (!mgr) {
+      Error("AddTask_V0ReaderV1", "No analysis manager found.");
+      return;
+    }
+
+    AliConvEventCuts *fEventCuts=NULL;
+    if(cutnumberEvent!=""){
+      fEventCuts= new AliConvEventCuts(cutnumberEvent.Data(),cutnumberEvent.Data());
+      fEventCuts->SetPreSelectionCutFlag(kTRUE);
+      fEventCuts->SetV0ReaderName(V0ReaderName);
+      if (periodNameV0Reader.CompareTo("") != 0) fEventCuts->SetPeriodEnum(periodNameV0Reader);
+      if(runLightOutput>0) fEventCuts->SetLightOutput(kTRUE);
+      if(fEventCuts->InitializeCutsFromCutString(cutnumberEvent.Data())){
+        fV0ReaderV1->SetEventCuts(fEventCuts);
+        fEventCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+
+    // Set AnalysisCut Number
+    AliConversionPhotonCuts *fCuts=NULL;
+    if(cutnumberPhoton!=""){
+      fCuts= new AliConversionPhotonCuts(cutnumberPhoton.Data(),cutnumberPhoton.Data());
+      fCuts->SetPreSelectionCutFlag(kTRUE);
+      fCuts->SetIsHeavyIon(isHeavyIon);
+      fCuts->SetV0ReaderName(V0ReaderName);
+      if(runLightOutput>0) fCuts->SetLightOutput(kTRUE);
+      if(fCuts->InitializeCutsFromCutString(cutnumberPhoton.Data())){
+        fV0ReaderV1->SetConversionCuts(fCuts);
+        fCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+
+    if(inputHandler->IsA()==AliAODInputHandler::Class()){
+    // AOD mode
+      fV0ReaderV1->AliV0ReaderV1::SetDeltaAODBranchName(Form("GammaConv_%s_gamma",cutnumberAODBranch.Data()));
+    }
+    fV0ReaderV1->Init();
+
+    AliLog::SetGlobalLogLevel(AliLog::kFatal);
+
+    //connect input V0Reader
+    mgr->AddTask(fV0ReaderV1);
+    mgr->ConnectInput(fV0ReaderV1,0,cinput);
+  }
+
+  //================================================
+  //========= Add Pion Selector ====================
+  if( !(AliPrimaryPionSelector*)mgr->GetTask("PionSelector") ){
+    AliPrimaryPionSelector *fPionSelector = new AliPrimaryPionSelector("PionSelector");
+    AliPrimaryPionCuts *fPionCuts=0;
+    if( PionCuts!=""){
+      fPionCuts= new AliPrimaryPionCuts(PionCuts.Data(),PionCuts.Data());
+      if(runLightOutput>0) fPionCuts->SetLightOutput(kTRUE);
+      //if(runLightOutput>0) fPionCuts->SetLightOutput(kTRUE);
+      if(fPionCuts->InitializeCutsFromCutString(PionCuts.Data())){
+        fPionSelector->SetPrimaryPionCuts(fPionCuts);
+        fPionCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+
+    fPionSelector->Init();
+    mgr->AddTask(fPionSelector);
+
+    AliAnalysisDataContainer *cinput1  = mgr->GetCommonInputContainer();
+    mgr->ConnectInput (fPionSelector,0,cinput1);
+  }
+
+  AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson *task=NULL;
+  task= new AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson(Form("GammaConvNeutralMesonPiPlPiMiNeutralMeson_%i_%i",neutralPionMode, trainConfig));
+  task->SetIsHeavyIon(isHeavyIon);
+  task->SetIsMC(isMC);
+  task->SetV0ReaderName(V0ReaderName);
+  if(runLightOutput>1) task->SetLightOutput(kTRUE);
+  task->SetTolerance(tolerance);
+
+  CutHandlerNeutralCalo cuts;
+
+
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  //                                          ETA MESON
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  if( trainConfig == 1 ) {
+    // everything open, min pt charged pi = 100 MeV
+    cuts.AddCut("00000113","1111113047032230000","000010400","0103503a00000000","0103503000000000");
+    cuts.AddCut("00000113","1111113047032230000","000010400","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 2 ) {
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, min pt charged pi = 100 MeV
+    cuts.AddCut("00000113","1111100047032230000","002010700","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 3) {
+    // eta < 0.9
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, pi+pi- mass cut of 0.65, min pt charged pi = 100 MeV
+    // closing neural pion cuts, 0.1 < M_gamma,gamma < 0.15
+    // maxChi2 per cluster TPC <4, require TPC refit, DCA XY pT dependend 0.0182+0.0350/pt^1.01, DCA_Z = 3.0
+    // timing cluster cut open
+    cuts.AddCut("00010113","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00052113","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00062113","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00083113","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00085113","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+  } else if( trainConfig == 4) {
+    // same as 3 but only MB
+    cuts.AddCut("00010113","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    
+    // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    //                                          OMEGA MESON
+    // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  } else if( trainConfig == 100 ) {
+    // everything open, min pt charged pi = 100 MeV
+    cuts.AddCut("00000113","1111100047032230000","000010400","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 101 ) {
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, min pt charged pi = 100 MeV
+    cuts.AddCut("00000113","1111100047032230000","002010700","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 102) {
+    // eta < 0.9
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, pi+pi- mass cut of 0.65, min pt charged pi = 100 MeV
+    // closing neural pion cuts, 0.1 < M_gamma,gamma < 0.15
+    // maxChi2 per cluster TPC <4, require TPC refit, DCA XY pT dependend 0.0182+0.0350/pt^1.01, DCA_Z = 3.0
+    // timing cluster cut open
+    cuts.AddCut("00010113","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00052113","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00062113","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00083113","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00085113","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    
+  } else if( trainConfig == 103) {
+    // same as 102 but only MB
+    cuts.AddCut("00010113","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    
+    
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  //                                          ETA PRIME MESON
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  
+  } else if( trainConfig == 200 ) {
+    // everything open, min pt charged pi = 100 MeV
+    cuts.AddCut("00000113","1111100047032230000","000010400","0103503m00000000","0103503000000000");
+  } else if( trainConfig == 201 ) {
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, min pt charged pi = 100 MeV
+    cuts.AddCut("00000113","1111100047032230000","002010700","0103503m00000000","0103503000000000");
+  } else if( trainConfig == 202) {
+    // eta < 0.9
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, pi+pi- mass cut of 1.5, min pt charged pi = 100 MeV
+    // closing neural pion cuts, 0.5 < M_gamma,gamma < 0.6
+    // maxChi2 per cluster TPC <4, require TPC refit, DCA XY pT dependend 0.0182+0.0350/pt^1.01, DCA_Z = 3.0
+    // timing cluster cut open
+    cuts.AddCut("00010113","1111100047032230000","30a330709","0103503l00000000","0153503000000000"); // all of the above
+    cuts.AddCut("00052113","1111100047032230000","30a330709","0103503l00000000","0153503000000000"); // all of the above
+    cuts.AddCut("00062113","1111100047032230000","30a330709","0103503l00000000","0153503000000000"); // all of the above
+    cuts.AddCut("00083113","1111100047032230000","30a330709","0103503l00000000","0153503000000000"); // all of the above
+    cuts.AddCut("00085113","1111100047032230000","30a330709","0103503l00000000","0153503000000000"); // all of the above
+  } else if( trainConfig == 203) {
+    // same as 202 but only MB
+    cuts.AddCut("00010113","1111100047032230000","30a330709","0103503l00000000","0153503000000000"); // 0.5-0.6 eta mass cut
+    cuts.AddCut("00010113","1111100047032230000","30a330709","0103503m00000000","0153503000000000"); // 0.4-0.7 eta mass cut
+  } else if( trainConfig == 204) {
+    // same as 202 but with mass cut variations
+    cuts.AddCut("00010113","1111100047032230000","30a330700","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 10
+    cuts.AddCut("00010113","1111100047032230000","30a330701","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 1
+    cuts.AddCut("00010113","1111100047032230000","30a330708","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 0.85
+    
+  } else {
+    Error(Form("GammaConvNeutralMeson_CaloMode_%i",trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");
+    return;
+  }
+
+  if(!cuts.AreValid()){
+    cout << "\n\n****************************************************" << endl;
+    cout << "ERROR: No valid cuts stored in CutHandlerNeutralCalo! Returning..." << endl;
+    cout << "****************************************************\n\n" << endl;
+    return;
+  }
+
+  Int_t numberOfCuts = cuts.GetNCuts();
+
+  TList *EventCutList = new TList();
+  TList *ClusterCutList  = new TList();
+  TList *NeutralPionCutList = new TList();
+  TList *MesonCutList = new TList();
+  TList *PionCutList  = new TList();
+
+  TList *HeaderList = new TList();
+  TObjString *Header1 = new TObjString("pi0_1");
+  HeaderList->Add(Header1);
+  TObjString *Header3 = new TObjString("eta_2");
+  HeaderList->Add(Header3);
+
+  EventCutList->SetOwner(kTRUE);
+  AliConvEventCuts **analysisEventCuts = new AliConvEventCuts*[numberOfCuts];
+  ClusterCutList->SetOwner(kTRUE);
+  AliCaloPhotonCuts **analysisClusterCuts = new AliCaloPhotonCuts*[numberOfCuts];
+  NeutralPionCutList->SetOwner(kTRUE);
+  AliConversionMesonCuts **analysisNeutralPionCuts   = new AliConversionMesonCuts*[numberOfCuts];
+  MesonCutList->SetOwner(kTRUE);
+  AliConversionMesonCuts **analysisMesonCuts   = new AliConversionMesonCuts*[numberOfCuts];
+  PionCutList->SetOwner(kTRUE);
+  AliPrimaryPionCuts **analysisPionCuts     = new AliPrimaryPionCuts*[numberOfCuts];
+
+  for(Int_t i = 0; i<numberOfCuts; i++){
+    //create AliCaloTrackMatcher instance, if there is none present
+    TString caloCutPos = cuts.GetClusterCut(i);
+    caloCutPos.Resize(1);
+    TString TrackMatcherName = Form("CaloTrackMatcher_%s",caloCutPos.Data());
+    if( !(AliCaloTrackMatcher*)mgr->GetTask(TrackMatcherName.Data()) ){
+      AliCaloTrackMatcher* fTrackMatcher = new AliCaloTrackMatcher(TrackMatcherName.Data(),caloCutPos.Atoi());
+      fTrackMatcher->SetV0ReaderName(V0ReaderName);
+      mgr->AddTask(fTrackMatcher);
+      mgr->ConnectInput(fTrackMatcher,0,cinput);
+    }
+
+    analysisEventCuts[i] = new AliConvEventCuts();
+    analysisEventCuts[i]->SetV0ReaderName(V0ReaderName);
+    if(runLightOutput>0) analysisEventCuts[i]->SetLightOutput(kTRUE);
+    analysisEventCuts[i]->InitializeCutsFromCutString((cuts.GetEventCut(i)).Data());
+    if (periodNameV0Reader.CompareTo("") != 0) analysisEventCuts[i]->SetPeriodEnum(periodNameV0Reader);
+    EventCutList->Add(analysisEventCuts[i]);
+    analysisEventCuts[i]->SetFillCutHistograms("",kFALSE);
+
+    analysisClusterCuts[i] = new AliCaloPhotonCuts();
+    analysisClusterCuts[i]->SetV0ReaderName(V0ReaderName);
+    if(runLightOutput>0) analysisClusterCuts[i]->SetLightOutput(kTRUE);
+    analysisClusterCuts[i]->SetCaloTrackMatcherName(TrackMatcherName);
+    if( ! analysisClusterCuts[i]->InitializeCutsFromCutString((cuts.GetClusterCut(i)).Data()) ) {
+      cout<<"ERROR: analysisClusterCuts [" <<i<<"]"<<endl;
+      return 0;
+    } else {
+      analysisClusterCuts[i]->InitializeCutsFromCutString((cuts.GetClusterCut(i)).Data());
+      ClusterCutList->Add(analysisClusterCuts[i]);
+      analysisClusterCuts[i]->SetFillCutHistograms("");
+    }
+
+    analysisNeutralPionCuts[i] = new AliConversionMesonCuts();
+    if(runLightOutput>0) analysisNeutralPionCuts[i]->SetLightOutput(kTRUE);
+    if( ! analysisNeutralPionCuts[i]->InitializeCutsFromCutString((cuts.GetNeutralPionCut(i)).Data()) ) {
+      cout<<"ERROR: analysisMesonCuts [ " <<i<<" ] "<<endl;
+      return 0;
+    } else {
+      NeutralPionCutList->Add(analysisNeutralPionCuts[i]);
+      analysisNeutralPionCuts[i]->SetFillCutHistograms("");
+    }
+
+    analysisMesonCuts[i] = new AliConversionMesonCuts();
+    if(runLightOutput>0) analysisMesonCuts[i]->SetLightOutput(kTRUE);
+    if( ! analysisMesonCuts[i]->InitializeCutsFromCutString((cuts.GetMesonCut(i)).Data()) ) {
+      cout<<"ERROR: analysisMesonCuts [ " <<i<<" ] "<<endl;
+      return 0;
+    } else {
+      MesonCutList->Add(analysisMesonCuts[i]);
+      analysisMesonCuts[i]->SetFillCutHistograms("");
+    }
+    analysisEventCuts[i]->SetAcceptedHeader(HeaderList);
+
+    TString cutName( Form("%s_%s_%s_%s_%s",(cuts.GetEventCut(i)).Data(), (cuts.GetClusterCut(i)).Data(),(cuts.GetPionCut(i)).Data(),(cuts.GetNeutralPionCut(i)).Data(), (cuts.GetMesonCut(i)).Data() ) );
+    analysisPionCuts[i] = new AliPrimaryPionCuts();
+    if(runLightOutput>0) analysisPionCuts[i]->SetLightOutput(kTRUE);
+
+        if( !analysisPionCuts[i]->InitializeCutsFromCutString((cuts.GetPionCut(i)).Data())) {
+      cout<< "ERROR:  analysisPionCuts [ " <<i<<" ] "<<endl;
+      return 0;
+    } else {
+      PionCutList->Add(analysisPionCuts[i]);
+      analysisPionCuts[i]->SetFillCutHistograms("",kFALSE,cutName);
+    }
+  }
+
+  task->SetNDMRecoMode(neutralPionMode);
+  task->SetEventCutList(numberOfCuts,EventCutList);
+  task->SetClusterCutList(ClusterCutList);
+  task->SetNeutralPionCutList(NeutralPionCutList);
+  task->SetMesonCutList(MesonCutList);
+  task->SetPionCutList(PionCutList);
+
+  task->SetMoveParticleAccordingToVertex(kTRUE);
+  task->SetSelectedHeavyNeutralMeson(selectHeavyNeutralMeson);
+
+  task->SetDoMesonQA(enableQAMesonTask );
+
+  //connect containers
+  AliAnalysisDataContainer *coutput =
+  mgr->CreateContainer(Form("GammaConvNeutralMesonPiPlPiMiNeutralMeson_%i_%i_%i.root",selectHeavyNeutralMeson,neutralPionMode, trainConfig), TList::Class(),
+              AliAnalysisManager::kOutputContainer,Form("GammaConvNeutralMesonPiPlPiMiNeutralMeson_%i_%i_%i.root",selectHeavyNeutralMeson,neutralPionMode, trainConfig));
+
+  mgr->AddTask(task);
+  mgr->ConnectInput(task,0,cinput);
+  mgr->ConnectOutput(task,1,coutput);
+
+  return;
+
+}

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pp.C
@@ -1,0 +1,418 @@
+/**************************************************************************
+ * Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
+ *                                       *
+ * Author: Friederike Bock, Daniel Mühlheim                     *
+ * Version 1.0                                 *
+ *                                       *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its    *
+ * documentation strictly for non-commercial purposes is hereby granted    *
+ * without fee, provided that the above copyright notice appears in all    *
+ * copies and that both the copyright notice and this permission notice    *
+ * appear in the supporting documentation. The authors make no claims    *
+ * about the suitability of this software for any purpose. It is      *
+ * provided "as is" without express or implied warranty.               *
+ **************************************************************************/
+
+//***************************************************************************************
+//This AddTask is supposed to set up the main task
+//($ALIPHYSICS/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.cxx) for
+//pp together with all supporting classes
+//***************************************************************************************
+
+//***************************************************************************************
+//CutHandler contains all cuts for a certain analysis and trainconfig,
+//it automatically checks length of cutStrings and takes care of the number of added cuts,
+//no specification of the variable 'numberOfCuts' needed anymore.
+//***************************************************************************************
+class CutHandlerNeutralConv{
+  public:
+    CutHandlerNeutralConv(Int_t nMax=10){
+      nCuts=0; nMaxCuts=nMax; validCuts = true;
+      eventCutArray = new TString[nMaxCuts]; conversionCutArray = new TString[nMaxCuts]; pionCutArray = new TString[nMaxCuts]; neutralPionCutArray = new TString[nMaxCuts]; mesonCutArray = new TString[nMaxCuts];
+      for(Int_t i=0; i<nMaxCuts; i++) {eventCutArray[i] = ""; conversionCutArray[i] = ""; pionCutArray[i] = ""; neutralPionCutArray[i] = ""; mesonCutArray[i] = "";}
+    }
+
+    void AddCut(TString eventCut, TString conversionCut, TString pionCut, TString neutralPionCut, TString mesonCut){
+      if(nCuts>=nMaxCuts) {cout << "ERROR in CutHandlerNeutralConv: Exceeded maximum number of cuts!" << endl; validCuts = false; return;}
+      if( eventCut.Length()!=8 || conversionCut.Length()!=26 || pionCut.Length()!=9 || neutralPionCut.Length()!=16 || mesonCut.Length()!=16 ) {cout << "ERROR in CutHandlerNeutralConv: Incorrect length of cut string!" << endl; validCuts = false; return;}
+      eventCutArray[nCuts]=eventCut; conversionCutArray[nCuts]=conversionCut; pionCutArray[nCuts]=pionCut; neutralPionCutArray[nCuts]=neutralPionCut; mesonCutArray[nCuts]=mesonCut;
+      nCuts++;
+      return;
+    }
+    Bool_t AreValid(){return validCuts;}
+    Int_t GetNCuts(){if(validCuts) return nCuts; else return 0;}
+    TString GetEventCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return eventCutArray[i]; else{cout << "ERROR in CutHandlerNeutralConv: GetEventCut wrong index i" << endl;return "";}}
+    TString GetConversionCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return conversionCutArray[i]; else {cout << "ERROR in CutHandlerNeutralConv: GetConversionCut wrong index i" << endl;return "";}}
+    TString GetPionCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return pionCutArray[i]; else {cout << "ERROR in CutHandlerNeutralConv: GetPionCut wrong index i" << endl;return "";}}
+    TString GetNeutralPionCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return neutralPionCutArray[i]; else {cout << "ERROR in CutHandlerNeutralConv: GetNeutralPionCut wrong index i" << endl;return "";}}
+    TString GetMesonCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return mesonCutArray[i]; else {cout << "ERROR in CutHandlerNeutralConv: GetMesonCut wrong index i" << endl;return "";}}
+  private:
+    Bool_t validCuts;
+    Int_t nCuts; Int_t nMaxCuts;
+    TString* eventCutArray;
+    TString* conversionCutArray;
+    TString* pionCutArray;
+    TString* neutralPionCutArray;
+    TString* mesonCutArray;
+};
+
+//***************************************************************************************
+//main function
+//***************************************************************************************
+void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pp(
+    Int_t trainConfig                 = 1,
+    Bool_t isMC                       = kFALSE,                          //run MC
+    Int_t selectHeavyNeutralMeson                  = 0,                          //run eta prime instead of omega
+    Int_t enableQAMesonTask           = 1,                               //enable QA in AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson
+    TString fileNameInputForWeighting = "MCSpectraInput.root",           // path to file for weigting input
+    Bool_t doWeighting                = kFALSE,                          //enable Weighting
+    TString generatorName             = "HIJING",
+    TString cutnumberAODBranch        = "000000006008400001001500000",
+    Double_t tolerance                = -1,
+    TString    periodNameV0Reader     = "",                               // period Name for V0Reader
+    Int_t   runLightOutput            = 0,                                 // run light output option 0: no light output 1: most cut histos stiched off 2: unecessary omega hists turned off as well
+    TString additionalTrainConfig     = "0"                               // additional counter for trainconfig, this has to be always the last parameter
+  ) {
+
+  //parse additionalTrainConfig flag
+  TObjArray *rAddConfigArr = additionalTrainConfig.Tokenize("_");
+  if(rAddConfigArr->GetEntries()<1){cout << "ERROR during parsing of additionalTrainConfig String '" << additionalTrainConfig.Data() << "'" << endl; return;}
+  TObjString* rAdditionalTrainConfig;
+  for(Int_t i = 0; i<rAddConfigArr->GetEntries() ; i++){
+    if(i==0) rAdditionalTrainConfig = (TObjString*)rAddConfigArr->At(i);
+    else{
+      TObjString* temp = (TObjString*) rAddConfigArr->At(i);
+      TString tempStr = temp->GetString();
+      cout << "INFO: nothing to do, no definition available!" << endl;
+    }
+  }
+  TString sAdditionalTrainConfig = rAdditionalTrainConfig->GetString();
+  if (sAdditionalTrainConfig.Atoi() > 0){
+    trainConfig = trainConfig + sAdditionalTrainConfig.Atoi();
+    cout << "INFO: AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pp running additionalTrainConfig '" << sAdditionalTrainConfig.Atoi() << "', train config: '" << trainConfig << "'" << endl;
+  }
+
+  Int_t isHeavyIon = 0;
+  Int_t neutralPionMode = 0;
+
+  // ================== GetAnalysisManager ===============================
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    Error(Form("AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pp_%i",trainConfig), "No analysis manager found.");
+    return ;
+  }
+
+  // ================== GetInputEventHandler =============================
+  AliVEventHandler *inputHandler=mgr->GetInputEventHandler();
+
+  //========= Add PID Reponse to ANALYSIS manager ====
+  if(!(AliPIDResponse*)mgr->GetTask("PIDResponseTask")){
+    gROOT->LoadMacro("$ALICE_ROOT/ANALYSIS/macros/AddTaskPIDResponse.C");
+    AddTaskPIDResponse(isMC);
+  }
+
+  //=========  Set Cutnumber for V0Reader ================================
+  TString cutnumberPhoton   = "06000008400100001500000000";
+  if (  periodNameV0Reader.CompareTo("LHC16f") == 0 || periodNameV0Reader.CompareTo("LHC17g")==0 || periodNameV0Reader.CompareTo("LHC18c")==0 ||
+        periodNameV0Reader.CompareTo("LHC17d1") == 0  || periodNameV0Reader.CompareTo("LHC17d12")==0 ||
+        periodNameV0Reader.CompareTo("LHC17h3")==0 || periodNameV0Reader.CompareTo("LHC17k1")==0 ||
+        periodNameV0Reader.CompareTo("LHC17f8b") == 0 ||
+        periodNameV0Reader.CompareTo("LHC16P1JJLowB") == 0 || periodNameV0Reader.CompareTo("LHC16P1Pyt8LowB") == 0 )
+    cutnumberPhoton         = "00000088400000000100000000";
+
+  TString cutnumberEvent    = "00000003";
+  TString PionCuts          = "000000200";            //Electron Cuts
+
+  AliAnalysisDataContainer *cinput = mgr->GetCommonInputContainer();
+
+  //========= Add V0 Reader to  ANALYSIS manager if not yet existent =====
+  TString V0ReaderName = Form("V0ReaderV1_%s_%s",cutnumberEvent.Data(),cutnumberPhoton.Data());
+  if( !(AliV0ReaderV1*)mgr->GetTask(V0ReaderName.Data()) ){
+
+    AliV0ReaderV1 *fV0ReaderV1 = new AliV0ReaderV1(V0ReaderName.Data());
+    if (periodNameV0Reader.CompareTo("") != 0) fV0ReaderV1->SetPeriodName(periodNameV0Reader);
+    fV0ReaderV1->SetUseOwnXYZCalculation(kTRUE);
+    fV0ReaderV1->SetCreateAODs(kFALSE);// AOD Output
+    fV0ReaderV1->SetUseAODConversionPhoton(kTRUE);
+
+    if (!mgr) {
+      Error("AddTask_V0ReaderV1", "No analysis manager found.");
+      return;
+    }
+
+    AliConvEventCuts *fEventCuts=NULL;
+    if(cutnumberEvent!=""){
+      fEventCuts= new AliConvEventCuts(cutnumberEvent.Data(),cutnumberEvent.Data());
+      fEventCuts->SetPreSelectionCutFlag(kTRUE);
+      fEventCuts->SetV0ReaderName(V0ReaderName);
+      if (periodNameV0Reader.CompareTo("") != 0) fEventCuts->SetPeriodEnum(periodNameV0Reader);
+      if(runLightOutput>0) fEventCuts->SetLightOutput(kTRUE);
+      if(fEventCuts->InitializeCutsFromCutString(cutnumberEvent.Data())){
+        fV0ReaderV1->SetEventCuts(fEventCuts);
+        fEventCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+
+    // Set AnalysisCut Number
+    AliConversionPhotonCuts *fCuts=NULL;
+    if(cutnumberPhoton!=""){
+      fCuts= new AliConversionPhotonCuts(cutnumberPhoton.Data(),cutnumberPhoton.Data());
+      fCuts->SetPreSelectionCutFlag(kTRUE);
+      fCuts->SetIsHeavyIon(isHeavyIon);
+      fCuts->SetV0ReaderName(V0ReaderName);
+      if(runLightOutput>0) fCuts->SetLightOutput(kTRUE);
+      if(fCuts->InitializeCutsFromCutString(cutnumberPhoton.Data())){
+        fV0ReaderV1->SetConversionCuts(fCuts);
+        fCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+
+    if(inputHandler->IsA()==AliAODInputHandler::Class()){
+    // AOD mode
+      fV0ReaderV1->AliV0ReaderV1::SetDeltaAODBranchName(Form("GammaConv_%s_gamma",cutnumberAODBranch.Data()));
+    }
+    fV0ReaderV1->Init();
+
+    AliLog::SetGlobalLogLevel(AliLog::kFatal);
+
+    //connect input V0Reader
+    mgr->AddTask(fV0ReaderV1);
+    mgr->ConnectInput(fV0ReaderV1,0,cinput);
+  }
+
+  //================================================
+  //========= Add Pion Selector ====================
+  if( !(AliPrimaryPionSelector*)mgr->GetTask("PionSelector") ){
+    AliPrimaryPionSelector *fPionSelector = new AliPrimaryPionSelector("PionSelector");
+    AliPrimaryPionCuts *fPionCuts=0;
+    if( PionCuts!=""){
+      fPionCuts= new AliPrimaryPionCuts(PionCuts.Data(),PionCuts.Data());
+      if(runLightOutput>0) fPionCuts->SetLightOutput(kTRUE);
+      if(fPionCuts->InitializeCutsFromCutString(PionCuts.Data())){
+        fPionSelector->SetPrimaryPionCuts(fPionCuts);
+        fPionCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+
+    fPionSelector->Init();
+    mgr->AddTask(fPionSelector);
+
+    AliAnalysisDataContainer *cinput1  = mgr->GetCommonInputContainer();
+    //connect input V0Reader
+    mgr->ConnectInput (fPionSelector,0,cinput1);
+
+  }
+
+  AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson *task=NULL;
+  task= new AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson(Form("GammaConvNeutralMesonPiPlPiMiNeutralMeson_%i_%i",neutralPionMode, trainConfig));
+  task->SetIsHeavyIon(isHeavyIon);
+  task->SetIsMC(isMC);
+  task->SetV0ReaderName(V0ReaderName);
+  if(runLightOutput>1) task->SetLightOutput(kTRUE);
+  task->SetTolerance(tolerance);
+  CutHandlerNeutralConv cuts;
+
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  //                                          ETA MESON
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  if( trainConfig == 1 ) {
+    // everything open, min pt charged pi = 100 MeV
+    cuts.AddCut("00000113","00200009327000008250400000","000010400","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 2 ) {
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, min pt charged pi = 100 MeV
+    cuts.AddCut("00000113","00200009327000008250400000","002010700","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 3) {
+    // eta < 0.9
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, pi+pi- mass cut of 0.65, min pt charged pi = 100 MeV
+    // closing neural pion cuts, 0.1 < M_gamma,gamma < 0.15
+    // maxChi2 per cluster TPC <4, require TPC refit, DCA XY pT dependend 0.0182+0.0350/pt^1.01, DCA_Z = 3.0
+    // timing cluster cut open
+    cuts.AddCut("00010113","00200009327000008250400000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00052113","00200009327000008250400000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00062113","00200009327000008250400000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00083113","00200009327000008250400000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00085113","00200009327000008250400000","30a330708","0103503400000000","0153503000000000"); // all of the above
+  } else if( trainConfig == 4) {
+    // same as 3 but only MB
+    cuts.AddCut("00010113","00200009327000008250400000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    
+    // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    //                                          OMEGA MESON
+    // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  } else if( trainConfig == 100 ) {
+    // everything open, min pt charged pi = 100 MeV
+    cuts.AddCut("00000113","00200009327000008250400000","000010400","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 101 ) {
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, min pt charged pi = 100 MeV
+    cuts.AddCut("00000113","00200009327000008250400000","002010700","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 102) {
+    // eta < 0.9
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, pi+pi- mass cut of 0.65, min pt charged pi = 100 MeV
+    // closing neural pion cuts, 0.1 < M_gamma,gamma < 0.15
+    // maxChi2 per cluster TPC <4, require TPC refit, DCA XY pT dependend 0.0182+0.0350/pt^1.01, DCA_Z = 3.0
+    // timing cluster cut open
+    cuts.AddCut("00010113","00200009327000008250400000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00052113","00200009327000008250400000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00062113","00200009327000008250400000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00083113","00200009327000008250400000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00085113","00200009327000008250400000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    
+  } else if( trainConfig == 103) {
+    // same as 102 but only MB
+    cuts.AddCut("00010113","00200009327000008250400000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    
+    
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  //                                          ETA PRIME MESON
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  
+  } else if( trainConfig == 200 ) {
+    // everything open, min pt charged pi = 100 MeV
+    cuts.AddCut("00000113","00200009327000008250400000","000010400","0103503m00000000","0103503000000000");
+  } else if( trainConfig == 201 ) {
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, min pt charged pi = 100 MeV
+    cuts.AddCut("00000113","00200009327000008250400000","002010700","0103503m00000000","0103503000000000");
+  } else if( trainConfig == 202) {
+    // eta < 0.9
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, pi+pi- mass cut of 1.5, min pt charged pi = 100 MeV
+    // closing neural pion cuts, 0.5 < M_gamma,gamma < 0.6
+    // maxChi2 per cluster TPC <4, require TPC refit, DCA XY pT dependend 0.0182+0.0350/pt^1.01, DCA_Z = 3.0
+    // timing cluster cut open
+    cuts.AddCut("00010113","00200009327000008250400000","30a330709","0103503l00000000","0153503000000000"); // all of the above
+    cuts.AddCut("00052113","00200009327000008250400000","30a330709","0103503l00000000","0153503000000000"); // all of the above
+    cuts.AddCut("00062113","00200009327000008250400000","30a330709","0103503l00000000","0153503000000000"); // all of the above
+    cuts.AddCut("00083113","00200009327000008250400000","30a330709","0103503l00000000","0153503000000000"); // all of the above
+    cuts.AddCut("00085113","00200009327000008250400000","30a330709","0103503l00000000","0153503000000000"); // all of the above
+  } else if( trainConfig == 203) {
+    // same as 202 but only MB
+    cuts.AddCut("00010113","00200009327000008250400000","30a330709","0103503l00000000","0153503000000000"); // 0.5-0.6 eta mass cut
+    cuts.AddCut("00010113","00200009327000008250400000","30a330709","0103503m00000000","0153503000000000"); // 0.4-0.7 eta mass cut
+  } else if( trainConfig == 204) {
+    // same as 202 but with mass cut variations
+    cuts.AddCut("00010113","00200009327000008250400000","30a330700","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 10
+    cuts.AddCut("00010113","00200009327000008250400000","30a330701","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 1
+    cuts.AddCut("00010113","00200009327000008250400000","30a330708","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 0.85
+    
+  } else {
+    Error(Form("GammaConvNeutralMeson_ConvMode_%i",trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");
+    return;
+  }
+
+  if(!cuts.AreValid()){
+    cout << "\n\n****************************************************" << endl;
+    cout << "ERROR: No valid cuts stored in CutHandlerNeutralConv! Returning..." << endl;
+    cout << "****************************************************\n\n" << endl;
+    return;
+  }
+
+  Int_t numberOfCuts = cuts.GetNCuts();
+
+  TList *EventCutList = new TList();
+  TList *ConvCutList  = new TList();
+  TList *NeutralPionCutList = new TList();
+  TList *MesonCutList = new TList();
+  TList *PionCutList  = new TList();
+
+  TList *HeaderList = new TList();
+  TObjString *Header1 = new TObjString("pi0_1");
+  HeaderList->Add(Header1);
+  TObjString *Header3 = new TObjString("eta_2");
+  HeaderList->Add(Header3);
+
+  EventCutList->SetOwner(kTRUE);
+  AliConvEventCuts **analysisEventCuts = new AliConvEventCuts*[numberOfCuts];
+  ConvCutList->SetOwner(kTRUE);
+  AliConversionPhotonCuts **analysisCuts = new AliConversionPhotonCuts*[numberOfCuts];
+  NeutralPionCutList->SetOwner(kTRUE);
+  AliConversionMesonCuts **analysisNeutralPionCuts   = new AliConversionMesonCuts*[numberOfCuts];
+  MesonCutList->SetOwner(kTRUE);
+  AliConversionMesonCuts **analysisMesonCuts   = new AliConversionMesonCuts*[numberOfCuts];
+  PionCutList->SetOwner(kTRUE);
+  AliPrimaryPionCuts **analysisPionCuts     = new AliPrimaryPionCuts*[numberOfCuts];
+
+  for(Int_t i = 0; i<numberOfCuts; i++){
+    analysisEventCuts[i] = new AliConvEventCuts();
+    analysisEventCuts[i]->SetV0ReaderName(V0ReaderName);
+    if(runLightOutput>0) analysisEventCuts[i]->SetLightOutput(kTRUE);
+    analysisEventCuts[i]->InitializeCutsFromCutString((cuts.GetEventCut(i)).Data());
+    if (periodNameV0Reader.CompareTo("") != 0) analysisEventCuts[i]->SetPeriodEnum(periodNameV0Reader);
+    EventCutList->Add(analysisEventCuts[i]);
+    analysisEventCuts[i]->SetFillCutHistograms("",kFALSE);
+
+    analysisCuts[i] = new AliConversionPhotonCuts();
+    if(runLightOutput>0) analysisCuts[i]->SetLightOutput(kTRUE);
+    analysisCuts[i]->SetV0ReaderName(V0ReaderName);
+    if( ! analysisCuts[i]->InitializeCutsFromCutString((cuts.GetConversionCut(i)).Data()) ) {
+      cout<<"ERROR: analysisCuts [" <<i<<"]"<<endl;
+      return 0;
+    } else {
+      ConvCutList->Add(analysisCuts[i]);
+      analysisCuts[i]->SetFillCutHistograms("",kFALSE);
+
+    }
+
+    analysisNeutralPionCuts[i] = new AliConversionMesonCuts();
+    if(runLightOutput>0) analysisNeutralPionCuts[i]->SetLightOutput(kTRUE);
+    if( ! analysisNeutralPionCuts[i]->InitializeCutsFromCutString((cuts.GetNeutralPionCut(i)).Data()) ) {
+      cout<<"ERROR: analysisMesonCuts [ " <<i<<" ] "<<endl;
+      return 0;
+    } else {
+      NeutralPionCutList->Add(analysisNeutralPionCuts[i]);
+      analysisNeutralPionCuts[i]->SetFillCutHistograms("");
+    }
+
+    analysisMesonCuts[i] = new AliConversionMesonCuts();
+    if(runLightOutput>0) analysisMesonCuts[i]->SetLightOutput(kTRUE);
+    if( ! analysisMesonCuts[i]->InitializeCutsFromCutString((cuts.GetMesonCut(i)).Data()) ) {
+      cout<<"ERROR: analysisMesonCuts [ " <<i<<" ] "<<endl;
+      return 0;
+    } else {
+      MesonCutList->Add(analysisMesonCuts[i]);
+      analysisMesonCuts[i]->SetFillCutHistograms("");
+    }
+    analysisEventCuts[i]->SetAcceptedHeader(HeaderList);
+
+    TString cutName( Form("%s_%s_%s_%s_%s",(cuts.GetEventCut(i)).Data(), (cuts.GetConversionCut(i)).Data(),(cuts.GetPionCut(i)).Data(),(cuts.GetNeutralPionCut(i)).Data(), (cuts.GetMesonCut(i)).Data() ) );
+    analysisPionCuts[i] = new AliPrimaryPionCuts();
+    if(runLightOutput>0) analysisPionCuts[i]->SetLightOutput(kTRUE);
+    if( !analysisPionCuts[i]->InitializeCutsFromCutString((cuts.GetPionCut(i)).Data())) {
+      cout<< "ERROR:  analysisPionCuts [ " <<i<<" ] "<<endl;
+      return 0;
+    } else {
+      PionCutList->Add(analysisPionCuts[i]);
+      analysisPionCuts[i]->SetFillCutHistograms("",kFALSE,cutName);
+    }
+  }
+
+  task->SetNDMRecoMode(neutralPionMode);
+  task->SetEventCutList(numberOfCuts,EventCutList);
+  task->SetConversionCutList(ConvCutList);
+  task->SetNeutralPionCutList(NeutralPionCutList);
+  task->SetMesonCutList(MesonCutList);
+  task->SetPionCutList(PionCutList);
+
+  task->SetMoveParticleAccordingToVertex(kTRUE);
+  
+  task->SetSelectedHeavyNeutralMeson(selectHeavyNeutralMeson);
+
+  task->SetDoMesonQA(enableQAMesonTask);
+
+  //connect containers
+  AliAnalysisDataContainer *coutput =
+  mgr->CreateContainer(Form("GammaConvNeutralMesonPiPlPiMiNeutralMeson_%i_%i_%i.root",selectHeavyNeutralMeson,neutralPionMode, trainConfig), TList::Class(),
+              AliAnalysisManager::kOutputContainer,Form("GammaConvNeutralMesonPiPlPiMiNeutralMeson_%i_%i_%i.root",selectHeavyNeutralMeson,neutralPionMode, trainConfig));
+
+  mgr->AddTask(task);
+  mgr->ConnectInput(task,0,cinput);
+  mgr->ConnectOutput(task,1,coutput);
+
+  return;
+
+}

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_MixedMode_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_MixedMode_pp.C
@@ -1,0 +1,450 @@
+/**************************************************************************
+ * Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
+ *                                       *
+ * Author: Friederike Bock, Daniel Mühlheim                     *
+ * Version 1.0                                 *
+ *                                       *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its    *
+ * documentation strictly for non-commercial purposes is hereby granted    *
+ * without fee, provided that the above copyright notice appears in all    *
+ * copies and that both the copyright notice and this permission notice    *
+ * appear in the supporting documentation. The authors make no claims    *
+ * about the suitability of this software for any purpose. It is      *
+ * provided "as is" without express or implied warranty.               *
+ **************************************************************************/
+
+//***************************************************************************************
+//This AddTask is supposed to set up the main task
+//($ALIPHYSICS/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.cxx) for
+//pp together with all supporting classes
+//***************************************************************************************
+
+//***************************************************************************************
+//CutHandler contains all cuts for a certain analysis and trainconfig,
+//it automatically checks length of cutStrings and takes care of the number of added cuts,
+//no specification of the variable 'numberOfCuts' needed anymore.
+//***************************************************************************************
+class CutHandlerNeutralMixed{
+  public:
+    CutHandlerNeutralMixed(Int_t nMax=10){
+      nCuts=0; nMaxCuts=nMax; validCuts = true;
+      eventCutArray = new TString[nMaxCuts]; clusterCutArray = new TString[nMaxCuts]; conversionCutArray = new TString[nMaxCuts]; pionCutArray = new TString[nMaxCuts]; neutralPionCutArray = new TString[nMaxCuts]; mesonCutArray = new TString[nMaxCuts];
+      for(Int_t i=0; i<nMaxCuts; i++) {eventCutArray[i] = ""; clusterCutArray[i] = ""; conversionCutArray[i] = ""; pionCutArray[i] = ""; neutralPionCutArray[i] = ""; mesonCutArray[i] = "";}
+    }
+
+    void AddCut(TString eventCut, TString conversionCut, TString clusterCut, TString pionCut, TString neutralPionCut, TString mesonCut){
+      if(nCuts>=nMaxCuts) {cout << "ERROR in CutHandlerNeutralMixed: Exceeded maximum number of cuts!" << endl; validCuts = false; return;}
+      if( eventCut.Length()!=8 || conversionCut.Length()!=26 || clusterCut.Length()!=19 || pionCut.Length()!=9 || neutralPionCut.Length()!=16 || mesonCut.Length()!=16 ) {cout << "ERROR in CutHandlerNeutralMixed: Incorrect length of cut string!" << endl; validCuts = false; return;}
+      eventCutArray[nCuts]=eventCut; conversionCutArray[nCuts]=conversionCut; clusterCutArray[nCuts]=clusterCut; pionCutArray[nCuts]=pionCut; neutralPionCutArray[nCuts]=neutralPionCut; mesonCutArray[nCuts]=mesonCut;
+      nCuts++;
+      return;
+    }
+    Bool_t AreValid(){return validCuts;}
+    Int_t GetNCuts(){if(validCuts) return nCuts; else return 0;}
+    TString GetEventCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return eventCutArray[i]; else{cout << "ERROR in CutHandlerNeutralMixed: GetEventCut wrong index i" << endl;return "";}}
+    TString GetClusterCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return clusterCutArray[i]; else {cout << "ERROR in CutHandlerNeutralMixed: GetClusterCut wrong index i" << endl;return "";}}
+    TString GetConversionCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return conversionCutArray[i]; else {cout << "ERROR in CutHandlerNeutralMixed: GetConversionCut wrong index i" << endl;return "";}}
+    TString GetPionCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return pionCutArray[i]; else {cout << "ERROR in CutHandlerNeutralMixed: GetPionCut wrong index i" << endl;return "";}}
+    TString GetNeutralPionCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return neutralPionCutArray[i]; else {cout << "ERROR in CutHandlerNeutralMixed: GetNeutralPionCut wrong index i" << endl;return "";}}
+    TString GetMesonCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return mesonCutArray[i]; else {cout << "ERROR in CutHandlerNeutralMixed: GetMesonCut wrong index i" << endl;return "";}}
+  private:
+    Bool_t validCuts;
+    Int_t nCuts; Int_t nMaxCuts;
+    TString* eventCutArray;
+    TString* clusterCutArray;
+    TString* conversionCutArray;
+    TString* pionCutArray;
+    TString* neutralPionCutArray;
+    TString* mesonCutArray;
+};
+
+//***************************************************************************************
+//main function
+//***************************************************************************************
+void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_MixedMode_pp(
+    Int_t trainConfig                 = 1,
+    Bool_t isMC                       = kFALSE,                         //run MC
+    Int_t selectHeavyNeutralMeson                  = 0,                          //run eta prime instead of omega
+    Int_t enableQAMesonTask          = 1,                               //enable QA in AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson
+    TString fileNameInputForWeighting = "MCSpectraInput.root",          // path to file for weigting input
+    Bool_t doWeighting                = kFALSE,                         //enable Weighting
+    TString generatorName             = "HIJING",
+    TString cutnumberAODBranch        = "000000006008400001001500000",
+    Double_t tolerance                = -1,
+    TString periodNameV0Reader        = "",                              // period Name for V0Reader
+    Int_t   runLightOutput            = 0,                               // run light output option 0: no light output 1: most cut histos stiched off 2: unecessary omega hists turned off as well
+    TString additionalTrainConfig     = "0"                              // additional counter for trainconfig, this has to be always the last parameter
+  ) {
+
+  //parse additionalTrainConfig flag
+  TObjArray *rAddConfigArr = additionalTrainConfig.Tokenize("_");
+  if(rAddConfigArr->GetEntries()<1){cout << "ERROR during parsing of additionalTrainConfig String '" << additionalTrainConfig.Data() << "'" << endl; return;}
+  TObjString* rAdditionalTrainConfig;
+  for(Int_t i = 0; i<rAddConfigArr->GetEntries() ; i++){
+    if(i==0) rAdditionalTrainConfig = (TObjString*)rAddConfigArr->At(i);
+    else{
+      TObjString* temp = (TObjString*) rAddConfigArr->At(i);
+      TString tempStr = temp->GetString();
+      cout << "INFO: nothing to do, no definition available!" << endl;
+    }
+  }
+  TString sAdditionalTrainConfig = rAdditionalTrainConfig->GetString();
+  if (sAdditionalTrainConfig.Atoi() > 0){
+    trainConfig = trainConfig + sAdditionalTrainConfig.Atoi();
+    cout << "INFO: AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_MixedMode_pp running additionalTrainConfig '" << sAdditionalTrainConfig.Atoi() << "', train config: '" << trainConfig << "'" << endl;
+  }
+
+  Int_t isHeavyIon = 0;
+  Int_t neutralPionMode = 1;
+
+  // ================== GetAnalysisManager ===============================
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    Error(Form("AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_MixedMode_pp_%i",trainConfig), "No analysis manager found.");
+    return ;
+  }
+
+  // ================== GetInputEventHandler =============================
+  AliVEventHandler *inputHandler=mgr->GetInputEventHandler();
+
+  //========= Add PID Reponse to ANALYSIS manager ====
+  if(!(AliPIDResponse*)mgr->GetTask("PIDResponseTask")){
+    gROOT->LoadMacro("$ALICE_ROOT/ANALYSIS/macros/AddTaskPIDResponse.C");
+    AddTaskPIDResponse(isMC);
+  }
+
+  //=========  Set Cutnumber for V0Reader ================================
+  TString cutnumberPhoton = "06000008400100001500000000";
+  if (  periodNameV0Reader.CompareTo("LHC16f") == 0 || periodNameV0Reader.CompareTo("LHC17g")==0 || periodNameV0Reader.CompareTo("LHC18c")==0 ||
+        periodNameV0Reader.CompareTo("LHC17d1") == 0  || periodNameV0Reader.CompareTo("LHC17d12")==0 ||
+        periodNameV0Reader.CompareTo("LHC17h3")==0 || periodNameV0Reader.CompareTo("LHC17k1")==0 ||
+        periodNameV0Reader.CompareTo("LHC17f8b") == 0 ||
+        periodNameV0Reader.CompareTo("LHC16P1JJLowB") == 0 || periodNameV0Reader.CompareTo("LHC16P1Pyt8LowB") == 0 )
+    cutnumberPhoton         = "00000088400000000100000000";
+
+  TString cutnumberEvent = "00000003";
+  TString PionCuts      = "000000200";            //Electron Cuts
+
+
+  AliAnalysisDataContainer *cinput = mgr->GetCommonInputContainer();
+
+  //========= Add V0 Reader to  ANALYSIS manager if not yet existent =====
+  TString V0ReaderName = Form("V0ReaderV1_%s_%s",cutnumberEvent.Data(),cutnumberPhoton.Data());
+  if( !(AliV0ReaderV1*)mgr->GetTask(V0ReaderName.Data()) ){
+    AliV0ReaderV1 *fV0ReaderV1 = new AliV0ReaderV1(V0ReaderName.Data());
+
+    if (periodNameV0Reader.CompareTo("") != 0) fV0ReaderV1->SetPeriodName(periodNameV0Reader);
+    fV0ReaderV1->SetUseOwnXYZCalculation(kTRUE);
+    fV0ReaderV1->SetCreateAODs(kFALSE);// AOD Output
+    fV0ReaderV1->SetUseAODConversionPhoton(kTRUE);
+
+    if (!mgr) {
+      Error("AddTask_V0ReaderV1", "No analysis manager found.");
+      return;
+    }
+
+    AliConvEventCuts *fEventCuts=NULL;
+    if(cutnumberEvent!=""){
+      fEventCuts= new AliConvEventCuts(cutnumberEvent.Data(),cutnumberEvent.Data());
+      fEventCuts->SetPreSelectionCutFlag(kTRUE);
+      fEventCuts->SetV0ReaderName(V0ReaderName);
+      if (periodNameV0Reader.CompareTo("") != 0) fEventCuts->SetPeriodEnum(periodNameV0Reader);
+      if(runLightOutput>0) fEventCuts->SetLightOutput(kTRUE);
+      if(fEventCuts->InitializeCutsFromCutString(cutnumberEvent.Data())){
+        fV0ReaderV1->SetEventCuts(fEventCuts);
+        fEventCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+
+    // Set AnalysisCut Number
+    AliConversionPhotonCuts *fCuts=NULL;
+    if(cutnumberPhoton!=""){
+      fCuts= new AliConversionPhotonCuts(cutnumberPhoton.Data(),cutnumberPhoton.Data());
+      fCuts->SetPreSelectionCutFlag(kTRUE);
+      fCuts->SetIsHeavyIon(isHeavyIon);
+      fCuts->SetV0ReaderName(V0ReaderName);
+      if(runLightOutput>0) fCuts->SetLightOutput(kTRUE);
+      if(fCuts->InitializeCutsFromCutString(cutnumberPhoton.Data())){
+        fV0ReaderV1->SetConversionCuts(fCuts);
+        fCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+
+    if(inputHandler->IsA()==AliAODInputHandler::Class()){
+    // AOD mode
+      fV0ReaderV1->AliV0ReaderV1::SetDeltaAODBranchName(Form("GammaConv_%s_gamma",cutnumberAODBranch.Data()));
+    }
+    fV0ReaderV1->Init();
+
+    AliLog::SetGlobalLogLevel(AliLog::kFatal);
+
+    //connect input V0Reader
+    mgr->AddTask(fV0ReaderV1);
+    mgr->ConnectInput(fV0ReaderV1,0,cinput);
+  }
+
+  //================================================
+  //========= Add Pion Selector ====================
+  if( !(AliPrimaryPionSelector*)mgr->GetTask("PionSelector") ){
+    AliPrimaryPionSelector *fPionSelector = new AliPrimaryPionSelector("PionSelector");
+    AliPrimaryPionCuts *fPionCuts=0;
+    if( PionCuts!=""){
+      fPionCuts= new AliPrimaryPionCuts(PionCuts.Data(),PionCuts.Data());
+      if(runLightOutput>0) fPionCuts->SetLightOutput(kTRUE);
+
+      if(fPionCuts->InitializeCutsFromCutString(PionCuts.Data())){
+        fPionSelector->SetPrimaryPionCuts(fPionCuts);
+        fPionCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+
+    fPionSelector->Init();
+    mgr->AddTask(fPionSelector);
+
+    AliAnalysisDataContainer *cinput1  = mgr->GetCommonInputContainer();
+    mgr->ConnectInput (fPionSelector,0,cinput1);
+  }
+
+  AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson *task=NULL;
+  task= new AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson(Form("GammaConvNeutralMesonPiPlPiMiNeutralMeson_%i_%i",neutralPionMode, trainConfig));
+  task->SetIsHeavyIon(isHeavyIon);
+  task->SetIsMC(isMC);
+  task->SetV0ReaderName(V0ReaderName);
+  if(runLightOutput>1) task->SetLightOutput(kTRUE);
+
+  task->SetTolerance(tolerance);
+
+  CutHandlerNeutralMixed cuts;
+
+
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  //                                          ETA MESON
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  if( trainConfig == 1 ) {
+    // everything open, min pt charged pi = 100 MeV
+    cuts.AddCut("00000113","00200009327000008250400000","1111100047032230000","000010400","0103503a00000000","0103503000000000");
+    cuts.AddCut("00000113","00200009327000008250400000","1111100047032230000","000010400","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 2 ) {
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, min pt charged pi = 100 MeV
+    cuts.AddCut("00000113","00200009327000008250400000","1111100047032230000","002010700","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 3) {
+    // eta < 0.9
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, pi+pi- mass cut of 0.65, min pt charged pi = 100 MeV
+    // closing neural pion cuts, 0.1 < M_gamma,gamma < 0.15
+    // maxChi2 per cluster TPC <4, require TPC refit, DCA XY pT dependend 0.0182+0.0350/pt^1.01, DCA_Z = 3.0
+    // timing cluster cut open
+    cuts.AddCut("00010113","00200009327000008250400000","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00052113","00200009327000008250400000","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00062113","00200009327000008250400000","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00083113","00200009327000008250400000","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00085113","00200009327000008250400000","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+  } else if( trainConfig == 4) {
+    // same as 3 but only MB
+    cuts.AddCut("00010113","00200009327000008250400000","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    
+    // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    //                                          OMEGA MESON
+    // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  } else if( trainConfig == 100 ) {
+    // everything open, min pt charged pi = 100 MeV
+    cuts.AddCut("00000113","00200009327000008250400000","1111100047032230000","000010400","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 101 ) {
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, min pt charged pi = 100 MeV
+    cuts.AddCut("00000113","00200009327000008250400000","1111100047032230000","002010700","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 102) {
+    // eta < 0.9
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, pi+pi- mass cut of 0.65, min pt charged pi = 100 MeV
+    // closing neural pion cuts, 0.1 < M_gamma,gamma < 0.15
+    // maxChi2 per cluster TPC <4, require TPC refit, DCA XY pT dependend 0.0182+0.0350/pt^1.01, DCA_Z = 3.0
+    // timing cluster cut open
+    cuts.AddCut("00010113","00200009327000008250400000","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00052113","00200009327000008250400000","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00062113","00200009327000008250400000","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00083113","00200009327000008250400000","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    cuts.AddCut("00085113","00200009327000008250400000","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    
+  } else if( trainConfig == 103) {
+    // same as 102 but only MB
+    cuts.AddCut("00010113","00200009327000008250400000","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // all of the above
+    
+    
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  //                                          ETA PRIME MESON
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  
+  } else if( trainConfig == 200 ) {
+    // everything open, min pt charged pi = 100 MeV
+    cuts.AddCut("00000113","00200009327000008250400000","1111100047032230000","000010400","0103503m00000000","0103503000000000");
+  } else if( trainConfig == 201 ) {
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, min pt charged pi = 100 MeV
+    cuts.AddCut("00000113","00200009327000008250400000","1111100047032230000","002010700","0103503m00000000","0103503000000000");
+  } else if( trainConfig == 202) {
+    // eta < 0.9
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, pi+pi- mass cut of 1.5, min pt charged pi = 100 MeV
+    // closing neural pion cuts, 0.5 < M_gamma,gamma < 0.6
+    // maxChi2 per cluster TPC <4, require TPC refit, DCA XY pT dependend 0.0182+0.0350/pt^1.01, DCA_Z = 3.0
+    // timing cluster cut open
+    cuts.AddCut("00010113","00200009327000008250400000","1111100047032230000","30a330709","0103503l00000000","0153503000000000"); // all of the above
+    cuts.AddCut("00052113","00200009327000008250400000","1111100047032230000","30a330709","0103503l00000000","0153503000000000"); // all of the above
+    cuts.AddCut("00062113","00200009327000008250400000","1111100047032230000","30a330709","0103503l00000000","0153503000000000"); // all of the above
+    cuts.AddCut("00083113","00200009327000008250400000","1111100047032230000","30a330709","0103503l00000000","0153503000000000"); // all of the above
+    cuts.AddCut("00085113","00200009327000008250400000","1111100047032230000","30a330709","0103503l00000000","0153503000000000"); // all of the above
+  } else if( trainConfig == 203) {
+    // same as 202 but only MB
+    cuts.AddCut("00010113","00200009327000008250400000","1111100047032230000","30a330709","0103503l00000000","0153503000000000"); // 0.5-0.6 eta mass cut
+    cuts.AddCut("00010113","00200009327000008250400000","1111100047032230000","30a330709","0103503m00000000","0153503000000000"); // 0.4-0.7 eta mass cut
+  } else if( trainConfig == 204) {
+    // same as 202 but with mass cut variations
+    cuts.AddCut("00010113","00200009327000008250400000","1111100047032230000","30a330700","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 10
+    cuts.AddCut("00010113","00200009327000008250400000","1111100047032230000","30a330701","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 1
+    cuts.AddCut("00010113","00200009327000008250400000","1111100047032230000","30a330708","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 0.85
+    
+  } else {
+    Error(Form("GammaConvNeutralMeson_MixedMode_%i",trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");
+    return;
+  }
+
+  if(!cuts.AreValid()){
+    cout << "\n\n****************************************************" << endl;
+    cout << "ERROR: No valid cuts stored in CutHandlerNeutralMixed! Returning..." << endl;
+    cout << "****************************************************\n\n" << endl;
+    return;
+  }
+
+  Int_t numberOfCuts = cuts.GetNCuts();
+
+  TList *EventCutList = new TList();
+  TList *ConvCutList  = new TList();
+  TList *ClusterCutList  = new TList();
+  TList *NeutralPionCutList = new TList();
+  TList *MesonCutList = new TList();
+  TList *PionCutList  = new TList();
+
+  TList *HeaderList = new TList();
+  TObjString *Header1 = new TObjString("pi0_1");
+  HeaderList->Add(Header1);
+  TObjString *Header3 = new TObjString("eta_2");
+  HeaderList->Add(Header3);
+
+  EventCutList->SetOwner(kTRUE);
+  AliConvEventCuts **analysisEventCuts = new AliConvEventCuts*[numberOfCuts];
+  ConvCutList->SetOwner(kTRUE);
+  AliConversionPhotonCuts **analysisCuts = new AliConversionPhotonCuts*[numberOfCuts];
+  ClusterCutList->SetOwner(kTRUE);
+  AliCaloPhotonCuts **analysisClusterCuts = new AliCaloPhotonCuts*[numberOfCuts];
+  NeutralPionCutList->SetOwner(kTRUE);
+  AliConversionMesonCuts **analysisNeutralPionCuts   = new AliConversionMesonCuts*[numberOfCuts];
+  MesonCutList->SetOwner(kTRUE);
+  AliConversionMesonCuts **analysisMesonCuts   = new AliConversionMesonCuts*[numberOfCuts];
+  PionCutList->SetOwner(kTRUE);
+  AliPrimaryPionCuts **analysisPionCuts     = new AliPrimaryPionCuts*[numberOfCuts];
+
+  for(Int_t i = 0; i<numberOfCuts; i++){
+    //create AliCaloTrackMatcher instance, if there is none present
+    TString caloCutPos = cuts.GetClusterCut(i);
+    caloCutPos.Resize(1);
+    TString TrackMatcherName = Form("CaloTrackMatcher_%s",caloCutPos.Data());
+    if( !(AliCaloTrackMatcher*)mgr->GetTask(TrackMatcherName.Data()) ){
+      AliCaloTrackMatcher* fTrackMatcher = new AliCaloTrackMatcher(TrackMatcherName.Data(),caloCutPos.Atoi());
+      fTrackMatcher->SetV0ReaderName(V0ReaderName);
+      mgr->AddTask(fTrackMatcher);
+      mgr->ConnectInput(fTrackMatcher,0,cinput);
+    }
+
+    analysisEventCuts[i] = new AliConvEventCuts();
+    analysisEventCuts[i]->SetV0ReaderName(V0ReaderName);
+    if(runLightOutput>0) analysisEventCuts[i]->SetLightOutput(kTRUE);
+    analysisEventCuts[i]->InitializeCutsFromCutString((cuts.GetEventCut(i)).Data());
+    if (periodNameV0Reader.CompareTo("") != 0) analysisEventCuts[i]->SetPeriodEnum(periodNameV0Reader);
+    EventCutList->Add(analysisEventCuts[i]);
+    analysisEventCuts[i]->SetFillCutHistograms("",kFALSE);
+
+    analysisCuts[i] = new AliConversionPhotonCuts();
+    analysisCuts[i]->SetV0ReaderName(V0ReaderName);
+    if(runLightOutput>0) analysisCuts[i]->SetLightOutput(kTRUE);
+    if( ! analysisCuts[i]->InitializeCutsFromCutString((cuts.GetConversionCut(i)).Data()) ) {
+      cout<<"ERROR: analysisCuts [" <<i<<"]"<<endl;
+      return 0;
+    } else {
+      ConvCutList->Add(analysisCuts[i]);
+      analysisCuts[i]->SetFillCutHistograms("",kFALSE);
+    }
+
+    analysisClusterCuts[i] = new AliCaloPhotonCuts();
+    analysisClusterCuts[i]->SetV0ReaderName(V0ReaderName);
+    if(runLightOutput>0) analysisClusterCuts[i]->SetLightOutput(kTRUE);
+    analysisClusterCuts[i]->SetCaloTrackMatcherName(TrackMatcherName);
+    if( ! analysisClusterCuts[i]->InitializeCutsFromCutString((cuts.GetClusterCut(i)).Data()) ) {
+      cout<<"ERROR: analysisClusterCuts [" <<i<<"]"<<endl;
+      return 0;
+    } else {
+      ClusterCutList->Add(analysisClusterCuts[i]);
+      analysisClusterCuts[i]->SetFillCutHistograms("");
+    }
+
+    analysisNeutralPionCuts[i] = new AliConversionMesonCuts();
+    if(runLightOutput>0) analysisNeutralPionCuts[i]->SetLightOutput(kTRUE);
+    if( ! analysisNeutralPionCuts[i]->InitializeCutsFromCutString((cuts.GetNeutralPionCut(i)).Data()) ) {
+      cout<<"ERROR: analysisMesonCuts [ " <<i<<" ] "<<endl;
+      return 0;
+    } else {
+      NeutralPionCutList->Add(analysisNeutralPionCuts[i]);
+      analysisNeutralPionCuts[i]->SetFillCutHistograms("");
+    }
+
+    analysisMesonCuts[i] = new AliConversionMesonCuts();
+    if(runLightOutput>0) analysisMesonCuts[i]->SetLightOutput(kTRUE);
+    if( ! analysisMesonCuts[i]->InitializeCutsFromCutString((cuts.GetMesonCut(i)).Data()) ) {
+      cout<<"ERROR: analysisMesonCuts [ " <<i<<" ] "<<endl;
+      return 0;
+    } else {
+      MesonCutList->Add(analysisMesonCuts[i]);
+      analysisMesonCuts[i]->SetFillCutHistograms("");
+    }
+    analysisEventCuts[i]->SetAcceptedHeader(HeaderList);
+
+    TString cutName( Form("%s_%s_%s_%s_%s_%s",(cuts.GetEventCut(i)).Data(), (cuts.GetConversionCut(i)).Data(), (cuts.GetClusterCut(i)).Data(),(cuts.GetPionCut(i)).Data(),(cuts.GetNeutralPionCut(i)).Data(), (cuts.GetMesonCut(i)).Data() ) );
+    analysisPionCuts[i] = new AliPrimaryPionCuts();
+    if(runLightOutput>0) analysisPionCuts[i]->SetLightOutput(kTRUE);
+
+    if( !analysisPionCuts[i]->InitializeCutsFromCutString((cuts.GetPionCut(i)).Data())) {
+      cout<< "ERROR:  analysisPionCuts [ " <<i<<" ] "<<endl;
+      return 0;
+    } else {
+      PionCutList->Add(analysisPionCuts[i]);
+      analysisPionCuts[i]->SetFillCutHistograms("",kFALSE,cutName);
+    }
+  }
+
+  task->SetNDMRecoMode(neutralPionMode);
+  task->SetEventCutList(numberOfCuts,EventCutList);
+  task->SetConversionCutList(ConvCutList);
+  task->SetClusterCutList(ClusterCutList);
+  task->SetNeutralPionCutList(NeutralPionCutList);
+  task->SetMesonCutList(MesonCutList);
+  task->SetPionCutList(PionCutList);
+
+  task->SetMoveParticleAccordingToVertex(kTRUE);
+  task->SetSelectedHeavyNeutralMeson(selectHeavyNeutralMeson);
+
+  task->SetDoMesonQA(enableQAMesonTask );
+
+  //connect containers
+  AliAnalysisDataContainer *coutput =
+  mgr->CreateContainer(Form("GammaConvNeutralMesonPiPlPiMiNeutralMeson_%i_%i_%i.root",selectHeavyNeutralMeson,neutralPionMode, trainConfig), TList::Class(),
+              AliAnalysisManager::kOutputContainer,Form("GammaConvNeutralMesonPiPlPiMiNeutralMeson_%i_%i_%i.root",selectHeavyNeutralMeson,neutralPionMode, trainConfig));
+
+  mgr->AddTask(task);
+  mgr->ConnectInput(task,0,cinput);
+  mgr->ConnectOutput(task,1,coutput);
+
+  return;
+
+}


### PR DESCRIPTION
This analysis task is derived from AliAnalysisTaskNeutralMesonToPiPlPiMiPiZero but now also supports the pi+pi-eta decay channel (or any other neutral meson in the dacay).
It will be developed in parallel to the existing omega/eta analysis task and at some point take over its place.