### PR TITLE
Initial draft of jet tree for HFtree framework

### DIFF
--- a/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.h
+++ b/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.h
@@ -47,8 +47,13 @@
 #include "AliHFTreeHandlerBplustoD0pi.h"
 #include "AliHFTreeHandlerDstartoKpipi.h"
 #include "AliHFTreeHandlerLc2V0bachelor.h"
+#include "AliJetTreeHandler.h"
+#include "AliJetContainer.h"
 
 class AliAODEvent;
+class TClonesArray;
+class AliEmcalJet;
+class AliRhoParameter;
 
 class AliAnalysisTaskSEHFTreeCreator : public AliAnalysisTaskSE
 {
@@ -57,7 +62,7 @@ public:
 
     
     AliAnalysisTaskSEHFTreeCreator();
-    AliAnalysisTaskSEHFTreeCreator(const char *name,TList *cutsList);
+    AliAnalysisTaskSEHFTreeCreator(const char *name,TList *cutsList, int fillNJetTrees);
     virtual ~AliAnalysisTaskSEHFTreeCreator();
     
     
@@ -66,6 +71,8 @@ public:
     virtual void Init();
     virtual void LocalInit() {Init();}
     virtual void UserExec(Option_t *option);
+    virtual void ExecOnce();
+    virtual Bool_t RetrieveEventObjects();
     virtual void Terminate(Option_t *option);
     
     
@@ -89,6 +96,15 @@ public:
     void SetPIDoptLc2V0bachelorTree(Int_t opt){fPIDoptLc2V0bachelor=opt;}
     void SetFillMCGenTrees(Bool_t fillMCgen) {fFillMCGenTrees=fillMCgen;}
   
+    void SetFillPtUncorr(bool b) { fFillPtUncorr = b; }
+    void SetFillArea(bool b) { fFillArea = b; }
+    void SetFillNConstituents(bool b) { fFillNConstituents = b; }
+    void SetFillZLeading(bool b) { fFillZLeading = b; }
+    void SetFillRadialMoment(bool b) { fFillRadialMoment = b; }
+    void SetFillpTD(bool b) { fFillpTD = b; }
+    void SetFillMass(bool b) { fFillMass = b; }
+    void SetFillMatchingJetID(bool b) { fFillMatchingJetID = b; }
+  
     void SetDsMassKKOption(AliHFTreeHandlerDstoKKpi::massKKopt opt) {fDsMassKKOpt=opt;}
     void SetLc2V0bachelorCalcSecoVtx(Int_t opt=1) {fLc2V0bachelorCalcSecoVtx=opt;}
   
@@ -105,6 +121,16 @@ public:
   
     Bool_t CheckDaugAcc(TClonesArray* arrayMC,Int_t nProng, Int_t *labDau);
     AliAODVertex* ReconstructBplusVertex(const AliVVertex *primary, TObjArray *tracks, Double_t bField, Double_t dispersion);
+  
+    // Jets
+    //-----------------------------------------------------------------------------------------------
+    void SetFillNJetTrees(Int_t n){fWriteNJetTrees=n;}
+  
+    AliJetContainer* AddJetContainer(AliJetContainer::EJetType_t jetType, AliJetContainer::EJetAlgo_t jetAlgo, AliJetContainer::ERecoScheme_t recoScheme, Double_t radius, UInt_t accType, AliParticleContainer* partCont, AliClusterContainer* clusCont, TString tag = "Jet");
+    AliJetContainer* AddJetContainer(const char *n, UInt_t accType, Float_t jetRadius);
+    AliJetContainer* GetJetContainer(Int_t i=0) const;
+    void FillJetTree();
+  
     
     unsigned int GetEvID();
     
@@ -220,6 +246,35 @@ private:
     Int_t                   fLc2V0bachelorCalcSecoVtx;             /// option to calculate the secondary vertex for Lc2V0bachelor. False by default, has to be added to AddTask in case we want to start using it.
   
     Int_t                   fTreeSingleTrackVarsOpt;               /// option for single-track variables to be filled in the trees
+  
+  
+    // Jets
+    //-----------------------------------------------------------------------------------------------
+  
+    // Tree
+    Int_t                   fWriteNJetTrees;                       ///< number of jet trees to write
+                                                                   // (should match number of jet containers added)
+    std::vector<TTree*>     fVariablesTreeJet;                     //!<! vector of trees of the candidate variables
+    std::vector<AliJetTreeHandler*> fTreeHandlerJet;               //!<! vector of handler objects for jet tree
+  
+    // Jet container and array
+    Bool_t                  fLocalInitialized;                     ///< whether or not the task has been already initialized
+    TObjArray               fJetCollArray;                         ///< array of jet containers
+  
+    // Jet background subtraction
+    TString                 fRhoName;                              ///<  rho name
+    AliRhoParameter        *fRho;                                  //!<! event rho
+    Double_t                fRhoVal;                               //!<! event rho value
+  
+    // Flags specifying what info to fill to the tree
+    bool                    fFillPtUncorr;                         ///< Pt of the jet (GeV/c) (not background subtracted)
+    bool                    fFillArea;                             ///< Area
+    bool                    fFillNConstituents;                    ///< N constituents
+    bool                    fFillZLeading;                         ///< ZLeading
+    bool                    fFillRadialMoment;                     ///< Radial moment
+    bool                    fFillpTD;                              ///< pT,D
+    bool                    fFillMass;                             ///< Mass
+    bool                    fFillMatchingJetID;                    ///< jet matching
   
     /// \cond CLASSIMP
     ClassDef(AliAnalysisTaskSEHFTreeCreator,10);

--- a/PWGHF/treeHF/AliJetTreeHandler.cxx
+++ b/PWGHF/treeHF/AliJetTreeHandler.cxx
@@ -1,0 +1,329 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+
+/**
+ * \class AliJetTreeHandler
+ * \brief Helper class to handle a tree for cut optimisation and MVA analyses, based heavily on AliHFTreeHandler and AliAnalysisTaskDmesonJets
+ *
+ * \author James Mulligan <james.mulligan@berkeley.edu>
+ * \date Feb 15 2019
+ */
+
+#include <TVector2.h>
+
+#include "AliJetTreeHandler.h"
+
+//________________________________________________________________
+/// \cond CLASSIMP
+ClassImp(AliJetTreeHandler);
+/// \endcond
+
+//________________________________________________________________
+// Default constructor
+AliJetTreeHandler::AliJetTreeHandler():
+  TObject(),
+  fTreeVar(nullptr),
+  fJetContainer(nullptr),
+  fFillPtUncorr(false),
+  fFillArea(true),
+  fFillNConstituents(true),
+  fFillZLeading(true),
+  fFillRadialMoment(true),
+  fFillpTD(true),
+  fFillMass(true),
+  fFillMatchingJetID(false),
+  fPtCorr(),
+  fEta(),
+  fPhi(),
+  fPtUncorr(),
+  fArea(),
+  fN(),
+  fZLeading(),
+  fRadialMoment(),
+  fpTD(),
+  fMass(),
+  fMatchedJetID()
+{
+}
+
+//________________________________________________________________
+// Destructor
+AliJetTreeHandler::~AliJetTreeHandler()
+{
+  if(fTreeVar) delete fTreeVar;
+}
+
+/**
+ * Create jet TTree, with a branch of vectors for each jet variable.
+ * There will be one entry in each vector for each jet that is found.
+ */
+//________________________________________________________________
+TTree* AliJetTreeHandler::BuildTree(TString name, TString title)
+{
+  if(fTreeVar) {
+    delete fTreeVar;
+    fTreeVar=0x0;
+  }
+  fTreeVar = new TTree(name.Data(),title.Data());
+  
+  // Create branches for each jet variable
+  fTreeVar->Branch("PtCorr",&fPtCorr);
+  fTreeVar->Branch("Eta",&fEta);
+  fTreeVar->Branch("Phi",&fPhi);
+  
+  if (fFillPtUncorr) {
+    fTreeVar->Branch("PtUncorr",&fPtUncorr);
+  }
+  
+  if (fFillArea) {
+    fTreeVar->Branch("Area",&fArea);
+  }
+  
+  if (fFillNConstituents) {
+    fTreeVar->Branch("N",&fN);
+  }
+  
+  if (fFillZLeading) {
+    fTreeVar->Branch("ZLeading", &fZLeading);
+  }
+  
+  if (fFillRadialMoment) {
+    fTreeVar->Branch("RadialMoment", &fRadialMoment);
+  }
+  
+  if (fFillpTD) {
+    fTreeVar->Branch("pTD", &fpTD);
+  }
+  
+  if (fFillMass) {
+    fTreeVar->Branch("Mass", &fMass);
+  }
+  
+  if (fFillMatchingJetID) {
+    fTreeVar->Branch("MatchedJetID", &fMatchedJetID);
+  }
+  
+  return fTreeVar;
+}
+
+/**
+ * Set jet tree variables
+ */
+//________________________________________________________________
+bool AliJetTreeHandler::SetJetVariables()
+{
+
+  for (const auto jet : fJetContainer->accepted()) {
+    
+    fPtCorr.push_back(GetJetPt(jet));
+    fEta.push_back(jet->Eta());
+    fPhi.push_back(jet->Phi_0_2pi());
+    
+    if (fFillPtUncorr) {
+      fPtUncorr.push_back(jet->Pt());
+    }
+    
+    if (fFillArea) {
+      fArea.push_back(jet->Area());
+    }
+    
+    if (fFillNConstituents) {
+      fN.push_back(jet->GetNumberOfConstituents());
+    }
+    
+    if (fFillZLeading) {
+      fZLeading.push_back(fJetContainer->GetZLeadingCharged(jet));
+    }
+    
+    if (fFillRadialMoment) {
+      fRadialMoment.push_back(RadialMoment(jet));
+    }
+    
+    if (fFillpTD) {
+      fpTD.push_back(PTD(jet));
+    }
+    
+    if (fFillMass) {
+      fMass.push_back(jet->M());
+    }
+    
+    // Get matched jet (assumes the matches have been filled by a previous task)
+    if (fFillMatchingJetID) {
+      
+      int matchedJetLabel = -1;
+      const AliEmcalJet* matchedJet = jet->ClosestJet();
+      if (matchedJet) {
+        matchedJetLabel = matchedJet->GetLabel();
+      }
+      fMatchedJetID.push_back(matchedJetLabel);
+      
+    }
+
+  }
+  
+  return true;
+}
+
+/**
+ * Fill jet tree, and reset all vectors
+ */
+//________________________________________________________________
+void AliJetTreeHandler::FillTree() {
+
+  fTreeVar->Fill();
+  
+  // Reset all vectors
+  fPtCorr.clear();
+  fEta.clear();
+  fPhi.clear();
+  
+  if (fFillPtUncorr) {
+    fPtUncorr.clear();
+  }
+  
+  if (fFillArea) {
+    fArea.clear();
+  }
+  
+  if (fFillNConstituents) {
+    fN.clear();
+  }
+  
+  if (fFillZLeading) {
+    fZLeading.clear();
+  }
+  
+  if (fFillRadialMoment) {
+    fRadialMoment.clear();
+  }
+  
+  if (fFillpTD) {
+    fpTD.clear();
+  }
+  
+  if (fFillMass) {
+    fMass.clear();
+  }
+  
+  if (fFillMatchingJetID) {
+    fMatchedJetID.clear();
+  }
+  
+}
+
+/**
+ *  If filling jet matching info (for MC), loop through jets and set fLabel,
+ *  which specifies the index of the jet in the tree variable std::vectors.
+
+ */
+//________________________________________________________________
+void AliJetTreeHandler::SetJetLabels()
+{
+  int i = 0;
+  for (auto jet : fJetContainer->accepted()) {
+    jet->SetLabel(i);
+    i++;
+  }
+}
+
+/**
+ * Get pT of jet -- background subtracted
+ */
+//________________________________________________________________
+Double_t AliJetTreeHandler::GetJetPt(const AliEmcalJet* jet)
+{
+  Float_t rhoVal = 0;
+  if (fJetContainer->GetRhoParameter()) {
+    rhoVal = fJetContainer->GetRhoVal();
+  }
+  
+  Float_t pTCorr = jet->Pt() - rhoVal * jet->Area();
+  return pTCorr;
+}
+
+//________________________________________________________________
+Double_t AliJetTreeHandler::PTD(const AliEmcalJet *jet){
+  
+  Double_t numeratorSquared=0;
+  Double_t denominator=0;
+  
+  for (Int_t i=0; i< jet->GetNumberOfTracks(); i++){
+    
+    AliVParticle *particle = static_cast<AliVParticle*>(jet->Track(i));
+    if (!particle) continue;
+    
+    numeratorSquared += particle->Pt() * particle->Pt();
+    denominator += particle->Pt();
+    
+  }
+  Double_t numerator = TMath::Sqrt(numeratorSquared);
+  
+  if(TMath::Abs(denominator) > 1e-3) {
+    return numerator/denominator;
+  }
+  else {
+    return -1;
+  }
+}
+
+//________________________________________________________________
+Double_t AliJetTreeHandler::RadialMoment(const AliEmcalJet* jet){
+  
+  Double_t numerator = 0;
+  Double_t denominator=0;
+  
+  for (Int_t i=0; i< jet->GetNumberOfTracks(); i++){
+    
+    const AliVParticle* particle = static_cast<AliVParticle*>(jet->Track(i));
+    if(!particle) continue;
+    
+    numerator += particle->Pt() * DeltaR(jet, particle);
+    denominator += particle->Pt();
+    
+  }
+  
+  if(TMath::Abs(denominator) > 1e-3) {
+    return numerator/denominator;
+  }
+  else {
+    return -1;
+  }
+  
+}
+
+//________________________________________________________________
+Double_t AliJetTreeHandler::DeltaR(const AliEmcalJet* jet, const AliVParticle* part) {
+  
+  Double_t jetEta = jet->Eta();
+  Double_t jetPhi = jet->Phi_0_2pi();
+
+  Double_t partEta = part->Eta();
+  Double_t partPhi = TVector2::Phi_0_2pi(part->Phi());
+  
+  return TMath::Sqrt( (jetEta-partEta)*(jetEta-partEta) + (jetPhi-partPhi)*(jetPhi-partPhi) );
+  
+}

--- a/PWGHF/treeHF/AliJetTreeHandler.h
+++ b/PWGHF/treeHF/AliJetTreeHandler.h
@@ -1,0 +1,118 @@
+/************************************************************************************
+ * Copyright (C) 2017, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+
+#ifndef ALIJETTREEHANDLER_H
+#define ALIJETTREEHANDLER_H
+
+/**
+ * \class AliJetTreeHandler
+ * \brief Helper class to handle a tree for cut optimisation and MVA analyses, based heavily on AliHFTreeHandler and AliAnalysisTaskDmesonJets
+ *
+ * \author James Mulligan <james.mulligan@berkeley.edu>
+ * \date Feb 15 2019
+ */
+
+#include "TTree.h"
+
+#include "AliJetContainer.h"
+
+//________________________________________________________________
+//****************************************************************
+class AliJetTreeHandler : public TObject
+{
+  public:
+
+    AliJetTreeHandler();
+    virtual ~AliJetTreeHandler();
+
+    // Core methods
+    TTree* BuildTree(TString name, TString title);
+    bool SetJetVariables();
+    void FillTree(); //to be called for each event
+  
+    // Setters
+    void SetJetContainer(AliJetContainer* jetCont) { fJetContainer = jetCont; }
+    void SetFillPtUncorr(bool b) { fFillPtUncorr = b; }
+    void SetFillArea(bool b) { fFillArea = b; }
+    void SetFillNConstituents(bool b) { fFillNConstituents = b; }
+    void SetFillZLeading(bool b) { fFillZLeading = b; }
+    void SetFillRadialMoment(bool b) { fFillRadialMoment = b; }
+    void SetFillpTD(bool b) { fFillpTD = b; }
+    void SetFillMass(bool b) { fFillMass = b; }
+    void SetFillMatchingJetID(bool b) { fFillMatchingJetID = b; }
+  
+    // Utility functions
+    void SetJetLabels();
+    Double_t GetJetPt(const AliEmcalJet* jet);
+    Double_t PTD(const AliEmcalJet *jet);
+    Double_t RadialMoment(const AliEmcalJet* jet);
+    Double_t DeltaR(const AliEmcalJet* jet, const AliVParticle* part);
+
+  protected:
+  
+    TTree*                       fTreeVar;                 ///< Tree with compressed jet objects
+    AliJetContainer*             fJetContainer;            //!<! Jet container for this tree
+  
+    // Flags specifying what info to fill to the tree
+    bool                         fFillPtUncorr;            ///< Pt of the jet (GeV/c) (not background subtracted)
+    bool                         fFillArea;                ///< Area
+    bool                         fFillNConstituents;       ///< N constituents
+    bool                         fFillZLeading;            ///< ZLeading
+    bool                         fFillRadialMoment;        ///< Radial moment
+    bool                         fFillpTD;                 ///< pT,D
+    bool                         fFillMass;                ///< Mass
+    bool                         fFillMatchingJetID;       ///< jet matching
+
+    // Jet parameters to be stored in the tree.
+    // Each branch in the tree consists of a vector of a given variable,
+    // where the i^th entry in the vector corresponds to the i^th jet.
+  
+    // Basic jet quantities (always filled)
+    std::vector<float>           fPtCorr;                  //!<! Pt of the jet after subtracting average background
+    std::vector<float>           fEta;                     //!<! Eta of the jet
+    std::vector<float>           fPhi;                     //!<! Phi of the jet (0 < phi < 2pi)
+
+    // Other jet quantities
+    std::vector<float>           fPtUncorr;                //!<! Pt of the jet (GeV/c) (not background subtracted)
+    std::vector<float>           fArea;                    //!<! Area of the jet
+  
+    // Jet substructure observables
+    std::vector<float>           fN;                       //!<! Number of jet constituents
+    std::vector<float>           fZLeading;                //!<! z of leading track
+    std::vector<float>           fRadialMoment;            //!<! Radial moment (not background subtracted)
+    std::vector<float>           fpTD;                     //!<! Momentum dispersion (not background subtracted)
+    std::vector<float>           fMass;                    //!<! Jet mass (not background subtracted)
+
+    // Jet matching
+    std::vector<float>           fMatchedJetID;            //!<! Index of matched jet in the matching container's std::vectors
+  
+  /// \cond CLASSIMP
+  ClassDef(AliJetTreeHandler,1); ///
+  /// \endcond
+};
+
+#endif

--- a/PWGHF/treeHF/CMakeLists.txt
+++ b/PWGHF/treeHF/CMakeLists.txt
@@ -27,9 +27,12 @@ include_directories(${ROOT_INCLUDE_DIRS}
 		    ${AliPhysics_SOURCE_DIR}/OADB/COMMON/MULTIPLICITY
                     ${AliPhysics_SOURCE_DIR}/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrections
 		    ${AliPhysics_SOURCE_DIR}/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrectionsInterface/
+                    ${AliPhysics_SOURCE_DIR}/PWG/EMCAL/EMCALbase
                     ${AliPhysics_SOURCE_DIR}/PWG/FLOW/Base
                     ${AliPhysics_SOURCE_DIR}/PWG/FLOW/Tasks
+                    ${AliPhysics_SOURCE_DIR}/PWG/JETFW
                     ${AliPhysics_SOURCE_DIR}/PWG/muon
+                    ${AliPhysics_SOURCE_DIR}/PWG/Tools
                     ${AliPhysics_SOURCE_DIR}/PWG/TRD
                     ${AliPhysics_SOURCE_DIR}/PWGHF/vertexingHF
   )
@@ -46,6 +49,7 @@ set(SRCS
   AliHFTreeHandlerBplustoD0pi.cxx
   AliHFTreeHandlerDstartoKpipi.cxx
   AliHFTreeHandlerLc2V0bachelor.cxx
+  AliJetTreeHandler.cxx
 
   )
 
@@ -62,7 +66,7 @@ add_library_tested(${MODULE} SHARED  ${SRCS} G__${MODULE}.cxx)
 
 # Generate the ROOT map
 # Dependecies
-set(LIBDEPS ANALYSISalice PWGflowTasks PWGTRD PWGPPevcharQn PWGPPevcharQnInterface PWGHFvertexingHF)
+set(LIBDEPS ANALYSISalice PWGflowTasks PWGTRD PWGPPevcharQn PWGPPevcharQnInterface PWGHFvertexingHF PWGEMCALbase PWGJETFW PWGTools)
 generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
 
 # Generate a PARfile target for this library
@@ -71,7 +75,7 @@ add_target_parfile(${MODULE} "${SRCS}" "${HDRS}" "${MODULE}LinkDef.h" "${LIBDEPS
 # Linking the library
 target_link_libraries(${MODULE} ${LIBDEPS})
 
-# Public include folders that will be propagated to the dependecies
+# Public include folders that will be propagated to the dependencies
 target_include_directories(${MODULE} PUBLIC ${incdirs})
 
 # System dependent: Modify the way the library is build

--- a/PWGHF/treeHF/PWGHFtreeHFLinkDef.h
+++ b/PWGHF/treeHF/PWGHFtreeHFLinkDef.h
@@ -14,8 +14,7 @@
 #pragma link C++ class   AliHFTreeHandlerLctopKpi+;
 #pragma link C++ class   AliHFTreeHandlerDstartoKpipi+;
 #pragma link C++ class   AliHFTreeHandlerLc2V0bachelor+;
-
-
+#pragma link C++ class   AliJetTreeHandler+;
 
 
 #endif

--- a/PWGHF/treeHF/macros/AddTaskHFTreeCreator.C
+++ b/PWGHF/treeHF/macros/AddTaskHFTreeCreator.C
@@ -19,7 +19,8 @@ AliAnalysisTaskSEHFTreeCreator *AddTaskHFTreeCreator(Bool_t readMC=kTRUE,
                                                      Int_t pidOptLctopKpi=AliHFTreeHandler::kRawAndNsigmaPID,
                                                      Int_t pidOptLc2V0bachelor=AliHFTreeHandler::kRawAndNsigmaPID,
                                                      Int_t pidOptBplus=AliHFTreeHandler::kRawAndNsigmaPID,
-                                                     Int_t singletrackvarsopt=AliHFTreeHandler::kRedSingleTrackVars)
+                                                     Int_t singletrackvarsopt=AliHFTreeHandler::kRedSingleTrackVars,
+                                                     Int_t fillNJetTrees = 0)
 {
     //
     //
@@ -91,7 +92,7 @@ AliAnalysisTaskSEHFTreeCreator *AddTaskHFTreeCreator(Bool_t readMC=kTRUE,
     cutsList->Add(analysisCutsDstartoKpipi);
     cutsList->Add(analysisCutsLc2V0bachelor);
 
-    AliAnalysisTaskSEHFTreeCreator *task = new AliAnalysisTaskSEHFTreeCreator("TreeCreatorTask",cutsList);
+    AliAnalysisTaskSEHFTreeCreator *task = new AliAnalysisTaskSEHFTreeCreator("TreeCreatorTask",cutsList, fillNJetTrees);
 
     task->SetReadMC(readMC);
     if(readMC) {
@@ -115,7 +116,7 @@ AliAnalysisTaskSEHFTreeCreator *AddTaskHFTreeCreator(Bool_t readMC=kTRUE,
     task->SetPIDoptDstarTree(pidOptDstar);
     task->SetPIDoptLc2V0bachelorTree(pidOptLc2V0bachelor);
     task->SetTreeSingleTrackVarsOpt(singletrackvarsopt);
-  
+
     //task->SetDebugLevel(4);
 
     mgr->AddTask(task);
@@ -142,6 +143,7 @@ AliAnalysisTaskSEHFTreeCreator *AddTaskHFTreeCreator(Bool_t readMC=kTRUE,
     TString treeGenBplusname = "coutputTreeGenBplus";
     TString treeGenDstarname = "coutputTreeGenDstar";
     TString treeGenLc2V0bachelorname = "coutputTreeGenLc2V0bachelor";
+    TString treeJetName = "coutputTreeJet%d";
  
     inname += finDirname.Data();
     histoname += finDirname.Data();
@@ -163,6 +165,7 @@ AliAnalysisTaskSEHFTreeCreator *AddTaskHFTreeCreator(Bool_t readMC=kTRUE,
     treeGenBplusname += finDirname.Data();
     treeGenDstarname += finDirname.Data();
     treeGenLc2V0bachelorname += finDirname.Data();
+    treeJetName += finDirname.Data();
 
     AliAnalysisDataContainer *cinput = mgr->CreateContainer(inname,TChain::Class(),AliAnalysisManager::kInputContainer);
     TString outputfile = AliAnalysisManager::GetCommonFileName();
@@ -189,6 +192,7 @@ AliAnalysisTaskSEHFTreeCreator *AddTaskHFTreeCreator(Bool_t readMC=kTRUE,
     AliAnalysisDataContainer *coutputTreeGenDstar = 0x0;
     AliAnalysisDataContainer *coutputTreeLc2V0bachelor = 0x0;
     AliAnalysisDataContainer *coutputTreeGenLc2V0bachelor = 0x0;
+    std::vector<AliAnalysisDataContainer*> coutputTreeJet;
 
     if(fillTreeD0) {
       coutputTreeD0 = mgr->CreateContainer(treeD0name,TTree::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
@@ -252,7 +256,12 @@ AliAnalysisTaskSEHFTreeCreator *AddTaskHFTreeCreator(Bool_t readMC=kTRUE,
             coutputTreeGenLc2V0bachelor->SetSpecialOutput();
         }
     }
-    
+  
+    for (int i=0; i<fillNJetTrees; i++) {
+      coutputTreeJet.push_back(mgr->CreateContainer(Form(treeJetName, i),TTree::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data()));
+      coutputTreeJet.at(i)->SetSpecialOutput();
+    }
+
     mgr->ConnectInput(task,0,mgr->GetCommonInputContainer());
     mgr->ConnectOutput(task,1,coutputEntries);
     mgr->ConnectOutput(task,2,coutputCounter);
@@ -287,5 +296,9 @@ AliAnalysisTaskSEHFTreeCreator *AddTaskHFTreeCreator(Bool_t readMC=kTRUE,
         mgr->ConnectOutput(task,18,coutputTreeLc2V0bachelor);
         if(readMC && fillMGgenTrees) mgr->ConnectOutput(task,19,coutputTreeGenLc2V0bachelor);
     }
+    for (int i=0; i<fillNJetTrees; i++) {
+      mgr->ConnectOutput(task,20+i,coutputTreeJet.at(i));
+    }
+
     return task;
 }


### PR DESCRIPTION
WIP: Please do not approve yet.

@ginnocen, @nzardosh, @fgrosa, @lvermunt,

Please have a look at this first draft of the jet tree. The jet info itself is minimal at this point (pT, eta, phi, etc.), but the infrastructure is there to easily add more.

The basic idea is as follows: One should run a `JetFinder` task before the `TreeCreator` task (which will write a jet array to the InputEvent), and then in `TreeCreator::AddTask` one should add a line to attach a jet container corresponding to that jet array. This mimics the standard workflow in ALICE jet framework -- the idea of the jet container is to automatically handle access to the jet array, and to provide a configurable set of cuts. The `JetTreeHandler` will then construct a std::vector of all of the jets (subject to whatever criteria one wants to configure via the jet container) in each event. The jet info is encapsulated in a small class `AliJetInfoCompressed`, which takes advantage of the `Double32_t` type to minimize the footprint.  One can add as many jet finders as you like, one branch will be written for each.

Some notes:
* There is just a single JetTreeHandler at the moment, rather than an inheritance structure, but this can easily change depending what direction we decide to go. 
* I haven't added yet the MC tree info
* Event selection will inherit whatever is used for the HF trees
* Track selection should be configured independently of the HF track selection, using track containers (hybrid tracks)
* I had to add a few dependencies to the treeHF compilation, I think it should not cause any problem but it would be good if someone more familiar with HF can verify.

I have only run this locally on a small number of events, so it has not been tested super rigorously. But I wanted to get this draft out there so we can discuss. Please let me know what you think, and we can decide how to proceed. 

Best,
James