### PR TITLE
For periods with EMCal triggers but no TPC load the kCaloOnly bit 

### DIFF
--- a/PWGGA/CaloTrackCorrelations/macros/CheckActiveEMCalTriggerPerPeriod.C
+++ b/PWGGA/CaloTrackCorrelations/macros/CheckActiveEMCalTriggerPerPeriod.C
@@ -28,13 +28,13 @@
 /// The options that can be passed to the macro are:
 ///
 /// \param simulation: bool with data (0) or MC (1) condition
-/// \param trigger: trigger string name (EMCAL_L0, EMCAL_L1, EMCAL_L2, DCAL_L0, DCAL_L1, DCAL_L2)
-/// \param period: LHCXX
+/// \param trigger: trigger string name (EMCAL_L0, EMCAL_L1, EMCAL_L2, DCAL_L0, DCAL_L1, DCAL_L2), it can be modified for CaloOnly periods.
+/// \param period: LHCXXx
 /// \param year: 2011, ...
 ///
 /// \return True if analysis can be done.
 ///
-Bool_t CheckActiveEMCalTriggerPerPeriod(Bool_t simulation, TString trigger, TString period, Int_t year)
+Bool_t CheckActiveEMCalTriggerPerPeriod(Bool_t simulation, TString & trigger, TString period, Int_t year)
 {
   // Accept directly all MB kind of events
   //
@@ -180,6 +180,16 @@ Bool_t CheckActiveEMCalTriggerPerPeriod(Bool_t simulation, TString trigger, TStr
            trigger.Data(),period.Data());
     
     return kFALSE;
+  }
+  
+  // Some periods with triggered events do not have TPC and the trigger mask is kCaloOnly, 
+  // indicate this via the trigger string, so that in macro ConfigureAndGetEventTriggerMaskAndCaloTriggerString.C
+  // the proper trigger mask AliVEvent::kCaloOnly is applied.
+  if ( !trigger.Contains("CaloOnly") && 
+      ( period == "LHC15n" || period == "LHC17p" || period == "LHC17q") ) 
+  {
+    trigger+="_CaloOnly";
+    printf("CheckActiveEMCalTriggerPerPeriod() - Add <_CaloOnly> to trigger string: %s!!!\n",trigger.Data());
   }
   
   return kTRUE;

--- a/PWGGA/CaloTrackCorrelations/macros/ConfigureAndGetEventTriggerMaskAndCaloTriggerString.C
+++ b/PWGGA/CaloTrackCorrelations/macros/ConfigureAndGetEventTriggerMaskAndCaloTriggerString.C
@@ -31,48 +31,63 @@
 UInt_t ConfigureAndGetEventTriggerMaskAndCaloTriggerString
 (TString trigger, Int_t year, TString & triggerString)
 {
-  //printf("ConfigureAndGetEventTriggerCaloTrackCorr - Set event trigger class for %s in year %d\n",
-  //       trigger.Data(),year);
+  printf("ConfigureAndGetEventTriggerCaloTrackCorr - Set event trigger class for %s in year %d\n",
+         trigger.Data(),year);
   
   triggerString = "";
   
+  UInt_t mask = AliVEvent::kAny;
+  
   if( trigger.Contains("INT") || trigger.Contains("MB") || trigger.Contains("default") )
   {
-    return ( AliVEvent::kINT7 | AliVEvent::kMB );
+    mask = ( AliVEvent::kINT7 | AliVEvent::kMB );
+    printf("ConfigureAndGetEventTriggerCaloTrackCorr - Set MB/INT7 mask %d\n",mask);
   }
   else if(trigger.Contains("EMCAL_L0"))
   {
     triggerString = "EMC";
-    return ( AliVEvent::kEMC7 | AliVEvent::kEMC8 | AliVEvent::kEMC1 );
+    mask = ( AliVEvent::kEMC7 | AliVEvent::kEMC8 | AliVEvent::kEMC1 );
+    printf("ConfigureAndGetEventTriggerCaloTrackCorr - Set L0 EMC1/7/8 mask %d and string %s\n",mask,triggerString.Data());
   }
   else if(trigger.Contains("DCAL_L0"))
   {
     triggerString = "DMC";
-    return ( AliVEvent::kEMC7 | AliVEvent::kEMC8 | AliVEvent::kEMC1 );
+    mask = ( AliVEvent::kEMC7 | AliVEvent::kEMC8 | AliVEvent::kEMC1 );
+    printf("ConfigureAndGetEventTriggerCaloTrackCorr - Set L0 EMC1/7/8 mask %d and string %s\n",mask,triggerString.Data());
   }
   else if(trigger.Contains("EMCAL_L1"))
   {
     if(year > 2012) triggerString = "EG1";
     // before 2013 only one kind of L1 trigger
     
-    return ( AliVEvent::kEMCEGA );
+    mask = ( AliVEvent::kEMCEGA );
+    printf("ConfigureAndGetEventTriggerCaloTrackCorr - Set L1 EMCEGA mask %d and string %s\n",mask,triggerString.Data());
   }
   else if(trigger.Contains("DCAL_L1"))
   {
     triggerString = "DG1";
-    return ( AliVEvent::kEMCEGA );
+    mask = ( AliVEvent::kEMCEGA );
+    printf("ConfigureAndGetEventTriggerCaloTrackCorr - Set L1 EMCEGA mask %d and string %s\n",mask,triggerString.Data());
   }
   else if(trigger.Contains("EMCAL_L2"))
   {
     triggerString = "EG2";
-    return ( AliVEvent::kEMCEGA );
+    mask = ( AliVEvent::kEMCEGA );
+    printf("ConfigureAndGetEventTriggerCaloTrackCorr - Set L1 EMCEGA mask %d and string %s\n",mask,triggerString.Data());
   }
   else if(trigger.Contains("DCAL_L2"))
   {
     triggerString = "DG2";
-    return ( AliVEvent::kEMCEGA );
+    mask = ( AliVEvent::kEMCEGA );
+    printf("ConfigureAndGetEventTriggerCaloTrackCorr - Set L1 EMCEGA mask %d and string %s\n",mask,triggerString.Data());
   }
   
-  return 0;
+  if ( trigger.Contains("CaloOnly") )
+  {
+    mask = AliVEvent::kCaloOnly;
+    printf("\t Periods without TPC, change trigger mask %d!!!!\n",mask);
+  }
+  
+  return mask;
 }
 


### PR DESCRIPTION
instead of the usual kEMC*. This applies right now to LHC15n and LHC17pq.