### PR TITLE
[WIP] Workaround for photon double counting issue in PYTHIA8

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalMCTrackSelector.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalMCTrackSelector.cxx
@@ -1,8 +1,29 @@
-//
-// Class to select particles in MC events.
-//
-// Author: S. Aiola
-
+/**************************************************************************************
+ * Copyright (C) 2012, Copyright Holders of the ALICE Collaboration                   *
+ * All rights reserved.                                                               *
+ *                                                                                    *
+ * Redistribution and use in source and binary forms, with or without                 *
+ * modification, are permitted provided that the following conditions are met:        *
+ *     * Redistributions of source code must retain the above copyright               *
+ *       notice, this list of conditions and the following disclaimer.                *
+ *     * Redistributions in binary form must reproduce the above copyright            *
+ *       notice, this list of conditions and the following disclaimer in the          *
+ *       documentation and/or other materials provided with the distribution.         *
+ *     * Neither the name of the <organization> nor the                               *
+ *       names of its contributors may be used to endorse or promote products         *
+ *       derived from this software without specific prior written permission.        *
+ *                                                                                    *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND    *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED      *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE             *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY                *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES         *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;       *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND        *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT         *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS      *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                       *
+ **************************************************************************************/
 #include "AliEmcalMCTrackSelector.h"
 
 #include <iostream>
@@ -21,7 +42,6 @@
 
 ClassImp(AliEmcalMCTrackSelector)
 
-//________________________________________________________________________
 AliEmcalMCTrackSelector::AliEmcalMCTrackSelector() : 
   AliAnalysisTaskSE("AliEmcalMCTrackSelector"),
   fParticlesOutName("MCParticlesSelected"),
@@ -29,6 +49,7 @@ AliEmcalMCTrackSelector::AliEmcalMCTrackSelector() :
   fRejectNK(kFALSE),
   fChargedMC(kFALSE),
   fOnlyHIJING(kFALSE),
+  fRejectPhotonMothers(false),
   fEtaMax(1),
   fParticlesMapName(""),
   fInit(kFALSE),
@@ -40,10 +61,8 @@ AliEmcalMCTrackSelector::AliEmcalMCTrackSelector() :
   fIsESD(kFALSE),
   fDisabled(kFALSE)
 {
-  // Constructor.
 }
 
-//________________________________________________________________________
 AliEmcalMCTrackSelector::AliEmcalMCTrackSelector(const char *name) : 
   AliAnalysisTaskSE(name),
   fParticlesOutName("MCParticlesSelected"),
@@ -51,6 +70,7 @@ AliEmcalMCTrackSelector::AliEmcalMCTrackSelector(const char *name) :
   fRejectNK(kFALSE),
   fChargedMC(kFALSE),
   fOnlyHIJING(kFALSE),
+  fRejectPhotonMothers(false),
   fEtaMax(1),
   fParticlesMapName(""),
   fInit(kFALSE),
@@ -62,32 +82,16 @@ AliEmcalMCTrackSelector::AliEmcalMCTrackSelector(const char *name) :
   fIsESD(kFALSE),
   fDisabled(kFALSE)
 {
-  // Constructor.
 }
 
