### PR TITLE
Update D0 systematics Pb-Pb 2018

### DIFF
--- a/PWGHF/vertexingHF/AliHFSystErr.cxx
+++ b/PWGHF/vertexingHF/AliHFSystErr.cxx
@@ -9220,111 +9220,36 @@ void AliHFSystErr::InitD0toKpi2018PbPb010() {
   for(Int_t i=1;i<=100;i++) fNorm->SetBinContent(i,0.04); // TAA and pp norm
 
   // Branching ratio
-  fBR = new TH1F("fBR","fBR",100,0,100);
+  fBR = new TH1F("fBR","fBR",100,0,50);
   for(Int_t i=1;i<=100;i++) fBR->SetBinContent(i,0.0004); // 0.04% PDG2016
 
   // Tracking efficiency
-  fTrackingEff = new TH1F("fTrackingEff","fTrackingEff",100,0,100);
-  fTrackingEff->SetBinContent(1,6.0*0.01); // Jacek, 5% per track
-  fTrackingEff->SetBinContent(2,6.0*0.01); // Jacek, 5% per track
-  fTrackingEff->SetBinContent(3,6.0*0.01);
-  fTrackingEff->SetBinContent(4,6.0*0.01);
-  fTrackingEff->SetBinContent(5,6.5*0.01);
-  fTrackingEff->SetBinContent(6,6.5*0.01);
-  fTrackingEff->SetBinContent(7,7.5*0.01);
-  fTrackingEff->SetBinContent(8,7.5*0.01);
-  fTrackingEff->SetBinContent(9,8.0*0.01);
-  fTrackingEff->SetBinContent(10,8.0*0.01);
-  fTrackingEff->SetBinContent(11,8.0*0.01);
-  fTrackingEff->SetBinContent(12,8.0*0.01);
-  fTrackingEff->SetBinContent(13,7.5*0.01);
-  fTrackingEff->SetBinContent(14,7.5*0.01);
-  fTrackingEff->SetBinContent(15,7.0*0.01);
-  fTrackingEff->SetBinContent(16,7.0*0.01);
-  fTrackingEff->SetBinContent(17,6.5*0.01);
-  fTrackingEff->SetBinContent(18,6.5*0.01);
-  fTrackingEff->SetBinContent(19,6.0*0.01);
-  fTrackingEff->SetBinContent(20,6.0*0.01);
-  fTrackingEff->SetBinContent(21,6.0*0.01);
-  fTrackingEff->SetBinContent(22,6.0*0.01);
-  fTrackingEff->SetBinContent(23,5.5*0.01);
-  fTrackingEff->SetBinContent(24,5.5*0.01);
-  fTrackingEff->SetBinContent(25,5.0*0.01);
-  fTrackingEff->SetBinContent(26,5.0*0.01);
-  fTrackingEff->SetBinContent(27,5.0*0.01);
-  fTrackingEff->SetBinContent(28,5.0*0.01);
-  fTrackingEff->SetBinContent(29,4.5*0.01);
-  fTrackingEff->SetBinContent(30,4.5*0.01);
-  fTrackingEff->SetBinContent(31,4.5*0.01);
-  fTrackingEff->SetBinContent(32,4.5*0.01);
-  fTrackingEff->SetBinContent(33,4.5*0.01);
-  fTrackingEff->SetBinContent(34,4.5*0.01);
-  fTrackingEff->SetBinContent(35,4.0*0.01);
-  fTrackingEff->SetBinContent(36,4.0*0.01);
-  fTrackingEff->SetBinContent(37,4.0*0.01);
-  fTrackingEff->SetBinContent(38,4.0*0.01);
-  fTrackingEff->SetBinContent(39,4.0*0.01);
-  fTrackingEff->SetBinContent(40,4.0*0.01);
-  fTrackingEff->SetBinContent(41,4.0*0.01);
-  fTrackingEff->SetBinContent(42,4.0*0.01);
-  fTrackingEff->SetBinContent(43,4.0*0.01);
-  fTrackingEff->SetBinContent(44,4.0*0.01);
-  fTrackingEff->SetBinContent(45,3.5*0.01);
-  fTrackingEff->SetBinContent(46,3.5*0.01);
-  fTrackingEff->SetBinContent(47,3.5*0.01);
-  fTrackingEff->SetBinContent(48,3.5*0.01);
-  fTrackingEff->SetBinContent(49,3.5*0.01);
-  fTrackingEff->SetBinContent(50,3.5*0.01);
-  fTrackingEff->SetBinContent(51,3.5*0.01);
-  fTrackingEff->SetBinContent(52,3.5*0.01);
-  fTrackingEff->SetBinContent(53,3.5*0.01);
-  fTrackingEff->SetBinContent(54,3.5*0.01);
-  fTrackingEff->SetBinContent(55,3.5*0.01);
-  fTrackingEff->SetBinContent(56,3.5*0.01);
-  fTrackingEff->SetBinContent(57,3.5*0.01);
-  fTrackingEff->SetBinContent(58,3.5*0.01);
-  fTrackingEff->SetBinContent(59,3.5*0.01);
-  fTrackingEff->SetBinContent(60,3.5*0.01);
-  fTrackingEff->SetBinContent(61,3.5*0.01);
-  fTrackingEff->SetBinContent(62,3.5*0.01);
-  fTrackingEff->SetBinContent(63,3.5*0.01);
-  fTrackingEff->SetBinContent(64,3.5*0.01);
-  fTrackingEff->SetBinContent(65,3.5*0.01);
-  fTrackingEff->SetBinContent(66,3.5*0.01);
-  fTrackingEff->SetBinContent(67,3.5*0.01);
-  fTrackingEff->SetBinContent(68,3.5*0.01);
-  fTrackingEff->SetBinContent(69,3.5*0.01);
-  fTrackingEff->SetBinContent(70,3.5*0.01);
-  fTrackingEff->SetBinContent(71,3.5*0.01);
-  fTrackingEff->SetBinContent(72,3.5*0.01);
-  fTrackingEff->SetBinContent(73,3.5*0.01);
-  fTrackingEff->SetBinContent(74,3.5*0.01);
-  fTrackingEff->SetBinContent(75,3.5*0.01);
-  fTrackingEff->SetBinContent(76,3.5*0.01);
-  fTrackingEff->SetBinContent(77,3.5*0.01);
-  fTrackingEff->SetBinContent(78,3.5*0.01);
-  fTrackingEff->SetBinContent(79,3.5*0.01);
-  fTrackingEff->SetBinContent(80,3.5*0.01);
-  fTrackingEff->SetBinContent(81,3.5*0.01);
-  fTrackingEff->SetBinContent(82,3.5*0.01);
-  fTrackingEff->SetBinContent(83,3.5*0.01);
-  fTrackingEff->SetBinContent(84,3.5*0.01);
-  fTrackingEff->SetBinContent(85,3.0*0.01);
-  fTrackingEff->SetBinContent(86,3.0*0.01);
-  fTrackingEff->SetBinContent(87,3.0*0.01);
-  fTrackingEff->SetBinContent(88,3.0*0.01);
-  fTrackingEff->SetBinContent(89,3.0*0.01);
-  fTrackingEff->SetBinContent(90,3.0*0.01);
-  fTrackingEff->SetBinContent(91,3.0*0.01);
-  fTrackingEff->SetBinContent(92,3.0*0.01);
-  fTrackingEff->SetBinContent(93,3.0*0.01);
-  fTrackingEff->SetBinContent(94,3.0*0.01);
-  fTrackingEff->SetBinContent(95,3.0*0.01);
-  fTrackingEff->SetBinContent(96,3.0*0.01);
-  fTrackingEff->SetBinContent(97,3.0*0.01);
-  fTrackingEff->SetBinContent(98,3.0*0.01);
-  fTrackingEff->SetBinContent(99,3.0*0.01);
-  fTrackingEff->SetBinContent(100,3.0*0.01);
+  fTrackingEff = new TH1F("fTrackingEff","fTrackingEff",100,0,50);
+  fTrackingEff->SetBinContent(1,0*0.01); //
+  fTrackingEff->SetBinContent(2,0*0.01); //
+  fTrackingEff->SetBinContent(3,9.5*0.01);
+  fTrackingEff->SetBinContent(4,9.5*0.01);
+  fTrackingEff->SetBinContent(5,10*0.01);
+  fTrackingEff->SetBinContent(6,10*0.01);
+  fTrackingEff->SetBinContent(7,11*0.01);
+  fTrackingEff->SetBinContent(8,11*0.01);
+  fTrackingEff->SetBinContent(9,11*0.01);
+  fTrackingEff->SetBinContent(10,11*0.01);
+  fTrackingEff->SetBinContent(11,9.5*0.01);
+  fTrackingEff->SetBinContent(12,9.5*0.01);
+  fTrackingEff->SetBinContent(13,9.0*0.01);
+  fTrackingEff->SetBinContent(14,9.0*0.01);
+  fTrackingEff->SetBinContent(15,8.5*0.01);
+  fTrackingEff->SetBinContent(16,8.5*0.01);
+  fTrackingEff->SetBinContent(17,8.0*0.01);
+  fTrackingEff->SetBinContent(18,8.0*0.01);
+  fTrackingEff->SetBinContent(19,8.0*0.01);
+  fTrackingEff->SetBinContent(20,8.0*0.01);
+  for(Int_t i=21;i<=24;i++) fTrackingEff->SetBinContent(i,7.5*0.01); //10-12
+  for(Int_t i=25;i<=32;i++) fTrackingEff->SetBinContent(i,7.0*0.01); //12-16
+  for(Int_t i=33;i<=48;i++) fTrackingEff->SetBinContent(i,6*0.01); //16-24
+  for(Int_t i=49;i<=72;i++) fTrackingEff->SetBinContent(i,5*0.01); //24-36
+  for(Int_t i=73;i<=100;i++) fTrackingEff->SetBinContent(i,5*0.01); //36-50
 
 
 
@@ -9332,56 +9257,56 @@ void AliHFSystErr::InitD0toKpi2018PbPb010() {
   fRawYield = new TH1F("fRawYield","fRawYield",100,0,50);
   fRawYield->SetBinContent(1,0);
   fRawYield->SetBinContent(2,0);
-  fRawYield->SetBinContent(3,0.145); // 1-1.5
-  fRawYield->SetBinContent(4,0.145); // 1.5-2
-  fRawYield->SetBinContent(5,0.05); // 2-2.5
-  fRawYield->SetBinContent(6,0.05); // 2.5-3
-  fRawYield->SetBinContent(7,0.03); // 3-3.5
-  fRawYield->SetBinContent(8,0.03); // 3.5-4
-  fRawYield->SetBinContent(9,0.04); // 4-4.5
-  fRawYield->SetBinContent(10,0.04); // 4.5-5
-  fRawYield->SetBinContent(11,0.04); // 5-5.5
-  fRawYield->SetBinContent(12,0.04); // 5.5-6
-  fRawYield->SetBinContent(13,0.04); // 6-6.5
-  fRawYield->SetBinContent(14,0.04); // 6.5-7
-  fRawYield->SetBinContent(15,0.05); // 7-7.5
-  fRawYield->SetBinContent(16,0.05); // 7.5-8
-  fRawYield->SetBinContent(17,0.05); // 8-8.5
-  fRawYield->SetBinContent(18,0.05); // 8.5-9
-  fRawYield->SetBinContent(19,0.05); // 9-9.5
-  fRawYield->SetBinContent(20,0.05); // 9.5-10
-  for(Int_t i=21;i<=24;i++) fRawYield->SetBinContent(i,0.065); //10-12
-  for(Int_t i=25;i<=32;i++) fRawYield->SetBinContent(i,0.065); //12-16
-  for(Int_t i=33;i<=48;i++) fRawYield->SetBinContent(i,0.1); //16-24
-  for(Int_t i=49;i<=72;i++) fRawYield->SetBinContent(i,0.1); //24-36
+  fRawYield->SetBinContent(3,0.1); // 1-1.5
+  fRawYield->SetBinContent(4,0.095); // 1.5-2
+  fRawYield->SetBinContent(5,0.035); // 2-2.5
+  fRawYield->SetBinContent(6,0.035); // 2.5-3
+  fRawYield->SetBinContent(7,0.035); // 3-3.5
+  fRawYield->SetBinContent(8,0.035); // 3.5-4
+  fRawYield->SetBinContent(9,0.03); // 4-4.5
+  fRawYield->SetBinContent(10,0.03); // 4.5-5
+  fRawYield->SetBinContent(11,0.025); // 5-5.5
+  fRawYield->SetBinContent(12,0.025); // 5.5-6
+  fRawYield->SetBinContent(13,0.045); // 6-6.5
+  fRawYield->SetBinContent(14,0.045); // 6.5-7
+  fRawYield->SetBinContent(15,0.045); // 7-7.5
+  fRawYield->SetBinContent(16,0.045); // 7.5-8
+  fRawYield->SetBinContent(17,0.045); // 8-8.5
+  fRawYield->SetBinContent(18,0.045); // 8.5-9
+  fRawYield->SetBinContent(19,0.045); // 9-9.5
+  fRawYield->SetBinContent(20,0.045); // 9.5-10
+  for(Int_t i=21;i<=24;i++) fRawYield->SetBinContent(i,0.048); //10-12
+  for(Int_t i=25;i<=32;i++) fRawYield->SetBinContent(i,0.05); //12-16
+  for(Int_t i=33;i<=48;i++) fRawYield->SetBinContent(i,0.06); //16-24
+  for(Int_t i=49;i<=72;i++) fRawYield->SetBinContent(i,0.06); //24-36
   for(Int_t i=73;i<=100;i++) fRawYield->SetBinContent(i,0.1); //36-50
 
-  fCutsEff = new TH1F("fCutsEff","fCutsEff",50,0,50);
+  fCutsEff = new TH1F("fCutsEff","fCutsEff",100,0,50);
   fCutsEff->SetBinContent(1,0);
   fCutsEff->SetBinContent(2,0);
-  fCutsEff->SetBinContent(3,0.145); // 1-1.5
-  fCutsEff->SetBinContent(4,0.145); // 1.5-2
+  fCutsEff->SetBinContent(3,0.1); // 1-1.5
+  fCutsEff->SetBinContent(4,0.1); // 1.5-2
   fCutsEff->SetBinContent(5,0.05); // 2-2.5
   fCutsEff->SetBinContent(6,0.05); // 2.5-3
-  fCutsEff->SetBinContent(7,0.03); // 3-3.5
-  fCutsEff->SetBinContent(8,0.03); // 3.5-4
-  fCutsEff->SetBinContent(9,0.04); // 4-4.5
-  fCutsEff->SetBinContent(10,0.04); // 4.5-5
-  fCutsEff->SetBinContent(11,0.04); // 5-5.5
-  fCutsEff->SetBinContent(12,0.04); // 5.5-6
-  fCutsEff->SetBinContent(13,0.04); // 6-6.5
-  fCutsEff->SetBinContent(14,0.04); // 6.5-7
-  fCutsEff->SetBinContent(15,0.05); // 7-7.5
-  fCutsEff->SetBinContent(16,0.05); // 7.5-8
-  fCutsEff->SetBinContent(17,0.05); // 8-8.5
-  fCutsEff->SetBinContent(18,0.05); // 8.5-9
-  fCutsEff->SetBinContent(19,0.05); // 9-9.5
-  fCutsEff->SetBinContent(20,0.05); // 9.5-10
-  for(Int_t i=21;i<=24;i++) fCutsEff->SetBinContent(i,0.065); //10-12
-  for(Int_t i=25;i<=32;i++) fCutsEff->SetBinContent(i,0.065); //12-16
-  for(Int_t i=33;i<=48;i++) fCutsEff->SetBinContent(i,0.1); //16-24
-  for(Int_t i=49;i<=72;i++) fCutsEff->SetBinContent(i,0.1); //24-36
-  for(Int_t i=73;i<=100;i++) fCutsEff->SetBinContent(i,0.1); //36-50
+  fCutsEff->SetBinContent(7,0.05); // 3-3.5
+  fCutsEff->SetBinContent(8,0.05); // 3.5-4
+  fCutsEff->SetBinContent(9,0.03); // 4-4.5
+  fCutsEff->SetBinContent(10,0.03); // 4.5-5
+  fCutsEff->SetBinContent(11,0.03); // 5-5.5
+  fCutsEff->SetBinContent(12,0.03); // 5.5-6
+  fCutsEff->SetBinContent(13,0.03); // 6-6.5
+  fCutsEff->SetBinContent(14,0.03); // 6.5-7
+  fCutsEff->SetBinContent(15,0.03); // 7-7.5
+  fCutsEff->SetBinContent(16,0.03); // 7.5-8
+  fCutsEff->SetBinContent(17,0.03); // 8-8.5
+  fCutsEff->SetBinContent(18,0.03); // 8.5-9
+  fCutsEff->SetBinContent(19,0.03); // 9-9.5
+  fCutsEff->SetBinContent(20,0.03); // 9.5-10
+  for(Int_t i=21;i<=24;i++) fCutsEff->SetBinContent(i,0.035); //10-12
+  for(Int_t i=25;i<=32;i++) fCutsEff->SetBinContent(i,0.035); //12-16
+  for(Int_t i=33;i<=48;i++) fCutsEff->SetBinContent(i,0.05); //16-24
+  for(Int_t i=49;i<=72;i++) fCutsEff->SetBinContent(i,0.05); //24-36
+  for(Int_t i=73;i<=100;i++) fCutsEff->SetBinContent(i,0.05); //36-50
 
 
   // PID efficiency (from PID/noPID)
@@ -9429,131 +9354,83 @@ void AliHFSystErr::InitD0toKpi2018PbPb3050() {
 
   // Tracking efficiency
   fTrackingEff = new TH1F("fTrackingEff","fTrackingEff",72,0,36);
-  fTrackingEff->SetBinContent(1,6.0*0.01); // Jacek, 5% per track
-  fTrackingEff->SetBinContent(2,6.0*0.01); // Jacek, 5% per track
-  fTrackingEff->SetBinContent(3,6.0*0.01);
-  fTrackingEff->SetBinContent(4,6.0*0.01);
-  fTrackingEff->SetBinContent(5,6.5*0.01);
-  fTrackingEff->SetBinContent(6,6.5*0.01);
-  fTrackingEff->SetBinContent(7,7.5*0.01);
-  fTrackingEff->SetBinContent(8,7.5*0.01);
-  fTrackingEff->SetBinContent(9,8.0*0.01);
-  fTrackingEff->SetBinContent(10,8.0*0.01);
-  fTrackingEff->SetBinContent(11,8.0*0.01);
-  fTrackingEff->SetBinContent(12,8.0*0.01);
-  fTrackingEff->SetBinContent(13,7.5*0.01);
-  fTrackingEff->SetBinContent(14,7.5*0.01);
-  fTrackingEff->SetBinContent(15,7.0*0.01);
-  fTrackingEff->SetBinContent(16,7.0*0.01);
-  fTrackingEff->SetBinContent(17,6.5*0.01);
-  fTrackingEff->SetBinContent(18,6.5*0.01);
-  fTrackingEff->SetBinContent(19,6.0*0.01);
-  fTrackingEff->SetBinContent(20,6.0*0.01);
-  fTrackingEff->SetBinContent(21,6.0*0.01);
-  fTrackingEff->SetBinContent(22,6.0*0.01);
-  fTrackingEff->SetBinContent(23,5.5*0.01);
-  fTrackingEff->SetBinContent(24,5.5*0.01);
-  fTrackingEff->SetBinContent(25,5.0*0.01);
-  fTrackingEff->SetBinContent(26,5.0*0.01);
-  fTrackingEff->SetBinContent(27,5.0*0.01);
-  fTrackingEff->SetBinContent(28,5.0*0.01);
-  fTrackingEff->SetBinContent(29,4.5*0.01);
-  fTrackingEff->SetBinContent(30,4.5*0.01);
-  fTrackingEff->SetBinContent(31,4.5*0.01);
-  fTrackingEff->SetBinContent(32,4.5*0.01);
-  fTrackingEff->SetBinContent(33,4.5*0.01);
-  fTrackingEff->SetBinContent(34,4.5*0.01);
-  fTrackingEff->SetBinContent(35,4.0*0.01);
-  fTrackingEff->SetBinContent(36,4.0*0.01);
-  fTrackingEff->SetBinContent(37,4.0*0.01);
-  fTrackingEff->SetBinContent(38,4.0*0.01);
-  fTrackingEff->SetBinContent(39,4.0*0.01);
-  fTrackingEff->SetBinContent(40,4.0*0.01);
-  fTrackingEff->SetBinContent(41,4.0*0.01);
-  fTrackingEff->SetBinContent(42,4.0*0.01);
-  fTrackingEff->SetBinContent(43,4.0*0.01);
-  fTrackingEff->SetBinContent(44,4.0*0.01);
-  fTrackingEff->SetBinContent(45,3.5*0.01);
-  fTrackingEff->SetBinContent(46,3.5*0.01);
-  fTrackingEff->SetBinContent(47,3.5*0.01);
-  fTrackingEff->SetBinContent(48,3.5*0.01);
-  fTrackingEff->SetBinContent(49,3.5*0.01);
-  fTrackingEff->SetBinContent(50,3.5*0.01);
-  fTrackingEff->SetBinContent(51,3.5*0.01);
-  fTrackingEff->SetBinContent(52,3.5*0.01);
-  fTrackingEff->SetBinContent(53,3.5*0.01);
-  fTrackingEff->SetBinContent(54,3.5*0.01);
-  fTrackingEff->SetBinContent(55,3.5*0.01);
-  fTrackingEff->SetBinContent(56,3.5*0.01);
-  fTrackingEff->SetBinContent(57,3.5*0.01);
-  fTrackingEff->SetBinContent(58,3.5*0.01);
-  fTrackingEff->SetBinContent(59,3.5*0.01);
-  fTrackingEff->SetBinContent(60,3.5*0.01);
-  fTrackingEff->SetBinContent(61,3.5*0.01);
-  fTrackingEff->SetBinContent(62,3.5*0.01);
-  fTrackingEff->SetBinContent(63,3.5*0.01);
-  fTrackingEff->SetBinContent(64,3.5*0.01);
-  fTrackingEff->SetBinContent(65,3.5*0.01);
-  fTrackingEff->SetBinContent(66,3.5*0.01);
-  fTrackingEff->SetBinContent(67,3.5*0.01);
-  fTrackingEff->SetBinContent(68,3.5*0.01);
-  fTrackingEff->SetBinContent(69,3.5*0.01);
-  fTrackingEff->SetBinContent(70,3.5*0.01);
-  fTrackingEff->SetBinContent(71,3.5*0.01);
-  fTrackingEff->SetBinContent(72,3.5*0.01);
+  fTrackingEff->SetBinContent(1,0*0.01); // Jacek, 5% per track
+  fTrackingEff->SetBinContent(2,0*0.01); // Jacek, 5% per track
+  fTrackingEff->SetBinContent(3,8.0*0.01);
+  fTrackingEff->SetBinContent(4,8.0*0.01);
+  fTrackingEff->SetBinContent(5,8.0*0.01);
+  fTrackingEff->SetBinContent(6,8.0*0.01);
+  fTrackingEff->SetBinContent(7,8.0*0.01);
+  fTrackingEff->SetBinContent(8,8.0*0.01);
+  fTrackingEff->SetBinContent(9,8.5*0.01);
+  fTrackingEff->SetBinContent(10,8.5*0.01);
+  fTrackingEff->SetBinContent(11,8.5*0.01);
+  fTrackingEff->SetBinContent(12,8.5*0.01);
+  fTrackingEff->SetBinContent(13,9.0*0.01);
+  fTrackingEff->SetBinContent(14,9.0*0.01);
+  fTrackingEff->SetBinContent(15,9.0*0.01);
+  fTrackingEff->SetBinContent(16,9.0*0.01);
+  fTrackingEff->SetBinContent(17,7.5*0.01);
+  fTrackingEff->SetBinContent(18,7.5*0.01);
+  fTrackingEff->SetBinContent(19,7.5*0.01);
+  fTrackingEff->SetBinContent(20,7.5*0.01);
+  for(Int_t i=21;i<=24;i++) fTrackingEff->SetBinContent(i,7.5*0.01); //10-12
+  for(Int_t i=25;i<=32;i++) fTrackingEff->SetBinContent(i,7.0*0.01); //12-16
+  for(Int_t i=33;i<=48;i++) fTrackingEff->SetBinContent(i,5.5*0.01); //16-24
+  for(Int_t i=49;i<=72;i++) fTrackingEff->SetBinContent(i,4.5*0.01); //24-36
 
   // Raw yield extraction
   fRawYield = new TH1F("fRawYield","fRawYield",72,0,36);
   fRawYield->SetBinContent(1,0);
   fRawYield->SetBinContent(2,0);
-  fRawYield->SetBinContent(3,0.145); // 1-1.5
-  fRawYield->SetBinContent(4,0.145); // 1.5-2
-  fRawYield->SetBinContent(5,0.05); // 2-2.5
-  fRawYield->SetBinContent(6,0.05); // 2.5-3
-  fRawYield->SetBinContent(7,0.03); // 3-3.5
-  fRawYield->SetBinContent(8,0.03); // 3.5-4
-  fRawYield->SetBinContent(9,0.04); // 4-4.5
-  fRawYield->SetBinContent(10,0.04); // 4.5-5
-  fRawYield->SetBinContent(11,0.04); // 5-5.5
-  fRawYield->SetBinContent(12,0.04); // 5.5-6
-  fRawYield->SetBinContent(13,0.04); // 6-6.5
-  fRawYield->SetBinContent(14,0.04); // 6.5-7
-  fRawYield->SetBinContent(15,0.05); // 7-7.5
-  fRawYield->SetBinContent(16,0.05); // 7.5-8
-  fRawYield->SetBinContent(17,0.05); // 8-8.5
-  fRawYield->SetBinContent(18,0.05); // 8.5-9
-  fRawYield->SetBinContent(19,0.05); // 9-9.5
-  fRawYield->SetBinContent(20,0.05); // 9.5-10
-  for(Int_t i=21;i<=24;i++) fRawYield->SetBinContent(i,0.065); //10-12
-  for(Int_t i=25;i<=32;i++) fRawYield->SetBinContent(i,0.065); //12-16
-  for(Int_t i=33;i<=48;i++) fRawYield->SetBinContent(i,0.1); //16-24
-  for(Int_t i=49;i<=72;i++) fRawYield->SetBinContent(i,0.1); //24-36
+  fRawYield->SetBinContent(3,0.065); // 1-1.5
+  fRawYield->SetBinContent(4,0.05); // 1.5-2
+  fRawYield->SetBinContent(5,0.035); // 2-2.5
+  fRawYield->SetBinContent(6,0.035); // 2.5-3
+  fRawYield->SetBinContent(7,0.028); // 3-3.5
+  fRawYield->SetBinContent(8,0.028); // 3.5-4
+  fRawYield->SetBinContent(9,0.025); // 4-4.5
+  fRawYield->SetBinContent(10,0.025); // 4.5-5
+  fRawYield->SetBinContent(11,0.025); // 5-5.5
+  fRawYield->SetBinContent(12,0.025); // 5.5-6
+  fRawYield->SetBinContent(13,0.042); // 6-6.5
+  fRawYield->SetBinContent(14,0.042); // 6.5-7
+  fRawYield->SetBinContent(15,0.042); // 7-7.5
+  fRawYield->SetBinContent(16,0.042); // 7.5-8
+  fRawYield->SetBinContent(17,0.042); // 8-8.5
+  fRawYield->SetBinContent(18,0.042); // 8.5-9
+  fRawYield->SetBinContent(19,0.042); // 9-9.5
+  fRawYield->SetBinContent(20,0.042); // 9.5-10
+  for(Int_t i=21;i<=24;i++) fRawYield->SetBinContent(i,0.045); //10-12
+  for(Int_t i=25;i<=32;i++) fRawYield->SetBinContent(i,0.05); //12-16
+  for(Int_t i=33;i<=48;i++) fRawYield->SetBinContent(i,0.055); //16-24
+  for(Int_t i=49;i<=72;i++) fRawYield->SetBinContent(i,0.12); //24-36
 
-  fCutsEff = new TH1F("fCutsEff","fCutsEff",36,0,36);
+  fCutsEff = new TH1F("fCutsEff","fCutsEff",72,0,36);
   fCutsEff->SetBinContent(1,0);
   fCutsEff->SetBinContent(2,0);
-  fCutsEff->SetBinContent(3,0.145); // 1-1.5
-  fCutsEff->SetBinContent(4,0.145); // 1.5-2
+  fCutsEff->SetBinContent(3,0.08); // 1-1.5
+  fCutsEff->SetBinContent(4,0.08); // 1.5-2
   fCutsEff->SetBinContent(5,0.05); // 2-2.5
   fCutsEff->SetBinContent(6,0.05); // 2.5-3
   fCutsEff->SetBinContent(7,0.03); // 3-3.5
   fCutsEff->SetBinContent(8,0.03); // 3.5-4
-  fCutsEff->SetBinContent(9,0.04); // 4-4.5
-  fCutsEff->SetBinContent(10,0.04); // 4.5-5
-  fCutsEff->SetBinContent(11,0.04); // 5-5.5
-  fCutsEff->SetBinContent(12,0.04); // 5.5-6
-  fCutsEff->SetBinContent(13,0.04); // 6-6.5
-  fCutsEff->SetBinContent(14,0.04); // 6.5-7
-  fCutsEff->SetBinContent(15,0.05); // 7-7.5
-  fCutsEff->SetBinContent(16,0.05); // 7.5-8
-  fCutsEff->SetBinContent(17,0.05); // 8-8.5
-  fCutsEff->SetBinContent(18,0.05); // 8.5-9
-  fCutsEff->SetBinContent(19,0.05); // 9-9.5
-  fCutsEff->SetBinContent(20,0.05); // 9.5-10
-  for(Int_t i=21;i<=24;i++) fCutsEff->SetBinContent(i,0.065); //10-12
-  for(Int_t i=25;i<=32;i++) fCutsEff->SetBinContent(i,0.065); //12-16
-  for(Int_t i=33;i<=48;i++) fCutsEff->SetBinContent(i,0.1); //16-24
-  for(Int_t i=49;i<=72;i++) fCutsEff->SetBinContent(i,0.1); //24-36
+  fCutsEff->SetBinContent(9,0.025); // 4-4.5
+  fCutsEff->SetBinContent(10,0.025); // 4.5-5
+  fCutsEff->SetBinContent(11,0.025); // 5-5.5
+  fCutsEff->SetBinContent(12,0.025); // 5.5-6
+  fCutsEff->SetBinContent(13,0.025); // 6-6.5
+  fCutsEff->SetBinContent(14,0.025); // 6.5-7
+  fCutsEff->SetBinContent(15,0.025); // 7-7.5
+  fCutsEff->SetBinContent(16,0.025); // 7.5-8
+  fCutsEff->SetBinContent(17,0.025); // 8-8.5
+  fCutsEff->SetBinContent(18,0.025); // 8.5-9
+  fCutsEff->SetBinContent(19,0.025); // 9-9.5
+  fCutsEff->SetBinContent(20,0.025); // 9.5-10
+  for(Int_t i=21;i<=24;i++) fCutsEff->SetBinContent(i,0.03); //10-12
+  for(Int_t i=25;i<=32;i++) fCutsEff->SetBinContent(i,0.03); //12-16
+  for(Int_t i=33;i<=48;i++) fCutsEff->SetBinContent(i,0.05); //16-24
+  for(Int_t i=49;i<=72;i++) fCutsEff->SetBinContent(i,0.05); //24-36
 
   // PID efficiency (from PID/noPID)
   fPIDEff = new TH1F("fPIDEff","fPIDEff",72,0,36);


### PR DESCRIPTION
Updating _InitD0toKpi2018PbPb010_ and _InitD0toKpi2018PbPb3050_ with the systematic uncertainty values from the following sources:
- Signal extraction
- Tracking efficiency 
- PID
In addition I have fixed some issues with the binning for the _Cut variation_ and BR sources histogram.