### PR TITLE
Use proper non-linearity function for MC

### DIFF
--- a/PWG/EMCAL/config/EMCalSampleConfigMC.yaml
+++ b/PWG/EMCAL/config/EMCalSampleConfigMC.yaml
@@ -20,6 +20,7 @@ ClusterExotics:
 ClusterNonLinearity:
     enabled: true
     createHistos: true
+    nonLinFunct: kPi0MCv3
 ClusterTrackMatcher:
     enabled: true
     createHistos: true

--- a/PWG/EMCAL/config/PWGJESampleConfigMC.yaml
+++ b/PWG/EMCAL/config/PWGJESampleConfigMC.yaml
@@ -20,6 +20,7 @@ ClusterExotics:
 ClusterNonLinearity:
     enabled: true
     createHistos: true
+    nonLinFunct: kPi0MCv3
 ClusterTrackMatcher:
     enabled: true
     createHistos: true


### PR DESCRIPTION
The non-linearity function must be specified explicitly for simulation,
otherwise the default function kTestbeamCorrectedv3 is used, which is
not the correct one for simulations