### PR TITLE
PWGHF/jetsHF/AliAnalysisTaskHFJetIPQA: adding new histograms

### DIFF
--- a/PWGHF/jetsHF/AliAnalysisTaskHFJetIPQA.h
+++ b/PWGHF/jetsHF/AliAnalysisTaskHFJetIPQA.h
@@ -72,12 +72,13 @@ public:
 
     //UTILITY STRUCT DEFINITIONS
     struct SJetIpPati {
-        SJetIpPati(Double_t v1, Double_t v2, Bool_t b, Bool_t c,Int_t tl): first(v1),second(v2),is_electron(b),is_fromB(c),trackLabel(tl){}
+        SJetIpPati(Double_t v1, Double_t v2, Bool_t b, Bool_t c,Int_t tl,Double_t pt): first(v1),second(v2),is_electron(b),is_fromB(c),trackLabel(tl),trackpt(pt){}
         Double_t first; // to be compatible with std::pair
         Double_t second;// to be compatible with std::pair
         Bool_t   is_electron; // added for electron contribution check
         Bool_t   is_fromB; // added for electron contribution check
         Int_t trackLabel=-1 ;
+        Double_t trackpt=-99;
     };
     //FUNCTION DEFINITIONS
     AliAnalysisTaskHFJetIPQA();
@@ -111,6 +112,7 @@ public:
     AliExternalTrackParam GetExternalParamFromJet(const AliEmcalJet *jet, const AliAODEvent *event);
     Bool_t GetImpactParameterWrtToJet(const AliAODTrack *track, const AliAODEvent *event, const AliEmcalJet *jet, Double_t *dca, Double_t *cov, Double_t *XYZatDCA, Double_t &jetsign);
     Bool_t getJetVtxMass( AliEmcalJet *jet, double &value);
+    void SetJetRadius(Double_t fJetRadRead){fJetRadius=fJetRadRead;}
     int GetMCTruth(AliAODTrack *track, int &motherpdg);
     bool GetPIDCombined(AliAODTrack * track, double *prob, int &nDetectors, UInt_t &usedDet , AliPID::EParticleType &MostProbablePID, bool setTrackPID );
     void setFProductionNumberPtHard(Int_t value=-1)
@@ -255,6 +257,7 @@ private:
     AliPIDCombined *fCombined ;//!
     Float_t fXsectionWeightingFactor;//
     Int_t   fProductionNumberPtHard;//
+    Double_t fJetRadius;//
     Double_t fMCglobalDCAxyShift;//
     Double_t fMCglobalDCASmear;//
     Double_t fVertexRecalcMinPt;//
@@ -324,7 +327,7 @@ private:
 
 
 
-    ClassDef(AliAnalysisTaskHFJetIPQA, 27)
+    ClassDef(AliAnalysisTaskHFJetIPQA, 28)
 };
 
 #endif

--- a/PWGHF/jetsHF/macros/AddTaskHFJetIPQA.C
+++ b/PWGHF/jetsHF/macros/AddTaskHFJetIPQA.C
@@ -106,6 +106,7 @@ AliAnalysisTaskHFJetIPQA* AddTaskHFJetIPQA(
     combinedName.Form("%s%s", name.Data(),suffix);
     AliAnalysisTaskHFJetIPQA* jetTask = new AliAnalysisTaskHFJetIPQA(combinedName);
     if(useCorrelationTree) jetTask->useTreeForCorrelations(kTRUE);
+    jetTask->SetJetRadius(jetradius);
 
     if(isMC && fileMCoverDataWeights){
         TH1F * h[20] = {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0};
@@ -119,6 +120,8 @@ AliAnalysisTaskHFJetIPQA* AddTaskHFJetIPQA(
         Printf("%s :: Weights written to analysis task.",taskname);
         if(fileMCoverDataWeights) fileMCoverDataWeights->Close();
     }
+
+
 
     // Load and setup Fluka correction factors from file
     //==============================================================================


### PR DESCRIPTION
- adding new QA histograms (fh1dJetArea, fh1dParticlesPerJet, fh2dNoAcceptedTracksvsJetArea, fh1dTrackPt_n_%i_all_Accepted, fh1dNoParticlesPerEvent, fh1dNoJetsPerEvent )
- expand struct SjetIpPati to contain also track pt
- go from fixed radius R=0.4 to flexible radius via new function SetJetRadius
- tidy up histogram generation in UserCreateOutputObjects
