### PR TITLE
PWGPP/TRD/TRDPID: add pile-up cut for LHC18q

### DIFF
--- a/PWGPP/TRD/TRDPID/AliTRDPIDTree.h
+++ b/PWGPP/TRD/TRDPID/AliTRDPIDTree.h
@@ -64,7 +64,13 @@ class AliTRDPIDTree : public AliAnalysisTaskSE {
       kpp = 0,
       kpPb = 1,
       kPbPb = 2
-    } ECollisionSystem_t;
+  } ECollisionSystem_t;
+
+  typedef enum{
+      kNoPileUpCut=0,
+      kLHC15o = 1,
+      kLHC18q = 2
+  } Period;
 
   AliTRDPIDTree(const char *name = "trd_pid_tree");
   virtual ~AliTRDPIDTree();
@@ -100,7 +106,7 @@ class AliTRDPIDTree : public AliAnalysisTaskSE {
       fCollisionSystem.SetBitNumber(kPbPb, kTRUE);
   };
 
-  void SetUseExtraPileupCut(Bool_t UseExtraPileupCut=kFALSE){
+  void SetUseExtraPileupCut(Int_t UseExtraPileupCut=0){
       fUseExtraPileupCut=UseExtraPileupCut;
   };
 
@@ -142,7 +148,7 @@ class AliTRDPIDTree : public AliAnalysisTaskSE {
   Float_t fpdg;                        //! particle type (pdg value)
   Int_t frun;                          //! run number
 
-  Bool_t fUseExtraPileupCut;           // cut on correlation of VZERO multiplicity & TPCout tracks (LHC15o pass1)
+  Int_t fUseExtraPileupCut;           // cut on correlation of VZERO multiplicity & TPCout tracks 
   
   // TTree stuff for PID References
   Int_t frunnumber;                  //! Tree: Run number
@@ -181,6 +187,6 @@ class AliTRDPIDTree : public AliAnalysisTaskSE {
   AliTRDPIDTree(const AliTRDPIDTree&); // not implemented
   AliTRDPIDTree& operator=(const AliTRDPIDTree&); // not implemented
   
-  ClassDef(AliTRDPIDTree, 4);
+  ClassDef(AliTRDPIDTree, 5);
 };
 #endif

--- a/PWGPP/TRD/TRDPID/macros/AddTaskTRDPIDTree.C
+++ b/PWGPP/TRD/TRDPID/macros/AddTaskTRDPIDTree.C
@@ -1,4 +1,4 @@
-AliAnalysisTask *AddTaskTRDPIDTree(Int_t trigger=0, Int_t system=0, Bool_t UseExtraPileupCut=kFALSE){
+AliAnalysisTask *AddTaskTRDPIDTree(Int_t trigger=0, Int_t system=0, Int_t UseExtraPileupCut=0){
   //get the current analysis manager
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
   if (!mgr) {


### PR DESCRIPTION
- add combination of enumerate and switch-case environment to make it possible to switch between pile-up cuts for different PbPb periods