### PR TITLE
Use vector as internal storage for combined track selection results

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultCombined.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultCombined.cxx
@@ -25,6 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
  ************************************************************************************/
 #include "AliEmcalTrackSelResultCombined.h"
+#include <TObjArray.h>
 
 /// \cond CLASSIMP
 ClassImp(PWG::EMCAL::AliEmcalTrackSelResultCombined)
@@ -39,18 +40,32 @@ AliEmcalTrackSelResultCombined::AliEmcalTrackSelResultCombined():
 
 }
 
+AliEmcalTrackSelResultCombined::AliEmcalTrackSelResultCombined(const std::vector<PWG::EMCAL::AliEmcalTrackSelResultPtr>& singleSelPointers):
+  TObject(),
+  fData(singleSelPointers)
+ {
+
+ }
+
+
 AliEmcalTrackSelResultCombined::AliEmcalTrackSelResultCombined(const TObjArray *singleSelPointers):
   TObject(),
-  fData("PWG::EMCAL::AliEmcalTrackSelResultPtr", singleSelPointers->GetEntries())
+  fData(singleSelPointers->GetEntries())
 {
-  for(auto o  : *singleSelPointers) new(fData[fData.GetEntries()]) AliEmcalTrackSelResultPtr(*(static_cast<AliEmcalTrackSelResultPtr *>(o)));
+  int index(0);
+  for(auto o  : *singleSelPointers) fData[index] = *static_cast<AliEmcalTrackSelResultPtr *>(o);
 }
 
-AliEmcalTrackSelResultPtr &AliEmcalTrackSelResultCombined::operator[](int index) const {
-  if(index < 0 || index >= fData.GetEntriesFast()) throw IndexException(index);
-  return *(static_cast<AliEmcalTrackSelResultPtr *>(fData.At(index)));
+const AliEmcalTrackSelResultPtr &AliEmcalTrackSelResultCombined::operator[](int index) const {
+  if(index < 0 || index >= static_cast<Int_t>(fData.size())) throw IndexException(index);
+  return fData[index];
+}
+
+AliEmcalTrackSelResultPtr &AliEmcalTrackSelResultCombined::operator[](int index) {
+  if(index < 0 || index >= static_cast<Int_t>(fData.size())) throw IndexException(index);
+  return fData[index];
 }
 
 Int_t AliEmcalTrackSelResultCombined::GetNumberOfSelectionResults() const {
-  return fData.GetEntriesFast();
+  return fData.size();
 }

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultCombined.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelResultCombined.h
@@ -28,10 +28,10 @@
 #define ALIEMCALTRACKSELRESULTCOMBINED_H
 
 #include <TObject.h>
-#include <TClonesArray.h>
 #include <exception>
 #include <sstream>
 #include <string>
+#include <vector>
 #include "AliEmcalTrackSelResultPtr.h"
 
 class TObjArray;
@@ -61,13 +61,15 @@ public:
   
   AliEmcalTrackSelResultCombined();
   AliEmcalTrackSelResultCombined(const TObjArray *singleSelPointers);
+  AliEmcalTrackSelResultCombined(const std::vector<PWG::EMCAL::AliEmcalTrackSelResultPtr>& singleSelPointers);
   virtual ~AliEmcalTrackSelResultCombined() {}
 
-  AliEmcalTrackSelResultPtr &operator[](int index) const;
+  const AliEmcalTrackSelResultPtr &operator[](int index) const;
+  AliEmcalTrackSelResultPtr &operator[](int index);
   Int_t GetNumberOfSelectionResults() const;
 
 private:
-  TClonesArray                   fData;    ///< Single 
+  std::vector<AliEmcalTrackSelResultPtr>        fData;    ///< Single 
 
   /// \cond CLASSIMP
   ClassDef(AliEmcalTrackSelResultCombined, 1);

--- a/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalTrackSelectionAOD.cxx
@@ -167,19 +167,18 @@ PWG::EMCAL::AliEmcalTrackSelResultPtr AliEmcalTrackSelectionAOD::IsTrackAccepted
   TBits trackbitmap(64);
   trackbitmap.ResetAllBits();
   UInt_t cutcounter(0);
-  TClonesArray selectionStatus("PWG::EMCAL::AliEmcalTrackSelResultPtr", fListOfCuts->GetEntries());
-  selectionStatus.SetOwner(kTRUE);
+  std::vector<PWG::EMCAL::AliEmcalTrackSelResultPtr> selectionStatus(fListOfCuts->GetEntries());
   if (fListOfCuts) {
     for (auto cutIter : *fListOfCuts){ // @suppress("Symbol is not resolved")
       PWG::EMCAL::AliEmcalCutBase *trackCuts = static_cast<PWG::EMCAL::AliEmcalCutBase*>(static_cast<AliEmcalManagedObject *>(cutIter)->GetObject());
       PWG::EMCAL::AliEmcalTrackSelResultPtr cutresults = trackCuts->IsSelected(aodt);
       if (cutresults) trackbitmap.SetBitNumber(cutcounter);
-      new(selectionStatus[selectionStatus.GetEntries()]) PWG::EMCAL::AliEmcalTrackSelResultPtr(cutresults);
+      selectionStatus.push_back(cutresults);
       cutcounter++;
     }
   }
 
-  PWG::EMCAL::AliEmcalTrackSelResultPtr result(aodt, kFALSE, new PWG::EMCAL::AliEmcalTrackSelResultCombined(&selectionStatus));
+  PWG::EMCAL::AliEmcalTrackSelResultPtr result(aodt, kFALSE, new PWG::EMCAL::AliEmcalTrackSelResultCombined(selectionStatus));
   if (fSelectionModeAny){
     // In case of ANY one of the cuts need to be fulfilled (equivalent to one but set)
     result.SetSelectionResult(trackbitmap.CountBits() > 0 || cutcounter == 0);

--- a/PWG/EMCAL/EMCALbase/PWGEMCALbaseLinkDef.h
+++ b/PWG/EMCAL/EMCALbase/PWGEMCALbaseLinkDef.h
@@ -50,5 +50,5 @@
 #pragma link C++ class PWG::EMCAL::TestAliEmcalTrackSelResultPtr+;
 #pragma link C++ class PWG::EMCAL::TestAliEmcalAODHybridTrackCuts+;
 #pragma link C++ class PWG::EMCAL::TestAliEmcalTrackSelectionAOD+;
-
+#pragma link C++ class std::vector<PWG::EMCAL::AliEmcalTrackSelResultPtr>+;
 #endif


### PR DESCRIPTION
TClonesArray is a very inefficient object for the underlying
user storage. Usage of std::vector improves performance by almost
factor 2.