### PR TITLE
Use AliEventCuts object by default in IsEventSelected

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
@@ -41,6 +41,7 @@
 #include "AliESDEvent.h"
 #include "AliAODInputHandler.h"
 #include "AliESDInputHandler.h"
+#include "AliEventCuts.h"
 #include "AliEventplane.h"
 #include "AliGenPythiaEventHeader.h"
 #include "AliGenHerwigEventHeader.h"
@@ -118,10 +119,12 @@ AliAnalysisTaskEmcal::AliAnalysisTaskEmcal() :
   fUseXsecFromHeader(kFALSE),
   fMCRejectFilter(kFALSE),
   fCountDownscaleCorrectedEvents(kFALSE),
+  fUseInternalEventSelection(kFALSE),
   fPtHardAndJetPtFactor(0.),
   fPtHardAndClusterPtFactor(0.),
   fPtHardAndTrackPtFactor(0.),
   fRunNumber(-1),
+  fAliEventCuts(nullptr),
   fAliAnalysisUtils(nullptr),
   fIsEsd(kFALSE),
   fGeom(nullptr),
@@ -233,10 +236,12 @@ AliAnalysisTaskEmcal::AliAnalysisTaskEmcal(const char *name, Bool_t histo) :
   fUseXsecFromHeader(kFALSE),
   fMCRejectFilter(kFALSE),
   fCountDownscaleCorrectedEvents(kFALSE),
+  fUseInternalEventSelection(kFALSE),
   fPtHardAndJetPtFactor(0.),
   fPtHardAndClusterPtFactor(0.),
   fPtHardAndTrackPtFactor(0.),
   fRunNumber(-1),
+  fAliEventCuts(nullptr),
   fAliAnalysisUtils(nullptr),
   fIsEsd(kFALSE),
   fGeom(nullptr),
@@ -362,6 +367,12 @@ void AliAnalysisTaskEmcal::UserCreateOutputObjects()
     AliError("Analysis manager not found!");
   }  
 
+  if(!fUseInternalEventSelection) {
+    fAliEventCuts = new AliEventCuts(true);
+    // Do not perform trigger selection in the AliEvent cuts but let the task do this before
+    fAliEventCuts->OverrideAutomaticTriggerSelection(AliVEvent::kAny, true);
+  }
+
   if (!fCreateHisto)
     return;
 
@@ -369,6 +380,8 @@ void AliAnalysisTaskEmcal::UserCreateOutputObjects()
   fOutput = new AliEmcalList();
   fOutput->SetUseScaling(fUsePtHardBinScaling);
   fOutput->SetOwner();
+  
+  if(fAliEventCuts) fOutput->Add(fAliEventCuts);
 
   if (fForceBeamType == kpp)
     fNcentBins = 1;
@@ -480,29 +493,31 @@ void AliAnalysisTaskEmcal::UserCreateOutputObjects()
     fOutput->Add(fHistEventPlane);
   }
 
