### PR TITLE
PWGDQ: Updates for calorimeter cluster handling in dielectron and reducedTree frameworks

### DIFF
--- a/PWGDQ/dielectron/CMakeLists.txt
+++ b/PWGDQ/dielectron/CMakeLists.txt
@@ -48,6 +48,7 @@ set(SRCS
       BtoJPSI/AliDielectronBtoJPSItoEle.cxx
       core/AliDielectronCF.cxx
       core/AliDielectronCFdraw.cxx
+      core/AliDielectronClusterCuts.cxx
       core/AliDielectronCutGroup.cxx
       core/AliDielectronCutQA.cxx
       core/AliDielectron.cxx

--- a/PWGDQ/dielectron/PWGDQdielectronLinkDef.h
+++ b/PWGDQ/dielectron/PWGDQdielectronLinkDef.h
@@ -11,6 +11,7 @@
 #pragma link C++ class AliDielectronHistos+;
 #pragma link C++ class AliDielectronCF+;
 #pragma link C++ class AliDielectronCFdraw+;
+#pragma link C++ class AliDielectronClusterCuts+;
 #pragma link C++ class AliDielectronHF+;
 #pragma link C++ class AliDielectronHFhelper+;
 #pragma link C++ class AliDielectronMC+;

--- a/PWGDQ/dielectron/core/AliDielectronClusterCuts.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronClusterCuts.cxx
@@ -1,0 +1,127 @@
+/*************************************************************************
+ * Copyright(c) 1998-2009, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: The ALICE Off-line Project.                                    *
+ * Contributors are mentioned in the code where appropriate.              *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+///////////////////////////////////////////////////////////////////////////
+//                Dielectron ClusterCuts                                  //
+//                                                                       //
+//                                                                       //
+/*
+ Detailed description
+ 
+ 
+ */
+//                                                                       //
+///////////////////////////////////////////////////////////////////////////
+
+
+#include <TMath.h>
+
+#include "AliDielectronClusterCuts.h"
+#include "AliVCluster.h"
+
+ClassImp(AliDielectronClusterCuts)
+
+//______________________________________________
+AliDielectronClusterCuts::AliDielectronClusterCuts() : AliAnalysisCuts(),
+  fCaloType(kAny),
+  fMinNCells(-999),
+  fRejectExotics(kFALSE),
+  fRequireTrackMatch(kFALSE),
+  fM02Min(-999.),
+  fM02Max(-999.),
+  fM20Min(-999.),
+  fM20Max(-999.),
+  fTrackDxMin(-999.),
+  fTrackDxMax(-999.),
+  fTrackDzMin(-999.),
+  fTrackDzMax(-999.)
+{
+  //
+  // default constructor
+  //
+}
+
+//______________________________________________
+AliDielectronClusterCuts::AliDielectronClusterCuts(const char* name, const char* title) : AliAnalysisCuts(name, title),
+  fCaloType(kAny),
+  fMinNCells(-999),
+  fRejectExotics(kFALSE),
+  fRequireTrackMatch(kFALSE),
+  fM02Min(-999.),
+  fM02Max(-999.),
+  fM20Min(-999.),
+  fM20Max(-999.),
+  fTrackDxMin(-999.),
+  fTrackDxMax(-999.),
+  fTrackDzMin(-999.),
+  fTrackDzMax(-999.)
+{
+  //
+  // named constructor
+  //
+}
+
+//______________________________________________
+AliDielectronClusterCuts::~AliDielectronClusterCuts()
+{
+  //
+  // default Destructor
+  //
+}
+
+//______________________________________________
+Bool_t AliDielectronClusterCuts::IsSelected(TObject* cluster)
+{
+  //
+  // apply configured cuts
+  //
+  AliVCluster *vcluster = dynamic_cast<AliVCluster*>(cluster);
+  if (!vcluster) return kFALSE;
+  
+  Bool_t accept = kTRUE;
+
+  // calo typ
+  if (fCaloType!=kAny) {
+    if (fCaloType==kEMCal)  accept *= vcluster->IsEMCAL();
+    if (fCaloType==kPHOS)   accept *= vcluster->IsPHOS();
+  }
+  
+  // min number of cells
+  if (fMinNCells!=-999) accept *= (vcluster->GetNCells()>=fMinNCells);
+  
+  // track match
+  if (fRequireTrackMatch) accept *= (vcluster->GetNTracksMatched()>0);
+  
+  // M02
+  if (fM02Min!=-999.) accept *= (vcluster->GetM02()>=fM02Min);
+  if (fM02Max!=-999.) accept *= (vcluster->GetM02()<=fM02Max);
+  
+  // M20
+  if (fM20Min!=-999.) accept *= (vcluster->GetM20()>=fM20Min);
+  if (fM20Max!=-999.) accept *= (vcluster->GetM20()<=fM20Max);
+
+  // track Dx
+  if (fTrackDxMin!=-999.) accept *= (vcluster->GetTrackDx()>=fTrackDxMin);
+  if (fTrackDxMax!=-999.) accept *= (vcluster->GetTrackDx()<=fTrackDxMax);
+
+  // track Dz
+  if (fTrackDzMin!=-999.) accept *= (vcluster->GetTrackDz()>=fTrackDzMin);
+  if (fTrackDzMax!=-999.) accept *= (vcluster->GetTrackDz()<=fTrackDzMax);
+
+  // exotics
+  if (fRejectExotics) accept *= !(vcluster->GetIsExotic());
+  
+  return accept;
+}

--- a/PWGDQ/dielectron/core/AliDielectronClusterCuts.h
+++ b/PWGDQ/dielectron/core/AliDielectronClusterCuts.h
@@ -1,0 +1,68 @@
+#ifndef ALIDIELECTRONCLUSTERCUTS_H
+#define ALIDIELECTRONCLUSTERCUTS_H
+
+/* Copyright(c) 1998-2009, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
+
+//#############################################################
+//#                                                           #
+//#         Class AliDielectronClusterCuts                    #
+//#                                                           #
+//#  Authors:                                                 #
+//#   Lucas Altenkamper, UiB / lucas.altenkamper@cern.ch      #
+//#                                                           #
+//#############################################################
+
+#include <AliPID.h>
+#include <AliAnalysisCuts.h>
+
+class AliDielectronClusterCuts : public AliAnalysisCuts {
+  
+public:
+  
+  enum Detector {
+    kEMCal=0, // calorimeter = EMCal/DCal
+    kPHOS,    // calorimeter = PHOS
+    kAny
+  };
+  AliDielectronClusterCuts();
+  AliDielectronClusterCuts(const char*name, const char* title);
+  virtual ~AliDielectronClusterCuts();
+
+  void SetCaloType(Short_t type) { fCaloType=type; }
+  void SetNCellsMinCut(Short_t val) { fMinNCells=val; }
+  void SetRejectExotics() { fRejectExotics=kTRUE; }
+  void SetRequireTrackMatch(Bool_t req) { fRequireTrackMatch=req; }
+  void SetM02Cut(Float_t min, Float_t max) { fM02Min=min; fM02Max=max; }
+  void SetM20Cut(Float_t min, Float_t max) { fM20Min=min; fM20Max=max; }
+  void SetTrackDxCut(Float_t min, Float_t max) { fTrackDxMin=min; fTrackDxMax=max; }
+  void SetTrackDzCut(Float_t min, Float_t max) { fTrackDzMin=min; fTrackDzMax=max; }
+
+  //
+  //Analysis cuts interface
+  //
+  virtual Bool_t IsSelected(TObject* cluster);
+  virtual Bool_t IsSelected(TList*   /* list */ ) {return kFALSE;}
+
+private:
+  
+  AliDielectronClusterCuts(const AliDielectronClusterCuts &c);
+  AliDielectronClusterCuts &operator=(const AliDielectronClusterCuts &c);
+
+  Short_t fCaloType;          // calorimeter type (EMCal/DCal, PHOS, any)
+  Short_t fMinNCells;         // min number of cells per cluster
+  Bool_t  fRejectExotics;     // reject exotic cluster
+  Bool_t  fRequireTrackMatch; // require at least one track matched to cluster
+  Float_t fM02Min;            // min cluster M02
+  Float_t fM02Max;            // max cluster M02
+  Float_t fM20Min;            // min cluster M20
+  Float_t fM20Max;            // max cluster M20
+  Float_t fTrackDxMin;        // min track Dx
+  Float_t fTrackDxMax;        // max track Dx
+  Float_t fTrackDzMin;        // min track Dz
+  Float_t fTrackDzMax;        // max track Dz
+  
+  ClassDef(AliDielectronClusterCuts,1);
+};
+
+#endif

