### PR TITLE
PWGUD/UPC: Y-dependent helicity analysis + neutron emission analysis

### DIFF
--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
@@ -1148,11 +1148,18 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
   for(Int_t iZDC = 0; iZDC < 4 ; iZDC++) {
     if ( (isZNAfired == 0) && (fZNATDC[iZDC] > -2.) && (fZNATDC[iZDC] < 2.) ) {
       isZNAfired = kTRUE;
-      fZNATimeAgainstEntriesH->Fill(fZNATDC[iZDC]);
+      /* - After mail with Chiara Oppedisano, it seems like the best way
+         - to proceed is to firstly call the IsZNAfired() and then filling...
+         -
+         - If this doesn't appear in later pulls it is because this
+         - doesn't seem to suit my case...
+         -
+       */
+      if( dataZDC->IsZNAfired() ) fZNATimeAgainstEntriesH->Fill(fZNATDC[iZDC]);
     }
     if ( (isZNCfired == 0) && (fZNCTDC[iZDC] > -2.) && (fZNCTDC[iZDC] < 2.) ) {
       isZNCfired = kTRUE;
-      fZNCTimeAgainstEntriesH->Fill(fZNCTDC[iZDC]);
+      if( dataZDC->IsZNCfired() ) fZNCTimeAgainstEntriesH->Fill(fZNCTDC[iZDC]);
     }
   }
 
