### PR TITLE
 Add methods to introduce eta gaps, and remove tracks from qn

### DIFF
--- a/PWGHF/vertexingHF/charmFlow/AliAnalysisTaskSECharmHadronvn.cxx
+++ b/PWGHF/vertexingHF/charmFlow/AliAnalysisTaskSECharmHadronvn.cxx
@@ -40,7 +40,6 @@
 #include "AliRDHFCutsDStartoKpipi.h"
 #include "AliRDHFCutsD0toKpi.h"
 
-#include "AliAnalysisVertexingHF.h"
 #include "AliMultSelection.h"
 #include "AliVertexingHFUtils.h"
 

--- a/PWGHF/vertexingHF/charmFlow/AliAnalysisTaskSECharmHadronvn.h
+++ b/PWGHF/vertexingHF/charmFlow/AliAnalysisTaskSECharmHadronvn.h
@@ -29,6 +29,7 @@
 #include "AliRDHFCuts.h"
 #include "AliAODEvent.h"
 #include "AliHFQnVectorHandler.h"
+#include "AliAnalysisVertexingHF.h"
 
 class AliAnalysisTaskSECharmHadronvn : public AliAnalysisTaskSE
 {

--- a/PWGHF/vertexingHF/charmFlow/AliAnalysisTaskSECharmHadronvn.h
+++ b/PWGHF/vertexingHF/charmFlow/AliAnalysisTaskSECharmHadronvn.h
@@ -45,37 +45,41 @@ class AliAnalysisTaskSECharmHadronvn : public AliAnalysisTaskSE
 
     virtual ~AliAnalysisTaskSECharmHadronvn();
 
-    void SetTenderTaskName(TString name)                        {fTenderTaskName = name;}
-    void SetAODMismatchProtection(int opt=1)                    {fAODProtection = opt;}
+    void SetTenderTaskName(TString name)                              {fTenderTaskName = name;}
+    void SetAODMismatchProtection(int opt=1)                          {fAODProtection = opt;}
 
-    void SetHarmonic(int harmonic)                              {fHarmonic = harmonic;}
-    void SetCalibrationType(int calibtype)                      {fCalibType = calibtype;}
-    void SetNormMethod(int norm)                                {fNormMethod = norm;}
-    void SetOADBFileName(TString filename)                      {fOADBFileName = filename;}
+    void SetHarmonic(int harmonic)                                    {fHarmonic = harmonic;}
+    void SetCalibrationType(int calibtype)                            {fCalibType = calibtype;}
+    void SetNormMethod(int norm)                                      {fNormMethod = norm;}
+    void SetOADBFileName(TString filename)                            {fOADBFileName = filename;}
 
-    void SetFlowMethod(int meth)                                {fFlowMethod = meth;}
-    void SetEventPlaneDetector(int det)                         {fEvPlaneDet = det;}
-    void SetSubEventDetectors(int detsubA, int detsubB)         {fSubEvDetA = detsubA; fSubEvDetB = detsubB;}
+    void SetFlowMethod(int meth)                                      {fFlowMethod = meth;}
+    void SetEventPlaneDetector(int det)                               {fEvPlaneDet = det;}
+    void SetSubEventDetectors(int detsubA, int detsubB)               {fSubEvDetA = detsubA; fSubEvDetB = detsubB;}
     void SetQnVectorDetConf(int detconf);
-    void SetTPCEPOnly()                                         {SetQnVectorDetConf(kTPC);}
-    void SetVZEROEP()                                           {SetQnVectorDetConf(kVZERO);}
-    void SetVZEROAEP()                                          {SetQnVectorDetConf(kVZEROA);}
-    void SetVZEROCEP()                                          {SetQnVectorDetConf(kVZEROC);}
-    void SetTPCEP()                                             {SetQnVectorDetConf(kTPCVZERO);}
-    void SetqnMethod(int qnmethod)                              {fqnMeth = qnmethod;}
-    void SetScalProdLimit(double limit=0.3)                     {limit < 1. ? fScalProdLimit = limit : fScalProdLimit = 1.;}
+    void SetTPCEPOnly()                                               {SetQnVectorDetConf(kTPC);}
+    void SetVZEROEP()                                                 {SetQnVectorDetConf(kVZERO);}
+    void SetVZEROAEP()                                                {SetQnVectorDetConf(kVZEROA);}
+    void SetVZEROCEP()                                                {SetQnVectorDetConf(kVZEROC);}
+    void SetTPCEP()                                                   {SetQnVectorDetConf(kTPCVZERO);}
+    void SetqnMethod(int qnmethod)                                    {fqnMeth = qnmethod;}
+    void SetScalProdLimit(double limit=0.3)                           {limit < 1. ? fScalProdLimit = limit : fScalProdLimit = 1.;}
     void SetqnPercentileSelection(TString splinesfilepath);
 
-    void SetMinCentrality(float mincentr)                       {fMinCentr = mincentr;}
-    void SetMaxCentrality(float maxcentr)                       {fMaxCentr = maxcentr;}
+    void SetMinCentrality(float mincentr)                             {fMinCentr = mincentr;}
+    void SetMaxCentrality(float maxcentr)                             {fMaxCentr = maxcentr;}
 
-    void SetDecayChannel(int decaychannel)                      {fDecChannel = decaychannel;}
+    void SetDecayChannel(int decaychannel)                            {fDecChannel = decaychannel;}
     void SetMassLimits(float range,int pdg);
     void SetMassLimits(float lowlimit, float uplimit);
-    void SetNMassBins(int nbins)                                {fNMassBins = nbins;}
-    float GetUpperMassLimit() const                             {return fUpmasslimit;}
-    float GetLowerMassLimit() const                             {return fLowmasslimit;}
-    int GetNMassBins() const                                    {return fNMassBins;}
+    void SetNMassBins(int nbins)                                      {fNMassBins = nbins;}
+    float GetUpperMassLimit() const                                   {return fUpmasslimit;}
+    float GetLowerMassLimit() const                                   {return fLowmasslimit;}
+    int GetNMassBins() const                                          {return fNMassBins;}
+
+    void SetTPCHalvesEtaGap(double etagap = 0.2)                      {fEtaGapInTPCHalves=etagap;}                             
+    void RemoveDauTracksFromqn(int removedau=1, bool remsoftpi=false) {fRemoveDauFromqn=removedau; fRemoveSoftPion=remsoftpi;}
+    void SetRandomDownsamplFromqn(double fractokeep = 0.5)            {fEnableDownsamplqn=true; fFracToKeepDownSamplqn=fractokeep;}
 
     // Implementation of interface methods
     virtual void UserCreateOutputObjects();
@@ -88,6 +92,8 @@ class AliAnalysisTaskSECharmHadronvn : public AliAnalysisTaskSE
     double GetDeltaPsiSubInRange(double psi1, double psi2);
     void CalculateInvMasses(AliAODRecoDecayHF* d,float* &masses,int& nmasses);
     void GetMainQnVectorInfo(double &mainPsin, double &mainMultQn, double mainQn[2], double &SubAPsin, double &SubAMultQn, double SubAQn[2], double &SubBPsin, double &SubBMultQn, double SubBQn[2], AliHFQnVectorHandler* HFQnVectorHandler);
+    void GetDaughterTracksToRemove(AliAODRecoDecayHF* d, int nDau, vector<AliAODTrack*> &trackstoremove);
+    int IsCandidateSelected(AliAODRecoDecayHF *&d, int nDau, int absPdgMom, AliAnalysisVertexingHF *vHF, AliAODRecoDecayHF2Prong *dD0);
 
     AliAODEvent* fAOD;                      /// AOD event
 
@@ -129,7 +135,13 @@ class AliAnalysisTaskSECharmHadronvn : public AliAnalysisTaskSE
     float fUpmasslimit;                     /// upper inv mass limit for histos
     int fNMassBins;                         /// number of bins in the mass histograms
     
-    ClassDef(AliAnalysisTaskSECharmHadronvn,1); // AliAnalysisTaskSE for the HF vn analysis
+    double fEtaGapInTPCHalves;              /// eta gap between TPC subevents
+    int fRemoveDauFromqn;                   /// flag to enable removal of D-meson daughter tracks from qn (1->remove single cand, 2->remove all cand of the analysed event)
+    bool fRemoveSoftPion;                   /// flag to enable removal of soft pion too (only D*)
+    bool fEnableDownsamplqn;                /// flag to enable random downsampling for qn
+    double fFracToKeepDownSamplqn;          /// fraction of tracks to keep in qn with random downsampling 
+
+    ClassDef(AliAnalysisTaskSECharmHadronvn,2); // AliAnalysisTaskSE for the HF vn analysis
 };
 
 #endif

