### PR TITLE
Fixes acapon_TTree PID correction application issue

### DIFF
--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskSimpleTreeMaker.cxx
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskSimpleTreeMaker.cxx
@@ -10,9 +10,9 @@
 *can then be worked on locally. The motivation for this was to create TTrees that *
 *could be easily used within TMVA.                                                *
 *                                                                                 *
-*The default track cuts are relatively loose, and the PID selects out electrons   *
-*within +-4 nSigma in the TPC. This value, as well as cuts on the other detector  *
-*response values, can be turned on and off via their relavent setter functions.   *
+*The standard TTree relies on the dielectron framework and sources cuts from a    *
+"CutLibrary" config file. An example can be found in macrosLMEE/LMEECuLib_acapon.C*
+*The desired cut is then specified in the AddTaskSimpleTreeMaker.C.               *
 *                                                                                 *
 *The GRID PID number for each job is stored with each event along with a simple   *
 *event counter ID, so that after merging each event still has a unique label.     *
@@ -20,7 +20,7 @@
 *By default, the class will return a TTree focused on selecting electrons from    *
 *primary decays. There are setter functions which can be used to instead create a *
 *TTree filled with tracks originating from V0 decays. In this case the DCA cuts   *
-*are removed.                                                                     *
+*are removed and standard methods for applying cuts are used.                     *
 **********************************************************************************/
 #include "Riostream.h"
 #include "TChain.h"
@@ -74,249 +74,235 @@
 
 ClassImp(AliAnalysisTaskSimpleTreeMaker)
 
-Int_t eventNum = 0;
-
 AliAnalysisTaskSimpleTreeMaker::AliAnalysisTaskSimpleTreeMaker():
-    AliAnalysisTaskSE(),
-		hasMC(kFALSE),
-    fESDtrackCuts(0),
-    fPIDResponse(0),
-		fMCevent(0),
-    fTree(0x0),
-		eventCuts(0),
-		eventFilter(0),
-		varCuts(0),
-		trackCuts(0),
-		pidCuts(0),
-		cuts(0),
-		trackFilter(0),
-		varManager(0),
-		primaryVertex{0,0,0},
-		multiplicityV0A(0),
-		multiplicityV0C(0),
-		multiplicityCL1(0),
-		runNumber(0),
-		event(0),
-		pt(0),
-		eta(0),
-		phi(0),
-		nTPCclusters(0),
-		nTPCcrossed(0),
-		fTPCcrossOverFind(0),
-		nTPCfindable(0),
-		tpcSharedMap(0),
-		nTPCshared(0),
-		chi2TPC(0),
-		DCA{0,0},
-		nITS(0),
-		chi2ITS(0),
-		fITSshared(0),
-		SPDfirst(0),
-		charge(0),
-		EnSigmaITS(0),
-		EnSigmaITScorr(0),
-		EnSigmaTPC(0),
-		EnSigmaTPCcorr(0),
-		EnSigmaTOF(0),
-		EnSigmaTOFcorr(0),
-		PnSigmaTPC(0),
-		PnSigmaITS(0),
-		PnSigmaTOF(0),
-		KnSigmaITS(0),
-		KnSigmaTPC(0),
-		KnSigmaTOF(0),
-		ITSsignal(0),
-		TPCsignal(0),
-		TOFsignal(0),
-		goldenChi2(0),
-		mcEta(0),
-		mcPhi(0),
-		mcPt(0),
-		mcVert{0,0,0},
-		iPdg(0),
-		iPdgMother(0),
-		HasMother(0),
-		motherLabel(0),
-		isInj(0),
-		iPdgFirstMother(0),
-		gLabelFirstMother(0),
-		gLabelMinFirstMother(0),
-		gLabelMaxFirstMother(0),
-		pointingAngle(0),
-		daughtersDCA(0),
-		decayLength(0),
-		v0mass(0),
-		ptArm(0),
-		alpha(0),
-    fQAhist(0),
-    fCentralityPercentileMin(0),
-    fCentralityPercentileMax(100),
-    fPtMin(0.2),
-    fPtMax(10),
-    fEtaMin(-0.8),
-    fEtaMax(0.8),
-    fESigITSMin(-3.),
-    fESigITSMax(3.),
-    fESigTPCMin(-4.),
-    fESigTPCMax(4.),
-    fESigTOFMin(-3.),
-    fESigTOFMax(3.),
-    fPIDcutITS(kFALSE),
-    fPIDcutTOF(kFALSE),
-    fPionPIDcutTPC(kFALSE),
-    fPSigTPCMin(-99.),
-    fPSigTPCMax(-3.),
-    fHasSDD(kTRUE),
-    fIsV0tree(kFALSE),
-    fArmPlot(0),
-    fIsAOD(kTRUE),
-    fFilterBit(16),
-    fIsGRIDanalysis(kTRUE),
-    fGridPID(-1),
-		fUseTPCcorr(kFALSE),
-		fWidthTPC(0),
-		fMeanTPC(0),
-		fUseITScorr(kFALSE),
-		fWidthITS(0),
-		fMeanITS(0),
-		fUseTOFcorr(kFALSE),
-		fWidthTOF(0),
-		fMeanTOF(0),
-		TOFstartMask(0),
-		fGeneratorHashes(0)
+	AliAnalysisTaskSE(),
+	eventNum(0),
+	hasMC(kFALSE),
+	fESDtrackCuts(0),
+	fPIDResponse(0),
+	fMCevent(0),
+	fTree(0x0),
+	eventCuts(0),
+	eventFilter(0),
+	varCuts(0),
+	trackCuts(0),
+	pidCuts(0),
+	cuts(0),
+	trackFilter(0),
+	varManager(0),
+	primaryVertex{0,0,0},
+	multiplicityV0A(0),
+	multiplicityV0C(0),
+	multiplicityCL1(0),
+	runNumber(0),
+	event(0),
+	pt(0),
+	eta(0),
+	phi(0),
+	nTPCclusters(0),
+	nTPCcrossed(0),
+	fTPCcrossOverFind(0),
+	nTPCfindable(0),
+	tpcSharedMap(0),
+	nTPCshared(0),
+	chi2TPC(0),
+	DCA{0,0},
+	nITS(0),
+	chi2ITS(0),
+	fITSshared(0),
+	SPDfirst(0),
+	charge(0),
+	EnSigmaITS(0),
+	EnSigmaITScorr(0),
+	EnSigmaTPC(0),
+	EnSigmaTPCcorr(0),
+	EnSigmaTOF(0),
+	EnSigmaTOFcorr(0),
+	maxPtPIDcorrection(5),
+	PnSigmaITS(0),
+	PnSigmaTPC(0),
+	PnSigmaTOF(0),
+	storeKaonPID(0),
+	KnSigmaITS(0),
+	KnSigmaTPC(0),
+	KnSigmaTOF(0),
+	ITSsignal(0),
+	TPCsignal(0),
+	TOFsignal(0),
+	goldenChi2(0),
+	mcEta(0),
+	mcPhi(0),
+	mcPt(0),
+	mcVert{0,0,0},
+	iPdg(0),
+	iPdgMother(0),
+	HasMother(0),
+	motherLabel(0),
+	isInj(0),
+	iPdgFirstMother(0),
+	gLabelFirstMother(0),
+	gLabelMinFirstMother(0),
+	gLabelMaxFirstMother(0),
+	pointingAngle(0),
+	daughtersDCA(0),
+	decayLength(0),
+	v0mass(0),
+	ptArm(0),
+	alpha(0),
+	fQAhist(0),
+	fCentralityPercentileMin(0),
+	fCentralityPercentileMax(100),
+	fPtMin(0.2),
+	fPtMax(10),
+	fEtaMin(-0.8),
+	fEtaMax(0.8),
+	fESigTPCMin(-4.),
+	fESigTPCMax(4.),
+	fHasSDD(kTRUE),
+	fIsV0tree(kFALSE),
+	fArmPlot(0),
+	fIsAOD(kTRUE),
+	fFilterBit(16),
+	fIsGRIDanalysis(kTRUE),
+	fGridPID(-1),
+	fUseTPCcorr(kFALSE),
+	fWidthTPC(0),
+	fMeanTPC(0),
+	fUseITScorr(kFALSE),
+	fWidthITS(0),
+	fMeanITS(0),
+	fUseTOFcorr(kFALSE),
+	fWidthTOF(0),
+	fMeanTOF(0),
+	TOFstartMask(0),
+	fGeneratorHashes(0)
 {
 
 }
 
 AliAnalysisTaskSimpleTreeMaker::AliAnalysisTaskSimpleTreeMaker(const char *name) :
