### PR TITLE
Fix narrowing conversion error in new  MacOS

### DIFF
--- a/PWGCF/FLOW/Forward/AliForwardGenericFramework.cxx
+++ b/PWGCF/FLOW/Forward/AliForwardGenericFramework.cxx
@@ -214,14 +214,14 @@ void AliForwardGenericFramework::saveEvent(TList* outputList, double cent, doubl
         if (prevRefEtaBin){ // only used once
 
           if (!(fSettings.etagap)){
-            Double_t z[5] = {noSamples, zvertex, refEtaA, cent, fSettings.kW2Two};
+            Double_t z[5] = {noSamples, zvertex, refEtaA, cent, static_cast<Double_t>(fSettings.kW2Two)};
             fQcorrfactor->Fill(z, fAutoRef.GetBinContent(etaBin));
           }
           // two-particle cumulant
           double two = Two(n, -n, refEtaBinA, refEtaBinB).Re();
           double dn2 = Two(0,0, refEtaBinA, refEtaBinB).Re();
 
-          Double_t x[5] = {noSamples, zvertex, refEtaA, cent, fSettings.kW4Four};
+          Double_t x[5] = {noSamples, zvertex, refEtaA, cent, static_cast<Double_t>(fSettings.kW4Four)};
           x[4] = fSettings.kW2Two;
           cumuRef->Fill(x, two);
           x[4] = fSettings.kW2;
@@ -240,14 +240,14 @@ void AliForwardGenericFramework::saveEvent(TList* outputList, double cent, doubl
         }
         // DIFFERENTIAL FLOW -----------------------------------------------------------------------------
         if (n == 2 && (!(fSettings.etagap))){
-          Double_t k[5] = {noSamples, zvertex, eta, cent, fSettings.kW2Two};
+          Double_t k[5] = {noSamples, zvertex, eta, cent, static_cast<Double_t>(fSettings.kW2Two)};
           fpcorrfactor->Fill(k, fAutoDiff.GetBinContent(etaBin));
         }
         // two-particle cumulant
         double twodiff = TwoDiff(n, -n, refEtaBinB, etaBin).Re();
         double dn2diff = TwoDiff(0,0, refEtaBinB, etaBin).Re();
 
-        Double_t y[5] = {noSamples, zvertex, eta, cent, fSettings.kW2Two};
+        Double_t y[5] = {noSamples, zvertex, eta, cent, static_cast<Double_t>(fSettings.kW2Two)};
         cumuDiff->Fill(y, twodiff);
         y[4] = fSettings.kW2;
         cumuDiff->Fill(y, dn2diff);

--- a/PWGCF/FLOW/Forward/AliForwardQCumulantRun2.cxx
+++ b/PWGCF/FLOW/Forward/AliForwardQCumulantRun2.cxx
@@ -211,7 +211,7 @@ void AliForwardQCumulantRun2::saveEvent(TH2D& dNdetadphi, TList* outputList, dou
             //if (w2 <= 0) continue;
             //if (two/w2 < 0) continue;
 
-            Double_t x[5] = {noSamples, vertexpos, refEtaA, cent, fSettings.kW4Four};
+            Double_t x[5] = {noSamples, vertexpos, refEtaA, cent, static_cast<Double_t>(fSettings.kW4Four)};
 
             x[4] = fSettings.kW2Two;
             cumuRef->Fill(x, two);
@@ -310,7 +310,7 @@ void AliForwardQCumulantRun2::saveEvent(TH2D& dNdetadphi, TList* outputList, dou
                       std::cout << "pnIm = " << pnIm << std::endl;
            std::cout << "dQnImB = " << dQnImB << std::endl;
 }
-        Double_t x[5] = {noSamples,vertexpos, eta, cent, fSettings.kW2Two};
+        Double_t x[5] = {noSamples,vertexpos, eta, cent, static_cast<Double_t>(fSettings.kW2Two)};
         cumuDiff->Fill(x, twoPrime);
 
         x[4] = fSettings.kW2;


### PR DESCRIPTION
Just a simple explicit cast in array initialisation to avoid compilation error in MacOS 10.14.4 with Xcode 10.2 due to narrowing conversion....