### PR TITLE
Added option to use EMCAL clusterizer v3 within old analysis framework

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEMCALClusterizeFast.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEMCALClusterizeFast.cxx
@@ -33,6 +33,7 @@
 #include "AliEMCALClusterizerNxN.h"
 #include "AliEMCALClusterizerv1.h"
 #include "AliEMCALClusterizerv2.h"
+#include "AliEMCALClusterizerv3.h"
 #include "AliEMCALClusterizerFixedWindow.h"
 #include "AliEMCALDigit.h"
 #include "AliEMCALGeometry.h"
@@ -1010,6 +1011,8 @@ void AliAnalysisTaskEMCALClusterizeFast::Init()
   } 
   else if (fRecParam->GetClusterizerFlag() == AliEMCALRecParam::kClusterizerv2) 
     fClusterizer = new AliEMCALClusterizerv2(fGeom);
+  else if (fRecParam->GetClusterizerFlag() == AliEMCALRecParam::kClusterizerv3)
+    fClusterizer = new AliEMCALClusterizerv3(fGeom);
   else if (fRecParam->GetClusterizerFlag() == AliEMCALRecParam::kClusterizerFW) {
     AliEMCALClusterizerFixedWindow *clusterizer = new AliEMCALClusterizerFixedWindow(fGeom);
     clusterizer->SetNphi(fNPhi);


### PR DESCRIPTION
This commit allows to use the old analysis framework with the new clusterizer v3.
NB: AliEMCALClusterizerv3.h is in the most recent AliRoot tag.