### PR TITLE
PWGUD/UPC: New part of helicity analysis. Possible bug fix too. Streamers indicators.

### DIFF
--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.h
@@ -635,7 +635,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * J/Psi. This histogram is needed to evaluate
                                  * the polarization of the J/Psi!
                                  */
-        TH1F*                   fAngularDistribOfPositiveMuonRestFrameJPsiH;
+        TH1F*                   fAngularDistribOfPositiveMuonRestFrameJPsiH;       //!
 
                                 /**
                                  * This histogram shows the angular distribution
@@ -643,14 +643,14 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * J/Psi. This histogram is needed to evaluate
                                  * the polarization of the J/Psi!
                                  */
-        TH1F*                   fAngularDistribOfNegativeMuonRestFrameJPsiH;
+        TH1F*                   fAngularDistribOfNegativeMuonRestFrameJPsiH;       //!
 
                                 /**
                                  * This histogram represents the check over
                                  * the helicity of the J/Psi. It should be flat
                                  * if I remember well enough!
                                  */
-        TH1F*                   fCheckHelicityRestFrameJPsiH;
+        TH1F*                   fCheckHelicityRestFrameJPsiH;       //!
 
                                 /**
                                  * This histogram shows the angular distribution
@@ -659,7 +659,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * the polarization of the J/Psi! Divided in
                                  * psudorapidity bins... 8??
                                  */
-        TH1F*                   fThetaDistribOfPositiveMuonRestFrameJPsiRapidityBinH[8];
+        TH1F*                   fThetaDistribOfPositiveMuonRestFrameJPsiRapidityBinH[8];       //!
 
 
 
@@ -674,28 +674,28 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * of the positive muon in the HELICITY frame.
                                  * COS(THETA) distribution.
                                  */
-        TH1F*                   fCosThetaHelicityFrameJPsiH;
+        TH1F*                   fCosThetaHelicityFrameJPsiH;       //!
 
                                 /**
                                  * This histogram shows the angular distribution
                                  * of the positive muon in the HELICITY frame.
                                  * PHI distribution.
                                  */
-        TH1F*                   fPhiHelicityFrameJPsiH;
+        TH1F*                   fPhiHelicityFrameJPsiH;       //!
 
                                 /**
                                  * This histogram shows the angular distribution
                                  * of the positive muon in the COLLINS-SOPER
                                  * frame.  COS(THETA) distribution.
                                  */
-        TH1F*                   fCosThetaCollinsSoperFrameJPsiH;
+        TH1F*                   fCosThetaCollinsSoperFrameJPsiH;       //!
 
                                 /**
                                  * This histogram shows the angular distribution
                                  * of the positive muon in the COLLINS-SOPER
                                  * frame. PHI distribution.
                                  */
-        TH1F*                   fPhiCollinsSoperFrameJPsiH;
+        TH1F*                   fPhiCollinsSoperFrameJPsiH;       //!
 
                                 /**
                                  * This histogram shows the angular distribution
@@ -703,7 +703,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * COS(THETA) distribution. Divided per
                                  * rapidity bins.
                                  */
-        TH1F*                   fCosThetaHelicityFrameJPsiRapidityBinsH[8];
+        TH1F*                   fCosThetaHelicityFrameJPsiRapidityBinsH[8];       //!
 
                                 /**
                                  * This histogram shows the angular distribution
@@ -711,7 +711,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * PHI distribution. Divided per
                                  * rapidity bins.
                                  */
-        TH1F*                   fPhiHelicityFrameJPsiRapidityBinsH[8];
+        TH1F*                   fPhiHelicityFrameJPsiRapidityBinsH[8];       //!
 
                                 /**
                                  * This histogram shows the angular distribution
@@ -719,7 +719,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * frame.  COS(THETA) distribution. Divided per
                                  * rapidity bins.
                                  */
-        TH1F*                   fCosThetaCollinsSoperFrameJPsiRapidityBinsH[8];
+        TH1F*                   fCosThetaCollinsSoperFrameJPsiRapidityBinsH[8];       //!
 
                                 /**
                                  * This histogram shows the angular distribution
@@ -727,7 +727,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * frame. PHI distribution. Divided per
                                  * rapidity bins.
                                  */
