### PR TITLE
PWGGA/GammaConv: Massive improvement for DCA trees in all tasks - now saved outside of TList

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskConversionQA.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskConversionQA.cxx
@@ -53,7 +53,6 @@ AliAnalysisTaskConversionQA::AliAnalysisTaskConversionQA() : AliAnalysisTaskSE()
   ffillTree(-100),
   ffillHistograms(kFALSE),
   fOutputList(NULL),
-  fTreeList(NULL),
   fESDList(NULL),
   hVertexZ(NULL),
   hNGoodESDTracks(NULL),
@@ -144,7 +143,6 @@ AliAnalysisTaskConversionQA::AliAnalysisTaskConversionQA(const char *name) : Ali
   ffillTree(-100),
   ffillHistograms(kFALSE),
   fOutputList(NULL),
-  fTreeList(NULL),
   fESDList(NULL),
   hVertexZ(NULL),
   hNGoodESDTracks(NULL),
@@ -224,6 +222,7 @@ AliAnalysisTaskConversionQA::AliAnalysisTaskConversionQA(const char *name) : Ali
 
   DefineInput(0, TChain::Class());
   DefineOutput(1, TList::Class());
+  DefineOutput(2, TTree::Class());
 }
 
 //________________________________________________________________________
@@ -417,16 +416,10 @@ void AliAnalysisTaskConversionQA::UserCreateOutputObjects()
       fOutputList->Add(fConversionCuts->GetCutHistograms());
     }
   }
-  
-  if(ffillTree>=1.0){
-    fTreeList = new TList();
-    fTreeList->SetOwner(kTRUE);
-    if(ffillTree>1.0) fTreeList->SetName(Form("TreeList_%f",ffillTree));
-    else fTreeList->SetName("TreeList");
-    fOutputList->Add(fTreeList);
 
-    fTreeQA = new TTree("PhotonQA","PhotonQA");   
-    
+  if(ffillTree>=1.0){
+    fTreeQA = new TTree("PhotonQA","PhotonQA");
+
     fTreeQA->Branch("daughterProp",&fDaughterProp);
     fTreeQA->Branch("recCords",&fGammaConvCoord);
     fTreeQA->Branch("photonProp",&fGammaPhotonProp);
@@ -435,8 +428,7 @@ void AliAnalysisTaskConversionQA::UserCreateOutputObjects()
     fTreeQA->Branch("chi2ndf",&fGammaChi2NDF,"fGammaChi2NDF/F");
     if (fIsMC) {
       fTreeQA->Branch("kind",&fKind,"fKind/b");
-    }   
-    fTreeList->Add(fTreeQA);
+    }
   }
 
   fV0Reader=(AliV0ReaderV1*)AliAnalysisManager::GetAnalysisManager()->GetTask(fV0ReaderName.Data());
@@ -445,8 +437,12 @@ void AliAnalysisTaskConversionQA::UserCreateOutputObjects()
     if (fV0Reader->GetV0FindingEfficiencyHistograms())
       fOutputList->Add(fV0Reader->GetV0FindingEfficiencyHistograms());
 
-  
+
   PostData(1, fOutputList);
+  if(ffillTree>=1.0){
+      OpenFile(2);
+      PostData(2, fTreeQA);
+  }
 }
 //_____________________________________________________________________________
 Bool_t AliAnalysisTaskConversionQA::Notify()

