### PR TITLE
Add option to use Track DCA cut also on FindMatches like in base class extrapolation method

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
@@ -69,7 +69,8 @@ AliEMCALRecoUtils::AliEMCALRecoUtils():
   fCutR(0),                               fCutEta(0),                             fCutPhi(0),
   fClusterWindow(0),                      fMass(0),                           
   fStepSurface(0),                        fStepCluster(0),
-  fITSTrackSA(kFALSE),                    fUseOuterTrackParam(kFALSE),            fEMCalSurfaceDistance(440.),
+  fITSTrackSA(kFALSE),                    fUseTrackDCA(kTRUE), // keep it active, but not working for old MC
+  fUseOuterTrackParam(kFALSE),            fEMCalSurfaceDistance(440.),
   fTrackCutsType(0),                      fCutMinTrackPt(0),                      fCutMinNClusterTPC(0), 
   fCutMinNClusterITS(0),                  fCutMaxChi2PerClusterTPC(0),            fCutMaxChi2PerClusterITS(0),
   fCutRequireTPCRefit(kFALSE),            fCutRequireITSRefit(kFALSE),            fCutAcceptKinkDaughters(kFALSE),
@@ -129,8 +130,8 @@ AliEMCALRecoUtils::AliEMCALRecoUtils(const AliEMCALRecoUtils & reco)
   fCutR(reco.fCutR),        fCutEta(reco.fCutEta),           fCutPhi(reco.fCutPhi),
   fClusterWindow(reco.fClusterWindow),
   fMass(reco.fMass),        fStepSurface(reco.fStepSurface), fStepCluster(reco.fStepCluster),
-  fITSTrackSA(reco.fITSTrackSA),                             fUseOuterTrackParam(reco.fUseOuterTrackParam),                           
-  fEMCalSurfaceDistance(440.),
+  fITSTrackSA(reco.fITSTrackSA),                             fUseTrackDCA(reco.fUseTrackDCA),
+  fUseOuterTrackParam(reco.fUseOuterTrackParam),             fEMCalSurfaceDistance(440.),
   fTrackCutsType(reco.fTrackCutsType),                       fCutMinTrackPt(reco.fCutMinTrackPt), 
   fCutMinNClusterTPC(reco.fCutMinNClusterTPC),               fCutMinNClusterITS(reco.fCutMinNClusterITS), 
   fCutMaxChi2PerClusterTPC(reco.fCutMaxChi2PerClusterTPC),   fCutMaxChi2PerClusterITS(reco.fCutMaxChi2PerClusterITS),
