### PR TITLE
AliFemtoKKTrackCutFull bug fix - NSigmaTOF for 450_500 never used

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoKKTrackCutFull.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoKKTrackCutFull.cxx
@@ -943,7 +943,7 @@ bool AliFemtoKKTrackCutFull::IsKaonNSigma(float mom, float nsigmaTPCK, float nsi
 	}
     }
 
- if(mom>=0.45 && mom<0.5)
+ if(mom>=0.45 && mom<0.5 && !fUseNsigmaTOF450_500)
     {
       if(TMath::Abs(nsigmaTPCK)<fNsigmaTPC450_500)
 	{ 


### PR DESCRIPTION
AliFemtoKKTrackCutFull bug fix.
NSigmaTOF for 450_500 never used regardless of settings.

There was a setter "fUseNsigmaTOF450" but was used in the non-reachable code, since earlier  if(mom>=0.45 && mom<0.5) returned already true or false basing on TPC Nsigma alone.