### PR TITLE
Recognize LHC11h in MultSelection

### DIFF
--- a/OADB/COMMON/MULTIPLICITY/AliMultSelectionTask.cxx
+++ b/OADB/COMMON/MULTIPLICITY/AliMultSelectionTask.cxx
@@ -2717,6 +2717,7 @@ TString AliMultSelectionTask::GetPeriodNameByRunNumber() const
     
     //Registered Productions : Run 1 Pb-Pb
     if ( fCurrentRun >= 136851 && fCurrentRun <= 139517 ) lProductionName = "LHC10h";
+    if ( fCurrentRun >= 167693 && fCurrentRun <= 170593 ) lProductionName = "LHC11h";
     
     //Registered Productions : Run 2 pp
     if ( fCurrentRun >= 225000 && fCurrentRun <= 226606 ) lProductionName = "LHC15f";
@@ -2814,6 +2815,7 @@ TString AliMultSelectionTask::GetSystemTypeByRunNumber() const
     
     //Registered Productions : Run 1 Pb-Pb
     if ( fCurrentRun >= 136851 && fCurrentRun <= 139517 ) lSystemType = "Pb-Pb";
+    if ( fCurrentRun >= 167693 && fCurrentRun <= 170593 ) lSystemType = "Pb-Pb";
     
     //Registered Productions : Run 2 pp
     if ( fCurrentRun >= 225000 && fCurrentRun <= 226606 ) lSystemType = "pp";


### PR DESCRIPTION
I only found this out accidentally, but despite the [twiki](https://twiki.cern.ch/twiki/bin/viewauth/ALICE/AliMultSelectionCalibStatus) marking LHC11h as calibrated for use with MultSelectionTask, the period auto detection doesn't appear to work. I've added the run number so that it's properly identified. The run numbers are from the RCT