### PR TITLE
fix to pointer handling in Lc TMVAApp task

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelorTMVAApp.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelorTMVAApp.cxx
@@ -1354,8 +1354,6 @@ void AliAnalysisTaskSELc2V0bachelorTMVAApp::MakeAnalysisForLc2prK0S(AliAODEvent 
 
     //FillLc2pK0Sspectrum(lcK0spr, isLc, nSelectedAnal, cutsAnal, mcArray, iLctopK0s);
     FillLc2pK0Sspectrum(lcK0spr, isLc, nSelectedAnal, cutsAnal, mcArray, mcLabel);    
-    AliAODVertex* v = lcK0spr->GetSecondaryVtx();
-    delete v;
   }
   
   delete vHF;


### PR DESCRIPTION
Deletion of secondary vtx within task caused segfault when trying to run multiple wagons of the task on the same train; removing these two lines.
The memory leak these lines were meant to fix can be fixed instead using AliAnalysisTaskSECleanupVertexingHF as the final wagon on the train.