--- a/PWGHF/vertexingHF/charmFlow/AliHFQnVectorHandler.cxx
+++ b/PWGHF/vertexingHF/charmFlow/AliHFQnVectorHandler.cxx
@@ -442,16 +442,16 @@ void AliHFQnVectorHandler::GetEventPlaneAngleV0(double &EvPlaneFullV0, double &E
 }
 
 //________________________________________________________________
-void AliHFQnVectorHandler::RemoveTracksFromQnTPC(vector<AliAODTrack*> trToRem, double QnVecFullTPC[2], double QnVecPosTPC[2], double QnVecNegTPC[2], bool getUnNormalised) 
+void AliHFQnVectorHandler::RemoveTracksFromQnTPC(vector<AliAODTrack*> trToRem, double QnVecFullTPC[2], double QnVecPosTPC[2], double QnVecNegTPC[2], double &multFullTPC, double &multPosTPC, double &multNegTPC, bool getUnNormalised) 
 {
     for(int iComp=0; iComp<2; iComp++) {
         QnVecFullTPC[iComp] = fQnVecFullTPC[iComp];
         QnVecPosTPC[iComp]  = fQnVecPosTPC[iComp];
         QnVecNegTPC[iComp]  = fQnVecNegTPC[iComp];
     }
-    double multFullTPC = fMultFullTPC;
-    double multPosTPC = fMultPosTPC;
-    double multNegTPC = fMultNegTPC;
+    multFullTPC = fMultFullTPC;
+    multPosTPC = fMultPosTPC;
+    multNegTPC = fMultNegTPC;
 
     TBits posIDsAfterRem(fUsedTrackPosIDs);
     TBits negIDsAfterRem(fUsedTrackNegIDs);
@@ -486,7 +486,6 @@ void AliHFQnVectorHandler::RemoveTracksFromQnTPC(vector<AliAODTrack*> trToRem, d
                 negIDsAfterRem.ResetBitNumber(TMath::Abs(trID));
         }
     }
