### PR TITLE
Fixes some errors in AliAnalysisTaskGammaHadron

### DIFF
--- a/PWGGA/EMCALTasks/AliAnalysisTaskGammaHadron.cxx
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskGammaHadron.cxx
@@ -521,6 +521,7 @@ void AliAnalysisTaskGammaHadron::UserCreateOutputObjects()
      	maxThn[dimThn] = centBinArray[nCentHistBins];
      	dimThn++;
     }
+
     if(fPlotQA==0)
     {
      	fCorrVsManyThings   = new THnSparseF("CorrVsManyThings", "CorrVsManyThings", dimThn, nbinsThn, minThn, maxThn);
@@ -1042,8 +1043,10 @@ void AliAnalysisTaskGammaHadron::UserCreateOutputObjects()
 				//..only if there is an eta dependency given
 				if(funcpEta_left[cent]->GetParameter(0)!=0 && funcpEta_right[cent]->GetParameter(0)!=0)
 				{
-					if(eta<=-0.04)DetectionEff*=funcpEta_left[cent]->Eval(eta,0,0);
-					else          DetectionEff*=funcpEta_right[cent]->Eval(eta,0,0);
+					if(TMath::Abs(eta) < 0.9) { //functions have singularity at .91
+						if(eta<=-0.04)DetectionEff*=funcpEta_left[cent]->Eval(eta,0,0);
+						else          DetectionEff*=funcpEta_right[cent]->Eval(eta,0,0);
+					}
 				}
 				if(fCorrectEff==1)fEffCorrectionCheck[cent]->SetBinContent(j,k,DetectionEff/fscaleEta[cent]);
 				if(fCorrectEff==0)fEffCorrectionCheck[cent]->SetBinContent(j,k,1);
@@ -2817,8 +2820,8 @@ Bool_t AliAnalysisTaskGammaHadron::DetermineMatchedTrack(AliVCluster* caloCluste
 		Double_t phiCut = fTrackMatchPhi;
 		Double_t trackPt = track->Pt();
 
-		fMatchDeltaPhiTrackPt->Fill(trackPt,etadiff);
-		fMatchDeltaEtaTrackPt->Fill(trackPt,phidiff);
+		fMatchDeltaPhiTrackPt->Fill(trackPt,phidiff);
+		fMatchDeltaEtaTrackPt->Fill(trackPt,etadiff);
 		//
 		// For input -1 or 0, use the parametrized track matching cuts given in https://alice-notes.web.cern.ch/node/813
 		if (etaCut <= 0) etaCut = 0.010 + TMath::Power((trackPt + 4.07), -2.5);

--- a/PWGGA/EMCALTasks/AliAnalysisTaskGammaHadron.h
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskGammaHadron.h
@@ -146,11 +146,9 @@ public:
   static const Int_t          kNoGammaBins=9;            ///< Bins in gamma pT
   static const Int_t          kNoZtBins=7;               ///< Bins in Zt
   static const Int_t          kNoXiBins=8;               ///< Bins in Xi
-  static const Int_t          kNoHPtBins=8;               ///< Bins in hadron pT
   Double_t                    fArray_G_Bins[10];         ///< 10=kNoGammaBins+1
   Double_t                    fArray_ZT_Bins[8];         ///< 8=kNoZtBins+1
   Double_t                    fArray_XI_Bins[9];         ///< 9=kNoXiBins+1
-  Double_t                    fArray_HPT_Bins[9];        ///< 9=kNoHPtBins+1
   Double_t                    fArrayNVertBins[21];       ///< 21=kNvertBins+1
 
   //..cuts

--- a/PWGGA/EMCALTasks/AliAnalysisTaskGammaHadron.h
+++ b/PWGGA/EMCALTasks/AliAnalysisTaskGammaHadron.h
@@ -51,7 +51,7 @@ public:
   void                        SetSubDetector(Int_t input)                           { fSubDetector     = input; }
   void                        SetEvtMixType(UInt_t input)                           { fMixingEventType = input  ; }
   void                        SetVetoTrigger(UInt_t input)                          { fVetoTrigger = input  ; }
-  void                        SetClEnergyMin(Int_t input)                           { fClEnergyMin     = input;}
+  void                        SetClEnergyMin(Double_t input)                        { fClEnergyMin     = input;}
   void                        SetOpeningAngleCut(Double_t input)                    { fOpeningAngleCut = input;}
   void                        SetNLM(Int_t input)                                   { fMaxNLM          = input;}
   void                        SetM02(Double_t inputMin,Double_t inputMax)           { fClShapeMin = inputMin; fClShapeMax = inputMax;}
@@ -146,9 +146,11 @@ public:
   static const Int_t          kNoGammaBins=9;            ///< Bins in gamma pT
   static const Int_t          kNoZtBins=7;               ///< Bins in Zt
   static const Int_t          kNoXiBins=8;               ///< Bins in Xi
+  static const Int_t          kNoHPtBins=8;               ///< Bins in hadron pT
   Double_t                    fArray_G_Bins[10];         ///< 10=kNoGammaBins+1
   Double_t                    fArray_ZT_Bins[8];         ///< 8=kNoZtBins+1
   Double_t                    fArray_XI_Bins[9];         ///< 9=kNoXiBins+1
+  Double_t                    fArray_HPT_Bins[9];        ///< 9=kNoHPtBins+1
   Double_t                    fArrayNVertBins[21];       ///< 21=kNvertBins+1
 
   //..cuts


### PR DESCRIPTION
Fixes a divide-by-zero error causing crashes in root 6.
Fixes a variable mix up.
Fixes a type error affecting minimum cluster energy.