### PR TITLE
PWGUD/UPC: Changed binning of 2D distributions for helicity analysis in the MC.

### DIFF
--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
@@ -772,13 +772,17 @@ void AliAnalysisTaskUPCforwardMC::UserCreateOutputObjects()
   fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH =
         new TH2F( "fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH",
                   "fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH",
-                  80, -4, 4, 80, -1, 1);
+                  80, -1, 1,
+                  80, -4, 4
+                  );
   fOutputList->Add(fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH);
 
   fMCInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH =
         new TH2F( "fMCInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH",
                   "fMCInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH",
-                  80, -4, 4, 80, -1, 1);
+                  80, -1, 1,
+                  80, -4, 4
+                  );
   fOutputList->Add(fMCInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH);
 
   //_______________________________


### PR DESCRIPTION
The LEGO train results showed that I had set the binning wrongly.
Now Phi is ~-4 to 4 and CosTheta ~-1 to 1.