### PR TITLE
[RooUnfold] Improve check for scale object support

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalList.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalList.cxx
@@ -24,24 +24,22 @@
 #include "RooUnfoldResponse.h"
 #endif
 
-/// \cond CLASSIMP
 ClassImp(AliEmcalList)
-/// \endcond
 
+/// \brief constructor
 //________________________________________________________________________
 AliEmcalList::AliEmcalList() : TList(), fUseScaling(kFALSE)
 {
-  // constructor
 }
 
-/// Overridden ::Merge function
+/// \brief Overridden ::Merge function
 //________________________________________________________________________
 Long64_t AliEmcalList::Merge(TCollection *hlist)
 {
   if(!hlist)
     return 0;
 
-  AliInfo(Form("Scaled merging for list %s is %sactivated.", hlist->GetName(),(fUseScaling) ? "" : "not "));
+  AliInfoStream() << "Scaled merging for list " <<hlist->GetName() << " is " << (fUseScaling ? "" : "not ") << "activated." << std::endl;
   if(!fUseScaling)
     return TList::Merge(hlist);
 
@@ -61,7 +59,7 @@ Long64_t AliEmcalList::Merge(TCollection *hlist)
   // #### On last level, do the scaling
   if(isLastLevel)
   {
-    AliInfo(Form("===== LAST LEVEL OF MERGING ====="));
+    AliInfoStream() << "===== LAST LEVEL OF MERGING =====" << std::endl;
 
     // Scale all histograms in this list
     Double_t scalingFactor = GetScalingFactor(xsection, ntrials);
@@ -78,13 +76,13 @@ Long64_t AliEmcalList::Merge(TCollection *hlist)
     }
   }
 
-  AliInfo("Merge() done.");
+  AliInfoStream() << "Merge() done." << std::endl;
 
   TList::Merge(hlist);
   return hlist->GetEntries() + 1;
 }
 
-/// Function that does the scaling of all histograms in hlist recursively
+/// \brief Function that does the scaling of all histograms in hlist recursively
 //________________________________________________________________________
 void AliEmcalList::ScaleAllHistograms(TCollection *hlist, Double_t scalingFactor)
 {
@@ -99,21 +97,23 @@ void AliEmcalList::ScaleAllHistograms(TCollection *hlist, Double_t scalingFactor
       continue;
     }
 
-    // Otherwise, scale TH1-derived / THnBase-derived histograms
-    if (!(listObject->InheritsFrom(TH1::Class()) || listObject->InheritsFrom(THnBase::Class())))
+    // Otherwise, scale object if scaling is supported
+    if (!IsScalingSupported(listObject)){
+      AliInfoStream() << "Scaling of objects of type " << listObject->IsA()->GetName() << " unsupported - object " << listObject->GetName() << " will not be scaled" << std::endl;
       continue;
+    }
 
     // Don't scale profiles and histograms used for scaling
     TString histogram_class (listObject->ClassName());
     TString histogram_name (listObject->GetName());
     if (histogram_name.Contains("fHistXsection") || histogram_name.Contains("fHistTrials") || histogram_name.Contains("fHistEvents"))
     {
-      AliInfo(Form("Histogram %s will not be scaled, because a scaling histogram", listObject->GetName()));
+      AliInfoStream() << "Histogram " << listObject->GetName() << " will not be scaled, because a scaling histogram" << std::endl;
       continue;
     }
     if (histogram_class.Contains("TProfile"))
     {
-      AliInfo(Form("Histogram %s will not be scaled, because it is a TProfile", listObject->GetName()));
+      AliInfoStream() << "Histogram " << listObject->GetName() << " will not be scaled, because it is a TProfile" << std::endl;
       continue;
     }
 
@@ -137,19 +137,19 @@ void AliEmcalList::ScaleAllHistograms(TCollection *hlist, Double_t scalingFactor
       if(auto responseND = response->Hresponse()) responseND->Scale(scalingFactor);
     }
 #endif
-    AliInfo(Form("Histogram %s (%s) was scaled...", listObject->GetName(), histogram_class.Data()));
+    AliInfoStream() << "Histogram " << listObject->GetName() << " (" << histogram_class.Data() << ") was scaled..." << std::endl;
 
   }
 }
 
-/// Helper function scaling factor
+/// \brief Helper function scaling factor
 //________________________________________________________________________
