### PR TITLE
Improver ask update for LHC18q,r periods

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSEImproveITS.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEImproveITS.cxx
@@ -113,10 +113,119 @@ AliAnalysisTaskSEImproveITS::AliAnalysisTaskSEImproveITS()
    fDebugNtuple (0),
    fDebugVars   (0), 
    fNDebug      (0)
+   // specific stuff for PbPb 2018
+  ,fIsPbPb2018(kFALSE)
+   // kFirst
+  ,fD0ZResPCur_PbPb2018_kFirst(0)
+  ,fD0ZResKCur_PbPb2018_kFirst(0) 
+  ,fD0ZResPiCur_PbPb2018_kFirst(0) 
+  ,fD0ZResECur_PbPb2018_kFirst(0) 
+  ,fD0RPResPCur_PbPb2018_kFirst(0) 
+  ,fD0RPResKCur_PbPb2018_kFirst(0) 
+  ,fD0RPResPiCur_PbPb2018_kFirst(0) 
+  ,fD0RPResECur_PbPb2018_kFirst(0)
+  ,fD0RPSigmaPullRatioP_PbPb2018_kFirst(0) 
+  ,fD0RPSigmaPullRatioK_PbPb2018_kFirst(0) 
+  ,fD0RPSigmaPullRatioPi_PbPb2018_kFirst(0) 
+  ,fD0RPSigmaPullRatioE_PbPb2018_kFirst(0)
+  ,fPt1ResPCur_PbPb2018_kFirst(0)
+  ,fPt1ResKCur_PbPb2018_kFirst(0)
+  ,fPt1ResPiCur_PbPb2018_kFirst(0) 
+  ,fPt1ResECur_PbPb2018_kFirst(0) 
+  ,fD0ZResPUpg_PbPb2018_kFirst(0) 
+  ,fD0ZResKUpg_PbPb2018_kFirst(0) 
+  ,fD0ZResPiUpg_PbPb2018_kFirst(0) 
+  ,fD0ZResEUpg_PbPb2018_kFirst(0)
+  ,fD0RPResPUpg_PbPb2018_kFirst(0)
+  ,fD0RPResKUpg_PbPb2018_kFirst(0) 
+  ,fD0RPResPiUpg_PbPb2018_kFirst(0) 
+  ,fD0RPResEUpg_PbPb2018_kFirst(0) 
+  ,fPt1ResPUpg_PbPb2018_kFirst(0)
+  ,fPt1ResKUpg_PbPb2018_kFirst(0) 
+  ,fPt1ResPiUpg_PbPb2018_kFirst(0)
+  ,fPt1ResEUpg_PbPb2018_kFirst(0) 
+  ,fD0ZResPCurSA_PbPb2018_kFirst(0) 
+  ,fD0ZResKCurSA_PbPb2018_kFirst(0)
+  ,fD0ZResPiCurSA_PbPb2018_kFirst(0) 
+  ,fD0ZResECurSA_PbPb2018_kFirst(0) 
+  ,fD0RPResPCurSA_PbPb2018_kFirst(0) 
+  ,fD0RPResKCurSA_PbPb2018_kFirst(0) 
+  ,fD0RPResPiCurSA_PbPb2018_kFirst(0) 
+  ,fD0RPResECurSA_PbPb2018_kFirst(0) 
+  ,fPt1ResPCurSA_PbPb2018_kFirst(0) 
+  ,fPt1ResKCurSA_PbPb2018_kFirst(0) 
+  ,fPt1ResPiCurSA_PbPb2018_kFirst(0) 
+  ,fPt1ResECurSA_PbPb2018_kFirst(0)
+  ,fD0ZResPUpgSA_PbPb2018_kFirst(0) 
+  ,fD0ZResKUpgSA_PbPb2018_kFirst(0) 
+  ,fD0ZResPiUpgSA_PbPb2018_kFirst(0) 
+  ,fD0ZResEUpgSA_PbPb2018_kFirst(0) 
+  ,fD0RPResPUpgSA_PbPb2018_kFirst(0) 
+  ,fD0RPResKUpgSA_PbPb2018_kFirst(0) 
+  ,fD0RPResPiUpgSA_PbPb2018_kFirst(0) 
+  ,fD0RPResEUpgSA_PbPb2018_kFirst(0) 
+  ,fPt1ResPUpgSA_PbPb2018_kFirst(0)
+  ,fPt1ResKUpgSA_PbPb2018_kFirst(0) 
+  ,fPt1ResPiUpgSA_PbPb2018_kFirst(0)
+  ,fPt1ResEUpgSA_PbPb2018_kFirst(0) 
+  // kOnlySecond
+  ,fD0ZResPCur_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResKCur_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResPiCur_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResECur_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResPCur_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResKCur_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResPiCur_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResECur_PbPb2018_kOnlySecond(0) 
+  ,fD0RPSigmaPullRatioP_PbPb2018_kOnlySecond(0) 
+  ,fD0RPSigmaPullRatioK_PbPb2018_kOnlySecond(0) 
+  ,fD0RPSigmaPullRatioPi_PbPb2018_kOnlySecond(0) 
+  ,fD0RPSigmaPullRatioE_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResPCur_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResKCur_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResPiCur_PbPb2018_kOnlySecond(0)
+  ,fPt1ResECur_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResPUpg_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResKUpg_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResPiUpg_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResEUpg_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResPUpg_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResKUpg_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResPiUpg_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResEUpg_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResPUpg_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResKUpg_PbPb2018_kOnlySecond(0)  
+  ,fPt1ResPiUpg_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResEUpg_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResPCurSA_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResKCurSA_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResPiCurSA_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResECurSA_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResPCurSA_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResKCurSA_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResPiCurSA_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResECurSA_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResPCurSA_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResKCurSA_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResPiCurSA_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResECurSA_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResPUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResKUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResPiUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResEUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResPUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResKUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResPiUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResEUpgSA_PbPb2018_kOnlySecond(0)  
+  ,fPt1ResPUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResKUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResPiUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResEUpgSA_PbPb2018_kOnlySecond(0) 
 {
   //
   // Default constructor.
   for(Int_t jh=0; jh<2; jh++){
+    // templates of mean (original)
     for(Int_t ih=0; ih<4; ih++){
       fD0RPMeanPCur[jh][ih]=0x0;
       fD0RPMeanKCur[jh][ih]=0x0;
@@ -127,6 +236,27 @@ AliAnalysisTaskSEImproveITS::AliAnalysisTaskSEImproveITS()
       fD0RPMeanPiUpg[jh][ih]=0x0;
       fD0RPMeanEUpg[jh][ih]=0x0;
     }
+    // templates of mean for Pb-Pb 2018 
+    for(UInt_t ih = 0; ih < 24; ih++)
+    {
+      fD0RPMeanPCur_PbPb2018_kFirst[jh][ih]=0x0;
+      fD0RPMeanKCur_PbPb2018_kFirst[jh][ih]=0x0;
+      fD0RPMeanPiCur_PbPb2018_kFirst[jh][ih]=0x0;
+      fD0RPMeanECur_PbPb2018_kFirst[jh][ih]=0x0;
+      fD0RPMeanPUpg_PbPb2018_kFirst[jh][ih]=0x0;
+      fD0RPMeanKUpg_PbPb2018_kFirst[jh][ih]=0x0;
+      fD0RPMeanPiUpg_PbPb2018_kFirst[jh][ih]=0x0;
+      fD0RPMeanEUpg_PbPb2018_kFirst[jh][ih]=0x0;
+      fD0RPMeanPCur_PbPb2018_kOnlySecond[jh][ih]=0x0;
+      fD0RPMeanKCur_PbPb2018_kOnlySecond[jh][ih]=0x0;
+      fD0RPMeanPiCur_PbPb2018_kOnlySecond[jh][ih]=0x0;
+      fD0RPMeanECur_PbPb2018_kOnlySecond[jh][ih]=0x0;
+      fD0RPMeanPUpg_PbPb2018_kOnlySecond[jh][ih]=0x0;
+      fD0RPMeanKUpg_PbPb2018_kOnlySecond[jh][ih]=0x0;
+      fD0RPMeanPiUpg_PbPb2018_kOnlySecond[jh][ih]=0x0;
+      fD0RPMeanEUpg_PbPb2018_kOnlySecond[jh][ih]=0x0;
+    }
+    
   }
   //
 }
