### PR TITLE
[ALIROOT-7981]: Fixes to D2H macros for ROOT6 compatibility

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSEImproveITS.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEImproveITS.cxx
@@ -227,132 +227,104 @@ AliAnalysisTaskSEImproveITS::AliAnalysisTaskSEImproveITS(const char *name,
   TFile *resfileCur=TFile::Open(resfileCurURI.Data());
   if(resfileCur) {    
     if(resfileCur->Get("D0RPResP" )) {
-      fD0RPResPCur =new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0RPResP" )));
-      fD0RPResPCur ->SetName("D0RPResPCur" );
+      fD0RPResPCur =(TGraph*)(resfileCur->Get("D0RPResP" )->Clone("D0RPResPCur" ));
     }
     if(resfileCur->Get("D0RPResK" )) {
-      fD0RPResKCur =new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0RPResK" )));
-      fD0RPResKCur ->SetName("D0RPResKCur" );
+      fD0RPResKCur =(TGraph*)(resfileCur->Get("D0RPResK" )->Clone("D0RPResKCur" ));
     }
     if(resfileCur->Get("D0RPResPi")) {
-      fD0RPResPiCur=new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0RPResPi")));
-      fD0RPResPiCur->SetName("D0RPResPiCur");
+      fD0RPResPiCur=(TGraph*)(resfileCur->Get("D0RPResPi")->Clone("D0RPResPiCur"));
     }
     if(resfileCur->Get("D0RPResE")) {
-      fD0RPResECur=new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0RPResE")));
-      fD0RPResECur->SetName("D0RPResECur");
+      fD0RPResECur=(TGraph*)(resfileCur->Get("D0RPResE")->Clone("D0RPResECur"));
     }
     if(resfileCur->Get("D0RPSigmaPullRatioP" )) {
-      fD0RPSigmaPullRatioP =new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0RPSigmaPullRatioP" )));
+      fD0RPSigmaPullRatioP =(TGraph*)(resfileCur->Get("D0RPSigmaPullRatioP" ));
     }
     if(resfileCur->Get("D0RPSigmaPullRatioK" )) {
-      fD0RPSigmaPullRatioK =new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0RPSigmaPullRatioK" )));
+      fD0RPSigmaPullRatioK =(TGraph*)(resfileCur->Get("D0RPSigmaPullRatioK" ));
     }
     if(resfileCur->Get("D0RPSigmaPullRatioPi")) {
-      fD0RPSigmaPullRatioPi=new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0RPSigmaPullRatioPi")));
+      fD0RPSigmaPullRatioPi=(TGraph*)(resfileCur->Get("D0RPSigmaPullRatioPi"));
     }
     if(resfileCur->Get("D0RPSigmaPullRatioE")) {
-      fD0RPSigmaPullRatioE=new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0RPSigmaPullRatioE")));
+      fD0RPSigmaPullRatioE=(TGraph*)(resfileCur->Get("D0RPSigmaPullRatioE"));
     }
     for(Int_t j=0; j<2; j++){
       for(Int_t i=0; i<4; i++){
 	if(resfileCur->Get(Form("D0RPMeanP_B%d_phi%d",j,i))) {
-	  fD0RPMeanPCur[j][i]=new TGraph(*static_cast<TGraph*>(resfileCur->Get(Form("D0RPMeanP_B%d_phi%d",j,i))));
-	  fD0RPMeanPCur[j][i]->SetName(Form("D0RPMeanPCur_B%d_phi%d",j,i));
+	  fD0RPMeanPCur[j][i]=(TGraph*)(resfileCur->Get(Form("D0RPMeanP_B%d_phi%d",j,i))->Clone(Form("D0RPMeanPCur_B%d_phi%d",j,i)));
 	}
 	if(resfileCur->Get(Form("D0RPMeanK_B%d_phi%d",j,i))) {
-	  fD0RPMeanKCur[j][i]=new TGraph(*static_cast<TGraph*>(resfileCur->Get(Form("D0RPMeanK_B%d_phi%d",j,i))));
-	  fD0RPMeanKCur[j][i]->SetName(Form("D0RPMeanKCur_B%d_phi%d",j,i));
+	  fD0RPMeanKCur[j][i]=(TGraph*)(resfileCur->Get(Form("D0RPMeanK_B%d_phi%d",j,i))->Clone(Form("D0RPMeanKCur_B%d_phi%d",j,i)));
 	}
 	if(resfileCur->Get(Form("D0RPMeanPi_B%d_phi%d",j,i))) {
-	  fD0RPMeanPiCur[j][i]=new TGraph(*static_cast<TGraph*>(resfileCur->Get(Form("D0RPMeanPi_B%d_phi%d",j,i))));
-	  fD0RPMeanPiCur[j][i]->SetName(Form("D0RPMeanPiCur_B%d_phi%d",j,i));
+	  fD0RPMeanPiCur[j][i]=(TGraph*)(resfileCur->Get(Form("D0RPMeanPi_B%d_phi%d",j,i))->Clone(Form("D0RPMeanPiCur_B%d_phi%d",j,i)));
 	}
 	if(resfileCur->Get(Form("D0RPMeanE_B%d_phi%d",j,i))) {
-	  fD0RPMeanECur[j][i]=new TGraph(*static_cast<TGraph*>(resfileCur->Get(Form("D0RPMeanE_B%d_phi%d",j,i))));
-	  fD0RPMeanECur[j][i]->SetName(Form("D0RPMeanECur_B%d_phi%d",j,i));
+	  fD0RPMeanECur[j][i]=(TGraph*)(resfileCur->Get(Form("D0RPMeanE_B%d_phi%d",j,i))->Clone(Form("D0RPMeanECur_B%d_phi%d",j,i)));
 	}
       }
     }
     if(resfileCur->Get("D0ZResP"  )) {
-      fD0ZResPCur  =new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0ZResP"  )));
-      fD0ZResPCur  ->SetName("D0ZResPCur"  );
+      fD0ZResPCur  =(TGraph*)(resfileCur->Get("D0ZResP"  )->Clone("D0ZResPCur"  ));
     }
     if(resfileCur->Get("D0ZResK"  )) {
-      fD0ZResKCur  =new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0ZResK"  )));
-      fD0ZResKCur  ->SetName("D0ZResKCur"  );
+      fD0ZResKCur  =(TGraph*)(resfileCur->Get("D0ZResK"  )->Clone("D0ZResKCur"  ));
     }
     if(resfileCur->Get("D0ZResPi" )) {
-      fD0ZResPiCur =new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0ZResPi" )));
-      fD0ZResPiCur ->SetName("D0ZResPiCur" );
+      fD0ZResPiCur =(TGraph*)(resfileCur->Get("D0ZResPi" )->Clone("D0ZResPiCur" ));
     }
     if(resfileCur->Get("D0ZResE" )) {
-      fD0ZResECur =new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0ZResE" )));
-      fD0ZResECur ->SetName("D0ZResECur" );
+      fD0ZResECur =(TGraph*)(resfileCur->Get("D0ZResE" )->Clone("D0ZResECur" ));
     }
     if(resfileCur->Get("Pt1ResP"  )) {
-      fPt1ResPCur  =new TGraph(*static_cast<TGraph*>(resfileCur->Get("Pt1ResP"  )));
-      fPt1ResPCur  ->SetName("Pt1ResPCur"  );
+      fPt1ResPCur  =(TGraph*)(resfileCur->Get("Pt1ResP"  )->Clone("Pt1ResPCur"  ));
     }
     if(resfileCur->Get("Pt1ResK"  )) {
-      fPt1ResKCur  =new TGraph(*static_cast<TGraph*>(resfileCur->Get("Pt1ResK"  )));
-      fPt1ResKCur  ->SetName("Pt1ResKCur"  );
+      fPt1ResKCur  =(TGraph*)(resfileCur->Get("Pt1ResK"  )->Clone("Pt1ResKCur"  ));
     }
     if(resfileCur->Get("Pt1ResPi" )) {
-      fPt1ResPiCur =new TGraph(*static_cast<TGraph*>(resfileCur->Get("Pt1ResPi" )));
-      fPt1ResPiCur ->SetName("Pt1ResPiCur" );
+      fPt1ResPiCur =(TGraph*)(resfileCur->Get("Pt1ResPi" )->Clone("Pt1ResPiCur" ));
     }
     if(resfileCur->Get("Pt1ResE" )) {
-      fPt1ResECur =new TGraph(*static_cast<TGraph*>(resfileCur->Get("Pt1ResE" )));
-      fPt1ResECur ->SetName("Pt1ResECur" );
+      fPt1ResECur =(TGraph*)(resfileCur->Get("Pt1ResE" )->Clone("Pt1ResECur" ));
     }
     if(resfileCur->Get("D0RPResPSA" )) {
-      fD0RPResPCurSA =new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0RPResPSA" )));
-      fD0RPResPCurSA ->SetName("D0RPResPCurSA" );
+      fD0RPResPCurSA =(TGraph*)(resfileCur->Get("D0RPResPSA" )->Clone("D0RPResPCurSA" ));
     }
     if(resfileCur->Get("D0RPResKSA" )) {
-      fD0RPResKCurSA =new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0RPResKSA" )));
-      fD0RPResKCurSA ->SetName("D0RPResKCurSA" );
+      fD0RPResKCurSA =(TGraph*)(resfileCur->Get("D0RPResKSA" )->Clone("D0RPResKCurSA" ));
     }
     if(resfileCur->Get("D0RPResPiSA")) {
-      fD0RPResPiCurSA=new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0RPResPiSA")));
-      fD0RPResPiCurSA->SetName("D0RPResPiCurSA");
+      fD0RPResPiCurSA=(TGraph*)(resfileCur->Get("D0RPResPiSA")->Clone("D0RPResPiCurSA"));
     }
     if(resfileCur->Get("D0RPResESA")) {
-      fD0RPResECurSA=new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0RPResESA")));
-      fD0RPResECurSA->SetName("D0RPResECurSA");
+      fD0RPResECurSA=(TGraph*)(resfileCur->Get("D0RPResESA")->Clone("D0RPResECurSA"));
     }
     if(resfileCur->Get("D0ZResPSA"  )) {
-      fD0ZResPCurSA  =new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0ZResPSA"  )));
-      fD0ZResPCurSA  ->SetName("D0ZResPCurSA"  );
+      fD0ZResPCurSA  =(TGraph*)(resfileCur->Get("D0ZResPSA"  )->Clone("D0ZResPCurSA"  ));
     }
     if(resfileCur->Get("D0ZResKSA"  )) {
-      fD0ZResKCurSA  =new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0ZResKSA"  )));
-      fD0ZResKCurSA  ->SetName("D0ZResKCurSA"  );
+      fD0ZResKCurSA  =(TGraph*)(resfileCur->Get("D0ZResKSA"  )->Clone("D0ZResKCurSA"  ));
     }
     if(resfileCur->Get("D0ZResPiSA" )) {
-      fD0ZResPiCurSA =new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0ZResPiSA" )));
-      fD0ZResPiCurSA ->SetName("D0ZResPiCurSA" );
+      fD0ZResPiCurSA =(TGraph*)(resfileCur->Get("D0ZResPiSA" )->Clone("D0ZResPiCurSA" ));
     }
     if(resfileCur->Get("D0ZResESA" )) {
-      fD0ZResECurSA =new TGraph(*static_cast<TGraph*>(resfileCur->Get("D0ZResESA" )));
-      fD0ZResECurSA ->SetName("D0ZResECurSA" );
+      fD0ZResECurSA =(TGraph*)(resfileCur->Get("D0ZResESA" )->Clone("D0ZResECurSA" ));
     }
     if(resfileCur->Get("Pt1ResPSA"  )) {
-      fPt1ResPCurSA  =new TGraph(*static_cast<TGraph*>(resfileCur->Get("Pt1ResPSA"  )));
-      fPt1ResPCurSA  ->SetName("Pt1ResPCurSA"  );
+      fPt1ResPCurSA  =(TGraph*)(resfileCur->Get("Pt1ResPSA"  )->Clone("Pt1ResPCurSA"  ));
     }
     if(resfileCur->Get("Pt1ResKSA"  )) {
-      fPt1ResKCurSA  =new TGraph(*static_cast<TGraph*>(resfileCur->Get("Pt1ResKSA"  )));
-      fPt1ResKCurSA  ->SetName("Pt1ResKCurSA"  );
+      fPt1ResKCurSA  =(TGraph*)(resfileCur->Get("Pt1ResKSA"  )->Clone("Pt1ResKCurSA"  ));
     }
     if(resfileCur->Get("Pt1ResPiSA" )) {
-      fPt1ResPiCurSA =new TGraph(*static_cast<TGraph*>(resfileCur->Get("Pt1ResPiSA" )));
-      fPt1ResPiCurSA ->SetName("Pt1ResPiCurSA" );
+      fPt1ResPiCurSA =(TGraph*)(resfileCur->Get("Pt1ResPiSA" )->Clone("Pt1ResPiCurSA" ));
     }
     if(resfileCur->Get("Pt1ResESA" )) {
-      fPt1ResECurSA =new TGraph(*static_cast<TGraph*>(resfileCur->Get("Pt1ResESA" )));
-      fPt1ResECurSA ->SetName("Pt1ResECurSA" );
+      fPt1ResECurSA =(TGraph*)(resfileCur->Get("Pt1ResESA" )->Clone("Pt1ResECurSA" ));
     }
     delete resfileCur;
   }
@@ -361,132 +333,104 @@ AliAnalysisTaskSEImproveITS::AliAnalysisTaskSEImproveITS(const char *name,
   TFile *resfileUpg=TFile::Open(resfileUpgURI.Data());
   if(resfileUpg) {
     if(resfileUpg->Get("D0RPResP" )) {
-      fD0RPResPUpg =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("D0RPResP" )));
-      fD0RPResPUpg ->SetName("D0RPResPUpg" );
+      fD0RPResPUpg =(TGraph*)(resfileUpg->Get("D0RPResP" )->Clone("D0RPResPUpg" ));
     }
     if(resfileUpg->Get("D0RPResK" )) {
-      fD0RPResKUpg =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("D0RPResK" )));
-      fD0RPResKUpg ->SetName("D0RPResKUpg" );
+      fD0RPResKUpg =(TGraph*)(resfileUpg->Get("D0RPResK" )->Clone("D0RPResKUpg" ));
     }
     if(resfileUpg->Get("D0RPResPi")) {
-      fD0RPResPiUpg=new TGraph(*static_cast<TGraph*>(resfileUpg->Get("D0RPResPi")));
-      fD0RPResPiUpg->SetName("D0RPResPiUpg");
+      fD0RPResPiUpg=(TGraph*)(resfileUpg->Get("D0RPResPi")->Clone("D0RPResPiUpg"));
     }
     if(resfileUpg->Get("D0RPResE")) {
-      fD0RPResEUpg=new TGraph(*static_cast<TGraph*>(resfileUpg->Get("D0RPResE")));
-      fD0RPResEUpg->SetName("D0RPResEUpg");
+      fD0RPResEUpg=(TGraph*)(resfileUpg->Get("D0RPResE")->Clone("D0RPResEUpg"));
     }
     for(Int_t j=0; j<2; j++){
       for(Int_t i=0; i<4; i++){
 	if(resfileUpg->Get(Form("D0RPMeanP_B%d_phi%d",j,i))) {
-	  fD0RPMeanPUpg[j][i]=new TGraph(*static_cast<TGraph*>(resfileUpg->Get(Form("D0RPMeanP_B%d_phi%d",j,i))));
-	  fD0RPMeanPUpg[j][i]->SetName(Form("D0RPMeanPUpg_B%d_phi%d",j,i));
+	  fD0RPMeanPUpg[j][i]=(TGraph*)(resfileUpg->Get(Form("D0RPMeanP_B%d_phi%d",j,i))->Clone(Form("D0RPMeanPUpg_B%d_phi%d",j,i)));
 	}
 	if(resfileUpg->Get(Form("D0RPMeanK_B%d_phi%d",j,i))) {
-	  fD0RPMeanKUpg[j][i]=new TGraph(*static_cast<TGraph*>(resfileUpg->Get(Form("D0RPMeanK_B%d_phi%d",j,i))));
-	  fD0RPMeanKUpg[j][i]->SetName(Form("D0RPMeanKUpg_B%d_phi%d",j,i));
+	  fD0RPMeanKUpg[j][i]=(TGraph*)(resfileUpg->Get(Form("D0RPMeanK_B%d_phi%d",j,i))->Clone(Form("D0RPMeanKUpg_B%d_phi%d",j,i)));
 	}
 	if(resfileUpg->Get(Form("D0RPMeanPi_B%d_phi%d",j,i))) {
-	  fD0RPMeanPiUpg[j][i]=new TGraph(*static_cast<TGraph*>(resfileUpg->Get(Form("D0RPMeanPi_B%d_phi%d",j,i))));
-	  fD0RPMeanPiUpg[j][i]->SetName(Form("D0RPMeanPiUpg_B%d_phi%d",j,i));
+	  fD0RPMeanPiUpg[j][i]=(TGraph*)(resfileUpg->Get(Form("D0RPMeanPi_B%d_phi%d",j,i))->Clone(Form("D0RPMeanPiUpg_B%d_phi%d",j,i)));
 	}
 	if(resfileUpg->Get(Form("D0RPMeanE_B%d_phi%d",j,i))) {
-	  fD0RPMeanEUpg[j][i]=new TGraph(*static_cast<TGraph*>(resfileUpg->Get(Form("D0RPMeanE_B%d_phi%d",j,i))));
-	  fD0RPMeanEUpg[j][i]->SetName(Form("D0RPMeanEUpg_B%d_phi%d",j,i));
+	  fD0RPMeanEUpg[j][i]=(TGraph*)(resfileUpg->Get(Form("D0RPMeanE_B%d_phi%d",j,i))->Clone(Form("D0RPMeanEUpg_B%d_phi%d",j,i)));
 	}
       }
     }
     if(resfileUpg->Get("D0ZResP"  )) {
-      fD0ZResPUpg  =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("D0ZResP"  )));
-      fD0ZResPUpg  ->SetName("D0ZResPUpg"  );
+      fD0ZResPUpg  =(TGraph*)(resfileUpg->Get("D0ZResP"  )->Clone("D0ZResPUpg"  ));
     }
     if(resfileUpg->Get("D0ZResK"  )) {
-      fD0ZResKUpg  =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("D0ZResK"  )));
-      fD0ZResKUpg  ->SetName("D0ZResKUpg"  );
+      fD0ZResKUpg  =(TGraph*)(resfileUpg->Get("D0ZResK"  )->Clone("D0ZResKUpg"  ));
     }
     if(resfileUpg->Get("D0ZResPi" )) {
-      fD0ZResPiUpg =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("D0ZResPi" )));
-      fD0ZResPiUpg ->SetName("D0ZResPiUpg" );
+      fD0ZResPiUpg =(TGraph*)(resfileUpg->Get("D0ZResPi" )->Clone("D0ZResPiUpg" ));
     }
     if(resfileUpg->Get("D0ZResE" )) {
-      fD0ZResEUpg =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("D0ZResE" )));
-      fD0ZResEUpg ->SetName("D0ZResEUpg" );
+      fD0ZResEUpg =(TGraph*)(resfileUpg->Get("D0ZResE" )->Clone("D0ZResEUpg" ));
     }
     if(resfileUpg->Get("Pt1ResP"  )) {
-      fPt1ResPUpg  =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("Pt1ResP"  )));
-      fPt1ResPUpg  ->SetName("Pt1ResPUpg"  );
+      fPt1ResPUpg  =(TGraph*)(resfileUpg->Get("Pt1ResP"  )->Clone("Pt1ResPUpg"  ));
     }
     if(resfileUpg->Get("Pt1ResK"  )) {
-      fPt1ResKUpg  =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("Pt1ResK"  )));
-      fPt1ResKUpg  ->SetName("Pt1ResKUpg"  );
+      fPt1ResKUpg  =(TGraph*)(resfileUpg->Get("Pt1ResK"  )->Clone("Pt1ResKUpg"  ));
     }
     if(resfileUpg->Get("Pt1ResPi" )) {
-      fPt1ResPiUpg =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("Pt1ResPi" )));
-      fPt1ResPiUpg ->SetName("Pt1ResPiUpg" );
+      fPt1ResPiUpg =(TGraph*)(resfileUpg->Get("Pt1ResPi" )->Clone("Pt1ResPiUpg" ));
     }
     if(resfileUpg->Get("Pt1ResE" )) {
-      fPt1ResEUpg =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("Pt1ResE" )));
-      fPt1ResEUpg ->SetName("Pt1ResEUpg" );
+      fPt1ResEUpg =(TGraph*)(resfileUpg->Get("Pt1ResE" )->Clone("Pt1ResEUpg" ));
     }
     if(resfileUpg->Get("D0RPResPSA" )) {
-      fD0RPResPUpgSA =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("D0RPResPSA" )));
-      fD0RPResPUpgSA ->SetName("D0RPResPUpgSA" );
+      fD0RPResPUpgSA =(TGraph*)(resfileUpg->Get("D0RPResPSA" )->Clone("D0RPResPUpgSA" ));
     }
     if(resfileUpg->Get("D0RPResKSA" )) {
-      fD0RPResKUpgSA =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("D0RPResKSA" )));
-      fD0RPResKUpgSA ->SetName("D0RPResKUpgSA" );
+      fD0RPResKUpgSA =(TGraph*)(resfileUpg->Get("D0RPResKSA" )->Clone("D0RPResKUpgSA" ));
     }
     if(resfileUpg->Get("D0RPResPiSA")) {
-      fD0RPResPiUpgSA=new TGraph(*static_cast<TGraph*>(resfileUpg->Get("D0RPResPiSA")));
-      fD0RPResPiUpgSA->SetName("D0RPResPiUpgSA");
+      fD0RPResPiUpgSA=(TGraph*)(resfileUpg->Get("D0RPResPiSA")->Clone("D0RPResPiUpgSA"));
     }
     if(resfileUpg->Get("D0RPResESA")) {
-      fD0RPResEUpgSA=new TGraph(*static_cast<TGraph*>(resfileUpg->Get("D0RPResESA")));
-      fD0RPResEUpgSA->SetName("D0RPResEUpgSA");
+      fD0RPResEUpgSA=(TGraph*)(resfileUpg->Get("D0RPResESA")->Clone("D0RPResEUpgSA"));
     }
     if(resfileUpg->Get("D0ZResPSA"  )) {
-      fD0ZResPUpgSA  =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("D0ZResPSA"  )));
-      fD0ZResPUpgSA  ->SetName("D0ZResPUpgSA"  );
+      fD0ZResPUpgSA  =(TGraph*)(resfileUpg->Get("D0ZResPSA"  )->Clone("D0ZResPUpgSA"  ));
     }
     if(resfileUpg->Get("D0ZResKSA"  )) {
-      fD0ZResKUpgSA  =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("D0ZResKSA"  )));
-      fD0ZResKUpgSA  ->SetName("D0ZResKUpgSA"  );
+      fD0ZResKUpgSA  =(TGraph*)(resfileUpg->Get("D0ZResKSA"  )->Clone("D0ZResKUpgSA"  ));
     }
     if(resfileUpg->Get("D0ZResPiSA" )) {
-      fD0ZResPiUpgSA =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("D0ZResPiSA" )));
-      fD0ZResPiUpgSA ->SetName("D0ZResPiUpgSA" );
+      fD0ZResPiUpgSA =(TGraph*)(resfileUpg->Get("D0ZResPiSA" )->Clone("D0ZResPiUpgSA" ));
     }
     if(resfileUpg->Get("D0ZResESA" )) {
-      fD0ZResEUpgSA =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("D0ZResESA" )));
-      fD0ZResEUpgSA ->SetName("D0ZResEUpgSA" );
+      fD0ZResEUpgSA =(TGraph*)(resfileUpg->Get("D0ZResESA" )->Clone("D0ZResEUpgSA" ));
     }
     if(resfileUpg->Get("Pt1ResPSA"  )) {
-      fPt1ResPUpgSA  =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("Pt1ResPSA"  )));
-      fPt1ResPUpgSA  ->SetName("Pt1ResPUpgSA"  );
+      fPt1ResPUpgSA  =(TGraph*)(resfileUpg->Get("Pt1ResPSA"  )->Clone("Pt1ResPUpgSA"  ));
     }
     if(resfileUpg->Get("Pt1ResKSA"  )) {
-      fPt1ResKUpgSA  =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("Pt1ResKSA"  )));
-      fPt1ResKUpgSA  ->SetName("Pt1ResKUpgSA"  );
+      fPt1ResKUpgSA  =(TGraph*)(resfileUpg->Get("Pt1ResKSA"  )->Clone("Pt1ResKUpgSA"  ));
     }
     if(resfileUpg->Get("Pt1ResPiSA" )) {
-      fPt1ResPiUpgSA =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("Pt1ResPiSA" )));
-      fPt1ResPiUpgSA ->SetName("Pt1ResPiUpgSA" );
+      fPt1ResPiUpgSA =(TGraph*)(resfileUpg->Get("Pt1ResPiSA" )->Clone("Pt1ResPiUpgSA" ));
     }
     if(resfileUpg->Get("Pt1ResESA" )) {
-      fPt1ResEUpgSA =new TGraph(*static_cast<TGraph*>(resfileUpg->Get("Pt1ResESA" )));
-      fPt1ResEUpgSA ->SetName("Pt1ResEUpgSA" );
+      fPt1ResEUpgSA =(TGraph*)(resfileUpg->Get("Pt1ResESA" )->Clone("Pt1ResEUpgSA" ));
     }
     delete resfileUpg;
   }
     
