### PR TITLE
Add missing protection for nullptr in cut array

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelection.cxx
@@ -116,6 +116,10 @@ void AliEmcalTrackSelection::AddTrackCuts(PWG::EMCAL::AliEmcalCutBase *cuts) {
 }
 
 void AliEmcalTrackSelection::AddTrackCuts(TObjArray *cuts){
+  if(!cuts) {
+    AliErrorStream() << "Not setting cuts since cut array is null" << std::endl; 
+    return;
+  }
   for(auto c : *cuts){
     PWG::EMCAL::AliEmcalCutBase *emccuts = dynamic_cast<PWG::EMCAL::AliEmcalCutBase*>(c);
     if(emccuts){

--- a/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
+++ b/PWG/EMCAL/EMCALbase/AliTrackContainer.cxx
@@ -150,7 +150,7 @@ void AliTrackContainer::SetArray(const AliVEvent *event)
           fEmcalTrackSelection->SetSelectionModeAll();
         }
 
-        fEmcalTrackSelection->AddTrackCuts(fListOfCuts);
+        if(fListOfCuts) fEmcalTrackSelection->AddTrackCuts(fListOfCuts);
       }
     }
     else {


### PR DESCRIPTION
In case only cuts on the AOD filter bit are applied, and
no additional track cuts, the cut array typically is a
nullptr, leading to a segfault dereferencing the array.
The function AddTrackCuts is only called in case the
array is not null. Furthermore the function checks itself
that the array is not null.