### PR TITLE
Add V0 feature histograms/switch on HF corr. check

### DIFF
--- a/PWGDQ/dielectron/macrosLMEE/Config_acapon.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_acapon.C
@@ -4,7 +4,7 @@
 R__ADD_INCLUDE_PATH($ALICE_PHYSICS)
 //#include <PWGDQ/dielectron/macrosLMEE/LMEECutLib_acapon.C>
 #endif
-void InitHistograms(AliDielectron *die, Bool_t doPairing, Bool_t trackVarPlots, Int_t whichDetPlots, Bool_t v0plots, Bool_t plots3D, Bool_t useRun1binning = kFALSE);
+void InitHistograms(AliDielectron *die, Bool_t doPairing, Bool_t trackVarPlots, Int_t whichDetPlots, Bool_t v0plots, Bool_t plots3D, Bool_t useRun1binning = kFALSE, TString cutDefinition);
 TVectorD* BinsToVector(Int_t nbins, Double_t min, Double_t max);
 TVectorD* GetVector(Int_t var, Bool_t useRun1binning = kFALSE);
 enum {kMee=0, kMee500, kPtee, kP2D, kRuns, kPhiV, kOpAng, kOpAng2, kEta2D, kEta3D, kSigmaEle, kSigmaOther, kTPCdEdx, kCent, kPhi2D};
@@ -389,6 +389,10 @@ AliDielectron* Config_acapon(TString cutDefinition,
   else if(cutDefinition == "kV0_MVAePID"){
     die->GetTrackFilter().AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kV0_trackCuts, LMEECutLib::kCutSet1));
   }
+  // Cut set to check V0 features in MC (for testing)
+  else if(cutDefinition == "kV0_allAcc"){
+    die->GetTrackFilter().AddCuts( LMcutlib->GetTrackCuts(LMEECutLib::kV0_allAcc, LMEECutLib::kV0_allAcc) );
+  }
   // ######## Different R factor bin mixing schemes #################
   else if(cutDefinition == "kMixScheme1"){
     die->GetTrackFilter().AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kCutSet1, LMEECutLib::kCutSet1));
@@ -448,14 +452,14 @@ AliDielectron* Config_acapon(TString cutDefinition,
     die->SetMixingHandler(mix);
   }
 
-  InitHistograms(die, doPairing, trackVarPlots, whichDetPlots, v0plots, plots3D, useRun1binning);
+  InitHistograms(die, doPairing, trackVarPlots, whichDetPlots, v0plots, plots3D, useRun1binning, cutDefinition);
 
   return die;
 }
 
 //______________________________________________________________________________________
 
-void InitHistograms(AliDielectron *die, Bool_t doPairing, Bool_t trackVarPlots, Int_t whichDetPlots, Bool_t v0plots, Bool_t plots3D, Bool_t useRun1binning){
+void InitHistograms(AliDielectron *die, Bool_t doPairing, Bool_t trackVarPlots, Int_t whichDetPlots, Bool_t v0plots, Bool_t plots3D, Bool_t useRun1binning, TString cutDefinition){
 
     // Setup histogram Manager
     AliDielectronHistos *histos = new AliDielectronHistos(die->GetName(),die->GetTitle());
@@ -781,6 +785,18 @@ void InitHistograms(AliDielectron *die, Bool_t doPairing, Bool_t trackVarPlots, 
                               AliDielectronVarManager::kM, AliDielectronVarManager::kPt, AliDielectronVarManager::kCentralityV0C);
     }// End doMixing histograms
 
+    // V0 feature histograms
+    if(cutDefinition == "kV0_allAcc"){
+      histos->UserHistogram("Pair", "CosPointingAngle", "", BinsToVector(100, 0, 1),    AliDielectronVarManager::kCosPointingAngle);
+      histos->UserHistogram("Pair", "Chi2NDF",          "", BinsToVector(100, 0, 100),  AliDielectronVarManager::kChi2NDF);
+      histos->UserHistogram("Pair", "LegDist",          "", BinsToVector(400, 0, 1),    AliDielectronVarManager::kLegDist);
+      histos->UserHistogram("Pair", "R",                "", BinsToVector(1000, 0, 200), AliDielectronVarManager::kR);
+      histos->UserHistogram("Pair", "PsiTrack",         "", BinsToVector(100, 0, TMath::Pi()), AliDielectronVarManager::kPsiPair);
+      histos->UserHistogram("Pair", "kM",               "", BinsToVector(2000, 0, 20),  AliDielectronVarManager::kM);
+
+      histos->UserHistogram("Pair", "ArmAlpha_armPt", "", BinsToVector(400, -2.5, 2.5), BinsToVector(500, 0, 3),
+                            AliDielectronVarManager::kArmAlpha, AliDielectronVarManager::kArmPt);
+    }
     die->SetHistogramManager(histos);
 }
 

