### PR TITLE
Remove prints from PHOSTriggerQA task to reduce the size of logs

### DIFF
--- a/PWGGA/PHOSTasks/PHOS_TriggerQA/AliAnalysisTaskPHOSTriggerQA.cxx
+++ b/PWGGA/PHOSTasks/PHOS_TriggerQA/AliAnalysisTaskPHOSTriggerQA.cxx
@@ -162,8 +162,8 @@ void AliAnalysisTaskPHOSTriggerQA::UserExec(Option_t *)
     FillHistogram("hNev",1.); // triggered events
   
   TString trigClasses = event->GetFiredTriggerClasses();
-  printf("\nEvent %d: %d non-zero trigger digits %s\n",
-	 fEventCounter,trgESD->GetEntries(),trigClasses.Data());
+  // printf("\nEvent %d: %d non-zero trigger digits %s\n",
+	 // fEventCounter,trgESD->GetEntries(),trigClasses.Data());
 
   // Get PHOS rotation matrices from ESD and set them to the PHOS geometry
   char key[55] ;  


### PR DESCRIPTION
This task produces too big log file (it prints trigger classes for all events) so it's impossible to run this task in trains.