### PR TITLE
Fixes needed for ZDC QA trending

### DIFF
--- a/PWGPP/QA/detectorQAscripts/ZDC.sh
+++ b/PWGPP/QA/detectorQAscripts/ZDC.sh
@@ -27,10 +27,6 @@ makeHTMLindexPerRun()
   <br>
   <h2>Signals: spectra</h2>
   </div>
-  <a href="cZNA_Spectra.png">ZNA spectrum</a><br>
-  <a href="cZNC_Spectra.png">ZNC spectrum</a><br>
-  <a href="cZPA_Spectra.png">ZPA spectrum</a><br>
-  <a href="cZPC_Spectra.png">ZPC spectrum</a><br>
   <a href="cZEM1_Spectra.png">ZEM1 spectrum</a><br>
   <a href="cZEM2_Spectra.png">ZEM2 spectrum</a><br>
   <h2>Signals: mean values</h2>

--- a/PWGPP/ZDC/macros/DrawPerformanceZDCQAMatch.C
+++ b/PWGPP/ZDC/macros/DrawPerformanceZDCQAMatch.C
@@ -144,8 +144,8 @@ ttree->SetBranchAddress("ZN_TDC_Sum",&ZN_TDC_Sum);
 ttree->SetBranchAddress("ZN_TDC_Diff",&ZN_TDC_Diff);
 ttree->SetBranchAddress("ZN_TDC_Sum_Err",&ZN_TDC_Sum_err);
 ttree->SetBranchAddress("ZN_TDC_Diff_Err",&ZN_TDC_Diff_err);
-//ttree->SetBranchAddress("ZNC_TDC",&ZNC_TDC);
-//ttree->SetBranchAddress("ZNA_TDC",&ZNA_TDC);
+ttree->SetBranchAddress("ZNC_TDC",&ZNC_TDC);
+ttree->SetBranchAddress("ZNA_TDC",&ZNA_TDC);
 
 printf(" branch addresses set\n");
 
@@ -554,6 +554,10 @@ cTimingDiff->Print(Form("%s/cTimingDiff.png",plotDir.Data()));
 //----------------------------------------------------------------------
 //out
 //----------------------------------------------------------------------
+TFile *fout = 0;
+fout = TFile::Open("prodQAhistos.root", "update");
+if(!fout) fout = new TFile("prodQAhistos.root","RECREATE");
+
 printf(" preparing output tree\n");
 tree->Branch("run",&runNumber,"runNumber/I");
 tree->Branch("ZNC_mean_value",&ZNC_mean,"ZNC_mean/D");
@@ -580,6 +584,8 @@ tree->Branch("ZN_TDC_Sum_Err",&ZN_TDC_Sum_err,"ZN_TDC_Sum_err/D");
 tree->Branch("ZN_TDC_Diff_Err",&ZN_TDC_Diff_err,"ZN_TDC_Diff_err/D");
 tree->Fill();
 
+fout->cd();
+
 if(hZNCpmcUncalib) list.Add(cZNC_Spectra_Uncal);
 if(hZNApmcUncalib) list.Add(cZNA_Spectra_Uncal);
 if(hZPCpmcUncalib) list.Add(cZPC_Spectra_Uncal);
@@ -593,10 +599,6 @@ list.Add(cZNA_Y_centroid);
 list.Add(cZNC_X_centroid);
 list.Add(cZNC_Y_centroid);
 
-TFile *fout;
-fout = TFile::Open("prodQAhistos.root", "update");
-if(!fout) fout = new TFile("prodQAhistos.root");
-fout->cd();
 list.Write();
 tree->Write();
 fout->Close();

--- a/PWGPP/ZDC/macros/DrawPerformanceZDCQAMatchTrends.C
+++ b/PWGPP/ZDC/macros/DrawPerformanceZDCQAMatchTrends.C
@@ -32,7 +32,7 @@
 
 TTree *tree;
 
