### PR TITLE
Simulation of the EMCAL energy scale shift in the trigger electronics

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.cxx
@@ -65,6 +65,7 @@ AliEmcalTriggerMakerKernel::AliEmcalTriggerMakerKernel():
   fSmearModelMean(nullptr),
   fSmearModelSigma(nullptr),
   fSmearThreshold(0.1),
+  fScaleShift(0.),
   fGeometry(nullptr),
   fPatchAmplitudes(nullptr),
   fPatchADCSimple(nullptr),
@@ -417,6 +418,8 @@ void AliEmcalTriggerMakerKernel::ReadCellData(AliVCaloCells *cells){
              celltime = cells->GetTime(iCell);
     if(celltime < fCellTimeLimits[0] || celltime > fCellTimeLimits[1]) continue;
     if(amp < fMinCellAmplitude) continue;
+    if(fScaleShift) amp += fScaleShift;
+    amp = TMath::Max(amp, 0.);      // never go negative in energy
     // get position
     Int_t absId=-1;
     fGeometry->GetFastORIndexFromCellIndex(cellId, absId);

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
@@ -389,6 +389,12 @@ public:
   void SetSmearThreshold(Double_t threshold) { fSmearThreshold = threshold; }
 
   /**
+   * @brief Simulate constant shift of the EMCAL Energy scale
+   * @param scaleshift Constant scale shift applied to each cell. In GeV
+   */
+  void SetScaleShift(Double_t scaleshift) { fScaleShift = scaleshift; }
+
+  /**
    * Check whether the trigger maker has been specially configured. Status has to
    * be set in the functions ConfigureForXX.
    * @return True if the trigger maker kernel is configured, false otherwise
@@ -498,6 +504,7 @@ protected:
   TF1                                       *fSmearModelMean;             ///< Smearing parameterization for the mean
   TF1                                       *fSmearModelSigma;            ///< Smearing parameterization for the width
   Double_t                                  fSmearThreshold;              ///< Smear threshold: Only cell energies above threshold are smeared
+  Double_t                                  fScaleShift;                  ///< Scale shift simulation
 
   const AliEMCALGeometry                    *fGeometry;                   //!<! Underlying EMCAL geometry
   AliEMCALTriggerDataGrid<double>           *fPatchAmplitudes;            //!<! TRU Amplitudes (for L0)

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetSubstructureTree.cxx
@@ -476,6 +476,7 @@ void AliAnalysisTaskEmcalJetSubstructureTree::UserExecOnce() {
       std::string clustname = clust->GetName();
       auto iscent = clustname.find("CENT") != std::string::npos, iscalo = clustname.find("CALO") != std::string::npos; 
       if(!(iscalo || iscent)) continue;
+      AliInfoStream() << "Adding trigger cluster " << clustname << " to cluster lumi monitor" << std::endl;
       clusternames.emplace_back(clustname);
    }
 
@@ -497,8 +498,9 @@ void AliAnalysisTaskEmcalJetSubstructureTree::FillLuminosity() {
         auto int7trigger = trigger.IsTriggerClass("INT7");
         auto bunchcrossing = trigger.BunchCrossing() == "B";
         auto nopf = trigger.PastFutureProtection() == "NOPF";
+        bool centcalo = (trigger.Triggercluster().find("CENT") != std::string::npos) || (trigger.Triggercluster().find("CALO") != std::string::npos);
         AliDebugStream(4) << "Full name: " << trigger.ExpandClassName() << ", INT7 trigger:  " << (int7trigger ? "Yes" : "No") << ", bunch crossing: " << (bunchcrossing ? "Yes" : "No") << ", no past-future protection: " << (nopf ? "Yes" : "No")  << ", Cluster: " << trigger.Triggercluster() << std::endl;
-        if(int7trigger && bunchcrossing && nopf) {
+        if(int7trigger && bunchcrossing && nopf && centcalo) {
           double downscale = downscalefactors->GetDownscaleFactorForTriggerClass(trigger.ExpandClassName());
           AliDebugStream(5) << "Using downscale " << downscale << std::endl;
           fLumiMonitor->Fill(trigger.Triggercluster().data(), 1./downscale);


### PR DESCRIPTION
A constant scale shift (in GeV) is added to each cell
when filling the offline simple ADC data grid. The scale
shift is applied before conversion to FastOR ADC values.