### PR TITLE
unify mixed v0 cuts with cuts on v0s in esd production

### DIFF
--- a/PWGCF/EBYE/NetLambda/AliAnalysisTaskNetLambdaIdent.cxx
+++ b/PWGCF/EBYE/NetLambda/AliAnalysisTaskNetLambdaIdent.cxx
@@ -55,72 +55,86 @@ ClassImp(AliAnalysisTaskNetLambdaIdent)
 //-----------------------------------------------------------------------------
 AliAnalysisTaskNetLambdaIdent::AliAnalysisTaskNetLambdaIdent(const char* name) :
 AliAnalysisTaskSE(name),
-    fESD(0x0),
-    fAOD(0x0),
-    fPIDResponse(0x0),
-    fEventCuts(0),
-    fListOfHistos(0x0),
-    fTree(0x0),
-    hEventStatistics(0x0),
-    fPoolMgr(0x0),
-    hGenPt(0x0),
-    hGenPhi(0x0),
-    hGenEta(0x0),
-    hTrackPt(0x0),
-    hTrackPhi(0x0),
-    hTrackEta(0x0),
-    hNSigmaProton(0x0),
-    hArmPod(0x0),
-    hVxVy(0x0),
-    hLambdaPtGen(0x0),
-    hAntiLambdaPtGen(0x0),
-    hLambdaPtReco(0x0),
-    hAntiLambdaPtReco(0x0),
-    hInvMassLambda(0x0),
-    hInvMassAntiLambda(0x0),
-    hInvMassLambdaOnTheFly(0x0),
-    hInvMassAntiLambdaOnTheFly(0x0),
-    hInvMassLambdaReco(0x0),
-    hInvMassAntiLambdaReco(0x0),
-    hInvMassLambdaSecFromMaterial(0x0),
-    hInvMassAntiLambdaSecFromMaterial(0x0),
-    hInvMassLambdaSecFromWeakDecay(0x0),
-    hInvMassAntiLambdaSecFromWeakDecay(0x0),
-    hInvMassLike(0x0),
+  fESD(0x0),
+  fAOD(0x0),
+  fPIDResponse(0x0),
+  fEventCuts(0),
+  fListOfHistos(0x0),
+  fTree(0x0),
+  hEventStatistics(0x0),
+  fPoolMgr(0x0),
+  hGenPt(0x0),
+  hGenPhi(0x0),
+  hGenEta(0x0),
+  hTrackPt(0x0),
+  hTrackPhi(0x0),
+  hTrackEta(0x0),
+  hNTracksEsd(0x0),
+  hNSigmaProton(0x0),
+  hArmPod(0x0),
+  hVxVy(0x0),
+  hLambdaPtGen(0x0),
+  hAntiLambdaPtGen(0x0),
+  hLambdaPtReco(0x0),
+  hAntiLambdaPtReco(0x0),
+  hInvMassLambda(0x0),
+  hInvMassAntiLambda(0x0),
+  hInvMassLambdaOnTheFly(0x0),
+  hInvMassAntiLambdaOnTheFly(0x0),
+  hInvMassLambdaReco(0x0),
+  hInvMassAntiLambdaReco(0x0),
+  hInvMassLambdaSecFromMaterial(0x0),
+  hInvMassAntiLambdaSecFromMaterial(0x0),
+  hInvMassLambdaSecFromWeakDecay(0x0),
+  hInvMassAntiLambdaSecFromWeakDecay(0x0),
+  hInvMassLambdaXiMismatch(0x0),
+  hInvMassAntiLambdaXiMismatch(0x0),
+  hInvMassLike(0x0),
+  hInvMassLambdaK0S(0x0),
+  hInvMassAntiLambdaK0S(0x0),
+  hInvMassLambdaConversions(0x0),
+  hInvMassAntiLambdaConversions(0x0),
 //hInvMassPtPidLambda(0x0),
 //hInvMassPtPidAntiLambda(0x0),
