### PR TITLE
Remove wrong cut on gen Zvtx in case of MC

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSEDs.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEDs.cxx
@@ -878,9 +878,6 @@ void AliAnalysisTaskSEDs::UserExec(Option_t * /*option*/)
     if (fAnalysisCuts->GetUseCentrality() > 0 && fAnalysisCuts->IsEventSelectedInCentrality(aod) != 0)
       // events not passing the centrality selection can be removed immediately.
       return;
-    Double_t zMCVertex = mcHeader->GetVtxZ();
-    if (TMath::Abs(zMCVertex) > fAnalysisCuts->GetMaxVtxZ())
-      return;
     FillMCGenAccHistos(arrayMC, mcHeader, nTracklets);
   }
 


### PR DESCRIPTION
This cut is already in FillMCGenAccHistos for the gen Ds selection, but if applied also outside the function it is also applied to the reco Ds