### PR TITLE
Change histogram for jet finding efficiency

### DIFF
--- a/PWG/JETFW/AliJetContainer.h
+++ b/PWG/JETFW/AliJetContainer.h
@@ -179,6 +179,7 @@ class AliJetContainer : public AliParticleContainer {
   Double_t                    GetJetPtCut()                         const    {return GetMinPt() ; }
   Double_t                    GetJetPtCutMax()                      const    {return GetMaxPt() ; }
 
+  UInt_t                      GetAcceptanceType()                   const    {return fJetAcceptanceType; }
   EJetType_t                  GetJetType()                          const    {return fJetType; }
   EJetAlgo_t                  GetJetAlgorithm()                     const    {return fJetAlgorithm; }
   ERecoScheme_t               GetRecombinationScheme()              const    {return fRecombinationScheme; }


### PR DESCRIPTION
- One histogram with ptpart, ptdet and status code
  (0 - all, 1 - tagged, 2 - accepted)
- Loop over all part. jets in acceptance
Adding also the information whether the particle
level jet was in the fiducial acceptance of the
detector level jet to the response matrix.