### PR TITLE
modify Time Calib code to handle runs with PAR/L1 splitting

### DIFF
--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALTimeCalib.cxx
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALTimeCalib.cxx
@@ -294,6 +294,51 @@ void AliAnalysisTaskEMCALTimeCalib::SetL1PhaseReferenceForGivenRun()
 }
 
 //_____________________________________________________________________
+//  Function for Setting L1 Phase reference in case of multiple phases for PAR
+
+void AliAnalysisTaskEMCALTimeCalib::SetL1PhaseReferencePAR(){
+  if(fCurrentPARs.runNumber == 0){
+    AliFatal("fCurrentPARs not properly set! Unable to get PAR information.");
+    return;
+  }
+
+  //if Reference is set, check if it is for correct PAR region
+  if(fhRefRuns!=0x0){
+    TString refName(fhRefRuns->GetName());
+    TString correctName;
+    if(fCurrentPARIndex < fCurrentPARs.numPARs){
+        correctName = Form("h%d_%llu", fRunNumber, fCurrentPARs.PARGlobalBCs[fCurrentPARIndex]);
+    }else{
+        correctName = Form("h%d", fRunNumber);
+    }
+    if(refName.CompareTo(correctName)==0) return;
+  }
+
+  fhRefRuns=NULL;
+  if(!fL1PhaseList) {
+    AliFatal("Array with reference L1 phase histograms do not exist in memory");
+    return;
+  }
+  if(fRunNumber<0) {
+    AliFatal("Negative run number");
+    return;
+  }
+    if(fCurrentPARIndex < fCurrentPARs.numPARs){
+    fhRefRuns=(TH1C*)fL1PhaseList->FindObject(Form("h%d_%llu", fRunNumber, fCurrentPARs.PARGlobalBCs[fCurrentPARIndex]));
+  }else{
+    fhRefRuns=(TH1C*)fL1PhaseList->FindObject(Form("h%d", fRunNumber));
+  }
+
+  if(fhRefRuns==0x0){
+      AliFatal(Form("No Reference R-b-R histo found for run %d PAR %d!", fRunNumber, fCurrentPARIndex));
+      return;
+    }
+  if(fhRefRuns->GetEntries()==0)AliWarning("fhRefRuns->GetEntries() = 0");
+  AliDebug(1,Form("hRefRuns entries %d", (Int_t)fhRefRuns->GetEntries() ));
+
+}
+
+//_____________________________________________________________________
 /// Connect ESD or AOD here
 /// Called when run is changed
 void AliAnalysisTaskEMCALTimeCalib::NotifyRun()
@@ -316,9 +361,16 @@ void AliAnalysisTaskEMCALTimeCalib::NotifyRun()
   if (!fgeom) SetEMCalGeometry();
   //Init EMCAL geometry done
 
+  GetPARInfoForRunNumber(fRunNumber);
+
   //set L1 phases for current run
-  if(fReferenceRunByRunFileName.Length()!=0)
-    SetL1PhaseReferenceForGivenRun();
+  if(fReferenceRunByRunFileName.Length()!=0){
+    if(fIsPARRun){
+      SetL1PhaseReferencePAR();
+    }else{
+      SetL1PhaseReferenceForGivenRun();
+    }
+  }
 
   // set bad channel map
   if(!fBadChannelMapSet && fSetBadChannelMapSource>0) LoadBadChannelMap();
@@ -425,6 +477,33 @@ void AliAnalysisTaskEMCALTimeCalib::UserCreateOutputObjects()
   if(fFillHeavyHisto){
     fhEneVsAbsIdHG = new TH2F("fhEneVsAbsIdHG", "energy vs ID for HG",1000,0,18000,200,0,10);
     fhEneVsAbsIdLG = new TH2F("fhEneVsAbsIdLG", "energy vs ID for LG",1000,0,18000,200,0,40);
+  }
+
+  //Set-up Info for PAR histograms 
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if(!mgr) AliFatal("No Analysis Manager available...\n");
+  Int_t runNum = mgr->GetRunFromPath();
+  GetPARInfoForRunNumber(runNum);
+
+  if(fIsPARRun){
+    for (Int_t iPAR = 0; iPAR <= fCurrentPARs.numPARs; iPAR++){
+      TH2F* fRawTimeSinglePAR;
+      TH2F* fRawTimeLGSinglePAR;
+      std::vector<TH2F*> vecRawTimePAR;
+      std::vector<TH2F*> vecRawTimeLGPAR;
+      for(Int_t iBC = 0; iBC < kNBCmask; iBC++){
+        fRawTimeSinglePAR = new TH2F(Form("RawTimeBeforePAR%dBC%d",iPAR+1, iBC),
+		  		    Form("cell raw time vs ID for high gain BC %d ", iBC),
+				    nChannels,0.,(Double_t)nChannels,fRawTimeNbins,fRawTimeMin,fRawTimeMax);
+        fRawTimeLGSinglePAR = new TH2F(Form("RawTimeLGBeforePAR%dBC%d",iPAR+1, iBC),
+				    Form("cell raw time vs ID for low gain BC %d ", iBC),
+				    nChannels,0.,(Double_t)nChannels,fRawTimeNbins,fRawTimeMin,fRawTimeMax);
+        vecRawTimePAR.push_back(fRawTimeSinglePAR);
+        vecRawTimeLGPAR.push_back(fRawTimeLGSinglePAR);  
+      }
+      fhRawTimePARs.push_back(vecRawTimePAR);
+      fhRawTimeLGPARs.push_back(vecRawTimeLGPAR);
+    }
   }
 
   for (Int_t i = 0; i < kNBCmask ;  i++)
