### PR TITLE
 Implement method to set NsigmaTPC correction for LHC18qr

### DIFF
--- a/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
+++ b/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
@@ -194,7 +194,9 @@ fFillZLeading(false),
 fFillRadialMoment(false),
 fFillpTD(false),
 fFillMass(false),
-fFillMatchingJetID(false)
+fFillMatchingJetID(false),
+fEnableNsigmaTPCDataCorr(false),
+fSystemForNsigmaTPCDataCorr(AliHFTreeHandler::kNone)
 {
 
 /// Default constructor
@@ -311,7 +313,9 @@ fFillZLeading(false),
 fFillRadialMoment(false),
 fFillpTD(false),
 fFillMass(false),
-fFillMatchingJetID(false)
+fFillMatchingJetID(false),
+fEnableNsigmaTPCDataCorr(false),
+fSystemForNsigmaTPCDataCorr(AliHFTreeHandler::kNone)
 {
     /// Standard constructor
   
@@ -721,6 +725,7 @@ void AliAnalysisTaskSEHFTreeCreator::UserCreateOutputObjects()
         fTreeHandlerD0 = new AliHFTreeHandlerD0toKpi(fPIDoptD0);
         fTreeHandlerD0->SetOptSingleTrackVars(fTreeSingleTrackVarsOpt);
         if(fReadMC && fWriteOnlySignal) fTreeHandlerD0->SetFillOnlySignal(fWriteOnlySignal);
+        if(fEnableNsigmaTPCDataCorr) fTreeHandlerD0->EnableNsigmaTPCDataDrivenCorrection(fSystemForNsigmaTPCDataCorr);
         fVariablesTreeD0 = (TTree*)fTreeHandlerD0->BuildTree(nameoutput,nameoutput);
         fVariablesTreeD0->SetMaxVirtualSize(1.e+8/nEnabledTrees);
         fTreeEvChar->AddFriend(fVariablesTreeD0);
@@ -740,6 +745,7 @@ void AliAnalysisTaskSEHFTreeCreator::UserCreateOutputObjects()
         fTreeHandlerDs = new AliHFTreeHandlerDstoKKpi(fPIDoptDs);
         fTreeHandlerDs->SetOptSingleTrackVars(fTreeSingleTrackVarsOpt);
         if(fReadMC && fWriteOnlySignal) fTreeHandlerDs->SetFillOnlySignal(fWriteOnlySignal);
+        if(fEnableNsigmaTPCDataCorr) fTreeHandlerDs->EnableNsigmaTPCDataDrivenCorrection(fSystemForNsigmaTPCDataCorr);
         fTreeHandlerDs->SetMassKKOption(fDsMassKKOpt);
         fVariablesTreeDs = (TTree*)fTreeHandlerDs->BuildTree(nameoutput,nameoutput);
         fVariablesTreeDs->SetMaxVirtualSize(1.e+8/nEnabledTrees);
@@ -760,6 +766,7 @@ void AliAnalysisTaskSEHFTreeCreator::UserCreateOutputObjects()
         fTreeHandlerDplus = new AliHFTreeHandlerDplustoKpipi(fPIDoptDplus);
         fTreeHandlerDplus->SetOptSingleTrackVars(fTreeSingleTrackVarsOpt);
         if(fReadMC && fWriteOnlySignal) fTreeHandlerDplus->SetFillOnlySignal(fWriteOnlySignal);
+        if(fEnableNsigmaTPCDataCorr) fTreeHandlerDplus->EnableNsigmaTPCDataDrivenCorrection(fSystemForNsigmaTPCDataCorr);
         fVariablesTreeDplus = (TTree*)fTreeHandlerDplus->BuildTree(nameoutput,nameoutput);
         fVariablesTreeDplus->SetMaxVirtualSize(1.e+8/nEnabledTrees);
         fTreeEvChar->AddFriend(fVariablesTreeDplus);
@@ -778,6 +785,7 @@ void AliAnalysisTaskSEHFTreeCreator::UserCreateOutputObjects()
         fTreeHandlerLctopKpi = new AliHFTreeHandlerLctopKpi(fPIDoptLctopKpi);
         fTreeHandlerLctopKpi->SetOptSingleTrackVars(fTreeSingleTrackVarsOpt);
         if(fReadMC && fWriteOnlySignal) fTreeHandlerLctopKpi->SetFillOnlySignal(fWriteOnlySignal);
+        if(fEnableNsigmaTPCDataCorr) fTreeHandlerLctopKpi->EnableNsigmaTPCDataDrivenCorrection(fSystemForNsigmaTPCDataCorr);
         fVariablesTreeLctopKpi = (TTree*)fTreeHandlerLctopKpi->BuildTree(nameoutput,nameoutput);
         fVariablesTreeLctopKpi->SetMaxVirtualSize(1.e+8/nEnabledTrees);
         fTreeEvChar->AddFriend(fVariablesTreeLctopKpi);
@@ -796,6 +804,7 @@ void AliAnalysisTaskSEHFTreeCreator::UserCreateOutputObjects()
         fTreeHandlerBplus = new AliHFTreeHandlerBplustoD0pi(fPIDoptBplus);
         fTreeHandlerBplus->SetOptSingleTrackVars(fTreeSingleTrackVarsOpt);
         if(fReadMC && fWriteOnlySignal) fTreeHandlerBplus->SetFillOnlySignal(fWriteOnlySignal);
+        if(fEnableNsigmaTPCDataCorr) fTreeHandlerBplus->EnableNsigmaTPCDataDrivenCorrection(fSystemForNsigmaTPCDataCorr);
         fVariablesTreeBplus = (TTree*)fTreeHandlerBplus->BuildTree(nameoutput,nameoutput);
         fVariablesTreeBplus->SetMaxVirtualSize(1.e+8/nEnabledTrees);
         fTreeEvChar->AddFriend(fVariablesTreeBplus);
@@ -814,6 +823,7 @@ void AliAnalysisTaskSEHFTreeCreator::UserCreateOutputObjects()
         fTreeHandlerDstar = new AliHFTreeHandlerDstartoKpipi(fPIDoptDstar);
         fTreeHandlerDstar->SetOptSingleTrackVars(fTreeSingleTrackVarsOpt);
         if(fReadMC && fWriteOnlySignal) fTreeHandlerDstar->SetFillOnlySignal(fWriteOnlySignal);
+        if(fEnableNsigmaTPCDataCorr) fTreeHandlerDstar->EnableNsigmaTPCDataDrivenCorrection(fSystemForNsigmaTPCDataCorr);
         fVariablesTreeDstar = (TTree*)fTreeHandlerDstar->BuildTree(nameoutput,nameoutput);
         fVariablesTreeDstar->SetMaxVirtualSize(1.e+8/nEnabledTrees);
         fTreeEvChar->AddFriend(fVariablesTreeDstar);
@@ -832,6 +842,7 @@ void AliAnalysisTaskSEHFTreeCreator::UserCreateOutputObjects()
         fTreeHandlerLc2V0bachelor = new AliHFTreeHandlerLc2V0bachelor(fPIDoptLc2V0bachelor);
         fTreeHandlerLc2V0bachelor->SetOptSingleTrackVars(fTreeSingleTrackVarsOpt);
         if(fReadMC && fWriteOnlySignal) fTreeHandlerLc2V0bachelor->SetFillOnlySignal(fWriteOnlySignal);
+        if(fEnableNsigmaTPCDataCorr) fTreeHandlerLc2V0bachelor->EnableNsigmaTPCDataDrivenCorrection(fSystemForNsigmaTPCDataCorr);
         fTreeHandlerLc2V0bachelor->SetCalcSecoVtx(fLc2V0bachelorCalcSecoVtx);
         fVariablesTreeLc2V0bachelor = (TTree*)fTreeHandlerLc2V0bachelor->BuildTree(nameoutput,nameoutput);
         fVariablesTreeLc2V0bachelor->SetMaxVirtualSize(1.e+8/nEnabledTrees);

--- a/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
+++ b/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
@@ -77,6 +77,7 @@
 #include "AliEmcalJet.h"
 #include "AliRhoParameter.h"
 #include "AliAnalysisTaskSEHFTreeCreator.h"
+#include "AliAODPidHF.h"
 
 using std::cout;
 using std::endl;
@@ -196,7 +197,7 @@ fFillpTD(false),
 fFillMass(false),
 fFillMatchingJetID(false),
 fEnableNsigmaTPCDataCorr(false),
-fSystemForNsigmaTPCDataCorr(AliHFTreeHandler::kNone)
+fSystemForNsigmaTPCDataCorr(AliAODPidHF::kNone)
 {
 
 /// Default constructor
@@ -315,7 +316,7 @@ fFillpTD(false),
 fFillMass(false),
 fFillMatchingJetID(false),
 fEnableNsigmaTPCDataCorr(false),
-fSystemForNsigmaTPCDataCorr(AliHFTreeHandler::kNone)
+fSystemForNsigmaTPCDataCorr(AliAODPidHF::kNone)
 {
     /// Standard constructor
   

--- a/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.h
+++ b/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.h
@@ -125,6 +125,11 @@ public:
     Bool_t CheckDaugAcc(TClonesArray* arrayMC,Int_t nProng, Int_t *labDau);
     AliAODVertex* ReconstructBplusVertex(const AliVVertex *primary, TObjArray *tracks, Double_t bField, Double_t dispersion);
   
+    void SetNsigmaTPCDataDrivenCorrection(Int_t syst) {
+        fEnableNsigmaTPCDataCorr=true; 
+        fSystemForNsigmaTPCDataCorr=syst; 
+    }
+
     // Jets
     //-----------------------------------------------------------------------------------------------
     void SetFillNJetTrees(Int_t n){fWriteNJetTrees=n;}
@@ -286,8 +291,11 @@ private:
     bool                    fFillMass;                             ///< Mass
     bool                    fFillMatchingJetID;                    ///< jet matching
   
+    bool fEnableNsigmaTPCDataCorr; /// flag to enable data-driven NsigmaTPC correction
+    int fSystemForNsigmaTPCDataCorr; /// system for data-driven NsigmaTPC correction
+
     /// \cond CLASSIMP
-    ClassDef(AliAnalysisTaskSEHFTreeCreator,12);
+    ClassDef(AliAnalysisTaskSEHFTreeCreator,13);
     /// \endcond
 };
 

--- a/PWGHF/treeHF/AliHFTreeHandler.cxx
+++ b/PWGHF/treeHF/AliHFTreeHandler.cxx
@@ -27,6 +27,7 @@
 #include "AliPIDResponse.h"
 #include "AliESDtrack.h"
 #include "TMath.h"
+#include "AliAODPidHF.h"
 
 using std::array;
 
@@ -61,7 +62,7 @@ AliHFTreeHandler::AliHFTreeHandler():
   fRunNumber(9999),
   fRunNumberPrevCand(9999),
   fApplyNsigmaTPCDataCorr(false),
-  fSystNsigmaTPCDataCorr(kNone),
+  fSystNsigmaTPCDataCorr(AliAODPidHF::kNone),
   fMeanNsigmaTPCPionData{},
   fMeanNsigmaTPCKaonData{},
   fMeanNsigmaTPCProtonData{},
@@ -97,6 +98,17 @@ AliHFTreeHandler::AliHFTreeHandler():
       }
     }
   }
+
+  for(int iP=0; iP<100; iP++) {
+    fMeanNsigmaTPCPionData[iP] = 0.;
+    fMeanNsigmaTPCKaonData[iP] = 0.;
+    fMeanNsigmaTPCProtonData[iP] = 0.;
+    fSigmaNsigmaTPCPionData[iP] = 1.;
+    fSigmaNsigmaTPCKaonData[iP] = 1.;
+    fSigmaNsigmaTPCProtonData[iP] = 1.;
+    fPlimitsNsigmaTPCDataCorr[iP] = 0.;
+  }
+  fPlimitsNsigmaTPCDataCorr[100] = 0.;
 }
 
 //________________________________________________________________
@@ -126,7 +138,7 @@ AliHFTreeHandler::AliHFTreeHandler(int PIDopt):
   fRunNumber(9999),
   fRunNumberPrevCand(9999),
   fApplyNsigmaTPCDataCorr(false),
