### PR TITLE
Fix getMCmother loop in TreeMaker

### DIFF
--- a/PWGDQ/dielectron/LMEE/AliAnalysisTaskSimpleTreeMaker.h
+++ b/PWGDQ/dielectron/LMEE/AliAnalysisTaskSimpleTreeMaker.h
@@ -174,6 +174,10 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 		// 0 = gen purp, 1=Pythia CC_1, 2= Pythia BB_1, 3=Pythia B_1, 4=Jpsi2ee_1, 5=B2Jpsi2ee_1";
 		Int_t CheckGenerator(Int_t trackID);
 
+		Bool_t isDPMJET(Bool_t answer){
+			ignoreFirstMother = answer;
+		}
+
   private:
  
 		Int_t IsEventAccepted(AliVEvent* event);
@@ -317,6 +321,8 @@ class AliAnalysisTaskSimpleTreeMaker : public AliAnalysisTaskSE {
 		// Store list of generator hashes which can be checked to determine whether
 		// or not the track was injected
 		std::vector<UInt_t> fGeneratorHashes;
+
+		Bool_t ignoreFirstMother;
 
 		ClassDef(AliAnalysisTaskSimpleTreeMaker, 6); 
 


### PR DESCRIPTION
Get first (initial) mother particle loop fails for DPMJET productions. 
Set up a flag to stop search if looking at DPMJET MC production.....