### PR TITLE
Add a momentum dependent track matching to the hadcorr

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterHadronicCorrection.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterHadronicCorrection.cxx
@@ -574,6 +574,11 @@ void AliEmcalCorrectionClusterHadronicCorrection::DoMatchedTracksLoop(Int_t iclu
   AliVCluster* cluster = fClusterContainerIndexMap.GetObjectFromGlobalIndex(icluster);
 
   if (!cluster) return;
+  //these are the functional forms for the momentum dependent eta-phi track matching cut
+  TF1 funcPtDepEta("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
+  funcPtDepEta.SetParameters(0.04, 0.010, 2.5);
+  TF1 funcPtDepPhi("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
+  funcPtDepPhi.SetParameters(0.09, 0.015, 2.);
   
   // loop over matched tracks
   Int_t Ntrks = cluster->GetNTracksMatched();
@@ -640,15 +645,10 @@ void AliEmcalCorrectionClusterHadronicCorrection::DoMatchedTracksLoop(Int_t iclu
     //Do momentum dependent track matching. Values taken from the PCM analyses see:
     //https://alice-notes.web.cern.ch/node/411  Fig. 46   for mom<3GeV these cuts are wider than the standard cuts
     //these values were extracted in the 2012 pp8 TeV MonteCarlo and apparently showed robustness throughout different periods
-    if (fDoMomDepMatching){
-      TF1* fFuncPtDepEta = new TF1("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
-      fFuncPtDepEta->SetParameters(0.04, 0.010, 2.5);
-      TF1* fFuncPtDepPhi = new TF1("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
-      fFuncPtDepPhi->SetParameters(0.09, 0.015, 2.);
-
-      phiCutlo = -fFuncPtDepPhi->Eval(mom);
-      phiCuthi = +fFuncPtDepPhi->Eval(mom);
-      etaCut   = fFuncPtDepEta->Eval(mom);
+    if (fDoMomDepMatching) {
+      phiCutlo = -funcPtDepPhi.Eval(mom);
+      phiCuthi = +funcPtDepPhi.Eval(mom);
+      etaCut   = funcPtDepEta.Eval(mom);
     }
     
     if ((phidiff < phiCuthi && phidiff > phiCutlo) && TMath::Abs(etadiff) < etaCut) {

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterHadronicCorrection.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterHadronicCorrection.cxx
@@ -574,7 +574,10 @@ void AliEmcalCorrectionClusterHadronicCorrection::DoMatchedTracksLoop(Int_t iclu
   AliVCluster* cluster = fClusterContainerIndexMap.GetObjectFromGlobalIndex(icluster);
 
   if (!cluster) return;
-  //these are the functional forms for the momentum dependent eta-phi track matching cut
+  //These are the functional forms for the momentum dependent eta-phi track matching cut
+  //Values taken from the PCM analyses see:
+  //https://alice-notes.web.cern.ch/node/411  Fig. 46   for mom<3GeV these cuts are wider than the standard cuts
+  //these values were extracted in the 2012 pp8 TeV MonteCarlo and apparently showed robustness throughout different periods
   TF1 funcPtDepEta("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
   funcPtDepEta.SetParameters(0.04, 0.010, 2.5);
   TF1 funcPtDepPhi("func", "[1] + 1 / pow(x + pow(1 / ([0] - [1]), 1 / [2]), [2])");
@@ -642,9 +645,7 @@ void AliEmcalCorrectionClusterHadronicCorrection::DoMatchedTracksLoop(Int_t iclu
     else {
       etaCut = GetEtaSigma(mombin);
     }
-    //Do momentum dependent track matching. Values taken from the PCM analyses see:
-    //https://alice-notes.web.cern.ch/node/411  Fig. 46   for mom<3GeV these cuts are wider than the standard cuts
-    //these values were extracted in the 2012 pp8 TeV MonteCarlo and apparently showed robustness throughout different periods
+    //Do momentum dependent track matching
     if (fDoMomDepMatching) {
       phiCutlo = -funcPtDepPhi.Eval(mom);
       phiCuthi = +funcPtDepPhi.Eval(mom);

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterHadronicCorrection.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterHadronicCorrection.h
@@ -58,6 +58,7 @@ protected:
   Double_t               fPhiMatch;                  ///< phi match value (pp=0.050)
   Double_t               fEtaMatch;                  ///< eta match value (pp=0.025)
   Bool_t                 fDoTrackClus;               ///< loop over tracks first
+  Bool_t                 fDoMomDepMatching;          ///< set the values fPhiMatch and fEtaMatch depending on the track momentum
   Double_t               fHadCorr;                   ///< hadronic correction (fraction)
   Double_t               fEexclCell;                 ///< energy/cell that we cannot subtract from the clusters
   Bool_t                 fPlotOversubtractionHistograms; ///< compute and plot oversubtracted energy from embedded/signal matches (embedding only)

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -225,6 +225,7 @@ ClusterHadronicCorrection:                          # Cluster hadronic correctio
     createHistos: false                             # Whether the task should create output histograms
     phiMatch: 0.030                                 # Phi match value
     etaMatch: 0.015                                 # Eta match value
+    doMomDepMatching: false                         # This enables a momentum dependent eta/phi window for track matching 
     hadCorr: 2.                                     # Sets the fraction f of track p to subtract from matched cluster. To subtract all tracks within the eta-phi cut set hadCorr = 1+f. To subtract only one track set 0<hadCorr<1 where hadCorr=f.
     Eexcl: 0                                        # Cell energy that cannot be subtracted
     doTrackClus: true                               # Loop over tracks first


### PR DESCRIPTION
This addition includes the pT dependent track matching as preformed in 
https://alice-notes.web.cern.ch/system/files/notes/analysis/411/ Fig. 46

It can be switched on and off with doMomDepMatching in the ClusterHadronicCorrection section.
It is disabled by defualt.

@jdmulligan and @raymondEhlers please have a look and add your suggestions for improvements.

Thank you!
Kind Regards
efranzis