### PR TITLE
Fix AliTriggerAnalysis: TPC HV dip detection

### DIFF
--- a/OADB/AliTriggerAnalysis.cxx
+++ b/OADB/AliTriggerAnalysis.cxx
@@ -1156,6 +1156,8 @@ Bool_t AliTriggerAnalysis::IsHVdipTPCEvent(const AliVEvent* event) {
   // The function IsDetectorOn is implemented in AliESDEvent and AliAODEvent
   //     by default it returns kTRUE (so also for MC). Therefore no extra treatment is required
   //
+
+  if (fMC) return kFALSE;
   return !event->IsDetectorOn(AliDAQ::kTPC);
 }
 

--- a/PWGLF/NUCLEX/Nuclei/NucleiKine/AliAnalysisTaskNucleiKineCor.cxx
+++ b/PWGLF/NUCLEX/Nuclei/NucleiKine/AliAnalysisTaskNucleiKineCor.cxx
@@ -21,6 +21,9 @@
 
 ClassImp(AliAnalysisTaskNucleiKineCor);
 
+using std::cout;
+using std::endl;
+
 AliAnalysisTaskNucleiKineCor::AliAnalysisTaskNucleiKineCor(const char* name) :
   AliAnalysisTaskSE{name},
   fPdgCodes{211, -211, 321, -321, 2212, -2212, 2112, -2112, 1000010020, -1000010020,3122,-3122,3312,-3312,3334,-3334},
@@ -73,6 +76,9 @@ void AliAnalysisTaskNucleiKineCor::UserCreateOutputObjects()
   fHists[2] = new TH1D("hNdeuterons",";Number of deuterons at |Y|<1; Events",15,-0.5,14.5);
   fHists[2]->Sumw2();
   fOutputList->Add(fHists[2]);
+  fHists[3] = new TH1D("hEtaHadrons",";#eta; Events",100,-fAcc,fAcc);
+  fHists[3]->Sumw2();
+  fOutputList->Add(fHists[3]);
 
   fHists[10] = new TH2D("hHadHad","Hadron-hadron correlation;#Delta#varphi;Associated p_{T} (GeV/c)",
 			128,-TMath::Pi()/2,3*TMath::Pi()/2,100,0.,10);
@@ -108,14 +114,49 @@ void AliAnalysisTaskNucleiKineCor::UserCreateOutputObjects()
   fHists[17]->Sumw2();
   fOutputList->Add(fHists[17]);
 
-  fHists[18] = new TH2D("hHadHadAcc","Acceptance correction;#Delta#varphi;Associated p_{T} (GeV/c)",
-			128,-TMath::Pi()/2,3*TMath::Pi()/2,100,0.,10);
+  fHists[18] = new TH3D("hHadHadAcc","Acceptance correction;#Delta#varphi;Associated p_{T} (GeV/c)",
+			128,-TMath::Pi()/2,3*TMath::Pi()/2,128,-fAcc,fAcc,100,0.,10);
   fHists[18]->Sumw2();
   fOutputList->Add(fHists[18]);
   fHists[19] = new TH2D("hHadHadwAcc","Hadron-hadron correlation;#Delta#varphi;Associated p_{T} (GeV/c)",
 			128,-TMath::Pi()/2,3*TMath::Pi()/2,100,0.,10);
   fHists[19]->Sumw2();
   fOutputList->Add(fHists[19]);
