### PR TITLE
fix incorrect cast from UInt_t to Int_t

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnTrueQ3DByParent.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnTrueQ3DByParent.cxx
@@ -62,7 +62,7 @@ AliFemtoModelCorrFctnTrueQ3DByParent::AliFemtoModelCorrFctnTrueQ3DByParent(const
     parent_min = -parent_max;
 
   Int_t inbins = nbins;
-  std::array<Int_t, 4> nbins_v = {static_cast<UInt_t>(par_nbins * 2 + 1), inbins, inbins, inbins};
+  std::array<Int_t, 4> nbins_v = {static_cast<Int_t>(par_nbins * 2 + 1), inbins, inbins, inbins};
   std::array<Double_t, 4> min_v = {parent_min, qmin, qmin, qmin};
   std::array<Double_t, 4> max_v = {parent_max, qmax, qmax, qmax};
 


### PR DESCRIPTION
Hi,

This fix a compilation error on MacOS Mojave (see below). If the fix is done in the right direction, can you merge it please?

@dberzano, I thought there were a continuous integration also done on macOS platform? Or maybe this is only for O2? Just wondering why this error didn't get catch when introduced (PR #8244).

Cheers,
Philippe

---

DEBUG:AliPhysics:AliPhysics:devphys: /Users/PILLOT/Work/Alice/sw/SOURCES/AliPhysics/devphys/0/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnTrueQ3DByParent.cxx:65:35: error: non-constant-expression cannot be narrowed from type 'UInt_t' (aka 'unsigned int') to 'std::__1::array<int, 4>::value_type' (aka 'int') in initializer list [-Wc++11-narrowing]
DEBUG:AliPhysics:AliPhysics:devphys:   std::array<Int_t, 4> nbins_v = {static_cast<UInt_t>(par_nbins * 2 + 1), inbins, inbins, inbins};
DEBUG:AliPhysics:AliPhysics:devphys:                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DEBUG:AliPhysics:AliPhysics:devphys: /Users/PILLOT/Work/Alice/sw/SOURCES/AliPhysics/devphys/0/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoModelCorrFctnTrueQ3DByParent.cxx:65:35: note: insert an explicit cast to silence this issue
DEBUG:AliPhysics:AliPhysics:devphys:   std::array<Int_t, 4> nbins_v = {static_cast<UInt_t>(par_nbins * 2 + 1), inbins, inbins, inbins};
DEBUG:AliPhysics:AliPhysics:devphys:                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DEBUG:AliPhysics:AliPhysics:devphys:                                   static_cast<value_type>(              )
DEBUG:AliPhysics:AliPhysics:devphys: 1 error generated.
