### PR TITLE
Use clusterizerv2 for embedding

### DIFF
--- a/PWGJE/EMCALJetTasks/macros/EMCalCorrectionTaskEmbeddingExample.yaml
+++ b/PWGJE/EMCALJetTasks/macros/EMCalCorrectionTaskEmbeddingExample.yaml
@@ -102,6 +102,8 @@ CellCombineCollections_combined:
 # Clusterizer
 Clusterizer:
     createHistos: true
+    # Clusterizerv3 won't properly clusterizer embedded cells without additional preprocessing, so use v2 instead.
+    clusterizer: kClusterizerv2
 Clusterizer_combined:
     enabled: true
     cellTimeMin: -50e-9


### PR DESCRIPTION
Due to modifications in the clusterizerv3 algorithm, it won't properly
clusterize embedded cells. So we use clusterizerv2 for embedding. Note
that the clusterization computation time is quite small compared to
cluster-track matching, so the speed up if clusterizerv3 was made
compatible won't make much difference.