### PR TITLE
Fix compilation issue when fastjet is disabled

### DIFF
--- a/PWGJE/FlavourJetTasks/CMakeLists.txt
+++ b/PWGJE/FlavourJetTasks/CMakeLists.txt
@@ -52,7 +52,6 @@ set(SRCS
     AliPicoV0RD.cxx
     AliPicoV0.cxx
     AliPicoBase.cxx
-    AliAnalysisTaskHFJetIPQA.cxx
    )
 
 if(FASTJET_FOUND)
@@ -68,7 +67,7 @@ if(FASTJET_FOUND)
            AliAnalysisTaskHFSubstructure.cxx
            AliDJetTTreeReader.cxx
            AliDJetTHnReader.cxx
-	   AliAnalysisTaskHFJetIPQA.cxx
+           AliAnalysisTaskHFJetIPQA.cxx
            )
 endif(FASTJET_FOUND)
 


### PR DESCRIPTION
The class AliAnalysisTaskHFJetIPQA.cxx was added twice in the SRCS of the CMakeLists.txt:
once in the SRCS that are always compilend and another time in the SRCS that are compiled only when fastjet is found.
Since the task depends on fastjet, it has to be added only in the second case.