### PR TITLE
Modifying the correction framework so it takes one histogram instead of four for all BCs

### DIFF
--- a/PWG/CaloTrackCorrBase/AliCalorimeterUtils.h
+++ b/PWG/CaloTrackCorrBase/AliCalorimeterUtils.h
@@ -277,9 +277,9 @@ class AliCalorimeterUtils : public TObject {
   void         SetEMCALChannelTimeRecalibrationFactor(Int_t bc, Int_t absID, Double_t c = 0)
   { fEMCALRecoUtils->SetEMCALChannelTimeRecalibrationFactor(bc, absID, c) ; }  
   
-  TH1F *       GetEMCALChannelTimeRecalibrationFactors(Int_t bc) const     { return fEMCALRecoUtils-> GetEMCALChannelTimeRecalibrationFactors(bc) ; }
+  TH1*         GetEMCALChannelTimeRecalibrationFactors(Int_t bc) const     { return (TH1*)fEMCALRecoUtils-> GetEMCALChannelTimeRecalibrationFactors(bc) ; }
   void         SetEMCALChannelTimeRecalibrationFactors(TObjArray *map)     { fEMCALRecoUtils->SetEMCALChannelTimeRecalibrationFactors(map)        ; }
-  void         SetEMCALChannelTimeRecalibrationFactors(Int_t bc , TH1F* h) { fEMCALRecoUtils->SetEMCALChannelTimeRecalibrationFactors(bc , h)     ; }
+  void         SetEMCALChannelTimeRecalibrationFactors(Int_t bc , TH1* h)  { fEMCALRecoUtils->SetEMCALChannelTimeRecalibrationFactors(bc , h)     ; }
 
   //------------------------------
   // Time Recalibration - L1 phase (EMCAL)
@@ -393,6 +393,8 @@ class AliCalorimeterUtils : public TObject {
   
   void          SetRunNumber(Int_t run)                         { fRunNumber  = run             ; }
   Int_t         GetRunNumber()                            const { return fRunNumber             ; }
+
+  void		SetUseOneHistForAllBCs(Bool_t useOneHist) 	{ fDoUseMergedBCs = useOneHist  ; fEMCALRecoUtils->SetUseOneHistForAllBCs(useOneHist) ; }
   
  private:
 
@@ -480,6 +482,8 @@ class AliCalorimeterUtils : public TObject {
   Bool_t             fMCECellClusFracCorrOn;    ///<  Correct or not the weight of cells in cluster.
   
   Float_t            fMCECellClusFracCorrParam[4]; ///<  Parameters for the function correcting the weight of the cells in the cluster.
+
+  Bool_t	     fDoUseMergedBCs;		///< flag to use one histo for all BCs
   
   /// Copy constructor not implemented.
   AliCalorimeterUtils(              const AliCalorimeterUtils & cu) ;
@@ -488,7 +492,7 @@ class AliCalorimeterUtils : public TObject {
   AliCalorimeterUtils & operator = (const AliCalorimeterUtils & cu) ; 
   
   /// \cond CLASSIMP
-  ClassDef(AliCalorimeterUtils,20) ;
+  ClassDef(AliCalorimeterUtils,21) ;
   /// \endcond
 
 } ;

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx
@@ -56,7 +56,7 @@ AliEMCALRecoUtils::AliEMCALRecoUtils():
   fSmearClusterEnergy(kFALSE),            fRandom(),
   fCellsRecalibrated(kFALSE),             fRecalibration(kFALSE),                 fEMCALRecalibrationFactors(),
   fConstantTimeShift(0),                  fTimeRecalibration(kFALSE),             fEMCALTimeRecalibrationFactors(),       fLowGain(kFALSE),
-  fUseL1PhaseInTimeRecalibration(kFALSE), fEMCALL1PhaseInTimeRecalibration(),
+  fUseL1PhaseInTimeRecalibration(kFALSE), fEMCALL1PhaseInTimeRecalibration(),     fDoUseMergedBC(kFALSE),
   fUseRunCorrectionFactors(kFALSE),       
   fRemoveBadChannels(kFALSE),             fRecalDistToBadChannels(kFALSE),        fEMCALBadChannelMap(),
   fNCellsFromEMCALBorder(0),              fNoEMCALBorderAtEta0(kTRUE),
@@ -113,6 +113,7 @@ AliEMCALRecoUtils::AliEMCALRecoUtils(const AliEMCALRecoUtils & reco)
   fLowGain(reco.fLowGain),
   fUseL1PhaseInTimeRecalibration(reco.fUseL1PhaseInTimeRecalibration), 
   fEMCALL1PhaseInTimeRecalibration(reco.fEMCALL1PhaseInTimeRecalibration),
+  fDoUseMergedBC(reco.fDoUseMergedBC),
   fUseRunCorrectionFactors(reco.fUseRunCorrectionFactors),   
   fRemoveBadChannels(reco.fRemoveBadChannels),               fRecalDistToBadChannels(reco.fRecalDistToBadChannels),
   fEMCALBadChannelMap(NULL),
@@ -202,6 +203,8 @@ AliEMCALRecoUtils & AliEMCALRecoUtils::operator = (const AliEMCALRecoUtils & rec
 
   fUseL1PhaseInTimeRecalibration   = reco.fUseL1PhaseInTimeRecalibration;
   fEMCALL1PhaseInTimeRecalibration = reco.fEMCALL1PhaseInTimeRecalibration;
+
+  fDoUseMergedBC	     = reco.fDoUseMergedBC;
   
   fUseRunCorrectionFactors   = reco.fUseRunCorrectionFactors;
   
@@ -1625,31 +1628,52 @@ void AliEMCALRecoUtils::InitEMCALTimeRecalibrationFactors()
   Bool_t oldStatus = TH1::AddDirectoryStatus();
   TH1::AddDirectory(kFALSE);
   
-  if(fLowGain) fEMCALTimeRecalibrationFactors = new TObjArray(8);
-  else fEMCALTimeRecalibrationFactors = new TObjArray(4);
+  if(fDoUseMergedBC){
 
-  for (int i = 0; i < 4; i++) 
-    fEMCALTimeRecalibrationFactors->Add(new TH1F(Form("hAllTimeAvBC%d",i),
-                                                 Form("hAllTimeAvBC%d",i),  
+    if(fLowGain) fEMCALTimeRecalibrationFactors = new TObjArray(2);
+    else fEMCALTimeRecalibrationFactors = new TObjArray(1);
+
+    fEMCALTimeRecalibrationFactors->Add(new TH1S("hAllTimeAv",
+                                                 "hAllTimeAv",  
                                                  48*24*22,0.,48*24*22)          );
-  // Init the histograms with 0
-  for (Int_t iBC = 0; iBC < 4; iBC++) 
-  {
+    // Init the histograms with 0
     for (Int_t iCh = 0; iCh < 48*24*22; iCh++) 
-      SetEMCALChannelTimeRecalibrationFactor(iBC,iCh,0.,kFALSE);
-  }
+      SetEMCALChannelTimeRecalibrationFactor(0,iCh,0.,kFALSE);
 
-  if(fLowGain) {
-    for (int iBC = 0; iBC < 4; iBC++) {
-      fEMCALTimeRecalibrationFactors->Add(new TH1F(Form("hAllTimeAvLGBC%d",iBC),
-						   Form("hAllTimeAvLGBC%d",iBC),  
+    if(fLowGain) {
+      fEMCALTimeRecalibrationFactors->Add(new TH1F("hAllTimeAvLG",
+						   "hAllTimeAvLG",  
 						   48*24*22,0.,48*24*22)        );
       for (Int_t iCh = 0; iCh < 48*24*22; iCh++) 
-	SetEMCALChannelTimeRecalibrationFactor(iBC,iCh,0.,kTRUE);
+  	SetEMCALChannelTimeRecalibrationFactor(1,iCh,0.,kTRUE);
     }
+
+  }else{
+    if(fLowGain) fEMCALTimeRecalibrationFactors = new TObjArray(8);
+    else fEMCALTimeRecalibrationFactors = new TObjArray(4);
+
+    for (int i = 0; i < 4; i++) 
+      fEMCALTimeRecalibrationFactors->Add(new TH1F(Form("hAllTimeAvBC%d",i),
+                                                 Form("hAllTimeAvBC%d",i),  
+                                                 48*24*22,0.,48*24*22)          );
+    // Init the histograms with 0
+    for (Int_t iBC = 0; iBC < 4; iBC++) 
+    {
+      for (Int_t iCh = 0; iCh < 48*24*22; iCh++) 
+        SetEMCALChannelTimeRecalibrationFactor(iBC,iCh,0.,kFALSE);
+    }
+
+    if(fLowGain) {
+      for (int iBC = 0; iBC < 4; iBC++) {
+        fEMCALTimeRecalibrationFactors->Add(new TH1F(Form("hAllTimeAvLGBC%d",iBC),
+						   Form("hAllTimeAvLGBC%d",iBC),  
+						   48*24*22,0.,48*24*22)        );
+        for (Int_t iCh = 0; iCh < 48*24*22; iCh++) 
+  	  SetEMCALChannelTimeRecalibrationFactor(iBC,iCh,0.,kTRUE);
+      }
+    }
+
   }
-
-
   
   fEMCALTimeRecalibrationFactors->SetOwner(kTRUE);
   fEMCALTimeRecalibrationFactors->Compress();
@@ -3767,14 +3791,14 @@ void  AliEMCALRecoUtils::SetEMCALChannelTimeRecalibrationFactors(const TObjArray
   }
 }
 
-void  AliEMCALRecoUtils::SetEMCALChannelTimeRecalibrationFactors(Int_t bc, const TH1F* h){ 
+void  AliEMCALRecoUtils::SetEMCALChannelTimeRecalibrationFactors(Int_t bc, const TH1* h){ 
   if(!fEMCALTimeRecalibrationFactors){
     fEMCALTimeRecalibrationFactors = new TObjArray(bc);
     fEMCALTimeRecalibrationFactors->SetOwner(true);
   }
   if(fEMCALTimeRecalibrationFactors->GetEntries() <= bc) fEMCALTimeRecalibrationFactors->Expand(bc+1);
   if(fEMCALTimeRecalibrationFactors->At(bc)) fEMCALTimeRecalibrationFactors->RemoveAt(bc);
-  TH1F *clone = new TH1F(*h);
+  TH1F *clone = new TH1F(*(TH1F*)h);
   clone->SetDirectory(NULL);
   fEMCALTimeRecalibrationFactors->AddAt(clone,bc); 
 }

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -189,7 +189,8 @@ public:
   void     SwitchOffRunDepCorrection()                   { fUseRunCorrectionFactors = kFALSE ; }
   void     SwitchOnRunDepCorrection()                    { fUseRunCorrectionFactors = kTRUE  ; 
                                                            SwitchOnRecalibration()           ; }      
-  // Time Recalibration  
+  // Time Recalibration
+  void	   SetUseOneHistForAllBCs(Bool_t useOneHist)     { fDoUseMergedBC = useOneHist ; }
   void     SetConstantTimeShift(Float_t shift)           { fConstantTimeShift = shift  ; }
 
   void     RecalibrateCellTime(Int_t absId, Int_t bc, Double_t & time,Bool_t isLGon = kFALSE) const;
@@ -202,16 +203,22 @@ public:
   TObjArray* GetEMCALTimeRecalibrationFactorsArray() const { return fEMCALTimeRecalibrationFactors ; }
 
   Float_t  GetEMCALChannelTimeRecalibrationFactor(Int_t bc, Int_t absID, Bool_t isLGon = kFALSE) const { 
-    if(fEMCALTimeRecalibrationFactors) 
-      return (Float_t) ((TH1F*)fEMCALTimeRecalibrationFactors->At(bc+4*isLGon))->GetBinContent(absID); 
-    else return 0 ; } 
+    if(fEMCALTimeRecalibrationFactors){
+      if(fDoUseMergedBC)
+        return (Float_t) ((TH1S*)fEMCALTimeRecalibrationFactors->At(1*isLGon))->GetBinContent(absID); 
+      else 
+	return (Float_t) ((TH1F*)fEMCALTimeRecalibrationFactors->At(bc+4*isLGon))->GetBinContent(absID);
+    } else return 0 ; } 
   void     SetEMCALChannelTimeRecalibrationFactor(Int_t bc, Int_t absID, Double_t c = 0, Bool_t isLGon=kFALSE) { 
     if(!fEMCALTimeRecalibrationFactors) InitEMCALTimeRecalibrationFactors() ;
-    ((TH1F*)fEMCALTimeRecalibrationFactors->At(bc+4*isLGon))->SetBinContent(absID,c) ; }  
+    if(fDoUseMergedBC)
+      ((TH1S*)fEMCALTimeRecalibrationFactors->At(isLGon))->SetBinContent(absID,c) ;
+    else
+      ((TH1F*)fEMCALTimeRecalibrationFactors->At(bc+4*isLGon))->SetBinContent(absID,c) ; }  
   
-  TH1F *   GetEMCALChannelTimeRecalibrationFactors(Int_t bc)const       { return (TH1F*)fEMCALTimeRecalibrationFactors->At(bc) ; }	
+  TH1  *   GetEMCALChannelTimeRecalibrationFactors(Int_t bc)const       { return (TH1*)fEMCALTimeRecalibrationFactors->At(bc) ; }	
   void     SetEMCALChannelTimeRecalibrationFactors(const TObjArray *map);
-  void     SetEMCALChannelTimeRecalibrationFactors(Int_t bc , const TH1F* h);
+  void     SetEMCALChannelTimeRecalibrationFactors(Int_t bc , const TH1* h);
 
   Bool_t   IsLGOn()const { return fLowGain   ; }
   void     SwitchOffLG() { fLowGain = kFALSE ; }
@@ -488,6 +495,7 @@ private:
   // Time Recalibration with L1 phase 
   Bool_t     fUseL1PhaseInTimeRecalibration;   ///< Switch on or off the L1 phase in time recalibration
   TObjArray* fEMCALL1PhaseInTimeRecalibration; ///< Histogram with map of L1 phase per SM, EMCAL
+  Bool_t     fDoUseMergedBC;		       ///< flag for using one histo for all BCs
 
   // Recalibrate with run dependent corrections, energy
   Bool_t     fUseRunCorrectionFactors;   ///< Use Run Dependent Correction
@@ -561,7 +569,7 @@ private:
   Bool_t     fMCGenerToAcceptForTrack;   ///<  Activate the removal of tracks entering the track matching that come from a particular generator
   
   /// \cond CLASSIMP
-  ClassDef(AliEMCALRecoUtils, 29) ;
+  ClassDef(AliEMCALRecoUtils, 30) ;
   /// \endcond
 
 };

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.cxx
@@ -51,7 +51,8 @@ AliEmcalCorrectionComponent::AliEmcalCorrectionComponent() :
   fRecoUtils(0),
   fOutput(0),
   fBasePath(""),
-  fCustomBadChannelFilePath("")
+  fCustomBadChannelFilePath(""),
+  fDoMergedBCs(kFALSE)
 
 {
   fVertex[0] = 0;
@@ -86,7 +87,8 @@ AliEmcalCorrectionComponent::AliEmcalCorrectionComponent(const char * name) :
   fRecoUtils(0),
   fOutput(0),
   fBasePath(""),
-  fCustomBadChannelFilePath("")
+  fCustomBadChannelFilePath(""),
+  fDoMergedBCs(kFALSE)
 {
   fVertex[0] = 0;
   fVertex[1] = 0;
@@ -282,7 +284,7 @@ void AliEmcalCorrectionComponent::GetPass()
   }
 }
 
-/**
+/*
  * Fills the Cell QA histograms
  */
 void AliEmcalCorrectionComponent::FillCellQA(TH1F* h){

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.h
@@ -104,6 +104,8 @@ class AliEmcalCorrectionComponent : public TNamed {
   void SetIsESD(Bool_t isESD) {fEsdMode = isESD; }
   void SetCustomBadChannels(TString customBC) {fCustomBadChannelFilePath = customBC; }
 
+  void SetUseMergedBCs(Bool_t useOneHist) {fDoMergedBCs = useOneHist; }
+
   /// Set %YAML Configuration
   void SetYAMLConfiguration(PWG::Tools::AliYAMLConfiguration config) { fYAMLConfig = config; }
 
@@ -136,12 +138,14 @@ class AliEmcalCorrectionComponent : public TNamed {
   TString                fBasePath;                       ///< Base folder path to get root files
   TString                fCustomBadChannelFilePath;       ///< Custom path to bad channel map OADB file
 
+  Bool_t 		 fDoMergedBCs;			  ///< flag to use one histo for all BCs
+
  private:
   AliEmcalCorrectionComponent(const AliEmcalCorrectionComponent &);               // Not implemented
   AliEmcalCorrectionComponent &operator=(const AliEmcalCorrectionComponent &);    // Not implemented
   
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionComponent, 6); // EMCal correction component
+  ClassDef(AliEmcalCorrectionComponent, 7); // EMCal correction component
   /// \endcond
 };
 

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
@@ -62,6 +62,7 @@ AliEmcalCorrectionTask::AliEmcalCorrectionTask() :
   fForceBeamType(kNA),
   fNeedEmcalGeom(kTRUE),
   fGeom(0),
+  fDoUseMergedBCs(kFALSE),
   fParticleCollArray(),
   fClusterCollArray(),
   fCellCollArray(),
@@ -108,6 +109,7 @@ AliEmcalCorrectionTask::AliEmcalCorrectionTask(const char * name) :
   fForceBeamType(kNA),
   fNeedEmcalGeom(kTRUE),
   fGeom(0),
+  fDoUseMergedBCs(kFALSE),
   fParticleCollArray(),
   fClusterCollArray(),
   fCellCollArray(),
@@ -154,6 +156,7 @@ AliEmcalCorrectionTask::AliEmcalCorrectionTask(const AliEmcalCorrectionTask & ta
   fForceBeamType(task.fForceBeamType),
   fNeedEmcalGeom(task.fNeedEmcalGeom),
   fGeom(task.fGeom),
+  fDoUseMergedBCs(task.fDoUseMergedBCs),
   fParticleCollArray(*(static_cast<TObjArray *>(task.fParticleCollArray.Clone()))),
   fClusterCollArray(*(static_cast<TObjArray *>(task.fClusterCollArray.Clone()))),
   fOutput(task.fOutput)                           // TODO: More care is needed here!
@@ -218,6 +221,7 @@ void swap(AliEmcalCorrectionTask & first, AliEmcalCorrectionTask & second)
   swap(first.fForceBeamType, second.fForceBeamType);
   swap(first.fNeedEmcalGeom, second.fNeedEmcalGeom);
   swap(first.fGeom, second.fGeom);
+  swap(first.fDoUseMergedBCs, second.fDoUseMergedBCs);
   swap(first.fParticleCollArray, second.fParticleCollArray);
   swap(first.fClusterCollArray, second.fClusterCollArray);
   swap(first.fCellCollArray, second.fCellCollArray);
@@ -1321,6 +1325,7 @@ Bool_t AliEmcalCorrectionTask::Run()
     component->SetCentralityBin(fCentBin);
     component->SetCentrality(fCent);
     component->SetVertex(fVertex);
+    component->SetUseMergedBCs(fDoUseMergedBCs);
 
     component->Run();
   }

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
@@ -100,6 +100,7 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
   // Set
   void                        SetForceBeamType(BeamType f)                          { fForceBeamType     = f                              ; }
   void                        SetNeedEmcalGeometry(Bool_t b)                        { fNeedEmcalGeom     = b                              ; }
+  void			      SetUseOneHistForAllBCs(Bool_t b)			    { fDoUseMergedBCs	 = b				  ; }
   // Centrality options
   void                        SetUseNewCentralityEstimation(Bool_t b)               { fUseNewCentralityEstimation = b                     ; }
   void                        SetCentralityEstimator(const char * c)                { fCentEst           = c                              ; }
@@ -243,6 +244,8 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
   Bool_t                      fNeedEmcalGeom;              ///< whether or not the task needs the emcal geometry
   AliEMCALGeometry           *fGeom;                       //!<! Emcal geometry
 
+  Bool_t		      fDoUseMergedBCs;		   ///< flag to use one histo for all BCs
+
   TObjArray                   fParticleCollArray;          ///< Particle/track collection array
   TObjArray                   fClusterCollArray;           ///< Cluster collection array
   std::vector <AliEmcalCorrectionCellContainer *> fCellCollArray; ///< Cells collection array
@@ -250,7 +253,7 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
   TList *                     fOutput;                     //!<! Output for histograms
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionTask, 6); // EMCal correction task
+  ClassDef(AliEmcalCorrectionTask, 7); // EMCal correction task
   /// \endcond
 };
 

--- a/PWG/EMCAL/macros/AddTaskEMCALTender.C
+++ b/PWG/EMCAL/macros/AddTaskEMCALTender.C
@@ -34,7 +34,8 @@ AliAnalysisTaskSE *AddTaskEMCALTender(
   TString customBCmap         = "",       // location of custom bad channel map (full path including file)
   Bool_t useNewRWTempCalib    = kFALSE,   // switch for usage of new temperature calib parameters (available for run1 and run2)
   TString customSMtemps       = "",       // location of custom SM-wise temperature OADB file (full path including file)
-  TString customTempParams    = ""        // location of custom temperature calibration parameters OADB file (full path including file)
+  TString customTempParams    = "",        // location of custom temperature calibration parameters OADB file (full path including file)
+  Bool_t useOneHistAllBCS     = kFALSE    // flag to use on histogram for the all the BCs
 ) 
 {
   // Get the pointer to the existing analysis manager via the static access method.
@@ -91,6 +92,8 @@ AliAnalysisTaskSE *AddTaskEMCALTender(
                                         fidRegion, calibEnergy, calibTime, remBC, nonLinFunct, reclusterize, seedthresh, 
                                         cellthresh, clusterizer, trackMatch, updateCellOnly, timeMin, timeMax, timeCut, diffEAggregation);
   #endif
+
+  EMCALSupply->SwitchUseMergedBCs(useOneHistAllBCS);
 
   if (pass) 
     EMCALSupply->SetPass(pass);
@@ -162,7 +165,7 @@ AliAnalysisTaskSE *AddTaskEMCALTender(
       EMCALSupply->SetRecoUtils(ru);
     }
   }
-  
+
   mgr->AddTask(ana);
 
   // Create ONLY the output containers for the data produced by the task.

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALClusterize.cxx
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALClusterize.cxx
@@ -100,6 +100,7 @@ AliAnalysisTaskEMCALClusterize::AliAnalysisTaskEMCALClusterize(const char *name)
 , fTCardCorrMinAmp(0.01), fTCardCorrMinInduced(0) 
 , fTCardCorrMaxInducedLowE(0), fTCardCorrMaxInduced(100)
 , fPrintOnce(0)
+, fDoMergedBCs(0x0)
 
 {
   for(Int_t i = 0; i < 22;    i++)  
@@ -165,6 +166,7 @@ AliAnalysisTaskEMCALClusterize::AliAnalysisTaskEMCALClusterize()
 , fTCardCorrMinAmp(0.01),   fTCardCorrMinInduced(0)
 , fTCardCorrMaxInducedLowE(0), fTCardCorrMaxInduced(100)
 , fPrintOnce(0)
+, fDoMergedBCs(0x0)
 {
   for(Int_t i = 0; i < 22;    i++)  
   {
@@ -476,28 +478,47 @@ void AliAnalysisTaskEMCALClusterize::AccessOADB()
 
       TObjArray *trecalpass=(TObjArray*)trecal->FindObject(passM);
 
-      if(trecalpass)
-      {
-        AliInfo("Time Recalibrate EMCAL");
-        for (Int_t ibc = 0; ibc < 4; ++ibc) 
+        if(trecalpass)
         {
-          TH1F *h = fRecoUtils->GetEMCALChannelTimeRecalibrationFactors(ibc);
+          AliInfo("Time Recalibrate EMCAL");
+
+	  if(fDoMergedBCs){
+
+            TH1S *h = (TH1S*)fRecoUtils->GetEMCALChannelTimeRecalibrationFactors(0);
+            
+            if (h)
+              delete h;
           
-          if (h)
-            delete h;
+            h = (TH1S*)trecalpass->FindObject("hAllTimeAv");// High Gain only
           
-          h = (TH1F*)trecalpass->FindObject(Form("hAllTimeAvBC%d",ibc));
+            if (!h) 
+              AliError("Could not load hAllTimeAv");
+            
+            h->SetDirectory(0);
+
+            fRecoUtils->SetEMCALChannelTimeRecalibrationFactors(0,h);
+
+	  }else{
+            for (Int_t ibc = 0; ibc < 4; ++ibc) 
+            {
+              TH1F *h = (TH1F*)fRecoUtils->GetEMCALChannelTimeRecalibrationFactors(ibc);
           
-          if (!h) 
-          {
-            AliError(Form("Could not load hAllTimeAvBC%d",ibc));
-            continue;
-          }
+              if (h)
+                delete h;
           
-          h->SetDirectory(0);
+              h = (TH1F*)trecalpass->FindObject(Form("hAllTimeAvBC%d",ibc));
           
-          fRecoUtils->SetEMCALChannelTimeRecalibrationFactors(ibc,h);
-        } // bunch crossing loop
+              if (!h) 
+              {
+                AliError(Form("Could not load hAllTimeAvBC%d",ibc));
+                continue;
+              }
+          
+              h->SetDirectory(0);
+          
+              fRecoUtils->SetEMCALChannelTimeRecalibrationFactors(ibc,h);
+            } // bunch crossing loop
+	  }
       } else AliInfo("Do NOT recalibrate time EMCAL, no params for pass"); // array pass ok
     } else AliInfo("Do NOT recalibrate time EMCAL, no params for run");  // run number array ok
     
@@ -1146,6 +1167,10 @@ void AliAnalysisTaskEMCALClusterize::ConfigureEMCALRecoUtils
     fRecoUtils->SwitchOnRunDepCorrection();    
   } 
   
+  // Use one histogram for all BCs
+  if (fDoMergedBCs)
+    fRecoUtils->SetUseOneHistForAllBCs(fDoMergedBCs);
+
   // Remove EMCAL hot channels 
   
   if(bBad)
@@ -1492,6 +1517,10 @@ void AliAnalysisTaskEMCALClusterize::Init()
   
   if(!fRecParam)     fRecParam  = new AliEMCALRecParam;
   if(!fRecoUtils)    fRecoUtils = new AliEMCALRecoUtils();  
+
+  // Use one histogram for all BCs
+  if (fDoMergedBCs)
+    fRecoUtils->SetUseOneHistForAllBCs(fDoMergedBCs);
   
   if(fMaxEvent          <= 0) fMaxEvent          = 1000000000;
   if(fSelectCellMinE    <= 0) fSelectCellMinE    = 0.005;     

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALClusterize.h
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALClusterize.h
@@ -314,6 +314,8 @@ class AliAnalysisTaskEMCALClusterize : public AliAnalysisTaskSE {
   void           SetInducedTCardMaximumLowE(Float_t ma)         { fTCardCorrMaxInducedLowE = ma ; }
   
   void           PrintTCardParam();
+
+  void     SwitchUseMergedBCs(Bool_t doUseMergedBC)     { fDoMergedBCs     = doUseMergedBC; }
   
   //------------------------------------------
   
@@ -449,6 +451,8 @@ private:
   Float_t               fTCardCorrMaxInduced;      ///<  Maximum induced energy signal on adjacent cells
   
   Bool_t                fPrintOnce;                ///< Print once analysis parameters
+
+  Bool_t		 fDoMergedBCs;		  // flag whether to load four histos for the time calib or one merged histo
   
   /// Copy constructor not implemented.
   AliAnalysisTaskEMCALClusterize(           const AliAnalysisTaskEMCALClusterize&) ;
@@ -457,7 +461,7 @@ private:
   AliAnalysisTaskEMCALClusterize& operator=(const AliAnalysisTaskEMCALClusterize&) ;
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskEMCALClusterize, 43) ;
+  ClassDef(AliAnalysisTaskEMCALClusterize, 44) ;
   /// \endcond
 
 };

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALTimeCalib.cxx
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALTimeCalib.cxx
@@ -107,6 +107,7 @@ AliAnalysisTaskEMCALTimeCalib::AliAnalysisTaskEMCALTimeCalib(const char *name)
   fL1PhaseList(0),
   fBadReco(kFALSE),
   fFillHeavyHisto(kFALSE),
+  fOneHistAllBCs(kFALSE),
   fBadChannelMapArray(0),
   fBadChannelMapSet(kFALSE),
   fSetBadChannelMapSource(0),
@@ -125,11 +126,19 @@ AliAnalysisTaskEMCALTimeCalib::AliAnalysisTaskEMCALTimeCalib(const char *name)
   fhTimeSumSq(),
   fhTimeEnt(),
   fhTimeSum(),
+  fhTimeSumSqAllBCs(0x0),
+  fhTimeEntAllBCs(0x0),
+  fhTimeSumAllBCs(0x0),
   fhTimeLGSumSq(),
   fhTimeLGEnt(),
   fhTimeLGSum(),
+  fhTimeLGSumSqAllBCs(0x0),
+  fhTimeLGEntAllBCs(0x0),
+  fhTimeLGSumAllBCs(0x0),
   fhAllAverageBC(),
   fhAllAverageLGBC(),
+  fhAllAverageAllBCs(0x0),
+  fhAllAverageLGAllBCs(0x0),
   fhRefRuns(0),
   fhTimeDsup(),
   fhTimeDsupBC(),
@@ -148,7 +157,9 @@ AliAnalysisTaskEMCALTimeCalib::AliAnalysisTaskEMCALTimeCalib(const char *name)
   fhRawCorrTimeVsIdBC(),
   fhRawCorrTimeVsIdLGBC(),
   fhTimeVsIdBC(),
-  fhTimeVsIdLGBC()
+  fhTimeVsIdLGBC(),
+  fhTimeVsIdAllBCs(0x0),
+  fhTimeVsIdLGAllBCs(0x0)
 {
   for(Int_t i = 0; i < kNBCmask; i++) 
   {
@@ -217,20 +228,32 @@ void AliAnalysisTaskEMCALTimeCalib::LoadReferenceHistos()
     } else {
 	AliDebug(1,"*** OK TFILE");
 	// connect ref run here
-	for(Int_t i = 0; i < kNBCmask; i++)
-	  {
-	    fhAllAverageBC[i]=(TH1F*) myFile->Get(Form("hAllTimeAvBC%d",i));
-	    if(fhAllAverageBC[i]==0x0) AliFatal(Form("Reference histogram for BC%d does not exist",i));
-	    if(fhAllAverageBC[i]->GetEntries()==0)AliWarning(Form("fhAllAverageLGBC[%d]->GetEntries() = 0",i));
-	    fhAllAverageLGBC[i]=(TH1F*) myFile->Get(Form("hAllTimeAvLGBC%d",i));
-	    if(fhAllAverageLGBC[i]==0x0) AliFatal(Form("Reference LG histogram for BC%d does not exist",i));
-	    if(fhAllAverageLGBC[i]->GetEntries()==0)AliFatal(Form("fhAllAverageLGBC[%d]->GetEntries() = 0",i));
-	  }
+	if(!fOneHistAllBCs){
+	  for(Int_t i = 0; i < kNBCmask; i++)
+	    {
+	      fhAllAverageBC[i]=(TH1F*) myFile->Get(Form("hAllTimeAvBC%d",i));
+	      if(fhAllAverageBC[i]==0x0) AliFatal(Form("Reference histogram for BC%d does not exist",i));
+	      if(fhAllAverageBC[i]->GetEntries()==0)AliWarning(Form("fhAllAverageLGBC[%d]->GetEntries() = 0",i));
+	      fhAllAverageLGBC[i]=(TH1F*) myFile->Get(Form("hAllTimeAvLGBC%d",i));
+	      if(fhAllAverageLGBC[i]==0x0) AliFatal(Form("Reference LG histogram for BC%d does not exist",i));
+	      if(fhAllAverageLGBC[i]->GetEntries()==0)AliFatal(Form("fhAllAverageLGBC[%d]->GetEntries() = 0",i));
+	    }
 	
-	AliDebug(1,Form("hAllAverage entries BC0 %d", (Int_t)fhAllAverageBC[0]->GetEntries() ));
-	AliDebug(1,Form("hAllAverage entries BC2 %d",(Int_t)fhAllAverageBC[2]->GetEntries() ));
-	AliDebug(1,Form("hAllAverageLG entries BC0 %d", (Int_t)fhAllAverageLGBC[0]->GetEntries() ));
-	AliDebug(1,Form("hAllAverageLG entries BC2 %d",(Int_t)fhAllAverageLGBC[2]->GetEntries() ));
+	  AliDebug(1,Form("hAllAverage entries BC0 %d", (Int_t)fhAllAverageBC[0]->GetEntries() ));
+	  AliDebug(1,Form("hAllAverage entries BC2 %d",(Int_t)fhAllAverageBC[2]->GetEntries() ));
+	  AliDebug(1,Form("hAllAverageLG entries BC0 %d", (Int_t)fhAllAverageLGBC[0]->GetEntries() ));
+	  AliDebug(1,Form("hAllAverageLG entries BC2 %d",(Int_t)fhAllAverageLGBC[2]->GetEntries() ));
+	}else{
+	  fhAllAverageAllBCs=(TH1S*) myFile->Get("hAllTimeAv");
+	  if(fhAllAverageAllBCs==0x0) AliFatal("Reference histogram for All BCs does not exist");
+	  if(fhAllAverageAllBCs->GetEntries()==0)AliWarning("fhAllAverageLGAllBCs->GetEntries() = 0");
+	  fhAllAverageLGAllBCs=(TH1S*) myFile->Get("hAllTimeAvLG");
+	  if(fhAllAverageLGAllBCs==0x0) AliFatal("Reference LG histogram for all BCs does not exist");
+	  if(fhAllAverageLGAllBCs->GetEntries()==0)AliFatal("fhAllAverageLGAllBCs->GetEntries() = 0");
+	
+	  AliDebug(1,Form("fhAllAverageAllBCs entries %d", (Int_t)fhAllAverageAllBCs->GetEntries() ));
+	  AliDebug(1,Form("fhAllAverageLGAllBCs entries %d", (Int_t)fhAllAverageLGAllBCs->GetEntries() ));
+	}
 	
     }
   } else { //end of reference file is provided
@@ -516,46 +539,105 @@ void AliAnalysisTaskEMCALTimeCalib::UserCreateOutputObjects()
     }
   }
 
+
+  if(fOneHistAllBCs){
+    //high gain
+    fhTimeSumSqAllBCs = new TH1F("hTimeSumSqAllBCs",
+  			      "cell Sum Square time HG, All BCs",
+			      nChannels,0.,(Double_t)nChannels);
+    fhTimeSumSqAllBCs->SetYTitle("Sum Sq Time ");
+    fhTimeSumSqAllBCs->SetXTitle("AbsId");
+    
+    fhTimeSumAllBCs = new TH1F("hTimeSumAllBCs",
+			    "cell Sum  time HG, All BCs",
+			    nChannels,0.,(Double_t)nChannels);
+    fhTimeSumAllBCs->SetYTitle("Sum  Time ");
+    fhTimeSumAllBCs->SetXTitle("AbsId");
+    
+    fhTimeEntAllBCs = new TH1F("hTimeEntAllBCs",
+			    "cell Entries HG, All BCs",
+			    nChannels,0.,(Double_t)nChannels);
+    fhTimeEntAllBCs->SetYTitle("Entries for Time ");
+    fhTimeEntAllBCs->SetXTitle("AbsId");
+    
+    //low gain 
+    fhTimeLGSumSqAllBCs = new TH1F("hTimeLGSumSqAllBCs",
+			      "cell Sum Square time LG, All BCs",
+  			      nChannels,0.,(Double_t)nChannels);
+    fhTimeLGSumSqAllBCs->SetYTitle("Sum Sq Time ");
+    fhTimeLGSumSqAllBCs->SetXTitle("AbsId");
+    
+    fhTimeLGSumAllBCs = new TH1F("hTimeLGSumAllBCs",
+			    "cell Sum time LG, All BCs",
+			    nChannels,0.,(Double_t)nChannels);
+    fhTimeLGSumAllBCs->SetYTitle("Sum  Time ");
+    fhTimeLGSumAllBCs->SetXTitle("AbsId");
+    
+    fhTimeLGEntAllBCs = new TH1F("hTimeLGEntAllBCs",
+			    "cell Entries LG, All BCs",
+			    nChannels,0.,(Double_t)nChannels);
+    fhTimeLGEntAllBCs->SetYTitle("Entries for Time ");
+    fhTimeLGEntAllBCs->SetXTitle("AbsId");
+
+    //histograms with corrected raw time for L1 shift and 100ns + new L1 phase
+    if(fReferenceRunByRunFileName.Length()!=0 && fFillHeavyHisto){
+      fhTimeVsIdAllBCs = new TH2F("TimeVsIdAllBCs",
+				 "cell time corrected for L1 shift, 100ns and L1 phase vs ID for high gain All BCs",
+				 nChannels,0.,(Double_t)nChannels,fPassTimeNbins,fPassTimeMin,fPassTimeMax);
+      fhTimeVsIdAllBCs->SetXTitle("AbsId");
+      fhTimeVsIdAllBCs->SetYTitle("Time");
+      
+      fhTimeVsIdLGAllBCs = new TH2F("TimeVsIdLGAllBCs",
+				   "cell time corrected for L1 shift, 100ns and L1 phase vs ID for low gain All BCs",
+				   nChannels,0.,(Double_t)nChannels,fPassTimeNbins,fPassTimeMin,fPassTimeMax);
+      fhTimeVsIdLGAllBCs->SetXTitle("AbsId");
+      fhTimeVsIdLGAllBCs->SetYTitle("Time");
+    }
+
+  }
+
   for (Int_t i = 0; i < kNBCmask ;  i++)
   {
     //already after correction
-    //high gain
-    fhTimeSumSq[i] = new TH1F(Form("hTimeSumSq%d", i),
-			      Form("cell Sum Square time HG, BC %d ", i),
+    if(!fOneHistAllBCs){
+      //high gain
+      fhTimeSumSq[i] = new TH1F(Form("hTimeSumSq%d", i),
+  			      Form("cell Sum Square time HG, BC %d ", i),
 			      nChannels,0.,(Double_t)nChannels);
-    fhTimeSumSq[i]->SetYTitle("Sum Sq Time ");
-    fhTimeSumSq[i]->SetXTitle("AbsId");
+      fhTimeSumSq[i]->SetYTitle("Sum Sq Time ");
+      fhTimeSumSq[i]->SetXTitle("AbsId");
     
-    fhTimeSum[i] = new TH1F(Form("hTimeSum%d", i),
+      fhTimeSum[i] = new TH1F(Form("hTimeSum%d", i),
 			    Form("cell Sum  time HG, BC %d ", i),
 			    nChannels,0.,(Double_t)nChannels);
-    fhTimeSum[i]->SetYTitle("Sum  Time ");
-    fhTimeSum[i]->SetXTitle("AbsId");
+      fhTimeSum[i]->SetYTitle("Sum  Time ");
+      fhTimeSum[i]->SetXTitle("AbsId");
     
-    fhTimeEnt[i] = new TH1F(Form("hTimeEnt%d", i),
+      fhTimeEnt[i] = new TH1F(Form("hTimeEnt%d", i),
 			    Form("cell Entries HG, BC %d ", i),
 			    nChannels,0.,(Double_t)nChannels);
-    fhTimeEnt[i]->SetYTitle("Entries for Time ");
-    fhTimeEnt[i]->SetXTitle("AbsId");
+      fhTimeEnt[i]->SetYTitle("Entries for Time ");
+      fhTimeEnt[i]->SetXTitle("AbsId");
     
-    //low gain 
-    fhTimeLGSumSq[i] = new TH1F(Form("hTimeLGSumSq%d", i),
+      //low gain 
+      fhTimeLGSumSq[i] = new TH1F(Form("hTimeLGSumSq%d", i),
 			      Form("cell Sum Square time LG, BC %d ", i),
-			      nChannels,0.,(Double_t)nChannels);
-    fhTimeLGSumSq[i]->SetYTitle("Sum Sq Time ");
-    fhTimeLGSumSq[i]->SetXTitle("AbsId");
+  			      nChannels,0.,(Double_t)nChannels);
+      fhTimeLGSumSq[i]->SetYTitle("Sum Sq Time ");
+      fhTimeLGSumSq[i]->SetXTitle("AbsId");
     
-    fhTimeLGSum[i] = new TH1F(Form("hTimeLGSum%d", i),
+      fhTimeLGSum[i] = new TH1F(Form("hTimeLGSum%d", i),
 			    Form("cell Sum time LG, BC %d ", i),
 			    nChannels,0.,(Double_t)nChannels);
-    fhTimeLGSum[i]->SetYTitle("Sum  Time ");
-    fhTimeLGSum[i]->SetXTitle("AbsId");
+      fhTimeLGSum[i]->SetYTitle("Sum  Time ");
+      fhTimeLGSum[i]->SetXTitle("AbsId");
     
-    fhTimeLGEnt[i] = new TH1F(Form("hTimeLGEnt%d", i),
+      fhTimeLGEnt[i] = new TH1F(Form("hTimeLGEnt%d", i),
 			    Form("cell Entries LG, BC %d ", i),
 			    nChannels,0.,(Double_t)nChannels);
-    fhTimeLGEnt[i]->SetYTitle("Entries for Time ");
-    fhTimeLGEnt[i]->SetXTitle("AbsId");
+      fhTimeLGEnt[i]->SetYTitle("Entries for Time ");
+      fhTimeLGEnt[i]->SetXTitle("AbsId");
+    }
 
     //raw time histograms
     //high gain
@@ -628,7 +710,7 @@ void AliAnalysisTaskEMCALTimeCalib::UserCreateOutputObjects()
     }
 
     //histograms with corrected raw time for L1 shift and 100ns + new L1 phase
-    if(fReferenceRunByRunFileName.Length()!=0 && fFillHeavyHisto){
+    if(fReferenceRunByRunFileName.Length()!=0 && fFillHeavyHisto && !fOneHistAllBCs){
       fhTimeVsIdBC[i] = new TH2F(Form("TimeVsIdBC%d", i),
 				 Form("cell time corrected for L1 shift, 100ns and L1 phase vs ID for high gain BC %d ", i),
 				 nChannels,0.,(Double_t)nChannels,fPassTimeNbins,fPassTimeMin,fPassTimeMax);
@@ -642,19 +724,22 @@ void AliAnalysisTaskEMCALTimeCalib::UserCreateOutputObjects()
       fhTimeVsIdLGBC[i]->SetYTitle("Time");
     }
 
-    for (Int_t j = 0; j < kNSM ;  j++) 
-    {
-      //High gain
-      //fhTimeDsupBC[j][i]= new TH2F(Form("SupMod%dBC%d",j,i), Form("SupMod %d time_vs_E  BC %d",j,i),500,0.0,20.0,2200,-350.0,750.0);
-      fhTimeDsupBC[j][i]= new TH2F(Form("SupMod%dBC%d",j,i), Form("SupMod %d time_vs_E, high gain, BC %d",j,i),fEnergyNbins,fEnergyMin,fEnergyMax,fPassTimeNbins,fPassTimeMin,fPassTimeMax);
-      fhTimeDsupBC[j][i]->SetYTitle(" Time (ns) "); 
-      fhTimeDsupBC[j][i]->SetXTitle(" E (GeV) "); 
+    if(!fOneHistAllBCs){
+      for (Int_t j = 0; j < kNSM ;  j++) 
+      {
+        //High gain
+        //fhTimeDsupBC[j][i]= new TH2F(Form("SupMod%dBC%d",j,i), Form("SupMod %d time_vs_E  BC %d",j,i),500,0.0,20.0,2200,-350.0,750.0);
+        fhTimeDsupBC[j][i]= new TH2F(Form("SupMod%dBC%d",j,i), Form("SupMod %d time_vs_E, high gain, BC %d",j,i),fEnergyNbins,fEnergyMin,fEnergyMax,fPassTimeNbins,fPassTimeMin,fPassTimeMax);
+        fhTimeDsupBC[j][i]->SetYTitle(" Time (ns) "); 
+        fhTimeDsupBC[j][i]->SetXTitle(" E (GeV) "); 
 
-      //low gain
-      fhTimeDsupLGBC[j][i]= new TH2F(Form("SupMod%dBC%dLG",j,i), Form("SupMod %d time_vs_E, low gain, BC %d",j,i),fEnergyLGNbins,fEnergyLGMin,fEnergyLGMax,fPassTimeNbins,fPassTimeMin,fPassTimeMax);
-      fhTimeDsupLGBC[j][i]->SetYTitle(" Time (ns) "); 
-      fhTimeDsupLGBC[j][i]->SetXTitle(" E (GeV) "); 
+        //low gain
+        fhTimeDsupLGBC[j][i]= new TH2F(Form("SupMod%dBC%dLG",j,i), Form("SupMod %d time_vs_E, low gain, BC %d",j,i),fEnergyLGNbins,fEnergyLGMin,fEnergyLGMax,fPassTimeNbins,fPassTimeMin,fPassTimeMax);
+        fhTimeDsupLGBC[j][i]->SetYTitle(" Time (ns) "); 
+        fhTimeDsupLGBC[j][i]->SetXTitle(" E (GeV) "); 
+      }
     }
+
   }
 
   for (Int_t jj = 0; jj < kNSM ;  jj++) 
@@ -697,15 +782,33 @@ void AliAnalysisTaskEMCALTimeCalib::UserCreateOutputObjects()
     }
   }
 
+  if(fOneHistAllBCs){
+    fOutputList->Add(fhTimeSumSqAllBCs);
+    fOutputList->Add(fhTimeEntAllBCs);
+    fOutputList->Add(fhTimeSumAllBCs);
+
+    fOutputList->Add(fhTimeLGSumSqAllBCs);
+    fOutputList->Add(fhTimeLGEntAllBCs);
+    fOutputList->Add(fhTimeLGSumAllBCs);
+
+    if(fReferenceRunByRunFileName.Length()!=0 && fFillHeavyHisto) {
+      fOutputList->Add(fhTimeVsIdAllBCs);
+      fOutputList->Add(fhTimeVsIdLGAllBCs);
+    }
+  }
+
   for (Int_t i = 0; i < kNBCmask ;  i++) 
   {
-    fOutputList->Add(fhTimeSumSq[i]);
-    fOutputList->Add(fhTimeEnt[i]);
-    fOutputList->Add(fhTimeSum[i]);
 
-    fOutputList->Add(fhTimeLGSumSq[i]);
-    fOutputList->Add(fhTimeLGEnt[i]);
-    fOutputList->Add(fhTimeLGSum[i]);
+    if(!fOneHistAllBCs){
+      fOutputList->Add(fhTimeSumSq[i]);
+      fOutputList->Add(fhTimeEnt[i]);
+      fOutputList->Add(fhTimeSum[i]);
+
+      fOutputList->Add(fhTimeLGSumSq[i]);
+      fOutputList->Add(fhTimeLGEnt[i]);
+      fOutputList->Add(fhTimeLGSum[i]);
+    }
 
     if(fFillHeavyHisto) {
       fOutputList->Add(fhRawTimeVsIdBC[i]);
@@ -723,16 +826,18 @@ void AliAnalysisTaskEMCALTimeCalib::UserCreateOutputObjects()
       fOutputList->Add(fhRawCorrTimeVsIdBC[i]);
       fOutputList->Add(fhRawCorrTimeVsIdLGBC[i]);
     }
-    if(fReferenceRunByRunFileName.Length()!=0 && fFillHeavyHisto) {
+    if(fReferenceRunByRunFileName.Length()!=0 && fFillHeavyHisto && !fOneHistAllBCs) {
       fOutputList->Add(fhTimeVsIdBC[i]);
       fOutputList->Add(fhTimeVsIdLGBC[i]);
     }
 
-    for (Int_t j = 0; j < kNSM ;  j++){
-      fOutputList->Add(fhTimeDsupBC[j][i]);
-      fOutputList->Add(fhTimeDsupLGBC[j][i]);
+    if(!fOneHistAllBCs) {
+      for (Int_t j = 0; j < kNSM ;  j++){
+        fOutputList->Add(fhTimeDsupBC[j][i]);
+        fOutputList->Add(fhTimeDsupLGBC[j][i]);
+      }
     }
-  }
+  }  
   
   for (Int_t j = 0; j < kNSM ;  j++)
   {
@@ -1020,19 +1125,35 @@ void AliAnalysisTaskEMCALTimeCalib::UserExec(Option_t *)
 	else {fhEneVsAbsIdLG->Fill(absId,amp);}
       }
       fhTimeVsBC->Fill(1.*BunchCrossNumber,hkdtime-timeBCoffset);
-      //important remark: We use 'Underflow bin' for absid=0 in OADB for time calibration 
-      if(isHighGain==kTRUE){
-	if(fhAllAverageBC[nBC]!=0) {//comming from file after the first iteration
-	  offset = (Float_t)(fhAllAverageBC[nBC]->GetBinContent(absId));//channel absId=0 has histogram bin=0
-	} else if(fReferenceFileName.Length()!=0){//protection against missing reference histogram
-	  AliFatal(Form("Reference histogram for BC%d not properly loaded",nBC));
-	}
-      } else {
-	if(fhAllAverageLGBC[nBC]!=0) {//comming from file after the first iteration
-	  offset = (Float_t)(fhAllAverageLGBC[nBC]->GetBinContent(absId));//channel absId=0 has histogram bin=0
-	} else if(fReferenceFileName.Length()!=0){//protection against missing reference histogram
-	  AliFatal(Form("Reference LG histogram for BC%d not properly loaded",nBC));
-	}
+      //important remark: We use 'Underflow bin' for absid=0 in OADB for time calibration
+      if(!fOneHistAllBCs){
+        if(isHighGain==kTRUE){
+	  if(fhAllAverageBC[nBC]!=0) {//comming from file after the first iteration
+	    offset = (Float_t)(fhAllAverageBC[nBC]->GetBinContent(absId));//channel absId=0 has histogram bin=0
+	  } else if(fReferenceFileName.Length()!=0){//protection against missing reference histogram
+	    AliFatal(Form("Reference histogram for BC%d not properly loaded",nBC));
+	  }
+        } else {
+	  if(fhAllAverageLGBC[nBC]!=0) {//comming from file after the first iteration
+	    offset = (Float_t)(fhAllAverageLGBC[nBC]->GetBinContent(absId));//channel absId=0 has histogram bin=0
+	  } else if(fReferenceFileName.Length()!=0){//protection against missing reference histogram
+	    AliFatal(Form("Reference LG histogram for BC%d not properly loaded",nBC));
+	  }
+        }
+      }else{
+        if(isHighGain==kTRUE){
+	  if(fhAllAverageAllBCs!=0) {//comming from file after the first iteration
+	    offset = (Float_t)(fhAllAverageAllBCs->GetBinContent(absId));//channel absId=0 has histogram bin=0
+	  } else if(fReferenceFileName.Length()!=0){//protection against missing reference histogram
+	    AliFatal("Reference histogram for all BCs not properly loaded");
+	  }
+        } else {
+	  if(fhAllAverageLGAllBCs!=0) {//comming from file after the first iteration
+	    offset = (Float_t)(fhAllAverageLGAllBCs->GetBinContent(absId));//channel absId=0 has histogram bin=0
+	  } else if(fReferenceFileName.Length()!=0){//protection against missing reference histogram
+	    AliFatal("Reference LG histogram for all BCs not properly loaded");
+	  }
+        }
       }
       //if(offset==0)cout<<"offset 0 in SM "<<nSupMod<<endl;
 
@@ -1075,11 +1196,19 @@ void AliAnalysisTaskEMCALTimeCalib::UserExec(Option_t *)
       }
 
       //fill time after L1 shift correction and 100ns and new L1 phase
-      if(fReferenceRunByRunFileName.Length()!=0 && fFillHeavyHisto && amp>fMinCellEnergy){
+      if(fReferenceRunByRunFileName.Length()!=0 && fFillHeavyHisto && amp>fMinCellEnergy && !fOneHistAllBCs){
         if(isHighGain){
-          fhTimeVsIdBC[nBC]->Fill(absId,hkdtime-L1shiftOffset-offsetPerSM);
+          fhTimeVsIdBC[nBC]->Fill(absId,hkdtime-offset-offsetPerSM-L1shiftOffset);
         }else{
-          fhTimeVsIdLGBC[nBC]->Fill(absId,hkdtime-L1shiftOffset-offsetPerSM);
+          fhTimeVsIdLGBC[nBC]->Fill(absId,hkdtime-offset-offsetPerSM-L1shiftOffset);
+        }
+      }
+
+      if(fOneHistAllBCs){
+        if(isHighGain){
+          fhTimeVsIdAllBCs->Fill(absId,hkdtime-offset-offsetPerSM-L1shiftOffset);
+        }else{
+          fhTimeVsIdLGAllBCs->Fill(absId,hkdtime-offset-offsetPerSM-L1shiftOffset);
         }
       }
 
@@ -1087,10 +1216,10 @@ void AliAnalysisTaskEMCALTimeCalib::UserExec(Option_t *)
       if(amp>0.5) {
 	if(isHighGain){				
 	  fhTimeDsup[nSupMod]->Fill(amp,hkdtime-offset-offsetPerSM-L1shiftOffset);
-	  fhTimeDsupBC[nSupMod][nBC]->Fill(amp,hkdtime-offset-offsetPerSM-L1shiftOffset);
+	  if(!fOneHistAllBCs) fhTimeDsupBC[nSupMod][nBC]->Fill(amp,hkdtime-offset-offsetPerSM-L1shiftOffset);
 	}else{
 	  fhTimeDsupLG[nSupMod]->Fill(amp,hkdtime-offset-offsetPerSM-L1shiftOffset);
-	  fhTimeDsupLGBC[nSupMod][nBC]->Fill(amp,hkdtime-offset-offsetPerSM-L1shiftOffset);
+	  if(!fOneHistAllBCs) fhTimeDsupLGBC[nSupMod][nBC]->Fill(amp,hkdtime-offset-offsetPerSM-L1shiftOffset);
 	}
       }
       
@@ -1120,14 +1249,26 @@ void AliAnalysisTaskEMCALTimeCalib::UserExec(Option_t *)
         //correction in 2015 for wrong L1 phase and L1 shift
 	hkdtime = hkdtime - offsetPerSM - L1shiftOffset;
 
-	if(isHighGain){
-	  fhTimeEnt[nBC]->Fill(absId,1.);
-	  fhTimeSumSq[nBC]->Fill(absId,hkdtime*hkdtime);
-	  fhTimeSum[nBC]->Fill(absId,hkdtime);
+ 	if(!fOneHistAllBCs){
+	  if(isHighGain){
+	    fhTimeEnt[nBC]->Fill(absId,1.);
+  	    fhTimeSumSq[nBC]->Fill(absId,hkdtime*hkdtime);
+	    fhTimeSum[nBC]->Fill(absId,hkdtime);
+	  }else{
+	    fhTimeLGEnt[nBC]->Fill(absId,1.);
+	    fhTimeLGSumSq[nBC]->Fill(absId,hkdtime*hkdtime);
+	    fhTimeLGSum[nBC]->Fill(absId,hkdtime);
+	  }
 	}else{
-	  fhTimeLGEnt[nBC]->Fill(absId,1.);
-	  fhTimeLGSumSq[nBC]->Fill(absId,hkdtime*hkdtime);
-	  fhTimeLGSum[nBC]->Fill(absId,hkdtime);
+	  if(isHighGain){
+	    fhTimeEntAllBCs->Fill(absId,1.);
+  	    fhTimeSumSqAllBCs->Fill(absId,hkdtime*hkdtime);
+	    fhTimeSumAllBCs->Fill(absId,hkdtime);
+	  }else{
+	    fhTimeLGEntAllBCs->Fill(absId,1.);
+	    fhTimeLGSumSqAllBCs->Fill(absId,hkdtime*hkdtime);
+	    fhTimeLGSumAllBCs->Fill(absId,hkdtime);
+	  }
 	}
 
 
@@ -1324,7 +1465,7 @@ void AliAnalysisTaskEMCALTimeCalib::SetDefaultCuts()
 /// input - root file with histograms 
 /// output - root file with constants in historams
 /// isFinal - flag: kFALSE-first iteration, kTRUE-final iteration
-void AliAnalysisTaskEMCALTimeCalib::ProduceCalibConsts(TString inputFile,TString outputFile,Bool_t isFinal,Bool_t isPAR)
+void AliAnalysisTaskEMCALTimeCalib::ProduceCalibConsts(TString inputFile,TString outputFile,Bool_t isFinal, Bool_t oneHistoAllBCs, Bool_t isPAR)
 {
   TFile *file =new TFile(inputFile.Data());
   if(file==0x0) {
@@ -1358,172 +1499,251 @@ void AliAnalysisTaskEMCALTimeCalib::ProduceCalibConsts(TString inputFile,TString
 
   if(numPARs == -1) isPAR = kFALSE;
 
-  //high gain
-  TH1F *h1[4];
-  TH1F *h2[4];
-  TH1F *h3[4];
-  TH1F *hAllTimeAvBC[4];
-  TH1F *hAllTimeRMSBC[4];
+  if(!oneHistoAllBCs){
+	  //high gain
+	  TH1F *h1[4];
+	  TH1F *h2[4];
+	  TH1F *h3[4];
+	  TH1F *hAllTimeAvBC[4];
+	  TH1F *hAllTimeRMSBC[4];
 
-  //low gain
-  TH1F *h4[4];
-  TH1F *h5[4];
-  TH1F *h6[4];
-  TH1F *hAllTimeAvLGBC[4];
-  TH1F *hAllTimeRMSLGBC[4];
+	  //low gain
+	  TH1F *h4[4];
+	  TH1F *h5[4];
+	  TH1F *h6[4];
+	  TH1F *hAllTimeAvLGBC[4];
+	  TH1F *hAllTimeRMSLGBC[4];
 
-  //PAR histos
-  TH1F *h1PAR[numPARs+1][4];
-  TH1F *h2PAR[numPARs+1][4];
-  //TH1F *h3PAR[numPARs+1][4];
-  TH1F *hAllTimeAvBCPAR[numPARs+1][4];
-  //TH1F *hAllTimeRMSBCPAR[numPARs+1][4];
+	  //PAR histos
+	  TH1F *h1PAR[numPARs+1][4];
+	  TH1F *h2PAR[numPARs+1][4];
+	  //TH1F *h3PAR[numPARs+1][4];
+	  TH1F *hAllTimeAvBCPAR[numPARs+1][4];
+	  //TH1F *hAllTimeRMSBCPAR[numPARs+1][4];
 
-  TH1F *h4PAR[numPARs+1][4];
-  TH1F *h5PAR[numPARs+1][4];
-  //TH1F *h6PAR[numPARs+1][4];
-  TH1F *hAllTimeAvLGBCPAR[numPARs+1][4];
-  //TH1F *hAllTimeRMSLGBCPAR[numPARs+1][4];
+	  TH1F *h4PAR[numPARs+1][4];
+	  TH1F *h5PAR[numPARs+1][4];
+	  //TH1F *h6PAR[numPARs+1][4];
+	  TH1F *hAllTimeAvLGBCPAR[numPARs+1][4];
+	  //TH1F *hAllTimeRMSLGBCPAR[numPARs+1][4];
 
-  TH2D* raw2D[4];
-  TH2D* rawLG2D[4];
+	  TH2D* raw2D[4];
+	  TH2D* rawLG2D[4];
 
-  if(isFinal==kFALSE){//first itereation
-    for(Int_t i=0;i<4;i++){
-      h1[i]=(TH1F *)list->FindObject(Form("RawTimeSumBC%d",i));
-      h2[i]=(TH1F *)list->FindObject(Form("RawTimeEntriesBC%d",i));
-      h3[i]=(TH1F *)list->FindObject(Form("RawTimeSumSqBC%d",i));
-      
-      h4[i]=(TH1F *)list->FindObject(Form("RawTimeSumLGBC%d",i));
-      h5[i]=(TH1F *)list->FindObject(Form("RawTimeEntriesLGBC%d",i));
-      h6[i]=(TH1F *)list->FindObject(Form("RawTimeSumSqLGBC%d",i));
-      
-      if(isPAR){ //set-up histograms for different PAR time regions
-        for(Int_t iPAR = 0; iPAR <= numPARs; iPAR++){
-          raw2D[i] = (TH2D*)list->FindObject(Form("RawTimeBeforePAR%dBC%d", iPAR+1, i));
-          rawLG2D[i] = (TH2D*)list->FindObject(Form("RawTimeLGBeforePAR%dBC%d", iPAR+1, i));
-          h1PAR[iPAR][i] = new TH1F(Form("hAllTimeSumPAR%dBC%d",iPAR, i), Form("hAlltimeSumPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
-          hAllTimeAvBCPAR[iPAR][i] = new TH1F(Form("hAllTimeAvPAR%dBC%d",iPAR, i), Form("hAlltimeAvPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
-          h2PAR[iPAR][i] = (TH1F*)raw2D[i]->ProjectionX(Form("hAllTimeEntriesPAR%dBC%d",iPAR, i), 0, raw2D[i]->GetYaxis()->GetNbins());
+	  if(isFinal==kFALSE){//first itereation
+	    for(Int_t i=0;i<4;i++){
+	      h1[i]=(TH1F *)list->FindObject(Form("RawTimeSumBC%d",i));
+	      h2[i]=(TH1F *)list->FindObject(Form("RawTimeEntriesBC%d",i));
+	      h3[i]=(TH1F *)list->FindObject(Form("RawTimeSumSqBC%d",i));
+	      
+	      h4[i]=(TH1F *)list->FindObject(Form("RawTimeSumLGBC%d",i));
+	      h5[i]=(TH1F *)list->FindObject(Form("RawTimeEntriesLGBC%d",i));
+	      h6[i]=(TH1F *)list->FindObject(Form("RawTimeSumSqLGBC%d",i));
+	      
+	      if(isPAR){ //set-up histograms for different PAR time regions
+		for(Int_t iPAR = 0; iPAR <= numPARs; iPAR++){
+		  raw2D[i] = (TH2D*)list->FindObject(Form("RawTimeBeforePAR%dBC%d", iPAR+1, i));
+		  rawLG2D[i] = (TH2D*)list->FindObject(Form("RawTimeLGBeforePAR%dBC%d", iPAR+1, i));
+		  h1PAR[iPAR][i] = new TH1F(Form("hAllTimeSumPAR%dBC%d",iPAR, i), Form("hAlltimeSumPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
+		  hAllTimeAvBCPAR[iPAR][i] = new TH1F(Form("hAllTimeAvPAR%dBC%d",iPAR, i), Form("hAlltimeAvPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
+		  h2PAR[iPAR][i] = (TH1F*)raw2D[i]->ProjectionX(Form("hAllTimeEntriesPAR%dBC%d",iPAR, i), 0, raw2D[i]->GetYaxis()->GetNbins());
 
-          h4PAR[iPAR][i] = new TH1F(Form("hAllTimeSumLGPAR%dBC%d",iPAR, i), Form("hAllTimeSumLGPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
-          hAllTimeAvLGBCPAR[iPAR][i] = new TH1F(Form("hAllTimeAvLGPAR%dBC%d",iPAR, i), Form("hAlltimeAvLGPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
-          h5PAR[iPAR][i] = (TH1F*)raw2D[i]->ProjectionX(Form("hAllTimeEntriesPAR%dLGBC%d",iPAR, i), 0, raw2D[i]->GetYaxis()->GetNbins());
-          for(int ixbin = 0; ixbin < raw2D[i]->GetXaxis()->GetNbins(); ixbin++){
-              float sumtime = 0.0;
-              float sumLGtime = 0.0;
-              for(int iybin = 0; iybin < raw2D[i]->GetYaxis()->GetNbins(); iybin++){
-                  sumtime += raw2D[i]->GetBinContent(ixbin, iybin)*raw2D[i]->GetYaxis()->GetBinCenter(iybin);
-                  sumLGtime += rawLG2D[i]->GetBinContent(ixbin, iybin)*rawLG2D[i]->GetYaxis()->GetBinCenter(iybin);
-              }
-              h1PAR[iPAR][i]->SetBinContent(ixbin, sumtime);
-              h4PAR[iPAR][i]->SetBinContent(ixbin, sumLGtime);
-              if(h2PAR[iPAR][i]->GetBinContent(ixbin) ==0){
-                  hAllTimeAvBCPAR[iPAR][i]->SetBinContent(ixbin, 0);
-              }else{
-                  hAllTimeAvBCPAR[iPAR][i]->SetBinContent(ixbin, h1PAR[iPAR][i]->GetBinContent(ixbin)/h2PAR[iPAR][i]->GetBinContent(ixbin));
-              }
+		  h4PAR[iPAR][i] = new TH1F(Form("hAllTimeSumLGPAR%dBC%d",iPAR, i), Form("hAllTimeSumLGPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
+		  hAllTimeAvLGBCPAR[iPAR][i] = new TH1F(Form("hAllTimeAvLGPAR%dBC%d",iPAR, i), Form("hAlltimeAvLGPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
+		  h5PAR[iPAR][i] = (TH1F*)raw2D[i]->ProjectionX(Form("hAllTimeEntriesPAR%dLGBC%d",iPAR, i), 0, raw2D[i]->GetYaxis()->GetNbins());
+		  for(int ixbin = 0; ixbin < raw2D[i]->GetXaxis()->GetNbins(); ixbin++){
+		      float sumtime = 0.0;
+		      float sumLGtime = 0.0;
+		      for(int iybin = 0; iybin < raw2D[i]->GetYaxis()->GetNbins(); iybin++){
+		          sumtime += raw2D[i]->GetBinContent(ixbin, iybin)*raw2D[i]->GetYaxis()->GetBinCenter(iybin);
+		          sumLGtime += rawLG2D[i]->GetBinContent(ixbin, iybin)*rawLG2D[i]->GetYaxis()->GetBinCenter(iybin);
+		      }
+		      h1PAR[iPAR][i]->SetBinContent(ixbin, sumtime);
+		      h4PAR[iPAR][i]->SetBinContent(ixbin, sumLGtime);
+		      if(h2PAR[iPAR][i]->GetBinContent(ixbin) ==0){
+		          hAllTimeAvBCPAR[iPAR][i]->SetBinContent(ixbin, 0);
+		      }else{
+		          hAllTimeAvBCPAR[iPAR][i]->SetBinContent(ixbin, h1PAR[iPAR][i]->GetBinContent(ixbin)/h2PAR[iPAR][i]->GetBinContent(ixbin));
+		      }
 
-              if(h5PAR[iPAR][i]->GetBinContent(ixbin) ==0){
-                  hAllTimeAvLGBCPAR[iPAR][i]->SetBinContent(ixbin, 0);
-              }else{
-                  hAllTimeAvLGBCPAR[iPAR][i]->SetBinContent(ixbin, h4PAR[iPAR][i]->GetBinContent(ixbin)/h5PAR[iPAR][i]->GetBinContent(ixbin));
-              }
-          }
+		      if(h5PAR[iPAR][i]->GetBinContent(ixbin) ==0){
+		          hAllTimeAvLGBCPAR[iPAR][i]->SetBinContent(ixbin, 0);
+		      }else{
+		          hAllTimeAvLGBCPAR[iPAR][i]->SetBinContent(ixbin, h4PAR[iPAR][i]->GetBinContent(ixbin)/h5PAR[iPAR][i]->GetBinContent(ixbin));
+		      }
+		  }
 
-        }
-      }
-    }
-  } else {//final iteration
-    for(Int_t i=0;i<4;i++){
-      h1[i]=(TH1F *)list->FindObject(Form("hTimeSum%d",i));
-      h2[i]=(TH1F *)list->FindObject(Form("hTimeEnt%d",i));
-      h3[i]=(TH1F *)list->FindObject(Form("hTimeSumSq%d",i));
-      
-      h4[i]=(TH1F *)list->FindObject(Form("hTimeLGSum%d",i));
-      h5[i]=(TH1F *)list->FindObject(Form("hTimeLGEnt%d",i));
-      h6[i]=(TH1F *)list->FindObject(Form("hTimeLGSumSq%d",i));
-    }
+		}
+	      }
+	    }
+	  } else {//final iteration
+	    for(Int_t i=0;i<4;i++){
+	      h1[i]=(TH1F *)list->FindObject(Form("hTimeSum%d",i));
+	      h2[i]=(TH1F *)list->FindObject(Form("hTimeEnt%d",i));
+	      h3[i]=(TH1F *)list->FindObject(Form("hTimeSumSq%d",i));
+	      
+	      h4[i]=(TH1F *)list->FindObject(Form("hTimeLGSum%d",i));
+	      h5[i]=(TH1F *)list->FindObject(Form("hTimeLGEnt%d",i));
+	      h6[i]=(TH1F *)list->FindObject(Form("hTimeLGSumSq%d",i));
+	    }
+	  }
+	  //AliWarning("Input histograms read.");
+
+	  for(Int_t i=0;i<4;i++){
+	    hAllTimeAvBC[i]=new TH1F(Form("hAllTimeAvBC%d",i),Form("hAllTimeAvBC%d",i),h1[i]->GetNbinsX(),h1[i]->GetXaxis()->GetXmin(),h1[i]->GetXaxis()->GetXmax());
+	    hAllTimeRMSBC[i]=new TH1F(Form("hAllTimeRMSBC%d",i),Form("hAllTimeRMSBC%d",i),h3[i]->GetNbinsX(),h3[i]->GetXaxis()->GetXmin(),h3[i]->GetXaxis()->GetXmax());
+
+	    hAllTimeAvLGBC[i]=new TH1F(Form("hAllTimeAvLGBC%d",i),Form("hAllTimeAvLGBC%d",i),h4[i]->GetNbinsX(),h4[i]->GetXaxis()->GetXmin(),h4[i]->GetXaxis()->GetXmax());
+	    hAllTimeRMSLGBC[i]=new TH1F(Form("hAllTimeRMSLGBC%d",i),Form("hAllTimeRMSLGBC%d",i),h6[i]->GetNbinsX(),h6[i]->GetXaxis()->GetXmin(),h6[i]->GetXaxis()->GetXmax());
+	  }
+	  
+	  //AliWarning("New histograms booked.");
+
+	  //important remark: we use 'underflow bin' for absid=0 in OADB  . That's why there is j-1 below.
+	  for(Int_t i=0;i<4;i++){
+	    for(Int_t j=1;j<=h1[i]->GetNbinsX();j++){
+	      //high gain
+	      if(h2[i]->GetBinContent(j)!=0){
+		hAllTimeAvBC[i]->SetBinContent(j-1,h1[i]->GetBinContent(j)/h2[i]->GetBinContent(j));
+		hAllTimeRMSBC[i]->SetBinContent(j-1,TMath::Sqrt(h3[i]->GetBinContent(j)/h2[i]->GetBinContent(j)) );
+	      } else {
+		hAllTimeAvBC[i]->SetBinContent(j-1,0.);
+		hAllTimeRMSBC[i]->SetBinContent(j-1,0.);
+	      }
+	      //low gain
+	      if(h5[i]->GetBinContent(j)!=0){
+		hAllTimeAvLGBC[i]->SetBinContent(j-1,h4[i]->GetBinContent(j)/h5[i]->GetBinContent(j));
+		hAllTimeRMSLGBC[i]->SetBinContent(j-1,TMath::Sqrt(h6[i]->GetBinContent(j)/h5[i]->GetBinContent(j)) );
+	      } else {
+		hAllTimeAvLGBC[i]->SetBinContent(j-1,0.);
+		hAllTimeRMSLGBC[i]->SetBinContent(j-1,0.);
+	      }
+
+	    }
+	  }
+
+	  //AliWarning("Average and rms calculated.");
+	  TFile *fileNew=new TFile(outputFile.Data(),"recreate");
+	  for(Int_t i=0;i<4;i++){
+	    if(isPAR){
+	      for(Int_t iPAR = 0; iPAR <= numPARs; iPAR++){
+		  hAllTimeAvBCPAR[iPAR][i]->Write();
+		  //hAllTimeRMSBCPAR[iPAR][i]->Write();
+		  hAllTimeAvLGBCPAR[iPAR][i]->Write();
+		  //hAllTimeRMSLGBCPAR[iPAR][i]->Write();
+	      }
+	    }else{
+	      hAllTimeAvBC[i]->Write();
+	      hAllTimeRMSBC[i]->Write();
+	      hAllTimeAvLGBC[i]->Write();
+	      hAllTimeRMSLGBC[i]->Write();
+	    }
+	  }
+
+	  //AliWarning(Form("Histograms saved in %s file.",outputFile.Data()));
+
+	  fileNew->Close();
+	  delete fileNew;
+
+	  for(Int_t i=0;i<4;i++){
+	    delete hAllTimeAvBC[i];
+	    delete hAllTimeRMSBC[i];
+	    delete hAllTimeAvLGBC[i];
+	    delete hAllTimeRMSLGBC[i];
+
+	    if(isPAR){ //set-up histograms for different PAR time regions
+	      for(Int_t iPAR = 0; iPAR <= numPARs; iPAR++){
+		delete h1PAR[iPAR][i];
+		delete hAllTimeAvBCPAR[iPAR][i];
+		delete h2PAR[iPAR][i];
+		delete h4PAR[iPAR][i];
+		delete hAllTimeAvLGBCPAR[iPAR][i];
+		delete h5PAR[iPAR][i];
+	      }
+	    }
+	  }
+	  list->SetOwner(1);
+	  delete list;
+	  file->Close();
+	  delete file;
+  }else{
+
+	  //high gain
+	  TH1F *h1;
+	  TH1F *h2;
+	  TH1F *h3;
+	  TH1S *hAllTimeAvBC;
+	  TH1S *hAllTimeRMSBC;
+
+	  //low gain
+	  TH1F *h4;
+	  TH1F *h5;
+	  TH1F *h6;
+	  TH1S *hAllTimeAvLGBC;
+	  TH1S *hAllTimeRMSLGBC;
+
+	  h1=(TH1F *)list->FindObject("hTimeSumAllBCs");
+	  h2=(TH1F *)list->FindObject("hTimeEntAllBCs");
+	  h3=(TH1F *)list->FindObject("hTimeSumSqAllBCs");
+	      
+	  h4=(TH1F *)list->FindObject("hTimeLGSumAllBCs");
+	  h5=(TH1F *)list->FindObject("hTimeLGEntAllBCs");
+	  h6=(TH1F *)list->FindObject("hTimeLGSumSqAllBCs");
+	  //AliWarning("Input histograms read.");
+
+	  hAllTimeAvBC=new TH1S("hAllTimeAv","hAllTimeAv",h1->GetNbinsX(),h1->GetXaxis()->GetXmin(),h1->GetXaxis()->GetXmax());
+	  hAllTimeRMSBC=new TH1S("hAllTimeRMS","hAllTimeRMS",h3->GetNbinsX(),h3->GetXaxis()->GetXmin(),h3->GetXaxis()->GetXmax());
+
+	  hAllTimeAvLGBC=new TH1S("hAllTimeAvLG","hAllTimeAvLG",h4->GetNbinsX(),h4->GetXaxis()->GetXmin(),h4->GetXaxis()->GetXmax());
+	  hAllTimeRMSLGBC=new TH1S("hAllTimeRMSLG","hAllTimeRMSLG",h6->GetNbinsX(),h6->GetXaxis()->GetXmin(),h6->GetXaxis()->GetXmax());
+	  
+	  //AliWarning("New histograms booked.");
+
+	  //important remark: we use 'underflow bin' for absid=0 in OADB  . That's why there is j-1 below.
+	  for(Int_t j=1;j<=h1->GetNbinsX();j++){
+	    //high gain
+	    if(h2->GetBinContent(j)!=0){
+		hAllTimeAvBC->SetBinContent(j-1,h1->GetBinContent(j)/h2->GetBinContent(j));
+		hAllTimeRMSBC->SetBinContent(j-1,TMath::Sqrt(h3->GetBinContent(j)/h2->GetBinContent(j)) );
+	    } else {
+		hAllTimeAvBC->SetBinContent(j-1,0.);
+		hAllTimeRMSBC->SetBinContent(j-1,0.);
+	    }
+	    //low gain
+	    if(h5->GetBinContent(j)!=0){
+		hAllTimeAvLGBC->SetBinContent(j-1,h4->GetBinContent(j)/h5->GetBinContent(j));
+		hAllTimeRMSLGBC->SetBinContent(j-1,TMath::Sqrt(h6->GetBinContent(j)/h5->GetBinContent(j)) );
+	    } else {
+		hAllTimeAvLGBC->SetBinContent(j-1,0.);
+		hAllTimeRMSLGBC->SetBinContent(j-1,0.);
+	    }
+
+	  }
+
+	  //AliWarning("Average and rms calculated.");
+	  TFile *fileNew=new TFile(outputFile.Data(),"recreate");
+
+	  hAllTimeAvBC->Write();
+	  hAllTimeRMSBC->Write();
+	  hAllTimeAvLGBC->Write();
+	  hAllTimeRMSLGBC->Write();
+
+	  //AliWarning(Form("Histograms saved in %s file.",outputFile.Data()));
+
+	  fileNew->Close();
+	  delete fileNew;
+
+	  delete hAllTimeAvBC;
+	  delete hAllTimeRMSBC;
+	  delete hAllTimeAvLGBC;
+	  delete hAllTimeRMSLGBC;
+
+	  list->SetOwner(1);
+	  delete list;
+	  file->Close();
+	  delete file;
+
   }
-  //AliWarning("Input histograms read.");
-
-  for(Int_t i=0;i<4;i++){
-    hAllTimeAvBC[i]=new TH1F(Form("hAllTimeAvBC%d",i),Form("hAllTimeAvBC%d",i),h1[i]->GetNbinsX(),h1[i]->GetXaxis()->GetXmin(),h1[i]->GetXaxis()->GetXmax());
-    hAllTimeRMSBC[i]=new TH1F(Form("hAllTimeRMSBC%d",i),Form("hAllTimeRMSBC%d",i),h3[i]->GetNbinsX(),h3[i]->GetXaxis()->GetXmin(),h3[i]->GetXaxis()->GetXmax());
-
-    hAllTimeAvLGBC[i]=new TH1F(Form("hAllTimeAvLGBC%d",i),Form("hAllTimeAvLGBC%d",i),h4[i]->GetNbinsX(),h4[i]->GetXaxis()->GetXmin(),h4[i]->GetXaxis()->GetXmax());
-    hAllTimeRMSLGBC[i]=new TH1F(Form("hAllTimeRMSLGBC%d",i),Form("hAllTimeRMSLGBC%d",i),h6[i]->GetNbinsX(),h6[i]->GetXaxis()->GetXmin(),h6[i]->GetXaxis()->GetXmax());
-  }
-  
-  //AliWarning("New histograms booked.");
-
-  //important remark: we use 'underflow bin' for absid=0 in OADB  . That's why there is j-1 below.
-  for(Int_t i=0;i<4;i++){
-    for(Int_t j=1;j<=h1[i]->GetNbinsX();j++){
-      //high gain
-      if(h2[i]->GetBinContent(j)!=0){
-	hAllTimeAvBC[i]->SetBinContent(j-1,h1[i]->GetBinContent(j)/h2[i]->GetBinContent(j));
-	hAllTimeRMSBC[i]->SetBinContent(j-1,TMath::Sqrt(h3[i]->GetBinContent(j)/h2[i]->GetBinContent(j)) );
-      } else {
-	hAllTimeAvBC[i]->SetBinContent(j-1,0.);
-	hAllTimeRMSBC[i]->SetBinContent(j-1,0.);
-      }
-      //low gain
-      if(h5[i]->GetBinContent(j)!=0){
-	hAllTimeAvLGBC[i]->SetBinContent(j-1,h4[i]->GetBinContent(j)/h5[i]->GetBinContent(j));
-	hAllTimeRMSLGBC[i]->SetBinContent(j-1,TMath::Sqrt(h6[i]->GetBinContent(j)/h5[i]->GetBinContent(j)) );
-      } else {
-	hAllTimeAvLGBC[i]->SetBinContent(j-1,0.);
-	hAllTimeRMSLGBC[i]->SetBinContent(j-1,0.);
-      }
-
-    }
-  }
-
-  //AliWarning("Average and rms calculated.");
-  TFile *fileNew=new TFile(outputFile.Data(),"recreate");
-  for(Int_t i=0;i<4;i++){
-    if(isPAR){
-      for(Int_t iPAR = 0; iPAR <= numPARs; iPAR++){
-          hAllTimeAvBCPAR[iPAR][i]->Write();
-          //hAllTimeRMSBCPAR[iPAR][i]->Write();
-          hAllTimeAvLGBCPAR[iPAR][i]->Write();
-          //hAllTimeRMSLGBCPAR[iPAR][i]->Write();
-      }
-    }else{
-      hAllTimeAvBC[i]->Write();
-      hAllTimeRMSBC[i]->Write();
-      hAllTimeAvLGBC[i]->Write();
-      hAllTimeRMSLGBC[i]->Write();
-    }
-  }
-
-  //AliWarning(Form("Histograms saved in %s file.",outputFile.Data()));
-
-  fileNew->Close();
-  delete fileNew;
-
-  for(Int_t i=0;i<4;i++){
-    delete hAllTimeAvBC[i];
-    delete hAllTimeRMSBC[i];
-    delete hAllTimeAvLGBC[i];
-    delete hAllTimeRMSLGBC[i];
-
-    if(isPAR){ //set-up histograms for different PAR time regions
-      for(Int_t iPAR = 0; iPAR <= numPARs; iPAR++){
-	delete h1PAR[iPAR][i];
-	delete hAllTimeAvBCPAR[iPAR][i];
-	delete h2PAR[iPAR][i];
-	delete h4PAR[iPAR][i];
-	delete hAllTimeAvLGBCPAR[iPAR][i];
-	delete h5PAR[iPAR][i];
-      }
-    }
-  }
-  list->SetOwner(1);
-  delete list;
-  file->Close();
-  delete file;
 
   //AliWarning("Pointers deleted. Memory cleaned.");
 }

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALTimeCalib.h
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALTimeCalib.h
@@ -1,5 +1,5 @@
-#ifndef AliAnalysisTaskEMCALTimeCalib_h
-#define AliAnalysisTaskEMCALTimeCalib_h
+#ifndef ALIANALYSISTASKEMCALTIMECALIB_H
+#define ALIANALYSISTASKEMCALTIMECALIB_H
 
 //_________________________________________________________________________
 /// \class AliAnalysisTaskEMCALTimeCalib
@@ -114,6 +114,7 @@ class AliAnalysisTaskEMCALTimeCalib : public AliAnalysisTaskSE
     fL1PhaseList(0),
     fBadReco(kFALSE),
     fFillHeavyHisto(kFALSE),
+    fOneHistAllBCs(kFALSE),
     fBadChannelMapArray(0),
     fBadChannelMapSet(kFALSE),
     fSetBadChannelMapSource(0),
@@ -132,11 +133,19 @@ class AliAnalysisTaskEMCALTimeCalib : public AliAnalysisTaskSE
     fhTimeSumSq(),
     fhTimeEnt(),
     fhTimeSum(),
+    fhTimeSumSqAllBCs(0x0),
+    fhTimeEntAllBCs(0x0),
+    fhTimeSumAllBCs(0x0),
     fhTimeLGSumSq(),
     fhTimeLGEnt(),
     fhTimeLGSum(),
+    fhTimeLGSumSqAllBCs(0x0),
+    fhTimeLGEntAllBCs(0x0),
+    fhTimeLGSumAllBCs(0x0),
     fhAllAverageBC(),
     fhAllAverageLGBC(),
+    fhAllAverageAllBCs(0x0),
+    fhAllAverageLGAllBCs(0x0),
     fhRefRuns(0),
     fhTimeDsup(),
     fhTimeDsupBC(),
@@ -155,7 +164,9 @@ class AliAnalysisTaskEMCALTimeCalib : public AliAnalysisTaskSE
     fhRawCorrTimeVsIdBC(),
     fhRawCorrTimeVsIdLGBC(),
     fhTimeVsIdBC(),
-    fhTimeVsIdLGBC()
+    fhTimeVsIdLGBC(),
+    fhTimeVsIdAllBCs(0x0),
+    fhTimeVsIdLGAllBCs(0x0)
     { ; }
   
   AliAnalysisTaskEMCALTimeCalib(const char *name);
@@ -277,8 +288,10 @@ class AliAnalysisTaskEMCALTimeCalib : public AliAnalysisTaskSE
     if(fBadChannelMapArray) return (Int_t) ((TH2I*)fBadChannelMapArray->At(0))->GetBinContent(absId+1);
     else return 0;}//Channel is ok by default
 
-  static void ProduceCalibConsts(TString inputFile="time186319testWOL0.root",TString outputFile="Reference.root",Bool_t isFinal=kFALSE, Bool_t isPAR=kFALSE);
+  static void ProduceCalibConsts(TString inputFile="time186319testWOL0.root",TString outputFile="Reference.root",Bool_t isFinal=kFALSE, Bool_t oneHistoAllBCs=kFALSE, Bool_t isPAR=kFALSE);
   static void ProduceOffsetForSMsV2(Int_t runNumber,TString inputFile="Reference.root",TString outputFile="ReferenceSM.root",Bool_t offset100=kTRUE, Bool_t justL1phase=kTRUE,TString PARfilename="");
+
+  void SwithOnFillOneHistAllBCs()  { fOneHistAllBCs = kTRUE ; }
 
   private:
   
@@ -358,6 +371,8 @@ class AliAnalysisTaskEMCALTimeCalib : public AliAnalysisTaskSE
 
   Bool_t         fFillHeavyHisto;       ///< flag to fill heavy histograms
 
+  Bool_t	 fOneHistAllBCs;		///< flag to use one histogram for all the BCs instead of four
+
   // bad channel map
   TObjArray     *fBadChannelMapArray;   ///< bad channel map array
   Bool_t         fBadChannelMapSet;     ///< flag whether bad channel map is set
@@ -381,13 +396,22 @@ class AliAnalysisTaskEMCALTimeCalib : public AliAnalysisTaskSE
   TH1F		*fhTimeSumSq  [kNBCmask]; //!<!  4
   TH1F		*fhTimeEnt    [kNBCmask]; //!<!  4
   TH1F		*fhTimeSum    [kNBCmask]; //!<!  4
+  TH1F		*fhTimeSumSqAllBCs  	; //!
+  TH1F		*fhTimeEntAllBCs    	; //!
+  TH1F		*fhTimeSumAllBCs    	; //!
   TH1F		*fhTimeLGSumSq[kNBCmask]; //!<!  4
   TH1F		*fhTimeLGEnt  [kNBCmask]; //!<!  4
   TH1F		*fhTimeLGSum  [kNBCmask]; //!<!  4
+  TH1F		*fhTimeLGSumSqAllBCs  	; //!
+  TH1F		*fhTimeLGEntAllBCs    	; //!
+  TH1F		*fhTimeLGSumAllBCs    	; //!
 
   // histos with reference values after the first iteration  
   TH1F		*fhAllAverageBC   [kNBCmask]; ///> 4 BCmask High gain
   TH1F		*fhAllAverageLGBC [kNBCmask]; ///> 4 BCmask Low gain
+
+  TH1S		*fhAllAverageAllBCs	; ///> High gain
+  TH1S		*fhAllAverageLGAllBCs   ; ///> Low gain
 
   // histo with reference values run-by-run after the first iteration 
   TH1C		*fhRefRuns; ///< 20 entries per run: nSM
@@ -419,6 +443,8 @@ class AliAnalysisTaskEMCALTimeCalib : public AliAnalysisTaskSE
   //histos for raw time after wrong reconstruction correction (100ns and L1 phase) and new L1 phase
   TH2F          *fhTimeVsIdBC  [kNBCmask]; //!<! 4 BCmask HG
   TH2F          *fhTimeVsIdLGBC[kNBCmask]; //!<! 4 BCmask LG
+  TH2F          *fhTimeVsIdAllBCs        ; //! HG
+  TH2F          *fhTimeVsIdLGAllBCs      ; //! LG
 
   /// Copy constructor not implemented.
   AliAnalysisTaskEMCALTimeCalib(           const AliAnalysisTaskEMCALTimeCalib&);
@@ -427,7 +453,7 @@ class AliAnalysisTaskEMCALTimeCalib : public AliAnalysisTaskSE
   AliAnalysisTaskEMCALTimeCalib& operator=(const AliAnalysisTaskEMCALTimeCalib&); 
   
 /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskEMCALTimeCalib, 5) ;
+  ClassDef(AliAnalysisTaskEMCALTimeCalib, 7) ;
 /// \endcond
 };
 

--- a/PWGPP/EMCAL/macros/AddTaskEMCALTimeCalibration.C
+++ b/PWGPP/EMCAL/macros/AddTaskEMCALTimeCalibration.C
@@ -50,6 +50,7 @@ AliAnalysisTaskEMCALTimeCalib* AddTaskEMCALTimeCalibration(TString  outputFile =
 							     Bool_t   fillHeavyHistos = kTRUE,
 							     Int_t    badMapType = 1,
 							     TString  badMapFileName = "",
+							     Bool_t   fillOneHistAllBCs=kFALSE,
                                  Bool_t mostEneCellOnly = kFALSE,
                                  TString  PARFileName = "")
 {
@@ -85,6 +86,8 @@ AliAnalysisTaskEMCALTimeCalib* AddTaskEMCALTimeCalibration(TString  outputFile =
   taskmbemcal->SetMinCellEnergy    (minCellEne);	   
   taskmbemcal->SetMinTime          (minTime);	   
   taskmbemcal->SetMaxTime          (maxTime);
+
+  if(fillOneHistAllBCs) taskmbemcal->SwithOnFillOneHistAllBCs();
 
   if(fillHeavyHistos) taskmbemcal->SwithOnFillHeavyHisto();
   else taskmbemcal->SwithOffFillHeavyHisto();

--- a/TENDER/TenderSupplies/AliEMCALTenderSupply.cxx
+++ b/TENDER/TenderSupplies/AliEMCALTenderSupply.cxx
@@ -102,6 +102,7 @@ AliEMCALTenderSupply::AliEMCALTenderSupply() :
   ,fExoticCellFraction(-1)
   ,fExoticCellDiffTime(-1)
   ,fExoticCellMinAmplitude(-1)
+  ,fDoMergedBCs(kFALSE)
   ,fSetCellMCLabelFromCluster(0)
   ,fSetCellMCLabelFromEdepFrac(0)
   ,fTempClusterArr(0)
@@ -176,6 +177,7 @@ AliEMCALTenderSupply::AliEMCALTenderSupply(const char *name, const AliTender *te
   ,fExoticCellFraction(-1)
   ,fExoticCellDiffTime(-1)
   ,fExoticCellMinAmplitude(-1)
+  ,fDoMergedBCs(kFALSE)
   ,fSetCellMCLabelFromCluster(0)
   ,fSetCellMCLabelFromEdepFrac(0)
   ,fTempClusterArr(0)
@@ -250,6 +252,7 @@ AliEMCALTenderSupply::AliEMCALTenderSupply(const char *name, AliAnalysisTaskSE *
   ,fExoticCellFraction(-1)
   ,fExoticCellDiffTime(-1)
   ,fExoticCellMinAmplitude(-1)
+  ,fDoMergedBCs(kFALSE)
   ,fSetCellMCLabelFromCluster(0)
   ,fSetCellMCLabelFromEdepFrac(0)
   ,fTempClusterArr(0)
@@ -427,6 +430,10 @@ void AliEMCALTenderSupply::Init()
   if (fEMCALGeoName.Length()>0) 
     fEMCALGeo = AliEMCALGeometry::GetInstance(fEMCALGeoName) ;
 
+  // Use one histogram for all BCs
+  if (fDoMergedBCs)
+    fEMCALRecoUtils->SetUseOneHistForAllBCs(fDoMergedBCs);
+	
   // digits array
   fDigitsArr       = new TClonesArray("AliEMCALDigit",1000);
 
@@ -1511,29 +1518,45 @@ Int_t AliEMCALTenderSupply::InitTimeCalibration()
 
   if (fDebugLevel>0) arrayBCpass->Print();
 
-  for(Int_t i = 0; i < 4; i++)
-  {
-    TH1F *h = fEMCALRecoUtils->GetEMCALChannelTimeRecalibrationFactors(i);
+  if(!fDoMergedBCs){
+    for(Int_t i = 0; i < 4; i++)
+    {
+      TH1F *h = (TH1F*)fEMCALRecoUtils->GetEMCALChannelTimeRecalibrationFactors(i);
+      if (h)
+        delete h;
+    
+      h = (TH1F*)arrayBCpass->FindObject(Form("hAllTimeAvBC%d",i));
+
+      if (!h)
+      {
+        AliError(Form("Can not get hAllTimeAvBC%d",i));
+        continue;
+      }
+   
+      // Shift parameters for bc0 and bc1 in this pass
+      if ( fFilepass=="spc_calo" && (i==0 || i==1) ) 
+      {
+        for(Int_t icell = 0; icell < h->GetNbinsX(); icell++) 
+          h->SetBinContent(icell,h->GetBinContent(icell)-100);
+      }
+    
+      h->SetDirectory(0);
+      fEMCALRecoUtils->SetEMCALChannelTimeRecalibrationFactors(i,h);
+    }
+  }else{
+
+    TH1S *h = (TH1S*)fEMCALRecoUtils->GetEMCALChannelTimeRecalibrationFactors(0);
     if (h)
       delete h;
     
-    h = (TH1F*)arrayBCpass->FindObject(Form("hAllTimeAvBC%d",i));
+    h = (TH1S*)arrayBCpass->FindObject("hAllTimeAv"); //only HG cells
 
     if (!h)
-    {
-      AliError(Form("Can not get hAllTimeAvBC%d",i));
-      continue;
-    }
-   
-    // Shift parameters for bc0 and bc1 in this pass
-    if ( fFilepass=="spc_calo" && (i==0 || i==1) ) 
-    {
-      for(Int_t icell = 0; icell < h->GetNbinsX(); icell++) 
-        h->SetBinContent(icell,h->GetBinContent(icell)-100);
-    }
+      AliError("Can not get hAllTimeAv");
     
     h->SetDirectory(0);
-    fEMCALRecoUtils->SetEMCALChannelTimeRecalibrationFactors(i,h);
+    fEMCALRecoUtils->SetEMCALChannelTimeRecalibrationFactors(0,h);
+
   }
   
   delete contBC;

--- a/TENDER/TenderSupplies/AliEMCALTenderSupply.h
+++ b/TENDER/TenderSupplies/AliEMCALTenderSupply.h
@@ -200,6 +200,7 @@ public:
   void     SwitchOffUseAutomaticRecParam()                 { fUseAutomaticRecParam      = kFALSE ; }
 
   void     SwitchUseNewRunDepTempCalib(Bool_t doUseTC)     { fUseNewRunDepTempCalib     = doUseTC; }
+  void     SwitchUseMergedBCs(Bool_t doUseMergedBC)     { fDoMergedBCs     = doUseMergedBC; }
 
 private:
 
@@ -278,6 +279,7 @@ private:
   Float_t                fExoticCellFraction;     // good cell if fraction < 1-ecross/ecell
   Float_t                fExoticCellDiffTime;     // if time of candidate to exotic and close cell is too different (in ns), it must be noisy, set amp to 0
   Float_t                fExoticCellMinAmplitude; // check for exotic only if amplitud is larger than this value
+  Bool_t		 fDoMergedBCs;		  // flag whether to load four histos for the time calib or one merged histo
 
   // MC labels
   static const Int_t     fgkTotalCellNumber = 17664 ; // Maximum number of cells in EMCAL/DCAL: (48*24)*(10+4/3.+6*2/3.)
@@ -305,6 +307,6 @@ private:
   AliEMCALTenderSupply(            const AliEMCALTenderSupply&c);
   AliEMCALTenderSupply& operator= (const AliEMCALTenderSupply&c);
   
-  ClassDef(AliEMCALTenderSupply, 22); // EMCAL tender task
+  ClassDef(AliEMCALTenderSupply, 23); // EMCAL tender task
 };
 #endif


### PR DESCRIPTION
The correction framework was modified by adding a switch whether someone want to use one histogram for the time calibration instead of four for all the BCs. Also in case it is one histogram, this histogram will be TH1S and not TH1F.