### PR TITLE
Use clusterizerv3 in examples, samples

### DIFF
--- a/PWG/EMCAL/READMEemcCorrections.txt
+++ b/PWG/EMCAL/READMEemcCorrections.txt
@@ -189,7 +189,7 @@ Clusterizer:
     clusterBranchName: "sharedParameters:clusterBranchName"
     # Sets the Clusterizer type based on the same familiar enumeration.
     # Note that you should _not_ include the prefix as you usually would for setting an enumeration. Only list the value.
-    clusterizer: kClusterizerv2
+    clusterizer: kClusterizerv3
     cellE: 0.05
     seedE: 0.1
     cellTimeMin: -1                    # Min cell time (s)

--- a/PWG/EMCAL/config/EMCalSampleConfig.yaml
+++ b/PWG/EMCAL/config/EMCalSampleConfig.yaml
@@ -10,7 +10,7 @@ Clusterizer:
     enabled: true
     # Note: These are the same values as in the defualt configuration, but these often need to be set and
     #       included here as a reminder.
-    clusterizer: kClusterizerv2
+    clusterizer: kClusterizerv3
     cellTimeMin: -1
     cellTimeMax: +1
     clusterTimeLength: 1

--- a/PWG/EMCAL/config/EMCalSampleConfigMC.yaml
+++ b/PWG/EMCAL/config/EMCalSampleConfigMC.yaml
@@ -10,7 +10,7 @@ Clusterizer:
     enabled: true
     # Note: These are the same values as in the defualt configuration, but these often need to be set and
     #       included here as a reminder.
-    clusterizer: kClusterizerv2
+    clusterizer: kClusterizerv3
     cellTimeMin: -1
     cellTimeMax: +1
     clusterTimeLength: 1

--- a/PWG/EMCAL/config/PWGJESampleConfig.yaml
+++ b/PWG/EMCAL/config/PWGJESampleConfig.yaml
@@ -10,7 +10,7 @@ Clusterizer:
     enabled: true
     # Note: These are the same values as in the defualt configuration, but these often need to be set and
     #       included here as a reminder.
-    clusterizer: kClusterizerv2
+    clusterizer: kClusterizerv3
     cellTimeMin: -1
     cellTimeMax: +1
     clusterTimeLength: 1

--- a/PWG/EMCAL/config/PWGJESampleConfigMC.yaml
+++ b/PWG/EMCAL/config/PWGJESampleConfigMC.yaml
@@ -10,7 +10,7 @@ Clusterizer:
     enabled: true
     # Note: These are the same values as in the defualt configuration, but these often need to be set and
     #       included here as a reminder.
-    clusterizer: kClusterizerv2
+    clusterizer: kClusterizerv3
     cellTimeMin: -1
     cellTimeMax: +1
     clusterTimeLength: 1


### PR DESCRIPTION
Update examples, samples to use clusterizerv3, as this is the new standard