### PR TITLE
PWGGA added code to handle jets

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskConvJet.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvJet.cxx
@@ -1,0 +1,449 @@
+/**************************************************************************
+ * Copyright(c) 1998-2016, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: The ALICE Off-line Project.                                    *
+ * Contributors are mentioned in the code where appropriate.              *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+#include <TClonesArray.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TList.h>
+
+#include <AliAnalysisManager.h>
+#include <AliVEventHandler.h>
+#include <AliVCluster.h>
+#include <AliVParticle.h>
+#include <AliLog.h>
+
+#include "AliTLorentzVector.h"
+#include "AliEmcalJet.h"
+#include "AliRhoParameter.h"
+#include "AliJetContainer.h"
+#include "AliParticleContainer.h"
+#include "AliClusterContainer.h"
+
+#include "AliAnalysisTaskConvJet.h"
+
+/// \cond CLASSIMP
+ClassImp(AliAnalysisTaskConvJet);
+/// \endcond
+
+/**
+ * Default constructor. Needed by ROOT I/O
+ */
+AliAnalysisTaskConvJet::AliAnalysisTaskConvJet() : 
+  AliAnalysisTaskEmcalJet(),
+//   fHistManager(),
+  fNJets(0),
+  fVectorJetPt(0),
+  fVectorJetEta(0),
+  fVectorJetPhi(0),
+  fVectorJetR(0)
+{
+}
+
+/**
+ * Standard constructor. Should be used by the user.
+ *
+ * @param[in] name Name of the task
+ */
+AliAnalysisTaskConvJet::AliAnalysisTaskConvJet(const char *name) : 
+  AliAnalysisTaskEmcalJet(name, kTRUE),
+//   fHistManager(name),
+  fNJets(0),
+  fVectorJetPt(0),
+  fVectorJetEta(0),
+  fVectorJetPhi(0),
+  fVectorJetR(0)
+{
+  SetMakeGeneralHistograms(kTRUE);
+}
+
+/**
+ * Destructor
+ */
+AliAnalysisTaskConvJet::~AliAnalysisTaskConvJet()
+{
+}
+
+/**
+ * Performing run-independent initialization.
+ * Here the histograms should be instantiated.
+ */
+void AliAnalysisTaskConvJet::UserCreateOutputObjects()
+{
+   AliAnalysisTaskEmcalJet::UserCreateOutputObjects();
+
+  PostData(1, fOutput); // Post data for ALL output slots > 0 here.
+}
+
+/**
+ * The body of this function should contain instructions to fill the output histograms.
+ * This function is called inside the event loop, after the function Run() has been
+ * executed successfully (i.e. it returned kTRUE).
+ * @return Always kTRUE
+ */
+Bool_t AliAnalysisTaskConvJet::FillHistograms()
+{
+  DoJetLoop();
+
+  return kTRUE;
+}
+
+/**
+ * This function performs a loop over the reconstructed jets
+ * in the current event and fills the relevant histograms.
+ */
+void AliAnalysisTaskConvJet::DoJetLoop()
+{
+  AliJetContainer* jetCont = 0;
+  TIter next(&fJetCollArray);
+  while ((jetCont = static_cast<AliJetContainer*>(next()))) {
+    UInt_t count = 0;
+    fNJets = 0 ;
+    fVectorJetPt.clear();
+    fVectorJetEta.clear();
+    fVectorJetPhi.clear();
+    fVectorJetR.clear();
+    for(auto jet : jetCont->accepted()) {
+      if (!jet) continue;
+      count++;
+      fVectorJetPt.push_back(jet->Pt());
+      fVectorJetEta.push_back(jet->Eta());
+      fVectorJetPhi.push_back(jet->Phi());
+      fVectorJetR.push_back(jet->Area());
+    }
+    fNJets = count ;
+  }
+}
+
+/**
+ * This function performs a loop over the reconstructed tracks
+ * in the current event and fills the relevant histograms.
+ */
+// void AliAnalysisTaskConvJet::DoTrackLoop()
+// {
+//   AliClusterContainer* clusCont = GetClusterContainer(0);
+// 
+//   TString histname;
+//   TString groupname;
+//   UInt_t sumAcceptedTracks = 0;
+//   AliParticleContainer* partCont = 0;
+//   TIter next(&fParticleCollArray);
+//   while ((partCont = static_cast<AliParticleContainer*>(next()))) {
+//     groupname = partCont->GetName();
+//     UInt_t count = 0;
+//     for(auto part : partCont->accepted()) {
+//       if (!part) continue;
+//       count++;
+// 
+//       histname = TString::Format("%s/histTrackPt", groupname.Data());
+//       fHistManager.FillTH1(histname, part->Pt());
+// 
+//       histname = TString::Format("%s/histTrackPhi", groupname.Data());
+//       fHistManager.FillTH1(histname, part->Phi());
+// 
+//       histname = TString::Format("%s/histTrackEta", groupname.Data());
+//       fHistManager.FillTH1(histname, part->Eta());
+// 
+//       if (partCont->GetLoadedClass()->InheritsFrom("AliVTrack")) {
+//         const AliVTrack* track = static_cast<const AliVTrack*>(part);
+// 
+//         histname = TString::Format("%s/fHistDeltaEtaPt", groupname.Data());
+//         fHistManager.FillTH1(histname, track->Pt(), track->Eta() - track->GetTrackEtaOnEMCal());
+// 
+//         histname = TString::Format("%s/fHistDeltaPhiPt", groupname.Data());
+//         fHistManager.FillTH1(histname, track->Pt(), track->Phi() - track->GetTrackPhiOnEMCal());
+// 
+//         histname = TString::Format("%s/fHistDeltaPtvsPt", groupname.Data());
+//         fHistManager.FillTH1(histname, track->Pt(), track->Pt() - track->GetTrackPtOnEMCal());
+// 
+//         if (clusCont) {
+//           Int_t iCluster = track->GetEMCALcluster();
+//           if (iCluster >= 0) {
+//             AliVCluster* cluster = clusCont->GetAcceptCluster(iCluster);
+//             if (cluster) {
+//               histname = TString::Format("%s/fHistEoverPvsP", groupname.Data());
+//               fHistManager.FillTH2(histname, track->P(), cluster->GetNonLinCorrEnergy() / track->P());
+//             }
+//           }
+//         }
+//       }
+//     }
+//     sumAcceptedTracks += count;
+// 
+//     histname = TString::Format("%s/histNTracks", groupname.Data());
+//     fHistManager.FillTH1(histname, count);
+//   }
+// 
+//   histname = "fHistSumNTracks";
+//   fHistManager.FillTH1(histname, sumAcceptedTracks);
+// }
+
+/**
+ * This function performs a loop over the reconstructed EMCal clusters
+ * in the current event and fills the relevant histograms.
+ */
+// void AliAnalysisTaskConvJet::DoClusterLoop()
+// {
+//   TString histname;
+//   TString groupname;
+//   UInt_t sumAcceptedClusters = 0;
+//   AliClusterContainer* clusCont = 0;
+//   TIter next(&fClusterCollArray);
+//   while ((clusCont = static_cast<AliClusterContainer*>(next()))) {
+//     groupname = clusCont->GetName();
+// 
+//     for(auto cluster : clusCont->all()) {
+//       if (!cluster) continue;
+// 
+//       if (cluster->GetIsExotic()) {
+//         histname = TString::Format("%s/histClusterEnergyExotic", groupname.Data());
+//         fHistManager.FillTH1(histname, cluster->E());
+//       }
+//     }
+// 
+//     UInt_t count = 0;
+//     for(auto cluster : clusCont->accepted()) {
+//       if (!cluster) continue;
+//       count++;
+// 
+//       AliTLorentzVector nPart;
+//       cluster->GetMomentum(nPart, fVertex);
+// 
+//       histname = TString::Format("%s/histClusterEnergy", groupname.Data());
+//       fHistManager.FillTH1(histname, cluster->E());
+// 
+//       histname = TString::Format("%s/histClusterNonLinCorrEnergy", groupname.Data());
+//       fHistManager.FillTH1(histname, cluster->GetNonLinCorrEnergy());
+// 
+//       histname = TString::Format("%s/histClusterHadCorrEnergy", groupname.Data());
+//       fHistManager.FillTH1(histname, cluster->GetHadCorrEnergy());
+// 
+//       histname = TString::Format("%s/histClusterPhi", groupname.Data());
+//       fHistManager.FillTH1(histname, nPart.Phi_0_2pi());
+// 
+//       histname = TString::Format("%s/histClusterEta", groupname.Data());
+//       fHistManager.FillTH1(histname, nPart.Eta());
+//     }
+//     sumAcceptedClusters += count;
+// 
+//     histname = TString::Format("%s/histNClusters", groupname.Data());
+//     fHistManager.FillTH1(histname, count);
+//   }
+// 
+//   histname = "fHistSumNClusters";
+//   fHistManager.FillTH1(histname, sumAcceptedClusters);
+// }
+// 
+// /**
+//  * This function performs a loop over the reconstructed EMCal cells
+//  * in the current event and fills the relevant histograms.
+//  */
+// void AliAnalysisTaskConvJet::DoCellLoop()
+// {
+//   if (!fCaloCells) return;
+// 
+//   TString histname;
+// 
+//   const Short_t ncells = fCaloCells->GetNumberOfCells();
+// 
+//   histname = TString::Format("%s/histNCells", fCaloCellsName.Data());
+//   fHistManager.FillTH1(histname, ncells);
+// 
+//   histname = TString::Format("%s/histCellEnergy", fCaloCellsName.Data());
+//   for (Short_t pos = 0; pos < ncells; pos++) {
+//     Double_t amp   = fCaloCells->GetAmplitude(pos);
+//     
+//     fHistManager.FillTH1(histname, amp);
+//   }
+// }
+
+/**
+ * This function is executed automatically for the first event.
+ * Some extra initialization can be performed here.
+ */
+void AliAnalysisTaskConvJet::ExecOnce()
+{
+  AliAnalysisTaskEmcalJet::ExecOnce();
+}
+
+/**
+ * Run analysis code here, if needed.
+ * It will be executed before FillHistograms().
+ * If this function return kFALSE, FillHistograms() will *not*
+ * be executed for the current event
+ * @return Always kTRUE
+ */
+Bool_t AliAnalysisTaskConvJet::Run()
+{
+  return kTRUE;
+}
+
+/**
+ * This function is called once at the end of the analysis.
+ */
+void AliAnalysisTaskConvJet::Terminate(Option_t *) 
+{
+}
+
+/**
+ * This function adds the task to the analysis manager. Often, this function is called
+ * by an AddTask C macro. However, by compiling the code, it ensures that we do not
+ * have to deal with difficulties caused by CINT.
+ */
+AliAnalysisTaskConvJet * AliAnalysisTaskConvJet::AddTask_GammaConvJet(
+  const char *ntracks,
+  const char *nclusters,
+  const char* ncells,
+  const char *suffix)
+{
+  // Get the pointer to the existing analysis manager via the static access method.
+  //==============================================================================
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr)
+  {
+    ::Error("AddTask_GammaConvJet", "No analysis manager to connect to.");
+    return 0;
+  }
+
+  // Check the analysis type using the event handlers connected to the analysis manager.
+  //==============================================================================
+  AliVEventHandler* handler = mgr->GetInputEventHandler();
+  if (!handler)
+  {
+    ::Error("AddTask_GammaConvJet", "This task requires an input event handler");
+    return 0;
+  }
+
+  enum EDataType_t {
+    kUnknown,
+    kESD,
+    kAOD
+  };
+
+  EDataType_t dataType = kUnknown;
+
+  if (handler->InheritsFrom("AliESDInputHandler")) {
+    dataType = kESD;
+  }
+  else if (handler->InheritsFrom("AliAODInputHandler")) {
+    dataType = kAOD;
+  }
+
+  //-------------------------------------------------------
+  // Init the task and do settings
+  //-------------------------------------------------------
+
+  TString trackName(ntracks);
+  TString clusName(nclusters);
+  TString cellName(ncells);
+
+  if (trackName == "usedefault") {
+    if (dataType == kESD) {
+      trackName = "Tracks";
+    }
+    else if (dataType == kAOD) {
+      trackName = "tracks";
+    }
+    else {
+      trackName = "";
+    }
+  }
+
+  if (clusName == "usedefault") {
+    if (dataType == kESD) {
+      clusName = "CaloClusters";
+    }
+    else if (dataType == kAOD) {
+      clusName = "caloClusters";
+    }
+    else {
+      clusName = "";
+    }
+  }
+
+  if (cellName == "usedefault") {
+    if (dataType == kESD) {
+      cellName = "EMCALCells";
+    }
+    else if (dataType == kAOD) {
+      cellName = "emcalCells";
+    }
+    else {
+      cellName = "";
+    }
+  }
+
+  TString name("AliAnalysisTaskConvJet");
+//   if (!trackName.IsNull()) {
+//     name += "_";
+//     name += trackName;
+//   }
+//   if (!clusName.IsNull()) {
+//     name += "_";
+//     name += clusName;
+//   }
+//   if (!cellName.IsNull()) {
+//     name += "_";
+//     name += cellName;
+//   }
+//   if (strcmp(suffix,"") != 0) {
+//     name += "_";
+//     name += suffix;
+//   }
+
+  AliAnalysisTaskConvJet* sampleTask = new AliAnalysisTaskConvJet(name);
+  sampleTask->SetCaloCellsName(cellName);
+  sampleTask->SetVzRange(-10,10);
+
+  if (trackName == "mcparticles") {
+    sampleTask->AddMCParticleContainer(trackName);
+  }
+  else if (trackName == "tracks" || trackName == "Tracks") {
+    sampleTask->AddTrackContainer(trackName);
+  }
+  else if (!trackName.IsNull()) {
+    sampleTask->AddParticleContainer(trackName);
+  }
+  sampleTask->AddClusterContainer(clusName);
+  
+  sampleTask->GetClusterContainer(0)->SetClusECut(0.);
+  sampleTask->GetClusterContainer(0)->SetClusPtCut(0.);
+  sampleTask->GetClusterContainer(0)->SetClusNonLinCorrEnergyCut(0.);
+  sampleTask->GetClusterContainer(0)->SetClusHadCorrEnergyCut(0.30);
+  sampleTask->GetClusterContainer(0)->SetDefaultClusterEnergy(AliVCluster::kHadCorr);
+  sampleTask->GetParticleContainer(0)->SetParticlePtCut(0.15);
+  sampleTask->GetParticleContainer(0)->SetParticleEtaLimits(-0.8,0.8);
+  sampleTask->GetTrackContainer(0)->SetParticlePtCut(0.15);
+  sampleTask->GetTrackContainer(0)->SetParticleEtaLimits(-0.8,0.8);
+  sampleTask->GetTrackContainer(0)->SetFilterHybridTracks(kTRUE);
+//   sampleTask->SetHistoBins(600, 0, 300);
+
+  //-------------------------------------------------------
+  // Final settings, pass to manager and set the containers
+  //-------------------------------------------------------
+
+  mgr->AddTask(sampleTask);
+
+  // Create containers for input/output
+  AliAnalysisDataContainer *cinput1  = mgr->GetCommonInputContainer()  ;
+  TString contname(name);
+  contname += "_histos";
+  AliAnalysisDataContainer *coutput1 = mgr->CreateContainer(contname.Data(),
+      TList::Class(),AliAnalysisManager::kOutputContainer,
+      Form("%s", AliAnalysisManager::GetCommonFileName()));
+  mgr->ConnectInput  (sampleTask, 0,  cinput1 );
+  mgr->ConnectOutput (sampleTask, 1, coutput1 );
+
+  return sampleTask;
+}

