### PR TITLE
 PWG/EMCAL: Added possibilty to load custom Recalib and BadChannel OADB 

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellBadChannel.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellBadChannel.cxx
@@ -49,6 +49,11 @@ Bool_t AliEmcalCorrectionCellBadChannel::Initialize()
 
   fRecoUtils->SetPositionAlgorithm(AliEMCALRecoUtils::kPosTowerGlobal);
 
+  TString customBCmapPath = "";
+  GetProperty("customBadChannelFilePath", customBCmapPath);
+  if (customBCmapPath!="")
+    AliEmcalCorrectionComponent::SetCustomBadChannels(customBCmapPath);
+
   Bool_t dead = kFALSE;
   GetProperty("acceptDead", dead);
   if ( dead ) fRecoUtils->SetDeadChannelAsGood();

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
@@ -28,6 +28,7 @@ AliEmcalCorrectionCellEnergy::AliEmcalCorrectionCellEnergy() :
   ,fUseAutomaticRecalib(1)
   ,fUseAutomaticRunDepRecalib(1)
   ,fUseRunDepTempCalibRun2(0)
+  ,fCustomRecalibFilePath("")
 {
 }
 
@@ -52,6 +53,9 @@ Bool_t AliEmcalCorrectionCellEnergy::Initialize()
 
   // check the YAML configuration if the Run2 calibration is requested (default is false)
   GetProperty("enableRun2TempCalib",fUseRunDepTempCalibRun2);
+
+  // check the YAML configuration if a custom energy calibration is requested (default is empty string "")
+  GetProperty("customRecalibFilePath",fCustomRecalibFilePath);
 
   if (!fRecoUtils)
     fRecoUtils  = new AliEMCALRecoUtils;
@@ -149,6 +153,19 @@ Int_t AliEmcalCorrectionCellEnergy::InitRecalib()
     if (!recalibFile || recalibFile->IsZombie())
     {
       AliFatal(Form("EMCALRecalib.root not found in %s",fBasePath.Data()));
+      return 0;
+    }
+    
+    contRF = std::unique_ptr<AliOADBContainer>(static_cast<AliOADBContainer *>(recalibFile->Get("AliEMCALRecalib")));
+  }
+  else if (fCustomRecalibFilePath!="")
+  { //if custom recalib requested
+    AliInfo(Form("Loading custom Recalib OADB from given path %s",fCustomRecalibFilePath.Data()));
+    
+    recalibFile = std::unique_ptr<TFile>(TFile::Open(Form("%s",fCustomRecalibFilePath.Data()),"read"));
+    if (!recalibFile || recalibFile->IsZombie())
+    {
+      AliFatal(Form("Recalibration not file found. Provided path was: %s",fCustomRecalibFilePath.Data()));
       return 0;
     }
     

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.h
@@ -45,6 +45,7 @@ private:
   Bool_t                 fUseAutomaticRecalib;       ///< On by default the check in the OADB of the energy recalibration
   Bool_t                 fUseAutomaticRunDepRecalib; ///< On by default the check in the OADB of the run dependent energy recalibration
   Bool_t                 fUseRunDepTempCalibRun2;    ///< Off by default the check in the OADB of the run dependent temp calib Run2
+  TString                fCustomRecalibFilePath;     ///< Empty string by default the path to the OADB file of the custom energy recalibration
   
   AliEmcalCorrectionCellEnergy(const AliEmcalCorrectionCellEnergy &);               // Not implemented
   AliEmcalCorrectionCellEnergy &operator=(const AliEmcalCorrectionCellEnergy &);    // Not implemented
@@ -53,7 +54,7 @@ private:
   static RegisterCorrectionComponent<AliEmcalCorrectionCellEnergy> reg;
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionCellEnergy, 2); // EMCal cell energy correction component
+  ClassDef(AliEmcalCorrectionCellEnergy, 3); // EMCal cell energy correction component
   /// \endcond
 };
 

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.cxx
@@ -50,7 +50,8 @@ AliEmcalCorrectionComponent::AliEmcalCorrectionComponent() :
   fCaloCells(0),
   fRecoUtils(0),
   fOutput(0),
