### PR TITLE
Use same SPD acceptance in 2015-2018 Pb-Pb

### DIFF
--- a/PWGHF/vertexingHF/AliRDHFCuts.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCuts.cxx
@@ -62,7 +62,7 @@ ClassImp(AliRDHFCuts);
 
 
 //--------------------------------------------------------------------------
-AliRDHFCuts::AliRDHFCuts(const Char_t* name, const Char_t* title) : 
+AliRDHFCuts::AliRDHFCuts(const Char_t* name, const Char_t* title) :
 AliAnalysisCuts(name,title),
 fMinVtxType(3),
 fMinVtxContr(1),
@@ -113,6 +113,7 @@ fIsCandTrackSPDFirst(kFALSE),
 fMaxPtCandTrackSPDFirst(0.),
 fApplySPDDeadPbPb2011(kFALSE),
 fApplySPDMisalignedPP2012(kFALSE),
+fApplySPDUniformAccPbPbRun2(kFALSE),
 fMaxDiffTRKV0Centr(-1.),
 fRemoveTrackletOutliers(kFALSE),
 fCutOnzVertexSPD(3),
@@ -201,6 +202,7 @@ AliRDHFCuts::AliRDHFCuts(const AliRDHFCuts &source) :
   fMaxPtCandTrackSPDFirst(source.fMaxPtCandTrackSPDFirst),
   fApplySPDDeadPbPb2011(source.fApplySPDDeadPbPb2011),
   fApplySPDMisalignedPP2012(source.fApplySPDMisalignedPP2012),
+  fApplySPDUniformAccPbPbRun2(source.fApplySPDUniformAccPbPbRun2),
   fMaxDiffTRKV0Centr(source.fMaxDiffTRKV0Centr),
   fRemoveTrackletOutliers(source.fRemoveTrackletOutliers),
   fCutOnzVertexSPD(source.fCutOnzVertexSPD),
@@ -233,7 +235,7 @@ AliRDHFCuts::AliRDHFCuts(const AliRDHFCuts &source) :
   // Copy constructor
   //
   cout<<"Copy constructor"<<endl;
-  fTriggerClass[0] = source.fTriggerClass[0]; 
+  fTriggerClass[0] = source.fTriggerClass[0];
   fTriggerClass[1] = source.fTriggerClass[1];
   if(source.GetTrackCuts()) AddTrackCuts(source.GetTrackCuts());
   if(source.fPtBinLimits) SetPtBins(source.fnPtBinLimits,source.fPtBinLimits);
@@ -302,6 +304,7 @@ AliRDHFCuts &AliRDHFCuts::operator=(const AliRDHFCuts &source)
   fIsCandTrackSPDFirst=source.fIsCandTrackSPDFirst;
   fMaxPtCandTrackSPDFirst=source.fMaxPtCandTrackSPDFirst;
   fApplySPDDeadPbPb2011=source.fApplySPDDeadPbPb2011;
+  fApplySPDUniformAccPbPbRun2=source.fApplySPDUniformAccPbPbRun2;
   fApplySPDMisalignedPP2012=source.fApplySPDMisalignedPP2012;
   fMaxDiffTRKV0Centr=source.fMaxDiffTRKV0Centr;
   fRemoveTrackletOutliers=source.fRemoveTrackletOutliers;
@@ -317,7 +320,7 @@ AliRDHFCuts &AliRDHFCuts::operator=(const AliRDHFCuts &source)
   if(source.fVarNames) SetVarNames(source.fnVars,source.fVarNames,source.fIsUpperCut);
   if(source.fCutsRD) SetCuts(source.fGlobalIndex,source.fCutsRD);
   if(source.fVarsForOpt) SetVarsForOpt(source.fnVarsForOpt,source.fVarsForOpt);
-  
+
   if(fCutMinCrossedRowsTPCPtDep) fCutMinCrossedRowsTPCPtDep=source.fCutMinCrossedRowsTPCPtDep;
   if(f1CutMinNCrossedRowsTPCPtDep) delete f1CutMinNCrossedRowsTPCPtDep;
   if(source.f1CutMinNCrossedRowsTPCPtDep) f1CutMinNCrossedRowsTPCPtDep=new TFormula(*(source.f1CutMinNCrossedRowsTPCPtDep));
