### PR TITLE
New Analysis Task for including Cascades for the PID Hadrons Vs Spherocity & Multiplicity

### DIFF
--- a/PWGLF/SPECTRA/CMakeLists.txt
+++ b/PWGLF/SPECTRA/CMakeLists.txt
@@ -26,7 +26,6 @@ include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/OADB
                     ${AliPhysics_SOURCE_DIR}/OADB/COMMON/MULTIPLICITY
                     ${AliPhysics_SOURCE_DIR}/PWG/Tools
-                    ${AliPhysics_SOURCE_DIR}/PWGLF/SPECTRA/PiKaPr/TestAOD
                     ${AliPhysics_SOURCE_DIR}/PWGLF/SPECTRA/XtAnalysis
             	    ${AliPhysics_SOURCE_DIR}/PWGCF/Correlations/JCORRAN/Base
                     ${AliPhysics_SOURCE_DIR}/PWGUD/base
@@ -74,6 +73,8 @@ set(SRCS
   PiKaPr/TPCTOFfits/AliAnalysisPIDTrack.cxx
   PiKaPr/TPCTOFfits/AliAnalysisPIDV0.cxx
   PiKaPr/TPCTOFfits/AliAnalysisTaskTPCTOFPID.cxx
+  PiKaPr/TPCTOFCascades/AliAnalysisPIDCascade.cxx
+  PiKaPr/TPCTOFCascades/AliAnalysisTaskTPCTOFCascade.cxx
   PiKaPr/TOF/pp13/AliAnalysisTaskTOFppSpectra.cxx
   PiKaPr/TOF/pp13/AliAnalysisTaskTOFMC.cxx
   PiKaPr/TOF/pp7/TOFSpectrappAnalysis.cxx
@@ -209,6 +210,8 @@ install(DIRECTORY PiKaPr/TestAOD DESTINATION PWGLF/SPECTRA/PiKaPr)
 install(DIRECTORY PiKaPr/ITSsa DESTINATION PWGLF/SPECTRA/PiKaPr)
 install(DIRECTORY PiKaPr/TPC/rTPC DESTINATION PWGLF/SPECTRA/PiKaPr/TPC)
 install(DIRECTORY PiKaPr/TPCTOFfits DESTINATION PWGLF/SPECTRA/PiKaPr)
+install(DIRECTORY PiKaPr/TPCTOFCascades DESTINATION PWGLF/SPECTRA/PiKaPr)
+
 install(FILES PiKaPr/TOF/PbPb502/task/AddTaskTOFSpectra.C DESTINATION  PWGLF/SPECTRA/PiKaPr/TOF)
 install(FILES PiKaPr/TOF/PbPb502/task/AliUtilTOFParams.h DESTINATION  PWGLF/SPECTRA/PiKaPr/TOF/utilities)
 install(FILES PiKaPr/TOF/PbPb502/task/AliUtilTOFParams.cxx DESTINATION  PWGLF/SPECTRA/PiKaPr/TOF/utilities)

--- a/PWGLF/SPECTRA/PWGLFspectraLinkDef.h
+++ b/PWGLF/SPECTRA/PWGLFspectraLinkDef.h
@@ -74,6 +74,7 @@
 #pragma link C++ class AliAnalysisPIDTrack+;
 #pragma link C++ class AliAnalysisPIDV0+;
 #pragma link C++ class AliAnalysisTaskTPCTOFPID+;
+#pragma link C++ class AliAnalysisTaskTPCTOFCascade+;
 
 #pragma link C++ class AliAnalysisTaskSEITSsaSpectraMultiplicity+;
 

--- a/PWGLF/SPECTRA/PWGLFspectraLinkDef.h
+++ b/PWGLF/SPECTRA/PWGLFspectraLinkDef.h
@@ -73,6 +73,7 @@
 #pragma link C++ class AliAnalysisPIDParticle+;
 #pragma link C++ class AliAnalysisPIDTrack+;
 #pragma link C++ class AliAnalysisPIDV0+;
+#pragma link C++ class AliAnalysisPIDCascade+;
 #pragma link C++ class AliAnalysisTaskTPCTOFPID+;
 #pragma link C++ class AliAnalysisTaskTPCTOFCascade+;
 

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AddAnalysisTaskTPCTOFCascade.C
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AddAnalysisTaskTPCTOFCascade.C
@@ -1,0 +1,81 @@
+AliAnalysisTaskTPCTOFCascade *
+AddAnalysisTaskTPCTOFCascade(Bool_t mcFlag = kFALSE, const char *PeriodName=NULL, Bool_t mcTuneFlag = kFALSE, Bool_t pbpbFlag = kFALSE)
+{
+
+  /* check analysis manager */
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    Error("AddAnalysisTaskTPCTOFCascade", "cannot get analysis manager");
+    return NULL;
+  }
+
+  /* check input event handler */
+  if (!mgr->GetInputEventHandler()) {
+    Error("AddAnalysisTaskTPCTOFCascade", "cannot get input event handler");
+    return NULL;
+  }
+  
+  /* check input data type */
+  TString str = mgr->GetInputEventHandler()->GetDataType();
+  if (str.CompareTo("ESD")) {
+    Error("AddAnalysisTaskTPCTOFPID", "input data type is not \"ESD\"");
+    return NULL;
+  }
+
+  /* check MC truth event handler */
+  if (mcFlag) {
+    if (!mgr->GetMCtruthEventHandler()) {
+      Error("AddAnalysisTaskTPCTOFCascade", "cannot get MC truth event handler");
+      return NULL;
+    }
+    AliMCEventHandler * handler = (AliMCEventHandler *) mgr->GetMCtruthEventHandler();
+    handler->SetReadTR(kTRUE);
+  }
+  //If MC and period name specified, set the AliMultSelectionTask to use the right calibration
+  if (mcFlag) {
+    AliMultSelectionTask *ams = (AliMultSelectionTask*)mgr->GetTask("taskMultSelection");
+    if(ams && PeriodName) {
+      ams->SetUseDefaultMCCalib(kTRUE);
+      ams->SetAlternateOADBforEstimators(PeriodName);
+    };
+  };
+  /* get common input data container */
+  AliAnalysisDataContainer *inputc = mgr->GetCommonInputContainer();
+  if (!inputc) {
+    Error("AddAnalysisTaskTPCTOFCascade", "cannot get common input container");
+    return NULL;
+  }
+  
+
+  /*  create task and connect input/output */
+  AliAnalysisTaskTPCTOFCascade *task = new AliAnalysisTaskTPCTOFCascade(mcFlag);
+  mgr->ConnectInput(task, 0, inputc);
+  AliAnalysisDataContainer *outcont = mgr->CreateContainer("PIDTree",TTree::Class(), AliAnalysisManager::kOutputContainer,AliAnalysisManager::GetCommonFileName());
+  mgr->ConnectOutput(task,1,outcont);
+  AliAnalysisDataContainer *outcont2 = mgr->CreateContainer("StatHist",TH1D::Class(), AliAnalysisManager::kOutputContainer,AliAnalysisManager::GetCommonFileName());
+  mgr->ConnectOutput(task,2,outcont2);
+  /* setup task */
+  task->SetMCFlag(mcFlag);
+  task->SetMCTuneFlag(mcTuneFlag);
+  task->SetPbPbFlag(pbpbFlag);
+  task->SelectCollisionCandidates(AliVEvent::kAny);
+  task->SetVertexSelectionFlag(kTRUE);
+  task->SetVertexCut(15.0);
+  task->SetRapidityCut(1.0);
+  //task->SetUseImprovedFinding();
+  /* setup TOF calib */
+  task->GetTOFcalib()->SetRemoveMeanT0(!mcFlag);
+  task->GetTOFcalib()->SetCalibrateTOFsignal(!mcFlag);
+  task->GetTOFcalib()->SetCorrectTExp(kFALSE);
+  /* setup resolution */
+  Double_t timeReso = 85.;
+  if (mcFlag && !mcTuneFlag) timeReso = 80.;
+  task->SetTimeResolution(timeReso);
+  task->GetESDpid()->GetTOFResponse().SetTimeResolution(timeReso);
+  task->GetTOFT0maker()->SetTimeResolution(timeReso);
+  
+  /* return task */
+  mgr->AddTask(task);
+  return task;
+  
+}

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascade.cxx
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascade.cxx
@@ -1,0 +1,69 @@
+#include "AliAnalysisPIDCascade.h"
+#include "AliAnalysisPIDV0.h"
+#include "AliAnalysisPIDTrack.h"
+AliAnalysisPIDCascade::AliAnalysisPIDCascade():
+  TObject(),
+  fInvMXi(0),
+  fInvMO(0),
+  fCascRadius(0),
+  fCascDCA(0),
+  fCascCosinePA(0),
+  fPtCasc(0),
+  fEtaCasc(0),
+  fCascDCAPV(-999)
+{
+  fBachAnalysisPIDTrack = new AliAnalysisPIDTrack();
+  fV0AnalysisPIDV0 = new AliAnalysisPIDV0();
+};
+
+AliAnalysisPIDCascade::AliAnalysisPIDCascade(const AliAnalysisPIDCascade &source):
+  TObject(source),
+  fV0AnalysisPIDV0(source.fV0AnalysisPIDV0),
+  fBachAnalysisPIDTrack(source.fBachAnalysisPIDTrack),
+  fInvMXi(source.fInvMXi),
+  fInvMO(source.fInvMO),
+  fCascRadius(source.fCascRadius),
+  fCascDCA(source.fCascDCA),
+  fCascCosinePA(source.fCascCosinePA),
+  fPtCasc(source.fPtCasc),
+  fEtaCasc(source.fEtaCasc),
+  fCascDCAPV(source.fCascDCAPV)
+{
+};
+AliAnalysisPIDCascade &AliAnalysisPIDCascade::operator=(const AliAnalysisPIDCascade &source) {
+  if(&source == this) return *this;
+  TObject::operator=(source);
+  fV0AnalysisPIDV0 = source.fV0AnalysisPIDV0;
+  fBachAnalysisPIDTrack = source.fBachAnalysisPIDTrack;
+  fInvMXi = source.fInvMXi;
+  fInvMO = source.fInvMO;
+  fCascRadius = source.fCascRadius;
+  fCascDCA = source.fCascDCA;
+  fCascCosinePA = source.fCascCosinePA;
+  fPtCasc = source.fPtCasc;
+  fEtaCasc = source.fEtaCasc;
+  fCascDCAPV = source.fCascDCAPV;
+  return *this;
+};
+void AliAnalysisPIDCascade::Update(AliAnalysisPIDV0* V0, AliAnalysisPIDTrack* BachTrack, Double_t *InvMasses, Double_t CascRadius,  Double_t CascDCA, Double_t CascCosinePA, Double_t PtCasc, Double_t EtaCasc, Double_t CascDCAPV, Int_t Charge) {
+  fV0AnalysisPIDV0 = V0;
+  fBachAnalysisPIDTrack = BachTrack;
+  fInvMXi=InvMasses[0];
+  fInvMO=InvMasses[1];
+  fCascRadius = CascRadius;
+  fCascDCA = CascDCA;
+  fCascCosinePA = CascCosinePA;
+  fPtCasc = PtCasc;
+  fEtaCasc = EtaCasc;
+  fCascDCAPV = CascDCAPV;
+  fCharge = Charge;
+};
+AliAnalysisPIDCascade::~AliAnalysisPIDCascade()
+{
+  delete fV0AnalysisPIDV0;
+  delete fBachAnalysisPIDTrack;
+};
+
+Double_t AliAnalysisPIDCascade::CalculateCascDCAPV() {
+  return fCascRadius * (TMath::Sqrt(1. - fCascCosinePA * fCascCosinePA));
+};

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascade.h
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisPIDCascade.h
@@ -1,0 +1,45 @@
+#ifndef ALIANALYSISPIDCascade__H
+#define ALIANALYSISPIDCascade__H
+#include "TObject.h"
+#include "AliAnalysisPIDTrack.h"
+#include "AliAnalysisPIDV0.h"
+
+class AliAnalysisPIDTrack;
+class AliAnalysisPIDV0;
+class AliAnalysisPIDCascade:
+public TObject
+{
+ public:
+  AliAnalysisPIDCascade();
+  AliAnalysisPIDCascade(const AliAnalysisPIDCascade &source); //copy const
+  AliAnalysisPIDCascade &operator=(const AliAnalysisPIDCascade &source); // operator =
+  virtual ~AliAnalysisPIDCascade();
+  void Update(AliAnalysisPIDV0* V0, AliAnalysisPIDTrack* BachTrack, Double_t *InvMasses, Double_t CascRadius, Double_t CascDCA,  Double_t CascCosinePA, Double_t PtCasc, Double_t EtaCasc, Double_t CascDCAPV, Int_t Charge);
+
+  AliAnalysisPIDV0    *GetV0()  { return fV0AnalysisPIDV0;};
+  AliAnalysisPIDTrack *GetBachAnalysisTrack() { return fBachAnalysisPIDTrack; };
+  Double_t GetIMXi()         { return fInvMXi; }; //M Xi
+  Double_t GetIMO()          { return fInvMO; }; //M Omega
+  Double_t GetCascRadius()   { return fCascRadius; };
+  Double_t GetCascDCA()   { return fCascDCA; } ;
+  Double_t GetCascCosinePA() { return fCascCosinePA; };
+  Double_t GetPtCasc() { return fPtCasc; };
+  Double_t GetEtaCasc() { return fEtaCasc; };
+  Double_t GetCascDCAPV()    { return fCascDCAPV; };
+  Double_t CalculateCascDCAPV();
+  Int_t GetCharge() { return fCharge;};
+
+ protected:  
+  AliAnalysisPIDV0 * fV0AnalysisPIDV0;
+  AliAnalysisPIDTrack *fBachAnalysisPIDTrack;
+  Double_t fInvMXi,fInvMO;
+  Double_t fCascRadius;
+  Double_t fCascDCA, fCascCosinePA;
+  Double_t fPtCasc;
+  Double_t fEtaCasc;
+  Double_t fCascDCAPV;
+  Int_t fCharge;
+  
+  ClassDef(AliAnalysisPIDCascade, 2);
+};
+#endif

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisTaskTPCTOFCascade.cxx
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisTaskTPCTOFCascade.cxx
@@ -1,0 +1,938 @@
+#include "AliAnalysisTaskTPCTOFCascade.h"
+#include "AliESDEvent.h"
+#include "AliMCEvent.h"
+//#include "AliMCParticle.h"
+//#include "AliStack.h"
+#include "AliPhysicsSelection.h"
+#include "AliESDtrackCuts.h"
+#include "AliESDpid.h"
+#include "AliTOFcalib.h"
+#include "AliTOFT0maker.h"
+#include "TList.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TH1D.h"
+#include "AliCDBManager.h"
+#include "AliLog.h"
+#include "AliESDtrack.h"
+#include "TObjArray.h"
+#include "TLorentzVector.h"
+#include "TParticle.h"
+#include "TDatabasePDG.h"
+#include "TParticlePDG.h"
+#include "AliAnalysisPIDTrack.h"
+#include "AliAnalysisPIDParticle.h"
+#include "AliAnalysisPIDEvent.h"
+#include "TClonesArray.h"
+#include "AliAnalysisManager.h"
+#include "AliAODHandler.h"
+#include "TTree.h"
+#include "AliCentrality.h"
+#include "AliInputEventHandler.h"
+#include "AliVEvent.h"
+#include "AliPIDResponse.h"
+#include "AliAnalysisUtils.h"
+#include "AliMultSelection.h"
+#include "TRandom.h"
+#include "AliESDVertex.h"
+#include "AliESDv0.h"
+#include "AliESDcascade.h"
+#include "AliAnalysisPIDV0.h"
+#include "AliAnalysisPIDCascade.h"
+#include "AliAODVertex.h"
+#include "AliKFParticle.h"
+#include "AliKFVertex.h"
+#include "AliVVZERO.h"
+#include "AliVCluster.h"
+#include "TMath.h"
+#include "AliNeutralTrackParam.h"
+
+ClassImp(AliAnalysisTaskTPCTOFCascade)
+  
+//_______________________________________________________
+  
+AliAnalysisTaskTPCTOFCascade::AliAnalysisTaskTPCTOFCascade() :
+  AliAnalysisTaskSE("AnalysisResults"),
+  fInitFlag(kFALSE),
+  fMCFlag(kFALSE),
+  fMCTuneFlag(kFALSE),
+  fPbPbFlag(kFALSE),
+  fVertexSelectionFlag(kFALSE),
+  fPrimaryDCASelectionFlag(kFALSE),
+  fPIDTree(0),
+  fEvHist(0),
+  fPIDResponse(0),
+  fAnUtils(0),
+  fRunNumber(0),
+  fStartTime(0),
+  fEndTime(0),
+  fESDEvent(NULL),
+  fMCEvent(NULL),
+//fMCStack(NULL),
+  fTrackCuts2010(NULL),
+  fTrackCuts2011(NULL),
+  fTrackCutsTPCRefit(NULL),
+  fTrackCuts2011Sys(NULL),
+  fESDpid(new AliESDpid()),
+  fIsCollisionCandidate(kFALSE),
+  fIsEventSelected(0),
+  fIsPileupFromSPD(kFALSE),
+  fHasVertex(kFALSE),
+  fVertexZ(0.),
+  fMCTimeZero(0.),
+  fCentrality(NULL),
+  fAnalysisEvent(new AliAnalysisPIDEvent()),
+  fAnalysisTrackArray(new TClonesArray("AliAnalysisPIDTrack")),
+  fAnalysisTrack(new AliAnalysisPIDTrack()),
+  fAnalysisParticleArray(new TClonesArray("AliAnalysisPIDParticle")),
+  fAnalysisParticle(new AliAnalysisPIDParticle()),
+  fAnalysisV0TrackArray(new TClonesArray("AliAnalysisPIDV0")),
+  fAnalysisV0Track(new AliAnalysisPIDV0()),
+  fAnalysisCascadeTrackArray(new TClonesArray("AliAnalysisPIDCascade")),
+  fAnalysisCascadeTrack(new AliAnalysisPIDCascade()),
+  fTOFcalib(new AliTOFcalib()),
+  fTOFT0maker(new AliTOFT0maker(fESDpid)),
+  fTimeResolution(80.),
+  fVertexCut(10.0),
+  fRapidityCut(1.0),
+  V0MBinCount(0),
+  fHistoList(new TList()),
+  fMCHistoList(new TList())
+{
+  /* 
+   * default constructor 
+   */
+  fTrackCuts2010 = new AliESDtrackCuts("AliESDtrackCuts2010","AliESDtrackCuts2010");
+  fTrackCuts2010 = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010(kFALSE); //If not running, set to kFALSE;
+  fTrackCuts2010->SetEtaRange(-0.8,0.8);
+  fTrackCuts2011 = new AliESDtrackCuts("AliESDtrackCuts2011","AliESDtrackCuts2011");
+  fTrackCuts2011 = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(kFALSE); //If not running, set to kFALSE;
+  fTrackCuts2011->SetEtaRange(-0.8,0.8);
+  fTrackCutsTPCRefit = new AliESDtrackCuts("AliESDtrackCutsTPCRefit","AliESDtrackCutsTPCRefit");
+  fTrackCutsTPCRefit = AliESDtrackCuts::GetStandardTPCOnlyTrackCuts(); //If not running, set to kFALSE;
+  fTrackCutsTPCRefit->SetRequireTPCRefit(kTRUE);
+  fTrackCutsTPCRefit->SetEtaRange(-0.8,0.8);
+  //Following is TC for systematics estimation. To compensate, once should probably reduce gamma DeltaM even further :)
+  fTrackCuts2011Sys = new AliESDtrackCuts("AliESDtrackCuts2011Sys","AliESDtrackCuts2011Sys");
+  fTrackCuts2011Sys = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(kFALSE); //If not running, set to kFALSE;                                                                                            
+  fTrackCuts2011Sys->SetEtaRange(-0.8,0.8);
+  fTrackCuts2011Sys->SetMinNCrossedRowsTPC(60);
+  fTrackCuts2011Sys->SetMaxChi2PerClusterTPC(5);
+  fTrackCuts2011Sys->SetMaxDCAToVertexZ(3);
+
+}
+
+
+
+
+AliAnalysisTaskTPCTOFCascade::AliAnalysisTaskTPCTOFCascade(Bool_t isMC) :
+  AliAnalysisTaskSE("AnalysisResults"),
+  fInitFlag(kFALSE),
+  fMCFlag(kFALSE),
+  fMCTuneFlag(kFALSE),
+  fPbPbFlag(kFALSE),
+  fVertexSelectionFlag(kFALSE),
+  fPrimaryDCASelectionFlag(kFALSE),
+  fPIDTree(0),
+  fEvHist(0),
+  fPIDResponse(0),
+  fAnUtils(0),
+  fRunNumber(0),
+  fStartTime(0),
+  fEndTime(0),
+  fESDEvent(NULL),
+  fMCEvent(NULL),
+  //fMCStack(NULL),
+  fTrackCuts2010(NULL),
+  fTrackCuts2011(NULL),
+  fTrackCutsTPCRefit(NULL),
+  fTrackCuts2011Sys(NULL),
+  fESDpid(new AliESDpid()),
+  fIsCollisionCandidate(kFALSE),
+  fIsEventSelected(0),
+  fIsPileupFromSPD(kFALSE),
+  fHasVertex(kFALSE),
+  fVertexZ(0.),
+  fMCTimeZero(0.),
+  fCentrality(NULL),
+  fAnalysisEvent(new AliAnalysisPIDEvent()),
+  fAnalysisTrackArray(new TClonesArray("AliAnalysisPIDTrack")),
+  fAnalysisTrack(new AliAnalysisPIDTrack()),
+  fAnalysisParticleArray(new TClonesArray("AliAnalysisPIDParticle")),
+  fAnalysisParticle(new AliAnalysisPIDParticle()),
+  fAnalysisV0TrackArray(new TClonesArray("AliAnalysisPIDV0")),
+  fAnalysisV0Track(new AliAnalysisPIDV0()),
+  fAnalysisCascadeTrackArray(new TClonesArray("AliAnalysisPIDCascade")),
+  fAnalysisCascadeTrack(new AliAnalysisPIDCascade()),
+  fTOFcalib(new AliTOFcalib()),
+  fTOFT0maker(new AliTOFT0maker(fESDpid)),
+  fTimeResolution(80.),
+  fVertexCut(10.0),
+  fRapidityCut(1.0),
+  V0MBinCount(0),
+  fHistoList(new TList()),
+  fMCHistoList(new TList())
+{
+  /* 
+   * default constructor 
+   */
+  fTrackCuts2010 = new AliESDtrackCuts("AliESDtrackCuts2010","AliESDtrackCuts2010");
+  fTrackCuts2010 = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010(kFALSE); //If not running, set to kFALSE;
+  fTrackCuts2010->SetEtaRange(-0.8,0.8);
+  fTrackCuts2011 = new AliESDtrackCuts("AliESDtrackCuts2011","AliESDtrackCuts2011");
+  fTrackCuts2011 = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(kFALSE); //If not running, set to kFALSE;
+  fTrackCuts2011->SetEtaRange(-0.8,0.8);
+  fTrackCutsTPCRefit = new AliESDtrackCuts("AliESDtrackCutsTPCRefit","AliESDtrackCutsTPCRefit");
+  fTrackCutsTPCRefit = AliESDtrackCuts::GetStandardTPCOnlyTrackCuts(); //If not running, set to kFALSE;
+  fTrackCutsTPCRefit->SetRequireTPCRefit(kTRUE);
+  fTrackCutsTPCRefit->SetEtaRange(-0.8,0.8);
+  //Following is TC for systematics estimation. To compensate, once should probably reduce gamma DeltaM even further :)                                                                                    
+  fTrackCuts2011Sys = new AliESDtrackCuts("AliESDtrackCuts2011Sys","AliESDtrackCuts2011Sys");
+  fTrackCuts2011Sys = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(kFALSE); //If not running, set to kFALSE;                                                                                            
+  fTrackCuts2011Sys->SetEtaRange(-0.8,0.8);
+  fTrackCuts2011Sys->SetMinNCrossedRowsTPC(60);
+  fTrackCuts2011Sys->SetMaxChi2PerClusterTPC(5);
+  fTrackCuts2011Sys->SetMaxDCAToVertexZ(3);
+
+  fMCFlag = isMC;
+  DefineOutput(1, TTree::Class());
+  DefineOutput(2, TH1D::Class());
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+//_______________________________________________________
+
+AliAnalysisTaskTPCTOFCascade::~AliAnalysisTaskTPCTOFCascade()
+{
+  /*
+   * default destructor
+   */
+
+  if (fTrackCuts2010) delete fTrackCuts2010;
+  if (fTrackCuts2011) delete fTrackCuts2011;
+  if (fTrackCutsTPCRefit) delete fTrackCutsTPCRefit;
+  if (fTrackCuts2011Sys) delete fTrackCuts2011Sys;
+  delete fESDpid;
+  delete fTOFcalib;
+  delete fTOFT0maker;
+  delete fHistoList;
+  delete fMCHistoList;
+}
+
+
+//________________________________________________________________________
+
+void
+AliAnalysisTaskTPCTOFCascade::UserCreateOutputObjects()
+{
+  /*
+   * user create output objects
+   */
+  OpenFile(1);
+  OpenFile(2);
+  /* output tree */
+  fPIDTree = new TTree("PIDTree","PIDTree");
+  fPIDTree->Branch("AnalysisEvent", "AliAnalysisPIDEvent", &fAnalysisEvent);  
+  fPIDTree->Branch("AnalysisTrack", "TClonesArray", &fAnalysisTrackArray); 
+  fPIDTree->Branch("AnalysisV0Track","TClonesArray",&fAnalysisV0TrackArray);
+  fPIDTree->Branch("AnalysisCascadeTrack","TClonesArray",&fAnalysisCascadeTrackArray);
+  if (fMCFlag)
+    fPIDTree->Branch("AnalysisParticle", "TClonesArray", &fAnalysisParticleArray);
+
+
+  AliAnalysisManager *man=AliAnalysisManager::GetAnalysisManager();
+  AliInputEventHandler* inputHandler = (AliInputEventHandler*) (man->GetInputEventHandler());
+  fPIDResponse = inputHandler->GetPIDResponse(); 
+  fAnUtils = new AliAnalysisUtils();
+  Double_t V0MbinsDefault[13] = {0, 0.01, 0.1, 1, 5, 10, 15, 20, 30, 40, 50, 70, 100};
+  V0MBinCount = new TH1F("V0MBinCount","V0MBinCount",12,V0MbinsDefault);
+
+  fEvHist = new TH1D("StatHist","StatHist",10,-0.5,9.5);
+  PostData(1,fPIDTree);
+  PostData(2,fEvHist);
+}
+
+//_______________________________________________________
+
+
+
+
+
+Bool_t
+AliAnalysisTaskTPCTOFCascade::InitRun()
+{
+  /*
+   * init run. 
+   */
+
+  /* get ESD event */
+  fESDEvent = dynamic_cast<AliESDEvent *>(InputEvent());
+  if (!fESDEvent) {
+    AliError("cannot get ESD event");
+    return kFALSE;
+  }
+
+  /* get run number */
+  Int_t runNb = fESDEvent->GetRunNumber();
+  /* check run already initialized */
+  if (fInitFlag && fRunNumber == runNb) return kTRUE;
+  /* init cdb */
+  AliCDBManager *cdb = AliCDBManager::Instance();
+  cdb->SetDefaultStorage("raw://");
+  cdb->SetRun(runNb);
+  /* init TOF calib */
+  if (!fTOFcalib->Init()) {
+    AliError("cannot init TOF calib");
+    return kFALSE;
+  }
+  AliInfo(Form("initialized for run %d", runNb));
+  fInitFlag = kTRUE;
+  fRunNumber = runNb;
+  return kTRUE;
+}
+
+//_______________________________________________________
+void AliAnalysisTaskTPCTOFCascade::FillHist(Double_t myflag) {
+  fEvHist->Fill(myflag);
+};
+Bool_t AliAnalysisTaskTPCTOFCascade::IsGoodSPDvertexRes(const AliESDVertex * spdVertex)
+{
+  if (!spdVertex) return kFALSE;
+  if (spdVertex->IsFromVertexerZ() && !(spdVertex->GetDispersion()<0.04 && spdVertex->GetZRes()<0.25)) return kFALSE;
+  return kTRUE;
+};
+Bool_t AliAnalysisTaskTPCTOFCascade::SelectVertex2015pp(AliESDEvent *esd,  Bool_t checkSPDres, Bool_t *SPDandTrkExists, Bool_t *PassProximityCut) 
+{
+  if (!esd) return kFALSE;
+  const AliESDVertex * trkVertex = esd->GetPrimaryVertexTracks();
+  const AliESDVertex * spdVertex = esd->GetPrimaryVertexSPD();
+  Bool_t hasSPD = spdVertex->GetStatus();
+  Bool_t hasTrk = trkVertex->GetStatus();
+  //Note that AliVertex::GetStatus checks that N_contributors is > 0
+  //reject events if both are explicitly requested and none is available
+  //MOD: do not reject if SPD&Trk vtx. not there, but store it to the variable, if requested:
+  if(SPDandTrkExists)
+    (*SPDandTrkExists) = hasSPD&&hasTrk;
+  //Set initial value for proximity check. Only checking the proximity if SPDandTrkExists,
+  //the default value should be 1, tracking vtx is not required
+  if(PassProximityCut)
+    (*PassProximityCut) = 1;
+  
+  //reject events if none between the SPD or track verteces are available
+  //if no trk vertex, try to fall back to SPD vertex;
+  if (!hasTrk) {
+    if (!hasSPD) return kFALSE;
+    //on demand check the spd vertex resolution and reject if not satisfied
+    if (checkSPDres && !IsGoodSPDvertexRes(spdVertex)) return kFALSE;
+  } else {
+    if (hasSPD) {
+      //if enabled check the spd vertex resolution and reject if not satisfied
+      //if enabled, check the proximity between the spd vertex and trak vertex, and reject if not satisfied
+      if (checkSPDres && !IsGoodSPDvertexRes(spdVertex)) return kFALSE;
+      if(PassProximityCut)
+	(*PassProximityCut) = TMath::Abs(spdVertex->GetZ() - trkVertex->GetZ())<=0.5;
+  //if ((checkProximity && TMath::Abs(spdVertex->GetZ() - trkVertex->GetZ())>0.5)) return kFALSE; 
+    }
+  }
+
+  //Not needed here, done separately
+  //Cut on the vertex z position
+  //const AliESDVertex * vertex = esd->GetPrimaryVertex();
+  //if (TMath::Abs(vertex->GetZ())>10) return kFALSE;
+  return kTRUE;
+};
+
+
+Bool_t
+AliAnalysisTaskTPCTOFCascade::InitEvent()
+{
+  /*
+   * init event
+   */
+
+  /* get ESD event */
+  fESDEvent = dynamic_cast<AliESDEvent *>(InputEvent());
+  FillHist(0);
+  if (!fESDEvent) return kFALSE;
+  /* get MC event */
+  FillHist(1);
+  if (fMCFlag) {
+    fMCEvent = dynamic_cast<AliMCEvent *>(MCEvent());
+    if (!fMCEvent) return kFALSE;
+  }
+  /* get stack */
+  //Stack is gone. Farewll, stack, you've served us well.
+  /*  if (fMCFlag) {
+    fMCStack = fMCEvent->Stack();
+    if (!fMCStack) return kFALSE;
+    }*/
+  FillHist(2);
+  /* event selection */
+  fIsCollisionCandidate = (((AliInputEventHandler*)(AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler()))->IsEventSelected() & AliVEvent::kAny);
+  fIsEventSelected = ((AliInputEventHandler*)(AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler()))->IsEventSelected();
+  fIsPileupFromSPD = fESDEvent->IsPileupFromSPD();
+  FillHist(3);  
+  if(fESDEvent->IsIncompleteDAQ()) return kFALSE;
+  if(fAnUtils->IsSPDClusterVsTrackletBG(fESDEvent)) return kFALSE;
+  /* vertex selection */
+  const AliESDVertex *vertex = fESDEvent->GetPrimaryVertexTracks();
+  if (vertex->GetNContributors() < 1) {
+    vertex = fESDEvent->GetPrimaryVertexSPD();
+    if (vertex->GetNContributors() < 1) fHasVertex = kFALSE;
+    else fHasVertex = kTRUE;
+    TString vtxTyp = vertex->GetTitle();
+    Double_t cov[6]={0};
+    vertex->GetCovarianceMatrix(cov);
+    Double_t zRes = TMath::Sqrt(cov[5]);
+    if (vtxTyp.Contains("vertexer:Z") && (zRes>0.25)) fHasVertex = kFALSE;
+  }
+  else fHasVertex = kTRUE;
+
+  
+  fVertexZ = vertex->GetZ();
+  /* centrality in PbPb */
+  if (fPbPbFlag) {
+    fCentrality = fESDEvent->GetCentrality();
+  }
+  /* calibrate ESD (also in MC to correct TExp) */
+  fTOFcalib->CalibrateESD(fESDEvent);
+
+  /* check MC flags */
+  if (fMCFlag && fMCTuneFlag)
+    fMCTimeZero = fTOFcalib->TuneForMC(fESDEvent, fTimeResolution);
+
+#if 0 /* NEW METHOD */
+  /* compute TOF-T0, fill ESD and make PID */
+  fTOFT0maker->ComputeT0TOF(fESDEvent);
+  fTOFT0maker->WriteInESD(fESDEvent);
+  fESDpid->SetTOFResponse(fESDEvent, AliESDpid::kTOF_T0);
+  fESDpid->MakePID(fESDEvent, kFALSE, 0.);
+#endif
+
+#if 1 /* OLD METHOD */
+  /* compute and apply TOF-T0 */
+  fTOFT0maker->ComputeT0TOF(fESDEvent);
+  fESDpid->MakePID(fESDEvent, kFALSE, 0.);
+#endif
+  
+  return kTRUE;
+}
+
+//_______________________________________________________
+
+Bool_t
+AliAnalysisTaskTPCTOFCascade::HasPrimaryDCA(AliESDtrack *track)
+{
+  /*
+   * has primary DCA
+   */
+  
+  // cut on transverse impact parameter
+  Float_t d0z0[2],covd0z0[3];
+  track->GetImpactParameters(d0z0, covd0z0);
+  Float_t sigma= 0.0050 + 0.0060 / TMath::Power(track->Pt(), 0.9);
+  Float_t d0max = 7. * sigma;
+  //
+  Float_t sigmaZ = 0.0146 + 0.0070 / TMath::Power(track->Pt(), 1.114758);
+  if (track->Pt() > 1.) sigmaZ = 0.0216;
+  Float_t d0maxZ = 5. * sigmaZ;
+  //
+  if(TMath::Abs(d0z0[0]) > d0max || TMath::Abs(d0z0[1]) > d0maxZ)
+    return kFALSE;
+  
+  /* primary DCA ok */
+  return kTRUE;
+}
+Int_t AliAnalysisTaskTPCTOFCascade::GetTrackCutsFlag(AliESDtrack *LocalTrack) {
+  Int_t ReturnFlag = 0;
+  if(fTrackCuts2010->AcceptTrack(LocalTrack)) ReturnFlag+=1;
+  if(fTrackCuts2011->AcceptTrack(LocalTrack)) ReturnFlag+=2;
+  if(fTrackCutsTPCRefit->AcceptTrack(LocalTrack)) ReturnFlag+=4;
+  if(fTrackCuts2011Sys->AcceptTrack(LocalTrack)) ReturnFlag+=8;
+  return ReturnFlag;
+};
+//_______________________________________________________
+void AliAnalysisTaskTPCTOFCascade::ProcessV0s() {
+  Int_t NV0s = fESDEvent->GetNumberOfV0s();
+  if(NV0s<1) return;
+  const AliESDVertex *BestPrimaryVertex = fESDEvent->GetPrimaryVertex();
+  if(!BestPrimaryVertex) return;
+  if(!(BestPrimaryVertex->GetStatus())) return;
+  Double_t IPrimaryVtxPosition[3];
+  BestPrimaryVertex->GetXYZ(IPrimaryVtxPosition);
+  Double_t IPrimaryVtxCov[6];
+  BestPrimaryVertex->GetCovMatrix(IPrimaryVtxCov);
+  Double_t IPrimaryVtxChi2 = BestPrimaryVertex->GetChi2toNDF();
+  AliAODVertex *PrimaryVertex = new AliAODVertex(IPrimaryVtxPosition,IPrimaryVtxCov,IPrimaryVtxChi2,NULL,-1,AliAODVertex::kPrimary);
+
+  /*Calculate DCA to prim. vertex
+    Taken from AliAnalysisVertexingHF*/
+  /*AliAODVertex *tmpVtx = new AliAODVertex(IPrimaryVtxPosition,BestPrimaryVertex->GetChi2V0(),AliAODVertex::kV0, 2);
+  Double_t xyz[3], pxpypz[3];
+  BestPrimaryVert*/
+
+  /*Done w/ calculation*/
+
+
+  Double_t InvMasses[4];
+  for(Int_t iV0=0;iV0<NV0s;iV0++) {
+    AliESDv0 *V0Vertex = fESDEvent->GetV0(iV0);
+    if(V0Vertex->GetOnFlyStatus()) continue;
+    if(!V0Vertex) continue;
+    //fAnalysisTrack->Update(track, fMCStack, fMCEvent,fPIDResponse, fTrackCuts->AcceptTrack(track));
+    AliAnalysisPIDTrack *pTrack = new AliAnalysisPIDTrack();
+    AliAnalysisPIDTrack *nTrack = new AliAnalysisPIDTrack();
+    AliESDtrack *temptrack = fESDEvent->GetTrack((UInt_t)TMath::Abs(V0Vertex->GetPindex()));
+    pTrack->Update(temptrack, fMCEvent,fPIDResponse, GetTrackCutsFlag(temptrack));
+    temptrack = fESDEvent->GetTrack((UInt_t)TMath::Abs(V0Vertex->GetNindex()));
+    nTrack->Update(temptrack, fMCEvent,fPIDResponse, GetTrackCutsFlag(temptrack));
+    
+
+    if(!pTrack||!nTrack) continue;
+    if(pTrack->GetSign()==nTrack->GetSign()) continue; //Remove like-sign
+    //if(TMath::Abs(pTrack->GetEta())>0.8 || TMath::Abs(nTrack->GetEta())>0.8) continue; //Eta cut
+    //if(pTrack->GetPt()<2) continue; //pT cut on decay product
+    //if(nTrack->GetPt()<2) continue; //pT cut on decay product
+    Bool_t ChargesSwitched=kFALSE;
+    if(pTrack->GetSign()<0) {
+      AliAnalysisPIDTrack *ttr = nTrack;
+      nTrack = pTrack;//fESDEvent->GetTrack((UInt_t)TMath::Abs(V0Vertex->GetPindex()));
+      pTrack = ttr;//nTrack;//fESDEvent->GetTrack((UInt_t)TMath::Abs(V0Vertex->GetNindex()));
+      ChargesSwitched=kTRUE;
+    };
+    //Double_t alpha = V0Vertex->AlphaV0(); //Probably save these
+    //Double_t ptarm = V0Vertex->PtArmV0(); //Probably save these
+    Double_t IV0Position[3];
+    V0Vertex->GetXYZ(IV0Position[0],IV0Position[1],IV0Position[2]);
+    Double_t IV0Radius = TMath::Sqrt(IV0Position[0]*IV0Position[0]+IV0Position[1]*IV0Position[1]);
+    if(IV0Radius>100||IV0Radius<0.1) continue;
+    AliKFVertex PrimaryVtxKF(*PrimaryVertex);
+    AliKFParticle::SetField(fESDEvent->GetMagneticField());
+
+
+    Int_t indecies[2] = {211,2212}; //pi,p
+    Double_t myMasses[] = {0.498,1.116,1.116}; //K0s, lambda, anti-lambda
+    AliKFParticle *negKF[2] = {0,0}; //-pi, -p
+    AliKFParticle *posKF[2] = {0,0}; // pi,  p
+    if(ChargesSwitched)
+      for(Int_t i=0;i<2;i++) {
+	negKF[i] = new AliKFParticle(*(V0Vertex->GetParamP()), -indecies[i]);
+	posKF[i] = new AliKFParticle(*(V0Vertex->GetParamN()), indecies[i]);
+      } else
+      for(Int_t i=0;i<2;i++) {
+	negKF[i] = new AliKFParticle(*(V0Vertex->GetParamN()), -indecies[i]);
+	posKF[i] = new AliKFParticle(*(V0Vertex->GetParamP()), indecies[i]);
+      };
+    AliKFParticle V0KFs[3];
+    Bool_t TrashTracks=kTRUE; //Trash tracks if all below inv. mass
+    for(Int_t i=0;i<3;i++) {
+      V0KFs[i]+=(*posKF[(i==1)?1:0]);
+      V0KFs[i]+=(*negKF[(i==2)?1:0]);
+      V0KFs[i].SetProductionVertex(PrimaryVtxKF);
+      InvMasses[i] = V0KFs[i].GetMass()-myMasses[i];
+	TrashTracks = TrashTracks&&(TMath::Abs(InvMasses[i])>0.06);
+    };
+    if(TrashTracks) continue;
+    Double_t lpT = V0Vertex->Pt();
+    Double_t lEta = V0Vertex->Eta();
+
+    /*Calculate DCA to prim. vertex
+      Taken from AliAnalysisVertexingHF*/
+    Double_t lDCAtoPrim = -999;
+    Double_t xyz[3], pxpypz[3];
+    V0Vertex->XvYvZv(xyz);
+    V0Vertex->PxPyPz(pxpypz);
+    Double_t cv[21]; for(Int_t i=0;i<21;i++) cv[i] = 0;
+    AliNeutralTrackParam *trackesdV0 = new AliNeutralTrackParam(xyz,pxpypz,cv,0);
+    if(!trackesdV0) lDCAtoPrim=-999; else {
+      Double_t d0[2], covd0[3];
+      trackesdV0->PropagateToDCA(PrimaryVertex,fESDEvent->GetMagneticField(),kVeryBig,d0,covd0);
+      lDCAtoPrim = TMath::Sqrt(covd0[0]);
+    };
+    delete trackesdV0;
+    /*AliAODVertex *tmpVtx = new AliAODVertex(IPrimaryVtxPosition,BestPrimaryVertex->GetChi2V0(),AliAODVertex::kV0, 2);
+      Double_t xyz[3], pxpypz[3];
+      BestPrimaryVert*/
+
+     if(V0Vertex->GetV0CosineOfPointingAngle()<0.99)
+       continue;
+     if(V0Vertex->GetDcaV0Daughters()>1.0)
+       continue;
+     if(TMath::Abs(V0Vertex->Eta())>0.8)
+       continue;
+    
+
+    /*Done w/ calculation*/
+    fAnalysisV0Track->Update(pTrack,nTrack,InvMasses,IV0Radius,V0Vertex->GetDcaV0Daughters(), V0Vertex->GetV0CosineOfPointingAngle(),lpT,lEta, lDCAtoPrim);
+    new ((*fAnalysisV0TrackArray)[fAnalysisV0TrackArray->GetEntries()]) AliAnalysisPIDV0(*fAnalysisV0Track);
+    
+  };
+
+};
+//_______________________________________________________
+void AliAnalysisTaskTPCTOFCascade::ProcessCascades() {
+  Int_t NCascades = fESDEvent->GetNumberOfCascades();
+  if(NCascades<1) return;
+  const AliESDVertex *BestPrimaryVertex = fESDEvent->GetPrimaryVertex();
+  if(!BestPrimaryVertex) return;
+  if(!BestPrimaryVertex->GetStatus()) return;
+  Double_t lPrimaryVtxPosition[3] = {-100.0 , -100.0, -100.0};
+  BestPrimaryVertex->GetXYZ(lPrimaryVtxPosition);
+  Double_t lMagneticField = fESDEvent->GetMagneticField();
+
+  Double_t InvMasses[2] = {0};
+  Double_t InvV0Masses[4] = {0};
+  Double_t ArrayCounter = 0;
+  for(Int_t iCasc = 0; iCasc<NCascades; iCasc++) {
+    AliESDcascade* casc = (AliESDcascade*)fESDEvent->GetCascade(iCasc);
+    if(!casc)
+      continue;
+/////////////////////////////////////////////////////////////////////////////
+    // Begin to evaluate Dca, Pointing Angle & Spatial position of Cascade
+    Double_t lDcaXiDaughters          = casc->GetDcaXiDaughters();
+    Double_t lXiCosineOfPointingAngle = casc->GetCascadeCosineOfPointingAngle(lPrimaryVtxPosition[0], lPrimaryVtxPosition[1], lPrimaryVtxPosition[2]);   
+    Double_t lDcaXiToPrimVertex = casc->GetD(lPrimaryVtxPosition[0], lPrimaryVtxPosition[1], lPrimaryVtxPosition[2]);
+
+    Double_t lPosXi[3] = {-1000.0, -1000.0, -1000.0};
+    casc->GetXYZcascade(lPosXi[0], lPosXi[1], lPosXi[2]);
+/////////////////////////////////////////////////////////////////////////////
+    // Begin to evaluate Dca, Pointing Angle & Spatial position of V0
+    Double_t lDcaV0DaughtersXi = casc->GetDcaV0Daughters();
+    Double_t lV0toXiCosineOfPointingAngle = casc->GetV0CosineOfPointingAngle(lPosXi[0], lPosXi[1], lPosXi[2]);
+    Double_t lDcaV0ToPrimVertexXi = casc->GetD(lPosXi[0], lPosXi[1], lPosXi[2]);
+    Double_t lPosV0[3] = {-1000.0, -1000.0, -1000.0};
+    casc->GetXYZ(lPosV0[0], lPosV0[1], lPosV0[2]);
+/////////////////////////////////////////////////////////////////////////////
+    //Calculate Radius for both V0 and Cascade
+    Double_t lXiRadius = TMath::Sqrt(lPosXi[0]*lPosXi[0] + lPosXi[1]*lPosXi[1]); 
+    Double_t lV0Radius = TMath::Sqrt(lPosV0[0]*lPosV0[0] + lPosV0[1]*lPosV0[1]);
+    /* ALL DCA & VERTEX CUTS ARE TO BE DONE IN POST-PROCESSING */
+
+/////////////////////////////////////////////////////////////////////////////
+    //Defining Mass Variables
+    Double_t lInvMassLambdaAsCascDghter = casc->GetEffMass(); //Lambda Mass
+    InvV0Masses[1] = lInvMassLambdaAsCascDghter;
+    Double_t lInvMassXi    = 0;
+    Double_t lInvMassOmega = 0;
+    Double_t lV0quality = 0.;
+/////////////////////////////////////////////////////////////////////////////
+    //Reconstructing & Check bachelor & V0 daughter tracks
+    AliESDtrack* temp_b = fESDEvent->GetTrack((UInt_t)TMath::Abs(casc->GetBindex()));
+    AliESDtrack* temp_p = fESDEvent->GetTrack((UInt_t)TMath::Abs(casc->GetPindex()));
+    AliESDtrack* temp_n = fESDEvent->GetTrack((UInt_t)TMath::Abs(casc->GetNindex()));
+    if (!temp_b || !temp_p || !temp_n)
+      continue;
+    UInt_t lIDtemp_p  = (UInt_t) TMath::Abs(temp_p->GetID());
+    UInt_t lIDtemp_n  = (UInt_t) TMath::Abs(temp_n->GetID());
+    UInt_t lIDtemp_b   = (UInt_t) TMath::Abs(temp_b->GetID());
+    if(lIDtemp_b == lIDtemp_n)
+      continue;
+    if(lIDtemp_b == lIDtemp_p)
+      continue;
+    //Cuts
+    
+    if (!(temp_p->IsOn(AliESDtrack::kTPCrefit)))
+      continue;
+    if (!(temp_n->IsOn(AliESDtrack::kTPCrefit)))
+      continue;
+    if (!(temp_b->IsOn(AliESDtrack::kTPCrefit)))
+      continue;
+    if (temp_p->GetTPCNcls()<70||temp_n->GetTPCNcls()<70||temp_b->GetTPCNcls()<70)
+      continue;
+    if (temp_b->GetTPCsignalN()<70||temp_n->GetTPCsignalN()<70||temp_p->GetTPCsignalN()<70)
+      continue;
+    
+    if (TMath::Abs(temp_p->Eta())>0.8||(TMath::Abs(temp_n->Eta())>0.8||TMath::Abs(temp_b->Eta())>0.8))
+      continue;
+    if (temp_p->Pt()<0.15||temp_n->Pt()<0.15||temp_b->Pt()<0.15)
+      continue;
+/////////////////////////////////////////////////////////////////////////////
+    //PID cuts & Mass Estimations
+    // Bachelor
+    // Double_t nSigmaBachK = TMath::Abs(fPIDResponse->NumberOfSigmasTPC(temp_b, AliPID::kKaon));
+    // Double_t nSigmaBachPi = TMath::Abs(fPIDResponse->NumberOfSigmasTPC(temp_b, AliPID::kPion));
+    // // Negative V0 daughter
+    // Double_t nSigmaPiNeg = TMath::Abs(fPIDResponse->NumberOfSigmasTPC(temp_n, AliPID::kPion));
+    // Double_t nSigmaPNeg = TMath::Abs(fPIDResponse->NumberOfSigmasTPC(temp_n,AliPID::kProton));
+    // // Positive V0 daughter
+    // Double_t nSigmaPiPos = TMath::Abs(fPIDResponse->NumberOfSigmasTPC(temp_p,AliPID::kPion));
+    // Double_t nSigmaPPos = TMath::Abs(fPIDResponse->NumberOfSigmasTPC(temp_p,AliPID::kProton));
+/////////////////////////////////////////////////////////////////////////////
+    if(temp_b->GetSign()<0){
+      casc->ChangeMassHypothesis(lV0quality, 3312); //Xi-
+      lInvMassXi    = casc->GetEffMassXi();
+      casc->ChangeMassHypothesis(lV0quality, 3334); //Omega-
+      lInvMassOmega = casc->GetEffMassXi();
+    }
+    if(temp_b->GetSign()>0)
+      {
+	casc->ChangeMassHypothesis(lV0quality, -3312); //Xi+
+	lInvMassXi    = casc->GetEffMassXi();
+	casc->ChangeMassHypothesis(lV0quality, -3334);// Omega+
+	lInvMassOmega = casc->GetEffMassXi();
+      }
+    if(lInvMassXi == 0 && lInvMassOmega == 0)
+      continue;
+    if(lInvMassOmega != 0)
+      {
+	// if(lInvMassOmega <=1.64||lInvMassOmega >=1.71)
+	//   continue;
+	// if(lInvMassOmega <=1.64||lInvMassOmega >=1.71||nSigmaBachK >= 3.)
+	//   continue;
+	// if((nSigmaPiNeg >= 3.0 && nSigmaPPos >=3.0)||(nSigmaPNeg >= 3. && nSigmaPiPos >=3.0))
+	//   continue;
+	InvMasses[1]  = lInvMassOmega;
+      }
+    if(lInvMassXi != 0)
+      {
+	// if(lInvMassXi <= 1.29||lInvMassXi >= 1.36)
+	//   continue;
+	// if(lInvMassXi <= 1.29||lInvMassXi >= 1.36||nSigmaBachPi >=3.0)
+	//   continue;
+	// if((nSigmaPiNeg >= 3.0 && nSigmaPPos >= 3.0)||(nSigmaPNeg >= 3.0 && nSigmaPiPos >= 3.0))
+	//   continue;
+	InvMasses[0]  = lInvMassXi;
+      }
+  
+    Double_t V0Px = casc->AliESDv0::Px();
+    Double_t V0Py = casc->AliESDv0::Py();
+    Double_t V0Pz = casc->AliESDv0::Pz();
+    Double_t V0P  = casc->AliESDv0::P();
+    Double_t CascPx = casc->AliESDcascade::Px();
+    Double_t CascPy = casc->AliESDcascade::Py();
+    Double_t CascPz = casc->AliESDcascade::Pz();
+    Double_t CascP  = casc->AliESDcascade::P();
+    Double_t V0P_Pz = V0P - V0Pz + 1.e-13;
+    Double_t CascP_Pz = CascP - CascPz + 1.e-13;
+    Double_t V0P_plus_Pz =  V0P + V0Pz;
+    Double_t CascP_plus_Pz = CascP + CascPz;
+    if(V0Pz>V0P)
+      continue;
+    if(CascPz>CascP)
+      continue;
+    if(V0P_plus_Pz/V0P_Pz <= 0)
+      continue;
+    if(CascP_plus_Pz/CascP_Pz <= 0)
+      continue;
+    Double_t V0Pt = TMath::Sqrt(V0Px*V0Px + V0Py*V0Py);
+    Double_t V0Eta = 0.5*TMath::Log(TMath::Abs((V0P_plus_Pz)/(V0P_Pz)));
+    if(TMath::Abs(V0Eta>0.8))
+      continue;
+    Double_t CascPt = TMath::Sqrt(CascPx*CascPx + CascPy*CascPy);
+    Double_t CascEta = 0.5*TMath::Log(TMath::Abs((CascP_plus_Pz)/(CascP_Pz)));
+    if(TMath::Abs(CascEta>0.8))
+      continue;
+/////////////////////////////////////////////////////////////////////////////
+    //Cascade is good! Bag & Tag.
+     AliAnalysisPIDCascade* Cascade = new ((*fAnalysisCascadeTrackArray)[ArrayCounter]) AliAnalysisPIDCascade();
+     ArrayCounter++;
+        
+     AliAnalysisPIDTrack* bTrack = (AliAnalysisPIDTrack*)Cascade->GetBachAnalysisTrack();
+     AliAnalysisPIDV0* V0 = (AliAnalysisPIDV0*)Cascade->GetV0();
+     
+     AliAnalysisPIDTrack* pTrack = new AliAnalysisPIDTrack();
+     AliAnalysisPIDTrack* nTrack = new AliAnalysisPIDTrack();
+     bTrack->Update(temp_b,fMCEvent,fPIDResponse, GetTrackCutsFlag(temp_b));
+     pTrack->Update(temp_p,fMCEvent,fPIDResponse, GetTrackCutsFlag(temp_p));
+     nTrack->Update(temp_n,fMCEvent,fPIDResponse, GetTrackCutsFlag(temp_n));
+
+     V0->Update(pTrack, nTrack, InvV0Masses, lV0Radius, lDcaV0DaughtersXi, lV0toXiCosineOfPointingAngle, V0Pt, V0Eta, lDcaV0ToPrimVertexXi);
+     Cascade->Update(V0, bTrack, InvMasses,  lXiRadius, lDcaXiDaughters, lXiCosineOfPointingAngle, CascPt, CascEta, lDcaXiToPrimVertex, temp_b->GetSign());
+
+  };   
+
+};
+
+
+
+
+void
+AliAnalysisTaskTPCTOFCascade::UserExec(Option_t *option)
+{
+  /*
+   * user exec
+   */
+
+  /*** INITIALIZATION ***/
+
+  /* init run */
+  if (!InitRun()) return;
+  FillHist(4);
+  /* init event */
+  if (!InitEvent()) return;
+  FillHist(5);
+  fAnalysisEvent->Reset();
+  Int_t EventSelectionFlag = 0;
+  Float_t V0MPercentile = -1000;
+  AliMultSelection *ams = (AliMultSelection*)fESDEvent->FindListObject("MultSelection");
+  if(!ams)
+    V0MPercentile = -999;
+  else {
+    V0MPercentile = ams->GetMultiplicityPercentile("V0M");
+    if(ams->GetThisEventIsNotPileup()) EventSelectionFlag += AliAnalysisPIDEvent::kNotPileupInSPD;
+    if(ams->GetThisEventIsNotPileupMV()) EventSelectionFlag += AliAnalysisPIDEvent::kNotPileupInMV;
+    if(ams->GetThisEventIsNotPileupInMultBins()) EventSelectionFlag += AliAnalysisPIDEvent::kNotPileupInMB;
+    if(ams->GetThisEventINELgtZERO()) EventSelectionFlag+=AliAnalysisPIDEvent::kINELgtZERO;
+    if(ams->GetThisEventHasNoInconsistentVertices()) EventSelectionFlag+=AliAnalysisPIDEvent::kNoInconsistentVtx;
+    if(ams->GetThisEventIsNotAsymmetricInVZERO()) EventSelectionFlag+=AliAnalysisPIDEvent::kNoV0Asym;
+  };
+  Bool_t lSPDandTrkVtxExists=kFALSE;
+  Bool_t lPassProximityCut=kTRUE;
+  if(SelectVertex2015pp(fESDEvent,kTRUE,&lSPDandTrkVtxExists,&lPassProximityCut)) EventSelectionFlag+=AliAnalysisPIDEvent::kVertexSelected2015pp;
+  if(lSPDandTrkVtxExists) EventSelectionFlag+=AliAnalysisPIDEvent::kSPDandTrkVtxExists;
+  if(lPassProximityCut) EventSelectionFlag+=AliAnalysisPIDEvent::kPassProximityCut;
+  fAnalysisEvent->SetV0Mmultiplicity(V0MPercentile);
+  fAnalysisEvent->SetEventFlags(EventSelectionFlag);
+  AliVVZERO *v0 = fESDEvent->GetVZEROData();
+  for(Int_t i=0;i<32;i++) fAnalysisEvent->SetV0CellAmplitude(i,v0->GetMultiplicityV0A(i));
+  for(Int_t i=32;i<64;i++) fAnalysisEvent->SetV0CellAmplitude(i,v0->GetMultiplicityV0C(i-32));
+  
+
+  /*** MC PRIMARY PARTICLES ***/
+
+  Int_t mcmulti = 0;
+  if (fMCFlag) {
+
+    /* reset track array */
+    fAnalysisParticleArray->Clear();
+    
+    /* loop over primary particles */
+    Int_t nPrimaries = fMCEvent->GetNumberOfPrimaries();//fMCStack->GetNprimary();
+    TParticle *particle;
+    TParticlePDG *particlePDG;
+    /* loop over primary particles */
+    for (Int_t ipart = 0; ipart < nPrimaries; ipart++) {
+      Bool_t OWSave=kFALSE; //Overwrite save -- used to add other particle than primaries
+      /* get particle */
+      particle = fMCEvent->Particle(ipart);//((AliMCParticle*)fMCEvent->GetTrack(ipart))->Particle();//fMCStack->Particle(ipart);
+      if (!particle) continue;
+      /* get particlePDG */
+      particlePDG = particle->GetPDG();
+      Int_t pdgcode = TMath::Abs(particle->GetPdgCode());
+      if (!particlePDG) continue;
+      OWSave = ((pdgcode==333)||(pdgcode==310)||(pdgcode==3122)||(pdgcode==11));
+
+      /* check primary */
+      if ((!fMCEvent->IsPhysicalPrimary(ipart))&&(!OWSave)) continue;
+
+      /* check charged */
+      if ((particlePDG->Charge()==0.)&&(!OWSave)) continue;
+      mcmulti++;
+      /* check rapidity and pt cuts */
+       if ( (TMath::Abs(particle->Energy() - particle->Pz()) < 1e-6)  ) continue;
+       if ( ((particle->Energy() + particle->Pz())/(particle->Energy() - particle->Pz())) < 0) continue;
+       Double_t PRap = particle->Y();
+       if(std::isnan(PRap))
+	 continue;
+	
+      if (TMath::Abs(particle->Y()) > fRapidityCut) continue;
+      if (particle->Pt() < 0.15) continue;
+      //Get mother PDG code. In principle, can be optimized by only doing if for OWSace, as the rest of the particles are physical primaries
+      Int_t indexMother = particle->GetFirstMother();
+      Int_t lMotherPDG=0; //Just to be safe
+      if(indexMother>=0) {
+	TParticle *MotherParticle = fMCEvent->Particle(indexMother);
+	lMotherPDG = MotherParticle->GetPdgCode();
+      }; 
+
+      /* update and add analysis particle */
+      fAnalysisParticle->Update(particle, ipart, lMotherPDG);
+      new ((*fAnalysisParticleArray)[fAnalysisParticleArray->GetEntries()]) AliAnalysisPIDParticle(*fAnalysisParticle);
+    } /* end of loop over primary particles */
+
+    
+  }
+
+  /*** GLOBAL EVENT INFORMATION ***/
+
+  //  fAnalysisEvent->Reset(); // Moved up
+  /* update global event info */
+  fAnalysisEvent->SetIsCollisionCandidate(fIsCollisionCandidate);
+  fAnalysisEvent->SetIsEventSelected(fIsEventSelected);
+  fAnalysisEvent->SetIsPileupFromSPD(fIsPileupFromSPD);
+  fAnalysisEvent->SetHasVertex(fHasVertex);
+  fAnalysisEvent->SetVertexZ(fVertexZ);
+  fAnalysisEvent->SetMCTimeZero(fMCTimeZero);
+  fAnalysisEvent->SetRunNumber(fRunNumber);
+  fAnalysisEvent->SetMagneticField(fESDEvent->GetMagneticField());
+				
+  /* update TOF event info */
+  for (Int_t i = 0; i < 10; i++) {
+    fAnalysisEvent->SetTimeZeroTOF(i, fESDpid->GetTOFResponse().GetT0bin(i));
+    fAnalysisEvent->SetTimeZeroTOFSigma(i, fESDpid->GetTOFResponse().GetT0binRes(i));
+  }
+  /* update T0 event info */
+  for (Int_t i = 0; i < 3; i++)
+    fAnalysisEvent->SetTimeZeroT0(i, fESDEvent->GetT0TOF(i));
+
+
+  Int_t refmulti;
+  refmulti = AliESDtrackCuts::GetReferenceMultiplicity(fESDEvent, AliESDtrackCuts::kTrackletsITSTPC,0.8);  
+  fAnalysisEvent->SetReferenceMultiplicity(refmulti);
+  fAnalysisEvent->SetMCMultiplicity(mcmulti);
+  /*** RECONSTRUCTED TRACKS ***/
+
+  /* reset track array */
+  fAnalysisTrackArray->Clear();
+  // fAnalysisV0TrackArray->Clear();
+  /* loop over ESD tracks */
+  Int_t nTracks = fESDEvent->GetNumberOfTracks();
+  AliESDtrack *track;
+  for (Int_t itrk = 0; itrk < nTracks; itrk++) {
+    /* get track */
+    track = fESDEvent->GetTrack(itrk);
+    if (!track) continue;
+    /* check accept track */
+    Int_t trflag = GetTrackCutsFlag(track);
+    if(!trflag) continue;
+    
+    /* update and add analysis track */
+    fAnalysisTrack->Update(track, fMCEvent,fPIDResponse, trflag);
+    const AliESDVertex *vtx = fESDEvent->GetPrimaryVertexTracks();
+    if(!vtx || !vtx->GetStatus())
+      vtx = fESDEvent->GetPrimaryVertexSPD();
+    if(vtx) {
+      if(vtx->GetStatus()) {
+	Double_t ChiConstrained = track->GetChi2TPCConstrainedVsGlobal(vtx);
+	fAnalysisTrack->SetChi2TPCConstrainedVsGlobal(ChiConstrained);
+      } else
+	fAnalysisTrack->SetChi2TPCConstrainedVsGlobal(-8);
+    };
+    if(track->IsEMCAL()) {
+      AliVCluster *lvcl = fESDEvent->GetCaloCluster(track->GetEMCALcluster());
+      if(lvcl)
+	fAnalysisTrack->SetEMCalPars(lvcl->E(),track->GetTrackPOnEMCal());
+    };
+    new ((*fAnalysisTrackArray)[fAnalysisTrackArray->GetEntries()]) AliAnalysisPIDTrack(*fAnalysisTrack);
+    //fAnalysisV0Track = (V0Track*)fAnalysisTrack;
+    /*fAnalysisV0Track->SetExtraParam(3);
+      new ((*fAnalysisV0TrackArray)[fAnalysisV0TrackArray->GetEntries()]) V0Track(*fAnalysisV0Track);*/
+    
+
+  } /* end of loop over ESD tracks */
+  ProcessV0s();
+  ProcessCascades();
+  fPIDTree->Fill();
+
+  PostData(1,fPIDTree);
+  PostData(2,fEvHist);
+
+  fAnalysisV0TrackArray->Clear();
+  fAnalysisCascadeTrackArray->Clear();
+}
+
+void AliAnalysisTaskTPCTOFCascade::Terminate(Option_t *) {
+  printf("Terminate!\n");
+}
+

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisTaskTPCTOFCascade.h
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades/AliAnalysisTaskTPCTOFCascade.h
@@ -1,0 +1,156 @@
+#ifndef ALIANALYSISTASKTPCTOFCascade_H
+#define ALIANALYSISTASKTPCTOFCascade_H
+
+#include "AliAnalysisTaskSE.h"
+#include "AliPID.h"
+
+class AliESDEvent;
+class AliMCEvent;
+//class AliStack;
+class AliPhysicsSelection;
+class AliESDtrackCuts;
+class AliESDpid;
+class AliESDtrack;
+class AliESDv0;
+class AliESDVertex;
+class AliAnalysisPIDV0;
+class AliAnalysisPIDCascade;
+class AliAODVertex;
+class AliTOFcalib;
+class AliTOFT0maker;
+class TList;
+class TH1F;
+class TH2F;
+class TH1D;
+class TObjArray;
+class AliAnalysisPIDEvent;
+class AliAnalysisPIDTrack;
+class AliAnalysisPIDParticle;
+class TClonesArray;
+class AliCentrality;
+class AliPIDResponse;
+class AliMultSelection;
+class AliAnalysisUtils;
+class AliESDtrackCuts;
+class TTree;
+class AliKFVertex;
+class AliKFParticle;
+class AliVVZERO;
+class AliAnalysisTaskTPCTOFCascade :
+public AliAnalysisTaskSE
+{
+
+ public:
+
+  AliAnalysisTaskTPCTOFCascade(); // default constructor
+  AliAnalysisTaskTPCTOFCascade(Bool_t isMC); // default constructor
+  virtual ~AliAnalysisTaskTPCTOFCascade(); // default destructor
+
+  virtual void UserCreateOutputObjects(); // user create output objects
+  
+  virtual void UserExec(Option_t *option); // user exec
+  virtual void Terminate(Option_t *option); // terminate
+
+
+
+  /* getters */
+  AliESDpid *GetESDpid() const {return fESDpid;}; // get ESD PID
+  AliTOFcalib *GetTOFcalib() const {return fTOFcalib;}; // getter
+  AliTOFT0maker *GetTOFT0maker() const {return fTOFT0maker;}; // getter
+  
+  /* setters */
+  void SetMCFlag(Bool_t value = kTRUE) {fMCFlag = value;}; // setter
+  void SetMCTuneFlag(Bool_t value = kTRUE) {fMCTuneFlag = value;}; // setter
+  void SetPbPbFlag(Bool_t value = kTRUE) {fPbPbFlag = value;}; // setter
+  void SetVertexSelectionFlag(Bool_t value = kTRUE) {fVertexSelectionFlag = value;}; // setter
+  void SetVertexCut(Double_t value) {fVertexCut = value;}; // setter
+  void SetRapidityCut(Double_t value) {fRapidityCut = value;}; // setter
+  void SetTimeResolution(Double_t value) {fTimeResolution = value;}; // setter
+  void ProcessV0s();
+  void ProcessCascades();
+  void FillHist(Double_t myflag);
+  Bool_t IsGoodSPDvertexRes(const AliESDVertex * spdVertex = NULL);
+  Bool_t SelectVertex2015pp(AliESDEvent *esd,
+			    Bool_t checkSPDres = kTRUE, //enable check on vtx resolution 
+			    Bool_t *SPDandTrkExists = NULL, //ask for both trk and SPD vertex
+			    Bool_t *checkProximity = NULL); //apply cut on relative position of spd and trk verteces
+
+ protected:
+
+  AliAnalysisTaskTPCTOFCascade(const AliAnalysisTaskTPCTOFCascade &); // copy constructor
+  AliAnalysisTaskTPCTOFCascade &operator=(const AliAnalysisTaskTPCTOFCascade &); // operator=
+ 
+
+  /* methods */
+  Bool_t InitRun(); // init run
+  Bool_t InitEvent(); // init event
+  Bool_t HasPrimaryDCA(AliESDtrack *track); // has primary DCA
+  Bool_t MakeTPCPID(AliESDtrack *track, Double_t *nsigma, Double_t *signal); // make TPC PID
+  Bool_t MakeTOFPID(AliESDtrack *track, Double_t *nsigma, Double_t *signal); // make TOF PID
+  Int_t GetTrackCutsFlag(AliESDtrack *LocalTrack);
+  /* flags */
+  //AliESDtrackCuts *fESDtrackCuts;
+  Bool_t fInitFlag; // init flag
+  Bool_t fMCFlag; // MC flag
+  Bool_t fMCTuneFlag; // MC tune flag
+  Bool_t fPbPbFlag; // PbPb flag
+  Bool_t fVertexSelectionFlag; // vertex selection flag
+  Bool_t fPrimaryDCASelectionFlag; // primary DCA selection flag
+  TTree *fPIDTree;
+  TH1D *fEvHist;
+  /* ESD analysis */
+  AliPIDResponse *fPIDResponse; //! PID object
+  AliAnalysisUtils *fAnUtils; //! Analysis Utils
+  Int_t fRunNumber; // run number
+  UInt_t fStartTime; // start time
+  UInt_t fEndTime; // end time
+  AliESDEvent *fESDEvent; // ESD event
+  AliMCEvent *fMCEvent; // MC event
+  //AliStack *fMCStack; // MC stack
+  AliESDtrackCuts *fTrackCuts2010; //! ITSTPC track cuts 2010
+  AliESDtrackCuts *fTrackCuts2011; //! ITSTPC track cuts 2011
+  AliESDtrackCuts *fTrackCutsTPCRefit; //! TPC only track cuts + refit
+  AliESDtrackCuts *fTrackCuts2011Sys; //! TPC only track cuts + refit 
+  AliESDpid *fESDpid; // ESD PID
+  Bool_t fIsCollisionCandidate; // is collision candidate
+  UInt_t fIsEventSelected; // is event selected
+  Bool_t fIsPileupFromSPD; // is pile-up from SPD
+  Bool_t fHasVertex; // has vertex
+  Float_t fVertexZ; // vertex z
+  Float_t fMCTimeZero; // MC time-zero
+  AliCentrality *fCentrality; // centrality
+  
+  AliAnalysisPIDEvent *fAnalysisEvent; // analysis event
+  TClonesArray *fAnalysisTrackArray; // analysis track array
+  AliAnalysisPIDTrack *fAnalysisTrack; // analysis track
+  TClonesArray *fAnalysisParticleArray; // analysis particle array
+  AliAnalysisPIDParticle *fAnalysisParticle; // analysis particle
+  TClonesArray *fAnalysisV0TrackArray; //V0 track array
+  AliAnalysisPIDV0 *fAnalysisV0Track; //V0 track object
+  TClonesArray *fAnalysisCascadeTrackArray; //Cascade track array
+  AliAnalysisPIDCascade *fAnalysisCascadeTrack; //Cascade track object
+
+  /* TOF related */
+  AliTOFcalib *fTOFcalib; // TOF calib
+  AliTOFT0maker *fTOFT0maker; // TOF-T0 maker
+  Float_t fTimeResolution; // time resolution
+
+  /*** CUTS ***/
+
+  /* vertex cut */
+  Double_t fVertexCut; // vertex cut
+  Double_t fRapidityCut; // rapidity cut
+
+  /*** HISTOGRAMS ***/
+  
+  TH1F *V0MBinCount;
+
+  /* histo lists */
+  TList *fHistoList; // histo list
+  TList *fMCHistoList; // MC histo list
+
+  
+  ClassDef(AliAnalysisTaskTPCTOFCascade, 3);
+};
+
+#endif /* ALIANALYSISTASKTPCTOFCascade_H */


### PR DESCRIPTION
Implementation for a new analysis task that handles Cascade particles (Xi & Omega) for the analysis of identified charged particles Vs multiplicity and spherocity.

The pathway for the new analysis task i preliminary set as: "AliPhysics/PWGLF/SPECTRA/PiKaPr/TPCTOFCascades". 

The code works as an extension, with additional corrections & minor bug fixes, to the analysis task found in "AliPhysics/PWGLF/SPECTRA/PiKaPr/TPCTOFfits"
 
The output is stored into  trees that are later used for more precise post-processing.

I've as of posting this managed to compile AliPhysics successfully, as well as a successful local train test.