### PR TITLE
Adding option to use AliEventCuts

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.cxx
@@ -41,6 +41,7 @@
 #include "AliEmcalJet.h"
 #include "AliEmcalTriggerDecisionContainer.h"
 #include "AliEmcalTriggerStringDecoder.h"
+#include "AliEventCuts.h"
 #include "AliInputEventHandler.h"
 #include "AliJetContainer.h"
 #include "AliLog.h"
@@ -54,6 +55,7 @@ using namespace EmcalTriggerJets;
 AliAnalysisTaskEmcalJetEnergySpectrum::AliAnalysisTaskEmcalJetEnergySpectrum():
   AliAnalysisTaskEmcalJet(),
   fHistos(nullptr),
+  fEventCuts(nullptr),
   fIsMC(false),
 	fTriggerSelectionBits(AliVEvent::kAny),
   fTriggerSelectionString(""),
@@ -65,6 +67,7 @@ AliAnalysisTaskEmcalJetEnergySpectrum::AliAnalysisTaskEmcalJetEnergySpectrum():
   fNameJetContainer("datajets"),
   fRequestTriggerClusters(true),
   fRequestCentrality(false),
+  fUseAliEventCuts(false),
   fCentralityEstimator("V0M")
 {
   SetUseAliAnaUtils(true);
@@ -73,6 +76,7 @@ AliAnalysisTaskEmcalJetEnergySpectrum::AliAnalysisTaskEmcalJetEnergySpectrum():
 AliAnalysisTaskEmcalJetEnergySpectrum::AliAnalysisTaskEmcalJetEnergySpectrum(const char *name):
   AliAnalysisTaskEmcalJet(name, true),
   fHistos(nullptr),
+  fEventCuts(nullptr),
   fIsMC(false),
 	fTriggerSelectionBits(AliVEvent::kAny),
   fTriggerSelectionString(""),
@@ -84,6 +88,7 @@ AliAnalysisTaskEmcalJetEnergySpectrum::AliAnalysisTaskEmcalJetEnergySpectrum(con
   fNameJetContainer("datajets"),
   fRequestTriggerClusters(true),
   fRequestCentrality(false),
+  fUseAliEventCuts(false),
   fCentralityEstimator("V0M")
 {
   SetUseAliAnaUtils(true);
@@ -118,7 +123,23 @@ void AliAnalysisTaskEmcalJetEnergySpectrum::UserCreateOutputObjects(){
   fHistos->CreateTHnSparse("hMaxJetTHnSparse", "jet thnsparse", 6, binnings, "s");
 
   for(auto h : *fHistos->GetListOfHistograms()) fOutput->Add(h);
+
+  if(fUseAliEventCuts) {
+    fEventCuts = new AliEventCuts(true);
+    // Do not perform trigger selection in the AliEvent cuts but let the task do this before
+    fEventCuts->OverrideAutomaticTriggerSelection(AliVEvent::kAny, true);
+    fEventCuts->AddQAplotsToList(fOutput, true);
+  }
   PostData(1, fOutput);
+}
+
+bool AliAnalysisTaskEmcalJetEnergySpectrum::IsEventSelected(){
+  if(fEventCuts) {
+    if(!IsTriggerSelected()) return false;
+    if(!fEventCuts->AcceptEvent(fInputEvent)) return false;
+    return true;
+  }
+  return AliAnalysisTaskEmcal::IsEventSelected();
 }
 
 bool AliAnalysisTaskEmcalJetEnergySpectrum::Run(){

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.h
@@ -32,6 +32,7 @@
 #include <TArrayD.h>
 
 class THistManager;
+class AliEventCuts;
 
 namespace EmcalTriggerJets {
 
@@ -63,6 +64,7 @@ public:
     fTriggerSelectionString = triggerstring;
   }
   void SetUseDownscaleWeight(bool doUse) { fUseDownscaleWeight = doUse; }
+  void SetUseAliEventCuts(bool doUse) { fUseAliEventCuts = doUse; }
   void SetUseTriggerSelectionForData(bool doUse) { fUseTriggerSelectionForData = doUse; }
   void SetRequireSubsetMB(bool doRequire, ULong_t minbiastrigger = AliVEvent::kAny) { fRequireSubsetMB = doRequire; fMinBiasTrigger = minbiastrigger; }
   void SetUserPtBinning(int nbins, double *binning) { fUserPtBinning.Set(nbins+1, binning); }
@@ -75,6 +77,7 @@ public:
 protected:
   virtual void UserCreateOutputObjects();
   virtual bool Run();
+  virtual bool IsEventSelected();
   virtual bool IsTriggerSelected();
   std::vector<TriggerCluster_t> GetTriggerClusterIndices(const TString &triggerstring) const;
   bool IsSelectEmcalTriggers(const std::string &triggerstring) const;
@@ -84,6 +87,7 @@ private:
   AliAnalysisTaskEmcalJetEnergySpectrum &operator=(const AliAnalysisTaskEmcalJetEnergySpectrum &);
 
   THistManager                  *fHistos;                       ///< Histogram manager
+  AliEventCuts                  *fEventCuts;                    ///< Event cuts as implemented in AliEventCuts
   Bool_t                        fIsMC;                          ///< Running on simulated events
 	UInt_t                        fTriggerSelectionBits;          ///< Trigger selection bits
   TString                       fTriggerSelectionString;        ///< Trigger selection string
@@ -95,6 +99,7 @@ private:
   TString                       fNameJetContainer;              ///< Name of the jet container 
   Bool_t                        fRequestTriggerClusters;        ///< Request distinction of trigger clusters
   Bool_t                        fRequestCentrality;             ///< Request centrality
+  Bool_t                        fUseAliEventCuts;               ///< Flag switching on AliEventCuts;
   TString                       fCentralityEstimator;           ///< Centrality estimator
   TArrayD                       fUserPtBinning;                 ///< User-defined pt-binning
 


### PR DESCRIPTION
With this option the AliEventCuts are used
instead of the event selection implemented
in AliAnalysisTaskEmcal. The trigger selection
from the AliEventCuts is disabled and still
done manually in the task before the event
selection.