### PR TITLE
few minor improvements to the rho task to analyze the 2016 data

### DIFF
--- a/PWGJE/EMCALJetTasks/AliAnalysisTaskRhoSparse.h
+++ b/PWGJE/EMCALJetTasks/AliAnalysisTaskRhoSparse.h
@@ -13,22 +13,24 @@ class AliAnalysisTaskRhoSparse : public AliAnalysisTaskRhoBase {
   virtual ~AliAnalysisTaskRhoSparse() {}
 
   void             UserCreateOutputObjects();
-  void             SetExcludeLeadJets(UInt_t n)    { fNExclLeadJets = n    ; }
-  void             SetRhoCMS(Bool_t cms)           { fRhoCMS = cms ; }
+  void             SetExcludeLeadJets(UInt_t n)         { fNExclLeadJets = n       ; }
+  void             SetExcludeOverlapJets(Bool_t input)  { fExcludeOverlaps = input ; }
+  void             SetRhoCMS(Bool_t cms)                { fRhoCMS = cms            ; }
   Bool_t           IsJetOverlapping(AliEmcalJet* jet1, AliEmcalJet* jet2);
   Bool_t           IsJetSignal(AliEmcalJet* jet1);
 
  protected:
   Bool_t           Run();
 
-  UInt_t           fNExclLeadJets;                 // number of leading jets to be excluded from the median calculation
-  Bool_t           fRhoCMS;                        // flag to run CMS method
+  UInt_t           fNExclLeadJets;                                    ///< number of leading jets to be excluded from the median calculation
+  Bool_t           fExcludeOverlaps;                                  ///< exclude background jets that overlap (share at least one track) with anti-KT signal jets
+  Bool_t           fRhoCMS;                                           ///< flag to run CMS method
 
-  TH2F            *fHistOccCorrvsCent;             //!occupancy correction vs. centrality
+  TH2F            *fHistOccCorrvsCent;            				    //!<! occupancy correction vs. centrality
 
-  AliAnalysisTaskRhoSparse(const AliAnalysisTaskRhoSparse&);             // not implemented
-  AliAnalysisTaskRhoSparse& operator=(const AliAnalysisTaskRhoSparse&);  // not implemented
+  AliAnalysisTaskRhoSparse(const AliAnalysisTaskRhoSparse&);           ///< not implemented
+  AliAnalysisTaskRhoSparse& operator=(const AliAnalysisTaskRhoSparse&);///< not implemented
   
-  ClassDef(AliAnalysisTaskRhoSparse, 2); // Rho task
+  ClassDef(AliAnalysisTaskRhoSparse, 2);                               ///< Rho task
 };
 #endif


### PR DESCRIPTION
Changed the way to check for ghost jets (was pT>0.1 now nTracks>0)
Changed the way the total covered area is determined (was sum of all jet areas (excluding two leading jets) now Area of the TPC)
Changed the way the total jet area that is used for the correction factor is used (was use all non-ghost jets w/o leading jets now use all jets that actually contribute to the rho calculation)