### PR TITLE
Extract trigger selection tools to new class

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
@@ -56,13 +56,8 @@ class AliESDInputHandler;
 #include "AliClusterContainer.h"
 #include "AliEmcalList.h"
 #include "AliEventCuts.h"
+#include "AliEmcalStringView.h"
 
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,10,0) 
-#include "RStringView.h"
-#define EMCAL_STRINGVIEW const std::string_view
-#else 
-#define EMCAL_STRINGVIEW const std::string &
-#endif
 
 #include "AliAnalysisTaskSE.h"
 /**

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.h
@@ -36,13 +36,8 @@ class AliAODTrack;
 #include "AliMCParticleContainer.h"
 #include "AliTrackContainer.h"
 #include "AliClusterContainer.h"
+#include "AliEmcalStringView.h"
 
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,10,0) 
-#include "RStringView.h"
-#define EMCAL_STRINGVIEW const std::string_view
-#else 
-#define EMCAL_STRINGVIEW const std::string &
-#endif
 
 #include "AliAnalysisTaskSE.h"
 /**

--- a/PWG/EMCAL/EMCALbase/AliEmcalStringView.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalStringView.h
@@ -1,0 +1,37 @@
+/************************************************************************************
+ * Copyright (C) 2019, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIEMCALSTRINGVIEW_H
+#define ALIEMCALSTRINGVIEW_H
+#include "RConfig.h"
+
+#if ROOT_VERSION_CODE > ROOT_VERSION(6,10,0) 
+#include "RStringView.h"
+#define EMCAL_STRINGVIEW const std::string_view
+#else 
+#define EMCAL_STRINGVIEW const std::string &
+#endif
+#endif

--- a/PWGJE/EMCALJetTasks/CMakeLists.txt
+++ b/PWGJE/EMCALJetTasks/CMakeLists.txt
@@ -141,6 +141,7 @@ set(SRCS
     Tracks/AliAnalysisTaskEmcalTriggerJets.cxx
     Tracks/AliAnalysisTaskEmcalTriggerJetsIDcorr.cxx
     Tracks/AliAnalysisTaskEmcalJetConstituentQA.cxx
+    Tracks/AliAnalysisEmcalTriggerSelectionHelper.cxx
     Tracks/AliAnalysisTaskEmcalJetEnergyScale.cxx
     Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.cxx
     Tracks/AliAnalysisTaskEmcalResponseOutliers.cxx

--- a/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
+++ b/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
@@ -236,6 +236,7 @@
 #pragma link C++ class PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetConstituentQA+;
 #pragma link C++ class PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetEnergyScale+;
 #pragma link C++ class PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetEnergySpectrum+;
+#pragma link C++ class PWGJE::EMCALJetTasks::AliAnalysisEmcalTriggerSelectionHelper+;
 #pragma link C++ namespace PWGJE::EMCALJetTasks::Test;
 #pragma link C++ class PWGJE::EMCALJetTasks::Test::AliAnalysisTaskEmcalTriggerSelectionTest+;
 

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisEmcalTriggerSelectionHelper.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisEmcalTriggerSelectionHelper.cxx
@@ -1,0 +1,109 @@
+/************************************************************************************
+ * Copyright (C) 2019, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <array>
+#include <algorithm>
+
+#include "AliAnalysisEmcalTriggerSelectionHelper.h"
+#include "AliEmcalTriggerStringDecoder.h"
+
+ClassImp(PWGJE::EMCALJetTasks::AliAnalysisEmcalTriggerSelectionHelper)
+
+using namespace PWGJE::EMCALJetTasks;
+
+bool AliAnalysisEmcalTriggerSelectionHelperImpl::IsSelectEmcalTriggers(EMCAL_STRINGVIEW triggerstring) const {
+  const std::array<std::string, 8> kEMCALTriggers = {
+    "EJ1", "EJ2", "DJ1", "DJ2", "EG1", "EG2", "DG1", "DG2"
+  };
+  bool isEMCAL = false;
+  for(auto emcaltrg : kEMCALTriggers) {
+    if(triggerstring.find(emcaltrg) != std::string::npos) {
+      isEMCAL = true;
+      break;
+    }
+  }
+  return isEMCAL;
+}
+
+std::string AliAnalysisEmcalTriggerSelectionHelperImpl::MatchTrigger(EMCAL_STRINGVIEW triggerstring, EMCAL_STRINGVIEW triggerselectionstring, bool useMuonCalo) const{
+  auto triggerclasses = PWG::EMCAL::Triggerinfo::DecodeTriggerString(triggerstring.data());
+  std::string result;
+  for(const auto &t : triggerclasses) {
+    // Use CENT cluster for downscaling
+    if(t.BunchCrossing() != "B") continue;
+    if(useMuonCalo){
+      if(t.Triggercluster() != "CALO") continue;
+    } else {
+      if(t.Triggercluster() != "CENT") continue;
+    }
+    if(t.Triggerclass().find(triggerselectionstring.data()) == std::string::npos) continue; 
+    result = t.ExpandClassName();
+    break;
+  }
+  return result;
+}
+
+std::vector<AliAnalysisEmcalTriggerSelectionHelper::TriggerCluster_t> AliAnalysisEmcalTriggerSelectionHelperImpl::GetTriggerClusterIndices(EMCAL_STRINGVIEW triggerstring) const {
+  // decode trigger string in order to determine the trigger clusters
+  std::vector<TriggerCluster_t> result;
+  result.emplace_back(kTrgClusterANY);      // cluster ANY always included 
+
+  // Data - separate trigger clusters
+  std::vector<std::string> clusternames;
+  auto triggerinfos = PWG::EMCAL::Triggerinfo::DecodeTriggerString(triggerstring.data());
+  for(auto t : triggerinfos) {
+    if(std::find(clusternames.begin(), clusternames.end(), t.Triggercluster()) == clusternames.end()) clusternames.emplace_back(t.Triggercluster());
+  }
+  bool isCENT = (std::find(clusternames.begin(), clusternames.end(), "CENT") != clusternames.end()),
+       isCENTNOTRD = (std::find(clusternames.begin(), clusternames.end(), "CENTNOTRD") != clusternames.end()),
+       isCALO = (std::find(clusternames.begin(), clusternames.end(), "CALO") != clusternames.end()),
+       isCALOFAST = (std::find(clusternames.begin(), clusternames.end(), "CALOFAST") != clusternames.end());
+  if(isCENT || isCENTNOTRD) {
+    if(isCENT) {
+      result.emplace_back(kTrgClusterCENT);
+      if(isCENTNOTRD) {
+        result.emplace_back(kTrgClusterCENTNOTRD);
+        result.emplace_back(kTrgClusterCENTBOTH);
+      } else result.emplace_back(kTrgClusterOnlyCENT);
+    } else {
+      result.emplace_back(kTrgClusterCENTNOTRD);
+      result.emplace_back(kTrgClusterOnlyCENTNOTRD);
+    }
+  }
+  if(isCALO || isCALOFAST) {
+    if(isCALO) {
+      result.emplace_back(kTrgClusterCALO);
+      if(isCALOFAST) {
+        result.emplace_back(kTrgClusterCALOFAST);
+        result.emplace_back(kTrgClusterCALOBOTH);
+      } else result.emplace_back(kTrgClusterOnlyCALO);
+    } else {
+      result.emplace_back(kTrgClusterCALOFAST);
+      result.emplace_back(kTrgClusterOnlyCALOFAST);
+    }
+  }
+  return result;
+}

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisEmcalTriggerSelectionHelper.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisEmcalTriggerSelectionHelper.h
@@ -1,0 +1,76 @@
+/************************************************************************************
+ * Copyright (C) 2019, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef ALIANALYSISEMCALTRIGGERSELECTIONHELPER_H
+#define ALIANALYSISEMCALTRIGGERSELECTIONHELPER_H
+
+#include <string>
+#include <vector>
+#include <TObject.h>
+#include "AliEmcalStringView.h"
+
+namespace PWGJE {
+
+namespace EMCALJetTasks {
+
+class AliAnalysisEmcalTriggerSelectionHelperImpl {
+public:
+  enum TriggerCluster_t {
+    kTrgClusterANY,
+    kTrgClusterCENT,
+    kTrgClusterCENTNOTRD,
+    kTrgClusterCALO,
+    kTrgClusterCALOFAST,
+    kTrgClusterCENTBOTH,
+    kTrgClusterOnlyCENT,
+    kTrgClusterOnlyCENTNOTRD,
+    kTrgClusterCALOBOTH,
+    kTrgClusterOnlyCALO,
+    kTrgClusterOnlyCALOFAST,
+    kTrgClusterN
+  };
+
+  AliAnalysisEmcalTriggerSelectionHelperImpl() {}
+  virtual ~AliAnalysisEmcalTriggerSelectionHelperImpl() {}
+
+  std::vector<TriggerCluster_t> GetTriggerClusterIndices(EMCAL_STRINGVIEW triggerstring) const;
+  std::vector<TriggerCluster_t> GetTriggerClustersANY() const { return {kTrgClusterANY}; }
+  bool IsSelectEmcalTriggers(EMCAL_STRINGVIEW triggerstring) const;
+  std::string MatchTrigger(EMCAL_STRINGVIEW striggerstring, EMCAL_STRINGVIEW triggerselectionstring, bool useMuonCalo = false) const;
+};
+
+class AliAnalysisEmcalTriggerSelectionHelper : public TObject, public AliAnalysisEmcalTriggerSelectionHelperImpl {
+public:
+  AliAnalysisEmcalTriggerSelectionHelper() : TObject(), AliAnalysisEmcalTriggerSelectionHelperImpl() {}
+  virtual ~AliAnalysisEmcalTriggerSelectionHelper() {}
+
+  ClassDef(AliAnalysisEmcalTriggerSelectionHelper, 1);
+}; 
+
+}
+
+}
+#endif

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.cxx
@@ -181,10 +181,12 @@ bool AliAnalysisTaskEmcalJetEnergySpectrum::Run(){
     AliDebugStream(1) << GetName() << ": No centrality selection applied" << std::endl;
   }
 
-  auto trgclusters = GetTriggerClusterIndices(fInputEvent->GetFiredTriggerClasses().Data());
+
+  auto trgclusters = GetTriggerClustersANY();
+  if(!fIsMC && fRequestTriggerClusters) GetTriggerClusterIndices(fInputEvent->GetFiredTriggerClasses().Data());
   Double_t weight = 1.;
   if(fUseDownscaleWeight) {
-    weight = 1./PWG::EMCAL::AliEmcalDownscaleFactorsOCDB::Instance()->GetDownscaleFactorForTriggerClass(MatchTrigger(fInputEvent->GetFiredTriggerClasses().Data()));
+    weight = 1./PWG::EMCAL::AliEmcalDownscaleFactorsOCDB::Instance()->GetDownscaleFactorForTriggerClass(MatchTrigger(fInputEvent->GetFiredTriggerClasses().Data(), fTriggerSelectionString.Data(), fUseMuonCalo));
   }
   fHistos->FillTH1("hEventCounterAbs", 1.);
   fHistos->FillTH1("hEventCounter", weight);
@@ -243,49 +245,6 @@ void AliAnalysisTaskEmcalJetEnergySpectrum::RunChanged(Int_t newrun){
   }
 }
 
-std::vector<AliAnalysisTaskEmcalJetEnergySpectrum::TriggerCluster_t> AliAnalysisTaskEmcalJetEnergySpectrum::GetTriggerClusterIndices(EMCAL_STRINGVIEW triggerstring) const {
-  // decode trigger string in order to determine the trigger clusters
-  std::vector<TriggerCluster_t> result;
-  result.emplace_back(kTrgClusterANY);      // cluster ANY always included 
-  if(!fIsMC && fRequestTriggerClusters){
-    // Data - separate trigger clusters
-    std::vector<std::string> clusternames;
-    auto triggerinfos = PWG::EMCAL::Triggerinfo::DecodeTriggerString(triggerstring.data());
-    for(auto t : triggerinfos) {
-      if(std::find(clusternames.begin(), clusternames.end(), t.Triggercluster()) == clusternames.end()) clusternames.emplace_back(t.Triggercluster());
-    }
-    bool isCENT = (std::find(clusternames.begin(), clusternames.end(), "CENT") != clusternames.end()),
-         isCENTNOTRD = (std::find(clusternames.begin(), clusternames.end(), "CENTNOTRD") != clusternames.end()),
-         isCALO = (std::find(clusternames.begin(), clusternames.end(), "CALO") != clusternames.end()),
-         isCALOFAST = (std::find(clusternames.begin(), clusternames.end(), "CALOFAST") != clusternames.end());
-    if(isCENT || isCENTNOTRD) {
-      if(isCENT) {
-        result.emplace_back(kTrgClusterCENT);
-        if(isCENTNOTRD) {
-          result.emplace_back(kTrgClusterCENTNOTRD);
-          result.emplace_back(kTrgClusterCENTBOTH);
-        } else result.emplace_back(kTrgClusterOnlyCENT);
-      } else {
-        result.emplace_back(kTrgClusterCENTNOTRD);
-        result.emplace_back(kTrgClusterOnlyCENTNOTRD);
-      }
-    }
-    if(isCALO || isCALOFAST) {
-      if(isCALO) {
-        result.emplace_back(kTrgClusterCALO);
-        if(isCALOFAST) {
-          result.emplace_back(kTrgClusterCALOFAST);
-          result.emplace_back(kTrgClusterCALOBOTH);
-        } else result.emplace_back(kTrgClusterOnlyCALO);
-      } else {
-        result.emplace_back(kTrgClusterCALOFAST);
-        result.emplace_back(kTrgClusterOnlyCALOFAST);
-      }
-    }
-  }
-  return result;
-}
-
 bool AliAnalysisTaskEmcalJetEnergySpectrum::IsTriggerSelected() {
   if(!fIsMC){
     // Pure data - do EMCAL trigger selection from selection string
@@ -320,39 +279,6 @@ bool AliAnalysisTaskEmcalJetEnergySpectrum::IsTriggerSelected() {
   }
   return true;
 }
-
-std::string AliAnalysisTaskEmcalJetEnergySpectrum::MatchTrigger(EMCAL_STRINGVIEW triggerstring){
-  auto triggerclasses = PWG::EMCAL::Triggerinfo::DecodeTriggerString(triggerstring.data());
-  std::string result;
-  for(const auto &t : triggerclasses) {
-    // Use CENT cluster for downscaling
-    if(t.BunchCrossing() != "B") continue;
-    if(fUseMuonCalo){
-      if(t.Triggercluster() != "CALO") continue;
-    } else {
-      if(t.Triggercluster() != "CENT") continue;
-    }
-    if(t.Triggerclass().find(fTriggerSelectionString.Data()) == std::string::npos) continue; 
-    result = t.ExpandClassName();
-    break;
-  }
-  return result;
-}
-
-bool AliAnalysisTaskEmcalJetEnergySpectrum::IsSelectEmcalTriggers(EMCAL_STRINGVIEW triggerstring) const {
-  const std::array<std::string, 8> kEMCALTriggers = {
-    "EJ1", "EJ2", "DJ1", "DJ2", "EG1", "EG2", "DG1", "DG2"
-  };
-  bool isEMCAL = false;
-  for(auto emcaltrg : kEMCALTriggers) {
-    if(triggerstring.find(emcaltrg) != std::string::npos) {
-      isEMCAL = true;
-      break;
-    }
-  }
-  return isEMCAL;
-}
-
 
 AliAnalysisTaskEmcalJetEnergySpectrum *AliAnalysisTaskEmcalJetEnergySpectrum::AddTaskJetEnergySpectrum(Bool_t isMC, AliJetContainer::EJetType_t jettype, AliJetContainer::ERecoScheme_t recoscheme, double radius, EMCAL_STRINGVIEW namepartcont, EMCAL_STRINGVIEW trigger, EMCAL_STRINGVIEW suffix){
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.h
@@ -28,6 +28,7 @@
 #define __ALINANLYSISTASKJETENERGYSPECTRUM_H__
 
 #include "AliAnalysisTaskEmcalJet.h"
+#include "AliAnalysisEmcalTriggerSelectionHelper.h"
 #include <vector>
 #include <TArrayD.h>
 
@@ -38,7 +39,7 @@ namespace PWGJE {
 
 namespace EMCALJetTasks {
 
-class AliAnalysisTaskEmcalJetEnergySpectrum : public AliAnalysisTaskEmcalJet {
+class AliAnalysisTaskEmcalJetEnergySpectrum : public AliAnalysisTaskEmcalJet, public AliAnalysisEmcalTriggerSelectionHelperImpl {
 public:
   enum TriggerCluster_t {
     kTrgClusterANY,
@@ -86,9 +87,6 @@ protected:
   virtual bool IsTriggerSelected();
   virtual Bool_t CheckMCOutliers();
   virtual void RunChanged(Int_t newrun);
-  std::vector<TriggerCluster_t> GetTriggerClusterIndices(EMCAL_STRINGVIEW triggerstring) const;
-  bool IsSelectEmcalTriggers(EMCAL_STRINGVIEW triggerstring) const;
-  std::string MatchTrigger(EMCAL_STRINGVIEW striggerstring);
 
 private:
   AliAnalysisTaskEmcalJetEnergySpectrum(const AliAnalysisTaskEmcalJetEnergySpectrum &);


### PR DESCRIPTION
Use multiple inheritance in order to share common code
for trigger section among several classes: The implementation
code is extracted into an implementation class
(AliAnalysisEmcalTriggerSelectionHelperImp) which can be
derived from in analysis tasks (no inheritance from TObject).
For classes which need streamer functionality from TObject
i.e. for encapsulation the interface class
AliAnalysisEmcalTriggerSelectionHelper should be used.