### PR TITLE
Add variable-width mass binning for vn vs. mass

### DIFF
--- a/PWGHF/vertexingHF/charmFlow/config_Dplus_v2_unbiased.yml
+++ b/PWGHF/vertexingHF/charmFlow/config_Dplus_v2_unbiased.yml
@@ -16,12 +16,16 @@ AnalysisOptions:
     PtMin: [ 2, 3, 4, 5, 6, 7, 8, 10, 12, 16, 24 ]    
     PtMax: [ 3, 4, 5, 6, 7, 8, 10, 12, 16, 24, 36 ]    
     MassMin: [ 1.70, 1.70, 1.70, 1.70, 1.70, 1.70, 1.70, 1.70, 1.70, 1.70, 1.70 ]    
-    MassMax: [ 2.05, 2.05, 2.05, 2.05, 2.05, 2.05, 2.05, 2.05, 2.05, 2.05, 2.05 ]
+    MassMax: [ 2.04, 2.04, 2.04, 2.04, 2.04, 2.04, 2.04, 2.04, 2.04, 2.04, 2.04 ]
     Rebin: [ 2, 2, 2, 2, 2, 2, 2, 4, 4, 4, 4 ]
     BkgFunc: [ 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo', 'kExpo' ]
     SgnFunc: [ 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus', 'kGaus' ]
     VnBkgFunc: [ 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin', 'kLin' ]
-    IncludeReflections: 0
+    FixMeanVnVsMassFit: 0 # 0->don't fix, 1->set initial value from prefit, 2->fix value from prefit  
+    FixSigmaVnVsMassFit: 2 # 0->don't fix, 1->set initial value from prefit, 2->fix value from prefit  
+    UseVarMassBinning: 0 # 0->false, 1->true
+    VnVsMassBins: [1.70,1.75,1.80,1.82,1.83,1.84,1.85,1.86,1.87,1.88,1.89,1.90,1.91,1.92,1.94,1.99,2.04]
+    IncludeReflections: 0 # 0->false, 1->true
     ReflFileName: "Refl_Templates.root"
     ReflOpt: "2gaus"
 


### PR DESCRIPTION
1) add variable-width mass binning for vn vs. mass
2) add parameters in config file for vn vs. mass:
    - flag to fix mean in vn vs. mass
    - flag to fix sigma in vn vs. mass
    - limits of the variable mass binning for vn vs. mass