### PR TITLE
PWG/EMCAL: Re-addition of stored MC label energy fraction to cluster

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEMCALClusterizeFast.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEMCALClusterizeFast.cxx
@@ -824,8 +824,7 @@ void AliAnalysisTaskEMCALClusterizeFast::RecPoints2Clusters(TClonesArray *clus)
     
     c->SetLabel(parentList, parentMult);
     
-    if(fSetCellMCLabelFromEdepFrac) 
-      c->SetClusterMCEdepFractionFromEdepArray(parentListDE);
+    c->SetClusterMCEdepFractionFromEdepArray(parentListDE);
     
     //
     // Set the cell energy deposition fraction map:

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.cxx
@@ -589,9 +589,7 @@ void AliEmcalCorrectionClusterizer::RecPoints2Clusters(TClonesArray *clus)
     Float_t *parentListDE = recpoint->GetParentsDE();  // deposited energy
     
     c->SetLabel(parentList, parentMult);
-    if(fSetCellMCLabelFromEdepFrac) {
-      c->SetClusterMCEdepFractionFromEdepArray(parentListDE);
-    }
+    c->SetClusterMCEdepFractionFromEdepArray(parentListDE);
     
     //
     // Set the cell energy deposition fraction map:

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALClusterize.cxx
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALClusterize.cxx
@@ -2196,8 +2196,7 @@ void AliAnalysisTaskEMCALClusterize::RecPoints2Clusters()
       Float_t *parentListDE = recPoint->GetParentsDE();         // deposited energy
       
       clus->SetLabel(parentList, parentMult);
-      if(fSetCellMCLabelFromEdepFrac)
-        clus->SetClusterMCEdepFractionFromEdepArray(parentListDE);
+      clus->SetClusterMCEdepFractionFromEdepArray(parentListDE);
       
       //
       // Set the cell energy deposition fraction map:


### PR DESCRIPTION
As already re-added for the Tender, i also propose to re-add the cluster energy fraction per MC label back to the clusters per default. (see https://github.com/alisw/AliPhysics/pull/9265 for the Tender PR.)
This is necessary as the boolean "fSetCellMCLabelFromEdepFrac" also modifies and limits the MC cluster label list to 4 labels, which is way too little.
Let me know if you have any objections. If not, then please give it a +1 as this additional cluster information is crucial for ongoing analyses.