### PR TITLE
Fix narrowing conversion error in new  MacOS

### DIFF
--- a/PWGLF/SPECTRA/ChargedHadrons/dNdPt/AlidNdPtAnalysis.cxx
+++ b/PWGLF/SPECTRA/ChargedHadrons/dNdPt/AlidNdPtAnalysis.cxx
@@ -2000,7 +2000,7 @@ void AlidNdPtAnalysis::Process(AliESDEvent *const esdEvent, AliMCEvent *const mc
                             Double_t vRecMCEventHist2[3] = {vtxESD->GetX()-vtxMC[0],vtxESD->GetZ()-vtxMC[2],static_cast<Double_t>(multMBTracks)};
                             fRecMCEventHist2->Fill(vRecMCEventHist2);
 
-                            Double_t vRecMCEventHist3[2] = {static_cast<Double_t>(multRecMult),evtType};
+                            Double_t vRecMCEventHist3[2] = {static_cast<Double_t>(multRecMult),static_cast<Double_t>(evtType)};
                             fRecMCEventHist3->Fill(vRecMCEventHist3);
                         }
 

--- a/PWGLF/SPECTRA/ChargedHadrons/dNdPt/AlidNdPtAnalysispPb.cxx
+++ b/PWGLF/SPECTRA/ChargedHadrons/dNdPt/AlidNdPtAnalysispPb.cxx
@@ -1920,7 +1920,7 @@ void AlidNdPtAnalysispPb::Process(AliESDEvent *const esdEvent, AliMCEvent *const
          Double_t vRecMCEventHist2[3] = {vtxESD->GetX()-vtxMC[0],vtxESD->GetZ()-vtxMC[2],static_cast<Double_t>(multMBTracks)};
          fRecMCEventHist2->Fill(vRecMCEventHist2);
 
-         Double_t vRecMCEventHist3[2] = {static_cast<Double_t>(multRec),evtType};
+         Double_t vRecMCEventHist3[2] = {static_cast<Double_t>(multRec),static_cast<Double_t>(evtType)};
          fRecMCEventHist3->Fill(vRecMCEventHist3);
        }
 


### PR DESCRIPTION
Cast conversion to avoid narrowing conversion error while compiling in new MacOS (10.14.4) and Xcode (10.2)