### PR TITLE
ATO-465 - check ESD track pointer - Fix Crash/Warning remained

### DIFF
--- a/PWGPP/AliESDtools.cxx
+++ b/PWGPP/AliESDtools.cxx
@@ -871,6 +871,7 @@ Int_t AliESDtools::DumpEventVariables() {
   Int_t eventMult = fEvent->GetNumberOfESDTracks();
   for (Int_t iTrack=0;iTrack<eventMult;++iTrack){
     AliESDtrack *track = fEvent->GetTrack(iTrack);
+    if (track== nullptr) continue;
     if (track->IsOn(AliESDtrack::kTPCin)) TPCMult++;
   }
 


### PR DESCRIPTION
seems to be ESD container is not compact anymore