-        TH1F*                   fPhiCollinsSoperFrameJPsiRapidityBinsH[8];
+        TH1F*                   fPhiCollinsSoperFrameJPsiRapidityBinsH[8];       //!
 
                                 /**
                                  * This histogram shows the angular distribution
@@ -735,7 +735,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * COS(THETA) distribution. Divided per
                                  * rapidity bins. 10 of them.
                                  */
-        TH1F*                   fCosThetaHelicityFrameJPsiTenRapidityBinsH[10];
+        TH1F*                   fCosThetaHelicityFrameJPsiTenRapidityBinsH[10];       //!
 
                                 /**
                                  * This histogram shows the angular distribution
@@ -743,7 +743,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * PHI distribution. Divided per
                                  * rapidity bins. 10 of them.
                                  */
-        TH1F*                   fPhiHelicityFrameJPsiTenRapidityBinsH[10];
+        TH1F*                   fPhiHelicityFrameJPsiTenRapidityBinsH[10];       //!
 
                                 /**
                                  * This histogram shows the angular distribution
@@ -751,7 +751,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * frame.  COS(THETA) distribution. Divided per
                                  * rapidity bins. 10 of them.
                                  */
-        TH1F*                   fCosThetaCollinsSoperFrameJPsiTenRapidityBinsH[10];
+        TH1F*                   fCosThetaCollinsSoperFrameJPsiTenRapidityBinsH[10];       //!
 
                                 /**
                                  * This histogram shows the angular distribution
@@ -759,8 +759,28 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * frame. PHI distribution. Divided per
                                  * rapidity bins. 10 of them.
                                  */
-        TH1F*                   fPhiCollinsSoperFrameJPsiTenRapidityBinsH[10];
+        TH1F*                   fPhiCollinsSoperFrameJPsiTenRapidityBinsH[10];       //!
 
+                                /**
+                                 * This histogram shows the invariant mass
+                                 * distribution of the dimuon pairs in terms
+                                 * of bins of cos theta of the positive muon
+                                 * in the helicity frame of the J/Psi.
+                                 *
+                                 * What it means is that we divide in 5 bins of
+                                 * possible CosTheta of the decaying J/Psi,
+                                 * meaning  (-1,-0.8), (-0.8,-0.6), (-0.6,-0.4),
+                                 * (-0.4,-0.2) and so on until (0.8,1). We fill
+                                 * the invariant mass distribution of the
+                                 * dimuons in this many bins.
+                                 *
+                                 * The next step is to fit this invariant mass
+                                 * distributions, so as to obtain the relative
+                                 * contribution of J/Psi and GammaGamma to the
+                                 * angular distributions. This should help in
+                                 * validating our results...
+                                 */
+        TH1F*                   fInvariantMassDistributionInBinsOfCosThetaHelicityFrameH[10];       //!
 
 
         //_______________________________
@@ -803,7 +823,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
         /**
          * This is the vector containing the GOOD RunNumbers.
          */
-        std::vector<Int_t> fVectorGoodRunNumbers;
+        std::vector<Int_t> fVectorGoodRunNumbers;       //!
 
 
 
