### PR TITLE
Interface for generic BDT models in AliPhysics

### DIFF
--- a/PWGLF/CMakeLists.txt
+++ b/PWGLF/CMakeLists.txt
@@ -26,6 +26,6 @@ add_subdirectory (totEt)
 add_subdirectory (ppVsMult)
 add_subdirectory (NUCLEX)
 add_subdirectory (CommonUtils)
-
+add_subdirectory (ML)
 
 message(STATUS "PWGLF enabled")

--- a/PWGLF/ML/AliExternalBDT.cxx
+++ b/PWGLF/ML/AliExternalBDT.cxx
@@ -1,0 +1,144 @@
+// Copyright CERN. This software is distributed under the terms of the GNU
+// General Public License v3 (GPL Version 3).
+//
+// See http://www.gnu.org/licenses/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file AliExternalBDT.cxx
+/// \author maximiliano.puccio@cern.ch, pietro.fecchio@cern.ch
+
+#include "AliExternalBDT.h"
+
+#include <cassert>
+#include <stdio.h>
+#include <iostream>
+
+#include <TSystem.h>
+
+namespace {
+  inline bool checkFile (const std::string name) {
+    FILE *file = fopen(name.c_str(), "r");
+    if (file != NULL) {
+      fclose(file);
+      return true;
+    } else {
+      return false;
+    }
+  }
+}
+
+AliExternalBDT::AliExternalBDT(std::string name) :
+  fBDTname{name},
+  fModel{},
+  fModelPath{""},
+  fModelName{""},
+  fCompiler{},
+  fPredictor{}
+{
+}
+
+
+bool AliExternalBDT::CompileAndLoadModelLibrary() {
+  std::string path = GetUniquePath();
+  if (checkFile(path + "/main.so")) {
+    std::cout << "Library found: " << path.data() << "/main.so . Loading it!" << std::endl;
+  } else {
+    std::cout << "Starting the model compilation, depending on the model size it can take a while..." << std::endl;
+    gSystem->Exec(Form("gcc -c -O1 -fPIC %s/main.c -o %s/main.o \
+          && gcc -shared %s/main.o -o %s/main.so", path.data(), path.data(), path.data(), path.data()));
+  }
+  return LoadModelLibrary(Form("%s/main.so", path.data()));
+}
+
+bool AliExternalBDT::CreateModelCode() {
+  std::string path = GetUniquePath();
+  if (checkFile(path + "/main.c")) {
+    std::cout << "Code found: " << path.data() << "/main.c . \
+      Remove it or unset/change the AliExternalBDT name to force its regeneration." << std::endl;
+  } else {
+    const int status_comp = TreeliteCompilerCreate("ast_native", &fCompiler);
+    if (status_comp != 0) {
+      std::cerr << "Compiler creation failed." << std::endl;
+      return false;
+    }
+    const int status_gen = TreeliteCompilerGenerateCode(fCompiler, fModel, 1, path.data());
+    if (status_gen != 0) {
+      std::cerr << "Code generation failed." << std::endl;
+      return false;
+    }
+  }
+  return true;
+}
+
+std::string AliExternalBDT::GetUniquePath() {
+  if (fBDTname.empty()) {
+    return std::string(Form("%s_%p",fModelName.data(),this));
+  } else {
+    return std::string(Form("%s_%s",fBDTname.data(), fModelName.data()));
+  }
+}
+
+bool AliExternalBDT::LoadModel(const std::string &path, int type) {
+  if (path.empty()) {
+    std::cout << "Invalid empty model path string" << std::endl;
+    return false;
+  }
+  fModelPath = path;
+  fModelName = fModelPath.substr(fModelPath.find_last_of("\\/")+1,fModelPath.size());
+  int status = 0;
+  switch (type) {
+    case 0:
+      status = TreeliteLoadXGBoostModel(fModelPath.data(), &fModel);
+      break;
+    case 1:
+      status = TreeliteLoadLightGBMModel(fModelPath.data(), &fModel);
+      break;
+    default:
+      std::cerr << "Invalid model type" << std::endl;
+      return false;
+  }
+  if (status != 0) {
+    std::cerr << "Model loading failed" << std::endl;
+    return false;
+  }
+  if (!CreateModelCode()) return false;
+  if (!CompileAndLoadModelLibrary()) return false;
+  return true;
+}
+
+bool AliExternalBDT::LoadXGBoostModel(std::string path) {
+  if (!LoadModel(path, 0)) return false;
+  return true;
+}
+
+bool AliExternalBDT::LoadLightGBMModel(std::string path) {
+  if (!LoadModel(path, 1)) return false;
+  return true;
+}
+
+bool AliExternalBDT::LoadModelLibrary(std::string path) {
+  const int status = TreelitePredictorLoad(path.data(), 1, 1, &fPredictor);
+  if (status != 0) {
+    std::cerr << "Library loading failed" << std::endl;
+    return false;
+  }
+  return true;
+}
+
+double AliExternalBDT::Predict(double *features, int size, bool useRawScore) {
+  std::vector<TreelitePredictorEntry> entries(size);
+  for (size_t iEntry = 0; iEntry < entries.size(); ++iEntry) {
+    entries[iEntry].fvalue = static_cast<float>(features[iEntry]);
+  }
+  size_t out_size{0u};
+  TreelitePredictorQueryResultSizeSingleInst(fPredictor, &out_size);
+  assert(out_size == 1);
+  float output = 0.f;
+  TreelitePredictorPredictInst(fPredictor, entries.data(),
+      static_cast<int>(useRawScore), &output,
+      &out_size);
+  return output;
+}