-Double_t AliEmcalList::GetScalingFactor(TH1* xsection, TH1* ntrials)
+Double_t AliEmcalList::GetScalingFactor(const TH1* xsection, const TH1* ntrials) const
 {
   Int_t binNumber = GetFilledBinNumber(xsection);
   if(!binNumber)
   {
-    AliInfo("List already scaled or scaling invalid. Scaling factor = 1.");
+    AliInfoStream() << "List already scaled or scaling invalid. Scaling factor = 1." << std::endl;
     return 1.0;
   }
 
@@ -159,14 +159,14 @@ Double_t AliEmcalList::GetScalingFactor(TH1* xsection, TH1* ntrials)
   if(valNTRIALS)
     scalingFactor = valXSEC/valNTRIALS;
 
-  AliInfo(Form("## Bin %i: trials=%f, xsec=%f -> scaling=%f", binNumber, valNTRIALS, valXSEC, scalingFactor));
+  AliInfoStream() << "## Bin " << binNumber << ": trials=" << valNTRIALS << ", xsec=" << valXSEC << " -> scaling=" << scalingFactor << std::endl;
   return scalingFactor;
 }
 
-/// Helper function to determine whether we are in last merge step
+/// \brief Helper function to determine whether we are in last merge step
 /// \param collection Collection of AliEmcalList objects
 //________________________________________________________________________
-Bool_t AliEmcalList::IsLastMergeLevel(TCollection* collection)
+Bool_t AliEmcalList::IsLastMergeLevel(const TCollection* collection) const 
 {
   // Get the pt hard bin number that is filled in this object
   TH1* xsection = static_cast<TH1*>(FindObject("fHistXsection"));
@@ -183,18 +183,36 @@ Bool_t AliEmcalList::IsLastMergeLevel(TCollection* collection)
   return kFALSE;
 }
 
-/// Helper function that returns the bin in a TH1 that is filled
+/// \brief Helper function checking whether type is supported for scaling
+///
+/// Supported types are: 
+///  - all TH1-derived / THnBase-derived histograms
+///  - objects inheriting from RooUnfoldResponse if AliPhysics is built with
+///    RooUnfold support
+///
+/// \param scaleobject Object for which to deterime scaling support
+/// \return true if object can be scaled, false otherwise
+//________________________________________________________________________
+bool AliEmcalList::IsScalingSupported(const TObject *scaleobject) const {
+  if(scaleobject->InheritsFrom(TH1::Class()) || scaleobject->InheritsFrom(THnBase::Class())) return true;
+#ifdef WITH_ROOUNFOLD
+  if(scaleobject->InheritsFrom(RooUnfoldResponse::Class())) return true;
+#endif
+  return false;
+}
+
+/// \brief Helper function that returns the bin in a TH1 that is filled
 /// \param hist  Histogram
 /// \return bin number that is filled. If no or more than one bin is filled, 0.
 //________________________________________________________________________
-Int_t AliEmcalList::GetFilledBinNumber(TH1* hist)
+Int_t AliEmcalList::GetFilledBinNumber(const TH1* hist) const
 {
-  AliInfo(Form("%s: nbinsX=%i", hist->GetName(), hist->GetNbinsX()));
+  AliInfoStream() << hist->GetName() << ": nbinsX=" << hist->GetNbinsX() << std::endl;;
 
   Int_t binFound = 0;
   for(Int_t i=1; i<=hist->GetNbinsX(); i++)
   {
-    AliInfo(Form("%s: bin=%i, val=%f", hist->GetName(), i, hist->GetBinContent(i)));
+    AliInfoStream() << hist->GetName() << ": bin=" << i << ", val=" << hist->GetBinContent(i) << std::endl;
     if(hist->GetBinContent(i))
     {
       if(!binFound)
@@ -207,7 +225,7 @@ Int_t AliEmcalList::GetFilledBinNumber(TH1* hist)
   }
 
   if(!binFound)
-    AliError("No bin filled in scaling histogram.");
+    AliErrorStream() << "No bin filled in scaling histogram." << std::endl;
 
   // 0 if no bin found or more than one filled, otherwise returns bin number
   return binFound;

--- a/PWG/EMCAL/EMCALbase/AliEmcalList.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalList.h
@@ -34,9 +34,10 @@ public:
 private:
   // ####### Helper functions
   void                        ScaleAllHistograms(TCollection *hlist, Double_t scalingFactor);
-  Double_t                    GetScalingFactor(TH1* xsection, TH1* ntrials);
-  Bool_t                      IsLastMergeLevel(TCollection* collection);
-  Int_t                       GetFilledBinNumber(TH1* hist);
+  Double_t                    GetScalingFactor(const TH1* xsection, const TH1* ntrials) const;
+  Bool_t                      IsLastMergeLevel(const TCollection* collection) const;
+  Int_t                       GetFilledBinNumber(const TH1* hist) const;
+  Bool_t                      IsScalingSupported(const TObject *scaleobject) const;
   
   Bool_t                      fUseScaling;                    ///< if true, scaling will be done. if false AliEmcalList simplifies to TList
 


### PR DESCRIPTION
Check for scale object support outsourced to new function.
This allows to add RooUnfoldResponse to the supported
object types including the check whether AliPhysics was
built with RooUnfold support.