### PR TITLE
Address assignment issues on the LEGO train

### DIFF
--- a/PWGJE/EMCALJetTasks/AliPWGJETrainHelpers.cxx
+++ b/PWGJE/EMCALJetTasks/AliPWGJETrainHelpers.cxx
@@ -13,9 +13,10 @@
  * provided "as is" without express or implied warranty.                  *
  **************************************************************************/
 
+#include <cstdlib>
 #include <iostream>
 #include <string>
-#include <cstdlib>
+#include <vector>
 
 #include <TSystem.h>
 #include <TString.h>
@@ -23,14 +24,13 @@
 
 #include "AliPWGJETrainHelpers.h"
 
-void AliPWGJETrainHelpers::ExtractAliEnProductionValuesForLEGOTrain(std::string& period, std::string& collType,
-                                  bool& mc, bool& isRun2)
+std::vector<std::string> AliPWGJETrainHelpers::ExtractAliEnProductionValuesForLEGOTrain()
 {
   // Automatically set shared common variables
   // The run period (ex. "LHC15o")
-  period = gSystem->Getenv("ALIEN_JDL_LPMPRODUCTIONTAG");
+  std::string period = gSystem->Getenv("ALIEN_JDL_LPMPRODUCTIONTAG");
   // either "pp", "pPb" or "PbPb"
-  collType = gSystem->Getenv("ALIEN_JDL_LPMINTERACTIONTYPE");
+  std::string collType = gSystem->Getenv("ALIEN_JDL_LPMINTERACTIONTYPE");
   // Used to get mc
   std::string prodType = gSystem->Getenv("ALIEN_JDL_LPMPRODUCTIONTYPE");
 
@@ -56,17 +56,22 @@ void AliPWGJETrainHelpers::ExtractAliEnProductionValuesForLEGOTrain(std::string&
   }
   // Validate the extract variables. Each one must be set at this point.
   if (period == "" || collType == "" || prodType == "") {
-    // Somehow failed to extract the vaariables which should always be available.
+    // Somehow failed to extract the variables which should always be available.
     ::Fatal("AliPWGJETrainHelpers", "Somehow failed to extract the period, collision type, or production type.\n");
   }
 
   // Determine if it's an MC production.
-  mc = (prodType == "MC");
+  const bool mc = (prodType == "MC");
 
   // Determine if it's Run2
   std::string yearString = period.substr(3, 2);
   int productionYear = std::atoi(yearString.c_str());
-  isRun2 = productionYear > 14;
+  const bool isRun2 = productionYear > 14;
 
-  // Values are returned via the function arguments, so there is nothing else to do here.
+  // We need to return multiple values, so we use a vector and convert the bools to strings temporarily.
+  // They should be converted back after returning.
+  // (Not that the bool text doesn't really matter as long as it's non-zero, but we select "true" as it
+  // corresponds to the variables being true).
+  return std::vector<std::string>{period, collType, mc ? "true" : "", isRun2 ? "true" : ""};
 }
+

--- a/PWGJE/EMCALJetTasks/AliPWGJETrainHelpers.h
+++ b/PWGJE/EMCALJetTasks/AliPWGJETrainHelpers.h
@@ -24,23 +24,27 @@ class AliPWGJETrainHelpers
    * Usage should look like:
    *
    * ~~~{.cxx}
-   * std::string period = "";
-   * std::string collType = "";
-   * bool kMC = false;
-   * bool kIsRun2 = false;
-   * AliPWGJETrainHelpers::ExtractAliEnProductionValuesForLEGOTrain(period, collType, kMC, kIsRun2);
-   * // Set the final string variables, which are expected to be c strings.
-   * const char* kPeriod = period.c_str();
-   * const char* kColType = collType.c_str();
+   * // Determine the variables.
+   * std::vector<std::string> tempVariables = AliPWGJETrainHelpers::ExtractAliEnProductionValuesForLEGOTrain();
+   * // Assign them to their final global variables.
+   * const char* kPeriod = tempVariables.at(0).c_str();
+   * const char* kColType = tempVariables.at(1).c_str();
+   * const bool kMC = (tempVariables.at(2) == "true" ? true : false);
+   * const bool kIsRun2 = (tempVariables.at(3) == "true" ? true : false);
    * ~~~
    *
-   * @param[out] period The run period. For example, "LHC15o".
-   * @param[out] collType The collision type. Can be "pp", "pPb", "PbPb", etc.
-   * @param[out] mc True if this is an MC production.
-   * @param[out] isRun2 True if the run period is in Run 2.
+   * Note that we cannot return the values by taking them by reference in the arguments because that would involve
+   * reassigning global variables, which is not allowed.
+   *
+   * The returned parameters correspond to:
+   *
+   * - period (std::string): The run period. For example, "LHC15o".
+   * - collType (std::string): The collision type. Can be "pp", "pPb", "PbPb", etc.
+   * - mc (bool): True if this is an MC production.
+   * - isRun2 (bool): True if the run period is in Run 2.
+   * @return std::vector<std::string> containing {run period, collision type, mc, isRun2}.
    */
-  static void ExtractAliEnProductionValuesForLEGOTrain(std::string& period, std::string& collType,
-                             bool& mc, bool& isRun2);
+  static std::vector<std::string> ExtractAliEnProductionValuesForLEGOTrain();
 };
 
 #endif /* AliPWGJETrainHelpers.h */


### PR DESCRIPTION
It appears that we're not allowed to reassign global variables, so we
can't pass variables by reference (See [this test train stdout](http://alitrain.cern.ch/train-workdir/PWGJE/Jets_EMC_pPb/1683_20181112-1624/test/__BASELINE__/stdout)). To avoid this issue, we return a
std::vector from which we can assign the extracted values.

Local tests appear to work

@mfasDa , @jdmulligan 