### PR TITLE
PWGCF: FEMTOSCOPY: Fixed bug in AliAnalysisV0Efficiency that was maki…

### DIFF
--- a/PWGCF/FEMTOSCOPY/V0LamAnalysis/AliAnalysisV0Efficiency.cxx
+++ b/PWGCF/FEMTOSCOPY/V0LamAnalysis/AliAnalysisV0Efficiency.cxx
@@ -458,7 +458,7 @@ void AliAnalysisV0Efficiency::ExtractOriginalParticles(const AliAODEvent *aEvent
 //    int tPartPID = tPart->GetPdgCode();
 
     bool tIsInjected = false;
-    if(fIgnoreInjectedV0s) IsInjected(tPart, mcP, tNumberOfLastHijingLabel);
+    if(fIgnoreInjectedV0s) tIsInjected = IsInjected(tPart, mcP, tNumberOfLastHijingLabel);
     AliAODMCParticle *tMother = NULL;
     if(tPart->GetMother() > -1)  //MC particle has a mother 
     {


### PR DESCRIPTION
…ng IsInjected option useless in ExtractOriginalParticles method