--- a/PWGGA/GammaConv/AliAnalysisTaskConvJet.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvJet.cxx
@@ -37,12 +37,9 @@
 ClassImp(AliAnalysisTaskConvJet);
 /// \endcond
 
-/**
- * Default constructor. Needed by ROOT I/O
- */
+
 AliAnalysisTaskConvJet::AliAnalysisTaskConvJet() : 
   AliAnalysisTaskEmcalJet(),
-//   fHistManager(),
   fNJets(0),
   fVectorJetPt(0),
   fVectorJetEta(0),
@@ -51,14 +48,8 @@ AliAnalysisTaskConvJet::AliAnalysisTaskConvJet() :
 {
 }
 
-/**
- * Standard constructor. Should be used by the user.
- *
- * @param[in] name Name of the task
- */
 AliAnalysisTaskConvJet::AliAnalysisTaskConvJet(const char *name) : 
   AliAnalysisTaskEmcalJet(name, kTRUE),
-//   fHistManager(name),
   fNJets(0),
   fVectorJetPt(0),
   fVectorJetEta(0),
@@ -68,9 +59,7 @@ AliAnalysisTaskConvJet::AliAnalysisTaskConvJet(const char *name) :
   SetMakeGeneralHistograms(kTRUE);
 }
 
-/**
- * Destructor
- */
+
 AliAnalysisTaskConvJet::~AliAnalysisTaskConvJet()
 {
 }