-//________________________________________________________________________
-AliEmcalMCTrackSelector::~AliEmcalMCTrackSelector()
-{
-  // Destructor.
-}
-
-//________________________________________________________________________
-void AliEmcalMCTrackSelector::UserCreateOutputObjects()
-{
-  // Create my user objects.
-}
-
-//________________________________________________________________________
 void AliEmcalMCTrackSelector::UserExec(Option_t *) 
 {
-  // Main loop, called for each event.
-
   if (fDisabled) return;
 
   if (!fInit) {
     fEvent = InputEvent();
     if (!fEvent) {
-      AliError("Could not retrieve event! Returning");
+      AliErrorStream() << "Could not retrieve event! Returning" << std::endl;
       return;
     }
 
@@ -96,7 +100,7 @@ void AliEmcalMCTrackSelector::UserExec(Option_t *)
 
     TObject *obj = fEvent->FindListObject(fParticlesOutName);
     if (obj) { // the output array is already present in the array!
-      AliError(Form("The output array %s is already present in the event! Task will be disabled.", fParticlesOutName.Data()));
+      AliErrorStream() << "The output array "  << fParticlesOutName <<  " is already present in the event! Task will be disabled." << std::endl;
       fDisabled = kTRUE;
       return;
     }
@@ -110,7 +114,7 @@ void AliEmcalMCTrackSelector::UserExec(Option_t *)
       fParticlesMapName += "_Map";
 
       if (fEvent->FindListObject(fParticlesMapName)) {
-        AliError(Form("The output array map %s is already present in the event! Task will be disabled.", fParticlesMapName.Data()));
+        AliErrorStream() << "The output array map " << fParticlesMapName << " is already present in the event! Task will be disabled." << std::endl;
         fDisabled = kTRUE;
         return;
       }
@@ -122,13 +126,13 @@ void AliEmcalMCTrackSelector::UserExec(Option_t *)
       if (!fIsESD) {
         fParticlesIn = static_cast<TClonesArray*>(InputEvent()->FindListObject(AliAODMCParticle::StdBranchName()));
         if (!fParticlesIn) {
-          AliError("Could not retrieve AOD MC particles! Task will be disabled.");
+          AliErrorStream() << "Could not retrieve AOD MC particles! Task will be disabled." << std::endl;
           fDisabled = kTRUE;
           return;
         }
         TClass *cl = fParticlesIn->GetClass();
         if (!cl->GetBaseClass("AliAODMCParticle")) {
-          AliError(Form("%s: Collection %s does not contain AliAODMCParticle! Task will be disabled.", GetName(), AliAODMCParticle::StdBranchName()));
+          AliErrorStream() << GetName() << ": Collection  " << AliAODMCParticle::StdBranchName() << " %s does not contain AliAODMCParticle! Task will be disabled." << std::endl;
           fDisabled = kTRUE;
           fParticlesIn = 0;
           return;
@@ -138,7 +142,7 @@ void AliEmcalMCTrackSelector::UserExec(Option_t *)
 
     fMC = MCEvent();
     if (!fMC) {
-      AliError("Could not retrieve MC event! Returning");
+      AliErrorStream() << "Could not retrieve MC event! Returning" << std::endl;
       fDisabled = kTRUE;
       return;
     }
@@ -150,10 +154,8 @@ void AliEmcalMCTrackSelector::UserExec(Option_t *)
   else CopyMCParticles(fParticlesIn, fParticlesOut, fParticlesMap);
 }
 
-//________________________________________________________________________
 void AliEmcalMCTrackSelector::ConvertMCParticles(AliMCEvent* mcEvent, TClonesArray* partOut, AliNamedArrayI* partMap)
 {
-  // Convert MC particles in MC AOD articles.
 
   // clear container (normally a null operation as the event should clean it already)
   partOut->Delete();
@@ -187,6 +189,27 @@ void AliEmcalMCTrackSelector::ConvertMCParticles(AliMCEvent* mcEvent, TClonesArr
     if (mcEvent->IsSecondaryFromWeakDecay(iPart)) flag |= AliAODMCParticle::kSecondaryFromWeakDecay;
     if (mcEvent->IsSecondaryFromMaterial(iPart)) flag |= AliAODMCParticle::kSecondaryFromMaterial;
 
+    // Reject particle if is a photon and mother of another photon
+    if (fRejectPhotonMothers) {
+      if(TMath::Abs(part->PdgCode()) == 22){
+        bool hasPhotonDaughter = false;
+        // check if particle has photon daughter
+        if(part->GetFirstDaughter() > -1 && part->GetLastDaughter() > -1) {
+          for(int idaughter = part->GetFirstDaughter(); idaughter <= part->GetLastDaughter(); idaughter++) {
+            AliMCParticle *daughter = static_cast<AliMCParticle *>(mcEvent->GetTrack(idaughter));
+            if(TMath::Abs(daughter->PdgCode()) == 22) {
+              hasPhotonDaughter = true;
+              break;
+            }
+          }
+        }
+        if(hasPhotonDaughter){
+          AliDebugStream(2) << "Found photon which is the mother of another photon, not selecting ..." << std::endl; 
+          continue;
+        } 
+      }
+    }
+
     AliDebugStream(3) << "Particle " << iPart << ": pt = " << part->Pt() << ", PDG = " << part->PdgCode() <<
         ", mother " << part->GetMother() <<
         ", kPrimary? " <<  Bool_t((flag & AliAODMCParticle::kPrimary) != 0) <<
@@ -197,24 +220,25 @@ void AliEmcalMCTrackSelector::ConvertMCParticles(AliMCEvent* mcEvent, TClonesArr
         ", iPart = " << iPart <<
         std::endl;
 
-    AliAODMCParticle *aodPart = new ((*partOut)[nacc]) AliAODMCParticle(part, iPart, flag);
-    aodPart->SetGeneratorIndex(part->GetGeneratorIndex());    
-    aodPart->SetStatus(part->Particle()->GetStatusCode());
-    aodPart->SetMCProcessCode(part->Particle()->GetUniqueID());
+    // Do not put rejected particles on the output container
+    AliAODMCParticle parttmp(part, iPart, flag);
+    parttmp.SetGeneratorIndex(part->GetGeneratorIndex());    
+    parttmp.SetStatus(part->Particle()->GetStatusCode());
+    parttmp.SetMCProcessCode(part->Particle()->GetUniqueID());
 
-    if (!AcceptParticle(aodPart)) continue;    
+    if (!AcceptParticle(&parttmp)) continue;    
 
+    new ((*partOut)[nacc]) AliAODMCParticle(parttmp);
     if (partMap) partMap->AddAt(nacc, iPart);
     nacc++;
   }
 }
 
-//________________________________________________________________________
 void AliEmcalMCTrackSelector::CopyMCParticles(TClonesArray* partIn, TClonesArray* partOut, AliNamedArrayI* partMap)
 {
-  // Convert standard MC AOD particles in a new array, and filter if requested.
 
   if (!partIn) return;
+  AliDebugStream(5) << "Particles in: " << partIn->GetName() << ", out: " << partOut->GetName() << std::endl;
 
   // clear container (normally a null operation as the event should clean it already)
   partOut->Delete();
@@ -227,7 +251,7 @@ void AliEmcalMCTrackSelector::CopyMCParticles(TClonesArray* partIn, TClonesArray
     if (partMap->GetSize() <= Nparticles) partMap->Set(Nparticles*2);
   }
 
-  AliDebug(2, Form("Total number of particles = %d", Nparticles));
+  AliDebugStream(2) << "Total number of particles = " << Nparticles << std::endl;
 
   Int_t nacc = 0;
 
@@ -239,6 +263,27 @@ void AliEmcalMCTrackSelector::CopyMCParticles(TClonesArray* partIn, TClonesArray
 
     if (!AcceptParticle(part)) continue;
 
+    // Reject particle if is a photon and mother of another photon
+    if (fRejectPhotonMothers) {
+      if(TMath::Abs(part->PdgCode()) == 22){
+        bool hasPhotonDaughter = false;
+        // check if particle has photon daughter
+        if(part->GetFirstDaughter() > -1 && part->GetLastDaughter() > -1) {
+          for(int idaughter = part->GetFirstDaughter(); idaughter <= part->GetLastDaughter(); idaughter++) {
+            AliAODMCParticle *daughter = static_cast<AliAODMCParticle *>(partIn->At(idaughter));
+            if(TMath::Abs(daughter->PdgCode()) == 22) {
+              hasPhotonDaughter = true;
+              break;
+            }
+          }
+        }
+        if(hasPhotonDaughter){
+          AliDebugStream(2) << "Found photon which is the mother of another photon, not selecting ..." << std::endl; 
+          continue;
+        } 
+      }
+    }
+
     if (partMap) partMap->AddAt(nacc, iPart);
 
     AliAODMCParticle *newPart = new ((*partOut)[nacc]) AliAODMCParticle(*part);
@@ -246,13 +291,11 @@ void AliEmcalMCTrackSelector::CopyMCParticles(TClonesArray* partIn, TClonesArray
 
     nacc++;
   }
+  AliDebugStream(5) << "Particles in: " << partIn->GetEntries() << ", out: " << partOut->GetEntries() << std::endl;
 }
 
-//________________________________________________________________________
 Bool_t AliEmcalMCTrackSelector::AcceptParticle(AliAODMCParticle* part) const
 {
-  // Determine whether the MC particle is accepted.
-
   if (!part) return kFALSE;
 
   Int_t partPdgCode = TMath::Abs(part->PdgCode());
@@ -270,7 +313,6 @@ Bool_t AliEmcalMCTrackSelector::AcceptParticle(AliAODMCParticle* part) const
   return kTRUE;
 }
 
-//________________________________________________________________________
 AliEmcalMCTrackSelector* AliEmcalMCTrackSelector::AddTaskMCTrackSelector(TString outname, Bool_t nk, Bool_t ch, Double_t etamax, Bool_t physPrim)
 {
   // Get the pointer to the existing analysis manager via the static access method.

--- a/PWG/EMCAL/EMCALtasks/AliEmcalMCTrackSelector.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalMCTrackSelector.h
@@ -1,3 +1,29 @@
+/**************************************************************************************
+ * Copyright (C) 2012, Copyright Holders of the ALICE Collaboration                   *
+ * All rights reserved.                                                               *
+ *                                                                                    *
+ * Redistribution and use in source and binary forms, with or without                 *
+ * modification, are permitted provided that the following conditions are met:        *
+ *     * Redistributions of source code must retain the above copyright               *
+ *       notice, this list of conditions and the following disclaimer.                *
+ *     * Redistributions in binary form must reproduce the above copyright            *
+ *       notice, this list of conditions and the following disclaimer in the          *
+ *       documentation and/or other materials provided with the distribution.         *
+ *     * Neither the name of the <organization> nor the                               *
+ *       names of its contributors may be used to endorse or promote products         *
+ *       derived from this software without specific prior written permission.        *
+ *                                                                                    *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND    *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED      *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE             *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY                *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES         *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;       *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND        *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT         *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS      *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                       *
+ **************************************************************************************/
 #ifndef ALIEMCALMCTRAKCSELECTOR_H
 #define ALIEMCALMCTRAKCSELECTOR_H
 
@@ -10,49 +36,168 @@ class AliAODMCParticle;
 
 #include "AliAnalysisTaskSE.h"
 
+/**
+ * @class AliEmcalMCTrackSelector
+ * @brief Class to select particles in MC events.
+ * @autor Salvatore Aiola, Yale Univeristy
+ * @ingroup EMCALFWTASKS
+ * @since Aug 5, 2012
+ */
 class AliEmcalMCTrackSelector : public AliAnalysisTaskSE {
  public:
+
+  /**
+   * @brief Dummy constructor
+   */
   AliEmcalMCTrackSelector();
+
+  /**
+   * @brief Main constructor
+   * 
+   * @param name Name of the task
+   */
   AliEmcalMCTrackSelector(const char *name);
-  virtual ~AliEmcalMCTrackSelector();
+  
+  /**
+   * @brief Destructor
+   */
+  virtual ~AliEmcalMCTrackSelector() {}
 
-  void UserCreateOutputObjects();
-  void UserExec(Option_t *option);
-
+  /**
+   * @brief Select only physical primary particles
+   * @param s If true only physical primary particles are used
+   */
   void SetOnlyPhysPrim(Bool_t s)                        { fOnlyPhysPrim     = s    ; }  
+
+  /**
+   * @brief Select only charged particles
+   * @param c If true only charged particles are selected
+   */
   void SetChargedMC(Bool_t c = kTRUE)                   { fChargedMC        = c    ; }
+
+  /**
+   * @brief Set the eta acceptance
+   * @param e Maximum eta acceptance
+   */
   void SetEtaMax(Double_t e)                            { fEtaMax           = e    ; }
+
+  /**
+   * @brief Reject neutrons and K0long particles
+   * @param r If true neutrons and K0long particles are rejected
+   */
   void SetRejectNK(Bool_t r = kTRUE)                    { fRejectNK         = r    ; }
+
+  /**
+   * @brief Reject photon in case it is the mother of another photon
+   * 
+   * In order to mimic processes PYTHIA8 puts mothers and daugthers of
+   * the process on the stack, which can lead in case of photons to 
+   * double counting. Photon mothers that are duaghters of photon mothers 
+   * need to be rejected.
+   * 
+   * @param doReject If true photons are rejected if they are mothers of other photons
+   */
+  void SetRejectPhotonMother(bool doReject)             { fRejectPhotonMothers = doReject; }
+
   void SetOnlyHIJING(Bool_t s)                          { fOnlyHIJING       = s    ; }
+
+  /**
+   * @brief Set the name of the output container
+   * 
+   * This container is attached to the input event with the corresponding name. 
+   * This name has to be used in the user tasks to connect the MC particle container
+   * to the particles selected by this instance of the task.
+   * 
+   * @param name Name of the output container attached to the input event
+   */
   void SetParticlesOutName(const char *name)            { fParticlesOutName = name ; }
 
-  void                      ConvertMCParticles(AliMCEvent* mcEvent, TClonesArray* partOut, AliNamedArrayI* partMap=0);    // for ESD analysis
-  void                      CopyMCParticles(TClonesArray* partIn, TClonesArray* partOut, AliNamedArrayI* partMap=0); // for AOD analysis
-  
+
+  /**
+   * @brief Create new AliEmcalMCTrackSelector task and add it to the analysis manager
+   * 
+   * @param outname name of the output contaienr
+   * @param nk Reject neutrons and K0long
+   * @param ch Select only charged particles
+   * @param etamax  Max eta acceptance
+   * @param physPrim Require physical primary particles
+   * @return AliEmcalMCTrackSelector* 
+   */
   static AliEmcalMCTrackSelector* AddTaskMCTrackSelector(TString outname = "mcparticles", Bool_t nk = kFALSE, Bool_t ch = kFALSE, Double_t etamax = 1, Bool_t physPrim = kTRUE);
+
  protected:
+
+  /**
+   * @brief Creating user output
+   * 
+   * Not used in this task
+   */
+  void UserCreateOutputObjects() {}
+
+  /**
+   * @brief Main event loop
+   * 
+   * Run selection of particles and convert them to AliAODMCParticles and copy them
+   * to the output container. Set AliEmcalMCTrackSelector::AccpetParticle for the 
+   * definition of selected particles.
+   * 
+   * @param option Not used
+   */
+  void UserExec(Option_t *option);
+
+  /**
+   * @brief Check whether paricle is selected
+   * 
+   * Acceptance criteria:
+   * - Physical primary
+   * - Charged / neutral
+   * - Is neutron or K0long
+   * - Eta range
+   * - Generator index (for HIJING prodctions)
+   * 
+   * @param part Particle to be checked
+   * @return True if the particle is accepted, false otherwise
+   */
   virtual Bool_t            AcceptParticle(AliAODMCParticle* part) const;
+
+  /**
+   * @brief Convert MC particles in MC AOD articles (for ESD analysis).
+   * @param mcEvent Input event
+   * @param partOut Output particle container with selected particles
+   * @param partMap 
+   */
+  void                      ConvertMCParticles(AliMCEvent* mcEvent, TClonesArray* partOut, AliNamedArrayI* partMap=0);
+
+  /**
+   * @brief Convert standard MC AOD particles in a new array, and filter if requested (for AOD analysis).
+   * @param partIn Input particle container
+   * @param partOut Output particle container with selected particles
+   * @param partMap Index map between particles in input and output container
+   */
+  void                      CopyMCParticles(TClonesArray* partIn, TClonesArray* partOut, AliNamedArrayI* partMap=0);
   
-  TString                   fParticlesOutName;     // name of output particle array
-  Bool_t                    fOnlyPhysPrim;         // true = only physical primary particles
-  Bool_t                    fRejectNK;             // true = reject K_0^L and neutrons
-  Bool_t                    fChargedMC;            // true = only charged particles
-  Bool_t                    fOnlyHIJING;           // true = only HIJING particles
-  Double_t                  fEtaMax;               // maximum eta to accept particles
-  TString                   fParticlesMapName;     //!name of the particle map
-  Bool_t                    fInit;                 //!true = task initialized
-  TClonesArray             *fParticlesIn;          //!particle array in (AOD)
-  TClonesArray             *fParticlesOut;         //!particle array out
-  AliNamedArrayI           *fParticlesMap;         //!particle index/label
-  AliVEvent                *fEvent;                //!event
-  AliMCEvent               *fMC;                   //!MC event (ESD)
-  Bool_t                    fIsESD;                //!ESD or AOD analysis
-  Bool_t                    fDisabled;             //!Disable task if a problem occurs at initialization
+  
+  TString                   fParticlesOutName;     ///< name of output particle array
+  Bool_t                    fOnlyPhysPrim;         ///< true = only physical primary particles
+  Bool_t                    fRejectNK;             ///< true = reject K_0^L and neutrons
+  Bool_t                    fChargedMC;            ///< true = only charged particles
+  Bool_t                    fOnlyHIJING;           ///< true = only HIJING particles
+  Bool_t                    fRejectPhotonMothers;  ///< Reject photons that are mothers of other photons
+  Double_t                  fEtaMax;               ///< maximum eta to accept particles
+  TString                   fParticlesMapName;     //!<! name of the particle map
+  Bool_t                    fInit;                 //!<! true = task initialized
+  TClonesArray             *fParticlesIn;          //!<! particle array in (AOD)
+  TClonesArray             *fParticlesOut;         //!<! particle array out
+  AliNamedArrayI           *fParticlesMap;         //!<! particle index/label
+  AliVEvent                *fEvent;                //!<! event
+  AliMCEvent               *fMC;                   //!<! MC event (ESD)
+  Bool_t                    fIsESD;                //!<! ESD or AOD analysis
+  Bool_t                    fDisabled;             //!<! Disable task if a problem occurs at initialization
 
  private:
   AliEmcalMCTrackSelector(const AliEmcalMCTrackSelector&);            // not implemented
   AliEmcalMCTrackSelector &operator=(const AliEmcalMCTrackSelector&); // not implemented
 
-  ClassDef(AliEmcalMCTrackSelector, 5); // Task to select particle in MC events
+  ClassDef(AliEmcalMCTrackSelector, 5); 
 };
 #endif


### PR DESCRIPTION
Use AliEmcalMCTrackSelector in order to reject photons
that are the mothers of other photons. The track selector
task needs to run in this case also for AOD analyses
as otherwise it cannot be guaranteed that the mother
photons are removed before.