### PR TITLE
Applies ePID post calibration to acapon_LMEE scripts

### DIFF
--- a/PWGDQ/dielectron/macrosLMEE/AddTaskSimpleTreeMaker.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTaskSimpleTreeMaker.C
@@ -3,6 +3,7 @@ AliAnalysisTaskSimpleTreeMaker *AddTaskSimpleTreeMaker(TString taskName = "MLtre
                                                        Bool_t useITScorr = kFALSE,
 																											 Bool_t useTPCcorr = kFALSE,
 																											 Bool_t useTOFcorr = kFALSE,
+																											 Bool_t isMC = kFALSE,
 																											 Bool_t getFromAlien = kFALSE) {				
 
     AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
@@ -65,11 +66,11 @@ AliAnalysisTaskSimpleTreeMaker *AddTaskSimpleTreeMaker(TString taskName = "MLtre
     if(useITScorr){
 			TH3D meanITS = cutLib->SetEtaCorrectionITSTTree(AliDielectronVarManager::kP,
                                               AliDielectronVarManager::kEta,
-                                              AliDielectronVarManager::kRefMultTPConly, kFALSE,1);
+                                              AliDielectronVarManager::kRefMultTPConly, kFALSE,1, isMC);
 
 			TH3D widthITS = cutLib->SetEtaCorrectionITSTTree(AliDielectronVarManager::kP,
                                                AliDielectronVarManager::kEta,
-                                               AliDielectronVarManager::kRefMultTPConly, kFALSE,2);
+                                               AliDielectronVarManager::kRefMultTPConly, kFALSE,2, isMC);
 			task->SetUseITScorr(kTRUE);
 			task->SetCorrWidthMeanITS((TH3D*)widthITS.Clone(),(TH3D*)meanITS.Clone());
 
@@ -77,11 +78,11 @@ AliAnalysisTaskSimpleTreeMaker *AddTaskSimpleTreeMaker(TString taskName = "MLtre
 		if(useTOFcorr){
 			TH3D meanTOF = cutLib->SetEtaCorrectionTOFTTree(AliDielectronVarManager::kP,
                                               AliDielectronVarManager::kEta,
-                                              AliDielectronVarManager::kRefMultTPConly, kFALSE,1);
+                                              AliDielectronVarManager::kRefMultTPConly, kFALSE,1, isMC);
 
 			TH3D widthTOF = cutLib->SetEtaCorrectionTOFTTree(AliDielectronVarManager::kP,
                                                AliDielectronVarManager::kEta,
-                                               AliDielectronVarManager::kRefMultTPConly, kFALSE,2);
+                                               AliDielectronVarManager::kRefMultTPConly, kFALSE,2, isMC);
 			task->SetUseTOFcorr(kTRUE);
 			task->SetCorrWidthMeanTOF((TH3D*)widthTOF.Clone(),(TH3D*)meanTOF.Clone());
 

--- a/PWGDQ/dielectron/macrosLMEE/AddTask_acapon_Efficiency.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTask_acapon_Efficiency.C
@@ -174,7 +174,9 @@ AliAnalysisTaskElectronEfficiencyV2* AddTask_acapon_Efficiency(TString names = "
     AliAnalysisFilter* filter = SetupTrackCutsAndSettings(cutDefinition);
     task->AddTrackCuts(filter);
 		Printf("Successfully added task with cut set: %s\n", cutDefinition);
-    //DoAdditionalWork(task);
+		// Apply PID post calibration to ITS(0) and TOF(1)
+    ApplyPIDpostCalibration(task, 0);
+    ApplyPIDpostCalibration(task, 1);
   }
 
 

--- a/PWGDQ/dielectron/macrosLMEE/Config_acapon_Efficiency.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_acapon_Efficiency.C
@@ -102,33 +102,13 @@ void GetCentrality(const Int_t centrality, Double_t& CentMin, Double_t& CentMax)
   return;
 }
 
