### PR TITLE
PWGUD/UPC: Added bin migration matrix and code for the helicity analysis of J/Psi.

### DIFF
--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
@@ -163,7 +163,11 @@ AliAnalysisTaskUPCforwardMC::AliAnalysisTaskUPCforwardMC()
       fBBAFlagsAD(0),
       fBBCFlagsAD(0),
       fBGAFlagsAD(0),
-      fBGCFlagsAD(0)
+      fBGCFlagsAD(0),
+      fVectorCosThetaGenerated(0),
+      fVectorCosThetaReconstructed(0),
+      fCounterUPCevent(0),
+      fBinMigrationHelicityH(0)
 {
     // default constructor, don't allocate memory here!
     // this is used by root for IO purposes, it needs to remain empty
@@ -252,7 +256,11 @@ AliAnalysisTaskUPCforwardMC::AliAnalysisTaskUPCforwardMC( const char* name )
       fBBAFlagsAD(0),
       fBBCFlagsAD(0),
       fBGAFlagsAD(0),
-      fBGCFlagsAD(0)
+      fBGCFlagsAD(0),
+      fVectorCosThetaGenerated(0),
+      fVectorCosThetaReconstructed(0),
+      fCounterUPCevent(0),
+      fBinMigrationHelicityH(0)
 {
     FillGoodRunVector(fVectorGoodRunNumbers);
 
@@ -423,6 +431,9 @@ void AliAnalysisTaskUPCforwardMC::UserCreateOutputObjects()
   fAngularDistribOfNegativeMuonRestFrameJPsiH = new TH1F("fAngularDistribOfNegativeMuonRestFrameJPsiH", "fAngularDistribOfNegativeMuonRestFrameJPsiH", 1000, -1., 1.);
   fOutputList->Add(fAngularDistribOfNegativeMuonRestFrameJPsiH);
 
+  fBinMigrationHelicityH = new TH2F("fBinMigrationHelicityH", "fBinMigrationHelicityH", 1000, -1., 1., 1000, -1., 1.);
+  fOutputList->Add(fBinMigrationHelicityH);
+
 
   //_______________________________
   // - MC-only plots
@@ -519,6 +530,7 @@ void AliAnalysisTaskUPCforwardMC::UserExec(Option_t *)
   }
   if(fMCEvent) {
     ProcessMCParticles(fMCEvent);
+    fCounterUPCevent += 1;
   }
   /* - We are now checking if there were any tracks. If there were at least one,
      - then the histogram gets filled again. If not we are returning. There
@@ -932,6 +944,19 @@ void AliAnalysisTaskUPCforwardMC::UserExec(Option_t *)
   }
   fAngularDistribOfPositiveMuonRestFrameJPsiH->Fill(cosThetaMuonsRestFrame[0]);
   fAngularDistribOfNegativeMuonRestFrameJPsiH->Fill(cosThetaMuonsRestFrame[1]);
+  fVectorCosThetaReconstructed.push_back(cosThetaMuonsRestFrame[0]);
+  /* - Mind that it could generate segmentation fault without
+     - fCounterUPCevent-1, because we are incrementing the counter right after
+     - it processes the MC events at Generated level...
+     -
+   */
+  if ( fVectorCosThetaGenerated.at(fCounterUPCevent-1) && cosThetaMuonsRestFrame[0] ) {
+        fBinMigrationHelicityH->Fill( fVectorCosThetaGenerated.at(fCounterUPCevent-1),
+                                      cosThetaMuonsRestFrame[0]
+                                    );
+  }
+
+
 
 
   // post the data
@@ -1084,9 +1109,11 @@ void AliAnalysisTaskUPCforwardMC::ProcessMCParticles(AliMCEvent* fMCEventArg)
                */
               fMCthetaDistribOfPositiveMuonRestFrameJPsiGeneratedTruthH->Fill(cosThetaMuonsRestFrameMC[0]);
               fMCthetaDistribOfNegativeMuonRestFrameJPsiGeneratedTruthH->Fill(cosThetaMuonsRestFrameMC[1]);
+              fVectorCosThetaGenerated.push_back(cosThetaMuonsRestFrameMC[0]);
       } else  {
               fMCthetaDistribOfNegativeMuonRestFrameJPsiGeneratedTruthH->Fill(cosThetaMuonsRestFrameMC[0]);
               fMCthetaDistribOfPositiveMuonRestFrameJPsiGeneratedTruthH->Fill(cosThetaMuonsRestFrameMC[1]);
+              fVectorCosThetaGenerated.push_back(cosThetaMuonsRestFrameMC[1]);
       }
     }
   }

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
@@ -249,7 +249,7 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
                                  * J/Psi. This histogram is needed to evaluate
                                  * the polarization of the J/Psi!
                                  */
