### PR TITLE
Uses the correct number of pairs for Close pair rejection

### DIFF
--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCollConfig.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamCollConfig.cxx
@@ -447,10 +447,10 @@ std::vector<bool> AliFemtoDreamCollConfig::GetClosePairRej() {
     AliFatal("Not all Pairs have a specified QA Behaviour, terminating \n");
   } else {
     fClosePairRej->SetBranchAddress("RejPair", &out);
-    for (int iRej = 0; iRej < fWhichQAPairs->GetEntries(); ++iRej) {
+    for (int iRej = 0; iRej < fClosePairRej->GetEntries(); ++iRej) {
       fClosePairRej->GetEntry(iRej);
       Pairs.push_back(TMath::Abs(out) < 1e-6 ? false : true);
-      std::cout << "Close Pair Rejection for Pair " << iRej << "is "
+      std::cout << "Close Pair Rejection for Pair " << iRej << " is "
                 << (TMath::Abs(out) < 1e-6 ? "deactivated" : "activated")
                 << std::endl;
     }

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoDreamSysVar.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoDreamSysVar.C
@@ -5,10 +5,10 @@ AliAnalysisTaskSE* AddTaskFemtoDreamSysVar(bool isMC = false,
                                            bool isESD = false, TString CentEst =
                                                "kInt7",
                                            bool notpp = true,  //1
-                                           bool kTBinning = false,  //2
-                                           bool kTCentBinning = false,  //3
-                                           bool mTBinning = false,  //4
-                                           bool eventMixing = true,  //5
+                                           bool fineBinning = true,  //2
+                                           bool kTBinning = false,  //3
+                                           bool kTCentBinning = false,  //4
+                                           bool mTBinning = false,  //5
                                            bool minimalBooking = true,  // 6
                                            const char *swuffix = "")  //7
                                            {
@@ -19,8 +19,8 @@ AliAnalysisTaskSE* AddTaskFemtoDreamSysVar(bool isMC = false,
   bool ContributionSplitting = false;
   bool ContributionSplittingDaug = false;
   bool PileUpRej = true;
-  bool fineBinning = true; 
-  bool phiSpin = false; 
+  bool eventMixing = true;
+  bool phiSpin = false;
   // the manager is static, so get the existing manager via the static method
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
 


### PR DESCRIPTION
Before fWhichQA was wrongly used to do so. Additionally removes unnecessary  arguments from the Systematics task