### PR TITLE
PWGGA/GammaConv Jet vector out of range fix

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
@@ -4384,7 +4384,7 @@ void AliAnalysisTaskGammaCalo::CalculatePi0Candidates(){
                             }
                           }
                           fJetPt = fVectorJetPt.at(i);
-                          fTrueJetPt = fTrueVectorJetPt.at(i);
+                          fTrueJetPt = fTrueVectorJetPt.at(match);
                           fPi0Pt = pi0cand->Pt();
                           fPi0InvMass = pi0cand->M();
                           tTreeJetPi0Correlations[fiCut]->Fill();


### PR DESCRIPTION
Fix for "terminate called after throwing an instance of 'std::out_of_range'" train error