### PR TITLE
Handle missing matched tracks in EpRatio task

### DIFF
--- a/PWGGA/PHOSTasks/PHOS_EpRatio/AliAnalysisTaskEpRatio.cxx
+++ b/PWGGA/PHOSTasks/PHOS_EpRatio/AliAnalysisTaskEpRatio.cxx
@@ -273,6 +273,9 @@ void AliAnalysisTaskEpRatio::UserExec(Option_t *)
     if(nMatched<=0) continue;
     
     AliVTrack* esdTrack = dynamic_cast<AliVTrack*> (c1->GetTrackMatched(0));
+    // track was not found
+    if(!esdTrack) continue;
+
     if( !(TMath::Abs(esdTrack->Eta())< 0.8) ) continue;
 
     Short_t charge   = esdTrack->Charge();


### PR DESCRIPTION
It seems that additional check is necessary for the matched tracks, otherwise this task fails.
Here is an example of the stack trace:

https://alimonitor.cern.ch/jobs/stackAnalysis.jsp?path=PWGGA%2FGA_pp_AOD%2F543_20181105-0923