@@ -87,7 +76,7 @@ void AliAnalysisTaskConvJet::UserCreateOutputObjects()
 }
 
 /**
- * The body of this function should contain instructions to fill the output histograms.
+ * The body of this function should contain instructions to fill the vectors.
  * This function is called inside the event loop, after the function Run() has been
  * executed successfully (i.e. it returned kTRUE).
  * @return Always kTRUE
@@ -101,7 +90,7 @@ Bool_t AliAnalysisTaskConvJet::FillHistograms()
 
 /**
  * This function performs a loop over the reconstructed jets
- * in the current event and fills the relevant histograms.
+ * in the current event and fills the vectors.
  */
 void AliAnalysisTaskConvJet::DoJetLoop()
 {
@@ -125,148 +114,6 @@ void AliAnalysisTaskConvJet::DoJetLoop()
     fNJets = count ;
   }
 }
-
-/**
- * This function performs a loop over the reconstructed tracks
- * in the current event and fills the relevant histograms.
- */
-// void AliAnalysisTaskConvJet::DoTrackLoop()
-// {
-//   AliClusterContainer* clusCont = GetClusterContainer(0);
-// 
-//   TString histname;
-//   TString groupname;
-//   UInt_t sumAcceptedTracks = 0;
-//   AliParticleContainer* partCont = 0;
-//   TIter next(&fParticleCollArray);
-//   while ((partCont = static_cast<AliParticleContainer*>(next()))) {
-//     groupname = partCont->GetName();
-//     UInt_t count = 0;
-//     for(auto part : partCont->accepted()) {
-//       if (!part) continue;
-//       count++;
-// 
-//       histname = TString::Format("%s/histTrackPt", groupname.Data());
-//       fHistManager.FillTH1(histname, part->Pt());
-// 
-//       histname = TString::Format("%s/histTrackPhi", groupname.Data());
-//       fHistManager.FillTH1(histname, part->Phi());
-// 
-//       histname = TString::Format("%s/histTrackEta", groupname.Data());
-//       fHistManager.FillTH1(histname, part->Eta());
-// 
-//       if (partCont->GetLoadedClass()->InheritsFrom("AliVTrack")) {
-//         const AliVTrack* track = static_cast<const AliVTrack*>(part);
-// 
-//         histname = TString::Format("%s/fHistDeltaEtaPt", groupname.Data());
-//         fHistManager.FillTH1(histname, track->Pt(), track->Eta() - track->GetTrackEtaOnEMCal());
-// 
-//         histname = TString::Format("%s/fHistDeltaPhiPt", groupname.Data());
-//         fHistManager.FillTH1(histname, track->Pt(), track->Phi() - track->GetTrackPhiOnEMCal());
-// 
-//         histname = TString::Format("%s/fHistDeltaPtvsPt", groupname.Data());
-//         fHistManager.FillTH1(histname, track->Pt(), track->Pt() - track->GetTrackPtOnEMCal());
-// 
-//         if (clusCont) {
-//           Int_t iCluster = track->GetEMCALcluster();
-//           if (iCluster >= 0) {
-//             AliVCluster* cluster = clusCont->GetAcceptCluster(iCluster);
-//             if (cluster) {
-//               histname = TString::Format("%s/fHistEoverPvsP", groupname.Data());
-//               fHistManager.FillTH2(histname, track->P(), cluster->GetNonLinCorrEnergy() / track->P());
-//             }
-//           }
-//         }
-//       }
-//     }
-//     sumAcceptedTracks += count;
-// 
-//     histname = TString::Format("%s/histNTracks", groupname.Data());
-//     fHistManager.FillTH1(histname, count);
-//   }
-// 
-//   histname = "fHistSumNTracks";
-//   fHistManager.FillTH1(histname, sumAcceptedTracks);
-// }
-
-/**
- * This function performs a loop over the reconstructed EMCal clusters
- * in the current event and fills the relevant histograms.
- */
-// void AliAnalysisTaskConvJet::DoClusterLoop()
-// {
-//   TString histname;
-//   TString groupname;
-//   UInt_t sumAcceptedClusters = 0;
-//   AliClusterContainer* clusCont = 0;
-//   TIter next(&fClusterCollArray);
-//   while ((clusCont = static_cast<AliClusterContainer*>(next()))) {
-//     groupname = clusCont->GetName();
-// 
-//     for(auto cluster : clusCont->all()) {
-//       if (!cluster) continue;
-// 
-//       if (cluster->GetIsExotic()) {
-//         histname = TString::Format("%s/histClusterEnergyExotic", groupname.Data());
-//         fHistManager.FillTH1(histname, cluster->E());
-//       }
-//     }
-// 
-//     UInt_t count = 0;
-//     for(auto cluster : clusCont->accepted()) {
-//       if (!cluster) continue;
-//       count++;
-// 
-//       AliTLorentzVector nPart;
-//       cluster->GetMomentum(nPart, fVertex);
-// 
-//       histname = TString::Format("%s/histClusterEnergy", groupname.Data());
-//       fHistManager.FillTH1(histname, cluster->E());
-// 
-//       histname = TString::Format("%s/histClusterNonLinCorrEnergy", groupname.Data());
-//       fHistManager.FillTH1(histname, cluster->GetNonLinCorrEnergy());
-// 
-//       histname = TString::Format("%s/histClusterHadCorrEnergy", groupname.Data());
-//       fHistManager.FillTH1(histname, cluster->GetHadCorrEnergy());
-// 
-//       histname = TString::Format("%s/histClusterPhi", groupname.Data());
-//       fHistManager.FillTH1(histname, nPart.Phi_0_2pi());
-// 
-//       histname = TString::Format("%s/histClusterEta", groupname.Data());
-//       fHistManager.FillTH1(histname, nPart.Eta());
-//     }
-//     sumAcceptedClusters += count;
-// 
-//     histname = TString::Format("%s/histNClusters", groupname.Data());
-//     fHistManager.FillTH1(histname, count);
-//   }
-// 
-//   histname = "fHistSumNClusters";
-//   fHistManager.FillTH1(histname, sumAcceptedClusters);
-// }
-// 
-// /**
-//  * This function performs a loop over the reconstructed EMCal cells
-//  * in the current event and fills the relevant histograms.
-//  */
-// void AliAnalysisTaskConvJet::DoCellLoop()
-// {
-//   if (!fCaloCells) return;
-// 
-//   TString histname;
-// 
-//   const Short_t ncells = fCaloCells->GetNumberOfCells();
-// 
-//   histname = TString::Format("%s/histNCells", fCaloCellsName.Data());
-//   fHistManager.FillTH1(histname, ncells);
-// 
-//   histname = TString::Format("%s/histCellEnergy", fCaloCellsName.Data());
-//   for (Short_t pos = 0; pos < ncells; pos++) {
-//     Double_t amp   = fCaloCells->GetAmplitude(pos);
-//     
-//     fHistManager.FillTH1(histname, amp);
-//   }
-// }
 
 /**
  * This function is executed automatically for the first event.
@@ -385,22 +232,6 @@ AliAnalysisTaskConvJet * AliAnalysisTaskConvJet::AddTask_GammaConvJet(
   }
 
   TString name("AliAnalysisTaskConvJet");
-//   if (!trackName.IsNull()) {
-//     name += "_";
-//     name += trackName;
-//   }
-//   if (!clusName.IsNull()) {
-//     name += "_";
-//     name += clusName;
-//   }
-//   if (!cellName.IsNull()) {
-//     name += "_";
-//     name += cellName;
-//   }
-//   if (strcmp(suffix,"") != 0) {
-//     name += "_";
-//     name += suffix;
-//   }
 
   AliAnalysisTaskConvJet* sampleTask = new AliAnalysisTaskConvJet(name);
   sampleTask->SetCaloCellsName(cellName);
@@ -427,7 +258,6 @@ AliAnalysisTaskConvJet * AliAnalysisTaskConvJet::AddTask_GammaConvJet(
   sampleTask->GetTrackContainer(0)->SetParticlePtCut(0.15);
   sampleTask->GetTrackContainer(0)->SetParticleEtaLimits(-0.8,0.8);
   sampleTask->GetTrackContainer(0)->SetFilterHybridTracks(kTRUE);
-//   sampleTask->SetHistoBins(600, 0, 300);
 
   //-------------------------------------------------------
   // Final settings, pass to manager and set the containers

--- a/PWGGA/GammaConv/AliAnalysisTaskConvJet.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvJet.h
@@ -1,0 +1,88 @@
+#ifndef AliAnalysisTaskConvJet_H
+#define AliAnalysisTaskConvJet_H
+/**
+ * \file AliAnalysisTaskConvJet.h
+ * \brief Declaration of class AliAnalysisTaskConvJet
+ *
+ * In this header file the class AliAnalysisTaskConvJet is declared.
+ * This is a sample task that shows how to write a simple user analysis task
+ * using the EMCal jet framework. It is also used to do automatic benchmark
+ * tests of the software.
+ *
+ * \author Lizette Lamers <lizette.jacqueline.lamers@cern.ch>, Utrecht University
+ * \author Mike Sas <mike.sas@cern.ch>, Utrecht University
+ * \date Okt 4, 2018
+ */
+
+/* Copyright(c) 1998-2016, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
+
+#include "AliAnalysisTaskEmcalJet.h"
+#include "THistManager.h"
+
+/**
+ * \class AliAnalysisTaskConvJet
+ * \brief Implementation of a sample jet analysis task.
+ *
+ * This class in an implementation of a sample task for EMCal jet analysis.
+ * It derives from AliAnalysisTaskEmcalJet.
+ * It performs a simple analysis, producing track, cluster and jet spectra.
+ * It also performs a QA of the cluster-track matching.
+ * Note: if jets are not used this class can be simplified by deriving
+ * from AliAnalysisTaskEmcal and removing the functions DoJetLoop()
+ * and AllocateJetHistograms().
+ */
+class AliAnalysisTaskConvJet : public AliAnalysisTaskEmcalJet {
+ public:
+
+  AliAnalysisTaskConvJet()                                               ;
+  AliAnalysisTaskConvJet(const char *name)                               ;
+  virtual ~AliAnalysisTaskConvJet()                                      ;
+
+  void                        UserCreateOutputObjects()                         ;
+  void                        Terminate(Option_t *option)                       ;
+
+  static AliAnalysisTaskConvJet* AddTask_GammaConvJet(
+      const char *ntracks            = "usedefault",
+      const char *nclusters          = "usedefault",
+      const char* ncells             = "usedefault",
+      const char *suffix             = "");
+
+  Double_t GetNJets() {return fNJets;}
+  vector<Double_t> GetVectorJetPt()  {return fVectorJetPt;}
+  vector<Double_t> GetVectorJetEta() {return fVectorJetEta;}
+  vector<Double_t> GetVectorJetPhi() {return fVectorJetPhi;}
+  vector<Double_t> GetVectorJetR()   {return fVectorJetR;}
+
+  Double_t Get_Jet_Radius(){
+      AliJetContainer* jetCont = 0;
+      TIter next(&fJetCollArray);
+      Double_t radius = -1;
+      while ((jetCont = static_cast<AliJetContainer*>(next()))) {
+         radius = jetCont->GetJetRadius();
+      }
+      return radius;
+ }
+
+ protected:
+  void                        ExecOnce()                                        ;
+  Bool_t                      FillHistograms()                                  ;
+  Bool_t                      Run()                                             ;
+
+  void                        DoJetLoop()                                       ;
+
+  Double_t                    fNJets                                            ; //
+  vector<Double_t>            fVectorJetPt                                      ;
+  vector<Double_t>            fVectorJetEta                                     ;
+  vector<Double_t>            fVectorJetPhi                                     ;
+  vector<Double_t>            fVectorJetR                                       ;
+
+ private:
+  AliAnalysisTaskConvJet(const AliAnalysisTaskConvJet&)           ; // not implemented
+  AliAnalysisTaskConvJet &operator=(const AliAnalysisTaskConvJet&); // not implemented
+
+  /// \cond CLASSIMP
+  ClassDef(AliAnalysisTaskConvJet, 7);
+  /// \endcond
+};
+#endif

