### PR TITLE
PWGUD/UPC: XNXN systematics + new binning 1D.

### DIFF
--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
@@ -99,8 +99,17 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward()
       fRunNumberTriggerCMUP13ClassProperlyH(0),
       fTriggersVsRunH(0),
       fInvariantMassDistributionCoherentH(0),
+      fInvariantMassDistributionCoherentShiftMinusTwoH(0),
+      fInvariantMassDistributionCoherentShiftMinusOneH(0),
+      fInvariantMassDistributionCoherentShiftPlusOneH(0),
+      fInvariantMassDistributionCoherentShiftPlusTwoH(0),
       fInvariantMassDistributionIncoherentH(0),
+      fInvariantMassDistributionIncoherentShiftMinusTwoH(0),
+      fInvariantMassDistributionIncoherentShiftMinusOneH(0),
+      fInvariantMassDistributionIncoherentShiftPlusOneH(0),
+      fInvariantMassDistributionIncoherentShiftPlusTwoH(0),
       fDimuonPtDistributionH(0),
+      fDimuonPtDistributionShiftPlusOneH(0),
       fZNCEnergyAgainstEntriesH(0),
       fZNAEnergyAgainstEntriesH(0),
       fZNCEnergyBeforeTimingSelectionH(0),
@@ -166,17 +175,53 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward()
       fV0TotalNCells(0),
       // fVectorGoodRunNumbers(0),
       fInvariantMassDistributionCoherentZNCzeroZNAzeroH(0),
+      fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftMinusTwoH(0),
+      fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftMinusOneH(0),
+      fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftPlusOneH(0),
+      fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftPlusTwoH(0),
       fInvariantMassDistributionCoherentZNCzeroZNAanyH(0),
+      fInvariantMassDistributionCoherentZNCzeroZNAanyShiftMinusTwoH(0),
+      fInvariantMassDistributionCoherentZNCzeroZNAanyShiftMinusOneH(0),
+      fInvariantMassDistributionCoherentZNCzeroZNAanyShiftPlusOneH(0),
+      fInvariantMassDistributionCoherentZNCzeroZNAanyShiftPlusTwoH(0),
       fInvariantMassDistributionCoherentZNCanyZNAzeroH(0),
+      fInvariantMassDistributionCoherentZNCanyZNAzeroShiftMinusTwoH(0),
+      fInvariantMassDistributionCoherentZNCanyZNAzeroShiftMinusOneH(0),
+      fInvariantMassDistributionCoherentZNCanyZNAzeroShiftPlusOneH(0),
+      fInvariantMassDistributionCoherentZNCanyZNAzeroShiftPlusTwoH(0),
       fInvariantMassDistributionCoherentZNCanyZNAanyH(0),
+      fInvariantMassDistributionCoherentZNCanyZNAanyShiftMinusTwoH(0),
+      fInvariantMassDistributionCoherentZNCanyZNAanyShiftMinusOneH(0),
+      fInvariantMassDistributionCoherentZNCanyZNAanyShiftPlusOneH(0),
+      fInvariantMassDistributionCoherentZNCanyZNAanyShiftPlusTwoH(0),
       fInvariantMassDistributionIncoherentZNCzeroZNAzeroH(0),
+      fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftMinusTwoH(0),
+      fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftMinusOneH(0),
+      fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftPlusOneH(0),
+      fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftPlusTwoH(0),
       fInvariantMassDistributionIncoherentZNCzeroZNAanyH(0),
+      fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftMinusTwoH(0),
+      fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftMinusOneH(0),
+      fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftPlusOneH(0),
+      fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftPlusTwoH(0),
       fInvariantMassDistributionIncoherentZNCanyZNAzeroH(0),
+      fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftMinusTwoH(0),
+      fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftMinusOneH(0),
+      fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftPlusOneH(0),
+      fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftPlusTwoH(0),
       fInvariantMassDistributionIncoherentZNCanyZNAanyH(0),
+      fInvariantMassDistributionIncoherentZNCanyZNAanyShiftMinusTwoH(0),
+      fInvariantMassDistributionIncoherentZNCanyZNAanyShiftMinusOneH(0),
+      fInvariantMassDistributionIncoherentZNCanyZNAanyShiftPlusOneH(0),
+      fInvariantMassDistributionIncoherentZNCanyZNAanyShiftPlusTwoH(0),
       fDimuonPtDistributionZNCzeroZNAzeroH(0),
       fDimuonPtDistributionZNCzeroZNAanyH(0),
       fDimuonPtDistributionZNCanyZNAzeroH(0),
       fDimuonPtDistributionZNCanyZNAanyH(0),
+      fDimuonPtDistributionZNCzeroZNAzeroShiftPlusOneH(0),
+      fDimuonPtDistributionZNCzeroZNAanyShiftPlusOneH(0),
+      fDimuonPtDistributionZNCanyZNAzeroShiftPlusOneH(0),
+      fDimuonPtDistributionZNCanyZNAanyShiftPlusOneH(0),
       fDimuonPtDistributionCoherentZNCzeroZNAzeroH(0),
       fDimuonPtDistributionCoherentZNCzeroZNAanyH(0),
       fDimuonPtDistributionCoherentZNCanyZNAzeroH(0),
@@ -232,7 +277,8 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward()
                                                                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                                                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
       fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMyStrictVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0 },
-      fInvariantMassDistributionOnlyPhiForSignalExtractionHelicityFrameMyStrictVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
+      fInvariantMassDistributionOnlyPhiForSignalExtractionHelicityFrameMyStrictVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+      fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMySeventeenBinsVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
 {
     // default constructor, don't allocate memory here!
     // this is used by root for IO purposes, it needs to remain empty
@@ -263,7 +309,15 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward(const char* name)
       fRunNumberTriggerCMUP13ClassProperlyH(0),
       fTriggersVsRunH(0),
       fInvariantMassDistributionCoherentH(0),
+      fInvariantMassDistributionCoherentShiftMinusTwoH(0),
+      fInvariantMassDistributionCoherentShiftMinusOneH(0),
+      fInvariantMassDistributionCoherentShiftPlusOneH(0),
+      fInvariantMassDistributionCoherentShiftPlusTwoH(0),
       fInvariantMassDistributionIncoherentH(0),
+      fInvariantMassDistributionIncoherentShiftMinusTwoH(0),
+      fInvariantMassDistributionIncoherentShiftMinusOneH(0),
+      fInvariantMassDistributionIncoherentShiftPlusOneH(0),
+      fInvariantMassDistributionIncoherentShiftPlusTwoH(0),
       fDimuonPtDistributionH(0),
       fZNCEnergyAgainstEntriesH(0),
       fZNAEnergyAgainstEntriesH(0),
@@ -396,7 +450,8 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward(const char* name)
                                                                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                                                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
       fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMyStrictVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0 },
