### PR TITLE
Store previous event selection and embedded status

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHPerformance.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHPerformance.h
@@ -106,6 +106,8 @@ class AliAnalysisTaskEmcalJetHPerformance : public AliAnalysisTaskEmcalJet {
 
   // QA variables
   std::string fEmbeddedCellsName;     ///<  Set the embedded cells collection name
+  UInt_t fPreviousEventTrigger;       ///<  Physics selection (offline trigger) of the previous event for determine why a small unumber of embedded event are double counted.
+  bool fPreviousEmbeddedEventSelected;///<  True if the previous embedded event was selected. Used to determine why a small unumber of embedded event are double counted.
 
   // Response matrix variables
   // Response matrix fill map
@@ -120,7 +122,7 @@ class AliAnalysisTaskEmcalJetHPerformance : public AliAnalysisTaskEmcalJet {
   double fMinFractionShared;             ///<  Minimum fraction of shared jet pt required for matching a hybrid jet to detector level
   AliAnalysisTaskEmcalJetHUtils::ELeadingHadronBiasType_t fLeadingHadronBiasType; ///<  Leading hadron in jet bias type (either charged, neutral, or both)
 
-  ClassDef(AliAnalysisTaskEmcalJetHPerformance, 3);
+  ClassDef(AliAnalysisTaskEmcalJetHPerformance, 4);
 };
 
 } /* namespace EMCALJetTasks */


### PR DESCRIPTION
Allows us to keep track of rare doubly corrected embedded events