### PR TITLE
[EMCAL-403]  Trigger separation in case L0 is INT7

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerBase.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerBase.cxx
@@ -289,19 +289,21 @@ void AliAnalysisTaskEmcalTriggerBase::TriggerSelection(){
         }
       }
     }
-    
-    if(fInputEvent->GetFiredTriggerClasses().Contains("EMC") || fInputEvent->GetFiredTriggerClasses().Contains("DMC")){
+    auto triggerstring =  fInputEvent->GetFiredTriggerClasses();
+    if(triggerstring.Contains("EMC") || triggerstring.Contains("DMC") || 
+       triggerstring.Contains("INT7E") || triggerstring.Contains("INT7D")){   // special conditions for 2015 PbPb
       // Apply cut on the trigger string - this basically discriminates high- and low-threshold
       // triggers
       auto triggers = PWG::EMCAL::Triggerinfo::DecodeTriggerString(fInputEvent->GetFiredTriggerClasses().Data());
       std::map<int, std::array<bool, 3>> matchedTriggers;
       for(auto t : triggers) {  
         const auto &triggerclass = t.Triggerclass();
-        if((triggerclass.find("EMC") != std::string::npos) || (triggerclass.find("DMC") != std::string::npos)) 
+        if((triggerclass.find("EMC") != std::string::npos) || (triggerclass.find("DMC") != std::string::npos) || 
+           (triggerclass.find("INT7E") != std::string::npos) || (triggerclass.find("INT7D") != std::string::npos)) 
           AliDebugStream(1) << GetName() << ": Trigger string " << t.ExpandClassName() << std::endl;
         else continue;    // No EMC / DMC trigger - not to be checked
-        bool isT0trigger = (triggerclass.find("EMC8") != std::string::npos) || (triggerclass.find("DMC8") != std::string::npos),
-             isVZEROtrigger = (triggerclass.find("EMC7") != std::string::npos) || (triggerclass.find("DMC7") != std::string::npos);
+        bool isT0trigger = (triggerclass.find("EMC8") != std::string::npos) || (triggerclass.find("DMC8") != std::string::npos) || (triggerclass.find("INT8") != std::string::npos),
+             isVZEROtrigger = (triggerclass.find("EMC7") != std::string::npos) || (triggerclass.find("DMC7") != std::string::npos) || (triggerclass.find("INT7") != std::string::npos);
         for(auto iclass = 0; iclass < AliEmcalTriggerOfflineSelection::kTrgn; iclass++){
           AliDebugStream(1) << "Next trigger: " << kEmcalSelectTriggerStrings[iclass] << std::endl;
           bool emcalSelectionStatus = MatchTriggerFromPattern(kEmcalSelectTriggerStrings[iclass], triggerclass);


### PR DESCRIPTION
Needed  for PbPb: As L0 trigger INT7 was used and not
0EMC/0DMC, so checkes for the E/DMC string failed and
the trigger selection was based purely on the trigger bits.