### PR TITLE
Fix for a wrong index assignment storing NUA and NUE corrections

### DIFF
--- a/PWGCF/Correlations/DPhi/Unfoldedhistos/AliDptDptCorrelations.cxx
+++ b/PWGCF/Correlations/DPhi/Unfoldedhistos/AliDptDptCorrelations.cxx
@@ -690,15 +690,14 @@ Bool_t AliDptDptCorrelations::SetWeigths(const TH3F *h3_1, const TH3F *h3_2) {
   Bool_t done = kTRUE;
 
   if (fUseWeights){
-    Int_t ixZ, ixEtaPhi, ixPt;
     if (h3_1) {
       /* allocate memory for track 1 weights */
       fCorrectionWeights_1 = new Float_t[fNBins_vertexZ*fNBins_etaPhi_1*fNBins_pt_1];
 
-      for (ixZ = 0; ixZ < fNBins_vertexZ; ixZ++) {
+      for (Int_t ixZ = 0; ixZ < fNBins_vertexZ; ixZ++) {
         Double_t zval = fMin_vertexZ + fWidth_vertexZ*(ixZ+0.5);
-        for (ixEtaPhi=0; ixEtaPhi < fNBins_etaPhi_1; ixEtaPhi++) {
-          for (ixPt=0; ixPt < fNBins_pt_1; ixPt++) {
+        for (Int_t ixEtaPhi=0; ixEtaPhi < fNBins_etaPhi_1; ixEtaPhi++) {
+          for (Int_t ixPt=0; ixPt < fNBins_pt_1; ixPt++) {
             Double_t pTval = fMin_pt_1 + fWidth_pt_1*(ixPt+0.5);
             fCorrectionWeights_1[ixZ*fNBins_etaPhi_1*fNBins_pt_1+ixEtaPhi*fNBins_pt_1+ixPt] = h3_1->GetBinContent(h3_1->GetXaxis()->FindBin(zval),ixEtaPhi+1,h3_1->GetZaxis()->FindBin(pTval));
           }
@@ -714,11 +713,11 @@ Bool_t AliDptDptCorrelations::SetWeigths(const TH3F *h3_1, const TH3F *h3_2) {
       /* allocate memory for track 1 weights */
       fCorrectionWeights_2 = new Float_t[fNBins_vertexZ*fNBins_etaPhi_2*fNBins_pt_2];
 
-      for (ixZ = 0; ixZ < fNBins_vertexZ; ixZ++) {
+      for (Int_t ixZ = 0; ixZ < fNBins_vertexZ; ixZ++) {
         Double_t zval = fMin_vertexZ + fWidth_vertexZ*(ixZ+0.5);
-        for (ixEtaPhi=0; ixEtaPhi < fNBins_etaPhi_2; ixEtaPhi++) {
-          Double_t pTval = fMin_pt_2 + fWidth_pt_2*(ixPt+0.5);
-          for (ixPt=0; ixPt < fNBins_pt_2; ixPt++) {
+        for (Int_t ixEtaPhi=0; ixEtaPhi < fNBins_etaPhi_2; ixEtaPhi++) {
+          for (Int_t ixPt=0; ixPt < fNBins_pt_2; ixPt++) {
+            Double_t pTval = fMin_pt_2 + fWidth_pt_2*(ixPt+0.5);
             fCorrectionWeights_2[ixZ*fNBins_etaPhi_2*fNBins_pt_2+ixEtaPhi*fNBins_pt_2+ixPt] = h3_2->GetBinContent(h3_2->GetXaxis()->FindBin(zval),ixEtaPhi+1,h3_2->GetZaxis()->FindBin(pTval));
           }
         }


### PR DESCRIPTION
The latest modification, for re-using weights when shortening the pT or
zvtx ranges, was wrongly implemented