### PR TITLE
Allow usage of AliEmcalList in AliAnalysisTaskEmcalLight

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.cxx
@@ -33,6 +33,7 @@
 #include "AliAODEvent.h"
 #include "AliAnalysisManager.h"
 #include "AliCentrality.h"
+#include "AliEmcalList.h"
 #include "AliEMCALGeometry.h"
 #include "AliESDEvent.h"
 #include "AliEmcalParticle.h"
@@ -99,6 +100,8 @@ AliAnalysisTaskEmcalLight::AliAnalysisTaskEmcalLight() :
   fPtHardAndTrackPtFactor(0.),
   fSwitchOffLHC15oFaultyBranches(kFALSE),
   fEventSelectionAfterRun(kFALSE),
+  fUseAliEmcalList(kFALSE),
+  fUsePtHardBinScaling(kFALSE),
   fSelectGeneratorName(),
   fMinimumEventWeight(1e-6),
   fMaximumEventWeight(1e6),
@@ -184,6 +187,8 @@ AliAnalysisTaskEmcalLight::AliAnalysisTaskEmcalLight(const char *name, Bool_t hi
   fPtHardAndTrackPtFactor(0.),
   fSwitchOffLHC15oFaultyBranches(kFALSE),
   fEventSelectionAfterRun(kFALSE),
+  fUseAliEmcalList(kFALSE),
+  fUsePtHardBinScaling(kFALSE),
   fSelectGeneratorName(),
   fMinimumEventWeight(1e-6),
   fMaximumEventWeight(1e6),
@@ -290,7 +295,15 @@ void AliAnalysisTaskEmcalLight::UserCreateOutputObjects()
     return;
 
   OpenFile(1);
-  fOutput = new TList();
+  if(fUseAliEmcalList) {
+    auto emclist = new AliEmcalList;
+    if(fUsePtHardBinScaling) emclist->SetUseScaling(true);
+    emclist->SetNameXsec("fHistXsectionExternalFile");
+    emclist->SetNameTrials("fHistTrialsExternalFile");
+    fOutput = emclist;
+  } else {
+    fOutput = new TList();
+  }
   fOutput->SetOwner(); // @suppress("Ambiguous problem")
 
   if (fCentralityEstimation == kNoCentrality) fCentBins.clear();

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.h
@@ -161,6 +161,8 @@ class AliAnalysisTaskEmcalLight : public AliAnalysisTaskSE {
   void                        SelectGeneratorName(TString gen)                      { fSelectGeneratorName = gen                          ; }
   void                        SetInhibit(Bool_t s)                                  { fInhibit = s                                        ; }
   void                        SetEventWeightRange(Double_t min, Double_t max)       { fMinimumEventWeight = min; fMaximumEventWeight = max; }
+  void                        SetUseAliEmcalList(Bool_t doUse)                      { fUseAliEmcalList = doUse                            ; }
+  void                        SetUsePtHardBinScaling(Bool_t b)                      { fUsePtHardBinScaling = b                            ; }
 
   Bool_t IsInhibit() const { return fInhibit; }
 
@@ -254,6 +256,8 @@ class AliAnalysisTaskEmcalLight : public AliAnalysisTaskSE {
   Float_t                     fPtHardAndTrackPtFactor;     ///< Factor between ptHard and track pT to reject/accept event.
   Bool_t                      fSwitchOffLHC15oFaultyBranches; ///< Switch off faulty tree branches in LHC15o AOD trees
   Bool_t                      fEventSelectionAfterRun;     ///< If kTRUE, the event selection is performed after Run() but before FillHistograms()
+  Bool_t                      fUseAliEmcalList;            ///< Use AliEmcalList as output object
+  Bool_t                      fUsePtHardBinScaling;        ///< Apply pt-hard bin scaling (in case AliEmcalList is used to handle the output)
   TString                     fSelectGeneratorName;        ///< Selects only events produced by a generator that has a name containing a string
   Double_t                    fMinimumEventWeight;         ///< Minimum event weight for the related bookkeping histogram
   Double_t                    fMaximumEventWeight;         ///< Minimum event weight for the related bookkeping histogram

--- a/PWG/EMCAL/EMCALbase/AliEmcalList.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEmcalList.cxx
@@ -29,7 +29,10 @@ ClassImp(AliEmcalList)
 
 /// \brief constructor
 //________________________________________________________________________
-AliEmcalList::AliEmcalList() : TList(), fUseScaling(kFALSE)
+AliEmcalList::AliEmcalList() : TList(), 
+  fUseScaling(kFALSE),
+  fNameXsec("fHistXsection"),
+  fNameNTrials("fHistTrials")
 {
 }
 
@@ -46,8 +49,8 @@ Long64_t AliEmcalList::Merge(TCollection *hlist)
 
   // #### Retrieve xsection and ntrials from histograms in this list
   // NOTE: they must be directly added to the AliEmcalList, not nested in sublists!
-  TH1* xsection = static_cast<TH1*>(FindObject("fHistXsection"));
-  TH1* ntrials  = static_cast<TH1*>(FindObject("fHistTrials"));
+  TH1* xsection = static_cast<TH1*>(FindObject(fNameXsec.Data()));
+  TH1* ntrials  = static_cast<TH1*>(FindObject(fNameNTrials.Data()));
 
   // #### If xsection or ntrials are not given, go to fatal
   if(!(xsection && ntrials))
@@ -70,8 +73,8 @@ Long64_t AliEmcalList::Merge(TCollection *hlist)
     TIter listIterator(hlist);
     while (AliEmcalList* tmpList = static_cast<AliEmcalList*>(listIterator()))
     {
-      xsection = static_cast<TH1*>(tmpList->FindObject("fHistXsection"));
-      ntrials  = static_cast<TH1*>(tmpList->FindObject("fHistTrials"));
+      xsection = static_cast<TH1*>(tmpList->FindObject(fNameXsec.Data()));
+      ntrials  = static_cast<TH1*>(tmpList->FindObject(fNameNTrials.Data()));
       scalingFactor = GetScalingFactor(xsection, ntrials);
       ScaleAllHistograms(tmpList, scalingFactor);
     }

--- a/PWG/EMCAL/EMCALbase/AliEmcalList.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalList.h
@@ -18,9 +18,9 @@
 //
 
 class TH1;
-class TList;
 
 #include "TList.h"
+#include "TString.h"
 
 class AliEmcalList : public TList {
 
@@ -30,6 +30,8 @@ public:
   Long64_t                    Merge(TCollection *hlist);
   void                        SetUseScaling(Bool_t val) {fUseScaling = val;}
   Bool_t                      IsUseScaling() const { return fUseScaling; }
+  void                        SetNameXsec(const char *name) { fNameXsec = name; }
+  void                        SetNameTrials(const char *name) { fNameNTrials = name; }
 
 private:
   // ####### Helper functions
@@ -40,6 +42,8 @@ private:
   Bool_t                      IsScalingSupported(const TObject *scaleobject) const;
   
   Bool_t                      fUseScaling;                    ///< if true, scaling will be done. if false AliEmcalList simplifies to TList
+  TString                     fNameXsec;                      ///< Name of the cross section histogram
+  TString                     fNameNTrials;                   ///< Name of the histogram with the number of trials
 
   /// \cond CLASSIMP
   ClassDef(AliEmcalList, 1);


### PR DESCRIPTION
Adding option to use the AliEmcalList in AliAnalysisTaskEmcalLight
instead of TList. Usage of the AliEmcalList allows for automatic
scaling in the last merging level. AliAnalysisTaskEmcalLight forwards
its scaling histograms, named slightly different than the ones in
AliAnalysisTaskEmcal, to the AliEmcalList.

The option can be switched in via SetUseAliEmcalList.