### PR TITLE
ATO-465 - Fix warning in track loop + adding precise time estimator

### DIFF
--- a/PWGPP/AliAnalysisTaskFilteredTree.cxx
+++ b/PWGPP/AliAnalysisTaskFilteredTree.cxx
@@ -488,7 +488,8 @@ void AliAnalysisTaskFilteredTree::ProcessCosmics(AliESDEvent *const event, AliES
       Int_t ntracksSPD = vertexSPD->GetNContributors();
       Int_t ntracksTPC = vertexTPC->GetNContributors();        
       Int_t runNumber     = event->GetRunNumber();        
-      Int_t timeStamp    = event->GetTimeStamp();
+      Int_t evtTimeStamp    = event->GetTimeStamp();
+      Double_t timeStamp= event->GetTimeStampCTPBCCorr();
       ULong64_t triggerMask = event->GetTriggerMask();
       Float_t magField    = event->GetMagneticField();
       TObjString triggerClass = event->GetFiredTriggerClasses().Data();
@@ -538,7 +539,8 @@ void AliAnalysisTaskFilteredTree::ProcessCosmics(AliESDEvent *const event, AliES
         "gid="<<gid<<                         // global id of track
         "fileName.="<<&fCurrentFileName<<     // file name
         "runNumber="<<runNumber<<             // run number	    
-        "evtTimeStamp="<<timeStamp<<          // time stamp of event
+        "evtTimeStamp="<<evtTimeStamp<<          // time stamp of event building
+        "timeStamp="<<timeStamp<<                // precise time stamp of interaction based on LHCclock
         "evtNumberInFile="<<eventNumber<<     // event number	    
         "trigger="<<triggerMask<<             // trigger mask
         "triggerClass="<<&triggerClass<<      // trigger class
@@ -694,6 +696,7 @@ void AliAnalysisTaskFilteredTree::Process(AliESDEvent *const esdEvent, AliMCEven
     Float_t bz = esdEvent->GetMagneticField();
     Int_t runNumber = esdEvent->GetRunNumber();
     Int_t evtTimeStamp = esdEvent->GetTimeStamp();
+    Double_t timeStamp= esdEvent->GetTimeStampCTPBCCorr();
     Int_t evtNumberInFile = esdEvent->GetEventNumberInFile();
    
     // Global event id calculation using orbitID, bunchCrossingID and periodID 
@@ -748,6 +751,7 @@ void AliAnalysisTaskFilteredTree::Process(AliESDEvent *const esdEvent, AliMCEven
         "fileName.="<<&fCurrentFileName<<            
         "runNumber="<<runNumber<<
         "evtTimeStamp="<<evtTimeStamp<<
+        "timeStamp="<<timeStamp<<              // excat time stamp -based on LHCclock
         "evtNumberInFile="<<evtNumberInFile<<
         "triggerClass="<<&triggerClass<<      //  trigger
         "Bz="<<bz<<                           //  magnetic field
@@ -965,6 +969,7 @@ void AliAnalysisTaskFilteredTree::ProcessAll(AliESDEvent *const esdEvent, AliMCE
   Float_t bz = esdEvent->GetMagneticField();
   Int_t runNumber = esdEvent->GetRunNumber();
   Int_t evtTimeStamp = esdEvent->GetTimeStamp();
+  Double_t timeStamp= esdEvent->GetTimeStampCTPBCCorr();
   Int_t evtNumberInFile = esdEvent->GetEventNumberInFile();
   Int_t mult = vtxESD->GetNContributors();
   (*fTreeSRedirector)<<"eventInfoTracks"<<
@@ -972,6 +977,7 @@ void AliAnalysisTaskFilteredTree::ProcessAll(AliESDEvent *const esdEvent, AliMCE
     "fileName.="<<&fCurrentFileName<<                // name of the chunk file (hopefully full)
     "runNumber="<<runNumber<<                             // runNumber
     "evtTimeStamp="<<evtTimeStamp<<           // time stamp of event (in seconds)
+    "timeStamp="<<timeStamp<<                 // prcize time stamp
     "evtNumberInFile="<<evtNumberInFile<<     // event number
     "triggerMask="<<triggerMask<<             // trigger mask
     "triggerClass="<<&triggerClass<<          // trigger class as a string
@@ -1488,6 +1494,7 @@ void AliAnalysisTaskFilteredTree::ProcessAll(AliESDEvent *const esdEvent, AliMCE
             "fileName.="<<&fCurrentFileName<<                // name of the chunk file (hopefully full)
             "runNumber="<<runNumber<<                // runNumber
             "evtTimeStamp="<<evtTimeStamp<<          // time stamp of event (in seconds)
+            "timeStamp="<<timeStamp<<                // precize time stamp based on the LHC clock
             "evtNumberInFile="<<evtNumberInFile<<    // event number
             "triggerClass="<<&triggerClass<<         // trigger class as a string
             "Bz="<<bz<<                              // solenoid magnetic field in the z direction (in kGaus)
@@ -1743,6 +1750,7 @@ void AliAnalysisTaskFilteredTree::ProcessMCEff(AliESDEvent *const esdEvent, AliM
     Double_t bz = esdEvent->GetMagneticField();
     Double_t runNumber = esdEvent->GetRunNumber();
     Double_t evtTimeStamp = esdEvent->GetTimeStamp();
+    Double_t timeStamp= esdEvent->GetTimeStampCTPBCCorr();
     Int_t evtNumberInFile = esdEvent->GetEventNumberInFile();
     // loop over MC stack
     for (Int_t iMc = 0; iMc < mcStackSize; ++iMc) 
@@ -1835,7 +1843,8 @@ void AliAnalysisTaskFilteredTree::ProcessMCEff(AliESDEvent *const esdEvent, AliM
           "fileName.="<<&fCurrentFileName<<
           "triggerClass.="<<&triggerClass<<
           "runNumber="<<runNumber<<
-          "evtTimeStamp="<<evtTimeStamp<<
+          "evtTimeStamp="<<evtTimeStamp<<           // time stamp at event build
+          "timeStamp="<<timeStamp<<                 // precise time stamp based on the LHC clock idicating collision time
           "evtNumberInFile="<<evtNumberInFile<<     // 
           "Bz="<<bz<<                               // magnetic field
           "vtxESD.="<<vtxESD<<                      // vertex info
@@ -1972,6 +1981,7 @@ void AliAnalysisTaskFilteredTree::ProcessV0(AliESDEvent *const esdEvent, AliMCEv
   Float_t bz = esdEvent->GetMagneticField();
   Int_t run = esdEvent->GetRunNumber();
   Int_t time = esdEvent->GetTimeStamp();
+  Double_t timeStamp= esdEvent->GetTimeStampCTPBCCorr();
   Int_t evtNumberInFile = esdEvent->GetEventNumberInFile();
   Int_t nV0s = esdEvent->GetNumberOfV0s();
   Int_t mult = vtxESD->GetNContributors();
@@ -1980,6 +1990,7 @@ void AliAnalysisTaskFilteredTree::ProcessV0(AliESDEvent *const esdEvent, AliMCEv
     "fileName.="<<&fCurrentFileName<<                // name of the chunk file (hopefully full)
     "run="<<run<<                             // runNumber
     "time="<<time<<                           // time stamp of event (in seconds)
+    "timeStamp="<<timeStamp<<                 // more precise time stamp based on LHC clock
     "evtNumberInFile="<<evtNumberInFile<<     // event number
     "triggerClass="<<&triggerClass<<          // trigger class as a string
     "Bz="<<bz<<                               // solenoid magnetic field in the z direction (in kGaus)
@@ -2210,6 +2221,7 @@ void AliAnalysisTaskFilteredTree::ProcessdEdx(AliESDEvent *const esdEvent, AliMC
     Double_t bz = esdEvent->GetMagneticField();
     Double_t runNumber = esdEvent->GetRunNumber();
     Double_t evtTimeStamp = esdEvent->GetTimeStamp();
+    Double_t timeStamp= esdEvent->GetTimeStampCTPBCCorr();
     Int_t evtNumberInFile = esdEvent->GetEventNumberInFile();
    
     // Global event id calculation using orbitID, bunchCrossingID and periodID 
@@ -2260,6 +2272,7 @@ void AliAnalysisTaskFilteredTree::ProcessdEdx(AliESDEvent *const esdEvent, AliMC
         "fileName.="<<&fCurrentFileName<<     // file name
         "runNumber="<<runNumber<<
         "evtTimeStamp="<<evtTimeStamp<<
+        "timeStamp="<<timeStamp<<
         "evtNumberInFile="<<evtNumberInFile<<
         "triggerClass="<<&triggerClass<<      //  trigger
         "Bz="<<bz<<

--- a/PWGPP/AliESDtools.cxx
+++ b/PWGPP/AliESDtools.cxx
@@ -843,6 +843,7 @@ Int_t AliESDtools::DumpEventVariables() {
   for (Int_t i=0;i<64;i++) { vZeroMult[i] = fEvent->GetVZEROData()-> GetMultiplicity(i); }
   for (Int_t i=0;i<6;i++)  { itsClustersPerLayer[i] = multObj->GetNumberOfITSClusters(i); }
   Int_t runNumber=fEvent->GetRunNumber();
+  Double_t timeStampS=fEvent->GetTimeStamp();
   Double_t timeStamp= fEvent->GetTimeStampCTPBCCorr();
   Double_t bField=fEvent->GetMagneticField();
   ULong64_t orbitID      = (ULong64_t)fEvent->GetOrbitNumber();
@@ -869,7 +870,8 @@ Int_t AliESDtools::DumpEventVariables() {
   Int_t primMult    = vertex->GetNContributors();
   Int_t TPCMult = 0;
   Int_t eventMult = fEvent->GetNumberOfESDTracks();
-  for (Int_t iTrack=0;iTrack<eventMult;++iTrack){
+  Int_t nTracksStored   = fEvent->GetNumberOfTracks();
+  for (Int_t iTrack=0;iTrack<nTracksStored;++iTrack){
     AliESDtrack *track = fEvent->GetTrack(iTrack);
     if (track== nullptr) continue;
     if (track->IsOn(AliESDtrack::kTPCin)) TPCMult++;
@@ -878,14 +880,16 @@ Int_t AliESDtools::DumpEventVariables() {
   (*fStreamer)<<"events"<<
                      "run="                  << runNumber                 <<  // run Number
                      "bField="               << bField                   <<  // b field
-                     "gid="                  << gid              <<  // global event ID
-                     "timestamp="            << timeStamp             <<  // timestamp
+                     "gid="                  << gid                   <<  // global event ID
+                     "timeStampS="           << timeStampS            <<  // time stamp in seconds -event building
+                     "timestamp="            << timeStamp             <<  // more precise timestamp based on LHC clock
                      "triggerMask="          << triggerMask           <<  //trigger mask
                      "vz="                   << fVz                    <<  // vertex Z
                      "tpcvz="                << TPCvZ                 <<
                      "spdvz="                << SPDvZ                 <<
                      "tpcMult="              << TPCMult               <<  //  TPC multiplicity
                      "eventMult="            << fEventMult             <<  //  event multiplicity
+                     "nTracksStored="        << nTracksStored          <<  // number of sored tracks
                      "primMult="             << primMult         <<  //  #prim tracks
                      "tpcClusterMult="       << tpcClusterMultiplicity <<  // tpc cluster multiplicity
                      "tpcTrackBeforeClean=" << tpcTrackBeforeClean <<   // tpc track before cleaning


### PR DESCRIPTION
## fix warning in the track loop - (needed because of the new track removal)
* including Ruben explanation why needed 
- GetNumberOfESDTracks returns the persistent data member fNumberOfESDTracks for the number of found tracks.
- It is filled before the filtering and used as an observed multiplicity measure.
- For the stored tracks count one should use GetNumberOfTracks().


## adding precise time stamp to all streamers
3 time stamps stamp stored
* gid            - based on LHC clock - - as always
* evtTimeStamp   - time of event build   - as always
* timeStamp      - real time stamp of collision - NEW
                 - before i calculated "real time based of GID - new we
                   use newly introduced getter