-  DefineOutput(1,TNtuple::Class());
+  DefineOutput(1,TList::Class());
 }
 
 AliAnalysisTaskSEImproveITS::~AliAnalysisTaskSEImproveITS() {
   //
   // Destructor.
   //
-  delete fDebugOutput;
+  if (fDebugOutput) delete fDebugOutput;
 }
 
 void AliAnalysisTaskSEImproveITS::UserCreateOutputObjects() {
@@ -495,6 +439,7 @@ void AliAnalysisTaskSEImproveITS::UserCreateOutputObjects() {
   //
   fDebugOutput=new TList();
   fDebugOutput->SetOwner();
+  fDebugOutput->SetName("debug");
   fDebugNtuple=new TNtuple("fDebugNtuple","Smearing","pdg:ptmc:d0rpo:d0zo:pt1o:sd0rpo:sd0zo:spt1o:d0rpn:d0zn:pt1n:sd0rpn:sd0zn:spt1n:d0rpmc:d0zmc:pt1mc:pullcorr:d0zoinsigma:d0zninsigma:d0rpoinsigma:d0rpninsigma");
   fDebugVars=new Float_t[fDebugNtuple->GetNvar()];
   

--- a/PWGHF/vertexingHF/macros/AddTaskB0Dminuspi.C
+++ b/PWGHF/vertexingHF/macros/AddTaskB0Dminuspi.C
@@ -2,11 +2,6 @@
 
 //by default the task is anyway computing 1, 2 and 3 sigmas
 
-const Bool_t theRareOn = kTRUE;
-
-const Bool_t anaType   = 1;//0 HD; 1 UU;
-
-const Bool_t doImp   = kFALSE;// imp par studies
 
 //----------------------------------------------------
 
@@ -23,12 +18,17 @@ AliAnalysisTaskSEB0toDminuspi *AddTaskB0Dminuspi(Int_t system=0/*0=pp,1=PbPb*/,
 {
 
 
+const Bool_t theRareOn = kTRUE;
+
+const Bool_t anaType   = 1;//0 HD; 1 UU;
+
+const Bool_t doImp   = kFALSE;// imp par studies
 
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
 
   if (!mgr) {
 
-    ::Error("AddTaskB0Dminuspi", "No analysis manager to connect to.");
+    Printf("ERROR: No analysis manager to connect to.");
 
     return NULL;
 
@@ -50,18 +50,19 @@ AliAnalysisTaskSEB0toDminuspi *AddTaskB0Dminuspi(Int_t system=0/*0=pp,1=PbPb*/,
       filecuts=TFile::Open(cutsfile.Data());
       if(!filecuts ||(filecuts&& !filecuts->IsOpen())){
 	//AliFatal("Input file not found : check your cut object");
-	Error("Input file not found : check your cut object");
+	Printf("ERROR: Input file not found : check your cut object");
+	return NULL;
       }
   }
   
 
 
-  AliRDHFCutsDplustoKpipi* RDHFB0toDminuspi=new AliRDHFCutsDplustoKpipi();
+  AliRDHFCutsDplustoKpipi* RDHFB0toDminuspi;
 
   
 
   if(stdcuts) {
-
+    RDHFB0toDminuspi=new AliRDHFCutsDplustoKpipi();
     if(system==0){ 
       RDHFB0toDminuspi->SetStandardCutsPP2010();
       //      RDHFB0toDminuspi->SetUseCentrality(kFALSE);
@@ -105,7 +106,7 @@ AliAnalysisTaskSEB0toDminuspi *AddTaskB0Dminuspi(Int_t system=0/*0=pp,1=PbPb*/,
 
     cout<<"Specific AliRDHFCuts not found"<<endl;
 
-    return;
+    return NULL;
 
   }
 

--- a/PWGHF/vertexingHF/macros/AddTaskCFVertexingHF.C
+++ b/PWGHF/vertexingHF/macros/AddTaskCFVertexingHF.C
@@ -1,3 +1,21 @@
+
+
+//
+// useWeight : flag for Pt weights (default are pp 2010 weights, functions per MC production existing)
+// useFlatPtWeight : flag to test flat Pt weights (computed for LHC10f7a MC)
+// useZWeight : flag to use z-vtx weight (used for systematics for now)
+// useNchWeight : flag to use weights on the distribution of simulated primary particles (default pp 2010)
+// useNtrkWeight : flag to use weights on the distribution of Ntracklets
+// isFinePtBin : flag for fine pt bin (100 MeV from 0 to 30 GeV)
+// multiplicityEstimator : varying the multiplicity (and not centrality) estimator
+// isPPData : flag to switch off centrality checks when runing on pp data (reduces a lot log files)
+// isPPbData : Flag for pPb data, changes the Ntrk bining
+// estimatorFilename, refMult : Ntrk vs z-vtx multiplicity correction file name and average value
+// isFineNtrkBin : gives Ntrk bins of 1 unit from 0-100 (200 for pPb)
+//----------------------------------------------------
+
+AliCFTaskVertexingHF *AddTaskCFVertexingHF(const char* cutFile = "./D0toKpiCuts.root", TString cutObjectName="D0toKpiCutsStandard", TString suffix="", Int_t configuration = AliCFTaskVertexingHF::kCheetah, Bool_t isKeepDfromB=kFALSE, Bool_t isKeepDfromBOnly=kFALSE, Int_t pdgCode = 421, Char_t isSign = 2, Bool_t useWeight=kFALSE, Bool_t useFlatPtWeight=kFALSE, Bool_t useZWeight=kFALSE, Bool_t useNchWeight=kFALSE, Bool_t useNtrkWeight=kFALSE, Bool_t isFinePtBin=kFALSE, TString estimatorFilename="", Int_t multiplicityEstimator = AliCFTaskVertexingHF::kNtrk10, Bool_t isPPData=kFALSE, Bool_t isPPbData=kFALSE, Double_t refMult = 9.26, Bool_t isFineNtrkBin=kFALSE)
+{
 //DEFINITION OF A FEW CONSTANTS
 const Double_t ymin  = -1.2 ;
 const Double_t ymax  =  1.2 ;
@@ -33,7 +51,7 @@ const Float_t centmin_60_100 = 60.;
 const Float_t centmax_60_100 = 100.;
 const Float_t centmax = 100.;
 const Float_t fakemin = -0.5;
-const Float_t fakemax = 2.5.;
+const Float_t fakemax = 2.5;
 const Float_t cosminXY = 0.95;
 const Float_t cosmaxXY = 1.0;
 const Float_t normDecLXYmin = 0;
@@ -49,22 +67,7 @@ const Float_t multmax_80_100 = 100;
 const Float_t multmin_100_400 = 100; // Only for pPb
 const Float_t multmax_100_400 = 400; // Only for pPb
 
-//
-// useWeight : flag for Pt weights (default are pp 2010 weights, functions per MC production existing)
-// useFlatPtWeight : flag to test flat Pt weights (computed for LHC10f7a MC)
-// useZWeight : flag to use z-vtx weight (used for systematics for now)
-// useNchWeight : flag to use weights on the distribution of simulated primary particles (default pp 2010)
-// useNtrkWeight : flag to use weights on the distribution of Ntracklets
-// isFinePtBin : flag for fine pt bin (100 MeV from 0 to 30 GeV)
-// multiplicityEstimator : varying the multiplicity (and not centrality) estimator
-// isPPData : flag to switch off centrality checks when runing on pp data (reduces a lot log files)
-// isPPbData : Flag for pPb data, changes the Ntrk bining
-// estimatorFilename, refMult : Ntrk vs z-vtx multiplicity correction file name and average value
-// isFineNtrkBin : gives Ntrk bins of 1 unit from 0-100 (200 for pPb)
-//----------------------------------------------------
 
-AliCFTaskVertexingHF *AddTaskCFVertexingHF(const char* cutFile = "./D0toKpiCuts.root", TString cutObjectName="D0toKpiCutsStandard", TString suffix="", Int_t configuration = AliCFTaskVertexingHF::kCheetah, Bool_t isKeepDfromB=kFALSE, Bool_t isKeepDfromBOnly=kFALSE, Int_t pdgCode = 421, Char_t isSign = 2, Bool_t useWeight=kFALSE, Bool_t useFlatPtWeight=kFALSE, Bool_t useZWeight=kFALSE, Bool_t useNchWeight=kFALSE, Bool_t useNtrkWeight=kFALSE, Bool_t isFinePtBin=kFALSE, TString estimatorFilename="", Int_t multiplicityEstimator = AliCFTaskVertexingHF::kNtrk10, Bool_t isPPData=kFALSE, Bool_t isPPbData=kFALSE, Double_t refMult = 9.26, Bool_t isFineNtrkBin=kFALSE)
-{
 	printf("Adding CF task using cuts from file %s\n",cutFile);
 	if (configuration == AliCFTaskVertexingHF::kSnail){
 		printf("The configuration is set to be SLOW --> all the variables will be used to fill the CF\n");
@@ -80,7 +83,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF(const char* cutFile = "./D0toKpiCuts.
   }
 	else{
 		printf("The configuration is not defined! returning\n");
-		return;
+		return NULL;
 	}
 	       
 	gSystem->Sleep(2000);
@@ -91,21 +94,21 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF(const char* cutFile = "./D0toKpiCuts.
 
 	TString expected;
 	if (isSign == 0 && pdgCode < 0){
-		AliError(Form("Error setting PDG code (%d) and sign (0 --> D0 only): they are not compatible, returning"));
+		Printf("ERROR:Error setting PDG code (%d) and sign (0 --> D0 only): they are not compatible, returning",pdgCode);
 		return 0x0;
 	}
 	else if (isSign == 1 && pdgCode > 0){
-		AliError(Form("Error setting PDG code (%d) and sign (1 --> D0bar only): they are not compatible, returning"));
+		Printf("ERROR:Error setting PDG code (%d) and sign (1 --> D0bar only): they are not compatible, returning",pdgCode);
 		return 0x0;
 	}
 	else if (isSign > 2 || isSign < 0){
-		AliError(Form("Sign not valid (%d, possible values are 0, 1, 2), returning"));
+		Printf("ERROR:Sign not valid (%d, possible values are 0, 1, 2), returning",isSign);
 		return 0x0;
 	}
 
 	TFile* fileCuts = TFile::Open(cutFile);
 	if(!fileCuts || (fileCuts && !fileCuts->IsOpen())){ 
-	  AliError("Wrong cut file");
+	  Printf("ERROR: Wrong cut file");
 	  return 0x0;
 	}
 
@@ -155,7 +158,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF(const char* cutFile = "./D0toKpiCuts.
 	const Int_t nbinfake = 3;  //bins in fake
 	const Int_t nbinpointingXY = 50;  //bins in cosPointingAngleXY
 	const Int_t nbinnormDecayLXY = 20;  //bins in NormDecayLengthXY
-	const Int_t nbinmult = 49;  //bins in multiplicity (total number)
+	Int_t nbinmult = 49;  //bins in multiplicity (total number)
 	const Int_t nbinmult_0_20 = 20; //bins in multiplicity between 0 and 20
 	const Int_t nbinmult_20_50 = 15; //bins in multiplicity between 20 and 50
 	const Int_t nbinmult_50_80 = 10; //bins in multiplicity between 50 and 100
@@ -742,7 +745,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF(const char* cutFile = "./D0toKpiCuts.
 	    task->SetMCNchHisto(hNchPrimaries);
 	    if(isPPbData) task->SetUseNchTrackletsWeight();
 	  } else {
-	    AliFatal("Histogram for multiplicity weights not found");
+	    Printf("FATAL: Histogram for multiplicity weights not found");
 	    return 0x0;
 	  }
 	  if(hNchMeasured) task->SetMeasuredNchHisto(hNchMeasured);
@@ -760,8 +763,8 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF(const char* cutFile = "./D0toKpiCuts.
 
 	  TFile* fileEstimator=TFile::Open(estimatorFilename.Data());
 	  if(!fileEstimator)  {
-	    AliFatal("File with multiplicity estimator not found"); 
-	    return;
+	    Printf("FATAL: File with multiplicity estimator not found"); 
+	    return NULL;
 	  }
 
 	  task->SetUseZvtxCorrectedNtrkEstimator(kTRUE);
@@ -773,8 +776,8 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF(const char* cutFile = "./D0toKpiCuts.
             for(Int_t ip=0; ip<2; ip++) {
 	      multEstimatorAvg[ip] = (TProfile*)(fileEstimator->Get(Form("SPDmult10_%s",periodNames[ip]))->Clone(Form("SPDmult10_%s_clone",periodNames[ip])));
 	      if (!multEstimatorAvg[ip]) {
-		AliFatal(Form("Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]));
-		return;
+		Printf("FATAL: Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]);
+		return NULL;
 	      }
             }
             task->SetMultiplVsZProfileLHC13b(multEstimatorAvg[0]);
@@ -786,8 +789,8 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF(const char* cutFile = "./D0toKpiCuts.
             for(Int_t ip=0; ip<4; ip++) {
 	      multEstimatorAvg[ip] = (TProfile*)(fileEstimator->Get(Form("SPDmult10_%s",periodNames[ip]))->Clone(Form("SPDmult10_%s_clone",periodNames[ip])));
 	      if (!multEstimatorAvg[ip]) {
-		AliFatal(Form("Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]));
-		return;
+		Printf("FATAL: Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]);
+		return NULL;
 	      }
             }
             task->SetMultiplVsZProfileLHC10b(multEstimatorAvg[0]);
@@ -847,7 +850,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF(const char* cutFile = "./D0toKpiCuts.
 	nameCorr += suffix;
 
         THnSparseD* correlation = new THnSparseD(nameCorr,"THnSparse with correlations",4,thnDim);
-        Double_t** binEdges = new Double_t[2];
+        Double_t** binEdges = new Double_t*[2];
 
         // set bin limits
 

--- a/PWGHF/vertexingHF/macros/AddTaskCFVertexingHF3Prong.C
+++ b/PWGHF/vertexingHF/macros/AddTaskCFVertexingHF3Prong.C
@@ -1,3 +1,12 @@
+
+
+
+//----------------------------------------------------
+
+AliCFTaskVertexingHF *AddTaskCFVertexingHF3Prong(TString suffixName="", const char* cutFile = "./DplustoKpipiCuts.root", Int_t configuration = AliCFTaskVertexingHF::kCheetah, Bool_t isKeepDfromB=kFALSE, Bool_t isKeepDfromBOnly=kFALSE, Int_t pdgCode = 411, Char_t isSign = 2, Bool_t useWeight=kFALSE, TString multFile="", Bool_t useNchWeight=kFALSE, Bool_t useNtrkWeight=kFALSE, TString estimatorFilename="", Int_t multiplicityEstimator = AliCFTaskVertexingHF::kNtrk10, Bool_t isPPbData = kFALSE, Double_t refMult=9.26, Bool_t isFineNtrkBin=kFALSE, TString multweighthistoname = "hNtrUnCorrEvWithCandWeight")
+//AliCFContainer *AddTaskCFVertexingHF3Prong(const char* cutFile = "./DplustoKpipiCuts.root", Int_t configuration = AliCFTaskVertexingHF::kSnail, Bool_t isKeepDfromB=kFALSE, Bool_t isKeepDfromBOnly=kFALSE, Int_t pdgCode = 411, Char_t isSign = 2)
+{
+
 //DEFINITION OF A FEW CONSTANTS
 const Double_t ymin  = -1.2 ;
 const Double_t ymax  =  1.2 ;
@@ -27,7 +36,7 @@ const Float_t centmin_60_100 = 60.;
 const Float_t centmax_60_100 = 100.;
 const Float_t centmax = 100.;
 const Float_t fakemin = -0.5;
-const Float_t fakemax = 2.5.;
+const Float_t fakemax = 2.5;
 const Float_t cosminXY = 0.95;
 const Float_t cosmaxXY = 1.0;
 const Float_t normDecLXYmin = 0;
@@ -43,13 +52,6 @@ const Float_t multmax_80_100 = 100;
 const Float_t multmin_100_400 = 100;
 const Float_t multmax_100_400 = 400;
 
-
-
-//----------------------------------------------------
-
-AliCFTaskVertexingHF *AddTaskCFVertexingHF3Prong(TString suffixName="", const char* cutFile = "./DplustoKpipiCuts.root", Int_t configuration = AliCFTaskVertexingHF::kCheetah, Bool_t isKeepDfromB=kFALSE, Bool_t isKeepDfromBOnly=kFALSE, Int_t pdgCode = 411, Char_t isSign = 2, Bool_t useWeight=kFALSE, TString multFile="", Bool_t useNchWeight=kFALSE, Bool_t useNtrkWeight=kFALSE, TString estimatorFilename="", Int_t multiplicityEstimator = AliCFTaskVertexingHF::kNtrk10, Bool_t isPPbData = kFALSE, Double_t refMult=9.26, Bool_t isFineNtrkBin=kFALSE, TString multweighthistoname = "hNtrUnCorrEvWithCandWeight")
-//AliCFContainer *AddTaskCFVertexingHF3Prong(const char* cutFile = "./DplustoKpipiCuts.root", Int_t configuration = AliCFTaskVertexingHF::kSnail, Bool_t isKeepDfromB=kFALSE, Bool_t isKeepDfromBOnly=kFALSE, Int_t pdgCode = 411, Char_t isSign = 2)
-{
 	printf("Addig CF task using cuts from file %s\n",cutFile);
 	if (configuration == AliCFTaskVertexingHF::kSnail){
 		printf("The configuration is set to be SLOW --> all the variables will be used to fill the CF\n");
@@ -65,7 +67,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3Prong(TString suffixName="", const ch
   }
 	else{
 		printf("The configuration is not defined! returning\n");
-		return;
+		return NULL;
 	}
 
 	gSystem->Sleep(2000);
@@ -76,21 +78,21 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3Prong(TString suffixName="", const ch
 
 	TString expected;
 	if (isSign == 0 && pdgCode < 0){
-		AliError(Form("Error setting PDG code (%d) and sign (0 --> particle (%d) only): they are not compatible, returning",pdgCode));
+		Printf("ERROR: Error setting PDG code (%d) and sign (0 --> particle (%d) only): they are not compatible, returning",pdgCode,isSign);
 		return 0x0;
 	}
 	else if (isSign == 1 && pdgCode > 0){
-		AliError(Form("Error setting PDG code (%d) and sign (1 --> antiparticle (%d) only): they are not compatible, returning",pdgCode));
+		Printf("ERROR: Error setting PDG code (%d) and sign (1 --> antiparticle (%d) only): they are not compatible, returning",pdgCode,isSign);
 		return 0x0;
 	}
 	else if (isSign > 2 || isSign < 0){
-		AliError(Form("Sign not valid (%d, possible values are 0, 1, 2), returning"));
+		Printf("ERROR: Sign not valid (%d, possible values are 0, 1, 2), returning",isSign);
 		return 0x0;
 	}
 
 	TFile* fileCuts = TFile::Open(cutFile);
 	if(!fileCuts || (fileCuts && !fileCuts->IsOpen())){
-	  AliFatal(" Cut file not found");
+	  Printf("FATAL:  Cut file not found");
 	  return 0x0;
 	}
 	AliRDHFCutsDplustoKpipi *cutsDplustoKpipi = (AliRDHFCutsDplustoKpipi*)fileCuts->Get("AnalysisCuts");
@@ -187,7 +189,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3Prong(TString suffixName="", const ch
 	const Int_t nbinfake = 3;  //bins in fake
 	const Int_t nbinpointingXY = 50;  //bins in cosPointingAngleXY
 	const Int_t nbinnormDecayLXY = 20;  //bins in NormDecayLengthXY
-	const Int_t nbinmult = 49;  //bins in multiplicity (total number)
+	Int_t nbinmult = 49;  //bins in multiplicity (total number)
 	const Int_t nbinmult_0_20 = 20; //bins in multiplicity between 0 and 20
 	const Int_t nbinmult_20_50 = 15; //bins in multiplicity between 20 and 50
 	const Int_t nbinmult_50_80 = 10; //bins in multiplicity between 50 and 80
@@ -680,7 +682,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3Prong(TString suffixName="", const ch
 	if(useNchWeight || useNtrkWeight){
 	  if(hMult) task->SetMCNchHisto(hMult);
 	  else{
-	    AliFatal("Histogram for multiplicity weights not found");
+	    Printf("FATAL: Histogram for multiplicity weights not found");
 	    return 0x0;
 	  }
 	  task->SetUseNchWeight(kTRUE);
@@ -712,8 +714,8 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3Prong(TString suffixName="", const ch
    } else{
      TFile* fileEstimator=TFile::Open(estimatorFilename.Data());
      if(!fileEstimator)  {
-       AliFatal("File with multiplicity estimator not found");
-       return;
+       Printf("FATAL: File with multiplicity estimator not found");
+       return NULL;
      }
      task->SetUseZvtxCorrectedNtrkEstimator(kTRUE);
      task->SetReferenceMultiplcity(refMult);
@@ -724,8 +726,8 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3Prong(TString suffixName="", const ch
          for (Int_t ip=0; ip < 2; ip++) {
             multEstimatorAvg[ip] = (TProfile*)(fileEstimator->Get(Form("SPDmult10_%s",periodNames[ip]))->Clone(Form("SPDmult10_%s_clone",periodNames[ip])));
             if (!multEstimatorAvg[ip]) {
-               AliFatal(Form("Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]));
-               return;
+               Printf("FATAL: Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]);
+               return NULL;
             }
          }
          task->SetMultiplVsZProfileLHC13b(multEstimatorAvg[0]);
@@ -738,8 +740,8 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3Prong(TString suffixName="", const ch
          for(Int_t ip=0; ip<4; ip++) {
             multEstimatorAvg[ip] = (TProfile*)(fileEstimator->Get(Form("SPDmult10_%s",periodNames[ip]))->Clone(Form("SPDmult10_%s_clone",periodNames[ip])));
             if (!multEstimatorAvg[ip]) {
-               AliFatal(Form("Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]));
-               return;
+               Printf("FATAL: Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]);
+               return NULL;
             }
          }
          task->SetMultiplVsZProfileLHC10b(multEstimatorAvg[0]);
@@ -790,7 +792,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3Prong(TString suffixName="", const ch
 
 
         THnSparseD* correlation = new THnSparseD(nameCorr,"THnSparse with correlations",4,thnDim);
-        Double_t** binEdges = new Double_t[2];
+        Double_t** binEdges = new Double_t*[2];
 
         // set bin limits
 

--- a/PWGHF/vertexingHF/macros/AddTaskCFVertexingHF3ProngDs.C
+++ b/PWGHF/vertexingHF/macros/AddTaskCFVertexingHF3ProngDs.C
@@ -1,3 +1,9 @@
+
+//----------------------------------------------------
+
+AliCFTaskVertexingHF *AddTaskCFVertexingHF3ProngDs(TString suffixName="", Int_t decayOption=AliCFVertexingHF3Prong::kCountResonant, const char* cutFile = "./DstoKKpiCuts.root", Int_t configuration = AliCFTaskVertexingHF::kSnail, Bool_t isKeepDfromB=kFALSE, Bool_t isKeepDfromBOnly=kFALSE, Int_t pdgCode = 431, Char_t isSign = 2, Bool_t useNtrkWeight=kFALSE, Bool_t isFineNtrkBin=kFALSE)
+//AliCFContainer *AddTaskCFVertexingHF3ProngDs(const char* cutFile = "./DstoKKpiCuts.root", Int_t configuration = AliCFTaskVertexingHF::kSnail, Bool_t isKeepDfromB=kFALSE, Bool_t isKeepDfromBOnly=kFALSE, Int_t pdgCode = 431, Char_t isSign = 2)
+{
 //DEFINITION OF A FEW CONSTANTS
 const Double_t ymin  = -1.2 ;
 const Double_t ymax  =  1.2 ;
@@ -27,7 +33,7 @@ const Float_t centmin_60_100 = 60.;
 const Float_t centmax_60_100 = 100.;
 const Float_t centmax = 100.;
 const Float_t fakemin = -0.5;
-const Float_t fakemax = 2.5.;
+const Float_t fakemax = 2.5;
 const Float_t cosminXY = 0.90;
 const Float_t cosmaxXY = 1.0;
 const Float_t normDecLXYmin = 0;
@@ -40,11 +46,6 @@ const Float_t multmin_50_102 = 50;
 const Float_t multmax_50_102 = 102;
 
 
-//----------------------------------------------------
-
-AliCFTaskVertexingHF *AddTaskCFVertexingHF3ProngDs(TString suffixName="", Int_t decayOption=AliCFVertexingHF3Prong::kCountResonant, const char* cutFile = "./DstoKKpiCuts.root", Int_t configuration = AliCFTaskVertexingHF::kSnail, Bool_t isKeepDfromB=kFALSE, Bool_t isKeepDfromBOnly=kFALSE, Int_t pdgCode = 431, Char_t isSign = 2, Bool_t useNtrkWeight=kFALSE, Bool_t isFineNtrkBin=kFALSE)
-//AliCFContainer *AddTaskCFVertexingHF3ProngDs(const char* cutFile = "./DstoKKpiCuts.root", Int_t configuration = AliCFTaskVertexingHF::kSnail, Bool_t isKeepDfromB=kFALSE, Bool_t isKeepDfromBOnly=kFALSE, Int_t pdgCode = 431, Char_t isSign = 2)
-{
 	printf("Addig CF task using cuts from file %s\n",cutFile);
 	if (configuration == AliCFTaskVertexingHF::kSnail){
 		printf("The configuration is set to be SLOW --> all the variables will be used to fill the CF\n");
@@ -57,7 +58,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3ProngDs(TString suffixName="", Int_t 
 	}
 	else{
 		printf("The configuration is not defined! returning\n");
-		return;
+		return NULL;
 	}
 	       
 	gSystem->Sleep(2000);
@@ -68,21 +69,21 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3ProngDs(TString suffixName="", Int_t 
 	
 	TString expected;
 	if (isSign == 0 && pdgCode < 0){
-		AliError(Form("Error setting PDG code (%d) and sign (0 --> particle (%d) only): they are not compatible, returning",pdgCode));
+		Printf("ERROR: Error setting PDG code (%d) and sign (0 --> particle (%d) only): they are not compatible, returning",pdgCode,isSign);
 		return 0x0;
 	}
 	else if (isSign == 1 && pdgCode > 0){
-		AliError(Form("Error setting PDG code (%d) and sign (1 --> antiparticle (%d) only): they are not compatible, returning",pdgCode));
+		Printf("ERROR: Error setting PDG code (%d) and sign (1 --> antiparticle (%d) only): they are not compatible, returning",pdgCode,isSign);
 		return 0x0;
 	}
 	else if (isSign > 2 || isSign < 0){
-		AliError(Form("Sign not valid (%d, possible values are 0, 1, 2), returning"));
+		Printf("ERROR: Sign not valid (%d, possible values are 0, 1, 2), returning",isSign);
 		return 0x0;
 	}
 
 	TFile* fileCuts = TFile::Open(cutFile);
 	if(!fileCuts || (fileCuts && !fileCuts->IsOpen())){ 
-	  AliError("Wrong cut file");
+	  Printf("ERROR: Wrong cut file");
 	  return 0x0;
 	}
 	AliRDHFCutsDstoKKpi *cutsDstoKKpi = (AliRDHFCutsDstoKKpi*)fileCuts->Get("AnalysisCuts");
@@ -170,8 +171,10 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3ProngDs(TString suffixName="", Int_t 
 	const Int_t nbinmult_50_102 = 13; //bins in multiplicity between 50 and 102
 	
     Int_t nbinmultTmp=nbinmult;
+    Int_t nbinLimmultFine;
+    Double_t* binLimmultFine;
     if(isFineNtrkBin){
-        Int_t nbinLimmultFine=250;
+        nbinLimmultFine=250;
         const UInt_t nbinMultFine = nbinLimmultFine;
         binLimmultFine = new Double_t[nbinMultFine+1];
         for (Int_t ibin0 = 0 ; ibin0<=nbinMultFine; ibin0++){
@@ -618,12 +621,12 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3ProngDs(TString suffixName="", Int_t 
         hNtrkMeasured = (TH1F*)fileCuts->Get("hNtrkMeasured");
         if(hNtrkMC) task->SetMCNchHisto(hNtrkMC);
         else {
-            AliFatal("Histogram for multiplicity weights not found");
+            Printf("FATAL: Histogram for multiplicity weights not found");
             return 0x0;
         }
         if(hNtrkMeasured) task->SetMeasuredNchHisto(hNtrkMeasured);
         else {
-            AliFatal("Histogram for multiplicity weights not found");
+            Printf("FATAL: Histogram for multiplicity weights not found");
             return 0x0;
         }
         task->SetUseNchTrackletsWeight(kTRUE);
@@ -682,7 +685,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3ProngDs(TString suffixName="", Int_t 
 	nameCorr+=suffixName.Data();
 
         THnSparseD* correlation = new THnSparseD(nameCorr,"THnSparse with correlations",4,thnDim);
-        Double_t** binEdges = new Double_t[2];
+        Double_t** binEdges = new Double_t*[2];
 
         // set bin limits
 

--- a/PWGHF/vertexingHF/macros/AddTaskCFVertexingHF3ProngLc.C
+++ b/PWGHF/vertexingHF/macros/AddTaskCFVertexingHF3ProngLc.C
@@ -1,3 +1,12 @@
+
+
+
+//----------------------------------------------------
+
+//AliCFTaskVertexingHF *AddTaskCFVertexingHF3ProngLc(const char* cutFile = "./cuts4LctopKpi.root", Int_t configuration = AliCFTaskVertexingHF::kSnail, Bool_t isKeepDfromB=kFALSE, Bool_t isKeepDfromBOnly=kFALSE, Int_t pdgCode = 4122, Char_t isSign = 2)
+AliCFTaskVertexingHF *AddTaskCFVertexingHF3ProngLc(const char* cutFile = "./cuts4LctopKpi.root", Int_t configuration = AliCFTaskVertexingHF::kSnail, Bool_t isKeepDfromB=kFALSE, Bool_t isKeepDfromBOnly=kFALSE, Int_t pdgCode = 4122, Char_t isSign = 2,UInt_t decayLc=AliCFTaskVertexingHF::kDelta,TString coutName="Delta",Int_t useNtrkWeight = 0, TString suffix = "")
+{
+
 //DEFINITION OF A FEW CONSTANTS
 const Double_t ymin  = -1.2 ;
 const Double_t ymax  =  1.2 ;
@@ -28,7 +37,7 @@ const Float_t centmax_60_100 = 100.;
 const Float_t centmin = 0.;
 const Float_t centmax = 100.;
 const Float_t fakemin = -0.5;
-const Float_t fakemax = 2.5.;
+const Float_t fakemax = 2.5;
 const Double_t distTwoPartmin=0;
 const Double_t distTwoPartmax=600;
 const Double_t dispVtxmin = 0;
@@ -45,14 +54,7 @@ const Float_t multmin_20_50 = 20;
 const Float_t multmax_20_50 = 50;
 const Float_t multmin_50_102 = 50;
 const Float_t multmax_50_102 = 102;
-
-
-//----------------------------------------------------
-
-//AliCFTaskVertexingHF *AddTaskCFVertexingHF3ProngLc(const char* cutFile = "./cuts4LctopKpi.root", Int_t configuration = AliCFTaskVertexingHF::kSnail, Bool_t isKeepDfromB=kFALSE, Bool_t isKeepDfromBOnly=kFALSE, Int_t pdgCode = 4122, Char_t isSign = 2)
-AliCFTaskVertexingHF *AddTaskCFVertexingHF3ProngLc(const char* cutFile = "./cuts4LctopKpi.root", Int_t configuration = AliCFTaskVertexingHF::kSnail, Bool_t isKeepDfromB=kFALSE, Bool_t isKeepDfromBOnly=kFALSE, Int_t pdgCode = 4122, Char_t isSign = 2,UInt_t decayLc=AliCFTaskVertexingHF::kDelta,TString coutName="Delta",Int_t useNtrkWeight = 0, const char* suffix = "")
-{
-	if(suffix!="") coutName+=Form("%s",suffix); //for subwagons containers 
+	if(suffix!="") coutName+=Form("%s",suffix.Data()); //for subwagons containers 
 	printf("Addig CF task using cuts from file %s\n",cutFile);
 	if (configuration == AliCFTaskVertexingHF::kSnail){
 		printf("The configuration is set to be SLOW --> all the variables will be used to fill the CF\n");
@@ -65,7 +67,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3ProngLc(const char* cutFile = "./cuts
 	}
 	else{
 		printf("The configuration is not defined! returning\n");
-		return;
+		return NULL;
 	}
 	
 	gSystem->Sleep(2000);
@@ -76,21 +78,21 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3ProngLc(const char* cutFile = "./cuts
 	
 	TString expected;
 	if (isSign == 0 && pdgCode < 0){
-		AliError(Form("Error setting PDG code (%d) and sign (0 --> particle (%d) only): they are not compatible, returning",pdgCode));
+		Printf("ERROR:Error setting PDG code (%d) and sign (0 --> particle (%d) only): they are not compatible, returning",pdgCode,isSign);
 		return 0x0;
 	}
 	else if (isSign == 1 && pdgCode > 0){
-		AliError(Form("Error setting PDG code (%d) and sign (1 --> antiparticle (%d) only): they are not compatible, returning",pdgCode));
+		Printf("ERROR:Error setting PDG code (%d) and sign (1 --> antiparticle (%d) only): they are not compatible, returning",pdgCode,isSign);
 		return 0x0;
 	}
 	else if (isSign > 2 || isSign < 0){
-		AliError(Form("Sign not valid (%d, possible values are 0, 1, 2), returning"));
+		Printf("ERROR:Sign not valid (%d, possible values are 0, 1, 2), returning",isSign);
 		return 0x0;
 	}
 	
 	TFile* fileCuts = TFile::Open(cutFile);
 	if(!fileCuts || (fileCuts && !fileCuts->IsOpen())){ 
-	  AliError("Wrong cut file");
+	  Printf("ERROR: Wrong cut file");
 	  return 0x0;
 	}
 
@@ -613,7 +615,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3ProngLc(const char* cutFile = "./cuts
 
 	// create the task
 	TString combinedName; //for subwagons
-	combinedName.Form("AliCFTaskVertexingHF%s", suffix);
+	combinedName.Form("AliCFTaskVertexingHF%s", suffix.Data());
 	AliCFTaskVertexingHF *task = new AliCFTaskVertexingHF(combinedName,cutsLctopKpi);
 	task->SetConfiguration(configuration);
 	task->SetFillFromGenerated(kFALSE);
@@ -649,7 +651,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3ProngLc(const char* cutFile = "./cuts
 		else if(useNtrkWeight==3) hNchPrimaries = (TH1F*)fileCuts->Get("hNtrUnCorrEvSel");
 		else if(useNtrkWeight==4) hNchPrimaries = (TH1F*)fileCuts->Get("hNtrUnCorrPSSel");
 		else {
-			AliFatal("useNtrkWeight value not a valid option - choice from 1-4");
+			Printf("FATAL: useNtrkWeight value not a valid option - choice from 1-4");
 			return 0x0;
 		}
 		if(hNchPrimaries) {
@@ -657,7 +659,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3ProngLc(const char* cutFile = "./cuts
 			task->SetMCNchHisto(hNchPrimaries);
 			task->SetUseNchTrackletsWeight();
 		} else {
-			AliFatal("Histogram for multiplicity weights not found");
+			Printf("FATAL: Histogram for multiplicity weights not found");
 			return 0x0;
 		}
 	}
@@ -713,7 +715,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHF3ProngLc(const char* cutFile = "./cuts
 	}
 	nameCorr+=coutName.Data();
         THnSparseD* correlation = new THnSparseD(nameCorr,"THnSparse with correlations",4,thnDim);
-        Double_t** binEdges = new Double_t[2];
+        Double_t** binEdges = new Double_t*[2];
 
         // set bin limits
 

--- a/PWGHF/vertexingHF/macros/AddTaskCFVertexingHFCascade.C
+++ b/PWGHF/vertexingHF/macros/AddTaskCFVertexingHFCascade.C
@@ -1,3 +1,10 @@
+
+
+
+//----------------------------------------------------
+
+AliCFTaskVertexingHF *AddTaskCFVertexingHFCascade(const char* cutFile = "DStartoKpipiCuts010.root", TString cutObjectName="DStartoKpipiCuts", TString suffix="suf", Int_t configuration = AliCFTaskVertexingHF::kCheetah, Bool_t isKeepDfromB=kFALSE, Bool_t isKeepDfromBOnly=kFALSE, Int_t pdgCode = 413, Char_t isSign = 2, Bool_t useWeight=kTRUE, Bool_t useFlatPtWeight=kFALSE, Bool_t useZWeight=kFALSE, Bool_t useNchWeight=kFALSE, Bool_t useNtrkWeight=kFALSE, TString estimatorFilename="", Int_t multiplicityEstimator = AliCFTaskVertexingHF::kNtrk10, Bool_t isPPData=kFALSE, Bool_t isPPbData=kFALSE, Double_t refMult=9.26, Bool_t isFineNtrkBin=kFALSE)
+{
 const Double_t ymin  = -1.2 ;
 const Double_t ymax  =  1.2 ;
 const Double_t cosminTS = -1.05;
@@ -32,7 +39,7 @@ const Float_t centmin_60_100 = 60.;
 const Float_t centmax_60_100 = 100.;
 const Float_t centmax = 100.;
 const Float_t fakemin = -0.5;
-const Float_t fakemax = 2.5.;
+const Float_t fakemax = 2.5;
 const Float_t cosminXY = 0.95;
 const Float_t cosmaxXY = 1.0;
 const Float_t normDecLXYmin = 0;
@@ -47,12 +54,6 @@ const Float_t multmin_80_100 = 80;
 const Float_t multmax_80_100 = 100;
 const Float_t multmin_100_400 = 100;
 const Float_t multmax_100_400 = 400;
-
-
-//----------------------------------------------------
-
-AliCFTaskVertexingHF *AddTaskCFVertexingHFCascade(const char* cutFile = "DStartoKpipiCuts010.root", TString cutObjectName="DStartoKpipiCuts", TString suffix="suf", Int_t configuration = AliCFTaskVertexingHF::kCheetah, Bool_t isKeepDfromB=kFALSE, Bool_t isKeepDfromBOnly=kFALSE, Int_t pdgCode = 413, Char_t isSign = 2, Bool_t useWeight=kTRUE, Bool_t useFlatPtWeight=kFALSE, Bool_t useZWeight=kFALSE, Bool_t useNchWeight=kFALSE, Bool_t useNtrkWeight=kFALSE, TString estimatorFilename="", Int_t multiplicityEstimator = AliCFTaskVertexingHF::kNtrk10, Bool_t isPPData=kFALSE, Bool_t isPPbData=kFALSE, Double_t refMult=9.26, Bool_t isFineNtrkBin=kFALSE)
-{
 	printf("Adding CF task using cuts from file %s\n",cutFile);
 	if (configuration == AliCFTaskVertexingHF::kSnail){
 		printf("The configuration is set to be SLOW --> all the variables will be used to fill the CF\n");
@@ -68,7 +69,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFCascade(const char* cutFile = "DStarto
   }
 	else{
 		printf("The configuration is not defined! returning\n");
-		return;
+		return NULL;
 	}
 	       
 	gSystem->Sleep(2000);
@@ -79,21 +80,21 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFCascade(const char* cutFile = "DStarto
 
 	TString expected;
 	if (isSign == 0 && pdgCode < 0){
-		AliError(Form("Error setting PDG code (%d) and sign (0 --> D* only): they are not compatible, returning"));
+		Printf("ERROR:Error setting PDG code (%d) and sign (0 --> D* only): they are not compatible, returning",pdgCode);
 		return 0x0;
 	}
 	else if (isSign == 1 && pdgCode > 0){
-		AliError(Form("Error setting PDG code (%d) and sign (1 --> D*bar only): they are not compatible, returning"));
+		Printf("ERROR:Error setting PDG code (%d) and sign (1 --> D*bar only): they are not compatible, returning",pdgCode);
 		return 0x0;
 	}
 	else if (isSign > 2 || isSign < 0){
-		AliError(Form("Sign not valid (%d, possible values are 0, 1, 2), returning"));
+		Printf("ERROR:Sign not valid (%d, possible values are 0, 1, 2), returning",isSign);
 		return 0x0;
 	}
 
 	TFile* fileCuts = TFile::Open(cutFile);
 	if(!fileCuts || (fileCuts && !fileCuts->IsOpen())){ 
-	  AliError("Wrong cut file");
+	  Printf("ERROR: Wrong cut file");
 	  return 0x0;
 	}
 
@@ -143,7 +144,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFCascade(const char* cutFile = "DStarto
         const Int_t nbinfake = 3;  //bins in fake
         const Int_t nbinpointingXY = 50;  //bins in cosPointingAngleXY
         const Int_t nbinnormDecayLXY = 20;  //bins in NormDecayLengthXY
-	const Int_t nbinmult = 49;  //bins in multiplicity (total number)
+	Int_t nbinmult = 49;  //bins in multiplicity (total number)
         const Int_t nbinmult_0_20 = 20; //bins in multiplicity between 0 and 20
         const Int_t nbinmult_20_50 = 15; //bins in multiplicity between 20 and 50
         const Int_t nbinmult_50_80 = 10; //bins in multiplicity between 50 and 80
@@ -655,7 +656,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFCascade(const char* cutFile = "DStarto
             task->SetMCNchHisto(hNchPrimaries);
 	    if(isPPbData) task->SetUseNchTrackletsWeight();
           } else {
-            AliFatal("Histogram for multiplicity weights not found");
+            Printf("FATAL: Histogram for multiplicity weights not found");
             return 0x0;
           }
 	  if(hNchMeasured) task->SetMeasuredNchHisto(hNchMeasured);
@@ -669,8 +670,8 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFCascade(const char* cutFile = "DStarto
 	} else{
 	  TFile* fileEstimator=TFile::Open(estimatorFilename.Data());
 	  if(!fileEstimator)  {
-	    AliFatal("File with multiplicity estimator not found"); 
-	    return;
+	    Printf("FATAL: File with multiplicity estimator not found"); 
+	    return NULL;
 	  }      
 	  task->SetUseZvtxCorrectedNtrkEstimator(kTRUE);
 	  task->SetReferenceMultiplcity(refMult);
@@ -682,8 +683,8 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFCascade(const char* cutFile = "DStarto
 	    for (Int_t ip=0; ip < 2; ip++) {
 	      multEstimatorAvg[ip] = (TProfile*)(fileEstimator->Get(Form("SPDmult10_%s",periodNames[ip]))->Clone(Form("SPDmult10_%s_clone",periodNames[ip])));    
 	      if (!multEstimatorAvg[ip]) {
-		AliFatal(Form("Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]));
-		return;               
+		Printf("FATAL: Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]);
+		return NULL;               
 	      }
 	    }
 	    task->SetMultiplVsZProfileLHC13b(multEstimatorAvg[0]);
@@ -696,8 +697,8 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFCascade(const char* cutFile = "DStarto
 	    for(Int_t ip=0; ip<4; ip++) {
 	      multEstimatorAvg[ip] = (TProfile*)(fileEstimator->Get(Form("SPDmult10_%s",periodNames[ip]))->Clone(Form("SPDmult10_%s_clone",periodNames[ip])));  
 	      if (!multEstimatorAvg[ip]) {
-		AliFatal(Form("Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]));
-		return;               
+		Printf("FATAL: Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]);
+		return NULL;               
 	      }  
 	    }
 	    task->SetMultiplVsZProfileLHC10b(multEstimatorAvg[0]);
@@ -755,7 +756,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFCascade(const char* cutFile = "DStarto
 	nameCorr += suffix;
 
         THnSparseD* correlation = new THnSparseD(nameCorr,"THnSparse with correlations",4,thnDim);
-        Double_t** binEdges = new Double_t[2];
+        Double_t** binEdges = new Double_t*[2];
 
         // set bin limits
 

--- a/PWGHF/vertexingHF/macros/AddTaskCFVertexingHFLctoV0bachelor.C
+++ b/PWGHF/vertexingHF/macros/AddTaskCFVertexingHFLctoV0bachelor.C
@@ -1,3 +1,28 @@
+
+
+//----------------------------------------------------
+
+AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelor(const char* cutFile = "./LctoV0bachelorCuts.root",
+							 Bool_t rejectIfNotFromQuark=kTRUE,
+							 //Bool_t isKeepDfromB = kTRUE, Bool_t isKeepDfromBOnly = kFALSE, // all in
+							 Bool_t isKeepDfromB = kFALSE, Bool_t isKeepDfromBOnly = kFALSE, // prompt
+							 //Bool_t isKeepDfromB = kTRUE, Bool_t isKeepDfromBOnly = kTRUE, // no-prompt
+							 Int_t configuration = AliCFTaskVertexingHF::kCheetah,
+							 Int_t pdgCode = 4122, Char_t isSign = 2, Char_t lcToV0bachelorDecayMode = 0,
+							 TString usercomment = "username",
+							 Bool_t useWeight=kFALSE, 
+							 Bool_t useFlatPtWeight = kFALSE, 
+							 Bool_t useZWeight = kFALSE, 
+							 Bool_t useNchWeight = kFALSE, 
+							 Bool_t useNtrkWeight = kFALSE, 
+							 TString estimatorFilename="", 
+							 Int_t multiplicityEstimator = AliCFTaskVertexingHF::kNtrk10, 
+							 Bool_t isPPData = kTRUE, 
+							 Bool_t isPPbData = kFALSE, 
+							 Double_t refMult = 9.26, 
+							 Bool_t isFineNtrkBin = kFALSE)
+{
+
 //DEFINITION OF A FEW CONSTANTS
 const Double_t ptmin =    0.0; // GeV/c
 const Double_t ptmax = 9999.0; // GeV/c
@@ -45,33 +70,12 @@ const Float_t cosPAmin    =-1.05;
 const Float_t cosPAmax    = 1.05;
 
 
-//----------------------------------------------------
 
-AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelor(const char* cutFile = "./LctoV0bachelorCuts.root",
-							 Bool_t rejectIfNotFromQuark=kTRUE,
-							 //Bool_t isKeepDfromB = kTRUE, Bool_t isKeepDfromBOnly = kFALSE, // all in
-							 Bool_t isKeepDfromB = kFALSE, Bool_t isKeepDfromBOnly = kFALSE, // prompt
-							 //Bool_t isKeepDfromB = kTRUE, Bool_t isKeepDfromBOnly = kTRUE, // no-prompt
-							 Int_t configuration = AliCFTaskVertexingHF::kCheetah,
-							 Int_t pdgCode = 4122, Char_t isSign = 2, Char_t lcToV0bachelorDecayMode = 0,
-							 TString usercomment = "username",
-							 Bool_t useWeight=kFALSE, 
-							 Bool_t useFlatPtWeight = kFALSE, 
-							 Bool_t useZWeight = kFALSE, 
-							 Bool_t useNchWeight = kFALSE, 
-							 Bool_t useNtrkWeight = kFALSE, 
-							 TString estimatorFilename="", 
-							 Int_t multiplicityEstimator = AliCFTaskVertexingHF::kNtrk10, 
-							 Bool_t isPPData = kTRUE, 
-							 Bool_t isPPbData = kFALSE, 
-							 Double_t refMult = 9.26, 
-							 Bool_t isFineNtrkBin = kFALSE)
-{
 
   if ( (isPPData && isPPbData) ||
        (!isPPData && !isPPbData) ) {
     printf("You have to choose the data kind; bad choise isPPData=%d isPPbData=%d\n",isPPData,isPPbData);
-    return;
+    return NULL;
   }
 
   printf("Adding CF task using cuts from file %s\n",cutFile);
@@ -86,7 +90,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelor(const char* cutFile = "
   }
   else{
     printf("The configuration is not defined! returning\n");
-    return;
+    return NULL;
   }
 	       
   gSystem->Sleep(2000);
@@ -97,15 +101,15 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelor(const char* cutFile = "
 
   TString expected;
   if (isSign == 0 && pdgCode < 0){
-    AliError(Form("Error setting PDG code (%d) and sign (0 --> Lc+ only): they are not compatible, returning",pdgCode));
+    Printf("ERROR:Error setting PDG code (%d) and sign (0 --> Lc+ only): they are not compatible, returning",pdgCode);
     return 0x0;
   }
   else if (isSign == 1 && pdgCode > 0){
-    AliError(Form("Error setting PDG code (%d) and sign (1 --> Lc- only): they are not compatible, returning",pdgCode));
+    Printf("ERROR:Error setting PDG code (%d) and sign (1 --> Lc- only): they are not compatible, returning",pdgCode);
     return 0x0;
   }
   else if (isSign > 2 || isSign < 0){
-    AliError(Form("Sign not valid (%d, possible values are 0, 1, 2), returning",isSign));
+    Printf("ERROR:Sign not valid (%d, possible values are 0, 1, 2), returning",isSign);
     return 0x0;
   }
 
@@ -135,7 +139,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelor(const char* cutFile = "
   const Int_t nbincent       =19+1; //bins in centrality (total number)
   const Int_t nbinfake       =   3; //bins in fake
   //const Int_t nbinmult       =  48; //bins in multiplicity (total number)
-  const Int_t nbinmult         = 49; //bins in multiplicity (total number)
+  Int_t nbinmult         = 49; //bins in multiplicity (total number)
   const Int_t nbinmult_0_20    = 20; //bins in multiplicity between 0 and 20
   const Int_t nbinmult_20_50   = 15; //bins in multiplicity between 20 and 50
   const Int_t nbinmult_50_80   = 10; //bins in multiplicity between 50 and 80
@@ -575,7 +579,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelor(const char* cutFile = "
       task->SetMCNchHisto(hNchPrimaries);
       if(isPPbData) task->SetUseNchTrackletsWeight();
     } else {
-      AliFatal("Histogram for multiplicity weights not found");
+      Printf("FATAL: Histogram for multiplicity weights not found");
       return 0x0;
     }
     if(hNchMeasured) task->SetMeasuredNchHisto(hNchMeasured);
@@ -589,8 +593,8 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelor(const char* cutFile = "
   } else {
     TFile* fileEstimator=TFile::Open(estimatorFilename.Data());
     if(!fileEstimator)  {
-      AliFatal("File with multiplicity estimator not found"); 
-      return;
+      Printf("FATAL: File with multiplicity estimator not found"); 
+      return NULL;
     }
     task->SetUseZvtxCorrectedNtrkEstimator(kTRUE);
     task->SetReferenceMultiplcity(refMult);
@@ -605,8 +609,8 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelor(const char* cutFile = "
       for (Int_t ip=0; ip < 2; ip++) {
 	multEstimatorAvg[ip] = (TProfile*)(fileEstimator->Get(Form("SPDmult10_%s",periodNames[ip]))->Clone(Form("SPDmult10_%s_clone",periodNames[ip])));    
 	if (!multEstimatorAvg[ip]) {
-	  AliFatal(Form("Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]));
-	  return;               
+	  Printf("FATAL: Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]);
+	  return NULL;               
 	}
       }
       task->SetMultiplVsZProfileLHC13b(multEstimatorAvg[0]);
@@ -619,8 +623,8 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelor(const char* cutFile = "
       for(Int_t ip=0; ip<4; ip++) {
 	multEstimatorAvg[ip] = (TProfile*)(fileEstimator->Get(Form("SPDmult10_%s",periodNames[ip]))->Clone(Form("SPDmult10_%s_clone",periodNames[ip])));  
 	if (!multEstimatorAvg[ip]) {
-	  AliFatal(Form("Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]));
-	  return;               
+	  Printf("FATAL: Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]);
+	  return NULL;               
 	}  
       }
       task->SetMultiplVsZProfileLHC10b(multEstimatorAvg[0]);
@@ -675,7 +679,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelor(const char* cutFile = "
   }
 
   THnSparseD* correlation = new THnSparseD(nameCorr,"THnSparse with correlations",4,thnDim);
-  Double_t** binEdges = new Double_t[2];
+  Double_t** binEdges = new Double_t*[2];
 
   // set bin limits
 

--- a/PWGHF/vertexingHF/macros/AddTaskCFVertexingHFLctoV0bachelorTMVA.C
+++ b/PWGHF/vertexingHF/macros/AddTaskCFVertexingHFLctoV0bachelorTMVA.C
@@ -1,3 +1,26 @@
+
+//----------------------------------------------------
+
+AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelorTMVA(const char* cutFile = "CutsLc2pK0STMVA_20140311.root", 
+							     TString cutObjectName = "LctoV0AnalysisCuts", 
+							     TString suffix = "TMVA", 
+							     Int_t configuration = AliCFTaskVertexingHF::kCheetah, 
+							     Bool_t isKeepDfromB = kTRUE, 
+							     Bool_t isKeepDfromBOnly = kFALSE, 
+							     Int_t pdgCode = 4122, 
+							     Char_t isSign = 2, 
+							     Bool_t useWeight = kFALSE, 
+							     Bool_t useFlatPtWeight = kFALSE, 
+							     Bool_t useZWeight = kFALSE, 
+							     Bool_t useNchWeight = kFALSE, 
+							     Bool_t useNtrkWeight = kFALSE, 
+							     TString estimatorFilename="", 
+							     Int_t multiplicityEstimator = AliCFTaskVertexingHF::kNtrk10, 
+							     Bool_t isPPData = kFALSE, 
+							     Bool_t isPPbData = kFALSE, 
+							     Double_t refMult = 9.26, 
+							     Bool_t isFineNtrkBin = kFALSE) 
+{
 const Double_t ymin  = -1.2 ;
 const Double_t ymax  =  1.2 ;
 const Double_t cosminTS = -1.05;
@@ -32,7 +55,7 @@ const Float_t centmin_60_100 = 60.;
 const Float_t centmax_60_100 = 100.;
 const Float_t centmax = 100.;
 const Float_t fakemin = -0.5;
-const Float_t fakemax = 2.5.;
+const Float_t fakemax = 2.5;
 const Float_t cosminXY = 0.95;
 const Float_t cosmaxXY = 1.0;
 const Float_t normDecLXYmin = 0;
@@ -48,29 +71,6 @@ const Float_t multmax_80_100 = 100;
 const Float_t multmin_100_400 = 100;
 const Float_t multmax_100_400 = 400;
 
-
-//----------------------------------------------------
-
-AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelorTMVA(const char* cutFile = "CutsLc2pK0STMVA_20140311.root", 
-							     TString cutObjectName = "LctoV0AnalysisCuts", 
-							     TString suffix = "TMVA", 
-							     Int_t configuration = AliCFTaskVertexingHF::kCheetah, 
-							     Bool_t isKeepDfromB = kTRUE, 
-							     Bool_t isKeepDfromBOnly = kFALSE, 
-							     Int_t pdgCode = 4122, 
-							     Char_t isSign = 2, 
-							     Bool_t useWeight = kFALSE, 
-							     Bool_t useFlatPtWeight = kFALSE, 
-							     Bool_t useZWeight = kFALSE, 
-							     Bool_t useNchWeight = kFALSE, 
-							     Bool_t useNtrkWeight = kFALSE, 
-							     TString estimatorFilename="", 
-							     Int_t multiplicityEstimator = AliCFTaskVertexingHF::kNtrk10, 
-							     Bool_t isPPData = kFALSE, 
-							     Bool_t isPPbData = kFALSE, 
-							     Double_t refMult = 9.26, 
-							     Bool_t isFineNtrkBin = kFALSE) 
-{
   printf("Adding CF task using cuts from file %s\n",cutFile);
   if (configuration == AliCFTaskVertexingHF::kSnail){
     printf("The configuration is set to be SLOW --> all the variables will be used to fill the CF\n");
@@ -83,7 +83,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelorTMVA(const char* cutFile
   }
   else{
     printf("The configuration is not defined! returning\n");
-    return;
+    return NULL;
   }
 	       
   gSystem->Sleep(2000);
@@ -94,21 +94,21 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelorTMVA(const char* cutFile
 
   TString expected;
   if (isSign == 0 && pdgCode < 0){
-    AliError(Form("Error setting PDG code (%d) and sign (0 --> D* only): they are not compatible, returning"));
+    Printf("ERROR:Error setting PDG code (%d) and sign (0 --> D* only): they are not compatible, returning",pdgCode);
     return 0x0;
   }
   else if (isSign == 1 && pdgCode > 0){
-    AliError(Form("Error setting PDG code (%d) and sign (1 --> D*bar only): they are not compatible, returning"));
+    Printf("ERROR:Error setting PDG code (%d) and sign (1 --> D*bar only): they are not compatible, returning",pdgCode);
     return 0x0;
   }
   else if (isSign > 2 || isSign < 0){
-    AliError(Form("Sign not valid (%d, possible values are 0, 1, 2), returning"));
+    Printf("ERROR:Sign not valid (%d, possible values are 0, 1, 2), returning",isSign);
     return 0x0;
   }
 
   TFile* fileCuts = TFile::Open(cutFile);
   if(!fileCuts || (fileCuts && !fileCuts->IsOpen())){ 
-    AliError("Wrong cut file");
+    Printf("ERROR: Wrong cut file");
     return 0x0;
   }
 
@@ -289,11 +289,11 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelorTMVA(const char* cutFile
   // centrality
   for(Int_t i=0; i<=nbincent_0_10; i++) binLimcent[i] = (Double_t)centmin_0_10 + (centmax_0_10-centmin_0_10)/nbincent_0_10*(Double_t)i ; 
   if (binLimcent[nbincent_0_10] != centmin_10_60)  {
-    Error("AliCFHeavyFlavourTaskMultiVarMultiStep","Calculated bin lim for cent - 1st range - differs from expected!\n");
+    Printf("Error: Calculated bin lim for cent - 1st range - differs from expected!\n");
   }
   for(Int_t i=0; i<=nbincent_10_60; i++) binLimcent[i+nbincent_0_10] = (Double_t)centmin_10_60 + (centmax_10_60-centmin_10_60)/nbincent_10_60*(Double_t)i ;
   if (binLimcent[nbincent_0_10+nbincent_10_60] != centmin_60_100)  {
-    Error("AliCFHeavyFlavourTaskMultiVarMultiStep","Calculated bin lim for cent - 2st range - differs from expected!\n");
+    Printf("Error: Calculated bin lim for cent - 2st range - differs from expected!\n");
   }
   for(Int_t i=0; i<=nbincent_60_100; i++) binLimcent[i+nbincent_0_10+nbincent_10_60] = (Double_t)centmin_60_100 + (centmax_60_100-centmin_60_100)/nbincent_60_100*(Double_t)i ;
 
@@ -614,7 +614,7 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelorTMVA(const char* cutFile
       task->SetMCNchHisto(hNchPrimaries);
       if(isPPbData) task->SetUseNchTrackletsWeight();
     } else {
-      AliFatal("Histogram for multiplicity weights not found");
+      Printf("FATAL: Histogram for multiplicity weights not found");
       return 0x0;
     }
     if(hNchMeasured) task->SetMeasuredNchHisto(hNchMeasured);
@@ -628,8 +628,8 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelorTMVA(const char* cutFile
   } else{
     TFile* fileEstimator=TFile::Open(estimatorFilename.Data());
     if(!fileEstimator)  {
-      AliFatal("File with multiplicity estimator not found"); 
-      return;
+      Printf("FATAL: File with multiplicity estimator not found"); 
+      return NULL;
     }      
     task->SetUseZvtxCorrectedNtrkEstimator(kTRUE);
     task->SetReferenceMultiplcity(refMult);
@@ -641,8 +641,8 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelorTMVA(const char* cutFile
       for (Int_t ip=0; ip < 2; ip++) {
 	multEstimatorAvg[ip] = (TProfile*)(fileEstimator->Get(Form("SPDmult10_%s",periodNames[ip]))->Clone(Form("SPDmult10_%s_clone",periodNames[ip])));    
 	if (!multEstimatorAvg[ip]) {
-	  AliFatal(Form("Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]));
-	  return;               
+	  Printf(Form("FATAL: Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]));
+	  return NULL;               
 	}
       }
       task->SetMultiplVsZProfileLHC13b(multEstimatorAvg[0]);
@@ -655,8 +655,8 @@ AliCFTaskVertexingHF *AddTaskCFVertexingHFLctoV0bachelorTMVA(const char* cutFile
       for(Int_t ip=0; ip<4; ip++) {
 	multEstimatorAvg[ip] = (TProfile*)(fileEstimator->Get(Form("SPDmult10_%s",periodNames[ip]))->Clone(Form("SPDmult10_%s_clone",periodNames[ip])));  
 	if (!multEstimatorAvg[ip]) {
-	  AliFatal(Form("Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]));
-	  return;               
+	  Printf(Form("FATAL: Multiplicity estimator for %s not found! Please check your estimator file",periodNames[ip]));
+	  return NULL;               
 	}  
       }
       task->SetMultiplVsZProfileLHC10b(multEstimatorAvg[0]);

--- a/PWGHF/vertexingHF/macros/AddTaskCombinHF.C
+++ b/PWGHF/vertexingHF/macros/AddTaskCombinHF.C
@@ -26,11 +26,12 @@ AliAnalysisTaskCombinHF *AddTaskCombinHF(Int_t meson = 0,
   
   AliRDHFCuts* analysiscuts=0x0;
   AliAODPidHF* pid=0x0;
+  AliESDtrackCuts* esdc = 0x0;
   if(!cutObjFile.IsNull()){
     TFile *f=TFile::Open(cutObjFile.Data(),"READ");
     if(f){
       analysiscuts=(AliRDHFCuts*)f->Get(cutObjNam.Data());
-      AliESDtrackCuts *esdc=analysiscuts->GetTrackCuts();
+      esdc=analysiscuts->GetTrackCuts();
       pid=analysiscuts->GetPidHF();
     }
   }

--- a/PWGHF/vertexingHF/macros/AddTaskImproveITS.C
+++ b/PWGHF/vertexingHF/macros/AddTaskImproveITS.C
@@ -20,9 +20,9 @@ AliAnalysisTaskSEImproveITS *AddTaskImproveITS(Bool_t isRunInVertexing=kFALSE, /
   outputFileName+=":ITSImprover";
   AliAnalysisDataContainer *coutput
      =mgr->CreateContainer("debug",
-                           TNtuple::Class(),
+                           TList::Class(),
                            AliAnalysisManager::kOutputContainer,
-                           outputFileName);
+                           outputFileName.Data());
   
   mgr->ConnectInput (task,0,mgr->GetCommonInputContainer());
   mgr->ConnectOutput(task,1,coutput);

--- a/PWGHF/vertexingHF/macros/AddTaskLambdac.C
+++ b/PWGHF/vertexingHF/macros/AddTaskLambdac.C
@@ -1,4 +1,4 @@
-AliAnalysisTaskSE *AddTaskLambdac(TString finname,Bool_t storeNtuple,Bool_t readMC,Bool_t MCPid,Bool_t realPid,Bool_t resPid,Bool_t useKF,
+ AliAnalysisTaskSELambdac* AddTaskLambdac(TString finname,Bool_t storeNtuple,Bool_t readMC,Bool_t MCPid,Bool_t realPid,Bool_t resPid,Bool_t useKF,
 				  Bool_t fillVarHists=kFALSE, Bool_t priorsHists=kFALSE, Bool_t multiplicityHists=kFALSE, Int_t syst=0, Int_t bit=0,  TString postname="")
 {
   //==============================================================================                                                      


### PR DESCRIPTION
fixes ROOT6 compilation errors for multiple PWGHFvertexingHF AddTask macros, and a segfault in the AliAnalysisTaskSEImproveITS task that appeared under ROOT6 due to the streaming of some TGraph objects [now uses TObject::Clone method instead of TGraph's copy constructor].