### PR TITLE
Add HF/LF MCsignal definitions to config

### DIFF
--- a/PWGDQ/dielectron/macrosLMEE/AddTask_acapon.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTask_acapon.C
@@ -19,7 +19,7 @@ AliAnalysisTask* AddTask_acapon(TString outputFileName = "AnalysisResult.root",
                                 Bool_t useCutLibrary   = kTRUE, // Use simple config instead?
                                 Bool_t getFromAlien    = kFALSE)
 {
-  
+
     TObjArray* arrNames = names.Tokenize(";");
     Int_t nDie = arrNames->GetEntries();
     Printf("Number of implemented cuts: %i", nDie);
@@ -37,9 +37,7 @@ AliAnalysisTask* AddTask_acapon(TString outputFileName = "AnalysisResult.root",
     std::cout << "Pairing         : " << doPairing      << std::endl;
     std::cout << "Event mixing    : " << doMixing       << std::endl;
     if(useCutLibrary){
-      std::cout << "Pairing         : " << doPairing      << std::endl;
       std::cout << "Pair cuts       : " << applyPairCuts  << std::endl;
-      std::cout << "Event mixing    : " << doMixing       << std::endl;
       std::cout << "Track plots     : " << trackVarPlots  << std::endl;
       std::cout << "Which det plots : " << whichDetPlots  << std::endl;
       std::cout << "v0 plots        : " << v0plots        << std::endl;
@@ -64,7 +62,7 @@ AliAnalysisTask* AddTask_acapon(TString outputFileName = "AnalysisResult.root",
 
     // Load updated macros from private ALIEN path
     TString myConfig = "alien_cp alien:///alice/cern.ch/user/a/acapon/PWGDQ/dielectron/macrosLMEE/Config_acapon.C .";
-    TString myCutLib = "alien_cp alien:///alice/cern.ch/user/a/acapon/PWGDQ/dielectron/macrosLMEE/LMEECutLib_acapon.C ."; 
+    TString myCutLib = "alien_cp alien:///alice/cern.ch/user/a/acapon/PWGDQ/dielectron/macrosLMEE/LMEECutLib_acapon.C .";
     if(getFromAlien && (!gSystem->Exec(myConfig)) && (!gSystem->Exec(myCutLib))){
       std::cout << "Copy config from Alien" << std::endl;
       configBasePath = TString::Format("%s/",gSystem->pwd());
@@ -82,10 +80,10 @@ AliAnalysisTask* AddTask_acapon(TString outputFileName = "AnalysisResult.root",
     }
 
     // Determine if ESDs or AODs are being analysed
-    // CutLibrary only tested for AODs
-    // noCutLib option only works with ESDs
+    // CutLibrary version only works/tested for AODs
+    // noCutLib version is mixed depending on cut setting
     if(mgr->GetInputEventHandler()->IsA() == AliAODInputHandler::Class()){
-      ::Info("AddTask_acapon", "AOD configuration"); 
+      ::Info("AddTask_acapon", "AOD configuration");
     }
     else if(mgr->GetInputEventHandler()->IsA() == AliESDInputHandler::Class()){
       if(useCutLibrary){
@@ -105,7 +103,7 @@ AliAnalysisTask* AddTask_acapon(TString outputFileName = "AnalysisResult.root",
     Int_t triggerNames = (AliVEvent::kINT7);
     task->SelectCollisionCandidates(triggerNames);
     task->SetTriggerMask(triggerNames);
-    
+
     // Event cuts are the same for all cut settings regardless
     // of config setup
     LMEECutLib* cutLib = 0x0;
@@ -120,13 +118,13 @@ AliAnalysisTask* AddTask_acapon(TString outputFileName = "AnalysisResult.root",
     // Add the task to the manager
     mgr->AddTask(task);
     // Add dielectron analysis with different cuts to the task
-    for(Int_t i = 0; i < nDie; ++i){ 
+    for(Int_t i = 0; i < nDie; ++i){
       TString dielTaskName(arrNames->At(i)->GetName());
       AliDielectron* diel_low = 0x0;
 
       if(useCutLibrary){
         diel_low = Config_acapon(dielTaskName, hasMC, SDDstatus,
-                                 doPairing, applyPairCuts, doMixing, 
+                                 doPairing, applyPairCuts, doMixing,
                                  trackVarPlots, whichDetPlots, v0plots,
                                  useITScorr, useTPCcorr, useTOFcorr,
                                  plots3D, useRun1binning);
@@ -142,25 +140,25 @@ AliAnalysisTask* AddTask_acapon(TString outputFileName = "AnalysisResult.root",
 
 
     // Create output container
-    AliAnalysisDataContainer *coutput1 =
+    AliAnalysisDataContainer* coutput1 =
     mgr->CreateContainer(::Form("acapon_tree_%d",wagonNum),
                          TTree::Class(),
                          AliAnalysisManager::kExchangeContainer,
                          outputFileName.Data());
 
-    AliAnalysisDataContainer *cOutputHist1 =
+    AliAnalysisDataContainer* cOutputHist1 =
     mgr->CreateContainer(::Form("acapon_out_%d", wagonNum),
                          TList::Class(),
                          AliAnalysisManager::kOutputContainer,
                          outputFileName.Data());
 
-    AliAnalysisDataContainer *cOutputHist2 =
+    AliAnalysisDataContainer* cOutputHist2 =
     mgr->CreateContainer(::Form("acapon_CF_%d", wagonNum),
                          TList::Class(),
                          AliAnalysisManager::kOutputContainer,
                          outputFileName.Data());
 
-    AliAnalysisDataContainer *cOutputHist3 =
+    AliAnalysisDataContainer* cOutputHist3 =
     mgr->CreateContainer(::Form("acapon_EventStat_%d", wagonNum),
                          TH1D::Class(),
                          AliAnalysisManager::kOutputContainer,

--- a/PWGDQ/dielectron/macrosLMEE/AddTask_acapon_Efficiency.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTask_acapon_Efficiency.C
@@ -19,11 +19,11 @@ AliAnalysisTaskElectronEfficiencyV2* AddTask_acapon_Efficiency(TString names    
 {
 
   std::cout << "########################################\nADDTASK of ANALYSIS started\n########################################" << std::endl;
-  
+
   TObjArray *arrNames = names.Tokenize(";");
   Int_t nDie          = arrNames->GetEntries();
   Printf("Number of implemented cuts: %i", nDie);
-  
+
   std::string resoFilenameFromAlien = "/alice/cern.ch/user/a/acapon/ResolutionFiles/";
   resoFilenameFromAlien.append(resoFilename);
 

--- a/PWGDQ/dielectron/macrosLMEE/Config_acapon_Efficiency.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_acapon_Efficiency.C
@@ -170,210 +170,210 @@ AliAnalysisFilter* SetupTrackCutsAndSettings(TString cutDefinition, Bool_t wSDD)
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kScheidCuts"){ 
+  else if(cutDefinition == "kScheidCuts"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kScheidCuts, LMEECutLib::kScheidCuts));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
   // ######## PID Cut variation settings #################
   // These variations use the kCutSet1 track cuts and only vary PID
-  else if(cutDefinition == "kPIDcut1"){ 
+  else if(cutDefinition == "kPIDcut1"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut1));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kPIDcut2"){ 
+  else if(cutDefinition == "kPIDcut2"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut2));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kPIDcut3"){ 
+  else if(cutDefinition == "kPIDcut3"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut3));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kPIDcut4"){ 
+  else if(cutDefinition == "kPIDcut4"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut4));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kPIDcut5"){ 
+  else if(cutDefinition == "kPIDcut5"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut5));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kPIDcut6"){ 
+  else if(cutDefinition == "kPIDcut6"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut6));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kPIDcut7"){ 
+  else if(cutDefinition == "kPIDcut7"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut7));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kPIDcut8"){ 
+  else if(cutDefinition == "kPIDcut8"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut8));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kPIDcut9"){ 
+  else if(cutDefinition == "kPIDcut9"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut9));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kPIDcut10"){ 
+  else if(cutDefinition == "kPIDcut10"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut10));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kPIDcut11"){ 
+  else if(cutDefinition == "kPIDcut11"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut11));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kPIDcut12"){ 
+  else if(cutDefinition == "kPIDcut12"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut12));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kPIDcut13"){ 
+  else if(cutDefinition == "kPIDcut13"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut13));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kPIDcut14"){ 
+  else if(cutDefinition == "kPIDcut14"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut14));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kPIDcut15"){ 
+  else if(cutDefinition == "kPIDcut15"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut15));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kPIDcut16"){ 
+  else if(cutDefinition == "kPIDcut16"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut16));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kPIDcut17"){ 
+  else if(cutDefinition == "kPIDcut17"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut17));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kPIDcut18"){ 
+  else if(cutDefinition == "kPIDcut18"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut18));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kPIDcut19"){ 
+  else if(cutDefinition == "kPIDcut19"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut19));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kPIDcut20"){ 
+  else if(cutDefinition == "kPIDcut20"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kPIDcut20));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
   // ######## Track+ePID Cut variation settings #################
