### PR TITLE
Move AliAnalysisTaskHFJetIPQA to PWGJE/FlavourJetTasks

### DIFF
--- a/PWGHF/jetsHF/CMakeLists.txt
+++ b/PWGHF/jetsHF/CMakeLists.txt
@@ -47,8 +47,7 @@ include_directories(${ROOT_INCLUDE_DIRS}
 set(SRCS
     AliHFJetsTagging.cxx
     AliHFJetTaggingIP.cxx
-    AliAnalysisTaskBJetTC.cxx	
-    AliAnalysisTaskHFJetIPQA.cxx	
+    AliAnalysisTaskBJetTC.cxx		
     AliAnalysisHFjetTagHFE.cxx
     AliAnalysisTaskEmcalHFCJQA.cxx	    
     AliAnalysisTaskEmcalHFeJetCorrel.cxx		    

--- a/PWGHF/jetsHF/PWGHFjetsHFLinkDef.h
+++ b/PWGHF/jetsHF/PWGHFjetsHFLinkDef.h
@@ -18,7 +18,6 @@
 #pragma link C++ class AliAnalysisHFjetTagHFE+;
 #pragma link C++ class AliAnalysisTaskEmcalHFCJQA+;
 #pragma link C++ class AliAnalysisTaskEmcalHFeJetCorrel+;
-#pragma link C++ class AliAnalysisTaskHFJetIPQA+;
 #pragma link C++ class AliAnalysisTaskBJetTC+;
 #pragma link C++ class AliDJetRawYieldUncertainty+;
 #pragma link C++ class AliAnalysisTaskDJetCorrelations+;

--- a/PWGJE/FlavourJetTasks/CMakeLists.txt
+++ b/PWGJE/FlavourJetTasks/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SRCS
     AliPicoV0RD.cxx
     AliPicoV0.cxx
     AliPicoBase.cxx
+    AliAnalysisTaskHFJetIPQA.cxx
    )
 
 if(FASTJET_FOUND)
@@ -67,6 +68,7 @@ if(FASTJET_FOUND)
            AliAnalysisTaskHFSubstructure.cxx
            AliDJetTTreeReader.cxx
            AliDJetTHnReader.cxx
+	   AliAnalysisTaskHFJetIPQA.cxx
            )
 endif(FASTJET_FOUND)
 

--- a/PWGJE/FlavourJetTasks/PWGJEFlavourJetTasksLinkDef.h
+++ b/PWGJE/FlavourJetTasks/PWGJEFlavourJetTasksLinkDef.h
@@ -46,6 +46,7 @@
 #pragma link C++ class std::pair<int,AliAnalysisTaskDmesonJets::AliDmesonJetInfo>+;
 #pragma link C++ class std::pair<std::string,AliAnalysisTaskDmesonJets::AliJetInfo>+;
 #pragma link C++ class AliAnalysisTaskDmesonJets+;
+#pragma link C++ class AliAnalysisTaskHFJetIPQA+;
 
 #pragma link C++ class AliAnalysisTaskDmesonJetsSub::AliJetInfo+;
 #pragma link C++ class AliAnalysisTaskDmesonJetsSub::AliDmesonJetInfo+;

--- a/PWGJE/FlavourJetTasks/macros/AddTaskHFJetIPQA.C
+++ b/PWGJE/FlavourJetTasks/macros/AddTaskHFJetIPQA.C
@@ -85,6 +85,11 @@ AliAnalysisTaskHFJetIPQA* AddTaskHFJetIPQA(
     }
     // Load and setup Monte Carlo composition correction factors from file
     //==============================================================================
+    if (!TGrid::Connect("alien://"))  {
+        printf("NoGridConnectionAvailable!\n");
+        return 0x0;
+    }
+
     TFile* fileMCoverDataWeights;
     if(isMC){
         if(PathToWeights.EqualTo("") ) {
@@ -198,7 +203,7 @@ AliAnalysisTaskHFJetIPQA* AddTaskHFJetIPQA(
         // Setup initial ESD track cuts
         //==============================================================================
       //  jetTask->SetRunESD();
-        AliESDtrackCuts * trackCuts = new AliESDtrackCuts();
+        /*AliESDtrackCuts * trackCuts = new AliESDtrackCuts();
         // trackCuts->SetMaxFractionSharedTPCClusters(0.4);
         // TFormula *f1NClustersTPCLinearPtDep = new TFormula("f1NClustersTPCLinearPtDep","70.+30./20.*x");
         //trackCuts->SetMinNClustersTPCPtDep(f1NClustersTPCLinearPtDep, 100);
@@ -218,7 +223,7 @@ AliAnalysisTaskHFJetIPQA* AddTaskHFJetIPQA(
         // trackCuts->SetMaxDCAToVertexXY(1E10);
         trackCuts->SetHistogramsOn(kTRUE);
         trackCuts->DefineHistograms();
-        jetTask->SetESDCuts(new AliESDtrackCuts(*trackCuts));
+        jetTask->SetESDCuts(new AliESDtrackCuts(*trackCuts));*/
     }
 
     //  Final settings, pass to manager and set the containers


### PR DESCRIPTION
- move PWGHF/jetsHF/AliAnalysisTaskHFJetIPQA to PWGJE/FlavourJetTasks for easy use of fastjet
- add routines for investigating the inclusive Lund Plane
- change flavour assignment (Pythia8: select particles outgoing from hardest process+MPI and do geometrical matching. Matching in terms of jet constituents can be turned on via fDoFlavourMatching)
- split routine for flavour assignment in subroutines for better overview
- add further monitoring histograms for flavour assignment
- delete Canvas monitoring cut settings and replace by histogram with cuts encoded in title and axis labels