### PR TITLE
Fixes issue of this class with standard macos compiler

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnTrueQ3DByParent.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnTrueQ3DByParent.cxx
@@ -18,6 +18,7 @@
 
 #include <tuple>
 #include <iostream>
+#include <array>
 
 AliFemtoModelCorrFctnTrueQ3DByParent::AliFemtoModelCorrFctnTrueQ3DByParent():
   AliFemtoModelCorrFctnTrueQ3DByParent("CF_TrueQ3DBP")


### PR DESCRIPTION
Error: PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnTrueQ3DByParent.cxx:85:24: error: 
      implicit instantiation of undefined template 'std::__1::array<int, 4>'
  std::array<Int_t, 4> nbins_v = {static_cast<int>(par_nbins * 2 + 1), nbins, nbins, nbins};
Fixed by including array