### PR TITLE
Major update of the FemtoDream and the Sigma0 analysis

### DIFF
--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskSigma0Femto.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskSigma0Femto.cxx
@@ -205,7 +205,6 @@ void AliAnalysisTaskSigma0Femto::UserExec(Option_t * /*option*/) {
   CastToVector(fSigmaCuts->GetSidebandDown(), sigma0sidebandLow);
   CastToVector(fAntiSigmaCuts->GetSidebandDown(), antiSigma0sidebandLow);
 
-
   CastToVector(lambdaSigma, sigma0lambda);
   CastToVector(photonSigma, sigma0photon);
   CastToVector(lambdaAntiSigma, antiSigma0lambda);
@@ -260,12 +259,18 @@ bool AliAnalysisTaskSigma0Femto::AcceptEvent(AliVEvent *event) {
   }
   fHistCutQA->Fill(0);
 
+  // Remove overlap with HM trigger from MB
+  if (!fIsMC && fTrigger == AliVEvent::kINT7 &&
+      (fInputHandler->IsEventSelected() & AliVEvent::kHighMultV0))
+    return false;
+  fHistCutQA->Fill(1);
+
   // EVENT SELECTION
   if (!fAliEventCuts.AcceptEvent(event)) return false;
   if (!fIsLightweight) {
     FillTriggerHisto(fHistTriggerAfter);
   }
-  fHistCutQA->Fill(1);
+  fHistCutQA->Fill(2);
 
   Float_t lPercentile = 300;
   AliMultSelection *MultSelection = 0x0;
@@ -285,7 +290,7 @@ bool AliAnalysisTaskSigma0Femto::AcceptEvent(AliVEvent *event) {
     if (!fIsLightweight) {
       fHistCentralityProfileAfter->Fill(lPercentile);
     }
-    fHistCutQA->Fill(2);
+    fHistCutQA->Fill(3);
   }
 
   bool isConversionEventSelected =
@@ -295,7 +300,7 @@ bool AliAnalysisTaskSigma0Femto::AcceptEvent(AliVEvent *event) {
 
   if (!fIsLightweight) fHistCentralityProfileCoarseAfter->Fill(lPercentile);
 
-  fHistCutQA->Fill(3);
+  fHistCutQA->Fill(4);
   return true;
 }
 
@@ -414,11 +419,12 @@ void AliAnalysisTaskSigma0Femto::UserCreateOutputObjects() {
     fOutputContainer->Add(fV0Reader->GetImpactParamHistograms());
   }
 
-  fHistCutQA = new TH1F("fHistCutQA", ";;Entries", 5, 0, 5);
+  fHistCutQA = new TH1F("fHistCutQA", ";;Entries", 10, 0, 10);
   fHistCutQA->GetXaxis()->SetBinLabel(1, "Event");
-  fHistCutQA->GetXaxis()->SetBinLabel(2, "AliEventCuts");
-  fHistCutQA->GetXaxis()->SetBinLabel(3, "Multiplicity selection");
-  fHistCutQA->GetXaxis()->SetBinLabel(4, "AliConversionCuts");
+  fHistCutQA->GetXaxis()->SetBinLabel(2, "Overlap with HM");
+  fHistCutQA->GetXaxis()->SetBinLabel(3, "AliEventCuts");
+  fHistCutQA->GetXaxis()->SetBinLabel(4, "Multiplicity selection");
+  fHistCutQA->GetXaxis()->SetBinLabel(5, "AliConversionCuts");
   fQA->Add(fHistCutQA);
 
   fHistPhotonPileUp =

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskSigma0Femto.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskSigma0Femto.cxx
@@ -403,20 +403,22 @@ void AliAnalysisTaskSigma0Femto::UserCreateOutputObjects() {
     return;
   }
 
-  if (fV0Reader->GetEventCuts() &&
-      fV0Reader->GetEventCuts()->GetCutHistograms()) {
-    fOutputContainer->Add(fV0Reader->GetEventCuts()->GetCutHistograms());
-  }
-  if (fV0Reader->GetConversionCuts() &&
-      fV0Reader->GetConversionCuts()->GetCutHistograms()) {
-    fOutputContainer->Add(fV0Reader->GetConversionCuts()->GetCutHistograms());
-  }
-  if (fV0Reader->GetProduceV0FindingEfficiency() &&
-      fV0Reader->GetV0FindingEfficiencyHistograms()) {
-    fOutputContainer->Add(fV0Reader->GetV0FindingEfficiencyHistograms());
-  }
-  if (fV0Reader->GetProduceImpactParamHistograms()) {
-    fOutputContainer->Add(fV0Reader->GetImpactParamHistograms());
+  if (!fIsLightweight) {
+    if (fV0Reader->GetEventCuts() &&
+        fV0Reader->GetEventCuts()->GetCutHistograms()) {
+      fOutputContainer->Add(fV0Reader->GetEventCuts()->GetCutHistograms());
+    }
+    if (fV0Reader->GetConversionCuts() &&
+        fV0Reader->GetConversionCuts()->GetCutHistograms()) {
+      fOutputContainer->Add(fV0Reader->GetConversionCuts()->GetCutHistograms());
+    }
+    if (fV0Reader->GetProduceV0FindingEfficiency() &&
+        fV0Reader->GetV0FindingEfficiencyHistograms()) {
+      fOutputContainer->Add(fV0Reader->GetV0FindingEfficiencyHistograms());
+    }
+    if (fV0Reader->GetProduceImpactParamHistograms()) {
+      fOutputContainer->Add(fV0Reader->GetImpactParamHistograms());
+    }
   }
 
   fHistCutQA = new TH1F("fHistCutQA", ";;Entries", 10, 0, 10);

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamAnalysis.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamAnalysis.cxx
@@ -428,7 +428,7 @@ void AliFemtoDreamAnalysis::Make(AliESDEvent *evt, AliMCEvent *mcEvent) {
 
   for (int iv0 = 0; iv0 < evt->GetNumberOfV0s(); ++iv0) {
     AliESDv0 *v0 = evt->GetV0(iv0);
-    fFemtov0->Setv0(evt, v0, fEvent->GetMultiplicity());
+    fFemtov0->Setv0(evt, mcEvent, v0, fEvent->GetMultiplicity());
     if (fv0Cuts->isSelected(fFemtov0)) {
       Decays.push_back(*fFemtov0);
     }
@@ -441,7 +441,7 @@ void AliFemtoDreamAnalysis::Make(AliESDEvent *evt, AliMCEvent *mcEvent) {
   std::vector<AliFemtoDreamBasePart> AntiXiDecays;
   for (Int_t nCascade = 0; nCascade < evt->GetNumberOfCascades(); ++nCascade) {
     AliESDcascade *esdCascade = evt->GetCascade(nCascade);
-    fFemtoCasc->SetCascade(evt, esdCascade);
+    fFemtoCasc->SetCascade(evt, mcEvent, esdCascade);
     if (fCascCuts->isSelected(fFemtoCasc)) {
       XiDecays.push_back(*fFemtoCasc);
     }

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCascade.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCascade.cxx
@@ -187,7 +187,8 @@ void AliFemtoDreamCascade::SetCascade(AliAODEvent *evt, AliAODcascade *casc) {
   }
 }
 
-void AliFemtoDreamCascade::SetCascade(AliESDEvent *evt, AliESDcascade *casc) {
+void AliFemtoDreamCascade::SetCascade(AliESDEvent *evt, AliMCEvent *mcEvent,
+                                      AliESDcascade *casc) {
   Reset();
   fIsReset = false;
   this->fIsSet = true;
@@ -196,11 +197,11 @@ void AliFemtoDreamCascade::SetCascade(AliESDEvent *evt, AliESDcascade *casc) {
   int idxBachFromCascade = casc->GetBindex();
 
   AliESDtrack *esdCascadePos = evt->GetTrack(idxPosFromV0Dghter);
-  fPosDaug->SetTrack(esdCascadePos,nullptr,-1,false);
+  fPosDaug->SetTrack(esdCascadePos,mcEvent,-1,false);
   AliESDtrack *esdCascadeNeg = evt->GetTrack(idxNegFromV0Dghter);
-  fNegDaug->SetTrack(esdCascadeNeg,nullptr,-1,false);
+  fNegDaug->SetTrack(esdCascadeNeg,mcEvent,-1,false);
   AliESDtrack *esdCascadeBach = evt->GetTrack(idxBachFromCascade);
-  fBach->SetTrack(esdCascadeBach,nullptr,-1,false);
+  fBach->SetTrack(esdCascadeBach,mcEvent,-1,false);
   // Identification of the V0 within the esdCascade (via both daughter track indices)
   AliESDv0 * currentV0 = 0x0;
   int idxV0FromCascade = -1;

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCascade.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCascade.h
@@ -24,7 +24,7 @@ class AliFemtoDreamCascade : public AliFemtoDreamBasePart {
   AliFemtoDreamCascade();
   virtual ~AliFemtoDreamCascade();
   void SetCascade(AliAODEvent *evt, AliAODcascade *casc);
-  void SetCascade(AliESDEvent *evt, AliESDcascade *casc);
+  void SetCascade(AliESDEvent *evt, AliMCEvent *mcEvent, AliESDcascade *casc);
   TString ClassName() {
     return "Cascade";
   }

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCascadeHist.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCascadeHist.cxx
@@ -107,14 +107,12 @@ AliFemtoDreamCascadeHist::AliFemtoDreamCascadeHist(float mass,
 
   fInvMassPt = new TH2F("InvMassXi", "InvMassXi", 13, -0.2, 6.3, 500,
                         mass * 0.9, mass * 1.3);
-  fInvMassPt->Sumw2();
   fInvMassPt->GetXaxis()->SetTitle("P_{T}");
   fInvMassPt->GetYaxis()->SetTitle("Inv Mass");
   fHistList->Add(fInvMassPt);
 
   fInvMassPtv0 = new TH2F("InvMassv0Pt", "InvMassv0Pt", 13, -0.2, 6.3, 400, 0.9,
                           1.2);
-  fInvMassPtv0->Sumw2();
   fInvMassPtv0->GetXaxis()->SetTitle("P_{T}");
   fInvMassPtv0->GetYaxis()->SetTitle("Inv Mass");
   fHistList->Add(fInvMassPtv0);
@@ -129,18 +127,15 @@ AliFemtoDreamCascadeHist::AliFemtoDreamCascadeHist(float mass,
     TString InvMassXiName = Form("InvariantMassXi_%s", sName[i].Data());
     fInvMass[i] = new TH1F(InvMassXiName.Data(), InvMassXiName.Data(), 500,
                            mass * 0.9, mass * 1.3);
-    fInvMass[i]->Sumw2();
     fCascadeQA[i]->Add(fInvMass[i]);
 
     TString InvMassv0Name = Form("InvariantMassv0_%s", sName[i].Data());
     fInvMassv0[i] = new TH1F(InvMassv0Name.Data(), InvMassv0Name.Data(), 500,
                              1.116 * 0.9, 1.116 * 1.3);
-    fInvMassv0[i]->Sumw2();
     fCascadeQA[i]->Add(fInvMassv0[i]);
 
     TString XiPtName = Form("XiPt_%s", sName[i].Data());
     fXiPt[i] = new TH1F(XiPtName.Data(), XiPtName.Data(), 13, -0.2, 6.3);
-    fXiPt[i]->Sumw2();
     fCascadeQA[i]->Add(fXiPt[i]);
 
     TString P_Y_XiName = Form("Xi_P_Y_%s", sName[i].Data());
@@ -148,7 +143,6 @@ AliFemtoDreamCascadeHist::AliFemtoDreamCascadeHist(float mass,
                           0., 5.);
     fP_Y_Xi[i]->GetXaxis()->SetName("Rapidity Y");
     fP_Y_Xi[i]->GetYaxis()->SetName("P");
-    fP_Y_Xi[i]->Sumw2();
     fCascadeQA[i]->Add(fP_Y_Xi[i]);
 
     TString P_Y_OmegaName = Form("Omega_P_Y_%s", sName[i].Data());
@@ -156,81 +150,67 @@ AliFemtoDreamCascadeHist::AliFemtoDreamCascadeHist(float mass,
                              -3., 3., 50, 0., 5.);
     fP_Y_Omega[i]->GetXaxis()->SetName("Rapidity Y");
     fP_Y_Omega[i]->GetYaxis()->SetName("P");
-    fP_Y_Omega[i]->Sumw2();
     fCascadeQA[i]->Add(fP_Y_Omega[i]);
 
     TString DCAXiName = Form("DCAXi_%s", sName[i].Data());  //ANDERUNG
     fDCAXi[i] = new TH1F(DCAXiName.Data(), DCAXiName.Data(), 50, 0, 10);
-    fDCAXi[i]->Sumw2();
     fCascadeQA[i]->Add(fDCAXi[i]);
 
     TString DCAXiDaugName = Form("DCAXiDaug_%s", sName[i].Data());
     fDCAXiDaug[i] = new TH1F(DCAXiDaugName.Data(), DCAXiDaugName.Data(), 50, 0,
                              10);
-    fDCAXiDaug[i]->Sumw2();
     fCascadeQA[i]->Add(fDCAXiDaug[i]);
 
     TString MinDistVtxBachName = Form("MinDistVtxBach_%s", sName[i].Data());
     fMinDistVtxBach[i] = new TH1F(MinDistVtxBachName.Data(),
                                   MinDistVtxBachName.Data(), 50, 0, 10);
-    fMinDistVtxBach[i]->Sumw2();
     fCascadeQA[i]->Add(fMinDistVtxBach[i]);
 
     TString CPAXiName = Form("CPAXi_%s", sName[i].Data());
     fCPAXi[i] = new TH1F(CPAXiName.Data(), CPAXiName.Data(), 100, 0.97, 1);
-    fCPAXi[i]->Sumw2();
     fCascadeQA[i]->Add(fCPAXi[i]);
 
     TString DecayLengthName = Form("DecayLength_%s", sName[i].Data());
     fDecayLength[i] = new TH1F(DecayLengthName.Data(), DecayLengthName.Data(),
                                200, 0, 50);
-    fDecayLength[i]->Sumw2();
     fCascadeQA[i]->Add(fDecayLength[i]);
 
     TString v0DecayLengthName = Form("v0DecayLength_%s", sName[i].Data());
     fv0DecayLength[i] = new TH1F(v0DecayLengthName.Data(),
                                  v0DecayLengthName.Data(), 400, 0, 100);
-    fv0DecayLength[i]->Sumw2();
     fCascadeQA[i]->Add(fv0DecayLength[i]);
 
     TString TransRadiusXiName = Form("TransRadiusXi_%s", sName[i].Data());
     fTransRadiusXi[i] = new TH1F(TransRadiusXiName.Data(),
                                  TransRadiusXiName.Data(), 200, 0, 200);
-    fTransRadiusXi[i]->Sumw2();
     fCascadeQA[i]->Add(fTransRadiusXi[i]);
 
     TString v0MaxDCADaugName = Form("v0MaxDCADaug_%s", sName[i].Data());
     fv0MaxDCADaug[i] = new TH1F(v0MaxDCADaugName.Data(),
                                 v0MaxDCADaugName.Data(), 50, 0, 10);
-    fv0MaxDCADaug[i]->Sumw2();
     fCascadeQA[i]->Add(fv0MaxDCADaug[i]);
 
     TString CPAv0Name = Form("CPAv0_%s", sName[i].Data());
     fCPAv0[i] = new TH1F(CPAv0Name.Data(), CPAv0Name.Data(), 100, 0.97, 1);
-    fCPAv0[i]->Sumw2();
     fCascadeQA[i]->Add(fCPAv0[i]);
 
     TString CPAv0XiName = Form("CPAv0Xi_%s", sName[i].Data());
     fCPAv0Xi[i] = new TH1F(CPAv0XiName.Data(), CPAv0XiName.Data(), 100, 0.97,
                            1);
-    fCPAv0Xi[i]->Sumw2();
     fCascadeQA[i]->Add(fCPAv0Xi[i]);
 
     TString v0PtName = Form("v0Pt_%s", sName[i].Data());
     fv0Pt[i] = new TH1F(v0PtName.Data(), v0PtName.Data(), 100, 0, 10);
-    fv0Pt[i]->Sumw2();
     fCascadeQA[i]->Add(fv0Pt[i]);
 
     TString TransRadiusv0Name = Form("TransRadiusv0_%s", sName[i].Data());
     fTransRadiusv0[i] = new TH1F(TransRadiusv0Name.Data(),
                                  TransRadiusv0Name.Data(), 200, 0, 200);
-    fTransRadiusv0[i]->Sumw2();
     fCascadeQA[i]->Add(fTransRadiusv0[i]);
 
     TString MinDistVtxv0Name = Form("MinDistVtxv0_%s", sName[i].Data());
     fMinDistVtxv0[i] = new TH1F(MinDistVtxv0Name.Data(),
                                 MinDistVtxv0Name.Data(), 50, 0, 10);
-    fMinDistVtxv0[i]->Sumw2();
     fCascadeQA[i]->Add(fMinDistVtxv0[i]);
 
     TString MinDistVtxv0DaugPosName = Form("MinDistVtxv0DaugPos_%s",
@@ -238,7 +218,6 @@ AliFemtoDreamCascadeHist::AliFemtoDreamCascadeHist(float mass,
     fMinDistVtxv0DaugPos[i] = new TH1F(MinDistVtxv0DaugPosName.Data(),
                                        MinDistVtxv0DaugPosName.Data(), 50, 0,
                                        10);
-    fMinDistVtxv0DaugPos[i]->Sumw2();
     fCascadeQA[i]->Add(fMinDistVtxv0DaugPos[i]);
 
     TString MinDistVtxv0DaugNameNeg = Form("MinDistVtxv0DaugNeg_%s",
@@ -246,13 +225,11 @@ AliFemtoDreamCascadeHist::AliFemtoDreamCascadeHist(float mass,
     fMinDistVtxv0DaugNeg[i] = new TH1F(MinDistVtxv0DaugNameNeg.Data(),
                                        MinDistVtxv0DaugNameNeg.Data(), 50, 0,
                                        10);
-    fMinDistVtxv0DaugNeg[i]->Sumw2();
     fCascadeQA[i]->Add(fMinDistVtxv0DaugNeg[i]);
 
     TString PodoName = Form("Hodorlanski_%s", sName[i].Data());
     fPodolandski[i] = new TH2F(PodoName.Data(), PodoName.Data(), 50, -1, 1, 50,
                                0, 1);
-    fPodolandski[i]->Sumw2();
     fCascadeQA[i]->Add(fPodolandski[i]);
   }
   if (perRunnumber) {
@@ -304,7 +281,6 @@ AliFemtoDreamCascadeHist::AliFemtoDreamCascadeHist(TString minimalBooking,
 
   fInvMassPt = new TH2F("InvMassXiPt", "InvMassXiPt", 13, -0.2, 6.3, 500,
                         mass * 0.9, mass * 1.3);
-  fInvMassPt->Sumw2();
   fInvMassPt->GetXaxis()->SetTitle("P_{T}");
   fInvMassPt->GetYaxis()->SetTitle("Inv Mass");
   fHistList->Add(fInvMassPt);

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCorrHists.cxx
@@ -440,7 +440,6 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
         fSameEventCommonAncestDist[Counter] = new TH1F(
             SameEventCommonAncestName.Data(), SameEventCommonAncestName.Data(),
             *itNBins, *itKMin, *itKMax);
-        fSameEventCommonAncestDist[Counter]->Sumw2();
         fPairs[Counter]->Add(fSameEventCommonAncestDist[Counter]);
 
         TString SameEventNonCommonAncestName = Form(
@@ -448,7 +447,6 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
         fSameEventNonCommonAncestDist[Counter] = new TH1F(
             SameEventNonCommonAncestName.Data(),
             SameEventNonCommonAncestName.Data(), *itNBins, *itKMin, *itKMax);
-        fSameEventNonCommonAncestDist[Counter]->Sumw2();
         fPairs[Counter]->Add(fSameEventNonCommonAncestDist[Counter]);
       }
 
@@ -461,7 +459,6 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
                                         2 * TMath::Pi());
         fdEtadPhiSE[Counter]->GetXaxis()->SetTitle("#Delta#eta");
         fdEtadPhiSE[Counter]->GetYaxis()->SetTitle("#Delta#phi");
-        fdEtadPhiSE[Counter]->Sumw2();
         fPairs[Counter]->Add(fdEtadPhiSE[Counter]);
 
         TString MixedEventdPhidEtaName = Form(
@@ -472,7 +469,6 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
                                         2 * TMath::Pi());
         fdEtadPhiME[Counter]->GetXaxis()->SetTitle("#Delta#eta");
         fdEtadPhiME[Counter]->GetYaxis()->SetTitle("#Delta#phi");
-        fdEtadPhiME[Counter]->Sumw2();
         fPairs[Counter]->Add(fdEtadPhiME[Counter]);
 
       }
@@ -488,7 +484,6 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
         fPairCounterSE[Counter] = new TH2F(PairCounterSEName.Data(),
                                            PairCounterSEName.Data(), 20, 0, 20,
                                            20, 0, 20);
-        fPairCounterSE[Counter]->Sumw2();
         fPairCounterSE[Counter]->GetXaxis()->SetTitle(
             Form("Particle%d", iPar1));
         fPairCounterSE[Counter]->GetYaxis()->SetTitle(
@@ -500,7 +495,6 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
         fPairCounterME[Counter] = new TH2F(PairCounterMEName.Data(),
                                            PairCounterMEName.Data(), 20, 0, 20,
                                            20, 0, 20);
-        fPairCounterME[Counter]->Sumw2();
         fPairCounterME[Counter]->GetXaxis()->SetTitle(
             Form("Particle%d", iPar1));
         fPairCounterME[Counter]->GetYaxis()->SetTitle(
@@ -515,7 +509,6 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
                                             EffMixingDepthName.Data(),
                                             MixingDepth, -0.5,
                                             MixingDepth - 0.5);
-        fEffMixingDepth[Counter]->Sumw2();
         fEffMixingDepth[Counter]->GetXaxis()->SetTitle("MixingDepth");
         fPairQA[Counter]->Add(fEffMixingDepth[Counter]);
 
@@ -531,7 +524,6 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
           fMomResolution[Counter] = new TH2F(MomResoName.Data(),
                                              MomResoName.Data(), nBims, 0, 1,
                                              nBims, 0, 1);
-          fMomResolution[Counter]->Sumw2();
           fMomResolution[Counter]->GetXaxis()->SetTitle("k_{Generated}");
           fMomResolution[Counter]->GetYaxis()->SetTitle("k_{Reco}");
           fPairQA[Counter]->Add(fMomResolution[Counter]);
@@ -541,7 +533,6 @@ AliFemtoDreamCorrHists::AliFemtoDreamCorrHists(AliFemtoDreamCollConfig *conf,
           fMomResolutionDist[Counter] = new TH2F(MomResoDistName.Data(),
                                                  MomResoDistName.Data(), 500,
                                                  -0.3, 0.3, nBims, 0, 1);
-          fMomResolutionDist[Counter]->Sumw2();
           fMomResolutionDist[Counter]->GetXaxis()->SetTitle(
               "k_{Reco}-k_{Generated}");
           fMomResolutionDist[Counter]->GetYaxis()->SetTitle("k_{Generated}");

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEventHist.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEventHist.cxx
@@ -70,25 +70,21 @@ AliFemtoDreamEventHist::AliFemtoDreamEventHist(bool centVsMultPlot) {
     TString vsV0AName = Form("CentvsV0A");
     fCentVsV0A = new TH2F(vsV0AName.Data(), vsV0AName.Data(), 100, 0.5, 100,
                           300, 0.5, 600.5);
-    fCentVsV0A->Sumw2();
     fEventCutList->Add(fCentVsV0A);
 
     TString vsV0MName = Form("CentvsV0M");
     fCentVsV0M = new TH2F(vsV0MName.Data(), vsV0MName.Data(), 100, 0.5, 100,
                           300, 0.5, 600.5);
-    fCentVsV0M->Sumw2();
     fEventCutList->Add(fCentVsV0M);
 
     TString vsV0CName = Form("CentvsV0C");
     fCentVsV0C = new TH2F(vsV0CName.Data(), vsV0CName.Data(), 100, 0.5, 100,
                           300, 0.5, 600.5);
-    fCentVsV0C->Sumw2();
     fEventCutList->Add(fCentVsV0C);
 
     TString vsV0RefName = Form("CentvsRefMult");
     fCentVsRefMult = new TH2F(vsV0RefName.Data(), vsV0RefName.Data(), 100, 0.5,
                               100, 100, 0.5, 200.5);
-    fCentVsRefMult->Sumw2();
     fEventCutList->Add(fCentVsRefMult);
   } else {
     fCentVsV0A = 0;
@@ -110,63 +106,54 @@ AliFemtoDreamEventHist::AliFemtoDreamEventHist(bool centVsMultPlot) {
     TString nEvtNContName = Form("nContributors_%s", sName[i].Data());
     fEvtNCont[i] = new TH1F(nEvtNContName.Data(), nEvtNContName.Data(), 350.,
                             -0.5, 349.5);
-    fEvtNCont[i]->Sumw2();
     fEvtNCont[i]->GetXaxis()->SetTitle("Number of Contributors");
     fEvtCutQA[i]->Add(fEvtNCont[i]);
 
     TString EvtVtxXName = Form("VtxX_%s", sName[i].Data());
     fEvtVtxX[i] = new TH1F(EvtVtxXName.Data(), EvtVtxXName.Data(), 50, -2.5,
                            2.5);
-    fEvtVtxX[i]->Sumw2();
     fEvtVtxX[i]->GetXaxis()->SetTitle("DCA_{x}");
     fEvtCutQA[i]->Add(fEvtVtxX[i]);
 
     TString EvtVtxYName = Form("VtxY_%s", sName[i].Data());
     fEvtVtxY[i] = new TH1F(EvtVtxYName.Data(), EvtVtxYName.Data(), 50, -2.5,
                            2.5);
-    fEvtVtxY[i]->Sumw2();
     fEvtVtxY[i]->GetXaxis()->SetTitle("DCA_{y}");
     fEvtCutQA[i]->Add(fEvtVtxY[i]);
 
     TString EvtVtxZName = Form("VtxZ_%s", sName[i].Data());
     fEvtVtxZ[i] = new TH1F(EvtVtxZName.Data(), EvtVtxZName.Data(), 300, -15.,
                            15.);
-    fEvtVtxZ[i]->Sumw2();
     fEvtVtxZ[i]->GetXaxis()->SetTitle("DCA_{z}");
     fEvtCutQA[i]->Add(fEvtVtxZ[i]);
 
     TString MultNameSPD = Form("MultiplicitySPD_%s", sName[i].Data());
     fMultDistSPD[i] = new TH1F(MultNameSPD.Data(), MultNameSPD.Data(), 600, 0.,
                                600.);
-    fMultDistSPD[i]->Sumw2();
     fMultDistSPD[i]->GetXaxis()->SetTitle("Multiplicity (SPD)");
     fEvtCutQA[i]->Add(fMultDistSPD[i]);
 
     TString MultNameV0A = Form("MultiplicityV0A_%s", sName[i].Data());
     fMultDistV0A[i] = new TH1F(MultNameV0A.Data(), MultNameV0A.Data(), 600, 0.,
                                600.);
-    fMultDistV0A[i]->Sumw2();
     fMultDistV0A[i]->GetXaxis()->SetTitle("Multiplicity (V0A)");
     fEvtCutQA[i]->Add(fMultDistV0A[i]);
 
     TString MultNameV0C = Form("MultiplicityV0C_%s", sName[i].Data());
     fMultDistV0C[i] = new TH1F(MultNameV0C.Data(), MultNameV0C.Data(), 600, 0.,
                                600.);
-    fMultDistV0C[i]->Sumw2();
     fMultDistV0C[i]->GetXaxis()->SetTitle("Multiplicity (V0C)");
     fEvtCutQA[i]->Add(fMultDistV0C[i]);
 
     TString MultNameRefMult08 = Form("MultiplicityRef08_%s", sName[i].Data());
     fMultDistRef08[i] = new TH1F(MultNameRefMult08.Data(),
                                  MultNameRefMult08.Data(), 600, 0., 600.);
-    fMultDistRef08[i]->Sumw2();
     fMultDistRef08[i]->GetXaxis()->SetTitle("Multiplicity (RefMult08)");
     fEvtCutQA[i]->Add(fMultDistRef08[i]);
 
     TString SPDtrklClsName = Form("SPDTrackletsVsCluster_%s", sName[i].Data());
     fSPDTrklCls[i] = new TH2F(SPDtrklClsName.Data(), SPDtrklClsName.Data(), 250,
                               0, 250, 1000, 0, 1000);
-    fSPDTrklCls[i]->Sumw2();
     fSPDTrklCls[i]->GetXaxis()->SetTitle("SPD Tracklets");
     fSPDTrklCls[i]->GetYaxis()->SetTitle("SPD Cluster");
     fEvtCutQA[i]->Add(fSPDTrklCls[i]);
@@ -175,7 +162,6 @@ AliFemtoDreamEventHist::AliFemtoDreamEventHist(bool centVsMultPlot) {
     fSPDTrackZVtx[i] = new TH2F(SPDvsTrkZVtxName.Data(),
                                 SPDvsTrkZVtxName.Data(), 300, -15, 15, 300, -15,
                                 15);
-    fSPDTrackZVtx[i]->Sumw2();
     fSPDTrackZVtx[i]->GetXaxis()->SetTitle("zVtx Position SPD");
     fSPDTrackZVtx[i]->GetYaxis()->SetTitle("zVtx Position Tracks");
     fEvtCutQA[i]->Add(fSPDTrackZVtx[i]);
@@ -184,19 +170,16 @@ AliFemtoDreamEventHist::AliFemtoDreamEventHist(bool centVsMultPlot) {
                                        sName[i].Data());
     fSPDTrkZVtxDispl[i] = new TH1F(SPDTrkZVtxDisplName.Data(),
                                    SPDTrkZVtxDisplName.Data(), 300, 0, 1.5);
-    fSPDTrkZVtxDispl[i]->Sumw2();
     fSPDTrkZVtxDispl[i]->GetXaxis()->SetTitle("zVtx Position |SPD - Tracks|");
     fEvtCutQA[i]->Add(fSPDTrkZVtxDispl[i]);
 
     TString BFieldName = Form("MagneticFieldkGauss_%s",sName[i].Data());
     fBField[i] = new TH1F(BFieldName.Data(),BFieldName.Data(),20,-10,10);
-    fBField[i]->Sumw2();
     fEvtCutQA[i]->Add(fBField[i]);
 
     TString EvtSpherName = Form("Sphericity_%s", sName[i].Data());
     fEvtSpher[i] = new TH1F(EvtSpherName.Data(), EvtSpherName.Data(), 50, 0.,
                            1.);
-    fEvtSpher[i]->Sumw2();
     fEvtSpher[i]->GetXaxis()->SetTitle("Sphericity S_{T}");
     fEvtCutQA[i]->Add(fEvtSpher[i]);
 

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPairCleanerHists.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPairCleanerHists.cxx
@@ -50,7 +50,6 @@ AliFemtoDreamPairCleanerHists::AliFemtoDreamPairCleanerHists(
     //introduced.
     fPairInvMass[i] = new TH1F(histName.Data(), histName.Data(), 1500, 2.25,
                                3.2);
-    fPairInvMass[i]->Sumw2();
     fOutput->Add(fPairInvMass[i]);
 
     histName += "Tuple";

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrack.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrack.cxx
@@ -122,9 +122,9 @@ void AliFemtoDreamTrack::SetTrack(AliESDtrack *track, AliMCEvent *mcEvent,
     this->SetEvtNumber(fESDTrack->GetESDEvent()->GetRunNumber());
     if (this->fIsSet) {
       this->SetESDPIDInformation();
-//      if (fIsMC) {
-//        this->SetMCInformation(mcEvent);
-//      }
+      if (fIsMC) {
+        this->SetMCInformation(mcEvent);
+      }
     }
     if (TPCOnlyTrack && fESDTPCOnlyTrack) {
       delete fESDTPCOnlyTrack;

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackCuts.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackCuts.cxx
@@ -17,6 +17,7 @@ AliFemtoDreamTrackCuts::AliFemtoDreamTrackCuts()
       fMinimalBooking(false),
       fMCData(false),
       fDCAPlots(false),
+      fDoMultBinning(false),
       fCombSigma(false),
       fContribSplitting(false),
       fFillQALater(false),
@@ -66,6 +67,7 @@ AliFemtoDreamTrackCuts::AliFemtoDreamTrackCuts(
       fMinimalBooking(cuts.fMinimalBooking),
       fMCData(cuts.fMCData),
       fDCAPlots(cuts.fDCAPlots),
+      fDoMultBinning(cuts.fDoMultBinning),
       fCombSigma(cuts.fCombSigma),
       fContribSplitting(cuts.fContribSplitting),
       fFillQALater(cuts.fFillQALater),
@@ -118,6 +120,7 @@ AliFemtoDreamTrackCuts &AliFemtoDreamTrackCuts::operator =(
   this->fMinimalBooking = cuts.fMinimalBooking;
   this->fMCData = cuts.fMCData;
   this->fDCAPlots = cuts.fDCAPlots;
+  this->fDoMultBinning = cuts.fDoMultBinning;
   this->fCombSigma = cuts.fCombSigma;
   this->fContribSplitting = cuts.fContribSplitting;
   this->fFillQALater = cuts.fFillQALater;
@@ -508,7 +511,7 @@ void AliFemtoDreamTrackCuts::Init(TString name) {
   if (!fMinimalBooking) {
     fHists = new AliFemtoDreamTrackHist(fDCAPlots, fCombSigma);
     if (fMCData) {
-      fMCHists = new AliFemtoDreamTrackMCHist(fContribSplitting, fDCAPlots);
+      fMCHists = new AliFemtoDreamTrackMCHist(fContribSplitting, fDCAPlots, fDoMultBinning);
     }
     BookTrackCuts();
   } else {

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackCuts.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackCuts.h
@@ -49,6 +49,9 @@ class AliFemtoDreamTrackCuts {
     fDCAPlots = plot;
   }
   ;
+  void SetOriginMultiplicityHists(bool plot) {
+    fDoMultBinning = plot;
+  }
   void SetPlotCombSigma(bool plot) {
     fCombSigma = plot;
   }
@@ -232,6 +235,7 @@ class AliFemtoDreamTrackCuts {
   bool fMinimalBooking;               //
   bool fMCData;                       //
   bool fDCAPlots;                     //
+  bool fDoMultBinning;                //
   bool fCombSigma;                    //
   bool fContribSplitting;             //
   bool fFillQALater;                  //
@@ -272,7 +276,7 @@ class AliFemtoDreamTrackCuts {
   float fNSigValue;                  // defaults to 3
   float fPIDPTPCThreshold;           // defaults to 0
   bool fRejectPions;  // Supress Pions at low pT with the TOF, if information is available
-ClassDef(AliFemtoDreamTrackCuts,3)
+ClassDef(AliFemtoDreamTrackCuts,4)
   ;
 };
 

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackHist.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackHist.cxx
@@ -120,40 +120,34 @@ AliFemtoDreamTrackHist::AliFemtoDreamTrackHist(bool DCADist, bool CombSig)
 
     TString ptName = Form("pTDist_%s", sName[i].Data());
     fpTDist[i] = new TH1F(ptName.Data(), ptName.Data(), ptBins, ptmin, ptmax);
-    fpTDist[i]->Sumw2();
     fpTDist[i]->GetXaxis()->SetTitle("p_{T}");
     fTrackCutQA[i]->Add(fpTDist[i]);
 
     TString pTPCName = Form("pTPCDist_%s", sName[i].Data());
     fpTPCDist[i] = new TH1F(pTPCName.Data(), pTPCName.Data(), ptBins, ptmin,
                             ptmax);
-    fpTPCDist[i]->Sumw2();
     fpTPCDist[i]->GetXaxis()->SetTitle("p_{TPC}");
     fTrackCutQA[i]->Add(fpTPCDist[i]);
 
     TString etaName = Form("EtaDist_%s", sName[i].Data());
     fetaDist[i] = new TH1F(etaName.Data(), etaName.Data(), 200, -10., 10.);
-    fetaDist[i]->Sumw2();
     fetaDist[i]->GetXaxis()->SetTitle("#eta");
     fTrackCutQA[i]->Add(fetaDist[i]);
 
     TString phiName = Form("phiDist_%s", sName[i].Data());
     fphiDist[i] = new TH1F(phiName.Data(), phiName.Data(), 200, 0.,
                            2 * TMath::Pi());
-    fphiDist[i]->Sumw2();
     fphiDist[i]->GetXaxis()->SetTitle("#phi");
     fTrackCutQA[i]->Add(fphiDist[i]);
 
     TString TPCName = Form("TPCCls_%s", sName[i].Data());
     fTPCCls[i] = new TH1F(TPCName.Data(), TPCName.Data(), 100, 0, 200.);
-    fTPCCls[i]->Sumw2();
     fTPCCls[i]->GetXaxis()->SetTitle("# cls TPC");
     fTrackCutQA[i]->Add(fTPCCls[i]);
 
     TString DCAXYName = Form("DCAXY_%s", sName[i].Data());
     fDCAxy[i] = new TH2F(DCAXYName.Data(), DCAXYName.Data(), ptBins, ptmin,
                          ptmax, 2.5 * twoDBins, -5., 5.);
-    fDCAxy[i]->Sumw2();
     fDCAxy[i]->GetXaxis()->SetTitle("p_{T}");
     fDCAxy[i]->GetYaxis()->SetTitle("DCA_{xy}");
 
@@ -162,7 +156,6 @@ AliFemtoDreamTrackHist::AliFemtoDreamTrackHist(bool DCADist, bool CombSig)
     TString DCAZName = Form("DCAZ_%s", sName[i].Data());
     fDCAz[i] = new TH2F(DCAZName.Data(), DCAZName.Data(), ptBins, ptmin, ptmax,
                         2.5 * twoDBins, -5., 5.);
-    fDCAz[i]->Sumw2();
     fDCAz[i]->GetXaxis()->SetTitle("p_{T}");
     fDCAz[i]->GetYaxis()->SetTitle("DCA_{z}");
     fTrackCutQA[i]->Add(fDCAz[i]);
@@ -170,27 +163,23 @@ AliFemtoDreamTrackHist::AliFemtoDreamTrackHist(bool DCADist, bool CombSig)
     TString TPCCRName = Form("CrossedRows_%s", sName[i].Data());
     fTPCCrossedRows[i] = new TH1F(TPCCRName.Data(), TPCCRName.Data(), 100, 0,
                                   200.);
-    fTPCCrossedRows[i]->Sumw2();
     fTPCCrossedRows[i]->GetXaxis()->SetTitle("# of crossed Rows");
     fTrackCutQA[i]->Add(fTPCCrossedRows[i]);
 
     TString TPCratioName = Form("TPCRatio_%s", sName[i].Data());
     fTPCRatio[i] = new TH1F(TPCratioName.Data(), TPCratioName.Data(), 100, 0.,
                             2.);
-    fTPCRatio[i]->Sumw2();
     fTPCRatio[i]->GetXaxis()->SetTitle("Ratio");
     fTrackCutQA[i]->Add(fTPCRatio[i]);
 
     TString TPCClsSName = Form("TPCClsS_%s", sName[i].Data());
     fTPCClsS[i] = new TH1F(TPCClsSName.Data(), TPCClsSName.Data(), 200, 0, 200);
-    fTPCClsS[i]->Sumw2();
     fTPCClsS[i]->GetXaxis()->SetTitle("TPC Cls S");
     fTrackCutQA[i]->Add(fTPCClsS[i]);
 
     TString ChiSquareName = Form("TrackChi2_%s", sName[i].Data());
     fTrackChi2[i] = new TH2F(ChiSquareName.Data(), ChiSquareName.Data(), ptBins,
                              ptmin, ptmax, 100, 0, 20);
-    fTrackChi2[i]->Sumw2();
     fTrackChi2[i]->GetXaxis()->SetTitle("#it{p}_T");
     fTrackChi2[i]->GetYaxis()->SetTitle("#chi^{2}/NDF");
     fTrackCutQA[i]->Add(fTrackChi2[i]);
@@ -198,7 +187,6 @@ AliFemtoDreamTrackHist::AliFemtoDreamTrackHist(bool DCADist, bool CombSig)
     TString ShrdClsITSName = Form("SharedClsITS_%s", sName[i].Data());
     fShrdClsITS[i] = new TH2F(ShrdClsITSName.Data(), ShrdClsITSName.Data(), 6,
                               1, 7, 2, 0, 2);
-    fShrdClsITS[i]->Sumw2();
     fShrdClsITS[i]->GetXaxis()->SetTitle("ITS Layer");
     fShrdClsITS[i]->GetYaxis()->SetBinLabel(1, "Has shared Cls");
     fShrdClsITS[i]->GetYaxis()->SetBinLabel(2, "Has no Shard Cls");
@@ -207,7 +195,6 @@ AliFemtoDreamTrackHist::AliFemtoDreamTrackHist(bool DCADist, bool CombSig)
     TString TPCdedxName = Form("TPCdedx_%s", sName[i].Data());
     fTPCdedx[i] = new TH2F(TPCdedxName.Data(), TPCdedxName.Data(), ptBins,
                            ptmin, ptmax, 2 * twoDBins, 0., 400);
-    fTPCdedx[i]->Sumw2();
     fTPCdedx[i]->GetXaxis()->SetTitle("p_{TPC}");
     fTPCdedx[i]->GetYaxis()->SetTitle("dEdx (arb. Units)");
 
@@ -216,7 +203,6 @@ AliFemtoDreamTrackHist::AliFemtoDreamTrackHist(bool DCADist, bool CombSig)
     TString TOFbetaName = Form("TOFbeta_%s", sName[i].Data());
     fTOFbeta[i] = new TH2F(TOFbetaName.Data(), TOFbetaName.Data(), ptBins,
                            ptmin, ptmax, 3.5 * twoDBins, 0.4, 1.1);
-    fTOFbeta[i]->Sumw2();
     fTOFbeta[i]->GetXaxis()->SetTitle("p_{TPC}");
     fTOFbeta[i]->GetYaxis()->SetTitle("#beta_{TOF}");
 
@@ -225,7 +211,6 @@ AliFemtoDreamTrackHist::AliFemtoDreamTrackHist(bool DCADist, bool CombSig)
     TString NSigTPCName = Form("NSigTPC_%s", sName[i].Data());
     fNSigTPC[i] = new TH2F(NSigTPCName.Data(), NSigTPCName.Data(), ptBins,
                            ptmin, ptmax, 3. * twoDBins, -60., 60.);
-    fNSigTPC[i]->Sumw2();
     fNSigTPC[i]->GetXaxis()->SetTitle("p_{TPC}");
     fNSigTPC[i]->GetYaxis()->SetTitle("n#sigma_{TPC}");
 
@@ -234,7 +219,6 @@ AliFemtoDreamTrackHist::AliFemtoDreamTrackHist(bool DCADist, bool CombSig)
     TString NSigTOFName = Form("NSigTOF_%s", sName[i].Data());
     fNSigTOF[i] = new TH2F(NSigTOFName.Data(), NSigTOFName.Data(), ptBins,
                            ptmin, ptmax, 3. * twoDBins, -60., 60.);
-    fNSigTOF[i]->Sumw2();
     fNSigTOF[i]->GetXaxis()->SetTitle("p_{TPC}");
     fNSigTOF[i]->GetYaxis()->SetTitle("n#sigma_{TOF}");
 
@@ -264,7 +248,6 @@ AliFemtoDreamTrackHist::AliFemtoDreamTrackHist(bool DCADist, bool CombSig)
     fTPCClsCPiluUp[i] = new TH2F(TPCClsCPileUpName.Data(),
                                  TPCClsCPileUpName.Data(), 15, 0, 15, 200, 0,
                                  200);
-    fTPCClsCPiluUp[i]->Sumw2();
     fTPCClsCPiluUp[i]->GetXaxis()->SetBinLabel(1, "Hit ITS Layer 1");
     fTPCClsCPiluUp[i]->GetXaxis()->SetBinLabel(2, "Hit ITS Layer 2");
     fTPCClsCPiluUp[i]->GetXaxis()->SetBinLabel(3, "Hit ITS Layer 3");
@@ -286,7 +269,6 @@ AliFemtoDreamTrackHist::AliFemtoDreamTrackHist(bool DCADist, bool CombSig)
     fITShrdClsPileUp[i] = new TH2F(ITSShrdClsPileUpName.Data(),
                                    ITSShrdClsPileUpName.Data(), 15, 0, 15, 12,
                                    0, 12);
-    fITShrdClsPileUp[i]->Sumw2();
     fITShrdClsPileUp[i]->GetXaxis()->SetBinLabel(1, "Hit ITS Layer 1");
     fITShrdClsPileUp[i]->GetXaxis()->SetBinLabel(2, "Hit ITS Layer 2");
     fITShrdClsPileUp[i]->GetXaxis()->SetBinLabel(3, "Hit ITS Layer 3");
@@ -322,7 +304,6 @@ AliFemtoDreamTrackHist::AliFemtoDreamTrackHist(bool DCADist, bool CombSig)
     fNSigCom = new TH3F("NSigComb", "NSigComb", 14, 0.5, 4.0, 300, -30, 30, 300,
                         -30, 30);
     fHistList->Add(fNSigCom);
-    fNSigCom->Sumw2();
   } else {
     fNSigCom = 0;
   }
@@ -330,7 +311,6 @@ AliFemtoDreamTrackHist::AliFemtoDreamTrackHist(bool DCADist, bool CombSig)
     TString dcaPtBinName = Form("DCAXYPtBinningTot");
     fDCAXYPtBins = new TH2F(dcaPtBinName.Data(), dcaPtBinName.Data(), 20, 0.5,
                             4.05, 500, -5, 5);
-    fDCAXYPtBins->Sumw2();
     fDCAXYPtBins->GetXaxis()->SetTitle("P#_{T}");
     fDCAXYPtBins->GetYaxis()->SetTitle("dca_{XY}");
     fHistList->Add(fDCAXYPtBins);
@@ -340,20 +320,17 @@ AliFemtoDreamTrackHist::AliFemtoDreamTrackHist(bool DCADist, bool CombSig)
         dcaPtBinName.Data(),
         Form("0 < mult < %i;P#_{T};dca_{XY}", fMultRangeLow), 20, 0.5, 4.05,
         500, -5, 5);
-    fDCAXYPtBinsMult[0]->Sumw2();
 
     dcaPtBinName = Form("DCAXYPtMult_%i_%i", fMultRangeLow, fMultRangeHigh);
     fDCAXYPtBinsMult[1] = new TH2F(
         dcaPtBinName.Data(),
         Form("%i < mult < %i;P#_{T};dca_{XY}", fMultRangeLow, fMultRangeHigh),
         20, 0.5, 4.05, 500, -5, 5);
-    fDCAXYPtBinsMult[1]->Sumw2();
 
     dcaPtBinName = Form("DCAXYPtMult_%i_inf", fMultRangeHigh);
     fDCAXYPtBinsMult[2] = new TH2F(
         dcaPtBinName.Data(), Form("mult > %i;P#_{T};dca_{XY}", fMultRangeHigh),
         20, 0.5, 4.05, 500, -5, 5);
-    fDCAXYPtBinsMult[2]->Sumw2();
 
     fHistList->Add(fDCAXYPtBinsMult[0]);
     fHistList->Add(fDCAXYPtBinsMult[1]);
@@ -399,7 +376,6 @@ AliFemtoDreamTrackHist::AliFemtoDreamTrackHist(TString MinimalBooking)
   fpTDist[0] = 0;
   TString ptName = Form("pTDist_%s", "after");
   fpTDist[1] = new TH1F(ptName.Data(), ptName.Data(), 100, 0, 5);
-  fpTDist[1]->Sumw2();
   fHistList->Add(fpTDist[1]);
 }
 

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackMCHist.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackMCHist.cxx
@@ -88,24 +88,20 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,
 
   fMCCorrPt = new TH1F("CorrParPt", "Correct Particles Pt", ptBins, ptmin,
                        ptmax);
-  fMCCorrPt->Sumw2();
   fMCCorrPt->GetXaxis()->SetTitle("p_{T}");
   fMCList->Add(fMCCorrPt);
 
   fMCIdentPt = new TH1F("IdentPartPt", "Ident Particles Pt", ptBins, ptmin,
                         ptmax);
-  fMCIdentPt->Sumw2();
   fMCIdentPt->GetXaxis()->SetTitle("p_{T}");
   fMCList->Add(fMCIdentPt);
 
   fMCGenPt = new TH1F("GenPartPt", "Gen Particles Pt", ptBins, ptmin, ptmax);
-  fMCGenPt->Sumw2();
   fMCGenPt->GetXaxis()->SetTitle("p_{T}");
   fMCList->Add(fMCGenPt);
 
   fPtResolution = new TH2F("DeltaPtRecoTruevsPtReco", "DeltaPtRecoTruevsPtReco",
                            100, 0, 5, 750, -3, 1);
-  fPtResolution->Sumw2();
   fPtResolution->GetXaxis()->SetTitle("P_{T,True}");
   fPtResolution->GetYaxis()->SetTitle("(P_{T,True}-P_{T,Reco})/P_{T,True}");
   fMCList->Add(fPtResolution);
@@ -113,7 +109,6 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,
   fThetaResolution = new TH2F("DeltaThetaRecoTruevsPtReco",
                               "DeltaThetaRecoTruevsPtReco", 100, 0, 5, 400,
                               -0.25, 0.25);
-  fThetaResolution->Sumw2();
   fThetaResolution->GetXaxis()->SetTitle("P_{T,True}");
   fThetaResolution->GetYaxis()->SetTitle("#Theta_{T,True}-#Theta_{T,Reco}");
   fMCList->Add(fThetaResolution);
@@ -121,7 +116,6 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,
   fPhiResolution = new TH2F("DeltaPhiRecoTruevsPtReco",
                             "DeltaPhiRecoTruevsPtReco", 100, 0, 5, 200, -0.2,
                             0.2);
-  fPhiResolution->Sumw2();
   fPhiResolution->GetXaxis()->SetTitle("P_{T,True}");
   fPhiResolution->GetYaxis()->SetTitle("(#Phi_{T,True}-#Phi_{T,Reco})");
   fMCList->Add(fPhiResolution);
@@ -136,28 +130,23 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,
 
   if (contribSplitting) {
     fMCContPt = new TH1F("ContPt", "ContPt", ptBins, ptmin, ptmax);
-    fMCContPt->Sumw2();
     fMCContPt->GetXaxis()->SetTitle("p_{T}");
     fMCList->Add(fMCContPt);
 
     fMCUnknownPt = new TH1F("UnknPt", "UnknPt", ptBins, ptmin, ptmax);
-    fMCUnknownPt->Sumw2();
     fMCUnknownPt->GetXaxis()->SetTitle("p_{T}");
     fMCList->Add(fMCUnknownPt);
 
     fMCPrimaryPt = new TH1F("PrimaryPt", "PrimaryPt", ptBins, ptmin, ptmax);
-    fMCPrimaryPt->Sumw2();
     fMCPrimaryPt->GetXaxis()->SetTitle("p_{T}");
     fMCList->Add(fMCPrimaryPt);
 
     fMCMaterialPt = new TH1F("MatPt", "MatPT", ptBins, ptmin, ptmax);
-    fMCMaterialPt->Sumw2();
     fMCMaterialPt->GetXaxis()->SetTitle("p_{T}");
     fMCList->Add(fMCMaterialPt);
 
     fMCFeeddownWeakPt = new TH2F("FeeddownPt", "Feeddown Pt", ptBins, ptmin,
                                  ptmax, 213, 3121, 3334);
-    fMCFeeddownWeakPt->Sumw2();
     fMCFeeddownWeakPt->GetXaxis()->SetTitle("p_{T}");
     fMCList->Add(fMCFeeddownWeakPt);
 
@@ -183,58 +172,46 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,
 
       fMCpTPCDist[i] = new TH1F(MCpTPCName.Data(), MCpTPCName.Data(), ptBins,
                                 ptmin, ptmax);
-      fMCpTPCDist[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCpTPCDist[i]);
 
       fMCetaDist[i] = new TH1F(MCetaName.Data(), MCetaName.Data(), 200, -10.,
                                10.);
-      fMCetaDist[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCetaDist[i]);
 
       fMCphiDist[i] = new TH1F(MCphiName.Data(), MCphiName.Data(), 200, 0.,
                                2 * TMath::Pi());
-      fMCphiDist[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCphiDist[i]);
 
       fMCTPCCls[i] = new TH2F(MCTPCName.Data(), MCTPCName.Data(), ptBins, ptmin,
                               ptmax, 100, 0, 200.);
-      fMCTPCCls[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCTPCCls[i]);
 
       fMCDCAxy[i] = new TH2F(MCDCAXYName.Data(), MCDCAXYName.Data(), ptBins,
                              ptmin, ptmax, 2.5 * twoDBins, -5., 5.);
-      fMCDCAxy[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCDCAxy[i]);
 
       fMCDCAz[i] = new TH2F(MCDCAZName.Data(), MCDCAZName.Data(), ptBins, ptmin,
                             ptmax, 2.5 * twoDBins, -5., 5.);
-      fMCDCAz[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCDCAz[i]);
 
       fMCTPCCrossedRows[i] = new TH2F(MCTPCCRName.Data(), MCTPCCRName.Data(),
                                       ptBins, ptmin, ptmax, 100, 0, 200.);
-      fMCTPCCrossedRows[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCTPCCrossedRows[i]);
 
       fMCTPCRatio[i] = new TH2F(MCTPCratioName.Data(), MCTPCratioName.Data(),
                                 ptBins, ptmin, ptmax, 100, 0., 2.);
-      fMCTPCRatio[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCTPCRatio[i]);
       fMCTPCdedx[i] = new TH2F(MCTPCdedxName.Data(), MCTPCdedxName.Data(),
                                ptBins, ptmin, ptmax, 2 * twoDBins, 0., 400);
-      fMCTPCdedx[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCTPCdedx[i]);
       fMCTOFbeta[i] = new TH2F(MCTOFbetaName.Data(), MCTOFbetaName.Data(),
                                ptBins, ptmin, ptmax, 3.5 * twoDBins, 0.4, 1.1);
-      fMCTOFbeta[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCTOFbeta[i]);
       fMCNSigTPC[i] = new TH2F(MCNSigTPCName.Data(), MCNSigTPCName.Data(),
                                ptBins, ptmin, ptmax, twoDBins, -20., 20.);
-      fMCNSigTPC[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCNSigTPC[i]);
       fMCNSigTOF[i] = new TH2F(MCNSigTOFName.Data(), MCNSigTOFName.Data(),
                                ptBins, ptmin, ptmax, twoDBins, -20., 20.);
-      fMCNSigTOF[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCNSigTOF[i]);
     }
   } else {
@@ -274,7 +251,6 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,
     fMCPrimDCAXYPtBins = new TH2F(MCPridcaPtBinName.Data(),
                                   MCPridcaPtBinName.Data(), fpTbins, fpTmin,
                                   fpTmax, 500, -5, 5);
-    fMCPrimDCAXYPtBins->Sumw2();
     fMCPrimDCAXYPtBins->GetXaxis()->SetTitle("dca_{XY}");
     fMCPrimDCAXYPtBins->GetYaxis()->SetTitle("dca_{Z}");
     fDCAPlots->Add(fMCPrimDCAXYPtBins);
@@ -282,7 +258,6 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,
     fMCMaterialDCAXYPtBins = new TH2F(MCMatdcaPtBinName.Data(),
                                       MCMatdcaPtBinName.Data(), fpTbins, fpTmin,
                                       fpTmax, 500, -5, 5);
-    fMCMaterialDCAXYPtBins->Sumw2();
     fMCMaterialDCAXYPtBins->GetXaxis()->SetTitle("dca_{XY}");
     fMCMaterialDCAXYPtBins->GetYaxis()->SetTitle("dca_{Z}");
     fDCAPlots->Add(fMCMaterialDCAXYPtBins);
@@ -290,7 +265,6 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,
     fMCSecondaryDCAXYPtBins = new TH2F(MCSecdcaPtBinName.Data(),
                                        MCSecdcaPtBinName.Data(), fpTbins,
                                        fpTmin, fpTmax, 500, -5, 5);
-    fMCSecondaryDCAXYPtBins->Sumw2();
     fMCSecondaryDCAXYPtBins->GetXaxis()->SetTitle("dca_{XY}");
     fMCSecondaryDCAXYPtBins->GetYaxis()->SetTitle("dca_{Z}");
     fDCAPlots->Add(fMCSecondaryDCAXYPtBins);
@@ -298,7 +272,6 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,
     fMCSecLambdaDCAXYPtBins = new TH2F(MCSecLamdcaPtBinName.Data(),
                                        MCSecLamdcaPtBinName.Data(), fpTbins,
                                        fpTmin, fpTmax, 500, -5, 5);
-    fMCSecLambdaDCAXYPtBins->Sumw2();
     fMCSecLambdaDCAXYPtBins->GetXaxis()->SetTitle("dca_{XY}");
     fMCSecLambdaDCAXYPtBins->GetYaxis()->SetTitle("dca_{Z}");
     fDCAPlots->Add(fMCSecLambdaDCAXYPtBins);
@@ -306,7 +279,6 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,
     fMCSecSigmaDCAXYPtBins = new TH2F(MCSecSigdcaPtBinName.Data(),
                                       MCSecSigdcaPtBinName.Data(), fpTbins,
                                       fpTmin, fpTmax, 500, -5, 5);
-    fMCSecSigmaDCAXYPtBins->Sumw2();
     fMCSecSigmaDCAXYPtBins->GetXaxis()->SetTitle("dca_{XY}");
     fMCSecSigmaDCAXYPtBins->GetYaxis()->SetTitle("dca_{Z}");
     fDCAPlots->Add(fMCSecSigmaDCAXYPtBins);
@@ -384,31 +356,26 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,
         fMCPrimDCAXYPtBinsMult[i] =
             new TH2F(primPtBinName[i].Data(), axisRange[i].Data(), fpTbins,
                      fpTmin, fpTmax, 500, -5, 5);
-        fMCPrimDCAXYPtBinsMult[i]->Sumw2();
         fDCAPlots->Add(fMCPrimDCAXYPtBinsMult[i]);
 
         fMCMaterialDCAXYPtBinsMult[i] =
             new TH2F(matPtBinName[i].Data(), axisRange[i].Data(), fpTbins,
                      fpTmin, fpTmax, 500, -5, 5);
-        fMCMaterialDCAXYPtBinsMult[i]->Sumw2();
         fDCAPlots->Add(fMCMaterialDCAXYPtBinsMult[i]);
 
         fMCSecondaryDCAXYPtBinsMult[i] =
             new TH2F(secPtBinName[i].Data(), axisRange[i].Data(), fpTbins,
                      fpTmin, fpTmax, 500, -5, 5);
-        fMCSecondaryDCAXYPtBinsMult[i]->Sumw2();
         fDCAPlots->Add(fMCSecondaryDCAXYPtBinsMult[i]);
 
         fMCSecLambdaDCAXYPtBinsMult[i] =
             new TH2F(secLambdaPtBinName[i].Data(), axisRange[i].Data(), fpTbins,
                      fpTmin, fpTmax, 500, -5, 5);
-        fMCSecLambdaDCAXYPtBinsMult[i]->Sumw2();
         fDCAPlots->Add(fMCSecLambdaDCAXYPtBinsMult[i]);
 
         fMCSecSigmaDCAXYPtBinsMult[i] =
             new TH2F(secSigmaPtBinName[i].Data(), axisRange[i].Data(), fpTbins,
                      fpTmin, fpTmax, 500, -5, 5);
-        fMCSecSigmaDCAXYPtBinsMult[i]->Sumw2();
         fDCAPlots->Add(fMCSecSigmaDCAXYPtBinsMult[i]);
       }
     }

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackMCHist.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackMCHist.cxx
@@ -15,6 +15,7 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist()
       fMultRangeHigh(55),
       fDoSplitting(false),
       fDoDCAPlots(false),
+      fDoMultiplicityBinning(false),
       fMCList(0),
       fDCAPlots(0),
       fMCCorrPt(0),
@@ -64,7 +65,8 @@ AliFemtoDreamTrackMCHist::~AliFemtoDreamTrackMCHist() {
 }
 
 AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,
-                                                   bool DCADist)
+                                                   bool DCADist,
+                                                   bool DoMultBinning)
     : fpTmin(0.5),
       fpTmax(4.05),
       fpTbins(20),
@@ -72,6 +74,7 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,
       fMultRangeHigh(55),
       fDoSplitting(contribSplitting),
       fDoDCAPlots(DCADist),
+      fDoMultiplicityBinning(DoMultBinning),
       fPtResolution(),
       fThetaResolution(),
       fPhiResolution() {
@@ -308,104 +311,106 @@ AliFemtoDreamTrackMCHist::AliFemtoDreamTrackMCHist(bool contribSplitting,
     fMCSecSigmaDCAXYPtBins->GetYaxis()->SetTitle("dca_{Z}");
     fDCAPlots->Add(fMCSecSigmaDCAXYPtBins);
 
-    TString name1 = "DCAPtBinningPriMult_0_";
-    name1 += fMultRangeLow;
-    TString name2 = "DCAPtBinningPriMult_";
-    name2 += fMultRangeLow;
-    name2 += "_";
-    name2 += fMultRangeHigh;
-    TString name3 = "DCAPtBinningPriMult_";
-    name3 += fMultRangeHigh;
-    name3 += "_inf";
-    TString primPtBinName[3] = { name1, name2, name3 };
+    if (fDoMultiplicityBinning) {
+      TString name1 = "DCAPtBinningPriMult_0_";
+      name1 += fMultRangeLow;
+      TString name2 = "DCAPtBinningPriMult_";
+      name2 += fMultRangeLow;
+      name2 += "_";
+      name2 += fMultRangeHigh;
+      TString name3 = "DCAPtBinningPriMult_";
+      name3 += fMultRangeHigh;
+      name3 += "_inf";
+      TString primPtBinName[3] = {name1, name2, name3};
 
-    name1 = "DCAPtBinningMatMult_0_";
-    name1 += fMultRangeLow;
-    name2 = "DCAPtBinningMatMult_";
-    name2 += fMultRangeLow;
-    name2 += "_";
-    name2 += fMultRangeHigh;
-    name3 = "DCAPtBinningMatMult_";
-    name3 += fMultRangeHigh;
-    name3 += "_inf";
-    TString matPtBinName[3] = { name1, name2, name3 };
+      name1 = "DCAPtBinningMatMult_0_";
+      name1 += fMultRangeLow;
+      name2 = "DCAPtBinningMatMult_";
+      name2 += fMultRangeLow;
+      name2 += "_";
+      name2 += fMultRangeHigh;
+      name3 = "DCAPtBinningMatMult_";
+      name3 += fMultRangeHigh;
+      name3 += "_inf";
+      TString matPtBinName[3] = {name1, name2, name3};
 
-    name1 = "DCAPtBinningSecMult_0_";
-    name1 += fMultRangeLow;
-    name2 = "DCAPtBinningSecMult_";
-    name2 += fMultRangeLow;
-    name2 += "_";
-    name2 += fMultRangeHigh;
-    name3 = "DCAPtBinningSecMult_";
-    name3 += fMultRangeHigh;
-    name3 += "_inf";
-    TString secPtBinName[3] = { name1, name2, name3 };
+      name1 = "DCAPtBinningSecMult_0_";
+      name1 += fMultRangeLow;
+      name2 = "DCAPtBinningSecMult_";
+      name2 += fMultRangeLow;
+      name2 += "_";
+      name2 += fMultRangeHigh;
+      name3 = "DCAPtBinningSecMult_";
+      name3 += fMultRangeHigh;
+      name3 += "_inf";
+      TString secPtBinName[3] = {name1, name2, name3};
 
-    name1 = "DCAPtBinningSecLambdaMult_0_";
-    name1 += fMultRangeLow;
-    name2 = "DCAPtBinningSecLambdaMult_";
-    name2 += fMultRangeLow;
-    name2 += "_";
-    name2 += fMultRangeHigh;
-    name3 = "DCAPtBinningSecLambdaMult_";
-    name3 += fMultRangeHigh;
-    name3 += "_inf";
-    TString secLambdaPtBinName[3] = { name1, name2, name3 };
+      name1 = "DCAPtBinningSecLambdaMult_0_";
+      name1 += fMultRangeLow;
+      name2 = "DCAPtBinningSecLambdaMult_";
+      name2 += fMultRangeLow;
+      name2 += "_";
+      name2 += fMultRangeHigh;
+      name3 = "DCAPtBinningSecLambdaMult_";
+      name3 += fMultRangeHigh;
+      name3 += "_inf";
+      TString secLambdaPtBinName[3] = {name1, name2, name3};
 
-    name1 = "DCAPtBinningSecSigmaMult_0_";
-    name1 += fMultRangeLow;
-    name2 = "DCAPtBinningSecSigmaMult_";
-    name2 += fMultRangeLow;
-    name2 += "_";
-    name2 += fMultRangeHigh;
-    name3 = "DCAPtBinningSecSigmaMult_";
-    name3 += fMultRangeHigh;
-    name3 += "_inf";
-    TString secSigmaPtBinName[3] = { name1, name2, name3 };
+      name1 = "DCAPtBinningSecSigmaMult_0_";
+      name1 += fMultRangeLow;
+      name2 = "DCAPtBinningSecSigmaMult_";
+      name2 += fMultRangeLow;
+      name2 += "_";
+      name2 += fMultRangeHigh;
+      name3 = "DCAPtBinningSecSigmaMult_";
+      name3 += fMultRangeHigh;
+      name3 += "_inf";
+      TString secSigmaPtBinName[3] = {name1, name2, name3};
 
-    name1 = "0 < mult < ";
-    name1 += fMultRangeLow;
-    name1 += ";P#_{T};dca_{XY}";
-    name2 = "";
-    name2 += fMultRangeLow;
-    name2 += " < mult < ";
-    name2 += fMultRangeHigh;
-    name2 += ";P#_{T};dca_{XY}";
-    name3 = "mult > ";
-    name3 += fMultRangeHigh;
-    name3 += ";P#_{T};dca_{XY}";
-    TString axisRange[3] = { name1, name2, name3 };
+      name1 = "0 < mult < ";
+      name1 += fMultRangeLow;
+      name1 += ";P#_{T};dca_{XY}";
+      name2 = "";
+      name2 += fMultRangeLow;
+      name2 += " < mult < ";
+      name2 += fMultRangeHigh;
+      name2 += ";P#_{T};dca_{XY}";
+      name3 = "mult > ";
+      name3 += fMultRangeHigh;
+      name3 += ";P#_{T};dca_{XY}";
+      TString axisRange[3] = {name1, name2, name3};
 
-    for (int i = 0; i < 3; ++i) {
-      fMCPrimDCAXYPtBinsMult[i] = new TH2F(primPtBinName[i].Data(),
-                                           axisRange[i].Data(), fpTbins, fpTmin,
-                                           fpTmax, 500, -5, 5);
-      fMCPrimDCAXYPtBinsMult[i]->Sumw2();
-      fDCAPlots->Add(fMCPrimDCAXYPtBinsMult[i]);
+      for (int i = 0; i < 3; ++i) {
+        fMCPrimDCAXYPtBinsMult[i] =
+            new TH2F(primPtBinName[i].Data(), axisRange[i].Data(), fpTbins,
+                     fpTmin, fpTmax, 500, -5, 5);
+        fMCPrimDCAXYPtBinsMult[i]->Sumw2();
+        fDCAPlots->Add(fMCPrimDCAXYPtBinsMult[i]);
 
-      fMCMaterialDCAXYPtBinsMult[i] = new TH2F(matPtBinName[i].Data(),
-                                               axisRange[i].Data(), fpTbins,
-                                               fpTmin, fpTmax, 500, -5, 5);
-      fMCMaterialDCAXYPtBinsMult[i]->Sumw2();
-      fDCAPlots->Add(fMCMaterialDCAXYPtBinsMult[i]);
+        fMCMaterialDCAXYPtBinsMult[i] =
+            new TH2F(matPtBinName[i].Data(), axisRange[i].Data(), fpTbins,
+                     fpTmin, fpTmax, 500, -5, 5);
+        fMCMaterialDCAXYPtBinsMult[i]->Sumw2();
+        fDCAPlots->Add(fMCMaterialDCAXYPtBinsMult[i]);
 
-      fMCSecondaryDCAXYPtBinsMult[i] = new TH2F(secPtBinName[i].Data(),
-                                                axisRange[i].Data(), fpTbins,
-                                                fpTmin, fpTmax, 500, -5, 5);
-      fMCSecondaryDCAXYPtBinsMult[i]->Sumw2();
-      fDCAPlots->Add(fMCSecondaryDCAXYPtBinsMult[i]);
+        fMCSecondaryDCAXYPtBinsMult[i] =
+            new TH2F(secPtBinName[i].Data(), axisRange[i].Data(), fpTbins,
+                     fpTmin, fpTmax, 500, -5, 5);
+        fMCSecondaryDCAXYPtBinsMult[i]->Sumw2();
+        fDCAPlots->Add(fMCSecondaryDCAXYPtBinsMult[i]);
 
-      fMCSecLambdaDCAXYPtBinsMult[i] = new TH2F(secLambdaPtBinName[i].Data(),
-                                                axisRange[i].Data(), fpTbins,
-                                                fpTmin, fpTmax, 500, -5, 5);
-      fMCSecLambdaDCAXYPtBinsMult[i]->Sumw2();
-      fDCAPlots->Add(fMCSecLambdaDCAXYPtBinsMult[i]);
+        fMCSecLambdaDCAXYPtBinsMult[i] =
+            new TH2F(secLambdaPtBinName[i].Data(), axisRange[i].Data(), fpTbins,
+                     fpTmin, fpTmax, 500, -5, 5);
+        fMCSecLambdaDCAXYPtBinsMult[i]->Sumw2();
+        fDCAPlots->Add(fMCSecLambdaDCAXYPtBinsMult[i]);
 
-      fMCSecSigmaDCAXYPtBinsMult[i] = new TH2F(secSigmaPtBinName[i].Data(),
-                                               axisRange[i].Data(), fpTbins,
-                                               fpTmin, fpTmax, 500, -5, 5);
-      fMCSecSigmaDCAXYPtBinsMult[i]->Sumw2();
-      fDCAPlots->Add(fMCSecSigmaDCAXYPtBinsMult[i]);
+        fMCSecSigmaDCAXYPtBinsMult[i] =
+            new TH2F(secSigmaPtBinName[i].Data(), axisRange[i].Data(), fpTbins,
+                     fpTmin, fpTmax, 500, -5, 5);
+        fMCSecSigmaDCAXYPtBinsMult[i]->Sumw2();
+        fDCAPlots->Add(fMCSecSigmaDCAXYPtBinsMult[i]);
+      }
     }
   } else {
     fDCAPlots = 0;
@@ -424,37 +429,43 @@ void AliFemtoDreamTrackMCHist::FillMCDCAXYPtBins(
   }
   if (org == AliFemtoDreamBasePart::kPhysPrimary) {
     fMCPrimDCAXYPtBins->Fill(pT, dcaxy);
-    FillMultiplicityHistos(multiplicity, pT, dcaxy, fMCPrimDCAXYPtBinsMult[0],
-                           fMCPrimDCAXYPtBinsMult[1],
-                           fMCPrimDCAXYPtBinsMult[2]);
+    if (fDoMultiplicityBinning) {
+      FillMultiplicityHistos(multiplicity, pT, dcaxy, fMCPrimDCAXYPtBinsMult[0],
+                             fMCPrimDCAXYPtBinsMult[1],
+                             fMCPrimDCAXYPtBinsMult[2]);
+    }
   } else if (org == AliFemtoDreamBasePart::kWeak) {
     fMCSecondaryDCAXYPtBins->Fill(pT, dcaxy);
-    FillMultiplicityHistos(multiplicity, pT, dcaxy,
-                           fMCSecondaryDCAXYPtBinsMult[0],
-                           fMCSecondaryDCAXYPtBinsMult[1],
-                           fMCSecondaryDCAXYPtBinsMult[2]);
+    if (fDoMultiplicityBinning) {
+      FillMultiplicityHistos(
+          multiplicity, pT, dcaxy, fMCSecondaryDCAXYPtBinsMult[0],
+          fMCSecondaryDCAXYPtBinsMult[1], fMCSecondaryDCAXYPtBinsMult[2]);
+    }
     if (TMath::Abs(PDGCodeMoth) == 3222) {
       fMCSecSigmaDCAXYPtBins->Fill(pT, dcaxy);
-      FillMultiplicityHistos(multiplicity, pT, dcaxy,
-                             fMCSecSigmaDCAXYPtBinsMult[0],
-                             fMCSecSigmaDCAXYPtBinsMult[1],
-                             fMCSecSigmaDCAXYPtBinsMult[2]);
+      if (fDoMultiplicityBinning) {
+        FillMultiplicityHistos(
+            multiplicity, pT, dcaxy, fMCSecSigmaDCAXYPtBinsMult[0],
+            fMCSecSigmaDCAXYPtBinsMult[1], fMCSecSigmaDCAXYPtBinsMult[2]);
+      }
     } else if (TMath::Abs(PDGCodeMoth) == 3122) {
       fMCSecLambdaDCAXYPtBins->Fill(pT, dcaxy);
-      FillMultiplicityHistos(multiplicity, pT, dcaxy,
-                             fMCSecLambdaDCAXYPtBinsMult[0],
-                             fMCSecLambdaDCAXYPtBinsMult[1],
-                             fMCSecLambdaDCAXYPtBinsMult[2]);
+      if (fDoMultiplicityBinning) {
+        FillMultiplicityHistos(
+            multiplicity, pT, dcaxy, fMCSecLambdaDCAXYPtBinsMult[0],
+            fMCSecLambdaDCAXYPtBinsMult[1], fMCSecLambdaDCAXYPtBinsMult[2]);
+      }
     } else {
       TString ErrHistSP = Form("Feeddown for %d not implemented", PDGCodeMoth);
       AliWarning(ErrHistSP.Data());
     }
   } else if (org == AliFemtoDreamBasePart::kMaterial) {
     fMCMaterialDCAXYPtBins->Fill(pT, dcaxy);
-    FillMultiplicityHistos(multiplicity, pT, dcaxy,
-                           fMCMaterialDCAXYPtBinsMult[0],
-                           fMCMaterialDCAXYPtBinsMult[1],
-                           fMCMaterialDCAXYPtBinsMult[2]);
+    if (fDoMultiplicityBinning) {
+      FillMultiplicityHistos(
+          multiplicity, pT, dcaxy, fMCMaterialDCAXYPtBinsMult[0],
+          fMCMaterialDCAXYPtBinsMult[1], fMCMaterialDCAXYPtBinsMult[2]);
+    }
   } else {
     AliFatal("Particle Origin not implemented");
   }

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackMCHist.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackMCHist.h
@@ -17,7 +17,7 @@
 class AliFemtoDreamTrackMCHist {
  public:
   AliFemtoDreamTrackMCHist();
-  AliFemtoDreamTrackMCHist(bool contribSplitting, bool DCADist);
+  AliFemtoDreamTrackMCHist(bool contribSplitting, bool DCADist, bool DoMultBinning = false);
   virtual ~AliFemtoDreamTrackMCHist();
   void FillMCDCAXYPtBins(AliFemtoDreamBasePart::PartOrigin org, int PDGCodeMoth,
                          float pT, float dcaxy, int multiplicity);
@@ -139,6 +139,7 @@ class AliFemtoDreamTrackMCHist {
   float fMultRangeHigh;			 //!
   bool fDoSplitting;              //!
   bool fDoDCAPlots;               //!
+  bool fDoMultiplicityBinning;    //!
 
   TList *fMCList;                 //!
   TList *fMCQAPlots[4];           //!
@@ -184,7 +185,7 @@ class AliFemtoDreamTrackMCHist {
   TH2F *fPtResolution;            //!
   TH2F *fThetaResolution;         //!
   TH2F *fPhiResolution;           //!
-ClassDef(AliFemtoDreamTrackMCHist,3)
+ClassDef(AliFemtoDreamTrackMCHist,4)
   ;
 };
 

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.cxx
@@ -66,7 +66,7 @@ void AliFemtoDreamv0::Setv0(AliAODEvent *evt, AliAODv0* v0,
   }
 }
 
-void AliFemtoDreamv0::Setv0(AliESDEvent *evt, AliESDv0* v0,
+void AliFemtoDreamv0::Setv0(AliESDEvent *evt, AliMCEvent *mcEvent, AliESDv0 *v0,
                             const int multiplicity) {
   if (!v0) {
     AliFatal("SetProng No v0 to work with");
@@ -80,7 +80,7 @@ void AliFemtoDreamv0::Setv0(AliESDEvent *evt, AliESDv0* v0,
     this->fOnlinev0 = false;
   }
   this->SetMotherInfo(evt, v0);
-  this->SetDaughter(evt, v0);
+  this->SetDaughter(evt, mcEvent, v0);
   this->SetEvtNumber(evt->GetRunNumber());
   this->fIsSet = fIsSet && fHasDaughter;
 //    if (fIsMC) {
@@ -120,7 +120,7 @@ void AliFemtoDreamv0::SetDaughter(AliAODv0 *v0) {
   }
 }
 
-void AliFemtoDreamv0::SetDaughter(AliESDEvent *evt, AliESDv0 *v0) {
+void AliFemtoDreamv0::SetDaughter(AliESDEvent *evt, AliMCEvent *mcEvent, AliESDv0 *v0) {
   int posFromV0 = v0->GetPindex();
   int negFromV0 = v0->GetNindex();
   AliESDtrack *esdV0Pos = evt->GetTrack(posFromV0);
@@ -128,8 +128,8 @@ void AliFemtoDreamv0::SetDaughter(AliESDEvent *evt, AliESDv0 *v0) {
   this->fHasDaughter = false;
   if (esdV0Pos && esdV0Neg) {
     if (esdV0Pos->Charge() > 0 && esdV0Neg->Charge() < 0) {
-      fnDaug->SetTrack(esdV0Neg, nullptr, -1, false);
-      fpDaug->SetTrack(esdV0Pos, nullptr, -1, false);
+      fnDaug->SetTrack(esdV0Neg, mcEvent, -1, false);
+      fpDaug->SetTrack(esdV0Pos, mcEvent, -1, false);
       if (fnDaug->IsSet() && fpDaug->IsSet()) {
         this->SetDaughterInfo(v0);
         this->fHasDaughter = true;
@@ -143,8 +143,8 @@ void AliFemtoDreamv0::SetDaughter(AliESDEvent *evt, AliESDv0 *v0) {
                            evt->GetMagneticField()));
       }
     } else if (esdV0Pos->Charge() < 0 && esdV0Neg->Charge() > 0) {
-      fnDaug->SetTrack(esdV0Pos, nullptr, -1, false);
-      fpDaug->SetTrack(esdV0Neg, nullptr, -1, false);
+      fnDaug->SetTrack(esdV0Pos, mcEvent, -1, false);
+      fpDaug->SetTrack(esdV0Neg, mcEvent, -1, false);
       if (fnDaug->IsSet() && fpDaug->IsSet()) {
         this->SetDaughterInfo(v0);
         this->fHasDaughter = true;

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.h
@@ -20,7 +20,8 @@ class AliFemtoDreamv0 : public AliFemtoDreamBasePart {
   AliFemtoDreamv0();
   virtual ~AliFemtoDreamv0();
   void Setv0(AliAODEvent *evt, AliAODv0 *v0, const int multiplicity = -1);
-  void Setv0(AliESDEvent *evt, AliESDv0 *v0, const int multiplicity = -1);
+  void Setv0(AliESDEvent *evt, AliMCEvent *mcEvent, AliESDv0 *v0,
+             const int multiplicity = -1);
   bool GetOnlinev0() const {
     return fOnlinev0;
   }
@@ -97,7 +98,7 @@ class AliFemtoDreamv0 : public AliFemtoDreamBasePart {
   AliFemtoDreamv0(const AliFemtoDreamv0&);
   void Reset();
   void SetDaughter(AliAODv0 *v0);
-  void SetDaughter(AliESDEvent *evt, AliESDv0 *v0);
+  void SetDaughter(AliESDEvent *evt, AliMCEvent *mcEvent, AliESDv0 *v0);
   void SetDaughterInfo(AliAODv0 *v0);
   void SetDaughterInfo(AliESDv0 *v0);
   void SetMotherInfo(AliAODEvent *evt, AliAODv0 *v0);

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0Cuts.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0Cuts.cxx
@@ -20,6 +20,7 @@ AliFemtoDreamv0Cuts::AliFemtoDreamv0Cuts()
       fMCData(false),
       fCPAPlots(false),
       fContribSplitting(false),
+      fDoMultBinning(false),
       fRunNumberQA(false),
       fMinRunNumber(0),
       fMaxRunNumber(0),
@@ -65,6 +66,7 @@ AliFemtoDreamv0Cuts::AliFemtoDreamv0Cuts(const AliFemtoDreamv0Cuts& cuts)
       fMCData(cuts.fMCData),
       fCPAPlots(cuts.fCPAPlots),
       fContribSplitting(cuts.fContribSplitting),
+      fDoMultBinning(cuts.fDoMultBinning),
       fRunNumberQA(cuts.fRunNumberQA),
       fMinRunNumber(cuts.fMinRunNumber),
       fMaxRunNumber(cuts.fMaxRunNumber),
@@ -112,6 +114,7 @@ AliFemtoDreamv0Cuts& AliFemtoDreamv0Cuts::operator=(
     this->fMCData = cuts.fMCData;
     this->fCPAPlots = cuts.fCPAPlots;
     this->fContribSplitting = cuts.fContribSplitting;
+    this->fDoMultBinning = cuts.fDoMultBinning;
     this->fRunNumberQA = cuts.fRunNumberQA;
     this->fMinRunNumber = cuts.fMinRunNumber;
     this->fMaxRunNumber = cuts.fMaxRunNumber;
@@ -417,7 +420,7 @@ void AliFemtoDreamv0Cuts::Init() {
     if (fMCData) {
       fMCHist = new AliFemtoDreamv0MCHist(fNumberXBins, fAxisMinMass,
                                           fAxisMaxMass, fContribSplitting,
-                                          fCPAPlots);
+                                          fCPAPlots, fDoMultBinning);
       fMCHistList = new TList();
       fMCHistList->SetOwner();
       fMCHistList->SetName("v0MCCuts");

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0Cuts.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0Cuts.h
@@ -45,6 +45,9 @@ class AliFemtoDreamv0Cuts {
     fContribSplitting = plot;
   }
   ;
+  void SetOriginMultiplicityHists(bool plot) {
+    fDoMultBinning = plot;
+  }
   void SetAxisInvMassPlots(int nBins, float minMass, float maxMass) {
     fNumberXBins = nBins;
     fAxisMinMass = minMass;
@@ -195,6 +198,7 @@ class AliFemtoDreamv0Cuts {
   bool fMCData;                       //
   bool fCPAPlots;                     //
   bool fContribSplitting;             //
+  bool fDoMultBinning;               //
   bool fRunNumberQA;                  //
   int fMinRunNumber;                  //
   int fMaxRunNumber;                  //
@@ -230,7 +234,7 @@ class AliFemtoDreamv0Cuts {
   int fPDGv0;                         //
   int fPDGDaugP;                      //
   int fPDGDaugN;                      //
-ClassDef(AliFemtoDreamv0Cuts,2)
+ClassDef(AliFemtoDreamv0Cuts,3)
 };
 
 #endif /* ALIFEMTODREAMV0CUTS_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0Hist.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0Hist.cxx
@@ -93,24 +93,20 @@ AliFemtoDreamv0Hist::AliFemtoDreamv0Hist(int MassNBins, float MassMin,
 
   fInvMassBefKaonRej = new TH1F("InvMassBefK0Rej", "InvMassBefK0Rej", MassNBins,
                                 MassMin, MassMax);
-  fInvMassBefKaonRej->Sumw2();
   fInvMassBefKaonRej->GetXaxis()->SetName("m_{Pair}");
   fHistList->Add(fInvMassBefKaonRej);
 
   fInvMassKaon = new TH1F("InvMassKaon", "InvMassKaon", 400, 0.4, 0.6);
-  fInvMassKaon->Sumw2();
   fInvMassKaon->GetXaxis()->SetName("m_{Pair}");
   fHistList->Add(fInvMassKaon);
 
   fInvMassBefSelection = new TH1F("InvMasswithCuts", "InvMasswithCuts",
                                   MassNBins, MassMin, MassMax);
-  fInvMassBefSelection->Sumw2();
   fInvMassBefSelection->GetXaxis()->SetName("m_{Pair}");
   fHistList->Add(fInvMassBefSelection);
 
   fInvMassPt = new TH2F("InvMassPt", "Invariant Mass in Pt Bins", 8, 0.3, 4.3,
                         MassNBins, MassMin, MassMax);
-  fInvMassPt->Sumw2();
   fInvMassPt->GetXaxis()->SetTitle("P_{T}");
   fInvMassPt->GetYaxis()->SetTitle("m_{Pair}");
   fHistList->Add(fInvMassPt);
@@ -123,90 +119,77 @@ AliFemtoDreamv0Hist::AliFemtoDreamv0Hist(int MassNBins, float MassMin,
 
     TString OnFlyName = Form("OnFly_%s", sName[i].Data());
     fOnFly[i] = new TH1F(OnFlyName.Data(), OnFlyName.Data(), 2, 0, 2.);
-    fOnFly[i]->Sumw2();
     fOnFly[i]->GetXaxis()->SetBinLabel(1, "Online");
     fOnFly[i]->GetXaxis()->SetBinLabel(2, "Offline");
     fv0CutQA[i]->Add(fOnFly[i]);
 
     TString ptname = Form("pTDist_%s", sName[i].Data());
     fpTDist[i] = new TH1F(ptname.Data(), ptname.Data(), 100, 0, 10.);
-    fpTDist[i]->Sumw2();
     fpTDist[i]->GetXaxis()->SetTitle("P_{T}");
     fv0CutQA[i]->Add(fpTDist[i]);
 
     TString etaname = Form("EtaDist_%s", sName[i].Data());
     fetaDist[i] = new TH1F(etaname.Data(), etaname.Data(), 200, -10., 10.);
-    fetaDist[i]->Sumw2();
     fetaDist[i]->GetXaxis()->SetTitle("#eta");
     fv0CutQA[i]->Add(fetaDist[i]);
 
     TString phiname = Form("PhiDist_%s", sName[i].Data());
     fPhiDist[i] = new TH1F(phiname.Data(), phiname.Data(), 100, 0.,
                            2 * TMath::Pi());
-    fPhiDist[i]->Sumw2();
     fPhiDist[i]->GetXaxis()->SetTitle("#phi");
     fv0CutQA[i]->Add(fPhiDist[i]);
 
     TString decayVtxXname = Form("DecayVtxXPV_%s", sName[i].Data());
     fDecayVtxv0X[i] = new TH1F(decayVtxXname.Data(), decayVtxXname.Data(), 400,
                                0., 200);
-    fDecayVtxv0X[i]->Sumw2();
     fDecayVtxv0X[i]->GetXaxis()->SetTitle("Decay Vtx To PV X");
     fv0CutQA[i]->Add(fDecayVtxv0X[i]);
 
     TString decayVtxYname = Form("DecayVtxYPV_%s", sName[i].Data());
     fDecayVtxv0Y[i] = new TH1F(decayVtxYname.Data(), decayVtxYname.Data(), 400,
                                0., 200);
-    fDecayVtxv0Y[i]->Sumw2();
     fDecayVtxv0Y[i]->GetXaxis()->SetTitle("Decay Vtx To PV Y");
     fv0CutQA[i]->Add(fDecayVtxv0Y[i]);
 
     TString decayVtxZname = Form("DecayVtxZPV_%s", sName[i].Data());
     fDecayVtxv0Z[i] = new TH1F(decayVtxZname.Data(), decayVtxZname.Data(), 400,
                                0., 200);
-    fDecayVtxv0Z[i]->Sumw2();
     fDecayVtxv0Z[i]->GetXaxis()->SetTitle("Decay Vtx To PV Z");
     fv0CutQA[i]->Add(fDecayVtxv0Z[i]);
 
     TString transverseRadname = Form("TransverseRadius_%s", sName[i].Data());
     fTransRadius[i] = new TH1F(transverseRadname.Data(),
                                transverseRadname.Data(), 750, 0, 150);
-    fTransRadius[i]->Sumw2();
     fTransRadius[i]->GetXaxis()->SetTitle("Transverse Radius");
     fv0CutQA[i]->Add(fTransRadius[i]);
 
     TString DCADauPVPname = Form("DCADauPToPV_%s", sName[i].Data());
     fDCAPosDaugToPrimVtx[i] = new TH1F(DCADauPVPname.Data(),
                                        DCADauPVPname.Data(), 500, 0, 100);
-    fDCAPosDaugToPrimVtx[i]->Sumw2();
     fDCAPosDaugToPrimVtx[i]->GetXaxis()->SetTitle("DCADaugther P to PV");
     fv0CutQA[i]->Add(fDCAPosDaugToPrimVtx[i]);
 
     TString DCADauPVNname = Form("DCADauNToPV_%s", sName[i].Data());
     fDCANegDaugToPrimVtx[i] = new TH1F(DCADauPVNname.Data(),
                                        DCADauPVNname.Data(), 500, 0, 100);
-    fDCANegDaugToPrimVtx[i]->Sumw2();
     fDCANegDaugToPrimVtx[i]->GetXaxis()->SetTitle("DCADaugther N to PV");
     fv0CutQA[i]->Add(fDCANegDaugToPrimVtx[i]);
 
     TString DCADaugVtxname = Form("DCADauToVtx_%s", sName[i].Data());
     fDCADaugToVtx[i] = new TH1F(DCADaugVtxname.Data(), DCADaugVtxname.Data(),
                                 100, 0, 10);
-    fDCADaugToVtx[i]->Sumw2();
     fDCADaugToVtx[i]->GetXaxis()->SetTitle("DCA Daug to Vtx");
     fv0CutQA[i]->Add(fDCADaugToVtx[i]);
 
     TString cosPointName = Form("PointingAngle_%s", sName[i].Data());
     fCPA[i] = new TH1F(cosPointName.Data(), cosPointName.Data(), 500, 0.8,
                        1.001);
-    fCPA[i]->Sumw2();
     fCPA[i]->GetXaxis()->SetTitle("Cos Pointing Angle");
     fv0CutQA[i]->Add(fCPA[i]);
 
     TString invMassName = Form("InvariantMass_%s", sName[i].Data());
     fInvMass[i] = new TH1F(invMassName.Data(), invMassName.Data(), MassNBins,
                            MassMin, MassMax);
-    fInvMass[i]->Sumw2();
     fInvMass[i]->GetXaxis()->SetTitle("m_{Pair}");
     fv0CutQA[i]->Add(fInvMass[i]);
   }
@@ -214,7 +197,6 @@ AliFemtoDreamv0Hist::AliFemtoDreamv0Hist(int MassNBins, float MassMin,
   if (CPAPlots) {
     fCPAPtBins = new TH2F("CPAPtBinsTot", "CPAPtBinsTot", 8, 0.3, 4.3, 1000,
                           0.90, 1.);
-    fCPAPtBins->Sumw2();
     fCPAPtBins->GetXaxis()->SetTitle("P_{T}");
     fCPAPtBins->GetYaxis()->SetTitle("CPA");
     fHistList->Add(fCPAPtBins);
@@ -226,7 +208,6 @@ AliFemtoDreamv0Hist::AliFemtoDreamv0Hist(int MassNBins, float MassMin,
     cpaAxisName += ";P#_{T};CPA";
     fCPAPtBinsMult[0] = new TH2F(cpaPtBinName.Data(), cpaAxisName.Data(), 8,
                                  0.3, 4.3, 1000, 0.90, 1.);
-    fCPAPtBinsMult[0]->Sumw2();
 
     cpaPtBinName = "CPAPtBinsMult_";
     cpaPtBinName += fMultRangeLow;
@@ -238,7 +219,6 @@ AliFemtoDreamv0Hist::AliFemtoDreamv0Hist(int MassNBins, float MassMin,
     cpaAxisName += ";P#_{T};CPA";
     fCPAPtBinsMult[1] = new TH2F(cpaPtBinName.Data(), cpaAxisName.Data(), 8,
                                  0.3, 4.3, 1000, 0.90, 1.);
-    fCPAPtBinsMult[1]->Sumw2();
 
     cpaPtBinName = "CPAPtBinsMult_";
     cpaPtBinName += fMultRangeHigh;
@@ -248,7 +228,6 @@ AliFemtoDreamv0Hist::AliFemtoDreamv0Hist(int MassNBins, float MassMin,
     cpaAxisName += ";P#_{T};CPA";
     fCPAPtBinsMult[2] = new TH2F(cpaPtBinName.Data(), cpaAxisName.Data(), 8,
                                  0.3, 4.3, 1000, 0.90, 1.);
-    fCPAPtBinsMult[2]->Sumw2();
 
     fHistList->Add(fCPAPtBinsMult[0]);
     fHistList->Add(fCPAPtBinsMult[1]);
@@ -304,7 +283,6 @@ AliFemtoDreamv0Hist::AliFemtoDreamv0Hist(TString MinimalBooking, int MassNBins,
 
   fInvMassPt = new TH2F("InvMassPt", "Invariant Mass in Pt Bins", 8, 0.3, 4.3,
                         MassNBins, MassMin, MassMax);
-  fInvMassPt->Sumw2();
   fInvMassPt->GetXaxis()->SetTitle("P_{T}");
   fInvMassPt->GetYaxis()->SetTitle("m_{Pair}");
   fHistList->Add(fInvMassPt);

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0MCHist.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0MCHist.cxx
@@ -12,6 +12,7 @@ AliFemtoDreamv0MCHist::AliFemtoDreamv0MCHist()
     : fMCList(0),
       fMultRangeLow(27),
       fMultRangeHigh(55),
+      fDoMultiplicityBinning(false),
       fCPAPlots(0),
       fMCCorrPt(0),
       fMCIdentPt(0),
@@ -61,9 +62,11 @@ AliFemtoDreamv0MCHist::AliFemtoDreamv0MCHist()
 AliFemtoDreamv0MCHist::AliFemtoDreamv0MCHist(int MassNBins, float MassMin,
                                              float MassMax,
                                              bool contribSplitting,
-                                             bool CPADist)
+                                             bool CPADist,
+                                             bool DoMultBinning)
     : fMultRangeLow(27),
-      fMultRangeHigh(55) {
+      fMultRangeHigh(55),
+      fDoMultiplicityBinning(DoMultBinning) {
   float ptmin = -0.2;
   float ptmax = 6.3;
   int ptBins = 13;
@@ -352,87 +355,89 @@ AliFemtoDreamv0MCHist::AliFemtoDreamv0MCHist(int MassNBins, float MassMin,
     fMCContCPAPtBins->GetYaxis()->SetTitle("CPA");
     fCPAPlots->Add(fMCContCPAPtBins);
 
-    TString name1 = "CPAPtBinningPriMult_0_";
-    name1 += fMultRangeLow;
-    TString name2 = "CPAPtBinningPriMult_";
-    name2 += fMultRangeLow;
-    name2 += "_";
-    name2 += fMultRangeHigh;
-    TString name3 = "CPAPtBinningPriMult_";
-    name3 += fMultRangeHigh;
-    name3 += "_inf";
-    TString primPtBinName[3] = { name1, name2, name3 };
+    if (fDoMultiplicityBinning) {
+      TString name1 = "CPAPtBinningPriMult_0_";
+      name1 += fMultRangeLow;
+      TString name2 = "CPAPtBinningPriMult_";
+      name2 += fMultRangeLow;
+      name2 += "_";
+      name2 += fMultRangeHigh;
+      TString name3 = "CPAPtBinningPriMult_";
+      name3 += fMultRangeHigh;
+      name3 += "_inf";
+      TString primPtBinName[3] = {name1, name2, name3};
 
-    name1 = "CPAPtBinningMatMult_0_";
-    name1 += fMultRangeLow;
-    name2 = "CPAPtBinningMatMult_";
-    name2 += fMultRangeLow;
-    name2 += "_";
-    name2 += fMultRangeHigh;
-    name3 = "CPAPtBinningMatMult_";
-    name3 += fMultRangeHigh;
-    name3 += "_inf";
-    TString matPtBinName[3] = { name1, name2, name3 };
+      name1 = "CPAPtBinningMatMult_0_";
+      name1 += fMultRangeLow;
+      name2 = "CPAPtBinningMatMult_";
+      name2 += fMultRangeLow;
+      name2 += "_";
+      name2 += fMultRangeHigh;
+      name3 = "CPAPtBinningMatMult_";
+      name3 += fMultRangeHigh;
+      name3 += "_inf";
+      TString matPtBinName[3] = {name1, name2, name3};
 
-    name1 = "CPAPtBinningSecMult_0_";
-    name1 += fMultRangeLow;
-    name2 = "CPAPtBinningSecMult_";
-    name2 += fMultRangeLow;
-    name2 += "_";
-    name2 += fMultRangeHigh;
-    name3 = "CPAPtBinningSecMult_";
-    name3 += fMultRangeHigh;
-    name3 += "_inf";
-    TString secPtBinName[3] = { name1, name2, name3 };
+      name1 = "CPAPtBinningSecMult_0_";
+      name1 += fMultRangeLow;
+      name2 = "CPAPtBinningSecMult_";
+      name2 += fMultRangeLow;
+      name2 += "_";
+      name2 += fMultRangeHigh;
+      name3 = "CPAPtBinningSecMult_";
+      name3 += fMultRangeHigh;
+      name3 += "_inf";
+      TString secPtBinName[3] = {name1, name2, name3};
 
-    name1 = "CPAPtBinningContMult_0_";
-    name1 += fMultRangeLow;
-    name2 = "CPAPtBinningContMult_";
-    name2 += fMultRangeLow;
-    name2 += "_";
-    name2 += fMultRangeHigh;
-    name3 = "CPAPtBinningContMult_";
-    name3 += fMultRangeHigh;
-    name3 += "_inf";
-    TString contPtBinName[3] = { name1, name2, name3 };
+      name1 = "CPAPtBinningContMult_0_";
+      name1 += fMultRangeLow;
+      name2 = "CPAPtBinningContMult_";
+      name2 += fMultRangeLow;
+      name2 += "_";
+      name2 += fMultRangeHigh;
+      name3 = "CPAPtBinningContMult_";
+      name3 += fMultRangeHigh;
+      name3 += "_inf";
+      TString contPtBinName[3] = {name1, name2, name3};
 
-    name1 = "0 < mult < ";
-    name1 += fMultRangeLow;
-    name1 += ";P#_{T};CPA";
-    name2 = "";
-    name2 += fMultRangeLow;
-    name2 += " < mult < ";
-    name2 += fMultRangeHigh;
-    name2 += ";P#_{T};CPA";
-    name3 = "mult > ";
-    name3 += fMultRangeHigh;
-    name3 += ";P#_{T};CPA";
-    TString axisRange[3] = { name1, name2, name3 };
+      name1 = "0 < mult < ";
+      name1 += fMultRangeLow;
+      name1 += ";P#_{T};CPA";
+      name2 = "";
+      name2 += fMultRangeLow;
+      name2 += " < mult < ";
+      name2 += fMultRangeHigh;
+      name2 += ";P#_{T};CPA";
+      name3 = "mult > ";
+      name3 += fMultRangeHigh;
+      name3 += ";P#_{T};CPA";
+      TString axisRange[3] = {name1, name2, name3};
 
-    for (int i = 0; i < 3; ++i) {
-      fMCPrimCPAPtBinsMult[i] = new TH2F(primPtBinName[i].Data(),
-                                         axisRange[i].Data(), 8, 0.3, 4.3, 1000,
-                                         0.90, 1.);
-      fMCPrimCPAPtBinsMult[i]->Sumw2();
-      fCPAPlots->Add(fMCPrimCPAPtBinsMult[i]);
+      for (int i = 0; i < 3; ++i) {
+        fMCPrimCPAPtBinsMult[i] =
+            new TH2F(primPtBinName[i].Data(), axisRange[i].Data(), 8, 0.3, 4.3,
+                     1000, 0.90, 1.);
+        fMCPrimCPAPtBinsMult[i]->Sumw2();
+        fCPAPlots->Add(fMCPrimCPAPtBinsMult[i]);
 
-      fMCMaterialCPAPtBinsMult[i] = new TH2F(matPtBinName[i].Data(),
-                                             axisRange[i].Data(), 8, 0.3, 4.3,
-                                             1000, 0.90, 1.);
-      fMCMaterialCPAPtBinsMult[i]->Sumw2();
-      fCPAPlots->Add(fMCMaterialCPAPtBinsMult[i]);
+        fMCMaterialCPAPtBinsMult[i] =
+            new TH2F(matPtBinName[i].Data(), axisRange[i].Data(), 8, 0.3, 4.3,
+                     1000, 0.90, 1.);
+        fMCMaterialCPAPtBinsMult[i]->Sumw2();
+        fCPAPlots->Add(fMCMaterialCPAPtBinsMult[i]);
 
-      fMCSecondaryCPAPtBinsMult[i] = new TH2F(secPtBinName[i].Data(),
-                                              axisRange[i].Data(), 8, 0.3, 4.3,
-                                              1000, 0.90, 1.);
-      fMCSecondaryCPAPtBinsMult[i]->Sumw2();
-      fCPAPlots->Add(fMCSecondaryCPAPtBinsMult[i]);
+        fMCSecondaryCPAPtBinsMult[i] =
+            new TH2F(secPtBinName[i].Data(), axisRange[i].Data(), 8, 0.3, 4.3,
+                     1000, 0.90, 1.);
+        fMCSecondaryCPAPtBinsMult[i]->Sumw2();
+        fCPAPlots->Add(fMCSecondaryCPAPtBinsMult[i]);
 
-      fMCContCPAPtBinsMult[i] = new TH2F(contPtBinName[i].Data(),
-                                         axisRange[i].Data(), 8, 0.3, 4.3, 1000,
-                                         0.90, 1.);
-      fMCContCPAPtBinsMult[i]->Sumw2();
-      fCPAPlots->Add(fMCContCPAPtBinsMult[i]);
+        fMCContCPAPtBinsMult[i] =
+            new TH2F(contPtBinName[i].Data(), axisRange[i].Data(), 8, 0.3, 4.3,
+                     1000, 0.90, 1.);
+        fMCContCPAPtBinsMult[i]->Sumw2();
+        fCPAPlots->Add(fMCContCPAPtBinsMult[i]);
+      }
     }
   } else {
     fCPAPlots = 0;
@@ -454,22 +459,30 @@ void AliFemtoDreamv0MCHist::FillMCCPAPtBins(
     int multiplicity) {
   if (org == AliFemtoDreamBasePart::kPhysPrimary) {
     fMCPrimCPAPtBins->Fill(pT, cpa);
-    FillMultiplicityHistos(multiplicity, pT, cpa, fMCPrimCPAPtBinsMult[0],
-                           fMCPrimCPAPtBinsMult[1], fMCPrimCPAPtBinsMult[2]);
+    if (fDoMultiplicityBinning) {
+      FillMultiplicityHistos(multiplicity, pT, cpa, fMCPrimCPAPtBinsMult[0],
+                             fMCPrimCPAPtBinsMult[1], fMCPrimCPAPtBinsMult[2]);
+    }
   } else if (org == AliFemtoDreamBasePart::kWeak) {
     fMCSecondaryCPAPtBins->Fill(pT, cpa);
-    FillMultiplicityHistos(multiplicity, pT, cpa, fMCSecondaryCPAPtBinsMult[0],
-                           fMCSecondaryCPAPtBinsMult[1],
-                           fMCSecondaryCPAPtBinsMult[2]);
+    if (fDoMultiplicityBinning) {
+      FillMultiplicityHistos(
+          multiplicity, pT, cpa, fMCSecondaryCPAPtBinsMult[0],
+          fMCSecondaryCPAPtBinsMult[1], fMCSecondaryCPAPtBinsMult[2]);
+    }
   } else if (org == AliFemtoDreamBasePart::kMaterial) {
     fMCMaterialCPAPtBins->Fill(pT, cpa);
-    FillMultiplicityHistos(multiplicity, pT, cpa, fMCMaterialCPAPtBinsMult[0],
-                           fMCMaterialCPAPtBinsMult[1],
-                           fMCMaterialCPAPtBinsMult[2]);
+    if (fDoMultiplicityBinning) {
+      FillMultiplicityHistos(multiplicity, pT, cpa, fMCMaterialCPAPtBinsMult[0],
+                             fMCMaterialCPAPtBinsMult[1],
+                             fMCMaterialCPAPtBinsMult[2]);
+    }
   } else if (org == AliFemtoDreamBasePart::kFake) {
     fMCContCPAPtBins->Fill(pT, cpa);
-    FillMultiplicityHistos(multiplicity, pT, cpa, fMCContCPAPtBinsMult[0],
-                           fMCContCPAPtBinsMult[1], fMCContCPAPtBinsMult[2]);
+    if (fDoMultiplicityBinning) {
+      FillMultiplicityHistos(multiplicity, pT, cpa, fMCContCPAPtBinsMult[0],
+                             fMCContCPAPtBinsMult[1], fMCContCPAPtBinsMult[2]);
+    }
   } else {
     AliFatal("Particle Origin not implemented");
   }

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0MCHist.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0MCHist.cxx
@@ -77,24 +77,20 @@ AliFemtoDreamv0MCHist::AliFemtoDreamv0MCHist(int MassNBins, float MassMin,
 
   fMCCorrPt = new TH1F("CorrParPt", "Correct Particles Pt", ptBins, ptmin,
                        ptmax);
-  fMCCorrPt->Sumw2();
   fMCCorrPt->GetXaxis()->SetTitle("p_{T}");
   fMCList->Add(fMCCorrPt);
 
   fMCIdentPt = new TH1F("IdentPartPt", "Ident Particles Pt", ptBins, ptmin,
                         ptmax);
-  fMCIdentPt->Sumw2();
   fMCIdentPt->GetXaxis()->SetTitle("p_{T}");
   fMCList->Add(fMCIdentPt);
 
   fMCGenPt = new TH1F("GenPartPt", "Gen Particles Pt", ptBins, ptmin, ptmax);
-  fMCGenPt->Sumw2();
   fMCGenPt->GetXaxis()->SetTitle("p_{T}");
   fMCList->Add(fMCGenPt);
 
   fPtResolution = new TH2F("DeltaPtRecoTruevsPtReco", "DeltaPtRecoTruevsPtReco",
                            100, 0, 5, 500, -1, 1);
-  fPtResolution->Sumw2();
   fPtResolution->GetXaxis()->SetTitle("P_{T,True}");
   fPtResolution->GetYaxis()->SetTitle("(P_{T,True}-P_{T,Reco})/P_{T,True}");
   fMCList->Add(fPtResolution);
@@ -102,7 +98,6 @@ AliFemtoDreamv0MCHist::AliFemtoDreamv0MCHist(int MassNBins, float MassMin,
   fThetaResolution = new TH2F("DeltaThetaRecoTruevsPtReco",
                               "DeltaThetaRecoTruevsPtReco", 100, 0, 5, 500,
                               -0.3, 0.3);
-  fThetaResolution->Sumw2();
   fThetaResolution->GetXaxis()->SetTitle("P_{T,True}");
   fThetaResolution->GetYaxis()->SetTitle("#Theta_{T,True}-#Theta_{T,Reco}");
   fMCList->Add(fThetaResolution);
@@ -110,7 +105,6 @@ AliFemtoDreamv0MCHist::AliFemtoDreamv0MCHist(int MassNBins, float MassMin,
   fPhiResolution = new TH2F("DeltaPhiRecoTruevsPtReco",
                             "DeltaPhiRecoTruevsPtReco", 100, 0, 5, 500, -0.3,
                             0.3);
-  fPhiResolution->Sumw2();
   fPhiResolution->GetXaxis()->SetTitle("P_{T,True}");
   fPhiResolution->GetYaxis()->SetTitle("#Phi_{T,True}-#Phi_{T,Reco}");
   fMCList->Add(fPhiResolution);
@@ -126,23 +120,19 @@ AliFemtoDreamv0MCHist::AliFemtoDreamv0MCHist(int MassNBins, float MassMin,
   if (contribSplitting) {
 
     fMCPrimaryPt = new TH1F("PrimaryPt", "PrimaryPt", ptBins, ptmin, ptmax);
-    fMCPrimaryPt->Sumw2();
     fMCPrimaryPt->GetXaxis()->SetTitle("p_{T}");
     fMCList->Add(fMCPrimaryPt);
 
     fMCMaterialPt = new TH1F("MatPt", "MatPT", ptBins, ptmin, ptmax);
-    fMCMaterialPt->Sumw2();
     fMCMaterialPt->GetXaxis()->SetTitle("p_{T}");
     fMCList->Add(fMCMaterialPt);
 
     fMCFeeddownWeakPt = new TH2F("FeeddownPt", "Feeddown Pt", ptBins, ptmin,
                                  ptmax, 213, 3121, 3334);
-    fMCFeeddownWeakPt->Sumw2();
     fMCFeeddownWeakPt->GetXaxis()->SetTitle("p_{T}");
     fMCList->Add(fMCFeeddownWeakPt);
 
     fMCContPt = new TH1F("ContPt", "ContPt", ptBins, ptmin, ptmax);
-    fMCContPt->Sumw2();
     fMCContPt->GetXaxis()->SetTitle("p_{T}");
     fMCList->Add(fMCContPt);
 
@@ -157,40 +147,34 @@ AliFemtoDreamv0MCHist::AliFemtoDreamv0MCHist(int MassNBins, float MassMin,
       TString MCPtDist = Form("MCPt%s", MCModes[i].Data());
       fMCpTDist[i] = new TH1F(MCPtDist.Data(), MCPtDist.Data(), ptBins, ptmin,
                               ptmax);
-      fMCpTDist[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCpTDist[i]);
 
       TString MCEtaDist = Form("MCEta%s", MCModes[i].Data());
       fMCetaDist[i] = new TH1F(MCEtaDist.Data(), MCEtaDist.Data(), 200, -10.,
                                10.);
-      fMCetaDist[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCetaDist[i]);
 
       TString MCPhiDist = Form("MCPhi%s", MCModes[i].Data());
       fMCphiDist[i] = new TH1F(MCPhiDist.Data(), MCPhiDist.Data(), 100, 0.,
                                2 * TMath::Pi());
-      fMCphiDist[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCphiDist[i]);
 
       TString MCDecayVtxv0XDist = Form("MCDecayVtxXPV%s", MCModes[i].Data());
       fMCDecayVtxv0X[i] = new TH2F(MCDecayVtxv0XDist.Data(),
                                    MCDecayVtxv0XDist.Data(), ptBins, ptmin,
                                    ptmax, 400, 0, 200);
-      fMCDecayVtxv0X[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCDecayVtxv0X[i]);
 
       TString MCDecayVtxv0YDist = Form("MCDecayVtxYPV%s", MCModes[i].Data());
       fMCDecayVtxv0Y[i] = new TH2F(MCDecayVtxv0YDist.Data(),
                                    MCDecayVtxv0YDist.Data(), ptBins, ptmin,
                                    ptmax, 400, 0, 200);
-      fMCDecayVtxv0Y[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCDecayVtxv0Y[i]);
 
       TString MCDecayVtxv0ZDist = Form("MCDecayVtxZPV%s", MCModes[i].Data());
       fMCDecayVtxv0Z[i] = new TH2F(MCDecayVtxv0ZDist.Data(),
                                    MCDecayVtxv0ZDist.Data(), ptBins, ptmin,
                                    ptmax, 400, 0, 200);
-      fMCDecayVtxv0Z[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCDecayVtxv0Z[i]);
 
       TString MCTransverseRadius = Form("MCTransverseRadius%s",
@@ -198,39 +182,33 @@ AliFemtoDreamv0MCHist::AliFemtoDreamv0MCHist(int MassNBins, float MassMin,
       fMCTransverseRadius[i] = new TH2F(MCTransverseRadius.Data(),
                                         MCTransverseRadius.Data(), ptBins,
                                         ptmin, ptmax, 750, 0, 150);
-      fMCTransverseRadius[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCTransverseRadius[i]);
 
       TString MCDCADaugPVP = Form("MCDCADauPToPV%s", MCModes[i].Data());
       fMCDCAPosDaugToPV[i] = new TH2F(MCDCADaugPVP.Data(), MCDCADaugPVP.Data(),
                                       ptBins, ptmin, ptmax, 500, 0, 100);
-      fMCDCAPosDaugToPV[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCDCAPosDaugToPV[i]);
 
       TString MCDCADaugPVN = Form("MCDCADauNToPV%s", MCModes[i].Data());
       fMCDCANegDaugToPV[i] = new TH2F(MCDCADaugPVN.Data(), MCDCADaugPVN.Data(),
                                       ptBins, ptmin, ptmax, 500, 0, 100);
-      fMCDCANegDaugToPV[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCDCANegDaugToPV[i]);
 
       TString MCDCADaugToVTX = Form("MCDCADauToVtx%s", MCModes[i].Data());
       fMCDCADaugToVtx[i] = new TH2F(MCDCADaugToVTX.Data(),
                                     MCDCADaugToVTX.Data(), ptBins, ptmin, ptmax,
                                     100, 0, 10);
-      fMCDCADaugToVtx[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCDCADaugToVtx[i]);
 
       TString MCCosPointing = Form("MCPointingAngle%s", MCModes[i].Data());
       fMCCosPointing[i] = new TH2F(MCCosPointing.Data(), MCCosPointing.Data(),
                                    ptBins, ptmin, ptmax, 400, 0.85, 1.001);
       ;
-      fMCCosPointing[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCCosPointing[i]);
 
       TString MCInvMass = Form("MCInvMass%s", MCModes[i].Data());
       fMCInvMass[i] = new TH1F(MCInvMass.Data(), MCInvMass.Data(), MassNBins,
                                MassMin, MassMax);
-      fMCInvMass[i]->Sumw2();
       fMCQAPlots[i]->Add(fMCInvMass[i]);
 
       TString MCBachDCAPV = Form("MCBachDCAPV%s", MCModes[i].Data());
@@ -326,7 +304,6 @@ AliFemtoDreamv0MCHist::AliFemtoDreamv0MCHist(int MassNBins, float MassMin,
     fMCPrimCPAPtBins = new TH2F(MCPricpaPtBinName.Data(),
                                 MCPricpaPtBinName.Data(), 8, 0.3, 4.3, 1000,
                                 0.90, 1.);
-    fMCPrimCPAPtBins->Sumw2();
     fMCPrimCPAPtBins->GetXaxis()->SetTitle("P_{T}");
     fMCPrimCPAPtBins->GetYaxis()->SetTitle("CPA");
     fCPAPlots->Add(fMCPrimCPAPtBins);
@@ -334,7 +311,6 @@ AliFemtoDreamv0MCHist::AliFemtoDreamv0MCHist(int MassNBins, float MassMin,
     fMCMaterialCPAPtBins = new TH2F(MCMatcpaPtBinName.Data(),
                                     MCMatcpaPtBinName.Data(), 8, 0.3, 4.3, 1000,
                                     0.90, 1.);
-    fMCMaterialCPAPtBins->Sumw2();
     fMCMaterialCPAPtBins->GetXaxis()->SetTitle("P_{T}");
     fMCMaterialCPAPtBins->GetYaxis()->SetTitle("CPA");
     fCPAPlots->Add(fMCMaterialCPAPtBins);
@@ -342,7 +318,6 @@ AliFemtoDreamv0MCHist::AliFemtoDreamv0MCHist(int MassNBins, float MassMin,
     fMCSecondaryCPAPtBins = new TH2F(MCSeccpaPtBinName.Data(),
                                      MCSeccpaPtBinName.Data(), 8, 0.3, 4.3,
                                      1000, 0.90, 1.);
-    fMCSecondaryCPAPtBins->Sumw2();
     fMCSecondaryCPAPtBins->GetXaxis()->SetTitle("P_{T}");
     fMCSecondaryCPAPtBins->GetYaxis()->SetTitle("CPA");
     fCPAPlots->Add(fMCSecondaryCPAPtBins);
@@ -350,7 +325,6 @@ AliFemtoDreamv0MCHist::AliFemtoDreamv0MCHist(int MassNBins, float MassMin,
     fMCContCPAPtBins = new TH2F(MCConcpaPtBinName.Data(),
                                 MCConcpaPtBinName.Data(), 8, 0.3, 4.3, 1000,
                                 0.90, 1.);
-    fMCContCPAPtBins->Sumw2();
     fMCContCPAPtBins->GetXaxis()->SetTitle("P_{T}");
     fMCContCPAPtBins->GetYaxis()->SetTitle("CPA");
     fCPAPlots->Add(fMCContCPAPtBins);
@@ -417,25 +391,21 @@ AliFemtoDreamv0MCHist::AliFemtoDreamv0MCHist(int MassNBins, float MassMin,
         fMCPrimCPAPtBinsMult[i] =
             new TH2F(primPtBinName[i].Data(), axisRange[i].Data(), 8, 0.3, 4.3,
                      1000, 0.90, 1.);
-        fMCPrimCPAPtBinsMult[i]->Sumw2();
         fCPAPlots->Add(fMCPrimCPAPtBinsMult[i]);
 
         fMCMaterialCPAPtBinsMult[i] =
             new TH2F(matPtBinName[i].Data(), axisRange[i].Data(), 8, 0.3, 4.3,
                      1000, 0.90, 1.);
-        fMCMaterialCPAPtBinsMult[i]->Sumw2();
         fCPAPlots->Add(fMCMaterialCPAPtBinsMult[i]);
 
         fMCSecondaryCPAPtBinsMult[i] =
             new TH2F(secPtBinName[i].Data(), axisRange[i].Data(), 8, 0.3, 4.3,
                      1000, 0.90, 1.);
-        fMCSecondaryCPAPtBinsMult[i]->Sumw2();
         fCPAPlots->Add(fMCSecondaryCPAPtBinsMult[i]);
 
         fMCContCPAPtBinsMult[i] =
             new TH2F(contPtBinName[i].Data(), axisRange[i].Data(), 8, 0.3, 4.3,
                      1000, 0.90, 1.);
-        fMCContCPAPtBinsMult[i]->Sumw2();
         fCPAPlots->Add(fMCContCPAPtBinsMult[i]);
       }
     }

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0MCHist.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0MCHist.h
@@ -16,7 +16,7 @@ class AliFemtoDreamv0MCHist {
  public:
   AliFemtoDreamv0MCHist();
   AliFemtoDreamv0MCHist(int MassNBins, float MassMin, float MassMax,
-                        bool contribSplitting, bool CPADist);
+                        bool contribSplitting, bool CPADist, bool DoMultBinning = false);
   virtual ~AliFemtoDreamv0MCHist();
   void FillMCCorr(float pT) {
     fMCCorrPt->Fill(pT);
@@ -169,6 +169,7 @@ class AliFemtoDreamv0MCHist {
   TList *fMCQAPlots[5];
   float fMultRangeLow;  //!
   float fMultRangeHigh;  //!
+  bool fDoMultiplicityBinning; //!
   TH1F *fMCCorrPt;
   TH1F *fMCIdentPt;
   TH1F *fMCGenPt;
@@ -211,7 +212,7 @@ class AliFemtoDreamv0MCHist {
   TH2F *fThetaResolution;         //!
   TH2F *fPhiResolution;           //!
 
-ClassDef(AliFemtoDreamv0MCHist,3)
+ClassDef(AliFemtoDreamv0MCHist,4)
 };
 
 #endif /* ALIFEMTODREAMV0MCHIST_H_ */

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskSigma0Femto.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskSigma0Femto.C
@@ -25,7 +25,77 @@ AliAnalysisTaskSE *AddTaskSigma0Femto(bool isMC = false,
   TString periodNameV0Reader = "";
   Bool_t enableV0findingEffi = kFALSE;
   Bool_t runLightOutput = kFALSE;
-  TString cutnumberAODBranch = "00000003_06000008400100001000000000";
+  if (suffix != "0" && suffix != "999") {
+    runLightOutput = kTRUE;
+  }
+  if (suffix == "28") {
+    // eta < 0.8
+    cutnumberPhoton = "1d200008400000002280920000";
+  } else if (suffix == "29") {
+    // eta < 0.75
+    cutnumberPhoton = "14200008400000002280920000";
+  } else if (suffix == "31") {
+    // r in 0 - 180 cm
+    cutnumberPhoton = "10000008400000002280920000";
+  } else if (suffix == "32") {
+    // r in 10 - 180 cm
+    cutnumberPhoton = "10500008400000002280920000";
+  } else if (suffix == "33") {
+    // single pT > 0, gammapT > 0
+    cutnumberPhoton = "10200078400000002280920000";
+  } else if (suffix == "34") {
+    // single pT > 0.150, gammapT > 0.02
+    cutnumberPhoton = "10200028400000002280920000";
+  } else if (suffix == "35") {
+    // single pT > 0.050, gammapT > 0.150
+    cutnumberPhoton = "102000a8400000002280920000";
+  } else if (suffix == "36") {
+    // TPC cluster, findable > 0.6
+    cutnumberPhoton = "10200009400000002280920000";
+  } else if (suffix == "37") {
+    // TPC PID -10,10
+    cutnumberPhoton = "10200008000000002280920000";
+  } else if (suffix == "38") {
+    // TPC PID -3,3
+    cutnumberPhoton = "10200008a00000002280920000";
+  } else if (suffix == "39") {
+    // TPC pi, p, k rejection -1,1
+    cutnumberPhoton = "10200008400020002280920000";
+  } else if (suffix == "40") {
+    // 1-D Qt cut, qt < 0.1
+    cutnumberPhoton = "10200008400000001280920000";
+  } else if (suffix == "41") {
+    // 2-D Qt cut, qt < 0.02
+    cutnumberPhoton = "10200008400000006280920000";
+  } else if (suffix == "42") {
+    // chi2 < 100
+    cutnumberPhoton = "10200008400000002080920000";
+  } else if (suffix == "43") {
+    // chi2 < 10
+    cutnumberPhoton = "10200008400000002780920000";
+  } else if (suffix == "44") {
+    // psiPair < 0.2, 1-D
+    cutnumberPhoton = "10200008400000002240920000";
+  } else if (suffix == "45") {
+    // psiPair < 0.1, 2-D
+    cutnumberPhoton = "10200008400000002250920000";
+  } else if (suffix == "46") {
+    // cosPA < 0.98
+    cutnumberPhoton = "10200008400000002280820000";
+  } else if (suffix == "47") {
+    // cosPA < 0.995
+    cutnumberPhoton = "10200008400000002280a20000";
+  } else if (suffix == "48") {
+    // shared electron cut, no photon QA selection
+    cutnumberPhoton = "10200008400000002280910000";
+  } else if (suffix == "49") {
+    // DCA_R < 5
+    cutnumberPhoton = "10200008400000002280920200";
+  } else if (suffix == "50") {
+    // DCA_Z < 5
+    cutnumberPhoton = "10200008400000002280920020";
+  }
+  // 50 - pile up cut, done in the task
 
   //========= Add V0 Reader to  ANALYSIS manager if not yet existent =====
   TString V0ReaderName =
@@ -101,6 +171,34 @@ AliAnalysisTaskSE *AddTaskSigma0Femto(bool isMC = false,
     TrackCuts->SetMinimalBooking(true);
     AntiTrackCuts->SetMinimalBooking(true);
   }
+  if (suffix == "52") {
+    TrackCuts->SetPtRange(0.4, 4.05);
+    AntiTrackCuts->SetPtRange(0.4, 4.05);
+  } else if (suffix == "53") {
+    TrackCuts->SetPtRange(0.5, 4.05);
+    AntiTrackCuts->SetPtRange(0.5, 4.05);
+  } else if (suffix == "54") {
+    TrackCuts->SetEtaRange(-0.7, 0.7);
+    AntiTrackCuts->SetEtaRange(-0.7, 0.7);
+  } else if (suffix == "55") {
+    TrackCuts->SetEtaRange(-0.9, 0.9);
+    AntiTrackCuts->SetEtaRange(-0.9, 0.9);
+  } else if (suffix == "56") {
+    TrackCuts->SetPID(AliPID::kProton, 0.75, 2);
+    AntiTrackCuts->SetPID(AliPID::kProton, 0.75, 2);
+  } else if (suffix == "57") {
+    TrackCuts->SetPID(AliPID::kProton, 0.75, 5);
+    AntiTrackCuts->SetPID(AliPID::kProton, 0.75, 5);
+  } else if (suffix == "58") {
+    TrackCuts->SetFilterBit(96);
+    AntiTrackCuts->SetFilterBit(96);
+  } else if (suffix == "59") {
+    TrackCuts->SetNClsTPC(70);
+    AntiTrackCuts->SetNClsTPC(70);
+  } else if (suffix == "60") {
+    TrackCuts->SetNClsTPC(90);
+    AntiTrackCuts->SetNClsTPC(90);
+  }
 
   AliSigma0V0Cuts *v0Cuts = AliSigma0V0Cuts::LambdaCuts();
   v0Cuts->SetIsMC(isMC);
@@ -118,10 +216,93 @@ AliAnalysisTaskSE *AddTaskSigma0Femto(bool isMC = false,
     antiv0Cuts->SetLightweight(true);
   }
   if (suffix == "1") {
-    v0Cuts->SetPileUpRejectionMode(AliSigma0V0Cuts::BothDaughtersCombined);
-    antiv0Cuts->SetPileUpRejectionMode(AliSigma0V0Cuts::BothDaughtersCombined);
+    v0Cuts->SetPileUpRejectionMode(AliSigma0V0Cuts::OneDaughterCombined);
+    antiv0Cuts->SetPileUpRejectionMode(AliSigma0V0Cuts::OneDaughterCombined);
+  } else if (suffix == "2") {
+    v0Cuts->SetV0PtMin(0.24);
+    antiv0Cuts->SetV0PtMin(0.24);
+  } else if (suffix == "3") {
+    v0Cuts->SetV0PtMin(0.36);
+    antiv0Cuts->SetV0PtMin(0.36);
+  } else if (suffix == "4") {
+    v0Cuts->SetV0CosPAMin(0.995);
+    antiv0Cuts->SetV0CosPAMin(0.995);
+  } else if (suffix == "5") {
+    v0Cuts->SetV0CosPAMin(0.98);
+    antiv0Cuts->SetV0CosPAMin(0.98);
+  } else if (suffix == "6") {
+    v0Cuts->SetPIDnSigma(3);
+    antiv0Cuts->SetPIDnSigma(3);
+  } else if (suffix == "7") {
+    v0Cuts->SetPIDnSigma(3);
+    antiv0Cuts->SetPIDnSigma(3);
+    v0Cuts->SetArmenterosCut(0, 1, -1, 1);
+    antiv0Cuts->SetArmenterosCut(0, 1, -1, 1);
+  } else if (suffix == "8") {
+    v0Cuts->SetPIDnSigma(6);
+    antiv0Cuts->SetPIDnSigma(6);
+  } else if (suffix == "9") {
+    v0Cuts->SetPIDnSigma(6);
+    antiv0Cuts->SetPIDnSigma(6);
+    v0Cuts->SetArmenterosCut(0, 1, -1, 1);
+    antiv0Cuts->SetArmenterosCut(0, 1, -1, 1);
+  } else if (suffix == "10") {
+    v0Cuts->SetArmenterosCut(0, 1, -1, 1);
+    antiv0Cuts->SetArmenterosCut(0, 1, -1, 1);
+  } else if (suffix == "11") {
+    v0Cuts->SetTPCclusterMin(80);
+    antiv0Cuts->SetTPCclusterMin(80);
+  } else if (suffix == "12") {
+    v0Cuts->SetTPCclusterMin(60);
+    antiv0Cuts->SetTPCclusterMin(60);
+  } else if (suffix == "13") {
+    v0Cuts->SetEtaMax(0.8);
+    antiv0Cuts->SetEtaMax(0.8);
+  } else if (suffix == "14") {
+    v0Cuts->SetEtaMax(0.75);
+    antiv0Cuts->SetEtaMax(0.75);
+  } else if (suffix == "15") {
+    v0Cuts->SetDaughterDCAMax(1.2);
+    antiv0Cuts->SetDaughterDCAMax(1.2);
+  } else if (suffix == "16") {
+    v0Cuts->SetDaughterDCAMax(0.9);
+    antiv0Cuts->SetDaughterDCAMax(0.9);
+  } else if (suffix == "17") {
+    v0Cuts->SetDaughterDCAtoPV(0.06);
+    antiv0Cuts->SetDaughterDCAtoPV(0.06);
+  } else if (suffix == "18") {
+    v0Cuts->SetDaughterDCAtoPV(0.04);
+    antiv0Cuts->SetDaughterDCAtoPV(0.04);
+  } else if (suffix == "19") {
+    v0Cuts->SetK0Rejection(0.48, 0.515);
+    antiv0Cuts->SetK0Rejection(0.48, 0.515);
+  } else if (suffix == "20") {
+    v0Cuts->SetLambdaSelection(1.115683 - 0.008, 1.115683 + 0.008);
+    antiv0Cuts->SetLambdaSelection(1.115683 - 0.008, 1.115683 + 0.008);
+  } else if (suffix == "21") {
+    v0Cuts->SetV0RadiusMax(120.f);
+    antiv0Cuts->SetV0RadiusMax(120.f);
+    v0Cuts->SetV0DecayVertexMax(120.f);
+    antiv0Cuts->SetV0DecayVertexMax(120.f);
+  } else if (suffix == "22") {
+    v0Cuts->SetV0RadiusMax(80.f);
+    antiv0Cuts->SetV0RadiusMax(80.f);
+  } else if (suffix == "23") {
+    v0Cuts->SetV0RadiusMin(0.);
+    antiv0Cuts->SetV0RadiusMin(0.);
+  } else if (suffix == "24") {
+    v0Cuts->SetV0RadiusMin(5.);
+    antiv0Cuts->SetV0RadiusMin(5.);
+  } else if (suffix == "25") {
+    v0Cuts->SetV0RadiusMin(5.);
+    antiv0Cuts->SetV0RadiusMin(5.);
+  } else if (suffix == "26") {
+    v0Cuts->SetV0DecayVertexMax(80.f);
+    antiv0Cuts->SetV0DecayVertexMax(80.f);
+  } else if (suffix == "27") {
+    v0Cuts->SetV0DecayVertexMax(120.f);
+    antiv0Cuts->SetV0DecayVertexMax(120.f);
   }
-
   if (suffix == "999") {
     v0Cuts->SetCheckCutsMC(true);
     antiv0Cuts->SetCheckCutsMC(true);
@@ -138,12 +319,6 @@ AliAnalysisTaskSE *AddTaskSigma0Femto(bool isMC = false,
   if (suffix != "0" && suffix != "999") {
     sigmaCuts->SetLightweight(true);
   }
-  if (suffix == "2" || suffix == "3") {
-    sigmaCuts->SetSigmaSideband(0.025, 0.05);
-  }
-  if (suffix == "4" || suffix == "5") {
-    sigmaCuts->SetSigmaSideband(0.025, 0.1);
-  }
 
   AliSigma0PhotonMotherCuts *antiSigmaCuts =
       AliSigma0PhotonMotherCuts::DefaultCuts();
@@ -154,11 +329,12 @@ AliAnalysisTaskSE *AddTaskSigma0Femto(bool isMC = false,
   if (suffix != "0" && suffix != "999") {
     antiSigmaCuts->SetLightweight(true);
   }
-  if (suffix == "2" || suffix == "3") {
-    antiSigmaCuts->SetSigmaSideband(0.025, 0.05);
-  }
-  if (suffix == "4" || suffix == "5") {
-    antiSigmaCuts->SetSigmaSideband(0.025, 0.1);
+  if (suffix == "61") {
+    sigmaCuts->SetPhotonMaxPt(1);
+    antiSigmaCuts->SetPhotonMaxPt(1);
+  } else if (suffix == "62") {
+    sigmaCuts->SetPhotonMaxPt(999);
+    antiSigmaCuts->SetPhotonMaxPt(999);
   }
 
   // Femto Collection
@@ -272,9 +448,6 @@ AliAnalysisTaskSE *AddTaskSigma0Femto(bool isMC = false,
   config->SetMinKRel(kMin);
   config->SetMaxKRel(kMax);
   config->SetMixingDepth(10);
-  if(suffix == "7") {
-    config->SetMixingDepth(25);
-  }
   config->SetUseEventMixing(true);
   config->SetMultiplicityEstimator(AliFemtoDreamEvent::kSPD);
   if (suffix != "0") {
@@ -304,7 +477,7 @@ AliAnalysisTaskSE *AddTaskSigma0Femto(bool isMC = false,
   if (suffix != "0" && suffix != "999") {
     task->SetLightweight(true);
   }
-  if (suffix == "1" || suffix == "3" || suffix == "5" || suffix == "6") {
+  if (suffix == "51") {
     task->SetPhotonLegPileUpCut(true);
   }
 

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskSigma0Femto.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskSigma0Femto.C
@@ -121,6 +121,7 @@ AliAnalysisTaskSE *AddTaskSigma0Femto(bool isMC = false,
           new AliConvEventCuts(cutnumberEvent.Data(), cutnumberEvent.Data());
       fEventCuts->SetPreSelectionCutFlag(kTRUE);
       fEventCuts->SetV0ReaderName(V0ReaderName);
+      fEventCuts->SetLightOutput(runLightOutput);
       if (periodNameV0Reader.CompareTo("") != 0)
         fEventCuts->SetPeriodEnum(periodNameV0Reader);
       fV0ReaderV1->SetEventCuts(fEventCuts);

--- a/PWGGA/Hyperon/AliSigma0PhotonMotherCuts.cxx
+++ b/PWGGA/Hyperon/AliSigma0PhotonMotherCuts.cxx
@@ -785,12 +785,12 @@ void AliSigma0PhotonMotherCuts::InitCutHistograms(TString appendix) {
   fHistInvMassPt = new TH2F("fHistInvMassPt",
                             "; #it{p}_{T} #Lambda#gamma (GeV/#it{c}); "
                             "M_{#Lambda#gamma} (GeV/#it{c}^{2})",
-                            100, 0, 10, 500, 1., 1.5);
+                            100, 0, 10, 300, 1., 1.3);
   fHistograms->Add(fHistInvMassPt);
   fHistMixedInvMassPt = new TH2F("fHistMixedInvMassPt",
                                  "; #it{p}_{T} #Lambda#gamma (GeV/#it{c}); "
                                  "M_{#Lambda#gamma} (GeV/#it{c}^{2})",
-                                 100, 0, 10, 500, 1., 1.5);
+                                 100, 0, 10, 300, 1., 1.3);
   fHistograms->Add(fHistMixedInvMassPt);
 
   std::vector<float> multBins = {{0, 0.01, 0.05, 0.1, 0.9, 1., 5., 10., 15.,
@@ -802,21 +802,21 @@ void AliSigma0PhotonMotherCuts::InitCutHistograms(TString appendix) {
                  Form("V0M: %.2f - %.2f %%; #it{p}_{T} (GeV/#it{c}); "
                       "M_{#Lambda#gamma} (GeV/#it{c}^{2})",
                       multBins[i], multBins[i + 1]),
-                 100, 0, 10, 150, 1.15, 1.3);
+                 100, 0, 10, 300, 1.15, 1.3);
     fHistograms->Add(fHistPtMult[i]);
     fHistMixedPtMult[i] =
         new TH2F(Form("fHistMixedPtMult_%i", i),
                  Form("V0M: %.2f - %.2f %%; #it{p}_{T} (GeV/#it{c}); "
                       "M_{#Lambda#gamma} (GeV/#it{c}^{2})",
                       multBins[i], multBins[i + 1]),
-                 100, 0, 10, 150, 1.15, 1.3);
+                 100, 0, 10, 300, 1.15, 1.3);
     fHistograms->Add(fHistMixedPtMult[i]);
     fHistMixedInvMassBinnedMultPt[i] =
         new TH2F(Form("fHistMixedInvMassBinnedMultPt_%i", i),
                  Form("V0M: %.2f - %.2f %%; #it{p}_{T} (GeV/#it{c}); "
                       "M_{#Lambda#gamma} (GeV/#it{c}^{2})",
                       multBins[i], multBins[i + 1]),
-                 100, 0, 10, 150, 1.15, 1.3);
+                 100, 0, 10, 300, 1.15, 1.3);
     fHistograms->Add(fHistMixedInvMassBinnedMultPt[i]);
   }
 
@@ -841,10 +841,10 @@ void AliSigma0PhotonMotherCuts::InitCutHistograms(TString appendix) {
                                50, 0, 10, 150, 1.15, 1.3);
     fHistArmenterosBefore =
         new TH2F("fHistArmenterosBefore", " ; #alpha; #it{q}_{T} (GeV/#it{c})",
-                 200, -1, 1, 100, 0, 0.5);
+                 100, -1, 1, 100, 0, 0.5);
     fHistArmenterosAfter =
         new TH2F("fHistArmenterosAfter", " ; #alpha; #it{q}_{T} (GeV/#it{c})",
-                 200, -1, 1, 100, 0, 0.5);
+                 100, -1, 1, 100, 0, 0.5);
     fHistEtaPhi = new TH2F("fHistEtaPhi", "; #eta; #phi", 100, -1, 1, 100,
                            -TMath::Pi(), TMath::Pi());
     fHistPtRapidity =

--- a/PWGGA/Hyperon/AliSigma0PhotonMotherCuts.cxx
+++ b/PWGGA/Hyperon/AliSigma0PhotonMotherCuts.cxx
@@ -21,7 +21,6 @@ ClassImp(AliSigma0PhotonMotherCuts)
       fPhotonMixed(),
       fLambdaMixedBinned(),
       fPhotonMixedBinned(),
-      fTreeVariables(),
       fLambdaCuts(nullptr),
       fPhotonCuts(nullptr),
       fV0Reader(nullptr),
@@ -47,21 +46,17 @@ ClassImp(AliSigma0PhotonMotherCuts)
       fHistNSigma(nullptr),
       fHistMassCutPt(nullptr),
       fHistInvMass(nullptr),
-      fHistInvMassBeforeArmenteros(nullptr),
       fHistInvMassRecPhoton(nullptr),
       fHistInvMassRecLambda(nullptr),
       fHistInvMassRec(nullptr),
       fHistInvMassPt(nullptr),
-      fHistInvMassEta(nullptr),
       fHistEtaPhi(nullptr),
-      fHistPtY(),
+      fHistPtRapidity(nullptr),
       fHistPtMult(),
       fHistArmenterosBefore(nullptr),
       fHistArmenterosAfter(nullptr),
-      fHistMixedPtY(),
       fHistMixedPtMult(),
       fHistMixedInvMassPt(nullptr),
-      fHistMixedInvMassBinnedPt(nullptr),
       fHistMixedInvMassBinnedMultPt(),
       fHistLambdaPtPhi(nullptr),
       fHistLambdaPtEta(nullptr),
@@ -73,18 +68,13 @@ ClassImp(AliSigma0PhotonMotherCuts)
       fHistSigmaPhotonPtCorr(nullptr),
       fHistSigmaLambdaPCorr(nullptr),
       fHistSigmaPhotonPCorr(nullptr),
+      fHistMCTruthPtMult(),
       fHistMCTruthPtY(nullptr),
-      fHistMCTruthPtEta(nullptr),
       fHistMCTruthDaughterPtY(nullptr),
-      fHistMCTruthDaughterPtEta(nullptr),
       fHistMCTruthDaughterPtYAccept(nullptr),
-      fHistMCTruthDaughterPtEtaAccept(nullptr),
       fHistMCTruthPtYHighMult(nullptr),
-      fHistMCTruthPtEtaHighMult(nullptr),
       fHistMCTruthDaughterPtYHighMult(nullptr),
-      fHistMCTruthDaughterPtEtaHighMult(nullptr),
       fHistMCTruthDaughterPtYAcceptHighMult(nullptr),
-      fHistMCTruthDaughterPtEtaAcceptHighMult(nullptr),
       fHistMCTrueSigmaLambdaPtCorr(nullptr),
       fHistMCTrueSigmaPhotonPtCorr(nullptr),
       fHistMCTrueSigmaLambdaPCorr(nullptr),
@@ -115,7 +105,6 @@ AliSigma0PhotonMotherCuts::AliSigma0PhotonMotherCuts(
       fSidebandDown(),
       fLambdaMixed(),
       fPhotonMixed(),
-      fTreeVariables(),
       fLambdaCuts(nullptr),
       fPhotonCuts(nullptr),
       fV0Reader(nullptr),
@@ -141,21 +130,17 @@ AliSigma0PhotonMotherCuts::AliSigma0PhotonMotherCuts(
       fHistNSigma(nullptr),
       fHistMassCutPt(nullptr),
       fHistInvMass(nullptr),
-      fHistInvMassBeforeArmenteros(nullptr),
       fHistInvMassRecPhoton(nullptr),
       fHistInvMassRecLambda(nullptr),
       fHistInvMassRec(nullptr),
       fHistInvMassPt(nullptr),
-      fHistInvMassEta(nullptr),
       fHistEtaPhi(nullptr),
-      fHistPtY(),
+      fHistPtRapidity(nullptr),
       fHistPtMult(),
       fHistArmenterosBefore(nullptr),
       fHistArmenterosAfter(nullptr),
-      fHistMixedPtY(),
       fHistMixedPtMult(),
       fHistMixedInvMassPt(nullptr),
-      fHistMixedInvMassBinnedPt(nullptr),
       fHistMixedInvMassBinnedMultPt(),
       fHistLambdaPtPhi(nullptr),
       fHistLambdaPtEta(nullptr),
@@ -167,18 +152,13 @@ AliSigma0PhotonMotherCuts::AliSigma0PhotonMotherCuts(
       fHistSigmaPhotonPtCorr(nullptr),
       fHistSigmaLambdaPCorr(nullptr),
       fHistSigmaPhotonPCorr(nullptr),
+      fHistMCTruthPtMult(),
       fHistMCTruthPtY(nullptr),
-      fHistMCTruthPtEta(nullptr),
       fHistMCTruthDaughterPtY(nullptr),
-      fHistMCTruthDaughterPtEta(nullptr),
       fHistMCTruthDaughterPtYAccept(nullptr),
-      fHistMCTruthDaughterPtEtaAccept(nullptr),
       fHistMCTruthPtYHighMult(nullptr),
-      fHistMCTruthPtEtaHighMult(nullptr),
       fHistMCTruthDaughterPtYHighMult(nullptr),
-      fHistMCTruthDaughterPtEtaHighMult(nullptr),
       fHistMCTruthDaughterPtYAcceptHighMult(nullptr),
-      fHistMCTruthDaughterPtEtaAcceptHighMult(nullptr),
       fHistMCTrueSigmaLambdaPtCorr(nullptr),
       fHistMCTrueSigmaPhotonPtCorr(nullptr),
       fHistMCTrueSigmaLambdaPCorr(nullptr),
@@ -282,7 +262,6 @@ void AliSigma0PhotonMotherCuts::SigmaToLambdaGamma(
       const float pT = sigma.GetPt();
       if (!fIsLightweight) {
         fHistArmenterosBefore->Fill(armAlpha, armQt);
-        fHistInvMassBeforeArmenteros->Fill(invMass);
       }
       // Armenteros cut
       if (fArmenterosCut) {
@@ -300,6 +279,7 @@ void AliSigma0PhotonMotherCuts::SigmaToLambdaGamma(
         if (!fIsLightweight) {
           fHistMassCutPt->Fill(pT);
           fHistEtaPhi->Fill(sigma.GetEta(), sigma.GetPhi());
+          fHistPtRapidity->Fill(pT, rap);
           fHistSigmaLambdaPtCorr->Fill(pT, lambda.GetPt());
           fHistSigmaPhotonPtCorr->Fill(pT, photon.GetPt());
           fHistSigmaLambdaPCorr->Fill(sigma.GetP(), lambda.GetP());
@@ -338,14 +318,11 @@ void AliSigma0PhotonMotherCuts::SigmaToLambdaGamma(
       fHistInvMass->Fill(invMass);
 
       if (std::abs(rap) > fRapidityMax || multBin < 0) continue;
-      const int rapBin = GetRapidityBin(rap);
       if (!fIsLightweight) {
         fHistArmenterosAfter->Fill(armAlpha, armQt);
         fHistInvMassRecPhoton->Fill(pT, sigma.GetRecMassPhoton());
         fHistInvMassRecLambda->Fill(pT, sigma.GetRecMassLambda());
         fHistInvMassRec->Fill(pT, sigma.GetRecMass());
-        if (rapBin > -1) fHistPtY[rapBin]->Fill(pT, invMass);
-        fHistInvMassEta->Fill(sigma.GetEta(), invMass);
       }
       fHistInvMassPt->Fill(pT, invMass);
       fHistPtMult[multBin]->Fill(pT, invMass);
@@ -361,31 +338,33 @@ void AliSigma0PhotonMotherCuts::SigmaToLambdaGamma(
           fHistMCV0Mass->Fill(invMass);
         }
 
-        // let's where the other particle comes from if one of them stems from
-        // a Sigma0
-        if (std::abs(pdgLambdaMother) == 3212 &&
-            std::abs(pdgLambdaMother) != 3212) {
-          fHistMCV0Mother->Fill(invMass, std::abs(pdgPhotonMother));
+        if (!fIsLightweight) {
+          // let's where the other particle comes from if one of them stems from
+          // a Sigma0
+          if (std::abs(pdgLambdaMother) == 3212 &&
+              std::abs(pdgLambdaMother) != 3212) {
+            fHistMCV0Mother->Fill(invMass, std::abs(pdgPhotonMother));
+          }
+          if (std::abs(pdgLambdaMother) == 3212 &&
+              std::abs(pdgLambdaMother) != 3212) {
+            fHistMCV0Mother->Fill(invMass, std::abs(pdgLambdaMother));
+          }
+          fHistMCV0MotherCheck->Fill(std::abs(pdgLambdaMother),
+                                     std::abs(pdgPhotonMother));
+
+          const int labV0 = photon.GetMCLabelV0();
+          const int labPhoton = lambda.GetMCLabelV0();
+          if (labV0 < 0 || labPhoton < 0) continue;
+
+          AliMCParticle *partV0 =
+              static_cast<AliMCParticle *>(fMCEvent->GetTrack(labV0));
+          AliMCParticle *partPhoton =
+              static_cast<AliMCParticle *>(fMCEvent->GetTrack(labPhoton));
+          if (!partV0 || !partPhoton) continue;
+
+          fHistMCV0Check->Fill(std::abs(partV0->PdgCode()),
+                               std::abs(partPhoton->PdgCode()));
         }
-        if (std::abs(pdgLambdaMother) == 3212 &&
-            std::abs(pdgLambdaMother) != 3212) {
-          fHistMCV0Mother->Fill(invMass, std::abs(pdgLambdaMother));
-        }
-        fHistMCV0MotherCheck->Fill(std::abs(pdgLambdaMother),
-                                   std::abs(pdgPhotonMother));
-
-        const int labV0 = photon.GetMCLabelV0();
-        const int labPhoton = lambda.GetMCLabelV0();
-        if (labV0 < 0 || labPhoton < 0) continue;
-
-        AliMCParticle *partV0 =
-            static_cast<AliMCParticle *>(fMCEvent->GetTrack(labV0));
-        AliMCParticle *partPhoton =
-            static_cast<AliMCParticle *>(fMCEvent->GetTrack(labPhoton));
-        if (!partV0 || !partPhoton) continue;
-
-        fHistMCV0Check->Fill(std::abs(partV0->PdgCode()),
-                             std::abs(partPhoton->PdgCode()));
       }
     }
   }
@@ -428,10 +407,6 @@ void AliSigma0PhotonMotherCuts::SigmaToLambdaGammaMixedEvent(
         if (std::abs(rap) > fRapidityMax || multBin < 0) continue;
         fHistMixedInvMassPt->Fill(pT, invMass);
         fHistMixedPtMult[multBin]->Fill(pT, invMass);
-        if (!fIsLightweight) {
-          const int rapBin = GetRapidityBin(rap);
-          if (rapBin > -1) fHistMixedPtY[rapBin]->Fill(pT, invMass);
-        }
       }
     }
   }
@@ -459,10 +434,6 @@ void AliSigma0PhotonMotherCuts::SigmaToLambdaGammaMixedEvent(
         if (std::abs(rap) > fRapidityMax || multBin < 0) continue;
         fHistMixedInvMassPt->Fill(pT, invMass);
         fHistMixedPtMult[multBin]->Fill(pT, invMass);
-        if (!fIsLightweight) {
-          const int rapBin = GetRapidityBin(rap);
-          if (rapBin > -1) fHistMixedPtY[rapBin]->Fill(pT, invMass);
-        }
       }
     }
   }
@@ -481,14 +452,11 @@ void AliSigma0PhotonMotherCuts::SigmaToLambdaGammaMixedEventBinned(
     lPercentile = MultSelection->GetMultiplicityPercentile("V0M");
   }
 
-  const float zVertex = fInputEvent->GetPrimaryVertex()->GetZ();
-  const int zVertexBin = GetZvertexBin(zVertex);
   const int multBin = GetMultiplicityBin(lPercentile);
-
-  if (zVertexBin < 0 || multBin < 0) return;
+  if (multBin < 0) return;
 
   // photons from this event with mixed lambdas
-  for (const auto &LambdaContainer : fLambdaMixedBinned[zVertexBin][multBin]) {
+  for (const auto &LambdaContainer : fLambdaMixedBinned[multBin]) {
     for (const auto &Lambda : LambdaContainer) {
       if (!Lambda.GetIsUse()) continue;
       for (auto Photon : photonCandidates) {
@@ -507,14 +475,13 @@ void AliSigma0PhotonMotherCuts::SigmaToLambdaGammaMixedEventBinned(
         const float invMass = sigma.GetMass();
         const float rap = sigma.GetRapidity();
         if (std::abs(rap) > fRapidityMax) continue;
-        fHistMixedInvMassBinnedPt->Fill(pT, invMass);
         fHistMixedInvMassBinnedMultPt[multBin]->Fill(pT, invMass);
       }
     }
   }
 
   // lambdas from this event with mixed photons
-  for (const auto &PhotonContainer : fPhotonMixedBinned[zVertexBin][multBin]) {
+  for (const auto &PhotonContainer : fPhotonMixedBinned[multBin]) {
     for (const auto &Photon : PhotonContainer) {
       if (Photon.GetPt() > fPhotonPtMax || Photon.GetPt() < fPhotonPtMin)
         continue;
@@ -533,7 +500,6 @@ void AliSigma0PhotonMotherCuts::SigmaToLambdaGammaMixedEventBinned(
         const float invMass = sigma.GetMass();
         const float rap = sigma.GetRapidity();
         if (std::abs(rap) > fRapidityMax) continue;
-        fHistMixedInvMassBinnedPt->Fill(pT, invMass);
         fHistMixedInvMassBinnedMultPt[multBin]->Fill(pT, invMass);
       }
     }
@@ -577,47 +543,29 @@ void AliSigma0PhotonMotherCuts::FillEventBuffer(
   if (MultSelection) {
     lPercentile = MultSelection->GetMultiplicityPercentile("V0M");
   }
-
-  const float zVertex = fInputEvent->GetPrimaryVertex()->GetZ();
-
-  const int zVertexBin = GetZvertexBin(zVertex);
   const int multBin = GetMultiplicityBin(lPercentile);
-
-  if (zVertexBin < 0 || multBin < 0) return;
+  if (multBin < 0) return;
 
   // Photon
   if (static_cast<int>(photonCandidates.size()) > 0) {
-    if (static_cast<int>(fPhotonMixedBinned[zVertexBin][multBin].size()) <
-        fMixingDepth) {
-      fPhotonMixedBinned[zVertexBin][multBin].push_back(photonCandidates);
+    if (static_cast<int>(fPhotonMixedBinned[multBin].size()) < fMixingDepth) {
+      fPhotonMixedBinned[multBin].push_back(photonCandidates);
     } else {
-      fPhotonMixedBinned[zVertexBin][multBin].pop_front();
-      fPhotonMixedBinned[zVertexBin][multBin].push_back(photonCandidates);
+      fPhotonMixedBinned[multBin].pop_front();
+      fPhotonMixedBinned[multBin].push_back(photonCandidates);
     }
   }
 
   // ++++++++++++++
   // Lambda
   if (static_cast<int>(lambdaCandidates.size()) > 0) {
-    if (static_cast<int>(fLambdaMixedBinned[zVertexBin][multBin].size()) <
-        fMixingDepth) {
-      fLambdaMixedBinned[zVertexBin][multBin].push_back(lambdaCandidates);
+    if (static_cast<int>(fLambdaMixedBinned[multBin].size()) < fMixingDepth) {
+      fLambdaMixedBinned[multBin].push_back(lambdaCandidates);
     } else {
-      fLambdaMixedBinned[zVertexBin][multBin].pop_front();
-      fLambdaMixedBinned[zVertexBin][multBin].push_back(lambdaCandidates);
+      fLambdaMixedBinned[multBin].pop_front();
+      fLambdaMixedBinned[multBin].push_back(lambdaCandidates);
     }
   }
-}
-
-//____________________________________________________________________________________________________
-float AliSigma0PhotonMotherCuts::ComputeRapidity(float pt, float pz,
-                                                 float m) const {
-  // calculates rapidity keeping the sign in case E == pz
-
-  float energy = std::sqrt(pt * pt + pz * pz + m * m);
-  if (energy != std::fabs(pz))
-    return 0.5 * std::log((energy + pz) / (energy - pz));
-  return (pz >= 0) ? 1.e30 : -1.e30;
 }
 
 //____________________________________________________________________________________________________
@@ -630,6 +578,7 @@ void AliSigma0PhotonMotherCuts::ProcessMC() const {
   if (MultSelection) {
     lPercentile = MultSelection->GetMultiplicityPercentile("V0M");
   }
+  const int multBin = GetMultiplicityBin(lPercentile);
 
   // Loop over the MC tracks
   for (int iPart = 1; iPart < (fMCEvent->GetNumberOfTracks()); iPart++) {
@@ -639,30 +588,27 @@ void AliSigma0PhotonMotherCuts::ProcessMC() const {
     //    if (!mcParticle->IsPhysicalPrimary()) continue;
     if (mcParticle->GetNDaughters() != 2) continue;
     if (mcParticle->PdgCode() != fPDG) continue;
+
+    if (multBin >= 0 && std::abs(mcParticle->Y()) <= fRapidityMax) {
+      fHistMCTruthPtMult[multBin]->Fill(mcParticle->Pt());
+    }
+
     fHistMCTruthPtY->Fill(mcParticle->Y(), mcParticle->Pt());
-    fHistMCTruthPtEta->Fill(mcParticle->Eta(), mcParticle->Pt());
     if (lPercentile < fMCHighMultThreshold) {
       fHistMCTruthPtYHighMult->Fill(mcParticle->Y(), mcParticle->Pt());
-      fHistMCTruthPtEtaHighMult->Fill(mcParticle->Eta(), mcParticle->Pt());
     }
 
     if (!CheckDaughters(mcParticle)) continue;
     fHistMCTruthDaughterPtY->Fill(mcParticle->Y(), mcParticle->Pt());
-    fHistMCTruthDaughterPtEta->Fill(mcParticle->Eta(), mcParticle->Pt());
     if (lPercentile < fMCHighMultThreshold) {
       fHistMCTruthDaughterPtYHighMult->Fill(mcParticle->Y(), mcParticle->Pt());
-      fHistMCTruthDaughterPtEtaHighMult->Fill(mcParticle->Eta(),
-                                              mcParticle->Pt());
     }
 
     if (!CheckDaughtersInAcceptance(mcParticle)) continue;
     fHistMCTruthDaughterPtYAccept->Fill(mcParticle->Y(), mcParticle->Pt());
-    fHistMCTruthDaughterPtEtaAccept->Fill(mcParticle->Eta(), mcParticle->Pt());
     if (lPercentile < fMCHighMultThreshold) {
       fHistMCTruthDaughterPtYAcceptHighMult->Fill(mcParticle->Y(),
                                                   mcParticle->Pt());
-      fHistMCTruthDaughterPtEtaAcceptHighMult->Fill(mcParticle->Eta(),
-                                                    mcParticle->Pt());
     }
   }
 }
@@ -743,40 +689,6 @@ bool AliSigma0PhotonMotherCuts::CheckDaughtersInAcceptance(
 }
 
 //____________________________________________________________________________________________________
-int AliSigma0PhotonMotherCuts::GetRapidityBin(float rapidity) const {
-  if (-10 < rapidity && rapidity <= -1)
-    return 0;
-  else if (-1 < rapidity && rapidity <= -0.5)
-    return 1;
-  else if (-0.5 < rapidity && rapidity <= -0.4)
-    return 2;
-  else if (-0.4 < rapidity && rapidity <= -0.3)
-    return 3;
-  else if (-0.3 < rapidity && rapidity <= -0.2)
-    return 4;
-  else if (-0.2 < rapidity && rapidity <= -0.1)
-    return 5;
-  else if (-0.1 < rapidity && rapidity <= 0.f)
-    return 6;
-  else if (0.f < rapidity && rapidity <= 0.1)
-    return 7;
-  else if (0.1 < rapidity && rapidity <= 0.2)
-    return 8;
-  else if (0.2 < rapidity && rapidity <= 0.3)
-    return 9;
-  else if (0.3 < rapidity && rapidity <= 0.4)
-    return 10;
-  else if (0.4 < rapidity && rapidity <= 0.5)
-    return 11;
-  else if (0.5 < rapidity && rapidity <= 1.f)
-    return 12;
-  else if (1.0 < rapidity && rapidity < 10.f)
-    return 13;
-  else
-    return -1;
-}
-
-//____________________________________________________________________________________________________
 int AliSigma0PhotonMotherCuts::GetMultiplicityBin(float percentile) const {
   if (0 < percentile && percentile <= 0.01)
     return 0;
@@ -811,32 +723,6 @@ int AliSigma0PhotonMotherCuts::GetMultiplicityBin(float percentile) const {
 }
 
 //____________________________________________________________________________________________________
-int AliSigma0PhotonMotherCuts::GetZvertexBin(float zVertex) const {
-  if (-10.f < zVertex && zVertex <= -8.f)
-    return 0;
-  else if (-8.f < zVertex && zVertex <= -6.f)
-    return 1;
-  else if (-6.f < zVertex && zVertex <= -4.f)
-    return 2;
-  else if (-4.f < zVertex && zVertex <= -2.f)
-    return 3;
-  else if (-2.f < zVertex && zVertex <= 0)
-    return 4;
-  else if (0.f < zVertex && zVertex <= 2.f)
-    return 5;
-  else if (2.f < zVertex && zVertex <= 4.f)
-    return 6;
-  else if (4.f < zVertex && zVertex <= 6.f)
-    return 7;
-  else if (6.f < zVertex && zVertex <= 8.f)
-    return 8;
-  else if (8.f < zVertex && zVertex <= 10.f)
-    return 9;
-  else
-    return -1;
-}
-
-//____________________________________________________________________________________________________
 void AliSigma0PhotonMotherCuts::InitCutHistograms(TString appendix) {
   fMassSigma = fDataBasePDG.GetParticle(fPDG)->Mass();
 
@@ -850,12 +736,6 @@ void AliSigma0PhotonMotherCuts::InitCutHistograms(TString appendix) {
             << " Photon pT max    " << fPhotonPtMax << "\n"
             << "============================\n";
 
-  std::vector<float> rapBins = {{-10., -1.f, -0.5, -0.4, -0.3, -0.2, -0.1, 0.f,
-                                 0.1, 0.2, 0.3, 0.4, 0.5, 1.f, 10.f}};
-
-  std::vector<float> multBins = {{0, 0.01, 0.05, 0.1, 0.9, 1., 5., 10., 15.,
-                                  20., 30., 40., 50., 70., 100.}};
-
   TH1::AddDirectory(kFALSE);
 
   TString name;
@@ -867,30 +747,6 @@ void AliSigma0PhotonMotherCuts::InitCutHistograms(TString appendix) {
     fHistograms = new TList();
     fHistograms->SetOwner(kTRUE);
     fHistograms->SetName(appendix);
-  }
-
-  for (int i = 0; i < static_cast<int>(multBins.size() - 1); i++) {
-    fHistPtMult[i] =
-        new TH2F(Form("fHistPtMult_%i", i),
-                 Form("%.2f < <N> < %.2f ; #it{p}_{T} (GeV/#it{c}); "
-                      "M_{#Lambda#gamma} (GeV/#it{c}^{2})",
-                      multBins[i], multBins[i + 1]),
-                 100, 0, 10, 150, 1.15, 1.3);
-    fHistograms->Add(fHistPtMult[i]);
-    fHistMixedPtMult[i] = new TH2F(
-        Form("fHistMixedPtMult_%i", i),
-        Form("%.2f < <N> < %.2f ; #it{p}_{T} (GeV/#it{c}); "
-             "M_{#Lambda#gamma} (GeV/#it{c}^{2})",
-             multBins[i], multBins[i + 1]),
-        100, 0, 10, 150, 1.15, 1.3);
-    fHistograms->Add(fHistMixedPtMult[i]);
-    fHistMixedInvMassBinnedMultPt[i] =
-        new TH2F(Form("fHistMixedInvMassBinnedMultPt_%i", i),
-                 Form("%.2f < <N> < %.2f ; #it{p}_{T} (GeV/#it{c}); "
-                      "M_{#Lambda#gamma} (GeV/#it{c}^{2})",
-                      multBins[i], multBins[i + 1]),
-                 100, 0, 10, 150, 1.15, 1.3);
-    fHistograms->Add(fHistMixedInvMassBinnedMultPt[i]);
   }
 
   fHistCutBooking = new TProfile("fHistCutBooking", ";;Cut value", 12, 0, 12);
@@ -921,6 +777,11 @@ void AliSigma0PhotonMotherCuts::InitCutHistograms(TString appendix) {
   fHistCutBooking->Fill(10.f, fRapidityMax);
   fHistCutBooking->Fill(11.f, fMCHighMultThreshold);
 
+  fHistInvMass =
+      new TH1F("fHistInvMass", "; M_{#Lambda#gamma} (GeV/#it{c}^{2}); Entries",
+               150, 1.15, 1.3);
+  fHistograms->Add(fHistInvMass);
+
   fHistInvMassPt = new TH2F("fHistInvMassPt",
                             "; #it{p}_{T} #Lambda#gamma (GeV/#it{c}); "
                             "M_{#Lambda#gamma} (GeV/#it{c}^{2})",
@@ -931,17 +792,33 @@ void AliSigma0PhotonMotherCuts::InitCutHistograms(TString appendix) {
                                  "M_{#Lambda#gamma} (GeV/#it{c}^{2})",
                                  100, 0, 10, 500, 1., 1.5);
   fHistograms->Add(fHistMixedInvMassPt);
-  fHistMixedInvMassBinnedPt =
-      new TH2F("fHistMixedInvMassBinnedPt",
-               "; #it{p}_{T} #Lambda#gamma (GeV/#it{c}); "
-               "M_{#Lambda#gamma} (GeV/#it{c}^{2})",
-               100, 0, 10, 500, 1., 1.5);
-  fHistograms->Add(fHistMixedInvMassBinnedPt);
 
-  fHistInvMass =
-      new TH1F("fHistInvMass", "; M_{#Lambda#gamma} (GeV/#it{c}^{2}); Entries",
-               150, 1.15, 1.3);
-  fHistograms->Add(fHistInvMass);
+  std::vector<float> multBins = {{0, 0.01, 0.05, 0.1, 0.9, 1., 5., 10., 15.,
+                                  20., 30., 40., 50., 70., 100.}};
+
+  for (int i = 0; i < static_cast<int>(multBins.size() - 1); i++) {
+    fHistPtMult[i] =
+        new TH2F(Form("fHistPtMult_%i", i),
+                 Form("V0M: %.2f - %.2f %%; #it{p}_{T} (GeV/#it{c}); "
+                      "M_{#Lambda#gamma} (GeV/#it{c}^{2})",
+                      multBins[i], multBins[i + 1]),
+                 100, 0, 10, 150, 1.15, 1.3);
+    fHistograms->Add(fHistPtMult[i]);
+    fHistMixedPtMult[i] =
+        new TH2F(Form("fHistMixedPtMult_%i", i),
+                 Form("V0M: %.2f - %.2f %%; #it{p}_{T} (GeV/#it{c}); "
+                      "M_{#Lambda#gamma} (GeV/#it{c}^{2})",
+                      multBins[i], multBins[i + 1]),
+                 100, 0, 10, 150, 1.15, 1.3);
+    fHistograms->Add(fHistMixedPtMult[i]);
+    fHistMixedInvMassBinnedMultPt[i] =
+        new TH2F(Form("fHistMixedInvMassBinnedMultPt_%i", i),
+                 Form("V0M: %.2f - %.2f %%; #it{p}_{T} (GeV/#it{c}); "
+                      "M_{#Lambda#gamma} (GeV/#it{c}^{2})",
+                      multBins[i], multBins[i + 1]),
+                 100, 0, 10, 150, 1.15, 1.3);
+    fHistograms->Add(fHistMixedInvMassBinnedMultPt[i]);
+  }
 
   if (!fIsLightweight) {
     fHistNSigma =
@@ -949,10 +826,6 @@ void AliSigma0PhotonMotherCuts::InitCutHistograms(TString appendix) {
     fHistMassCutPt = new TH1F(
         "fHistMassCutPt", "; #it{p}_{T} #Lambda#gamma (GeV/#it{c}); Entries",
         100, 0, 10);
-
-    fHistInvMassBeforeArmenteros = new TH1F(
-        "fHistInvMassBeforeArmenteros",
-        "; M_{#Lambda#gamma} (GeV/#it{c}^{2}); Entries", 150, 1.15, 1.3);
 
     fHistInvMassRecPhoton = new TH2F("fHistInvMassRecPhoton",
                                      "; #it{p}_{T} #Lambda#gamma (GeV/#it{c}); "
@@ -966,9 +839,6 @@ void AliSigma0PhotonMotherCuts::InitCutHistograms(TString appendix) {
                                "; #it{p}_{T} #Lambda#gamma (GeV/#it{c}); "
                                "M_{#Lambda_{rec}#gamma_{rec}} (GeV/#it{c}^{2})",
                                50, 0, 10, 150, 1.15, 1.3);
-    fHistInvMassEta = new TH2F("fHistInvMassEta",
-                               "; #eta; M_{#Lambda#gamma} (GeV/#it{c}^{2})",
-                               250, -1, 1, 150, 1.15, 1.3);
     fHistArmenterosBefore =
         new TH2F("fHistArmenterosBefore", " ; #alpha; #it{q}_{T} (GeV/#it{c})",
                  200, -1, 1, 100, 0, 0.5);
@@ -977,53 +847,38 @@ void AliSigma0PhotonMotherCuts::InitCutHistograms(TString appendix) {
                  200, -1, 1, 100, 0, 0.5);
     fHistEtaPhi = new TH2F("fHistEtaPhi", "; #eta; #phi", 100, -1, 1, 100,
                            -TMath::Pi(), TMath::Pi());
+    fHistPtRapidity =
+        new TH2F("fHistPtRapidity", "; #it{p}_{T} (GeV/#it{c}); y", 100, 0, 10,
+                 50, -5, 5);
 
     fHistograms->Add(fHistNSigma);
     fHistograms->Add(fHistMassCutPt);
-    fHistograms->Add(fHistInvMassBeforeArmenteros);
     fHistograms->Add(fHistInvMassRecPhoton);
     fHistograms->Add(fHistInvMassRecLambda);
     fHistograms->Add(fHistInvMassRec);
-    fHistograms->Add(fHistInvMassEta);
     fHistograms->Add(fHistEtaPhi);
+    fHistograms->Add(fHistPtRapidity);
     fHistograms->Add(fHistArmenterosBefore);
     fHistograms->Add(fHistArmenterosAfter);
 
-    for (int i = 0; i < static_cast<int>(rapBins.size() - 1); ++i) {
-      fHistPtY[i] =
-          new TH2F(Form("fHistPtY_%.2f_%.2f", rapBins[i], rapBins[i + 1]),
-                   Form("%.2f < y < %.2f ; #it{p}_{T} (GeV/#it{c}); "
-                        "M_{#Lambda#gamma} (GeV/#it{c}^{2})",
-                        rapBins[i], rapBins[i + 1]),
-                   100, 0, 10, 150, 1.15, 1.3);
-      fHistMixedPtY[i] =
-          new TH2F(Form("fHistMixedPtY_%.2f_%.2f", rapBins[i], rapBins[i + 1]),
-                   Form("%.2f < y < %.2f ; #it{p}_{T} (GeV/#it{c}); "
-                        "M_{#Lambda#gamma} (GeV/#it{c}^{2})",
-                        rapBins[i], rapBins[i + 1]),
-                   100, 0, 10, 150, 1.15, 1.3);
-      fHistograms->Add(fHistPtY[i]);
-      fHistograms->Add(fHistMixedPtY[i]);
-    }
-
     fHistLambdaPtPhi =
         new TH2F("fHistLambdaPtPhi", "; #it{p}_{T} (GeV/#it{c}); #phi (rad)",
-                 100, 0, 10, 100, 0, 2.f * TMath::Pi());
+                 50, 0, 10, 50, 0, 2.f * TMath::Pi());
     fHistLambdaPtEta =
-        new TH2F("fHistLambdaPtEta", "; #it{p}_{T} (GeV/#it{c}); #eta", 100, 0,
-                 10, 100, -1, 1);
+        new TH2F("fHistLambdaPtEta", "; #it{p}_{T} (GeV/#it{c}); #eta", 50, 0,
+                 10, 50, -1, 1);
     fHistLambdaMassPt =
-        new TH2F("fHistLambdaMassPt", "; #it{p}_{T} (GeV/#it{c}); M_{p#pi}",
-                 100, 0, 10, 250, 1., 1.5);
+        new TH2F("fHistLambdaMassPt", "; #it{p}_{T} (GeV/#it{c}); M_{p#pi}", 50,
+                 0, 10, 50, 1., 1.3);
     fHistPhotonPtPhi =
         new TH2F("fHistPhotonPtPhi", "; #it{p}_{T} (GeV/#it{c}); #phi (rad)",
-                 100, 0, 10, 100, 0, 2.f * TMath::Pi());
+                 50, 0, 10, 50, 0, 2.f * TMath::Pi());
     fHistPhotonPtEta =
-        new TH2F("fHistPhotonPtEta", "; #it{p}_{T} (GeV/#it{c}); #eta", 100, 0,
-                 10, 100, -1, 1);
+        new TH2F("fHistPhotonPtEta", "; #it{p}_{T} (GeV/#it{c}); #eta", 50, 0,
+                 10, 50, -1, 1);
     fHistPhotonMassPt =
-        new TH2F("fHistPhotonMassPt", "; #it{p}_{T} (GeV/#it{c}); M_{p#pi}",
-                 100, 0, 10, 250, 0., 0.1);
+        new TH2F("fHistPhotonMassPt", "; #it{p}_{T} (GeV/#it{c}); M_{p#pi}", 50,
+                 0, 10, 50, 0., 0.1);
 
     fHistograms->Add(fHistLambdaPtPhi);
     fHistograms->Add(fHistLambdaPtEta);
@@ -1035,19 +890,19 @@ void AliSigma0PhotonMotherCuts::InitCutHistograms(TString appendix) {
     fHistSigmaLambdaPtCorr = new TH2F("fHistSigmaLambdaPtCorr",
                                       "; #Sigma^{0} #it{p}_{T} (GeV/#it{c}; "
                                       "#Lambda #it{p}_{T} (GeV/#it{c}",
-                                      250, 0, 10, 250, 0, 10);
+                                      100, 0, 10, 100, 0, 10);
     fHistSigmaPhotonPtCorr = new TH2F("fHistSigmaPhotonPtCorr",
                                       "; #Sigma^{0} #it{p}_{T} (GeV/#it{c}; "
                                       "#gamma #it{p}_{T} (GeV/#it{c}",
-                                      250, 0, 10, 250, 0, 10);
+                                      100, 0, 10, 100, 0, 10);
     fHistSigmaLambdaPCorr = new TH2F("fHistSigmaLambdaPCorr",
                                      "; #Sigma^{0} #it{p} (GeV/#it{c}; "
                                      "#Lambda #it{p} (GeV/#it{c}",
-                                     250, 0, 10, 250, 0, 10);
+                                     100, 0, 10, 100, 0, 10);
     fHistSigmaPhotonPCorr = new TH2F("fHistSigmaPhotonPCorr",
                                      "; #Sigma^{0} #it{p} (GeV/#it{c}; "
                                      "#gamma #it{p} (GeV/#it{c}",
-                                     250, 0, 10, 250, 0, 10);
+                                     100, 0, 10, 100, 0, 10);
 
     fHistograms->Add(fHistSigmaLambdaPtCorr);
     fHistograms->Add(fHistSigmaPhotonPtCorr);
@@ -1066,79 +921,33 @@ void AliSigma0PhotonMotherCuts::InitCutHistograms(TString appendix) {
       fHistogramsMC->SetName("MC");
     }
 
+    for (int i = 0; i < static_cast<int>(multBins.size() - 1); i++) {
+      fHistMCTruthPtMult[i] =
+          new TH1F(Form("fHistMCTruthPtMult%i", i),
+                   Form("V0M: %.2f - %.2f %%; #it{p}_{T} (GeV/#it{c})",
+                        multBins[i], multBins[i + 1]),
+                   100, 0, 10);
+      fHistogramsMC->Add(fHistMCTruthPtMult[i]);
+    }
+
     fHistMCTruthPtY =
-        new TH2F("fHistMCTruthPtY", "; y; #it{p}_{T} (GeV/#it{c})", 200, -10,
-                 10, 100, 0, 10);
-    fHistMCTruthPtEta =
-        new TH2F("fHistMCTruthPtEta", "; #eta; #it{p}_{T} (GeV/#it{c})", 200,
-                 -10, 10, 100, 0, 10);
+        new TH2F("fHistMCTruthPtY", "; y; #it{p}_{T} (GeV/#it{c})", 100, -5, 5,
+                 100, 0, 10);
     fHistMCTruthDaughterPtY =
         new TH2F("fHistMCTruthDaughterPtY", "; y; #it{p}_{T} (GeV/#it{c})", 200,
                  -10, 10, 100, 0, 10);
-    fHistMCTruthDaughterPtEta =
-        new TH2F("fHistMCTruthDaughterPtEta", "; #eta; #it{p}_{T} (GeV/#it{c})",
-                 200, -10, 10, 100, 0, 10);
     fHistMCTruthDaughterPtYAccept =
         new TH2F("fHistMCTruthDaughterPtYAccept",
                  "; y; #it{p}_{T} (GeV/#it{c})", 200, -10, 10, 100, 0, 10);
-    fHistMCTruthDaughterPtEtaAccept =
-        new TH2F("fHistMCTruthDaughterPtEtaAccept",
-                 "; #eta; #it{p}_{T} (GeV/#it{c})", 200, -10, 10, 100, 0, 10);
     fHistMCTruthPtYHighMult =
         new TH2F("fHistMCTruthPtYHighMult", "; y; #it{p}_{T} (GeV/#it{c})", 200,
                  -10, 10, 100, 0, 10);
-    fHistMCTruthPtEtaHighMult =
-        new TH2F("fHistMCTruthPtEtaHighMult", "; #eta; #it{p}_{T} (GeV/#it{c})",
-                 200, -10, 10, 100, 0, 10);
     fHistMCTruthDaughterPtYHighMult =
         new TH2F("fHistMCTruthDaughterPtYHighMult",
                  "; y; #it{p}_{T} (GeV/#it{c})", 200, -10, 10, 100, 0, 10);
-    fHistMCTruthDaughterPtEtaHighMult =
-        new TH2F("fHistMCTruthDaughterPtEtaHighMult",
-                 "; #eta; #it{p}_{T} (GeV/#it{c})", 200, -10, 10, 100, 0, 10);
     fHistMCTruthDaughterPtYAcceptHighMult =
         new TH2F("fHistMCTruthDaughterPtYAcceptHighMult",
                  "; y; #it{p}_{T} (GeV/#it{c})", 200, -10, 10, 100, 0, 10);
-    fHistMCTruthDaughterPtEtaAcceptHighMult =
-        new TH2F("fHistMCTruthDaughterPtEtaAcceptHighMult",
-                 "; #eta; #it{p}_{T} (GeV/#it{c})", 200, -10, 10, 100, 0, 10);
-
-    fHistMCTrueSigmaLambdaPtCorr =
-        new TH2F("fHistMCTrueSigmaLambdaPtCorr",
-                 "; #Sigma^{0} #it{p}_{T} (GeV/#it{c}; "
-                 "#Lambda #it{p}_{T} (GeV/#it{c}",
-                 250, 0, 10, 250, 0, 10);
-    fHistMCTrueSigmaPhotonPtCorr =
-        new TH2F("fHistMCTrueSigmaPhotonPtCorr",
-                 "; #Sigma^{0} #it{p}_{T} (GeV/#it{c}; "
-                 "#gamma #it{p}_{T} (GeV/#it{c}",
-                 250, 0, 10, 250, 0, 10);
-    fHistMCTrueSigmaLambdaPCorr = new TH2F("fHistMCTrueSigmaLambdaPCorr",
-                                           "; #Sigma^{0} #it{p} (GeV/#it{c}; "
-                                           "#Lambda #it{p} (GeV/#it{c}",
-                                           250, 0, 10, 250, 0, 10);
-    fHistMCTrueSigmaPhotonPCorr = new TH2F("fHistMCTrueSigmaPhotonPCorr",
-                                           "; #Sigma^{0} #it{p} (GeV/#it{c}; "
-                                           "#gamma #it{p} (GeV/#it{c}",
-                                           250, 0, 10, 250, 0, 10);
-    fHistMCBkgSigmaLambdaPtCorr =
-        new TH2F("fHistMCBkgSigmaLambdaPtCorr",
-                 "; #Sigma^{0} #it{p}_{T} (GeV/#it{c}; "
-                 "#Lambda #it{p}_{T} (GeV/#it{c}",
-                 250, 0, 10, 250, 0, 10);
-    fHistMCBkgSigmaPhotonPtCorr =
-        new TH2F("fHistMCBkgSigmaPhotonPtCorr",
-                 "; #Sigma^{0} #it{p}_{T} (GeV/#it{c}; "
-                 "#gamma #it{p}_{T} (GeV/#it{c}",
-                 250, 0, 10, 250, 0, 10);
-    fHistMCBkgSigmaLambdaPCorr = new TH2F("fHistMCBkgSigmaLambdaPCorr",
-                                          "; #Sigma^{0} #it{p} (GeV/#it{c}; "
-                                          "#Lambda #it{p} (GeV/#it{c}",
-                                          250, 0, 10, 250, 0, 10);
-    fHistMCBkgSigmaPhotonPCorr = new TH2F("fHistMCBkgSigmaPhotonPCorr",
-                                          "; #Sigma^{0} #it{p} (GeV/#it{c}; "
-                                          "#gamma #it{p} (GeV/#it{c}",
-                                          250, 0, 10, 250, 0, 10);
 
     fHistMCV0Pt = new TH1F("fHistMCV0Pt",
                            "; #it{p}_{T} #Lambda#gamma (GeV/#it{c}); Entries",
@@ -1146,44 +955,78 @@ void AliSigma0PhotonMotherCuts::InitCutHistograms(TString appendix) {
     fHistMCV0Mass =
         new TH1F("fHistMCV0Mass",
                  "; M_{#Lambda#gamma} (GeV/#it{c}^{2}); Entries", 500, 1., 1.5);
-    fHistMCV0Mother =
-        new TH2F("fHistMCV0Mother",
-                 "; M_{#Lambda#gamma} (GeV/#it{c}^{2}); PDG code mother", 250,
-                 1., 2., 4000, 0, 4000);
-    fHistMCV0Check =
-        new TH2F("fHistMCV0Check",
-                 "; PDG code #Lambda candidate; PDG code #gamma candidate",
-                 4000, 0, 4000, 4000, 0, 4000);
-    fHistMCV0MotherCheck =
-        new TH2F("fHistMCV0MotherCheck",
-                 "; PDG code #Lambda mother; PDG code #gamma mother", 4000, 0,
-                 4000, 4000, 0, 4000);
-
-    fHistogramsMC->Add(fHistMCTruthPtY);
-    fHistogramsMC->Add(fHistMCTruthPtEta);
-    fHistogramsMC->Add(fHistMCTruthDaughterPtY);
-    fHistogramsMC->Add(fHistMCTruthDaughterPtEta);
-    fHistogramsMC->Add(fHistMCTruthDaughterPtYAccept);
-    fHistogramsMC->Add(fHistMCTruthDaughterPtEtaAccept);
-    fHistogramsMC->Add(fHistMCTruthPtYHighMult);
-    fHistogramsMC->Add(fHistMCTruthPtEtaHighMult);
-    fHistogramsMC->Add(fHistMCTruthDaughterPtYHighMult);
-    fHistogramsMC->Add(fHistMCTruthDaughterPtEtaHighMult);
-    fHistogramsMC->Add(fHistMCTruthDaughterPtYAcceptHighMult);
-    fHistogramsMC->Add(fHistMCTruthDaughterPtEtaAcceptHighMult);
-    fHistogramsMC->Add(fHistMCTrueSigmaLambdaPtCorr);
-    fHistogramsMC->Add(fHistMCTrueSigmaPhotonPtCorr);
-    fHistogramsMC->Add(fHistMCTrueSigmaLambdaPCorr);
-    fHistogramsMC->Add(fHistMCTrueSigmaPhotonPCorr);
-    fHistogramsMC->Add(fHistMCBkgSigmaLambdaPtCorr);
-    fHistogramsMC->Add(fHistMCBkgSigmaPhotonPtCorr);
-    fHistogramsMC->Add(fHistMCBkgSigmaLambdaPCorr);
-    fHistogramsMC->Add(fHistMCBkgSigmaPhotonPCorr);
     fHistogramsMC->Add(fHistMCV0Pt);
     fHistogramsMC->Add(fHistMCV0Mass);
-    fHistogramsMC->Add(fHistMCV0Mother);
-    fHistogramsMC->Add(fHistMCV0Check);
-    fHistogramsMC->Add(fHistMCV0MotherCheck);
+
+    if (!fIsLightweight) {
+      fHistMCTrueSigmaLambdaPtCorr =
+          new TH2F("fHistMCTrueSigmaLambdaPtCorr",
+                   "; #Sigma^{0} #it{p}_{T} (GeV/#it{c}; "
+                   "#Lambda #it{p}_{T} (GeV/#it{c}",
+                   250, 0, 10, 250, 0, 10);
+      fHistMCTrueSigmaPhotonPtCorr =
+          new TH2F("fHistMCTrueSigmaPhotonPtCorr",
+                   "; #Sigma^{0} #it{p}_{T} (GeV/#it{c}; "
+                   "#gamma #it{p}_{T} (GeV/#it{c}",
+                   250, 0, 10, 250, 0, 10);
+      fHistMCTrueSigmaLambdaPCorr = new TH2F("fHistMCTrueSigmaLambdaPCorr",
+                                             "; #Sigma^{0} #it{p} (GeV/#it{c}; "
+                                             "#Lambda #it{p} (GeV/#it{c}",
+                                             250, 0, 10, 250, 0, 10);
+      fHistMCTrueSigmaPhotonPCorr = new TH2F("fHistMCTrueSigmaPhotonPCorr",
+                                             "; #Sigma^{0} #it{p} (GeV/#it{c}; "
+                                             "#gamma #it{p} (GeV/#it{c}",
+                                             250, 0, 10, 250, 0, 10);
+      fHistMCBkgSigmaLambdaPtCorr =
+          new TH2F("fHistMCBkgSigmaLambdaPtCorr",
+                   "; #Sigma^{0} #it{p}_{T} (GeV/#it{c}; "
+                   "#Lambda #it{p}_{T} (GeV/#it{c}",
+                   250, 0, 10, 250, 0, 10);
+      fHistMCBkgSigmaPhotonPtCorr =
+          new TH2F("fHistMCBkgSigmaPhotonPtCorr",
+                   "; #Sigma^{0} #it{p}_{T} (GeV/#it{c}; "
+                   "#gamma #it{p}_{T} (GeV/#it{c}",
+                   250, 0, 10, 250, 0, 10);
+      fHistMCBkgSigmaLambdaPCorr = new TH2F("fHistMCBkgSigmaLambdaPCorr",
+                                            "; #Sigma^{0} #it{p} (GeV/#it{c}; "
+                                            "#Lambda #it{p} (GeV/#it{c}",
+                                            250, 0, 10, 250, 0, 10);
+      fHistMCBkgSigmaPhotonPCorr = new TH2F("fHistMCBkgSigmaPhotonPCorr",
+                                            "; #Sigma^{0} #it{p} (GeV/#it{c}; "
+                                            "#gamma #it{p} (GeV/#it{c}",
+                                            250, 0, 10, 250, 0, 10);
+
+      fHistMCV0Mother =
+          new TH2F("fHistMCV0Mother",
+                   "; M_{#Lambda#gamma} (GeV/#it{c}^{2}); PDG code mother", 250,
+                   1., 2., 4000, 0, 4000);
+      fHistMCV0Check =
+          new TH2F("fHistMCV0Check",
+                   "; PDG code #Lambda candidate; PDG code #gamma candidate",
+                   4000, 0, 4000, 4000, 0, 4000);
+      fHistMCV0MotherCheck =
+          new TH2F("fHistMCV0MotherCheck",
+                   "; PDG code #Lambda mother; PDG code #gamma mother", 4000, 0,
+                   4000, 4000, 0, 4000);
+
+      fHistogramsMC->Add(fHistMCTruthPtY);
+      fHistogramsMC->Add(fHistMCTruthDaughterPtY);
+      fHistogramsMC->Add(fHistMCTruthDaughterPtYAccept);
+      fHistogramsMC->Add(fHistMCTruthPtYHighMult);
+      fHistogramsMC->Add(fHistMCTruthDaughterPtYHighMult);
+      fHistogramsMC->Add(fHistMCTruthDaughterPtYAcceptHighMult);
+      fHistogramsMC->Add(fHistMCTrueSigmaLambdaPtCorr);
+      fHistogramsMC->Add(fHistMCTrueSigmaPhotonPtCorr);
+      fHistogramsMC->Add(fHistMCTrueSigmaLambdaPCorr);
+      fHistogramsMC->Add(fHistMCTrueSigmaPhotonPCorr);
+      fHistogramsMC->Add(fHistMCBkgSigmaLambdaPtCorr);
+      fHistogramsMC->Add(fHistMCBkgSigmaPhotonPtCorr);
+      fHistogramsMC->Add(fHistMCBkgSigmaLambdaPCorr);
+      fHistogramsMC->Add(fHistMCBkgSigmaPhotonPCorr);
+      fHistogramsMC->Add(fHistMCV0Mother);
+      fHistogramsMC->Add(fHistMCV0Check);
+      fHistogramsMC->Add(fHistMCV0MotherCheck);
+    }
 
     fHistograms->Add(fHistogramsMC);
   }

--- a/PWGGA/Hyperon/AliSigma0PhotonMotherCuts.h
+++ b/PWGGA/Hyperon/AliSigma0PhotonMotherCuts.h
@@ -45,10 +45,7 @@ class AliSigma0PhotonMotherCuts : public TObject {
   void FillEventBuffer(
       const std::vector<AliSigma0ParticleV0> &photonCandidates,
       const std::vector<AliSigma0ParticleV0> &lambdaCandidates);
-  float ComputeRapidity(float pt, float pz, float m) const;
-  int GetRapidityBin(float rapidity) const;
   int GetMultiplicityBin(float percentile) const;
-  int GetZvertexBin(float zVertex) const;
   void ProcessMC() const;
   bool CheckDaughters(const AliMCParticle *particle) const;
   bool CheckDaughtersInAcceptance(const AliMCParticle *particle) const;
@@ -110,7 +107,6 @@ class AliSigma0PhotonMotherCuts : public TObject {
     }
   }
 
-
  protected:
   TList *fHistograms;    //!
   TList *fHistogramsMC;  //!
@@ -126,11 +122,10 @@ class AliSigma0PhotonMotherCuts : public TObject {
   std::vector<AliSigma0ParticlePhotonMother> fSidebandUp;    //!
   std::vector<AliSigma0ParticlePhotonMother> fSidebandDown;  //!
 
-  deque<vector<AliSigma0ParticleV0> > fLambdaMixed;                //!
-  deque<vector<AliSigma0ParticleV0> > fPhotonMixed;                //!
-  deque<vector<AliSigma0ParticleV0> > fLambdaMixedBinned[10][22];  //!
-  deque<vector<AliSigma0ParticleV0> > fPhotonMixedBinned[10][22];  //!
-  float fTreeVariables[4];                                         //!
+  deque<vector<AliSigma0ParticleV0> > fLambdaMixed;            //!
+  deque<vector<AliSigma0ParticleV0> > fPhotonMixed;            //!
+  deque<vector<AliSigma0ParticleV0> > fLambdaMixedBinned[14];  //!
+  deque<vector<AliSigma0ParticleV0> > fPhotonMixedBinned[14];  //!
 
   AliSigma0V0Cuts *fLambdaCuts;  //
   AliSigma0V0Cuts *fPhotonCuts;  //
@@ -142,13 +137,13 @@ class AliSigma0PhotonMotherCuts : public TObject {
   int fPDGDaughter1;   //
   int fPDGDaughter2;   //
 
-  float fMassSigma;       //
-  float fSigmaMassCut;    //
-  float fSidebandCutUp;   //
-  float fSidebandCutDown; //
-  float fPhotonPtMin;     //
-  float fPhotonPtMax;     //
-  float fRapidityMax;     //
+  float fMassSigma;        //
+  float fSigmaMassCut;     //
+  float fSidebandCutUp;    //
+  float fSidebandCutDown;  //
+  float fPhotonPtMin;      //
+  float fPhotonPtMax;      //
+  float fRapidityMax;      //
 
   float fArmenterosCut;       //
   float fArmenterosQtLow;     //
@@ -165,22 +160,18 @@ class AliSigma0PhotonMotherCuts : public TObject {
   TH1F *fHistNSigma;                        //!
   TH1F *fHistMassCutPt;                     //!
   TH1F *fHistInvMass;                       //!
-  TH1F *fHistInvMassBeforeArmenteros;       //!
   TH2F *fHistInvMassRecPhoton;              //!
   TH2F *fHistInvMassRecLambda;              //!
   TH2F *fHistInvMassRec;                    //!
   TH2F *fHistInvMassPt;                     //!
-  TH2F *fHistInvMassEta;                    //!
   TH2F *fHistEtaPhi;                        //!
-  TH2F *fHistPtY[22];                       //!
-  TH2F *fHistPtMult[22];                    //!
+  TH2F *fHistPtRapidity;                    //!
+  TH2F *fHistPtMult[14];                    //!
   TH2F *fHistArmenterosBefore;              //!
   TH2F *fHistArmenterosAfter;               //!
-  TH2F *fHistMixedPtY[22];                  //!
-  TH2F *fHistMixedPtMult[22];               //!
+  TH2F *fHistMixedPtMult[14];               //!
   TH2F *fHistMixedInvMassPt;                //!
-  TH2F *fHistMixedInvMassBinnedPt;          //!
-  TH2F *fHistMixedInvMassBinnedMultPt[22];  //!
+  TH2F *fHistMixedInvMassBinnedMultPt[14];  //!
 
   TH2F *fHistLambdaPtPhi;   //!
   TH2F *fHistLambdaPtEta;   //!
@@ -194,18 +185,13 @@ class AliSigma0PhotonMotherCuts : public TObject {
   TH2F *fHistSigmaLambdaPCorr;   //!
   TH2F *fHistSigmaPhotonPCorr;   //!
 
+  TH1F *fHistMCTruthPtMult[14];                   //!
   TH2F *fHistMCTruthPtY;                          //!
-  TH2F *fHistMCTruthPtEta;                        //!
   TH2F *fHistMCTruthDaughterPtY;                  //!
-  TH2F *fHistMCTruthDaughterPtEta;                //!
   TH2F *fHistMCTruthDaughterPtYAccept;            //!
-  TH2F *fHistMCTruthDaughterPtEtaAccept;          //!
   TH2F *fHistMCTruthPtYHighMult;                  //!
-  TH2F *fHistMCTruthPtEtaHighMult;                //!
   TH2F *fHistMCTruthDaughterPtYHighMult;          //!
-  TH2F *fHistMCTruthDaughterPtEtaHighMult;        //!
   TH2F *fHistMCTruthDaughterPtYAcceptHighMult;    //!
-  TH2F *fHistMCTruthDaughterPtEtaAcceptHighMult;  //!
 
   TH2F *fHistMCTrueSigmaLambdaPtCorr;  //!
   TH2F *fHistMCTrueSigmaPhotonPtCorr;  //!
@@ -223,7 +209,7 @@ class AliSigma0PhotonMotherCuts : public TObject {
   TH2F *fHistMCV0MotherCheck;  //!
 
  private:
-  ClassDef(AliSigma0PhotonMotherCuts, 13)
+  ClassDef(AliSigma0PhotonMotherCuts, 14)
 };
 
 #endif

--- a/PWGGA/Hyperon/AliSigma0PhotonMotherCuts.h
+++ b/PWGGA/Hyperon/AliSigma0PhotonMotherCuts.h
@@ -126,11 +126,11 @@ class AliSigma0PhotonMotherCuts : public TObject {
   std::vector<AliSigma0ParticlePhotonMother> fSidebandUp;    //!
   std::vector<AliSigma0ParticlePhotonMother> fSidebandDown;  //!
 
-  deque<vector<AliSigma0ParticleV0> > fLambdaMixed;               //!
-  deque<vector<AliSigma0ParticleV0> > fPhotonMixed;               //!
-  deque<vector<AliSigma0ParticleV0> > fLambdaMixedBinned[10][6];  //!
-  deque<vector<AliSigma0ParticleV0> > fPhotonMixedBinned[10][6];  //!
-  float fTreeVariables[4];                                        //!
+  deque<vector<AliSigma0ParticleV0> > fLambdaMixed;                //!
+  deque<vector<AliSigma0ParticleV0> > fPhotonMixed;                //!
+  deque<vector<AliSigma0ParticleV0> > fLambdaMixedBinned[10][22];  //!
+  deque<vector<AliSigma0ParticleV0> > fPhotonMixedBinned[10][22];  //!
+  float fTreeVariables[4];                                         //!
 
   AliSigma0V0Cuts *fLambdaCuts;  //
   AliSigma0V0Cuts *fPhotonCuts;  //
@@ -142,13 +142,13 @@ class AliSigma0PhotonMotherCuts : public TObject {
   int fPDGDaughter1;   //
   int fPDGDaughter2;   //
 
-  float fMassSigma;        //
-  float fSigmaMassCut;     //
-  float fSidebandCutUp;    //
-  float fSidebandCutDown;  //
-  float fPhotonPtMin;      //
-  float fPhotonPtMax;      //
-  float fRapidityMax;      //
+  float fMassSigma;       //
+  float fSigmaMassCut;    //
+  float fSidebandCutUp;   //
+  float fSidebandCutDown; //
+  float fPhotonPtMin;     //
+  float fPhotonPtMax;     //
+  float fRapidityMax;     //
 
   float fArmenterosCut;       //
   float fArmenterosQtLow;     //
@@ -162,22 +162,25 @@ class AliSigma0PhotonMotherCuts : public TObject {
   // =====================================================================
   TProfile *fHistCutBooking;  //!
 
-  TH1F *fHistNSigma;                   //!
-  TH1F *fHistMassCutPt;                //!
-  TH1F *fHistInvMass;                  //!
-  TH1F *fHistInvMassBeforeArmenteros;  //!
-  TH2F *fHistInvMassRecPhoton;         //!
-  TH2F *fHistInvMassRecLambda;         //!
-  TH2F *fHistInvMassRec;               //!
-  TH2F *fHistInvMassPt;                //!
-  TH2F *fHistInvMassEta;               //!
-  TH2F *fHistEtaPhi;                   //!
-  TH2F *fHistPtY[22];                  //!
-  TH2F *fHistArmenterosBefore;         //!
-  TH2F *fHistArmenterosAfter;          //!
-  TH2F *fHistMixedPtY[22];             //!
-  TH2F *fHistMixedInvMassPt;           //!
-  TH2F *fHistMixedInvMassBinnedPt;     //!
+  TH1F *fHistNSigma;                        //!
+  TH1F *fHistMassCutPt;                     //!
+  TH1F *fHistInvMass;                       //!
+  TH1F *fHistInvMassBeforeArmenteros;       //!
+  TH2F *fHistInvMassRecPhoton;              //!
+  TH2F *fHistInvMassRecLambda;              //!
+  TH2F *fHistInvMassRec;                    //!
+  TH2F *fHistInvMassPt;                     //!
+  TH2F *fHistInvMassEta;                    //!
+  TH2F *fHistEtaPhi;                        //!
+  TH2F *fHistPtY[22];                       //!
+  TH2F *fHistPtMult[22];                    //!
+  TH2F *fHistArmenterosBefore;              //!
+  TH2F *fHistArmenterosAfter;               //!
+  TH2F *fHistMixedPtY[22];                  //!
+  TH2F *fHistMixedPtMult[22];               //!
+  TH2F *fHistMixedInvMassPt;                //!
+  TH2F *fHistMixedInvMassBinnedPt;          //!
+  TH2F *fHistMixedInvMassBinnedMultPt[22];  //!
 
   TH2F *fHistLambdaPtPhi;   //!
   TH2F *fHistLambdaPtEta;   //!

--- a/PWGGA/Hyperon/AliSigma0V0Cuts.cxx
+++ b/PWGGA/Hyperon/AliSigma0V0Cuts.cxx
@@ -394,11 +394,11 @@ AliSigma0V0Cuts *AliSigma0V0Cuts::LambdaCuts() {
   v0Cuts->SetV0DecayVertexMax(100.f);
   v0Cuts->SetPIDnSigma(5.f);
   v0Cuts->SetTPCclusterMin(70.f);
-  v0Cuts->SetEtaMax(0.8);
+  v0Cuts->SetEtaMax(0.9);
   v0Cuts->SetDaughterDCAMax(1.5);
   v0Cuts->SetDaughterDCAtoPV(0.05);
   v0Cuts->SetK0Rejection(0., 0.);
-  v0Cuts->SetLambdaSelection(1.115683 - 0.008, 1.115683 + 0.008);
+  v0Cuts->SetLambdaSelection(1.115683 - 0.005, 1.115683 + 0.005);
   v0Cuts->SetPileUpRejectionMode(OneDaughterCombined);
   v0Cuts->SetChi2Max(4);
   v0Cuts->SetArmenterosCut(0.01, 0.12, 0.3, 0.95);

--- a/PWGGA/Hyperon/AliSigma0V0Cuts.cxx
+++ b/PWGGA/Hyperon/AliSigma0V0Cuts.cxx
@@ -70,7 +70,6 @@ ClassImp(AliSigma0V0Cuts)
       fHistK0Mass(nullptr),
       fHistV0Pt(nullptr),
       fHistV0Mass(nullptr),
-      fHistV0PtY(),
       fHistV0MassPt(nullptr),
       fHistLambdaMassK0Rej(nullptr),
       fHistK0MassAfter(nullptr),
@@ -94,17 +93,11 @@ ClassImp(AliSigma0V0Cuts)
       fHistArmenterosBefore(nullptr),
       fHistArmenterosAfter(nullptr),
       fHistMCTruthV0PtY(nullptr),
-      fHistMCTruthV0PtEta(nullptr),
       fHistMCTruthV0DaughterPtY(nullptr),
-      fHistMCTruthV0DaughterPtEta(nullptr),
       fHistMCTruthV0DaughterPtYAccept(nullptr),
-      fHistMCTruthV0DaughterPtEtaAccept(nullptr),
       fHistMCTruthPtYHighMult(nullptr),
-      fHistMCTruthPtEtaHighMult(nullptr),
       fHistMCTruthDaughterPtYHighMult(nullptr),
-      fHistMCTruthDaughterPtEtaHighMult(nullptr),
       fHistMCTruthDaughterPtYAcceptHighMult(nullptr),
-      fHistMCTruthDaughterPtEtaAcceptHighMult(nullptr),
       fHistMCV0Pt(nullptr),
       fHistV0Mother(nullptr),
       fHistV0MotherTrue(nullptr),
@@ -252,7 +245,6 @@ AliSigma0V0Cuts::AliSigma0V0Cuts(const AliSigma0V0Cuts &ref)
       fHistK0Mass(nullptr),
       fHistV0Pt(nullptr),
       fHistV0Mass(nullptr),
-      fHistV0PtY(),
       fHistV0MassPt(nullptr),
       fHistLambdaMassK0Rej(nullptr),
       fHistK0MassAfter(nullptr),
@@ -276,17 +268,11 @@ AliSigma0V0Cuts::AliSigma0V0Cuts(const AliSigma0V0Cuts &ref)
       fHistArmenterosBefore(nullptr),
       fHistArmenterosAfter(nullptr),
       fHistMCTruthV0PtY(nullptr),
-      fHistMCTruthV0PtEta(nullptr),
       fHistMCTruthV0DaughterPtY(nullptr),
-      fHistMCTruthV0DaughterPtEta(nullptr),
       fHistMCTruthV0DaughterPtYAccept(nullptr),
-      fHistMCTruthV0DaughterPtEtaAccept(nullptr),
       fHistMCTruthPtYHighMult(nullptr),
-      fHistMCTruthPtEtaHighMult(nullptr),
       fHistMCTruthDaughterPtYHighMult(nullptr),
-      fHistMCTruthDaughterPtEtaHighMult(nullptr),
       fHistMCTruthDaughterPtYAcceptHighMult(nullptr),
-      fHistMCTruthDaughterPtEtaAcceptHighMult(nullptr),
       fHistMCV0Pt(nullptr),
       fHistV0Mother(nullptr),
       fHistV0MotherTrue(nullptr),
@@ -933,13 +919,9 @@ bool AliSigma0V0Cuts::LambdaSelection(AliESDv0 *v0) const {
   }
   if (!fIsLightweight) fHistCuts->Fill(16);
 
-  float rap = v0->RapLambda();
-  int rapBin = GetRapidityBin(rap);
-
   fHistV0MassPt->Fill(v0->Pt(), massLambda);
   if (!fIsLightweight) {
     fHistLambdaMassK0Rej->Fill(massLambda);
-    if (rapBin > -1) fHistV0PtY[rapBin]->Fill(v0->Pt(), massLambda);
     fHistK0MassAfter->Fill(massK0);
     fHistEtaPhi->Fill(v0->Eta(), v0->Phi());
   }
@@ -976,12 +958,8 @@ bool AliSigma0V0Cuts::PhotonSelection(AliESDv0 *v0) const {
   }
   if (!fIsLightweight) fHistCuts->Fill(17);
 
-  float rap = ComputeRapidity(v0->Pt(), v0->Pz(), massPhoton);
-  int rapBin = GetRapidityBin(rap);
-
   fHistV0MassPt->Fill(v0->Pt(), massPhoton);
   if (!fIsLightweight) {
-    if (rapBin > -1) fHistV0PtY[rapBin]->Fill(v0->Pt(), massPhoton);
     fHistK0MassAfter->Fill(massK0);
     fHistEtaPhi->Fill(v0->Eta(), v0->Phi());
   }
@@ -998,16 +976,6 @@ bool AliSigma0V0Cuts::PhotonSelection(AliESDv0 *v0) const {
 
   if (!fIsLightweight) fHistCuts->Fill(18);
   return true;
-}
-
-//____________________________________________________________________________________________________
-float AliSigma0V0Cuts::ComputeRapidity(float pt, float pz, float m) const {
-  // calculates rapidity keeping the sign in case E == pz
-
-  float energy = std::sqrt(pt * pt + pz * pz + m * m);
-  if (energy != std::fabs(pz))
-    return 0.5 * std::log((energy + pz) / (energy - pz));
-  return (pz >= 0) ? 1.e30 : -1.e30;
 }
 
 //____________________________________________________________________________________________________
@@ -1127,30 +1095,21 @@ void AliSigma0V0Cuts::ProcessMC() const {
     if (!mcParticle->IsPhysicalPrimary()) continue;
     if (mcParticle->PdgCode() != fPID) continue;
     fHistMCTruthV0PtY->Fill(mcParticle->Y(), mcParticle->Pt());
-    fHistMCTruthV0PtEta->Fill(mcParticle->Eta(), mcParticle->Pt());
     if (lPercentile < fMCHighMultThreshold) {
       fHistMCTruthPtYHighMult->Fill(mcParticle->Y(), mcParticle->Pt());
-      fHistMCTruthPtEtaHighMult->Fill(mcParticle->Eta(), mcParticle->Pt());
     }
 
     if (!CheckDaughters(mcParticle)) continue;
     fHistMCTruthV0DaughterPtY->Fill(mcParticle->Y(), mcParticle->Pt());
-    fHistMCTruthV0DaughterPtEta->Fill(mcParticle->Eta(), mcParticle->Pt());
     if (lPercentile < fMCHighMultThreshold) {
       fHistMCTruthDaughterPtYHighMult->Fill(mcParticle->Y(), mcParticle->Pt());
-      fHistMCTruthDaughterPtEtaHighMult->Fill(mcParticle->Eta(),
-                                              mcParticle->Pt());
     }
 
     if (!CheckDaughtersInAcceptance(mcParticle)) continue;
     fHistMCTruthV0DaughterPtYAccept->Fill(mcParticle->Y(), mcParticle->Pt());
-    fHistMCTruthV0DaughterPtEtaAccept->Fill(mcParticle->Eta(),
-                                            mcParticle->Pt());
     if (lPercentile < fMCHighMultThreshold) {
       fHistMCTruthDaughterPtYAcceptHighMult->Fill(mcParticle->Y(),
                                                   mcParticle->Pt());
-      fHistMCTruthDaughterPtEtaAcceptHighMult->Fill(mcParticle->Eta(),
-                                                    mcParticle->Pt());
     }
   }
 }
@@ -1459,40 +1418,6 @@ bool AliSigma0V0Cuts::CheckDaughtersInAcceptance(
 }
 
 //____________________________________________________________________________________________________
-int AliSigma0V0Cuts::GetRapidityBin(float rapidity) const {
-  if (-10 < rapidity && rapidity <= -1)
-    return 0;
-  else if (-1 < rapidity && rapidity <= -0.5)
-    return 1;
-  else if (-0.5 < rapidity && rapidity <= -0.4)
-    return 2;
-  else if (-0.4 < rapidity && rapidity <= -0.3)
-    return 3;
-  else if (-0.3 < rapidity && rapidity <= -0.2)
-    return 4;
-  else if (-0.2 < rapidity && rapidity <= -0.1)
-    return 5;
-  else if (-0.1 < rapidity && rapidity <= 0.f)
-    return 6;
-  else if (0.f < rapidity && rapidity <= 0.1)
-    return 7;
-  else if (0.1 < rapidity && rapidity <= 0.2)
-    return 8;
-  else if (0.2 < rapidity && rapidity <= 0.3)
-    return 9;
-  else if (0.3 < rapidity && rapidity <= 0.4)
-    return 10;
-  else if (0.4 < rapidity && rapidity <= 0.5)
-    return 11;
-  else if (0.5 < rapidity && rapidity <= 1.f)
-    return 12;
-  else if (1.0 < rapidity && rapidity < 10.f)
-    return 13;
-  else
-    return -1;
-}
-
-//____________________________________________________________________________________________________
 void AliSigma0V0Cuts::InitCutHistograms(TString appendix) {
   std::cout << "============================\n"
             << " V0 CUT CONFIGURATION " << appendix << "\n"
@@ -1525,9 +1450,6 @@ void AliSigma0V0Cuts::InitCutHistograms(TString appendix) {
             << " PDG pos      " << fNegPDG << "\n"
             << "============================\n";
 
-  std::vector<float> rapBins = {{-10., -1.f, -0.5, -0.4, -0.3, -0.2, -0.1, 0.f,
-                                 0.1, 0.2, 0.3, 0.4, 0.5, 1.f, 10.f}};
-
   const float pi = TMath::Pi();
 
   TH1::AddDirectory(kFALSE);
@@ -1543,24 +1465,26 @@ void AliSigma0V0Cuts::InitCutHistograms(TString appendix) {
     fHistograms->SetName(name);
   }
 
-  if (fHistogramsPos != nullptr) {
-    delete fHistogramsPos;
-    fHistogramsPos = nullptr;
-  }
-  if (fHistogramsPos == nullptr) {
-    fHistogramsPos = new TList();
-    fHistogramsPos->SetOwner(kTRUE);
-    fHistogramsPos->SetName("V0_PosDaughter");
-  }
+  if (!fIsLightweight) {
+    if (fHistogramsPos != nullptr) {
+      delete fHistogramsPos;
+      fHistogramsPos = nullptr;
+    }
+    if (fHistogramsPos == nullptr) {
+      fHistogramsPos = new TList();
+      fHistogramsPos->SetOwner(kTRUE);
+      fHistogramsPos->SetName("V0_PosDaughter");
+    }
 
-  if (fHistogramsNeg != nullptr) {
-    delete fHistogramsNeg;
-    fHistogramsNeg = nullptr;
-  }
-  if (fHistogramsNeg == nullptr) {
-    fHistogramsNeg = new TList();
-    fHistogramsNeg->SetOwner(kTRUE);
-    fHistogramsNeg->SetName("V0_NegDaughter");
+    if (fHistogramsNeg != nullptr) {
+      delete fHistogramsNeg;
+      fHistogramsNeg = nullptr;
+    }
+    if (fHistogramsNeg == nullptr) {
+      fHistogramsNeg = new TList();
+      fHistogramsNeg->SetOwner(kTRUE);
+      fHistogramsNeg->SetName("V0_NegDaughter");
+    }
   }
 
   fHistCutBooking = new TProfile("fHistCutBooking", ";;Cut value", 32, 0, 32);
@@ -1746,25 +1670,6 @@ void AliSigma0V0Cuts::InitCutHistograms(TString appendix) {
           new TH2F("fHistPsiPair", "; #it{p}_{T} (GeV/#it{c}); #Psi_{pair}",
                    100, 0, 10, 200, -pi / 2.f, pi / 2.f);
       fHistograms->Add(fHistPsiPair);
-    }
-
-    for (int i = 0; i < static_cast<int>(rapBins.size() - 1); ++i) {
-      if (std::abs(fPID) == 3122) {
-        fHistV0PtY[i] = new TH2F(
-            Form("fHistV0PtY_%.2f_%.2f", rapBins[i], rapBins[i + 1]),
-            Form("%.2f < y < %.2f ; #it{p}_{T} (GeV/#it{c}); Invariant "
-                 "mass (GeV/#it{c}^{2})",
-                 rapBins[i], rapBins[i + 1]),
-            100, 0, 10, 400, 1., 1.2);
-      } else if (std::abs(fPID) == 22) {
-        fHistV0PtY[i] = new TH2F(
-            Form("fHistV0PtY_%.2f_%.2f", rapBins[i], rapBins[i + 1]),
-            Form("%.2f < y < %.2f ; #it{p}_{T} (GeV/#it{c}); Invariant "
-                 "mass (GeV/#it{c}^{2})",
-                 rapBins[i], rapBins[i + 1]),
-            100, 0, 10, 400, 0., 0.4);
-      }
-      fHistograms->Add(fHistV0PtY[i]);
     }
   }
 
@@ -2113,40 +2018,22 @@ void AliSigma0V0Cuts::InitCutHistograms(TString appendix) {
     fHistMCTruthV0PtY =
         new TH2F("fHistMCTruthV0PtY", "; y; #it{p}_{T} (GeV/#it{c})", 100, -10,
                  10, 100, 0, 10);
-    fHistMCTruthV0PtEta =
-        new TH2F("fHistMCTruthV0PtEta", "; #eta; #it{p}_{T} (GeV/#it{c})", 100,
-                 -10, 10, 100, 0, 10);
     fHistMCTruthV0DaughterPtY =
         new TH2F("fHistMCTruthV0DaughterPtY", "; y; #it{p}_{T} (GeV/#it{c})",
                  100, -10, 10, 100, 0, 10);
-    fHistMCTruthV0DaughterPtEta =
-        new TH2F("fHistMCTruthV0DaughterPtEta",
-                 "; #eta; #it{p}_{T} (GeV/#it{c})", 100, -10, 10, 100, 0, 10);
     fHistMCTruthV0DaughterPtYAccept =
         new TH2F("fHistMCTruthV0DaughterPtYAccept",
                  "; y; #it{p}_{T} (GeV/#it{c})", 100, -10, 10, 100, 0, 10);
-    fHistMCTruthV0DaughterPtEtaAccept =
-        new TH2F("fHistMCTruthV0DaughterPtEtaAccept",
-                 "; #eta; #it{p}_{T} (GeV/#it{c})", 100, -10, 10, 100, 0, 10);
 
     fHistMCTruthPtYHighMult =
         new TH2F("fHistMCTruthPtYHighMult", "; y; #it{p}_{T} (GeV/#it{c})", 100,
                  -10, 10, 100, 0, 10);
-    fHistMCTruthPtEtaHighMult =
-        new TH2F("fHistMCTruthPtEtaHighMult", "; #eta; #it{p}_{T} (GeV/#it{c})",
-                 100, -10, 10, 100, 0, 10);
     fHistMCTruthDaughterPtYHighMult =
         new TH2F("fHistMCTruthDaughterPtYHighMult",
                  "; y; #it{p}_{T} (GeV/#it{c})", 100, -10, 10, 100, 0, 10);
-    fHistMCTruthDaughterPtEtaHighMult =
-        new TH2F("fHistMCTruthDaughterPtEtaHighMult",
-                 "; #eta; #it{p}_{T} (GeV/#it{c})", 100, -10, 10, 100, 0, 10);
     fHistMCTruthDaughterPtYAcceptHighMult =
         new TH2F("fHistMCTruthDaughterPtYAcceptHighMult",
                  "; y; #it{p}_{T} (GeV/#it{c})", 100, -10, 10, 100, 0, 10);
-    fHistMCTruthDaughterPtEtaAcceptHighMult =
-        new TH2F("fHistMCTruthDaughterPtEtaAcceptHighMult",
-                 "; #eta; #it{p}_{T} (GeV/#it{c})", 100, -10, 10, 100, 0, 10);
 
     fHistMCV0Pt = new TH1F("fHistMCV0Pt", "; #it{p}_{T} (GeV/#it{c}); Entries",
                            100, 0, 10);
@@ -2156,17 +2043,11 @@ void AliSigma0V0Cuts::InitCutHistograms(TString appendix) {
                  100, 0, 10, 4000, 0, 4000);
 
     fHistogramsMC->Add(fHistMCTruthV0PtY);
-    fHistogramsMC->Add(fHistMCTruthV0PtEta);
     fHistogramsMC->Add(fHistMCTruthV0DaughterPtY);
-    fHistogramsMC->Add(fHistMCTruthV0DaughterPtEta);
     fHistogramsMC->Add(fHistMCTruthV0DaughterPtYAccept);
-    fHistogramsMC->Add(fHistMCTruthV0DaughterPtEtaAccept);
     fHistogramsMC->Add(fHistMCTruthPtYHighMult);
-    fHistogramsMC->Add(fHistMCTruthPtEtaHighMult);
     fHistogramsMC->Add(fHistMCTruthDaughterPtYHighMult);
-    fHistogramsMC->Add(fHistMCTruthDaughterPtEtaHighMult);
     fHistogramsMC->Add(fHistMCTruthDaughterPtYAcceptHighMult);
-    fHistogramsMC->Add(fHistMCTruthDaughterPtEtaAcceptHighMult);
     fHistogramsMC->Add(fHistMCV0Pt);
     fHistogramsMC->Add(fHistV0Mother);
 

--- a/PWGGA/Hyperon/AliSigma0V0Cuts.cxx
+++ b/PWGGA/Hyperon/AliSigma0V0Cuts.cxx
@@ -399,7 +399,7 @@ AliSigma0V0Cuts *AliSigma0V0Cuts::LambdaCuts() {
   v0Cuts->SetDaughterDCAtoPV(0.05);
   v0Cuts->SetK0Rejection(0., 0.);
   v0Cuts->SetLambdaSelection(1.115683 - 0.005, 1.115683 + 0.005);
-  v0Cuts->SetPileUpRejectionMode(OneDaughterCombined);
+  v0Cuts->SetPileUpRejectionMode(BothDaughtersCombined);
   v0Cuts->SetChi2Max(4);
   v0Cuts->SetArmenterosCut(0.01, 0.12, 0.3, 0.95);
   return v0Cuts;

--- a/PWGGA/Hyperon/AliSigma0V0Cuts.h
+++ b/PWGGA/Hyperon/AliSigma0V0Cuts.h
@@ -52,11 +52,9 @@ class AliSigma0V0Cuts : public TObject {
   void PlotMasses(AliESDv0 *v0) const;
   bool LambdaSelection(AliESDv0 *v0) const;
   bool PhotonSelection(AliESDv0 *v0) const;
-  float ComputeRapidity(float pt, float pz, float m) const;
   float ComputePhotonMass(const AliESDv0 *v0) const;
   float ComputePhotonMassRefit(const AliESDv0 *v0) const;
   float ComputePsiPair(const AliESDv0 *v0) const;
-  int GetRapidityBin(float rapidity) const;
 
   void SetLightweight(bool isLightweight) { fIsLightweight = isLightweight; }
   void SetCheckCutsMC(bool checkCuts) { fCheckCutsMC = checkCuts; }
@@ -197,7 +195,6 @@ class AliSigma0V0Cuts : public TObject {
   TH1F *fHistK0Mass;           //!
   TH1F *fHistV0Pt;             //!
   TH1F *fHistV0Mass;           //!
-  TH2F *fHistV0PtY[20];        //!
   TH2F *fHistV0MassPt;         //!
   TH1F *fHistLambdaMassK0Rej;  //!
   TH1F *fHistK0MassAfter;      //!
@@ -223,17 +220,11 @@ class AliSigma0V0Cuts : public TObject {
   TH2F *fHistArmenterosAfter;         //!
 
   TH2F *fHistMCTruthV0PtY;                        //!
-  TH2F *fHistMCTruthV0PtEta;                      //!
   TH2F *fHistMCTruthV0DaughterPtY;                //!
-  TH2F *fHistMCTruthV0DaughterPtEta;              //!
   TH2F *fHistMCTruthV0DaughterPtYAccept;          //!
-  TH2F *fHistMCTruthV0DaughterPtEtaAccept;        //!
   TH2F *fHistMCTruthPtYHighMult;                  //!
-  TH2F *fHistMCTruthPtEtaHighMult;                //!
   TH2F *fHistMCTruthDaughterPtYHighMult;          //!
-  TH2F *fHistMCTruthDaughterPtEtaHighMult;        //!
   TH2F *fHistMCTruthDaughterPtYAcceptHighMult;    //!
-  TH2F *fHistMCTruthDaughterPtEtaAcceptHighMult;  //!
   TH1F *fHistMCV0Pt;                              //!
 
   TH2F *fHistV0Mother;                                        //!
@@ -320,7 +311,7 @@ class AliSigma0V0Cuts : public TObject {
   TH2F *fHistSingleParticlePID[2];                         //!
 
  private:
-  ClassDef(AliSigma0V0Cuts, 8)
+  ClassDef(AliSigma0V0Cuts, 9)
 };
 
 #endif

--- a/PWGGA/Hyperon/macros/AddTaskSigma0Run2syst.C
+++ b/PWGGA/Hyperon/macros/AddTaskSigma0Run2syst.C
@@ -313,7 +313,8 @@ AliAnalysisTaskSE *AddTaskSigma0Run2syst(bool isMC = false,
   AliSigma0PhotonMotherCuts *antiSigmaCuts =
       AliSigma0PhotonMotherCuts::DefaultCuts();
   antiSigmaCuts->SetIsMC(isMC);
-  antiSigmaCuts->SetPDG(3212, 3122, 22);
+  // Fixed sign of PDG Codes.
+  antiSigmaCuts->SetPDG(-3212, -3122, 22);
   antiSigmaCuts->SetSigmaMassCut(0.2);
   antiSigmaCuts->SetLambdaCuts(antiv0Cuts);
   antiSigmaCuts->SetV0ReaderName(V0ReaderName.Data());


### PR DESCRIPTION
- FemtoDream
  - Propagate MC information in ESD case for tracks
  - Remove Sumw2() for track, V0 and cascade histos
  - By default the proton/V0 origin histograms vs. multiplicity are not initialized


- Sigma0 Analysis
  - Introducing systematic cut variations (62)
  - Multiplicity-binned analysis
  - Histogram improvements
  - Minor cleaning of the selection criteria