-    AliAnalysisTaskSE(name),
-		hasMC(kFALSE),
-   	fESDtrackCuts(0),
-    fPIDResponse(0),
-		fMCevent(0),
-    fTree(0),
-		eventCuts(0),
-		eventFilter(0),
-		varCuts(0),
-		trackCuts(0),
-		pidCuts(0),
-		cuts(0),
-		trackFilter(0),
-		varManager(0),
-		primaryVertex{0,0,0},
-		multiplicityV0A(0),
-		multiplicityV0C(0),
-		multiplicityCL1(0),
-		runNumber(0),
-		event(0),
-		pt(0),
-		eta(0),
-		phi(0),
-		nTPCclusters(0),
-		nTPCcrossed(0),
-		fTPCcrossOverFind(0),
-		nTPCfindable(0),
-		tpcSharedMap(0),
-		nTPCshared(0),
-		chi2TPC(0),
-		DCA{0,0},
-		nITS(0),
-		chi2ITS(0),
-		fITSshared(0),
-		SPDfirst(0),
-		charge(0),
-		EnSigmaITS(0),
-		EnSigmaITScorr(0),
-		EnSigmaTPC(0),
-		EnSigmaTPCcorr(0),
-		EnSigmaTOF(0),
-		EnSigmaTOFcorr(0),
-		PnSigmaTPC(0),
-		PnSigmaITS(0),
-		PnSigmaTOF(0),
-		KnSigmaITS(0),
-		KnSigmaTPC(0),
-		KnSigmaTOF(0),
-		ITSsignal(0),
-		TPCsignal(0),
-		TOFsignal(0),
-		goldenChi2(0),
-		mcEta(0),
-		mcPhi(0),
-		mcPt(0),
-		mcVert{0,0,0},
-		iPdg(0),
-		iPdgMother(0),
-		HasMother(0),
-		motherLabel(0),
-		isInj(0),
-		iPdgFirstMother(0),
-		gLabelFirstMother(0),
-		gLabelMinFirstMother(0),
-		gLabelMaxFirstMother(0),
-		pointingAngle(0),
-		daughtersDCA(0),
-		decayLength(0),
-		v0mass(0),
-		ptArm(0),
-		alpha(0),
-    fQAhist(0),
-    fCentralityPercentileMin(0),
-    fCentralityPercentileMax(100),
-    fPtMin(0.2),
-    fPtMax(10),
-    fEtaMin(-0.8),
-    fEtaMax(0.8),
-    fESigITSMin(-3.),
-    fESigITSMax(3.),
-    fESigTPCMin(-4.),
-    fESigTPCMax(4.),
-    fESigTOFMin(-3.),
-    fESigTOFMax(3.),
-    fPIDcutITS(kFALSE),
-    fPIDcutTOF(kFALSE),
-    fPionPIDcutTPC(kFALSE),
-		fPSigTPCMin(-99.),
-    fPSigTPCMax(-3.),
-    fHasSDD(kTRUE),
-    fIsV0tree(kFALSE),
-    fArmPlot(0),
-    fIsAOD(kTRUE),
-    fFilterBit(16),
-    fIsGRIDanalysis(kTRUE),
-    fGridPID(0),
-		fUseTPCcorr(kFALSE),
-		fWidthTPC(0),
-		fMeanTPC(0),
-		fUseITScorr(kFALSE),
-		fWidthITS(0),
-		fMeanITS(0),
-		fUseTOFcorr(kFALSE),
-		fWidthTOF(0),
-		fMeanTOF(0),
-		TOFstartMask(0),
-		fGeneratorHashes(0)
+	AliAnalysisTaskSE(name),
+	eventNum(0),
+	hasMC(kFALSE),
+	fESDtrackCuts(0),
+	fPIDResponse(0),
+	fMCevent(0),
+	fTree(0),
+	eventCuts(0),
+	eventFilter(0),
+	varCuts(0),
+	trackCuts(0),
+	pidCuts(0),
+	cuts(0),
+	trackFilter(0),
+	varManager(0),
+	primaryVertex{0,0,0},
+	multiplicityV0A(0),
+	multiplicityV0C(0),
+	multiplicityCL1(0),
+	runNumber(0),
+	event(0),
+	pt(0),
+	eta(0),
+	phi(0),
+	nTPCclusters(0),
+	nTPCcrossed(0),
+	fTPCcrossOverFind(0),
+	nTPCfindable(0),
+	tpcSharedMap(0),
+	nTPCshared(0),
+	chi2TPC(0),
+	DCA{0,0},
+	nITS(0),
+	chi2ITS(0),
+	fITSshared(0),
+	SPDfirst(0),
+	charge(0),
+	EnSigmaITS(0),
+	EnSigmaITScorr(0),
+	EnSigmaTPC(0),
+	EnSigmaTPCcorr(0),
+	EnSigmaTOF(0),
+	EnSigmaTOFcorr(0),
+	maxPtPIDcorrection(5),
+	PnSigmaITS(0),
+	PnSigmaTPC(0),
+	PnSigmaTOF(0),
+	storeKaonPID(0),
+	KnSigmaITS(0),
+	KnSigmaTPC(0),
+	KnSigmaTOF(0),
+	ITSsignal(0),
+	TPCsignal(0),
+	TOFsignal(0),
+	goldenChi2(0),
+	mcEta(0),
+	mcPhi(0),
+	mcPt(0),
+	mcVert{0,0,0},
+	iPdg(0),
+	iPdgMother(0),
+	HasMother(0),
+	motherLabel(0),
+	isInj(0),
+	iPdgFirstMother(0),
+	gLabelFirstMother(0),
+	gLabelMinFirstMother(0),
+	gLabelMaxFirstMother(0),
+	pointingAngle(0),
+	daughtersDCA(0),
+	decayLength(0),
+	v0mass(0),
+	ptArm(0),
+	alpha(0),
+	fQAhist(0),
+	fCentralityPercentileMin(0),
+	fCentralityPercentileMax(100),
+	fPtMin(0.2),
+	fPtMax(10),
+	fEtaMin(-0.8),
+	fEtaMax(0.8),
+	fESigTPCMin(-4.),
+	fESigTPCMax(4.),
+	fHasSDD(kTRUE),
+	fIsV0tree(kFALSE),
+	fArmPlot(0),
+	fIsAOD(kTRUE),
+	fFilterBit(16),
+	fIsGRIDanalysis(kTRUE),
+	fGridPID(0),
+	fUseTPCcorr(kFALSE),
+	fWidthTPC(0),
+	fMeanTPC(0),
+	fUseITScorr(kFALSE),
+	fWidthITS(0),
+	fMeanITS(0),
+	fUseTOFcorr(kFALSE),
+	fWidthTOF(0),
+	fMeanTOF(0),
+	TOFstartMask(0),
+	fGeneratorHashes(0)
 
 {
-    if(fIsV0tree){
-      fESDtrackCuts = AliESDtrackCuts::GetStandardV0DaughterCuts();
-    }
+	if(fIsV0tree){
+		fESDtrackCuts = AliESDtrackCuts::GetStandardV0DaughterCuts();
+	}
 
-		// Create hashes of generators used for injected signals in MC
-		TString generatorNames = "Pythia CC_1;Pythia BB_1;Pythia B_1;Jpsi2ee_1;B2Jpsi2ee_1";
-		TObjArray arr = *(generatorNames.Tokenize(";"));
-		for(Int_t i = 0; i < arr.GetEntries(); i++){
-			TString temp = arr.At(i)->GetName();
-			std::cout << "---" << temp << std::endl;
-			fGeneratorHashes.push_back(temp.Hash());
-		}
+	// Create hashes of generators used for injected signals in MC
+	TString generatorNames = "Pythia CC_1;Pythia BB_1;Pythia B_1;Jpsi2ee_1;B2Jpsi2ee_1";
+	TObjArray arr = *(generatorNames.Tokenize(";"));
+	for(Int_t i = 0; i < arr.GetEntries(); i++){
+		TString temp = arr.At(i)->GetName();
+		std::cout << "---" << temp << std::endl;
+		fGeneratorHashes.push_back(temp.Hash());
+	}
 
 
-    // Input slot #0 works with a TChain
-    DefineInput(0, TChain::Class());
-    DefineOutput(1, TTree::Class()); //will be connected to fTree
-    DefineOutput(2, TH1F::Class());
-    DefineOutput(3, TH2F::Class());
+	// Input slot #0 works with a TChain
+	DefineInput(0, TChain::Class());
+	DefineOutput(1, TTree::Class()); //will be connected to fTree
+	DefineOutput(2, TH1F::Class());
+	DefineOutput(3, TH2F::Class());
 
 }
 
