### PR TITLE
Main changes: support for V0 candidates in AOD; compute TPC event plane;

### DIFF
--- a/PWGDQ/dielectron/core/AliDielectronVarManager.h
+++ b/PWGDQ/dielectron/core/AliDielectronVarManager.h
@@ -2463,7 +2463,7 @@ inline void AliDielectronVarManager::FillVarDielectronPair(const AliDielectronPa
     values[AliDielectronVarManager::kOneOverPairEffSq] = (values[AliDielectronVarManager::kPairEff]>0.0 ? 1./values[AliDielectronVarManager::kPairEff]/values[AliDielectronVarManager::kPairEff] : 1.0);
   }
 
-  if(kRndmPair) values[AliDielectronVarManager::kRndmPair] = gRandom->Rndm();
+  if(Req(kRndmPair)) values[AliDielectronVarManager::kRndmPair] = gRandom->Rndm();
 } // end FillVarDielectronPair
 
 inline void AliDielectronVarManager::FillVarKFParticle(const AliKFParticle *particle, Double_t * const values)

--- a/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.h
+++ b/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.h
@@ -14,8 +14,12 @@ class TTree;
 class TFile;
 class TBits;
 class AliESDtrack;
+class AliAODTrack;
+class AliESDv0;
+class AliAODv0;
 class AliESDv0Cuts;
 class AliESDv0KineCuts;
+class AliAODv0KineCuts;
 class AliKFVertex;
 class AliReducedBaseEvent;
 class AliReducedPairInfo;
@@ -78,6 +82,7 @@ public:
   void SetGammaConvCuts(AliESDv0KineCuts* const cuts) {fGammaConvCuts = cuts;}
   void SetV0OpenCuts(AliESDv0KineCuts* const cuts) {fV0OpenCuts = cuts;}
   void SetV0StrongCuts(AliESDv0KineCuts* const cuts) {fV0StrongCuts = cuts;}
+  void SetV0CutsAOD(AliAODv0KineCuts* const cuts) {fV0CutsAOD = cuts;}
   void SetK0sMassRange(Double_t min=0.4, Double_t max=0.6) {fK0sMassRange[0]=min; fK0sMassRange[1]=max;}
   void SetLambdaMassRange(Double_t min=1.08, Double_t max=1.15) {fLambdaMassRange[0]=min; fLambdaMassRange[1]=max;}
   void SetGammaConvMassRange(Double_t min=0.0, Double_t max=0.1) {fGammaMassRange[0]=min; fGammaMassRange[1]=max;}
@@ -103,6 +108,7 @@ public:
   void SetFillFMDInfo(Bool_t flag=kTRUE)               {fFillFMDInfo = flag;}
   //void SetFillBayesianPIDInfo(Bool_t flag=kTRUE)  {fFillBayesianPIDInfo = flag;}
   void SetFillEventPlaneInfo(Bool_t flag=kTRUE)    {fFillEventPlaneInfo = flag;}
