### PR TITLE
EMCal CorrFW: Add additional non-linearity enums

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterNonLinearity.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterNonLinearity.cxx
@@ -28,7 +28,11 @@ const std::map <std::string, AliEMCALRecoUtils::NonlinearityFunctions> AliEmcalC
     { "kPi0MCv5", AliEMCALRecoUtils::kPi0MCv5 },
     { "kSDMv6", AliEMCALRecoUtils::kSDMv6 },
     { "kPi0MCv6", AliEMCALRecoUtils::kPi0MCv6 },
-    { "kBeamTestCorrectedv3", AliEMCALRecoUtils::kBeamTestCorrectedv3 }
+    { "kBeamTestCorrectedv3", AliEMCALRecoUtils::kBeamTestCorrectedv3 },
+    { "kPCMv1", AliEMCALRecoUtils::kPCMv1 },
+    { "kPCMplusBTCv1", AliEMCALRecoUtils::kPCMplusBTCv1 },
+    { "kPCMsysv1", AliEMCALRecoUtils::kPCMsysv1 },
+    { "kBeamTestCorrectedv4", AliEMCALRecoUtils::kBeamTestCorrectedv4 }
 };
 
 /**


### PR DESCRIPTION
Each enum value needs to be explicitly added to the string map to allow the value to be set from the YAML config. Adds `kBeamTestCorrectedv4` (from #6912) and some PCM parameterizations.