### PR TITLE
PWGUD/UPC: Added pt-distr analysis for neutron emission classes.

### DIFF
--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
@@ -162,6 +162,18 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward()
       fInvariantMassDistributionIncoherentZNCzeroZNAanyH(0),
       fInvariantMassDistributionIncoherentZNCanyZNAzeroH(0),
       fInvariantMassDistributionIncoherentZNCanyZNAanyH(0),
+      fDimuonPtDistributionZNCzeroZNAzeroH(0),
+      fDimuonPtDistributionZNCzeroZNAanyH(0),
+      fDimuonPtDistributionZNCanyZNAzeroH(0),
+      fDimuonPtDistributionZNCanyZNAanyH(0),
+      fDimuonPtDistributionCoherentZNCzeroZNAzeroH(0),
+      fDimuonPtDistributionCoherentZNCzeroZNAanyH(0),
+      fDimuonPtDistributionCoherentZNCanyZNAzeroH(0),
+      fDimuonPtDistributionCoherentZNCanyZNAanyH(0),
+      fDimuonPtDistributionIncoherentZNCzeroZNAzeroH(0),
+      fDimuonPtDistributionIncoherentZNCzeroZNAanyH(0),
+      fDimuonPtDistributionIncoherentZNCanyZNAzeroH(0),
+      fDimuonPtDistributionIncoherentZNCanyZNAanyH(0),
       fAngularDistribOfPositiveMuonRestFrameJPsiH(0),
       fAngularDistribOfNegativeMuonRestFrameJPsiH(0),
       fCheckHelicityRestFrameJPsiH(0),
@@ -275,6 +287,18 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward(const char* name)
       fInvariantMassDistributionIncoherentZNCzeroZNAanyH(0),
       fInvariantMassDistributionIncoherentZNCanyZNAzeroH(0),
       fInvariantMassDistributionIncoherentZNCanyZNAanyH(0),
+      fDimuonPtDistributionZNCzeroZNAzeroH(0),
+      fDimuonPtDistributionZNCzeroZNAanyH(0),
+      fDimuonPtDistributionZNCanyZNAzeroH(0),
+      fDimuonPtDistributionZNCanyZNAanyH(0),
+      fDimuonPtDistributionCoherentZNCzeroZNAzeroH(0),
+      fDimuonPtDistributionCoherentZNCzeroZNAanyH(0),
+      fDimuonPtDistributionCoherentZNCanyZNAzeroH(0),
+      fDimuonPtDistributionCoherentZNCanyZNAanyH(0),
+      fDimuonPtDistributionIncoherentZNCzeroZNAzeroH(0),
+      fDimuonPtDistributionIncoherentZNCzeroZNAanyH(0),
+      fDimuonPtDistributionIncoherentZNCanyZNAzeroH(0),
+      fDimuonPtDistributionIncoherentZNCanyZNAanyH(0),
       fAngularDistribOfPositiveMuonRestFrameJPsiH(0),
       fAngularDistribOfNegativeMuonRestFrameJPsiH(0),
       fCheckHelicityRestFrameJPsiH(0),
@@ -632,6 +656,43 @@ void AliAnalysisTaskUPCforward::UserCreateOutputObjects()
 
   fInvariantMassDistributionIncoherentZNCanyZNAanyH = new TH1F("fInvariantMassDistributionIncoherentZNCanyZNAanyH", "fInvariantMassDistributionIncoherentZNCanyZNAanyH", 2000, 0, 20);
   fOutputList->Add(fInvariantMassDistributionIncoherentZNCanyZNAanyH);
