### PR TITLE
Bug fixes

### DIFF
--- a/PWGHF/vertexingHF/AliCFTaskVertexingHF.cxx
+++ b/PWGHF/vertexingHF/AliCFTaskVertexingHF.cxx
@@ -803,6 +803,11 @@ void AliCFTaskVertexingHF::UserExec(Option_t *)
     trackCuts[0]=fCuts->GetTrackCuts();
     trackCuts[1]=fCuts->GetTrackCutsV0daughters();
     trackCuts[2]=fCuts->GetTrackCutsV0daughters();
+    if (fUseCascadeTaskForLctoV0bachelor){ // the bachelor is prong 2 in this case
+      trackCuts[2]=fCuts->GetTrackCuts();
+      trackCuts[0]=fCuts->GetTrackCutsV0daughters();
+      trackCuts[1]=fCuts->GetTrackCutsV0daughters();
+    }
   }
   else {
     for (Int_t iProng = 0; iProng<cfVtxHF->GetNProngs(); iProng++){

--- a/PWGHF/vertexingHF/AliCFVertexingHFCascade.cxx
+++ b/PWGHF/vertexingHF/AliCFVertexingHFCascade.cxx
@@ -704,13 +704,12 @@ Double_t AliCFVertexingHFCascade::GetEtaProng(Int_t iProng) const
 
     Double_t etaProng =-9999;
     AliAODRecoDecay* neutrDaugh=0; 
-    Int_t ibachelor = 1;
+    Int_t ibachelor = 0;
     if (fPDGcascade == 413) {
       neutrDaugh = cascade->Get2Prong();
     }
     else if (fPDGcascade == 4122) {
       neutrDaugh = cascade->Getv0();
-      ibachelor = 0;
     }
     if (iProng==0) etaProng = neutrDaugh->EtaProng(0);
     if (iProng==1) etaProng = neutrDaugh->EtaProng(1);
@@ -732,12 +731,17 @@ Double_t AliCFVertexingHFCascade::GetPtProng(Int_t iProng) const
 
     AliAODRecoCascadeHF* cascade = (AliAODRecoCascadeHF*)fRecoCandidate;
     Double_t ptProng= -9999;
-    AliAODRecoDecay* neutrDaugh=0; 
-    if (fPDGcascade == 413) neutrDaugh = cascade->Get2Prong();
-    else if (fPDGcascade == 4122) neutrDaugh = cascade->Getv0();
+    AliAODRecoDecay* neutrDaugh=0;
+    Int_t ibachelor = 0;
+    if (fPDGcascade == 413) {
+      neutrDaugh = cascade->Get2Prong();
+    }
+    else if (fPDGcascade == 4122) {
+      neutrDaugh = cascade->Getv0();
+    }
     if (iProng == 0) ptProng = neutrDaugh->PtProng(0);
     if (iProng == 1) ptProng = neutrDaugh->PtProng(1);
-    if (iProng == 2) ptProng = cascade->PtProng(1);
+    if (iProng == 2) ptProng = cascade->PtProng(ibachelor);
     
     //	Double_t ptProng = fRecoCandidate->PtProng(iProng);  
     return ptProng;


### PR DESCRIPTION
- AliCFVertexingHFCascade: The prong for the bachelor is the 0 (both for D* and Lc).
- In the CF task, if one uses AliCFVertexingHFCascade for the Lc (and not
AliCFVertexingHFLctoV0bachelor), the order of the track cuts need to be different
(the proton is the third in the array)