### PR TITLE
PWGGA/GammaConv Rewritten ConvJet class for mutiple jet finders in on…

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskConvJet.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvJet.cxx
@@ -38,53 +38,64 @@ ClassImp(AliAnalysisTaskConvJet);
 /// \endcond
 
 
-AliAnalysisTaskConvJet::AliAnalysisTaskConvJet() : 
+AliAnalysisTaskConvJet::AliAnalysisTaskConvJet(Int_t IsMC) :
   AliAnalysisTaskEmcalJet(),
-  fNJets(0),
-  fVectorJetPt(0),
-  fVectorJetPx(0),
-  fVectorJetPy(0),
-  fVectorJetPz(0),
-  fVectorJetEta(0),
-  fVectorJetPhi(0),
-  fVectorJetR(0),
-  fTrueNJets(0),
-  fTrueVectorJetPt(0),
-  fTrueVectorJetPx(0),
-  fTrueVectorJetPy(0),
-  fTrueVectorJetPz(0),
-  fTrueVectorJetEta(0),
-  fTrueVectorJetPhi(0),
-  fTrueVectorJetR(0)
+  fIsMC(IsMC),
+  fNJetContainers(0),
+  fJetContainersAdded(0),
+  fTrueJetContainersAdded(0),
+  fJetNameArray(NULL),
+  fTrueJetNameArray(NULL),
+  fTrainconfigArray(NULL),
+  fTrueTrainconfigArray(NULL),
+  fListNJets(0),
+  fListJetPt(0),
+  fListJetPx(0),
+  fListJetPy(0),
+  fListJetPz(0),
+  fListJetEta(0),
+  fListJetPhi(0),
+  fListJetArea(0),
+  fListTrueNJets(0),
+  fListTrueJetPt(0),
+  fListTrueJetPx(0),
+  fListTrueJetPy(0),
+  fListTrueJetPz(0),
+  fListTrueJetEta(0),
+  fListTrueJetPhi(0),
+  fListTrueJetArea(0)
 {
 }
 
-AliAnalysisTaskConvJet::AliAnalysisTaskConvJet(const char *name) : 
+AliAnalysisTaskConvJet::AliAnalysisTaskConvJet(const char *name, Int_t IsMC) :
   AliAnalysisTaskEmcalJet(name, kTRUE),
-  fNJets(0),
-  fVectorJetPt(0),
-  fVectorJetPx(0),
-  fVectorJetPy(0),
-  fVectorJetPz(0),
-  fVectorJetEta(0),
-  fVectorJetPhi(0),
-  fVectorJetR(0),
-  fTrueVectorJetPt(0),
-  fTrueVectorJetPx(0),
-  fTrueVectorJetPy(0),
-  fTrueVectorJetPz(0),
-  fTrueVectorJetEta(0),
-  fTrueVectorJetPhi(0),
-  fTrueVectorJetR(0)
+  fIsMC(IsMC),
+  fNJetContainers(0),
+  fJetContainersAdded(0),
+  fTrueJetContainersAdded(0),
+  fJetNameArray(NULL),
+  fTrueJetNameArray(NULL),
+  fTrainconfigArray(NULL),
+  fTrueTrainconfigArray(NULL),
+  fListNJets(0),
+  fListJetPt(0),
+  fListJetPx(0),
+  fListJetPy(0),
+  fListJetPz(0),
+  fListJetEta(0),
+  fListJetPhi(0),
+  fListJetArea(0),
+  fListTrueNJets(0),
+  fListTrueJetPt(0),
+  fListTrueJetPx(0),
+  fListTrueJetPy(0),
+  fListTrueJetPz(0),
+  fListTrueJetEta(0),
+  fListTrueJetPhi(0),
+  fListTrueJetArea(0)
 {
   SetMakeGeneralHistograms(kTRUE);
 }
