### PR TITLE
Adds flag to remove centrality checks for run 1

### DIFF
--- a/PWGDQ/dielectron/core/AliAnalysisTaskElectronEfficiencyV2.cxx
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskElectronEfficiencyV2.cxx
@@ -87,7 +87,7 @@ AliAnalysisTaskElectronEfficiencyV2::AliAnalysisTaskElectronEfficiencyV2(): AliA
                                                                               , fGenNegPart(), fGenPosPart(), fRecNegPart(), fRecPosPart()
                                                                               , fDoCocktailWeighting(false), fCocktailFilename(""), fCocktailFilenameFromAlien(""), fCocktailFile(0x0)
                                                                               , fPtPion(0x0), fPtEta(0x0), fPtEtaPrime(0x0), fPtRho(0x0), fPtOmega(0x0), fPtPhi(0x0), fPtJPsi(0x0),
-                                                                              fPostPIDCntrdCorrTPC(0x0), fPostPIDWdthCorrTPC(0x0), fPostPIDCntrdCorrITS(0x0), fPostPIDWdthCorrITS(0x0), fPostPIDCntrdCorrTOF(0x0), fPostPIDWdthCorrTOF(0x0)
+                                                                              fPostPIDCntrdCorrTPC(0x0), fPostPIDWdthCorrTPC(0x0), fPostPIDCntrdCorrITS(0x0), fPostPIDWdthCorrITS(0x0), fPostPIDCntrdCorrTOF(0x0), fPostPIDWdthCorrTOF(0x0), run1analysis(kFALSE)
 {
 // ROOT IO constructor , don ’t allocate memory here !
 }
@@ -119,7 +119,7 @@ AliAnalysisTaskElectronEfficiencyV2::AliAnalysisTaskElectronEfficiencyV2(const c
                                                                               , fGenNegPart(), fGenPosPart(), fRecNegPart(), fRecPosPart()
                                                                               , fDoCocktailWeighting(false), fCocktailFilename(""), fCocktailFilenameFromAlien(""), fCocktailFile(0x0)
                                                                               , fPtPion(0x0), fPtEta(0x0), fPtEtaPrime(0x0), fPtRho(0x0), fPtOmega(0x0), fPtPhi(0x0), fPtJPsi(0x0),
-                                                                              fPostPIDCntrdCorrTPC(0x0), fPostPIDWdthCorrTPC(0x0), fPostPIDCntrdCorrITS(0x0), fPostPIDWdthCorrITS(0x0), fPostPIDCntrdCorrTOF(0x0), fPostPIDWdthCorrTOF(0x0)
+                                                                              fPostPIDCntrdCorrTPC(0x0), fPostPIDWdthCorrTPC(0x0), fPostPIDCntrdCorrITS(0x0), fPostPIDWdthCorrITS(0x0), fPostPIDCntrdCorrTOF(0x0), fPostPIDWdthCorrTOF(0x0), run1analysis(kFALSE)
 
 {
   DefineInput (0, TChain::Class());
@@ -707,7 +707,7 @@ void AliAnalysisTaskElectronEfficiencyV2::UserExec(Option_t* option){
   // Apply centrality selection
   double centralityF = -1;
   AliMultSelection *multSelection = (AliMultSelection*)fEvent->FindListObject("MultSelection");
-  if (multSelection) centralityF  = multSelection->GetMultiplicityPercentile("V0M",kFALSE);
+  if (multSelection && !run1analysis) centralityF  = multSelection->GetMultiplicityPercentile("V0M",kFALSE);
   if (centralityF == -1 && fMaxCentrality == -1 && fMinCentrality == -1) {/*do nothing*/} // is used for pp and pPb analysis
   else if (centralityF > fMaxCentrality || centralityF < fMinCentrality) { return;} // reject event
 

--- a/PWGDQ/dielectron/core/AliAnalysisTaskElectronEfficiencyV2.h
+++ b/PWGDQ/dielectron/core/AliAnalysisTaskElectronEfficiencyV2.h
@@ -45,6 +45,7 @@ public:
    // called at end of analysis
    virtual void Terminate(Option_t* option);
 
+   void SetRun1Analysis(Bool_t answer){ run1analysis = answer; }
 
    enum Detector {kITS, kTPC, kTOF};
    Bool_t               GetEnablePhysicsSelection() const   {return fSelectPhysics; }
@@ -319,6 +320,8 @@ private:
   TH1* fPostPIDWdthCorrITS;      // post pid correction object for widths in ITS
   TH1* fPostPIDCntrdCorrTOF;     // post pid correction object for centroids in TOF
   TH1* fPostPIDWdthCorrTOF;      // post pid correction object for widths in TOF
+
+  Bool_t run1analysis;
 
 
   AliAnalysisTaskElectronEfficiencyV2(const AliAnalysisTaskElectronEfficiencyV2&); // not implemented

--- a/PWGDQ/dielectron/macrosLMEE/AddTask_acapon_Efficiency.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTask_acapon_Efficiency.C
@@ -97,6 +97,9 @@ AliAnalysisTaskElectronEfficiencyV2* AddTask_acapon_Efficiency(TString names    
   GetCentrality(centrality, centMin, centMax);
   std::cout << "CentMin = " << centMin << "  CentMax = " << centMax << std::endl;
   task->SetCentrality(centMin, centMax);
+  if(centrality == 8){
+    task->SetRun1Analysis(kTRUE);
+  }
 
   // #########################################################
   // #########################################################

--- a/PWGDQ/dielectron/macrosLMEE/Config_acapon_Efficiency.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_acapon_Efficiency.C
@@ -84,6 +84,7 @@ void GetCentrality(const Int_t centrality, Double_t& CentMin, Double_t& CentMax)
   else if(centrality == 5){CentMin = 60; CentMax = 80;}
   else if(centrality == 6){CentMin = 80; CentMax = 100;}
   else if(centrality == 7){CentMin = 0;  CentMax = 5;}
+  else if(centrality == 8){CentMin = -1; CentMax = -1;}
   else                      {std::cout << "WARNING::Centrality range not found....." std::endl;}
   return;
 }


### PR DESCRIPTION
Access to centrality information changed between run 1 and run 2. Switch
off centrality dependence when looking at run 1 data.
Also includes necessary changes to AddTask and Config file if wanting to look at run 1.