@@ -597,7 +676,16 @@ void AliAnalysisTaskEMCALTimeCalib::UserCreateOutputObjects()
     fOutputList->Add(fhEneVsAbsIdHG);
     fOutputList->Add(fhEneVsAbsIdLG);
   }
-  fOutputList->Add(fhTcellvsSM);
+  fOutputList->Add(fhTcellvsSM);  
+
+  if(fIsPARRun && fFillHeavyHisto){
+    for (Int_t iPAR = 0; iPAR <= fCurrentPARs.numPARs; iPAR++){
+      for(Int_t iBC = 0; iBC < kNBCmask; iBC++){
+        fOutputList->Add(fhRawTimePARs[iPAR][iBC]);
+        fOutputList->Add(fhRawTimeLGPARs[iPAR][iBC]);
+      }
+    }
+  }
 
   for (Int_t i = 0; i < kNBCmask ;  i++) 
   {
@@ -613,7 +701,6 @@ void AliAnalysisTaskEMCALTimeCalib::UserCreateOutputObjects()
       fOutputList->Add(fhRawTimeVsIdBC[i]);
       fOutputList->Add(fhRawTimeVsIdLGBC[i]);
     }
-
     fOutputList->Add(fhRawTimeSumBC[i]);
     fOutputList->Add(fhRawTimeEntriesBC[i]);
     fOutputList->Add(fhRawTimeSumSqBC[i]);
@@ -824,6 +911,22 @@ void AliAnalysisTaskEMCALTimeCalib::UserExec(Option_t *)
   Int_t mostEneId=-1;
   Float_t mostEneEn=0.;
   
