### PR TITLE
jira:ALPHY-89. Missing path included in jetsHF/CMakeLists 

### DIFF
--- a/PWGHF/jetsHF/CMakeLists.txt
+++ b/PWGHF/jetsHF/CMakeLists.txt
@@ -36,6 +36,7 @@ include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/PWGLF/STRANGENESS/Cascades/Run2
                     ${AliRoot_SOURCE_DIR}/PYTHIA6/pythia6
 		    ${AliPhysics_SOURCE_DIR}/PWG/JETFW
+		    ${AliPhysics_SOURCE_DIR}/PWGJE/EMCALJetTasks
 		    ${AliPhysics_SOURCE_DIR}/PWGHF/vertexingHF
                     )
 


### PR DESCRIPTION
AliAnalysisTaskLocalRho.h was missing from PWGHF/jetsHF/AliAnalysisTaskDJetCorrelations.cxx for some. Path included in PWGHF/jetsHF/CMakeLists.txt