-  fBasePath("")
+  fBasePath(""),
+  fCustomBadChannelFilePath("")
 
 {
   fVertex[0] = 0;
@@ -84,7 +85,8 @@ AliEmcalCorrectionComponent::AliEmcalCorrectionComponent(const char * name) :
   fCaloCells(0),
   fRecoUtils(0),
   fOutput(0),
-  fBasePath("")
+  fBasePath(""),
+  fCustomBadChannelFilePath("")
 {
   fVertex[0] = 0;
   fVertex[1] = 0;
@@ -338,7 +340,7 @@ Int_t AliEmcalCorrectionComponent::InitBadChannels()
     contBC = std::unique_ptr<AliOADBContainer>(static_cast<AliOADBContainer *>(fbad->Get("AliEMCALBadChannels")));
   }
   else if (fCustomBadChannelFilePath!="")
-  { //if fBasePath specified in the ->SetBasePath()
+  { //if fCustomBadChannelFilePath specified in the configuration for custom bad channel maps
     AliInfo(Form("Loading custom Bad Channels OADB from given path %s",fCustomBadChannelFilePath.Data()));
     
     fbad = std::unique_ptr<TFile>(TFile::Open(Form("%s",fCustomBadChannelFilePath.Data()),"read"));

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.cxx
@@ -337,6 +337,19 @@ Int_t AliEmcalCorrectionComponent::InitBadChannels()
     
     contBC = std::unique_ptr<AliOADBContainer>(static_cast<AliOADBContainer *>(fbad->Get("AliEMCALBadChannels")));
   }
+  else if (fCustomBadChannelFilePath!="")
+  { //if fBasePath specified in the ->SetBasePath()
+    AliInfo(Form("Loading custom Bad Channels OADB from given path %s",fCustomBadChannelFilePath.Data()));
+    
+    fbad = std::unique_ptr<TFile>(TFile::Open(Form("%s",fCustomBadChannelFilePath.Data()),"read"));
+    if (!fbad || fbad->IsZombie())
+    {
+      AliFatal(Form("No valid Bad channel OADB object was not found in the path provided: %s",fCustomBadChannelFilePath.Data()));
+      return 0;
+    }
+    
+    contBC = std::unique_ptr<AliOADBContainer>(static_cast<AliOADBContainer *>(fbad->Get("AliEMCALBadChannels")));
+  }
   else
   { // Else choose the one in the $ALICE_PHYSICS directory
     AliInfo("Loading Bad Channels OADB from $ALICE_PHYSICS/OADB/EMCAL");

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.h
@@ -102,6 +102,7 @@ class AliEmcalCorrectionComponent : public TNamed {
   void SetNcentralityBins(Int_t n) { fNcentBins = n; }
   void SetVertex(Double_t * vertex) { fVertex[0] = vertex[0]; fVertex[1] = vertex[1]; fVertex[2] = vertex[2]; }
   void SetIsESD(Bool_t isESD) {fEsdMode = isESD; }
+  void SetCustomBadChannels(TString customBC) {fCustomBadChannelFilePath = customBC; }
 
   /// Set %YAML Configuration
   void SetYAMLConfiguration(PWG::Tools::AliYAMLConfiguration config) { fYAMLConfig = config; }
@@ -133,13 +134,14 @@ class AliEmcalCorrectionComponent : public TNamed {
   TList                  *fOutput;                        //!<! List of output histograms
   
   TString                fBasePath;                       ///< Base folder path to get root files
+  TString                fCustomBadChannelFilePath;       ///< Custom path to bad channel map OADB file
 
  private:
   AliEmcalCorrectionComponent(const AliEmcalCorrectionComponent &);               // Not implemented
   AliEmcalCorrectionComponent &operator=(const AliEmcalCorrectionComponent &);    // Not implemented
   
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionComponent, 5); // EMCal correction component
+  ClassDef(AliEmcalCorrectionComponent, 6); // EMCal correction component
   /// \endcond
 };
 

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -55,11 +55,13 @@ CellEnergy:                                         # Cell Energy correction com
     enabled: false                                  # Whether to enable the task
     createHistos: false                             # Whether the task should create output histograms
     enableRun2TempCalib: false                      # Whether the temperature calibration should be done for Run2
+    customRecalibFilePath: ""                       # Full path including .root file for custom recalibration object
     cellsNames:                                     # Names of the cells input objects which should be attached to the correction
         - defaultCells                              # This object is defined above in the cells section of the input objects
 CellBadChannel:                                     # Bad channel removal at the cell level component
     enabled: false                                  # Whether to enable the task
     createHistos: false                             # Whether the task should create output histograms
+    customBadChannelFilePath: ""                    # Full path to a custom bad channel OADB object
     acceptDead: false                               # Declare dead channels as good
     acceptHot: false                                # Declare hot channels as good
     acceptWarm: false                               # Declare warm channels as good  


### PR DESCRIPTION
Due to a request by @loizides, @gconesab  and @FriederikeBock we now have the possibility to set custom OADB objects for the recalibration as well as bad channel maps. For this, simply set  one or both of the following values in the .yaml configuration:

```
CellEnergy:
    customRecalibFilePath: "" 
CellBadChannel: 
    customBadChannelFilePath: ""
```
In both cases, the full path including the .root filename must be provided. This allows also for custom names of the .root files.
