### PR TITLE
Change AliVEvent::EOfflineTriggerTypes to ULong64 

### DIFF
--- a/PWGHF/vertexingHF/macros/AddTaskHFSystPID.C
+++ b/PWGHF/vertexingHF/macros/AddTaskHFSystPID.C
@@ -1,7 +1,7 @@
 AliAnalysisTaskSEHFSystPID *AddTaskHFSystPID(int system = 0,
                                             bool readMC = false,
                                             TString trigClass = "",
-                                            AliVEvent::EOfflineTriggerTypes trigMask = AliVEvent::kINT7,
+                                            unsigned long long trigMask = AliVEvent::kINT7,
                                             TString outputSuffix = "_ppMB_kINT7",
                                             float nsigmafortag = 0.02,
                                             double fracdownsampl = 1.,


### PR DESCRIPTION
Modification that allows the selection of more trigger masks at the same time (i.e. kINT7 | kCentral)