### PR TITLE
EMCal CorrFW: Default same min cellE and crosstalk induced energy, add docs

### DIFF
--- a/PWG/EMCAL/READMEemcCorrections.txt
+++ b/PWG/EMCAL/READMEemcCorrections.txt
@@ -280,7 +280,11 @@ There are a number of useful advanced options to make the Corrections Framework 
 
 #### Shared parameters
 
-Often, a user will want to change some parameters in unison. Say, if a pt cut is changed, it should be changed everywhere. In such a case, it is useful to able to define a variable so that one change will change things everything. This can be accomplished by defining a parameters in the "shared parameters" section of the %YAML file. The name of the parameter defined in the shared parameters section can be referenced in other areas of the file by prepending ``sharedParameters:`` to the parameter name. Consider the example below:
+Often, a user will want to change some parameters in unison. Say, if a pt cut is changed, it should be changed
+everywhere. In such a case, it is useful to able to define a variable so that one change will change things everything.
+This can be accomplished by defining a parameters in the "shared parameters" section of the %YAML file. The name of the
+parameter defined in the shared parameters section can be referenced in other areas of the file by prepending
+``sharedParameters:`` to the parameter name. Consider the example below:
 
 ~~~
 sharedParameters:
@@ -292,7 +296,42 @@ Correction2:
     anotherExample: "sharedParameters:aMinimumValue"
 ~~~
 
-In the example, any change to ``aMinimumValue`` will be propagated to ``exampleValue`` in ``Correction1`` and ``anotherExample`` in ``Correction2``. Note that the parameter name (here, ``aMinimumValu``) can be anything that the user desires. When setting the value, don't forget to prepend "sharedParameters:" (in our example, "sharedParameters:aMinimumValu")!
+In the example, any change to ``aMinimumValue`` will be propagated to ``exampleValue`` in ``Correction1`` and
+``anotherExample`` in ``Correction2``. Note that the parameter name (here, ``aMinimumValu``) can be anything that
+the user desires. When setting the value, don't forget to prepend "sharedParameters:" (in our example,
+"sharedParameters:aMinimumValu")!
+
+Note that shared parameters are inherently somewhat limited. It can only retrieve values where the requested type
+is arithmetic, string, or bool. The retrieved shared parameters value can only be of those same types. Note that
+the shared parameters correspond to each configuration file.  ie. If ``sharedParameters:test`` is requested in the
+first configuration file, then it will only look for the sharedParameters value in that configuration. Thus, if a
+sharedParameter is requested in a later configuration file, the earlier configuration shared parameter values
+**will not** be considered.
+
+As an explicit example, to change the T-card minimum to ``0.1`` while leaving the clusterizer minimum cell energy
+the same in your user config, it should look like (omitting unrelated values for brevity):
+
+~~~
+sharedParameter:
+    minCellE: 0.05
+EmulateCrosstalk:
+    inducedTCardMinimum: 0.1
+Clusterizer:
+    minE: "sharedParameters:minCellE"
+~~~
+
+To change the minCellE for both in your user config, you'll need to do:
+
+~~~
+sharedParameter:
+    minCellE: 0.05
+EmulateCrosstalk:
+    inducedTCardMinimum: "sharedParameter:minCellE"
+Clusterizer:
+    minE: "sharedParameters:minCellE"
+~~~
+
+**It isn't enough to just change the value in the shared parameter!**
 
 ## Running multiple corrections at once ("specializing")                      {#emcCorrectionsSpecialization}
 

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -40,7 +40,10 @@ inputObjects:                                       # Define all of the input ob
             #    - 16
             #    - 1
 sharedParameters:
-    # You can define here any parameters that you would like to share between tasks. See the documentation for more information
+    # You can define here any parameters that you would like to share between tasks. Note that you cannot directly
+    # override a shared parameter in your config! Instead, you'll need to explicitly set the parameter value, as well
+    # as whichever parameters it is supposed to override, in your user config. See the documentation for  more
+    # information.
     minCellE: 0.05                                  # Minimum cell energy (GeV).
     enableFracEMCRecalc: false                      # Enables the recalculation of the MC labels including the fractional energy on cell level
     removeNMCGenerators: 0                          # set number of accepted MC generators input (only for enableFracEMCRecalc=1)

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -41,6 +41,7 @@ inputObjects:                                       # Define all of the input ob
             #    - 1
 sharedParameters:
     # You can define here any parameters that you would like to share between tasks. See the documentation for more information
+    minCellE: 0.05                                  # Minimum cell energy (GeV).
     enableFracEMCRecalc: false                      # Enables the recalculation of the MC labels including the fractional energy on cell level
     removeNMCGenerators: 0                          # set number of accepted MC generators input (only for enableFracEMCRecalc=1)
     enableMCGenRemovTrack: true                     # apply the MC generators rejection also for track matching
@@ -71,7 +72,7 @@ CellEmulateCrosstalk:                               # Component to emulate cross
     randomizeTCardInducedEnergy: true               # Randomize the energy fraction induced by the TCard
     inducedTCardMinimumCellEnergy: 0.01             # Minimum cell energy induced by the TCard
     inducedTCardMaximum: 100                        # Maximum energy induced by the TCard
-    inducedTCardMinimum: 0.05                       # Minimum energy induced by the TCard + cell energy, IMPORTANT use the same value as the clusterization cell E threshold or not too far from it
+    inducedTCardMinimum: "sharedParameters:minCellE" # Minimum energy induced by the TCard + cell energy, IMPORTANT use the same value as the clusterization cell E threshold or not too far from it
     inducedTCardMaximumELeak: 0                     # Maximum energy that is going to be leaked independently of what is set with inducedTCardMinimum
     # Note on using the following section:
     # Each setting can be enabled or disabled. If disabled, the settings will _not_ be applied
@@ -143,7 +144,7 @@ Clusterizer:                                        # Clusterizer component
     enabled: false                                  # Whether to enable the task
     createHistos: false                             # Whether the task should create output histograms
     clusterizer: kClusterizerv2                     # Type of clusterizer to use. Possible options are defined in the header of the clusterizer
-    cellE: 0.05                                     # Minimum cell energy (GeV)
+    cellE: "sharedParameters:minCellE"              # Minimum cell energy (GeV)
     seedE: 0.1                                      # Seed energy threshold (GeV)
     cellTimeMin: -1                                 # Min cell time (s)
     cellTimeMax: +1                                 # Max cell time (s)


### PR DESCRIPTION
This implements the recommendation that the cross-talk induced T-card minimum should be equal to the clusterizer min energy by default. I also added documentation to clarify how to use the shared parameters properly.  In particular, note that a user can't directly override a shared parameter - setting just the shared parameter is not sufficient! Instead, one must set both the value, as well as which values will share it, in their user config.

There is more information in the commit messages and documentation, including explicit examples.

If we think this is too complicated, we don't have to merge it. @gconesab , @jdmulligan, what do you think?