### PR TITLE
PWGHF: Update Bplus for MVA studies

### DIFF
--- a/PWGHF/vertexingHF/AliRDHFCutsBPlustoD0Pi.h
+++ b/PWGHF/vertexingHF/AliRDHFCutsBPlustoD0Pi.h
@@ -52,6 +52,7 @@ class AliRDHFCutsBPlustoD0Pi : public AliRDHFCuts
   Int_t IsBplusPionSelectedMVA(TObject* obj,Int_t selectionLevel, AliAODEvent* aod, AliAODVertex *primaryVertex, Double_t bz);
   Int_t IsD0FromBPlusSelectedMVA(Double_t ptBPlus, TObject* obj,Int_t selectionLevel, AliAODEvent* aod, AliAODVertex *primaryVertex, Double_t bz);
   Int_t IsD0forD0ptbinSelectedMVA(TObject* obj,Int_t selectionLevel, AliAODEvent* aod, AliAODVertex *primaryVertex, Double_t bz);
+  Int_t IsD0SelectedPreRecVtxMVA(AliAODRecoDecayHF2Prong* d, AliAODTrack* pion, AliAODVertex *primaryVertex, Double_t bz, Int_t selLevel);
 
   virtual Int_t IsSelectedPID(AliAODRecoDecayHF *rd);
   virtual Int_t SelectPID(AliAODTrack *track, Int_t type);


### PR DESCRIPTION
Added a function to cut on PID D0 daughters and a D0 + Bplus invariant mass window before the reconstruction of the Bplus vertex to save CPU time. 

Needed to speed up task for MVA studies Bplus (will probably also replace similar hardcoded selections in AnalysisTask)