### PR TITLE
EMCal Embed: Validate physics selection

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
@@ -552,7 +552,7 @@ bool AliAnalysisTaskEmcalEmbeddingHelper::GetFilenames()
 }
 
 /**
- * Determine the Pythia cross section filename by checking for the existance of files with various possible filenames.
+ * Determine the Pythia cross section filename by checking for the existence of files with various possible filenames.
  * Note that it uses the first input filename as a proxy for all other input files following the same pattern.
  */
 void AliAnalysisTaskEmcalEmbeddingHelper::DeterminePythiaXSecFilename()
@@ -719,9 +719,9 @@ bool AliAnalysisTaskEmcalEmbeddingHelper::AutoConfigurePtHardBins()
       config.WriteProperty(propertyName.str(), trainNumber, fAutoConfigureIdentifier);
       config.WriteConfiguration(filename, fAutoConfigureIdentifier);
 
-      // NOTE: Cannot clean up the yaml file on the last pt hard bin because the train can be launched
+      // NOTE: Cannot clean up the YAML file on the last pt hard bin because the train can be launched
       // multiple times due to tests, etc. Therefore, we have to accept that we are leaving around used
-      // yaml config files.
+      // YAML config files.
 
       // We are done - continue on.
       returnValue = true;
@@ -771,7 +771,7 @@ std::string AliAnalysisTaskEmcalEmbeddingHelper::GenerateUniqueFileListFilename(
  *
  * @param[in] filename String containing a filename with some number of extra trailing slashes.
  *
- * @return string without trailing slahes.
+ * @return string without trailing slashes.
  */
 std::string AliAnalysisTaskEmcalEmbeddingHelper::RemoveTrailingSlashes(std::string filename) const
 {
@@ -834,12 +834,13 @@ Bool_t AliAnalysisTaskEmcalEmbeddingHelper::GetNextEntry()
     }
     else {
       // NOTE: On transition from one file to the next, this calls the next entry that would be expected.
-      //       However, if it is for the last file, it tries to GetEntry() of one entry past the end of the last file.
-      //       Normally, this would be a problem, however GetEntry() just doesn't fill the fields of an invalid index
-      //       instead of throwing an error. So "invalid values" are filled for a file that doesn't exist, but then 
-      //       they are immediately replaced by the lines below that reset the access values and re-init the tree.
-      //       The benefit of this approach is it simplies file counting (we don't need to carefully increment here
-      //       and in InitTree()) and preserves the desired behavior when we are not at the last file.
+      //       However, if it is for the last file, it tries to GetEntry() of one entry past the end of the last
+      //       file. Normally, this would be a problem, however GetEntry() just doesn't fill the fields of an
+      //       invalid index instead of throwing an error. So "invalid values" are filled for a file that doesn't
+      //       exist, but then they are immediately replaced by the lines below that reset the access values and
+      //       re-init the tree. The benefit of this approach is it simplies file counting (we don't need to
+      //       carefully increment here and in InitTree()) and preserves the desired behavior when we are not at
+      //       the last file.
       InitTree();
     }
 
@@ -1436,7 +1437,7 @@ void AliAnalysisTaskEmcalEmbeddingHelper::InitTree()
   }
   
   // Load first entry of the (next) file so that we can query information about it
-  // (it is unaccessible otherwise).
+  // (it is inaccessible otherwise).
   // Since fUpperEntry is the total number of entries, loading it will retrieve the
   // next tree (in the next file) since entries are indexed starting from 0.
   fChain->GetEntry(fUpperEntry);
