### PR TITLE
Add option for multiplicity-dependent normalization in p-Pb

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerNormalization.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerNormalization.cxx
@@ -48,7 +48,8 @@ AliAnalysisTaskEmcalTriggerNormalization::AliAnalysisTaskEmcalTriggerNormalizati
     fTriggerCluster(),
     fTriggerClusterEMCAL(),
     fEMCALL0trigger(),
-    fMBTriggerClasses()
+    fMBTriggerClasses(),
+    fUseCentralityForpPb(false)
 {
 }
 
@@ -58,7 +59,8 @@ AliAnalysisTaskEmcalTriggerNormalization::AliAnalysisTaskEmcalTriggerNormalizati
     fTriggerCluster(),
     fTriggerClusterEMCAL(),
     fEMCALL0trigger(),
-    fMBTriggerClasses()
+    fMBTriggerClasses(),
+    fUseCentralityForpPb(false)
 {
   SetMakeGeneralHistograms(true);
 }
@@ -87,7 +89,7 @@ Bool_t AliAnalysisTaskEmcalTriggerNormalization::Run(){
   if(!fTriggerClusterEMCAL.length()) fTriggerClusterEMCAL = fTriggerCluster;
 
   double centralitypercentile = 99.;
-  if(this->GetBeamType() == AliAnalysisTaskEmcal::kAA) {
+  if(this->GetBeamType() == AliAnalysisTaskEmcal::kAA || (fUseCentralityForpPb && (GetBeamType() == AliAnalysisTaskEmcal::kpA))) {
     AliMultSelection *mult = static_cast<AliMultSelection*>(InputEvent()->FindListObject("MultSelection"));
     if(mult){
       centralitypercentile = mult->GetMultiplicityPercentile(fCentEst.Data());

--- a/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerNormalization.h
+++ b/PWG/EMCAL/EMCALtasks/AliAnalysisTaskEmcalTriggerNormalization.h
@@ -156,6 +156,15 @@ public:
    */
   void AddMBTriggerClass(const char *triggerclass) { fMBTriggerClasses.emplace_back(triggerclass); }
 
+  /**
+   * @brief Request normalization as function of mulitplicity for p-Pb
+   * 
+   * Attention: Relies on AliMultiplicitySelection. If not found an exception 
+   * is raised.
+   * 
+   * @param doRequest If true the multiplicity percentile is requested for pPb
+   */
+  void SetRequestCentralityForpPb(Bool_t doRequest) { fUseCentralityForpPb = doRequest; }
 
   /**
    * @brief Configure normalization task and add it to the analysis manager
@@ -305,7 +314,7 @@ private:
   std::string               fTriggerClusterEMCAL;   ///< Cluster of the EMCAL triggers (if different)
   std::string               fEMCALL0trigger;        ///< L0 trigger required for L1
   std::vector<std::string>  fMBTriggerClasses;      ///< List of valid min. bias trigger classes
-
+  Bool_t                    fUseCentralityForpPb;   ///< Request centrality also for p-Pb (from AliMultiplicitySelection)
 
   AliAnalysisTaskEmcalTriggerNormalization(const AliAnalysisTaskEmcalTriggerNormalization &);
   AliAnalysisTaskEmcalTriggerNormalization &operator=(const AliAnalysisTaskEmcalTriggerNormalization &);


### PR DESCRIPTION
If requested normalization histograms are filled as function
of centrality. Must be enabled explicitly by the user as
the task will crash in case the AliMultiplicitySelection is
not found.