### PR TITLE
Use ClassDefNV for non virtual classes

### DIFF
--- a/PWGCF/FLOW/GF/AliUniFlowCorrTask.h
+++ b/PWGCF/FLOW/GF/AliUniFlowCorrTask.h
@@ -30,7 +30,7 @@ class AliUniFlowCorrTask
     protected:
     private:
 
-    ClassDef(AliUniFlowCorrTask, 1);
+    ClassDefNV(AliUniFlowCorrTask, 1);
 };
 
 


### PR DESCRIPTION
This fixes the error with the new mac clang