### PR TITLE
PWGGA/GammaConv: added pPb GammaHeavyMeson trainconfigs without 0-20% centrality

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_GammaHeavyMeson_CaloMode_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaHeavyMeson_CaloMode_pPb.C
@@ -252,6 +252,8 @@ void AddTask_GammaHeavyMeson_CaloMode_pPb(  Int_t     selectedMeson             
   } else if (trainConfig == 300){
     cuts.AddCut("80010113","1111100057032230000","01631030000000d0"); // default MB
     cuts.AddCut("80210113","1111100057032230000","01631030000000d0"); // default 0-20
+  } else if (trainConfig == 301){ // same as 300, but no 0-20% centrality
+    cuts.AddCut("80010113","1111100057032230000","01631030000000d0"); // default MB
 
   //****************************************************************
   // Run 2, DMC
@@ -259,6 +261,8 @@ void AddTask_GammaHeavyMeson_CaloMode_pPb(  Int_t     selectedMeson             
   } else if (trainConfig == 400){
     cuts.AddCut("80010113","3885500057032230000","01631030000000d0"); // default MB
     cuts.AddCut("80210113","3885500057032230000","01631030000000d0"); // default 0-20
+  } else if (trainConfig == 401){ // same as 400, but no 0-20% centrality
+    cuts.AddCut("80010113","3885500057032230000","01631030000000d0"); // default MB
 
   //****************************************************************
   // Run 2, PHOS
@@ -266,6 +270,8 @@ void AddTask_GammaHeavyMeson_CaloMode_pPb(  Int_t     selectedMeson             
   } else if (trainConfig == 500){
     cuts.AddCut("80010113","2446600051013200000","0163103000000010"); // default MB
     cuts.AddCut("80210113","2446600051013200000","0163103000000010"); // default 0-20
+  } else if (trainConfig == 501){ // same as 500, but no 0-20% centrality
+    cuts.AddCut("80010113","2446600051013200000","0163103000000010"); // default MB
 
   } else {
     Error(Form("HeavyNeutralMesonToGG_%i_%i", mesonRecoMode, trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");

--- a/PWGGA/GammaConv/macros/AddTask_GammaHeavyMeson_ConvMode_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaHeavyMeson_ConvMode_pPb.C
@@ -215,6 +215,8 @@ void AddTask_GammaHeavyMeson_ConvMode_pPb(  Int_t     selectedMeson             
   } else if (trainConfig == 100){
     cuts.AddCut("80010113","00200009327000008250400000","0163103000000010");
     cuts.AddCut("80210113","00200009327000008250400000","0163103000000010");
+  } else if (trainConfig == 101){ // same as 100, but no 0-20% centrality
+    cuts.AddCut("80010113","00200009327000008250400000","0163103000000010");
   } else {
     Error(Form("HeavyNeutralMesonToGG_%i",trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");
     return;

--- a/PWGGA/GammaConv/macros/AddTask_GammaHeavyMeson_MixedMode_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaHeavyMeson_MixedMode_pPb.C
@@ -255,6 +255,8 @@ void AddTask_GammaHeavyMeson_MixedMode_pPb( Int_t     selectedMeson             
   } else if (trainConfig == 300){
     cuts.AddCut("80010113","00200009327000008250400000","1111100057022230000","0163103000000010");
     cuts.AddCut("80210113","00200009327000008250400000","1111100057022230000","0163103000000010");
+  } else if (trainConfig == 301){ // same as 300, but no 0-20% centrality
+    cuts.AddCut("80010113","00200009327000008250400000","1111100057022230000","0163103000000010");
 
   //****************************************************************
   // Run 2, DMC
@@ -262,6 +264,8 @@ void AddTask_GammaHeavyMeson_MixedMode_pPb( Int_t     selectedMeson             
   } else if (trainConfig == 400){
     cuts.AddCut("80010113","00200009327000008250400000","3885500057032230000","0163103000000010");
     cuts.AddCut("80210113","00200009327000008250400000","3885500057032230000","0163103000000010");
+  } else if (trainConfig == 401){ // same as 400, but no 0-20% centrality
+    cuts.AddCut("80010113","00200009327000008250400000","3885500057032230000","0163103000000010");
 
   //****************************************************************
   // Run 2, PHOS
@@ -269,6 +273,8 @@ void AddTask_GammaHeavyMeson_MixedMode_pPb( Int_t     selectedMeson             
   } else if (trainConfig == 500){
     cuts.AddCut("80010113","00200009327000008250400000","2446600051013200000","0163103000000010"); // PHOS group standard +-50ns
     cuts.AddCut("80210113","00200009327000008250400000","2446600051013200000","0163103000000010");
+  } else if (trainConfig == 501){ // same as 500, but no 0-20% centrality
+    cuts.AddCut("80010113","00200009327000008250400000","2446600051013200000","0163103000000010"); // PHOS group standard +-50ns
   } else {
     Error(Form("HeavyNeutralMesonToGG_%i",trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");
     return;


### PR DESCRIPTION
Created 'thinner' copies of p-Pb GammaHeavymeson trainconfigs (all three methods) that contain only 0-100% centrality