### PR TITLE
Vertex selection on original events implemented in EmbeddingHelper

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
@@ -116,6 +116,7 @@ AliAnalysisTaskEmcalEmbeddingHelper::AliAnalysisTaskEmcalEmbeddingHelper() :
   fMCRejectOutliers(false),
   fPtHardJetPtRejectionFactor(4),
   fZVertexCut(10),
+  fInternalZVertexCut(999),
   fMaxVertexDist(999),
   fInitializedConfiguration(false),
   fInitializedNewFile(false),
@@ -188,6 +189,7 @@ AliAnalysisTaskEmcalEmbeddingHelper::AliAnalysisTaskEmcalEmbeddingHelper(const c
   fMCRejectOutliers(false),
   fPtHardJetPtRejectionFactor(4),
   fZVertexCut(10),
+  fInternalZVertexCut(999),
   fMaxVertexDist(999),
   fInitializedConfiguration(false),
   fInitializedNewFile(false),
@@ -1581,10 +1583,23 @@ bool AliAnalysisTaskEmcalEmbeddingHelper::PythiaInfoFromCrossSectionFile(std::st
  */
 void AliAnalysisTaskEmcalEmbeddingHelper::UserExec(Option_t*)
 {
-  if (!fInitializedEmbedding) {
-    AliError("Chain not initialized before running! Setting up now.");
-    SetupEmbedding();
-  }
+	if (!fInitializedEmbedding) {
+		AliError("Chain not initialized before running! Setting up now.");
+		SetupEmbedding();
+	}
+	AliVEvent* internalevent = AliAnalysisTaskSE::InputEvent();                         
+	if (!internalevent) {                                                                             
+		Printf("ERROR: Could not retrieve event");   
+		return;                                                                                       
+	}                                                                                             
+	const AliVVertex *inputVert = internalevent -> GetPrimaryVertex();                              
+	Double_t inputVertex[3]={0,0,0};                                                               
+	inputVert->GetXYZ(inputVertex);                                                               
+	if(fInternalZVertexCut != 999 && TMath::Abs(inputVertex[2]) > fInternalZVertexCut) {           
+		AliDebug(3,Form("Event rejected due to internal Z vertex selection. Event Z vertex: %f, Z vertex cut: %f",inputVertex[2], fInternalZVertexCut));                                      
+		return ;                                                                                       
+	}                                                                                         
+
 
   // Apply internal event selection
   if (fUseInternalEventSelection) {

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
@@ -194,12 +194,15 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   bool GetMCRejectOutliers()                                const { return fMCRejectOutliers; }
   Double_t GetPtHardJetPtRejectionFactor()                  const { return fPtHardJetPtRejectionFactor; }
   Double_t GetZVertexCut()                                  const { return fZVertexCut; }
+  Double_t GetInternalZVertexCut()                          const { return fInternalZVertexCut; }
+
   Double_t GetMaxVertexDistance()                           const { return fMaxVertexDist; }
 
   void SetTriggerMask(UInt_t triggerMask)                         { fTriggerMask = triggerMask; }
   void SetMCRejectOutliers(bool reject = true)                    { fMCRejectOutliers = reject; }
   void SetPtHardJetPtRejectionFactor(double factor)               { fPtHardJetPtRejectionFactor = factor; }
   void SetZVertexCut(Double_t zVertex)                            { fZVertexCut = zVertex; }
+  void SetInternalZVertexCut(Double_t zVertex)                    { fInternalZVertexCut = zVertex; }
   void SetMaxVertexDistance(Double_t distance)                    { fMaxVertexDist = distance; }
   /* @} */
 
@@ -310,6 +313,8 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   bool                                          fMCRejectOutliers;  ///<  If true, MC outliers will be rejected
   Double_t                                      fPtHardJetPtRejectionFactor; ///<  Factor which the pt hard bin is multiplied by to compare against pythia header jets pt
   Double_t                                      fZVertexCut;        ///<  Z vertex cut on embedded event
+  Double_t                                      fInternalZVertexCut;  ///< Z vertex cut on original event
+
   Double_t                                      fMaxVertexDist;     ///<  Max distance between Z vertex of internal and embedded event
 
   bool                                          fInitializedConfiguration; ///< Notes if the configuration has been initialized

--- a/PWGCF/Correlations/macros/jcorran/AddTaskBSDiJet.C
+++ b/PWGCF/Correlations/macros/jcorran/AddTaskBSDiJet.C
@@ -55,7 +55,7 @@ AliBSDiJetTask * AddTaskBSDiJet(TString taskname, bool isAA, Double_t leadingPar
 		//embeddingHelper->SetFilePattern("alien:///alice/data/2015/LHC15o/000246844/pass1/AOD194/");
 		//embeddingHelper->SetFilePattern("alien:///alice/sim/2016/LHC16j5/15/246488/AOD200/");
 		//if (option.Contains("LHC15o")) gSystem->Exec(Form("alien_find /alice/sim/2016/LHC16j5/ AliAOD.root | grep AOD200 | perl -nle'print \"alien://\".$_' | sort -R | head -300 > embfile.txt"));
-		if (option.Contains("LHC15o")) gSystem->Exec(Form("alien_find /alice/sim/2016/LHC16j5/ AliAOD.root | grep AOD200 | perl -nle'print \"alien://\".$_' > embfile.txt"));
+		if (option.Contains("LHC15o")) gSystem->Exec(Form("alien_find /alice/sim/2016/LHC16j5/ AliAOD.root | grep AOD200 | perl -nle'print \"alien://\".$_' | head -1000 > embfile.txt"));
 		embeddingHelper->SetFileListFilename("./embfile.txt");
 
 		//embeddingHelper->SetFilePattern("alien:///alice/sim/2016/LHC16j5/%d/%d/AOD200/");
@@ -68,9 +68,10 @@ AliBSDiJetTask * AddTaskBSDiJet(TString taskname, bool isAA, Double_t leadingPar
 		embeddingHelper->SetRandomFileAccess(kTRUE);
 		// ... Start from a random event within each file
 		//embeddingHelper->SetRandomEventNumberAccess(kTRUE);
-		embeddingHelper->SetTriggerMask(AliVEvent::kINT7);
+		//embeddingHelper->SetTriggerMask(AliVEvent::kINT7);
 		embeddingHelper->SetZVertexCut(10);
-		//embeddingHelper->SetMaxVertexDistance(2);
+		embeddingHelper->SetInternalZVertexCut(10);
+		embeddingHelper->SetMaxVertexDistance(2);
 		//embeddingHelper->SetCentralityRange(centmin,centmax);
 		//embeddingHelper->SetUseManualInternalEventCuts(true) ;
 		// ... Set pt hard bin properties

--- a/PWGCF/Correlations/macros/jcorran/AddTaskBSDiJet.C
+++ b/PWGCF/Correlations/macros/jcorran/AddTaskBSDiJet.C
@@ -55,7 +55,8 @@ AliBSDiJetTask * AddTaskBSDiJet(TString taskname, bool isAA, Double_t leadingPar
 		//embeddingHelper->SetFilePattern("alien:///alice/data/2015/LHC15o/000246844/pass1/AOD194/");
 		//embeddingHelper->SetFilePattern("alien:///alice/sim/2016/LHC16j5/15/246488/AOD200/");
 		//if (option.Contains("LHC15o")) gSystem->Exec(Form("alien_find /alice/sim/2016/LHC16j5/ AliAOD.root | grep AOD200 | perl -nle'print \"alien://\".$_' | sort -R | head -300 > embfile.txt"));
-		if (option.Contains("LHC15o")) gSystem->Exec(Form("alien_find /alice/sim/2016/LHC16j5/ AliAOD.root | grep AOD200 | perl -nle'print \"alien://\".$_' | head -1000 > embfile.txt"));
+		//if (option.Contains("LHC15o")) gSystem->Exec(Form("alien_find /alice/sim/2016/LHC16j5/ AliAOD.root | grep AOD200 | perl -nle'print \"alien://\".$_' | head -1000 > embfile.txt"));
+		if (option.Contains("LHC15o")) gSystem->Exec(Form("alien_find /alice/sim/2016/LHC16j5/ AliAOD.root | grep AOD200 | perl -nle'print \"alien://\".$_'  > embfile.txt"));
 		embeddingHelper->SetFileListFilename("./embfile.txt");
 
 		//embeddingHelper->SetFilePattern("alien:///alice/sim/2016/LHC16j5/%d/%d/AOD200/");


### PR DESCRIPTION
A functionality added in AliAnalysisTaskEmcalEmbeddingHelper.* concerning the vertex cut on original events. When embeddingHelper->SetMaxVertexDistance(2); setter is enabled (distance between the primary vertices of embedding and embedded events), it takes infinite time to find a correct embedded event. 
For example, when an original event has a z vertex like 27 cm, then it fails to find an MC event having z vtx in 25 to 29 cm, and it goes to an infinite loop. 

 