### PR TITLE
New Tasks and Classes for proton-Omega femto analysis.

### DIFF
--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskOtonOmega.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskOtonOmega.cxx
@@ -1,0 +1,598 @@
+/*
+ * AliAnalysisTaskFemtoPlotration.cxx
+ *
+ *  Created on: 24 Nov 2017
+ *      Author: bernhardhohlweger
+ */
+
+#include "AliAnalysisTaskOtonOmega.h"
+#include "AliLog.h"
+ClassImp(AliAnalysisTaskOtonOmega)
+
+AliAnalysisTaskOtonOmega::AliAnalysisTaskOtonOmega()
+    : AliAnalysisTaskSE(),
+      fTrackBufferSize(0),
+      fESDAnalysis(false),
+      fCascadeTreeFlag(false),
+      fOmegaTreeFlag(false),
+      fMinBookingME(false),
+      fMinBookingSample(false),
+      fMVPileUp(false),
+      fEvtCutQA(false),
+      fIsMC(false),
+      fAnalysis(),
+      fQA(0),
+      fEvtCuts(),
+      fEvtHistList(0),
+      fTrackCuts(),
+      fTrackCutHistList(0),
+      fTrackCutHistMCList(0),
+      fAntiTrackCuts(),
+      fAntiTrackCutHistList(0),
+      fAntiTrackCutHistMCList(0),
+      fv0Cuts(),
+      fv0CutHistList(0),
+      fv0CutHistMCList(0),
+      fAntiv0Cuts(),
+      fAntiv0CutHistList(0),
+      fAntiv0CutHistMCList(0),
+      fCascCuts(),
+      fCascCutList(0),
+      fCascCutMCList(0),
+      fAntiCascCuts(),
+      fAntiCascCutList(0),
+      fAntiCascCutMCList(0),
+      fCascOmegaCuts(),
+      fCascOmegaCutList(0),
+      fCascOmegaCutMCList(0),
+      fAntiCascOmegaCuts(),
+      fAntiCascOmegaCutList(0),
+      fAntiCascOmegaCutMCList(0),
+      fConfig(),
+      fResults(0),
+      fResultQA(0),
+      fResultsSample(0),
+      fResultQASample(0),
+      fTreeCascade(0),
+      fTreeOmega(0) {
+}
+
+AliAnalysisTaskOtonOmega::AliAnalysisTaskOtonOmega(const char *name,
+                                                     bool isESD, bool isMC, bool CascadeTreeFlag, bool OmegaTreeFlag)
+    : AliAnalysisTaskSE(name),
+      fTrackBufferSize(0),
+      fESDAnalysis(isESD),
+      fCascadeTreeFlag(CascadeTreeFlag),
+      fOmegaTreeFlag(OmegaTreeFlag),
+      fMinBookingME(false),
+      fMinBookingSample(false),
+      fMVPileUp(false),
+      fEvtCutQA(false),
+      fIsMC(isMC),
+      fAnalysis(),
+      fQA(0),
+      fEvtCuts(),
+      fEvtHistList(0),
+      fTrackCuts(),
+      fTrackCutHistList(0),
+      fTrackCutHistMCList(0),
+      fAntiTrackCuts(),
+      fAntiTrackCutHistList(0),
+      fAntiTrackCutHistMCList(0),
+      fv0Cuts(),
+      fv0CutHistList(0),
+      fv0CutHistMCList(0),
+      fAntiv0Cuts(),
+      fAntiv0CutHistList(0),
+      fAntiv0CutHistMCList(0),
+      fCascCuts(),
+      fCascCutList(0),
+      fCascCutMCList(0),
+      fAntiCascCuts(),
+      fAntiCascCutList(0),
+      fAntiCascCutMCList(0),
+      fCascOmegaCuts(),
+      fCascOmegaCutList(0),
+      fCascOmegaCutMCList(0),
+      fAntiCascOmegaCuts(),
+      fAntiCascOmegaCutList(0),
+      fAntiCascOmegaCutMCList(0),
+      fConfig(),
+      fResults(0),
+      fResultQA(0),
+      fResultsSample(0),
+      fResultQASample(0),
+      fTreeCascade(0),
+      fTreeOmega(0) {
+  DefineOutput(1, TList::Class());  //Output for the Event Class and Pair Cleaner
+  DefineOutput(2, TList::Class());  //Output for the Event Cuts
+  DefineOutput(3, TList::Class());  //Output for the Track Cuts
+  DefineOutput(4, TList::Class());  //Output for the Antitrack Cuts
+  DefineOutput(5, TList::Class());  //Output for the v0 Cuts -> Moved to Omega
+  DefineOutput(6, TList::Class());  //Output for the Antiv0 Cuts -> Moved to Omega
+  DefineOutput(7, TList::Class());  //Output for the Cascade Cuts
+  DefineOutput(8, TList::Class());  //Output for the Anti Cascade
+  DefineOutput(9, TList::Class());  //Output for the Results
+  DefineOutput(10, TList::Class());  //Output for the Results QA
+  DefineOutput(11, TList::Class());  //Output for the Sample
+  DefineOutput(12, TList::Class());  //Output for the Sample QA
+  DefineOutput(13, TTree::Class());  // Cascade Tree
+  DefineOutput(14, TTree::Class());  // Omega Tree
+  if (fIsMC) {
+    DefineOutput(15, TList::Class());  //Output for the Track Cut MC Info
+    DefineOutput(16, TList::Class());  //Output for the AntiTrack Cut MC Info
+    DefineOutput(17, TList::Class());  //Output for the v0 Cut MC Info
+    DefineOutput(18, TList::Class());  //Output for the Antiv0 Cut MC Info
+    DefineOutput(19, TList::Class());  //Output for the Xi Cut MC Info
+    DefineOutput(20, TList::Class());  //Output for the AntiXi Cut MC Info
+  }
+}
+
+AliAnalysisTaskOtonOmega::AliAnalysisTaskOtonOmega(
+    const AliAnalysisTaskOtonOmega& task)
+    : AliAnalysisTaskSE(task),
+      fTrackBufferSize(task.fTrackBufferSize),
+      fESDAnalysis(task.fESDAnalysis),
+      fCascadeTreeFlag(task.fCascadeTreeFlag),
+      fOmegaTreeFlag(task.fOmegaTreeFlag),
+      fMinBookingME(task.fMinBookingME),
+      fMinBookingSample(task.fMinBookingSample),
+      fMVPileUp(task.fMVPileUp),
+      fEvtCutQA(task.fEvtCutQA),
+      fIsMC(task.fIsMC),
+      fAnalysis(task.fAnalysis),
+      fQA(task.fQA),
+      fEvtCuts(task.fEvtCuts),
+      fEvtHistList(task.fEvtHistList),
+      fTrackCuts(task.fTrackCuts),
+      fTrackCutHistList(task.fTrackCutHistList),
+      fTrackCutHistMCList(task.fTrackCutHistMCList),
+      fAntiTrackCuts(task.fAntiTrackCuts),
+      fAntiTrackCutHistList(task.fAntiTrackCutHistList),
+      fAntiTrackCutHistMCList(task.fAntiTrackCutHistMCList),
+      fv0Cuts(task.fv0Cuts),
+      fv0CutHistList(task.fv0CutHistList),
+      fv0CutHistMCList(task.fv0CutHistMCList),
+      fAntiv0Cuts(task.fAntiv0Cuts),
+      fAntiv0CutHistList(task.fAntiv0CutHistList),
+      fAntiv0CutHistMCList(task.fAntiv0CutHistMCList),
+      fCascCuts(task.fCascCuts),
+      fCascCutList(task.fCascCutList),
+      fCascCutMCList(task.fCascCutMCList),
+      fAntiCascCuts(task.fAntiCascCuts),
+      fAntiCascCutList(task.fAntiCascCutList),
+      fAntiCascCutMCList(task.fAntiCascCutMCList),
+      fCascOmegaCuts(task.fCascOmegaCuts),
+      fCascOmegaCutList(task.fCascOmegaCutList),
+      fCascOmegaCutMCList(task.fCascOmegaCutMCList),
+      fAntiCascOmegaCuts(task.fAntiCascOmegaCuts),
+      fAntiCascOmegaCutList(task.fAntiCascOmegaCutList),
+      fAntiCascOmegaCutMCList(task.fAntiCascOmegaCutMCList),
+      fConfig(task.fConfig),
+      fResults(task.fResults),
+      fResultQA(task.fResultQA),
+      fResultsSample(task.fResultsSample),
+      fResultQASample(task.fResultQASample),
+      fTreeCascade(task.fTreeCascade),
+      fTreeOmega(task.fTreeOmega) {
+}
+
+AliAnalysisTaskOtonOmega& AliAnalysisTaskOtonOmega::operator=(
+    const AliAnalysisTaskOtonOmega& task) {
+  if (this != &task) {
+    AliAnalysisTaskSE::operator=(task);
+    this->fTrackBufferSize = task.fTrackBufferSize;
+    this->fESDAnalysis = task.fESDAnalysis;
+    this->fMinBookingME = task.fMinBookingME;
+    this->fMinBookingSample = task.fMinBookingSample;
+    this->fMVPileUp = task.fMVPileUp;
+    this->fEvtCutQA = task.fEvtCutQA;
+    this->fIsMC = task.fIsMC;
+    this->fAnalysis = task.fAnalysis;
+    this->fQA = task.fQA;
+    this->fEvtCuts = task.fEvtCuts;
+    this->fEvtHistList = task.fEvtHistList;
+    this->fTrackCuts = task.fTrackCuts;
+    this->fTrackCutHistList = task.fTrackCutHistList;
+    this->fTrackCutHistMCList = task.fTrackCutHistMCList;
+    this->fAntiTrackCuts = task.fAntiTrackCuts;
+    this->fAntiTrackCutHistList = task.fAntiTrackCutHistList;
+    this->fAntiTrackCutHistMCList = task.fAntiTrackCutHistMCList;
+    this->fv0Cuts = task.fv0Cuts;
+    this->fv0CutHistList = task.fv0CutHistList;
+    this->fv0CutHistMCList = task.fv0CutHistMCList;
+    this->fAntiv0Cuts = task.fAntiv0Cuts;
+    this->fAntiv0CutHistList = task.fAntiv0CutHistList;
+    this->fAntiv0CutHistMCList = task.fAntiv0CutHistMCList;
+    this->fCascCuts = task.fCascCuts;
+    this->fCascCutList = task.fCascCutList;
+    this->fCascCutMCList = task.fCascCutMCList;
+    this->fAntiCascCuts = task.fAntiCascCuts;
+    this->fAntiCascCutList = task.fAntiCascCutList;
+    this->fAntiCascCutMCList = task.fAntiCascCutMCList;
+    this->fCascOmegaCuts = task.fCascOmegaCuts;
+    this->fCascOmegaCutList = task.fCascOmegaCutList;
+    this->fCascOmegaCutMCList = task.fCascOmegaCutMCList;
+    this->fAntiCascOmegaCuts = task.fAntiCascOmegaCuts;
+    this->fAntiCascOmegaCutList = task.fAntiCascOmegaCutList;
+    this->fAntiCascOmegaCutMCList = task.fAntiCascOmegaCutMCList;
+    this->fConfig = task.fConfig;
+    this->fResults = task.fResults;
+    this->fResultQA = task.fResultQA;
+    this->fResultsSample = task.fResultsSample;
+    this->fResultQASample = task.fResultQASample;
+  }
+  return *this;
+}
+
+AliAnalysisTaskOtonOmega::~AliAnalysisTaskOtonOmega() {
+  if (fAnalysis) {
+    delete fAnalysis;
+  }
+}
+
+void AliAnalysisTaskOtonOmega::UserCreateOutputObjects() {
+  fAnalysis = new AliOtonOmegaAnalysis();
+  fAnalysis->SetTrackBufferSize(fTrackBufferSize);
+  fAnalysis->SetMVPileUp(fMVPileUp);
+  fAnalysis->SetEvtCutQA(fEvtCutQA);
+
+  if (fEvtCuts) {
+    fAnalysis->SetEventCuts(fEvtCuts);
+  } else {
+    AliFatal("Event cuts missing!");
+  }
+  if (fTrackCuts) {
+    fAnalysis->SetTrackCuts(fTrackCuts);
+  } else {
+    AliFatal("TrackCuts missing!");
+  }
+  if (fAntiTrackCuts) {
+    fAnalysis->SetAntiTrackCuts(fAntiTrackCuts);
+  } else {
+    AliFatal("Antitrack cuts missing");
+  }
+//Leave v0's apart
+/*
+  if (fv0Cuts) {
+    fAnalysis->Setv0Cuts(fv0Cuts);
+  } else {
+    AliFatal("v0 cuts missing");
+  }
+  if (fAntiv0Cuts) {
+    fAnalysis->SetAntiv0Cuts(fAntiv0Cuts);
+  } else {
+    AliFatal("Antiv0 cuts missing");
+  }
+*/
+  if (fCascCuts) {
+    fAnalysis->SetCascadeCuts(fCascCuts);
+  } else {
+    AliFatal("Cascade cuts missing");
+  }
+  if (fAntiCascCuts) {
+    fAnalysis->SetAntiCascadeCuts(fAntiCascCuts);
+  } else {
+    AliFatal("AntiCascade cuts missing");
+  }
+  if (fCascOmegaCuts) {
+    fAnalysis->SetCascadeOmegaCuts(fCascOmegaCuts);
+  } else {
+    AliFatal("Cascade cuts missing");
+  }
+  if (fAntiCascOmegaCuts) {
+    fAnalysis->SetAntiCascadeOmegaCuts(fAntiCascOmegaCuts);
+  } else {
+    AliFatal("AntiCascade cuts missing");
+  }
+
+  if (fConfig) {
+    fAnalysis->SetCollectionConfig(fConfig);
+    fMinBookingME = fConfig->GetMinimalBookingME();
+    fMinBookingSample = fConfig->GetMinimalBookingSample();
+  } else {
+    AliFatal("Event Collection Config missing");
+  }
+
+  fAnalysis->Init(fIsMC, GetCollisionCandidates());
+  if ((!fMinBookingME) || (!fMinBookingSample)) {
+    if (fAnalysis->GetQAList()) {
+      fQA = fAnalysis->GetQAList();
+    } else {
+      fQA = new TList();
+      fQA->SetName("QA");
+      fQA->SetOwner();
+    }
+  } else {
+    fQA = new TList();
+    fQA->SetName("QA");
+    fQA->SetOwner();
+  }
+
+  if (!fMinBookingME) {
+    if (fAnalysis->GetResultQAList()) {
+      fResultQA = fAnalysis->GetResultQAList();
+    } else {
+      fResultQA = new TList();
+      fResultQA->SetName("ResultQA");
+      fResultQA->SetOwner();
+    }
+  } else {
+    fResultQA = new TList();
+    fResultQA->SetName("ResultQA");
+    fResultQA->SetOwner();
+  }
+
+  if (!fMinBookingSample) {
+    if (fAnalysis->GetResultSampleQAList()) {
+      fResultQASample = fAnalysis->GetResultSampleQAList();
+    } else {
+      fResultQASample = new TList();
+      fResultQASample->SetOwner();
+      fResultQASample->SetName("ResultsQASample");
+    }
+  } else {
+    fResultQASample = new TList();
+    fResultQASample->SetOwner();
+    fResultQASample->SetName("ResultsQASample");
+  }
+
+  if (!fEvtCuts->GetMinimalBooking()) {
+    if (fAnalysis->GetEventCutHists()) {
+      fEvtHistList = fAnalysis->GetEventCutHists();
+    }
+  } else {
+    fEvtHistList = new TList();
+    fEvtHistList->SetName("EventCuts");
+    fEvtHistList->SetOwner();
+  }
+  if (fAnalysis->GetTrackCutHists()) {
+    fTrackCutHistList = fAnalysis->GetTrackCutHists();
+  } else {
+    fTrackCutHistList = new TList();
+    fTrackCutHistList->SetName("TrackCuts");
+    fTrackCutHistList->SetOwner();
+  }
+  if (fAnalysis->GetAntitrackCutHists()) {
+    fAntiTrackCutHistList = fAnalysis->GetAntitrackCutHists();
+  } else {
+    fAntiTrackCutHistList = new TList();
+    fAntiTrackCutHistList->SetName("AntiTrackCuts");
+    fAntiTrackCutHistList->SetOwner();
+  }
+
+//Leave v0s apart
+/*
+  if (fAnalysis->Getv0CutHist()) {
+    fv0CutHistList = fAnalysis->Getv0CutHist();
+  } else {
+    fv0CutHistList = new TList();
+    fv0CutHistList->SetName("v0Cuts");
+    fv0CutHistList->SetOwner();
+  }
+  if (fAnalysis->GetAntiv0CutHist()) {
+    fAntiv0CutHistList = fAnalysis->GetAntiv0CutHist();
+  } else {
+    fAntiv0CutHistList = new TList();
+    fAntiv0CutHistList->SetName("Antiv0Cuts");
+    fAntiv0CutHistList->SetOwner();
+  }
+*/
+
+  if (fAnalysis->GetCascadeCutHist()) {
+    fCascCutList = fAnalysis->GetCascadeCutHist();
+  } else {
+    fCascCutList = new TList();
+    fCascCutList->SetName("CascadeCuts");
+    fCascCutList->SetOwner();
+  }
+  if (fAnalysis->GetAntiCascadeCutHist()) {
+    fAntiCascCutList = fAnalysis->GetAntiCascadeCutHist();
+  } else {
+    fAntiCascCutList = new TList();
+    fAntiCascCutList->SetName("AntiCascadeCuts");
+    fAntiCascCutList->SetOwner();
+  }
+
+  if (fAnalysis->GetCascadeOmegaCutHist()) {
+    fCascOmegaCutList = fAnalysis->GetCascadeOmegaCutHist();
+  } else {
+    fCascOmegaCutList = new TList();
+    fCascOmegaCutList->SetName("CascadeOmegaCuts");
+    fCascOmegaCutList->SetOwner();
+  }
+  if (fAnalysis->GetAntiCascadeOmegaCutHist()) {
+    fAntiCascOmegaCutList = fAnalysis->GetAntiCascadeOmegaCutHist();
+  } else {
+    fAntiCascOmegaCutList = new TList();
+    fAntiCascOmegaCutList->SetName("AntiCascadeOmegaCuts");
+    fAntiCascOmegaCutList->SetOwner();
+  }
+
+  //Results we always post
+  if (fAnalysis->GetResultList()) {
+    fResults = fAnalysis->GetResultList();
+  } else {
+    AliWarning("Results List not Available");
+    fResults = new TList();
+    fResults->SetOwner();
+    fResults->SetName("ResultsSample");
+  }
+  if (fAnalysis->GetResultSampleList()) {
+    fResultsSample = fAnalysis->GetResultSampleList();
+  } else {
+    AliWarning("Results Sample List not Available");
+    fResultsSample = new TList();
+    fResultsSample->SetOwner();
+    fResultsSample->SetName("ResultsSample");
+  }
+  if(fAnalysis->GetTreeCascade()){
+   fTreeCascade = fAnalysis->GetTreeCascade();
+  }else{
+   AliFatal(" fTreeCascade missing ");
+  }
+  if(fAnalysis->GetTreeOmega()){
+   fTreeOmega = fAnalysis->GetTreeOmega();
+  }else{
+   AliFatal(" fTreeOmega missing ");
+  }
+
+  PostData(1, fQA);
+  PostData(2, fEvtHistList);
+  PostData(3, fTrackCutHistList);
+  PostData(4, fAntiTrackCutHistList);
+//  PostData(5, fv0CutHistList);// ->moved to omega
+//  PostData(6, fAntiv0CutHistList);//  -> moved to omega
+  PostData(5, fCascOmegaCutList);
+  PostData(6, fAntiCascOmegaCutList);
+  PostData(7, fCascCutList);
+  PostData(8, fAntiCascCutList);
+  PostData(9, fResults);
+  PostData(10, fResultQA);
+  PostData(11, fResultsSample);
+  PostData(12, fResultQASample);
+  PostData(13, fTreeCascade);
+  PostData(14, fTreeOmega);
+
+  if (fIsMC) {
+    if (!fTrackCuts->GetMinimalBooking()) {
+      if (fTrackCuts->GetIsMonteCarlo()) {
+        fTrackCutHistMCList = fTrackCuts->GetMCQAHists();
+      }
+    } else {
+      fTrackCutHistMCList = new TList();
+      fTrackCutHistMCList->SetName("MCTrkCuts");
+      fTrackCutHistMCList->SetOwner();
+    }
+    if (!fAntiTrackCuts->GetMinimalBooking()) {
+      if (fAntiTrackCuts->GetIsMonteCarlo()) {
+        fAntiTrackCutHistMCList = fAntiTrackCuts->GetMCQAHists();
+      }
+    } else {
+      fAntiTrackCutHistMCList = new TList();
+      fAntiTrackCutHistMCList->SetName("MCAntiTrkCuts");
+      fAntiTrackCutHistMCList->SetOwner();
+    }
+
+//Leave v0s apart
+/*
+    if (!fv0Cuts->GetMinimalBooking()) {
+      if (fv0Cuts->GetIsMonteCarlo()) {
+        fv0CutHistMCList = fv0Cuts->GetMCQAHists();
+      }
+    } else {
+      fv0CutHistMCList = new TList();
+      fv0CutHistMCList->SetName("MCv0Cuts");
+      fv0CutHistMCList->SetOwner();
+    }
+    if (!fAntiv0Cuts->GetMinimalBooking()) {
+      if (fAntiv0Cuts->GetIsMonteCarlo()) {
+        fAntiv0CutHistMCList = fAntiv0Cuts->GetMCQAHists();
+      }
+    } else {
+      fAntiv0CutHistMCList = new TList();
+      fAntiv0CutHistMCList->SetName("MCAntiv0Cuts");
+      fAntiv0CutHistMCList->SetOwner();
+    }
+*/
+
+
+    if (!fCascCuts->GetMinimalBooking()) {
+      if (fCascCuts->GetIsMonteCarlo()) {
+        fCascCutMCList = fCascCuts->GetMCQAHists();
+      }
+    } else {
+      fCascCutMCList = new TList();
+      fCascCutMCList->SetName("MCCascCuts");
+      fCascCutMCList->SetOwner();
+    }
+    if (!fAntiCascCuts->GetMinimalBooking()) {
+      if (fAntiCascCuts->GetIsMonteCarlo()) {
+        fAntiCascCutMCList = fAntiCascCuts->GetMCQAHists();
+      }
+    } else {
+      fAntiCascCutMCList = new TList();
+      fAntiCascCutMCList->SetName("MCAntiCascCuts");
+      fAntiCascCutMCList->SetOwner();
+    }
+
+
+    if (!fCascOmegaCuts->GetMinimalBooking()) {
+      if (fCascOmegaCuts->GetIsMonteCarlo()) {
+        fCascOmegaCutMCList = fCascOmegaCuts->GetMCQAHists();
+      }
+    } else {
+      fCascOmegaCutMCList = new TList();
+      fCascOmegaCutMCList->SetName("MCCascOmegaCuts");
+      fCascOmegaCutMCList->SetOwner();
+    }
+    if (!fAntiCascOmegaCuts->GetMinimalBooking()) {
+      if (fAntiCascOmegaCuts->GetIsMonteCarlo()) {
+        fAntiCascOmegaCutMCList = fAntiCascOmegaCuts->GetMCQAHists();
+      }
+    } else {
+      fAntiCascOmegaCutMCList = new TList();
+      fAntiCascOmegaCutMCList->SetName("MCAntiCascOmegaCuts");
+      fAntiCascOmegaCutMCList->SetOwner();
+    }
+
+
+    PostData(15, fTrackCutHistMCList);
+    PostData(16, fAntiTrackCutHistMCList);
+//move v0
+//    PostData(17, fv0CutHistMCList);
+//    PostData(18, fAntiv0CutHistMCList);
+    PostData(17, fCascOmegaCutMCList);
+    PostData(18, fAntiCascOmegaCutMCList);
+    PostData(19, fCascCutMCList);
+    PostData(20, fAntiCascCutMCList);
+  }
+}
+
+void AliAnalysisTaskOtonOmega::UserExec(Option_t *) {
+  if (fESDAnalysis) {
+    AliESDEvent *Event = static_cast<AliESDEvent*>(fInputEvent);
+    AliMCEvent *mcEvent=nullptr;
+    if (fIsMC) {
+      mcEvent = MCEvent();
+    }
+    if (!Event) {
+      AliWarning("No Input Event");
+    } else {
+      fAnalysis->Make(Event, mcEvent, fCascadeTreeFlag, fOmegaTreeFlag);
+    }
+  } else {
+    AliAODEvent *Event = static_cast<AliAODEvent*>(fInputEvent);
+    if (!Event) {
+      AliWarning("No Input Event");
+    } else {
+      fAnalysis->Make(Event);
+    }
+  }
+  PostData(1, fQA);
+  PostData(2, fEvtHistList);
+  PostData(3, fTrackCutHistList);
+  PostData(4, fAntiTrackCutHistList);
+//  PostData(5, fv0CutHistList);
+//  PostData(6, fAntiv0CutHistList);
+  PostData(5, fCascOmegaCutList);
+  PostData(6, fAntiCascOmegaCutList);
+  PostData(7, fCascCutList);
+  PostData(8, fAntiCascCutList);
+  PostData(9, fResults);
+  PostData(10, fResultQA);
+  PostData(11, fResultsSample);
+  PostData(12, fResultQASample);
+  PostData(13, fTreeCascade);
+  PostData(14, fTreeOmega);
+  if (fIsMC) {
+    PostData(15, fTrackCutHistMCList);
+    PostData(16, fAntiTrackCutHistMCList);
+//    PostData(17, fv0CutHistMCList);
+//    PostData(18, fAntiv0CutHistMCList);
+    PostData(17, fCascOmegaCutMCList);
+    PostData(18, fAntiCascOmegaCutMCList);
+    PostData(19, fCascCutMCList);
+    PostData(20, fAntiCascCutMCList);
+  }
+}

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskOtonOmega.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskOtonOmega.h
@@ -1,0 +1,135 @@
+/*
+ * AliAnalysisTaskFemtoPlotration.h
+ *
+ *  Created on: 24 Nov 2017
+ *      Author: bernhardhohlweger
+ */
+
+#ifndef ALIANALYSISTASKOTONOMEGA_H_
+#define ALIANALYSISTASKOTONOMEGA_H_
+#include "AliAnalysisTaskSE.h"
+#include "AliOtonOmegaAnalysis.h"
+#include "AliFemtoDreamCollConfig.h"
+#include "AliFemtoDreamEventCuts.h"
+#include "AliFemtoDreamTrackCuts.h"
+#include "AliFemtoDreamv0Cuts.h"
+#include "AliOtonOmegaCascadeCuts.h"
+#include "TList.h"
+#include "TTree.h"
+class AliAnalysisTaskOtonOmega : public AliAnalysisTaskSE {
+ public:
+  AliAnalysisTaskOtonOmega();
+  AliAnalysisTaskOtonOmega(const char *name, bool isESD, bool isMC, bool CascadeTreeFlag, bool OmegaTreeFlag);
+  AliAnalysisTaskOtonOmega(const AliAnalysisTaskOtonOmega& task);
+  AliAnalysisTaskOtonOmega& operator=(const AliAnalysisTaskOtonOmega& task);
+  virtual ~AliAnalysisTaskOtonOmega();
+  virtual void UserCreateOutputObjects();
+  virtual void UserExec(Option_t *);
+  virtual void Terminate(Option_t *) {
+  }
+  ;
+  void SetMVPileUp(bool mvPileUp) {
+    fMVPileUp = mvPileUp;
+  }
+  ;
+  void SetEvtCutQA(bool setQA) {
+    fEvtCutQA = setQA;
+  }
+  ;
+  void SetEventCuts(AliFemtoDreamEventCuts *cuts) {
+    fEvtCuts = cuts;
+  }
+  ;
+  void SetTrackCuts(AliFemtoDreamTrackCuts *cuts) {
+    fTrackCuts = cuts;
+  }
+  ;
+  void SetAntiTrackCuts(AliFemtoDreamTrackCuts *cuts) {
+    fAntiTrackCuts = cuts;
+  }
+  ;
+  void Setv0Cuts(AliFemtoDreamv0Cuts *cuts) {
+    fv0Cuts = cuts;
+  }
+  ;
+  void SetAntiv0Cuts(AliFemtoDreamv0Cuts *cuts) {
+    fAntiv0Cuts = cuts;
+  }
+  ;
+  void SetCascadeCuts(AliOtonOmegaCascadeCuts *cuts) {
+    fCascCuts = cuts;
+  }
+  ;
+  void SetAntiCascadeCuts(AliOtonOmegaCascadeCuts *cuts) {
+    fAntiCascCuts = cuts;
+  }
+  ;
+
+  void SetCascadeOmegaCuts(AliOtonOmegaCascadeCuts *cuts) {
+    fCascOmegaCuts = cuts;
+  }
+  ;
+  void SetAntiCascadeOmegaCuts(AliOtonOmegaCascadeCuts *cuts) {
+    fAntiCascOmegaCuts = cuts;
+  }
+  ;
+
+
+  void SetTrackBufferSize(int size) {
+    fTrackBufferSize = size;
+  }
+  ;
+  void SetCollectionConfig(AliFemtoDreamCollConfig *conf) {
+    fConfig = conf;
+  }
+  ;
+ private:
+  int fTrackBufferSize;                     //
+  bool fESDAnalysis;                        //
+  bool fCascadeTreeFlag;                        //
+  bool fOmegaTreeFlag;                        //
+  bool fMinBookingME;                       //
+  bool fMinBookingSample;                   //
+  bool fMVPileUp;                           //
+  bool fEvtCutQA;                           //
+  bool fIsMC;                               //
+  AliOtonOmegaAnalysis *fAnalysis;         //!
+  TList *fQA;                               //!
+  AliFemtoDreamEventCuts *fEvtCuts;         //
+  TList *fEvtHistList;                      //!
+  AliFemtoDreamTrackCuts *fTrackCuts;       //
+  TList *fTrackCutHistList;                 //!
+  TList *fTrackCutHistMCList;               //!
+  AliFemtoDreamTrackCuts *fAntiTrackCuts;   //
+  TList *fAntiTrackCutHistList;             //!
+  TList *fAntiTrackCutHistMCList;           //!
+  AliFemtoDreamv0Cuts *fv0Cuts;             //
+  TList *fv0CutHistList;                    //!
+  TList *fv0CutHistMCList;                  //!
+  AliFemtoDreamv0Cuts *fAntiv0Cuts;         //
+  TList *fAntiv0CutHistList;                //!
+  TList *fAntiv0CutHistMCList;              //!
+  AliOtonOmegaCascadeCuts *fCascCuts;      //
+  TList *fCascCutList;                      //!
+  TList *fCascCutMCList;                    //!
+  AliOtonOmegaCascadeCuts *fAntiCascCuts;  //
+  TList *fAntiCascCutList;                  //!
+  TList *fAntiCascCutMCList;                //!
+  AliOtonOmegaCascadeCuts *fCascOmegaCuts;      //
+  TList *fCascOmegaCutList;                      //!
+  TList *fCascOmegaCutMCList;                    //!
+  AliOtonOmegaCascadeCuts *fAntiCascOmegaCuts;  //
+  TList *fAntiCascOmegaCutList;                  //!
+  TList *fAntiCascOmegaCutMCList;                //!
+
+  AliFemtoDreamCollConfig *fConfig;         //
+  TList *fResults;                          //!
+  TList *fResultQA;                         //!
+  TList *fResultsSample;                    //!
+  TList *fResultQASample;					//!
+  TTree* fTreeCascade;  //!
+  TTree* fTreeOmega;  //!
+ClassDef(AliAnalysisTaskOtonOmega,4)
+};
+
+#endif /* ALIANALYSISTASKOTONOMEGA_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliOtonOmegaAnalysis.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliOtonOmegaAnalysis.cxx
@@ -1,0 +1,971 @@
+/*
+ * AliOtonOmegaAnalysis.cxx
+ *
+ *  Created on: 24 Nov 2017
+ *      Author: bernhardhohlweger. Adapted for Proton-Omega by Oton Vazquez Doce.
+ */
+#include <vector>
+#include "AliLog.h"
+#include "AliOtonOmegaAnalysis.h"
+#include "TClonesArray.h"
+#include "AliAODInputHandler.h"
+#include "AliAnalysisManager.h"
+#include <iostream>
+ClassImp(AliOtonOmegaAnalysis)
+AliOtonOmegaAnalysis::AliOtonOmegaAnalysis()
+    : fMVPileUp(false),
+      fEvtCutQA(false),
+      fQA(),
+      fFemtoTrack(nullptr),
+      fFemtov0(nullptr),
+      fFemtoCasc(nullptr),
+      fEvent(nullptr),
+      fEvtCuts(nullptr),
+      fTrackCuts(nullptr),
+      fAntiTrackCuts(nullptr),
+      fv0Cuts(nullptr),
+      fAntiv0Cuts(nullptr),
+      fCascCuts(nullptr),
+      fAntiCascCuts(nullptr),
+      fCascOmegaCuts(nullptr),
+      fAntiCascOmegaCuts(nullptr),
+      fPairCleaner(nullptr),
+      fControlSample(nullptr),
+      fTrackBufferSize(0),
+      fGTI(nullptr),
+      fConfig(nullptr),
+      fPartColl(nullptr),
+      fPIDResponse(NULL),
+      fIsMC(false) {
+
+}
+
+AliOtonOmegaAnalysis::AliOtonOmegaAnalysis(
+    const AliOtonOmegaAnalysis& analysis)
+    : fMVPileUp(analysis.fMVPileUp),
+      fEvtCutQA(analysis.fEvtCutQA),
+      fQA(nullptr),
+      fFemtoTrack(nullptr),
+      fFemtov0(nullptr),
+      fFemtoCasc(nullptr),
+      fEvent(nullptr),
+      fEvtCuts(analysis.fEvtCuts),
+      fTrackCuts(analysis.fTrackCuts),
+      fAntiTrackCuts(analysis.fAntiTrackCuts),
+      fv0Cuts(analysis.fv0Cuts),
+      fAntiv0Cuts(analysis.fAntiv0Cuts),
+      fCascCuts(analysis.fCascCuts),
+      fAntiCascCuts(analysis.fAntiCascCuts),
+      fCascOmegaCuts(analysis.fCascOmegaCuts),
+      fAntiCascOmegaCuts(analysis.fAntiCascOmegaCuts),
+      fPairCleaner(nullptr),
+      fControlSample(nullptr),
+      fTrackBufferSize(analysis.fTrackBufferSize),
+      fGTI(nullptr),
+      fConfig(analysis.fConfig),
+      fPartColl(nullptr),
+      fPIDResponse(NULL),
+      fIsMC(analysis.fIsMC) {
+  Init(fIsMC, AliVEvent::kINT7);
+}
+
+AliOtonOmegaAnalysis& AliOtonOmegaAnalysis::operator=(
+    const AliOtonOmegaAnalysis& analysis) {
+  if (this != &analysis) {
+    this->fMVPileUp = analysis.fMVPileUp;
+    this->fEvtCutQA = analysis.fEvtCutQA;
+    this->fQA = nullptr;
+    this->fFemtoTrack = nullptr;
+    this->fFemtov0 = nullptr;
+    this->fFemtoCasc = nullptr;
+    this->fEvent = nullptr;
+    this->fEvtCuts = analysis.fEvtCuts;
+    this->fTrackCuts = analysis.fTrackCuts;
+    this->fAntiTrackCuts = analysis.fAntiTrackCuts;
+    this->fv0Cuts = analysis.fv0Cuts;
+    this->fAntiv0Cuts = analysis.fAntiv0Cuts;
+    this->fCascCuts = analysis.fCascCuts;
+    this->fAntiCascCuts = analysis.fAntiCascCuts;
+    this->fCascOmegaCuts = analysis.fCascOmegaCuts;
+    this->fAntiCascOmegaCuts = analysis.fAntiCascOmegaCuts;
+    this->fPairCleaner = nullptr;
+    this->fControlSample = nullptr;
+    this->fTrackBufferSize = analysis.fTrackBufferSize;
+    this->fGTI = nullptr;
+    this->fConfig = analysis.fConfig;
+    this->fPartColl = nullptr;
+    this->fIsMC = analysis.fIsMC;
+    this->Init(this->fIsMC, AliVEvent::kINT7);
+  }
+  return *this;
+}
+
+AliOtonOmegaAnalysis::~AliOtonOmegaAnalysis() {
+  if (fEvent) {
+    delete fEvent;
+  }
+  if (fFemtoTrack) {
+    delete fFemtoTrack;
+  }
+  if (fFemtov0) {
+    delete fFemtov0;
+  }
+  if (fFemtoCasc) {
+    delete fFemtoCasc;
+  }
+  if (fPairCleaner) {
+    delete fPairCleaner;
+  }
+  if (fPartColl) {
+    delete fPartColl;
+  }
+  if(fPIDResponse) delete fPIDResponse;
+  if (fControlSample) {
+    delete fControlSample;
+  }
+}
+
+void AliOtonOmegaAnalysis::Init(bool isMonteCarlo, UInt_t trigger) {
+  fIsMC = isMonteCarlo;
+  fFemtoTrack = new AliFemtoDreamTrack();
+  fFemtoTrack->SetUseMCInfo(isMonteCarlo);
+
+  fFemtov0 = new AliFemtoDreamv0();
+//do not set v0s
+/*
+  fFemtov0->SetPDGCode(fv0Cuts->GetPDGv0());
+  fFemtov0->SetUseMCInfo(isMonteCarlo);
+  fFemtov0->SetPDGDaughterPos(fv0Cuts->GetPDGPosDaug());  //order +sign doesnt play a role
+  fFemtov0->GetPosDaughter()->SetUseMCInfo(isMonteCarlo);
+  fFemtov0->SetPDGDaughterNeg(fv0Cuts->GetPDGNegDaug());  //only used for MC Matching
+  fFemtov0->GetNegDaughter()->SetUseMCInfo(isMonteCarlo);
+*/
+
+
+//For MC this will have to be probably changed, in order to have Xi and Omega (ask B. Hohlweger):
+  fFemtoCasc = new AliOtonOmegaCascade();
+  fFemtoCasc->SetUseMCInfo(isMonteCarlo);
+  //PDG Codes should be set assuming Xi- to also work for Xi+
+  fFemtoCasc->SetPDGCode(fCascCuts->GetPDGCodeCasc());
+  fFemtoCasc->SetPDGDaugPos(fCascCuts->GetPDGCodePosDaug());
+  fFemtoCasc->GetPosDaug()->SetUseMCInfo(isMonteCarlo);
+  fFemtoCasc->SetPDGDaugNeg(fCascCuts->GetPDGCodeNegDaug());
+  fFemtoCasc->GetNegDaug()->SetUseMCInfo(isMonteCarlo);
+  fFemtoCasc->SetPDGDaugBach(fCascCuts->GetPDGCodeBach());
+  fFemtoCasc->GetBach()->SetUseMCInfo(isMonteCarlo);
+  fFemtoCasc->Setv0PDGCode(fCascCuts->GetPDGv0());
+
+
+  fEvtCuts->InitQA();
+  fTrackCuts->Init();
+  fAntiTrackCuts->Init();
+//  fv0Cuts->Init();
+//  fAntiv0Cuts->Init();
+  fCascCuts->Init();
+  fAntiCascCuts->Init();
+ if(!fCascOmegaCuts) { AliFatal("omegaCuts not set");}
+  fCascOmegaCuts->Init();
+  fAntiCascOmegaCuts->Init();
+  fGTI = new AliAODTrack*[fTrackBufferSize];
+  fEvent = new AliFemtoDreamEvent(fMVPileUp, fEvtCutQA, trigger);
+  fEvent->SetMultiplicityEstimator(fConfig->GetMultiplicityEstimator());
+  bool MinBooking = !((!fConfig->GetMinimalBookingME())
+      || (!fConfig->GetMinimalBookingSample()));
+  fPairCleaner = new AliFemtoDreamPairCleaner(4, 4, MinBooking);
+
+  if (!MinBooking) {
+    fQA = new TList();
+    fQA->SetOwner();
+    fQA->SetName("QA");
+    fQA->Add(fPairCleaner->GetHistList());
+    if (fEvtCutQA) {
+      fQA->Add(fEvent->GetEvtCutList());
+    }
+  }
+  if (fConfig->GetUseEventMixing()) {
+    fPartColl = new AliFemtoDreamPartCollection(fConfig,
+                                                fConfig->GetMinimalBookingME());
+  }
+  if (fConfig->GetUsePhiSpinning()) {
+    fControlSample = new AliFemtoDreamControlSample(
+        fConfig, fConfig->GetMinimalBookingSample());
+  }
+
+  InitializeTreeBooking();
+
+  return;
+}
+
+
+void AliOtonOmegaAnalysis::InitializeTreeBooking() {
+
+ AliAnalysisManager *man=AliAnalysisManager::GetAnalysisManager();
+ AliInputEventHandler* inputHandler = (AliInputEventHandler*) (man->GetInputEventHandler());
+ fPIDResponse = inputHandler->GetPIDResponse();
+
+ //book tree:
+ foTTree = new TTree("oTTree","a simple TTree");
+ foTTree->SetDirectory(0); // This is to force a memory-resident Tree, and avoid errors. // ????? is this necessary? does it create memory problems?
+ foTTree->Branch("RunNumber",&fTRunNumber,"fTRunNumber/I");
+ foTTree->Branch("V",&fTV,"fTV[3]/F");
+ foTTree->Branch("nCascade",&fTnCascade,"fTnCascade/I");
+ foTTree->Branch("CascadePx",&fTCascadePx,"fTCascadePx[fTnCascade]/F");
+ foTTree->Branch("CascadePy",&fTCascadePy,"fTCascadePy[fTnCascade]/F");
+ foTTree->Branch("CascadePz",&fTCascadePz,"fTCascadePz[fTnCascade]/F");
+ foTTree->Branch("CascadeCharge",&fTCascadeCharge,"fTCascadeCharge[fTnCascade]/S");
+ foTTree->Branch("CascadeDCA",&fTCascadeDCA,"fTCascadeDCA[fTnCascade]/F");
+ foTTree->Branch("CascadeDaughtersDCA",&fTCascadeDaughtersDCA,"fTCascadeDaughtersDCA[fTnCascade]/F");
+ foTTree->Branch("CascadeXiMass",&fTCascadeXiMass,"fTCascadeXiMass[fTnCascade]/F");
+ foTTree->Branch("CascadeOmegaMass",&fTCascadeOmegaMass,"fTCascadeOmegaMass[fTnCascade]/F");
+ foTTree->Branch("CascadeVx",&fTCascadeVx,"fTCascadeVx[fTnCascade]/F");
+ foTTree->Branch("CascadeVy",&fTCascadeVy,"fTCascadeVy[fTnCascade]/F");
+ foTTree->Branch("CascadeVz",&fTCascadeVz,"fTCascadeVz[fTnCascade]/F");
+ foTTree->Branch("CascadePA",&fTCascadePA,"fTCascadePA[fTnCascade]/F");
+ foTTree->Branch("LambdaPx",&fTLambdaPx,"fTLambdaPx[fTnCascade]/F");
+ foTTree->Branch("LambdaPy",&fTLambdaPy,"fTLambdaPy[fTnCascade]/F");
+ foTTree->Branch("LambdaPz",&fTLambdaPz,"fTLambdaPz[fTnCascade]/F");
+ foTTree->Branch("LambdaDCA",&fTLambdaDCA,"fTLambdaDCA[fTnCascade]/F");
+ foTTree->Branch("LambdaDaughtersDCA",&fTLambdaDaughtersDCA,"fTLambdaDaughtersDCA[fTnCascade]/F");
+ foTTree->Branch("LambdaMass",&fTLambdaMass,"fTLambdaMass[fTnCascade]/F");
+ foTTree->Branch("LambdaK0Mass",&fTLambdaK0Mass,"fTLambdaK0Mass[fTnCascade]/F");
+ foTTree->Branch("LambdaVx",&fTLambdaVx,"fTLambdaVx[fTnCascade]/F");
+ foTTree->Branch("LambdaVy",&fTLambdaVy,"fTLambdaVy[fTnCascade]/F");
+ foTTree->Branch("LambdaVz",&fTLambdaVz,"fTLambdaVz[fTnCascade]/F");
+ foTTree->Branch("LambdaPA",&fTLambdaPA,"fTLambdaPA[fTnCascade]/F");
+ foTTree->Branch("TrackPx",&fTTrackPx,"fTTrackPx[fTnCascade][3]/F");
+ foTTree->Branch("TrackPy",&fTTrackPy,"fTTrackPy[fTnCascade][3]/F");
+ foTTree->Branch("TrackPz",&fTTrackPz,"fTTrackPz[fTnCascade][3]/F");
+ foTTree->Branch("TrackTPCmom",&fTTrackTPCmom,"fTTrackTPCmom[fTnCascade][3]/F");
+ foTTree->Branch("TrackEta",&fTTrackEta,"fTTrackEta[fTnCascade][3]/F");
+ foTTree->Branch("TrackCharge",&fTTrackCharge,"fTTrackCharge[fTnCascade][3]/S");
+ foTTree->Branch("TrackDCA",&fTTrackDCA,"fTTrackDCA[fTnCascade][3]/F");
+ foTTree->Branch("TrackITSspi",&fTTrackITSspi,"fTTrackITSspi[fTnCascade][3]/F");
+ foTTree->Branch("TrackITSsk",&fTTrackITSsk,"fTTrackITSsk[fTnCascade][3]/F");
+ foTTree->Branch("TrackITSsp",&fTTrackITSsp,"fTTrackITSsp[fTnCascade][3]/F");
+ foTTree->Branch("TrackTPCspi",&fTTrackTPCspi,"fTTrackTPCspi[fTnCascade][3]/F");
+ foTTree->Branch("TrackTPCsk",&fTTrackTPCsk,"fTTrackTPCsk[fTnCascade][3]/F");
+ foTTree->Branch("TrackTPCsp",&fTTrackTPCsp,"fTTrackTPCsp[fTnCascade][3]/F");
+ foTTree->Branch("TrackTOFspi",&fTTrackTOFspi,"fTTrackTOFspi[fTnCascade][3]/F");
+ foTTree->Branch("TrackTOFsk",&fTTrackTOFsk,"fTTrackTOFsk[fTnCascade][3]/F");
+ foTTree->Branch("TrackTOFsp",&fTTrackTOFsp,"fTTrackTOFsp[fTnCascade][3]/F");
+ foTTree->Branch("TrackITStime",&fTTrackITStime,"fTTrackITStime[fTnCascade][3]/O");
+ foTTree->Branch("TrackTOFtime",&fTTrackTOFtime,"fTTrackTOFtime[fTnCascade][3]/O");
+ foTTree->Branch("TrackTPConly",&fTTrackTPConly,"fTTrackTPConly[fTnCascade][3]/O");
+ foTTree->Branch("TrackITScomplementary",&fTTrackITScomplementary,"fTTrackITScomplementary[fTnCascade][3]/O");
+ foTTree->Branch("TrackITSpure",&fTTrackITSpure,"fTTrackITSpure[fTnCascade][3]/O");
+ foTTree->Branch("TrackGLOBAL",&fTTrackGLOBAL,"fTTrackGLOBAL[fTnCascade][3]/O");
+
+ fomegaTTree = new TTree("omegaTTree","a simple TTree of omega leafs and life truths");
+ fomegaTTree->SetDirectory(0); // This is to force a memory-resident Tree, and avoid errors. // ????? is this necessary? does it create memory problems?
+ fomegaTTree->Branch("RunNumber",&fTRunNumber,"fTRunNumber/I");
+ fomegaTTree->Branch("V",&fTV,"fTV[3]/F");
+ fomegaTTree->Branch("nCascade",&fTnCascade,"fTnCascade/I");
+ fomegaTTree->Branch("CascadePx",&fTCascadePx,"fTCascadePx[fTnCascade]/F");
+ fomegaTTree->Branch("CascadePy",&fTCascadePy,"fTCascadePy[fTnCascade]/F");
+ fomegaTTree->Branch("CascadePz",&fTCascadePz,"fTCascadePz[fTnCascade]/F");
+ fomegaTTree->Branch("CascadeCharge",&fTCascadeCharge,"fTCascadeCharge[fTnCascade]/S");
+ fomegaTTree->Branch("CascadeDCA",&fTCascadeDCA,"fTCascadeDCA[fTnCascade]/F");
+ fomegaTTree->Branch("CascadeDaughtersDCA",&fTCascadeDaughtersDCA,"fTCascadeDaughtersDCA[fTnCascade]/F");
+ fomegaTTree->Branch("CascadeXiMass",&fTCascadeXiMass,"fTCascadeXiMass[fTnCascade]/F");
+ fomegaTTree->Branch("CascadeOmegaMass",&fTCascadeOmegaMass,"fTCascadeOmegaMass[fTnCascade]/F");
+ fomegaTTree->Branch("CascadeVx",&fTCascadeVx,"fTCascadeVx[fTnCascade]/F");
+ fomegaTTree->Branch("CascadeVy",&fTCascadeVy,"fTCascadeVy[fTnCascade]/F");
+ fomegaTTree->Branch("CascadeVz",&fTCascadeVz,"fTCascadeVz[fTnCascade]/F");
+ fomegaTTree->Branch("CascadePA",&fTCascadePA,"fTCascadePA[fTnCascade]/F");
+ fomegaTTree->Branch("LambdaPx",&fTLambdaPx,"fTLambdaPx[fTnCascade]/F");
+ fomegaTTree->Branch("LambdaPy",&fTLambdaPy,"fTLambdaPy[fTnCascade]/F");
+ fomegaTTree->Branch("LambdaPz",&fTLambdaPz,"fTLambdaPz[fTnCascade]/F");
+ fomegaTTree->Branch("LambdaDCA",&fTLambdaDCA,"fTLambdaDCA[fTnCascade]/F");
+ fomegaTTree->Branch("LambdaDaughtersDCA",&fTLambdaDaughtersDCA,"fTLambdaDaughtersDCA[fTnCascade]/F");
+ fomegaTTree->Branch("LambdaMass",&fTLambdaMass,"fTLambdaMass[fTnCascade]/F");
+ fomegaTTree->Branch("LambdaK0Mass",&fTLambdaK0Mass,"fTLambdaK0Mass[fTnCascade]/F");
+ fomegaTTree->Branch("LambdaVx",&fTLambdaVx,"fTLambdaVx[fTnCascade]/F");
+ fomegaTTree->Branch("LambdaVy",&fTLambdaVy,"fTLambdaVy[fTnCascade]/F");
+ fomegaTTree->Branch("LambdaVz",&fTLambdaVz,"fTLambdaVz[fTnCascade]/F");
+ fomegaTTree->Branch("LambdaPA",&fTLambdaPA,"fTLambdaPA[fTnCascade]/F");
+ fomegaTTree->Branch("TrackPx",&fTTrackPx,"fTTrackPx[fTnCascade][3]/F");
+ fomegaTTree->Branch("TrackPy",&fTTrackPy,"fTTrackPy[fTnCascade][3]/F");
+ fomegaTTree->Branch("TrackPz",&fTTrackPz,"fTTrackPz[fTnCascade][3]/F");
+ fomegaTTree->Branch("TrackTPCmom",&fTTrackTPCmom,"fTTrackTPCmom[fTnCascade][3]/F");
+ fomegaTTree->Branch("TrackEta",&fTTrackEta,"fTTrackEta[fTnCascade][3]/F");
+ fomegaTTree->Branch("TrackCharge",&fTTrackCharge,"fTTrackCharge[fTnCascade][3]/S");
+ fomegaTTree->Branch("TrackDCA",&fTTrackDCA,"fTTrackDCA[fTnCascade][3]/F");
+ fomegaTTree->Branch("TrackITSspi",&fTTrackITSspi,"fTTrackITSspi[fTnCascade][3]/F");
+ fomegaTTree->Branch("TrackITSsk",&fTTrackITSsk,"fTTrackITSsk[fTnCascade][3]/F");
+ fomegaTTree->Branch("TrackITSsp",&fTTrackITSsp,"fTTrackITSsp[fTnCascade][3]/F");
+ fomegaTTree->Branch("TrackTPCspi",&fTTrackTPCspi,"fTTrackTPCspi[fTnCascade][3]/F");
+ fomegaTTree->Branch("TrackTPCsk",&fTTrackTPCsk,"fTTrackTPCsk[fTnCascade][3]/F");
+ fomegaTTree->Branch("TrackTPCsp",&fTTrackTPCsp,"fTTrackTPCsp[fTnCascade][3]/F");
+ fomegaTTree->Branch("TrackTOFspi",&fTTrackTOFspi,"fTTrackTOFspi[fTnCascade][3]/F");
+ fomegaTTree->Branch("TrackTOFsk",&fTTrackTOFsk,"fTTrackTOFsk[fTnCascade][3]/F");
+ fomegaTTree->Branch("TrackTOFsp",&fTTrackTOFsp,"fTTrackTOFsp[fTnCascade][3]/F");
+ fomegaTTree->Branch("TrackNcl",&fTTrackNcl,"fTTrackNcl[fTnCascade][3]/I");
+ fomegaTTree->Branch("TrackCrF",&fTTrackCrF,"fTTrackCrF[fTnCascade][3]/F");
+ fomegaTTree->Branch("TrackShared",&fTTrackShared,"fTTrackShared[fTnCascade][3]/I");
+ fomegaTTree->Branch("TrackTPCchi2",&fTTrackTPCchi2,"fTTrackTPCchi2[fTnCascade][3]/F");
+ fomegaTTree->Branch("TrackITStime",&fTTrackITStime,"fTTrackITStime[fTnCascade][3]/O");
+ fomegaTTree->Branch("TrackTOFtime",&fTTrackTOFtime,"fTTrackTOFtime[fTnCascade][3]/O");
+ fomegaTTree->Branch("TrackTPConly",&fTTrackTPConly,"fTTrackTPConly[fTnCascade][3]/O");
+ fomegaTTree->Branch("TrackITScomplementary",&fTTrackITScomplementary,"fTTrackITScomplementary[fTnCascade][3]/O");
+ fomegaTTree->Branch("TrackITSpure",&fTTrackITSpure,"fTTrackITSpure[fTnCascade][3]/O");
+ fomegaTTree->Branch("TrackGLOBAL",&fTTrackGLOBAL,"fTTrackGLOBAL[fTnCascade][3]/O");
+}
+
+
+void AliOtonOmegaAnalysis::ResetGlobalTrackReference() {
+  //This method was inherited form H. Beck analysis
+
+  // Sets all the pointers to zero. To be called at
+  // the beginning or end of an event
+  for (UShort_t i = 0; i < fTrackBufferSize; i++) {
+    fGTI[i] = 0;
+  }
+}
+void AliOtonOmegaAnalysis::StoreGlobalTrackReference(AliAODTrack *track) {
+  //This method was inherited form H. Beck analysis
+
+  //bhohlweg@cern.ch: We ask for the Unique Track ID that points back to the
+  //ESD. Seems like global tracks have a positive ID, Tracks with Filterbit
+  //128 only have negative ID, this is used to match the Tracks later to their
+  //global counterparts
+
+  // Stores the pointer to the global track
+
+  // This was AOD073
+  // // Don't use the filter bits 2 (ITS standalone) and 128 TPC only
+  // // Remove this return statement and you'll see they don't have
+  // // any TPC signal
+  // if(track->TestFilterBit(128) || track->TestFilterBit(2))
+  //   return;
+  // This is AOD086
+  // Another set of tracks was introduced: Global constrained.
+  // We only want filter bit 1 <-- NO! we also want no
+  // filter bit at all, which are the v0 tracks
+  //  if(!track->TestFilterBit(1))
+  //    return;
+
+  // There are also tracks without any filter bit, i.e. filter map 0,
+  // at the beginning of the event: they have ~id 1 to 5, 1 to 12
+  // This are tracks that didn't survive the primary track filter but
+  // got written cause they are V0 daughters
+
+  // Check whether the track has some info
+  // I don't know: there are tracks with filter bit 0
+  // and no TPC signal. ITS standalone V0 daughters?
+  // if(!track->GetTPCsignal()){
+  //   printf("Warning: track has no TPC signal, "
+  //     //    "not adding it's info! "
+  //     "ID: %d FilterMap: %d\n"
+  //     ,track->GetID(),track->GetFilterMap());
+  //   //    return;
+  // }
+
+  // Check that the id is positive
+  const int trackID = track->GetID();
+  if (trackID < 0) {
+    return;
+  }
+
+  // Check id is not too big for buffer
+  if (trackID >= fTrackBufferSize) {
+    printf("Warning: track ID too big for buffer: ID: %d, buffer %d\n", trackID,
+           fTrackBufferSize);
+    return;
+  }
+
+  // Warn if we overwrite a track
+  if (fGTI[trackID]) {
+    // Seems like there are FilterMap 0 tracks
+    // that have zero TPCNcls, don't store these!
+    if ((!track->GetFilterMap()) && (!track->GetTPCNcls())) {
+      return;
+    }
+    // Imagine the other way around, the zero map zero clusters track
+    // is stored and the good one wants to be added. We ommit the warning
+    // and just overwrite the 'bad' track
+    if (fGTI[trackID]->GetFilterMap() || fGTI[trackID]->GetTPCNcls()) {
+      // If we come here, there's a problem
+      printf("Warning! global track info already there!");
+      printf("         TPCNcls track1 %u track2 %u",
+             (fGTI[trackID])->GetTPCNcls(), track->GetTPCNcls());
+      printf("         FilterMap track1 %u track2 %u\n",
+             (fGTI[trackID])->GetFilterMap(), track->GetFilterMap());
+    }
+  }  // Two tracks same id
+
+  // // There are tracks with filter bit 0,
+  // // do they have TPCNcls stored?
+  // if(!track->GetFilterMap()){
+  //   printf("Filter map is zero, TPCNcls: %u\n"
+  //     ,track->GetTPCNcls());
+  // }
+
+  // Assign the pointer
+  (fGTI[trackID]) = track;
+}
+
+void AliOtonOmegaAnalysis::Make(AliAODEvent *evt) {
+  if (!evt) {
+    AliFatal("No Input Event");
+  }
+  fEvent->SetEvent(evt);
+  if (!fEvtCuts->isSelected(fEvent)) {
+    return;
+  }
+  ResetGlobalTrackReference();
+  for (int iTrack = 0; iTrack < evt->GetNumberOfTracks(); ++iTrack) {
+    AliAODTrack *track = static_cast<AliAODTrack*>(evt->GetTrack(iTrack));
+    if (!track) {
+      AliFatal("No Standard AOD");
+      return;
+    }
+    StoreGlobalTrackReference(track);
+  }
+  std::vector<AliFemtoDreamBasePart> Particles;
+  std::vector<AliFemtoDreamBasePart> AntiParticles;
+  fFemtoTrack->SetGlobalTrackInfo(fGTI, fTrackBufferSize);
+  for (int iTrack = 0; iTrack < evt->GetNumberOfTracks(); ++iTrack) {
+    AliAODTrack *track = static_cast<AliAODTrack*>(evt->GetTrack(iTrack));
+    if (!track) {
+      AliFatal("No Standard AOD");
+      return;
+    }
+    fFemtoTrack->SetTrack(track, fEvent->GetMultiplicity());
+    if (fTrackCuts->isSelected(fFemtoTrack)) {
+      Particles.push_back(*fFemtoTrack);
+    }
+    if (fAntiTrackCuts->isSelected(fFemtoTrack)) {
+      AntiParticles.push_back(*fFemtoTrack);
+    }
+  }
+  std::vector<AliFemtoDreamBasePart> Decays;
+  std::vector<AliFemtoDreamBasePart> AntiDecays;
+  //  Look for the lambda, store it in an event
+  //  Get a V0 from the event:
+  TClonesArray *v01 = static_cast<TClonesArray*>(evt->GetV0s());
+  //number of V0s:
+
+  fFemtov0->SetGlobalTrackInfo(fGTI, fTrackBufferSize);
+  int entriesV0 = v01->GetEntriesFast();
+  for (int iv0 = 0; iv0 < entriesV0; iv0++) {
+    AliAODv0 *v0 = evt->GetV0(iv0);
+    fFemtov0->Setv0(evt, v0, fEvent->GetMultiplicity());
+    if (fv0Cuts->isSelected(fFemtov0)) {
+      Decays.push_back(*fFemtov0);
+    }
+    if (fAntiv0Cuts->isSelected(fFemtov0)) {
+      AntiDecays.push_back(*fFemtov0);
+    }
+  }
+  //  std::cout << "=====================================\n" ;
+  //  std::cout << "=====================================\n" ;
+  //  std::cout << "==========New event==================\n" ;
+  //  std::cout << "=====================================\n" ;
+  //  std::cout << "=====================================\n" ;
+
+  std::vector<AliFemtoDreamBasePart> XiDecays;
+  std::vector<AliFemtoDreamBasePart> AntiXiDecays;
+  int numcascades = evt->GetNumberOfCascades();
+  for (int iXi = 0; iXi < numcascades; ++iXi) {
+    AliAODcascade *xi = evt->GetCascade(iXi);
+    if (!xi)
+      continue;
+    fFemtoCasc->SetCascade(evt, xi);
+    if (fCascCuts->isSelected(fFemtoCasc)) {
+      XiDecays.push_back(*fFemtoCasc);
+    }
+    if (fAntiCascCuts->isSelected(fFemtoCasc)) {
+      AntiXiDecays.push_back(*fFemtoCasc);
+    }
+  }
+  //loop once over the MC stack to calculate Efficiency/Purity
+  if (fIsMC) {
+    AliAODInputHandler *eventHandler =
+        dynamic_cast<AliAODInputHandler*>(AliAnalysisManager::GetAnalysisManager()
+            ->GetInputEventHandler());
+    AliMCEvent* fMC = eventHandler->MCEvent();
+
+    for (int iPart = 0; iPart < (fMC->GetNumberOfTracks()); iPart++) {
+      AliAODMCParticle *mcPart = (AliAODMCParticle*) fMC->GetTrack(iPart);
+      if (TMath::Abs(mcPart->Eta()) < 0.8 && mcPart->IsPhysicalPrimary()) {
+        if (mcPart->GetPdgCode() == fTrackCuts->GetPDGCode()) {
+          fTrackCuts->FillGenerated(mcPart->Pt());
+        } else if (mcPart->GetPdgCode() == fAntiTrackCuts->GetPDGCode()) {
+          fAntiTrackCuts->FillGenerated(mcPart->Pt());
+        } else if (mcPart->GetPdgCode() == fv0Cuts->GetPDGv0()) {
+          fv0Cuts->FillGenerated(mcPart->Pt());
+        } else if (mcPart->GetPdgCode() == fAntiv0Cuts->GetPDGv0()) {
+          fAntiv0Cuts->FillGenerated(mcPart->Pt());
+        } else if (mcPart->GetPdgCode() == fCascCuts->GetPDGCodeCasc()) {
+          fCascCuts->FillGenerated(mcPart->Pt());
+        } else if (mcPart->GetPdgCode() == fAntiCascCuts->GetPDGCodeCasc()) {
+          fAntiCascCuts->FillGenerated(mcPart->Pt());
+        }
+      }
+    }
+  }
+  fPairCleaner->ResetArray();
+  fPairCleaner->CleanTrackAndDecay(&Particles, &Decays, 0);
+  fPairCleaner->CleanTrackAndDecay(&Particles, &XiDecays, 2);
+  fPairCleaner->CleanTrackAndDecay(&AntiParticles, &AntiDecays, 1);
+  fPairCleaner->CleanTrackAndDecay(&AntiParticles, &AntiXiDecays, 3);
+
+  fPairCleaner->CleanDecay(&Decays, 0);
+  fPairCleaner->CleanDecay(&AntiDecays, 1);
+  fPairCleaner->CleanDecay(&XiDecays, 2);
+  fPairCleaner->CleanDecay(&AntiXiDecays, 3);
+
+  fPairCleaner->StoreParticle(Particles);
+  fPairCleaner->StoreParticle(AntiParticles);
+  fPairCleaner->StoreParticle(Decays);
+  fPairCleaner->StoreParticle(AntiDecays);
+  fPairCleaner->StoreParticle(XiDecays);
+  fPairCleaner->StoreParticle(AntiXiDecays);
+  if (fConfig->GetInvMassPairs()) {
+    fPairCleaner->FillInvMassPair((fPairCleaner->GetCleanParticles().at(0)),
+                                  2212,
+                                  (fPairCleaner->GetCleanParticles().at(4)),
+                                  3312, 0);
+    fPairCleaner->FillInvMassPair((fPairCleaner->GetCleanParticles().at(1)),
+                                  2212,
+                                  (fPairCleaner->GetCleanParticles().at(5)),
+                                  3312, 1);
+  }
+  if (fConfig->GetUseEventMixing()) {
+    fPartColl->SetEvent(fPairCleaner->GetCleanParticles(), fEvent->GetZVertex(),
+                        fEvent->GetMultiplicity(), fEvent->GetV0MCentrality());
+  }
+  if (fConfig->GetUsePhiSpinning()) {
+    fControlSample->SetEvent(fPairCleaner->GetCleanParticles(),
+                             fEvent->GetMultiplicity());
+  }
+}
+
+void AliOtonOmegaAnalysis::Make(AliESDEvent *evt, AliMCEvent *mcEvent, bool CascadeTreeFlag, bool OmegaTreeFlag, Int_t Cut) {
+  if (!evt) {
+    AliFatal("No Input Event");
+  }
+  fEvent->SetEvent(evt);
+  if (!fEvtCuts->isSelected(fEvent)) {
+    return;
+  }
+
+  //Initalize Tree
+  for(int ii=0;ii<MAXCASCADES;ii++){
+   fTCascadePx[ii]=-100000.;
+   fTCascadePy[ii]=-100000.;
+   fTCascadePz[ii]=-100000.;
+   fTCascadeCharge[ii]=-10;
+   fTCascadeDCA[ii]=-100000.;
+   fTCascadeDaughtersDCA[ii]=-100000.;
+   fTCascadeXiMass[ii]=-100000.;
+   fTCascadeOmegaMass[ii]=-100000.;
+   fTCascadeVx[ii]=-100000.;
+   fTCascadeVy[ii]=-100000.;
+   fTCascadeVz[ii]=-100000.;
+   fTCascadePA[ii]=-100000.;
+   fTLambdaPx[ii]=-100000.;
+   fTLambdaPy[ii]=-100000.;
+   fTLambdaPz[ii]=-100000.;
+   fTLambdaDCA[ii]=-100000.;
+   fTLambdaDaughtersDCA[ii]=-100000.;
+   fTLambdaMass[ii]=-100000.;
+   fTLambdaK0Mass[ii]=-100000.;
+   fTLambdaVx[ii]=-100000.;
+   fTLambdaVy[ii]=-100000.;
+   fTLambdaVz[ii]=-100000.;
+   fTLambdaPA[ii]=-100000.;
+
+   for(int jj=0;jj<3;jj++){
+    fTTrackPx[ii][jj]=-100000.;
+    fTTrackPy[ii][jj]=-100000.;
+    fTTrackPz[ii][jj]=-100000.;
+    fTTrackTPCmom[ii][jj]=-100000.;
+    fTTrackEta[ii][jj]=-100000.;
+    fTTrackCharge[ii][jj]=-10;
+    fTTrackDCA[ii][jj]=-100000.;
+    fTTrackITSspi[ii][jj]=-100000.;
+    fTTrackITSsk[ii][jj]=-100000.;
+    fTTrackITSsp[ii][jj]=-100000.;
+    fTTrackTPCspi[ii][jj]=-100000.;
+    fTTrackTPCsk[ii][jj]=-100000.;
+    fTTrackTPCsp[ii][jj]=-100000.;
+    fTTrackTOFspi[ii][jj]=-100000.;
+    fTTrackTOFsk[ii][jj]=-100000.;
+    fTTrackTOFsp[ii][jj]=-100000.;
+    fTTrackNcl[ii][jj]=-100000;
+    fTTrackCrF[ii][jj]=-100000.;
+    fTTrackShared[ii][jj]=-100000;
+    fTTrackTPCchi2[ii][jj]=-100000.;
+    fTTrackITStime[ii][jj]=kFALSE;
+    fTTrackTOFtime[ii][jj]=kFALSE;
+    fTTrackTPConly[ii][jj]=kFALSE;
+    fTTrackITScomplementary[ii][jj]=kFALSE;
+    fTTrackITSpure[ii][jj]=kFALSE;
+    fTTrackGLOBAL[ii][jj]=kFALSE;
+   }
+
+  }
+  fTnCascade=0;
+
+  //start filling Tree, event properties and other things:
+  fTRunNumber = evt->GetRunNumber();
+  Double_t PrimVtx[3];
+  evt->GetPrimaryVertex()->GetXYZ(PrimVtx);
+  fTV[0]=PrimVtx[0];
+  fTV[1]=PrimVtx[1];
+  fTV[2]=PrimVtx[2];
+  FillOmegaTree = kFALSE; // by default do not fill the omega tree
+
+  std::vector<AliFemtoDreamBasePart> Particles;
+  std::vector<AliFemtoDreamBasePart> AntiParticles;
+  for (int iTrack = 0; iTrack < evt->GetNumberOfTracks(); ++iTrack) {
+    AliESDtrack *track = static_cast<AliESDtrack *>(evt->GetTrack(iTrack));
+    fFemtoTrack->SetTrack(track, mcEvent, fEvent->GetMultiplicity());
+    if (fTrackCuts->isSelected(fFemtoTrack)) {
+      Particles.push_back(*fFemtoTrack);
+    }
+    if (fAntiTrackCuts->isSelected(fFemtoTrack)) {
+      AntiParticles.push_back(*fFemtoTrack);
+    }
+  }
+
+/*
+  std::vector<AliFemtoDreamBasePart> Decays;
+  std::vector<AliFemtoDreamBasePart> AntiDecays;
+
+  for (int iv0 = 0; iv0 < evt->GetNumberOfV0s(); ++iv0) {
+    AliESDv0 *v0 = evt->GetV0(iv0);
+    fFemtov0->Setv0(evt, mcEvent, v0, fEvent->GetMultiplicity());
+    if (fv0Cuts->isSelected(fFemtov0)) {
+      Decays.push_back(*fFemtov0);
+    }
+    if (fAntiv0Cuts->isSelected(fFemtov0)) {
+      AntiDecays.push_back(*fFemtov0);
+    }
+  }
+*/
+  std::vector<AliFemtoDreamBasePart> XiOmegaDecays;
+  std::vector<AliFemtoDreamBasePart> AntiXiOmegaDecays;
+  std::vector<AliFemtoDreamBasePart> XiDecays;
+  std::vector<AliFemtoDreamBasePart> AntiXiDecays;
+  for (Int_t nCascade = 0; nCascade < evt->GetNumberOfCascades(); ++nCascade) {
+    AliESDcascade *esdCascade = evt->GetCascade(nCascade);
+
+    //Tree filling:
+    //-------------
+
+    //initializations:
+    FillOmegaTree_tracks = kFALSE;
+    FillOmegaTree_lambda = kFALSE;
+    FillOmegaTree_omega = kFALSE;
+
+    Bool_t CascadeFilled = FillTreeCascade(evt, esdCascade);
+
+
+    //Cuts for Omega Tree filling:
+    if(
+     abs(fTTrackEta[fTnCascade][0])<.8&&abs(fTTrackEta[fTnCascade][1])<.8&&abs(fTTrackEta[fTnCascade][2])<.8
+     &&((
+      abs(fTTrackTPCsp[fTnCascade][0])<6.&&(abs(fTTrackTPCspi[fTnCascade][1])<6.||abs(fTTrackITSspi[fTnCascade][1])<6.)
+      )||(
+      abs(fTTrackTPCsp[fTnCascade][1])<6.&&(abs(fTTrackTPCspi[fTnCascade][2])<6.||abs(fTTrackITSspi[fTnCascade][2])<6.)
+      ))
+     &&(abs(fTTrackITSsk[fTnCascade][2])<6.||abs(fTTrackTPCsk[fTnCascade][2])<6.)
+    )FillOmegaTree_tracks = kTRUE;
+    if(
+     fTLambdaPA[fTnCascade]>.97
+     &&abs(fTLambdaMass[fTnCascade]-1.116)<0.006
+     &&fTLambdaDaughtersDCA[fTnCascade]<1.5
+     &&fTLambdaDCA[fTnCascade]>.05
+    )FillOmegaTree_lambda = kTRUE;
+    if(
+     fTCascadePA[fTnCascade]>.98
+     &&fTCascadeOmegaMass[fTnCascade]>1.632&&fTCascadeOmegaMass[fTnCascade]<1.712
+     &&abs(fTCascadeXiMass[fTnCascade]-1.322)>.005
+     &&fTCascadeDaughtersDCA[fTnCascade]<2.
+    )FillOmegaTree_omega = kTRUE;
+    if(CascadeFilled&&FillOmegaTree_tracks&&FillOmegaTree_lambda&&FillOmegaTree_omega) FillOmegaTree = kTRUE;
+
+
+
+    if(CascadeFilled) fTnCascade++;
+
+    //Continue with Standard Cascade filling:
+    fFemtoCasc->SetCascade(evt, mcEvent, esdCascade);
+    if (fCascCuts->isSelected(fFemtoCasc)) {
+      XiDecays.push_back(*fFemtoCasc);
+    }
+    if (fAntiCascCuts->isSelected(fFemtoCasc)) {
+      AntiXiDecays.push_back(*fFemtoCasc);
+    }
+    //omega:
+    if (fCascOmegaCuts->isSelected(fFemtoCasc)) {
+      XiOmegaDecays.push_back(*fFemtoCasc);
+    }
+    if (fAntiCascOmegaCuts->isSelected(fFemtoCasc)) {
+      AntiXiOmegaDecays.push_back(*fFemtoCasc);
+    }
+
+
+  }//cascades loop
+
+  if(CascadeTreeFlag) foTTree->Fill();
+  //if(CascadeTreeFlag&&fTnCascade>0) foTTree->Fill();
+  if(OmegaTreeFlag&&FillOmegaTree) fomegaTTree->Fill();
+
+
+  fPairCleaner->ResetArray();
+//  fPairCleaner->CleanTrackAndDecay(&Particles, &Decays, 0);
+  fPairCleaner->CleanTrackAndDecay(&Particles, &XiDecays, 2);
+  fPairCleaner->CleanTrackAndDecay(&Particles, &XiOmegaDecays, 0);
+//  fPairCleaner->CleanTrackAndDecay(&AntiParticles, &AntiDecays, 1);
+  fPairCleaner->CleanTrackAndDecay(&AntiParticles, &AntiXiDecays, 3);
+  fPairCleaner->CleanTrackAndDecay(&AntiParticles, &AntiXiOmegaDecays, 1);
+
+//  fPairCleaner->CleanDecay(&Decays, 0);
+//  fPairCleaner->CleanDecay(&AntiDecays, 1);
+  fPairCleaner->CleanDecay(&XiDecays, 2);
+  fPairCleaner->CleanDecay(&AntiXiDecays, 3);
+  fPairCleaner->CleanDecay(&XiOmegaDecays, 0);
+  fPairCleaner->CleanDecay(&AntiXiOmegaDecays, 1);
+
+  fPairCleaner->StoreParticle(Particles);
+  fPairCleaner->StoreParticle(AntiParticles);
+//  fPairCleaner->StoreParticle(Decays);
+//  fPairCleaner->StoreParticle(AntiDecays);
+  fPairCleaner->StoreParticle(XiDecays);
+  fPairCleaner->StoreParticle(AntiXiDecays);
+  fPairCleaner->StoreParticle(XiOmegaDecays); // comes in the same order as in the addtask
+  fPairCleaner->StoreParticle(AntiXiOmegaDecays); // comes in the same order as in the addtask
+
+  if (fConfig->GetUseEventMixing()) {
+    fPartColl->SetEvent(fPairCleaner->GetCleanParticles(), fEvent->GetZVertex(),
+                        fEvent->GetMultiplicity(), fEvent->GetV0MCentrality());
+  }
+  if (fConfig->GetUsePhiSpinning()) {
+    fControlSample->SetEvent(fPairCleaner->GetCleanParticles(),
+                             fEvent->GetMultiplicity());
+  }
+}
+
+
+
+
+
+
+//_______________________________________________________________________________________________________
+Bool_t AliOtonOmegaAnalysis::FillTreeCascade(AliESDEvent *evt, AliESDcascade *casc) {
+
+ Bool_t Filled = kFALSE;
+ Double_t PrimVtx[3];
+ evt->GetPrimaryVertex()->GetXYZ(PrimVtx);
+
+ //First of all check if the V0 of the Cascade is good:
+ int idxPosFromV0Dghter = casc->GetPindex();
+ int idxNegFromV0Dghter = casc->GetNindex();
+ AliESDv0 * currentV0 = 0x0;
+ int idxV0FromCascade = -1;
+ for (int iV0 = 0; iV0 < evt->GetNumberOfV0s(); ++iV0) {
+  currentV0 = evt->GetV0(iV0);
+  // Make sure not to use online v0 here
+  // (the cascade is reconstructed with offline v0 only)
+  if (currentV0->GetOnFlyStatus() == kTRUE) continue;
+  int posCurrentV0 = currentV0->GetPindex();
+  int negCurrentV0 = currentV0->GetNindex();
+  if (posCurrentV0 == idxPosFromV0Dghter&& negCurrentV0 == idxNegFromV0Dghter) {
+   idxV0FromCascade = iV0;
+   break;
+  }
+ }
+
+ if (idxV0FromCascade >= 0) { //we got a correct Lambda
+ //----------------------------------------------------
+  //fill the tracks
+  Bool_t tr0 = FillTreeTrack(0, casc->GetPindex() , idxV0FromCascade,  evt , casc);
+  Bool_t tr1 = FillTreeTrack(1, casc->GetNindex() , idxV0FromCascade, evt , casc);
+  Bool_t tr2 = FillTreeTrack(2, casc->GetBindex() , idxV0FromCascade, evt , casc);
+
+  //tracks are filled
+  //-----------------
+  if(tr0&&tr1&&tr2) {
+
+   //get the Lambda:
+   AliESDv0* v0 = evt->GetV0(idxV0FromCascade);
+
+   //Check the Xi/Omega mass mass:
+   //Lambda E:
+   Double_t Ev0 = sqrt( pow(TDatabasePDG::Instance()->GetParticle(3122)->Mass(),2) + (v0->Px()*v0->Px()+v0->Py()*v0->Py()+v0->Pz()*v0->Pz()));
+   //Bach E:
+   Double_t EBach = sqrt( pow(TDatabasePDG::Instance()->GetParticle(211)->Mass(),2) + pow(fTTrackPx[fTnCascade][2],2)+pow(fTTrackPy[fTnCascade][2],2)+pow(fTTrackPz[fTnCascade][2],2));
+   //Cascade momentum:
+   fTCascadePx[fTnCascade] = fTTrackPx[fTnCascade][0] + fTTrackPx[fTnCascade][1] + fTTrackPx[fTnCascade][2];
+   fTCascadePy[fTnCascade] = fTTrackPy[fTnCascade][0] + fTTrackPy[fTnCascade][1] + fTTrackPy[fTnCascade][2];
+   fTCascadePz[fTnCascade] = fTTrackPz[fTnCascade][0] + fTTrackPz[fTnCascade][1] + fTTrackPz[fTnCascade][2];
+   Double_t mXi = sqrt( pow(Ev0 + EBach, 2) - (pow(fTCascadePx[fTnCascade],2)+pow(fTCascadePy[fTnCascade],2)+pow(fTCascadePz[fTnCascade],2)) );
+   //for bachelor kaon:
+   EBach = sqrt( pow(TDatabasePDG::Instance()->GetParticle(321)->Mass(),2) + pow(fTTrackPx[fTnCascade][2],2)+pow(fTTrackPy[fTnCascade][2],2)+pow(fTTrackPz[fTnCascade][2],2));
+   Double_t mOmega = sqrt( pow(Ev0 + EBach, 2) - (pow(fTCascadePx[fTnCascade],2)+pow(fTCascadePy[fTnCascade],2)+pow(fTCascadePz[fTnCascade],2)) );
+
+   //good Xi/Omega mass:
+   //-------------------
+   if((mXi>1.20&&mXi<1.45)||(mOmega>1.55&&mOmega<1.80)){
+
+    //fill lambda
+    fTLambdaPx[fTnCascade] = v0->Px();
+    fTLambdaPy[fTnCascade] = v0->Py();
+    fTLambdaPz[fTnCascade] = v0->Pz();
+    fTLambdaDCA[fTnCascade] = v0->GetD(PrimVtx[0], PrimVtx[1], PrimVtx[2]);
+    fTLambdaDaughtersDCA[fTnCascade] = v0->GetDcaV0Daughters();
+    v0->ChangeMassHypothesis(kK0Short);
+    fTLambdaK0Mass[fTnCascade]=v0->GetEffMass();
+    if(casc->Charge()>0) {
+     v0->ChangeMassHypothesis(kLambda0Bar);
+    } else {
+     v0->ChangeMassHypothesis(kLambda0);
+    }
+    fTLambdaMass[fTnCascade]=v0->GetEffMass();
+    fTLambdaVx[fTnCascade] = v0->Xv();
+    fTLambdaVy[fTnCascade] = v0->Yv();
+    fTLambdaVz[fTnCascade] = v0->Zv();
+    fTLambdaPA[fTnCascade] = v0->GetV0CosineOfPointingAngle(PrimVtx[0], PrimVtx[1], PrimVtx[2]);
+
+    //fill cascade
+    fTCascadeCharge[fTnCascade] = casc->Charge();
+    fTCascadeDaughtersDCA[fTnCascade] = casc->GetDcaXiDaughters();
+    fTCascadeXiMass[fTnCascade] = mXi;
+    fTCascadeOmegaMass[fTnCascade] = mOmega;
+    double decayPosXi[3] = { 0. };
+    casc->GetXYZcascade(decayPosXi[0], decayPosXi[1], decayPosXi[2]);
+    fTCascadeVx[fTnCascade] = decayPosXi[0];
+    fTCascadeVy[fTnCascade] = decayPosXi[1];
+    fTCascadeVz[fTnCascade] = decayPosXi[2];
+    //calc cascade dca, following recipe of AOD
+    fTCascadeDCA[fTnCascade] = casc->GetDcascade(PrimVtx[0], PrimVtx[1], PrimVtx[2]);
+    fTCascadePA[fTnCascade] = casc->GetCascadeCosineOfPointingAngle(PrimVtx[0], PrimVtx[1], PrimVtx[2]);
+
+    Filled = kTRUE;
+
+   }//good Xi/Omega mass
+  } //tracks filled
+ } //correct lambda
+ return Filled;
+}
+
+
+
+//_______________________________________________________________________________________________________________________________
+Bool_t AliOtonOmegaAnalysis::FillTreeTrack(Int_t jj, Int_t idtrack, Int_t V0index, AliESDEvent *evt, AliESDcascade *casc) {
+//here jj=0 refers to pos, 1 neg, 2 bach
+
+ Bool_t Filled = kFALSE;
+
+ //primary vertex
+ Double_t PrimVtx[3];
+ evt->GetPrimaryVertex()->GetXYZ(PrimVtx);
+
+ //get ESD track
+ AliESDtrack *track = evt->GetTrack(idtrack);
+
+ //fill tpc inner momentum
+ fTTrackTPCmom[fTnCascade][jj]= track->GetTPCmomentum();
+
+ //REQUIRE EVERYTHING TO HAVE TPCMOM > 50MeV
+ if(track->GetTPCmomentum()>.050){
+
+ //fill dca
+ fTTrackDCA[fTnCascade][jj]= track->GetD(PrimVtx[0], PrimVtx[1], evt->GetMagneticField());
+
+ //fill momentum in the correct vertex position:
+ double Mom[3] = { 0. };
+ //the momenta of the daughters have to be taken at the v0 vertex,
+ //the bachelor momenta at the cascade vertex
+ if(jj<2){
+  AliESDv0 * V0 = 0x0;
+  V0 = evt->GetV0(V0index);
+  if(jj==0)V0->GetPPxPyPz(Mom[0],Mom[1],Mom[2]);
+  if(jj==1)V0->GetNPxPyPz(Mom[0],Mom[1],Mom[2]);
+ }else{
+  casc->GetBPxPyPz(Mom[0], Mom[1], Mom[2]);
+ }
+ fTTrackPx[fTnCascade][jj]=Mom[0];
+ fTTrackPy[fTnCascade][jj]=Mom[1];
+ fTTrackPz[fTnCascade][jj]=Mom[2];
+
+ if(sqrt(pow(Mom[0],2)+pow(Mom[1],2))>0.
+  && fabs(fTTrackPx[fTnCascade][jj])<1000.
+  && fabs(fTTrackPy[fTnCascade][jj])<1000.
+  && fabs(fTTrackPz[fTnCascade][jj])<1000.
+  ){
+
+   //fill Eta:
+   fTTrackEta[fTnCascade][jj]= track->Eta();
+
+   //fill charge:
+   fTTrackCharge[fTnCascade][jj]=track->Charge();
+
+   //fill #TPCclusters
+   fTTrackNcl[fTnCascade][jj]  = track->GetTPCNcls();
+
+   //fill TPC CrF : Crossed rows / findable
+   if(track->GetTPCNclsF()>0) fTTrackCrF[fTnCascade][jj]  = track->GetTPCCrossedRows()/track->GetTPCNclsF();
+
+   //fill chi2 TPC
+   fTTrackTPCchi2[fTnCascade][jj]  = track->GetTPCchi2();
+
+   //fill #shared TPC clusters
+   fTTrackShared[fTnCascade][jj]  = track->GetTPCnclsS();
+
+   //does it have a hit in SPD, SSD or TOF?
+   if(track->HasPointOnITSLayer(0)||track->HasPointOnITSLayer(1)||track->HasPointOnITSLayer(4)||track->HasPointOnITSLayer(5)) fTTrackITStime[fTnCascade][jj] = kTRUE;
+   if(track->GetTOFBunchCrossing() == 0) fTTrackTOFtime[fTnCascade][jj] = kTRUE;
+
+   //-----------------------------------------------------------------------------------------
+   //-----------------------------------------------------------------------------------------
+   //-----------------------------------------------------------------------------------------
+   //The question here is, is that enough that they have ITS or TOF time (in particular ITS),
+   //or do I have to do SOMETHING with this time, i.e. check that is in
+   //time with the vertex or with the other tracks of the cascade etc.
+   //-----------------------------------------------------------------------------------------
+   //-----------------------------------------------------------------------------------------
+   //-----------------------------------------------------------------------------------------
+
+   //TPCtrack only?
+   if(track->GetStatus()&AliESDtrack::kTPCrefit && track->GetStatus()&AliESDtrack::kTPCin && track->GetStatus()&AliESDtrack::kITSrefit && track->GetStatus()&AliESDtrack::kITSin) fTTrackGLOBAL[fTnCascade][jj]=kTRUE;
+   if(track->GetStatus()&AliESDtrack::kTPCrefit && track->GetStatus()&AliESDtrack::kTPCin && !(track->GetStatus()&AliESDtrack::kITSrefit) && !(track->GetStatus()&AliESDtrack::kITSin)) fTTrackTPConly[fTnCascade][jj]=kTRUE;
+   if(!(track->GetStatus()&AliESDtrack::kTPCin) && track->GetStatus()&AliESDtrack::kITSrefit && track->GetStatus()&AliESDtrack::kITSin && !(track->GetStatus()&AliESDtrack::kITSpureSA)) fTTrackITScomplementary[fTnCascade][jj]=kTRUE;
+   if(track->GetStatus()&AliESDtrack::kITSrefit && track->GetStatus()&AliESDtrack::kITSpureSA) fTTrackITSpure[fTnCascade][jj]=kTRUE;
+
+
+  //Info not included so far, to be considered: - number of its clusters,  - number of tpc shared clusters,  - its shared clusters,  - track index
+  //STILL TO BE CHECKED: - is the dca, momentum, etc evaluated for each track in the correct way?
+  //                     - For tpc only tracks, using or not the vertex, etc...
+  //                     - The info here stored coincides with the info evaluated by the vertexer?
+
+   //pid
+   AliPIDResponse::EDetPidStatus statusPID = fPIDResponse->CheckPIDStatus(AliPIDResponse::kITS, track);
+   if (statusPID == AliPIDResponse::kDetPidOk)  {
+     fTTrackITSspi[fTnCascade][jj] = fPIDResponse->NumberOfSigmas(AliPIDResponse::kITS, track, AliPID::kPion);
+     fTTrackITSsk[fTnCascade][jj] = fPIDResponse->NumberOfSigmas(AliPIDResponse::kITS, track, AliPID::kKaon);
+     fTTrackITSsp[fTnCascade][jj] = fPIDResponse->NumberOfSigmas(AliPIDResponse::kITS, track, AliPID::kProton);
+    }
+   statusPID = fPIDResponse->CheckPIDStatus(AliPIDResponse::kTPC, track);
+   if (statusPID == AliPIDResponse::kDetPidOk) {
+     fTTrackTPCspi[fTnCascade][jj] = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC, track, AliPID::kPion);
+     fTTrackTPCsk[fTnCascade][jj] = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC, track, AliPID::kKaon);
+     fTTrackTPCsp[fTnCascade][jj] = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTPC, track, AliPID::kProton);
+    }
+   statusPID = fPIDResponse->CheckPIDStatus(AliPIDResponse::kTOF, track);
+   if (statusPID == AliPIDResponse::kDetPidOk)  {
+     fTTrackTOFspi[fTnCascade][jj] = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTOF, track, AliPID::kPion);
+     fTTrackTOFsk[fTnCascade][jj] = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTOF, track, AliPID::kKaon);
+     fTTrackTOFsp[fTnCascade][jj] = fPIDResponse->NumberOfSigmas(AliPIDResponse::kTOF, track, AliPID::kProton);
+    }
+
+  Filled = kTRUE;
+
+ }//good momentum
+}//tpcmom>50 for all 
+
+ return Filled;
+}

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliOtonOmegaAnalysis.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliOtonOmegaAnalysis.h
@@ -1,0 +1,299 @@
+/*
+ * AliOtonOmegaAnalysis.h
+ *
+ *  Created on: 24 Nov 2017
+ *      Author: bernhardhohlweger. Adapted for Proton-Omega by Oton Vazquez Doce.
+ */
+
+#ifndef ALIOTONOMEGAANALYSIS_H_
+#define ALIOTONOMEGAANALYSIS_H_
+
+#include "AliAODEvent.h"
+#include "AliESDEvent.h"
+#include "AliAODTrack.h"
+#include "AliFemtoDreamEvent.h"
+#include "AliFemtoDreamEventCuts.h"
+#include "AliFemtoDreamPairCleaner.h"
+#include "AliFemtoDreamPartCollection.h"
+#include "AliFemtoDreamTrack.h"
+#include "AliFemtoDreamTrackCuts.h"
+#include "AliFemtoDreamv0.h"
+#include "AliFemtoDreamv0Cuts.h"
+#include "AliOtonOmegaCascade.h"
+#include "AliOtonOmegaCascadeCuts.h"
+#include "AliFemtoDreamControlSample.h"
+#include "AliPIDResponse.h"
+#include "Rtypes.h"
+class AliOtonOmegaAnalysis {
+ public:
+  AliOtonOmegaAnalysis();
+  AliOtonOmegaAnalysis(const AliOtonOmegaAnalysis& analysis);
+  AliOtonOmegaAnalysis& operator=(const AliOtonOmegaAnalysis& analysis);
+  virtual ~AliOtonOmegaAnalysis();
+  void SetMVPileUp(bool mvPileUp) {
+    fMVPileUp = mvPileUp;
+  }
+  ;
+  void SetEvtCutQA(bool setQA) {
+    fEvtCutQA = setQA;
+  }
+  ;
+  void SetEventCuts(AliFemtoDreamEventCuts *cuts) {
+    fEvtCuts = cuts;
+  }
+  ;
+  TList *GetEventCutHists() {
+    return fEvtCuts->GetHistList();
+  }
+  ;
+  void SetTrackCuts(AliFemtoDreamTrackCuts *cuts) {
+    fTrackCuts = cuts;
+  }
+  ;
+  TList *GetTrackCutHists() {
+    return fTrackCuts->GetQAHists();
+  }
+  ;
+  TList *GetTrackCutHistsMC() {
+    return fTrackCuts->GetMCQAHists();
+  }
+  ;
+  void SetAntiTrackCuts(AliFemtoDreamTrackCuts *cuts) {
+    fAntiTrackCuts = cuts;
+  }
+  ;
+  TList *GetAntitrackCutHists() {
+    return fAntiTrackCuts->GetQAHists();
+  }
+  ;
+  TList *GetAntitrackCutHistsMC() {
+    return fAntiTrackCuts->GetMCQAHists();
+  }
+  ;
+  void Setv0Cuts(AliFemtoDreamv0Cuts *cuts) {
+    fv0Cuts = cuts;
+  }
+  ;
+  TList *Getv0CutHist() {
+    return fv0Cuts->GetQAHists();
+  }
+  ;
+  TList *Getv0MCHist() {
+    return fv0Cuts->GetMCQAHists();
+  }
+  ;
+  void SetAntiv0Cuts(AliFemtoDreamv0Cuts *cuts) {
+    fAntiv0Cuts = cuts;
+  }
+  ;
+  TList *GetAntiv0CutHist() {
+    return fAntiv0Cuts->GetQAHists();
+  }
+  ;
+  TList *GetAntiv0MCHist() {
+    return fAntiv0Cuts->GetMCQAHists();
+  }
+  ;
+  void SetCascadeCuts(AliOtonOmegaCascadeCuts *cuts) {
+    fCascCuts = cuts;
+  }
+  ;
+  TList *GetCascadeCutHist() {
+    return fCascCuts->GetQAHists();
+  }
+  ;
+  TList *GetCascadeMCHist() {
+    return fCascCuts->GetMCQAHists();
+  }
+  ;
+  void SetAntiCascadeCuts(AliOtonOmegaCascadeCuts *cuts) {
+    fAntiCascCuts = cuts;
+  }
+  ;
+  TList *GetAntiCascadeMCHist() {
+    return fAntiCascCuts->GetMCQAHists();
+  }
+  ;
+  TList *GetAntiCascadeCutHist() {
+    return fAntiCascCuts->GetQAHists();
+  }
+  ;
+
+
+
+  void SetCascadeOmegaCuts(AliOtonOmegaCascadeCuts *cuts) {
+    fCascOmegaCuts = cuts;
+  }
+  ;
+  TList *GetCascadeOmegaCutHist() {
+    return fCascOmegaCuts->GetQAHists();
+  }
+  ;
+  TList *GetCascadeOmegaMCHist() {
+    return fCascOmegaCuts->GetMCQAHists();
+  }
+  ;
+  void SetAntiCascadeOmegaCuts(AliOtonOmegaCascadeCuts *cuts) {
+    fAntiCascOmegaCuts = cuts;
+  }
+  ;
+  TList *GetAntiCascadeOmegaMCHist() {
+    return fAntiCascOmegaCuts->GetMCQAHists();
+  }
+  ;
+  TList *GetAntiCascadeOmegaCutHist() {
+    return fAntiCascOmegaCuts->GetQAHists();
+  }
+  ;
+
+
+
+
+  TList *GetResultList() {
+    return fPartColl ? fPartColl->GetHistList() : nullptr;
+  }
+  ;
+  TList *GetResultQAList() {
+    return fPartColl ? fPartColl->GetQAList() : nullptr;
+  }
+  ;
+  TList *GetResultSampleList() {
+    return fControlSample ? fControlSample->GetHistList() : nullptr;
+  }
+  ;
+  TList *GetResultSampleQAList() {
+    return fControlSample ? fControlSample->GetQAList() : nullptr;
+  }
+  ;
+  TList *GetQAList() {
+    return fQA;
+  }
+  ;
+  void SetTrackBufferSize(int size) {
+    fTrackBufferSize = size;
+  }
+  ;
+  void SetCollectionConfig(AliFemtoDreamCollConfig *conf) {
+    fConfig = conf;
+  }
+  ;
+  void Init(bool isMonteCarlo, UInt_t trigger);
+
+
+  //tree stuff:
+  TTree *GetTreeCascade() {
+   return foTTree;
+  }
+  TTree *GetTreeOmega() {
+   return fomegaTTree;
+  }
+  void InitializeTreeBooking();
+  Bool_t FillTreeCascade(AliESDEvent *evt, AliESDcascade *casc);
+  Bool_t FillTreeTrack(Int_t jj, Int_t idtrack, Int_t V0index, AliESDEvent *evt, AliESDcascade *casc);
+
+
+  TString ClassName() {
+    return "AliOtonOmegaAnalysis";
+  }
+  ;
+  void Make(AliAODEvent *evt);
+  void Make(AliESDEvent *evt, AliMCEvent *mcEvent, bool CascadeTreeFlag, bool OmegaTreeFlag, Int_t Cut = 0);
+ private:
+  void ResetGlobalTrackReference();
+  void StoreGlobalTrackReference(AliAODTrack *track);
+  bool fMVPileUp;                           //!
+  bool fEvtCutQA;                           //!
+  TList *fQA;                               //!
+  AliFemtoDreamTrack *fFemtoTrack;          //!
+  AliFemtoDreamv0 *fFemtov0;                //!
+  AliOtonOmegaCascade *fFemtoCasc;         //!
+  AliFemtoDreamEvent *fEvent;               //!
+  AliFemtoDreamEventCuts *fEvtCuts;         //!
+  AliFemtoDreamTrackCuts *fTrackCuts;       //!
+  AliFemtoDreamTrackCuts *fAntiTrackCuts;   //!
+  AliFemtoDreamv0Cuts *fv0Cuts;             //!
+  AliFemtoDreamv0Cuts *fAntiv0Cuts;         //!
+  AliOtonOmegaCascadeCuts *fCascCuts;      //!
+  AliOtonOmegaCascadeCuts *fAntiCascCuts;  //!
+  AliOtonOmegaCascadeCuts *fCascOmegaCuts;      //!
+  AliOtonOmegaCascadeCuts *fAntiCascOmegaCuts;  //!
+  AliFemtoDreamPairCleaner *fPairCleaner;   //!
+  AliFemtoDreamControlSample *fControlSample;   //!
+  int fTrackBufferSize;
+  AliAODTrack **fGTI;             //!
+  AliFemtoDreamCollConfig *fConfig;         //!
+  AliFemtoDreamPartCollection *fPartColl;   //!
+  AliPIDResponse *fPIDResponse; //! PID response object
+  bool fIsMC;                               //!
+
+  
+  //more tree stuff:
+  Bool_t FillOmegaTree_tracks;
+  Bool_t FillOmegaTree_lambda;
+  Bool_t FillOmegaTree_omega;
+  Bool_t FillOmegaTree;
+  TTree* fomegaTTree;
+  TTree* foTTree;
+  Int_t fTRunNumber;
+  Float_t fTV[3];
+  const Int_t MAXCASCADES = 150;
+  Int_t fTnCascade;
+  //cascades:
+  Float_t fTCascadePx[150];
+  Float_t fTCascadePy[150];
+  Float_t fTCascadePz[150];
+  Short_t fTCascadeCharge[150];
+  Float_t fTCascadeDCA[150];
+  Float_t fTCascadeDaughtersDCA[150];
+  Float_t fTCascadeXiMass[150];
+  Float_t fTCascadeOmegaMass[150];
+  Float_t fTCascadeVx[150];
+  Float_t fTCascadeVy[150];
+  Float_t fTCascadeVz[150];
+  Float_t fTCascadePA[150];
+  //lambda
+  Float_t fTLambdaPx[150];
+  Float_t fTLambdaPy[150];
+  Float_t fTLambdaPz[150];
+  Float_t fTLambdaDCA[150];
+  Float_t fTLambdaDaughtersDCA[150];
+  Float_t fTLambdaMass[150];
+  Float_t fTLambdaK0Mass[150];
+  Float_t fTLambdaVx[150];
+  Float_t fTLambdaVy[150];
+  Float_t fTLambdaVz[150];
+  Float_t fTLambdaPA[150];
+//tracks: 0 proton, 1 pion, 2 bachelor
+  Float_t fTTrackPx[150][3];
+  Float_t fTTrackPy[150][3];
+  Float_t fTTrackPz[150][3];
+  Float_t fTTrackTPCmom[150][3];
+  Float_t fTTrackEta[150][3];
+  Short_t fTTrackCharge[150][3];
+  Float_t fTTrackDCA[150][3];
+  Float_t fTTrackITSspi[150][3];
+  Float_t fTTrackITSsp[150][3];
+  Float_t fTTrackITSsk[150][3];
+  Float_t fTTrackTPCspi[150][3];
+  Float_t fTTrackTPCsp[150][3];
+  Float_t fTTrackTPCsk[150][3];
+  Float_t fTTrackTOFse[150][3];
+  Float_t fTTrackTOFspi[150][3];
+  Float_t fTTrackTOFsp[150][3];
+  Float_t fTTrackTOFsk[150][3];
+  Int_t fTTrackNcl[150][3];
+  Float_t fTTrackCrF[150][3];
+  Int_t fTTrackShared[150][3];
+  Float_t fTTrackTPCchi2[150][3];
+  Bool_t fTTrackITStime[150][3];
+  Bool_t fTTrackTOFtime[150][3];
+  Bool_t fTTrackTPConly[150][3];
+  Bool_t fTTrackITScomplementary[150][3];
+  Bool_t fTTrackITSpure[150][3];
+  Bool_t fTTrackGLOBAL[150][3];
+
+
+ClassDef(AliOtonOmegaAnalysis,3)
+};
+
+#endif /* ALIOTONOMEGAANALYSIS_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliOtonOmegaCascade.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliOtonOmegaCascade.cxx
@@ -1,0 +1,524 @@
+/*
+ * AliOtonOmegaCascade.cxx
+ *
+ *  Created on: Jan 11, 2018
+ *      Author: gu74req
+ */
+#include <TMath.h>
+
+#include "AliOtonOmegaCascade.h"
+#include "AliLog.h"
+#include "AliAnalysisManager.h"
+#include "AliInputEventHandler.h"
+#include "AliAODMCParticle.h"
+
+ClassImp(AliOtonOmegaCascade)
+AliOtonOmegaCascade::AliOtonOmegaCascade()
+    : AliFemtoDreamBasePart(),
+      fPosDaug(new AliFemtoDreamTrack()),
+      fNegDaug(new AliFemtoDreamTrack()),
+      fBach(new AliFemtoDreamTrack()),
+      fXiMass(0),
+      fOmegaMass(0),
+      fDCAXiDaug(0),
+      fTransRadius(0),
+      fRapXi(0),
+      fRapOmega(0),
+      fAlphaXi(0),
+      fPtArmXi(0),
+      fDCAXiPrimVtx(0),
+      fLength(0),
+      fMassv0(0),
+      fv0DCADaug(0),
+      fv0DCAPrimVtx(0),
+      fv0Momentum(),
+      fv0Pt(0),
+      fDCABachPrimVtx(0),
+      fv0TransRadius(0),
+      fv0CPA(0),
+      fv0PosToPrimVtx(0),
+      fv0NegToPrimVtx(0),
+      fv0ToXiPointAngle(0),
+      fv0Length(0),
+      fDCAv0Xi(0),
+      fv0PDG(0) {
+}
+
+AliOtonOmegaCascade::~AliOtonOmegaCascade() {
+  if (fPosDaug) {
+    delete fPosDaug;
+  }
+  if (fNegDaug) {
+    delete fNegDaug;
+  }
+  if (fBach) {
+    delete fBach;
+  }
+}
+
+void AliOtonOmegaCascade::SetCascade(AliAODEvent *evt, AliAODcascade *casc) {
+  //xi business
+  Reset();
+  fIsReset = false;
+  fIsSet = true;
+  this->SetCharge(casc->ChargeXi());
+  this->SetMomentum(casc->MomXiX(), casc->MomXiY(), casc->MomXiZ());
+  this->SetPt(fP.Pt());
+  double PrimVtx[3] = { 99., 99., 99 };
+  double decayPosXi[3] = { casc->DecayVertexXiX(), casc->DecayVertexXiY(), casc
+      ->DecayVertexXiZ() };
+  fXiMass = casc->MassXi();
+  fOmegaMass = casc->MassOmega();
+  fDCAXiDaug = casc->DcaXiDaughters();
+  evt->GetPrimaryVertex()->GetXYZ(PrimVtx);
+  this->SetEvtNumber(evt->GetRunNumber());
+  fCPA = casc->CosPointingAngleXi(PrimVtx[0], PrimVtx[1], PrimVtx[2]);
+  fTransRadius = TMath::Sqrt(
+      decayPosXi[0] * decayPosXi[0] + decayPosXi[1] * decayPosXi[1]);
+  fRapXi = casc->RapXi();
+  fRapOmega = casc->RapOmega();
+  this->SetEta(casc->Eta());
+  this->SetTheta(fP.Theta());
+  this->SetPhi(fP.Phi());
+  fAlphaXi = casc->AlphaXi();
+  fPtArmXi = casc->PtArmXi();
+  fDCAXiPrimVtx = casc->DcaXiToPrimVertex(PrimVtx[0], PrimVtx[1], PrimVtx[2]);
+  fLength = TMath::Sqrt(
+      TMath::Power((decayPosXi[0] - PrimVtx[0]), 2)
+          + TMath::Power((decayPosXi[1] - PrimVtx[1]), 2)
+          + TMath::Power((decayPosXi[2] - PrimVtx[2]), 2));
+  if (this->GetMomentum().Mag() > 0) {
+    static double mass =
+        TDatabasePDG::Instance()->GetParticle(fPDGCode)->Mass();
+    fLength = fLength * mass / this->GetMomentum().Mag();
+  } else {
+    fLength = -1.;
+  }
+
+  //From here daughter business
+  AliAODTrack *nTrackXi = dynamic_cast<AliAODTrack*>(casc->GetDaughter(1));
+  AliAODTrack *pTrackXi = dynamic_cast<AliAODTrack*>(casc->GetDaughter(0));
+  AliAODTrack *bachTrackXi = dynamic_cast<AliAODTrack*>(casc->GetDecayVertexXi()
+      ->GetDaughter(0));
+  fNegDaug->SetTrack(nTrackXi);
+  fPosDaug->SetTrack(pTrackXi);
+  fBach->SetTrack(bachTrackXi);
+  fNegDaug->SetMomentum(casc->MomNegX(), casc->MomNegY(), casc->MomNegZ());
+  fPosDaug->SetMomentum(casc->MomPosX(), casc->MomPosY(), casc->MomPosZ());
+  fBach->SetMomentum(casc->MomBachX(), casc->MomBachY(), casc->MomBachZ());
+
+  double posMom[3] = { 0. };
+  double negMom[3] = { 0. };
+  double bachMom[3] = { 0. };
+
+  fNegDaug->GetMomentum().GetXYZ(negMom);
+  fPosDaug->GetMomentum().GetXYZ(posMom);
+  fBach->GetMomentum().GetXYZ(bachMom);
+
+//  fMass = MassCasc();
+  this->SetIDTracks(nTrackXi->GetID());
+  this->SetIDTracks(pTrackXi->GetID());
+  this->SetIDTracks(bachTrackXi->GetID());
+
+  this->SetEta(fNegDaug->GetMomentum().Eta());
+  this->SetEta(fPosDaug->GetMomentum().Eta());
+  this->SetEta(fBach->GetMomentum().Eta());
+
+  this->SetTheta(fNegDaug->GetMomentum().Theta());
+  this->SetTheta(fPosDaug->GetMomentum().Theta());
+  this->SetTheta(fBach->GetMomentum().Theta());
+
+  this->SetPhi(fNegDaug->GetMomentum().Phi());
+  this->SetPhi(fPosDaug->GetMomentum().Phi());
+  this->SetPhi(fBach->GetMomentum().Phi());
+
+  this->SetCharge(nTrackXi->Charge());
+  this->SetCharge(pTrackXi->Charge());
+  this->SetCharge(bachTrackXi->Charge());
+  if (fNegDaug->IsSet()) {
+    this->SetPhiAtRadius(fNegDaug->GetPhiAtRaidius().at(0));
+  }
+  if (fPosDaug->IsSet()) {
+    this->SetPhiAtRadius(fPosDaug->GetPhiAtRaidius().at(0));
+  }
+  if (fBach->IsSet()) {
+    this->SetPhiAtRadius(fBach->GetPhiAtRaidius().at(0));
+  }
+
+  //v0 business
+  if (bachTrackXi->Charge() < 0) {  //Xi minus
+    fMassv0 = casc->MassLambda();
+  } else {  //Xi plus case
+    //Workaround to identify also Xi+. We usually only set the PDG code once,
+    //assuming a Xi -, meaning we expect a Lambda, not an Antilambda.
+    fMassv0 = casc->MassAntiLambda();
+  }
+  fv0Momentum.SetXYZ(casc->MomV0X(), casc->MomV0Y(), casc->MomV0Z());
+  fv0Pt = casc->MomV0X() * casc->MomV0X() + casc->MomV0Y() * casc->MomV0Y();
+  fv0DCADaug = casc->DcaV0Daughters();
+  fv0DCAPrimVtx = casc->DcaV0ToPrimVertex();
+  double decayPosV0[3] = { casc->DecayVertexV0X(), casc->DecayVertexV0Y(), casc
+      ->DecayVertexV0Z() };
+  fv0TransRadius = TMath::Sqrt(
+      decayPosV0[0] * decayPosV0[0] + decayPosV0[1] * decayPosV0[1]);
+  fv0CPA = casc->CosPointingAngle(evt->GetPrimaryVertex());
+
+  fDCABachPrimVtx = casc->DcaBachToPrimVertex();
+  fv0PosToPrimVtx = casc->DcaPosToPrimVertex();
+  fv0NegToPrimVtx = casc->DcaNegToPrimVertex();
+  fv0ToXiPointAngle = casc->CosPointingAngle(casc->GetDecayVertexXi());
+  float LamPDGMass = 1.115683;
+  fv0Length = TMath::Sqrt(
+      TMath::Power((decayPosV0[0] - decayPosXi[0]), 2)
+          + TMath::Power((decayPosV0[1] - decayPosXi[1]), 2)
+          + TMath::Power((decayPosV0[2] - decayPosXi[2]), 2));
+  //  Float_t lctauV0 = -1.;
+  if (fv0Momentum.Mag() > 0) {
+    fv0Length = fv0Length * LamPDGMass / fv0Momentum.Mag();
+  } else {
+    fv0Length = -1.;
+  }
+  fDCAv0Xi = TMath::Sqrt(
+      TMath::Power((decayPosV0[0] - decayPosXi[0]), 2)
+          + TMath::Power((decayPosV0[1] - decayPosXi[1]), 2));
+  if (fIsMC) {
+    SetMCMotherInfo(evt, casc);
+  }
+}
+
+void AliOtonOmegaCascade::SetCascade(AliESDEvent *evt, AliMCEvent *mcEvent,
+                                      AliESDcascade *casc) {
+  Reset();
+  fIsReset = false;
+  this->fIsSet = true;
+  int idxPosFromV0Dghter = casc->GetPindex();
+  int idxNegFromV0Dghter = casc->GetNindex();
+  int idxBachFromCascade = casc->GetBindex();
+
+  AliESDtrack *esdCascadePos = evt->GetTrack(idxPosFromV0Dghter);
+  fPosDaug->SetTrack(esdCascadePos,mcEvent,-1,false);
+  AliESDtrack *esdCascadeNeg = evt->GetTrack(idxNegFromV0Dghter);
+  fNegDaug->SetTrack(esdCascadeNeg,mcEvent,-1,false);
+  AliESDtrack *esdCascadeBach = evt->GetTrack(idxBachFromCascade);
+  fBach->SetTrack(esdCascadeBach,mcEvent,-1,false);
+  // Identification of the V0 within the esdCascade (via both daughter track indices)
+  AliESDv0 * currentV0 = 0x0;
+  int idxV0FromCascade = -1;
+  for (int iV0 = 0; iV0 < evt->GetNumberOfV0s(); ++iV0) {
+    currentV0 = evt->GetV0(iV0);
+    // Make sure not to use online v0 here
+    // (the cascade is reconstructed with offline v0 only)
+    if (currentV0->GetOnFlyStatus() == kTRUE) continue;
+    int posCurrentV0 = currentV0->GetPindex();
+    int negCurrentV0 = currentV0->GetNindex();
+    if (posCurrentV0 == idxPosFromV0Dghter
+        && negCurrentV0 == idxNegFromV0Dghter) {
+      idxV0FromCascade = iV0;
+      break;
+    }
+  }
+  if (idxV0FromCascade < 0) {
+    AliWarning("Cascade - no matching for the V0, skipping ... \n");
+    return;
+  }
+  double posMom[3] = { 0. };
+  double negMom[3] = { 0. };
+  double bachMom[3] = { 0. };
+  //the momenta of the daughters have to be taken at the v0 vertex,
+  //the bachelor momenta at the cascade vertex
+  currentV0->GetPPxPyPz(posMom[0], posMom[1], posMom[2]);
+  fPosDaug->SetMomentum(posMom[0], posMom[1], posMom[2]);
+  currentV0->GetNPxPyPz(negMom[0], negMom[1], negMom[2]);
+  fNegDaug->SetMomentum(negMom[0], negMom[1], negMom[2]);
+  casc->GetBPxPyPz(bachMom[0], bachMom[1], bachMom[2]);
+  fBach->SetMomentum(bachMom[0], bachMom[1], bachMom[2]);
+
+  TVector3 xiMom = fPosDaug->GetMomentum();
+  xiMom += fNegDaug->GetMomentum();
+  xiMom += fBach->GetMomentum();
+
+  this->SetMomentum(xiMom.X(), xiMom.Y(), xiMom.Z());
+  this->SetPt(fP.Pt());
+
+  double PrimVtx[3] = { 99., 99., 99 };
+  double decayPosXi[3] = { 0. };
+  casc->GetXYZcascade(decayPosXi[0], decayPosXi[1], decayPosXi[2]);
+  evt->GetPrimaryVertex()->GetXYZ(PrimVtx);
+
+//  fMass = MassCasc();
+  fXiMass = MassXi();
+  fOmegaMass = MassOmega();
+  fDCAXiDaug = casc->GetDcaXiDaughters();
+  this->SetEvtNumber(evt->GetRunNumber());
+
+  fTransRadius = TMath::Sqrt(
+      decayPosXi[0] * decayPosXi[0] + decayPosXi[1] * decayPosXi[1]);
+  this->SetCharge(casc->Charge());
+  fRapXi = casc->RapXi();
+  fRapOmega = casc->RapOmega();
+  this->SetEta(casc->Eta());
+  this->SetTheta(casc->Theta());
+  this->SetPhi(casc->Phi());
+  fAlphaXi = casc->AlphaXi();
+  fPtArmXi = casc->PtArmXi();
+  fCPA = casc->GetCascadeCosineOfPointingAngle(PrimVtx[0], PrimVtx[1],
+                                               PrimVtx[2]);
+  fDCAXiPrimVtx = DcaXiToPrimVertex(PrimVtx, decayPosXi);
+  fLength = TMath::Sqrt(
+      TMath::Power((decayPosXi[0] - PrimVtx[0]), 2)
+          + TMath::Power((decayPosXi[1] - PrimVtx[1]), 2)
+          + TMath::Power((decayPosXi[2] - PrimVtx[2]), 2));
+  if (this->GetMomentum().Mag() > 0) {
+    static double mass =
+        TDatabasePDG::Instance()->GetParticle(fPDGCode)->Mass();
+    fLength = fLength * mass / this->GetMomentum().Mag();
+  } else {
+    fLength = -1.;
+  }
+  this->SetIDTracks(esdCascadeNeg->GetID());
+  this->SetIDTracks(esdCascadePos->GetID());
+  this->SetIDTracks(esdCascadeBach->GetID());
+
+  this->SetEta(esdCascadeNeg->Eta());
+  this->SetEta(esdCascadePos->Eta());
+  this->SetEta(esdCascadeBach->Eta());
+
+  this->SetTheta(esdCascadeNeg->Theta());
+  this->SetTheta(esdCascadePos->Theta());
+  this->SetTheta(esdCascadeBach->Theta());
+
+  this->SetPhi(esdCascadeNeg->Phi());
+  this->SetPhi(esdCascadePos->Phi());
+  this->SetPhi(esdCascadeBach->Phi());
+
+  this->SetCharge(esdCascadeNeg->Charge());
+  this->SetCharge(esdCascadePos->Charge());
+  this->SetCharge(esdCascadeBach->Charge());
+
+  if (fNegDaug->IsSet()) {
+    this->SetPhiAtRadius(fNegDaug->GetPhiAtRaidius().at(0));
+  }
+  if (fPosDaug->IsSet()) {
+    this->SetPhiAtRadius(fPosDaug->GetPhiAtRaidius().at(0));
+  }
+  if (fBach->IsSet()) {
+    this->SetPhiAtRadius(fBach->GetPhiAtRaidius().at(0));
+  }
+
+  TVector3 v0Mom = fPosDaug->GetMomentum() + fNegDaug->GetMomentum();
+  fv0Momentum.SetXYZ(v0Mom.X(), v0Mom.Y(), v0Mom.Z());
+  fv0Pt = fv0Momentum.Pt();
+  if (esdCascadeBach->Charge() < 0) {
+    fMassv0 = Massv0(fPosDaug->GetPDGCode(), fNegDaug->GetPDGCode());
+  } else {
+    //Workaround to identify also Xi+. We usually only set the PDG code once,
+    //assuming a Xi -, meaning we expect a Lambda, not an Antilambda.
+    fMassv0 = Massv0(fNegDaug->GetPDGCode(), fPosDaug->GetPDGCode());
+  }
+  fv0DCADaug = casc->GetDcaV0Daughters();
+  fv0DCAPrimVtx = currentV0->GetD(evt->GetPrimaryVertex()->GetX(),
+                                  evt->GetPrimaryVertex()->GetY(),
+                                  evt->GetPrimaryVertex()->GetZ());
+  double decayPosV0[3] = { 0. };
+  currentV0->GetXYZ(decayPosV0[0], decayPosV0[1], decayPosV0[2]);
+  fv0TransRadius = TMath::Sqrt(
+      decayPosV0[0] * decayPosV0[0] + decayPosV0[1] * decayPosV0[1]);
+  fv0CPA = currentV0->GetV0CosineOfPointingAngle(
+      evt->GetPrimaryVertex()->GetX(), evt->GetPrimaryVertex()->GetY(),
+      evt->GetPrimaryVertex()->GetZ());
+
+  fDCABachPrimVtx = TMath::Abs(
+      esdCascadeBach->GetD(evt->GetPrimaryVertex()->GetX(),
+                           evt->GetPrimaryVertex()->GetY(),
+                           evt->GetMagneticField()));
+  fv0PosToPrimVtx = TMath::Abs(
+      esdCascadePos->GetD(evt->GetPrimaryVertex()->GetX(),
+                          evt->GetPrimaryVertex()->GetY(),
+                          evt->GetMagneticField()));
+  fv0NegToPrimVtx = TMath::Abs(
+      esdCascadeNeg->GetD(evt->GetPrimaryVertex()->GetX(),
+                          evt->GetPrimaryVertex()->GetY(),
+                          evt->GetMagneticField()));
+  fv0ToXiPointAngle = casc->GetV0CosineOfPointingAngle(decayPosXi[0],
+                                                       decayPosXi[1],
+                                                       decayPosXi[2]);
+  fv0Length = TMath::Sqrt(
+      TMath::Power((decayPosV0[0] - decayPosXi[0]), 2)
+          + TMath::Power((decayPosV0[1] - decayPosXi[1]), 2)
+          + TMath::Power((decayPosV0[2] - decayPosXi[2]), 2));
+  if (fv0Momentum.Mag() > 0) {
+    float LamPDGMass = TDatabasePDG::Instance()->GetParticle(fv0PDG)->Mass();
+    fv0Length = fv0Length * LamPDGMass / fv0Momentum.Mag();
+  } else {
+    fv0Length = -1.;
+  }
+  fDCAv0Xi = TMath::Sqrt(
+      TMath::Power((decayPosV0[0] - decayPosXi[0]), 2)
+          + TMath::Power((decayPosV0[1] - decayPosXi[1]), 2));
+
+  return;
+}
+
+void AliOtonOmegaCascade::Reset() {
+  if (!fIsReset) {
+//    fMass = 0;
+    fXiMass = 0;
+    fOmegaMass = 0;
+    fDCAXiPrimVtx = 0;
+    fDCAXiDaug = 0;
+    fTransRadius = 0;
+    fRapXi = -99;
+    fRapOmega = -99;
+    fAlphaXi = 99;
+    fPtArmXi = 99;
+    fLength = 0;
+    fMassv0 = 0;
+    fv0DCADaug = 0;
+    fv0DCAPrimVtx = 0;
+    fv0Momentum.SetXYZ(0, 0, 0);
+    fv0Pt = 0;
+    fDCABachPrimVtx = 0;
+    fv0TransRadius = 0;
+    fv0CPA = 0;
+    fv0PosToPrimVtx = 0;
+    fv0NegToPrimVtx = 0;
+    fv0ToXiPointAngle = 0;
+    fv0Length = 0;
+    fDCAv0Xi = 0;
+    fP.SetXYZ(0, 0, 0);
+    fMCP.SetXYZ(0, 0, 0);
+    fPt = 0;
+    fMCPt = 0;
+    fMCPt = 0;
+    fP_TPC = 0;
+    fEta.clear();
+    fTheta.clear();
+    fMCTheta.clear();
+    fPhi.clear();
+    fPhiAtRadius.clear();
+    fMCPhi.clear();
+    fIDTracks.clear();
+    fCharge.clear();
+    fCPA = 0;
+    fOrigin = AliFemtoDreamBasePart::kUnknown;
+    //we don't want to reset the fPDGCode
+    fMCPDGCode = 0;
+    fPDGMotherWeak = 0;
+    //we don't want to reset isMC
+    fUse = false;
+    fIsSet = false;
+    fIsReset = true;
+  }
+}
+
+void AliOtonOmegaCascade::SetMCMotherInfo(AliAODEvent *evt,
+                                           AliAODcascade *casc) {
+  TClonesArray *mcarray = dynamic_cast<TClonesArray*>(evt->FindListObject(
+      AliAODMCParticle::StdBranchName()));
+  if (!mcarray) {
+    AliFatal("No MC Array found");
+  }
+  if (fBach->IsSet() && fPosDaug->IsSet() && fNegDaug->IsSet()) {
+    //look if the bachelor is from a weak decay and find the label of the
+    //mother
+    int labelBachMother = -1;
+    if (fBach->GetParticleOrigin() == AliFemtoDreamBasePart::kWeak) {
+      //      std::cout << "Bachelor ID" << fBach->GetIDTracks().at(0) << "\n";
+      AliAODTrack* bachTrk = dynamic_cast<AliAODTrack*>(casc->GetDecayVertexXi()
+          ->GetDaughter(0));
+      int labelBach = bachTrk->GetLabel();
+      labelBachMother =
+          ((AliAODMCParticle*) mcarray->At(labelBach))->GetMother();
+      if (labelBachMother < 0) {
+        //This should not happen, just in case somethings very fishy
+        this->SetParticleOrigin(AliFemtoDreamBasePart::kFake);
+      } else {
+//        std::cout << "Found a Track weakling and his mother is: " << labelBachMother <<'\n';
+//        std::cout << "PDG Bach: "<<((AliAODMCParticle*)mcarray->At(labelBach))->GetPdgCode() << "\n";
+//        std::cout << "PDG Bach-Mother: "<<((AliAODMCParticle*)mcarray->At(labelBachMother))->GetPdgCode() << "\n";
+        //look if a v0 exists, and if this v0 stems from a weak decay, and
+        //get the label of the mother particle
+        int labelv0Mother = -1;
+        int PDGDaug[2];
+        //order doesn't matter for the MatchToMC
+        PDGDaug[0] = TMath::Abs(fPosDaug->GetPDGCode());
+        PDGDaug[1] = TMath::Abs(fNegDaug->GetPDGCode());
+        int labelv0 = casc->MatchToMC(TMath::Abs(fv0PDG), mcarray, 2, PDGDaug);
+        if (labelv0 < 0) {
+          //both daughters exist as an MC Particle, therfore this can only
+          //be a fake v0, and therefore a fake candidate overall
+          this->SetParticleOrigin(AliFemtoDreamBasePart::kFake);
+        } else {
+//          std::cout <<"Potential v0 weakling with ID: " << labelv0 << " found \n";
+          AliAODMCParticle* mcv0 = (AliAODMCParticle*) mcarray->At(labelv0);
+          if (!mcv0) {
+            this->fIsSet = false;
+          } else {
+            if (mcv0->IsSecondaryFromWeakDecay()
+                && !(mcv0->IsSecondaryFromMaterial())) {
+              //the v0 candidate has to be from a weak decay itself
+              labelv0Mother = mcv0->GetMother();
+//              std::cout << "Indeed a v0 weakling his mothers number is " << labelv0Mother << "\n";
+//              std::cout << "PDG v0: "<< mcv0->GetPdgCode() << "\n";
+//              std::cout << "PDG v0-Mother: "<<((AliAODMCParticle*)mcarray->At(labelv0Mother))->GetPdgCode() << "\n";
+              if (labelv0Mother < 0) {
+                //Again, this should not happen, just in case somethings
+                //very fishy
+                this->fIsSet = false;
+              } else {
+                //now, for a real candidate bachelor and v0 need to have the
+                //same mom, NO ADOPTION OR PATCHWORK :(
+                //                std::cout << labelv0Mother << '\t' << labelBachMother << '\n';
+                if (labelv0Mother == labelBachMother) {
+                  //MOMMY?
+                  AliAODMCParticle* mcPart = (AliAODMCParticle*) mcarray->At(
+                      labelv0Mother);
+//                  std::cout << "MOOOOOM: " << mcPart->GetPdgCode() << "\n";
+                  this->SetMCPDGCode(mcPart->GetPdgCode());
+                  double mcMom[3] = { 0., 0., 0. };
+                  mcPart->PxPyPz(mcMom);
+                  this->SetMCMomentum(mcMom[0], mcMom[1], mcMom[2]);
+                  this->SetMCPt(mcPart->Pt());
+                  this->SetMCPhi(mcPart->Phi());
+                  this->SetMCTheta(mcPart->Theta());
+                  if (mcPart->IsPhysicalPrimary()
+                      && !(mcPart->IsSecondaryFromWeakDecay())) {
+                    this->SetParticleOrigin(
+                        AliFemtoDreamBasePart::kPhysPrimary);
+//                    std::cout << "A primary \n";
+                  } else if (mcPart->IsSecondaryFromWeakDecay()
+                      && !(mcPart->IsSecondaryFromMaterial())) {
+                    this->SetParticleOrigin(AliFemtoDreamBasePart::kWeak);
+                    this->SetPDGMotherWeak(
+                        ((AliAODMCParticle*) mcarray->At(mcPart->GetMother()))
+                            ->PdgCode());
+//                    std::cout << "A secondary from" << ((AliAODMCParticle*)mcarray->At(mcPart->GetMother()))->PdgCode() << std::endl;
+                  } else if (mcPart->IsSecondaryFromMaterial()) {
+                    this->SetParticleOrigin(AliFemtoDreamBasePart::kMaterial);
+//                    std::cout << "A Material \n";
+                  } else {
+                    this->SetParticleOrigin(AliFemtoDreamBasePart::kUnknown);
+//                    std::cout << "An Unknown \n";
+                  }
+                } else {
+                  //combinatorial background
+                  this->SetParticleOrigin(AliFemtoDreamBasePart::kFake);
+                }
+              }
+            } else {
+              //if its not from a secondary decay, this cant be a candidate
+              this->SetParticleOrigin(AliFemtoDreamBasePart::kFake);
+            }
+          }
+        }
+      }
+    } else {
+      //if the bachlor is not from a weak decay, then it is a ...
+      this->SetParticleOrigin(AliFemtoDreamBasePart::kFake);
+    }
+  } else {
+    //this means the bachelor and daughter tracks have no corresponding MC Particle
+    this->fIsSet = false;
+  }
+}
+

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliOtonOmegaCascade.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliOtonOmegaCascade.h
@@ -1,0 +1,267 @@
+/*
+ * AliOtonOmegaCascade.h
+ *
+ *  Created on: Jan 11, 2018
+ *      Author: gu74req
+ */
+
+#ifndef ALIOTONOMEGACASCADE_H_
+#define ALIOTONOMEGACASCADE_H_
+#include "Rtypes.h"
+#include "TVector3.h"
+#include "TMath.h"
+
+#include "AliFemtoDreamBasePart.h"
+#include "AliFemtoDreamTrack.h"
+#include "AliAODEvent.h"
+#include "AliAODcascade.h"
+#include "AliESDEvent.h"
+#include "AliESDcascade.h"
+#include "TDatabasePDG.h"
+
+class AliOtonOmegaCascade : public AliFemtoDreamBasePart {
+ public:
+  AliOtonOmegaCascade();
+  virtual ~AliOtonOmegaCascade();
+  void SetCascade(AliAODEvent *evt, AliAODcascade *casc);
+  void SetCascade(AliESDEvent *evt, AliMCEvent *mcEvent, AliESDcascade *casc);
+  TString ClassName() {
+    return "Cascade";
+  }
+  ;
+  float GetXiMass() {
+    return fXiMass;
+  }
+  ;
+  float GetOmegaMass() {
+    return fOmegaMass;
+  }
+  ;
+  float GetMass(int PDGValue) const {
+    if (TMath::Abs(PDGValue) == 3312) {
+      return fXiMass;
+    } else if (TMath::Abs(PDGValue) == 3334) {
+      return fOmegaMass;
+    } else {
+      return 0.;
+    }
+  }
+  ;
+  float GetDCAXiPrimVtx() {
+    return fDCAXiPrimVtx;
+  }
+  ;
+  float GetXiDCADaug() {
+    return fDCAXiDaug;
+  }
+  ;
+  float GetXiTransverseRadius() {
+    return fTransRadius;
+  }
+  ;
+  float GetXiRapidity() {
+    return fRapXi;
+  }
+  ;
+  float GetOmegaRapidity() {
+    return fRapOmega;
+  }
+  ;
+  float GetXiAlpha() {
+    return fAlphaXi;
+  }
+  ;
+  float GetPtArmXi() {
+    return fPtArmXi;
+  }
+  ;
+  float GetDecayLength() {
+    return fLength;
+  }
+  ;
+  float BachDCAPrimVtx() {
+    return fDCABachPrimVtx;
+  }
+  ;
+  float Getv0Mass() {
+    return fMassv0;
+  }
+  ;
+  float Getv0DCADaug() {
+    return fv0DCADaug;
+  }
+  ;
+  float Getv0DCAPrimVtx() {
+    return fv0DCAPrimVtx;
+  }
+  ;
+  float Getv0TransverseRadius() {
+    return fv0TransRadius;
+  }
+  ;
+  float Getv0CPA() {
+    return fv0CPA;
+  }
+  ;
+  float Getv0PosToPrimVtx() {
+    return fv0PosToPrimVtx;
+  }
+  ;
+  float Getv0NegToPrimVtx() {
+    return fv0NegToPrimVtx;
+  }
+  ;
+  float Getv0XiPointingAngle() {
+    return fv0ToXiPointAngle;
+  }
+  ;
+  float Getv0DecayLength() {
+    return fv0Length;
+  }
+  ;
+  float GetDCAv0Xi() {
+    return fDCAv0Xi;
+  }
+  ;
+  void SetPDGDaugPos(int PDGCode) {
+    fPosDaug->SetPDGCode(PDGCode);
+  }
+  ;
+  void SetPDGDaugNeg(int PDGCode) {
+    fNegDaug->SetPDGCode(PDGCode);
+  }
+  ;
+  void SetPDGDaugBach(int PDGCode) {
+    fBach->SetPDGCode(PDGCode);
+  }
+  ;
+  TVector3 Getv0P() {
+    return fv0Momentum;
+  }
+  ;
+  float Getv0Pt() {
+    return fv0Pt;
+  }
+  ;
+  void Setv0PDGCode(int PDG) {
+    fv0PDG = PDG;
+  }
+  ;
+  double E2(int pdgCode, double Ptot2);
+  double Ptot2V0();
+  double Ptot2Casc();
+  double MassCasc(int PDGv0, int PDGBach);
+  double Massv0(int PDGPos, int PDGNeg);
+  double MassXi();
+  double MassOmega();
+  double CosPointingAngle(double *primVtx, double *secondVtx);
+  float DcaXiToPrimVertex(double *primVtx, double *secondVtx);
+  AliFemtoDreamTrack *GetPosDaug() const {
+    return fPosDaug;
+  }
+  ;
+  AliFemtoDreamTrack *GetNegDaug() const {
+    return fNegDaug;
+  }
+  ;
+  AliFemtoDreamTrack *GetBach() const {
+    return fBach;
+  }
+  ;
+ private:
+  AliOtonOmegaCascade &operator=(const AliOtonOmegaCascade &obj);
+  AliOtonOmegaCascade(const AliOtonOmegaCascade&);
+  void Reset();
+  void SetMCMotherInfo(AliAODEvent *evt, AliAODcascade *casc);
+  AliFemtoDreamTrack *fPosDaug;
+  AliFemtoDreamTrack *fNegDaug;
+  AliFemtoDreamTrack *fBach;
+  float fXiMass;
+  float fOmegaMass;
+  float fDCAXiDaug;
+  float fTransRadius;
+  float fRapXi;
+  float fRapOmega;
+  float fAlphaXi;
+  float fPtArmXi;
+  float fDCAXiPrimVtx;
+  float fLength;
+  float fMassv0;
+  float fv0DCADaug;
+  float fv0DCAPrimVtx;
+  TVector3 fv0Momentum;
+  float fv0Pt;
+  float fDCABachPrimVtx;
+  float fv0TransRadius;
+  float fv0CPA;
+  float fv0PosToPrimVtx;
+  float fv0NegToPrimVtx;
+  float fv0ToXiPointAngle;
+  float fv0Length;
+  float fDCAv0Xi;
+  int fv0PDG;ClassDef(AliOtonOmegaCascade,2)
+};
+
+inline double AliOtonOmegaCascade::E2(int pdgCode, double Ptot2) {
+  double mass = TDatabasePDG::Instance()->GetParticle(pdgCode)->Mass();
+  return mass * mass + Ptot2;
+}
+
+inline double AliOtonOmegaCascade::Ptot2V0() {
+  return (fPosDaug->GetMomentum() + fNegDaug->GetMomentum()).Mag2();
+}
+
+inline double AliOtonOmegaCascade::Ptot2Casc() {
+  return fP.Mag2();
+}
+
+inline double AliOtonOmegaCascade::MassCasc(int PDGv0, int PDGBach) {
+  double Ev0 = ::sqrt(E2(PDGv0, Ptot2V0()));
+  double EBach = ::sqrt(E2(PDGBach, fBach->GetMomentum().Mag2()));
+  double Ptot2 = Ptot2Casc();
+  return ::sqrt(::pow(Ev0 + EBach, 2) - Ptot2);
+}
+
+inline double AliOtonOmegaCascade::Massv0(int PDGPos, int PDGNeg) {
+  double EPos = ::sqrt(E2(PDGPos, fPosDaug->GetMomentum().Mag2()));
+  double ENeg = ::sqrt(E2(PDGNeg, fNegDaug->GetMomentum().Mag2()));
+  return ::sqrt(
+      (EPos + ENeg) * (EPos + ENeg)
+          - (fPosDaug->GetMomentum() + fNegDaug->GetMomentum()).Mag2());
+}
+
+inline double AliOtonOmegaCascade::MassXi() {
+  double Ev0 = ::sqrt(E2(3122, Ptot2V0()));
+  double EBach = ::sqrt(E2(211, fBach->GetMomentum().Mag2()));
+  double Ptot2 = Ptot2Casc();
+  return ::sqrt(::pow(Ev0 + EBach, 2) - Ptot2);
+}
+
+inline double AliOtonOmegaCascade::MassOmega() {
+  double Ev0 = TMath::Sqrt(E2(3122, Ptot2V0()));
+  double EBach = TMath::Sqrt(E2(321, fBach->GetMomentum().Mag2()));
+  double Ptot2 = Ptot2Casc();
+  return ::sqrt(::pow(Ev0 + EBach, 2) - Ptot2);
+}
+
+inline double AliOtonOmegaCascade::CosPointingAngle(double *primVtx,
+                                                     double *secondVtx) {
+  TVector3 lVectPrimVtxToXi(secondVtx[0] - primVtx[0],
+                            secondVtx[1] - primVtx[1],
+                            secondVtx[2] - primVtx[2]);
+  return fP.Dot(lVectPrimVtxToXi)
+      / TMath::Sqrt(fP.Mag2() * lVectPrimVtxToXi.Mag2());
+}
+
+inline float AliOtonOmegaCascade::DcaXiToPrimVertex(double *primVtx,
+                                                     double *secondVtx) {
+  Double_t dx = (primVtx[1] - secondVtx[1]) * fP.Z()
+      - (primVtx[2] - secondVtx[2]) * fP.Y();
+  Double_t dy = (primVtx[2] - secondVtx[2]) * fP.X()
+      - (primVtx[0] - secondVtx[0]) * fP.Z();
+  Double_t dz = (primVtx[0] - secondVtx[0]) * fP.Y()
+      - (primVtx[1] - secondVtx[1]) * fP.X();
+  return TMath::Sqrt((dx * dx + dy * dy + dz * dz) / fP.Mag2());
+}
+
+#endif /* ALIOTONOMEGACASCADE_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliOtonOmegaCascadeCuts.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliOtonOmegaCascadeCuts.cxx
@@ -528,7 +528,7 @@ void AliOtonOmegaCascadeCuts::Init() {
   fBachCuts->SetMinimalBooking(fMinimalBooking);
   fBachCuts->Init();
   if (!fMinimalBooking) {
-    fHist = new AliOtonOmegaCascadeHist(fXiMass, fRunNumberQA, fMinRunNumber,
+    fHist = new AliFemtoDreamCascadeHist(fXiMass, fRunNumberQA, fMinRunNumber,
                                          fMaxRunNumber);
     BookCuts();
     if (!(fNegCuts || fPosCuts || fBachCuts)) {
@@ -561,7 +561,7 @@ void AliOtonOmegaCascadeCuts::Init() {
       fMCHistList->Add(fBachCuts->GetMCQAHists());
     }
   } else {
-    fHist = new AliOtonOmegaCascadeHist("MinimalBooking", fXiMass);
+    fHist = new AliFemtoDreamCascadeHist("MinimalBooking", fXiMass);
     fHistList = new TList();
     fHistList->SetOwner();
     fHistList->SetName("CascadeCuts");

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliOtonOmegaCascadeCuts.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliOtonOmegaCascadeCuts.cxx
@@ -1,0 +1,778 @@
+/*
+ * AliOtonOmegaCascadeCuts.cxx
+ *
+ *  Created on: Jan 11, 2018
+ *      Author: gu74req
+ */
+
+#include "vector"
+#include "AliOtonOmegaCascadeCuts.h"
+#include "AliLog.h"
+ClassImp(AliOtonOmegaCascadeCuts)
+AliOtonOmegaCascadeCuts::AliOtonOmegaCascadeCuts()
+    : fHist(nullptr),
+      fMCHist(nullptr),
+      fNegCuts(0),
+      fPosCuts(0),
+      fBachCuts(0),
+      fHistList(0),
+      fMCHistList(0),
+      fMinimalBooking(false),
+      fMCData(false),
+      fContribSplitting(false),
+      fCutFlag(0),
+      fRunNumberQA(false),
+      fMinRunNumber(0),
+      fMaxRunNumber(0),
+      fCutPt(false),
+      fPtMin(0),
+      fPtMax(0),
+      fCutPtv0(false),
+      fPtMinv0(0),
+      fPtMaxv0(0),
+      fcutXiMass(false),
+      fXiMass(0),
+      fXiMassWidth(0),
+      fcutXiCharge(false),
+      fXiCharge(0),
+      fcutDCAXiDaug(false),
+      fMaxDCAXiDaug(0),
+      fcutMinDistVtxBach(false),
+      fMinDistVtxBach(0),
+      fcutCPAXi(false),
+      fCPAXi(0),
+      fcutXiTransRadius(false),
+      fMinXiTransRadius(0),
+      fMaxXiTransRadius(0),
+      fcutv0Mass(false),
+      fv0Mass(0),
+      fv0Width(0),
+      fcutv0MaxDCADaug(false),
+      fv0MaxDCADaug(0),
+      fcutCPAv0(false),
+      fCPAv0(0),
+      fcutv0TransRadius(false),
+      fMinv0TransRadius(0),
+      fMaxv0TransRadius(0),
+      fcutv0MinDistVtx(false),
+      fv0MinDistVtx(0),
+      fcutv0DaugMinDistVtx(false),
+      fv0DaugMinDistVtx(0),
+      fRejMassCut(false),
+      fRejPDG(0),
+      fRejMass(0),
+      fRejWidth(0),
+      fPDGCasc(0),
+      fPDGv0(0),
+      fPDGPosDaug(0),
+      fPDGNegDaug(0),
+      fPDGBachDaug(0) {
+}
+
+AliOtonOmegaCascadeCuts::AliOtonOmegaCascadeCuts(
+    const AliOtonOmegaCascadeCuts& cuts)
+    : fHist(cuts.fHist),
+      fMCHist(cuts.fMCHist),
+      fNegCuts(cuts.fNegCuts),
+      fPosCuts(cuts.fPosCuts),
+      fBachCuts(cuts.fBachCuts),
+      fHistList(cuts.fHistList),
+      fMCHistList(cuts.fMCHistList),
+      fMinimalBooking(cuts.fMinimalBooking),
+      fMCData(cuts.fMCData),
+      fContribSplitting(cuts.fContribSplitting),
+      fCutFlag(cuts.fCutFlag),
+      fRunNumberQA(cuts.fRunNumberQA),
+      fMinRunNumber(cuts.fMinRunNumber),
+      fMaxRunNumber(cuts.fMaxRunNumber),
+      fCutPt(cuts.fCutPt),
+      fPtMin(cuts.fPtMin),
+      fPtMax(cuts.fPtMax),
+      fCutPtv0(cuts.fCutPtv0),
+      fPtMinv0(cuts.fPtMinv0),
+      fPtMaxv0(cuts.fPtMaxv0),
+      fcutXiMass(cuts.fcutXiMass),
+      fXiMass(cuts.fXiMass),
+      fXiMassWidth(cuts.fXiMassWidth),
+      fcutXiCharge(cuts.fcutXiCharge),
+      fXiCharge(cuts.fXiCharge),
+      fcutDCAXiDaug(cuts.fcutDCAXiDaug),
+      fMaxDCAXiDaug(cuts.fMaxDCAXiDaug),
+      fcutMinDistVtxBach(cuts.fcutMinDistVtxBach),
+      fMinDistVtxBach(cuts.fMinDistVtxBach),
+      fcutCPAXi(cuts.fcutCPAXi),
+      fCPAXi(cuts.fCPAXi),
+      fcutXiTransRadius(cuts.fcutXiTransRadius),
+      fMinXiTransRadius(cuts.fMinXiTransRadius),
+      fMaxXiTransRadius(cuts.fMaxXiTransRadius),
+      fcutv0Mass(cuts.fcutv0Mass),
+      fv0Mass(cuts.fv0Mass),
+      fv0Width(cuts.fv0Width),
+      fcutv0MaxDCADaug(cuts.fcutv0MaxDCADaug),
+      fv0MaxDCADaug(cuts.fv0MaxDCADaug),
+      fcutCPAv0(cuts.fcutCPAv0),
+      fCPAv0(cuts.fCPAv0),
+      fcutv0TransRadius(cuts.fcutv0TransRadius),
+      fMinv0TransRadius(cuts.fMinv0TransRadius),
+      fMaxv0TransRadius(cuts.fMaxv0TransRadius),
+      fcutv0MinDistVtx(cuts.fcutv0MinDistVtx),
+      fv0MinDistVtx(cuts.fv0MinDistVtx),
+      fcutv0DaugMinDistVtx(cuts.fcutv0DaugMinDistVtx),
+      fv0DaugMinDistVtx(cuts.fv0DaugMinDistVtx),
+      fRejMassCut(cuts.fRejMassCut),
+      fRejPDG(cuts.fRejPDG),
+      fRejMass(cuts.fRejMass),
+      fRejWidth(cuts.fRejWidth),
+      fPDGCasc(cuts.fPDGCasc),
+      fPDGv0(cuts.fPDGv0),
+      fPDGPosDaug(cuts.fPDGPosDaug),
+      fPDGNegDaug(cuts.fPDGNegDaug),
+      fPDGBachDaug(cuts.fPDGBachDaug) {
+}
+
+AliOtonOmegaCascadeCuts& AliOtonOmegaCascadeCuts::operator=(
+    const AliOtonOmegaCascadeCuts& cuts) {
+  if (this == &cuts) {
+    return *this;
+  }
+
+  this->fHist = cuts.fHist;
+  this->fMCHist = cuts.fMCHist;
+  this->fNegCuts = cuts.fNegCuts;
+  this->fPosCuts = cuts.fPosCuts;
+  this->fBachCuts = cuts.fBachCuts;
+  this->fHistList = cuts.fHistList;
+  this->fMCHistList = cuts.fMCHistList;
+  this->fMinimalBooking = cuts.fMinimalBooking;
+  this->fMCData = cuts.fMCData;
+  this->fContribSplitting = cuts.fContribSplitting;
+  this->fCutFlag = cuts.fCutFlag;
+  this->fRunNumberQA = cuts.fRunNumberQA;
+  this->fMinRunNumber = cuts.fMinRunNumber;
+  this->fMaxRunNumber = cuts.fMaxRunNumber;
+  this->fCutPt = cuts.fCutPt;
+  this->fPtMin = cuts.fPtMin;
+  this->fPtMax = cuts.fPtMax;
+  this->fCutPtv0 = cuts.fCutPtv0;
+  this->fPtMinv0 = cuts.fPtMinv0;
+  this->fPtMaxv0 = cuts.fPtMaxv0;
+  this->fcutXiMass = cuts.fcutXiMass;
+  this->fXiMass = cuts.fXiMass;
+  this->fXiMassWidth = cuts.fXiMassWidth;
+  this->fcutXiCharge = cuts.fcutXiCharge;
+  this->fXiCharge = cuts.fXiCharge;
+  this->fcutDCAXiDaug = cuts.fcutDCAXiDaug;
+  this->fMaxDCAXiDaug = cuts.fMaxDCAXiDaug;
+  this->fcutMinDistVtxBach = cuts.fcutMinDistVtxBach;
+  this->fMinDistVtxBach = cuts.fMinDistVtxBach;
+  this->fcutCPAXi = cuts.fcutCPAXi;
+  this->fCPAXi = cuts.fCPAXi;
+  this->fcutXiTransRadius = cuts.fcutXiTransRadius;
+  this->fMinXiTransRadius = cuts.fMinXiTransRadius;
+  this->fMaxXiTransRadius = cuts.fMaxXiTransRadius;
+  this->fcutv0Mass = cuts.fcutv0Mass;
+  this->fv0Mass = cuts.fv0Mass;
+  this->fv0Width = cuts.fv0Width;
+  this->fcutv0MaxDCADaug = cuts.fcutv0MaxDCADaug;
+  this->fv0MaxDCADaug = cuts.fv0MaxDCADaug;
+  this->fcutCPAv0 = cuts.fcutCPAv0;
+  this->fCPAv0 = cuts.fCPAv0;
+  this->fcutv0TransRadius = cuts.fcutv0TransRadius;
+  this->fMinv0TransRadius = cuts.fMinv0TransRadius;
+  this->fMaxv0TransRadius = cuts.fMaxv0TransRadius;
+  this->fcutv0MinDistVtx = cuts.fcutv0MinDistVtx;
+  this->fv0MinDistVtx = cuts.fv0MinDistVtx;
+  this->fcutv0DaugMinDistVtx = cuts.fcutv0DaugMinDistVtx;
+  this->fv0DaugMinDistVtx = cuts.fv0DaugMinDistVtx;
+  this->fRejMassCut = cuts.fRejMassCut;
+  this->fRejPDG = cuts.fRejPDG;
+  this->fRejMass = cuts.fRejMass;
+  this->fRejWidth = cuts.fRejWidth;
+  this->fPDGCasc = cuts.fPDGCasc;
+  this->fPDGv0 = cuts.fPDGv0;
+  this->fPDGPosDaug = cuts.fPDGPosDaug;
+  this->fPDGNegDaug = cuts.fPDGNegDaug;
+  this->fPDGBachDaug = cuts.fPDGBachDaug;
+
+  return *this;
+}
+
+AliOtonOmegaCascadeCuts::~AliOtonOmegaCascadeCuts() {
+  if (fNegCuts) {
+    delete fNegCuts;
+  }
+  if (fPosCuts) {
+    delete fPosCuts;
+  }
+  if (fBachCuts) {
+    delete fBachCuts;
+  }
+}
+
+AliOtonOmegaCascadeCuts* AliOtonOmegaCascadeCuts::XiCuts(
+    bool isMC, bool contribSplitting, Int_t CutFlag) {
+  AliOtonOmegaCascadeCuts *XiCuts = new AliOtonOmegaCascadeCuts();
+  XiCuts->SetIsMonteCarlo(isMC);
+  XiCuts->SetContributionSplitting(contribSplitting);
+  
+  if(CutFlag == 1){ // Cuts with TIME info for 2 tracks: proton and bachelor (its or tof time)
+                    // sigmas TPC 5 for proton, pion, and bachelor
+   XiCuts->SetXiMassRange(1.322, 0.005);	//YES
+   XiCuts->SetCutXiDaughterDCA(.9);		//YES
+   XiCuts->SetCutXiMinDistBachToPrimVtx(0.03);	//as ESD new vertexer cut
+   XiCuts->SetCutXiCPA(0.991);			//YES
+   XiCuts->SetCutXiTransverseRadius(0.4, 200);	//as ESD new vertexer cut
+   XiCuts->Setv0MassRange(1.116, 0.006);  	//YES
+   XiCuts->SetCutv0MaxDaughterDCA(2.);   	//ESD new vertexer cut
+   XiCuts->SetCutv0CPA(0.99);			//YES
+   XiCuts->SetCutv0TransverseRadius(1., 200);	//as ESD new vertexer cut
+   XiCuts->SetCutv0MinDistToPrimVtx(0.05);   	//as ESD new vertexer cut
+   XiCuts->SetCutv0MinDaugDistToPrimVtx(0.02);	//as ESD new vertexer cut
+   XiCuts->SetRejectMass(1.672, 0.005, 3334);	//YES
+   XiCuts->SetPtRangeXi(0., 999.9);   		//as ESD new vertexer cut
+  }else if(CutFlag == 2){ // Cuts with TIME info for 3 tracks: proton and bachelor (its or tof time)
+                    // sigmas TPC 5 for proton, pion, and bachelor
+   XiCuts->SetXiMassRange(1.322, 0.005);        //YES
+   XiCuts->SetCutXiDaughterDCA(.9);             //YES
+   XiCuts->SetCutXiMinDistBachToPrimVtx(0.03);  //as ESD new vertexer cut
+   XiCuts->SetCutXiCPA(0.991);                  //YES
+   XiCuts->SetCutXiTransverseRadius(0.4, 200);  //as ESD new vertexer cut
+   XiCuts->Setv0MassRange(1.116, 0.006);        //YES   
+   XiCuts->SetCutv0MaxDaughterDCA(2.);         	//as ESD new vertexer cut
+   XiCuts->SetCutv0CPA(0.99);                   //YES
+   XiCuts->SetCutv0TransverseRadius(1., 200);  	//as ESD new vertexer cut
+   XiCuts->SetCutv0MinDistToPrimVtx(0.05);      //as ESD new vertexer cut
+   XiCuts->SetCutv0MinDaugDistToPrimVtx(0.02);  //as ESD new vertexer cut
+   XiCuts->SetRejectMass(1.672, 0.005, 3334);   //YES
+   XiCuts->SetPtRangeXi(0., 999.9);            	//as ESD new vertexer cut
+  }else{ // CutFlag == 0) // Bernie&Andi cuts
+   XiCuts->SetXiMassRange(1.322, 0.005);
+   XiCuts->SetCutXiDaughterDCA(1.6);
+   XiCuts->SetCutXiMinDistBachToPrimVtx(0.05);
+   XiCuts->SetCutXiCPA(0.98);
+   XiCuts->SetCutXiTransverseRadius(0.8, 200);
+   XiCuts->Setv0MassRange(1.116, 0.006);
+   XiCuts->SetCutv0MaxDaughterDCA(1.5);
+   XiCuts->SetCutv0CPA(0.97);
+   XiCuts->SetCutv0TransverseRadius(1.4, 200);
+   XiCuts->SetCutv0MinDistToPrimVtx(0.07);
+   XiCuts->SetCutv0MinDaugDistToPrimVtx(0.05);
+   XiCuts->SetRejectMass(1.672, 0.005, 3334);
+   XiCuts->SetPtRangeXi(0.3, 999.9);
+  }
+  return XiCuts;
+}
+
+AliOtonOmegaCascadeCuts* AliOtonOmegaCascadeCuts::OmegaCuts(
+    bool isMC, bool contribSplitting, Int_t CutFlag) {
+  AliOtonOmegaCascadeCuts *OmegaCuts = new AliOtonOmegaCascadeCuts();
+  OmegaCuts->SetIsMonteCarlo(isMC);
+  OmegaCuts->SetContributionSplitting(contribSplitting);
+  if(CutFlag == 1){ // Cuts with TIME info for 2 tracks: proton and bachelor (its or tof time)
+                    // sigmas TPC 5 for proton, pion, and bachelor
+   OmegaCuts->SetXiMassRange(1.672, 0.005);		//YES
+   OmegaCuts->SetCutXiDaughterDCA(.8);			//YES
+   OmegaCuts->SetCutXiMinDistBachToPrimVtx(0.03);	//as ESD new vertexer cut
+   OmegaCuts->SetCutXiCPA(0.995);			//YES
+   OmegaCuts->SetCutXiTransverseRadius(0.4, 200);       //as ESD new vertexer cut
+   OmegaCuts->Setv0MassRange(1.116, 0.006);		//YES
+   OmegaCuts->SetCutv0MaxDaughterDCA(1.2);		//YES
+   OmegaCuts->SetCutv0CPA(0.99);			//YES
+   OmegaCuts->SetCutv0TransverseRadius(1., 200);       	//as ESD new vertexer cut
+   OmegaCuts->SetCutv0MinDistToPrimVtx(0.06);		//YES
+   OmegaCuts->SetCutv0MinDaugDistToPrimVtx(0.02);       //as ESD new vertexer cut
+   OmegaCuts->SetRejectMass(1.322, 0.013, 3312);	//YES...but should be changed to asymmetric from 1.322+0.013
+   OmegaCuts->SetPtRangeXi(0., 999.9);       		//as ESD new vertexer cut
+  }else if(CutFlag == 2){ // Cuts with TIME info for 3 tracks: proton and bachelor (its or tof time)
+                          // sigmas TPC 6 for proton, pion, and bachelor || SIX SIGMAS HERE!!!!
+   OmegaCuts->SetXiMassRange(1.672, 0.005);             //YES
+   OmegaCuts->SetCutXiDaughterDCA(.8);                  //YES
+   OmegaCuts->SetCutXiMinDistBachToPrimVtx(0.03);       //as ESD new vertexer cut
+   OmegaCuts->SetCutXiCPA(0.995);                       //YES
+   OmegaCuts->SetCutXiTransverseRadius(0.4, 200);       //as ESD new vertexer cut
+   OmegaCuts->Setv0MassRange(1.116, 0.006);             //YES
+   OmegaCuts->SetCutv0MaxDaughterDCA(1.2);              //YES
+   OmegaCuts->SetCutv0CPA(0.99);                        //YES
+   OmegaCuts->SetCutv0TransverseRadius(1., 200);       	//as ESD new vertexer cut
+   OmegaCuts->SetCutv0MinDistToPrimVtx(0.05);           //YES...but I think this ESD new vertexer cut
+   OmegaCuts->SetCutv0MinDaugDistToPrimVtx(0.02);       //as ESD new vertexer cut
+   OmegaCuts->SetRejectMass(1.322, 0.013, 3312);        //YES...but should be changed to asymmetric from 1.322+0.013
+   OmegaCuts->SetPtRangeXi(0., 999.9);                 	//as ESD new vertexer cut
+  }else{ // CutFlag == 0) // Bernie&Andi cuts
+   OmegaCuts->SetXiMassRange(1.672, 0.005);
+   OmegaCuts->SetCutXiDaughterDCA(2.);
+   OmegaCuts->SetCutXiMinDistBachToPrimVtx(0.04);
+   OmegaCuts->SetCutXiCPA(0.98);
+   OmegaCuts->SetCutXiTransverseRadius(0.5, 200);
+   OmegaCuts->Setv0MassRange(1.116, 0.006);
+   OmegaCuts->SetCutv0MaxDaughterDCA(1.5);
+   OmegaCuts->SetCutv0CPA(0.97);
+   OmegaCuts->SetCutv0TransverseRadius(1.1, 200);
+   OmegaCuts->SetCutv0MinDistToPrimVtx(0.06);
+   OmegaCuts->SetCutv0MinDaugDistToPrimVtx(0.04);
+   OmegaCuts->SetRejectMass(1.322, 0.005, 3312);
+   OmegaCuts->SetPtRangeXi(0.3, 999.9);
+  }
+  return OmegaCuts;
+}
+
+bool AliOtonOmegaCascadeCuts::isSelected(AliOtonOmegaCascade *casc) {
+  bool pass = true;
+  if (casc->IsSet()) {
+    if (!fMinimalBooking)
+      fHist->FillCutCounter(0);
+    if (fcutXiCharge) {
+      if (!(casc->GetCharge().at(0) == fXiCharge)) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(1);
+      }
+    }
+    if (pass) {
+      std::vector<int> IDTracks = casc->GetIDTracks();
+      if (IDTracks[0] == IDTracks[1]) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(2);
+      }
+      if (IDTracks[0] == IDTracks[2]) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(3);
+      }
+      if (IDTracks[1] == IDTracks[2]) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(4);
+      }
+    }
+    if (pass) {
+      if (!fNegCuts->isSelected(casc->GetNegDaug())) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(5);
+      }
+    }
+    if (pass) {
+      if (!fPosCuts->isSelected(casc->GetPosDaug())) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(6);
+      }
+    }
+    if (pass && fcutv0MaxDCADaug) {
+      if (casc->Getv0DCADaug() > fv0MaxDCADaug) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(7);
+      }
+    }
+    if (pass && fcutCPAv0) {
+      if (casc->Getv0CPA() < fCPAv0) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(8);
+      }
+    }
+    if (pass && fCutPtv0) {
+      if ((casc->Getv0Pt() < fPtMinv0) || (fPtMaxv0 < casc->Getv0Pt())) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(9);
+      }
+    }
+    if (pass && fcutv0TransRadius) {
+      if ((casc->Getv0TransverseRadius() < fMinv0TransRadius)
+          || (casc->Getv0TransverseRadius() > fMaxv0TransRadius)) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(10);
+      }
+    }
+    if (pass && fcutv0MinDistVtx) {
+      if (casc->Getv0DCAPrimVtx() < fv0MinDistVtx) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(11);
+      }
+    }
+    if (pass && fcutv0DaugMinDistVtx) {
+      if ((casc->Getv0PosToPrimVtx() < fv0DaugMinDistVtx)
+          || (casc->Getv0NegToPrimVtx() < fv0DaugMinDistVtx)) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(12);
+      }
+    }
+    if (pass) {
+      if (!fMinimalBooking)
+        fHist->FillInvMassPtv0(casc->GetPt(), casc->Getv0Mass());
+    }
+    if (pass && fcutv0Mass) {
+      if ((casc->Getv0Mass() < (fv0Mass - fv0Width))
+          || (casc->Getv0Mass() > (fv0Mass + fv0Width))) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(13);
+      }
+    }
+    if (pass) {
+      if (!fBachCuts->isSelected(casc->GetBach())) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(14);
+      }
+    }
+    if (pass && fcutDCAXiDaug) {
+      if (casc->GetXiDCADaug() > fMaxDCAXiDaug) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(15);
+      }
+    }
+    if (pass && fcutMinDistVtxBach) {
+      if (casc->BachDCAPrimVtx() < fMinDistVtxBach) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(16);
+      }
+    }
+    if (pass && fcutCPAXi) {
+      if (casc->GetCPA() < fCPAXi) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(17);
+      }
+    }
+    if (pass && fcutXiTransRadius) {
+      if ((casc->GetXiTransverseRadius() < fMinXiTransRadius)
+          || (casc->GetXiTransverseRadius() > fMaxXiTransRadius)) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(18);
+      }
+    }
+    if (pass && fRejMassCut) {
+      if ((casc->GetMass(fRejPDG) > (fRejMass - fRejWidth))
+          && (casc->GetMass(fRejPDG) < (fRejMass + fRejWidth))) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(19);
+      }
+    }
+    if (pass && fCutPt) {
+      if ((casc->GetPt() < fPtMin) || (fPtMax < casc->GetPt())) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(20);
+      }
+    }
+    if (pass) {
+      fHist->FillInvMassPt(casc->GetPt(), casc->GetMass(fPDGCasc));
+      if (fRunNumberQA) {
+        fHist->FillInvMassPerRunNumber(casc->GetEvtNumber(), casc->GetMass(fPDGCasc));
+      }
+    }
+    if (pass && fcutXiMass) {
+      if ((casc->GetMass(fPDGCasc) < (fXiMass - fXiMassWidth))
+          || (casc->GetMass(fPDGCasc) > (fXiMass + fXiMassWidth))) {
+        pass = false;
+      } else {
+        if (!fMinimalBooking)
+          fHist->FillCutCounter(21);
+      }
+    }
+    casc->SetUse(pass);
+    casc->GetNegDaug()->SetUse(pass);
+    casc->GetPosDaug()->SetUse(pass);
+    casc->GetBach()->SetUse(pass);
+    BookQA(casc);
+    if (!fMinimalBooking) {
+      if (fMCData) {
+        BookMCQA(casc);
+      }
+    }
+  } else {
+    pass = false;
+    if (!fMinimalBooking)
+      fHist->FillCutCounter(22);
+  }
+  return pass;
+}
+
+void AliOtonOmegaCascadeCuts::Init() {
+  fNegCuts->SetMinimalBooking(fMinimalBooking);
+  fNegCuts->Init();
+  fPosCuts->SetMinimalBooking(fMinimalBooking);
+  fPosCuts->Init();
+  fBachCuts->SetMinimalBooking(fMinimalBooking);
+  fBachCuts->Init();
+  if (!fMinimalBooking) {
+    fHist = new AliOtonOmegaCascadeHist(fXiMass, fRunNumberQA, fMinRunNumber,
+                                         fMaxRunNumber);
+    BookCuts();
+    if (!(fNegCuts || fPosCuts || fBachCuts)) {
+      AliFatal("Track Cuts Object Missing");
+    }
+    fHistList = new TList();
+    fHistList->SetOwner();
+    fHistList->SetName("CascadeCuts");
+    fHistList->Add(fHist->GetHistList());
+    fNegCuts->SetName("NegCuts");
+    fHistList->Add(fNegCuts->GetQAHists());
+    fPosCuts->SetName("PosCuts");
+    fHistList->Add(fPosCuts->GetQAHists());
+    fBachCuts->SetName("BachelorCuts");
+    fHistList->Add(fBachCuts->GetQAHists());
+
+    if (fMCData) {
+      fMCHist = new AliFemtoDreamv0MCHist(400, 1.0, 1.2, fContribSplitting,
+                                          false);
+      fMCHistList = new TList();
+      fMCHistList->SetOwner();
+      fMCHistList->SetName("CascadeMC");
+      fMCHistList->Add(fMCHist->GetHistList());
+
+      fNegCuts->SetMCName("NegCuts");
+      fMCHistList->Add(fNegCuts->GetMCQAHists());
+      fPosCuts->SetMCName("PosCuts");
+      fMCHistList->Add(fPosCuts->GetMCQAHists());
+      fBachCuts->SetMCName("BachCuts");
+      fMCHistList->Add(fBachCuts->GetMCQAHists());
+    }
+  } else {
+    fHist = new AliOtonOmegaCascadeHist("MinimalBooking", fXiMass);
+    fHistList = new TList();
+    fHistList->SetOwner();
+    fHistList->SetName("CascadeCuts");
+    fHistList->Add(fHist->GetHistList());
+    fNegCuts->SetName("NegCuts");
+    fHistList->Add(fNegCuts->GetQAHists());
+    fPosCuts->SetName("PosCuts");
+    fHistList->Add(fPosCuts->GetQAHists());
+    fBachCuts->SetName("BachelorCuts");
+    fHistList->Add(fBachCuts->GetQAHists());
+  }
+}
+
+void AliOtonOmegaCascadeCuts::BookQA(AliOtonOmegaCascade *casc) {
+  if (!fMinimalBooking) {
+    for (int i = 0; i < 2; ++i) {
+      if (i == 0 || (i == 1 && casc->UseParticle())) {
+        fHist->FillInvMass(i, casc->GetMass(fPDGCasc));
+        fHist->FillInvMassLambda(i, casc->Getv0Mass());
+        fHist->FillXiPt(i, casc->GetMomentum().Pt());
+        fHist->FillMomRapXi(i, casc->GetXiRapidity(),
+                            casc->GetMomentum().Mag());
+        fHist->FillMomRapOmega(i, casc->GetOmegaRapidity(),
+                               casc->GetMomentum().Mag());
+        fHist->FillDCAXiPrimVtx(i, casc->GetDCAXiPrimVtx());
+        fHist->FillDCAXiDaug(i, casc->GetXiDCADaug());
+        fHist->FillMinDistPrimVtxBach(i, casc->BachDCAPrimVtx());
+        fHist->FillCPAXi(i, casc->GetCPA());
+        fHist->FillDecayLength(i, casc->GetDecayLength());
+        fHist->Fillv0DecayLength(i, casc->Getv0DecayLength());
+        fHist->FillTransverseRadiusXi(i, casc->GetXiTransverseRadius());
+        fHist->FillMaxDCAv0Daug(i, casc->Getv0DCADaug());
+        fHist->FillCPAv0(i, casc->Getv0CPA());
+        fHist->FillCPAv0Xi(i, casc->Getv0XiPointingAngle());
+        fHist->Fillv0Pt(i, casc->Getv0Pt());
+        fHist->FillTransverseRadiusv0(i, casc->Getv0TransverseRadius());
+        fHist->FillMinDistPrimVtxv0(i, casc->Getv0DCAPrimVtx());
+        fHist->FillMinDistPrimVtxv0DaugPos(i, casc->Getv0PosToPrimVtx());
+        fHist->FillMinDistPrimVtxv0DaugNeg(i, casc->Getv0NegToPrimVtx());
+        fHist->FillPodolandski(i, casc->GetXiAlpha(), casc->GetPtArmXi());
+      }
+    }
+  }
+  if (casc->GetNegDaug()->IsSet())
+    fNegCuts->BookQA(casc->GetNegDaug());
+  if (casc->GetPosDaug()->IsSet())
+    fPosCuts->BookQA(casc->GetPosDaug());
+  if (casc->GetBach()->IsSet())
+    fBachCuts->BookQA(casc->GetBach());
+  return;
+}
+
+void AliOtonOmegaCascadeCuts::BookMCQA(AliOtonOmegaCascade *casc) {
+  if (!fMinimalBooking) {
+    float pT = casc->GetPt();
+    //  if (casc->GetHasDaughters()) {
+    //    float etaNegDaug=casc->GetEta().at(1);
+    //    float etaPosDaug=casc->GetEta().at(2);
+    //    if (casc->GetMCPDGCode()==fPDGv0) {
+    //      if (fpTmin<pT&&pT<fpTmax) {
+    //        if (fPosCuts->GetEtaMin()<etaPosDaug&&etaPosDaug<fPosCuts->GetEtaMax()) {
+    //          if (fNegCuts->GetEtaMin()<etaNegDaug&&etaNegDaug<fNegCuts->GetEtaMax()) {
+    //            fMCHist->FillMCGen(pT);
+    //          }
+    //        }
+    //      }
+    //    }
+    //  }
+    if (casc->UseParticle()) {
+      fMCHist->FillMCIdent(pT);
+      fMCHist->FillMCIdent(pT);
+      AliFemtoDreamBasePart::PartOrigin tmpOrg = casc->GetParticleOrigin();
+      if (casc->GetParticleOrigin() != AliFemtoDreamBasePart::kFake) {
+        if (casc->GetMCPDGCode() == fPDGCasc) {
+          if (tmpOrg == AliFemtoDreamBasePart::kPhysPrimary) {
+            fMCHist->FillMCCorr(pT);
+            fMCHist->FillMCPtResolution(casc->GetMCPt(), casc->GetPt());
+            fMCHist->FillMCThetaResolution(casc->GetMCTheta().at(0),
+                                           casc->GetTheta().at(0),
+                                           casc->GetMCPt());
+            fMCHist->FillMCPhiResolution(casc->GetMCPhi().at(0),
+                                         casc->GetPhi().at(0), casc->GetMCPt());
+          }
+        } else {
+          casc->SetParticleOrigin(AliFemtoDreamBasePart::kContamination);
+        }
+      }
+      if (fContribSplitting) {
+        FillMCContributions(casc);
+      }
+      casc->GetPosDaug()->SetParticleOrigin(casc->GetParticleOrigin());
+      casc->GetNegDaug()->SetParticleOrigin(casc->GetParticleOrigin());
+      casc->GetBach()->SetParticleOrigin(casc->GetParticleOrigin());
+      fPosCuts->BookMC(casc->GetPosDaug());
+      fNegCuts->BookMC(casc->GetNegDaug());
+      fBachCuts->BookMC(casc->GetBach());
+      casc->SetParticleOrigin(tmpOrg);
+    }
+  }
+  return;
+}
+
+void AliOtonOmegaCascadeCuts::FillMCContributions(AliOtonOmegaCascade *casc) {
+  if (!fMinimalBooking) {
+    Double_t pT = casc->GetPt();
+    Int_t iFill = -1;
+    switch (casc->GetParticleOrigin()) {
+      case AliFemtoDreamBasePart::kPhysPrimary:
+        fMCHist->FillMCPrimary(pT);
+        iFill = 0;
+        break;
+      case AliFemtoDreamBasePart::kWeak:
+        fMCHist->FillMCFeeddown(pT, TMath::Abs(casc->GetMotherWeak()));
+        iFill = 1;
+        break;
+      case AliFemtoDreamBasePart::kMaterial:
+        fMCHist->FillMCMaterial(pT);
+        iFill = 2;
+        break;
+      case AliFemtoDreamBasePart::kContamination:
+        fMCHist->FillMCCont(pT);
+        iFill = 3;
+        break;
+      case AliFemtoDreamBasePart::kFake:
+        fMCHist->FillMCCont(pT);
+        iFill = 4;
+        break;
+      default:
+        AliFatal("Type Not implemented");
+        break;
+    }
+    if (iFill != -1) {
+      fMCHist->FillMCpT(iFill, pT);
+      fMCHist->FillMCEta(iFill, casc->GetEta().at(0));
+      fMCHist->FillMCPhi(iFill, casc->GetPhi().at(0));
+      fMCHist->FillMCPodolanski(iFill, casc->GetPtArmXi(), casc->GetXiAlpha());
+      fMCHist->FillMCCosPoint(iFill, pT, casc->GetCPA());
+      fMCHist->FillMCBachDCAToPV(iFill, pT, casc->BachDCAPrimVtx());
+      fMCHist->FillMCv0DecayLength(iFill, pT, casc->Getv0DecayLength());
+      fMCHist->FillMCv0CPA(iFill, pT, casc->Getv0CPA());
+      fMCHist->FillMCDecayLength(iFill, pT, casc->GetDecayLength());
+      fMCHist->FillMCXiRapidity(iFill, casc->GetMomentum().Mag(),
+                                casc->GetXiRapidity());
+      fMCHist->FillMCOmegaRapidity(iFill, casc->GetMomentum().Mag(),
+                                   casc->GetOmegaRapidity());
+      fMCHist->FillMCTransverseRadius(iFill, pT, casc->GetXiTransverseRadius());
+      fMCHist->FillMCDCAPosDaugPrimVtx(iFill, pT, casc->Getv0PosToPrimVtx());
+      fMCHist->FillMCDCANegDaugPrimVtx(iFill, pT, casc->Getv0NegToPrimVtx());
+      fMCHist->FillMCDCADaugVtx(iFill, pT, casc->GetXiDCADaug());
+      fMCHist->FillMCInvMass(iFill, casc->Getv0Mass());
+      fMCHist->FillMCXiInvMass(iFill, pT, casc->GetXiMass());
+      fMCHist->FillMCOmegaInvMass(iFill, pT, casc->GetOmegaMass());
+
+    } else {
+      std::cout << "this should not happen \n";
+    }
+  }
+}
+
+void AliOtonOmegaCascadeCuts::BookCuts() {
+  if (fCutPt) {
+    fHist->FillConfig(0, fPtMin);
+    fHist->FillConfig(1, fPtMax);
+  }
+  if (fCutPtv0) {
+    fHist->FillConfig(2, fPtMinv0);
+    fHist->FillConfig(3, fPtMaxv0);
+  }
+  if (fcutXiMass) {
+    fHist->FillConfig(4, fXiMass);
+    fHist->FillConfig(5, fXiMassWidth);
+  }
+  if (fcutXiCharge) {
+    fHist->FillConfig(6, fXiCharge);
+  }
+  if (fcutDCAXiDaug) {
+    fHist->FillConfig(7, fMaxDCAXiDaug);
+  }
+  if (fcutMinDistVtxBach) {
+    fHist->FillConfig(8, fMinDistVtxBach);
+  }
+  if (fcutCPAXi) {
+    fHist->FillConfig(9, fCPAXi);
+  }
+  if (fcutXiTransRadius) {
+    fHist->FillConfig(10, fMinXiTransRadius);
+    fHist->FillConfig(11, fMaxXiTransRadius);
+  }
+  if (fcutv0Mass) {
+    fHist->FillConfig(12, fv0Mass);
+    fHist->FillConfig(13, fv0Width);
+  }
+  if (fcutv0MaxDCADaug) {
+    fHist->FillConfig(14, fv0MaxDCADaug);
+  }
+  if (fcutCPAv0) {
+    fHist->FillConfig(15, fCPAv0);
+  }
+  if (fcutv0TransRadius) {
+    fHist->FillConfig(16, fMinv0TransRadius);
+    fHist->FillConfig(17, fMaxv0TransRadius);
+  }
+  if (fcutv0MinDistVtx) {
+    fHist->FillConfig(18, fv0MinDistVtx);
+  }
+  if (fcutv0DaugMinDistVtx) {
+    fHist->FillConfig(19, fv0DaugMinDistVtx);
+  }
+  if (fRejMassCut) {
+    fHist->FillConfig(20, fRejMass);
+    fHist->FillConfig(21, fRejWidth);
+  }
+}
+

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliOtonOmegaCascadeCuts.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliOtonOmegaCascadeCuts.h
@@ -11,7 +11,7 @@
 #include "TList.h"
 #include "AliMCEvent.h"
 #include "AliOtonOmegaCascade.h"
