### PR TITLE
PWGUD/UPC: Binning for Helicity analysis.

### DIFF
--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
@@ -179,7 +179,8 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward()
       fPhiHelicityFrameJPsiTenRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
       fPhiCollinsSoperFrameJPsiTenRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
       fInvariantMassDistributionInBinsOfCosThetaHelicityFrameH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-      fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH(0)
+      fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH(0),
+      fCosThetaAndPhiHelicityFrameInclusivePeopleBinningH(0)
 {
     // default constructor, don't allocate memory here!
     // this is used by root for IO purposes, it needs to remain empty
@@ -290,7 +291,8 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward(const char* name)
       fPhiHelicityFrameJPsiTenRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
       fPhiCollinsSoperFrameJPsiTenRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
       fInvariantMassDistributionInBinsOfCosThetaHelicityFrameH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-      fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH(0)
+      fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH(0),
+      fCosThetaAndPhiHelicityFrameInclusivePeopleBinningH(0)
 {
     FillGoodRunVector(fVectorGoodRunNumbers);
 
@@ -741,15 +743,41 @@ void AliAnalysisTaskUPCforward::UserCreateOutputObjects()
                 Form("fInvariantMassDistributionInBinsOfCosThetaHelicityFrameH_%d", iCosThetaBins),
                 Form("fInvariantMassDistributionInBinsOfCosThetaHelicityFrameH_%d", iCosThetaBins),
                 2000, 0, 20
-              );
+                );
     fOutputList->Add(fInvariantMassDistributionInBinsOfCosThetaHelicityFrameH[iCosThetaBins]);
   }
 
   fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH =
         new TH2F( "fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH",
                   "fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH",
-                  80, -1, 1, 80, -4, 4);
+                  80, -1, 1, 80, -4, 4
+                  );
   fOutputList->Add(fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH);
+
+  /* - Variable binning for CosTheta and Phi.
+     - Adopting same binning as inclusive people's.
+     -
+   */
+  const Int_t XBINS = 19;
+  const Int_t YBINS = 20;
+  Double_t CosThetaBinning[ XBINS + 1 ] = { -1. , -0.8, -0.7 , -0.6 , -0.5, -0.4,
+                                            -0.3, -0.2, -0.12, -0.04,  0.04, 0.12,
+                                             0.2,  0.3,  0.4,   0.5,   0.6,  0.7,
+                                             0.8,  1
+                                             };
+  Double_t PhiBinning[ YBINS + 1 ] = { -3.142, -2.639, -2.136, -1.885, -1.696,
+                                       -1.571, -1.445, -1.257, -1.005, -0.502,
+                                        0.,     0.502,  1.005,  1.257,  1.445,
+                                        1.571,  1.696,  1.885,  2.136,  2.639,
+                                        3.142
+                                      };
+  fCosThetaAndPhiHelicityFrameInclusivePeopleBinningH =
+        new TH2F( "fCosThetaAndPhiHelicityFrameInclusivePeopleBinningH",
+                  "fCosThetaAndPhiHelicityFrameInclusivePeopleBinningH",
+                  XBINS, CosThetaBinning,
+                  YBINS, PhiBinning
+                  );
+  fOutputList->Add(fCosThetaAndPhiHelicityFrameInclusivePeopleBinningH);
 
 
   //_______________________________
@@ -1700,6 +1728,16 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
                                                                                              possibleJPsiCopy
                                                                                              )
                                                                         );
+    fCosThetaAndPhiHelicityFrameInclusivePeopleBinningH->Fill( CosThetaHelicityFrame( muonsCopy2[0],
+                                                                                      muonsCopy2[1],
+                                                                                      possibleJPsiCopy
+                                                                                      ),
+                                                               CosPhiHelicityFrame( muonsCopy2[0],
+                                                                                    muonsCopy2[1],
+                                                                                    possibleJPsiCopy
+                                                                                    )
+                                                               );
+
   }
 
   // post the data

--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.h
@@ -801,11 +801,41 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * angular distributions. This should help in
                                  * validating our results...
                                  *
-                                 * NEW: This histogram how this thing in 2D.
+                                 * NEW: This histogram shows this thing in 2D.
                                  * IT is shown the same distribution in terms of
                                  * CosTheta and Phi bins. Let's see the results!
                                  */
         TH2F*                   fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH;  //!
+
+                                /**
+                                 * This histogram shows the invariant mass
+                                 * distribution of the dimuon pairs in terms
+                                 * of bins of cos theta of the positive muon
+                                 * in the helicity frame of the J/Psi.
+                                 *
+                                 * What it means is that we divide in 5 bins of
+                                 * possible CosTheta of the decaying J/Psi,
+                                 * meaning  (-1,-0.8), (-0.8,-0.6), (-0.6,-0.4),
+                                 * (-0.4,-0.2) and so on until (0.8,1). We fill
+                                 * the invariant mass distribution of the
+                                 * dimuons in this many bins.
+                                 *
+                                 * The next step is to fit this invariant mass
+                                 * distributions, so as to obtain the relative
+                                 * contribution of J/Psi and GammaGamma to the
+                                 * angular distributions. This should help in
+                                 * validating our results...
+                                 *
+                                 * NEW: This histogram shows this thing in 2D.
+                                 * IT is shown the same distribution in terms of
+                                 * CosTheta and Phi bins. Let's see the results!
+                                 *
+                                 * NEW: this specific histogram follows the
+                                 * binning of the inclusive people...
+                                 * Hopefully this would yield better results!
+                                 */
+        TH2F*                   fCosThetaAndPhiHelicityFrameInclusivePeopleBinningH;  //!
+
 
         //_______________________________
         // CUTS