@@ -340,166 +326,165 @@ AliAnalysisTaskSimpleTreeMaker::~AliAnalysisTaskSimpleTreeMaker(){
 
 void AliAnalysisTaskSimpleTreeMaker::UserCreateOutputObjects(){
 
-    AliAnalysisManager* man = AliAnalysisManager::GetAnalysisManager();
-    AliInputEventHandler* inputHandler = dynamic_cast<AliInputEventHandler*>(man->GetInputEventHandler());
-    inputHandler->SetNeedField();
+	AliAnalysisManager* man = AliAnalysisManager::GetAnalysisManager();
+	AliInputEventHandler* inputHandler = dynamic_cast<AliInputEventHandler*>(man->GetInputEventHandler());
+	inputHandler->SetNeedField();
 
-    fPIDResponse = inputHandler->GetPIDResponse();
-    if(!fPIDResponse){
-        AliFatal("This task needs the PID response attached to the inputHandler");
-      return;
-    }
+	fPIDResponse = inputHandler->GetPIDResponse();
+	if(!fPIDResponse){
+		AliFatal("This task needs the PID response attached to the inputHandler");
+		return;
+	}
 
-    fTree = new TTree("tracks", "tracks");
-		//Common branches to all variants of class
+	fTree = new TTree("tracks", "tracks");
+	//Common branches to all variants of class
 
-		//Track variables
-		fTree->Branch("pt",                &pt);
-		fTree->Branch("eta",               &eta);
-		fTree->Branch("phi",               &phi);
-		fTree->Branch("nTPCclusters",      &nTPCclusters);
-		fTree->Branch("nTPCcrossed",       &nTPCcrossed);
-		fTree->Branch("nTPCfindable",      &nTPCfindable);
-		fTree->Branch("nTPCshared",        &nTPCshared);
-		fTree->Branch("fTPCcrossOverFind", &fTPCcrossOverFind);
-		fTree->Branch("chi2TPC",           &chi2TPC);
-		fTree->Branch("nITS",              &nITS);
-		fTree->Branch("fITSshared",        &fITSshared);
-		fTree->Branch("chi2ITS",           &chi2ITS);
-		fTree->Branch("SPDfirst",          &SPDfirst);
-		fTree->Branch("DCAxy",             &DCA[0]);
-		fTree->Branch("DCAz",              &DCA[1]);
-		fTree->Branch("goldenChi2",        &goldenChi2);
-		fTree->Branch("charge",            &charge);
-		fTree->Branch("EsigITS",           &EnSigmaITS);
-		if(fUseITScorr){
-			fTree->Branch("EsigITScorr",     &EnSigmaITScorr);
-		}
-		fTree->Branch("EsigTPC",           &EnSigmaTPC);
-		if(fUseTPCcorr){
-			fTree->Branch("EsigTPCcorr",     &EnSigmaTPCcorr);
-		}
-		fTree->Branch("EsigTOF",           &EnSigmaTOF);
-		if(fUseTOFcorr){
-			fTree->Branch("EsigTOFcorr",     &EnSigmaTOFcorr);
-		}
-		fTree->Branch("PsigITS",           &PnSigmaITS);
-		fTree->Branch("PsigTPC",           &PnSigmaTPC);
-		fTree->Branch("PsigTOF",           &PnSigmaTOF);
-		fTree->Branch("KsigITS",           &KnSigmaITS);
-		fTree->Branch("KsigTPC",           &KnSigmaTPC);
-		fTree->Branch("KsigTOF",           &KnSigmaTOF);
-		fTree->Branch("ITSsignal",         &ITSsignal);
-		fTree->Branch("TPCsignal",         &TPCsignal);
-		fTree->Branch("TOFsignal",         &TOFsignal);
-		//V0 tree variables
-		if(fIsV0tree){
-				fTree->Branch("pointingAngle", &pointingAngle);
-				fTree->Branch("daughtersDCA",  &daughtersDCA);
-				fTree->Branch("decayLength",   &decayLength);
-				fTree->Branch("v0mass",        &v0mass);
-				fTree->Branch("ptArm",         &ptArm);
-				fTree->Branch("alpha",         &alpha);
-		}
-		//MC variables
-		if(hasMC){
-			fTree->Branch("mcPt",              &mcPt);
-			fTree->Branch("mcEta",             &mcEta);
-			fTree->Branch("mcPhi",             &mcPhi);
-			fTree->Branch("mcVertx",           &mcVert[0]);
-			fTree->Branch("mcVerty",           &mcVert[1]);
-			fTree->Branch("mcVertz",           &mcVert[2]);
-			fTree->Branch("pdg",               &iPdg);
-			fTree->Branch("pdgMother",         &iPdgMother);
-			fTree->Branch("HasMother",         &HasMother);
-			fTree->Branch("motherLabel",       &motherLabel);
-			fTree->Branch("pdgFirstMother",    &iPdgFirstMother);
-			fTree->Branch("gLabelFirstMother", &gLabelFirstMother);
-			fTree->Branch("labelMinInitial",   &gLabelMinFirstMother);
-			fTree->Branch("labelMaxInitial",   &gLabelMaxFirstMother);
-			fTree->Branch("isInjected",        &isInj);
-		}
-		//Event variables
-		fTree->Branch("vertexX",         &primaryVertex[0]);
-		fTree->Branch("vertexY",         &primaryVertex[1]);
-		fTree->Branch("vertexZ",         &primaryVertex[2]);
-		fTree->Branch("runNumber",       &runNumber);
-		fTree->Branch("eventNum",        &eventNum);
-		fTree->Branch("multiplicityV0A", &multiplicityV0A);
-		fTree->Branch("multiplicityV0C", &multiplicityV0C);
-		fTree->Branch("multiplicityCL1", &multiplicityCL1);
-		fTree->Branch("gridPID",         &fGridPID);
-		fTree->Branch("TOFstartMask", &TOFstartMask);
+	//Track variables
+	fTree->Branch("pt",                &pt,                "pt/F");
+	fTree->Branch("eta",               &eta,               "eta/F");
+	fTree->Branch("phi",               &phi,               "phi/F");
+	fTree->Branch("nTPCclusters",      &nTPCclusters,      "nTPCclusters/F");
+	fTree->Branch("nTPCcrossed",       &nTPCcrossed,       "nTPCcrossed/F");
+	fTree->Branch("nTPCfindable",      &nTPCfindable,      "nTPCfindable/F");
+	fTree->Branch("nTPCshared",        &nTPCshared,        "nTPCshared/F");
+	fTree->Branch("fTPCcrossOverFind", &fTPCcrossOverFind, "fTPCcrossOverFind/F");
+	fTree->Branch("chi2TPC",           &chi2TPC,           "chi2TPC/F");
+	fTree->Branch("nITS",              &nITS,              "nITS/F");
+	fTree->Branch("fITSshared",        &fITSshared,        "fITSshared/F");
+	fTree->Branch("chi2ITS",           &chi2ITS,           "chi2ITS/F");
+	fTree->Branch("SPDfirst",          &SPDfirst,          "SPDfirst/F");
+	fTree->Branch("DCAxy",             &DCA[0],            "DCAxy/F");
+	fTree->Branch("DCAz",              &DCA[1],            "DCAz/F");
+	fTree->Branch("goldenChi2",        &goldenChi2,        "goldenChi2/F");
+	fTree->Branch("charge",            &charge,            "charge/F");
+	fTree->Branch("EsigITS",           &EnSigmaITS,     "EsigITS/F");
+	if(fUseITScorr){
+		fTree->Branch("EsigITScorr",     &EnSigmaITScorr, "EsigITScorr/F");
+	}
+	fTree->Branch("EsigTPC",           &EnSigmaTPC,     "EsigTPC/F");
+	if(fUseTPCcorr){
+		fTree->Branch("EsigTPCcorr",     &EnSigmaTPCcorr, "EsigTPCcorr/F");
+	}
+	fTree->Branch("EsigTOF",           &EnSigmaTOF,     "EsigTOF/F");
+	if(fUseTOFcorr){
+		fTree->Branch("EsigTOFcorr",     &EnSigmaTOFcorr, "EsigTOFcorr/F");
+	}
+	fTree->Branch("PsigITS",           &PnSigmaITS, "PsigITS/F");
+	fTree->Branch("PsigTPC",           &PnSigmaTPC, "PsigTPC/F");
+	fTree->Branch("PsigTOF",           &PnSigmaTOF, "PsigTOF/F");
+	if(storeKaonPID){
+		fTree->Branch("KsigITS",           &KnSigmaITS, "KsigITS/F");
+		fTree->Branch("KsigTPC",           &KnSigmaTPC, "KsigTPC/F");
+		fTree->Branch("KsigTOF",           &KnSigmaTOF, "KsigTOF/F");
+	}
+	fTree->Branch("ITSsignal",         &ITSsignal,  "ITSsignal/F");
+	fTree->Branch("TPCsignal",         &TPCsignal,  "TPCsignal/F");
+	fTree->Branch("TOFsignal",         &TOFsignal,  "TOFsignal/F");
+	//V0 tree variables
+	if(fIsV0tree){
+		fTree->Branch("pointingAngle", &pointingAngle, "pointingAngle/F");
+		fTree->Branch("daughtersDCA",  &daughtersDCA,  "daughtersDCA/F");
+		fTree->Branch("decayLength",   &decayLength,   "decayLength/F");
+		fTree->Branch("v0mass",        &v0mass,        "v0mass/F");
+		fTree->Branch("ptArm",         &ptArm,         "ptArm/F");
+		fTree->Branch("alpha",         &alpha,         "alpha/F");
+	}
+	//MC variables
+	if(hasMC){
+		fTree->Branch("mcPt",              &mcPt,                 "mcPt/F");
+		fTree->Branch("mcEta",             &mcEta,                "mcEta/F");
+		fTree->Branch("mcPhi",             &mcPhi,                "mcPhi/F");
+		fTree->Branch("mcVertx",           &mcVert[0],            "mcVertx/F");
+		fTree->Branch("mcVerty",           &mcVert[1],            "mcVerty/F");
+		fTree->Branch("mcVertz",           &mcVert[2],            "mcVertz/F");
+		fTree->Branch("pdg",               &iPdg,                 "pdg/I");
+		fTree->Branch("pdgMother",         &iPdgMother,           "pdgMother/I");
+		fTree->Branch("HasMother",         &HasMother,            "HasMother/O");
+		fTree->Branch("motherLabel",       &motherLabel,          "motherLabel/I");
+		fTree->Branch("pdgFirstMother",    &iPdgFirstMother,      "pdgFirstMother/I");
+		fTree->Branch("gLabelFirstMother", &gLabelFirstMother,    "gLabelFirstMother/I");
+		fTree->Branch("labelMinInitial",   &gLabelMinFirstMother, "labelMinInitial/I");
+		fTree->Branch("labelMaxInitial",   &gLabelMaxFirstMother, "labelMaxInitial/I");
+		fTree->Branch("isInjected",        &isInj,                "isInjected/O");
+	}
+	//Event variables
+	fTree->Branch("vertexX",         &primaryVertex[0], "vertexX/F");
+	fTree->Branch("vertexY",         &primaryVertex[1], "vertexY/F");
+	fTree->Branch("vertexZ",         &primaryVertex[2], "vertexZ/F");
+	fTree->Branch("runNumber",       &runNumber,        "runNumber/I");
+	fTree->Branch("eventNum",        &eventNum,         "eventNum/I");
+	fTree->Branch("multiplicityV0A", &multiplicityV0A,  "multiplicityV0A/F");
+	fTree->Branch("multiplicityV0C", &multiplicityV0C,  "multiplicityV0C/F");
+	fTree->Branch("multiplicityCL1", &multiplicityCL1,  "multiplicityCL1/F");
+	fTree->Branch("gridPID",         &fGridPID,         "gridPID/I");
+	fTree->Branch("TOFstartMask",    &TOFstartMask,     "TOFstartMask/F");
 
-    //Get grid PID which can be used later to assign unique event numbers
-    if(fIsGRIDanalysis){
-        const char* gridIDchar = gSystem->Getenv("ALIEN_PROC_ID");
-        std::string str(gridIDchar);
-        SetGridPID(str);
-    }
-    else{
-        fGridPID = -1;
-    }
+	//Get grid PID which can be used later to assign unique event numbers
+	if(fIsGRIDanalysis){
+		const char* gridIDchar = gSystem->Getenv("ALIEN_PROC_ID");
+		std::string str(gridIDchar);
+		SetGridPID(str);
+	}
+	else{
+		fGridPID = -1;
+	}
 
-		//Setup correction maps
-		if(fUseTPCcorr){
-			AliDielectronPID::SetCentroidCorrFunction( (TH1*)fMeanTPC->Clone() );
-			AliDielectronPID::SetWidthCorrFunction( (TH1*)fWidthTPC->Clone() );
-			::Info("AliAnalysisTaskSimpleTreeMaker::UserExec","Setting TPC Correction Histos");
-		}
+	//Setup correction maps
+	if(fUseTPCcorr){
+		AliDielectronPID::SetCentroidCorrFunction( (TH1*)fMeanTPC->Clone() );
+		AliDielectronPID::SetWidthCorrFunction( (TH1*)fWidthTPC->Clone() );
+		::Info("AliAnalysisTaskSimpleTreeMaker::UserExec","Setting TPC Correction Histos");
+	}
 
-		if(fUseITScorr){
-			AliDielectronPID::SetCentroidCorrFunctionITS( (TH1*)fMeanITS->Clone() );
-			AliDielectronPID::SetWidthCorrFunctionITS( (TH1*)fWidthITS->Clone() );
-			::Info("AliAnalysisTaskSimpleTreeMaker::UserExec","Setting ITS Correction Histos");
-		}
-		
-		if(fUseTOFcorr){
-			AliDielectronPID::SetCentroidCorrFunctionTOF( (TH1*)fMeanTOF->Clone() );
-			AliDielectronPID::SetWidthCorrFunctionTOF( (TH1*)fWidthTOF->Clone() );
-			::Info("AliAnalysisTaskSimpleTreeMaker::UserExec","Setting TOF Correction Histos");
-		}
+	if(fUseITScorr){
+		AliDielectronPID::SetCentroidCorrFunctionITS( (TH1*)fMeanITS->Clone() );
+		AliDielectronPID::SetWidthCorrFunctionITS( (TH1*)fWidthITS->Clone() );
+		::Info("AliAnalysisTaskSimpleTreeMaker::UserExec","Setting ITS Correction Histos");
+	}
+	
+	if(fUseTOFcorr){
+		AliDielectronPID::SetCentroidCorrFunctionTOF( (TH1*)fMeanTOF->Clone() );
+		AliDielectronPID::SetWidthCorrFunctionTOF( (TH1*)fWidthTOF->Clone() );
+		::Info("AliAnalysisTaskSimpleTreeMaker::UserExec","Setting TOF Correction Histos");
+	}
 
-		//Needed by the dielectron framework
-		varManager->SetPIDResponse(fPIDResponse);
+	//Needed by the dielectron framework
+	varManager->SetPIDResponse(fPIDResponse);
 
-    //Create TH2F for armenteros plot. Filled if creating v0 tree
-		//NOTE: Class designed to study electrons with weak EsigTPC cuts
-		//applied. Therefore, the number of tracks will not necessarily be twice the
-		//number of V0 particles (as one might expect).
-    fArmPlot = new TH2F("ArmPlot", "Armenteros Plot", 100, -1, 1, 100, 0, 0.4);
-    if(fIsV0tree){
-        fArmPlot->GetXaxis()->SetTitle("#alpha = (p^{+}-p^{-})/(p^{+}+p^{-})");
-        fArmPlot->GetYaxis()->SetTitle("p_{T}");
-    }
+	//Create TH2F for armenteros plot. Filled if creating v0 tree
+	//NOTE: Class designed to study electrons with weak EsigTPC cuts
+	//applied. Therefore, the number of tracks will not necessarily be twice the
+	//number of V0 particles (as one might expect).
+	fArmPlot = new TH2F("ArmPlot", "Armenteros Plot", 100, -1, 1, 100, 0, 0.4);
+	if(fIsV0tree){
+		fArmPlot->GetXaxis()->SetTitle("#alpha = (p^{+}-p^{-})/(p^{+}+p^{-})");
+		fArmPlot->GetYaxis()->SetTitle("p_{T}");
+	}
 
-    fQAhist = new TH1F("h1", "Event and track QA", 8, 0, 8);
-		//Fill each bin with nothing to ensure correct ordering
-		fQAhist->Fill("Events_check",0);
-		fQAhist->Fill("Events_accepted",0);
-		fQAhist->Fill("Events_MCcheck",0);
-		fQAhist->Fill("Tracks_all",0);
-		fQAhist->Fill("Tracks_MCcheck",0);
-		fQAhist->Fill("Tracks_Cuts",0);
+	fQAhist = new TH1F("h1", "Event and track QA", 8, 0, 8);
+	//Fill each bin with nothing to ensure correct ordering
+	fQAhist->Fill("Events_check",0);
+	fQAhist->Fill("Events_accepted",0);
+	fQAhist->Fill("Events_MCcheck",0);
+	fQAhist->Fill("Tracks_all",0);
+	fQAhist->Fill("Tracks_MCcheck",0);
+	fQAhist->Fill("Tracks_Cuts",0);
 
-		PostData(1, fTree);
-    PostData(2, fQAhist);
-    PostData(3, fArmPlot);
+	PostData(1, fTree);
+	PostData(2, fQAhist);
+	PostData(3, fArmPlot);
 }
 
 //________________________________________________________________________
-
+//Main loop: called for each event
 void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 
-	//Main loop
-	//Called for each event
 	AliVEvent* event = 0x0;
 	AliESDEvent* esdEvent = 0x0;
 	if(!fIsV0tree){
 		event = dynamic_cast<AliVEvent*>(InputEvent());
 	}else{
 		esdEvent = dynamic_cast<AliESDEvent*>(InputEvent());
-		//event = dynamic_cast<AliESDEvent*>(InputEvent());
 		event = esdEvent;
 	}
 	if(!event){
@@ -510,7 +495,7 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 		fQAhist->Fill("Events_check",1);
 	}
 
-	// check event cuts
+	// Check event cuts
 	if(IsEventAccepted(event) == 0){
 		return;
 	}
@@ -518,7 +503,7 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 		fQAhist->Fill("Events_accepted",1);
 	}
 
