### PR TITLE
 PWGGA/GammaConv: Implemented TPC dE/dx recalibration OADB for conversion tasks

### DIFF
--- a/OADB/PWGGA/ReadmeRecalibOADB.txt
+++ b/OADB/PWGGA/ReadmeRecalibOADB.txt
@@ -1,0 +1,24 @@
+The TPC dEdx recalibration files are stored in the EOS directory /eos/experiment/alice/analysis-data/OADB/PWGGA which is accessible via lxplus.
+Analysis tasks can access these files via, for example: ```AliDataFile::GetFileNameOADB("PWGGA/TPCdEdxRecalibOADB.root")``` which has been implemented into AliConversionPhotonCuts and the corresponding analysis tasks in AliPhysics.
+If you want to have the OADB files locally, you can download them from lxplus via:
+~~~{.sh}
+rsync -av --delete cern_user@lxplus.cern.ch:/eos/experiment/alice/analysis-data/ /path/to/my/local/oadb/
+~~~
+
+In order for local tests to work properly, please add the ALICE_DATA global variable to your bashrc or similar.
+~~~{.sh}
+ALICE_DATA=/path/to/my/local/oadb
+~~~
+
+Furthermore, the "export" command should be used in addition to adding the path to the bashrc. This will make the variable available to all processes:
+~~~{.sh}
+export ALICE_DATA=/path/to/my/local/oadb
+~~~
+
+The code for the creation of the OADB files as well as for bookkeeping of input files can be found in the following repository: https://gitlab.cern.ch/alice-pcg/AnalysisSoftware (folder TaskQA/UpdatedEdxRecalib_OADB.C)
+
+In addition, a short history of changes to the files in EOS will be listed here:
+
+- 20180524: Created first file on EOS containing calibrations for LHC13b-f
+
+*/

--- a/PWGGA/GammaConv/AliAnalysisTaskConversionQA.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskConversionQA.cxx
@@ -52,7 +52,6 @@ AliAnalysisTaskConversionQA::AliAnalysisTaskConversionQA() : AliAnalysisTaskSE()
   fIsHeavyIon(kFALSE),
   ffillTree(-100),
   ffillHistograms(kFALSE),
-  fDoElecDeDxPostCalibration(kFALSE),
   fOutputList(NULL),
   fESDList(NULL),
   hVertexZ(NULL),
@@ -143,7 +142,6 @@ AliAnalysisTaskConversionQA::AliAnalysisTaskConversionQA(const char *name) : Ali
   fIsHeavyIon(kFALSE),
   ffillTree(-100),
   ffillHistograms(kFALSE),
-  fDoElecDeDxPostCalibration(kFALSE),
   fOutputList(NULL),
   fESDList(NULL),
   hVertexZ(NULL),
@@ -527,6 +525,12 @@ void AliAnalysisTaskConversionQA::UserExec(Option_t *){
     }
   }
 