@@ -867,7 +897,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforward, 13);
+        ClassDef(AliAnalysisTaskUPCforward, 14);
 };
 
 #endif

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
@@ -199,7 +199,9 @@ AliAnalysisTaskUPCforwardMC::AliAnalysisTaskUPCforwardMC()
       fMCPhiHelicityFrameJPsiTenRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
       fMCPhiCollinsSoperFrameJPsiTenRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
       fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH(0),
-      fMCInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH(0)
+      fMCInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH(0),
+      fCosThetaAndPhiHelicityFrameInclusivePeopleBinningH(0),
+      fMCCosThetaAndPhiHelicityFrameInclusivePeopleBinningH(0)
 {
     // default constructor, don't allocate memory here!
     // this is used by root for IO purposes, it needs to remain empty
@@ -324,7 +326,9 @@ AliAnalysisTaskUPCforwardMC::AliAnalysisTaskUPCforwardMC( const char* name )
       fMCPhiHelicityFrameJPsiTenRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
       fMCPhiCollinsSoperFrameJPsiTenRapidityBinsH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
       fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH(0),
-      fMCInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH(0)
+      fMCInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH(0),
+      fCosThetaAndPhiHelicityFrameInclusivePeopleBinningH(0),
+      fMCCosThetaAndPhiHelicityFrameInclusivePeopleBinningH(0)
 {
     FillGoodRunVector(fVectorGoodRunNumbers);
 
@@ -784,6 +788,40 @@ void AliAnalysisTaskUPCforwardMC::UserCreateOutputObjects()
                   80, -4, 4
                   );
   fOutputList->Add(fMCInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH);
+
+  /* - Variable binning for CosTheta and Phi.
+     - Adopting same binning as inclusive people's.
+     -
+   */
+  const Int_t XBINS = 19;
+  const Int_t YBINS = 20;
+  Double_t CosThetaBinning[ XBINS + 1 ] = { -1. , -0.8, -0.7 , -0.6 , -0.5, -0.4,
+                                            -0.3, -0.2, -0.12, -0.04,  0.04, 0.12,
+                                             0.2,  0.3,  0.4,   0.5,   0.6,  0.7,
+                                             0.8,  1
+                                             };
+  Double_t PhiBinning[ YBINS + 1 ] = { -3.142, -2.639, -2.136, -1.885, -1.696,
+                                       -1.571, -1.445, -1.257, -1.005, -0.502,
+                                        0.,     0.502,  1.005,  1.257,  1.445,
+                                        1.571,  1.696,  1.885,  2.136,  2.639,
+                                        3.142
+                                      };
+  fCosThetaAndPhiHelicityFrameInclusivePeopleBinningH =
+        new TH2F( "fCosThetaAndPhiHelicityFrameInclusivePeopleBinningH",
+                  "fCosThetaAndPhiHelicityFrameInclusivePeopleBinningH",
+                  XBINS, CosThetaBinning,
+                  YBINS, PhiBinning
+                  );
+  fOutputList->Add(fCosThetaAndPhiHelicityFrameInclusivePeopleBinningH);
+
+  fMCCosThetaAndPhiHelicityFrameInclusivePeopleBinningH =
+        new TH2F( "fMCCosThetaAndPhiHelicityFrameInclusivePeopleBinningH",
+                  "fMCCosThetaAndPhiHelicityFrameInclusivePeopleBinningH",
+                  XBINS, CosThetaBinning,
+                  YBINS, PhiBinning
+                  );
+  fOutputList->Add(fMCCosThetaAndPhiHelicityFrameInclusivePeopleBinningH);
+
 
   //_______________________________
   // - End of the function
@@ -1365,6 +1403,16 @@ void AliAnalysisTaskUPCforwardMC::UserExec(Option_t *)
                                                                                              possibleJPsiCopy
                                                                                              )
                                                                         );
+    fCosThetaAndPhiHelicityFrameInclusivePeopleBinningH->Fill( CosThetaHelicityFrame( muonsCopy2[0],
+                                                                                      muonsCopy2[1],
+                                                                                      possibleJPsiCopy
+                                                                                      ),
+                                                               CosPhiHelicityFrame( muonsCopy2[0],
+                                                                                    muonsCopy2[1],
+                                                                                    possibleJPsiCopy
+                                                                                    )
+                                                               );
+
 
   }
 
