### PR TITLE
Allow AliEmcalJetTask to be compatible with AliBasicParticle

### DIFF
--- a/PWGJE/EMCALJetTasks/AliEmcalJetTask.cxx
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetTask.cxx
@@ -82,6 +82,7 @@ AliEmcalJetTask::AliEmcalJetTask() :
   fIsInit(0),
   fIsPSelSet(0),
   fIsEmcPart(0),
+  fEnableAliBasicParticleCompatibility(kFALSE),
   fLegacyMode(kFALSE),
   fFillGhost(kFALSE),
   fJets(0),
@@ -121,6 +122,7 @@ AliEmcalJetTask::AliEmcalJetTask(const char *name) :
   fIsInit(0),
   fIsPSelSet(0),
   fIsEmcPart(0),
+  fEnableAliBasicParticleCompatibility(kFALSE),
   fLegacyMode(kFALSE),
   fFillGhost(kFALSE),
   fJets(0),
@@ -539,9 +541,10 @@ void AliEmcalJetTask::FillJetConstituents(AliEmcalJet *jet, std::vector<fastjet:
       Double_t cEta = t->Eta();
       Double_t cPhi = t->Phi();
       Double_t cPt  = t->Pt();
-      Double_t cP   = t->P();
       if (t->Charge() == 0) {
-        neutralE += cP;
+        if (!fEnableAliBasicParticleCompatibility) {
+          neutralE += t->P();
+        }
         ++nneutral;
         if (cPt > maxNe) maxNe = cPt;
       } else {
@@ -550,7 +553,9 @@ void AliEmcalJetTask::FillJetConstituents(AliEmcalJet *jet, std::vector<fastjet:
       }
 
       // check if MC particle
-      if (TMath::Abs(t->GetLabel()) > fMinMCLabel) mcpt += cPt;
+      if (!fEnableAliBasicParticleCompatibility) {
+        if (TMath::Abs(t->GetLabel()) > fMinMCLabel) mcpt += cPt;
+      }
 
       if (fGeom) {
         if (cPhi < 0) cPhi += TMath::TwoPi();

--- a/PWGJE/EMCALJetTasks/AliEmcalJetTask.h
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetTask.h
@@ -79,6 +79,7 @@ class AliEmcalJetTask : public AliAnalysisTaskEmcal {
   void                   SetRecombScheme(ERecoScheme_t scheme)      { if (IsLocked()) return; fRecombScheme     = scheme; }
   void                   SetTrackEfficiency(Double_t t)             { if (IsLocked()) return; fTrackEfficiency  = t     ; }
   void                   SetTrackEfficiencyOnlyForEmbedding(Bool_t b) { if (IsLocked()) return; fTrackEfficiencyOnlyForEmbedding = b     ; }
+  void                   SetEnableAliBasicParticleCompatibility(Bool_t b) { if (IsLocked()) return; fEnableAliBasicParticleCompatibility = b; }
   void                   SetLegacyMode(Bool_t mode)                 { if (IsLocked()) return; fLegacyMode       = mode  ; }
   void                   SetFillGhost(Bool_t b=kTRUE)               { if (IsLocked()) return; fFillGhost        = b     ; }
   void                   SetRadius(Double_t r)                      { if (IsLocked()) return; fRadius           = r     ; }
@@ -195,6 +196,7 @@ class AliEmcalJetTask : public AliAnalysisTaskEmcal {
   Bool_t                 fIsInit;                 //!<!=true if already initialized
   Bool_t                 fIsPSelSet;              //!<!=true if physics selection was set
   Bool_t                 fIsEmcPart;              //!<!=true if emcal particles are given as input (for clusters)
+  Bool_t                 fEnableAliBasicParticleCompatibility; ///< Flag to allow compatibility with AliBasicParticle constituents
   Bool_t                 fLegacyMode;             //!<!=true to enable FJ 2.x behavior
   Bool_t                 fFillGhost;              ///< =true ghost particles will be filled in AliEmcalJet obj
 
@@ -214,7 +216,7 @@ class AliEmcalJetTask : public AliAnalysisTaskEmcal {
   AliEmcalJetTask &operator=(const AliEmcalJetTask&); // not implemented
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalJetTask, 28);
+  ClassDef(AliEmcalJetTask, 29);
   /// \endcond
 };
 #endif


### PR DESCRIPTION
This change is needed for closure test studies, in which one creates a toy thermal model of AliBasicParticles and wants to cluster them with the jet finder. The feature is of course turned off by default.