### PR TITLE
Added a class of histograms which can have the VZERO channel number o…

### DIFF
--- a/PWGDQ/reducedTree/AliReducedAnalysisJpsi2ee.cxx
+++ b/PWGDQ/reducedTree/AliReducedAnalysisJpsi2ee.cxx
@@ -277,7 +277,7 @@ void AliReducedAnalysisJpsi2ee::Process() {
   }
 
   // apply event selection
-  if(!IsEventSelected(fEvent)) return;
+  if(!IsEventSelected(fEvent, fValues)) return;
   
   // fill calorimeter info histograms before event cuts
   if(fFillCaloClusterHistograms) {
@@ -335,6 +335,11 @@ void AliReducedAnalysisJpsi2ee::Process() {
      AliReducedVarManager::FillEventOnlineTrigger(ibit, fValues);
      fHistosManager->FillHistClass("EventTriggers_AfterCuts", fValues);
   }
+  for(UShort_t ich=0; ich<64; ++ich) {
+     AliReducedVarManager::FillV0Channel(ich, fValues);
+     fHistosManager->FillHistClass("V0Channels", fValues);
+  }
+  
 }
 
 

--- a/PWGDQ/reducedTree/AliReducedAnalysisTest.cxx
+++ b/PWGDQ/reducedTree/AliReducedAnalysisTest.cxx
@@ -339,8 +339,13 @@ void AliReducedAnalysisTest::Process() {
     }  // end loop over pairs
   }  // end if(pairList)
     
-  if(fFillEventHistograms)
+  if(fFillEventHistograms) {
       fHistosManager->FillHistClass("Event_AfterCuts", fValues);
+      for(UShort_t ich=0; ich<64; ++ich) {
+         AliReducedVarManager::FillV0Channel(ich, fValues);
+         fHistosManager->FillHistClass("V0Channels", fValues);
+      }
+  }
 }
 
 //___________________________________________________________________________

--- a/PWGDQ/reducedTree/AliReducedVarManager.cxx
+++ b/PWGDQ/reducedTree/AliReducedVarManager.cxx
@@ -1292,6 +1292,23 @@ void AliReducedVarManager::FillEventOnlineTrigger(UShort_t triggerBit, Float_t* 
      values[kOnlineTriggerFired2] = (((AliReducedEventInfo*)fgEvent)->TriggerMask()&(ULong_t(1)<<triggerBit2) ? triggerBit2 : -1.0);
 }
 
+//________________________________________________________________
+void AliReducedVarManager::FillV0Channel(Int_t ich, Float_t* values) {
+   //
+   // Update the V0 channel number
+   //
+   if(ich>=0 && ich<64) {
+      values[kVZEROCurrentChannel] = ich;
+      values[kVZEROCurrentChannelMult] = values[kVZEROChannelMult+ich];
+      values[kVZEROCurrentChannelMultCalib] = values[kVZEROChannelMultCalib+ich];
+   }
+   else {
+      values[kVZEROCurrentChannel] = -1;
+      values[kVZEROCurrentChannelMult] = -999.;
+      values[kVZEROCurrentChannelMultCalib] = -999.;
+   }
+}
+
 //_________________________________________________________________
 void AliReducedVarManager::FillMCTruthInfo(TRACK* p, Float_t* values, TRACK* leg1 /* = 0x0 */, TRACK* leg2 /* = 0x0 */) {
    //
@@ -2690,6 +2707,9 @@ void AliReducedVarManager::SetDefaultVarNames() {
   }
   fgVariableNames[kSPDnSingleClusters]  = "SPD single clusters";    fgVariableUnits[kSPDnSingleClusters]  = "";  
   fgVariableNames[kEventMixingId]       = "Event mixing id";        fgVariableUnits[kEventMixingId]       = "";  
+  fgVariableNames[kVZEROCurrentChannel] = "VZERO channel";          fgVariableUnits[kVZEROCurrentChannel] = "";
+  fgVariableNames[kVZEROCurrentChannelMult] = "VZERO channel multiplicity";   fgVariableUnits[kVZEROCurrentChannelMult] = "";
+  fgVariableNames[kVZEROCurrentChannelMultCalib] = "VZERO channel calibrated multiplicity";   fgVariableUnits[kVZEROCurrentChannelMultCalib] = "";
   fgVariableNames[kVZEROAemptyChannels] = "VZERO-A empty channels"; fgVariableUnits[kVZEROAemptyChannels] = "";
   fgVariableNames[kVZEROCemptyChannels] = "VZERO-C empty channels"; fgVariableUnits[kVZEROCemptyChannels] = "";
   for(Int_t ich=0;ich<64;++ich) {

--- a/PWGDQ/reducedTree/AliReducedVarManager.h
+++ b/PWGDQ/reducedTree/AliReducedVarManager.h
@@ -340,6 +340,9 @@ class AliReducedVarManager : public TObject {
     kSPDnSingleClusters=kITSnClusters+6,   // number of clusters in SPD layer 1 not mached to tracklets from layer 2
     kEventMixingId,     // Id of the event mixing category 
     // VZERO event plane related variables
+    kVZEROCurrentChannel,         // current VZERO channel
+    kVZEROCurrentChannelMult,     // current VZERO channel multiplicity
+    kVZEROCurrentChannelMultCalib,  // current VZERO channel calibrated multiplicity
     kVZEROAemptyChannels,  // Number of empty VZERO channels in A side          
     kVZEROCemptyChannels,  // Number of empty VZERO channels in C side          
     kVZEROChannelMult,                        // VZERO multiplicity per channel 
@@ -685,6 +688,7 @@ class AliReducedVarManager : public TObject {
   static void FillL0TriggerInputs(AliReducedEventInfo* event, Int_t input, Float_t* values, Int_t input2=999);
   static void FillL1TriggerInputs(AliReducedEventInfo* event, Int_t input, Float_t* values, Int_t input2=999);
   static void FillL2TriggerInputs(AliReducedEventInfo* event, Int_t input, Float_t* values, Int_t input2=999);
+  static void FillV0Channel(Int_t ich, Float_t* values);
   static void FillTrackingFlag(AliReducedTrackInfo* track, UInt_t flag, Float_t* values);
   static void FillTrackQualityFlag(AliReducedBaseTrack* track, UShort_t flag, Float_t* values, UShort_t flag2=999);
   static void FillTrackMCFlag(AliReducedBaseTrack* track, UShort_t flag, Float_t* values, UShort_t flag2=999);


### PR DESCRIPTION
…n one of the axes

and fill, e.g., per channel multiplicity or other quantities. The histogram class is called V0Channels
and is added to both jpsi2ee and testTask.
One small fix in the jpsi2ee task: in Process(), the IsEventSelected() is called now using
IsEventSelected(event, fValues) instead of IsEventSelected(event) which does not need an additional VarManager::FillEventInfo()