### PR TITLE
Cent supercalib fix, better defaults for weak dec finder

### DIFF
--- a/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibratorMC.cxx
+++ b/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibratorMC.cxx
@@ -536,6 +536,12 @@ Bool_t AliMultSelectionCalibratorMC::Calibrate() {
     //Create 2D correlation plots as needed
     TH2F *l2dTrackletVsEstimatorData [1000] [lNEstimators];
     TH2F *l2dTrackletVsEstimatorMC   [1000] [lNEstimators];
+    for(Int_t ii=0; ii<1000; ii++)
+        for(Int_t jj=0; jj<lNEstimators; jj++){
+            l2dTrackletVsEstimatorData[ii][jj] = 0x0;
+            l2dTrackletVsEstimatorMC[ii][jj] = 0x0;
+        }
+    
     cout<<"(5) Creating histograms..."<<endl;
 
     for(Int_t iRun=0; iRun<lNRuns; iRun++) {
@@ -595,9 +601,17 @@ Bool_t AliMultSelectionCalibratorMC::Calibrate() {
     //Prepare 1D fits
     TProfile *profdata[1000][lNEstimators];
     TProfile *profmc[1000][lNEstimators];
-
+    
     TF1 *fitdata[1000][lNEstimators];
     TF1 *fitmc[1000][lNEstimators];
+    
+    for(Int_t ii=0; ii<1000; ii++)
+        for(Int_t jj=0; jj<lNEstimators; jj++){
+            profdata[ii][jj]=0x0;
+            profmc[ii][jj]=0x0;
+            fitdata[ii][jj]=0x0;
+            fitmc[ii][jj]=0x0;
+        }
     
     TString fFormula = "[0]*x";
     
@@ -613,9 +627,16 @@ Bool_t AliMultSelectionCalibratorMC::Calibrate() {
                 lLowestX=fSelection->GetEstimator(iEst)->GetAnchorPoint(); //Remove lowest
             }
             
-            cout<<"At Run "<<lRunNumbers[iRun]<<" ("<<iRun<<"/"<<lNRuns<<"), estimator "<<fSelection->GetEstimator(iEst)->GetName()<<", fit range "<<lMaxEst[iEst][iRun]<<endl;
+            cout<<"---> At Run "<<lRunNumbers[iRun]<<" ("<<iRun<<"/"<<lNRuns<<"), estimator "<<fSelection->GetEstimator(iEst)->GetName()<<", fit range "<<lMaxEst[iEst][iRun]<<endl;
+            if(!l2dTrackletVsEstimatorData[iRun][iEst]) cout<<"Null pointer for l2dTrackletVsEstimatorData"<<endl;
+            if(!l2dTrackletVsEstimatorMC[iRun][iEst]) cout<<"Null pointer for l2dTrackletVsEstimatorMC"<<endl;
+            cout<<"Profdata: setting up..."<<endl;
             profdata[ iRun ][ iEst ] = l2dTrackletVsEstimatorData[iRun][iEst]->ProfileY(Form("profdata_%i_%s",lRunNumbers[iRun],fSelection->GetEstimator(iEst)->GetName() ) ) ;
+            cout<<"Profmc: setting up..."<<endl;
             profmc[ iRun ][ iEst ] = l2dTrackletVsEstimatorMC[iRun][iEst]->ProfileY(Form("profmc_%i_%s",lRunNumbers[iRun],fSelection->GetEstimator(iEst)->GetName() ) ) ;
+            
+            fitdata[iRun][iEst] = new TF1(Form("fitdata_%i_%s",lRunNumbers[iRun],fSelection->GetEstimator(iEst)->GetName() ), fFormula.Data(), lLowestX, lMaxEst[iEst][iRun]);
+            fitmc[iRun][iEst] = new TF1(Form("fitmc_%i_%s",lRunNumbers[iRun],fSelection->GetEstimator(iEst)->GetName() ), fFormula.Data(), lLowestX, lMaxEst[iEst][iRun]);
             
             if(fkUseQuadraticMapping){
                 fitdata[iRun][iEst]->SetParameter(0,0);
@@ -651,10 +672,15 @@ Bool_t AliMultSelectionCalibratorMC::Calibrate() {
             Double_t lIncline   = 1e-3;
             Double_t lInclineMC = 1e-3;
             
+            if( !profdata[iRun][iEst]) cout<<"Null pointer!"<<endl;
+            if( !profmc[iRun][iEst]) cout<<"Null pointer!"<<endl;
             if( TMath::Abs(lAvEst[iEst][iRun])>1e-3 ){
                 lIncline   = profdata[iRun][iEst]->GetBinContent( profdata[iRun][iEst]->FindBin(lAvEst[iEst][iRun]) ) / lAvEst[iEst][iRun];
                 lInclineMC = profmc  [iRun][iEst]->GetBinContent( profmc  [iRun][iEst]->FindBin(lAvEst[iEst][iRun]) ) / lAvEst[iEst][iRun];
             }
+            
+            if( !fitdata[iRun][iEst]) cout<<"Null pointer!"<<endl;
+            if( !fitmc[iRun][iEst]) cout<<"Null pointer!"<<endl;
             
             fitdata[iRun][iEst]->SetParameter(0,lIncline);
             fitmc[iRun][iEst]->SetParameter(0,lIncline);

--- a/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskWeakDecayVertexer.cxx
+++ b/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskWeakDecayVertexer.cxx
@@ -123,7 +123,7 @@ fkRevertexAllEvents(kTRUE),
 //Flags for both V0+cascade vertexer
 fkPreselectDedx ( kFALSE ),
 fkPreselectDedxLambda ( kFALSE ),
-fkExtraCleanup    ( kFALSE ), //extra cleanup: eta, etc
+fkExtraCleanup    ( kTRUE ), //extra cleanup: eta, etc
 //________________________________________________
 //Flags for V0 vertexer
 fkRunV0Vertexer (kFALSE),
@@ -183,7 +183,7 @@ fkRevertexAllEvents(kTRUE),
 //Flags for both V0+cascade vertexer
 fkPreselectDedx ( kFALSE ),
 fkPreselectDedxLambda ( kFALSE ),
-fkExtraCleanup    ( kFALSE ), //extra cleanup: eta, etc
+fkExtraCleanup    ( kTRUE ), //extra cleanup: eta, etc
 //________________________________________________
 //Flags for V0 vertexer
 fkRunV0Vertexer (kFALSE),
@@ -229,17 +229,17 @@ fHistV0Statistics(0)
     //Re-vertex: Will only apply for cascade candidates
     
     fV0VertexerSels[0] =  33.  ;  // max allowed chi2
-    fV0VertexerSels[1] =   0.02;  // min allowed impact parameter for the 1st daughter (LHC09a4 : 0.05)
-    fV0VertexerSels[2] =   0.02;  // min allowed impact parameter for the 2nd daughter (LHC09a4 : 0.05)
+    fV0VertexerSels[1] =   0.1;  // min allowed impact parameter for the 1st daughter (LHC09a4 : 0.05)
+    fV0VertexerSels[2] =   0.1;  // min allowed impact parameter for the 2nd daughter (LHC09a4 : 0.05)
     fV0VertexerSels[3] =   2.0 ;  // max allowed DCA between the daughter tracks       (LHC09a4 : 0.5)
     fV0VertexerSels[4] =   0.95;  // min allowed cosine of V0's pointing angle         (LHC09a4 : 0.99)
     fV0VertexerSels[5] =   1.0 ;  // min radius of the fiducial volume                 (LHC09a4 : 0.2)
     fV0VertexerSels[6] = 200.  ;  // max radius of the fiducial volume                 (LHC09a4 : 100.0)
     
     fCascadeVertexerSels[0] =  33.   ;  // max allowed chi2 (same as PDC07)
-    fCascadeVertexerSels[1] =   0.05 ;  // min allowed V0 impact parameter                    (PDC07 : 0.05   / LHC09a4 : 0.025 )
-    fCascadeVertexerSels[2] =   0.010;  // "window" around the Lambda mass                    (PDC07 : 0.008  / LHC09a4 : 0.010 )
-    fCascadeVertexerSels[3] =   0.03 ;  // min allowed bachelor's impact parameter            (PDC07 : 0.035  / LHC09a4 : 0.025 )
+    fCascadeVertexerSels[1] =   0.1 ;  // min allowed V0 impact parameter                    (PDC07 : 0.05   / LHC09a4 : 0.025 )
+    fCascadeVertexerSels[2] =   0.008;  // "window" around the Lambda mass                    (PDC07 : 0.008  / LHC09a4 : 0.010 )
+    fCascadeVertexerSels[3] =   0.1 ;  // min allowed bachelor's impact parameter            (PDC07 : 0.035  / LHC09a4 : 0.025 )
     fCascadeVertexerSels[4] =   2.0  ;  // max allowed DCA between the V0 and the bachelor    (PDC07 : 0.1    / LHC09a4 : 0.2   )
     fCascadeVertexerSels[5] =   0.95 ;  // min allowed cosine of the cascade pointing angle   (PDC07 : 0.9985 / LHC09a4 : 0.998 )
     fCascadeVertexerSels[6] =   0.4  ;  // min radius of the fiducial volume                  (PDC07 : 0.9    / LHC09a4 : 0.2   )


### PR DESCRIPTION
- Supercalib fix applied to MultSelection MC calibrator task (mundane bug) 
- Changed defaults for weak decay finding - these were set to loose after a PWG-LF discussion but if this finder is used systematically then better set to a compromise between loose and (too) tight to conserve computing power