--- a/PWGLF/ML/AliExternalBDT.h
+++ b/PWGLF/ML/AliExternalBDT.h
@@ -1,0 +1,48 @@
+// Copyright CERN. This software is distributed under the terms of the GNU
+// General Public License v3 (GPL Version 3).
+//
+// See http://www.gnu.org/licenses/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file AliExternalBDT.h
+/// \brief Implementation of a C++ interface in AliPhysics for XGboost,
+////       LightGBM and SciKit BDT models.
+/// \author maximiliano.puccio@cern.ch, pietro.fecchio@cern.ch
+
+#ifndef ALIEXTERNALBDT_H
+#define ALIEXTERNALBDT_H
+
+#include "treelite/c_api.h"
+#include "treelite/c_api_runtime.h"
+#include <string>
+#include <vector>
+
+class AliExternalBDT {
+public:
+  AliExternalBDT(std::string name = "");
+  virtual ~AliExternalBDT(){};
+
+  bool LoadLightGBMModel(std::string path);
+  bool LoadModelLibrary(std::string path);
+  bool LoadXGBoostModel(std::string path);
+
+  double Predict(double *features, int size, bool useRaw = false);
+
+private:
+  bool CompileAndLoadModelLibrary();
+  bool CreateModelCode();
+  std::string GetUniquePath();
+  bool LoadModel(const std::string &path, int type);
+
+  std::string fBDTname;       /// Unique name of this external BDT handler
+  ModelHandle fModel;
+  std::string fModelPath;
+  std::string fModelName;
+  CompilerHandle fCompiler;
+  PredictorHandle fPredictor;
+};
+
+#endif

