### PR TITLE
PWGUD/UPC: Switched to arrays for run selection...

### DIFF
--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
@@ -16,8 +16,8 @@
 // c++ headers
 #include <iostream>
 #include <fstream>
-#include <vector>
-#include <algorithm>
+// #include <vector>
+// #include <algorithm>
 
 
 // root headers
@@ -153,7 +153,7 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward()
                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
       fV0TotalNCells(0),
-      fVectorGoodRunNumbers(0),
+      // fVectorGoodRunNumbers(0),
       fInvariantMassDistributionCoherentZNCzeroZNAzeroH(0),
       fInvariantMassDistributionCoherentZNCzeroZNAanyH(0),
       fInvariantMassDistributionCoherentZNCanyZNAzeroH(0),
@@ -278,7 +278,7 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward(const char* name)
                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
       fV0TotalNCells(0),
-      fVectorGoodRunNumbers(0),
+      // fVectorGoodRunNumbers(0),
       fInvariantMassDistributionCoherentZNCzeroZNAzeroH(0),
       fInvariantMassDistributionCoherentZNCzeroZNAanyH(0),
       fInvariantMassDistributionCoherentZNCanyZNAzeroH(0),
@@ -320,7 +320,7 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward(const char* name)
       fCosThetaAndPhiHelicityFrameInclusivePeopleBinningH(0),
       fInvariantMassDistributionForSignalExtractionHelicityFrameH(0)
 {
-    FillGoodRunVector(fVectorGoodRunNumbers);
+    // FillGoodRunVector(fVectorGoodRunNumbers);
 
     // constructor
     DefineInput(0, TChain::Class());    // define the input of the analysis: in this case we take a 'chain' of events
@@ -339,96 +339,96 @@ AliAnalysisTaskUPCforward::~AliAnalysisTaskUPCforward()
     if(fMuonTrackCuts) {delete fMuonTrackCuts;}   // from memory by calling this function
 }
 //_____________________________________________________________________________