+
+  fDimuonPtDistributionZNCzeroZNAzeroH = new TH1F("fDimuonPtDistributionZNCzeroZNAzeroH", "fDimuonPtDistributionZNCzeroZNAzeroH", 2000, 0, 20);
+  fOutputList->Add(fDimuonPtDistributionZNCzeroZNAzeroH);
+
+  fDimuonPtDistributionZNCzeroZNAanyH = new TH1F("fDimuonPtDistributionZNCzeroZNAanyH", "fDimuonPtDistributionZNCzeroZNAanyH", 2000, 0, 20);
+  fOutputList->Add(fDimuonPtDistributionZNCzeroZNAanyH);
+
+  fDimuonPtDistributionZNCanyZNAzeroH = new TH1F("fDimuonPtDistributionZNCanyZNAzeroH", "fDimuonPtDistributionZNCanyZNAzeroH", 2000, 0, 20);
+  fOutputList->Add(fDimuonPtDistributionZNCanyZNAzeroH);
+
+  fDimuonPtDistributionZNCanyZNAanyH = new TH1F("fDimuonPtDistributionZNCanyZNAanyH", "fDimuonPtDistributionZNCanyZNAanyH", 2000, 0, 20);
+  fOutputList->Add(fDimuonPtDistributionZNCanyZNAanyH);
+
+  fDimuonPtDistributionCoherentZNCzeroZNAzeroH = new TH1F("fDimuonPtDistributionCoherentZNCzeroZNAzeroH", "fDimuonPtDistributionCoherentZNCzeroZNAzeroH", 2000, 0, 20);
+  fOutputList->Add(fDimuonPtDistributionCoherentZNCzeroZNAzeroH);
+
+  fDimuonPtDistributionCoherentZNCzeroZNAanyH = new TH1F("fDimuonPtDistributionCoherentZNCzeroZNAanyH", "fDimuonPtDistributionCoherentZNCzeroZNAanyH", 2000, 0, 20);
+  fOutputList->Add(fDimuonPtDistributionCoherentZNCzeroZNAanyH);
+
+  fDimuonPtDistributionCoherentZNCanyZNAzeroH = new TH1F("fDimuonPtDistributionCoherentZNCanyZNAzeroH", "fDimuonPtDistributionCoherentZNCanyZNAzeroH", 2000, 0, 20);
+  fOutputList->Add(fDimuonPtDistributionCoherentZNCanyZNAzeroH);
+
+  fDimuonPtDistributionCoherentZNCanyZNAanyH = new TH1F("fDimuonPtDistributionCoherentZNCanyZNAanyH", "fDimuonPtDistributionCoherentZNCanyZNAanyH", 2000, 0, 20);
+  fOutputList->Add(fDimuonPtDistributionCoherentZNCanyZNAanyH);
+
+  fDimuonPtDistributionIncoherentZNCzeroZNAzeroH = new TH1F("fDimuonPtDistributionIncoherentZNCzeroZNAzeroH", "fDimuonPtDistributionIncoherentZNCzeroZNAzeroH", 2000, 0, 20);
+  fOutputList->Add(fDimuonPtDistributionIncoherentZNCzeroZNAzeroH);
+
+  fDimuonPtDistributionIncoherentZNCzeroZNAanyH = new TH1F("fDimuonPtDistributionIncoherentZNCzeroZNAanyH", "fDimuonPtDistributionIncoherentZNCzeroZNAanyH", 2000, 0, 20);
+  fOutputList->Add(fDimuonPtDistributionIncoherentZNCzeroZNAanyH);
+
+  fDimuonPtDistributionIncoherentZNCanyZNAzeroH = new TH1F("fDimuonPtDistributionIncoherentZNCanyZNAzeroH", "fDimuonPtDistributionIncoherentZNCanyZNAzeroH", 2000, 0, 20);
+  fOutputList->Add(fDimuonPtDistributionIncoherentZNCanyZNAzeroH);
+
+  fDimuonPtDistributionIncoherentZNCanyZNAanyH = new TH1F("fDimuonPtDistributionIncoherentZNCanyZNAanyH", "fDimuonPtDistributionIncoherentZNCanyZNAanyH", 2000, 0, 20);
+  fOutputList->Add(fDimuonPtDistributionIncoherentZNCanyZNAanyH);
+
 
 
   /* - Here starts the list of histograms needed for the analysis of the J/Psi's
@@ -1562,32 +1623,44 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
                       if( fZNCEnergy < 1250 ) {
                                   if( fZNAEnergy > -5000 ) {
                                               if( fZNAEnergy < 1000 ) {
+                                                          fDimuonPtDistributionZNCzeroZNAzeroH->Fill(ptOfTheDimuonPair);
                                                           if( ptOfTheDimuonPair < 0.25) {
                                                                     fInvariantMassDistributionCoherentZNCzeroZNAzeroH->Fill(possibleJPsi.Mag());
+                                                                    fDimuonPtDistributionCoherentZNCzeroZNAzeroH->Fill(ptOfTheDimuonPair);
                                                           } else {
                                                                     fInvariantMassDistributionIncoherentZNCzeroZNAzeroH->Fill(possibleJPsi.Mag());
+                                                                    fDimuonPtDistributionIncoherentZNCzeroZNAzeroH->Fill(ptOfTheDimuonPair);
                                                           }
                                               } else {
+                                                          fDimuonPtDistributionZNCzeroZNAanyH->Fill(ptOfTheDimuonPair);
                                                           if( ptOfTheDimuonPair < 0.25) {
                                                                     fInvariantMassDistributionCoherentZNCzeroZNAanyH->Fill(possibleJPsi.Mag());
+                                                                    fDimuonPtDistributionCoherentZNCzeroZNAanyH->Fill(ptOfTheDimuonPair);
                                                           } else {
                                                                     fInvariantMassDistributionIncoherentZNCzeroZNAanyH->Fill(possibleJPsi.Mag());
+                                                                    fDimuonPtDistributionIncoherentZNCzeroZNAanyH->Fill(ptOfTheDimuonPair);
                                                           }
                                               }
                                   }
                       } else {
                                   if( fZNAEnergy > -5000 ) {
                                               if( fZNAEnergy < 1000 ) {
+                                                          fDimuonPtDistributionZNCanyZNAzeroH->Fill(ptOfTheDimuonPair);
                                                           if( ptOfTheDimuonPair < 0.25) {
                                                                     fInvariantMassDistributionCoherentZNCanyZNAzeroH->Fill(possibleJPsi.Mag());
+                                                                    fDimuonPtDistributionCoherentZNCanyZNAzeroH->Fill(ptOfTheDimuonPair);
                                                           } else {
                                                                     fInvariantMassDistributionIncoherentZNCanyZNAzeroH->Fill(possibleJPsi.Mag());
+                                                                    fDimuonPtDistributionIncoherentZNCanyZNAzeroH->Fill(ptOfTheDimuonPair);
                                                           }
                                               } else {
+                                                          fDimuonPtDistributionZNCanyZNAanyH->Fill(ptOfTheDimuonPair);
                                                           if( ptOfTheDimuonPair < 0.25) {
                                                                     fInvariantMassDistributionCoherentZNCanyZNAanyH->Fill(possibleJPsi.Mag());
+                                                                    fDimuonPtDistributionCoherentZNCanyZNAanyH->Fill(ptOfTheDimuonPair);
                                                           } else {
                                                                     fInvariantMassDistributionIncoherentZNCanyZNAanyH->Fill(possibleJPsi.Mag());
+                                                                    fDimuonPtDistributionIncoherentZNCanyZNAanyH->Fill(ptOfTheDimuonPair);
                                                           }
                                               }
                                   }

--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.h
@@ -636,6 +636,105 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
         TH1F*                   fInvariantMassDistributionIncoherentZNCanyZNAanyH;       //!
 
                                 /**
+                                 * This histogram records the pt-ditribution
+                                 * of the dimuon pairs. This is divided in
+                                 * neutron emission classes.
+                                 * ZNC=0n, ZNA=0n.
+                                 */
+        TH1F*                   fDimuonPtDistributionZNCzeroZNAzeroH;         //!
+
+                                /**
+                                 * This histogram records the pt-ditribution
+                                 * of the dimuon pairs. This is divided in
+                                 * neutron emission classes.
+                                 * ZNC=0n, ZNA=Xn.
+                                 */
+        TH1F*                   fDimuonPtDistributionZNCzeroZNAanyH;         //!
+
+                                /**
+                                 * This histogram records the pt-ditribution
+                                 * of the dimuon pairs. This is divided in
+                                 * neutron emission classes.
+                                 * ZNC=Xn, ZNA=0n.
+                                 */
+        TH1F*                   fDimuonPtDistributionZNCanyZNAzeroH;         //!
+
+                                /**
+                                 * This histogram records the pt-ditribution
+                                 * of the dimuon pairs. This is divided in
+                                 * neutron emission classes and pt.
+                                 * ZNC=Xn, ZNA=Xn.
+                                 */
+        TH1F*                   fDimuonPtDistributionZNCanyZNAanyH;         //!
+
+                                /**
+                                 * This histogram records the pt-ditribution
+                                 * of the dimuon pairs. This is divided in
+                                 * neutron emission classes and pt.
+                                 * COHERENT, ZNC=0n, ZNA=0n.
+                                 */
+        TH1F*                   fDimuonPtDistributionCoherentZNCzeroZNAzeroH;         //!
+
+                                /**
+                                 * This histogram records the pt-ditribution
+                                 * of the dimuon pairs. This is divided in
+                                 * neutron emission classes and pt.
+                                 * COHERENT, ZNC=0n, ZNA=Xn.
+                                 */
+        TH1F*                   fDimuonPtDistributionCoherentZNCzeroZNAanyH;         //!
+
+                                /**
+                                 * This histogram records the pt-ditribution
+                                 * of the dimuon pairs. This is divided in
+                                 * neutron emission classes and pt.
+                                 * COHERENT, ZNC=Xn, ZNA=0n.
+                                 */
+        TH1F*                   fDimuonPtDistributionCoherentZNCanyZNAzeroH;         //!
+
+                                /**
+                                 * This histogram records the pt-ditribution
+                                 * of the dimuon pairs. This is divided in
+                                 * neutron emission classes and pt.
+                                 * COHERENT, ZNC=Xn, ZNA=Xn.
+                                 */
+        TH1F*                   fDimuonPtDistributionCoherentZNCanyZNAanyH;         //!
+
+                                /**
+                                 * This histogram records the pt-ditribution
+                                 * of the dimuon pairs. This is divided in
+                                 * neutron emission classes and pt.
+                                 * INCOHERENT, ZNC=0n, ZNA=0n.
+                                 */
+        TH1F*                   fDimuonPtDistributionIncoherentZNCzeroZNAzeroH;         //!
+
+                                /**
+                                 * This histogram records the pt-ditribution
+                                 * of the dimuon pairs. This is divided in
+                                 * neutron emission classes and pt.
+                                 * INCOHERENT, ZNC=0n, ZNA=Xn.
+                                 */
+        TH1F*                   fDimuonPtDistributionIncoherentZNCzeroZNAanyH;         //!
+
+                                /**
+                                 * This histogram records the pt-ditribution
+                                 * of the dimuon pairs. This is divided in
+                                 * neutron emission classes and pt.
+                                 * INCOHERENT, ZNC=Xn, ZNA=0n.
+                                 */
+        TH1F*                   fDimuonPtDistributionIncoherentZNCanyZNAzeroH;         //!
+
+                                /**
+                                 * This histogram records the pt-ditribution
+                                 * of the dimuon pairs. This is divided in
+                                 * neutron emission classes and pt.
+                                 * INCOHERENT, ZNC=Xn, ZNA=Xn.
+                                 */
+        TH1F*                   fDimuonPtDistributionIncoherentZNCanyZNAanyH;         //!
+
+
+        //_______________________________
+
+                                /**
                                  * This histogram shows the angular distribution
                                  * of the positive muon in the rest frame of the
                                  * J/Psi. This histogram is needed to evaluate
@@ -953,7 +1052,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforward, 15);
+        ClassDef(AliAnalysisTaskUPCforward, 18);
 };
 
 #endif


### PR DESCRIPTION
Added the analysis of the pt-distribution divided for neutron emission classes.
IMPORTANT: tested.
IMPORTANT: still using vectors... Awaiting tests to switch to new code.