### PR TITLE
add graceful check for cut object in Ds addtask

### DIFF
--- a/PWGHF/vertexingHF/macros/AddTaskDs.C
+++ b/PWGHF/vertexingHF/macros/AddTaskDs.C
@@ -27,9 +27,9 @@ AliAnalysisTaskSEDs *AddTaskDs(Int_t system=0/*0=pp,1=PbPb*/,
   } else {
     filecuts=TFile::Open(filename.Data());
     if(!filecuts ||(filecuts&& !filecuts->IsOpen())){
-      ::Fatal("AddTaskDs", "Cut object not found: analysis will not start!\n");
+      ::Fatal("AddTaskDs", "Cut file not found on Grid: analysis will not start!\n");
     }
-    else printf("Cut object correctly found\n");
+    else printf("Cut file correctly found\n");
   }
     
   //Analysis Task
@@ -43,8 +43,13 @@ AliAnalysisTaskSEDs *AddTaskDs(Int_t system=0/*0=pp,1=PbPb*/,
     }
     else ::Fatal("AddTaskDs", "Standard cut object not available for PbPb: analysis will not start!\n");
   }
-  else analysiscuts = (AliRDHFCutsDstoKKpi*)filecuts->Get("AnalysisCuts");
-    
+  else {analysiscuts = (AliRDHFCutsDstoKKpi*)filecuts->Get("AnalysisCuts");
+    if (!analysiscuts)
+	{ ::Fatal("AddTaskDs", "Cut object named \"AnalysisCuts\" not found in cutfile.");
+	  return NULL;
+	}
+}
+
   AliAnalysisTaskSEDs *dsTask = new AliAnalysisTaskSEDs("DsAnalysis",analysiscuts,storeNtuple);
     
   dsTask->SetReadMC(readMC);


### PR DESCRIPTION
[minor] Adds check in D_s AddTask that makes sure cut object is pulled from ROOT file correctly before constructing.

Without this, constructor segfaults without a useful error due to the cut object being a null pointer, if the file exists but doesn't contain the right cut object.