### PR TITLE
#ATO-452 - add AliPIDtools to enable AliPID in TFormula and TTreeFormula

### DIFF
--- a/PWGPP/AliPIDtools.cxx
+++ b/PWGPP/AliPIDtools.cxx
@@ -1,0 +1,59 @@
+#include "AliESDEvent.h"
+#include "AliTPCPIDResponse.h"
+#include "AliPIDResponse.h"
+#include "AliESDtrack.h"
+#include "AliPIDtools.h"
+
+std::map<Int_t, AliTPCPIDResponse *> AliPIDtools::pidTPC;     /// we should use better hash map
+std::map<Int_t, AliPIDResponse *> AliPIDtools::pidAll;        /// we should use better hash map
+AliESDtrack  AliPIDtools::dummyTrack;/// dummy value to save CPU - unfortunately PID object use AliVtrack - for the moment create global varaible t avoid object constructions
+
+AliTPCPIDResponse* AliPIDtools::GetTPCPID(Int_t hash ) {return pidTPC[hash];}
+Int_t AliPIDtools::GetHash(Int_t run, Int_t passNumber, TString recoPass,Bool_t isMC){
+  recoPass+=run;
+  recoPass+=passNumber;
+  recoPass+=isMC;
+  return recoPass.Hash();
+}
+
+Double_t AliPIDtools::BetheBlochAleph(Int_t hash, Double_t bg){
+  AliTPCPIDResponse *tpcPID=pidTPC[hash];
+  if (tpcPID) return tpcPID->Bethe(bg);
+  return 0;
+}
+/// GetExpectedTPCSignal
+/// \param hash       - hash value of the PID version
+/// \param p          - momenta
+/// \param particle   - particle type
+/// \return           - mean TPCdedx
+Double_t AliPIDtools::GetExpectedTPCSignal(Int_t hash, Double_t p, AliPID::EParticleType particle) {
+  Double_t xyz[3] = {0., 0., 0.};
+  Double_t pxyz[3] = {0, 0., 0.};
+  Double_t cv[21] = {0.}; // dummy parameters for dummy tracks
+  AliTPCPIDResponse *tpcPID=pidTPC[hash];
+  if (tpcPID==0) return 0;
+  pxyz[0]=p;
+  dummyTrack.Set(xyz, pxyz, cv, 1);
+  Double_t dEdx = tpcPID->GetExpectedSignal(&dummyTrack, particle, AliTPCPIDResponse::kdEdxDefault, kFALSE, kTRUE);
+  return dEdx;
+}
+/// Load and reguster PID objects in hash maps
+/// \param run
+/// \param passNumber
+/// \param recoPass
+/// \param isMC
+/// \return  - hash value of PID
+Int_t AliPIDtools::LoadPID(Int_t run, Int_t passNumber, TString recoPass, Bool_t isMC){
+  // Int_t run=246751, passNumber=1; TString recoPass("pass1"); Bool_t isMC=0;
+  AliESDEvent ev;
+  AliPIDResponse *pid = new AliPIDResponse(isMC);
+  pid->SetUseTPCMultiplicityCorrection();
+  pid->SetOADBPath("$ALICE_PHYSICS/OADB");
+  pid->InitialiseEvent(&ev,passNumber, recoPass, run);
+  AliTPCPIDResponse &tpcpid=pid->GetTPCResponse();
+  // pid.InitFromOADB(246751,1,"pass1");
+  Int_t  hash=GetHash(run,passNumber, recoPass,isMC);
+  pidAll[hash]=pid;     /// we should clone them
+  pidTPC[hash]=&tpcpid;  ///
+  return hash;
+}

