### PR TITLE
Porting EMCAL_STRINGVIEW also to AliAnalysisTaskEmcal

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
@@ -57,6 +57,13 @@ class AliESDInputHandler;
 #include "AliEmcalList.h"
 #include "AliEventCuts.h"
 
+#if ROOT_VERSION_CODE > ROOT_VERSION(6,10,0) 
+#include "RStringView.h"
+#define EMCAL_STRINGVIEW const std::string_view
+#else 
+#define EMCAL_STRINGVIEW const std::string &
+#endif
+
 #include "AliAnalysisTaskSE.h"
 /**
  * @class AliAnalysisTaskEmcal


### PR DESCRIPTION
Allows transparent usage of std::string_view from ROOT in case of ROOT6 builds for non-owning strings (i.e. in interfaces).