@@ -1637,6 +1685,15 @@ void AliAnalysisTaskUPCforwardMC::ProcessMCParticles(AliMCEvent* fMCEventArg)
                                                                                                              possibleJPsiMC
                                                                                                              )
                                                                                         );
+                  fMCCosThetaAndPhiHelicityFrameInclusivePeopleBinningH->Fill( CosThetaHelicityFrame( muonsMCcopy[0],
+                                                                                                      muonsMCcopy[1],
+                                                                                                      possibleJPsiMC
+                                                                                                      ),
+                                                                               CosPhiHelicityFrame( muonsMCcopy[0],
+                                                                                                    muonsMCcopy[1],
+                                                                                                    possibleJPsiMC
+                                                                                                    )
+                                                                               );
           } else  {
                   fMCthetaDistribOfNegativeMuonRestFrameJPsiGeneratedTruthH->Fill(cosThetaMuonsRestFrameMC[0]);
                   fMCthetaDistribOfPositiveMuonRestFrameJPsiGeneratedTruthH->Fill(cosThetaMuonsRestFrameMC[1]);
@@ -1748,7 +1805,15 @@ void AliAnalysisTaskUPCforwardMC::ProcessMCParticles(AliMCEvent* fMCEventArg)
                                                                                                              possibleJPsiMC
                                                                                                              )
                                                                                         );
-
+                  fMCCosThetaAndPhiHelicityFrameInclusivePeopleBinningH->Fill( CosThetaHelicityFrame( muonsMCcopy[1],
+                                                                                                      muonsMCcopy[0],
+                                                                                                      possibleJPsiMC
+                                                                                                      ),
+                                                                               CosPhiHelicityFrame( muonsMCcopy[1],
+                                                                                                    muonsMCcopy[0],
+                                                                                                    possibleJPsiMC
+                                                                                                    )
+                                                                               );
           }
       }
     }

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
@@ -760,7 +760,67 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
                                  */
         TH2F*                   fMCInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH;  //!
 
+                                /**
+                                 * This histogram shows the invariant mass
+                                 * distribution of the dimuon pairs in terms
+                                 * of bins of cos theta of the positive muon
+                                 * in the helicity frame of the J/Psi.
+                                 *
+                                 * What it means is that we divide in 5 bins of
+                                 * possible CosTheta of the decaying J/Psi,
+                                 * meaning  (-1,-0.8), (-0.8,-0.6), (-0.6,-0.4),
+                                 * (-0.4,-0.2) and so on until (0.8,1). We fill
+                                 * the invariant mass distribution of the
+                                 * dimuons in this many bins.
+                                 *
+                                 * The next step is to fit this invariant mass
+                                 * distributions, so as to obtain the relative
+                                 * contribution of J/Psi and GammaGamma to the
+                                 * angular distributions. This should help in
+                                 * validating our results...
+                                 *
+                                 * NEW: This histogram shows this thing in 2D.
+                                 * IT is shown the same distribution in terms of
+                                 * CosTheta and Phi bins. Let's see the results!
+                                 *
+                                 * NEW: this specific histogram follows the
+                                 * binning of the inclusive people...
+                                 * Hopefully this would yield better results!
+                                 *
+                                 * RECONSTRUCTED level.
+                                 */
+        TH2F*                   fCosThetaAndPhiHelicityFrameInclusivePeopleBinningH;  //!
 
+                                /**
+                                 * This histogram shows the invariant mass
+                                 * distribution of the dimuon pairs in terms
+                                 * of bins of cos theta of the positive muon
+                                 * in the helicity frame of the J/Psi.
+                                 *
+                                 * What it means is that we divide in 5 bins of
+                                 * possible CosTheta of the decaying J/Psi,
+                                 * meaning  (-1,-0.8), (-0.8,-0.6), (-0.6,-0.4),
+                                 * (-0.4,-0.2) and so on until (0.8,1). We fill
+                                 * the invariant mass distribution of the
+                                 * dimuons in this many bins.
+                                 *
+                                 * The next step is to fit this invariant mass
+                                 * distributions, so as to obtain the relative
+                                 * contribution of J/Psi and GammaGamma to the
+                                 * angular distributions. This should help in
+                                 * validating our results...
+                                 *
+                                 * NEW: This histogram shows this thing in 2D.
+                                 * IT is shown the same distribution in terms of
+                                 * CosTheta and Phi bins. Let's see the results!
+                                 *
+                                 * NEW: this specific histogram follows the
+                                 * binning of the inclusive people...
+                                 * Hopefully this would yield better results!
+                                 *
+                                 * GENERATED level.
+                                 */
+        TH2F*                   fMCCosThetaAndPhiHelicityFrameInclusivePeopleBinningH;  //!
 
 
         //_______________________________
@@ -844,7 +904,7 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforwardMC, 9);
+        ClassDef(AliAnalysisTaskUPCforwardMC, 11);
 };
 
 #endif


### PR DESCRIPTION
Added new binning for helicity analysis.
This is the same binning as the inclusive people's, apart from the difference in the handling if Phi (this commit has  ~-3.14 to ~3.14).
Implemented both in data and MC.
IMPORTANT: tested.