-	//Check if running on MC files
+	// Check if running on MC files
 	fMCevent = MCEvent();
 	if(fMCevent){
 		hasMC = kTRUE;
@@ -532,8 +517,7 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 
 	eventNum += 1;
 
-
-	//PID Response task active?
+	// PID Response task active?
 	fPIDResponse = (dynamic_cast<AliInputEventHandler*>((AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler())))->GetPIDResponse();
 
 	if(!fPIDResponse){ AliFatal("This task needs the PID response attached to the inputHandler"); }
@@ -544,8 +528,7 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 	primaryVertex[1] = vertex->GetY();
 	primaryVertex[2] = vertex->GetZ();
 
-
-	//Get Multiplicity
+	// Get Multiplicity
 	AliMultSelection* multSelection = dynamic_cast<AliMultSelection*>(event->FindListObject("MultSelection"));
 	if(!multSelection){
 		AliWarning("AliMultSelection object not found");
@@ -556,8 +539,8 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 		multiplicityCL1 = multSelection->GetMultiplicityPercentile("CL1");
 	}
 
-	//Check if ESD or AOD analysis
-	//Get ClassName from file and set appropriate ESD or AOD flag
+	// Check if ESD or AOD analysis
+	// Get ClassName from file and set appropriate ESD or AOD flag
 	TString className = static_cast<TString>(event->ClassName());
 	if(className.Contains("AOD")){
 		fIsAOD = kTRUE;
@@ -578,7 +561,7 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 	AliVParticle* mcTrack = 0x0;
 	AliVParticle* motherMCtrack = 0x0;
 
-	//Loop over tracks for event
+	// Loop over tracks for event
 	if(!fIsV0tree){
 		for(Int_t iTrack = 0; iTrack < eventTracks; iTrack++){
 
@@ -590,12 +573,12 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 
 			fQAhist->Fill("Tracks_all",1);
 
-			//Get MC information
+			// Get MC information
 			if(hasMC){
 
 				//Printf("--- Particle: %i", iTrack);
 
-				//Set MC features to dummy values
+				// Set MC features to dummy values
 				mcEta           = -99;
 				mcPhi           = -99;
 				mcPt            = -99;
@@ -613,14 +596,14 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 				if(fIsAOD){
 					mcTrack = dynamic_cast<AliAODMCParticle*>(fMCevent->GetTrack(TMath::Abs(track->GetLabel())));
 
-					//Check valid pointer has been returned. If not, disregard track.
+					// Check valid pointer has been returned. If not, disregard track.
 					if(!mcTrack){
 						continue;
 					}
 				}else{
 					mcTrack = dynamic_cast<AliMCParticle*>(fMCevent->GetTrack(TMath::Abs(track->GetLabel())));
 
-					//Check valid pointer has been returned. If not, disregard track.
+					// Check valid pointer has been returned. If not, disregard track.
 					if(!mcTrack){
 						continue;
 					}
@@ -645,13 +628,13 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 				if(!(gMotherIndex < 0)){
 					if(fIsAOD){
 						motherMCtrack = dynamic_cast<AliAODMCParticle*>((fMCevent->GetTrack(gMotherIndex)));
-						//Check for mother particle.
+						// Check for mother particle.
 						if(!motherMCtrack){
 							continue;
 						}
 					}else{
 						motherMCtrack = dynamic_cast<AliMCParticle*>((fMCevent->GetTrack(gMotherIndex)));
-						//Check for mother particle.
+						// Check for mother particle.
 						if(!motherMCtrack){
 							continue;
 						}
@@ -730,12 +713,12 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 					}
 					gLabelMaxFirstMother --; // set back by one
 				}
-			}//End if(hasMC)
+			}// End if(hasMC)
 
-			//Apply global track trackFilter
+			// Apply global track trackFilter
 			if(!fIsAOD){
 				if(!(fESDtrackCuts->AcceptTrack(dynamic_cast<const AliESDtrack*>(track)))){
-						continue;
+					continue;
 				}
 			}
 			else{
@@ -751,54 +734,52 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 			eta = track->Eta();
 			phi = track->Phi();
 
-			//Get PID response of track without TPC calibration
-			EnSigmaTPC = fPIDResponse->NumberOfSigmasTPC(track,(AliPID::EParticleType)AliPID::kElectron);
-			if(fUseTPCcorr){
-				EnSigmaTPCcorr = EnSigmaTPC;
+			// Get PID response values from available detectors
+			EnSigmaTPC = fPIDResponse->NumberOfSigmasTPC(track, AliPID::kElectron);
+			EnSigmaTPCcorr = EnSigmaTPC;
+			if(fUseTPCcorr && pt < maxPtPIDcorrection){
 				EnSigmaTPCcorr -= AliDielectronPID::GetCntrdCorr(track);
 				EnSigmaTPCcorr /= AliDielectronPID::GetWdthCorr(track);
 			}
-			EnSigmaITS = -999;
 			if(fHasSDD){
-				EnSigmaITS = fPIDResponse->NumberOfSigmasITS(track,(AliPID::EParticleType)AliPID::kElectron);
+				EnSigmaITS = fPIDResponse->NumberOfSigmasITS(track, AliPID::kElectron);
 				EnSigmaITScorr = EnSigmaITS;
-				// Only apply ITS correction if valid PID signal returned
-				if(fUseITScorr && (EnSigmaITS != -999)){
+				if(fUseITScorr && (EnSigmaITS != -999.) && pt < maxPtPIDcorrection){
 					EnSigmaITScorr -= AliDielectronPID::GetCntrdCorrITS(track);
 					EnSigmaITScorr /= AliDielectronPID::GetWdthCorrITS(track);
 				}
 			}
-			EnSigmaTOF = fPIDResponse->NumberOfSigmasTOF(track,(AliPID::EParticleType)AliPID::kElectron);
+			EnSigmaTOF = fPIDResponse->NumberOfSigmasTOF(track, AliPID::kElectron);
 			EnSigmaTOFcorr = EnSigmaTOF;
-			if(fUseTOFcorr && (EnSigmaTOF != -999)){
+			if(fUseTOFcorr && (EnSigmaTOF != -999.) && pt < maxPtPIDcorrection){
 				EnSigmaTOFcorr -= AliDielectronPID::GetCntrdCorrTOF(track);
 				EnSigmaTOFcorr /= AliDielectronPID::GetWdthCorrTOF(track);
 			}
 
-			PnSigmaTPC = fPIDResponse->NumberOfSigmasTPC(track,(AliPID::EParticleType)AliPID::kPion);
+			PnSigmaITS = fPIDResponse->NumberOfSigmasITS(track, AliPID::kPion);
+			PnSigmaTPC = fPIDResponse->NumberOfSigmasTPC(track, AliPID::kPion);
+			PnSigmaTOF = fPIDResponse->NumberOfSigmasTOF(track, AliPID::kPion);
 
-			//Get rest of nSigma values for pion and kaon
-			PnSigmaITS = fPIDResponse->NumberOfSigmasITS(track,(AliPID::EParticleType)AliPID::kPion);
-			PnSigmaTOF = fPIDResponse->NumberOfSigmasTOF(track,(AliPID::EParticleType)AliPID::kPion);
-
-			KnSigmaITS = fPIDResponse->NumberOfSigmasITS(track,(AliPID::EParticleType)AliPID::kKaon);
-			KnSigmaTPC = fPIDResponse->NumberOfSigmasTPC(track,(AliPID::EParticleType)AliPID::kKaon);
-			KnSigmaTOF = fPIDResponse->NumberOfSigmasTOF(track,(AliPID::EParticleType)AliPID::kKaon);
+			if(storeKaonPID){
+				KnSigmaITS = fPIDResponse->NumberOfSigmasITS(track, AliPID::kKaon);
+				KnSigmaTPC = fPIDResponse->NumberOfSigmasTPC(track, AliPID::kKaon);
+				KnSigmaTOF = fPIDResponse->NumberOfSigmasTOF(track, AliPID::kKaon);
+			}
 
 			// Get TOF start time mask
 			AliTOFPIDResponse TOFresponse = fPIDResponse->GetTOFResponse();
 			TOFstartMask = TOFresponse.GetStartTimeMask((Float_t)track->GetP());
 
-			//Get TPC information
-			//kNclsTPC
+			// Get TPC information
+			// kNclsTPC
 			nTPCclusters = track->GetTPCNcls();
 
-			//kNFclsTPCr
+			// kNFclsTPCr
 			nTPCcrossed = track->GetTPCClusterInfo(2,1);
 
 			fTPCcrossOverFind = 0;
 			nTPCfindable = track->GetTPCNclsF();
-			//kNFclsTPCfCross
+			// kNFclsTPCfCross
 			if(nTPCfindable > 0){
 				fTPCcrossOverFind = nTPCcrossed/nTPCfindable;
 			}
@@ -817,20 +798,20 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 				nTPCshared = (dynamic_cast<AliESDtrack*>(track))->GetTPCnclsS();
 			}
 
-			chi2TPC = track->GetTPCchi2(); //Function only implemented in ESDs. Returns dumym value for AODs
+			chi2TPC = track->GetTPCchi2(); // Function only implemented in ESDs. Returns dumym value for AODs
 
-			//DCA values
+			// DCA values
 			Float_t  DCAesd[2] = {0.0, 0.0};
 			Double_t DCAaod[2] = {0.0, 0.0};
 			Double_t DCAcov[2] = {0.0, 0.0};
 			if(!fIsAOD){
-				//Arguments: xy, z
+				// Arguments: xy, z
 				track->GetImpactParameters( &DCAesd[0], &DCAesd[1]);
 			}
 			else{
 				GetDCA(const_cast<const AliVEvent*>(event), dynamic_cast<const AliAODTrack*>(track), DCAaod, DCAcov);
 			}
-			//Final DCA values stored here
+			// Final DCA values stored here
 			if(!fIsAOD){
 				DCA[0] = static_cast<Double_t>(DCAesd[0]);
 				DCA[1] = static_cast<Double_t>(DCAesd[1]);
@@ -840,8 +821,8 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 				DCA[1] = static_cast<Double_t>(DCAaod[1]);
 			}
 
-			//Get ITS information
-			//kNclsITS
+			// Get ITS information
+			// kNclsITS
 			nITS = track->GetNcls(0);
 			chi2ITS = track->GetITSchi2();
 
@@ -857,7 +838,7 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 				SPDfirst = (dynamic_cast<AliESDtrack*>(track))->HasPointOnITSLayer(0);
 			}
 
-			//Get ITS and TPC signals
+			// Get ITS and TPC signals
 			ITSsignal = track->GetITSsignal();
 			TPCsignal = track->GetTPCsignal();
 			TOFsignal = track->GetTOFsignal();
@@ -878,7 +859,7 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 				vertex = track->GetEvent()->GetPrimaryVertexTPC();
 			}
 
-			//Get golden Chi2
+			// Get golden Chi2
 			goldenChi2 = -1;
 			if(vertex->GetStatus()){
 				if(fIsAOD){
@@ -890,10 +871,11 @@ void AliAnalysisTaskSimpleTreeMaker::UserExec(Option_t *){
 			}
 
 			charge = track->Charge();
-
+	
 			fTree->Fill();
-    } //End loop over tracks
-  }//End of "normal" TTree creation
+
+    } // End loop over tracks
+  }// End of standard TTree creation
   else if(fIsV0tree){
 		for(Int_t iV0 = 0; iV0 < numV0s; iV0++){
 

--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskSimpleTreeMaker.h
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskSimpleTreeMaker.h
@@ -42,8 +42,8 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 		void SetupTrackCuts(AliDielectronCutGroup* finalTrackCuts);
 		void SetupEventCuts(AliDielectronEventCuts* finalEventCuts);
 	
-		//PID calibration function to correct the width and mean of detector
-		//response (I.e should be unit guassian)
+		// PID calibration function to correct the width and mean of detector
+		// response (I.e should be unit guassian)
 		void SetCorrWidthMeanTPC(TH3D* width, TH3D* mean){
 			fMeanTPC  = mean;
 			fWidthTPC = width;
@@ -64,44 +64,32 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 				fCentralityPercentileMax = max;
 		}
 
+		// Kinematic cuts set here only applied to V0 TTrees
+		// For standard TTree a dielectron cut library is needed
 		void SetPtRange(Float_t min, Float_t max){
-				fPtMin = min;
-				fPtMax = max;
+			fPtMin = min;
+			fPtMax = max;
 		}
 
 		void SetEtaRange(Float_t min, Float_t max){
-				fEtaMin = min;
-				fEtaMax = max;
+			fEtaMin = min;
+			fEtaMax = max;
 		}
 
-		//Set inclusive electron PID cuts
-		void SetESigRangeITS(Float_t min, Float_t max){
-				fPIDcutITS = kTRUE;
-				fESigITSMin = min;
-				fESigITSMax = max;
-		}
-
+		// PID cut used for V0 TTrees
 		void SetESigRangeTPC(Float_t min, Float_t max){
-				fESigTPCMin = min;
-				fESigTPCMax = max;
+			fESigTPCMin = min;
+			fESigTPCMax = max;
 		}
 
-		void SetESigRangeTOF(Float_t min, Float_t max){
-				fPIDcutTOF = kTRUE;
-				fESigTOFMin = min;
-				fESigTOFMax = max;
-		}
-
-		//Set pion PID exclusion cut
-		void SetPSigRangeTPC(Float_t min, Float_t max){
-				fPionPIDcutTPC = kTRUE;
-				fPSigTPCMin = min;
-				fPSigTPCMax = max;
+		// Kaon PID values not saved by default
+		void writeKaonPIDtoTree(Bool_t answer){
+			storeKaonPID = answer;
 		}
 
 		void SetMC(Bool_t answer){ hasMC = answer; }
 
-		//Track cut setters. StandardITSTPC2011 cuts used if nothing specified
+		// Track cut setters. StandardITSTPC2011 cuts used if nothing specified
 		void SetTPCminClusters(Int_t number){
 				fESDtrackCuts->SetMinNClustersTPC(number);
 		}
@@ -175,22 +163,26 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 			fUseTOFcorr = answer;
 		}
 
+		void SetMaxPtPIDcorrection(Float_t answer){
+			maxPtPIDcorrection = answer;
+		}
+
 		Bool_t GetDCA(const AliVEvent* event, const AliAODTrack* track, Double_t* d0z0, Double_t* covd0z0);
 
 		// Check if the generator is on the list of generators
 		// If found, assign track with integer value correspding to generator
-		//0 = gen purp, 1=Pythia CC_1, 2= Pythia BB_1, 3=Pythia B_1, 4=Jpsi2ee_1, 5=B2Jpsi2ee_1";
+		// 0 = gen purp, 1=Pythia CC_1, 2= Pythia BB_1, 3=Pythia B_1, 4=Jpsi2ee_1, 5=B2Jpsi2ee_1";
 		Int_t CheckGenerator(Int_t trackID);
 
   private:
  
 		Int_t IsEventAccepted(AliVEvent* event);
-		//Int_t GetAcceptedTracks(AliVEvent *event, Double_t gCentrality);
 	
 		AliAnalysisTaskSimpleTreeMaker(const AliAnalysisTaskSimpleTreeMaker&); // not implemented
 
 		AliAnalysisTaskSimpleTreeMaker& operator=(const AliAnalysisTaskSimpleTreeMaker&); // not implemented
 
+		Int_t eventNum; //!
 		Bool_t hasMC;
 
 		AliESDtrackCuts* fESDtrackCuts;
@@ -200,8 +192,8 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 
 		TTree* fTree;
 	
-		//Dielectron cut classes needed to source cuts from LMEE cut libraries
-		//The desired cut library should be specified in the AddTask
+		// Dielectron cut classes needed to source cuts from LMEE cut libraries
+		// The desired cut library should be specified in the AddTask
 		AliDielectronEventCuts* eventCuts;
 		AliAnalysisFilter* eventFilter;
 		
@@ -211,7 +203,7 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 		AliDielectronCutGroup* cuts;
 		AliAnalysisFilter* trackFilter;
 
-		//Class needed to use PID within the Dielectron Framework
+		// Class needed to use PID within the Dielectron Framework
 		AliDielectronVarManager* varManager;
 
 		// TTree branch variables
@@ -245,9 +237,11 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 		Float_t EnSigmaTPCcorr;
 		Float_t EnSigmaTOF;
 		Float_t EnSigmaTOFcorr;
-		Float_t PnSigmaTPC;
+		Float_t maxPtPIDcorrection;
 		Float_t PnSigmaITS;
+		Float_t PnSigmaTPC;
 		Float_t PnSigmaTOF;
+		Bool_t storeKaonPID;
 		Float_t KnSigmaITS;
 		Float_t KnSigmaTPC;
 		Float_t KnSigmaTOF;
@@ -255,7 +249,7 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 		Float_t TPCsignal;
 		Float_t TOFsignal;
 		Float_t goldenChi2;
-		//MC 
+		// MC 
 		Float_t mcEta;
 		Float_t mcPhi;
 		Float_t mcPt;
@@ -264,13 +258,13 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 		Int_t iPdgMother;
 		Bool_t HasMother;
 		Int_t motherLabel;
-		Int_t isInj; // If track is injected 
+		Int_t isInj; 
 		// Pdg and label for initial particle in decay chain
 		Int_t iPdgFirstMother;
 		Int_t gLabelFirstMother;
 		Int_t gLabelMinFirstMother;
 		Int_t gLabelMaxFirstMother;
-		//V0 features
+		// V0 features
 		Float_t pointingAngle;
 		Float_t daughtersDCA;
 		Float_t decayLength;
@@ -280,29 +274,18 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 
 		TH1F* fQAhist; //!
 		// Currently no cut on centrality
-		Float_t fCentralityPercentileMin;// minimum centrality threshold (default = 0)
-		Float_t fCentralityPercentileMax;// maximum centrality threshold (default = 100)
+		Float_t fCentralityPercentileMin;
+		Float_t fCentralityPercentileMax;
 
-		Float_t fPtMin;// minimum pT threshold (default = 0)
-		Float_t fPtMax;// maximum pT threshold (default = 10)
-		Float_t fEtaMin;// minimum eta threshold (default = -0.8)
-		Float_t fEtaMax;// maximum eta threshold (default = 0.8)
+		// Kinematic cuts used in the creation of the V0 TTrees
+		Float_t fPtMin;
+		Float_t fPtMax;
+		Float_t fEtaMin;
+		Float_t fEtaMax;
 
-		//Values and flags for PID cuts in ITS and TOF
-		Float_t fESigITSMin;
-		Float_t fESigITSMax;
+		// TPC PID cuts for V0 TTree
 		Float_t fESigTPCMin; 
 		Float_t fESigTPCMax; 
-		Float_t fESigTOFMin;
-		Float_t fESigTOFMax;
-		
-		Bool_t fPIDcutITS;
-		Bool_t fPIDcutTOF;
-		
-		//Values and flag for pion PID cuts in TPC
-		Bool_t fPionPIDcutTPC;
-		Float_t fPSigTPCMin;
-		Float_t fPSigTPCMax;
 		
 		Bool_t fHasSDD;
 
@@ -331,10 +314,11 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 		// Temp variable (needed for testing MC issues)
 		Int_t TOFstartMask;
 
-		// Store list of generator hashes which can be checked against to determine
-		// whether or not the track was injected
+		// Store list of generator hashes which can be checked to determine whether
+		// or not the track was injected
 		std::vector<UInt_t> fGeneratorHashes;
-		ClassDef(AliAnalysisTaskSimpleTreeMaker, 5); //
+
+		ClassDef(AliAnalysisTaskSimpleTreeMaker, 6); 
 
 };
 


### PR DESCRIPTION
Fixes issue where large pt tracks were being scaled by 0, resulting in inf values.
Function to set max pt for PID correction (default now at 9 Gev/c).
Additionally:
-A lot of unused variables either deleted, or now by default not written to TTree.
-Much formatting....