@@ -232,6 +233,7 @@ AliEMCALRecoUtils & AliEMCALRecoUtils::operator = (const AliEMCALRecoUtils & rec
   fStepSurface               = reco.fStepSurface;
   fStepCluster               = reco.fStepCluster;
   fITSTrackSA                = reco.fITSTrackSA;
+  fUseTrackDCA               = reco.fUseTrackDCA;
   fUseOuterTrackParam        = reco.fUseOuterTrackParam;
   fEMCalSurfaceDistance      = reco.fEMCalSurfaceDistance;
   
@@ -2783,7 +2785,12 @@ void AliEMCALRecoUtils::FindMatches(AliVEvent *event,
       }
       
       Double_t pos[3],mom[3];
-      aodTrack->GetXYZ(pos);
+      
+      if ( fUseTrackDCA )
+        aodTrack->GetXYZ(pos);
+      else
+        aodTrack->XvYvZv(pos);
+        
       aodTrack->GetPxPyPz(mom);
       AliDebug(5,Form("aod track: i=%d | pos=(%5.4f,%5.4f,%5.4f) | mom=(%5.4f,%5.4f,%5.4f) | charge=%d\n",
                       itr,pos[0],pos[1],pos[2],mom[0],mom[1],mom[2],aodTrack->Charge()));

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -382,8 +382,9 @@ public:
   void     SetMaxDCAToVertexXY(Float_t dist=1e10)    { fCutMaxDCAToVertexXY     = dist ; }
   void     SetMaxDCAToVertexZ(Float_t dist=1e10)     { fCutMaxDCAToVertexZ      = dist ; }
   void     SetDCAToVertex2D(Bool_t b=kFALSE)         { fCutDCAToVertex2D        = b    ; }
-  void     SetRequireITSStandAlone(Bool_t b=kFALSE)    {fCutRequireITSStandAlone = b;} //Marcel
-  void     SetRequireITSPureStandAlone(Bool_t b=kFALSE){fCutRequireITSpureSA     = b;}
+  void     SetRequireITSStandAlone(Bool_t b=kFALSE)    {fCutRequireITSStandAlone= b    ; } //Marcel
+  void     SetRequireITSPureStandAlone(Bool_t b=kFALSE){fCutRequireITSpureSA    = b    ; }
+  void     SetRequireTrackDCA(Bool_t b=kFALSE)       { fUseTrackDCA             = b    ; }
   
   // getters								
   Double_t GetMinTrackPt()                     const { return fCutMinTrackPt           ; }
@@ -397,7 +398,8 @@ public:
   Float_t  GetMaxDCAToVertexXY()               const { return fCutMaxDCAToVertexXY     ; }
   Float_t  GetMaxDCAToVertexZ()                const { return fCutMaxDCAToVertexZ      ; }
   Bool_t   GetDCAToVertex2D()                  const { return fCutDCAToVertex2D        ; }
-  Bool_t   GetRequireITSStandAlone()           const { return fCutRequireITSStandAlone ; } //Marcel	
+  Bool_t   GetRequireITSStandAlone()           const { return fCutRequireITSStandAlone ; } //Marcel  
+  Bool_t   GetRequireTrackDCA()                const { return fUseTrackDCA             ; } 
 
   //----------------------------------------------------
   // Exotic cells / clusters
@@ -531,6 +533,7 @@ private:
   Double_t   fStepSurface;               ///< Length of step to extrapolate tracks to EMCal surface
   Double_t   fStepCluster;               ///< Length of step to extrapolate tracks to clusters
   Bool_t     fITSTrackSA;                ///< If track matching is to be done with ITS tracks standing alone, ESDs	
+  Bool_t     fUseTrackDCA;               ///< Activate use of aodtrack->GetXYZ or XvYxZv like in AliEMCALRecoUtilsBase::ExtrapolateTrackToEMCalSurface 
   Bool_t     fUseOuterTrackParam;        ///< Use OuterTrackParam not InnerTrackParam, ESDs
   Double_t   fEMCalSurfaceDistance;      ///< EMCal surface distance (= 430 by default, the last 10 cm are propagated on a cluster-track pair basis)
  
@@ -556,7 +559,7 @@ private:
   Bool_t     fMCGenerToAcceptForTrack;   ///<  Activate the removal of tracks entering the track matching that come from a particular generator
   
   /// \cond CLASSIMP
-  ClassDef(AliEMCALRecoUtils, 27) ;
+  ClassDef(AliEMCALRecoUtils, 28) ;
   /// \endcond
 
 };

--- a/PWGGA/CaloTrackCorrelations/macros/ana.C
+++ b/PWGGA/CaloTrackCorrelations/macros/ana.C
@@ -1348,6 +1348,8 @@ void ana ( anaModes mode = mGRID )
     //  cl->GetRecoUtils()->SwitchOnAODHybridTracksMatch();
     //  cl->GetRecoUtils()->SwitchOnAODTPCOnlyTracksMatch();
     //  cl->GetRecoUtils()->SetAODTrackFilterMask(128);
+    cl->GetRecoUtils()->SetRequireTrackDCA(kFALSE); // careful with this on old MC
+
     //  
     if ( kMC )
     {


### PR DESCRIPTION
In case of matching of TPC only tracks and old MCs/Data (not checked in new) the use of track DCA gives large eta residual.