### PR TITLE
Maintenance on AliAnalysisPIDtrack and AliGFWFlowContainers

### DIFF
--- a/PWGCF/FLOW/GF/AliAnalysisTaskGFWFlow.cxx
+++ b/PWGCF/FLOW/GF/AliAnalysisTaskGFWFlow.cxx
@@ -270,6 +270,7 @@ void AliAnalysisTaskGFWFlow::UserCreateOutputObjects(){
     Double_t multibins[] = {0,10,20,30,40,50,60,70,80};
     fFC = new AliGFWFlowContainer();
     fFC->SetName(Form("FC%s",fSelections[fCurrSystFlag]->GetSystPF()));
+    fFC->SetXAxis(fPtAxis);
     fFC->Initialize(OAforPt,8,multibins,fCurrSystFlag?1:10); //Statistics only required for nominal profiles, so do not create randomized profiles for systematics
     fGFW = new AliGFW();
     //Full regions

--- a/PWGCF/FLOW/GF/AliGFWFlowContainer.h
+++ b/PWGCF/FLOW/GF/AliGFWFlowContainer.h
@@ -14,6 +14,7 @@
 #include "TRandom.h"
 #include "TString.h"
 #include "TCollection.h"
+#include "TAxis.h"
 
 class AliGFWFlowContainer:public TNamed {
  public:
@@ -23,6 +24,9 @@ class AliGFWFlowContainer:public TNamed {
   enum StatisticsType {kSingleSample, kJackKnife, kBootstrap};
   void Initialize(TObjArray *inputList, Int_t nMultiBins, Double_t *multiBins, Int_t nRandomized=0);
   void Initialize(TObjArray *inputList, Int_t nMultiBins, Double_t MultiMin, Double_t MultiMax, Int_t nRandomized=0);
+  Bool_t CreateBinsFromAxis(TAxis *inax);
+  void SetXAxis(TAxis *inax);
+  void SetXAxis();
   void RebinMulti(Int_t rN) { if(fProf) fProf->RebinX(rN); };
   Int_t GetNMultiBins() { return fProf->GetNbinsX(); };
   Double_t GetMultiAtBin(Int_t bin) { return fProf->GetXaxis()->GetBinCenter(bin); };
@@ -130,9 +134,12 @@ class AliGFWFlowContainer:public TNamed {
   TString fIDName;
   Int_t fPtRebin; //! do not store
   Double_t *fPtRebinEdges; //! do not store
+  TAxis *fXAxis;
+  Int_t fNbinsPt; //! Do not store; stored in the fXAxis
+  Double_t *fbinsPt; //! Do not store; stored in fXAxis
   Bool_t fPropagateErrors; //! do not store
   TProfile *GetRefFlowProfile(const char *order, Double_t m1=-1, Double_t m2=-1);
-  ClassDef(AliGFWFlowContainer, 1);
+  ClassDef(AliGFWFlowContainer, 2);
 };
 
 

--- a/PWGLF/SPECTRA/PiKaPr/TPCTOFfits/AliAnalysisPIDTrack.h
+++ b/PWGLF/SPECTRA/PiKaPr/TPCTOFfits/AliAnalysisPIDTrack.h
@@ -161,6 +161,9 @@ public TObject
   static void SetRejectITSFakes(Bool_t value) {fgRejectITSFakes = value;}; // setter
   static void SetMatchTrackDeltaX(Float_t value) {fgMatchTrackDeltaX = value;}; // setter
   static void SetMatchTrackDeltaZ(Float_t value) {fgMatchTrackDeltaZ = value;}; // setter
+  static AliTPCPIDResponse *fgTPCResponse;
+  static AliTOFPIDResponse *fgTOFResponse;
+
 
  private:
 
@@ -172,7 +175,7 @@ public TObject
   Double_t fSign; // sign
   ULong64_t fStatus; // status
   Int_t fLabel; // label
-  Float_t fImpactParameter[2]; // impact parameters 
+  Float_t fImpactParameter[2]; // impact parameters
   //Float_t fImpactParameterCov[3]; // impact parameters covariance
   /*** TPC PID info ***/
   Float_t fTPCmomentum; // TPC inner wall momentum
@@ -203,8 +206,8 @@ public TObject
   Short_t fMCTOFMatchLevel; // MC TOF match level
   Float_t fMCTOFTime; // MC TOF time
   Float_t fMCTOFLength; // MC TOF length
-  Bool_t fMCSecondaryWeak; 
-  Bool_t fMCSecondaryMaterial; 
+  Bool_t fMCSecondaryWeak;
+  Bool_t fMCSecondaryMaterial;
   /*** HMPID PID info ***/
   //Float_t fHMPIDmomentum;
   //Float_t fHMPIDsignal;
@@ -246,8 +249,6 @@ public TObject
   //static AliTOFGeometry fgTOFGeometry;
   //  static AliTOFcalibHisto fgTOFcalibHisto;
   //  static Bool_t fgTOFcalibHistoFlag;
-  static AliTPCPIDResponse *fgTPCResponse;
-  static AliTOFPIDResponse *fgTOFResponse;
   static TH2F *hTOFtuned_th[AliPID::kSPECIES];
 
   Float_t fTimeZeroSigma; //!


### PR DESCRIPTION
1) fgTOFPIDResponse in AliAnalysisPIDtrack.h is now public static
2) AliGFWFlowContainers now also store the pT-axis of the preset binning I also add the default pT binning, in case older files are used