### PR TITLE
PWGUD/UPC: Added rapidity study for helicity J/Psi and templates for Pt-fit.

### DIFF
--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.h
@@ -98,9 +98,6 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
         AliMuonTrackCuts*       fMuonTrackCuts;
 
 
-
-        // Bool_t                  CheckIfPassedCuts(vector<>)
-
     protected:
 
                                 /// The input events for the analysis.
@@ -133,13 +130,12 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * As far as I understand, it should be the
                                  * pseudorapidity distribution of the many muons.
                                  */
-	      TH1F*                   fEtaMuonH;          //!
+        TH1F*                   fEtaMuonH;          //!
 
                                 /**
                                  *
                                  */
-	      TH1F*                   fRAbsMuonH;         //!
-
+        TH1F*                   fRAbsMuonH;         //!
 
                                 /**
                                  * This histogram records the invariant mass
@@ -484,6 +480,23 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * the polarization of the J/Psi!
                                  */
         TH1F*                   fAngularDistribOfNegativeMuonRestFrameJPsiH;
+
+                                /**
+                                 * This histogram represents the check over
+                                 * the helicity of the J/Psi. It should be flat
+                                 * if I remember well enough!
+                                 */
+        TH1F*                   fCheckHelicityRestFrameJPsiH;
+
+                                /**
+                                 * This histogram shows the angular distribution
+                                 * of the positive muon in the rest frame of the
+                                 * J/Psi. This histogram is needed to evaluate
+                                 * the polarization of the J/Psi! Divided in
+                                 * psudorapidity bins... 8??
+                                 */
+        TH1F*                   fThetaDistribOfPositiveMuonRestFrameJPsiRapidityBinH[8];
+
 
 
         // END DIFFERENTIAL NEUTRON EMISSION PLOTS

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
@@ -96,6 +96,7 @@ AliAnalysisTaskUPCforwardMC::AliAnalysisTaskUPCforwardMC()
       fInvariantMassDistributionCoherentH(0),
       fInvariantMassDistributionIncoherentH(0),
       fDimuonPtDistributionH(0),
+      fTemplatePtDistributionH(0),
       fDcaAgainstInvariantMassH(0),
       fInvariantMassDistributionExtendedH(0),
       fInvariantMassDistributionCoherentExtendedH(0),
@@ -192,6 +193,7 @@ AliAnalysisTaskUPCforwardMC::AliAnalysisTaskUPCforwardMC( const char* name )
       fInvariantMassDistributionCoherentH(0),
       fInvariantMassDistributionIncoherentH(0),
       fDimuonPtDistributionH(0),
+      fTemplatePtDistributionH(0),
       fDcaAgainstInvariantMassH(0),
       fInvariantMassDistributionExtendedH(0),
       fInvariantMassDistributionCoherentExtendedH(0),
@@ -411,6 +413,9 @@ void AliAnalysisTaskUPCforwardMC::UserCreateOutputObjects()
 
   fDimuonPtDistributionH = new TH1F("fDimuonPtDistributionH", "fDimuonPtDistributionH", 2000, 0, 20);
   fOutputList->Add(fDimuonPtDistributionH);
+
+  fTemplatePtDistributionH = new TH1F("fTemplatePtDistributionH", "fTemplatePtDistributionH", 2000, 0, 20);
+  fOutputList->Add(fTemplatePtDistributionH);
 
   fDcaAgainstInvariantMassH = new TH2F("fDcaAgainstInvariantMassH", "fDcaAgainstInvariantMassH", 4000, 0, 40, 2000, -100, 100);
   fOutputList->Add(fDcaAgainstInvariantMassH);
@@ -934,6 +939,7 @@ void AliAnalysisTaskUPCforwardMC::UserExec(Option_t *)
         fInvariantMassDistributionIncoherentExtendedH->Fill(possibleJPsi.Mag());
   }
   fDimuonPtDistributionH->Fill(ptOfTheDimuonPair);