--- a/PWGGA/GammaConv/AliAnalysisTaskConvJet.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvJet.h
@@ -2,12 +2,6 @@
 #define AliAnalysisTaskConvJet_H
 /**
  * \file AliAnalysisTaskConvJet.h
- * \brief Declaration of class AliAnalysisTaskConvJet
- *
- * In this header file the class AliAnalysisTaskConvJet is declared.
- * This is a sample task that shows how to write a simple user analysis task
- * using the EMCal jet framework. It is also used to do automatic benchmark
- * tests of the software.
  *
  * \author Lizette Lamers <lizette.jacqueline.lamers@cern.ch>, Utrecht University
  * \author Mike Sas <mike.sas@cern.ch>, Utrecht University
@@ -26,11 +20,7 @@
  *
  * This class in an implementation of a sample task for EMCal jet analysis.
  * It derives from AliAnalysisTaskEmcalJet.
- * It performs a simple analysis, producing track, cluster and jet spectra.
- * It also performs a QA of the cluster-track matching.
- * Note: if jets are not used this class can be simplified by deriving
- * from AliAnalysisTaskEmcal and removing the functions DoJetLoop()
- * and AllocateJetHistograms().
+ * It performs a simple analysis, producing jet spectra.
  */
 class AliAnalysisTaskConvJet : public AliAnalysisTaskEmcalJet {
  public:
@@ -71,18 +61,18 @@ class AliAnalysisTaskConvJet : public AliAnalysisTaskEmcalJet {
 
   void                        DoJetLoop()                                       ;
 
-  Double_t                    fNJets                                            ; //
+  Double_t                    fNJets                                            ;
   vector<Double_t>            fVectorJetPt                                      ;
   vector<Double_t>            fVectorJetEta                                     ;
   vector<Double_t>            fVectorJetPhi                                     ;
   vector<Double_t>            fVectorJetR                                       ;
 
  private:
-  AliAnalysisTaskConvJet(const AliAnalysisTaskConvJet&)           ; // not implemented
-  AliAnalysisTaskConvJet &operator=(const AliAnalysisTaskConvJet&); // not implemented
+  AliAnalysisTaskConvJet(const AliAnalysisTaskConvJet&)           ;
+  AliAnalysisTaskConvJet &operator=(const AliAnalysisTaskConvJet&);
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskConvJet, 7);
+  ClassDef(AliAnalysisTaskConvJet, 1);
   /// \endcond
 };
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
@@ -729,8 +729,10 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
   fV0Reader=(AliV0ReaderV1*)AliAnalysisManager::GetAnalysisManager()->GetTask(fV0ReaderName.Data());
   if(!fV0Reader){printf("Error: No V0 Reader");return;} // GetV0Reader
 