+
+  fHists[20] = new TH2D("hHadEta","Hadron;#eta;Associated p_{T} (GeV/c)",
+			128,-fAcc,fAcc,100,0.,10);
+  fHists[20]->Sumw2();
+
+  fOutputList->Add(fHists[20]);
+
+  fHists[21] = new TH2D("hProtEta","Proton correlation;#eta;Associated p_{T} (GeV/c)",
+			128,-fAcc,fAcc,100,0.,10);
+  fHists[21]->Sumw2();
+  fOutputList->Add(fHists[21]);
+
+  fHists[22] = new TH2D("hDeutEta","Deuteron correlation;#eta;Associated p_{T} (GeV/c)",
+			128,-fAcc,fAcc,100,0.,10);
+  fHists[22]->Sumw2();
+  fOutputList->Add(fHists[22]);
+
+  fHists[23] = new TH2D("heHadHad","Hadron-hadron correlation (half #eta);#Delta#varphi;Associated p_{T} (GeV/c)",
+			128,-TMath::Pi()/2,3*TMath::Pi()/2,100,0.,10);
+  fHists[23]->Sumw2();
+  fOutputList->Add(fHists[23]);
+
+  fHists[24] = new TH2D("heHadProt","Hadron-proton correlation (half #eta);#Delta#varphi;Associated p_{T} (GeV/c)",
+			128,-TMath::Pi()/2,3*TMath::Pi()/2,100,0.,10);
+  fHists[24]->Sumw2();
+  fOutputList->Add(fHists[24]);
+
+  fHists[25] = new TH2D("heHadDeut","Hadron-deuteron correlation (half #eta);#Delta#varphi;Associated p_{T} (GeV/c)",
+			128,-TMath::Pi()/2,3*TMath::Pi()/2,100,0.,10);
+  fHists[25]->Sumw2();
+  fOutputList->Add(fHists[25]);
+
+  fHists[26] = new TH1D("feHadTrigs",";Number; Entries",25,-0.5,24.5);
+  fHists[26]->Sumw2();
+  fOutputList->Add(fHists[26]);
 
   fHists[97] = new TProfile("hXsec",";Cross section;;",1,-0.5,0.5,"e");
   fOutputList->Add(fHists[97]);
@@ -215,7 +256,9 @@ void AliAnalysisTaskNucleiKineCor::UserExec(Option_t*)
       arrd.Add(track);
     } 
   }
-  fPtLead->Fill(leadP->Pt());
+
+  if (leadP!=0) 
+    fPtLead->Fill(leadP->Pt());
 
   Int_t nh = arrh.GetEntries();
   fHists[0]->Fill(nh);
@@ -226,9 +269,12 @@ void AliAnalysisTaskNucleiKineCor::UserExec(Option_t*)
 
   // hadron - hadron
   TH2 *hh  = (TH2*)fHists[10];
-  TH2 *ac  = (TH2*)fHists[18];
+  TH3 *ac  = (TH3*)fHists[18];
   TH2 *hh2 = (TH2*)fHists[19];
-  Int_t ntrigs = 0;
+  TH2 *hhe = (TH2*)fHists[20];
+  TH2 *hh3 = (TH2*)fHists[23];
+  Int_t ntrigs  = 0;
+  Int_t ntrigs2 = 0;
   for (Int_t i=0;i<nh;++i) {
     TParticle *part1 = (TParticle*)arrh.At(i);
     const double pt1 = part1->Pt();
@@ -236,7 +282,10 @@ void AliAnalysisTaskNucleiKineCor::UserExec(Option_t*)
       continue;
     const double phi1 = part1->Phi();
     const double eta1 = part1->Eta();
+    fHists[3]->Fill(eta1);
     ntrigs++;
+    if (TMath::Abs(eta1)<fAcc/2.)
+      ntrigs2++;
     for (Int_t j=0;j<nh;++j) {
       TParticle *part2 = (TParticle*)arrh.At(j);
       if (part2==part1) 
@@ -244,17 +293,22 @@ void AliAnalysisTaskNucleiKineCor::UserExec(Option_t*)
       const double dphi = DeltaPhi(phi1,part2->Phi());
       const double deta = part2->Eta()-eta1;
       hh->Fill(dphi,part2->Pt());
+      hhe->Fill(part2->Eta(),part2->Pt());
       const double acorr = 1-TMath::Abs(deta)/2/fAcc; 
       if (acorr>0) {
-	ac->Fill(dphi,part2->Pt(),1./acorr);
+	ac->Fill(dphi,deta,part2->Pt());
 	hh2->Fill(dphi,part2->Pt(),1./acorr);
       }
+      if (TMath::Abs(eta1)<fAcc/2.)
+	hh3->Fill(dphi,part2->Pt());
     }
     fHists[11]->Fill(ntrigs);  
+    fHists[26]->Fill(ntrigs2);  
   }
 
   // leading hadron - hadron
   hh = (TH2*)fHists[12];