-void DrawPerformanceZDCQAMatchTrends(const char* inFile = "prodQAhistos.root"){
+Int_t DrawPerformanceZDCQAMatchTrends(const char* inFile = "trending.root"){
 
   /*set graphic style*/
   gStyle->SetCanvasColor(kWhite);
@@ -57,11 +57,11 @@ void DrawPerformanceZDCQAMatchTrends(const char* inFile = "prodQAhistos.root"){
   gStyle->SetTitleOffset(1.0,"y");
 
   TFile *file0 = TFile::Open(inFile);
-  if(!file0) return;
+  if(!file0) return 1;
   file0->cd();
 
   tree = (TTree*) file0->Get("tree");
-  if(!tree) return;
+  if(!tree) return 2;
   //tree->Print();
 
   int const entries = tree->GetEntries();
@@ -159,7 +159,7 @@ tree->SetBranchAddress("ZN_TDC_Diff_Err",&ZN_TDC_Diff_err);
   for (int i=0; i<entries; i++){
      tree->GetEntry(i);
     printf("ZNC %f ZNA %f\n", ZNC_mean, ZNA_mean);
-    printf("ZEM1 %f ZEM2 %f\n", ZEM1_mean, ZEM2_mean);
+    //printf("ZEM1 %f ZEM2 %f\n", ZEM1_mean, ZEM2_mean);
      ZNC_tot += ZNC_mean;
      ZNA_tot += ZNA_mean;
      ZPC_tot += ZPC_mean;
@@ -330,5 +330,7 @@ tree->SetBranchAddress("ZN_TDC_Diff_Err",&ZN_TDC_Diff_err);
   gr_zntdcdiff->GetYaxis()->SetTitle("(ns)");
   gr_zntdcdiff->GetYaxis()->SetRangeUser(TdcDiff_avg-offset_tdc,TdcDiff_avg+offset_tdc);
   c6->Print("ZN_timing_trending.png");
+
+  return 0;
 
 }

--- a/PWGPP/ZDC/macros/MakeTrendZDC.C
+++ b/PWGPP/ZDC/macros/MakeTrendZDC.C
@@ -41,13 +41,11 @@ int MakeTrendZDC(TString infile, int run) {
 
   TString outfile = "trending.root";
 
-  //if(!infile) return -1;
-  //if(!outfile) return -1;
   TFile *f =0;
   f=TFile::Open(infile,"read");
   if(!f) {
     printf("File %s not available\n", infile.Data());
-    return -1;
+    return 1;
   }
 
   //access histograms lists
@@ -57,14 +55,13 @@ int MakeTrendZDC(TString infile, int run) {
   TDirectoryFile * zdcQAdir=(TDirectoryFile*)f->Get(zdcQAdirName);
   if(!zdcQAdir) {
     Printf("ERROR: ZDC QA directory not present in input file.\n");
-    return -1;
+    return 2;
   }
 
   TList * generalList=(TList*)zdcQAdir->Get(genListName);
-
   if(!generalList){
      Printf("WARNING: general QA histograms absent or not accessible\n");
-     return -1;
+     return 3;
   }
 
   TH1D    *fhTDCZNC           = (TH1D*)generalList->FindObject("fhTDCZNC");       //! TDC ZNC sum
@@ -85,8 +82,6 @@ int MakeTrendZDC(TString infile, int run) {
   TH1D    *fhPMCZNAemd        = (TH1D*)generalList->FindObject("fhPMCZNAemd");    //! ZNA PMC low gain chain
   TH1D    *fhPMCZNCemdUncalib = (TH1D*)generalList->FindObject("fhPMCZNCemdUncalib");  //! ZNC PMC low gain chain uncalibrated
   TH1D    *fhPMCZNAemdUncalib = (TH1D*)generalList->FindObject("fhPMCZNAemdUncalib");  //! ZNA PMC low gain chain uncalibrated
-  TH1D    *fhTDCZNAcorr       = (TH1D*)generalList->FindObject("fhTDCZNAcorr");   //! ZNA corrected TDC
-  TH1D    *fhTDCZNCcorr       = (TH1D*)generalList->FindObject("fhTDCZNCcorr");   //! ZNC corrected TDC
   TH2F    *fhZNCCentroid      = (TH2F*)generalList->FindObject("fhZNCCentroid");  //! ZNC centroid
   TH2F    *fhZNACentroid      = (TH2F*)generalList->FindObject("fhZNACentroid");  //! ZNA centroid
   TH2F    *fDebunch           = (TH2F*)generalList->FindObject("fDebunch");       //! TDC sum vs. diff
@@ -157,6 +152,7 @@ int MakeTrendZDC(TString infile, int run) {
 
   Printf(":::: Getting post-analysis info for run %i",run);
   TFile * trendFile = new TFile(outfile.Data(),"recreate");
+  trendFile->cd();
 
   printf("==============  Saving histograms for run %i ===============\n",run);
 
@@ -183,8 +179,8 @@ int MakeTrendZDC(TString infile, int run) {
   ttree->Fill();
   printf("==============  Saving trending quantities in tree for run %i ===============\n",run);
 
-  trendFile->cd();
+  //trendFile->cd();
   ttree->Write();
   trendFile->Close();
-
+  return 0;
 }


### PR DESCRIPTION
These changes are needed in order to update the QA trending macros to use the QA classes.