### PR TITLE
Allow trigger track label selection

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetExtractor.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetExtractor.cxx
@@ -349,6 +349,7 @@ AliAnalysisTaskJetExtractor::AliAnalysisTaskJetExtractor() :
   fSetEmcalJetFlavour(0),
   fEventCut_TriggerTrackMinPt(0),
   fEventCut_TriggerTrackMaxPt(0),
+  fEventCut_TriggerTrackMinLabel(0),
   fJetsCont(0),
   fTracksCont(0),
   fTruthParticleArray(0),
@@ -381,6 +382,7 @@ AliAnalysisTaskJetExtractor::AliAnalysisTaskJetExtractor(const char *name) :
   fSetEmcalJetFlavour(0),
   fEventCut_TriggerTrackMinPt(0),
   fEventCut_TriggerTrackMaxPt(0),
+  fEventCut_TriggerTrackMinLabel(0),
   fJetsCont(0),
   fTracksCont(0),
   fTruthParticleArray(0),
@@ -623,7 +625,7 @@ Bool_t AliAnalysisTaskJetExtractor::IsEventSelected()
     // Go through all tracks and check whether trigger tracks can be found
     fTracksCont->ResetCurrentID();
     while(AliVTrack *track = static_cast<AliVTrack*>(fTracksCont->GetNextAcceptParticle()))
-      if( (track->Pt() >= fEventCut_TriggerTrackMinPt) && (track->Pt() < fEventCut_TriggerTrackMaxPt) )
+      if( (track->GetLabel() >= fEventCut_TriggerTrackMinLabel) && (track->Pt() >= fEventCut_TriggerTrackMinPt) && (track->Pt() < fEventCut_TriggerTrackMaxPt) )
       {
         fTriggerTracks_Pt.push_back(track->Pt());
         fTriggerTracks_Eta.push_back(track->Eta());

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetExtractor.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetExtractor.h
@@ -43,8 +43,8 @@ class AliAnalysisTaskJetExtractor : public AliAnalysisTaskEmcalJet {
   void                        SetVertexerCuts(AliRDHFJetsCutsVertex* val)         { fVertexerCuts = val; }
   void                        SetSetEmcalJetFlavour(Bool_t val)                   { fSetEmcalJetFlavour = val; }
 
-  void                        SetEventCutTriggerTrack(Double_t minPt, Double_t maxPt)
-                                { fEventCut_TriggerTrackMinPt = minPt; fEventCut_TriggerTrackMaxPt = maxPt;}
+  void                        SetEventCutTriggerTrack(Double_t minPt, Double_t maxPt, Int_t minLabel=0)
+                                { fEventCut_TriggerTrackMinPt = minPt; fEventCut_TriggerTrackMaxPt = maxPt; fEventCut_TriggerTrackMinLabel = minLabel; }
 
  protected:
   Bool_t                      CreateControlHistograms();
@@ -77,6 +77,7 @@ class AliAnalysisTaskJetExtractor : public AliAnalysisTaskEmcalJet {
   // ################## EVENT CUTS
   Double_t                    fEventCut_TriggerTrackMinPt;              ///< Event requirement, trigger track min pT
   Double_t                    fEventCut_TriggerTrackMaxPt;              ///< Event requirement, trigger track max pT
+  Int_t                       fEventCut_TriggerTrackMinLabel;           ///< Event requirement, trigger track min label (can be used to selected embedded particles)
 
   // ################## BASIC EVENT VARIABLES
   AliJetContainer            *fJetsCont;                                //!<! Jets

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskParticleRandomizer.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskParticleRandomizer.cxx
@@ -201,7 +201,7 @@ AliAODTrack* AliAnalysisTaskParticleRandomizer::GetAODTrack(AliPicoTrack* track)
   newTrack->SetTheta(2.*atan(exp(-track->Eta()))); // there is no setter for eta
   newTrack->SetPhi(track->Phi());
   newTrack->SetCharge(track->Charge());
-  newTrack->SetLabel(track->GetLabel());
+  newTrack->SetLabel(100000+track->GetLabel()); // this tags tracks as 'embedded tracks'
 
   // Hybrid tracks (compatible with LHC11h)
   UInt_t filterMap = BIT(8) | BIT(9);


### PR DESCRIPTION
New option: Trigger track in extractor will only be used if it has a label above a value (e.g. when from MC/embedding)