### PR TITLE
Add fill function for the event mixing pool

### DIFF
--- a/PWGLF/RESONANCES/extra/AddTaskXi1530.C
+++ b/PWGLF/RESONANCES/extra/AddTaskXi1530.C
@@ -1,6 +1,6 @@
 AliAnalysisTaskXi1530* AddTaskXi1530(const char *taskname = "Xi1530"
                                      , const char *option = "LHC16k"
-                                     , int nmix=10
+                                     , int nmix=20
                                      , bool hightmult=kFALSE
                                      , bool isaa=kFALSE
                                      , bool ismc=kFALSE
@@ -28,11 +28,11 @@ AliAnalysisTaskXi1530* AddTaskXi1530(const char *taskname = "Xi1530"
     
     
     AliAnalysisDataContainer *cinput = mgr->GetCommonInputContainer();
-    AliAnalysisDataContainer *coutputXi1530 = mgr->CreateContainer("Xi1530", TList::Class(), AliAnalysisManager::kOutputContainer,"AnalysisResults.root");
+    AliAnalysisDataContainer *coutputXi1530 = mgr->CreateContainer(Form("%s_%s",taskname,option), TList::Class(), AliAnalysisManager::kOutputContainer,"AnalysisResults.root");
     
     mgr->ConnectInput(taskXi1530, 0, cinput);
     mgr->ConnectOutput(taskXi1530, 1, coutputXi1530);
-
+    
     return taskXi1530;
 }
 

--- a/PWGLF/RESONANCES/extra/AliAnalysisTaskXi1530.h
+++ b/PWGLF/RESONANCES/extra/AliAnalysisTaskXi1530.h
@@ -78,6 +78,7 @@ public:
     Bool_t IsMCEventTrueINEL0();
     Bool_t IsTrueXi1530(AliESDcascade* Xi, AliVTrack* pion);
     void FillMCinput(AliStack* fMCStack);
+    void FillTrackToEventPool();
     
     TAxis AxisFix( TString name, int nbin, Double_t xmin, Double_t xmax);
     TAxis AxisVar( TString name, std::vector<Double_t> bin );
@@ -136,9 +137,10 @@ private:
     Double_t                        PVy = 999;
     Double_t                        PVz = 999;
     Double_t                        bField = 999;
-    ClassDef(AliAnalysisTaskXi1530, 2);
+    ClassDef(AliAnalysisTaskXi1530, 3);
     //1: Frist version
     //2: Add Track cut2 for the Xi daughter particles
+    //3: Add FillMixingPool function
 };
 
 #endif


### PR DESCRIPTION
Add "FillTrackToEventPool" function to make mixing pool.
It was done in GoodTracksSelection() before, but it has filled 'current' event track list to the mixing pool. As a result, mixed background contains "real" signal, so that I changed order of making mixing pool after use it.