-  fConvJetReader=(AliAnalysisTaskConvJet*)AliAnalysisManager::GetAnalysisManager()->GetTask("AliAnalysisTaskConvJet");
-  if(!fConvJetReader){printf("Error: No AliAnalysisTaskConvJet");return;} // GetV0Reader
+  if(fDoJetAnalysis){
+    fConvJetReader=(AliAnalysisTaskConvJet*)AliAnalysisManager::GetAnalysisManager()->GetTask("AliAnalysisTaskConvJet");
+    if(!fConvJetReader){printf("Error: No AliAnalysisTaskConvJet");return;} // GetV0Reader
+  }
 
   if (fDoClusterQA == 2) fProduceCellIDPlots = kTRUE;
   if (fIsMC == 2){
@@ -3905,24 +3907,24 @@ void AliAnalysisTaskGammaCalo::CalculatePi0Candidates(){
         if((((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(pi0cand,kTRUE,((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(),gamma0->GetLeadingCellID(),gamma1->GetLeadingCellID()))){
           if(fLocalDebugFlag == 1) DebugMethodPrint1(pi0cand,gamma0,gamma1);
           fHistoMotherInvMassPt[fiCut]->Fill(pi0cand->M(),pi0cand->Pt(), tempPi0CandWeight);
-          if(fDoJetAnalysis && fConvJetReader->GetNJets()>0){
-            fHistoJetMotherInvMassPt[fiCut]->Fill(pi0cand->M(),pi0cand->Pt(), tempPi0CandWeight);
-            Double_t RJetPi0Cand = 0;
-//             cout << "sizes: " << fVectorJetPt.size() << "  " << fVectorJetEta.size() <<  "  " << fVectorJetPhi.size() << endl;
-            if(fVectorJetPt.size() == fConvJetReader->GetNJets() && fVectorJetEta.size() == fConvJetReader->GetNJets() && fVectorJetPhi.size() == fConvJetReader->GetNJets() && fVectorJetArea.size() == fConvJetReader->GetNJets()){
+          if(fDoJetAnalysis){
+            if(fConvJetReader->GetNJets()>0){
+              fHistoJetMotherInvMassPt[fiCut]->Fill(pi0cand->M(),pi0cand->Pt(), tempPi0CandWeight);
+              Double_t RJetPi0Cand = 0;
+              if(fVectorJetPt.size() == fConvJetReader->GetNJets() && fVectorJetEta.size() == fConvJetReader->GetNJets() && fVectorJetPhi.size() == fConvJetReader->GetNJets() && fVectorJetArea.size() == fConvJetReader->GetNJets()){
                 Int_t counter = 0;
                 for(Int_t i=0; i<fConvJetReader->GetNJets(); i++){
                   RJetPi0Cand = TMath::Sqrt(pow((fVectorJetEta.at(i)-pi0cand->Eta()),2)+pow((fVectorJetPhi.at(i)-pi0cand->Phi()),2));
-//                   cout << "RJetPi0Cand= " << RJetPi0Cand << endl;
                   fHistoRJetPi0Cand[fiCut]->Fill(RJetPi0Cand,pi0cand->Pt(), tempPi0CandWeight);
                   if(fConvJetReader->Get_Jet_Radius() > 0 ){
                     if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
-                        counter ++;
+                      counter ++;
                       fHistoPi0InJetMotherInvMassPt[fiCut]->Fill(pi0cand->M(),pi0cand->Pt(), tempPi0CandWeight);
                     }
                   }
                 }
                 fHistoDoubleCounting[fiCut]->Fill(counter);
+              }
             }
           }
           // fill new histograms
@@ -4902,8 +4904,10 @@ void AliAnalysisTaskGammaCalo::CalculateBackground(){
                   tempBGCandidateWeight = 1;
               }
               fHistoMotherBackInvMassPt[fiCut]->Fill(backgroundCandidate->M(),backgroundCandidate->Pt(), tempBGCandidateWeight);
-              if(fConvJetReader->GetNJets() > 0){
-                fHistoMotherBackJetInvMassPt[fiCut]->Fill(backgroundCandidate->M(),backgroundCandidate->Pt(), tempBGCandidateWeight);
+              if(fDoJetAnalysis){
+                if(fConvJetReader->GetNJets() > 0){
+                  fHistoMotherBackJetInvMassPt[fiCut]->Fill(backgroundCandidate->M(),backgroundCandidate->Pt(), tempBGCandidateWeight);
+                }
               }
               if(fDoTHnSparse){
                 Double_t sparesFill[4] = {backgroundCandidate->M(),backgroundCandidate->Pt(),(Double_t)zbin,(Double_t)mbin};

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
@@ -86,6 +86,9 @@ AliAnalysisTaskGammaCalo::AliAnalysisTaskGammaCalo(): AliAnalysisTaskSE(),
   fCaloPhotonCuts(NULL),
   fMesonCutArray(NULL),
   fMesonCuts(NULL),
+  fConvJetReader(NULL),
+  fDoJetAnalysis(kFALSE),
+  fJetHistograms(NULL),
   fHistoMotherInvMassPt(NULL),
   fSparseMotherInvMassPtZM(NULL),
   fHistoMotherBackInvMassPt(NULL),
@@ -267,6 +270,21 @@ AliAnalysisTaskGammaCalo::AliAnalysisTaskGammaCalo(): AliAnalysisTaskSE(),
   fProfileJetJetXSection(NULL),
   fHistoJetJetNTrials(NULL),
   fHistoEventSphericity(NULL),
+  fHistoPtJet(NULL),
+  fHistoJetEta(NULL),
+  fHistoJetPhi(NULL),
+  fHistoJetArea(NULL),
+  fHistoNJets(NULL),
+  fHistoEventwJets(NULL),
+  fHistoDoubleCounting(NULL),
+  fHistoJetMotherInvMassPt(NULL),
+  fHistoPi0InJetMotherInvMassPt(NULL),
+  fHistoMotherBackJetInvMassPt(NULL),
+  fHistoRJetPi0Cand(NULL),
+  fVectorJetPt(0),
+  fVectorJetEta(0),
+  fVectorJetPhi(0),
+  fVectorJetArea(0),
   tTrueInvMassROpenABPtFlag(NULL),
   fInvMass(-1),
   fRconv(-1),
@@ -359,6 +377,9 @@ AliAnalysisTaskGammaCalo::AliAnalysisTaskGammaCalo(const char *name):
   fCaloPhotonCuts(NULL),
   fMesonCutArray(NULL),
   fMesonCuts(NULL),
+  fConvJetReader(NULL),
+  fDoJetAnalysis(kFALSE),
+  fJetHistograms(NULL),
   fHistoMotherInvMassPt(NULL),
   fSparseMotherInvMassPtZM(NULL),
   fHistoMotherBackInvMassPt(NULL),
@@ -540,6 +561,21 @@ AliAnalysisTaskGammaCalo::AliAnalysisTaskGammaCalo(const char *name):
   fProfileJetJetXSection(NULL),
   fHistoJetJetNTrials(NULL),
   fHistoEventSphericity(NULL),
+  fHistoPtJet(NULL),
+  fHistoJetEta(NULL),
+  fHistoJetPhi(NULL),
+  fHistoJetArea(NULL),
+  fHistoNJets(NULL),
+  fHistoEventwJets(NULL),
+  fHistoDoubleCounting(NULL),
+  fHistoJetMotherInvMassPt(NULL),
+  fHistoPi0InJetMotherInvMassPt(NULL),
+  fHistoMotherBackJetInvMassPt(NULL),
+  fHistoRJetPi0Cand(NULL),
+  fVectorJetPt(0),
+  fVectorJetEta(0),
+  fVectorJetPhi(0),
+  fVectorJetArea(0),
   tTrueInvMassROpenABPtFlag(NULL),
   fInvMass(-1),
   fRconv(-1),
@@ -692,6 +728,9 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
 
   fV0Reader=(AliV0ReaderV1*)AliAnalysisManager::GetAnalysisManager()->GetTask(fV0ReaderName.Data());
   if(!fV0Reader){printf("Error: No V0 Reader");return;} // GetV0Reader
+
+  fConvJetReader=(AliAnalysisTaskConvJet*)AliAnalysisManager::GetAnalysisManager()->GetTask("AliAnalysisTaskConvJet");
+  if(!fConvJetReader){printf("Error: No AliAnalysisTaskConvJet");return;} // GetV0Reader
 
   if (fDoClusterQA == 2) fProduceCellIDPlots = kTRUE;
   if (fIsMC == 2){
@@ -1004,6 +1043,22 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
   if (fProduceTreeEOverP){
     fClusterTreeList                = new TList*[fnCuts];
     tClusterEOverP                  = new TTree*[fnCuts];
+  }
+  if(fDoJetAnalysis){
+    fJetHistograms            = new TList*[fnCuts];
+
+    fHistoPtJet               = new TH1F*[fnCuts];
+    fHistoJetEta              = new TH1F*[fnCuts];
+    fHistoJetPhi              = new TH1F*[fnCuts];
+    fHistoJetArea             = new TH1F*[fnCuts];
+    fHistoNJets               = new TH1F*[fnCuts];
+    fHistoEventwJets          = new TH1F*[fnCuts];
+    fHistoDoubleCounting      = new TH1F*[fnCuts];
+
+    fHistoJetMotherInvMassPt                  = new TH2F*[fnCuts];
+    fHistoPi0InJetMotherInvMassPt             = new TH2F*[fnCuts];
+    fHistoMotherBackJetInvMassPt              = new TH2F*[fnCuts];
+    fHistoRJetPi0Cand                         = new TH2F*[fnCuts];
   }
 
   for(Int_t iCut = 0; iCut<fnCuts;iCut++){
@@ -1354,6 +1409,36 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
         fClusterTreeList[iCut]->Add(tClusterEOverP[iCut]);
       }
     }
+    if(fDoJetAnalysis){
+
+      fJetHistograms[iCut] = new TList();
+      fJetHistograms[iCut]->SetOwner(kTRUE);
+      fJetHistograms[iCut]->SetName("JetFolder");
+
+      fHistoPtJet[iCut] = new TH1F("JetPt", "JetPt", 40, 0, 20);
+      fJetHistograms[iCut]->Add(fHistoPtJet[iCut]);
+      fHistoJetEta[iCut] = new TH1F("JetEta", "JetEta", 100, -1, 1);
+      fJetHistograms[iCut]->Add(fHistoJetEta[iCut]);
+      fHistoJetPhi[iCut] = new TH1F("JetPhi", "JetPhi", 70, 0, 7);
+      fJetHistograms[iCut]->Add(fHistoJetPhi[iCut]);
+      fHistoJetArea[iCut] = new TH1F("JetArea", "JetArea", 50, 0, 1);
+      fJetHistograms[iCut]->Add(fHistoJetArea[iCut]);
+      fHistoNJets[iCut] = new TH1F("NJets", "NJets", 10, 0, 10);
+      fJetHistograms[iCut]->Add(fHistoNJets[iCut]);
+      fHistoEventwJets[iCut] = new TH1F("NEvents_with_Jets", "NEvents_with_Jets", 5, 0, 5);
+      fJetHistograms[iCut]->Add(fHistoEventwJets[iCut]);
+
+      fHistoDoubleCounting[iCut] = new TH1F("Double_Counting_Mesons_Jets", "Double_Counting_Mesons_Jets", 6, 0, 6);
+      fJetHistograms[iCut]->Add(fHistoDoubleCounting[iCut]);
+      fHistoJetMotherInvMassPt[iCut] = new TH2F("ESD_Jet_Mother_InvMass_Pt", "ESD_Jet_Mother_InvMass_Pt", 800, 0, 0.8, nBinsPt, arrPtBinning);
+      fJetHistograms[iCut]->Add(fHistoJetMotherInvMassPt[iCut]);
+      fHistoPi0InJetMotherInvMassPt[iCut] = new TH2F("ESD_Candidate_Jet_Mother_InvMass_Pt", "ESD_Candidate_Jet_Mother_InvMass_Pt", 800, 0, 0.8, nBinsPt, arrPtBinning);
+      fJetHistograms[iCut]->Add(fHistoPi0InJetMotherInvMassPt[iCut]);
+      fHistoMotherBackJetInvMassPt[iCut] = new TH2F("ESD_Candidate_Jet_Background_InvMass_Pt", "ESD_Candidate_Jet_Background_InvMass_Pt", 800, 0, 0.8, nBinsPt, arrPtBinning);
+      fJetHistograms[iCut]->Add(fHistoMotherBackJetInvMassPt[iCut]);
+      fHistoRJetPi0Cand[iCut] = new TH2F("ESD_Jet_RJetPi0Cand_Pt", "ESD_Jet_RJetPi0Cand_Pt", 70, 0, 7, nBinsPt, arrPtBinning);
+      fJetHistograms[iCut]->Add(fHistoRJetPi0Cand[iCut]);
+      }
   }
   if(fDoMesonAnalysis){
     InitBack(); // Init Background Handler
@@ -2395,6 +2480,9 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
         fCutFolder[iCut]->Add(((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->GetCutHistograms());
       }
     }
+    if(fDoJetAnalysis){
+      fCutFolder[iCut]->Add(fJetHistograms[iCut]);
+    }
   }
 
   if (fIsMC > 0 ){
@@ -2597,6 +2685,8 @@ void AliAnalysisTaskGammaCalo::UserExec(Option_t *)
 
     // it is in the loop to have the same conversion cut string (used also for MC stuff that should be same for V0 and Cluster)
     ProcessClusters();            // process calo clusters
+
+    if(fDoJetAnalysis)   ProcessJets();
 
     fHistoNGammaCandidatesBasic[iCut]->Fill(fNCurrentClusterBasic, fWeightJetJetMC);
 
@@ -2987,6 +3077,36 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
   if(fLocalDebugFlag == 2) EventDebugMethod();
 
   return;
+}
+//________________________________________________________________________
+void AliAnalysisTaskGammaCalo::ProcessJets()
+{
+  fHistoNJets[fiCut]->Fill(fConvJetReader->GetNJets());
+  if(fConvJetReader->GetNJets()>0){
+    fVectorJetPt  = fConvJetReader->GetVectorJetPt();
+    fVectorJetEta = fConvJetReader->GetVectorJetEta();
+    fVectorJetPhi = fConvJetReader->GetVectorJetPhi();
+    fVectorJetArea = fConvJetReader->GetVectorJetR();
+    if(fVectorJetPt.size() == fConvJetReader->GetNJets() && fVectorJetEta.size() == fConvJetReader->GetNJets() && fVectorJetPhi.size() == fConvJetReader->GetNJets() && fVectorJetArea.size() == fConvJetReader->GetNJets()){
+      for(Int_t i=0; i<fConvJetReader->GetNJets(); i++){
+        //cout << " jet " << i << endl;
+        //cout << "jetpt=  " << fVectorJetPt.at(i) << endl;
+        //cout << "jeteta= " << fVectorJetEta.at(i) << endl;
+        //cout << "jetphi= " << fVectorJetPhi.at(i) << endl;
+
+        fHistoPtJet[fiCut]->Fill(fVectorJetPt.at(i));
+        fHistoJetEta[fiCut]->Fill(fVectorJetEta.at(i));
+        fHistoJetPhi[fiCut]->Fill(fVectorJetPhi.at(i));
+        fHistoJetArea[fiCut]->Fill(fVectorJetArea.at(i));
+      }
+      fHistoEventwJets[fiCut]->Fill(0);
+    }
+  }else{
+    fVectorJetPt.clear();
+    fVectorJetEta.clear();
+    fVectorJetPhi.clear();
+    fVectorJetArea.clear();
+  }
 }
 
 //________________________________________________________________________
@@ -3785,6 +3905,26 @@ void AliAnalysisTaskGammaCalo::CalculatePi0Candidates(){
         if((((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelected(pi0cand,kTRUE,((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(),gamma0->GetLeadingCellID(),gamma1->GetLeadingCellID()))){
           if(fLocalDebugFlag == 1) DebugMethodPrint1(pi0cand,gamma0,gamma1);
           fHistoMotherInvMassPt[fiCut]->Fill(pi0cand->M(),pi0cand->Pt(), tempPi0CandWeight);
+          if(fDoJetAnalysis && fConvJetReader->GetNJets()>0){
+            fHistoJetMotherInvMassPt[fiCut]->Fill(pi0cand->M(),pi0cand->Pt(), tempPi0CandWeight);
+            Double_t RJetPi0Cand = 0;
+//             cout << "sizes: " << fVectorJetPt.size() << "  " << fVectorJetEta.size() <<  "  " << fVectorJetPhi.size() << endl;
+            if(fVectorJetPt.size() == fConvJetReader->GetNJets() && fVectorJetEta.size() == fConvJetReader->GetNJets() && fVectorJetPhi.size() == fConvJetReader->GetNJets() && fVectorJetArea.size() == fConvJetReader->GetNJets()){
+                Int_t counter = 0;
+                for(Int_t i=0; i<fConvJetReader->GetNJets(); i++){
+                  RJetPi0Cand = TMath::Sqrt(pow((fVectorJetEta.at(i)-pi0cand->Eta()),2)+pow((fVectorJetPhi.at(i)-pi0cand->Phi()),2));
+//                   cout << "RJetPi0Cand= " << RJetPi0Cand << endl;
+                  fHistoRJetPi0Cand[fiCut]->Fill(RJetPi0Cand,pi0cand->Pt(), tempPi0CandWeight);
+                  if(fConvJetReader->Get_Jet_Radius() > 0 ){
+                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                        counter ++;
+                      fHistoPi0InJetMotherInvMassPt[fiCut]->Fill(pi0cand->M(),pi0cand->Pt(), tempPi0CandWeight);
+                    }
+                  }
+                }
+                fHistoDoubleCounting[fiCut]->Fill(counter);
+            }
+          }
           // fill new histograms
           if(!fDoLightOutput && TMath::Abs(pi0cand->GetAlpha())<0.1){
             fHistoMotherInvMassECalib[fiCut]->Fill(pi0cand->M(),pi0cand->E(),tempPi0CandWeight);
@@ -4762,6 +4902,9 @@ void AliAnalysisTaskGammaCalo::CalculateBackground(){
                   tempBGCandidateWeight = 1;
               }
               fHistoMotherBackInvMassPt[fiCut]->Fill(backgroundCandidate->M(),backgroundCandidate->Pt(), tempBGCandidateWeight);
+              if(fConvJetReader->GetNJets() > 0){
+                fHistoMotherBackJetInvMassPt[fiCut]->Fill(backgroundCandidate->M(),backgroundCandidate->Pt(), tempBGCandidateWeight);
+              }
               if(fDoTHnSparse){
                 Double_t sparesFill[4] = {backgroundCandidate->M(),backgroundCandidate->Pt(),(Double_t)zbin,(Double_t)mbin};
                 fSparseMotherBackInvMassPtZM[fiCut]->Fill(sparesFill,1);

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
@@ -11,6 +11,7 @@
 #include "AliConvEventCuts.h"
 #include "AliConversionPhotonCuts.h"
 #include "AliConversionMesonCuts.h"
+#include "AliAnalysisTaskConvJet.h"
 #include "AliAnalysisManager.h"
 #include "TProfile2D.h"
 #include "TH3.h"
@@ -38,6 +39,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
 
     // base functions for selecting photon and meson candidates in reconstructed data
     void ProcessClusters();
+    void ProcessJets();
     void CalculatePi0Candidates();
 
     // MC functions
@@ -118,6 +120,8 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
 
     void SetTrackMatcherRunningMode(Int_t mode){fTrackMatcherRunningMode = mode;}
 
+    void SetJetAnalysis(Bool_t DoJets)  {fDoJetAnalysis = DoJets;}
+
   protected:
     AliV0ReaderV1*        fV0Reader;                                            // basic photon Selection Task
     TString               fV0ReaderName;
@@ -141,6 +145,9 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     AliCaloPhotonCuts*    fCaloPhotonCuts;                                      // CaloPhotonCutObject
     TList*                fMesonCutArray;                                       // List with Meson Cuts
     AliConversionMesonCuts*   fMesonCuts;                                       // MesonCutObject
+    AliAnalysisTaskConvJet*   fConvJetReader;                                   // JetReader
+    Bool_t                fDoJetAnalysis;                                       // Bool to produce Jet Plots
+    TList**               fJetHistograms;                                       // Jet Histograms
 
     //histograms for mesons reconstructed quantities
     TH2F**                fHistoMotherInvMassPt;                                //! array of histogram with signal + BG for same event photon pairs, inv Mass, pt
@@ -332,6 +339,23 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     TProfile**            fProfileJetJetXSection;                               //! array of profiles with xsection for jetjet
     TH1F**                fHistoJetJetNTrials;                                  //! array of histos with ntrials for jetjet
     TH1F**                fHistoEventSphericity;                                //! array of histos with event Sphericity
+
+    TH1F**                 fHistoPtJet;                                          // Histogram of Jet Pt
+    TH1F**                 fHistoJetEta;                                         // Histogram of Jet Eta
+    TH1F**                 fHistoJetPhi;                                         // Histogram of Jet Phi
+    TH1F**                 fHistoJetArea;                                        // Histogram of Jet Area
+    TH1F**                 fHistoNJets;                                          // Histogram of number of jets
+    TH1F**                 fHistoEventwJets;                                     // Histogram of number of events with jets > 0
+    TH1F**                 fHistoDoubleCounting;                                 // Histogram if NM candidates are defined within multiple jets
+    TH2F**                 fHistoJetMotherInvMassPt;                             // Histogram of NM candidates with a jet in the event
+    TH2F**                 fHistoPi0InJetMotherInvMassPt;                        // Histogram of NM candidates that are inside a jet
+    TH2F**                 fHistoMotherBackJetInvMassPt;                         // Histogram of Backgrouns candidates that are involved with jets
+    TH2F**                 fHistoRJetPi0Cand;                                    // Histogram of RJetPi0Cand vs Pt
+
+    vector<Double_t>      fVectorJetPt;                                         // Vector of JetPt
+    vector<Double_t>      fVectorJetEta;                                        // Vector of JetEta
+    vector<Double_t>      fVectorJetPhi;                                        // Vector of JetPhi
+    vector<Double_t>      fVectorJetArea;                                       // Vector of JetArea
 
     // tree for identified particle properties
     TTree**               tTrueInvMassROpenABPtFlag;                            //! array of trees with

--- a/PWGGA/GammaConv/CMakeLists.txt
+++ b/PWGGA/GammaConv/CMakeLists.txt
@@ -30,7 +30,10 @@ include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/PWG/CaloTrackCorrBase
                     ${AliPhysics_SOURCE_DIR}/PWG/Cocktail                    
                     ${AliPhysics_SOURCE_DIR}/PWG/FLOW
+		    ${AliPhysics_SOURCE_DIR}/PWG/JETFW
+		    ${AliPhysics_SOURCE_DIR}/PWG/Tools
                     ${AliPhysics_SOURCE_DIR}/PWG/TRD
+		    ${AliPhysics_SOURCE_DIR}/PWGJE/EMCALJetTasks
                     ${AliPhysics_SOURCE_DIR}/TENDER/Tender
                     ${AliPhysics_SOURCE_DIR}/TENDER/TenderSupplies
                     ${AliPhysics_SOURCE_DIR}/PWGGA/PHOSTasks/PHOS_PbPb
@@ -44,6 +47,7 @@ set(SRCS
     AliAnaConvCorrPion.cxx
     AliAnaConvIsolation.cxx
     AliAnalysisTaskConversionQA.cxx
+    AliAnalysisTaskConvJet.cxx
     AliAnalysisTaskClusterQA.cxx
     AliAnalysisTaskdPhi.cxx
     AliAnalysisTaskEtaToPiPlPiMiGamma.cxx
@@ -103,7 +107,7 @@ get_directory_property(incdirs INCLUDE_DIRECTORIES)
 generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 set(ROOT_DEPENDENCIES Core EG GenVector Geom Gpad Hist MathCore Matrix Net Physics RIO Tree)
-set(ALIROOT_DEPENDENCIES ANALYSIS ANALYSISalice AOD EMCALbase EMCALUtils ESD STEERBase PWGTRD PWGflowTasks Tender TenderSupplies PWGEMCALbase PWGEMCALtasks PWGEMCALtrigger PWGCaloTrackCorrBase PWGGAUtils)
+set(ALIROOT_DEPENDENCIES ANALYSIS ANALYSISalice AOD EMCALbase EMCALUtils ESD STEERBase PWGTRD PWGflowTasks Tender TenderSupplies PWGEMCALbase PWGEMCALtasks PWGEMCALtrigger PWGCaloTrackCorrBase PWGGAUtils PWGJETFW )
 set(ALIPHYSICS_DECPENDENCIES PWGCocktail)
 
 # Generate the ROOT map

--- a/PWGGA/GammaConv/PWGGAGammaConvLinkDef.h
+++ b/PWGGA/GammaConv/PWGGAGammaConvLinkDef.h
@@ -31,6 +31,7 @@
 #pragma link C++ class AliAnalysisTaskGammaConvV1+;
 #pragma link C++ class AliAnalysisTaskGammaConvDalitzV1+;
 #pragma link C++ class AliAnalysisTaskConversionQA+;
+#pragma link C++ class AliAnalysisTaskConvJet+;
 #pragma link C++ class AliAnalysisTaskClusterQA+;
 #pragma link C++ class AliAnalysisTaskMaterial+;
 #pragma link C++ class AliAnalysisTaskMaterialHistos+;

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
@@ -1321,6 +1321,15 @@ void AddTask_GammaCalo_pp(  Int_t     trainConfig                   = 1,        
     cuts.AddCut("00010113","2446600044012300000","0163103100000010"); // INT7 w/ TM NCells 2
   } else if (trainConfig ==806){//Comparing CellQA Config from GammaConv
       cuts.AddCut("00010113","2446600000013300000","0163103100000010"); // INT7
+
+  // *********************************************************************************************************
+  // 5 TeV 2017 pp - Jet configurations
+  // *********************************************************************************************************
+
+  } else if (trainConfig == 900){
+    cuts.AddCut("00010113","11111110a7032230000","01631031000000d0"); // std
+    cuts.AddCut("00010113","1111111097032230000","01631031000000d0");
+
   } else {
     Error(Form("GammaCalo_%i",trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");
     return;
@@ -1476,6 +1485,7 @@ void AddTask_GammaCalo_pp(  Int_t     trainConfig                   = 1,        
   task->SetDoTHnSparse(isUsingTHnSparse);
   task->SetProduceTreeEOverP(doTreeEOverP);
   task->SetEnableSortingOfMCClusLabels(enableSortingMCLabels);
+  if(trainConfig == 900)  task->SetJetAnalysis(kTRUE);
   if(enableExtMatchAndQA > 1){ task->SetPlotHistsExtQA(kTRUE);}
   if(trainConfig == 106 || trainConfig == 125 || trainConfig == 145){
     task->SetInOutTimingCluster(-30e-9,35e-9);

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
@@ -1328,7 +1328,6 @@ void AddTask_GammaCalo_pp(  Int_t     trainConfig                   = 1,        
 
   } else if (trainConfig == 900){
     cuts.AddCut("00010113","11111110a7032230000","01631031000000d0"); // std
-    cuts.AddCut("00010113","1111111097032230000","01631031000000d0");
 
   } else {
     Error(Form("GammaCalo_%i",trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvJet.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvJet.C
@@ -1,0 +1,12 @@
+AliAnalysisTaskConvJet* AddTask_GammaConvJet(
+  const char *ntracks            = "usedefault",
+  const char *nclusters          = "usedefault",
+  const char* ncells             = "usedefault",
+  const char *suffix             = ""
+)
+{
+  return AliAnalysisTaskConvJet::AddTask_GammaConvJet(ntracks,
+      nclusters,
+      ncells,
+      suffix);
+}


### PR DESCRIPTION
Added a ConvJet class that reads in the jet results from AliEmcalJetTask. The changes in AliAnalysisTaskGammaCalo read in the results retrieved from the ConvJet class to make jet histograms for every cut number (if fDoJetAnalysis ik kTRUE, which is only the case if TrainConfig 900 is used). The changes in AddTask_GammaCalo_pp are to add this TrainConfig and the case that if this TrainConfig is used the jet analysis will be used.