### PR TITLE
Add possibility to cut on det-lvl jet pT to clean up false matches in RM

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetPerformance.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetPerformance.cxx
@@ -106,6 +106,7 @@ AliAnalysisTaskEmcalJetPerformance::AliAnalysisTaskEmcalJetPerformance() :
   fJetMatchingR(0.),
   fMinSharedMomentumFraction(0.5),
   fMCJetMinMatchingPt(0.15),
+  fDetJetMinMatchingPt(0.15),
   fPlotJetMatchCandThresh(1.),
   fUseAliEventCuts(kTRUE),
   fEventCuts(0),
@@ -2833,15 +2834,17 @@ void AliAnalysisTaskEmcalJetPerformance::ComputeJetMatches(AliJetContainer* jetC
     jet2->ResetMatching();
   }
 
-  for (auto jet1 : jetCont1->accepted()) {
-    
+  for (auto jet1 : jetCont1->accepted()) {//detector level
+    if (jet1->Pt() < fDetJetMinMatchingPt) {
+        continue;
+    }
     if (bUseJetCont2Acceptance) {
       for (auto jet2 : jetCont2->accepted()) {
         SetJetClosestCandidate(jet1, jet2);
       }
     }
     else {
-      for (auto jet2 : jetCont2->all()) {
+      for (auto jet2 : jetCont2->all()) {//truth level
         if (jet2->Pt() < fMCJetMinMatchingPt) {
           continue;
         }

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetPerformance.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetPerformance.h
@@ -128,6 +128,7 @@ class AliAnalysisTaskEmcalJetPerformance : public AliAnalysisTaskEmcalJet {
   void SetJetMatchingR(Double_t r)                          { fJetMatchingR = r; }
   void SetMinimumSharedMomentumFraction(double d)           { fMinSharedMomentumFraction = d; }
   void SetMCJetMinMatchingPt(Double_t min)                  { fMCJetMinMatchingPt = min; }
+  void SetDetJetMinMatchingPt(Double_t min)                 { fDetJetMinMatchingPt = min; }
   void SetPlotJetMatchCandThresh(Double_t r)                { fPlotJetMatchCandThresh = r; };
   void SetDoTriggerResponse(Bool_t b)                       { fDoTriggerResponse = b; };
   void SetDoClosureTest(Bool_t b)                           { fDoClosureTest = b; }
@@ -220,6 +221,7 @@ class AliAnalysisTaskEmcalJetPerformance : public AliAnalysisTaskEmcalJet {
   Double_t                    fJetMatchingR;                        ///< Jet matching R threshold
   Double_t                    fMinSharedMomentumFraction;           ///< Minimum shared momentum (pp det-level track pT in combined jet) / (pp det-level track pT)
   Double_t                    fMCJetMinMatchingPt;                  ///< Min jet pT for MC jets being matched, for when container criteria is not applied
+  Double_t                    fDetJetMinMatchingPt;                 ///< Min jet pT for Det jets being matched, for when container criteria is not applied
   Double_t                    fPlotJetMatchCandThresh;              ///< Threshold for jet R to count candidates, affects plotting only
   
   // Event selection


### PR DESCRIPTION
@jdmulligan these are the proposed changes