-void DoAdditionalWork(AliAnalysisTaskElectronEfficiencyV2* task){
+void ApplyPIDpostCalibration(AliAnalysisTaskElectronEfficiencyV2* task, Int_t whichDet){
   std::cout << task << std::endl;
 
-  std::cout << "starting DoAdditionalWork()\n";
-  if(SetTPCCorrection == kTRUE){
-    std::cout << "Loading TPC correction" << std::endl;
-    std::string file_name = "outputTPC.root";
-    TFile* _file = TFile::Open(file_name.c_str());
-
-    if(!_file){
-      gSystem->Exec(("alien_cp alien:///alice/cern.ch/user/a/acapon/PIDcalibration/" + file_name + " .").c_str());
-      std::cout << "Copy TPC correction from Alien" << std::endl;
-      _file = TFile::Open(file_name.c_str());
-    }
-    else {
-      std::cout << "Correction loaded" << std::endl;
-    }
-
-    TH3D* mean = dynamic_cast<TH3D*>(_file->Get("sum_mean_correction"));
-    TH3D* width= dynamic_cast<TH3D*>(_file->Get("sum_width_correction"));
-
-    task->SetCentroidCorrFunction(AliAnalysisTaskElectronEfficiencyV2::kTPC, mean,  AliDielectronVarManager::kP, AliDielectronVarManager::kEta, AliDielectronVarManager::kRefMultTPConly);
-    task->SetWidthCorrFunction   (AliAnalysisTaskElectronEfficiencyV2::kTPC, width, AliDielectronVarManager::kP, AliDielectronVarManager::kEta, AliDielectronVarManager::kRefMultTPConly);
-  }
-  if(SetITSCorrection == kTRUE){
+  std::cout << "starting ApplyPIDpostCalibration()\n";
+  if(whichDet == 0){// ITS
     std::cout << "Loading ITS correction" << std::endl;
-    std::string file_name = "outputITS.root";
+    std::string file_name = "outputITS_17f2a.root";
     TFile* _file = TFile::Open(file_name.c_str());
 
     if(!_file){
@@ -146,9 +126,9 @@ void DoAdditionalWork(AliAnalysisTaskElectronEfficiencyV2* task){
     task->SetCentroidCorrFunction(AliAnalysisTaskElectronEfficiencyV2::kITS, mean,  AliDielectronVarManager::kP, AliDielectronVarManager::kEta, AliDielectronVarManager::kRefMultTPConly);
     task->SetWidthCorrFunction   (AliAnalysisTaskElectronEfficiencyV2::kITS, width, AliDielectronVarManager::kP, AliDielectronVarManager::kEta, AliDielectronVarManager::kRefMultTPConly);
   }
-  if(SetTOFCorrection == kTRUE){
+  if(whichDet == 1){// TOF
     std::cout << "Loading TOF correction" << std::endl;
-    std::string file_name = "outputTOF.root";
+    std::string file_name = "outputTOF_17f2a.root";
     TFile* _file = TFile::Open(file_name.c_str());
 
     if(!_file){
@@ -188,7 +168,6 @@ AliAnalysisFilter* SetupTrackCutsAndSettings(TString cutDefinition)
 	else if(cutDefinition = "kCutSet1"){ //TMVA
 		std::cout << "Setting up cut set 1" << std::endl;
 		anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kCutSet1));
-		anaFilter->AddCuts(LMcutlib->GetPairCuts(LMEECutLib::kCutSet1));
 		anaFilter->SetName(cutDefinition);
 		anaFilter->Print();
 	}

--- a/PWGDQ/dielectron/macrosLMEE/LMEECutLib_acapon.C
+++ b/PWGDQ/dielectron/macrosLMEE/LMEECutLib_acapon.C
@@ -61,6 +61,7 @@ void LMEECutLib::SetEtaCorrectionTPC(AliDielectron *die, Int_t corrXdim, Int_t c
   //
   // eta correction for the centroid and width of electron sigmas in the TPC, can be one/two/three-dimensional
   //
+	
   std::cout << "starting LMEECutLib::SetEtaCorrectionTPC()\n";
   std::string file_name = "/home/aaron/Data/PIDcalibration/outputTPC.root";
 
@@ -91,21 +92,34 @@ void LMEECutLib::SetEtaCorrectionTPC(AliDielectron *die, Int_t corrXdim, Int_t c
 
 }
 
-void LMEECutLib::SetEtaCorrectionITS(AliDielectron *die, Int_t corrXdim, Int_t corrYdim, Int_t corrZdim, Bool_t runwise) {
+void LMEECutLib::SetEtaCorrectionITS(AliDielectron *die, Int_t corrXdim, Int_t corrYdim, Int_t corrZdim, Bool_t runwise, Bool_t hasMC){
   //
   // eta correction for the centroid and width of electron sigmas in the TPC, can be one/two/three-dimensional
   //
   std::cout << "starting LMEECutLib::SetEtaCorrectionITS()\n";
-  std::string file_name = "/home/aaron/Data/PIDcalibration/outputITS.root";
+  TString file_name = "/home/aaron/Data/PIDcalibration/output";
+	if(hasMC){
+		file_name.Append("ITS_17f2a.root");
+	}else{
+		file_name.Append("ITS.root");
+	}
 
-  TFile* inFile = TFile::Open(file_name.c_str());
+  TFile* inFile = TFile::Open(file_name.Data());
   std::cout << inFile << std::endl;
   if(!inFile){
-    gSystem->Exec("alien_cp alien:///alice/cern.ch/user/a/acapon/PIDcalibration/outputITS.root .");
+		if(!hasMC){
+			gSystem->Exec("alien_cp alien:///alice/cern.ch/user/a/acapon/PIDcalibration/outputITS.root .");
+		}else{
+			gSystem->Exec("alien_cp alien:///alice/cern.ch/user/a/acapon/PIDcalibration/outputITS_17f2a.root .");
+		}
     std::cout << "Copy ITS correction from Alien" << std::endl;
-    inFile = TFile::Open("outputITS.root");
+		if(!hasMC){
+			inFile = TFile::Open("outputITS.root");
+		}else{
+			inFile = TFile::Open("outputITS_17f2a.root");
+		}
   }
-  else {
+  else{
     std::cout << "Correction loaded" << std::endl;
   }
   if(runwise){
@@ -124,21 +138,35 @@ void LMEECutLib::SetEtaCorrectionITS(AliDielectron *die, Int_t corrXdim, Int_t c
   }
 
 }
-void LMEECutLib::SetEtaCorrectionTOF(AliDielectron *die, Int_t corrXdim, Int_t corrYdim, Int_t corrZdim, Bool_t runwise) {
+
+void LMEECutLib::SetEtaCorrectionTOF(AliDielectron *die, Int_t corrXdim, Int_t corrYdim, Int_t corrZdim, Bool_t runwise, Bool_t hasMC){
   //
   // eta correction for the centroid and width of electron sigmas in the TPC, can be one/two/three-dimensional
   //
   std::cout << "starting LMEECutLib::SetEtaCorrectionTOF()\n";
-  std::string file_name = "/home/aaron/Data/PIDcalibration/outputTOF.root";
+  TString file_name = "/home/aaron/Data/PIDcalibration/output";
+	if(hasMC){
+		file_name.Append("TOF_17f2a.root");
+	}else{
+		file_name.Append("TOF.root");
+	}
 
-  TFile* inFile = TFile::Open(file_name.c_str());
+  TFile* inFile = TFile::Open(file_name.Data());
   std::cout << inFile << std::endl;
   if(!inFile){
-    gSystem->Exec("alien_cp alien:///alice/cern.ch/user/a/acapon/PIDcalibration/outputTOF.root .");
+		if(!hasMC){
+			gSystem->Exec("alien_cp alien:///alice/cern.ch/user/a/acapon/PIDcalibration/outputTOF.root .");
+		}else{
+			gSystem->Exec("alien_cp alien:///alice/cern.ch/user/a/acapon/PIDcalibration/outputTOF_17f2a.root .");
+		}
     std::cout << "Copy TOF correction from Alien" << std::endl;
-    inFile = TFile::Open("outputTOF.root");
+		if(!hasMC){
+			inFile = TFile::Open("outputTOF.root");
+		}else{
+			inFile = TFile::Open("outputTOF_17f2a.root");
+		}
   }
-  else {
+  else{
     std::cout << "Correction loaded" << std::endl;
   }
   if(runwise){
@@ -157,6 +185,8 @@ void LMEECutLib::SetEtaCorrectionTOF(AliDielectron *die, Int_t corrXdim, Int_t c
   }
 
 }
+
+
 static TH3D LMEECutLib::SetEtaCorrectionTPCTTree( Int_t corrXdim, Int_t corrYdim, Int_t corrZdim, Bool_t runwise, Int_t selection) {
 	
 
@@ -264,18 +294,27 @@ static TH3D LMEECutLib::SetEtaCorrectionTPCTTree( Int_t corrXdim, Int_t corrYdim
 
 }
 
-static TH3D LMEECutLib::SetEtaCorrectionITSTTree( Int_t corrXdim, Int_t corrYdim, Int_t corrZdim, Bool_t runwise, Int_t selection) {
+static TH3D LMEECutLib::SetEtaCorrectionITSTTree( Int_t corrXdim, Int_t corrYdim, Int_t corrZdim, Bool_t runwise, Int_t selection, Bool_t hasMC) {
 	
 
   ::Info("LMEECutLib_acapon", " >>>>>>>>>>>>>>>>>>>>>> SetEtaCorrectionITSTTree() >>>>>>>>>>>>>>>>>>>>>> ");
 
   std::cout << "starting LMEECutLib::SetEtaCorrectionITSTTree()\n";
-  std::string file_name = "/home/aaron/Data/PIDcalibration/outputITS.root";
+  std::string file_name;
+	if(!hasMC){
+		file_name = "/home/aaron/Data/PIDcalibration/outputITS.root";
+	}else{
+		file_name = "/home/aaron/Data/PIDcalibration/outputITS_17f2a.root";
+	}
 
   TFile* recalFile = TFile::Open(file_name.c_str());
   std::cout << recalFile << std::endl;
   if(!recalFile){
-    gSystem->Exec("alien_cp alien:///alice/cern.ch/user/a/acapon/PIDcalibration/outputITS.root .");
+		if(hasMC){
+			gSystem->Exec("alien_cp alien:///alice/cern.ch/user/a/acapon/PIDcalibration/outputITS.root .");
+		}else{
+			gSystem->Exec("alien_cp alien:///alice/cern.ch/user/a/acapon/PIDcalibration/outputITS_17f2a.root .");
+		}
     std::cout << "Copy ITS correction from Alien" << std::endl;
     recalFile = TFile::Open("outputITS.root");
   }
@@ -371,18 +410,27 @@ static TH3D LMEECutLib::SetEtaCorrectionITSTTree( Int_t corrXdim, Int_t corrYdim
 
 }
 
-static TH3D LMEECutLib::SetEtaCorrectionTOFTTree( Int_t corrXdim, Int_t corrYdim, Int_t corrZdim, Bool_t runwise, Int_t selection) {
+static TH3D LMEECutLib::SetEtaCorrectionTOFTTree( Int_t corrXdim, Int_t corrYdim, Int_t corrZdim, Bool_t runwise, Int_t selection, Bool_t hasMC) {
 	
 
   ::Info("LMEECutLib_acapon", " >>>>>>>>>>>>>>>>>>>>>> SetEtaCorrectionTOFTTree() >>>>>>>>>>>>>>>>>>>>>> ");
 
   std::cout << "starting LMEECutLib::SetEtaCorrectionTOFTTree()\n";
-  std::string file_name = "/home/aaron/Data/PIDcalibration/outputTOF.root";
+  std::string file_name;
+	if(hasMC){
+		file_name = "/home/aaron/Data/PIDcalibration/outputTOF.root";
+	}else{
+		file_name = "/home/aaron/Data/PIDcalibration/outputTOF_17f2a.root";
+	}
 
   TFile* recalFile = TFile::Open(file_name.c_str());
   std::cout << recalFile << std::endl;
   if(!recalFile){
-    gSystem->Exec("alien_cp alien:///alice/cern.ch/user/a/acapon/PIDcalibration/outputTOF.root .");
+		if(hasMC){
+			gSystem->Exec("alien_cp alien:///alice/cern.ch/user/a/acapon/PIDcalibration/outputTOF.root .");
+		}else{
+			gSystem->Exec("alien_cp alien:///alice/cern.ch/user/a/acapon/PIDcalibration/outputTOF_17f2a.root .");
+		}
     std::cout << "Copy TOF correction from Alien" << std::endl;
     recalFile = TFile::Open("outputTOF.root");
   }


### PR DESCRIPTION
All configs, AddTasks and CutLib belonging to acapon have been updated to apply ePID
post calibration to the ITS and TOF now, in addition to calibration already being applied to the data.