-      fInvariantMassDistributionOnlyPhiForSignalExtractionHelicityFrameMyStrictVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
+      fInvariantMassDistributionOnlyPhiForSignalExtractionHelicityFrameMyStrictVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+      fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMySeventeenBinsVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
 {
     // FillGoodRunVector(fVectorGoodRunNumbers);
 
@@ -631,11 +686,38 @@ void AliAnalysisTaskUPCforward::UserCreateOutputObjects()
   fInvariantMassDistributionCoherentH = new TH1F("fInvariantMassDistributionCoherentH", "fInvariantMassDistributionCoherentH", 2000, 0, 20);
   fOutputList->Add(fInvariantMassDistributionCoherentH);
 
+  fInvariantMassDistributionCoherentShiftMinusTwoH = new TH1F("fInvariantMassDistributionCoherentShiftMinusTwoH", "fInvariantMassDistributionCoherentShiftMinusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentShiftMinusTwoH);
+
+  fInvariantMassDistributionCoherentShiftMinusOneH = new TH1F("fInvariantMassDistributionCoherentShiftMinusOneH", "fInvariantMassDistributionCoherentShiftMinusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentShiftMinusOneH);
+
+  fInvariantMassDistributionCoherentShiftPlusOneH = new TH1F("fInvariantMassDistributionCoherentShiftPlusOneH", "fInvariantMassDistributionCoherentShiftPlusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentShiftPlusOneH);
+
+  fInvariantMassDistributionCoherentShiftPlusTwoH = new TH1F("fInvariantMassDistributionCoherentShiftPlusTwoH", "fInvariantMassDistributionCoherentShiftPlusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentShiftPlusTwoH);
+
   fInvariantMassDistributionIncoherentH = new TH1F("fInvariantMassDistributionIncoherentH", "fInvariantMassDistributionIncoherentH", 2000, 0, 20);
   fOutputList->Add(fInvariantMassDistributionIncoherentH);
 
+  fInvariantMassDistributionIncoherentShiftMinusTwoH = new TH1F("fInvariantMassDistributionIncoherentShiftMinusTwoH", "fInvariantMassDistributionIncoherentShiftMinusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentShiftMinusTwoH);
+
+  fInvariantMassDistributionIncoherentShiftMinusOneH = new TH1F("fInvariantMassDistributionIncoherentShiftMinusOneH", "fInvariantMassDistributionIncoherentShiftMinusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentShiftMinusOneH);
+
+  fInvariantMassDistributionIncoherentShiftPlusOneH = new TH1F("fInvariantMassDistributionIncoherentShiftPlusOneH", "fInvariantMassDistributionIncoherentShiftPlusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentShiftPlusOneH);
+
+  fInvariantMassDistributionIncoherentShiftPlusTwoH = new TH1F("fInvariantMassDistributionIncoherentShiftPlusTwoH", "fInvariantMassDistributionIncoherentShiftPlusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentShiftPlusTwoH);
+
   fDimuonPtDistributionH = new TH1F("fDimuonPtDistributionH", "fDimuonPtDistributionH", 4000, 0, 20);
   fOutputList->Add(fDimuonPtDistributionH);
+
+  fDimuonPtDistributionShiftPlusOneH = new TH1F("fDimuonPtDistributionShiftPlusOneH", "fDimuonPtDistributionShiftPlusOneH", 4000, 0.02, 20.02);
+  fOutputList->Add(fDimuonPtDistributionShiftPlusOneH);
 
   fZNCEnergyAgainstEntriesH = new TH1F("fZNCEnergyAgainstEntriesH", "fZNCEnergyAgainstEntriesH", 20000, -10000, 40000);
   fOutputList->Add(fZNCEnergyAgainstEntriesH);
@@ -767,26 +849,122 @@ void AliAnalysisTaskUPCforward::UserCreateOutputObjects()
   fInvariantMassDistributionCoherentZNCzeroZNAzeroH = new TH1F("fInvariantMassDistributionCoherentZNCzeroZNAzeroH", "fInvariantMassDistributionCoherentZNCzeroZNAzeroH", 2000, 0, 20);
   fOutputList->Add(fInvariantMassDistributionCoherentZNCzeroZNAzeroH);
 
+  fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftMinusTwoH = new TH1F("fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftMinusTwoH", "fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftMinusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftMinusTwoH);
+
+  fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftMinusOneH = new TH1F("fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftMinusOneH", "fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftMinusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftMinusOneH);
+
+  fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftPlusOneH = new TH1F("fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftPlusOneH", "fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftPlusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftPlusOneH);
+
+  fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftPlusTwoH = new TH1F("fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftPlusTwoH", "fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftPlusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftPlusTwoH);
+
   fInvariantMassDistributionCoherentZNCzeroZNAanyH = new TH1F("fInvariantMassDistributionCoherentZNCzeroZNAanyH", "fInvariantMassDistributionCoherentZNCzeroZNAanyH", 2000, 0, 20);
   fOutputList->Add(fInvariantMassDistributionCoherentZNCzeroZNAanyH);
+
+  fInvariantMassDistributionCoherentZNCzeroZNAanyShiftMinusTwoH = new TH1F("fInvariantMassDistributionCoherentZNCzeroZNAanyShiftMinusTwoH", "fInvariantMassDistributionCoherentZNCzeroZNAanyShiftMinusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentZNCzeroZNAanyShiftMinusTwoH);
+
+  fInvariantMassDistributionCoherentZNCzeroZNAanyShiftMinusOneH = new TH1F("fInvariantMassDistributionCoherentZNCzeroZNAanyShiftMinusOneH", "fInvariantMassDistributionCoherentZNCzeroZNAanyShiftMinusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentZNCzeroZNAanyShiftMinusOneH);
+
+  fInvariantMassDistributionCoherentZNCzeroZNAanyShiftPlusOneH = new TH1F("fInvariantMassDistributionCoherentZNCzeroZNAanyShiftPlusOneH", "fInvariantMassDistributionCoherentZNCzeroZNAanyShiftPlusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentZNCzeroZNAanyShiftPlusOneH);
+
+  fInvariantMassDistributionCoherentZNCzeroZNAanyShiftPlusTwoH = new TH1F("fInvariantMassDistributionCoherentZNCzeroZNAanyShiftPlusTwoH", "fInvariantMassDistributionCoherentZNCzeroZNAanyShiftPlusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentZNCzeroZNAanyShiftPlusTwoH);
 
   fInvariantMassDistributionCoherentZNCanyZNAzeroH = new TH1F("fInvariantMassDistributionCoherentZNCanyZNAzeroH", "fInvariantMassDistributionCoherentZNCanyZNAzeroH", 2000, 0, 20);
   fOutputList->Add(fInvariantMassDistributionCoherentZNCanyZNAzeroH);
 
+  fInvariantMassDistributionCoherentZNCanyZNAzeroShiftMinusTwoH = new TH1F("fInvariantMassDistributionCoherentZNCanyZNAzeroShiftMinusTwoH", "fInvariantMassDistributionCoherentZNCanyZNAzeroShiftMinusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentZNCanyZNAzeroShiftMinusTwoH);
+
+  fInvariantMassDistributionCoherentZNCanyZNAzeroShiftMinusOneH = new TH1F("fInvariantMassDistributionCoherentZNCanyZNAzeroShiftMinusOneH", "fInvariantMassDistributionCoherentZNCanyZNAzeroShiftMinusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentZNCanyZNAzeroShiftMinusOneH);
+
+  fInvariantMassDistributionCoherentZNCanyZNAzeroShiftPlusOneH = new TH1F("fInvariantMassDistributionCoherentZNCanyZNAzeroShiftPlusOneH", "fInvariantMassDistributionCoherentZNCanyZNAzeroShiftPlusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentZNCanyZNAzeroShiftPlusOneH);
+
+  fInvariantMassDistributionCoherentZNCanyZNAzeroShiftPlusTwoH = new TH1F("fInvariantMassDistributionCoherentZNCanyZNAzeroShiftPlusTwoH", "fInvariantMassDistributionCoherentZNCanyZNAzeroShiftPlusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentZNCanyZNAzeroShiftPlusTwoH);
+
   fInvariantMassDistributionCoherentZNCanyZNAanyH = new TH1F("fInvariantMassDistributionCoherentZNCanyZNAanyH", "fInvariantMassDistributionCoherentZNCanyZNAanyH", 2000, 0, 20);
   fOutputList->Add(fInvariantMassDistributionCoherentZNCanyZNAanyH);
+
+  fInvariantMassDistributionCoherentZNCanyZNAanyShiftMinusTwoH = new TH1F("fInvariantMassDistributionCoherentZNCanyZNAanyShiftMinusTwoH", "fInvariantMassDistributionCoherentZNCanyZNAanyShiftMinusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentZNCanyZNAanyShiftMinusTwoH);
+
+  fInvariantMassDistributionCoherentZNCanyZNAanyShiftMinusOneH = new TH1F("fInvariantMassDistributionCoherentZNCanyZNAanyShiftMinusOneH", "fInvariantMassDistributionCoherentZNCanyZNAanyShiftMinusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentZNCanyZNAanyShiftMinusOneH);
+
+  fInvariantMassDistributionCoherentZNCanyZNAanyShiftPlusOneH = new TH1F("fInvariantMassDistributionCoherentZNCanyZNAanyShiftPlusOneH", "fInvariantMassDistributionCoherentZNCanyZNAanyShiftPlusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentZNCanyZNAanyShiftPlusOneH);
+
+  fInvariantMassDistributionCoherentZNCanyZNAanyShiftPlusTwoH = new TH1F("fInvariantMassDistributionCoherentZNCanyZNAanyShiftPlusTwoH", "fInvariantMassDistributionCoherentZNCanyZNAanyShiftPlusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionCoherentZNCanyZNAanyShiftPlusTwoH);
 
   fInvariantMassDistributionIncoherentZNCzeroZNAzeroH = new TH1F("fInvariantMassDistributionIncoherentZNCzeroZNAzeroH", "fInvariantMassDistributionIncoherentZNCzeroZNAzeroH", 2000, 0, 20);
   fOutputList->Add(fInvariantMassDistributionIncoherentZNCzeroZNAzeroH);
 
+  fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftMinusTwoH = new TH1F("fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftMinusTwoH", "fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftMinusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftMinusTwoH);
+
+  fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftMinusOneH = new TH1F("fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftMinusOneH", "fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftMinusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftMinusOneH);
+
+  fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftPlusOneH = new TH1F("fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftPlusOneH", "fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftPlusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftPlusOneH);
+
+  fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftPlusTwoH = new TH1F("fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftPlusTwoH", "fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftPlusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftPlusTwoH);
+
   fInvariantMassDistributionIncoherentZNCzeroZNAanyH = new TH1F("fInvariantMassDistributionIncoherentZNCzeroZNAanyH", "fInvariantMassDistributionIncoherentZNCzeroZNAanyH", 2000, 0, 20);
   fOutputList->Add(fInvariantMassDistributionIncoherentZNCzeroZNAanyH);
+
+  fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftMinusTwoH = new TH1F("fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftMinusTwoH", "fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftMinusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftMinusTwoH);
+
+  fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftMinusOneH = new TH1F("fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftMinusOneH", "fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftMinusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftMinusOneH);
+
+  fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftPlusOneH = new TH1F("fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftPlusOneH", "fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftPlusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftPlusOneH);
+
+  fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftPlusTwoH = new TH1F("fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftPlusTwoH", "fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftPlusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftPlusTwoH);
 
   fInvariantMassDistributionIncoherentZNCanyZNAzeroH = new TH1F("fInvariantMassDistributionIncoherentZNCanyZNAzeroH", "fInvariantMassDistributionIncoherentZNCanyZNAzeroH", 2000, 0, 20);
   fOutputList->Add(fInvariantMassDistributionIncoherentZNCanyZNAzeroH);
 
+  fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftMinusTwoH = new TH1F("fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftMinusTwoH", "fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftMinusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftMinusTwoH);
+
+  fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftMinusOneH = new TH1F("fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftMinusOneH", "fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftMinusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftMinusOneH);
+
+  fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftPlusOneH = new TH1F("fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftPlusOneH", "fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftPlusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftPlusOneH);
+
+  fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftPlusTwoH = new TH1F("fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftPlusTwoH", "fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftPlusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftPlusTwoH);
+
   fInvariantMassDistributionIncoherentZNCanyZNAanyH = new TH1F("fInvariantMassDistributionIncoherentZNCanyZNAanyH", "fInvariantMassDistributionIncoherentZNCanyZNAanyH", 2000, 0, 20);
   fOutputList->Add(fInvariantMassDistributionIncoherentZNCanyZNAanyH);
+
+  fInvariantMassDistributionIncoherentZNCanyZNAanyShiftMinusTwoH = new TH1F("fInvariantMassDistributionIncoherentZNCanyZNAanyShiftMinusTwoH", "fInvariantMassDistributionIncoherentZNCanyZNAanyShiftMinusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentZNCanyZNAanyShiftMinusTwoH);
+
+  fInvariantMassDistributionIncoherentZNCanyZNAanyShiftMinusOneH = new TH1F("fInvariantMassDistributionIncoherentZNCanyZNAanyShiftMinusOneH", "fInvariantMassDistributionIncoherentZNCanyZNAanyShiftMinusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentZNCanyZNAanyShiftMinusOneH);
+
+  fInvariantMassDistributionIncoherentZNCanyZNAanyShiftPlusOneH = new TH1F("fInvariantMassDistributionIncoherentZNCanyZNAanyShiftPlusOneH", "fInvariantMassDistributionIncoherentZNCanyZNAanyShiftPlusOneH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentZNCanyZNAanyShiftPlusOneH);
+
+  fInvariantMassDistributionIncoherentZNCanyZNAanyShiftPlusTwoH = new TH1F("fInvariantMassDistributionIncoherentZNCanyZNAanyShiftPlusTwoH", "fInvariantMassDistributionIncoherentZNCanyZNAanyShiftPlusTwoH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionIncoherentZNCanyZNAanyShiftPlusTwoH);
 
   fDimuonPtDistributionZNCzeroZNAzeroH = new TH1F("fDimuonPtDistributionZNCzeroZNAzeroH", "fDimuonPtDistributionZNCzeroZNAzeroH", 4000, 0, 20);
   fOutputList->Add(fDimuonPtDistributionZNCzeroZNAzeroH);
@@ -799,6 +977,18 @@ void AliAnalysisTaskUPCforward::UserCreateOutputObjects()
 
   fDimuonPtDistributionZNCanyZNAanyH = new TH1F("fDimuonPtDistributionZNCanyZNAanyH", "fDimuonPtDistributionZNCanyZNAanyH", 4000, 0, 20);
   fOutputList->Add(fDimuonPtDistributionZNCanyZNAanyH);
+
+  fDimuonPtDistributionZNCzeroZNAzeroShiftPlusOneH = new TH1F("fDimuonPtDistributionZNCzeroZNAzeroShiftPlusOneH", "fDimuonPtDistributionZNCzeroZNAzeroShiftPlusOneH", 4000, 0.02, 20.02);
+  fOutputList->Add(fDimuonPtDistributionZNCzeroZNAzeroShiftPlusOneH);
+
+  fDimuonPtDistributionZNCzeroZNAanyShiftPlusOneH = new TH1F("fDimuonPtDistributionZNCzeroZNAanyShiftPlusOneH", "fDimuonPtDistributionZNCzeroZNAanyShiftPlusOneH", 4000, 0.02, 20.02);
+  fOutputList->Add(fDimuonPtDistributionZNCzeroZNAanyShiftPlusOneH);
+
+  fDimuonPtDistributionZNCanyZNAzeroShiftPlusOneH = new TH1F("fDimuonPtDistributionZNCanyZNAzeroShiftPlusOneH", "fDimuonPtDistributionZNCanyZNAzeroShiftPlusOneH", 4000, 0.02, 20.02);
+  fOutputList->Add(fDimuonPtDistributionZNCanyZNAzeroShiftPlusOneH);
+
+  fDimuonPtDistributionZNCanyZNAanyShiftPlusOneH = new TH1F("fDimuonPtDistributionZNCanyZNAanyShiftPlusOneH", "fDimuonPtDistributionZNCanyZNAanyShiftPlusOneH", 4000, 0.02, 20.02);
+  fOutputList->Add(fDimuonPtDistributionZNCanyZNAanyShiftPlusOneH);
 
   fDimuonPtDistributionCoherentZNCzeroZNAzeroH = new TH1F("fDimuonPtDistributionCoherentZNCzeroZNAzeroH", "fDimuonPtDistributionCoherentZNCzeroZNAzeroH", 4000, 0, 20);
   fOutputList->Add(fDimuonPtDistributionCoherentZNCzeroZNAzeroH);
@@ -1084,6 +1274,15 @@ void AliAnalysisTaskUPCforward::UserCreateOutputObjects()
                 2000, 0, 20
                 );
     fOutputList->Add(fInvariantMassDistributionOnlyPhiForSignalExtractionHelicityFrameMyStrictVariableBinningH[iPhiBins]);
+  }
+
+  for(Int_t iCosThetaBins = 0; iCosThetaBins < 17; iCosThetaBins++ ){
+    fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMySeventeenBinsVariableBinningH[iCosThetaBins] = new TH1F(
+                Form("fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMySeventeenBinsVariableBinningH_%d", iCosThetaBins),
+                Form("fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMySeventeenBinsVariableBinningH_%d", iCosThetaBins),
+                2000, 0, 20
+                );
+    fOutputList->Add(fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMySeventeenBinsVariableBinningH[iCosThetaBins]);
   }
 
 
@@ -1781,9 +1980,30 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
   }
   // fDimuonPtDistributionH->Fill(ptOfTheDimuonPair);
   if ( (possibleJPsi.Mag() > 2.8) && (possibleJPsi.Mag() < 3.3) ) {
-    fDimuonPtDistributionH->Fill(ptOfTheDimuonPair);
+    fDimuonPtDistributionH            ->Fill(ptOfTheDimuonPair);
+    fDimuonPtDistributionShiftPlusOneH->Fill(ptOfTheDimuonPair);
   }
 
+  if( ptOfTheDimuonPair < 0.200 ) {
+    fInvariantMassDistributionCoherentShiftMinusTwoH->Fill(possibleJPsi.Mag());
+  } else {
+    fInvariantMassDistributionIncoherentShiftMinusTwoH->Fill(possibleJPsi.Mag());
+  }
+  if( ptOfTheDimuonPair < 0.225 ) {
+    fInvariantMassDistributionCoherentShiftMinusOneH->Fill(possibleJPsi.Mag());
+  } else {
+    fInvariantMassDistributionIncoherentShiftMinusOneH->Fill(possibleJPsi.Mag());
+  }
+  if( ptOfTheDimuonPair < 0.275 ) {
+    fInvariantMassDistributionCoherentShiftPlusOneH ->Fill(possibleJPsi.Mag());
+  } else {
+    fInvariantMassDistributionIncoherentShiftPlusOneH ->Fill(possibleJPsi.Mag());
+  }
+  if( ptOfTheDimuonPair < 0.300 ) {
+    fInvariantMassDistributionCoherentShiftPlusTwoH ->Fill(possibleJPsi.Mag());
+  } else {
+    fInvariantMassDistributionIncoherentShiftPlusTwoH ->Fill(possibleJPsi.Mag());
+  }
 
 
 
@@ -1842,7 +2062,7 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
 
 
   /* - Now this is a critical part of  the analysis. What happens next is a
-     - differential analysisin terms of the energy perceived by the neutron ZDC.
+     - differential analysis in terms of the energy perceived by the neutron ZDC.
      - What it means is that now we may cut on those sensible values to select
      - only those J/Psi candidates falling under a certain peak of the neutron
      - ZNC energy distribution. It will be seen that the fZNCEnergyAgainstEntriesH
@@ -2044,44 +2264,128 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
                       if( fZNCEnergy < 1250 ) {
                                   if( fZNAEnergy > -5000 ) {
                                               if( fZNAEnergy < 1000 ) {
-                                                          fDimuonPtDistributionZNCzeroZNAzeroH->Fill(ptOfTheDimuonPair);
-                                                          if( ptOfTheDimuonPair < 0.25) {
+                                                          fDimuonPtDistributionZNCzeroZNAzeroH            ->Fill(ptOfTheDimuonPair);
+                                                          fDimuonPtDistributionZNCzeroZNAzeroShiftPlusOneH->Fill(ptOfTheDimuonPair);
+                                                          if( ptOfTheDimuonPair < 0.25 ) {
                                                                     fInvariantMassDistributionCoherentZNCzeroZNAzeroH->Fill(possibleJPsi.Mag());
                                                                     fDimuonPtDistributionCoherentZNCzeroZNAzeroH->Fill(ptOfTheDimuonPair);
                                                           } else {
                                                                     fInvariantMassDistributionIncoherentZNCzeroZNAzeroH->Fill(possibleJPsi.Mag());
                                                                     fDimuonPtDistributionIncoherentZNCzeroZNAzeroH->Fill(ptOfTheDimuonPair);
                                                           }
+                                                          if( ptOfTheDimuonPair < 0.200 ) {
+                                                            fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftMinusTwoH->Fill(possibleJPsi.Mag());
+                                                          } else {
+                                                            fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftMinusTwoH->Fill(possibleJPsi.Mag());
+                                                          }
+                                                          if( ptOfTheDimuonPair < 0.225 ) {
+                                                            fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftMinusOneH->Fill(possibleJPsi.Mag());
+                                                          } else {
+                                                            fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftMinusOneH->Fill(possibleJPsi.Mag());
+                                                          }
+                                                          if( ptOfTheDimuonPair < 0.275 ) {
+                                                            fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftPlusOneH->Fill(possibleJPsi.Mag());
+                                                          } else {
+                                                            fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftPlusOneH->Fill(possibleJPsi.Mag());
+                                                          }
+                                                          if( ptOfTheDimuonPair < 0.300 ) {
+                                                            fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftPlusTwoH->Fill(possibleJPsi.Mag());
+                                                          } else {
+                                                            fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftPlusTwoH->Fill(possibleJPsi.Mag());
+                                                          }
                                               } else {
-                                                          fDimuonPtDistributionZNCzeroZNAanyH->Fill(ptOfTheDimuonPair);
-                                                          if( ptOfTheDimuonPair < 0.25) {
+                                                          fDimuonPtDistributionZNCzeroZNAanyH            ->Fill(ptOfTheDimuonPair);
+                                                          fDimuonPtDistributionZNCzeroZNAanyShiftPlusOneH->Fill(ptOfTheDimuonPair);
+                                                          if( ptOfTheDimuonPair < 0.25 ) {
                                                                     fInvariantMassDistributionCoherentZNCzeroZNAanyH->Fill(possibleJPsi.Mag());
                                                                     fDimuonPtDistributionCoherentZNCzeroZNAanyH->Fill(ptOfTheDimuonPair);
                                                           } else {
                                                                     fInvariantMassDistributionIncoherentZNCzeroZNAanyH->Fill(possibleJPsi.Mag());
                                                                     fDimuonPtDistributionIncoherentZNCzeroZNAanyH->Fill(ptOfTheDimuonPair);
                                                           }
+                                                          if( ptOfTheDimuonPair < 0.200 ) {
+                                                            fInvariantMassDistributionCoherentZNCzeroZNAanyShiftMinusTwoH->Fill(possibleJPsi.Mag());
+                                                          } else {
+                                                            fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftMinusTwoH->Fill(possibleJPsi.Mag());
+                                                          }
+                                                          if( ptOfTheDimuonPair < 0.225 ) {
+                                                            fInvariantMassDistributionCoherentZNCzeroZNAanyShiftMinusOneH->Fill(possibleJPsi.Mag());
+                                                          } else {
+                                                            fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftMinusOneH->Fill(possibleJPsi.Mag());
+                                                          }
+                                                          if( ptOfTheDimuonPair < 0.275 ) {
+                                                            fInvariantMassDistributionCoherentZNCzeroZNAanyShiftPlusOneH->Fill(possibleJPsi.Mag());
+                                                          } else {
+                                                            fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftPlusOneH->Fill(possibleJPsi.Mag());
+                                                          }
+                                                          if( ptOfTheDimuonPair < 0.300 ) {
+                                                            fInvariantMassDistributionCoherentZNCzeroZNAanyShiftPlusTwoH->Fill(possibleJPsi.Mag());
+                                                          } else {
+                                                            fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftPlusTwoH->Fill(possibleJPsi.Mag());
+                                                          }
                                               }
                                   }
                       } else {
                                   if( fZNAEnergy > -5000 ) {
                                               if( fZNAEnergy < 1000 ) {
-                                                          fDimuonPtDistributionZNCanyZNAzeroH->Fill(ptOfTheDimuonPair);
-                                                          if( ptOfTheDimuonPair < 0.25) {
+                                                          fDimuonPtDistributionZNCanyZNAzeroH            ->Fill(ptOfTheDimuonPair);
+                                                          fDimuonPtDistributionZNCanyZNAzeroShiftPlusOneH->Fill(ptOfTheDimuonPair);
+                                                          if( ptOfTheDimuonPair < 0.25 ) {
                                                                     fInvariantMassDistributionCoherentZNCanyZNAzeroH->Fill(possibleJPsi.Mag());
                                                                     fDimuonPtDistributionCoherentZNCanyZNAzeroH->Fill(ptOfTheDimuonPair);
                                                           } else {
                                                                     fInvariantMassDistributionIncoherentZNCanyZNAzeroH->Fill(possibleJPsi.Mag());
                                                                     fDimuonPtDistributionIncoherentZNCanyZNAzeroH->Fill(ptOfTheDimuonPair);
                                                           }
+                                                          if( ptOfTheDimuonPair < 0.200 ) {
+                                                            fInvariantMassDistributionCoherentZNCanyZNAzeroShiftMinusTwoH->Fill(possibleJPsi.Mag());
+                                                          } else {
+                                                            fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftMinusTwoH->Fill(possibleJPsi.Mag());
+                                                          }
+                                                          if( ptOfTheDimuonPair < 0.225 ) {
+                                                            fInvariantMassDistributionCoherentZNCanyZNAzeroShiftMinusOneH->Fill(possibleJPsi.Mag());
+                                                          } else {
+                                                            fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftMinusOneH->Fill(possibleJPsi.Mag());
+                                                          }
+                                                          if( ptOfTheDimuonPair < 0.275 ) {
+                                                            fInvariantMassDistributionCoherentZNCanyZNAzeroShiftPlusOneH->Fill(possibleJPsi.Mag());
+                                                          } else {
+                                                            fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftPlusOneH->Fill(possibleJPsi.Mag());
+                                                          }
+                                                          if( ptOfTheDimuonPair < 0.300 ) {
+                                                            fInvariantMassDistributionCoherentZNCanyZNAzeroShiftPlusTwoH->Fill(possibleJPsi.Mag());
+                                                          } else {
+                                                            fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftPlusTwoH->Fill(possibleJPsi.Mag());
+                                                          }
                                               } else {
-                                                          fDimuonPtDistributionZNCanyZNAanyH->Fill(ptOfTheDimuonPair);
-                                                          if( ptOfTheDimuonPair < 0.25) {
+                                                          fDimuonPtDistributionZNCanyZNAanyH            ->Fill(ptOfTheDimuonPair);
+                                                          fDimuonPtDistributionZNCanyZNAanyShiftPlusOneH->Fill(ptOfTheDimuonPair);
+                                                          if( ptOfTheDimuonPair < 0.25 ) {
                                                                     fInvariantMassDistributionCoherentZNCanyZNAanyH->Fill(possibleJPsi.Mag());
                                                                     fDimuonPtDistributionCoherentZNCanyZNAanyH->Fill(ptOfTheDimuonPair);
                                                           } else {
                                                                     fInvariantMassDistributionIncoherentZNCanyZNAanyH->Fill(possibleJPsi.Mag());
                                                                     fDimuonPtDistributionIncoherentZNCanyZNAanyH->Fill(ptOfTheDimuonPair);
+                                                          }
+                                                          if( ptOfTheDimuonPair < 0.200 ) {
+                                                            fInvariantMassDistributionCoherentZNCanyZNAanyShiftMinusTwoH->Fill(possibleJPsi.Mag());
+                                                          } else {
+                                                            fInvariantMassDistributionIncoherentZNCanyZNAanyShiftMinusTwoH->Fill(possibleJPsi.Mag());
+                                                          }
+                                                          if( ptOfTheDimuonPair < 0.225 ) {
+                                                            fInvariantMassDistributionCoherentZNCanyZNAanyShiftMinusOneH->Fill(possibleJPsi.Mag());
+                                                          } else {
+                                                            fInvariantMassDistributionIncoherentZNCanyZNAanyShiftMinusOneH->Fill(possibleJPsi.Mag());
+                                                          }
+                                                          if( ptOfTheDimuonPair < 0.275 ) {
+                                                            fInvariantMassDistributionCoherentZNCanyZNAanyShiftPlusOneH->Fill(possibleJPsi.Mag());
+                                                          } else {
+                                                            fInvariantMassDistributionIncoherentZNCanyZNAanyShiftPlusOneH->Fill(possibleJPsi.Mag());
+                                                          }
+                                                          if( ptOfTheDimuonPair < 0.300 ) {
+                                                            fInvariantMassDistributionCoherentZNCanyZNAanyShiftPlusTwoH->Fill(possibleJPsi.Mag());
+                                                          } else {
+                                                            fInvariantMassDistributionIncoherentZNCanyZNAanyShiftPlusTwoH->Fill(possibleJPsi.Mag());
                                                           }
                                               }
                                   }
@@ -2379,6 +2683,27 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
         }
   }
 
+  /* - NEW:
+   * - My SEVENTEEN BINS variable binning for 1D analysis
+   */
+  Bool_t controlFlag9  = 0;
+  Bool_t controlFlag10 = 0;
+  Double_t MyVariableCosThetaBinning1Dv3[] = { -0.65,  -0.5,  -0.425, -0.35,
+                                               -0.275, -0.2,  -0.125, -0.075,
+                                               -0.025,  0.025, 0.075,  0.125,
+                                                0.2,    0.275, 0.35,   0.425,
+                                                0.5,    0.65 };
+  if ( possibleJPsiCopy.Pt() < 0.25 ) {
+        Double_t CosThetaHelicityFrameValue6 = CosThetaHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
+        Double_t PhiHelicityFrameValue6      =   CosPhiHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
+        for(Int_t iCosThetaBins = 0; iCosThetaBins < 17; iCosThetaBins++) {
+          if( controlFlag9 == 1) break;
+          if( CosThetaHelicityFrameValue6 < MyVariableCosThetaBinning1Dv3[iCosThetaBins + 1] ){
+            fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMySeventeenBinsVariableBinningH[iCosThetaBins]->Fill(possibleJPsiCopyMag);
+            controlFlag9 = 1;
+          }
+        }
+  }
 
 
   /* - Strict binning in Pt.

--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
@@ -1290,6 +1290,24 @@ void AliAnalysisTaskUPCforward::UserCreateOutputObjects()
   fCosThetaHelicityFrameJPsiAlreadyCorrectedH = new TH1F("fCosThetaHelicityFrameJPsiAlreadyCorrectedH", "fCosThetaHelicityFrameJPsiAlreadyCorrectedH", 100, -1., 1.);
   fOutputList->Add(fCosThetaHelicityFrameJPsiAlreadyCorrectedH);
 
+  for(Int_t iCosThetaBins = 0; iCosThetaBins < 50; iCosThetaBins++ ){
+    fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameForAlreadyCorrectedFiftyH[iCosThetaBins] = new TH1F(
+                Form("fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameForAlreadyCorrectedFiftyH_%d", iCosThetaBins),
+                Form("fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameForAlreadyCorrectedFiftyH_%d", iCosThetaBins),
+                2000, 0, 20
+                );
+    fOutputList->Add(fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameForAlreadyCorrectedFiftyH[iCosThetaBins]);
+  }
+
+  for(Int_t iCosThetaBins = 0; iCosThetaBins < 100; iCosThetaBins++ ){
+    fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameForAlreadyCorrectedHundredH[iCosThetaBins] = new TH1F(
+                Form("fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameForAlreadyCorrectedHundredH_%d", iCosThetaBins),
+                Form("fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameForAlreadyCorrectedHundredH_%d", iCosThetaBins),
+                2000, 0, 20
+                );
+    fOutputList->Add(fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameForAlreadyCorrectedHundredH[iCosThetaBins]);
+  }
+
 
   //_______________________________
   // - End of the function
@@ -2693,6 +2711,8 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
    */
   Bool_t controlFlag9  = 0;
   Bool_t controlFlag10 = 0;
+  Bool_t controlFlag11 = 0;
+  Bool_t controlFlag12 = 0;
   Double_t MyVariableCosThetaBinning1Dv3[] = { -0.65,  -0.5,  -0.425, -0.35,
                                                -0.275, -0.2,  -0.125, -0.075,
                                                -0.025,  0.025, 0.075,  0.125,
@@ -2702,12 +2722,28 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
         Double_t CosThetaHelicityFrameValue6 = CosThetaHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
         Double_t PhiHelicityFrameValue6      =   CosPhiHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
         Double_t WeightFromAcceptance        =      AccEffCorrection( CosThetaHelicityFrameValue6 );
-        fCosThetaHelicityFrameJPsiAlreadyCorrectedH->Fill( CosThetaHelicityFrameValue6, 1/WeightFromAcceptance );
+        if ( ( possibleJPsiCopyMag > 2.85 ) && ( possibleJPsiCopyMag < 3.35 ) ) {
+          fCosThetaHelicityFrameJPsiAlreadyCorrectedH->Fill( CosThetaHelicityFrameValue6, 1/WeightFromAcceptance );
+        }
         for(Int_t iCosThetaBins = 0; iCosThetaBins < 17; iCosThetaBins++) {
           if( controlFlag9 == 1) break;
           if( CosThetaHelicityFrameValue6 < MyVariableCosThetaBinning1Dv3[iCosThetaBins + 1] ){
             fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMySeventeenBinsVariableBinningH[iCosThetaBins]->Fill(possibleJPsiCopyMag);
             controlFlag9 = 1;
+          }
+        }
+        for(Int_t iCosThetaBins = 0; iCosThetaBins < 50; iCosThetaBins++) {
+          if( controlFlag11 == 1) break;
+          if( (CosThetaHelicityFrameValue6 + 1.) < 2.*((Double_t)iCosThetaBins + 1.)/50. ) {
+            fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameForAlreadyCorrectedFiftyH[iCosThetaBins]->Fill(possibleJPsiCopyMag);
+            controlFlag11 = 1;
+          }
+        }
+        for(Int_t iCosThetaBins = 0; iCosThetaBins < 100; iCosThetaBins++) {
+          if( controlFlag12 == 1) break;
+          if( (CosThetaHelicityFrameValue6 + 1.) < 2.*((Double_t)iCosThetaBins + 1.)/100. ) {
+            fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameForAlreadyCorrectedHundredH[iCosThetaBins]->Fill(possibleJPsiCopyMag);
+            controlFlag12 = 1;
           }
         }
   }

--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.h
@@ -300,15 +300,58 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * This histogram records the invariant mass
                                  * distribution of the dimuon system, only
                                  * coherent component, so as to say, only
+                                 * pt < 0.2 (MinusTwoShift) GeV/c for pt
+                                 * of the dimuon pair.
+                                 */
+        TH1F*                   fInvariantMassDistributionCoherentShiftMinusTwoH;       //!
+
+                                /**
+                                 * This histogram records the invariant mass
+                                 * distribution of the dimuon system, only
+                                 * coherent component, so as to say, only
+                                 * pt < 0.225 (MinusOneShift) GeV/c for
+                                 * pt of the dimuon pair.
+                                 */
+        TH1F*                   fInvariantMassDistributionCoherentShiftMinusOneH;       //!
+
+                                /**
+                                 * This histogram records the invariant mass
+                                 * distribution of the dimuon system, only
+                                 * coherent component, so as to say, only
+                                 * pt < 0.275 (PlusOneShift) GeV/c for
+                                 * pt of the dimuon pair.
+                                 */
+        TH1F*                   fInvariantMassDistributionCoherentShiftPlusOneH;       //!
+
+                                /**
+                                 * This histogram records the invariant mass
+                                 * distribution of the dimuon system, only
+                                 * coherent component, so as to say, only
+                                 * pt < 0.3 (PlusTwoShift) GeV/c for
+                                 * pt of the dimuon pair.
+                                 */
+        TH1F*                   fInvariantMassDistributionCoherentShiftPlusTwoH;       //!
+
+                                /**
+                                 * This histogram records the invariant mass
+                                 * distribution of the dimuon system, only
+                                 * coherent component, so as to say, only
                                  * pt > 0.25 GeV/c for pt of the dimuon pair.
                                  */
-        TH1F*                   fInvariantMassDistributionIncoherentH;     //!
+        TH1F*                   fInvariantMassDistributionIncoherentH;                   //!
+        TH1F*                   fInvariantMassDistributionIncoherentShiftMinusTwoH;      //!
+        TH1F*                   fInvariantMassDistributionIncoherentShiftMinusOneH;      //!
+        TH1F*                   fInvariantMassDistributionIncoherentShiftPlusOneH;       //!
+        TH1F*                   fInvariantMassDistributionIncoherentShiftPlusTwoH;       //!
 
                                 /**
                                  * This histogram records the pt-ditribution
                                  * of the dimuon pairs.
+                                 *
+                                 * Shift +1 => 20 Mev/c shift
                                  */
-        TH1F*                   fDimuonPtDistributionH;         //!
+        TH1F*                   fDimuonPtDistributionH;                     //!
+        TH1F*                   fDimuonPtDistributionShiftPlusOneH;         //!
 
                                 /**
                                  * This histogram records the energy distri-
@@ -651,8 +694,18 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * pt < 0.25 GeV/c for pt of the dimuon pair.
                                  * The ZNC has 0 neutrons.
                                  * The ZNA has 0 neutrons.
+                                 *
+                                 * Shift -2 => pt < 0.200 GeV/c
+                                 * Shift -1 => pt < 0.225 GeV/c
+                                 * Shift +1 => pt < 0.275 GeV/c
+                                 * Shift +2 => pt < 0.300 GeV/c
                                  */
-        TH1F*                   fInvariantMassDistributionCoherentZNCzeroZNAzeroH;       //!
+        TH1F*                   fInvariantMassDistributionCoherentZNCzeroZNAzeroH;                   //!
+        TH1F*                   fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftMinusTwoH;      //!
+        TH1F*                   fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftMinusOneH;      //!
+        TH1F*                   fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftPlusOneH;       //!
+        TH1F*                   fInvariantMassDistributionCoherentZNCzeroZNAzeroShiftPlusTwoH;       //!
+
 
                                 /**
                                  * This histogram records the invariant mass
@@ -661,8 +714,17 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * pt < 0.25 GeV/c for pt of the dimuon pair.
                                  * The ZNC has 0 neutrons.
                                  * The ZNA has ANY neutrons.
+                                 *
+                                 * Shift -2 => pt < 0.200 GeV/c
+                                 * Shift -1 => pt < 0.225 GeV/c
+                                 * Shift +1 => pt < 0.275 GeV/c
+                                 * Shift +2 => pt < 0.300 GeV/c
                                  */
-        TH1F*                   fInvariantMassDistributionCoherentZNCzeroZNAanyH;       //!
+        TH1F*                   fInvariantMassDistributionCoherentZNCzeroZNAanyH;                   //!
+        TH1F*                   fInvariantMassDistributionCoherentZNCzeroZNAanyShiftMinusTwoH;      //!
+        TH1F*                   fInvariantMassDistributionCoherentZNCzeroZNAanyShiftMinusOneH;      //!
+        TH1F*                   fInvariantMassDistributionCoherentZNCzeroZNAanyShiftPlusOneH;       //!
+        TH1F*                   fInvariantMassDistributionCoherentZNCzeroZNAanyShiftPlusTwoH;       //!
 
                                 /**
                                  * This histogram records the invariant mass
@@ -671,8 +733,17 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * pt < 0.25 GeV/c for pt of the dimuon pair.
                                  * The ZNC has ANY neutrons.
                                  * The ZNA has 0 neutrons.
+                                 *
+                                 * Shift -2 => pt < 0.200 GeV/c
+                                 * Shift -1 => pt < 0.225 GeV/c
+                                 * Shift +1 => pt < 0.275 GeV/c
+                                 * Shift +2 => pt < 0.300 GeV/c
                                  */
-        TH1F*                   fInvariantMassDistributionCoherentZNCanyZNAzeroH;       //!
+        TH1F*                   fInvariantMassDistributionCoherentZNCanyZNAzeroH;                   //!
+        TH1F*                   fInvariantMassDistributionCoherentZNCanyZNAzeroShiftMinusTwoH;      //!
+        TH1F*                   fInvariantMassDistributionCoherentZNCanyZNAzeroShiftMinusOneH;      //!
+        TH1F*                   fInvariantMassDistributionCoherentZNCanyZNAzeroShiftPlusOneH;       //!
+        TH1F*                   fInvariantMassDistributionCoherentZNCanyZNAzeroShiftPlusTwoH;       //!
 
                                 /**
                                  * This histogram records the invariant mass
@@ -681,8 +752,17 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * pt < 0.25 GeV/c for pt of the dimuon pair.
                                  * The ZNC has ANY neutrons.
                                  * The ZNA has ANY neutrons.
+                                 *
+                                 * Shift -2 => pt < 0.200 GeV/c
+                                 * Shift -1 => pt < 0.225 GeV/c
+                                 * Shift +1 => pt < 0.275 GeV/c
+                                 * Shift +2 => pt < 0.300 GeV/c
                                  */
         TH1F*                   fInvariantMassDistributionCoherentZNCanyZNAanyH;       //!
+        TH1F*                   fInvariantMassDistributionCoherentZNCanyZNAanyShiftMinusTwoH;      //!
+        TH1F*                   fInvariantMassDistributionCoherentZNCanyZNAanyShiftMinusOneH;      //!
+        TH1F*                   fInvariantMassDistributionCoherentZNCanyZNAanyShiftPlusOneH;       //!
+        TH1F*                   fInvariantMassDistributionCoherentZNCanyZNAanyShiftPlusTwoH;       //!
 
                                 /**
                                  * This histogram records the invariant mass
@@ -691,8 +771,17 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * pt > 0.25 GeV/c for pt of the dimuon pair.
                                  * The ZNC has 0 neutrons.
                                  * The ZNA has 0 neutrons.
+                                 *
+                                 * Shift -2 => pt > 0.200 GeV/c
+                                 * Shift -1 => pt > 0.225 GeV/c
+                                 * Shift +1 => pt > 0.275 GeV/c
+                                 * Shift +2 => pt > 0.300 GeV/c
                                  */
-        TH1F*                   fInvariantMassDistributionIncoherentZNCzeroZNAzeroH;       //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCzeroZNAzeroH;                   //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftMinusTwoH;      //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftMinusOneH;      //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftPlusOneH;       //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCzeroZNAzeroShiftPlusTwoH;       //!
 
                                 /**
                                  * This histogram records the invariant mass
@@ -701,8 +790,17 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * pt > 0.25 GeV/c for pt of the dimuon pair.
                                  * The ZNC has 0 neutrons.
                                  * The ZNA has ANY neutrons.
+                                 *
+                                 * Shift -2 => pt > 0.200 GeV/c
+                                 * Shift -1 => pt > 0.225 GeV/c
+                                 * Shift +1 => pt > 0.275 GeV/c
+                                 * Shift +2 => pt > 0.300 GeV/c
                                  */
-        TH1F*                   fInvariantMassDistributionIncoherentZNCzeroZNAanyH;       //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCzeroZNAanyH;                   //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftMinusTwoH;      //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftMinusOneH;      //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftPlusOneH;       //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCzeroZNAanyShiftPlusTwoH;       //!
 
                                 /**
                                  * This histogram records the invariant mass
@@ -711,8 +809,17 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * pt > 0.25 GeV/c for pt of the dimuon pair.
                                  * The ZNC has ANY neutrons.
                                  * The ZNA has 0 neutrons.
+                                 *
+                                 * Shift -2 => pt > 0.200 GeV/c
+                                 * Shift -1 => pt > 0.225 GeV/c
+                                 * Shift +1 => pt > 0.275 GeV/c
+                                 * Shift +2 => pt > 0.300 GeV/c
                                  */
-        TH1F*                   fInvariantMassDistributionIncoherentZNCanyZNAzeroH;       //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCanyZNAzeroH;                  //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftMinusTwoH;      //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftMinusOneH;      //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftPlusOneH;       //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCanyZNAzeroShiftPlusTwoH;       //!
 
                                 /**
                                  * This histogram records the invariant mass
@@ -721,40 +828,61 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * pt > 0.25 GeV/c for pt of the dimuon pair.
                                  * The ZNC has ANY neutrons.
                                  * The ZNA has ANY neutrons.
+                                 *
+                                 * Shift -2 => pt > 0.200 GeV/c
+                                 * Shift -1 => pt > 0.225 GeV/c
+                                 * Shift +1 => pt > 0.275 GeV/c
+                                 * Shift +2 => pt > 0.300 GeV/c
                                  */
-        TH1F*                   fInvariantMassDistributionIncoherentZNCanyZNAanyH;       //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCanyZNAanyH;                   //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCanyZNAanyShiftMinusTwoH;      //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCanyZNAanyShiftMinusOneH;      //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCanyZNAanyShiftPlusOneH;       //!
+        TH1F*                   fInvariantMassDistributionIncoherentZNCanyZNAanyShiftPlusTwoH;       //!
 
                                 /**
                                  * This histogram records the pt-ditribution
                                  * of the dimuon pairs. This is divided in
                                  * neutron emission classes.
                                  * ZNC=0n, ZNA=0n.
+                                 *
+                                 * Shift +1 => 20 MeV/c shift
                                  */
-        TH1F*                   fDimuonPtDistributionZNCzeroZNAzeroH;         //!
+        TH1F*                   fDimuonPtDistributionZNCzeroZNAzeroH;                     //!
+        TH1F*                   fDimuonPtDistributionZNCzeroZNAzeroShiftPlusOneH;         //!
 
                                 /**
                                  * This histogram records the pt-ditribution
                                  * of the dimuon pairs. This is divided in
                                  * neutron emission classes.
                                  * ZNC=0n, ZNA=Xn.
+                                 *
+                                 * Shift +1 => 20 MeV/c shift
                                  */
-        TH1F*                   fDimuonPtDistributionZNCzeroZNAanyH;         //!
+        TH1F*                   fDimuonPtDistributionZNCzeroZNAanyH;                     //!
+        TH1F*                   fDimuonPtDistributionZNCzeroZNAanyShiftPlusOneH;         //!
 
                                 /**
                                  * This histogram records the pt-ditribution
                                  * of the dimuon pairs. This is divided in
                                  * neutron emission classes.
                                  * ZNC=Xn, ZNA=0n.
+                                 *
+                                 * Shift +1 => 20 MeV/c shift
                                  */
-        TH1F*                   fDimuonPtDistributionZNCanyZNAzeroH;         //!
+        TH1F*                   fDimuonPtDistributionZNCanyZNAzeroH;                     //!
+        TH1F*                   fDimuonPtDistributionZNCanyZNAzeroShiftPlusOneH;         //!
 
                                 /**
                                  * This histogram records the pt-ditribution
                                  * of the dimuon pairs. This is divided in
                                  * neutron emission classes and pt.
                                  * ZNC=Xn, ZNA=Xn.
+                                 *
+                                 * Shift +1 => 20 MeV/c shift
                                  */
-        TH1F*                   fDimuonPtDistributionZNCanyZNAanyH;         //!
+        TH1F*                   fDimuonPtDistributionZNCanyZNAanyH;                     //!
+        TH1F*                   fDimuonPtDistributionZNCanyZNAanyShiftPlusOneH;         //!
 
                                 /**
                                  * This histogram records the pt-ditribution
@@ -1211,6 +1339,15 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  */
         TH1F*                   fInvariantMassDistributionOnlyPhiForSignalExtractionHelicityFrameMyStrictVariableBinningH[15];  //!
 
+                                /**
+                                 * This histogram shows the invariant mass
+                                 * distribution of the dimuon pairs in terms
+                                 * of bins of cos theta of the positive muon
+                                 * in the helicity frame of the J/Psi.
+                                 * My variable binning 17 bins.
+                                 */
+        TH1F*                   fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMySeventeenBinsVariableBinningH[17];  //!
+
         //_______________________________
         // CUTS
         /*
@@ -1271,7 +1408,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforward, 28);
+        ClassDef(AliAnalysisTaskUPCforward, 31);
 };
 
 #endif

--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.h
@@ -1361,8 +1361,13 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * COS(THETA) distribution.
                                  * Already corrected by ACCxEFF thanks to
                                  * a weight...
+                                 *
+                                 * Plus the distributions in invariant mass
+                                 * for signal extraction.
                                  */
         TH1F*                   fCosThetaHelicityFrameJPsiAlreadyCorrectedH;       //!
+        TH1F*                   fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameForAlreadyCorrectedFiftyH[50];  //!
+        TH1F*                   fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameForAlreadyCorrectedHundredH[100];  //!
 
         //_______________________________
         // CUTS
@@ -1424,7 +1429,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforward, 32);
+        ClassDef(AliAnalysisTaskUPCforward, 33);
 };
 
 #endif

--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.h
@@ -134,6 +134,13 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                                      TLorentzVector possibleJPsi );
 
                                 /**
+                                 * This function computes the acceptance
+                                 * value to fix the weight of the entry
+                                 * to the CosTheta in the helicity frame.
+                                 */
+        Double_t                AccEffCorrection( Double_t CosThetaToBeWeighted );
+
+                                /**
                                  * Use the class as a data member. It contains
                                  * the cuts for the muon track.
                                  */
@@ -1348,6 +1355,15 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  */
         TH1F*                   fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMySeventeenBinsVariableBinningH[17];  //!
 
+                                /**
+                                 * This histogram shows the angular distribution
+                                 * of the positive muon in the HELICITY frame.
+                                 * COS(THETA) distribution.
+                                 * Already corrected by ACCxEFF thanks to
+                                 * a weight...
+                                 */
+        TH1F*                   fCosThetaHelicityFrameJPsiAlreadyCorrectedH;       //!
+
         //_______________________________
         // CUTS
         /*
@@ -1408,7 +1424,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforward, 31);
+        ClassDef(AliAnalysisTaskUPCforward, 32);
 };
 
 #endif

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
@@ -228,6 +228,8 @@ AliAnalysisTaskUPCforwardMC::AliAnalysisTaskUPCforwardMC()
       fMCCosThetaHelicityFrameMyBinningH(0),
       fCosThetaHelicityFrameMyBinningSmallH(0),
       fMCCosThetaHelicityFrameMyBinningSmallH(0),
+      fCosThetaHelicityFrameMySeventeenBinningH(0),
+      fMCCosThetaHelicityFrameMySeventeenBinningH(0),
       fPhiHelicityFrameMyBinningH(0),
       fMCPhiHelicityFrameMyBinningH(0),
       fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMyVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -388,6 +390,8 @@ AliAnalysisTaskUPCforwardMC::AliAnalysisTaskUPCforwardMC( const char* name )
       fMCCosThetaHelicityFrameMyBinningH(0),
       fCosThetaHelicityFrameMyBinningSmallH(0),
       fMCCosThetaHelicityFrameMyBinningSmallH(0),
+      fCosThetaHelicityFrameMySeventeenBinningH(0),
+      fMCCosThetaHelicityFrameMySeventeenBinningH(0),
       fPhiHelicityFrameMyBinningH(0),
       fMCPhiHelicityFrameMyBinningH(0),
       fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMyVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1106,6 +1110,12 @@ void AliAnalysisTaskUPCforwardMC::UserCreateOutputObjects()
   const Int_t XBINS4 = 9;
   Double_t MyVariableCosThetaBinning1Dv2[] = { -0.65, -0.45, -0.3, -0.15,  -0.05,
                                                 0.05,  0.15,  0.3,  0.45,   0.65 };
+  const Int_t XBINS5 = 17;
+  Double_t MyVariableCosThetaBinning1Dv3[] = { -0.65,  -0.5,  -0.425, -0.35,
+                                               -0.275, -0.2,  -0.125, -0.075,
+                                               -0.025,  0.025, 0.075,  0.125,
+                                                0.2,    0.275, 0.35,   0.425,
+                                                0.5,    0.65 };
   fCosThetaHelicityFrameMyBinningH =
         new TH1F( "fCosThetaHelicityFrameMyBinningH",
                   "fCosThetaHelicityFrameMyBinningH",
@@ -1133,6 +1143,20 @@ void AliAnalysisTaskUPCforwardMC::UserCreateOutputObjects()
                   XBINS4, MyVariableCosThetaBinning1Dv2
                   );
   fOutputList->Add(fMCCosThetaHelicityFrameMyBinningSmallH);
+
+  fCosThetaHelicityFrameMySeventeenBinningH =
+        new TH1F( "fCosThetaHelicityFrameMySeventeenBinningH",
+                  "fCosThetaHelicityFrameMySeventeenBinningH",
+                  XBINS5, MyVariableCosThetaBinning1Dv3
+                  );
+  fOutputList->Add(fCosThetaHelicityFrameMySeventeenBinningH);
+
+  fMCCosThetaHelicityFrameMySeventeenBinningH =
+        new TH1F( "fMCCosThetaHelicityFrameMySeventeenBinningH",
+                  "fMCCosThetaHelicityFrameMySeventeenBinningH",
+                  XBINS5, MyVariableCosThetaBinning1Dv3
+                  );
+  fOutputList->Add(fMCCosThetaHelicityFrameMySeventeenBinningH);
 
   fPhiHelicityFrameMyBinningH =
         new TH1F( "fPhiHelicityFrameMyBinningH",
@@ -1862,9 +1886,10 @@ void AliAnalysisTaskUPCforwardMC::UserExec(Option_t *)
     if ( possibleJPsiCopy.Pt() < 0.25 ) {
           Double_t CosThetaHelicityFrameValue4 = CosThetaHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
           Double_t PhiHelicityFrameValue4      =   CosPhiHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
-          fCosThetaHelicityFrameMyBinningH     ->Fill( CosThetaHelicityFrameValue4 );
-          fCosThetaHelicityFrameMyBinningSmallH->Fill( CosThetaHelicityFrameValue4 );
-          fPhiHelicityFrameMyBinningH          ->Fill( PhiHelicityFrameValue4      );
+          fCosThetaHelicityFrameMyBinningH         ->Fill( CosThetaHelicityFrameValue4 );
+          fCosThetaHelicityFrameMyBinningSmallH    ->Fill( CosThetaHelicityFrameValue4 );
+          fCosThetaHelicityFrameMySeventeenBinningH->Fill( CosThetaHelicityFrameValue4 );
+          fPhiHelicityFrameMyBinningH              ->Fill( PhiHelicityFrameValue4      );
           for(Int_t iCosThetaBins = 0; iCosThetaBins < 26; iCosThetaBins++) {
             if( controlFlag5 == 1) break;
             if( CosThetaHelicityFrameValue4 < MyVariableCosThetaBinning1D[iCosThetaBins + 1] ){
@@ -2165,6 +2190,11 @@ void AliAnalysisTaskUPCforwardMC::ProcessMCParticles(AliMCEvent* fMCEventArg)
                                                                                          possibleJPsiMC
                                                                                          )
                                                                                         );
+                  fMCCosThetaHelicityFrameMySeventeenBinningH->Fill( CosThetaHelicityFrame(  muonsMCcopy[0],
+                                                                                             muonsMCcopy[1],
+                                                                                             possibleJPsiMC
+                                                                                             )
+                                                                                            );
                   fMCPhiHelicityFrameMyBinningH->Fill( CosPhiHelicityFrame( muonsMCcopy[0],
                                                                             muonsMCcopy[1],
                                                                             possibleJPsiMC
@@ -2329,6 +2359,11 @@ void AliAnalysisTaskUPCforwardMC::ProcessMCParticles(AliMCEvent* fMCEventArg)
                                                                                          possibleJPsiMC
                                                                                          )
                                                                                         );
+                  fMCCosThetaHelicityFrameMySeventeenBinningH->Fill( CosThetaHelicityFrame(  muonsMCcopy[1],
+                                                                                             muonsMCcopy[0],
+                                                                                             possibleJPsiMC
+                                                                                             )
+                                                                                            );
                   fMCPhiHelicityFrameMyBinningH->Fill( CosPhiHelicityFrame( muonsMCcopy[1],
                                                                             muonsMCcopy[0],
                                                                             possibleJPsiMC

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
@@ -1012,6 +1012,20 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
 
                                 /**
                                  * This histogram shows CosTheta
+                                 * distribution with my variable 17 binning.
+                                 * RECON level.
+                                 */
+        TH1F*                   fCosThetaHelicityFrameMySeventeenBinningH;   //!
+
+                                /**
+                                 * This histogram shows CosTheta
+                                 * distribution with my variable 17 binning.
+                                 * GENERATED level.
+                                 */
+        TH1F*                   fMCCosThetaHelicityFrameMySeventeenBinningH;   //!
+
+                                /**
+                                 * This histogram shows CosTheta
                                  * distribution with my variable SMALL binning.
                                  * RECON level.
                                  */
@@ -1141,7 +1155,7 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforwardMC, 25);
+        ClassDef(AliAnalysisTaskUPCforwardMC, 26);
 };
 
 #endif


### PR DESCRIPTION
Added systematics plots for the neutron emission analysis. 
The plan is the following:

- Coh   Inv Mass Spectra 
- Coh   Inv Mass Spectra XNXN
- Incoh Inv Mass Spectra 
- Incoh Inv Mass Spectra XNXN

x5 due to the different Pt-thresholds (0.200, 0.225, 0.250, 0.275, 0.300). In addition, 

- Pt-distr (normal + XNXN) with 20 MeV/c shift

Furthermore, new binning for 1D pol + 1D acceptance.

IMPORTANT: tested.
