### PR TITLE
TENDER/TenderSupplies: Re-added the MC energy fractions per label to the output

### DIFF
--- a/TENDER/TenderSupplies/AliEMCALTenderSupply.cxx
+++ b/TENDER/TenderSupplies/AliEMCALTenderSupply.cxx
@@ -2063,8 +2063,7 @@ void AliEMCALTenderSupply::RecPoints2Clusters(TClonesArray *clus)
     if (parentMult > 0)
     {
       c->SetLabel(parentList, parentMult);
-      if(fSetCellMCLabelFromEdepFrac)
-        c->SetClusterMCEdepFractionFromEdepArray(parentListDE);
+      c->SetClusterMCEdepFractionFromEdepArray(parentListDE);
     }
     
     //


### PR DESCRIPTION
Some time ago, there was a commit that removed the MC energy fractions from the standard output of the Tender, see https://github.com/alisw/AliPhysics/commit/2f73f2c9d567be9d01552e3c6c52090622fa8f22#diff-ce4c5e3ee3cdb974ac13f17ca80cbf21 
As this is rather crucial information and the boolean fSetCellMCLabelFromEdepFrac also modifies the information stored in these fractions, i would highly recommend to add the fractions back to the output.

Maybe @gconesab knows why this was put behind the if() condition.