### PR TITLE
Fix including headers from global include path (needed for ROOT6)

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetSpectra8TeVTriggerQA.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetSpectra8TeVTriggerQA.h
@@ -49,8 +49,8 @@
 #include "THistManager.h"
 #include <string>
 #include <vector>
-#include "Tracks/AliAnalysisTaskEmcalTriggerBase.h"
-#include "Tracks/AliCutValueRange.h"
+#include "AliAnalysisTaskEmcalTriggerBase.h"
+#include "AliCutValueRange.h"
 #include "AliEventCuts.h"
 #include <TCustomBinning.h>
 #include <TString.h>


### PR DESCRIPTION
Headers are installed in global include directory and
have to be taken from the global include dir. Incorrect
include paths show up as problems with symbols from the
dictionary in train tests using the ROOT6-based versions.