-        TH1F*                   fAngularDistribOfPositiveMuonRestFrameJPsiH;
+        TH1F*                   fAngularDistribOfPositiveMuonRestFrameJPsiH;      //!
 
                                 /**
                                  * This histogram shows the angular distribution
@@ -257,7 +257,7 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
                                  * J/Psi. This histogram is needed to evaluate
                                  * the polarization of the J/Psi!
                                  */
-        TH1F*                   fAngularDistribOfNegativeMuonRestFrameJPsiH;
+        TH1F*                   fAngularDistribOfNegativeMuonRestFrameJPsiH;      //!
 
         //_______________________________
         // MC TRUTH PLOTS
@@ -265,69 +265,69 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
                                  * This histogram records the pdgCodes of all
                                  * the MC GENERATED particles...
                                  */
-        TH1F*                   fMCpdgCodesH;
+        TH1F*                   fMCpdgCodesH;           //!
 
                                 /**
                                  * This histogram records the pdgCodes of all
                                  * the MC GENERATED PRIMARY particles...
                                  */
-        TH1F*                   fMCpdgCodesOnlyPrimaryH;
+        TH1F*                   fMCpdgCodesOnlyPrimaryH;           //!
 
         // MC TRUTH GENERATED FEATURES
                                 /**
                                  * This histogram records the PHI of all
                                  * the MC GENERATED particles...
                                  */
-        TH1F*                   fMCphiGeneratedTruthH;
+        TH1F*                   fMCphiGeneratedTruthH;           //!
 
                                 /**
                                  * This histogram records the ETA of all
                                  * the MC GENERATED PRIMARY particles...
                                  */
-        TH1F*                   fMCetaGeneratedTruthH;
+        TH1F*                   fMCetaGeneratedTruthH;           //!
 
                                 /**
                                  * This histogram records the PSEUDORAPIDITY of
                                  * all the MC GENERATED PRIMARY particles...
                                  */
-        TH1F*                   fMCpseudorapidityGeneratedTruthH;
+        TH1F*                   fMCpseudorapidityGeneratedTruthH;           //!
 
                                 /**
                                  * This histogram records the Pt of all
                                  * the MC GENERATED particles...
                                  */
-        TH1F*                   fMCptGeneratedTruthH;
+        TH1F*                   fMCptGeneratedTruthH;           //!
 
         // MC TRUTH GENERATED DIMUONS FEATURES
                                 /**
                                  * This histogram records the PHI of all
                                  * the MC GENERATED muons of the J/Psi...
                                  */
-        TH1F*                   fMCphiDimuonGeneratedTruthH;
+        TH1F*                   fMCphiDimuonGeneratedTruthH;           //!
 
                                 /**
                                  * This histogram records the ETA of all
                                  * the MC GENERATED muons of the J/Psi...
                                  */
-        TH1F*                   fMCetaDimuonGeneratedTruthH;
+        TH1F*                   fMCetaDimuonGeneratedTruthH;           //!
 
                                 /**
                                  * This histogram records the PSEUDORAPIDITY of
                                  * all the MC GENERATED muons of the J/Psi...
                                  */
-        TH1F*                   fMCpseudorapidityDimuonGeneratedTruthH;
+        TH1F*                   fMCpseudorapidityDimuonGeneratedTruthH;           //!
 
                                 /**
                                  * This histogram records the Pt of all
                                  * the MC GENERATED muons of the J/Psi...
                                  */
-        TH1F*                   fMCptDimuonGeneratedTruthSingleMuonsH;
+        TH1F*                   fMCptDimuonGeneratedTruthSingleMuonsH;           //!
 
                                 /**
                                  * This histogram records the Pt of all
                                  * the MC GENERATED J/Psi.
                                  */
