### PR TITLE
EMCal CorrFW: Fatal if the user config is missing

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
@@ -374,7 +374,8 @@ void AliEmcalCorrectionTask::InitializeConfiguration()
     AliInfoStream() << "Using user EMCal corrections configuration located at \"" << fUserConfigurationFilename << "\"\n";
   }
   else {
-    AliInfoStream() << "User file at \"" << fUserConfigurationFilename << "\" does not exist! All settings will be from the default file!\n";
+    // For any tasks to be enabled, we must have a user config. So we make a missing user config a fatal.
+    AliFatal(TString::Format("User config file at \"%s\" does not exist! Please check the user config filename!", fUserConfigurationFilename.c_str()));
   }
 
   // Initialize


### PR DESCRIPTION
A fatal error is raised early if the user config is missing (either
because it wasn't set or because it couldn't be found due to typo,
not existing, etc). Previously, this generated a warning and there would
be not histogram output, but it is better to explicitly make it a fatal
error.

cc: @jdmulligan , @mfasDa