@@ -1541,7 +1542,7 @@ bool AliAnalysisTaskEmcalEmbeddingHelper::PythiaInfoFromCrossSectionFile(std::st
     }
     else {
       // Check if it's instead the histograms
-      // find the tlist we want to be independtent of the name so use the Tkey
+      // find the Tlist we want to be independent of the name so use the Tkey
       TKey* key = static_cast<TKey*>(fxsec->GetListOfKeys()->At(0));
       if (!key) return false;
       TList *list = dynamic_cast<TList*>(key->ReadObj());
@@ -1549,7 +1550,7 @@ bool AliAnalysisTaskEmcalEmbeddingHelper::PythiaInfoFromCrossSectionFile(std::st
       TProfile * crossSectionHist = static_cast<TProfile*>(list->FindObject("h1Xsec"));
       // check for failure
       if(!(crossSectionHist->GetEntries())) {
-        // No cross seciton information available - fall back to raw
+        // No cross section information available - fall back to raw
         AliErrorStream() << "No cross section information available in file \"" << fxsec->GetName() << "\". Will still attempt to extract cross section information from pythia header.\n";
       } else {
         // Cross section histogram filled - take it from there
@@ -1561,7 +1562,7 @@ bool AliAnalysisTaskEmcalEmbeddingHelper::PythiaInfoFromCrossSectionFile(std::st
       nEvents = trialsHist->GetEntries();
     }
 
-    // If successful in retrieveing the values, normalizae the xsec and trials by the number of events
+    // If successful in retrieving the values, normalize the xsec and trials by the number of events
     // in the file. This way, we can use it as an approximate event-by-event value
     // We do not want to just use the overall value because some of the events may be rejected by various
     // event selections, so we only want that ones that were actually use. The easiest way to do so is by
@@ -1573,7 +1574,7 @@ bool AliAnalysisTaskEmcalEmbeddingHelper::PythiaInfoFromCrossSectionFile(std::st
     return true;
   }
   else {
-    AliDebugStream(3) << "Unable to open file \"" << pythiaFileName << "\". Will attempt to use values from the hader.";
+    AliDebugStream(3) << "Unable to open file \"" << pythiaFileName << "\". Will attempt to use values from the header.";
   }
 
   // Could not open file
@@ -1737,7 +1738,7 @@ void AliAnalysisTaskEmcalEmbeddingHelper::Terminate(Option_t*)
 
 /**
  * Remove the dummy task which had to be added by ConfigureEmcalEmbeddingHelperOnLEGOTrain()
- * from the Analysis Mangaer. This is the same function as in AliEmcalCorrectionTask.
+ * from the Analysis Manager. This is the same function as in AliEmcalCorrectionTask.
  */
 void AliAnalysisTaskEmcalEmbeddingHelper::RemoveDummyTask() const
 {

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
@@ -329,6 +329,8 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   bool                                 fUseManualInternalEventCuts; ///<  If true, manual event cuts mode will be used for AliEventCuts
   AliEventCuts                                  fInternalEventCuts; ///<  If enabled, Handles internal event selection
   bool                                          fEmbeddedEventUsed; //!<! If true, the internal event was selected, so the embedded event is used. Defaults to true so other tasks are not disrupted if internal event selection is disabled.
+  bool                                  fValidatedPhysicsSelection; ///<  Validate that the physics selection is set appropriately.
+  UInt_t                                 fInternalEventTriggerMask; ///<  Internal event physics selection (trigger mask) to be used with AliEventCuts.
   double                                        fCentMin          ; ///<  Minimum centrality for internal event selection
   double                                        fCentMax          ; ///<  Maximum centrality for internal event selection
   Double_t                                      fRandomRejectionFactor; ///< factor by which to reject events
@@ -378,7 +380,7 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   AliAnalysisTaskEmcalEmbeddingHelper &operator=(const AliAnalysisTaskEmcalEmbeddingHelper&); // not implemented
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskEmcalEmbeddingHelper, 11);
+  ClassDef(AliAnalysisTaskEmcalEmbeddingHelper, 12);
   /// \endcond
 };
 #endif

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.h
@@ -300,6 +300,8 @@ class AliAnalysisTaskEmcalEmbeddingHelper : public AliAnalysisTaskSE {
   Bool_t          InitEvent()           ;
   void            InitTree()            ;
   bool            PythiaInfoFromCrossSectionFile(std::string filename);
+  // Validation helper
+  void            ValidatePhysicsSelectionForInternalEventSelection();
   // Helper functions
   bool            IsFileAccessible() const;
   void            ConnectToAliEn() const;

--- a/PWG/EMCAL/READMEemcEmbedding.txt
+++ b/PWG/EMCAL/READMEemcEmbedding.txt
@@ -373,9 +373,9 @@ In addition to the information below, in terms of best practices for the user, a
 are a few additional points which should be checked:
 - Check that all of the embedding helper histograms look reasonable.
 - Check the train number to pt hard bin map provides the correct mapping, as described [below](\ref emcEmbeddingAutoConfigurePtHard).
-- If ]internal event selection](\ref emcEmbeddingEventSelection) is enabled (it is highly recommended), check
+- If [internal event selection](\ref emcEmbeddingEventSelection) is enabled (it is highly recommended), check
   that embedded event recycling is properly enabled for every task. This is easiest to do by looking at the event
-  rejection histogra. If even just one task is missed, it will negate the performance benefits for the entire train.
+  rejection histogram. If even just one task is missed, it will negate the performance benefits for the entire train.
 
 ## Configuring the LEGO Train Wagon                                         {#emcEmbeddingLEGOTrainWagon}
 
@@ -440,10 +440,12 @@ as well as define the base and train type paths, such that all you need to do is
 
 # Optimization of Event Selection and Computing                                 {#emcEmbeddingEventSelection}
 
+**It is highly recommended to follow the advice of this section. It will often substantially improve performance!**
+
 It is important to take care when applying event selection during embedding. For example, if the embedding helper
 is run with `AliVEvent::kAny`, but your task is run with `AliVEvent::kAnyINT`, some good embedded events will be
 missed because the physics selection of your task is more restrictive. There are two parts to solution to this issue.
-First, it is best to have the same collision candidates for the embedding helper and all other tasks.
+As a start, it is best to have the same collision candidates for the embedding helper and all other tasks.
 
 While this is a good start, it is not sufficient in all cases, such as selecting on centrality. To address this
 issue, the embedding helper allows for more complicated internal event selection via AliEventCuts (disabled by default).
@@ -482,7 +484,7 @@ embeddingHelper->SetUseInternalEventSelection(true);
 // Use manual event cuts
 embeddingHelper->SetUseManualInternalEventCuts(true);
 auto eventCuts = embeddingHelper->GetInternalEventCuts();
-eventCuts->SetupLHC11h();
+eventCuts->SetupRun1PbPb();
 // Use 0-10%
 eventCuts->SetCentralityRange(0, 10);
 ~~~

--- a/PWG/EMCAL/READMEemcEmbedding.txt
+++ b/PWG/EMCAL/READMEemcEmbedding.txt
@@ -469,7 +469,8 @@ calling `%Setup{Period}()` for the event cuts object) and then configure it via 
 notable exception. Additional centrality selection is implemented in the embedding helper. To use it, simply set the
 centrality range ("internalEventSelection:centralityRange" in YAML or via SetCentralityRange(min, max)). Note that if
 a centrality range is set in AliEventCuts (for example, through the automatic setup), that range must be wider than or
-equal to the range in the embedding helper for the embedding helper setting to be meaningful.
+equal to the range in the embedding helper for the embedding helper setting to be meaningful. Physics selection of
+the `AliEventCuts` object can also be configured via YAML.
 
 Alternatively, the user may use manual cuts in AliEventCuts, configure it for a particular period, and then set the
 centrality range in AliEventCuts and disregard the centrality selection capabilities in the embedding helper. In code,


### PR DESCRIPTION
If other analysis tasks have broader physics selections than the embedding helper, then those other tasks can access an already used embedding event when the task is selected and the embedding helper isn't. To address this, the embedding helper will checks the other tasks connected to the analysis manager and throws an error if:

- The internal physics selection is broader than the embedding helper physics selection.
- Any other task has a broader physics selection than the embedding helper.

This should ensure that the are no events should are selected for other tasks, but not the embedding helper. It will now also require explicit configuration of the internal physics selection if not using the automatic physics selection from AliEventCuts. This will ensure that it isn't changed unexpectedly.

I tested this in a variety of scenarios, and it seems to work as expected.

cc: @jdmulligan 