### PR TITLE
PWG/EMCAL: Added switch for new temperature calibration to also be used in Run1 data

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
@@ -27,7 +27,7 @@ AliEmcalCorrectionCellEnergy::AliEmcalCorrectionCellEnergy() :
   ,fCellEnergyDistAfter(0)
   ,fUseAutomaticRecalib(1)
   ,fUseAutomaticRunDepRecalib(1)
-  ,fUseRunDepTempCalibRun2(0)
+  ,fUseNewRunDepTempCalib(0)
   ,fCustomRecalibFilePath("")
 {
 }
@@ -52,7 +52,7 @@ Bool_t AliEmcalCorrectionCellEnergy::Initialize()
   if(fFilepass.Contains("LHC14a1a")) fUseAutomaticRecalib = kTRUE;
 
   // check the YAML configuration if the Run2 calibration is requested (default is false)
-  GetProperty("enableRun2TempCalib",fUseRunDepTempCalibRun2);
+  GetProperty("enableNewTempCalib",fUseNewRunDepTempCalib);
 
   // check the YAML configuration if a custom energy calibration is requested (default is empty string "")
   GetProperty("customRecalibFilePath",fCustomRecalibFilePath);
@@ -246,16 +246,10 @@ Int_t AliEmcalCorrectionCellEnergy::InitRunDepRecalib()
   if (!fRecoUtils->GetEMCALRecalibrationFactorsArray())
     fRecoUtils->InitEMCALRecalibrationFactors();
 
