### PR TITLE
[EMCAL-403] Centrality dependence in trigger overlap

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerCorrelation.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerCorrelation.cxx
@@ -28,25 +28,58 @@
 #include <TList.h>
 #include "AliAnalysisManager.h"
 #include "AliAnalysisTaskEmcalTriggerCorrelation.h"
+#include "AliMultSelection.h"
 
 ClassImp(EMCalTriggerPtAnalysis::AliAnalysisTaskEmcalTriggerCorrelation)
 
 using namespace EMCalTriggerPtAnalysis;
 
 AliAnalysisTaskEmcalTriggerCorrelation::AliAnalysisTaskEmcalTriggerCorrelation():
-  AliAnalysisTaskEmcalTriggerBase()
+  AliAnalysisTaskEmcalTriggerBase(),
+  fRequestCentrality(false),
+  fEventCentrality(99.),
+  fCentralityRange(0.,100.),
+  fCentralityEstimator("V0M")
 {
   SetRequireAnalysisUtils(true);
 }
 
 AliAnalysisTaskEmcalTriggerCorrelation::AliAnalysisTaskEmcalTriggerCorrelation(const char *name):
-  AliAnalysisTaskEmcalTriggerBase(name)
+  AliAnalysisTaskEmcalTriggerBase(name),
+  fRequestCentrality(false),
+  fEventCentrality(99.),
+  fCentralityRange(0.,100.),
+  fCentralityEstimator("V0M")
 {
   SetRequireAnalysisUtils(true);
 }
 
 AliAnalysisTaskEmcalTriggerCorrelation::~AliAnalysisTaskEmcalTriggerCorrelation(){
 
+}
+
+bool AliAnalysisTaskEmcalTriggerCorrelation::IsUserEventSelected(){
+  fEventCentrality = 99;   // without centrality put everything in the peripheral bin
+  if(fRequestCentrality){
+    AliMultSelection *mult = dynamic_cast<AliMultSelection *>(InputEvent()->FindListObject("MultSelection"));
+    if(!mult){
+      AliErrorStream() << GetName() << ": Centrality selection enabled but no centrality estimator found" << std::endl;
+      return false;
+    }
+    if(mult->IsEventSelected()) return false;
+    fEventCentrality = mult->GetEstimator(fCentralityEstimator)->GetPercentile();
+    AliDebugStream(1) << GetName() << ": Centrality " <<  fEventCentrality << std::endl;
+    if(!fCentralityRange.IsInRange(fEventCentrality)){
+      AliDebugStream(1) << GetName() << ": reject centrality: " << fEventCentrality << std::endl;
+      return false;
+    } else {
+      AliDebugStream(1) << GetName() << ": select centrality " << fEventCentrality << std::endl;
+    }
+  } else {
+    AliDebugStream(1) << GetName() << ": No centrality selection applied" << std::endl;
+  }
+
+  return true;
 }
 
 AliAnalysisTaskEmcalTriggerCorrelation *AliAnalysisTaskEmcalTriggerCorrelation::AddTaskTriggerCorrelation(const char *name){

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerCorrelation.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerCorrelation.h
@@ -28,6 +28,8 @@
 #define ALIANALYSISTASKEMCALTRIGGERCORRELATION_H
 
 #include "AliAnalysisTaskEmcalTriggerBase.h"
+#include "AliCutValueRange.h"
+#include "TString.h"
 
 namespace EMCalTriggerPtAnalysis {
 
@@ -39,11 +41,19 @@ public:
 
   static AliAnalysisTaskEmcalTriggerCorrelation *AddTaskTriggerCorrelation(const char *name);
 
+  void SetCentralityRange(double mincent, double maxcent) { fCentralityRange.SetLimits(mincent, maxcent);  fRequestCentrality = true; }
+  void SetCentralityEstimator(const char *estimator) { fCentralityEstimator = estimator; }
+
 protected:
   virtual void CreateUserHistos() {}
   virtual void CreateUserObjects() {}
+  virtual bool IsUserEventSelected();
 
 private:
+  Bool_t                    fRequestCentrality;           ///< Request centrality
+  Double_t                  fEventCentrality;             //!<! Event centrality: Tranisent worker variable
+  TString                   fCentralityEstimator;         ///< Centrality estimator (default: V0M)
+  AliCutValueRange<double>  fCentralityRange;             ///< Selected centrality range
 
   AliAnalysisTaskEmcalTriggerCorrelation(const AliAnalysisTaskEmcalTriggerCorrelation &);
   AliAnalysisTaskEmcalTriggerCorrelation &operator=(const AliAnalysisTaskEmcalTriggerCorrelation &);


### PR DESCRIPTION
Allow trigger correlation to be evaluated in classes of centrality.
Each class of centrality needs to be defined as separate wagon with
a range.