### PR TITLE
Get the FemtoDream ready for NanoAODs

### DIFF
--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskFemtoDreamPhi.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskFemtoDreamPhi.cxx
@@ -145,10 +145,14 @@ void AliAnalysisTaskFemtoDreamPhi::UserExec(Option_t *) {
   static std::vector<AliFemtoDreamBasePart> V0Particles;
   V0Particles.clear();
 
+  static float massKaon =
+      TDatabasePDG::Instance()->GetParticle(fPosKaonCuts->GetPDGCode())->Mass();
+
   for (int iTrack = 0; iTrack < Event->GetNumberOfTracks(); ++iTrack) {
     AliAODTrack *track = static_cast<AliAODTrack *>(Event->GetTrack(iTrack));
     if (!track) continue;
     fTrack->SetTrack(track);
+    fTrack->SetInvMass(massKaon);
     if (fPosKaonCuts->isSelected(fTrack)) {
       Particles.push_back(*fTrack);
     }
@@ -157,12 +161,10 @@ void AliAnalysisTaskFemtoDreamPhi::UserExec(Option_t *) {
     }
   }
 
-  static float massKaon =
-      TDatabasePDG::Instance()->GetParticle(fPosKaonCuts->GetPDGCode())->Mass();
   fPhiParticle->SetGlobalTrackInfo(fGTI, fTrackBufferSize);
   for (const auto &posK : Particles) {
     for (const auto &negK : AntiParticles) {
-      fPhiParticle->Setv0(posK, massKaon, negK, massKaon);
+      fPhiParticle->Setv0(posK, negK);
       if (fPhiCuts->isSelected(fPhiParticle)) {
         V0Particles.push_back(*fPhiParticle);
       }

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskGrandma.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskGrandma.h
@@ -68,6 +68,8 @@ class AliAnalysisTaskGrandma : public AliAnalysisTaskSE {
   }
   ;
  private:
+  AliAnalysisTaskGrandma(const AliAnalysisTaskGrandma &task);
+  AliAnalysisTaskGrandma &operator=(const AliAnalysisTaskGrandma &task);
   int fTrackBufferSize;                     //
   bool fIsMC;                               //
   TList *fQA;                               //!

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskNanoAODSigma0Femto.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskNanoAODSigma0Femto.cxx
@@ -1,0 +1,520 @@
+#include "AliAnalysisTaskNanoAODSigma0Femto.h"
+
+#include "AliAnalysisManager.h"
+#include "AliInputEventHandler.h"
+#include "AliMCEvent.h"
+#include "AliMultSelection.h"
+#include "AliNanoAODTrack.h"
+#include "AliPIDResponse.h"
+
+ClassImp(AliAnalysisTaskNanoAODSigma0Femto)
+
+    //____________________________________________________________________________________________________
+    AliAnalysisTaskNanoAODSigma0Femto::AliAnalysisTaskNanoAODSigma0Femto()
+    : AliAnalysisTaskSE("AliAnalysisTaskNanoAODSigma0Femto"),
+      fInputEvent(nullptr),
+      fMCEvent(nullptr),
+      fV0Reader(nullptr),
+      //      fPhotonQA(nullptr),
+      fSigmaCuts(nullptr),
+      fAntiSigmaCuts(nullptr),
+      fRandom(nullptr),
+      fEvent(nullptr),
+      fEvtCuts(nullptr),
+      fProtonTrack(nullptr),
+      fTrackCutsPartProton(nullptr),
+      fTrackCutsPartAntiProton(nullptr),
+      fLambda(nullptr),
+      fV0Cuts(nullptr),
+      fAntiV0Cuts(nullptr),
+      fConfig(nullptr),
+      fPairCleaner(nullptr),
+      fPartColl(nullptr),
+      fIsMC(false),
+      fIsLightweight(false),
+      fV0PercentileMax(100.f),
+      fTrigger(AliVEvent::kINT7),
+      fGammaArray(nullptr),
+      fTrackBufferSize(2500),
+      fGTI(nullptr),
+      fQA(nullptr),
+      fEvtHistList(nullptr),
+      fTrackCutHistList(nullptr),
+      fTrackCutHistMCList(nullptr),
+      fAntiTrackCutHistList(nullptr),
+      fAntiTrackCutHistMCList(nullptr),
+      fLambdaHistList(nullptr),
+      fLambdaHistMCList(nullptr),
+      fAntiLambdaHistList(nullptr),
+      fAntiLambdaHistMCList(nullptr),
+      fPhotonHistList(nullptr),
+      fSigmaHistList(nullptr),
+      fAntiSigmaHistList(nullptr),
+      fResultList(nullptr),
+      fResultQAList(nullptr) {
+  fRandom = new TRandom3();
+}
+
+//____________________________________________________________________________________________________
+AliAnalysisTaskNanoAODSigma0Femto::AliAnalysisTaskNanoAODSigma0Femto(
+    const char *name, const bool isMC)
+    : AliAnalysisTaskSE(name),
+      fInputEvent(nullptr),
+      fMCEvent(nullptr),
+      fV0Reader(nullptr),
+      //      fPhotonQA(nullptr),
+      fSigmaCuts(nullptr),
+      fAntiSigmaCuts(nullptr),
+      fRandom(nullptr),
+      fEvent(nullptr),
+      fEvtCuts(nullptr),
+      fProtonTrack(nullptr),
+      fTrackCutsPartProton(nullptr),
+      fTrackCutsPartAntiProton(nullptr),
+      fLambda(nullptr),
+      fV0Cuts(nullptr),
+      fAntiV0Cuts(nullptr),
+      fConfig(nullptr),
+      fPairCleaner(nullptr),
+      fPartColl(nullptr),
+      fIsMC(isMC),
+      fIsLightweight(false),
+      fV0PercentileMax(100.f),
+      fTrigger(AliVEvent::kINT7),
+      fGammaArray(nullptr),
+      fTrackBufferSize(2500),
+      fGTI(nullptr),
+      fQA(nullptr),
+      fEvtHistList(nullptr),
+      fTrackCutHistList(nullptr),
+      fTrackCutHistMCList(nullptr),
+      fAntiTrackCutHistList(nullptr),
+      fAntiTrackCutHistMCList(nullptr),
+      fLambdaHistList(nullptr),
+      fLambdaHistMCList(nullptr),
+      fAntiLambdaHistList(nullptr),
+      fAntiLambdaHistMCList(nullptr),
+      fPhotonHistList(nullptr),
+      fSigmaHistList(nullptr),
+      fAntiSigmaHistList(nullptr),
+      fResultList(nullptr),
+      fResultQAList(nullptr) {
+  DefineInput(0, TChain::Class());
+  DefineOutput(1, TList::Class());
+  DefineOutput(2, TList::Class());
+  DefineOutput(3, TList::Class());
+  DefineOutput(4, TList::Class());
+  DefineOutput(5, TList::Class());
+  DefineOutput(6, TList::Class());
+  DefineOutput(7, TList::Class());
+  DefineOutput(8, TList::Class());
+  DefineOutput(9, TList::Class());
+  DefineOutput(10, TList::Class());
+  DefineOutput(11, TList::Class());
+
+  fRandom = new TRandom3();
+  if (fIsMC) {
+    DefineOutput(12, TList::Class());
+    DefineOutput(13, TList::Class());
+    DefineOutput(14, TList::Class());
+    DefineOutput(15, TList::Class());
+  }
+}
+
+//____________________________________________________________________________________________________
+AliAnalysisTaskNanoAODSigma0Femto::~AliAnalysisTaskNanoAODSigma0Femto() {
+  delete fPartColl;
+  delete fPairCleaner;
+  delete fProtonTrack;
+  delete fLambda;
+}
+//____________________________________________________________________________________________________
+void AliAnalysisTaskNanoAODSigma0Femto::UserExec(Option_t * /*option*/) {
+  AliVEvent *fInputEvent = InputEvent();
+  if (fIsMC) fMCEvent = MCEvent();
+
+  // PREAMBLE - CHECK EVERYTHING IS THERE
+  if (!fInputEvent) {
+    AliError("No Input event");
+    return;
+  }
+
+  if (fIsMC && !fMCEvent) {
+    AliError("No MC event");
+    return;
+  }
+
+  if (!fEvtCuts) {
+    AliError("Event Cuts missing");
+    return;
+  }
+
+  if (!fTrackCutsPartProton || !fTrackCutsPartAntiProton) {
+    AliError("Proton Cuts missing");
+    return;
+  }
+
+  if (!fV0Cuts || !fAntiV0Cuts) {
+    AliError("V0 Cuts missing");
+    return;
+  }
+
+  if (!fSigmaCuts || !fAntiSigmaCuts) {
+    AliError("Sigma0 Cuts missing");
+    return;
+  }
+
+  // EVENT SELECTION
+  fEvent->SetEvent(fInputEvent);
+  if (!fEvtCuts->isSelected(fEvent)) return;
+
+  // PROTON SELECTION
+  ResetGlobalTrackReference();
+  for (int iTrack = 0; iTrack < fInputEvent->GetNumberOfTracks(); ++iTrack) {
+    AliVTrack *track = static_cast<AliVTrack *>(fInputEvent->GetTrack(iTrack));
+    if (!track) {
+      AliFatal("No Standard AOD");
+      return;
+    }
+    StoreGlobalTrackReference(track);
+  }
+  std::vector<AliFemtoDreamBasePart> Particles;
+  std::vector<AliFemtoDreamBasePart> AntiParticles;
+  const int multiplicity = fEvent->GetMultiplicity();
+  fProtonTrack->SetGlobalTrackInfo(fGTI, fTrackBufferSize);
+  for (int iTrack = 0; iTrack < fInputEvent->GetNumberOfTracks(); ++iTrack) {
+    AliVTrack *track = static_cast<AliVTrack *>(fInputEvent->GetTrack(iTrack));
+    fProtonTrack->SetTrack(track, fInputEvent, multiplicity);
+    if (fTrackCutsPartProton->isSelected(fProtonTrack)) {
+      Particles.push_back(*fProtonTrack);
+    }
+    if (fTrackCutsPartAntiProton->isSelected(fProtonTrack)) {
+      AntiParticles.push_back(*fProtonTrack);
+    }
+  }
+
+  // LAMBDA SELECTION
+  std::vector<AliFemtoDreamBasePart> Decays;
+  std::vector<AliFemtoDreamBasePart> AntiDecays;
+
+  AliAODEvent *aod = dynamic_cast<AliAODEvent *>(fInputEvent);
+  if (aod->GetV0s()) {
+    fLambda->SetGlobalTrackInfo(fGTI, fTrackBufferSize);
+    for (int iv0 = 0;
+         iv0 < static_cast<TClonesArray *>(aod->GetV0s())->GetEntriesFast();
+         iv0++) {
+      AliAODv0 *v0 = aod->GetV0(iv0);
+      fLambda->Setv0(fInputEvent, v0, multiplicity);
+      if (fV0Cuts->isSelected(fLambda)) {
+        Decays.push_back(*fLambda);
+      }
+      if (fAntiV0Cuts->isSelected(fLambda)) {
+        AntiDecays.push_back(*fLambda);
+      }
+    }
+  }
+
+  // PHOTON SELECTION
+  fGammaArray = dynamic_cast<TClonesArray *>(
+      fInputEvent->FindListObject("conversionphotons"));
+  std::vector<AliFemtoDreamBasePart> Gammas;
+  CastToVector(Gammas, aod);
+  //  if (!fIsLightweight) {
+  //    fPhotonQA->PhotonQA(fInputEvent, fMCEvent, fGammaArray);
+  //  }
+
+  // Sigma0 selection
+  fSigmaCuts->SelectPhotonMother(fInputEvent, fMCEvent, Gammas, Decays);
+
+  // Sigma0 selection
+  fAntiSigmaCuts->SelectPhotonMother(fInputEvent, fMCEvent, Gammas, AntiDecays);
+
+  auto sigma0particles = fSigmaCuts->GetSigma();
+  auto sigma0sidebandUp = fSigmaCuts->GetSidebandUp();
+  auto sigma0sidebandLow = fSigmaCuts->GetSidebandDown();
+
+  auto antiSigma0particles = fAntiSigmaCuts->GetSigma();
+  auto antiSigma0sidebandUp = fAntiSigmaCuts->GetSidebandUp();
+  auto antiSigma0sidebandLow = fAntiSigmaCuts->GetSidebandDown();
+
+  fPairCleaner->CleanTrackAndDecay(&Particles, &sigma0particles, 0);
+  fPairCleaner->CleanTrackAndDecay(&AntiParticles, &antiSigma0particles, 1);
+  fPairCleaner->CleanTrackAndDecay(&Particles, &sigma0sidebandUp, 2);
+  fPairCleaner->CleanTrackAndDecay(&AntiParticles, &antiSigma0sidebandUp, 3);
+  fPairCleaner->CleanTrackAndDecay(&Particles, &sigma0sidebandLow, 4);
+  fPairCleaner->CleanTrackAndDecay(&AntiParticles, &antiSigma0sidebandLow, 5);
+
+  fPairCleaner->ResetArray();
+  fPairCleaner->StoreParticle(Particles);
+  fPairCleaner->StoreParticle(AntiParticles);
+  fPairCleaner->StoreParticle(sigma0particles);
+  fPairCleaner->StoreParticle(antiSigma0particles);
+  fPairCleaner->StoreParticle(sigma0sidebandUp);
+  fPairCleaner->StoreParticle(antiSigma0sidebandUp);
+  fPairCleaner->StoreParticle(sigma0sidebandLow);
+  fPairCleaner->StoreParticle(antiSigma0sidebandLow);
+
+  fPartColl->SetEvent(fPairCleaner->GetCleanParticles(), fEvent->GetZVertex(),
+                      fEvent->GetMultiplicity(), fEvent->GetV0MCentrality());
+
+  // flush the data
+  PostData(1, fQA);
+  PostData(2, fEvtHistList);
+  PostData(3, fTrackCutHistList);
+  PostData(4, fAntiTrackCutHistList);
+  PostData(5, fLambdaHistList);
+  PostData(6, fAntiLambdaHistList);
+  PostData(7, fPhotonHistList);
+  PostData(8, fSigmaHistList);
+  PostData(9, fAntiSigmaHistList);
+  PostData(10, fResultList);
+  PostData(11, fResultQAList);
+  if (fIsMC) {
+    PostData(12, fTrackCutHistMCList);
+    PostData(13, fAntiTrackCutHistMCList);
+    PostData(14, fLambdaHistMCList);
+    PostData(15, fAntiLambdaHistMCList);
+  }
+}
+
+//____________________________________________________________________________________________________
+void AliAnalysisTaskNanoAODSigma0Femto::CastToVector(
+    std::vector<AliFemtoDreamBasePart> &container,
+    const AliVEvent *inputEvent) {
+  if (!fGammaArray) return;
+  for (int iGamma = 0; iGamma < fGammaArray->GetEntriesFast(); ++iGamma) {
+    auto *PhotonCandidate =
+        dynamic_cast<AliAODConversionPhoton *>(fGammaArray->At(iGamma));
+    if (!PhotonCandidate) continue;
+    auto pos = GetTrack(inputEvent, PhotonCandidate->GetTrackLabelPositive());
+    auto neg = GetTrack(inputEvent, PhotonCandidate->GetTrackLabelNegative());
+    if (!pos || !neg) continue;
+    container.push_back({PhotonCandidate, pos, neg, inputEvent});
+  }
+}
+
+//____________________________________________________________________________________________________
+AliVTrack *AliAnalysisTaskNanoAODSigma0Femto::GetTrack(const AliVEvent *event,
+                                                       int label) const {
+  if (fV0Reader->AreAODsRelabeled()) {
+    return dynamic_cast<AliVTrack *>(event->GetTrack(label));
+  } else {
+    return fGTI[label];
+  }
+}
+
+//____________________________________________________________________________________________________
+void AliAnalysisTaskNanoAODSigma0Femto::ResetGlobalTrackReference() {
+  // see AliFemtoDreamAnalysis for details
+  for (int i = 0; i < fTrackBufferSize; i++) {
+    fGTI[i] = 0;
+  }
+}
+
+//____________________________________________________________________________________________________
+void AliAnalysisTaskNanoAODSigma0Femto::StoreGlobalTrackReference(
+    AliVTrack *track) {
+  // see AliFemtoDreamAnalysis for details
+  AliNanoAODTrack *nanoTrack = dynamic_cast<AliNanoAODTrack *>(track);
+  const int trackID = track->GetID();
+  if (trackID < 0) {
+    return;
+  }
+  if (trackID >= fTrackBufferSize) {
+    printf("Warning: track ID too big for buffer: ID: %d, buffer %d\n", trackID,
+           fTrackBufferSize);
+    return;
+  }
+
+  if (fGTI[trackID]) {
+    if ((!nanoTrack->GetFilterMap()) && (!track->GetTPCNcls())) {
+      return;
+    }
+    if (dynamic_cast<AliNanoAODTrack *>(fGTI[trackID])->GetFilterMap() ||
+        fGTI[trackID]->GetTPCNcls()) {
+      printf("Warning! global track info already there!");
+      printf("         TPCNcls track1 %u track2 %u",
+             (fGTI[trackID])->GetTPCNcls(), track->GetTPCNcls());
+      printf("         FilterMap track1 %u track2 %u\n",
+             dynamic_cast<AliNanoAODTrack *>(fGTI[trackID])->GetFilterMap(),
+             nanoTrack->GetFilterMap());
+    }
+  }
+  (fGTI[trackID]) = track;
+}
+
+//____________________________________________________________________________________________________
+void AliAnalysisTaskNanoAODSigma0Femto::UserCreateOutputObjects() {
+  fGTI = new AliVTrack *[fTrackBufferSize];
+
+  fEvent = new AliFemtoDreamEvent(true, !fIsLightweight, fTrigger);
+
+  fProtonTrack = new AliFemtoDreamTrack();
+  fProtonTrack->SetUseMCInfo(fIsMC);
+
+  fLambda = new AliFemtoDreamv0();
+  fLambda->SetUseMCInfo(fIsMC);
+  fLambda->SetPDGCode(fV0Cuts->GetPDGv0());
+  fLambda->SetPDGDaughterPos(fV0Cuts->GetPDGPosDaug());
+  fLambda->GetPosDaughter()->SetUseMCInfo(fIsMC);
+  fLambda->SetPDGDaughterNeg(fV0Cuts->GetPDGNegDaug());
+  fLambda->GetNegDaughter()->SetUseMCInfo(fIsMC);
+
+  const int nPairs = 6;
+  fPairCleaner =
+      new AliFemtoDreamPairCleaner(nPairs, 0, fConfig->GetMinimalBookingME());
+  fPartColl =
+      new AliFemtoDreamPartCollection(fConfig, fConfig->GetMinimalBookingME());
+
+  fQA = new TList();
+  fQA->SetName("QA");
+  fQA->SetOwner(kTRUE);
+
+  if (!fV0Reader) {
+    AliError("No V0 reader");
+    //    return;
+  }
+
+  if (!fIsLightweight && fV0Reader) {
+    if (fV0Reader->GetConversionCuts() &&
+        fV0Reader->GetConversionCuts()->GetCutHistograms()) {
+      fQA->Add(fV0Reader->GetConversionCuts()->GetCutHistograms());
+    }
+  }
+
+  std::cout << "Setting up the event cuts \n";
+  std::cout << fEvtCuts << "\n";
+  if (fEvtCuts) {
+    fEvtCuts->InitQA();
+    fQA->Add(fEvent->GetEvtCutList());
+    if (fEvtCuts->GetHistList() && !fIsLightweight) {
+      fEvtHistList = fEvtCuts->GetHistList();
+    } else {
+      fEvtHistList = new TList();
+      fEvtHistList->SetName("EvtCuts");
+      fEvtHistList->SetOwner(true);
+    }
+  } else {
+    AliWarning("Event cuts are missing! \n");
+  }
+
+  if (!fConfig->GetMinimalBookingME() && fPairCleaner &&
+      fPairCleaner->GetHistList()) {
+    fQA->Add(fPairCleaner->GetHistList());
+  }
+
+  fTrackCutsPartProton->Init("Proton");
+  // necessary for the non-min booking case
+  fTrackCutsPartProton->SetName("Proton");
+
+  if (fTrackCutsPartProton && fTrackCutsPartProton->GetQAHists()) {
+    fTrackCutHistList = fTrackCutsPartProton->GetQAHists();
+    if (fIsMC && fTrackCutsPartProton->GetMCQAHists() &&
+        fTrackCutsPartProton->GetIsMonteCarlo()) {
+      fTrackCutHistMCList = fTrackCutsPartProton->GetMCQAHists();
+    }
+  }
+
+  fTrackCutsPartAntiProton->Init("Anti-proton");
+  // necessary for the non-min booking case
+  fTrackCutsPartAntiProton->SetName("Anti-proton");
+
+  if (fTrackCutsPartAntiProton && fTrackCutsPartAntiProton->GetQAHists()) {
+    fAntiTrackCutHistList = fTrackCutsPartAntiProton->GetQAHists();
+    if (fIsMC && fTrackCutsPartAntiProton->GetMCQAHists() &&
+        fTrackCutsPartAntiProton->GetIsMonteCarlo()) {
+      fAntiTrackCutHistMCList = fTrackCutsPartAntiProton->GetMCQAHists();
+    }
+  }
+
+  fV0Cuts->Init();
+  fAntiV0Cuts->Init();
+
+  if (fV0Cuts->GetQAHists()) {
+    fLambdaHistList = fV0Cuts->GetQAHists();
+  } else {
+    fLambdaHistList = new TList();
+    fLambdaHistList->SetName("v0Cuts");
+    fLambdaHistList->SetOwner();
+  }
+  if (fAntiV0Cuts->GetQAHists()) {
+    fAntiLambdaHistList = fAntiV0Cuts->GetQAHists();
+  } else {
+    fAntiLambdaHistList = new TList();
+    fAntiLambdaHistList->SetName("Antiv0Cuts");
+    fAntiLambdaHistList->SetOwner();
+  }
+  if (!fV0Cuts->GetMinimalBooking()) {
+    if (fV0Cuts->GetIsMonteCarlo()) {
+      fLambdaHistMCList = fV0Cuts->GetMCQAHists();
+    }
+  } else {
+    fLambdaHistMCList = new TList();
+    fLambdaHistMCList->SetName("MCv0Cuts");
+    fLambdaHistMCList->SetOwner();
+  }
+  if (!fAntiV0Cuts->GetMinimalBooking()) {
+    if (fAntiV0Cuts->GetIsMonteCarlo()) {
+      fAntiLambdaHistMCList = fAntiV0Cuts->GetMCQAHists();
+    }
+  } else {
+    fAntiLambdaHistMCList = new TList();
+    fAntiLambdaHistMCList->SetName("MCAntiv0Cuts");
+    fAntiLambdaHistMCList->SetOwner();
+  }
+
+  if (fSigmaCuts) fSigmaCuts->InitCutHistograms(TString("Sigma0"));
+  if (fAntiSigmaCuts) fAntiSigmaCuts->InitCutHistograms(TString("AntiSigma0"));
+
+  //  if (!fIsLightweight) {
+  //    fPhotonQA = new AliSigma0V0Cuts();
+  //    fPhotonQA->SetIsMC(fIsMC);
+  //    fPhotonQA->SetLightweight(false);
+  //    fPhotonQA->SetPID(22);
+  //    fPhotonQA->SetPosPID(AliPID::kElectron, 11);
+  //    fPhotonQA->SetNegPID(AliPID::kElectron, -11);
+  //    fPhotonQA->InitCutHistograms(TString("Photon"));
+  //    fPhotonHistList = fPhotonQA->GetCutHistograms();
+  //  } else {
+  //    fPhotonHistList = new TList();
+  //    fPhotonHistList->SetName("V0_Photon");
+  //    fPhotonHistList->SetOwner(true);
+  //  }
+
+  if (fSigmaCuts && fSigmaCuts->GetCutHistograms()) {
+    fSigmaHistList = fSigmaCuts->GetCutHistograms();
+  }
+
+  if (fAntiSigmaCuts && fAntiSigmaCuts->GetCutHistograms()) {
+    fAntiSigmaHistList = fAntiSigmaCuts->GetCutHistograms();
+  }
+
+  if (fPartColl && fPartColl->GetHistList()) {
+    fResultList = fPartColl->GetHistList();
+  }
+  if (!fConfig->GetMinimalBookingME() && fPartColl && fPartColl->GetQAList()) {
+    fResultQAList = fPartColl->GetQAList();
+  } else {
+    fResultQAList = new TList();
+    fResultQAList->SetName("ResultsQA");
+    fResultQAList->SetOwner(true);
+  }
+
+  PostData(1, fQA);
+  PostData(2, fEvtHistList);
+  PostData(3, fTrackCutHistList);
+  PostData(4, fAntiTrackCutHistList);
+  PostData(5, fLambdaHistList);
+  PostData(6, fAntiLambdaHistList);
+  PostData(7, fPhotonHistList);
+  PostData(8, fSigmaHistList);
+  PostData(9, fAntiSigmaHistList);
+  PostData(10, fResultList);
+  PostData(11, fResultQAList);
+  if (fIsMC) {
+    PostData(12, fTrackCutHistMCList);
+    PostData(13, fAntiTrackCutHistMCList);
+    PostData(14, fLambdaHistMCList);
+    PostData(15, fAntiLambdaHistMCList);
+  }
+}

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskNanoAODSigma0Femto.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskNanoAODSigma0Femto.h
@@ -1,0 +1,114 @@
+#ifndef AliAnalysisTaskNanoAODSigma0Femto_H
+#define AliAnalysisTaskNanoAODSigma0Femto_H
+
+#include "AliAnalysisTaskSE.h"
+#include "AliConvEventCuts.h"
+#include "AliEventCuts.h"
+#include "AliFemtoDreamCollConfig.h"
+#include "AliFemtoDreamEventCuts.h"
+#include "AliFemtoDreamPairCleaner.h"
+#include "AliFemtoDreamPartCollection.h"
+#include "AliFemtoDreamTrack.h"
+#include "AliFemtoDreamTrackCuts.h"
+#include "AliFemtoDreamv0.h"
+#include "AliFemtoDreamv0Cuts.h"
+#include "AliMCEvent.h"
+#include "AliSigma0AODPhotonMotherCuts.h"
+#include "AliStack.h"
+#include "AliV0ReaderV1.h"
+#include "TChain.h"
+
+class AliVParticle;
+class AliVTrack;
+
+class AliAnalysisTaskNanoAODSigma0Femto : public AliAnalysisTaskSE {
+ public:
+  AliAnalysisTaskNanoAODSigma0Femto();
+  AliAnalysisTaskNanoAODSigma0Femto(const char *name, const bool isMC);
+  virtual ~AliAnalysisTaskNanoAODSigma0Femto();
+
+  virtual void UserCreateOutputObjects();
+  virtual void UserExec(Option_t *option);
+
+  void CastToVector(std::vector<AliFemtoDreamBasePart> &container,
+                    const AliVEvent *inputEvent);
+  AliVTrack *GetTrack(const AliVEvent *event, int label) const;
+
+  void SetV0Reader(AliV0ReaderV1 *v0Reader) { fV0Reader = v0Reader; }
+  void SetIsMC(bool isMC) { fIsMC = isMC; }
+  void SetLightweight(bool isLightweight) { fIsLightweight = isLightweight; }
+  void SetV0Percentile(float v0perc) { fV0PercentileMax = v0perc; }
+  void SetTrigger(UInt_t trigger) { fTrigger = trigger; }
+  void SetEventCuts(AliFemtoDreamEventCuts *cuts) { fEvtCuts = cuts; }
+  void SetProtonCuts(AliFemtoDreamTrackCuts *cuts) {
+    fTrackCutsPartProton = cuts;
+  }
+  void SetAntiProtonCuts(AliFemtoDreamTrackCuts *cuts) {
+    fTrackCutsPartAntiProton = cuts;
+  }
+  void SetV0Cuts(AliFemtoDreamv0Cuts *cuts) { fV0Cuts = cuts; }
+  void SetAntiV0Cuts(AliFemtoDreamv0Cuts *cuts) { fAntiV0Cuts = cuts; }
+  void SetSigmaCuts(AliSigma0AODPhotonMotherCuts *cuts) { fSigmaCuts = cuts; }
+  void SetAntiSigmaCuts(AliSigma0AODPhotonMotherCuts *cuts) {
+    fAntiSigmaCuts = cuts;
+  }
+  void SetCollectionConfig(AliFemtoDreamCollConfig *config) {
+    fConfig = config;
+  }
+
+ private:
+  AliAnalysisTaskNanoAODSigma0Femto(
+      const AliAnalysisTaskNanoAODSigma0Femto &task);
+  AliAnalysisTaskNanoAODSigma0Femto &operator=(
+      const AliAnalysisTaskNanoAODSigma0Femto &task);
+  void ResetGlobalTrackReference();
+  void StoreGlobalTrackReference(AliVTrack *track);
+
+  AliVEvent *fInputEvent;                        //! current event
+  AliMCEvent *fMCEvent;                          //! corresponding MC event
+  AliV0ReaderV1 *fV0Reader;                      // basic photon Selection Task
+  AliSigma0AODPhotonMotherCuts *fSigmaCuts;      //
+  AliSigma0AODPhotonMotherCuts *fAntiSigmaCuts;  //
+
+  TRandom3 *fRandom;  //!
+
+  AliFemtoDreamEvent *fEvent;                        //!
+  AliFemtoDreamEventCuts *fEvtCuts;                  //
+  AliFemtoDreamTrack *fProtonTrack;                  //!
+  AliFemtoDreamTrackCuts *fTrackCutsPartProton;      //
+  AliFemtoDreamTrackCuts *fTrackCutsPartAntiProton;  //
+  AliFemtoDreamv0 *fLambda;                          //!
+  AliFemtoDreamv0Cuts *fV0Cuts;                      //
+  AliFemtoDreamv0Cuts *fAntiV0Cuts;                  //
+  AliFemtoDreamCollConfig *fConfig;                  //
+  AliFemtoDreamPairCleaner *fPairCleaner;            //!
+  AliFemtoDreamPartCollection *fPartColl;            //!
+
+  bool fIsMC;              //
+  bool fIsLightweight;     //
+  float fV0PercentileMax;  //
+  UInt_t fTrigger;         //
+
+  TClonesArray *fGammaArray;  //!
+  int fTrackBufferSize;
+  AliVTrack **fGTI;  //!
+
+  TList *fQA;                      //!
+  TList *fEvtHistList;             //!
+  TList *fTrackCutHistList;        //!
+  TList *fTrackCutHistMCList;      //!
+  TList *fAntiTrackCutHistList;    //!
+  TList *fAntiTrackCutHistMCList;  //!
+  TList *fLambdaHistList;          //!
+  TList *fLambdaHistMCList;        //!
+  TList *fAntiLambdaHistList;      //!
+  TList *fAntiLambdaHistMCList;    //!
+  TList *fPhotonHistList;          //!
+  TList *fSigmaHistList;           //!
+  TList *fAntiSigmaHistList;       //!
+  TList *fResultList;              //!
+  TList *fResultQAList;            //!
+
+  ClassDef(AliAnalysisTaskNanoAODSigma0Femto, 1)
+};
+#endif

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskSigma0Femto.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskSigma0Femto.cxx
@@ -65,8 +65,8 @@ AliAnalysisTaskSigma0Femto::AliAnalysisTaskSigma0Femto(const char *name,
       fPhotonQA(nullptr),
       fSigmaCuts(nullptr),
       fAntiSigmaCuts(nullptr),
-      fEvent(nullptr),
       fRandom(nullptr),
+      fEvent(nullptr),
       fEvtCuts(nullptr),
       fProtonTrack(nullptr),
       fTrackCutsPartProton(nullptr),
@@ -303,7 +303,7 @@ void AliAnalysisTaskSigma0Femto::CastToVector(
 
     AliSigma0ParticleV0 phot(PhotonCandidate, pos, neg, inputEvent);
     if (fIsMC) {
-      const int label = phot.MatchToMC(fMCEvent, 22, {{11, -11}});
+      phot.MatchToMC(fMCEvent, 22, {{11, -11}});
     }
     container.push_back(phot);
   }

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamBasePart.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamBasePart.cxx
@@ -13,6 +13,7 @@
 ClassImp(AliFemtoDreamBasePart) AliFemtoDreamBasePart::AliFemtoDreamBasePart()
     : fIsReset(false),
       fGTI(0),
+      fVGTI(0),
       fTrackBufferSize(0),
       fP(),
       fMCP(),
@@ -45,6 +46,7 @@ ClassImp(AliFemtoDreamBasePart) AliFemtoDreamBasePart::AliFemtoDreamBasePart()
 AliFemtoDreamBasePart::AliFemtoDreamBasePart(const AliFemtoDreamBasePart &part)
     : fIsReset(part.fIsReset),
       fGTI(part.fGTI),
+      fVGTI(part.fVGTI),
       fTrackBufferSize(part.fTrackBufferSize),
       fP(part.fP),
       fMCP(part.fMCP),
@@ -81,6 +83,7 @@ AliFemtoDreamBasePart &AliFemtoDreamBasePart::operator=(
   }
   fIsReset = obj.fIsReset;
   fGTI = 0;
+  fVGTI = 0;
   fTrackBufferSize = obj.fTrackBufferSize;
   fP = obj.fP;
   fMCPt = obj.fMCPt;
@@ -114,6 +117,7 @@ AliFemtoDreamBasePart::AliFemtoDreamBasePart(
     const AliSigma0ParticlePhotonMother &mother, const AliMCEvent *mcEvent)
     : fIsReset(false),
       fGTI(0),
+      fVGTI(0),
       fTrackBufferSize(0),
       fP(TVector3(mother.GetPx(), mother.GetPy(), mother.GetPz())),
       fMCP(TVector3(mother.GetPxMC(), mother.GetPyMC(), mother.GetPzMC())),
@@ -217,6 +221,7 @@ AliFemtoDreamBasePart::AliFemtoDreamBasePart(
     const AliSigma0ParticleV0 &daughter, const AliMCEvent *mcEvent)
     : fIsReset(false),
       fGTI(0),
+      fVGTI(0),
       fTrackBufferSize(0),
       fP(TVector3(daughter.GetPx(), daughter.GetPy(), daughter.GetPz())),
       fMCP(
@@ -299,10 +304,11 @@ AliFemtoDreamBasePart::AliFemtoDreamBasePart(
 }
 
 AliFemtoDreamBasePart::AliFemtoDreamBasePart(
-    const AliAODConversionPhoton *gamma, const AliAODTrack *posTrack,
-    const AliAODTrack *negTrack, const AliVEvent *inputEvent)
+    const AliAODConversionPhoton *gamma, const AliVTrack *posTrack,
+    const AliVTrack *negTrack, const AliVEvent *inputEvent)
     : fIsReset(false),
       fGTI(0),
+      fVGTI(0),
       fTrackBufferSize(0),
       fP(TVector3(gamma->GetPx(), gamma->GetPy(), gamma->GetPz())),
       fMCP(),

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamBasePart.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamBasePart.h
@@ -24,7 +24,7 @@ class AliFemtoDreamBasePart {
   AliFemtoDreamBasePart(const AliSigma0ParticlePhotonMother &mother, const AliMCEvent *mcEvent);
   AliFemtoDreamBasePart(const AliSigma0ParticleV0 &daughter, const AliMCEvent *mcEvent);
   AliFemtoDreamBasePart(const AliAODConversionPhoton *gamma,
-                        const AliAODTrack *pos, const AliAODTrack *neg,
+                        const AliVTrack *pos, const AliVTrack *neg,
                         const AliVEvent *inputEvent);
   virtual ~AliFemtoDreamBasePart();
   enum PartOrigin {
@@ -249,7 +249,10 @@ class AliFemtoDreamBasePart {
     fGTI = GTI;
     fTrackBufferSize = size;
   }
-  ;
+  void SetGlobalTrackInfo(AliVTrack **VGTI, Int_t size) {
+    fVGTI = VGTI;
+    fTrackBufferSize = size;
+  }
   int GetEventMultiplicity() const {
     return fEvtMultiplicity;
   }
@@ -259,6 +262,7 @@ class AliFemtoDreamBasePart {
  protected:
   bool fIsReset;
   AliAODTrack **fGTI;
+  AliVTrack **fVGTI;
   int fTrackBufferSize;
   TVector3 fP;
   TVector3 fMCP;
@@ -293,7 +297,7 @@ class AliFemtoDreamBasePart {
   void PhiAtRadii(const AliVTrack *track, const float bfield,
                   std::vector<float> &tmpVec);
   //  AliFemtoDreamBasePart(const AliFemtoDreamBasePart&);
-  ClassDef(AliFemtoDreamBasePart, 4);
+  ClassDef(AliFemtoDreamBasePart, 5);
 };
 
 #endif /* ALIFEMTODREAMBASEPART_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEvent.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEvent.cxx
@@ -134,7 +134,6 @@ AliFemtoDreamEvent &AliFemtoDreamEvent::operator=(
 void AliFemtoDreamEvent::SetEvent(AliAODEvent *evt) {
   AliAODVertex *vtx = evt->GetPrimaryVertex();
   AliAODVZERO *vZERO = evt->GetVZEROData();
-  AliAODHeader *header = dynamic_cast<AliAODHeader*>(evt->GetHeader());
   if (!vtx) {
     this->fHasVertex = false;
   } else {
@@ -338,8 +337,6 @@ double AliFemtoDreamEvent::CalculateSphericityEvent(AliAODEvent *evt) {
     double pt = aodtrack->Pt();
     double px = aodtrack->Px();
     double py = aodtrack->Py();
-    double pz = aodtrack->Pz();
-    double eta = aodtrack->Eta();
 
     ptTot += pt;
 

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEvent.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEvent.cxx
@@ -164,7 +164,6 @@ void AliFemtoDreamEvent::SetEvent(AliAODEvent *evt) {
   this->fNSPDClusterLy1 = evt->GetNumberOfITSClusters(1);
   this->fV0AMult = vZERO->GetMTotV0A();
   this->fV0CMult = vZERO->GetMTotV0C();
-  this->fRefMult08 = header->GetRefMultiplicityComb08();
   this->fspher = CalculateSphericityEvent(evt);
 
   AliMultSelection *MultSelection = 0x0;
@@ -174,6 +173,7 @@ void AliFemtoDreamEvent::SetEvent(AliAODEvent *evt) {
     AliWarning("AliMultSelection object not found!");
   } else {
     fV0MCentrality = MultSelection->GetMultiplicityPercentile("V0M");
+    fRefMult08 = MultSelection->GetMultiplicityPercentile("RefMult08");
   }
   return;
 }

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEvent.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEvent.cxx
@@ -9,6 +9,7 @@
 #include "AliAODHeader.h"
 #include "AliAODVertex.h"
 #include "AliAODVZERO.h"
+#include "AliVEvent.h"
 #include "AliMultSelection.h"
 #include "AliESDtrackCuts.h"
 
@@ -176,6 +177,46 @@ void AliFemtoDreamEvent::SetEvent(AliAODEvent *evt) {
     fRefMult08 = MultSelection->GetMultiplicityPercentile("RefMult08");
   }
   return;
+}
+
+void AliFemtoDreamEvent::SetEvent(AliVEvent *evt) {
+  AliNanoAODHeader* nanoHeader = dynamic_cast<AliNanoAODHeader*>(evt->GetHeader());
+  const AliVVertex *vtx = evt->GetPrimaryVertex();
+  if (!vtx) {
+    this->fHasVertex = false;
+  } else {
+    this->fHasVertex = true;
+    this->fnContrib = vtx->GetNContributors();
+    this->fxVtx = vtx->GetX();
+    this->fyVtx = vtx->GetY();
+    this->fzVtx = vtx->GetZ();
+  }
+  if (TMath::Abs(evt->GetMagneticField()) < 0.001) {
+    this->fHasMagField = false;
+  } else {
+    this->fHasMagField = true;
+    this->fBField = evt->GetMagneticField();
+  }
+
+  // This we already know since the NanoAOD filtering was done
+  this->fisPileUp = false;
+  this->fPassAliEvtSelection = true;
+
+  this->fNSPDClusterLy0 = evt->GetNumberOfITSClusters(0);
+  this->fNSPDClusterLy1 = evt->GetNumberOfITSClusters(1);
+  static const Int_t kRefMult =
+      nanoHeader->GetVarIndex("MultSelection.RefMult08");
+  if (kRefMult != -1) {
+    this->fRefMult08 = nanoHeader->GetVar(kRefMult);
+  }
+  this->fV0MCentrality = nanoHeader->GetCentr("V0M");
+
+  // TODO
+  //  this->fSPDMult = CalculateITSMultiplicity(evt);
+  //  const AliVVZERO *vZERO = evt->GetVZEROData();
+  //  this->fV0AMult = vZERO->GetMTotV0A();
+  //  this->fV0CMult = vZERO->GetMTotV0C();
+  //  this->fspher = CalculateSphericityEvent(evt);
 }
 
 void AliFemtoDreamEvent::SetEvent(AliESDEvent *evt) {

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEvent.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEvent.cxx
@@ -77,11 +77,9 @@ AliFemtoDreamEvent::AliFemtoDreamEvent(bool mvPileUp, bool EvtCutQA,
   }
 
   if (trigger != AliVEvent::kINT7) {
-    fEvtCuts->SetManualMode();
-    fEvtCuts->SetupRun2pp();
     std::cout << "Setting up Track Cuts correspondingly for pp trigger: "
               << trigger << std::endl;
-    fEvtCuts->fTriggerMask = trigger;
+    fEvtCuts->OverrideAutomaticTriggerSelection(trigger);
   }
   if (EvtCutQA) {
     fEvtCutList = new TList();

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEvent.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamEvent.h
@@ -28,6 +28,7 @@ class AliFemtoDreamEvent {
   AliFemtoDreamEvent &operator=(const AliFemtoDreamEvent &obj);
   virtual ~AliFemtoDreamEvent();
   void SetEvent(AliAODEvent *evt);
+  void SetEvent(AliVEvent *evt);
   void SetEvent(AliESDEvent *evt);
   TList *GetEvtCutList() const {
     return fEvtCutList;

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrack.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrack.cxx
@@ -13,6 +13,7 @@
 #include "AliESDVertex.h"
 #include "AliInputEventHandler.h"
 #include "AliFemtoDreamTrack.h"
+#include "AliNanoAODTrack.h"
 #include "AliLog.h"
 #include "TClonesArray.h"
 #include "TMath.h"
@@ -53,6 +54,8 @@ AliFemtoDreamTrack::AliFemtoDreamTrack()
       fESDTrack(0),
       fESDTPCOnlyTrack(0),
       fESDTrackCuts(AliESDtrackCuts::GetStandardTPCOnlyTrackCuts()),
+      fVTrack(nullptr),
+      fVGlobalTrack(nullptr),
       fAODTrack(0),
       fAODGlobalTrack(0) {
   for (int i = 0; i < 5; ++i) {
@@ -99,6 +102,43 @@ void AliFemtoDreamTrack::SetTrack(AliAODTrack *track, const int multiplicity) {
     this->SetAODTrackingInformation();
     this->SetAODPIDInformation();
     this->SetEvtNumber(fAODTrack->GetAODEvent()->GetRunNumber());
+    if (fIsMC) {
+      this->SetMCInformation();
+    }
+  } else {
+    this->fIsSet = false;
+  }
+}
+
+void AliFemtoDreamTrack::SetTrack(AliVTrack *track, AliVEvent *event,
+                                  const int multiplicity) {
+  AliNanoAODTrack* nanoTrack = dynamic_cast<AliNanoAODTrack*>(track);
+  this->Reset();
+  SetEventMultiplicity(multiplicity);
+  fVTrack = track;
+  int trackID = nanoTrack->GetID();
+  if (trackID < 0) {
+    if (!fVGTI) {
+      AliFatal("AliFemtoSPTrack::SetTrack No fVGTI Set");
+      fVGlobalTrack = NULL;
+    } else if (-trackID - 1 >= fTrackBufferSize) {
+      //      AliFatal("Buffer Size too small");
+      this->fIsSet = false;
+      fIsReset = false;
+      fVGlobalTrack = NULL;
+    } else if (!CheckGlobalVTrack(trackID)) {
+      fVGlobalTrack = NULL;
+    } else {
+      fVGlobalTrack = fVGTI[-trackID - 1];
+    }
+  } else {
+    fVGlobalTrack = track;
+  }
+  fIsReset = false;
+  if (fVGlobalTrack && fVTrack) {
+    SetVInformation(event);
+    this->SetIDTracks(dynamic_cast<AliNanoAODTrack *>(fVGlobalTrack)->GetID());
+    this->SetEvtNumber(event->GetRunNumber());
     if (fIsMC) {
       this->SetMCInformation();
     }
@@ -418,6 +458,117 @@ void AliFemtoDreamTrack::SetESDPIDInformation() {
     }
   }
 }
+
+//_______________________________________________
+void AliFemtoDreamTrack::SetVInformation(AliVEvent *event) {
+  AliNanoAODTrack *nanoTrack = dynamic_cast<AliNanoAODTrack *>(fVTrack);
+  AliNanoAODTrack *globalNanoTrack =
+      dynamic_cast<AliNanoAODTrack *>(fVGlobalTrack);
+  this->SetEta(fVTrack->Eta());
+  this->SetPhi(fVTrack->Phi());
+  this->SetTheta(fVTrack->Theta());
+  this->SetCharge(fVTrack->Charge());
+  this->SetMomentum(fVTrack->Px(), fVTrack->Py(), fVTrack->Pz());
+  this->SetPt(fVTrack->Pt());
+
+  // loop over the 6 ITS Layrs and check for a hit!
+  for (int i = 0; i < 6; ++i) {
+    fITSHit.push_back(fVTrack->HasPointOnITSLayer(i));
+    if (fVTrack->HasPointOnITSLayer(i)) {
+      this->fHasITSHit = true;
+    }
+  }
+  if (fVTrack->IsOn(AliVTrack::kTPCrefit)) {
+    fTPCRefit = true;
+  }
+  if (fVTrack->GetTOFBunchCrossing() == 0) {
+    this->fTOFTiming = true;
+  } else {
+    this->fTOFTiming = false;
+  }
+  this->fNClsTPC = fVTrack->GetTPCNcls();
+  this->fTPCCrossedRows = nanoTrack->GetTPCNCrossedRows();
+  const float findable = nanoTrack->GetTPCNclsF();
+  this->fRatioCR = (findable > 0) ? fTPCCrossedRows / findable : 0;
+  this->fTPCClsS = nanoTrack->GetTPCnclsS();
+  this->fChi2 = nanoTrack->Chi2perNDF();
+  this->fFilterMap = nanoTrack->GetFilterMap();
+  this->SetMomTPC(globalNanoTrack->GetTPCmomentum());
+  this->fdcaXY = nanoTrack->DCA();
+  this->fdcaZ = nanoTrack->ZAtDCA();
+  double dcaVals[2] = {-99., -99.};
+  double pos[3] = {0., 0., 0.};
+  double covar[3] = {0., 0., 0.};
+  AliNanoAODTrack copy(*globalNanoTrack);
+  copy.GetPosition(pos);
+  if (pos[0] * pos[0] + pos[1] * pos[1] <= 3. * 3. &&
+      copy.PropagateToDCA(event->GetPrimaryVertex(), event->GetMagneticField(),
+                          10, dcaVals, covar)) {
+    this->fdcaXYProp = dcaVals[0];
+    this->fdcaZProp = dcaVals[1];
+  } else {
+    this->fdcaXYProp = -99;
+    this->fdcaZProp = -99;
+  }
+
+  SetPhiAtRadii(event->GetMagneticField());
+
+  // PID stuff
+  static Bool_t bPIDAvailable = AliNanoAODTrack::InitPIDIndex();
+  if (!bPIDAvailable) {
+    this->fIsSet = false;
+    return;
+  }
+
+  AliPID::EParticleType particleID[5] = {AliPID::kElectron, AliPID::kMuon,
+                                         AliPID::kPion, AliPID::kKaon,
+                                         AliPID::kProton};
+
+  this->fstatusTPC =
+      (std::abs(globalNanoTrack->GetVar(AliNanoAODTrack::GetPIDIndex(
+                    AliNanoAODTrack::kSigmaTPC, AliPID::kPion)) +
+                999.f) > 1E-6)
+          ? AliPIDResponse::kDetPidOk
+          : AliPIDResponse::kDetNoSignal;
+  this->fstatusTOF =
+      (std::abs(globalNanoTrack->GetVar(AliNanoAODTrack::GetPIDIndex(
+                    AliNanoAODTrack::kSigmaTOF, AliPID::kPion)) +
+                999.f) > 1E-6)
+          ? AliPIDResponse::kDetPidOk
+          : AliPIDResponse::kDetNoSignal;
+
+  for (int i = 0; i < 5; ++i) {
+    this->fnSigmaTPC[i] = globalNanoTrack->GetVar(AliNanoAODTrack::GetPIDIndex(
+        AliNanoAODTrack::kSigmaTPC, particleID[i]));
+    this->fnSigmaTOF[i] = globalNanoTrack->GetVar(AliNanoAODTrack::GetPIDIndex(
+        AliNanoAODTrack::kSigmaTOF, particleID[i]));
+  }
+
+  if (fTPCClsS > 0) {
+    // Bad Track, has too many shared clusters!
+    this->fnoSharedClst = false;
+  } else {
+    this->fnoSharedClst = true;
+  }
+
+  // TODO
+  //  this->fdEdxTPC = fVTrack->GetTPCsignal();
+  //  this->fbetaTOF = GetBeta(fVTrack);
+  // For the moment we don't need ITS PID
+  //  this->fstatusITS = statusITS;
+  //          this->fnSigmaITS)[i] =
+  //    AliNanoAODTrack::GetPIDIndex(AliNanoAODTrack::kSigmaITS,
+  //    particleID[i]);
+  //  for (int i = 0; i < 6; ++i) {
+  //    fSharedClsITSLayer.push_back(fAODTrack->HasSharedPointOnITSLayer(i));
+  //    if (track->HasSharedPointOnITSLayer(i)) {
+  //      fHasSharedClsITSLayer = true;
+  //    }
+  //  }
+  return;
+}
+
+
 void AliFemtoDreamTrack::SetAODTrackingInformation() {
   this->fFilterMap = fAODTrack->GetFilterMap();
   this->SetEta(fAODTrack->Eta());
@@ -726,6 +877,15 @@ bool AliFemtoDreamTrack::CheckGlobalTrack(const Int_t TrackID) {
   bool isGlobal = true;
   if (TMath::Abs(TrackID) < fTrackBufferSize) {
     if (!(fGTI[-TrackID - 1])) {
+      isGlobal = false;
+    }
+  }
+  return isGlobal;
+}
+bool AliFemtoDreamTrack::CheckGlobalVTrack(const Int_t TrackID) {
+  bool isGlobal = true;
+  if (TMath::Abs(TrackID) < fTrackBufferSize) {
+    if (!(fVGTI[-TrackID - 1])) {
       isGlobal = false;
     }
   }

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrack.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrack.h
@@ -18,6 +18,8 @@ class AliFemtoDreamTrack : public AliFemtoDreamBasePart {
   AliFemtoDreamTrack();
   virtual ~AliFemtoDreamTrack();
   void SetTrack(AliAODTrack *track, const int multiplicity = -1);
+  void SetTrack(AliVTrack *track, AliVEvent *event,
+                const int multiplicity = -1);
   void SetTrack(AliESDtrack *track, AliMCEvent *mcEvent = nullptr,
                 const int multiplicity = -1, const bool TPCOnlyTrack = true,
                 const bool IsOmegaTrack = false);
@@ -73,6 +75,9 @@ class AliFemtoDreamTrack : public AliFemtoDreamBasePart {
     return fTPCClsS;
   }
   ;
+  std::vector<bool> GetSharedClusterITS() const {
+    return fSharedClsITSLayer;
+  }
   bool GetSharedClusterITS(int i) const {
     return fSharedClsITSLayer.at(i);
   }
@@ -89,6 +94,7 @@ class AliFemtoDreamTrack : public AliFemtoDreamBasePart {
     return fHasITSHit;
   }
   ;
+  std::vector<bool> GetITSHits() const { return fITSHit; }
   bool GetITSHit(int i) const {
     return fITSHit.at(i);
   }
@@ -145,7 +151,9 @@ class AliFemtoDreamTrack : public AliFemtoDreamBasePart {
   float GetBeta(AliAODTrack *track);
   float GetBeta(AliESDtrack *track);
   bool CheckGlobalTrack(const Int_t TrackID);
+  bool CheckGlobalVTrack(const Int_t TrackID);
   void SetAODTrackingInformation();
+  void SetVInformation(AliVEvent *event);
   void ApplyESDtoAODFilter(const bool TPCOnlyTrack = true);
   void SetESDTrackingInformation(const bool TPCOnlyTrack = true);
   void SetESDTrackingInformationOmega();
@@ -191,8 +199,10 @@ class AliFemtoDreamTrack : public AliFemtoDreamBasePart {
   AliESDtrack *fESDTrack;
   AliESDtrack *fESDTPCOnlyTrack;
   AliESDtrackCuts *fESDTrackCuts;
+  AliVTrack *fVTrack;
+  AliVTrack *fVGlobalTrack;
   AliAODTrack *fAODTrack;
-  AliAODTrack *fAODGlobalTrack;ClassDef(AliFemtoDreamTrack,3)
+  AliAODTrack *fAODGlobalTrack;ClassDef(AliFemtoDreamTrack,4)
 };
 
 #endif /* ALIFEMTODREAMTRACK_H_ */

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackCuts.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrackCuts.cxx
@@ -610,7 +610,7 @@ void AliFemtoDreamTrackCuts::BookQA(AliFemtoDreamTrack *Track) {
         fHists->FillTPCCrossedRowCut(i, Track->GetTPCCrossedRows());
         fHists->FillTPCRatioCut(i, Track->GetRatioCr());
         fHists->FillTPCClsS(i, Track->GetTPCClsC());
-        for (int j = 0; j < 6; ++j) {
+        for (size_t j = 0; j < Track->GetITSHits().size(); ++j) {
           if (Track->GetITSHit(j)) {
             fHists->FillTPCClsCPileUp(i, j, Track->GetTPCClsC());
           } else if (Track->GetHasITSHit()
@@ -626,7 +626,7 @@ void AliFemtoDreamTrackCuts::BookQA(AliFemtoDreamTrack *Track) {
           fHists->FillTPCClsCPileUp(i, 14, Track->GetTPCClsC());
         }
 
-        for (int j = 0; j < 6; ++j) {
+        for (size_t j = 0; j < Track->GetSharedClusterITS().size(); ++j) {
           if (Track->GetSharedClusterITS(j)) {
             fHists->FillHasSharedClsITS(i, j + 1, 0);
           } else {

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.cxx
@@ -88,9 +88,8 @@ void AliFemtoDreamv0::Setv0(AliESDEvent *evt, AliMCEvent *mcEvent, AliESDv0 *v0,
 }
 
 void AliFemtoDreamv0::Setv0(const AliFemtoDreamBasePart &posDaughter,
-                            const float posMass,
                             const AliFemtoDreamBasePart &negDaughter,
-                            const float negMass, const bool ignoreFirstPos,
+                            const bool ignoreFirstPos,
                             const bool ignoreFirstNeg, const bool setDaughter) {
   Reset();
   SetEventMultiplicity(posDaughter.GetEventMultiplicity());
@@ -102,8 +101,8 @@ void AliFemtoDreamv0::Setv0(const AliFemtoDreamBasePart &posDaughter,
   posDaughter.GetMomentum().GetXYZ(posP);
   negDaughter.GetMomentum().GetXYZ(negP);
   TLorentzVector trackPos, trackNeg;
-  trackPos.SetXYZM(posP[0], posP[1], posP[2], posMass);
-  trackNeg.SetXYZM(negP[0], negP[1], negP[2], negMass);
+  trackPos.SetXYZM(posP[0], posP[1], posP[2], posDaughter.GetInvMass());
+  trackNeg.SetXYZM(negP[0], negP[1], negP[2], negDaughter.GetInvMass());
   TLorentzVector trackSum = trackPos + trackNeg;
   this->SetPt(trackSum.Pt());
   this->SetMomentum(trackSum.Px(), trackSum.Py(), trackSum.Pz());

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.cxx
@@ -65,6 +65,34 @@ void AliFemtoDreamv0::Setv0(AliAODEvent *evt, AliAODv0* v0,
   }
 }
 
+void AliFemtoDreamv0::Setv0(AliVEvent *evt, AliAODv0* v0,
+                            const int multiplicity) {
+  if (!fVGTI) {
+    AliFatal("no GTI Array set");
+  }
+  if (!v0) {
+    AliFatal("SetProng No v0 to work with");
+  }
+  SetEventMultiplicity(multiplicity);
+  Reset();
+  if (v0->GetNProngs() == 2 && v0->GetNDaughters() == 2) {
+    fIsReset = false;
+    if (v0->GetOnFlyStatus()) {
+      this->fOnlinev0 = true;
+    } else {
+      this->fOnlinev0 = false;
+    }
+    this->SetMotherInfo(static_cast<AliAODEvent*>(evt), v0);
+    this->SetEvtNumber(evt->GetRunNumber());
+    if (fIsMC) {
+//      this->SetMCMotherInfo(evt, v0);
+    }
+    this->SetDaughter(v0, evt);
+  } else {
+    this->SetUse(false);
+  }
+}
+
 void AliFemtoDreamv0::Setv0(AliESDEvent *evt, AliMCEvent *mcEvent, AliESDv0 *v0,
                             const int multiplicity) {
   if (!v0) {
@@ -235,6 +263,38 @@ void AliFemtoDreamv0::SetDaughter(AliAODv0 *v0) {
           && fGTI[v0->GetNegID()]->Charge() > 0) {
         fnDaug->SetTrack(fGTI[v0->GetPosID()]);
         fpDaug->SetTrack(fGTI[v0->GetNegID()]);
+        this->SetDaughterInfo(v0);
+        this->fHasDaughter = true;
+      } else {
+        this->fHasDaughter = false;
+      }
+    } else {
+      this->fHasDaughter = false;
+    }
+  }
+}
+
+void AliFemtoDreamv0::SetDaughter(AliAODv0 *v0, AliVEvent *evt) {
+  if (v0->GetPosID() >= fTrackBufferSize
+      || v0->GetNegID() >= fTrackBufferSize) {
+    std::cout << "fVGTI too small, no Global Tracks to work with, PosID:  "
+              << v0->GetPosID() << " and NegID: " << v0->GetNegID()
+              << std::endl;
+    this->fHasDaughter = false;
+  } else {
+    fpDaug->SetGlobalTrackInfo(fVGTI, fTrackBufferSize);
+    fnDaug->SetGlobalTrackInfo(fVGTI, fTrackBufferSize);
+    if (fVGTI[v0->GetPosID()] && fVGTI[v0->GetNegID()]) {
+      if (fVGTI[v0->GetPosID()]->Charge() > 0
+          && fVGTI[v0->GetNegID()]->Charge() < 0) {
+        fnDaug->SetTrack(fVGTI[v0->GetNegID()], evt);
+        fpDaug->SetTrack(fVGTI[v0->GetPosID()], evt);
+        this->SetDaughterInfo(v0);
+        this->fHasDaughter = true;
+      } else if (fVGTI[v0->GetPosID()]->Charge() < 0
+          && fVGTI[v0->GetNegID()]->Charge() > 0) {
+        fnDaug->SetTrack(fVGTI[v0->GetPosID()], evt);
+        fpDaug->SetTrack(fVGTI[v0->GetNegID()], evt);
         this->SetDaughterInfo(v0);
         this->fHasDaughter = true;
       } else {

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.h
@@ -20,6 +20,7 @@ class AliFemtoDreamv0 : public AliFemtoDreamBasePart {
   AliFemtoDreamv0();
   virtual ~AliFemtoDreamv0();
   void Setv0(AliAODEvent *evt, AliAODv0 *v0, const int multiplicity = -1);
+  void Setv0(AliVEvent *evt, AliAODv0 *v0, const int multiplicity = -1);
   void Setv0(AliESDEvent *evt, AliMCEvent *mcEvent, AliESDv0 *v0,
              const int multiplicity = -1);
   // the last two are switches to ignore the first entry in the phi, eta, ...
@@ -107,6 +108,7 @@ class AliFemtoDreamv0 : public AliFemtoDreamBasePart {
   AliFemtoDreamv0(const AliFemtoDreamv0&);
   void Reset();
   void SetDaughter(AliAODv0 *v0);
+  void SetDaughter(AliAODv0 *v0, AliVEvent *evt);
   void SetDaughter(const AliFemtoDreamBasePart &posDaughter, const AliFemtoDreamBasePart &negDaughter);
   void SetDaughter(AliESDEvent *evt, AliMCEvent *mcEvent, AliESDv0 *v0);
   void SetDaughterInfo(AliAODv0 *v0);

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamv0.h
@@ -25,8 +25,8 @@ class AliFemtoDreamv0 : public AliFemtoDreamBasePart {
   // the last two are switches to ignore the first entry in the phi, eta, ...
   // vector in case one cases a V0 in this object, and only wants to keep the
   // daughter information
-  void Setv0(const AliFemtoDreamBasePart &posDaughter, const float posMass,
-             const AliFemtoDreamBasePart &negDaughter, const float negMass,
+  void Setv0(const AliFemtoDreamBasePart &posDaughter,
+             const AliFemtoDreamBasePart &negDaughter,
              const bool ignoreFirstPos = false,
              const bool ignoreFirstNeg = false, const bool setDaughter = true);
   bool GetOnlinev0() const {

--- a/PWGCF/FEMTOSCOPY/FemtoDream/CMakeLists.txt
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/CMakeLists.txt
@@ -20,7 +20,8 @@ add_definitions(-D_MODULE_="${MODULE}")
 # Module include folder
 include_directories(${AliPhysics_SOURCE_DIR}/PWGCF/FEMTOSCOPY/FemtoDream
                     ${AliPhysics_SOURCE_DIR}/PWGGA/GammaConvBase
-                    ${AliPhysics_SOURCE_DIR}/PWGGA/Hyperon)
+                    ${AliPhysics_SOURCE_DIR}/PWGGA/Hyperon
+                    ${AliPhysics_SOURCE_DIR}/PWG/DevNanoAOD)
 
 # Additional includes - alphabetical order except ROOT
 include_directories(${ROOT_INCLUDE_DIRS}
@@ -59,6 +60,7 @@ set(SRCS
   AliAnalysisTaskFemtoDreamPhi.cxx
   AliAnalysisTaskSigma0Femto.cxx
   AliAnalysisTaskAODSigma0Femto.cxx
+  AliAnalysisTaskNanoAODSigma0Femto.cxx
   AliAnalysisTaskGrandma.cxx
   AliAnalysisTaskOtonOmega.cxx
   AliOtonOmegaAnalysis.cxx

--- a/PWGCF/FEMTOSCOPY/FemtoDream/PWGCFFemtoDreamLinkDef.h
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/PWGCFFemtoDreamLinkDef.h
@@ -32,6 +32,7 @@
 #pragma link C++ class AliAnalysisTaskFemtoDreamPhi+;
 #pragma link C++ class AliAnalysisTaskSigma0Femto+;
 #pragma link C++ class AliAnalysisTaskAODSigma0Femto+;
+#pragma link C++ class AliAnalysisTaskNanoAODSigma0Femto+;
 #pragma link C++ class AliAnalysisTaskGrandma+;
 #pragma link C++ class AliAnalysisTaskOtonOmega+;
 #pragma link C++ class AliOtonOmegaAnalysis+;

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskSigma0FemtoNanoAOD.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskSigma0FemtoNanoAOD.C
@@ -1,0 +1,583 @@
+AliAnalysisTaskSE *AddTaskSigma0FemtoNanoAOD(bool isMC = false,
+                                             bool MomRes = false,
+                                             bool fullBlastQA = false,
+                                             TString trigger = "kINT7",
+                                             const char *cutVariation = "0") {
+  TString suffix = TString::Format("%s", cutVariation);
+
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    Error("AddTaskSigma0Run2()", "No analysis manager found.");
+    return 0x0;
+  }
+
+  // ================== GetInputEventHandler =============================
+  AliVEventHandler *inputHandler = mgr->GetInputEventHandler();
+  AliAnalysisDataContainer *cinput = mgr->GetCommonInputContainer();
+
+  //=========  Set Cutnumber for V0Reader ================================
+  TString cutnumberPhoton;
+  cutnumberPhoton = "00200008400000002280920000";
+  TString cutnumberEvent = "00000000";
+  TString periodNameV0Reader = "";
+  Bool_t enableV0findingEffi = kFALSE;
+  Bool_t fillHistos = kTRUE;
+  Bool_t runLightOutput = kFALSE;
+  if (suffix != "0" && suffix != "999") {
+    runLightOutput = kTRUE;
+    fillHistos = kFALSE;
+  }
+  if (suffix == "21") {
+    // eta < 0.8
+    cutnumberPhoton = "0d200008400000002280920000";
+  } else if (suffix == "22") {
+    // single pT > 0, gammapT > 0
+    cutnumberPhoton = "00200078400000002280920000";
+  } else if (suffix == "23") {
+    // single pT > 0.050, gammapT > 0.150
+    cutnumberPhoton = "002000a8400000002280920000";
+  } else if (suffix == "24") {
+    // TPC cluster, findable > 0.6
+    cutnumberPhoton = "00200009400000002280920000";
+  } else if (suffix == "25") {
+    // TPC PID -10,10
+    cutnumberPhoton = "00200008000000002280920000";
+  } else if (suffix == "26") {
+    // TPC PID -3,3
+    cutnumberPhoton = "00200008a00000002280920000";
+  } else if (suffix == "27") {
+    // 1-D Qt cut, qt < 0.1
+    cutnumberPhoton = "00200008400000001280920000";
+  } else if (suffix == "28") {
+    // 2-D Qt cut, qt < 0.05
+    cutnumberPhoton = "00200008400000003280920000";
+  } else if (suffix == "29") {
+    // psiPair < 0.2, 1-D
+    cutnumberPhoton = "00200008400000002240920000";
+  } else if (suffix == "30") {
+    // psiPair < 0.1, 2-D
+    cutnumberPhoton = "00200008400000002250920000";
+  } else if (suffix == "31") {
+    // cosPA < 0.98
+    cutnumberPhoton = "00200008400000002280820000";
+  } else if (suffix == "32") {
+    // cosPA < 0.995
+    cutnumberPhoton = "00200008400000002280a20000";
+  }
+
+  //========= Add V0 Reader to  ANALYSIS manager if not yet existent =====
+  TString V0ReaderName = TString::Format(
+      "V0ReaderV1_%s_%s", cutnumberEvent.Data(), cutnumberPhoton.Data());
+  AliConvEventCuts *fEventCuts = NULL;
+
+  AliV0ReaderV1 *fV0ReaderV1 = nullptr;
+  if (!(AliV0ReaderV1 *)mgr->GetTask(V0ReaderName.Data())) {
+    fV0ReaderV1 = new AliV0ReaderV1(V0ReaderName.Data());
+    if (periodNameV0Reader.CompareTo("") != 0)
+      fV0ReaderV1->SetPeriodName(periodNameV0Reader);
+    fV0ReaderV1->SetUseOwnXYZCalculation(kTRUE);
+    fV0ReaderV1->SetCreateAODs(kFALSE);  // AOD Output
+    fV0ReaderV1->SetUseAODConversionPhoton(kTRUE);
+    fV0ReaderV1->SetProduceV0FindingEfficiency(enableV0findingEffi);
+
+    if (!mgr) {
+      Error("AddTask_V0ReaderV1", "No analysis manager found.");
+      return NULL;
+    }
+
+    if (cutnumberEvent != "") {
+      fEventCuts =
+          new AliConvEventCuts(cutnumberEvent.Data(), cutnumberEvent.Data());
+      fEventCuts->SetPreSelectionCutFlag(kTRUE);
+      fEventCuts->SetV0ReaderName(V0ReaderName);
+      fEventCuts->SetLightOutput(runLightOutput);
+      if (periodNameV0Reader.CompareTo("") != 0)
+        fEventCuts->SetPeriodEnum(periodNameV0Reader);
+      fV0ReaderV1->SetEventCuts(fEventCuts);
+      fEventCuts->SetFillCutHistograms("", kFALSE);
+    }
+
+    // Set AnalysisCut Number
+    AliConversionPhotonCuts *fCuts = NULL;
+    if (cutnumberPhoton != "") {
+      fCuts = new AliConversionPhotonCuts(cutnumberPhoton.Data(),
+                                          cutnumberPhoton.Data());
+      fCuts->SetPreSelectionCutFlag(kTRUE);
+      fCuts->SetIsHeavyIon(false);
+      fCuts->SetV0ReaderName(V0ReaderName);
+      fCuts->SetLightOutput(runLightOutput);
+      fCuts->SetFillCutHistograms("", fillHistos);
+      if (fCuts->InitializeCutsFromCutString(cutnumberPhoton.Data())) {
+        fV0ReaderV1->SetConversionCuts(fCuts);
+      }
+    }
+    fV0ReaderV1->Init();
+    AliLog::SetGlobalLogLevel(AliLog::kFatal);
+
+    // connect input V0Reader
+//    mgr->AddTask(fV0ReaderV1);
+//    mgr->ConnectInput(fV0ReaderV1, 0, cinput);
+  }
+
+  //========= Init subtasks and start analyis ============================
+  // Event Cuts
+  AliFemtoDreamEventCuts *evtCuts = AliFemtoDreamEventCuts::StandardCutsRun2();
+  evtCuts->CleanUpMult(false, false, false, true);
+
+  // Track Cuts
+  AliFemtoDreamTrackCuts *TrackCuts =
+      AliFemtoDreamTrackCuts::PrimProtonCuts(isMC, true, false, false);
+  TrackCuts->SetFilterBit(128);
+  TrackCuts->SetCutCharge(1);
+
+  AliFemtoDreamTrackCuts *AntiTrackCuts =
+      AliFemtoDreamTrackCuts::PrimProtonCuts(isMC, true, false, false);
+  AntiTrackCuts->SetFilterBit(128);
+  AntiTrackCuts->SetCutCharge(-1);
+
+  if (suffix != "0" && suffix != "999") {
+    TrackCuts->SetMinimalBooking(true);
+    AntiTrackCuts->SetMinimalBooking(true);
+  }
+  if (suffix == "1") {
+    TrackCuts->SetPtRange(0.4, 4.05);
+    AntiTrackCuts->SetPtRange(0.4, 4.05);
+  } else if (suffix == "2") {
+    TrackCuts->SetPtRange(0.6, 4.05);
+    AntiTrackCuts->SetPtRange(0.6, 4.05);
+  } else if (suffix == "3") {
+    TrackCuts->SetEtaRange(-0.7, 0.7);
+    AntiTrackCuts->SetEtaRange(-0.7, 0.7);
+  } else if (suffix == "4") {
+    TrackCuts->SetEtaRange(-0.9, 0.9);
+    AntiTrackCuts->SetEtaRange(-0.9, 0.9);
+  } else if (suffix == "5") {
+    TrackCuts->SetPID(AliPID::kProton, 0.75, 2);
+    AntiTrackCuts->SetPID(AliPID::kProton, 0.75, 2);
+  } else if (suffix == "6") {
+    TrackCuts->SetPID(AliPID::kProton, 0.75, 5);
+    AntiTrackCuts->SetPID(AliPID::kProton, 0.75, 5);
+  } else if (suffix == "7") {
+    TrackCuts->SetFilterBit(96);
+    AntiTrackCuts->SetFilterBit(96);
+  } else if (suffix == "8") {
+    TrackCuts->SetNClsTPC(70);
+    AntiTrackCuts->SetNClsTPC(70);
+  } else if (suffix == "9") {
+    TrackCuts->SetNClsTPC(90);
+    AntiTrackCuts->SetNClsTPC(90);
+  }
+
+  // Lambda Cuts
+  AliFemtoDreamv0Cuts *v0Cuts =
+      AliFemtoDreamv0Cuts::LambdaSigma0Cuts(isMC, false, false);
+  AliFemtoDreamTrackCuts *Posv0Daug =
+      AliFemtoDreamTrackCuts::DecayProtonCuts(isMC, false, false);
+  Posv0Daug->SetEtaRange(-0.9, 0.9);
+  AliFemtoDreamTrackCuts *Negv0Daug =
+      AliFemtoDreamTrackCuts::DecayPionCuts(isMC, false, false);
+  Negv0Daug->SetEtaRange(-0.9, 0.9);
+
+  AliFemtoDreamv0Cuts *antiv0Cuts =
+      AliFemtoDreamv0Cuts::LambdaSigma0Cuts(isMC, false, false);
+  AliFemtoDreamTrackCuts *PosAntiv0Daug =
+      AliFemtoDreamTrackCuts::DecayPionCuts(isMC, false, false);
+  PosAntiv0Daug->SetCutCharge(1);
+  PosAntiv0Daug->SetEtaRange(-0.9, 0.9);
+  AliFemtoDreamTrackCuts *NegAntiv0Daug =
+      AliFemtoDreamTrackCuts::DecayProtonCuts(isMC, false, false);
+  NegAntiv0Daug->SetCutCharge(-1);
+  NegAntiv0Daug->SetEtaRange(-0.9, 0.9);
+
+  if (suffix != "0") {
+    v0Cuts->SetMinimalBooking(true);
+    antiv0Cuts->SetMinimalBooking(true);
+  }
+  if (suffix == "10") {
+    v0Cuts->SetPtRange(0.24, 999.9);
+    antiv0Cuts->SetPtRange(0.24, 999.9);
+  } else if (suffix == "11") {
+    v0Cuts->SetPtRange(0.36, 999.9);
+    antiv0Cuts->SetPtRange(0.36, 999.9);
+  } else if (suffix == "12") {
+    v0Cuts->SetCutCPA(0.995);
+    antiv0Cuts->SetCutCPA(0.995);
+  } else if (suffix == "13") {
+    v0Cuts->SetCutCPA(0.98);
+    antiv0Cuts->SetCutCPA(0.998);
+  } else if (suffix == "14") {
+    Posv0Daug->SetPID(AliPID::kProton, 999.9, 3);
+    Negv0Daug->SetPID(AliPID::kPion, 999.9, 3);
+    PosAntiv0Daug->SetPID(AliPID::kPion, 999.9, 3);
+    NegAntiv0Daug->SetPID(AliPID::kProton, 999.9, 3);
+  } else if (suffix == "15") {
+    Posv0Daug->SetPID(AliPID::kProton, 999.9, 6);
+    Negv0Daug->SetPID(AliPID::kPion, 999.9, 6);
+    PosAntiv0Daug->SetPID(AliPID::kPion, 999.9, 6);
+    NegAntiv0Daug->SetPID(AliPID::kProton, 999.9, 6);
+  } else if (suffix == "16") {
+    v0Cuts->SetArmenterosCut(0., 0.15, 0.2, 1);
+    antiv0Cuts->SetArmenterosCut(0, 0.15, 0.2, 1);
+  } else if (suffix == "17") {
+    Posv0Daug->SetNClsTPC(80);
+    Negv0Daug->SetNClsTPC(80);
+    PosAntiv0Daug->SetNClsTPC(80);
+    NegAntiv0Daug->SetNClsTPC(80);
+  } else if (suffix == "18") {
+    Posv0Daug->SetNClsTPC(60);
+    Negv0Daug->SetNClsTPC(60);
+    PosAntiv0Daug->SetNClsTPC(60);
+    NegAntiv0Daug->SetNClsTPC(60);
+  } else if (suffix == "19") {
+    Posv0Daug->SetEtaRange(-0.8, 0.8);
+    Negv0Daug->SetEtaRange(-0.8, 0.8);
+    PosAntiv0Daug->SetEtaRange(-0.8, 0.8);
+    NegAntiv0Daug->SetEtaRange(-0.8, 0.8);
+  } else if (suffix == "20") {
+    v0Cuts->SetCutInvMass(0.008);
+    antiv0Cuts->SetCutInvMass(0.008);
+  }
+
+  v0Cuts->SetPosDaugterTrackCuts(Posv0Daug);
+  v0Cuts->SetNegDaugterTrackCuts(Negv0Daug);
+  v0Cuts->SetPDGCodePosDaug(2212);  // Proton
+  v0Cuts->SetPDGCodeNegDaug(211);   // Pion
+  v0Cuts->SetPDGCodev0(3122);       // Lambda
+  antiv0Cuts->SetPosDaugterTrackCuts(PosAntiv0Daug);
+  antiv0Cuts->SetNegDaugterTrackCuts(NegAntiv0Daug);
+  antiv0Cuts->SetPDGCodePosDaug(211);   // Pion
+  antiv0Cuts->SetPDGCodeNegDaug(2212);  // Proton
+  antiv0Cuts->SetPDGCodev0(-3122);      // Lambda
+
+  AliSigma0AODPhotonMotherCuts *sigmaCuts =
+      AliSigma0AODPhotonMotherCuts::DefaultCuts();
+  sigmaCuts->SetIsMC(isMC);
+  sigmaCuts->SetPDG(3212, 3122, 22);
+  if (suffix != "0" && suffix != "999") {
+    sigmaCuts->SetLightweight(true);
+  }
+
+  AliSigma0AODPhotonMotherCuts *antiSigmaCuts =
+      AliSigma0AODPhotonMotherCuts::DefaultCuts();
+  antiSigmaCuts->SetIsMC(isMC);
+  antiSigmaCuts->SetPDG(-3212, -3122, 22);
+  if (suffix != "0" && suffix != "999") {
+    antiSigmaCuts->SetLightweight(true);
+  }
+
+  // vary the sidebands
+  if (suffix == "33") {
+    sigmaCuts->SetSigmaSideband(0.01, 0.075);
+    antiSigmaCuts->SetSigmaSideband(0.01, 0.075);
+  } else if (suffix == "34") {
+    sigmaCuts->SetSigmaSideband(0.01, 0.1);
+    antiSigmaCuts->SetSigmaSideband(0.01, 0.1);
+  } else if (suffix == "35") {
+    sigmaCuts->SetSigmaSideband(0.025, 0.05);
+    antiSigmaCuts->SetSigmaSideband(0.025, 0.05);
+  } else if (suffix == "36") {
+    sigmaCuts->SetSigmaSideband(0.025, 0.075);
+    antiSigmaCuts->SetSigmaSideband(0.025, 0.075);
+  } else if (suffix == "37") {
+    sigmaCuts->SetSigmaSideband(0.025, 0.1);
+    antiSigmaCuts->SetSigmaSideband(0.025, 0.1);
+  } else if (suffix == "38") {
+    sigmaCuts->SetSigmaSideband(0.005, 0.025);
+    antiSigmaCuts->SetSigmaSideband(0.005, 0.025);
+  } else if (suffix == "39") {
+    sigmaCuts->SetSigmaSideband(0.005, 0.05);
+    antiSigmaCuts->SetSigmaSideband(0.005, 0.05);
+  } else if (suffix == "40") {
+    sigmaCuts->SetSigmaSideband(0.005, 0.075);
+    antiSigmaCuts->SetSigmaSideband(0.005, 0.075);
+  } else if (suffix == "41") {
+    sigmaCuts->SetSigmaSideband(0.005, 0.1);
+    antiSigmaCuts->SetSigmaSideband(0.005, 0.1);
+  }
+
+  // Femto Collection
+  std::vector<int> PDGParticles;
+  PDGParticles.push_back(2212);
+  PDGParticles.push_back(2212);
+  PDGParticles.push_back(3212);
+  PDGParticles.push_back(3212);
+  PDGParticles.push_back(3212);
+  PDGParticles.push_back(3212);
+  PDGParticles.push_back(3212);
+  PDGParticles.push_back(3212);
+
+  std::vector<float> ZVtxBins;
+  ZVtxBins.push_back(-10);
+  ZVtxBins.push_back(-8);
+  ZVtxBins.push_back(-6);
+  ZVtxBins.push_back(-4);
+  ZVtxBins.push_back(-2);
+  ZVtxBins.push_back(0);
+  ZVtxBins.push_back(2);
+  ZVtxBins.push_back(4);
+  ZVtxBins.push_back(6);
+  ZVtxBins.push_back(8);
+  ZVtxBins.push_back(10);
+
+  std::vector<int> NBins;
+  std::vector<float> kMin;
+  std::vector<float> kMax;
+  std::vector<int> pairQA;
+  std::vector<bool> closeRejection;
+  const int nPairs = 36;
+  for (int i = 0; i < nPairs; ++i) {
+    pairQA.push_back(0);
+    closeRejection.push_back(false);
+    if (suffix == "0") {
+      NBins.push_back(600);
+      kMin.push_back(0.);
+      kMax.push_back(3.);
+    } else {
+      NBins.push_back(200);
+      kMin.push_back(0.);
+      kMax.push_back(1.);
+    }
+  }
+
+  NBins[0] = 250;  // pp
+  NBins[8] = 250;  // barp barp
+
+  closeRejection[0] = true;  // pp
+  closeRejection[8] = true;  // barp barp
+
+  // do extended QA for the pairs in default mode
+  if (suffix == "0") {
+    NBins[0] = 750;  // pp
+    NBins[8] = 750;  // barp barp
+
+    pairQA[0] = 11;   // pp
+    pairQA[2] = 14;   // pSigma
+    pairQA[8] = 11;   // barp barp
+    pairQA[10] = 14;  // barp bSigma
+  }
+
+  AliFemtoDreamCollConfig *config =
+      new AliFemtoDreamCollConfig("Femto", "Femto");
+  std::vector<int> MultBins;
+  if (trigger == "kHighMultV0") {
+    std::vector<int> MultBins;
+    MultBins.push_back(0);
+    MultBins.push_back(4);
+    MultBins.push_back(8);
+    MultBins.push_back(12);
+    MultBins.push_back(16);
+    MultBins.push_back(20);
+    MultBins.push_back(24);
+    MultBins.push_back(28);
+    MultBins.push_back(32);
+    MultBins.push_back(36);
+    MultBins.push_back(40);
+    MultBins.push_back(44);
+    MultBins.push_back(48);
+    MultBins.push_back(52);
+    MultBins.push_back(56);
+    MultBins.push_back(60);
+    MultBins.push_back(64);
+    MultBins.push_back(68);
+    MultBins.push_back(72);
+    MultBins.push_back(76);
+    MultBins.push_back(80);
+    MultBins.push_back(84);
+    MultBins.push_back(88);
+    MultBins.push_back(92);
+    MultBins.push_back(96);
+    MultBins.push_back(100);
+    config->SetMultBins(MultBins);
+  } else {
+    std::vector<int> MultBins;
+    MultBins.push_back(0);
+    MultBins.push_back(4);
+    MultBins.push_back(8);
+    MultBins.push_back(12);
+    MultBins.push_back(16);
+    MultBins.push_back(20);
+    MultBins.push_back(24);
+    MultBins.push_back(28);
+    MultBins.push_back(32);
+    MultBins.push_back(36);
+    MultBins.push_back(40);
+    MultBins.push_back(60);
+    MultBins.push_back(80);
+    config->SetMultBins(MultBins);
+  }
+  config->SetMultBinning(true);
+
+  config->SetExtendedQAPairs(pairQA);
+  config->SetdPhidEtaPlotsSmallK(false);
+  config->SetZBins(ZVtxBins);
+  if (MomRes && isMC) {
+    config->SetMomentumResolution(true);
+  }
+
+  if (trigger == "kHighMultV0") {
+    config->SetDeltaEtaMax(0.01);
+    config->SetDeltaPhiMax(0.01);
+    config->SetClosePairRejection(closeRejection);
+  }
+
+  if (suffix == "0" && fullBlastQA) {
+    config->SetPhiEtaBinnign(true);
+    config->SetkTBinning(true);
+    config->SetmTBinning(true);
+    config->SetPtQA(true);
+  }
+  config->SetdPhidEtaPlots(false);
+  config->SetPDGCodes(PDGParticles);
+  config->SetNBinsHist(NBins);
+  config->SetMinKRel(kMin);
+  config->SetMaxKRel(kMax);
+  config->SetMixingDepth(10);
+  config->SetUseEventMixing(true);
+  config->SetMultiplicityEstimator(AliFemtoDreamEvent::kRef08);
+  if (suffix != "0") {
+    config->SetMinimalBookingME(true);
+  }
+
+  AliAnalysisTaskNanoAODSigma0Femto *task =
+      new AliAnalysisTaskNanoAODSigma0Femto("AliAnalysisTaskNanoAODSigma0Femto", isMC);
+
+  task->SetEventCuts(evtCuts);
+  task->SetV0Reader(fV0ReaderV1);
+  task->SetProtonCuts(TrackCuts);
+  task->SetAntiProtonCuts(AntiTrackCuts);
+  task->SetV0Cuts(v0Cuts);
+  task->SetAntiV0Cuts(antiv0Cuts);
+  task->SetSigmaCuts(sigmaCuts);
+  task->SetAntiSigmaCuts(antiSigmaCuts);
+  task->SetCollectionConfig(config);
+
+  if (suffix != "0" && suffix != "999") {
+    task->SetLightweight(true);
+  }
+
+  mgr->AddTask(task);
+
+  TString addon = "";
+  if (trigger == "kINT7") {
+    addon += "MB";
+  } else if (trigger == "kHighMultV0") {
+    addon += "HM";
+  }
+
+  TString file = AliAnalysisManager::GetCommonFileName();
+
+  mgr->ConnectInput(task, 0, cinput);
+
+  TString QAName = Form("%sQA%s", addon.Data(), suffix.Data());
+  AliAnalysisDataContainer *coutputQA = mgr->CreateContainer(
+      //@suppress("Invalid arguments") it works ffs
+      QAName.Data(), TList::Class(), AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), QAName.Data()));
+  mgr->ConnectOutput(task, 1, coutputQA);
+
+  TString EvtCutsName = Form("%sEvtCuts%s", addon.Data(), suffix.Data());
+  AliAnalysisDataContainer *coutputEvtCuts = mgr->CreateContainer(
+      EvtCutsName.Data(), TList::Class(), AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), EvtCutsName.Data()));
+  mgr->ConnectOutput(task, 2, coutputEvtCuts);
+
+  TString TrackCutsName = Form("%sTrackCuts%s", addon.Data(), suffix.Data());
+  AliAnalysisDataContainer *couputTrkCuts =
+      mgr->CreateContainer(TrackCutsName.Data(), TList::Class(),
+                           AliAnalysisManager::kOutputContainer,
+                           Form("%s:%s", file.Data(), TrackCutsName.Data()));
+  mgr->ConnectOutput(task, 3, couputTrkCuts);
+
+  TString AntiTrackCutsName =
+      Form("%sAntiTrackCuts%s", addon.Data(), suffix.Data());
+  AliAnalysisDataContainer *coutputAntiTrkCuts = mgr->CreateContainer(
+      AntiTrackCutsName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), AntiTrackCutsName.Data()));
+  mgr->ConnectOutput(task, 4, coutputAntiTrkCuts);
+
+  TString v0CutsName = Form("%sv0Cuts%s", addon.Data(), suffix.Data());
+  AliAnalysisDataContainer *coutputv0Cuts = mgr->CreateContainer(
+      v0CutsName.Data(), TList::Class(), AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), v0CutsName.Data()));
+  mgr->ConnectOutput(task, 5, coutputv0Cuts);
+
+  TString Antiv0CutsName = Form("%sAntiv0Cuts%s", addon.Data(), suffix.Data());
+  AliAnalysisDataContainer *coutputAntiv0Cuts =
+      mgr->CreateContainer(Antiv0CutsName.Data(), TList::Class(),
+                           AliAnalysisManager::kOutputContainer,
+                           Form("%s:%s", file.Data(), Antiv0CutsName.Data()));
+  mgr->ConnectOutput(task, 6, coutputAntiv0Cuts);
+
+  TString Photonv0CutsName =
+      Form("%sPhotonCuts%s", addon.Data(), suffix.Data());
+  AliAnalysisDataContainer *coutputPhotonv0Cuts =
+      mgr->CreateContainer(Photonv0CutsName.Data(), TList::Class(),
+                           AliAnalysisManager::kOutputContainer,
+                           Form("%s:%s", file.Data(), Photonv0CutsName.Data()));
+  mgr->ConnectOutput(task, 7, coutputPhotonv0Cuts);
+
+  TString SigmaCutsName = Form("%sSigma0Cuts%s", addon.Data(), suffix.Data());
+  AliAnalysisDataContainer *coutputSigmaCuts =
+      mgr->CreateContainer(SigmaCutsName.Data(), TList::Class(),
+                           AliAnalysisManager::kOutputContainer,
+                           Form("%s:%s", file.Data(), SigmaCutsName.Data()));
+  mgr->ConnectOutput(task, 8, coutputSigmaCuts);
+
+  TString AntiSigmaCutsName =
+      Form("%sAntiSigma0Cuts%s", addon.Data(), suffix.Data());
+  AliAnalysisDataContainer *coutputAntiSigmaCuts = mgr->CreateContainer(
+      AntiSigmaCutsName.Data(), TList::Class(),
+      AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), AntiSigmaCutsName.Data()));
+  mgr->ConnectOutput(task, 9, coutputAntiSigmaCuts);
+
+  AliAnalysisDataContainer *coutputResults;
+  TString ResultsName = Form("%sResults%s", addon.Data(), suffix.Data());
+  coutputResults = mgr->CreateContainer(
+      ResultsName.Data(), TList::Class(), AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), ResultsName.Data()));
+  mgr->ConnectOutput(task, 10, coutputResults);
+
+  AliAnalysisDataContainer *coutputResultQA;
+  TString ResultQAName = Form("%sResultQA%s", addon.Data(), suffix.Data());
+  coutputResultQA = mgr->CreateContainer(
+      ResultQAName.Data(), TList::Class(), AliAnalysisManager::kOutputContainer,
+      Form("%s:%s", file.Data(), ResultQAName.Data()));
+  mgr->ConnectOutput(task, 11, coutputResultQA);
+
+  if (isMC) {
+    TString TrkCutsMCName =
+        Form("%sTrackCutsMC%s", addon.Data(), suffix.Data());
+    AliAnalysisDataContainer *coutputTrkCutsMC =
+        mgr->CreateContainer(TrkCutsMCName.Data(), TList::Class(),
+                             AliAnalysisManager::kOutputContainer,
+                             Form("%s:%s", file.Data(), TrkCutsMCName.Data()));
+    mgr->ConnectOutput(task, 12, coutputTrkCutsMC);
+
+    TString AntiTrkCutsMCName =
+        Form("%sAntiTrackCutsMC%s", addon.Data(), suffix.Data());
+    AliAnalysisDataContainer *coutputAntiTrkCutsMC = mgr->CreateContainer(
+        AntiTrkCutsMCName.Data(), TList::Class(),
+        AliAnalysisManager::kOutputContainer,
+        Form("%s:%s", file.Data(), AntiTrkCutsMCName.Data()));
+    mgr->ConnectOutput(task, 13, coutputAntiTrkCutsMC);
+
+    TString V0CutsMCName = Form("%sv0CutsMC%s", addon.Data(), suffix.Data());
+    AliAnalysisDataContainer *coutputV0CutsMC =
+        mgr->CreateContainer(V0CutsMCName.Data(), TList::Class(),
+                             AliAnalysisManager::kOutputContainer,
+                             Form("%s:%s", file.Data(), V0CutsMCName.Data()));
+    mgr->ConnectOutput(task, 14, coutputV0CutsMC);
+
+    TString AntiV0CutsMCName =
+        Form("%sAntiv0CutsMC%s", addon.Data(), suffix.Data());
+    AliAnalysisDataContainer *coutputAntiV0CutsMC = mgr->CreateContainer(
+        AntiTrkCutsMCName.Data(), TList::Class(),
+        AliAnalysisManager::kOutputContainer,
+        Form("%s:%s", file.Data(), AntiV0CutsMCName.Data()));
+    mgr->ConnectOutput(task, 15, coutputAntiV0CutsMC);
+  }
+
+  return task;
+}

--- a/PWGGA/Hyperon/AliAnalysisTaskSigma0Run2.cxx
+++ b/PWGGA/Hyperon/AliAnalysisTaskSigma0Run2.cxx
@@ -294,7 +294,7 @@ void AliAnalysisTaskSigma0Run2::CastToVector(
 
     AliSigma0ParticleV0 phot(PhotonCandidate, pos, neg, inputEvent);
     if (fIsMC) {
-      const int label = phot.MatchToMC(fMCEvent, 22, {{11, -11}});
+      phot.MatchToMC(fMCEvent, 22, {{11, -11}});
     }
     container.push_back(phot);
   }

--- a/PWGGA/Hyperon/AliAnalysisTaskSigma0Run2.cxx
+++ b/PWGGA/Hyperon/AliAnalysisTaskSigma0Run2.cxx
@@ -316,9 +316,7 @@ void AliAnalysisTaskSigma0Run2::UserCreateOutputObjects() {
   fQA->SetOwner(true);
 
   if (fTrigger != AliVEvent::kINT7) {
-    fAliEventCuts.SetManualMode();
-    if (!fIsHeavyIon) fAliEventCuts.SetupRun2pp();
-    fAliEventCuts.fTriggerMask = fTrigger;
+    fAliEventCuts.OverrideAutomaticTriggerSelection(fTrigger);
   }
 
   fV0Reader =

--- a/PWGGA/Hyperon/AliSigma0AODPhotonMotherCuts.cxx
+++ b/PWGGA/Hyperon/AliSigma0AODPhotonMotherCuts.cxx
@@ -503,7 +503,9 @@ void AliSigma0AODPhotonMotherCuts::SigmaToLambdaGamma(
 
     for (const auto &lambda : lambdaCandidates) {
       if (!lambda.UseParticle()) continue;
-      sigma.Setv0(lambda, lambdaMass, photon, photonMass, true, true, false);
+      sigma.Setv0(lambda, photon, true, true, false);
+      sigma.Setv0Mass(sigma.GetInvMass() - lambda.GetInvMass() + lambdaMass -
+                      photon.GetInvMass());
       const float invMass = sigma.GetInvMass();
       const float armAlpha = GetArmenterosAlpha(photon, lambda, sigma);
       const float armQt = GetArmenterosQt(photon, lambda, sigma);

--- a/PWGGA/Hyperon/AliSigma0AODPhotonMotherCuts.cxx
+++ b/PWGGA/Hyperon/AliSigma0AODPhotonMotherCuts.cxx
@@ -493,7 +493,6 @@ void AliSigma0AODPhotonMotherCuts::SigmaToLambdaGamma(
   fSidebandDown.clear();
   int nSigma = 0;
   const float lambdaMass = fDataBasePDG.GetParticle(fPDGDaughter1)->Mass();
-  const float photonMass = fDataBasePDG.GetParticle(fPDGDaughter2)->Mass();
   // SAME EVENT
   AliFemtoDreamv0 sigma;
   for (const auto &photon : photonCandidates) {
@@ -526,10 +525,11 @@ void AliSigma0AODPhotonMotherCuts::SigmaToLambdaGamma(
         fHistArmenterosAfter->Fill(armAlpha, armQt);
       }
 
-      int label = -10;
-      int pdgLambdaMother = 0;
-      int pdgPhotonMother = 0;
-      //      if (fIsMC) {
+      // TODO Implement MC handling
+      // int label = -10;
+      // int pdgLambdaMother = 0;
+      // int pdgPhotonMother = 0;
+      // if (fIsMC) {
       //        label =
       //            sigma.MatchToMC(fMCEvent, fPDG, {{fPDGDaughter1,
       //            fPDGDaughter2}},


### PR DESCRIPTION
o NanoFemto!
o Example task: AliAnalysisTaskNanoAODSigma0Femto, called from PWGCF/FEMTOSCOPY/macros/AddTaskSigma0FemtoNanoAOD.C
o Minor feature fixes
  - Obtain the daughter mass from the DreamTrack when constructing the V0 
  - Properly set the trigger selection for the AliEventCuts 
  - Silence a few compiler warnings 