--- a/PWGDQ/dielectron/macrosLMEE/Config_acapon_noCutLib.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_acapon_noCutLib.C
@@ -337,7 +337,7 @@ void SetSignalsMC(AliDielectron* die){
   eleFinalStateFromB->SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
   eleFinalStateFromB->SetMotherPDGs(502, 502);
   eleFinalStateFromB->SetCheckBothChargesMothers(kTRUE,kTRUE);
-  //eleFinalStateFromB->SetFillPureMCStep(kTRUE);
+  eleFinalStateFromB->SetCheckCorrelatedHF(kTRUE);
   die->AddSignalMC(eleFinalStateFromB);
 
   // Electrons from open charm mesons and baryons
@@ -347,7 +347,7 @@ void SetSignalsMC(AliDielectron* die){
   eleFinalStateFromD->SetLegSources(AliDielectronSignalMC::kFinalState, AliDielectronSignalMC::kFinalState);
   eleFinalStateFromD->SetMotherPDGs(402, 402);
   eleFinalStateFromD->SetCheckBothChargesMothers(kTRUE,kTRUE);
-  //eleFinalStateFromD->SetFillPureMCStep(kTRUE);
+  eleFinalStateFromD->SetCheckCorrelatedHF(kTRUE);
   die->AddSignalMC(eleFinalStateFromD);
 
   /* // D+- meson (1)(1) */

--- a/PWGDQ/dielectron/macrosLMEE/LMEECutLib_acapon.C
+++ b/PWGDQ/dielectron/macrosLMEE/LMEECutLib_acapon.C
@@ -13,6 +13,7 @@ class LMEECutLib {
     kV0_trackCuts,
     kPdgSel,
     kMCsel,
+    kV0_allAcc,
     kResolutionTrackCuts,
     // Linearly increasing cuts over MVA output
     kPIDcut1,
@@ -1228,21 +1229,21 @@ AliDielectronCutGroup* LMEECutLib::GetTrackCuts(Int_t cutSet, Int_t PIDcuts){
       gammaV0cuts->SetV0finder(AliDielectronV0Cuts::kOnTheFly);
       // Cut on the angle between the total momentum vector of the daughter
       // tracks and a line connecting the primary and secondary vertices
-      gammaV0cuts->AddCut(AliDielectronVarManager::kCosPointingAngle, TMath::Cos(0.02), 1.0,  kFALSE);
-      gammaV0cuts->AddCut(AliDielectronVarManager::kChi2NDF, 0.0, 10.0, kFALSE);
+      gammaV0cuts->AddCut(AliDielectronVarManager::kCosPointingAngle, TMath::Cos(0.02), 1.0);
+      gammaV0cuts->AddCut(AliDielectronVarManager::kChi2NDF, 0.0, 10.0);
       // Restrict distance between legs
-      gammaV0cuts->AddCut(AliDielectronVarManager::kLegDist, 0.0, 0.25, kFALSE);
+      gammaV0cuts->AddCut(AliDielectronVarManager::kLegDist, 0.0, 0.25);
       // Require minimum distance to secondary vertex
-      gammaV0cuts->AddCut(AliDielectronVarManager::kR, 3.0, 90.0, kFALSE);
+      gammaV0cuts->AddCut(AliDielectronVarManager::kR, 3.0, 90.0);
       // Angle between daughter momentum plane and plane perpendicular to magnetic field
-      gammaV0cuts->AddCut(AliDielectronVarManager::kPsiPair, 0.0, 0.05, kFALSE);
+      gammaV0cuts->AddCut(AliDielectronVarManager::kPsiPair, 0.0, 0.05);
       // Mass cut on V0 (mother) particle
-      gammaV0cuts->AddCut(AliDielectronVarManager::kM, 0.0, 0.05, kFALSE);
+      gammaV0cuts->AddCut(AliDielectronVarManager::kM, 0.0, 0.05);
       // Armenteros-Podolanksi variables
       // Pt
-      gammaV0cuts->AddCut(AliDielectronVarManager::kArmPt, 0.0, 0.05, kFALSE);
+      gammaV0cuts->AddCut(AliDielectronVarManager::kArmPt, 0.0, 0.05);
       // Longitudinal momentum asymmentry between daughter particles
-      gammaV0cuts->AddCut(AliDielectronVarManager::kArmAlpha, -0.35, 0.35, kFALSE);
+      gammaV0cuts->AddCut(AliDielectronVarManager::kArmAlpha, -0.35, 0.35);
       // Default setting is to exclude V0 tracks
       gammaV0cuts->SetExcludeTracks(kFALSE);
       // Standard track cut variables
@@ -1253,6 +1254,20 @@ AliDielectronCutGroup* LMEECutLib::GetTrackCuts(Int_t cutSet, Int_t PIDcuts){
       trackCuts->AddCut(gammaV0cuts);
       trackCuts->AddCut(trackCutsV0);
       trackCuts->AddCut(GetPIDCuts(PIDcuts));
+      trackCuts->Print();
+      return trackCuts;
+    case kV0_allAcc: // Cut setting to check MC V0 features
+      // No V0 track cuts applied as want to see distributions
+      gammaV0cuts->SetV0finder(AliDielectronV0Cuts::kOnTheFly);
+      // Default setting is to exclude V0 tracks
+      gammaV0cuts->SetExcludeTracks(kFALSE);
+      /* // Standard track cut variables */
+      trackCutsV0->AddCut(AliDielectronVarManager::kTPCchi2Cl, 0.0, 4.0);
+      trackCutsV0->AddCut(AliDielectronVarManager::kNFclsTPCr, 100.0, 160.0);
+      trackCutsV0->AddCut(AliDielectronVarManager::kNFclsTPCfCross, 0.8, 1.1);
+      trackCuts->AddCut(gammaV0cuts);
+      trackCuts->AddCut(trackCutsV0);
+      /* trackCuts->AddCut(GetPIDCuts(PIDcuts)); */
       trackCuts->Print();
       return trackCuts;
     case kMCsel:


### PR DESCRIPTION
V0 histograms added to a new cut setting "kV0_allAcc" which finds all V0 candidates but does not apply cuts. 

HF particle correlation check now switched on in no cut lib config file.

Passing of default arguments removed from a cut setting in my CutLib to avoid confusion.