### PR TITLE
PWGGA/GammaConv: Adding more kinenmatic histograms for MC truth

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.cxx
@@ -56,7 +56,7 @@ ClassImp( AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson )
 
 //-----------------------------------------------------------------------------------------------
 AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson():
-  fV0Reader(NULL),
+  fV0Reader(nullptr),
   fV0ReaderName("V0ReaderV1"),
   fPionSelector(NULL),
   fBGHandlerPiPl(NULL),
@@ -69,28 +69,28 @@ AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::AliAnalysisTaskNeutralMesonTo
   fTrueTreeList(NULL),
   fMCList(NULL),
   fOutputContainer(0),
-  fReaderGammas(NULL),
+  fReaderGammas(nullptr),
   fSelectorNegPionIndex(0),
   fSelectorPosPionIndex(0),
-  fGoodConvGammas(NULL),
-  fClusterCandidates(NULL),
-  fNeutralDecayParticleCandidates(NULL),
-  fNeutralDecayParticleSidebandCandidates(NULL),
-  fPosPionCandidates(NULL),
-  fNegPionCandidates(NULL),
-  fGoodVirtualParticles(NULL),
-  fEventCutArray(NULL),
-  fGammaCutArray(NULL),
-  fClusterCutArray(NULL),
-  fPionCutArray(NULL),
-  fNeutralDecayMesonCutArray(NULL),
-  fMesonCutArray(NULL),
-  fEventCuts(NULL),
-  fConversionCuts(NULL),
-  fClusterCuts(NULL),
-  fTreePiPiSameMother(NULL),
-  fTreePiPiPiSameMother(NULL),
-  fTreeEventInfoHNM(NULL),
+  fGoodConvGammas(nullptr),
+  fClusterCandidates(nullptr),
+  fNeutralDecayParticleCandidates(nullptr),
+  fNeutralDecayParticleSidebandCandidates(nullptr),
+  fPosPionCandidates(nullptr),
+  fNegPionCandidates(nullptr),
+  fGoodVirtualParticles(nullptr),
+  fEventCutArray(nullptr),
+  fGammaCutArray(nullptr),
+  fClusterCutArray(nullptr),
+  fPionCutArray(nullptr),
+  fNeutralDecayMesonCutArray(nullptr),
+  fMesonCutArray(nullptr),
+  fEventCuts(nullptr),
+  fConversionCuts(nullptr),
+  fClusterCuts(nullptr),
+  fTreePiPiSameMother(nullptr),
+  fTreePiPiPiSameMother(nullptr),
+  fTreeEventInfoHNM(nullptr),
   fCasePiPi(-1),
   fSamePiPiMotherID(-1),
   fSamePiPiMotherInvMass(-1),
@@ -105,103 +105,150 @@ AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::AliAnalysisTaskNeutralMesonTo
   fPDGMassNDM(-1),
   fPDGCodeNDM(-1),
   fPDGCodeAnalyzedMeson(-1),
-  fHistoConvGammaPt(NULL),
-  fHistoConvGammaEta(NULL),
-  fHistoClusterGammaPt(NULL),
-  fHistoClusterGammaEta(NULL),
-  fHistoNegPionPt(NULL),
-  fHistoPosPionPt(NULL),
-  fHistoNegPionPhi(NULL),
-  fHistoPosPionPhi(NULL),
-  fHistoNegPionEta(NULL),
-  fHistoPosPionEta(NULL),
-  fHistoNegPionClsTPC(NULL),
-  fHistoPosPionClsTPC(NULL),
-  fHistoPionDCAxy(NULL),
-  fHistoPionDCAz(NULL),
-  fHistoPionTPCdEdxNSigma(NULL),
-  fHistoPionTPCdEdx(NULL),
-  fHistoPionPionInvMassPt(NULL),
-  fHistoGammaGammaInvMassPt(NULL),
-  fHistoGammaGammaInvMassPtBeforeCuts(NULL),
-  fHistoMotherInvMassPt(NULL),
-  fHistoMotherInvMassPtRejectedKinematic(NULL),
-  fHistoBackInvMassPtGroup1(NULL),
-  fHistoBackInvMassPtGroup2(NULL),
-  fHistoBackInvMassPtGroup3(NULL),
-  fHistoBackInvMassPtGroup4(NULL),
-  fHistoMotherLikeSignBackInvMassPt(NULL),
-  fHistoAngleHNMesonPiPlPiMi(NULL),
-  fHistoAngleHNMesonNDM(NULL),
-  fHistoAngleHNMesonPiPl(NULL),
-  fHistoAngleHNMesonPiMi(NULL),
-  fHistoAnglePiPlPiMi(NULL),
-  fHistoAngleNDMPiMi(NULL),
-  fHistoAnglePiPlNDM(NULL),
-  fHistoAngleSum(NULL),
-  fHistoTrueAngleSum(NULL),
-  fHistoMotherInvMassSubNDM(NULL),
-  fHistoBackInvMassPtGroup1SubNDM(NULL),
-  fHistoBackInvMassPtGroup2SubNDM(NULL),
-  fHistoBackInvMassPtGroup3SubNDM(NULL),
-  fHistoBackInvMassPtGroup4SubNDM(NULL),
-  fHistoMotherLikeSignBackInvMassSubNDMPt(NULL),
-  fHistoMotherInvMassFixedPzNDM(NULL),
-  fHistoBackInvMassPtGroup1FixedPzNDM(NULL),
-  fHistoBackInvMassPtGroup2FixedPzNDM(NULL),
-  fHistoBackInvMassPtGroup3FixedPzNDM(NULL),
-  fHistoBackInvMassPtGroup4FixedPzNDM(NULL),
-  fHistoMotherLikeSignBackInvMassFixedPzNDMPt(NULL),
-  fHistoMCAllGammaPt(NULL),
-  fHistoMCConvGammaPt(NULL),
-  fHistoMCAllPosPionsPt(NULL),
-  fHistoMCAllNegPionsPt(NULL),
-  fHistoMCGammaFromNeutralMesonPt(NULL),
-  fHistoMCPosPionsFromNeutralMesonPt(NULL),
-  fHistoMCNegPionsFromNeutralMesonPt(NULL),
-  fHistoMCHNMPiPlPiMiNDMPt(NULL),
-  fHistoMCHNMPiPlPiMiNDMInAccPt(NULL),
-  fHistoTrueMotherPiPlPiMiNDMInvMassPt(NULL),
-  fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt(NULL),
-  fHistoTrueMotherGammaGammaInvMassPt(NULL),
-  fHistoTrueMotherGammaGammaFromHNMInvMassPt(NULL),
-  fHistoTrueConvGammaPt(NULL),
-  fHistoTrueConvGammaFromNeutralMesonPt(NULL),
-  fHistoTrueClusterGammaPt(NULL),
-  fHistoTrueClusterGammaFromNeutralMesonPt(NULL),
-  fHistoTruePosPionPt(NULL),
-  fHistoTruePosPionFromNeutralMesonPt(NULL),
-  fHistoTrueNegPionPt(NULL),
-  fHistoTrueNegPionFromNeutralMesonPt(NULL),
-  fHistoTruePionPionInvMassPt(NULL),
-  fHistoTruePionPionFromSameMotherInvMassPt(NULL),
-  fHistoTruePionPionFromHNMInvMassPt(NULL),
-  fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt(NULL),
-  fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt(NULL),
-  fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt(NULL),
-  fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt(NULL),
-  fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt(NULL),
-  fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt(NULL),
-  fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt(NULL),
-  fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt(NULL),
-  fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt(NULL),
-  fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt(NULL),
-  fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt(NULL),
-  fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt(NULL),
-  fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt(NULL),
-  fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt(NULL),
-  fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt(NULL),
-  fHistoTruePiPlPiMiNDMContaminationInvMassPt(NULL),
-  fHistoDoubleCountTruePi0InvMassPt(NULL),
-  fHistoDoubleCountTrueHNMInvMassPt(NULL),
-  fHistoDoubleCountTrueConvGammaRPt(NULL),
+  fHistoConvGammaPt(nullptr),
+  fHistoConvGammaEta(nullptr),
+  fHistoClusterGammaPt(nullptr),
+  fHistoClusterGammaEta(nullptr),
+  fHistoNegPionPt(nullptr),
+  fHistoPosPionPt(nullptr),
+  fHistoNegPionPhi(nullptr),
+  fHistoPosPionPhi(nullptr),
+  fHistoNegPionEta(nullptr),
+  fHistoPosPionEta(nullptr),
+  fHistoNegPionClsTPC(nullptr),
+  fHistoPosPionClsTPC(nullptr),
+  fHistoPionDCAxy(nullptr),
+  fHistoPionDCAz(nullptr),
+  fHistoPionTPCdEdxNSigma(nullptr),
+  fHistoPionTPCdEdx(nullptr),
+  fHistoPionPionInvMassPt(nullptr),
+  fHistoGammaGammaInvMassPt(nullptr),
+  fHistoGammaGammaInvMassPtBeforeCuts(nullptr),
+  fHistoMotherInvMassPt(nullptr),
+  fHistoMotherInvMassPtRejectedKinematic(nullptr),
+  fHistoBackInvMassPtGroup1(nullptr),
+  fHistoBackInvMassPtGroup2(nullptr),
+  fHistoBackInvMassPtGroup3(nullptr),
+  fHistoBackInvMassPtGroup4(nullptr),
+  fHistoMotherLikeSignBackInvMassPt(nullptr),
+  fHistoAngleHNMesonPiPlPiMi(nullptr),
+  fHistoAngleHNMesonNDM(nullptr),
+  fHistoAngleHNMesonPiPl(nullptr),
+  fHistoAngleHNMesonPiMi(nullptr),
+  fHistoAnglePiPlPiMi(nullptr),
+  fHistoAngleNDMPiMi(nullptr),
+  fHistoAnglePiPlNDM(nullptr),
+  fHistoAngleSum(nullptr),
+  fHistoTrueAngleSum(nullptr),
+  fHistoMotherInvMassSubNDM(nullptr),
+  fHistoBackInvMassPtGroup1SubNDM(nullptr),
+  fHistoBackInvMassPtGroup2SubNDM(nullptr),
+  fHistoBackInvMassPtGroup3SubNDM(nullptr),
+  fHistoBackInvMassPtGroup4SubNDM(nullptr),
+  fHistoMotherLikeSignBackInvMassSubNDMPt(nullptr),
+  fHistoMotherInvMassFixedPzNDM(nullptr),
+  fHistoBackInvMassPtGroup1FixedPzNDM(nullptr),
+  fHistoBackInvMassPtGroup2FixedPzNDM(nullptr),
+  fHistoBackInvMassPtGroup3FixedPzNDM(nullptr),
+  fHistoBackInvMassPtGroup4FixedPzNDM(nullptr),
+  fHistoMotherLikeSignBackInvMassFixedPzNDMPt(nullptr),
+  fHistoMCAllGammaPt(nullptr),
+  fHistoMCConvGammaPt(nullptr),
+  fHistoMCAllMesonPt(nullptr),
+  fHistoMCAllMesonEta(nullptr),
+  fHistoMCAllMesonPhi(nullptr),
+  fHistoMCMesonFromNeutralMesonPt(nullptr),
+  fHistoMCMesonFromNeutralMesonEta(nullptr),
+  fHistoMCMesonFromNeutralMesonPhi(nullptr),
+  fHistoMCAllPosPionsPt(nullptr),
+  fHistoMCAllPosPionsEta(nullptr),
+  fHistoMCAllPosPionsPhi(nullptr),
+  fHistoMCAllNegPionsPt(nullptr),
+  fHistoMCAllNegPionsEta(nullptr),
+  fHistoMCAllNegPionsPhi(nullptr),
+  fHistoMCGammaFromNeutralMesonPt(nullptr),
+  fHistoMCPosPionsFromNeutralMesonPt(nullptr),
+  fHistoMCPosPionsFromNeutralMesonEta(nullptr),
+  fHistoMCPosPionsFromNeutralMesonPhi(nullptr),
+  fHistoMCNegPionsFromNeutralMesonPt(nullptr),
+  fHistoMCNegPionsFromNeutralMesonEta(nullptr),
+  fHistoMCNegPionsFromNeutralMesonPhi(nullptr),
+  fHistoMCHNMPiPlPiMiNDMPt(nullptr),
+  fHistoMCHNMPiPlPiMiNDMInAccPt(nullptr),
+  fHistoMCHeavyAllPt(nullptr),
+  fHistoMCHeavyAllEta(nullptr),
+  fHistoMCHeavyAllPhi(nullptr),
+  fHistoMCHeavyChannelPt(nullptr),
+  fHistoMCHeavyChannelEta(nullptr),
+  fHistoMCHeavyChannelPhi(nullptr),
+  fHistMCChannelNDMFromHeavyPt(nullptr),
+  fHistMCChannelNDMFromHeavyEta(nullptr),
+  fHistMCChannelNDMFromHeavyPhi(nullptr),
+  fHistMCChannelPiPlusFromHeavyPt(nullptr),
+  fHistMCChannelPiPlusFromHeavyEta(nullptr),
+  fHistMCChannelPiPlusFromHeavyPhi(nullptr),
+  fHistMCChannelPiMinusFromHeavyPt(nullptr),
+  fHistMCChannelPiMinusFromHeavyEta(nullptr),
+  fHistMCChannelPiPMinusFromHeavyPhi(nullptr),
+  fHistMCChannelNDMPtHeavyPt(nullptr),
+  fHistMCChannelPiPlusPtHeavyPt(nullptr),
+  fHistMCChannelPiMinusPtHeavyPt(nullptr),
+  fHistoMCHeavyReconstructiblePt(nullptr),
+  fHistoMCHeavyReconstructibleEta(nullptr),
+  fHistoMCHeavyReconstructiblePhi(nullptr),
+  fHistMCReconstructibleNDMFromHeavyPt(nullptr),
+  fHistMCReconstructibleNDMFromHeavyEta(nullptr),
+  fHistMCReconstructibleNDMFromHeavyPhi(nullptr),
+  fHistMCReconstructiblePiPlusFromHeavyPt(nullptr),
+  fHistMCReconstructiblePiPlusFromHeavyEta(nullptr),
+  fHistMCReconstructiblePiPlusFromHeavyPhi(nullptr),
+  fHistMCReconstructiblePiMinusFromHeavyPt(nullptr),
+  fHistMCReconstructiblePiMinusFromHeavyEta(nullptr),
+  fHistMCReconstructiblePiPMinusFromHeavyPhi(nullptr),
+  fHistMCReconstructibleNDMPtHeavyPt(nullptr),
+  fHistMCReconstructiblePiPlusPtHeavyPt(nullptr),
+  fHistMCReconstructiblePiMinusPtHeavyPt(nullptr),
+  fHistoTrueMotherPiPlPiMiNDMInvMassPt(nullptr),
+  fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt(nullptr),
+  fHistoTrueMotherGammaGammaInvMassPt(nullptr),
+  fHistoTrueMotherGammaGammaFromHNMInvMassPt(nullptr),
+  fHistoTrueConvGammaPt(nullptr),
+  fHistoTrueConvGammaFromNeutralMesonPt(nullptr),
+  fHistoTrueClusterGammaPt(nullptr),
+  fHistoTrueClusterGammaFromNeutralMesonPt(nullptr),
+  fHistoTruePosPionPt(nullptr),
+  fHistoTruePosPionFromNeutralMesonPt(nullptr),
+  fHistoTrueNegPionPt(nullptr),
+  fHistoTrueNegPionFromNeutralMesonPt(nullptr),
+  fHistoTruePionPionInvMassPt(nullptr),
+  fHistoTruePionPionFromSameMotherInvMassPt(nullptr),
+  fHistoTruePionPionFromHNMInvMassPt(nullptr),
+  fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt(nullptr),
+  fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt(nullptr),
+  fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt(nullptr),
+  fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt(nullptr),
+  fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt(nullptr),
+  fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt(nullptr),
+  fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt(nullptr),
+  fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt(nullptr),
+  fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt(nullptr),
+  fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt(nullptr),
+  fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt(nullptr),
+  fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt(nullptr),
+  fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt(nullptr),
+  fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt(nullptr),
+  fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt(nullptr),
+  fHistoTruePiPlPiMiNDMContaminationInvMassPt(nullptr),
+  fHistoDoubleCountTruePi0InvMassPt(nullptr),
+  fHistoDoubleCountTrueHNMInvMassPt(nullptr),
+  fHistoDoubleCountTrueConvGammaRPt(nullptr),
   fVectorDoubleCountTruePi0s(0),
   fVectorDoubleCountTrueHNMs(0),
   fVectorDoubleCountTrueConvGammas(0),
-  fHistoNEvents(NULL),
-  fHistoNGoodESDTracks(NULL),
-  fProfileEtaShift(NULL),
-  fHistoSPDClusterTrackletBackground(NULL),
+  fHistoNEvents(nullptr),
+  fHistoNGoodESDTracks(nullptr),
+  fProfileEtaShift(nullptr),
+  fHistoSPDClusterTrackletBackground(nullptr),
   fRandom(0),
   fnCuts(0),
   fiCut(0),
@@ -223,7 +270,7 @@ AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::AliAnalysisTaskNeutralMesonTo
 //-----------------------------------------------------------------------------------------------
 AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson( const char* name ):
   AliAnalysisTaskSE(name),
-  fV0Reader(NULL),
+  fV0Reader(nullptr),
   fV0ReaderName("V0ReaderV1"),
   fPionSelector(NULL),
   fBGHandlerPiPl(NULL),
@@ -236,28 +283,28 @@ AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::AliAnalysisTaskNeutralMesonTo
   fTrueTreeList(NULL),
   fMCList(NULL),
   fOutputContainer(0),
-  fReaderGammas(NULL),
+  fReaderGammas(nullptr),
   fSelectorNegPionIndex(0),
   fSelectorPosPionIndex(0),
-  fGoodConvGammas(NULL),
-  fClusterCandidates(NULL),
-  fNeutralDecayParticleCandidates(NULL),
-  fNeutralDecayParticleSidebandCandidates(NULL),
-  fPosPionCandidates(NULL),
-  fNegPionCandidates(NULL),
-  fGoodVirtualParticles(NULL),
-  fEventCutArray(NULL),
-  fGammaCutArray(NULL),
-  fClusterCutArray(NULL),
-  fPionCutArray(NULL),
-  fNeutralDecayMesonCutArray(NULL),
-  fMesonCutArray(NULL),
-  fEventCuts(NULL),
-  fConversionCuts(NULL),
-  fClusterCuts(NULL),
-  fTreePiPiSameMother(NULL),
-  fTreePiPiPiSameMother(NULL),
-  fTreeEventInfoHNM(NULL),
+  fGoodConvGammas(nullptr),
+  fClusterCandidates(nullptr),
+  fNeutralDecayParticleCandidates(nullptr),
+  fNeutralDecayParticleSidebandCandidates(nullptr),
+  fPosPionCandidates(nullptr),
+  fNegPionCandidates(nullptr),
+  fGoodVirtualParticles(nullptr),
+  fEventCutArray(nullptr),
+  fGammaCutArray(nullptr),
+  fClusterCutArray(nullptr),
+  fPionCutArray(nullptr),
+  fNeutralDecayMesonCutArray(nullptr),
+  fMesonCutArray(nullptr),
+  fEventCuts(nullptr),
+  fConversionCuts(nullptr),
+  fClusterCuts(nullptr),
+  fTreePiPiSameMother(nullptr),
+  fTreePiPiPiSameMother(nullptr),
+  fTreeEventInfoHNM(nullptr),
   fCasePiPi(-1),
   fSamePiPiMotherID(-1),
   fSamePiPiMotherInvMass(-1),
@@ -272,103 +319,150 @@ AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::AliAnalysisTaskNeutralMesonTo
   fPDGMassNDM(-1),
   fPDGCodeNDM(-1),
   fPDGCodeAnalyzedMeson(-1),
