### PR TITLE
Two new PID cases for Lc --> pK0s (A. Alici)

### DIFF
--- a/PWGHF/vertexingHF/AliRDHFCutsLctoV0.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCutsLctoV0.cxx
@@ -1156,7 +1156,7 @@ void AliRDHFCutsLctoV0::CheckPID(AliAODTrack *bachelor,
 
   case 12:
 
-    // identify bachelor with an N-sigma cut
+    // identify bachelor with an N-sigma cut - TOF required
     nTOFsigmas = -999;
     tofID = fPidHF->GetnSigmaTOF(bachelor, 4, nTOFsigmas);
     nTPCsigmas = -999;
@@ -1174,6 +1174,46 @@ void AliRDHFCutsLctoV0::CheckPID(AliAODTrack *bachelor,
 
     break;
 
+  case 13:
+
+    // identify bachelor with an N-sigma cut - TOF required when available
+    nTOFsigmas = -999;
+    tofID = fPidHF->GetnSigmaTOF(bachelor, 4, nTOFsigmas);
+    nTPCsigmas = -999;
+    tpcID = fPidHF->GetnSigmaTPC(bachelor, 4, nTPCsigmas);
+    
+    isBachelorID1 = TMath::Abs(nTPCsigmas) < 3. && (TMath::Abs(nTOFsigmas) < 3. || nTOFsigmas == -999) && (tpcID == 1) && (tofID == 1);
+
+    nTOFsigmas = -999;
+    tofID = fPidHF->GetnSigmaTOF(bachelor, 2, nTOFsigmas);
+    nTPCsigmas = -999;
+    tpcID = fPidHF->GetnSigmaTPC(bachelor, 2, nTPCsigmas);
+
+    isBachelorID2 = TMath::Abs(nTPCsigmas) < 3. && (TMath::Abs(nTOFsigmas) < 3. || nTOFsigmas == -999) && (tpcID == 1) && (tofID == 1);
+    isBachelorID4 = isBachelorID2;
+
+    break;
+
+  case 14:
+    
+    // identify bachelor with an N-sigma cut - TOF required up to fLowPtCut
+    nTOFsigmas = -999;
+    tofID = fPidHF->GetnSigmaTOF(bachelor, 4, nTOFsigmas);
+    nTPCsigmas = -999;
+    tpcID = fPidHF->GetnSigmaTPC(bachelor, 4, nTPCsigmas);
+    
+    isBachelorID1 = (tpcID == 1) && (tofID == 1) && ( (bachelor->P() < fLowPtCut && TMath::Abs(nTPCsigmas) < 3. && TMath::Abs(nTOFsigmas) < 3.) || (bachelor->P() >= fLowPtCut && TMath::Abs(nTPCsigmas) < 3.) );
+    
+    nTOFsigmas = -999;
+    tofID = fPidHF->GetnSigmaTOF(bachelor, 2, nTOFsigmas);
+    nTPCsigmas = -999;
+    tpcID = fPidHF->GetnSigmaTPC(bachelor, 2, nTPCsigmas);
+    
+    isBachelorID2 = (tpcID == 1) && (tofID == 1) && ( (bachelor->P() < fLowPtCut && TMath::Abs(nTPCsigmas) < 3. && TMath::Abs(nTOFsigmas) < 3.) || (bachelor->P() >= fLowPtCut && TMath::Abs(nTPCsigmas) < 3.) );
+    isBachelorID4 = isBachelorID2;
+    
+    break;
+    
   }
 
 }


### PR DESCRIPTION
- case 13: use TOF only when available, and apply a 3 sigma cut on both TOF
and TPC
- case 14: 3 sigma cut on both TOF and TPCm with TOF always required but
only up to low momentum