-#include "AliOtonOmegaCascadeHist.h"
+#include "AliFemtoDreamCascadeHist.h"
 #include "AliFemtoDreamv0MCHist.h"
 #include "AliFemtoDreamTrackCuts.h"
 class AliOtonOmegaCascadeCuts {
@@ -206,7 +206,7 @@ class AliOtonOmegaCascadeCuts {
   }
   ;
  private:
-  AliOtonOmegaCascadeHist *fHist;            //!
+  AliFemtoDreamCascadeHist *fHist;            //!
   AliFemtoDreamv0MCHist *fMCHist;             //!
   AliFemtoDreamTrackCuts *fNegCuts;   //
   AliFemtoDreamTrackCuts *fPosCuts;   //

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliOtonOmegaCascadeCuts.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliOtonOmegaCascadeCuts.h
@@ -1,0 +1,269 @@
+/*
+ * AliOtonOmegaCascadeCuts.h
+ *
+ *  Created on: Jan 11, 2018
+ *      Author: gu74req
+ */
+
+#ifndef ALIOTONOMEGACASCADECUTS_H_
+#define ALIOTONOMEGACASCADECUTS_H_
+#include "Rtypes.h"
+#include "TList.h"
+#include "AliMCEvent.h"
+#include "AliOtonOmegaCascade.h"
+#include "AliOtonOmegaCascadeHist.h"
+#include "AliFemtoDreamv0MCHist.h"
+#include "AliFemtoDreamTrackCuts.h"
+class AliOtonOmegaCascadeCuts {
+ public:
+  AliOtonOmegaCascadeCuts();
+  AliOtonOmegaCascadeCuts(const AliOtonOmegaCascadeCuts& cuts);
+  AliOtonOmegaCascadeCuts &operator=(const AliOtonOmegaCascadeCuts& cuts);
+  virtual ~AliOtonOmegaCascadeCuts();
+  static AliOtonOmegaCascadeCuts *XiCuts(bool isMC, bool contribSplitting, Int_t CutFlag = 0);
+  static AliOtonOmegaCascadeCuts *OmegaCuts(bool isMC, bool contribSplitting, Int_t CutFlag = 0);
+  void SetMinimalBooking(bool doIt) {
+    fMinimalBooking = doIt;
+  }
+  ;
+  bool GetMinimalBooking() {
+    return fMinimalBooking;
+  }
+  ;
+  void Setv0Negcuts(AliFemtoDreamTrackCuts *cuts) {
+    fNegCuts = cuts;
+  }
+  ;
+  void Setv0PosCuts(AliFemtoDreamTrackCuts *cuts) {
+    fPosCuts = cuts;
+  }
+  ;
+  void SetBachCuts(AliFemtoDreamTrackCuts *cuts) {
+    fBachCuts = cuts;
+  }
+  ;
+  void SetIsMonteCarlo(bool isMC) {
+    fMCData = isMC;
+  }
+  ;
+  bool GetIsMonteCarlo() {
+    return fMCData;
+  }
+  ;
+  void SetContributionSplitting(bool contrSplit) {
+    fContribSplitting = contrSplit;
+  }
+  ;
+  void SetRunNumberQA(int iMinRun, int iMaxRun) {
+    fRunNumberQA = true;
+    fMinRunNumber = iMinRun;
+    fMaxRunNumber = iMaxRun;
+  }
+  void SetXiMassRange(float mass, float width) {
+    fcutXiMass = true;
+    fXiMass = mass;
+    fXiMassWidth = width;
+  }
+  ;
+  void SetXiCharge(int charge) {
+    fcutXiCharge = true;
+    fXiCharge = charge;
+  }
+  void SetCutXiDaughterDCA(float maxDCA) {
+    fcutDCAXiDaug = true;
+    fMaxDCAXiDaug = maxDCA;
+  }
+  ;
+  void SetCutXiMinDistBachToPrimVtx(float minDist) {
+    fcutMinDistVtxBach = true;
+    fMinDistVtxBach = minDist;
+  }
+  ;
+  void SetCutXiCPA(float cpa) {
+    fcutCPAXi = true;
+    fCPAXi = cpa;
+  }
+  ;
+  void SetCutXiTransverseRadius(float minRad, float maxRad) {
+    fcutXiTransRadius = true;
+    fMinXiTransRadius = minRad;
+    fMaxXiTransRadius = maxRad;
+  }
+  void Setv0MassRange(float mass, float width) {
+    fcutv0Mass = true;
+    fv0Mass = mass;
+    fv0Width = width;
+  }
+  void SetCutv0MaxDaughterDCA(float maxDCA) {
+    fcutv0MaxDCADaug = true;
+    fv0MaxDCADaug = maxDCA;
+  }
+  void SetCutv0CPA(float CPA) {
+    fcutCPAv0 = true;
+    fCPAv0 = CPA;
+  }
+  void SetCutv0TransverseRadius(float minRad, float maxRad) {
+    fcutv0TransRadius = true;
+    fMinv0TransRadius = minRad;
+    fMaxv0TransRadius = maxRad;
+  }
+  void SetCutv0MinDistToPrimVtx(float minDist) {
+    fcutv0MinDistVtx = true;
+    fv0MinDistVtx = minDist;
+  }
+  void SetCutv0MinDaugDistToPrimVtx(float minDist) {
+    fcutv0DaugMinDistVtx = true;
+    fv0DaugMinDistVtx = minDist;
+  }
+  ;
+  void SetRejectMass(float mass, float width, int PDGCode) {
+    fRejMassCut = true;
+    fRejPDG = PDGCode;
+    fRejMass = mass;
+    fRejWidth = width;
+  }
+  void SetPtRangeXi(float PtMin, float PtMax) {
+    fPtMin = PtMin;
+    fPtMax = PtMax;
+    fCutPt = true;
+  }
+  void SetPtRangev0(float PtMin, float PtMax) {
+    fPtMinv0 = PtMin;
+    fPtMaxv0 = PtMax;
+    fCutPtv0 = true;
+  }
+  void SetPDGCodeCasc(int PDG) {
+    fPDGCasc = PDG;
+  }
+  ;
+  int GetPDGCodeCasc() {
+    return fPDGCasc;
+  }
+  ;
+  void SetPDGCodePosDaug(int PDG) {
+    fPDGPosDaug = PDG;
+  }
+  ;
+  int GetPDGCodePosDaug() {
+    return fPDGPosDaug;
+  }
+  ;
+  void SetPDGCodeNegDaug(int PDG) {
+    fPDGNegDaug = PDG;
+  }
+  ;
+  int GetPDGCodeNegDaug() {
+    return fPDGNegDaug;
+  }
+  ;
+  void SetPDGCodeBach(int PDG) {
+    fPDGBachDaug = PDG;
+  }
+  ;
+  int GetPDGCodeBach() {
+    return fPDGBachDaug;
+  }
+  ;
+  void SetPDGCodev0(int PDG) {
+    fPDGv0 = PDG;
+  }
+  ;
+  int GetPDGv0() {
+    return fPDGv0;
+  }
+  ;
+  TString ClassName() const {
+    return "AliOtonOmegaCascadeCuts";
+  }
+  ;
+  void Init();
+  bool isSelected(AliOtonOmegaCascade *casc);
+  void BookQA(AliOtonOmegaCascade *casc);
+  void BookCuts();
+  void BookMCQA(AliOtonOmegaCascade *casc);
+  void FillMCContributions(AliOtonOmegaCascade *casc);
+  void SetName(TString OutputName) {
+    if (fHistList)
+      fHistList->SetName(OutputName.Data());
+  }
+  ;
+  void SetMCName(TString OutputName) {
+    if (fMCHistList)
+      fMCHistList->SetName(OutputName.Data());
+  }
+  ;
+  TList *GetQAHists() {
+    return fHistList;
+  }
+  ;
+  TList *GetMCQAHists() {
+    return fMCHistList;
+  }
+  ;
+  void FillGenerated(float pT) {
+    if (fMCHist)
+      fMCHist->FillMCGen(pT);
+  }
+  ;
+ private:
+  AliOtonOmegaCascadeHist *fHist;            //!
+  AliFemtoDreamv0MCHist *fMCHist;             //!
+  AliFemtoDreamTrackCuts *fNegCuts;   //
+  AliFemtoDreamTrackCuts *fPosCuts;   //
+  AliFemtoDreamTrackCuts *fBachCuts;  //
+  TList *fHistList;  //!
+  TList *fMCHistList;                 //!
+  bool fMinimalBooking;               //
+  bool fMCData;                       //
+  bool fContribSplitting;             //
+  Int_t fCutFlag;             //
+  bool fRunNumberQA;                  //
+  int fMinRunNumber;                  //
+  int fMaxRunNumber;                  //
+  bool fCutPt;                        //
+  double fPtMin;                  //
+  double fPtMax;          //
+  bool fCutPtv0;          //
+  double fPtMinv0;  //
+  double fPtMaxv0;    //
+  bool fcutXiMass;    //
+  float fXiMass;    //
+  float fXiMassWidth;  //
+  bool fcutXiCharge;  //
+  int fXiCharge;  //
+  bool fcutDCAXiDaug;  //
+  float fMaxDCAXiDaug;  //
+  bool fcutMinDistVtxBach;  //
+  float fMinDistVtxBach;    //
+  bool fcutCPAXi;     //
+  float fCPAXi;   //
+  bool fcutXiTransRadius;  //
+  float fMinXiTransRadius;  //
+  float fMaxXiTransRadius;  //
+  bool fcutv0Mass;  //
+  float fv0Mass;    //
+  float fv0Width;   //
+  bool fcutv0MaxDCADaug;  //
+  float fv0MaxDCADaug;    //
+  bool fcutCPAv0;     //
+  float fCPAv0;       //
+  bool fcutv0TransRadius;       //
+  float fMinv0TransRadius;      //
+  float fMaxv0TransRadius;      //
+  bool fcutv0MinDistVtx;        //
+  float fv0MinDistVtx;          //
+  bool fcutv0DaugMinDistVtx;    //
+  float fv0DaugMinDistVtx;      //
+  bool  fRejMassCut;               //
+  float fRejPDG;          //
+  float fRejMass;          //
+  float fRejWidth;         //
+  int fPDGCasc;                 //
+  int fPDGv0;                   //
+  int fPDGPosDaug;              //
+  int fPDGNegDaug;              //
+  int fPDGBachDaug;             //
+ClassDef(AliOtonOmegaCascadeCuts,3)
+};
+
+#endif /* ALIOTONOMEGACASCADECUTS_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/CMakeLists.txt
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/CMakeLists.txt
@@ -58,6 +58,10 @@ set(SRCS
   AliAnalysisTaskFemtoDream.cxx
   AliAnalysisTaskSigma0Femto.cxx
   AliAnalysisTaskGrandma.cxx
+  AliAnalysisTaskOtonOmega.cxx
+  AliOtonOmegaAnalysis.cxx
+  AliOtonOmegaCascadeCuts.cxx
+  AliOtonOmegaCascade.cxx
   )
 
 

--- a/PWGCF/FEMTOSCOPY/FemtoDream/PWGCFFemtoDreamLinkDef.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/PWGCFFemtoDreamLinkDef.h
@@ -31,6 +31,10 @@
 #pragma link C++ class AliAnalysisTaskFemtoDream+;
 #pragma link C++ class AliAnalysisTaskSigma0Femto+;
 #pragma link C++ class AliAnalysisTaskGrandma+;
+#pragma link C++ class AliAnalysisTaskOtonOmega+;
+#pragma link C++ class AliOtonOmegaAnalysis+;
+#pragma link C++ class AliOtonOmegaCascadeCuts+;
+#pragma link C++ class AliOtonOmegaCascade+;
 
 #endif
 

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskOtonOmega.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskOtonOmega.C
@@ -1,0 +1,789 @@
+#include "TROOT.h"
+#include "TSystem.h"
+AliAnalysisTaskSE* AddTaskOtonOmega(bool isMC = false,     
+                                     bool isESD = false,
+                                     TString CentEst = "kInt7",
+                                     bool CascadeTreeFlag = false,
+                                     bool OmegaTreeFlag = true,
+                                     Int_t CutFlag = 0,
+                                     bool GetConfigFromAlien = true,
+                                     TString cFileName = "ConfigOtonOmega.C")
+{
+
+
+//Start with fixed definitions from AddTaskFemtoDream:
+bool notpp = true;  //1
+bool fineBinning = true;  //2
+bool DCAPlots = false;  //3
+bool CPAPlots = false;  //4
+bool MomReso = false;  //5
+bool etaPhiPlotsAtTPCRadii = false;  //6
+bool CombSigma = false;  //7
+bool PileUpRej = true;  //8
+bool mTkTPlot = true;  //9
+bool kTCentPlot = false;  //10
+bool MultvsCentPlot = false;  //11
+bool dPhidEtaPlots = false;  //12
+bool eventMixing = true;  //13
+bool phiSpin = true;  //14
+bool stravinskyPhiSpin = true;  //15
+bool ContributionSplitting = false;  //16
+bool ContributionSplittingDaug = false;  //17
+bool RunNumberQA = false;  //18
+int FilterBit = 128;  //19
+bool InvMassPairs = false;  //20
+bool DeltaEtaDeltaPhiCut = false;  //21
+int SphericityRange = 0;  //22
+
+
+
+    //Get Config File:
+    TString configBasePath= "$ALICE_PHYSICS/PWGCF/FEMTOSCOPY/macros/";
+    if(GetConfigFromAlien && (!gSystem->Exec(Form("alien_cp alien:///alice/cern.ch/user/o/ovazquez/%s .",cFileName.Data()))) ){
+        configBasePath=Form("%s/",gSystem->pwd());
+    } else {
+        cFileName = "ConfigOtonOmega.C"; //if not getting it from alien, take the standard one
+    }
+    TString configFilePath(configBasePath+cFileName);
+    std::cout << "Configpath: " << configFilePath << std::endl;
+    TString configFunction(cFileName(0,cFileName.Length() - 2));
+    if (!gROOT->GetListOfGlobalFunctions()->FindObject(configFunction.Data())) gROOT->LoadMacro(configFilePath.Data());
+
+
+
+
+
+  // 1    2     3     4     5     6     7    8    9      10   11     12   13    14    15    16   17
+  //true,true,false,false,false,false,false,true,false,false,true,false,true,false,false,false,true
+  // the manager is static, so get the existing manager via the static method
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+
+  if (!mgr) {
+    printf("No analysis manager to connect to!\n");
+    return nullptr;
+  }
+  // just to see if all went well, check if the input event handler has been
+  // connected
+  if (!mgr->GetInputEventHandler()) {
+    printf("This task requires an input event handler!\n");
+    return nullptr;
+  }
+
+  if (!(AliPIDResponse*) mgr->GetTask("PIDResponseTask")) {
+    if (isMC) {
+      // IMPORTANT - SET WHEN USING DIFFERENT PASS
+      AliAnalysisTaskPIDResponse *pidResponse =
+          reinterpret_cast<AliAnalysisTaskPIDResponse *>(
+          */gInterpreter->ExecuteMacro("$ALICE_ROOT/ANALYSIS/macros/"
+                                     "AddTaskPIDResponse.C (kTRUE, kTRUE, "
+                                     "kTRUE, \"1\")"));
+    } else {
+      AliAnalysisTaskPIDResponse *pidResponse =
+          reinterpret_cast<AliAnalysisTaskPIDResponse *>(
+          gInterpreter->ExecuteMacro(
+              "$ALICE_ROOT/ANALYSIS/macros/AddTaskPIDResponse.C)"));
+    }
+  }
+
+  AliFemtoDreamEventCuts *evtCuts = AliFemtoDreamEventCuts::StandardCutsRun2();
+  evtCuts->CleanUpMult(false, false, false, true);
+  evtCuts->SetMultVsCentPlots(MultvsCentPlot);
+  if (SphericityRange != 0) {
+    if (SphericityRange == 1) {
+      evtCuts->SetSphericityCuts(0., 0.3);
+    } else if (SphericityRange == 2) {
+      evtCuts->SetSphericityCuts(0.3, 0.7);
+    } else if (SphericityRange == 3) {
+      evtCuts->SetSphericityCuts(0.7, 1.0);
+    } else if (SphericityRange == 4) {
+      evtCuts->SetSphericityCuts(0.7, 0.8);
+    } else if (SphericityRange == 5) {
+      evtCuts->SetSphericityCuts(0.8, 0.9);
+    } else if (SphericityRange == 6) {
+      evtCuts->SetSphericityCuts(0.9, 1.0);
+    } else {
+      std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";
+      std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";
+      std::cout << "Warning: Unkown Sphericity Type\n";
+      std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";
+      std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";
+
+    }
+  }
+  //Track Cuts
+  AliFemtoDreamTrackCuts *TrackCuts = AliFemtoDreamTrackCuts::PrimProtonCuts(
+      isMC, DCAPlots, CombSigma, ContributionSplitting);
+  if (isESD) {
+    TrackCuts->SetCheckFilterBit(false);
+    TrackCuts->SetCheckESDFiltering(true);
+    TrackCuts->SetDCAReCalculation(false);
+  } else {
+    TrackCuts->SetFilterBit(FilterBit);
+  }
+  TrackCuts->SetCutCharge(1);
+  AliFemtoDreamTrackCuts *AntiTrackCuts =
+      AliFemtoDreamTrackCuts::PrimProtonCuts(isMC, DCAPlots, CombSigma,
+                                             ContributionSplitting);
+  if (isESD) {
+    AntiTrackCuts->SetCheckFilterBit(false);
+    AntiTrackCuts->SetCheckESDFiltering(true);
+    AntiTrackCuts->SetDCAReCalculation(false);
+  } else {
+    AntiTrackCuts->SetFilterBit(FilterBit);
+  }
+  AntiTrackCuts->SetCutCharge(-1);
+//  AliFemtoDreamv0Cuts *v0Cuts;
+//  AliFemtoDreamv0Cuts *Antiv0Cuts;
+  AliOtonOmegaCascadeCuts *AntiCascadeCuts;
+  AliOtonOmegaCascadeCuts *CascadeOmegaCuts;
+  AliOtonOmegaCascadeCuts *AntiCascadeOmegaCuts;
+
+//skip lambda
+/*
+  //Lambda Cuts
+  v0Cuts = AliFemtoDreamv0Cuts::LambdaCuts(isMC, CPAPlots,
+                                           ContributionSplitting);
+  AliFemtoDreamTrackCuts *Posv0Daug = AliFemtoDreamTrackCuts::DecayProtonCuts(
+      isMC, PileUpRej, false);
+  AliFemtoDreamTrackCuts *Negv0Daug = AliFemtoDreamTrackCuts::DecayPionCuts(
+      isMC, PileUpRej, false);
+  v0Cuts->SetPosDaugterTrackCuts(Posv0Daug);
+  v0Cuts->SetNegDaugterTrackCuts(Negv0Daug);
+  v0Cuts->SetPDGCodePosDaug(2212);  //Proton
+  v0Cuts->SetPDGCodeNegDaug(211);  //Pion
+  v0Cuts->SetPDGCodev0(3122);  //Lambda
+  Antiv0Cuts = AliFemtoDreamv0Cuts::LambdaCuts(isMC, CPAPlots,
+                                               ContributionSplitting);
+  AliFemtoDreamTrackCuts *PosAntiv0Daug = AliFemtoDreamTrackCuts::DecayPionCuts(
+      isMC, PileUpRej, false);
+  PosAntiv0Daug->SetCutCharge(1);
+  AliFemtoDreamTrackCuts *NegAntiv0Daug =
+      AliFemtoDreamTrackCuts::DecayProtonCuts(isMC, PileUpRej, false);
+  NegAntiv0Daug->SetCutCharge(-1);
+  Antiv0Cuts->SetPosDaugterTrackCuts(PosAntiv0Daug);
+  Antiv0Cuts->SetNegDaugterTrackCuts(NegAntiv0Daug);
+  Antiv0Cuts->SetPDGCodePosDaug(211);  //Pion
+  Antiv0Cuts->SetPDGCodeNegDaug(2212);  //Proton
+  Antiv0Cuts->SetPDGCodev0(-3122);  //Lambda
+*/
+
+
+  AliOtonOmegaCascadeCuts *CascadeCuts;
+
+  //CUT TYPE = 0  // MB and pPb cuts
+  CascadeCuts = AliOtonOmegaCascadeCuts::XiCuts(isMC, ContributionSplitting, CutFlag);
+  CascadeCuts->SetXiCharge(-1);
+  //pdg codes:
+  CascadeCuts->SetPDGCodeCasc(3312);
+  CascadeCuts->SetPDGCodev0(3122);
+  CascadeCuts->SetPDGCodePosDaug(2212);
+  CascadeCuts->SetPDGCodeNegDaug(-211);
+  CascadeCuts->SetPDGCodeBach(-211);
+  CascadeCuts->SetRunNumberQA(265309, 267167);
+  //proton track cuts
+  AliFemtoDreamTrackCuts *XiPosCuts = AliFemtoDreamTrackCuts::Xiv0ProtonCuts(isMC, PileUpRej, false);
+  //pion track cuts
+  AliFemtoDreamTrackCuts *XiNegCuts = AliFemtoDreamTrackCuts::Xiv0PionCuts(isMC, PileUpRej, false);
+  //bachelor pion cuts
+  AliFemtoDreamTrackCuts *XiBachCuts = AliFemtoDreamTrackCuts::XiBachPionCuts(isMC, PileUpRej, false);
+
+  AntiCascadeCuts = AliOtonOmegaCascadeCuts::XiCuts( isMC, ContributionSplitting, CutFlag);
+  AntiCascadeCuts->SetXiCharge(1);
+  AliFemtoDreamTrackCuts *AntiXiNegCuts = AliFemtoDreamTrackCuts::Xiv0ProtonCuts(isMC, PileUpRej, false);
+  AntiXiNegCuts->SetCutCharge(-1);
+  AliFemtoDreamTrackCuts *AntiXiPosCuts = AliFemtoDreamTrackCuts::Xiv0PionCuts(isMC, PileUpRej, false);
+  AntiXiPosCuts->SetCutCharge(1);
+  AliFemtoDreamTrackCuts *AntiXiBachCuts = AliFemtoDreamTrackCuts::XiBachPionCuts(isMC, PileUpRej, false);
+  AntiXiBachCuts->SetCutCharge(1);
+  AntiCascadeCuts->SetPDGCodeCasc(-3312);
+  AntiCascadeCuts->SetPDGCodev0(-3122);
+  AntiCascadeCuts->SetPDGCodePosDaug(211);
+  AntiCascadeCuts->SetPDGCodeNegDaug(-2212);
+  AntiCascadeCuts->SetPDGCodeBach(-211);
+  if(RunNumberQA) AntiCascadeCuts->SetRunNumberQA(265309, 267167);
+
+  CascadeOmegaCuts = AliOtonOmegaCascadeCuts::OmegaCuts(isMC,ContributionSplitting, CutFlag);
+  CascadeOmegaCuts->SetXiCharge(-1);
+  AliFemtoDreamTrackCuts *OmegaNegCuts = AliFemtoDreamTrackCuts::Xiv0PionCuts(isMC,PileUpRej,false);
+  AliFemtoDreamTrackCuts *OmegaPosCuts = AliFemtoDreamTrackCuts::Xiv0ProtonCuts(isMC,PileUpRej,false);
+  AliFemtoDreamTrackCuts *OmegaBachCuts = AliFemtoDreamTrackCuts::OmegaBachKaonCuts(isMC,PileUpRej,false);
+  CascadeOmegaCuts->SetPDGCodeCasc(3334);
+  CascadeOmegaCuts->SetPDGCodev0(3122);
+  CascadeOmegaCuts->SetPDGCodePosDaug(2212);
+  CascadeOmegaCuts->SetPDGCodeNegDaug(-211);
+  CascadeOmegaCuts->SetPDGCodeBach(-321);
+  if(RunNumberQA) CascadeOmegaCuts->SetRunNumberQA(265309, 267167);
+
+  AntiCascadeOmegaCuts = AliOtonOmegaCascadeCuts::OmegaCuts(isMC,ContributionSplitting, CutFlag);
+  AntiCascadeOmegaCuts->SetXiCharge(1);
+  AliFemtoDreamTrackCuts *AntiOmegaNegCuts = AliFemtoDreamTrackCuts::Xiv0ProtonCuts(isMC,PileUpRej,false);
+  AntiOmegaNegCuts->SetCutCharge(-1);
+  AliFemtoDreamTrackCuts *AntiOmegaPosCuts = AliFemtoDreamTrackCuts::Xiv0PionCuts(isMC,PileUpRej,false);
+  AntiOmegaPosCuts->SetCutCharge(1);
+  AliFemtoDreamTrackCuts *AntiOmegaBachCuts = AliFemtoDreamTrackCuts::OmegaBachKaonCuts(isMC,PileUpRej,false);
+  AntiOmegaBachCuts->SetCutCharge(1);
+  AntiCascadeOmegaCuts->SetPDGCodeCasc(-3334);
+  AntiCascadeOmegaCuts->SetPDGCodev0(-3122);
+  AntiCascadeOmegaCuts->SetPDGCodePosDaug(211);
+  AntiCascadeOmegaCuts->SetPDGCodeNegDaug(-2212);
+  if(RunNumberQA) AntiCascadeOmegaCuts->SetPDGCodeBach(-321);
+
+  //Pass to config file
+  ConfigOtonOmega(CascadeCuts,XiPosCuts,XiNegCuts,XiBachCuts,AntiCascadeCuts,AntiXiPosCuts,AntiXiNegCuts,AntiXiBachCuts,CascadeOmegaCuts,OmegaPosCuts,OmegaNegCuts,OmegaBachCuts,AntiCascadeOmegaCuts,AntiOmegaPosCuts,AntiOmegaNegCuts,AntiOmegaBachCuts);
+  CascadeCuts->SetBachCuts(XiBachCuts);
+  CascadeCuts->Setv0Negcuts(XiNegCuts);
+  CascadeCuts->Setv0PosCuts(XiPosCuts);
+  AntiCascadeCuts->Setv0Negcuts(AntiXiNegCuts);
+  AntiCascadeCuts->Setv0PosCuts(AntiXiPosCuts);
+  AntiCascadeCuts->SetBachCuts(AntiXiBachCuts);
+  CascadeOmegaCuts->Setv0Negcuts(OmegaNegCuts);
+  CascadeOmegaCuts->Setv0PosCuts(OmegaPosCuts);
+  CascadeOmegaCuts->SetBachCuts(OmegaBachCuts);
+  AntiCascadeOmegaCuts->Setv0Negcuts(AntiOmegaNegCuts);
+  AntiCascadeOmegaCuts->Setv0PosCuts(AntiOmegaPosCuts);
+  AntiCascadeOmegaCuts->SetBachCuts(AntiOmegaBachCuts);
+  if(RunNumberQA) AntiCascadeOmegaCuts->SetRunNumberQA(265309, 267167);
+
+  //skip v0s
+  //if (RunNumberQA) {
+    //    v0Cuts->SetRunNumberQA(265309, 267167);
+    //    Antiv0Cuts->SetRunNumberQA(265309, 267167);
+  //}
+
+  //Thanks, CINT - will not compile due to an illegal constructor
+  //std::vector<int> PDGParticles ={2212,2212,3122,3122,3312,3312};
+  std::vector<int> PDGParticles;
+  PDGParticles.push_back(2212);
+  PDGParticles.push_back(2212);
+//reorder to get Xi and Omega, this order is preserved afterwards in the code,
+//for example in AliOtonOmegaAnalysis when doing the paircleaner
+//  PDGParticles.push_back(3122);
+//  PDGParticles.push_back(3122);
+  PDGParticles.push_back(3312);
+  PDGParticles.push_back(3312);
+  PDGParticles.push_back(3334);
+  PDGParticles.push_back(3334);
+  //std::vector<double> ZVtxBins = {-10,-8,-6,-4,-2,0,2,4,6,8,10};
+  std::vector<float> ZVtxBins;
+  ZVtxBins.push_back(-10);
+  ZVtxBins.push_back(-8);
+  ZVtxBins.push_back(-6);
+  ZVtxBins.push_back(-4);
+  ZVtxBins.push_back(-2);
+  ZVtxBins.push_back(0);
+  ZVtxBins.push_back(2);
+  ZVtxBins.push_back(4);
+  ZVtxBins.push_back(6);
+  ZVtxBins.push_back(8);
+  ZVtxBins.push_back(10);
+  std::vector<int> NBins;
+  if (fineBinning) {
+    NBins.push_back(750);  // p p
+    NBins.push_back(750);  // p barp
+    NBins.push_back(750);  // p Lambda
+    NBins.push_back(750);  // p barLambda
+    NBins.push_back(750);  // p Xi
+    NBins.push_back(750);  // p barXi
+    NBins.push_back(750);  // barp barp
+    NBins.push_back(750);  // barp Lambda
+    NBins.push_back(750);  // barp barLambda
+    NBins.push_back(750);  // barp Xi
+    NBins.push_back(750);  // barp barXi
+    NBins.push_back(750);  // Lambda Lambda
+    NBins.push_back(750);  // Lambda barLambda
+    NBins.push_back(750);  // Lambda Xi
+    NBins.push_back(750);  // Lambda barXi
+    NBins.push_back(750);  // barLambda barLambda
+    NBins.push_back(750);  // barLambda Xi
+    NBins.push_back(750);  // barLambda barXi
+    NBins.push_back(750);  // Xi Xi
+    NBins.push_back(750);  // Xi barXi
+    NBins.push_back(750);  // barXi barXi
+  } else {  //standard binning Run1
+    NBins.push_back(750);  // p p
+    NBins.push_back(750);  // p barp
+    NBins.push_back(150);  // p Lambda
+    NBins.push_back(150);  // p barLambda
+    NBins.push_back(150);  // p Xi
+    NBins.push_back(150);  // p barXi
+    NBins.push_back(750);  // barp barp
+    NBins.push_back(150);  // barp Lambda
+    NBins.push_back(150);  // barp barLambda
+    NBins.push_back(150);  // barp Xi
+    NBins.push_back(150);  // barp barXi
+    NBins.push_back(150);  // Lambda Lambda
+    NBins.push_back(150);  // Lambda barLambda
+    NBins.push_back(150);  // Lambda Xi
+    NBins.push_back(150);  // Lambda barXi
+    NBins.push_back(150);  // barLambda barLambda
+    NBins.push_back(150);  // barLambda Xi
+    NBins.push_back(150);  // barLambda barXi
+    NBins.push_back(150);  // Xi Xi
+    NBins.push_back(150);  // Xi barXi
+    NBins.push_back(150);  // barXi barXi
+  }
+  std::vector<float> kMin;
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  kMin.push_back(0.);
+  std::vector<float> kMax;
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  kMax.push_back(3.);
+  AliFemtoDreamCollConfig *config = new AliFemtoDreamCollConfig("Femto",
+                                                                "Femto");
+  if (notpp) {
+    std::vector<int> MultBins;
+    MultBins.push_back(0);
+    MultBins.push_back(4);
+    MultBins.push_back(8);
+    MultBins.push_back(12);
+    MultBins.push_back(16);
+    MultBins.push_back(20);
+    MultBins.push_back(24);
+    MultBins.push_back(28);
+    MultBins.push_back(32);
+    MultBins.push_back(36);
+    MultBins.push_back(40);
+    MultBins.push_back(44);
+    MultBins.push_back(48);
+    MultBins.push_back(52);
+    MultBins.push_back(56);
+    MultBins.push_back(60);
+    MultBins.push_back(64);
+    MultBins.push_back(68);
+    MultBins.push_back(72);
+    MultBins.push_back(76);
+    MultBins.push_back(80);
+    MultBins.push_back(84);
+    MultBins.push_back(88);
+    MultBins.push_back(92);
+    MultBins.push_back(96);
+    MultBins.push_back(100);
+    config->SetMultBins(MultBins);
+  } else {
+    std::vector<int> MultBins;
+    MultBins.push_back(0);
+    MultBins.push_back(4);
+    MultBins.push_back(8);
+    MultBins.push_back(12);
+    MultBins.push_back(16);
+    MultBins.push_back(20);
+    MultBins.push_back(24);
+    MultBins.push_back(28);
+    MultBins.push_back(32);
+    MultBins.push_back(36);
+    MultBins.push_back(40);
+    MultBins.push_back(60);
+    MultBins.push_back(80);
+    config->SetMultBins(MultBins);
+  }
+  config->SetMultBinning(true);
+  if (notpp)
+    config->SetCentBinning(true);
+  config->SetkTBinning(mTkTPlot);
+  config->SetmTBinning(mTkTPlot);
+  config->SetkTCentralityBinning(kTCentPlot);
+  config->SetInvMassPairs(InvMassPairs);
+  if (kTCentPlot) {
+    std::vector<float> centBins;
+    centBins.push_back(20);
+    centBins.push_back(40);
+    centBins.push_back(90);
+    config->SetCentBins(centBins);
+  }
+  config->SetZBins(ZVtxBins);
+  if (MomReso) {
+    if (isMC) {
+      config->SetMomentumResolution(true);
+    } else {
+      std::cout
+          << "You are trying to request the Momentum Resolution without MC Info; fix it wont work! \n";
+    }
+  }
+  if (etaPhiPlotsAtTPCRadii) {
+    if (isMC) {
+      config->SetPhiEtaBinnign(true);
+    } else {
+      std::cout
+          << "You are trying to request the Eta Phi Plots without MC Info; fix it wont work! \n";
+    }
+  }
+  if (DeltaEtaDeltaPhiCut) {
+    config->SetDeltaEtaMax(0.01);
+    config->SetDeltaPhiMax(0.01);
+  }
+  config->SetdPhidEtaPlots(dPhidEtaPlots);
+  config->SetPDGCodes(PDGParticles);
+  config->SetNBinsHist(NBins);
+  config->SetMinKRel(kMin);
+  config->SetMaxKRel(kMax);
+  config->SetMixingDepth(10);
+  config->SetSpinningDepth(10);
+  config->SetUseEventMixing(eventMixing);
+  config->SetUsePhiSpinning(phiSpin);
+  config->SetUseStravinskyMethod(stravinskyPhiSpin);
+  config->SetMinimalBookingME(false);
+  config->SetMinimalBookingSample(true);
+  if (!notpp) {
+    config->SetMultiplicityEstimator(AliFemtoDreamEvent::kSPD);
+  } else {
+    config->SetMultiplicityEstimator(AliFemtoDreamEvent::kRef08);
+  }
+  AliAnalysisTaskOtonOmega *task = new AliAnalysisTaskOtonOmega(
+      "FemtoDreamDefault", isESD, isMC, CascadeTreeFlag, OmegaTreeFlag);
+  if (CentEst == "kInt7") {
+    task->SelectCollisionCandidates(AliVEvent::kINT7);
+    std::cout << "Added kINT7 Trigger \n";
+    task->SetMVPileUp(kTRUE);
+  } else if (CentEst == "kMB") {
+    task->SelectCollisionCandidates(AliVEvent::kMB);
+    std::cout << "Added kMB Trigger \n";
+    task->SetMVPileUp(kFALSE);
+  } else if (CentEst == "kHM") {
+    task->SelectCollisionCandidates(AliVEvent::kHighMultV0);
+    std::cout << "Added kHighMultV0 Trigger \n";
+    task->SetMVPileUp(kFALSE);
+  } else {
+    std::cout
+        << "====================================================================="
+        << std::endl;
+    std::cout
+        << "====================================================================="
+        << std::endl;
+    std::cout
+        << "Centrality Estimator not set, fix it else your Results will be empty!"
+        << std::endl;
+    std::cout
+        << "====================================================================="
+        << std::endl;
+    std::cout
+        << "====================================================================="
+        << std::endl;
+  }
+  //	task->SetDebugLevel(0);
+  task->SetEvtCutQA(true);
+  task->SetTrackBufferSize(2000);
+  task->SetEventCuts(evtCuts);
+  task->SetTrackCuts(TrackCuts);
+  task->SetAntiTrackCuts(AntiTrackCuts);
+//again skip v0s
+//  task->Setv0Cuts(v0Cuts);
+//  task->SetAntiv0Cuts(Antiv0Cuts);
+  task->SetCascadeCuts(CascadeCuts);
+  task->SetAntiCascadeCuts(AntiCascadeCuts);
+  task->SetCascadeOmegaCuts(CascadeOmegaCuts);
+  task->SetAntiCascadeOmegaCuts(AntiCascadeOmegaCuts);
+  task->SetCollectionConfig(config);
+  mgr->AddTask(task);
+
+  TString file = AliAnalysisManager::GetCommonFileName();
+
+  AliAnalysisDataContainer *cinput = mgr->GetCommonInputContainer();
+
+  mgr->ConnectInput(task, 0, cinput);
+
+  AliAnalysisDataContainer *coutputQA;
+  TString addon = "";    
+  if (CentEst == "kInt7") {
+    addon += "MB";
+  } else if (CentEst == "kHM") {
+    addon += "HM";
+  }
+  if (SphericityRange != 0 ) {
+    addon += "_Sphericity_";
+    addon += SphericityRange;
+    addon += "_";
+  }
+  std::cout << "CONTAINTER NAME: " << addon.Data() << std::endl;
+  TString QAName = Form("%sQA", addon.Data());
+  coutputQA = mgr->CreateContainer(
+      //@suppress("Invalid arguments") it works ffs
+      QAName.Data(),
+      TList::Class(), AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), QAName.Data()));
+  mgr->ConnectOutput(task, 1, coutputQA);
+
+  AliAnalysisDataContainer *coutputEvtCuts;
+  TString EvtCutsName = Form("%sEvtCuts", addon.Data());
+  coutputEvtCuts = mgr->CreateContainer(
+      //@suppress("Invalid arguments") it works ffs
+      EvtCutsName.Data(),
+      TList::Class(), AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), EvtCutsName.Data()));
+  mgr->ConnectOutput(task, 2, coutputEvtCuts);
+
+  AliAnalysisDataContainer *couputTrkCuts;
+  TString TrackCutsName = Form("%sTrackCuts", addon.Data());
+  couputTrkCuts = mgr->CreateContainer(
+      //@suppress("Invalid arguments") it works ffs
+      TrackCutsName.Data(),
+      TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), TrackCutsName.Data()));
+  mgr->ConnectOutput(task, 3, couputTrkCuts);
+
+  AliAnalysisDataContainer *coutputAntiTrkCuts;
+  TString AntiTrackCutsName = Form("%sAntiTrackCuts", addon.Data());
+  coutputAntiTrkCuts = mgr->CreateContainer(
+      //@suppress("Invalid arguments") it works ffs
+      AntiTrackCutsName.Data(),
+      TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), AntiTrackCutsName.Data()));
+  mgr->ConnectOutput(task, 4, coutputAntiTrkCuts);
+
+//skip v0s
+/*
+  AliAnalysisDataContainer *coutputv0Cuts;
+  TString v0CutsName = Form("%sv0Cuts", addon.Data());
+  coutputv0Cuts = mgr->CreateContainer(
+      //@suppress("Invalid arguments") it works ffs
+      v0CutsName.Data(),
+      TList::Class(), AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), v0CutsName.Data()));
+  mgr->ConnectOutput(task, 5, coutputv0Cuts);
+
+  AliAnalysisDataContainer *coutputAntiv0Cuts;
+  TString Antiv0CutsName = Form("%sAntiv0Cuts", addon.Data());
+  coutputAntiv0Cuts = mgr->CreateContainer(
+      //@suppress("Invalid arguments") it works ffs
+      Antiv0CutsName.Data(),
+      TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), Antiv0CutsName.Data()));
+  mgr->ConnectOutput(task, 6, coutputAntiv0Cuts);
+*/
+
+  AliAnalysisDataContainer *coutputCascadeCuts;
+  TString CascadeCutsName = Form("%sCascadeCuts", addon.Data());
+  coutputCascadeCuts = mgr->CreateContainer(
+      //@suppress("Invalid arguments") it works ffs
+      CascadeCutsName.Data(),
+      TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), CascadeCutsName.Data()));
+  mgr->ConnectOutput(task, 7, coutputCascadeCuts);
+
+  AliAnalysisDataContainer *coutputAntiCascadeCuts;
+  TString AntiCascadeCutsName = Form("%sAntiCascadeCuts", addon.Data());
+  coutputAntiCascadeCuts = mgr->CreateContainer(
+      //@suppress("Invalid arguments") it works ffs
+      AntiCascadeCutsName.Data(),
+      TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), AntiCascadeCutsName.Data()));
+  mgr->ConnectOutput(task, 8, coutputAntiCascadeCuts);
+
+
+  AliAnalysisDataContainer *coutputCascadeOmegaCuts;
+  TString CascadeOmegaCutsName = Form("%sCascadeOmegaCuts", addon.Data());
+  coutputCascadeOmegaCuts = mgr->CreateContainer(
+      //@suppress("Invalid arguments") it works ffs
+      CascadeOmegaCutsName.Data(),
+      TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), CascadeOmegaCutsName.Data()));
+  mgr->ConnectOutput(task, 5, coutputCascadeOmegaCuts);
+
+  AliAnalysisDataContainer *coutputAntiCascadeOmegaCuts;
+  TString AntiCascadeOmegaCutsName = Form("%sAntiCascadeOmegaCuts", addon.Data());
+  coutputAntiCascadeOmegaCuts = mgr->CreateContainer(
+      //@suppress("Invalid arguments") it works ffs
+      AntiCascadeOmegaCutsName.Data(),
+      TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), AntiCascadeOmegaCutsName.Data()));
+  mgr->ConnectOutput(task, 6, coutputAntiCascadeOmegaCuts);
+
+
+
+  AliAnalysisDataContainer *coutputResults;
+  TString ResultsName = Form("%sResults", addon.Data());
+  coutputResults = mgr->CreateContainer(
+      //@suppress("Invalid arguments") it works ffs
+      ResultsName.Data(),
+      TList::Class(), AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), ResultsName.Data()));
+  mgr->ConnectOutput(task, 9, coutputResults);
+
+  AliAnalysisDataContainer *coutputResultQA;
+  TString ResultQAName = Form("%sResultQA", addon.Data());
+  coutputResultQA = mgr->CreateContainer(
+      //@suppress("Invalid arguments") it works ffs
+      ResultQAName.Data(),
+      TList::Class(), AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), ResultQAName.Data()));
+  mgr->ConnectOutput(task, 10, coutputResultQA);
+
+  AliAnalysisDataContainer *coutputResultsSample;
+  TString ResultsSampleName = Form("%sResultsSample", addon.Data());
+  coutputResultsSample = mgr->CreateContainer(
+      //@suppress("Invalid arguments") it works ffs
+      ResultsSampleName.Data(),
+      TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), ResultsSampleName.Data()));
+  mgr->ConnectOutput(task, 11, coutputResultsSample);
+
+  AliAnalysisDataContainer *coutputResultQASample;
+  TString ResultQASampleName = Form("%sResultQASample", addon.Data());
+  coutputResultQASample = mgr->CreateContainer(
+      //@suppress("Invalid arguments") it works ffs
+      ResultQASampleName.Data(),
+      TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), ResultQASampleName.Data()));
+  mgr->ConnectOutput(task, 12, coutputResultQASample);
+
+  //Cascade Tree:
+  AliAnalysisDataContainer *coutputTreeCascade;
+  TString TreeCascadeName = Form("%sTreeCascade",addon.Data());
+  coutputTreeCascade = mgr->CreateContainer(
+    //@suppress("Invalid arguments") it works ffs
+    "TreeCascade",
+    TTree::Class(),
+    AliAnalysisManager::kOutputContainer,
+    "TreeCascade.root");
+  mgr->ConnectOutput(task, 13, coutputTreeCascade);
+
+
+  //omega tree:
+    AliAnalysisDataContainer *coutputTreeOmega;
+    TString TreeOmegaName = Form("%sTreeOmega",addon.Data());
+    coutputTreeOmega = mgr->CreateContainer(
+      //@suppress("Invalid arguments") it works ffs
+      "TreeOmega",
+      TTree::Class(),
+      AliAnalysisManager::kOutputContainer,
+      "TreeOmega.root");
+    mgr->ConnectOutput(task, 14, coutputTreeOmega);
+
+  if (isMC) {
+    AliAnalysisDataContainer *coutputTrkCutsMC;
+    TString TrkCutsMCName = Form("%sTrkCutsMC", addon.Data());
+    coutputTrkCutsMC = mgr->CreateContainer(
+        //@suppress("Invalid arguments") it works ffs
+        TrkCutsMCName.Data(),
+        TList::Class(),
+        AliAnalysisManager::kOutputContainer,
+        Form("%s:%s", file.Data(), TrkCutsMCName.Data()));
+    mgr->ConnectOutput(task, 15, coutputTrkCutsMC);
+
+    AliAnalysisDataContainer *coutputAntiTrkCutsMC;
+    TString AntiTrkCutsMCName = Form("%sAntiTrkCutsMC", addon.Data());
+    coutputAntiTrkCutsMC = mgr->CreateContainer(
+        //@suppress("Invalid arguments") it works ffs
+        AntiTrkCutsMCName.Data(),
+        TList::Class(),
+        AliAnalysisManager::kOutputContainer,
+        Form("%s:%s", file.Data(), AntiTrkCutsMCName.Data()));
+    mgr->ConnectOutput(task, 16, coutputAntiTrkCutsMC);
+
+//skip v0's as well in MC
+/*
+    AliAnalysisDataContainer *coutputv0CutsMC;
+    TString v0CutsMCName = Form("%sv0CutsMC", addon.Data());
+    coutputv0CutsMC = mgr->CreateContainer(
+        //@suppress("Invalid arguments") it works ffs
+        v0CutsMCName.Data(),
+        TList::Class(),
+        AliAnalysisManager::kOutputContainer,
+        Form("%s:%s", file.Data(), v0CutsMCName.Data()));
+    mgr->ConnectOutput(task, 17, coutputv0CutsMC);
+
+    AliAnalysisDataContainer *coutputAntiv0CutsMC;
+    TString Antiv0CutsMCName = Form("%sAntiv0CutsMC", addon.Data());
+    coutputAntiv0CutsMC = mgr->CreateContainer(
+        //@suppress("Invalid arguments") it works ffs
+        Antiv0CutsMCName.Data(),
+        TList::Class(),
+        AliAnalysisManager::kOutputContainer,
+        Form("%s:%s", file.Data(), Antiv0CutsMCName.Data()));
+    mgr->ConnectOutput(task, 18, coutputAntiv0CutsMC);
+
+*/
+
+    AliAnalysisDataContainer *coutputXiCutsMC;
+    TString XiCutsMCName = Form("%sXiCutsMC", addon.Data());
+    coutputXiCutsMC = mgr->CreateContainer(
+        //@suppress("Invalid arguments") it works ffs
+        XiCutsMCName.Data(),
+        TList::Class(),
+        AliAnalysisManager::kOutputContainer,
+        Form("%s:%s", file.Data(), XiCutsMCName.Data()));
+    mgr->ConnectOutput(task, 19, coutputXiCutsMC);
+
+    AliAnalysisDataContainer *coutputAntiXiCutsMC;
+    TString AntiXiCutsMCName = Form("%sAntiXiCutsMC", addon.Data());
+    coutputAntiXiCutsMC = mgr->CreateContainer(
+        //@suppress("Invalid arguments") it works ffs
+        AntiXiCutsMCName.Data(),
+        TList::Class(),
+        AliAnalysisManager::kOutputContainer,
+        Form("%s:%s", file.Data(), AntiXiCutsMCName.Data()));
+    mgr->ConnectOutput(task, 20, coutputAntiXiCutsMC);
+
+    AliAnalysisDataContainer *coutputXiOmegaCutsMC;
+    TString XiOmegaCutsMCName = Form("%sXiOmegaCutsMC", addon.Data());
+    coutputXiOmegaCutsMC = mgr->CreateContainer(
+        //@suppress("Invalid arguments") it works ffs
+        XiOmegaCutsMCName.Data(),
+        TList::Class(),
+        AliAnalysisManager::kOutputContainer,
+        Form("%s:%s", file.Data(), XiOmegaCutsMCName.Data()));
+    mgr->ConnectOutput(task, 17, coutputXiOmegaCutsMC);
+
+    AliAnalysisDataContainer *coutputAntiXiOmegaCutsMC;
+    TString AntiXiOmegaCutsMCName = Form("%sAntiXiOmegaCutsMC", addon.Data());
+    coutputAntiXiOmegaCutsMC = mgr->CreateContainer(
+        //@suppress("Invalid arguments") it works ffs
+        AntiXiOmegaCutsMCName.Data(),
+        TList::Class(),
+        AliAnalysisManager::kOutputContainer,
+        Form("%s:%s", file.Data(), AntiXiOmegaCutsMCName.Data()));
+    mgr->ConnectOutput(task, 18, coutputAntiXiOmegaCutsMC);
+   }
+
+
+
+
+  return task;
+}
+

