### PR TITLE
PWGGA/GammaConv Get rid of compiler warning and make ConvJetReader mo…

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskConvJet.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskConvJet.h
@@ -65,8 +65,16 @@ class AliAnalysisTaskConvJet : public AliAnalysisTaskEmcalJet {
       TString Add = "_";
       Add.Append(JetContainerName);
       Add.Append("_pT1000");
+      Bool_t ContainerAlreadyAdded = kFALSE;
+      for(Int_t i = 0; i < fJetContainersAdded; i++){
+        if(Add == fJetNameArray[i]){
+            ContainerAlreadyAdded = kTRUE;
+        }
+      }
         if(fJetContainersAdded < fNJetContainers){
-          AddJetContainer(JetContainerName, AliEmcalJet::kTPCfid, Radius);
+          if(!ContainerAlreadyAdded){
+            AddJetContainer(JetContainerName, AliEmcalJet::kTPCfid, Radius);
+          }
           fJetNameArray[fJetContainersAdded] = Add;
           fTrainconfigArray[fJetContainersAdded] = Trainconfig;
           vector<Double_t> JetPt;
@@ -97,8 +105,16 @@ class AliAnalysisTaskConvJet : public AliAnalysisTaskEmcalJet {
       TString AddTrue = "_";
       AddTrue.Append(TrueJetContainerName);
       AddTrue.Append("_pT1000");
+      Bool_t ContainerAlreadyAdded = kFALSE;
+      for(Int_t i = 0; i < fJetContainersAdded; i++){
+        if(AddRec == fJetNameArray[i]){
+            ContainerAlreadyAdded = kTRUE;
+        }
+      }
       if(fJetContainersAdded < fNJetContainers){
-        jetContRec = AddJetContainer(RecJetContainerName, AliEmcalJet::kTPCfid, Radius);
+        if(!ContainerAlreadyAdded){
+          jetContRec = AddJetContainer(RecJetContainerName, AliEmcalJet::kTPCfid, Radius);
+        }
         fJetNameArray[fJetContainersAdded] = AddRec;
         fTrainconfigArray[fJetContainersAdded] = Trainconfig;
         vector<Double_t> JetPt;
@@ -119,13 +135,15 @@ class AliAnalysisTaskConvJet : public AliAnalysisTaskEmcalJet {
         fJetContainersAdded++;
       }
       if(fTrueJetContainersAdded < fNTrueJetContainers){
-        AliParticleContainer *trackCont = AddParticleContainer("tracks");
-        AliClusterContainer *clusterCont = AddClusterContainer("caloClusters");
-        jetContRec->ConnectParticleContainer(trackCont);
-        jetContRec->ConnectClusterContainer(clusterCont);
-        jetContTrue = AddJetContainer(TrueJetContainerName, AliEmcalJet::kTPCfid, Radius);
-        jetContTrue->ConnectParticleContainer(trackCont);
-        jetContTrue->ConnectClusterContainer(clusterCont);
+        if(!ContainerAlreadyAdded){
+          AliParticleContainer *trackCont = AddParticleContainer("tracks");
+          AliClusterContainer *clusterCont = AddClusterContainer("caloClusters");
+          jetContRec->ConnectParticleContainer(trackCont);
+          jetContRec->ConnectClusterContainer(clusterCont);
+          jetContTrue = AddJetContainer(TrueJetContainerName, AliEmcalJet::kTPCfid, Radius);
+          jetContTrue->ConnectParticleContainer(trackCont);
+          jetContTrue->ConnectClusterContainer(clusterCont);
+        }
         fTrueJetNameArray[fTrueJetContainersAdded] = AddTrue;
         fTrueTrainconfigArray[fTrueJetContainersAdded] = Trainconfig;
         vector<Double_t> JetPt;
@@ -368,7 +386,7 @@ class AliAnalysisTaskConvJet : public AliAnalysisTaskEmcalJet {
   AliAnalysisTaskConvJet &operator=(const AliAnalysisTaskConvJet&);
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskConvJet, 6);
+  ClassDef(AliAnalysisTaskConvJet, 7);
   /// \endcond
 };
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCalo.cxx
@@ -1116,14 +1116,11 @@ void AliAnalysisTaskGammaCalo::UserCreateOutputObjects(){
     }
   }
 
-  Double_t* arrLogBinning;
-  if(fDoJetAnalysis){
-    arrLogBinning = new Double_t[51]{1.00e-03, 1.20e-03, 1.45e-03, 1.74e-03, 2.01e-03, 2.51e-03, 3.02e-03, 3.63e-03, 4.37e-03, 5.25e-03, 6.31e-03, 7.60e-03,
+ Double_t* arrLogBinning = new Double_t[51]{1.00e-03, 1.20e-03, 1.45e-03, 1.74e-03, 2.01e-03, 2.51e-03, 3.02e-03, 3.63e-03, 4.37e-03, 5.25e-03, 6.31e-03, 7.60e-03,
                                      9.12e-03, 1.01e-02, 1.32e-02, 1.58e-02, 1.91e-02, 2.29e-02, 2.75e-02, 3.31e-02, 3.98e-02, 4.79e-02, 5.75e-02, 6.91e-02,
                                      8.32e-02, 1.00e-01, 1.20e-01, 1.45e-01, 1.74e-01, 2.09e-01, 2.51e-01, 3.02e-01, 3.63e-01, 4.37e-01, 5.25e-01, 6.31e-01,
                                      7.59e-01, 9.12e-01, 1.10e+00, 1.32e+00, 1.58e+00, 1.91e+00, 2.29e+00, 2.75e+00, 3.31e+00, 3.98e+00, 4.79e+00, 5.75e+00,
                                      6.92e+00, 8.32e+00, 1.00e+01};
-  }
   // Create histograms
   if(fOutputContainer != NULL){
     delete fOutputContainer;

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCaloIso.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCaloIso.cxx
@@ -1129,14 +1129,11 @@ void AliAnalysisTaskGammaCaloIso::UserCreateOutputObjects(){
     }
   }
 
-  Double_t* arrLogBinning;
-  if(fDoJetAnalysis){
-    arrLogBinning = new Double_t[51]{1.00e-03, 1.20e-03, 1.45e-03, 1.74e-03, 2.01e-03, 2.51e-03, 3.02e-03, 3.63e-03, 4.37e-03, 5.25e-03, 6.31e-03, 7.60e-03,
+  Double_t* arrLogBinning = new Double_t[51]{1.00e-03, 1.20e-03, 1.45e-03, 1.74e-03, 2.01e-03, 2.51e-03, 3.02e-03, 3.63e-03, 4.37e-03, 5.25e-03, 6.31e-03, 7.60e-03,
                                      9.12e-03, 1.01e-02, 1.32e-02, 1.58e-02, 1.91e-02, 2.29e-02, 2.75e-02, 3.31e-02, 3.98e-02, 4.79e-02, 5.75e-02, 6.91e-02,
                                      8.32e-02, 1.00e-01, 1.20e-01, 1.45e-01, 1.74e-01, 2.09e-01, 2.51e-01, 3.02e-01, 3.63e-01, 4.37e-01, 5.25e-01, 6.31e-01,
                                      7.59e-01, 9.12e-01, 1.10e+00, 1.32e+00, 1.58e+00, 1.91e+00, 2.29e+00, 2.75e+00, 3.31e+00, 3.98e+00, 4.79e+00, 5.75e+00,
                                      6.92e+00, 8.32e+00, 1.00e+01};
-  }
   // Create histograms
   if(fOutputContainer != NULL){
     delete fOutputContainer;


### PR DESCRIPTION
…re efficient

the compiler warning in AliAnalysisTaskGammaCalo and AliAnalysisTaskGammaCaloIso is now removed
I added that the ConvJetReader class first checks if a jet container is already added with the same name before it adds it to the class. That way, it doesn't need to loop over more jet containers which are the same anyway