@@ -823,7 +843,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforward, 10);
+        ClassDef(AliAnalysisTaskUPCforward, 11);
 };
 
 #endif

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
@@ -1261,7 +1261,7 @@ void AliAnalysisTaskUPCforwardMC::UserExec(Option_t *)
        -
        */
     for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++){
-        if( (possibleJPsiCopy.Rapidity() + 4) < 1.5*(iRapidityBin + 1)/8 ){
+        if( (possibleJPsiCopy.Rapidity() + 4.) < 1.5*((Double_t)iRapidityBin + 1.)/8. ){
           fThetaDistribOfPositiveMuonRestFrameJPsiRapidityBinH[iRapidityBin]->Fill(cosThetaMuonsRestFrame[0]);
           /* - New part: filling all possible histograms!
              -
@@ -1302,7 +1302,7 @@ void AliAnalysisTaskUPCforwardMC::UserExec(Option_t *)
        - NEW: the following code is for 10 rapidity bins...
        */
     for(Int_t iRapidityBin = 0; iRapidityBin < 10; iRapidityBin++){
-        if( (possibleJPsiCopy.Rapidity() + 4) < 1.5*(iRapidityBin + 1)/10 ){
+        if( (possibleJPsiCopy.Rapidity() + 4.) < 1.5*((Double_t)iRapidityBin + 1.)/10. ){
           fCosThetaHelicityFrameJPsiTenRapidityBinsH[iRapidityBin]->Fill( CosThetaHelicityFrame( muonsCopy2[0],
                                                                                                  muonsCopy2[1],
                                                                                                  possibleJPsiCopy
@@ -1523,7 +1523,7 @@ void AliAnalysisTaskUPCforwardMC::ProcessMCParticles(AliMCEvent* fMCEventArg)
                      -
                      */
                   for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++){
-                      if( (possibleJPsiMC.Rapidity() + 4) < 1.5*(iRapidityBin + 1)/8 ){
+                      if( (possibleJPsiMC.Rapidity() + 4.) < 1.5*((Double_t)iRapidityBin + 1.)/8. ){
                         fMCthetaDistribOfPositiveMuonRestFrameJPsiGeneratedTruthRapidityBinH[iRapidityBin]->Fill(cosThetaMuonsRestFrameMC[0]);
                         /* - New part: filling all possible histograms!
                            -
@@ -1556,7 +1556,7 @@ void AliAnalysisTaskUPCforwardMC::ProcessMCParticles(AliMCEvent* fMCEventArg)
                      -
                    */
                   for(Int_t iRapidityBin = 0; iRapidityBin < 10; iRapidityBin++){
-                      if( (possibleJPsiMC.Rapidity() + 4) < 1.5*(iRapidityBin + 1)/10 ){
+                      if( (possibleJPsiMC.Rapidity() + 4.) < 1.5*((Double_t)iRapidityBin + 1.)/10. ){
                         fMCCosThetaHelicityFrameJPsiTenRapidityBinsH[iRapidityBin]->Fill( CosThetaHelicityFrame( muonsMCcopy[0],
                                                                                                                  muonsMCcopy[1],
                                                                                                                  possibleJPsiMC
@@ -1617,7 +1617,7 @@ void AliAnalysisTaskUPCforwardMC::ProcessMCParticles(AliMCEvent* fMCEventArg)
                      -
                      */
                   for(Int_t iRapidityBin = 0; iRapidityBin < 8; iRapidityBin++){
-                      if( (possibleJPsiMC.Rapidity() + 4) < 1.5*(iRapidityBin + 1)/8 ){
+                      if( (possibleJPsiMC.Rapidity() + 4.) < 1.5*((Double_t)iRapidityBin + 1.)/8. ){
                         fMCthetaDistribOfPositiveMuonRestFrameJPsiGeneratedTruthRapidityBinH[iRapidityBin]->Fill(cosThetaMuonsRestFrameMC[1]);
                         /* - New part: filling all possible histograms!
                            -
@@ -1650,7 +1650,7 @@ void AliAnalysisTaskUPCforwardMC::ProcessMCParticles(AliMCEvent* fMCEventArg)
                      -
                    */
                   for(Int_t iRapidityBin = 0; iRapidityBin < 10; iRapidityBin++){
-                      if( (possibleJPsiMC.Rapidity() + 4) < 1.5*(iRapidityBin + 1)/10 ){
+                      if( (possibleJPsiMC.Rapidity() + 4.) < 1.5*((Double_t)iRapidityBin + 1.)/10. ){
                         fMCCosThetaHelicityFrameJPsiTenRapidityBinsH[iRapidityBin]->Fill( CosThetaHelicityFrame( muonsMCcopy[1],
                                                                                                                  muonsMCcopy[0],
                                                                                                                  possibleJPsiMC

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
@@ -785,7 +785,7 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforwardMC, 7);
+        ClassDef(AliAnalysisTaskUPCforwardMC, 8);
 };
 
 #endif


### PR DESCRIPTION
This pull request is divided in many parts. On one hand, I have added a new part for the helicity analysis. In this new piece of code I try to obtain the relative abundance of GammaGamma and J/Psi to the decay angular distribution, simply by obtaining the invariant mass distribution in a specific CosTheta bin. On the other hand, I have noticed a possible bug that was not easy to spot. When trying to fill, it seems like the program implicitly converted Double_t to Int_t. This could possibly the reason why the acceptance distributions for the angular distributions showed such a strange shape... Now an explicit conversion to Double_t is requested every time. In addition, I have added the streamer indicators for the private class members that I had previously missed...
IMPORTANT: all these changes have been tested on local for both Analysis Tasks.