### PR TITLE
Add flag to select pile-up events only

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSED0Mass.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSED0Mass.cxx
@@ -118,7 +118,8 @@ AliAnalysisTaskSED0Mass::AliAnalysisTaskSED0Mass():
   fEnablePileupRejVZEROTPCout(kFALSE),
   fhMultVZEROTPCclustersCorrNoCut(0x0),
   fhMultVZEROTPCclustersCorr(0x0),
-  fEnablePileupRejVZEROTPCcls(kFALSE)
+  fEnablePileupRejVZEROTPCcls(kFALSE),
+  fRejectOutOfBunchPileUp(kFALSE)
 {
   /// Default constructor
   for(Int_t ih=0; ih<5; ih++) fHistMassPtImpParTC[ih]=0x0;
@@ -179,7 +180,8 @@ AliAnalysisTaskSED0Mass::AliAnalysisTaskSED0Mass(const char *name,AliRDHFCutsD0t
   fEnablePileupRejVZEROTPCout(kFALSE),
   fhMultVZEROTPCclustersCorrNoCut(0x0),
   fhMultVZEROTPCclustersCorr(0x0),
-  fEnablePileupRejVZEROTPCcls(kFALSE)
+  fEnablePileupRejVZEROTPCcls(kFALSE),
+  fRejectOutOfBunchPileUp(kFALSE)
 {
   /// Default constructor
 
@@ -1261,7 +1263,8 @@ void AliAnalysisTaskSED0Mass::UserExec(Option_t */*option*/)
   if(fhMultVZEROTPCclustersCorrNoCut) fhMultVZEROTPCclustersCorrNoCut->Fill(nTPCcls,mTotV0);
   Float_t mV0TPCclsCut=-2000.+(0.013*nTPCcls)+(1.25e-9*nTPCcls*nTPCcls);
   if(fEnablePileupRejVZEROTPCcls){ // this pile-up rejection is specific for 2018 Pb-Pb analysis
-    if(mTotV0<mV0TPCclsCut) return;
+    if(fRejectOutOfBunchPileUp && mTotV0<mV0TPCclsCut) return;
+    else if(!fRejectOutOfBunchPileUp && mTotV0>mV0TPCclsCut) return; //keep only out-of-bunch pile-up events
   }
   if(fhMultVZEROTPCclustersCorr) fhMultVZEROTPCclustersCorr->Fill(nTPCcls,mTotV0);
 

--- a/PWGHF/vertexingHF/AliAnalysisTaskSED0Mass.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSED0Mass.h
@@ -75,7 +75,7 @@ class AliAnalysisTaskSED0Mass : public AliAnalysisTaskSE
   void SetUseQuarkLevelTag(Bool_t opt){fUseQuarkTagInKine=opt;}
   void SetAODMismatchProtection(Int_t opt=1) {fAODProtection=opt;}
   void SetPileupRejectionVZEROTPCout(Bool_t flag) {fEnablePileupRejVZEROTPCout=flag;}
-  void SetPileupRejectionVZEROTPCcls(Bool_t flag) {fEnablePileupRejVZEROTPCcls=flag;}
+  void SetPileupRejectionVZEROTPCcls(Bool_t flag, Bool_t rejpileup) {fEnablePileupRejVZEROTPCcls=flag; fRejectOutOfBunchPileUp=rejpileup;}
   void SetFillSubSampleHist(Bool_t flag) {fFillSubSampleHist=flag;}
 
   void SetEnableCentralityCorrCutsPbPb(Bool_t flag=kFALSE, Int_t year=2018) {
@@ -174,6 +174,7 @@ class AliAnalysisTaskSED0Mass : public AliAnalysisTaskSE
   TH2F *fhMultVZEROTPCclustersCorrNoCut;  //!<!
   TH2F *fhMultVZEROTPCclustersCorr;  //!<!
   Bool_t    fEnablePileupRejVZEROTPCcls;
+  Bool_t    fRejectOutOfBunchPileUp;  //!<!
 
 
   /// \cond CLASSIMP


### PR DESCRIPTION
Add flag to select out-of-bunch pile-up events only. This flag will be used to cross-check the pile-up events for the D-meson analyses. 