--- a/PWGDQ/dielectron/core/AliDielectronClusterCuts.h
+++ b/PWGDQ/dielectron/core/AliDielectronClusterCuts.h
@@ -29,6 +29,7 @@ public:
   AliDielectronClusterCuts(const char*name, const char* title);
   virtual ~AliDielectronClusterCuts();
 
+  // setters
   void SetCaloType(Short_t type) { fCaloType=type; }
   void SetNCellsMinCut(Short_t val) { fMinNCells=val; }
   void SetRejectExotics() { fRejectExotics=kTRUE; }
@@ -37,6 +38,16 @@ public:
   void SetM20Cut(Float_t min, Float_t max) { fM20Min=min; fM20Max=max; }
   void SetTrackDxCut(Float_t min, Float_t max) { fTrackDxMin=min; fTrackDxMax=max; }
   void SetTrackDzCut(Float_t min, Float_t max) { fTrackDzMin=min; fTrackDzMax=max; }
+
+  // getters
+  Short_t GetCaloType() { return fCaloType; }
+  Short_t GetNCellsMinCut() { return fMinNCells; }
+  Bool_t  GetRejectExotics() { return fRejectExotics; }
+  Bool_t  GetRequireTrackMatch() { return fRequireTrackMatch; }
+  void    GetM02Cut(Float_t &min, Float_t &max) { min=fM02Min; max=fM02Max; }
+  void    GetM20Cut(Float_t &min, Float_t &max) { min=fM20Min; max=fM20Max; }
+  void    GetTrackDxCut(Float_t &min, Float_t &max) { min=fTrackDxMin; max=fTrackDxMax; }
+  void    GetTrackDzCut(Float_t &min, Float_t &max) { min=fTrackDzMin; max=fTrackDzMax; }
 
   //
   //Analysis cuts interface
@@ -62,7 +73,7 @@ private:
   Float_t fTrackDzMin;        // min track Dz
   Float_t fTrackDzMax;        // max track Dz
   
-  ClassDef(AliDielectronClusterCuts,1);
+  ClassDef(AliDielectronClusterCuts,2);
 };
 
 #endif

--- a/PWGDQ/dielectron/core/AliDielectronTrackCuts.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronTrackCuts.cxx
@@ -29,6 +29,7 @@ Detailed description
 #include <TMath.h>
 
 #include "AliDielectronTrackCuts.h"
+#include "AliDielectronClusterCuts.h"
 #include "AliVTrack.h"
 #include "AliAODTrack.h"
 
@@ -46,7 +47,9 @@ AliDielectronTrackCuts::AliDielectronTrackCuts() :
   fTPCNclRobustCut(-1),
   fTPCcrossedOverFindable(-1.),
   fAODFilterBit(kSwitchOff),
-  fWaiveITSNcls(-1)
+  fWaiveITSNcls(-1),
+  fRequireCaloClusterMatch(kFALSE),
+  fClusterMatchCaloType(AliDielectronClusterCuts::kAny)
 {
   //
   // Default Constructor
@@ -70,7 +73,9 @@ AliDielectronTrackCuts::AliDielectronTrackCuts(const char* name, const char* tit
   fTPCNclRobustCut(-1),
   fTPCcrossedOverFindable(-1.),
   fAODFilterBit(kSwitchOff),
-  fWaiveITSNcls(-1)
+  fWaiveITSNcls(-1),
+  fRequireCaloClusterMatch(kFALSE),
+  fClusterMatchCaloType(AliDielectronClusterCuts::kAny)
 {
   //
   // Named Constructor
@@ -160,6 +165,18 @@ Bool_t AliDielectronTrackCuts::IsSelected(TObject* track)
     }
   }
 
+  // calo cluster-track match
+  // NOTE: logic correct?
+  if (fRequireCaloClusterMatch) {
+    Int_t fCaloIndex = vtrack->GetEMCALcluster();
+    if (fCaloIndex!=AliVTrack::kEMCALNoMatch) {
+      if (fClusterMatchCaloType==AliDielectronClusterCuts::kEMCal)  accept*=vtrack->IsEMCAL();
+      if (fClusterMatchCaloType==AliDielectronClusterCuts::kPHOS)   accept*=vtrack->IsPHOS();
+      if (fClusterMatchCaloType==AliDielectronClusterCuts::kAny)    accept*=kTRUE;
+    } else {
+      accept*=kFALSE;
+    }
+  }
 
   return accept;
 }

--- a/PWGDQ/dielectron/core/AliDielectronTrackCuts.h
+++ b/PWGDQ/dielectron/core/AliDielectronTrackCuts.h
@@ -56,6 +56,8 @@ public:
   void SetAODFilterBit(EFilterBit type) { fAODFilterBit = type; }
   void SetMaxWaivedITSNcls(Int_t max) { fWaiveITSNcls = max; }
 
+  void SetRequireCaloClusterMatch(Bool_t req, Short_t caloType) { fRequireCaloClusterMatch=req; fClusterMatchCaloType=caloType; }
+
   //
   //Analysis cuts interface
   //
@@ -86,10 +88,13 @@ private:
   Int_t fAODFilterBit;                                 // Filter bit for AOD analysis
   Int_t fWaiveITSNcls;                                 // max number of waived ITS clusters after first hit
 
+  Bool_t  fRequireCaloClusterMatch;                    // require calo cluster matched to track
+  Short_t fClusterMatchCaloType;                       // calo type for track match: AliDielectronClusterCuts::Detector
+
   Bool_t CheckITSClusterRequirement(ITSClusterRequirement req, Bool_t clusterL1, Bool_t clusterL2) const;
   Bool_t CheckITSClusterCut(UChar_t itsBits) const;
 
-  ClassDef(AliDielectronTrackCuts,3)         // Dielectron TrackCuts
+  ClassDef(AliDielectronTrackCuts,4)         // Dielectron TrackCuts
 };
 
 

--- a/PWGDQ/dielectron/core/AliDielectronTrackCuts.h
+++ b/PWGDQ/dielectron/core/AliDielectronTrackCuts.h
@@ -56,7 +56,9 @@ public:
   void SetAODFilterBit(EFilterBit type) { fAODFilterBit = type; }
   void SetMaxWaivedITSNcls(Int_t max) { fWaiveITSNcls = max; }
 