-void AliAnalysisTaskUPCforward::FillGoodRunVector(std::vector<Int_t> &fVectorGoodRunNumbers)
-{
-  fVectorGoodRunNumbers.clear();
-  Int_t listOfGoodRunNumbersLHC18q[] = { 295585, 295586, 295587, 295588, 295589, 295612,
-                                         295615, 295665, 295666, 295667, 295668, 295671,
-                                         295673, 295675, 295676, 295677, 295714, 295716,
-                                         295717, 295718, 295719, 295723, 295725, 295753,
-                                         295754, 295755, 295758, 295759, 295762, 295763,
-                                         295786, 295788, 295791, 295816, 295818, 295819,
-                                         295822, 295825, 295826, 295829, 295831, 295854,
-                                         295855, 295856, 295859, 295860, 295861, 295863,
-                                         295881, 295908, 295909, 295910, 295913, 295936,
-                                         295937, 295941, 295942, 295943, 295945, 295947,
-                                         296061, 296062, 296063, 296065, 296066, 296068,
-                                         296123, 296128, 296132, 296133, 296134, 296135,
-                                         296142, 296143, 296191, 296192, 296194, 296195,
-                                         296196, 296197, 296198, 296241, 296242, 296243,
-                                         296244, 296246, 296247, 296269, 296270, 296273,
-                                         296279, 296280, 296303, 296304, 296307, 296309,
-                                         296312, 296376, 296377, 296378, 296379, 296380,
-                                         296381, 296383, 296414, 296419, 296420, 296423,
-                                         296424, 296433, 296472, 296509, 296510, 296511,
-                                         296514, 296516, 296547, 296548, 296549, 296550,
-                                         296551, 296552, 296553, 296615, 296616, 296618,
-                                         296619, 296622, 296623 };
-  Int_t listOfGoodRunNumbersLHC18r[] = { 296690, 296691, 296694, 296749, 296750, 296781,
-                                         296784, 296785, 296786, 296787, 296791, 296793,
-                                         296794, 296799, 296836, 296838, 296839, 296848,
-                                         296849, 296850, 296851, 296852, 296890, 296894,
-                                         296899, 296900, 296903, 296930, 296931, 296932,
-                                         296934, 296935, 296938, 296941, 296966, 296967,
-                                         296968, 296969, 296971, 296975, 296976, 296977,
-                                         296979, 297029, 297031, 297035, 297085, 297117,
-                                         297118, 297119, 297123, 297124, 297128, 297129,
-                                         297132, 297133, 297193, 297194, 297196, 297218,
-                                         297219, 297221, 297222, 297278, 297310, 297312,
-                                         297315, 297317, 297363, 297366, 297367, 297372,
-                                         297379, 297380, 297405, 297408, 297413, 297414,
-                                         297415, 297441, 297442, 297446, 297450, 297451,
-                                         297452, 297479, 297481, 297483, 297512, 297537,
-                                         297540, 297541, 297542, 297544, 297558, 297588,
-                                         297590, 297595/*, 297623, 297624*/ };
-  /* - This good run number list has been taken from the analysis
-     - note of Kay's talk for DIS 2017, see:
-     - https://alice-notes.web.cern.ch/system/files/notes/analysis/596/2017-Feb-08-analysis_note-2017-Feb-08-analysis-note.pdf
-     -
-   */
-  Int_t listOfGoodRunNumbersLHC15o[] = { 244918, 244980, 244982, 244983, 245064, 245066, 245068, 245145, 245146, 245151,
-                                         245152, 245231, 245232, 245233, 245253, 245259, 245343, 245345, 245346, 245347,
-                                         245353, 245401, 245407, 245409, 245410, 245446, 245450, 245496, 245501, 245504,
-                                         245505, 245507, 245535, 245540, 245542, 245543, 245554, 245683, 245692, 245700,
-                                         245705, 245729, 245731, 245738, 245752, 245759, 245766, 245775, 245785, 245793,
-                                         245829, 245831, 245833, 245949, 245952, 245954, 245963, 245996, 246001, 246003,
-                                         246012, 246036, 246037, 246042, 246048, 246049, 246053, 246087, 246089, 246113,
-                                         246115, 246148, 246151, 246152, 246153, 246178, 246181, 246182, 246217, 246220,
-                                         246222, 246225, 246272, 246275, 246276, 246390, 246391, 246392, 246424, 246428,
-                                         246431, 246433, 246434, 246487, 246488, 246493, 246495, 246675, 246676, 246750,
-                                         246751, 246755, 246757, 246758, 246759, 246760, 246763, 246765, 246804, 246805,
-                                         246806, 246807, 246808, 246809, 246844, 246845, 246846, 246847, 246851, 246855,
-                                         246859, 246864, 246865, 246867, 246871, 246930, 246937, 246942, 246945, 246948,
-                                         246949, 246980, 246982, 246984, 246989, 246991, 246994
-                                       };
-  Int_t sizeOfLHC18q = 0;
-  Int_t sizeOfLHC18r = 0;
-  Int_t sizeOfLHC15o = 0;
-  for ( Int_t GoodRunNumberLHC18q : listOfGoodRunNumbersLHC18q ) {
-        fVectorGoodRunNumbers.push_back(GoodRunNumberLHC18q);
-        sizeOfLHC18q++;
-  }
-  for ( Int_t GoodRunNumberLHC18r : listOfGoodRunNumbersLHC18r ) {
-        fVectorGoodRunNumbers.push_back(GoodRunNumberLHC18r);
-        sizeOfLHC18r++;
-  }
-  for ( Int_t GoodRunNumberLHC15o : listOfGoodRunNumbersLHC15o ) {
-        fVectorGoodRunNumbers.push_back(GoodRunNumberLHC15o);
-        sizeOfLHC15o++;
-  }
-  cout << std::endl << "LHC18q GOOD RUNS:  " << std::endl;
-  for ( Int_t i = 0; i < sizeOfLHC18q; i++ ) {
-        cout << fVectorGoodRunNumbers.at(i) << ",   number: " << i << std::endl;
-  }
-  cout << std::endl << "LHC18r GOOD RUNS:  " << std::endl;
-  for ( Int_t i = sizeOfLHC18q; i < sizeOfLHC18q + sizeOfLHC18r; i++ ) {
-        cout << fVectorGoodRunNumbers.at(i) << ",   number: " << (i-sizeOfLHC18q) << std::endl;
-  }
-  cout << std::endl << "LHC15o GOOD RUNS:  " << std::endl;
-  for ( Int_t i = sizeOfLHC18q + sizeOfLHC18r; i < sizeOfLHC18q + sizeOfLHC18r + sizeOfLHC15o; i++ ) {
-        cout << fVectorGoodRunNumbers.at(i) << ",   number: " << (i-sizeOfLHC18q-sizeOfLHC18r) << std::endl;
-  }
-}
+// void AliAnalysisTaskUPCforward::FillGoodRunVector(std::vector<Int_t> &fVectorGoodRunNumbers)
+// {
+//   fVectorGoodRunNumbers.clear();
+//   Int_t listOfGoodRunNumbersLHC18q[] = { 295585, 295586, 295587, 295588, 295589, 295612,
+//                                          295615, 295665, 295666, 295667, 295668, 295671,
+//                                          295673, 295675, 295676, 295677, 295714, 295716,
+//                                          295717, 295718, 295719, 295723, 295725, 295753,
+//                                          295754, 295755, 295758, 295759, 295762, 295763,
+//                                          295786, 295788, 295791, 295816, 295818, 295819,
+//                                          295822, 295825, 295826, 295829, 295831, 295854,
+//                                          295855, 295856, 295859, 295860, 295861, 295863,
+//                                          295881, 295908, 295909, 295910, 295913, 295936,
+//                                          295937, 295941, 295942, 295943, 295945, 295947,
+//                                          296061, 296062, 296063, 296065, 296066, 296068,
+//                                          296123, 296128, 296132, 296133, 296134, 296135,
+//                                          296142, 296143, 296191, 296192, 296194, 296195,
+//                                          296196, 296197, 296198, 296241, 296242, 296243,
+//                                          296244, 296246, 296247, 296269, 296270, 296273,
+//                                          296279, 296280, 296303, 296304, 296307, 296309,
+//                                          296312, 296376, 296377, 296378, 296379, 296380,
+//                                          296381, 296383, 296414, 296419, 296420, 296423,
+//                                          296424, 296433, 296472, 296509, 296510, 296511,
+//                                          296514, 296516, 296547, 296548, 296549, 296550,
+//                                          296551, 296552, 296553, 296615, 296616, 296618,
+//                                          296619, 296622, 296623 };
+//   Int_t listOfGoodRunNumbersLHC18r[] = { 296690, 296691, 296694, 296749, 296750, 296781,
+//                                          296784, 296785, 296786, 296787, 296791, 296793,
+//                                          296794, 296799, 296836, 296838, 296839, 296848,
+//                                          296849, 296850, 296851, 296852, 296890, 296894,
+//                                          296899, 296900, 296903, 296930, 296931, 296932,
+//                                          296934, 296935, 296938, 296941, 296966, 296967,
+//                                          296968, 296969, 296971, 296975, 296976, 296977,
+//                                          296979, 297029, 297031, 297035, 297085, 297117,
+//                                          297118, 297119, 297123, 297124, 297128, 297129,
+//                                          297132, 297133, 297193, 297194, 297196, 297218,
+//                                          297219, 297221, 297222, 297278, 297310, 297312,
+//                                          297315, 297317, 297363, 297366, 297367, 297372,
+//                                          297379, 297380, 297405, 297408, 297413, 297414,
+//                                          297415, 297441, 297442, 297446, 297450, 297451,
+//                                          297452, 297479, 297481, 297483, 297512, 297537,
+//                                          297540, 297541, 297542, 297544, 297558, 297588,
+//                                          297590, 297595/*, 297623, 297624*/ };
+//   /* - This good run number list has been taken from the analysis
+//      - note of Kay's talk for DIS 2017, see:
+//      - https://alice-notes.web.cern.ch/system/files/notes/analysis/596/2017-Feb-08-analysis_note-2017-Feb-08-analysis-note.pdf
+//      -
+//    */
+//   Int_t listOfGoodRunNumbersLHC15o[] = { 244918, 244980, 244982, 244983, 245064, 245066, 245068, 245145, 245146, 245151,
+//                                          245152, 245231, 245232, 245233, 245253, 245259, 245343, 245345, 245346, 245347,
+//                                          245353, 245401, 245407, 245409, 245410, 245446, 245450, 245496, 245501, 245504,
+//                                          245505, 245507, 245535, 245540, 245542, 245543, 245554, 245683, 245692, 245700,
+//                                          245705, 245729, 245731, 245738, 245752, 245759, 245766, 245775, 245785, 245793,
+//                                          245829, 245831, 245833, 245949, 245952, 245954, 245963, 245996, 246001, 246003,
+//                                          246012, 246036, 246037, 246042, 246048, 246049, 246053, 246087, 246089, 246113,
+//                                          246115, 246148, 246151, 246152, 246153, 246178, 246181, 246182, 246217, 246220,
+//                                          246222, 246225, 246272, 246275, 246276, 246390, 246391, 246392, 246424, 246428,
+//                                          246431, 246433, 246434, 246487, 246488, 246493, 246495, 246675, 246676, 246750,
+//                                          246751, 246755, 246757, 246758, 246759, 246760, 246763, 246765, 246804, 246805,
+//                                          246806, 246807, 246808, 246809, 246844, 246845, 246846, 246847, 246851, 246855,
+//                                          246859, 246864, 246865, 246867, 246871, 246930, 246937, 246942, 246945, 246948,
+//                                          246949, 246980, 246982, 246984, 246989, 246991, 246994
+//                                        };
+//   Int_t sizeOfLHC18q = 0;
+//   Int_t sizeOfLHC18r = 0;
+//   Int_t sizeOfLHC15o = 0;
+//   for ( Int_t GoodRunNumberLHC18q : listOfGoodRunNumbersLHC18q ) {
+//         fVectorGoodRunNumbers.push_back(GoodRunNumberLHC18q);
+//         sizeOfLHC18q++;
+//   }
+//   for ( Int_t GoodRunNumberLHC18r : listOfGoodRunNumbersLHC18r ) {
+//         fVectorGoodRunNumbers.push_back(GoodRunNumberLHC18r);
+//         sizeOfLHC18r++;
+//   }
+//   for ( Int_t GoodRunNumberLHC15o : listOfGoodRunNumbersLHC15o ) {
+//         fVectorGoodRunNumbers.push_back(GoodRunNumberLHC15o);
+//         sizeOfLHC15o++;
+//   }
+//   cout << std::endl << "LHC18q GOOD RUNS:  " << std::endl;
+//   for ( Int_t i = 0; i < sizeOfLHC18q; i++ ) {
+//         cout << fVectorGoodRunNumbers.at(i) << ",   number: " << i << std::endl;
+//   }
+//   cout << std::endl << "LHC18r GOOD RUNS:  " << std::endl;
+//   for ( Int_t i = sizeOfLHC18q; i < sizeOfLHC18q + sizeOfLHC18r; i++ ) {
+//         cout << fVectorGoodRunNumbers.at(i) << ",   number: " << (i-sizeOfLHC18q) << std::endl;
+//   }
+//   cout << std::endl << "LHC15o GOOD RUNS:  " << std::endl;
+//   for ( Int_t i = sizeOfLHC18q + sizeOfLHC18r; i < sizeOfLHC18q + sizeOfLHC18r + sizeOfLHC15o; i++ ) {
+//         cout << fVectorGoodRunNumbers.at(i) << ",   number: " << (i-sizeOfLHC18q-sizeOfLHC18r) << std::endl;
+//   }
+// }
 //_____________________________________________________________________________
 void AliAnalysisTaskUPCforward::UserCreateOutputObjects()
 {
@@ -1100,20 +1100,102 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
      - them I move on to the next event.
      -
    */
-  auto findRunNumber = std::find(  std::begin(fVectorGoodRunNumbers),
-                                   std::end(fVectorGoodRunNumbers),
-                                   fRunNum
-                                   );
-  if (findRunNumber != std::end(fVectorGoodRunNumbers)) {
-      // std::cout << "fVectorGoodRunNumbers DOES     contain: " << fRunNum << std::endl;
-      fCounterH->Fill(15);
-  } else {
-      // std::cout << "fVectorGoodRunNumbers does not contain: " << fRunNum << std::endl;
-      fCounterH->Fill(16);
-      PostData(1, fOutputList);
-      return;
+  // auto findRunNumber = std::find(  std::begin(fVectorGoodRunNumbers),
+  //                                  std::end(fVectorGoodRunNumbers),
+  //                                  fRunNum
+  //                                  );
+  // if (findRunNumber != std::end(fVectorGoodRunNumbers)) {
+  //     // std::cout << "fVectorGoodRunNumbers DOES     contain: " << fRunNum << std::endl;
+  //     fCounterH->Fill(15);
+  // } else {
+  //     // std::cout << "fVectorGoodRunNumbers does not contain: " << fRunNum << std::endl;
+  //     fCounterH->Fill(16);
+  //     PostData(1, fOutputList);
+  //     return;
+  // }
+  // fCounterH->Fill(17);
+
+
+
+  fCounterH->Fill(15);
+  Int_t listOfGoodRunNumbersLHC18q[] = { 295585, 295586, 295587, 295588, 295589, 295612,
+                                         295615, 295665, 295666, 295667, 295668, 295671,
+                                         295673, 295675, 295676, 295677, 295714, 295716,
+                                         295717, 295718, 295719, 295723, 295725, 295753,
+                                         295754, 295755, 295758, 295759, 295762, 295763,
+                                         295786, 295788, 295791, 295816, 295818, 295819,
+                                         295822, 295825, 295826, 295829, 295831, 295854,
+                                         295855, 295856, 295859, 295860, 295861, 295863,
+                                         295881, 295908, 295909, 295910, 295913, 295936,
+                                         295937, 295941, 295942, 295943, 295945, 295947,
+                                         296061, 296062, 296063, 296065, 296066, 296068,
+                                         296123, 296128, 296132, 296133, 296134, 296135,
+                                         296142, 296143, 296191, 296192, 296194, 296195,
+                                         296196, 296197, 296198, 296241, 296242, 296243,
+                                         296244, 296246, 296247, 296269, 296270, 296273,
+                                         296279, 296280, 296303, 296304, 296307, 296309,
+                                         296312, 296376, 296377, 296378, 296379, 296380,
+                                         296381, 296383, 296414, 296419, 296420, 296423,
+                                         296424, 296433, 296472, 296509, 296510, 296511,
+                                         296514, 296516, 296547, 296548, 296549, 296550,
+                                         296551, 296552, 296553, 296615, 296616, 296618,
+                                         296619, 296622, 296623 };
+  Int_t listOfGoodRunNumbersLHC18r[] = { 296690, 296691, 296694, 296749, 296750, 296781,
+                                         296784, 296785, 296786, 296787, 296791, 296793,
+                                         296794, 296799, 296836, 296838, 296839, 296848,
+                                         296849, 296850, 296851, 296852, 296890, 296894,
+                                         296899, 296900, 296903, 296930, 296931, 296932,
+                                         296934, 296935, 296938, 296941, 296966, 296967,
+                                         296968, 296969, 296971, 296975, 296976, 296977,
+                                         296979, 297029, 297031, 297035, 297085, 297117,
+                                         297118, 297119, 297123, 297124, 297128, 297129,
+                                         297132, 297133, 297193, 297194, 297196, 297218,
+                                         297219, 297221, 297222, 297278, 297310, 297312,
+                                         297315, 297317, 297363, 297366, 297367, 297372,
+                                         297379, 297380, 297405, 297408, 297413, 297414,
+                                         297415, 297441, 297442, 297446, 297450, 297451,
+                                         297452, 297479, 297481, 297483, 297512, 297537,
+                                         297540, 297541, 297542, 297544, 297558, 297588,
+                                         297590, 297595/*, 297623, 297624*/ };
+  /* - This good run number list has been taken from the analysis
+     - note of Kay's talk for DIS 2017, see:
+     - https://alice-notes.web.cern.ch/system/files/notes/analysis/596/2017-Feb-08-analysis_note-2017-Feb-08-analysis-note.pdf
+     -
+   */
+  Int_t listOfGoodRunNumbersLHC15o[] = { 244918, 244980, 244982, 244983, 245064, 245066, 245068, 245145, 245146, 245151,
+                                         245152, 245231, 245232, 245233, 245253, 245259, 245343, 245345, 245346, 245347,
+                                         245353, 245401, 245407, 245409, 245410, 245446, 245450, 245496, 245501, 245504,
+                                         245505, 245507, 245535, 245540, 245542, 245543, 245554, 245683, 245692, 245700,
+                                         245705, 245729, 245731, 245738, 245752, 245759, 245766, 245775, 245785, 245793,
+                                         245829, 245831, 245833, 245949, 245952, 245954, 245963, 245996, 246001, 246003,
+                                         246012, 246036, 246037, 246042, 246048, 246049, 246053, 246087, 246089, 246113,
+                                         246115, 246148, 246151, 246152, 246153, 246178, 246181, 246182, 246217, 246220,
+                                         246222, 246225, 246272, 246275, 246276, 246390, 246391, 246392, 246424, 246428,
+                                         246431, 246433, 246434, 246487, 246488, 246493, 246495, 246675, 246676, 246750,
+                                         246751, 246755, 246757, 246758, 246759, 246760, 246763, 246765, 246804, 246805,
+                                         246806, 246807, 246808, 246809, 246844, 246845, 246846, 246847, 246851, 246855,
+                                         246859, 246864, 246865, 246867, 246871, 246930, 246937, 246942, 246945, 246948,
+                                         246949, 246980, 246982, 246984, 246989, 246991, 246994
+                                       };
+  Bool_t checkIfGoodRun = kFALSE;
+  for( Int_t iRunLHC18q = 0; iRunLHC18q < 129; iRunLHC18q++){
+    if( fRunNum == listOfGoodRunNumbersLHC18q[iRunLHC18q] ) checkIfGoodRun = kTRUE;
+  }
+  for( Int_t iRunLHC18r = 0; iRunLHC18r <  98; iRunLHC18r++){
+    if( fRunNum == listOfGoodRunNumbersLHC18r[iRunLHC18r] ) checkIfGoodRun = kTRUE;
+  }
+  for( Int_t iRunLHC15o = 0; iRunLHC15o < 137; iRunLHC15o++){
+    if( fRunNum == listOfGoodRunNumbersLHC15o[iRunLHC15o] ) checkIfGoodRun = kTRUE;
+  }
+  // cout << "fRunNum = " << fRunNum << "   and   checkIfGoodRun = " << checkIfGoodRun << endl;
+  if(checkIfGoodRun != 1) {
+       PostData(1, fOutputList);
+       // cout << "OPS!" << endl;
+       return;
   }
   fCounterH->Fill(17);
+
+
 
   // END RUN SELECTION
   //_____________________________________

--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.h
@@ -20,7 +20,7 @@ class AliMuonTrackCuts; 											// Include class for standard muon tack cuts
  * \class MatrixTH1F
  * \brief Alias for a 2D vector of TH1F, roughly speaking an arary of TH1F.
  */
-typedef std::vector< std::vector< TH1F* > >  MatrixTH1F;
+// typedef std::vector< std::vector< TH1F* > >  MatrixTH1F;
 
 /**
  * \file AliAnalysisTaskUPCforward.h
@@ -95,7 +95,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * run numbers. For now this function will be
                                  * inside the constructor of the class.
                                  */
-        void                    FillGoodRunVector(std::vector<Int_t> &fVectorGoodRunNumbers);
+        // void                    FillGoodRunVector(std::vector<Int_t> &fVectorGoodRunNumbers);
 
                                 /**
                                  * This function computes the cos(theta) in the
@@ -1032,7 +1032,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
         /**
          * This is the vector containing the GOOD RunNumbers.
          */
-        std::vector<Int_t> fVectorGoodRunNumbers;       //!
+        // std::vector<Int_t> fVectorGoodRunNumbers;       //!
 
 
 
@@ -1052,7 +1052,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforward, 18);
+        ClassDef(AliAnalysisTaskUPCforward, 20);
 };
 
 #endif


### PR DESCRIPTION
After experiencing some issues due to the usage of c++11's vectors on the LEGO framework, we have decided to go back to normal arrays... Only the tests on the datasets will prove if this works fine.
IMPORTANT: tested on local => same results as before (not sure about the total execution time though).