@@ -1237,10 +1244,10 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
   if ( isZNAfired != 0 ) {
     if ( isZNCfired != 0 ) {
           /* At any levels, this means |fZNCTime| < 5. */
-          if( fZNCEnergy > -300 ) {
-                      if( fZNCEnergy < 125 ) {
-                                  if( fZNAEnergy > -300 ) {
-                                              if( fZNAEnergy < 125 ) {
+          if( fZNCEnergy > -5000 ) {
+                      if( fZNCEnergy < 1250 ) {
+                                  if( fZNAEnergy > -5000 ) {
+                                              if( fZNAEnergy < 1000 ) {
                                                           if( ptOfTheDimuonPair < 0.25) {
                                                                     fInvariantMassDistributionCoherentZNCzeroZNAzeroH->Fill(possibleJPsi.Mag());
                                                           } else {
@@ -1255,8 +1262,8 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
                                               }
                                   }
                       } else {
-                                  if( fZNAEnergy > -300 ) {
-                                              if( fZNAEnergy < 125 ) {
+                                  if( fZNAEnergy > -5000 ) {
+                                              if( fZNAEnergy < 1000 ) {
                                                           if( ptOfTheDimuonPair < 0.25) {
                                                                     fInvariantMassDistributionCoherentZNCanyZNAzeroH->Fill(possibleJPsi.Mag());
                                                           } else {

--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
@@ -157,7 +157,11 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward()
       fCosThetaHelicityFrameJPsiH(0),
       fCosThetaCollinsSoperFrameJPsiH(0),
       fPhiHelicityFrameJPsiH(0),
-      fPhiCollinsSoperFrameJPsiH(0)
+      fPhiCollinsSoperFrameJPsiH(0),
+      fCosThetaHelicityFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fCosThetaCollinsSoperFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fPhiHelicityFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fPhiCollinsSoperFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0}
 {
     // default constructor, don't allocate memory here!
     // this is used by root for IO purposes, it needs to remain empty
@@ -246,7 +250,11 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward(const char* name)
       fCosThetaHelicityFrameJPsiH(0),
       fCosThetaCollinsSoperFrameJPsiH(0),
       fPhiHelicityFrameJPsiH(0),
-      fPhiCollinsSoperFrameJPsiH(0)
+      fPhiCollinsSoperFrameJPsiH(0),
+      fCosThetaHelicityFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fCosThetaCollinsSoperFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fPhiHelicityFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fPhiCollinsSoperFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0}
 {
     FillGoodRunVector(fVectorGoodRunNumbers);
 
@@ -569,6 +577,42 @@ void AliAnalysisTaskUPCforward::UserCreateOutputObjects()
 
   fPhiCollinsSoperFrameJPsiH = new TH1F("fPhiCollinsSoperFrameJPsiH", "fPhiCollinsSoperFrameJPsiH", 10000, -10., 10.);
   fOutputList->Add(fPhiCollinsSoperFrameJPsiH);
+
+  for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++ ){
+    fCosThetaHelicityFrameJPsiRapidityBinsH[iRapidityBin] = new TH1F(
+                Form("fCosThetaHelicityFrameJPsiH_%d", iRapidityBin),
+                Form("fCosThetaHelicityFrameJPsiH_%d", iRapidityBin),
+                1000, -1., 1.
+              );
+    fOutputList->Add(fCosThetaHelicityFrameJPsiRapidityBinsH[iRapidityBin]);
+  }
+
+  for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++ ){
+    fCosThetaCollinsSoperFrameJPsiH[iRapidityBin] = new TH1F(
+                Form("fCosThetaCollinsSoperFrameJPsiH_%d", iRapidityBin),
+                Form("fCosThetaCollinsSoperFrameJPsiH_%d", iRapidityBin),
+                1000, -1., 1.
+              );
+    fOutputList->Add(fCosThetaCollinsSoperFrameJPsiH[iRapidityBin]);
+  }
+
+  for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++ ){
+    fPhiHelicityFrameJPsiH[iRapidityBin] = new TH1F(
+                Form("fPhiHelicityFrameJPsiH_%d", iRapidityBin),
+                Form("fPhiHelicityFrameJPsiH_%d", iRapidityBin),
+                10000, -10., 10.
+              );
+    fOutputList->Add(fPhiHelicityFrameJPsiH[iRapidityBin]);
+  }
+
+  for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++ ){
+    fPhiCollinsSoperFrameJPsiH[iRapidityBin] = new TH1F(
+                Form("fPhiCollinsSoperFrameJPsiH_%d", iRapidityBin),
+                Form("fPhiCollinsSoperFrameJPsiH_%d", iRapidityBin),
+                10000, -10., 10.
+              );
+    fOutputList->Add(fPhiCollinsSoperFrameJPsiH[iRapidityBin]);
+  }
 
   //_______________________________
   // - End of the function

--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
@@ -580,38 +580,38 @@ void AliAnalysisTaskUPCforward::UserCreateOutputObjects()
 
   for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++ ){
     fCosThetaHelicityFrameJPsiRapidityBinsH[iRapidityBin] = new TH1F(
-                Form("fCosThetaHelicityFrameJPsiH_%d", iRapidityBin),
-                Form("fCosThetaHelicityFrameJPsiH_%d", iRapidityBin),
+                Form("fCosThetaHelicityFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                Form("fCosThetaHelicityFrameJPsiRapidityBinsH_%d", iRapidityBin),
                 1000, -1., 1.
               );
     fOutputList->Add(fCosThetaHelicityFrameJPsiRapidityBinsH[iRapidityBin]);
   }
 
   for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++ ){
-    fCosThetaCollinsSoperFrameJPsiH[iRapidityBin] = new TH1F(
-                Form("fCosThetaCollinsSoperFrameJPsiH_%d", iRapidityBin),
-                Form("fCosThetaCollinsSoperFrameJPsiH_%d", iRapidityBin),
+    fCosThetaCollinsSoperFrameJPsiRapidityBinsH[iRapidityBin] = new TH1F(
+                Form("fCosThetaCollinsSoperFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                Form("fCosThetaCollinsSoperFrameJPsiRapidityBinsH_%d", iRapidityBin),
                 1000, -1., 1.
               );
-    fOutputList->Add(fCosThetaCollinsSoperFrameJPsiH[iRapidityBin]);
+    fOutputList->Add(fCosThetaCollinsSoperFrameJPsiRapidityBinsH[iRapidityBin]);
   }
 
   for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++ ){
-    fPhiHelicityFrameJPsiH[iRapidityBin] = new TH1F(
-                Form("fPhiHelicityFrameJPsiH_%d", iRapidityBin),
-                Form("fPhiHelicityFrameJPsiH_%d", iRapidityBin),
+    fPhiHelicityFrameJPsiRapidityBinsH[iRapidityBin] = new TH1F(
+                Form("fPhiHelicityFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                Form("fPhiHelicityFrameJPsiRapidityBinsH_%d", iRapidityBin),
                 10000, -10., 10.
               );
-    fOutputList->Add(fPhiHelicityFrameJPsiH[iRapidityBin]);
+    fOutputList->Add(fPhiHelicityFrameJPsiRapidityBinsH[iRapidityBin]);
   }
 
   for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++ ){
-    fPhiCollinsSoperFrameJPsiH[iRapidityBin] = new TH1F(
-                Form("fPhiCollinsSoperFrameJPsiH_%d", iRapidityBin),
-                Form("fPhiCollinsSoperFrameJPsiH_%d", iRapidityBin),
+    fPhiCollinsSoperFrameJPsiRapidityBinsH[iRapidityBin] = new TH1F(
+                Form("fPhiCollinsSoperFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                Form("fPhiCollinsSoperFrameJPsiRapidityBinsH_%d", iRapidityBin),
                 10000, -10., 10.
               );
-    fOutputList->Add(fPhiCollinsSoperFrameJPsiH[iRapidityBin]);
+    fOutputList->Add(fPhiCollinsSoperFrameJPsiRapidityBinsH[iRapidityBin]);
   }
 
   //_______________________________
@@ -1408,6 +1408,29 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
     for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++){
         if( (possibleJPsiCopy.Rapidity() + 4) < 1.5*(iRapidityBin + 1)/8 ){
           fThetaDistribOfPositiveMuonRestFrameJPsiRapidityBinH[iRapidityBin]->Fill(cosThetaMuonsRestFrame[0]);
+          /* - New part: filling all possible histograms!
+             -
+           */
+          fCosThetaHelicityFrameJPsiRapidityBinsH[iRapidityBin]->Fill( CosThetaHelicityFrame( muonsCopy2[0],
+                                                                                              muonsCopy2[1],
+                                                                                              possibleJPsiCopy
+                                                                                              )
+                                                                                           );
+          fCosThetaCollinsSoperFrameJPsiRapidityBinsH[iRapidityBin]->Fill( CosThetaCollinsSoper( muonsCopy2[0],
+                                                                                                 muonsCopy2[1],
+                                                                                                 possibleJPsiCopy
+                                                                                                 )
+                                                                                               );
+          fPhiHelicityFrameJPsiRapidityBinsH[iRapidityBin]->Fill( CosPhiHelicityFrame( muonsCopy2[0],
+                                                                                       muonsCopy2[1],
+                                                                                       possibleJPsiCopy
+                                                                                       )
+                                                                                     );
+          fPhiCollinsSoperFrameJPsiRapidityBinsH[iRapidityBin]->Fill( CosPhiCollinsSoper( muonsCopy2[0],
+                                                                                          muonsCopy2[1],
+                                                                                          possibleJPsiCopy
+                                                                                          )
+                                                                                        );
           break;
         }
     }

--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.h
@@ -577,6 +577,39 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  */
         TH1F*                   fPhiCollinsSoperFrameJPsiH;
 
+                                /**
+                                 * This histogram shows the angular distribution
+                                 * of the positive muon in the HELICITY frame.
+                                 * COS(THETA) distribution. Divided per
+                                 * rapidity bins.
+                                 */
+        TH1F*                   fCosThetaHelicityFrameJPsiRapidityBinsH[8];
+
+                                /**
+                                 * This histogram shows the angular distribution
+                                 * of the positive muon in the HELICITY frame.
+                                 * PHI distribution. Divided per
+                                 * rapidity bins.
+                                 */
+        TH1F*                   fPhiHelicityFrameJPsiRapidityBinsH[8];
+
+                                /**
+                                 * This histogram shows the angular distribution
+                                 * of the positive muon in the COLLINS-SOPER
+                                 * frame.  COS(THETA) distribution. Divided per
+                                 * rapidity bins.
+                                 */
+        TH1F*                   fCosThetaCollinsSoperFrameJPsiRapidityBinsH[8];
+
+                                /**
+                                 * This histogram shows the angular distribution
+                                 * of the positive muon in the COLLINS-SOPER
+                                 * frame. PHI distribution. Divided per
+                                 * rapidity bins.
+                                 */
+        TH1F*                   fPhiCollinsSoperFrameJPsiRapidityBinsH[8];
+
+
         //_______________________________
         // CUTS
         /*
@@ -637,7 +670,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforward, 4);
+        ClassDef(AliAnalysisTaskUPCforward, 5);
 };
 
 #endif

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
@@ -181,7 +181,15 @@ AliAnalysisTaskUPCforwardMC::AliAnalysisTaskUPCforwardMC()
       fMCCosThetaHelicityFrameJPsiH(0),
       fMCCosThetaCollinsSoperFrameJPsiH(0),
       fMCPhiHelicityFrameJPsiH(0),
-      fMCPhiCollinsSoperFrameJPsiH(0)
+      fMCPhiCollinsSoperFrameJPsiH(0),
+      fCosThetaHelicityFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fCosThetaCollinsSoperFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fPhiHelicityFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fPhiCollinsSoperFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fMCCosThetaHelicityFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fMCCosThetaCollinsSoperFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fMCPhiHelicityFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fMCPhiCollinsSoperFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0}
 {
     // default constructor, don't allocate memory here!
     // this is used by root for IO purposes, it needs to remain empty
@@ -288,7 +296,15 @@ AliAnalysisTaskUPCforwardMC::AliAnalysisTaskUPCforwardMC( const char* name )
       fMCCosThetaHelicityFrameJPsiH(0),
       fMCCosThetaCollinsSoperFrameJPsiH(0),
       fMCPhiHelicityFrameJPsiH(0),
-      fMCPhiCollinsSoperFrameJPsiH(0)
+      fMCPhiCollinsSoperFrameJPsiH(0),
+      fCosThetaHelicityFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fCosThetaCollinsSoperFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fPhiHelicityFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fPhiCollinsSoperFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fMCCosThetaHelicityFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fMCCosThetaCollinsSoperFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fMCPhiHelicityFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0},
+      fMCPhiCollinsSoperFrameJPsiRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0}
 {
     FillGoodRunVector(fVectorGoodRunNumbers);
 
@@ -567,6 +583,84 @@ void AliAnalysisTaskUPCforwardMC::UserCreateOutputObjects()
 
   fMCPhiCollinsSoperFrameJPsiH = new TH1F("fMCPhiCollinsSoperFrameJPsiH", "fMCPhiCollinsSoperFrameJPsiH", 10000, -10., 10.);
   fOutputList->Add(fMCPhiCollinsSoperFrameJPsiH);
+
+  /* - Rapidity-dependent analysis for the helicity of the J/Psi.
+     - It is divided into RECONSTRUCTED and GENERATED for both
+     - helicity frame and Colin-Sopers.
+     -
+   */
+  for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++ ){
+    fCosThetaHelicityFrameJPsiRapidityBinsH[iRapidityBin] = new TH1F(
+                Form("fCosThetaHelicityFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                Form("fCosThetaHelicityFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                1000, -1., 1.
+              );
+    fOutputList->Add(fCosThetaHelicityFrameJPsiRapidityBinsH[iRapidityBin]);
+  }
+
+  for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++ ){
+    fCosThetaCollinsSoperFrameJPsiRapidityBinsH[iRapidityBin] = new TH1F(
+                Form("fCosThetaCollinsSoperFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                Form("fCosThetaCollinsSoperFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                1000, -1., 1.
+              );
+    fOutputList->Add(fCosThetaCollinsSoperFrameJPsiRapidityBinsH[iRapidityBin]);
+  }
+
+  for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++ ){
+    fPhiHelicityFrameJPsiRapidityBinsH[iRapidityBin] = new TH1F(
+                Form("fPhiHelicityFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                Form("fPhiHelicityFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                10000, -10., 10.
+              );
+    fOutputList->Add(fPhiHelicityFrameJPsiRapidityBinsH[iRapidityBin]);
+  }
+
+  for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++ ){
+    fPhiCollinsSoperFrameJPsiRapidityBinsH[iRapidityBin] = new TH1F(
+                Form("fPhiCollinsSoperFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                Form("fPhiCollinsSoperFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                10000, -10., 10.
+              );
+    fOutputList->Add(fPhiCollinsSoperFrameJPsiRapidityBinsH[iRapidityBin]);
+  }
+
+  for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++ ){
+    fMCCosThetaHelicityFrameJPsiRapidityBinsH[iRapidityBin] = new TH1F(
+                Form("fMCCosThetaHelicityFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                Form("fMCCosThetaHelicityFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                1000, -1., 1.
+              );
+    fOutputList->Add(fMCCosThetaHelicityFrameJPsiRapidityBinsH[iRapidityBin]);
+  }
+
+  for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++ ){
+    fMCCosThetaCollinsSoperFrameJPsiRapidityBinsH[iRapidityBin] = new TH1F(
+                Form("fMCCosThetaCollinsSoperFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                Form("fMCCosThetaCollinsSoperFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                1000, -1., 1.
+              );
+    fOutputList->Add(fMCCosThetaCollinsSoperFrameJPsiRapidityBinsH[iRapidityBin]);
+  }
+
+  for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++ ){
+    fMCPhiHelicityFrameJPsiRapidityBinsH[iRapidityBin] = new TH1F(
+                Form("fMCPhiHelicityFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                Form("fMCPhiHelicityFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                10000, -10., 10.
+              );
+    fOutputList->Add(fMCPhiHelicityFrameJPsiRapidityBinsH[iRapidityBin]);
+  }
+
+  for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++ ){
+    fMCPhiCollinsSoperFrameJPsiRapidityBinsH[iRapidityBin] = new TH1F(
+                Form("fMCPhiCollinsSoperFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                Form("fMCPhiCollinsSoperFrameJPsiRapidityBinsH_%d", iRapidityBin),
+                10000, -10., 10.
+              );
+    fOutputList->Add(fMCPhiCollinsSoperFrameJPsiRapidityBinsH[iRapidityBin]);
+  }
+
 
   //_______________________________
   // - End of the function

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
@@ -1160,6 +1160,29 @@ void AliAnalysisTaskUPCforwardMC::UserExec(Option_t *)
     for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++){
         if( (possibleJPsiCopy.Rapidity() + 4) < 1.5*(iRapidityBin + 1)/8 ){
           fThetaDistribOfPositiveMuonRestFrameJPsiRapidityBinH[iRapidityBin]->Fill(cosThetaMuonsRestFrame[0]);
+          /* - New part: filling all possible histograms!
+             -
+           */
+          fCosThetaHelicityFrameJPsiRapidityBinsH[iRapidityBin]->Fill( CosThetaHelicityFrame( muonsCopy2[0],
+                                                                                              muonsCopy2[1],
+                                                                                              possibleJPsiCopy
+                                                                                              )
+                                                                                           );
+          fCosThetaCollinsSoperFrameJPsiRapidityBinsH[iRapidityBin]->Fill( CosThetaCollinsSoper( muonsCopy2[0],
+                                                                                                 muonsCopy2[1],
+                                                                                                 possibleJPsiCopy
+                                                                                                 )
+                                                                                               );
+          fPhiHelicityFrameJPsiRapidityBinsH[iRapidityBin]->Fill( CosPhiHelicityFrame( muonsCopy2[0],
+                                                                                       muonsCopy2[1],
+                                                                                       possibleJPsiCopy
+                                                                                       )
+                                                                                     );
+          fPhiCollinsSoperFrameJPsiRapidityBinsH[iRapidityBin]->Fill( CosPhiCollinsSoper( muonsCopy2[0],
+                                                                                          muonsCopy2[1],
+                                                                                          possibleJPsiCopy
+                                                                                          )
+                                                                                        );
           break;
         }
     }
@@ -1421,6 +1444,29 @@ void AliAnalysisTaskUPCforwardMC::ProcessMCParticles(AliMCEvent* fMCEventArg)
                   for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++){
                       if( (possibleJPsiMC.Rapidity() + 4) < 1.5*(iRapidityBin + 1)/8 ){
                         fMCthetaDistribOfPositiveMuonRestFrameJPsiGeneratedTruthRapidityBinH[iRapidityBin]->Fill(cosThetaMuonsRestFrameMC[1]);
+                        /* - New part: filling all possible histograms!
+                           -
+                         */
+                        fMCCosThetaHelicityFrameJPsiRapidityBinsH[iRapidityBin]->Fill( CosThetaHelicityFrame( muonsMCcopy[1],
+                                                                                                              muonsMCcopy[0],
+                                                                                                              possibleJPsiMC
+                                                                                                              )
+                                                                                                            );
+                        fMCCosThetaCollinsSoperFrameJPsiRapidityBinsH[iRapidityBin]->Fill( CosThetaCollinsSoper( muonsMCcopy[1],
+                                                                                                                 muonsMCcopy[0],
+                                                                                                                 possibleJPsiMC
+                                                                                                                 )
+                                                                                                               );
+                        fMCPhiHelicityFrameJPsiRapidityBinsH[iRapidityBin]->Fill( CosPhiHelicityFrame( muonsMCcopy[1],
+                                                                                                       muonsMCcopy[0],
+                                                                                                       possibleJPsiMC
+                                                                                                       )
+                                                                                                     );
+                        fMCPhiCollinsSoperFrameJPsiRapidityBinsH[iRapidityBin]->Fill( CosPhiCollinsSoper( muonsMCcopy[1],
+                                                                                                          muonsMCcopy[0],
+                                                                                                          possibleJPsiMC
+                                                                                                          )
+                                                                                                        );
                         break;
                       }
                   }

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
@@ -549,6 +549,39 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
                                 /**
                                  * This histogram shows the angular distribution
                                  * of the positive muon in the HELICITY frame.
+                                 * COS(THETA) distribution. Divided per
+                                 * rapidity bins. RECONSTRUCTED.
+                                 */
+        TH1F*                   fCosThetaHelicityFrameJPsiRapidityBinsH[8];
+
+                                /**
+                                 * This histogram shows the angular distribution
+                                 * of the positive muon in the HELICITY frame.
+                                 * PHI distribution. Divided per
+                                 * rapidity bins. RECONSTRUCTED.
+                                 */
+        TH1F*                   fPhiHelicityFrameJPsiRapidityBinsH[8];
+
+                                /**
+                                 * This histogram shows the angular distribution
+                                 * of the positive muon in the COLLINS-SOPER
+                                 * frame.  COS(THETA) distribution. Divided per
+                                 * rapidity bins. RECONSTRUCTED.
+                                 */
+        TH1F*                   fCosThetaCollinsSoperFrameJPsiRapidityBinsH[8];
+
+                                /**
+                                 * This histogram shows the angular distribution
+                                 * of the positive muon in the COLLINS-SOPER
+                                 * frame. PHI distribution. Divided per
+                                 * rapidity bins. RECONSTRUCTED.
+                                 */
+        TH1F*                   fPhiCollinsSoperFrameJPsiRapidityBinsH[8];
+
+
+                                /**
+                                 * This histogram shows the angular distribution
+                                 * of the positive muon in the HELICITY frame.
                                  * COS(THETA) distribution. GENERATED
                                  */
         TH1F*                   fMCCosThetaHelicityFrameJPsiH;
@@ -573,6 +606,39 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
                                  * frame. PHI distribution. GENERATED
                                  */
         TH1F*                   fMCPhiCollinsSoperFrameJPsiH;
+
+                                /**
+                                 * This histogram shows the angular distribution
+                                 * of the positive muon in the HELICITY frame.
+                                 * COS(THETA) distribution. Divided per
+                                 * rapidity bins. GENERATED.
+                                 */
+        TH1F*                   fMCCosThetaHelicityFrameJPsiRapidityBinsH[8];
+
+                                /**
+                                 * This histogram shows the angular distribution
+                                 * of the positive muon in the HELICITY frame.
+                                 * PHI distribution. Divided per
+                                 * rapidity bins. GENERATED.
+                                 */
+        TH1F*                   fMCPhiHelicityFrameJPsiRapidityBinsH[8];
+
+                                /**
+                                 * This histogram shows the angular distribution
+                                 * of the positive muon in the COLLINS-SOPER
+                                 * frame.  COS(THETA) distribution. Divided per
+                                 * rapidity bins. GENERATED.
+                                 */
+        TH1F*                   fMCCosThetaCollinsSoperFrameJPsiRapidityBinsH[8];
+
+                                /**
+                                 * This histogram shows the angular distribution
+                                 * of the positive muon in the COLLINS-SOPER
+                                 * frame. PHI distribution. Divided per
+                                 * rapidity bins. GENERATED.
+                                 */
+        TH1F*                   fMCPhiCollinsSoperFrameJPsiRapidityBinsH[8];
+
 
         //_______________________________
         // CUTS
@@ -655,7 +721,7 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforwardMC, 4);
+        ClassDef(AliAnalysisTaskUPCforwardMC, 5);
 };
 
 #endif


### PR DESCRIPTION
Added the Y-dependent helicity analysis both for the Helicity frame and the Colin-Soper helicity frame. Changed the ZNC and ZNA energy threshold values for the differential neutron emission analysis. This way the 0N0N, XN0N, 0NXN, XNXN invariant mass plots would become available.
TESTED