### PR TITLE
Added JEWEL generator scripts, taking configuration as input

### DIFF
--- a/PWG/MCLEGO/JEWEL/gen_jewel_user.sh
+++ b/PWG/MCLEGO/JEWEL/gen_jewel_user.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+if [[ $# -lt 3 ]]; then
+    echo "You must specify exactly 3 parameters."
+    exit -1
+fi
+
+echo "running in `pwd`, writing HepMC to $1"
+
+# prepare environment
+source /cvmfs/alice.cern.ch/etc/login.sh
+eval $(alienv printenv JEWEL::v2.0.2-2)
+
+# take configuration from arguments
+echo -e "$2" >> params-simple.dat
+echo -e "$3" >> medium-params.dat
+
+# Add NJOB to time-based random seed
+nrandom=`date '+%d%H%M%S'`
+sed -i "1s/^/NJOB $nrandom\n/" ./params-simple.dat
+
+# run JEWEL
+jewel-2.0.2-simple params-simple.dat

--- a/PWG/MCLEGO/JEWEL/gen_jewel_vacuum_user.sh
+++ b/PWG/MCLEGO/JEWEL/gen_jewel_vacuum_user.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+if [[ $# -lt 2 ]]; then
+    echo "You must specify exactly 2 parameters."
+    exit -1
+fi
+
+echo "running in `pwd`, writing HepMC to $1"
+
+# prepare environment
+source /cvmfs/alice.cern.ch/etc/login.sh
+eval $(alienv printenv JEWEL::v2.0.2-2)
+
+# take configuration from arguments
+echo -e "$2" >> params-simple.dat
+
+# Add NJOB to time-based random seed
+nrandom=`date '+%d%H%M%S'`
+sed -i "1s/^/NJOB $nrandom\n/" ./params-simple.dat
+
+# run JEWEL
+jewel-2.0.2-vac params-simple.dat


### PR DESCRIPTION
The commit add external MC generator shell scripts to run JEWEL (medium & vacuum mode). The configuration files can be given as parameters to the shell script.

The code was tested locally and worked fine.

This PR is connected to a PR in AliRoot: https://github.com/alisw/AliRoot/pull/818