### PR TITLE
[EMCAL-191] PWG/EMCAL & TENDER: Implementation of Run2 EMCal/DCal temperature calib in OADB

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
@@ -27,6 +27,7 @@ AliEmcalCorrectionCellEnergy::AliEmcalCorrectionCellEnergy() :
   ,fCellEnergyDistAfter(0)
   ,fUseAutomaticRecalib(1)
   ,fUseAutomaticRunDepRecalib(1)
+  ,fUseRunDepTempCalibRun2(0)
 {
 }
 
@@ -219,103 +220,205 @@ Int_t AliEmcalCorrectionCellEnergy::InitRunDepRecalib()
   if (!fEventManager.InputEvent())
     return 0;
 
-  AliInfo("Initialising recalibration factors");
-  
-  // init default maps first
-  if (!fRecoUtils->GetEMCALRecalibrationFactorsArray())
-    fRecoUtils->InitEMCALRecalibrationFactors() ;
-  
   Int_t runRC = fEventManager.InputEvent()->GetRunNumber();
-  
-  std::unique_ptr<AliOADBContainer> contRF;
-  std::unique_ptr<TFile> runDepRecalibFile;
-  if (fBasePath!="")
-  { //if fBasePath specified in the ->SetBasePath()
-    AliInfo(Form("Loading Recalib OADB from given path %s",fBasePath.Data()));
-    
-    runDepRecalibFile = std::unique_ptr<TFile>(TFile::Open(Form("%s/EMCALTemperatureCorrCalib.root",fBasePath.Data()),"read"));
-    if (!runDepRecalibFile || runDepRecalibFile->IsZombie())
-    {
-      AliFatal(Form("EMCALTemperatureCorrCalib.root not found in %s",fBasePath.Data()));
+
+  // Treat Run2 calibration differently. Loading of two OADB objects required for calibration
+  // Calibration can be turned on or off via: doTempCalibRun2: true in the YAML configuration
+  if(runRC > 197692){
+
+    AliInfo("Initialising Run2 recalibration factors");
+
+    // init default maps first
+    if (!fRecoUtils->GetEMCALRecalibrationFactorsArray())
+      fRecoUtils->InitEMCALRecalibrationFactors() ;
+
+    // check the YAML configuration if the Run2 calibration is requested (default is false)
+    GetProperty("doTempCalibRun2",fUseRunDepTempCalibRun2);
+    if(!fUseRunDepTempCalibRun2){
+      AliInfo("Temperature calibration for Run2 not requested");
       return 0;
     }
-    
-    contRF = std::unique_ptr<AliOADBContainer>(static_cast<AliOADBContainer *>(runDepRecalibFile->Get("AliEMCALRunDepTempCalibCorrections")));
-  }
-  else
-  { // Else choose the one in the $ALICE_PHYSICS directory
-    AliInfo("Loading Recalib OADB from OADB/EMCAL");
-    
-    runDepRecalibFile = std::unique_ptr<TFile>(TFile::Open(AliDataFile::GetFileNameOADB("EMCAL/EMCALTemperatureCorrCalib.root").data(),"read"));
-    if (!runDepRecalibFile || runDepRecalibFile->IsZombie())
+
+    // two files and two OADB containers are needed for the correction factor
+    std::unique_ptr<AliOADBContainer> contTemperature;
+    std::unique_ptr<AliOADBContainer> contParams;
+    std::unique_ptr<TFile> runDepTemperatureFile;
+    std::unique_ptr<TFile> temperatureCalibParamFile;
+
+    if (fBasePath!="")
+    { //if fBasePath specified in the ->SetBasePath()
+      runDepTemperatureFile             = std::unique_ptr<TFile>(TFile::Open(Form("%s/EMCALTemperatureCalibSM.root",fBasePath.Data()),"read"));
+      if (!runDepTemperatureFile || runDepTemperatureFile->IsZombie()) {
+        AliFatal(Form("EMCALTemperatureCalibSM.root not found in %s",fBasePath.Data()));
+        return 0;
+      }
+
+      temperatureCalibParamFile  = std::unique_ptr<TFile>(TFile::Open(Form("%s/EMCALTemperatureCalibParam.root",fBasePath.Data()),"read"));
+      if (!temperatureCalibParamFile || temperatureCalibParamFile->IsZombie()) {
+        AliFatal(Form("EMCALTemperatureCalibParam.root not found in %s",fBasePath.Data()));
+        return 0;
+      }
+
+      contTemperature = std::unique_ptr<AliOADBContainer>(static_cast<AliOADBContainer *>(runDepTemperatureFile->Get("AliEMCALTemperatureCalibSM")));
+      contParams      = std::unique_ptr<AliOADBContainer>(static_cast<AliOADBContainer *>(temperatureCalibParamFile->Get("AliEMCALTemperatureCalibParam")));
+    }
+    else
+    { // Else choose the one in the $ALICE_PHYSICS directory or on EOS via the wrapper function
+      runDepTemperatureFile= std::unique_ptr<TFile>(TFile::Open(AliDataFile::GetFileNameOADB("EMCAL/EMCALTemperatureCalibSM.root").data(),"read"));
+      if (!runDepTemperatureFile || runDepTemperatureFile->IsZombie()) {
+        AliFatal("OADB/EMCAL/EMCALTemperatureCalibSM.root was not found");
+        return 0;
+      }
+
+      temperatureCalibParamFile= std::unique_ptr<TFile>(TFile::Open(AliDataFile::GetFileNameOADB("EMCAL/EMCALTemperatureCalibParam.root").data(),"read"));
+      if (!temperatureCalibParamFile || temperatureCalibParamFile->IsZombie()) {
+        AliFatal("OADB/EMCAL/EMCALTemperatureCalibParam.root was not found");
+        return 0;
+      }
+
+      contTemperature = std::unique_ptr<AliOADBContainer>(static_cast<AliOADBContainer *>(runDepTemperatureFile->Get("AliEMCALTemperatureCalibSM")));
+      contParams      = std::unique_ptr<AliOADBContainer>(static_cast<AliOADBContainer *>(temperatureCalibParamFile->Get("AliEMCALTemperatureCalibParam")));
+    }
+
+
+    TObjArray *arrayParams=(TObjArray*)contParams->GetObject(runRC);
+    if (!arrayParams)
     {
-      AliFatal("OADB/EMCAL/EMCALTemperatureCorrCalib.root was not found");
+      AliError(Form("No calibration parameters can be found for run number: %d", runRC));
       return 0;
     }
-    
-    contRF = std::unique_ptr<AliOADBContainer>(static_cast<AliOADBContainer *>(runDepRecalibFile->Get("AliEMCALRunDepTempCalibCorrections")));
-  }
-  if(!contRF) {
-    AliError("No OADB container found");
-    return 0;
-  }
-  contRF->SetOwner(true);
-  
-  TH1S *rundeprecal=(TH1S*)contRF->GetObject(runRC);
-  
-  if (!rundeprecal)
-  {
-    AliWarning(Form("No TemperatureCorrCalib Objects for run: %d",runRC));
-    // let's get the closest runnumber instead then..
-    Int_t lower = 0;
-    Int_t ic = 0;
-    Int_t maxEntry = contRF->GetNumberOfEntries();
-    
-    while ((ic < maxEntry) && (contRF->UpperLimit(ic) < runRC)) {
-      lower = ic;
-      ic++;
-    }
-    
-    Int_t closest = lower;
-    if ((ic<maxEntry) &&
-        (contRF->LowerLimit(ic)-runRC) < (runRC - contRF->UpperLimit(lower))) {
-      closest = ic;
-    }
-    
-    AliWarning(Form("TemperatureCorrCalib Objects found closest id %d from run: %d", closest, contRF->LowerLimit(closest)));
-    rundeprecal = (TH1S*) contRF->GetObjectByIndex(closest);
-  }
-  
-  Int_t nSM = fGeom->GetEMCGeometry()->GetNumberOfSuperModules();
-  Int_t nbins = rundeprecal->GetNbinsX();
-  
-  // Avoid use of Run1 param for Run2
-  if(nSM > 12 && nbins < 12288)
-  {
-    AliError(Form("Total SM is %d but T corrections available for %d channels, skip Init of T recalibration factors",nSM,nbins));
-    
-    return 2;
-  }
-  
-  //AliDebug(1, rundeprecal->Print());
-  
-  for (Int_t ism=0; ism<nSM; ++ism)
-  {
-    for (Int_t icol=0; icol<48; ++icol)
+    TH1D *hRundepTemp = (TH1D*)contTemperature->GetObject(runRC);
+    TH1F *hSlopeParam = (TH1F*)arrayParams->FindObject("hParamSlope");
+    TH1F *hA0Param    = (TH1F*)arrayParams->FindObject("hParamA0");
+
+    if (!hRundepTemp || !hSlopeParam || !hA0Param)
     {
-      for (Int_t irow=0; irow<24; ++irow)
+      AliError(Form("Histogram missing for Run2 temperature calibration for run number: %d", runRC));
+      return 0;
+    }
+
+    Int_t nSM = fGeom->GetEMCGeometry()->GetNumberOfSuperModules();
+    for (Int_t ism=0; ism<nSM; ++ism)
+    {
+      Double_t temperature = hRundepTemp->GetBinContent(ism+1);
+      for (Int_t icol=0; icol<48; ++icol)
       {
-        Float_t factor = fRecoUtils->GetEMCALChannelRecalibrationFactor(ism,icol,irow);
-        
-        Int_t absID = fGeom->GetAbsCellIdFromCellIndexes(ism, irow, icol); // original calibration factor
-        factor *= rundeprecal->GetBinContent(absID) / 10000. ; // correction dependent on T
-        
-        fRecoUtils->SetEMCALChannelRecalibrationFactor(ism,icol,irow,factor);
-      } // columns
-    } // rows
-  } // SM loop
-  
-  return 1;
+        for (Int_t irow=0; irow<24; ++irow)
+        {
+          Int_t absID     = fGeom->GetAbsCellIdFromCellIndexes(ism, irow, icol); // original calibration factor
+          Float_t factor  = 1;
+          Float_t slope   = 0;
+          Float_t offset  = 0;
+          slope           = hSlopeParam->GetBinContent(absID+1);
+          offset          = hA0Param->GetBinContent(absID+1);
+          if(slope || offset)
+            factor = offset + (slope * temperature) ; // correction dependent on T
+          fRecoUtils->SetEMCALChannelRecalibrationFactor(ism,icol,irow,factor);
+        } // columns
+      } // rows
+    } // SM loop
+
+    return 1;
+
+  // standard treatment of Run1 data
+  } else {
+
+    AliInfo("Initialising recalibration factors");
+
+    // init default maps first
+    if (!fRecoUtils->GetEMCALRecalibrationFactorsArray())
+      fRecoUtils->InitEMCALRecalibrationFactors() ;
+
+    std::unique_ptr<AliOADBContainer> contRF;
+    std::unique_ptr<TFile> runDepRecalibFile;
+    if (fBasePath!="")
+    { //if fBasePath specified in the ->SetBasePath()
+      AliInfo(Form("Loading Recalib OADB from given path %s",fBasePath.Data()));
+
+      runDepRecalibFile = std::unique_ptr<TFile>(TFile::Open(Form("%s/EMCALTemperatureCorrCalib.root",fBasePath.Data()),"read"));
+      if (!runDepRecalibFile || runDepRecalibFile->IsZombie())
+      {
+        AliFatal(Form("EMCALTemperatureCorrCalib.root not found in %s",fBasePath.Data()));
+        return 0;
+      }
+
+      contRF = std::unique_ptr<AliOADBContainer>(static_cast<AliOADBContainer *>(runDepRecalibFile->Get("AliEMCALRunDepTempCalibCorrections")));
+    }
+    else
+    { // Else choose the one in the $ALICE_PHYSICS directory
+      AliInfo("Loading Recalib OADB from OADB/EMCAL");
+
+      runDepRecalibFile = std::unique_ptr<TFile>(TFile::Open(AliDataFile::GetFileNameOADB("EMCAL/EMCALTemperatureCorrCalib.root").data(),"read"));
+      if (!runDepRecalibFile || runDepRecalibFile->IsZombie())
+      {
+        AliFatal("OADB/EMCAL/EMCALTemperatureCorrCalib.root was not found");
+        return 0;
+      }
+
+      contRF = std::unique_ptr<AliOADBContainer>(static_cast<AliOADBContainer *>(runDepRecalibFile->Get("AliEMCALRunDepTempCalibCorrections")));
+    }
+    if(!contRF) {
+      AliError("No OADB container found");
+      return 0;
+    }
+    contRF->SetOwner(true);
+
+    TH1S *rundeprecal=(TH1S*)contRF->GetObject(runRC);
+
+    if (!rundeprecal)
+    {
+      AliWarning(Form("No TemperatureCorrCalib Objects for run: %d",runRC));
+      // let's get the closest runnumber instead then..
+      Int_t lower = 0;
+      Int_t ic = 0;
+      Int_t maxEntry = contRF->GetNumberOfEntries();
+
+      while ((ic < maxEntry) && (contRF->UpperLimit(ic) < runRC)) {
+        lower = ic;
+        ic++;
+      }
+
+      Int_t closest = lower;
+      if ((ic<maxEntry) &&
+          (contRF->LowerLimit(ic)-runRC) < (runRC - contRF->UpperLimit(lower))) {
+        closest = ic;
+      }
+
+      AliWarning(Form("TemperatureCorrCalib Objects found closest id %d from run: %d", closest, contRF->LowerLimit(closest)));
+      rundeprecal = (TH1S*) contRF->GetObjectByIndex(closest);
+    }
+
+    Int_t nSM = fGeom->GetEMCGeometry()->GetNumberOfSuperModules();
+    Int_t nbins = rundeprecal->GetNbinsX();
+
+    // Avoid use of Run1 param for Run2
+    if(nSM > 12 && nbins < 12288)
+    {
+      AliError(Form("Total SM is %d but T corrections available for %d channels, skip Init of T recalibration factors",nSM,nbins));
+
+      return 2;
+    }
+
+    //AliDebug(1, rundeprecal->Print());
+
+    for (Int_t ism=0; ism<nSM; ++ism)
+    {
+      for (Int_t icol=0; icol<48; ++icol)
+      {
+        for (Int_t irow=0; irow<24; ++irow)
+        {
+          Float_t factor = fRecoUtils->GetEMCALChannelRecalibrationFactor(ism,icol,irow);
+
+          Int_t absID = fGeom->GetAbsCellIdFromCellIndexes(ism, irow, icol); // original calibration factor
+          factor *= rundeprecal->GetBinContent(absID) / 10000. ; // correction dependent on T
+
+          fRecoUtils->SetEMCALChannelRecalibrationFactor(ism,icol,irow,factor);
+        } // columns
+      } // rows
+    } // SM loop
+
+    return 1;
+  }
 }
 
 /**

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.h
@@ -44,6 +44,7 @@ private:
   // Change to false if experts
   Bool_t                 fUseAutomaticRecalib;       ///< On by default the check in the OADB of the energy recalibration
   Bool_t                 fUseAutomaticRunDepRecalib; ///< On by default the check in the OADB of the run dependent energy recalibration
+  Bool_t                 fUseRunDepTempCalibRun2;    ///< Off by default the check in the OADB of the run dependent temp calib Run2
   
   AliEmcalCorrectionCellEnergy(const AliEmcalCorrectionCellEnergy &);               // Not implemented
   AliEmcalCorrectionCellEnergy &operator=(const AliEmcalCorrectionCellEnergy &);    // Not implemented
@@ -52,7 +53,7 @@ private:
   static RegisterCorrectionComponent<AliEmcalCorrectionCellEnergy> reg;
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionCellEnergy, 1); // EMCal cell energy correction component
+  ClassDef(AliEmcalCorrectionCellEnergy, 2); // EMCal cell energy correction component
   /// \endcond
 };
 

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -51,7 +51,7 @@ sharedParameters:
 CellEnergy:                                         # Cell Energy correction component
     enabled: false                                  # Whether to enable the task
     createHistos: false                             # Whether the task should create output histograms
-    doTempCalibRun2: false                          # Whether the temperature calibration should be done for Run2
+    enableRun2TempCalib: false                      # Whether the temperature calibration should be done for Run2
     cellsNames:                                     # Names of the cells input objects which should be attached to the correction
         - defaultCells                              # This object is defined above in the cells section of the input objects
 CellBadChannel:                                     # Bad channel removal at the cell level component

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -51,6 +51,7 @@ sharedParameters:
 CellEnergy:                                         # Cell Energy correction component
     enabled: false                                  # Whether to enable the task
     createHistos: false                             # Whether the task should create output histograms
+    doTempCalibRun2: false                          # Whether the temperature calibration should be done for Run2
     cellsNames:                                     # Names of the cells input objects which should be attached to the correction
         - defaultCells                              # This object is defined above in the cells section of the input objects
 CellBadChannel:                                     # Bad channel removal at the cell level component

--- a/PWG/EMCAL/macros/AddTaskEMCALTender.C
+++ b/PWG/EMCAL/macros/AddTaskEMCALTender.C
@@ -32,7 +32,9 @@ AliAnalysisTaskSE *AddTaskEMCALTender(
   TString removeMCGen1        = "",       // name of generator input to be accepted
   TString removeMCGen2        = "",       // name of generator input to be accepted
   TString customBCmap         = "",       // location of custom bad channel map (full path including file)
-  Bool_t useRWTempCalibRun2   = kFALSE    // switch for usage of temperature calib in run2
+  Bool_t useRWTempCalibRun2   = kFALSE,   // switch for usage of temperature calib in run2
+  TString customSMtemps       = "",       // location of custom SM-wise temperature OADB file (full path including file)
+  TString customTempParams    = ""        // location of custom temperature calibration parameters OADB file (full path including file)
 ) 
 {
   // Get the pointer to the existing analysis manager via the static access method.
@@ -96,7 +98,8 @@ AliAnalysisTaskSE *AddTaskEMCALTender(
     EMCALSupply->SetCustomBC(customBCmap);
   if (useRWTempCalibRun2)
     EMCALSupply->SwitchUseRunDepTempCalibRun2(useRWTempCalibRun2);
-
+  if(customSMtemps!="" && customTempParams!="")
+    EMCALSupply->SetCustomTimeCalibration(customSMtemps,customTempParams);
   if (evhand->InheritsFrom("AliESDInputHandler")) {
     #ifdef __CLING__
         AliTender* alitender = dynamic_cast<AliTender *>(mgr->GetTopTasks()->FindObject("AliTender"));

--- a/PWG/EMCAL/macros/AddTaskEMCALTender.C
+++ b/PWG/EMCAL/macros/AddTaskEMCALTender.C
@@ -31,7 +31,8 @@ AliAnalysisTaskSE *AddTaskEMCALTender(
   Bool_t enableMCGenRemovTrack= 1,        // apply the MC generators rejection also for track matching  
   TString removeMCGen1        = "",       // name of generator input to be accepted
   TString removeMCGen2        = "",       // name of generator input to be accepted
-  TString customBCmap         = ""        // location of custom bad channel map (full path including file)
+  TString customBCmap         = "",       // location of custom bad channel map (full path including file)
+  Bool_t useRWTempCalibRun2   = kFALSE    // switch for usage of temperature calib in run2
 ) 
 {
   // Get the pointer to the existing analysis manager via the static access method.
@@ -74,7 +75,8 @@ AliAnalysisTaskSE *AddTaskEMCALTender(
     configbuilder << (updateCellOnly ? "kTRUE" : "kFALSE") << ", ";
     configbuilder << timeMin << ", ";
     configbuilder << timeMax << ", ";
-    configbuilder << timeCut;
+    configbuilder << timeCut << ", ";
+    configbuilder << diffEAggregation;
     configbuilder << ")";
     std::string configbuilderstring = configbuilder.str();
     std::cout << "Running config macro " << configbuilderstring << std::endl;
@@ -90,8 +92,10 @@ AliAnalysisTaskSE *AddTaskEMCALTender(
 
   if (pass) 
     EMCALSupply->SetPass(pass);
-  if (customBCmap!="") 
+  if (customBCmap!="")
     EMCALSupply->SetCustomBC(customBCmap);
+  if (useRWTempCalibRun2)
+    EMCALSupply->SwitchUseRunDepTempCalibRun2(useRWTempCalibRun2);
 
   if (evhand->InheritsFrom("AliESDInputHandler")) {
     #ifdef __CLING__

--- a/PWGGA/GammaConv/config/PWGGA_CF_config_p1.yaml
+++ b/PWGGA/GammaConv/config/PWGGA_CF_config_p1.yaml
@@ -38,6 +38,7 @@ CellEnergy:
     createHistos: true
 CellEnergy_defaultSetting:
     enabled: true
+    doTempCalibRun2: false
 
 CellBadChannel:
     createHistos: true

--- a/PWGGA/GammaConv/config/PWGGA_CF_config_p1.yaml
+++ b/PWGGA/GammaConv/config/PWGGA_CF_config_p1.yaml
@@ -38,7 +38,7 @@ CellEnergy:
     createHistos: true
 CellEnergy_defaultSetting:
     enabled: true
-    doTempCalibRun2: false
+    enableRun2TempCalib: true
 
 CellBadChannel:
     createHistos: true

--- a/TENDER/TenderSupplies/AliEMCALTenderSupply.cxx
+++ b/TENDER/TenderSupplies/AliEMCALTenderSupply.cxx
@@ -86,6 +86,8 @@ AliEMCALTenderSupply::AliEMCALTenderSupply() :
   ,fPhicut(-1)
   ,fBasePath("")
   ,fCustomBC("")
+  ,fCustomTempCalibSM("")
+  ,fCustomTempCalibParams("")
   ,fReClusterize(kFALSE)
   ,fClusterizer(0)
   ,fGeomMatrixSet(kFALSE)
@@ -158,6 +160,8 @@ AliEMCALTenderSupply::AliEMCALTenderSupply(const char *name, const AliTender *te
   ,fPhicut(-1)  
   ,fBasePath("")
   ,fCustomBC("")
+  ,fCustomTempCalibSM("")
+  ,fCustomTempCalibParams("")
   ,fReClusterize(kFALSE)
   ,fClusterizer(0)
   ,fGeomMatrixSet(kFALSE)
@@ -230,6 +234,8 @@ AliEMCALTenderSupply::AliEMCALTenderSupply(const char *name, AliAnalysisTaskSE *
   ,fPhicut(-1)  
   ,fBasePath("")
   ,fCustomBC("")
+  ,fCustomTempCalibSM("")
+  ,fCustomTempCalibParams("")
   ,fReClusterize(kFALSE)
   ,fClusterizer(0)
   ,fGeomMatrixSet(kFALSE)
@@ -392,7 +398,9 @@ void AliEMCALTenderSupply::Init()
     AliInfo("------------ Variables -------------------------"); 
     AliInfo(Form("DebugLevel : %d", fDebugLevel)); 
     AliInfo(Form("BasePath : %s", fBasePath.Data())); 
-    AliInfo(Form("CustomBCFile : %s", fCustomBC.Data())); 
+    AliInfo(Form("CustomBCFile : %s", fCustomBC.Data()));
+    AliInfo(Form("CustomSMTempFile : %s", fCustomTempCalibSM.Data()));
+    AliInfo(Form("CustomTempParamFile : %s", fCustomTempCalibParams.Data()));
     AliInfo(Form("ConfigFileName : %s", fConfigName.Data())); 
     AliInfo(Form("EMCALGeometryName : %s", fEMCALGeoName.Data())); 
     AliInfo(Form("NonLinearityFunction : %d", fNonLinearFunc)); 
@@ -1230,6 +1238,28 @@ Int_t AliEMCALTenderSupply::InitRunDepRecalib()
 
       contTemperature->InitFromFile(Form("%s/EMCALTemperatureCalibSM.root",fBasePath.Data()),"AliEMCALTemperatureCalibSM");
       contParams->InitFromFile(Form("%s/EMCALTemperatureCalibParam.root",fBasePath.Data()),"AliEMCALTemperatureCalibParam");
+    }
+    else if (fCustomTempCalibSM!="" && fCustomTempCalibParams!="" )
+    { //if fBasePath specified in the ->SetBasePath()
+      if (fDebugLevel>0)  AliInfo(Form("Loading custom recalib OADB from given paths %s and %s",fCustomTempCalibSM.Data(),fCustomTempCalibParams.Data()));
+
+      TFile *fRunDepTemperature       = new TFile(Form("%s",fCustomTempCalibSM.Data()),"read");
+      if (!fRunDepTemperature || fRunDepTemperature->IsZombie()) {
+        AliFatal(Form("SM-wise temperature file %s not found",fCustomTempCalibSM.Data()));
+        return 0;
+      }
+      if (fRunDepTemperature) delete fRunDepTemperature;
+
+      TFile *fTemperatureCalibParam   = new TFile(Form("%s",fCustomTempCalibParams.Data()),"read");
+      if (!fTemperatureCalibParam || fTemperatureCalibParam->IsZombie()) {
+        AliFatal(Form("Temp calibration params file %s not found",fCustomTempCalibParams.Data()));
+        return 0;
+      }
+
+      if (fTemperatureCalibParam) delete fTemperatureCalibParam;
+
+      contTemperature->InitFromFile(Form("%s",fCustomTempCalibSM.Data()),"AliEMCALTemperatureCalibSM");
+      contParams->InitFromFile(Form("%s",fCustomTempCalibParams.Data()),"AliEMCALTemperatureCalibParam");
     }
     else
     { // Else choose the one in the $ALICE_PHYSICS directory

--- a/TENDER/TenderSupplies/AliEMCALTenderSupply.cxx
+++ b/TENDER/TenderSupplies/AliEMCALTenderSupply.cxx
@@ -106,6 +106,7 @@ AliEMCALTenderSupply::AliEMCALTenderSupply() :
   ,fRemapMCLabelForAODs(0)
   ,fUseAutomaticRecalib(1)
   ,fUseAutomaticRunDepRecalib(1)
+  ,fUseRunDepTempCalibRun2(0)
   ,fUseAutomaticTimeCalib(1)
   ,fUseAutomaticRecParam(1)
 {
@@ -177,6 +178,7 @@ AliEMCALTenderSupply::AliEMCALTenderSupply(const char *name, const AliTender *te
   ,fRemapMCLabelForAODs(0)
   ,fUseAutomaticRecalib(1)
   ,fUseAutomaticRunDepRecalib(1)
+  ,fUseRunDepTempCalibRun2(0)
   ,fUseAutomaticTimeCalib(1)
   ,fUseAutomaticRecParam(1)
 {
@@ -248,6 +250,7 @@ AliEMCALTenderSupply::AliEMCALTenderSupply(const char *name, AliAnalysisTaskSE *
   ,fRemapMCLabelForAODs(0)
   ,fUseAutomaticRecalib(1)
   ,fUseAutomaticRunDepRecalib(1)
+  ,fUseRunDepTempCalibRun2(0)
   ,fUseAutomaticTimeCalib(1)
   ,fUseAutomaticRecParam(1)
 {
@@ -1192,110 +1195,215 @@ Int_t AliEMCALTenderSupply::InitRunDepRecalib()
   // 
   // For more information see https://alice.its.cern.ch/jira/browse/EMCAL-135
   if(event->GetRunNumber() > 197692){
-    AliError("Temperature recalibration disabled for run2");
-    return 0;
-  }
-  
-  if (fDebugLevel>0) 
-    AliInfo("Initialising recalibration factors");
-  
-  // init default maps first
-  if (!fEMCALRecoUtils->GetEMCALRecalibrationFactorsArray())
-    fEMCALRecoUtils->InitEMCALRecalibrationFactors() ;
-  
-  Int_t runRC = event->GetRunNumber();
-  
-  AliOADBContainer *contRF=new AliOADBContainer("");
-  if (fBasePath!="") 
-  { //if fBasePath specified in the ->SetBasePath()
-    if (fDebugLevel>0)  AliInfo(Form("Loading Recalib OADB from given path %s",fBasePath.Data()));
-    
-    TFile *fRunDepRecalib= new TFile(Form("%s/EMCALTemperatureCorrCalib.root",fBasePath.Data()),"read");
-    if (!fRunDepRecalib || fRunDepRecalib->IsZombie()) 
+    if(!fUseRunDepTempCalibRun2)
+      return 0;
+
+    if (fDebugLevel>0)
+      AliInfo("Initialising Run2 temperature recalibration factors");
+
+    // init default maps first
+    if (!fEMCALRecoUtils->GetEMCALRecalibrationFactorsArray())
+      fEMCALRecoUtils->InitEMCALRecalibrationFactors() ;
+
+    Int_t runRC = event->GetRunNumber();
+
+    AliOADBContainer *contTemperature = new AliOADBContainer("");
+    AliOADBContainer *contParams      = new AliOADBContainer("");
+    if (fBasePath!="")
+    { //if fBasePath specified in the ->SetBasePath()
+      if (fDebugLevel>0)  AliInfo(Form("Loading Recalib OADB from given path %s",fBasePath.Data()));
+
+      TFile *fRunDepTemperature       = new TFile(Form("%s/EMCALTemperatureCalibSM.root",fBasePath.Data()),"read");
+      if (!fRunDepTemperature || fRunDepTemperature->IsZombie()) {
+        AliFatal(Form("EMCALTemperatureCalibSM.root not found in %s",fBasePath.Data()));
+        return 0;
+      }
+      if (fRunDepTemperature) delete fRunDepTemperature;
+
+      TFile *fTemperatureCalibParam   = new TFile(Form("%s/EMCALTemperatureCalibParam.root",fBasePath.Data()),"read");
+      if (!fTemperatureCalibParam || fTemperatureCalibParam->IsZombie()) {
+        AliFatal(Form("EMCALTemperatureCalibParam.root not found in %s",fBasePath.Data()));
+        return 0;
+      }
+
+      if (fTemperatureCalibParam) delete fTemperatureCalibParam;
+
+      contTemperature->InitFromFile(Form("%s/EMCALTemperatureCalibSM.root",fBasePath.Data()),"AliEMCALTemperatureCalibSM");
+      contParams->InitFromFile(Form("%s/EMCALTemperatureCalibParam.root",fBasePath.Data()),"AliEMCALTemperatureCalibParam");
+    }
+    else
+    { // Else choose the one in the $ALICE_PHYSICS directory
+      if (fDebugLevel>0)  AliInfo("Loading Recalib OADB from OADB/EMCAL");
+      TFile *fRunDepTemperature= new TFile(AliDataFile::GetFileNameOADB("EMCAL/EMCALTemperatureCalibSM.root").data(),"read");
+      if (!fRunDepTemperature || fRunDepTemperature->IsZombie()) {
+        AliFatal("OADB/EMCAL/EMCALTemperatureCalibSM.root was not found");
+        return 0;
+      }
+      if (fRunDepTemperature) delete fRunDepTemperature;
+
+      TFile *fTemperatureCalibParam= new TFile(AliDataFile::GetFileNameOADB("EMCAL/EMCALTemperatureCalibParam.root").data(),"read");
+      if (!fTemperatureCalibParam || fTemperatureCalibParam->IsZombie()) {
+        AliFatal("OADB/EMCAL/EMCALTemperatureCalibParam.root was not found");
+        return 0;
+      }
+      if (fTemperatureCalibParam) delete fTemperatureCalibParam;
+
+
+      contTemperature->InitFromFile(AliDataFile::GetFileNameOADB("EMCAL/EMCALTemperatureCalibSM.root").data(),"AliEMCALTemperatureCalibSM");
+      contParams->InitFromFile(AliDataFile::GetFileNameOADB("EMCAL/EMCALTemperatureCalibParam.root").data(),"AliEMCALTemperatureCalibParam");
+    }
+
+
+    TObjArray *arrayParams=(TObjArray*)contParams->GetObject(runRC);
+    if (!arrayParams)
     {
-      AliFatal(Form("EMCALTemperatureCorrCalib.root not found in %s",fBasePath.Data()));
+      AliError(Form("No external temperature calibration set for run number: %d", runRC));
+      delete contParams;
+      delete contTemperature;
       return 0;
     }
-    
-    if (fRunDepRecalib) delete fRunDepRecalib;
-    
-    contRF->InitFromFile(Form("%s/EMCALTemperatureCorrCalib.root",fBasePath.Data()),"AliEMCALRunDepTempCalibCorrections");
-  }
-  else
-  { // Else choose the one in the $ALICE_PHYSICS directory
-    if (fDebugLevel>0)  AliInfo("Loading Recalib OADB from OADB/EMCAL");
-    
-    TFile *fRunDepRecalib= new TFile(AliDataFile::GetFileNameOADB("EMCAL/EMCALTemperatureCorrCalib.root").data(),"read");
-    if (!fRunDepRecalib || fRunDepRecalib->IsZombie())
+    TH1D *hRundepTemp = (TH1D*)contTemperature->GetObject(runRC);
+    TH1F *hSlopeParam = (TH1F*)arrayParams->FindObject("hParamSlope");
+    TH1F *hA0Param    = (TH1F*)arrayParams->FindObject("hParamA0");
+
+    if (!hRundepTemp || !hSlopeParam || !hA0Param)
     {
-      AliFatal("OADB/EMCAL/EMCALTemperatureCorrCalib.root was not found");
+      AliError(Form("Histogram missing for temperature calibration for run number: %d", runRC));
+      delete contParams;
+      delete contTemperature;
       return 0;
     }
-    
-    if (fRunDepRecalib) delete fRunDepRecalib;
-    
-    contRF->InitFromFile(AliDataFile::GetFileNameOADB("EMCAL/EMCALTemperatureCorrCalib.root").data(),"AliEMCALRunDepTempCalibCorrections");
-  }
-  
-  TH1S *rundeprecal=(TH1S*)contRF->GetObject(runRC);
-    
-  if (!rundeprecal)
-  {
-    AliWarning(Form("No TemperatureCorrCalib Objects for run: %d",runRC));
-    // let's get the closest runnumber instead then..
-    Int_t lower = 0;
-    Int_t ic = 0;
-    Int_t maxEntry = contRF->GetNumberOfEntries();
 
-    while ((ic < maxEntry) && (contRF->UpperLimit(ic) < runRC)) {
-      lower = ic;
-      ic++; 
-    }
-
-    Int_t closest = lower;
-    if ((ic<maxEntry) && 
-	 (contRF->LowerLimit(ic)-runRC) < (runRC - contRF->UpperLimit(lower))) {
-	 closest = ic;
-    }
-
-    AliWarning(Form("TemperatureCorrCalib Objects found closest id %d from run: %d", closest, contRF->LowerLimit(closest)));
-    rundeprecal = (TH1S*) contRF->GetObjectByIndex(closest);  
-  } 
-  
-  Int_t nSM = fEMCALGeo->GetEMCGeometry()->GetNumberOfSuperModules();
-  Int_t nbins = rundeprecal->GetNbinsX();
-  
-  // Avoid use of Run1 param for Run2
-  if(nSM > 12 && nbins < 12288)
-  {
-    AliError(Form("Total SM is %d but T corrections available for %d channels, skip Init of T recalibration factors",nSM,nbins));
-    
-    delete contRF;
-    
-    return 2;
-  }
-  
-  if (fDebugLevel>0) rundeprecal->Print();
-
-  for (Int_t ism=0; ism<nSM; ++ism) 
-  {        
-    for (Int_t icol=0; icol<48; ++icol) 
-    {        
-      for (Int_t irow=0; irow<24; ++irow) 
+    Int_t nSM = fEMCALGeo->GetEMCGeometry()->GetNumberOfSuperModules();
+    for (Int_t ism=0; ism<nSM; ++ism)
+    {
+      Double_t temperature = hRundepTemp->GetBinContent(ism+1);
+      for (Int_t icol=0; icol<48; ++icol)
       {
-        Float_t factor = fEMCALRecoUtils->GetEMCALChannelRecalibrationFactor(ism,icol,irow);
-        
-        Int_t absID = fEMCALGeo->GetAbsCellIdFromCellIndexes(ism, irow, icol); // original calibration factor
-        factor *= rundeprecal->GetBinContent(absID) / 10000. ; // correction dependent on T
+        for (Int_t irow=0; irow<24; ++irow)
+        {
+          Int_t absID     = fEMCALGeo->GetAbsCellIdFromCellIndexes(ism, irow, icol); // original calibration factor
+          Float_t factor  = 1;
+          Float_t slope   = 0;
+          Float_t offset  = 0;
+          slope           = hSlopeParam->GetBinContent(absID+1);
+          offset          = hA0Param->GetBinContent(absID+1);
+          if(slope || offset)
+            factor = offset + (slope * temperature) ; // correction dependent on T
+          fEMCALRecoUtils->SetEMCALChannelRecalibrationFactor(ism,icol,irow,factor);
+        } // columns
+      } // rows
+    } // SM loop
 
-        fEMCALRecoUtils->SetEMCALChannelRecalibrationFactor(ism,icol,irow,factor);
-      } // columns
-    } // rows 
-  } // SM loop
-  
-  delete contRF;
-  
-  return 1;
+    delete contParams;
+    delete contTemperature;
+
+    return 1;
+
+    // Run1 treatment with old calibration
+  } else {
+
+    if (fDebugLevel>0)
+      AliInfo("Initialising Run1 recalibration factors");
+
+    // init default maps first
+    if (!fEMCALRecoUtils->GetEMCALRecalibrationFactorsArray())
+      fEMCALRecoUtils->InitEMCALRecalibrationFactors() ;
+
+    Int_t runRC = event->GetRunNumber();
+
+    AliOADBContainer *contRF=new AliOADBContainer("");
+    if (fBasePath!="")
+    { //if fBasePath specified in the ->SetBasePath()
+      if (fDebugLevel>0)  AliInfo(Form("Loading Recalib OADB from given path %s",fBasePath.Data()));
+
+      TFile *fRunDepRecalib= new TFile(Form("%s/EMCALTemperatureCorrCalib.root",fBasePath.Data()),"read");
+      if (!fRunDepRecalib || fRunDepRecalib->IsZombie())
+      {
+        AliFatal(Form("EMCALTemperatureCorrCalib.root not found in %s",fBasePath.Data()));
+        return 0;
+      }
+
+      if (fRunDepRecalib) delete fRunDepRecalib;
+
+      contRF->InitFromFile(Form("%s/EMCALTemperatureCorrCalib.root",fBasePath.Data()),"AliEMCALRunDepTempCalibCorrections");
+    }
+    else
+    { // Else choose the one in the $ALICE_PHYSICS directory
+      if (fDebugLevel>0)  AliInfo("Loading Recalib OADB from OADB/EMCAL");
+
+      TFile *fRunDepRecalib= new TFile(AliDataFile::GetFileNameOADB("EMCAL/EMCALTemperatureCorrCalib.root").data(),"read");
+      if (!fRunDepRecalib || fRunDepRecalib->IsZombie())
+      {
+        AliFatal("OADB/EMCAL/EMCALTemperatureCorrCalib.root was not found");
+        return 0;
+      }
+
+      if (fRunDepRecalib) delete fRunDepRecalib;
+
+      contRF->InitFromFile(AliDataFile::GetFileNameOADB("EMCAL/EMCALTemperatureCorrCalib.root").data(),"AliEMCALRunDepTempCalibCorrections");
+    }
+
+    TH1S *rundeprecal=(TH1S*)contRF->GetObject(runRC);
+
+    if (!rundeprecal)
+    {
+      AliWarning(Form("No TemperatureCorrCalib Objects for run: %d",runRC));
+      // let's get the closest runnumber instead then..
+      Int_t lower = 0;
+      Int_t ic = 0;
+      Int_t maxEntry = contRF->GetNumberOfEntries();
+
+      while ((ic < maxEntry) && (contRF->UpperLimit(ic) < runRC)) {
+        lower = ic;
+        ic++;
+      }
+
+      Int_t closest = lower;
+      if ((ic<maxEntry) &&
+    (contRF->LowerLimit(ic)-runRC) < (runRC - contRF->UpperLimit(lower))) {
+    closest = ic;
+      }
+
+      AliWarning(Form("TemperatureCorrCalib Objects found closest id %d from run: %d", closest, contRF->LowerLimit(closest)));
+      rundeprecal = (TH1S*) contRF->GetObjectByIndex(closest);
+    }
+
+    Int_t nSM = fEMCALGeo->GetEMCGeometry()->GetNumberOfSuperModules();
+    Int_t nbins = rundeprecal->GetNbinsX();
+
+    // Avoid use of Run1 param for Run2
+    if(nSM > 12 && nbins < 12288)
+    {
+      AliError(Form("Total SM is %d but T corrections available for %d channels, skip Init of T recalibration factors",nSM,nbins));
+
+      delete contRF;
+
+      return 2;
+    }
+
+    if (fDebugLevel>0) rundeprecal->Print();
+
+    for (Int_t ism=0; ism<nSM; ++ism)
+    {
+      for (Int_t icol=0; icol<48; ++icol)
+      {
+        for (Int_t irow=0; irow<24; ++irow)
+        {
+          Float_t factor = fEMCALRecoUtils->GetEMCALChannelRecalibrationFactor(ism,icol,irow);
+
+          Int_t absID = fEMCALGeo->GetAbsCellIdFromCellIndexes(ism, irow, icol); // original calibration factor
+          factor *= rundeprecal->GetBinContent(absID) / 10000. ; // correction dependent on T
+
+          fEMCALRecoUtils->SetEMCALChannelRecalibrationFactor(ism,icol,irow,factor);
+        } // columns
+      } // rows
+    } // SM loop
+
+    delete contRF;
+
+    return 1;
+  }
 }
 
 

--- a/TENDER/TenderSupplies/AliEMCALTenderSupply.h
+++ b/TENDER/TenderSupplies/AliEMCALTenderSupply.h
@@ -65,6 +65,10 @@ public:
  
   void     SetCustomBC(const Char_t *BCfile)              { fCustomBC = BCfile               ;}
  
+  void     SetCustomTimeCalibration(const Char_t *SMFile, const Char_t *ParamFile)
+                                                          { fCustomTempCalibSM = SMFile      ;
+                                                          fCustomTempCalibParams = ParamFile ;}
+ 
   void     SetConfigFileName(const char *name)            { fConfigName = name               ;}
 
   void     SetNonLinearityFunction(Int_t fun)             { fNonLinearFunc = fun             ;}
@@ -258,6 +262,8 @@ private:
   Float_t                fPhicut;                 // phi cut for track matching  
   TString                fBasePath;               // base folder path to get root files 
   TString                fCustomBC;               // custom BC map file
+  TString                fCustomTempCalibSM;      // custom temperature per SM file
+  TString                fCustomTempCalibParams;  // custom temp calib params file
   Bool_t                 fReClusterize;           // switch for reclustering
   AliEMCALClusterizer   *fClusterizer;            //!clusterizer 
   Bool_t                 fGeomMatrixSet;          // set geometry matrices only once, for the first event.         

--- a/TENDER/TenderSupplies/AliEMCALTenderSupply.h
+++ b/TENDER/TenderSupplies/AliEMCALTenderSupply.h
@@ -194,7 +194,9 @@ public:
   void     SwitchOffUseAutomaticRunDepRecalibParam()       { fUseAutomaticRunDepRecalib = kFALSE ; }
   void     SwitchOffUseAutomaticTimeCalibParam()           { fUseAutomaticTimeCalib     = kFALSE ; }
   void     SwitchOffUseAutomaticRecParam()                 { fUseAutomaticRecParam      = kFALSE ; }
-  
+
+  void     SwitchUseRunDepTempCalibRun2(Bool_t doUseTC)    { fUseRunDepTempCalibRun2    = doUseTC; }
+
 private:
 
   AliVEvent* GetEvent();
@@ -290,12 +292,13 @@ private:
   // Change to false if experts
   Bool_t                 fUseAutomaticRecalib;       // On by default the check in the OADB of the energy recalibration
   Bool_t                 fUseAutomaticRunDepRecalib; // On by default the check in the OADB of the run dependent energy recalibration
+  Bool_t                 fUseRunDepTempCalibRun2;    // Off by default the check in the OADB of the run dependent temperature calib Run2
   Bool_t                 fUseAutomaticTimeCalib;     // On by default the check in the OADB of the time recalibration
   Bool_t                 fUseAutomaticRecParam;      // On the auto setting of the rec param
   
   AliEMCALTenderSupply(            const AliEMCALTenderSupply&c);
   AliEMCALTenderSupply& operator= (const AliEMCALTenderSupply&c);
   
-  ClassDef(AliEMCALTenderSupply, 20); // EMCAL tender task
+  ClassDef(AliEMCALTenderSupply, 21); // EMCAL tender task
 };
 #endif


### PR DESCRIPTION
The interface for the new temperature calibrations for Run2 is now available!

As soon as the calibration files are available on EOS (EMCALTemperatureCalibSM.root and EMCALTemperatureCalibParam.root) one can activate the temperature calibration in one of two ways:
1. Using the Tender: Set the last argument of AddTaskEMCALTender.C to kTRUE
2. Using the correction framework: Set doTempCalibRun2: true in the CellEnergy category.

The standard settig in both, tender and CF, is that no temperature correction is applied for Run2. Therefore nothing changes for run2 analyzers at the moment (except if they themselves activate it).

In both calibration tools, the implementation first checks the runnumber to be greater than 197692 to be certain that Run2 data is being handled. Then for Run2, two OADB containers are being loaded. One with the temperature per supermodule and one with slope and offset of the temperature dependent correction. It was made sure that in the CF, the std::unique_ptr is used to avoid memory leaks. 

In case of questions, ask me for the implementation of the OADB changes or @FriederikeBock and @loizides for the temperature calibration procedure which is documented in [EMCAL-191].