### PR TITLE
PsiPair correction with a new train to test ITS option kBoth

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.h
@@ -14,6 +14,7 @@
 #include "AliConversionMesonCuts.h"
 #include "AliGammaConversionAODBGHandler.h"
 #include "TProfile2D.h"
+#include "TH3F.h"
 #include <vector>
 #include <memory>
 using  std::unique_ptr;
@@ -291,6 +292,7 @@ class AliAnalysisTaskGammaConvDalitzV1: public AliAnalysisTaskSE {
     TH2F                              **hNGoodESDTracksVsNGoodVGammas;
     TH2F                              **fHistoSPDClusterTrackletBackground;        //! array of histos with SPD tracklets vs SPD clusters for background rejection
     TH1I                              **hNV0Tracks;
+    TH3F                              **hESDEposEnegPsiPairpTleptonsDPhi;
     TProfile                          **hEtaShift;
     TH2F                              **fHistoDoubleCountTruePi0InvMassPt;      //! array of histos with double counted pi0s, invMass, pT
     TH2F                              **fHistoDoubleCountTrueEtaInvMassPt;      //! array of histos with double counted etas, invMass, pT

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvDalitzV1_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvDalitzV1_pp.C
@@ -358,6 +358,9 @@ void AddTask_GammaConvDalitzV1_pp(  Int_t trainConfig = 1,  //change different s
     cuts.AddCutPCMDalitz("00010113", "0d200009227300008250400000", "204c4640263202223710", "0152103500000000"); // no double counting
     cuts.AddCutPCMDalitz("00010113", "0d200009227300008250404000", "204c4640263202223710", "0152101500000000"); // meson alpha pt dep
     cuts.AddCutPCMDalitz("00010113", "0d200009227300008250404000", "204c4640263202223710", "0152107500000000"); // meson alpha < 0.85
+  } else if (trainConfig == 416) {//Primary cut, dE/dx sigma, min pT, max pT for pions.
+    cuts.AddCutPCMDalitz("00010113", "0d200009227300008250404000", "204c4640863202223710", "0152103500000000");//Standard with kBoth on electrons
+    cuts.AddCutPCMDalitz("00010113", "0d200009227300008250404000", "204c4640863002223710", "0152103500000000");//No PsiPair cut with kBoth on electrons
 
     //  6XX for lowB,    65X  lowB and MBW
   } else if (trainConfig == 606) {  // low B   eta<0.8


### PR DESCRIPTION
Remove extra variables to propagate the momentum like dielectrons, and adding a TH3F for extra study on PsiPair and theta in terms of the momentum. Plus an extra train ID for the study of ITS.