-  else if(cutDefinition == "kCutVar1"){ 
+  else if(cutDefinition == "kCutVar1"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar1, LMEECutLib::kCutVar1));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kCutVar2"){ 
+  else if(cutDefinition == "kCutVar2"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar2, LMEECutLib::kCutVar2));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kCutVar3"){ 
+  else if(cutDefinition == "kCutVar3"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar3, LMEECutLib::kCutVar3));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kCutVar4"){ 
+  else if(cutDefinition == "kCutVar4"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar4, LMEECutLib::kCutVar4));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kCutVar5"){ 
+  else if(cutDefinition == "kCutVar5"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar5, LMEECutLib::kCutVar5));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kCutVar6"){ 
+  else if(cutDefinition == "kCutVar6"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar6, LMEECutLib::kCutVar6));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kCutVar7"){ 
+  else if(cutDefinition == "kCutVar7"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar7, LMEECutLib::kCutVar7));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kCutVar8"){ 
+  else if(cutDefinition == "kCutVar8"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar8, LMEECutLib::kCutVar8));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kCutVar9"){ 
+  else if(cutDefinition == "kCutVar9"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar9, LMEECutLib::kCutVar9));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kCutVar10"){ 
+  else if(cutDefinition == "kCutVar10"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar10, LMEECutLib::kCutVar10));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kCutVar11"){ 
+  else if(cutDefinition == "kCutVar11"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar11, LMEECutLib::kCutVar11));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kCutVar12"){ 
+  else if(cutDefinition == "kCutVar12"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar12, LMEECutLib::kCutVar12));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kCutVar13"){ 
+  else if(cutDefinition == "kCutVar13"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar13, LMEECutLib::kCutVar13));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kCutVar14"){ 
+  else if(cutDefinition == "kCutVar14"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar14, LMEECutLib::kCutVar14));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kCutVar15"){ 
+  else if(cutDefinition == "kCutVar15"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar15, LMEECutLib::kCutVar15));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kCutVar16"){ 
+  else if(cutDefinition == "kCutVar16"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar16, LMEECutLib::kCutVar16));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kCutVar17"){ 
+  else if(cutDefinition == "kCutVar17"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar17, LMEECutLib::kCutVar17));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kCutVar18"){ 
+  else if(cutDefinition == "kCutVar18"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar18, LMEECutLib::kCutVar18));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kCutVar19"){ 
+  else if(cutDefinition == "kCutVar19"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar19, LMEECutLib::kCutVar19));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
   }
