### PR TITLE
Add task for EMCAL trigger normalization based on downscale method

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.cxx
@@ -1052,9 +1052,10 @@ AliAnalysisTaskEmcal::BeamType AliAnalysisTaskEmcal::GetBeamType() const
   } else {
     Int_t runNumber = InputEvent()->GetRunNumber();
     // All run number ranges taken from the RCT
-    if ((runNumber >= 136833 && runNumber <= 139517) ||  // LHC10h
-        (runNumber >= 167693 && runNumber <= 170593) || // LHC11h
-        (runNumber >= 244824 && runNumber <= 246994)) { // LHC15o
+    if ((runNumber >= 136833 && runNumber <= 139517) ||   // LHC10h
+        (runNumber >= 167693 && runNumber <= 170593) ||   // LHC11h
+        (runNumber >= 244824 && runNumber <= 246994) ||   // LHC15o
+        (runNumber >= 295581 && runNumber <= 297624)) {   // LHC18p-q
       return kAA;
     } else if ((runNumber >= 188356 && runNumber <= 188366) ||   // LHC12g
                (runNumber >= 195164 && runNumber <= 197388) ||  // LHC13b-f

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerStringDecoder.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerStringDecoder.cxx
@@ -36,13 +36,13 @@ std::string Triggerinfo::ExpandClassName() const {
   return result;
 }
 
-bool Triggerinfo::IsTriggerClass(const std::string &triggerclass) const {
+bool Triggerinfo::IsTriggerClass(EMCAL_STRINGVIEW triggerclass) const {
   return fTriggerClass.substr(1) == triggerclass; // remove C from trigger class part
 }
 
-std::vector<Triggerinfo> Triggerinfo::DecodeTriggerString(const std::string &triggerstring) {
+std::vector<Triggerinfo> Triggerinfo::DecodeTriggerString(EMCAL_STRINGVIEW triggerstring) {
   std::vector<Triggerinfo> result;
-  std::stringstream triggerparser(triggerstring);
+  std::stringstream triggerparser(triggerstring.data());
   std::string currenttrigger;
   while(std::getline(triggerparser, currenttrigger, ' ')){
     if(!currenttrigger.length()) continue;

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerStringDecoder.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerStringDecoder.h
@@ -29,6 +29,7 @@
 #include <string>
 #include <vector>
 #include <TObject.h>
+#include "AliEmcalStringView.h"
 
 namespace PWG {
 
@@ -69,7 +70,7 @@ public:
    * @return true Trigger class matches
    * @return false Trigger class does not match
    */
-  bool IsTriggerClass(const std::string &triggerclass) const;
+  bool IsTriggerClass(EMCAL_STRINGVIEW triggerclass) const;
 
   const std::string &Triggerclass() const { return fTriggerClass; }
   const std::string &BunchCrossing() const { return fBunchCrossing; }
@@ -87,7 +88,7 @@ public:
    * @param triggerstring Valid trigger class string
    * @return std::vector<Triggerinfo> Trigger info objects for all trigger classes found in the trigger string
    */
-  static std::vector<PWG::EMCAL::Triggerinfo> DecodeTriggerString(const std::string &triggerstring);
+  static std::vector<PWG::EMCAL::Triggerinfo> DecodeTriggerString(EMCAL_STRINGVIEW triggerstring);
 private:
   std::string fTriggerClass;              ///< Trigger class
   std::string fBunchCrossing;             ///< Bunch crossing type

--- a/PWGJE/EMCALJetTasks/CMakeLists.txt
+++ b/PWGJE/EMCALJetTasks/CMakeLists.txt
@@ -151,6 +151,7 @@ set(SRCS
     Tracks/AliAnalysisTaskEmcalTriggerCorrelationMC.cxx
     Tracks/AliAnalysisTaskEmcalHighEClusterTree.cxx
     Tracks/AliAnalysisTaskEmcalEG1Correlation.cxx
+    Tracks/AliAnalysisTaskEmcalTriggerNormalization.cxx
     Tracks/AliAnalysisTaskEmcalTriggerBackground.cxx
     Tracks/AliAnalysisTaskEmcalTriggerSelectionTest.cxx
     UserTasks/AliAnalysisTaskJetUEStudies.cxx

--- a/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
+++ b/PWGJE/EMCALJetTasks/PWGJEEMCALJetTasksLinkDef.h
@@ -237,6 +237,7 @@
 #pragma link C++ class PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetEnergyScale+;
 #pragma link C++ class PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetEnergySpectrum+;
 #pragma link C++ class PWGJE::EMCALJetTasks::AliAnalysisEmcalTriggerSelectionHelper+;
+#pragma link C++ class PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalTriggerNormalization+;
 #pragma link C++ namespace PWGJE::EMCALJetTasks::Test;
 #pragma link C++ class PWGJE::EMCALJetTasks::Test::AliAnalysisTaskEmcalTriggerSelectionTest+;
 

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerNormalization.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerNormalization.cxx
@@ -1,0 +1,157 @@
+/************************************************************************************
+ * Copyright (C) 2019, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#include <THistManager.h>
+
+#include "AliAnalysisManager.h"
+#include "AliAnalysisTaskEmcalTriggerNormalization.h"
+#include "AliEmcalDownscaleFactorsOCDB.h"
+#include "AliEmcalTriggerStringDecoder.h"
+#include "AliInputEventHandler.h"
+#include "AliLog.h"
+#include "AliMultSelection.h"
+#include "AliVEvent.h"
+
+ClassImp(PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalTriggerNormalization)
+
+using namespace PWGJE::EMCALJetTasks;
+
+AliAnalysisTaskEmcalTriggerNormalization::AliAnalysisTaskEmcalTriggerNormalization():
+    AliAnalysisTaskEmcal(),
+    fHistos(nullptr),
+    fTriggerCluster(),
+    fMBTriggerClasses()
+{
+}
+
+AliAnalysisTaskEmcalTriggerNormalization::AliAnalysisTaskEmcalTriggerNormalization(const char *name):
+    AliAnalysisTaskEmcal(name, kTRUE),
+    fHistos(nullptr),
+    fTriggerCluster(),
+    fMBTriggerClasses()
+{
+}
+
+void AliAnalysisTaskEmcalTriggerNormalization::UserCreateOutputObjects(){
+  AliAnalysisTaskEmcal::UserCreateOutputObjects();
+
+  fHistos = new THistManager("HistosTriggerNorm");
+
+  fHistos->CreateTH2("hTriggerNorm", "Histogram for the trigger normalization", 11, -0.5, 10.5, 100, 0., 100.);
+  auto normhist = static_cast<TH1 *>(fHistos->GetListOfHistograms()->FindObject("hTriggerNorm"));
+  std::array<std::string, 9> triggers = {"INT7", "EG", "EG2", "EJ1", "EJ2", "DG1", "DG2", "DJ1", "DJ2"};
+  for(auto ib = 0; ib < triggers.size(); ib++){
+    normhist->GetXaxis()->SetBinLabel(ib+1, triggers[ib].data());
+  }
+
+  for(auto h : *fHistos->GetListOfHistograms()) fOutput->Add(h);
+  PostData(1, fOutput);
+}
+
+Bool_t AliAnalysisTaskEmcalTriggerNormalization::Run(){
+  if(!fTriggerCluster.length()) throw TriggerClusterNotSetException(); 
+  if(!fMBTriggerClasses.size()) throw MBTriggerNotSetException();
+
+  double centralitypercentile = 99.;
+  if(this->GetBeamType() == AliAnalysisTaskEmcal::kAA) {
+    AliMultSelection *mult = static_cast<AliMultSelection*>(InputEvent()->FindListObject("MultSelection"));
+    if(mult){
+      centralitypercentile = mult->GetMultiplicityPercentile(fCentEst.Data());
+    } else {
+      throw CentralityNotSetException();
+    }
+  }
+
+  EMCAL_STRINGVIEW triggerstring(fInputEvent->GetFiredTriggerClasses().Data());
+
+  // Min. bias trigger (reference trigger)
+  if(fInputHandler->IsEventSelected() & AliVEvent::kINT7) {
+    auto match_triggerclass = MatchTrigger(triggerstring, fMBTriggerClasses, fTriggerCluster);
+    if(match_triggerclass.length()){
+      double weight = 1./PWG::EMCAL::AliEmcalDownscaleFactorsOCDB::Instance()->GetDownscaleFactorForTriggerClass(match_triggerclass.data());
+      auto normhist = static_cast<TH2 *>(fHistos->FindObject("hTriggerNorm"));
+      auto triggerbin = normhist->GetXaxis()->FindBin("INT7");
+      normhist->Fill(normhist->GetXaxis()->GetBinCenter(triggerbin), centralitypercentile, weight);
+    }
+  }
+
+  // EMCAL triggers
+  const UInt_t EGABIT = AliVEvent::kEMCEGA,
+               EJEBIT = AliVEvent::kEMCEJE;
+  const Int_t NEMCAL_TRIGGERS = 8;
+  const std::array<std::string, NEMCAL_TRIGGERS> EMCAL_TRIGGERS = {{"EG1", "EG2", "EJ1", "EJ2", "DG1", "DG2", "DJ1", "DJ2"}};
+  const std::array<UInt_t, NEMCAL_TRIGGERS> EMCAL_TRIGGERBITS = {{EGABIT, EGABIT, EJEBIT, EJEBIT, EGABIT, EGABIT, EJEBIT, EJEBIT}};
+  for(Int_t i = 0; i < NEMCAL_TRIGGERS; i++) {
+    std::vector<std::string> match_emctriggers = {EMCAL_TRIGGERS[i]};
+    if(fInputHandler->IsEventSelected() & EMCAL_TRIGGERBITS[i]){
+      auto match_triggerclass = MatchTrigger(triggerstring, match_emctriggers, fTriggerCluster);
+      if(!match_triggerclass.length()) continue;      // match trigger class not found
+      double weight = 1./PWG::EMCAL::AliEmcalDownscaleFactorsOCDB::Instance()->GetDownscaleFactorForTriggerClass(match_triggerclass.data());
+      auto normhist = static_cast<TH2 *>(fHistos->FindObject("hTriggerNorm"));
+      auto triggerbin = normhist->GetXaxis()->FindBin(EMCAL_TRIGGERS[i].data());
+      normhist->Fill(normhist->GetXaxis()->GetBinCenter(triggerbin), centralitypercentile, weight);
+    }
+  }
+  return true;
+}
+
+std::string AliAnalysisTaskEmcalTriggerNormalization::MatchTrigger(EMCAL_STRINGVIEW triggerstring, const std::vector<std::string> &triggerclasses, EMCAL_STRINGVIEW triggercluster) const {
+  std::string result;
+  auto triggers = PWG::EMCAL::Triggerinfo::DecodeTriggerString(triggerstring);
+  for(const auto &t : triggers) {
+    if(t.Triggercluster() != triggercluster) continue;
+    for(const auto &c : triggerclasses) {
+      if(t.IsTriggerClass(c)) {
+        result = t.ExpandClassName();
+        break;
+      }
+    }
+  }
+  return result;
+}
+
+void AliAnalysisTaskEmcalTriggerNormalization::RunChanged(int newrun){
+  PWG::EMCAL::AliEmcalDownscaleFactorsOCDB::Instance()->SetRun(newrun);
+}
+
+AliAnalysisTaskEmcalTriggerNormalization *AliAnalysisTaskEmcalTriggerNormalization::AddTaskTriggerNormalization(const char *name) {
+  auto mgr = AliAnalysisManager::GetAnalysisManager();
+  if(!mgr) {
+    AliErrorGeneralStream("AliAnalysisTaskEmcalTriggerNormalization::AddTaskTriggerNormalization") << "No analysis manager defined" << std::endl;
+    return nullptr;
+  }
+
+  auto task = new AliAnalysisTaskEmcalTriggerNormalization(name);
+  mgr->AddTask(task);
+
+  std::string outputfile = mgr->GetCommonFileName();
+  outputfile += Form(":EmcalTriggerNorm%s", name);
+
+  mgr->ConnectInput(task, 0, mgr->GetCommonInputContainer());
+  mgr->ConnectOutput(task, 1, mgr->CreateContainer("EmcalNormalizationHistograms", TList::Class(), AliAnalysisManager::kOutputContainer, outputfile.data()));
+
+  return task;
+}

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerNormalization.h
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalTriggerNormalization.h
@@ -1,0 +1,99 @@
+/************************************************************************************
+ * Copyright (C) 2019, Copyright Holders of the ALICE Collaboration                 *
+ * All rights reserved.                                                             *
+ *                                                                                  *
+ * Redistribution and use in source and binary forms, with or without               *
+ * modification, are permitted provided that the following conditions are met:      *
+ *     * Redistributions of source code must retain the above copyright             *
+ *       notice, this list of conditions and the following disclaimer.              *
+ *     * Redistributions in binary form must reproduce the above copyright          *
+ *       notice, this list of conditions and the following disclaimer in the        *
+ *       documentation and/or other materials provided with the distribution.       *
+ *     * Neither the name of the <organization> nor the                             *
+ *       names of its contributors may be used to endorse or promote products       *
+ *       derived from this software without specific prior written permission.      *
+ *                                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           *
+ * DISCLAIMED. IN NO EVENT SHALL ALICE COLLABORATION BE LIABLE FOR ANY              *
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES       *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      *
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     *
+ ************************************************************************************/
+#ifndef __ALIANALYSISTASKEMCALTRIGGERNORMALIZATION_H__
+#define __ALIANALYSISTASKEMCALTRIGGERNORMALIZATION_H__
+
+#include "AliAnalysisTaskEmcal.h"
+#include <exception>
+#include <string>
+#include <vector>
+
+class THistManager;
+
+namespace PWGJE {
+
+namespace EMCALJetTasks {
+
+class AliAnalysisTaskEmcalTriggerNormalization : public AliAnalysisTaskEmcal {
+public:
+  AliAnalysisTaskEmcalTriggerNormalization();
+  AliAnalysisTaskEmcalTriggerNormalization(const char *name);
+  virtual ~AliAnalysisTaskEmcalTriggerNormalization() {}
+
+  void SetTriggerCluster(const char *triggercluster) { fTriggerCluster = triggercluster; } 
+  void AddMBTriggerClass(const char *triggerclass) { fMBTriggerClasses.emplace_back(triggerclass); }
+
+  static AliAnalysisTaskEmcalTriggerNormalization *AddTaskTriggerNormalization(const char *name);
+
+  class TriggerClusterNotSetException : public std::exception {
+  public:
+    TriggerClusterNotSetException() {}
+    virtual ~TriggerClusterNotSetException() throw() {}
+
+    virtual const char *what() const throw() { return "Trigger cluster not set."; }
+  };
+
+  class MBTriggerNotSetException : public std::exception {
+  public:
+    MBTriggerNotSetException() {}
+    virtual ~MBTriggerNotSetException() throw() {}
+
+    virtual const char *what() const throw() { return "No min. bias trigger defined."; }
+  };
+
+  class CentralityNotSetException : public std::exception {
+  public:
+    CentralityNotSetException() {}
+    virtual ~CentralityNotSetException() throw() {}
+
+    virtual const char *what() const throw() { return "Centrality estimator not available"; }
+  };
+
+protected:
+  virtual void UserCreateOutputObjects();
+  virtual bool Run();
+  virtual void RunChanged(int newrun);
+  std::string MatchTrigger(EMCAL_STRINGVIEW triggerstring, const std::vector<std::string> &triggers, EMCAL_STRINGVIEW triggercluster) const;
+
+private:
+  THistManager             *fHistos;                ///< List of histograms
+  std::string               fTriggerCluster;        ///< Trigger cluster       
+  std::vector<std::string>  fMBTriggerClasses;      ///< List of valid min. bias trigger classes
+
+
+  AliAnalysisTaskEmcalTriggerNormalization(const AliAnalysisTaskEmcalTriggerNormalization &);
+  AliAnalysisTaskEmcalTriggerNormalization &operator=(const AliAnalysisTaskEmcalTriggerNormalization &);
+
+  ClassDef(AliAnalysisTaskEmcalTriggerNormalization, 1);
+};
+
+}
+
+}
+
+
+#endif

--- a/PWGJE/EMCALJetTasks/macros/AddTaskEmcalTriggerNormalization.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskEmcalTriggerNormalization.C
@@ -1,0 +1,3 @@
+PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalTriggerNormalization AddTaskEmcalTriggerNormalization(const char *name) {
+  PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalTriggerNormalization::AddTaskEmcalTriggerNormalization(name);
+}


### PR DESCRIPTION
Calculate the donnscale-corrected number of min. bias events
(cluster luminosity) and the corrected number of events for
the various EMCAL triggers. The event counts are organized in
centrality percentiles.