### PR TITLE
Make AliEmcalFastOrMonitor inheriting from AliAnalysisTaskEmcal

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalFastOrMonitorTask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalFastOrMonitorTask.cxx
@@ -55,9 +55,8 @@ ClassImp(PWG::EMCAL::AliEmcalFastOrMonitorTask)
 using namespace PWG::EMCAL;
 
 AliEmcalFastOrMonitorTask::AliEmcalFastOrMonitorTask() :
-  AliAnalysisTaskSE(),
-  fHistos(nullptr),
-  fGeom(nullptr),
+  AliAnalysisTaskEmcal(),
+  fHistosQA(nullptr),
   fLocalInitialized(false),
   fOldRun(-1),
   fRequestTrigger(AliVEvent::kAny),
@@ -70,13 +69,12 @@ AliEmcalFastOrMonitorTask::AliEmcalFastOrMonitorTask() :
   fMaskedFastorOADB(nullptr),
   fMaskedCellOADB(nullptr)
 {
-
+  SetNeedEmcalGeom(kTRUE);
 }
 
 AliEmcalFastOrMonitorTask::AliEmcalFastOrMonitorTask(const char *name) :
-  AliAnalysisTaskSE(name),
-  fHistos(nullptr),
-  fGeom(nullptr),
+  AliAnalysisTaskEmcal(name, kTRUE),
+  fHistosQA(nullptr),
   fLocalInitialized(false),
   fOldRun(-1),
   fRequestTrigger(AliVEvent::kAny),
@@ -88,6 +86,7 @@ AliEmcalFastOrMonitorTask::AliEmcalFastOrMonitorTask(const char *name) :
   fMaskedFastorOADB(nullptr),
   fMaskedCellOADB(nullptr)
 {
+  SetNeedEmcalGeom(kTRUE);
   DefineOutput(1, TList::Class());
 }
 
