### PR TITLE
Make jetType settable in the jet container and AliAnalysisTaskEmcalJet

### DIFF
--- a/PWG/JETFW/AliAnalysisTaskEmcalJet.cxx
+++ b/PWG/JETFW/AliAnalysisTaskEmcalJet.cxx
@@ -423,6 +423,23 @@ void AliAnalysisTaskEmcalJet::SetJetAcceptanceType(TString cutType, Int_t c)
   } else
     cont->SetJetAcceptanceType(AliEmcalJet::kUser);
 }
+/**
+ * Set the jet type (Full, Charged, Neutral) of the \f$ i^{th} \f$
+ * jet container attached to this task
+ */
+void AliAnalysisTaskEmcalJet::SetJetType(EJetType_t type, Int_t c)
+{
+  AliJetContainer *cont = GetJetContainer(c);
+  if (cont)
+  {
+    cont->SetJetType(type);
+  }
+  else
+  {
+    AliError(Form("%s in SetJetType(...): container %d not found",GetName(),c));
+    return;
+  }
+}
 
 void AliAnalysisTaskEmcalJet::SetRhoName(const char *n, Int_t c)
 {

--- a/PWG/JETFW/AliAnalysisTaskEmcalJet.h
+++ b/PWG/JETFW/AliAnalysisTaskEmcalJet.h
@@ -41,6 +41,7 @@ class AliAnalysisTaskEmcalJet : public AliAnalysisTaskEmcal {
   void                        SetAnaType(UInt_t t, Int_t c = 0) { SetJetAcceptanceType(t,c); }
   void                        SetJetAcceptanceType(UInt_t t, Int_t c = 0);
   void                        SetJetAcceptanceType(TString cutType, Int_t c = 0);
+  void                        SetJetType(EJetType_t type, Int_t c = 0);
   void                        SetJetEtaLimits(Float_t min, Float_t max, Int_t c = 0);
   void                        SetJetPhiLimits(Float_t min, Float_t max, Int_t c = 0);
   void                        SetJetAreaCut(Float_t cut, Int_t c = 0);

--- a/PWG/JETFW/AliJetContainer.cxx
+++ b/PWG/JETFW/AliJetContainer.cxx
@@ -896,6 +896,9 @@ TString AliJetContainer::GenerateJetName(EJetType_t jetType, EJetAlgo_t jetAlgo,
   case kNeutralJet:
     typeString = "Neutral";
     break;
+  case kUndefinedJetType:
+    typeString = "Undefined";
+    break;
   }
 
   TString radiusString = TString::Format("R%03.0f", radius*100.0);

--- a/PWG/JETFW/AliJetContainer.h
+++ b/PWG/JETFW/AliJetContainer.h
@@ -104,6 +104,7 @@ class AliJetContainer : public AliParticleContainer {
   void                        SetJetPtCutMax(Float_t cut)                          { SetMaxPt(cut)                      ; }
   void                        SetRunNumber(Int_t r)                                { fRunNumber = r;                      }
   void                        SetJetRadius(Float_t r)                              { fJetRadius      = r                ; } 
+  void                        SetJetType(EJetType_t type)                          { fJetType        = type             ; }
   void                        SetJetAreaCut(Float_t cut)                           { fJetAreaCut     = cut              ; }
   void                        SetPercAreaCut(Float_t p)                            { if(fJetRadius==0.) AliWarning("JetRadius not set. Area cut will be 0"); 
                                                                                      fJetAreaCut = p*TMath::Pi()*fJetRadius*fJetRadius; }


### PR DESCRIPTION
To use the JetType information in your task you have to call the AddJetContainer version with
AliAnalysisTaskEmcalJet::AddJetContainer(EJetType_t jetType, ….
or set the jet type by hand after you added the jet container to the task in another way.

@mfasDa added this setter as discussed.