-
-
-AliAnalysisTaskConvJet::~AliAnalysisTaskConvJet()
-{
-}
-
 /**
  * Performing run-independent initialization.
  * Here the histograms should be instantiated.
@@ -116,55 +127,69 @@ Bool_t AliAnalysisTaskConvJet::FillHistograms()
 void AliAnalysisTaskConvJet::DoJetLoop()
 {
   AliJetContainer* jetCont = 0;
+  Int_t j = 0;
   TIter next(&fJetCollArray);
   while ((jetCont = static_cast<AliJetContainer*>(next()))) {
     TString JetName = jetCont->GetTitle();
     TObjArray *arr = JetName.Tokenize("__");
     TObjString* testObjString = (TObjString*)arr->At(2);
+    Int_t TotalContainers;
+    if(fIsMC == 0) TotalContainers = fNJetContainers;
+    else TotalContainers = fNJetContainers/2;
     if(testObjString->GetString() != "mcparticles"){
+      for(Int_t i = 0; i < TotalContainers; i++){
+        if(JetName == fJetNameArray[i]){
+          j = i;
+          break;
+        }
+      }
       UInt_t count = 0;
-      fNJets = 0 ;
-      fVectorJetPt.clear();
-      fVectorJetPx.clear();
-      fVectorJetPy.clear();
-      fVectorJetPz.clear();
-      fVectorJetEta.clear();
-      fVectorJetPhi.clear();
-      fVectorJetR.clear();
+      fListJetPt.at(j).clear();
+      fListJetPx.at(j).clear();
+      fListJetPy.at(j).clear();
+      fListJetPz.at(j).clear();
+      fListJetEta.at(j).clear();
+      fListJetPhi.at(j).clear();
+      fListJetArea.at(j).clear();
       for(auto jet : jetCont->accepted()) {
         if (!jet) continue;
         count++;
-        fVectorJetPt.push_back(jet->Pt());
-        fVectorJetPx.push_back(jet->Px());
-        fVectorJetPy.push_back(jet->Py());
-        fVectorJetPz.push_back(jet->Pz());
-        fVectorJetEta.push_back(jet->Eta());
-        fVectorJetPhi.push_back(jet->Phi());
-        fVectorJetR.push_back(jet->Area());
+        fListJetPt.at(j).push_back(jet->Pt());
+        fListJetPx.at(j).push_back(jet->Px());
+        fListJetPy.at(j).push_back(jet->Py());
+        fListJetPz.at(j).push_back(jet->Pz());
+        fListJetEta.at(j).push_back(jet->Eta());
+        fListJetPhi.at(j).push_back(jet->Phi());
+        fListJetArea.at(j).push_back(jet->Area());
       }
-      fNJets = count ;
+      fListNJets.at(j) = count;
     }else{
+      for(Int_t i = 0; i < fNJetContainers/2; i++){
+        if(JetName == fTrueJetNameArray[i]){
+          j = i;
+          break;
+        }
+      }
       UInt_t count = 0;
-      fTrueNJets = 0 ;
-      fTrueVectorJetPt.clear();
-      fTrueVectorJetPx.clear();
-      fTrueVectorJetPy.clear();
-      fTrueVectorJetPz.clear();
-      fTrueVectorJetEta.clear();
-      fTrueVectorJetPhi.clear();
-      fTrueVectorJetR.clear();
+      fListTrueJetPt.at(j).clear();
+      fListTrueJetPx.at(j).clear();
+      fListTrueJetPy.at(j).clear();
+      fListTrueJetPz.at(j).clear();
+      fListTrueJetEta.at(j).clear();
+      fListTrueJetPhi.at(j).clear();
+      fListTrueJetArea.at(j).clear();
       for(auto jet : jetCont->accepted()) {
         if (!jet) continue;
         count++;
-        fTrueVectorJetPt.push_back(jet->Pt());
-        fTrueVectorJetPx.push_back(jet->Px());
-        fTrueVectorJetPy.push_back(jet->Py());
-        fTrueVectorJetPz.push_back(jet->Pz());
-        fTrueVectorJetEta.push_back(jet->Eta());
-        fTrueVectorJetPhi.push_back(jet->Phi());
-        fTrueVectorJetR.push_back(jet->Area());
+        fListTrueJetPt.at(j).push_back(jet->Pt());
+        fListTrueJetPx.at(j).push_back(jet->Px());
+        fListTrueJetPy.at(j).push_back(jet->Py());
+        fListTrueJetPz.at(j).push_back(jet->Pz());
+        fListTrueJetEta.at(j).push_back(jet->Eta());
+        fListTrueJetPhi.at(j).push_back(jet->Phi());
+        fListTrueJetArea.at(j).push_back(jet->Area());
       }
-      fTrueNJets = count ;
+      fListTrueNJets.at(j) = count;
     }
   }
 }
@@ -206,7 +231,9 @@ AliAnalysisTaskConvJet * AliAnalysisTaskConvJet::AddTask_GammaConvJet(
   const char *ntracks,
   const char *nclusters,
   const char *ncells,
-  const char *suffix)
+  const char *suffix,
+  Int_t IsMC,
+  Int_t NContainers)
 {
   // Get the pointer to the existing analysis manager via the static access method.
   //==============================================================================
@@ -287,33 +314,38 @@ AliAnalysisTaskConvJet * AliAnalysisTaskConvJet::AddTask_GammaConvJet(
 
   TString name("AliAnalysisTaskConvJet");
 
-  AliAnalysisTaskConvJet* sampleTask = new AliAnalysisTaskConvJet(name);
+  AliAnalysisTaskConvJet* sampleTask = new AliAnalysisTaskConvJet(name, IsMC);
   sampleTask->SetCaloCellsName(cellName);
   sampleTask->SetVzRange(-10,10);
 
-  if (trackName == "mcparticles") {
-    sampleTask->AddMCParticleContainer(trackName);
-  }
-  else if (trackName == "tracks" || trackName == "Tracks") {
-    sampleTask->AddTrackContainer(trackName);
-  }
-  else if (!trackName.IsNull()) {
-    sampleTask->AddParticleContainer(trackName);
-  }
-  sampleTask->AddClusterContainer(clusName);
-  
-  sampleTask->GetClusterContainer(0)->SetClusECut(0.);
-  sampleTask->GetClusterContainer(0)->SetClusPtCut(0.);
-  sampleTask->GetClusterContainer(0)->SetClusNonLinCorrEnergyCut(0.);
-  sampleTask->GetClusterContainer(0)->SetClusHadCorrEnergyCut(0.30);
-  sampleTask->GetClusterContainer(0)->SetDefaultClusterEnergy(AliVCluster::kHadCorr);
-  sampleTask->GetParticleContainer(0)->SetParticlePtCut(0.15);
-  sampleTask->GetParticleContainer(0)->SetParticleEtaLimits(-0.8,0.8);
+  sampleTask->SetNumberOfContainers(NContainers);
 
-  if(trackName != "mcparticles"){
-      sampleTask->GetTrackContainer(0)->SetFilterHybridTracks(kTRUE);
-      sampleTask->GetTrackContainer(0)->SetParticlePtCut(0.15);
-      sampleTask->GetTrackContainer(0)->SetParticleEtaLimits(-0.8,0.8);
+  for(Int_t i = 0; i < sampleTask->GetNumberOfContainers(); i++){
+
+    if (trackName == "mcparticles") {
+      sampleTask->AddMCParticleContainer(trackName);
+    }
+    else if (trackName == "tracks" || trackName == "Tracks") {
+      sampleTask->AddTrackContainer(trackName);
+    }
+    else if (!trackName.IsNull()) {
+     sampleTask->AddParticleContainer(trackName);
+    }
+    sampleTask->AddClusterContainer(clusName);
+  
+    sampleTask->GetClusterContainer(i)->SetClusECut(0.);
+    sampleTask->GetClusterContainer(i)->SetClusPtCut(0.);
+    sampleTask->GetClusterContainer(i)->SetClusNonLinCorrEnergyCut(0.);
+    sampleTask->GetClusterContainer(i)->SetClusHadCorrEnergyCut(0.30);
+    sampleTask->GetClusterContainer(i)->SetDefaultClusterEnergy(AliVCluster::kHadCorr);
+    sampleTask->GetParticleContainer(i)->SetParticlePtCut(0.15);
+    sampleTask->GetParticleContainer(i)->SetParticleEtaLimits(-0.8,0.8);
+
+    if(trackName != "mcparticles"){
+      sampleTask->GetTrackContainer(i)->SetFilterHybridTracks(kTRUE);
+      sampleTask->GetTrackContainer(i)->SetParticlePtCut(0.15);
+      sampleTask->GetTrackContainer(i)->SetParticleEtaLimits(-0.8,0.8);
+    }
   }
 
   //-------------------------------------------------------

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
@@ -92,6 +92,7 @@ AliAnalysisTaskGammaCalo::AliAnalysisTaskGammaCalo(): AliAnalysisTaskSE(),
   fJetHistograms(NULL),
   fTrueJetHistograms(NULL),
   fJetSector(0),
+  fTrainConfig(0),
   fHistoMotherInvMassPt(NULL),
   fSparseMotherInvMassPtZM(NULL),
   fHistoMotherBackInvMassPt(NULL),
@@ -445,6 +446,7 @@ AliAnalysisTaskGammaCalo::AliAnalysisTaskGammaCalo(const char *name):
   fJetHistograms(NULL),
   fTrueJetHistograms(NULL),
   fJetSector(0),
+  fTrainConfig(0),
   fHistoMotherInvMassPt(NULL),
   fSparseMotherInvMassPtZM(NULL),
   fHistoMotherBackInvMassPt(NULL),
@@ -861,7 +863,7 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
   fV0Reader=(AliV0ReaderV1*)AliAnalysisManager::GetAnalysisManager()->GetTask(fV0ReaderName.Data());
   if(!fV0Reader){printf("Error: No V0 Reader");return;} // GetV0Reader
 
-  if(fDoMesonAnalysis){
+  if(fDoMesonAnalysis){ //Same Jet Finder MUST be used within same trainconfig
     if( ((AliConversionMesonCuts*)fMesonCutArray->At(0))->DoJetAnalysis())  fDoJetAnalysis = kTRUE;
     if( ((AliConversionMesonCuts*)fMesonCutArray->At(0))->DoJetQA())        fDoJetQA       = kTRUE;
   }
@@ -2962,7 +2964,7 @@ void AliAnalysisTaskGammaCalo::UserExec(Option_t *)
       if(((AliConvEventCuts*)fEventCutArray->At(iCut))->GetUseSphericity()!=0){
         if(fV0Reader->GetSphericity() != -1 && fV0Reader->GetSphericity() != 0){
           if(fDoJetAnalysis && !fDoSoftAnalysis){
-            if(fConvJetReader->GetNJets() > 0){
+            if(fConvJetReader->GetNJets(fTrainConfig) > 0){
                 fHistoNEvents[iCut]->Fill(eventQuality, fWeightJetJetMC); // Should be 0 here
                 if (fIsMC>1) fHistoNEventsWOWeight[iCut]->Fill(eventQuality); // Should be 0 here
                 fHistoNGoodESDTracks[iCut]->Fill(fV0Reader->GetNumberOfPrimaryTracks(), fWeightJetJetMC);
@@ -2970,9 +2972,9 @@ void AliAnalysisTaskGammaCalo::UserExec(Option_t *)
                 fHistoEventSphericity[iCut]->Fill(fV0Reader->GetSphericity(), fWeightJetJetMC);
                 fHistoEventSphericityvsNtracks[iCut]->Fill(fV0Reader->GetSphericity(), fV0Reader->GetNumberOfPrimaryTracks(), fWeightJetJetMC);
             }
-            fHistoEventSphericityvsNJets[iCut]->Fill(fV0Reader->GetSphericity(), fConvJetReader->GetNJets(), fWeightJetJetMC);
+            fHistoEventSphericityvsNJets[iCut]->Fill(fV0Reader->GetSphericity(), fConvJetReader->GetNJets(fTrainConfig), fWeightJetJetMC);
           }else if(fDoJetAnalysis && fDoSoftAnalysis){
-            if(fConvJetReader->GetNJets() < 1){  
+            if(fConvJetReader->GetNJets(fTrainConfig) < 1){
                 fHistoNEvents[iCut]->Fill(eventQuality, fWeightJetJetMC); // Should be 0 here
                 if (fIsMC>1) fHistoNEventsWOWeight[iCut]->Fill(eventQuality); // Should be 0 here
                 fHistoNGoodESDTracks[iCut]->Fill(fV0Reader->GetNumberOfPrimaryTracks(), fWeightJetJetMC);
@@ -2980,7 +2982,7 @@ void AliAnalysisTaskGammaCalo::UserExec(Option_t *)
                 fHistoEventSphericity[iCut]->Fill(fV0Reader->GetSphericity(), fWeightJetJetMC);
                 fHistoEventSphericityvsNtracks[iCut]->Fill(fV0Reader->GetSphericity(), fV0Reader->GetNumberOfPrimaryTracks(), fWeightJetJetMC);
             }
-            fHistoEventSphericityvsNJets[iCut]->Fill(fV0Reader->GetSphericity(), fConvJetReader->GetNJets(), fWeightJetJetMC);
+            fHistoEventSphericityvsNJets[iCut]->Fill(fV0Reader->GetSphericity(), fConvJetReader->GetNJets(fTrainConfig), fWeightJetJetMC);
           }else{
             fHistoNEvents[iCut]->Fill(eventQuality, fWeightJetJetMC); // Should be 0 here
             if (fIsMC>1) fHistoNEventsWOWeight[iCut]->Fill(eventQuality); // Should be 0 here
@@ -3480,33 +3482,33 @@ void AliAnalysisTaskGammaCalo::ProcessClusters()
 //________________________________________________________________________
 void AliAnalysisTaskGammaCalo::ProcessJets()
 {
-  fHistoNJets[fiCut]->Fill(fConvJetReader->GetNJets());
-  if(fConvJetReader->GetNJets()>0){
-    fVectorJetPt  = fConvJetReader->GetVectorJetPt();
-    fVectorJetPx  = fConvJetReader->GetVectorJetPx();
-    fVectorJetPy  = fConvJetReader->GetVectorJetPy();
-    fVectorJetPz  = fConvJetReader->GetVectorJetPz();
-    fVectorJetEta = fConvJetReader->GetVectorJetEta();
-    fVectorJetPhi = fConvJetReader->GetVectorJetPhi();
-    fVectorJetArea = fConvJetReader->GetVectorJetR();
-    if(fIsMC > 0 && fConvJetReader->GetTrueNJets()>0){
-      fTrueVectorJetPt = fConvJetReader->GetTrueVectorJetPt();
-      fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-      fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+  fHistoNJets[fiCut]->Fill(fConvJetReader->GetNJets(fTrainConfig));
+  if(fConvJetReader->GetNJets(fTrainConfig)>0){
+    fVectorJetPt  = fConvJetReader->GetVectorJetPt(fTrainConfig);
+    fVectorJetPx  = fConvJetReader->GetVectorJetPx(fTrainConfig);
+    fVectorJetPy  = fConvJetReader->GetVectorJetPy(fTrainConfig);
+    fVectorJetPz  = fConvJetReader->GetVectorJetPz(fTrainConfig);
+    fVectorJetEta = fConvJetReader->GetVectorJetEta(fTrainConfig);
+    fVectorJetPhi = fConvJetReader->GetVectorJetPhi(fTrainConfig);
+    fVectorJetArea = fConvJetReader->GetVectorJetArea(fTrainConfig);
+    if(fIsMC > 0 && fConvJetReader->GetTrueNJets(fTrainConfig)>0){
+      fTrueVectorJetPt = fConvJetReader->GetTrueVectorJetPt(fTrainConfig);
+      fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+      fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
     }
-    if(fVectorJetPt.size() == fConvJetReader->GetNJets() && fVectorJetEta.size() == fConvJetReader->GetNJets() && fVectorJetPhi.size() == fConvJetReader->GetNJets() && fVectorJetArea.size() == fConvJetReader->GetNJets()){
+    if(fVectorJetPt.size() == fConvJetReader->GetNJets(fTrainConfig) && fVectorJetEta.size() == fConvJetReader->GetNJets(fTrainConfig) && fVectorJetPhi.size() == fConvJetReader->GetNJets(fTrainConfig) && fVectorJetArea.size() == fConvJetReader->GetNJets(fTrainConfig)){
       fJetSector = 0;
       Double_t tempMaxJetPt = 0.;
       Int_t MaxPtJetID = 0;
-      for(Int_t i=0; i<fConvJetReader->GetNJets(); i++){
+      for(Int_t i=0; i<fConvJetReader->GetNJets(fTrainConfig); i++){
         fHistoPtJet[fiCut]->Fill(fVectorJetPt.at(i));
         fHistoJetEta[fiCut]->Fill(fVectorJetEta.at(i));
         fHistoJetPhi[fiCut]->Fill(fVectorJetPhi.at(i));
         fHistoJetArea[fiCut]->Fill(fVectorJetArea.at(i));
-        if(fIsMC > 0 && fConvJetReader->GetNJets()>0 && fConvJetReader->GetTrueNJets()>0){
+        if(fIsMC > 0 && fConvJetReader->GetNJets(fTrainConfig)>0 && fConvJetReader->GetTrueNJets(fTrainConfig)>0){
           Double_t min = 100;
           Int_t match = 0;
-          for(Int_t j = 0; j<fConvJetReader->GetTrueNJets(); j++){
+          for(Int_t j = 0; j<fConvJetReader->GetTrueNJets(fTrainConfig); j++){
             Double_t R_jetjet;
             Double_t DeltaEta = fVectorJetEta.at(i)-fTrueVectorJetEta.at(j);
             Double_t DeltaPhi = abs(fVectorJetPhi.at(i)-fTrueVectorJetPhi.at(j));
@@ -3547,7 +3549,7 @@ void AliAnalysisTaskGammaCalo::ProcessJets()
     fVectorJetEta.clear();
     fVectorJetPhi.clear();
     fVectorJetArea.clear();
-    if(fIsMC > 0 && fConvJetReader->GetTrueNJets()>0){
+    if(fIsMC > 0 && fConvJetReader->GetTrueNJets(fTrainConfig)>0){
       fTrueVectorJetPt.clear();
       fTrueVectorJetEta.clear();
       fTrueVectorJetPhi.clear();
@@ -4010,20 +4012,20 @@ void AliAnalysisTaskGammaCalo::ProcessAODMCParticles()
           if(particle->GetPdgCode() == 111){
             fHistoMCPi0Pt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // All MC Pi0
             if(fDoJetAnalysis){
-              if(fConvJetReader->GetTrueNJets()>0){
+              if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
                 fHistoMCPi0JetEventGenerated[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in jet event
-                fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-                fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+                fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+                fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
                 Double_t RJetPi0Cand;
-                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                   Double_t DeltaEta = fTrueVectorJetEta.at(i)-particle->Eta();
                   Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-particle->Phi());
                   if(DeltaPhi > M_PI) {
                     DeltaPhi = 2*M_PI - DeltaPhi;
                   }
                   RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                  if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                  if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                       fHistoMCPi0inJetGenerated[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in a jet
                     }
                   }
@@ -4042,20 +4044,20 @@ void AliAnalysisTaskGammaCalo::ProcessAODMCParticles()
           } else if(particle->GetPdgCode() == 221){
             fHistoMCEtaPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // All MC Eta
             if(fDoJetAnalysis){
-              if(fConvJetReader->GetTrueNJets()>0){
+              if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
                 fHistoMCEtaJetEventGenerated[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in jet event
-                fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-                fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+                fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+                fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
                 Double_t RJetPi0Cand;
-                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                   Double_t DeltaEta = fTrueVectorJetEta.at(i)-particle->Eta();
                   Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-particle->Phi());
                   if(DeltaPhi > M_PI) {
                     DeltaPhi = 2*M_PI - DeltaPhi;
                   }
                   RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                  if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                  if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                       fHistoMCEtainJetGenerated[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in a jet
                     }
                   }
@@ -4081,20 +4083,20 @@ void AliAnalysisTaskGammaCalo::ProcessAODMCParticles()
               fHistoMCPi0InAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc
               if(fIsMC > 1) fHistoMCPi0WOEvtWeightInAccPt[fiCut]->Fill(particle->Pt()); // MC Pi0 with gamma in acc
               if(fDoJetAnalysis){
-                if(fConvJetReader->GetTrueNJets()>0){
+                if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
                   fHistoMCPi0JetInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in jet event
-                  fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-                  fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+                  fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+                  fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
                   Double_t RJetPi0Cand;
-                  for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                  for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                     Double_t DeltaEta = fTrueVectorJetEta.at(i)-particle->Eta();
                     Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-particle->Phi());
                     if(DeltaPhi > M_PI) {
                       DeltaPhi = 2*M_PI - DeltaPhi;
                     }
                     RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                    if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                      if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                    if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                      if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                         fHistoMCPi0inJetInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in a jet
                       }
                     }
@@ -4107,20 +4109,20 @@ void AliAnalysisTaskGammaCalo::ProcessAODMCParticles()
               fHistoMCEtaInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Eta with gamma in acc
               if(fIsMC > 1) fHistoMCEtaWOEvtWeightInAccPt[fiCut]->Fill(particle->Pt()); // MC Eta with gamma in acc
               if(fDoJetAnalysis){
-                if(fConvJetReader->GetTrueNJets()>0){
+                if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
                   fHistoMCEtaJetInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in jet event
-                  fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-                  fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+                  fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+                  fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
                   Double_t RJetPi0Cand;
-                  for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                  for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                     Double_t DeltaEta = fTrueVectorJetEta.at(i)-particle->Eta();
                     Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-particle->Phi());
                     if(DeltaPhi > M_PI) {
                       DeltaPhi = 2*M_PI - DeltaPhi;
                     }
                     RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                    if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                      if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                    if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                      if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                         fHistoMCEtainJetInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in a jet
                       }
                     }
@@ -4308,20 +4310,20 @@ void AliAnalysisTaskGammaCalo::ProcessMCParticles()
           if(particle->GetPdgCode() == 111){
             fHistoMCPi0Pt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // All MC Pi0
             if(fDoJetAnalysis){
-              if(fConvJetReader->GetTrueNJets()>0){
+              if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
                 fHistoMCPi0JetEventGenerated[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in jet event
-                fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-                fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+                fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+                fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
                 Double_t RJetPi0Cand;
-                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                   Double_t DeltaEta = fTrueVectorJetEta.at(i)-particle->Eta();
                   Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-particle->Phi());
                   if(DeltaPhi > M_PI) {
                     DeltaPhi = 2*M_PI - DeltaPhi;
                   }
                   RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                  if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                  if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                       fHistoMCPi0inJetGenerated[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in a jet
                     }
                   }
@@ -4340,20 +4342,20 @@ void AliAnalysisTaskGammaCalo::ProcessMCParticles()
           } else if(particle->GetPdgCode() == 221){
             fHistoMCEtaPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // All MC Eta
             if(fDoJetAnalysis){
-              if(fConvJetReader->GetTrueNJets()>0){
+              if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
                 fHistoMCEtaJetEventGenerated[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in jet event
-                fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-                fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+                fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+                fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
                 Double_t RJetPi0Cand;
-                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                   Double_t DeltaEta = fTrueVectorJetEta.at(i)-particle->Eta();
                   Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-particle->Phi());
                   if(DeltaPhi > M_PI) {
                     DeltaPhi = 2*M_PI - DeltaPhi;
                   }
                   RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                  if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                  if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                       fHistoMCEtainJetGenerated[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in a jet
                     }
                   }
@@ -4382,20 +4384,20 @@ void AliAnalysisTaskGammaCalo::ProcessMCParticles()
               fHistoMCPi0InAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc
               if(fIsMC > 1) fHistoMCPi0WOEvtWeightInAccPt[fiCut]->Fill(particle->Pt()); // MC Pi0 with gamma in acc
               if(fDoJetAnalysis){
-                if(fConvJetReader->GetTrueNJets()>0){
+                if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
                   fHistoMCPi0JetInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in jet event
-                  fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-                  fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+                  fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+                  fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
                   Double_t RJetPi0Cand;
-                  for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                  for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                     Double_t DeltaEta = fTrueVectorJetEta.at(i)-particle->Eta();
                     Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-particle->Phi());
                     if(DeltaPhi > M_PI) {
                       DeltaPhi = 2*M_PI - DeltaPhi;
                     }
                     RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                    if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                      if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                    if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                      if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                         fHistoMCPi0inJetInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in a jet
                       }
                     }
@@ -4408,20 +4410,20 @@ void AliAnalysisTaskGammaCalo::ProcessMCParticles()
               fHistoMCEtaInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Eta with gamma in acc
               if(fIsMC > 1) fHistoMCEtaWOEvtWeightInAccPt[fiCut]->Fill(particle->Pt()); // MC Eta with gamma in acc
               if(fDoJetAnalysis){
-                if(fConvJetReader->GetTrueNJets()>0){
+                if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
                   fHistoMCEtaJetInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in jet event
-                  fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-                  fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+                  fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+                  fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
                   Double_t RJetPi0Cand;
-                  for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                  for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                     Double_t DeltaEta = fTrueVectorJetEta.at(i)-particle->Eta();
                     Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-particle->Phi());
                     if(DeltaPhi > M_PI) {
                       DeltaPhi = 2*M_PI - DeltaPhi;
                     }
                     RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                    if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                      if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                    if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                      if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                         fHistoMCEtainJetInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in a jet
                       }
                     }
@@ -4536,18 +4538,18 @@ void AliAnalysisTaskGammaCalo::CalculatePi0Candidates(){
           if(fLocalDebugFlag == 1) DebugMethodPrint1(pi0cand,gamma0,gamma1);
           fHistoMotherInvMassPt[fiCut]->Fill(pi0cand->M(),pi0cand->Pt(), tempPi0CandWeight);
           if(fDoJetAnalysis){
-            if(fConvJetReader->GetNJets()>0){
-              fVectorJetPt = fConvJetReader->GetVectorJetPt();
-              fVectorJetPx = fConvJetReader->GetVectorJetPx();
-              fVectorJetPy = fConvJetReader->GetVectorJetPy();
-              fVectorJetPz = fConvJetReader->GetVectorJetPz();
-              fVectorJetEta = fConvJetReader->GetVectorJetEta();
-              fVectorJetPhi = fConvJetReader->GetVectorJetPhi();
+            if(fConvJetReader->GetNJets(fTrainConfig)>0){
+              fVectorJetPt = fConvJetReader->GetVectorJetPt(fTrainConfig);
+              fVectorJetPx = fConvJetReader->GetVectorJetPx(fTrainConfig);
+              fVectorJetPy = fConvJetReader->GetVectorJetPy(fTrainConfig);
+              fVectorJetPz = fConvJetReader->GetVectorJetPz(fTrainConfig);
+              fVectorJetEta = fConvJetReader->GetVectorJetEta(fTrainConfig);
+              fVectorJetPhi = fConvJetReader->GetVectorJetPhi(fTrainConfig);
               fHistoJetMotherInvMassPt[fiCut]->Fill(pi0cand->M(),pi0cand->Pt(), tempPi0CandWeight);
               Double_t RJetPi0Cand = 0;
-              if(fVectorJetPt.size() == fConvJetReader->GetNJets() && fVectorJetEta.size() == fConvJetReader->GetNJets() && fVectorJetPhi.size() == fConvJetReader->GetNJets()){
+              if(fVectorJetPt.size() == fConvJetReader->GetNJets(fTrainConfig) && fVectorJetEta.size() == fConvJetReader->GetNJets(fTrainConfig) && fVectorJetPhi.size() == fConvJetReader->GetNJets(fTrainConfig)){
                 Int_t counter = 0;
-                for(Int_t i=0; i<fConvJetReader->GetNJets(); i++){
+                for(Int_t i=0; i<fConvJetReader->GetNJets(fTrainConfig); i++){
                   Double_t DeltaEta = fVectorJetEta.at(i)-pi0cand->Eta();
                   Double_t DeltaPhi = abs(fVectorJetPhi.at(i)-pi0cand->Phi());
                   if(DeltaPhi > M_PI) {
@@ -4556,8 +4558,8 @@ void AliAnalysisTaskGammaCalo::CalculatePi0Candidates(){
                   RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
                   fHistoRJetPi0Cand[fiCut]->Fill(RJetPi0Cand,pi0cand->Pt(), tempPi0CandWeight);
                   fHistoEtaPhiJetPi0Cand[fiCut]->Fill(DeltaPhi,DeltaEta, tempPi0CandWeight);
-                  if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                  if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                       counter ++;
                       fHistoPi0InJetMotherInvMassPt[fiCut]->Fill(pi0cand->M(),pi0cand->Pt(), tempPi0CandWeight);
                       fHistoEtaPhiJetWithPi0Cand[fiCut]->Fill(DeltaPhi, DeltaEta, tempPi0CandWeight);
@@ -4569,13 +4571,13 @@ void AliAnalysisTaskGammaCalo::CalculatePi0Candidates(){
                       fHistoJetFragmFunc[fiCut]->Fill(z,fVectorJetPt.at(i));
 
                       if(fDoJetQA){
-                        if(fIsMC > 0 && fConvJetReader->GetTrueNJets()>0){
-                          fTrueVectorJetPt = fConvJetReader->GetTrueVectorJetPt();
-                          fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-                          fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+                        if(fIsMC > 0 && fConvJetReader->GetTrueNJets(fTrainConfig)>0){
+                          fTrueVectorJetPt = fConvJetReader->GetTrueVectorJetPt(fTrainConfig);
+                          fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+                          fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
                           Double_t min = 100;
                           Int_t match = 0;
-                          for(Int_t j = 0; j<fConvJetReader->GetTrueNJets(); j++){
+                          for(Int_t j = 0; j<fConvJetReader->GetTrueNJets(fTrainConfig); j++){
                             Double_t R_jetjet;
                             DeltaEta = fVectorJetEta.at(i)-fTrueVectorJetEta.at(j);
                             DeltaPhi = abs(fVectorJetPhi.at(i)-fTrueVectorJetPhi.at(j));
@@ -4871,21 +4873,21 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidates(AliAODConversionMother
     if (isTruePi0){
       fHistoTruePi0InvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),  tempTruePi0CandWeight);
       if(fDoJetAnalysis){
-        if(fConvJetReader->GetTrueNJets()>0){
+        if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
           fHistoTruePi0JetMotherInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),  tempTruePi0CandWeight);
-          fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-          fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+          fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+          fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
           Double_t RJetPi0Cand;
           Int_t counter = 0;
-          for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+          for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
             Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
             Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
             if(DeltaPhi > M_PI) {
               DeltaPhi = 2*M_PI - DeltaPhi;
             }
             RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-            if(fConvJetReader->Get_Jet_Radius() > 0 ){
-              if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+            if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+              if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                 counter ++;
                 fHistoTruePi0InJetMotherInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), tempTruePi0CandWeight);
                 fHistoMotherPi0inJetPtY[fiCut]->Fill(Pi0Candidate->Pt(),Pi0Candidate->Rapidity()-((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), tempTruePi0CandWeight);
@@ -4910,21 +4912,21 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidates(AliAODConversionMother
     if (isTrueEta){
       fHistoTrueEtaInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),  tempTruePi0CandWeight);
       if(fDoJetAnalysis){
-        if(fConvJetReader->GetTrueNJets()>0){
+        if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
           fHistoTrueEtaJetMotherInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),  tempTruePi0CandWeight);
           Double_t RJetEtaCand;
-          fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-          fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+          fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+          fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
           Int_t counter = 0;
-          for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+          for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
             Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
             Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
             if(DeltaPhi > M_PI) {
               DeltaPhi = 2*M_PI - DeltaPhi;
             }
             RJetEtaCand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-            if(fConvJetReader->Get_Jet_Radius() > 0 ){
-              if(RJetEtaCand < fConvJetReader->Get_Jet_Radius()){
+            if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+              if(RJetEtaCand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                 counter ++;
                 fHistoTrueEtaInJetMotherInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), tempTruePi0CandWeight);
                 fHistoMotherEtainJetPtY[fiCut]->Fill(Pi0Candidate->Pt(),Pi0Candidate->Rapidity()-((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), tempTruePi0CandWeight);
@@ -5088,20 +5090,20 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidates(AliAODConversionMother
       if (isTruePi0) {
         fHistoTrueSecondaryPi0InvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
         if(fDoJetAnalysis){
-          if(fConvJetReader->GetTrueNJets()>0){
+          if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
             fHistoTrueSecondaryPi0InvJetMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
-            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
             Double_t RJetPi0Cand;
-              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                 Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                 Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                 if(DeltaPhi > M_PI) {
                   DeltaPhi = 2*M_PI - DeltaPhi;
                 }
                 RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                     fHistoTrueSecondaryPi0InvinJetMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
                   }
                 }
@@ -5120,20 +5122,20 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidates(AliAODConversionMother
             if (!isSameConvertedGamma)tTrueInvMassROpenABPtFlag[fiCut]->Fill();
           }
           if(fDoJetAnalysis){
-            if(fConvJetReader->GetTrueNJets()>0){
+            if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
               fHistoTrueSecondaryPi0FromK0sJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
-              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
               Double_t RJetPi0Cand;
-                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                   Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                   Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                   if(DeltaPhi > M_PI) {
                     DeltaPhi = 2*M_PI - DeltaPhi;
                   }
                   RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                  if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                  if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                       fHistoTrueSecondaryPi0FromK0sinJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
                     }
                   }
@@ -5146,20 +5148,20 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidates(AliAODConversionMother
           fHistoTrueSecondaryPi0FromK0lInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
           if (fDoMesonQA > 0 && fDoMesonQA < 3 && fIsMC < 2)fHistoTrueK0lWithPi0DaughterMCPt[fiCut]->Fill(fMCEvent->Particle(secMotherLabel)->Pt(), tempTruePi0CandWeight);
           if(fDoJetAnalysis){
-            if(fConvJetReader->GetTrueNJets()>0){
+            if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
               fHistoTrueSecondaryPi0FromK0lJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
-              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
               Double_t RJetPi0Cand;
-                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                   Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                   Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                   if(DeltaPhi > M_PI) {
                     DeltaPhi = 2*M_PI - DeltaPhi;
                   }
                   RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                  if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                  if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                       fHistoTrueSecondaryPi0FromK0linJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
                     }
                   }
@@ -5184,20 +5186,20 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidates(AliAODConversionMother
             if (!isSameConvertedGamma)tTrueInvMassROpenABPtFlag[fiCut]->Fill();
           }
           if(fDoJetAnalysis){
-            if(fConvJetReader->GetTrueNJets()>0){
+            if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
               fHistoTrueSecondaryPi0FromLambdaJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
-              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
               Double_t RJetPi0Cand;
-                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                   Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                   Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                   if(DeltaPhi > M_PI) {
                     DeltaPhi = 2*M_PI - DeltaPhi;
                   }
                   RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                  if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                  if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                       fHistoTrueSecondaryPi0FromLambdainJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
                     }
                   }
@@ -5238,24 +5240,24 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidates(AliAODConversionMother
         fProfileTruePrimaryPi0WeightsInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weighted* tempTruePi0CandWeight);
         if (CheckVectorForDoubleCount(fVectorDoubleCountTruePi0s,gamma0MotherLabel)) fHistoDoubleCountTruePi0InvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), weighted*tempTruePi0CandWeight);
         if(fDoJetAnalysis){
-          if(fConvJetReader->GetTrueNJets()>0){
+          if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
             fHistoTruePrimaryPi0JetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weighted* tempTruePi0CandWeight);
-            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
-            fTrueVectorJetPt  = fConvJetReader->GetTrueVectorJetPt();
-            fTrueVectorJetPx  = fConvJetReader->GetTrueVectorJetPx();
-            fTrueVectorJetPy  = fConvJetReader->GetTrueVectorJetPy();
-            fTrueVectorJetPz  = fConvJetReader->GetTrueVectorJetPz();
+            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
+            fTrueVectorJetPt  = fConvJetReader->GetTrueVectorJetPt(fTrainConfig);
+            fTrueVectorJetPx  = fConvJetReader->GetTrueVectorJetPx(fTrainConfig);
+            fTrueVectorJetPy  = fConvJetReader->GetTrueVectorJetPy(fTrainConfig);
+            fTrueVectorJetPz  = fConvJetReader->GetTrueVectorJetPz(fTrainConfig);
             Double_t RJetPi0Cand;
-              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                 Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                 Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                 if(DeltaPhi > M_PI) {
                   DeltaPhi = 2*M_PI - DeltaPhi;
                 }
                 RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                     fHistoTruePrimaryPi0inJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weighted* tempTruePi0CandWeight);
                     Double_t dotproduct = fTrueVectorJetPx.at(i)*Pi0Candidate->Px() + fTrueVectorJetPy.at(i)*Pi0Candidate->Py() + fTrueVectorJetPz.at(i)*Pi0Candidate->Pz();
                     Double_t magn = pow(fTrueVectorJetPx.at(i),2) + pow(fTrueVectorJetPy.at(i),2) + pow(fTrueVectorJetPz.at(i),2);
@@ -5283,24 +5285,24 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidates(AliAODConversionMother
         fProfileTruePrimaryEtaWeightsInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weighted* tempTruePi0CandWeight);
         if (CheckVectorForDoubleCount(fVectorDoubleCountTrueEtas,gamma0MotherLabel)) fHistoDoubleCountTrueEtaInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), weighted*tempTruePi0CandWeight);
         if(fDoJetAnalysis){
-          if(fConvJetReader->GetTrueNJets()>0){
+          if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
             fHistoTruePrimaryEtaJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weighted* tempTruePi0CandWeight);
-            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
-            fTrueVectorJetPt  = fConvJetReader->GetTrueVectorJetPt();
-            fTrueVectorJetPx  = fConvJetReader->GetTrueVectorJetPx();
-            fTrueVectorJetPy  = fConvJetReader->GetTrueVectorJetPy();
-            fTrueVectorJetPz  = fConvJetReader->GetTrueVectorJetPz();
+            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
+            fTrueVectorJetPt  = fConvJetReader->GetTrueVectorJetPt(fTrainConfig);
+            fTrueVectorJetPx  = fConvJetReader->GetTrueVectorJetPx(fTrainConfig);
+            fTrueVectorJetPy  = fConvJetReader->GetTrueVectorJetPy(fTrainConfig);
+            fTrueVectorJetPz  = fConvJetReader->GetTrueVectorJetPz(fTrainConfig);
             Double_t RJetPi0Cand;
-              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                 Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                 Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                 if(DeltaPhi > M_PI) {
                   DeltaPhi = 2*M_PI - DeltaPhi;
                 }
                 RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                     fHistoTruePrimaryEtainJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weighted* tempTruePi0CandWeight);
                     Double_t dotproduct = fTrueVectorJetPx.at(i)*Pi0Candidate->Px() + fTrueVectorJetPy.at(i)*Pi0Candidate->Py() + fTrueVectorJetPz.at(i)*Pi0Candidate->Pz();
                     Double_t magn = pow(fTrueVectorJetPx.at(i),2) + pow(fTrueVectorJetPy.at(i),2) + pow(fTrueVectorJetPz.at(i),2);
@@ -5446,21 +5448,21 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidatesAOD(AliAODConversionMot
     if(isTruePi0){
       fHistoTruePi0InvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), tempTruePi0CandWeight);
       if(fDoJetAnalysis){
-        if(fConvJetReader->GetTrueNJets()>0){
+        if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
           fHistoTruePi0JetMotherInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),  tempTruePi0CandWeight);
-          fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-          fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+          fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+          fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
           Double_t RJetPi0Cand;
           Int_t counter = 0;
-          for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+          for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
             Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
             Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
             if(DeltaPhi > M_PI) {
               DeltaPhi = 2*M_PI - DeltaPhi;
             }
             RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-            if(fConvJetReader->Get_Jet_Radius() > 0 ){
-              if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+            if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+              if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                 counter ++;
                 fHistoTruePi0InJetMotherInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), tempTruePi0CandWeight);
                 fHistoMotherPi0inJetPtY[fiCut]->Fill(Pi0Candidate->Pt(),Pi0Candidate->Rapidity()-((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), tempTruePi0CandWeight);
@@ -5486,21 +5488,21 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidatesAOD(AliAODConversionMot
       fHistoTrueEtaInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), tempTruePi0CandWeight);
 
       if(fDoJetAnalysis){
-        if(fConvJetReader->GetTrueNJets()>0){
+        if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
           fHistoTrueEtaJetMotherInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),  tempTruePi0CandWeight);
-          fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-          fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+          fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+          fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
           Double_t RJetPi0Cand;
           Int_t counter = 0;
-          for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+          for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
             Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
             Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
             if(DeltaPhi > M_PI) {
               DeltaPhi = 2*M_PI - DeltaPhi;
             }
             RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-            if(fConvJetReader->Get_Jet_Radius() > 0 ){
-              if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+            if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+              if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                 counter ++;
                 fHistoTrueEtaInJetMotherInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), tempTruePi0CandWeight);
                 fHistoMotherEtainJetPtY[fiCut]->Fill(Pi0Candidate->Pt(),Pi0Candidate->Rapidity()-((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift(), tempTruePi0CandWeight);
@@ -5659,20 +5661,20 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidatesAOD(AliAODConversionMot
       if (isTruePi0) {
         fHistoTrueSecondaryPi0InvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
         if(fDoJetAnalysis){
-          if(fConvJetReader->GetTrueNJets()>0){
+          if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
             fHistoTrueSecondaryPi0InvJetMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
-            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
             Double_t RJetPi0Cand;
-              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                 Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                 Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                 if(DeltaPhi > M_PI) {
                   DeltaPhi = 2*M_PI - DeltaPhi;
                 }
                 RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                     fHistoTrueSecondaryPi0InvinJetMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
                   }
                 }
@@ -5687,20 +5689,20 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidatesAOD(AliAODConversionMot
           fHistoTrueSecondaryPi0FromK0sInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
           if (fDoMesonQA > 0 && fDoMesonQA < 3 && fIsMC < 2 )fHistoTrueK0sWithPi0DaughterMCPt[fiCut]->Fill(static_cast<AliAODMCParticle*>(AODMCTrackArray->At(secMotherLabel))->Pt(), tempTruePi0CandWeight);
           if(fDoJetAnalysis){
-            if(fConvJetReader->GetTrueNJets()>0){
+            if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
               fHistoTrueSecondaryPi0FromK0sJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
-              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
               Double_t RJetPi0Cand;
-                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                   Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                   Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                   if(DeltaPhi > M_PI) {
                     DeltaPhi = 2*M_PI - DeltaPhi;
                   }
                   RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                  if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                  if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                       fHistoTrueSecondaryPi0FromK0sinJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
                     }
                   }
@@ -5714,20 +5716,20 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidatesAOD(AliAODConversionMot
           fHistoTrueSecondaryPi0FromK0lInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
           if (fDoMesonQA > 0 && fDoMesonQA < 3 && fIsMC < 2 )fHistoTrueK0lWithPi0DaughterMCPt[fiCut]->Fill(static_cast<AliAODMCParticle*>(AODMCTrackArray->At(secMotherLabel))->Pt(), tempTruePi0CandWeight);
           if(fDoJetAnalysis){
-            if(fConvJetReader->GetTrueNJets()>0){
+            if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
               fHistoTrueSecondaryPi0FromK0lJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
-              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
               Double_t RJetPi0Cand;
-                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                   Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                   Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                   if(DeltaPhi > M_PI) {
                     DeltaPhi = 2*M_PI - DeltaPhi;
                   }
                   RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                  if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                  if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                       fHistoTrueSecondaryPi0FromK0linJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
                     }
                   }
@@ -5745,20 +5747,20 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidatesAOD(AliAODConversionMot
           fHistoTrueSecondaryPi0FromLambdaInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
           if (fDoMesonQA > 0 && fDoMesonQA < 3 && fIsMC < 2)fHistoTrueLambdaWithPi0DaughterMCPt[fiCut]->Fill(static_cast<AliAODMCParticle*>(AODMCTrackArray->At(secMotherLabel))->Pt(), tempTruePi0CandWeight);
           if(fDoJetAnalysis){
-            if(fConvJetReader->GetTrueNJets()>0){
+            if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
               fHistoTrueSecondaryPi0FromLambdaJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
-              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
               Double_t RJetPi0Cand;
-                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                   Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                   Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                   if(DeltaPhi > M_PI) {
                     DeltaPhi = 2*M_PI - DeltaPhi;
                   }
                   RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                  if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                  if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                       fHistoTrueSecondaryPi0FromLambdainJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weightedSec* tempTruePi0CandWeight);
                     }
                   }
@@ -5783,24 +5785,24 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidatesAOD(AliAODConversionMot
         fProfileTruePrimaryPi0WeightsInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weighted* tempTruePi0CandWeight);
         if (CheckVectorForDoubleCount(fVectorDoubleCountTruePi0s,gamma0MotherLabel)) fHistoDoubleCountTruePi0InvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), weighted*tempTruePi0CandWeight);
         if(fDoJetAnalysis){
-          if(fConvJetReader->GetTrueNJets()>0){
+          if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
             fHistoTruePrimaryPi0JetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weighted* tempTruePi0CandWeight);
-            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
-            fTrueVectorJetPt  = fConvJetReader->GetTrueVectorJetPt();
-            fTrueVectorJetPx  = fConvJetReader->GetTrueVectorJetPx();
-            fTrueVectorJetPy  = fConvJetReader->GetTrueVectorJetPy();
-            fTrueVectorJetPz  = fConvJetReader->GetTrueVectorJetPz();
+            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
+            fTrueVectorJetPt  = fConvJetReader->GetTrueVectorJetPt(fTrainConfig);
+            fTrueVectorJetPx  = fConvJetReader->GetTrueVectorJetPx(fTrainConfig);
+            fTrueVectorJetPy  = fConvJetReader->GetTrueVectorJetPy(fTrainConfig);
+            fTrueVectorJetPz  = fConvJetReader->GetTrueVectorJetPz(fTrainConfig);
             Double_t RJetPi0Cand;
-              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                 Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                 Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                 if(DeltaPhi > M_PI) {
                   DeltaPhi = 2*M_PI - DeltaPhi;
                 }
                 RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                     fHistoTruePrimaryPi0inJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weighted* tempTruePi0CandWeight);
                     Double_t dotproduct = fTrueVectorJetPx.at(i)*Pi0Candidate->Px() + fTrueVectorJetPy.at(i)*Pi0Candidate->Py() + fTrueVectorJetPz.at(i)*Pi0Candidate->Pz();
                     Double_t magn = pow(fTrueVectorJetPx.at(i),2) + pow(fTrueVectorJetPy.at(i),2) + pow(fTrueVectorJetPz.at(i),2);
@@ -5823,24 +5825,24 @@ void AliAnalysisTaskGammaCalo::ProcessTrueMesonCandidatesAOD(AliAODConversionMot
         fProfileTruePrimaryEtaWeightsInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weighted* tempTruePi0CandWeight);
         if (CheckVectorForDoubleCount(fVectorDoubleCountTrueEtas,gamma0MotherLabel)) fHistoDoubleCountTrueEtaInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(), weighted*tempTruePi0CandWeight);
         if(fDoJetAnalysis){
-          if(fConvJetReader->GetTrueNJets()>0){
+          if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
             fHistoTruePrimaryEtaJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weighted* tempTruePi0CandWeight);
-            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
-            fTrueVectorJetPt  = fConvJetReader->GetTrueVectorJetPt();
-            fTrueVectorJetPx  = fConvJetReader->GetTrueVectorJetPx();
-            fTrueVectorJetPy  = fConvJetReader->GetTrueVectorJetPy();
-            fTrueVectorJetPz  = fConvJetReader->GetTrueVectorJetPz();
+            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
+            fTrueVectorJetPt  = fConvJetReader->GetTrueVectorJetPt(fTrainConfig);
+            fTrueVectorJetPx  = fConvJetReader->GetTrueVectorJetPx(fTrainConfig);
+            fTrueVectorJetPy  = fConvJetReader->GetTrueVectorJetPy(fTrainConfig);
+            fTrueVectorJetPz  = fConvJetReader->GetTrueVectorJetPz(fTrainConfig);
             Double_t RJetPi0Cand;
-              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                 Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                 Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                 if(DeltaPhi > M_PI) {
                   DeltaPhi = 2*M_PI - DeltaPhi;
                 }
                 RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                     fHistoTruePrimaryEtainJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),Pi0Candidate->Pt(),weighted* tempTruePi0CandWeight);
                     Double_t dotproduct = fTrueVectorJetPx.at(i)*Pi0Candidate->Px() + fTrueVectorJetPy.at(i)*Pi0Candidate->Py() + fTrueVectorJetPz.at(i)*Pi0Candidate->Pz();
                     Double_t magn = pow(fTrueVectorJetPx.at(i),2) + pow(fTrueVectorJetPy.at(i),2) + pow(fTrueVectorJetPz.at(i),2);
@@ -6051,7 +6053,7 @@ void AliAnalysisTaskGammaCalo::CalculateBackground(){
                     }
                     fHistoMotherBackInvMassPt[fiCut]->Fill(backgroundCandidate->M(),backgroundCandidate->Pt(), tempBGCandidateWeight);
                     if(fDoJetAnalysis){
-                      if(fConvJetReader->GetNJets() > 0){
+                      if(fConvJetReader->GetNJets(fTrainConfig) > 0){
                         fHistoMotherBackJetInvMassPt[fiCut]->Fill(backgroundCandidate->M(),backgroundCandidate->Pt(), tempBGCandidateWeight);
                       }
                     }
@@ -6105,7 +6107,7 @@ void AliAnalysisTaskGammaCalo::CalculateBackground(){
               }
               fHistoMotherBackInvMassPt[fiCut]->Fill(backgroundCandidate->M(),backgroundCandidate->Pt(), tempBGCandidateWeight);
               if(fDoJetAnalysis){
-                if(fConvJetReader->GetNJets() > 0){
+                if(fConvJetReader->GetNJets(fTrainConfig) > 0){
                   fHistoMotherBackJetInvMassPt[fiCut]->Fill(backgroundCandidate->M(),backgroundCandidate->Pt(), tempBGCandidateWeight);
                 }
               }
@@ -6151,7 +6153,7 @@ void AliAnalysisTaskGammaCalo::RotateParticle(AliAODConversionPhoton *gamma){
 //________________________________________________________________________
 void AliAnalysisTaskGammaCalo::UpdateEventByEventData(){
   //see header file for documentation
-  if(fDoJetAnalysis && fConvJetReader->GetNJets() == 0) return;
+  if(fDoJetAnalysis && fConvJetReader->GetNJets(fTrainConfig) == 0) return;
   if(fClusterCandidates->GetEntries() >0 ){
     if( ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->DoSectorMixing() ){
       fBGHandler[fiCut]->AddEvent(fClusterCandidates,fInputEvent->GetPrimaryVertex()->GetX(),fInputEvent->GetPrimaryVertex()->GetY(),fV0Reader->GetPtMaxSector(),fClusterCandidates->GetEntries(),fEventPlaneAngle);

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.h
@@ -121,6 +121,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     void SetTrackMatcherRunningMode(Int_t mode){fTrackMatcherRunningMode = mode;}
 
     void SetSoftAnalysis(Bool_t DoSoft)  {fDoSoftAnalysis = DoSoft;}
+    void SetTrainConfig(Int_t Config)    {fTrainConfig = Config;}
 
   protected:
     AliV0ReaderV1*        fV0Reader;                                            // basic photon Selection Task
@@ -151,6 +152,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     TList**               fJetHistograms;                                       // Jet Histograms
     TList**               fTrueJetHistograms;                                   // True Jet Histograms
     Int_t                 fJetSector;                                           // Sector of the detector with the maximum pt jet
+    Int_t                 fTrainConfig;                                         // TrainConfig used in AddTask_pp
 
     //histograms for mesons reconstructed quantities
     TH2F**                fHistoMotherInvMassPt;                                //! array of histogram with signal + BG for same event photon pairs, inv Mass, pt
@@ -498,7 +500,7 @@ class AliAnalysisTaskGammaCalo : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaCalo(const AliAnalysisTaskGammaCalo&);                  // Prevent copy-construction
     AliAnalysisTaskGammaCalo &operator=(const AliAnalysisTaskGammaCalo&);       // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaCalo, 57);
+    ClassDef(AliAnalysisTaskGammaCalo, 58);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCaloIso.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCaloIso.cxx
@@ -94,6 +94,7 @@ AliAnalysisTaskGammaCaloIso::AliAnalysisTaskGammaCaloIso(): AliAnalysisTaskSE(),
   fDoJetQA(kFALSE),
   fJetHistograms(NULL),
   fTrueJetHistograms(NULL),
+  fTrainConfig(0),
   fHistoMotherInvMassPt(NULL),
   fSparseMotherInvMassPtZM(NULL),
   fHistoMotherBackInvMassPt(NULL),
@@ -458,6 +459,7 @@ AliAnalysisTaskGammaCaloIso::AliAnalysisTaskGammaCaloIso(const char *name):
   fDoJetQA(kFALSE),
   fJetHistograms(NULL),
   fTrueJetHistograms(NULL),
+  fTrainConfig(0),
   fHistoMotherInvMassPt(NULL),
   fSparseMotherInvMassPtZM(NULL),
   fHistoMotherBackInvMassPt(NULL),
@@ -3075,7 +3077,7 @@ void AliAnalysisTaskGammaCaloIso::UserExec(Option_t *)
       if(((AliConvEventCuts*)fEventCutArray->At(iCut))->GetUseSphericity()!=0){
         if(fV0Reader->GetSphericity() != -1 && fV0Reader->GetSphericity() != 0){
           if(fDoJetAnalysis && !fDoSoftAnalysis){
-            if(fConvJetReader->GetNJets() > 0){
+            if(fConvJetReader->GetNJets(fTrainConfig) > 0){
                 fHistoNEvents[iCut]->Fill(eventQuality, fWeightJetJetMC); // Should be 0 here
                 if (fIsMC>1) fHistoNEventsWOWeight[iCut]->Fill(eventQuality); // Should be 0 here
                 fHistoNGoodESDTracks[iCut]->Fill(fV0Reader->GetNumberOfPrimaryTracks(), fWeightJetJetMC);
@@ -3084,7 +3086,7 @@ void AliAnalysisTaskGammaCaloIso::UserExec(Option_t *)
                 fHistoEventSphericityvsNtracks[iCut]->Fill(fV0Reader->GetSphericity(), fV0Reader->GetNumberOfPrimaryTracks(), fWeightJetJetMC);
             }
           }else if(fDoJetAnalysis && fDoSoftAnalysis){
-            if(fConvJetReader->GetNJets() < 1){  
+            if(fConvJetReader->GetNJets(fTrainConfig) < 1){
                 fHistoNEvents[iCut]->Fill(eventQuality, fWeightJetJetMC); // Should be 0 here
                 if (fIsMC>1) fHistoNEventsWOWeight[iCut]->Fill(eventQuality); // Should be 0 here
                 fHistoNGoodESDTracks[iCut]->Fill(fV0Reader->GetNumberOfPrimaryTracks(), fWeightJetJetMC);
@@ -3607,30 +3609,30 @@ void AliAnalysisTaskGammaCaloIso::ProcessClusters()
 //________________________________________________________________________
 void AliAnalysisTaskGammaCaloIso::ProcessJets()
 {
-  fHistoNJets[fiCut]->Fill(fConvJetReader->GetNJets());
-  if(fConvJetReader->GetNJets()>0){
-    fVectorJetPt  = fConvJetReader->GetVectorJetPt();
-    fVectorJetPx  = fConvJetReader->GetVectorJetPx();
-    fVectorJetPy  = fConvJetReader->GetVectorJetPy();
-    fVectorJetPz  = fConvJetReader->GetVectorJetPz();
-    fVectorJetEta = fConvJetReader->GetVectorJetEta();
-    fVectorJetPhi = fConvJetReader->GetVectorJetPhi();
-    fVectorJetArea = fConvJetReader->GetVectorJetR();
-    if(fIsMC > 0 && fConvJetReader->GetTrueNJets()>0){
-      fTrueVectorJetPt = fConvJetReader->GetTrueVectorJetPt();
-      fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-      fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+  fHistoNJets[fiCut]->Fill(fConvJetReader->GetNJets(fTrainConfig));
+  if(fConvJetReader->GetNJets(fTrainConfig)>0){
+    fVectorJetPt  = fConvJetReader->GetVectorJetPt(fTrainConfig);
+    fVectorJetPx  = fConvJetReader->GetVectorJetPx(fTrainConfig);
+    fVectorJetPy  = fConvJetReader->GetVectorJetPy(fTrainConfig);
+    fVectorJetPz  = fConvJetReader->GetVectorJetPz(fTrainConfig);
+    fVectorJetEta = fConvJetReader->GetVectorJetEta(fTrainConfig);
+    fVectorJetPhi = fConvJetReader->GetVectorJetPhi(fTrainConfig);
+    fVectorJetArea = fConvJetReader->GetVectorJetArea(fTrainConfig);
+    if(fIsMC > 0 && fConvJetReader->GetTrueNJets(fTrainConfig)>0){
+      fTrueVectorJetPt = fConvJetReader->GetTrueVectorJetPt(fTrainConfig);
+      fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+      fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
     }
-    if(fVectorJetPt.size() == fConvJetReader->GetNJets() && fVectorJetEta.size() == fConvJetReader->GetNJets() && fVectorJetPhi.size() == fConvJetReader->GetNJets() && fVectorJetArea.size() == fConvJetReader->GetNJets()){
-      for(Int_t i=0; i<fConvJetReader->GetNJets(); i++){
+    if(fVectorJetPt.size() == fConvJetReader->GetNJets(fTrainConfig) && fVectorJetEta.size() == fConvJetReader->GetNJets(fTrainConfig) && fVectorJetPhi.size() == fConvJetReader->GetNJets(fTrainConfig) && fVectorJetArea.size() == fConvJetReader->GetNJets(fTrainConfig)){
+      for(Int_t i=0; i<fConvJetReader->GetNJets(fTrainConfig); i++){
         fHistoPtJet[fiCut]->Fill(fVectorJetPt.at(i));
         fHistoJetEta[fiCut]->Fill(fVectorJetEta.at(i));
         fHistoJetPhi[fiCut]->Fill(fVectorJetPhi.at(i));
         fHistoJetArea[fiCut]->Fill(fVectorJetArea.at(i));
-        if(fIsMC > 0 && fConvJetReader->GetNJets()>0 && fConvJetReader->GetTrueNJets()>0){
+        if(fIsMC > 0 && fConvJetReader->GetNJets(fTrainConfig)>0 && fConvJetReader->GetTrueNJets(fTrainConfig)>0){
           Double_t min = 100;
           Int_t match = 0;
-          for(Int_t j = 0; j<fConvJetReader->GetTrueNJets(); j++){
+          for(Int_t j = 0; j<fConvJetReader->GetTrueNJets(fTrainConfig); j++){
             Double_t R_jetjet;
             Double_t DeltaEta = fVectorJetEta.at(i)-fTrueVectorJetEta.at(j);
             Double_t DeltaPhi = abs(fVectorJetPhi.at(i)-fTrueVectorJetPhi.at(j));
@@ -3655,7 +3657,7 @@ void AliAnalysisTaskGammaCaloIso::ProcessJets()
     fVectorJetEta.clear();
     fVectorJetPhi.clear();
     fVectorJetArea.clear();
-    if(fIsMC > 0 && fConvJetReader->GetTrueNJets()>0){
+    if(fIsMC > 0 && fConvJetReader->GetTrueNJets(fTrainConfig)>0){
       fTrueVectorJetPt.clear();
       fTrueVectorJetEta.clear();
       fTrueVectorJetPhi.clear();
@@ -4145,20 +4147,20 @@ void AliAnalysisTaskGammaCaloIso::ProcessAODMCParticles()
               fHistoMCPi0InAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc
               if(fIsMC > 1) fHistoMCPi0WOEvtWeightInAccPt[fiCut]->Fill(particle->Pt()); // MC Pi0 with gamma in acc
               if(fDoJetAnalysis){
-                if(fConvJetReader->GetTrueNJets()>0){
+                if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
                   fHistoMCPi0JetInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in jet event
-                  fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-                  fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+                  fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+                  fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
                   Double_t RJetPi0Cand;
-                  for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                  for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                     Double_t DeltaEta = fTrueVectorJetEta.at(i)-particle->Eta();
                     Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-particle->Phi());
                     if(DeltaPhi > M_PI) {
                       DeltaPhi = 2*M_PI - DeltaPhi;
                     }
                     RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                    if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                      if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                    if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                      if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                         fHistoMCPi0inJetInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in a jet
                       }
                     }
@@ -4171,20 +4173,20 @@ void AliAnalysisTaskGammaCaloIso::ProcessAODMCParticles()
               fHistoMCEtaInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Eta with gamma in acc
               if(fIsMC > 1) fHistoMCEtaWOEvtWeightInAccPt[fiCut]->Fill(particle->Pt()); // MC Eta with gamma in acc
               if(fDoJetAnalysis){
-                if(fConvJetReader->GetTrueNJets()>0){
+                if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
                   fHistoMCEtaJetInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in jet event
-                  fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-                  fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+                  fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+                  fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
                   Double_t RJetPi0Cand;
-                  for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                  for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                     Double_t DeltaEta = fTrueVectorJetEta.at(i)-particle->Eta();
                     Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-particle->Phi());
                     if(DeltaPhi > M_PI) {
                       DeltaPhi = 2*M_PI - DeltaPhi;
                     }
                     RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                    if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                      if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                    if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                      if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                         fHistoMCEtainJetInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in a jet
                       }
                     }
@@ -4401,20 +4403,20 @@ void AliAnalysisTaskGammaCaloIso::ProcessMCParticles()
               fHistoMCPi0InAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc
               if(fIsMC > 1) fHistoMCPi0WOEvtWeightInAccPt[fiCut]->Fill(particle->Pt()); // MC Pi0 with gamma in acc
               if(fDoJetAnalysis){
-                if(fConvJetReader->GetTrueNJets()>0){
+                if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
                   fHistoMCPi0JetInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in jet event
-                  fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-                  fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+                  fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+                  fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
                   Double_t RJetPi0Cand;
-                  for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                  for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                     Double_t DeltaEta = fTrueVectorJetEta.at(i)-particle->Eta();
                     Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-particle->Phi());
                     if(DeltaPhi > M_PI) {
                       DeltaPhi = 2*M_PI - DeltaPhi;
                     }
                     RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                    if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                      if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                    if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                      if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                         fHistoMCPi0inJetInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in a jet
                       }
                     }
@@ -4427,20 +4429,20 @@ void AliAnalysisTaskGammaCaloIso::ProcessMCParticles()
               fHistoMCEtaInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Eta with gamma in acc
               if(fIsMC > 1) fHistoMCEtaWOEvtWeightInAccPt[fiCut]->Fill(particle->Pt()); // MC Eta with gamma in acc
               if(fDoJetAnalysis){
-                if(fConvJetReader->GetTrueNJets()>0){
+                if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
                   fHistoMCEtaJetInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in jet event
-                  fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-                  fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+                  fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+                  fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
                   Double_t RJetPi0Cand;
-                  for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                  for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                     Double_t DeltaEta = fTrueVectorJetEta.at(i)-particle->Eta();
                     Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-particle->Phi());
                     if(DeltaPhi > M_PI) {
                       DeltaPhi = 2*M_PI - DeltaPhi;
                     }
                     RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                    if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                      if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                    if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                      if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                         fHistoMCEtainJetInAccPt[fiCut]->Fill(particle->Pt(),weighted* tempParticleWeight); // MC Pi0 with gamma in acc in a jet
                       }
                     }
@@ -4557,18 +4559,18 @@ void AliAnalysisTaskGammaCaloIso::CalculatePi0CandidatesIsolation(){
           if(fLocalDebugFlag == 1) DebugMethodPrint1(pi0cand,gamma0,gamma1);
           fHistoMotherInvMassPt[fiCut]->Fill(pi0cand->M(),gamma0->Pt(), tempPi0CandWeight);
           if(fDoJetAnalysis){
-            if(fConvJetReader->GetNJets()>0){
-              fVectorJetPt = fConvJetReader->GetVectorJetPt();
-              fVectorJetPx = fConvJetReader->GetVectorJetPx();
-              fVectorJetPy = fConvJetReader->GetVectorJetPy();
-              fVectorJetPz = fConvJetReader->GetVectorJetPz();
-              fVectorJetEta = fConvJetReader->GetVectorJetEta();
-              fVectorJetPhi = fConvJetReader->GetVectorJetPhi();
+            if(fConvJetReader->GetNJets(fTrainConfig)>0){
+              fVectorJetPt = fConvJetReader->GetVectorJetPt(fTrainConfig);
+              fVectorJetPx = fConvJetReader->GetVectorJetPx(fTrainConfig);
+              fVectorJetPy = fConvJetReader->GetVectorJetPy(fTrainConfig);
+              fVectorJetPz = fConvJetReader->GetVectorJetPz(fTrainConfig);
+              fVectorJetEta = fConvJetReader->GetVectorJetEta(fTrainConfig);
+              fVectorJetPhi = fConvJetReader->GetVectorJetPhi(fTrainConfig);
               fHistoJetMotherInvMassPt[fiCut]->Fill(pi0cand->M(),gamma0->Pt(), tempPi0CandWeight);
               Double_t RJetPi0Cand = 0;
-              if(fVectorJetPt.size() == fConvJetReader->GetNJets() && fVectorJetEta.size() == fConvJetReader->GetNJets() && fVectorJetPhi.size() == fConvJetReader->GetNJets()){
+              if(fVectorJetPt.size() == fConvJetReader->GetNJets(fTrainConfig) && fVectorJetEta.size() == fConvJetReader->GetNJets(fTrainConfig) && fVectorJetPhi.size() == fConvJetReader->GetNJets(fTrainConfig)){
                 Int_t counter = 0;
-                for(Int_t i=0; i<fConvJetReader->GetNJets(); i++){
+                for(Int_t i=0; i<fConvJetReader->GetNJets(fTrainConfig); i++){
                   Double_t DeltaEta = fVectorJetEta.at(i)-pi0cand->Eta();
                   Double_t DeltaPhi = abs(fVectorJetPhi.at(i)-pi0cand->Phi());
                   if(DeltaPhi > M_PI) {
@@ -4577,8 +4579,8 @@ void AliAnalysisTaskGammaCaloIso::CalculatePi0CandidatesIsolation(){
                   RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
                   fHistoRJetPi0Cand[fiCut]->Fill(RJetPi0Cand,gamma0->Pt(), tempPi0CandWeight);
                   fHistoEtaPhiJetPi0Cand[fiCut]->Fill(DeltaPhi,DeltaEta, tempPi0CandWeight);
-                  if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                  if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                       counter ++;
                       fHistoPi0InJetMotherInvMassPt[fiCut]->Fill(pi0cand->M(),gamma0->Pt(), tempPi0CandWeight);
                       fHistoEtaPhiJetWithPi0Cand[fiCut]->Fill(DeltaPhi, DeltaEta, tempPi0CandWeight);
@@ -4590,13 +4592,13 @@ void AliAnalysisTaskGammaCaloIso::CalculatePi0CandidatesIsolation(){
                       fHistoJetFragmFunc[fiCut]->Fill(z,fVectorJetPt.at(i));
 
                       if(fDoJetQA){
-                        if(fIsMC > 0 && fConvJetReader->GetTrueNJets()>0){
-                          fTrueVectorJetPt = fConvJetReader->GetTrueVectorJetPt();
-                          fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-                          fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+                        if(fIsMC > 0 && fConvJetReader->GetTrueNJets(fTrainConfig)>0){
+                          fTrueVectorJetPt = fConvJetReader->GetTrueVectorJetPt(fTrainConfig);
+                          fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+                          fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
                           Double_t min = 100;
                           Int_t match = 0;
-                          for(Int_t j = 0; j<fConvJetReader->GetTrueNJets(); j++){
+                          for(Int_t j = 0; j<fConvJetReader->GetTrueNJets(fTrainConfig); j++){
                             Double_t R_jetjet;
                             DeltaEta = fVectorJetEta.at(i)-fTrueVectorJetEta.at(j);
                             DeltaPhi = abs(fVectorJetPhi.at(i)-fTrueVectorJetPhi.at(j));
@@ -5064,21 +5066,21 @@ void AliAnalysisTaskGammaCaloIso::ProcessTrueMesonCandidates(AliAODConversionMot
       fHistoTruePi0InvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),  tempTruePi0CandWeight);
       if (CheckVectorForDoubleCount(fVectorDoubleCountTruePi0s,gamma0MotherLabel)) fHistoDoubleCountTruePi0InvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(), tempTruePi0CandWeight);
       if(fDoJetAnalysis){
-        if(fConvJetReader->GetTrueNJets()>0){
+        if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
           fHistoTruePi0JetMotherInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),  tempTruePi0CandWeight);
-          fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-          fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+          fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+          fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
           Double_t RJetPi0Cand;
           Int_t counter = 0;
-          for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+          for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
             Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
             Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
             if(DeltaPhi > M_PI) {
               DeltaPhi = 2*M_PI - DeltaPhi;
             }
             RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-            if(fConvJetReader->Get_Jet_Radius() > 0 ){
-              if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+            if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+              if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                 counter ++;
                 fHistoTruePi0InJetMotherInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(), tempTruePi0CandWeight);
               }
@@ -5101,21 +5103,21 @@ void AliAnalysisTaskGammaCaloIso::ProcessTrueMesonCandidates(AliAODConversionMot
     if (isTrueEta){
       fHistoTrueEtaInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),  tempTruePi0CandWeight);
       if(fDoJetAnalysis){
-        if(fConvJetReader->GetTrueNJets()>0){
+        if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
           fHistoTrueEtaJetMotherInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),  tempTruePi0CandWeight);
           Double_t RJetEtaCand;
-          fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-          fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+          fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+          fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
           Int_t counter = 0;
-          for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+          for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
             Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
             Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
             if(DeltaPhi > M_PI) {
               DeltaPhi = 2*M_PI - DeltaPhi;
             }
             RJetEtaCand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-            if(fConvJetReader->Get_Jet_Radius() > 0 ){
-              if(RJetEtaCand < fConvJetReader->Get_Jet_Radius()){
+            if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+              if(RJetEtaCand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                 counter ++;
                 fHistoTrueEtaInJetMotherInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(), tempTruePi0CandWeight);
               }
@@ -5277,20 +5279,20 @@ void AliAnalysisTaskGammaCaloIso::ProcessTrueMesonCandidates(AliAODConversionMot
       if (isTruePi0) {
         fHistoTrueSecondaryPi0InvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
         if(fDoJetAnalysis){
-          if(fConvJetReader->GetTrueNJets()>0){
+          if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
             fHistoTrueSecondaryPi0InvJetMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
-            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
             Double_t RJetPi0Cand;
-              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                 Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                 Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                 if(DeltaPhi > M_PI) {
                   DeltaPhi = 2*M_PI - DeltaPhi;
                 }
                 RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                     fHistoTrueSecondaryPi0InvinJetMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
                   }
                 }
@@ -5309,20 +5311,20 @@ void AliAnalysisTaskGammaCaloIso::ProcessTrueMesonCandidates(AliAODConversionMot
             if (!isSameConvertedGamma)tTrueInvMassROpenABPtFlag[fiCut]->Fill();
           }
           if(fDoJetAnalysis){
-            if(fConvJetReader->GetTrueNJets()>0){
+            if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
               fHistoTrueSecondaryPi0FromK0sJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
-              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
               Double_t RJetPi0Cand;
-                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                   Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                   Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                   if(DeltaPhi > M_PI) {
                     DeltaPhi = 2*M_PI - DeltaPhi;
                   }
                   RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                  if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                  if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                       fHistoTrueSecondaryPi0FromK0sinJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
                     }
                   }
@@ -5335,20 +5337,20 @@ void AliAnalysisTaskGammaCaloIso::ProcessTrueMesonCandidates(AliAODConversionMot
           fHistoTrueSecondaryPi0FromK0lInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
           if (fDoMesonQA > 0 && fDoMesonQA < 3 && fIsMC < 2)fHistoTrueK0lWithPi0DaughterMCPt[fiCut]->Fill(fMCEvent->Particle(secMotherLabel)->Pt(), tempTruePi0CandWeight);
           if(fDoJetAnalysis){
-            if(fConvJetReader->GetTrueNJets()>0){
+            if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
               fHistoTrueSecondaryPi0FromK0lJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
-              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
               Double_t RJetPi0Cand;
-                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                   Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                   Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                   if(DeltaPhi > M_PI) {
                     DeltaPhi = 2*M_PI - DeltaPhi;
                   }
                   RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                  if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                  if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                       fHistoTrueSecondaryPi0FromK0linJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
                     }
                   }
@@ -5373,20 +5375,20 @@ void AliAnalysisTaskGammaCaloIso::ProcessTrueMesonCandidates(AliAODConversionMot
             if (!isSameConvertedGamma)tTrueInvMassROpenABPtFlag[fiCut]->Fill();
           }
           if(fDoJetAnalysis){
-            if(fConvJetReader->GetTrueNJets()>0){
+            if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
               fHistoTrueSecondaryPi0FromLambdaJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
-              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
               Double_t RJetPi0Cand;
-                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                   Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                   Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                   if(DeltaPhi > M_PI) {
                     DeltaPhi = 2*M_PI - DeltaPhi;
                   }
                   RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                  if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                  if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                       fHistoTrueSecondaryPi0FromLambdainJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
                     }
                   }
@@ -5426,24 +5428,24 @@ void AliAnalysisTaskGammaCaloIso::ProcessTrueMesonCandidates(AliAODConversionMot
         fHistoTruePrimaryPi0W0WeightingInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(), tempTruePi0CandWeight);
         fProfileTruePrimaryPi0WeightsInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weighted* tempTruePi0CandWeight);
         if(fDoJetAnalysis){
-          if(fConvJetReader->GetTrueNJets()>0){
+          if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
             fHistoTruePrimaryPi0JetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weighted* tempTruePi0CandWeight);
-            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
-            fTrueVectorJetPt  = fConvJetReader->GetTrueVectorJetPt();
-            fTrueVectorJetPx  = fConvJetReader->GetTrueVectorJetPx();
-            fTrueVectorJetPy  = fConvJetReader->GetTrueVectorJetPy();
-            fTrueVectorJetPz  = fConvJetReader->GetTrueVectorJetPz();
+            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
+            fTrueVectorJetPt  = fConvJetReader->GetTrueVectorJetPt(fTrainConfig);
+            fTrueVectorJetPx  = fConvJetReader->GetTrueVectorJetPx(fTrainConfig);
+            fTrueVectorJetPy  = fConvJetReader->GetTrueVectorJetPy(fTrainConfig);
+            fTrueVectorJetPz  = fConvJetReader->GetTrueVectorJetPz(fTrainConfig);
             Double_t RJetPi0Cand;
-              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                 Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                 Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                 if(DeltaPhi > M_PI) {
                   DeltaPhi = 2*M_PI - DeltaPhi;
                 }
                 RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                     fHistoTruePrimaryPi0inJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weighted* tempTruePi0CandWeight);
                     Double_t dotproduct = fTrueVectorJetPx.at(i)*Pi0Candidate->Px() + fTrueVectorJetPy.at(i)*Pi0Candidate->Py() + fTrueVectorJetPz.at(i)*Pi0Candidate->Pz();
                     Double_t magn = pow(fTrueVectorJetPx.at(i),2) + pow(fTrueVectorJetPy.at(i),2) + pow(fTrueVectorJetPz.at(i),2);
@@ -5471,24 +5473,24 @@ void AliAnalysisTaskGammaCaloIso::ProcessTrueMesonCandidates(AliAODConversionMot
         fProfileTruePrimaryEtaWeightsInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weighted* tempTruePi0CandWeight);
         if (CheckVectorForDoubleCount(fVectorDoubleCountTrueEtas,gamma0MotherLabel)) fHistoDoubleCountTrueEtaInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(), weighted*tempTruePi0CandWeight);
         if(fDoJetAnalysis){
-          if(fConvJetReader->GetTrueNJets()>0){
+          if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
             fHistoTruePrimaryEtaJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weighted* tempTruePi0CandWeight);
-            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
-            fTrueVectorJetPt  = fConvJetReader->GetTrueVectorJetPt();
-            fTrueVectorJetPx  = fConvJetReader->GetTrueVectorJetPx();
-            fTrueVectorJetPy  = fConvJetReader->GetTrueVectorJetPy();
-            fTrueVectorJetPz  = fConvJetReader->GetTrueVectorJetPz();
+            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
+            fTrueVectorJetPt  = fConvJetReader->GetTrueVectorJetPt(fTrainConfig);
+            fTrueVectorJetPx  = fConvJetReader->GetTrueVectorJetPx(fTrainConfig);
+            fTrueVectorJetPy  = fConvJetReader->GetTrueVectorJetPy(fTrainConfig);
+            fTrueVectorJetPz  = fConvJetReader->GetTrueVectorJetPz(fTrainConfig);
             Double_t RJetPi0Cand;
-              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                 Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                 Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                 if(DeltaPhi > M_PI) {
                   DeltaPhi = 2*M_PI - DeltaPhi;
                 }
                 RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                     fHistoTruePrimaryEtainJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weighted* tempTruePi0CandWeight);
                     Double_t dotproduct = fTrueVectorJetPx.at(i)*Pi0Candidate->Px() + fTrueVectorJetPy.at(i)*Pi0Candidate->Py() + fTrueVectorJetPz.at(i)*Pi0Candidate->Pz();
                     Double_t magn = pow(fTrueVectorJetPx.at(i),2) + pow(fTrueVectorJetPy.at(i),2) + pow(fTrueVectorJetPz.at(i),2);
@@ -5645,21 +5647,21 @@ void AliAnalysisTaskGammaCaloIso::ProcessTrueMesonCandidatesAOD(AliAODConversion
       fHistoTruePi0DecayCand[fiCut]->Fill(TrueGammaCandidate0->GetPhotonPt(), tempTruePi0CandWeight);
       fHistoTruePi0DecayCandBinning[fiCut]->Fill(TrueGammaCandidate0->GetPhotonPt(), tempTruePi0CandWeight);
       if(fDoJetAnalysis){
-        if(fConvJetReader->GetTrueNJets()>0){
+        if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
           fHistoTruePi0JetMotherInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),  tempTruePi0CandWeight);
           Double_t RJetPi0Cand;
           Int_t counter = 0;
-          for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
-              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+          for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
+              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
             Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
             Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
             if(DeltaPhi > M_PI) {
               DeltaPhi = 2*M_PI - DeltaPhi;
             }
             RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-            if(fConvJetReader->Get_Jet_Radius() > 0 ){
-              if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+            if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+              if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                 counter ++;
                 fHistoTruePi0InJetMotherInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(), tempTruePi0CandWeight);
               }
@@ -5683,21 +5685,21 @@ void AliAnalysisTaskGammaCaloIso::ProcessTrueMesonCandidatesAOD(AliAODConversion
       fHistoTrueEtaInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(), tempTruePi0CandWeight);
 
       if(fDoJetAnalysis){
-        if(fConvJetReader->GetTrueNJets()>0){
+        if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
           fHistoTrueEtaJetMotherInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),  tempTruePi0CandWeight);
-          fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-          fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+          fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+          fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
           Double_t RJetPi0Cand;
           Int_t counter = 0;
-          for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+          for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
             Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
             Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
             if(DeltaPhi > M_PI) {
               DeltaPhi = 2*M_PI - DeltaPhi;
             }
             RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-            if(fConvJetReader->Get_Jet_Radius() > 0 ){
-              if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+            if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+              if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                 counter ++;
                 fHistoTrueEtaInJetMotherInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(), tempTruePi0CandWeight);
               }
@@ -5855,20 +5857,20 @@ void AliAnalysisTaskGammaCaloIso::ProcessTrueMesonCandidatesAOD(AliAODConversion
       if (isTruePi0) {
         fHistoTrueSecondaryPi0InvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
         if(fDoJetAnalysis){
-          if(fConvJetReader->GetTrueNJets()>0){
+          if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
             fHistoTrueSecondaryPi0InvJetMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
-            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
             Double_t RJetPi0Cand;
-              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                 Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                 Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                 if(DeltaPhi > M_PI) {
                   DeltaPhi = 2*M_PI - DeltaPhi;
                 }
                 RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                     fHistoTrueSecondaryPi0InvinJetMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
                   }
                 }
@@ -5883,20 +5885,20 @@ void AliAnalysisTaskGammaCaloIso::ProcessTrueMesonCandidatesAOD(AliAODConversion
           fHistoTrueSecondaryPi0FromK0sInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
           if (fDoMesonQA > 0 && fDoMesonQA < 3 && fIsMC < 2 )fHistoTrueK0sWithPi0DaughterMCPt[fiCut]->Fill(static_cast<AliAODMCParticle*>(AODMCTrackArray->At(secMotherLabel))->Pt(), tempTruePi0CandWeight);
           if(fDoJetAnalysis){
-            if(fConvJetReader->GetTrueNJets()>0){
+            if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
               fHistoTrueSecondaryPi0FromK0sJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
-              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
               Double_t RJetPi0Cand;
-                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                   Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                   Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                   if(DeltaPhi > M_PI) {
                     DeltaPhi = 2*M_PI - DeltaPhi;
                   }
                   RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                  if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                  if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                       fHistoTrueSecondaryPi0FromK0sinJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
                     }
                   }
@@ -5910,20 +5912,20 @@ void AliAnalysisTaskGammaCaloIso::ProcessTrueMesonCandidatesAOD(AliAODConversion
           fHistoTrueSecondaryPi0FromK0lInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
           if (fDoMesonQA > 0 && fDoMesonQA < 3 && fIsMC < 2 )fHistoTrueK0lWithPi0DaughterMCPt[fiCut]->Fill(static_cast<AliAODMCParticle*>(AODMCTrackArray->At(secMotherLabel))->Pt(), tempTruePi0CandWeight);
           if(fDoJetAnalysis){
-            if(fConvJetReader->GetTrueNJets()>0){
+            if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
               fHistoTrueSecondaryPi0FromK0lJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
-              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
               Double_t RJetPi0Cand;
-                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                   Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                   Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                   if(DeltaPhi > M_PI) {
                     DeltaPhi = 2*M_PI - DeltaPhi;
                   }
                   RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                  if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                  if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                       fHistoTrueSecondaryPi0FromK0linJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
                     }
                   }
@@ -5941,20 +5943,20 @@ void AliAnalysisTaskGammaCaloIso::ProcessTrueMesonCandidatesAOD(AliAODConversion
           fHistoTrueSecondaryPi0FromLambdaInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
           if (fDoMesonQA > 0 && fDoMesonQA < 3 && fIsMC < 2)fHistoTrueLambdaWithPi0DaughterMCPt[fiCut]->Fill(static_cast<AliAODMCParticle*>(AODMCTrackArray->At(secMotherLabel))->Pt(), tempTruePi0CandWeight);
           if(fDoJetAnalysis){
-            if(fConvJetReader->GetTrueNJets()>0){
+            if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
               fHistoTrueSecondaryPi0FromLambdaJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
-              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
+              fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+              fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
               Double_t RJetPi0Cand;
-                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+                for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                   Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                   Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                   if(DeltaPhi > M_PI) {
                     DeltaPhi = 2*M_PI - DeltaPhi;
                   }
                   RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                  if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                  if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                    if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                       fHistoTrueSecondaryPi0FromLambdainJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weightedSec* tempTruePi0CandWeight);
                     }
                   }
@@ -5979,24 +5981,24 @@ void AliAnalysisTaskGammaCaloIso::ProcessTrueMesonCandidatesAOD(AliAODConversion
         fProfileTruePrimaryPi0WeightsInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weighted* tempTruePi0CandWeight);
         if (CheckVectorForDoubleCount(fVectorDoubleCountTruePi0s,gamma0MotherLabel)) fHistoDoubleCountTruePi0InvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(), weighted*tempTruePi0CandWeight);
         if(fDoJetAnalysis){
-          if(fConvJetReader->GetTrueNJets()>0){
+          if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
             fHistoTruePrimaryPi0JetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weighted* tempTruePi0CandWeight);
-            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
-            fTrueVectorJetPt  = fConvJetReader->GetTrueVectorJetPt();
-            fTrueVectorJetPx  = fConvJetReader->GetTrueVectorJetPx();
-            fTrueVectorJetPy  = fConvJetReader->GetTrueVectorJetPy();
-            fTrueVectorJetPz  = fConvJetReader->GetTrueVectorJetPz();
+            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
+            fTrueVectorJetPt  = fConvJetReader->GetTrueVectorJetPt(fTrainConfig);
+            fTrueVectorJetPx  = fConvJetReader->GetTrueVectorJetPx(fTrainConfig);
+            fTrueVectorJetPy  = fConvJetReader->GetTrueVectorJetPy(fTrainConfig);
+            fTrueVectorJetPz  = fConvJetReader->GetTrueVectorJetPz(fTrainConfig);
             Double_t RJetPi0Cand;
-              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                 Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                 Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                 if(DeltaPhi > M_PI) {
                   DeltaPhi = 2*M_PI - DeltaPhi;
                 }
                 RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                     fHistoTruePrimaryPi0inJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weighted* tempTruePi0CandWeight);
                     Double_t dotproduct = fTrueVectorJetPx.at(i)*Pi0Candidate->Px() + fTrueVectorJetPy.at(i)*Pi0Candidate->Py() + fTrueVectorJetPz.at(i)*Pi0Candidate->Pz();
                     Double_t magn = pow(fTrueVectorJetPx.at(i),2) + pow(fTrueVectorJetPy.at(i),2) + pow(fTrueVectorJetPz.at(i),2);
@@ -6019,24 +6021,24 @@ void AliAnalysisTaskGammaCaloIso::ProcessTrueMesonCandidatesAOD(AliAODConversion
         fProfileTruePrimaryEtaWeightsInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weighted* tempTruePi0CandWeight);
         if (CheckVectorForDoubleCount(fVectorDoubleCountTrueEtas,gamma0MotherLabel)) fHistoDoubleCountTrueEtaInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(), weighted*tempTruePi0CandWeight);
         if(fDoJetAnalysis){
-          if(fConvJetReader->GetTrueNJets()>0){
+          if(fConvJetReader->GetTrueNJets(fTrainConfig)>0){
             fHistoTruePrimaryEtaJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weighted* tempTruePi0CandWeight);
-            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta();
-            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi();
-            fTrueVectorJetPt  = fConvJetReader->GetTrueVectorJetPt();
-            fTrueVectorJetPx  = fConvJetReader->GetTrueVectorJetPx();
-            fTrueVectorJetPy  = fConvJetReader->GetTrueVectorJetPy();
-            fTrueVectorJetPz  = fConvJetReader->GetTrueVectorJetPz();
+            fTrueVectorJetEta = fConvJetReader->GetTrueVectorJetEta(fTrainConfig);
+            fTrueVectorJetPhi = fConvJetReader->GetTrueVectorJetPhi(fTrainConfig);
+            fTrueVectorJetPt  = fConvJetReader->GetTrueVectorJetPt(fTrainConfig);
+            fTrueVectorJetPx  = fConvJetReader->GetTrueVectorJetPx(fTrainConfig);
+            fTrueVectorJetPy  = fConvJetReader->GetTrueVectorJetPy(fTrainConfig);
+            fTrueVectorJetPz  = fConvJetReader->GetTrueVectorJetPz(fTrainConfig);
             Double_t RJetPi0Cand;
-              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(); i++){
+              for(Int_t i=0; i<fConvJetReader->GetTrueNJets(fTrainConfig); i++){
                 Double_t DeltaEta = fTrueVectorJetEta.at(i)-Pi0Candidate->Eta();
                 Double_t DeltaPhi = abs(fTrueVectorJetPhi.at(i)-Pi0Candidate->Phi());
                 if(DeltaPhi > M_PI) {
                   DeltaPhi = 2*M_PI - DeltaPhi;
                 }
                 RJetPi0Cand = TMath::Sqrt(pow((DeltaEta),2)+pow((DeltaPhi),2));
-                if(fConvJetReader->Get_Jet_Radius() > 0 ){
-                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius()){
+                if(fConvJetReader->Get_Jet_Radius(fTrainConfig) > 0 ){
+                  if(RJetPi0Cand < fConvJetReader->Get_Jet_Radius(fTrainConfig)){
                     fHistoTruePrimaryEtainJetInvMassPt[fiCut]->Fill(Pi0Candidate->M(),TrueGammaCandidate0->GetPhotonPt(),weighted* tempTruePi0CandWeight);
                     Double_t dotproduct = fTrueVectorJetPx.at(i)*Pi0Candidate->Px() + fTrueVectorJetPy.at(i)*Pi0Candidate->Py() + fTrueVectorJetPz.at(i)*Pi0Candidate->Pz();
                     Double_t magn = pow(fTrueVectorJetPx.at(i),2) + pow(fTrueVectorJetPy.at(i),2) + pow(fTrueVectorJetPz.at(i),2);
@@ -6249,7 +6251,7 @@ void AliAnalysisTaskGammaCaloIso::CalculateBackgroundIsolation(){
                     }
                     fHistoMotherBackInvMassPt[fiCut]->Fill(backgroundCandidate->M(),currentEventGoodV0.Pt(), tempBGCandidateWeight);
                     if(fDoJetAnalysis){
-                      if(fConvJetReader->GetNJets() > 0){
+                      if(fConvJetReader->GetNJets(fTrainConfig) > 0){
                         fHistoMotherBackJetInvMassPt[fiCut]->Fill(backgroundCandidate->M(),backgroundCandidate->Pt(), tempBGCandidateWeight);
                       }
                     }
@@ -6303,7 +6305,7 @@ void AliAnalysisTaskGammaCaloIso::CalculateBackgroundIsolation(){
               }
               fHistoMotherBackInvMassPt[fiCut]->Fill(backgroundCandidate->M(),currentEventGoodV0.Pt(), tempBGCandidateWeight);
               if(fDoJetAnalysis){
-                if(fConvJetReader->GetNJets() > 0){
+                if(fConvJetReader->GetNJets(fTrainConfig) > 0){
                   fHistoMotherBackJetInvMassPt[fiCut]->Fill(backgroundCandidate->M(),backgroundCandidate->Pt(), tempBGCandidateWeight);
                 }
               }

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCaloIso.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCaloIso.h
@@ -122,6 +122,7 @@ class AliAnalysisTaskGammaCaloIso : public AliAnalysisTaskSE {
     void SetTrackMatcherRunningMode(Int_t mode){fTrackMatcherRunningMode = mode;}
 
     void SetSoftAnalysis(Bool_t DoSoft)  {fDoSoftAnalysis = DoSoft;}
+    void SetTrainConfig(Int_t Config)    {fTrainConfig = Config;}
 
   protected:
     AliV0ReaderV1*        fV0Reader;                                            // basic photon Selection Task
@@ -153,6 +154,7 @@ class AliAnalysisTaskGammaCaloIso : public AliAnalysisTaskSE {
     Bool_t                fDoJetQA;                                             // Bool to produce Jet QA Plots
     TList**               fJetHistograms;                                       // Jet Histograms
     TList**               fTrueJetHistograms;                                   // True Jet Histograms
+    Int_t                 fTrainConfig;                                         // TrainConfig specified in AddTask
 
     //histograms for mesons reconstructed quantities
     TH2F**                fHistoMotherInvMassPt;                                //! array of histogram with signal + BG for same event photon pairs, inv Mass, pt
@@ -515,7 +517,7 @@ class AliAnalysisTaskGammaCaloIso : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaCaloIso(const AliAnalysisTaskGammaCaloIso&);                  // Prevent copy-construction
     AliAnalysisTaskGammaCaloIso &operator=(const AliAnalysisTaskGammaCaloIso&);       // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaCaloIso, 55);
+    ClassDef(AliAnalysisTaskGammaCaloIso, 56);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_GammaCaloIso_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCaloIso_pp.C
@@ -379,6 +379,7 @@ void AddTask_GammaCaloIso_pp(
   task->SetDoTHnSparse(enableTHnSparse);
   task->SetProduceTreeEOverP(doTreeEOverP);
   task->SetEnableSortingOfMCClusLabels(enableSortingMCLabels);
+  task->SetTrainConfig(trainConfig);
   if(trainConfig == 446) task->SetSoftAnalysis(kTRUE);
   if(enableExtMatchAndQA > 1){ task->SetPlotHistsExtQA(kTRUE);}
   if(trainConfig == 106 || trainConfig == 125 || trainConfig == 145){

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
@@ -1530,6 +1530,7 @@ void AddTask_GammaCalo_pp(
   task->SetDoTHnSparse(enableTHnSparse);
   task->SetProduceTreeEOverP(doTreeEOverP);
   task->SetEnableSortingOfMCClusLabels(enableSortingMCLabels);
+  task->SetTrainConfig(trainConfig);
   if(trainConfig == 446) task->SetSoftAnalysis(kTRUE);
   if(enableExtMatchAndQA > 1){ task->SetPlotHistsExtQA(kTRUE);}
   if(trainConfig == 106 || trainConfig == 125 || trainConfig == 145){

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvJet.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvJet.C
@@ -2,11 +2,15 @@ AliAnalysisTaskConvJet* AddTask_GammaConvJet(
   const char *ntracks            = "usedefault",
   const char *nclusters          = "usedefault",
   const char* ncells             = "usedefault",
-  const char *suffix             = ""
+  const char *suffix             = "",
+  Int_t IsMC			 = 0,
+  Int_t NContainers              = 1
 )
 {
   return AliAnalysisTaskConvJet::AddTask_GammaConvJet(ntracks,
       nclusters,
       ncells,
-      suffix);
+      suffix,
+      IsMC,
+      NContainers);
 }


### PR DESCRIPTION
…e train

Almost completely rewritten ConvJet class to be able to handle mutiple jet finders in the same train.
You need to add a JetContainer name with the corresponding trainconfig. When something gets asked about the jets (inside AliAnalysisTaskGammaCalo or AliAnalaysisTaskGammaCaloIso) the corresponding trainconfig needs be given to give the correct corresponding jet characteristics.

The addTasks are also changed to load the trainconfig into the GammaCalo and GammaCaloIso class
And the ConvJet AddTask is changed to handle the input arguments for the class.