### PR TITLE
[EMCAL-406] Option to use ESD track Outer Param instead of Inner Param 

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
@@ -69,7 +69,7 @@ AliEMCALRecoUtils::AliEMCALRecoUtils():
   fCutR(0),                               fCutEta(0),                             fCutPhi(0),
   fClusterWindow(0),                      fMass(0),                           
   fStepSurface(0),                        fStepCluster(0),
-  fITSTrackSA(kFALSE),                    fEMCalSurfaceDistance(440.),
+  fITSTrackSA(kFALSE),                    fUseOuterTrackParam(kFALSE),            fEMCalSurfaceDistance(440.),
   fTrackCutsType(0),                      fCutMinTrackPt(0),                      fCutMinNClusterTPC(0), 
   fCutMinNClusterITS(0),                  fCutMaxChi2PerClusterTPC(0),            fCutMaxChi2PerClusterITS(0),
   fCutRequireTPCRefit(kFALSE),            fCutRequireITSRefit(kFALSE),            fCutAcceptKinkDaughters(kFALSE),
@@ -129,7 +129,8 @@ AliEMCALRecoUtils::AliEMCALRecoUtils(const AliEMCALRecoUtils & reco)
   fCutR(reco.fCutR),        fCutEta(reco.fCutEta),           fCutPhi(reco.fCutPhi),
   fClusterWindow(reco.fClusterWindow),
   fMass(reco.fMass),        fStepSurface(reco.fStepSurface), fStepCluster(reco.fStepCluster),
-  fITSTrackSA(reco.fITSTrackSA),                             fEMCalSurfaceDistance(440.),
+  fITSTrackSA(reco.fITSTrackSA),                             fUseOuterTrackParam(reco.fUseOuterTrackParam),                           
+  fEMCalSurfaceDistance(440.),
   fTrackCutsType(reco.fTrackCutsType),                       fCutMinTrackPt(reco.fCutMinTrackPt), 
   fCutMinNClusterTPC(reco.fCutMinNClusterTPC),               fCutMinNClusterITS(reco.fCutMinNClusterITS), 
   fCutMaxChi2PerClusterTPC(reco.fCutMaxChi2PerClusterTPC),   fCutMaxChi2PerClusterITS(reco.fCutMaxChi2PerClusterITS),
@@ -231,6 +232,7 @@ AliEMCALRecoUtils & AliEMCALRecoUtils::operator = (const AliEMCALRecoUtils & rec
   fStepSurface               = reco.fStepSurface;
   fStepCluster               = reco.fStepCluster;
   fITSTrackSA                = reco.fITSTrackSA;
+  fUseOuterTrackParam        = reco.fUseOuterTrackParam;
   fEMCalSurfaceDistance      = reco.fEMCalSurfaceDistance;
   
   fTrackCutsType             = reco.fTrackCutsType;
@@ -2731,8 +2733,13 @@ void AliEMCALRecoUtils::FindMatches(AliVEvent *event,
         if ( phi <= 10 || phi >= 250 ) continue;
       }
       
-      if (!fITSTrackSA)
-        trackParam =  const_cast<AliExternalTrackParam*>(esdTrack->GetInnerParam());  // if TPC Available
+      if (!fITSTrackSA) // if TPC Available
+      {
+        if ( fUseOuterTrackParam )
+          trackParam =  const_cast<AliExternalTrackParam*>(esdTrack->GetOuterParam());  
+        else
+          trackParam =  const_cast<AliExternalTrackParam*>(esdTrack->GetInnerParam());  
+      }
       else
         trackParam =  new AliExternalTrackParam(*esdTrack); // If ITS Track Standing alone		
       
@@ -2906,8 +2913,13 @@ Int_t AliEMCALRecoUtils::FindMatchedClusterInEvent(const AliESDtrack *track,
   }
   
   AliExternalTrackParam *trackParam = 0;
-  if (!fITSTrackSA)
-    trackParam = const_cast<AliExternalTrackParam*>(track->GetInnerParam());  // If TPC
+  if (!fITSTrackSA) // If TPC
+  {
+    if ( fUseOuterTrackParam )
+      trackParam = const_cast<AliExternalTrackParam*>(track->GetOuterParam());  
+    else 
+      trackParam = const_cast<AliExternalTrackParam*>(track->GetInnerParam());  
+  }
   else
     trackParam = new AliExternalTrackParam(*track);
   

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -351,7 +351,10 @@ public:
   void     SetStep(Double_t step)                     { fStepSurface = step           ; }
   void     SetStepCluster(Double_t step)              { fStepCluster = step           ; }
   void     SetITSTrackSA(Bool_t isITS)                { fITSTrackSA = isITS           ; } //Special Handle of AliExternTrackParam    
-    
+  void     SwitchOnOuterTrackParam()                  { fUseOuterTrackParam = kTRUE   ; } 
+  void     SwitchOffOuterTrackParam()                 { fUseOuterTrackParam = kFALSE  ; } 
+  
+  
   // Track Cuts 
   Bool_t   IsAccepted(AliESDtrack *track);
   void     InitTrackCuts();
@@ -527,7 +530,8 @@ private:
   Double_t   fMass;                      ///< Mass hypothesis of the track
   Double_t   fStepSurface;               ///< Length of step to extrapolate tracks to EMCal surface
   Double_t   fStepCluster;               ///< Length of step to extrapolate tracks to clusters
-  Bool_t     fITSTrackSA;                ///< If track matching is to be done with ITS tracks standing alone	
+  Bool_t     fITSTrackSA;                ///< If track matching is to be done with ITS tracks standing alone, ESDs	
+  Bool_t     fUseOuterTrackParam;        ///< Use OuterTrackParam not InnerTrackParam, ESDs
   Double_t   fEMCalSurfaceDistance;      ///< EMCal surface distance (= 430 by default, the last 10 cm are propagated on a cluster-track pair basis)
  
   // Track cuts  
@@ -552,7 +556,7 @@ private:
   Bool_t     fMCGenerToAcceptForTrack;   ///<  Activate the removal of tracks entering the track matching that come from a particular generator
   
   /// \cond CLASSIMP
-  ClassDef(AliEMCALRecoUtils, 26) ;
+  ClassDef(AliEMCALRecoUtils, 27) ;
   /// \endcond
 
 };


### PR DESCRIPTION
to extrapolate ESD tracks to EMCal.

Note that:
- This only works for ESDs
- This is not enough to run with the correction framework since it makes use of a method in AliEMCALRecoUtilsBase in AliRoot and I have prefered for the moment not to touch aliroot and wait for new tags with now the Pb-Pb rush
- It can be used with the standalone clusterization task and possibly with the tender, not checked in the last case.
