### PR TITLE
PWGUD/UPC: Helicity update: two 1D aanlysis for CosTheta and Phi for Signal Ex.

### DIFF
--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
@@ -204,7 +204,16 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward()
       fInvariantMassDistributionInBinsOfCosThetaHelicityFrameH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
       fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH(0),
       fCosThetaAndPhiHelicityFrameInclusivePeopleBinningH(0),
-      fInvariantMassDistributionForSignalExtractionHelicityFrameH(0)
+      fInvariantMassDistributionForSignalExtractionHelicityFrameH(0),
+      fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                               0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                               0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                               0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+      fInvariantMassDistributionOnlyPhiForSignalExtractionHelicityFrameH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
 {
     // default constructor, don't allocate memory here!
     // this is used by root for IO purposes, it needs to remain empty
@@ -340,7 +349,16 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward(const char* name)
       fInvariantMassDistributionInBinsOfCosThetaHelicityFrameH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
       fInvariantMassDistributionBinsOfCosThetaAndPhiHelicityFrameH(0),
       fCosThetaAndPhiHelicityFrameInclusivePeopleBinningH(0),
-      fInvariantMassDistributionForSignalExtractionHelicityFrameH(0)
+      fInvariantMassDistributionForSignalExtractionHelicityFrameH(0),
+      fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                               0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                               0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                               0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+      fInvariantMassDistributionOnlyPhiForSignalExtractionHelicityFrameH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
 {
     // FillGoodRunVector(fVectorGoodRunNumbers);
 
@@ -933,6 +951,25 @@ void AliAnalysisTaskUPCforward::UserCreateOutputObjects()
       fOutputList->Add(fInvariantMassDistributionForSignalExtractionHelicityFrameH[iCosTheta][iPhi]);
     }
   }
+
+  for(Int_t iCosThetaBins = 0; iCosThetaBins < 40; iCosThetaBins++ ){
+    fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameH[iCosThetaBins] = new TH1F(
+                Form("fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameH_%d", iCosThetaBins),
+                Form("fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameH_%d", iCosThetaBins),
+                2000, 0, 20
+                );
+    fOutputList->Add(fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameH[iCosThetaBins]);
+  }
+
+  for(Int_t iPhiBins = 0; iPhiBins < 50; iPhiBins++ ){
+    fInvariantMassDistributionOnlyPhiForSignalExtractionHelicityFrameH[iPhiBins] = new TH1F(
+                Form("fInvariantMassDistributionOnlyPhiForSignalExtractionHelicityFrameH_%d", iPhiBins),
+                Form("fInvariantMassDistributionOnlyPhiForSignalExtractionHelicityFrameH_%d", iPhiBins),
+                2000, 0, 20
+                );
+    fOutputList->Add(fInvariantMassDistributionOnlyPhiForSignalExtractionHelicityFrameH[iPhiBins]);
+  }
+
   // for( Int_t iCosTheta = 0; iCosTheta < 10; iCosTheta++ ){
   //   std::vector<TH1F> auxiliaryVector;
   //   for( Int_t iPhi = 0; iPhi < 10; iPhi++ ){
@@ -1941,6 +1978,33 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
           }
         }
   }
