### PR TITLE
PWGGA/GammaConv: Added mult. pi0 treatment and cluster energy fraction per MC label for mEDC

### DIFF
--- a/PWGGA/GammaConv/AliAODConversionPhoton.h
+++ b/PWGGA/GammaConv/AliAODConversionPhoton.h
@@ -67,9 +67,12 @@ class AliAODConversionPhoton : public AliAODConversionParticle, public AliConver
     Int_t GetCaloPhotonMotherMCLabel(Int_t i){return fCaloPhotonMotherMCLabels[i];}
     Int_t GetNNeutralPionMCLabels(){return fNNeutralPionLabels;}
     Int_t GetNeutralPionMCLabel(Int_t i){return fNeutralPionLabels[i];}
+    Float_t GetNeutralPionEnergyFraction(Int_t i){return fNeutralPionEnergyFraction[i];}
+    Float_t GetLeadingNeutralPionIndex(){return fLeadingNeutralPionIndex;}
+    Int_t GetLeadingNeutralPionDaughterIndex(){return fLeadingNeutralPionDaughterIndex;}
 
-    void SetCaloPhotonMCFlags(AliMCEvent *mcEvent, Bool_t enableSort, Bool_t mergedAnalysis = kFALSE);
-    void SetCaloPhotonMCFlagsAOD(AliVEvent* event, Bool_t enableSort, Bool_t mergedAnalysis = kFALSE);
+    void SetCaloPhotonMCFlags(AliMCEvent *mcEvent, Bool_t enableSort, Bool_t mergedAnalysis = kFALSE, AliVCluster* cluster = NULL);
+    void SetCaloPhotonMCFlagsAOD(AliVEvent* event, Bool_t enableSort, Bool_t mergedAnalysis = kFALSE, AliVCluster* cluster = NULL);
     void SetCaloClusterRef(Long_t ref){fCaloClusterRef = ref;}
     Long_t GetCaloClusterRef()const {return fCaloClusterRef;}
     void PrintCaloMCLabelsAndInfo(AliMCEvent *mcEvent);
@@ -100,6 +103,9 @@ class AliAODConversionPhoton : public AliAODConversionParticle, public AliConver
     Long_t fCaloPhotonMCLabels[50];         //!
     Long_t fCaloPhotonMotherMCLabels[20];   //!
     Long_t fNeutralPionLabels[20];   //!
+    Int_t fLeadingNeutralPionIndex;   //!
+    Int_t fLeadingNeutralPionDaughterIndex;   //!
+    Float_t fNeutralPionEnergyFraction[20];   //!
     Long_t fCaloClusterRef;                 //!
     Float_t fDCArPrimVtx;
     Float_t fDCAzPrimVtx;
@@ -112,7 +118,7 @@ class AliAODConversionPhoton : public AliAODConversionParticle, public AliConver
     Bool_t fCaloPhoton;                     //!
     Bool_t fUseForMesonPair;                //!
 
