### PR TITLE
Replacing TAlien specific classes with abstract TGrid classes

### DIFF
--- a/CORRFW/test/AliCFRsnTask.C
+++ b/CORRFW/test/AliCFRsnTask.C
@@ -37,7 +37,7 @@ Bool_t AliCFRsnTask(
     //  Create an AliTagAnalysis Object and chain the tags
     AliTagAnalysis   *tagAna = new AliTagAnalysis(); 
     tagAna->SetType("ESD");  //for aliroot > v4-05
-    TAlienCollection *coll   = TAlienCollection::Open(kTagXMLFile); 
+    TGridCollection *coll   = gGrid->OpenCollection(kTagXMLFile);
     TGridResult      *tagResult = coll->GetGridResult("",0,0);
     tagResult->Print();
     tagAna->ChainGridTags(tagResult);

--- a/CORRFW/test/AliCFSingleTrackTask.C
+++ b/CORRFW/test/AliCFSingleTrackTask.C
@@ -40,7 +40,7 @@ Bool_t AliCFSingleTrackTask(
     AliTagAnalysis   *tagAna = new AliTagAnalysis(); 
     if (readAOD) tagAna->SetType("AOD");  //for aliroot > v4-05
     else         tagAna->SetType("ESD");  //for aliroot > v4-05
-    TAlienCollection *coll   = TAlienCollection::Open(kTagXMLFile); 
+    TGridCollection *coll   = gGrid->OpenCollection(kTagXMLFile);
     TGridResult      *tagResult = coll->GetGridResult("",0,0);
     tagResult->Print();
     tagAna->ChainGridTags(tagResult);

--- a/CORRFW/test/AliCFV0Task.C
+++ b/CORRFW/test/AliCFV0Task.C
@@ -41,7 +41,7 @@ Bool_t AliCFV0Task(
     //  Create an AliTagAnalysis Object and chain the tags
     AliTagAnalysis   *tagAna = new AliTagAnalysis(); 
     tagAna->SetType("ESD");  //for aliroot > v4-05
-    TAlienCollection *coll   = TAlienCollection::Open(kTagXMLFile); 
+    TGridCollection *coll   = gGrid->OpenCollection(kTagXMLFile);
     TGridResult      *tagResult = coll->GetGridResult("",0,0);
     tagResult->Print();
     tagAna->ChainGridTags(tagResult);

--- a/JETAN/JetAnalysisManager.C
+++ b/JETAN/JetAnalysisManager.C
@@ -24,7 +24,7 @@ void JetAnalysisManager()
     //EvCuts->SetNChargedAbove1GeVRange(1, 1000);
     //EvCuts->SetMultiplicityRange(11,120);
     //EvCuts->SetNPionRange(2,10000);
-     TAlienCollection* coll = TAlienCollection::Open("tag100.xml");
+     TGridCollection* coll = gGrid->OpenCollection("tag100.xml");
      TGridResult* TagResult = coll->GetGridResult("", 0, 0);
      TagResult->Print();
      TagAna->ChainGridTags(TagResult);

--- a/JETAN/macros/demoJETAN.C
+++ b/JETAN/macros/demoJETAN.C
@@ -100,7 +100,7 @@ Int_t demoJETAN() {
   printf("*******************************\n");
   
   //grid tags
-  TAlienCollection* coll = TAlienCollection::Open("tag100.xml");
+  TGridCollection* coll = gGrid->OpenCollection("tag100.xml");
   TGridResult* TagResult = coll->GetGridResult("");
   TagAna->ChainGridTags(TagResult);
 

--- a/PWG/HMTF/MonteCarlo/runTask.C
+++ b/PWG/HMTF/MonteCarlo/runTask.C
@@ -19,7 +19,7 @@ void runTask(Float_t etamax=0.5,const char * incollection = 0, const char * outf
   }
   else if (TString(incollection).Contains("xml")){
     TGrid::Connect("alien://");
-    TAlienCollection * coll = TAlienCollection::Open (incollection);
+    TGridCollection * coll = gGrid->OpenCollection(incollection);
     while(coll->Next()){
       chain->Add(TString("alien://")+coll->GetLFN());
     }

--- a/PWG/muon/AliCFMuonResTask1.C
+++ b/PWG/muon/AliCFMuonResTask1.C
@@ -64,7 +64,7 @@ Bool_t AliCFMuonResTask1(
     AliTagAnalysis   *tagAna = new AliTagAnalysis(); 
     if (readAOD) tagAna->SetType("AOD");  // for aliroot > v4-05
     else         tagAna->SetType("ESD");  // for aliroot > v4-05
-    TAlienCollection *coll   = TAlienCollection::Open(kTagXMLFile); 
+    TGridCollection *coll   = gGrid->OpenCollection(kTagXMLFile);
     TGridResult      *tagResult = coll->GetGridResult("",0,0);
     tagResult->Print();
     tagAna->ChainGridTags(tagResult);

--- a/PWG/muon/AnalysisTrainFromESDToAOD.C
+++ b/PWG/muon/AnalysisTrainFromESDToAOD.C
@@ -290,7 +290,7 @@ TChain* CreateChainSingle(const char* xmlfile, const char *treeName)
    printf("*******************************\n");
    printf("*** Getting the ESD Chain   ***\n");
    printf("*******************************\n");
-   TAlienCollection * myCollection  = TAlienCollection::Open(xmlfile);
+   TGridCollection * myCollection  = gGrid->OpenCollection(xmlfile);
 
    if (!myCollection) {
       ::Error("CreateChainSingle", "Cannot create an AliEn collection from %s", xmlfile) ;

--- a/PWG/muon/RunSingleMuonAnalysisFromESD.C
+++ b/PWG/muon/RunSingleMuonAnalysisFromESD.C
@@ -32,7 +32,7 @@ void RunSingleMuonAnalysisFromESD(Bool_t local = kFALSE) {
   if (!local) {
     printf("*** Connect to AliEn ***\n");
     TGrid::Connect("alien://");
-    TAlienCollection* coll = TAlienCollection::Open("wn.xml");
+    TGridCollection* coll = gGrid->OpenCollection("wn.xml");
     TGridResult* result = coll->GetGridResult("",0,0);
     for(Int_t i = 0; i < result->GetEntries(); i++) {
       printf("TURL = %s \n",result->GetKey(i,"turl"));

--- a/PWG/muon/analysisTaskLUTNT.C
+++ b/PWG/muon/analysisTaskLUTNT.C
@@ -3,7 +3,7 @@ void analysisTaskLUTNT() {
 
   TChain* chain = new TChain("esdTree");
 
-  TAlienCollection* coll = TAlienCollection::Open("wn.xml");
+  TGridCollection* coll = gGrid->OpenCollection("wn.xml");
 
   TGridResult* result = coll->GetGridResult("",0,0);
   Int_t nFiles = 0;

--- a/PWG/muon/runNorm.C
+++ b/PWG/muon/runNorm.C
@@ -148,7 +148,7 @@ Int_t GetMode(TString inputFileName)
 TChain* CreateChainFromCollection(const char *xmlfile)
 {
   // Create a chain from the collection of tags.
-  TAlienCollection* coll = TAlienCollection::Open(xmlfile);
+  TGridCollection* coll = gGrid->OpenCollection(xmlfile);
   if (!coll) {
     ::Error("CreateChainFromTags", "Cannot create an AliEn collection from %s", xmlfile);
     return NULL;

--- a/PWG/muondep/QAMergeTemplates/QAMerge.C
+++ b/PWG/muondep/QAMergeTemplates/QAMerge.C
@@ -446,7 +446,7 @@ void QAMerge(const char* inputfilelist, const char* mergedFile)
   
   if (sinput.Contains(".xml"))
   {
-    TGridCollection *coll = reinterpret_cast<TGridCollection*>(gROOT->ProcessLine(Form("TAlienCollection::Open(\"%s\");", inputfilelist)));
+    TGridCollection *coll = gGrid->OpenCollection(inputfilelist);
     if (!coll)
     {
       ::Error("MergeOutput", "Input XML collection empty.");

--- a/PWGCF/Correlations/macros/cftree/correlations.C
+++ b/PWGCF/Correlations/macros/cftree/correlations.C
@@ -9,7 +9,6 @@
 #include "Pool.h"
 #include "fstream"
 
-#include "TAlienCollection.h"
 #include "TGrid.h"
 #include "utils.h"
 #include "env.h"

--- a/PWGCF/Correlations/macros/mutklcorrelations/correlations.C
+++ b/PWGCF/Correlations/macros/mutklcorrelations/correlations.C
@@ -8,7 +8,6 @@
 #include "AliVEvent.h"
 #include "Pool.h"
 #include "fstream"
-#include "TAlienCollection.h"
 #include "TGrid.h"
 #include "env.h"
 
@@ -173,7 +172,7 @@ void correlations(
 //  for (Int_t i=0;i<64;i++) fTree->AddFile(Form("/data/trees/mu/lhc13f/AnalysisResults.%03i.root",i));
 
 //  if (!TGrid::Connect("alien://")) return;
-//  TAlienCollection* coll = (TAlienCollection*) TAlienCollection::Open("wn.xml");
+//  TGridCollection* coll = gGrid->OpenCollection("wn.xml");
 //  while (coll->Next()) { fTree->Add(coll->GetTURL());}
 
   

--- a/PWGCF/EBYE/PIDFluctuation/task/SteerAODAnalysisTaskPIDFluctuation.C
+++ b/PWGCF/EBYE/PIDFluctuation/task/SteerAODAnalysisTaskPIDFluctuation.C
@@ -17,10 +17,10 @@ SteerAODAnalysisTaskPIDFluctuation(const Char_t *inputfilename, Int_t maxFiles =
   if (str.EndsWith(".xml")) {
     TGrid::Connect("alien://");
     Info("", "reading data list from collection:");
-    TAlienCollection coll(inputfilename, maxFiles);
-    coll.Reset();
-    while (coll.Next()) {
-      filename = coll.GetTURL();
+    TGridCollection *coll gGrid->OpenCollection(inputfilename, maxFiles);
+    coll->Reset();
+    while (coll->Next()) {
+      filename = coll->GetTURL();
       Info("", Form("%s", filename));
       chain->Add(filename);
     }

--- a/PWGCF/EBYE/PIDFluctuation/task/SteerAnalysisTaskPIDFluctuation.C
+++ b/PWGCF/EBYE/PIDFluctuation/task/SteerAnalysisTaskPIDFluctuation.C
@@ -17,10 +17,10 @@ SteerAnalysisTaskPIDFluctuation(const Char_t *inputfilename, Int_t maxFiles = kM
   if (str.EndsWith(".xml")) {
     TGrid::Connect("alien://");
     Info("", "reading data list from collection:");
-    TAlienCollection coll(inputfilename, maxFiles);
-    coll.Reset();
-    while (coll.Next()) {
-      filename = coll.GetTURL();
+    TGridCollection *coll = gGrid->OpenCollection(inputfilename, maxFiles);
+    coll->Reset();
+    while (coll->Next()) {
+      filename = coll->GetTURL();
       Info("", Form("%s", filename));
       chain->Add(filename);
     }

--- a/PWGCF/EBYE/PIDFluctuation/task/SteerESDAnalysisTaskPIDFluctuation.C
+++ b/PWGCF/EBYE/PIDFluctuation/task/SteerESDAnalysisTaskPIDFluctuation.C
@@ -17,10 +17,10 @@ SteerESDAnalysisTaskPIDFluctuation(const Char_t *inputfilename, Int_t maxFiles =
   if (str.EndsWith(".xml")) {
     TGrid::Connect("alien://");
     Info("", "reading data list from collection:");
-    TAlienCollection coll(inputfilename, maxFiles);
-    coll.Reset();
-    while (coll.Next()) {
-      filename = coll.GetTURL();
+    TGridCollection *coll = gGrid->OpenCollection(inputfilename, maxFiles);
+    coll->Reset();
+    while (coll->Next()) {
+      filename = coll->GetTURL();
       Info("", Form("%s", filename));
       chain->Add(filename);
     }

--- a/PWGCF/EBYE/macros/runLRCAnalysis.C
+++ b/PWGCF/EBYE/macros/runLRCAnalysis.C
@@ -188,21 +188,20 @@ void runLRCInteractive(const char* inputName= "wn.xml",Bool_t LoadTaskLocal=kFAL
   gROOT->LoadMacro("AddTaskLRC.C");
   AddTaskLRC(runKine);
 
-     TAlienCollection * myCollection = 
-	new TAlienCollection("wn.xml",100000) ; 
-    if (!myCollection) { 
-	cout << "XML collection file: " << xmlFileName << " not found" << endl;
-	return;
-    }
+  TGridCollection * myCollection = gGrid->OpenCollection("wn.xml", 100000);
+  if (!myCollection) {
+    cout << "XML collection file: " << xmlFileName << " not found" << endl;
+    return;
+  }
 
-    TChain* chain = new TChain("esdTree");
+  TChain* chain = new TChain("esdTree");
     
-    cout << "Preparing the file list" << endl; 
-    myCollection->Reset() ; 
-    while ( myCollection->Next() ) {
-	cout << "Adding ESD file: " << myCollection->GetTURL("") << endl; 
-	chain->Add(myCollection->GetTURL("")) ; 
-    }
+  cout << "Preparing the file list" << endl;
+  myCollection->Reset();
+  while ( myCollection->Next() ) {
+    cout << "Adding ESD file: " << myCollection->GetTURL("") << endl;
+    chain->Add(myCollection->GetTURL(""));
+  }
     
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
   if (!mgr->InitAnalysis()) return;

--- a/PWGCF/FEMTOSCOPY/UNICOR/runAsTask.C
+++ b/PWGCF/FEMTOSCOPY/UNICOR/runAsTask.C
@@ -44,7 +44,7 @@ void runAsTask(int grid=0) {
 TChain* CreateChainFromTags(const char *xmlfile, const char *type="ESD")
 {
   // Create a chain using tags from the xml file.
-  TAlienCollection* coll = TAlienCollection::Open(xmlfile);
+  TGridCollection* coll = gGrid->OpenCollection(xmlfile);
   if (!coll) {
     ::Error("CreateChainFromTags", "Cannot create an AliEn collection from %s", xmlfile);
     return NULL;

--- a/PWGGA/CaloTrackCorrelations/macros/QA/anaQA.C
+++ b/PWGGA/CaloTrackCorrelations/macros/QA/anaQA.C
@@ -23,7 +23,6 @@
 
 #include "TGrid.h"
 #include "TGridCollection.h"
-#include "TAlienCollection.h"
 #include "TGridResult.h"
 #include "AliLog.h"
 
@@ -435,7 +434,7 @@ void CreateChain(const Int_t mode, TChain * chain)
     TGrid::Connect("alien://") ;
 
     //Feed Grid with collection file
-    TGridCollection * collection = (TGridCollection*) TAlienCollection::Open(kXML);
+    TGridCollection * collection = gGrid->OpenCollection(kXML);
     if (! collection) {
       printf("%s not found\n", kXML) ; 
       return  ; 

--- a/PWGGA/CaloTrackCorrelations/macros/ana.C
+++ b/PWGGA/CaloTrackCorrelations/macros/ana.C
@@ -31,7 +31,6 @@ R__ADD_INCLUDE_PATH($ALICE_PHYSICS)
 
 #include "TGrid.h"
 #include "TGridCollection.h"
-#include "TAlienCollection.h"
 #include "TGridResult.h"
 //#include "TProof.h"
 //#include "TFileCollection.h"
@@ -341,7 +340,7 @@ void CheckInputData(const anaModes mode)
     TGrid::Connect("alien://") ;
         
     // Feed Grid with collection file
-    TGridCollection * collection = (TGridCollection*) TAlienCollection::Open(kXML);
+    TGridCollection * collection = gGrid->OpenCollection(kXML);
     if ( !collection )
     {
       printf("%s not found\n", kXML) ; 
@@ -639,7 +638,7 @@ void CreateChain(const anaModes mode, TChain * chain, TChain * chainxs)
     // variable XML
     
     // Feed Grid with collection file
-    TGridCollection * collection = (TGridCollection*) TAlienCollection::Open(kXML);
+    TGridCollection * collection = gGrid->OpenCollection(kXML);
     if (! collection ) 
     {
       printf("%s not found \n", kXML) ; 

--- a/PWGGA/CaloTrackCorrelations/macros/anaM.C
+++ b/PWGGA/CaloTrackCorrelations/macros/anaM.C
@@ -300,8 +300,7 @@ void CreateChain(const anaModes mode, TChain * chain){//, TChain * chainxs){
     TGrid::Connect("alien://") ;
     
     //Feed Grid with collection file
-    //TGridCollection * collection =  (TGridCollection*)gROOT->ProcessLine(Form("TAlienCollection::Open(\"%s\", 0)", kXML));
-    TGridCollection * collection = (TGridCollection*) TAlienCollection::Open(kXML);
+    TGridCollection * collection = gGrid->OpenCollection(kXML);
     if (! collection) {
       AliError(Form("%s not found", kXML)) ; 
       return kFALSE ; 

--- a/PWGGA/Hyperon/macros/Hyperon.C
+++ b/PWGGA/Hyperon/macros/Hyperon.C
@@ -32,9 +32,9 @@ void Hyperon(const char* dataset="collection.xml")
   // Create the chain
   TChain* chain = new TChain("aodTree");
 
-  TGridCollection * collection = dynamic_cast<TGridCollection*>(TAlienCollection::Open(dataset));
+  TGridCollection * collection = gGrid->OpenCollection(dataset);
   
-  TAlienResult* result = collection->GetGridResult("",0 ,0);
+  TGridResult* result = collection->GetGridResult("", 0, 0);
   TList* rawFileList = result->GetFileInfoList();
   
   for (Int_t counter=0 ; counter < rawFileList->GetEntries() ; counter++) {

--- a/PWGGA/Hyperon/macros/Sigma0.C
+++ b/PWGGA/Hyperon/macros/Sigma0.C
@@ -32,9 +32,9 @@ void Hyperon(const char* dataset="collection.xml")
   // Create the chain
   TChain* chain = new TChain("aodTree");
 
-  TGridCollection * collection = dynamic_cast<TGridCollection*>(TAlienCollection::Open(dataset));
+  TGridCollection *collection = gGrid->OpenCollection(dataset);
   
-  TAlienResult* result = collection->GetGridResult("",0 ,0);
+  TGridResult* result = collection->GetGridResult("", 0, 0);
   TList* rawFileList = result->GetFileInfoList();
   
   for (Int_t counter=0 ; counter < rawFileList->GetEntries() ; counter++) {

--- a/PWGGA/PHOSTasks/CPVperf/macros/CPVanalysis.C
+++ b/PWGGA/PHOSTasks/CPVperf/macros/CPVanalysis.C
@@ -35,9 +35,9 @@ void CPVanalysis(const TString dataset="")
   }
   else if (dataset.Contains(".xml")) {
     chain = new TChain("esdTree");
-    TGridCollection * collection = dynamic_cast<TGridCollection*>(TAlienCollection::Open(dataset));
+    TGridCollection * collection = gGrid->OpenCollection(dataset);
   
-    TAlienResult* result = collection->GetGridResult("",0 ,0);
+    TGridResult* result = collection->GetGridResult("", 0, 0);
     TList* rawFileList = result->GetFileInfoList();
     
     for (Int_t counter=0 ; counter < rawFileList->GetEntries() ; counter++) {

--- a/PWGGA/PHOSTasks/PHOS_PbPb/macros/GRID/Pi0Spectrum.C
+++ b/PWGGA/PHOSTasks/PHOS_PbPb/macros/GRID/Pi0Spectrum.C
@@ -31,9 +31,9 @@ void Pi0Spectrum(const char* dataset="collection.xml")
   // Create the chain
   TChain* chain = new TChain("esdTree");
  
-  TGridCollection * collection = dynamic_cast<TGridCollection*>(TAlienCollection::Open(dataset));
+  TGridCollection * collection = gGrid->OpenCollection(dataset);
   
-  TAlienResult* result = collection->GetGridResult("",0 ,0);
+  TGridResult* result = collection->GetGridResult("", 0, 0);
   TList* rawFileList = result->GetFileInfoList();
   
   for (Int_t counter=0 ; counter < rawFileList->GetEntries() ; counter++) {

--- a/PWGGA/PHOSTasks/PHOS_PbPb/macros/GRID/Pi0SpectrumLHC11h.C
+++ b/PWGGA/PHOSTasks/PHOS_PbPb/macros/GRID/Pi0SpectrumLHC11h.C
@@ -44,9 +44,9 @@ void Pi0SpectrumLHC11h(const char* dataset="collection.xml",
   // Create the chain
   TChain* chain = new TChain("aodTree");
 
-  TGridCollection * collection = dynamic_cast<TGridCollection*>(TAlienCollection::Open(dataset));
+  TGridCollection * collection = gGrid->OpenCollection(dataset);
   
-  TAlienResult* result = collection->GetGridResult("",0 ,0);
+  TGridResult* result = collection->GetGridResult("", 0, 0);
   TList* rawFileList = result->GetFileInfoList();
   
   for (Int_t counter=0 ; counter < rawFileList->GetEntries() ; counter++) {

--- a/PWGGA/PHOSTasks/PHOS_PbPbQA/macros/PHOSPbPb.C
+++ b/PWGGA/PHOSTasks/PHOS_PbPbQA/macros/PHOSPbPb.C
@@ -23,9 +23,9 @@ void PHOSPbPbQA(const char* dataset="collection.xml")
     TGrid::Connect("alien://");
     
     chain = new TChain("esdTree");
-    TGridCollection * collection = dynamic_cast<TGridCollection*>(TAlienCollection::Open(dataset));
+    TGridCollection * collection = gGrid->OpenCollection(dataset);
     
-    TAlienResult* result = collection->GetGridResult("",0 ,0);
+    TGridResult* result = collection->GetGridResult("", 0, 0);
     TList* rawFileList = result->GetFileInfoList();
     
     for (Int_t counter=0 ; counter < rawFileList->GetEntries() ; counter++) {

--- a/PWGGA/PHOSTasks/PHOS_Run2embedding/macros/Embedding.C
+++ b/PWGGA/PHOSTasks/PHOS_Run2embedding/macros/Embedding.C
@@ -32,9 +32,9 @@ void Embedding(const char* dataset="collection.xml")
   // Create the chain
   TChain* chain = new TChain("esdTree");
 
-  TGridCollection * collection = dynamic_cast<TGridCollection*>(TAlienCollection::Open(dataset));
+  TGridCollection * collection = gGrid->OpenCollection(dataset);
   
-  TAlienResult* result = collection->GetGridResult("",0 ,0);
+  TGridResult* result = collection->GetGridResult("", 0, 0);
   TList* rawFileList = result->GetFileInfoList();
   for (Int_t counter=0 ; counter < rawFileList->GetEntries() ; counter++) {
     TFileInfo * fi =  static_cast<TFileInfo*>(rawFileList->At(counter)) ; 

--- a/PWGGA/PHOSTasks/PHOS_embedding/Embedding.C
+++ b/PWGGA/PHOSTasks/PHOS_embedding/Embedding.C
@@ -27,9 +27,9 @@ void Embedding(const char* dataset="collection.xml")
   // Create the chain
   TChain* chain = new TChain("esdTree");
 
-  TGridCollection * collection = dynamic_cast<TGridCollection*>(TAlienCollection::Open(dataset));
+  TGridCollection * collection = gGrid->OpenCollection(dataset);
   
-  TAlienResult* result = collection->GetGridResult("",0 ,0);
+  TGridResult* result = collection->GetGridResult("", 0, 0);
   TList* rawFileList = result->GetFileInfoList();
   for (Int_t counter=0 ; counter < rawFileList->GetEntries() ; counter++) {
     TFileInfo * fi =  static_cast<TFileInfo*>(rawFileList->At(counter)) ; 

--- a/PWGGA/PHOSTasks/PHOS_pp_pi0/macros/Pi0Spectrum_LHC11a.C
+++ b/PWGGA/PHOSTasks/PHOS_pp_pi0/macros/Pi0Spectrum_LHC11a.C
@@ -27,9 +27,9 @@ void Pi0Spectrum(const char* dataset="")
   
   // Create the chain
   TChain* chain = new TChain("esdTree");
-  TGridCollection * collection = dynamic_cast<TGridCollection*>(TAlienCollection::Open(dataset));
+  TGridCollection * collection = gGrid->OpenCollection(dataset);
   
-  TAlienResult* result = collection->GetGridResult("",0 ,0);
+  TGridResult* result = collection->GetGridResult("", 0, 0);
   TList* rawFileList = result->GetFileInfoList();
   
   for (Int_t counter=0 ; counter < rawFileList->GetEntries() ; counter++) {

--- a/PWGGA/PHOSTasks/omega3pi/grid/AnaTaskOmega3pi.C
+++ b/PWGGA/PHOSTasks/omega3pi/grid/AnaTaskOmega3pi.C
@@ -24,9 +24,9 @@ void AnaTask(const char* dataset="minbias_LHC09a4_81040_81050.xml")
 
     // Create the chain
     TChain* chain = new TChain("esdTree");
-    TGridCollection * collection = dynamic_cast<TGridCollection*>(TAlienCollection::Open(dataset));
+    TGridCollection * collection = gGrid->OpenCollection(dataset);
    
-    TAlienResult* result = collection->GetGridResult("",0 ,0);
+    TGridResult* result = collection->GetGridResult("", 0, 0);
     TList* rawFileList = result->GetFileInfoList();
 
     for (Int_t counter=0 ; counter < rawFileList->GetEntries() ; counter++) {

--- a/PWGHF/centraltrain/AnalysisTrainPWG3.C
+++ b/PWGHF/centraltrain/AnalysisTrainPWG3.C
@@ -701,7 +701,7 @@ TChain* CreateChainSingle(const char* xmlfile, const char *treeName)
    printf("*******************************\n");
    printf("*** Getting the ESD Chain   ***\n");
    printf("*******************************\n");
-   TAlienCollection * myCollection  = TAlienCollection::Open(xmlfile);
+   TGridCollection * myCollection  = gGrid->OpenCollection(xmlfile);
 
    if (!myCollection) {
       ::Error("AnalysisTrainNew.C::CreateChainSingle", "Cannot create an AliEn collection from %s", xmlfile) ;

--- a/PWGHF/centraltrain/AnalysisTrainPWG3AOD.C
+++ b/PWGHF/centraltrain/AnalysisTrainPWG3AOD.C
@@ -709,7 +709,7 @@ TChain* CreateChainSingle(const char* xmlfile, const char *treeName)
    printf("*******************************\n");
    printf("*** Getting the ESD Chain   ***\n");
    printf("*******************************\n");
-   TAlienCollection * myCollection  = TAlienCollection::Open(xmlfile);
+   TGridCollection * myCollection  = gGrid->OpenCollection(xmlfile);
 
    if (!myCollection) {
       ::Error("AnalysisTrainNew.C::CreateChainSingle", "Cannot create an AliEn collection from %s", xmlfile) ;

--- a/PWGHF/hfe/macros/runElectronTask.C
+++ b/PWGHF/hfe/macros/runElectronTask.C
@@ -107,8 +107,7 @@ TChain * CreateXMLChain(char* xmlfile)
 
 
 
-  //  TGridCollection * collection =  (TGridCollection*)gROOT->ProcessLine(Form("TAlienCollection::Open(\"%s\", 0)", kXML));
-  TGridCollection * collection = (TGridCollection*) TAlienCollection::Open(kXML);
+  TGridCollection * collection = gGrid->OpenCollection(kXML);
   if (! collection) {
     AliError(Form("%s not found", kXML)) ; 
     return kFALSE ; 

--- a/PWGHF/hfe/macros/runPIDqa.C
+++ b/PWGHF/hfe/macros/runPIDqa.C
@@ -113,8 +113,7 @@ TChain * CreateXMLChain(char* xmlfile)
 
 
 
-  //  TGridCollection * collection =  (TGridCollection*)gROOT->ProcessLine(Form("TAlienCollection::Open(\"%s\", 0)", kXML));
-  TGridCollection * collection = (TGridCollection*) TAlienCollection::Open(kXML);
+  TGridCollection * collection = gGrid->OpenCollection(kXML);
   if (! collection) {
     AliError(Form("%s not found", kXML)) ; 
     return kFALSE ; 

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEVertexingHFTest.C
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEVertexingHFTest.C
@@ -35,7 +35,7 @@ void AliAnalysisTaskSEVertexingHFTest()
     //Fetch files with AliEn :
     const char *collectionfile = "Collection.xml";
     TGrid::Connect("alien://") ;
-    TAlienCollection *coll   = TAlienCollection::Open(collectionfile);
+    TGridCollection *coll   = gGrid->OpenCollection(collectionfile);
     if(inputAOD) { // input AOD
       chain = new TChain("aodTree");
       while(coll->Next()) chain->Add(coll->GetTURL(""));

--- a/PWGHF/vertexingHF/MakeAODInputChain.C
+++ b/PWGHF/vertexingHF/MakeAODInputChain.C
@@ -7,13 +7,13 @@ TChain *MakeAODInputChain(const char* collectionfileAOD,
   // Origin: A.Rossi, andrea.rossi@ts.infn.it
   //
 
-  TAlienCollection *collectionAOD       = TAlienCollection::Open(collectionfileAOD);
+  TGridCollection *collectionAOD = gGrid->OpenCollection(dataset);
   TGridResult *tagResultAOD = collectionAOD->GetGridResult("",0,0);
   TChain *chainAOD = new TChain("aodTree");
   TChain *chainAODfriend = new TChain("aodTree");
   Int_t nmaxentr;
   if(collectionfileAODfriend!="none"){
-    TAlienCollection *collectionAODfriend = TAlienCollection::Open(collectionfileAODfriend);
+    TGridCollection *collectionAODfrined = gGrid->OpenCollection(dataset);
     TGridResult *tagResultAODFriend = collectionAODfriend->GetGridResult("",0,0);
     //  tagResultAOD->Print();
     TMap *mappa;
@@ -185,7 +185,7 @@ TFileCollection* MakeRootArchFileCollection(const char* collectionfileAOD,
   // Origin: A.Rossi, andrea.rossi@ts.infn.it
   //
   
-  TAlienCollection *collectionAOD       = TAlienCollection::Open(collectionfileAOD);
+  TGridCollection *collectionAOD = gGrid->OpenCollection(collectionfileAOD);
   TGridResult *tagResultAOD = collectionAOD->GetGridResult("",0,0);
 
   Int_t nmaxentr;

--- a/PWGJE/macros/AnalysisTrainCAF.C
+++ b/PWGJE/macros/AnalysisTrainCAF.C
@@ -324,7 +324,7 @@ void AnalysisTrainCAF(Int_t nEvents = 10000, Int_t nOffset = 0, char *ds = "/PWG
 TChain *CreateChainFromCollection(const char* xmlfile, const char *treeName="esdTree",Int_t nFiles = 0)
 {
 // Create a chain from an alien collection.                                                                          
-   TAlienCollection * myCollection  = TAlienCollection::Open(xmlfile);
+   TGridCollection * myCollection  = gGrid->OpenCollection(xmlfile);
 
    if (!myCollection) {
       ::Error("CreateChainSingle", "Cannot create an AliEn collection from %s", xmlfile) ;

--- a/PWGJE/macros/AnalysisTrainPWGJets.C
+++ b/PWGJE/macros/AnalysisTrainPWGJets.C
@@ -2050,7 +2050,7 @@ TChain* CreateChainSingle(const char* xmlfile, const char *treeName)
    printf("*******************************\n");
    printf("*** Getting the ESD Chain   ***\n");
    printf("*******************************\n");
-   TAlienCollection * myCollection  = TAlienCollection::Open(xmlfile);
+   TGridCollection * myCollection  = gGrid->OpenCollection(xmlfile);
 
    if (!myCollection) {
       ::Error("AnalysisTrainPWG4Jets.C::CreateChainSingle", "Cannot create an AliEn collection from %s", xmlfile) ;

--- a/PWGLF/RESONANCES/extra/AliAnalysisTaskSigma1385.C
+++ b/PWGLF/RESONANCES/extra/AliAnalysisTaskSigma1385.C
@@ -28,7 +28,7 @@ void AliAnalysisTaskSigma1385()
    const char *collectionfile = "sigmaLHC10d1.xml";
 
 
-   TAlienCollection * myCollection  = TAlienCollection::Open(collectionfile);
+   TGridCollection * myCollection  = gGrid->OpenCollection(collectionfile);
 
    if (!myCollection) {
       Error("AliAnalysisTaskSigma1385", Form("Cannot create an AliEn collection from %s", collectionfile)) ;

--- a/PWGLF/RESONANCES/macros/RunAnalysisPhi900GeV.C
+++ b/PWGLF/RESONANCES/macros/RunAnalysisPhi900GeV.C
@@ -137,7 +137,7 @@ TChain* CreateChainFromXML
   TChain *chain = new TChain(treeName);
 
   // initialize the AliEn collection
-  TAlienCollection *myCollection = TAlienCollection::Open(xmlFileName);
+  TGridCollection *myCollection = gGrid->OpenCollection(xmlFileName);
   if (!myCollection)
   {
     Error("CreateChainFromXML", "Cannot create an AliEn collection from %s", xmlFileName);

--- a/PWGLF/RESONANCES/macros/train/runLocal.C
+++ b/PWGLF/RESONANCES/macros/train/runLocal.C
@@ -149,7 +149,7 @@ TChain* CreateChainFromXML
    TChain *chain = new TChain(treeName);
 
    // initialize the AliEn collection
-   TAlienCollection *myCollection = TAlienCollection::Open(xmlFileName);
+   TGridCollection *myCollection = gGrid->OpenCollection(xmlFileName);
    if (!myCollection) {
       Error("CreateChainFromXML", "Cannot create an AliEn collection from %s", xmlFileName);
       return 0x0;

--- a/PWGLF/SPECTRA/AntiprotonToProton/runProtonAnalysis.C
+++ b/PWGLF/SPECTRA/AntiprotonToProton/runProtonAnalysis.C
@@ -211,7 +211,7 @@ void runInteractive(const char* mode = "ESD",
   AliEventTagCuts *evCuts = new AliEventTagCuts();
  
   //grid tags
-  TAlienCollection* coll = TAlienCollection::Open(collectionName);
+  TGridCollection* coll = gGrid->OpenCollection(collectionName);
   TGridResult* TagResult = coll->GetGridResult("",0,0);
   tagAnalysis->ChainGridTags(TagResult);
   TChain* chain = 0x0;

--- a/PWGLF/SPECTRA/AntiprotonToProton/runProtonAnalysisQA.C
+++ b/PWGLF/SPECTRA/AntiprotonToProton/runProtonAnalysisQA.C
@@ -225,7 +225,7 @@ void runInteractive(const char* mode = "ESD",
   AliEventTagCuts *evCuts = new AliEventTagCuts();
  
   //grid tags
-  TAlienCollection* coll = TAlienCollection::Open(collectionName);
+  TGridCollection* coll = gGrid->OpenCollection(collectionName);
   TGridResult* TagResult = coll->GetGridResult("",0,0);
   tagAnalysis->ChainGridTags(TagResult);
   TChain* chain = 0x0;

--- a/PWGLF/SPECTRA/AntiprotonToProton/runProtonsCorrectionAnalysis.C
+++ b/PWGLF/SPECTRA/AntiprotonToProton/runProtonsCorrectionAnalysis.C
@@ -184,7 +184,7 @@ void runInteractive(const char* mode = "ESD",
   AliEventTagCuts *evCuts = new AliEventTagCuts();
   
   //grid tags
-  TAlienCollection* coll = TAlienCollection::Open(collectionName);
+  TGridCollection* coll = gGrid->OpenCollection(collectionName);
   TGridResult* TagResult = coll->GetGridResult("",0,0);
   tagAnalysis->ChainGridTags(TagResult);
   TChain* chain = 0x0;

--- a/PWGLF/SPECTRA/AntiprotonToProton/runProtonsFeedDownAnalysis.C
+++ b/PWGLF/SPECTRA/AntiprotonToProton/runProtonsFeedDownAnalysis.C
@@ -157,7 +157,7 @@ void runInteractive(const char* mode = "ESD",
   AliEventTagCuts *evCuts = new AliEventTagCuts();
  
   //grid tags
-  TAlienCollection* coll = TAlienCollection::Open(collectionName);
+  TGridCollection* coll = gGrid->OpenCollection(collectionName);
   TGridResult* TagResult = coll->GetGridResult("",0,0);
   tagAnalysis->ChainGridTags(TagResult);
   TChain* chain = 0x0;

--- a/PWGLF/SPECTRA/ChargedHadrons/multPbPb/run.C
+++ b/PWGLF/SPECTRA/ChargedHadrons/multPbPb/run.C
@@ -267,7 +267,7 @@ TChain * GetAnalysisChain(const char * incollection){
   }
   else if (TString(incollection).Contains("xml")){
     TGrid::Connect("alien://");
-    TAlienCollection * coll = TAlienCollection::Open (incollection);
+    TGridCollection * coll = gGrid->OpenCollection(incollection);
     while(coll->Next()){
       analysisChain->Add(TString("alien://")+coll->GetLFN());
     }

--- a/PWGLF/SPECTRA/ChargedHadrons/multPbPb/runTriggerStudy.C
+++ b/PWGLF/SPECTRA/ChargedHadrons/multPbPb/runTriggerStudy.C
@@ -150,7 +150,7 @@ TChain * GetAnalysisChain(const char * incollection){
   }
   else if (TString(incollection).Contains("xml")){
     TGrid::Connect("alien://");
-    TAlienCollection * coll = TAlienCollection::Open (incollection);
+    TGridCollection * coll = gGrid->OpenCollection(incollection);
     while(coll->Next()){
       analysisChain->Add(TString("alien://")+coll->GetLFN());
     }

--- a/PWGLF/SPECTRA/IdentifiedHighPt/grid/macro_HighPtDeDx_lhc10b_Data_ESDs.C
+++ b/PWGLF/SPECTRA/IdentifiedHighPt/grid/macro_HighPtDeDx_lhc10b_Data_ESDs.C
@@ -78,7 +78,7 @@ TChain* CreateChain(const char *xmlfile, const char *type="ESD")
    printf("***************************************\n");
    printf("    Getting chain of trees %s\n", treename.Data());
    printf("***************************************\n");
-   TAlienCollection *coll = TAlienCollection::Open(xmlfile);
+   TGridCollection *coll = gGrid->OpenCollection(xmlfile);
    if (!coll) {
       ::Error("CreateChain", "Cannot create an AliEn collection from %s", xmlfile);
       return NULL;

--- a/PWGLF/SPECTRA/MultEvShape/run.C
+++ b/PWGLF/SPECTRA/MultEvShape/run.C
@@ -11,7 +11,6 @@
 #include <TGrid.h>
 #include <TList.h>
 #include <TMethodCall.h>
-#include <TAlienCollection.h>
 #include <TGridCollection.h>
 #include <TGridResult.h>
 #include <TGeoGlobalMagField.h>

--- a/PWGLF/SPECTRA/ParticleEfficiency/SteerAnalysisTaskParticleEfficiencyLF.C
+++ b/PWGLF/SPECTRA/ParticleEfficiency/SteerAnalysisTaskParticleEfficiencyLF.C
@@ -17,10 +17,10 @@ SteerAnalysisTaskParticleEfficiencyLF(const Char_t *inputfilename, Int_t maxFile
   if (str.EndsWith(".xml")) {
     TGrid::Connect("alien://");
     Info("SteerTaskParticleEfficiency", "reading data list from collection:");
-    TAlienCollection coll(inputfilename, maxFiles);
-    coll.Reset();
-    while (coll.Next()) {
-      filename = coll.GetTURL();
+    TGridCollection *coll = gGrid->OpenCollection(inputfilename, maxFiles);
+    coll->Reset();
+    while (coll->Next()) {
+      filename = coll->GetTURL();
       Info("SteerTaskParticleEfficiency", Form("%s", filename));
       chain->Add(filename);
     }

--- a/PWGLF/SPECTRA/PiKaPr/HMPID/AnalysisTrainHMPID.C
+++ b/PWGLF/SPECTRA/PiKaPr/HMPID/AnalysisTrainHMPID.C
@@ -728,7 +728,7 @@ TChain* CreateChainSingle(const char* xmlfile, const char *treeName)
    printf("*******************************\n");
    printf("*** Getting the ESD Chain   ***\n");
    printf("*******************************\n");
-   TAlienCollection * myCollection  = TAlienCollection::Open(xmlfile);
+   TGridCollection * myCollection  = gGrid->OpenCollection(xmlfile);
 
    if (!myCollection) {
       ::Error("AnalysisTrainHMPID.C::CreateChainSingle", "Cannot create an AliEn collection from %s", xmlfile) ;

--- a/PWGLF/SPECTRA/PiKaPr/TOF/PbPb276/task/SteerAnalysisTaskTOFSpectraPbPb.C
+++ b/PWGLF/SPECTRA/PiKaPr/TOF/PbPb276/task/SteerAnalysisTaskTOFSpectraPbPb.C
@@ -20,10 +20,10 @@ SteerAnalysisTaskTOFSpectraPbPb(const Char_t *inputfilename, Bool_t mcFlag = kFA
   if (str.EndsWith(".xml")) {
     TGrid::Connect("alien://");
     Info("SteerTaskTOFSpectraPbPb", "reading data list from collection:");
-    TAlienCollection coll(inputfilename, maxFiles);
-    coll.Reset();
-    while (coll.Next()) {
-      filename = coll.GetTURL();
+    TGridCollection *coll = gGrid->OpenCollection(inputfilename, maxFiles);
+    coll->Reset();
+    while (coll->Next()) {
+      filename = coll->GetTURL();
       Info("SteerTaskTOFSpectraPbPb", Form("%s", filename));
       chain->Add(filename);
     }

--- a/PWGLF/SPECTRA/PiKaPr/TOF/pPb502/task/SteerAnalysisTaskTOFSpectraPbPb.C
+++ b/PWGLF/SPECTRA/PiKaPr/TOF/pPb502/task/SteerAnalysisTaskTOFSpectraPbPb.C
@@ -22,10 +22,10 @@ SteerAnalysisTaskTOFSpectraPbPb(const Char_t *inputfilename, Bool_t mcFlag = kFA
   if (str.EndsWith(".xml")) {
     TGrid::Connect("alien://");
     Info("SteerTaskTOFSpectraPbPb", "reading data list from collection:");
-    TAlienCollection coll(inputfilename, maxFiles);
-    coll.Reset();
-    while (coll.Next()) {
-      filename = coll.GetTURL();
+    TGridCollection *coll = gGrid->OpenCollection(inputfilename, maxFiles);
+    coll->Reset();
+    while (coll->Next()) {
+      filename = coll->GetTURL();
       Info("SteerTaskTOFSpectraPbPb", Form("%s", filename));
       chain->Add(filename);
     }

--- a/PWGLF/SPECTRA/PiKaPr/TestAOD/runProof.C
+++ b/PWGLF/SPECTRA/PiKaPr/TestAOD/runProof.C
@@ -139,7 +139,7 @@ TChain * GetAnalysisChain(const char * incollection)
    else if (TString(incollection).Contains("xml"))
    {
       TGrid::Connect("alien://");
-      TAlienCollection * coll = TAlienCollection::Open(incollection);
+      TGridCollection * coll = gGrid->OpenCollection(incollection);
       while (coll->Next())
       {
          analysisChain->Add(TString("alien://") + coll->GetLFN());

--- a/PWGLF/STRANGENESS/LambdaK0PbPb/AnalysisStrange.C
+++ b/PWGLF/STRANGENESS/LambdaK0PbPb/AnalysisStrange.C
@@ -90,7 +90,7 @@ TChain* CreateChain(const char *xmlfile, const char *type="ESD")
    printf("***************************************\n");
    printf("    Getting chain of trees %s\n", treename.Data());
    printf("***************************************\n");
-   TAlienCollection *coll = TAlienCollection::Open(xmlfile);
+   TGridCollection *coll = gGrid->OpenCollection(xmlfile);
    if (!coll) {
       ::Error("CreateChain", "Cannot create an AliEn collection from %s", xmlfile);
       return NULL;

--- a/PWGLF/STRANGENESS/LambdaK0PbPb/MainStreamAnalysis/AnalysisStrange.C
+++ b/PWGLF/STRANGENESS/LambdaK0PbPb/MainStreamAnalysis/AnalysisStrange.C
@@ -79,7 +79,7 @@ TChain* CreateChain(const char *xmlfile, const char *type="ESD")
    printf("***************************************\n");
    printf("    Getting chain of trees %s\n", treename.Data());
    printf("***************************************\n");
-   TAlienCollection *coll = TAlienCollection::Open(xmlfile);
+   TGridCollection *coll = gGrid->OpenCollection(xmlfile);
    if (!coll) {
       ::Error("CreateChain", "Cannot create an AliEn collection from %s", xmlfile);
       return NULL;

--- a/PWGLF/STRANGENESS/LambdaK0PbPb/MainStreamAnalysis/run.C
+++ b/PWGLF/STRANGENESS/LambdaK0PbPb/MainStreamAnalysis/run.C
@@ -8,7 +8,6 @@
 // #include "AliAnalysisTaskPerformanceStrange.h"
 // #include "TString.h"
 // #include "TChain.h"
-// #include "TAlienCollection.h"
 // #include <fstream>
 // #include "TObjString.h"
 // #include "TIterator.h"
@@ -201,7 +200,7 @@ TChain * GetAnalysisChain(const char * incollection){
   }
   else if (TString(incollection).Contains("xml")){
     TGrid::Connect("alien://");
-    TGridCollection * coll = TAlienCollection::Open (incollection);
+    TGridCollection * coll = gGrid->OpenCollection(incollection);
     while(coll->Next()){
       analysisChain->Add(TString("alien://")+coll->GetLFN());
     }

--- a/PWGLF/STRANGENESS/LambdaK0PbPb/MainStreamAnalysis/runQA.C
+++ b/PWGLF/STRANGENESS/LambdaK0PbPb/MainStreamAnalysis/runQA.C
@@ -8,7 +8,6 @@
 // #include "AliAnalysisTaskPerformanceStrange.h"
 // #include "TString.h"
 // #include "TChain.h"
-// #include "TAlienCollection.h"
 // #include <fstream>
 // #include "TObjString.h"
 // #include "TIterator.h"
@@ -192,7 +191,7 @@ TChain * GetAnalysisChain(const char * incollection){
   }
   else if (TString(incollection).Contains("xml")){
     TGrid::Connect("alien://");
-    TGridCollection * coll = TAlienCollection::Open (incollection);
+    TGridCollection * coll = gGrid->OpenCollection(incollection);
     while(coll->Next()){
       analysisChain->Add(TString("alien://")+coll->GetLFN());
     }

--- a/PWGLF/STRANGENESS/LambdaK0PbPb/run.C
+++ b/PWGLF/STRANGENESS/LambdaK0PbPb/run.C
@@ -8,7 +8,6 @@
 // #include "AliAnalysisTaskPerformanceStrange.h"
 // #include "TString.h"
 // #include "TChain.h"
-// #include "TAlienCollection.h"
 // #include <fstream>
 // #include "TObjString.h"
 // #include "TIterator.h"
@@ -170,7 +169,7 @@ TChain * GetAnalysisChain(const char * incollection){
   }
   else if (TString(incollection).Contains("xml")){
     TGrid::Connect("alien://");
-    TGridCollection * coll = TAlienCollection::Open (incollection);
+    TGridCollection * coll = gGrid->OpenCollection(incollection);
     while(coll->Next()){
       analysisChain->Add(TString("alien://")+coll->GetLFN());
     }

--- a/PWGLF/STRANGENESS/LambdaK0PbPb/runAOD.C
+++ b/PWGLF/STRANGENESS/LambdaK0PbPb/runAOD.C
@@ -8,7 +8,6 @@
 // #include "AliAnalysisTaskPerformanceStrange.h"
 // #include "TString.h"
 // #include "TChain.h"
-// #include "TAlienCollection.h"
 // #include <fstream>
 // #include "TObjString.h"
 // #include "TIterator.h"
@@ -207,7 +206,7 @@ TChain * GetAnalysisChain(const char * incollection){
   }
   else if (TString(incollection).Contains("xml")){
     TGrid::Connect("alien://");
-    TGridCollection * coll = TAlienCollection::Open (incollection);
+    TGridCollection * coll = gGrid->OpenCollection(incollection);
     while(coll->Next()){
       analysisChain->Add(TString("alien://")+coll->GetLFN());
     }

--- a/PWGLF/STRANGENESS/LambdaK0PbPb/runLK0Spectra.C
+++ b/PWGLF/STRANGENESS/LambdaK0PbPb/runLK0Spectra.C
@@ -8,7 +8,6 @@
 // #include "AliAnalysisTaskLK0Spectra.h"
 // #include "TString.h"
 // #include "TChain.h"
-// #include "TAlienCollection.h"
 // #include <fstream>
 // #include "TObjString.h"
 // #include "TIterator.h"
@@ -176,7 +175,7 @@ TChain * GetAnalysisChain(const char * incollection){
   }
   else if (TString(incollection).Contains("xml")){
     TGrid::Connect("alien://");
-    TGridCollection * coll = TAlienCollection::Open (incollection);
+    TGridCollection * coll = gGrid->OpenCollection(incollection);
     while(coll->Next()){
       analysisChain->Add(TString("alien://")+coll->GetLFN());
     }

--- a/PWGLF/STRANGENESS/LambdaK0PbPb/runQA.C
+++ b/PWGLF/STRANGENESS/LambdaK0PbPb/runQA.C
@@ -8,7 +8,6 @@
 // #include "AliAnalysisTaskPerformanceStrange.h"
 // #include "TString.h"
 // #include "TChain.h"
-// #include "TAlienCollection.h"
 // #include <fstream>
 // #include "TObjString.h"
 // #include "TIterator.h"
@@ -192,7 +191,7 @@ TChain * GetAnalysisChain(const char * incollection){
   }
   else if (TString(incollection).Contains("xml")){
     TGrid::Connect("alien://");
-    TGridCollection * coll = TAlienCollection::Open (incollection);
+    TGridCollection * coll = gGrid->OpenCollection(incollection);
     while(coll->Next()){
       analysisChain->Add(TString("alien://")+coll->GetLFN());
     }

--- a/PWGLF/ppVsMult/dNdEta/task/SteerAnalysisTaskdNdEtaRuben.C
+++ b/PWGLF/ppVsMult/dNdEta/task/SteerAnalysisTaskdNdEtaRuben.C
@@ -27,10 +27,10 @@ SteerAnalysisTaskdNdEtaRuben(const Char_t *inputfilename = NULL, Int_t type = 0,
     if (str.EndsWith(".xml")) {
         TGrid::Connect("alien://");
         Info("", "reading data list from collection:");
-        TAlienCollection coll(inputfilename, maxFiles);
-        coll.Reset();
-        while (coll.Next()) {
-            filename = coll.GetTURL();
+        TGridCollection *coll = gGrid->OpenCollection(inputfilename, maxFiles);
+        coll->Reset();
+        while (coll-.Next()) {
+            filename = coll->GetTURL();
             Info("", Form("%s", filename));
             chain->Add(filename);
         }

--- a/PWGLF/ppVsMult/dNdEtaPP13/task/SteerAnalysisTaskdNdEtaPP13.C
+++ b/PWGLF/ppVsMult/dNdEtaPP13/task/SteerAnalysisTaskdNdEtaPP13.C
@@ -27,10 +27,10 @@ SteerAnalysisTaskdNdEtaPP13(const Char_t *inputfilename = NULL, Int_t type = 0, 
     if (str.EndsWith(".xml")) {
         TGrid::Connect("alien://");
         Info("", "reading data list from collection:");
-        TAlienCollection coll(inputfilename, maxFiles);
-        coll.Reset();
-        while (coll.Next()) {
-            filename = coll.GetTURL();
+        TGridCollection *coll = gGrid->OpenCollection(inputfilename, maxFiles);
+        coll->Reset();
+        while (coll->Next()) {
+            filename = coll->GetTURL();
             Info("", Form("%s", filename));
             chain->Add(filename);
         }

--- a/PWGPP/AliOfflineTrigger.cxx
+++ b/PWGPP/AliOfflineTrigger.cxx
@@ -81,7 +81,7 @@
 #include "AliSysInfo.h"
 #include "TTimeStamp.h"
 #ifdef WITHALIEN
-#include "TAlienCollection.h"
+#include "TGridCollection.h"
 #endif
 #include "TPRegexp.h"
 using std::cout;
@@ -642,7 +642,7 @@ void   AliOfflineTrigger::ExtractSelected(const char *rawList, const char * trig
   TObjArray* rawArray = 0;
   if (TPRegexp(".xml$").Match(rawList)){
 #ifdef WITHALIEN
-    TAlienCollection *coll = (TAlienCollection *)TAlienCollection::Open(rawList);
+    TGridCollection *coll = gGrid->OpenCollection(rawList);
     Int_t nFiles =  coll->GetNofGroups();
     rawArray=new TObjArray(nFiles);
     while( coll->Next()){

--- a/PWGPP/Alignment/macros/runGloAlgTask.C
+++ b/PWGPP/Alignment/macros/runGloAlgTask.C
@@ -100,7 +100,7 @@ TChain* CreateChainXML(const char *xmlfile)
    printf("***************************************\n");
    printf("    Getting chain of trees %s\n", treename.Data());
    printf("***************************************\n");
-   TAlienCollection *coll = TAlienCollection::Open(xmlfile);
+   TGridCollection *coll = gGrid->OpenCollection(xmlfile);
    if (!coll) {
       ::Error("CreateChain", "Cannot create an AliEn collection from %s", xmlfile);
       return NULL;

--- a/PWGPP/EMCAL/macros/anaCaloFilter.C
+++ b/PWGPP/EMCAL/macros/anaCaloFilter.C
@@ -387,8 +387,7 @@ void CreateChain(const anaModes mode, TChain * chain){
     TGrid::Connect("alien://") ;
 
     //Feed Grid with collection file
-    //TGridCollection * collection =  (TGridCollection*)gROOT->ProcessLine(Form("TAlienCollection::Open(\"%s\", 0)", kXML));
-    TGridCollection * collection = (TGridCollection*) TAlienCollection::Open(kXML);
+    TGridCollection * collection = gGrid->OpenCollection(kXML);
     if (! collection) {
       AliError(Form("%s not found", kXML)) ; 
       return kFALSE ; 

--- a/PWGPP/EMCAL/macros/emcalReclusterize.C
+++ b/PWGPP/EMCAL/macros/emcalReclusterize.C
@@ -405,8 +405,7 @@ void CreateChain(const anaModes mode, TChain * chain){
     TGrid::Connect("alien://") ;
 
     //Feed Grid with collection file
-    //TGridCollection * collection =  (TGridCollection*)gROOT->ProcessLine(Form("TAlienCollection::Open(\"%s\", 0)", kXML));
-    TGridCollection * collection = (TGridCollection*) TAlienCollection::Open(kXML);
+    TGridCollection * collection = gGrid->OpenCollection(kXML);
     if (! collection) {
       AliError(Form("%s not found", kXML)) ; 
       return kFALSE ; 

--- a/PWGPP/EMCAL/macros/runEMCALTimeCalibTask.C
+++ b/PWGPP/EMCAL/macros/runEMCALTimeCalibTask.C
@@ -206,7 +206,7 @@ void runEMCALTimeCalibTask(Int_t type=0, Bool_t isESD=kTRUE, Bool_t isPhysicsSel
 TChain *CreateChainFromCollection(const char* xmlfile, const char *treeName="esdTree")
 {
 // Create a chain from an alien collection.
-   TAlienCollection * myCollection  = TAlienCollection::Open(xmlfile);
+   TGridCollection * myCollection  = gGrid->OpenCollection(xmlfile);
 
    if (!myCollection) {
       ::Error("CreateChainSingle", "Cannot create an AliEn collection from %s", xmlfile) ;

--- a/PWGPP/MUON/dep/MuonResolution.C
+++ b/PWGPP/MUON/dep/MuonResolution.C
@@ -24,7 +24,6 @@
 #include <TAxis.h>
 #include <THashList.h>
 #include <TFileCollection.h>
-#include <TAlienCollection.h>
 #include <TGridCollection.h>
 #include <TGridResult.h>
 
@@ -933,7 +932,7 @@ TChain* CreateChainFromCollection(const char *xmlfile)
   // Create a chain from the collection of tags.
   if (!TGrid::Connect("alien://")) return NULL;
   
-  TGridCollection* coll = TAlienCollection::Open(xmlfile);
+  TGridCollection* coll = gGrid->OpenCollection(xmlfile);
   if (!coll) {
     Error("CreateChainFromCollection", "Cannot create the AliEn collection");
     return NULL;

--- a/PWGPP/MUON/lite/RunMuonQA.C
+++ b/PWGPP/MUON/lite/RunMuonQA.C
@@ -103,7 +103,7 @@ Int_t GetMode(TString inputFileName)
 TChain* CreateChainFromCollection(const char *xmlfile)
 {
   // Create a chain from the collection of tags.
-  TAlienCollection* coll = TAlienCollection::Open(xmlfile);
+  TGridCollection* coll = gGrid->OpenCollection(xmlfile);
   if (!coll) {
     ::Error("CreateChainFromTags", "Cannot create an AliEn collection from %s", xmlfile);
     return NULL;

--- a/PWGPP/TRD/run.C
+++ b/PWGPP/TRD/run.C
@@ -57,7 +57,6 @@
 #include "TError.h"
 #include "TChain.h"
 #include "TGrid.h"
-#include "TAlienCollection.h"
 #include "TGridCollection.h"
 #include "TGridResult.h"
 #include "TGeoGlobalMagField.h"
@@ -225,7 +224,7 @@ TChain* MakeChainXML(const char* xmlfile)
   if(gSystem->Load("libRAliEn")<0) return NULL;
   TGrid::Connect("alien://") ;
 
-  TGridCollection *collection = (TGridCollection*) TAlienCollection::Open(xmlfile);
+  TGridCollection *collection = gGrid->OpenCollection(xmlfile);
   if (!collection) {
     Error("MakeChainXML", Form("No collection found in %s", xmlfile)) ; 
     return NULL;

--- a/PWGPP/background/runBGvsTime.C
+++ b/PWGPP/background/runBGvsTime.C
@@ -16,7 +16,7 @@ void runBGvsTime(const char * incollection,const char *filename,UInt_t start, UI
   }
   else if (TString(incollection).Contains("xml")){
     TGrid::Connect("alien://");
-    TAlienCollection * coll = TAlienCollection::Open (incollection);
+    TGridCollection * coll = gGrid->OpenCollection(incollection);
     while(coll->Next()){
       analysisChain->Add(TString("alien://")+coll->GetLFN());
     }

--- a/PWGPP/macros/AddTrainPerformanceTRD.C
+++ b/PWGPP/macros/AddTrainPerformanceTRD.C
@@ -44,7 +44,6 @@
 #include <TError.h>
 #include <TChain.h>
 #include <TGrid.h>
-#include <TAlienCollection.h>
 #include <TGridCollection.h>
 #include <TGridResult.h>
 #include <TGeoGlobalMagField.h>

--- a/PWGPP/macros/rawmerge.C
+++ b/PWGPP/macros/rawmerge.C
@@ -174,7 +174,7 @@ Bool_t makeAlienInputEventList( TString outputFileName="wn.list",
                                 TString referenceFileName="filteredEvents.list",
                                 TString inputCollectionName="wn.xml" )
 {
-   TAlienCollection *coll = TAlienCollection::Open(inputCollectionName);
+   TGridCollection *coll = gGrid->OpenCollection(inputCollectionName);
    if (!coll)
    {
       ::Error("makeAlienInputEventList", "Cannot open collection from %s", xmlfile);

--- a/PWGPP/rawmerge/mergeOfflineTriggerList.C
+++ b/PWGPP/rawmerge/mergeOfflineTriggerList.C
@@ -6,7 +6,6 @@
 */
 
 void mergeOfflineTriggerList(const char * inputList){
-  TAlienCollection col;
   AliOfflineTrigger trigger("default", 30,100000000);
   trigger.LoadTriggerList("filteredHighPtV0s.list");
   trigger.LoadTriggerList("filteredMult.list");

--- a/PWGPP/rawmerge/rawmerge.C
+++ b/PWGPP/rawmerge/rawmerge.C
@@ -18,7 +18,7 @@
 #include "TString.h"
 #include "TEnv.h"
 #include "TSystem.h"
-#include "TAlienCollection.h"
+#include "TGridCollection.h"
 #include "TGrid.h"
 #include "TStopwatch.h"
 #include "AliRawVEvent.h"
@@ -234,7 +234,7 @@ Bool_t makeAlienInputEventList( TString outputFileName,
                                 TString referenceFileName,
                                 TString inputCollectionName )
 {
-  TAlienCollection *coll = (TAlienCollection *)TAlienCollection::Open(inputCollectionName);
+  TGridCollection *coll = gGrid->OpenCollection(inputCollectionName);
   if (!coll)
   {
     ::Error("makeAlienInputEventList", "Cannot open collection from %s", inputCollectionName.Data());

--- a/PWGPP/runITSTPCalignment.C
+++ b/PWGPP/runITSTPCalignment.C
@@ -131,7 +131,7 @@ void runInteractive(const char* collectionName = "tag.xml") {
   AliEventTagCuts *evCuts = new AliEventTagCuts();
  
   //grid tags
-  TAlienCollection* coll = TAlienCollection::Open(collectionName);
+  TGridCollection* coll = gGrid->OpenCollection(collectionName);
   TGridResult* TagResult = coll->GetGridResult("",0,0);
   tagAnalysis->ChainGridTags(TagResult);
   TChain* chain = 0x0;

--- a/PWGUD/macros/genLevelSimulation/MergeCollectionFromGrid.C
+++ b/PWGUD/macros/genLevelSimulation/MergeCollectionFromGrid.C
@@ -2,7 +2,7 @@
 #include "TSystem.h"
 #include "TFileMerger.h"
 #include "TGrid.h"
-#include "TAlienCollection.h"
+#include "TGridCollection.h"
 #include "TFile.h"
 #include "TH1F.h"
 #include "TList.h"
@@ -37,7 +37,7 @@ void MergeCollectionFromGrid(const char * incollection = "test.xml", const char 
   TFileMerger * fileMerger  = new TFileMerger(0); // dont merge local files
 
   TGrid::Connect("alien://");
-  TGridCollection * coll = TAlienCollection::Open (incollection);
+  TGridCollection * coll = gGrid->OpenCollection(incollection);
   Int_t  ifile=0;
   while(coll->Next()){
     fileMerger->AddFile(TString("alien://")+coll->GetLFN());

--- a/PWGUD/macros/genLevelSimulation/runTask.C
+++ b/PWGUD/macros/genLevelSimulation/runTask.C
@@ -19,7 +19,7 @@ void runTask(Float_t etamax=0.5,const char * incollection = 0, const char * outf
   }
   else if (TString(incollection).Contains("xml")){
     TGrid::Connect("alien://");
-    TAlienCollection * coll = TAlienCollection::Open (incollection);
+    TGridCollection * coll = gGrid->OpenCollection(incollection);
     while(coll->Next()){
       chain->Add(TString("alien://")+coll->GetLFN());
     }

--- a/cmake/FindROOT.cmake
+++ b/cmake/FindROOT.cmake
@@ -32,7 +32,6 @@
 # - ROOT_CXX_FLAGS - flags used by the C++ compiler for building ROOT
 # - ROOT_HAS_LIBCXX - TRUE if ROOT was built against libc++ (as opposed to libstdc++)
 # - ROOT_HAS_CXX11 - TRUE if ROOT was built with C++11 support
-# - ROOT_HASALIEN - ROOT was built with AliEn support
 # - ROOT_HASOPENGL - ROOT was built with OpenGL support
 # - ROOT_HASXML - ROOT was built with XML support
 # - ROOT_HASMONALISA - ROOT was built with MonAlisa support - needed by SHUTTLE
@@ -181,48 +180,34 @@ if(ROOTSYS)
     string(STRIP "${ROOT_GLIBRARIES}" ROOT_GLIBRARIES)
     separate_arguments(ROOT_GLIBRARIES)
 
-    # Checking for AliEn support
-    # If AliEn support is enabled we need to point to AliEn
-    execute_process(COMMAND ${ROOT_CONFIG} --has-alien OUTPUT_VARIABLE ROOT_HASALIEN ERROR_VARIABLE error OUTPUT_STRIP_TRAILING_WHITESPACE )
-    if(error)
-        message(FATAL_ERROR "Error checking if ROOT was built with AliEn support: ${error}")
-    endif(error)
-    
-    #if defined
-    if(ROOT_HASALIEN)
-        string(STRIP "${ROOT_HASALIEN}" ROOT_HASALIEN)
-        if(ROOT_HASALIEN STREQUAL "yes")
-            if(ALIEN)
-            add_definitions(-DWITHALIEN)
+    # Assume AliEn support as external ROOT plugin.
+    if(ALIEN)
+    add_definitions(-DWITHALIEN)
 
-            # AliEn might bring some system libraries, we need to use them
-            if(EXISTS "${ALIEN}/lib")
-                link_directories(${ALIEN}/lib)
-            endif()
+    # AliEn might bring some system libraries, we need to use them
+    if(EXISTS "${ALIEN}/lib")
+        link_directories(${ALIEN}/lib)
+    endif()
 
-            # api/lib should always exists
-            if(EXISTS "${ALIEN}/api/lib")
-                link_directories(${ALIEN}/api/lib)
-            endif()
+    # api/lib should always exists
+    if(EXISTS "${ALIEN}/api/lib")
+        link_directories(${ALIEN}/api/lib)
+    endif()
 
-            # include for AliEn
-            if(EXISTS "${ALIEN}/include")
-                include_directories(SYSTEM ${ALIEN}/include)
-            endif()
+    # include for AliEn
+    if(EXISTS "${ALIEN}/include")
+        include_directories(SYSTEM ${ALIEN}/include)
+    endif()
 
-            # api/include always exists
-            if(EXISTS "${ALIEN}/api/include")
-                include_directories(SYSTEM ${ALIEN}/api/include)
-            endif()
+    # api/include always exists
+    if(EXISTS "${ALIEN}/api/include")
+        include_directories(SYSTEM ${ALIEN}/api/include)
+    endif()
 
-            set(ROOT_HASALIEN TRUE)
-            else(ALIEN)
-            message(FATAL_ERROR "ROOT was built with AliEn support but no AliEn installation found. Please set \"ALIEN\" to point to your AliEn installation.")
-            endif(ALIEN)
-        else()
-            set(ROOT_HASALIEN FALSE)
-        endif()
-    endif(ROOT_HASALIEN)
+    set(ROOT_HASALIEN TRUE)
+    else(ALIEN)
+    message(FATAL_ERROR "ROOT was built with AliEn support but no AliEn installation found. Please set \"ALIEN\" to point to your AliEn installation.")
+    endif(ALIEN)
 
     # Checking for xml support
     execute_process(COMMAND ${ROOT_CONFIG} --has-xml OUTPUT_VARIABLE ROOT_HASXML ERROR_VARIABLE error OUTPUT_STRIP_TRAILING_WHITESPACE )

--- a/cmake/PARfiles/Makefile.in
+++ b/cmake/PARfiles/Makefile.in
@@ -35,7 +35,6 @@ endif
 
 # Get some ROOT build flags from the current installation
 ROOT_DEFINES += $(shell root-config --features | grep -q xml && echo '-DWITHXML')
-ROOT_DEFINES += $(shell root-config --features | grep -q alien && echo '-DWITHALIEN')
 ifneq ($(FASTJET),)
 	ROOT_DEFINES += -DHAVE_FASTJET
 endif


### PR DESCRIPTION
This pull request introduces changes in AliPhysics in such a way that access to the GRID is done through abstract classes instead of using specific implementations. These changes are needed in order to support both GRID plugins and their corresponding classes (TAlien and TJalien). Modifications in this pull request have been discussed in Computing Board ([link](https://indico.cern.ch/event/788465/)).

The corresponding AliRoot pull request is here: https://github.com/alisw/AliRoot/pull/889

The changes are split into the following 5 steps:
- [x] cf2512c19a1b119fccd9fd63e8bd2c5e84cd2598 Don't check if ROOT has alien
- [x]  1e9ae98d434b38cf1ee60f01d126da0fa40e3b4a Remove strong dependencies on TAlien in .cxx files
- [x] 3c0db4acdb1f71fcea8378937b84600baa607c68, Changes from TAlien to TGrid in macros (runtime)
- [ ] ~Update validation scripts to check for JAliEn errors, too~
- [ ] ~Changes related to TAlienCollection and TAlienFile (needs more attention)~

Edit 1: Updated hashes after rebase.
Edit 2: Added the AliRoot pull request.
Edit 3: Added the commit for changes in the macros.