-
     else if(fCalibType==kQnFrameworkCalib) {
 
         TString detTPCConfName[3] = {"TPC","TPCPosEta","TPCNegEta"};

--- a/PWGHF/vertexingHF/charmFlow/AliHFQnVectorHandler.h
+++ b/PWGHF/vertexingHF/charmFlow/AliHFQnVectorHandler.h
@@ -88,7 +88,7 @@ class AliHFQnVectorHandler : public TObject
     void GetEventPlaneAngleTPC(double &EvPlaneFullTPC, double &EvPlanePosTPC, double &EvPlaneNegTPC);
     void GetEventPlaneAngleV0(double &EvPlaneFullV0, double &EvPlaneV0A, double &EvPlaneV0C);
 
-    void RemoveTracksFromQnTPC(vector<AliAODTrack*> trToRem, double QnVecFullTPC[2], double QnVecPosTPC[2], double QnVecNegTPC[2], bool getUnNormalised=false);
+    void RemoveTracksFromQnTPC(vector<AliAODTrack*> trToRem, double QnVecFullTPC[2], double QnVecPosTPC[2], double QnVecNegTPC[2], double &multFullTPC, double &multPosTPC, double &multNegTPC, bool getUnNormalised=false); 
 
   private:  
 


### PR DESCRIPTION
1) add method to introduce eta gap between resolution sub-events
2) add method to remove daughter tracks from qn (1: remove daughter tracks of selected candidate, 2: remove daughter tracks of all the candidates in the selected event)
3) add method to perform random downsampling of tracks from qn

The three methods can be called together.