### PR TITLE
Provisions to supercalibrate old datasets

### DIFF
--- a/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibratorMC.h
+++ b/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibratorMC.h
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include "TNamed.h"
+#include <map>
 
 using namespace std;
 class AliESDEvent;
@@ -66,6 +67,8 @@ public:
     //Helper
     Float_t MinVal( Float_t A, Float_t B );
     
+    void AddV0MCutoff( Int_t lRunNumber, Float_t lV0MCutoff );
+    
 private:
     AliMultInput     *fInput;     //Object for all input
     AliMultSelection *fSelection; //Object for all estimators
@@ -91,8 +94,12 @@ private:
     AliMultSelectionCuts *fMultSelectionCuts;
     
     // TList object for storing histograms
-    TList *fCalibHists; 
+    TList *fCalibHists;
 
+    //Run maps: for manual V0M cutoff if requested
+    Long_t fNV0MCutoffs;
+    std::map<int, float> fV0MCutoffs;
+    
     ClassDef(AliMultSelectionCalibratorMC, 1);
 };
 #endif


### PR DESCRIPTION
Implements a map that allows the MC calibrator steering macro to define a highest-threshold for the V0M amplitudes so that one can reject too-high-multiplicity events roughly. This is not a replacement for generating tuned MC but will serve as a stopgap solution that allows us to use older, already generated MC using the same supercalibration used in 2018 MC to almost the same effect in terms of <Ntracklets> vs V0M matchup. 