--- a/PWGGA/GammaConv/AliAnalysisTaskConversionQA.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskConversionQA.h
@@ -83,7 +83,6 @@ class AliAnalysisTaskConversionQA : public AliAnalysisTaskSE{
     Double_t                    ffillTree;                  //
     Bool_t                      ffillHistograms;            //
     TList*                      fOutputList;                //
-    TList*                      fTreeList;                  //
     TList*                      fESDList;                   //
     TH1F*                       hVertexZ;                   //
     TH1I*                       hNGoodESDTracks;            //
@@ -136,7 +135,7 @@ class AliAnalysisTaskConversionQA : public AliAnalysisTaskSE{
     Int_t*                      fMCStackPos;                //[fnGammaCandidates]
     Int_t*                      fMCStackNeg;                //[fnGammaCandidates]
     
-    ClassDef(AliAnalysisTaskConversionQA, 8);
+    ClassDef(AliAnalysisTaskConversionQA, 9);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
@@ -76,7 +76,6 @@ AliAnalysisTaskGammaConvCalo::AliAnalysisTaskGammaConvCalo(): AliAnalysisTaskSE(
   fESDList(NULL),
   fBackList(NULL),
   fMotherList(NULL),
-  fPhotonDCAList(NULL),
   fGammaERM02(NULL),
   fInvMassShowerShape(NULL),
   fTrueList(NULL),
@@ -376,7 +375,6 @@ AliAnalysisTaskGammaConvCalo::AliAnalysisTaskGammaConvCalo(const char *name):
   fESDList(NULL),
   fBackList(NULL),
   fMotherList(NULL),
-  fPhotonDCAList(NULL),
   fGammaERM02(NULL),
   fInvMassShowerShape(NULL),
   fTrueList(NULL),
@@ -659,6 +657,12 @@ AliAnalysisTaskGammaConvCalo::AliAnalysisTaskGammaConvCalo(const char *name):
 {
   // Define output slots here
   DefineOutput(1, TList::Class());
+  DefineOutput(2, TTree::Class());
+  DefineOutput(3, TTree::Class());
+  DefineOutput(4, TTree::Class());
+  DefineOutput(5, TTree::Class());
+  DefineOutput(6, TTree::Class());
+  DefineOutput(7, TTree::Class());
 }
 
 AliAnalysisTaskGammaConvCalo::~AliAnalysisTaskGammaConvCalo()
@@ -836,7 +840,6 @@ void AliAnalysisTaskGammaConvCalo::UserCreateOutputObjects(){
   }
 
   if (fDoPhotonQA == 2){
-    fPhotonDCAList            = new TList*[fnCuts];
     fTreeConvGammaPtDcazCat   = new TTree*[fnCuts];
   }
 
@@ -1255,19 +1258,13 @@ void AliAnalysisTaskGammaConvCalo::UserCreateOutputObjects(){
     }
 
     if (fDoPhotonQA == 2 ){
-      fPhotonDCAList[iCut]          = new TList();
-      fPhotonDCAList[iCut]->SetName(Form("%s_%s_%s_%s Photon DCA tree",cutstringEvent.Data(),cutstringPhoton.Data(),cutstringCalo.Data(),cutstringMeson.Data()));
-      fPhotonDCAList[iCut]->SetOwner(kTRUE);
-      fCutFolder[iCut]->Add(fPhotonDCAList[iCut]);
-
-      fTreeConvGammaPtDcazCat[iCut] = new TTree("ESD_ConvGamma_Pt_Dcaz", "ESD_ConvGamma_Pt_Dcaz_Cat");
+      fTreeConvGammaPtDcazCat[iCut] = new TTree(Form("%s_%s_%s_%s Photon DCA tree",cutstringEvent.Data(),cutstringPhoton.Data(),cutstringCalo.Data(),cutstringMeson.Data()), "ESD_ConvGamma_Pt_Dcaz_Cat");
       fTreeConvGammaPtDcazCat[iCut]->Branch("Pt",&fPtGamma,"fPtGamma/s");
       fTreeConvGammaPtDcazCat[iCut]->Branch("DcaZPhoton",&fDCAzPhoton,"fDCAzPhoton/S");
       fTreeConvGammaPtDcazCat[iCut]->Branch("cat",&fCharCatPhoton,"fCharCatPhoton/b");
       if (fIsMC > 1){
         fTreeConvGammaPtDcazCat[iCut]->Branch("weightEvent",&fWeightJetJetMC,"fWeightJetJetMC/f");
       }
-      fPhotonDCAList[iCut]->Add(fTreeConvGammaPtDcazCat[iCut]);
     }
 
     fClusterOutputList[iCut]        = new TList();
@@ -2502,6 +2499,12 @@ void AliAnalysisTaskGammaConvCalo::UserCreateOutputObjects(){
 
 
   PostData(1, fOutputContainer);
+  if(fDoPhotonQA == 2){
+    for(Int_t iCut = 0; iCut<fnCuts;iCut++){
+      OpenFile(iCut+2);
+      PostData(iCut+2, fTreeConvGammaPtDcazCat[iCut]);
+    }
+  }
 }
 //_____________________________________________________________________________
 Bool_t AliAnalysisTaskGammaConvCalo::Notify()

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.h
@@ -155,7 +155,6 @@ class AliAnalysisTaskGammaConvCalo : public AliAnalysisTaskSE {
     TList**                             fESDList;               // Array of lists with histograms with reconstructed properties
     TList**                             fBackList;              // Array of lists with BG THnSparseF
     TList**                             fMotherList;            // Array of lists with Signal THnSparseF
-    TList**                             fPhotonDCAList;         // Array of lists with photon dca trees
     TList**                             fGammaERM02;            // Array of lists with conv photon shower shape trees
     TList**                             fInvMassShowerShape;    // Array of lists with invMass shower shape trees
     TList**                             fTrueList;              // Array of lists with histograms with MC validated reconstructed properties
@@ -479,7 +478,7 @@ class AliAnalysisTaskGammaConvCalo : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaConvCalo(const AliAnalysisTaskGammaConvCalo&); // Prevent copy-construction
     AliAnalysisTaskGammaConvCalo &operator=(const AliAnalysisTaskGammaConvCalo&); // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaConvCalo, 46);
+    ClassDef(AliAnalysisTaskGammaConvCalo, 47);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
@@ -73,8 +73,6 @@ AliAnalysisTaskGammaConvV1::AliAnalysisTaskGammaConvV1(): AliAnalysisTaskSE(),
   fESDList(NULL),
   fBackList(NULL),
   fMotherList(NULL),
-  fPhotonDCAList(NULL),
-  fMesonDCAList(NULL),
   fTrueList(NULL),
   fMCList(NULL),
   fHeaderNameList(NULL),
@@ -283,8 +281,6 @@ AliAnalysisTaskGammaConvV1::AliAnalysisTaskGammaConvV1(const char *name):
   fESDList(NULL),
   fBackList(NULL),
   fMotherList(NULL),
-  fPhotonDCAList(NULL),
-  fMesonDCAList(NULL),
   fTrueList(NULL),
   fMCList(NULL),
   fHeaderNameList(NULL),
@@ -478,6 +474,14 @@ AliAnalysisTaskGammaConvV1::AliAnalysisTaskGammaConvV1(const char *name):
 {
   // Define output slots here
   DefineOutput(1, TList::Class());
+  DefineOutput(2, TTree::Class());
+  DefineOutput(3, TTree::Class());
+  DefineOutput(4, TTree::Class());
+  DefineOutput(5, TTree::Class());
+  DefineOutput(6, TTree::Class());
+  DefineOutput(7, TTree::Class());
+  DefineOutput(8, TTree::Class());
+  DefineOutput(9, TTree::Class());
 }
 
 AliAnalysisTaskGammaConvV1::~AliAnalysisTaskGammaConvV1()
@@ -855,7 +859,6 @@ void AliAnalysisTaskGammaConvV1::UserCreateOutputObjects(){
     fHistoConvGammaPhi          = new TH1F*[fnCuts];
   }
   if (fDoPhotonQA == 2){
-    fPhotonDCAList              = new TList*[fnCuts];
     tESDConvGammaPtDcazCat      = new TTree*[fnCuts];
   }
   if(fDoMesonAnalysis){
@@ -871,7 +874,6 @@ void AliAnalysisTaskGammaConvV1::UserCreateOutputObjects(){
       fHistoMotherEtaPtOpenAngle    = new TH2F*[fnCuts];
     }
     if(fDoMesonQA == 2){
-      fMesonDCAList                         = new TList*[fnCuts];
       tESDMesonsInvMassPtDcazMinDcazMaxFlag = new TTree*[fnCuts];
     }
     if(fDoMesonQA == 3){
@@ -1079,12 +1081,7 @@ void AliAnalysisTaskGammaConvV1::UserCreateOutputObjects(){
     }
 
     if (fDoPhotonQA == 2){
-      fPhotonDCAList[iCut]        = new TList();
-      fPhotonDCAList[iCut]->SetName(Form("%s_%s_%s Photon DCA tree", cutstringEvent.Data(), cutstringPhoton.Data(), cutstringMeson.Data()));
-      fPhotonDCAList[iCut]->SetOwner(kTRUE);
-      fCutFolder[iCut]->Add(fPhotonDCAList[iCut]);
-
-      tESDConvGammaPtDcazCat[iCut]= new TTree("ESD_ConvGamma_Pt_Dcaz_R_Eta", "ESD_ConvGamma_Pt_Dcaz_R_Eta_Cat");
+      tESDConvGammaPtDcazCat[iCut]= new TTree(Form("%s_%s_%s Photon DCA tree", cutstringEvent.Data(), cutstringPhoton.Data(), cutstringMeson.Data()), "ESD_ConvGamma_Pt_Dcaz_R_Eta_Cat");
       tESDConvGammaPtDcazCat[iCut]->Branch("Pt",&fPtGamma,"fPtGamma/F");
       tESDConvGammaPtDcazCat[iCut]->Branch("DcaZPhoton",&fDCAzPhoton,"fDCAzPhoton/F");
       tESDConvGammaPtDcazCat[iCut]->Branch("cat",&iCatPhoton,"iCatPhoton/b");
@@ -1094,8 +1091,6 @@ void AliAnalysisTaskGammaConvV1::UserCreateOutputObjects(){
       if (fIsMC > 1){
         tESDConvGammaPtDcazCat[iCut]->Branch("weightEvent",&fWeightJetJetMC,"fWeightJetJetMC/F");
       }
-
-      fPhotonDCAList[iCut]->Add(tESDConvGammaPtDcazCat[iCut]);
     }
 
     if(fDoPhotonQA > 0 && fIsMC < 2){
@@ -1130,12 +1125,7 @@ void AliAnalysisTaskGammaConvV1::UserCreateOutputObjects(){
       }
 
       if(fDoMesonQA == 2){
-        fMesonDCAList[iCut]       = new TList();
-        fMesonDCAList[iCut]->SetName(Form("%s_%s_%s Meson DCA tree",cutstringEvent.Data() ,cutstringPhoton.Data(),cutstringMeson.Data()));
-        fMesonDCAList[iCut]->SetOwner(kTRUE);
-        fCutFolder[iCut]->Add(fMesonDCAList[iCut]);
-
-        tESDMesonsInvMassPtDcazMinDcazMaxFlag[iCut] = new TTree("ESD_Mesons_InvMass_Pt_DcazMin_DcazMax_Flag", "ESD_Mesons_InvMass_Pt_DcazMin_DcazMax_Flag");
+        tESDMesonsInvMassPtDcazMinDcazMaxFlag[iCut] = new TTree(Form("%s_%s_%s Meson DCA tree",cutstringEvent.Data() ,cutstringPhoton.Data(),cutstringMeson.Data()), "ESD_Mesons_InvMass_Pt_DcazMin_DcazMax_Flag");
         tESDMesonsInvMassPtDcazMinDcazMaxFlag[iCut]->Branch("InvMass",&fInvMass,"fInvMass/F");
         tESDMesonsInvMassPtDcazMinDcazMaxFlag[iCut]->Branch("Pt",&fPt,"fPt/F");
         tESDMesonsInvMassPtDcazMinDcazMaxFlag[iCut]->Branch("DcaZMin",&fDCAzGammaMin,"fDCAzGammaMin/F");
@@ -1144,8 +1134,6 @@ void AliAnalysisTaskGammaConvV1::UserCreateOutputObjects(){
         if(fIsMC>0){
           tESDMesonsInvMassPtDcazMinDcazMaxFlag[iCut]->Branch("mesonMCInfo",&iMesonMCInfo,"iMesonMCInfo/b");
         }
-        fMesonDCAList[iCut]->Add(tESDMesonsInvMassPtDcazMinDcazMaxFlag[iCut]);
-
       }
       if(fDoMesonQA > 0 ){
         if (fIsMC < 2){
@@ -1755,8 +1743,22 @@ void AliAnalysisTaskGammaConvV1::UserCreateOutputObjects(){
     tBrokenFiles->Branch("fileName",&fFileNameBroken);
     fOutputContainer->Add(tBrokenFiles);
   }
-
+  OpenFile(1);
   PostData(1, fOutputContainer);
+  Int_t nContainerOutput = 2;
+  for(Int_t iCut = 0; iCut<fnCuts;iCut++){
+    if(fDoPhotonQA == 2){
+      OpenFile(nContainerOutput);
+      PostData(nContainerOutput, tESDConvGammaPtDcazCat[iCut]);
+      nContainerOutput++;
+    }
+    if(fDoMesonQA == 2){
+      OpenFile(nContainerOutput);
+      PostData(nContainerOutput, tESDMesonsInvMassPtDcazMinDcazMaxFlag[iCut]);
+      nContainerOutput++;
+    }
+  }
+
 }
 //_____________________________________________________________________________
 Bool_t AliAnalysisTaskGammaConvV1::Notify()

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.h
@@ -96,8 +96,6 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
     TList**                           fESDList;                                   //
     TList**                           fBackList;                                  //
     TList**                           fMotherList;                                //
-    TList**                           fPhotonDCAList;                             //
-    TList**                           fMesonDCAList;                              //
     TList**                           fTrueList;                                  //
     TList**                           fMCList;                                    //
     TList**                           fHeaderNameList;                            //
@@ -307,7 +305,7 @@ class AliAnalysisTaskGammaConvV1 : public AliAnalysisTaskSE {
 
     AliAnalysisTaskGammaConvV1(const AliAnalysisTaskGammaConvV1&); // Prevent copy-construction
     AliAnalysisTaskGammaConvV1 &operator=(const AliAnalysisTaskGammaConvV1&); // Prevent assignment
-    ClassDef(AliAnalysisTaskGammaConvV1, 42);
+    ClassDef(AliAnalysisTaskGammaConvV1, 43);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
@@ -1037,6 +1037,9 @@ void AddTask_GammaConvCalo_PbPb(  Int_t     trainConfig                     = 1,
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);
   mgr->ConnectOutput(task,1,coutput);
+  for(Int_t i = 0; i<numberOfCuts; i++){
+    mgr->ConnectOutput(task,2+i,mgr->CreateContainer(Form("%s_%s_%s_%s Photon DCA tree",(cuts.GetEventCut(i)).Data(),(cuts.GetPhotonCut(i)).Data(),cuts.GetClusterCut(i).Data(),(cuts.GetMesonCut(i)).Data()), TTree::Class(), AliAnalysisManager::kOutputContainer, Form("GammaConvCalo_%i.root",trainConfig)) );
+  }
 
   return;
 

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pPb.C
@@ -1464,6 +1464,9 @@ void AddTask_GammaConvCalo_pPb( Int_t     trainConfig                   = 1,    
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);
   mgr->ConnectOutput(task,1,coutput);
+  for(Int_t i = 0; i<numberOfCuts; i++){
+    mgr->ConnectOutput(task,2+i,mgr->CreateContainer(Form("%s_%s_%s_%s Photon DCA tree",(cuts.GetEventCut(i)).Data(),(cuts.GetPhotonCut(i)).Data(),cuts.GetClusterCut(i).Data(),(cuts.GetMesonCut(i)).Data()), TTree::Class(), AliAnalysisManager::kOutputContainer, Form("GammaConvCalo_%i.root",trainConfig)) );
+  }
 
   return;
 

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
@@ -1736,6 +1736,9 @@ void AddTask_GammaConvCalo_pp(  Int_t     trainConfig                   = 1,    
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);
   mgr->ConnectOutput(task,1,coutput);
+    for(Int_t i = 0; i<numberOfCuts; i++){
+    mgr->ConnectOutput(task,2+i,mgr->CreateContainer(Form("%s_%s_%s_%s Photon DCA tree",(cuts.GetEventCut(i)).Data(),(cuts.GetPhotonCut(i)).Data(),cuts.GetClusterCut(i).Data(),(cuts.GetMesonCut(i)).Data()), TTree::Class(), AliAnalysisManager::kOutputContainer, Form("GammaConvCalo_%i.root",trainConfig)) );
+  }
 
   return;
 

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
@@ -2669,6 +2669,17 @@ void AddTask_GammaConvV1_PbPb(  Int_t     trainConfig                     = 1,  
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);
   mgr->ConnectOutput(task,1,coutput);
+  Int_t nContainer = 2;
+  for(Int_t i = 0; i<numberOfCuts; i++){
+    if(enableQAPhotonTask>1){
+      mgr->ConnectOutput(task,nContainer,mgr->CreateContainer(Form("%s_%s_%s Photon DCA tree",(cuts.GetEventCut(i)).Data(),(cuts.GetPhotonCut(i)).Data(),(cuts.GetMesonCut(i)).Data()), TTree::Class(), AliAnalysisManager::kOutputContainer, Form("GammaConvV1_%i.root",trainConfig)) );
+      nContainer++;
+    }
+    if(enableQAMesonTask>1){
+      mgr->ConnectOutput(task,nContainer,mgr->CreateContainer(Form("%s_%s_%s Meson DCA tree",(cuts.GetEventCut(i)).Data(),(cuts.GetPhotonCut(i)).Data(),(cuts.GetMesonCut(i)).Data()), TTree::Class(), AliAnalysisManager::kOutputContainer, Form("GammaConvV1_%i.root",trainConfig)) );
+      nContainer++;
+    }
+  }
 
   return;
 

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb2.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb2.C
@@ -381,7 +381,17 @@ void AddTask_GammaConvV1_PbPb2( Int_t         trainConfig                   = 1,
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);
   mgr->ConnectOutput(task,1,coutput);
-
+  Int_t nContainer = 2;
+  for(Int_t i = 0; i<numberOfCuts; i++){
+    if(enableQAPhotonTask>1){
+      mgr->ConnectOutput(task,nContainer,mgr->CreateContainer(Form("%s_%s_%s Photon DCA tree",(cuts.GetEventCut(i)).Data(),(cuts.GetPhotonCut(i)).Data(),(cuts.GetMesonCut(i)).Data()), TTree::Class(), AliAnalysisManager::kOutputContainer, Form("GammaConvV1_%i.root",trainConfig)) );
+      nContainer++;
+    }
+    if(enableQAMesonTask>1){
+      mgr->ConnectOutput(task,nContainer,mgr->CreateContainer(Form("%s_%s_%s Meson DCA tree",(cuts.GetEventCut(i)).Data(),(cuts.GetPhotonCut(i)).Data(),(cuts.GetMesonCut(i)).Data()), TTree::Class(), AliAnalysisManager::kOutputContainer, Form("GammaConvV1_%i.root",trainConfig)) );
+      nContainer++;
+    }
+  }
   return;
 
 }

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pPb.C
@@ -1205,6 +1205,17 @@ void AddTask_GammaConvV1_pPb(   Int_t     trainConfig                   = 1,    
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);
   mgr->ConnectOutput(task,1,coutput);
+  Int_t nContainer = 2;
+  for(Int_t i = 0; i<numberOfCuts; i++){
+    if(enableQAPhotonTask>1){
+      mgr->ConnectOutput(task,nContainer,mgr->CreateContainer(Form("%s_%s_%s Photon DCA tree",(cuts.GetEventCut(i)).Data(),(cuts.GetPhotonCut(i)).Data(),(cuts.GetMesonCut(i)).Data()), TTree::Class(), AliAnalysisManager::kOutputContainer, Form("GammaConvV1_%i.root",trainConfig)) );
+      nContainer++;
+    }
+    if(enableQAMesonTask>1){
+      mgr->ConnectOutput(task,nContainer,mgr->CreateContainer(Form("%s_%s_%s Meson DCA tree",(cuts.GetEventCut(i)).Data(),(cuts.GetPhotonCut(i)).Data(),(cuts.GetMesonCut(i)).Data()), TTree::Class(), AliAnalysisManager::kOutputContainer, Form("GammaConvV1_%i.root",trainConfig)) );
+      nContainer++;
+    }
+  }
 
   return;
 

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pPb2.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pPb2.C
@@ -468,6 +468,17 @@ void AddTask_GammaConvV1_pPb2(  Int_t         trainConfig                   = 1,
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);
   mgr->ConnectOutput(task,1,coutput);
+  Int_t nContainer = 2;
+  for(Int_t i = 0; i<numberOfCuts; i++){
+    if(enableQAPhotonTask>1){
+      mgr->ConnectOutput(task,nContainer,mgr->CreateContainer(Form("%s_%s_%s Photon DCA tree",(cuts.GetEventCut(i)).Data(),(cuts.GetPhotonCut(i)).Data(),(cuts.GetMesonCut(i)).Data()), TTree::Class(), AliAnalysisManager::kOutputContainer, Form("GammaConvV1_%i.root",trainConfig)) );
+      nContainer++;
+    }
+    if(enableQAMesonTask>1){
+      mgr->ConnectOutput(task,nContainer,mgr->CreateContainer(Form("%s_%s_%s Meson DCA tree",(cuts.GetEventCut(i)).Data(),(cuts.GetPhotonCut(i)).Data(),(cuts.GetMesonCut(i)).Data()), TTree::Class(), AliAnalysisManager::kOutputContainer, Form("GammaConvV1_%i.root",trainConfig)) );
+      nContainer++;
+    }
+  }
 
   return;
 }

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pPb3.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pPb3.C
@@ -304,6 +304,17 @@ void AddTask_GammaConvV1_pPb3(  Int_t         trainConfig                   = 1,
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);
   mgr->ConnectOutput(task,1,coutput);
+  Int_t nContainer = 2;
+  for(Int_t i = 0; i<numberOfCuts; i++){
+    if(enableQAPhotonTask>1){
+      mgr->ConnectOutput(task,nContainer,mgr->CreateContainer(Form("%s_%s_%s Photon DCA tree",(cuts.GetEventCut(i)).Data(),(cuts.GetPhotonCut(i)).Data(),(cuts.GetMesonCut(i)).Data()), TTree::Class(), AliAnalysisManager::kOutputContainer, Form("GammaConvV1_%i.root",trainConfig)) );
+      nContainer++;
+    }
+    if(enableQAMesonTask>1){
+      mgr->ConnectOutput(task,nContainer,mgr->CreateContainer(Form("%s_%s_%s Meson DCA tree",(cuts.GetEventCut(i)).Data(),(cuts.GetPhotonCut(i)).Data(),(cuts.GetMesonCut(i)).Data()), TTree::Class(), AliAnalysisManager::kOutputContainer, Form("GammaConvV1_%i.root",trainConfig)) );
+      nContainer++;
+    }
+  }
 
   return;
 

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pp.C
@@ -1421,6 +1421,17 @@ if(!cuts.AreValid()){
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);
   mgr->ConnectOutput(task,1,coutput);
+  Int_t nContainer = 2;
+  for(Int_t i = 0; i<numberOfCuts; i++){
+    if(enableQAPhotonTask>1){
+      mgr->ConnectOutput(task,nContainer,mgr->CreateContainer(Form("%s_%s_%s Photon DCA tree",(cuts.GetEventCut(i)).Data(),(cuts.GetPhotonCut(i)).Data(),(cuts.GetMesonCut(i)).Data()), TTree::Class(), AliAnalysisManager::kOutputContainer, Form("GammaConvV1_%i.root",trainConfig)) );
+      nContainer++;
+    }
+    if(enableQAMesonTask>1){
+      mgr->ConnectOutput(task,nContainer,mgr->CreateContainer(Form("%s_%s_%s Meson DCA tree",(cuts.GetEventCut(i)).Data(),(cuts.GetPhotonCut(i)).Data(),(cuts.GetMesonCut(i)).Data()), TTree::Class(), AliAnalysisManager::kOutputContainer, Form("GammaConvV1_%i.root",trainConfig)) );
+      nContainer++;
+    }
+  }
 
   return;
 

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pp2.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pp2.C
@@ -502,6 +502,17 @@ void AddTask_GammaConvV1_pp2(   Int_t    trainConfig                 = 1,       
   mgr->AddTask(task);
   mgr->ConnectInput(task,0,cinput);
   mgr->ConnectOutput(task,1,coutput);
+  Int_t nContainer = 2;
+  for(Int_t i = 0; i<numberOfCuts; i++){
+    if(enableQAPhotonTask>1){
+      mgr->ConnectOutput(task,nContainer,mgr->CreateContainer(Form("%s_%s_%s Photon DCA tree",(cuts.GetEventCut(i)).Data(),(cuts.GetPhotonCut(i)).Data(),(cuts.GetMesonCut(i)).Data()), TTree::Class(), AliAnalysisManager::kOutputContainer, Form("GammaConvV1_%i.root",trainConfig)) );
+      nContainer++;
+    }
+    if(enableQAMesonTask>1){
+      mgr->ConnectOutput(task,nContainer,mgr->CreateContainer(Form("%s_%s_%s Meson DCA tree",(cuts.GetEventCut(i)).Data(),(cuts.GetPhotonCut(i)).Data(),(cuts.GetMesonCut(i)).Data()), TTree::Class(), AliAnalysisManager::kOutputContainer, Form("GammaConvV1_%i.root",trainConfig)) );
+      nContainer++;
+    }
+  }
 
   return;
 

--- a/PWGGA/GammaConv/macros/AddTask_PhotonQA.C
+++ b/PWGGA/GammaConv/macros/AddTask_PhotonQA.C
@@ -113,6 +113,7 @@ void AddTask_PhotonQA(  TString   V0ReaderEventCutNumber        = "00000003",
         AliAnalysisManager::kOutputContainer, Form("GammaConvV1_QA_%s_%s.root", TaskEventCutnumber.Data(), TaskPhotonCutnumber.Data()));
     mgr->ConnectOutput(fQA,  1, coutput);
   }
+  mgr->ConnectOutput(fQA,2,mgr->CreateContainer("PhotonQA", TTree::Class(), AliAnalysisManager::kOutputContainer, AliAnalysisManager::GetCommonFileName()) );
   mgr->ConnectInput(fQA,0,cinput);
 
 


### PR DESCRIPTION
As the increasing amount of statistics in our data sets lead to the outputfiles no longer merging, i have implemented a change to the tasks that the TTrees are being saved outside of the TList. This allows for ROOT files greater than 1GB. With this change, all future train outputs should be able to merge without problems.
The Afterburners have been adjusted accordingly, too. They can now handle both formats (TTree in TList and TTree outside of TList).