-    ClassDef(AliAODConversionPhoton,8)
+    ClassDef(AliAODConversionPhoton,9)
 };
 
 

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMerged.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaCaloMerged.h
@@ -50,9 +50,9 @@ class AliAnalysisTaskGammaCaloMerged : public AliAnalysisTaskSE {
     // determine source according to pdg code of mother
     Int_t GetSourceClassification(Int_t daughter, Int_t pdgCode);
 
-    void ProcessTrueClusterCandidates( AliAODConversionPhoton* TruePhotonCandidate, Float_t m02, AliAODConversionPhoton *TrueSubClusterCandidate1,
+    void ProcessTrueClusterCandidates( AliAODConversionPhoton* TruePhotonCandidate, AliVCluster* cluster, AliAODConversionPhoton *TrueSubClusterCandidate1,
                                     AliAODConversionPhoton *TrueSubClusterCandidate2);
-    void ProcessTrueClusterCandidatesAOD( AliAODConversionPhoton* TruePhotonCandidate, Float_t m02, AliAODConversionPhoton *TrueSubClusterCandidate1,
+    void ProcessTrueClusterCandidatesAOD( AliAODConversionPhoton* TruePhotonCandidate, AliVCluster* cluster, AliAODConversionPhoton *TrueSubClusterCandidate1,
                                     AliAODConversionPhoton *TrueSubClusterCandidate2);
 // //     void ProcessTrueMesonCandidates( AliAODConversionMother *Pi0Candidate, AliAODConversionPhoton *TrueGammaCandidate0, AliAODConversionPhoton *TrueGammaCandidate1);
 
@@ -92,6 +92,8 @@ class AliAnalysisTaskGammaCaloMerged : public AliAnalysisTaskSE {
     void SetLogBinningXTH2(TH2* histoRebin);
 
     Bool_t CheckVectorForDoubleCount(vector<Int_t> &vec, Int_t tobechecked);
+    Bool_t CheckVector1ForEntryAndFillVector2(vector<Int_t> vecCheck, vector<Int_t> &vecFill, Int_t tobechecked);
+
     void FillMultipleCountMap(map<Int_t,Int_t> &ma, Int_t tobechecked);
     void FillMultipleCountHistoAndClear(map<Int_t,Int_t> &ma, TH1F* hist);
 
@@ -163,6 +165,7 @@ class AliAnalysisTaskGammaCaloMerged : public AliAnalysisTaskSE {
     TH1F**                  fHistoMCEtaDalitzWOWeightPt;                        //! array of histos with unweighted eta Dalitz, pT
     TH1F**                  fHistoMCEtaDalitzWOEvtWeightPt;                     //! array of histos without event weights eta Dalitz, pT
     TH1F**                  fHistoMCPi0InAccPt;                                 //! array of histos with weighted pi0 in acceptance, pT
+    TH1F**                  fHistoMCPi0ReducedInAccPt;                          //! array of histos with weighted pi0 in acceptance, pT
     TH1F**                  fHistoMCEtaInAccPt;                                 //! array of histos with weighted eta in acceptance, pT
     TH1F**                  fHistoMCPi0WOEvtWeightInAccPt;                      //! array of histos without evt weight pi0 in acceptance, pT
     TH1F**                  fHistoMCEtaWOEvtWeightInAccPt;                      //! array of histos without evt weight eta in acceptance, pT
@@ -247,6 +250,9 @@ class AliAnalysisTaskGammaCaloMerged : public AliAnalysisTaskSE {
     TH2F**                  fHistoDoubleCountTrueMultiplePi0PtvsM02;            //! array of histos with double counted pi0s, pT, M02
     TH1F**                  fHistoDoubleCountTrueMultipleSecPi0Pt;              //! array of histos with double counted secondary pi0s, pT, M02
     TH2F**                  fHistoDoubleCountTrueEtaPtvsM02;                    //! array of histos with double counted etas, pT, M02
+    vector<Int_t>           fVectorLabelsLeadingPi0;                            //! vector containing labels of validated pi0
+    vector<Int_t>           fVectorLabelsMultiplePi0;                           //! vector containing labels of validated pi0
+    vector<Int_t>           fVectorLabelsMultiplePi0Reduced;                    //! vector containing labels of validated pi0
     vector<Int_t>           fVectorDoubleCountTruePi0s;                         //! vector containing labels of validated pi0
     vector<Int_t>           fVectorDoubleCountTrueMultilePi0s;                  //! vector containing labels of validated pi0
     vector<Int_t>           fVectorDoubleCountTrueEtas;                         //! vector containing labels of validated eta
@@ -289,7 +295,7 @@ class AliAnalysisTaskGammaCaloMerged : public AliAnalysisTaskSE {
     AliAnalysisTaskGammaCaloMerged(const AliAnalysisTaskGammaCaloMerged&); // Prevent copy-construction
     AliAnalysisTaskGammaCaloMerged &operator=(const AliAnalysisTaskGammaCaloMerged&); // Prevent assignment
 
-    ClassDef(AliAnalysisTaskGammaCaloMerged, 30);
+    ClassDef(AliAnalysisTaskGammaCaloMerged, 31);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_ClusterQA.C
+++ b/PWGGA/GammaConv/macros/AddTask_ClusterQA.C
@@ -102,7 +102,8 @@ TObjArray *rmaxFacPtHardSetting = settingMaxFacPtHard.Tokenize("_");
   if(fMaxPtHardSet)
     analysisEventCuts->SetMaxFacPtHard(maxFacPtHard);
   if(fSingleMaxPtHardSet)
-    analysisEventCuts->SetMaxFacPtHardSingleParticle(maxFacPtHardSingle);  analysisEventCuts->SetCorrectionTaskSetting(corrTaskSetting);
+    analysisEventCuts->SetMaxFacPtHardSingleParticle(maxFacPtHardSingle);
+  analysisEventCuts->SetCorrectionTaskSetting(corrTaskSetting);
   if (periodNameV0Reader.CompareTo("") != 0) analysisEventCuts->SetPeriodEnum(periodNameV0Reader);
   analysisEventCuts->InitializeCutsFromCutString(TaskEventCutnumber.Data());
   analysisEventCuts->SetFillCutHistograms("",kFALSE);


### PR DESCRIPTION
This PR provides a better MC treatment for the merged cluster analysis. 
The main change is that one now has access to all MC pi0s that contributed to a cluster as well as the leading pi0 whose daughters deposited the most energy. Everything that was added is well protected by the "mergedAnalysis" boolean which is only set in the merged analysis task.

The changes to the merged analysis task involve the treatment of multiple pi0s in one cluster where a new histogram is filled with all true MC pi0s that could never be reconstructed due to overlap in a cluster. Extensive comments in the code were added to ensure proper documentation of the changes.