### PR TITLE
Addind AOD compatibility to AliSpherocotyEstimator

### DIFF
--- a/PWGLF/SPECTRA/Spherocity/AliSpherocityEstimator.cxx
+++ b/PWGLF/SPECTRA/Spherocity/AliSpherocityEstimator.cxx
@@ -10,9 +10,10 @@ ClassImp(AliSpherocityEstimator)
 AliSpherocityEstimator::AliSpherocityEstimator():
   TNamed(),
   fSphTrackCuts(0),
+  fAODFilterBit(128), //TPCOnly by default
   fMinMulti(10),
   fTrackMulti(0),
-  fMinPt(0.15)
+  fOnAODs(kFALSE)
 {
   fSphTrackCuts = AliESDtrackCuts::GetStandardTPCOnlyTrackCuts();
   fSphTrackCuts->SetRequireTPCRefit(kTRUE);
@@ -22,9 +23,11 @@ AliSpherocityEstimator::AliSpherocityEstimator():
 AliSpherocityEstimator::AliSpherocityEstimator(const AliSpherocityEstimator &source):
   TNamed(source.GetName(), source.GetTitle()),
   fSphTrackCuts(source.fSphTrackCuts),
+  fAODFilterBit(source.fAODFilterBit),
   fMinMulti(source.fMinMulti),
   fTrackMulti(source.fTrackMulti),
-  fMinPt(source.fMinPt)
+  fMinPt(source.fMinPt),
+  fOnAODs(source.fOnAODs)
 {
 };
 AliSpherocityEstimator &AliSpherocityEstimator::operator=(const AliSpherocityEstimator &source) {
@@ -43,21 +46,35 @@ void AliSpherocityEstimator::SetESDtrackCuts(AliESDtrackCuts *newcuts) {
   if(fSphTrackCuts)
     delete fSphTrackCuts;
   fSphTrackCuts = newcuts;
+  fOnAODs = kFALSE; //Overriding AOD, if it was set
 };
-Double_t AliSpherocityEstimator::GetSpherocity(AliESDEvent *inevent) {
+void AliSpherocityEstimator::SetAODFilterBit(Int_t newvalue) {
+  fAODFilterBit=newvalue;
+  fOnAODs = kTRUE; //Overriding if previously set different
+}
+Double_t AliSpherocityEstimator::GetSpherocity(AliVEvent *inevent) {
   if(!inevent) return -1; //If a problem with event, return -1
   if(inevent->GetNumberOfTracks()<fMinMulti) return -2;//if not enough tracks (1st check), return -2
   fTrackMulti=0;
-  AliESDtrack *track; //Create pointer here, not for each track
+  AliVTrack *track; //Create pointer here, not for each track
   Double_t sumpt=0;
   std::vector<Double_t> nx;
   std::vector<Double_t> ny;
   std::vector<Double_t> px;
   std::vector<Double_t> py;
   for(Int_t itrk=0;itrk<inevent->GetNumberOfTracks();++itrk) {
-    track = inevent->GetTrack(itrk);
+    if(fOnAODs)
+      track=(AliAODTrack*)inevent->GetTrack(itrk);
+    else
+      track = (AliESDtrack*)inevent->GetTrack(itrk);
     if(!track) continue;
-    if(!fSphTrackCuts->AcceptTrack(track)) continue;
+    if(fOnAODs) {
+      if(!((AliAODTrack*)track)->TestFilterBit(fAODFilterBit)) continue; //Check filter bit
+      //Manually check for ITS & TPC refit
+      if((track->GetStatus()&AliVTrack::kITSrefit)!=AliVTrack::kITSrefit) continue;
+      if((track->GetStatus()&AliVTrack::kTPCrefit)!=AliVTrack::kTPCrefit) continue;
+    } else if(!fSphTrackCuts->AcceptTrack((AliESDtrack*)track)) continue;
+    printf("\n");
     Double_t pt = track->Pt();
     if(pt<fMinPt) continue;
     sumpt+=pt;
@@ -67,13 +84,13 @@ Double_t AliSpherocityEstimator::GetSpherocity(AliESDEvent *inevent) {
     px.push_back(pt*nx[fTrackMulti]);
     py.push_back(pt*ny[fTrackMulti]);
     ++fTrackMulti;
-  }; 
+  };
   if(fTrackMulti<fMinMulti) {
     px.clear();
     py.clear();
     nx.clear();
     ny.clear();
-    return -2; //if not enought tracks 
+    return -2; //if not enought tracks
   };
   //Calculating spherocity now
   Double_t retval=2; //Return value should be the minimal value in range 0..1, so 2 is a good starting point.
@@ -92,5 +109,4 @@ Double_t AliSpherocityEstimator::GetSpherocity(AliESDEvent *inevent) {
   if(retval>1) return -3; //If sph>1, something went wrong
   retval=retval*TMath::Pi()*TMath::Pi()/4; //normalization
   return retval;
-}; 
-
+};

--- a/PWGLF/SPECTRA/Spherocity/AliSpherocityEstimator.cxx
+++ b/PWGLF/SPECTRA/Spherocity/AliSpherocityEstimator.cxx
@@ -10,9 +10,10 @@ ClassImp(AliSpherocityEstimator)
 AliSpherocityEstimator::AliSpherocityEstimator():
   TNamed(),
   fSphTrackCuts(0),
-  fAODFilterBit(128), //TPCOnly by default
+  fAODFilterBit(1), //TPCOnly by default
   fMinMulti(10),
   fTrackMulti(0),
+  fMinPt(0.15),
   fOnAODs(kFALSE)
 {
   fSphTrackCuts = AliESDtrackCuts::GetStandardTPCOnlyTrackCuts();

--- a/PWGLF/SPECTRA/Spherocity/AliSpherocityEstimator.h
+++ b/PWGLF/SPECTRA/Spherocity/AliSpherocityEstimator.h
@@ -3,6 +3,10 @@
 #include "AliESDtrack.h"
 #include "AliESDtrackCuts.h"
 #include "AliESDEvent.h"
+#include "AliAODEvent.h"
+#include "AliAODTrack.h"
+#include "AliVEvent.h"
+#include "AliVTrack.h"
 #include "TNamed.h"
 
 class AliSpherocityEstimator: public TNamed
@@ -17,14 +21,17 @@ class AliSpherocityEstimator: public TNamed
   void SetMinPt(Double_t MinPt) { if(MinPt>=0) fMinPt=MinPt; };
   Double_t GetMinPt() { return fMinPt; };
   Int_t GetTrackMulti() { return fTrackMulti; };
-  Double_t GetSpherocity(AliESDEvent *inevent);
+  Double_t GetSpherocity(AliVEvent *inevent);
   AliESDtrackCuts *GetESDtrackCuts() { return fSphTrackCuts; };
   void SetESDtrackCuts(AliESDtrackCuts *newcuts);
+  void SetAODFilterBit(Int_t newval=128);
  private:
   AliESDtrackCuts *fSphTrackCuts; //! No need to store
+  Int_t fAODFilterBit; //! no need to store either
   Int_t fMinMulti;
   Int_t fTrackMulti;
   Double_t fMinPt;
+  Bool_t fOnAODs; //! AOD flag
   ClassDef(AliSpherocityEstimator,1);
 };
 #endif


### PR DESCRIPTION
AliSpherocityEstimator now works with AOD tracks too (note one has to set the filterbit manually to enable the AOD flag). Added default value for fMinPt cut in the default constructor.