-  fHistEventRejection = new TH1F("fHistEventRejection","Reasons to reject event",20,0,20);
+  if(fUseInternalEventSelection){
+    fHistEventRejection = new TH1F("fHistEventRejection","Reasons to reject event",20,0,20);
 #if ROOT_VERSION_CODE < ROOT_VERSION(6,4,2)
-  fHistEventRejection->SetBit(TH1::kCanRebin);
+    fHistEventRejection->SetBit(TH1::kCanRebin);
 #else
-  fHistEventRejection->SetCanExtend(TH1::kAllAxes);
+    fHistEventRejection->SetCanExtend(TH1::kAllAxes);
 #endif
-  fHistEventRejection->GetXaxis()->SetBinLabel(1,"PhysSel");
-  fHistEventRejection->GetXaxis()->SetBinLabel(2,"trigger");
-  fHistEventRejection->GetXaxis()->SetBinLabel(3,"trigTypeSel");
-  fHistEventRejection->GetXaxis()->SetBinLabel(4,"Cent");
-  fHistEventRejection->GetXaxis()->SetBinLabel(5,"vertex contr.");
-  fHistEventRejection->GetXaxis()->SetBinLabel(6,"Vz");
-  fHistEventRejection->GetXaxis()->SetBinLabel(7,"VzSPD");
-  fHistEventRejection->GetXaxis()->SetBinLabel(8,"trackInEmcal");
-  fHistEventRejection->GetXaxis()->SetBinLabel(9,"minNTrack");
-  fHistEventRejection->GetXaxis()->SetBinLabel(10,"VtxSel2013pA");
-  fHistEventRejection->GetXaxis()->SetBinLabel(11,"PileUp");
-  fHistEventRejection->GetXaxis()->SetBinLabel(12,"EvtPlane");
-  fHistEventRejection->GetXaxis()->SetBinLabel(13,"SelPtHardBin");
-  fHistEventRejection->GetXaxis()->SetBinLabel(14,"Bkg evt");
-  fHistEventRejection->GetXaxis()->SetBinLabel(15,"RecycleEmbeddedEvent");
-  fHistEventRejection->GetYaxis()->SetTitle("counts");
-  fOutput->Add(fHistEventRejection);
+    fHistEventRejection->GetXaxis()->SetBinLabel(1,"PhysSel");
+    fHistEventRejection->GetXaxis()->SetBinLabel(2,"trigger");
+    fHistEventRejection->GetXaxis()->SetBinLabel(3,"trigTypeSel");
+    fHistEventRejection->GetXaxis()->SetBinLabel(4,"Cent");
+    fHistEventRejection->GetXaxis()->SetBinLabel(5,"vertex contr.");
+    fHistEventRejection->GetXaxis()->SetBinLabel(6,"Vz");
+    fHistEventRejection->GetXaxis()->SetBinLabel(7,"VzSPD");
+    fHistEventRejection->GetXaxis()->SetBinLabel(8,"trackInEmcal");
+    fHistEventRejection->GetXaxis()->SetBinLabel(9,"minNTrack");
+    fHistEventRejection->GetXaxis()->SetBinLabel(10,"VtxSel2013pA");
+    fHistEventRejection->GetXaxis()->SetBinLabel(11,"PileUp");
+    fHistEventRejection->GetXaxis()->SetBinLabel(12,"EvtPlane");
+    fHistEventRejection->GetXaxis()->SetBinLabel(13,"SelPtHardBin");
+    fHistEventRejection->GetXaxis()->SetBinLabel(14,"Bkg evt");
+    fHistEventRejection->GetXaxis()->SetBinLabel(15,"RecycleEmbeddedEvent");
+    fHistEventRejection->GetYaxis()->SetTitle("counts");
+    fOutput->Add(fHistEventRejection);
+  }
 
   fHistTriggerClasses = new TH1F("fHistTriggerClasses","fHistTriggerClasses",3,0,3);
 #if ROOT_VERSION_CODE < ROOT_VERSION(6,4,2)
@@ -1087,7 +1102,14 @@ Bool_t AliAnalysisTaskEmcal::HasTriggerType(TriggerType trigger)
   return TESTBIT(fTriggers, trigger);
 }
 
