### PR TITLE
Fixing Streaming issue, modify finding run no. for train test

### DIFF
--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALTimeCalib.cxx
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALTimeCalib.cxx
@@ -479,10 +479,16 @@ void AliAnalysisTaskEMCALTimeCalib::UserCreateOutputObjects()
     fhEneVsAbsIdLG = new TH2F("fhEneVsAbsIdLG", "energy vs ID for LG",1000,0,18000,200,0,40);
   }
 
-  //Set-up Info for PAR histograms 
+  //Set-up Info for PAR histograms
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
   if(!mgr) AliFatal("No Analysis Manager available...\n");
   Int_t runNum = mgr->GetRunFromPath();
+  if(runNum == 0){
+    runNum = TString(gSystem->Getenv("RUNNO")).Atoi();
+    if(runNum < 200000){
+        AliFatal("Run Number not correctly set in UserCreateOutputObjects()!");
+    }
+  }
   GetPARInfoForRunNumber(runNum);
 
   if(fIsPARRun){
@@ -979,6 +985,7 @@ void AliAnalysisTaskEMCALTimeCalib::UserExec(Option_t *)
 	  if(fFillHeavyHisto){
           fhRawTimeVsIdBC[nBC]->Fill(absId,hkdtime);
           if(fIsPARRun){
+            if(fhRawTimePARs[fCurrentPARIndex][nBC]==0x0)AliFatal(Form("No Histogram for PAR number %d! Problem with Create Output Objects", fCurrentPARIndex));
             fhRawTimePARs[fCurrentPARIndex][nBC]->Fill(absId, hkdtime);
           }
       }
@@ -1871,11 +1878,16 @@ void AliAnalysisTaskEMCALTimeCalib::SetPARInfo(TString PARFileName){
 //_______________________________________________________________________
 // Get Par info for the current run number, set-up PAR info variables
 void AliAnalysisTaskEMCALTimeCalib::GetPARInfoForRunNumber(Int_t runnum){
-
+  if(runnum < 200000) AliFatal(Form("Bad Run Number %d passed to GetPARInfo!", runnum));
   if(fRunNumber!=runnum) fRunNumber = runnum;
   fIsPARRun = kFALSE;
   fCurrentPARs.PARGlobalBCs.erase(fCurrentPARs.PARGlobalBCs.begin(), fCurrentPARs.PARGlobalBCs.end());
   for(int iPARrun = 0; iPARrun < fPARvec.size(); iPARrun++){
+      //printf("from stored vectors: %d %d", fPARvec[iPARrun].runNumber, fPARvec[iPARrun].numPARs);
+      //for(int i = 0; i < fPARvec[iPARrun].numPARs; i++){
+      //  printf(" %llu", fPARvec[iPARrun].PARGlobalBCs[i]);
+      //}
+      //printf("\n");
       if (fRunNumber==fPARvec[iPARrun].runNumber){
           //set PAR flag & setup copy of specific PAR info
           fIsPARRun = kTRUE;

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALTimeCalib.h
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALTimeCalib.h
@@ -277,12 +277,13 @@ class AliAnalysisTaskEMCALTimeCalib : public AliAnalysisTaskSE
   private:
   
   // variables and functions needed for PAR handling
-  std::vector<PARInfo> fPARvec;
-  PARInfo fCurrentPARs;
-  Int_t fCurrentPARIndex = 0;
-  Bool_t fIsPARRun = kFALSE; 
+  std::vector<PARInfo> fPARvec; ///< vector of PAR info for all runs
+  PARInfo fCurrentPARs; //! Par Info for current Run Number
+  Int_t fCurrentPARIndex = 0; //! Which PAR the currnt event is after
+  Bool_t fIsPARRun = kFALSE; //! Does current run have PAR info? 
   void GetPARInfoForRunNumber(Int_t runnum);
 
+  
   virtual void PrepareTOFT0maker();
   Bool_t SetEMCalGeometry();
   Bool_t AcceptCluster(AliVCluster* clus);

--- a/PWGPP/EMCAL/PWGPPEMCALLinkDef.h
+++ b/PWGPP/EMCAL/PWGPPEMCALLinkDef.h
@@ -11,6 +11,7 @@
 #pragma link C++ class AliAnalysisTaskEMCALPi0CalibSelection+;
 #pragma link C++ class AliAnalysisTaskEMCALTriggerQA+;
 #pragma link C++ class AliAnalysisTaskEMCALTimeCalib+;
+#pragma link C++ struct AliAnalysisTaskEMCALTimeCalib::PARInfo+;
 #pragma link C++ class BadChannelAna+;
 #pragma link C++ class ElectronForAlignment+;
 


### PR DESCRIPTION
Adding struct PARInfo to LinkDef for streaming, adding extra steps for determining run number in the case of train test (where AliAnalysisManager::GetRunAlienPath() would fail due to path to local train test files).