### PR TITLE
Update code for HF PID syst

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSEDmesonPIDSysProp.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEDmesonPIDSysProp.cxx
@@ -56,7 +56,8 @@ fKaonTOFHistoOpt(kSamePionV0tag),
 fAODProtection(1),
 fNPtBins(0),
 fPtLimits(nullptr),
-fAnalysisCuts(nullptr)
+fAnalysisCuts(nullptr),
+fVarForProp(kPt)
 {
   for(int iHist=0; iHist<2; iHist++) {
     fHistEffPionTPC[iHist]=nullptr;
@@ -91,7 +92,8 @@ fKaonTOFHistoOpt(kSamePionV0tag),
 fAODProtection(1),
 fNPtBins(0),
 fPtLimits(nullptr),
-fAnalysisCuts(cuts)
+fAnalysisCuts(cuts),
+fVarForProp(kPt)
 {
   for(int iHist=0; iHist<2; iHist++) {
     fHistEffPionTPC[iHist]=nullptr;
@@ -165,8 +167,14 @@ void AliAnalysisTaskSEDmesonPIDSysProp::UserCreateOutputObjects()
   }
   if(fPtLimits[fNPtBins]>100) fPtLimits[fNPtBins] = 100.;
   
+  TString varname = "";
+  if(fVarForProp==kPt) 
+    varname = "#it{p}_{T}";
+  else if(fVarForProp==kP) 
+    varname = "#it{p}";
+
   fHistSystPIDEffD = new TH2F("fHistSystPIDEffD","PID efficiency systematic uncertainty; #it{p}_{T}^{D} (GeV/#it{c}); relative systematic uncertainty",fNPtBins,fPtLimits,500,0.,0.5);
-  fHistPtDauVsD = new TH2F("fHistPtDauVsD","#it{p}_{T} Dau vs #it{p}_{T} D; #it{p}_{T}^{D} (GeV/#it{c}); #it{p}_{T}^{daugh} (GeV/#it{c})",static_cast<int>(fPtLimits[fNPtBins] * 10),0.,fPtLimits[fNPtBins],static_cast<int>(fPtLimits[fNPtBins] * 10),0.,fPtLimits[fNPtBins]);
+  fHistPtDauVsD = new TH2F("fHistPtDauVsD",Form("%s Dau vs #it{p}_{T} D; #it{p}_{T}^{D} (GeV/#it{c}); %s^{daugh} (GeV/#it{c})",varname.Data(),varname.Data()),static_cast<int>(fPtLimits[fNPtBins] * 10),0.,fPtLimits[fNPtBins],static_cast<int>(fPtLimits[fNPtBins] * 10),0.,fPtLimits[fNPtBins]);
   fOutput->Add(fHistSystPIDEffD);
   fOutput->Add(fHistPtDauVsD);
     
@@ -560,13 +568,19 @@ double AliAnalysisTaskSEDmesonPIDSysProp::GetDmesonPIDuncertainty(AliAODTrack *t
     
     int daupdgcode = TMath::Abs(p->GetPdgCode());
     double daupt = track[iDau]->Pt();
+    double daupTPC = track[iDau]->GetTPCmomentum();
+    double dauvar = -1.;
+    if(fVarForProp==kPt)
+      dauvar = daupt;
+    else if(fVarForProp==kP)
+      dauvar = daupTPC;
 
     bool isTPCok = false;
     bool isTOFok = false;
     if(fPIDresp->CheckPIDStatus(AliPIDResponse::kTPC,track[iDau]) == AliPIDResponse::kDetPidOk) isTPCok = true;
     if(fPIDresp->CheckPIDStatus(AliPIDResponse::kTOF,track[iDau]) == AliPIDResponse::kDetPidOk) isTOFok = true;
 
-    int bin = fHistSystPionTPC[0]->GetXaxis()->FindBin(daupt);
+    int bin = fHistSystPionTPC[0]->GetXaxis()->FindBin(dauvar);
     double systTPC=0.;
     double systTOF=0.;
     double probTPC=0.;
@@ -624,7 +638,7 @@ double AliAnalysisTaskSEDmesonPIDSysProp::GetDmesonPIDuncertainty(AliAODTrack *t
       probTPCandTOF = probTPC*probTOF;
       if(probTPCandTOF>1.e-20) syst += TMath::Sqrt(probTPC*probTPC*systTOF*systTOF+probTOF*probTOF*systTPC*systTPC)/probTPCandTOF;
     }
-    fHistPtDauVsD->Fill(ptD,daupt);
+    fHistPtDauVsD->Fill(ptD,dauvar);
   }
   
   return TMath::Abs(syst);

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEDmesonPIDSysProp.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEDmesonPIDSysProp.h
@@ -25,6 +25,8 @@ public:
   enum KaonTOFhisto {kKaonTPCtag,kSamePionV0tag};
   enum KaonTPChisto {kKaonTOFtag,kKaonKinkstag};
 
+  enum VarForProp {kPt, kP};
+
   AliAnalysisTaskSEDmesonPIDSysProp();
   AliAnalysisTaskSEDmesonPIDSysProp(int ch, AliRDHFCuts* cuts, TString systfilename);
   virtual ~AliAnalysisTaskSEDmesonPIDSysProp();
@@ -37,6 +39,7 @@ public:
   void SetPIDEffSystFileName(TString filename) {fSystFileName=filename;}
   void SetPIDStrategy(int PIDst=kStrongPID) {fPIDstrategy=PIDst;}
   void SetKaonHistoOptions(int tpcopt, int tofopt) {fKaonTPCHistoOpt=tpcopt; fKaonTOFHistoOpt=tofopt;}
+  void SetVariableForUncProp(int var=kPt) {fVarForProp=var;}
 
   int GetDecayChannel()const {return fDecayChannel;}
   
@@ -76,9 +79,11 @@ private:
   int fNPtBins;                   /// number of pT bins
   double *fPtLimits;              //! limits of pT bins
   
-  AliRDHFCuts* fAnalysisCuts;   /// cuts
+  AliRDHFCuts* fAnalysisCuts;     /// cuts
   
-  ClassDef(AliAnalysisTaskSEDmesonPIDSysProp, 1);
+  int fVarForProp;                /// variable used for propagation (p or pT)
+
+  ClassDef(AliAnalysisTaskSEDmesonPIDSysProp, 2);
 };
 
 #endif

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.cxx
@@ -66,6 +66,7 @@ fFillTreeWithNsigmaPIDOnly(false),
 fEnabledDownSampling(false),
 fFracToKeepDownSampling(0.1),
 fPtMaxDownSampling(1.5),
+fDownSamplingOpt(0),
 fAODProtection(1),
 fRunNumberPrevEvent(-1),
 fEnableNsigmaTPCDataCorr(false),
@@ -143,6 +144,7 @@ fFillTreeWithNsigmaPIDOnly(false),
 fEnabledDownSampling(false),
 fFracToKeepDownSampling(0.1),
 fPtMaxDownSampling(1.5),
+fDownSamplingOpt(0),
 fAODProtection(1),
 fRunNumberPrevEvent(-1),
 fEnableNsigmaTPCDataCorr(false),
@@ -391,9 +393,10 @@ void AliAnalysisTaskSEHFSystPID::UserExec(Option_t */*option*/)
     //applying ESDtrackCut
     if(!fESDtrackCuts->IsSelected(track)) continue;
 
-    if(fEnabledDownSampling && track->Pt()<fPtMaxDownSampling) {
+    if(fEnabledDownSampling && fFracToKeepDownSampling<1. && track->Pt()<fPtMaxDownSampling) {
       double pseudoRand = track->Pt()*1000.-(long)(track->Pt()*1000);
-      if(pseudoRand>fFracToKeepDownSampling) continue;
+      if(fDownSamplingOpt==0 && pseudoRand>fFracToKeepDownSampling) continue; //keep tracks with pseudorand < fFracToKeepDownSampling
+      else if(fDownSamplingOpt==1 && pseudoRand<(1-fFracToKeepDownSampling)) continue; //keep tracks with pseudorand > 1-fFracToKeepDownSampling
     }
 
     fPt = ConvertFloatToUnsignedShort(track->Pt()*1000);

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEHFSystPID.h
@@ -62,9 +62,10 @@ public:
   void SetNsigmaKaonForTagging(float nsigmamax = 0.02)                        {fNsigmaMaxForTag=nsigmamax;}
   void SetKinksSelections(float qtmin=0.15, float Rmin=120, float Rmax=210)   {fQtMinKinks=qtmin; fRMinKinks=Rmin; fRMaxKinks=Rmax;}
   void SetfFillTreeWithNsigmaPIDOnly(bool fillonlyNsigma=true)                {fFillTreeWithNsigmaPIDOnly=fillonlyNsigma;}
-  void EnableDownSampling(double fractokeep=0.1, double ptmax=1.5)            {fEnabledDownSampling=true; fFracToKeepDownSampling=fractokeep; fPtMaxDownSampling=ptmax;}
+  void EnableDownSampling(double fractokeep=0.1, double ptmax=1.5, int opt=0) {fEnabledDownSampling=true; fFracToKeepDownSampling=fractokeep; fPtMaxDownSampling=ptmax; fDownSamplingOpt=opt;}
   void SetAODMismatchProtection(int opt=1)                                    {fAODProtection=opt;}
-  
+  void SetDownSamplingOption(int opt=0)                                       {fDownSamplingOpt=opt;}
+
   void EnableNsigmaDataDrivenCorrection(int syst) {
     fEnableNsigmaTPCDataCorr = true;
     fSystNsigmaTPCDataCorr = syst;
@@ -138,6 +139,7 @@ private:
   bool fEnabledDownSampling;                       /// flag to enable/disable downsampling
   double fFracToKeepDownSampling;                  /// fraction to keep when downsampling activated
   double fPtMaxDownSampling;                       /// pT max of tracks to downsample
+  int fDownSamplingOpt;                            /// option for downsampling 
   
   int fAODProtection;                              /// flag to activate protection against AOD-dAOD mismatch
 
@@ -153,7 +155,7 @@ private:
   float fPlimitsNsigmaTPCDataCorr[101];            /// array of p limits for data-driven NsigmaTPC correction
   int fNPbinsNsigmaTPCDataCorr;                    /// number of p bins for data-driven NsigmaTPC correction
 
-  ClassDef(AliAnalysisTaskSEHFSystPID, 3);
+  ClassDef(AliAnalysisTaskSEHFSystPID, 4);
 };
 
 #endif


### PR DESCRIPTION
1) add possibility to use daughter-track p instead of daughter-track pT for systematic propagation to the D mesons

2) add additional option for track downsampling in order to have independent samples (e.g. one for the calibration of Nsigma and another one to estimate the residual systematic uncertainty)