### PR TITLE
Adding event cut historgrams directly to EMCAL list

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
@@ -608,10 +608,10 @@ void AliAnalysisTaskEmcal::UserExec(Option_t *option)
     // Initialize event cuts here: This prevents a segfault
     // in case a user task overwrites the function UserCreateOutputObjects
     if(!fUseInternalEventSelection) {
-      fAliEventCuts = new AliEventCuts(true);
+      fAliEventCuts = new AliEventCuts(false); // Event cut should add the QA plots to the EMCAL list directly
       // Do not perform trigger selection in the AliEvent cuts but let the task do this before
       fAliEventCuts->OverrideAutomaticTriggerSelection(AliVEvent::kAny, true);
-      if(fOutput) fOutput->Add(fAliEventCuts);
+      if(fOutput) fAliEventCuts->AddQAplotsToList(fOutput);
     }
   }
 


### PR DESCRIPTION
Adding the event cut object introduced a segfault
in the merging in the destructor of AliEventCuts
for several EMCAL framework users. In order to
circumvent this the histograms are stored directly
in the EMCAL list. This also restores the behaviour
of the internal event selection in which the cut
histograms are stored directly in the EMCAL list.