### PR TITLE
Correct vertex cut from 2015 to 2016

### DIFF
--- a/PWGLF/RESONANCES/PostProcessing/Xi1530/AliAnalysisTaskXi1530.cxx
+++ b/PWGLF/RESONANCES/PostProcessing/Xi1530/AliAnalysisTaskXi1530.cxx
@@ -23,7 +23,7 @@
 //  author: Bong-Hwi Lim (bong-hwi.lim@cern.ch)
 //        , Beomkyu  KIM (kimb@cern.ch)
 //
-//  Last Modified Date: 2019/04/07
+//  Last Modified Date: 2019/04/08
 //
 ////////////////////////////////////////////////////////////////////////////
 
@@ -70,7 +70,7 @@ enum {
     kMixing,
     kMCReco,
     kMCTrue,
-    kMCTruePS,
+    kMCTruePS,  // 6
     kINEL10,
     kINEL,
     kAllType
@@ -256,11 +256,10 @@ void AliAnalysisTaskXi1530::UserCreateOutputObjects() {
                         "s");  // inv mass distribution of Xi
     }
 
-    std::vector<TString> ent = {
-        "All",         "Trigger",     "InCompleteDAQ",
-        "No BG",       "No pile up",  "Tracklet>1",
-        "Good vertex", "|Zvtx|<10cm", "AliMultSelection",
-        "INELg0True"};  // Normal setup
+    std::vector<TString> ent = {"All",         "Trigger",    "InCompleteDAQ",
+                                "No BG",       "No pile up", "Good vertex",
+                                "|Zvtx|<10cm", "IENLgtZERO", "AliMultSelection",
+                                "INELg0True"};  // Normal setup
     auto hNofEvt =
         fHistos->CreateTH1("hEventNumbers", "", ent.size(), 0, ent.size());
     for (auto i = 0u; i < ent.size(); i++)
