### PR TITLE
ZDC ESD: Using standard pp centroid also for Pb-Pb

### DIFF
--- a/PWGPP/ZDC/AliAnalysisTaskZDCPbPb.cxx
+++ b/PWGPP/ZDC/AliAnalysisTaskZDCPbPb.cxx
@@ -347,7 +347,8 @@ void AliAnalysisTaskZDCPbPb::UserExec(Option_t */*option*/)
     fhZPApmc->Fill(towZPA[0]/1000.);
 
     Double_t xyZNC[2]={-99.,-99.}, xyZNA[2]={-99.,-99.};
-    esdZDC->GetZNCentroidInPbPb(2510., xyZNC, xyZNA);
+    //esdZDC->GetZNCentroidInPbPb(2510., xyZNC, xyZNA);
+    esdZDC->GetZNCentroidInpp(xyZNC, xyZNA);
 
     fhZNCCentroid->Fill(xyZNC[0], xyZNC[1]);
     fhZNACentroid->Fill(xyZNA[0], xyZNA[1]);


### PR DESCRIPTION
Use simplified centroid calculation for Pb_Pb to avoid the beam energy dependence.