-  else if(cutDefinition == "kCutVar20"){ 
+  else if(cutDefinition == "kCutVar20"){
     anaFilter->AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutVar20, LMEECutLib::kCutVar20));
     anaFilter->SetName(cutDefinition);
     anaFilter->Print();
@@ -396,7 +396,7 @@ std::vector<Bool_t> AddSingleLegMCSignal(AliAnalysisTaskElectronEfficiencyV2* ta
 
   // All final state electrons (excluding conversion electrons)
   AliDielectronSignalMC eleFinalState("eleFinalState","eleFinalState");
-  eleFinalState.SetLegPDGs(11,1); 
+  eleFinalState.SetLegPDGs(11,1);
   eleFinalState.SetCheckBothChargesLegs(kTRUE,kTRUE);
   eleFinalState.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
   eleFinalState.SetMotherPDGs(22, 22, kTRUE, kTRUE); // Exclude conversion electrons
@@ -408,13 +408,13 @@ std::vector<Bool_t> AddSingleLegMCSignal(AliAnalysisTaskElectronEfficiencyV2* ta
   eleFinalStateFromD.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
   eleFinalStateFromD.SetMotherPDGs(402, 402);
   eleFinalStateFromD.SetCheckBothChargesMothers(kTRUE,kTRUE);
-  
+
   // Electrons from open beauty mesons and baryons
   AliDielectronSignalMC eleFinalStateFromB("eleFinalStateFromB","eleFinalStateFromB");
   eleFinalStateFromB.SetLegPDGs(11,1);
   eleFinalStateFromB.SetCheckBothChargesLegs(kTRUE,kTRUE);
   eleFinalStateFromB.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
-  eleFinalStateFromB.SetMotherPDGs(502, 502); 
+  eleFinalStateFromB.SetMotherPDGs(502, 502);
   eleFinalStateFromB.SetCheckBothChargesMothers(kTRUE,kTRUE);
 
   // Add signals
@@ -457,7 +457,7 @@ void AddPairMCSignal(AliAnalysisTaskElectronEfficiencyV2* task){
   pair_sameMother_pion.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
   // Set mother properties
   pair_sameMother_pion.SetMothersRelation(AliDielectronSignalMC::kSame);
-  pair_sameMother_pion.SetMotherPDGs(111,111); 
+  pair_sameMother_pion.SetMotherPDGs(111,111);
 
   AliDielectronSignalMC pair_sameMother_eta("sameMother_eta","sameMother_eta");
   pair_sameMother_eta.SetLegPDGs(11,-11);
@@ -465,7 +465,7 @@ void AddPairMCSignal(AliAnalysisTaskElectronEfficiencyV2* task){
   pair_sameMother_eta.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
   // Set mother properties
   pair_sameMother_eta.SetMothersRelation(AliDielectronSignalMC::kSame);
-  pair_sameMother_eta.SetMotherPDGs(221,221); 
+  pair_sameMother_eta.SetMotherPDGs(221,221);
 
   AliDielectronSignalMC pair_sameMother_etaP("sameMother_etaP","sameMother_etaP");
   pair_sameMother_etaP.SetLegPDGs(11,-11);
@@ -497,7 +497,7 @@ void AddPairMCSignal(AliAnalysisTaskElectronEfficiencyV2* task){
   pair_sameMother_phi.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
   // Set mother properties
   pair_sameMother_phi.SetMothersRelation(AliDielectronSignalMC::kSame);
-  pair_sameMother_phi.SetMotherPDGs(333, 333); 
+  pair_sameMother_phi.SetMotherPDGs(333, 333);
 
   AliDielectronSignalMC pair_sameMother_jpsi("sameMother_jpsi","sameMother_jpsi");
   pair_sameMother_jpsi.SetLegPDGs(11,-11);
@@ -505,7 +505,7 @@ void AddPairMCSignal(AliAnalysisTaskElectronEfficiencyV2* task){
   pair_sameMother_jpsi.SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
   // Set mother properties
   pair_sameMother_jpsi.SetMothersRelation(AliDielectronSignalMC::kSame);
-  pair_sameMother_jpsi.SetMotherPDGs(443, 443); 
+  pair_sameMother_jpsi.SetMotherPDGs(443, 443);
 
   task->AddPairMCSignal(pair_sameMother);
   // task->AddPairMCSignal(pair_sameMother_pion);


### PR DESCRIPTION
Updated Config_acapon_noCutLib to now have four cut settings which select MC tracks based on MCtruth information. Two for dielectrons from pions, and two for HF (one for charm and one for beauty). 

All other files that were changed only had trailing white spaces removed from any lines. 