### PR TITLE
Do not use event selection from mulitplicity selection

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalClustersRef.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalClustersRef.cxx
@@ -163,7 +163,7 @@ bool AliAnalysisTaskEmcalClustersRef::IsUserEventSelected(){
       AliErrorStream() << GetName() << ": Centrality selection enabled but no centrality estimator found" << std::endl;
       return false;
     }
-    if(mult->IsEventSelected()) return false;
+    //if(mult->IsEventSelected()) return false;
     fEventCentrality = mult->GetEstimator(fCentralityEstimator)->GetPercentile();
     AliDebugStream(1) << GetName() << ": Centrality " <<  fEventCentrality << std::endl;
     if(!fCentralityRange.IsInRange(fEventCentrality)){


### PR DESCRIPTION
This kills all CV0L7 triggers