### PR TITLE
AliAnalysisCuts interface + MCGEN train support

### DIFF
--- a/OADB/AliEventCuts.cxx
+++ b/OADB/AliEventCuts.cxx
@@ -87,7 +87,7 @@ AliEventCuts::AliEventCuts(bool saveplots) : TList(),
   fkLabels{"raw","selected"},
   fManualMode{false},
   fSavePlots{saveplots},
-  fCurrentRun{-1},
+  fCurrentRun{-0xBADCAFE},
   fFlag{BIT(kNoCuts)},
   fCentEstimators{"V0M","CL0"},
   fCentPercentiles{-1.f},
@@ -422,7 +422,14 @@ void AliEventCuts::AutomaticSetup(AliVEvent *ev) {
     AliFatal("I don't find the AOD event nor the ESD one, aborting.");
   else {
     AliMCEventHandler* eventHandler = dynamic_cast<AliMCEventHandler*> (AliAnalysisManager::GetAnalysisManager()->GetMCtruthEventHandler());
-    fMC = (eventHandler) ? true : false;
+    TClonesArray* aodMC = (TClonesArray*)ev->GetList()->FindObject(AliAODMCParticle::StdBranchName());
+    fMC = (eventHandler || aodMC);
+  }
+
+  if (fCurrentRun == -1 && fMC) {
+    ::Info("AliEventCuts::AutomaticSetup","MCGEN train / Kinematics only production detected, disabling all the cuts.");
+    fGreenLight = true;
+    return;
   }
 
   if (fCurrentRun == 280234 || fCurrentRun == 280235) {

--- a/OADB/AliEventCuts.h
+++ b/OADB/AliEventCuts.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "AliVEvent.h"
+#include "AliAnalysisCuts.h"
 #include "AliAnalysisUtils.h"
 
 class AliESDtrackCuts;
@@ -209,6 +210,14 @@ class AliEventCuts : public TList {
     AliESDtrackCuts* fTPConlyCuts;   //!<! Cuts corresponding to the standalone TPC cuts in the ESDs (used only for correlations cuts in ESDs)
 
     ClassDef(AliEventCuts,8)
+};
+
+class AliEventCutsNanoInterface : public AliEventCuts, public virtual AliAnalysisCuts  {
+  public:
+  virtual Bool_t IsSelected(TObject* ev) {
+    SetSelected(AcceptEvent(static_cast<AliVEvent*>(ev))); 
+    return Selected();
+  }
 };
 
 template<typename F> F AliEventCuts::PolN(F x,F* coef, int n) {


### PR DESCRIPTION
@fprino this changes should be transparent for the everyday use of AliEventCuts.
MCGEN trains and Kine only production have run number equal -1, however I wonder if there are some other corner cases in MC that can hurt us badly...

@mfasDa @jgrosseo fyi