@@ -201,6 +331,114 @@ AliAnalysisTaskSEImproveITS::AliAnalysisTaskSEImproveITS(const char *name,
    fDebugNtuple (0),
    fDebugVars   (0),
    fNDebug      (ndebug)
+   // specific stuff for PbPb 2018
+  ,fIsPbPb2018(kFALSE)
+   // kFirst
+  ,fD0ZResPCur_PbPb2018_kFirst(0)
+  ,fD0ZResKCur_PbPb2018_kFirst(0) 
+  ,fD0ZResPiCur_PbPb2018_kFirst(0) 
+  ,fD0ZResECur_PbPb2018_kFirst(0) 
+  ,fD0RPResPCur_PbPb2018_kFirst(0) 
+  ,fD0RPResKCur_PbPb2018_kFirst(0) 
+  ,fD0RPResPiCur_PbPb2018_kFirst(0) 
+  ,fD0RPResECur_PbPb2018_kFirst(0)
+  ,fD0RPSigmaPullRatioP_PbPb2018_kFirst(0) 
+  ,fD0RPSigmaPullRatioK_PbPb2018_kFirst(0) 
+  ,fD0RPSigmaPullRatioPi_PbPb2018_kFirst(0) 
+  ,fD0RPSigmaPullRatioE_PbPb2018_kFirst(0)
+  ,fPt1ResPCur_PbPb2018_kFirst(0)
+  ,fPt1ResKCur_PbPb2018_kFirst(0)
+  ,fPt1ResPiCur_PbPb2018_kFirst(0) 
+  ,fPt1ResECur_PbPb2018_kFirst(0) 
+  ,fD0ZResPUpg_PbPb2018_kFirst(0) 
+  ,fD0ZResKUpg_PbPb2018_kFirst(0) 
+  ,fD0ZResPiUpg_PbPb2018_kFirst(0) 
+  ,fD0ZResEUpg_PbPb2018_kFirst(0)
+  ,fD0RPResPUpg_PbPb2018_kFirst(0)
+  ,fD0RPResKUpg_PbPb2018_kFirst(0) 
+  ,fD0RPResPiUpg_PbPb2018_kFirst(0) 
+  ,fD0RPResEUpg_PbPb2018_kFirst(0) 
+  ,fPt1ResPUpg_PbPb2018_kFirst(0)
+  ,fPt1ResKUpg_PbPb2018_kFirst(0) 
+  ,fPt1ResPiUpg_PbPb2018_kFirst(0)
+  ,fPt1ResEUpg_PbPb2018_kFirst(0) 
+  ,fD0ZResPCurSA_PbPb2018_kFirst(0) 
+  ,fD0ZResKCurSA_PbPb2018_kFirst(0)
+  ,fD0ZResPiCurSA_PbPb2018_kFirst(0) 
+  ,fD0ZResECurSA_PbPb2018_kFirst(0) 
+  ,fD0RPResPCurSA_PbPb2018_kFirst(0) 
+  ,fD0RPResKCurSA_PbPb2018_kFirst(0) 
+  ,fD0RPResPiCurSA_PbPb2018_kFirst(0) 
+  ,fD0RPResECurSA_PbPb2018_kFirst(0) 
+  ,fPt1ResPCurSA_PbPb2018_kFirst(0) 
+  ,fPt1ResKCurSA_PbPb2018_kFirst(0) 
+  ,fPt1ResPiCurSA_PbPb2018_kFirst(0) 
+  ,fPt1ResECurSA_PbPb2018_kFirst(0)
+  ,fD0ZResPUpgSA_PbPb2018_kFirst(0) 
+  ,fD0ZResKUpgSA_PbPb2018_kFirst(0) 
+  ,fD0ZResPiUpgSA_PbPb2018_kFirst(0) 
+  ,fD0ZResEUpgSA_PbPb2018_kFirst(0) 
+  ,fD0RPResPUpgSA_PbPb2018_kFirst(0) 
+  ,fD0RPResKUpgSA_PbPb2018_kFirst(0) 
+  ,fD0RPResPiUpgSA_PbPb2018_kFirst(0) 
+  ,fD0RPResEUpgSA_PbPb2018_kFirst(0) 
+  ,fPt1ResPUpgSA_PbPb2018_kFirst(0)
+  ,fPt1ResKUpgSA_PbPb2018_kFirst(0) 
+  ,fPt1ResPiUpgSA_PbPb2018_kFirst(0)
+  ,fPt1ResEUpgSA_PbPb2018_kFirst(0) 
+  // kOnlySecond
+  ,fD0ZResPCur_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResKCur_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResPiCur_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResECur_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResPCur_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResKCur_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResPiCur_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResECur_PbPb2018_kOnlySecond(0) 
+  ,fD0RPSigmaPullRatioP_PbPb2018_kOnlySecond(0) 
+  ,fD0RPSigmaPullRatioK_PbPb2018_kOnlySecond(0) 
+  ,fD0RPSigmaPullRatioPi_PbPb2018_kOnlySecond(0) 
+  ,fD0RPSigmaPullRatioE_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResPCur_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResKCur_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResPiCur_PbPb2018_kOnlySecond(0)
+  ,fPt1ResECur_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResPUpg_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResKUpg_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResPiUpg_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResEUpg_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResPUpg_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResKUpg_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResPiUpg_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResEUpg_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResPUpg_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResKUpg_PbPb2018_kOnlySecond(0)  
+  ,fPt1ResPiUpg_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResEUpg_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResPCurSA_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResKCurSA_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResPiCurSA_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResECurSA_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResPCurSA_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResKCurSA_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResPiCurSA_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResECurSA_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResPCurSA_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResKCurSA_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResPiCurSA_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResECurSA_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResPUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResKUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResPiUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fD0ZResEUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResPUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResKUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResPiUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fD0RPResEUpgSA_PbPb2018_kOnlySecond(0)  
+  ,fPt1ResPUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResKUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResPiUpgSA_PbPb2018_kOnlySecond(0) 
+  ,fPt1ResEUpgSA_PbPb2018_kOnlySecond(0) 
 {
   //
   // Constructor to be used to create the task.
@@ -211,6 +449,7 @@ AliAnalysisTaskSEImproveITS::AliAnalysisTaskSEImproveITS(const char *name,
   // is written to the output.
   //
   for(Int_t jh=0; jh<2; jh++){
+    // templates of mean (original)
     for(Int_t ih=0; ih<4; ih++){
       fD0RPMeanPCur[jh][ih]=0x0;
       fD0RPMeanKCur[jh][ih]=0x0;
@@ -221,206 +460,619 @@ AliAnalysisTaskSEImproveITS::AliAnalysisTaskSEImproveITS(const char *name,
       fD0RPMeanPiUpg[jh][ih]=0x0;
       fD0RPMeanEUpg[jh][ih]=0x0;
     }
+    // templates of mean for Pb-Pb 2018 
+    for(UInt_t ih = 0; ih < 24; ih++)
+    {
+      fD0RPMeanPCur_PbPb2018_kFirst[jh][ih]=0x0;
+      fD0RPMeanKCur_PbPb2018_kFirst[jh][ih]=0x0;
+      fD0RPMeanPiCur_PbPb2018_kFirst[jh][ih]=0x0;
+      fD0RPMeanECur_PbPb2018_kFirst[jh][ih]=0x0;
+      fD0RPMeanPUpg_PbPb2018_kFirst[jh][ih]=0x0;
+      fD0RPMeanKUpg_PbPb2018_kFirst[jh][ih]=0x0;
+      fD0RPMeanPiUpg_PbPb2018_kFirst[jh][ih]=0x0;
+      fD0RPMeanEUpg_PbPb2018_kFirst[jh][ih]=0x0;
+      fD0RPMeanPCur_PbPb2018_kOnlySecond[jh][ih]=0x0;
+      fD0RPMeanKCur_PbPb2018_kOnlySecond[jh][ih]=0x0;
+      fD0RPMeanPiCur_PbPb2018_kOnlySecond[jh][ih]=0x0;
+      fD0RPMeanECur_PbPb2018_kOnlySecond[jh][ih]=0x0;
+      fD0RPMeanPUpg_PbPb2018_kOnlySecond[jh][ih]=0x0;
+      fD0RPMeanKUpg_PbPb2018_kOnlySecond[jh][ih]=0x0;
+      fD0RPMeanPiUpg_PbPb2018_kOnlySecond[jh][ih]=0x0;
+      fD0RPMeanEUpg_PbPb2018_kOnlySecond[jh][ih]=0x0;
+    }
   }
   
   TString resfileCurURI = Form("alien:///alice/cern.ch/user/p/pwg_hf/common/Improver/%s/%s/ITSgraphs_Current.root",period,systematic);
+  TString resfileUpgURI = Form("alien:///alice/cern.ch/user/p/pwg_hf/common/Improver/%s/%s/ITSgraphs_NewAll-X0.3-Res4um.root",period,systematic);
+
+  printf("\n### reading file %s ...\n",resfileCurURI.Data());
   TFile *resfileCur=TFile::Open(resfileCurURI.Data());
-  if(resfileCur) {    
-    if(resfileCur->Get("D0RPResP" )) {
-      fD0RPResPCur =(TGraph*)(resfileCur->Get("D0RPResP" )->Clone("D0RPResPCur" ));
-    }
-    if(resfileCur->Get("D0RPResK" )) {
-      fD0RPResKCur =(TGraph*)(resfileCur->Get("D0RPResK" )->Clone("D0RPResKCur" ));
-    }
-    if(resfileCur->Get("D0RPResPi")) {
-      fD0RPResPiCur=(TGraph*)(resfileCur->Get("D0RPResPi")->Clone("D0RPResPiCur"));
-    }
-    if(resfileCur->Get("D0RPResE")) {
-      fD0RPResECur=(TGraph*)(resfileCur->Get("D0RPResE")->Clone("D0RPResECur"));
-    }
-    if(resfileCur->Get("D0RPSigmaPullRatioP" )) {
-      fD0RPSigmaPullRatioP =(TGraph*)(resfileCur->Get("D0RPSigmaPullRatioP" ));
-    }
-    if(resfileCur->Get("D0RPSigmaPullRatioK" )) {
-      fD0RPSigmaPullRatioK =(TGraph*)(resfileCur->Get("D0RPSigmaPullRatioK" ));
-    }
-    if(resfileCur->Get("D0RPSigmaPullRatioPi")) {
-      fD0RPSigmaPullRatioPi=(TGraph*)(resfileCur->Get("D0RPSigmaPullRatioPi"));
-    }
-    if(resfileCur->Get("D0RPSigmaPullRatioE")) {
-      fD0RPSigmaPullRatioE=(TGraph*)(resfileCur->Get("D0RPSigmaPullRatioE"));
-    }
-    for(Int_t j=0; j<2; j++){
-      for(Int_t i=0; i<4; i++){
-	if(resfileCur->Get(Form("D0RPMeanP_B%d_phi%d",j,i))) {
-	  fD0RPMeanPCur[j][i]=(TGraph*)(resfileCur->Get(Form("D0RPMeanP_B%d_phi%d",j,i))->Clone(Form("D0RPMeanPCur_B%d_phi%d",j,i)));
-	}
-	if(resfileCur->Get(Form("D0RPMeanK_B%d_phi%d",j,i))) {
-	  fD0RPMeanKCur[j][i]=(TGraph*)(resfileCur->Get(Form("D0RPMeanK_B%d_phi%d",j,i))->Clone(Form("D0RPMeanKCur_B%d_phi%d",j,i)));
-	}
-	if(resfileCur->Get(Form("D0RPMeanPi_B%d_phi%d",j,i))) {
-	  fD0RPMeanPiCur[j][i]=(TGraph*)(resfileCur->Get(Form("D0RPMeanPi_B%d_phi%d",j,i))->Clone(Form("D0RPMeanPiCur_B%d_phi%d",j,i)));
-	}
-	if(resfileCur->Get(Form("D0RPMeanE_B%d_phi%d",j,i))) {
-	  fD0RPMeanECur[j][i]=(TGraph*)(resfileCur->Get(Form("D0RPMeanE_B%d_phi%d",j,i))->Clone(Form("D0RPMeanECur_B%d_phi%d",j,i)));
-	}
+  if(resfileCur)  printf("... READ ###\n");
+  if( (resfileCurURI.Contains("LHC18r") || resfileCurURI.Contains("LHC18q")) && 
+      (resfileUpgURI.Contains("LHC18r") || resfileUpgURI.Contains("LHC18q")))     fIsPbPb2018=kTRUE; 
+  printf("\n\n===\n=== fIsPbPb2018: %s\n===\n\n",fIsPbPb2018?"kTRUE":"kFALSE");
+  if(resfileCur) {
+    if(!fIsPbPb2018){    
+      if(resfileCur->Get("D0RPResP" )) {
+        fD0RPResPCur =(TGraph*)(resfileCur->Get("D0RPResP" )->Clone("D0RPResPCur" ));
       }
+      if(resfileCur->Get("D0RPResK" )) {
+        fD0RPResKCur =(TGraph*)(resfileCur->Get("D0RPResK" )->Clone("D0RPResKCur" ));
+      }
+      if(resfileCur->Get("D0RPResPi")) {
+        fD0RPResPiCur=(TGraph*)(resfileCur->Get("D0RPResPi")->Clone("D0RPResPiCur"));
+      }
+      if(resfileCur->Get("D0RPResE")) {
+        fD0RPResECur=(TGraph*)(resfileCur->Get("D0RPResE")->Clone("D0RPResECur"));
+      }
+      if(resfileCur->Get("D0RPSigmaPullRatioP" )) {
+        fD0RPSigmaPullRatioP =(TGraph*)(resfileCur->Get("D0RPSigmaPullRatioP" ));
+      }
+      if(resfileCur->Get("D0RPSigmaPullRatioK" )) {
+        fD0RPSigmaPullRatioK =(TGraph*)(resfileCur->Get("D0RPSigmaPullRatioK" ));
+      }
+      if(resfileCur->Get("D0RPSigmaPullRatioPi")) {
+        fD0RPSigmaPullRatioPi=(TGraph*)(resfileCur->Get("D0RPSigmaPullRatioPi"));
+      }
+      if(resfileCur->Get("D0RPSigmaPullRatioE")) {
+        fD0RPSigmaPullRatioE=(TGraph*)(resfileCur->Get("D0RPSigmaPullRatioE"));
+      }
+      for(Int_t j=0; j<2; j++){
+        for(Int_t i=0; i<4; i++){
+	        if(resfileCur->Get(Form("D0RPMeanP_B%d_phi%d",j,i))) {
+	          fD0RPMeanPCur[j][i]=(TGraph*)(resfileCur->Get(Form("D0RPMeanP_B%d_phi%d",j,i))->Clone(Form("D0RPMeanPCur_B%d_phi%d",j,i)));
+	        }
+	        if(resfileCur->Get(Form("D0RPMeanK_B%d_phi%d",j,i))) {
+	          fD0RPMeanKCur[j][i]=(TGraph*)(resfileCur->Get(Form("D0RPMeanK_B%d_phi%d",j,i))->Clone(Form("D0RPMeanKCur_B%d_phi%d",j,i)));
+	        }
+	        if(resfileCur->Get(Form("D0RPMeanPi_B%d_phi%d",j,i))) {
+	          fD0RPMeanPiCur[j][i]=(TGraph*)(resfileCur->Get(Form("D0RPMeanPi_B%d_phi%d",j,i))->Clone(Form("D0RPMeanPiCur_B%d_phi%d",j,i)));
+	        }
+	        if(resfileCur->Get(Form("D0RPMeanE_B%d_phi%d",j,i))) {
+	          fD0RPMeanECur[j][i]=(TGraph*)(resfileCur->Get(Form("D0RPMeanE_B%d_phi%d",j,i))->Clone(Form("D0RPMeanECur_B%d_phi%d",j,i)));
+	        }
+        }
+      }
+      if(resfileCur->Get("D0ZResP"  )) {
+        fD0ZResPCur  =(TGraph*)(resfileCur->Get("D0ZResP"  )->Clone("D0ZResPCur"  ));
+      }
+      if(resfileCur->Get("D0ZResK"  )) {
+        fD0ZResKCur  =(TGraph*)(resfileCur->Get("D0ZResK"  )->Clone("D0ZResKCur"  ));
+      }
+      if(resfileCur->Get("D0ZResPi" )) {
+        fD0ZResPiCur =(TGraph*)(resfileCur->Get("D0ZResPi" )->Clone("D0ZResPiCur" ));
+      }
+      if(resfileCur->Get("D0ZResE" )) {
+        fD0ZResECur =(TGraph*)(resfileCur->Get("D0ZResE" )->Clone("D0ZResECur" ));
+      }
+      if(resfileCur->Get("Pt1ResP"  )) {
+        fPt1ResPCur  =(TGraph*)(resfileCur->Get("Pt1ResP"  )->Clone("Pt1ResPCur"  ));
+      }
+      if(resfileCur->Get("Pt1ResK"  )) {
+        fPt1ResKCur  =(TGraph*)(resfileCur->Get("Pt1ResK"  )->Clone("Pt1ResKCur"  ));
+      }
+      if(resfileCur->Get("Pt1ResPi" )) {
+        fPt1ResPiCur =(TGraph*)(resfileCur->Get("Pt1ResPi" )->Clone("Pt1ResPiCur" ));
+      }
+      if(resfileCur->Get("Pt1ResE" )) {
+        fPt1ResECur =(TGraph*)(resfileCur->Get("Pt1ResE" )->Clone("Pt1ResECur" ));
+      }
+      if(resfileCur->Get("D0RPResPSA" )) {
+        fD0RPResPCurSA =(TGraph*)(resfileCur->Get("D0RPResPSA" )->Clone("D0RPResPCurSA" ));
+      }
+      if(resfileCur->Get("D0RPResKSA" )) {
+        fD0RPResKCurSA =(TGraph*)(resfileCur->Get("D0RPResKSA" )->Clone("D0RPResKCurSA" ));
+      }
+      if(resfileCur->Get("D0RPResPiSA")) {
+        fD0RPResPiCurSA=(TGraph*)(resfileCur->Get("D0RPResPiSA")->Clone("D0RPResPiCurSA"));
+      }
+      if(resfileCur->Get("D0RPResESA")) {
+        fD0RPResECurSA=(TGraph*)(resfileCur->Get("D0RPResESA")->Clone("D0RPResECurSA"));
+      }
+      if(resfileCur->Get("D0ZResPSA"  )) {
+        fD0ZResPCurSA  =(TGraph*)(resfileCur->Get("D0ZResPSA"  )->Clone("D0ZResPCurSA"  ));
+      }
+      if(resfileCur->Get("D0ZResKSA"  )) {
+        fD0ZResKCurSA  =(TGraph*)(resfileCur->Get("D0ZResKSA"  )->Clone("D0ZResKCurSA"  ));
+      }
+      if(resfileCur->Get("D0ZResPiSA" )) {
+        fD0ZResPiCurSA =(TGraph*)(resfileCur->Get("D0ZResPiSA" )->Clone("D0ZResPiCurSA" ));
+      }
+      if(resfileCur->Get("D0ZResESA" )) {
+        fD0ZResECurSA =(TGraph*)(resfileCur->Get("D0ZResESA" )->Clone("D0ZResECurSA" ));
+      }
+      if(resfileCur->Get("Pt1ResPSA"  )) {
+        fPt1ResPCurSA  =(TGraph*)(resfileCur->Get("Pt1ResPSA"  )->Clone("Pt1ResPCurSA"  ));
+      }
+      if(resfileCur->Get("Pt1ResKSA"  )) {
+        fPt1ResKCurSA  =(TGraph*)(resfileCur->Get("Pt1ResKSA"  )->Clone("Pt1ResKCurSA"  ));
+      }
+      if(resfileCur->Get("Pt1ResPiSA" )) {
+        fPt1ResPiCurSA =(TGraph*)(resfileCur->Get("Pt1ResPiSA" )->Clone("Pt1ResPiCurSA" ));
+      }
+      if(resfileCur->Get("Pt1ResESA" )) {
+        fPt1ResECurSA =(TGraph*)(resfileCur->Get("Pt1ResESA" )->Clone("Pt1ResECurSA" ));
+      }
+      delete resfileCur;
     }
-    if(resfileCur->Get("D0ZResP"  )) {
-      fD0ZResPCur  =(TGraph*)(resfileCur->Get("D0ZResP"  )->Clone("D0ZResPCur"  ));
-    }
-    if(resfileCur->Get("D0ZResK"  )) {
-      fD0ZResKCur  =(TGraph*)(resfileCur->Get("D0ZResK"  )->Clone("D0ZResKCur"  ));
-    }
-    if(resfileCur->Get("D0ZResPi" )) {
-      fD0ZResPiCur =(TGraph*)(resfileCur->Get("D0ZResPi" )->Clone("D0ZResPiCur" ));
-    }
-    if(resfileCur->Get("D0ZResE" )) {
-      fD0ZResECur =(TGraph*)(resfileCur->Get("D0ZResE" )->Clone("D0ZResECur" ));
-    }
-    if(resfileCur->Get("Pt1ResP"  )) {
-      fPt1ResPCur  =(TGraph*)(resfileCur->Get("Pt1ResP"  )->Clone("Pt1ResPCur"  ));
-    }
-    if(resfileCur->Get("Pt1ResK"  )) {
-      fPt1ResKCur  =(TGraph*)(resfileCur->Get("Pt1ResK"  )->Clone("Pt1ResKCur"  ));
-    }
-    if(resfileCur->Get("Pt1ResPi" )) {
-      fPt1ResPiCur =(TGraph*)(resfileCur->Get("Pt1ResPi" )->Clone("Pt1ResPiCur" ));
-    }
-    if(resfileCur->Get("Pt1ResE" )) {
-      fPt1ResECur =(TGraph*)(resfileCur->Get("Pt1ResE" )->Clone("Pt1ResECur" ));
-    }
-    if(resfileCur->Get("D0RPResPSA" )) {
-      fD0RPResPCurSA =(TGraph*)(resfileCur->Get("D0RPResPSA" )->Clone("D0RPResPCurSA" ));
-    }
-    if(resfileCur->Get("D0RPResKSA" )) {
-      fD0RPResKCurSA =(TGraph*)(resfileCur->Get("D0RPResKSA" )->Clone("D0RPResKCurSA" ));
-    }
-    if(resfileCur->Get("D0RPResPiSA")) {
-      fD0RPResPiCurSA=(TGraph*)(resfileCur->Get("D0RPResPiSA")->Clone("D0RPResPiCurSA"));
-    }
-    if(resfileCur->Get("D0RPResESA")) {
-      fD0RPResECurSA=(TGraph*)(resfileCur->Get("D0RPResESA")->Clone("D0RPResECurSA"));
-    }
-    if(resfileCur->Get("D0ZResPSA"  )) {
-      fD0ZResPCurSA  =(TGraph*)(resfileCur->Get("D0ZResPSA"  )->Clone("D0ZResPCurSA"  ));
-    }
-    if(resfileCur->Get("D0ZResKSA"  )) {
-      fD0ZResKCurSA  =(TGraph*)(resfileCur->Get("D0ZResKSA"  )->Clone("D0ZResKCurSA"  ));
-    }
-    if(resfileCur->Get("D0ZResPiSA" )) {
-      fD0ZResPiCurSA =(TGraph*)(resfileCur->Get("D0ZResPiSA" )->Clone("D0ZResPiCurSA" ));
-    }
-    if(resfileCur->Get("D0ZResESA" )) {
-      fD0ZResECurSA =(TGraph*)(resfileCur->Get("D0ZResESA" )->Clone("D0ZResECurSA" ));
-    }
-    if(resfileCur->Get("Pt1ResPSA"  )) {
-      fPt1ResPCurSA  =(TGraph*)(resfileCur->Get("Pt1ResPSA"  )->Clone("Pt1ResPCurSA"  ));
-    }
-    if(resfileCur->Get("Pt1ResKSA"  )) {
-      fPt1ResKCurSA  =(TGraph*)(resfileCur->Get("Pt1ResKSA"  )->Clone("Pt1ResKCurSA"  ));
-    }
-    if(resfileCur->Get("Pt1ResPiSA" )) {
-      fPt1ResPiCurSA =(TGraph*)(resfileCur->Get("Pt1ResPiSA" )->Clone("Pt1ResPiCurSA" ));
-    }
-    if(resfileCur->Get("Pt1ResESA" )) {
-      fPt1ResECurSA =(TGraph*)(resfileCur->Get("Pt1ResESA" )->Clone("Pt1ResECurSA" ));
-    }
-    delete resfileCur;
+    else  // analysing PbPb 2018 periods
+    {
+      printf("\nCur\n--------------------\n");
+      if(resfileCur->Get("kFirst_D0RPResP") && resfileCur->Get("kOnlySecond_D0RPResP")){
+        fD0RPResPCur_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0RPResP")->Clone("kFirst_D0RPResPCur"));
+        fD0RPResPCur_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0RPResP")->Clone("kOnlySecond_D0RPResPCur"));
+        printf("%p\n",fD0RPResPCur_PbPb2018_kFirst);
+        printf("%p\n",fD0RPResPCur_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_D0RPResK") && resfileCur->Get("kOnlySecond_D0RPResK")){
+        fD0RPResKCur_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0RPResK")->Clone("kFirst_D0RPResKCur"));
+        fD0RPResKCur_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0RPResK")->Clone("kOnlySecond_D0RPResKCur"));
+        printf("%p\n",fD0RPResKCur_PbPb2018_kFirst);
+        printf("%p\n",fD0RPResKCur_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_D0RPResPi") && resfileCur->Get("kOnlySecond_D0RPResPi")){
+        fD0RPResPiCur_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0RPResPi")->Clone("kFirst_D0RPResPiCur"));
+        fD0RPResPiCur_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0RPResPi")->Clone("kOnlySecond_D0RPResPiCur"));
+        printf("%p\n",fD0RPResPiCur_PbPb2018_kFirst);
+        printf("%p\n",fD0RPResPiCur_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_D0RPResE") && resfileCur->Get("kOnlySecond_D0RPResE")){
+        fD0RPResECur_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0RPResE")->Clone("kFirst_D0RPResECur"));
+        fD0RPResECur_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0RPResE")->Clone("kOnlySecond_D0RPResECur"));
+        printf("%p\n",fD0RPResECur_PbPb2018_kFirst);
+        printf("%p\n",fD0RPResECur_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_D0RPSigmaPullRatioP") && resfileCur->Get("kOnlySecond_D0RPSigmaPullRatioP")){
+        fD0RPSigmaPullRatioP_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0RPSigmaPullRatioP"));
+        fD0RPSigmaPullRatioP_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0RPSigmaPullRatioP"));
+        printf("%p\n",fD0RPSigmaPullRatioP_PbPb2018_kFirst);
+        printf("%p\n",fD0RPSigmaPullRatioP_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_D0RPSigmaPullRatioK") && resfileCur->Get("kOnlySecond_D0RPSigmaPullRatioK")){
+        fD0RPSigmaPullRatioK_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0RPSigmaPullRatioK"));
+        fD0RPSigmaPullRatioK_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0RPSigmaPullRatioK"));
+        printf("%p\n",fD0RPSigmaPullRatioK_PbPb2018_kFirst);
+        printf("%p\n",fD0RPSigmaPullRatioK_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_D0RPSigmaPullRatioPi") && resfileCur->Get("kOnlySecond_D0RPSigmaPullRatioPi")){
+        fD0RPSigmaPullRatioPi_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0RPSigmaPullRatioPi"));
+        fD0RPSigmaPullRatioPi_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0RPSigmaPullRatioPi"));
+        printf("%p\n",fD0RPSigmaPullRatioPi_PbPb2018_kFirst);
+        printf("%p\n",fD0RPSigmaPullRatioPi_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_D0RPSigmaPullRatioE") && resfileCur->Get("kOnlySecond_D0RPSigmaPullRatioE")){
+        fD0RPSigmaPullRatioE_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0RPSigmaPullRatioE"));
+        fD0RPSigmaPullRatioE_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0RPSigmaPullRatioE"));
+        printf("%p\n",fD0RPSigmaPullRatioE_PbPb2018_kFirst);
+        printf("%p\n",fD0RPSigmaPullRatioE_PbPb2018_kOnlySecond);
+      }
+      for(UInt_t j = 0; j < 2; j++)
+      {
+        for(Int_t i=0; i<24; i++){
+          if(resfileCur->Get(Form("kFirst_D0RPMeanP_B%d_phi%d",j,i)) && resfileCur->Get(Form("kOnlySecond_D0RPMeanP_B%d_phi%d",j,i))){
+            fD0RPMeanPCur_PbPb2018_kFirst[j][i]=(TGraph*)resfileCur->Get(Form("kFirst_D0RPMeanP_B%d_phi%d",j,i))->Clone(Form("kFirst_D0RPMeanPCur_B%d_phi%d",j,i));
+            fD0RPMeanPCur_PbPb2018_kOnlySecond[j][i]=(TGraph*)resfileCur->Get(Form("kOnlySecond_D0RPMeanP_B%d_phi%d",j,i))->Clone(Form("kOnlySecond_D0RPMeanPCur_B%d_phi%d",j,i));
+            printf("%p\n",fD0RPMeanPCur_PbPb2018_kFirst[j][i]);
+            printf("%p\n",fD0RPMeanPCur_PbPb2018_kOnlySecond[j][i]);
+          }
+          if(resfileCur->Get(Form("kFirst_D0RPMeanK_B%d_phi%d",j,i)) && resfileCur->Get(Form("kOnlySecond_D0RPMeanK_B%d_phi%d",j,i))){
+            fD0RPMeanKCur_PbPb2018_kFirst[j][i]=(TGraph*)resfileCur->Get(Form("kFirst_D0RPMeanK_B%d_phi%d",j,i))->Clone(Form("kFirst_D0RPMeanKCur_B%d_phi%d",j,i));
+            fD0RPMeanKCur_PbPb2018_kOnlySecond[j][i]=(TGraph*)resfileCur->Get(Form("kOnlySecond_D0RPMeanK_B%d_phi%d",j,i))->Clone(Form("kOnlySecond_D0RPMeanKCur_B%d_phi%d",j,i));
+            printf("%p\n",fD0RPMeanKCur_PbPb2018_kFirst[j][i]);
+            printf("%p\n",fD0RPMeanKCur_PbPb2018_kOnlySecond[j][i]);
+          }
+          if(resfileCur->Get(Form("kFirst_D0RPMeanPi_B%d_phi%d",j,i)) && resfileCur->Get(Form("kOnlySecond_D0RPMeanPi_B%d_phi%d",j,i))){
+            fD0RPMeanPiCur_PbPb2018_kFirst[j][i]=(TGraph*)resfileCur->Get(Form("kFirst_D0RPMeanPi_B%d_phi%d",j,i))->Clone(Form("kFirst_D0RPMeanPiCur_B%d_phi%d",j,i));
+            fD0RPMeanPiCur_PbPb2018_kOnlySecond[j][i]=(TGraph*)resfileCur->Get(Form("kOnlySecond_D0RPMeanPi_B%d_phi%d",j,i))->Clone(Form("kOnlySecond_D0RPMeanPiCur_B%d_phi%d",j,i));
+            printf("%p\n",fD0RPMeanPiCur_PbPb2018_kFirst[j][i]);
+            printf("%p\n",fD0RPMeanPiCur_PbPb2018_kOnlySecond[j][i]);
+          }      
+          if(resfileCur->Get(Form("kFirst_D0RPMeanE_B%d_phi%d",j,i)) && resfileCur->Get(Form("kOnlySecond_D0RPMeanE_B%d_phi%d",j,i))){
+            fD0RPMeanECur_PbPb2018_kFirst[j][i]=(TGraph*)resfileCur->Get(Form("kFirst_D0RPMeanE_B%d_phi%d",j,i))->Clone(Form("kFirst_D0RPMeanECur_B%d_phi%d",j,i));
+            fD0RPMeanECur_PbPb2018_kOnlySecond[j][i]=(TGraph*)resfileCur->Get(Form("kOnlySecond_D0RPMeanE_B%d_phi%d",j,i))->Clone(Form("kOnlySecond_D0RPMeanECur_B%d_phi%d",j,i));
+            printf("%p\n",fD0RPMeanECur_PbPb2018_kFirst[j][i]);
+            printf("%p\n",fD0RPMeanECur_PbPb2018_kOnlySecond[j][i]);
+          }    
+        }
+      }
+      if(resfileCur->Get("kFirst_D0ZResP") && resfileCur->Get("kOnlySecond_D0ZResP")){
+        fD0ZResPCur_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0ZResP")->Clone("kFirst_D0ZResPCur"));
+        fD0ZResPCur_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0ZResP")->Clone("kOnlySecond_D0ZResPCur"));
+        printf("%p\n",fD0ZResPCur_PbPb2018_kFirst);
+        printf("%p\n",fD0ZResPCur_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_D0ZResK") && resfileCur->Get("kOnlySecond_D0ZResK")){
+        fD0ZResKCur_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0ZResK")->Clone("kFirst_D0ZResKCur"));
+        fD0ZResKCur_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0ZResK")->Clone("kOnlySecond_D0ZResKCur"));
+        printf("%p\n",fD0ZResKCur_PbPb2018_kFirst);
+        printf("%p\n",fD0ZResKCur_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_D0ZResPi") && resfileCur->Get("kOnlySecond_D0ZResPi")){
+        fD0ZResPiCur_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0ZResPi")->Clone("kFirst_D0ZResPiCur"));
+        fD0ZResPiCur_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0ZResPi")->Clone("kOnlySecond_D0ZResPiCur"));
+        printf("%p\n",fD0ZResPiCur_PbPb2018_kFirst);
+        printf("%p\n",fD0ZResPiCur_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_D0ZResE") && resfileCur->Get("kOnlySecond_D0ZResE")){
+        fD0ZResECur_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0ZResE")->Clone("kFirst_D0ZResECur"));
+        fD0ZResECur_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0ZResE")->Clone("kOnlySecond_D0ZResECur"));
+        printf("%p\n",fD0ZResECur_PbPb2018_kFirst);
+        printf("%p\n",fD0ZResECur_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_Pt1ResP") && resfileCur->Get("kOnlySecond_Pt1ResP")){
+        fPt1ResPCur_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_Pt1ResP")->Clone("kFirst_Pt1ResPCur"));
+        fPt1ResPCur_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_Pt1ResP")->Clone("kOnlySecond_Pt1ResPCur"));
+        printf("%p\n",fPt1ResPCur_PbPb2018_kFirst);
+        printf("%p\n",fPt1ResPCur_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_Pt1ResK") && resfileCur->Get("kOnlySecond_Pt1ResK")){
+        fPt1ResKCur_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_Pt1ResK")->Clone("kFirst_Pt1ResKCur"));
+        fPt1ResKCur_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_Pt1ResK")->Clone("kOnlySecond_Pt1ResKCur"));
+        printf("%p\n",fPt1ResKCur_PbPb2018_kFirst);
+        printf("%p\n",fPt1ResKCur_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_Pt1ResPi") && resfileCur->Get("kOnlySecond_Pt1ResPi")){
+        fPt1ResPiCur_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_Pt1ResPi")->Clone("kFirst_Pt1ResPiCur"));
+        fPt1ResPiCur_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_Pt1ResPi")->Clone("kOnlySecond_Pt1ResPiCur"));
+        printf("%p\n",fPt1ResPiCur_PbPb2018_kFirst);
+        printf("%p\n",fPt1ResPiCur_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_Pt1ResE") && resfileCur->Get("kOnlySecond_Pt1ResE")){
+        fPt1ResECur_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_Pt1ResE")->Clone("kFirst_Pt1ResECur"));
+        fPt1ResECur_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_Pt1ResE")->Clone("kOnlySecond_Pt1ResECur"));
+        printf("%p\n",fPt1ResECur_PbPb2018_kFirst);
+        printf("%p\n",fPt1ResECur_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_D0RPResPSA") && resfileCur->Get("kOnlySecond_D0RPResPSA")){
+        fD0RPResPCurSA_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0RPResPSA")->Clone("kFirst_D0RPResPCurSA"));
+        fD0RPResPCurSA_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0RPResPSA")->Clone("kOnlySecond_D0RPResPCurSA"));
+        printf("%p\n",fD0RPResPCurSA_PbPb2018_kFirst);
+        printf("%p\n",fD0RPResPCurSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_D0RPResKSA") && resfileCur->Get("kOnlySecond_D0RKResPSA")){
+        fD0RPResKCurSA_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0RPResKSA")->Clone("kFirst_D0RPResKCurSA"));
+        fD0RPResKCurSA_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0RPResKSA")->Clone("kOnlySecond_D0RPResKCurSA"));
+        printf("%p\n",fD0RPResKCurSA_PbPb2018_kFirst);
+        printf("%p\n",fD0RPResKCurSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_D0RPResPiSA") && resfileCur->Get("kOnlySecond_D0RPResPiSA")){
+        fD0RPResPiCurSA_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0RPResPiSA")->Clone("kFirst_D0RPResPiCurSA"));
+        fD0RPResPiCurSA_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0RPResPiSA")->Clone("kOnlySecond_D0RPResPiCurSA"));
+        printf("%p\n",fD0RPResPiCurSA_PbPb2018_kFirst);
+        printf("%p\n",fD0RPResPiCurSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_D0RPResESA") && resfileCur->Get("kOnlySecond_D0RPResESA")){
+        fD0RPResECurSA_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0RPResESA")->Clone("kFirst_D0RPResECurSA"));
+        fD0RPResECurSA_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0RPResESA")->Clone("kOnlySecond_D0RPResECurSA"));
+        printf("%p\n",fD0RPResECurSA_PbPb2018_kFirst);
+        printf("%p\n",fD0RPResECurSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_D0ZResPSA") && resfileCur->Get("kOnlySecond_D0ZResPSA")){
+        fD0ZResPCurSA_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0ZResPSA")->Clone("kFirst_D0ZResPCurSA"));
+        fD0ZResPCurSA_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0ZResPSA")->Clone("kOnlySecond_D0ZResPCurSA"));
+        printf("%p\n",fD0ZResPCurSA_PbPb2018_kFirst);
+        printf("%p\n",fD0ZResPCurSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_D0ZResKSA") && resfileCur->Get("kOnlySecond_D0ZResKSA")){
+        fD0ZResKCurSA_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0ZResKSA")->Clone("kFirst_D0ZResKCurSA"));
+        fD0ZResKCurSA_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0ZResKSA")->Clone("kOnlySecond_D0ZResKCurSA"));
+        printf("%p\n",fD0ZResKCurSA_PbPb2018_kFirst);
+        printf("%p\n",fD0ZResKCurSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_D0ZResPiSA") && resfileCur->Get("kOnlySecond_D0ZResPiSA")){
+        fD0ZResPiCurSA_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0ZResPiSA")->Clone("kFirst_D0ZResPiCurSA"));
+        fD0ZResPiCurSA_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0ZResPiSA")->Clone("kOnlySecond_D0ZResPiCurSA"));
+        printf("%p\n",fD0ZResPiCurSA_PbPb2018_kFirst);
+        printf("%p\n",fD0ZResPiCurSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_D0ZResESA") && resfileCur->Get("kOnlySecond_D0ZResESA")){
+        fD0ZResECurSA_PbPb2018_kFirst=(TGraph*)(resfileCur->Get("kFirst_D0ZResESA")->Clone("kFirst_D0ZResECurSA"));
+        fD0ZResECurSA_PbPb2018_kOnlySecond=(TGraph*)(resfileCur->Get("kOnlySecond_D0ZResESA")->Clone("kOnlySecond_D0ZResECurSA"));
+        printf("%p\n",fD0ZResECurSA_PbPb2018_kFirst);
+        printf("%p\n",fD0ZResECurSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_Pt1ResPSA") && resfileCur->Get("kOnlySecond_Pt1ResPSA")){
+        fPt1ResPCurSA_PbPb2018_kFirst=(TGraph*) (resfileCur->Get("kFirst_Pt1ResPSA")->Clone("kFirst_Pt1ResPCurSA"));
+        fPt1ResPCurSA_PbPb2018_kOnlySecond=(TGraph*) (resfileCur->Get("kOnlySecond_Pt1ResPSA")->Clone("kOnlySecond_Pt1ResPCurSA"));
+        printf("%p\n",fPt1ResPCurSA_PbPb2018_kFirst);
+        printf("%p\n",fPt1ResPCurSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_Pt1ResKSA") && resfileCur->Get("kOnlySecond_Pt1ResKSA")){
+        fPt1ResKCurSA_PbPb2018_kFirst=(TGraph*) (resfileCur->Get("kFirst_Pt1ResKSA")->Clone("kFirst_Pt1ResKCurSA"));
+        fPt1ResKCurSA_PbPb2018_kOnlySecond=(TGraph*) (resfileCur->Get("kOnlySecond_Pt1ResKSA")->Clone("kOnlySecond_Pt1ResKCurSA"));
+        printf("%p\n",fPt1ResKCurSA_PbPb2018_kFirst);
+        printf("%p\n",fPt1ResKCurSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_Pt1ResPiSA") && resfileCur->Get("kOnlySecond_Pt1ResPiSA")){
+        fPt1ResPiCurSA_PbPb2018_kFirst=(TGraph*) (resfileCur->Get("kFirst_Pt1ResPiSA")->Clone("kFirst_Pt1ResPiCurSA"));
+        fPt1ResPiCurSA_PbPb2018_kOnlySecond=(TGraph*) (resfileCur->Get("kOnlySecond_Pt1ResPiSA")->Clone("kOnlySecond_Pt1ResPiCurSA"));
+        printf("%p\n",fPt1ResPiCurSA_PbPb2018_kFirst);
+        printf("%p\n",fPt1ResPiCurSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileCur->Get("kFirst_Pt1ResESA") && resfileCur->Get("kOnlySecond_Pt1ResESA")){
+        fPt1ResECurSA_PbPb2018_kFirst=(TGraph*) (resfileCur->Get("kFirst_Pt1ResESA")->Clone("kFirst_Pt1ResECurSA"));
+        fPt1ResECurSA_PbPb2018_kOnlySecond=(TGraph*) (resfileCur->Get("kOnlySecond_Pt1ResESA")->Clone("kOnlySecond_Pt1ResECurSA"));
+        printf("%p\n",fPt1ResECurSA_PbPb2018_kFirst);
+        printf("%p\n",fPt1ResECurSA_PbPb2018_kOnlySecond);
+      }
+      delete resfileCur;
+    }    
   }
     
-  TString resfileUpgURI = Form("alien:///alice/cern.ch/user/p/pwg_hf/common/Improver/%s/%s/ITSgraphs_NewAll-X0.3-Res4um.root",period,systematic);
+  //TString resfileUpgURI = Form("alien:///alice/cern.ch/user/p/pwg_hf/common/Improver/%s/%s/ITSgraphs_NewAll-X0.3-Res4um.root",period,systematic);
+  printf("\n### reading file %s ...\n",resfileUpgURI.Data());
   TFile *resfileUpg=TFile::Open(resfileUpgURI.Data());
+  if(resfileUpg)  printf("... READ ###\n");
   if(resfileUpg) {
-    if(resfileUpg->Get("D0RPResP" )) {
-      fD0RPResPUpg =(TGraph*)(resfileUpg->Get("D0RPResP" )->Clone("D0RPResPUpg" ));
-    }
-    if(resfileUpg->Get("D0RPResK" )) {
-      fD0RPResKUpg =(TGraph*)(resfileUpg->Get("D0RPResK" )->Clone("D0RPResKUpg" ));
-    }
-    if(resfileUpg->Get("D0RPResPi")) {
-      fD0RPResPiUpg=(TGraph*)(resfileUpg->Get("D0RPResPi")->Clone("D0RPResPiUpg"));
-    }
-    if(resfileUpg->Get("D0RPResE")) {
-      fD0RPResEUpg=(TGraph*)(resfileUpg->Get("D0RPResE")->Clone("D0RPResEUpg"));
-    }
-    for(Int_t j=0; j<2; j++){
-      for(Int_t i=0; i<4; i++){
-	if(resfileUpg->Get(Form("D0RPMeanP_B%d_phi%d",j,i))) {
-	  fD0RPMeanPUpg[j][i]=(TGraph*)(resfileUpg->Get(Form("D0RPMeanP_B%d_phi%d",j,i))->Clone(Form("D0RPMeanPUpg_B%d_phi%d",j,i)));
-	}
-	if(resfileUpg->Get(Form("D0RPMeanK_B%d_phi%d",j,i))) {
-	  fD0RPMeanKUpg[j][i]=(TGraph*)(resfileUpg->Get(Form("D0RPMeanK_B%d_phi%d",j,i))->Clone(Form("D0RPMeanKUpg_B%d_phi%d",j,i)));
-	}
-	if(resfileUpg->Get(Form("D0RPMeanPi_B%d_phi%d",j,i))) {
-	  fD0RPMeanPiUpg[j][i]=(TGraph*)(resfileUpg->Get(Form("D0RPMeanPi_B%d_phi%d",j,i))->Clone(Form("D0RPMeanPiUpg_B%d_phi%d",j,i)));
-	}
-	if(resfileUpg->Get(Form("D0RPMeanE_B%d_phi%d",j,i))) {
-	  fD0RPMeanEUpg[j][i]=(TGraph*)(resfileUpg->Get(Form("D0RPMeanE_B%d_phi%d",j,i))->Clone(Form("D0RPMeanEUpg_B%d_phi%d",j,i)));
-	}
+    if(!fIsPbPb2018){ 
+      if(resfileUpg->Get("D0RPResP" )) {
+        fD0RPResPUpg =(TGraph*)(resfileUpg->Get("D0RPResP" )->Clone("D0RPResPUpg" ));
       }
+      if(resfileUpg->Get("D0RPResK" )) {
+        fD0RPResKUpg =(TGraph*)(resfileUpg->Get("D0RPResK" )->Clone("D0RPResKUpg" ));
+      }
+      if(resfileUpg->Get("D0RPResPi")) {
+        fD0RPResPiUpg=(TGraph*)(resfileUpg->Get("D0RPResPi")->Clone("D0RPResPiUpg"));
+      }
+      if(resfileUpg->Get("D0RPResE")) {
+        fD0RPResEUpg=(TGraph*)(resfileUpg->Get("D0RPResE")->Clone("D0RPResEUpg"));
+      }
+      for(Int_t j=0; j<2; j++){
+        for(Int_t i=0; i<4; i++){
+	        if(resfileUpg->Get(Form("D0RPMeanP_B%d_phi%d",j,i))) {
+	          fD0RPMeanPUpg[j][i]=(TGraph*)(resfileUpg->Get(Form("D0RPMeanP_B%d_phi%d",j,i))->Clone(Form("D0RPMeanPUpg_B%d_phi%d",j,i)));
+	        }
+	        if(resfileUpg->Get(Form("D0RPMeanK_B%d_phi%d",j,i))) {
+	          fD0RPMeanKUpg[j][i]=(TGraph*)(resfileUpg->Get(Form("D0RPMeanK_B%d_phi%d",j,i))->Clone(Form("D0RPMeanKUpg_B%d_phi%d",j,i)));
+	        }
+	        if(resfileUpg->Get(Form("D0RPMeanPi_B%d_phi%d",j,i))) {
+	          fD0RPMeanPiUpg[j][i]=(TGraph*)(resfileUpg->Get(Form("D0RPMeanPi_B%d_phi%d",j,i))->Clone(Form("D0RPMeanPiUpg_B%d_phi%d",j,i)));
+	        }
+	        if(resfileUpg->Get(Form("D0RPMeanE_B%d_phi%d",j,i))) {
+	          fD0RPMeanEUpg[j][i]=(TGraph*)(resfileUpg->Get(Form("D0RPMeanE_B%d_phi%d",j,i))->Clone(Form("D0RPMeanEUpg_B%d_phi%d",j,i)));
+	        }
+        }
+      }
+      if(resfileUpg->Get("D0ZResP"  )) {
+        fD0ZResPUpg  =(TGraph*)(resfileUpg->Get("D0ZResP"  )->Clone("D0ZResPUpg"  ));
+      }
+      if(resfileUpg->Get("D0ZResK"  )) {
+        fD0ZResKUpg  =(TGraph*)(resfileUpg->Get("D0ZResK"  )->Clone("D0ZResKUpg"  ));
+      }
+      if(resfileUpg->Get("D0ZResPi" )) {
+        fD0ZResPiUpg =(TGraph*)(resfileUpg->Get("D0ZResPi" )->Clone("D0ZResPiUpg" ));
+      }
+      if(resfileUpg->Get("D0ZResE" )) {
+        fD0ZResEUpg =(TGraph*)(resfileUpg->Get("D0ZResE" )->Clone("D0ZResEUpg" ));
+      }
+      if(resfileUpg->Get("Pt1ResP"  )) {
+        fPt1ResPUpg  =(TGraph*)(resfileUpg->Get("Pt1ResP"  )->Clone("Pt1ResPUpg"  ));
+      }
+      if(resfileUpg->Get("Pt1ResK"  )) {
+        fPt1ResKUpg  =(TGraph*)(resfileUpg->Get("Pt1ResK"  )->Clone("Pt1ResKUpg"  ));
+      }
+      if(resfileUpg->Get("Pt1ResPi" )) {
+        fPt1ResPiUpg =(TGraph*)(resfileUpg->Get("Pt1ResPi" )->Clone("Pt1ResPiUpg" ));
+      }
+      if(resfileUpg->Get("Pt1ResE" )) {
+        fPt1ResEUpg =(TGraph*)(resfileUpg->Get("Pt1ResE" )->Clone("Pt1ResEUpg" ));
+      }
+      if(resfileUpg->Get("D0RPResPSA" )) {
+        fD0RPResPUpgSA =(TGraph*)(resfileUpg->Get("D0RPResPSA" )->Clone("D0RPResPUpgSA" ));
+      }
+      if(resfileUpg->Get("D0RPResKSA" )) {
+        fD0RPResKUpgSA =(TGraph*)(resfileUpg->Get("D0RPResKSA" )->Clone("D0RPResKUpgSA" ));
+      }
+      if(resfileUpg->Get("D0RPResPiSA")) {
+        fD0RPResPiUpgSA=(TGraph*)(resfileUpg->Get("D0RPResPiSA")->Clone("D0RPResPiUpgSA"));
+      }
+      if(resfileUpg->Get("D0RPResESA")) {
+        fD0RPResEUpgSA=(TGraph*)(resfileUpg->Get("D0RPResESA")->Clone("D0RPResEUpgSA"));
+      }
+      if(resfileUpg->Get("D0ZResPSA"  )) {
+        fD0ZResPUpgSA  =(TGraph*)(resfileUpg->Get("D0ZResPSA"  )->Clone("D0ZResPUpgSA"  ));
+      }
+      if(resfileUpg->Get("D0ZResKSA"  )) {
+        fD0ZResKUpgSA  =(TGraph*)(resfileUpg->Get("D0ZResKSA"  )->Clone("D0ZResKUpgSA"  ));
+      }
+      if(resfileUpg->Get("D0ZResPiSA" )) {
+        fD0ZResPiUpgSA =(TGraph*)(resfileUpg->Get("D0ZResPiSA" )->Clone("D0ZResPiUpgSA" ));
+      }
+      if(resfileUpg->Get("D0ZResESA" )) {
+        fD0ZResEUpgSA =(TGraph*)(resfileUpg->Get("D0ZResESA" )->Clone("D0ZResEUpgSA" ));
+      }
+      if(resfileUpg->Get("Pt1ResPSA"  )) {
+        fPt1ResPUpgSA  =(TGraph*)(resfileUpg->Get("Pt1ResPSA"  )->Clone("Pt1ResPUpgSA"  ));
+      }
+      if(resfileUpg->Get("Pt1ResKSA"  )) {
+        fPt1ResKUpgSA  =(TGraph*)(resfileUpg->Get("Pt1ResKSA"  )->Clone("Pt1ResKUpgSA"  ));
+      }
+      if(resfileUpg->Get("Pt1ResPiSA" )) {
+        fPt1ResPiUpgSA =(TGraph*)(resfileUpg->Get("Pt1ResPiSA" )->Clone("Pt1ResPiUpgSA" ));
+      }
+      if(resfileUpg->Get("Pt1ResESA" )) {
+        fPt1ResEUpgSA =(TGraph*)(resfileUpg->Get("Pt1ResESA" )->Clone("Pt1ResEUpgSA" ));
+      }
+      delete resfileUpg;
     }
-    if(resfileUpg->Get("D0ZResP"  )) {
-      fD0ZResPUpg  =(TGraph*)(resfileUpg->Get("D0ZResP"  )->Clone("D0ZResPUpg"  ));
+    else  // analysing PbPb 2018 periods
+    {
+      printf("\nNew\n--------------------\n");
+      if(resfileUpg->Get("kFirst_D0RPResP") && resfileUpg->Get("kOnlySecond_D0RPResP")){
+        fD0RPResPUpg_PbPb2018_kFirst=(TGraph*)(resfileUpg->Get("kFirst_D0RPResP")->Clone("kFirst_D0RPResPUpg"));
+        fD0RPResPUpg_PbPb2018_kOnlySecond=(TGraph*)(resfileUpg->Get("kOnlySecond_D0RPResP")->Clone("kOnlySecond_D0RPResPUpg"));
+        printf("%p\n",fD0RPResPUpg_PbPb2018_kFirst);
+        printf("%p\n",fD0RPResPUpg_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_D0RPResK") && resfileUpg->Get("kOnlySecond_D0RPResK")){
+        fD0RPResKUpg_PbPb2018_kFirst=(TGraph*)(resfileUpg->Get("kFirst_D0RPResK")->Clone("kFirst_D0RPResKUpg"));
+        fD0RPResKUpg_PbPb2018_kOnlySecond=(TGraph*)(resfileUpg->Get("kOnlySecond_D0RPResK")->Clone("kOnlySecond_D0RPResKUpg"));
+        printf("%p\n",fD0RPResKUpg_PbPb2018_kFirst);
+        printf("%p\n",fD0RPResKUpg_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_D0RPResPi") && resfileUpg->Get("kOnlySecond_D0RPResPi")){
+        fD0RPResPiUpg_PbPb2018_kFirst=(TGraph*)(resfileUpg->Get("kFirst_D0RPResPi")->Clone("kFirst_D0RPResPiUpg"));
+        fD0RPResPiUpg_PbPb2018_kOnlySecond=(TGraph*)(resfileUpg->Get("kOnlySecond_D0RPResPi")->Clone("kOnlySecond_D0RPResPiUpg"));
+        printf("%p\n",fD0RPResPiUpg_PbPb2018_kFirst);
+        printf("%p\n",fD0RPResPiUpg_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_D0RPResE") && resfileUpg->Get("kOnlySecond_D0RPResE")){
+        fD0RPResEUpg_PbPb2018_kFirst=(TGraph*)(resfileUpg->Get("kFirst_D0RPResE")->Clone("kFirst_D0RPResEUpg"));
+        fD0RPResEUpg_PbPb2018_kOnlySecond=(TGraph*)(resfileUpg->Get("kOnlySecond_D0RPResE")->Clone("kOnlySecond_D0RPResEUpg"));
+        printf("%p\n",fD0RPResEUpg_PbPb2018_kFirst);
+        printf("%p\n",fD0RPResEUpg_PbPb2018_kOnlySecond);
+      }
+      for(UInt_t j = 0; j < 2; j++){
+        for(UInt_t i = 0; i < 24; i++){
+          if(resfileUpg->Get(Form("kFirst_D0RPMeanP_B%d_phi%d",j,i)) && resfileUpg->Get(Form("kOnlySecond_D0RPMeanP_B%d_phi%d",j,i))){
+            fD0RPMeanPUpg_PbPb2018_kFirst[j][i]=(TGraph*)(resfileUpg->Get(Form("kFirst_D0RPMeanP_B%d_phi%d",j,i))->Clone(Form("kFirst_D0RPMeanP_B%d_phi%d",j,i)));
+            fD0RPMeanPUpg_PbPb2018_kOnlySecond[j][i]=(TGraph*)(resfileUpg->Get(Form("kOnlySecond_D0RPMeanP_B%d_phi%d",j,i))->Clone(Form("kOnlySecond_D0RPMeanP_B%d_phi%d",j,i)));          
+            printf("%p\n",fD0RPMeanPUpg_PbPb2018_kFirst[j][i]);
+            printf("%p\n",fD0RPMeanPUpg_PbPb2018_kOnlySecond[j][i]);
+          }
+          if(resfileUpg->Get(Form("kFirst_D0RPMeanK_B%d_phi%d",j,i)) && resfileUpg->Get(Form("kOnlySecond_D0RPMeanK_B%d_phi%d",j,i))){
+            fD0RPMeanKUpg_PbPb2018_kFirst[j][i]=(TGraph*)(resfileUpg->Get(Form("kFirst_D0RPMeanK_B%d_phi%d",j,i))->Clone(Form("kFirst_D0RPMeanK_B%d_phi%d",j,i)));
+            fD0RPMeanKUpg_PbPb2018_kOnlySecond[j][i]=(TGraph*)(resfileUpg->Get(Form("kOnlySecond_D0RPMeanK_B%d_phi%d",j,i))->Clone(Form("kOnlySecond_D0RPMeanK_B%d_phi%d",j,i)));          
+            printf("%p\n",fD0RPMeanKUpg_PbPb2018_kFirst[j][i]);
+            printf("%p\n",fD0RPMeanKUpg_PbPb2018_kOnlySecond[j][i]);
+          }
+          if(resfileUpg->Get(Form("kFirst_D0RPMeanPi_B%d_phi%d",j,i)) && resfileUpg->Get(Form("kOnlySecond_D0RPMeanPi_B%d_phi%d",j,i))){
+            fD0RPMeanPiUpg_PbPb2018_kFirst[j][i]=(TGraph*)(resfileUpg->Get(Form("kFirst_D0RPMeanPi_B%d_phi%d",j,i))->Clone(Form("kFirst_D0RPMeanPi_B%d_phi%d",j,i)));
+            fD0RPMeanPiUpg_PbPb2018_kOnlySecond[j][i]=(TGraph*)(resfileUpg->Get(Form("kOnlySecond_D0RPMeanPi_B%d_phi%d",j,i))->Clone(Form("kOnlySecond_D0RPMeanPi_B%d_phi%d",j,i)));          
+            printf("%p\n",fD0RPMeanPiUpg_PbPb2018_kFirst[j][i]);
+            printf("%p\n",fD0RPMeanPiUpg_PbPb2018_kOnlySecond[j][i]);
+          }
+          if(resfileUpg->Get(Form("kFirst_D0RPMeanE_B%d_phi%d",j,i)) && resfileUpg->Get(Form("kOnlySecond_D0RPMeanE_B%d_phi%d",j,i))){
+            fD0RPMeanEUpg_PbPb2018_kFirst[j][i]=(TGraph*)(resfileUpg->Get(Form("kFirst_D0RPMeanE_B%d_phi%d",j,i))->Clone(Form("kFirst_D0RPMeanE_B%d_phi%d",j,i)));
+            fD0RPMeanEUpg_PbPb2018_kOnlySecond[j][i]=(TGraph*)(resfileUpg->Get(Form("kOnlySecond_D0RPMeanE_B%d_phi%d",j,i))->Clone(Form("kOnlySecond_D0RPMeanE_B%d_phi%d",j,i)));          
+            printf("%p\n",fD0RPMeanEUpg_PbPb2018_kFirst[j][i]);
+            printf("%p\n",fD0RPMeanEUpg_PbPb2018_kOnlySecond[j][i]);
+          }
+        } 
+      }
+      if(resfileUpg->Get("kFirst_D0ZResP") && resfileUpg->Get("kOnlySecond_D0ZResP")){
+        fD0ZResPUpg_PbPb2018_kFirst=(TGraph*)(resfileUpg->Get("kFirst_D0ZResP")->Clone("kFirst_D0ZResPUpg"));
+        fD0ZResPUpg_PbPb2018_kOnlySecond=(TGraph*)(resfileUpg->Get("kOnlySecond_D0ZResP")->Clone("kOnlySecond_D0ZResPUpg"));
+        printf("%p\n",fD0ZResPUpg_PbPb2018_kFirst);
+        printf("%p\n",fD0ZResPUpg_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_D0ZResK") && resfileUpg->Get("kOnlySecond_D0ZResK")){
+        fD0ZResKUpg_PbPb2018_kFirst=(TGraph*)(resfileUpg->Get("kFirst_D0ZResK")->Clone("kFirst_D0ZResKUpg"));
+        fD0ZResKUpg_PbPb2018_kOnlySecond=(TGraph*)(resfileUpg->Get("kOnlySecond_D0ZResK")->Clone("kOnlySecond_D0ZResKUpg"));
+        printf("%p\n",fD0ZResKUpg_PbPb2018_kFirst);
+        printf("%p\n",fD0ZResKUpg_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_D0ZResPi") && resfileUpg->Get("kOnlySecond_D0ZResPi")){
+        fD0ZResPiUpg_PbPb2018_kFirst=(TGraph*)(resfileUpg->Get("kFirst_D0ZResPi")->Clone("kFirst_D0ZResPiUpg"));
+        fD0ZResPiUpg_PbPb2018_kOnlySecond=(TGraph*)(resfileUpg->Get("kOnlySecond_D0ZResPi")->Clone("kOnlySecond_D0ZResPiUpg"));
+        printf("%p\n",fD0ZResPiUpg_PbPb2018_kFirst);
+        printf("%p\n",fD0ZResPiUpg_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_D0ZResE") && resfileUpg->Get("kOnlySecond_D0ZResE")){
+        fD0ZResEUpg_PbPb2018_kFirst=(TGraph*)(resfileUpg->Get("kFirst_D0ZResE")->Clone("kFirst_D0ZResEUpg"));
+        fD0ZResEUpg_PbPb2018_kOnlySecond=(TGraph*)(resfileUpg->Get("kOnlySecond_D0ZResE")->Clone("kOnlySecond_D0ZResEUpg"));
+        printf("%p\n",fD0ZResEUpg_PbPb2018_kFirst);
+        printf("%p\n",fD0ZResEUpg_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_Pt1ResP") && resfileUpg->Get("kOnlySecond_Pt1ResP")){
+        fPt1ResPUpg_PbPb2018_kFirst=(TGraph*) (resfileUpg->Get("kFirst_Pt1ResP")->Clone("kFirst_Pt1ResPUpg"));
+        fPt1ResPUpg_PbPb2018_kOnlySecond=(TGraph*) (resfileUpg->Get("kOnlySecond_Pt1ResP")->Clone("kOnlySecond_Pt1ResPUpg"));
+        printf("%p\n",fPt1ResPUpg_PbPb2018_kFirst);
+        printf("%p\n",fPt1ResPUpg_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_Pt1ResK") && resfileUpg->Get("kOnlySecond_Pt1ResK")){
+        fPt1ResKUpg_PbPb2018_kFirst=(TGraph*) (resfileUpg->Get("kFirst_Pt1ResK")->Clone("kFirst_Pt1ResKUpg"));
+        fPt1ResKUpg_PbPb2018_kOnlySecond=(TGraph*) (resfileUpg->Get("kOnlySecond_Pt1ResK")->Clone("kOnlySecond_Pt1ResKUpg"));
+        printf("%p\n",fPt1ResKUpg_PbPb2018_kFirst);
+        printf("%p\n",fPt1ResKUpg_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_Pt1ResPi") && resfileUpg->Get("kOnlySecond_Pt1ResPi")){
+        fPt1ResPiUpg_PbPb2018_kFirst=(TGraph*) (resfileUpg->Get("kFirst_Pt1ResPi")->Clone("kFirst_Pt1ResPiUpg"));
+        fPt1ResPiUpg_PbPb2018_kOnlySecond=(TGraph*) (resfileUpg->Get("kOnlySecond_Pt1ResPi")->Clone("kOnlySecond_Pt1ResPiUpg"));
+        printf("%p\n",fPt1ResPiUpg_PbPb2018_kFirst);
+        printf("%p\n",fPt1ResPiUpg_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_Pt1ResE") && resfileUpg->Get("kOnlySecond_Pt1ResE")){
+        fPt1ResEUpg_PbPb2018_kFirst=(TGraph*) (resfileUpg->Get("kFirst_Pt1ResE")->Clone("kFirst_Pt1ResEUpg"));
+        fPt1ResEUpg_PbPb2018_kOnlySecond=(TGraph*) (resfileUpg->Get("kOnlySecond_Pt1ResE")->Clone("kOnlySecond_Pt1ResEUpg"));
+        printf("%p\n",fPt1ResEUpg_PbPb2018_kFirst);
+        printf("%p\n",fPt1ResEUpg_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_D0RPResPSA") && resfileUpg->Get("kOnlySecond_D0RPResPSA")){
+        fD0RPResPUpgSA_PbPb2018_kFirst=(TGraph*) (resfileUpg->Get("kFirst_D0RPResPSA")->Clone("kFirst_D0RPResPUpgSA"));
+        fD0RPResPUpgSA_PbPb2018_kOnlySecond=(TGraph*) (resfileUpg->Get("kOnlySecond_D0RPResPSA")->Clone("kOnlySecond_D0RPResPUpgSA"));
+        printf("%p\n",fD0RPResPUpgSA_PbPb2018_kFirst);
+        printf("%p\n",fD0RPResPUpgSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_D0RPResKSA") && resfileUpg->Get("kOnlySecond_D0RPResKSA")){
+        fD0RPResKUpgSA_PbPb2018_kFirst=(TGraph*) (resfileUpg->Get("kFirst_D0RPResKSA")->Clone("kFirst_D0RPResKUpgSA"));
+        fD0RPResKUpgSA_PbPb2018_kOnlySecond=(TGraph*) (resfileUpg->Get("kOnlySecond_D0RPResKSA")->Clone("kOnlySecond_D0RPResKUpgSA"));
+        printf("%p\n",fD0RPResKUpgSA_PbPb2018_kFirst);
+        printf("%p\n",fD0RPResKUpgSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_D0RPResPiSA") && resfileUpg->Get("kOnlySecond_D0RPResPiSA")){
+        fD0RPResPiUpgSA_PbPb2018_kFirst=(TGraph*) (resfileUpg->Get("kFirst_D0RPResPiSA")->Clone("kFirst_D0RPResPiUpgSA"));
+        fD0RPResPiUpgSA_PbPb2018_kOnlySecond=(TGraph*) (resfileUpg->Get("kOnlySecond_D0RPResPiSA")->Clone("kOnlySecond_D0RPResPiUpgSA"));
+        printf("%p\n",fD0RPResPiUpgSA_PbPb2018_kFirst);
+        printf("%p\n",fD0RPResPiUpgSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_D0RPResESA") && resfileUpg->Get("kOnlySecond_D0RPResESA")){
+        fD0RPResEUpgSA_PbPb2018_kFirst=(TGraph*) (resfileUpg->Get("kFirst_D0RPResESA")->Clone("kFirst_D0RPResEUpgSA"));
+        fD0RPResEUpgSA_PbPb2018_kOnlySecond=(TGraph*) (resfileUpg->Get("kOnlySecond_D0RPResESA")->Clone("kOnlySecond_D0RPResEUpgSA"));
+        printf("%p\n",fD0RPResEUpgSA_PbPb2018_kFirst);
+        printf("%p\n",fD0RPResEUpgSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_D0ZResPSA") && resfileUpg->Get("kOnlyFirst_D0ZResPSA")){
+        fD0ZResPUpgSA_PbPb2018_kFirst=(TGraph*) (resfileUpg->Get("kFirst_D0ZResPSA")->Clone("kFirst_D0ZResPUpgSA"));
+        fD0ZResPUpgSA_PbPb2018_kOnlySecond=(TGraph*) (resfileUpg->Get("kOnlySecond_D0ZResPSA")->Clone("kOnlySecond_D0ZResPUpgSA"));
+        printf("%p\n",fD0ZResPUpgSA_PbPb2018_kFirst);
+        printf("%p\n",fD0ZResPUpgSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_D0ZResKSA") && resfileUpg->Get("kOnlyFirst_D0ZResKSA")){
+        fD0ZResKUpgSA_PbPb2018_kFirst=(TGraph*) (resfileUpg->Get("kFirst_D0ZResKSA")->Clone("kFirst_D0ZResKUpgSA"));
+        fD0ZResKUpgSA_PbPb2018_kOnlySecond=(TGraph*) (resfileUpg->Get("kOnlySecond_D0ZResKSA")->Clone("kOnlySecond_D0ZResKUpgSA"));
+        printf("%p\n",fD0ZResKUpgSA_PbPb2018_kFirst);
+        printf("%p\n",fD0ZResKUpgSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_D0ZResPiSA") && resfileUpg->Get("kOnlyFirst_D0ZResPiSA")){
+        fD0ZResPiUpgSA_PbPb2018_kFirst=(TGraph*) (resfileUpg->Get("kFirst_D0ZResPiSA")->Clone("kFirst_D0ZResPiUpgSA"));
+        fD0ZResPiUpgSA_PbPb2018_kOnlySecond=(TGraph*) (resfileUpg->Get("kOnlySecond_D0ZResPiSA")->Clone("kOnlySecond_D0ZResPiUpgSA"));
+        printf("%p\n",fD0ZResPiUpgSA_PbPb2018_kFirst);
+        printf("%p\n",fD0ZResPiUpgSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_D0ZResESA") && resfileUpg->Get("kOnlyFirst_D0ZResESA")){
+        fD0ZResEUpgSA_PbPb2018_kFirst=(TGraph*) (resfileUpg->Get("kFirst_D0ZResESA")->Clone("kFirst_D0ZResEUpgSA"));
+        fD0ZResEUpgSA_PbPb2018_kOnlySecond=(TGraph*) (resfileUpg->Get("kOnlySecond_D0ZResESA")->Clone("kOnlySecond_D0ZResEUpgSA"));
+        printf("%p\n",fD0ZResEUpgSA_PbPb2018_kFirst);
+        printf("%p\n",fD0ZResEUpgSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_Pt1ResPSA") && resfileUpg->Get("kOnlySecond_Pt1ResPSA")){
+        fPt1ResPUpgSA_PbPb2018_kFirst=(TGraph*) (resfileUpg->Get("kFirst_Pt1ResPSA")->Clone("kFirst_Pt1ResPUpgSA"));
+        fPt1ResPUpgSA_PbPb2018_kOnlySecond=(TGraph*) (resfileUpg->Get("kOnlySecond_Pt1ResPSA")->Clone("kOnlySecond_Pt1ResPUpgSA"));
+        printf("%p\n",fPt1ResPUpgSA_PbPb2018_kFirst);
+        printf("%p\n",fPt1ResPUpgSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_Pt1ResKSA") && resfileUpg->Get("kOnlySecond_Pt1ResKSA")){
+        fPt1ResKUpgSA_PbPb2018_kFirst=(TGraph*) (resfileUpg->Get("kFirst_Pt1ResKSA")->Clone("kFirst_Pt1ResKUpgSA"));
+        fPt1ResKUpgSA_PbPb2018_kOnlySecond=(TGraph*) (resfileUpg->Get("kOnlySecond_Pt1ResKSA")->Clone("kOnlySecond_Pt1ResKUpgSA"));
+        printf("%p\n",fPt1ResKUpgSA_PbPb2018_kFirst);
+        printf("%p\n",fPt1ResKUpgSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_Pt1ResPiSA") && resfileUpg->Get("kOnlySecond_Pt1ResPiSA")){
+        fPt1ResPiUpgSA_PbPb2018_kFirst=(TGraph*) (resfileUpg->Get("kFirst_Pt1ResPiSA")->Clone("kFirst_Pt1ResPiUpgSA"));
+        fPt1ResPiUpgSA_PbPb2018_kOnlySecond=(TGraph*) (resfileUpg->Get("kOnlySecond_Pt1ResPiSA")->Clone("kOnlySecond_Pt1ResPiUpgSA"));
+        printf("%p\n",fPt1ResPiUpgSA_PbPb2018_kFirst);
+        printf("%p\n",fPt1ResPiUpgSA_PbPb2018_kOnlySecond);
+      }
+      if(resfileUpg->Get("kFirst_Pt1ResESA") && resfileUpg->Get("kOnlySecond_Pt1ResESA")){
+        fPt1ResEUpgSA_PbPb2018_kFirst=(TGraph*) (resfileUpg->Get("kFirst_Pt1ResESA")->Clone("kFirst_Pt1ResEUpgSA"));
+        fPt1ResEUpgSA_PbPb2018_kOnlySecond=(TGraph*) (resfileUpg->Get("kOnlySecond_Pt1ResESA")->Clone("kOnlySecond_Pt1ResEUpgSA"));
+        printf("%p\n",fPt1ResEUpgSA_PbPb2018_kFirst);
+        printf("%p\n",fPt1ResEUpgSA_PbPb2018_kOnlySecond);
+      }
+      delete resfileUpg;
     }
-    if(resfileUpg->Get("D0ZResK"  )) {
-      fD0ZResKUpg  =(TGraph*)(resfileUpg->Get("D0ZResK"  )->Clone("D0ZResKUpg"  ));
-    }
-    if(resfileUpg->Get("D0ZResPi" )) {
-      fD0ZResPiUpg =(TGraph*)(resfileUpg->Get("D0ZResPi" )->Clone("D0ZResPiUpg" ));
-    }
-    if(resfileUpg->Get("D0ZResE" )) {
-      fD0ZResEUpg =(TGraph*)(resfileUpg->Get("D0ZResE" )->Clone("D0ZResEUpg" ));
-    }
-    if(resfileUpg->Get("Pt1ResP"  )) {
-      fPt1ResPUpg  =(TGraph*)(resfileUpg->Get("Pt1ResP"  )->Clone("Pt1ResPUpg"  ));
-    }
-    if(resfileUpg->Get("Pt1ResK"  )) {
-      fPt1ResKUpg  =(TGraph*)(resfileUpg->Get("Pt1ResK"  )->Clone("Pt1ResKUpg"  ));
-    }
-    if(resfileUpg->Get("Pt1ResPi" )) {
-      fPt1ResPiUpg =(TGraph*)(resfileUpg->Get("Pt1ResPi" )->Clone("Pt1ResPiUpg" ));
-    }
-    if(resfileUpg->Get("Pt1ResE" )) {
-      fPt1ResEUpg =(TGraph*)(resfileUpg->Get("Pt1ResE" )->Clone("Pt1ResEUpg" ));
-    }
-    if(resfileUpg->Get("D0RPResPSA" )) {
-      fD0RPResPUpgSA =(TGraph*)(resfileUpg->Get("D0RPResPSA" )->Clone("D0RPResPUpgSA" ));
-    }
-    if(resfileUpg->Get("D0RPResKSA" )) {
-      fD0RPResKUpgSA =(TGraph*)(resfileUpg->Get("D0RPResKSA" )->Clone("D0RPResKUpgSA" ));
-    }
-    if(resfileUpg->Get("D0RPResPiSA")) {
-      fD0RPResPiUpgSA=(TGraph*)(resfileUpg->Get("D0RPResPiSA")->Clone("D0RPResPiUpgSA"));
-    }
-    if(resfileUpg->Get("D0RPResESA")) {
-      fD0RPResEUpgSA=(TGraph*)(resfileUpg->Get("D0RPResESA")->Clone("D0RPResEUpgSA"));
-    }
-    if(resfileUpg->Get("D0ZResPSA"  )) {
-      fD0ZResPUpgSA  =(TGraph*)(resfileUpg->Get("D0ZResPSA"  )->Clone("D0ZResPUpgSA"  ));
-    }
-    if(resfileUpg->Get("D0ZResKSA"  )) {
-      fD0ZResKUpgSA  =(TGraph*)(resfileUpg->Get("D0ZResKSA"  )->Clone("D0ZResKUpgSA"  ));
-    }
-    if(resfileUpg->Get("D0ZResPiSA" )) {
-      fD0ZResPiUpgSA =(TGraph*)(resfileUpg->Get("D0ZResPiSA" )->Clone("D0ZResPiUpgSA" ));
-    }
-    if(resfileUpg->Get("D0ZResESA" )) {
-      fD0ZResEUpgSA =(TGraph*)(resfileUpg->Get("D0ZResESA" )->Clone("D0ZResEUpgSA" ));
-    }
-    if(resfileUpg->Get("Pt1ResPSA"  )) {
-      fPt1ResPUpgSA  =(TGraph*)(resfileUpg->Get("Pt1ResPSA"  )->Clone("Pt1ResPUpgSA"  ));
-    }
-    if(resfileUpg->Get("Pt1ResKSA"  )) {
-      fPt1ResKUpgSA  =(TGraph*)(resfileUpg->Get("Pt1ResKSA"  )->Clone("Pt1ResKUpgSA"  ));
-    }
-    if(resfileUpg->Get("Pt1ResPiSA" )) {
-      fPt1ResPiUpgSA =(TGraph*)(resfileUpg->Get("Pt1ResPiSA" )->Clone("Pt1ResPiUpgSA" ));
-    }
-    if(resfileUpg->Get("Pt1ResESA" )) {
-      fPt1ResEUpgSA =(TGraph*)(resfileUpg->Get("Pt1ResESA" )->Clone("Pt1ResEUpgSA" ));
-    }
-    delete resfileUpg;
+  
   }
     
   DefineOutput(1,TList::Class());
@@ -485,6 +1137,139 @@ void AliAnalysisTaskSEImproveITS::UserCreateOutputObjects() {
   if(fPt1ResKUpg) fDebugOutput->Add(fPt1ResKUpg  );
   if(fPt1ResPiUpg) fDebugOutput->Add(fPt1ResPiUpg );
   if(fPt1ResEUpg) fDebugOutput->Add(fPt1ResEUpg );
+
+  // stuff for PbPb 2018 periods
+  // Cur
+  if(fD0RPResPCur_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPResPCur_PbPb2018_kFirst);
+  if(fD0RPResPCur_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPResPCur_PbPb2018_kOnlySecond);
+  if(fD0RPResKCur_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPResKCur_PbPb2018_kFirst);
+  if(fD0RPResKCur_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPResKCur_PbPb2018_kOnlySecond);
+  if(fD0RPResPiCur_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPResPiCur_PbPb2018_kFirst);
+  if(fD0RPResPiCur_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPResPiCur_PbPb2018_kOnlySecond);
+  if(fD0RPResECur_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPResECur_PbPb2018_kFirst);
+  if(fD0RPResECur_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPResECur_PbPb2018_kOnlySecond);
+  if(fD0RPSigmaPullRatioP_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPSigmaPullRatioP_PbPb2018_kFirst);
+  if(fD0RPSigmaPullRatioP_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPSigmaPullRatioP_PbPb2018_kOnlySecond);
+  if(fD0RPSigmaPullRatioK_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPSigmaPullRatioK_PbPb2018_kFirst);
+  if(fD0RPSigmaPullRatioK_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPSigmaPullRatioK_PbPb2018_kOnlySecond);
+  if(fD0RPSigmaPullRatioPi_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPSigmaPullRatioPi_PbPb2018_kFirst);
+  if(fD0RPSigmaPullRatioPi_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPSigmaPullRatioPi_PbPb2018_kOnlySecond);
+  if(fD0RPSigmaPullRatioE_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPSigmaPullRatioE_PbPb2018_kFirst);
+  if(fD0RPSigmaPullRatioE_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPSigmaPullRatioE_PbPb2018_kOnlySecond);
+  for(UInt_t j = 0; j < 2; j++){
+    for(Int_t i=0; i<24; i++){
+      if(fD0RPMeanPCur_PbPb2018_kFirst[j][i])  fDebugOutput->Add(fD0RPMeanPCur_PbPb2018_kFirst[j][i]);
+      if(fD0RPMeanPCur_PbPb2018_kOnlySecond[j][i])  fDebugOutput->Add(fD0RPMeanPCur_PbPb2018_kOnlySecond[j][i]);
+      if(fD0RPMeanKCur_PbPb2018_kFirst[j][i])  fDebugOutput->Add(fD0RPMeanKCur_PbPb2018_kFirst[j][i]);
+      if(fD0RPMeanKCur_PbPb2018_kOnlySecond[j][i])  fDebugOutput->Add(fD0RPMeanKCur_PbPb2018_kOnlySecond[j][i]);
+      if(fD0RPMeanPiCur_PbPb2018_kFirst[j][i])  fDebugOutput->Add(fD0RPMeanPiCur_PbPb2018_kFirst[j][i]);
+      if(fD0RPMeanPiCur_PbPb2018_kOnlySecond[j][i])  fDebugOutput->Add(fD0RPMeanPiCur_PbPb2018_kOnlySecond[j][i]);
+      if(fD0RPMeanECur_PbPb2018_kFirst[j][i])  fDebugOutput->Add(fD0RPMeanECur_PbPb2018_kFirst[j][i]);
+      if(fD0RPMeanECur_PbPb2018_kOnlySecond[j][i])  fDebugOutput->Add(fD0RPMeanECur_PbPb2018_kOnlySecond[j][i]);
+    }
+  }
+  if(fD0ZResPCur_PbPb2018_kFirst)  fDebugOutput->Add(fD0ZResPCur_PbPb2018_kFirst);
+  if(fD0ZResPCur_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0ZResPCur_PbPb2018_kOnlySecond);
+  if(fD0ZResKCur_PbPb2018_kFirst)  fDebugOutput->Add(fD0ZResKCur_PbPb2018_kFirst);
+  if(fD0ZResKCur_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0ZResKCur_PbPb2018_kOnlySecond);
+  if(fD0ZResPiCur_PbPb2018_kFirst)  fDebugOutput->Add(fD0ZResPiCur_PbPb2018_kFirst);
+  if(fD0ZResPiCur_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0ZResPiCur_PbPb2018_kOnlySecond);
+  if(fD0ZResECur_PbPb2018_kFirst)  fDebugOutput->Add(fD0ZResECur_PbPb2018_kFirst);
+  if(fD0ZResECur_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0ZResECur_PbPb2018_kOnlySecond);
+  if(fPt1ResPCur_PbPb2018_kFirst)  fDebugOutput->Add(fPt1ResPCur_PbPb2018_kFirst);
+  if(fPt1ResPCur_PbPb2018_kOnlySecond)  fDebugOutput->Add(fPt1ResPCur_PbPb2018_kOnlySecond);
+  if(fPt1ResKCur_PbPb2018_kFirst)  fDebugOutput->Add(fPt1ResKCur_PbPb2018_kFirst);
+  if(fPt1ResKCur_PbPb2018_kOnlySecond)  fDebugOutput->Add(fPt1ResKCur_PbPb2018_kOnlySecond);
+  if(fPt1ResPiCur_PbPb2018_kFirst)  fDebugOutput->Add(fPt1ResPiCur_PbPb2018_kFirst);
+  if(fPt1ResPiCur_PbPb2018_kOnlySecond)  fDebugOutput->Add(fPt1ResPiCur_PbPb2018_kOnlySecond);
+  if(fPt1ResECur_PbPb2018_kFirst)  fDebugOutput->Add(fPt1ResECur_PbPb2018_kFirst);
+  if(fPt1ResECur_PbPb2018_kOnlySecond)  fDebugOutput->Add(fPt1ResECur_PbPb2018_kOnlySecond);
+  if(fD0RPResPCurSA_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPResPCurSA_PbPb2018_kFirst);
+  if(fD0RPResPCurSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPResPCurSA_PbPb2018_kOnlySecond);
+  if(fD0RPResKCurSA_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPResKCurSA_PbPb2018_kFirst);
+  if(fD0RPResKCurSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPResKCurSA_PbPb2018_kOnlySecond);
+  if(fD0RPResPiCurSA_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPResPiCurSA_PbPb2018_kFirst);
+  if(fD0RPResPiCurSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPResPiCurSA_PbPb2018_kOnlySecond);
+  if(fD0RPResECurSA_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPResECurSA_PbPb2018_kFirst);
+  if(fD0RPResECurSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPResECurSA_PbPb2018_kOnlySecond);
+  if(fD0ZResPCurSA_PbPb2018_kFirst)  fDebugOutput->Add(fD0ZResPCurSA_PbPb2018_kFirst);
+  if(fD0ZResPCurSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0ZResPCurSA_PbPb2018_kOnlySecond);
+  if(fD0ZResKCurSA_PbPb2018_kFirst)  fDebugOutput->Add(fD0ZResKCurSA_PbPb2018_kFirst);
+  if(fD0ZResKCurSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0ZResKCurSA_PbPb2018_kOnlySecond);
+  if(fD0ZResPiCurSA_PbPb2018_kFirst)  fDebugOutput->Add(fD0ZResPiCurSA_PbPb2018_kFirst);
+  if(fD0ZResPiCurSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0ZResPiCurSA_PbPb2018_kOnlySecond);
+  if(fD0ZResECurSA_PbPb2018_kFirst)  fDebugOutput->Add(fD0ZResECurSA_PbPb2018_kFirst);
+  if(fD0ZResECurSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0ZResECurSA_PbPb2018_kOnlySecond);
+  if(fPt1ResPCurSA_PbPb2018_kFirst)  fDebugOutput->Add(fPt1ResPCurSA_PbPb2018_kFirst);
+  if(fPt1ResPCurSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fPt1ResPCurSA_PbPb2018_kOnlySecond);
+  if(fPt1ResKCurSA_PbPb2018_kFirst)  fDebugOutput->Add(fPt1ResKCurSA_PbPb2018_kFirst);
+  if(fPt1ResKCurSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fPt1ResKCurSA_PbPb2018_kOnlySecond);
+  if(fPt1ResPiCurSA_PbPb2018_kFirst)  fDebugOutput->Add(fPt1ResPiCurSA_PbPb2018_kFirst);
+  if(fPt1ResPiCurSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fPt1ResPiCurSA_PbPb2018_kOnlySecond);
+  if(fPt1ResECurSA_PbPb2018_kFirst)  fDebugOutput->Add(fPt1ResECurSA_PbPb2018_kFirst);
+  if(fPt1ResECurSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fPt1ResECurSA_PbPb2018_kOnlySecond);
+  // New
+  if(fD0RPResPUpg_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPResPUpg_PbPb2018_kFirst);
+  if(fD0RPResPUpg_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPResPUpg_PbPb2018_kOnlySecond);
+  if(fD0RPResKUpg_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPResKUpg_PbPb2018_kFirst);
+  if(fD0RPResKUpg_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPResKUpg_PbPb2018_kOnlySecond);
+  if(fD0RPResPiUpg_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPResPiUpg_PbPb2018_kFirst);
+  if(fD0RPResPiUpg_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPResPiUpg_PbPb2018_kOnlySecond);
+  if(fD0RPResEUpg_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPResEUpg_PbPb2018_kFirst);
+  if(fD0RPResEUpg_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPResEUpg_PbPb2018_kOnlySecond);
+  for(UInt_t j = 0; j < 2; j++){
+    for(Int_t i=0; i<24; i++){
+      if(fD0RPMeanPUpg_PbPb2018_kFirst[j][i])  fDebugOutput->Add(fD0RPMeanPUpg_PbPb2018_kFirst[j][i]);
+      if(fD0RPMeanPUpg_PbPb2018_kOnlySecond[j][i])  fDebugOutput->Add(fD0RPMeanPUpg_PbPb2018_kOnlySecond[j][i]);
+      if(fD0RPMeanKUpg_PbPb2018_kFirst[j][i])  fDebugOutput->Add(fD0RPMeanKUpg_PbPb2018_kFirst[j][i]);
+      if(fD0RPMeanKUpg_PbPb2018_kOnlySecond[j][i])  fDebugOutput->Add(fD0RPMeanKUpg_PbPb2018_kOnlySecond[j][i]);
+      if(fD0RPMeanPiUpg_PbPb2018_kFirst[j][i])  fDebugOutput->Add(fD0RPMeanPiUpg_PbPb2018_kFirst[j][i]);
+      if(fD0RPMeanPiUpg_PbPb2018_kOnlySecond[j][i])  fDebugOutput->Add(fD0RPMeanPiUpg_PbPb2018_kOnlySecond[j][i]);
+      if(fD0RPMeanEUpg_PbPb2018_kFirst[j][i])  fDebugOutput->Add(fD0RPMeanEUpg_PbPb2018_kFirst[j][i]);
+      if(fD0RPMeanEUpg_PbPb2018_kOnlySecond[j][i])  fDebugOutput->Add(fD0RPMeanEUpg_PbPb2018_kOnlySecond[j][i]);
+    }
+  }
+  if(fD0ZResPUpg_PbPb2018_kFirst)  fDebugOutput->Add(fD0ZResPUpg_PbPb2018_kFirst);
+  if(fD0ZResPUpg_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0ZResPUpg_PbPb2018_kOnlySecond);
+  if(fD0ZResKUpg_PbPb2018_kFirst)  fDebugOutput->Add(fD0ZResKUpg_PbPb2018_kFirst);
+  if(fD0ZResKUpg_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0ZResKUpg_PbPb2018_kOnlySecond);
+  if(fD0ZResPiUpg_PbPb2018_kFirst)  fDebugOutput->Add(fD0ZResPiUpg_PbPb2018_kFirst);
+  if(fD0ZResPiUpg_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0ZResPiUpg_PbPb2018_kOnlySecond);
+  if(fD0ZResEUpg_PbPb2018_kFirst)  fDebugOutput->Add(fD0ZResEUpg_PbPb2018_kFirst);
+  if(fD0ZResEUpg_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0ZResEUpg_PbPb2018_kOnlySecond);
+  if(fPt1ResPUpg_PbPb2018_kFirst)  fDebugOutput->Add(fPt1ResPUpg_PbPb2018_kFirst);
+  if(fPt1ResPUpg_PbPb2018_kOnlySecond)  fDebugOutput->Add(fPt1ResPUpg_PbPb2018_kOnlySecond);
+  if(fPt1ResKUpg_PbPb2018_kFirst)  fDebugOutput->Add(fPt1ResKUpg_PbPb2018_kFirst);
+  if(fPt1ResKUpg_PbPb2018_kOnlySecond)  fDebugOutput->Add(fPt1ResKUpg_PbPb2018_kOnlySecond);
+  if(fPt1ResPiUpg_PbPb2018_kFirst)  fDebugOutput->Add(fPt1ResPiUpg_PbPb2018_kFirst);
+  if(fPt1ResPiUpg_PbPb2018_kOnlySecond)  fDebugOutput->Add(fPt1ResPiUpg_PbPb2018_kOnlySecond);
+  if(fPt1ResEUpg_PbPb2018_kFirst)  fDebugOutput->Add(fPt1ResEUpg_PbPb2018_kFirst);
+  if(fPt1ResEUpg_PbPb2018_kOnlySecond)  fDebugOutput->Add(fPt1ResEUpg_PbPb2018_kOnlySecond);
+  if(fD0RPResPUpgSA_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPResPUpgSA_PbPb2018_kFirst);
+  if(fD0RPResPUpgSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPResPUpgSA_PbPb2018_kOnlySecond);
+  if(fD0RPResKUpgSA_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPResKUpgSA_PbPb2018_kFirst);
+  if(fD0RPResKUpgSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPResKUpgSA_PbPb2018_kOnlySecond);
+  if(fD0RPResPiUpgSA_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPResPiUpgSA_PbPb2018_kFirst);
+  if(fD0RPResPiUpgSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPResPiUpgSA_PbPb2018_kOnlySecond);
+  if(fD0RPResEUpgSA_PbPb2018_kFirst)  fDebugOutput->Add(fD0RPResEUpgSA_PbPb2018_kFirst);
+  if(fD0RPResEUpgSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0RPResEUpgSA_PbPb2018_kOnlySecond);
+  if(fD0ZResPUpgSA_PbPb2018_kFirst)  fDebugOutput->Add(fD0ZResPUpgSA_PbPb2018_kFirst);
+  if(fD0ZResPUpgSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0ZResPUpgSA_PbPb2018_kOnlySecond);
+  if(fD0ZResKUpgSA_PbPb2018_kFirst)  fDebugOutput->Add(fD0ZResKUpgSA_PbPb2018_kFirst);
+  if(fD0ZResKUpgSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0ZResKUpgSA_PbPb2018_kOnlySecond);
+  if(fD0ZResPiUpgSA_PbPb2018_kFirst)  fDebugOutput->Add(fD0ZResPiUpgSA_PbPb2018_kFirst);
+  if(fD0ZResPiUpgSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0ZResPiUpgSA_PbPb2018_kOnlySecond);
+  if(fD0ZResEUpgSA_PbPb2018_kFirst)  fDebugOutput->Add(fD0ZResEUpgSA_PbPb2018_kFirst);
+  if(fD0ZResEUpgSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fD0ZResEUpgSA_PbPb2018_kOnlySecond);
+  if(fPt1ResPUpgSA_PbPb2018_kFirst)  fDebugOutput->Add(fPt1ResPUpgSA_PbPb2018_kFirst);
+  if(fPt1ResPUpgSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fPt1ResPUpgSA_PbPb2018_kOnlySecond);
+  if(fPt1ResKUpgSA_PbPb2018_kFirst)  fDebugOutput->Add(fPt1ResKUpgSA_PbPb2018_kFirst);
+  if(fPt1ResKUpgSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fPt1ResKUpgSA_PbPb2018_kOnlySecond);
+  if(fPt1ResPiUpgSA_PbPb2018_kFirst)  fDebugOutput->Add(fPt1ResPiUpgSA_PbPb2018_kFirst);
+  if(fPt1ResPiUpgSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fPt1ResPiUpgSA_PbPb2018_kOnlySecond);
+  if(fPt1ResEUpgSA_PbPb2018_kFirst)  fDebugOutput->Add(fPt1ResEUpgSA_PbPb2018_kFirst);
+  if(fPt1ResEUpgSA_PbPb2018_kOnlySecond)  fDebugOutput->Add(fPt1ResEUpgSA_PbPb2018_kOnlySecond);
+
 
   PostData(1,fDebugOutput);
 }
@@ -557,10 +1342,9 @@ void AliAnalysisTaskSEImproveITS::UserExec(Option_t*) {
 	SmearTrack(trk,bz);
       }
     }
-    
+
     // TODO: recalculated primary vertex
     AliVVertex *primaryVertex=ev->GetPrimaryVertex();
-    
     
     // Recalculate all candidates
     // D0->Kpi
@@ -571,8 +1355,7 @@ void AliAnalysisTaskSEImproveITS::UserExec(Option_t*) {
 	
 	// recalculate vertices
 	AliVVertex *oldSecondaryVertex=decay->GetSecondaryVtx();
-	
-	
+		
 	AliExternalTrackParam et1; et1.CopyFromVTrack(static_cast<AliAODTrack*>(decay->GetDaughter(0)));
 	AliExternalTrackParam et2; et2.CopyFromVTrack(static_cast<AliAODTrack*>(decay->GetDaughter(1)));
 	
@@ -776,15 +1559,27 @@ void AliAnalysisTaskSEImproveITS::UserExec(Option_t*) {
 }
 
 void AliAnalysisTaskSEImproveITS::SmearTrack(AliVTrack *track,Double_t bz) {
-  // Early exit, if this track has nothing in common with the ITS
 
-  if (!(track->HasPointOnITSLayer(0) || track->HasPointOnITSLayer(1)))
-    return;
+  // flags for PbPb 2018 
+  Bool_t is_kFirst_Trk      = kFALSE;
+  Bool_t is_kOnlySecond_Trk = kFALSE;
+
+  // Early exit, if this track has nothing in common with the ITS
+  if(!fIsPbPb2018){
+    if (!(track->HasPointOnITSLayer(0) || track->HasPointOnITSLayer(1)))  return;
+  }
+  else{ // PbPb 2018 analysed
+    // kFirst tracks
+    if(track->HasPointOnITSLayer(0))  is_kFirst_Trk = kTRUE;
+    // kOnlySecond tracks  
+    else if( !(track->HasPointOnITSLayer(0)) && track->HasPointOnITSLayer(1) )  is_kOnlySecond_Trk = kTRUE; 
+    if( !is_kFirst_Trk && !is_kOnlySecond_Trk ) return;
+  }
+  
 
   // Check if the track was already "improved" (this is done with a trick using layer 7 (ie the 8th))
   if (TESTBIT(track->GetITSClusterMap(),7)) return;
   //
-
 
   // Get reconstructed track parameters
   AliExternalTrackParam et; et.CopyFromVTrack(track);
@@ -849,54 +1644,161 @@ void AliAnalysisTaskSEImproveITS::SmearTrack(AliVTrack *track,Double_t bz) {
     pdgcode = emcpart->PdgCode();
   }
     
-  switch (pdgcode) {
-  case 2212: case -2212:
-    sd0rpo=EvalGraph(ptmc,fD0RPResPCur,fD0RPResPCurSA);
-    sd0zo =EvalGraph(ptmc,fD0ZResPCur,fD0ZResPCurSA);
-    spt1o =EvalGraph(ptmc,fPt1ResPCur,fPt1ResPCurSA);
-    sd0rpn=EvalGraph(ptmc,fD0RPResPUpg,fD0RPResPUpgSA);
-    sd0zn =EvalGraph(ptmc,fD0ZResPUpg,fD0ZResPUpgSA);
-    spt1n =EvalGraph(ptmc,fPt1ResPUpg,fPt1ResPUpgSA);
-    sd0mrpo=EvalGraph(ptmc,fD0RPMeanPCur[magfield][phiBin],fD0RPMeanPCur[magfield][phiBin]);
-    sd0mrpn=EvalGraph(ptmc,fD0RPMeanPUpg[magfield][phiBin],fD0RPMeanPUpg[magfield][phiBin]);
-    if(fD0RPSigmaPullRatioP) pullcorr=EvalGraph(ptmc,fD0RPSigmaPullRatioP,fD0RPSigmaPullRatioP);
-    break;
-  case 321: case -321:
-    sd0rpo=EvalGraph(ptmc,fD0RPResKCur,fD0RPResKCurSA);
-    sd0zo =EvalGraph(ptmc,fD0ZResKCur,fD0ZResKCurSA);
-    spt1o =EvalGraph(ptmc,fPt1ResKCur,fPt1ResKCurSA);
-    sd0rpn=EvalGraph(ptmc,fD0RPResKUpg,fD0RPResKUpgSA);
-    sd0zn =EvalGraph(ptmc,fD0ZResKUpg,fD0ZResKUpgSA);
-    spt1n =EvalGraph(ptmc,fPt1ResKUpg,fPt1ResKUpgSA);
-    sd0mrpo=EvalGraph(ptmc,fD0RPMeanKCur[magfield][phiBin],fD0RPMeanKCur[magfield][phiBin]);
-    sd0mrpn=EvalGraph(ptmc,fD0RPMeanKUpg[magfield][phiBin],fD0RPMeanKUpg[magfield][phiBin]);
-    if(fD0RPSigmaPullRatioK) pullcorr=EvalGraph(ptmc,fD0RPSigmaPullRatioK,fD0RPSigmaPullRatioK);
-    break;
-  case 211: case -211:
-    sd0rpo=EvalGraph(ptmc,fD0RPResPiCur,fD0RPResPiCurSA);
-    sd0zo =EvalGraph(ptmc,fD0ZResPiCur,fD0ZResPiCurSA);
-    spt1o =EvalGraph(ptmc,fPt1ResPiCur,fPt1ResPiCurSA);
-    sd0rpn=EvalGraph(ptmc,fD0RPResPiUpg,fD0RPResPiUpgSA);
-    sd0zn =EvalGraph(ptmc,fD0ZResPiUpg,fD0ZResPiUpgSA);
-    spt1n =EvalGraph(ptmc,fPt1ResPiUpg,fPt1ResPiUpgSA);
-    sd0mrpo=EvalGraph(ptmc,fD0RPMeanPiCur[magfield][phiBin],fD0RPMeanPiCur[magfield][phiBin]);
-    sd0mrpn=EvalGraph(ptmc,fD0RPMeanPiUpg[magfield][phiBin],fD0RPMeanPiUpg[magfield][phiBin]);
-    if(fD0RPSigmaPullRatioPi) pullcorr=EvalGraph(ptmc,fD0RPSigmaPullRatioPi,fD0RPSigmaPullRatioPi);
-    break;
-  case 11: case -11:
-    sd0rpo=EvalGraph(ptmc,fD0RPResECur,fD0RPResECurSA);
-    sd0zo =EvalGraph(ptmc,fD0ZResECur,fD0ZResECurSA);
-    spt1o =EvalGraph(ptmc,fPt1ResECur,fPt1ResECurSA);
-    sd0rpn=EvalGraph(ptmc,fD0RPResEUpg,fD0RPResEUpgSA);
-    sd0zn =EvalGraph(ptmc,fD0ZResEUpg,fD0ZResEUpgSA);
-    spt1n =EvalGraph(ptmc,fPt1ResEUpg,fPt1ResEUpgSA);
-    sd0mrpo=EvalGraph(ptmc,fD0RPMeanECur[magfield][phiBin],fD0RPMeanECur[magfield][phiBin]);
-    sd0mrpn=EvalGraph(ptmc,fD0RPMeanEUpg[magfield][phiBin],fD0RPMeanEUpg[magfield][phiBin]);
-    if(fD0RPSigmaPullRatioE) pullcorr=EvalGraph(ptmc,fD0RPSigmaPullRatioE,fD0RPSigmaPullRatioE);
-    break;
-  default:
-    return;
+  if(!fIsPbPb2018){  
+    switch (pdgcode) {
+    case 2212: case -2212:
+      sd0rpo=EvalGraph(ptmc,fD0RPResPCur,fD0RPResPCurSA);
+      sd0zo =EvalGraph(ptmc,fD0ZResPCur,fD0ZResPCurSA);
+      spt1o =EvalGraph(ptmc,fPt1ResPCur,fPt1ResPCurSA);
+      sd0rpn=EvalGraph(ptmc,fD0RPResPUpg,fD0RPResPUpgSA);
+      sd0zn =EvalGraph(ptmc,fD0ZResPUpg,fD0ZResPUpgSA);
+      spt1n =EvalGraph(ptmc,fPt1ResPUpg,fPt1ResPUpgSA);
+      sd0mrpo=EvalGraph(ptmc,fD0RPMeanPCur[magfield][phiBin],fD0RPMeanPCur[magfield][phiBin]);
+      sd0mrpn=EvalGraph(ptmc,fD0RPMeanPUpg[magfield][phiBin],fD0RPMeanPUpg[magfield][phiBin]);
+      if(fD0RPSigmaPullRatioP) pullcorr=EvalGraph(ptmc,fD0RPSigmaPullRatioP,fD0RPSigmaPullRatioP);
+      break;
+    case 321: case -321:
+      sd0rpo=EvalGraph(ptmc,fD0RPResKCur,fD0RPResKCurSA);
+      sd0zo =EvalGraph(ptmc,fD0ZResKCur,fD0ZResKCurSA);
+      spt1o =EvalGraph(ptmc,fPt1ResKCur,fPt1ResKCurSA);
+      sd0rpn=EvalGraph(ptmc,fD0RPResKUpg,fD0RPResKUpgSA);
+      sd0zn =EvalGraph(ptmc,fD0ZResKUpg,fD0ZResKUpgSA);
+      spt1n =EvalGraph(ptmc,fPt1ResKUpg,fPt1ResKUpgSA);
+      sd0mrpo=EvalGraph(ptmc,fD0RPMeanKCur[magfield][phiBin],fD0RPMeanKCur[magfield][phiBin]);
+      sd0mrpn=EvalGraph(ptmc,fD0RPMeanKUpg[magfield][phiBin],fD0RPMeanKUpg[magfield][phiBin]);
+      if(fD0RPSigmaPullRatioK) pullcorr=EvalGraph(ptmc,fD0RPSigmaPullRatioK,fD0RPSigmaPullRatioK);
+      break;
+    case 211: case -211:
+      sd0rpo=EvalGraph(ptmc,fD0RPResPiCur,fD0RPResPiCurSA);
+      sd0zo =EvalGraph(ptmc,fD0ZResPiCur,fD0ZResPiCurSA);
+      spt1o =EvalGraph(ptmc,fPt1ResPiCur,fPt1ResPiCurSA);
+      sd0rpn=EvalGraph(ptmc,fD0RPResPiUpg,fD0RPResPiUpgSA);
+      sd0zn =EvalGraph(ptmc,fD0ZResPiUpg,fD0ZResPiUpgSA);
+      spt1n =EvalGraph(ptmc,fPt1ResPiUpg,fPt1ResPiUpgSA);
+      sd0mrpo=EvalGraph(ptmc,fD0RPMeanPiCur[magfield][phiBin],fD0RPMeanPiCur[magfield][phiBin]);
+      sd0mrpn=EvalGraph(ptmc,fD0RPMeanPiUpg[magfield][phiBin],fD0RPMeanPiUpg[magfield][phiBin]);
+      if(fD0RPSigmaPullRatioPi) pullcorr=EvalGraph(ptmc,fD0RPSigmaPullRatioPi,fD0RPSigmaPullRatioPi);
+      break;
+    case 11: case -11:
+      sd0rpo=EvalGraph(ptmc,fD0RPResECur,fD0RPResECurSA);
+      sd0zo =EvalGraph(ptmc,fD0ZResECur,fD0ZResECurSA);
+      spt1o =EvalGraph(ptmc,fPt1ResECur,fPt1ResECurSA);
+      sd0rpn=EvalGraph(ptmc,fD0RPResEUpg,fD0RPResEUpgSA);
+      sd0zn =EvalGraph(ptmc,fD0ZResEUpg,fD0ZResEUpgSA);
+      spt1n =EvalGraph(ptmc,fPt1ResEUpg,fPt1ResEUpgSA);
+      sd0mrpo=EvalGraph(ptmc,fD0RPMeanECur[magfield][phiBin],fD0RPMeanECur[magfield][phiBin]);
+      sd0mrpn=EvalGraph(ptmc,fD0RPMeanEUpg[magfield][phiBin],fD0RPMeanEUpg[magfield][phiBin]);
+      if(fD0RPSigmaPullRatioE) pullcorr=EvalGraph(ptmc,fD0RPSigmaPullRatioE,fD0RPSigmaPullRatioE);
+      break;
+    default:
+      return;
+    }
   }
+  else{ // PbPb 2018 periods templates
+    // kFirst tracks
+    if(is_kFirst_Trk){
+      switch (pdgcode) {
+      case 2212: case -2212:
+        sd0rpo=EvalGraph(ptmc,fD0RPResPCur_PbPb2018_kFirst,fD0RPResPCurSA_PbPb2018_kFirst);
+        sd0zo =EvalGraph(ptmc,fD0ZResPCur_PbPb2018_kFirst,fD0ZResPCurSA_PbPb2018_kFirst);
+        spt1o =EvalGraph(ptmc,fPt1ResPCur_PbPb2018_kFirst,fPt1ResPCurSA_PbPb2018_kFirst);
+        sd0rpn=EvalGraph(ptmc,fD0RPResPUpg_PbPb2018_kFirst,fD0RPResPUpgSA_PbPb2018_kFirst);
+        sd0zn =EvalGraph(ptmc,fD0ZResPUpg_PbPb2018_kFirst,fD0ZResPUpgSA_PbPb2018_kFirst);
+        spt1n =EvalGraph(ptmc,fPt1ResPUpg_PbPb2018_kFirst,fPt1ResPUpgSA_PbPb2018_kFirst);
+        sd0mrpo=EvalGraph(ptmc,fD0RPMeanKCur_PbPb2018_kFirst[magfield][phiBin],fD0RPMeanKCur_PbPb2018_kFirst[magfield][phiBin]);
+        sd0mrpn=EvalGraph(ptmc,fD0RPMeanKUpg_PbPb2018_kFirst[magfield][phiBin],fD0RPMeanKUpg_PbPb2018_kFirst[magfield][phiBin]);
+        if(fD0RPSigmaPullRatioP_PbPb2018_kFirst) pullcorr=EvalGraph(ptmc,fD0RPSigmaPullRatioP_PbPb2018_kFirst,fD0RPSigmaPullRatioP_PbPb2018_kFirst);
+        break;
+      case 321: case -321:
+        sd0rpo=EvalGraph(ptmc,fD0RPResKCur_PbPb2018_kFirst,fD0RPResKCurSA_PbPb2018_kFirst);
+        sd0zo =EvalGraph(ptmc,fD0ZResKCur_PbPb2018_kFirst,fD0ZResKCurSA_PbPb2018_kFirst);
+        spt1o =EvalGraph(ptmc,fPt1ResKCur_PbPb2018_kFirst,fPt1ResKCurSA_PbPb2018_kFirst);
+        sd0rpn=EvalGraph(ptmc,fD0RPResKUpg_PbPb2018_kFirst,fD0RPResKUpgSA_PbPb2018_kFirst);
+        sd0zn =EvalGraph(ptmc,fD0ZResKUpg_PbPb2018_kFirst,fD0ZResKUpgSA_PbPb2018_kFirst);
+        spt1n =EvalGraph(ptmc,fPt1ResKUpg_PbPb2018_kFirst,fPt1ResKUpgSA_PbPb2018_kFirst);
+        sd0mrpo=EvalGraph(ptmc,fD0RPMeanKCur_PbPb2018_kFirst[magfield][phiBin],fD0RPMeanKCur_PbPb2018_kFirst[magfield][phiBin]);
+        sd0mrpn=EvalGraph(ptmc,fD0RPMeanKUpg_PbPb2018_kFirst[magfield][phiBin],fD0RPMeanKUpg_PbPb2018_kFirst[magfield][phiBin]);
+        if(fD0RPSigmaPullRatioK_PbPb2018_kFirst) pullcorr=EvalGraph(ptmc,fD0RPSigmaPullRatioK_PbPb2018_kFirst,fD0RPSigmaPullRatioK_PbPb2018_kFirst);
+        break;
+      case 211: case -211:
+        sd0rpo=EvalGraph(ptmc,fD0RPResPiCur_PbPb2018_kFirst,fD0RPResPiCurSA_PbPb2018_kFirst);
+        sd0zo =EvalGraph(ptmc,fD0ZResPiCur_PbPb2018_kFirst,fD0ZResPiCurSA_PbPb2018_kFirst);
+        spt1o =EvalGraph(ptmc,fPt1ResPiCur_PbPb2018_kFirst,fPt1ResPiCurSA_PbPb2018_kFirst);
+        sd0rpn=EvalGraph(ptmc,fD0RPResPiUpg_PbPb2018_kFirst,fD0RPResPiUpgSA_PbPb2018_kFirst);
+        sd0zn =EvalGraph(ptmc,fD0ZResPiUpg_PbPb2018_kFirst,fD0ZResPiUpgSA_PbPb2018_kFirst);
+        spt1n =EvalGraph(ptmc,fPt1ResPiUpg_PbPb2018_kFirst,fPt1ResPiUpgSA_PbPb2018_kFirst); 
+        sd0mrpo=EvalGraph(ptmc,fD0RPMeanPiCur_PbPb2018_kFirst[magfield][phiBin],fD0RPMeanPiCur_PbPb2018_kFirst[magfield][phiBin]);
+        sd0mrpn=EvalGraph(ptmc,fD0RPMeanPiUpg_PbPb2018_kFirst[magfield][phiBin],fD0RPMeanPiUpg_PbPb2018_kFirst[magfield][phiBin]);
+        if(fD0RPSigmaPullRatioPi_PbPb2018_kFirst) pullcorr=EvalGraph(ptmc,fD0RPSigmaPullRatioPi_PbPb2018_kFirst,fD0RPSigmaPullRatioPi_PbPb2018_kFirst);
+        break;
+      case 11: case -11:
+        sd0rpo=EvalGraph(ptmc,fD0RPResECur_PbPb2018_kFirst,fD0RPResECurSA_PbPb2018_kFirst);
+        sd0zo =EvalGraph(ptmc,fD0ZResECur_PbPb2018_kFirst,fD0ZResECurSA_PbPb2018_kFirst);
+        spt1o =EvalGraph(ptmc,fPt1ResECur_PbPb2018_kFirst,fPt1ResECurSA_PbPb2018_kFirst);
+        sd0rpn=EvalGraph(ptmc,fD0RPResEUpg_PbPb2018_kFirst,fD0RPResEUpgSA_PbPb2018_kFirst);
+        sd0zn =EvalGraph(ptmc,fD0ZResEUpg_PbPb2018_kFirst,fD0ZResEUpgSA_PbPb2018_kFirst);
+        spt1n =EvalGraph(ptmc,fPt1ResEUpg_PbPb2018_kFirst,fPt1ResEUpgSA_PbPb2018_kFirst);
+        sd0mrpo=EvalGraph(ptmc,fD0RPMeanECur_PbPb2018_kFirst[magfield][phiBin],fD0RPMeanECur_PbPb2018_kFirst[magfield][phiBin]);
+        sd0mrpn=EvalGraph(ptmc,fD0RPMeanEUpg_PbPb2018_kFirst[magfield][phiBin],fD0RPMeanEUpg_PbPb2018_kFirst[magfield][phiBin]);
+        if(fD0RPSigmaPullRatioE_PbPb2018_kFirst) pullcorr=EvalGraph(ptmc,fD0RPSigmaPullRatioE_PbPb2018_kFirst,fD0RPSigmaPullRatioE_PbPb2018_kFirst);
+        break;
+      default:
+        return;
+      }
+    }
+    // kOnlySecond tracks
+    else if(is_kOnlySecond_Trk){
+      switch (pdgcode) {
+      case 2212: case -2212:
+        sd0rpo=EvalGraph(ptmc,fD0RPResPCur_PbPb2018_kOnlySecond,fD0RPResPCurSA_PbPb2018_kOnlySecond);
+        sd0zo =EvalGraph(ptmc,fD0ZResPCur_PbPb2018_kOnlySecond,fD0ZResPCurSA_PbPb2018_kOnlySecond);
+        spt1o =EvalGraph(ptmc,fPt1ResPCur_PbPb2018_kOnlySecond,fPt1ResPCurSA_PbPb2018_kOnlySecond);
+        sd0rpn=EvalGraph(ptmc,fD0RPResPUpg_PbPb2018_kOnlySecond,fD0RPResPUpgSA_PbPb2018_kOnlySecond);
+        sd0zn =EvalGraph(ptmc,fD0ZResPUpg_PbPb2018_kOnlySecond,fD0ZResPUpgSA_PbPb2018_kOnlySecond);
+        spt1n =EvalGraph(ptmc,fPt1ResPUpg_PbPb2018_kOnlySecond,fPt1ResPUpgSA_PbPb2018_kOnlySecond);
+        sd0mrpo=EvalGraph(ptmc,fD0RPMeanKCur_PbPb2018_kOnlySecond[magfield][phiBin],fD0RPMeanKCur_PbPb2018_kOnlySecond[magfield][phiBin]);
+        sd0mrpn=EvalGraph(ptmc,fD0RPMeanKUpg_PbPb2018_kOnlySecond[magfield][phiBin],fD0RPMeanKUpg_PbPb2018_kOnlySecond[magfield][phiBin]);
+        if(fD0RPSigmaPullRatioP_PbPb2018_kOnlySecond) pullcorr=EvalGraph(ptmc,fD0RPSigmaPullRatioP_PbPb2018_kOnlySecond,fD0RPSigmaPullRatioP_PbPb2018_kOnlySecond);
+        break;
+      case 321: case -321:
+        sd0rpo=EvalGraph(ptmc,fD0RPResKCur_PbPb2018_kOnlySecond,fD0RPResKCurSA_PbPb2018_kOnlySecond);
+        sd0zo =EvalGraph(ptmc,fD0ZResKCur_PbPb2018_kOnlySecond,fD0ZResKCurSA_PbPb2018_kOnlySecond);
+        spt1o =EvalGraph(ptmc,fPt1ResKCur_PbPb2018_kOnlySecond,fPt1ResKCurSA_PbPb2018_kOnlySecond);
+        sd0rpn=EvalGraph(ptmc,fD0RPResKUpg_PbPb2018_kOnlySecond,fD0RPResKUpgSA_PbPb2018_kOnlySecond);
+        sd0zn =EvalGraph(ptmc,fD0ZResKUpg_PbPb2018_kOnlySecond,fD0ZResKUpgSA_PbPb2018_kOnlySecond);
+        spt1n =EvalGraph(ptmc,fPt1ResKUpg_PbPb2018_kOnlySecond,fPt1ResKUpgSA_PbPb2018_kOnlySecond);
+        sd0mrpo=EvalGraph(ptmc,fD0RPMeanKCur_PbPb2018_kOnlySecond[magfield][phiBin],fD0RPMeanKCur_PbPb2018_kOnlySecond[magfield][phiBin]);
+        sd0mrpn=EvalGraph(ptmc,fD0RPMeanKUpg_PbPb2018_kOnlySecond[magfield][phiBin],fD0RPMeanKUpg_PbPb2018_kOnlySecond[magfield][phiBin]);
+        if(fD0RPSigmaPullRatioK_PbPb2018_kOnlySecond) pullcorr=EvalGraph(ptmc,fD0RPSigmaPullRatioK_PbPb2018_kOnlySecond,fD0RPSigmaPullRatioK_PbPb2018_kOnlySecond);
+        break;
+      case 211: case -211:
+        sd0rpo=EvalGraph(ptmc,fD0RPResPiCur_PbPb2018_kOnlySecond,fD0RPResPiCurSA_PbPb2018_kOnlySecond);
+        sd0zo =EvalGraph(ptmc,fD0ZResPiCur_PbPb2018_kOnlySecond,fD0ZResPiCurSA_PbPb2018_kOnlySecond);
+        spt1o =EvalGraph(ptmc,fPt1ResPiCur_PbPb2018_kOnlySecond,fPt1ResPiCurSA_PbPb2018_kOnlySecond);
+        sd0rpn=EvalGraph(ptmc,fD0RPResPiUpg_PbPb2018_kOnlySecond,fD0RPResPiUpgSA_PbPb2018_kOnlySecond);
+        sd0zn =EvalGraph(ptmc,fD0ZResPiUpg_PbPb2018_kOnlySecond,fD0ZResPiUpgSA_PbPb2018_kOnlySecond);
+        spt1n =EvalGraph(ptmc,fPt1ResPiUpg_PbPb2018_kOnlySecond,fPt1ResPiUpgSA_PbPb2018_kOnlySecond); 
+        sd0mrpo=EvalGraph(ptmc,fD0RPMeanPiCur_PbPb2018_kOnlySecond[magfield][phiBin],fD0RPMeanPiCur_PbPb2018_kOnlySecond[magfield][phiBin]);
+        sd0mrpn=EvalGraph(ptmc,fD0RPMeanPiUpg_PbPb2018_kOnlySecond[magfield][phiBin],fD0RPMeanPiUpg_PbPb2018_kOnlySecond[magfield][phiBin]);
+        if(fD0RPSigmaPullRatioPi_PbPb2018_kOnlySecond) pullcorr=EvalGraph(ptmc,fD0RPSigmaPullRatioPi_PbPb2018_kOnlySecond,fD0RPSigmaPullRatioPi_PbPb2018_kOnlySecond);
+        break;
+      case 11: case -11:
+        sd0rpo=EvalGraph(ptmc,fD0RPResECur_PbPb2018_kOnlySecond,fD0RPResECurSA_PbPb2018_kOnlySecond);
+        sd0zo =EvalGraph(ptmc,fD0ZResECur_PbPb2018_kOnlySecond,fD0ZResECurSA_PbPb2018_kOnlySecond);
+        spt1o =EvalGraph(ptmc,fPt1ResECur_PbPb2018_kOnlySecond,fPt1ResECurSA_PbPb2018_kOnlySecond);
+        sd0rpn=EvalGraph(ptmc,fD0RPResEUpg_PbPb2018_kOnlySecond,fD0RPResEUpgSA_PbPb2018_kOnlySecond);
+        sd0zn =EvalGraph(ptmc,fD0ZResEUpg_PbPb2018_kOnlySecond,fD0ZResEUpgSA_PbPb2018_kOnlySecond);
+        spt1n =EvalGraph(ptmc,fPt1ResEUpg_PbPb2018_kOnlySecond,fPt1ResEUpgSA_PbPb2018_kOnlySecond);
+        sd0mrpo=EvalGraph(ptmc,fD0RPMeanECur_PbPb2018_kOnlySecond[magfield][phiBin],fD0RPMeanECur_PbPb2018_kOnlySecond[magfield][phiBin]);
+        sd0mrpn=EvalGraph(ptmc,fD0RPMeanEUpg_PbPb2018_kOnlySecond[magfield][phiBin],fD0RPMeanEUpg_PbPb2018_kOnlySecond[magfield][phiBin]);
+        if(fD0RPSigmaPullRatioE_PbPb2018_kOnlySecond) pullcorr=EvalGraph(ptmc,fD0RPSigmaPullRatioE_PbPb2018_kOnlySecond,fD0RPSigmaPullRatioE_PbPb2018_kOnlySecond);
+        break;
+      default:
+        return;
+      }
+    }
+  }
+  
 
   // Use the same units (i.e. cm and GeV/c)! TODO: pt!
   sd0rpo*=1.e-4;
@@ -974,6 +1876,14 @@ void AliAnalysisTaskSEImproveITS::SmearTrack(AliVTrack *track,Double_t bz) {
   et.GetPxPyPz(p);
   Double_t cv[21];
   et.GetCovarianceXYZPxPyPz(cv);
+
+  //if(fIsPbPb2018){
+  //  printf("--- is_kFirst_Trk: %d\n", is_kFirst_Trk);
+  //  printf("--- is_kOnlySecond_Trk: %d\n", is_kOnlySecond_Trk);
+  //  for(UInt_t ibin=0; ibin<21; ibin++) printf("%f\n",cv[ibin]);
+  //  printf("\n");
+  //}
+
   if(fIsAOD) {
     AliAODTrack *aodtrack = static_cast<AliAODTrack *>(track);
     aodtrack->SetPosition(x,kFALSE);
@@ -1046,7 +1956,10 @@ Double_t AliAnalysisTaskSEImproveITS::EvalGraph(Double_t x,const TGraph *graph,c
   // The function assumes an ascending order of X.
   //
 
-  if(!graph) return 0.;
+  if(!graph){
+    printf("\tEvalGraph fails !\n");
+    return 0.;
+  } 
 
   // TODO: find a pretty solution for this:
   Int_t    n   =graph->GetN();
@@ -1067,10 +1980,20 @@ Double_t AliAnalysisTaskSEImproveITS::EvalGraph(Double_t x,const TGraph *graph,c
 Int_t AliAnalysisTaskSEImproveITS::PhiBin(Double_t phi) const { 
   Double_t pi=TMath::Pi();
   if(phi>2.*pi || phi<0.) return -1;
-  if((phi<=(pi/4.)) || (phi>7.*(pi/4.))) return 0;
-  if((phi>(pi/4.)) && (phi<=3.*(pi/4.))) return 1;
-  if((phi>3.*(pi/4.)) && (phi<=5.*(pi/4.))) return 2;
-  if((phi>(5.*pi/4.)) && (phi<=7.*(pi/4.))) return 3;
+
+  if(!fIsPbPb2018){
+    if((phi<=(pi/4.)) || (phi>7.*(pi/4.))) return 0;
+    if((phi>(pi/4.)) && (phi<=3.*(pi/4.))) return 1;
+    if((phi>3.*(pi/4.)) && (phi<=5.*(pi/4.))) return 2;
+    if((phi>(5.*pi/4.)) && (phi<=7.*(pi/4.))) return 3;
+  }
+  else{ // correction performed in 24 φ bins for PbPb 2018 periods
+    Double_t width = 2.*pi/24;
+    for(UInt_t i = 0; i < 24; i++){
+      if(phi>i*width && phi<=(i+1)*width)    return i;
+    }
+  }
+  
   return -1;
 }
 

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEImproveITS.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEImproveITS.h
@@ -17,6 +17,8 @@ class TObjArray;
 class AliESDVertex;
 class AliVVertex;
 
+class TNtuple;
+
 class AliAnalysisTaskSEImproveITS:public AliAnalysisTaskSE {
 public:
   AliAnalysisTaskSEImproveITS();
@@ -112,6 +114,142 @@ private:
   TGraph *fPt1ResPiUpgSA ; /// new standalone pt dep. 1/pt res. for pions
   TGraph *fPt1ResEUpgSA ; /// new standalone pt dep. 1/pt res. for electrons
 
+  /////////////////////////////////////////////////////////////////////////////
+  //                                                                         //
+  //  Specific stuff for PbPb 2018 periods                                   //
+  //                                                                         //
+  //  The correction is supposed to be different for tracks                  //
+  //  satisfying the following SPD requirements:                             //
+  //    1) kFirst                                                            //
+  //    2) kOnlySecond                                                       //
+  //  The correction for the mean is then performed in 24 bins of φ,         //
+  //  instead of quarters.                                                   //
+  //                                                                         //
+  /////////////////////////////////////////////////////////////////////////////
+  Bool_t fIsPbPb2018;  // flag declaring wheter the PbPb 2018 periods are analysed
+  // kFirst
+  TGraph *fD0ZResPCur_PbPb2018_kFirst; /// 
+  TGraph *fD0ZResKCur_PbPb2018_kFirst; /// 
+  TGraph *fD0ZResPiCur_PbPb2018_kFirst; /// 
+  TGraph *fD0ZResECur_PbPb2018_kFirst; /// 
+  TGraph *fD0RPResPCur_PbPb2018_kFirst; /// 
+  TGraph *fD0RPResKCur_PbPb2018_kFirst; /// 
+  TGraph *fD0RPResPiCur_PbPb2018_kFirst; /// 
+  TGraph *fD0RPResECur_PbPb2018_kFirst; ///
+  TGraph *fD0RPSigmaPullRatioP_PbPb2018_kFirst; /// 
+  TGraph *fD0RPSigmaPullRatioK_PbPb2018_kFirst; /// 
+  TGraph *fD0RPSigmaPullRatioPi_PbPb2018_kFirst; /// 
+  TGraph *fD0RPSigmaPullRatioE_PbPb2018_kFirst; ///
+  TGraph *fD0RPMeanPCur_PbPb2018_kFirst[2][24]; ///
+  TGraph *fD0RPMeanKCur_PbPb2018_kFirst[2][24]; ///
+  TGraph *fD0RPMeanPiCur_PbPb2018_kFirst[2][24]; ///
+  TGraph *fD0RPMeanECur_PbPb2018_kFirst[2][24]; ///
+  TGraph *fPt1ResPCur_PbPb2018_kFirst; /// 
+  TGraph *fPt1ResKCur_PbPb2018_kFirst; /// 
+  TGraph *fPt1ResPiCur_PbPb2018_kFirst; /// 
+  TGraph *fPt1ResECur_PbPb2018_kFirst; /// 
+  TGraph *fD0ZResPUpg_PbPb2018_kFirst; /// 
+  TGraph *fD0ZResKUpg_PbPb2018_kFirst; /// 
+  TGraph *fD0ZResPiUpg_PbPb2018_kFirst; /// 
+  TGraph *fD0ZResEUpg_PbPb2018_kFirst; /// 
+  TGraph *fD0RPResPUpg_PbPb2018_kFirst; /// 
+  TGraph *fD0RPResKUpg_PbPb2018_kFirst; /// 
+  TGraph *fD0RPResPiUpg_PbPb2018_kFirst; /// 
+  TGraph *fD0RPResEUpg_PbPb2018_kFirst; /// 
+  TGraph *fD0RPMeanPUpg_PbPb2018_kFirst[2][24]; ///
+  TGraph *fD0RPMeanKUpg_PbPb2018_kFirst[2][24]; ///
+  TGraph *fD0RPMeanPiUpg_PbPb2018_kFirst[2][24]; ///
+  TGraph *fD0RPMeanEUpg_PbPb2018_kFirst[2][24]; ///
+  TGraph *fPt1ResPUpg_PbPb2018_kFirst; /// 
+  TGraph *fPt1ResKUpg_PbPb2018_kFirst; /// 
+  TGraph *fPt1ResPiUpg_PbPb2018_kFirst; ///
+  TGraph *fPt1ResEUpg_PbPb2018_kFirst; /// 
+  TGraph *fD0ZResPCurSA_PbPb2018_kFirst; /// 
+  TGraph *fD0ZResKCurSA_PbPb2018_kFirst; ///
+  TGraph *fD0ZResPiCurSA_PbPb2018_kFirst; /// 
+  TGraph *fD0ZResECurSA_PbPb2018_kFirst; /// 
+  TGraph *fD0RPResPCurSA_PbPb2018_kFirst; /// 
+  TGraph *fD0RPResKCurSA_PbPb2018_kFirst; /// 
+  TGraph *fD0RPResPiCurSA_PbPb2018_kFirst; /// 
+  TGraph *fD0RPResECurSA_PbPb2018_kFirst; /// 
+  TGraph *fPt1ResPCurSA_PbPb2018_kFirst; /// 
+  TGraph *fPt1ResKCurSA_PbPb2018_kFirst; /// 
+  TGraph *fPt1ResPiCurSA_PbPb2018_kFirst; /// 
+  TGraph *fPt1ResECurSA_PbPb2018_kFirst; /// 
+  TGraph *fD0ZResPUpgSA_PbPb2018_kFirst; /// 
+  TGraph *fD0ZResKUpgSA_PbPb2018_kFirst; /// 
+  TGraph *fD0ZResPiUpgSA_PbPb2018_kFirst; /// 
+  TGraph *fD0ZResEUpgSA_PbPb2018_kFirst; /// 
+  TGraph *fD0RPResPUpgSA_PbPb2018_kFirst; /// 
+  TGraph *fD0RPResKUpgSA_PbPb2018_kFirst; /// 
+  TGraph *fD0RPResPiUpgSA_PbPb2018_kFirst; /// 
+  TGraph *fD0RPResEUpgSA_PbPb2018_kFirst; /// 
+  TGraph *fPt1ResPUpgSA_PbPb2018_kFirst; ///
+  TGraph *fPt1ResKUpgSA_PbPb2018_kFirst; /// 
+  TGraph *fPt1ResPiUpgSA_PbPb2018_kFirst; ///
+  TGraph *fPt1ResEUpgSA_PbPb2018_kFirst; /// 
+  // kOnlySecond
+  TGraph *fD0ZResPCur_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0ZResKCur_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0ZResPiCur_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0ZResECur_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPResPCur_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPResKCur_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPResPiCur_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPResECur_PbPb2018_kOnlySecond; ///
+  TGraph *fD0RPSigmaPullRatioP_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPSigmaPullRatioK_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPSigmaPullRatioPi_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPSigmaPullRatioE_PbPb2018_kOnlySecond; ///
+  TGraph *fD0RPMeanPCur_PbPb2018_kOnlySecond[2][24]; ///
+  TGraph *fD0RPMeanKCur_PbPb2018_kOnlySecond[2][24]; ///
+  TGraph *fD0RPMeanPiCur_PbPb2018_kOnlySecond[2][24]; ///
+  TGraph *fD0RPMeanECur_PbPb2018_kOnlySecond[2][24]; ///
+  TGraph *fPt1ResPCur_PbPb2018_kOnlySecond; /// 
+  TGraph *fPt1ResKCur_PbPb2018_kOnlySecond; /// 
+  TGraph *fPt1ResPiCur_PbPb2018_kOnlySecond; /// 
+  TGraph *fPt1ResECur_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0ZResPUpg_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0ZResKUpg_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0ZResPiUpg_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0ZResEUpg_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPResPUpg_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPResKUpg_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPResPiUpg_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPResEUpg_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPMeanPUpg_PbPb2018_kOnlySecond[2][24]; ///
+  TGraph *fD0RPMeanKUpg_PbPb2018_kOnlySecond[2][24]; ///
+  TGraph *fD0RPMeanPiUpg_PbPb2018_kOnlySecond[2][24]; ///
+  TGraph *fD0RPMeanEUpg_PbPb2018_kOnlySecond[2][24]; ///
+  TGraph *fPt1ResPUpg_PbPb2018_kOnlySecond; /// 
+  TGraph *fPt1ResKUpg_PbPb2018_kOnlySecond; /// 
+  TGraph *fPt1ResPiUpg_PbPb2018_kOnlySecond; ///
+  TGraph *fPt1ResEUpg_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0ZResPCurSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0ZResKCurSA_PbPb2018_kOnlySecond; ///
+  TGraph *fD0ZResPiCurSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0ZResECurSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPResPCurSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPResKCurSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPResPiCurSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPResECurSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fPt1ResPCurSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fPt1ResKCurSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fPt1ResPiCurSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fPt1ResECurSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0ZResPUpgSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0ZResKUpgSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0ZResPiUpgSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0ZResEUpgSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPResPUpgSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPResKUpgSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPResPiUpgSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fD0RPResEUpgSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fPt1ResPUpgSA_PbPb2018_kOnlySecond; ///
+  TGraph *fPt1ResKUpgSA_PbPb2018_kOnlySecond; /// 
+  TGraph *fPt1ResPiUpgSA_PbPb2018_kOnlySecond; ///
+  TGraph *fPt1ResEUpgSA_PbPb2018_kOnlySecond; /// 
+
   Bool_t fRunInVertexing; /// flag to run hybrid task before the vertexingHF task or in standard mode
   Bool_t fImproveTracks; /// this is always kTRUE. kFALSE only if re-running on already improved AODs
   Bool_t fUpdateSecVertCovMat; /// flag to swicth on/off the modification of the sec vert cov matrix
@@ -126,7 +264,7 @@ private:
   Int_t   fNDebug;       /// Max number of debug entries into Ntuple
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskSEImproveITS,10);
+  ClassDef(AliAnalysisTaskSEImproveITS,11);
   /// \endcond
 };
 


### PR DESCRIPTION
----------------------------------------
 - correction templates for dca sigma, mean and ratio pulls developed separately for tracks requiring kFirst or kOnlySecond condition in the SPD
 - correction templates for dca mean developed in 24 bins of phi, instead of 4
The correction is performed in this way only for PbPb2018 period. This is ruled by a boolean variable (fIsPbPb2018), which is switched to the kTRUE value only
wheter the files, containing the correction templates, called from the AddTask are stored in a path including a "LHC18r" or "LHC18q" directory.
Backward compatibility tested on a LHC18d period (pp collisions)