### PR TITLE
PWGCF: Add alternative implementations of share-quality algorithm

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisPionPion.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisPionPion.cxx
@@ -260,6 +260,8 @@ struct CutConfig_Pair {
   Bool_t remove_same_label { kFALSE },
          TPCOnly { kTRUE };
 
+  Int_t algorithm_code { 2 };
+
   CutConfig_Pair(){};
 };
 
@@ -587,6 +589,7 @@ AliFemtoAnalysisPionPion::DefaultCutConfig()
   , default_pair.max_share_quality
   , default_pair.max_share_fraction
   , default_pair.remove_same_label
+  , default_pair.algorithm_code
   };
 
   // sanity checks
@@ -731,6 +734,8 @@ AliFemtoAnalysisPionPion::BuildPairCut(const CutParams &p) const
   cut->SetShareQualityMax(p.pair_max_share_quality);
   cut->SetShareFractionMax(p.pair_max_share_fraction);
   cut->SetRemoveSameLabel(p.pair_remove_same_label);
+
+  cut->SetAlternativeAlgorithm(p.pair_algorithm);
 
   return cut;
 }

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisPionPion.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisPionPion.h
@@ -281,6 +281,7 @@ struct AliFemtoAnalysisPionPion::CutParams {
   Float_t pair_max_share_quality,
           pair_max_share_fraction;
   Bool_t pair_remove_same_label;
+  Int_t pair_algorithm;
 
 };
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoShareQualityPairCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoShareQualityPairCut.cxx
@@ -6,6 +6,7 @@
 #include "AliFemtoShareQualityPairCut.h"
 #include <string>
 #include <cstdio>
+#include <bitset>
 
 #ifdef __ROOT__
 ClassImp(AliFemtoShareQualityPairCut)
@@ -18,6 +19,7 @@ AliFemtoShareQualityPairCut::AliFemtoShareQualityPairCut():
   fShareQualityMax(1.0),
   fShareFractionMax(1.0),
   fRemoveSameLabel(false)
+  , fAlternativeAlgorithm(0)
 {
   // Default constructor
   // Nothing to do
@@ -71,6 +73,46 @@ bool AliFemtoShareQualityPairCut::Pass(const AliFemtoPair* pair)
     const auto tpc_sharing_1 = track1->TPCsharing(),
                tpc_sharing_2 = track2->TPCsharing();
 
+    // equivalent methods of determining the share quality and fraction
+    if (fAlternativeAlgorithm == 1) {
+
+      const auto cls1_and_cls2 = tpc_clusters_1 & tpc_clusters_2,
+                 cls1_xor_cls2 = tpc_clusters_1 ^ tpc_clusters_2,
+                 shr1_and_shr2 = tpc_sharing_1 & tpc_sharing_2,
+                 not_sharing = ~*const_cast<TBits*>(&shr1_and_shr2);
+                              // ^ weird const-cast to get around bug in ROOT5
+
+      int cls1_xor_cls2_bits = cls1_xor_cls2.CountBits();
+
+      nh = cls1_xor_cls2_bits + 2 * cls1_and_cls2.CountBits();
+      ns = 2 * (cls1_and_cls2 & shr1_and_shr2).CountBits();
+      an = cls1_xor_cls2_bits + ns / 2 - (cls1_and_cls2 & not_sharing).CountBits();
+
+    } else if (fAlternativeAlgorithm == 2) {
+      if (n_bits != 159) {
+        std::cerr << "n_bits: " << n_bits << " != 159\n";
+      }
+
+      std::bitset<159> a, b, c, d;
+      tpc_clusters_1.Get(reinterpret_cast<ULong64_t*>(&a));
+      tpc_clusters_2.Get(reinterpret_cast<ULong64_t*>(&b));
+      tpc_sharing_1.Get(reinterpret_cast<ULong64_t*>(&c));
+      tpc_sharing_2.Get(reinterpret_cast<ULong64_t*>(&d));
+
+      const auto cls1_and_cls2 = a & b,
+                 cls1_xor_cls2 = a ^ b,
+                 sharing = c & d,
+                 not_sharing = ~sharing;
+
+      const int cls1_xor_cls2_bits = cls1_xor_cls2.count();
+
+      nh = cls1_xor_cls2_bits + 2 * cls1_and_cls2.count();
+      ns = 2 * (cls1_and_cls2 & sharing).count();
+      an = cls1_xor_cls2_bits + ns / 2 - (cls1_and_cls2 & not_sharing).count();
+
+    } else {
+      // Below is the original algorithm
+
     for (unsigned int imap = 0; imap < n_bits; imap++) {
         const bool cluster_bit_1 = tpc_clusters_1.TestBitNumber(imap),
                    cluster_bit_2 = tpc_clusters_2.TestBitNumber(imap);
@@ -99,6 +141,7 @@ bool AliFemtoShareQualityPairCut::Pass(const AliFemtoPair* pair)
            nh++;
         }
      }
+    }
 
      Float_t hsmval = 0.0;
      Float_t hsfval = 0.0;

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoShareQualityPairCut.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoShareQualityPairCut.h
@@ -43,6 +43,9 @@ public:
   void SetRemoveSameLabel(Bool_t aRemove);
   Bool_t GetRemoveSameLabel() const;
 
+  /// Select sharing-calculation algorithm
+  void SetAlternativeAlgorithm(Int_t code) { fAlternativeAlgorithm = code; }
+
   /// Putting the equality in sharequality
   bool operator==(const AliFemtoShareQualityPairCut &) const;
 
@@ -55,6 +58,9 @@ public:
   Double_t fShareFractionMax;  ///< Maximum allowed share fraction
   Bool_t   fRemoveSameLabel;   ///< Pairs with two tracks with the same label will be removed
 
+
+  /// Use the CountBit() method instead of TestBit()
+  Int_t fAlternativeAlgorithm;
 
 #ifdef __ROOT__
   ClassDef(AliFemtoShareQualityPairCut, 0)


### PR DESCRIPTION
This is an experimental feature to check performance of various bit-wise operations when calculating track quality in femtoscopic pairs (disabled by default)