### PR TITLE
PWGGA/GammaConv fDoJetQA bool fix

### DIFF
--- a/PWGGA/GammaConv/AliConversionMesonCuts.cxx
+++ b/PWGGA/GammaConv/AliConversionMesonCuts.cxx
@@ -1323,6 +1323,7 @@ Bool_t AliConversionMesonCuts::SetMesonKind(Int_t mesonKind){
   case 2:
     fMesonKind = 0;
     fDoJetAnalysis = kTRUE;
+    break;
   case 3:
     fMesonKind = 0;
     fDoJetAnalysis = kTRUE;


### PR DESCRIPTION
Fix to ensure that a MesonKind with 2 will not also set fDoJetQA to kTRUE