@@ -97,25 +96,27 @@ AliEmcalFastOrMonitorTask::~AliEmcalFastOrMonitorTask() {
 }
 
 void AliEmcalFastOrMonitorTask::UserCreateOutputObjects() {
-  fHistos = new THistManager("fastOrHistos");
+  AliAnalysisTaskEmcal::UserCreateOutputObjects();
+
+  fHistosQA = new THistManager("fastOrHistos");
 
   const int kMaxCol = 48, kMaxRow = 104, kMaxFastOr = kMaxRow * kMaxCol;
 
-  fHistos->CreateTH1("hEvents", "Number of events", 1, 0.5, 1.5);
-  fHistos->CreateTH1("hFastOrFrequencyL0", "FastOr frequency at Level0", kMaxFastOr, -0.5, kMaxFastOr - 0.5);
-  fHistos->CreateTH1("hFastOrFrequencyL1", "FastOr frequency at Level1", kMaxFastOr, -0.5, kMaxFastOr - 0.5);
-  fHistos->CreateTH2("hFastOrAmplitude", "FastOr amplitudes; FastOR Abs ID; Amplitude", kMaxFastOr, -0.5, kMaxFastOr - 0.5, 513, -0.5, 512.5);
-  fHistos->CreateTH2("hFastOrTimeSum", "FastOr time sum; FastOR Abs ID; L0 time sum", kMaxFastOr, -0.5, kMaxFastOr - 0.5, 2049, -0.5, 2048.5);
-  fHistos->CreateTH2("hFastOrTransverseTimeSum", "FastOr transverse time sum; FastOR Abs ID; L0 transverse time sum", kMaxFastOr, -0.5, kMaxFastOr - 0.5, 2049, -0.5, 2048.5);
-  fHistos->CreateTH2("hFastOrNL0Times", "FastOr Number of L0 times; FastOR AbsID; Number of L0 times", kMaxFastOr, -0.5, kMaxFastOr - 0.5, 16, -0.5, 15.5);
-  fHistos->CreateTH2("hFastOrColRowFrequencyL0", "FastOr Frequency (col-row) at Level0; col; row", kMaxCol, -0.5, kMaxCol - 0.5, kMaxRow, -0.5, kMaxRow - 0.5);
-  fHistos->CreateTH2("hFastOrColRowFrequencyL1", "FastOr Frequency (col-row) at Level1; col; row", kMaxCol, -0.5, kMaxCol - 0.5, kMaxRow, -0.5, kMaxRow - 0.5);
-  fHistos->CreateTH2("hEnergyFastorCell", "Sum of cell energy vs. fastor Energy", 1000, 0., 20., 1000 , 0., 20.);
+  fHistosQA->CreateTH1("hEvents", "Number of events", 1, 0.5, 1.5);
+  fHistosQA->CreateTH1("hFastOrFrequencyL0", "FastOr frequency at Level0", kMaxFastOr, -0.5, kMaxFastOr - 0.5);
+  fHistosQA->CreateTH1("hFastOrFrequencyL1", "FastOr frequency at Level1", kMaxFastOr, -0.5, kMaxFastOr - 0.5);
+  fHistosQA->CreateTH2("hFastOrAmplitude", "FastOr amplitudes; FastOR Abs ID; Amplitude", kMaxFastOr, -0.5, kMaxFastOr - 0.5, 513, -0.5, 512.5);
+  fHistosQA->CreateTH2("hFastOrTimeSum", "FastOr time sum; FastOR Abs ID; L0 time sum", kMaxFastOr, -0.5, kMaxFastOr - 0.5, 2049, -0.5, 2048.5);
+  fHistosQA->CreateTH2("hFastOrTransverseTimeSum", "FastOr transverse time sum; FastOR Abs ID; L0 transverse time sum", kMaxFastOr, -0.5, kMaxFastOr - 0.5, 2049, -0.5, 2048.5);
+  fHistosQA->CreateTH2("hFastOrNL0Times", "FastOr Number of L0 times; FastOR AbsID; Number of L0 times", kMaxFastOr, -0.5, kMaxFastOr - 0.5, 16, -0.5, 15.5);
+  fHistosQA->CreateTH2("hFastOrColRowFrequencyL0", "FastOr Frequency (col-row) at Level0; col; row", kMaxCol, -0.5, kMaxCol - 0.5, kMaxRow, -0.5, kMaxRow - 0.5);
+  fHistosQA->CreateTH2("hFastOrColRowFrequencyL1", "FastOr Frequency (col-row) at Level1; col; row", kMaxCol, -0.5, kMaxCol - 0.5, kMaxRow, -0.5, kMaxRow - 0.5);
+  fHistosQA->CreateTH2("hEnergyFastorCell", "Sum of cell energy vs. fastor Energy", 1000, 0., 20., 1000 , 0., 20.);
 
   // Helper histograms checking the mask status of cells and FastORs
-  fHistos->CreateTH1("hMaskedFastors", "Index of masked FastOR; FastOR index; Counts", 3001, -0.5, 3000.5);
-  fHistos->CreateTH1("hMaskedCells", "Index of masked cell; Cell index; Counts", 20001, -0.5, 20000.5);
-  fHistos->CreateTH1("hCellEnergyCount", "Counts of non-0 cell entries; Cell index; Counts", 20001, -0.5, 20000.5);
+  fHistosQA->CreateTH1("hMaskedFastors", "Index of masked FastOR; FastOR index; Counts", 3001, -0.5, 3000.5);
+  fHistosQA->CreateTH1("hMaskedCells", "Index of masked cell; Cell index; Counts", 20001, -0.5, 20000.5);
+  fHistosQA->CreateTH1("hCellEnergyCount", "Counts of non-0 cell entries; Cell index; Counts", 20001, -0.5, 20000.5);
 
   // THnSparse for fastor-by-fastor energy decalibration
   TAxis fastorIDAxis(4992, -0.5, 4991.5), offlineaxis(200, 0., 20.), onlineaxis(200, 0., 20.), cellmaskaxis(5, -0.5, 4.5);
@@ -124,14 +125,13 @@ void AliEmcalFastOrMonitorTask::UserCreateOutputObjects() {
   offlineaxis.SetNameTitle("offlinenergy", "E_{2x2 cells} (GeV)");
   onlineaxis.SetNameTitle("onlineenergy", "E_{FastOR} (GeV)");
   cellmaskaxis.SetNameTitle("maskedcells", "Number of masked cells");
-  fHistos->CreateTHnSparse("hFastOrEnergyOfflineOnline", "FastOr Offline vs Online energy", 4, sparseaxis);
+  fHistosQA->CreateTHnSparse("hFastOrEnergyOfflineOnline", "FastOr Offline vs Online energy", 4, sparseaxis);
 
-  PostData(1, fHistos->GetListOfHistograms());
+  for(auto h : *(fHistosQA->GetListOfHistograms())) fOutput->Add(h);
+  PostData(1, fOutput);
 }
 
-void AliEmcalFastOrMonitorTask::ExecOnce(){
-  fGeom = AliEMCALGeometry::GetInstanceFromRunNumber(InputEvent()->GetRunNumber());
-
+void AliEmcalFastOrMonitorTask::UserExecOnce(){
   int nrow = fGeom->GetTriggerMappingVersion() == 2 ? 104 : 64;
   fCellData.Allocate(48, nrow);
 
@@ -156,7 +156,7 @@ void AliEmcalFastOrMonitorTask::RunChanged(Int_t newrun){
       for(auto masked : *maskedfastors){
         TParameter<int> *fastOrAbsID = static_cast<TParameter<int> *>(masked);
         fMaskedFastors.push_back(fastOrAbsID->GetVal());
-        fHistos->FillTH1("hMaskedFastors", fastOrAbsID->GetVal());
+        fHistosQA->FillTH1("hMaskedFastors", fastOrAbsID->GetVal());
       }
       std::sort(fMaskedFastors.begin(), fMaskedFastors.end(), std::less<int>());
     }
@@ -179,7 +179,7 @@ void AliEmcalFastOrMonitorTask::RunChanged(Int_t newrun){
             if(modhist->GetBinContent(icol, irow) > 0.){
               int cellindex = fGeom->GetAbsCellIdFromCellIndexes(modid, irow, icol);
               fMaskedCells.push_back(cellindex);
-              fHistos->FillTH1("hMaskedCells", cellindex);
+              fHistosQA->FillTH1("hMaskedCells", cellindex);
             }
           }
         }
@@ -189,32 +189,18 @@ void AliEmcalFastOrMonitorTask::RunChanged(Int_t newrun){
   }
 }
 
-void AliEmcalFastOrMonitorTask::UserExec(Option_t *) {
-  if(!fLocalInitialized){
-    ExecOnce();
-    fLocalInitialized = true;
-  }
-
-  // Run change
-  if(InputEvent()->GetRunNumber() != fOldRun){
-    RunChanged(InputEvent()->GetRunNumber());
-    fOldRun = InputEvent()->GetRunNumber();
-  }
-
+bool AliEmcalFastOrMonitorTask::IsEventSelected() {
   // Check trigger
-  if(!(fInputHandler->IsEventSelected() & fRequestTrigger)) return;
+  if(!(fInputHandler->IsEventSelected() & fRequestTrigger)) return false;
   if(fTriggerPattern.Length()){
-    if(!TString(InputEvent()->GetFiredTriggerClasses()).Contains(fTriggerPattern)) return;
+    if(!TString(InputEvent()->GetFiredTriggerClasses()).Contains(fTriggerPattern)) return false;
   }
+  return true;
+}
 
-  const AliVVertex *vtx = fInputEvent->GetPrimaryVertex();
-  Double_t vtxpos[3];
-  vtx->GetXYZ(vtxpos);
-
+bool AliEmcalFastOrMonitorTask::Run() {
   LoadEventCellData();
-
-  fHistos->FillTH1("hEvents", 1);
-
+  fHistosQA->FillTH1("hEvents", 1);
   AliVCaloTrigger *triggerdata = InputEvent()->GetCaloTrigger("EMCAL");
   triggerdata->Reset();
   Int_t nl0times, l1timesum, fastOrID, globCol, globRow;
@@ -226,19 +212,19 @@ void AliEmcalFastOrMonitorTask::UserExec(Option_t *) {
     triggerdata->GetPosition(globCol, globRow);
     fGeom->GetTriggerMapping()->GetAbsFastORIndexFromPositionInEMCAL(globCol, globRow, fastOrID);
     if(amp > 1e-5){
-      fHistos->FillTH2("hFastOrColRowFrequencyL0", globCol, globRow);
-      fHistos->FillTH1("hFastOrFrequencyL0", fastOrID);
+      fHistosQA->FillTH2("hFastOrColRowFrequencyL0", globCol, globRow);
+      fHistosQA->FillTH1("hFastOrFrequencyL0", fastOrID);
     }
     if(l1timesum){
-      fHistos->FillTH2("hFastOrColRowFrequencyL1", globCol, globRow);
-      fHistos->FillTH1("hFastOrFrequencyL1", fastOrID);
+      fHistosQA->FillTH2("hFastOrColRowFrequencyL1", globCol, globRow);
+      fHistosQA->FillTH1("hFastOrFrequencyL1", fastOrID);
     }
     if(std::find(fMaskedFastors.begin(), fMaskedFastors.end(), fastOrID) == fMaskedFastors.end()){
-      fHistos->FillTH2("hFastOrAmplitude", fastOrID, amp);
-      fHistos->FillTH2("hFastOrTimeSum", fastOrID, l1timesum);
-      fHistos->FillTH2("hFastOrNL0Times", fastOrID, nl0times);
-      fHistos->FillTH2("hFastOrTransverseTimeSum", fastOrID, GetTransverseTimeSum(fastOrID, l1timesum, vtxpos));
-      fHistos->FillTH2("hEnergyFastorCell", fCellData(globCol, globRow), l1timesum * EMCALTrigger::kEMCL1ADCtoGeV);
+      fHistosQA->FillTH2("hFastOrAmplitude", fastOrID, amp);
+      fHistosQA->FillTH2("hFastOrTimeSum", fastOrID, l1timesum);
+      fHistosQA->FillTH2("hFastOrNL0Times", fastOrID, nl0times);
+      fHistosQA->FillTH2("hFastOrTransverseTimeSum", fastOrID, GetTransverseTimeSum(fastOrID, l1timesum, fVertex));
+      fHistosQA->FillTH2("hEnergyFastorCell", fCellData(globCol, globRow), l1timesum * EMCALTrigger::kEMCL1ADCtoGeV);
       int ncellmasked = 0;
       int fastorCells[4];
       fGeom->GetTriggerMapping()->GetCellIndexFromFastORIndex(fastOrID, fastorCells);
@@ -251,11 +237,10 @@ void AliEmcalFastOrMonitorTask::UserExec(Option_t *) {
             l1timesum * EMCALTrigger::kEMCL1ADCtoGeV,
             static_cast<double>(ncellmasked)
       };
-      fHistos->FillTHnSparse("hFastOrEnergyOfflineOnline", energydata);
+      fHistosQA->FillTHnSparse("hFastOrEnergyOfflineOnline", energydata);
     }
   }
-
-  PostData(1, fHistos->GetListOfHistograms());
+  return true;
 }
 
 void AliEmcalFastOrMonitorTask::LoadEventCellData(){
@@ -265,7 +250,7 @@ void AliEmcalFastOrMonitorTask::LoadEventCellData(){
      int position = emccells->GetCellNumber(icell);
      double amplitude = emccells->GetAmplitude(icell);
      if(amplitude > 0){
-       fHistos->FillTH1("hCellEnergyCount", position);
+       fHistosQA->FillTH1("hCellEnergyCount", position);
        if(std::find(fMaskedCells.begin(), fMaskedCells.end(), position) != fMaskedCells.end()){
          AliErrorStream() << "Non-0 cell energy " << amplitude << " found for masked cell " << position << std::endl;
        }

--- a/PWG/EMCAL/EMCALtasks/AliEmcalFastOrMonitorTask.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalFastOrMonitorTask.h
@@ -27,7 +27,7 @@
 #ifndef ALIEMCALFASTORMONITORTASK_H
 #define ALIEMCALFASTORMONITORTASK_H
 
-#include "AliAnalysisTaskSE.h"
+#include "AliAnalysisTaskEmcal.h"
 #include "AliEMCALTriggerDataGrid.h"
 #include <TString.h>
 
@@ -70,7 +70,7 @@ namespace EMCAL {
  *  AddEmcalFastOrMonitorTask();
  *  ~~~
  */
-class AliEmcalFastOrMonitorTask : public AliAnalysisTaskSE {
+class AliEmcalFastOrMonitorTask : public AliAnalysisTaskEmcal {
 public:
 
   /**
@@ -134,6 +134,13 @@ protected:
   virtual void UserCreateOutputObjects();
 
   /**
+   * @brief Perform event selection
+   * 
+   * Overwriting default event selection from AliAnalysisTaskEmcal
+   */
+  virtual bool IsEventSelected();
+
+  /**
    * @brief Event loop
    *
    * Processing of events: Filling the monitoring histograms for each FastOR:
@@ -144,7 +151,7 @@ protected:
    * - Position in the col-row space
    * @param
    */
-  virtual void UserExec(Option_t *);
+  virtual bool Run();
 
   /**
    * @brief Initialization of the task
@@ -154,7 +161,7 @@ protected:
    * within the event loop. At that step some basic event information is already
    * available,
    */
-  virtual void ExecOnce();
+  virtual void UserExecOnce();
 
   /**
    * @brief Run-dependent setup of the task
@@ -186,8 +193,7 @@ protected:
    */
   void LoadEventCellData();
 
-  THistManager                            *fHistos;           //!<! Histogram handler
-  AliEMCALGeometry                        *fGeom;             //!<! EMCAL Geometry object
+  THistManager                            *fHistosQA;           //!<! Histogram handler
   Bool_t                                  fLocalInitialized;  ///< Switch whether task is initialized (for ExecOnce)
   Int_t                                   fOldRun;            ///< Old Run (for RunChanged())
 


### PR DESCRIPTION
Event selection and event loop ported to IsEventSelected
and Run methods of AliAnalysisTaskEmcal, so the logics
doesn't change. Output object changes from TList to
AliEmcalList. Adds filling the weighting histograms
and therefore allows running on jet-jet Monte-Carlos.