### PR TITLE
D0 to 3-pion: Enable general histograms

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvDtrue.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvDtrue.cxx
@@ -44,7 +44,7 @@ AliAnalysisTaskGammaConvDtrue::AliAnalysisTaskGammaConvDtrue():
 }
 
 AliAnalysisTaskGammaConvDtrue::AliAnalysisTaskGammaConvDtrue(const char *name):
-  AliAnalysisTaskEmcal(name),
+  AliAnalysisTaskEmcal(name, true),
   fHistos(nullptr)
 {
   this->SetMakeGeneralHistograms(true);

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvDtrue.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvDtrue.cxx
@@ -47,6 +47,7 @@ AliAnalysisTaskGammaConvDtrue::AliAnalysisTaskGammaConvDtrue(const char *name):
   AliAnalysisTaskEmcal(name),
   fHistos(nullptr)
 {
+  this->SetMakeGeneralHistograms(true);
   DefineOutput(1, TList::Class());
 }
 


### PR DESCRIPTION
Needed for the container and the weight histograms
for the jet-jet Monte-Carlo.