-        TH1F*                   fMCptDimuonGeneratedTruthH;
+        TH1F*                   fMCptDimuonGeneratedTruthH;           //!
 
 
 
@@ -339,14 +339,14 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
                                  * before EVENT and TRACK selection for the MC
                                  * (aka GENERATED).
                                  */
-        TH1F*                   fMCinvariantMassDistrJPsiGeneratedTruthH;
+        TH1F*                   fMCinvariantMassDistrJPsiGeneratedTruthH;           //!
 
                                 /**
                                  * Invariant Mass Distribution of the J/Psi
                                  * after EVENT and TRACK selection for the MC
                                  * WITH MC TRUTH.
                                  */
-        TH1F*                   fMCinvariantMassDistrJPsiAfterEvtAndTrkSelectionTruthH;
+        TH1F*                   fMCinvariantMassDistrJPsiAfterEvtAndTrkSelectionTruthH;           //!
 
                                 /**
                                  * This histogram shows the angular distribution
@@ -354,7 +354,7 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
                                  * J/Psi. This histogram is needed to evaluate
                                  * the polarization of the J/Psi!
                                  */
-        TH1F*                   fMCthetaDistribOfPositiveMuonRestFrameJPsiGeneratedTruthH;
+        TH1F*                   fMCthetaDistribOfPositiveMuonRestFrameJPsiGeneratedTruthH;           //!
 
                                 /**
                                  * This histogram shows the angular distribution
@@ -362,7 +362,60 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
                                  * J/Psi. This histogram is needed to evaluate
                                  * the polarization of the J/Psi!
                                  */
-        TH1F*                   fMCthetaDistribOfNegativeMuonRestFrameJPsiGeneratedTruthH;
+        TH1F*                   fMCthetaDistribOfNegativeMuonRestFrameJPsiGeneratedTruthH;           //!
+
+                                /**
+                                 * This is the vector containing the GENERATED
+                                 * values of the cos(theta). It should be
+                                 * needed for the "bin migration" study...
+                                 * As far as I can imagine, in each event there
+                                 * should only be a single J/Psi because these
+                                 * are all UPC events, as such I should record
+                                 * all possible values for cos(theta) and plot
+                                 * only when the corresponding J/Psi falls
+                                 * inside the detector acceptance...
+                                 * The resulting plot should be TH2F and be like
+                                 * a lego plot. See for an example:
+                                 *https://www.researchgate.net/figure/The-migration-matrix-for-leading-p-jet-T-Element-i-j-is-the-probability-for-a-particle_fig1_222896619
+                                 */
+        std::vector<Double_t>   fVectorCosThetaGenerated;           //!
+
+                                /**
+                                 * This is the vector containing the
+                                 * RECONSTRUCTED
+                                 * values of the cos(theta). It should be
+                                 * needed for the "bin migration" study...
+                                 * Actually if I fill everytime the TH2F
+                                 * as soon as I compute the cos(theta)
+                                 * there should be no real need for it...
+                                 * The only thing that matters is a counter to
+                                 * give me the proper value of the vector for
+                                 * the generated value I should consider inside
+                                 * the vector of the GENERATED level.
+                                 * It is important to remember there is at MOST
+                                 * a single J/Psi for UPC event!!!
+                                 */
+        std::vector<Double_t>   fVectorCosThetaReconstructed;           //!
+
+                                /**
+                                 * Counter for the UPC events to access vectors.
+                                 * The only thing that matters is a counter to
+                                 * give me the proper value of the vector for
+                                 * the generated value I should consider inside
+                                 * the vector of the GENERATED level.
+                                 * It is important to remember there is at MOST
+                                 * a single J/Psi for UPC event!!!
+                                 */
+        Int_t                   fCounterUPCevent;           //!
+
+                                /**
+                                 * This histogram shows the bin migration for
+                                 * the helicity Analysis...
+                                 */
+        TH2F*                   fBinMigrationHelicityH;           //!
+
+
+
 
 
 


### PR DESCRIPTION
Added bin migration matrix and code for the helicity analysis of J/Psi. The concerned files are those of the MC study, hence AliAnalysisTaskUPCforwardMC.{h, cxx}. 
IMPORTANT: the code has been tested on local. The bin migration trend is linear as expected, possibly very mild bin migration effect in Coherent J/Psi to dimuon.