### PR TITLE
changes the close pair rejection criterium to the radius

### DIFF
--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamZVtxMultContainer.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamZVtxMultContainer.cxx
@@ -460,7 +460,7 @@ bool AliFemtoDreamZVtxMultContainer::RejectClosePairs(
           dphi += piHi * 2;
         }
         dphi = TVector2::Phi_mpi_pi(dphi);
-        if (dphi * dphi + deta * deta < fDeltaPhiEtaMax * fDeltaPhiEtaMax) {
+        if (dphi * dphi + deta * deta < fDeltaPhiEtaMax) {
           outBool = false;
           break;
         }


### PR DESCRIPTION
Fixes a bug. Instead of using ((dPhiMin)^2 + (dEtaMin)^2)^2 it uses as intended (dPhiMin)^2 + (dEtaMin)^2