### PR TITLE
PWGUD/UPC: Fixed binning heat map helicity (now CosTheta=x, Phi=y).

### DIFF
--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
@@ -748,7 +748,7 @@ void AliAnalysisTaskUPCforward::UserCreateOutputObjects()
   fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH =
         new TH2F( "fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH",
                   "fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH",
-                  80, -4, 4, 80, -1, 1);
+                  80, -1, 1, 80, -4, 4);
   fOutputList->Add(fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH);
 
 


### PR DESCRIPTION
It is more comfortable to have CosTheta in the x-axis and Phi as the y-axis...