### PR TITLE
Minor improvements for Sigma0 and NanoAOD analysis

### DIFF
--- a/PWG/DevNanoAOD/macros/AddTask_ConversionsForNano.C
+++ b/PWG/DevNanoAOD/macros/AddTask_ConversionsForNano.C
@@ -1,6 +1,6 @@
 AliAnalysisTask *AddTask_ConversionsForNano(
     Int_t dataset = 0, Bool_t isMC = kFALSE, TString periodNameV0Reader = "",
-    TString cutnumberPhoton = "00200078400000001240820000") {
+    TString cutnumberPhoton = "00200078000000001240820000") {
   gSystem->Load("libPWGGAGammaConv");
 
   // get the current analysis manager
@@ -25,6 +25,7 @@ AliAnalysisTask *AddTask_ConversionsForNano(
 
   if (periodNameV0Reader.CompareTo("") != 0)
     fV0ReaderV1->SetPeriodName(periodNameV0Reader);
+  fV0ReaderV1->SetAddv0sInESDFilter(kTRUE);
   fV0ReaderV1->SetCreateAODs(kTRUE);
   fV0ReaderV1->SetUseOwnXYZCalculation(kTRUE);
   fV0ReaderV1->SetUseAODConversionPhoton(kTRUE);

--- a/PWGGA/Hyperon/AliSigma0AODPhotonMotherCuts.cxx
+++ b/PWGGA/Hyperon/AliSigma0AODPhotonMotherCuts.cxx
@@ -50,6 +50,7 @@ ClassImp(AliSigma0AODPhotonMotherCuts)
       fHistNLambdaGammaLabel(nullptr),
       fHistMassCutPt(nullptr),
       fHistInvMass(nullptr),
+      fHistInvMassK0Gamma(nullptr),
       fHistInvMassSelected(nullptr),
       fHistInvMassRecPhoton(nullptr),
       fHistInvMassRecLambda(nullptr),
@@ -132,6 +133,7 @@ AliSigma0AODPhotonMotherCuts::AliSigma0AODPhotonMotherCuts(
       fHistNLambdaGammaLabel(nullptr),
       fHistMassCutPt(nullptr),
       fHistInvMass(nullptr),
+      fHistInvMassK0Gamma(nullptr),
       fHistInvMassSelected(nullptr),
       fHistInvMassRecPhoton(nullptr),
       fHistInvMassRecLambda(nullptr),
@@ -488,6 +490,8 @@ void AliSigma0AODPhotonMotherCuts::SingleV0QA(
 void AliSigma0AODPhotonMotherCuts::SigmaToLambdaGamma(
     const std::vector<AliFemtoDreamBasePart> &photonCandidates,
     const std::vector<AliFemtoDreamBasePart> &lambdaCandidates) {
+  static float massK0 = TDatabasePDG::Instance()->GetParticle(311)->Mass();
+
   fSigma.clear();
   fSidebandUp.clear();
   fSidebandDown.clear();
@@ -514,6 +518,14 @@ void AliSigma0AODPhotonMotherCuts::SigmaToLambdaGamma(
 
       if (!fIsLightweight) {
         fHistArmenterosBefore->Fill(armAlpha, armQt);
+
+        TLorentzVector track1, track2;
+        track1.SetXYZM(lambda.GetMomentum().Px(), lambda.GetMomentum().Py(),
+                       lambda.GetMomentum().Pz(), massK0);
+        track2.SetXYZM(photon.GetMomentum().Px(), photon.GetMomentum().Py(),
+                       photon.GetMomentum().Pz(), 0.f);
+        TLorentzVector trackSum = track1 + track2;
+        fHistInvMassK0Gamma->Fill(trackSum.M());
       }
       // Armenteros cut
       if (fArmenterosCut) {
@@ -743,6 +755,10 @@ void AliSigma0AODPhotonMotherCuts::InitCutHistograms(TString appendix) {
         "fHistMassCutPt", "; #it{p}_{T} #Lambda#gamma (GeV/#it{c}); Entries",
         100, 0, 10);
 
+    fHistInvMassK0Gamma = new TH1F("fHistInvMassK0Gamma",
+                                   "; M_{K^{0}#gamma} (GeV/#it{c}); Entries",
+                                   1000, 0.5, 3);
+
     fHistInvMassSelected = new TH2F("fHistInvMassSelected",
                                     "; #it{p}_{T} #Lambda#gamma (GeV/#it{c}); "
                                     "M_{#Lambda#gamma} (GeV/#it{c}^{2})",
@@ -768,6 +784,7 @@ void AliSigma0AODPhotonMotherCuts::InitCutHistograms(TString appendix) {
     fHistEtaPhi = new TH2F("fHistEtaPhi", "; #eta; #phi", 100, -1, 1, 100,
                            -TMath::Pi(), TMath::Pi());
 
+    fHistograms->Add(fHistInvMassK0Gamma);
     fHistograms->Add(fHistNPhotonBefore);
     fHistograms->Add(fHistNPhotonAfter);
     fHistograms->Add(fHistNLambdaBefore);

--- a/PWGGA/Hyperon/AliSigma0AODPhotonMotherCuts.h
+++ b/PWGGA/Hyperon/AliSigma0AODPhotonMotherCuts.h
@@ -139,6 +139,7 @@ class AliSigma0AODPhotonMotherCuts : public TObject {
   TH1F *fHistNLambdaGammaLabel;                     //!
   TH1F *fHistMassCutPt;                             //!
   TH1F *fHistInvMass;                               //!
+  TH1F* fHistInvMassK0Gamma;                        //!
   TH2F *fHistInvMassSelected;                       //!
   TH2F *fHistInvMassRecPhoton;                      //!
   TH2F *fHistInvMassRecLambda;                      //!
@@ -179,7 +180,7 @@ class AliSigma0AODPhotonMotherCuts : public TObject {
   TH2F *fHistMCV0MotherCheck;  //!
 
  private:
-  ClassDef(AliSigma0AODPhotonMotherCuts, 1)
+  ClassDef(AliSigma0AODPhotonMotherCuts, 2)
 };
 
 #endif

--- a/PWGGA/Hyperon/AliSigma0PhotonMotherCuts.cxx
+++ b/PWGGA/Hyperon/AliSigma0PhotonMotherCuts.cxx
@@ -62,6 +62,7 @@ ClassImp(AliSigma0PhotonMotherCuts)
       fHistNLambdaGammaLabel(nullptr),
       fHistMassCutPt(nullptr),
       fHistInvMass(nullptr),
+      fHistInvMassK0Gamma(nullptr),
       fHistInvMassSelected(nullptr),
       fHistInvMassRecPhoton(nullptr),
       fHistInvMassRecLambda(nullptr),
@@ -167,6 +168,7 @@ AliSigma0PhotonMotherCuts::AliSigma0PhotonMotherCuts(
       fHistNLambdaGammaLabel(nullptr),
       fHistMassCutPt(nullptr),
       fHistInvMass(nullptr),
+      fHistInvMassK0Gamma(nullptr),
       fHistInvMassSelected(nullptr),
       fHistInvMassRecPhoton(nullptr),
       fHistInvMassRecLambda(nullptr),
@@ -547,6 +549,8 @@ void AliSigma0PhotonMotherCuts::SigmaToLambdaGamma(
   fSidebandUp.clear();
   fSidebandDown.clear();
 
+  static float massK0 = TDatabasePDG::Instance()->GetParticle(311)->Mass();
+
   // Mulitplicity estimator: V0M
   Float_t lPercentile = 300;
   AliMultSelection *MultSelection = 0x0;
@@ -590,6 +594,12 @@ void AliSigma0PhotonMotherCuts::SigmaToLambdaGamma(
         fHistInvMassRecPhoton->Fill(pT, sigma.GetRecMassPhoton());
         fHistInvMassRecLambda->Fill(pT, sigma.GetRecMassLambda());
         fHistInvMassRec->Fill(pT, sigma.GetRecMass());
+
+        TLorentzVector track1, track2;
+        track1.SetXYZM(lambda.GetPx(), lambda.GetPy(), lambda.GetPz(), massK0);
+        track2.SetXYZM(photon.GetPx(), photon.GetPy(), photon.GetPz(), 0.f);
+        TLorentzVector trackSum = track1 + track2;
+        fHistInvMassK0Gamma->Fill(trackSum.M());
       }
 
       int label = -10;
@@ -1197,6 +1207,10 @@ void AliSigma0PhotonMotherCuts::InitCutHistograms(TString appendix) {
         "fHistMassCutPt", "; #it{p}_{T} #Lambda#gamma (GeV/#it{c}); Entries",
         100, 0, 10);
 
+    fHistInvMassK0Gamma = new TH1F("fHistInvMassK0Gamma",
+                                   "; M_{K^{0}#gamma} (GeV/#it{c}); Entries",
+                                   1000, 0.5, 3);
+
     fHistInvMassSelected = new TH2F("fHistInvMassSelected",
                                     "; #it{p}_{T} #Lambda#gamma (GeV/#it{c}); "
                                     "M_{#Lambda#gamma} (GeV/#it{c}^{2})",
@@ -1225,6 +1239,7 @@ void AliSigma0PhotonMotherCuts::InitCutHistograms(TString appendix) {
         new TH2F("fHistPtRapidity", "; #it{p}_{T} (GeV/#it{c}); y", 100, 0, 10,
                  100, -2, 2);
 
+    fHistograms->Add(fHistInvMassK0Gamma);
     fHistograms->Add(fHistNPhotonBefore);
     fHistograms->Add(fHistNPhotonAfter);
     fHistograms->Add(fHistNLambdaBefore);

--- a/PWGGA/Hyperon/AliSigma0PhotonMotherCuts.h
+++ b/PWGGA/Hyperon/AliSigma0PhotonMotherCuts.h
@@ -189,6 +189,7 @@ class AliSigma0PhotonMotherCuts : public TObject {
   TH1F *fHistNLambdaGammaLabel;                     //!
   TH1F *fHistMassCutPt;                             //!
   TH1F *fHistInvMass;                               //!
+  TH1F *fHistInvMassK0Gamma;                        //!
   TH2F *fHistInvMassSelected;                       //!
   TH2F *fHistInvMassRecPhoton;                      //!
   TH2F *fHistInvMassRecLambda;                      //!
@@ -243,7 +244,7 @@ class AliSigma0PhotonMotherCuts : public TObject {
   TH2F *fHistMCV0MotherCheck;  //!
 
  private:
-  ClassDef(AliSigma0PhotonMotherCuts, 28)
+  ClassDef(AliSigma0PhotonMotherCuts, 29)
 };
 
 #endif


### PR DESCRIPTION
- The v0 of the photons is not saved in the NanoAOD -> protection implemented
- Enable Addv0InESDs for the photons
- Check gamma+K0 inv. mass for weird structures (that hopefully won't show up)