--- a/PWGCF/FEMTOSCOPY/macros/ConfigOtonOmega.C
+++ b/PWGCF/FEMTOSCOPY/macros/ConfigOtonOmega.C
@@ -1,0 +1,26 @@
+//ConfigOtonOmega called by AddTaskOtonOmega to set additional cuts or overwrite the standards
+
+void ConfigOtonOmega(AliOtonOmegaCascadeCuts *CascadeCuts,AliFemtoDreamTrackCuts *XiPosCuts,AliFemtoDreamTrackCuts *XiNegCuts,AliFemtoDreamTrackCuts *XiBachCuts,AliOtonOmegaCascadeCuts *AntiCascadeCuts,AliFemtoDreamTrackCuts *AntiXiPosCuts,AliFemtoDreamTrackCuts *AntiXiNegCuts,AliFemtoDreamTrackCuts *AntiXiBachCuts,AliOtonOmegaCascadeCuts * CascadeOmegaCuts,AliFemtoDreamTrackCuts *OmegaPosCuts,AliFemtoDreamTrackCuts *OmegaNegCuts,AliFemtoDreamTrackCuts *OmegaBachCuts,AliOtonOmegaCascadeCuts *AntiCascadeOmegaCuts,AliFemtoDreamTrackCuts *AntiOmegaPosCuts,AliFemtoDreamTrackCuts *AntiOmegaNegCuts,AliFemtoDreamTrackCuts *AntiOmegaBachCuts){
+
+
+  CascadeCuts->SetXiMassRange(1.322, 0.020);
+//  XiPosCuts->SetCheckPileUp(false);
+//  XiNegCuts->SetCheckPileUp(false);
+//  XiBachCuts->SetCheckPileUp(false);
+
+  AntiCascadeCuts->SetXiMassRange(1.322, 0.020);
+//  AntiXiPosCuts->SetCheckPileUp(false);
+//  AntiXiNegCuts->SetCheckPileUp(false);
+//  AntiXiBachCuts->SetCheckPileUp(false);
+
+  CascadeOmegaCuts->SetXiMassRange(1.672, 0.020);
+//  OmegaPosCuts->SetCheckPileUp(false);
+//  OmegaNegCuts->SetCheckPileUp(false);
+//  OmegaBachCuts->SetCheckPileUp(false);
+
+  AntiCascadeOmegaCuts->SetXiMassRange(1.672, 0.020);
+//  AntiOmegaPosCuts->SetCheckPileUp(false);
+//  AntiOmegaNegCuts->SetCheckPileUp(false);
+//  AntiOmegaBachCuts->SetCheckPileUp(false);
+
+}


### PR DESCRIPTION
-Added tasks and classes based in the FemtoDream code.
-Now Xi and Omega are treated independently and can be directed into the otuput.
-Config File added so the AddTask can be set via alien.
-Tree for Xi and Omega selection added as additional output.