+  hhe = (TH2*)fHists[21];
   if (ptl>fPt) {
     const double phi1 = leadP->Phi();
     const double eta1 = leadP->Eta();
@@ -265,12 +319,14 @@ void AliAnalysisTaskNucleiKineCor::UserExec(Option_t*)
       const double dphi = DeltaPhi(phi1,part2->Phi());
       const double deta = part2->Eta()-eta1;
       hh->Fill(dphi,part2->Pt());
+      hhe->Fill(part2->Eta(),part2->Pt());
     }
     fHists[13]->Fill(1);  
   }
 
   // hadron - proton
   hh = (TH2*)fHists[14];
+  hh3 = (TH2*)fHists[24];
   for (Int_t i=0;i<nh;++i) {
     TParticle *part1 = (TParticle*)arrh.At(i);
     const double pt1 = part1->Pt();
@@ -285,6 +341,8 @@ void AliAnalysisTaskNucleiKineCor::UserExec(Option_t*)
       const double dphi = DeltaPhi(phi1,part2->Phi());
       const double deta = part2->Eta()-eta1;
       hh->Fill(dphi,part2->Pt());
+      if (TMath::Abs(eta1)<fAcc/2.)
+	hh3->Fill(dphi,part2->Pt());
     }
   }
 
@@ -305,6 +363,8 @@ void AliAnalysisTaskNucleiKineCor::UserExec(Option_t*)
 
   // hadron - deuteron
   hh = (TH2*)fHists[16];
+  hhe = (TH2*)fHists[22];
+  hh3 = (TH2*)fHists[25];
   for (Int_t i=0;i<nh;++i) {
     TParticle *part1 = (TParticle*)arrh.At(i);
     const double pt1 = part1->Pt();
@@ -319,6 +379,9 @@ void AliAnalysisTaskNucleiKineCor::UserExec(Option_t*)
       const double dphi = DeltaPhi(phi1,part2->Phi());
       const double deta = part2->Eta()-eta1;
       hh->Fill(dphi,part2->Pt());
+      hhe->Fill(part2->Eta(),part2->Pt());
+      if (TMath::Abs(eta1)<fAcc/2.)
+	hh3->Fill(dphi,part2->Pt());
     }
   }
 


### PR DESCRIPTION
Revert partially change of 
https://github.com/alisw/AliRoot/pull/678
https://github.com/alisw/AliPhysics/pull/5489
to avoid calling IsDetectorOn for MC