+  if(fConversionCuts->GetDoElecDeDxPostCalibration()){
+    if(!fConversionCuts->LoadElecDeDxPostCalibration(fInputEvent->GetRunNumber())){
+      AliFatal(Form("ERROR: LoadElecDeDxPostCalibration returned kFALSE for %d despite being requested!",fInputEvent->GetRunNumber()));
+    }
+  }
+
   for(Int_t firstGammaIndex=0;firstGammaIndex<fConversionGammas->GetEntriesFast();firstGammaIndex++){
     AliAODConversionPhoton *gamma=dynamic_cast<AliAODConversionPhoton*>(fConversionGammas->At(firstGammaIndex));
     if (gamma==NULL) continue;
@@ -601,7 +605,7 @@ void AliAnalysisTaskConversionQA::ProcessQATree(AliAODConversionPhoton *gamma){
   Double_t electronNSigmaTPCCor=0.;
   Double_t positronNSigmaTPC = pidResonse->NumberOfSigmasTPC(posTrack,AliPID::kElectron);
   Double_t positronNSigmaTPCCor=0.;
-  if(fDoElecDeDxPostCalibration && fConversionCuts->GetElecDeDxPostCalibrationInitialized()){
+  if(fConversionCuts->GetDoElecDeDxPostCalibration()){
     electronNSigmaTPCCor = fConversionCuts->GetCorrectedElectronTPCResponse(negTrack->Charge(),electronNSigmaTPC,negTrack->P(),negTrack->Eta(),gamma->GetConversionRadius());
     positronNSigmaTPCCor = fConversionCuts->GetCorrectedElectronTPCResponse(posTrack->Charge(),positronNSigmaTPC,posTrack->P(),posTrack->Eta(),gamma->GetConversionRadius());
     fDaughterProp(3) =  positronNSigmaTPCCor;

--- a/PWGGA/GammaConv/AliAnalysisTaskConversionQA.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskConversionQA.h
@@ -50,7 +50,6 @@ class AliAnalysisTaskConversionQA : public AliAnalysisTaskSE{
                                                                                             ffillHistograms = fillHistorams     ;
                                                                                           }
     void SetIsMC                            ( Bool_t isMC )                               { fIsMC = isMC                        ; }
-    void SetDoElecDeDxPostCalibration       (Bool_t k=kTRUE)                              { fDoElecDeDxPostCalibration = k      ; }
 
   private:
         
@@ -83,7 +82,6 @@ class AliAnalysisTaskConversionQA : public AliAnalysisTaskSE{
     Bool_t                      fIsHeavyIon;                //
     Double_t                    ffillTree;                  //
     Bool_t                      ffillHistograms;            //
-    Bool_t                      fDoElecDeDxPostCalibration; ///<
     TList*                      fOutputList;                //
     TList*                      fESDList;                   //
     TH1F*                       hVertexZ;                   //
@@ -137,7 +135,7 @@ class AliAnalysisTaskConversionQA : public AliAnalysisTaskSE{
     Int_t*                      fMCStackPos;                //[fnGammaCandidates]
     Int_t*                      fMCStackNeg;                //[fnGammaCandidates]
     
-    ClassDef(AliAnalysisTaskConversionQA, 10);
+    ClassDef(AliAnalysisTaskConversionQA, 11);
 };
 
 #endif

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvCalo.cxx
@@ -3073,6 +3073,12 @@ void AliAnalysisTaskGammaConvCalo::UserExec(Option_t *)
       }
     }
 
+      if(((AliConversionPhotonCuts*)fCutArray->At(fiCut))->GetDoElecDeDxPostCalibration()){
+        if(!((AliConversionPhotonCuts*)fCutArray->At(fiCut))->LoadElecDeDxPostCalibration(fInputEvent->GetRunNumber())){
+          AliFatal(Form("ERROR: LoadElecDeDxPostCalibration returned kFALSE for %d despite being requested!",fInputEvent->GetRunNumber()));
+        }
+      }
+
     if(fIsMC>0){
       // Process MC Particle
       if(((AliConvEventCuts*)fEventCutArray->At(iCut))->GetSignalRejection() != 0){

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvV1.cxx
@@ -2464,7 +2464,11 @@ void AliAnalysisTaskGammaConvV1::ProcessPhotonCandidates()
     if (fDoMaterialBudgetWeightingOfGammasForTrueMesons && ((AliConversionPhotonCuts*)fCutArray->At(fiCut))->GetMaterialBudgetWeightsInitialized()) {
       weightMatBudgetGamma = ((AliConversionPhotonCuts*)fCutArray->At(fiCut))->GetMaterialBudgetCorrectingWeightForTrueGamma(PhotonCandidate);
     }
-
+    if(((AliConversionPhotonCuts*)fCutArray->At(fiCut))->GetDoElecDeDxPostCalibration()){
+      if(!(((AliConversionPhotonCuts*)fCutArray->At(fiCut))->LoadElecDeDxPostCalibration(fInputEvent->GetRunNumber()))){
+        AliFatal(Form("ERROR: LoadElecDeDxPostCalibration returned kFALSE for %d despite being requested!",fInputEvent->GetRunNumber()));
+      }
+    }
 
     if( fIsMC > 0 && ((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetSignalRejection() != 0){
       Int_t isPosFromMBHeader

--- a/PWGGA/GammaConv/AliAnalysisTaskHeavyNeutralMesonToGG.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskHeavyNeutralMesonToGG.cxx
@@ -1563,6 +1563,12 @@ void AliAnalysisTaskHeavyNeutralMesonToGG::UserExec(Option_t *){
         continue;
       }
 
+      if(((AliConversionPhotonCuts*)fCutArray->At(fiCut))->GetDoElecDeDxPostCalibration()){
+        if(!((AliConversionPhotonCuts*)fCutArray->At(fiCut))->LoadElecDeDxPostCalibration(fInputEvent->GetRunNumber())){
+          AliFatal(Form("ERROR: LoadElecDeDxPostCalibration returned kFALSE for %d despite being requested!",fInputEvent->GetRunNumber()));
+        }
+      }
+
       if (triggered==kTRUE){
         fHistoNEvents[iCut]->Fill(eventQuality, fWeightJetJetMC); // Should be 0 here
         if (fIsMC>1) fHistoNEventsWOWeight[iCut]->Fill(eventQuality); // Should be 0 here

--- a/PWGGA/GammaConv/AliAnalysisTaskMaterialHistos.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskMaterialHistos.cxx
@@ -804,6 +804,11 @@ void AliAnalysisTaskMaterialHistos::UserExec(Option_t *){
     fNESDtracksEta14 = fNESDtracksEta08 + fNESDtracksEta0814;
 
 
+    if(((AliConversionPhotonCuts*)fConversionCutArray->At(fiCut))->GetDoElecDeDxPostCalibration()){
+      if(!((AliConversionPhotonCuts*)fConversionCutArray->At(fiCut))->LoadElecDeDxPostCalibration(fInputEvent->GetRunNumber())){
+        AliFatal(Form("ERROR: LoadElecDeDxPostCalibration returned kFALSE for %d despite being requested!",fInputEvent->GetRunNumber()));
+      }
+    }
 
     hNGoodESDTracksEta08[iCut]->Fill(fNESDtracksEta08);
     hNGoodESDTracksEta14[iCut]->Fill(fNESDtracksEta14);
@@ -1016,7 +1021,7 @@ void AliAnalysisTaskMaterialHistos::ProcessPhotons(){
     Double_t P=0.;         
     Double_t Eta=0.;  
 
-    if( ((AliConversionPhotonCuts*)fConversionCutArray->At(fiCut))->GetElecDeDxPostCalibrationInitialized() ){
+    if( ((AliConversionPhotonCuts*)fConversionCutArray->At(fiCut))->GetDoElecDeDxPostCalibration() ){
       Charge = negTrack->Charge();
       P = negTrack->P();
       Eta = negTrack->Eta();
@@ -1041,7 +1046,7 @@ void AliAnalysisTaskMaterialHistos::ProcessPhotons(){
     hESDConversionREta[fiCut]->Fill(gamma->GetPhotonEta(),gamma->GetConversionRadius());
 
 
-    if( ((AliConversionPhotonCuts*)fConversionCutArray->At(fiCut))->GetElecDeDxPostCalibrationInitialized() ){
+    if( ((AliConversionPhotonCuts*)fConversionCutArray->At(fiCut))->GetDoElecDeDxPostCalibration() ){
       if(negTrack->GetTPCsignal()){
         hElectronRdEdx[fiCut]->Fill(negTrack->GetTPCsignal(),gamma->GetConversionRadius());
         hElectronRNSigmadEdx[fiCut]->Fill( electronNSigmaTPCCor, gamma->GetConversionRadius());
@@ -1083,7 +1088,7 @@ void AliAnalysisTaskMaterialHistos::ProcessPhotons(){
     }
 
     if(fDoDeDxMaps > 0 ) {
-      if( ((AliConversionPhotonCuts*)fConversionCutArray->At(fiCut))->GetElecDeDxPostCalibrationInitialized()){
+      if( ((AliConversionPhotonCuts*)fConversionCutArray->At(fiCut))->GetDoElecDeDxPostCalibration()){
 	if(gamma->GetConversionRadius() < 33.5){
 	  hElectrondEdxMapsR0[fiCut]->Fill(electronNSigmaTPCCor, gamma->GetPhotonEta(), negTrack->P());
 	  hPositrondEdxMapsR0[fiCut]->Fill(positronNSigmaTPCCor, gamma->GetPhotonEta(), posTrack->P());

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_PbPb.C
@@ -47,6 +47,7 @@ void AddTask_GammaConvCalo_PbPb(
   TString   generatorName                 = "DPMJET", // generator Name
   Bool_t    enableMultiplicityWeighting   = kFALSE,   //
   Int_t     enableMatBudWeightsPi0        = 0,        // 1 = three radial bins, 2 = 10 radial bins (2 is the default when using weights)
+  Bool_t    enableElecDeDxPostCalibration = kFALSE,
   TString   periodNameAnchor              = "",       //
   Bool_t    enableFlattening              = kFALSE,                 // switch on centrality flattening for LHC11h
   // special settings
@@ -65,6 +66,7 @@ void AddTask_GammaConvCalo_PbPb(
   TString fileNameMultWeights   = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FMUW:");
   TString fileNameCentFlattening= cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FCEF:");
   TString fileNameMatBudWeights = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FMAW:");
+  TString fileNamedEdxPostCalib = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FEPC:");
 
 
   TString addTaskName                 = "AddTask_GammaConvCalo_PbPb";
@@ -1279,6 +1281,20 @@ void AddTask_GammaConvCalo_PbPb(
     }
 
     analysisCuts[i]->SetV0ReaderName(V0ReaderName);
+    if (enableElecDeDxPostCalibration){
+      if (isMC == 0){
+        if(fileNamedEdxPostCalib.CompareTo("") != 0){
+          analysisCuts[i]->SetElecDeDxPostCalibrationCustomFile(fileNamedEdxPostCalib);
+          cout << "Setting custom dEdx recalibration file: " << fileNamedEdxPostCalib.Data() << endl;
+        }
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+        cout << "Enabled TPC dEdx recalibration." << endl;
+      } else{
+        cout << "ERROR enableElecDeDxPostCalibration set to True even if MC file. Automatically reset to 0"<< endl;
+        enableElecDeDxPostCalibration=kFALSE;
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(kFALSE);
+      }
+    }
     if (enableLightOutput > 0) analysisCuts[i]->SetLightOutput(kTRUE);
     analysisCuts[i]->InitializeCutsFromCutString((cuts.GetPhotonCut(i)).Data());
     ConvCutList->Add(analysisCuts[i]);

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pPb.C
@@ -47,6 +47,7 @@ void AddTask_GammaConvCalo_pPb(
   TString   generatorName                 = "DPMJET", // generator Name
   Bool_t    enableMultiplicityWeighting   = kFALSE,   //
   Int_t     enableMatBudWeightsPi0        = 0,        // 1 = three radial bins, 2 = 10 radial bins (2 is the default when using weights)
+  Bool_t    enableElecDeDxPostCalibration = kFALSE,
   TString   periodNameAnchor              = "",       //
   // special settings
   Bool_t    enableSortingMCLabels         = kTRUE,    // enable sorting for MC cluster labels
@@ -60,6 +61,7 @@ void AddTask_GammaConvCalo_pPb(
   TString fileNamePtWeights           = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FPTW:");
   TString fileNameMultWeights         = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FMUW:");
   TString fileNameMatBudWeights       = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FMAW:");
+  TString fileNamedEdxPostCalib       = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FEPC:");
 
   TString addTaskName                 = "AddTask_GammaConvCalo_pPb";
   TString sAdditionalTrainConfig      = cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "", "", addTaskName);
@@ -2123,6 +2125,20 @@ void AddTask_GammaConvCalo_pPb(
     }
 
     analysisCuts[i]->SetV0ReaderName(V0ReaderName);
+    if (enableElecDeDxPostCalibration){
+      if (isMC == 0){
+        if(fileNamedEdxPostCalib.CompareTo("") != 0){
+          analysisCuts[i]->SetElecDeDxPostCalibrationCustomFile(fileNamedEdxPostCalib);
+          cout << "Setting custom dEdx recalibration file: " << fileNamedEdxPostCalib.Data() << endl;
+        }
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+        cout << "Enabled TPC dEdx recalibration." << endl;
+      } else{
+        cout << "ERROR enableElecDeDxPostCalibration set to True even if MC file. Automatically reset to 0"<< endl;
+        enableElecDeDxPostCalibration=kFALSE;
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(kFALSE);
+      }
+    }
     if (enableLightOutput > 0) analysisCuts[i]->SetLightOutput(kTRUE);
     analysisCuts[i]->InitializeCutsFromCutString((cuts.GetPhotonCut(i)).Data());
     analysisCuts[i]->SetIsHeavyIon(isHeavyIon);

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
@@ -47,6 +47,7 @@ void AddTask_GammaConvCalo_pp(
   TString   generatorName                 = "DPMJET", // generator Name
   Bool_t    enableMultiplicityWeighting   = kFALSE,   //
   Int_t     enableMatBudWeightsPi0        = 0,        // 1 = three radial bins, 2 = 10 radial bins (2 is the default when using weights)
+  Bool_t    enableElecDeDxPostCalibration = kFALSE,
   TString   periodNameAnchor              = "",       //
   // special settings
   Bool_t    enableSortingMCLabels         = kTRUE,    // enable sorting for MC cluster labels
@@ -65,6 +66,7 @@ void AddTask_GammaConvCalo_pp(
   TString fileNamePtWeights     = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FPTW:");
   TString fileNameMultWeights   = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FMUW:");
   TString fileNameMatBudWeights = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FMAW:");
+  TString fileNamedEdxPostCalib = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FEPC:");
 
   TString addTaskName                 = "AddTask_GammaConvCalo_pp";
   TString sAdditionalTrainConfig      = cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "", "", addTaskName);
@@ -1950,6 +1952,20 @@ void AddTask_GammaConvCalo_pp(
     }
 
     analysisCuts[i]->SetV0ReaderName(V0ReaderName);
+    if (enableElecDeDxPostCalibration){
+      if (isMC == 0){
+        if(fileNamedEdxPostCalib.CompareTo("") != 0){
+          analysisCuts[i]->SetElecDeDxPostCalibrationCustomFile(fileNamedEdxPostCalib);
+          cout << "Setting custom dEdx recalibration file: " << fileNamedEdxPostCalib.Data() << endl;
+        }
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+        cout << "Enabled TPC dEdx recalibration." << endl;
+      } else{
+        cout << "ERROR enableElecDeDxPostCalibration set to True even if MC file. Automatically reset to 0"<< endl;
+        enableElecDeDxPostCalibration=kFALSE;
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(kFALSE);
+      }
+    }
     if (enableLightOutput > 0 && enableLightOutput < 3) analysisCuts[i]->SetLightOutput(kTRUE);
     analysisCuts[i]->InitializeCutsFromCutString((cuts.GetPhotonCut(i)).Data());
     analysisCuts[i]->SetIsHeavyIon(isHeavyIon);

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_PbPb.C
@@ -3381,6 +3381,20 @@ void AddTask_GammaConvV1_PbPb(
     analysisCuts[i]->SetIsHeavyIon(isHeavyIon);
     analysisCuts[i]->SetV0ReaderName(V0ReaderName);
     analysisCuts[i]->SetLightOutput(enableLightOutput);
+    if (enableElecDeDxPostCalibration){
+      if (isMC == 0){
+        if(fileNamedEdxPostCalib.CompareTo("") != 0){
+          analysisCuts[i]->SetElecDeDxPostCalibrationCustomFile(fileNamedEdxPostCalib);
+          cout << "Setting custom dEdx recalibration file: " << fileNamedEdxPostCalib.Data() << endl;
+        }
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+        cout << "Enabled TPC dEdx recalibration." << endl;
+      } else{
+        cout << "ERROR enableElecDeDxPostCalibration set to True even if MC file. Automatically reset to 0"<< endl;
+        enableElecDeDxPostCalibration=kFALSE;
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(kFALSE);
+      }
+    }
     analysisCuts[i]->InitializeCutsFromCutString((cuts.GetPhotonCut(i)).Data());
 
     ConvCutList->Add(analysisCuts[i]);

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pPb.C
@@ -1257,18 +1257,18 @@ void AddTask_GammaConvV1_pPb(
         else {cout << "ERROR The initialization of the materialBudgetWeights did not work out." << endl;}
       } else {cout << "ERROR 'enableMatBudWeightsPi0'-flag was set > 0 even though this is not a MC task. It was automatically reset to 0." << endl;}
     }
-    if (enableElecDeDxPostCalibration>0){
+    if (enableElecDeDxPostCalibration){
       if (isMC == 0){
-        if( analysisCuts[i]->InitializeElecDeDxPostCalibration(fileNamedEdxPostCalib)){
-          analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
-        } else {
-          enableElecDeDxPostCalibration=kFALSE;
-          analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+        if(fileNamedEdxPostCalib.CompareTo("") != 0){
+          analysisCuts[i]->SetElecDeDxPostCalibrationCustomFile(fileNamedEdxPostCalib);
+          cout << "Setting custom dEdx recalibration file: " << fileNamedEdxPostCalib.Data() << endl;
         }
-            } else{
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+        cout << "Enabled TPC dEdx recalibration." << endl;
+      } else{
         cout << "ERROR enableElecDeDxPostCalibration set to True even if MC file. Automatically reset to 0"<< endl;
         enableElecDeDxPostCalibration=kFALSE;
-        analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(kFALSE);
       }
     }
     analysisCuts[i]->SetV0ReaderName(V0ReaderName);

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvV1_pp.C
@@ -1599,18 +1599,18 @@ if(!cuts.AreValid()){
         }
         else {cout << "ERROR 'enableMatBudWeightsPi0'-flag was set > 0 even though this is not a MC task. It was automatically reset to 0." << endl;}
     }
-    if (enableElecDeDxPostCalibration>0){
+    if (enableElecDeDxPostCalibration){
       if (isMC == 0){
-        if( analysisCuts[i]->InitializeElecDeDxPostCalibration(fileNamedEdxPostCalib)){
-          analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
-        } else {
-          enableElecDeDxPostCalibration=kFALSE;
-          analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+        if(fileNamedEdxPostCalib.CompareTo("") != 0){
+          analysisCuts[i]->SetElecDeDxPostCalibrationCustomFile(fileNamedEdxPostCalib);
+          cout << "Setting custom dEdx recalibration file: " << fileNamedEdxPostCalib.Data() << endl;
         }
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+        cout << "Enabled TPC dEdx recalibration." << endl;
       } else{
         cout << "ERROR enableElecDeDxPostCalibration set to True even if MC file. Automatically reset to 0"<< endl;
         enableElecDeDxPostCalibration=kFALSE;
-        analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(kFALSE);
       }
     }
 

--- a/PWGGA/GammaConv/macros/AddTask_GammaHeavyMeson_ConvMode_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaHeavyMeson_ConvMode_pPb.C
@@ -245,6 +245,20 @@ void AddTask_GammaHeavyMeson_ConvMode_pPb(
 
     analysisCuts[i] = new AliConversionPhotonCuts();
     analysisCuts[i]->SetV0ReaderName(V0ReaderName);
+    if (enableElecDeDxPostCalibration){
+      if (isMC == 0){
+        if(fileNamedEdxPostCalib.CompareTo("") != 0){
+          analysisCuts[i]->SetElecDeDxPostCalibrationCustomFile(fileNamedEdxPostCalib);
+          cout << "Setting custom dEdx recalibration file: " << fileNamedEdxPostCalib.Data() << endl;
+        }
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+        cout << "Enabled TPC dEdx recalibration." << endl;
+      } else{
+        cout << "ERROR enableElecDeDxPostCalibration set to True even if MC file. Automatically reset to 0"<< endl;
+        enableElecDeDxPostCalibration=kFALSE;
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(kFALSE);
+      }
+    }
     if (enableLightOutput > 0) analysisCuts[i]->SetLightOutput(kTRUE);
     analysisCuts[i]->InitializeCutsFromCutString((cuts.GetPhotonCut(i)).Data());
     analysisCuts[i]->SetIsHeavyIon(isHeavyIon);

--- a/PWGGA/GammaConv/macros/AddTask_GammaHeavyMeson_ConvMode_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaHeavyMeson_ConvMode_pp.C
@@ -401,6 +401,20 @@ void AddTask_GammaHeavyMeson_ConvMode_pp(
     analysisCuts[i]->SetV0ReaderName(V0ReaderName);
     if (enableLightOutput > 0) analysisCuts[i]->SetLightOutput(kTRUE);
     analysisCuts[i]->InitializeCutsFromCutString((cuts.GetPhotonCut(i)).Data());
+    if (enableElecDeDxPostCalibration){
+      if (isMC == 0){
+        if(fileNamedEdxPostCalib.CompareTo("") != 0){
+          analysisCuts[i]->SetElecDeDxPostCalibrationCustomFile(fileNamedEdxPostCalib);
+          cout << "Setting custom dEdx recalibration file: " << fileNamedEdxPostCalib.Data() << endl;
+        }
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+        cout << "Enabled TPC dEdx recalibration." << endl;
+      } else{
+        cout << "ERROR enableElecDeDxPostCalibration set to True even if MC file. Automatically reset to 0"<< endl;
+        enableElecDeDxPostCalibration=kFALSE;
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(kFALSE);
+      }
+    }
     analysisCuts[i]->SetIsHeavyIon(isHeavyIon);
     ConvCutList->Add(analysisCuts[i]);
     analysisCuts[i]->SetFillCutHistograms("",kFALSE);

--- a/PWGGA/GammaConv/macros/AddTask_GammaHeavyMeson_MixedMode_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaHeavyMeson_MixedMode_pPb.C
@@ -45,6 +45,7 @@ void AddTask_GammaHeavyMeson_MixedMode_pPb(
   Int_t     doWeightingPart               = 0,        // enable Weighting
   TString   generatorName                 = "DPMJET", // generator Name
   Bool_t    enableMultiplicityWeighting   = kFALSE,   //
+  Bool_t    enableElecDeDxPostCalibration = kFALSE,
   TString   periodNameAnchor              = "",       //
   // special settings
   Bool_t    enableSortingMCLabels         = kTRUE,    // enable sorting for MC cluster labels
@@ -57,6 +58,7 @@ void AddTask_GammaHeavyMeson_MixedMode_pPb(
 
   TString fileNamePtWeights           = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FPTW:");
   TString fileNameMultWeights         = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FMUW:");
+  TString fileNamedEdxPostCalib       = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FEPC:");
 
   TString addTaskName                 = "AddTask_GammaHeavyMeson_MixedMode_pPb";
   TString sAdditionalTrainConfig      = cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "", "", addTaskName);
@@ -321,6 +323,20 @@ void AddTask_GammaHeavyMeson_MixedMode_pPb(
 
     analysisCuts[i] = new AliConversionPhotonCuts();
     analysisCuts[i]->SetV0ReaderName(V0ReaderName);
+    if (enableElecDeDxPostCalibration){
+      if (isMC == 0){
+        if(fileNamedEdxPostCalib.CompareTo("") != 0){
+          analysisCuts[i]->SetElecDeDxPostCalibrationCustomFile(fileNamedEdxPostCalib);
+          cout << "Setting custom dEdx recalibration file: " << fileNamedEdxPostCalib.Data() << endl;
+        }
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+        cout << "Enabled TPC dEdx recalibration." << endl;
+      } else{
+        cout << "ERROR enableElecDeDxPostCalibration set to True even if MC file. Automatically reset to 0"<< endl;
+        enableElecDeDxPostCalibration=kFALSE;
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(kFALSE);
+      }
+    }
     if (enableLightOutput > 0) analysisCuts[i]->SetLightOutput(kTRUE);
     analysisCuts[i]->InitializeCutsFromCutString((cuts.GetPhotonCut(i)).Data());
     analysisCuts[i]->SetIsHeavyIon(isHeavyIon);

--- a/PWGGA/GammaConv/macros/AddTask_GammaHeavyMeson_MixedMode_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaHeavyMeson_MixedMode_pp.C
@@ -45,6 +45,7 @@ void AddTask_GammaHeavyMeson_MixedMode_pp(
   Int_t     doWeightingPart               = 0,        // enable Weighting
   TString   generatorName                 = "DPMJET", // generator Name
   Bool_t    enableMultiplicityWeighting   = kFALSE,   //
+  Bool_t    enableElecDeDxPostCalibration = kFALSE,
   TString   periodNameAnchor              = "",       //
   // special settings
   Bool_t    enableSortingMCLabels         = kTRUE,    // enable sorting for MC cluster labels
@@ -62,6 +63,7 @@ void AddTask_GammaHeavyMeson_MixedMode_pp(
 
   TString fileNamePtWeights           = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FPTW:");
   TString fileNameMultWeights         = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FMUW:");
+  TString fileNamedEdxPostCalib       = cuts.GetSpecialFileNameFromString (fileNameExternalInputs, "FEPC:");
 
   TString addTaskName                 = "AddTask_GammaHeavyMeson_MixedMode_pp";
   TString sAdditionalTrainConfig      = cuts.GetSpecialSettingFromAddConfig(additionalTrainConfig, "", "", addTaskName);
@@ -515,6 +517,20 @@ void AddTask_GammaHeavyMeson_MixedMode_pp(
 
     analysisCuts[i] = new AliConversionPhotonCuts();
     analysisCuts[i]->SetV0ReaderName(V0ReaderName);
+    if (enableElecDeDxPostCalibration){
+      if (isMC == 0){
+        if(fileNamedEdxPostCalib.CompareTo("") != 0){
+          analysisCuts[i]->SetElecDeDxPostCalibrationCustomFile(fileNamedEdxPostCalib);
+          cout << "Setting custom dEdx recalibration file: " << fileNamedEdxPostCalib.Data() << endl;
+        }
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+        cout << "Enabled TPC dEdx recalibration." << endl;
+      } else{
+        cout << "ERROR enableElecDeDxPostCalibration set to True even if MC file. Automatically reset to 0"<< endl;
+        enableElecDeDxPostCalibration=kFALSE;
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(kFALSE);
+      }
+    }
     if (enableLightOutput > 0) analysisCuts[i]->SetLightOutput(kTRUE);
     analysisCuts[i]->InitializeCutsFromCutString((cuts.GetPhotonCut(i)).Data());
     analysisCuts[i]->SetIsHeavyIon(isHeavyIon);

--- a/PWGGA/GammaConv/macros/AddTask_MaterialHistos_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_MaterialHistos_pPb.C
@@ -254,25 +254,18 @@ void AddTask_MaterialHistos_pPb(
     analysisEventCuts[i]->SetFillCutHistograms("", kTRUE);
 
     analysisCuts[i] = new AliConversionPhotonCuts();
-    if (enableElecDeDxPostCalibration > 0)
-    {
-      if (isMC == 0)
-      {
-        if (analysisCuts[i]->InitializeElecDeDxPostCalibration(fileNameElecDeDxPostCalibration))
-        {
-          analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+    if (enableElecDeDxPostCalibration){
+      if (isMC == 0){
+        if(fileNamedEdxPostCalib.CompareTo("") != 0){
+          analysisCuts[i]->SetElecDeDxPostCalibrationCustomFile(fileNamedEdxPostCalib);
+          cout << "Setting custom dEdx recalibration file: " << fileNamedEdxPostCalib.Data() << endl;
         }
-        else
-        {
-          enableElecDeDxPostCalibration = kFALSE;
-          analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
-        }
-      }
-      else
-      {
-        cout << "ERROR enableElecDeDxPostCalibration set to True even if MC file. Automatically reset to 0" << endl;
-        enableElecDeDxPostCalibration = kFALSE;
         analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+        cout << "Enabled TPC dEdx recalibration." << endl;
+      } else{
+        cout << "ERROR enableElecDeDxPostCalibration set to True even if MC file. Automatically reset to 0"<< endl;
+        enableElecDeDxPostCalibration=kFALSE;
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(kFALSE);
       }
     }
 

--- a/PWGGA/GammaConv/macros/AddTask_MaterialHistos_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_MaterialHistos_pp.C
@@ -371,19 +371,18 @@ void AddTask_MaterialHistos_pp( Int_t   trainConfig             = 1,            
     analysisEventCuts[i]->SetFillCutHistograms("",kTRUE);
 
     analysisCuts[i]               = new AliConversionPhotonCuts();
-    if (enableElecDeDxPostCalibration>0){
+    if (enableElecDeDxPostCalibration){
       if (isMC == 0){
-	if( analysisCuts[i]->InitializeElecDeDxPostCalibration(fileNamedEdxPostCalib)){
-	  analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
-	} else {
-	  enableElecDeDxPostCalibration=kFALSE;
-	  analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
-	}
-
+        if(fileNamedEdxPostCalib.CompareTo("") != 0){
+          analysisCuts[i]->SetElecDeDxPostCalibrationCustomFile(fileNamedEdxPostCalib);
+          cout << "Setting custom dEdx recalibration file: " << fileNamedEdxPostCalib.Data() << endl;
+        }
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+        cout << "Enabled TPC dEdx recalibration." << endl;
       } else{
-	cout << "ERROR enableElecDeDxPostCalibration set to True even if MC file. Automatically reset to 0"<< endl;
-	enableElecDeDxPostCalibration=kFALSE;
-	analysisCuts[i]->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+        cout << "ERROR enableElecDeDxPostCalibration set to True even if MC file. Automatically reset to 0"<< endl;
+        enableElecDeDxPostCalibration=kFALSE;
+        analysisCuts[i]->SetDoElecDeDxPostCalibration(kFALSE);
       }
     }
 

--- a/PWGGA/GammaConv/macros/AddTask_PhotonQA.C
+++ b/PWGGA/GammaConv/macros/AddTask_PhotonQA.C
@@ -51,18 +51,18 @@ void AddTask_PhotonQA(
 
   AliConversionPhotonCuts *analysisCuts = new AliConversionPhotonCuts();
   analysisCuts->SetV0ReaderName(V0ReaderName);
-  if (enableElecDeDxPostCalibration>0){
+  if (enableElecDeDxPostCalibration){
     if (isMC == 0){
-      if( analysisCuts->InitializeElecDeDxPostCalibration(fileNamedEdxPostCalib)){
-        analysisCuts->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
-      } else {
-        enableElecDeDxPostCalibration=kFALSE;
-        analysisCuts->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
-      }
+      if(fileNamedEdxPostCalib.CompareTo("") != 0){
+        analysisCuts->SetElecDeDxPostCalibrationCustomFile(fileNamedEdxPostCalib);
+        cout << "Setting custom dEdx recalibration file: " << fileNamedEdxPostCalib.Data() << endl;
+     }
+      analysisCuts->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+      cout << "Enabled TPC dEdx recalibration." << endl;
     } else{
       cout << "ERROR enableElecDeDxPostCalibration set to True even if MC file. Automatically reset to 0"<< endl;
       enableElecDeDxPostCalibration=kFALSE;
-      analysisCuts->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
+      analysisCuts->SetDoElecDeDxPostCalibration(kFALSE);
     }
   }
   analysisCuts->InitializeCutsFromCutString(TaskPhotonCutnumber.Data());
@@ -73,7 +73,6 @@ void AddTask_PhotonQA(
   fQA->SetConversionCuts(analysisCuts,IsHeavyIon);
   fQA->FillType(kTree,kHistograms);
   fQA->SetIsMC(isMC);
-  fQA->SetDoElecDeDxPostCalibration(enableElecDeDxPostCalibration);
   fQA->SetV0ReaderName(V0ReaderName);
   mgr->AddTask(fQA);
 

--- a/PWGGA/GammaConvBase/AliConversionPhotonCuts.h
+++ b/PWGGA/GammaConvBase/AliConversionPhotonCuts.h
@@ -258,8 +258,9 @@ class AliConversionPhotonCuts : public AliAnalysisCuts {
 
     Int_t GetV0FinderSameSign(){return fUseOnFlyV0FinderSameSign;}
     Bool_t GetUseBDTPhotonCuts(){return fUseBDTPhotonCuts;}
-    Bool_t GetElecDeDxPostCalibrationInitialized() {return fElecDeDxPostCalibrationInitialized;}
-    Bool_t  InitializeElecDeDxPostCalibration(TString filename);
+    Int_t GetDoElecDeDxPostCalibration() {return fDoElecDeDxPostCalibration;}
+    void  SetElecDeDxPostCalibrationCustomFile(TString filename){fFileNameElecDeDxPostCalibration = filename; return;};
+    Bool_t  LoadElecDeDxPostCalibration(Int_t runNumber);
     Double_t GetCorrectedElectronTPCResponse(Short_t charge,Double_t nsig,Double_t P,Double_t Eta,Double_t R);
 
 
@@ -280,14 +281,6 @@ class AliConversionPhotonCuts : public AliAnalysisCuts {
     Float_t           fMinPhiCut;                           ///< phi sector cut
     Float_t           fMaxPhiCut;                           ///< phi sector cut
     Int_t             fDoShrinkTPCAcceptance;               ///< Flag for shrinking the TPC acceptance due to different reasons
-    Double_t          fGoodRegionCMin;                      ///< regions WITHOUT strong space charge distortions on C side
-    Double_t          fGoodRegionCMax;                      ///<
-    Double_t          fGoodRegionAMin;                      ///<
-    Double_t          fGoodRegionAMax;                      ///<
-    Double_t          fBadRegionCMin;                       ///< regions WITH strong space charge distortions on C side
-    Double_t          fBadRegionCMax;                       ///<
-    Double_t          fBadRegionAMin;                       ///<
-    Double_t          fBadRegionAMax;                       ///<
     Double_t          fPtCut;                               ///< pt cut
     Double_t          fSinglePtCut;                         ///< pt cut for electron/positron
     Double_t          fSinglePtCut2;                        ///< second pt cut for electron/positron if asymmetric cut is chosen
@@ -411,16 +404,25 @@ class AliConversionPhotonCuts : public AliAnalysisCuts {
     Bool_t            fProcessAODCheck;                     ///< Flag for processing check for AOD to be contained in AliAODs.root and AliAODGammaConversion.root
     Bool_t            fMaterialBudgetWeightsInitialized;    ///< weights for conversions photons due due deviating material budget in MC compared to data
     TProfile*         fProfileContainingMaterialBudgetWeights;
-    Bool_t            fElecDeDxPostCalibrationInitialized;  ///< flag to check that initialization worked  
+    TString           fFileNameElecDeDxPostCalibration;     ///< name of recalibration file (if no special non-OADB is required)
+    Int_t             fRecalibCurrentRun;                   ///< runnumber for correct loading of recalib from OADB
     Int_t             fnRBins;                              //
     TH2F**            fHistoEleMapMean;  //[fnRBins]
     TH2F**            fHistoEleMapWidth; //[fnRBins] 
     TH2F**            fHistoPosMapMean;  //[fnRBins] 
     TH2F**            fHistoPosMapWidth; //[fnRBins] 
+    Double_t          fGoodRegionCMin;                      ///< regions WITHOUT strong space charge distortions on C side
+    Double_t          fGoodRegionAMin;                      ///<
+    Double_t          fBadRegionCMin;                       ///< regions WITH strong space charge distortions on C side
+    Double_t          fBadRegionAMin;                       ///<
+    Double_t          fGoodRegionCMax;                      ///<
+    Double_t          fGoodRegionAMax;                      ///<
+    Double_t          fBadRegionCMax;                       ///<
+    Double_t          fBadRegionAMax;                       ///<
 
   private:
     /// \cond CLASSIMP
-    ClassDef(AliConversionPhotonCuts,24)
+    ClassDef(AliConversionPhotonCuts,25)
     /// \endcond
 };
 


### PR DESCRIPTION
By using "enableElecDeDxPostCalibration = kTRUE" and not setting a dEdx recalib file name one can now acess the OADB file stored in OADB/PWGGA which contains period-dependent recalibrations.
If one also sets a filename, then the recalibration parameters will be loaded from the file instead of the OADB (this is the old standard procedure).