+  void SetFlowTrackFilter(AliAnalysisCuts* const filter)  {fFlowTrackFilter=filter;}
   void SetFillMCInfo(Bool_t flag=kTRUE)               {fFillMCInfo = flag;}
   void AddMCsignal(AliSignalMC* mc, Int_t wOpt=kFullTrack) {
      if(fMCsignals.GetEntries()>=kMaxMCsignals) return; 
@@ -187,6 +193,7 @@ public:
   AliAnalysisCuts *fGammaElectronCuts;  // filter for electrons from gamma conversions
   AliESDv0KineCuts *fV0OpenCuts;        // v0 strong filter for tagged V0s
   AliESDv0KineCuts *fV0StrongCuts;      // v0 strong filter for tagged V0s
+  AliAODv0KineCuts *fV0CutsAOD;        // filter for tagged V0s in AODs
   
   TH2D* fFMDhist;  // FMD map from AliForwardMult
 
@@ -213,6 +220,8 @@ public:
   void FillMCTruthInfo();                   // fill MC truth particles
   void FillV0PairInfo();                    // fill V0 reduced pair information
   AliReducedPairInfo* FillV0PairInfo(AliESDv0* v0, Int_t id, AliESDtrack* legPos, AliESDtrack* legNeg, AliKFVertex* vtxKF, Bool_t chargesAreCorrect);
+  void FillV0PairInfoAOD();                    // fill V0 reduced pair information
+  AliReducedPairInfo* FillV0PairInfoAOD(AliAODv0* v0, Int_t id, AliAODTrack* legPos, AliAODTrack* legNeg, AliKFVertex* vtxKF);
   UChar_t EncodeTPCClusterMap(AliVParticle* track, Bool_t isAOD);
   void FillCaloClusters();
   void FillFMDInfo(Bool_t isAOD);

--- a/PWGDQ/reducedTree/AliReducedEventInfo.h
+++ b/PWGDQ/reducedTree/AliReducedEventInfo.h
@@ -144,17 +144,12 @@ class AliReducedEventInfo : public AliReducedBaseEvent {
 	 			    Bool_t (*IsTrackSelected)(AliReducedTrackInfo*)=NULL);
   
   // Event plane information handling for the case when event plane information is written directly in the trees
-  //void SetEventPlane(const AliReducedEventPlaneInfo* ep) 
-  //    {if(ep) {fEventPlane=new AliReducedEventPlaneInfo(); fEventPlane->CopyEvent(ep);}};
-  //AliReducedEventPlaneInfo* GetEventPlane() const {return fEventPlane;};
   void SetEventPlane(const AliReducedEventPlaneInfo* ep) {if(ep) fEventPlane.CopyEvent(ep);}
+  Double_t GetEventPlane(Int_t detector, Int_t harmonic) const {return fEventPlane.EventPlane(detector, harmonic);};    
+  Double_t GetQx(Int_t detector, Int_t harmonic) const {return fEventPlane.Qx(detector, harmonic);}
+  Double_t GetQy(Int_t detector, Int_t harmonic) const {return fEventPlane.Qy(detector, harmonic);}
+  Double_t GetEventPlaneStatus(Int_t detector, Int_t harmonic) const {return fEventPlane.GetEventPlaneStatus(detector, harmonic);}
   
-  //Double_t GetEventPlane(Int_t detector, Int_t harmonic) const 
-   //   {if(fEventPlane) return fEventPlane->EventPlane(detector, harmonic); return 0.0;};
-  Double_t GetEventPlane(Int_t detector, Int_t harmonic) const 
-      {return fEventPlane.EventPlane(detector, harmonic); return 0.0;};    
-      
-
   virtual void ClearEvent();
   
   static const Float_t fgkZdcNalpha;

--- a/PWGDQ/reducedTree/AliReducedEventPlaneInfo.cxx
+++ b/PWGDQ/reducedTree/AliReducedEventPlaneInfo.cxx
@@ -23,7 +23,7 @@ AliReducedEventPlaneInfo::AliReducedEventPlaneInfo() :
   //
   for(Int_t idet=0; idet<kNdetectors; ++idet) {
     for(Int_t ih=0; ih<fgkNMaxHarmonics; ++ih) {
-      fEventPlaneStatus[idet][ih] = 0;
+      fEventPlaneStatus[idet][ih] = kUnset;
       for(Int_t ic=0; ic<2; ++ic)
 	fQvector[idet][ih][ic] = 0.0;
     }
@@ -48,7 +48,7 @@ void AliReducedEventPlaneInfo::ClearEvent() {
   //
   for(Int_t idet=0; idet<kNdetectors; ++idet) {
     for(Int_t ih=0; ih<fgkNMaxHarmonics; ++ih) {
-      fEventPlaneStatus[idet][ih] = 0;
+      fEventPlaneStatus[idet][ih] = kUnset;
       for(Int_t ic=0; ic<2; ++ic)
 	fQvector[idet][ih][ic] = 0.0;
     }

--- a/PWGDQ/reducedTree/AliReducedVarManager.h
+++ b/PWGDQ/reducedTree/AliReducedVarManager.h
@@ -14,6 +14,7 @@
 #include <TH2F.h>
 #include <TH3F.h>
 #include <TProfile2D.h>
+#include <TGraphErrors.h>
 
 #include <AliReducedPairInfo.h>
 
@@ -217,6 +218,7 @@ class AliReducedVarManager : public TObject {
     kRunNo,             // run number         
     kRunID,             // variable for easy filling of histograms vs. run number, without empty bins
     kBeamEnergy,        // LHC beam energy
+    kInstLumi,           // instantaneous interaction rate
     kDetectorMask,      // detector mask
     kNumberOfDetectors, // number of active detectors
     kBC,                // bunch crossing     
@@ -370,9 +372,22 @@ class AliReducedVarManager : public TObject {
     kTPCQvecXtotal  = kTPCRPright+6,            
     kTPCQvecYtotal  = kTPCQvecXtotal+6,         
     kTPCRPtotal     = kTPCQvecYtotal+6,         
-    kTPCsubResCos   = kTPCRPtotal+6,            
+    kTPCsubResCos   = kTPCRPtotal+6, 
+    // TPC event plane obtained from the precomputed Q vector in the trees
+    kTPCQvecXtree   = kTPCsubResCos+6,
+    kTPCQvecYtree   = kTPCQvecXtree+6,
+    kTPCRPtree      = kTPCQvecYtree+6,
+    kTPCQvecXptWeightsTree = kTPCRPtree+6,
+    kTPCQvecYptWeightsTree = kTPCQvecXptWeightsTree+6,
+    kTPCRPptWeightsTree    = kTPCQvecYptWeightsTree+6,
+    kTPCQvecXposTree   = kTPCRPptWeightsTree+6,
+    kTPCQvecYposTree   = kTPCQvecXposTree+6,
+    kTPCRPposTree      = kTPCQvecYposTree+6,
+    kTPCQvecXnegTree   = kTPCRPposTree+6,
+    kTPCQvecYnegTree   = kTPCQvecXnegTree+6,
+    kTPCRPnegTree      = kTPCQvecYnegTree+6,
     // ZDC variables
-    kZDCnEnergyCh   = kTPCsubResCos+6,         // ZDCn energy in each channel
+    kZDCnEnergyCh   = kTPCRPnegTree+6,         // ZDCn energy in each channel
     kZDCpEnergyCh   = kZDCnEnergyCh+10,        // ZDCp energy in each channel
     // TZERO variables
     kTZEROAmplitudeCh = kZDCpEnergyCh+10,      // TZERO aplitudes in all channels
@@ -682,6 +697,7 @@ class AliReducedVarManager : public TObject {
   static void SetAssociatedHadronEfficiencyMap(TH3F* map, Variables varX, Variables varY, Variables varZ);
   static void SetLHCDataInfo(TH1F* totalLumi, TH1F* totalInt0, TH1F* totalInt1, TH1I* fillNumber);
   static void SetGRPDataInfo(TH1I* dipolePolarity, TH1I* l3Polarity, TH1I* timeStart, TH1I* timeStop);
+  static void SetupGRPinformation(const Char_t* filename);
   static void SetRunNumbers( TString runNumbers );
   static void SetMultiplicityProfile( TH2* profile, Int_t estimator );
   static void SetVZEROCalibrationPath(const Char_t* path);
@@ -730,6 +746,8 @@ class AliReducedVarManager : public TObject {
   static TH1I* fgRunL3Polarity;                // L3 magnet polarity, GRP/GRP/Data::GetL3Polarity()
   static TH1I* fgRunTimeStart;                // run start time, GRP/GRP/Data::GetTimeStart()
   static TH1I* fgRunTimeEnd;                  // run stop time, GRP/GRP/Data::GetTimeEnd()
+  static TFile* fgGRPfile;                    // file containing GRP information
+  static TGraphErrors* fgRunInstLumi;         // time dependence of the instantaneous lumi for the current run, AliLumiTools::GetLumiFromCTP(run)
   static std::vector<Int_t> fgRunNumbers;     // vector with run numbers (for histograms vs. run number)
   static Int_t fgRunID;                       // run ID
   static TH1* fgAvgMultVsVtxGlobal      [kNMultiplicityEstimators];        // average multiplicity vs. z-vertex position (global)


### PR DESCRIPTION
Changes:
1) Added support such that V0 candidates from AODs are also written to trees.
    K0s and conversions were tested ok. Lambda and anti-Lambda candidates still problematic.
2) Q-vector from the TPC for the 1st,2nd and 3rd harmonics are precomputed in the tree maker using user specified track selection. The Q vector is written in the event plane object stored in the event class.
3) Instantaneous luminosity as extracted from OCDB is implemented in the VarManager and can be plotted optionally.
4) Small fixes 