@@ -346,7 +349,7 @@ AliRDHFCuts &AliRDHFCuts::operator=(const AliRDHFCuts &source)
 }
 //--------------------------------------------------------------------------
 AliRDHFCuts::~AliRDHFCuts() {
-  //  
+  //
   // Default Destructor
   //
   if(fTrackCuts) { delete fTrackCuts; fTrackCuts=0; }
@@ -358,7 +361,7 @@ AliRDHFCuts::~AliRDHFCuts() {
     fCutsRD=0;
   }
   if(fIsUpperCut) {delete [] fIsUpperCut; fIsUpperCut=0;}
-  if(fPidHF){ 
+  if(fPidHF){
     delete fPidHF;
     fPidHF=0;
   }
@@ -375,42 +378,42 @@ Int_t AliRDHFCuts::IsEventSelectedInCentrality(AliVEvent *event) {
   //
   // Centrality selection
   //
-  if(fUseCentrality<kCentOff||fUseCentrality>=kCentInvalid){    
-    AliWarning("Centrality estimator not valid");    
-    return 3;  
-  }else{    
-    Float_t centvalue=GetCentrality((AliAODEvent*)event);          
+  if(fUseCentrality<kCentOff||fUseCentrality>=kCentInvalid){
+    AliWarning("Centrality estimator not valid");
+    return 3;
+  }else{
+    Float_t centvalue=GetCentrality((AliAODEvent*)event);
     if (centvalue<-998.){//-999 if no centralityP
       return 3;
     }else if(fEvRejectionBits&(1<<kMismatchOldNewCentrality)){
       return 3;
-    }else{      
+    }else{
       if (centvalue<fMinCentrality || centvalue>fMaxCentrality){
-	return 2;      
+	return 2;
       }
       // selection to flatten the centrality distribution
       if(fHistCentrDistr){
-	if(!IsEventSelectedForCentrFlattening(centvalue))return 4;     
+	if(!IsEventSelectedForCentrFlattening(centvalue))return 4;
       }
-    } 
-  }  
+    }
+  }
   return 0;
 }
 
 
 //-------------------------------------------------
 void AliRDHFCuts::SetHistoForCentralityFlattening(TH1F *h,Double_t minCentr,Double_t maxCentr,Double_t centrRef,Int_t switchTRand){
-  // set the histo for centrality flattening 
+  // set the histo for centrality flattening
   // the centrality is flatten in the range minCentr,maxCentr
-  // if centrRef is zero, the minimum in h within (minCentr,maxCentr) defines the reference 
+  // if centrRef is zero, the minimum in h within (minCentr,maxCentr) defines the reference
   //                positive, the value of h(centrRef) defines the reference (-> the centrality distribution might be not flat in the whole desired range)
-  //                negative, h(bin with max in range)*centrRef is used to define the reference (-> defines the maximum loss of events, also in this case the distribution might be not flat) 
-  // switchTRand is used to set the unerflow bin of the histo: if it is < -1 in the analysis the random event selection will be done on using TRandom 
-  
+  //                negative, h(bin with max in range)*centrRef is used to define the reference (-> defines the maximum loss of events, also in this case the distribution might be not flat)
+  // switchTRand is used to set the unerflow bin of the histo: if it is < -1 in the analysis the random event selection will be done on using TRandom
+
   if(maxCentr<minCentr){
     AliWarning("AliRDHFCuts::Wrong centralities values while setting the histogram for centrality flattening");
   }
-  
+
   if(fHistCentrDistr)delete fHistCentrDistr;
   fHistCentrDistr=(TH1F*)h->Clone("hCentralityFlat");
   fHistCentrDistr->SetTitle("Reference histo for centrality flattening");
@@ -422,7 +425,7 @@ void AliRDHFCuts::SetHistoForCentralityFlattening(TH1F *h,Double_t minCentr,Doub
   if(TMath::Abs(centrRef)<0.0001){
     binref=fHistCentrDistr->GetMinimumBin();
     binrefwidth=fHistCentrDistr->GetBinWidth(binref);
-    ref=fHistCentrDistr->GetBinContent(binref)/binrefwidth;   
+    ref=fHistCentrDistr->GetBinContent(binref)/binrefwidth;
   }
   else if(centrRef>0.){
     binref=h->FindBin(centrRef);
@@ -436,9 +439,9 @@ void AliRDHFCuts::SetHistoForCentralityFlattening(TH1F *h,Double_t minCentr,Doub
     if(centrRef<-1) AliWarning("AliRDHFCuts: with this centrality reference no flattening will be applied");
     binref=fHistCentrDistr->GetMaximumBin();
     binrefwidth=fHistCentrDistr->GetBinWidth(binref);
-    ref=fHistCentrDistr->GetMaximum()*TMath::Abs(centrRef)/binrefwidth;   
+    ref=fHistCentrDistr->GetMaximum()*TMath::Abs(centrRef)/binrefwidth;
   }
-  
+
   for(Int_t j=1;j<=h->GetNbinsX();j++){// Now set the "probabilities"
     if(h->GetBinLowEdge(j)*1.0001>=minCentr&&h->GetBinLowEdge(j+1)*0.9999<=maxCentr){
       bincont=h->GetBinContent(j);
@@ -460,8 +463,8 @@ Bool_t AliRDHFCuts::IsEventSelectedForCentrFlattening(Float_t centvalue){
   //
   //  Random event selection, based on fHistCentrDistr, to flatten the centrality distribution
   //  Can be faster if it was required that fHistCentrDistr covers
-  //  exactly the desired centrality range (e.g. part of the lines below should be done during the 
-  // setting of the histo) and TH1::SetMinimum called 
+  //  exactly the desired centrality range (e.g. part of the lines below should be done during the
+  // setting of the histo) and TH1::SetMinimum called
   //
 
   if(!fHistCentrDistr) return kTRUE;
@@ -469,18 +472,18 @@ Bool_t AliRDHFCuts::IsEventSelectedForCentrFlattening(Float_t centvalue){
   //   if(maxbin>fHistCentrDistr->GetNbinsX()){
   //     AliWarning("AliRDHFCuts: The maximum centrality exceeds the x-axis limit of the histogram for centrality flattening");
   //   }
-  
+
   Int_t bin=fHistCentrDistr->FindBin(centvalue); // Fast if the histo has a fix bin
   Double_t bincont=fHistCentrDistr->GetBinContent(bin);
   Double_t centDigits=centvalue-(Int_t)(centvalue*100.)/100.;// this is to extract a random number between 0 and 0.01
-  
+
   if(fHistCentrDistr->GetBinContent(0)<-0.9999){
     if(gRandom->Uniform(1.)<bincont)return kTRUE;
     return kFALSE;
   }
 
   if(centDigits*100.<bincont)return kTRUE;
-  return kFALSE;   
+  return kFALSE;
 
 }
 //---------------------------------------------------------------------------
@@ -531,7 +534,7 @@ void AliRDHFCuts::SetupPID(AliVEvent *event) {
 Bool_t AliRDHFCuts::IsEventSelected(AliVEvent *event) {
   //
   // Event selection
-  // 
+  //
   //if(fTriggerMask && event->GetTriggerMask()!=fTriggerMask) return kFALSE;
 
   // commented for the time being
@@ -554,14 +557,14 @@ Bool_t AliRDHFCuts::IsEventSelected(AliVEvent *event) {
   TString firedTriggerClasses=((AliAODEvent*)event)->GetFiredTriggerClasses();
   // don't do for MC and for PbPb 2010 data
   if(!isMC && (event->GetRunNumber()<136851 || event->GetRunNumber()>139517)) {
-    if(!firedTriggerClasses.Contains(fTriggerClass[0].Data()) && 
+    if(!firedTriggerClasses.Contains(fTriggerClass[0].Data()) &&
        (fTriggerClass[1].CompareTo("")==0 || !firedTriggerClasses.Contains(fTriggerClass[1].Data())) ) {
       fWhyRejection=5;
       fEvRejectionBits+=1<<kNotSelTrigger;
       accept=kFALSE;
     }
   }
-  
+
 
   // TEMPORARY FIX FOR GetEvent
   Int_t nTracks=((AliAODEvent*)event)->GetNumberOfTracks();
@@ -621,17 +624,17 @@ Bool_t AliRDHFCuts::IsEventSelected(AliVEvent *event) {
 
   // centrality selection
   if (fUseCentrality!=kCentOff) {
-    Int_t rejection=IsEventSelectedInCentrality(event);    
+    Int_t rejection=IsEventSelectedInCentrality(event);
     Bool_t okCent=kFALSE;
     if(rejection==0) okCent=kTRUE;
     if(isMC && rejection==4 && !fUseCentrFlatteningInMC) okCent=kTRUE;
-    if(!okCent){      
-      if(accept) fWhyRejection=rejection;      
+    if(!okCent){
+      if(accept) fWhyRejection=rejection;
       if(fWhyRejection==4)fEvRejectionBits+=1<<kCentralityFlattening;
       else fEvRejectionBits+=1<<kOutsideCentrality;
       accept=kFALSE;
     }
-   
+
   }
 
   // PbPb2011 outliers in tracklets vs. VZERO and centTRK vs. centV0
@@ -641,7 +644,7 @@ Bool_t AliRDHFCuts::IsEventSelected(AliVEvent *event) {
       Double_t ntracklets=((AliAODEvent*)event)->GetTracklets()->GetNumberOfTracklets();
       Double_t cutval=60.-0.08*ntracklets+1./50000.*ntracklets*ntracklets;
       if(ntracklets<1000. && v0cent<cutval){
-	if(accept) fWhyRejection=2;      
+	if(accept) fWhyRejection=2;
 	fEvRejectionBits+=1<<kOutsideCentrality;
 	 accept=kFALSE;
       }
@@ -652,11 +655,11 @@ Bool_t AliRDHFCuts::IsEventSelected(AliVEvent *event) {
       if(TMath::Abs(trkcent-v0cent)>fMaxDiffTRKV0Centr){
 	if(accept) fWhyRejection=1;
 	fEvRejectionBits+=1<<kBadTrackV0Correl;
-	accept=kFALSE;	
+	accept=kFALSE;
       }
     }
   }
-  
+
   // cuts on correlations between centrality estimators in Pb-Pb 2015 and Pb-Pb 2018
   if(fApplyCentralityCorrCuts && doAliEvCuts){
     if(!fAliEventCuts->PassedCut(AliEventCuts::kMultiplicity)){
@@ -665,9 +668,9 @@ Bool_t AliRDHFCuts::IsEventSelected(AliVEvent *event) {
       accept=kFALSE;
     }
   }
-  
+
   // vertex requirements
-   
+
   const AliVVertex *vertex = event->GetPrimaryVertex();
 
   if(!vertex){
@@ -737,13 +740,13 @@ Bool_t AliRDHFCuts::IsEventSelected(AliVEvent *event) {
     }
     else zvert = vSPD->GetZ();
   }
-  
+
   if(TMath::Abs(zvert)>fMaxVtxZ) {
     fEvRejectionBits+=1<<kZVtxOutFid;
     if(accept) fWhyRejection=6;
     accept=kFALSE;
   }
-  
+
   // pile-up rejection
   if(fOptPileup==kRejectPileupEvent){
     Bool_t isPileup=kFALSE;
@@ -773,8 +776,8 @@ Bool_t AliRDHFCuts::IsEventSelected(AliVEvent *event) {
       accept=kFALSE;
     }
   }
-  
-  // cut on correlations for out of bunch pileup in PbPb run2  
+
+  // cut on correlations for out of bunch pileup in PbPb run2
   if(fApplyPbPbOutOfBunchPileupCuts==1 && doAliEvCuts){
     if(!fAliEventCuts->PassedCut(AliEventCuts::kCorrelations)){
       if(accept) fWhyRejection=1; // for fWhyRejection they are classified as pileup
@@ -803,7 +806,7 @@ Bool_t AliRDHFCuts::IsEventSelected(AliVEvent *event) {
 Bool_t AliRDHFCuts::IsEventSelectedWithAliEventCuts(AliVEvent *event) {
   //
   // Event selection with AliEventCuts
-  // 
+  //
 
   fWhyRejection=0;
   fEvRejectionBits=0;
@@ -828,7 +831,7 @@ Bool_t AliRDHFCuts::IsEventSelectedWithAliEventCuts(AliVEvent *event) {
   if(runNumb >= 244917 && runNumb <= 246994) fAliEventCuts->SetupRun2PbPb();
   else if(runNumb >= 295369 && runNumb <= 297624) fAliEventCuts->SetupPbPb2018();
   else fAliEventCuts->SetManualMode(kFALSE);
-  
+
   // setup cuts
   TString selTrigClassClass="";
   if(!isMC && (event->GetRunNumber()<136851 || event->GetRunNumber()>139517)) {
@@ -865,7 +868,7 @@ Bool_t AliRDHFCuts::IsEventSelectedWithAliEventCuts(AliVEvent *event) {
     fEvRejectionBits+=1<<kNotSelTrigger;
     accept=kFALSE;
   }
-  
+
   // physics selection requirements
   if(fUsePhysicsSelection){
     if(!fAliEventCuts->PassedCut(AliEventCuts::kTrigger)){
@@ -888,12 +891,12 @@ Bool_t AliRDHFCuts::IsEventSelectedWithAliEventCuts(AliVEvent *event) {
 
   // centrality selection
   if (fUseCentrality!=kCentOff) {
-    Int_t rejection=IsEventSelectedInCentrality(event);    
+    Int_t rejection=IsEventSelectedInCentrality(event);
     Bool_t okCent=kFALSE;
     if(rejection==0) okCent=kTRUE;
     if(isMC && rejection==4 && !fUseCentrFlatteningInMC) okCent=kTRUE;
-    if(!okCent){      
-      if(accept) fWhyRejection=rejection;      
+    if(!okCent){
+      if(accept) fWhyRejection=rejection;
       if(fWhyRejection==4)fEvRejectionBits+=1<<kCentralityFlattening;
       else fEvRejectionBits+=1<<kOutsideCentrality;
       accept=kFALSE;
@@ -907,7 +910,7 @@ Bool_t AliRDHFCuts::IsEventSelectedWithAliEventCuts(AliVEvent *event) {
       Double_t ntracklets=((AliAODEvent*)event)->GetTracklets()->GetNumberOfTracklets();
       Double_t cutval=60.-0.08*ntracklets+1./50000.*ntracklets*ntracklets;
       if(ntracklets<1000. && v0cent<cutval){
-	if(accept) fWhyRejection=2;      
+	if(accept) fWhyRejection=2;
 	fEvRejectionBits+=1<<kOutsideCentrality;
 	 accept=kFALSE;
       }
@@ -918,11 +921,11 @@ Bool_t AliRDHFCuts::IsEventSelectedWithAliEventCuts(AliVEvent *event) {
       if(TMath::Abs(trkcent-v0cent)>fMaxDiffTRKV0Centr){
 	if(accept) fWhyRejection=1;
 	fEvRejectionBits+=1<<kBadTrackV0Correl;
-	accept=kFALSE;	
+	accept=kFALSE;
       }
     }
   }
-  
+
   // cuts on correlations between centrality estimators in Pb-Pb 2015 and Pb-Pb 2018
   if(fApplyCentralityCorrCuts){
     if(!fAliEventCuts->PassedCut(AliEventCuts::kMultiplicity)){
@@ -931,9 +934,9 @@ Bool_t AliRDHFCuts::IsEventSelectedWithAliEventCuts(AliVEvent *event) {
       accept=kFALSE;
     }
   }
-  
+
   // vertex requirements
-   
+
   if(fMinVtxType>2 && !fAliEventCuts->PassedCut(AliEventCuts::kVertexTracks)){
     accept=kFALSE;
     fEvRejectionBits+=1<<kNoVertex;
@@ -942,7 +945,7 @@ Bool_t AliRDHFCuts::IsEventSelectedWithAliEventCuts(AliVEvent *event) {
     accept=kFALSE;
     fEvRejectionBits+=1<<kNoVertex;
   }
-  
+
   if(fCutOnzVertexSPD>0){
     if(!fAliEventCuts->PassedCut(AliEventCuts::kVertexSPD)){
       accept=kFALSE;
@@ -967,7 +970,7 @@ Bool_t AliRDHFCuts::IsEventSelectedWithAliEventCuts(AliVEvent *event) {
     if(accept) fWhyRejection=6;
     accept=kFALSE;
   }
-  
+
   // pile-up rejection
   if(fOptPileup==kRejectPileupEvent || fOptPileup==kRejectMVPileupEvent){
     if(!fAliEventCuts->PassedCut(AliEventCuts::kPileUp)){
@@ -975,8 +978,8 @@ Bool_t AliRDHFCuts::IsEventSelectedWithAliEventCuts(AliVEvent *event) {
       fEvRejectionBits+=1<<kPileup;
       accept=kFALSE;
     }
-  }  
-  // cut on correlations for out of bunch pileup in PbPb run2  
+  }
+  // cut on correlations for out of bunch pileup in PbPb run2
   if(fApplyPbPbOutOfBunchPileupCuts==1){
     if(!fAliEventCuts->PassedCut(AliEventCuts::kCorrelations)){
       if(accept) fWhyRejection=1; // for fWhyRejection they are classified as pileup
@@ -1005,18 +1008,18 @@ Bool_t AliRDHFCuts::IsEventSelectedWithAliEventCuts(AliVEvent *event) {
 Bool_t AliRDHFCuts::AreDaughtersSelected(AliAODRecoDecayHF *d, const AliAODEvent* aod) const{
   //
   // Daughter tracks selection
-  // 
+  //
   if(!fTrackCuts) return kTRUE;
- 
+
   Int_t ndaughters = d->GetNDaughters();
   AliAODVertex *vAOD = d->GetPrimaryVtx();
   Double_t pos[3],cov[6];
   vAOD->GetXYZ(pos);
   vAOD->GetCovarianceMatrix(cov);
   const AliESDVertex vESD(pos,cov,100.,100);
-  
+
   Bool_t retval=kTRUE;
-  
+
   for(Int_t idg=0; idg<ndaughters; idg++) {
     AliAODTrack *dgTrack = (AliAODTrack*)d->GetDaughter(idg);
     if(!dgTrack) {retval = kFALSE; continue;}
@@ -1028,7 +1031,7 @@ Bool_t AliRDHFCuts::AreDaughtersSelected(AliAODRecoDecayHF *d, const AliAODEvent
 
     if(!IsDaughterSelected(dgTrack,&vESD,fTrackCuts,aod)) retval = kFALSE;
   }
-  
+
   return retval;
 }
 //---------------------------------------------------------------------------
@@ -1101,11 +1104,11 @@ Bool_t AliRDHFCuts::CheckPtDepCrossedRows(TString rows,Bool_t print) const {
 //---------------------------------------------------------------------------
 void AliRDHFCuts::SetMinCrossedRowsTPCPtDep(const char *rows){
   //
-  //Create the TFormula from TString for TPC crossed rows pT dependent cut 
+  //Create the TFormula from TString for TPC crossed rows pT dependent cut
   //
 
 
-  // setting data member that describes the TPC crossed rows pT dependent cut 
+  // setting data member that describes the TPC crossed rows pT dependent cut
   fCutMinCrossedRowsTPCPtDep = rows;
 
   // creating TFormula from TString
@@ -1114,13 +1117,13 @@ void AliRDHFCuts::SetMinCrossedRowsTPCPtDep(const char *rows){
      // resetting TFormula
      f1CutMinNCrossedRowsTPCPtDep = 0;
    }
-   if(!CheckPtDepCrossedRows(rows,kTRUE))return;   
-   
+   if(!CheckPtDepCrossedRows(rows,kTRUE))return;
+
    TString tmp(rows);
    tmp.ReplaceAll("pt","x");
    f1CutMinNCrossedRowsTPCPtDep = new TFormula("f1CutMinNCrossedRowsTPCPtDep",tmp.Data());
 
-   
+
 }
 //---------------------------------------------------------------------------
 Bool_t AliRDHFCuts::IsDaughterSelected(AliAODTrack *track,const AliESDVertex *primary,AliESDtrackCuts *cuts, const AliAODEvent* aod) const{
@@ -1142,7 +1145,7 @@ Bool_t AliRDHFCuts::IsDaughterSelected(AliAODTrack *track,const AliESDVertex *pr
   esdTrack.RelateToVertex(primary,0.,3.);
 
   //applying ESDtrackCut
-  if(!cuts->IsSelected(&esdTrack)) return kFALSE; 
+  if(!cuts->IsSelected(&esdTrack)) return kFALSE;
 
   //appliyng kink rejection
   if(fKinkReject){
@@ -1155,12 +1158,12 @@ Bool_t AliRDHFCuts::IsDaughterSelected(AliAODTrack *track,const AliESDVertex *pr
     Float_t nCrossedRowsTPC = esdTrack.GetTPCCrossedRows();
     if(nCrossedRowsTPC<f1CutMinNCrossedRowsTPCPtDep->Eval(esdTrack.Pt())) return kFALSE;
   }
-  
+
   //appliyng NTPCcls/NTPCcrossedRows cut
   if(fCutRatioClsOverCrossRowsTPC && fUseTPCtrackCutsOnThisDaughter){
     Float_t nCrossedRowsTPC = esdTrack.GetTPCCrossedRows();
     Float_t nClustersTPC = esdTrack.GetTPCNcls();
-    if(nCrossedRowsTPC!=0){ 
+    if(nCrossedRowsTPC!=0){
       Float_t ratio = nClustersTPC/nCrossedRowsTPC;
       if(ratio<fCutRatioClsOverCrossRowsTPC) return kFALSE;
     }
@@ -1193,7 +1196,7 @@ Bool_t AliRDHFCuts::IsDaughterSelected(AliAODTrack *track,const AliESDVertex *pr
 
   if(fOptPileup==kRejectTracksFromPileupVertex){
     // to be implemented
-    // we need either to have here the AOD Event, 
+    // we need either to have here the AOD Event,
     // or to have the pileup vertex object
   }
 
@@ -1260,7 +1263,7 @@ Bool_t AliRDHFCuts::IsDaughterSelected(AliAODTrack *track,const AliESDVertex *pr
       {kFALSE,kFALSE,kFALSE,kFALSE},
       {kFALSE,kFALSE,kFALSE,kFALSE},
       {kFALSE,kFALSE,kFALSE,kFALSE},
-      {kFALSE,kFALSE,kFALSE,kFALSE}     
+      {kFALSE,kFALSE,kFALSE,kFALSE}
     };
     Double_t xyz1[3],xyz2[3];
     esdTrack.GetXYZAt(3.9,0.,xyz1);
@@ -1300,7 +1303,20 @@ Bool_t AliRDHFCuts::IsDaughterSelected(AliAODTrack *track,const AliESDVertex *pr
     if(!lay1ok || !lay2ok) return kFALSE;
   }
 
-  return kTRUE; 
+  if(fApplySPDUniformAccPbPbRun2){
+    // Cut tracks crossing the regions at
+    // -->  0.94<phi<1.34 and 0<z<14cm (corresponding to the region of SPD HS 1A0)
+    // -->  3.49<phi<3.9 and -14<z<0 cm (corresponding to the region of SPD HS 5C0)
+    // Reason: HS 1A0 and 5C0 were excluded from 2018 Pb-Pb data taking, while were present in 2015 Pb-Pb data taking
+    // Goal: this patch should allow to use the same SPD regions between the two periods
+    Double_t xyz1[3];
+    esdTrack.GetXYZAt(3.9,0.,xyz1);
+    Double_t phi1=TMath::ATan2(xyz1[1],xyz1[0]);
+    if((phi1<1.34 && phi1>0.94) && (xyz1[2]>0 && xyz1[2]<14)) return kFALSE; // exclude region of 1A0
+    if((phi1<3.9 && phi1>3.49) && (xyz1[2]>-14 && xyz1[2]<0)) return kFALSE; //exclude region of 5C0
+  }
+
+  return kTRUE;
 }
 //---------------------------------------------------------------------------
 void AliRDHFCuts::SetPtBins(Int_t nPtBinLimits,Float_t *ptBinLimits) {
@@ -1357,12 +1373,12 @@ void AliRDHFCuts::SetVarsForOpt(Int_t nVars,Bool_t *forOpt) {
     fVarsForOpt = NULL;
     //printf("Changing the variables for cut optimization\n");
   }
-  
+
   if(nVars==0){//!=fnVars) {
     printf("%d not accepted as number of variables: it has to be %d\n",nVars,fnVars);
     return;
-  } 
-  
+  }
+
   fnVarsForOpt = 0;
   fVarsForOpt = new Bool_t[fnVars];
   for(Int_t iv=0; iv<fnVars; iv++) {
@@ -1376,11 +1392,11 @@ void AliRDHFCuts::SetVarsForOpt(Int_t nVars,Bool_t *forOpt) {
 //---------------------------------------------------------------------------
 void AliRDHFCuts::SetUseCentrality(Int_t flag) {
   //
-  // set centrality estimator  
+  // set centrality estimator
   //
   fUseCentrality=flag;
   if(fUseCentrality<kCentOff||fUseCentrality>=kCentInvalid) AliWarning("Centrality estimator not valid");
- 
+
   return;
 }
 
@@ -1393,14 +1409,14 @@ void AliRDHFCuts::SetCuts(Int_t nVars,Int_t nPtBins,Float_t **cutsRD) {
   if(nVars!=fnVars) {
     printf("Wrong number of variables: it has to be %d\n",fnVars);
     AliFatal("exiting");
-  } 
+  }
   if(nPtBins!=fnPtBins) {
     printf("Wrong number of pt bins: it has to be %d\n",fnPtBins);
     AliFatal("exiting");
-  } 
+  }
 
   if(!fCutsRD)  fCutsRD = new Float_t[fGlobalIndex];
-  
+
 
   for(Int_t iv=0; iv<fnVars; iv++) {
 
@@ -1438,7 +1454,7 @@ void AliRDHFCuts::SetCuts(Int_t glIndex,Float_t* cutsRDGlob){
 void AliRDHFCuts::PrintAll() const {
   //
   // print all cuts values
-  // 
+  //
 
   printf("Minimum vtx type %d\n",fMinVtxType);
   printf("Minimum vtx contr %d\n",fMinVtxContr);
@@ -1456,8 +1472,8 @@ void AliRDHFCuts::PrintAll() const {
     if(fUseCentrality==kCentTRK) estimator = "Tracks";
     if(fUseCentrality==kCentTKL) estimator = "Tracklets";
     if(fUseCentrality==kCentCL1) estimator = "SPD clusters outer";
-    if(fUseCentrality==kCentZNA) estimator = "ZNA"; 
-    if(fUseCentrality==kCentZPA) estimator = "ZPA"; 
+    if(fUseCentrality==kCentZNA) estimator = "ZNA";
+    if(fUseCentrality==kCentZPA) estimator = "ZPA";
     if(fUseCentrality==kCentV0A) estimator = "V0A";
     if(fUseCentrality==kCentCL0) estimator = "SPD clusters inner";
     printf("Centrality class considered: %.1f-%.1f, estimated with %s\n",fMinCentrality,fMaxCentrality,estimator.Data());
@@ -1501,7 +1517,7 @@ void AliRDHFCuts::PrintAll() const {
    for(Int_t iv=0;iv<fnVars;iv++){
      for(Int_t ib=0;ib<fnPtBins;ib++){
        cout<<"fCutsRD["<<iv<<"]["<<ib<<"] = "<<fCutsRD[GetGlobalIndex(iv,ib)]<<"\t";
-     } 
+     }
      cout<<endl;
    }
    cout<<endl;
@@ -1515,7 +1531,7 @@ void AliRDHFCuts::PrintAll() const {
 
 //--------------------------------------------------------------------------
 void AliRDHFCuts::PrintTrigger() const{
-  // print the trigger selection 
+  // print the trigger selection
 
   printf("Selected trigger classes: %s %s\n",fTriggerClass[0].Data(),fTriggerClass[1].Data());
 
@@ -1551,7 +1567,7 @@ void AliRDHFCuts::GetCuts(Float_t**& cutsRD) const{
       cutsRD[iv] = new Float_t[fnPtBins];
     }
   }
-  
+
   for(Int_t iGlobal=0; iGlobal<fGlobalIndex; iGlobal++) {
     GetVarPtIndex(iGlobal,iv,ib);
     cutsRD[iv][ib] = fCutsRD[iGlobal];
@@ -1596,7 +1612,7 @@ Int_t AliRDHFCuts::PtBin(Double_t pt) const {
 }
 //-------------------------------------------------------------------
 Float_t AliRDHFCuts::GetCutValue(Int_t iVar,Int_t iPtBin) const {
-  // 
+  //
   // Give the value of cut set for the variable iVar and the pt bin iPtBin
   //
   if(!fCutsRD){
@@ -1608,7 +1624,7 @@ Float_t AliRDHFCuts::GetCutValue(Int_t iVar,Int_t iPtBin) const {
 
 //-------------------------------------------------------------------
 Float_t AliRDHFCuts::GetCentrality(AliAODEvent* aodEvent,AliRDHFCuts::ECentrality estimator) {
-  
+
   if(aodEvent->GetRunNumber()<244824)return GetCentralityOldFramework(aodEvent,estimator);
   Double_t cent=-999;
 
@@ -1734,7 +1750,7 @@ Float_t AliRDHFCuts::GetCentralityOldFramework(AliAODEvent* aodEvent,AliRDHFCuts
 	    }
 	      }
 	      if((quality==8||quality==9)&&isSelRun)cent=(Float_t)centrality->GetCentralityPercentileUnchecked("TKL");
-	    }   
+	    }
 	  }
 	}
 	else{
@@ -1815,7 +1831,7 @@ Float_t AliRDHFCuts::GetCentralityOldFramework(AliAODEvent* aodEvent,AliRDHFCuts
 	  }
 	  else {
 	    AliWarning("Centrality estimator not valid");
-	    
+
 	  }
 	}
     }
@@ -1854,7 +1870,7 @@ Bool_t AliRDHFCuts::CompareCuts(const AliRDHFCuts *obj) const {
 
     if(fTrackCuts->GetClusterRequirementITS(AliESDtrackCuts::kSPD)!=obj->fTrackCuts->GetClusterRequirementITS(AliESDtrackCuts::kSPD)) {printf("ClusterReq SPD %d  %d\n",fTrackCuts->GetClusterRequirementITS(AliESDtrackCuts::kSPD),obj->fTrackCuts->GetClusterRequirementITS(AliESDtrackCuts::kSPD)); areEqual=kFALSE;}
   }
-  
+
   if(fUsePreselect!=obj->fUsePreselect){printf("fUsePreselect: %d %d\n",fUsePreselect,obj->fUsePreselect);areEqual=kFALSE;}
 
   if(fCutsRD) {
@@ -1874,7 +1890,7 @@ Bool_t AliRDHFCuts::CompareCuts(const AliRDHFCuts *obj) const {
 void AliRDHFCuts::MakeTable() const {
   //
   // print cuts values in table format
-  // 
+  //
 
 	TString ptString = "pT range";
 	if(fVarNames && fPtBinLimits && fCutsRD){
@@ -1886,7 +1902,7 @@ void AliRDHFCuts::MakeTable() const {
 			}
 		}
 		Printf("%s",firstLine.Data());
-		
+
 		for (Int_t ipt=0; ipt<fnPtBins; ipt++){
 			TString line;
 			if (ipt==fnPtBins-1){
@@ -1917,7 +1933,7 @@ Bool_t AliRDHFCuts::RecalcOwnPrimaryVtx(AliAODRecoDecayHF *d,
   if(!aod) {
     AliError("Can not remove daughters from vertex without AOD event");
     return 0;
-  }   
+  }
 
   AliAODVertex *recvtx=d->RemoveDaughtersFromPrimaryVtx(aod);
   if(!recvtx){
@@ -1942,10 +1958,10 @@ Bool_t AliRDHFCuts::SetMCPrimaryVtx(AliAODRecoDecayHF *d,AliAODEvent *aod) const
   if(!aod) {
     AliError("Can not get MC vertex without AOD event");
     return kFALSE;
-  }   
+  }
 
   // load MC header
-  AliAODMCHeader *mcHeader = 
+  AliAODMCHeader *mcHeader =
     (AliAODMCHeader*)aod->GetList()->FindObject(AliAODMCHeader::StdBranchName());
   if(!mcHeader) {
     AliError("Can not get MC vertex without AODMCHeader event");
@@ -1994,11 +2010,11 @@ void AliRDHFCuts::CleanOwnPrimaryVtx(AliAODRecoDecayHF *d,
   return;
 }
 //--------------------------------------------------------------------------
-Bool_t AliRDHFCuts::IsSignalMC(AliAODRecoDecay *d,AliAODEvent *aod,Int_t pdg) const 
+Bool_t AliRDHFCuts::IsSignalMC(AliAODRecoDecay *d,AliAODEvent *aod,Int_t pdg) const
 {
   //
   // Checks if this candidate is matched to MC signal
-  // 
+  //
 
   if(!aod) return kFALSE;
 
@@ -2007,9 +2023,9 @@ Bool_t AliRDHFCuts::IsSignalMC(AliAODRecoDecay *d,AliAODEvent *aod,Int_t pdg) co
 
   if(!mcArray) return kFALSE;
 
-  // try to match  
+  // try to match
   Int_t label = d->MatchToMC(pdg,mcArray);
-  
+
   if(label>=0) {
     //printf("MATCH!\n");
     return kTRUE;
@@ -2027,7 +2043,7 @@ Bool_t AliRDHFCuts::RecomputePrimaryVertex(AliAODEvent* event) const{
    vertexer->SetITSMode();
    vertexer->SetMinClusters(3);
 
-   AliAODVertex* pvtx=event->GetPrimaryVertex(); 
+   AliAODVertex* pvtx=event->GetPrimaryVertex();
    if(strstr(pvtx->GetTitle(),"VertexerTracksWithConstraint")) {
      Float_t diamondcovxy[3];
      event->GetDiamondCovXY(diamondcovxy);
@@ -2038,10 +2054,10 @@ Bool_t AliRDHFCuts::RecomputePrimaryVertex(AliAODEvent* event) const{
      delete diamond; diamond=NULL;
    }
 
-   AliESDVertex* vertexESD = (AliESDVertex*)vertexer->FindPrimaryVertex(event); 
+   AliESDVertex* vertexESD = (AliESDVertex*)vertexer->FindPrimaryVertex(event);
    if(!vertexESD) return kFALSE;
-   if(vertexESD->GetNContributors()<=0) { 
-     //AliDebug(2,"vertexing failed"); 
+   if(vertexESD->GetNContributors()<=0) {
+     //AliDebug(2,"vertexing failed");
      delete vertexESD; vertexESD=NULL;
      return kFALSE;
    }
@@ -2053,7 +2069,7 @@ Bool_t AliRDHFCuts::RecomputePrimaryVertex(AliAODEvent* event) const{
    vertexESD->GetCovMatrix(cov); //covariance matrix
    chi2perNDF = vertexESD->GetChi2toNDF();
    delete vertexESD; vertexESD=NULL;
-   
+
    pvtx->SetPosition(pos[0],pos[1],pos[2]);
    pvtx->SetChi2perNDF(chi2perNDF);
    pvtx->SetCovMatrix(cov);

--- a/PWGHF/vertexingHF/AliRDHFCuts.h
+++ b/PWGHF/vertexingHF/AliRDHFCuts.h
@@ -27,7 +27,7 @@ class TF1;
 class TFormula;
 class AliEventCuts;
 
-class AliRDHFCuts : public AliAnalysisCuts 
+class AliRDHFCuts : public AliAnalysisCuts
 {
  public:
 
@@ -39,9 +39,9 @@ class AliRDHFCuts : public AliAnalysisCuts
   enum EV0sel  {kAllV0s = 0, kOnlyOfflineV0s = 1, kOnlyOnTheFlyV0s = 2};
 
   AliRDHFCuts(const Char_t* name="RDHFCuts", const Char_t* title="");
-  
+
   virtual ~AliRDHFCuts();
-  
+
   AliRDHFCuts(const AliRDHFCuts& source);
   AliRDHFCuts& operator=(const AliRDHFCuts& source);
 
@@ -53,15 +53,15 @@ class AliRDHFCuts : public AliAnalysisCuts
   void SetMinCentrality(Float_t minCentrality=0.) {fMinCentrality=minCentrality;}
   void SetMaxCentrality(Float_t maxCentrality=100.) {fMaxCentrality=maxCentrality;}
   void SetMultSelectionObjectName(TString str){fMultSelectionObjectName=str;}
-  void SetMinVtxType(Int_t type=3) {fMinVtxType=type;}  
-  void SetUseEventsWithOnlySPDVertex(Bool_t flag=kTRUE){ 
+  void SetMinVtxType(Int_t type=3) {fMinVtxType=type;}
+  void SetUseEventsWithOnlySPDVertex(Bool_t flag=kTRUE){
     if(flag) fMinVtxType=1;
     else fMinVtxType=3;
   }
-  void SetMinVtxContr(Int_t contr=1) {fMinVtxContr=contr;}  
-  void SetMaxVtxRdChi2(Float_t chi2=1e6) {fMaxVtxRedChi2=chi2;}  
-  void SetMaxVtxZ(Float_t z=1e6) {fMaxVtxZ=z;}  
-  void SetMinSPDMultiplicity(Int_t mult=0) {fMinSPDMultiplicity=mult;}  
+  void SetMinVtxContr(Int_t contr=1) {fMinVtxContr=contr;}
+  void SetMaxVtxRdChi2(Float_t chi2=1e6) {fMaxVtxRedChi2=chi2;}
+  void SetMaxVtxZ(Float_t z=1e6) {fMaxVtxZ=z;}
+  void SetMinSPDMultiplicity(Int_t mult=0) {fMinSPDMultiplicity=mult;}
   void SetMinContribPileupMV(Int_t contr=5) {fMinContrPileupMV=contr;}
   void SetMaxVtxChi2PileupMV(Float_t chi2=5.) {fMaxVtxChi2PileupMV=chi2;}
   void SetMinWeightedDzVtxPileupMV(Float_t min=15.) {fMinWDzPileupMV=min;}
@@ -116,7 +116,7 @@ class AliRDHFCuts : public AliAnalysisCuts
   void ResetMaskAndEnableEMCALTrigger(){
     fTriggerMask=(AliVEvent::kEMCEJE|AliVEvent::kEMCEGA);
     fUseOnlyOneTrigger=kFALSE;
-  } 
+  }
   void SetUseEMCALTriggerExclusively(){
     fTriggerMask=(AliVEvent::kEMCEJE|AliVEvent::kEMCEGA);
     fUseOnlyOneTrigger=kTRUE;
@@ -201,25 +201,26 @@ class AliRDHFCuts : public AliAnalysisCuts
   void SetUseCentralityCorrelationCuts(Bool_t opt){fApplyCentralityCorrCuts=opt;}
   void SetUsePbPbOutOfBunchPileupCut(Int_t opt){fApplyPbPbOutOfBunchPileupCuts=opt;}
   void SetUseAliEventCuts(){fUseAliEventCuts=kTRUE;}
-  
+
   AliEventCuts* GetAliEventCuts() const { return fAliEventCuts;}
 
-  void SetTriggerClass(TString trclass0, TString trclass1="") {fTriggerClass[0]=trclass0; fTriggerClass[1]=trclass1;} 
+  void SetTriggerClass(TString trclass0, TString trclass1="") {fTriggerClass[0]=trclass0; fTriggerClass[1]=trclass1;}
   void ApplySPDDeadPbPb2011(){fApplySPDDeadPbPb2011=kTRUE;}
   void ApplySPDMisalignedCutPP2012(){fApplySPDMisalignedPP2012=kTRUE;}
+  void ApplySPDUniformAccPbPbRun2(){fApplySPDUniformAccPbPbRun2=kTRUE;}
   void SetVarsForOpt(Int_t nVars,Bool_t *forOpt);
   void SetGlobalIndex(){fGlobalIndex=fnVars*fnPtBins;}
   void SetGlobalIndex(Int_t nVars,Int_t nptBins){fnVars=nVars; fnPtBins=nptBins; SetGlobalIndex();}
-  void SetVarNames(Int_t nVars,TString *varNames,Bool_t *isUpperCut);  
+  void SetVarNames(Int_t nVars,TString *varNames,Bool_t *isUpperCut);
   void SetPtBins(Int_t nPtBinLimits,Float_t *ptBinLimits);
   void SetCuts(Int_t nVars,Int_t nPtBins,Float_t** cutsRD);
   void SetCuts(Int_t glIndex, Float_t* cutsRDGlob);
-  void AddTrackCuts(const AliESDtrackCuts *cuts) 
+  void AddTrackCuts(const AliESDtrackCuts *cuts)
           {delete fTrackCuts; fTrackCuts=new AliESDtrackCuts(*cuts); return;}
   void SetUsePID(Bool_t flag=kTRUE) {fUsePID=flag; return;}
   void SetUseAOD049(Bool_t flag=kTRUE) {fUseAOD049=flag; return;}
   void SetKinkRejection(Bool_t flag=kTRUE) {fKinkReject=flag; return;}
-  void SetUseTrackSelectionWithFilterBits(Bool_t flag=kTRUE){ 
+  void SetUseTrackSelectionWithFilterBits(Bool_t flag=kTRUE){
     fUseTrackSelectionWithFilterBits=flag; return;}
   void SetUseCentrality(Int_t flag=1);    /// see enum below
   void SetPidHF(AliAODPidHF* pidObj) {
@@ -261,14 +262,14 @@ class AliRDHFCuts : public AliAnalysisCuts
   AliAODPidHF* GetPidHF() const {return fPidHF;}
   Float_t *GetPtBinLimits() const {return fPtBinLimits;}
   Int_t   GetNPtBins() const {return fnPtBins;}
-  Int_t   GetNVars() const {return fnVars;} 
-  TString *GetVarNames() const {return fVarNames;} 
-  Bool_t  *GetVarsForOpt() const {return fVarsForOpt;} 
+  Int_t   GetNVars() const {return fnVars;}
+  TString *GetVarNames() const {return fVarNames;}
+  Bool_t  *GetVarsForOpt() const {return fVarsForOpt;}
   Int_t   GetNVarsForOpt() const {return fnVarsForOpt;}
-  const Float_t *GetCuts() const {return fCutsRD;} 
+  const Float_t *GetCuts() const {return fCutsRD;}
   void    GetCuts(Float_t**& cutsRD) const;
   Float_t GetCutValue(Int_t iVar,Int_t iPtBin) const;
-  Double_t GetMaxVtxZ() const {return fMaxVtxZ;}  
+  Double_t GetMaxVtxZ() const {return fMaxVtxZ;}
   Float_t GetCentrality(AliAODEvent* aodEvent){return GetCentrality(aodEvent,(AliRDHFCuts::ECentrality)fUseCentrality);}
   Float_t GetCentrality(AliAODEvent* aodEvent, AliRDHFCuts::ECentrality estimator);
   Float_t GetCentralityOldFramework(AliAODEvent* aodEvent, AliRDHFCuts::ECentrality estimator);
@@ -397,7 +398,7 @@ class AliRDHFCuts : public AliAnalysisCuts
   Bool_t SetMCPrimaryVtx(AliAODRecoDecayHF *d,AliAODEvent *aod) const;
   void   CleanOwnPrimaryVtx(AliAODRecoDecayHF *d,AliAODEvent *aod,AliAODVertex *origownvtx) const;
 
-  Bool_t CountEventForNormalization() const 
+  Bool_t CountEventForNormalization() const
   { if(fWhyRejection==0) {return kTRUE;} else {return kFALSE;} }
 
   void SetKeepSignalMC() {fKeepSignalMC=kTRUE; return;}
@@ -466,21 +467,21 @@ class AliRDHFCuts : public AliAnalysisCuts
   Int_t fWhyRejection; /// used to code the step at which candidate was rejected
   UInt_t fEvRejectionBits; //bit map storing the full info about event rejection
   Bool_t fRemoveDaughtersFromPrimary; /// flag to switch on the removal of duaghters from the primary vertex computation
-  Bool_t fUseMCVertex; /// use MC primary vertex 
+  Bool_t fUseMCVertex; /// use MC primary vertex
   Bool_t fUsePhysicsSelection; /// use Physics selection criteria
   Int_t  fOptPileup;      /// option for pielup selection
   Int_t  fMinContrPileup; /// min. n. of tracklets in pileup vertex
   Float_t fMinDzPileup;   /// min deltaz between main and pileup vertices
   Bool_t fUseMultDepPileupCut; /// flag to use a multiplicity dependent pileup selection
   Int_t   fUseCentrality; /// off =0 (default)
-                          /// 1 = V0 
+                          /// 1 = V0
                           /// 2 = Tracks
                           /// 3 = Tracklets
-                          /// 4 = SPD clusters outer 
+                          /// 4 = SPD clusters outer
   Float_t fMinCentrality; /// minimum centrality for selected events
   Float_t fMaxCentrality; /// maximum centrality for selected events
   TString fMultSelectionObjectName; /// name of the AliMultSelection object to be considered
-  Bool_t  fFixRefs;       /// fix the daughter track references 
+  Bool_t  fFixRefs;       /// fix the daughter track references
   Int_t  fIsSelectedCuts; /// outcome of cuts selection
   Int_t  fIsSelectedPID;  /// outcome of PID selection
   Double_t fMinPtCand; /// minimum pt of the candidate
@@ -491,6 +492,7 @@ class AliRDHFCuts : public AliAnalysisCuts
   Double_t fMaxPtCandTrackSPDFirst; /// maximum pt of the candidate for which to check if the daughters fulfill kFirst criteria
   Bool_t fApplySPDDeadPbPb2011;  /// flag to apply SPD dead module map of PbPb2011
   Bool_t fApplySPDMisalignedPP2012; /// flag to apply cut on tracks crossing SPD misaligned modules for PP2012 data
+  Bool_t fApplySPDUniformAccPbPbRun2; /// flag to apply the same SPD acceptance between Pb-Pb 2015 and Pb-Pb 2018 (PbPb Run2 periods)
   Double_t fMaxDiffTRKV0Centr;   /// Max. difference between TRK and V0 centrality (remove TPC pileup for PbPb 2011)
   Bool_t fRemoveTrackletOutliers; /// flag to apply cut on tracklets vs. centrality for 2011 data
   Int_t fCutOnzVertexSPD; /// cut on zSPD vertex to remove outliers in centrality vs. tracklets (0=no cut, 1= cut at 12 cm, 2= cut on difference to z of vtx tracks, 3=cut on nsigma distance between SPD and track vertices
@@ -499,7 +501,7 @@ class AliRDHFCuts : public AliAnalysisCuts
   Bool_t fUseCentrFlatteningInMC; /// flag for enabling/diabling centrality flattening in MC
   TH1F *fHistCentrDistr;   /// histogram with reference centrality distribution for centrality distribution flattening
   Float_t fCutRatioClsOverCrossRowsTPC; /// min. value ratio NTPCClusters/NTPCCrossedRows, cut if !=0
-  Float_t fCutRatioSignalNOverCrossRowsTPC;   /// min. value ratio TPCPointsUsedForPID/NTPCCrossedRows, cut if !=0 
+  Float_t fCutRatioSignalNOverCrossRowsTPC;   /// min. value ratio TPCPointsUsedForPID/NTPCCrossedRows, cut if !=0
   TString fCutMinCrossedRowsTPCPtDep; /// pT-dep cut in TPC minimum n crossed rows
   TFormula *f1CutMinNCrossedRowsTPCPtDep; /// pT-dep cut in TPC minimum n crossed rows
   Bool_t fUseCutGeoNcrNcl; /// flag for enabling/disabling geometrical cut on TPC track
@@ -515,12 +517,12 @@ class AliRDHFCuts : public AliAnalysisCuts
   AliEventCuts* fAliEventCuts;   /// AliEventCuts object used in Pb-Pb for cuts on correlations and out-of-bunch pileup
   Bool_t fApplyCentralityCorrCuts; /// swicth to enable/disable cuts on centrality correlations
   Int_t fApplyPbPbOutOfBunchPileupCuts; /// switch for additional correlation cuts for out-of-bunch pileup (0=no cut, 1=AliEVentCuts, 2=Ionut cut vs. nTPC cls)
-  Bool_t fUseAliEventCuts;  /// flag for using AliEventCuts 
-  
+  Bool_t fUseAliEventCuts;  /// flag for using AliEventCuts
+
   Bool_t fEnableNsigmaTPCDataCorr; /// flag to enable data-driven NsigmaTPC correction
   Int_t fSystemForNsigmaTPCDataCorr; /// system for data-driven NsigmaTPC correction
 
-  /// \cond CLASSIMP    
+  /// \cond CLASSIMP
   ClassDef(AliRDHFCuts,48);  /// base class for cuts on AOD reconstructed heavy-flavour decays
   /// \endcond
 };


### PR DESCRIPTION
Add the flag and the method to use the same SPD acceptance in 2015 and 2018 Pb-Pb analysis.
The two regions excluded are defined in order to avoid to use candidates which could have passed in SPD HSs 1A0 or 5C0, which were out during 2018 Pb-Pb data taking period.