### PR TITLE
Removes unnessessary function and equalizes to nano to AODs

### DIFF
--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskNanoXioton.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliAnalysisTaskNanoXioton.cxx
@@ -208,7 +208,7 @@ void AliAnalysisTaskNanoXioton::UserCreateOutputObjects() {
 }
 
 void AliAnalysisTaskNanoXioton::UserExec(Option_t *option) {
-  AliVEvent *fInputEvent = InputEvent();
+//  AliVEvent *fInputEvent = InputEvent();
   if (!fInputEvent) {
     AliError("No input event");
     return;

--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrack.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamTrack.cxx
@@ -473,8 +473,8 @@ void AliFemtoDreamTrack::SetVInformation(AliVEvent *event) {
 
   // loop over the 6 ITS Layrs and check for a hit!
   for (int i = 0; i < 6; ++i) {
-    fITSHit.push_back(fVTrack->HasPointOnITSLayer(i));
-    if (fVTrack->HasPointOnITSLayer(i)) {
+    fITSHit.push_back(fVGlobalTrack->HasPointOnITSLayer(i));
+    if (fVGlobalTrack->HasPointOnITSLayer(i)) {
       this->fHasITSHit = true;
     }
   }
@@ -482,7 +482,7 @@ void AliFemtoDreamTrack::SetVInformation(AliVEvent *event) {
 //    //doesn't seem to work for nanos.
 //    fTPCRefit = true;
 //  }
-  if (fVTrack->GetTOFBunchCrossing() == 0) {
+  if (fVGlobalTrack->GetTOFBunchCrossing() == 0) {
     this->fTOFTiming = true;
   } else {
     this->fTOFTiming = false;
@@ -497,7 +497,7 @@ void AliFemtoDreamTrack::SetVInformation(AliVEvent *event) {
   this->SetMomTPC(globalNanoTrack->GetTPCmomentum());
   this->fdcaXY = nanoTrack->DCA();
   this->fdcaZ = nanoTrack->ZAtDCA();
-  nanoTrack->GetImpactParameters(fdcaXYProp, fdcaZProp);
+  globalNanoTrack->GetImpactParameters(fdcaXYProp, fdcaZProp);
   SetPhiAtRadii(event->GetMagneticField());
 
   // PID stuff

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoDream.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoDream.C
@@ -419,7 +419,6 @@ AliAnalysisTaskSE* AddTaskFemtoDream(bool isMC = false, bool isESD = false,
   config->SetkTBinning(mTkTPlot);
   config->SetmTBinning(mTkTPlot);
   config->SetkTCentralityBinning(kTCentPlot);
-  config->SetInvMassPairs(InvMassPairs);
   if (kTCentPlot) {
     std::vector<float> centBins;
     centBins.push_back(20);

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoDreamRun1.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoDreamRun1.C
@@ -329,7 +329,6 @@ AliAnalysisTaskSE* AddTaskFemtoDreamRun1(
   config->SetkTBinning(mTkTPlot);
   config->SetmTBinning(mTkTPlot);
   config->SetkTCentralityBinning(kTCentPlot);
-  config->SetInvMassPairs(InvMassPairs);
   if (kTCentPlot) {
     std::vector<float> centBins;
     centBins.push_back(20);

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoDreamTrackSplit.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoDreamTrackSplit.C
@@ -354,7 +354,6 @@ AliAnalysisTaskSE *AddTaskFemtoDreamTrackSplit(
   config->SetkTBinning(mTkTPlot);
   config->SetmTBinning(mTkTPlot);
   config->SetkTCentralityBinning(kTCentPlot);
-  config->SetInvMassPairs(InvMassPairs);
   if (kTCentPlot) {
     std::vector<float> centBins;
     centBins.push_back(20);

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoGranma.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoGranma.C
@@ -212,7 +212,6 @@ AliAnalysisTaskSE* AddTaskFemtoGranma(
   centBins.push_back(90);
   config->SetCentBins(centBins);
   config->SetkTCentralityBinning(kTCentBins);
-  config->SetInvMassPairs(InvMassPairs);
 
 
 if(isMC)

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoGranma_systcuts.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoGranma_systcuts.C
@@ -163,7 +163,6 @@ AliAnalysisTaskSE* AddTaskFemtoGranma_systcuts(bool isMC, TString CentEst = "kIn
   config->SetCentBins(centBins);
   config->SetkTCentralityBinning(false);
 
-  config->SetInvMassPairs(false);
 
   if (isMC) {
     config->SetMomentumResolution(false);//kstar true vs. kstar reco

--- a/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoXoton.C
+++ b/PWGCF/FEMTOSCOPY/macros/AddTaskFemtoXoton.C
@@ -202,6 +202,7 @@ AliAnalysisTaskSE *AddTaskFemtoXoton(bool fullBlastQA = false,
   config->SetMultBinning(true);
   config->SetdPhidEtaPlotsSmallK(false);
   config->SetdPhidEtaPlots(false);
+
   config->SetPhiEtaBinnign(false);
 
   if (suffix == "0" && fullBlastQA) {


### PR DESCRIPTION
Invariant mass of pairs was used for a short investigation, however it is not used anymore and just lingers around. 
Additionally a redifinition of the VEvent was removed, which was already a member of the analysis task. Further pile up rejection & dcas were taken from the 128 track rather than the global track - fixed. 