### PR TITLE
[ALIROOT-7874] Separate refit and non-refit tracks using kTRDUpdate flag

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalTrackingQATask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalTrackingQATask.cxx
@@ -26,6 +26,7 @@ AliEmcalTrackingQATask::AliEmcalTrackingQATask() :
   fDoSigma1OverPt(kFALSE),
   fDoSigmaPtOverPtGen(kFALSE),
   fDoSeparateTRDrefit(kFALSE),
+  fUseTRDUpdateFlag(kTRUE),
   fIsEsd(kFALSE),
   fGeneratorLevel(nullptr),
   fDetectorLevel(nullptr),
@@ -54,6 +55,7 @@ AliEmcalTrackingQATask::AliEmcalTrackingQATask(const char *name) :
   fDoSigma1OverPt(kFALSE),
   fDoSigmaPtOverPtGen(kFALSE),
   fDoSeparateTRDrefit(kFALSE),
+  fUseTRDUpdateFlag(kTRUE),
   fIsEsd(kFALSE),
   fGeneratorLevel(nullptr),
   fDetectorLevel(nullptr),
@@ -434,7 +436,11 @@ Bool_t AliEmcalTrackingQATask::FillHistograms()
       if(fDoSeparateTRDrefit) {
         // Gold condition:
         // - at least 3 TRD tracklets (with this cut track without TRD in global track fit is at % level)
-        if(ntracklets < 3) type += 4;    // failed TRD gold condition
+        if(fUseTRDUpdateFlag) {
+          if(!(track->GetStatus() && AliVTrack::kTRDupdate)) type += 4;
+        } else  {
+          if(ntracklets < 3) type += 4;    // failed TRD gold condition
+        }
       }
 
       Int_t label = TMath::Abs(track->GetLabel());

--- a/PWG/EMCAL/EMCALtasks/AliEmcalTrackingQATask.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalTrackingQATask.h
@@ -33,6 +33,7 @@ class AliEmcalTrackingQATask : public AliAnalysisTaskEmcalLight {
   void                   SetDoSigma1OverPt(Bool_t s)      {fDoSigma1OverPt     = s; }
   void                   SetDoSigmaPtOverPtGen(Bool_t s)  {fDoSigmaPtOverPtGen = s; }
   void                   SetDoSeparateTRDrefit(Bool_t s)  {fDoSeparateTRDrefit = s; }
+  void                   SetUseTRDUpdateFlag(Bool_t s)    {fUseTRDUpdateFlag   = s; }
 
   static AliEmcalTrackingQATask* AddTaskTrackingQA(Bool_t isMC, const char *suffix = "");
 
@@ -56,6 +57,7 @@ class AliEmcalTrackingQATask : public AliAnalysisTaskEmcalLight {
   Bool_t                  fDoSigma1OverPt        ; ///<  add sigma(1/pt), if false add sigma(pt)/pt instead
   Bool_t                  fDoSigmaPtOverPtGen    ; ///<  MC: if true do sigma((ptgen - ptdet) / ptgen), otherwise do sigma((ptgen - ptdet) / ptdet)
   Bool_t                  fDoSeparateTRDrefit    ; ///<  Separate tracks into tracks with TRD refit and 4 tracklets (gold) or not (sub-gold)
+  Bool_t                  fUseTRDUpdateFlag      ; ///<  Use TRD update flag to separate tracks into gold and semi-gold
 
   // Service fields (non-streamed)
   Bool_t                  fIsEsd                 ; //!<! whether it is ESD data


### PR DESCRIPTION
Usage of kTRDUpdate flag default but made optional. If
it is off, then fall back to old method (at least 3 tracklets)