### PR TITLE
Add PID cut for V0 particles

### DIFF
--- a/PWGDQ/dielectron/macrosLMEE/Config_acapon.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_acapon.C
@@ -373,6 +373,14 @@ AliDielectron* Config_acapon(TString cutDefinition,
       die->GetPairFilter().AddCuts(LMcutlib->GetPairCuts(LMEECutLib::kCutSet1));
     }
   }
+  // Two cut settings to check PID efficiency using V0 electrons 
+  // (does not work MC, checked 2019.05.08)
+  else if(cutDefinition == "kV0_TTreeCutPID"){
+    die->GetTrackFilter().AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kV0_trackCuts, LMEECutLib::kTTreeCuts));
+  }
+  else if(cutDefinition == "kV0_MVAePID"){
+    die->GetTrackFilter().AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kV0_trackCuts, LMEECutLib::kCutSet1));
+  }
   else{
     cout << " =============================== " << endl;
     cout << " ==== INVALID CONFIGURATION ==== " << endl;

--- a/PWGDQ/dielectron/macrosLMEE/LMEECutLib_acapon.C
+++ b/PWGDQ/dielectron/macrosLMEE/LMEECutLib_acapon.C
@@ -1181,7 +1181,7 @@ AliDielectronCutGroup* LMEECutLib::GetTrackCuts(Int_t cutSet, Int_t PIDcuts){
       trackCuts->AddCut(GetPIDCuts(PIDcuts));
       trackCuts->Print();
       return trackCuts;
-    case kV0_trackCuts:
+    case kV0_trackCuts: // Does not work for MC (checked 2019.05.08)
       // V0 specific track cuts
       gammaV0cuts->SetV0finder(AliDielectronV0Cuts::kOnTheFly);
       // Cut on the angle between the total momentum vector of the daughter


### PR DESCRIPTION
Add cut settings to obtain a selection of V0 electrons with and without ePID. 
The "without PID" selection applies very loose eSigTPC cuts to mimic those used in the analysis.