### PR TITLE
Introduction of PreSelect method that allows to select candidates before filling them

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSED0Mass.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSED0Mass.cxx
@@ -28,6 +28,7 @@
 
 #include <Riostream.h>
 #include <TClonesArray.h>
+#include <TObjArray.h>
 #include <TCanvas.h>
 #include <TNtuple.h>
 #include <TTree.h>
@@ -973,7 +974,7 @@ void AliAnalysisTaskSED0Mass::UserCreateOutputObjects()
 
   const char* nameoutput=GetOutputSlot(3)->GetContainer()->GetName();
 
-  fNentries=new TH1F(nameoutput, "Integral(1,2) = number of AODs *** Integral(2,3) = number of candidates selected with cuts *** Integral(3,4) = number of D0 selected with cuts *** Integral(4,5) = events with good vertex ***  Integral(5,6) = pt out of bounds", 23,-0.5,22.5);
+  fNentries=new TH1F(nameoutput, "Integral(1,2) = number of AODs *** Integral(2,3) = number of candidates selected with cuts *** Integral(3,4) = number of D0 selected with cuts *** Integral(4,5) = events with good vertex ***  Integral(5,6) = pt out of bounds", 24,-0.5,23.5);
 
   fNentries->GetXaxis()->SetBinLabel(1,"nEventsAnal");
   fNentries->GetXaxis()->SetBinLabel(2,"nCandSel(Cuts)");
@@ -1003,6 +1004,7 @@ void AliAnalysisTaskSED0Mass::UserCreateOutputObjects()
   fNentries->GetXaxis()->SetBinLabel(21,"fisFilled is 1");
   fNentries->GetXaxis()->SetBinLabel(22,"AOD/dAOD mismatch");
   fNentries->GetXaxis()->SetBinLabel(23,"AOD/dAOD #events ok");
+  fNentries->GetXaxis()->SetBinLabel(24,"PreSelect rejection");
   fNentries->GetXaxis()->SetNdivisions(1,kFALSE);
 
   fCounter = new AliNormalizationCounter(Form("%s",GetOutputSlot(5)->GetContainer()->GetName()));
@@ -1263,6 +1265,21 @@ void AliAnalysisTaskSED0Mass::UserExec(Option_t */*option*/)
       }
     if(d->GetIsFilled()==0)fNentries->Fill(19);//tmp check
     if(d->GetIsFilled()==1)fNentries->Fill(20);//tmp check
+    TObjArray arrTracks(2);
+    Float_t xy[2],z[2];
+    Float_t px[2],py[2];
+    for(Int_t ipr=0;ipr<2;ipr++){
+      AliAODTrack *tr=vHF->GetProng(aod,d,ipr);
+      arrTracks.AddAt(tr,ipr);
+      tr->GetImpactParameters(xy[ipr],z[ipr]);
+      px[ipr]=tr->Px();
+      py[ipr]=tr->Py();
+    }
+
+    if(!fCuts->PreSelect(arrTracks)){
+      fNentries->Fill(23);
+      continue;
+    }
     if(!(vHF->FillRecoCand(aod,d))) {//Fill the data members of the candidate only if they are empty.   
       fNentries->Fill(18); //monitor how often this fails 
       continue;

--- a/PWGHF/vertexingHF/AliAnalysisVertexingHF.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisVertexingHF.cxx
@@ -1694,6 +1694,14 @@ void AliAnalysisVertexingHF::FixReferences(AliAODEvent *aod)
 
   return;
 }
