### PR TITLE
acapon_LMEE_effCorr: turned off gen. naming

### DIFF
--- a/PWGDQ/dielectron/macrosLMEE/AddTask_acapon_Efficiency.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTask_acapon_Efficiency.C
@@ -1,18 +1,18 @@
 //Names should contain a comma seperated list of cut settings
 //Current options: all, electrons, kCutSet1, TTreeCuts, V0_TPCcorr, V0_ITScorr
 AliAnalysisTaskElectronEfficiencyV2* AddTask_acapon_Efficiency(TString names = "kCutSet1",
-                                                                Bool_t isAOD,
-                                                                Bool_t getFromAlien = kFALSE,
-                                                                TString configFile="Config_acapon_Efficiency.C",
-                                                                Bool_t DoCentralityCorrection = kFALSE,
-                                                                Bool_t cutlibPreloaded = kFALSE,
-                                                                Int_t wagonnr = 0,
-                                                                Int_t centrality = 0) {
+                                                               Int_t whichGen = 0, // 0=gen. purpose, 1=Jpsi, 2=HF, 3=all
+                                                               Int_t wagonnr = 0,
+                                                               Int_t centrality = 0,
+                                                               Bool_t cutlibPreloaded = kFALSE,
+                                                               Bool_t getFromAlien = kFALSE
+																																) {
 
   std::cout << "########################################\nADDTASK of ANALYSIS started\n########################################" << std::endl;
 	
+  TString configFile  = "Config_acapon_Efficiency.C";
 	TObjArray *arrNames = names.Tokenize(";");
-	Int_t nDie = arrNames->GetEntries();
+	Int_t nDie          = arrNames->GetEntries();
 	Printf("Number of implemented cuts: %i", nDie);
 
 	Bool_t SDDstatus = kTRUE;
@@ -60,9 +60,21 @@ AliAnalysisTaskElectronEfficiencyV2* AddTask_acapon_Efficiency(TString names = "
   // #########################################################
   // #########################################################
   // Possibility to set generator. If nothing set all generators are taken into account
-  // task->SetGeneratorName(generatorName);
-  task->SetGeneratorMCSignalName(generatorNameForMCSignal);
-  task->SetGeneratorULSSignalName(generatorNameForULSSignal);
+	if(whichGen == 0){
+		std::cout << "No generator specified. Looking at all sources" << std::endl;
+		task->SetGeneratorMCSignalName("");
+		task->SetGeneratorULSSignalName("");
+	}
+	else if(whichGen == 1){
+		std::cout << "Generator names specified -> Jpsi2ee_1 and B2Jpsi2ee_1" << std::endl;
+		task->SetGeneratorMCSignalName("Jpsi2ee_1;B2Jpsi2ee_1");
+		task->SetGeneratorULSSignalName("Jpsi2ee_1;B2Jpsi2ee_1");
+	}
+	else if(whichGen == 2){
+		std::cout << "Generator names specified -> Pythia CC_1, Pythia BB_1 and Pythia B_1" << std::endl;
+		task->SetGeneratorMCSignalName("Pythia CC_1;Pythia BB_1;Pythia B_1");
+		task->SetGeneratorULSSignalName("Pythia CC_1;Pythia BB_1;Pythia B_1");
+	}
 
   // #########################################################
   // #########################################################
@@ -160,7 +172,7 @@ AliAnalysisTaskElectronEfficiencyV2* AddTask_acapon_Efficiency(TString names = "
   // Adding cutsettings
   for(Int_t iCut = 0; iCut < nDie; ++iCut){
     TString cutDefinition(arrNames->At(iCut)->GetName());
-    AliAnalysisFilter* filter = SetupTrackCutsAndSettings(cutDefinition, isAOD);
+    AliAnalysisFilter* filter = SetupTrackCutsAndSettings(cutDefinition);
     task->AddTrackCuts(filter);
 		Printf("Successfully added task with cut set: %s\n", cutDefinition);
     //DoAdditionalWork(task);

--- a/PWGDQ/dielectron/macrosLMEE/Config_acapon_Efficiency.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_acapon_Efficiency.C
@@ -1,6 +1,8 @@
-TString generatorNameForMCSignal  = "EPOS-LHC_0;Pythia CC_1;Pythia BB_1;Pythia B_1;Jpsi2ee_1;B2Jpsi2ee_1";
-TString generatorNameForULSSignal = "EPOS-LHC_0;Pythia CC_1;Pythia BB_1;Pythia B_1;Jpsi2ee_1;B2Jpsi2ee_1";
+/* TString generatorNameForMCSignal  = "EPOS-LHC_0;Pythia CC_1;Pythia BB_1;Pythia B_1;Jpsi2ee_1;B2Jpsi2ee_1"; */
+/* TString generatorNameForULSSignal = "EPOS-LHC_0;Pythia CC_1;Pythia BB_1;Pythia B_1;Jpsi2ee_1;B2Jpsi2ee_1"; */
 
+TString generatorNameForMCSignal  = "";
+TString generatorNameForULSSignal = "";
 
 Bool_t SetTPCCorrection = kFALSE;
 Bool_t SetITSCorrection = kFALSE;
@@ -189,8 +191,8 @@ AliAnalysisFilter* SetupTrackCutsAndSettings(TString cutDefinition, Bool_t isAOD
 		anaFilter->SetName(cutDefinition);
 		anaFilter->Print();
   }
-	else if(cutDefinition = "kCutSet1"){ //TMVA (unweighted cut at 0.05)
-		std::cout << "Setting up cut set 1 (unweighted TMVA)" << std::endl;
+	else if(cutDefinition = "kCutSet1"){ //TMVA
+		std::cout << "Setting up cut set 1" << std::endl;
 		anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kCutSet1));
 		anaFilter->AddCuts(LMcutlib->GetPairCuts(LMEECutLib::kCutSet1));
 		anaFilter->SetName(cutDefinition);

--- a/PWGDQ/dielectron/macrosLMEE/Config_acapon_Efficiency.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_acapon_Efficiency.C
@@ -1,5 +1,5 @@
-/* TString generatorNameForMCSignal  = "EPOS-LHC_0;Pythia CC_1;Pythia BB_1;Pythia B_1;Jpsi2ee_1;B2Jpsi2ee_1"; */
-/* TString generatorNameForULSSignal = "EPOS-LHC_0;Pythia CC_1;Pythia BB_1;Pythia B_1;Jpsi2ee_1;B2Jpsi2ee_1"; */
+TString generatorNameForMCSignal  = "EPOS-LHC_0;Pythia CC_1;Pythia BB_1;Pythia B_1;Jpsi2ee_1;B2Jpsi2ee_1";
+TString generatorNameForULSSignal = "EPOS-LHC_0;Pythia CC_1;Pythia BB_1;Pythia B_1;Jpsi2ee_1;B2Jpsi2ee_1";
 
 TString generatorNameForMCSignal  = "";
 TString generatorNameForULSSignal = "";
@@ -177,7 +177,7 @@ void DoAdditionalWork(AliAnalysisTaskElectronEfficiencyV2* task){
 // #########################################################
 // #########################################################
 
-AliAnalysisFilter* SetupTrackCutsAndSettings(TString cutDefinition, Bool_t isAOD)
+AliAnalysisFilter* SetupTrackCutsAndSettings(TString cutDefinition)
 {
   std::cout << "SetupTrackCutsAndSettings( cutInstance = " << cutDefinition << " )" <<std::endl;
   AliAnalysisFilter *anaFilter = new AliAnalysisFilter("anaFilter","anaFilter"); // named constructor seems mandatory!


### PR DESCRIPTION
No electron tracks are found in the general purpose (EPOS-LHC) MC production if the
generator is specified. Leaving the strings blank means all present generators will be used. 