-  fHistoConvGammaPt(NULL),
-  fHistoConvGammaEta(NULL),
-  fHistoClusterGammaPt(NULL),
-  fHistoClusterGammaEta(NULL),
-  fHistoNegPionPt(NULL),
-  fHistoPosPionPt(NULL),
-  fHistoNegPionPhi(NULL),
-  fHistoPosPionPhi(NULL),
-  fHistoNegPionEta(NULL),
-  fHistoPosPionEta(NULL),
-  fHistoNegPionClsTPC(NULL),
-  fHistoPosPionClsTPC(NULL),
-  fHistoPionDCAxy(NULL),
-  fHistoPionDCAz(NULL),
-  fHistoPionTPCdEdxNSigma(NULL),
-  fHistoPionTPCdEdx(NULL),
-  fHistoPionPionInvMassPt(NULL),
-  fHistoGammaGammaInvMassPt(NULL),
-  fHistoGammaGammaInvMassPtBeforeCuts(NULL),
-  fHistoMotherInvMassPt(NULL),
-  fHistoMotherInvMassPtRejectedKinematic(NULL),
-  fHistoBackInvMassPtGroup1(NULL),
-  fHistoBackInvMassPtGroup2(NULL),
-  fHistoBackInvMassPtGroup3(NULL),
-  fHistoBackInvMassPtGroup4(NULL),
-  fHistoMotherLikeSignBackInvMassPt(NULL),
-  fHistoAngleHNMesonPiPlPiMi(NULL),
-  fHistoAngleHNMesonNDM(NULL),
-  fHistoAngleHNMesonPiPl(NULL),
-  fHistoAngleHNMesonPiMi(NULL),
-  fHistoAnglePiPlPiMi(NULL),
-  fHistoAngleNDMPiMi(NULL),
-  fHistoAnglePiPlNDM(NULL),
-  fHistoAngleSum(NULL),
-  fHistoTrueAngleSum(NULL),
-  fHistoMotherInvMassSubNDM(NULL),
-  fHistoBackInvMassPtGroup1SubNDM(NULL),
-  fHistoBackInvMassPtGroup2SubNDM(NULL),
-  fHistoBackInvMassPtGroup3SubNDM(NULL),
-  fHistoBackInvMassPtGroup4SubNDM(NULL),
-  fHistoMotherLikeSignBackInvMassSubNDMPt(NULL),
-  fHistoMotherInvMassFixedPzNDM(NULL),
-  fHistoBackInvMassPtGroup1FixedPzNDM(NULL),
-  fHistoBackInvMassPtGroup2FixedPzNDM(NULL),
-  fHistoBackInvMassPtGroup3FixedPzNDM(NULL),
-  fHistoBackInvMassPtGroup4FixedPzNDM(NULL),
-  fHistoMotherLikeSignBackInvMassFixedPzNDMPt(NULL),
-  fHistoMCAllGammaPt(NULL),
-  fHistoMCConvGammaPt(NULL),
-  fHistoMCAllPosPionsPt(NULL),
-  fHistoMCAllNegPionsPt(NULL),
-  fHistoMCGammaFromNeutralMesonPt(NULL),
-  fHistoMCPosPionsFromNeutralMesonPt(NULL),
-  fHistoMCNegPionsFromNeutralMesonPt(NULL),
-  fHistoMCHNMPiPlPiMiNDMPt(NULL),
-  fHistoMCHNMPiPlPiMiNDMInAccPt(NULL),
-  fHistoTrueMotherPiPlPiMiNDMInvMassPt(NULL),
-  fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt(NULL),
-  fHistoTrueMotherGammaGammaInvMassPt(NULL),
-  fHistoTrueMotherGammaGammaFromHNMInvMassPt(NULL),
-  fHistoTrueConvGammaPt(NULL),
-  fHistoTrueConvGammaFromNeutralMesonPt(NULL),
-  fHistoTrueClusterGammaPt(NULL),
-  fHistoTrueClusterGammaFromNeutralMesonPt(NULL),
-  fHistoTruePosPionPt(NULL),
-  fHistoTruePosPionFromNeutralMesonPt(NULL),
-  fHistoTrueNegPionPt(NULL),
-  fHistoTrueNegPionFromNeutralMesonPt(NULL),
-  fHistoTruePionPionInvMassPt(NULL),
-  fHistoTruePionPionFromSameMotherInvMassPt(NULL),
-  fHistoTruePionPionFromHNMInvMassPt(NULL),
-  fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt(NULL),
-  fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt(NULL),
-  fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt(NULL),
-  fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt(NULL),
-  fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt(NULL),
-  fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt(NULL),
-  fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt(NULL),
-  fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt(NULL),
-  fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt(NULL),
-  fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt(NULL),
-  fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt(NULL),
-  fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt(NULL),
-  fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt(NULL),
-  fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt(NULL),
-  fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt(NULL),
-  fHistoTruePiPlPiMiNDMContaminationInvMassPt(NULL),
-  fHistoDoubleCountTruePi0InvMassPt(NULL),
-  fHistoDoubleCountTrueHNMInvMassPt(NULL),
-  fHistoDoubleCountTrueConvGammaRPt(NULL),
+  fHistoConvGammaPt(nullptr),
+  fHistoConvGammaEta(nullptr),
+  fHistoClusterGammaPt(nullptr),
+  fHistoClusterGammaEta(nullptr),
+  fHistoNegPionPt(nullptr),
+  fHistoPosPionPt(nullptr),
+  fHistoNegPionPhi(nullptr),
+  fHistoPosPionPhi(nullptr),
+  fHistoNegPionEta(nullptr),
+  fHistoPosPionEta(nullptr),
+  fHistoNegPionClsTPC(nullptr),
+  fHistoPosPionClsTPC(nullptr),
+  fHistoPionDCAxy(nullptr),
+  fHistoPionDCAz(nullptr),
+  fHistoPionTPCdEdxNSigma(nullptr),
+  fHistoPionTPCdEdx(nullptr),
+  fHistoPionPionInvMassPt(nullptr),
+  fHistoGammaGammaInvMassPt(nullptr),
+  fHistoGammaGammaInvMassPtBeforeCuts(nullptr),
+  fHistoMotherInvMassPt(nullptr),
+  fHistoMotherInvMassPtRejectedKinematic(nullptr),
+  fHistoBackInvMassPtGroup1(nullptr),
+  fHistoBackInvMassPtGroup2(nullptr),
+  fHistoBackInvMassPtGroup3(nullptr),
+  fHistoBackInvMassPtGroup4(nullptr),
+  fHistoMotherLikeSignBackInvMassPt(nullptr),
+  fHistoAngleHNMesonPiPlPiMi(nullptr),
+  fHistoAngleHNMesonNDM(nullptr),
+  fHistoAngleHNMesonPiPl(nullptr),
+  fHistoAngleHNMesonPiMi(nullptr),
+  fHistoAnglePiPlPiMi(nullptr),
+  fHistoAngleNDMPiMi(nullptr),
+  fHistoAnglePiPlNDM(nullptr),
+  fHistoAngleSum(nullptr),
+  fHistoTrueAngleSum(nullptr),
+  fHistoMotherInvMassSubNDM(nullptr),
+  fHistoBackInvMassPtGroup1SubNDM(nullptr),
+  fHistoBackInvMassPtGroup2SubNDM(nullptr),
+  fHistoBackInvMassPtGroup3SubNDM(nullptr),
+  fHistoBackInvMassPtGroup4SubNDM(nullptr),
+  fHistoMotherLikeSignBackInvMassSubNDMPt(nullptr),
+  fHistoMotherInvMassFixedPzNDM(nullptr),
+  fHistoBackInvMassPtGroup1FixedPzNDM(nullptr),
+  fHistoBackInvMassPtGroup2FixedPzNDM(nullptr),
+  fHistoBackInvMassPtGroup3FixedPzNDM(nullptr),
+  fHistoBackInvMassPtGroup4FixedPzNDM(nullptr),
+  fHistoMotherLikeSignBackInvMassFixedPzNDMPt(nullptr),
+  fHistoMCAllGammaPt(nullptr),
+  fHistoMCConvGammaPt(nullptr),
+  fHistoMCAllMesonPt(nullptr),
+  fHistoMCAllMesonEta(nullptr),
+  fHistoMCAllMesonPhi(nullptr),
+  fHistoMCMesonFromNeutralMesonPt(nullptr),
+  fHistoMCMesonFromNeutralMesonEta(nullptr),
+  fHistoMCMesonFromNeutralMesonPhi(nullptr),
+  fHistoMCAllPosPionsPt(nullptr),
+  fHistoMCAllPosPionsEta(nullptr),
+  fHistoMCAllPosPionsPhi(nullptr),
+  fHistoMCAllNegPionsPt(nullptr),
+  fHistoMCAllNegPionsEta(nullptr),
+  fHistoMCAllNegPionsPhi(nullptr),
+  fHistoMCGammaFromNeutralMesonPt(nullptr),
+  fHistoMCPosPionsFromNeutralMesonPt(nullptr),
+  fHistoMCPosPionsFromNeutralMesonEta(nullptr),
+  fHistoMCPosPionsFromNeutralMesonPhi(nullptr),
+  fHistoMCNegPionsFromNeutralMesonPt(nullptr),
+  fHistoMCNegPionsFromNeutralMesonEta(nullptr),
+  fHistoMCNegPionsFromNeutralMesonPhi(nullptr),
+  fHistoMCHNMPiPlPiMiNDMPt(nullptr),
+  fHistoMCHNMPiPlPiMiNDMInAccPt(nullptr),
+  fHistoMCHeavyAllPt(nullptr),
+  fHistoMCHeavyAllEta(nullptr),
+  fHistoMCHeavyAllPhi(nullptr),
+  fHistoMCHeavyChannelPt(nullptr),
+  fHistoMCHeavyChannelEta(nullptr),
+  fHistoMCHeavyChannelPhi(nullptr),
+  fHistMCChannelNDMFromHeavyPt(nullptr),
+  fHistMCChannelNDMFromHeavyEta(nullptr),
+  fHistMCChannelNDMFromHeavyPhi(nullptr),
+  fHistMCChannelPiPlusFromHeavyPt(nullptr),
+  fHistMCChannelPiPlusFromHeavyEta(nullptr),
+  fHistMCChannelPiPlusFromHeavyPhi(nullptr),
+  fHistMCChannelPiMinusFromHeavyPt(nullptr),
+  fHistMCChannelPiMinusFromHeavyEta(nullptr),
+  fHistMCChannelPiPMinusFromHeavyPhi(nullptr),
+  fHistMCChannelNDMPtHeavyPt(nullptr),
+  fHistMCChannelPiPlusPtHeavyPt(nullptr),
+  fHistMCChannelPiMinusPtHeavyPt(nullptr),
+  fHistoMCHeavyReconstructiblePt(nullptr),
+  fHistoMCHeavyReconstructibleEta(nullptr),
+  fHistoMCHeavyReconstructiblePhi(nullptr),
+  fHistMCReconstructibleNDMFromHeavyPt(nullptr),
+  fHistMCReconstructibleNDMFromHeavyEta(nullptr),
+  fHistMCReconstructibleNDMFromHeavyPhi(nullptr),
+  fHistMCReconstructiblePiPlusFromHeavyPt(nullptr),
+  fHistMCReconstructiblePiPlusFromHeavyEta(nullptr),
+  fHistMCReconstructiblePiPlusFromHeavyPhi(nullptr),
+  fHistMCReconstructiblePiMinusFromHeavyPt(nullptr),
+  fHistMCReconstructiblePiMinusFromHeavyEta(nullptr),
+  fHistMCReconstructiblePiPMinusFromHeavyPhi(nullptr),
+  fHistMCReconstructibleNDMPtHeavyPt(nullptr),
+  fHistMCReconstructiblePiPlusPtHeavyPt(nullptr),
+  fHistMCReconstructiblePiMinusPtHeavyPt(nullptr),
+  fHistoTrueMotherPiPlPiMiNDMInvMassPt(nullptr),
+  fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt(nullptr),
+  fHistoTrueMotherGammaGammaInvMassPt(nullptr),
+  fHistoTrueMotherGammaGammaFromHNMInvMassPt(nullptr),
+  fHistoTrueConvGammaPt(nullptr),
+  fHistoTrueConvGammaFromNeutralMesonPt(nullptr),
+  fHistoTrueClusterGammaPt(nullptr),
+  fHistoTrueClusterGammaFromNeutralMesonPt(nullptr),
+  fHistoTruePosPionPt(nullptr),
+  fHistoTruePosPionFromNeutralMesonPt(nullptr),
+  fHistoTrueNegPionPt(nullptr),
+  fHistoTrueNegPionFromNeutralMesonPt(nullptr),
+  fHistoTruePionPionInvMassPt(nullptr),
+  fHistoTruePionPionFromSameMotherInvMassPt(nullptr),
+  fHistoTruePionPionFromHNMInvMassPt(nullptr),
+  fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt(nullptr),
+  fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt(nullptr),
+  fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt(nullptr),
+  fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt(nullptr),
+  fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt(nullptr),
+  fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt(nullptr),
+  fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt(nullptr),
+  fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt(nullptr),
+  fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt(nullptr),
+  fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt(nullptr),
+  fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt(nullptr),
+  fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt(nullptr),
+  fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt(nullptr),
+  fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt(nullptr),
+  fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt(nullptr),
+  fHistoTruePiPlPiMiNDMContaminationInvMassPt(nullptr),
+  fHistoDoubleCountTruePi0InvMassPt(nullptr),
+  fHistoDoubleCountTrueHNMInvMassPt(nullptr),
+  fHistoDoubleCountTrueConvGammaRPt(nullptr),
   fVectorDoubleCountTruePi0s(0),
   fVectorDoubleCountTrueHNMs(0),
   fVectorDoubleCountTrueConvGammas(0),
-  fHistoNEvents(NULL),
-  fHistoNGoodESDTracks(NULL),
-  fProfileEtaShift(NULL),
-  fHistoSPDClusterTrackletBackground(NULL),
+  fHistoNEvents(nullptr),
+  fHistoNGoodESDTracks(nullptr),
+  fProfileEtaShift(nullptr),
+  fHistoSPDClusterTrackletBackground(nullptr),
   fRandom(0),
   fnCuts(0),
   fiCut(0),
@@ -594,11 +688,11 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::UserCreateOutputObjects(
   }
 
   // Create the output container