-Bool_t AliAnalysisTaskEmcal::IsEventSelected()
+Bool_t AliAnalysisTaskEmcal::IsEventSelected(){
+  if(fUseInternalEventSelection) return IsEventSelectedInternal();
+  if(!IsTriggerSelected()) return false;
+  if(!CheckMCOutliers()) return false;
+  return fAliEventCuts->AcceptEvent(fInputEvent);
+}
+
+Bool_t AliAnalysisTaskEmcal::IsEventSelectedInternal()
 {
   AliDebugStream(1) << "Using default event selection" << std::endl;
   if (fOffTrigger != AliVEvent::kAny) {

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
@@ -2,7 +2,6 @@
 #define ALIANALYSISTASKEMCAL_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
  * See cxx source for full Copyright notice                               */
-
 class TClonesArray;
 class TString;
 class AliMCParticle;
@@ -17,6 +16,7 @@ class AliGenPythiaEventHeader;
 class AliGenHerwigEventHeader;
 class AliVCaloTrigger;
 class AliAnalysisUtils;
+class AliEventCuts;
 class AliEMCALTriggerPatchInfo;
 class AliAODTrack;
 class AliEmcalPythiaInfo;
@@ -324,6 +324,7 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   void                        SetMinBiasTriggerClassName(const char *n)             { fMinBiasRefTrigger = n                              ; }
   void                        SetTriggerTypeSel(TriggerType t)                      { fTriggerTypeSel    = t                              ; } 
   void                        SetUseAliAnaUtils(Bool_t b, Bool_t bRejPilup = kTRUE) { fUseAliAnaUtils    = b ; fRejectPileup = bRejPilup  ; }
+  void                        SetUseInternalEventSelection(Bool_t doUse)            { fUseInternalEventSelection = doUse                  ; }
   void                        SetVzRange(Double_t min, Double_t max)                { fMinVz             = min  ; fMaxVz   = max          ; }
   void                        SetMinVertexContrib(Int_t min)                        { fMinVertexContrib = min                             ; }
   void                        SetUseSPDTrackletVsClusterBG(Bool_t b)                { fTklVsClusSPDCut   = b                              ; }
@@ -670,23 +671,9 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   /**
    * @brief Performing event selection.
    *
-   * This contains
-   * - Selection of the trigger class
-   * - Selection according to the centrality class
-   * - Selection of event with good vertex quality
-   * - Selection of the event plane orientation
-   * - Selection of the multiplicity (including
-   *   above minimum \f$ p_{t} \f$ and tracks in the
-   *   EMCAL acceptance
-   *
-   * Note that for the vertex selection both the usage
-   * of the analysis util and the range of the z-position
-   * of the primary vertex need to be specified.
-   *
-   * In case the event is rejected, a histogram
-   * monitoring the rejection reason is filled with
-   * the bin corresponding to the source of the rejection
-   * of the current event.
+   * By default the event selection is delegated to the 
+   * AliEventCuts. Users can specify to use a builtin 
+   * event select (old method) by calling SetUseInternalEventSelection.
    *
    * The Run function is only called in case the event
    * is selected by this function, providing a default
@@ -816,6 +803,31 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   static void                 GenerateFixedBinArray(Int_t n, Double_t min, Double_t max, Double_t* array);
 
   /**
+   * @brief Perform event selection (old method)
+   * 
+   * This contains
+   * - Selection of the trigger class
+   * - Selection according to the centrality class
+   * - Selection of event with good vertex quality
+   * - Selection of the event plane orientation
+   * - Selection of the multiplicity (including
+   *   above minimum \f$ p_{t} \f$ and tracks in the
+   *   EMCAL acceptance
+   *
+   * Note that for the vertex selection both the usage
+   * of the analysis util and the range of the z-position
+   * of the primary vertex need to be specified.
+   *
+   * In case the event is rejected, a histogram
+   * monitoring the rejection reason is filled with
+   * the bin corresponding to the source of the rejection
+   * of the current event.
+   * 
+   * @return True if the event is selected, false if it is rejected
+   */
+  Bool_t                      IsEventSelectedInternal();
+
+  /**
    * @brief Calculates the fraction of momentum z of part 1 w.r.t. part 2 in the direction of part 2.
    * @param[in] part1 Momentum vector for which the relative fraction is calculated
    * @param[in] part2 Reference momentum vector for the calculation
@@ -886,12 +898,14 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   Bool_t                      fUseXsecFromHeader;          //!<! Use cross section from header instead of pyxsec.root (purely transient)
   Bool_t                      fMCRejectFilter;             ///< enable the filtering of events by tail rejection
   Bool_t                      fCountDownscaleCorrectedEvents; ///< Count event number corrected for downscaling
+  Bool_t                      fUseInternalEventSelection;  ///< Use builtin event selection of the AliAnalysisTaskEmcal instead of AliEventCuts
   Float_t                     fPtHardAndJetPtFactor;       ///< Factor between ptHard and jet pT to reject/accept event.
   Float_t                     fPtHardAndClusterPtFactor;   ///< Factor between ptHard and cluster pT to reject/accept event.
   Float_t                     fPtHardAndTrackPtFactor;     ///< Factor between ptHard and track pT to reject/accept event.
 
   // Service fields
-  Int_t                       fRunNumber;                  //!<!run number (triggering RunChanged()
+  Int_t                       fRunNumber;                  //!<!run number (triggering RunChanged())
+  AliEventCuts               *fAliEventCuts;               //!<!Event cuts (run2 defaults)
   AliAnalysisUtils           *fAliAnalysisUtils;           //!<!vertex selection (optional)
   Bool_t                      fIsEsd;                      //!<!whether it's an ESD analysis
   AliEMCALGeometry           *fGeom;                       //!<!emcal geometry


### PR DESCRIPTION
Old builtin event selection is moved to
IsEventSelectedInternal and needs to be
enabled explicitly. Event selection contains
- Trigger selection (in AliAnalysisTaskEmcal
  or inheriting - not handled by AliEventCuts)
- MC outlier removal
- Event selection by the AliEventCuts
Old optional event cuts (number of tracks in
acceptance, event plane orientation) are
only accessible in the old event selection
and are not (yet) ported to the new one based
on AliEventCuts.