### PR TITLE
Add option to set a user-configured event cuts object

### DIFF
--- a/PWG/JETFW/CMakeLists.txt
+++ b/PWG/JETFW/CMakeLists.txt
@@ -25,6 +25,7 @@ include_directories(
 include_directories(${ROOT_INCLUDE_DIRS}
   ${AliPhysics_SOURCE_DIR}/PWG/EMCAL/EMCALbase
   ${AliPhysics_SOURCE_DIR}/PWG/Tools
+  ${AliPhysics_SOURCE_DIR}/OADB
   )
 
 # Sources in alphabetical order
@@ -51,7 +52,7 @@ get_directory_property(incdirs INCLUDE_DIRECTORIES)
 generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}")
 
 set(ROOT_DEPENDENCIES)
-set(ALIROOT_DEPENDENCIES PWGEMCALbase)
+set(ALIROOT_DEPENDENCIES PWGEMCALbase OADB)
 
 # Generate the ROOT map
 # Dependecies

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.cxx
@@ -1745,7 +1745,7 @@ std::string AliAnalysisTaskEmcalJetHCorrelations::toString() const
   tempSS << "Event selection\n";
   tempSS << "\tUse AliEventCuts: " << fUseAliEventCuts << "\n";
   // AliEventCuts in the base class needs to be __disabled__ because the implementation isn't compatible with how it's implemented here.
-  tempSS << "\tUse AliAnalysisTaskEmcal event selection (needs to be enabled to use AliEventCuts): " << fUseInternalEventSelection << "\n";
+  tempSS << "\tUse AliAnalysisTaskEmcal event selection (needs to be enabled to use AliEventCuts): " << fUseBuiltinEventSelection << "\n";
   tempSS << "\tTrigger event selection: " << std::bitset<32>(fTriggerType) << "\n";
   tempSS << "\tMixed event selection: " << std::bitset<32>(fMixingEventType) << "\n";
   tempSS << "\tEnabled only for non-fast partition: " << fDisableFastPartition << "\n";

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHPerformance.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHPerformance.cxx
@@ -694,7 +694,7 @@ std::string AliAnalysisTaskEmcalJetHPerformance::toString() const
   tempSS << "AliEventCuts\n";
   tempSS << "\tEnabled: " << fUseAliEventCuts << "\n";
   // AliEventCuts in the base class needs to be __disabled__ because the implementation isn't compatible with how it's implemented here.
-  tempSS << "\tUse AliAnalysisTaskEmcal event selection (needs to be enabled to use AliEventCuts): " << fUseInternalEventSelection << "\n";
+  tempSS << "\tUse AliAnalysisTaskEmcal event selection (needs to be enabled to use AliEventCuts): " << fUseBuiltinEventSelection << "\n";
   tempSS << "QA Hists:\n";
   tempSS << "\tEnabled: " << fCreateQAHists << "\n";
   tempSS << "Response matrix:\n";

--- a/PWGJE/FlavourJetTasks/CMakeLists.txt
+++ b/PWGJE/FlavourJetTasks/CMakeLists.txt
@@ -30,6 +30,7 @@ include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/PWG/Tools
                     ${AliPhysics_SOURCE_DIR}/PWGHF/vertexingHF
                     ${AliPhysics_SOURCE_DIR}/PWGJE/EMCALJetTasks
+                    ${AliPhysics_SOURCE_DIR}/OADB
                    )
 
 # Sources in alphabetical order
@@ -78,7 +79,7 @@ get_directory_property(incdirs INCLUDE_DIRECTORIES)
 generate_dictionary("${MODULE}" "${MODULE}LinkDef.h" "${HDRS}" "${incdirs}" "${FASTJET_ROOTDICT_OPTS}")
 
 set(ROOT_DEPENDENCIES Core Geom)
-set(ALIROOT_DEPENDENCIES ANALYSIS ANALYSISalice AOD ESD STEERBase PWGJEEMCALJetTasks PWGEMCALbase PWGEMCALtasks PWGEMCALtrigger PWGJETFW PWGTools PWGCaloTrackCorrBase PWGHFvertexingHF)
+set(ALIROOT_DEPENDENCIES ANALYSIS ANALYSISalice AOD ESD OADB STEERBase PWGJEEMCALJetTasks PWGEMCALbase PWGEMCALtasks PWGEMCALtrigger PWGJETFW PWGTools PWGCaloTrackCorrBase PWGHFvertexingHF)
 
 # Generate the ROOT map
 # Dependecies


### PR DESCRIPTION
In order to allow for user-configured event cuts
objects (in the AddTask) an option to set the
event cut object is added. In case of a valid event
cuts object the object is not constructed any
more in the ExecOnce part but only the histograms
are added to the output list. Option sets usage
of internal event selection to false.