-    hXiPlus(0x0),
-    hXiMinus(0x0),
-    hXiZero(0x0),
-    hXiZeroAnti(0x0),
-    hPtResLambda(0x0),
-    hPtResAntiLambda(0x0),
-    hPtResLambdaPrim(0x0),
-    hPtResAntiLambdaPrim(0x0),
-    centcut(80.),
-    ptminlambda(0.5),
-    etacutlambda(0.8),
-    cospacut(0.95),
-    minradius(5.),
-    ncrossedrowscut(70),
-    crossedrowsclustercut(0.8),
-    fCentV0M(-1),
-    fCentCL1(-1),
-    fMultV0M(-1),
-    fNtracksTPCout(-1),
-    fVtxZ(-20),
-    fRunNumber(-1),
-    fAcceptV0(0x0),
-    fGenLambda(0x0),
-    fGenCascade(0x0),
-    fMixV0(0x0),
-    fIsMC(kFALSE),
-    fIsAOD(kTRUE),
-    fEvSel(AliVEvent::kINT7),
-    fLambdaTree(kTRUE),
-    fEventMixingTree(kFALSE),
-    nmaxmixtracks(1000),
-    nmaxmixevents(5)
+  hCorrPidPid(0x0),
+  hCorrMpidMpid(0x0),
+  hCorrGpidGpid(0x0),
+  hCorrPidMpid(0x0),
+  hCorrPidGpid(0x0),
+  hCorrMpidGpid(0x0),
+  hXiPlus(0x0),
+  hXiMinus(0x0),
+  hXiZero(0x0),
+  hXiZeroAnti(0x0),
+  hPtResLambda(0x0),
+  hPtResAntiLambda(0x0),
+  hPtResLambdaPrim(0x0),
+  hPtResAntiLambdaPrim(0x0),
+  centcut(80.),
+  ptminlambda(0.5),
+  etacutlambda(0.8),
+  cospacut(0.95),
+  minradius(5.),
+  ncrossedrowscut(70),
+  crossedrowsclustercut(0.8),
+  fCentV0M(-1),
+  fCentCL1(-1),
+  fMultV0M(-1),
+  fNtracksTPCout(-1),
+  fVtxZ(-20),
+  fRunNumber(-1),
+  fAcceptV0(0x0),
+  fGenLambda(0x0),
+  fGenCascade(0x0),
+  fMixV0(0x0),
+  fIsMC(kFALSE),
+  fIsAOD(kTRUE),
+  fEvSel(AliVEvent::kINT7),
+  fLambdaTree(kTRUE),
+  fEventMixingTree(kFALSE),
+  nmaxmixtracks(1000),
+  nmaxmixevents(5),
+  pidVals(0x0)
 {
   Info("AliAnalysisTaskNetLambdaIdent","Calling Constructor");
 
@@ -145,11 +159,16 @@ void AliAnalysisTaskNetLambdaIdent::UserCreateOutputObjects(){
   fListOfHistos->Add(hEventStatistics);
 
   Int_t ncentbinspool = 10;
-  Double_t centbinspool[11] = {0,10,20,30,40,50,60,70,80,90,100.1};
-  //Int_t nzvtxbinspool = 10;
-  //Double_t zvtxbinspool[11] = {-10,-8,-6,-4,-2,0,2,4,6,8,10};
+  //Double_t centbinspool[11] = {0,100,200,400,600,1000,2000,3000,4000,5000,100000};
+  Double_t centbinspool[11] = {0,5,10,20,30,40,50,60,70,80,90};
+  //Int_t nzvtxbinspool = 2;
+  //Double_t zvtxbinspool[3] = {-10,0,10};
   Int_t nzvtxbinspool = 20;
   Double_t zvtxbinspool[21] = {-10,-9,-8,-7,-6,-5,-4,-3,-2,-1,0,1,2,3,4,5,6,7,8,9,10};
+  //Int_t nzvtxbinspool = 100;
+  //Double_t zvtxbinspool[101];
+  //for(Int_t i = 0; i < 100; i++) zvtxbinspool[i] = -10.+0.2*i;
+  //zvtxbinspool[100] = 10.;
   fPoolMgr = new AliEventPoolManager(nmaxmixevents,nmaxmixtracks, ncentbinspool, centbinspool, nzvtxbinspool, zvtxbinspool);
   fPoolMgr->SetTargetValues(nmaxmixtracks, 0.1, 2);
   
@@ -166,6 +185,8 @@ void AliAnalysisTaskNetLambdaIdent::UserCreateOutputObjects(){
   fListOfHistos->Add(hGenPhi);
   hGenEta = new TH1F("hGenEta","generated #eta;#eta;",100,-0.8,0.8);
   fListOfHistos->Add(hGenEta);
+  hNTracksEsd = new TH1F("hNTracksEsd","number of tracks for event mixing",300,0,9000);
+  fListOfHistos->Add(hNTracksEsd);
 
   hVxVy = new TH2F("hVxVy","vx vs vy;v_{x};v_{y}",50,0.073,0.083,50,0.331,0.341);
   fListOfHistos->Add(hVxVy);
@@ -210,9 +231,56 @@ void AliAnalysisTaskNetLambdaIdent::UserCreateOutputObjects(){
   fListOfHistos->Add(hInvMassLambdaSecFromWeakDecay);
   hInvMassAntiLambdaSecFromWeakDecay = new TH2F("hInvMassAntiLambdaSecFromWeakDecay","#bar{#Lambda} from weak decays",100,1.05,1.25,100,0,10);
   fListOfHistos->Add(hInvMassAntiLambdaSecFromWeakDecay);
-
+  
+  hInvMassLambdaXiMismatch = new TH2F("hInvMassLambdaXiMismatch","#Lambda from Xi decay mismatch",100,1.05,1.25,100,0,10);
+  fListOfHistos->Add(hInvMassLambdaXiMismatch);
+  hInvMassAntiLambdaXiMismatch = new TH2F("hInvMassAntiLambdaXiMismatch","#bar{#Lambda} from Xi decay mismatch",100,1.05,1.25,100,0,10);
+  fListOfHistos->Add(hInvMassAntiLambdaXiMismatch);
+  
+  hInvMassLambdaK0S = new TH2F("hInvMassLambdaK0S","#Lambda vs K0S invariant mass",100,1.08,1.18,100,0.45,0.55);
+  fListOfHistos->Add(hInvMassLambdaK0S);
+  hInvMassAntiLambdaK0S = new TH2F("hInvMassAntiLambdaK0S","#bar{#Lambda} vs K0S invariant mass",100,1.08,1.18,100,0.45,0.55);
+  fListOfHistos->Add(hInvMassAntiLambdaK0S);
+  
+  hInvMassLambdaConversions = new TH2F("hInvMassLambdaConversions","#Lambda vs e+e- invariant mass",100,1.08,1.18,100,0.,0.1);
+  fListOfHistos->Add(hInvMassLambdaConversions);
+  hInvMassAntiLambdaConversions = new TH2F("hInvMassAntiLambdaConversions","#bar{#Lambda} vs e+e- invariant mass",100,1.08,1.18,100,0.,0.1);
+  fListOfHistos->Add(hInvMassAntiLambdaConversions);
+  
   hInvMassLike = new TH2F("hInvMassLike","like-sign pair invariant mass",100,1.05,1.25,100,0,10);
   fListOfHistos->Add(hInvMassLike);
+
+  hCorrPidPid = new TH2F("hCorrPidPid","V0 PID values",25,0.5,25.5,25,0.5,25.5);
+  fListOfHistos->Add(hCorrPidPid);
+  hCorrMpidMpid = new TH2F("hCorrMpidMpid","V0 mother PID values",25,0.5,25.5,25,0.5,25.5);
+  fListOfHistos->Add(hCorrMpidMpid);
+  hCorrGpidGpid = new TH2F("hCorrGpidGpid","V0 grandmother PID values",25,0.5,25.5,25,0.5,25.5);
+  fListOfHistos->Add(hCorrGpidGpid);
+  hCorrPidMpid = new TH2F("hCorrPidMpid","daughter PID vs mother PID",25,0.5,25.5,25,0.5,25.5);
+  fListOfHistos->Add(hCorrPidMpid);
+  hCorrPidGpid = new TH2F("hCorrPidGpid","daughter PID vs grandmother PID",25,0.5,25.5,25,0.5,25.5);
+  fListOfHistos->Add(hCorrPidGpid);
+  hCorrMpidGpid = new TH2F("hCorrMpidGpid","mother PID vs grandmother PID",25,0.5,25.5,25,0.5,25.5);
+  fListOfHistos->Add(hCorrMpidGpid);
+  pidVals = new Int_t[24];
+  Int_t pidValsTemp[24] = { 22,     11,  -11, 13,   -13,  -211, 211,  111,  -111,      -321, 321, 311, -311,     310,  130,  2212, -2212,   3122,    -3122,        3312, -3312, 3322, -3322, 113};
+  TString pidLabels[24]   = {"gamma","e-","e+","mu-","mu+","pi-","pi+","pi0","anti pi0","K-", "K+","K0","anti K0","K0S","K0L","p",  "anti p","lambda","anti lambda","Xi-","Xi+", "Xi0","anti Xi0","rho0"};
+  for(Int_t i = 0; i < 24; i++)
+    {
+      pidVals[i] = pidValsTemp[i];
+      hCorrPidPid->GetXaxis()->SetBinLabel(i+1,pidLabels[i]);
+      hCorrPidPid->GetYaxis()->SetBinLabel(i+1,pidLabels[i]);
+      hCorrMpidMpid->GetXaxis()->SetBinLabel(i+1,pidLabels[i]);
+      hCorrMpidMpid->GetYaxis()->SetBinLabel(i+1,pidLabels[i]);
+      hCorrGpidGpid->GetXaxis()->SetBinLabel(i+1,pidLabels[i]);
+      hCorrGpidGpid->GetYaxis()->SetBinLabel(i+1,pidLabels[i]);
+      hCorrPidMpid->GetXaxis()->SetBinLabel(i+1,pidLabels[i]);
+      hCorrPidMpid->GetYaxis()->SetBinLabel(i+1,pidLabels[i]);
+      hCorrPidGpid->GetXaxis()->SetBinLabel(i+1,pidLabels[i]);
+      hCorrPidGpid->GetYaxis()->SetBinLabel(i+1,pidLabels[i]);
+      hCorrMpidGpid->GetXaxis()->SetBinLabel(i+1,pidLabels[i]);
+      hCorrMpidGpid->GetYaxis()->SetBinLabel(i+1,pidLabels[i]);
+    }
 
   //hInvMassPtPidLambda = new TH3F("hInvMassPtPidLambda","inv mass of lambda candidates",100,1.08,1.15,17,0.6,4,14,-0.5,13.5);
   //fListOfHistos->Add(hInvMassPtPidLambda);
@@ -238,16 +306,19 @@ void AliAnalysisTaskNetLambdaIdent::UserCreateOutputObjects(){
   fListOfHistos->Add(hPtResAntiLambdaPrim);
   
   fEventCuts.AddQAplotsToList(fListOfHistos,true);  
-  
-  fAcceptV0 = new TClonesArray("AliLightV0",1000);
-  if(fIsMC)
+
+  if(fLambdaTree)
     {
-      fGenLambda = new TClonesArray("AliLightGenV0",1000);
-      fGenCascade = new TClonesArray("AliLightGenV0",1000);
-    }
-  if(fEventMixingTree)
-    {
-      fMixV0 = new TClonesArray("AliLightV0",1000);
+      fAcceptV0 = new TClonesArray("AliLightV0",1000);
+      if(fIsMC)
+	{
+	  fGenLambda = new TClonesArray("AliLightGenV0",1000);
+	  fGenCascade = new TClonesArray("AliLightGenV0",1000);
+	}
+      if(fEventMixingTree)
+	{
+	  fMixV0 = new TClonesArray("AliLightV0",1000);
+	}
     }
   
   // create file-resident tree
@@ -261,15 +332,18 @@ void AliAnalysisTaskNetLambdaIdent::UserCreateOutputObjects(){
   fTree->Branch("fNtracksTPCout",&fNtracksTPCout);
   fTree->Branch("fVtxZ",&fVtxZ);
   fTree->Branch("fRunNumber",&fRunNumber);
-  fTree->Branch("fAcceptV0",&fAcceptV0);
-  if(fIsMC)
+  if(fLambdaTree)
     {
-      fTree->Branch("fGenLambda",&fGenLambda);
-      fTree->Branch("fGenCascade",&fGenCascade);
-    }
-  if(fEventMixingTree)
-    {
-      fTree->Branch("fMixV0",&fMixV0);
+      fTree->Branch("fAcceptV0",&fAcceptV0);
+      if(fIsMC)
+	{
+	  fTree->Branch("fGenLambda",&fGenLambda);
+	  fTree->Branch("fGenCascade",&fGenCascade);
+	}
+      if(fEventMixingTree)
+	{
+	  fTree->Branch("fMixV0",&fMixV0);
+	}
     }
   
   //fUtils = new AliAnalysisUtils();
@@ -340,26 +414,26 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
   Double_t fVtx[3];
   /*if(fIsAOD) // aod
     {
-      AliAODVertex *aodVertex = (AliAODVertex*)fInputEvent->GetPrimaryVertex();
-      if (!aodVertex) return;
-      fVtx[0] = aodVertex->GetX();
-      fVtx[1] = aodVertex->GetY();
-      fVtx[2] = aodVertex->GetZ();
+    AliAODVertex *aodVertex = (AliAODVertex*)fInputEvent->GetPrimaryVertex();
+    if (!aodVertex) return;
+    fVtx[0] = aodVertex->GetX();
+    fVtx[1] = aodVertex->GetY();
+    fVtx[2] = aodVertex->GetZ();
     }
-  else // esd
+    else // esd
     {
-      AliESDVertex *esdVertex = (AliESDVertex*)fInputEvent->GetPrimaryVertex();
-      if (!esdVertex) return;
-      fVtx[0] = esdVertex->GetX();
-      fVtx[1] = esdVertex->GetY();
-      fVtx[2] = esdVertex->GetZ();
-      }*/
+    AliESDVertex *esdVertex = (AliESDVertex*)fInputEvent->GetPrimaryVertex();
+    if (!esdVertex) return;
+    fVtx[0] = esdVertex->GetX();
+    fVtx[1] = esdVertex->GetY();
+    fVtx[2] = esdVertex->GetZ();
+    }*/
   AliVVertex *vvertex = (AliVVertex*)fInputEvent->GetPrimaryVertex();
-      if (!vvertex) return;
-      fVtx[0] = vvertex->GetX();
-      fVtx[1] = vvertex->GetY();
-      fVtx[2] = vvertex->GetZ();
-      hEventStatistics->Fill("found primary vertex",1);
+  if (!vvertex) return;
+  fVtx[0] = vvertex->GetX();
+  fVtx[1] = vvertex->GetY();
+  fVtx[2] = vvertex->GetZ();
+  hEventStatistics->Fill("found primary vertex",1);
 
   if(fVtx[2] < -10. || fVtx[2] > 10.) return;
   hEventStatistics->Fill("vz cut",1);
@@ -373,23 +447,23 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
   hEventStatistics->Fill("centrality selection",1);
 
   /*Printf("require track vertex = %i",fEventCuts.fRequireTrackVertex);
-  Printf("min z-vertex = %lf",fEventCuts.fMinVtz);
-  Printf("max z-vertex = %lf",fEventCuts.fMaxVtz);
-  Printf("spd to track vertex = %lf",fEventCuts.fMaxDeltaSpdTrackAbsolute);
-  Printf("resolution spd vertex = %lf",fEventCuts.fMaxResolutionSPDvertex);
-  Printf("trigger mask = %lf",fEventCuts.fTriggerMask);
-  Printf("reject incomplete daq = %i",fEventCuts.fRejectDAQincomplete);
-  Printf("min spd pileup contribs = %lf",fEventCuts.fSPDpileupMinContributors);
-  Printf("spd pileup min z distance = %lf",fEventCuts.fSPDpileupMinZdist);
-  Printf("spd pileup nsigma z distance = %lf",fEventCuts.fSPDpileupNsigmaZdist);
-  Printf("spd pileup nsigma diam xy = %lf",fEventCuts.fSPDpileupNsigmaDiamXY);
-  Printf("spd pileup nsigma diam z = %lf",fEventCuts.fSPDpileupNsigmaDiamZ);
-  Printf("tracklet background cut = %i",fEventCuts.fTrackletBGcut);*/
+    Printf("min z-vertex = %lf",fEventCuts.fMinVtz);
+    Printf("max z-vertex = %lf",fEventCuts.fMaxVtz);
+    Printf("spd to track vertex = %lf",fEventCuts.fMaxDeltaSpdTrackAbsolute);
+    Printf("resolution spd vertex = %lf",fEventCuts.fMaxResolutionSPDvertex);
+    Printf("trigger mask = %lf",fEventCuts.fTriggerMask);
+    Printf("reject incomplete daq = %i",fEventCuts.fRejectDAQincomplete);
+    Printf("min spd pileup contribs = %lf",fEventCuts.fSPDpileupMinContributors);
+    Printf("spd pileup min z distance = %lf",fEventCuts.fSPDpileupMinZdist);
+    Printf("spd pileup nsigma z distance = %lf",fEventCuts.fSPDpileupNsigmaZdist);
+    Printf("spd pileup nsigma diam xy = %lf",fEventCuts.fSPDpileupNsigmaDiamXY);
+    Printf("spd pileup nsigma diam z = %lf",fEventCuts.fSPDpileupNsigmaDiamZ);
+    Printf("tracklet background cut = %i",fEventCuts.fTrackletBGcut);*/
   
   if (!fEventCuts.AcceptEvent(fInputEvent)) return;
   hEventStatistics->Fill("AliEventCuts",1);
 
-  TObjArray* mixtracks = 0x0, *mixprotons;
+  TObjArray* mixtracks = 0x0, *mixprotons = 0x0;
   if(fEventMixingTree)
     {
       mixtracks = new TObjArray();
@@ -397,6 +471,8 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
       //mixprotons = new TObjArray();
       //mixprotons->SetOwner(kTRUE);
     }
+
+  Double_t b = fInputEvent->GetMagneticField();
   
   // loop over reconstructed tracks
   Int_t nTracks = 0;
@@ -404,6 +480,7 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
   else nTracks = fESD->GetNumberOfTracks(); // esd
 
   fNtracksTPCout = 0;
+  Int_t nTracksEsd = 0;
   for(Int_t iTrack = 0; iTrack < nTracks; iTrack++)
     {
       Float_t pt = -999, eta = -999, phi = -999;
@@ -411,8 +488,9 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 	{
 	  AliAODTrack* track = (AliAODTrack*)fAOD->GetTrack(iTrack);
 	  if(!track) continue;
-	  if(TMath::Abs(track->Eta()) > 0.8) continue;
 	  if(track->Pt() > 0.15 && (track->GetStatus() & AliESDtrack::kTPCout) && track->GetID() > 0) fNtracksTPCout += 1.;
+	  if(!TrackCutsForTreeAOD(track)) continue;
+	  if(TMath::Abs(track->Eta()) > 0.8) continue;
 	  if(!(track->TestFilterBit(96))) continue; //filter bits 5+6
 	  pt = track->Pt();
 	  eta = track->Eta();
@@ -422,23 +500,28 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 	{
 	  AliESDtrack* track = (AliESDtrack*)fESD->GetTrack(iTrack);
 	  if(!track) continue;
-	  if(TMath::Abs(track->Eta()) > 0.8) continue;
 	  if(track->Pt() > 0.15 && (track->GetStatus() & AliESDtrack::kTPCout)) fNtracksTPCout += 1.;
+	  if(!TrackCutsForTreeESD(track)) continue;
 	  pt = track->Pt();
 	  eta = track->Eta();
 	  phi = track->Phi();
 
-	  if(fEventMixingTree)
+	  if((track->GetStatus()&AliESDtrack::kTPCrefit) != 0)
 	    {
-	      if(TrackCutsForTreeESD(track) && (track->GetStatus() & AliESDtrack::kTPCrefit))
+	      nTracksEsd++;
+	      if(fEventMixingTree)
 		{
-		  AliLightV0track* lighttrack = new AliLightV0track(*track,fPIDResponse->NumberOfSigmasTPC(track, AliPID::kProton));
-		  mixtracks->Add(lighttrack);
-		  //if(TMath::Abs(fPIDResponse->NumberOfSigmasTPC(track, AliPID::kProton)) < 5.)
-		  //{
-		  //AliLightV0track* lightproton = new AliLightV0track(*track,fPIDResponse->NumberOfSigmasTPC(track, AliPID::kProton));
-		  //mixprotons->Add(lightproton);
-		  //}
+		  Double_t dn = TMath::Abs(track->GetD(fVtx[0],fVtx[1],b));
+		  if(dn > 0.1 && dn < 100)
+		    {
+		      AliLightV0track* lighttrack = new AliLightV0track(*track,fPIDResponse->NumberOfSigmasTPC(track, AliPID::kProton),fVtx);
+		      mixtracks->Add(lighttrack);
+		      //if(TMath::Abs(fPIDResponse->NumberOfSigmasTPC(track, AliPID::kProton)) < 5.)
+		      //{
+		      //AliLightV0track* lightproton = new AliLightV0track(*track,fPIDResponse->NumberOfSigmasTPC(track, AliPID::kProton),fVtx);
+		      //mixprotons->Add(lightproton);
+		      //}
+		    }
 		}
 	    }
 	}
@@ -446,15 +529,19 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
       hTrackPhi->Fill(phi);
       hTrackEta->Fill(eta);
     } // end loop over reconstructed tracks
+  hNTracksEsd->Fill(nTracksEsd);
 
   fRunNumber = fInputEvent->GetRunNumber();
 
   Int_t nGen = 0;
   
   if(fIsMC)
-    { 
-      fGenLambda->Clear();
-      fGenCascade->Clear();
+    {
+      if(fLambdaTree)
+	{
+	  fGenLambda->Clear();
+	  fGenCascade->Clear();
+	}
       
       // loop over generated particles to find lambdas
       if(fIsAOD) nGen = fMCEvent->GetNumberOfTracks(); // aod
@@ -505,27 +592,27 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 	  if(abseta > etacutlambda) continue;
 	  
 	  // cascades for feeddown correction
-	      AliLightGenV0* tempGenCascade = 0x0;
-	      if(pid == -3312) // xi+
-		{
-		  hXiPlus->Fill(pt,eta,fCentV0M);
-		  tempGenCascade = new((*fGenCascade)[fGenCascade->GetEntriesFast()]) AliLightGenV0(pt,eta,1);
-		}
-	      else if(pid == 3312) // xi-
-		{
-		  hXiMinus->Fill(pt,eta,fCentV0M);
-		  tempGenCascade = new((*fGenCascade)[fGenCascade->GetEntriesFast()]) AliLightGenV0(pt,eta,-1);
-		}
-	      else if(pid == 3322) // xi0
-		{
-		  hXiZero->Fill(pt,eta,fCentV0M);
-		  tempGenCascade = new((*fGenCascade)[fGenCascade->GetEntriesFast()]) AliLightGenV0(pt,eta,-2);
-		}
-	      else if(pid == -3322) // anti-xi0
-		{
-		  hXiZeroAnti->Fill(pt,eta,fCentV0M);
-		  tempGenCascade = new((*fGenCascade)[fGenCascade->GetEntriesFast()]) AliLightGenV0(pt,eta,2);
-		}
+	  AliLightGenV0* tempGenCascade = 0x0;
+	  if(pid == -3312) // xi+
+	    {
+	      hXiPlus->Fill(pt,eta,fCentV0M);
+	      if(fLambdaTree) tempGenCascade = new((*fGenCascade)[fGenCascade->GetEntriesFast()]) AliLightGenV0(pt,eta,1);
+	    }
+	  else if(pid == 3312) // xi-
+	    {
+	      hXiMinus->Fill(pt,eta,fCentV0M);
+	      if(fLambdaTree) tempGenCascade = new((*fGenCascade)[fGenCascade->GetEntriesFast()]) AliLightGenV0(pt,eta,-1);
+	    }
+	  else if(pid == 3322) // xi0
+	    {
+	      hXiZero->Fill(pt,eta,fCentV0M);
+	      if(fLambdaTree) tempGenCascade = new((*fGenCascade)[fGenCascade->GetEntriesFast()]) AliLightGenV0(pt,eta,-2);
+	    }
+	  else if(pid == -3322) // anti-xi0
+	    {
+	      hXiZeroAnti->Fill(pt,eta,fCentV0M);
+	      if(fLambdaTree) tempGenCascade = new((*fGenCascade)[fGenCascade->GetEntriesFast()]) AliLightGenV0(pt,eta,2);
+	    }
 
 	  
 	  //if(abspid != 3122) continue;
@@ -537,7 +624,7 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 	      hLambdaPtGen->Fill(pt);
 	      if(pt >= ptminlambda)
 		{
-		  tempGenLambda = new((*fGenLambda)[fGenLambda->GetEntriesFast()]) AliLightGenV0(pt,eta,1);
+		  if(fLambdaTree) tempGenLambda = new((*fGenLambda)[fGenLambda->GetEntriesFast()]) AliLightGenV0(pt,eta,1);
 		}
 	    }
 	  else if(pid == -3122)
@@ -545,7 +632,7 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 	      hAntiLambdaPtGen->Fill(pt);
 	      if(pt >= ptminlambda)
 		{
-		  tempGenLambda = new((*fGenLambda)[fGenLambda->GetEntriesFast()]) AliLightGenV0(pt,eta,-1);
+		  if(fLambdaTree) tempGenLambda = new((*fGenLambda)[fGenLambda->GetEntriesFast()]) AliLightGenV0(pt,eta,-1);
 		}
 	    }
 
@@ -641,18 +728,18 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
     }
 
   /*AliESDv0Cuts* v0cuts = new AliESDv0Cuts();
-  v0cuts->SetMinDcaPosToVertex(0.05);
-  v0cuts->SetMinDcaNegToVertex(0.05);
-  v0cuts->SetMaxChi2(33.);
-  v0cuts->SetMaxDcaV0Daughters(1.5);
-  v0cuts->SetMinRadius(0.2);
-  v0cuts->SetMaxRadius(200.);
-  v0cuts->SetMinCosinePointingAngle(0.99);
-  v0cuts->SetMaxDcaV0ToVertex(5*7.89);
-  Int_t nV0 = v0cuts->CountAcceptedV0s(fESD);
-  TObjArray* v0array = v0cuts->GetAcceptedV0s(fESD);*/
-  
-  fAcceptV0->Clear();
+    v0cuts->SetMinDcaPosToVertex(0.05);
+    v0cuts->SetMinDcaNegToVertex(0.05);
+    v0cuts->SetMaxChi2(33.);
+    v0cuts->SetMaxDcaV0Daughters(1.5);
+    v0cuts->SetMinRadius(0.2);
+    v0cuts->SetMaxRadius(200.);
+    v0cuts->SetMinCosinePointingAngle(0.99);
+    v0cuts->SetMaxDcaV0ToVertex(5*7.89);
+    Int_t nV0 = v0cuts->CountAcceptedV0s(fESD);
+    TObjArray* v0array = v0cuts->GetAcceptedV0s(fESD);*/
+
+  if(fLambdaTree) fAcceptV0->Clear();
 
   Int_t nV0 = 0;
   //TObjArray *v0array = 0x0;
@@ -665,7 +752,9 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
   AliAODv0 *aodv0 = 0x0;
   AliAODTrack *aodTrackPos = 0x0;
   AliAODTrack *aodTrackNeg = 0x0;
-   
+
+  //Printf("same event");
+  
   for(Int_t iV0 = 0; iV0 < nV0; iV0++)
     {
       esdv0 = 0x0;
@@ -677,12 +766,11 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 
       Double_t  secvtx[3];
 
-      Float_t invMassLambda = -999, invMassAntiLambda = -999;
+      Float_t invMassLambda = -999, invMassAntiLambda = -999, invMassK0S = -999, invMassEplusEminus = -999;
       Float_t alpha = -999, ptarm = -999;
       Float_t pt = -999, phi = -999, eta = -999, pmom = -999;
       Float_t ppt = -999, pphi = -999, peta = -999, pnsigmapr = -999;
       Float_t npt = -999, nphi = -999, neta = -999, nnsigmapr = -999;
-      Bool_t swapflag = kFALSE, ontheflystat = kFALSE;
       Float_t /*dcaV0ToVertex = -999,*/ dcaPosToVertex = -999, dcaNegToVertex = -999, dcaDaughters = -999, cosPointingAngle = -999;
       
       if(fIsAOD) // aod
@@ -691,6 +779,12 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 	  if(!aodv0) continue;
 	  AliAODVertex* v0vtx = (AliAODVertex*)aodv0->GetSecondaryVtx();
 	  if(!v0vtx) continue;
+	  if(aodv0->GetOnFlyStatus() == kTRUE)
+	    {
+	      hInvMassLambdaOnTheFly->Fill(aodv0->MassLambda(),aodv0->Pt());
+	      hInvMassAntiLambdaOnTheFly->Fill(aodv0->MassAntiLambda(),aodv0->Pt());
+	      continue;
+	    }
 	  v0vtx->GetPosition(secvtx);
 	  aodTrackPos = (AliAODTrack*)v0vtx->GetDaughter(0);
 	  if(!aodTrackPos) continue;
@@ -703,6 +797,8 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 
 	  invMassLambda = aodv0->MassLambda();
 	  invMassAntiLambda = aodv0->MassAntiLambda();
+	  invMassK0S = aodv0->MassK0Short();
+	  invMassEplusEminus = aodv0->InvMass2Prongs(0,1,11,11);
 	  alpha = aodv0->AlphaV0();
 	  ptarm = aodv0->PtArmV0();
 
@@ -720,7 +816,6 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 	      invMassAntiLambda = aodv0->MassLambda();
 	      ptarm = aodv0->QtProng(1);
 	      alpha = -1.*alpha;
-	      swapflag = kTRUE;
 	    }
 	  
 	  pt = aodv0->Pt();
@@ -733,7 +828,6 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 	  npt = aodTrackNeg->Pt();
 	  neta = aodTrackNeg->Eta();
 	  nphi = aodTrackNeg->Phi();
-	  ontheflystat = aodv0->GetOnFlyStatus();
 	  pnsigmapr = fPIDResponse->NumberOfSigmasTPC(aodTrackPos, AliPID::kProton);
 	  nnsigmapr = fPIDResponse->NumberOfSigmasTPC(aodTrackNeg, AliPID::kProton);
 
@@ -748,6 +842,12 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 	  esdv0 = fESD->GetV0(iV0);
 	  //esdv0 = (AliESDv0*)v0array->At(iV0);
 	  if(!esdv0) continue;
+	  if(esdv0->GetOnFlyStatus() == kTRUE)
+	    {
+	      hInvMassLambdaOnTheFly->Fill(esdv0->GetEffMass(4,2),esdv0->Pt());
+	      hInvMassAntiLambdaOnTheFly->Fill(esdv0->GetEffMass(2,4),esdv0->Pt());
+	      continue;
+	    }
 	  esdv0->GetXYZ(secvtx[0], secvtx[1], secvtx[2]);
 	  esdTrackPos =  (AliESDtrack*)fESD->GetTrack(TMath::Abs(esdv0->GetPindex()));
 	  if(!esdTrackPos) continue;
@@ -756,11 +856,12 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 	  if(!esdTrackNeg) continue;
 	  if(!TrackCutsForTreeESD(esdTrackNeg)) continue;
 
-	  if(!V0CutsForTreeESD(esdv0,fVtx,esdTrackPos,esdTrackNeg,fInputEvent->GetMagneticField())) continue;
+	  if(!V0CutsForTreeESD(esdv0,fVtx,esdTrackPos,esdTrackNeg,b)) continue;
 
 	  invMassLambda = esdv0->GetEffMass(4,2);
 	  invMassAntiLambda = esdv0->GetEffMass(2,4);
-	  //invMassK0S = esdv0->GetEffMass(2,2);
+	  invMassK0S = esdv0->GetEffMass(2,2);
+	  invMassEplusEminus = esdv0->GetEffMass(0,0);
 	  alpha = esdv0->AlphaV0();
 	  ptarm = esdv0->PtArmV0();
 	  
@@ -777,9 +878,18 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 	      
 	      invMassLambda = esdv0->GetEffMass(2,4);
 	      invMassAntiLambda = esdv0->GetEffMass(4,2);
-	      ptarm = 0;//esdv0->QtProng(1); // fix later
+
+	      Double_t tot = esdv0->Px()*esdv0->Px()+esdv0->Py()*esdv0->Py()+esdv0->Pz()*esdv0->Pz();
+	      Double_t ss = esdv0->Px()*esdTrackNeg->Px()+esdv0->Py()*esdTrackNeg->Py()+esdv0->Pz()*esdTrackNeg->Pz();
+	      Double_t per = esdTrackNeg->Px()*esdTrackNeg->Px()+esdTrackNeg->Py()*esdTrackNeg->Py()+esdTrackNeg->Pz()*esdTrackNeg->Pz();
+	      if(tot > 0.) per -= ss*ss/tot;
+	      if(per < 0.) per = 0;
+	      //TVector3 momNeg(esdTrackNeg->Px(),esdTrackNeg->Py(),esdTrackNeg->Pz());
+	      //TVector3 momTot(esdv0->Px(),esdv0->Py(),esdv0->Pz());
+	      //ptarm = momNeg.Perp(momTot);
+	      ptarm = TMath::Sqrt(per);
+	      //Printf("%.3lf   %.3lf",ptarm,momNeg.Perp(momTot));
 	      alpha = -1.*alpha;
-	      swapflag = kTRUE;
 	    }
 
 	  pt = esdv0->Pt();
@@ -792,7 +902,6 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 	  npt = esdTrackNeg->Pt();
 	  neta = esdTrackNeg->Eta();
 	  nphi = esdTrackNeg->Phi();
-	  ontheflystat = esdv0->GetOnFlyStatus();
 	  pnsigmapr = fPIDResponse->NumberOfSigmasTPC(esdTrackPos, AliPID::kProton);
 	  nnsigmapr = fPIDResponse->NumberOfSigmasTPC(esdTrackNeg, AliPID::kProton);
 
@@ -807,54 +916,58 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
       	}
 
       if(TMath::Abs(eta) > etacutlambda) continue;
-     
-      if(ontheflystat == kTRUE)
-	{
-	  hInvMassLambdaOnTheFly->Fill(invMassLambda,pt);
-	  hInvMassAntiLambdaOnTheFly->Fill(invMassAntiLambda,pt);
-	  continue;
-	}
       
       hInvMassLambda->Fill(invMassLambda,pt);
       hInvMassAntiLambda->Fill(invMassAntiLambda,pt);
+      hInvMassLambdaK0S->Fill(invMassLambda,invMassK0S);
+      hInvMassAntiLambdaK0S->Fill(invMassAntiLambda,invMassK0S);
+      hInvMassLambdaConversions->Fill(invMassLambda,invMassEplusEminus);
+      hInvMassAntiLambdaConversions->Fill(invMassAntiLambda,invMassEplusEminus);
 
       hNSigmaProton->Fill(ppt,pnsigmapr);
       hNSigmaProton->Fill(-1.*npt,nnsigmapr);
 
       Float_t v0Radius      = TMath::Sqrt(secvtx[0]*secvtx[0]+secvtx[1]*secvtx[1]);
       Float_t v0DecayLength = TMath::Sqrt(TMath::Power(secvtx[0] - fVtx[0],2) +
-					   TMath::Power(secvtx[1] - fVtx[1],2) +
-					   TMath::Power(secvtx[2] - fVtx[2],2 ));
+					  TMath::Power(secvtx[1] - fVtx[1],2) +
+					  TMath::Power(secvtx[2] - fVtx[2],2 ));
 
-      if(!swapflag) hArmPod->Fill(alpha,ptarm);
-      
-      AliLightV0* tempLightV0 = 0x0;
-      // make tree      
-      if(invMassLambda < 1.16 && TMath::Abs(pnsigmapr) < 5.) // lambda candidate
+      hArmPod->Fill(alpha,ptarm);
+
+      AliLightV0* tempLightV0L = 0x0, *tempLightV0AL = 0x0;
+      if(fLambdaTree)
 	{
-	  tempLightV0 = new((*fAcceptV0)[fAcceptV0->GetEntriesFast()]) AliLightV0(pt,eta);
-	  tempLightV0->SetInvMass(invMassLambda);
-	  tempLightV0->SetCosPointingAngle(cosPointingAngle);
-	  tempLightV0->SetDecayR(v0Radius);
-	  tempLightV0->SetProperLifetime(pmom > 0. ? invMassLambda*v0DecayLength/pmom : 0.);
-	  //tempLightV0->SetDCAV0(dcaV0ToVertex);
-	  tempLightV0->SetDCADaughters(dcaDaughters);
-	  tempLightV0->SetMcStatus(0);
-	  tempLightV0->SetPosDaughter(ppt,peta,pnsigmapr, dcaPosToVertex);
-	  tempLightV0->SetNegDaughter(npt,neta,nnsigmapr, dcaNegToVertex);
-	}
-      if(invMassAntiLambda < 1.16 && TMath::Abs(nnsigmapr) < 5.) // anti-lambda candidate
-	{
-	  tempLightV0 = new((*fAcceptV0)[fAcceptV0->GetEntriesFast()]) AliLightV0(pt,eta);
-	  tempLightV0->SetInvMass(-1.*invMassAntiLambda);
-	  tempLightV0->SetCosPointingAngle(cosPointingAngle);
-	  tempLightV0->SetDecayR(v0Radius);
-	  tempLightV0->SetProperLifetime(pmom > 0. ? invMassAntiLambda*v0DecayLength/pmom : 0.);
-	  //tempLightV0->SetDCAV0(dcaV0ToVertex);
-	  tempLightV0->SetDCADaughters(dcaDaughters);
-	  tempLightV0->SetMcStatus(0);
-	  tempLightV0->SetPosDaughter(ppt,peta,pnsigmapr, dcaPosToVertex);
-	  tempLightV0->SetNegDaughter(npt,neta,nnsigmapr, dcaNegToVertex);
+	  // make tree      
+	  if(invMassLambda < 1.16 && TMath::Abs(pnsigmapr) < 5.) // lambda candidate
+	    {
+	      tempLightV0L = new((*fAcceptV0)[fAcceptV0->GetEntriesFast()]) AliLightV0(pt,eta);
+	      tempLightV0L->SetInvMass(invMassLambda);
+	      tempLightV0L->SetInvMassK0S(invMassK0S);
+	      tempLightV0L->SetCosPointingAngle(cosPointingAngle);
+	      tempLightV0L->SetDecayR(v0Radius);
+	      tempLightV0L->SetProperLifetime(pmom > 0. ? invMassLambda*v0DecayLength/pmom : 0.);
+	      //tempLightV0L->SetDCAV0(dcaV0ToVertex);
+	      tempLightV0L->SetDCADaughters(dcaDaughters);
+	      tempLightV0L->SetMcStatus(0);
+	      tempLightV0L->SetPosDaughter(ppt,peta,pnsigmapr, dcaPosToVertex);
+	      tempLightV0L->SetNegDaughter(npt,neta,nnsigmapr, dcaNegToVertex);
+	      //Printf("pt = %.3lf   eta = %.3lf   minv = %.3lf   cosPA = %.3lf   decayR = %.3lf   propLife = %.3lf   DCAdaughters = %.3lf   posPt = %.3lf   posDCA = %.3lf   posNSigma = %.3lf   posD = %.3lf   negPt = %.3lf   negDCA = %.3lf   negNSigma = %.3lf   negD = %.3lf",pt,eta,invMassLambda,cosPointingAngle,v0Radius,invMassLambda*v0DecayLength/pmom,dcaDaughters,ppt,dcaPosToVertex,pnsigmapr,esdTrackPos->GetD(fVtx[0],fVtx[1],b),npt,dcaNegToVertex,nnsigmapr,esdTrackNeg->GetD(fVtx[0],fVtx[1],b));
+	    }
+	  if(invMassAntiLambda < 1.16 && TMath::Abs(nnsigmapr) < 5.) // anti-lambda candidate
+	    {
+	      tempLightV0AL = new((*fAcceptV0)[fAcceptV0->GetEntriesFast()]) AliLightV0(pt,eta);
+	      tempLightV0AL->SetInvMass(-1.*invMassAntiLambda);
+	      tempLightV0AL->SetInvMassK0S(invMassK0S);
+	      tempLightV0AL->SetCosPointingAngle(cosPointingAngle);
+	      tempLightV0AL->SetDecayR(v0Radius);
+	      tempLightV0AL->SetProperLifetime(pmom > 0. ? invMassAntiLambda*v0DecayLength/pmom : 0.);
+	      //tempLightV0AL->SetDCAV0(dcaV0ToVertex);
+	      tempLightV0AL->SetDCADaughters(dcaDaughters);
+	      tempLightV0AL->SetMcStatus(0);
+	      tempLightV0AL->SetPosDaughter(ppt,peta,pnsigmapr, dcaPosToVertex);
+	      tempLightV0AL->SetNegDaughter(npt,neta,nnsigmapr, dcaNegToVertex);
+	      //Printf("pt = %.3lf   eta = %.3lf   minv = %.3lf   cosPA = %.3lf   decayR = %.3lf   propLife = %.3lf   DCAdaughters = %.3lf   posPt = %.3lf   posDCA = %.3lf   posNSigma = %.3lf   posD = %.3lf   negPt = %.3lf   negDCA = %.3lf   negNSigma = %.3lf   negD = %.3lf",pt,eta,invMassAntiLambda,cosPointingAngle,v0Radius,invMassAntiLambda*v0DecayLength/pmom,dcaDaughters,ppt,dcaPosToVertex,pnsigmapr,esdTrackPos->GetD(fVtx[0],fVtx[1],b),npt,dcaNegToVertex,nnsigmapr,esdTrackNeg->GetD(fVtx[0],fVtx[1],b));
+	    }
 	}
       
       //Armenteros-Podolanski plot
@@ -891,6 +1004,87 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 	      if(m1 < 0) continue;
 	      Int_t m2 = aodGenTrackNeg->GetMother();
 	      if(m2 < 0) continue;
+	      
+	      // look for special cases, such as xi->Lambda+pi->p+pi+pi with mismatched pions
+	      if((invMassLambda > 1.08 && invMassLambda < 1.15) || (invMassAntiLambda > 1.08 && invMassAntiLambda < 1.15))
+		{
+		  Int_t pidind1 = 0, pidind2 = 0;
+		  for(Int_t i = 0; i < 24; i++)
+		    {
+		      if(aodGenTrackPos->PdgCode() == pidVals[i]) pidind1 = i+1;
+		      if(aodGenTrackNeg->PdgCode() == pidVals[i]) pidind2 = i+1;
+		    }
+		  hCorrPidPid->Fill(pidind1,pidind2);
+
+		  AliVParticle *aodTestMother1 = fMCEvent->GetTrack(m1);
+		  if(aodTestMother1)
+		    {
+		      AliVParticle *aodTestMother2 = fMCEvent->GetTrack(m2);
+		      if(aodTestMother2)
+			{
+			  Int_t mpid1 = aodTestMother1->PdgCode();
+			  Int_t mpid2 = aodTestMother2->PdgCode();
+
+			  Int_t mpidind1 = 0, mpidind2 = 0;
+			  for(Int_t i = 0; i < 24; i++)
+			    {
+			      if(mpid1 == pidVals[i]) mpidind1 = i+1;
+			      if(mpid2 == pidVals[i]) mpidind2 = i+1;
+			    }
+			  hCorrMpidMpid->Fill(mpidind1,mpidind2);
+			  if(TMath::Abs(aodTrackPos->GetLabel()) == m2) hCorrPidMpid->Fill(aodGenTrackPos->PdgCode(),mpidind2);
+			  if(TMath::Abs(aodTrackNeg->GetLabel()) == m1) hCorrPidMpid->Fill(aodGenTrackNeg->PdgCode(),mpidind1);
+
+			  Int_t gm1 = aodTestMother1->GetMother();
+			  Int_t gm2 = aodTestMother2->GetMother();
+
+			  if(gm1 >= 0)
+			    {
+			      AliVParticle *aodGrandmother1 = fMCEvent->GetTrack(gm1);
+			      if(aodGrandmother1)
+				{
+				  if(gm2 >= 0)
+				    {
+				      AliVParticle *aodGrandmother2 = fMCEvent->GetTrack(gm2);
+				      if(aodGrandmother2)
+					{
+					  Int_t gmpid1 = aodGrandmother1->PdgCode();
+					  Int_t gmpid2 = aodGrandmother2->PdgCode();
+
+					  Int_t gmpidind1 = 0, gmpidind2 = 0;
+					  for(Int_t i = 0; i < 24; i++)
+					    {
+					      if(gmpid1 == pidVals[i]) gmpidind1 = i+1;
+					      if(gmpid2 == pidVals[i]) gmpidind2 = i+1;
+					    }
+					  hCorrGpidGpid->Fill(gmpidind1,gmpidind2);
+					  if(TMath::Abs(aodTrackPos->GetLabel()) == gm2) hCorrPidGpid->Fill(aodGenTrackPos->PdgCode(),gmpidind2);
+					  if(TMath::Abs(aodTrackNeg->GetLabel()) == gm1) hCorrPidGpid->Fill(aodGenTrackNeg->PdgCode(),gmpidind1);
+					  
+					  if(m1 == gm2)
+					    {
+					      hCorrMpidGpid->Fill(mpidind1,gmpidind2);
+					      Printf("mismatch!!   %i -> %i -> %i   %i -> %i",gmpid2,mpid2,aodGenTrackNeg->PdgCode(),mpid1,aodGenTrackPos->PdgCode());
+					      hInvMassLambdaXiMismatch->Fill(invMassLambda,pt);
+					      hInvMassAntiLambdaXiMismatch->Fill(invMassAntiLambda,pt);
+					    } 
+					  if(m2 == gm1)
+					    {
+					      hCorrMpidGpid->Fill(mpidind2,gmpidind1);
+					      Printf("mismatch!!   %i -> %i -> %i   %i -> %i",gmpid1,mpid1,aodGenTrackPos->PdgCode(),mpid2,aodGenTrackNeg->PdgCode());
+					      hInvMassLambdaXiMismatch->Fill(invMassLambda,pt);
+					      hInvMassAntiLambdaXiMismatch->Fill(invMassAntiLambda,pt);
+					    }
+					}
+				    }
+				}
+			    }
+			}
+		    }
+		}
+
+
+		      
 	      if(m1 != m2) continue;
 	      
 	      AliVParticle *aodTestMother = fMCEvent->GetTrack(m1);
@@ -906,10 +1100,10 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 		{
 		  if(isSecFromWeakDecay)
 		    {
-		      Int_t gm1 = aodTestMother->GetMother();
-		      if(gm1 >= 0)
+		      Int_t gm = aodTestMother->GetMother();
+		      if(gm >= 0)
 			{
-			  AliVParticle *aodGrandmother = fMCEvent->GetTrack(gm1);
+			  AliVParticle *aodGrandmother = fMCEvent->GetTrack(gm);
 			  if(aodGrandmother)
 			    {
 			      if(aodGrandmother->IsPhysicalPrimary())
@@ -982,29 +1176,6 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 		    }
 		}
 	    }
-
-	  //if((invMassLambda > 1.08 && invMassLambda < 1.15) || (invMassAntiLambda > 1.08 && invMassAntiLambda < 1.15))
-	  //{
-	  //Printf("%i   %.4lf   %.4lf   %.4lf",mpid,mpt,invMassLambda,invMassAntiLambda);
-	  //}
-	  /*if(pt > 0.8)
-	    {
-	      if(mpid==3122) {hInvMassPtPidLambda->Fill(invMassLambda,mpt,0); hInvMassPtPidAntiLambda->Fill(invMassAntiLambda,mpt,0);}
-	      else if(mpid==-3122) {hInvMassPtPidLambda->Fill(invMassLambda,mpt,1); hInvMassPtPidAntiLambda->Fill(invMassAntiLambda,mpt,1);}
-	      else if(mpid==22) {hInvMassPtPidLambda->Fill(invMassLambda,mpt,2); hInvMassPtPidAntiLambda->Fill(invMassAntiLambda,mpt,2);}
-	      else if(mpid==111) {hInvMassPtPidLambda->Fill(invMassLambda,mpt,3); hInvMassPtPidAntiLambda->Fill(invMassAntiLambda,mpt,3);}
-	      else if(mpid==130) {hInvMassPtPidLambda->Fill(invMassLambda,mpt,4); hInvMassPtPidAntiLambda->Fill(invMassAntiLambda,mpt,4);}
-	      else if(mpid==211) {hInvMassPtPidLambda->Fill(invMassLambda,mpt,5); hInvMassPtPidAntiLambda->Fill(invMassAntiLambda,mpt,5);}
-	      else if(mpid==-211) {hInvMassPtPidLambda->Fill(invMassLambda,mpt,6); hInvMassPtPidAntiLambda->Fill(invMassAntiLambda,mpt,6);}
-	      else if(mpid==310) {hInvMassPtPidLambda->Fill(invMassLambda,mpt,7); hInvMassPtPidAntiLambda->Fill(invMassAntiLambda,mpt,7);}
-	      else if(mpid==321) {hInvMassPtPidLambda->Fill(invMassLambda,mpt,8); hInvMassPtPidAntiLambda->Fill(invMassAntiLambda,mpt,8);}
-	      else if(mpid==-321) {hInvMassPtPidLambda->Fill(invMassLambda,mpt,9); hInvMassPtPidAntiLambda->Fill(invMassAntiLambda,mpt,9);}
-	      else if(mpid==2112) {hInvMassPtPidLambda->Fill(invMassLambda,mpt,10); hInvMassPtPidAntiLambda->Fill(invMassAntiLambda,mpt,10);}
-	      else if(mpid==-2112) {hInvMassPtPidLambda->Fill(invMassLambda,mpt,11); hInvMassPtPidAntiLambda->Fill(invMassAntiLambda,mpt,11);}
-	      else if(mpid==2212) {hInvMassPtPidLambda->Fill(invMassLambda,mpt,12); hInvMassPtPidAntiLambda->Fill(invMassAntiLambda,mpt,12);}
-	      else if(mpid==-2212) {hInvMassPtPidLambda->Fill(invMassLambda,mpt,13); hInvMassPtPidAntiLambda->Fill(invMassAntiLambda,mpt,13);}
-	      //else Printf("mid = %i  mL = %.4lf  mAL = %.4lf  pt = %.4lf",mpid,invMassLambda,invMassAntiLambda,pt);
-	      }*/
 	  
 	  if(TMath::Abs(mpid) != 3122) continue;
 	  
@@ -1024,20 +1195,26 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 	    {
 	      mcstatus += 2; // mcstatus = 4 means secondary from weak decay
 	      if(mpid == 3122)
-		hInvMassLambdaSecFromWeakDecay->Fill(invMassLambda,pt);
+		{
+		  hInvMassLambdaSecFromWeakDecay->Fill(invMassLambda,pt);
+		  if(tempLightV0L) tempLightV0L->SetCascadePtEta(cascpt,casceta);
+		}
 	      if(mpid == -3122)
-		hInvMassAntiLambdaSecFromWeakDecay->Fill(invMassAntiLambda,pt);
-	      if(tempLightV0) tempLightV0->SetCascadePtEta(cascpt,casceta);
+		{
+		  hInvMassAntiLambdaSecFromWeakDecay->Fill(invMassAntiLambda,pt);
+		  if(tempLightV0AL) tempLightV0AL->SetCascadePtEta(cascpt,casceta);
+		}
 	    }
 	  
 	  //if(!(stack->IsPhysicalPrimary(m1))) continue;
 	  if(!isPrim) mcstatus += 1; // mcstatus = 2 means secondary
 
-	  if(tempLightV0) tempLightV0->SetGenPtEta(mpt,meta);
+	  if(tempLightV0L) tempLightV0L->SetGenPtEta(mpt,meta);
+	  if(tempLightV0AL) tempLightV0AL->SetGenPtEta(mpt,meta);
 	  
 	  if(mpid == 3122)
 	    {
-	      if(tempLightV0) tempLightV0->SetMcStatus(mcstatus);
+	      if(tempLightV0L) tempLightV0L->SetMcStatus(mcstatus);
 	      hPtResLambda->Fill(mpt,pt);
 	      if(isPrim) hPtResLambdaPrim->Fill(mpt,pt);
 	      if(TMath::Abs(meta) <= etacutlambda)
@@ -1048,7 +1225,7 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 	    }
 	  else if(mpid == -3122)
 	    {
-	      if(tempLightV0) tempLightV0->SetMcStatus(-1*mcstatus); // mcstatus < 0 means antilambda
+	      if(tempLightV0AL) tempLightV0AL->SetMcStatus(-1*mcstatus); // mcstatus < 0 means antilambda
 	      hPtResAntiLambda->Fill(mpt,pt);
 	      if(isPrim) hPtResAntiLambdaPrim->Fill(mpt,pt);
 	      if(TMath::Abs(meta) <= etacutlambda)
@@ -1060,24 +1237,30 @@ void AliAnalysisTaskNetLambdaIdent::UserExec(Option_t *){
 	}
     }
 
+  //Printf("mixed event");
   // event mixing
-  if(fEventMixingTree)
+  if(fLambdaTree && fEventMixingTree)
     {
       fMixV0->Clear();
       AliEventPool* pool = fPoolMgr->GetEventPool(fCentV0M,fVtxZ);
-      if (pool->IsReady())
+      if(pool)
 	{
-	  //Printf("found pool for cent %lf vz %lf with %i entries",fCentV0M,fVtxZ,pool->GetCurrentNEvents());
-	  for (Int_t jMix=0; jMix<TMath::Min(nmaxmixevents,pool->GetCurrentNEvents()); jMix++) 
+	  if (pool->IsReady())
 	    {
-	      Tracks2V0vertices(mixtracks,pool->GetEvent(jMix),vvertex,fInputEvent->GetMagneticField());
+	      //Printf("found pool for cent %lf vz %lf with %i entries",fCentV0M,fVtxZ,pool->GetCurrentNEvents());
+	      for (Int_t jMix=0; jMix<TMath::Min(nmaxmixevents,pool->GetCurrentNEvents()); jMix++) 
+		{
+		  Tracks2V0vertices(mixtracks,pool->GetEvent(jMix),vvertex,b);
+		}
 	    }
+	  //pool->UpdatePool(mixprotons);
+	  pool->UpdatePool(mixtracks);
 	}
-      //pool->UpdatePool(mixprotons);
+      //Tracks2V0vertices(mixtracks,mixtracks,vvertex,b);
       //mixtracks->Clear();
-      pool->UpdatePool(mixtracks);
+      //Printf("%i  %i",fAcceptV0->GetEntriesFast(),fMixV0->GetEntriesFast()/2);
     }
-
+  
   fTree->Fill();
   
   hEventStatistics->Fill("after event loop",1);
@@ -1095,102 +1278,106 @@ void AliAnalysisTaskNetLambdaIdent::Tracks2V0vertices(TObjArray* ev1, TObjArray*
 
   //A set of very loose cuts
   Double_t fChi2max=33.; //max chi2
-  Double_t fDNmin=0.05;  //min imp parameter for the 1st daughter
-  Double_t fDPmin=0.05;  //min imp parameter for the 2nd daughter
-  Double_t fDCAmax=1.5;  //max DCA between the daughter tracks
-  Double_t fCPAmin=0.9;  //min cosine of V0's pointing angle
+  Double_t fDmin=0.1;//0.05;  //min imp parameter for the 1st daughter
+  Double_t fDCAmax=1.;//1.5;  //max DCA between the daughter tracks
+  Double_t fCPAmin=0.998;//0.9;  //min cosine of V0's pointing angle
   Double_t fRmin=0.2;    //min radius of the fiducial volume
-  Double_t fRmax=200.;   //max radius of the fiducial volume
+  Double_t fRmax=100.;//200.;   //max radius of the fiducial volume
   
   //const AliESDVertex *vtxT3D=event->GetPrimaryVertex();
   Double_t primVtx[3] = {vtxT3D->GetX(),vtxT3D->GetY(),vtxT3D->GetZ()};
+  Double_t covMat[6];
+  vtxT3D->GetCovarianceMatrix(covMat);
 
-  AliExternalTrackParam *ntrk, *ptrk, *temptrk;
-  Float_t pnsigmapr, nnsigmapr;
-  
+  AliExternalTrackParam *temptrk1 = 0x0, *temptrk2 = 0x0;
+
   for(Int_t i = 0; i < ev1->GetEntries(); i++)
     {
-      temptrk = ((AliLightV0track*)ev1->At(i))->GetExtParam();
+      temptrk1 = (AliExternalTrackParam*)((AliLightV0track*)ev1->At(i))->GetExtParam();
 
-      Double_t dn = TMath::Abs(temptrk->GetD(primVtx[0],primVtx[1],b));
-      if (dn<fDNmin) continue;
-      if (dn>fRmax) continue;
-      
-      Int_t trksign = temptrk->GetSign();
-      Bool_t isProtonCand = kFALSE;
-      
-      if(trksign > 0)
-	{
-	  ptrk = temptrk;
-	  pnsigmapr = ((AliLightV0track*)ev1->At(i))->GetProtonPID();
-	  if(TMath::Abs(pnsigmapr) < 5.) isProtonCand = kTRUE;
-	}
-      else if(trksign < 0)
-	{
-	  ntrk = temptrk;
-	  nnsigmapr = ((AliLightV0track*)ev1->At(i))->GetProtonPID();
-	  if(TMath::Abs(nnsigmapr) < 5.) isProtonCand = kTRUE;
-	}
-      else continue;
+      //Double_t dn = TMath::Abs(temptrk1->GetD(primVtx[0],primVtx[1],b));
+      //if (dn<fDmin) continue;
+      //if (dn>fRmax) continue;
 
       for(Int_t k = 0; k < ev2->GetEntries(); k++)
 	{
-	  temptrk = (AliExternalTrackParam*)((AliLightV0track*)ev2->At(k))->GetExtParam();
+	  temptrk2 = (AliExternalTrackParam*)((AliLightV0track*)ev2->At(k))->GetExtParam();
+	  
+	  if(temptrk1->GetSign() == temptrk2->GetSign()) continue;
 
-	  Double_t dp = TMath::Abs(temptrk->GetD(primVtx[0],primVtx[1],b));
-	  if (dp<fDPmin) continue;
-	  if (dp>fRmax) continue;
+	  if(TMath::Abs(((AliLightV0track*)ev1->At(i))->GetProtonPID()) > 5. && TMath::Abs(((AliLightV0track*)ev2->At(k))->GetProtonPID()) > 5.) continue;
 	  
-	  if(trksign == temptrk->GetSign()) continue;
-	  if(trksign > 0)
+	  AliExternalTrackParam *ntrk = 0x0, *ptrk = 0x0;
+	  Float_t pnsigmapr, nnsigmapr;
+
+	  if(temptrk1->GetSign() > 0 && temptrk2->GetSign() < 0)
 	    {
-	      ntrk = temptrk;
+	      ntrk = new AliExternalTrackParam(*temptrk2);
 	      nnsigmapr = ((AliLightV0track*)ev2->At(k))->GetProtonPID();
-	      if(!isProtonCand){if(TMath::Abs(nnsigmapr) > 5.) continue;}
+	      Double_t diffVtx[3];
+	      ((AliLightV0track*)ev2->At(k))->GetPrimaryVertex(diffVtx[0],diffVtx[1],diffVtx[2]);
+	      //Printf("zvtx1 = %.3lf, zvtx2 = %.3lf   old z1 = %.3lf, old z2 = %.3lf",primVtx[2],diffVtx[2],temptrk1->GetZ(),temptrk2->GetZ());
+	      //diffVtx[0] = primVtx[0]-diffVtx[0];
+	      //diffVtx[1] = primVtx[1]-diffVtx[1];
+	      //diffVtx[2] = primVtx[2]-diffVtx[2];
+	      diffVtx[0] -= primVtx[0];
+	      diffVtx[1] -= primVtx[1];
+	      diffVtx[2] -= primVtx[2];
+	      //Printf("old D = %.3lf",ntrk->GetD(primVtx[0],primVtx[1],b));
+	      ntrk->Translate(diffVtx,covMat);
+	      //Printf("new D = %.3lf",ntrk->GetD(primVtx[0],primVtx[1],b));
+	      //Double_t dp = TMath::Abs(ntrk->GetD(primVtx[0],primVtx[1],b));
+	      //if (dp<fDmin) {delete ntrk; continue;}
+	      //if (dp>fRmax) {delete ntrk; continue;}
+	      
+	      ptrk = new AliExternalTrackParam(*temptrk1);
+	      pnsigmapr = ((AliLightV0track*)ev1->At(i))->GetProtonPID();
+	      //Printf("new z1 = %.3lf, old z2 = %.3lf",ptrk->GetZ(),ntrk->GetZ());
 	    }
-	  else
+	  else if(temptrk1->GetSign() < 0 && temptrk2->GetSign() > 0)
 	    {
-	      ptrk = temptrk;
+	      ptrk = new AliExternalTrackParam(*temptrk2);
 	      pnsigmapr = ((AliLightV0track*)ev2->At(k))->GetProtonPID();
-	      if(!isProtonCand){if(TMath::Abs(pnsigmapr) > 5.) continue;}
+	      Double_t diffVtx[3];
+	      ((AliLightV0track*)ev2->At(k))->GetPrimaryVertex(diffVtx[0],diffVtx[1],diffVtx[2]);
+	      //Printf("zvtx1 = %.3lf, zvtx2 = %.3lf   old z1 = %.3lf, old z2 = %.3lf",primVtx[2],diffVtx[2],temptrk1->GetZ(),temptrk2->GetZ());
+	      //diffVtx[0] = primVtx[0]-diffVtx[0];
+	      //diffVtx[1] = primVtx[1]-diffVtx[1];
+	      //diffVtx[2] = primVtx[2]-diffVtx[2];
+	      diffVtx[0] -= primVtx[0];
+	      diffVtx[1] -= primVtx[1];
+	      diffVtx[2] -= primVtx[2];
+	      //Printf("old D = %.3lf",ptrk->GetD(primVtx[0],primVtx[1],b));
+	      ptrk->Translate(diffVtx,covMat);
+	      //Printf("new D = %.3lf",ptrk->GetD(primVtx[0],primVtx[1],b));
+	      
+	      //Double_t dp = TMath::Abs(ptrk->GetD(primVtx[0],primVtx[1],b));
+	      //if (dp<fDmin) {delete ptrk; continue;}
+	      //if (dp>fRmax) {delete ptrk; continue;}
+
+	      ntrk = new AliExternalTrackParam(*temptrk1);
+	      nnsigmapr = ((AliLightV0track*)ev1->At(i))->GetProtonPID();
+	      //Printf("new z1 = %.3lf, old z2 = %.3lf",ntrk->GetZ(),ptrk->GetZ());
 	    }
-	  
+	  else continue;
+
 	  Double_t xn, xp;
 	  Double_t dca = ntrk->GetDCA(ptrk,b,xn,xp);
-	  if (dca > fDCAmax) continue;
-	  if ((xn+xp) > 2*fRmax) continue;
-	  if ((xn+xp) < 2*fRmin) continue;
-	  
-	  //AliExternalTrackParam nt(*ntrk), pt(*ptrk);
-	  Bool_t corrected=kFALSE;
-	  if ((ntrk->GetX() > 3.) && (xn < 3.))
-	    {
-	      //correct for the beam pipe material
-	      corrected=kTRUE;
-	    }
-	  if ((ptrk->GetX() > 3.) && (xp < 3.))
-	    {
-	      //correct for the beam pipe material
-	      corrected=kTRUE;
-	    }
-	  if (corrected)
-	    {
-	      dca = ntrk->GetDCA(ptrk,b,xn,xp);
-	      if (dca > fDCAmax) continue;
-	      if ((xn+xp) > 2*fRmax) continue;
-	      if ((xn+xp) < 2*fRmin) continue;
-	    }
+	  if (dca > fDCAmax) {delete ntrk; delete ptrk; continue;}
+	  if ((xn+xp) > 2*fRmax) {delete ntrk; delete ptrk; continue;}
+	  if ((xn+xp) < 2*fRmin) {delete ntrk; delete ptrk; continue;}
 	  
 	  ntrk->PropagateTo(xn,b); // check this
 	  ptrk->PropagateTo(xp,b);
-
+	  
 	  AliESDv0 vertex(*ntrk,i,*ptrk,k);
+	  
 	  if (vertex.GetChi2V0() > fChi2max) continue;
 	  
 	  Double_t x = vertex.Xv(), y=vertex.Yv(), z=vertex.Zv();
 	  Double_t r2 = x*x + y*y;
-	  if (r2 < fRmin*fRmin) continue;
-	  if (r2 > fRmax*fRmax) continue;
+	  if (r2 < fRmin*fRmin) {delete ntrk; delete ptrk; continue;}
+	  if (r2 > fRmax*fRmax) {delete ntrk; delete ptrk; continue;}
 
 	  Double_t v0DecayLength = TMath::Sqrt(TMath::Power(x - primVtx[0],2) +
 					       TMath::Power(y - primVtx[1],2) +
@@ -1199,6 +1386,7 @@ void AliAnalysisTaskNetLambdaIdent::Tracks2V0vertices(TObjArray* ev1, TObjArray*
 	  Float_t cpa = vertex.GetV0CosineOfPointingAngle(primVtx[0],primVtx[1],primVtx[2]);
 	  const Double_t pThr=1.5;
 	  Double_t pv0 = vertex.P();
+
 	  if (pv0<pThr)
 	    {
 	      //Below the threshold "pThr", try a momentum dependent cos(PA) cut 
@@ -1207,40 +1395,53 @@ void AliAnalysisTaskNetLambdaIdent::Tracks2V0vertices(TObjArray* ev1, TObjArray*
 	      const Double_t cpaThr=TMath::Cos(TMath::ATan(qt/pThr) + bend);
 	      Double_t 
 		cpaCut=(fCPAmin/cpaThr)*TMath::Cos(TMath::ATan(qt/pv0) + bend); 
-	      if (cpa < cpaCut) continue;
+	      if (cpa < cpaCut) {delete ntrk; delete ptrk; continue;}
 	    }
 	  else
 	    {
-	      if (cpa < fCPAmin) continue;
+	      if (cpa < fCPAmin) {delete ntrk; delete ptrk; continue;}
 	    }
 	  vertex.SetV0CosineOfPointingAngle(cpa);
 	  vertex.SetDcaV0Daughters(dca);
 	  
-	  if(!V0CutsForTreeESD(&vertex,primVtx,ptrk,ntrk,b)) continue;
+	  if(!V0CutsForTreeESD(&vertex,primVtx,ptrk,ntrk,b)) {delete ntrk; delete ptrk; continue;}
+
+	  Float_t nd[2] = {0,0};
+	  Float_t pd[2] = {0,0};
+	  ntrk->GetDZ(primVtx[0],primVtx[1],primVtx[2],b,nd);
+	  ptrk->GetDZ(primVtx[0],primVtx[1],primVtx[2],b,pd);
+
+	  //Double_t alpha = vertex.AlphaV0();
+	  //Double_t ptarm = vertex.PtArmV0();
 	  
 	  if(vertex.GetEffMass(4,2) < 1.16 && TMath::Abs(pnsigmapr) < 5.) // mixed lambda candidate
 	    {
 	      AliLightV0 *tempLightV0 = new((*fMixV0)[fMixV0->GetEntriesFast()]) AliLightV0(vertex.Pt(),vertex.Eta());
 	      tempLightV0->SetInvMass(vertex.GetEffMass(4,2));
+	      tempLightV0->SetInvMassK0S(vertex.GetEffMass(2,2));
 	      tempLightV0->SetCosPointingAngle(cpa);
 	      tempLightV0->SetDecayR(TMath::Sqrt(r2));
 	      tempLightV0->SetProperLifetime(vertex.P() > 0. ? vertex.GetEffMass(4,2)*v0DecayLength/vertex.P() : 0.);
 	      tempLightV0->SetDCADaughters(dca);
 	      tempLightV0->SetMcStatus(0);
-	      tempLightV0->SetPosDaughter(ptrk->Pt(),ptrk->Eta(),pnsigmapr,TMath::Abs(ptrk->GetD(primVtx[0],primVtx[1],b)));
-	      tempLightV0->SetNegDaughter(ntrk->Pt(),ntrk->Eta(),nnsigmapr,TMath::Abs(ntrk->GetD(primVtx[0],primVtx[1],b)));
+	      tempLightV0->SetPosDaughter(ptrk->Pt(),ptrk->Eta(),pnsigmapr,TMath::Sqrt(pd[0]*pd[0]+pd[1]*pd[1]));
+	      tempLightV0->SetNegDaughter(ntrk->Pt(),ntrk->Eta(),nnsigmapr,TMath::Sqrt(nd[0]*nd[0]+nd[1]*nd[1]));
+
+	      //Printf("pt = %.3lf   eta = %.3lf   minv = %.3lf   cosPA = %.3lf   decayR = %.3lf   propLife = %.3lf   DCAdaughters = %.3lf   posPt = %.3lf   posDCA = %.3lf   posNSigma = %.3lf   posD = %.3lf   negPt = %.3lf   negDCA = %.3lf   negNSigma = %.3lf   negD = %.3lf",vertex.Pt(),vertex.Eta(),vertex.GetEffMass(4,2),cpa,TMath::Sqrt(r2),vertex.GetEffMass(4,2)*v0DecayLength/vertex.P(),dca,ptrk->Pt(),TMath::Sqrt(pd[0]*pd[0]+pd[1]*pd[1]),pnsigmapr,ptrk->GetD(primVtx[0],primVtx[1],b),ntrk->Pt(),TMath::Sqrt(nd[0]*nd[0]+nd[1]*nd[1]),nnsigmapr,ntrk->GetD(primVtx[0],primVtx[1],b));
 	    }
 	  if(vertex.GetEffMass(2,4) < 1.16 && TMath::Abs(nnsigmapr) < 5.) // mixed anti-lambda candidate
 	    {
 	      AliLightV0 *tempLightV0 = new((*fMixV0)[fMixV0->GetEntriesFast()]) AliLightV0(vertex.Pt(),vertex.Eta());
 	      tempLightV0->SetInvMass(-1.*vertex.GetEffMass(2,4));
+	      tempLightV0->SetInvMassK0S(vertex.GetEffMass(2,2));
 	      tempLightV0->SetCosPointingAngle(cpa);
 	      tempLightV0->SetDecayR(TMath::Sqrt(r2));
 	      tempLightV0->SetProperLifetime(vertex.P() > 0. ? vertex.GetEffMass(2,4)*v0DecayLength/vertex.P() : 0.);
 	      tempLightV0->SetDCADaughters(dca);
 	      tempLightV0->SetMcStatus(0);
-	      tempLightV0->SetPosDaughter(ptrk->Pt(),ptrk->Eta(),pnsigmapr,TMath::Abs(ptrk->GetD(primVtx[0],primVtx[1],b)));
-	      tempLightV0->SetNegDaughter(ntrk->Pt(),ntrk->Eta(),nnsigmapr,TMath::Abs(ntrk->GetD(primVtx[0],primVtx[1],b)));
+	      tempLightV0->SetPosDaughter(ptrk->Pt(),ptrk->Eta(),pnsigmapr,TMath::Sqrt(pd[0]*pd[0]+pd[1]*pd[1]));
+	      tempLightV0->SetNegDaughter(ntrk->Pt(),ntrk->Eta(),nnsigmapr,TMath::Sqrt(nd[0]*nd[0]+nd[1]*nd[1]));
+	      //Printf("pt = %.3lf   eta = %.3lf   minv = %.3lf   cosPA = %.3lf   decayR = %.3lf   propLife = %.3lf   DCAdaughters = %.3lf   posPt = %.3lf   posDCA = %.3lf   posNSigma = %.3lf   posD = %.3lf   negPt = %.3lf   negDCA = %.3lf   negNSigma = %.3lf   negD = %.3lf",vertex.Pt(),vertex.Eta(),vertex.GetEffMass(2,4),cpa,TMath::Sqrt(r2),vertex.GetEffMass(2,4)*v0DecayLength/vertex.P(),dca,ptrk->Pt(),TMath::Sqrt(pd[0]*pd[0]+pd[1]*pd[1]),pnsigmapr,ptrk->GetD(primVtx[0],primVtx[1],b),ntrk->Pt(),TMath::Sqrt(nd[0]*nd[0]+nd[1]*nd[1]),nnsigmapr,ntrk->GetD(primVtx[0],primVtx[1],b));
 	    }
 	}
     }
@@ -1251,7 +1452,7 @@ void AliAnalysisTaskNetLambdaIdent::Tracks2V0vertices(TObjArray* ev1, TObjArray*
 Bool_t AliAnalysisTaskNetLambdaIdent::TrackCutsForTreeAOD(AliAODTrack* trk)
 {
   if(TMath::Abs(trk->Eta()) > 1.) return kFALSE;
-  if(TMath::Abs(trk->Pt()) < 0.15) return kFALSE;
+  if(trk->Pt() < 0.15) return kFALSE;
   if(trk->GetTPCNCrossedRows() < ncrossedrowscut) return kFALSE;
   if(trk->GetTPCNclsF() <= 0) return kFALSE;
   if(trk->GetTPCNCrossedRows()/Float_t(trk->GetTPCNclsF()) < crossedrowsclustercut) return kFALSE;
@@ -1262,7 +1463,7 @@ Bool_t AliAnalysisTaskNetLambdaIdent::TrackCutsForTreeAOD(AliAODTrack* trk)
 Bool_t AliAnalysisTaskNetLambdaIdent::TrackCutsForTreeESD(AliESDtrack* trk)
 {
   if(TMath::Abs(trk->Eta()) > 1.) return kFALSE;
-  if(TMath::Abs(trk->Pt()) < 0.15) return kFALSE;
+  if(trk->Pt() < 0.15) return kFALSE;
   if(trk->GetTPCCrossedRows() < ncrossedrowscut) return kFALSE;
   if(trk->GetTPCNclsF() <= 0) return kFALSE;
   if(trk->GetTPCCrossedRows()/Float_t(trk->GetTPCNclsF()) < crossedrowsclustercut) return kFALSE;
@@ -1273,6 +1474,7 @@ Bool_t AliAnalysisTaskNetLambdaIdent::TrackCutsForTreeESD(AliESDtrack* trk)
 Bool_t AliAnalysisTaskNetLambdaIdent::V0CutsForTreeAOD(AliAODv0* v0, Double_t* vt)
 {
   if(v0->Pt() < ptminlambda) return kFALSE;
+  if(TMath::Abs(v0->Eta()) > etacutlambda) return kFALSE; 
 	    
   if(v0->CosPointingAngle(vt) < cospacut) return kFALSE;
   if(v0->DcaV0Daughters() > 1.5) return kFALSE; // these are default cuts from AODs
@@ -1291,25 +1493,21 @@ Bool_t AliAnalysisTaskNetLambdaIdent::V0CutsForTreeAOD(AliAODv0* v0, Double_t* v
 Bool_t AliAnalysisTaskNetLambdaIdent::V0CutsForTreeESD(AliESDv0* v0, Double_t* vt, AliExternalTrackParam* ptrk, AliExternalTrackParam* ntrk, Double_t b)
 {
   if(v0->Pt() < ptminlambda) return kFALSE;
+  if(TMath::Abs(v0->Eta()) > etacutlambda) return kFALSE; 
   
   if(v0->GetV0CosineOfPointingAngle() < cospacut) return kFALSE;
   if(v0->GetDcaV0Daughters() > 1.5) return kFALSE; // these are default cuts from AODs
 
   Float_t nd[2] = {0,0};
   Float_t pd[2] = {0,0};
-  ptrk->GetImpactParameters(pd[0],pd[1]);
-  ntrk->GetImpactParameters(nd[0],nd[1]);
-  if(pd[0] == 0 && nd[0] == 0)
-    {
-      ntrk->GetDZ(vt[0],vt[1],vt[2],b,nd);
-      ptrk->GetDZ(vt[0],vt[1],vt[2],b,pd);
-    }
+  ntrk->GetDZ(vt[0],vt[1],vt[2],b,nd);
+  ptrk->GetDZ(vt[0],vt[1],vt[2],b,pd);
   
   if(pd[0]*pd[0]+pd[1]*pd[1] < 0.05*0.05) return kFALSE;
   if(nd[0]*nd[0]+nd[1]*nd[1] < 0.05*0.05) return kFALSE;
 
 
-  Double_t sv[3];
+  Double_t sv[3] = {0,0,0};
   v0->GetXYZ(sv[0], sv[1], sv[2]);
   Float_t v0Radius2 = sv[0]*sv[0]+sv[1]*sv[1];
   if(v0Radius2 < minradius*minradius) return kFALSE;


### PR DESCRIPTION
also: enable translation of vertices for mixed events, add additional histograms for PID checks, add K0S inv mass to tree, enable switch for producing V0 tree, fix Armenteros-Podolanski calculation for swapped charges