--- a/PWGPP/AliPIDtools.h
+++ b/PWGPP/AliPIDtools.h
@@ -1,0 +1,42 @@
+#ifndef ALIPIDTOOLS_H
+#define ALIPIDTOOLS_H
+
+/// \ingroup PWGPP
+/// \class AliPIDtools
+/// \brief Wrapper for the AliPID classes - enable to use function in TFormula, TTreeFormula and Python
+
+/// #### Example 1: register PID for run 246751 and draw dEdx as function of BetaGamma
+/// \code
+/// Int_t hash= AliPIDtools::LoadPID(246751,1,"pass1",0);
+///  TF1 * fbb = new TF1("fbb",Form("AliPIDtools::BetheBlochAleph(%d,x)",hash),1,100);
+///  fbb->SetNpx(1000); fbb->Draw();
+/// \endcode
+/// #### Example 2: Draw dEdx ratios pi/proton resp. pi/Kaon
+/// \code
+/// TF1 *fPionToProton1P=new TF1("fPionToProton",Form("AliPIDtools::GetExpectedTPCSignal(%d,1/x,2)/AliPIDtools::GetExpectedTPCSignal(%d,1/x*%f/%f,4)",hash,hash,massProton,massPi),0.,5);
+///  TF1 *fPionToKaon1P=new TF1("fPionToKaon",Form("AliPIDtools::GetExpectedTPCSignal(%d,1/x,2)/AliPIDtools::GetExpectedTPCSignal(%d,1/x*%f/%f,3)",hash,hash,massKaon,massPi),0.,5);
+///  fPionToKaon->SetLineColor(4);
+///  fPionToProton1P->Draw(); fPionToKaon1P->Draw("same");
+/// \endcode
+
+
+#include "map"
+#include  "AliESDtrack.h"
+class AliPIDResponse;
+class AliTPCPIDResponse;
+
+
+class AliPIDtools {
+public:
+  static Int_t GetHash(Int_t run, Int_t passNumber, TString recoPass, Bool_t isMC);
+  static Int_t LoadPID(Int_t run, Int_t passNumber, TString recoPass, Bool_t isMC);
+  static AliTPCPIDResponse *GetTPCPID(Int_t hash);
+  static Double_t BetheBlochAleph(Int_t hash, Double_t bg);
+  static Double_t GetExpectedTPCSignal(Int_t hash, Double_t p, AliPID::EParticleType particle);
+  static std::map<Int_t, AliTPCPIDResponse *> pidTPC;     /// we should use better hash map
+  static std::map<Int_t, AliPIDResponse *> pidAll;        /// we should use better hash map
+private:
+  static AliESDtrack  dummyTrack;/// dummy value to save CPU - unfortunately PID object use AliVtrack - for the moment create global varaible t avoid object constructions
+};
+
+#endif //ALIPIDTOOLS_H

--- a/PWGPP/CMakeLists.txt
+++ b/PWGPP/CMakeLists.txt
@@ -59,6 +59,7 @@ set ( SRCS1
   AliTrackComparisonESD.cxx
   AliOfflineTrigger.cxx
 		AliMCTreeTools.cxx
+		AliPIDtools.cxx
   )
 #file ( GLOB SRCS2 "global/*.cxx" )
 set ( SRCS2

--- a/PWGPP/PWGPPLinkDef.h
+++ b/PWGPP/PWGPPLinkDef.h
@@ -55,6 +55,9 @@
 #pragma link C++ class AliTPCPerformanceSummary+;
 #pragma link C++ class AliAnalysisNoiseTPC+;
 #pragma link C++ class AliMCTreeTools+;
+#pragma link C++ class AliPIDtools+;
+#pragma link C++ class std::map<int,AliTPCPIDResponse *>+;
+#pragma link C++ class std::map<int,AliPIDResponse *>+;
 
 #pragma link C++ class AliIntSpotEstimator+;
 #pragma link C++ class AliAnalysisTaskIPInfo+;


### PR DESCRIPTION
## Example usage:
* Register PID object for given production
````
 Int_t hash= AliPIDtools::LoadPID(246751,1,"pass1",0);
````
* Use function in TFormula
````
 TF1 * fbb = new TF1("fbb",Form("AliPIDtools::BetheBlochAleph(%d,x)",hash),1,100);
 fbb->SetNpx(1000); fbb->Draw();
````
* Or TTreeFormula
 esdTree->SetAlias("dEdxExpPion",Form("AliPIDtools::BetheBlochAleph(%d,Tracks[].fIp.P()/%f)",hash,massPion))
esdTree->Draw("Tracks[].fTPCsignal:dEdxExpPion");
````