### PR TITLE
Update SimpleTree AddTask

### DIFF
--- a/PWGDQ/dielectron/macrosLMEE/AddTaskSimpleTreeMaker.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTaskSimpleTreeMaker.C
@@ -93,7 +93,7 @@ AliAnalysisTaskSimpleTreeMaker *AddTaskSimpleTreeMaker(TString taskName    = "ML
 		}
     //Add event filter
 		task->SelectCollisionCandidates(AliVEvent::kINT7);
-    task->SetupEventCuts(cutLib->GetEventCuts(LMEECutLib::kAllSpecies));
+    task->SetupEventCuts(cutLib->GetEventCuts());
 		task->SetupTrackCuts(cutLib->GetTrackCuts(LMEECutLib::kTTreeCuts, LMEECutLib::kTTreeCuts));
 
     // ==========================================================================


### PR DESCRIPTION
All cut sets use the same event cuts, so, for clarity, now the event cut function doesn't take an argument. 