+  if ( (possibleJPsi.Mag() > 2.8) && (possibleJPsi.Mag() < 3.3) ) fTemplatePtDistributionH->Fill(ptOfTheDimuonPair);
 
 
   /* - Filling the J/Psi's polarization plots.

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
@@ -202,6 +202,14 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
         TH1F*                   fDimuonPtDistributionH;         //!
 
                                 /**
+                                 * This histogram records the pt-ditribution
+                                 * of the dimuon pairs. This is the template
+                                 * to be used for the Pt-distribution fit.
+                                 */
+        TH1F*                   fTemplatePtDistributionH;         //!
+
+
+                                /**
                                  * This histogram records the invariant mass
                                  * distribution of the dimuon system, but the
                                  * novelty is the use of a different method to

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
@@ -83,14 +83,14 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
                                  * parameters at each new runs. Sets the run
                                  * number for the successive cuts.
                                  */
-        virtual void   			    NotifyRun();
+        virtual void            NotifyRun();
 
                                 /**
                                  * This will fill the vector containing the good
                                  * run numbers. For now this function will be
                                  * inside the constructor of the class.
                                  */
-        void   			            FillGoodRunVector(std::vector<Int_t> &fVectorGoodRunNumbers);
+        void                    FillGoodRunVector(std::vector<Int_t> &fVectorGoodRunNumbers);
 
                                 /**
                                  * This function substitutes the roel of the
@@ -111,11 +111,8 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
                                  * Use the class as a data member. It contains
                                  * the cuts for the muon track.
                                  */
-        AliMuonTrackCuts* 		  fMuonTrackCuts;
+        AliMuonTrackCuts*       fMuonTrackCuts;
 
-
-
-        // Bool_t                  CheckIfPassedCuts(vector<>)
 
     private:
 
@@ -155,12 +152,12 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
                                  * As far as I understand, it should be the
                                  * pseudorapidity distribution of the many muons.
                                  */
-	      TH1F*                   fEtaMuonH;          //!
+        TH1F*                   fEtaMuonH;          //!
 
                                 /**
                                  *
                                  */
-	      TH1F*                   fRAbsMuonH;         //!
+        TH1F*                   fRAbsMuonH;         //!
 
                                 /**
                                  * This histogram records the invariant mass
@@ -258,6 +255,23 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
                                  * the polarization of the J/Psi!
                                  */
         TH1F*                   fAngularDistribOfNegativeMuonRestFrameJPsiH;      //!
+
+                                /**
+                                 * This histogram represents the check over
+                                 * the helicity of the J/Psi. It should be flat
+                                 * if I remember well enough!
+                                 */
+        TH1F*                   fCheckHelicityRestFrameJPsiH;
+
+                                /**
+                                 * This histogram shows the angular distribution
+                                 * of the positive muon in the rest frame of the
+                                 * J/Psi. This histogram is needed to evaluate
+                                 * the polarization of the J/Psi! Divided in
+                                 * psudorapidity bins... 8??
+                                 */
+        TH1F*                   fThetaDistribOfPositiveMuonRestFrameJPsiRapidityBinH[8];
+
 
         //_______________________________
         // MC TRUTH PLOTS
@@ -363,6 +377,15 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
                                  * the polarization of the J/Psi!
                                  */
         TH1F*                   fMCthetaDistribOfNegativeMuonRestFrameJPsiGeneratedTruthH;           //!
+
+                                /**
+                                 * This histogram shows the angular distribution
+                                 * of the positive muon in the rest frame of the
+                                 * J/Psi. This histogram is needed to evaluate
+                                 * the polarization of the J/Psi! Divided in
+                                 * psudorapidity bins... 8??
+                                 */
+        TH1F*                   fMCthetaDistribOfPositiveMuonRestFrameJPsiGeneratedTruthRapidityBinH[8];
 
                                 /**
                                  * This is the vector containing the GENERATED


### PR DESCRIPTION
Changes involve my analysis tasks, so AliAnalysisTaskUPCforward{MC}.{ h. cxx }. Added the rapidity study for the helicity of the J/Psi. This is to check whether there are scarcely populated regions in acceptance and potentially exclude them for the analysis. Preliminary studies on a small sample on local actually show that this is the case... Added the properly set code enabling the creation of the templates for the Pt-distribution fits.
IMPORTANT: the code has been tested on local, both tasks compile and yield the expected results. The entries for the rapidity study properly add up to the rapidity integrated case... 