### PR TITLE
add LctopKpi resonant decay ID at reco and gen level when running on MC

### DIFF
--- a/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
+++ b/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
@@ -838,6 +838,7 @@ void AliAnalysisTaskSEHFTreeCreator::UserCreateOutputObjects()
         TString nameoutput = "tree_LctopKpi_gen";
         fTreeHandlerGenLctopKpi = new AliHFTreeHandlerLctopKpi(0);
         fGenTreeLctopKpi = (TTree*)fTreeHandlerGenLctopKpi->BuildTreeMCGen(nameoutput,nameoutput);
+        fTreeHandlerGenLctopKpi->AddBranchResonantDecay(fGenTreeLctopKpi);
         fGenTreeLctopKpi->SetMaxVirtualSize(1.e+8/nEnabledTrees);
         fTreeEvChar->AddFriend(fGenTreeLctopKpi);
       }
@@ -2192,6 +2193,7 @@ void AliAnalysisTaskSEHFTreeCreator::Process3Prong(TClonesArray *array3Prong, Al
                   bool isrefl=kFALSE;
                   Int_t labDp=-1;
                   Float_t ptGenLcpKpi = -99.;
+                  int restype = -1;
                   if(ispKpi) {
                     //read MC
                     if(fReadMC){
@@ -2210,18 +2212,19 @@ void AliAnalysisTaskSEHFTreeCreator::Process3Prong(TClonesArray *array3Prong, Al
                                 isPrimary=kFALSE;
                                 isFeeddown=kTRUE;
                             }
-                            //check daughters
-                            Int_t labDauLc0=((AliAODTrack*)lctopkpi->GetDaughter(0))->GetLabel();
-                            Int_t labDauLc1=((AliAODTrack*)lctopkpi->GetDaughter(1))->GetLabel();
-                            Int_t labDauLc2=((AliAODTrack*)lctopkpi->GetDaughter(2))->GetLabel();
-                            AliAODMCParticle* pDauLc0=(AliAODMCParticle*)arrMC->UncheckedAt(TMath::Abs(labDauLc0));
-                            AliAODMCParticle* pDauLc1=(AliAODMCParticle*)arrMC->UncheckedAt(TMath::Abs(labDauLc1));
-                            AliAODMCParticle* pDauLc2=(AliAODMCParticle*)arrMC->UncheckedAt(TMath::Abs(labDauLc2));
-                            Int_t pdgDauLc0=TMath::Abs(pDauLc0->GetPdgCode());
-                            Int_t pdgDauLc1=TMath::Abs(pDauLc1->GetPdgCode());
-                            Int_t pdgDauLc2=TMath::Abs(pDauLc2->GetPdgCode());
-                            if(pdgDauLc0==211 && pdgDauLc1==321 && pdgDauLc2==2212) isrefl=kTRUE;
                         }
+                        //check daughters
+                        Int_t labDauLc0=((AliAODTrack*)lctopkpi->GetDaughter(0))->GetLabel();
+                        Int_t labDauLc1=((AliAODTrack*)lctopkpi->GetDaughter(1))->GetLabel();
+                        Int_t labDauLc2=((AliAODTrack*)lctopkpi->GetDaughter(2))->GetLabel();
+                        AliAODMCParticle* pDauLc0=(AliAODMCParticle*)arrMC->UncheckedAt(TMath::Abs(labDauLc0));
+                        AliAODMCParticle* pDauLc1=(AliAODMCParticle*)arrMC->UncheckedAt(TMath::Abs(labDauLc1));
+                        AliAODMCParticle* pDauLc2=(AliAODMCParticle*)arrMC->UncheckedAt(TMath::Abs(labDauLc2));
+                        Int_t pdgDauLc0=TMath::Abs(pDauLc0->GetPdgCode());
+                        Int_t pdgDauLc1=TMath::Abs(pDauLc1->GetPdgCode());
+                        Int_t pdgDauLc2=TMath::Abs(pDauLc2->GetPdgCode());
+                        if(pdgDauLc0==211 && pdgDauLc1==321 && pdgDauLc2==2212) isrefl=kTRUE;
+                        restype = fTreeHandlerLctopKpi->GetLcResonantDecay(arrMC,partDp);
                       }
                       else isbkg=kTRUE;
                       if(issignal || isbkg) fTreeHandlerLctopKpi->SetCandidateType(issignal,isbkg,isPrimary,isFeeddown,isrefl);
@@ -2232,6 +2235,7 @@ void AliAnalysisTaskSEHFTreeCreator::Process3Prong(TClonesArray *array3Prong, Al
                     if(!fReadMC || (issignal || isbkg)) {
                         fTreeHandlerLctopKpi->SetIsSelectedStd(isSelAnCutspKpi,isSelTopopKpi,isSelPIDpKpi,isSelTracksAnCuts);
                         fTreeHandlerLctopKpi->SetVariables(fRunNumber,fEventID,ptGenLcpKpi,lctopkpi,bfield,1,fPIDresp);
+                        fTreeHandlerLctopKpi->SetVariableResonantDecay(restype);
                         fTreeHandlerLctopKpi->FillTree();
                     }
                   } // end pKpi
@@ -2241,6 +2245,7 @@ void AliAnalysisTaskSEHFTreeCreator::Process3Prong(TClonesArray *array3Prong, Al
                   isbkg=kFALSE;
                   isrefl=kFALSE;
                   labDp=-1;
+                  restype = -1;
                   if(ispiKp) {
                     //read MC
                     if(fReadMC){
@@ -2271,6 +2276,7 @@ void AliAnalysisTaskSEHFTreeCreator::Process3Prong(TClonesArray *array3Prong, Al
                             Int_t pdgDauLc1=TMath::Abs(pDauLc1->GetPdgCode());
                             Int_t pdgDauLc2=TMath::Abs(pDauLc2->GetPdgCode());
                             if(pdgDauLc0==2212 && pdgDauLc1==321 && pdgDauLc2==211) isrefl=kTRUE;
+                            restype = fTreeHandlerLctopKpi->GetLcResonantDecay(arrMC,partDp);
                       }
                       else isbkg=kTRUE;
                       if(issignal || isbkg) fTreeHandlerLctopKpi->SetCandidateType(issignal,isbkg,isPrimary,isFeeddown,isrefl);
@@ -2281,6 +2287,7 @@ void AliAnalysisTaskSEHFTreeCreator::Process3Prong(TClonesArray *array3Prong, Al
                     if(!fReadMC || (issignal || isbkg)) {
                         fTreeHandlerLctopKpi->SetIsSelectedStd(isSelAnCutspiKp,isSelTopopiKp,isSelPIDpiKp,isSelTracksAnCuts);
                         fTreeHandlerLctopKpi->SetVariables(fRunNumber,fEventID,ptGenLcpKpi,lctopkpi,bfield,2,fPIDresp);
+                        fTreeHandlerLctopKpi->SetVariableResonantDecay(restype);
                         fTreeHandlerLctopKpi->FillTree();
                     }
                   } // end fill piKpi
@@ -2666,6 +2673,8 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessMCGen(TClonesArray *arrayMC){
             fTreeHandlerGenLctopKpi->SetDauInAcceptance(isDaugInAcc);
             fTreeHandlerGenLctopKpi->SetCandidateType(kTRUE,kFALSE,isPrimary,isFeeddown,kFALSE);
             fTreeHandlerGenLctopKpi->SetMCGenVariables(fRunNumber,fEventID, mcPart);
+            int resdecay = fTreeHandlerGenLctopKpi->GetLcResonantDecay(arrayMC,mcPart);
+            fTreeHandlerGenLctopKpi->SetMCGenVariableResonantDecay(resdecay);
             fTreeHandlerGenLctopKpi->FillTree();
           }
         }

--- a/PWGHF/treeHF/AliHFTreeHandlerLctopKpi.cxx
+++ b/PWGHF/treeHF/AliHFTreeHandlerLctopKpi.cxx
@@ -33,7 +33,9 @@ AliHFTreeHandlerLctopKpi::AliHFTreeHandlerLctopKpi():
   fDist12toPrim(-9999.),
   fDist23toPrim(-9999.),
   fNormd0MeasMinusExp(-9999.),
-  fSumImpParProngs(-9999.)
+  fSumImpParProngs(-9999.),
+  fResonantDecayType(0),
+  fResonantDecayTypeMC(0)
 {
   //
   // Default constructor
@@ -53,7 +55,9 @@ AliHFTreeHandlerLctopKpi::AliHFTreeHandlerLctopKpi(int PIDopt):
   fDist12toPrim(-9999.),
   fDist23toPrim(-9999.),
   fNormd0MeasMinusExp(-9999.),
-  fSumImpParProngs(-9999.)
+  fSumImpParProngs(-9999.),
+  fResonantDecayType(0),
+  fResonantDecayTypeMC(0)
 {
   //
   // Standard constructor
@@ -98,6 +102,7 @@ TTree* AliHFTreeHandlerLctopKpi::BuildTree(TString name, TString title)
     fTreeVar->Branch(Form("imp_par_prong%d",iProng),&fImpParProng[iProng]);
     fTreeVar->Branch(Form("dca_prong%d",iProng),&fDCAProng[iProng]);
   }
+  fTreeVar->Branch("resonant_decay_mc",&fResonantDecayType);
 
   //set single-track variables
   AddSingleTrackBranches();
@@ -164,4 +169,93 @@ bool AliHFTreeHandlerLctopKpi::SetVariables(int runnumber, unsigned int eventID,
   if(!setpid) return false;
 
   return true;
+}
+
+void AliHFTreeHandlerLctopKpi::AddBranchResonantDecay(TTree *t) {
+  t->Branch("resonant_decay_mc",&fResonantDecayTypeMC);
+}
+
+
+int AliHFTreeHandlerLctopKpi::GetLcResonantDecay(TClonesArray *arrMC, AliAODMCParticle *mcPart) 
+{
+  int numberOfLambdac=0;
+  if(TMath::Abs(mcPart->GetPdgCode())!=4122) return -1;
+  Int_t nDaugh = (Int_t)mcPart->GetNDaughters();
+  if(nDaugh<2) return -1;
+  if(nDaugh>3) return -1;
+  AliAODMCParticle* pdaugh1 = (AliAODMCParticle*)arrMC->At(mcPart->GetDaughterLabel(0));
+  if(!pdaugh1) {return -1;}
+  Int_t number1 = TMath::Abs(pdaugh1->GetPdgCode());
+  AliAODMCParticle* pdaugh2 = (AliAODMCParticle*)arrMC->At(mcPart->GetDaughterLabel(1));
+  if(!pdaugh2) {return -1;}
+  Int_t number2 = TMath::Abs(pdaugh2->GetPdgCode());
+  if(nDaugh==3){
+    Int_t thirdDaugh=mcPart->GetDaughterLabel(1)-1;
+    AliAODMCParticle* pdaugh3 = (AliAODMCParticle*)arrMC->At(thirdDaugh);
+    if(!pdaugh3) return -1;
+    Int_t number3 = TMath::Abs(pdaugh3->GetPdgCode());
+    if((number1==321 && number2==211 && number3==2212) || (number1==211 && number2==321 && number3==2212) || (number1==211 && number2==2212 && number3==321) || (number1==321 && number2==2212 && number3==211) || (number1==2212 && number2==321 && number3==211) || (number1==2212 && number2==211 && number3==321)) numberOfLambdac = kNonResonant;
+  }
+  if(nDaugh==2){
+    Int_t nfiglieK=0;
+    if((number1==2212 && number2==313)){
+      nfiglieK=pdaugh2->GetNDaughters();
+      if(nfiglieK!=2) return -1;
+      AliAODMCParticle* pdaughK1 = (AliAODMCParticle*)arrMC->At(pdaugh2->GetDaughterLabel(0));
+      AliAODMCParticle* pdaughK2 = (AliAODMCParticle*)arrMC->At(pdaugh2->GetDaughterLabel(1));
+      if(!pdaughK1) return -1;
+      if(!pdaughK2) return -1;
+      if((TMath::Abs(pdaughK1->GetPdgCode())==211 && TMath::Abs(pdaughK2->GetPdgCode())==321) || (TMath::Abs(pdaughK1->GetPdgCode())==321 && TMath::Abs(pdaughK2->GetPdgCode())==211)) numberOfLambdac = kKstar;
+    }
+    if((number1==313 && number2==2212)){
+      nfiglieK=pdaugh1->GetNDaughters();
+      if(nfiglieK!=2) return -1;
+      AliAODMCParticle* pdaughK1 = (AliAODMCParticle*)arrMC->At(pdaugh1->GetDaughterLabel(0));
+      AliAODMCParticle* pdaughK2 = (AliAODMCParticle*)arrMC->At(pdaugh1->GetDaughterLabel(1));
+      if(!pdaughK1) return -1;
+      if(!pdaughK2) return -1;
+      if((TMath::Abs(pdaughK1->GetPdgCode())==211 && TMath::Abs(pdaughK2->GetPdgCode())==321) || (TMath::Abs(pdaughK1->GetPdgCode())==321 && TMath::Abs(pdaughK2->GetPdgCode())==211)) numberOfLambdac = kKstar;
+    }
+    Int_t nfiglieDelta=0;
+    if(number1==321 && number2==2224){
+      nfiglieDelta=pdaugh2->GetNDaughters();
+      if(nfiglieDelta!=2) return -1;
+      AliAODMCParticle *pdaughD1=(AliAODMCParticle*)arrMC->At(pdaugh2->GetDaughterLabel(0));
+      AliAODMCParticle *pdaughD2=(AliAODMCParticle*)arrMC->At(pdaugh2->GetDaughterLabel(1));
+      if(!pdaughD1) return -1;
+      if(!pdaughD2) return -1;
+      if((TMath::Abs(pdaughD1->GetPdgCode())==211 && TMath::Abs(pdaughD2->GetPdgCode())==2212) || (TMath::Abs(pdaughD1->GetPdgCode())==2212 && TMath::Abs(pdaughD2->GetPdgCode())==211)) numberOfLambdac = kDelta;
+    }
+    if(number1==2224 && number2==321){
+      nfiglieDelta=pdaugh1->GetNDaughters();
+      if(nfiglieDelta!=2) return -1;
+      AliAODMCParticle* pdaughD1 = (AliAODMCParticle*)arrMC->At(pdaugh1->GetDaughterLabel(0));
+      AliAODMCParticle* pdaughD2 = (AliAODMCParticle*)arrMC->At(pdaugh1->GetDaughterLabel(1));
+      if(!pdaughD1) return -1;
+      if(!pdaughD2) return -1;
+      if((TMath::Abs(pdaughD1->GetPdgCode())==211 && TMath::Abs(pdaughD2->GetPdgCode())==2212) || (TMath::Abs(pdaughD1->GetPdgCode())==2212 && TMath::Abs(pdaughD2->GetPdgCode())==211)) numberOfLambdac = kDelta;
+    }
+
+    Int_t nfiglieLa=0;
+    if(number1==3124 && number2==211){
+      nfiglieLa=pdaugh1->GetNDaughters();
+      if(nfiglieLa!=2) return -1;
+      AliAODMCParticle *pdaughL1=(AliAODMCParticle*)arrMC->At(pdaugh1->GetDaughterLabel(0));
+      AliAODMCParticle *pdaughL2=(AliAODMCParticle*)arrMC->At(pdaugh1->GetDaughterLabel(1));
+      if(!pdaughL1) return -1;
+      if(!pdaughL2) return -1;
+      if((TMath::Abs(pdaughL1->GetPdgCode())==321 && TMath::Abs(pdaughL2->GetPdgCode())==2212) || (TMath::Abs(pdaughL1->GetPdgCode())==2212 && TMath::Abs(pdaughL2->GetPdgCode())==321)) numberOfLambdac = kL1520;
+    }
+    if(number1==211 && number2==3124){
+      nfiglieLa=pdaugh2->GetNDaughters();
+      if(nfiglieLa!=2) return -1;
+      AliAODMCParticle *pdaughL1=(AliAODMCParticle*)arrMC->At(pdaugh2->GetDaughterLabel(0));
+      AliAODMCParticle *pdaughL2=(AliAODMCParticle*)arrMC->At(pdaugh2->GetDaughterLabel(1));
+      if(!pdaughL1) return -1;
+      if(!pdaughL2) return -1;
+      if((TMath::Abs(pdaughL1->GetPdgCode())==321 && TMath::Abs(pdaughL2->GetPdgCode())==2212) || (TMath::Abs(pdaughL1->GetPdgCode())==2212 && TMath::Abs(pdaughL2->GetPdgCode())==321)) numberOfLambdac = kL1520;
+
+    }
+  }
+  return numberOfLambdac;
 }

--- a/PWGHF/treeHF/AliHFTreeHandlerLctopKpi.h
+++ b/PWGHF/treeHF/AliHFTreeHandlerLctopKpi.h
@@ -26,6 +26,14 @@
 class AliHFTreeHandlerLctopKpi : public AliHFTreeHandler
 {
   public:
+
+    enum resdecaytype {
+      kNonResonant = BIT(0),
+      kL1520       = BIT(1),
+      kKstar       = BIT(2),
+      kDelta       = BIT(3)
+    };
+
     AliHFTreeHandlerLctopKpi();
     AliHFTreeHandlerLctopKpi(int PIDopt);
 
@@ -33,6 +41,10 @@ class AliHFTreeHandlerLctopKpi : public AliHFTreeHandler
 
     virtual TTree* BuildTree(TString name="tree", TString title="tree");
     virtual bool SetVariables(int runnumber, unsigned int eventID, float ptgen, AliAODRecoDecayHF* cand, float bfield, int masshypo=0, AliPIDResponse *pidrespo=0x0);
+    void SetVariableResonantDecay(int restype) {fResonantDecayType = restype;}
+    void SetMCGenVariableResonantDecay(int restype) {fResonantDecayTypeMC = restype;}
+    void AddBranchResonantDecay(TTree *t);
+    int GetLcResonantDecay(TClonesArray *arrMC, AliAODMCParticle *mcPart);
 
   private:
 
@@ -43,9 +55,11 @@ class AliHFTreeHandlerLctopKpi : public AliHFTreeHandler
     float fDist23toPrim; ///candidate distance between track 2-3 vertex to primary vertex
     float fNormd0MeasMinusExp; ///candidate topomatic variable
     float fSumImpParProngs; ///sum of prong impact parameter squared
+    int fResonantDecayType; ///resonant decay type reco
+    int fResonantDecayTypeMC; ///resonant decay type MC
 
     /// \cond CLASSIMP
-    ClassDef(AliHFTreeHandlerLctopKpi,4); ///
+    ClassDef(AliHFTreeHandlerLctopKpi,5); ///
     /// \endcond
 };
 #endif


### PR DESCRIPTION
in Lc tree handler:
- added branches to reco and gen ttrees to store resonant decay info
- added bitmap for 4 different decays
- added function to ID resonant decay (based on AliCFVertexingHF3Prong::CheckLc3Prong() )
In tree creator analysis task:
- added id and setting of resonant decays