+
+  /* - NEW:
+     -
+   */
+  Bool_t controlFlag2 = 0;
+  Bool_t controlFlag3 = 0;
+  if ( possibleJPsiCopy.Pt() < 0.25 ) {
+        Double_t CosThetaHelicityFrameValue = CosThetaHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
+        Double_t PhiHelicityFrameValue      =   CosPhiHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
+        for(Int_t iCosThetaBins = 0; iCosThetaBins < 40; iCosThetaBins++) {
+          if( controlFlag2 == 1) break;
+          if( (CosThetaHelicityFrameValue + 1.) < 2.*((Double_t)iCosThetaBins + 1.)/40. ){
+              fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameH[iCosThetaBins]->Fill(possibleJPsiCopyMag);
+              controlFlag2 = 1;
+          }
+        }
+        for(Int_t iPhiBins = 0; iPhiBins < 50; iPhiBins++) {
+          if( controlFlag3 == 1) break;
+          if( (PhiHelicityFrameValue + 3.14) < 6.28*((Double_t)iPhiBins + 1.)/50. ){
+              fInvariantMassDistributionOnlyPhiForSignalExtractionHelicityFrameH[iPhiBins]->Fill(possibleJPsiCopyMag);
+              controlFlag3 = 1;
+          }
+        }
+
+  }
+
+
 
   if ( (possibleJPsiCopy.Mag() > 2.8) && (possibleJPsiCopy.Mag() < 3.3) && (possibleJPsiCopy.Pt() < 0.25) ) {
     fAngularDistribOfPositiveMuonRestFrameJPsiH->Fill(cosThetaMuonsRestFrame[0]);

--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.h
@@ -1055,31 +1055,55 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  */
         TH1F***                 fInvariantMassDistributionForSignalExtractionHelicityFrameH;  //!
 
-        //                         /**
-        //                          * This histogram shows the invariant mass
-        //                          * distribution of the dimuon pairs in terms
-        //                          * of bins of cos theta of the positive muon
-        //                          * in the helicity frame of the J/Psi.
-        //                          *
-        //                          * What it means is that we divide in 5 bins of
-        //                          * possible CosTheta of the decaying J/Psi,
-        //                          * meaning  (-1,-0.8), (-0.8,-0.6), (-0.6,-0.4),
-        //                          * (-0.4,-0.2) and so on until (0.8,1). We fill
-        //                          * the invariant mass distribution of the
-        //                          * dimuons in this many bins.
-        //                          *
-        //                          * The next step is to fit this invariant mass
-        //                          * distributions, so as to obtain the relative
-        //                          * contribution of J/Psi and GammaGamma to the
-        //                          * angular distributions. This should help in
-        //                          * validating our results...
-        //                          *
-        //                          * NEW: the mass range has been extended.
-        //                          * Meaning there are no bounds on the invariant
-        //                          * mass range BEFORE signal extraction.
-        //                          */
-        // MatrixTH1F              fInvariantMassDistributionForSignalExtractionHelicityFrameH;  //!
+                            /**
+                             * This histogram shows the invariant mass
+                             * distribution of the dimuon pairs in terms
+                             * of bins of cos theta of the positive muon
+                             * in the helicity frame of the J/Psi.
+                             *
+                             * What it means is that we divide in 40 bins of
+                             * possible CosTheta of the decaying J/Psi,
+                             * meaning  (-1,-0.8), (-0.8,-0.6), (-0.6,-0.4),
+                             * (-0.4,-0.2) and so on until (0.8,1). We fill
+                             * the invariant mass distribution of the
+                             * dimuons in this many bins.
+                             *
+                             * The next step is to fit this invariant mass
+                             * distributions, so as to obtain the relative
+                             * contribution of J/Psi and GammaGamma to the
+                             * angular distributions. This should help in
+                             * validating our results...
+                             *
+                             * NEW: the mass range has been extended.
+                             * Meaning there are no bounds on the invariant
+                             * mass range BEFORE signal extraction.
+                             */
+        TH1F*               fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameH[40];  //!
 
+                            /**
+                             * This histogram shows the invariant mass
+                             * distribution of the dimuon pairs in terms
+                             * of bins of cos theta of the positive muon
+                             * in the helicity frame of the J/Psi.
+                             *
+                             * What it means is that we divide in 40 bins of
+                             * possible CosTheta of the decaying J/Psi,
+                             * meaning  (-1,-0.8), (-0.8,-0.6), (-0.6,-0.4),
+                             * (-0.4,-0.2) and so on until (0.8,1). We fill
+                             * the invariant mass distribution of the
+                             * dimuons in this many bins.
+                             *
+                             * The next step is to fit this invariant mass
+                             * distributions, so as to obtain the relative
+                             * contribution of J/Psi and GammaGamma to the
+                             * angular distributions. This should help in
+                             * validating our results...
+                             *
+                             * NEW: the mass range has been extended.
+                             * Meaning there are no bounds on the invariant
+                             * mass range BEFORE signal extraction.
+                             */
+        TH1F*               fInvariantMassDistributionOnlyPhiForSignalExtractionHelicityFrameH[50];  //!
 
         //_______________________________
         // CUTS
@@ -1141,7 +1165,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforward, 22);
+        ClassDef(AliAnalysisTaskUPCforward, 23);
 };
 
 #endif


### PR DESCRIPTION
Added two arrays of histograms to do Signal Extraction on CosTheta and Phi for J/Psi's polarisation in UPC. This is due to the possible lack of statistics for a full 2D analysis...
IMPORTANT: tested.