-  fSystNsigmaTPCDataCorr(kNone),
+  fSystNsigmaTPCDataCorr(AliAODPidHF::kNone),
   fMeanNsigmaTPCPionData{},
   fMeanNsigmaTPCKaonData{},
   fMeanNsigmaTPCProtonData{},
@@ -389,7 +401,7 @@ bool AliHFTreeHandler::SetPidVars(AliAODTrack* prongtracks[], AliPIDResponse* pi
         if(useHypo[iPartHypo]) {
           if(useTPC) {
           float nSigmaTPC = pidrespo->NumberOfSigmasTPC(prongtracks[iProng],parthypo[iPartHypo]);
-            if(fApplyNsigmaTPCDataCorr) {
+            if(fApplyNsigmaTPCDataCorr && nSigmaTPC>-990.) {
               float sigma=1., mean=0.;
               GetNsigmaTPCMeanSigmaData(mean, sigma, parthypo[iPartHypo], prongtracks[iProng]->GetTPCmomentum());
               nSigmaTPC = (nSigmaTPC-mean)/sigma;
@@ -572,100 +584,10 @@ float AliHFTreeHandler::GetTOFmomentum(AliAODTrack* track, AliPIDResponse* pidre
 }
 
 //________________________________________________________________
-void AliHFTreeHandler::SetNsigmaTPCDataCorr() {
-  
-    if(fRunNumber>=295585 && fRunNumber<=296623 && fSystNsigmaTPCDataCorr==kPbPb010) { //LHC18q 0-10%
-    fNPbinsNsigmaTPCDataCorr = 8;
-    array<float,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
-    array<float,8> meanPion = {-0.476642, -0.611512, -0.70491, -0.785863, -0.858335, -0.913384, -0.926733, -1.03424};
-    array<float,8> meanKaon = {-0.376284, -0.689586, -0.752243, -0.922438, -0.95792, -0.958785, -1.00629, -1.10473};
-    array<float,8> meanProton = {-0.162057, -0.222369, -0.517459, -0.874908, -0.961924, -1.01193, -0.839815, -0.691694};
-    array<float,8> sigmaPion = {0.98579, 0.962247, 0.945548, 0.920657, 0.909255, 0.957158, 0.907777, 0.954516};
-    array<float,8> sigmaKaon = {0.851531, 0.909522, 0.96582, 0.900314, 0.887377, 0.880861, 0.848008, 0.916044};
-    array<float,8> sigmaProton = {0.748482, 0.79806, 0.852967, 0.979616, 0.997911, 0.860067, 0.883535, 0.929892};
-    std::copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
-    std::copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
-    std::copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
-    std::copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
-    std::copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
-    std::copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
-    std::copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
-  }
-  else if(fRunNumber>=295585 && fRunNumber<=296623 && fSystNsigmaTPCDataCorr==kPbPb3050) { //LHC18q 30-50%
-    fNPbinsNsigmaTPCDataCorr = 8;
-    array<float,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
-    array<float,8> meanPion = {-0.282783, -0.351074, -0.370549, -0.368398, -0.37546, -0.332551, -0.304001, -0.329724};
-    array<float,8> meanKaon = {-0.147986, -0.26169, -0.339263, -0.566137, -0.619671, -0.586758, -0.430222, -0.243858};
-    array<float,8> meanProton = {-0.116342, -0.204619, -0.18317, -0.288015, -0.431383, -0.496598, -0.476154, -0.464085};
-    array<float,8> sigmaPion = {1.15354, 1.1191, 1.11418, 1.11474, 1.11121, 1.10621, 1.05918, 1.05666};
-    array<float,8> sigmaKaon = {1.07676, 1.11978, 1.14182, 1.09804, 1.09674, 1.08182, 1.07091, 1.00419};
-    array<float,8> sigmaProton = {1.07493, 1.11953, 1.14044, 1.14904, 1.12158, 1.09405, 1.06465, 1.11152};
-    std::copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
-    std::copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
-    std::copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
-    std::copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
-    std::copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
-    std::copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
-    std::copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
-  }
-  else if(fRunNumber>296690 && fRunNumber<297595 && fSystNsigmaTPCDataCorr==kPbPb010) { //LHC18r 0-10%
-    fNPbinsNsigmaTPCDataCorr = 8;
-    array<float,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
-    array<float,8> meanPion = {-0.4669, -0.651889, -0.731293, -0.750849, -0.767918, -0.769948, -0.729383, -0.7741};
-    array<float,8> meanKaon = {-0.420412, -0.656824, -0.728482, -0.99377, -1.11258, -1.04111, -1.05214, -0.778762};
-    array<float,8> meanProton = {-0.346431, -0.445263, -0.504456, -0.80259, -0.971442, -1.00859, -0.853291, -0.595747};
-    array<float,8> sigmaPion = {1.31686, 1.24606, 1.21786, 1.21274, 1.21565, 1.29167, 1.26293, 1.27201};
-    array<float,8> sigmaKaon = {1.1904, 1.27156, 1.27005, 1.15127, 1.09914, 1.12193, 1.07542, 1.27068};
-    array<float,8> sigmaProton = {1.10662, 1.18216, 1.25083, 1.3166, 1.25666, 1.12755, 1.12149, 1.20881};
-    std::copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
-    std::copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
-    std::copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
-    std::copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
-    std::copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
-    std::copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
-    std::copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
-  }
-  else if(fRunNumber>296690 && fRunNumber<297595 && fSystNsigmaTPCDataCorr==kPbPb3050) { //LHC18r 30-50%
-    fNPbinsNsigmaTPCDataCorr = 8;
-    array<float,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
-    array<float,8> meanPion = {-0.298388, -0.342664, -0.396873, -0.462451, -0.538392, -0.58011, -0.612805, -0.642393};
-    array<float,8> meanKaon = {-0.152114, -0.00548698, -0.425063, -0.546696, -0.530307, -0.599359, -0.605992, -0.774291};
-    array<float,8> meanProton = {-0.0368995, -0.0849347, -0.30911, -0.479177, -0.584153, -0.578737, -0.568087, -0.489077};
-    array<float,8> sigmaPion = {0.878966, 0.88176, 0.883022, 0.873402, 0.859262, 0.847664, 0.828672, 0.800194};
-    array<float,8> sigmaKaon = {0.775762, 1.00624, 0.886505, 0.885096, 0.91232, 0.867032, 0.833827, 0.987321};
-    array<float,8> sigmaProton = {0.751132, 0.788041, 0.81738, 0.862206, 0.876342, 0.863609, 0.825849, 0.937087};
-    std::copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
-    std::copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
-    std::copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
-    std::copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
-    std::copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
-    std::copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
-    std::copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
-  }
-  else { //default: no correction applied
-    fNPbinsNsigmaTPCDataCorr = 1;
-    array<float,2> pTPClims = {0.,1000.};    
-    array<float,1> meanPion = {0.};
-    array<float,1> meanKaon = {0.};
-    array<float,1> meanProton = {0.};
-    array<float,1> sigmaPion = {1.};
-    array<float,1> sigmaKaon = {1.};
-    array<float,1> sigmaProton = {1.};
-    std::copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
-    std::copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
-    std::copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
-    std::copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
-    std::copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
-    std::copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
-    std::copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
-  }
-}
-
-//________________________________________________________________
 void AliHFTreeHandler::GetNsigmaTPCMeanSigmaData(float &mean, float &sigma, AliPID::EParticleType species, float pTPC) {
     
   if(fRunNumber!=fRunNumberPrevCand)
-    SetNsigmaTPCDataCorr();
+    AliAODPidHF::SetNsigmaTPCDataDrivenCorrection(fRunNumber, fSystNsigmaTPCDataCorr, fNPbinsNsigmaTPCDataCorr, fPlimitsNsigmaTPCDataCorr, fMeanNsigmaTPCPionData, fMeanNsigmaTPCKaonData, fMeanNsigmaTPCProtonData, fSigmaNsigmaTPCPionData, fSigmaNsigmaTPCKaonData, fSigmaNsigmaTPCProtonData);
 
   int bin = TMath::BinarySearch(fNPbinsNsigmaTPCDataCorr,fPlimitsNsigmaTPCDataCorr,pTPC);
   if(bin<0) bin=0; //underflow --> equal to min value

--- a/PWGHF/treeHF/AliHFTreeHandler.cxx
+++ b/PWGHF/treeHF/AliHFTreeHandler.cxx
@@ -20,11 +20,15 @@
 
 #include <cmath>
 #include <limits>
+#include <array>
 #include "AliHFTreeHandler.h"
 #include "AliPID.h"
 #include "AliAODRecoDecayHF.h"
 #include "AliPIDResponse.h"
 #include "AliESDtrack.h"
+#include "TMath.h"
+
+using std::array;
 
 /// \cond CLASSIMP
 ClassImp(AliHFTreeHandler);
@@ -54,7 +58,18 @@ AliHFTreeHandler::AliHFTreeHandler():
   fIsMCGenTree(false),
   fDauInAcceptance(false),
   fEvID(9999),
-  fRunNumber(9999)
+  fRunNumber(9999),
+  fRunNumberPrevCand(9999),
+  fApplyNsigmaTPCDataCorr(false),
+  fSystNsigmaTPCDataCorr(kNone),
+  fMeanNsigmaTPCPionData{},
+  fMeanNsigmaTPCKaonData{},
+  fMeanNsigmaTPCProtonData{},
+  fSigmaNsigmaTPCPionData{},
+  fSigmaNsigmaTPCKaonData{},
+  fSigmaNsigmaTPCProtonData{},
+  fPlimitsNsigmaTPCDataCorr{},
+  fNPbinsNsigmaTPCDataCorr(0)
 {
   //
   // Default constructor
@@ -108,7 +123,18 @@ AliHFTreeHandler::AliHFTreeHandler(int PIDopt):
   fIsMCGenTree(false),
   fDauInAcceptance(false),
   fEvID(9999),
-  fRunNumber(9999)
+  fRunNumber(9999),
+  fRunNumberPrevCand(9999),
+  fApplyNsigmaTPCDataCorr(false),
+  fSystNsigmaTPCDataCorr(kNone),
+  fMeanNsigmaTPCPionData{},
+  fMeanNsigmaTPCKaonData{},
+  fMeanNsigmaTPCProtonData{},
+  fSigmaNsigmaTPCPionData{},
+  fSigmaNsigmaTPCKaonData{},
+  fSigmaNsigmaTPCProtonData{},
+  fPlimitsNsigmaTPCDataCorr{},
+  fNPbinsNsigmaTPCDataCorr(0)
 {
   //
   // Standard constructor
@@ -361,7 +387,15 @@ bool AliHFTreeHandler::SetPidVars(AliAODTrack* prongtracks[], AliPIDResponse* pi
     if((fPidOpt>=kNsigmaPID && fPidOpt<=kNsigmaCombPIDfloatandint) || fPidOpt==kRawAndNsigmaPID) {
       for(unsigned int iPartHypo=0; iPartHypo<knMaxHypo4Pid; iPartHypo++) {
         if(useHypo[iPartHypo]) {
-          if(useTPC) sig[iProng][kTPC][iPartHypo] = pidrespo->NumberOfSigmasTPC(prongtracks[iProng],parthypo[iPartHypo]);
+          if(useTPC) {
+          float nSigmaTPC = pidrespo->NumberOfSigmasTPC(prongtracks[iProng],parthypo[iPartHypo]);
+            if(fApplyNsigmaTPCDataCorr) {
+              float sigma=1., mean=0.;
+              GetNsigmaTPCMeanSigmaData(mean, sigma, parthypo[iPartHypo], prongtracks[iProng]->GetTPCmomentum());
+              nSigmaTPC = (nSigmaTPC-mean)/sigma;
+            }
+            sig[iProng][kTPC][iPartHypo] = nSigmaTPC;
+          }
           if(useTOF) sig[iProng][kTOF][iPartHypo] = pidrespo->NumberOfSigmasTOF(prongtracks[iProng],parthypo[iPartHypo]);
           if(fPidOpt>=kNsigmaCombPID && fPidOpt<=kNsigmaCombPIDfloatandint) {
             sigComb[iProng][iPartHypo] = CombineNsigmaDiffDet(sig[iProng][kTPC][iPartHypo],sig[iProng][kTOF][iPartHypo]);
@@ -535,4 +569,132 @@ float AliHFTreeHandler::GetTOFmomentum(AliAODTrack* track, AliPIDResponse* pidre
 
   if(TMath::Abs(beta_d-1.) < 1.e-12) return track->GetTPCmomentum();
   else return mass*beta_d/sqrt(1.-(beta_d*beta_d));
+}
+
+//________________________________________________________________
+void AliHFTreeHandler::SetNsigmaTPCDataCorr() {
+  
+    if(fRunNumber>=295585 && fRunNumber<=296623 && fSystNsigmaTPCDataCorr==kPbPb010) { //LHC18q 0-10%
+    fNPbinsNsigmaTPCDataCorr = 8;
+    array<float,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
+    array<float,8> meanPion = {-0.476642, -0.611512, -0.70491, -0.785863, -0.858335, -0.913384, -0.926733, -1.03424};
+    array<float,8> meanKaon = {-0.376284, -0.689586, -0.752243, -0.922438, -0.95792, -0.958785, -1.00629, -1.10473};
+    array<float,8> meanProton = {-0.162057, -0.222369, -0.517459, -0.874908, -0.961924, -1.01193, -0.839815, -0.691694};
+    array<float,8> sigmaPion = {0.98579, 0.962247, 0.945548, 0.920657, 0.909255, 0.957158, 0.907777, 0.954516};
+    array<float,8> sigmaKaon = {0.851531, 0.909522, 0.96582, 0.900314, 0.887377, 0.880861, 0.848008, 0.916044};
+    array<float,8> sigmaProton = {0.748482, 0.79806, 0.852967, 0.979616, 0.997911, 0.860067, 0.883535, 0.929892};
+    std::copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
+    std::copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
+    std::copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
+    std::copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
+    std::copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
+    std::copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
+    std::copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
+  }
+  else if(fRunNumber>=295585 && fRunNumber<=296623 && fSystNsigmaTPCDataCorr==kPbPb3050) { //LHC18q 30-50%
+    fNPbinsNsigmaTPCDataCorr = 8;
+    array<float,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
+    array<float,8> meanPion = {-0.282783, -0.351074, -0.370549, -0.368398, -0.37546, -0.332551, -0.304001, -0.329724};
+    array<float,8> meanKaon = {-0.147986, -0.26169, -0.339263, -0.566137, -0.619671, -0.586758, -0.430222, -0.243858};
+    array<float,8> meanProton = {-0.116342, -0.204619, -0.18317, -0.288015, -0.431383, -0.496598, -0.476154, -0.464085};
+    array<float,8> sigmaPion = {1.15354, 1.1191, 1.11418, 1.11474, 1.11121, 1.10621, 1.05918, 1.05666};
+    array<float,8> sigmaKaon = {1.07676, 1.11978, 1.14182, 1.09804, 1.09674, 1.08182, 1.07091, 1.00419};
+    array<float,8> sigmaProton = {1.07493, 1.11953, 1.14044, 1.14904, 1.12158, 1.09405, 1.06465, 1.11152};
+    std::copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
+    std::copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
+    std::copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
+    std::copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
+    std::copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
+    std::copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
+    std::copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
+  }
+  else if(fRunNumber>296690 && fRunNumber<297595 && fSystNsigmaTPCDataCorr==kPbPb010) { //LHC18r 0-10%
+    fNPbinsNsigmaTPCDataCorr = 8;
+    array<float,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
+    array<float,8> meanPion = {-0.4669, -0.651889, -0.731293, -0.750849, -0.767918, -0.769948, -0.729383, -0.7741};
+    array<float,8> meanKaon = {-0.420412, -0.656824, -0.728482, -0.99377, -1.11258, -1.04111, -1.05214, -0.778762};
+    array<float,8> meanProton = {-0.346431, -0.445263, -0.504456, -0.80259, -0.971442, -1.00859, -0.853291, -0.595747};
+    array<float,8> sigmaPion = {1.31686, 1.24606, 1.21786, 1.21274, 1.21565, 1.29167, 1.26293, 1.27201};
+    array<float,8> sigmaKaon = {1.1904, 1.27156, 1.27005, 1.15127, 1.09914, 1.12193, 1.07542, 1.27068};
+    array<float,8> sigmaProton = {1.10662, 1.18216, 1.25083, 1.3166, 1.25666, 1.12755, 1.12149, 1.20881};
+    std::copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
+    std::copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
+    std::copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
+    std::copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
+    std::copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
+    std::copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
+    std::copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
+  }
+  else if(fRunNumber>296690 && fRunNumber<297595 && fSystNsigmaTPCDataCorr==kPbPb3050) { //LHC18r 30-50%
+    fNPbinsNsigmaTPCDataCorr = 8;
+    array<float,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
+    array<float,8> meanPion = {-0.298388, -0.342664, -0.396873, -0.462451, -0.538392, -0.58011, -0.612805, -0.642393};
+    array<float,8> meanKaon = {-0.152114, -0.00548698, -0.425063, -0.546696, -0.530307, -0.599359, -0.605992, -0.774291};
+    array<float,8> meanProton = {-0.0368995, -0.0849347, -0.30911, -0.479177, -0.584153, -0.578737, -0.568087, -0.489077};
+    array<float,8> sigmaPion = {0.878966, 0.88176, 0.883022, 0.873402, 0.859262, 0.847664, 0.828672, 0.800194};
+    array<float,8> sigmaKaon = {0.775762, 1.00624, 0.886505, 0.885096, 0.91232, 0.867032, 0.833827, 0.987321};
+    array<float,8> sigmaProton = {0.751132, 0.788041, 0.81738, 0.862206, 0.876342, 0.863609, 0.825849, 0.937087};
+    std::copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
+    std::copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
+    std::copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
+    std::copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
+    std::copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
+    std::copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
+    std::copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
+  }
+  else { //default: no correction applied
+    fNPbinsNsigmaTPCDataCorr = 1;
+    array<float,2> pTPClims = {0.,1000.};    
+    array<float,1> meanPion = {0.};
+    array<float,1> meanKaon = {0.};
+    array<float,1> meanProton = {0.};
+    array<float,1> sigmaPion = {1.};
+    array<float,1> sigmaKaon = {1.};
+    array<float,1> sigmaProton = {1.};
+    std::copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
+    std::copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
+    std::copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
+    std::copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
+    std::copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
+    std::copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
+    std::copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
+  }
+}
+
+//________________________________________________________________
+void AliHFTreeHandler::GetNsigmaTPCMeanSigmaData(float &mean, float &sigma, AliPID::EParticleType species, float pTPC) {
+    
+  if(fRunNumber!=fRunNumberPrevCand)
+    SetNsigmaTPCDataCorr();
+
+  int bin = TMath::BinarySearch(fNPbinsNsigmaTPCDataCorr,fPlimitsNsigmaTPCDataCorr,pTPC);
+  if(bin<0) bin=0; //underflow --> equal to min value
+  else if(bin>fNPbinsNsigmaTPCDataCorr-1) bin=fNPbinsNsigmaTPCDataCorr-1; //overflow --> equal to max value
+
+  switch(species) {
+    case AliPID::kPion: 
+    {
+      mean = fMeanNsigmaTPCPionData[bin];
+      sigma = fSigmaNsigmaTPCPionData[bin];
+      break;
+    }
+    case AliPID::kKaon: 
+    {
+      mean = fMeanNsigmaTPCKaonData[bin];
+      sigma = fSigmaNsigmaTPCKaonData[bin];
+      break;
+    }
+    case AliPID::kProton: 
+    {
+      mean = fMeanNsigmaTPCProtonData[bin];
+      sigma = fSigmaNsigmaTPCProtonData[bin];
+      break;
+    }
+    default: 
+    {
+      mean = 0.;
+      sigma = 1.;
+      break;
+    }
+  }
 }

--- a/PWGHF/treeHF/AliHFTreeHandler.h
+++ b/PWGHF/treeHF/AliHFTreeHandler.h
@@ -66,12 +66,6 @@ class AliHFTreeHandler : public TObject
       kAllSingleTrackVars // all single-track vars
     };
 
-    enum systemforNsigmadatacorr {
-      kNone=-1,
-      kPbPb010,
-      kPbPb3050
-    };
-
     AliHFTreeHandler();
     AliHFTreeHandler(int PIDopt);
 
@@ -178,7 +172,6 @@ class AliHFTreeHandler : public TObject
     float GetTOFmomentum(AliAODTrack* track, AliPIDResponse* pidrespo);
   
     void GetNsigmaTPCMeanSigmaData(float &mean, float &sigma, AliPID::EParticleType species, float pTPC);
-    void SetNsigmaTPCDataCorr();
 
     TTree* fTreeVar; /// tree with variables
     unsigned int fNProngs; /// number of prongs

--- a/PWGHF/treeHF/AliHFTreeHandler.h
+++ b/PWGHF/treeHF/AliHFTreeHandler.h
@@ -66,6 +66,12 @@ class AliHFTreeHandler : public TObject
       kAllSingleTrackVars // all single-track vars
     };
 
+    enum systemforNsigmadatacorr {
+      kNone=-1,
+      kPbPb010,
+      kPbPb3050
+    };
+
     AliHFTreeHandler();
     AliHFTreeHandler(int PIDopt);
 
@@ -85,6 +91,7 @@ class AliHFTreeHandler : public TObject
       else {      
         fTreeVar->Fill(); 
         fCandType=0;
+        fRunNumberPrevCand = fRunNumber;
       }
     } 
     
@@ -144,6 +151,11 @@ class AliHFTreeHandler : public TObject
         return false;
     }
 
+    void EnableNsigmaTPCDataDrivenCorrection(int syst) {
+      fApplyNsigmaTPCDataCorr=true;
+      fSystNsigmaTPCDataCorr=syst;
+    }
+
   protected:  
     //constant variables
     static const unsigned int knMaxProngs   = 3;
@@ -165,6 +177,9 @@ class AliHFTreeHandler : public TObject
     float ComputeMaxd0MeasMinusExp(AliAODRecoDecayHF* cand, float bfield);
     float GetTOFmomentum(AliAODTrack* track, AliPIDResponse* pidrespo);
   
+    void GetNsigmaTPCMeanSigmaData(float &mean, float &sigma, AliPID::EParticleType species, float pTPC);
+    void SetNsigmaTPCDataCorr();
+
     TTree* fTreeVar; /// tree with variables
     unsigned int fNProngs; /// number of prongs
     unsigned int fNCandidates; /// number of candidates in one fill (event)
@@ -205,9 +220,20 @@ class AliHFTreeHandler : public TObject
     bool fDauInAcceptance; ///flag to know if the daughter are in acceptance in case of MC gen
     unsigned int fEvID; ///event ID corresponding to the one set in fTreeEvChar
     int fRunNumber; ///run number
-  
+    int fRunNumberPrevCand; ///run number of previous candidate
+    bool fApplyNsigmaTPCDataCorr; /// flag to enable data-driven NsigmaTPC correction
+    int fSystNsigmaTPCDataCorr; /// system for data-driven NsigmaTPC correction
+    float fMeanNsigmaTPCPionData[100]; /// array of NsigmaTPC pion mean in data 
+    float fMeanNsigmaTPCKaonData[100]; /// array of NsigmaTPC kaon mean in data 
+    float fMeanNsigmaTPCProtonData[100]; /// array of NsigmaTPC proton mean in data 
+    float fSigmaNsigmaTPCPionData[100]; /// array of NsigmaTPC pion mean in data 
+    float fSigmaNsigmaTPCKaonData[100]; /// array of NsigmaTPC kaon mean in data 
+    float fSigmaNsigmaTPCProtonData[100]; /// array of NsigmaTPC proton mean in data 
+    float fPlimitsNsigmaTPCDataCorr[101]; /// array of p limits for data-driven NsigmaTPC correction
+    int fNPbinsNsigmaTPCDataCorr;/// number of p bins for data-driven NsigmaTPC correction
+
   /// \cond CLASSIMP
-  ClassDef(AliHFTreeHandler,5); ///
+  ClassDef(AliHFTreeHandler,6); ///
   /// \endcond
 };
 #endif

--- a/PWGHF/vertexingHF/AliAODPidHF.cxx
+++ b/PWGHF/vertexingHF/AliAODPidHF.cxx
@@ -131,6 +131,16 @@ fNPbinsNsigmaTPCDataCorr(0)
     }
   }
   
+  for(int iP=0; iP<100; iP++) {
+    fMeanNsigmaTPCPionData[iP] = 0.;
+    fMeanNsigmaTPCKaonData[iP] = 0.;
+    fMeanNsigmaTPCProtonData[iP] = 0.;
+    fSigmaNsigmaTPCPionData[iP] = 1.;
+    fSigmaNsigmaTPCKaonData[iP] = 1.;
+    fSigmaNsigmaTPCProtonData[iP] = 1.;
+    fPlimitsNsigmaTPCDataCorr[iP] = 0.;
+  }
+  fPlimitsNsigmaTPCDataCorr[100] = 0.;
 }
 //----------------------
 AliAODPidHF::~AliAODPidHF()
@@ -650,7 +660,7 @@ Int_t AliAODPidHF::MatchTPCTOF(AliAODTrack *track, Int_t specie){
     if(okTPC) {
       nSigmaTPC = fPidResponse->NumberOfSigmasTPC(track, (AliPID::EParticleType)specie);
       if(fApplyNsigmaTPCDataCorr && nSigmaTPC>-990.) { 
-        Double_t mean=0., sigma=1.; 
+        Float_t mean=0., sigma=1.; 
         GetNsigmaTPCMeanSigmaData(mean, sigma, (AliPID::EParticleType)specie, track->GetTPCmomentum());
         nSigmaTPC = (nSigmaTPC-mean)/sigma;
       }
@@ -938,7 +948,7 @@ Int_t AliAODPidHF::GetnSigmaTPC(AliAODTrack *track, Int_t species, Double_t &nsi
     AliPID::EParticleType type=AliPID::EParticleType(species);
     nsigmaTPC = fPidResponse->NumberOfSigmasTPC(track,type);
     if(fApplyNsigmaTPCDataCorr && nsigmaTPC>-990.) {
-      Double_t mean=0., sigma=1.; 
+      Float_t mean=0., sigma=1.; 
       GetNsigmaTPCMeanSigmaData(mean, sigma, type, track->GetTPCmomentum());
       nsigmaTPC = (nsigmaTPC-mean)/sigma;
     }
@@ -1328,7 +1338,7 @@ Float_t AliAODPidHF::NumberOfSigmas(AliPID::EParticleType specie, AliPIDResponse
     {
       Double_t nsigmaTPC = fPidResponse->NumberOfSigmasTPC(track, specie);
       if(fApplyNsigmaTPCDataCorr && nsigmaTPC>-990.) {
-        Double_t mean=0., sigma=1.; 
+        Float_t mean=0., sigma=1.; 
         GetNsigmaTPCMeanSigmaData(mean, sigma, specie, track->GetTPCmomentum());
         nsigmaTPC = (nsigmaTPC-mean)/sigma;
       }
@@ -1586,86 +1596,14 @@ void AliAODPidHF::SetIdCompAsymmetricPID() {
 }
 
 //------------------
-void AliAODPidHF::SetNsigmaTPCDataDrivenCorrection(Int_t run, Int_t system) {
+void AliAODPidHF::EnableNsigmaTPCDataCorr(Int_t run, Int_t system) {
 
   fApplyNsigmaTPCDataCorr = kTRUE;
-
-  if(run>=295585 && run<=296623 && system==kPbPb010) { //LHC18q 0-10%
-    fNPbinsNsigmaTPCDataCorr = 8;
-    array<Double_t,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
-    array<Double_t,8> meanPion = {-0.476642, -0.611512, -0.70491, -0.785863, -0.858335, -0.913384, -0.926733, -1.03424};
-    array<Double_t,8> meanKaon = {-0.376284, -0.689586, -0.752243, -0.922438, -0.95792, -0.958785, -1.00629, -1.10473};
-    array<Double_t,8> meanProton = {-0.162057, -0.222369, -0.517459, -0.874908, -0.961924, -1.01193, -0.839815, -0.691694};
-    array<Double_t,8> sigmaPion = {0.98579, 0.962247, 0.945548, 0.920657, 0.909255, 0.957158, 0.907777, 0.954516};
-    array<Double_t,8> sigmaKaon = {0.851531, 0.909522, 0.96582, 0.900314, 0.887377, 0.880861, 0.848008, 0.916044};
-    array<Double_t,8> sigmaProton = {0.748482, 0.79806, 0.852967, 0.979616, 0.997911, 0.860067, 0.883535, 0.929892};
-    std::copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
-    std::copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
-    std::copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
-    std::copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
-    std::copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
-    std::copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
-    std::copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
-  }
-  else if(run>=295585 && run<=296623 && system==kPbPb3050) { //LHC18q 30-50%
-    fNPbinsNsigmaTPCDataCorr = 8;
-    array<Double_t,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
-    array<Double_t,8> meanPion = {-0.282783, -0.351074, -0.370549, -0.368398, -0.37546, -0.332551, -0.304001, -0.329724};
-    array<Double_t,8> meanKaon = {-0.147986, -0.26169, -0.339263, -0.566137, -0.619671, -0.586758, -0.430222, -0.243858};
-    array<Double_t,8> meanProton = {-0.116342, -0.204619, -0.18317, -0.288015, -0.431383, -0.496598, -0.476154, -0.464085};
-    array<Double_t,8> sigmaPion = {1.15354, 1.1191, 1.11418, 1.11474, 1.11121, 1.10621, 1.05918, 1.05666};
-    array<Double_t,8> sigmaKaon = {1.07676, 1.11978, 1.14182, 1.09804, 1.09674, 1.08182, 1.07091, 1.00419};
-    array<Double_t,8> sigmaProton = {1.07493, 1.11953, 1.14044, 1.14904, 1.12158, 1.09405, 1.06465, 1.11152};
-    std::copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
-    std::copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
-    std::copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
-    std::copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
-    std::copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
-    std::copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
-    std::copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
-  }
-  else if(run>296690 && run<297595 && system==kPbPb010) { //LHC18r 0-10%
-    fNPbinsNsigmaTPCDataCorr = 8;
-    array<Double_t,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
-    array<Double_t,8> meanPion = {-0.4669, -0.651889, -0.731293, -0.750849, -0.767918, -0.769948, -0.729383, -0.7741};
-    array<Double_t,8> meanKaon = {-0.420412, -0.656824, -0.728482, -0.99377, -1.11258, -1.04111, -1.05214, -0.778762};
-    array<Double_t,8> meanProton = {-0.346431, -0.445263, -0.504456, -0.80259, -0.971442, -1.00859, -0.853291, -0.595747};
-    array<Double_t,8> sigmaPion = {1.31686, 1.24606, 1.21786, 1.21274, 1.21565, 1.29167, 1.26293, 1.27201};
-    array<Double_t,8> sigmaKaon = {1.1904, 1.27156, 1.27005, 1.15127, 1.09914, 1.12193, 1.07542, 1.27068};
-    array<Double_t,8> sigmaProton = {1.10662, 1.18216, 1.25083, 1.3166, 1.25666, 1.12755, 1.12149, 1.20881};
-    std::copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
-    std::copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
-    std::copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
-    std::copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
-    std::copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
-    std::copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
-    std::copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
-  }
-  else if(run>296690 && run<297595 && system==kPbPb3050) { //LHC18r 30-50%
-    fNPbinsNsigmaTPCDataCorr = 8;
-    array<Double_t,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
-    array<Double_t,8> meanPion = {-0.298388, -0.342664, -0.396873, -0.462451, -0.538392, -0.58011, -0.612805, -0.642393};
-    array<Double_t,8> meanKaon = {-0.152114, -0.00548698, -0.425063, -0.546696, -0.530307, -0.599359, -0.605992, -0.774291};
-    array<Double_t,8> meanProton = {-0.0368995, -0.0849347, -0.30911, -0.479177, -0.584153, -0.578737, -0.568087, -0.489077};
-    array<Double_t,8> sigmaPion = {0.878966, 0.88176, 0.883022, 0.873402, 0.859262, 0.847664, 0.828672, 0.800194};
-    array<Double_t,8> sigmaKaon = {0.775762, 1.00624, 0.886505, 0.885096, 0.91232, 0.867032, 0.833827, 0.987321};
-    array<Double_t,8> sigmaProton = {0.751132, 0.788041, 0.81738, 0.862206, 0.876342, 0.863609, 0.825849, 0.937087};
-    std::copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
-    std::copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
-    std::copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
-    std::copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
-    std::copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
-    std::copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
-    std::copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
-  }
-  else { //default: no correction applied
-    fApplyNsigmaTPCDataCorr = kFALSE;
-    fNPbinsNsigmaTPCDataCorr = 0;
-  }
+  SetNsigmaTPCDataDrivenCorrection(run, system, fNPbinsNsigmaTPCDataCorr, fPlimitsNsigmaTPCDataCorr, fMeanNsigmaTPCPionData, fMeanNsigmaTPCKaonData, fMeanNsigmaTPCProtonData, fSigmaNsigmaTPCPionData, fSigmaNsigmaTPCKaonData, fSigmaNsigmaTPCProtonData);
 }
 
 //------------------
-void AliAODPidHF::GetNsigmaTPCMeanSigmaData(Double_t &mean, Double_t &sigma, AliPID::EParticleType species, Double_t pTPC) const {
+void AliAODPidHF::GetNsigmaTPCMeanSigmaData(Float_t &mean, Float_t &sigma, AliPID::EParticleType species, Float_t pTPC) const {
     
   Int_t bin = TMath::BinarySearch(fNPbinsNsigmaTPCDataCorr,fPlimitsNsigmaTPCDataCorr,pTPC);
   if(bin<0) bin=0; //underflow --> equal to min value
@@ -1696,5 +1634,95 @@ void AliAODPidHF::GetNsigmaTPCMeanSigmaData(Double_t &mean, Double_t &sigma, Ali
       sigma = 1.;
       break;
     }
+  }
+}
+
+//___________________________________________________________________________________//
+void AliAODPidHF::SetNsigmaTPCDataDrivenCorrection(Int_t run, Int_t system, Int_t &nPbins, Float_t Plims[], Float_t meanNsigmaTPCpion[], Float_t meanNsigmaTPCkaon[], Float_t meanNsigmaTPCproton[], Float_t sigmaNsigmaTPCpion[], Float_t sigmaNsigmaTPCkaon[], Float_t sigmaNsigmaTPCproton[]) {
+
+  if(run>=295585 && run<=296623 && system==kPbPb010) { //LHC18q 0-10%
+    nPbins = 8;
+    array<Float_t,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
+    array<Float_t,8> meanPion = {-0.476642, -0.611512, -0.70491, -0.785863, -0.858335, -0.913384, -0.926733, -1.03424};
+    array<Float_t,8> meanKaon = {-0.376284, -0.689586, -0.752243, -0.922438, -0.95792, -0.958785, -1.00629, -1.10473};
+    array<Float_t,8> meanProton = {-0.162057, -0.222369, -0.517459, -0.874908, -0.961924, -1.01193, -0.839815, -0.691694};
+    array<Float_t,8> sigmaPion = {0.98579, 0.962247, 0.945548, 0.920657, 0.909255, 0.957158, 0.907777, 0.954516};
+    array<Float_t,8> sigmaKaon = {0.851531, 0.909522, 0.96582, 0.900314, 0.887377, 0.880861, 0.848008, 0.916044};
+    array<Float_t,8> sigmaProton = {0.748482, 0.79806, 0.852967, 0.979616, 0.997911, 0.860067, 0.883535, 0.929892};
+    std::copy(pTPClims.begin(),pTPClims.end(),Plims);
+    std::copy(meanPion.begin(),meanPion.end(),meanNsigmaTPCpion);
+    std::copy(meanKaon.begin(),meanKaon.end(),meanNsigmaTPCkaon);
+    std::copy(meanProton.begin(),meanProton.end(),meanNsigmaTPCproton);
+    std::copy(sigmaPion.begin(),sigmaPion.end(),sigmaNsigmaTPCpion);
+    std::copy(sigmaKaon.begin(),sigmaKaon.end(),sigmaNsigmaTPCkaon);
+    std::copy(sigmaProton.begin(),sigmaProton.end(),sigmaNsigmaTPCproton);
+  }
+  else if(run>=295585 && run<=296623 && system==kPbPb3050) { //LHC18q 30-50%
+    nPbins = 8;
+    array<Float_t,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
+    array<Float_t,8> meanPion = {-0.282783, -0.351074, -0.370549, -0.368398, -0.37546, -0.332551, -0.304001, -0.329724};
+    array<Float_t,8> meanKaon = {-0.147986, -0.26169, -0.339263, -0.566137, -0.619671, -0.586758, -0.430222, -0.243858};
+    array<Float_t,8> meanProton = {-0.116342, -0.204619, -0.18317, -0.288015, -0.431383, -0.496598, -0.476154, -0.464085};
+    array<Float_t,8> sigmaPion = {1.15354, 1.1191, 1.11418, 1.11474, 1.11121, 1.10621, 1.05918, 1.05666};
+    array<Float_t,8> sigmaKaon = {1.07676, 1.11978, 1.14182, 1.09804, 1.09674, 1.08182, 1.07091, 1.00419};
+    array<Float_t,8> sigmaProton = {1.07493, 1.11953, 1.14044, 1.14904, 1.12158, 1.09405, 1.06465, 1.11152};
+    std::copy(pTPClims.begin(),pTPClims.end(),Plims);
+    std::copy(meanPion.begin(),meanPion.end(),meanNsigmaTPCpion);
+    std::copy(meanKaon.begin(),meanKaon.end(),meanNsigmaTPCkaon);
+    std::copy(meanProton.begin(),meanProton.end(),meanNsigmaTPCproton);
+    std::copy(sigmaPion.begin(),sigmaPion.end(),sigmaNsigmaTPCpion);
+    std::copy(sigmaKaon.begin(),sigmaKaon.end(),sigmaNsigmaTPCkaon);
+    std::copy(sigmaProton.begin(),sigmaProton.end(),sigmaNsigmaTPCproton);
+  }
+  else if(run>=296690 && run<=297595 && system==kPbPb010) { //LHC18r 0-10%
+    nPbins = 8;
+    array<Float_t,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
+    array<Float_t,8> meanPion = {-0.4669, -0.651889, -0.731293, -0.750849, -0.767918, -0.769948, -0.729383, -0.7741};
+    array<Float_t,8> meanKaon = {-0.420412, -0.656824, -0.728482, -0.99377, -1.11258, -1.04111, -1.05214, -0.778762};
+    array<Float_t,8> meanProton = {-0.346431, -0.445263, -0.504456, -0.80259, -0.971442, -1.00859, -0.853291, -0.595747};
+    array<Float_t,8> sigmaPion = {1.31686, 1.24606, 1.21786, 1.21274, 1.21565, 1.29167, 1.26293, 1.27201};
+    array<Float_t,8> sigmaKaon = {1.1904, 1.27156, 1.27005, 1.15127, 1.09914, 1.12193, 1.07542, 1.27068};
+    array<Float_t,8> sigmaProton = {1.10662, 1.18216, 1.25083, 1.3166, 1.25666, 1.12755, 1.12149, 1.20881};
+    std::copy(pTPClims.begin(),pTPClims.end(),Plims);
+    std::copy(meanPion.begin(),meanPion.end(),meanNsigmaTPCpion);
+    std::copy(meanKaon.begin(),meanKaon.end(),meanNsigmaTPCkaon);
+    std::copy(meanProton.begin(),meanProton.end(),meanNsigmaTPCproton);
+    std::copy(sigmaPion.begin(),sigmaPion.end(),sigmaNsigmaTPCpion);
+    std::copy(sigmaKaon.begin(),sigmaKaon.end(),sigmaNsigmaTPCkaon);
+    std::copy(sigmaProton.begin(),sigmaProton.end(),sigmaNsigmaTPCproton);
+  }
+  else if(run>=296690 && run<=297595 && system==kPbPb3050) { //LHC18r 30-50%
+    nPbins = 8;
+    array<Float_t,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
+    array<Float_t,8> meanPion = {-0.298388, -0.342664, -0.396873, -0.462451, -0.538392, -0.58011, -0.612805, -0.642393};
+    array<Float_t,8> meanKaon = {-0.152114, -0.00548698, -0.425063, -0.546696, -0.530307, -0.599359, -0.605992, -0.774291};
+    array<Float_t,8> meanProton = {-0.0368995, -0.0849347, -0.30911, -0.479177, -0.584153, -0.578737, -0.568087, -0.489077};
+    array<Float_t,8> sigmaPion = {0.878966, 0.88176, 0.883022, 0.873402, 0.859262, 0.847664, 0.828672, 0.800194};
+    array<Float_t,8> sigmaKaon = {0.775762, 1.00624, 0.886505, 0.885096, 0.91232, 0.867032, 0.833827, 0.987321};
+    array<Float_t,8> sigmaProton = {0.751132, 0.788041, 0.81738, 0.862206, 0.876342, 0.863609, 0.825849, 0.937087};
+    std::copy(pTPClims.begin(),pTPClims.end(),Plims);
+    std::copy(meanPion.begin(),meanPion.end(),meanNsigmaTPCpion);
+    std::copy(meanKaon.begin(),meanKaon.end(),meanNsigmaTPCkaon);
+    std::copy(meanProton.begin(),meanProton.end(),meanNsigmaTPCproton);
+    std::copy(sigmaPion.begin(),sigmaPion.end(),sigmaNsigmaTPCpion);
+    std::copy(sigmaKaon.begin(),sigmaKaon.end(),sigmaNsigmaTPCkaon);
+    std::copy(sigmaProton.begin(),sigmaProton.end(),sigmaNsigmaTPCproton);
+  }
+  else { //default: no correction applied
+    nPbins = 1;
+    array<Float_t,2> pTPClims = {0.,1000.};    
+    array<Float_t,1> meanPion = {0.};
+    array<Float_t,1> meanKaon = {0.};
+    array<Float_t,1> meanProton = {0.};
+    array<Float_t,1> sigmaPion = {1.};
+    array<Float_t,1> sigmaKaon = {1.};
+    array<Float_t,1> sigmaProton = {1.};
+    std::copy(pTPClims.begin(),pTPClims.end(),Plims);
+    std::copy(meanPion.begin(),meanPion.end(),meanNsigmaTPCpion);
+    std::copy(meanKaon.begin(),meanKaon.end(),meanNsigmaTPCkaon);
+    std::copy(meanProton.begin(),meanProton.end(),meanNsigmaTPCproton);
+    std::copy(sigmaPion.begin(),sigmaPion.end(),sigmaNsigmaTPCpion);
+    std::copy(sigmaKaon.begin(),sigmaKaon.end(),sigmaNsigmaTPCkaon);
+    std::copy(sigmaProton.begin(),sigmaProton.end(),sigmaNsigmaTPCproton);
   }
 }

--- a/PWGHF/vertexingHF/AliAODPidHF.h
+++ b/PWGHF/vertexingHF/AliAODPidHF.h
@@ -31,6 +31,12 @@ public:
     kTPCITS
   };
   
+  enum SystemForNsigmaDataCorr {
+    kNone=-1,
+    kPbPb010,
+    kPbPb3050
+  };
+
   AliAODPidHF();
   AliAODPidHF(const AliAODPidHF& pid);
   virtual ~AliAODPidHF();
@@ -224,12 +230,17 @@ public:
   void SetIdAsymmetricPID();
   void SetIdCompAsymmetricPID();
   
+  ///Set Nsigma data-driven correction
+  void SetNsigmaTPCDataDrivenCorrection(Int_t run, Int_t system);
+
 protected:
   
   
 private:
 
   AliAODPidHF& operator=(const AliAODPidHF& pid);
+
+  void GetNsigmaTPCMeanSigmaData(Double_t &mean, Double_t &sigma, AliPID::EParticleType species, Double_t pTPC) const;
 
   Int_t fnNSigma; /// number of sigmas
   /// sigma for the raw signal PID: 0-2 for TPC, 3 for TOF, 4 for ITS
@@ -290,8 +301,18 @@ private:
   TF1 *fCompBandMin[AliPID::kSPECIES][4];
   TF1 *fCompBandMax[AliPID::kSPECIES][4];
 
+  Bool_t fApplyNsigmaTPCDataCorr; /// flag to enable data-driven NsigmaTPC correction
+  Double_t fMeanNsigmaTPCPionData[100]; /// array of NsigmaTPC pion mean in data 
+  Double_t fMeanNsigmaTPCKaonData[100]; /// array of NsigmaTPC kaon mean in data 
+  Double_t fMeanNsigmaTPCProtonData[100]; /// array of NsigmaTPC proton mean in data 
+  Double_t fSigmaNsigmaTPCPionData[100]; /// array of NsigmaTPC pion mean in data 
+  Double_t fSigmaNsigmaTPCKaonData[100]; /// array of NsigmaTPC kaon mean in data 
+  Double_t fSigmaNsigmaTPCProtonData[100]; /// array of NsigmaTPC proton mean in data 
+  Double_t fPlimitsNsigmaTPCDataCorr[101]; /// array of p limits for data-driven NsigmaTPC correction
+  Int_t fNPbinsNsigmaTPCDataCorr;/// number of p bins for data-driven NsigmaTPC correction
+
   /// \cond CLASSIMP
-  ClassDef(AliAODPidHF,24); /// AliAODPid for heavy flavor PID
+  ClassDef(AliAODPidHF,25); /// AliAODPid for heavy flavor PID
   /// \endcond
 
 };

--- a/PWGHF/vertexingHF/AliAODPidHF.h
+++ b/PWGHF/vertexingHF/AliAODPidHF.h
@@ -30,7 +30,7 @@ public:
     kTPCTOF,
     kTPCITS
   };
-  
+
   enum SystemForNsigmaDataCorr {
     kNone=-1,
     kPbPb010,
@@ -231,7 +231,10 @@ public:
   void SetIdCompAsymmetricPID();
   
   ///Set Nsigma data-driven correction
-  void SetNsigmaTPCDataDrivenCorrection(Int_t run, Int_t system);
+  void EnableNsigmaTPCDataCorr(Int_t run, Int_t system);
+
+  //method to get parameters for NsigmaTPC correction
+  static void SetNsigmaTPCDataDrivenCorrection(Int_t run, Int_t system, Int_t &nPbins, Float_t Plims[], Float_t meanNsigmaTPCpion[], Float_t meanNsigmaTPCkaon[], Float_t meanNsigmaTPCproton[], Float_t sigmaNsigmaTPCpion[], Float_t sigmaNsigmaTPCkaon[], Float_t sigmaNsigmaTPCproton[]);
 
 protected:
   
@@ -240,7 +243,7 @@ private:
 
   AliAODPidHF& operator=(const AliAODPidHF& pid);
 
-  void GetNsigmaTPCMeanSigmaData(Double_t &mean, Double_t &sigma, AliPID::EParticleType species, Double_t pTPC) const;
+  void GetNsigmaTPCMeanSigmaData(Float_t &mean, Float_t &sigma, AliPID::EParticleType species, Float_t pTPC) const;
 
   Int_t fnNSigma; /// number of sigmas
   /// sigma for the raw signal PID: 0-2 for TPC, 3 for TOF, 4 for ITS
@@ -302,13 +305,13 @@ private:
   TF1 *fCompBandMax[AliPID::kSPECIES][4];
 
   Bool_t fApplyNsigmaTPCDataCorr; /// flag to enable data-driven NsigmaTPC correction
-  Double_t fMeanNsigmaTPCPionData[100]; /// array of NsigmaTPC pion mean in data 
-  Double_t fMeanNsigmaTPCKaonData[100]; /// array of NsigmaTPC kaon mean in data 
-  Double_t fMeanNsigmaTPCProtonData[100]; /// array of NsigmaTPC proton mean in data 
-  Double_t fSigmaNsigmaTPCPionData[100]; /// array of NsigmaTPC pion mean in data 
-  Double_t fSigmaNsigmaTPCKaonData[100]; /// array of NsigmaTPC kaon mean in data 
-  Double_t fSigmaNsigmaTPCProtonData[100]; /// array of NsigmaTPC proton mean in data 
-  Double_t fPlimitsNsigmaTPCDataCorr[101]; /// array of p limits for data-driven NsigmaTPC correction
+  Float_t fMeanNsigmaTPCPionData[100]; /// array of NsigmaTPC pion mean in data 
+  Float_t fMeanNsigmaTPCKaonData[100]; /// array of NsigmaTPC kaon mean in data 
+  Float_t fMeanNsigmaTPCProtonData[100]; /// array of NsigmaTPC proton mean in data 
+  Float_t fSigmaNsigmaTPCPionData[100]; /// array of NsigmaTPC pion mean in data 
+  Float_t fSigmaNsigmaTPCKaonData[100]; /// array of NsigmaTPC kaon mean in data 
+  Float_t fSigmaNsigmaTPCProtonData[100]; /// array of NsigmaTPC proton mean in data 
+  Float_t fPlimitsNsigmaTPCDataCorr[101]; /// array of p limits for data-driven NsigmaTPC correction
   Int_t fNPbinsNsigmaTPCDataCorr;/// number of p bins for data-driven NsigmaTPC correction
 
   /// \cond CLASSIMP

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.cxx
@@ -65,7 +65,18 @@ fFillTreeWithNsigmaPIDOnly(false),
 fEnabledDownSampling(false),
 fFracToKeepDownSampling(0.1),
 fPtMaxDownSampling(1.5),
-fAODProtection(1)
+fAODProtection(1),
+fRunNumberPrevEvent(-1),
+fEnableNsigmaTPCDataCorr(false),
+fSystNsigmaTPCDataCorr{},
+fMeanNsigmaTPCPionData{},
+fMeanNsigmaTPCKaonData{}, 
+fMeanNsigmaTPCProtonData{},
+fSigmaNsigmaTPCPionData{},
+fSigmaNsigmaTPCKaonData{},
+fSigmaNsigmaTPCProtonData{},
+fPlimitsNsigmaTPCDataCorr{},
+fNPbinsNsigmaTPCDataCorr(0)
 {
   //
   // default constructur
@@ -120,7 +131,18 @@ fFillTreeWithNsigmaPIDOnly(false),
 fEnabledDownSampling(false),
 fFracToKeepDownSampling(0.1),
 fPtMaxDownSampling(1.5),
-fAODProtection(1)
+fAODProtection(1),
+fRunNumberPrevEvent(-1),
+fEnableNsigmaTPCDataCorr(false),
+fSystNsigmaTPCDataCorr{},
+fMeanNsigmaTPCPionData{},
+fMeanNsigmaTPCKaonData{}, 
+fMeanNsigmaTPCProtonData{},
+fSigmaNsigmaTPCPionData{},
+fSigmaNsigmaTPCKaonData{},
+fSigmaNsigmaTPCProtonData{},
+fPlimitsNsigmaTPCDataCorr{},
+fNPbinsNsigmaTPCDataCorr(0)
 {
   //
   // standard constructur
@@ -315,6 +337,13 @@ void AliAnalysisTaskSEHFSystPID::UserExec(Option_t */*option*/)
   //get pid response
   if(!fPIDresp) fPIDresp = ((AliInputEventHandler*)(AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler()))->GetPIDResponse();
 
+  //load data correction for NsigmaTPC, if enabled
+  if(fEnableNsigmaTPCDataCorr) {
+    if(fAOD->GetRunNumber()!=fRunNumberPrevEvent) {
+      SetNsigmaTPCDataCorr(fAOD->GetRunNumber());
+    }
+  }
+
   // V0 selection
   if(fSystem==0) fV0cuts->SetMode(AliAODv0KineCuts::kPurity,AliAODv0KineCuts::kPP);
   else if(fSystem==1) fV0cuts->SetMode(AliAODv0KineCuts::kPurity,AliAODv0KineCuts::kPbPb);
@@ -377,9 +406,24 @@ void AliAnalysisTaskSEHFSystPID::UserExec(Option_t */*option*/)
     if (fPIDresp->CheckPIDStatus(AliPIDResponse::kTOF,track) == AliPIDResponse::kDetPidOk) isTOFok = true;
 
     if(isTPCok) {
-      fPIDNsigma[0] = ConvertFloatToShort(fPIDresp->NumberOfSigmasTPC(track,AliPID::kPion)*100);
-      fPIDNsigma[1] = ConvertFloatToShort(fPIDresp->NumberOfSigmasTPC(track,AliPID::kKaon)*100);
-      fPIDNsigma[2] = ConvertFloatToShort(fPIDresp->NumberOfSigmasTPC(track,AliPID::kProton)*100);
+      float nSigmaTPCPion = fPIDresp->NumberOfSigmasTPC(track,AliPID::kPion);
+      float nSigmaTPCKaon = fPIDresp->NumberOfSigmasTPC(track,AliPID::kKaon);
+      float nSigmaTPCProton = fPIDresp->NumberOfSigmasTPC(track,AliPID::kProton);
+
+      if(fEnableNsigmaTPCDataCorr) {
+        float meanPion = 0., meanKaon = 0., meanProton = 0., sigmaPion = 0., sigmaKaon = 0., sigmaProton = 0.;
+        GetNsigmaTPCMeanSigmaData(meanPion, sigmaPion, AliPID::kPion, track->GetTPCmomentum());
+        GetNsigmaTPCMeanSigmaData(meanKaon, sigmaKaon, AliPID::kKaon, track->GetTPCmomentum());
+        GetNsigmaTPCMeanSigmaData(meanProton, sigmaProton, AliPID::kProton, track->GetTPCmomentum());
+
+        nSigmaTPCPion = (nSigmaTPCPion-meanPion) / sigmaPion;
+        nSigmaTPCKaon = (nSigmaTPCKaon-meanKaon) / sigmaKaon;
+        nSigmaTPCProton = (nSigmaTPCProton-meanProton) / sigmaProton;
+      }
+
+      fPIDNsigma[0] = ConvertFloatToShort(nSigmaTPCPion*100);
+      fPIDNsigma[1] = ConvertFloatToShort(nSigmaTPCKaon*100);
+      fPIDNsigma[2] = ConvertFloatToShort(nSigmaTPCProton*100);
     }
     else for(int iVar=0; iVar<3; iVar++) fPIDNsigma[iVar] = numeric_limits<short>::min();
     if(isTOFok) {
@@ -442,6 +486,8 @@ void AliAnalysisTaskSEHFSystPID::UserExec(Option_t */*option*/)
   idProtonFromL.clear();
   idElectronFromGamma.clear();
   idKaonFromKinks.clear();
+
+  fRunNumberPrevEvent = fAOD->GetRunNumber();
 
   // Post output data
   PostData(1, fOutputList);
@@ -695,4 +741,129 @@ unsigned short AliAnalysisTaskSEHFSystPID::ConvertFloatToUnsignedShort(float num
   else if(num<=static_cast<float>(numeric_limits<unsigned short>::min())) return numeric_limits<unsigned short>::min();
  
   return static_cast<unsigned short>(num);
+}
+
+//________________________________________________________________
+void AliAnalysisTaskSEHFSystPID::SetNsigmaTPCDataCorr(int run) {
+  
+  if(run>=295585 && run<=296623 && fSystNsigmaTPCDataCorr==kPbPb010) { //LHC18q 0-10%
+    fNPbinsNsigmaTPCDataCorr = 8;
+    array<float,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
+    array<float,8> meanPion = {-0.476642, -0.611512, -0.70491, -0.785863, -0.858335, -0.913384, -0.926733, -1.03424};
+    array<float,8> meanKaon = {-0.376284, -0.689586, -0.752243, -0.922438, -0.95792, -0.958785, -1.00629, -1.10473};
+    array<float,8> meanProton = {-0.162057, -0.222369, -0.517459, -0.874908, -0.961924, -1.01193, -0.839815, -0.691694};
+    array<float,8> sigmaPion = {0.98579, 0.962247, 0.945548, 0.920657, 0.909255, 0.957158, 0.907777, 0.954516};
+    array<float,8> sigmaKaon = {0.851531, 0.909522, 0.96582, 0.900314, 0.887377, 0.880861, 0.848008, 0.916044};
+    array<float,8> sigmaProton = {0.748482, 0.79806, 0.852967, 0.979616, 0.997911, 0.860067, 0.883535, 0.929892};
+    copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
+    copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
+    copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
+    copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
+    copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
+    copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
+    copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
+  }
+  else if(run>=295585 && run<=296623 && fSystNsigmaTPCDataCorr==kPbPb3050) { //LHC18q 30-50%
+    fNPbinsNsigmaTPCDataCorr = 8;
+    array<float,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
+    array<float,8> meanPion = {-0.282783, -0.351074, -0.370549, -0.368398, -0.37546, -0.332551, -0.304001, -0.329724};
+    array<float,8> meanKaon = {-0.147986, -0.26169, -0.339263, -0.566137, -0.619671, -0.586758, -0.430222, -0.243858};
+    array<float,8> meanProton = {-0.116342, -0.204619, -0.18317, -0.288015, -0.431383, -0.496598, -0.476154, -0.464085};
+    array<float,8> sigmaPion = {1.15354, 1.1191, 1.11418, 1.11474, 1.11121, 1.10621, 1.05918, 1.05666};
+    array<float,8> sigmaKaon = {1.07676, 1.11978, 1.14182, 1.09804, 1.09674, 1.08182, 1.07091, 1.00419};
+    array<float,8> sigmaProton = {1.07493, 1.11953, 1.14044, 1.14904, 1.12158, 1.09405, 1.06465, 1.11152};
+    copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
+    copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
+    copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
+    copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
+    copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
+    copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
+    copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
+  }
+  else if(run>296690 && run<297595 && fSystNsigmaTPCDataCorr==kPbPb010) { //LHC18r 0-10%
+    fNPbinsNsigmaTPCDataCorr = 8;
+    array<float,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
+    array<float,8> meanPion = {-0.4669, -0.651889, -0.731293, -0.750849, -0.767918, -0.769948, -0.729383, -0.7741};
+    array<float,8> meanKaon = {-0.420412, -0.656824, -0.728482, -0.99377, -1.11258, -1.04111, -1.05214, -0.778762};
+    array<float,8> meanProton = {-0.346431, -0.445263, -0.504456, -0.80259, -0.971442, -1.00859, -0.853291, -0.595747};
+    array<float,8> sigmaPion = {1.31686, 1.24606, 1.21786, 1.21274, 1.21565, 1.29167, 1.26293, 1.27201};
+    array<float,8> sigmaKaon = {1.1904, 1.27156, 1.27005, 1.15127, 1.09914, 1.12193, 1.07542, 1.27068};
+    array<float,8> sigmaProton = {1.10662, 1.18216, 1.25083, 1.3166, 1.25666, 1.12755, 1.12149, 1.20881};
+    copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
+    copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
+    copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
+    copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
+    copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
+    copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
+    copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
+  }
+  else if(run>296690 && run<297595 && fSystNsigmaTPCDataCorr==kPbPb3050) { //LHC18r 30-50%
+    fNPbinsNsigmaTPCDataCorr = 8;
+    array<float,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
+    array<float,8> meanPion = {-0.298388, -0.342664, -0.396873, -0.462451, -0.538392, -0.58011, -0.612805, -0.642393};
+    array<float,8> meanKaon = {-0.152114, -0.00548698, -0.425063, -0.546696, -0.530307, -0.599359, -0.605992, -0.774291};
+    array<float,8> meanProton = {-0.0368995, -0.0849347, -0.30911, -0.479177, -0.584153, -0.578737, -0.568087, -0.489077};
+    array<float,8> sigmaPion = {0.878966, 0.88176, 0.883022, 0.873402, 0.859262, 0.847664, 0.828672, 0.800194};
+    array<float,8> sigmaKaon = {0.775762, 1.00624, 0.886505, 0.885096, 0.91232, 0.867032, 0.833827, 0.987321};
+    array<float,8> sigmaProton = {0.751132, 0.788041, 0.81738, 0.862206, 0.876342, 0.863609, 0.825849, 0.937087};
+    copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
+    copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
+    copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
+    copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
+    copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
+    copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
+    copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
+  }
+  else { //default: no correction applied
+    fNPbinsNsigmaTPCDataCorr = 1;
+    array<float,2> pTPClims = {0.,1000.};    
+    array<float,1> meanPion = {0.};
+    array<float,1> meanKaon = {0.};
+    array<float,1> meanProton = {0.};
+    array<float,1> sigmaPion = {1.};
+    array<float,1> sigmaKaon = {1.};
+    array<float,1> sigmaProton = {1.};
+    copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
+    copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
+    copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
+    copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
+    copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
+    copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
+    copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
+  }
+}
+
+//________________________________________________________________
+void AliAnalysisTaskSEHFSystPID::GetNsigmaTPCMeanSigmaData(float &mean, float &sigma, AliPID::EParticleType species, float pTPC) {
+    
+  int bin = TMath::BinarySearch(fNPbinsNsigmaTPCDataCorr,fPlimitsNsigmaTPCDataCorr,pTPC);
+  if(bin<0) bin=0; //underflow --> equal to min value
+  else if(bin>fNPbinsNsigmaTPCDataCorr-1) bin=fNPbinsNsigmaTPCDataCorr-1; //overflow --> equal to max value
+
+  switch(species) {
+    case AliPID::kPion: 
+    {
+      mean = fMeanNsigmaTPCPionData[bin];
+      sigma = fSigmaNsigmaTPCPionData[bin];
+      break;
+    }
+    case AliPID::kKaon: 
+    {
+      mean = fMeanNsigmaTPCKaonData[bin];
+      sigma = fSigmaNsigmaTPCKaonData[bin];
+      break;
+    }
+    case AliPID::kProton: 
+    {
+      mean = fMeanNsigmaTPCProtonData[bin];
+      sigma = fSigmaNsigmaTPCProtonData[bin];
+      break;
+    }
+    default: 
+    {
+      mean = 0.;
+      sigma = 1.;
+      break;
+    }
+  }
 }

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.cxx
@@ -21,6 +21,7 @@
 #include "AliMultSelection.h"
 #include "AliESDtrack.h"
 #include "AliRDHFCuts.h"
+#include "AliAODPidHF.h"
 
 ClassImp(AliAnalysisTaskSEHFSystPID)
 
@@ -68,7 +69,7 @@ fPtMaxDownSampling(1.5),
 fAODProtection(1),
 fRunNumberPrevEvent(-1),
 fEnableNsigmaTPCDataCorr(false),
-fSystNsigmaTPCDataCorr{},
+fSystNsigmaTPCDataCorr(AliAODPidHF::kNone),
 fMeanNsigmaTPCPionData{},
 fMeanNsigmaTPCKaonData{}, 
 fMeanNsigmaTPCProtonData{},
@@ -88,6 +89,17 @@ fNPbinsNsigmaTPCDataCorr(0)
     fHistNsigmaTPCvsPt[iHisto] = nullptr;
     fHistNsigmaTOFvsPt[iHisto] = nullptr;
   }
+
+  for(int iP=0; iP<100; iP++) {
+    fMeanNsigmaTPCPionData[iP] = 0.;
+    fMeanNsigmaTPCKaonData[iP] = 0.;
+    fMeanNsigmaTPCProtonData[iP] = 0.;
+    fSigmaNsigmaTPCPionData[iP] = 1.;
+    fSigmaNsigmaTPCKaonData[iP] = 1.;
+    fSigmaNsigmaTPCProtonData[iP] = 1.;
+    fPlimitsNsigmaTPCDataCorr[iP] = 0.;
+  }
+  fPlimitsNsigmaTPCDataCorr[100] = 0.;
 }
 
 //________________________________________________________________________
@@ -134,7 +146,7 @@ fPtMaxDownSampling(1.5),
 fAODProtection(1),
 fRunNumberPrevEvent(-1),
 fEnableNsigmaTPCDataCorr(false),
-fSystNsigmaTPCDataCorr{},
+fSystNsigmaTPCDataCorr(AliAODPidHF::kNone),
 fMeanNsigmaTPCPionData{},
 fMeanNsigmaTPCKaonData{}, 
 fMeanNsigmaTPCProtonData{},
@@ -154,6 +166,17 @@ fNPbinsNsigmaTPCDataCorr(0)
     fHistNsigmaTPCvsPt[iHisto] = nullptr;
     fHistNsigmaTOFvsPt[iHisto] = nullptr;
   }
+
+  for(int iP=0; iP<100; iP++) {
+    fMeanNsigmaTPCPionData[iP] = 0.;
+    fMeanNsigmaTPCKaonData[iP] = 0.;
+    fMeanNsigmaTPCProtonData[iP] = 0.;
+    fSigmaNsigmaTPCPionData[iP] = 1.;
+    fSigmaNsigmaTPCKaonData[iP] = 1.;
+    fSigmaNsigmaTPCProtonData[iP] = 1.;
+    fPlimitsNsigmaTPCDataCorr[iP] = 0.;
+  }
+  fPlimitsNsigmaTPCDataCorr[100] = 0.;
 
   DefineInput(0, TChain::Class());
   DefineOutput(1, TList::Class());
@@ -340,7 +363,7 @@ void AliAnalysisTaskSEHFSystPID::UserExec(Option_t */*option*/)
   //load data correction for NsigmaTPC, if enabled
   if(fEnableNsigmaTPCDataCorr) {
     if(fAOD->GetRunNumber()!=fRunNumberPrevEvent) {
-      SetNsigmaTPCDataCorr(fAOD->GetRunNumber());
+      AliAODPidHF::SetNsigmaTPCDataDrivenCorrection(fAOD->GetRunNumber(), fSystNsigmaTPCDataCorr, fNPbinsNsigmaTPCDataCorr, fPlimitsNsigmaTPCDataCorr, fMeanNsigmaTPCPionData, fMeanNsigmaTPCKaonData, fMeanNsigmaTPCProtonData, fSigmaNsigmaTPCPionData, fSigmaNsigmaTPCKaonData, fSigmaNsigmaTPCProtonData);
     }
   }
 
@@ -409,16 +432,18 @@ void AliAnalysisTaskSEHFSystPID::UserExec(Option_t */*option*/)
       float nSigmaTPCPion = fPIDresp->NumberOfSigmasTPC(track,AliPID::kPion);
       float nSigmaTPCKaon = fPIDresp->NumberOfSigmasTPC(track,AliPID::kKaon);
       float nSigmaTPCProton = fPIDresp->NumberOfSigmasTPC(track,AliPID::kProton);
-
       if(fEnableNsigmaTPCDataCorr) {
-        float meanPion = 0., meanKaon = 0., meanProton = 0., sigmaPion = 0., sigmaKaon = 0., sigmaProton = 0.;
+        float meanPion = 0., meanKaon = 0., meanProton = 0., sigmaPion = 1., sigmaKaon = 1., sigmaProton = 1.;
         GetNsigmaTPCMeanSigmaData(meanPion, sigmaPion, AliPID::kPion, track->GetTPCmomentum());
         GetNsigmaTPCMeanSigmaData(meanKaon, sigmaKaon, AliPID::kKaon, track->GetTPCmomentum());
         GetNsigmaTPCMeanSigmaData(meanProton, sigmaProton, AliPID::kProton, track->GetTPCmomentum());
 
-        nSigmaTPCPion = (nSigmaTPCPion-meanPion) / sigmaPion;
-        nSigmaTPCKaon = (nSigmaTPCKaon-meanKaon) / sigmaKaon;
-        nSigmaTPCProton = (nSigmaTPCProton-meanProton) / sigmaProton;
+        if(nSigmaTPCPion>-990.)
+          nSigmaTPCPion = (nSigmaTPCPion-meanPion) / sigmaPion;
+        if(nSigmaTPCKaon>-990.)
+          nSigmaTPCKaon = (nSigmaTPCKaon-meanKaon) / sigmaKaon;
+        if(nSigmaTPCProton>-990.)
+          nSigmaTPCProton = (nSigmaTPCProton-meanProton) / sigmaProton;
       }
 
       fPIDNsigma[0] = ConvertFloatToShort(nSigmaTPCPion*100);
@@ -741,96 +766,6 @@ unsigned short AliAnalysisTaskSEHFSystPID::ConvertFloatToUnsignedShort(float num
   else if(num<=static_cast<float>(numeric_limits<unsigned short>::min())) return numeric_limits<unsigned short>::min();
  
   return static_cast<unsigned short>(num);
-}
-
-//________________________________________________________________
-void AliAnalysisTaskSEHFSystPID::SetNsigmaTPCDataCorr(int run) {
-  
-  if(run>=295585 && run<=296623 && fSystNsigmaTPCDataCorr==kPbPb010) { //LHC18q 0-10%
-    fNPbinsNsigmaTPCDataCorr = 8;
-    array<float,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
-    array<float,8> meanPion = {-0.476642, -0.611512, -0.70491, -0.785863, -0.858335, -0.913384, -0.926733, -1.03424};
-    array<float,8> meanKaon = {-0.376284, -0.689586, -0.752243, -0.922438, -0.95792, -0.958785, -1.00629, -1.10473};
-    array<float,8> meanProton = {-0.162057, -0.222369, -0.517459, -0.874908, -0.961924, -1.01193, -0.839815, -0.691694};
-    array<float,8> sigmaPion = {0.98579, 0.962247, 0.945548, 0.920657, 0.909255, 0.957158, 0.907777, 0.954516};
-    array<float,8> sigmaKaon = {0.851531, 0.909522, 0.96582, 0.900314, 0.887377, 0.880861, 0.848008, 0.916044};
-    array<float,8> sigmaProton = {0.748482, 0.79806, 0.852967, 0.979616, 0.997911, 0.860067, 0.883535, 0.929892};
-    copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
-    copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
-    copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
-    copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
-    copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
-    copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
-    copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
-  }
-  else if(run>=295585 && run<=296623 && fSystNsigmaTPCDataCorr==kPbPb3050) { //LHC18q 30-50%
-    fNPbinsNsigmaTPCDataCorr = 8;
-    array<float,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
-    array<float,8> meanPion = {-0.282783, -0.351074, -0.370549, -0.368398, -0.37546, -0.332551, -0.304001, -0.329724};
-    array<float,8> meanKaon = {-0.147986, -0.26169, -0.339263, -0.566137, -0.619671, -0.586758, -0.430222, -0.243858};
-    array<float,8> meanProton = {-0.116342, -0.204619, -0.18317, -0.288015, -0.431383, -0.496598, -0.476154, -0.464085};
-    array<float,8> sigmaPion = {1.15354, 1.1191, 1.11418, 1.11474, 1.11121, 1.10621, 1.05918, 1.05666};
-    array<float,8> sigmaKaon = {1.07676, 1.11978, 1.14182, 1.09804, 1.09674, 1.08182, 1.07091, 1.00419};
-    array<float,8> sigmaProton = {1.07493, 1.11953, 1.14044, 1.14904, 1.12158, 1.09405, 1.06465, 1.11152};
-    copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
-    copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
-    copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
-    copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
-    copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
-    copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
-    copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
-  }
-  else if(run>296690 && run<297595 && fSystNsigmaTPCDataCorr==kPbPb010) { //LHC18r 0-10%
-    fNPbinsNsigmaTPCDataCorr = 8;
-    array<float,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
-    array<float,8> meanPion = {-0.4669, -0.651889, -0.731293, -0.750849, -0.767918, -0.769948, -0.729383, -0.7741};
-    array<float,8> meanKaon = {-0.420412, -0.656824, -0.728482, -0.99377, -1.11258, -1.04111, -1.05214, -0.778762};
-    array<float,8> meanProton = {-0.346431, -0.445263, -0.504456, -0.80259, -0.971442, -1.00859, -0.853291, -0.595747};
-    array<float,8> sigmaPion = {1.31686, 1.24606, 1.21786, 1.21274, 1.21565, 1.29167, 1.26293, 1.27201};
-    array<float,8> sigmaKaon = {1.1904, 1.27156, 1.27005, 1.15127, 1.09914, 1.12193, 1.07542, 1.27068};
-    array<float,8> sigmaProton = {1.10662, 1.18216, 1.25083, 1.3166, 1.25666, 1.12755, 1.12149, 1.20881};
-    copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
-    copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
-    copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
-    copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
-    copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
-    copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
-    copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
-  }
-  else if(run>296690 && run<297595 && fSystNsigmaTPCDataCorr==kPbPb3050) { //LHC18r 30-50%
-    fNPbinsNsigmaTPCDataCorr = 8;
-    array<float,9> pTPClims = {0.3,0.5,0.75,1.,1.5,2.,3.,5.,10.};    
-    array<float,8> meanPion = {-0.298388, -0.342664, -0.396873, -0.462451, -0.538392, -0.58011, -0.612805, -0.642393};
-    array<float,8> meanKaon = {-0.152114, -0.00548698, -0.425063, -0.546696, -0.530307, -0.599359, -0.605992, -0.774291};
-    array<float,8> meanProton = {-0.0368995, -0.0849347, -0.30911, -0.479177, -0.584153, -0.578737, -0.568087, -0.489077};
-    array<float,8> sigmaPion = {0.878966, 0.88176, 0.883022, 0.873402, 0.859262, 0.847664, 0.828672, 0.800194};
-    array<float,8> sigmaKaon = {0.775762, 1.00624, 0.886505, 0.885096, 0.91232, 0.867032, 0.833827, 0.987321};
-    array<float,8> sigmaProton = {0.751132, 0.788041, 0.81738, 0.862206, 0.876342, 0.863609, 0.825849, 0.937087};
-    copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
-    copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
-    copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
-    copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
-    copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
-    copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
-    copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
-  }
-  else { //default: no correction applied
-    fNPbinsNsigmaTPCDataCorr = 1;
-    array<float,2> pTPClims = {0.,1000.};    
-    array<float,1> meanPion = {0.};
-    array<float,1> meanKaon = {0.};
-    array<float,1> meanProton = {0.};
-    array<float,1> sigmaPion = {1.};
-    array<float,1> sigmaKaon = {1.};
-    array<float,1> sigmaProton = {1.};
-    copy(pTPClims.begin(),pTPClims.end(),fPlimitsNsigmaTPCDataCorr);
-    copy(meanPion.begin(),meanPion.end(),fMeanNsigmaTPCPionData);
-    copy(meanKaon.begin(),meanKaon.end(),fMeanNsigmaTPCKaonData);
-    copy(meanProton.begin(),meanProton.end(),fMeanNsigmaTPCProtonData);
-    copy(sigmaPion.begin(),sigmaPion.end(),fSigmaNsigmaTPCPionData);
-    copy(sigmaKaon.begin(),sigmaKaon.end(),fSigmaNsigmaTPCKaonData);
-    copy(sigmaProton.begin(),sigmaProton.end(),fSigmaNsigmaTPCProtonData);
-  }
 }
 
 //________________________________________________________________

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.h
@@ -47,12 +47,6 @@ public:
     kCentCL1
   };
 
-  enum SystemForNsigmaDataCorr {
-    kNone=-1,
-    kPbPb010,
-    kPbPb3050
-  };
-
   AliAnalysisTaskSEHFSystPID();
   AliAnalysisTaskSEHFSystPID(const char *name, int system=0);
   virtual ~AliAnalysisTaskSEHFSystPID();

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.h
@@ -47,6 +47,12 @@ public:
     kCentCL1
   };
 
+  enum SystemForNsigmaDataCorr {
+    kNone=-1,
+    kPbPb010,
+    kPbPb3050
+  };
+
   AliAnalysisTaskSEHFSystPID();
   AliAnalysisTaskSEHFSystPID(const char *name, int system=0);
   virtual ~AliAnalysisTaskSEHFSystPID();
@@ -65,6 +71,11 @@ public:
   void EnableDownSampling(double fractokeep=0.1, double ptmax=1.5)            {fEnabledDownSampling=true; fFracToKeepDownSampling=fractokeep; fPtMaxDownSampling=ptmax;}
   void SetAODMismatchProtection(int opt=1)                                    {fAODProtection=opt;}
   
+  void EnableNsigmaDataDrivenCorrection(int syst) {
+    fEnableNsigmaTPCDataCorr = true;
+    fSystNsigmaTPCDataCorr = syst;
+  }
+
 private:
 
   bool IsVertexAccepted();
@@ -77,6 +88,8 @@ private:
   float GetTOFmomentum(AliAODTrack* track);
   short ConvertFloatToShort(float num);
   unsigned short ConvertFloatToUnsignedShort(float num);
+  void GetNsigmaTPCMeanSigmaData(float &mean, float &sigma, AliPID::EParticleType species, float pTPC);
+  void SetNsigmaTPCDataCorr(int run);
 
   enum hypos{kPion,kKaon,kProton};
   static const int kNHypo = 3;
@@ -134,7 +147,19 @@ private:
   
   int fAODProtection;                              /// flag to activate protection against AOD-dAOD mismatch
 
-  ClassDef(AliAnalysisTaskSEHFSystPID, 2);
+  int fRunNumberPrevEvent;                         /// run number of previous event
+  bool fEnableNsigmaTPCDataCorr;                   /// flag to enable data-driven NsigmaTPC correction
+  int fSystNsigmaTPCDataCorr;                      /// system for data-driven NsigmaTPC correction
+  float fMeanNsigmaTPCPionData[100];               /// array of NsigmaTPC pion mean in data 
+  float fMeanNsigmaTPCKaonData[100];               /// array of NsigmaTPC kaon mean in data 
+  float fMeanNsigmaTPCProtonData[100];             /// array of NsigmaTPC proton mean in data 
+  float fSigmaNsigmaTPCPionData[100];              /// array of NsigmaTPC pion mean in data 
+  float fSigmaNsigmaTPCKaonData[100];              /// array of NsigmaTPC kaon mean in data 
+  float fSigmaNsigmaTPCProtonData[100];            /// array of NsigmaTPC proton mean in data 
+  float fPlimitsNsigmaTPCDataCorr[101];            /// array of p limits for data-driven NsigmaTPC correction
+  int fNPbinsNsigmaTPCDataCorr;                    /// number of p bins for data-driven NsigmaTPC correction
+
+  ClassDef(AliAnalysisTaskSEHFSystPID, 3);
 };
 
 #endif

--- a/PWGHF/vertexingHF/AliRDHFCuts.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCuts.cxx
@@ -523,7 +523,7 @@ void AliRDHFCuts::SetupPID(AliVEvent *event) {
     }
 
     if(fEnableNsigmaTPCDataCorr) {
-      fPidHF->SetNsigmaTPCDataDrivenCorrection(event->GetRunNumber(),fSystemForNsigmaTPCDataCorr);
+      fPidHF->EnableNsigmaTPCDataCorr(event->GetRunNumber(),fSystemForNsigmaTPCDataCorr);
     }
   }
 }

--- a/PWGHF/vertexingHF/AliRDHFCuts.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCuts.cxx
@@ -137,7 +137,9 @@ fUsePreselect(0),
 fAliEventCuts(0x0),
 fApplyCentralityCorrCuts(kFALSE),
 fApplyPbPbOutOfBunchPileupCuts(0),
-fUseAliEventCuts(kFALSE)
+fUseAliEventCuts(kFALSE),
+fEnableNsigmaTPCDataCorr(kFALSE),
+fSystemForNsigmaTPCDataCorr(AliAODPidHF::kNone)
 {
   //
   // Default Constructor
@@ -223,7 +225,9 @@ AliRDHFCuts::AliRDHFCuts(const AliRDHFCuts &source) :
   fAliEventCuts(source.fAliEventCuts),
   fApplyCentralityCorrCuts(source.fApplyCentralityCorrCuts),
   fApplyPbPbOutOfBunchPileupCuts(source.fApplyPbPbOutOfBunchPileupCuts),
-  fUseAliEventCuts(source.fUseAliEventCuts)
+  fUseAliEventCuts(source.fUseAliEventCuts),
+  fEnableNsigmaTPCDataCorr(source.fEnableNsigmaTPCDataCorr),
+  fSystemForNsigmaTPCDataCorr(source.fSystemForNsigmaTPCDataCorr)
 {
   //
   // Copy constructor
@@ -333,6 +337,9 @@ AliRDHFCuts &AliRDHFCuts::operator=(const AliRDHFCuts &source)
   fApplyCentralityCorrCuts=source.fApplyCentralityCorrCuts;
   fApplyPbPbOutOfBunchPileupCuts=source.fApplyPbPbOutOfBunchPileupCuts;
   fUseAliEventCuts=source.fUseAliEventCuts;
+  fEnableNsigmaTPCDataCorr=source.fEnableNsigmaTPCDataCorr;
+  fSystemForNsigmaTPCDataCorr=source.fSystemForNsigmaTPCDataCorr;
+
   PrintAll();
 
   return *this;
@@ -513,6 +520,10 @@ void AliRDHFCuts::SetupPID(AliVEvent *event) {
     }else{
       // check that AliPIDResponse object was properly set in case of using OADB
       if(fPidHF->GetPidResponse()==0x0) AliFatal("AliPIDResponse object not set");
+    }
+
+    if(fEnableNsigmaTPCDataCorr) {
+      fPidHF->SetNsigmaTPCDataDrivenCorrection(event->GetRunNumber(),fSystemForNsigmaTPCDataCorr);
     }
   }
 }

--- a/PWGHF/vertexingHF/AliRDHFCuts.h
+++ b/PWGHF/vertexingHF/AliRDHFCuts.h
@@ -418,6 +418,11 @@ class AliRDHFCuts : public AliAnalysisCuts
 
   void SetZcutOnSPDvtx() { fApplyZcutOnSPDvtx=kTRUE; }
 
+  void EnableNsigmaDataDrivenCorrection(Bool_t enableNsigmaCorr, Int_t system) {
+    fEnableNsigmaTPCDataCorr = enableNsigmaCorr;
+    fSystemForNsigmaTPCDataCorr = system;
+  }
+
  protected:
 
   void SetNPtBins(Int_t nptBins){fnPtBins=nptBins;}
@@ -509,8 +514,11 @@ class AliRDHFCuts : public AliAnalysisCuts
   Int_t fApplyPbPbOutOfBunchPileupCuts; /// switch for additional correlation cuts for out-of-bunch pileup (0=no cut, 1=AliEVentCuts, 2=Ionut cut vs. nTPC cls)
   Bool_t fUseAliEventCuts;  /// flag for using AliEventCuts 
   
+  Bool_t fEnableNsigmaTPCDataCorr; /// flag to enable data-driven NsigmaTPC correction
+  Int_t fSystemForNsigmaTPCDataCorr; /// system for data-driven NsigmaTPC correction
+
   /// \cond CLASSIMP    
-  ClassDef(AliRDHFCuts,47);  /// base class for cuts on AOD reconstructed heavy-flavour decays
+  ClassDef(AliRDHFCuts,48);  /// base class for cuts on AOD reconstructed heavy-flavour decays
   /// \endcond
 };
 

--- a/PWGHF/vertexingHF/macros/AddTaskHFSystPID.C
+++ b/PWGHF/vertexingHF/macros/AddTaskHFSystPID.C
@@ -50,7 +50,7 @@ AliAnalysisTaskSEHFSystPID *AddTaskHFSystPID(int system = 0,
     mgr->AddTask(task);
 
     TString outputfile = AliAnalysisManager::GetCommonFileName();
-    outputfile += ":PWGHF_D2H_SystNsigmaPID";
+    outputfile += Form(":PWGHF_D2H_SystNsigmaPID%s",outputSuffix.Data());
 
     //define input container
     AliAnalysisDataContainer *cinput = mgr->CreateContainer("cinputPID",TChain::Class(),AliAnalysisManager::kInputContainer);


### PR DESCRIPTION
Implement a method to apply a correction to the NsigmaTPC for pion, kaon and proton (independently) in LHC18q and LHC18r data. The correction is implemented as:

NsigmaCorr = (Nsigma - mean(Nsigma)) / sigma(Nsigma)

where mean(Nsigma) and sigma(Nsigma) are the mean and sigma values of the Nsigma distributions extracted from the data using tagged samples of pions, kaons and protons