### PR TITLE
Some histograms are not optional (debug mode)

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelorTMVAApp.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelorTMVAApp.cxx
@@ -202,7 +202,8 @@ AliAnalysisTaskSELc2V0bachelorTMVAApp::AliAnalysisTaskSELc2V0bachelorTMVAApp():
   fBDTHistoVsSignd0(0),
   fBDTHistoVsCosThetaStar(0),
   fHistoNsigmaTPC(0),
-  fHistoNsigmaTOF(0)
+  fHistoNsigmaTOF(0),
+  fDebugHistograms(kFALSE)
 {
   /// Default ctor
   //
@@ -328,7 +329,8 @@ AliAnalysisTaskSELc2V0bachelorTMVAApp::AliAnalysisTaskSELc2V0bachelorTMVAApp(con
   fBDTHistoVsSignd0(0),
   fBDTHistoVsCosThetaStar(0),
   fHistoNsigmaTPC(0),
-  fHistoNsigmaTOF(0)
+  fHistoNsigmaTOF(0),
+  fDebugHistograms(kFALSE)
 {
   //
   /// Constructor. Initialization of Inputs and Outputs
@@ -671,18 +673,19 @@ void AliAnalysisTaskSELc2V0bachelorTMVAApp::UserCreateOutputObjects() {
   
 
   fBDTHisto = new TH2D("fBDTHisto", "Lc inv mass vs bdt output; bdt; m_{inv}(pK^{0}_{S})[GeV/#it{c}^{2}]", 10000, -1, 1, 1000, 2.05, 2.55);
-  fBDTHistoVsMassK0S = new TH2D("fBDTHistoVsMassK0S", "K0S inv mass vs bdt output; bdt; m_{inv}(#pi^{+}#pi^{#minus})[GeV/#it{c}^{2}]", 10000, -1, 1, 1000, 0.485, 0.51);
-  fBDTHistoVstImpParBach = new TH2D("fBDTHistoVstImpParBach", "d0 bachelor vs bdt output; bdt; d_{0, bachelor}[cm]", 10000, -1, 1, 1000, -1, 1);
-  fBDTHistoVstImpParV0 = new TH2D("fBDTHistoVstImpParV0", "d0 K0S vs bdt output; bdt; d_{0, V0}[cm]", 10000, -1, 1, 1000, -1, 1);
-  fBDTHistoVsBachelorPt = new TH2D("fBDTHistoVsBachelorPt", "bachelor pT vs bdt output; bdt; p_{T, bachelor}[GeV/#it{c}]", 10000, -1, 1, 1000, 0, 20);
-  fBDTHistoVsCombinedProtonProb = new TH2D("fBDTHistoVsCombinedProtonProb", "combined proton probability vs bdt output; bdt; Bayesian PID_{bachelor}", 10000, -1, 1, 1000, 0, 1);
-  fBDTHistoVsCtau = new TH2D("fBDTHistoVsCtau", "K0S ctau vs bdt output; bdt; c#tau_{V0}[cm]",  10000, -1, 1, 1000, -2, 2);
-  fBDTHistoVsCosPAK0S = new TH2D("fBDTHistoVsCosPAK0S", "V0 cosine pointing angle vs bdt output; bdt; CosPAK^{0}_{S}", 10000, -1, 1, 1000, 0.9, 1);
-  fBDTHistoVsCosThetaStar = new TH2D("fBDTHistoVsCosThetaStar", "proton emission angle in pK0s pair rest frame vs bdt output; bdt; Cos#Theta*", 10000, -1, 1, 1000, -1, 1);
-  fBDTHistoVsSignd0 = new TH2D("fBDTHistoVstImpParBach", "signed d0 bachelor vs bdt output; bdt; signd_{0, bachelor}[cm]", 10000, -1, 1, 1000, -1, 1);
-  fHistoNsigmaTPC = new TH2D("fHistoNsigmaTPC", "; #it{p} (GeV/#it{c}); n_{#sigma}^{TPC} (proton hypothesis)", 500, 0, 5, 1000, -5, 5);
-  fHistoNsigmaTOF = new TH2D("fHistoNsigmaTOF", "; #it{p} (GeV/#it{c}); n_{#sigma}^{TOF} (proton hypothesis)", 500, 0, 5, 1000, -5, 5);
-  
+  if (fDebugHistograms) {    
+    fBDTHistoVsMassK0S = new TH2D("fBDTHistoVsMassK0S", "K0S inv mass vs bdt output; bdt; m_{inv}(#pi^{+}#pi^{#minus})[GeV/#it{c}^{2}]", 1000, -1, 1, 1000, 0.485, 0.51);
+    fBDTHistoVstImpParBach = new TH2D("fBDTHistoVstImpParBach", "d0 bachelor vs bdt output; bdt; d_{0, bachelor}[cm]", 1000, -1, 1, 100, -1, 1);
+    fBDTHistoVstImpParV0 = new TH2D("fBDTHistoVstImpParV0", "d0 K0S vs bdt output; bdt; d_{0, V0}[cm]", 1000, -1, 1, 100, -1, 1);
+    fBDTHistoVsBachelorPt = new TH2D("fBDTHistoVsBachelorPt", "bachelor pT vs bdt output; bdt; p_{T, bachelor}[GeV/#it{c}]", 1000, -1, 1, 100, 0, 20);
+    fBDTHistoVsCombinedProtonProb = new TH2D("fBDTHistoVsCombinedProtonProb", "combined proton probability vs bdt output; bdt; Bayesian PID_{bachelor}", 1000, -1, 1, 100, 0, 1);
+    fBDTHistoVsCtau = new TH2D("fBDTHistoVsCtau", "K0S ctau vs bdt output; bdt; c#tau_{V0}[cm]",  1000, -1, 1, 100, -2, 2);
+    fBDTHistoVsCosPAK0S = new TH2D("fBDTHistoVsCosPAK0S", "V0 cosine pointing angle vs bdt output; bdt; CosPAK^{0}_{S}", 1000, -1, 1, 100, 0.9, 1);
+    fBDTHistoVsCosThetaStar = new TH2D("fBDTHistoVsCosThetaStar", "proton emission angle in pK0s pair rest frame vs bdt output; bdt; Cos#Theta*", 1000, -1, 1, 100, -1, 1);
+    fBDTHistoVsSignd0 = new TH2D("fBDTHistoVsSignd0", "signed d0 bachelor vs bdt output; bdt; signd_{0, bachelor}[cm]", 1000, -1, 1, 100, -1, 1);
+    fHistoNsigmaTPC = new TH2D("fHistoNsigmaTPC", "; #it{p} (GeV/#it{c}); n_{#sigma}^{TPC} (proton hypothesis)", 500, 0, 5, 1000, -5, 5);
+    fHistoNsigmaTOF = new TH2D("fHistoNsigmaTOF", "; #it{p} (GeV/#it{c}); n_{#sigma}^{TOF} (proton hypothesis)", 500, 0, 5, 1000, -5, 5);
+  }
   
   fOutput->Add(fHistoEvents);
   fOutput->Add(fHistoLc);
@@ -698,18 +701,19 @@ void AliAnalysisTaskSELc2V0bachelorTMVAApp::UserCreateOutputObjects() {
   fOutput->Add(fHistoMCLcK0SpGenLimAcc);
   fOutput->Add(fHistoCentrality);
   fOutput->Add(fBDTHisto);
-  fOutput->Add(fBDTHistoVsMassK0S);
-  fOutput->Add(fBDTHistoVstImpParBach);
-  fOutput->Add(fBDTHistoVstImpParV0);
-  fOutput->Add(fBDTHistoVsBachelorPt);
-  fOutput->Add(fBDTHistoVsCombinedProtonProb);
-  fOutput->Add(fBDTHistoVsCtau);
-  fOutput->Add(fBDTHistoVsCosPAK0S);
-  fOutput->Add(fBDTHistoVsCosThetaStar);
-  fOutput->Add(fBDTHistoVsSignd0);
-  fOutput->Add(fHistoNsigmaTPC);
-  fOutput->Add(fHistoNsigmaTOF);
-  
+  if (fDebugHistograms) {    
+    fOutput->Add(fBDTHistoVsMassK0S);
+    fOutput->Add(fBDTHistoVstImpParBach);
+    fOutput->Add(fBDTHistoVstImpParV0);
+    fOutput->Add(fBDTHistoVsBachelorPt);
+    fOutput->Add(fBDTHistoVsCombinedProtonProb);
+    fOutput->Add(fBDTHistoVsCtau);
+    fOutput->Add(fBDTHistoVsCosPAK0S);
+    fOutput->Add(fBDTHistoVsCosThetaStar);
+    fOutput->Add(fBDTHistoVsSignd0);
+    fOutput->Add(fHistoNsigmaTPC);
+    fOutput->Add(fHistoNsigmaTOF);
+  }
   
   PostData(1, fOutput);
   PostData(4, fVariablesTreeSgn);
@@ -718,7 +722,7 @@ void AliAnalysisTaskSELc2V0bachelorTMVAApp::UserCreateOutputObjects() {
   AliInputEventHandler* inputHandler = (AliInputEventHandler*) (man->GetInputEventHandler());
   fPIDResponse = inputHandler->GetPIDResponse();
 
-  fAnalCuts->SetUsePID(kTRUE);
+  //  fAnalCuts->SetUsePID(kTRUE); // this forces the PID to be used, despite the settings in the cut object
   // if (fAnalCuts->GetIsUsePID()){
   //   /*
   //     fAnalCuts->GetPidHF()->SetPidResponse(fPIDResponse);
@@ -1876,18 +1880,20 @@ void AliAnalysisTaskSELc2V0bachelorTMVAApp::FillLc2pK0Sspectrum(AliAODRecoCascad
       Double_t BDTResponse = -1;
       BDTResponse = fBDTReader->GetMvaValue(inputVars);
       fBDTHisto->Fill(BDTResponse, invmassLc); 
-      fBDTHistoVsMassK0S->Fill(BDTResponse, invmassK0s);
-      fBDTHistoVstImpParBach->Fill(BDTResponse, part->Getd0Prong(0));
-      fBDTHistoVstImpParV0->Fill(BDTResponse, part->Getd0Prong(1));
-      fBDTHistoVsBachelorPt->Fill(BDTResponse, bachelor->Pt());
-      fBDTHistoVsCombinedProtonProb->Fill(BDTResponse, probProton);
-      fBDTHistoVsCtau->Fill(BDTResponse, (part->DecayLengthV0())*0.497/(v0part->P()));
-      fBDTHistoVsCosPAK0S->Fill(BDTResponse, part->CosV0PointingAngle());
-      fBDTHistoVsSignd0->Fill(BDTResponse, signd0);
-      fBDTHistoVsCosThetaStar->Fill(BDTResponse, cts);
-      
-      fHistoNsigmaTPC->Fill(bachelor->P(), nSigmaTPCpr);
-      fHistoNsigmaTOF->Fill(bachelor->P(), nSigmaTOFpr);
+      if (fDebugHistograms) {    
+	fBDTHistoVsMassK0S->Fill(BDTResponse, invmassK0s);
+	fBDTHistoVstImpParBach->Fill(BDTResponse, part->Getd0Prong(0));
+	fBDTHistoVstImpParV0->Fill(BDTResponse, part->Getd0Prong(1));
+	fBDTHistoVsBachelorPt->Fill(BDTResponse, bachelor->Pt());
+	fBDTHistoVsCombinedProtonProb->Fill(BDTResponse, probProton);
+	fBDTHistoVsCtau->Fill(BDTResponse, (part->DecayLengthV0())*0.497/(v0part->P()));
+	fBDTHistoVsCosPAK0S->Fill(BDTResponse, part->CosV0PointingAngle());
+	fBDTHistoVsSignd0->Fill(BDTResponse, signd0);
+	fBDTHistoVsCosThetaStar->Fill(BDTResponse, cts);
+	
+	fHistoNsigmaTPC->Fill(bachelor->P(), nSigmaTPCpr);
+	fHistoNsigmaTOF->Fill(bachelor->P(), nSigmaTOFpr);
+      }
     }
     
   }

--- a/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelorTMVAApp.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSELc2V0bachelorTMVAApp.h
@@ -144,6 +144,8 @@ class AliAnalysisTaskSELc2V0bachelorTMVAApp : public AliAnalysisTaskSE
     fHistoMCNch = new TH1F(*h);
   }
     
+  void SetDebugHistograms(Bool_t flag) {fDebugHistograms = flag;}
+  Bool_t GetDebugHistograms() const {return fDebugHistograms;}
 
  private:
   
@@ -313,7 +315,8 @@ class AliAnalysisTaskSELc2V0bachelorTMVAApp : public AliAnalysisTaskSE
   TH2D *fHistoNsigmaTPC;               //!<! 
   TH2D *fHistoNsigmaTOF;               //!<! 
 
-
+  Bool_t fDebugHistograms;             /// flag to decide whether or not to have extra histograms (useful mainly for debug)
+  
   /// \cond CLASSIMP    
   ClassDef(AliAnalysisTaskSELc2V0bachelorTMVAApp, 1); /// class for Lc->p K0
   /// \endcond    


### PR DESCRIPTION
The concerned histograms are the 2D with the BDT variables vs BDT response.
They are needed for debugging purposes, and take a lot of memory.
In this commit, also the number of bins was decreased.