Discussion by email attached below:
> Hi all,
>
> sorry for the confusion.
> You are right. If you use ESD MC indeed the events can be rejected with the addition of realistic time stamps, which was not there in the past.
>
> Then we should add back the check for MC. Sorry, this I didn't think about when modifying the code. I was fooled since I thought about AliMCEvent, which is of course not for the reconstructed MC data ...
>
> For the data analysis, of course, this is what we want, since those events will have bad PID. This in turn can lead to different results. The rejection in MC, however, should not have an influence on the analysis, except statistical, since we don't use the voltages in the simulation.
>
> Cheers,
> Jens
>
> On 21.09.2018 14:39, Constantin Loizides wrote:
>> Hi all,
>>
>> let me add that reading the code / commits it seems to me that unlike on AOD for ESD
>>
>> the change in the AliTriggerAnalysis::IsHVdipTPCEvent function would change between
>>
>> these two tags. (So I am betting a few beers that somehow on MC the function does not
>>
>> always return false)
>>
>> Constantin
>>
>>
>>
>> On 09/21/2018 02:37 PM, Daniel Mühlheim wrote:
>>> Dear all,
>>>
>>> The paper results were produced using ESDs because of much better grid efficiency compared to AODs. Hence, we are talking about ESDs and we do run PS.
>>>
>>> We are sure that it is not a grid glitch since our results are stable until 20180524 (we checked many tags from mid-2017 until 20180524) and it is persistent beyond 20180525 up to latest tags from today (the results are identical since 20180525, again checked with many tags in between).
>>>
>>> I'm trying to demonstrate the issue now locally. If I do not suceed in this I will run a train for further demonstration. I'll keep you updated.
>>>
>>> Cheers,
>>> Daniel
>>>
>>> On 21.09.2018 09:56, Evgeny Kryshen wrote:
>>>>
>>>> Dear all,
>>>>
>>>> I am also surprised to see this strange 5% effect in MC. Two questions:
>>>>
>>>> * Do you run PS on ESDs or AODs?
>>>>
>>>> * Are you sure that this 5% effect is not due to some glitch in the grid analysis? Could you take one ESD/AOD chunk and demonstrate the problem explicitly? If the effect is 5%-tish, it should be visible with one chunk.
>>>>
>>>> Cheers,
>>>>
>>>> Evgeny
>>>>
>>>>
>>>> On 09/20/2018 09:08 PM, Constantin Loizides wrote:
>>>>>
>>>>> To check it I would propose to add
>>>>>
>>>>> if (fMC) return kFALSE;
>>>>>
>>>>> in the Bool_t AliTriggerAnalysis::IsHVdipTPCEvent(const AliVEvent* event) {
>>>>>
>>>>> function...
>>>>>
>>>>> This should not hurt and could be tested with the next tag.
>>>>>
>>>>> Constantin
>>>>>
>>>>> On 09/20/2018 06:56 PM, Daniel Mühlheim wrote:
>>>>>> Dear Jens, all,
>>>>>>
>>>>>> Thanks for your explanations, I understand that in principle nothing should have changed. But the problem is that we see a difference and no other commit touched anything concerning trigger.
>>>>>>
>>>>>> Does anyone know if it is possible to create a tag like vAN-20180920-2 containing a revert of this TPC HV commit in addition? Then we could verify easily.
>>>>>>
>>>>>> Cheers,
>>>>>> Daniel
>>>>>>
>>>>>> On 20.09.2018 17:07, Jens Wiechula wrote:
>>>>>>> Hi all,
>>>>>>>
>>>>>>> the following two pull requests are of interest:
>>>>>>> https://github.com/alisw/AliRoot/pull/678
>>>>>>> https://github.com/alisw/AliPhysics/pull/5489
>>>>>>>
>>>>>>> The changes were done in a way that MC should not be affected. It is steered via
>>>>>>> AliVEvent.h
>>>>>>> virtual Bool_t IsDetectorOn(ULong_t /*detMask*/) const { return kTRUE; }
>>>>>>>
>>>>>>> which is only implemented for AliESDEvent and AliAODEvent
>>>>>>>
>>>>>>> git grep IsDetectorOn
>>>>>>> STEER/AOD/AliAODEvent.h:  virtual Bool_t IsDetectorOn(ULong_t detMask) const { return fHeader ? fHeader->IsDetectorOn(UInt_t(detMask)) : kTRUE; }
>>>>>>> STEER/AOD/AliAODHeader.h:  Bool_t IsDetectorOn(ULong_t detMask) const    { return (fDetectorStatus&detMask)>0; }
>>>>>>> STEER/AOD/AliNanoAODHeader.h:  virtual Bool_t IsDetectorOn(ULong_t /*detMask*/) const { return kTRUE; }
>>>>>>> STEER/ESD/AliESDEvent.h:  Bool_t IsDetectorOn(ULong_t detMask) const {return (fDetectorStatus&detMask)>0;}
>>>>>>> STEER/STEERBase/AliVAODHeader.h:  virtual Bool_t IsDetectorOn(ULong_t detMask) const = 0;
>>>>>>> STEER/STEERBase/AliVEvent.h:  virtual Bool_t IsDetectorOn(ULong_t /*detMask*/) const { return kTRUE; }
>>>>>>> TPC/TPCrec/AliTPCtracker.cxx:  //printf("Status %d \n", event->IsDetectorOn(AliDAQ::kTPC));
>>>>>>>
>>>>>>> So I don't see how this could influence MC since
>>>>>>>
>>>>>>> Bool_t AliTriggerAnalysis::IsHVdipTPCEvent(const AliVEvent* event) {
>>>>>>>   // The function IsDetectorOn is implemented in AliESDEvent and AliAODEvent
>>>>>>>   //     by default it returns kTRUE (so also for MC). Therefore no extra treatment is required
>>>>>>>   //
>>>>>>>   return !event->IsDetectorOn(AliDAQ::kTPC);
>>>>>>> }
>>>>>>>
>>>>>>> will always return false and not events will be rejected.
>>>>>>>
>>>>>>> There were also changes in other files between vAN-20180524..vAN-20180525
>>>>>>> git diff --stat vAN-20180524..vAN-20180525
>>>>>>>
>>>>>>>
>>>>>>> Please let me know in case of further questions.
>>>>>>>
>>>>>>> Cheers,
>>>>>>> Jens
>>>>>>>
>>>>>>>
>>>>>>> On 20.09.2018 14:17, Constantin Loizides wrote:
>>>>>>>> Hi everyone,
>>>>>>>>
>>>>>>>> thanks for this big step forward in understanding where the discrepancy comes from.
>>>>>>>>
>>>>>>>> Jens, in addition to the specifc question from Daniel, is there a potential dataset (or readout-cluster)
>>>>>>>>
>>>>>>>> dependence?
>>>>>>>>
>>>>>>>> Could run1 pPb datasets be affected?
>>>>>>>>
>>>>>>>> thanks
>>>>>>>>
>>>>>>>> Constantin
>>>>>>>>
>>>>>>>>
>>>>>>>> On 09/20/2018 10:11 AM, Daniel Mühlheim wrote:
>>>>>>>>> Dear Jens, Evgeny,
>>>>>>>>>
>>>>>>>>> we tried to validate our results on photon and meson production in pp collisions at 8 TeV (LHC12a-i and LHC15h1a-i + LHC15h2a-i) which entered
>>>>>>>>> arXiv earlier this year for the purpose of journal publication. However, we observed a disagreement on the level of approximately 5% compared
>>>>>>>>> to our old output.
>>>>>>>>>
>>>>>>>>> After some extensive studies, we found that this disagreement appears between AliPhysics tags 20180524 and 20180525 (both share the same
>>>>>>>>> AliRoot tag). At the same time we observe an increase of 5% of the total number of MC events being rejected due to some trigger condition. On
>>>>>>>>> the other hand, the data is completely unaffected.
>>>>>>>>> In the attachment, you can find the spectrum of our Pi0 measurement. "PUB" (neutral meson paper) denotes the spectrum entering publication in
>>>>>>>>> August 2017, "PUB dirG" (paper on direct photon production) entered arXiv in March this year. Some fluctuations are visible compared to both
>>>>>>>>> paper versions because we did not run full MC set to save resources during debugging.
>>>>>>>>>
>>>>>>>>> During these two tags, 24.05. and 25.05., a commit concerning TPC HV dip detection was made which we consider a possible cause for this
>>>>>>>>> behavior. In between these two tags, no other commit relevant to the trigger condition was made and there are no other commits we could
>>>>>>>>> identify that may cause this behavior.
>>>>>>>>>
>>>>>>>>> We are puzzled about this behavior, could you please have a look?
>>>>>>>>>
>>>>>>>>> Best regards,
>>>>>>>>> Daniel
>>>>>>>>
>>>>>>
>>>>>
>>>>
>>>
>>
