### PR TITLE
Fix for ROOT6

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_ConversionAODProduction.C
+++ b/PWGGA/GammaConv/macros/AddTask_ConversionAODProduction.C
@@ -23,11 +23,11 @@ AliAnalysisTask *AddTask_ConversionAODProduction( Int_t dataset                 
     //get CDB entry
     AliCDBEntry* entry = AliCDBManager::Instance()->Get("GRP/GRP/Data");
     if(!entry){
-      AliInfo("AddTask_ConversionAODProduction", "cannot get AliCDBEntry for GRP/GRP/Data");
+      Info("AddTask_ConversionAODProduction", "cannot get AliCDBEntry for GRP/GRP/Data");
     }else{
       const AliGRPObject* grpData = dynamic_cast<AliGRPObject*>(entry->GetObject());
       if(!grpData){
-        AliInfo("AddTask_ConversionAODProduction", "cannot get AliCDBEntry for GRP/GRP/Data");
+        Info("AddTask_ConversionAODProduction", "cannot get AliCDBEntry for GRP/GRP/Data");
       }else{
         Float_t fL3current = grpData->GetL3Current((AliGRPObject::Stats)0);
         if(TMath::Abs(fL3current) < 15000) lowBfield = kTRUE;

--- a/PWGHF/vertexingHF/macros/AddTaskDmesonMCPerform.C
+++ b/PWGHF/vertexingHF/macros/AddTaskDmesonMCPerform.C
@@ -13,7 +13,7 @@ AliAnalysisTaskDmesonMCPerform *AddTaskDmesonMCPerform(TString suffix="",
   if(dpluscutfilename!="") {
     TFile* fileDpcuts=TFile::Open(dpluscutfilename.Data());
     if(!fileDpcuts ||(fileDpcuts&& !fileDpcuts->IsOpen())){
-      AliFatal("Input file not found : check your cut object");
+      ::Fatal("AddTaskDmesonMCPerform", "Input file not found : check your cut object");
     }else{
       analysiscutsdp = (AliRDHFCutsDplustoKpipi*)fileDpcuts->Get("AnalysisCuts");
     }

--- a/PWGPP/CMakeLists.txt
+++ b/PWGPP/CMakeLists.txt
@@ -388,6 +388,7 @@ install(DIRECTORY benchmark DESTINATION PWGPP USE_SOURCE_PERMISSIONS)
 install(DIRECTORY EvTrkSelection/macros DESTINATION PWGPP/EvTrkSelection FILES_MATCHING PATTERN "*.C")
 install(FILES EvTrkSelection/macros/AddTaskTrackingUncert.C
 	      EvTrkSelection/macros/AddSingleTrackEfficiencyTaskForAutomaticQA.C
+	      EvTrkSelection/macros/main_AddSingleTrackEfficiencyTaskForAutomaticQA.C
 	      DESTINATION PWGPP/EvTrkSelection)
 install(FILES CalibMacros/CPass0/LoadLibraries.C
 	      CalibMacros/CPass0/ConfigCalibTrain.C

--- a/PWGPP/EvTrkSelection/macros/AddSingleTrackEfficiencyTaskForAutomaticQA.C
+++ b/PWGPP/EvTrkSelection/macros/AddSingleTrackEfficiencyTaskForAutomaticQA.C
@@ -7,47 +7,13 @@
 // Authors: Jitendra Kumar, Zaida Conesa del Valle
 //
 
-#if (!defined(__CLING__) && !defined(__CINT__)) || defined(__ROOTCLING__) || defined(__ROOTCINT__)
-#include "AliCFSingleTrackEfficiencyTask.h"
-#endif
-
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
-#include "PWGPP/EvTrkSelection/macros/AddSingleTrackEfficiencyTask.C"
-#endif
+class AliAnalysisTask;
 
 AliAnalysisTask *AddSingleTrackEfficiencyTaskForAutomaticQA(const Bool_t readAOD = 0, // Flag to read AOD:1 or ESD:0
                                            ULong64_t triggerMask=AliVEvent::kAnyINT,
                                            Bool_t useCentrality = kFALSE)
 {
-
-    Info("AliCFSingleTrackEfficiencyTaskForAutomaticQA","Setting up instances");
-    
-    // The AddTask
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
-#else
     gROOT->LoadMacro("$ALICE_PHYSICS/PWGPP/EvTrkSelection/macros/AddSingleTrackEfficiencyTask.C");
-#endif
-    
-    // Charged particles, filter bit 0
-    AliCFSingleTrackEfficiencyTask * nchFB0 = AddSingleTrackEfficiencyTask(readAOD,"NchFbit0",AliPID::kPion,0,triggerMask,useCentrality);
-    nchFB0->SetFilterType(0);
-    
-    // Charged particles, filter bit 4
-    AliCFSingleTrackEfficiencyTask * nchFB4 = AddSingleTrackEfficiencyTask(readAOD,"NchFbit4",AliPID::kPion,0,triggerMask,useCentrality);
-    nchFB4->SetFilterType(4);
-    
-    // Pions, filter bit 0
-    AliCFSingleTrackEfficiencyTask * pions = AddSingleTrackEfficiencyTask(readAOD,"PionFbit0",AliPID::kPion,211,triggerMask,useCentrality);
-    
-    // Kaons, filter bit 0
-    AliCFSingleTrackEfficiencyTask * kaons = AddSingleTrackEfficiencyTask(readAOD,"KaonFbit0",AliPID::kKaon,321,triggerMask,useCentrality);
-    
-    // Protons, filter bit 0
-    AliCFSingleTrackEfficiencyTask * protons = AddSingleTrackEfficiencyTask(readAOD,"ProtonFbit0",AliPID::kProton,2212,triggerMask,useCentrality);
-    
-    // Electrons, filter bit 0
-    AliCFSingleTrackEfficiencyTask * electrons = AddSingleTrackEfficiencyTask(readAOD,"ElectronFbit0",AliPID::kElectron,11,triggerMask,useCentrality);
-
-    
+    gROOT->Macro(TString::Format("$ALICE_PHYSICS/PWGPP/EvTrkSelection/main_AddSingleTrackEfficiencyTaskForAutomaticQA.C(%d, %llu, %d)", readAOD, triggerMask, useCentrality));
     return NULL;
 }

--- a/PWGPP/EvTrkSelection/macros/main_AddSingleTrackEfficiencyTaskForAutomaticQA.C
+++ b/PWGPP/EvTrkSelection/macros/main_AddSingleTrackEfficiencyTaskForAutomaticQA.C
@@ -1,0 +1,43 @@
+//
+// Add task to add the instances of the single track efficiency calculation
+//  required for the automatic Montecarlo QA trending. This concerns:
+//   charged particles with filter bit 0 or 4,
+//   and pion/proton/kaon/electron with filter bit 0
+//
+// Authors: Jitendra Kumar, Zaida Conesa del Valle
+//
+
+#if (!defined(__CLING__) && !defined(__CINT__)) || defined(__ROOTCLING__) || defined(__ROOTCINT__)
+#include "AliCFSingleTrackEfficiencyTask.h"
+#endif
+
+AliAnalysisTask *main_AddSingleTrackEfficiencyTaskForAutomaticQA(const Bool_t readAOD, // Flag to read AOD:1 or ESD:0
+                                           ULong64_t triggerMask,
+                                           Bool_t useCentrality)
+{
+
+    Info("AliCFSingleTrackEfficiencyTaskForAutomaticQA","Setting up instances");
+    
+    // Charged particles, filter bit 0
+    AliCFSingleTrackEfficiencyTask * nchFB0 = AddSingleTrackEfficiencyTask(readAOD,"NchFbit0",AliPID::kPion,0,triggerMask,useCentrality);
+    nchFB0->SetFilterType(0);
+    
+    // Charged particles, filter bit 4
+    AliCFSingleTrackEfficiencyTask * nchFB4 = AddSingleTrackEfficiencyTask(readAOD,"NchFbit4",AliPID::kPion,0,triggerMask,useCentrality);
+    nchFB4->SetFilterType(4);
+    
+    // Pions, filter bit 0
+    AliCFSingleTrackEfficiencyTask * pions = AddSingleTrackEfficiencyTask(readAOD,"PionFbit0",AliPID::kPion,211,triggerMask,useCentrality);
+    
+    // Kaons, filter bit 0
+    AliCFSingleTrackEfficiencyTask * kaons = AddSingleTrackEfficiencyTask(readAOD,"KaonFbit0",AliPID::kKaon,321,triggerMask,useCentrality);
+    
+    // Protons, filter bit 0
+    AliCFSingleTrackEfficiencyTask * protons = AddSingleTrackEfficiencyTask(readAOD,"ProtonFbit0",AliPID::kProton,2212,triggerMask,useCentrality);
+    
+    // Electrons, filter bit 0
+    AliCFSingleTrackEfficiencyTask * electrons = AddSingleTrackEfficiencyTask(readAOD,"ElectronFbit0",AliPID::kElectron,11,triggerMask,useCentrality);
+
+    
+    return NULL;
+}


### PR DESCRIPTION
cannot include macro with $ALICE_PHYSICS in #include directory, and le is not in $ROOT_INCLUDE_PATH.

As discussed with @dberzano , this is a better fix as compared to alisw/alidist#1246, as it does not pollute the global include space.