### PR TITLE
Set default flag in case time cut is not applied

### DIFF
--- a/OADB/AliEventCuts.cxx
+++ b/OADB/AliEventCuts.cxx
@@ -298,6 +298,8 @@ bool AliEventCuts::AcceptEvent(AliVEvent *ev) {
     if ( fTimeRangeCut.CutEvent(ev) ) {
       fFlag |= BIT(kTimeRangeCut);
     }
+  } else {
+    fFlag |= BIT(kTimeRangeCut);
   }
 
   /// Ignore SPD/tracks vertex position and reconstruction individual flags


### PR DESCRIPTION
Fixing alisw/AliPhysics#10350: In case the time cut is not
applied the flag has to be set, otherwise all events
are rejected.