--- a/PWGLF/ML/CMakeLists.txt
+++ b/PWGLF/ML/CMakeLists.txt
@@ -1,0 +1,94 @@
+# **************************************************************************
+# * Copyright(c) 1998-2014, ALICE Experiment at CERN, All rights reserved. *
+# *                                                                        *
+# * Author: The ALICE Off-line Project.                                    *
+# * Contributors are mentioned in the code where appropriate.              *
+# *                                                                        *
+# * Permission to use, copy, modify and distribute this software and its   *
+# * documentation strictly for non-commercial purposes is hereby granted   *
+# * without fee, provided that the above copyright notice appears in all   *
+# * copies and that both the copyright notice and this permission notice   *
+# * appear in the supporting documentation. The authors make no claims     *
+# * about the suitability of this software for any purpose. It is          *
+# * provided "as is" without express or implied warranty.                  *
+# **************************************************************************
+
+if (TREELITE_ROOT)
+#Module
+set(MODULE ML)
+add_definitions(-D_MODULE_="${MODULE}")
+
+# Module include folder
+include_directories(${AliPhysics_SOURCE_DIR}/PWGLF/ML
+)
+
+# Additional includes - alphabetical order except ROOT
+include_directories(${ROOT_INCLUDE_DIRS}
+                    ${TREELITE_ROOT}/include
+  )
+set(SRCS
+    AliExternalBDT.cxx
+)
+
+# Headers from sources
+string(REPLACE ".cxx" ".h" HDRS "${SRCS}")
+
+# Generate the dictionary
+# It will create G_ARG1.cxx and G_ARG1.h / ARG1 = function first argument
+get_directory_property(incdirs INCLUDE_DIRECTORIES)
+generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
+
+set(ROOT_DEPENDENCIES)
+set(ALIROOT_DEPENDENCIES ANALYSISalice EVGEN)
+
+# Generate the ROOT map
+# Dependecies
+set(LIBDEPS ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES} ${TREELITE_ROOT}/lib/libtreelite.so ${TREELITE_ROOT}/lib/libtreelite_runtime.so)
+generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
+
+# Generate a PARfile target for this library. Note the extra includes ("Tracks UserTasks")
+add_target_parfile(${MODULE} "${SRCS}" "${HDRS}" "${MODULE}LinkDef.h" "${LIBDEPS}" "Tracks UserTasks")
+
+# Create an object to be reused in case of static libraries
+# Otherwise the sources will be compiled twice
+add_library(${MODULE}-object OBJECT ${SRCS} G__${MODULE}.cxx)
+
+# Add a library to the project using the object
+add_library_tested(${MODULE} SHARED $<TARGET_OBJECTS:${MODULE}-object>)
+target_link_libraries(${MODULE} ${ALIROOT_DEPENDENCIES} ${ROOT_DEPENDENCIES} ${TREELITE_ROOT}/lib/libtreelite.so ${TREELITE_ROOT}/lib/libtreelite_runtime.so)
+
+# Setting the correct headers for the object as gathered from the dependencies
+target_include_directories(${MODULE}-object PUBLIC $<TARGET_PROPERTY:${MODULE},INCLUDE_DIRECTORIES>)
+set_target_properties(${MODULE}-object PROPERTIES COMPILE_DEFINITIONS $<TARGET_PROPERTY:${MODULE},COMPILE_DEFINITIONS>)
+
+# Public include folders that will be propagated to the dependecies
+target_include_directories(${MODULE} PUBLIC ${incdirs})
+
+set(MODULE_COMPILE_FLAGS)
+set(MODULE_LINK_FLAGS)
+
+# Additional compilation and linking flags
+set(MODULE_COMPILE_FLAGS " ${MODULE_COMPILE_FLAGS}")
+
+# System dependent: Modify the way the library is build
+if(${CMAKE_SYSTEM} MATCHES Darwin)
+    set(MODULE_LINK_FLAGS "-undefined dynamic_lookup ${MODULE_LINK_FLAGS}")
+endif(${CMAKE_SYSTEM} MATCHES Darwin)
+
+# Setting compilation flags for the object
+set_target_properties(${MODULE}-object PROPERTIES COMPILE_FLAGS "${MODULE_COMPILE_FLAGS}")
+# Setting the linking flags for the library
+set_target_properties(${MODULE} PROPERTIES LINK_FLAGS "${MODULE_LINK_FLAGS}")
+
+# Installation
+install(TARGETS ${MODULE}
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib)
+
+install(FILES ${HDRS} DESTINATION include)
+
+# install macros
+install(DIRECTORY . DESTINATION ML/ FILES_MATCHING PATTERN "*.C")
+
+message(STATUS "ML enabled")
+endif(TREELITE_ROOT)

--- a/PWGLF/ML/MLLinkDef.h
+++ b/PWGLF/ML/MLLinkDef.h
@@ -1,0 +1,9 @@
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class AliExternalBDT+ ;
+
+#endif


### PR DESCRIPTION
This commit, prepared with @pfecchio, introduces an interface to the
treelite library. Treelite takes serialised models created by xgboost,
lightgbm and scikit-learn and turns them in C code.
The C code can then be compiled into a library that is used for
inference.
For the time being the interface allows the user to load a serialised
model from LightGBM, xgboost or a compiled library generated locally.
Local tests on a small dataset show that the inference with this
interface and with xgboost (in python) gives exactly the same results.