### PR TITLE
PWGHF: Adding Bplus decay in standard HF functions

### DIFF
--- a/PWGHF/vertexingHF/AliAODRecoDecayHF2Prong.h
+++ b/PWGHF/vertexingHF/AliAODRecoDecayHF2Prong.h
@@ -66,6 +66,7 @@ class AliAODRecoDecayHF2Prong : public AliAODRecoDecayHF {
 
   Bool_t   SelectBtoJPSI(const Double_t* cuts,Int_t &okB) const;
   
+  Int_t MatchToMCB2Prong(Int_t pdgabs,Int_t pdgabs2prong, Int_t *pdgDg, Int_t *pdgDg2prong, TClonesArray *mcArray) const;
   Int_t MatchToMCB3Prong(Int_t pdgabs,Int_t pdgabs3prong, Int_t *pdgBDg,Int_t *pdgDg3prong, TClonesArray *mcArray) const;
 
  private:

--- a/PWGHF/vertexingHF/AliVertexingHFUtils.cxx
+++ b/PWGHF/vertexingHF/AliVertexingHFUtils.cxx
@@ -2102,6 +2102,153 @@ Int_t AliVertexingHFUtils::CheckXicXipipiDecay(AliMCEvent* mcEvent, Int_t label,
   return 1;
 
 }
+
+//____________________________________________________________________________
+Int_t AliVertexingHFUtils::CheckBplusDecay(AliMCEvent* mcEvent, Int_t label, Int_t* arrayDauLab){
+  /// Checks the Bplus decay channel. Returns 1 for Bplus->D0pi->Kpipi, -1 in other cases
+
+  if(label<0) return -1;
+  TParticle* mcPart = mcEvent->Particle(label);
+  Int_t pdgD=mcPart->GetPdgCode();
+  if(TMath::Abs(pdgD)!=521) return -1;
+
+  Int_t nDau=mcPart->GetNDaughters();
+  if(nDau!=2) return -1;
+
+  Int_t labelFirstDau = mcPart->GetDaughter(0);
+  Int_t nKaons=0;
+  Int_t nPions=0;
+  Double_t sumPxDau=0.;
+  Double_t sumPyDau=0.;
+  Double_t sumPzDau=0.;
+  Int_t nFoundKpi=0;
+
+  for(Int_t iDau=0; iDau<nDau; iDau++){
+    Int_t indDau = labelFirstDau+iDau;
+    if(indDau<0) return -1;
+    TParticle* dau=mcEvent->Particle(indDau);
+    if(!dau) return -1;
+    Int_t pdgdau=dau->GetPdgCode();
+    if(TMath::Abs(pdgdau)==421){
+      Int_t nResDau=dau->GetNDaughters();
+      if(nResDau!=2) return -1;
+      Int_t indFirstResDau=dau->GetDaughter(0);
+      for(Int_t resDau=0; resDau<2; resDau++){
+	Int_t indResDau=indFirstResDau+resDau;
+	if(indResDau<0) return -1;
+	TParticle* resdau=mcEvent->Particle(indResDau);
+	if(!resdau) return -1;
+	Int_t pdgresdau=resdau->GetPdgCode();
+	if(TMath::Abs(pdgresdau)==321){
+	  if(pdgD*pdgresdau>0) return -1;
+	  sumPxDau+=resdau->Px();
+	  sumPyDau+=resdau->Py();
+	  sumPzDau+=resdau->Pz();
+	  nKaons++;
+	  arrayDauLab[nFoundKpi++]=indResDau;
+	  if(nFoundKpi>3) return -1;
+	}
+	if(TMath::Abs(pdgresdau)==211){
+	  if(pdgD*pdgresdau<0) return -1;
+	  sumPxDau+=resdau->Px();
+	  sumPyDau+=resdau->Py();
+	  sumPzDau+=resdau->Pz();
+	  nPions++;
+	  arrayDauLab[nFoundKpi++]=indResDau;
+	  if(nFoundKpi>3) return -1;
+	}
+      }
+    }else if(TMath::Abs(pdgdau)==211){
+      if(pdgD*pdgdau<0) return -1;
+      nPions++;
+      sumPxDau+=dau->Px();
+      sumPyDau+=dau->Py();
+      sumPzDau+=dau->Pz();
+      arrayDauLab[nFoundKpi++]=indDau;
+      if(nFoundKpi>3) return -1;
+    }
+  }
+
+  if(nPions!=2) return -1;
+  if(nKaons!=1) return -1;
+  if(TMath::Abs(mcPart->Px()-sumPxDau)>0.001) return -2;
+  if(TMath::Abs(mcPart->Py()-sumPyDau)>0.001) return -2;
+  if(TMath::Abs(mcPart->Pz()-sumPzDau)>0.001) return -2;
+  return 1;
+
+}
+//____________________________________________________________________________
+Int_t AliVertexingHFUtils::CheckBplusDecay(TClonesArray* arrayMC, AliAODMCParticle *mcPart, Int_t* arrayDauLab){
+  /// Checks the Bplus decay channel. Returns 1 for Bplus->D0pi->Kpipi, -1 in other cases
+
+  Int_t pdgD=mcPart->GetPdgCode();
+  if(TMath::Abs(pdgD)!=521) return -1;
+
+  Int_t nDau=mcPart->GetNDaughters();
+  if(nDau!=2) return -1;
+
+  Int_t labelFirstDau = mcPart->GetDaughter(0);
+  Int_t nKaons=0;
+  Int_t nPions=0;
+  Double_t sumPxDau=0.;
+  Double_t sumPyDau=0.;
+  Double_t sumPzDau=0.;
+  Int_t nFoundKpi=0;
+
+  for(Int_t iDau=0; iDau<nDau; iDau++){
+    Int_t indDau = labelFirstDau+iDau;
+    if(indDau<0) return -1;
+    AliAODMCParticle* dau=dynamic_cast<AliAODMCParticle*>(arrayMC->At(indDau));
+    if(!dau) return -1;
+    Int_t pdgdau=dau->GetPdgCode();
+    if(TMath::Abs(pdgdau)==421){
+      Int_t nResDau=dau->GetNDaughters();
+      if(nResDau!=2) return -1;
+      Int_t indFirstResDau=dau->GetDaughter(0);
+      for(Int_t resDau=0; resDau<2; resDau++){
+	Int_t indResDau=indFirstResDau+resDau;
+	if(indResDau<0) return -1;
+	AliAODMCParticle* resdau=dynamic_cast<AliAODMCParticle*>(arrayMC->At(indResDau));
+	if(!resdau) return -1;
+	Int_t pdgresdau=resdau->GetPdgCode();
+	if(TMath::Abs(pdgresdau)==321){
+	  if(pdgD*pdgresdau>0) return -1;
+	  sumPxDau+=resdau->Px();
+	  sumPyDau+=resdau->Py();
+	  sumPzDau+=resdau->Pz();
+	  nKaons++;
+	  arrayDauLab[nFoundKpi++]=indResDau;
+	  if(nFoundKpi>3) return -1;
+	}
+	if(TMath::Abs(pdgresdau)==211){
+	  if(pdgD*pdgresdau<0) return -1;
+	  sumPxDau+=resdau->Px();
+	  sumPyDau+=resdau->Py();
+	  sumPzDau+=resdau->Pz();
+	  nPions++;
+	  arrayDauLab[nFoundKpi++]=indResDau;
+	  if(nFoundKpi>3) return -1;
+	}
+      }
+    }else if(TMath::Abs(pdgdau)==211){
+      if(pdgD*pdgdau<0) return -1;
+      nPions++;
+      sumPxDau+=dau->Px();
+      sumPyDau+=dau->Py();
+      sumPzDau+=dau->Pz();
+      arrayDauLab[nFoundKpi++]=indDau;
+      if(nFoundKpi>3) return -1;
+    }
+  }
+
+  if(nPions!=2) return -1;
+  if(nKaons!=1) return -1;
+  if(TMath::Abs(mcPart->Px()-sumPxDau)>0.001) return -2;
+  if(TMath::Abs(mcPart->Py()-sumPyDau)>0.001) return -2;
+  if(TMath::Abs(mcPart->Pz()-sumPzDau)>0.001) return -2;
+  return 1;
+
+}
 //________________________________________________________________________
 Double_t AliVertexingHFUtils::GetSphericity(AliAODEvent* aod,
                                             Double_t etaMin, Double_t etaMax,

--- a/PWGHF/vertexingHF/AliVertexingHFUtils.h
+++ b/PWGHF/vertexingHF/AliVertexingHFUtils.h
@@ -151,6 +151,8 @@ class AliVertexingHFUtils : public TObject{
   static Int_t CheckLcpKpiDecay(TClonesArray* arrayMC, AliAODMCParticle *mcPart, Int_t* arrayDauLab);
   static Int_t CheckLcV0bachelorDecay(AliMCEvent* mcEvent, Int_t label, Int_t* arrayDauLab);
   static Int_t CheckXicXipipiDecay(AliMCEvent* mcEvent, Int_t label, Int_t* arrayDauLab);
+  static Int_t CheckBplusDecay(AliMCEvent* mcEvent, Int_t label, Int_t* arrayDauLab);
+  static Int_t CheckBplusDecay(TClonesArray* arrayMC, AliAODMCParticle *mcPart, Int_t* arrayDauLab);
 
  private:
 


### PR DESCRIPTION
- Added Bplus decay in HFUtils
- Added MatchToMC for non-resonant 2prong -> daughter + 2prong decays (coming from Bplus analysis task). So it can be accessed in MVA task