-  // Treat Run2 calibration differently. Loading of two OADB objects required for calibration
-  // Calibration can be turned on or off via: enableRun2TempCalib: true in the YAML configuration
-  if(runRC > 197692){
-
-    AliInfo("Initialising Run2 recalibration factors");
-
-    if(!fUseRunDepTempCalibRun2){
-      AliInfo("Temperature calibration for Run2 not requested");
-      return 0;
-    }
+  // Treat new temp. calibration differently. Loading of two OADB objects required for calibration
+  // Calibration can be turned on or off via: enableNewTempCalib: true in the YAML configuration
+  if(!fUseNewRunDepTempCalib){
+    AliInfo("Initialising New recalibration factors");
 
     // two files and two OADB containers are needed for the correction factor
     std::unique_ptr<AliOADBContainer> contTemperature;
@@ -347,8 +341,11 @@ Int_t AliEmcalCorrectionCellEnergy::InitRunDepRecalib()
 
   // standard treatment of Run1 data
   } else {
-
-    AliInfo("Initialising recalibration factors");
+    if(runRC > 197692){
+      AliInfo("Temperature calibration could not be loaded. Please use enableNewTempCalib: true in your configuration file for Run2 data!");
+      return 0;
+    }
+    AliInfo("Initialising Run1 recalibration factors");
 
     std::unique_ptr<AliOADBContainer> contRF;
     std::unique_ptr<TFile> runDepRecalibFile;

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.cxx
@@ -248,7 +248,7 @@ Int_t AliEmcalCorrectionCellEnergy::InitRunDepRecalib()
 
   // Treat new temp. calibration differently. Loading of two OADB objects required for calibration
   // Calibration can be turned on or off via: enableNewTempCalib: true in the YAML configuration
-  if(!fUseNewRunDepTempCalib){
+  if(fUseNewRunDepTempCalib){
     AliInfo("Initialising New recalibration factors");
 
     // two files and two OADB containers are needed for the correction factor

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.h
@@ -44,7 +44,7 @@ private:
   // Change to false if experts
   Bool_t                 fUseAutomaticRecalib;       ///< On by default the check in the OADB of the energy recalibration
   Bool_t                 fUseAutomaticRunDepRecalib; ///< On by default the check in the OADB of the run dependent energy recalibration
-  Bool_t                 fUseRunDepTempCalibRun2;    ///< Off by default the check in the OADB of the run dependent temp calib Run2
+  Bool_t                 fUseNewRunDepTempCalib;     ///< Off by default the check in the OADB of the new run dependent temp calib Run1/Run2
   TString                fCustomRecalibFilePath;     ///< Empty string by default the path to the OADB file of the custom energy recalibration
   
   AliEmcalCorrectionCellEnergy(const AliEmcalCorrectionCellEnergy &);               // Not implemented
@@ -54,7 +54,7 @@ private:
   static RegisterCorrectionComponent<AliEmcalCorrectionCellEnergy> reg;
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionCellEnergy, 3); // EMCal cell energy correction component
+  ClassDef(AliEmcalCorrectionCellEnergy, 4); // EMCal cell energy correction component
   /// \endcond
 };
 

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -59,7 +59,7 @@ sharedParameters:
 CellEnergy:                                         # Cell Energy correction component
     enabled: false                                  # Whether to enable the task
     createHistos: false                             # Whether the task should create output histograms
-    enableRun2TempCalib: false                      # Whether the temperature calibration should be done for Run2
+    enableNewTempCalib: false                       # Whether the new temperature calibration parmeters should be used (available for Run1 and Run2)
     customRecalibFilePath: ""                       # Full path including .root file for custom recalibration object
     cellsNames:                                     # Names of the cells input objects which should be attached to the correction
         - defaultCells                              # This object is defined above in the cells section of the input objects

--- a/PWG/EMCAL/macros/AddTaskEMCALTender.C
+++ b/PWG/EMCAL/macros/AddTaskEMCALTender.C
@@ -32,7 +32,7 @@ AliAnalysisTaskSE *AddTaskEMCALTender(
   TString removeMCGen1        = "",       // name of generator input to be accepted
   TString removeMCGen2        = "",       // name of generator input to be accepted
   TString customBCmap         = "",       // location of custom bad channel map (full path including file)
-  Bool_t useNewRWTempCalib    = kFALSE,   // switch for usage of temperature calib in run2
+  Bool_t useNewRWTempCalib    = kFALSE,   // switch for usage of new temperature calib parameters (available for run1 and run2)
   TString customSMtemps       = "",       // location of custom SM-wise temperature OADB file (full path including file)
   TString customTempParams    = ""        // location of custom temperature calibration parameters OADB file (full path including file)
 ) 

--- a/PWG/EMCAL/macros/AddTaskEMCALTender.C
+++ b/PWG/EMCAL/macros/AddTaskEMCALTender.C
@@ -32,7 +32,7 @@ AliAnalysisTaskSE *AddTaskEMCALTender(
   TString removeMCGen1        = "",       // name of generator input to be accepted
   TString removeMCGen2        = "",       // name of generator input to be accepted
   TString customBCmap         = "",       // location of custom bad channel map (full path including file)
-  Bool_t useRWTempCalibRun2   = kFALSE,   // switch for usage of temperature calib in run2
+  Bool_t useNewRWTempCalib    = kFALSE,   // switch for usage of temperature calib in run2
   TString customSMtemps       = "",       // location of custom SM-wise temperature OADB file (full path including file)
   TString customTempParams    = ""        // location of custom temperature calibration parameters OADB file (full path including file)
 ) 
@@ -96,8 +96,8 @@ AliAnalysisTaskSE *AddTaskEMCALTender(
     EMCALSupply->SetPass(pass);
   if (customBCmap!="")
     EMCALSupply->SetCustomBC(customBCmap);
-  if (useRWTempCalibRun2)
-    EMCALSupply->SwitchUseRunDepTempCalibRun2(useRWTempCalibRun2);
+  if (useNewRWTempCalib)
+    EMCALSupply->SwitchUseNewRunDepTempCalib(useNewRWTempCalib);
   if(customSMtemps!="" && customTempParams!="")
     EMCALSupply->SetCustomTimeCalibration(customSMtemps,customTempParams);
   if (evhand->InheritsFrom("AliESDInputHandler")) {

--- a/PWGGA/CaloTrackCorrelations/yaml/EMCalCorrConfig_Data_ClV1_Run2TCalib.yaml
+++ b/PWGGA/CaloTrackCorrelations/yaml/EMCalCorrConfig_Data_ClV1_Run2TCalib.yaml
@@ -3,7 +3,7 @@ configurationName: "EMCal Data Correction Cluster V1, Run2 T corrections"
 CellEnergy:
     enabled: true
     createHistos: true
-    enableRun2TempCalib: true
+    enableNewTempCalib: true
 CellBadChannel:
     enabled: true
     createHistos: true

--- a/PWGGA/CaloTrackCorrelations/yaml/EMCalCorrConfig_Data_ClV2_Run2TCalib.yaml
+++ b/PWGGA/CaloTrackCorrelations/yaml/EMCalCorrConfig_Data_ClV2_Run2TCalib.yaml
@@ -3,7 +3,7 @@ configurationName: "EMCal Data Correction Cluster V2, Run2 T corrections"
 CellEnergy:
     enabled: true
     createHistos: true
-    enableRun2TempCalib: true
+    enableNewTempCalib: true
 CellBadChannel:
     enabled: true
     createHistos: true

--- a/TENDER/TenderSupplies/AliEMCALTenderSupply.cxx
+++ b/TENDER/TenderSupplies/AliEMCALTenderSupply.cxx
@@ -108,7 +108,7 @@ AliEMCALTenderSupply::AliEMCALTenderSupply() :
   ,fRemapMCLabelForAODs(0)
   ,fUseAutomaticRecalib(1)
   ,fUseAutomaticRunDepRecalib(1)
-  ,fUseRunDepTempCalibRun2(0)
+  ,fUseNewRunDepTempCalib(0)
   ,fUseAutomaticTimeCalib(1)
   ,fUseAutomaticRecParam(1)
 {
@@ -182,7 +182,7 @@ AliEMCALTenderSupply::AliEMCALTenderSupply(const char *name, const AliTender *te
   ,fRemapMCLabelForAODs(0)
   ,fUseAutomaticRecalib(1)
   ,fUseAutomaticRunDepRecalib(1)
-  ,fUseRunDepTempCalibRun2(0)
+  ,fUseNewRunDepTempCalib(0)
   ,fUseAutomaticTimeCalib(1)
   ,fUseAutomaticRecParam(1)
 {
@@ -256,7 +256,7 @@ AliEMCALTenderSupply::AliEMCALTenderSupply(const char *name, AliAnalysisTaskSE *
   ,fRemapMCLabelForAODs(0)
   ,fUseAutomaticRecalib(1)
   ,fUseAutomaticRunDepRecalib(1)
-  ,fUseRunDepTempCalibRun2(0)
+  ,fUseNewRunDepTempCalib(0)
   ,fUseAutomaticTimeCalib(1)
   ,fUseAutomaticRecParam(1)
 {
@@ -1202,9 +1202,7 @@ Int_t AliEMCALTenderSupply::InitRunDepRecalib()
   // opening the OADB container
   // 
   // For more information see https://alice.its.cern.ch/jira/browse/EMCAL-135
-  if(event->GetRunNumber() > 197692){
-    if(!fUseRunDepTempCalibRun2)
-      return 0;
+  if(fUseNewRunDepTempCalib){
 
     if (fDebugLevel>0)
       AliInfo("Initialising Run2 temperature recalibration factors");
@@ -1333,6 +1331,10 @@ Int_t AliEMCALTenderSupply::InitRunDepRecalib()
 
     // Run1 treatment with old calibration
   } else {
+    if(event->GetRunNumber() > 197692){
+      AliInfo("Temperature calibration could not be loaded. Please use useNewRWTempCalib = kTRUE in the AddTaskEMCALTender for Run2 data!");
+      return 0;
+    }
 
     if (fDebugLevel>0)
       AliInfo("Initialising Run1 recalibration factors");

--- a/TENDER/TenderSupplies/AliEMCALTenderSupply.h
+++ b/TENDER/TenderSupplies/AliEMCALTenderSupply.h
@@ -199,7 +199,7 @@ public:
   void     SwitchOffUseAutomaticTimeCalibParam()           { fUseAutomaticTimeCalib     = kFALSE ; }
   void     SwitchOffUseAutomaticRecParam()                 { fUseAutomaticRecParam      = kFALSE ; }
 
-  void     SwitchUseRunDepTempCalibRun2(Bool_t doUseTC)    { fUseRunDepTempCalibRun2    = doUseTC; }
+  void     SwitchUseNewRunDepTempCalib(Bool_t doUseTC)     { fUseNewRunDepTempCalib     = doUseTC; }
 
 private:
 
@@ -298,13 +298,13 @@ private:
   // Change to false if experts
   Bool_t                 fUseAutomaticRecalib;       // On by default the check in the OADB of the energy recalibration
   Bool_t                 fUseAutomaticRunDepRecalib; // On by default the check in the OADB of the run dependent energy recalibration
-  Bool_t                 fUseRunDepTempCalibRun2;    // Off by default the check in the OADB of the run dependent temperature calib Run2
+  Bool_t                 fUseNewRunDepTempCalib;     // Off by default the check in the OADB of the new run dependent temperature calib which covers Run1 and Run2
   Bool_t                 fUseAutomaticTimeCalib;     // On by default the check in the OADB of the time recalibration
   Bool_t                 fUseAutomaticRecParam;      // On the auto setting of the rec param
   
   AliEMCALTenderSupply(            const AliEMCALTenderSupply&c);
   AliEMCALTenderSupply& operator= (const AliEMCALTenderSupply&c);
   
-  ClassDef(AliEMCALTenderSupply, 21); // EMCAL tender task
+  ClassDef(AliEMCALTenderSupply, 22); // EMCAL tender task
 };
 #endif


### PR DESCRIPTION
The new temperature calibration parameters are also available for Run1 data. The previously implemented switch only allowed for these parameters to be used in Run2.
The switch has therefore now been renamed to "enableNewTempCalib" in the YAML file and "useNewRWTempCalib" in the AddTaskEMCALTender.
Once these changes are approved, it will also be announced via mail that any existing yaml configuration files should be adjusted for the renamed parameter (otherwise the traintests will crash).