### PR TITLE
PWG/EMCAL: Added improved high energy nonlinearity parametrizations (kBeamTestNS,kPi0MCNS)

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
@@ -938,6 +938,24 @@ Float_t AliEMCALRecoUtils::CorrectClusterEnergyLinearity(AliVCluster* cluster)
       
       break;
     }
+    case kBeamTestNS:
+    {
+      // New parametrization of testbeam data points, 
+      // includes also points for E>100 GeV.
+      // See EMCal meeting 07/12/2018 slides
+      // https://indico.cern.ch/event/761682/contributions/3245317/attachments/1767706/2870846/2018_12_pp5TeV_NonlinearityStudies_update.pdf
+      
+//      fNonLinearityParams[0] = 0.986154;
+//      fNonLinearityParams[1] = 0.214860;
+//      fNonLinearityParams[2] = 0.717724;
+//      fNonLinearityParams[3] = 0.069200;
+//      fNonLinearityParams[4] = 155.497605;
+//      fNonLinearityParams[5] = 48.868069;
+//      fNonLinearityParams[6] = 0.972947;
+      energy *= fNonLinearityParams[6]/(fNonLinearityParams[0]*(1./(1.+fNonLinearityParams[1]*exp(-energy/fNonLinearityParams[2]))*1./(1.+fNonLinearityParams[3]*exp((energy-fNonLinearityParams[4])/fNonLinearityParams[5]))));
+      
+      break;
+    }
       
     case kSDMv5:
     {
@@ -998,6 +1016,24 @@ Float_t AliEMCALRecoUtils::CorrectClusterEnergyLinearity(AliVCluster* cluster)
       //fNonLinearityParams[4] =  244.586;
       //fNonLinearityParams[5] =  116.938;
       //fNonLinearityParams[6] =  1.00437;
+      energy *= fNonLinearityParams[6]/(fNonLinearityParams[0]*(1./(1.+fNonLinearityParams[1]*exp(-energy/fNonLinearityParams[2]))*1./(1.+fNonLinearityParams[3]*exp((energy-fNonLinearityParams[4])/fNonLinearityParams[5]))));
+      
+      break;
+    }
+      
+    case kPi0MCNS:
+    {
+      // New parametrization of testbeam MC points,
+      // includes also points for E>100 GeV.
+      // See EMCal meeting 07/12/2018 slides
+      // https://indico.cern.ch/event/761682/contributions/3245317/attachments/1767706/2870846/2018_12_pp5TeV_NonlinearityStudies_update.pdf
+      //fNonLinearityParams[0] =  1.009121;
+      //fNonLinearityParams[1] =  0.083153;
+      //fNonLinearityParams[2] =  1.444362;
+      //fNonLinearityParams[3] =  0.100294;
+      //fNonLinearityParams[4] =  416.897753;
+      //fNonLinearityParams[5] =  324.246101;
+      //fNonLinearityParams[6] =  1.004055;
       energy *= fNonLinearityParams[6]/(fNonLinearityParams[0]*(1./(1.+fNonLinearityParams[1]*exp(-energy/fNonLinearityParams[2]))*1./(1.+fNonLinearityParams[3]*exp((energy-fNonLinearityParams[4])/fNonLinearityParams[5]))));
       
       break;
@@ -1185,6 +1221,22 @@ void AliEMCALRecoUtils::InitNonLinearityParam()
     fNonLinearityParams[5] = 47.18;
     fNonLinearityParams[6] = 0.97;
   }
+
+  if (fNonLinearityFunction == kBeamTestNS) {
+    
+    // New parametrization of testbeam data points, 
+    // includes also points for E>100 GeV.
+    // See EMCal meeting 07/12/2018 slides
+    // https://indico.cern.ch/event/761682/contributions/3245317/attachments/1767706/2870846/2018_12_pp5TeV_NonlinearityStudies_update.pdf
+    
+     fNonLinearityParams[0] = 0.986154;
+     fNonLinearityParams[1] = 0.214860;
+     fNonLinearityParams[2] = 0.717724;
+     fNonLinearityParams[3] = 0.069200;
+     fNonLinearityParams[4] = 155.497605;
+     fNonLinearityParams[5] = 48.868069;
+     fNonLinearityParams[6] = 0.972947;
+  }
   
   if (fNonLinearityFunction == kSDMv5) {
     fNonLinearityParams[0] =  1.0;
@@ -1224,6 +1276,16 @@ void AliEMCALRecoUtils::InitNonLinearityParam()
     fNonLinearityParams[4] = 244.586;   
     fNonLinearityParams[5] = 116.938;   
     fNonLinearityParams[6] = 1.00437;   
+  }
+
+  if (fNonLinearityFunction == kPi0MCNS) {
+    fNonLinearityParams[0] =  1.009121;
+    fNonLinearityParams[1] =  0.083153;
+    fNonLinearityParams[2] =  1.444362;
+    fNonLinearityParams[3] =  0.100294;
+    fNonLinearityParams[4] =  416.897753;
+    fNonLinearityParams[5] =  324.246101;
+    fNonLinearityParams[6] =  1.004055;
   }
 
 if (fNonLinearityFunction == kPCMv1) {

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -84,7 +84,9 @@ public:
     kPCMv1 = 14,               // pure symmetric decay muon method 
     kPCMplusBTCv1 = 15,        // kPCMv1 convoluted with kBeamTestCorrectedv3
     kPCMsysv1 = 16,            // variation of kPCMv1 to calculate systematics
-    kBeamTestCorrectedv4 = 17  // Different parametrization of v3 but similar, improve E>100 GeV linearity
+    kBeamTestCorrectedv4 = 17, // Different parametrization of v3 but similar, improve E>100 GeV linearity
+    kBeamTestNS = 18,          // Custom fit of all avail. TB points and E>100 GeV data
+    kPi0MCNS = 19              // Custom fit of all avail. TB points and E>100 GeV MC
   };
 
   /// Cluster position enum list of possible algoritms
