### PR TITLE
Bugfix: Function in underlying framework was masked

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetExtractor.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetExtractor.cxx
@@ -499,7 +499,7 @@ void AliAnalysisTaskJetExtractor::ExecOnce()
 Bool_t AliAnalysisTaskJetExtractor::Run()
 {
   // ################################### EVENT PROPERTIES
-  if(!IsEventSelected())
+  if(!IsTriggerTrackInEvent())
     return kFALSE;
 
   FillEventControlHistograms();
@@ -612,7 +612,7 @@ Bool_t AliAnalysisTaskJetExtractor::Run()
 }
 
 //________________________________________________________________________
-Bool_t AliAnalysisTaskJetExtractor::IsEventSelected()
+Bool_t AliAnalysisTaskJetExtractor::IsTriggerTrackInEvent()
 {
   // Cut for trigger track requirement
   if(fEventCut_TriggerTrackMinPt || fEventCut_TriggerTrackMaxPt)

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetExtractor.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskJetExtractor.h
@@ -50,7 +50,7 @@ class AliAnalysisTaskJetExtractor : public AliAnalysisTaskEmcalJet {
   Bool_t                      CreateControlHistograms();
   void                        ExecOnce();
   Bool_t                      Run();
-  Bool_t                      IsEventSelected();
+  Bool_t                      IsTriggerTrackInEvent();
   void                        FillTrackControlHistograms(AliVTrack* track);
   void                        FillEventControlHistograms();
   void                        FillJetControlHistograms(AliEmcalJet* jet);


### PR DESCRIPTION
Small bugfix, the event selection function in underlying emcal jet framework was accidentally overwritten in an earlier commit.