### PR TITLE
PWGGA/GammaConv: added  addtasks for pPb NeutralMesonPiPlPiMiNeutralMes

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pPb.C
@@ -1,0 +1,449 @@
+/**************************************************************************
+ * Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: Remco de Boer                                                  *
+ * Version 1.0                                                            *
+ *                                                                        *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+//***************************************************************************************
+//This AddTask is supposed to set up the main task
+//($ALIPHYSICS/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.cxx) for
+//pPb together with all supporting classes
+//***************************************************************************************
+
+//***************************************************************************************
+//CutHandler contains all cuts for a certain analysis and trainconfig,
+//it automatically checks length of cutStrings and takes care of the number of added cuts,
+//no specification of the variable 'numberOfCuts' needed anymore.
+//***************************************************************************************
+class CutHandlerNeutralCalo{
+  public:
+    CutHandlerNeutralCalo(Int_t nMax=10){
+      nCuts=0; nMaxCuts=nMax; validCuts = true;
+      eventCutArray = new TString[nMaxCuts]; clusterCutArray = new TString[nMaxCuts]; pionCutArray = new TString[nMaxCuts]; neutralPionCutArray = new TString[nMaxCuts]; mesonCutArray = new TString[nMaxCuts];
+      for(Int_t i=0; i<nMaxCuts; i++) {eventCutArray[i] = ""; clusterCutArray[i] = ""; pionCutArray[i] = ""; neutralPionCutArray[i] = ""; mesonCutArray[i] = "";}
+    }
+
+    void AddCut(TString eventCut, TString clusterCut, TString pionCut, TString neutralPionCut, TString mesonCut){
+      if(nCuts>=nMaxCuts) {cout << "ERROR in CutHandlerNeutralCalo: Exceeded maximum number of cuts!" << endl; validCuts = false; return;}
+      if( eventCut.Length()!=8 || clusterCut.Length()!=19 || pionCut.Length()!=9 || neutralPionCut.Length()!=16 || mesonCut.Length()!=16 ) {cout << "ERROR in CutHandlerNeutralCalo: Incorrect length of cut string!" << endl; validCuts = false; return;}
+      eventCutArray[nCuts]=eventCut; clusterCutArray[nCuts]=clusterCut; pionCutArray[nCuts]=pionCut; neutralPionCutArray[nCuts]=neutralPionCut; mesonCutArray[nCuts]=mesonCut;
+      nCuts++;
+      return;
+    }
+    Bool_t AreValid(){return validCuts;}
+    Int_t GetNCuts(){if(validCuts) return nCuts; else return 0;}
+    TString GetEventCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return eventCutArray[i]; else{cout << "ERROR in CutHandlerNeutralCalo: GetEventCut wrong index i" << endl;return "";}}
+    TString GetClusterCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return clusterCutArray[i]; else {cout << "ERROR in CutHandlerNeutralCalo: GetClusterCut wrong index i" << endl;return "";}}
+    TString GetPionCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return pionCutArray[i]; else {cout << "ERROR in CutHandlerNeutralCalo: GetPionCut wrong index i" << endl;return "";}}
+    TString GetNeutralPionCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return neutralPionCutArray[i]; else {cout << "ERROR in CutHandlerNeutralCalo: GetNeutralPionCut wrong index i" << endl;return "";}}
+    TString GetMesonCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return mesonCutArray[i]; else {cout << "ERROR in CutHandlerNeutralCalo: GetMesonCut wrong index i" << endl;return "";}}
+  private:
+    Bool_t validCuts;
+    Int_t nCuts; Int_t nMaxCuts;
+    TString* eventCutArray;
+    TString* clusterCutArray;
+    TString* pionCutArray;
+    TString* neutralPionCutArray;
+    TString* mesonCutArray;
+};
+
+//***************************************************************************************
+//main function
+//***************************************************************************************
+void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pPb(
+    Int_t trainConfig                 = 1,
+    Bool_t isMC                       = kFALSE,                           // run MC
+    Int_t selectHeavyNeutralMeson     = 0,                                // run eta prime instead of omega
+    Int_t enableQAMesonTask           = 1,                                // enable QA in AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson
+    TString fileNameInputForWeighting = "MCSpectraInput.root",            // path to file for weigting input
+    Bool_t doWeighting                = kFALSE,                           // enable Weighting
+    TString generatorName             = "HIJING",
+    TString cutnumberAODBranch        = "000000006008400001001500000",
+    Double_t tolerance                = -1,
+    TString periodNameV0Reader        = "",                               // period Name for V0Reader
+    Int_t runLightOutput              = 0,                                // run light output option 0: no light output 1: most cut histos stiched off 2: unecessary omega hists turned off as well
+    TString additionalTrainConfig     = "0"                               // additional counter for trainconfig, this has to be always the last parameter
+  ) {
+
+  //parse additionalTrainConfig flag
+  TObjArray *rAddConfigArr = additionalTrainConfig.Tokenize("_");
+  if(rAddConfigArr->GetEntries()<1){cout << "ERROR during parsing of additionalTrainConfig String '" << additionalTrainConfig.Data() << "'" << endl; return;}
+  TObjString* rAdditionalTrainConfig;
+  for(Int_t i = 0; i<rAddConfigArr->GetEntries() ; i++){
+    if(i==0) rAdditionalTrainConfig = (TObjString*)rAddConfigArr->At(i);
+    else{
+      TObjString* temp = (TObjString*) rAddConfigArr->At(i);
+      TString tempStr = temp->GetString();
+      cout << "INFO: nothing to do, no definition available!" << endl;
+    }
+  }
+  TString sAdditionalTrainConfig = rAdditionalTrainConfig->GetString();
+  if (sAdditionalTrainConfig.Atoi() > 0){
+    trainConfig = trainConfig + sAdditionalTrainConfig.Atoi();
+    cout << "INFO: AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pPb running additionalTrainConfig '" << sAdditionalTrainConfig.Atoi() << "', train config: '" << trainConfig << "'" << endl;
+  }
+
+  Int_t isHeavyIon = 0;
+  Int_t neutralPionMode = 2;
+
+  // ================== GetAnalysisManager ===============================
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    Error(Form("AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pPb_%i",trainConfig), "No analysis manager found.");
+    return ;
+  }
+
+  // ================== GetInputEventHandler =============================
+  AliVEventHandler *inputHandler=mgr->GetInputEventHandler();
+
+  //========= Add PID Reponse to ANALYSIS manager ====
+  if(!(AliPIDResponse*)mgr->GetTask("PIDResponseTask")){
+    gROOT->LoadMacro("$ALICE_ROOT/ANALYSIS/macros/AddTaskPIDResponse.C");
+    AddTaskPIDResponse(isMC);
+  }
+
+  //=========  Set Cutnumber for V0Reader ================================
+  TString cutnumberPhoton = "06000008400100001500000000";
+  if (  periodNameV0Reader.CompareTo("LHC16f") == 0 || periodNameV0Reader.CompareTo("LHC17g")==0 || periodNameV0Reader.CompareTo("LHC18c")==0 ||
+        periodNameV0Reader.CompareTo("LHC17d1") == 0  || periodNameV0Reader.CompareTo("LHC17d12")==0 ||
+        periodNameV0Reader.CompareTo("LHC17h3")==0 || periodNameV0Reader.CompareTo("LHC17k1")==0 ||
+        periodNameV0Reader.CompareTo("LHC17f8b") == 0 ||
+        periodNameV0Reader.CompareTo("LHC16P1JJLowB") == 0 || periodNameV0Reader.CompareTo("LHC16P1Pyt8LowB") == 0 )
+    cutnumberPhoton         = "00000088400000000100000000";
+
+  TString cutnumberEvent = "00000003";
+  TString PionCuts      = "000000200";            //Electron Cuts
+
+
+  AliAnalysisDataContainer *cinput = mgr->GetCommonInputContainer();
+
+  //========= Add V0 Reader to  ANALYSIS manager if not yet existent =====
+  TString V0ReaderName = Form("V0ReaderV1_%s_%s",cutnumberEvent.Data(),cutnumberPhoton.Data());
+  if( !(AliV0ReaderV1*)mgr->GetTask(V0ReaderName.Data()) ){
+    AliV0ReaderV1 *fV0ReaderV1 = new AliV0ReaderV1(V0ReaderName.Data());
+    if (periodNameV0Reader.CompareTo("") != 0) fV0ReaderV1->SetPeriodName(periodNameV0Reader);
+    fV0ReaderV1->SetUseOwnXYZCalculation(kTRUE);
+    fV0ReaderV1->SetCreateAODs(kFALSE);// AOD Output
+    fV0ReaderV1->SetUseAODConversionPhoton(kTRUE);
+
+    if (!mgr) {
+      Error("AddTask_V0ReaderV1", "No analysis manager found.");
+      return;
+    }
+
+    AliConvEventCuts *fEventCuts=NULL;
+    if(cutnumberEvent!=""){
+      fEventCuts= new AliConvEventCuts(cutnumberEvent.Data(),cutnumberEvent.Data());
+      fEventCuts->SetPreSelectionCutFlag(kTRUE);
+      fEventCuts->SetV0ReaderName(V0ReaderName);
+      if (periodNameV0Reader.CompareTo("") != 0) fEventCuts->SetPeriodEnum(periodNameV0Reader);
+      if(runLightOutput>0) fEventCuts->SetLightOutput(kTRUE);
+      if(fEventCuts->InitializeCutsFromCutString(cutnumberEvent.Data())){
+        fV0ReaderV1->SetEventCuts(fEventCuts);
+        fEventCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+
+    // Set AnalysisCut Number
+    AliConversionPhotonCuts *fCuts=NULL;
+    if(cutnumberPhoton!=""){
+      fCuts= new AliConversionPhotonCuts(cutnumberPhoton.Data(),cutnumberPhoton.Data());
+      fCuts->SetPreSelectionCutFlag(kTRUE);
+      fCuts->SetIsHeavyIon(isHeavyIon);
+      fCuts->SetV0ReaderName(V0ReaderName);
+      if(runLightOutput>0) fCuts->SetLightOutput(kTRUE);
+      if(fCuts->InitializeCutsFromCutString(cutnumberPhoton.Data())){
+        fV0ReaderV1->SetConversionCuts(fCuts);
+        fCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+
+    if(inputHandler->IsA()==AliAODInputHandler::Class()){
+    // AOD mode
+      fV0ReaderV1->AliV0ReaderV1::SetDeltaAODBranchName(Form("GammaConv_%s_gamma",cutnumberAODBranch.Data()));
+    }
+    fV0ReaderV1->Init();
+
+    AliLog::SetGlobalLogLevel(AliLog::kFatal);
+
+    //connect input V0Reader
+    mgr->AddTask(fV0ReaderV1);
+    mgr->ConnectInput(fV0ReaderV1,0,cinput);
+  }
+
+  //================================================
+  //========= Add Pion Selector ====================
+  if( !(AliPrimaryPionSelector*)mgr->GetTask("PionSelector") ){
+    AliPrimaryPionSelector *fPionSelector = new AliPrimaryPionSelector("PionSelector");
+    AliPrimaryPionCuts *fPionCuts=0;
+    if( PionCuts!=""){
+      fPionCuts= new AliPrimaryPionCuts(PionCuts.Data(),PionCuts.Data());
+      if(runLightOutput>0) fPionCuts->SetLightOutput(kTRUE);
+      //if(runLightOutput>0) fPionCuts->SetLightOutput(kTRUE);
+      if(fPionCuts->InitializeCutsFromCutString(PionCuts.Data())){
+        fPionSelector->SetPrimaryPionCuts(fPionCuts);
+        fPionCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+
+    fPionSelector->Init();
+    mgr->AddTask(fPionSelector);
+
+    AliAnalysisDataContainer *cinput1  = mgr->GetCommonInputContainer();
+    mgr->ConnectInput (fPionSelector,0,cinput1);
+  }
+
+  AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson *task=NULL;
+  task= new AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson(Form("GammaConvNeutralMesonPiPlPiMiNeutralMeson_%i_%i",neutralPionMode, trainConfig));
+  task->SetIsHeavyIon(isHeavyIon);
+  task->SetIsMC(isMC);
+  task->SetV0ReaderName(V0ReaderName);
+  if(runLightOutput>1) task->SetLightOutput(kTRUE);
+  task->SetTolerance(tolerance);
+
+  CutHandlerNeutralCalo cuts;
+
+
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  //                                          ETA MESON
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  if( trainConfig == 1 ) {
+    // everything open, min pt charged pi = 100 MeV
+    cuts.AddCut("80000113","1111113047032230000","000010400","0103503a00000000","0103503000000000"); // cent 0-100%
+    cuts.AddCut("80200113","1111113047032230000","000010400","0103503a00000000","0103503000000000"); // cent 0-20%
+  } else if( trainConfig == 2 ) {
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, min pt charged pi = 100 MeV
+    cuts.AddCut("80000113","1111100047032230000","002010700","0103503a00000000","0103503000000000"); // cent 0-100%
+    cuts.AddCut("80200113","1111100047032230000","002010700","0103503a00000000","0103503000000000"); // cent 0-20%
+  } else if( trainConfig == 3 ) {
+    // eta < 0.9
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, pi+pi- mass cut of 0.65, min pt charged pi = 100 MeV
+    // closing neural pion cuts, 0.1 < M_gamma,gamma < 0.15
+    // maxChi2 per cluster TPC <4, require TPC refit, DCA XY pT dependend 0.0182+0.0350/pt^1.01, DCA_Z = 3.0
+    // timing cluster cut open
+    cuts.AddCut("80010113","1111100047032230000","30a330708","0103503400000000","0153503000000000");
+    cuts.AddCut("80210113","1111100047032230000","30a330708","0103503400000000","0153503000000000");
+
+  } else if( trainConfig == 51 ) { // same as 1, but 0-20% centrality excluded
+    cuts.AddCut("80000113","1111113047032230000","000010400","0103503a00000000","0103503000000000");
+    cuts.AddCut("80000113","1111113047032230000","000010400","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 52 ) { // same as 2, but 0-20% centrality excluded
+    cuts.AddCut("80000113","1111100047032230000","002010700","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 53 ) { // same as 3, but 0-20% centrality excluded
+    cuts.AddCut("80010113","1111100047032230000","30a330708","0103503400000000","0153503000000000");
+
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  //                                          OMEGA MESON
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  } else if( trainConfig == 100 ) {
+    // everything open, min pt charged pi = 100 MeV
+    cuts.AddCut("80000113","1111100047032230000","000010400","0103503a00000000","0103503000000000"); // cent 0-100%
+    cuts.AddCut("80200113","1111100047032230000","000010400","0103503a00000000","0103503000000000"); // cent 0-20%
+  } else if( trainConfig == 101 ) {
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, min pt charged pi = 100 MeV
+    cuts.AddCut("80000113","1111100047032230000","002010700","0103503a00000000","0103503000000000"); // cent 0-100%
+    cuts.AddCut("80200113","1111100047032230000","002010700","0103503a00000000","0103503000000000"); // cent 0-20%
+  } else if( trainConfig == 102 ) {
+    // eta < 0.9
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, pi+pi- mass cut of 0.65, min pt charged pi = 100 MeV
+    // closing neural pion cuts, 0.1 < M_gamma,gamma < 0.15
+    // maxChi2 per cluster TPC <4, require TPC refit, DCA XY pT dependend 0.0182+0.0350/pt^1.01, DCA_Z = 3.0
+    // timing cluster cut open
+    cuts.AddCut("80010113","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // cent 0-100%
+    cuts.AddCut("80210113","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // cent 0-20%
+
+  } else if( trainConfig == 150 ) { // same as 100, but 0-20% centrality excluded
+    cuts.AddCut("80000113","1111100047032230000","000010400","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 151 ) { // same as 101, but 0-20% centrality excluded
+    cuts.AddCut("80000113","1111100047032230000","002010700","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 152 ) { // same as 102, but 0-20% centrality excluded
+    cuts.AddCut("80010113","1111100047032230000","30a330708","0103503400000000","0153503000000000");
+
+
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  //                                          ETA PRIME MESON
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+  } else if( trainConfig == 200 ) {
+    // everything open, min pt charged pi = 100 MeV
+    cuts.AddCut("80000113","1111100047032230000","000010400","0103503m00000000","0103503000000000");
+    cuts.AddCut("80200113","1111100047032230000","000010400","0103503m00000000","0103503000000000");
+  } else if( trainConfig == 201 ) {
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, min pt charged pi = 100 MeV
+    cuts.AddCut("80000113","1111100047032230000","002010700","0103503m00000000","0103503000000000");
+    cuts.AddCut("80200113","1111100047032230000","002010700","0103503m00000000","0103503000000000");
+  } else if( trainConfig == 202 ) {
+    // eta < 0.9
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, pi+pi- mass cut of 1.5, min pt charged pi = 100 MeV
+    // closing neural pion cuts, 0.5 < M_gamma,gamma < 0.6
+    // maxChi2 per cluster TPC <4, require TPC refit, DCA XY pT dependend 0.0182+0.0350/pt^1.01, DCA_Z = 3.0
+    // timing cluster cut open
+    cuts.AddCut("80010113","1111100047032230000","30a330709","0103503l00000000","0153503000000000"); // all of the above
+    cuts.AddCut("80010113","1111100047032230000","30a330709","0103503m00000000","0153503000000000"); // 0.4-0.7 eta mass cut
+    cuts.AddCut("80210113","1111100047032230000","30a330709","0103503l00000000","0153503000000000"); // all of the above
+    cuts.AddCut("80210113","1111100047032230000","30a330709","0103503m00000000","0153503000000000"); // 0.4-0.7 eta mass cut
+  } else if( trainConfig == 204 ) {
+    // same as 202 but with mass cut variations
+    cuts.AddCut("80010113","1111100047032230000","30a330700","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 10
+    cuts.AddCut("80010113","1111100047032230000","30a330701","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 1
+    cuts.AddCut("80010113","1111100047032230000","30a330708","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 0.85
+    cuts.AddCut("80210113","1111100047032230000","30a330700","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 10
+    cuts.AddCut("80210113","1111100047032230000","30a330701","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 1
+    cuts.AddCut("80210113","1111100047032230000","30a330708","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 0.85
+
+  } else if( trainConfig == 250 ) { // same as 200, but 0-20% centrality excluded
+    cuts.AddCut("80000113","1111100047032230000","000010400","0103503m00000000","0103503000000000");
+  } else if( trainConfig == 251 ) { // same as 201, but 0-20% centrality excluded
+    cuts.AddCut("80000113","1111100047032230000","002010700","0103503m00000000","0103503000000000");
+  } else if( trainConfig == 252 ) { // same as 202, but 0-20% centrality excluded
+    cuts.AddCut("80010113","1111100047032230000","30a330709","0103503l00000000","0153503000000000");
+    cuts.AddCut("80010113","1111100047032230000","30a330709","0103503m00000000","0153503000000000");
+  } else if( trainConfig == 254 ) { // same as 204, but 0-20% centrality excluded
+    cuts.AddCut("80010113","1111100047032230000","30a330700","0103503l00000000","0153503000000000");
+    cuts.AddCut("80010113","1111100047032230000","30a330701","0103503l00000000","0153503000000000");
+    cuts.AddCut("80010113","1111100047032230000","30a330708","0103503l00000000","0153503000000000");
+
+  } else {
+    Error(Form("GammaConvNeutralMeson_CaloMode_%i",trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");
+    return;
+  }
+
+  if(!cuts.AreValid()){
+    cout << "\n\n****************************************************" << endl;
+    cout << "ERROR: No valid cuts stored in CutHandlerNeutralCalo! Returning..." << endl;
+    cout << "****************************************************\n\n" << endl;
+    return;
+  }
+
+  Int_t numberOfCuts = cuts.GetNCuts();
+
+  TList *EventCutList = new TList();
+  TList *ClusterCutList  = new TList();
+  TList *NeutralPionCutList = new TList();
+  TList *MesonCutList = new TList();
+  TList *PionCutList  = new TList();
+
+  TList *HeaderList = new TList();
+  TObjString *Header1 = new TObjString("pi0_1");
+  HeaderList->Add(Header1);
+  TObjString *Header3 = new TObjString("eta_2");
+  HeaderList->Add(Header3);
+
+  EventCutList->SetOwner(kTRUE);
+  AliConvEventCuts **analysisEventCuts = new AliConvEventCuts*[numberOfCuts];
+  ClusterCutList->SetOwner(kTRUE);
+  AliCaloPhotonCuts **analysisClusterCuts = new AliCaloPhotonCuts*[numberOfCuts];
+  NeutralPionCutList->SetOwner(kTRUE);
+  AliConversionMesonCuts **analysisNeutralPionCuts   = new AliConversionMesonCuts*[numberOfCuts];
+  MesonCutList->SetOwner(kTRUE);
+  AliConversionMesonCuts **analysisMesonCuts   = new AliConversionMesonCuts*[numberOfCuts];
+  PionCutList->SetOwner(kTRUE);
+  AliPrimaryPionCuts **analysisPionCuts     = new AliPrimaryPionCuts*[numberOfCuts];
+
+  for(Int_t i = 0; i<numberOfCuts; i++){
+    //create AliCaloTrackMatcher instance, if there is none present
+    TString caloCutPos = cuts.GetClusterCut(i);
+    caloCutPos.Resize(1);
+    TString TrackMatcherName = Form("CaloTrackMatcher_%s",caloCutPos.Data());
+    if( !(AliCaloTrackMatcher*)mgr->GetTask(TrackMatcherName.Data()) ){
+      AliCaloTrackMatcher* fTrackMatcher = new AliCaloTrackMatcher(TrackMatcherName.Data(),caloCutPos.Atoi());
+      fTrackMatcher->SetV0ReaderName(V0ReaderName);
+      mgr->AddTask(fTrackMatcher);
+      mgr->ConnectInput(fTrackMatcher,0,cinput);
+    }
+
+    analysisEventCuts[i] = new AliConvEventCuts();
+    analysisEventCuts[i]->SetV0ReaderName(V0ReaderName);
+    if(runLightOutput>0) analysisEventCuts[i]->SetLightOutput(kTRUE);
+    analysisEventCuts[i]->InitializeCutsFromCutString((cuts.GetEventCut(i)).Data());
+    if (periodNameV0Reader.CompareTo("") != 0) analysisEventCuts[i]->SetPeriodEnum(periodNameV0Reader);
+    EventCutList->Add(analysisEventCuts[i]);
+    analysisEventCuts[i]->SetFillCutHistograms("",kFALSE);
+
+    analysisClusterCuts[i] = new AliCaloPhotonCuts();
+    analysisClusterCuts[i]->SetV0ReaderName(V0ReaderName);
+    if(runLightOutput>0) analysisClusterCuts[i]->SetLightOutput(kTRUE);
+    analysisClusterCuts[i]->SetCaloTrackMatcherName(TrackMatcherName);
+    if( ! analysisClusterCuts[i]->InitializeCutsFromCutString((cuts.GetClusterCut(i)).Data()) ) {
+      cout<<"ERROR: analysisClusterCuts [" <<i<<"]"<<endl;
+      return 0;
+    } else {
+      analysisClusterCuts[i]->InitializeCutsFromCutString((cuts.GetClusterCut(i)).Data());
+      ClusterCutList->Add(analysisClusterCuts[i]);
+      analysisClusterCuts[i]->SetFillCutHistograms("");
+    }
+
+    analysisNeutralPionCuts[i] = new AliConversionMesonCuts();
+    if(runLightOutput>0) analysisNeutralPionCuts[i]->SetLightOutput(kTRUE);
+    if( ! analysisNeutralPionCuts[i]->InitializeCutsFromCutString((cuts.GetNeutralPionCut(i)).Data()) ) {
+      cout<<"ERROR: analysisMesonCuts [ " <<i<<" ] "<<endl;
+      return 0;
+    } else {
+      NeutralPionCutList->Add(analysisNeutralPionCuts[i]);
+      analysisNeutralPionCuts[i]->SetFillCutHistograms("");
+    }
+
+    analysisMesonCuts[i] = new AliConversionMesonCuts();
+    if(runLightOutput>0) analysisMesonCuts[i]->SetLightOutput(kTRUE);
+    if( ! analysisMesonCuts[i]->InitializeCutsFromCutString((cuts.GetMesonCut(i)).Data()) ) {
+      cout<<"ERROR: analysisMesonCuts [ " <<i<<" ] "<<endl;
+      return 0;
+    } else {
+      MesonCutList->Add(analysisMesonCuts[i]);
+      analysisMesonCuts[i]->SetFillCutHistograms("");
+    }
+    analysisEventCuts[i]->SetAcceptedHeader(HeaderList);
+
+    TString cutName( Form("%s_%s_%s_%s_%s",(cuts.GetEventCut(i)).Data(), (cuts.GetClusterCut(i)).Data(),(cuts.GetPionCut(i)).Data(),(cuts.GetNeutralPionCut(i)).Data(), (cuts.GetMesonCut(i)).Data() ) );
+    analysisPionCuts[i] = new AliPrimaryPionCuts();
+    if(runLightOutput>0) analysisPionCuts[i]->SetLightOutput(kTRUE);
+
+        if( !analysisPionCuts[i]->InitializeCutsFromCutString((cuts.GetPionCut(i)).Data())) {
+      cout<< "ERROR:  analysisPionCuts [ " <<i<<" ] "<<endl;
+      return 0;
+    } else {
+      PionCutList->Add(analysisPionCuts[i]);
+      analysisPionCuts[i]->SetFillCutHistograms("",kFALSE,cutName);
+    }
+  }
+
+  task->SetNDMRecoMode(neutralPionMode);
+  task->SetEventCutList(numberOfCuts,EventCutList);
+  task->SetClusterCutList(ClusterCutList);
+  task->SetNeutralPionCutList(NeutralPionCutList);
+  task->SetMesonCutList(MesonCutList);
+  task->SetPionCutList(PionCutList);
+
+  task->SetMoveParticleAccordingToVertex(kTRUE);
+  task->SetSelectedHeavyNeutralMeson(selectHeavyNeutralMeson);
+
+  task->SetDoMesonQA(enableQAMesonTask );
+
+  //connect containers
+  AliAnalysisDataContainer *coutput =
+  mgr->CreateContainer(Form("GammaConvNeutralMesonPiPlPiMiNeutralMeson_%i_%i_%i.root",selectHeavyNeutralMeson,neutralPionMode, trainConfig), TList::Class(),
+              AliAnalysisManager::kOutputContainer,Form("GammaConvNeutralMesonPiPlPiMiNeutralMeson_%i_%i_%i.root",selectHeavyNeutralMeson,neutralPionMode, trainConfig));
+
+  mgr->AddTask(task);
+  mgr->ConnectInput(task,0,cinput);
+  mgr->ConnectOutput(task,1,coutput);
+
+  return;
+
+}

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pPb.C
@@ -1,0 +1,435 @@
+/**************************************************************************
+ * Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: Remco de Boer                                                  *
+ * Version 1.0                                                            *
+ *                                                                        *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+//***************************************************************************************
+//This AddTask is supposed to set up the main task
+//($ALIPHYSICS/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.cxx) for
+//pPb together with all supporting classes
+//***************************************************************************************
+
+//***************************************************************************************
+//CutHandler contains all cuts for a certain analysis and trainconfig,
+//it automatically checks length of cutStrings and takes care of the number of added cuts,
+//no specification of the variable 'numberOfCuts' needed anymore.
+//***************************************************************************************
+class CutHandlerNeutralConv{
+  public:
+    CutHandlerNeutralConv(Int_t nMax=10){
+      nCuts=0; nMaxCuts=nMax; validCuts = true;
+      eventCutArray = new TString[nMaxCuts]; conversionCutArray = new TString[nMaxCuts]; pionCutArray = new TString[nMaxCuts]; neutralPionCutArray = new TString[nMaxCuts]; mesonCutArray = new TString[nMaxCuts];
+      for(Int_t i=0; i<nMaxCuts; i++) {eventCutArray[i] = ""; conversionCutArray[i] = ""; pionCutArray[i] = ""; neutralPionCutArray[i] = ""; mesonCutArray[i] = "";}
+    }
+
+    void AddCut(TString eventCut, TString conversionCut, TString pionCut, TString neutralPionCut, TString mesonCut){
+      if(nCuts>=nMaxCuts) {cout << "ERROR in CutHandlerNeutralConv: Exceeded maximum number of cuts!" << endl; validCuts = false; return;}
+      if( eventCut.Length()!=8 || conversionCut.Length()!=26 || pionCut.Length()!=9 || neutralPionCut.Length()!=16 || mesonCut.Length()!=16 ) {cout << "ERROR in CutHandlerNeutralConv: Incorrect length of cut string!" << endl; validCuts = false; return;}
+      eventCutArray[nCuts]=eventCut; conversionCutArray[nCuts]=conversionCut; pionCutArray[nCuts]=pionCut; neutralPionCutArray[nCuts]=neutralPionCut; mesonCutArray[nCuts]=mesonCut;
+      nCuts++;
+      return;
+    }
+    Bool_t AreValid(){return validCuts;}
+    Int_t GetNCuts(){if(validCuts) return nCuts; else return 0;}
+    TString GetEventCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return eventCutArray[i]; else{cout << "ERROR in CutHandlerNeutralConv: GetEventCut wrong index i" << endl;return "";}}
+    TString GetConversionCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return conversionCutArray[i]; else {cout << "ERROR in CutHandlerNeutralConv: GetConversionCut wrong index i" << endl;return "";}}
+    TString GetPionCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return pionCutArray[i]; else {cout << "ERROR in CutHandlerNeutralConv: GetPionCut wrong index i" << endl;return "";}}
+    TString GetNeutralPionCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return neutralPionCutArray[i]; else {cout << "ERROR in CutHandlerNeutralConv: GetNeutralPionCut wrong index i" << endl;return "";}}
+    TString GetMesonCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return mesonCutArray[i]; else {cout << "ERROR in CutHandlerNeutralConv: GetMesonCut wrong index i" << endl;return "";}}
+  private:
+    Bool_t validCuts;
+    Int_t nCuts; Int_t nMaxCuts;
+    TString* eventCutArray;
+    TString* conversionCutArray;
+    TString* pionCutArray;
+    TString* neutralPionCutArray;
+    TString* mesonCutArray;
+};
+
+//***************************************************************************************
+//main function
+//***************************************************************************************
+void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pPb(
+    Int_t trainConfig                 = 1,
+    Bool_t isMC                       = kFALSE,                           // run MC
+    Int_t selectHeavyNeutralMeson     = 0,                                // run eta prime instead of omega
+    Int_t enableQAMesonTask           = 1,                                // enable QA in AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson
+    TString fileNameInputForWeighting = "MCSpectraInput.root",            // path to file for weigting input
+    Bool_t doWeighting                = kFALSE,                           // enable Weighting
+    TString generatorName             = "HIJING",
+    TString cutnumberAODBranch        = "000000006008400001001500000",
+    Double_t tolerance                = -1,
+    TString periodNameV0Reader        = "",                               // period Name for V0Reader
+    Int_t runLightOutput              = 0,                                // run light output option 0: no light output 1: most cut histos stiched off 2: unecessary omega hists turned off as well
+    TString additionalTrainConfig     = "0"                               // additional counter for trainconfig, this has to be always the last parameter
+  ) {
+
+  //parse additionalTrainConfig flag
+  TObjArray *rAddConfigArr = additionalTrainConfig.Tokenize("_");
+  if(rAddConfigArr->GetEntries()<1){cout << "ERROR during parsing of additionalTrainConfig String '" << additionalTrainConfig.Data() << "'" << endl; return;}
+  TObjString* rAdditionalTrainConfig;
+  for(Int_t i = 0; i<rAddConfigArr->GetEntries() ; i++){
+    if(i==0) rAdditionalTrainConfig = (TObjString*)rAddConfigArr->At(i);
+    else{
+      TObjString* temp = (TObjString*) rAddConfigArr->At(i);
+      TString tempStr = temp->GetString();
+      cout << "INFO: nothing to do, no definition available!" << endl;
+    }
+  }
+  TString sAdditionalTrainConfig = rAdditionalTrainConfig->GetString();
+  if (sAdditionalTrainConfig.Atoi() > 0){
+    trainConfig = trainConfig + sAdditionalTrainConfig.Atoi();
+    cout << "INFO: AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pPb running additionalTrainConfig '" << sAdditionalTrainConfig.Atoi() << "', train config: '" << trainConfig << "'" << endl;
+  }
+
+  Int_t isHeavyIon = 0;
+  Int_t neutralPionMode = 0;
+
+  // ================== GetAnalysisManager ===============================
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    Error(Form("AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_ConvMode_pPb_%i",trainConfig), "No analysis manager found.");
+    return ;
+  }
+
+  // ================== GetInputEventHandler =============================
+  AliVEventHandler *inputHandler=mgr->GetInputEventHandler();
+
+  //========= Add PID Reponse to ANALYSIS manager ====
+  if(!(AliPIDResponse*)mgr->GetTask("PIDResponseTask")){
+    gROOT->LoadMacro("$ALICE_ROOT/ANALYSIS/macros/AddTaskPIDResponse.C");
+    AddTaskPIDResponse(isMC);
+  }
+
+  //=========  Set Cutnumber for V0Reader ================================
+  TString cutnumberPhoton   = "06000008400100001500000000";
+  if (  periodNameV0Reader.CompareTo("LHC16f") == 0 || periodNameV0Reader.CompareTo("LHC17g")==0 || periodNameV0Reader.CompareTo("LHC18c")==0 ||
+        periodNameV0Reader.CompareTo("LHC17d1") == 0  || periodNameV0Reader.CompareTo("LHC17d12")==0 ||
+        periodNameV0Reader.CompareTo("LHC17h3")==0 || periodNameV0Reader.CompareTo("LHC17k1")==0 ||
+        periodNameV0Reader.CompareTo("LHC17f8b") == 0 ||
+        periodNameV0Reader.CompareTo("LHC16P1JJLowB") == 0 || periodNameV0Reader.CompareTo("LHC16P1Pyt8LowB") == 0 )
+    cutnumberPhoton         = "00000088400000000100000000";
+
+  TString cutnumberEvent    = "00000003";
+  TString PionCuts          = "000000200";            //Electron Cuts
+
+  AliAnalysisDataContainer *cinput = mgr->GetCommonInputContainer();
+
+  //========= Add V0 Reader to  ANALYSIS manager if not yet existent =====
+  TString V0ReaderName = Form("V0ReaderV1_%s_%s",cutnumberEvent.Data(),cutnumberPhoton.Data());
+  if( !(AliV0ReaderV1*)mgr->GetTask(V0ReaderName.Data()) ){
+
+    AliV0ReaderV1 *fV0ReaderV1 = new AliV0ReaderV1(V0ReaderName.Data());
+    if (periodNameV0Reader.CompareTo("") != 0) fV0ReaderV1->SetPeriodName(periodNameV0Reader);
+    fV0ReaderV1->SetUseOwnXYZCalculation(kTRUE);
+    fV0ReaderV1->SetCreateAODs(kFALSE);// AOD Output
+    fV0ReaderV1->SetUseAODConversionPhoton(kTRUE);
+
+    if (!mgr) {
+      Error("AddTask_V0ReaderV1", "No analysis manager found.");
+      return;
+    }
+
+    AliConvEventCuts *fEventCuts=NULL;
+    if(cutnumberEvent!=""){
+      fEventCuts= new AliConvEventCuts(cutnumberEvent.Data(),cutnumberEvent.Data());
+      fEventCuts->SetPreSelectionCutFlag(kTRUE);
+      fEventCuts->SetV0ReaderName(V0ReaderName);
+      if (periodNameV0Reader.CompareTo("") != 0) fEventCuts->SetPeriodEnum(periodNameV0Reader);
+      if(runLightOutput>0) fEventCuts->SetLightOutput(kTRUE);
+      if(fEventCuts->InitializeCutsFromCutString(cutnumberEvent.Data())){
+        fV0ReaderV1->SetEventCuts(fEventCuts);
+        fEventCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+
+    // Set AnalysisCut Number
+    AliConversionPhotonCuts *fCuts=NULL;
+    if(cutnumberPhoton!=""){
+      fCuts= new AliConversionPhotonCuts(cutnumberPhoton.Data(),cutnumberPhoton.Data());
+      fCuts->SetPreSelectionCutFlag(kTRUE);
+      fCuts->SetIsHeavyIon(isHeavyIon);
+      fCuts->SetV0ReaderName(V0ReaderName);
+      if(runLightOutput>0) fCuts->SetLightOutput(kTRUE);
+      if(fCuts->InitializeCutsFromCutString(cutnumberPhoton.Data())){
+        fV0ReaderV1->SetConversionCuts(fCuts);
+        fCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+
+    if(inputHandler->IsA()==AliAODInputHandler::Class()){
+    // AOD mode
+      fV0ReaderV1->AliV0ReaderV1::SetDeltaAODBranchName(Form("GammaConv_%s_gamma",cutnumberAODBranch.Data()));
+    }
+    fV0ReaderV1->Init();
+
+    AliLog::SetGlobalLogLevel(AliLog::kFatal);
+
+    //connect input V0Reader
+    mgr->AddTask(fV0ReaderV1);
+    mgr->ConnectInput(fV0ReaderV1,0,cinput);
+  }
+
+  //================================================
+  //========= Add Pion Selector ====================
+  if( !(AliPrimaryPionSelector*)mgr->GetTask("PionSelector") ){
+    AliPrimaryPionSelector *fPionSelector = new AliPrimaryPionSelector("PionSelector");
+    AliPrimaryPionCuts *fPionCuts=0;
+    if( PionCuts!=""){
+      fPionCuts= new AliPrimaryPionCuts(PionCuts.Data(),PionCuts.Data());
+      if(runLightOutput>0) fPionCuts->SetLightOutput(kTRUE);
+      if(fPionCuts->InitializeCutsFromCutString(PionCuts.Data())){
+        fPionSelector->SetPrimaryPionCuts(fPionCuts);
+        fPionCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+
+    fPionSelector->Init();
+    mgr->AddTask(fPionSelector);
+
+    AliAnalysisDataContainer *cinput1  = mgr->GetCommonInputContainer();
+    //connect input V0Reader
+    mgr->ConnectInput (fPionSelector,0,cinput1);
+
+  }
+
+  AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson *task=NULL;
+  task= new AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson(Form("GammaConvNeutralMesonPiPlPiMiNeutralMeson_%i_%i",neutralPionMode, trainConfig));
+  task->SetIsHeavyIon(isHeavyIon);
+  task->SetIsMC(isMC);
+  task->SetV0ReaderName(V0ReaderName);
+  if(runLightOutput>1) task->SetLightOutput(kTRUE);
+  task->SetTolerance(tolerance);
+  CutHandlerNeutralConv cuts;
+
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  //                                          ETA MESON
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  if( trainConfig == 1 ) {
+    // everything open, min pt charged pi = 100 MeV
+    cuts.AddCut("80000113","00200009327000008250400000","000010400","0103503a00000000","0103503000000000"); // cent 0-100%
+    cuts.AddCut("80200113","00200009327000008250400000","000010400","0103503a00000000","0103503000000000"); // cent 0-20%
+  } else if( trainConfig == 2 ) {
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, min pt charged pi = 100 MeV
+    cuts.AddCut("80000113","00200009327000008250400000","002010700","0103503a00000000","0103503000000000"); // cent 0-100%
+    cuts.AddCut("80200113","00200009327000008250400000","002010700","0103503a00000000","0103503000000000"); // cent 0-20%
+  } else if( trainConfig == 3 ) {
+    // eta < 0.9
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, pi+pi- mass cut of 0.65, min pt charged pi = 100 MeV
+    // closing neural pion cuts, 0.1 < M_gamma,gamma < 0.15
+    // maxChi2 per cluster TPC <4, require TPC refit, DCA XY pT dependend 0.0182+0.0350/pt^1.01, DCA_Z = 3.0
+    // timing cluster cut open
+    cuts.AddCut("80010113","00200009327000008250400000","30a330708","0103503400000000","0153503000000000"); // cent 0-100%
+    cuts.AddCut("80210113","00200009327000008250400000","30a330708","0103503400000000","0153503000000000"); // cent 0-20%
+
+  } else if( trainConfig == 51 ) { // same as 1, but 0-20% centrality excluded
+    cuts.AddCut("80000113","00200009327000008250400000","000010400","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 52 ) { // same as 2, but 0-20% centrality excluded
+    cuts.AddCut("80000113","00200009327000008250400000","002010700","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 53 ) { // same as 3, but 0-20% centrality excluded
+    cuts.AddCut("80010113","00200009327000008250400000","30a330708","0103503400000000","0153503000000000");
+
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  //                                          OMEGA MESON
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  } else if( trainConfig == 100 ) {
+    // everything open, min pt charged pi = 100 MeV
+    cuts.AddCut("80000113","00200009327000008250400000","000010400","0103503a00000000","0103503000000000"); // cent 0-100%
+    cuts.AddCut("80200113","00200009327000008250400000","000010400","0103503a00000000","0103503000000000"); // cent 0-20%
+  } else if( trainConfig == 101 ) {
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, min pt charged pi = 100 MeV
+    cuts.AddCut("80000113","00200009327000008250400000","002010700","0103503a00000000","0103503000000000"); // cent 0-100%
+    cuts.AddCut("80200113","00200009327000008250400000","002010700","0103503a00000000","0103503000000000"); // cent 0-20%
+  } else if( trainConfig == 102 ) {
+    // eta < 0.9
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, pi+pi- mass cut of 0.65, min pt charged pi = 100 MeV
+    // closing neural pion cuts, 0.1 < M_gamma,gamma < 0.15
+    // maxChi2 per cluster TPC <4, require TPC refit, DCA XY pT dependend 0.0182+0.0350/pt^1.01, DCA_Z = 3.0
+    // timing cluster cut open
+    cuts.AddCut("80010113","00200009327000008250400000","30a330708","0103503400000000","0153503000000000"); // cent 0-100%
+    cuts.AddCut("80210113","00200009327000008250400000","30a330708","0103503400000000","0153503000000000"); // cent 0-20%
+
+  } else if( trainConfig == 150 ) { // same as 100, but 0-20% centrality excluded
+    cuts.AddCut("80000113","00200009327000008250400000","000010400","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 151 ) { // same as 101, but 0-20% centrality excluded
+    cuts.AddCut("80000113","00200009327000008250400000","002010700","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 152 ) { // same as 102, but 0-20% centrality excluded
+    cuts.AddCut("80010113","00200009327000008250400000","30a330708","0103503400000000","0153503000000000");
+
+
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  //                                          ETA PRIME MESON
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+  } else if( trainConfig == 200 ) {
+    // everything open, min pt charged pi = 100 MeV
+    cuts.AddCut("80000113","00200009327000008250400000","000010400","0103503m00000000","0103503000000000"); // cent 0-100%
+    cuts.AddCut("80200113","00200009327000008250400000","000010400","0103503m00000000","0103503000000000"); // cent 0-20%
+  } else if( trainConfig == 201 ) {
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, min pt charged pi = 100 MeV
+    cuts.AddCut("80000113","00200009327000008250400000","002010700","0103503m00000000","0103503000000000"); // cent 0-100%
+    cuts.AddCut("80200113","00200009327000008250400000","002010700","0103503m00000000","0103503000000000"); // cent 0-20%
+  } else if( trainConfig == 202 ) {
+    // eta < 0.9
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, pi+pi- mass cut of 1.5, min pt charged pi = 100 MeV
+    // closing neural pion cuts, 0.5 < M_gamma,gamma < 0.6
+    // maxChi2 per cluster TPC <4, require TPC refit, DCA XY pT dependend 0.0182+0.0350/pt^1.01, DCA_Z = 3.0
+    // timing cluster cut open
+    cuts.AddCut("80010113","00200009327000008250400000","30a330709","0103503l00000000","0153503000000000"); // cent 0-100% 0.5-0.6 eta mass cut
+    cuts.AddCut("80010113","00200009327000008250400000","30a330709","0103503m00000000","0153503000000000"); // cent 0-100% 0.4-0.7 eta mass cut
+    cuts.AddCut("80210113","00200009327000008250400000","30a330709","0103503l00000000","0153503000000000"); // cent 0-20%  0.5-0.6 eta mass cut
+    cuts.AddCut("80210113","00200009327000008250400000","30a330709","0103503m00000000","0153503000000000"); // cent 0-20%  0.4-0.7 eta mass cut
+  } else if( trainConfig == 204 ) {
+    // same as 202 but with mass cut variations
+    cuts.AddCut("80010113","00200009327000008250400000","30a330700","0103503l00000000","0153503000000000"); // cent 0-100% pi+pi- mass cut of 10
+    cuts.AddCut("80010113","00200009327000008250400000","30a330701","0103503l00000000","0153503000000000"); // cent 0-100% pi+pi- mass cut of 1
+    cuts.AddCut("80010113","00200009327000008250400000","30a330708","0103503l00000000","0153503000000000"); // cent 0-100% pi+pi- mass cut of 0.85
+    cuts.AddCut("80210113","00200009327000008250400000","30a330700","0103503l00000000","0153503000000000"); // cent 0-20%  pi+pi- mass cut of 10
+    cuts.AddCut("80210113","00200009327000008250400000","30a330701","0103503l00000000","0153503000000000"); // cent 0-20%  pi+pi- mass cut of 1
+    cuts.AddCut("80210113","00200009327000008250400000","30a330708","0103503l00000000","0153503000000000"); // cent 0-20%  pi+pi- mass cut of 0.85
+
+  } else if( trainConfig == 250 ) { // same as 200, but 0-20% centrality excluded
+    cuts.AddCut("80000113","00200009327000008250400000","000010400","0103503m00000000","0103503000000000");
+  } else if( trainConfig == 251 ) { // same as 201, but 0-20% centrality excluded
+    cuts.AddCut("80000113","00200009327000008250400000","002010700","0103503m00000000","0103503000000000");
+  } else if( trainConfig == 252 ) { // same as 202, but 0-20% centrality excluded
+    cuts.AddCut("80010113","00200009327000008250400000","30a330709","0103503l00000000","0153503000000000");
+    cuts.AddCut("80010113","00200009327000008250400000","30a330709","0103503m00000000","0153503000000000");
+  } else if( trainConfig == 254 ) { // same as 204, but 0-20% centrality excluded
+    cuts.AddCut("80010113","00200009327000008250400000","30a330700","0103503l00000000","0153503000000000");
+    cuts.AddCut("80010113","00200009327000008250400000","30a330701","0103503l00000000","0153503000000000");
+    cuts.AddCut("80010113","00200009327000008250400000","30a330708","0103503l00000000","0153503000000000");
+
+  } else {
+    Error(Form("GammaConvNeutralMeson_ConvMode_%i",trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");
+    return;
+  }
+
+  if(!cuts.AreValid()){
+    cout << "\n\n****************************************************" << endl;
+    cout << "ERROR: No valid cuts stored in CutHandlerNeutralConv! Returning..." << endl;
+    cout << "****************************************************\n\n" << endl;
+    return;
+  }
+
+  Int_t numberOfCuts = cuts.GetNCuts();
+
+  TList *EventCutList = new TList();
+  TList *ConvCutList  = new TList();
+  TList *NeutralPionCutList = new TList();
+  TList *MesonCutList = new TList();
+  TList *PionCutList  = new TList();
+
+  TList *HeaderList = new TList();
+  TObjString *Header1 = new TObjString("pi0_1");
+  HeaderList->Add(Header1);
+  TObjString *Header3 = new TObjString("eta_2");
+  HeaderList->Add(Header3);
+
+  EventCutList->SetOwner(kTRUE);
+  AliConvEventCuts **analysisEventCuts = new AliConvEventCuts*[numberOfCuts];
+  ConvCutList->SetOwner(kTRUE);
+  AliConversionPhotonCuts **analysisCuts = new AliConversionPhotonCuts*[numberOfCuts];
+  NeutralPionCutList->SetOwner(kTRUE);
+  AliConversionMesonCuts **analysisNeutralPionCuts   = new AliConversionMesonCuts*[numberOfCuts];
+  MesonCutList->SetOwner(kTRUE);
+  AliConversionMesonCuts **analysisMesonCuts   = new AliConversionMesonCuts*[numberOfCuts];
+  PionCutList->SetOwner(kTRUE);
+  AliPrimaryPionCuts **analysisPionCuts     = new AliPrimaryPionCuts*[numberOfCuts];
+
+  for(Int_t i = 0; i<numberOfCuts; i++){
+    analysisEventCuts[i] = new AliConvEventCuts();
+    analysisEventCuts[i]->SetV0ReaderName(V0ReaderName);
+    if(runLightOutput>0) analysisEventCuts[i]->SetLightOutput(kTRUE);
+    analysisEventCuts[i]->InitializeCutsFromCutString((cuts.GetEventCut(i)).Data());
+    if (periodNameV0Reader.CompareTo("") != 0) analysisEventCuts[i]->SetPeriodEnum(periodNameV0Reader);
+    EventCutList->Add(analysisEventCuts[i]);
+    analysisEventCuts[i]->SetFillCutHistograms("",kFALSE);
+
+    analysisCuts[i] = new AliConversionPhotonCuts();
+    if(runLightOutput>0) analysisCuts[i]->SetLightOutput(kTRUE);
+    analysisCuts[i]->SetV0ReaderName(V0ReaderName);
+    if( ! analysisCuts[i]->InitializeCutsFromCutString((cuts.GetConversionCut(i)).Data()) ) {
+      cout<<"ERROR: analysisCuts [" <<i<<"]"<<endl;
+      return 0;
+    } else {
+      ConvCutList->Add(analysisCuts[i]);
+      analysisCuts[i]->SetFillCutHistograms("",kFALSE);
+
+    }
+
+    analysisNeutralPionCuts[i] = new AliConversionMesonCuts();
+    if(runLightOutput>0) analysisNeutralPionCuts[i]->SetLightOutput(kTRUE);
+    if( ! analysisNeutralPionCuts[i]->InitializeCutsFromCutString((cuts.GetNeutralPionCut(i)).Data()) ) {
+      cout<<"ERROR: analysisMesonCuts [ " <<i<<" ] "<<endl;
+      return 0;
+    } else {
+      NeutralPionCutList->Add(analysisNeutralPionCuts[i]);
+      analysisNeutralPionCuts[i]->SetFillCutHistograms("");
+    }
+
+    analysisMesonCuts[i] = new AliConversionMesonCuts();
+    if(runLightOutput>0) analysisMesonCuts[i]->SetLightOutput(kTRUE);
+    if( ! analysisMesonCuts[i]->InitializeCutsFromCutString((cuts.GetMesonCut(i)).Data()) ) {
+      cout<<"ERROR: analysisMesonCuts [ " <<i<<" ] "<<endl;
+      return 0;
+    } else {
+      MesonCutList->Add(analysisMesonCuts[i]);
+      analysisMesonCuts[i]->SetFillCutHistograms("");
+    }
+    analysisEventCuts[i]->SetAcceptedHeader(HeaderList);
+
+    TString cutName( Form("%s_%s_%s_%s_%s",(cuts.GetEventCut(i)).Data(), (cuts.GetConversionCut(i)).Data(),(cuts.GetPionCut(i)).Data(),(cuts.GetNeutralPionCut(i)).Data(), (cuts.GetMesonCut(i)).Data() ) );
+    analysisPionCuts[i] = new AliPrimaryPionCuts();
+    if(runLightOutput>0) analysisPionCuts[i]->SetLightOutput(kTRUE);
+    if( !analysisPionCuts[i]->InitializeCutsFromCutString((cuts.GetPionCut(i)).Data())) {
+      cout<< "ERROR:  analysisPionCuts [ " <<i<<" ] "<<endl;
+      return 0;
+    } else {
+      PionCutList->Add(analysisPionCuts[i]);
+      analysisPionCuts[i]->SetFillCutHistograms("",kFALSE,cutName);
+    }
+  }
+
+  task->SetNDMRecoMode(neutralPionMode);
+  task->SetEventCutList(numberOfCuts,EventCutList);
+  task->SetConversionCutList(ConvCutList);
+  task->SetNeutralPionCutList(NeutralPionCutList);
+  task->SetMesonCutList(MesonCutList);
+  task->SetPionCutList(PionCutList);
+
+  task->SetMoveParticleAccordingToVertex(kTRUE);
+
+  task->SetSelectedHeavyNeutralMeson(selectHeavyNeutralMeson);
+
+  task->SetDoMesonQA(enableQAMesonTask);
+
+  //connect containers
+  AliAnalysisDataContainer *coutput =
+  mgr->CreateContainer(Form("GammaConvNeutralMesonPiPlPiMiNeutralMeson_%i_%i_%i.root",selectHeavyNeutralMeson,neutralPionMode, trainConfig), TList::Class(),
+              AliAnalysisManager::kOutputContainer,Form("GammaConvNeutralMesonPiPlPiMiNeutralMeson_%i_%i_%i.root",selectHeavyNeutralMeson,neutralPionMode, trainConfig));
+
+  mgr->AddTask(task);
+  mgr->ConnectInput(task,0,cinput);
+  mgr->ConnectOutput(task,1,coutput);
+
+  return;
+
+}

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_MixedMode_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_MixedMode_pPb.C
@@ -1,0 +1,465 @@
+/**************************************************************************
+ * Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: Remco de Boer                                                  *
+ * Version 1.0                                                            *
+ *                                                                        *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+//***************************************************************************************
+//This AddTask is supposed to set up the main task
+//($ALIPHYSICS/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.cxx) for
+//pPb together with all supporting classes
+//***************************************************************************************
+
+//***************************************************************************************
+//CutHandler contains all cuts for a certain analysis and trainconfig,
+//it automatically checks length of cutStrings and takes care of the number of added cuts,
+//no specification of the variable 'numberOfCuts' needed anymore.
+//***************************************************************************************
+class CutHandlerNeutralMixed{
+  public:
+    CutHandlerNeutralMixed(Int_t nMax=10){
+      nCuts=0; nMaxCuts=nMax; validCuts = true;
+      eventCutArray = new TString[nMaxCuts]; clusterCutArray = new TString[nMaxCuts]; conversionCutArray = new TString[nMaxCuts]; pionCutArray = new TString[nMaxCuts]; neutralPionCutArray = new TString[nMaxCuts]; mesonCutArray = new TString[nMaxCuts];
+      for(Int_t i=0; i<nMaxCuts; i++) {eventCutArray[i] = ""; clusterCutArray[i] = ""; conversionCutArray[i] = ""; pionCutArray[i] = ""; neutralPionCutArray[i] = ""; mesonCutArray[i] = "";}
+    }
+
+    void AddCut(TString eventCut, TString conversionCut, TString clusterCut, TString pionCut, TString neutralPionCut, TString mesonCut){
+      if(nCuts>=nMaxCuts) {cout << "ERROR in CutHandlerNeutralMixed: Exceeded maximum number of cuts!" << endl; validCuts = false; return;}
+      if( eventCut.Length()!=8 || conversionCut.Length()!=26 || clusterCut.Length()!=19 || pionCut.Length()!=9 || neutralPionCut.Length()!=16 || mesonCut.Length()!=16 ) {cout << "ERROR in CutHandlerNeutralMixed: Incorrect length of cut string!" << endl; validCuts = false; return;}
+      eventCutArray[nCuts]=eventCut; conversionCutArray[nCuts]=conversionCut; clusterCutArray[nCuts]=clusterCut; pionCutArray[nCuts]=pionCut; neutralPionCutArray[nCuts]=neutralPionCut; mesonCutArray[nCuts]=mesonCut;
+      nCuts++;
+      return;
+    }
+    Bool_t AreValid(){return validCuts;}
+    Int_t GetNCuts(){if(validCuts) return nCuts; else return 0;}
+    TString GetEventCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return eventCutArray[i]; else{cout << "ERROR in CutHandlerNeutralMixed: GetEventCut wrong index i" << endl;return "";}}
+    TString GetClusterCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return clusterCutArray[i]; else {cout << "ERROR in CutHandlerNeutralMixed: GetClusterCut wrong index i" << endl;return "";}}
+    TString GetConversionCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return conversionCutArray[i]; else {cout << "ERROR in CutHandlerNeutralMixed: GetConversionCut wrong index i" << endl;return "";}}
+    TString GetPionCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return pionCutArray[i]; else {cout << "ERROR in CutHandlerNeutralMixed: GetPionCut wrong index i" << endl;return "";}}
+    TString GetNeutralPionCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return neutralPionCutArray[i]; else {cout << "ERROR in CutHandlerNeutralMixed: GetNeutralPionCut wrong index i" << endl;return "";}}
+    TString GetMesonCut(Int_t i){if(validCuts&&i<nMaxCuts&&i>=0) return mesonCutArray[i]; else {cout << "ERROR in CutHandlerNeutralMixed: GetMesonCut wrong index i" << endl;return "";}}
+  private:
+    Bool_t validCuts;
+    Int_t nCuts; Int_t nMaxCuts;
+    TString* eventCutArray;
+    TString* clusterCutArray;
+    TString* conversionCutArray;
+    TString* pionCutArray;
+    TString* neutralPionCutArray;
+    TString* mesonCutArray;
+};
+
+//***************************************************************************************
+//main function
+//***************************************************************************************
+void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_MixedMode_pPb(
+    Int_t trainConfig                 = 1,
+    Bool_t isMC                       = kFALSE,                           // run MC
+    Int_t selectHeavyNeutralMeson     = 0,                                // run eta prime instead of omega
+    Int_t enableQAMesonTask           = 1,                                // enable QA in AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson
+    TString fileNameInputForWeighting = "MCSpectraInput.root",            // path to file for weigting input
+    Bool_t doWeighting                = kFALSE,                           // enable Weighting
+    TString generatorName             = "HIJING",
+    TString cutnumberAODBranch        = "000000006008400001001500000",
+    Double_t tolerance                = -1,
+    TString periodNameV0Reader        = "",                               // period Name for V0Reader
+    Int_t runLightOutput              = 0,                                // run light output option 0: no light output 1: most cut histos stiched off 2: unecessary omega hists turned off as well
+    TString additionalTrainConfig     = "0"                               // additional counter for trainconfig, this has to be always the last parameter
+  ) {
+
+  //parse additionalTrainConfig flag
+  TObjArray *rAddConfigArr = additionalTrainConfig.Tokenize("_");
+  if(rAddConfigArr->GetEntries()<1){cout << "ERROR during parsing of additionalTrainConfig String '" << additionalTrainConfig.Data() << "'" << endl; return;}
+  TObjString* rAdditionalTrainConfig;
+  for(Int_t i = 0; i<rAddConfigArr->GetEntries() ; i++){
+    if(i==0) rAdditionalTrainConfig = (TObjString*)rAddConfigArr->At(i);
+    else{
+      TObjString* temp = (TObjString*) rAddConfigArr->At(i);
+      TString tempStr = temp->GetString();
+      cout << "INFO: nothing to do, no definition available!" << endl;
+    }
+  }
+  TString sAdditionalTrainConfig = rAdditionalTrainConfig->GetString();
+  if (sAdditionalTrainConfig.Atoi() > 0){
+    trainConfig = trainConfig + sAdditionalTrainConfig.Atoi();
+    cout << "INFO: AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_MixedMode_pPb running additionalTrainConfig '" << sAdditionalTrainConfig.Atoi() << "', train config: '" << trainConfig << "'" << endl;
+  }
+
+  Int_t isHeavyIon = 0;
+  Int_t neutralPionMode = 1;
+
+  // ================== GetAnalysisManager ===============================
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    Error(Form("AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_MixedMode_pPb_%i",trainConfig), "No analysis manager found.");
+    return ;
+  }
+
+  // ================== GetInputEventHandler =============================
+  AliVEventHandler *inputHandler=mgr->GetInputEventHandler();
+
+  //========= Add PID Reponse to ANALYSIS manager ====
+  if(!(AliPIDResponse*)mgr->GetTask("PIDResponseTask")){
+    gROOT->LoadMacro("$ALICE_ROOT/ANALYSIS/macros/AddTaskPIDResponse.C");
+    AddTaskPIDResponse(isMC);
+  }
+
+  //=========  Set Cutnumber for V0Reader ================================
+  TString cutnumberPhoton = "06000008400100001500000000";
+  if (  periodNameV0Reader.CompareTo("LHC16f") == 0 || periodNameV0Reader.CompareTo("LHC17g")==0 || periodNameV0Reader.CompareTo("LHC18c")==0 ||
+        periodNameV0Reader.CompareTo("LHC17d1") == 0  || periodNameV0Reader.CompareTo("LHC17d12")==0 ||
+        periodNameV0Reader.CompareTo("LHC17h3")==0 || periodNameV0Reader.CompareTo("LHC17k1")==0 ||
+        periodNameV0Reader.CompareTo("LHC17f8b") == 0 ||
+        periodNameV0Reader.CompareTo("LHC16P1JJLowB") == 0 || periodNameV0Reader.CompareTo("LHC16P1Pyt8LowB") == 0 )
+    cutnumberPhoton         = "00000088400000000100000000";
+
+  TString cutnumberEvent = "00000003";
+  TString PionCuts      = "000000200";            //Electron Cuts
+
+
+  AliAnalysisDataContainer *cinput = mgr->GetCommonInputContainer();
+
+  //========= Add V0 Reader to  ANALYSIS manager if not yet existent =====
+  TString V0ReaderName = Form("V0ReaderV1_%s_%s",cutnumberEvent.Data(),cutnumberPhoton.Data());
+  if( !(AliV0ReaderV1*)mgr->GetTask(V0ReaderName.Data()) ){
+    AliV0ReaderV1 *fV0ReaderV1 = new AliV0ReaderV1(V0ReaderName.Data());
+
+    if (periodNameV0Reader.CompareTo("") != 0) fV0ReaderV1->SetPeriodName(periodNameV0Reader);
+    fV0ReaderV1->SetUseOwnXYZCalculation(kTRUE);
+    fV0ReaderV1->SetCreateAODs(kFALSE);// AOD Output
+    fV0ReaderV1->SetUseAODConversionPhoton(kTRUE);
+
+    if (!mgr) {
+      Error("AddTask_V0ReaderV1", "No analysis manager found.");
+      return;
+    }
+
+    AliConvEventCuts *fEventCuts=NULL;
+    if(cutnumberEvent!=""){
+      fEventCuts= new AliConvEventCuts(cutnumberEvent.Data(),cutnumberEvent.Data());
+      fEventCuts->SetPreSelectionCutFlag(kTRUE);
+      fEventCuts->SetV0ReaderName(V0ReaderName);
+      if (periodNameV0Reader.CompareTo("") != 0) fEventCuts->SetPeriodEnum(periodNameV0Reader);
+      if(runLightOutput>0) fEventCuts->SetLightOutput(kTRUE);
+      if(fEventCuts->InitializeCutsFromCutString(cutnumberEvent.Data())){
+        fV0ReaderV1->SetEventCuts(fEventCuts);
+        fEventCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+
+    // Set AnalysisCut Number
+    AliConversionPhotonCuts *fCuts=NULL;
+    if(cutnumberPhoton!=""){
+      fCuts= new AliConversionPhotonCuts(cutnumberPhoton.Data(),cutnumberPhoton.Data());
+      fCuts->SetPreSelectionCutFlag(kTRUE);
+      fCuts->SetIsHeavyIon(isHeavyIon);
+      fCuts->SetV0ReaderName(V0ReaderName);
+      if(runLightOutput>0) fCuts->SetLightOutput(kTRUE);
+      if(fCuts->InitializeCutsFromCutString(cutnumberPhoton.Data())){
+        fV0ReaderV1->SetConversionCuts(fCuts);
+        fCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+
+    if(inputHandler->IsA()==AliAODInputHandler::Class()){
+    // AOD mode
+      fV0ReaderV1->AliV0ReaderV1::SetDeltaAODBranchName(Form("GammaConv_%s_gamma",cutnumberAODBranch.Data()));
+    }
+    fV0ReaderV1->Init();
+
+    AliLog::SetGlobalLogLevel(AliLog::kFatal);
+
+    //connect input V0Reader
+    mgr->AddTask(fV0ReaderV1);
+    mgr->ConnectInput(fV0ReaderV1,0,cinput);
+  }
+
+  //================================================
+  //========= Add Pion Selector ====================
+  if( !(AliPrimaryPionSelector*)mgr->GetTask("PionSelector") ){
+    AliPrimaryPionSelector *fPionSelector = new AliPrimaryPionSelector("PionSelector");
+    AliPrimaryPionCuts *fPionCuts=0;
+    if( PionCuts!=""){
+      fPionCuts= new AliPrimaryPionCuts(PionCuts.Data(),PionCuts.Data());
+      if(runLightOutput>0) fPionCuts->SetLightOutput(kTRUE);
+
+      if(fPionCuts->InitializeCutsFromCutString(PionCuts.Data())){
+        fPionSelector->SetPrimaryPionCuts(fPionCuts);
+        fPionCuts->SetFillCutHistograms("",kTRUE);
+      }
+    }
+
+    fPionSelector->Init();
+    mgr->AddTask(fPionSelector);
+
+    AliAnalysisDataContainer *cinput1  = mgr->GetCommonInputContainer();
+    mgr->ConnectInput (fPionSelector,0,cinput1);
+  }
+
+  AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson *task=NULL;
+  task= new AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson(Form("GammaConvNeutralMesonPiPlPiMiNeutralMeson_%i_%i",neutralPionMode, trainConfig));
+  task->SetIsHeavyIon(isHeavyIon);
+  task->SetIsMC(isMC);
+  task->SetV0ReaderName(V0ReaderName);
+  if(runLightOutput>1) task->SetLightOutput(kTRUE);
+
+  task->SetTolerance(tolerance);
+
+  CutHandlerNeutralMixed cuts;
+
+
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  //                                          ETA MESON
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  if( trainConfig == 1 ) {
+    // everything open, min pt charged pi = 100 MeV
+    cuts.AddCut("80000113","00200009327000008250400000","1111100047032230000","000010400","0103503a00000000","0103503000000000"); // cent 0-100%
+    cuts.AddCut("80200113","00200009327000008250400000","1111100047032230000","000010400","0103503a00000000","0103503000000000"); // cent 0-20%
+  } else if( trainConfig == 2 ) {
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, min pt charged pi = 100 MeV
+    cuts.AddCut("80000113","00200009327000008250400000","1111100047032230000","002010700","0103503a00000000","0103503000000000"); // cent 0-100%
+    cuts.AddCut("80200113","00200009327000008250400000","1111100047032230000","002010700","0103503a00000000","0103503000000000"); // cent 0-20%
+  } else if( trainConfig == 3 ) {
+    // eta < 0.9
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, pi+pi- mass cut of 0.65, min pt charged pi = 100 MeV
+    // closing neural pion cuts, 0.1 < M_gamma,gamma < 0.15
+    // maxChi2 per cluster TPC <4, require TPC refit, DCA XY pT dependend 0.0182+0.0350/pt^1.01, DCA_Z = 3.0
+    // timing cluster cut open
+    cuts.AddCut("80010113","00200009327000008250400000","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // cent 0-100%
+    cuts.AddCut("80210113","00200009327000008250400000","1111100047032230000","30a330708","0103503400000000","0153503000000000"); // cent 0-20%
+
+  } else if( trainConfig == 51 ) { // same as 1, but 0-20% centrality excluded
+    cuts.AddCut("80000113","00200009327000008250400000","1111100047032230000","000010400","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 52 ) { // same as 2, but 0-20% centrality excluded
+    cuts.AddCut("80000113","00200009327000008250400000","1111100047032230000","002010700","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 53 ) { // same as 3, but 0-20% centrality excluded
+    cuts.AddCut("80010113","00200009327000008250400000","1111100047032230000","30a330708","0103503400000000","0153503000000000");
+
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  //                                          OMEGA MESON
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  } else if( trainConfig == 100 ) {
+    // everything open, min pt charged pi = 100 MeV
+    cuts.AddCut("80000113","00200009327000008250400000","1111100047032230000","000010400","0103503a00000000","0103503000000000"); // cent 0-100%
+    cuts.AddCut("80200113","00200009327000008250400000","1111100047032230000","000010400","0103503a00000000","0103503000000000"); // cent 0-20%
+  } else if( trainConfig == 101 ) {
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, min pt charged pi = 100 MeV
+    cuts.AddCut("80000113","00200009327000008250400000","1111100047032230000","002010700","0103503a00000000","0103503000000000"); // cent 0-100%
+    cuts.AddCut("80200113","00200009327000008250400000","1111100047032230000","002010700","0103503a00000000","0103503000000000"); // cent 0-20%
+  } else if( trainConfig == 102 ) {
+    // eta < 0.9
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, pi+pi- mass cut of 0.65, min pt charged pi = 100 MeV
+    // closing neural pion cuts, 0.1 < M_gamma,gamma < 0.15
+    // maxChi2 per cluster TPC <4, require TPC refit, DCA XY pT dependend 0.0182+0.0350/pt^1.01, DCA_Z = 3.0
+    // timing cluster cut open
+    cuts.AddCut("80010113","00200009327000008250400000","1111100047032230000","30a330708","0103503400000000","0153503000000000");
+
+  } else if( trainConfig == 150 ) { // same as 100, but 0-20% centrality excluded
+    cuts.AddCut("80000113","00200009327000008250400000","1111100047032230000","000010400","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 151 ) { // same as 101, but 0-20% centrality excluded
+    cuts.AddCut("80000113","00200009327000008250400000","1111100047032230000","002010700","0103503a00000000","0103503000000000");
+  } else if( trainConfig == 152 ) { // same as 102, but 0-20% centrality excluded
+    cuts.AddCut("80010113","00200009327000008250400000","1111100047032230000","30a330708","0103503400000000","0153503000000000");
+
+
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  //                                          ETA PRIME MESON
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+  } else if( trainConfig == 200 ) {
+    // everything open, min pt charged pi = 100 MeV
+    cuts.AddCut("80000113","00200009327000008250400000","1111100047032230000","000010400","0103503m00000000","0103503000000000"); // cent 0-100%
+    cuts.AddCut("80200113","00200009327000008250400000","1111100047032230000","000010400","0103503m00000000","0103503000000000"); // cent 0-20%
+  } else if( trainConfig == 201 ) {
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, min pt charged pi = 100 MeV
+    cuts.AddCut("80000113","00200009327000008250400000","1111100047032230000","002010700","0103503m00000000","0103503000000000"); // cent 0-100%
+    cuts.AddCut("80200113","00200009327000008250400000","1111100047032230000","002010700","0103503m00000000","0103503000000000"); // cent 0-20%
+  } else if( trainConfig == 202 ) {
+    // eta < 0.9
+    // closing charged pion cuts, minimum TPC cluster = 80, TPC dEdx pi = \pm 3 sigma, pi+pi- mass cut of 1.5, min pt charged pi = 100 MeV
+    // closing neural pion cuts, 0.5 < M_gamma,gamma < 0.6
+    // maxChi2 per cluster TPC <4, require TPC refit, DCA XY pT dependend 0.0182+0.0350/pt^1.01, DCA_Z = 3.0
+    // timing cluster cut open
+    cuts.AddCut("80010113","00200009327000008250400000","1111100047032230000","30a330709","0103503l00000000","0153503000000000"); // 0.5-0.6 eta mass cut // cent 0-100%
+    cuts.AddCut("80010113","00200009327000008250400000","1111100047032230000","30a330709","0103503m00000000","0153503000000000"); // 0.4-0.7 eta mass cut // cent 0-100%
+    cuts.AddCut("80210113","00200009327000008250400000","1111100047032230000","30a330709","0103503l00000000","0153503000000000"); // 0.5-0.6 eta mass cut // cent 0-20%
+    cuts.AddCut("80210113","00200009327000008250400000","1111100047032230000","30a330709","0103503m00000000","0153503000000000"); // 0.4-0.7 eta mass cut // cent 0-20%
+  } else if( trainConfig == 204 ) {
+    // same as 202 but with mass cut variations
+    cuts.AddCut("80010113","00200009327000008250400000","1111100047032230000","30a330700","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 10 // cent 0-100%
+    cuts.AddCut("80010113","00200009327000008250400000","1111100047032230000","30a330701","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 1 // cent 0-100%
+    cuts.AddCut("80010113","00200009327000008250400000","1111100047032230000","30a330708","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 0.85 // cent 0-100%
+    cuts.AddCut("80210113","00200009327000008250400000","1111100047032230000","30a330700","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 10 // cent 0-20%
+    cuts.AddCut("80210113","00200009327000008250400000","1111100047032230000","30a330701","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 1 // cent 0-20%
+    cuts.AddCut("80210113","00200009327000008250400000","1111100047032230000","30a330708","0103503l00000000","0153503000000000"); // pi+pi- mass cut of 0.85 // cent 0-20%
+
+  } else if( trainConfig == 250 ) { // same as 200, but 0-20% centrality excluded
+    cuts.AddCut("80000113","00200009327000008250400000","1111100047032230000","000010400","0103503m00000000","0103503000000000");
+  } else if( trainConfig == 251 ) { // same as 201, but 0-20% centrality excluded
+    cuts.AddCut("80000113","00200009327000008250400000","1111100047032230000","002010700","0103503m00000000","0103503000000000");
+  } else if( trainConfig == 252 ) { // same as 202, but 0-20% centrality excluded
+    cuts.AddCut("80010113","00200009327000008250400000","1111100047032230000","30a330709","0103503l00000000","0153503000000000");
+    cuts.AddCut("80010113","00200009327000008250400000","1111100047032230000","30a330709","0103503m00000000","0153503000000000");
+  } else if( trainConfig == 254 ) { // same as 204, but 0-20% centrality excluded
+    cuts.AddCut("80010113","00200009327000008250400000","1111100047032230000","30a330700","0103503l00000000","0153503000000000");
+    cuts.AddCut("80010113","00200009327000008250400000","1111100047032230000","30a330701","0103503l00000000","0153503000000000");
+    cuts.AddCut("80010113","00200009327000008250400000","1111100047032230000","30a330708","0103503l00000000","0153503000000000");
+
+  } else {
+    Error(Form("GammaConvNeutralMeson_MixedMode_%i",trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");
+    return;
+  }
+
+  if(!cuts.AreValid()){
+    cout << "\n\n****************************************************" << endl;
+    cout << "ERROR: No valid cuts stored in CutHandlerNeutralMixed! Returning..." << endl;
+    cout << "****************************************************\n\n" << endl;
+    return;
+  }
+
+  Int_t numberOfCuts = cuts.GetNCuts();
+
+  TList *EventCutList = new TList();
+  TList *ConvCutList  = new TList();
+  TList *ClusterCutList  = new TList();
+  TList *NeutralPionCutList = new TList();
+  TList *MesonCutList = new TList();
+  TList *PionCutList  = new TList();
+
+  TList *HeaderList = new TList();
+  TObjString *Header1 = new TObjString("pi0_1");
+  HeaderList->Add(Header1);
+  TObjString *Header3 = new TObjString("eta_2");
+  HeaderList->Add(Header3);
+
+  EventCutList->SetOwner(kTRUE);
+  AliConvEventCuts **analysisEventCuts = new AliConvEventCuts*[numberOfCuts];
+  ConvCutList->SetOwner(kTRUE);
+  AliConversionPhotonCuts **analysisCuts = new AliConversionPhotonCuts*[numberOfCuts];
+  ClusterCutList->SetOwner(kTRUE);
+  AliCaloPhotonCuts **analysisClusterCuts = new AliCaloPhotonCuts*[numberOfCuts];
+  NeutralPionCutList->SetOwner(kTRUE);
+  AliConversionMesonCuts **analysisNeutralPionCuts   = new AliConversionMesonCuts*[numberOfCuts];
+  MesonCutList->SetOwner(kTRUE);
+  AliConversionMesonCuts **analysisMesonCuts   = new AliConversionMesonCuts*[numberOfCuts];
+  PionCutList->SetOwner(kTRUE);
+  AliPrimaryPionCuts **analysisPionCuts     = new AliPrimaryPionCuts*[numberOfCuts];
+
+  for(Int_t i = 0; i<numberOfCuts; i++){
+    //create AliCaloTrackMatcher instance, if there is none present
+    TString caloCutPos = cuts.GetClusterCut(i);
+    caloCutPos.Resize(1);
+    TString TrackMatcherName = Form("CaloTrackMatcher_%s",caloCutPos.Data());
+    if( !(AliCaloTrackMatcher*)mgr->GetTask(TrackMatcherName.Data()) ){
+      AliCaloTrackMatcher* fTrackMatcher = new AliCaloTrackMatcher(TrackMatcherName.Data(),caloCutPos.Atoi());
+      fTrackMatcher->SetV0ReaderName(V0ReaderName);
+      mgr->AddTask(fTrackMatcher);
+      mgr->ConnectInput(fTrackMatcher,0,cinput);
+    }
+
+    analysisEventCuts[i] = new AliConvEventCuts();
+    analysisEventCuts[i]->SetV0ReaderName(V0ReaderName);
+    if(runLightOutput>0) analysisEventCuts[i]->SetLightOutput(kTRUE);
+    analysisEventCuts[i]->InitializeCutsFromCutString((cuts.GetEventCut(i)).Data());
+    if (periodNameV0Reader.CompareTo("") != 0) analysisEventCuts[i]->SetPeriodEnum(periodNameV0Reader);
+    EventCutList->Add(analysisEventCuts[i]);
+    analysisEventCuts[i]->SetFillCutHistograms("",kFALSE);
+
+    analysisCuts[i] = new AliConversionPhotonCuts();
+    analysisCuts[i]->SetV0ReaderName(V0ReaderName);
+    if(runLightOutput>0) analysisCuts[i]->SetLightOutput(kTRUE);
+    if( ! analysisCuts[i]->InitializeCutsFromCutString((cuts.GetConversionCut(i)).Data()) ) {
+      cout<<"ERROR: analysisCuts [" <<i<<"]"<<endl;
+      return 0;
+    } else {
+      ConvCutList->Add(analysisCuts[i]);
+      analysisCuts[i]->SetFillCutHistograms("",kFALSE);
+    }
+
+    analysisClusterCuts[i] = new AliCaloPhotonCuts();
+    analysisClusterCuts[i]->SetV0ReaderName(V0ReaderName);
+    if(runLightOutput>0) analysisClusterCuts[i]->SetLightOutput(kTRUE);
+    analysisClusterCuts[i]->SetCaloTrackMatcherName(TrackMatcherName);
+    if( ! analysisClusterCuts[i]->InitializeCutsFromCutString((cuts.GetClusterCut(i)).Data()) ) {
+      cout<<"ERROR: analysisClusterCuts [" <<i<<"]"<<endl;
+      return 0;
+    } else {
+      ClusterCutList->Add(analysisClusterCuts[i]);
+      analysisClusterCuts[i]->SetFillCutHistograms("");
+    }
+
+    analysisNeutralPionCuts[i] = new AliConversionMesonCuts();
+    if(runLightOutput>0) analysisNeutralPionCuts[i]->SetLightOutput(kTRUE);
+    if( ! analysisNeutralPionCuts[i]->InitializeCutsFromCutString((cuts.GetNeutralPionCut(i)).Data()) ) {
+      cout<<"ERROR: analysisMesonCuts [ " <<i<<" ] "<<endl;
+      return 0;
+    } else {
+      NeutralPionCutList->Add(analysisNeutralPionCuts[i]);
+      analysisNeutralPionCuts[i]->SetFillCutHistograms("");
+    }
+
+    analysisMesonCuts[i] = new AliConversionMesonCuts();
+    if(runLightOutput>0) analysisMesonCuts[i]->SetLightOutput(kTRUE);
+    if( ! analysisMesonCuts[i]->InitializeCutsFromCutString((cuts.GetMesonCut(i)).Data()) ) {
+      cout<<"ERROR: analysisMesonCuts [ " <<i<<" ] "<<endl;
+      return 0;
+    } else {
+      MesonCutList->Add(analysisMesonCuts[i]);
+      analysisMesonCuts[i]->SetFillCutHistograms("");
+    }
+    analysisEventCuts[i]->SetAcceptedHeader(HeaderList);
+
+    TString cutName( Form("%s_%s_%s_%s_%s_%s",(cuts.GetEventCut(i)).Data(), (cuts.GetConversionCut(i)).Data(), (cuts.GetClusterCut(i)).Data(),(cuts.GetPionCut(i)).Data(),(cuts.GetNeutralPionCut(i)).Data(), (cuts.GetMesonCut(i)).Data() ) );
+    analysisPionCuts[i] = new AliPrimaryPionCuts();
+    if(runLightOutput>0) analysisPionCuts[i]->SetLightOutput(kTRUE);
+
+    if( !analysisPionCuts[i]->InitializeCutsFromCutString((cuts.GetPionCut(i)).Data())) {
+      cout<< "ERROR:  analysisPionCuts [ " <<i<<" ] "<<endl;
+      return 0;
+    } else {
+      PionCutList->Add(analysisPionCuts[i]);
+      analysisPionCuts[i]->SetFillCutHistograms("",kFALSE,cutName);
+    }
+  }
+
+  task->SetNDMRecoMode(neutralPionMode);
+  task->SetEventCutList(numberOfCuts,EventCutList);
+  task->SetConversionCutList(ConvCutList);
+  task->SetClusterCutList(ClusterCutList);
+  task->SetNeutralPionCutList(NeutralPionCutList);
+  task->SetMesonCutList(MesonCutList);
+  task->SetPionCutList(PionCutList);
+
+  task->SetMoveParticleAccordingToVertex(kTRUE);
+  task->SetSelectedHeavyNeutralMeson(selectHeavyNeutralMeson);
+
+  task->SetDoMesonQA(enableQAMesonTask );
+
+  //connect containers
+  AliAnalysisDataContainer *coutput =
+  mgr->CreateContainer(Form("GammaConvNeutralMesonPiPlPiMiNeutralMeson_%i_%i_%i.root",selectHeavyNeutralMeson,neutralPionMode, trainConfig), TList::Class(),
+              AliAnalysisManager::kOutputContainer,Form("GammaConvNeutralMesonPiPlPiMiNeutralMeson_%i_%i_%i.root",selectHeavyNeutralMeson,neutralPionMode, trainConfig));
+
+  mgr->AddTask(task);
+  mgr->ConnectInput(task,0,cinput);
+  mgr->ConnectOutput(task,1,coutput);
+
+  return;
+
+}


### PR DESCRIPTION
Added 3 `AddTask`s for `NeutralMesonPiPlPiMiNeutralMeson` **p-Pb** analysis (`ConvMode`, `MixedMode`, and `CaloMode`). The tasks and their train configs are derived from the tasks for pp analysis (only MinBias retained and `000` -> `800` in event cut numbers).