@@ -559,7 +561,7 @@ private:
   Bool_t     fMCGenerToAcceptForTrack;   ///<  Activate the removal of tracks entering the track matching that come from a particular generator
   
   /// \cond CLASSIMP
-  ClassDef(AliEMCALRecoUtils, 28) ;
+  ClassDef(AliEMCALRecoUtils, 29) ;
   /// \endcond
 
 };

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterNonLinearity.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterNonLinearity.cxx
@@ -32,7 +32,9 @@ const std::map <std::string, AliEMCALRecoUtils::NonlinearityFunctions> AliEmcalC
     { "kPCMv1", AliEMCALRecoUtils::kPCMv1 },
     { "kPCMplusBTCv1", AliEMCALRecoUtils::kPCMplusBTCv1 },
     { "kPCMsysv1", AliEMCALRecoUtils::kPCMsysv1 },
-    { "kBeamTestCorrectedv4", AliEMCALRecoUtils::kBeamTestCorrectedv4 }
+    { "kBeamTestCorrectedv4", AliEMCALRecoUtils::kBeamTestCorrectedv4 },
+    { "kBeamTestNS", AliEMCALRecoUtils::kBeamTestNS },
+    { "kPi0MCNS", AliEMCALRecoUtils::kPi0MCNS }
 };
 
 /**

--- a/PWGGA/GammaConvBase/AliV0ReaderV1.cxx
+++ b/PWGGA/GammaConvBase/AliV0ReaderV1.cxx
@@ -570,8 +570,11 @@ Bool_t AliV0ReaderV1::Notify(){
         fEventCuts->GetPeriodEnum() == AliConvEventCuts::kLHC16c3c  ||
         fEventCuts->GetPeriodEnum() == AliConvEventCuts::kLHC16rP1JJ  || fEventCuts->GetPeriodEnum() == AliConvEventCuts::kLHC16sP1JJ  ||
         fEventCuts->GetPeriodEnum() == AliConvEventCuts::kLHC16P1JJ || fEventCuts->GetPeriodEnum() == AliConvEventCuts::kLHC16P1JJLowB ||
+        fEventCuts->GetPeriodEnum() == AliConvEventCuts::kLHC17P1JJ || fEventCuts->GetPeriodEnum() == AliConvEventCuts::kLHC17P1JJLowB ||
+        fEventCuts->GetPeriodEnum() == AliConvEventCuts::kLHC18P1JJ ||
         fEventCuts->GetPeriodEnum() == AliConvEventCuts::kLHC18b8 || fEventCuts->GetPeriodEnum() == AliConvEventCuts::kLHC18b10 ||
-        fEventCuts->GetPeriodEnum() == AliConvEventCuts::kLHC18l6b1 || fEventCuts->GetPeriodEnum() == AliConvEventCuts::kLHC18l6c1 
+        fEventCuts->GetPeriodEnum() == AliConvEventCuts::kLHC19a4 ||
+        fEventCuts->GetPeriodEnum() == AliConvEventCuts::kLHC18l6b1 || fEventCuts->GetPeriodEnum() == AliConvEventCuts::kLHC18l6c1
      ){
         TObjArray *arr = fCurrentFileName.Tokenize("/");
         fPtHardBin = -1;


### PR DESCRIPTION
[nonlin_Evi_Nico_NewhotonPoints.pdf](https://github.com/alisw/AliPhysics/files/3252080/nonlin_Evi_Nico_NewhotonPoints.pdf)
The new parametrizations correspond to the blue (kBeamTestNS) and the green (kPi0MCNS) curves in the attached plot. The most important difference to the existing nonlinearity parametrizations is the strongly reduced drop of the MC parametrization.