-  if(fOutputContainer != NULL){
+  if(fOutputContainer != nullptr){
     delete fOutputContainer;
-    fOutputContainer            = NULL;
+    fOutputContainer            = nullptr;
   }
-  if(fOutputContainer == NULL){
+  if(fOutputContainer == nullptr){
     fOutputContainer            = new TList();
     fOutputContainer->SetOwner(kTRUE);
   }
@@ -626,43 +720,43 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::UserCreateOutputObjects(
   fHistoNEvents                 = new TH1I*[fnCuts];
   fHistoNGoodESDTracks          = new TH1I*[fnCuts];
   if(!fDoLightOutput){
-      fProfileEtaShift              = new TProfile*[fnCuts];
-      fHistoSPDClusterTrackletBackground = new TH2F*[fnCuts];
+    fProfileEtaShift              = new TProfile*[fnCuts];
+    fHistoSPDClusterTrackletBackground = new TH2F*[fnCuts];
 
-      if (fNDMRecoMode < 2){
-          fHistoConvGammaPt           = new TH1F*[fnCuts];
-          fHistoConvGammaEta          = new TH1F*[fnCuts];
-      }
-      if (fNDMRecoMode > 0){
-          fHistoClusterGammaPt        = new TH1F*[fnCuts];
-          fHistoClusterGammaEta       = new TH1F*[fnCuts];
-      }
-      fHistoNegPionPt               = new TH1F*[fnCuts];
-      fHistoPosPionPt               = new TH1F*[fnCuts];
-      fHistoNegPionPhi              = new TH1F*[fnCuts];
-      fHistoPosPionPhi              = new TH1F*[fnCuts];
-      fHistoPionPionInvMassPt       = new TH2F*[fnCuts];
+    if (fNDMRecoMode < 2){
+      fHistoConvGammaPt           = new TH1F*[fnCuts];
+      fHistoConvGammaEta          = new TH1F*[fnCuts];
+    }
+    if (fNDMRecoMode > 0){
+      fHistoClusterGammaPt        = new TH1F*[fnCuts];
+      fHistoClusterGammaEta       = new TH1F*[fnCuts];
+    }
+    fHistoNegPionPt               = new TH1F*[fnCuts];
+    fHistoPosPionPt               = new TH1F*[fnCuts];
+    fHistoNegPionPhi              = new TH1F*[fnCuts];
+    fHistoPosPionPhi              = new TH1F*[fnCuts];
+    fHistoPionPionInvMassPt       = new TH2F*[fnCuts];
 
-      if( fDoMesonQA>0 ) {
-          fHistoNegPionEta            = new TH1F*[fnCuts];
-          fHistoPosPionEta            = new TH1F*[fnCuts];
-          fHistoNegPionClsTPC         = new TH2F*[fnCuts];
-          fHistoPosPionClsTPC         = new TH2F*[fnCuts];
-          fHistoPionDCAxy             = new TH2F*[fnCuts];
-          fHistoPionDCAz              = new TH2F*[fnCuts];
-          fHistoPionTPCdEdxNSigma     = new TH2F*[fnCuts];
-          fHistoPionTPCdEdx           = new TH2F*[fnCuts];
-      }
+    if( fDoMesonQA>0 ) {
+      fHistoNegPionEta            = new TH1F*[fnCuts];
+      fHistoPosPionEta            = new TH1F*[fnCuts];
+      fHistoNegPionClsTPC         = new TH2F*[fnCuts];
+      fHistoPosPionClsTPC         = new TH2F*[fnCuts];
+      fHistoPionDCAxy             = new TH2F*[fnCuts];
+      fHistoPionDCAz              = new TH2F*[fnCuts];
+      fHistoPionTPCdEdxNSigma     = new TH2F*[fnCuts];
+      fHistoPionTPCdEdx           = new TH2F*[fnCuts];
+    }
 
 
-      fHistoAngleHNMesonPiPlPiMi    = new TH2F*[fnCuts];
-      fHistoAngleHNMesonNDM      = new TH2F*[fnCuts];
-      fHistoAngleHNMesonPiPl        = new TH2F*[fnCuts];
-      fHistoAngleHNMesonPiMi        = new TH2F*[fnCuts];
-      fHistoAngleNDMPiMi       = new TH2F*[fnCuts];
-      fHistoAnglePiPlPiMi         = new TH2F*[fnCuts];
-      fHistoAnglePiPlNDM       = new TH2F*[fnCuts];
-      fHistoAngleSum              = new TH2F*[fnCuts];
+    fHistoAngleHNMesonPiPlPiMi    = new TH2F*[fnCuts];
+    fHistoAngleHNMesonNDM      = new TH2F*[fnCuts];
+    fHistoAngleHNMesonPiPl        = new TH2F*[fnCuts];
+    fHistoAngleHNMesonPiMi        = new TH2F*[fnCuts];
+    fHistoAngleNDMPiMi       = new TH2F*[fnCuts];
+    fHistoAnglePiPlPiMi         = new TH2F*[fnCuts];
+    fHistoAnglePiPlNDM       = new TH2F*[fnCuts];
+    fHistoAngleSum              = new TH2F*[fnCuts];
   }
 
   fHistoGammaGammaInvMassPt               = new TH2F*[fnCuts];
@@ -748,97 +842,97 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::UserCreateOutputObjects(
     fHistoNGoodESDTracks[iCut]->GetYaxis()->SetTitle("N_{events}");
     fESDList[iCut]->Add(fHistoNGoodESDTracks[iCut]);
     if(!fDoLightOutput){
-        fProfileEtaShift[iCut]        = new TProfile("Eta Shift","Eta Shift",1, -0.5,0.5);
-        fESDList[iCut]->Add(fProfileEtaShift[iCut]);
-        fHistoSPDClusterTrackletBackground[iCut] = new TH2F("SPD tracklets vs SPD clusters","SPD tracklets vs SPD clusters",100,0,200,250,0,1000);
-        fHistoSPDClusterTrackletBackground[iCut]->GetXaxis()->SetTitle("N_{SPD tracklets}");
-        fHistoSPDClusterTrackletBackground[iCut]->GetYaxis()->SetTitle("N_{SPD clusters}");
-        fESDList[iCut]->Add(fHistoSPDClusterTrackletBackground[iCut]);
-        if (fNDMRecoMode < 2){
-            fHistoConvGammaPt[iCut]     = new TH1F("ESD_ConvGamma_Pt","ESD_ConvGamma_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-            fHistoConvGammaPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-            fHistoConvGammaPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,conv}");
-            fESDList[iCut]->Add(fHistoConvGammaPt[iCut]);
-            fHistoConvGammaEta[iCut]    = new TH1F("ESD_ConvGamma_Eta","ESD_ConvGamma_Eta",600,-1.5,1.5);
-            fHistoConvGammaEta[iCut]->GetXaxis()->SetTitle("#eta");
-            fHistoConvGammaEta[iCut]->GetYaxis()->SetTitle("N_{#gamma,conv}");
-            fESDList[iCut]->Add(fHistoConvGammaEta[iCut]);
-        }
-        if (fNDMRecoMode > 0){
-            fHistoClusterGammaPt[iCut]  = new TH1F("ESD_ClusterGamma_Pt","ESD_ClusterGamma_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-            fHistoClusterGammaPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-            fHistoClusterGammaPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,cluster}");
-            fESDList[iCut]->Add(fHistoClusterGammaPt[iCut]);
-            fHistoClusterGammaEta[iCut] = new TH1F("ESD_ClusterGamma_Eta","ESD_ClusterGamma_Eta",600,-1.5,1.5);
-            fHistoClusterGammaEta[iCut]->GetXaxis()->SetTitle("#eta");
-            fHistoClusterGammaEta[iCut]->GetYaxis()->SetTitle("N_{#gamma,cluster}");
-            fESDList[iCut]->Add(fHistoClusterGammaEta[iCut]);
-        }
-        fHistoNegPionPt[iCut]         = new TH1F("ESD_PrimaryNegPions_Pt","ESD_PrimaryNegPions_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-        fHistoNegPionPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-        fHistoNegPionPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
-        fESDList[iCut]->Add(fHistoNegPionPt[iCut]);
-        fHistoPosPionPt[iCut]         = new TH1F("ESD_PrimaryPosPions_Pt","ESD_PrimaryPosPions_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-        fHistoPosPionPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-        fHistoPosPionPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
-        fESDList[iCut]->Add(fHistoPosPionPt[iCut]);
-        fHistoNegPionPhi[iCut]        = new TH1F("ESD_PrimaryNegPions_Phi","ESD_PrimaryNegPions_Phi",360,0,2*TMath::Pi());
-        fHistoNegPionPhi[iCut]->GetXaxis()->SetTitle("#phi");
-        fHistoNegPionPhi[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
-        fESDList[iCut]->Add(fHistoNegPionPhi[iCut]);
-        fHistoPosPionPhi[iCut]        = new TH1F("ESD_PrimaryPosPions_Phi","ESD_PrimaryPosPions_Phi",360,0,2*TMath::Pi());
-        fHistoPosPionPhi[iCut]->GetXaxis()->SetTitle("#phi");
-        fHistoPosPionPhi[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
-        fESDList[iCut]->Add(fHistoPosPionPhi[iCut]);
-        fHistoPionPionInvMassPt[iCut] = new TH2F("ESD_PiPlusPiNeg_InvMassPt","ESD_PiPlusPiNeg_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-        fHistoPionPionInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
-        fHistoPionPionInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-        fESDList[iCut]->Add(fHistoPionPionInvMassPt[iCut]);
+      fProfileEtaShift[iCut]        = new TProfile("Eta Shift","Eta Shift",1, -0.5,0.5);
+      fESDList[iCut]->Add(fProfileEtaShift[iCut]);
+      fHistoSPDClusterTrackletBackground[iCut] = new TH2F("SPD tracklets vs SPD clusters","SPD tracklets vs SPD clusters",100,0,200,250,0,1000);
+      fHistoSPDClusterTrackletBackground[iCut]->GetXaxis()->SetTitle("N_{SPD tracklets}");
+      fHistoSPDClusterTrackletBackground[iCut]->GetYaxis()->SetTitle("N_{SPD clusters}");
+      fESDList[iCut]->Add(fHistoSPDClusterTrackletBackground[iCut]);
+      if (fNDMRecoMode < 2){
+        fHistoConvGammaPt[iCut]     = new TH1F("ESD_ConvGamma_Pt","ESD_ConvGamma_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+        fHistoConvGammaPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoConvGammaPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,conv}");
+        fESDList[iCut]->Add(fHistoConvGammaPt[iCut]);
+        fHistoConvGammaEta[iCut]    = new TH1F("ESD_ConvGamma_Eta","ESD_ConvGamma_Eta",600,-1.5,1.5);
+        fHistoConvGammaEta[iCut]->GetXaxis()->SetTitle("#eta");
+        fHistoConvGammaEta[iCut]->GetYaxis()->SetTitle("N_{#gamma,conv}");
+        fESDList[iCut]->Add(fHistoConvGammaEta[iCut]);
+      }
+      if (fNDMRecoMode > 0){
+        fHistoClusterGammaPt[iCut]  = new TH1F("ESD_ClusterGamma_Pt","ESD_ClusterGamma_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+        fHistoClusterGammaPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoClusterGammaPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,cluster}");
+        fESDList[iCut]->Add(fHistoClusterGammaPt[iCut]);
+        fHistoClusterGammaEta[iCut] = new TH1F("ESD_ClusterGamma_Eta","ESD_ClusterGamma_Eta",600,-1.5,1.5);
+        fHistoClusterGammaEta[iCut]->GetXaxis()->SetTitle("#eta");
+        fHistoClusterGammaEta[iCut]->GetYaxis()->SetTitle("N_{#gamma,cluster}");
+        fESDList[iCut]->Add(fHistoClusterGammaEta[iCut]);
+      }
+      fHistoNegPionPt[iCut]         = new TH1F("ESD_PrimaryNegPions_Pt","ESD_PrimaryNegPions_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+      fHistoNegPionPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+      fHistoNegPionPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
+      fESDList[iCut]->Add(fHistoNegPionPt[iCut]);
+      fHistoPosPionPt[iCut]         = new TH1F("ESD_PrimaryPosPions_Pt","ESD_PrimaryPosPions_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+      fHistoPosPionPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+      fHistoPosPionPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
+      fESDList[iCut]->Add(fHistoPosPionPt[iCut]);
+      fHistoNegPionPhi[iCut]        = new TH1F("ESD_PrimaryNegPions_Phi","ESD_PrimaryNegPions_Phi",360,0,2*TMath::Pi());
+      fHistoNegPionPhi[iCut]->GetXaxis()->SetTitle("#phi");
+      fHistoNegPionPhi[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
+      fESDList[iCut]->Add(fHistoNegPionPhi[iCut]);
+      fHistoPosPionPhi[iCut]        = new TH1F("ESD_PrimaryPosPions_Phi","ESD_PrimaryPosPions_Phi",360,0,2*TMath::Pi());
+      fHistoPosPionPhi[iCut]->GetXaxis()->SetTitle("#phi");
+      fHistoPosPionPhi[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
+      fESDList[iCut]->Add(fHistoPosPionPhi[iCut]);
+      fHistoPionPionInvMassPt[iCut] = new TH2F("ESD_PiPlusPiNeg_InvMassPt","ESD_PiPlusPiNeg_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+      fHistoPionPionInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+      fHistoPionPionInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+      fESDList[iCut]->Add(fHistoPionPionInvMassPt[iCut]);
 
-        if ( fDoMesonQA>0 ) {
-            fHistoNegPionEta[iCut]        = new TH1F("ESD_PrimaryNegPions_Eta","ESD_PrimaryNegPions_Eta",600,-1.5,1.5);
-            fHistoNegPionEta[iCut]->GetXaxis()->SetTitle("#eta");
-            fHistoNegPionEta[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
-            fESDList[iCut]->Add(fHistoNegPionEta[iCut]);
-            fHistoPosPionEta[iCut]        = new TH1F("ESD_PrimaryPosPions_Eta","ESD_PrimaryPosPions_Eta",600,-1.5,1.5);
-            fHistoPosPionEta[iCut]->GetXaxis()->SetTitle("#eta");
-            fHistoPosPionEta[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
-            fESDList[iCut]->Add(fHistoPosPionEta[iCut]);
-            fHistoNegPionClsTPC[iCut]     = new TH2F("ESD_PrimaryNegPions_ClsTPC","ESD_PrimaryNegPions_ClsTPC",100,0,1,400,0.,10.);
-            fHistoNegPionClsTPC[iCut]->GetXaxis()->SetTitle("N_{findable cls. TPC #pi^{-}}");
-            fHistoNegPionClsTPC[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-            fESDList[iCut]->Add(fHistoNegPionClsTPC[iCut]);
-            fHistoPosPionClsTPC[iCut]     = new TH2F("ESD_PrimaryPosPions_ClsTPC","ESD_PrimaryPosPions_ClsTPC",100,0,1,400,0.,10.);
-            fHistoPosPionClsTPC[iCut]->GetXaxis()->SetTitle("N_{findable cls. TPC #pi^{+}}");
-            fHistoPosPionClsTPC[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-            fESDList[iCut]->Add(fHistoPosPionClsTPC[iCut]);
-            fHistoPionDCAxy[iCut]         = new TH2F("ESD_PrimaryPions_DCAxy","ESD_PrimaryPions_DCAxy",800,-4.0,4.0,400,0.,10.);
-            fHistoPionDCAxy[iCut]->GetXaxis()->SetTitle("DCA_{xy}");
-            fHistoPionDCAxy[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-            fESDList[iCut]->Add(fHistoPionDCAxy[iCut]);
-            fHistoPionDCAz[iCut]          = new TH2F("ESD_PrimaryPions_DCAz","ESD_PrimaryPions_DCAz",800,-4.0,4.0,400,0.,10.);
-            fHistoPionDCAz[iCut]->GetXaxis()->SetTitle("DCA_{z}");
-            fHistoPionDCAz[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-            fESDList[iCut]->Add(fHistoPionDCAz[iCut]);
-            fHistoPionTPCdEdxNSigma[iCut] = new TH2F("ESD_PrimaryPions_TPCdEdx","ESD_PrimaryPions_TPCdEdx",150,0.05,20,400,-10,10);
-            fHistoPionTPCdEdxNSigma[iCut]->GetXaxis()->SetTitle("p (GeV/c)");
-            fHistoPionTPCdEdxNSigma[iCut]->GetYaxis()->SetTitle("#sigma_{PID,TPC}");
-            fESDList[iCut]->Add(fHistoPionTPCdEdxNSigma[iCut]);
-            fHistoPionTPCdEdx[iCut]       = new TH2F("ESD_PrimaryPions_TPCdEdxSignal","ESD_PrimaryPions_TPCdEdxSignal" ,150,0.05,20.0,800,0.0,200);
-            fHistoPionTPCdEdx[iCut]->GetXaxis()->SetTitle("p (GeV/c)");
-            fHistoPionTPCdEdx[iCut]->GetYaxis()->SetTitle("dE/dx signal (au)");
-            fESDList[iCut]->Add(fHistoPionTPCdEdx[iCut]);
-        }
-    fHistoGammaGammaInvMassPt[iCut]               = new TH2F("ESD_GammaGamma_InvMass_Pt","ESD_GammaGamma_InvMass_Pt",HistoNMassBinsDecayMeson,HistoMassRangeNDM[0],HistoMassRangeNDM[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-    fHistoGammaGammaInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#gamma #gamma} (GeV/c^{2})");
-    fHistoGammaGammaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-    fESDList[iCut]->Add(fHistoGammaGammaInvMassPt[iCut]);
+      if ( fDoMesonQA>0 ) {
+        fHistoNegPionEta[iCut]        = new TH1F("ESD_PrimaryNegPions_Eta","ESD_PrimaryNegPions_Eta",600,-1.5,1.5);
+        fHistoNegPionEta[iCut]->GetXaxis()->SetTitle("#eta");
+        fHistoNegPionEta[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
+        fESDList[iCut]->Add(fHistoNegPionEta[iCut]);
+        fHistoPosPionEta[iCut]        = new TH1F("ESD_PrimaryPosPions_Eta","ESD_PrimaryPosPions_Eta",600,-1.5,1.5);
+        fHistoPosPionEta[iCut]->GetXaxis()->SetTitle("#eta");
+        fHistoPosPionEta[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
+        fESDList[iCut]->Add(fHistoPosPionEta[iCut]);
+        fHistoNegPionClsTPC[iCut]     = new TH2F("ESD_PrimaryNegPions_ClsTPC","ESD_PrimaryNegPions_ClsTPC",100,0,1,400,0.,10.);
+        fHistoNegPionClsTPC[iCut]->GetXaxis()->SetTitle("N_{findable cls. TPC #pi^{-}}");
+        fHistoNegPionClsTPC[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+        fESDList[iCut]->Add(fHistoNegPionClsTPC[iCut]);
+        fHistoPosPionClsTPC[iCut]     = new TH2F("ESD_PrimaryPosPions_ClsTPC","ESD_PrimaryPosPions_ClsTPC",100,0,1,400,0.,10.);
+        fHistoPosPionClsTPC[iCut]->GetXaxis()->SetTitle("N_{findable cls. TPC #pi^{+}}");
+        fHistoPosPionClsTPC[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+        fESDList[iCut]->Add(fHistoPosPionClsTPC[iCut]);
+        fHistoPionDCAxy[iCut]         = new TH2F("ESD_PrimaryPions_DCAxy","ESD_PrimaryPions_DCAxy",800,-4.0,4.0,400,0.,10.);
+        fHistoPionDCAxy[iCut]->GetXaxis()->SetTitle("DCA_{xy}");
+        fHistoPionDCAxy[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+        fESDList[iCut]->Add(fHistoPionDCAxy[iCut]);
+        fHistoPionDCAz[iCut]          = new TH2F("ESD_PrimaryPions_DCAz","ESD_PrimaryPions_DCAz",800,-4.0,4.0,400,0.,10.);
+        fHistoPionDCAz[iCut]->GetXaxis()->SetTitle("DCA_{z}");
+        fHistoPionDCAz[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+        fESDList[iCut]->Add(fHistoPionDCAz[iCut]);
+        fHistoPionTPCdEdxNSigma[iCut] = new TH2F("ESD_PrimaryPions_TPCdEdx","ESD_PrimaryPions_TPCdEdx",150,0.05,20,400,-10,10);
+        fHistoPionTPCdEdxNSigma[iCut]->GetXaxis()->SetTitle("p (GeV/c)");
+        fHistoPionTPCdEdxNSigma[iCut]->GetYaxis()->SetTitle("#sigma_{PID,TPC}");
+        fESDList[iCut]->Add(fHistoPionTPCdEdxNSigma[iCut]);
+        fHistoPionTPCdEdx[iCut]       = new TH2F("ESD_PrimaryPions_TPCdEdxSignal","ESD_PrimaryPions_TPCdEdxSignal" ,150,0.05,20.0,800,0.0,200);
+        fHistoPionTPCdEdx[iCut]->GetXaxis()->SetTitle("p (GeV/c)");
+        fHistoPionTPCdEdx[iCut]->GetYaxis()->SetTitle("dE/dx signal (au)");
+        fESDList[iCut]->Add(fHistoPionTPCdEdx[iCut]);
+      }
+      fHistoGammaGammaInvMassPt[iCut]               = new TH2F("ESD_GammaGamma_InvMass_Pt","ESD_GammaGamma_InvMass_Pt",HistoNMassBinsDecayMeson,HistoMassRangeNDM[0],HistoMassRangeNDM[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+      fHistoGammaGammaInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#gamma #gamma} (GeV/c^{2})");
+      fHistoGammaGammaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+      fESDList[iCut]->Add(fHistoGammaGammaInvMassPt[iCut]);
 
-    fHistoGammaGammaInvMassPtBeforeCuts[iCut]               = new TH2F("ESD_GammaGamma_InvMass_Pt_Before_Cuts","ESD_GammaGamma_InvMass_Pt_Before_Cuts",HistoNMassBinsDecayMeson,HistoMassRangeNDM[0],HistoMassRangeNDM[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-    fHistoGammaGammaInvMassPtBeforeCuts[iCut]->GetXaxis()->SetTitle("M_{#gamma #gamma} (GeV/c^{2})");
-    fHistoGammaGammaInvMassPtBeforeCuts[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-    fESDList[iCut]->Add(fHistoGammaGammaInvMassPtBeforeCuts[iCut]);
-  }
+      fHistoGammaGammaInvMassPtBeforeCuts[iCut]               = new TH2F("ESD_GammaGamma_InvMass_Pt_Before_Cuts","ESD_GammaGamma_InvMass_Pt_Before_Cuts",HistoNMassBinsDecayMeson,HistoMassRangeNDM[0],HistoMassRangeNDM[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+      fHistoGammaGammaInvMassPtBeforeCuts[iCut]->GetXaxis()->SetTitle("M_{#gamma #gamma} (GeV/c^{2})");
+      fHistoGammaGammaInvMassPtBeforeCuts[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+      fESDList[iCut]->Add(fHistoGammaGammaInvMassPtBeforeCuts[iCut]);
+    }
     fHistoMotherInvMassPt[iCut]                   = new TH2F("ESD_Mother_InvMass_Pt","ESD_Mother_InvMass_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
     fHistoMotherInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} (GeV/c^{2})",NameNDMLatex.Data()));
     fHistoMotherInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
@@ -862,16 +956,16 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::UserCreateOutputObjects(
     fHistoBackInvMassPtGroup4[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
     if(!(((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->UseLikeSignMixing())){
        fESDList[iCut]->Add(fHistoBackInvMassPtGroup1[iCut]);
-        fESDList[iCut]->Add(fHistoBackInvMassPtGroup2[iCut]);
-        fESDList[iCut]->Add(fHistoBackInvMassPtGroup3[iCut]);
-        fESDList[iCut]->Add(fHistoBackInvMassPtGroup4[iCut]);
+       fESDList[iCut]->Add(fHistoBackInvMassPtGroup2[iCut]);
+       fESDList[iCut]->Add(fHistoBackInvMassPtGroup3[iCut]);
+       fESDList[iCut]->Add(fHistoBackInvMassPtGroup4[iCut]);
     }
 
     fHistoMotherLikeSignBackInvMassPt[iCut]  = new TH2F("ESD_Background_LikeSign_InvMass_Pt","ESD_Background_LikeSign_InvMass_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
     fHistoMotherLikeSignBackInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{#pm} #pi^{#pm} %s} (GeV/c^{2})",NameNDMLatex.Data()));
     fHistoMotherLikeSignBackInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
     if(((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->UseLikeSignMixing()){
-        fESDList[iCut]->Add(fHistoMotherLikeSignBackInvMassPt[iCut]);
+      fESDList[iCut]->Add(fHistoMotherLikeSignBackInvMassPt[iCut]);
     }
     fHistoMotherInvMassSubNDM[iCut]                       = new TH2F("ESD_InvMass_Mother_Sub_InvMass_Neutral_Pt","ESD_InvMass_Mother_Sub_InvMass_Neutral_Pt",HistoNMassBinsSub,HistoMassRangeSub[0],HistoMassRangeSub[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
     fHistoMotherInvMassSubNDM[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} - (M_{%s}-M_{%s},PDG}) (GeV/c^{2})",NameNDMLatex.Data(),NameNDMLatex.Data(),NameNDMLatex.Data()));
@@ -896,17 +990,17 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::UserCreateOutputObjects(
     fHistoBackInvMassPtGroup4SubNDM[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} - (M_{%s}-M_{%s},PDG}) (GeV/c^{2})",NameNDMLatex.Data(),NameNDMLatex.Data(),NameNDMLatex.Data()));
     fHistoBackInvMassPtGroup4SubNDM[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
     if(!(((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->UseLikeSignMixing())){
-        fESDList[iCut]->Add(fHistoBackInvMassPtGroup4SubNDM[iCut]);
-        fESDList[iCut]->Add(fHistoBackInvMassPtGroup1SubNDM[iCut]);
-        fESDList[iCut]->Add(fHistoBackInvMassPtGroup2SubNDM[iCut]);
-        fESDList[iCut]->Add(fHistoBackInvMassPtGroup3SubNDM[iCut]);
+      fESDList[iCut]->Add(fHistoBackInvMassPtGroup4SubNDM[iCut]);
+      fESDList[iCut]->Add(fHistoBackInvMassPtGroup1SubNDM[iCut]);
+      fESDList[iCut]->Add(fHistoBackInvMassPtGroup2SubNDM[iCut]);
+      fESDList[iCut]->Add(fHistoBackInvMassPtGroup3SubNDM[iCut]);
     }
     fHistoMotherLikeSignBackInvMassSubNDMPt[iCut]    = new TH2F("ESD_Background_LikeSign_InvMass_Sub_InvMass_Neutral_Pt","ESD_Background_LikeSign_InvMass_Sub_InvMass_Neutral_Pt",
                                                                 HistoNMassBinsSub,HistoMassRangeSub[0],HistoMassRangeSub[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
     fHistoMotherLikeSignBackInvMassSubNDMPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{#pm} #pi^{#pm} %s} - M_{%s} (GeV/c^{2})",NameNDMLatex.Data(),NameNDMLatex.Data()));
     fHistoMotherLikeSignBackInvMassSubNDMPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
     if(((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->UseLikeSignMixing()){
-        fESDList[iCut]->Add(fHistoMotherLikeSignBackInvMassSubNDMPt[iCut]);
+      fESDList[iCut]->Add(fHistoMotherLikeSignBackInvMassSubNDMPt[iCut]);
     }
     fHistoMotherInvMassFixedPzNDM[iCut]                     = new TH2F("ESD_InvMass_Mother_FixedPz_Neutral_Pt","ESD_Mother_InvMass_FixedPz_Neutral_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
     fHistoMotherInvMassFixedPzNDM[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} (GeV/c^{2})",NameNDMLatex.Data()));
@@ -926,50 +1020,50 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::UserCreateOutputObjects(
     fHistoBackInvMassPtGroup4FixedPzNDM[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} (GeV/c^{2})",NameNDMLatex.Data()));
     fHistoBackInvMassPtGroup4FixedPzNDM[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
     if(!(((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->UseLikeSignMixing())){
-        fESDList[iCut]->Add(fHistoBackInvMassPtGroup1FixedPzNDM[iCut]);
-        fESDList[iCut]->Add(fHistoBackInvMassPtGroup2FixedPzNDM[iCut]);
-        fESDList[iCut]->Add(fHistoBackInvMassPtGroup3FixedPzNDM[iCut]);
-        fESDList[iCut]->Add(fHistoBackInvMassPtGroup4FixedPzNDM[iCut]);
+      fESDList[iCut]->Add(fHistoBackInvMassPtGroup1FixedPzNDM[iCut]);
+      fESDList[iCut]->Add(fHistoBackInvMassPtGroup2FixedPzNDM[iCut]);
+      fESDList[iCut]->Add(fHistoBackInvMassPtGroup3FixedPzNDM[iCut]);
+      fESDList[iCut]->Add(fHistoBackInvMassPtGroup4FixedPzNDM[iCut]);
     }
     fHistoMotherLikeSignBackInvMassFixedPzNDMPt[iCut]  = new TH2F("ESD_Background_LikeSign_InvMass_FixedPz_Neutral_Pt","ESD_Background_LikeSign_InvMass_FixedPz_Neutral_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
     fHistoMotherLikeSignBackInvMassFixedPzNDMPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{#pm} #pi^{#pm} %s} (GeV/c^{2})",NameNDMLatex.Data()));
     fHistoMotherLikeSignBackInvMassFixedPzNDMPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
     if(((AliConversionMesonCuts*)fMesonCutArray->At(iCut))->UseLikeSignMixing()){
-        fESDList[iCut]->Add(fHistoMotherLikeSignBackInvMassFixedPzNDMPt[iCut]);
+      fESDList[iCut]->Add(fHistoMotherLikeSignBackInvMassFixedPzNDMPt[iCut]);
     }
     if(!fDoLightOutput){
-        fHistoAngleHNMesonPiPlPiMi[iCut]      = new TH2F(Form("ESD_Mother_Angle%sNegPionsPosPions_Pt",NameNeutralMesonAnalyzed.Data()),Form("ESD_Mother_Angle%sNegPionsPosPions_Pt",NameNeutralMesonAnalyzed.Data()),HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
-        fHistoAngleHNMesonPiPlPiMi[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-        fHistoAngleHNMesonPiPlPiMi[iCut]->GetYaxis()->SetTitle("#angle (meson,#pi^{+}#pi^{-})");
-        fESDList[iCut]->Add(fHistoAngleHNMesonPiPlPiMi[iCut]);
-        fHistoAngleHNMesonPiMi[iCut]          = new TH2F(Form("ESD_Mother_Angle%sNegPions_Pt",NameNeutralMesonAnalyzed.Data()),Form("ESD_Mother_Angle%sNegPions_Pt",NameNeutralMesonAnalyzed.Data()),HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
-        fHistoAngleHNMesonPiMi[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-        fHistoAngleHNMesonPiMi[iCut]->GetYaxis()->SetTitle("#angle (meson,#pi^{-})");
-        fESDList[iCut]->Add(fHistoAngleHNMesonPiMi[iCut]);
-        fHistoAngleHNMesonPiPl[iCut]          = new TH2F(Form("ESD_Mother_Angle%sPosPions_Pt",NameNeutralMesonAnalyzed.Data()),Form("ESD_Mother_Angle%sPosPions_Pt",NameNeutralMesonAnalyzed.Data()),HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
-        fHistoAngleHNMesonPiPl[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-        fHistoAngleHNMesonPiPl[iCut]->GetYaxis()->SetTitle("#angle (meson,#pi^{+})");
-        fESDList[iCut]->Add(fHistoAngleHNMesonPiPl[iCut]);
-        fHistoAngleHNMesonNDM[iCut]        = new TH2F(Form("ESD_Mother_Angle%s%s_Pt",NameNeutralMesonAnalyzed.Data(),NameNDM.Data()),Form("ESD_Mother_Angle%s%s_Pt",NameNeutralMesonAnalyzed.Data(),NameNDM.Data()),HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
-        fHistoAngleHNMesonNDM[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-        fHistoAngleHNMesonNDM[iCut]->GetYaxis()->SetTitle(Form("#angle (meson,%s)",NameNDMLatex.Data()));
-        fESDList[iCut]->Add(fHistoAngleHNMesonNDM[iCut]);
-        fHistoAnglePiPlNDM[iCut]         = new TH2F(Form("ESD_Mother_AnglePosPions%s_Pt",NameNDM.Data()),Form("ESD_Mother_AnglePosPions%s_Pt",NameNDM.Data()),HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
-        fHistoAnglePiPlNDM[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-        fHistoAnglePiPlNDM[iCut]->GetYaxis()->SetTitle(Form("#angle (#pi^{+},%s)",NameNDMLatex.Data()));
-        fESDList[iCut]->Add(fHistoAnglePiPlNDM[iCut]);
-        fHistoAnglePiPlPiMi[iCut]           = new TH2F("ESD_Mother_AnglePosPionsNegPions_Pt","ESD_Mother_AnglePosPionsNegPions_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
-        fHistoAnglePiPlPiMi[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-        fHistoAnglePiPlPiMi[iCut]->GetYaxis()->SetTitle("#angle (#pi^{+},#pi^{-})");
-        fESDList[iCut]->Add(fHistoAnglePiPlPiMi[iCut]);
-        fHistoAngleNDMPiMi[iCut]         = new TH2F(Form("ESD_Mother_Angle%sNegPions_Pt",NameNDM.Data()),Form("ESD_Mother_Angle%sNegPions_Pt",NameNDM.Data()),HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
-        fHistoAngleNDMPiMi[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-        fHistoAngleNDMPiMi[iCut]->GetYaxis()->SetTitle(Form("#angle (%s,#pi^{-})",NameNDMLatex.Data()));
-        fESDList[iCut]->Add(fHistoAngleNDMPiMi[iCut]);
-        fHistoAngleSum[iCut]                = new TH2F("ESD_Mother_AngleSum_Pt","ESD_Mother_AngleSum_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1],720,0,2*TMath::Pi());
-        fHistoAngleSum[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-        fHistoAngleSum[iCut]->GetYaxis()->SetTitle("#sum #angle");
-        fESDList[iCut]->Add(fHistoAngleSum[iCut]);
+      fHistoAngleHNMesonPiPlPiMi[iCut]      = new TH2F(Form("ESD_Mother_Angle%sNegPionsPosPions_Pt",NameNeutralMesonAnalyzed.Data()),Form("ESD_Mother_Angle%sNegPionsPosPions_Pt",NameNeutralMesonAnalyzed.Data()),HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
+      fHistoAngleHNMesonPiPlPiMi[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+      fHistoAngleHNMesonPiPlPiMi[iCut]->GetYaxis()->SetTitle("#angle (meson,#pi^{+}#pi^{-})");
+      fESDList[iCut]->Add(fHistoAngleHNMesonPiPlPiMi[iCut]);
+      fHistoAngleHNMesonPiMi[iCut]          = new TH2F(Form("ESD_Mother_Angle%sNegPions_Pt",NameNeutralMesonAnalyzed.Data()),Form("ESD_Mother_Angle%sNegPions_Pt",NameNeutralMesonAnalyzed.Data()),HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
+      fHistoAngleHNMesonPiMi[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+      fHistoAngleHNMesonPiMi[iCut]->GetYaxis()->SetTitle("#angle (meson,#pi^{-})");
+      fESDList[iCut]->Add(fHistoAngleHNMesonPiMi[iCut]);
+      fHistoAngleHNMesonPiPl[iCut]          = new TH2F(Form("ESD_Mother_Angle%sPosPions_Pt",NameNeutralMesonAnalyzed.Data()),Form("ESD_Mother_Angle%sPosPions_Pt",NameNeutralMesonAnalyzed.Data()),HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
+      fHistoAngleHNMesonPiPl[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+      fHistoAngleHNMesonPiPl[iCut]->GetYaxis()->SetTitle("#angle (meson,#pi^{+})");
+      fESDList[iCut]->Add(fHistoAngleHNMesonPiPl[iCut]);
+      fHistoAngleHNMesonNDM[iCut]        = new TH2F(Form("ESD_Mother_Angle%s%s_Pt",NameNeutralMesonAnalyzed.Data(),NameNDM.Data()),Form("ESD_Mother_Angle%s%s_Pt",NameNeutralMesonAnalyzed.Data(),NameNDM.Data()),HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
+      fHistoAngleHNMesonNDM[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+      fHistoAngleHNMesonNDM[iCut]->GetYaxis()->SetTitle(Form("#angle (meson,%s)",NameNDMLatex.Data()));
+      fESDList[iCut]->Add(fHistoAngleHNMesonNDM[iCut]);
+      fHistoAnglePiPlNDM[iCut]         = new TH2F(Form("ESD_Mother_AnglePosPions%s_Pt",NameNDM.Data()),Form("ESD_Mother_AnglePosPions%s_Pt",NameNDM.Data()),HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
+      fHistoAnglePiPlNDM[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+      fHistoAnglePiPlNDM[iCut]->GetYaxis()->SetTitle(Form("#angle (#pi^{+},%s)",NameNDMLatex.Data()));
+      fESDList[iCut]->Add(fHistoAnglePiPlNDM[iCut]);
+      fHistoAnglePiPlPiMi[iCut]           = new TH2F("ESD_Mother_AnglePosPionsNegPions_Pt","ESD_Mother_AnglePosPionsNegPions_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
+      fHistoAnglePiPlPiMi[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+      fHistoAnglePiPlPiMi[iCut]->GetYaxis()->SetTitle("#angle (#pi^{+},#pi^{-})");
+      fESDList[iCut]->Add(fHistoAnglePiPlPiMi[iCut]);
+      fHistoAngleNDMPiMi[iCut]         = new TH2F(Form("ESD_Mother_Angle%sNegPions_Pt",NameNDM.Data()),Form("ESD_Mother_Angle%sNegPions_Pt",NameNDM.Data()),HistoNPtBins,HistoPtRange[0],HistoPtRange[1],360,0,TMath::Pi());
+      fHistoAngleNDMPiMi[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+      fHistoAngleNDMPiMi[iCut]->GetYaxis()->SetTitle(Form("#angle (%s,#pi^{-})",NameNDMLatex.Data()));
+      fESDList[iCut]->Add(fHistoAngleNDMPiMi[iCut]);
+      fHistoAngleSum[iCut]                = new TH2F("ESD_Mother_AngleSum_Pt","ESD_Mother_AngleSum_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1],720,0,2*TMath::Pi());
+      fHistoAngleSum[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+      fHistoAngleSum[iCut]->GetYaxis()->SetTitle("#sum #angle");
+      fESDList[iCut]->Add(fHistoAngleSum[iCut]);
     }
     if ( fDoMesonQA>0 && (!fDoLightOutput) ) {
       TAxis *AxisAfter        = fHistoPionTPCdEdxNSigma[iCut]->GetXaxis();
@@ -997,73 +1091,123 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::UserCreateOutputObjects(
     // True Histogramms
     fTrueList                               = new TList*[fnCuts];
     if(!fDoLightOutput){
-        if (fNDMRecoMode < 2){
-            fHistoTrueConvGammaPt                 = new TH1F*[fnCuts];
-            fHistoDoubleCountTrueConvGammaRPt     = new TH2F*[fnCuts];
-            fHistoTrueConvGammaFromNeutralMesonPt = new TH1F*[fnCuts];
-        }
-        if (fNDMRecoMode > 0){
-            fHistoTrueClusterGammaPt                  = new TH1F*[fnCuts];
-            fHistoTrueClusterGammaFromNeutralMesonPt  = new TH1F*[fnCuts];
-        }
-        fHistoTruePosPionPt                     = new TH1F*[fnCuts];
-        fHistoTrueNegPionPt                     = new TH1F*[fnCuts];
-        fHistoTruePosPionFromNeutralMesonPt     = new TH1F*[fnCuts];
-        fHistoTrueNegPionFromNeutralMesonPt     = new TH1F*[fnCuts];
+      if (fNDMRecoMode < 2){
+        fHistoTrueConvGammaPt                 = new TH1F*[fnCuts];
+        fHistoDoubleCountTrueConvGammaRPt     = new TH2F*[fnCuts];
+        fHistoTrueConvGammaFromNeutralMesonPt = new TH1F*[fnCuts];
+      }
+      if (fNDMRecoMode > 0){
+        fHistoTrueClusterGammaPt                  = new TH1F*[fnCuts];
+        fHistoTrueClusterGammaFromNeutralMesonPt  = new TH1F*[fnCuts];
+      }
+      fHistoTruePosPionPt                     = new TH1F*[fnCuts];
+      fHistoTrueNegPionPt                     = new TH1F*[fnCuts];
+      fHistoTruePosPionFromNeutralMesonPt     = new TH1F*[fnCuts];
+      fHistoTrueNegPionFromNeutralMesonPt     = new TH1F*[fnCuts];
 
 
-        fHistoMCAllGammaPt                      = new TH1F*[fnCuts];
-        if (fNDMRecoMode < 2){
-            fHistoMCConvGammaPt                   = new TH1F*[fnCuts];
-        }
-        fHistoMCAllPosPionsPt                   = new TH1F*[fnCuts];
-        fHistoMCAllNegPionsPt                   = new TH1F*[fnCuts];
-        fHistoMCGammaFromNeutralMesonPt         = new TH1F*[fnCuts];
-        fHistoMCPosPionsFromNeutralMesonPt      = new TH1F*[fnCuts];
-        fHistoMCNegPionsFromNeutralMesonPt      = new TH1F*[fnCuts];
+      fHistoMCAllGammaPt                      = new TH1F*[fnCuts];
+      if (fNDMRecoMode < 2){
+        fHistoMCConvGammaPt                   = new TH1F*[fnCuts];
+      }
+      fHistoMCAllPosPionsPt                   = new TH1F*[fnCuts];
+      fHistoMCAllNegPionsPt                   = new TH1F*[fnCuts];
+      fHistoMCGammaFromNeutralMesonPt         = new TH1F*[fnCuts];
+      fHistoMCPosPionsFromNeutralMesonPt      = new TH1F*[fnCuts];
+      fHistoMCNegPionsFromNeutralMesonPt      = new TH1F*[fnCuts];
+
+      if(fDoMesonQA > 0){
+        fHistoMCAllMesonPt                      = new TH1F*[fnCuts];
+        fHistoMCAllMesonEta                     = new TH1F*[fnCuts];
+        fHistoMCAllMesonPhi                     = new TH1F*[fnCuts];
+        fHistoMCMesonFromNeutralMesonPt         = new TH1F*[fnCuts];
+        fHistoMCMesonFromNeutralMesonEta        = new TH1F*[fnCuts];
+        fHistoMCMesonFromNeutralMesonPhi        = new TH1F*[fnCuts];
+        fHistoMCAllPosPionsEta                        = new TH1F*[fnCuts];
+        fHistoMCAllPosPionsPhi                        = new TH1F*[fnCuts];
+        fHistoMCAllNegPionsEta                        = new TH1F*[fnCuts];
+        fHistoMCAllNegPionsPhi                        = new TH1F*[fnCuts];
+        fHistoMCPosPionsFromNeutralMesonEta           = new TH1F*[fnCuts];
+        fHistoMCPosPionsFromNeutralMesonPhi           = new TH1F*[fnCuts];
+        fHistoMCNegPionsFromNeutralMesonEta           = new TH1F*[fnCuts];
+        fHistoMCNegPionsFromNeutralMesonPhi           = new TH1F*[fnCuts];
+        fHistoMCHeavyAllPt                            = new TH1F*[fnCuts];
+        fHistoMCHeavyAllEta                           = new TH1F*[fnCuts];
+        fHistoMCHeavyAllPhi                           = new TH1F*[fnCuts];
+        fHistoMCHeavyChannelPt                        = new TH1F*[fnCuts];
+        fHistoMCHeavyChannelEta                       = new TH1F*[fnCuts];
+        fHistoMCHeavyChannelPhi                       = new TH1F*[fnCuts];
+        fHistMCChannelNDMFromHeavyPt                  = new TH1F*[fnCuts];
+        fHistMCChannelNDMFromHeavyEta                 = new TH1F*[fnCuts];
+        fHistMCChannelNDMFromHeavyPhi                 = new TH1F*[fnCuts];
+        fHistMCChannelPiPlusFromHeavyPt               = new TH1F*[fnCuts];
+        fHistMCChannelPiPlusFromHeavyEta              = new TH1F*[fnCuts];
+        fHistMCChannelPiPlusFromHeavyPhi              = new TH1F*[fnCuts];
+        fHistMCChannelPiMinusFromHeavyPt              = new TH1F*[fnCuts];
+        fHistMCChannelPiMinusFromHeavyEta             = new TH1F*[fnCuts];
+        fHistMCChannelPiPMinusFromHeavyPhi            = new TH1F*[fnCuts];
+        fHistMCChannelNDMPtHeavyPt                    = new TH2F*[fnCuts];
+        fHistMCChannelPiPlusPtHeavyPt                 = new TH2F*[fnCuts];
+        fHistMCChannelPiMinusPtHeavyPt                = new TH2F*[fnCuts];
+        fHistoMCHeavyReconstructiblePt                = new TH1F*[fnCuts];
+        fHistoMCHeavyReconstructibleEta               = new TH1F*[fnCuts];
+        fHistoMCHeavyReconstructiblePhi               = new TH1F*[fnCuts];
+        fHistMCReconstructibleNDMFromHeavyPt          = new TH1F*[fnCuts];
+        fHistMCReconstructibleNDMFromHeavyEta         = new TH1F*[fnCuts];
+        fHistMCReconstructibleNDMFromHeavyPhi         = new TH1F*[fnCuts];
+        fHistMCReconstructiblePiPlusFromHeavyPt       = new TH1F*[fnCuts];
+        fHistMCReconstructiblePiPlusFromHeavyEta      = new TH1F*[fnCuts];
+        fHistMCReconstructiblePiPlusFromHeavyPhi      = new TH1F*[fnCuts];
+        fHistMCReconstructiblePiMinusFromHeavyPt      = new TH1F*[fnCuts];
+        fHistMCReconstructiblePiMinusFromHeavyEta     = new TH1F*[fnCuts];
+        fHistMCReconstructiblePiPMinusFromHeavyPhi    = new TH1F*[fnCuts];
+        fHistMCReconstructibleNDMPtHeavyPt            = new TH2F*[fnCuts];
+        fHistMCReconstructiblePiPlusPtHeavyPt         = new TH2F*[fnCuts];
+        fHistMCReconstructiblePiMinusPtHeavyPt        = new TH2F*[fnCuts];
+      }
     }
     fHistoMCHNMPiPlPiMiNDMPt                     = new TH1F*[fnCuts];
     fHistoMCHNMPiPlPiMiNDMInAccPt                = new TH1F*[fnCuts];
     if(!fDoLightOutput){
-        fHistoDoubleCountTruePi0InvMassPt               = new TH2F*[fnCuts];
-        fHistoDoubleCountTrueHNMInvMassPt               = new TH2F*[fnCuts];
+      fHistoDoubleCountTruePi0InvMassPt               = new TH2F*[fnCuts];
+      fHistoDoubleCountTrueHNMInvMassPt               = new TH2F*[fnCuts];
     }
     fHistoTrueMotherPiPlPiMiNDMInvMassPt         = new TH2F*[fnCuts];
     fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt      = new TH2F*[fnCuts];
     if(!fDoLightOutput){
-        fHistoTrueMotherGammaGammaInvMassPt             = new TH2F*[fnCuts];
-        fHistoTrueMotherGammaGammaFromHNMInvMassPt      = new TH2F*[fnCuts];
-        fHistoTrueAngleSum                              = new TH2F*[fnCuts];
+      fHistoTrueMotherGammaGammaInvMassPt             = new TH2F*[fnCuts];
+      fHistoTrueMotherGammaGammaFromHNMInvMassPt      = new TH2F*[fnCuts];
+      fHistoTrueAngleSum                              = new TH2F*[fnCuts];
     }
     if(!fDoLightOutput){
-        if (fDoMesonQA>0){
-            fHistoTruePionPionInvMassPt                               = new TH2F*[fnCuts];
-            fHistoTruePionPionFromSameMotherInvMassPt                 = new TH2F*[fnCuts];
-            fHistoTruePionPionFromHNMInvMassPt                        = new TH2F*[fnCuts];
+      if (fDoMesonQA>0){
+        fHistoTruePionPionInvMassPt                               = new TH2F*[fnCuts];
+        fHistoTruePionPionFromSameMotherInvMassPt                 = new TH2F*[fnCuts];
+        fHistoTruePionPionFromHNMInvMassPt                        = new TH2F*[fnCuts];
 
-            fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt              = new TH2F*[fnCuts];
-            fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt            = new TH2F*[fnCuts];
-            fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt              = new TH2F*[fnCuts];
-            fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt         = new TH2F*[fnCuts];
-            fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt              = new TH2F*[fnCuts];
-            fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt              = new TH2F*[fnCuts];
-            fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt            = new TH2F*[fnCuts];
-            fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt          = new TH2F*[fnCuts];
-            fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt            = new TH2F*[fnCuts];
-            fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt            = new TH2F*[fnCuts];
-            fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt            = new TH2F*[fnCuts];
-            fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt          = new TH2F*[fnCuts];
-            fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt            = new TH2F*[fnCuts];
-            fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt            = new TH2F*[fnCuts];
-            fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt       = new TH2F*[fnCuts];
-            fHistoTruePiPlPiMiNDMContaminationInvMassPt            = new TH2F*[fnCuts];
-            if (fDoMesonQA>1){
-                fTrueTreeList                                           = new TList*[fnCuts];
-                fTreePiPiSameMother                                     = new TTree*[fnCuts];
-                fTreePiPiPiSameMother                                   = new TTree*[fnCuts];
-                fTreeEventInfoHNM                                       = new TTree*[fnCuts];
-            }
+        fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt              = new TH2F*[fnCuts];
+        fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt            = new TH2F*[fnCuts];
+        fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt              = new TH2F*[fnCuts];
+        fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt         = new TH2F*[fnCuts];
+        fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt              = new TH2F*[fnCuts];
+        fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt              = new TH2F*[fnCuts];
+        fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt            = new TH2F*[fnCuts];
+        fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt          = new TH2F*[fnCuts];
+        fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt            = new TH2F*[fnCuts];
+        fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt            = new TH2F*[fnCuts];
+        fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt            = new TH2F*[fnCuts];
+        fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt          = new TH2F*[fnCuts];
+        fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt            = new TH2F*[fnCuts];
+        fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt            = new TH2F*[fnCuts];
+        fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt       = new TH2F*[fnCuts];
+        fHistoTruePiPlPiMiNDMContaminationInvMassPt            = new TH2F*[fnCuts];
+        if (fDoMesonQA>1){
+          fTrueTreeList                                           = new TList*[fnCuts];
+          fTreePiPiSameMother                                     = new TTree*[fnCuts];
+          fTreePiPiPiSameMother                                   = new TTree*[fnCuts];
+          fTreeEventInfoHNM                                       = new TTree*[fnCuts];
         }
+      }
     }
 
     for(Int_t iCut = 0; iCut<fnCuts;iCut++){
@@ -1098,37 +1242,235 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::UserCreateOutputObjects(
       fCutFolder[iCut]->Add(fMCList[iCut]);
 
       if(!fDoLightOutput){
-          fHistoMCAllGammaPt[iCut]          = new TH1F("MC_AllGamma_Pt","MC_AllGamma_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-          fHistoMCAllGammaPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-          fHistoMCAllGammaPt[iCut]->GetYaxis()->SetTitle("N_{#gamma}");
-          fMCList[iCut]->Add(fHistoMCAllGammaPt[iCut]);
-          if (fNDMRecoMode < 2){
-              fHistoMCConvGammaPt[iCut]       = new TH1F("MC_ConvGamma_Pt","MC_ConvGamma_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoMCConvGammaPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-              fHistoMCConvGammaPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,conv}");
-              fMCList[iCut]->Add(fHistoMCConvGammaPt[iCut]);
-          }
+        fHistoMCAllGammaPt[iCut]          = new TH1F("MC_AllGamma_Pt","MC_AllGamma_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+        fHistoMCAllGammaPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoMCAllGammaPt[iCut]->GetYaxis()->SetTitle("N_{#gamma}");
+        fMCList[iCut]->Add(fHistoMCAllGammaPt[iCut]);
+        if (fNDMRecoMode < 2){
+          fHistoMCConvGammaPt[iCut]       = new TH1F("MC_ConvGamma_Pt","MC_ConvGamma_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoMCConvGammaPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+          fHistoMCConvGammaPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,conv}");
+          fMCList[iCut]->Add(fHistoMCConvGammaPt[iCut]);
+        }
+        fHistoMCAllPosPionsPt[iCut]               = new TH1F("MC_AllPosPions_Pt","MC_AllPosPions_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+        fHistoMCAllPosPionsPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoMCAllPosPionsPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
+        fMCList[iCut]->Add(fHistoMCAllPosPionsPt[iCut]);
+        fHistoMCAllNegPionsPt[iCut]               = new TH1F("MC_AllNegPions_Pt","MC_AllNegPions_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+        fHistoMCAllNegPionsPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoMCAllNegPionsPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
+        fMCList[iCut]->Add(fHistoMCAllNegPionsPt[iCut]);
+        fHistoMCPosPionsFromNeutralMesonEta[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
+        fMCList[iCut]->Add(fHistoMCPosPionsFromNeutralMesonEta[iCut]);
+        fHistoMCPosPionsFromNeutralMesonPhi[iCut]  = new TH1F("MC_PosPionsFromNeutralMeson_Phi","MC_PosPionsFromNeutralMeson_Phi", 200, 0., TMath::TwoPi());
+        fHistoMCPosPionsFromNeutralMesonPhi[iCut]->GetXaxis()->SetTitle("#eta");
+        fHistoMCPosPionsFromNeutralMesonPhi[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
+        fMCList[iCut]->Add(fHistoMCPosPionsFromNeutralMesonPhi[iCut]);
+        fHistoMCNegPionsFromNeutralMesonPt[iCut]  = new TH1F("MC_NegPionsFromNeutralMeson_Pt","MC_NegPionsFromNeutralMeson_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+        fHistoMCNegPionsFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoMCNegPionsFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
+        fMCList[iCut]->Add(fHistoMCNegPionsFromNeutralMesonPt[iCut]);
 
-          fHistoMCAllPosPionsPt[iCut]               = new TH1F("MC_AllPosPions_Pt","MC_AllPosPions_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-          fHistoMCAllPosPionsPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-          fHistoMCAllPosPionsPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
-          fMCList[iCut]->Add(fHistoMCAllPosPionsPt[iCut]);
-          fHistoMCAllNegPionsPt[iCut]               = new TH1F("MC_AllNegPions_Pt","MC_AllNegPions_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-          fHistoMCAllNegPionsPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-          fHistoMCAllNegPionsPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
-          fMCList[iCut]->Add(fHistoMCAllNegPionsPt[iCut]);
-          fHistoMCGammaFromNeutralMesonPt[iCut]     = new TH1F("MC_GammaFromNeutralMeson_Pt","MC_GammaFromNeutralMeson_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-          fHistoMCGammaFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-          fHistoMCGammaFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle("N_{#gamma}");
-          fMCList[iCut]->Add(fHistoMCGammaFromNeutralMesonPt[iCut]);
-          fHistoMCPosPionsFromNeutralMesonPt[iCut]  = new TH1F("MC_PosPionsFromNeutralMeson_Pt","MC_PosPionsFromNeutralMeson_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-          fHistoMCPosPionsFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-          fHistoMCPosPionsFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
-          fMCList[iCut]->Add(fHistoMCPosPionsFromNeutralMesonPt[iCut]);
-          fHistoMCNegPionsFromNeutralMesonPt[iCut]  = new TH1F("MC_NegPionsFromNeutralMeson_Pt","MC_NegPionsFromNeutralMeson_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-          fHistoMCNegPionsFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-          fHistoMCNegPionsFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
-          fMCList[iCut]->Add(fHistoMCNegPionsFromNeutralMesonPt[iCut]);
+        if (fDoMesonQA>0){
+          fHistoMCAllMesonPt[iCut]                  = new TH1F("MC_AllNDM_Pt", "MC_AllNDM_Pt", HistoNPtBins, HistoPtRange[0], HistoPtRange[1]);
+          fHistoMCAllMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+          fHistoMCAllMesonPt[iCut]->GetYaxis()->SetTitle(Form("N_{%s}}", NameNDMLatex.Data()));
+          fMCList[iCut]->Add(fHistoMCAllMesonPt[iCut]);
+          fHistoMCAllMesonEta[iCut]                 = new TH1F("MC_AllNDM_Eta", "MC_AllNDM_Eta", 200, -2, 2);
+          fHistoMCAllMesonEta[iCut]->GetXaxis()->SetTitle("#eta");
+          fHistoMCAllMesonEta[iCut]->GetYaxis()->SetTitle(Form("N_{%s}}", NameNDMLatex.Data()));
+          fMCList[iCut]->Add(fHistoMCAllMesonEta[iCut]);
+          fHistoMCAllMesonPhi[iCut]                 = new TH1F("MC_AllNDM_Phi", "MC_AllNDM_Phi", 200, 0, TMath::TwoPi());
+          fHistoMCAllMesonPhi[iCut]->GetXaxis()->SetTitle("#varphi");
+          fHistoMCAllMesonPhi[iCut]->GetYaxis()->SetTitle(Form("N_{%s}}", NameNDMLatex.Data()));
+          fMCList[iCut]->Add(fHistoMCAllMesonPhi[iCut]);
+          fHistoMCMesonFromNeutralMesonPt[iCut]     = new TH1F("MC_NDMFromNeutralMeson_Pt", "MC_NDMFormNeutralMeson_Pt", HistoNPtBins, HistoPtRange[0], HistoPtRange[1]);
+          fHistoMCMesonFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+          fHistoMCMesonFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle(Form("N_{%s}}", NameNDMLatex.Data()));
+          fMCList[iCut]->Add(fHistoMCMesonFromNeutralMesonPt[iCut]);
+          fHistoMCMesonFromNeutralMesonEta[iCut]    = new TH1F("MC_NDMFromNeutralMeson_Eta", "MC_NDMFromNeutralMeson_Eta", 200, -2, 2);
+          fHistoMCMesonFromNeutralMesonEta[iCut]->GetXaxis()->SetTitle("#eta");
+          fHistoMCMesonFromNeutralMesonEta[iCut]->GetYaxis()->SetTitle(Form("N_{%s}}", NameNDMLatex.Data()));
+          fMCList[iCut]->Add(fHistoMCMesonFromNeutralMesonEta[iCut]);
+          fHistoMCMesonFromNeutralMesonPhi[iCut]    = new TH1F("MC_NDMFromNeutralMeson_Phi", "MC_NDMFromNeutralMeson_Phi", 200, 0, TMath::TwoPi());
+          fHistoMCMesonFromNeutralMesonPhi[iCut]->GetXaxis()->SetTitle("#varphi");
+          fHistoMCMesonFromNeutralMesonPhi[iCut]->GetYaxis()->SetTitle(Form("N_{%s}}", NameNDMLatex.Data()));
+          fMCList[iCut]->Add(fHistoMCMesonFromNeutralMesonPhi[iCut]);
+          fHistoMCAllPosPionsEta[iCut]               = new TH1F("MC_AllPosPions_Eta","MC_AllPosPions_Eta", 200, -2., 2.);
+          fHistoMCAllPosPionsEta[iCut]->GetXaxis()->SetTitle("#eta");
+          fHistoMCAllPosPionsEta[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
+          fMCList[iCut]->Add(fHistoMCAllPosPionsEta[iCut]);
+          fHistoMCAllPosPionsPhi[iCut]               = new TH1F("MC_AllPosPions_Phi","MC_AllPosPions_Phi", 200, 0., TMath::TwoPi());
+          fHistoMCAllPosPionsPhi[iCut]->GetXaxis()->SetTitle("#phi");
+          fHistoMCAllPosPionsPhi[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
+          fMCList[iCut]->Add(fHistoMCAllPosPionsPhi[iCut]);
+          fHistoMCAllNegPionsEta[iCut]               = new TH1F("MC_AllNegPions_Eta","MC_AllNegPions_Eta", 200, -2., 2.);
+          fHistoMCAllNegPionsEta[iCut]->GetXaxis()->SetTitle("#eta");
+          fHistoMCAllNegPionsEta[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
+          fMCList[iCut]->Add(fHistoMCAllNegPionsEta[iCut]);
+          fHistoMCAllNegPionsPhi[iCut]               = new TH1F("MC_AllNegPions_Phi","MC_AllNegPions_Phi", 200, 0., TMath::TwoPi());
+          fHistoMCAllNegPionsPhi[iCut]->GetXaxis()->SetTitle("#phi");
+          fHistoMCAllNegPionsPhi[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
+          fMCList[iCut]->Add(fHistoMCAllNegPionsPhi[iCut]);
+          fHistoMCPosPionsFromNeutralMesonEta[iCut]  = new TH1F("MC_PosPionsFromNeutralMeson_Eta","MC_PosPionsFromNeutralMeson_Eta", 200, -2., 2.);
+          fHistoMCPosPionsFromNeutralMesonEta[iCut]->GetXaxis()->SetTitle("#eta");
+          fHistoMCPosPionsFromNeutralMesonEta[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
+          fMCList[iCut]->Add(fHistoMCPosPionsFromNeutralMesonEta[iCut]);
+          fHistoMCPosPionsFromNeutralMesonPhi[iCut]  = new TH1F("MC_PosPionsFromNeutralMeson_Phi","MC_PosPionsFromNeutralMeson_Phi", 200, 0., TMath::TwoPi());
+          fHistoMCPosPionsFromNeutralMesonPhi[iCut]->GetXaxis()->SetTitle("#eta");
+          fHistoMCPosPionsFromNeutralMesonPhi[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
+          fMCList[iCut]->Add(fHistoMCPosPionsFromNeutralMesonPhi[iCut]);
+          fHistoMCNegPionsFromNeutralMesonEta[iCut]  = new TH1F("MC_NegPionsFromNeutralMeson_Eta","MC_NegPionsFromNeutralMeson_Eta", 200, -2., 2.);
+          fHistoMCNegPionsFromNeutralMesonEta[iCut]->GetXaxis()->SetTitle("#eta");
+          fHistoMCNegPionsFromNeutralMesonEta[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
+          fMCList[iCut]->Add(fHistoMCNegPionsFromNeutralMesonEta[iCut]);
+          fHistoMCNegPionsFromNeutralMesonPhi[iCut]  = new TH1F("MC_NegPionsFromNeutralMeson_Phi","MC_NegPionsFromNeutralMeson_Phi", 200, 0., TMath::TwoPi());
+          fHistoMCNegPionsFromNeutralMesonPhi[iCut]->GetXaxis()->SetTitle("#eta");
+          fHistoMCNegPionsFromNeutralMesonPhi[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
+
+          fMCList[iCut]->Add(fHistoMCNegPionsFromNeutralMesonPhi[iCut]);
+          fHistoMCHeavyAllPt[iCut]                            = new TH1F("MC_HeavyAll_Pt", "MC_HeavyAll_Pt", HistoNPtBins, HistoPtRange[0], HistoPtRange[1]);
+          fHistoMCHeavyAllPt[iCut]->SetXTitle("p_{t} (GeV/c)");
+          fHistoMCHeavyAllPt[iCut]->SetYTitle(Form("N_{%s}", NameNeutralMesonAnalyzedLatex.Data()));
+          fMCList[iCut]->Add(fHistoMCHeavyAllPt[iCut]);
+          fHistoMCHeavyAllEta[iCut]                           = new TH1F("MC_HeavyAll_Eta", "MC_HeavyAll_Eta", 200, -2., 2.);
+          fHistoMCHeavyAllEta[iCut]->SetXTitle("#eta");
+          fHistoMCHeavyAllEta[iCut]->SetYTitle(Form("N_{%s}", NameNeutralMesonAnalyzedLatex.Data()));
+          fMCList[iCut]->Add(fHistoMCHeavyAllEta[iCut]);
+          fHistoMCHeavyAllPhi[iCut]                           = new TH1F("MC_HeavyAll_Phi", "MC_HeavyAll_Phi", 200, 0., TMath::TwoPi());
+          fHistoMCHeavyAllPhi[iCut]->SetXTitle("#phi{t} (GeV/c");
+          fHistoMCHeavyAllPhi[iCut]->SetYTitle(Form("N_{%s}", NameNeutralMesonAnalyzedLatex.Data()));
+          fMCList[iCut]->Add(fHistoMCHeavyAllPhi[iCut]);
+          fHistoMCHeavyChannelPt[iCut]                        = new TH1F("MC_HeavyChannel_Pt", "MC_HeavyChannel_Pt", HistoNPtBins, HistoPtRange[0], HistoPtRange[1]);
+          fHistoMCHeavyChannelPt[iCut]->SetXTitle("p_{t} (GeV/c)");
+          fHistoMCHeavyChannelPt[iCut]->SetYTitle(Form("N_{%s}", NameNeutralMesonAnalyzedLatex.Data()));
+          fMCList[iCut]->Add(fHistoMCHeavyChannelPt[iCut]);
+          fHistoMCHeavyChannelEta[iCut]                       = new TH1F("MC_HeavyChannel_Eta", "MC_HeavyChannel_Eta", 200, -2., 2.);
+          fHistoMCHeavyAllEta[iCut]->SetXTitle("#eta");
+          fHistoMCHeavyAllEta[iCut]->SetYTitle(Form("N_{%s}", NameNeutralMesonAnalyzedLatex.Data()));
+          fMCList[iCut]->Add(fHistoMCHeavyChannelEta[iCut]);
+          fHistoMCHeavyChannelPhi[iCut]                       = new TH1F("MC_HeavyChannel_Phi", "MC_HeavyChannel_Phi", 200, 0., TMath::TwoPi());
+          fHistoMCHeavyChannelPhi[iCut]->SetXTitle("#phi{t} (GeV/c");
+          fHistoMCHeavyChannelPhi[iCut]->SetYTitle(Form("N_{%s}", NameNeutralMesonAnalyzedLatex.Data()));
+          fMCList[iCut]->Add(fHistoMCHeavyChannelPhi[iCut]);
+          fHistMCChannelNDMFromHeavyPt[iCut]                  = new TH1F("MC_NDMFromHeavyChannel_Pt", "MC_NDMFromHeavyChannel_Pt", HistoNPtBins, HistoPtRange[0], HistoPtRange[1]);
+          fHistMCChannelNDMFromHeavyPt[iCut]->SetXTitle("p_{t} (GeV/c)");
+          fHistMCChannelNDMFromHeavyPt[iCut]->SetYTitle(Form("N_{%s}", NameNDMLatex.Data()));
+          fMCList[iCut]->Add(fHistMCChannelNDMFromHeavyPt[iCut]);
+          fHistMCChannelNDMFromHeavyEta[iCut]                 = new TH1F("MC_NDMFromHeavyChannel_Eta", "MC_NDMFromHeavyChannel_Eta", 200, -2., 2.);
+          fHistMCChannelNDMFromHeavyEta[iCut]->SetXTitle("#eta");
+          fHistMCChannelNDMFromHeavyEta[iCut]->SetYTitle(Form("N_{%s}", NameNDMLatex.Data()));
+          fMCList[iCut]->Add(fHistMCChannelNDMFromHeavyEta[iCut]);
+          fHistMCChannelNDMFromHeavyPhi[iCut]                 = new TH1F("MC_NDMFromHeavyChannel_Phi", "MC_NDMFromHeavyChannel_Phi", 200, 0., TMath::TwoPi());
+          fHistMCChannelNDMFromHeavyPhi[iCut]->SetXTitle("#phi");
+          fHistMCChannelNDMFromHeavyPhi[iCut]->SetYTitle(Form("N_{%s}", NameNDMLatex.Data()));
+          fMCList[iCut]->Add(fHistMCChannelNDMFromHeavyPhi[iCut]);
+          fHistMCChannelPiPlusFromHeavyPt[iCut]               = new TH1F("MC_PiPlusFromHeavyChannel_Pt", "MC_PiPlusFromHeavyChannel_Pt", HistoNPtBins, HistoPtRange[0], HistoPtRange[1]);
+          fHistMCChannelPiPlusFromHeavyPt[iCut]->SetXTitle("p_{t} (GeV/c)");
+          fHistMCChannelPiPlusFromHeavyPt[iCut]->SetYTitle("N_{#pi^{+}}");
+          fMCList[iCut]->Add(fHistMCChannelPiPlusFromHeavyPt[iCut]);
+          fHistMCChannelPiPlusFromHeavyEta[iCut]              = new TH1F("MC_PiPlusFromHeavyChannel_Eta", "MC_PiPlusFromHeavyChannel_Eta", 200, -2., 2.);
+          fHistMCChannelPiPlusFromHeavyEta[iCut]->SetXTitle("#eta");
+          fHistMCChannelPiPlusFromHeavyEta[iCut]->SetYTitle("N_{#pi^{+}}");
+          fMCList[iCut]->Add(fHistMCChannelPiPlusFromHeavyEta[iCut]);
+          fHistMCChannelPiPlusFromHeavyPhi[iCut]              = new TH1F("MC_PiPlusFromHeavyChannel_Phi", "MC_PiPlusFromHeavyChannel_Phi", 200, 0., TMath::TwoPi());
+          fHistMCChannelPiPlusFromHeavyPhi[iCut]->SetXTitle("#phi");
+          fHistMCChannelPiPlusFromHeavyPhi[iCut]->SetYTitle("N_{#pi^{+}}");
+          fMCList[iCut]->Add(fHistMCChannelPiPlusFromHeavyPhi[iCut]);
+          fHistMCChannelPiMinusFromHeavyPt[iCut]              = new TH1F("MC_PiMinusFromHeavyChannel_Pt", "MC_PiMinusFromHeavyChannel_Pt", HistoNPtBins, HistoPtRange[0], HistoPtRange[1]);
+          fHistMCChannelPiMinusFromHeavyPt[iCut]->SetXTitle("p_{t} (GeV/c)");
+          fHistMCChannelPiMinusFromHeavyPt[iCut]->SetYTitle("N_{#pi^{-}}");
+          fMCList[iCut]->Add(fHistMCChannelPiMinusFromHeavyPt[iCut]);
+          fHistMCChannelPiMinusFromHeavyEta[iCut]             = new TH1F("MC_PiMinusFromHeavyChannel_Eta", "MC_PiMinusFromHeavyChannel_Eta", 200, -2., 2.);
+          fHistMCChannelPiMinusFromHeavyEta[iCut]->SetXTitle("#eta");
+          fHistMCChannelPiMinusFromHeavyEta[iCut]->SetYTitle("N_{#pi^{-}}");
+          fMCList[iCut]->Add(fHistMCChannelPiMinusFromHeavyEta[iCut]);
+          fHistMCChannelPiPMinusFromHeavyPhi[iCut]            = new TH1F("MC_PiMinusFromHeavyChannel_Phi", "MC_PiMinusFromHeavyChannel_Phi", 200, 0., TMath::TwoPi());
+          fHistMCChannelPiPMinusFromHeavyPhi[iCut]->SetXTitle("#phi");
+          fHistMCChannelPiPMinusFromHeavyPhi[iCut]->SetYTitle("N_{#pi^{-}}");
+          fMCList[iCut]->Add(fHistMCChannelPiPMinusFromHeavyPhi[iCut]);
+        
+          fHistMCChannelNDMPtHeavyPt[iCut]                    = new TH2F("MC_CorrPtNDMHeavyChannel", "MC_CorrPtNDMHeavyChannel", HistoNPtBins, HistoPtRange[0], HistoPtRange[1], HistoNPtBins, HistoPtRange[0], HistoPtRange[1]);
+          fHistMCChannelNDMPtHeavyPt[iCut]->SetXTitle(Form("p_{t, %s} (GeV/c)", NameNeutralMesonAnalyzedLatex.Data()));
+          fHistMCChannelNDMPtHeavyPt[iCut]->SetYTitle(Form("p_{t, %s} (GeV/c)", NameNDMLatex.Data()));
+          fHistMCChannelNDMPtHeavyPt[iCut]->SetZTitle(Form("N_{%s}", NameNeutralMesonAnalyzedLatex.Data()));
+          fMCList[iCut]->Add(fHistMCChannelNDMPtHeavyPt[iCut]);
+          fHistMCChannelPiPlusPtHeavyPt[iCut]                 = new TH2F("MC_CorrPtPiPlusHeavyChannel", "MC_CorrPtPiPlusHeavyChannel", HistoNPtBins, HistoPtRange[0], HistoPtRange[1], HistoNPtBins, HistoPtRange[0], HistoPtRange[1]);
+          fHistMCChannelPiPlusPtHeavyPt[iCut]->SetXTitle(Form("p_{t, %s} (GeV/c)", NameNeutralMesonAnalyzedLatex.Data()));
+          fHistMCChannelPiPlusPtHeavyPt[iCut]->SetYTitle("p_{t, #pi^{-}%s} (GeV/c)");
+          fHistMCChannelPiPlusPtHeavyPt[iCut]->SetZTitle(Form("N_{%s}", NameNeutralMesonAnalyzedLatex.Data()));
+          fMCList[iCut]->Add(fHistMCChannelPiPlusPtHeavyPt[iCut]);
+          fHistMCChannelPiMinusPtHeavyPt[iCut]                = new TH2F("MC_CorrPtPiMinusHeavyChannel", "MC_CorrPtPiMinusHeavyChannel", HistoNPtBins, HistoPtRange[0], HistoPtRange[1], HistoNPtBins, HistoPtRange[0], HistoPtRange[1]);
+          fHistMCChannelPiMinusPtHeavyPt[iCut]->SetXTitle(Form("p_{t, %s} (GeV/c)", NameNeutralMesonAnalyzedLatex.Data()));
+          fHistMCChannelPiMinusPtHeavyPt[iCut]->SetYTitle("p_{t, #pi^{-}%s} (GeV/c)");
+          fHistMCChannelPiMinusPtHeavyPt[iCut]->SetZTitle(Form("N_{%s}", NameNeutralMesonAnalyzedLatex.Data()));
+          fMCList[iCut]->Add(fHistMCChannelPiMinusPtHeavyPt[iCut]);
+
+          fHistoMCHeavyReconstructiblePt[iCut]                        = new TH1F("MC_HeavyReconstructible_Pt", "MC_HeavyReconstructible_Pt", HistoNPtBins, HistoPtRange[0], HistoPtRange[1]);
+          fHistoMCHeavyReconstructiblePt[iCut]->SetXTitle("p_{t} (GeV/c)");
+          fHistoMCHeavyReconstructiblePt[iCut]->SetYTitle(Form("N_{%s}", NameNeutralMesonAnalyzedLatex.Data()));
+          fMCList[iCut]->Add(fHistoMCHeavyReconstructiblePt[iCut]);
+          fHistoMCHeavyReconstructibleEta[iCut]                       = new TH1F("MC_HeavyReconstructible_Eta", "MC_HeavyReconstructible_Eta", 200, -2., 2.);
+          fHistoMCHeavyAllEta[iCut]->SetXTitle("#eta");
+          fHistoMCHeavyAllEta[iCut]->SetYTitle(Form("N_{%s}", NameNeutralMesonAnalyzedLatex.Data()));
+          fMCList[iCut]->Add(fHistoMCHeavyReconstructibleEta[iCut]);
+          fHistoMCHeavyReconstructiblePhi[iCut]                       = new TH1F("MC_HeavyReconstructible_Phi", "MC_HeavyReconstructible_Phi", 200, 0., TMath::TwoPi());
+          fHistoMCHeavyReconstructiblePhi[iCut]->SetXTitle("#phi{t} (GeV/c");
+          fHistoMCHeavyReconstructiblePhi[iCut]->SetYTitle(Form("N_{%s}", NameNeutralMesonAnalyzedLatex.Data()));
+          fMCList[iCut]->Add(fHistoMCHeavyReconstructiblePhi[iCut]);
+          fHistMCReconstructibleNDMFromHeavyPt[iCut]                  = new TH1F("MC_NDMFromHeavyReconstructible_Pt", "MC_NDMFromHeavyReconstructible_Pt", HistoNPtBins, HistoPtRange[0], HistoPtRange[1]);
+          fHistMCReconstructibleNDMFromHeavyPt[iCut]->SetXTitle("p_{t} (GeV/c)");
+          fHistMCReconstructibleNDMFromHeavyPt[iCut]->SetYTitle(Form("N_{%s}", NameNDMLatex.Data()));
+          fMCList[iCut]->Add(fHistMCReconstructibleNDMFromHeavyPt[iCut]);
+          fHistMCReconstructibleNDMFromHeavyEta[iCut]                 = new TH1F("MC_NDMFromHeavyReconstructible_Eta", "MC_NDMFromHeavyReconstructible_Eta", 200, -2., 2.);
+          fHistMCReconstructibleNDMFromHeavyEta[iCut]->SetXTitle("#eta");
+          fHistMCReconstructibleNDMFromHeavyEta[iCut]->SetYTitle(Form("N_{%s}", NameNDMLatex.Data()));
+          fMCList[iCut]->Add(fHistMCReconstructibleNDMFromHeavyEta[iCut]);
+          fHistMCReconstructibleNDMFromHeavyPhi[iCut]                 = new TH1F("MC_NDMFromHeavyReconstructible_Phi", "MC_NDMFromHeavyReconstructible_Phi", 200, 0., TMath::TwoPi());
+          fHistMCReconstructibleNDMFromHeavyPhi[iCut]->SetXTitle("#phi");
+          fHistMCReconstructibleNDMFromHeavyPhi[iCut]->SetYTitle(Form("N_{%s}", NameNDMLatex.Data()));
+          fMCList[iCut]->Add(fHistMCReconstructibleNDMFromHeavyPhi[iCut]);
+          fHistMCReconstructiblePiPlusFromHeavyPt[iCut]               = new TH1F("MC_PiPlusFromHeavyReconstructible_Pt", "MC_PiPlusFromHeavyReconstructible_Pt", HistoNPtBins, HistoPtRange[0], HistoPtRange[1]);
+          fHistMCReconstructiblePiPlusFromHeavyPt[iCut]->SetXTitle("p_{t} (GeV/c)");
+          fHistMCReconstructiblePiPlusFromHeavyPt[iCut]->SetYTitle("N_{#pi^{+}}");
+          fMCList[iCut]->Add(fHistMCReconstructiblePiPlusFromHeavyPt[iCut]);
+          fHistMCReconstructiblePiPlusFromHeavyEta[iCut]              = new TH1F("MC_PiPlusFromHeavyReconstructible_Eta", "MC_PiPlusFromHeavyReconstructible_Eta", 200, -2., 2.);
+          fHistMCReconstructiblePiPlusFromHeavyEta[iCut]->SetXTitle("#eta");
+          fHistMCReconstructiblePiPlusFromHeavyEta[iCut]->SetYTitle("N_{#pi^{+}}");
+          fMCList[iCut]->Add(fHistMCReconstructiblePiPlusFromHeavyEta[iCut]);
+          fHistMCReconstructiblePiPlusFromHeavyPhi[iCut]              = new TH1F("MC_PiPlusFromHeavyReconstructible_Phi", "MC_PiPlusFromHeavyReconstructible_Phi", 200, 0., TMath::TwoPi());
+          fHistMCReconstructiblePiPlusFromHeavyPhi[iCut]->SetXTitle("#phi");
+          fHistMCReconstructiblePiPlusFromHeavyPhi[iCut]->SetYTitle("N_{#pi^{+}}");
+          fMCList[iCut]->Add(fHistMCReconstructiblePiPlusFromHeavyPhi[iCut]);
+          fHistMCReconstructiblePiMinusFromHeavyPt[iCut]              = new TH1F("MC_PiMinusFromHeavyReconstructible_Pt", "MC_PiMinusFromHeavyReconstructible_Pt", HistoNPtBins, HistoPtRange[0], HistoPtRange[1]);
+          fHistMCReconstructiblePiMinusFromHeavyPt[iCut]->SetXTitle("p_{t} (GeV/c)");
+          fHistMCReconstructiblePiMinusFromHeavyPt[iCut]->SetYTitle("N_{#pi^{-}}");
+          fMCList[iCut]->Add(fHistMCReconstructiblePiMinusFromHeavyPt[iCut]);
+          fHistMCReconstructiblePiMinusFromHeavyEta[iCut]             = new TH1F("MC_PiMinusFromHeavyReconstructible_Eta", "MC_PiMinusFromHeavyReconstructible_Eta", 200, -2., 2.);
+          fHistMCReconstructiblePiMinusFromHeavyEta[iCut]->SetXTitle("#eta");
+          fHistMCReconstructiblePiMinusFromHeavyEta[iCut]->SetYTitle("N_{#pi^{-}}");
+          fMCList[iCut]->Add(fHistMCReconstructiblePiMinusFromHeavyEta[iCut]);
+          fHistMCReconstructiblePiPMinusFromHeavyPhi[iCut]            = new TH1F("MC_PiMinusFromHeavyReconstructible_Phi", "MC_PiMinusFromHeavyReconstructible_Phi", 200, 0., TMath::TwoPi());
+          fHistMCReconstructiblePiPMinusFromHeavyPhi[iCut]->SetXTitle("#phi");
+          fHistMCReconstructiblePiPMinusFromHeavyPhi[iCut]->SetYTitle("N_{#pi^{-}}");
+          fMCList[iCut]->Add(fHistMCReconstructiblePiPMinusFromHeavyPhi[iCut]);        
+
+          fHistMCReconstructibleNDMPtHeavyPt[iCut]                    = new TH2F("MC_CorrPtNDMHeavyReconstructible", "MC_CorrPtNDMHeavyReconstructible", HistoNPtBins, HistoPtRange[0], HistoPtRange[1], HistoNPtBins, HistoPtRange[0], HistoPtRange[1]);
+          fHistMCReconstructibleNDMPtHeavyPt[iCut]->SetXTitle(Form("p_{t, %s} (GeV/c)", NameNeutralMesonAnalyzedLatex.Data()));
+          fHistMCReconstructibleNDMPtHeavyPt[iCut]->SetYTitle(Form("p_{t, %s} (GeV/c)", NameNDMLatex.Data()));
+          fHistMCReconstructibleNDMPtHeavyPt[iCut]->SetZTitle(Form("N_{%s}", NameNeutralMesonAnalyzedLatex.Data()));
+          fMCList[iCut]->Add(fHistMCReconstructibleNDMPtHeavyPt[iCut]);
+          fHistMCReconstructiblePiPlusPtHeavyPt[iCut]                 = new TH2F("MC_CorrPtPiPlusHeavyReconstructible", "MC_CorrPtPiPlusHeavyReconstructible", HistoNPtBins, HistoPtRange[0], HistoPtRange[1], HistoNPtBins, HistoPtRange[0], HistoPtRange[1]);
+          fHistMCReconstructiblePiPlusPtHeavyPt[iCut]->SetXTitle(Form("p_{t, %s} (GeV/c)", NameNeutralMesonAnalyzedLatex.Data()));
+          fHistMCReconstructiblePiPlusPtHeavyPt[iCut]->SetYTitle("p_{t, #pi^{-}%s} (GeV/c)");
+          fHistMCReconstructiblePiPlusPtHeavyPt[iCut]->SetZTitle(Form("N_{%s}", NameNeutralMesonAnalyzedLatex.Data()));
+          fMCList[iCut]->Add(fHistMCReconstructiblePiPlusPtHeavyPt[iCut]);
+          fHistMCReconstructiblePiMinusPtHeavyPt[iCut]                = new TH2F("MC_CorrPtPiMinusHeavyReconstructible", "MC_CorrPtPiMinusHeavyReconstructible", HistoNPtBins, HistoPtRange[0], HistoPtRange[1], HistoNPtBins, HistoPtRange[0], HistoPtRange[1]);
+          fHistMCReconstructiblePiMinusPtHeavyPt[iCut]->SetXTitle(Form("p_{t, %s} (GeV/c)", NameNeutralMesonAnalyzedLatex.Data()));
+          fHistMCReconstructiblePiMinusPtHeavyPt[iCut]->SetYTitle("p_{t, #pi^{-}%s} (GeV/c)");
+          fHistMCReconstructiblePiMinusPtHeavyPt[iCut]->SetZTitle(Form("N_{%s}", NameNeutralMesonAnalyzedLatex.Data()));
+          fMCList[iCut]->Add(fHistMCReconstructiblePiMinusPtHeavyPt[iCut]);
+        }
       }
       fHistoMCHNMPiPlPiMiNDMPt[iCut]         = new TH1F("MC_HNM_Pt","MC_HNM_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
       fHistoMCHNMPiPlPiMiNDMPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
@@ -1148,56 +1490,56 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::UserCreateOutputObjects(
       fCutFolder[iCut]->Add(fTrueList[iCut]);
 
       if(!fDoLightOutput){
-          if (fNDMRecoMode < 2){
-              fHistoTrueConvGammaPt[iCut]                 = new TH1F("ESD_TrueConvGamma_Pt","ESD_TrueConvGamma_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTrueConvGammaPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-              fHistoTrueConvGammaPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,conv}");
-              fTrueList[iCut]->Add(fHistoTrueConvGammaPt[iCut]);
-              fHistoDoubleCountTrueConvGammaRPt[iCut]     = new TH2F("ESD_TrueDoubleCountConvGamma_R_Pt","ESD_TrueDoubleCountConvGamma_R_Pt",800,0,200,HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoDoubleCountTrueConvGammaRPt[iCut]->GetXaxis()->SetTitle("R_{conv} (cm)");
-              fHistoDoubleCountTrueConvGammaRPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoDoubleCountTrueConvGammaRPt[iCut]);
-              fHistoTrueConvGammaFromNeutralMesonPt[iCut] = new TH1F("ESD_TrueConvGammaFromNeutralMeson_Pt","ESD_TrueConvGammaFromNeutralMeson_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTrueConvGammaFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-              fHistoTrueConvGammaFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,conv}");
-              fTrueList[iCut]->Add(fHistoTrueConvGammaFromNeutralMesonPt[iCut]);
-          }
-          if (fNDMRecoMode > 0){
-              fHistoTrueClusterGammaPt[iCut]                  = new TH1F("ESD_TrueClusterGamma_Pt","ESD_TrueClusterGamma_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTrueClusterGammaPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-              fHistoTrueClusterGammaPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,cluster}");
-              fTrueList[iCut]->Add(fHistoTrueClusterGammaPt[iCut]);
-              fHistoTrueClusterGammaFromNeutralMesonPt[iCut]  = new TH1F("ESD_TrueClusterGammaFromNeutralMeson_Pt","ESD_TrueClusterGammaFromNeutralMeson_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTrueClusterGammaFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-              fHistoTrueClusterGammaFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,cluster}");
-              fTrueList[iCut]->Add(fHistoTrueClusterGammaFromNeutralMesonPt[iCut]);
-          }
-          fHistoTruePosPionPt[iCut]                       = new TH1F("ESD_TruePosPion_Pt","ESD_TruePosPion_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-          fHistoTruePosPionPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-          fHistoTruePosPionPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
-          fTrueList[iCut]->Add(fHistoTruePosPionPt[iCut]);
-          fHistoTrueNegPionPt[iCut]                       = new TH1F("ESD_TrueNegPion_Pt","ESD_TrueNegPion_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-          fHistoTrueNegPionPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-          fHistoTrueNegPionPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
-          fTrueList[iCut]->Add(fHistoTrueNegPionPt[iCut]);
+        if (fNDMRecoMode < 2){
+          fHistoTrueConvGammaPt[iCut]                 = new TH1F("ESD_TrueConvGamma_Pt","ESD_TrueConvGamma_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTrueConvGammaPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+          fHistoTrueConvGammaPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,conv}");
+          fTrueList[iCut]->Add(fHistoTrueConvGammaPt[iCut]);
+          fHistoDoubleCountTrueConvGammaRPt[iCut]     = new TH2F("ESD_TrueDoubleCountConvGamma_R_Pt","ESD_TrueDoubleCountConvGamma_R_Pt",800,0,200,HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoDoubleCountTrueConvGammaRPt[iCut]->GetXaxis()->SetTitle("R_{conv} (cm)");
+          fHistoDoubleCountTrueConvGammaRPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoDoubleCountTrueConvGammaRPt[iCut]);
+          fHistoTrueConvGammaFromNeutralMesonPt[iCut] = new TH1F("ESD_TrueConvGammaFromNeutralMeson_Pt","ESD_TrueConvGammaFromNeutralMeson_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTrueConvGammaFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+          fHistoTrueConvGammaFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,conv}");
+          fTrueList[iCut]->Add(fHistoTrueConvGammaFromNeutralMesonPt[iCut]);
+        }
+        if (fNDMRecoMode > 0){
+          fHistoTrueClusterGammaPt[iCut]                  = new TH1F("ESD_TrueClusterGamma_Pt","ESD_TrueClusterGamma_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTrueClusterGammaPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+          fHistoTrueClusterGammaPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,cluster}");
+          fTrueList[iCut]->Add(fHistoTrueClusterGammaPt[iCut]);
+          fHistoTrueClusterGammaFromNeutralMesonPt[iCut]  = new TH1F("ESD_TrueClusterGammaFromNeutralMeson_Pt","ESD_TrueClusterGammaFromNeutralMeson_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTrueClusterGammaFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+          fHistoTrueClusterGammaFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle("N_{#gamma,cluster}");
+          fTrueList[iCut]->Add(fHistoTrueClusterGammaFromNeutralMesonPt[iCut]);
+        }
+        fHistoTruePosPionPt[iCut]                       = new TH1F("ESD_TruePosPion_Pt","ESD_TruePosPion_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+        fHistoTruePosPionPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoTruePosPionPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
+        fTrueList[iCut]->Add(fHistoTruePosPionPt[iCut]);
+        fHistoTrueNegPionPt[iCut]                       = new TH1F("ESD_TrueNegPion_Pt","ESD_TrueNegPion_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+        fHistoTrueNegPionPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoTrueNegPionPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
+        fTrueList[iCut]->Add(fHistoTrueNegPionPt[iCut]);
 
-          fHistoTrueNegPionFromNeutralMesonPt[iCut]       = new TH1F("ESD_TrueNegPionFromNeutralMeson_Pt","ESD_TrueNegPionFromNeutralMeson_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-          fHistoTrueNegPionFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-          fHistoTrueNegPionFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
-          fTrueList[iCut]->Add(fHistoTrueNegPionFromNeutralMesonPt[iCut]);
-          fHistoTruePosPionFromNeutralMesonPt[iCut]       = new TH1F("ESD_TruePosPionFromNeutralMeson_Pt","ESD_TruePosPionFromNeutralMeson_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-          fHistoTruePosPionFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-          fHistoTruePosPionFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
-          fTrueList[iCut]->Add(fHistoTruePosPionFromNeutralMesonPt[iCut]);
+        fHistoTrueNegPionFromNeutralMesonPt[iCut]       = new TH1F("ESD_TrueNegPionFromNeutralMeson_Pt","ESD_TrueNegPionFromNeutralMeson_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+        fHistoTrueNegPionFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoTrueNegPionFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{-}}");
+        fTrueList[iCut]->Add(fHistoTrueNegPionFromNeutralMesonPt[iCut]);
+        fHistoTruePosPionFromNeutralMesonPt[iCut]       = new TH1F("ESD_TruePosPionFromNeutralMeson_Pt","ESD_TruePosPionFromNeutralMeson_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+        fHistoTruePosPionFromNeutralMesonPt[iCut]->GetXaxis()->SetTitle("p_{T} (GeV/c)");
+        fHistoTruePosPionFromNeutralMesonPt[iCut]->GetYaxis()->SetTitle("N_{#pi^{+}}");
+        fTrueList[iCut]->Add(fHistoTruePosPionFromNeutralMesonPt[iCut]);
 
-          fHistoDoubleCountTruePi0InvMassPt[iCut]         = new TH2F("ESD_TrueDoubleCountPi0_InvMass_Pt","ESD_TrueDoubleCountPi0_InvMass_Pt",800,0,0.8,HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-          fHistoDoubleCountTruePi0InvMassPt[iCut]->GetXaxis()->SetTitle("M_{#gamma #gamma} (GeV/c^{2})");
-          fHistoDoubleCountTruePi0InvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-          fTrueList[iCut]->Add(fHistoDoubleCountTruePi0InvMassPt[iCut]);
-          fHistoDoubleCountTrueHNMInvMassPt[iCut]         = new TH2F("ESD_TrueDoubleCountHNM_InvMass_Pt","ESD_TrueDoubleCountHNM_InvMass_Pt",800,0,0.8,HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-          fHistoDoubleCountTrueHNMInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#eta} (GeV/c^{2})");
-          fHistoDoubleCountTrueHNMInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-          fTrueList[iCut]->Add(fHistoDoubleCountTrueHNMInvMassPt[iCut]);
+        fHistoDoubleCountTruePi0InvMassPt[iCut]         = new TH2F("ESD_TrueDoubleCountPi0_InvMass_Pt","ESD_TrueDoubleCountPi0_InvMass_Pt",800,0,0.8,HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+        fHistoDoubleCountTruePi0InvMassPt[iCut]->GetXaxis()->SetTitle("M_{#gamma #gamma} (GeV/c^{2})");
+        fHistoDoubleCountTruePi0InvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+        fTrueList[iCut]->Add(fHistoDoubleCountTruePi0InvMassPt[iCut]);
+        fHistoDoubleCountTrueHNMInvMassPt[iCut]         = new TH2F("ESD_TrueDoubleCountHNM_InvMass_Pt","ESD_TrueDoubleCountHNM_InvMass_Pt",800,0,0.8,HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+        fHistoDoubleCountTrueHNMInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#eta} (GeV/c^{2})");
+        fHistoDoubleCountTrueHNMInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+        fTrueList[iCut]->Add(fHistoDoubleCountTrueHNMInvMassPt[iCut]);
       }
       fHistoTrueMotherPiPlPiMiNDMInvMassPt[iCut]       = new TH2F("ESD_TrueMotherPiPlPiMiNDM_InvMass_Pt","ESD_TrueMotherPiPlPiMiNDM_InvMass_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
       fHistoTrueMotherPiPlPiMiNDMInvMassPt[iCut]->Sumw2();
@@ -1205,134 +1547,134 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::UserCreateOutputObjects(
       fHistoTrueMotherPiPlPiMiNDMInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
       fTrueList[iCut]->Add(fHistoTrueMotherPiPlPiMiNDMInvMassPt[iCut]);
 
-          fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt[iCut]  = new TH2F("ESD_TrueMotherHNMPiPlPiMiNDM_InvMass_Pt","ESD_TrueMotherHNMPiPlPiMiNDM_InvMass_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-          fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt[iCut]->Sumw2();
-          fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} (GeV/c^{2})",NameNDMLatex.Data()));
-          fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-          fTrueList[iCut]->Add(fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt[iCut]);
+      fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt[iCut]  = new TH2F("ESD_TrueMotherHNMPiPlPiMiNDM_InvMass_Pt","ESD_TrueMotherHNMPiPlPiMiNDM_InvMass_Pt",HistoNMassBins,HistoMassRange[0],HistoMassRange[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+      fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt[iCut]->Sumw2();
+      fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+} #pi^{-} %s} (GeV/c^{2})",NameNDMLatex.Data()));
+      fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+      fTrueList[iCut]->Add(fHistoTrueMotherHNMPiPlPiMiNDMInvMassPt[iCut]);
 
       if(!fDoLightOutput){
-          fHistoTrueMotherGammaGammaInvMassPt[iCut]           = new TH2F("ESD_TrueMotherGG_InvMass_Pt","ESD_TrueMotherGG_InvMass_Pt",HistoNMassBinsDecayMeson,HistoMassRangeNDM[0],HistoMassRangeNDM[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-          fHistoTrueMotherGammaGammaInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#gamma #gamma} (GeV/c^{2})");
-          fHistoTrueMotherGammaGammaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-          fTrueList[iCut]->Add(fHistoTrueMotherGammaGammaInvMassPt[iCut]);
-          fHistoTrueMotherGammaGammaFromHNMInvMassPt[iCut]    = new TH2F("ESD_TrueMotherGGFromHNM_InvMass_Pt","ESD_TrueMotherGGFromHNM_InvMass_Pt",HistoNMassBinsDecayMeson,HistoMassRangeNDM[0],HistoMassRangeNDM[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-          fHistoTrueMotherGammaGammaFromHNMInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#gamma #gamma} (GeV/c^{2})");
-          fHistoTrueMotherGammaGammaFromHNMInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-          fTrueList[iCut]->Add(fHistoTrueMotherGammaGammaFromHNMInvMassPt[iCut]);
-          fHistoTrueAngleSum[iCut]                            = new TH2F("ESD_TrueMother_AngleSum_Pt","ESD_TrueMother_AngleSum_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1],720,0,2*TMath::Pi());
-          fHistoTrueAngleSum[iCut]->GetXaxis()->SetTitle("#sum #angle");
-          fHistoTrueAngleSum[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-          fTrueList[iCut]->Add(fHistoTrueAngleSum[iCut]);
+        fHistoTrueMotherGammaGammaInvMassPt[iCut]           = new TH2F("ESD_TrueMotherGG_InvMass_Pt","ESD_TrueMotherGG_InvMass_Pt",HistoNMassBinsDecayMeson,HistoMassRangeNDM[0],HistoMassRangeNDM[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+        fHistoTrueMotherGammaGammaInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#gamma #gamma} (GeV/c^{2})");
+        fHistoTrueMotherGammaGammaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+        fTrueList[iCut]->Add(fHistoTrueMotherGammaGammaInvMassPt[iCut]);
+        fHistoTrueMotherGammaGammaFromHNMInvMassPt[iCut]    = new TH2F("ESD_TrueMotherGGFromHNM_InvMass_Pt","ESD_TrueMotherGGFromHNM_InvMass_Pt",HistoNMassBinsDecayMeson,HistoMassRangeNDM[0],HistoMassRangeNDM[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+        fHistoTrueMotherGammaGammaFromHNMInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#gamma #gamma} (GeV/c^{2})");
+        fHistoTrueMotherGammaGammaFromHNMInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+        fTrueList[iCut]->Add(fHistoTrueMotherGammaGammaFromHNMInvMassPt[iCut]);
+        fHistoTrueAngleSum[iCut]                            = new TH2F("ESD_TrueMother_AngleSum_Pt","ESD_TrueMother_AngleSum_Pt",HistoNPtBins,HistoPtRange[0],HistoPtRange[1],720,0,2*TMath::Pi());
+        fHistoTrueAngleSum[iCut]->GetXaxis()->SetTitle("#sum #angle");
+        fHistoTrueAngleSum[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+        fTrueList[iCut]->Add(fHistoTrueAngleSum[iCut]);
 
-          if (fDoMesonQA>0){
-              fHistoTruePionPionInvMassPt[iCut]                 = new TH2F("ESD_TruePiPlusPiNeg_InvMassPt","ESD_TruePiPlusPiNeg_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTruePionPionInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
-              fHistoTruePionPionInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoTruePionPionInvMassPt[iCut]);
-              fHistoTruePionPionFromSameMotherInvMassPt[iCut]   = new TH2F("ESD_TruePiPlusPiNegFromSameMother_InvMassPt","ESD_TruePiPlusPiNegFromSameMother_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTruePionPionFromSameMotherInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
-              fHistoTruePionPionFromSameMotherInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoTruePionPionFromSameMotherInvMassPt[iCut]);
-              fHistoTruePionPionFromHNMInvMassPt[iCut]          = new TH2F("ESD_TruePiPlusPiNegFromHNM_InvMassPt","ESD_TruePiPlusPiNegFromHNM_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTruePionPionFromHNMInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
-              fHistoTruePionPionFromHNMInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoTruePionPionFromHNMInvMassPt[iCut]);
+        if (fDoMesonQA>0){
+          fHistoTruePionPionInvMassPt[iCut]                 = new TH2F("ESD_TruePiPlusPiNeg_InvMassPt","ESD_TruePiPlusPiNeg_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePionPionInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+          fHistoTruePionPionInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePionPionInvMassPt[iCut]);
+          fHistoTruePionPionFromSameMotherInvMassPt[iCut]   = new TH2F("ESD_TruePiPlusPiNegFromSameMother_InvMassPt","ESD_TruePiPlusPiNegFromSameMother_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePionPionFromSameMotherInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+          fHistoTruePionPionFromSameMotherInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePionPionFromSameMotherInvMassPt[iCut]);
+          fHistoTruePionPionFromHNMInvMassPt[iCut]          = new TH2F("ESD_TruePiPlusPiNegFromHNM_InvMassPt","ESD_TruePiPlusPiNegFromHNM_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePionPionFromHNMInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+          fHistoTruePionPionFromHNMInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePionPionFromHNMInvMassPt[iCut]);
 
-              fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt[iCut]    = new TH2F("ESD_TruePiPlPiMiSameMotherFromEta_InvMassPt","ESD_TruePiPlPiMiSameMotherFromEta_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
-              fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt[iCut]);
-              fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt[iCut]  = new TH2F("ESD_TruePiPlPiMiSameMotherFromOmega_InvMassPt","ESD_TruePiPlPiMiSameMotherFromOmega_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
-              fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt[iCut]);
-              fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt[iCut]    = new TH2F("ESD_TruePiPlPiMiSameMotherFromRho_InvMassPt","ESD_TruePiPlPiMiSameMotherFromRho_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
-              fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt[iCut]);
-              fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt[iCut] = new TH2F("ESD_TruePiPlPiMiSameMotherFromEtaPrime_InvMassPt","ESD_TruePiPlPiMiSameMotherFromEtaPrime_InvMassPt",
+          fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt[iCut]    = new TH2F("ESD_TruePiPlPiMiSameMotherFromEta_InvMassPt","ESD_TruePiPlPiMiSameMotherFromEta_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+          fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePiPlPiMiSameMotherFromEtaInvMassPt[iCut]);
+          fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt[iCut]  = new TH2F("ESD_TruePiPlPiMiSameMotherFromOmega_InvMassPt","ESD_TruePiPlPiMiSameMotherFromOmega_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+          fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePiPlPiMiSameMotherFromOmegaInvMassPt[iCut]);
+          fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt[iCut]    = new TH2F("ESD_TruePiPlPiMiSameMotherFromRho_InvMassPt","ESD_TruePiPlPiMiSameMotherFromRho_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+          fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePiPlPiMiSameMotherFromRhoInvMassPt[iCut]);
+          fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt[iCut] = new TH2F("ESD_TruePiPlPiMiSameMotherFromEtaPrime_InvMassPt","ESD_TruePiPlPiMiSameMotherFromEtaPrime_InvMassPt",
                                                                                  HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
-              fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt[iCut]);
-              fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt[iCut]    = new TH2F("ESD_TruePiPlPiMiSameMotherFromK0s_InvMassPt","ESD_TruePiPlPiMiSameMotherFromK0s_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
-              fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt[iCut]);
-              fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt[iCut]    = new TH2F("ESD_TruePiPlPiMiSameMotherFromK0l_InvMassPt","ESD_TruePiPlPiMiSameMotherFromK0l_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
-              fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt[iCut]);
+          fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+          fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePiPlPiMiSameMotherFromEtaPrimeInvMassPt[iCut]);
+          fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt[iCut]    = new TH2F("ESD_TruePiPlPiMiSameMotherFromK0s_InvMassPt","ESD_TruePiPlPiMiSameMotherFromK0s_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+          fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePiPlPiMiSameMotherFromK0sInvMassPt[iCut]);
+          fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt[iCut]    = new TH2F("ESD_TruePiPlPiMiSameMotherFromK0l_InvMassPt","ESD_TruePiPlPiMiSameMotherFromK0l_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt[iCut]->GetXaxis()->SetTitle("M_{#pi^{+}#pi^{-}} (GeV/c^{2})");
+          fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePiPlPiMiSameMotherFromK0lInvMassPt[iCut]);
 
-              fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt[iCut]  = new TH2F("ESD_TruePiMiPiZeroSameMotherFromEta_InvMassPt","ESD_TruePiMiPiZeroSameMotherFromEta_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{-}%s} (GeV/c^{2})",NameNDMLatex.Data()));
-              fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt[iCut]);
-              fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt[iCut] = new TH2F("ESD_TruePiMiPiZeroSameMotherFromOmega_InvMassPt","ESD_TruePiMiPiZeroSameMotherFromOmega_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{-}%s} (GeV/c^{2})",NameNDMLatex.Data()));
-              fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt[iCut]);
-              fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt[iCut]  = new TH2F("ESD_TruePiMiPiZeroSameMotherFromRho_InvMassPt","ESD_TruePiMiPiZeroSameMotherFromRho_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{-}%s} (GeV/c^{2})",NameNDMLatex.Data()));
-              fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt[iCut]);
-              fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt[iCut]  = new TH2F("ESD_TruePiMiPiZeroSameMotherFromK0l_InvMassPt","ESD_TruePiMiPiZeroSameMotherFromK0l_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{-}%s} (GeV/c^{2})",NameNDMLatex.Data()));
-              fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt[iCut]);
+          fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt[iCut]  = new TH2F("ESD_TruePiMiPiZeroSameMotherFromEta_InvMassPt","ESD_TruePiMiPiZeroSameMotherFromEta_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{-}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+          fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePiMiPiZeroSameMotherFromEtaInvMassPt[iCut]);
+          fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt[iCut] = new TH2F("ESD_TruePiMiPiZeroSameMotherFromOmega_InvMassPt","ESD_TruePiMiPiZeroSameMotherFromOmega_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{-}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+          fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePiMiPiZeroSameMotherFromOmegaInvMassPt[iCut]);
+          fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt[iCut]  = new TH2F("ESD_TruePiMiPiZeroSameMotherFromRho_InvMassPt","ESD_TruePiMiPiZeroSameMotherFromRho_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{-}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+          fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt[iCut]);
+          fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt[iCut]  = new TH2F("ESD_TruePiMiPiZeroSameMotherFromK0l_InvMassPt","ESD_TruePiMiPiZeroSameMotherFromK0l_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{-}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+          fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePiMiPiZeroSameMotherFromK0lInvMassPt[iCut]);
 
-              fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt[iCut]  = new TH2F("ESD_TruePiPlPiZeroSameMotherFromEta_InvMassPt","ESD_TruePiPlPiZeroSameMotherFromEta_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+}%s} (GeV/c^{2})",NameNDMLatex.Data()));
-              fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt[iCut]);
-              fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt[iCut] = new TH2F("ESD_TruePiPlPiZeroSameMotherFromOmega_InvMassPt","ESD_TruePiPlPiZeroSameMotherFromOmega_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+}%s} (GeV/c^{2})",NameNDMLatex.Data()));
-              fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt[iCut]);
-              fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt[iCut]  = new TH2F("ESD_TruePiPlPiZeroSameMotherFromRho_InvMassPt","ESD_TruePiPlPiZeroSameMotherFromRho_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+}%s} (GeV/c^{2})",NameNDMLatex.Data()));
-              fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt[iCut]);
-              fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt[iCut]  = new TH2F("ESD_TruePiPlPiZeroSameMotherFromK0l_InvMassPt","ESD_TruePiPlPiZeroSameMotherFromK0l_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+}%s} (GeV/c^{2})",NameNDMLatex.Data()));
-              fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt[iCut]);
-              fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt[iCut]  = new TH2F("ESD_TruePiPlPiMiNDMPureCombinatorical_InvMassPt","ESD_TruePiPlPiMiNDMPureCombinatorical_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+}#pi^{-}%s} (GeV/c^{2})",NameNDMLatex.Data()));
-              fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt[iCut]);
-              fHistoTruePiPlPiMiNDMContaminationInvMassPt[iCut]  = new TH2F("ESD_TruePiPlPiMiNDMContamination_InvMassPt","ESD_TruePiPlPiMiNDMContamination_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
-              fHistoTruePiPlPiMiNDMContaminationInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+}#pi^{-}%s} (GeV/c^{2})",NameNDMLatex.Data()));
-              fHistoTruePiPlPiMiNDMContaminationInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
-              fTrueList[iCut]->Add(fHistoTruePiPlPiMiNDMContaminationInvMassPt[iCut]);
-              if(fDoMesonQA>1){
-                  fTrueTreeList[iCut]                               = new TList();
-                  fTrueTreeList[iCut]->SetName(nameTrueRecTTreeList.Data());
-                  fTrueTreeList[iCut]->SetOwner(kTRUE);
-                  fCutFolder[iCut]->Add(fTrueTreeList[iCut]);
+          fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt[iCut]  = new TH2F("ESD_TruePiPlPiZeroSameMotherFromEta_InvMassPt","ESD_TruePiPlPiZeroSameMotherFromEta_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+          fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePiPlPiZeroSameMotherFromEtaInvMassPt[iCut]);
+          fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt[iCut] = new TH2F("ESD_TruePiPlPiZeroSameMotherFromOmega_InvMassPt","ESD_TruePiPlPiZeroSameMotherFromOmega_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+          fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePiPlPiZeroSameMotherFromOmegaInvMassPt[iCut]);
+          fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt[iCut]  = new TH2F("ESD_TruePiPlPiZeroSameMotherFromRho_InvMassPt","ESD_TruePiPlPiZeroSameMotherFromRho_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+          fHistoTruePiMiPiZeroSameMotherFromRhoInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePiPlPiZeroSameMotherFromRhoInvMassPt[iCut]);
+          fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt[iCut]  = new TH2F("ESD_TruePiPlPiZeroSameMotherFromK0l_InvMassPt","ESD_TruePiPlPiZeroSameMotherFromK0l_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+          fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePiPlPiZeroSameMotherFromK0lInvMassPt[iCut]);
+          fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt[iCut]  = new TH2F("ESD_TruePiPlPiMiNDMPureCombinatorical_InvMassPt","ESD_TruePiPlPiMiNDMPureCombinatorical_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+}#pi^{-}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+          fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePiPlPiMiNDMPureCombinatoricalInvMassPt[iCut]);
+          fHistoTruePiPlPiMiNDMContaminationInvMassPt[iCut]  = new TH2F("ESD_TruePiPlPiMiNDMContamination_InvMassPt","ESD_TruePiPlPiMiNDMContamination_InvMassPt",HistoNMassBinsPiPlusPiMinus,HistoMassRangePiPlusPiMinus[0],HistoMassRangePiPlusPiMinus[1],HistoNPtBins,HistoPtRange[0],HistoPtRange[1]);
+          fHistoTruePiPlPiMiNDMContaminationInvMassPt[iCut]->GetXaxis()->SetTitle(Form("M_{#pi^{+}#pi^{-}%s} (GeV/c^{2})",NameNDMLatex.Data()));
+          fHistoTruePiPlPiMiNDMContaminationInvMassPt[iCut]->GetYaxis()->SetTitle("p_{T} (GeV/c)");
+          fTrueList[iCut]->Add(fHistoTruePiPlPiMiNDMContaminationInvMassPt[iCut]);
+          if(fDoMesonQA>1){
+            fTrueTreeList[iCut]                               = new TList();
+            fTrueTreeList[iCut]->SetName(nameTrueRecTTreeList.Data());
+            fTrueTreeList[iCut]->SetOwner(kTRUE);
+            fCutFolder[iCut]->Add(fTrueTreeList[iCut]);
 
-                  fTreePiPiSameMother[iCut]                         = new TTree("TreePiPiSameMother","TreePiPiSameMother");
-                  fTreePiPiSameMother[iCut]->Branch("fCasePiPi", &fCasePiPi, "fCasePiPi/S");
-                  fTreePiPiSameMother[iCut]->Branch("fSamePiPiMotherID", &fSamePiPiMotherID, "fSamePiPiMotherID/F");
-                  fTreePiPiSameMother[iCut]->Branch("fSamePiPiMotherInvMass", &fSamePiPiMotherInvMass, "fSamePiPiMotherInvMass/F");
-                  fTreePiPiSameMother[iCut]->Branch("fSamePiPiMotherPt", &fSamePiPiMotherPt, "fSamePiPiMotherPt/F");
-                  fTrueTreeList[iCut]->Add(fTreePiPiSameMother[iCut]);
+            fTreePiPiSameMother[iCut]                         = new TTree("TreePiPiSameMother","TreePiPiSameMother");
+            fTreePiPiSameMother[iCut]->Branch("fCasePiPi", &fCasePiPi, "fCasePiPi/S");
+            fTreePiPiSameMother[iCut]->Branch("fSamePiPiMotherID", &fSamePiPiMotherID, "fSamePiPiMotherID/F");
+            fTreePiPiSameMother[iCut]->Branch("fSamePiPiMotherInvMass", &fSamePiPiMotherInvMass, "fSamePiPiMotherInvMass/F");
+            fTreePiPiSameMother[iCut]->Branch("fSamePiPiMotherPt", &fSamePiPiMotherPt, "fSamePiPiMotherPt/F");
+            fTrueTreeList[iCut]->Add(fTreePiPiSameMother[iCut]);
 
-                  fTreePiPiPiSameMother[iCut]                         = new TTree("TreePiPiPiSameMother","TreePiPiPiSameMother");
-                  fTreePiPiPiSameMother[iCut]->Branch("fSamePiPiPiMotherID", &fSamePiPiPiMotherID, "fSamePiPiPiMotherID/F");
-                  fTreePiPiPiSameMother[iCut]->Branch("fSamePiPiPiMotherInvMass", &fSamePiPiPiMotherInvMass, "fSamePiPiPiMotherInvMass/F");
-                  fTreePiPiPiSameMother[iCut]->Branch("fSamePiPiPiMotherPt", &fSamePiPiPiMotherPt, "fSamePiPiPiMotherPt/F");
-                  fTrueTreeList[iCut]->Add(fTreePiPiPiSameMother[iCut]);
+            fTreePiPiPiSameMother[iCut]                         = new TTree("TreePiPiPiSameMother","TreePiPiPiSameMother");
+            fTreePiPiPiSameMother[iCut]->Branch("fSamePiPiPiMotherID", &fSamePiPiPiMotherID, "fSamePiPiPiMotherID/F");
+            fTreePiPiPiSameMother[iCut]->Branch("fSamePiPiPiMotherInvMass", &fSamePiPiPiMotherInvMass, "fSamePiPiPiMotherInvMass/F");
+            fTreePiPiPiSameMother[iCut]->Branch("fSamePiPiPiMotherPt", &fSamePiPiPiMotherPt, "fSamePiPiPiMotherPt/F");
+            fTrueTreeList[iCut]->Add(fTreePiPiPiSameMother[iCut]);
 
-                  fTreeEventInfoHNM[iCut]                         = new TTree("TreeEventInfoHNM","TreeEventInfoHNM");
-                  fTreeEventInfoHNM[iCut]->Branch("fV0MultiplicityHNMEvent", &fV0MultiplicityHNMEvent, "fV0MultiplicityHNMEvent/F");
-                  fTreeEventInfoHNM[iCut]->Branch("fTrackMultiplicityHNMEvent", &fTrackMultiplicityHNMEvent, "fTrackMultiplicityHNMEvent/F");
-                  fTreeEventInfoHNM[iCut]->Branch("fZVertexHNMEvent", &fZVertexHNMEvent, "fZVertexHNMEvent/F");
-                  fTreeEventInfoHNM[iCut]->Branch("fPtHNM", &fPtHNM, "fPtHNM/F");
-                  fTrueTreeList[iCut]->Add(fTreeEventInfoHNM[iCut]);
-              }
+            fTreeEventInfoHNM[iCut]                         = new TTree("TreeEventInfoHNM","TreeEventInfoHNM");
+            fTreeEventInfoHNM[iCut]->Branch("fV0MultiplicityHNMEvent", &fV0MultiplicityHNMEvent, "fV0MultiplicityHNMEvent/F");
+            fTreeEventInfoHNM[iCut]->Branch("fTrackMultiplicityHNMEvent", &fTrackMultiplicityHNMEvent, "fTrackMultiplicityHNMEvent/F");
+            fTreeEventInfoHNM[iCut]->Branch("fZVertexHNMEvent", &fZVertexHNMEvent, "fZVertexHNMEvent/F");
+            fTreeEventInfoHNM[iCut]->Branch("fPtHNM", &fPtHNM, "fPtHNM/F");
+            fTrueTreeList[iCut]->Add(fTreeEventInfoHNM[iCut]);
           }
+        }
       }
     }
   }
@@ -1603,7 +1945,7 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessCaloPhotonCandida
   // Loop over EMCal clusters
   for(Long_t i = 0; i < nclus; i++){
 
-    AliVCluster* clus = NULL;
+    AliVCluster* clus = nullptr;
     if(fInputEvent->IsA()==AliESDEvent::Class()) clus = new AliESDCaloCluster(*(AliESDCaloCluster*)fInputEvent->GetCaloCluster(i));
     else if(fInputEvent->IsA()==AliAODEvent::Class()) clus = new AliAODCaloCluster(*(AliAODCaloCluster*)fInputEvent->GetCaloCluster(i));
 
@@ -1663,7 +2005,7 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessCaloPhotonCandida
 //________________________________________________________________________
 void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessTrueCaloPhotonCandidates(AliAODConversionPhoton *TruePhotonCandidate)
 {
-  TParticle *Photon = NULL;
+  TParticle *Photon = nullptr;
   if (!TruePhotonCandidate->GetIsCaloPhoton()) AliFatal("CaloPhotonFlag has not been set task will abort");
     if (TruePhotonCandidate->GetCaloPhotonMCLabel(0)<0) return;
 	// fHistoTrueNLabelsInClus[fiCut]->Fill(TruePhotonCandidate->GetNCaloPhotonMCLabels());
@@ -1676,7 +2018,7 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessTrueCaloPhotonCan
   if (TruePhotonCandidate->GetNCaloPhotonMCLabels()>0)Photon = fMCEvent->Particle(TruePhotonCandidate->GetCaloPhotonMCLabel(0));
     else return;
 
-  if(Photon == NULL){
+  if(Photon == nullptr){
   //    cout << "no photon" << endl;
     return;
   }
@@ -1982,11 +2324,11 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessNeutralDecayMeson
   if(fGoodConvGammas->GetEntries()>1){
     for(Int_t firstGammaIndex=0;firstGammaIndex<fGoodConvGammas->GetEntries()-1;firstGammaIndex++){
       AliAODConversionPhoton *gamma0=dynamic_cast<AliAODConversionPhoton*>(fGoodConvGammas->At(firstGammaIndex));
-      if (gamma0==NULL) continue;
+      if (gamma0==nullptr) continue;
       for(Int_t secondGammaIndex=firstGammaIndex+1;secondGammaIndex<fGoodConvGammas->GetEntries();secondGammaIndex++){
         AliAODConversionPhoton *gamma1=dynamic_cast<AliAODConversionPhoton*>(fGoodConvGammas->At(secondGammaIndex));
         //Check for same Electron ID
-        if (gamma1==NULL) continue;
+        if (gamma1==nullptr) continue;
         if(gamma0->GetTrackLabelPositive() == gamma1->GetTrackLabelPositive() ||
         gamma0->GetTrackLabelNegative() == gamma1->GetTrackLabelNegative() ||
         gamma0->GetTrackLabelNegative() == gamma1->GetTrackLabelPositive() ||
@@ -2054,12 +2396,12 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessNeutralPionCandid
 
     for(Int_t firstGammaIndex=0;firstGammaIndex<fClusterCandidates->GetEntries();firstGammaIndex++){
       AliAODConversionPhoton *gamma0=dynamic_cast<AliAODConversionPhoton*>(fClusterCandidates->At(firstGammaIndex));
-      if (gamma0==NULL) continue;
+      if (gamma0==nullptr) continue;
 
       for(Int_t secondGammaIndex=0;secondGammaIndex<fClusterCandidates->GetEntries();secondGammaIndex++){
         if (firstGammaIndex == secondGammaIndex) continue;
         AliAODConversionPhoton *gamma1=dynamic_cast<AliAODConversionPhoton*>(fClusterCandidates->At(secondGammaIndex));
-        if (gamma1==NULL) continue;
+        if (gamma1==nullptr) continue;
 
         AliAODConversionMother *NDMcand = new AliAODConversionMother(gamma0,gamma1);
         NDMcand->SetLabels(firstGammaIndex,secondGammaIndex);
@@ -2390,7 +2732,7 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessTrueNeutralPionCa
   Bool_t gamma1DalitzCand = kFALSE;
   Int_t motherRealLabel = -1;
 
-  if (AODMCTrackArray!=NULL && TrueGammaCandidate0 != NULL){
+  if (AODMCTrackArray!=nullptr && TrueGammaCandidate0 != nullptr){
     AliAODMCParticle *positiveMC = static_cast<AliAODMCParticle*>(AODMCTrackArray->At(TrueGammaCandidate0->GetMCLabelPositive()));
     AliAODMCParticle *negativeMC = static_cast<AliAODMCParticle*>(AODMCTrackArray->At(TrueGammaCandidate0->GetMCLabelNegative()));
 
@@ -2506,12 +2848,12 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessNeutralPionCandid
 
     for(Int_t firstGammaIndex=0;firstGammaIndex<fGoodConvGammas->GetEntries();firstGammaIndex++){
       AliAODConversionPhoton *gamma0=dynamic_cast<AliAODConversionPhoton*>(fGoodConvGammas->At(firstGammaIndex));
-      if (gamma0==NULL) continue;
+      if (gamma0==nullptr) continue;
 
       for(Int_t secondGammaIndex=0;secondGammaIndex<fClusterCandidates->GetEntries();secondGammaIndex++){
         Bool_t matched = kFALSE;
         AliAODConversionPhoton *gamma1=dynamic_cast<AliAODConversionPhoton*>(fClusterCandidates->At(secondGammaIndex));
-        if (gamma1==NULL) continue;
+        if (gamma1==nullptr) continue;
 
         if (gamma1->GetIsCaloPhoton()){
           AliVCluster* cluster = fInputEvent->GetCaloCluster(gamma1->GetCaloClusterRef());
@@ -2905,7 +3247,7 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessPionCandidates(){
       AliVTrack *posPionCandidate = dynamic_cast<AliVTrack*>(fInputEvent->GetTrack(lGoodPosPionIndexPrev[j]));
       AliKFParticle posPionCandidateKF( *posPionCandidate->GetConstrainedParam(), 211 );
 
-      AliKFConversionPhoton* virtualPhoton = NULL;
+      AliKFConversionPhoton* virtualPhoton = nullptr;
       virtualPhoton = new AliKFConversionPhoton(negPionCandidateKF,posPionCandidateKF);
       AliKFVertex primaryVertexImproved(*fInputEvent->GetPrimaryVertex());
 			// primaryVertexImproved+=*virtualPhoton;
@@ -2916,15 +3258,15 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessPionCandidates(){
       Int_t labelp=0;
       Int_t motherlabelp = 0;
       Int_t motherlabeln = 0;
-      TParticle *fNegativeMCParticle =NULL;
-      TParticle *fPositiveMCParticle =NULL;
+      TParticle *fNegativeMCParticle =nullptr;
+      TParticle *fPositiveMCParticle =nullptr;
       if( fMCEvent ) {
         labeln=TMath::Abs(negPionCandidate->GetLabel());
         labelp=TMath::Abs(posPionCandidate->GetLabel());
-                if(labeln>-1) fNegativeMCParticle = fMCEvent->Particle(labeln);
-                if(labelp>-1) fPositiveMCParticle = fMCEvent->Particle(labelp);
+        if(labeln>-1) fNegativeMCParticle = fMCEvent->Particle(labeln);
+        if(labelp>-1) fPositiveMCParticle = fMCEvent->Particle(labelp);
         // check whether MC particles exist, else abort
-        if (fNegativeMCParticle == NULL || fPositiveMCParticle == NULL) return;
+        if (fNegativeMCParticle == nullptr || fPositiveMCParticle == nullptr) return;
 
         motherlabeln = fNegativeMCParticle->GetMother(0);
         motherlabelp = fPositiveMCParticle->GetMother(0);
@@ -3000,19 +3342,19 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessPionCandidates(){
 
       if (((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->DoMassCut()){
         if (vParticle->GetMass() < ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->GetMassCut()){
-                    fGoodVirtualParticles->Add( vParticle );
-                    if(!fDoLightOutput){
-                      fHistoPionPionInvMassPt[fiCut]->Fill( vParticle->GetMass(),vParticle->Pt());
-                    }
+          fGoodVirtualParticles->Add( vParticle );
+          if(!fDoLightOutput){
+            fHistoPionPionInvMassPt[fiCut]->Fill( vParticle->GetMass(),vParticle->Pt());
+          }
         }else{
           delete vParticle;
           vParticle=0x0;
         }
       } else {
-                fGoodVirtualParticles->Add( vParticle );
-                if(!fDoLightOutput){
-                  fHistoPionPionInvMassPt[fiCut]->Fill( vParticle->GetMass(),vParticle->Pt());
-                }
+        fGoodVirtualParticles->Add( vParticle );
+        if(!fDoLightOutput){
+          fHistoPionPionInvMassPt[fiCut]->Fill( vParticle->GetMass(),vParticle->Pt());
+        }
       }
 
       Double_t clsToFPos = -1.0;
@@ -3069,7 +3411,7 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessPionCandidates(){
       }
 
       delete virtualPhoton;
-      virtualPhoton=NULL;
+      virtualPhoton=nullptr;
     }
   }
 }
@@ -3408,16 +3750,125 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessMCParticles(){
       }
 
       if(!fDoLightOutput){
+        if(fDoMesonQA > 0){
+          // Fill kinematics for heavy particle
+          // This also contains not-reconstructed particles
+          if(TMath::Abs(particle->GetPdgCode()) == fPDGCodeAnalyzedMeson){
+            fHistoMCHeavyAllPt[fiCut]->Fill(particle->Pt());
+            fHistoMCHeavyAllEta[fiCut]->Fill(particle->Eta());
+            fHistoMCHeavyAllPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particle->Phi()));
+            // check for Decay kinematics
+            if(particle->GetNDaughters() == 3){
+              AliVParticle *neutralMeson(nullptr), *piplus(nullptr), *piminus(nullptr);
+              Int_t indexpiplus(-1), indexpiminus(-1);
+              for(int idaug = particle->GetFirstDaughter(); idaug <= particle->GetLastDaughter(); idaug++) {
+                AliVParticle *daughter = fMCEvent->GetTrack(idaug);
+                if(daughter->PdgCode() == kPiPlus){
+                  piplus = daughter;
+                  indexpiplus = idaug;
+                }  else if(daughter->PdgCode() == kPiMinus) {
+                  piminus = daughter;
+                  indexpiminus = idaug;
+                } else if(TMath::Abs(daughter->PdgCode()) == fPDGCodeNDM){
+                  neutralMeson = daughter;
+                }
+              }
+              if(neutralMeson && piplus && piminus) {
+                fHistoMCHeavyChannelPt[fiCut]->Fill(particle->Pt());
+                fHistoMCHeavyChannelEta[fiCut]->Fill(particle->Eta());
+                fHistoMCHeavyChannelPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particle->Phi()));
+                // Fill kinematics for daughter particles
+                fHistMCChannelNDMFromHeavyPt[fiCut]->Fill(neutralMeson->Pt());
+                fHistMCChannelNDMFromHeavyEta[fiCut]->Fill(neutralMeson->Eta());
+                fHistMCChannelNDMFromHeavyPhi[fiCut]->Fill(TVector2::Phi_0_2pi(neutralMeson->Phi()));
+                fHistMCChannelPiPlusFromHeavyPt[fiCut]->Fill(piplus->Pt());
+                fHistMCChannelPiPlusFromHeavyEta[fiCut]->Fill(piplus->Eta());
+                fHistMCChannelPiPlusFromHeavyPhi[fiCut]->Fill(TVector2::Phi_0_2pi(piplus->Phi()));
+                fHistMCChannelPiMinusFromHeavyPt[fiCut]->Fill(piminus->Pt());
+                fHistMCChannelPiMinusFromHeavyEta[fiCut]->Fill(piminus->Eta());
+                fHistMCChannelPiPMinusFromHeavyPhi[fiCut]->Fill(TVector2::Phi_0_2pi(piminus->Phi()));
+                fHistMCChannelNDMPtHeavyPt[fiCut]->Fill(particle->Pt(), neutralMeson->Pt());
+                fHistMCChannelPiPlusPtHeavyPt[fiCut]->Fill(particle->Pt(), piplus->Pt());
+                fHistMCChannelPiMinusPtHeavyPt[fiCut]->Fill(particle->Pt(), piminus->Pt());
+              } 
+              // check if particle is reconstructible
+              bool reconstructible(true);
+              if(((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(indexpiminus,fMCEvent)) reconstructible = false;
+              if(((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(indexpiplus,fMCEvent)) reconstructible = false;
+              if(neutralMeson->GetNDaughters() == 3) {
+                // exclude Dalitz-decays
+                reconstructible = false;
+              } else {
+                AliVParticle *photon1 = fMCEvent->GetTrack(neutralMeson->GetFirstDaughter()), *photon2 = fMCEvent->GetTrack(neutralMeson->GetLastDaughter());
+                if(!(photon1 && photon2)) reconstructible = false;
+                else {
+                  switch(fNDMRecoMode) {
+                    case 0 : {
+                      if(!((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedMC(photon1->Particle(),fMCEvent,kFALSE)) reconstructible = false;
+                      if(!((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedMC(photon2->Particle(),fMCEvent,kFALSE)) reconstructible = false;
+                      break;
+                    }
+                    case 1: {
+                      if(!(((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedMC(photon1->Particle(),fMCEvent,kFALSE)  &&
+                           ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedMC(photon1->Particle(),fMCEvent)) ||
+                         !(((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedMC(photon2->Particle(),fMCEvent,kFALSE)  &&
+                           ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedMC(photon1->Particle(),fMCEvent))                  
+                      ) reconstructible = false;
+                      break;
+                    }
+                    case 2: {
+                      if(!((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedMC(photon1->Particle(),fMCEvent)) reconstructible = false;
+                      if(!((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedMC(photon1->Particle(),fMCEvent)) reconstructible = false;
+                      break;
+                    }
+                  };
+                }
+              }
+              if(reconstructible) {
+                fHistoMCHeavyReconstructiblePt[fiCut]->Fill(particle->Pt());
+                fHistoMCHeavyReconstructibleEta[fiCut]->Fill(particle->Eta());
+                fHistoMCHeavyReconstructiblePhi[fiCut]->Fill(TVector2::Phi_0_2pi(particle->Phi()));
+                // Fill kinematics for daughter particles
+                fHistMCReconstructibleNDMFromHeavyPt[fiCut]->Fill(neutralMeson->Pt());
+                fHistMCReconstructibleNDMFromHeavyEta[fiCut]->Fill(neutralMeson->Eta());
+                fHistMCReconstructibleNDMFromHeavyPhi[fiCut]->Fill(TVector2::Phi_0_2pi(neutralMeson->Phi()));
+                fHistMCReconstructiblePiPlusFromHeavyPt[fiCut]->Fill(piplus->Pt());
+                fHistMCReconstructiblePiPlusFromHeavyEta[fiCut]->Fill(piplus->Eta());
+                fHistMCReconstructiblePiPlusFromHeavyPhi[fiCut]->Fill(TVector2::Phi_0_2pi(piplus->Phi()));
+                fHistMCReconstructiblePiMinusFromHeavyPt[fiCut]->Fill(piminus->Pt());
+                fHistMCReconstructiblePiMinusFromHeavyEta[fiCut]->Fill(piminus->Eta());
+                fHistMCReconstructiblePiPMinusFromHeavyPhi[fiCut]->Fill(TVector2::Phi_0_2pi(piminus->Phi()));
+                fHistMCReconstructibleNDMPtHeavyPt[fiCut]->Fill(particle->Pt(), neutralMeson->Pt());
+                fHistMCReconstructiblePiPlusPtHeavyPt[fiCut]->Fill(particle->Pt(), piplus->Pt());
+                fHistMCReconstructiblePiMinusPtHeavyPt[fiCut]->Fill(particle->Pt(), piminus->Pt());
+              }
+            }
+          }
+        }
+
+        if(((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(i, fMCEvent,fInputEvent)){
           // find MC photons
           if (fNDMRecoMode < 2 ){
             if(((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedMC(particle,fMCEvent,kFALSE)){
               fHistoMCAllGammaPt[fiCut]->Fill(particle->Pt()); // All MC Gamma
               if(particle->GetMother(0) >-1){
                 if (fMCEvent->Particle(particle->GetMother(0))->GetPdgCode() ==fPDGCodeNDM){
+                  TParticle *particleNDM = fMCEvent->Particle(particle->GetMother(0));
+                  if(fDoMesonQA){
+                    fHistoMCAllMesonPt[fiCut]->Fill(particleNDM->Pt());
+                    fHistoMCAllMesonEta[fiCut]->Fill(particleNDM->Eta());
+                    fHistoMCAllMesonPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particleNDM->Phi()));
+                  }
                   if (fMCEvent->Particle(particle->GetMother(0))->GetMother(0) > -1){
                     if ( fMCEvent->Particle((fMCEvent->Particle(particle->GetMother(0)))->GetMother(0))->GetPdgCode() == fPDGCodeAnalyzedMeson ){
-                      if ( fMCEvent->Particle(particle->GetMother(0))->GetNDaughters()==3 )
+                      if ( fMCEvent->Particle((fMCEvent->Particle(particle->GetMother(0)))->GetMother(0))->GetNDaughters()==3 ){
                         fHistoMCGammaFromNeutralMesonPt[fiCut]->Fill(particle->Pt()); // All photons from eta or omega via pi0
+                        if(fDoMesonQA > 0) {
+                          fHistoMCMesonFromNeutralMesonPt[fiCut]->Fill(particleNDM->Pt());   // ALl meson mothers (pi0/eta) from analyzed heavy meson
+                          fHistoMCMesonFromNeutralMesonEta[fiCut]->Fill(particleNDM->Eta());   // All meson mothers (pi0/eta) from analyzed heavy meson
+                          fHistoMCMesonFromNeutralMesonPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particleNDM->Phi()));   // All meson mothers (pi0/eta) from analyzed heavy meson
+                        }
+                      }
                     }
                   }
                 }
@@ -3428,10 +3879,22 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessMCParticles(){
               fHistoMCAllGammaPt[fiCut]->Fill(particle->Pt()); // All MC Gamma
               if(particle->GetMother(0) >-1){
                 if (fMCEvent->Particle(particle->GetMother(0))->GetPdgCode() ==fPDGCodeNDM){
+                  TParticle *particleNDM = fMCEvent->Particle(particle->GetMother(0));
+                  if(fDoMesonQA > 0){
+                    fHistoMCAllMesonPt[fiCut]->Fill(particleNDM->Pt());
+                    fHistoMCAllMesonEta[fiCut]->Fill(particleNDM->Eta());
+                    fHistoMCAllMesonPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particleNDM->Phi()));
+                  }
                   if (fMCEvent->Particle(particle->GetMother(0))->GetMother(0) > -1){
                     if ( fMCEvent->Particle((fMCEvent->Particle(particle->GetMother(0)))->GetMother(0))->GetPdgCode() == fPDGCodeAnalyzedMeson ){
-                      if ( fMCEvent->Particle(particle->GetMother(0))->GetNDaughters()==3 )
+                      if ( fMCEvent->Particle((fMCEvent->Particle(particle->GetMother(0)))->GetMother(0))->GetNDaughters()==3 ){
                         fHistoMCGammaFromNeutralMesonPt[fiCut]->Fill(particle->Pt()); // All photons from analyzed meson via pi0 or eta from decay
+                        if(fDoMesonQA > 0){
+                          fHistoMCMesonFromNeutralMesonPt[fiCut]->Fill(particleNDM->Pt());   // All meson mothers (pi0/eta) from analyzed heavy meson
+                          fHistoMCMesonFromNeutralMesonEta[fiCut]->Fill(particleNDM->Eta());   // All meson mothers (pi0/eta) from analyzed heavy meson
+                          fHistoMCMesonFromNeutralMesonPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particleNDM->Phi()));   // All meson mothers (pi0/eta) from analyzed heavy meson
+                        }
+                      }
                     }
                   }
                 }
@@ -3446,84 +3909,104 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessMCParticles(){
           if(((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(i,fMCEvent)){
             if( particle->GetPdgCode() == 211){
               fHistoMCAllPosPionsPt[fiCut]->Fill(particle->Pt()); // All pos pions
+              if(fDoMesonQA > 0){
+                fHistoMCAllPosPionsEta[fiCut]->Fill(particle->Eta()); // All pos pions
+                fHistoMCAllPosPionsPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particle->Phi())); // All pos pions
+              }
               if(particle->GetMother(0) >-1){
-                if (fMCEvent->Particle(particle->GetMother(0))->GetPdgCode() ==fPDGCodeAnalyzedMeson)
+                if (fMCEvent->Particle(particle->GetMother(0))->GetPdgCode() ==fPDGCodeAnalyzedMeson){
                   fHistoMCPosPionsFromNeutralMesonPt[fiCut]->Fill(particle->Pt()); // All pos from neutral heavy meson (omega, eta OR eta prime)
+                  if(fDoMesonQA > 0){
+                    fHistoMCPosPionsFromNeutralMesonEta[fiCut]->Fill(particle->Eta()); // All pos from neutral heavy meson (omega, eta OR eta prime)
+                    fHistoMCPosPionsFromNeutralMesonPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particle->Phi())); // All pos from neutral heavy meson (omega, eta OR eta prime)
+                  }
+                }
               }
             }
             if( particle->GetPdgCode() == -211){
               fHistoMCAllNegPionsPt[fiCut]->Fill(particle->Pt()); // All neg pions
+              if(fDoMesonQA > 0) {
+                fHistoMCAllNegPionsEta[fiCut]->Fill(particle->Eta()); // All neg pions
+                fHistoMCAllNegPionsPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particle->Phi())); // All neg pions
+              }
               if(particle->GetMother(0) >-1){
-                if (fMCEvent->Particle(particle->GetMother(0))->GetPdgCode() ==fPDGCodeAnalyzedMeson)
+                if (fMCEvent->Particle(particle->GetMother(0))->GetPdgCode() ==fPDGCodeAnalyzedMeson){
                   fHistoMCNegPionsFromNeutralMesonPt[fiCut]->Fill(particle->Pt()); // All pos from neutral heavy meson (omega, eta OR eta prime)
-              }
-            }
-          }
-      }
-
-        // \eta -> pi+ pi- \gamma
-        Int_t labelNDM = -1;
-        Int_t labelNegPion = -1;
-        Int_t labelPosPion = -1;
-
-        if( ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelectedMCPiPlPiMiPiZero(particle,fMCEvent,labelNegPion,labelPosPion,labelNDM,((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift()) ||   ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelectedMCPiPlPiMiEta(particle,fMCEvent,labelNegPion,labelPosPion,labelNDM,((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift())){
-          Float_t weighted= 1;
-          if( ((AliPrimaryPionCuts*) fPionCutArray->At(fiCut))->DoWeights() ) {
-            if(((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(i, fMCEvent,fInputEvent)){
-              if (particle->Pt()>0.005){
-                weighted= ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetWeightForMeson(i, fMCEvent,fInputEvent);
-              }
-            }
-          }
-          if(particle->GetPdgCode() == fPDGCodeAnalyzedMeson)fHistoMCHNMPiPlPiMiNDMPt[fiCut]->Fill(particle->Pt(), weighted); 	// All MC eta, omega OR eta prime in respective decay channel
-
-          if(labelNDM>-1){
-            TParticle *particleNDM    = fMCEvent->Particle(labelNDM);
-            if(particleNDM->GetDaughter(0)>-1 && particleNDM->GetDaughter(1)>-1){
-              TParticle *gamma1 = fMCEvent->Particle(particleNDM->GetDaughter(0));
-              TParticle *gamma2 = fMCEvent->Particle(particleNDM->GetDaughter(1));
-              Bool_t kDaughter0IsPrim = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryESD( fMCEvent, particleNDM->GetDaughter(0), mcProdVtxX, mcProdVtxY, mcProdVtxZ);
-              Bool_t kDaughter1IsPrim = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryESD( fMCEvent, particleNDM->GetDaughter(1), mcProdVtxX, mcProdVtxY, mcProdVtxZ);
-              Bool_t kNegPionIsPrim = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryESD( fMCEvent, labelNegPion, mcProdVtxX, mcProdVtxY, mcProdVtxZ);
-              Bool_t kPosPionIsPrim = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryESD( fMCEvent, labelPosPion, mcProdVtxX, mcProdVtxY, mcProdVtxZ);
-
-              if (fNDMRecoMode == 0){
-                if( kDaughter0IsPrim && kDaughter1IsPrim && kNegPionIsPrim && kPosPionIsPrim &&
-                    ((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedMC(gamma1,fMCEvent,kFALSE) &&					// test first daugther of pi0
-                    ((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedMC(gamma2,fMCEvent,kFALSE) &&					// test second daughter of pi0
-                    ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(labelNegPion,fMCEvent) &&								// test negative pion
-                    ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(labelPosPion,fMCEvent) 								// test positive pion
-                ) {
-                  if(particle->GetPdgCode() == fPDGCodeAnalyzedMeson) fHistoMCHNMPiPlPiMiNDMInAccPt[fiCut]->Fill(particle->Pt(), weighted ); 		// MC Eta, omega or eta prime with pi+ pi- pi0 with gamma's and e+e- in acc
-                }
-              } else if (fNDMRecoMode == 1){ // mixed mode
-                // check if within PCM acceptance first
-                if( kDaughter0IsPrim && kDaughter1IsPrim && kNegPionIsPrim && kPosPionIsPrim &&
-                        ((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedMC(gamma1,fMCEvent,kFALSE) &&					// test first daugther of pi0
-                        ((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedMC(gamma2,fMCEvent,kFALSE) &&					// test second daughter of pi0
-                        ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(labelNegPion,fMCEvent) &&								// test negative pion
-                        ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(labelPosPion,fMCEvent) 								// test positive pion
-                        ) {
-                    // check acceptance of clusters as well, true if one of them points into the Calo acceptance
-                   if (((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedMC(gamma1,fMCEvent) ||
-                       ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedMC(gamma2,fMCEvent) ){
-                       if(particle->GetPdgCode() == fPDGCodeAnalyzedMeson) fHistoMCHNMPiPlPiMiNDMInAccPt[fiCut]->Fill(particle->Pt(), weighted ); 		// MC Eta, omega or eta prime with pi+ pi- pi0 with gamma's and e+e- in acc
-                   }
-                }
-              } else if (fNDMRecoMode == 2){
-                if( kDaughter0IsPrim && kDaughter1IsPrim && kNegPionIsPrim && kPosPionIsPrim &&
-                    ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedMC(gamma1,fMCEvent) &&					// test first daugther of pi0
-                    ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedMC(gamma2,fMCEvent) &&					// test second daughter of pi0
-                    ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(labelNegPion,fMCEvent) &&								// test negative pion
-                    ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(labelPosPion,fMCEvent) 								// test positive pion
-                ) {
-                  if(particle->GetPdgCode() == fPDGCodeAnalyzedMeson) fHistoMCHNMPiPlPiMiNDMInAccPt[fiCut]->Fill(particle->Pt(), weighted ); 		// MC Eta pi+ pi- pi0 with gamma's and e+e- in acc
+                  if(fDoMesonQA > 0){
+                    fHistoMCNegPionsFromNeutralMesonEta[fiCut]->Fill(particle->Eta()); // All pos from neutral heavy meson (omega, eta OR eta prime)
+                    fHistoMCNegPionsFromNeutralMesonPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particle->Phi())); // All pos from neutral heavy meson (omega, eta OR eta prime)
+                  }
                 }
               }
             }
           }
         }
-    }
+      }
+
+      // \eta -> pi+ pi- \gamma
+      Int_t labelNDM = -1;
+      Int_t labelNegPion = -1;
+      Int_t labelPosPion = -1;
+
+      if( ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelectedMCPiPlPiMiPiZero(particle,fMCEvent,labelNegPion,labelPosPion,labelNDM,((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift()) ||   ((AliConversionMesonCuts*)fMesonCutArray->At(fiCut))->MesonIsSelectedMCPiPlPiMiEta(particle,fMCEvent,labelNegPion,labelPosPion,labelNDM,((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift())){
+        Float_t weighted= 1;
+        if( ((AliPrimaryPionCuts*) fPionCutArray->At(fiCut))->DoWeights() ) {
+          if(((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsParticleFromBGEvent(i, fMCEvent,fInputEvent)){
+            if (particle->Pt()>0.005){
+              weighted= ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetWeightForMeson(i, fMCEvent,fInputEvent);
+            }
+          }
+        }
+        if(particle->GetPdgCode() == fPDGCodeAnalyzedMeson)fHistoMCHNMPiPlPiMiNDMPt[fiCut]->Fill(particle->Pt(), weighted); 	// All MC eta, omega OR eta prime in respective decay channel
+
+        if(labelNDM>-1){
+          TParticle *particleNDM    = fMCEvent->Particle(labelNDM);
+          if(particleNDM->GetDaughter(0)>-1 && particleNDM->GetDaughter(1)>-1){
+            TParticle *gamma1 = fMCEvent->Particle(particleNDM->GetDaughter(0));
+            TParticle *gamma2 = fMCEvent->Particle(particleNDM->GetDaughter(1));
+            Bool_t kDaughter0IsPrim = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryESD( fMCEvent, particleNDM->GetDaughter(0), mcProdVtxX, mcProdVtxY, mcProdVtxZ);
+            Bool_t kDaughter1IsPrim = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryESD( fMCEvent, particleNDM->GetDaughter(1), mcProdVtxX, mcProdVtxY, mcProdVtxZ);
+            Bool_t kNegPionIsPrim = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryESD( fMCEvent, labelNegPion, mcProdVtxX, mcProdVtxY, mcProdVtxZ);
+            Bool_t kPosPionIsPrim = ((AliConvEventCuts*)fEventCutArray->At(fiCut))->IsConversionPrimaryESD( fMCEvent, labelPosPion, mcProdVtxX, mcProdVtxY, mcProdVtxZ);
+
+            if (fNDMRecoMode == 0){
+              if( kDaughter0IsPrim && kDaughter1IsPrim && kNegPionIsPrim && kPosPionIsPrim &&
+                  ((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedMC(gamma1,fMCEvent,kFALSE) &&					// test first daugther of pi0
+                  ((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedMC(gamma2,fMCEvent,kFALSE) &&					// test second daughter of pi0
+                  ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(labelNegPion,fMCEvent) &&								// test negative pion
+                  ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(labelPosPion,fMCEvent) 								// test positive pion
+              ) {
+                if(particle->GetPdgCode() == fPDGCodeAnalyzedMeson) fHistoMCHNMPiPlPiMiNDMInAccPt[fiCut]->Fill(particle->Pt(), weighted ); 		// MC Eta, omega or eta prime with pi+ pi- pi0 with gamma's and e+e- in acc
+              }
+            } else if (fNDMRecoMode == 1){ // mixed mode
+              // check if within PCM acceptance first
+              if( kDaughter0IsPrim && kDaughter1IsPrim && kNegPionIsPrim && kPosPionIsPrim &&
+                      ((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedMC(gamma1,fMCEvent,kFALSE) &&					// test first daugther of pi0
+                      ((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedMC(gamma2,fMCEvent,kFALSE) &&					// test second daughter of pi0
+                      ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(labelNegPion,fMCEvent) &&								// test negative pion
+                      ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(labelPosPion,fMCEvent) 								// test positive pion
+                ) {
+                // check acceptance of clusters as well, true if one of them points into the Calo acceptance
+                if (((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedMC(gamma1,fMCEvent) ||
+                       ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedMC(gamma2,fMCEvent) ){
+                  if(particle->GetPdgCode() == fPDGCodeAnalyzedMeson) fHistoMCHNMPiPlPiMiNDMInAccPt[fiCut]->Fill(particle->Pt(), weighted ); 		// MC Eta, omega or eta prime with pi+ pi- pi0 with gamma's and e+e- in acc
+                }
+              }
+            } else if (fNDMRecoMode == 2){
+              if( kDaughter0IsPrim && kDaughter1IsPrim && kNegPionIsPrim && kPosPionIsPrim &&
+                  ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedMC(gamma1,fMCEvent) &&					// test first daugther of pi0
+                  ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedMC(gamma2,fMCEvent) &&					// test second daughter of pi0
+                  ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(labelNegPion,fMCEvent) &&								// test negative pion
+                  ((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(labelPosPion,fMCEvent) 								// test positive pion
+              ) {
+                if(particle->GetPdgCode() == fPDGCodeAnalyzedMeson) fHistoMCHNMPiPlPiMiNDMInAccPt[fiCut]->Fill(particle->Pt(), weighted ); 		// MC Eta pi+ pi- pi0 with gamma's and e+e- in acc
+              }
+            }
+          }
+        }
+      }
+    } 
+    
   }
 }
 
@@ -3550,16 +4033,120 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessAODMCParticles(){
           if(isMCFromMBHeader == 0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 3) continue;
         }
         if(!fDoLightOutput){
+          // Fill kinematics for heavy particle
+          // This also contains not-reconstructed particles
+          if(fDoMesonQA > 0){
+            if(TMath::Abs(particle->GetPdgCode()) == fPDGCodeAnalyzedMeson){
+              fHistoMCHeavyAllPt[fiCut]->Fill(particle->Pt());
+              fHistoMCHeavyAllEta[fiCut]->Fill(particle->Eta());
+              fHistoMCHeavyAllPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particle->Phi()));
+              // check for Decay kinematics
+              if(particle->GetNDaughters() == 3){
+                AliAODMCParticle *neutralMeson(nullptr), *piplus(nullptr), *piminus(nullptr);
+                Int_t indexpiplus(-1), indexpiminus(-1);
+                for(int idaug = particle->GetFirstDaughter(); idaug <= particle->GetLastDaughter(); idaug++) {
+                  AliAODMCParticle *daughter = static_cast<AliAODMCParticle *>(AODMCTrackArray->At(idaug));
+                  if(daughter->PdgCode() == kPiPlus){
+                    piplus = daughter;
+                    indexpiplus = idaug;
+                  } else if(daughter->PdgCode() == kPiMinus) {
+                    piminus = daughter;
+                    indexpiminus = idaug;
+                  } else if(TMath::Abs(daughter->PdgCode()) == fPDGCodeNDM){
+                    neutralMeson = daughter;
+                  }
+                }
+                if(neutralMeson && piplus && piminus) {
+                  fHistoMCHeavyChannelPt[fiCut]->Fill(particle->Pt());
+                  fHistoMCHeavyChannelEta[fiCut]->Fill(particle->Eta());
+                  fHistoMCHeavyChannelPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particle->Phi()));
+                  // Fill kinematics for daughter particles
+                  fHistMCChannelNDMFromHeavyPt[fiCut]->Fill(neutralMeson->Pt());
+                  fHistMCChannelNDMFromHeavyEta[fiCut]->Fill(neutralMeson->Eta());
+                  fHistMCChannelNDMFromHeavyPhi[fiCut]->Fill(TVector2::Phi_0_2pi(neutralMeson->Phi()));
+                  fHistMCChannelPiPlusFromHeavyPt[fiCut]->Fill(piplus->Pt());
+                  fHistMCChannelPiPlusFromHeavyEta[fiCut]->Fill(piplus->Eta());
+                  fHistMCChannelPiPlusFromHeavyPhi[fiCut]->Fill(TVector2::Phi_0_2pi(piplus->Phi()));
+                  fHistMCChannelPiMinusFromHeavyPt[fiCut]->Fill(piminus->Pt());
+                  fHistMCChannelPiMinusFromHeavyEta[fiCut]->Fill(piminus->Eta());
+                  fHistMCChannelPiPMinusFromHeavyPhi[fiCut]->Fill(TVector2::Phi_0_2pi(piminus->Phi()));
+                  fHistMCChannelNDMPtHeavyPt[fiCut]->Fill(particle->Pt(), neutralMeson->Pt());
+                  fHistMCChannelPiPlusPtHeavyPt[fiCut]->Fill(particle->Pt(), piplus->Pt());
+                  fHistMCChannelPiMinusPtHeavyPt[fiCut]->Fill(particle->Pt(), piminus->Pt());
+                } 
+                // check if particle is reconstructible
+                bool reconstructible(true);
+                if(((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(indexpiminus,fMCEvent)) reconstructible = false;
+                if(((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedMC(indexpiplus,fMCEvent)) reconstructible = false;
+                if(neutralMeson->GetNDaughters() == 3) {
+                  // exclude Dalitz-decays
+                  reconstructible = false;
+                } else {
+                  AliAODMCParticle *photon1 = static_cast<AliAODMCParticle *>(AODMCTrackArray->At(neutralMeson->GetFirstDaughter())), 
+                                   *photon2 = static_cast<AliAODMCParticle *>(AODMCTrackArray->At(neutralMeson->GetLastDaughter()));
+                  if(!(photon1 && photon2)) reconstructible = false;
+                  else {
+                    switch(fNDMRecoMode) {
+                      case 0 : {
+                        if(!((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedAODMC(photon1, AODMCTrackArray, kFALSE)) reconstructible = false;
+                        if(!((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedAODMC(photon2, AODMCTrackArray, kFALSE)) reconstructible = false;
+                        break;
+                      }
+                      case 1: {
+                        if(!(((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedAODMC(photon1, AODMCTrackArray, kFALSE)  &&
+                            ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedAODMC(photon1, AODMCTrackArray)) ||
+                           !(((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedAODMC(photon2, AODMCTrackArray, kFALSE)  &&
+                            ((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedAODMC(photon1, AODMCTrackArray))                  
+                        ) reconstructible = false;
+                        break;
+                      }
+                      case 2: {
+                        if(!((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedAODMC(photon1, AODMCTrackArray)) reconstructible = false;
+                        if(!((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedAODMC(photon1, AODMCTrackArray)) reconstructible = false;
+                        break;
+                      }
+                    };
+                  }
+                }
+                if(reconstructible) {
+                  fHistoMCHeavyReconstructiblePt[fiCut]->Fill(particle->Pt());
+                  fHistoMCHeavyReconstructibleEta[fiCut]->Fill(particle->Eta());
+                  fHistoMCHeavyReconstructiblePhi[fiCut]->Fill(TVector2::Phi_0_2pi(particle->Phi()));
+                  // Fill kinematics for daughter particles
+                  fHistMCReconstructibleNDMFromHeavyPt[fiCut]->Fill(neutralMeson->Pt());
+                  fHistMCReconstructibleNDMFromHeavyEta[fiCut]->Fill(neutralMeson->Eta());
+                  fHistMCReconstructibleNDMFromHeavyPhi[fiCut]->Fill(TVector2::Phi_0_2pi(neutralMeson->Phi()));
+                  fHistMCReconstructiblePiPlusFromHeavyPt[fiCut]->Fill(piplus->Pt());
+                  fHistMCReconstructiblePiPlusFromHeavyEta[fiCut]->Fill(piplus->Eta());
+                  fHistMCReconstructiblePiPlusFromHeavyPhi[fiCut]->Fill(TVector2::Phi_0_2pi(piplus->Phi()));
+                  fHistMCReconstructiblePiMinusFromHeavyPt[fiCut]->Fill(piminus->Pt());
+                  fHistMCReconstructiblePiMinusFromHeavyEta[fiCut]->Fill(piminus->Eta());
+                  fHistMCReconstructiblePiPMinusFromHeavyPhi[fiCut]->Fill(TVector2::Phi_0_2pi(piminus->Phi()));
+                  fHistMCReconstructibleNDMPtHeavyPt[fiCut]->Fill(particle->Pt(), neutralMeson->Pt());
+                  fHistMCReconstructiblePiPlusPtHeavyPt[fiCut]->Fill(particle->Pt(), piplus->Pt());
+                  fHistMCReconstructiblePiMinusPtHeavyPt[fiCut]->Fill(particle->Pt(), piminus->Pt());
+                }
+              }
+            }
+          }
             // find MC photons
             if (fNDMRecoMode < 2 ){
               if(((AliConversionPhotonCuts*)fGammaCutArray->At(fiCut))->PhotonIsSelectedAODMC(particle,AODMCTrackArray,kFALSE)){
                 fHistoMCAllGammaPt[fiCut]->Fill(particle->Pt()); // All MC Gamma
                 if(particle->GetMother() >-1){
+                  AliAODMCParticle *particleNDM = static_cast<AliAODMCParticle *>(AODMCTrackArray->At(particle->GetMother()));
+                  fHistoMCAllMesonPt[fiCut]->Fill(particleNDM->Pt());
+                  fHistoMCAllMesonEta[fiCut]->Fill(particleNDM->Eta());
+                  fHistoMCAllMesonPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particleNDM->Phi()));
                   if ((static_cast<AliAODMCParticle*>(AODMCTrackArray->At(particle->GetMother())))->GetPdgCode() ==fPDGCodeNDM){
                     if ((static_cast<AliAODMCParticle*>(AODMCTrackArray->At(particle->GetMother())))->GetMother() > -1){
                       if ( (static_cast<AliAODMCParticle*>(AODMCTrackArray->At( (static_cast<AliAODMCParticle*>(AODMCTrackArray->At(particle->GetMother())))->GetMother() )))->GetPdgCode() == fPDGCodeAnalyzedMeson ){
-                        if ( (static_cast<AliAODMCParticle*>(AODMCTrackArray->At(particle->GetMother())))->GetNDaughters() ==3 )
+                        if ( (static_cast<AliAODMCParticle*>(AODMCTrackArray->At( (static_cast<AliAODMCParticle*>(AODMCTrackArray->At(particle->GetMother())))->GetMother() )))->GetNDaughters() ==3 ) {
                           fHistoMCGammaFromNeutralMesonPt[fiCut]->Fill(particle->Pt()); // All photons from eta or omega via pi0
+                          fHistoMCMesonFromNeutralMesonPt[fiCut]->Fill(particleNDM->Pt());   // ALl meson mothers (pi0/eta) from analyzed heavy meson
+                          fHistoMCMesonFromNeutralMesonEta[fiCut]->Fill(particleNDM->Eta());   // All meson mothers (pi0/eta) from analyzed heavy meson
+                          fHistoMCMesonFromNeutralMesonPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particleNDM->Phi()));   // All meson mothers (pi0/eta) from analyzed heavy meson
+                        }
                       }
                     }
                   }
@@ -3569,11 +4156,23 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessAODMCParticles(){
               if(((AliCaloPhotonCuts*)fClusterCutArray->At(fiCut))->ClusterIsSelectedAODMC(particle,AODMCTrackArray)){
                 fHistoMCAllGammaPt[fiCut]->Fill(particle->Pt()); // All MC Gamma
                 if(particle->GetMother() >-1){
+                  AliAODMCParticle *particleNDM = static_cast<AliAODMCParticle *>(AODMCTrackArray->At(particle->GetMother()));
+                  if(fDoMesonQA > 0){
+                    fHistoMCAllMesonPt[fiCut]->Fill(particleNDM->Pt());
+                    fHistoMCAllMesonEta[fiCut]->Fill(particleNDM->Eta());
+                    fHistoMCAllMesonPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particleNDM->Phi()));
+                  }
                   if ( (static_cast<AliAODMCParticle*>(AODMCTrackArray->At(particle->GetMother())))->GetPdgCode() == fPDGCodeNDM){
                     if ((static_cast<AliAODMCParticle*>(AODMCTrackArray->At(particle->GetMother())))->GetMother() > -1){
                       if ( (static_cast<AliAODMCParticle*>(AODMCTrackArray->At( (static_cast<AliAODMCParticle*>(AODMCTrackArray->At(particle->GetMother())))->GetMother() )))->GetPdgCode() == fPDGCodeAnalyzedMeson ){
-                        if ( (static_cast<AliAODMCParticle*>(AODMCTrackArray->At(particle->GetMother())))->GetNDaughters() ==3 )
+                        if ( (static_cast<AliAODMCParticle*>(AODMCTrackArray->At( (static_cast<AliAODMCParticle*>(AODMCTrackArray->At(particle->GetMother())))->GetMother() )))->GetNDaughters() ==3 ) {
                           fHistoMCGammaFromNeutralMesonPt[fiCut]->Fill(particle->Pt()); // All photons from analyzed meson via pi0 or eta from decay
+                          if(fDoMesonQA > 0){
+                            fHistoMCMesonFromNeutralMesonPt[fiCut]->Fill(particleNDM->Pt());   // All meson mothers (pi0/eta) from analyzed heavy meson
+                            fHistoMCMesonFromNeutralMesonEta[fiCut]->Fill(particleNDM->Eta());   // All meson mothers (pi0/eta) from analyzed heavy meson
+                            fHistoMCMesonFromNeutralMesonPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particleNDM->Phi()));   // All meson mothers (pi0/eta) from analyzed heavy meson
+                          }
+                        }
                       }
                     }
                   }
@@ -3588,16 +4187,34 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessAODMCParticles(){
             if(((AliPrimaryPionCuts*)fPionCutArray->At(fiCut))->PionIsSelectedAODMC(i,AODMCTrackArray)){
               if( particle->GetPdgCode() == 211){
                 fHistoMCAllPosPionsPt[fiCut]->Fill(particle->Pt()); // All pos pions
+                if(fDoMesonQA > 0){
+                  fHistoMCAllPosPionsEta[fiCut]->Fill(particle->Eta()); // All pos pions
+                  fHistoMCAllPosPionsPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particle->Phi())); // All pos pions
+                }
                 if(particle->GetMother() >-1){
-                  if ( (static_cast<AliAODMCParticle*>(AODMCTrackArray->At(particle->GetMother())))->GetPdgCode() ==fPDGCodeAnalyzedMeson)
+                  if ( (static_cast<AliAODMCParticle*>(AODMCTrackArray->At(particle->GetMother())))->GetPdgCode() ==fPDGCodeAnalyzedMeson){
                     fHistoMCPosPionsFromNeutralMesonPt[fiCut]->Fill(particle->Pt()); // All pos from neutral heavy meson (omega, eta OR eta prime)
+                    if(fDoMesonQA > 0){
+                      fHistoMCPosPionsFromNeutralMesonEta[fiCut]->Fill(particle->Eta()); // All pos from neutral heavy meson (omega, eta OR eta prime)
+                      fHistoMCPosPionsFromNeutralMesonPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particle->Phi())); // All pos from neutral heavy meson (omega, eta OR eta prime)
+                    }
+                  }
                 }
               }
               if( particle->GetPdgCode() == -211){
                 fHistoMCAllNegPionsPt[fiCut]->Fill(particle->Pt()); // All neg pions
+                if(fDoMesonQA){
+                  fHistoMCAllNegPionsEta[fiCut]->Fill(particle->Eta()); // All neg pions
+                  fHistoMCAllNegPionsPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particle->Phi())); // All neg pions
+                }
                 if(particle->GetMother() >-1){
-                  if ((static_cast<AliAODMCParticle*>(AODMCTrackArray->At(particle->GetMother())))->GetPdgCode() ==fPDGCodeAnalyzedMeson)
+                  if ((static_cast<AliAODMCParticle*>(AODMCTrackArray->At(particle->GetMother())))->GetPdgCode() ==fPDGCodeAnalyzedMeson) {
                     fHistoMCNegPionsFromNeutralMesonPt[fiCut]->Fill(particle->Pt()); // All pos from neutral heavy meson (omega, eta OR eta prime)
+                    if(fDoMesonQA) {
+                      fHistoMCNegPionsFromNeutralMesonEta[fiCut]->Fill(particle->Eta()); // All pos from neutral heavy meson (omega, eta OR eta prime)
+                      fHistoMCNegPionsFromNeutralMesonPhi[fiCut]->Fill(TVector2::Phi_0_2pi(particle->Phi())); // All pos from neutral heavy meson (omega, eta OR eta prime)
+                    }
+                  }
                 }
               }
             }
@@ -3679,11 +4296,11 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::CalculateMesonCandidates
   if( fNeutralDecayParticleCandidates->GetEntries() > 0 && fGoodVirtualParticles->GetEntries() > 0 ){
     for(Int_t mesonIndex=0; mesonIndex<fNeutralDecayParticleCandidates->GetEntries(); mesonIndex++){
       AliAODConversionMother *neutralDecayMeson=dynamic_cast<AliAODConversionMother*>(fNeutralDecayParticleCandidates->At(mesonIndex));
-      if (neutralDecayMeson==NULL) continue;
+      if (neutralDecayMeson==nullptr) continue;
 
       for(Int_t virtualParticleIndex=0;virtualParticleIndex<fGoodVirtualParticles->GetEntries();virtualParticleIndex++){
         AliAODConversionPhoton *vParticle=dynamic_cast<AliAODConversionPhoton*>(fGoodVirtualParticles->At(virtualParticleIndex));
-        if (vParticle==NULL) continue;
+        if (vParticle==nullptr) continue;
         //Check for same Electron ID
 
         AliAODConversionMother* mesoncand = new AliAODConversionMother(neutralDecayMeson,vParticle);
@@ -3760,8 +4377,8 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::CalculateBackground(){
       mbin = fBGHandlerPiMi[fiCut]->GetMultiplicityBinIndex(fClusterCandidates->GetEntries());
   }
 
-  AliGammaConversionAODBGHandler::GammaConversionVertex *bgEventVertexPl = NULL;
-  AliGammaConversionAODBGHandler::GammaConversionVertex *bgEventVertexMi = NULL;
+  AliGammaConversionAODBGHandler::GammaConversionVertex *bgEventVertexPl = nullptr;
+  AliGammaConversionAODBGHandler::GammaConversionVertex *bgEventVertexMi = nullptr;
 
   // Get N of Pi0 according to chosen mix mode
   Int_t NNDMCandidates = 0;

--- a/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.h
@@ -241,16 +241,65 @@ class AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson: public AliAnalysisTaskS
     TH2F**                            fHistoMotherLikeSignBackInvMassFixedPzNDMPt;        // array of histos of pi+pi+pi0 likesign mixed event, invMass, pT_{pi+pi+pi0}, the Pz of the pi0 was fixed such that
                                                                                           // its invMass matches the PDG value
     // pure MC properties
-    TH1F**                            fHistoMCAllGammaPt;                                 // array of histos of all produced gammas in the specified y range
-    TH1F**                            fHistoMCConvGammaPt;                                // array of histos of all converted gammas in the specified y range
-    TH1F**                            fHistoMCAllPosPionsPt;                              // array of histos with all produced primary positive pions in the specified y range
-    TH1F**                            fHistoMCAllNegPionsPt;                              // array of histos with all produced primary negative pions in the specified y range
-    TH1F**                            fHistoMCGammaFromNeutralMesonPt;                    // array of histos of all produced gammas from omega or eta via pi+pi-pi0 in the specified y range/
-    TH1F**                            fHistoMCPosPionsFromNeutralMesonPt;                 // array of histos of all produced positive pions from omega or eta via pi+pi-pi0 in the specified y range/
-    TH1F**                            fHistoMCNegPionsFromNeutralMesonPt;                 // array of histos of all produced negative pions from omega or eta via pi+pi-pi0 in the specified y range/
-    TH1F**                            fHistoMCHNMPiPlPiMiNDMPt;                        // array of histos of produced etas via pi+pi-pi0 in the specified y range
-    TH1F**                            fHistoMCHNMPiPlPiMiNDMInAccPt;                   // array of histos of produced etas via pi+pi-pi0 in the specified y range,
+    TH1F**                            fHistoMCAllGammaPt;                                 ///< array of histos of all produced gammas in the specified y range
+    TH1F**                            fHistoMCConvGammaPt;                                ///< array of histos of all converted gammas in the specified y range
+    TH1F**                            fHistoMCAllMesonPt;                                 ///< array of histos of pt of all neutral decay mesons in the specified y range
+    TH1F**                            fHistoMCAllMesonEta;                                ///< array of histos of eta of all neutral decay mesons in the specified y range
+    TH1F**                            fHistoMCAllMesonPhi;                                ///< array of histos of phi of all neutral decay mesons in the specified y range
+    TH1F**                            fHistoMCMesonFromNeutralMesonPt;                    ///< array of histos of pt of neutral decay mesons from heavy meson in the specified y range
+    TH1F**                            fHistoMCMesonFromNeutralMesonEta;                   ///< array of histos of eta of neutral decay mesons from heavy meson in the specified y range
+    TH1F**                            fHistoMCMesonFromNeutralMesonPhi;                   ///< array of histos of phi of neutral decay mesons from heavy meson in the specified y range
+    TH1F**                            fHistoMCAllPosPionsPt;                              ///< array of histos with all produced primary positive pions in the specified y range
+    TH1F**                            fHistoMCAllPosPionsEta;                             ///< array of histos with all produced primary positive pions in the specified y range
+    TH1F**                            fHistoMCAllPosPionsPhi;                             ///< array of histos with all produced primary positive pions in the specified y range
+    TH1F**                            fHistoMCAllNegPionsPt;                              ///< array of histos with all produced primary negative pions in the specified y range
+    TH1F**                            fHistoMCAllNegPionsEta;                             ///< array of histos with all produced primary negative pions in the specified y range
+    TH1F**                            fHistoMCAllNegPionsPhi;                             ///< array of histos with all produced primary negative pions in the specified y range
+    TH1F**                            fHistoMCGammaFromNeutralMesonPt;                    ///< array of histos of all produced gammas from omega or eta via pi+pi-pi0 in the specified y range/
+    TH1F**                            fHistoMCPosPionsFromNeutralMesonPt;                 ///< array of histos of all produced positive pions from omega or eta via pi+pi-pi0 in the specified y range/
+    TH1F**                            fHistoMCPosPionsFromNeutralMesonEta;                ///< array of histos of all produced positive pions from omega or eta via pi+pi-pi0 in the specified y range/
+    TH1F**                            fHistoMCPosPionsFromNeutralMesonPhi;                ///< array of histos of all produced positive pions from omega or eta via pi+pi-pi0 in the specified y range/
+    TH1F**                            fHistoMCNegPionsFromNeutralMesonPt;                 ///< array of histos of all produced negative pions from omega or eta via pi+pi-pi0 in the specified y range/
+    TH1F**                            fHistoMCNegPionsFromNeutralMesonEta;                ///< array of histos of all produced negative pions from omega or eta via pi+pi-pi0 in the specified y range/
+    TH1F**                            fHistoMCNegPionsFromNeutralMesonPhi;                ///< array of histos of all produced negative pions from omega or eta via pi+pi-pi0 in the specified y range/
+    TH1F**                            fHistoMCHNMPiPlPiMiNDMPt;                           ///< array of histos of produced etas via pi+pi-pi0 in the specified y range
+    TH1F**                            fHistoMCHNMPiPlPiMiNDMInAccPt;                      ///< array of histos of produced etas via pi+pi-pi0 in the specified y range,
                                                                                           // with decay products in respective y, eta ranges
+    
+    // MC truth properties for heavy meson (and decay products)
+    TH1F**                            fHistoMCHeavyAllPt;                                 ///< array of histos with pt of all heavy mesons
+    TH1F**                            fHistoMCHeavyAllEta;                                ///< array of histos with eta of all heavy mesons
+    TH1F**                            fHistoMCHeavyAllPhi;                                ///< array of histos with phi of all heavy mesons
+    TH1F**                            fHistoMCHeavyChannelPt;                             ///< array of histos with pt of heavy mesons in the decay channel
+    TH1F**                            fHistoMCHeavyChannelEta;                            ///< array of histos with eta of heavy mesons in the decay channel
+    TH1F**                            fHistoMCHeavyChannelPhi;                            ///< array of histos with phi of heavy mesons in the decay channel
+    TH1F**                            fHistMCChannelNDMFromHeavyPt;                       ///< array if histos with pt of the ndm of the heavy meson
+    TH1F**                            fHistMCChannelNDMFromHeavyEta;                      ///< array if histos with eta of the ndm of the heavy meson
+    TH1F**                            fHistMCChannelNDMFromHeavyPhi;                      ///< array if histos with phi of the ndm of the heavy meson
+    TH1F**                            fHistMCChannelPiPlusFromHeavyPt;                    ///< array if histos with pt of the piplus of the heavy meson
+    TH1F**                            fHistMCChannelPiPlusFromHeavyEta;                   ///< array if histos with eta of the piplus of the heavy meson
+    TH1F**                            fHistMCChannelPiPlusFromHeavyPhi;                   ///< array if histos with phi of the piplus of the heavy meson
+    TH1F**                            fHistMCChannelPiMinusFromHeavyPt;                   ///< array if histos with pt of the piminus of the heavy meson
+    TH1F**                            fHistMCChannelPiMinusFromHeavyEta;                  ///< array if histos with eta of the piminus of the heavy meson
+    TH1F**                            fHistMCChannelPiPMinusFromHeavyPhi;                 ///< array if histos with phi of the piminus of the heavy meson
+    TH2F**                            fHistMCChannelNDMPtHeavyPt;                         ///< array of histos of pt correlation ndm - heavy meson
+    TH2F**                            fHistMCChannelPiPlusPtHeavyPt;                      ///< array of histos of pt correlation piplus - heavy meson
+    TH2F**                            fHistMCChannelPiMinusPtHeavyPt;                     ///< array of histos of pt correlation piminus - heavy meson
+    TH1F**                            fHistoMCHeavyReconstructiblePt;                     ///< array of histos with pt of reconstructible heavy mesons 
+    TH1F**                            fHistoMCHeavyReconstructibleEta;                    ///< array of histos with eta of reconstructible heavy mesons
+    TH1F**                            fHistoMCHeavyReconstructiblePhi;                    ///< array of histos with phi of reconstructible heavy mesons
+    TH1F**                            fHistMCReconstructibleNDMFromHeavyPt;               ///< array if histos with pt of the ndm of the reconstructible heavy meson
+    TH1F**                            fHistMCReconstructibleNDMFromHeavyEta;              ///< array if histos with eta of the ndm of the reconstructible heavy meson
+    TH1F**                            fHistMCReconstructibleNDMFromHeavyPhi;              ///< array if histos with phi of the ndm of the reconstructible heavy meson
+    TH1F**                            fHistMCReconstructiblePiPlusFromHeavyPt;            ///< array if histos with pt of the piplus of the reconstructible heavy meson
+    TH1F**                            fHistMCReconstructiblePiPlusFromHeavyEta;           ///< array if histos with eta of the piplus of the reconstructible heavy meson
+    TH1F**                            fHistMCReconstructiblePiPlusFromHeavyPhi;           ///< array if histos with phi of the piplus of the reconstructible heavy meson
+    TH1F**                            fHistMCReconstructiblePiMinusFromHeavyPt;           ///< array if histos with pt of the piminus of the reconstructible heavy meson
+    TH1F**                            fHistMCReconstructiblePiMinusFromHeavyEta;          ///< array if histos with eta of the piminus of the reconstructible heavy meson
+    TH1F**                            fHistMCReconstructiblePiPMinusFromHeavyPhi;         ///< array if histos with phi of the piminus of the reconstructible heavy meson
+    TH2F**                            fHistMCReconstructibleNDMPtHeavyPt;                 ///< array of histos of pt correlation ndm - reconstructible heavy meson
+    TH2F**                            fHistMCReconstructiblePiPlusPtHeavyPt;              ///< array of histos of pt correlation piplus - reconstructible heavy meson
+    TH2F**                            fHistMCReconstructiblePiMinusPtHeavyPt;             ///< array of histos of pt correlation piminus - reconstructible heavy meson
 
     // reconstructed particles MC validated
     TH2F**                          fHistoTrueMotherPiPlPiMiNDMInvMassPt;                 // histos with reconstructed validated eta or omega, inv mass, pT


### PR DESCRIPTION
- Adding more kinematic histograms (pt, eta, phi) for the
  heavy meson and its decay products at various steps
  (all, in channel, reconstrutible, reconstructed)
- Fix indentation in various places
- Modernize: Use nullptr instead of NULL