### PR TITLE
EMCal CorrFW: Implement cluster energy scaling/smearing component

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterEnergyVariation.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterEnergyVariation.cxx
@@ -1,0 +1,104 @@
+// AliEmcalCorrectionClusterEnergyVariation
+//
+
+#include "AliEmcalCorrectionClusterEnergyVariation.h"
+
+#include "AliClusterContainer.h"
+
+/// \cond CLASSIMP
+ClassImp(AliEmcalCorrectionClusterEnergyVariation);
+/// \endcond
+
+// Actually registers the class with the base class
+RegisterCorrectionComponent<AliEmcalCorrectionClusterEnergyVariation> AliEmcalCorrectionClusterEnergyVariation::reg("AliEmcalCorrectionClusterEnergyVariation");
+
+/**
+ * Default constructor
+ */
+AliEmcalCorrectionClusterEnergyVariation::AliEmcalCorrectionClusterEnergyVariation() :
+  AliEmcalCorrectionComponent("AliEmcalCorrectionClusterEnergyVariation"),
+  fEnergyScaleShift(0.),
+  fSmearingWidth(0.),
+  fRandom(0)
+{
+}
+
+/**
+ * Destructor
+ */
+AliEmcalCorrectionClusterEnergyVariation::~AliEmcalCorrectionClusterEnergyVariation()
+{
+}
+
+/**
+ * Initialize and configure the component.
+ */
+Bool_t AliEmcalCorrectionClusterEnergyVariation::Initialize()
+{
+  // Initialization
+  AliEmcalCorrectionComponent::Initialize();
+  
+  GetProperty("energyScaleShift", fEnergyScaleShift);
+  GetProperty("smearingWidth", fSmearingWidth);
+
+  return kTRUE;
+}
+
+/**
+ * Create run-independent objects for output. Called before running over events.
+ */
+void AliEmcalCorrectionClusterEnergyVariation::UserCreateOutputObjects()
+{   
+  AliEmcalCorrectionComponent::UserCreateOutputObjects();
+}
+
+/**
+ * Called before the first event to initialize the correction.
+ */
+void AliEmcalCorrectionClusterEnergyVariation::ExecOnce()
+{
+  fRandom.SetSeed(0);
+}
+
+/**
+ * Called for each event to process the event data.
+ */
+Bool_t AliEmcalCorrectionClusterEnergyVariation::Run()
+{
+  AliEmcalCorrectionComponent::Run();
+  
+  // Loop over all clusters
+  AliTLorentzVector clusFourVec;
+  AliVCluster *cluster = 0;
+  AliClusterContainer * clusCont = 0;
+  TIter nextClusCont(&fClusterCollArray);
+  while ((clusCont = static_cast<AliClusterContainer*>(nextClusCont()))) {
+    auto clusItCont = clusCont->all_momentum();
+    for (AliClusterIterableMomentumContainer::iterator clusIterator = clusItCont.begin(); clusIterator != clusItCont.end(); ++clusIterator) {
+      
+      // Get the cluster energy (using the default energy type set in the cluster container)
+      clusFourVec.Clear();
+      clusFourVec = clusIterator->first;
+      Double_t energyclus = clusFourVec.E();
+
+      // Scale energy (if applicable)
+      if (TMath::Abs(fEnergyScaleShift) > 1e-6) {
+        energyclus *= (1 + fEnergyScaleShift);
+      }
+      
+      // Smear energy (if applicable)
+      if (fSmearingWidth > 1e-6) {
+        energyclus *= (1 + fRandom.Gaus(0, fSmearingWidth) );
+      }
+      
+      // Set the shifted/smeared energy to the user-defined energy field
+      cluster = static_cast<AliVCluster *>(clusIterator->second);
+      if (cluster->IsEMCAL() && energyclus > 0) {
+        cluster->SetUserDefEnergy(AliVCluster::kUserDefEnergy1, energyclus);
+      }
+      
+    }
+  }
+
+  return kTRUE;
+}

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterEnergyVariation.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterEnergyVariation.h
@@ -1,0 +1,53 @@
+#ifndef ALIEMCALCORRECTIONCLUSTERENERGYVARIATION_H
+#define ALIEMCALCORRECTIONCLUSTERENERGYVARIATION_H
+
+#include "AliEmcalCorrectionComponent.h"
+
+#include "TRandom3.h"
+
+/**
+ * @class AliEmcalCorrectionClusterEnergyVariation
+ * @ingroup EMCALCOREFW
+ * @brief Cluster energy variation component in the EMCal correction framework, for EMCal systematics.
+ *
+ * This component allows the cluster energy to be scaled by a constant factor and smeared by a random value drawn
+ * from a Gaussian with specified width. Note that you must configure the input cluster container (in the YAML file)
+ * with the desired default cluster energy type (nonlincorr, hadcorr, etc) to be shifted/smeared.
+ * The shifted/smeared energy is written into the user-defined cluster energy field AliVCluster::kUserDefEnergy1,
+ * which can then be retrieved in later tasks through AliVCluster::GetUserDefEnergy() or through the usual cluster
+ * container machinery (see http://alidoc.cern.ch/AliPhysics/master/READMEcontainers.html#emcalContainerClusterEnergyCorrections).
+ *
+ * @author James Mulligan <james.mulligan@yale.edu>, Yale University
+ * @date Oct 30 2018
+ */
+
+class AliEmcalCorrectionClusterEnergyVariation : public AliEmcalCorrectionComponent {
+ public:
+  AliEmcalCorrectionClusterEnergyVariation();
+  virtual ~AliEmcalCorrectionClusterEnergyVariation();
+
+  // Sets up and runs the task
+  Bool_t Initialize();
+  void UserCreateOutputObjects();
+  void ExecOnce();
+  Bool_t Run();
+  
+protected:
+  Double_t               fEnergyScaleShift;               ///< Fraction of cluster energy to shift (positive means upward shift)
+  Double_t               fSmearingWidth;                  ///< Width of Gaussian used to smear cluster energy
+  
+  TRandom3               fRandom;                         //!<! Random number generator for cluster energy smearing
+
+ private:
+  AliEmcalCorrectionClusterEnergyVariation(const AliEmcalCorrectionClusterEnergyVariation &);               // Not implemented
+  AliEmcalCorrectionClusterEnergyVariation &operator=(const AliEmcalCorrectionClusterEnergyVariation &);    // Not implemented
+
+  // Allows the registration of the class so that it is available to be used by the correction task.
+  static RegisterCorrectionComponent<AliEmcalCorrectionClusterEnergyVariation> reg;
+  
+  /// \cond CLASSIMP
+  ClassDef(AliEmcalCorrectionClusterEnergyVariation, 1); // EMCal cluster energy variation component
+  /// \endcond
+};
+
+#endif /* ALIEMCALCORRECTIONCLUSTERENERGYVARIATION_H */

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
@@ -890,14 +890,13 @@ void AliEmcalCorrectionTask::SetupContainer(const AliEmcalContainerUtils::InputO
   AliClusterContainer * clusterContainer = dynamic_cast<AliClusterContainer *>(cont);
   if (clusterContainer) {
     // Default energy
-    // Probably not needed for the corrections
-    /*result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "defaultClusterEnergy", tempString, false);
+    result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "defaultClusterEnergy", tempString, false);
     if (result) {
       // Need to get the enumeration
       AliVCluster::VCluUserDefEnergy_t clusterEnergyType = AliClusterContainer::fgkClusterEnergyTypeMap.at(tempString);
       AliDebugStream(2) << clusterContainer->GetName() << ": Setting cluster energy type to " << clusterEnergyType << std::endl;
       clusterContainer->SetDefaultClusterEnergy(clusterEnergyType);
-    }*/
+    }
 
     // NonLinCorrEnergyCut
     result = fYAMLConfig.GetProperty(inputObjectPropertiesPath, "clusNonLinCorrEnergyCut", tempDouble, false);

--- a/PWG/EMCAL/EMCALtasks/CMakeLists.txt
+++ b/PWG/EMCAL/EMCALtasks/CMakeLists.txt
@@ -78,6 +78,7 @@ set(SRCS
   AliEmcalCorrectionClusterExotics.cxx
   AliEmcalCorrectionClusterTrackMatcher.cxx
   AliEmcalCorrectionClusterHadronicCorrection.cxx
+  AliEmcalCorrectionClusterEnergyVariation.cxx
   AliEmcalCorrectionPHOSCorrections.cxx
   AliAnalysisTaskEmcalOccupancy.cxx
   TestAliEmcalAODFilterBitCuts.cxx

--- a/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
+++ b/PWG/EMCAL/EMCALtasks/PWGEMCALtasksLinkDef.h
@@ -46,6 +46,7 @@
 #pragma link C++ class  AliEmcalCorrectionClusterExotics+;
 #pragma link C++ class  AliEmcalCorrectionClusterTrackMatcher+;
 #pragma link C++ class  AliEmcalCorrectionClusterHadronicCorrection+;
+#pragma link C++ class  AliEmcalCorrectionClusterEnergyVariation+;
 #pragma link C++ class  std::map<AliVTrack *,AliParticleContainer *>+;
 #pragma link C++ class  std::pair<AliVTrack *,AliParticleContainer *>+;
 #pragma link C++ class  AliEmcalCorrectionPHOSCorrections+;

--- a/PWG/EMCAL/READMEemcCorrections.txt
+++ b/PWG/EMCAL/READMEemcCorrections.txt
@@ -236,6 +236,7 @@ __Clusters__ (Includes all options for EMCal Containers):
 | --------------------- | --------------------------------- |
 | clusNonLinCorrEnergyCut | Double determining the cluster non-linearity energy cut |
 | clusHadCorrEnergyCut  | Double determining the cluster hadronic cluster energy cut |
+| defaultClusterEnergy  | String defining the default energy type of the container (kNonLinCorr, kHadCorr, ...) |
 | includePHOS           | True if PHOS cluster should be included |
 
 __Tracks__ (Includes all options for EMCal Containers):

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -22,6 +22,11 @@ inputObjects:                                       # Define all of the input ob
             minE: 0.0                               # Cluster min E.
             minPt: 0.0                              # Cluster min pt.
             clusNonLinCorrEnergyCut: 0.15           # Cluster non-linearity min E. Formerly "minPt" in the non-linearity AddTask()
+        defaultClusterContainer_3:                  # Name of another cluster input which inherits from defaultClusterContainer
+            # The branch name is inherited from defaultClusterContainer!
+            minE: 0.0                               # Cluster min E.
+            minPt: 0.0                              # Cluster min pt.
+            defaultClusterEnergy: kHadCorr          # Default energy type
     trackContainers:                                # Configure tracks
         # The user can select the name of each container
         # The names don't need to correspond to any particular scheme
@@ -234,6 +239,13 @@ ClusterHadronicCorrection:                          # Cluster hadronic correctio
         - defaultClusterContainer_2                 # This object is defined above in the cluster section of the input objects
     trackContainersNames:                           # Names of the track input objects which should be attached to the correection
         - defaultTrackContainer_1                   # This object is defined above in the track section of the input objects
+ClusterEnergyVariation:                             # Cluster energy shift correction component (for systematics studies)
+    enabled: false                                  # Whether to enable the task
+    createHistos: false                             # Whether the task should create output histograms
+    energyScaleShift: 0.                            # Fraction of cluster energy to shift (positive means upward shift)
+    smearingWidth: 0.                               # Width of Gaussian used to smear cluster energy
+    clusterContainersNames:                         # Names of the cluster input objects which should be attached to the correction
+        - defaultClusterContainer_3                 # This object is defined above in the cluster section of the input objects
 PHOSCorrections:                                    # PHOS recalibration component (wraps PHOS Tender Supply)
     enabled: false                                  # Whether to enable the task
     isMC: false                                     # Whether is MC
@@ -253,4 +265,5 @@ executionOrder:
     - ClusterNonLinearity
     - ClusterTrackMatcher
     - ClusterHadronicCorrection
+    - ClusterEnergyVariation
     - PHOSCorrections


### PR DESCRIPTION
Please do not approve yet.

This is a draft of how we could implement scaling/smearing of the cluster energy in order to evaluate systematics, e.g. in jet analyses, but also available for everyone.

@efranzis @raymondEhlers please let me know what you think.