+  fCurrentPARIndex = 0;
+  if(fIsPARRun){
+      ULong64_t eventBC = (ULong64_t)event->GetBunchCrossNumber();
+      ULong64_t eventOrbit = ((ULong64_t)(3564))*((ULong64_t)event->GetOrbitNumber());
+      ULong64_t eventPeriod = ((ULong64_t)(59793994260))*((ULong64_t)(event->GetPeriodNumber()));
+      //ULong64_t globalBC = event->GetBunchCrossNumber() + 3564*event->GetOrbitNumber() + 59793994260*event->GetPeriodNumber();
+      ULong64_t globalBC = eventBC + eventOrbit + eventPeriod;
+      for(int ipar = 0; ipar < fCurrentPARs.numPARs; ipar++){
+          if(globalBC >= fCurrentPARs.PARGlobalBCs[ipar]){
+              fCurrentPARIndex ++;
+          }
+      }
+  }
+  if(fReferenceRunByRunFileName.Length()!=0 && fIsPARRun){
+    SetL1PhaseReferencePAR();
+  }
   for (Int_t icl = 0; icl < nclus; icl++) {
     //ESD and AOD CaloCells carries the same information
     AliVCluster* clus = (AliVCluster*)caloClusters->At(icl);
@@ -871,13 +974,24 @@ void AliAnalysisTaskEMCALTimeCalib::UserExec(Option_t *)
 
       //main histograms with raw time information 
       if(amp>fMinCellEnergy){
+          
 	if(isHighGain){
-	  if(fFillHeavyHisto) fhRawTimeVsIdBC[nBC]->Fill(absId,hkdtime);
+	  if(fFillHeavyHisto){
+          fhRawTimeVsIdBC[nBC]->Fill(absId,hkdtime);
+          if(fIsPARRun){
+            fhRawTimePARs[fCurrentPARIndex][nBC]->Fill(absId, hkdtime);
+          }
+      }
 	  fhRawTimeSumBC[nBC]->Fill(absId,hkdtime);
 	  fhRawTimeEntriesBC[nBC]->Fill(absId,1.);
 	  fhRawTimeSumSqBC[nBC]->Fill(absId,hkdtime*hkdtime);
 	}else{
-	  if(fFillHeavyHisto) fhRawTimeVsIdLGBC[nBC]->Fill(absId,hkdtime);
+	  if(fFillHeavyHisto){
+          fhRawTimeVsIdLGBC[nBC]->Fill(absId,hkdtime);
+          if(fIsPARRun){
+            fhRawTimeLGPARs[fCurrentPARIndex][nBC]->Fill(absId, hkdtime);
+          }
+      }
 	  fhRawTimeSumLGBC[nBC]->Fill(absId,hkdtime);
 	  fhRawTimeEntriesLGBC[nBC]->Fill(absId,1.);
 	  fhRawTimeSumSqLGBC[nBC]->Fill(absId,hkdtime*hkdtime);
@@ -1199,7 +1313,7 @@ void AliAnalysisTaskEMCALTimeCalib::SetDefaultCuts()
 /// input - root file with histograms 
 /// output - root file with constants in historams
 /// isFinal - flag: kFALSE-first iteration, kTRUE-final iteration
-void AliAnalysisTaskEMCALTimeCalib::ProduceCalibConsts(TString inputFile,TString outputFile,Bool_t isFinal)
+void AliAnalysisTaskEMCALTimeCalib::ProduceCalibConsts(TString inputFile,TString outputFile,Bool_t isFinal,Bool_t isPAR)
 {
   TFile *file =new TFile(inputFile.Data());
   if(file==0x0) {
@@ -1213,6 +1327,21 @@ void AliAnalysisTaskEMCALTimeCalib::ProduceCalibConsts(TString inputFile,TString
     //AliWarning("List chistolist does not exist in file!");
     return;
   }
+
+  Int_t numPARs = 0;
+  Int_t counter = 0;
+  if(isPAR){
+    TIter next(list);
+    TObject* obj;
+    while((obj = next())){
+      TString name(obj->GetName());
+      if(name.BeginsWith("RawTimeBeforePAR")) counter++;
+    }
+  }
+  numPARs = Int_t(counter/4) - 1;
+  printf("number of PARs found to be %d!\n", numPARs);
+
+  if(numPARs == -1) isPAR = kFALSE;
 
   //high gain
   TH1F *h1[4];
@@ -1228,6 +1357,22 @@ void AliAnalysisTaskEMCALTimeCalib::ProduceCalibConsts(TString inputFile,TString
   TH1F *hAllTimeAvLGBC[4];
   TH1F *hAllTimeRMSLGBC[4];
 
+  //PAR histos
+  TH1F *h1PAR[numPARs+1][4];
+  TH1F *h2PAR[numPARs+1][4];
+  //TH1F *h3PAR[numPARs+1][4];
+  TH1F *hAllTimeAvBCPAR[numPARs+1][4];
+  TH1F *hAllTimeRMSBCPAR[numPARs+1][4];
+
+  TH1F *h4PAR[numPARs+1][4];
+  TH1F *h5PAR[numPARs+1][4];
+  //TH1F *h6PAR[numPARs+1][4];
+  TH1F *hAllTimeAvLGBCPAR[numPARs+1][4];
+  TH1F *hAllTimeRMSLGBCPAR[numPARs+1][4];
+
+  TH2D* raw2D[4];
+  TH2D* rawLG2D[4];
+
   if(isFinal==kFALSE){//first itereation
     for(Int_t i=0;i<4;i++){
       h1[i]=(TH1F *)list->FindObject(Form("RawTimeSumBC%d",i));
@@ -1237,6 +1382,42 @@ void AliAnalysisTaskEMCALTimeCalib::ProduceCalibConsts(TString inputFile,TString
       h4[i]=(TH1F *)list->FindObject(Form("RawTimeSumLGBC%d",i));
       h5[i]=(TH1F *)list->FindObject(Form("RawTimeEntriesLGBC%d",i));
       h6[i]=(TH1F *)list->FindObject(Form("RawTimeSumSqLGBC%d",i));
+      
+      if(isPAR){ //set-up histograms for different PAR time regions
+        for(Int_t iPAR = 0; iPAR <= numPARs; iPAR++){
+          raw2D[i] = (TH2D*)list->FindObject(Form("RawTimeBeforePAR%dBC%d", iPAR+1, i));
+          rawLG2D[i] = (TH2D*)list->FindObject(Form("RawTimeLGBeforePAR%dBC%d", iPAR+1, i));
+          h1PAR[iPAR][i] = new TH1F(Form("hAllTimeSumPAR%dBC%d",iPAR, i), Form("hAlltimeSumPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
+          hAllTimeAvBCPAR[iPAR][i] = new TH1F(Form("hAllTimeAvPAR%dBC%d",iPAR, i), Form("hAlltimeAvPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
+          h2PAR[iPAR][i] = (TH1F*)raw2D[i]->ProjectionX(Form("hAllTimeEntriesPAR%dBC%d",iPAR, i), 0, raw2D[i]->GetYaxis()->GetNbins());
+
+          h4PAR[iPAR][i] = new TH1F(Form("hAllTimeSumLGPAR%dBC%d",iPAR, i), Form("hAllTimeSumLGPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
+          hAllTimeAvLGBCPAR[iPAR][i] = new TH1F(Form("hAllTimeAvLGPAR%dBC%d",iPAR, i), Form("hAlltimeAvLGPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
+          h5PAR[iPAR][i] = (TH1F*)raw2D[i]->ProjectionX(Form("hAllTimeEntriesPAR%dLGBC%d",iPAR, i), 0, raw2D[i]->GetYaxis()->GetNbins());
+          for(int ixbin = 0; ixbin < raw2D[i]->GetXaxis()->GetNbins(); ixbin++){
+              float sumtime = 0.0;
+              float sumLGtime = 0.0;
+              for(int iybin = 0; iybin < raw2D[i]->GetYaxis()->GetNbins(); iybin++){
+                  sumtime += raw2D[i]->GetBinContent(ixbin, iybin)*raw2D[i]->GetYaxis()->GetBinCenter(iybin);
+                  sumLGtime += rawLG2D[i]->GetBinContent(ixbin, iybin)*rawLG2D[i]->GetYaxis()->GetBinCenter(iybin);
+              }
+              h1PAR[iPAR][i]->SetBinContent(ixbin, sumtime);
+              h4PAR[iPAR][i]->SetBinContent(ixbin, sumLGtime);
+              if(h2PAR[iPAR][i]->GetBinContent(ixbin) ==0){
+                  hAllTimeAvBCPAR[iPAR][i]->SetBinContent(ixbin, 0);
+              }else{
+                  hAllTimeAvBCPAR[iPAR][i]->SetBinContent(ixbin, h1PAR[iPAR][i]->GetBinContent(ixbin)/h2PAR[iPAR][i]->GetBinContent(ixbin));
+              }
+
+              if(h5PAR[iPAR][i]->GetBinContent(ixbin) ==0){
+                  hAllTimeAvLGBCPAR[iPAR][i]->SetBinContent(ixbin, 0);
+              }else{
+                  hAllTimeAvLGBCPAR[iPAR][i]->SetBinContent(ixbin, h4PAR[iPAR][i]->GetBinContent(ixbin)/h5PAR[iPAR][i]->GetBinContent(ixbin));
+              }
+          }
+
+        }
+      }
     }
   } else {//final iteration
     for(Int_t i=0;i<4;i++){
@@ -1287,10 +1468,19 @@ void AliAnalysisTaskEMCALTimeCalib::ProduceCalibConsts(TString inputFile,TString
   //AliWarning("Average and rms calculated.");
   TFile *fileNew=new TFile(outputFile.Data(),"recreate");
   for(Int_t i=0;i<4;i++){
-    hAllTimeAvBC[i]->Write();
-    hAllTimeRMSBC[i]->Write();
-    hAllTimeAvLGBC[i]->Write();
-    hAllTimeRMSLGBC[i]->Write();
+    if(isPAR){
+      for(Int_t iPAR = 0; iPAR <= numPARs; iPAR++){
+          hAllTimeAvBCPAR[iPAR][i]->Write();
+          //hAllTimeRMSBCPAR[iPAR][i]->Write();
+          hAllTimeAvLGBCPAR[iPAR][i]->Write();
+          //hAllTimeRMSLGBCPAR[iPAR][i]->Write();
+      }
+    }else{
+      hAllTimeAvBC[i]->Write();
+      hAllTimeRMSBC[i]->Write();
+      hAllTimeAvLGBC[i]->Write();
+      hAllTimeRMSLGBC[i]->Write();
+    }
   }
 
   //AliWarning(Form("Histograms saved in %s file.",outputFile.Data()));
@@ -1322,7 +1512,7 @@ void AliAnalysisTaskEMCALTimeCalib::ProduceCalibConsts(TString inputFile,TString
 /// Calculate calibration constants per SM (equivalent of L1 phase)
 /// input - root file with calibration constants from 1st pass
 /// output - root file with histograms for given run offset per SM 
-void AliAnalysisTaskEMCALTimeCalib::ProduceOffsetForSMsV2(Int_t runNumber,TString inputFile,TString outputFile, Bool_t offset100, Bool_t justL1phase){
+void AliAnalysisTaskEMCALTimeCalib::ProduceOffsetForSMsV2(Int_t runNumber,TString inputFile,TString outputFile, Bool_t offset100, Bool_t justL1phase, TString PARFilename){
 
 const  Double_t lowerLimit[]={
     0,
@@ -1368,24 +1558,88 @@ const  Double_t upperLimit[]={
     17279,
     17663};
 
+  PARInfo info;
+  info.numPARs = 0;
+  Bool_t isPAR = kFALSE;
+  if(PARFilename.Length() != 0){
+      std::ifstream input;
+      int inputrunnumber = 0, numPARs = 0;
+      ULong64_t PAR = 0;
+      input.open(PARFilename.Data());
+      if(!input.good()){
+          printf("PAR info file not accessable: %s\n", PARFilename.Data());
+          return;
+      }
+      while(input.good()){
+          input >> inputrunnumber >> numPARs;
+          if(!input.good()) break;
+          info.runNumber = inputrunnumber;
+          info.numPARs = numPARs;
+          //printf("\n\n!!!!\n\n from file: runnumber = %d, numPars = %d\n\n", info.runNumber, info.numPARs);
+          if(numPARs <= 0 || numPARs > 10){
+              printf("Number of PARS incorrectly found to be %d!\n", numPARs);
+              return;
+          }
+          for(int iPAR = 0; iPAR < numPARs; iPAR++){
+              input >> PAR;
+              if(info.runNumber == runNumber){
+                info.PARGlobalBCs.push_back(PAR);
+              }
+          }
+          if(info.runNumber == runNumber) break;
+      }
+      input.close();
+
+      if(info.runNumber != runNumber){
+          isPAR = kFALSE;
+          info.numPARs = 0;
+      }else{
+        isPAR = kTRUE;
+        printf("info.runNumber = %d\n", info.runNumber);
+        printf("info.numPARs = %d\n", info.numPARs);
+        for(int i = 0; i < info.numPARs; i++){
+        printf("info.PARGlobalBCs[%d] = %llu\n", i, info.PARGlobalBCs[i]);
+        }
+      }
+  }
+
   TFile *file =new TFile(inputFile.Data());
-  if(file==0x0) return;
+  if(file==0x0) return; 
 
   TH1F *ccBC[4];
   Bool_t shouldBeEmpty[4];
+  TH1F *ccBCPAR[info.numPARs+1][4];
   Int_t emptyCounter;
+  Bool_t shouldBeEmptyPAR[info.numPARs+1][4];
+
   for(Int_t i = 0; i < kNBCmask; i++){
-    ccBC[i]=(TH1F*) file->Get(Form("hAllTimeAvBC%d",i));
-    shouldBeEmpty[i]=kFALSE;
-    emptyCounter=0;
-    for(Int_t j=0;j<upperLimit[19];j++){
-      if(ccBC[i]->GetBinContent(j)>0.) emptyCounter++;
+    if(isPAR){
+      for(Int_t iPAR = 0; iPAR <= info.numPARs; iPAR++){
+        ccBCPAR[iPAR][i] = (TH1F*)file->Get(Form("hAllTimeAvPAR%dBC%d", iPAR, i));
+        shouldBeEmptyPAR[iPAR][i]=kFALSE;
+        emptyCounter=0;
+        for(Int_t j=0;j<upperLimit[19];j++){
+          if(ccBCPAR[iPAR][i]->GetBinContent(j)>0.) emptyCounter++;
+        }
+        if(emptyCounter<1500) shouldBeEmptyPAR[iPAR][i]=kTRUE;
+        printf("Non-zero channels %d BC %d should be empty: %d \n",emptyCounter,i,shouldBeEmptyPAR[iPAR][i]);
+
+      }
+    }else{
+      ccBC[i]=(TH1F*) file->Get(Form("hAllTimeAvBC%d",i));
+      shouldBeEmpty[i]=kFALSE;
+      emptyCounter=0;
+      for(Int_t j=0;j<upperLimit[19];j++){
+        if(ccBC[i]->GetBinContent(j)>0.) emptyCounter++;
+      }
+      if(emptyCounter<1500) shouldBeEmpty[i]=kTRUE;
+      printf("Non-zero channels %d BC %d should be empty: %d \n",emptyCounter,i,shouldBeEmpty[i]);
     }
-    if(emptyCounter<1500) shouldBeEmpty[i]=kTRUE;
-    printf("Non-zero channels %d BC %d should be empty: %d \n",emptyCounter,i,shouldBeEmpty[i]);
   }
 
+
   TH1C *hRun=new TH1C(Form("h%d",runNumber),Form("h%d",runNumber),19,0,19);
+  TH1C *hPARRun[info.numPARs+1];
   Int_t fitResult=0;
   Double_t minimumValue=10000.;
   Int_t minimumIndex=-1;
@@ -1399,18 +1653,39 @@ const  Double_t upperLimit[]={
   Int_t L1shift=0;
   Int_t totalValue=0;
 
-  for(Int_t i=0;i<20;i++){
-    minimumValue=10000;
-    for(j=0;j<kNBCmask;j++){
-      if(shouldBeEmpty[j]) {
-	meanBC[j]=-1;
-	continue;
-      }
-      fitResult=ccBC[j]->Fit("f1","CQ","",lowerLimit[i],upperLimit[i]);
-      if(fitResult<0){
+  for(Int_t iPAR = 0; iPAR <= info.numPARs; iPAR++){
+    if(iPAR != info.numPARs){
+      hPARRun[iPAR] =new TH1C(Form("h%d_%llu", runNumber, info.PARGlobalBCs[iPAR]), Form("h%d_%llu", runNumber, info.PARGlobalBCs[iPAR]),19,0,19);
+    }else{
+      hPARRun[iPAR] =new TH1C(Form("h%d", runNumber), Form("h%d", runNumber),19,0,19);
+    }
+    for(Int_t i=0;i<20;i++){
+      minimumValue=10000;
+      for(j=0;j<kNBCmask;j++){
+        if(isPAR){
+          if(shouldBeEmptyPAR[iPAR][j]){
+            meanBC[j]=-1;
+            continue;
+          }
+        }else{
+          if(shouldBeEmpty[j]) {
+	        meanBC[j]=-1;
+	        continue;
+          }
+        }
+        if(isPAR){
+          fitResult=ccBCPAR[iPAR][j]->Fit("f1", "CQ", "", lowerLimit[i],upperLimit[i]);
+        }else{
+          fitResult=ccBC[j]->Fit("f1","CQ","",lowerLimit[i],upperLimit[i]);
+        }
+        if(fitResult<0){
 	//hRun->SetBinContent(i,0);//correct it please
 	meanBC[j]=-1;
-	printf("Fit failed for SM %d BC%d, integral %f\n",i,j,ccBC[j]->Integral(lowerLimit[i],upperLimit[i]));
+	if(isPAR){
+      printf("Fit failed for SM %d BC%d, integral %f\n",i,j,ccBCPAR[iPAR][j]->Integral(lowerLimit[i],upperLimit[i]));
+    }else{
+      printf("Fit failed for SM %d BC%d, integral %f\n",i,j,ccBC[j]->Integral(lowerLimit[i],upperLimit[i]));
+    }
 	continue;
       } else {
 	fitParameter = f1->GetParameter(0);
@@ -1440,7 +1715,11 @@ const  Double_t upperLimit[]={
     else totalValue = L1shift<<2 | minimumIndex ;
     //printf("L1 phase %d, L1 shift %d *25ns= %d, L1p+L1s %d, total %d, L1pback %d, L1sback %d\n",minimumIndex,L1shift,L1shift*25,minimumIndex+L1shift,totalValue,totalValue&3,totalValue>>2);
 
-    hRun->SetBinContent(i,totalValue);
+    if(isPAR){
+      hPARRun[iPAR]->SetBinContent(i,totalValue);
+    }else{
+      hRun->SetBinContent(i,totalValue);
+    }
     orderTest=kTRUE;
     for(iorder=minimumIndex;iorder<minimumIndex+4-1;iorder++){
       if( meanBC[(iorder+1)%4] <= meanBC[iorder%4] ) orderTest=kFALSE;
@@ -1452,24 +1731,44 @@ const  Double_t upperLimit[]={
     //manual patch for LHC16q - pPb@5TeV - only BC0 is filled and phase rotate
     if(shouldBeEmpty[0] || shouldBeEmpty[1] || shouldBeEmpty[2] || shouldBeEmpty[3]){
     Double_t newMean = meanBC[minimumIndex]-600;
-    if(newMean<=12.5) hRun->SetBinContent(i,minimumIndex);
-    else {
+    if(newMean<=12.5){
+      if(isPAR){
+        hPARRun[iPAR]->SetBinContent(i,minimumIndex);
+      }else{
+        hRun->SetBinContent(i,minimumIndex);
+      }
+    } else {
       Int_t minIndexTmp=-1;
       if(newMean/25. - (Int_t)(newMean/25.) <0.5)
 	minIndexTmp = (Int_t)(newMean/25.);
       else
 	minIndexTmp = 1+(Int_t)(newMean/25.);
 
-      hRun->SetBinContent(i,(4-minIndexTmp+minimumIndex)%4);
+      if(isPAR){
+        hPARRun[iPAR]->SetBinContent(i,(4-minIndexTmp+minimumIndex)%4);
+      }else{
+        hRun->SetBinContent(i,(4-minIndexTmp+minimumIndex)%4);
+      }
       //cout<<newMean/25.<<" int "<<(Int_t)(newMean/25.)<<" dif "<< newMean/25.-(Int_t)(newMean/25.)<<endl;
       }
-    printf("run with missing BC; new L1 phase set to %d\n",(Int_t)hRun->GetBinContent(i));
-    }//end of patch for LHC16q and other runs with not filled BCs
-  }//end of loop over SM
+    if(isPAR){
+      printf("run with missing BC; new L1 phase set to %d\n",(Int_t)hPARRun[iPAR]->GetBinContent(i));
+    }else{
+      printf("run with missing BC; new L1 phase set to %d\n",(Int_t)hRun->GetBinContent(i));
+    }
+      }//end of patch for LHC16q and other runs with not filled BCs
+    }//end of loop over SM
+  }//end of loop over PARs
 
   delete f1;
   TFile *fileNew=new TFile(outputFile.Data(),"update");
-  hRun->Write();
+  if(isPAR){
+    for(Int_t iPAR = 0; iPAR <= info.numPARs; iPAR++){
+      hPARRun[iPAR]->Write();
+    }
+  }else{
+    hRun->Write();
+  }
   fileNew->Close();
   delete fileNew;
 
@@ -1529,4 +1828,62 @@ void AliAnalysisTaskEMCALTimeCalib::LoadBadChannelMapFile()
 void AliAnalysisTaskEMCALTimeCalib::LoadBadChannelMap(){
   if(fSetBadChannelMapSource==1) LoadBadChannelMapOADB();
   else if(fSetBadChannelMapSource==2) LoadBadChannelMapFile();
+}
+
+//_____________________________________________________________________
+// Load PAR info from text file
+void AliAnalysisTaskEMCALTimeCalib::SetPARInfo(TString PARFileName){
+    std::ifstream input;
+    int runnumber = 0, numPARs = 0, numRuns=0;
+    ULong64_t PAR = 0;
+    gSystem->ExpandPathName(PARFileName);
+    //handle case of PAR file in Alien location, needs to be copied to working directory before ifstream can open.
+    if(PARFileName.Contains("alien://")){
+        TString localFileName(gSystem->BaseName(PARFileName.Data()));
+        TFile::Cp(PARFileName.Data(), localFileName.Data());
+        PARFileName = localFileName;
+    }
+    input.open(PARFileName.Data());
+    if(!input.good()){
+        AliFatal(Form("PAR info file not accessable: %s", PARFileName.Data()));
+    }
+    while(input.good()){
+        input >> runnumber >> numPARs;
+        if(!input.good()) break;
+        PARInfo info;
+        info.runNumber = runnumber;
+        info.numPARs = numPARs;
+        //printf("\n\n!!!!\n\n from file: runnumber = %d, numPars = %d\n\n", info.runNumber, info.numPARs);
+        if(numPARs <= 0 || numPARs > 10){
+            AliFatal(Form("Number of PARS incorrectly found to be %d!", numPARs));
+        }
+        for(int iPAR = 0; iPAR < numPARs; iPAR++){
+            input >> PAR;
+            info.PARGlobalBCs.push_back(PAR);
+        }
+        fPARvec.push_back(info);
+        numRuns++;
+    }
+    printf("number of runs processed in PAR file: %d\n", numRuns);
+    input.close();
+}
+
+//_______________________________________________________________________
+// Get Par info for the current run number, set-up PAR info variables
+void AliAnalysisTaskEMCALTimeCalib::GetPARInfoForRunNumber(Int_t runnum){
+
+  if(fRunNumber!=runnum) fRunNumber = runnum;
+  fIsPARRun = kFALSE;
+  fCurrentPARs.PARGlobalBCs.erase(fCurrentPARs.PARGlobalBCs.begin(), fCurrentPARs.PARGlobalBCs.end());
+  for(int iPARrun = 0; iPARrun < fPARvec.size(); iPARrun++){
+      if (fRunNumber==fPARvec[iPARrun].runNumber){
+          //set PAR flag & setup copy of specific PAR info
+          fIsPARRun = kTRUE;
+          fCurrentPARs.runNumber = fRunNumber;
+          fCurrentPARs.numPARs = fPARvec[iPARrun].numPARs;
+          for(int ipar = 0; ipar < fPARvec[iPARrun].numPARs; ipar++){
+              fCurrentPARs.PARGlobalBCs.push_back(fPARvec[iPARrun].PARGlobalBCs[ipar]);
+          }
+      }
+  }
 }

--- a/PWGPP/EMCAL/macros/AddTaskEMCALTimeCalibration.C
+++ b/PWGPP/EMCAL/macros/AddTaskEMCALTimeCalibration.C
@@ -24,13 +24,14 @@
 /// \param badMapType: Int_t,settype of bad channel map acces
 /// \param badMapFileName: TString, file with bad channels map (absID)
 /// \param mostEneCellOnly: Bool_t, flag to calibrate only on most energetic cell in cluster
+/// \param PARFileName: TString, path to text file with the PAR information for the desired period
 ///
 /// \author Adam Matyja <adam.tomasz.matyja@ifj.edu.pl>, INP PAN Cracow
 ///
 
-AliAnalysisTaskEMCALTimeCalib  * AddTaskEMCALTimeCalibration(TString  outputFile = "", // timeResults.root
+AliAnalysisTaskEMCALTimeCalib* AddTaskEMCALTimeCalibration(TString  outputFile = "", // timeResults.root
 							     TString  geometryName = "",//EMCAL_COMPLETE12SMV1_DCAL_8SM
-							     Double_t minClusterEne = 1.0,
+							     Double_t minClusterEne = 0.9,
 							     Double_t maxClusterEne = 500,
 							     Int_t    minNcells = 2,
 							     Int_t    maxNcells = 200,
@@ -43,13 +44,14 @@ AliAnalysisTaskEMCALTimeCalib  * AddTaskEMCALTimeCalibration(TString  outputFile
 							     Double_t minTime = -20.,
 							     Double_t maxTime = 20.,
 							     Bool_t   pileupFromSPDFlag = kFALSE,
-							     TString  referenceFileName = "",//Reference.root
-							     TString  referenceSMFileName = "",//ReferenceSM.root
+							     TString  referenceFileName = "alien:///alice/cern.ch/user/j/jblair/TimeCalibRef/Reference_LHC17n_mcp1_step3.root",//Reference.root
+							     TString  referenceSMFileName = "alien:///alice/cern.ch/user/j/jblair/TimeCalibRef/ReferenceSM_LHC17n_mcp1_step1.root",//ReferenceSM.root
 							     Bool_t   badReconstruction = kFALSE,
-							     Bool_t   fillHeavyHistos = kFALSE,
-							     Int_t    badMapType = 0,
+							     Bool_t   fillHeavyHistos = kTRUE,
+							     Int_t    badMapType = 1,
 							     TString  badMapFileName = "",
-							     Bool_t   mostEneCellOnly = kFALSE)
+                                 Bool_t mostEneCellOnly = kFALSE,
+                                 TString  PARFileName = "")
 {
   // Get the pointer to the existing analysis manager via the static access method.
   //==============================================================================
@@ -115,9 +117,15 @@ AliAnalysisTaskEMCALTimeCalib  * AddTaskEMCALTimeCalibration(TString  outputFile
 
   //bad channel map
   taskmbemcal->SetBadChannelMapSource(badMapType);
-  if(badMapType==2) {
-    taskmbemcal->SetBadChannelFileName(badMapFileName);
-    taskmbemcal->LoadBadChannelMapFile();
+  if(badMapType==2){
+      taskmbemcal->SetBadChannelFileName(badMapFileName);
+      taskmbemcal->LoadBadChannelMap();
+  }
+
+  //set-up PAR file
+  if(PARFileName.Length()!=0){
+    //printf("We Got to the PAR part of the Add Task!");
+    taskmbemcal->SetPARInfo(PARFileName);
   }
 
   //taskmbemcal->PrintInfo();


### PR DESCRIPTION
Time Calib code is modified to handle runs with PAR/L1 phase splitting.   Modification happened on two levels:

### Analysis:
* **AddTaskEMCALTimeCalib** - Addtask now loads in text file containing PAR information (with workaround to locally copy any remote alien:// path to the local working directory, due to .txt file not being a root file - this is similar to how YAML files are dealt with in EMCAL Correction Framework).
* **AliAnalysisTaskEMCALTimeCalib** - step 1 now produces N+1 time vs. cellAbsID histograms, with N being the number of PARs in the event (which is set by the above txt file). Step 2 and Step 3 now look for multiple L1 phase histograms for an affected run and choose the correct histogram for a given event by calculating the event global BC (calculated as: *eventBC + 3564\*eventOrbit + 59793994260\*eventPeriod* ) and comparing if against the PAR global BCs.

### Post-Processing:
* **AliAnalysisTaskEMCALTimeCalib::ProduceCalibConsts()** - modify static function that takes run-by-run Analysis output and generates the necessary 1D histograms to calculate L1 phase for all PAR regions.
* **AliAnalysisTaskEMCALTimeCalib::ProduceOffsetsForSMsV2()** - modify static function that takes output of previous function and calculates the L1 phase to now separately calculate it for all PAR histograms that were produced. Requires a local copy of the PAR info .txt file.

See also presentation at EMCAL Calibration Meeting: https://indico.cern.ch/event/761682/