@@ -526,7 +525,6 @@ void AliAnalysisTaskXi1530::UserExec(Option_t*) {
     fPIDResponse = (AliPIDResponse*)inputHandler->GetPIDResponse();
     if (!fPIDResponse)
         AliInfo("No PIDd");
-    // -----------------------------------------------------------------------
 
     // Vertex Check-----------------------------------------------------------
     const AliVVertex* pVtx = fEvt->GetPrimaryVertex();
@@ -536,7 +534,8 @@ void AliAnalysisTaskXi1530::UserExec(Option_t*) {
     PVy = pVtx->GetY();
     PVz = pVtx->GetZ();
     fZ = spdVtx->GetZ();
-
+    /*
+    // 2015 configuration
     Bool_t IsGoodVertex =
         spdVtx->GetStatus() &&
         SelectVertex2015pp(((AliESDEvent*)fEvt),
@@ -546,20 +545,37 @@ void AliAnalysisTaskXi1530::UserExec(Option_t*) {
                            kFALSE  // Don't need both trk and spd
                            ,
                            kTRUE);  // z-position difference      < 0.5 cm
+    */
+    Bool_t IsGoodVertex =
+        AliMultSelectionTask::HasGoodVertex2016(fEvt) &&
+        AliMultSelectionTask::HasNoInconsistentSPDandTrackVertices(fEvt);
     Bool_t IsVtxInZCut = (fabs(fZ) < 10);
+    // Bool_t IsVtxInZCut =
+    // AliMultSelectionTask::IsAcceptedVertexPosition(fEvt);
     Bool_t IsTrackletinEta1 =
         (AliESDtrackCuts::GetReferenceMultiplicity(
              ((AliESDEvent*)fEvt), AliESDtrackCuts::kTracklets, 1.0) >= 1);
 
     // Multi Selection--------------------------------------------------------
     // Include:
-    //    – INEL>0 selection: At least one SPD tracklet is required within |η| <
-    //    1 (IsTrackletinEta1) – Pileup rejection using
-    //    AliAnalysisUtils::IsPileUpSPD()                 (IsNotPileUp) – SPD
-    //    vertex z resolution < 0.02 cm (IsGoodVertex) -> GetZRes()<0.25 (rough)
+    //    – INEL>0 selection: At least one SPD tracklet is required within
+    //       |η| < 1 (IsTrackletinEta1)
+    //    – Pileup rejection using AliAnalysisUtils::IsPileUpSPD()
+    //      + IsPileupFromSPDInMultBins() (IsNotPileUp)
+    //      + IsPileUpMV()
+    //    - IsSPDClusterVsTrackletBG
+    //    - IsSelectedTrigger: for given trigger. default: AliVEvent::kMB
+    //    – SPD vertex z resolution < 0.2 cm (IsGoodVertex)
     //    – z-position difference between trackand SPD vertex < 0.5 cm
-    //    (IsGoodVertex) – vertex z position: |vz| < 10 cm (IsVtxInZCut)
+    //      (IsGoodVertex)
+    //    – vertex z position: |vz| < 10 cm (IsVtxInZCut)
+    //    - INEL>0: at least 1 tracklet in eta +_1 region. (IsTrackletinEta1)
+    //    - IsNotAsymmetricInVZERO: checks if VZERO signals are not heavily
+    //                              asymmetric
     // Most of them are already choosed in above sections.
+    // Not included:
+    //    - IsPileUpMV
+    //    - IsNotAsymmetricInVZERO
 
     AliMultSelection* MultSelection =
         (AliMultSelection*)fEvt->FindListObject("MultSelection");
@@ -567,15 +583,15 @@ void AliAnalysisTaskXi1530::UserExec(Option_t*) {
     if (IsSelectedTrig && IsMultSelcted && fQA)
         fHistos->FillTH1("hMult_QA_onlyMult", (double)fCent);
     // Physics Selection------------------------------------------------------
-    IsPS = IsSelectedTrig        // CINT7 Trigger selected
-           && !IncompleteDAQ     // No IncompleteDAQ
-           && !SPDvsClustersBG   // No SPDvsClusters Background
-           && IsNotPileUp        // PileUp rejection
-           && IsTrackletinEta1;  // at least 1 tracklet in eta +_1 region.
+    IsPS = IsSelectedTrig       // CINT7 Trigger selected
+           && !IncompleteDAQ    // No IncompleteDAQ
+           && !SPDvsClustersBG  // No SPDvsClusters Background
+           && IsNotPileUp;      // PileUp rejection
 
     IsINEL0Rec =
         IsPS && IsGoodVertex &&
-        IsVtxInZCut;  // recontructed INEL > 0 is PS + vtx + Zvtx inside +-10
+        IsVtxInZCut &&  // recontructed INEL > 0 is PS + vtx + Zvtx inside +-10
+        IsTrackletinEta1;  // at least 1 tracklet in eta +_1 region.
 
     // Fill Numver of Events -------------------------------------------------
     fHistos->FillTH1("hEventNumbers", "All", 1);
@@ -587,12 +603,12 @@ void AliAnalysisTaskXi1530::UserExec(Option_t*) {
         fHistos->FillTH1("hEventNumbers", "No BG", 1);
     if (IsSelectedTrig && !IncompleteDAQ && !SPDvsClustersBG && IsNotPileUp)
         fHistos->FillTH1("hEventNumbers", "No pile up", 1);
-    if (IsPS)
-        fHistos->FillTH1("hEventNumbers", "Tracklet>1", 1);
     if (IsPS && IsGoodVertex)
         fHistos->FillTH1("hEventNumbers", "Good vertex", 1);
     if (IsPS && IsGoodVertex && IsVtxInZCut)
         fHistos->FillTH1("hEventNumbers", "|Zvtx|<10cm", 1);
+    if (IsINEL0Rec)
+        fHistos->FillTH1("hEventNumbers", "IENLgtZERO", 1);
     if (IsPS && IsGoodVertex && IsVtxInZCut && IsMultSelcted)
         fHistos->FillTH1("hEventNumbers", "AliMultSelection", 1);
 
@@ -667,11 +683,9 @@ void AliAnalysisTaskXi1530::UserExec(Option_t*) {
     // ----------------------------------------------------------------------
 
     // Check tracks and casade, Fill histo************************************
-    if ((IsINEL0Rec && IsMultSelcted) ||
-        (IsMC &&
-         IsINEL0Rec)) {  // In Good Event condition: (IsPS && IsGoodVertex &&
-                         // IsVtxInZCut) && IsMultSelcted
-
+    if (IsINEL0Rec &&
+        IsMultSelcted) {  // In Good Event condition: (IsPS && IsGoodVertex &&
+                          // IsVtxInZCut) && IsMultSelcted
         // Draw Multiplicity QA plot in only selected event.
         if (fQA) {
             FillTHnSparse("hMult", {(double)fCent});


### PR DESCRIPTION
Change vertex cut configuration from 2015 to 2016 so that it can match with AliMultSelection.
Change the order in a number of event Histogram.