+
+//----------------------------------------------------------------------------
+AliAODTrack* AliAnalysisVertexingHF::GetProng(AliVEvent *event,AliAODRecoDecayHF *rd,Int_t iprong){
+  if(!fAODMap)MapAODtracks(event);
+  return (AliAODTrack*)event->GetTrack(fAODMap[rd->GetProngID(iprong)]);
+}
+
+
 //----------------------------------------------------------------------------
 Bool_t AliAnalysisVertexingHF::FillRecoCand(AliVEvent *event,AliAODRecoDecayHF3Prong *rd){
   // method to retrieve daughters from trackID and reconstruct secondary vertex

--- a/PWGHF/vertexingHF/AliAnalysisVertexingHF.h
+++ b/PWGHF/vertexingHF/AliAnalysisVertexingHF.h
@@ -243,6 +243,8 @@ class AliAnalysisVertexingHF : public TNamed {
 
   void SetPidResponse(AliPIDResponse* p){fPidResponse=p;}
 
+  AliAODTrack *GetProng(AliVEvent *event,AliAODRecoDecayHF *rd,Int_t iprong);
+
   //
  private:
   //

--- a/PWGHF/vertexingHF/AliRDHFCuts.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCuts.cxx
@@ -130,7 +130,8 @@ fCutGeoNcrNclFractionNcr(0.85),
 fCutGeoNcrNclFractionNcl(0.7),
 fUseV0ANDSelectionOffline(kFALSE),
 fUseTPCtrackCutsOnThisDaughter(kTRUE),
-fApplyZcutOnSPDvtx(kFALSE)
+fApplyZcutOnSPDvtx(kFALSE),
+fUsePreselect(0)
 {
   //
   // Default Constructor
@@ -208,7 +209,8 @@ AliRDHFCuts::AliRDHFCuts(const AliRDHFCuts &source) :
   fCutGeoNcrNclFractionNcl(source.fCutGeoNcrNclFractionNcl),
   fUseV0ANDSelectionOffline(source.fUseV0ANDSelectionOffline),
   fUseTPCtrackCutsOnThisDaughter(source.fUseTPCtrackCutsOnThisDaughter),
-  fApplyZcutOnSPDvtx(source.fApplyZcutOnSPDvtx)
+  fApplyZcutOnSPDvtx(source.fApplyZcutOnSPDvtx),
+  fUsePreselect(source.fUsePreselect)
 {
   //
   // Copy constructor
@@ -312,6 +314,7 @@ AliRDHFCuts &AliRDHFCuts::operator=(const AliRDHFCuts &source)
   fCutGeoNcrNclFractionNcl=source.fCutGeoNcrNclFractionNcl;
   fUseV0ANDSelectionOffline=source.fUseV0ANDSelectionOffline;
   fUseTPCtrackCutsOnThisDaughter=source.fUseTPCtrackCutsOnThisDaughter;
+  fUsePreselect=source.fUsePreselect;
 
   PrintAll();
 
@@ -1232,6 +1235,7 @@ void AliRDHFCuts::PrintAll() const {
    }
    cout<<endl;
   }
+  printf("fUsePreselect=%d \n",fUsePreselect);
   if(fPidHF) fPidHF->PrintAll();
   return;
 }
@@ -1577,6 +1581,8 @@ Bool_t AliRDHFCuts::CompareCuts(const AliRDHFCuts *obj) const {
 
     if(fTrackCuts->GetClusterRequirementITS(AliESDtrackCuts::kSPD)!=obj->fTrackCuts->GetClusterRequirementITS(AliESDtrackCuts::kSPD)) {printf("ClusterReq SPD %d  %d\n",fTrackCuts->GetClusterRequirementITS(AliESDtrackCuts::kSPD),obj->fTrackCuts->GetClusterRequirementITS(AliESDtrackCuts::kSPD)); areEqual=kFALSE;}
   }
+  
+  if(fUsePreselect!=obj->fUsePreselect){printf("fUsePreselect: %d %d\n",fUsePreselect,obj->fUsePreselect);areEqual=kFALSE;}
 
   if(fCutsRD) {
    for(Int_t iv=0;iv<fnVars;iv++) {

--- a/PWGHF/vertexingHF/AliRDHFCuts.h
+++ b/PWGHF/vertexingHF/AliRDHFCuts.h
@@ -18,6 +18,7 @@
 #include "AliAODPidHF.h"
 #include "AliAODEvent.h"
 #include "AliVEvent.h"
+#include "TObjArray.h"
 
 class AliAODTrack;
 class AliAODRecoDecayHF;
@@ -291,6 +292,7 @@ class AliRDHFCuts : public AliAnalysisCuts
   Bool_t GetUseTPCtrackCutsOnThisDaughter() const {return fUseTPCtrackCutsOnThisDaughter;}
   Bool_t IsSelected(TObject *obj) {return IsSelected(obj,AliRDHFCuts::kAll);}
   Bool_t IsSelected(TList *list) {if(!list) return kTRUE; return kFALSE;}
+  virtual Int_t PreSelect(TObjArray aodtracks){return 3;}
   Int_t  IsEventSelectedInCentrality(AliVEvent *event);
   Bool_t IsEventSelectedForCentrFlattening(Float_t centvalue);
   Bool_t IsEventSelected(AliVEvent *event);
@@ -362,7 +364,8 @@ class AliRDHFCuts : public AliAnalysisCuts
   void SetUsePhysicsSelection(Bool_t use=kTRUE){fUsePhysicsSelection=use; return;}
   Bool_t GetUsePhysicsSelection() const { return fUsePhysicsSelection; }
 
-
+  void SetUsePreSelect(Int_t usePreselect){fUsePreselect=usePreselect;return;}
+  Int_t GetUsePreselect(){return fUsePreselect;}
 
   Bool_t CompareCuts(const AliRDHFCuts *obj) const;
   void MakeTable()const;
@@ -482,9 +485,9 @@ class AliRDHFCuts : public AliAnalysisCuts
   Bool_t fUseV0ANDSelectionOffline; ///flag to apply V0AND selection offline
   Bool_t fUseTPCtrackCutsOnThisDaughter; ///flag to apply TPC track quality cuts on specific D-meson daughter (used for different strategies for soft pion and D0daughters from Dstar decay)
   Bool_t fApplyZcutOnSPDvtx; //flag to apply the cut on |Zvtx| > X cm using the z coordinate of the SPD vertex
-
+  Int_t fUsePreselect;  /// flag that defines whether the PreSelect method has to be used: note that it is up to the task user to call it. This flag is mainly for bookkeeping
   /// \cond CLASSIMP    
-  ClassDef(AliRDHFCuts,43);  /// base class for cuts on AOD reconstructed heavy-flavour decays
+  ClassDef(AliRDHFCuts,44);  /// base class for cuts on AOD reconstructed heavy-flavour decays
   /// \endcond
 };
 

--- a/PWGHF/vertexingHF/AliRDHFCutsD0toKpi.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCutsD0toKpi.cxx
@@ -34,6 +34,7 @@
 #include "AliAODVertex.h"
 #include "AliKFVertex.h"
 #include "AliKFParticle.h"
+#include "TObjArray.h"
 
 using std::cout;
 using std::endl;
@@ -362,6 +363,41 @@ void AliRDHFCutsD0toKpi::GetCutVarsForOpt(AliAODRecoDecayHF *d,Float_t *vars,Int
 
   return;
 }
+
+//---------------------------------------------------------------------------
+Int_t AliRDHFCutsD0toKpi::PreSelect(TObjArray aodTracks){
+
+  if(!fUsePreselect)return 3;
+  Int_t retVal=3;
+  AliAODTrack *track0 = (AliAODTrack*)aodTracks.At(0);
+  AliAODTrack *track1 = (AliAODTrack*)aodTracks.At(1); 
+
+  // calculate pt
+  Double_t px0=track0->Px();
+  Double_t px1=track1->Px();
+
+  Double_t py0=track0->Py();
+  Double_t py1=track1->Py();
+
+  Double_t ptD=TMath::Sqrt((px0+px1)*(px0+px1)+(py0+py1)*(py0+py1));
+  
+  if(ptD<fMinPtCand) return 0;
+  if(ptD>fMaxPtCand) return 0;
+  Int_t ptbin=PtBin(ptD);
+  if (ptbin==-1) {
+    return 0;
+  }
+  Float_t xy[2],z[2];
+  track0->GetImpactParameters(xy[0],z[0]);
+  track1->GetImpactParameters(xy[1],z[1]);
+  if(xy[0]*xy[1] > fCutsRD[GetGlobalIndex(7,ptbin)])return 0; 
+
+  retVal=IsSelectedPID(ptD,aodTracks);
+
+
+  return retVal;
+}
+
 //---------------------------------------------------------------------------
 Int_t AliRDHFCutsD0toKpi::IsSelected(TObject* obj,Int_t selectionLevel,AliAODEvent* aod) {
   //
@@ -824,9 +860,23 @@ Bool_t AliRDHFCutsD0toKpi::IsInFiducialAcceptance(Double_t pt, Double_t y) const
 
   return kTRUE;
 }
+
 //---------------------------------------------------------------------------
 Int_t AliRDHFCutsD0toKpi::IsSelectedPID(AliAODRecoDecayHF* d) 
 {
+  if(!fUsePID) return 3;
+  if(fDefaultPID) return IsSelectedPIDdefault(d);
+  if (fCombPID) return IsSelectedCombPID(d); //to use Bayesian method if applicable
+ 
+  TObjArray aodTracks(2);
+  aodTracks.AddAt(d->GetDaughter(0),0);
+  aodTracks.AddAt(d->GetDaughter(1),1);
+  Double_t pt=d->Pt();
+  return IsSelectedPID(pt,aodTracks);
+}
+
+//---------------------------------------------------------------------------
+Int_t AliRDHFCutsD0toKpi::IsSelectedPID(Double_t pt, TObjArray aodTracks){
   // ############################################################
   //
   // Apply PID selection
@@ -834,9 +884,6 @@ Int_t AliRDHFCutsD0toKpi::IsSelectedPID(AliAODRecoDecayHF* d)
   //
   // ############################################################
 
-  if(!fUsePID) return 3;
-  if(fDefaultPID) return IsSelectedPIDdefault(d);
-  if (fCombPID) return IsSelectedCombPID(d); //to use Bayesian method if applicable
   fWhyRejection=0;
   Int_t isD0D0barPID[2]={1,2};
   Int_t combinedPID[2][2];// CONVENTION: [daught][isK,IsPi]; [0][0]=(prong 1, isK)=value [0][1]=(prong 1, isPi)=value; 
@@ -854,12 +901,12 @@ Int_t AliRDHFCutsD0toKpi::IsSelectedPID(AliAODRecoDecayHF* d)
   Bool_t checkPIDInfo[2]={kTRUE,kTRUE};
   Double_t sigma_tmp[3]={fPidHF->GetSigma(0),fPidHF->GetSigma(1),fPidHF->GetSigma(2)};
   Bool_t isTOFused=fPidHF->GetTOF(),isCompat=fPidHF->GetCompat();
-  AliAODTrack *aodtrack1=(AliAODTrack*)d->GetDaughter(0);
-  AliAODTrack *aodtrack2=(AliAODTrack*)d->GetDaughter(1);
+  AliAODTrack *aodtrack1=(AliAODTrack*)aodTracks.At(0);
+  AliAODTrack *aodtrack2=(AliAODTrack*)aodTracks.At(1);
   Short_t relativeSign = aodtrack1->Charge() * aodtrack2->Charge();
   for(Int_t daught=0;daught<2;daught++){
     //Loop con prongs
-    AliAODTrack *aodtrack=(AliAODTrack*)d->GetDaughter(daught);
+    AliAODTrack *aodtrack=(AliAODTrack*)aodTracks.At(daught);
     if(fPidHF->IsTOFPiKexcluded(aodtrack,5.)) return 0; 
 
     if(!(fPidHF->CheckStatus(aodtrack,"TPC")) && !(fPidHF->CheckStatus(aodtrack,"TOF"))) {
@@ -906,7 +953,7 @@ Int_t AliRDHFCutsD0toKpi::IsSelectedPID(AliAODRecoDecayHF* d)
       else isD0D0barPID[1]=0;// not a D0bar if pi+ or if K+ excluded
     }
 
-    if(fLowPt && d->Pt()<fPtLowPID){
+    if(fLowPt && pt<fPtLowPID){
       Double_t sigmaTPC[3]={3.,2.,0.};
       fPidHF->SetSigmaForTPC(sigmaTPC);
       // identify kaon
@@ -953,7 +1000,7 @@ Int_t AliRDHFCutsD0toKpi::IsSelectedPID(AliAODRecoDecayHF* d)
     return 0;
   }
 
-  if(fLowPt && d->Pt()<fPtLowPID){    
+  if(fLowPt && pt<fPtLowPID){    
     if(combinedPID[0][0]<=0&&combinedPID[1][0]<=0){
       fWhyRejection=32;// reject cases where the Kaon is not identified
       fPidHF->SetSigmaForTPC(sigma_tmp);
@@ -969,6 +1016,14 @@ Int_t AliRDHFCutsD0toKpi::IsSelectedPID(AliAODRecoDecayHF* d)
 //---------------------------------------------------------------------------
 Int_t AliRDHFCutsD0toKpi::IsSelectedPIDdefault(AliAODRecoDecayHF* d) 
 {
+
+  TObjArray aodTracks(2);
+  aodTracks.AddAt(d->GetDaughter(0),0);
+  aodTracks.AddAt(d->GetDaughter(1),1);
+  Double_t pt=d->Pt();
+  return IsSelectedPIDdefault(pt,aodTracks); 
+}
+Int_t AliRDHFCutsD0toKpi::IsSelectedPIDdefault(Double_t pt, TObjArray aodTracks) {
   // ############################################################
   //
   // Apply PID selection
@@ -1033,7 +1088,7 @@ Int_t AliRDHFCutsD0toKpi::IsSelectedPIDdefault(AliAODRecoDecayHF* d)
 
     // ########### Step 0- CHECKING minimal PID "ACCEPTANCE" ####################
 
-    AliAODTrack *aodtrack=(AliAODTrack*)d->GetDaughter(daught); 
+    AliAODTrack *aodtrack=(AliAODTrack*)aodTracks.At(daught); 
 
     if(!(aodtrack->GetStatus()&AliESDtrack::kTPCrefit)){
       fWhyRejection=26;
@@ -1137,7 +1192,7 @@ Int_t AliRDHFCutsD0toKpi::IsSelectedPIDdefault(AliAODRecoDecayHF* d)
     // ##########  ALSO DIFFERENT TPC PID REQUEST FOR LOW pt D0: request of K identification      ###############################
     // ########## more tolerant criteria for single particle ID-> more selective criteria for D0   ##############################
     // ###############                     NOT OPTIMIZED YET                                  ###################################
-    if(d->Pt()<2.){
+    if(pt<2.){
       isKaonPionTPC[daught][0]=0;
       isKaonPionTPC[daught][1]=0;
       AliAODPid *pidObj = aodtrack->GetDetPid();
@@ -1173,7 +1228,7 @@ Int_t AliRDHFCutsD0toKpi::IsSelectedPIDdefault(AliAODRecoDecayHF* d)
     fWhyRejection=28;// reject cases in which no PID info is available  
     return 0;
   }
-  if(d->Pt()<2.){
+  if(pt<2.){
     // request of K identification at low D0 pt
     combinedPID[0][0]=0;
     combinedPID[0][1]=0;
@@ -1981,10 +2036,17 @@ Int_t AliRDHFCutsD0toKpi::IsSelectedCombPID(AliAODRecoDecayHF* d)
 
   if (!fUsePID || !d) return 3;
 
-
+  TObjArray aodTracks(2);
+  aodTracks.AddAt(d->GetDaughter(0),0);
+  aodTracks.AddAt(d->GetDaughter(1),1);
+  Double_t pt=d->Pt();
+  return IsSelectedCombPID(aodTracks); 
+}
+Int_t AliRDHFCutsD0toKpi::IsSelectedCombPID(TObjArray aodTracks){
+  
   if (fBayesianStrategy == kBayesWeightNoFilter) {
     //WeightNoFilter: Accept all particles (no PID cut) but fill mass histos with weights in task
-    CalculateBayesianWeights(d);
+    CalculateBayesianWeights(aodTracks);
     return 3;
   }
 
@@ -1997,7 +2059,7 @@ Int_t AliRDHFCutsD0toKpi::IsSelectedCombPID(AliAODRecoDecayHF* d)
   //Bayesian methods used here check for ID of kaon, and whether it is positive or negative.
 
   Bool_t checkPIDInfo[2] = {kTRUE, kTRUE};
-  AliAODTrack *aodtrack[2] = {(AliAODTrack*)d->GetDaughter(0), (AliAODTrack*)d->GetDaughter(1)};
+  AliAODTrack *aodtrack[2] = {(AliAODTrack*)aodTracks.At(0), (AliAODTrack*)aodTracks.At(1)};
 
   if ((aodtrack[0]->Charge()*aodtrack[1]->Charge()) != -1) {
     return 0;  //reject if charges not opposite
@@ -2025,7 +2087,7 @@ Int_t AliRDHFCutsD0toKpi::IsSelectedCombPID(AliAODRecoDecayHF* d)
     return 0;      //Reject if both daughters lack both TPC and TOF info
   }
 
-  CalculateBayesianWeights(d);        //Calculates all Bayesian probabilities for both positive and negative tracks
+  CalculateBayesianWeights(aodTracks);        //Calculates all Bayesian probabilities for both positive and negative tracks
   //      Double_t prob0[AliPID::kSPECIES];
   //      fPidHF->GetPidCombined()->ComputeProbabilities(aodtrack[daught], fPidHF->GetPidResponse(), prob0);
   ///Three possible Bayesian probability cuts: Picked using SetBayesianCondition(int).
@@ -2147,11 +2209,19 @@ Int_t AliRDHFCutsD0toKpi::IsSelectedCombPID(AliAODRecoDecayHF* d)
 }
 
 //---------------------------------------------------------------------------
-void AliRDHFCutsD0toKpi::CalculateBayesianWeights(AliAODRecoDecayHF* d)
+void AliRDHFCutsD0toKpi::CalculateBayesianWeights(AliAODRecoDecayHF* d){
+
+  TObjArray aodTracks(2);
+  aodTracks.AddAt(d->GetDaughter(0),0);
+  aodTracks.AddAt(d->GetDaughter(1),1);
+  CalculateBayesianWeights(aodTracks);
+}
+//---------------------------------------------------------------------------
+void AliRDHFCutsD0toKpi::CalculateBayesianWeights(TObjArray aodTracks)
 {
   //Function to compute weights for Bayesian method
 
-  AliAODTrack *aodtrack[2] = {(AliAODTrack*)d->GetDaughter(0), (AliAODTrack*)d->GetDaughter(1)};
+  AliAODTrack *aodtrack[2] = {(AliAODTrack*)aodTracks.At(0), (AliAODTrack*)aodTracks.At(1)};
   if ((aodtrack[0]->Charge() * aodtrack[1]->Charge()) != -1) {
     return;  //Reject if charges do not oppose
   }

--- a/PWGHF/vertexingHF/AliRDHFCutsD0toKpi.h
+++ b/PWGHF/vertexingHF/AliRDHFCutsD0toKpi.h
@@ -12,6 +12,7 @@
 //***********************************************************
 
 #include "AliRDHFCuts.h"
+#include "TObjArray.h"
 
 class AliAODEvent;
 class AliAODRecoDecayHF;
@@ -39,9 +40,11 @@ class AliRDHFCutsD0toKpi : public AliRDHFCuts
   virtual Int_t IsSelected(TObject* obj,Int_t selectionLevel) 
                          {return IsSelected(obj,selectionLevel,0);}
   virtual Int_t IsSelected(TObject* obj,Int_t selectionLevel,AliAODEvent* aod);
-
+  virtual Int_t PreSelect(TObjArray aodtracks);
   virtual Int_t IsSelectedCombPID(AliAODRecoDecayHF* d); 
+  Int_t IsSelectedCombPID(TObjArray aodTracks); 
   virtual void CalculateBayesianWeights(AliAODRecoDecayHF* d);
+  void CalculateBayesianWeights(TObjArray aodTracks);
 
   Float_t GetMassCut(Int_t iPtBin=0) const { return (GetCuts() ? fCutsRD[GetGlobalIndex(0,iPtBin)] : 1.e6);}
   Float_t GetDCACut(Int_t iPtBin=0) const { return (GetCuts() ? fCutsRD[GetGlobalIndex(1,iPtBin)] : 1.e6);}
@@ -54,7 +57,9 @@ class AliRDHFCutsD0toKpi : public AliRDHFCuts
   virtual void SetStandardCutsPbPb2011();
   void SetStandardCutsPbPb2010Peripherals();
   virtual Int_t IsSelectedPID(AliAODRecoDecayHF *rd);
+  Int_t IsSelectedPID(Double_t pt, TObjArray aodTracks);
   Int_t IsSelectedPIDdefault(AliAODRecoDecayHF *rd);
+  Int_t IsSelectedPIDdefault(Double_t pt, TObjArray aodTracks);
   Int_t IsSelectedSpecialCuts(AliAODRecoDecayHF *d) const;
   void SetUseSpecialCuts(Bool_t useSpecialCuts) {fUseSpecialCuts=useSpecialCuts;}
   void Setd0MeasMinusExpCut(UInt_t nPtBins, Float_t *cutval);


### PR DESCRIPTION
Introduction of PreSelect method that allows to skip filling of candidates at analysis level if they do not pass selections that can be evaluated w/o secondary vtx.