-  void SetRequireCaloClusterMatch(Bool_t req, Short_t caloType) { fRequireCaloClusterMatch=req; fClusterMatchCaloType=caloType; }
+  void    SetRequireCaloClusterMatch(Bool_t req, Short_t caloType) { fRequireCaloClusterMatch=req; fClusterMatchCaloType=caloType; }
+  Bool_t  GetRequireCaloClusterMatch() { return fRequireCaloClusterMatch; }
+  Short_t GetCaloClusterMatchDetector() { return fClusterMatchCaloType; }
 
   //
   //Analysis cuts interface
@@ -94,7 +96,7 @@ private:
   Bool_t CheckITSClusterRequirement(ITSClusterRequirement req, Bool_t clusterL1, Bool_t clusterL2) const;
   Bool_t CheckITSClusterCut(UChar_t itsBits) const;
 
-  ClassDef(AliDielectronTrackCuts,4)         // Dielectron TrackCuts
+  ClassDef(AliDielectronTrackCuts,5)         // Dielectron TrackCuts
 };
 
 

--- a/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
+++ b/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
@@ -879,6 +879,16 @@ void AliAnalysisTaskReducedTreeMaker::AddTrackFilter(AliAnalysisCuts * const fil
 }
 
 //_________________________________________________________________________________
+void AliAnalysisTaskReducedTreeMaker::AddCaloClusterFilter(AliAnalysisCuts * const filter)
+{
+  //
+  // add cluster filter to cluster filter list
+  //
+  if (fClusterFilter.GetEntries()<32) fClusterFilter.Add(filter);
+  else printf("AliAnalysisTaskReducedTreeMaker::AddCaloClusterFilter() WARNING: Cluster filter list full (%d entries), will not add another filter!\n", fClusterFilter.GetEntries());
+}
+
+//_________________________________________________________________________________
 Bool_t AliAnalysisTaskReducedTreeMaker::IsTrackSelected(AliVParticle* track, std::vector<Bool_t>& filterDecision)
 {
   //
@@ -916,6 +926,24 @@ Bool_t AliAnalysisTaskReducedTreeMaker::IsSelectedTrackRequestedBaseTrack(std::v
       isBaseTrack = kFALSE;
   }
   return isBaseTrack;
+}
+
+//_________________________________________________________________________________
+Bool_t AliAnalysisTaskReducedTreeMaker::IsClusterSelected(AliVCluster* cluster, std::vector<Bool_t>& filterDecision) {
+  //
+  // check if cluster is selected and write filter decision to vector
+  //
+  Bool_t clusterIsSelected = kFALSE;
+  for (Int_t i=0; i<fClusterFilter.GetEntries(); i++) {
+    AliAnalysisCuts* filter = (AliAnalysisCuts*)fClusterFilter.At(i);
+    if (filter->IsSelected(cluster)) {
+      filterDecision.push_back(kTRUE);
+      clusterIsSelected = kTRUE;
+    } else {
+      filterDecision.push_back(kFALSE);
+    }
+  }
+  return clusterIsSelected;
 }
 
 //_________________________________________________________________________________
