### PR TITLE
PWGUD/UPC: Increased streamers. Eliminated the usage of problematic vectors.

### DIFF
--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.h
@@ -562,7 +562,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforward, 1);
+        ClassDef(AliAnalysisTaskUPCforward, 2);
 };
 
 #endif

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
@@ -167,6 +167,8 @@ AliAnalysisTaskUPCforwardMC::AliAnalysisTaskUPCforwardMC()
       fBGCFlagsAD(0),
       fVectorCosThetaGenerated(0),
       fVectorCosThetaReconstructed(0),
+      fCosThetaGeneratedHelicityFrame(0),
+      fCosThetaReconHelicityFrame(0),
       fCounterUPCevent(0),
       fBinMigrationHelicityH(0),
       fCheckHelicityRestFrameJPsiH(0),
@@ -264,6 +266,8 @@ AliAnalysisTaskUPCforwardMC::AliAnalysisTaskUPCforwardMC( const char* name )
       fBGCFlagsAD(0),
       fVectorCosThetaGenerated(0),
       fVectorCosThetaReconstructed(0),
+      fCosThetaGeneratedHelicityFrame(0),
+      fCosThetaReconHelicityFrame(0),
       fCounterUPCevent(0),
       fBinMigrationHelicityH(0),
       fCheckHelicityRestFrameJPsiH(0),
@@ -1000,15 +1004,24 @@ void AliAnalysisTaskUPCforwardMC::UserExec(Option_t *)
     }
   }
 
-  fVectorCosThetaReconstructed.push_back(cosThetaMuonsRestFrame[0]);
+  // fVectorCosThetaReconstructed.push_back(cosThetaMuonsRestFrame[0]);
+  fCosThetaReconHelicityFrame = cosThetaMuonsRestFrame[0];
   /* - Mind that it could generate segmentation fault without
      - fCounterUPCevent-1, because we are incrementing the counter right after
      - it processes the MC events at Generated level...
      -
+     - Comparing old version with vector (unusable on MC due to the huge
+     - vector size) to the new easier on resources...
+     -
    */
-  if ( fVectorCosThetaGenerated.at(fCounterUPCevent-1) && cosThetaMuonsRestFrame[0] ) {
-        fBinMigrationHelicityH->Fill( fVectorCosThetaGenerated.at(fCounterUPCevent-1),
-                                      cosThetaMuonsRestFrame[0]
+  // if ( fVectorCosThetaGenerated.at(fCounterUPCevent-1) && cosThetaMuonsRestFrame[0] ) {
+  //       fBinMigrationHelicityH->Fill( fVectorCosThetaGenerated.at(fCounterUPCevent-1),
+  //                                     cosThetaMuonsRestFrame[0]
+  //                                   );
+  // }
+  if ( fCosThetaReconHelicityFrame ) {
+        fBinMigrationHelicityH->Fill( fCosThetaGeneratedHelicityFrame,
+                                      fCosThetaReconHelicityFrame
                                     );
   }
 
@@ -1166,7 +1179,8 @@ void AliAnalysisTaskUPCforwardMC::ProcessMCParticles(AliMCEvent* fMCEventArg)
                    */
                   fMCthetaDistribOfPositiveMuonRestFrameJPsiGeneratedTruthH->Fill(cosThetaMuonsRestFrameMC[0]);
                   fMCthetaDistribOfNegativeMuonRestFrameJPsiGeneratedTruthH->Fill(cosThetaMuonsRestFrameMC[1]);
-                  fVectorCosThetaGenerated.push_back(cosThetaMuonsRestFrameMC[0]);
+                  // fVectorCosThetaGenerated.push_back(cosThetaMuonsRestFrameMC[0]);
+                  fCosThetaGeneratedHelicityFrame = cosThetaMuonsRestFrameMC[0];
                   /* - Now we are filling in terms of rapidity...
                      - The easiest way to do so I have envisioned is to simply
                      - check everytime if we are below the following threshold
@@ -1184,7 +1198,8 @@ void AliAnalysisTaskUPCforwardMC::ProcessMCParticles(AliMCEvent* fMCEventArg)
           } else  {
                   fMCthetaDistribOfNegativeMuonRestFrameJPsiGeneratedTruthH->Fill(cosThetaMuonsRestFrameMC[0]);
                   fMCthetaDistribOfPositiveMuonRestFrameJPsiGeneratedTruthH->Fill(cosThetaMuonsRestFrameMC[1]);
-                  fVectorCosThetaGenerated.push_back(cosThetaMuonsRestFrameMC[1]);
+                  // fVectorCosThetaGenerated.push_back(cosThetaMuonsRestFrameMC[1]);
+                  fCosThetaGeneratedHelicityFrame = cosThetaMuonsRestFrameMC[1];
                   /* - Now we are filling in terms of rapidity...
                      - The easiest way to do so I have envisioned is to simply
                      - check everytime if we are below the following threshold

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
@@ -429,6 +429,40 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
         std::vector<Double_t>   fVectorCosThetaReconstructed;           //!
 
                                 /**
+                                 * This is the GENERATED
+                                 * value of the cos(theta) in the HELICITY
+                                 * frame. It should be
+                                 * needed for the "bin migration" study...
+                                 * As far as I can imagine, in each event there
+                                 * should only be a single J/Psi because these
+                                 * are all UPC events, as such I should record
+                                 * all possible values for cos(theta) and plot
+                                 * only when the corresponding J/Psi falls
+                                 * inside the detector acceptance...
+                                 * The resulting plot should be TH2F and be like
+                                 * a lego plot. See for an example:
+                                 *https://www.researchgate.net/figure/The-migration-matrix-for-leading-p-jet-T-Element-i-j-is-the-probability-for-a-particle_fig1_222896619
+                                 */
+        Double_t                fCosThetaGeneratedHelicityFrame;           //!
+
+                                /**
+                                 * This is the RECONSTRUCTED
+                                 * value of the cos(theta) in the HELICITY
+                                 * frame. It should be
+                                 * needed for the "bin migration" study...
+                                 * As far as I can imagine, in each event there
+                                 * should only be a single J/Psi because these
+                                 * are all UPC events, as such I should record
+                                 * all possible values for cos(theta) and plot
+                                 * only when the corresponding J/Psi falls
+                                 * inside the detector acceptance...
+                                 * The resulting plot should be TH2F and be like
+                                 * a lego plot. See for an example:
+                                 *https://www.researchgate.net/figure/The-migration-matrix-for-leading-p-jet-T-Element-i-j-is-the-probability-for-a-particle_fig1_222896619
+                                 */
+        Double_t                fCosThetaReconHelicityFrame;           //!
+
+                                /**
                                  * Counter for the UPC events to access vectors.
                                  * The only thing that matters is a counter to
                                  * give me the proper value of the vector for
@@ -535,7 +569,7 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforwardMC, 1);
+        ClassDef(AliAnalysisTaskUPCforwardMC, 2);
 };
 
 #endif


### PR DESCRIPTION
Due to issues with the LEGO trains, increased all the streamers, and eliminated the usage of the incriminated vectors. Only kept those related to good quality runs, considering their modest size (vectors of ~200 doubles). 
IMPORTANT: this code has been tested on local. The MC class has the exact same output as the version before on the small data sample I am using for tests. It is possible that the issues were due to the massive size of the vectors when analysing MC, considering that ~10^7 reconstructed UPC events are expected each time on the full LHC18l7 simulations...