@@ -1345,10 +1373,16 @@ void AliAnalysisTaskReducedTreeMaker::FillCaloClusters() {
   eventInfo->fNCaloClusters = 0;
   for(Int_t iclus=0; iclus<nclusters; ++iclus) {
     AliVCluster* cluster = event->GetCaloCluster(iclus);
+
+    Bool_t clusterFilterDecision = kTRUE;
+    std::vector<Bool_t> individualFilterDecisions;
+    if (fClusterFilter.GetEntries()>0)  clusterFilterDecision = IsClusterSelected(cluster, individualFilterDecisions);
+    if (!clusterFilterDecision) continue;
     
     TClonesArray& clusters = *(eventInfo->fCaloClusters);
     AliReducedCaloClusterInfo *reducedCluster=new(clusters[eventInfo->fNCaloClusters]) AliReducedCaloClusterInfo();
     
+    reducedCluster->fClusterID = iclus;
     reducedCluster->fType    = (cluster->IsEMCAL() ? AliReducedCaloClusterInfo::kEMCAL : AliReducedCaloClusterInfo::kPHOS);
     reducedCluster->fEnergy  = cluster->E();
     reducedCluster->fTrackDx = cluster->GetTrackDx();
@@ -1356,6 +1390,7 @@ void AliAnalysisTaskReducedTreeMaker::FillCaloClusters() {
     reducedCluster->fM20     = cluster->GetM20();
     reducedCluster->fM02     = cluster->GetM02();
     reducedCluster->fDispersion = cluster->GetDispersion();
+    reducedCluster->fNMatchedTracks = cluster->GetNTracksMatched();
     cluster->GetPosition(reducedCluster->fPosition);
     reducedCluster->fTOF = cluster->GetTOF();
     reducedCluster->fNCells = cluster->GetNCells();

--- a/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
+++ b/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
@@ -364,6 +364,9 @@ void AliAnalysisTaskReducedTreeMaker::UserCreateOutputObjects()
 		if(!fFillEventPlaneInfo) {
 			fTree->SetBranchStatus("fEventPlane.*", 0);
 		}
+
+    // if calorimeter cluster is filled, switch on cluster ID branch
+    if (fFillCaloClusterInfo) fTree->SetBranchStatus("fCaloClusters.fClusterID", 1);
 	}
 
   /*if(fFillBayesianPIDInfo) {

--- a/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.h
+++ b/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.h
@@ -71,6 +71,8 @@ public:
   // Cuts for selecting tracks included in the tree
   void SetTrackFilter(AliAnalysisCuts * const filter);
   void AddTrackFilter(AliAnalysisCuts * const filter, Bool_t option=kFALSE);
+  // Cuts for calorimeter clusters included in the tree
+  void AddCaloClusterFilter(AliAnalysisCuts * const filter);
     
   // Cuts for selecting V0s
   void SetK0sPionCuts(AliAnalysisCuts * const filter) {fK0sPionCuts=filter;}
@@ -131,6 +133,7 @@ public:
 
   Bool_t  IsTrackSelected(AliVParticle* track, std::vector<Bool_t>& filterDecision);
   Bool_t  IsSelectedTrackRequestedBaseTrack(std::vector<Bool_t> filterDecision, Bool_t usedForV0Or);
+  Bool_t  IsClusterSelected(AliVCluster* cluster, std::vector<Bool_t>& filterDecision);
   void    SetTrackFilterQualityFlags(AliReducedBaseTrack* track, std::vector<Bool_t> filterDecision);
   void    FillTrackStatisticsHistogram(std::vector<Bool_t> filterDecision, Bool_t usedForV0Or);
 
@@ -183,7 +186,8 @@ public:
   AliAnalysisCuts *fEventFilter;      // event filter
   TList            fTrackFilter;      // filter for the hadrons to be correlated with the dielectrons
   AliAnalysisCuts *fFlowTrackFilter;  // filter for the barrel tracks to be used for the Q-vector
-  
+  TList            fClusterFilter;    // filter for the calorimeter clusters
+
   AliESDv0Cuts *fK0sCuts;            // v0 standard filter for K0s->pi+pi-
   AliESDv0Cuts *fLambdaCuts;         // v0 standard filter for Lambda0->p + pi
   AliESDv0KineCuts *fGammaConvCuts;  // v0 standard filter for gamma conversions
@@ -235,6 +239,6 @@ public:
   AliAnalysisTaskReducedTreeMaker(const AliAnalysisTaskReducedTreeMaker &c);
   AliAnalysisTaskReducedTreeMaker& operator= (const AliAnalysisTaskReducedTreeMaker &c);
 
-  ClassDef(AliAnalysisTaskReducedTreeMaker, 13); //Analysis Task for creating a reduced event information tree
+  ClassDef(AliAnalysisTaskReducedTreeMaker, 14); //Analysis Task for creating a reduced event information tree
 };
 #endif

--- a/PWGDQ/reducedTree/AliReducedAnalysisJpsi2ee.cxx
+++ b/PWGDQ/reducedTree/AliReducedAnalysisJpsi2ee.cxx
@@ -356,7 +356,7 @@ void AliReducedAnalysisJpsi2ee::FillTrackHistograms(TString trackClass /*= "Trac
       //Int_t tpcSector = TMath::FloorNint(18.*track->Phi()/TMath::TwoPi());
       fValues[AliReducedVarManager::kNtracksAnalyzedInPhiBins+(track->Eta()<0.0 ? 0 : 18) + TMath::FloorNint(18.*track->Phi()/TMath::TwoPi())] += 1;
       // reset track variables
-      for(Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedEOverP; ++i) fValues[i]=-9999.;
+      for(Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedM20; ++i) fValues[i]=-9999.;
       
       AliReducedVarManager::FillTrackInfo(track, fValues);
       FillTrackHistograms(track, trackClass);
@@ -367,7 +367,7 @@ void AliReducedAnalysisJpsi2ee::FillTrackHistograms(TString trackClass /*= "Trac
       //Int_t tpcSector = TMath::FloorNint(18.*track->Phi()/TMath::TwoPi());
       fValues[AliReducedVarManager::kNtracksAnalyzedInPhiBins+(track->Eta()<0.0 ? 0 : 18) + TMath::FloorNint(18.*track->Phi()/TMath::TwoPi())] += 1;
       // reset track variables
-      for(Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedEOverP; ++i) fValues[i]=-9999.;
+      for(Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedM20; ++i) fValues[i]=-9999.;
       
       AliReducedVarManager::FillTrackInfo(track, fValues);
       FillTrackHistograms(track, trackClass);
@@ -496,7 +496,7 @@ void AliReducedAnalysisJpsi2ee::LoopOverTracks(Int_t arrayOption /*=1*/) {
       // NOTE: this can be also handled via AliReducedTrackCut::SetRejectPureMC()
       if(fOptionRunOverMC && track->IsMCTruth()) continue;     
       // reset track variables
-      for(Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedEOverP; ++i) fValues[i]=-9999.;
+      for(Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedM20; ++i) fValues[i]=-9999.;
 
       AliReducedVarManager::FillTrackInfo(track, fValues);
       fHistosManager->FillHistClass("Track_BeforeCuts", fValues);
@@ -858,7 +858,7 @@ void AliReducedAnalysisJpsi2ee::LoopOverMCTracks(Int_t trackArray /*=1*/) {
       daughter2 = FindMCtruthTrackByLabel(daughter2Label);
       
       // reset track variables and fill info
-      for(Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedEOverP; ++i) fValues[i]=-9999.;
+      for(Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedM20; ++i) fValues[i]=-9999.;
       AliReducedVarManager::FillMCTruthInfo(mother, fValues, daughter1, daughter2);
       
       // loop over jpsi mother selections and fill histograms before the kine cuts on electrons
@@ -913,8 +913,7 @@ void AliReducedAnalysisJpsi2ee::LoopOverMCTracks(Int_t trackArray /*=1*/) {
          
          if(daughter1 && daughter2) {
             daughterDecisions = daughter1Decisions & daughter2Decisions;
-            
-            for(Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedEOverP; ++i) fValues[i]=-9999.;
+            for(Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedM20; ++i) fValues[i]=-9999.;
             AliReducedVarManager::FillMCTruthInfo(daughter1, daughter2, fValues);
             
             // loop over cuts and fill histograms

--- a/PWGDQ/reducedTree/AliReducedAnalysisJpsi2ee.cxx
+++ b/PWGDQ/reducedTree/AliReducedAnalysisJpsi2ee.cxx
@@ -279,7 +279,7 @@ void AliReducedAnalysisJpsi2ee::Process() {
   // apply event selection
   if(!IsEventSelected(fEvent, fValues)) return;
   
-  // fill calorimeter info histograms before event cuts
+  // fill calorimeter info histograms
   if(fFillCaloClusterHistograms) {
     for(Int_t icl=0; icl<eventInfo->GetNCaloClusters(); ++icl) {
       AliReducedVarManager::FillCaloClusterInfo(eventInfo->GetCaloCluster(icl), fValues);

--- a/PWGDQ/reducedTree/AliReducedAnalysisSingleTrack.cxx
+++ b/PWGDQ/reducedTree/AliReducedAnalysisSingleTrack.cxx
@@ -39,6 +39,7 @@ using std::endl;
 #include "AliReducedBaseTrack.h"
 #include "AliReducedTrackInfo.h"
 #include "AliReducedPairInfo.h"
+#include "AliReducedCaloClusterInfo.h"
 #include "AliHistogramManager.h"
 
 ClassImp(AliReducedAnalysisSingleTrack);
@@ -48,10 +49,13 @@ AliReducedAnalysisSingleTrack::AliReducedAnalysisSingleTrack() :
   AliReducedAnalysisTaskSE(),
   fHistosManager(new AliHistogramManager("Histogram Manager", AliReducedVarManager::kNVars)),
   fOptionRunOverMC(kTRUE),
+  fOptionRunOverCaloCluster(kFALSE),
   fEventCuts(),
   fTrackCuts(),
+  fClusterCuts(),
   fMCSignalCuts(),
-  fTracks()
+  fTracks(),
+  fClusters()
 {
   //
   // default constructor
@@ -63,18 +67,23 @@ AliReducedAnalysisSingleTrack::AliReducedAnalysisSingleTrack(const Char_t* name,
   AliReducedAnalysisTaskSE(name,title),
   fHistosManager(new AliHistogramManager("Histogram Manager", AliReducedVarManager::kNVars)),
   fOptionRunOverMC(kTRUE),
+  fOptionRunOverCaloCluster(kFALSE),
   fEventCuts(),
   fTrackCuts(),
+  fClusterCuts(),
   fMCSignalCuts(),
-  fTracks()
+  fTracks(),
+  fClusters()
 {
   //
   // named constructor
   //
   fEventCuts.SetOwner(kTRUE);
   fTrackCuts.SetOwner(kTRUE);
+  fClusterCuts.SetOwner(kTRUE);
   fMCSignalCuts.SetOwner(kTRUE);
   fTracks.SetOwner(kFALSE);
+  fClusters.SetOwner(kFALSE);
 }
 
 //___________________________________________________________________________
@@ -85,8 +94,10 @@ AliReducedAnalysisSingleTrack::~AliReducedAnalysisSingleTrack()
   //
   fEventCuts.Clear("C");
   fTrackCuts.Clear("C");
+  fClusterCuts.Clear("C");
   fMCSignalCuts.Clear("C");
   fTracks.Clear("C");
+  fClusters.Clear("C");
   if (fHistosManager) delete fHistosManager;
 }
 
@@ -118,6 +129,21 @@ Bool_t AliReducedAnalysisSingleTrack::IsTrackSelected(AliReducedBaseTrack* track
     else { if (cut->IsSelected(track)) track->SetFlag(i); }
   }
   return (track->GetFlags()>0 ? kTRUE : kFALSE);
+}
+
+//___________________________________________________________________________
+Bool_t AliReducedAnalysisSingleTrack::IsClusterSelected(AliReducedCaloClusterInfo* cluster, Float_t* values/*=0x0*/) {
+  //
+  // apply cluster cuts
+  //
+  if (fClusterCuts.GetEntries()==0) return kTRUE;
+  cluster->ResetFlags();
+  for (Int_t i=0; i<fClusterCuts.GetEntries(); ++i) {
+    AliReducedInfoCut* cut = (AliReducedInfoCut*)fClusterCuts.At(i);
+    if (values) { if (cut->IsSelected(cluster, values)) cluster->SetFlag(i); }
+    else { if (cut->IsSelected(cluster)) cluster->SetFlag(i); }
+  }
+  return (cluster->GetFlags()>0 ? kTRUE : kFALSE);
 }
 
 //___________________________________________________________________________
@@ -310,6 +336,55 @@ void AliReducedAnalysisSingleTrack::FillTrackHistograms(AliReducedBaseTrack* tra
 }
 
 //___________________________________________________________________________
+void AliReducedAnalysisSingleTrack::RunClusterSelection() {
+  //
+  // select cluster
+  //
+  fClusters.Clear("C");
+
+  if (fEvent->IsA() == AliReducedBaseEvent::Class()) return;
+  Int_t nCaloCluster = ((AliReducedEventInfo*)fEvent)->GetNCaloClusters();
+  if (!nCaloCluster) return;
+
+  AliReducedCaloClusterInfo* cluster = NULL;
+  for (Int_t icl=0; icl<nCaloCluster; ++icl) {
+    cluster = ((AliReducedEventInfo*)fEvent)->GetCaloCluster(icl);
+
+    for (Int_t i=AliReducedVarManager::kEMCALclusterEnergy; i<=AliReducedVarManager::kEMCALnMatchedTracks; ++i) fValues[i] = -9999.;
+
+    AliReducedVarManager::FillCaloClusterInfo(cluster, fValues);
+    fHistosManager->FillHistClass("CaloCluster_BeforeCuts", fValues);
+
+    if (IsClusterSelected(cluster, fValues)) fClusters.Add(cluster);
+  }
+}
+
+//___________________________________________________________________________
+void AliReducedAnalysisSingleTrack::FillClusterHistograms(TString clusterClass/*="CaloCluster"*/) {
+  //
+  // fill cluster histograms
+  //
+  AliReducedCaloClusterInfo* cluster = NULL;
+  TIter nextCluster(&fClusters);
+  for (Int_t i=0; i<fClusters.GetEntries(); ++i) {
+    cluster = (AliReducedCaloClusterInfo*)nextCluster();
+    for (Int_t i=AliReducedVarManager::kEMCALclusterEnergy; i<=AliReducedVarManager::kEMCALnMatchedTracks; ++i) fValues[i] = -9999.;
+    AliReducedVarManager::FillCaloClusterInfo(cluster, fValues);
+    FillClusterHistograms(cluster, clusterClass);
+  }
+}
+
+//___________________________________________________________________________
+void AliReducedAnalysisSingleTrack::FillClusterHistograms(AliReducedCaloClusterInfo* cluster, TString clusterClass/*="CaloCluster"*/) {
+  //
+  // fill cluster histograms
+  //
+  for (Int_t icut=0; icut<fClusterCuts.GetEntries(); ++icut) {
+    if (cluster->TestFlag(icut)) fHistosManager->FillHistClass(Form("%s_%s", clusterClass.Data(), fClusterCuts.At(icut)->GetName()), fValues);
+  }
+}
+
+//___________________________________________________________________________
 void AliReducedAnalysisSingleTrack::Init() {
   //
   // initialize stuff
@@ -358,6 +433,12 @@ void AliReducedAnalysisSingleTrack::Process() {
   
   // fill MC truth histograms
   if (fOptionRunOverMC) FillMCTruthHistograms();
+
+  // select cluster and fill histograms
+  if (fOptionRunOverCaloCluster) {
+    RunClusterSelection();
+    FillClusterHistograms();
+  }
 
   // select tracks
   RunTrackSelection();

--- a/PWGDQ/reducedTree/AliReducedAnalysisSingleTrack.cxx
+++ b/PWGDQ/reducedTree/AliReducedAnalysisSingleTrack.cxx
@@ -180,7 +180,7 @@ void AliReducedAnalysisSingleTrack::FillMCTruthHistograms() {
     if (!mcDecisionMap) continue;
     
     // reset track variables and fill info
-    for (Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedEOverP; ++i) fValues[i]=-9999.;
+    for (Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedM20; ++i) fValues[i]=-9999.;
     AliReducedVarManager::FillMCTruthInfo(track, fValues);
     
     // loop over track selections and fill histograms
@@ -213,7 +213,7 @@ void AliReducedAnalysisSingleTrack::RunTrackSelection() {
     if (fOptionRunOverMC && track->IsMCTruth()) continue;
     
     // reset track variables
-    for (Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedEOverP; ++i) fValues[i] = -9999.;
+    for (Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedM20; ++i) fValues[i] = -9999.;
     
     AliReducedVarManager::FillTrackInfo(track, fValues);
     fHistosManager->FillHistClass("Track_BeforeCuts", fValues);
@@ -258,7 +258,7 @@ void AliReducedAnalysisSingleTrack::FillTrackHistograms(TString trackClass/*="Tr
     fValues[AliReducedVarManager::kNtracksAnalyzedInPhiBins+(track->Eta()<0.0 ? 0 : 18) + TMath::FloorNint(18.*track->Phi()/TMath::TwoPi())] += 1;
     
     // reset track variables
-    for (Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedEOverP; ++i) fValues[i] = -9999.;
+    for (Int_t i=AliReducedVarManager::kNEventVars; i<AliReducedVarManager::kEMCALmatchedM20; ++i) fValues[i] = -9999.;
     
     AliReducedVarManager::FillTrackInfo(track, fValues);
     FillTrackHistograms(track, trackClass);

--- a/PWGDQ/reducedTree/AliReducedAnalysisSingleTrack.h
+++ b/PWGDQ/reducedTree/AliReducedAnalysisSingleTrack.h
@@ -17,6 +17,7 @@
 #include "AliReducedBaseEvent.h"
 #include "AliReducedBaseTrack.h"
 #include "AliReducedTrackInfo.h"
+#include "AliReducedCaloClusterInfo.h"
 #include "AliHistogramManager.h"
 #include "AliMixingHandler.h"
 
@@ -38,13 +39,18 @@ public:
   // setters
   void AddEventCut(AliReducedInfoCut* cut) {fEventCuts.Add(cut);}
   void AddTrackCut(AliReducedInfoCut* cut) {fTrackCuts.Add(cut);}
+  void AddClusterCut(AliReducedInfoCut* cut) {fClusterCuts.Add(cut);}
   void AddMCSignalCut(AliReducedInfoCut* cut) {if (fMCSignalCuts.GetEntries()>=32) return; fMCSignalCuts.Add(cut);}
-  void SetRunOverMC(Bool_t option) {fOptionRunOverMC = option;};
+  void SetRunOverMC(Bool_t option) {fOptionRunOverMC = option;}
+  void SetRunOverCaloCluster(Bool_t option) {fOptionRunOverCaloCluster = option;}
 
   //getters
   virtual AliHistogramManager*  GetHistogramManager() const {return fHistosManager;}
   Int_t                         GetNTrackCuts() const {return fTrackCuts.GetEntries();}
   const Char_t*                 GetTrackCutName(Int_t i) const {return (i<fTrackCuts.GetEntries() ? fTrackCuts.At(i)->GetName() : "");}
+  Bool_t                        GetRunOverCaloCluster() const {return fOptionRunOverCaloCluster;};
+  Int_t                         GetNClusterCuts() const {return fClusterCuts.GetEntries();}
+  const Char_t*                 GetClusterCutName(Int_t i) const {return (i<fClusterCuts.GetEntries() ? fClusterCuts.At(i)->GetName() : "");}
   Bool_t                        GetRunOverMC() const {return fOptionRunOverMC;};
   Int_t                         GetNMCSignalCuts() const {return fMCSignalCuts.GetEntries();}
   const Char_t*                 GetMCSignalCutName(Int_t i) const {return (i<fMCSignalCuts.GetEntries() ? fMCSignalCuts.At(i)->GetName() : "");}
@@ -52,23 +58,30 @@ public:
 protected:
   AliHistogramManager* fHistosManager;   // Histogram manager
   
-  Bool_t fOptionRunOverMC;  // true: trees contain MC info -> fill histos to compute efficiencies, false: run normally as on data
-  
+  Bool_t fOptionRunOverMC;          // true: trees contain MC info -> fill histos to compute efficiencies, false: run normally as on data
+  Bool_t fOptionRunOverCaloCluster; // true: run over calorimeter clusters and fill histograms
+
   TList fEventCuts;     // array of event cuts
   TList fTrackCuts;     // array of track cuts
+  TList fClusterCuts;   // array of cluster cuts
   TList fMCSignalCuts;  // array of MC signal cuts
 
-  TList fTracks; // list of selected tracks
+  TList fTracks;        // list of selected tracks
+  TList fClusters;      // list of selected clusters
 
   Bool_t  IsEventSelected(AliReducedBaseEvent* event, Float_t* values=0x0);
   Bool_t  IsTrackSelected(AliReducedBaseTrack* track, Float_t* values=0x0);
+  Bool_t  IsClusterSelected(AliReducedCaloClusterInfo* cluster, Float_t* values=0x0);
   UInt_t  CheckTrackMCTruth(AliReducedBaseTrack* track);
   void    FillMCTruthHistograms();
   void    RunTrackSelection();
+  void    RunClusterSelection();
   void    FillTrackHistograms(TString trackClass="Track");
   void    FillTrackHistograms(AliReducedBaseTrack* track, TString trackClass="Track");
+  void    FillClusterHistograms(TString clusterClass="CaloCluster");
+  void    FillClusterHistograms(AliReducedCaloClusterInfo* cluster, TString clusterClass="CaloCluster");
 
-  ClassDef(AliReducedAnalysisSingleTrack,1);
+  ClassDef(AliReducedAnalysisSingleTrack,2);
 };
 
 #endif

--- a/PWGDQ/reducedTree/AliReducedCaloClusterCut.cxx
+++ b/PWGDQ/reducedTree/AliReducedCaloClusterCut.cxx
@@ -1,0 +1,82 @@
+/*
+ ***********************************************************
+ Implementation of AliReducedCaloClusterCut class.
+ Contact: lucasaltenkamper@cern.ch
+ 13/04/2019
+ *********************************************************
+ */
+
+#ifndef ALIREDUCEDCALOCLUSTERCUT_H
+#include "AliReducedCaloClusterCut.h"
+#endif
+
+#include "AliReducedBaseTrack.h"
+#include "AliReducedTrackInfo.h"
+#include "AliReducedCaloClusterInfo.h"
+#include "AliReducedVarManager.h"
+
+ClassImp(AliReducedCaloClusterCut)
+
+//____________________________________________________________________________
+AliReducedCaloClusterCut::AliReducedCaloClusterCut() :
+  AliReducedVarCut(),
+  fDoTrackMatch(kFALSE),
+  fMaxDistanceTrackMatch(-999.)
+{
+  //
+  // default constructor
+  //
+}
+
+//____________________________________________________________________________
+AliReducedCaloClusterCut::AliReducedCaloClusterCut(const Char_t* name, const Char_t* title) :
+  AliReducedVarCut(name, title),
+  fDoTrackMatch(kFALSE),
+  fMaxDistanceTrackMatch(-999.)
+{
+  //
+  // named constructor
+  //
+}
+
+//____________________________________________________________________________
+AliReducedCaloClusterCut::~AliReducedCaloClusterCut() {
+  //
+  // destructor
+  //
+}
+
+//____________________________________________________________________________
+Bool_t AliReducedCaloClusterCut::IsSelected(TObject* obj) {
+  //
+  // apply cuts
+  //
+  if(!obj->InheritsFrom(AliReducedCaloClusterInfo::Class())) return kFALSE;
+  
+  //Fill values
+  Float_t values[AliReducedVarManager::kNVars];
+  AliReducedVarManager::FillCaloClusterInfo((AliReducedCaloClusterInfo*)obj, values);
+  
+  return IsSelected(obj, values);
+}
+
+//____________________________________________________________________________
+Bool_t AliReducedCaloClusterCut::IsSelected(TObject* obj, Float_t* values) {
+  //
+  // apply cuts
+  //
+  if(!obj->InheritsFrom(AliReducedCaloClusterInfo::Class())) return kFALSE;
+  
+  // selection based on track match
+  // NOTE: not sure about the distance cut, also could probably do something more sophisticated
+  if (fDoTrackMatch) {
+    Short_t nMatchedTracks = ((AliReducedCaloClusterInfo*)obj)->NMatchedTracks();
+    if (nMatchedTracks<1) return kFALSE;
+    Float_t deltaPhi = ((AliReducedCaloClusterInfo*)obj)->Dx();
+    Float_t deltaEta = ((AliReducedCaloClusterInfo*)obj)->Dz();
+    Float_t distance = TMath::Sqrt(deltaPhi*deltaPhi + deltaEta*deltaEta);
+    if (distance>fMaxDistanceTrackMatch) return kFALSE;
+  }
+  
+  return AliReducedVarCut::IsSelected(values);
+}

--- a/PWGDQ/reducedTree/AliReducedCaloClusterCut.h
+++ b/PWGDQ/reducedTree/AliReducedCaloClusterCut.h
@@ -1,0 +1,38 @@
+// Class for cutting on ALICE Var manager and other cluster specific information
+// Author: Lucas Altenkamper (lucas.altenkamper@cern.ch)
+//   13/04/2019
+
+#ifndef ALIREDUCEDCALOCLUSTERCUT_H
+#define ALIREDUCEDCALOCLUSTERCUT_H
+
+#include "AliReducedVarCut.h"
+
+//_________________________________________________________________________
+class AliReducedCaloClusterCut : public AliReducedVarCut {
+
+public:
+  AliReducedCaloClusterCut();
+  AliReducedCaloClusterCut(const Char_t* name, const Char_t* title);
+  virtual ~AliReducedCaloClusterCut();
+
+  // setters
+  void SetMaxTrackMatchDistance(Float_t maxDist) {fDoTrackMatch=kTRUE; fMaxDistanceTrackMatch=maxDist;}
+  
+  // getters
+  Float_t GetMaxTrackMatchDistance() const {return fMaxDistanceTrackMatch;}
+
+  virtual Bool_t IsSelected(TObject* obj);
+  virtual Bool_t IsSelected(TObject* obj, Float_t* values);
+  
+protected:
+  
+  Bool_t  fDoTrackMatch;            // if true, cluster w/o track match within defined distance are rejected
+  Float_t fMaxDistanceTrackMatch;   // max distance for cluster-track matching
+  
+  AliReducedCaloClusterCut(const AliReducedCaloClusterCut &c);
+  AliReducedCaloClusterCut& operator= (const AliReducedCaloClusterCut &c);
+  
+  ClassDef(AliReducedCaloClusterCut, 1);
+};
+
+#endif

--- a/PWGDQ/reducedTree/AliReducedCaloClusterInfo.cxx
+++ b/PWGDQ/reducedTree/AliReducedCaloClusterInfo.cxx
@@ -14,6 +14,7 @@ ClassImp(AliReducedCaloClusterInfo)
 
 //_____________________________________________________________________________
 AliReducedCaloClusterInfo::AliReducedCaloClusterInfo() :
+ fFlags(0),
  fClusterID(-999),
  fType(kUndefined),
  fEnergy(-999.),

--- a/PWGDQ/reducedTree/AliReducedCaloClusterInfo.cxx
+++ b/PWGDQ/reducedTree/AliReducedCaloClusterInfo.cxx
@@ -14,6 +14,7 @@ ClassImp(AliReducedCaloClusterInfo)
 
 //_____________________________________________________________________________
 AliReducedCaloClusterInfo::AliReducedCaloClusterInfo() :
+ fClusterID(-999),
  fType(kUndefined),
  fEnergy(-999.),
  fTrackDx(-999.),
@@ -23,7 +24,8 @@ AliReducedCaloClusterInfo::AliReducedCaloClusterInfo() :
  fDispersion(-999.),
  fPosition(),
  fTOF(-999.),
- fNCells(0)
+ fNCells(0),
+ fNMatchedTracks(0)
 {
   //
   // default constructor

--- a/PWGDQ/reducedTree/AliReducedCaloClusterInfo.h
+++ b/PWGDQ/reducedTree/AliReducedCaloClusterInfo.h
@@ -19,7 +19,8 @@ class AliReducedCaloClusterInfo : public TObject {
    
   AliReducedCaloClusterInfo();
   virtual ~AliReducedCaloClusterInfo();
-  
+
+  Int_t   ClusterID()  const {return fClusterID;}
   Bool_t  IsEMCAL()    const {return (fType==kEMCAL ? kTRUE : kFALSE);}
   Bool_t  IsPHOS()     const {return (fType==kPHOS ? kTRUE : kFALSE);}
   Float_t Energy()     const {return fEnergy;}
@@ -33,8 +34,10 @@ class AliReducedCaloClusterInfo : public TObject {
   Float_t Z()          const {return fPosition[2];}
   Float_t TOF()        const {return fTOF;}
   Short_t NCells()     const {return fNCells;}
-  
+  Short_t NMatchedTracks() const {return fNMatchedTracks;}
+
  protected:
+  Int_t   fClusterID;    // calo cluster ID
   Char_t  fType;         // cluster type (EMCAL/PHOS)
   Float_t fEnergy;       // cluster energy
   Float_t fTrackDx;      // distance to closest track in phi
@@ -45,12 +48,13 @@ class AliReducedCaloClusterInfo : public TObject {
   Float_t fPosition[3];  // cluster position
   Float_t fTOF;          // time of flight
   Short_t fNCells;       // number of cells
+  Short_t fNMatchedTracks;  // number of matched tracks
   //---------------------------------------------------
   
   AliReducedCaloClusterInfo(const AliReducedCaloClusterInfo &c);
   AliReducedCaloClusterInfo& operator= (const AliReducedCaloClusterInfo &c);
 
-  ClassDef(AliReducedCaloClusterInfo, 1);
+  ClassDef(AliReducedCaloClusterInfo, 2);
 };
 
 #endif

--- a/PWGDQ/reducedTree/AliReducedCaloClusterInfo.h
+++ b/PWGDQ/reducedTree/AliReducedCaloClusterInfo.h
@@ -20,6 +20,8 @@ class AliReducedCaloClusterInfo : public TObject {
   AliReducedCaloClusterInfo();
   virtual ~AliReducedCaloClusterInfo();
 
+  Bool_t  TestFlag(UShort_t iflag)  const {return ((iflag<(8*sizeof(ULong_t))) ? fFlags&(ULong_t(1)<<iflag) : kFALSE);}
+  ULong_t GetFlags()                const {return fFlags;}
   Int_t   ClusterID()  const {return fClusterID;}
   Bool_t  IsEMCAL()    const {return (fType==kEMCAL ? kTRUE : kFALSE);}
   Bool_t  IsPHOS()     const {return (fType==kPHOS ? kTRUE : kFALSE);}
@@ -36,7 +38,14 @@ class AliReducedCaloClusterInfo : public TObject {
   Short_t NCells()     const {return fNCells;}
   Short_t NMatchedTracks() const {return fNMatchedTracks;}
 
+  // setters
+  void   ResetFlags() {fFlags=0;}
+  void   SetFlags(ULong_t flags) {fFlags=flags;}
+  Bool_t SetFlag(UShort_t iflag)  {if(iflag>=8*sizeof(ULong_t)) return kFALSE; fFlags|=(ULong_t(1)<<iflag); return kTRUE;}
+  Bool_t UnsetFlag(UShort_t iflag) {if(iflag>=8*sizeof(ULong_t)) return kFALSE; if(TestFlag(iflag)) fFlags^=(ULong_t(1)<<iflag); return kTRUE;}
+
  protected:
+  ULong_t fFlags;        // flags reserved for various operations
   Int_t   fClusterID;    // calo cluster ID
   Char_t  fType;         // cluster type (EMCAL/PHOS)
   Float_t fEnergy;       // cluster energy
@@ -54,7 +63,7 @@ class AliReducedCaloClusterInfo : public TObject {
   AliReducedCaloClusterInfo(const AliReducedCaloClusterInfo &c);
   AliReducedCaloClusterInfo& operator= (const AliReducedCaloClusterInfo &c);
 
-  ClassDef(AliReducedCaloClusterInfo, 2);
+  ClassDef(AliReducedCaloClusterInfo, 3);
 };
 
 #endif

--- a/PWGDQ/reducedTree/AliReducedEventInfo.cxx
+++ b/PWGDQ/reducedTree/AliReducedEventInfo.cxx
@@ -337,6 +337,19 @@ void AliReducedEventInfo::ClearEvent() {
 }
 
 //_______________________________________________________________________________
+AliReducedCaloClusterInfo* AliReducedEventInfo::GetCaloClusterFromID(Int_t clusterID) const {
+  //
+  // get calorimeter cluster from ID
+  //
+  AliReducedCaloClusterInfo* cluster = NULL;
+  for (Int_t i=0; i<fNCaloClusters; ++i) {
+    cluster = (AliReducedCaloClusterInfo*)fCaloClusters->At(i);
+    if (clusterID==cluster->ClusterID()) return cluster;
+  }
+  return NULL;
+}
+
+//_______________________________________________________________________________
 void AliReducedEventInfo::GetQvector(Double_t Qvec[][2], Int_t det,
                                  Float_t etaMin/*=-0.8*/, Float_t etaMax/*=+0.8*/,
 				 Bool_t (*IsTrackSelected)(AliReducedTrackInfo*)/*=NULL*/) {

--- a/PWGDQ/reducedTree/AliReducedEventInfo.h
+++ b/PWGDQ/reducedTree/AliReducedEventInfo.h
@@ -137,6 +137,7 @@ class AliReducedEventInfo : public AliReducedBaseEvent {
   Int_t GetNCaloClusters() const {return fNCaloClusters;}
   AliReducedCaloClusterInfo* GetCaloCluster(Int_t i) const 
     {return (i>=0 && i<fNCaloClusters ? (AliReducedCaloClusterInfo*)fCaloClusters->At(i) : 0x0);}
+  AliReducedCaloClusterInfo* GetCaloClusterFromID(Int_t clusterID) const;
   
   void  GetQvector(Double_t Qvec[][2], Int_t det, Float_t etaMin=-0.8, Float_t etaMax=+0.8, Bool_t (*IsTrackSelected)(AliReducedTrackInfo*)=NULL);
   Int_t GetTPCQvector(Double_t Qvec[][2], Int_t det, Float_t etaMin=-0.8, Float_t etaMax=+0.8, Bool_t (*IsTrackSelected)(AliReducedTrackInfo*)=NULL);

--- a/PWGDQ/reducedTree/AliReducedVarManager.cxx
+++ b/PWGDQ/reducedTree/AliReducedVarManager.cxx
@@ -3178,7 +3178,9 @@ void AliReducedVarManager::SetDefaultVarNames() {
   fgVariableNames[kEMCALdetector]         = "Calo detector";           fgVariableUnits[kEMCALdetector] = "";  
   fgVariableNames[kEMCALm20]              = "Cluster short axis M20";  fgVariableUnits[kEMCALm20] = "";  
   fgVariableNames[kEMCALm02]              = "Cluster short axis M02";  fgVariableUnits[kEMCALm02] = "";  
-  fgVariableNames[kEMCALdispersion]       = "Cluster dispersion";      fgVariableUnits[kEMCALdispersion] = "";  
+  fgVariableNames[kEMCALdispersion]       = "Cluster dispersion";      fgVariableUnits[kEMCALdispersion] = "";
+  fgVariableNames[kEMCALnCells]           = "Cluster No. cells";       fgVariableUnits[kEMCALnCells] = "";
+  fgVariableNames[kEMCALnMatchedTracks]   = "Cluster No. matched tracks"; fgVariableUnits[kEMCALnMatchedTracks] = "";
   fgVariableNames[kTrackingFlag] = "Tracking flag";  fgVariableUnits[kTrackingFlag] = "";  
   fgVariableNames[kTrackingStatus] = "Tracking status";  fgVariableUnits[kTrackingStatus] = "";  
   fgVariableNames[kDeltaPhi]              = "#Delta #varphi";             fgVariableUnits[kDeltaPhi]              = "rad.";

--- a/PWGDQ/reducedTree/AliReducedVarManager.cxx
+++ b/PWGDQ/reducedTree/AliReducedVarManager.cxx
@@ -1735,13 +1735,13 @@ void AliReducedVarManager::FillTrackInfo(BASETRACK* p, Float_t* values) {
     values[kEMCALmatchedClusterId] = pinfo->CaloClusterId();
     if(fgEvent && (fgEvent->IsA()==EVENT::Class())){
       CLUSTER* cluster = ((EVENT*)fgEvent)->GetCaloCluster(pinfo->CaloClusterId());
-      values[kEMCALmatchedEnergy] = (cluster ? cluster->Energy() : -999.0);
-      values[kEMCALmatchedM02]    = (cluster ? cluster->M02() : -999.0);
-      values[kEMCALmatchedM20]    = (cluster ? cluster->M20() : -999.0);
+      values[kEMCALmatchedEnergy] = (cluster ? cluster->Energy() : -9999.);
+      values[kEMCALmatchedM02]    = (cluster ? cluster->M02() : -9999.);
+      values[kEMCALmatchedM20]    = (cluster ? cluster->M20() : -9999.);
       Float_t               mom = 0.0;
       if (pinfo->PonCalo()) mom = pinfo->PonCalo();
       else                  mom = pinfo->P();
-      values[kEMCALmatchedEOverP] = (TMath::Abs(mom)>1.e-8 && cluster ? values[kEMCALmatchedEnergy]/mom : -999.0);
+      values[kEMCALmatchedEOverP] = (TMath::Abs(mom)>1.e-8 && cluster ? values[kEMCALmatchedEnergy]/mom : -9999.);
     }
   }  
 

--- a/PWGDQ/reducedTree/AliReducedVarManager.cxx
+++ b/PWGDQ/reducedTree/AliReducedVarManager.cxx
@@ -1734,7 +1734,7 @@ void AliReducedVarManager::FillTrackInfo(BASETRACK* p, Float_t* values) {
   if(fgUsedVars[kEMCALmatchedEnergy] || fgUsedVars[kEMCALmatchedEOverP] || fgUsedVars[kEMCALmatchedM02] || fgUsedVars[kEMCALmatchedM20]) {
     values[kEMCALmatchedClusterId] = pinfo->CaloClusterId();
     if(fgEvent && (fgEvent->IsA()==EVENT::Class())){
-      CLUSTER* cluster = ((EVENT*)fgEvent)->GetCaloCluster(pinfo->CaloClusterId());
+      CLUSTER* cluster = ((EVENT*)fgEvent)->GetCaloClusterFromID(pinfo->CaloClusterId());
       values[kEMCALmatchedEnergy] = (cluster ? cluster->Energy() : -9999.);
       values[kEMCALmatchedM02]    = (cluster ? cluster->M02() : -9999.);
       values[kEMCALmatchedM20]    = (cluster ? cluster->M20() : -9999.);

--- a/PWGDQ/reducedTree/AliReducedVarManager.cxx
+++ b/PWGDQ/reducedTree/AliReducedVarManager.cxx
@@ -1785,6 +1785,8 @@ void AliReducedVarManager::FillCaloClusterInfo(CLUSTER* cl, Float_t* values) {
   values[kEMCALm02] = cl->M02();
   values[kEMCALm20] = cl->M20();
   values[kEMCALdispersion] = cl->Dispersion();
+  values[kEMCALnCells] = cl->NCells();
+  values[kEMCALnMatchedTracks] = cl->NMatchedTracks();
 }
 
 //_________________________________________________________________

--- a/PWGDQ/reducedTree/AliReducedVarManager.h
+++ b/PWGDQ/reducedTree/AliReducedVarManager.h
@@ -614,6 +614,8 @@ class AliReducedVarManager : public TObject {
     kEMCALm20,
     kEMCALm02,
     kEMCALdispersion,
+    kEMCALnCells,
+    kEMCALnMatchedTracks,
     // Track flags -----------------------------------------------------
     kTrackingFlag,
     kTrackQualityFlag,
@@ -807,7 +809,7 @@ class AliReducedVarManager : public TObject {
   AliReducedVarManager(AliReducedVarManager const&);
   AliReducedVarManager& operator=(AliReducedVarManager const&);  
   
-  ClassDef(AliReducedVarManager, 8);
+  ClassDef(AliReducedVarManager, 9);
 };
 
 #endif

--- a/PWGDQ/reducedTree/CMakeLists.txt
+++ b/PWGDQ/reducedTree/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SRCS
       AliReducedBaseEvent.cxx
       AliReducedBaseTrackCut.cxx
       AliReducedBaseTrack.cxx
+      AliReducedCaloClusterCut.cxx
       AliReducedCaloClusterInfo.cxx
       AliReducedCompositeCut.cxx
       AliReducedEventCut.cxx

--- a/PWGDQ/reducedTree/PWGDQreducedTreeLinkDef.h
+++ b/PWGDQ/reducedTree/PWGDQreducedTreeLinkDef.h
@@ -21,6 +21,7 @@
 #pragma link C++ class AliReducedBaseEvent+;
 #pragma link C++ class AliReducedBaseTrackCut+;
 #pragma link C++ class AliReducedBaseTrack+;
+#pragma link C++ class AliReducedCaloClusterCut+;
 #pragma link C++ class AliReducedCaloClusterInfo+;
 #pragma link C++ class AliReducedCompositeCut+;
 #pragma link C++ class AliReducedEventCut+;


### PR DESCRIPTION
- introduced calorimeter cluster cut classes to dielectron and reducedTree frameworks
- added possibility to select on cluster-track matches in  dielectron/core/AliDielectronTrackCuts
- added possibility to select on calorimeter clusters in AliAnalysisTaskReducedTreeMaker
- updated AliReducedAnalysisSingleTrack with calorimeter cluster selection and histograms