### PR TITLE
In tree maker, added option to reject events from writing based on ti…

### DIFF
--- a/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
+++ b/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
@@ -161,7 +161,8 @@ AliAnalysisTaskReducedTreeMaker::AliAnalysisTaskReducedTreeMaker() :
   fNevents(0),
   fReducedEvent(0x0),
   fUsedVars(0x0),
-  fTimeRangeCut()
+  fTimeRangeCut(),
+  fTimeRangeReject(kFALSE)
 {
   //
   // Constructor
@@ -237,7 +238,8 @@ AliAnalysisTaskReducedTreeMaker::AliAnalysisTaskReducedTreeMaker(const char *nam
   fNevents(0),
   fReducedEvent(0x0),
   fUsedVars(0x0),
-  fTimeRangeCut()
+  fTimeRangeCut(),
+  fTimeRangeReject(kFALSE)
 {
   //
   // Constructor
@@ -253,13 +255,7 @@ AliAnalysisTaskReducedTreeMaker::AliAnalysisTaskReducedTreeMaker(const char *nam
   DefineOutput(1, AliReducedBaseEvent::Class());   // reduced information tree
   if(writeTree) {
     DefineOutput(2, TTree::Class());  // reduced information tree
-		DefineOutput(3, TList::Class());  // Tlist of event statistics information
-
-//    DefineOutput(3, TH2I::Class());   // event statistics information
-//    DefineOutput(4, TH2I::Class());   // track statistics information
-//    DefineOutput(5, TH2I::Class());   // MC signals statistics information
-//    DefineOutput(6, TH2I::Class());   // TRD event statistics information
-//	 	  DefineOutput(7, TList::Class());  // Cent event statistics information
+    DefineOutput(3, TList::Class());  // Tlist of event statistics information
   }
 }
 
@@ -390,18 +386,19 @@ void AliAnalysisTaskReducedTreeMaker::UserCreateOutputObjects()
 	fEventsList->SetOwner();
 
   // event statistics histogram
-  fEventsHistogram = new TH2I("EventStatistics", "Event statistics", 14, -0.5,13.5,34,-2.5,31.5);
+  fEventsHistogram = new TH2I("EventStatistics", "Event statistics", 16, -0.5,15.5,34,-2.5,31.5);
   const Char_t* offlineTriggerNames[34] = {"Total", "No Phys Sel", "MB/INT1", "INT7", "MUON", "HighMult/HighMultSPD", "EMC1", "CINT5/INT5", "CMUS5/MUSPB/INT7inMUON",
      "MuonSingleHighPt7/MUSH7/MUSHPB", "MuonLikeLowPt7/MUL7/MuonLikePB", "MuonUnlikeLowPt7/MUU7/MuonUnlikePB", "EMC7/EMC8", 
      "MUS7/MuonSingleLowPt7", "PHI1", "PHI7/PHI8/PHOSPb", "EMCEJE", "EMCEGA", "Central/HighMultV0", "SemiCentral", "DG/DG5", "ZED", 
      "SPI7/SPI", "INT8", "MuonSingleLowPt8", "MuonSingleHighPt8", "MuonLikeLowPt8", "MuonUnlikeLowPt8", "MuonUnlikeLowPt0/INT6", "UserDefined", 
      "TRD", "MuonCalo/CaloOnly", "FastOnly", "N/A"
   };  
-  const Char_t* selectionNames[14] = {"All events", 
-     "Physics Selection events (PS)", "Rejected due to PS",
+  const Char_t* selectionNames[16] = {"All events", 
+     "TR and Physics Selection events (PS)", "Rejected due to PS",
      "PS and Trigger Selected (TS)", "Rejected due to TS",
      "TS and Pileup Checked (PC)", "Rejected due to PC",
      "PC and Event cuts Checked (EC)", "Rejected due to EC",
+     "EC and Time Range accepted events (TR)", "Rejected due to TR",
      Form("Written ev. (>=%d tracks, >=%d base tracks)", fMinSelectedTracks, fMinSelectedBaseTracks), 
      Form("Written ev. (<%d tracks, >=%d base tracks)", fMinSelectedTracks, fMinSelectedBaseTracks), 
      Form("Written ev. (<%d tracks, <%d base tracks)", fMinSelectedTracks, fMinSelectedBaseTracks),
@@ -409,15 +406,15 @@ void AliAnalysisTaskReducedTreeMaker::UserCreateOutputObjects()
      Form("Not written (<%d tracks and <%d base tracks)", fMinSelectedTracks, fMinSelectedBaseTracks)};
   for(Int_t i=1;i<=34;++i)
      fEventsHistogram->GetYaxis()->SetBinLabel(i, offlineTriggerNames[i-1]);
-  for(Int_t i=1;i<=14;++i)
+  for(Int_t i=1;i<=16;++i)
      fEventsHistogram->GetXaxis()->SetBinLabel(i, selectionNames[i-1]);
 	fEventsList->Add(fEventsHistogram);
 
   // TRD event statistics histogram
   const Char_t* offlineTRDTriggerNames[7] = {"Total", "No Phys Sel", "HQUorHSE", "HQU", "HSE", "Nuclei", "Jet"};
-  fTRDEventsHistogram = new TH2I("TRDEventStatistics", "TRD Event statistics", 14, -0.5,13.5,12,-2.5,9.5);
+  fTRDEventsHistogram = new TH2I("TRDEventStatistics", "TRD Event statistics", 16, -0.5,15.5,12,-2.5,9.5);
   for(Int_t i=1;i<=7;++i)  fTRDEventsHistogram->GetYaxis()->SetBinLabel(i, offlineTRDTriggerNames[i-1]);
-  for(Int_t i=1;i<=14;++i) fTRDEventsHistogram->GetXaxis()->SetBinLabel(i, selectionNames[i-1]);
+  for(Int_t i=1;i<=16;++i) fTRDEventsHistogram->GetXaxis()->SetBinLabel(i, selectionNames[i-1]);
 	fEventsList->Add(fTRDEventsHistogram);
 
   // EMCal event statistics histogram
@@ -425,9 +422,9 @@ void AliAnalysisTaskReducedTreeMaker::UserCreateOutputObjects()
     "EMC7orDMC7", "EMC7", "DMC7", "EMC1orDMC1", "EMC1", "DMC1",
     "EMCEGA", "EG1/DG1", "EG2/DG2", "EG1", "EG2", "DG1", "DG2",
     "EMCEJE", "EJ1/DJ1", "EJ2/DJ2", "EJ1", "EJ2", "DJ1", "DJ2"};
-  fEMCalEventsHistogram = new TH2I("EMCalEventStatistics", "EMCal Event statistics", 14,-0.5,13.5, 22,-2.5,19.5);
+  fEMCalEventsHistogram = new TH2I("EMCalEventStatistics", "EMCal Event statistics", 16,-0.5,15.5, 22,-2.5,19.5);
   for(Int_t i=1;i<=22;++i) fEMCalEventsHistogram->GetYaxis()->SetBinLabel(i, offlineEMCalTriggerNames[i-1]);
-  for(Int_t i=1;i<=14;++i) fEMCalEventsHistogram->GetXaxis()->SetBinLabel(i, selectionNames[i-1]);
+  for(Int_t i=1;i<=16;++i) fEMCalEventsHistogram->GetXaxis()->SetBinLabel(i, selectionNames[i-1]);
   fEventsList->Add(fEMCalEventsHistogram);
 
 	// Event Centrality statistics List of histograms (for the provided trigger mask)
@@ -438,8 +435,8 @@ void AliAnalysisTaskReducedTreeMaker::UserCreateOutputObjects()
 	const Char_t* estimatorNames[nCentEstimators] = {"V0M", "ZNA", "CL1"};
 	TH2I *centEventsHistogram[nCentEstimators];
 	for (Int_t i=0; i<nCentEstimators; ++i) {
-		centEventsHistogram[i] = new TH2I(estimatorNames[i], Form("%s estimator",estimatorNames[i]), 14, -0.5,13.5,120,-5.,115.);
-		for(Int_t xi=1;xi<=14;++xi) centEventsHistogram[i]->GetXaxis()->SetBinLabel(xi, selectionNames[xi-1]);
+		centEventsHistogram[i] = new TH2I(estimatorNames[i], Form("%s estimator",estimatorNames[i]), 16, -0.5,15.5,120,-5.,115.);
+		for(Int_t xi=1;xi<=16;++xi) centEventsHistogram[i]->GetXaxis()->SetBinLabel(xi, selectionNames[xi-1]);
 		fCentEventsList->Add(centEventsHistogram[i]);
 	}
 	fEventsList->Add(fCentEventsList);
@@ -501,7 +498,7 @@ void AliAnalysisTaskReducedTreeMaker::UserExec(Option_t *option)
   } else {
     AliFatal("This task needs the PID response attached to the input event handler!");
   }
-
+  
   // Was event selected ?
   UInt_t isPhysSel = AliVEvent::kAny;
   UInt_t isPhysAndTrigSel = AliVEvent::kAny;
@@ -547,18 +544,19 @@ void AliAnalysisTaskReducedTreeMaker::UserExec(Option_t *option)
     }
   }
 
-	// Get centrality object
-	const Int_t nCentEstimators = 3;
-	const Char_t* estimatorNames[nCentEstimators] = {"V0M", "ZNA", "CL1"};
-	AliVEvent* event = InputEvent();
-	AliCentrality *centrality = 0x0;
-	AliMultSelection* multSelection = 0x0;
-	Bool_t isOldCent = kFALSE;
-	if(event->GetRunNumber()<200000) isOldCent = kTRUE;
-	if(isOldCent) centrality = event->GetCentrality(); // old centrality framework
-	else multSelection = (AliMultSelection*)event->FindListObject("MultSelection"); // new centrality framework
-	if (!centrality && !multSelection) AliInfo("No centrality object found");
-
+  // Get centrality object
+  const Int_t nCentEstimators = 3;
+  const Char_t* estimatorNames[nCentEstimators] = {"V0M", "ZNA", "CL1"};
+  AliVEvent* event = InputEvent();
+  AliCentrality *centrality = 0x0;
+  AliMultSelection* multSelection = 0x0;
+  Bool_t isOldCent = kFALSE;
+  if(event->GetRunNumber()<200000) isOldCent = kTRUE;
+  if(isOldCent) centrality = event->GetCentrality(); // old centrality framework
+  else multSelection = (AliMultSelection*)event->FindListObject("MultSelection"); // new centrality framework
+  if (!centrality && !multSelection) AliInfo("No centrality object found");
+  
+        
   // event statistics before any selection
   if(isPhysSel) {
     for(Int_t i=0;i<32;++i) 
@@ -735,6 +733,63 @@ void AliAnalysisTaskReducedTreeMaker::UserExec(Option_t *option)
 			((TH2I*)fCentEventsList->At(i))->Fill(7.,isOldCent?centrality->GetCentralityPercentile(Form("%s",estimatorNames[i])):multSelection->GetMultiplicityPercentile(Form("%s",estimatorNames[i])));
   }
   
+  // Apply the time range cut needed to reject events with bad TPC pid in some chambers
+  // For details see: https://indico.cern.ch/event/830757/contributions/3479738/attachments/1873483/3083952/IArsene_DPG_2019July3.pdf
+  fTimeRangeCut.InitFromEvent(InputEvent());
+  if(fTimeRangeCut.CutEvent(InputEvent())) {
+     if(fTimeRangeReject) {
+        // if rejecting the bad events from writing, fill the appropriate event stats bins and return 
+        if(isPhysSel) {
+           for(Int_t i=0;i<32;++i) 
+              if(isPhysSel & (UInt_t(1)<<i)) 
+                 fEventsHistogram->Fill(10.,Double_t(i));
+           for(Int_t i=0;i<5;++i)
+              if(trdtrgtype[i]!=0) 
+                 fTRDEventsHistogram->Fill(10.,i);
+           for(Int_t i=0;i<20;++i)
+              if(emcaltrgtype[i]!=0) 
+                 fEMCalEventsHistogram->Fill(10.,i);
+        }
+        else {
+           fEventsHistogram->Fill(10.,-1.);   
+           fTRDEventsHistogram->Fill(10.,-1.);
+           fEMCalEventsHistogram->Fill(10.,-1.);
+        }
+        fEventsHistogram->Fill(10.,-2.);   
+        fTRDEventsHistogram->Fill(10.,-2.);
+        fEMCalEventsHistogram->Fill(10.,-2.);
+        
+        for(Int_t i=0;i<nCentEstimators;++i)
+           ((TH2I*)fCentEventsList->At(i))->Fill(10., isOldCent ? centrality->GetCentralityPercentile(Form("%s",estimatorNames[i])) : multSelection->GetMultiplicityPercentile(Form("%s",estimatorNames[i])));
+        
+        PostData(3, fEventsList);
+        return;
+     }
+     fReducedEvent->fEventTag |= (ULong64_t(1)<<15);
+  }
+  // fill the event statistics for events passing the Time Range cut
+  if(isPhysSel) {
+     for(Int_t i=0;i<32;++i) 
+        if(isPhysSel & (UInt_t(1)<<i)) 
+           fEventsHistogram->Fill(9.,Double_t(i));
+     for(Int_t i=0;i<5;++i)
+        if(trdtrgtype[i]!=0) 
+           fTRDEventsHistogram->Fill(9.,i);
+     for(Int_t i=0;i<20;++i)
+        if(emcaltrgtype[i]!=0) 
+           fEMCalEventsHistogram->Fill(9.,i);
+  }
+  else {
+     fEventsHistogram->Fill(9.,-1.);   
+     fTRDEventsHistogram->Fill(9.,-1.);
+     fEMCalEventsHistogram->Fill(9.,-1.);
+  }
+  fEventsHistogram->Fill(9.,-2.);   
+  fTRDEventsHistogram->Fill(9.,-2.);
+  fEMCalEventsHistogram->Fill(9.,-2.);
+  for(Int_t i=0;i<nCentEstimators;++i)
+     ((TH2I*)fCentEventsList->At(i))->Fill(9., isOldCent ? centrality->GetCentralityPercentile(Form("%s",estimatorNames[i])) : multSelection->GetMultiplicityPercentile(Form("%s",estimatorNames[i])));
+  
   if(fFillMCInfo) {
      Bool_t hasMC=AliDielectronMC::Instance()->HasMC();
      if(hasMC) {
@@ -750,7 +805,7 @@ void AliAnalysisTaskReducedTreeMaker::UserExec(Option_t *option)
   AliKFParticle::SetField( bz );
   
   //Fill event wise information
-  fReducedEvent->ClearEvent();
+  fReducedEvent->ClearEvent();  
   FillEventInfo();
 
   // NOTE: It is important that FillV0PairInfo() is called before FillTrackInfo()
@@ -769,9 +824,9 @@ void AliAnalysisTaskReducedTreeMaker::UserExec(Option_t *option)
       writeEvent = kTRUE;
       fReducedEvent->fEventTag |= (ULong64_t(1)<<14);                    // mark unbiased events
        
-      Int_t binToFill = 11;
-      if(nTracks>=fMinSelectedTracks && nTracks2>=fMinSelectedBaseTracks) binToFill = 9;
-      if(nTracks<fMinSelectedTracks && nTracks2>=fMinSelectedBaseTracks) binToFill = 10;
+      Int_t binToFill = 13;
+      if(nTracks>=fMinSelectedTracks && nTracks2>=fMinSelectedBaseTracks) binToFill = 11;
+      if(nTracks<fMinSelectedTracks && nTracks2>=fMinSelectedBaseTracks) binToFill = 12;
        
       if(isPhysSel) {
         for(Int_t i=0;i<32;++i)
@@ -798,61 +853,61 @@ void AliAnalysisTaskReducedTreeMaker::UserExec(Option_t *option)
       writeEvent = kTRUE;
       if(isPhysSel) {
         for(Int_t i=0;i<32;++i)
-          if(isPhysSel & (UInt_t(1)<<i)) fEventsHistogram->Fill(9.,Double_t(i));
+          if(isPhysSel & (UInt_t(1)<<i)) fEventsHistogram->Fill(11.,Double_t(i));
         for(Int_t i=0;i<5;++i)
-          if(trdtrgtype[i]!=0) fTRDEventsHistogram->Fill(9.,i);
+          if(trdtrgtype[i]!=0) fTRDEventsHistogram->Fill(11.,i);
         for(Int_t i=0;i<20;++i)
-          if(emcaltrgtype[i]!=0) fEMCalEventsHistogram->Fill(9.,i);
+          if(emcaltrgtype[i]!=0) fEMCalEventsHistogram->Fill(11.,i);
       } else{
-        fEventsHistogram->Fill(9., -1.);
-        fTRDEventsHistogram->Fill(9., -1.);
-        fEMCalEventsHistogram->Fill(9., -1.);
+        fEventsHistogram->Fill(11., -1.);
+        fTRDEventsHistogram->Fill(11., -1.);
+        fEMCalEventsHistogram->Fill(11., -1.);
       }
-      fEventsHistogram->Fill(9.,-2.);
-      fTRDEventsHistogram->Fill(9.,-2.);
-      fEMCalEventsHistogram->Fill(9.,-2.);
+      fEventsHistogram->Fill(11.,-2.);
+      fTRDEventsHistogram->Fill(11.,-2.);
+      fEMCalEventsHistogram->Fill(11.,-2.);
       for (Int_t i=0;i<nCentEstimators;++i)
-        ((TH2I*)fCentEventsList->At(i))->Fill(9.,isOldCent?centrality->GetCentralityPercentile(Form("%s",estimatorNames[i])):multSelection->GetMultiplicityPercentile(Form("%s",estimatorNames[i])));
+        ((TH2I*)fCentEventsList->At(i))->Fill(11.,isOldCent?centrality->GetCentralityPercentile(Form("%s",estimatorNames[i])):multSelection->GetMultiplicityPercentile(Form("%s",estimatorNames[i])));
     }
     
     // count the events not to be written
     if(!writeEvent && nTracks<fMinSelectedTracks && nTracks2>=fMinSelectedBaseTracks) {
       if(isPhysSel) {
         for(Int_t i=0;i<32;++i)
-          if(isPhysSel & (UInt_t(1)<<i)) fEventsHistogram->Fill(12.,Double_t(i));
+          if(isPhysSel & (UInt_t(1)<<i)) fEventsHistogram->Fill(14.,Double_t(i));
         for(Int_t i=0;i<5;++i)
-          if(trdtrgtype[i]!=0) fTRDEventsHistogram->Fill(12.,i);
+          if(trdtrgtype[i]!=0) fTRDEventsHistogram->Fill(14.,i);
         for(Int_t i=0;i<20;++i)
-          if(emcaltrgtype[i]!=0) fEMCalEventsHistogram->Fill(12.,i);
+          if(emcaltrgtype[i]!=0) fEMCalEventsHistogram->Fill(14.,i);
       } else{
-        fEventsHistogram->Fill(12., -1.);
-        fTRDEventsHistogram->Fill(12., -1.);
-        fEMCalEventsHistogram->Fill(12., -1.);
+        fEventsHistogram->Fill(14., -1.);
+        fTRDEventsHistogram->Fill(14., -1.);
+        fEMCalEventsHistogram->Fill(14., -1.);
       }
-      fEventsHistogram->Fill(12.,-2.);
-      fTRDEventsHistogram->Fill(12.,-2.);
-      fEMCalEventsHistogram->Fill(12.,-2.);
-			for (Int_t i=0;i<nCentEstimators;++i)
-				((TH2I*)fCentEventsList->At(i))->Fill(12.,isOldCent?centrality->GetCentralityPercentile(Form("%s",estimatorNames[i])):multSelection->GetMultiplicityPercentile(Form("%s",estimatorNames[i])));
+      fEventsHistogram->Fill(14.,-2.);
+      fTRDEventsHistogram->Fill(14.,-2.);
+      fEMCalEventsHistogram->Fill(14.,-2.);
+         for (Int_t i=0;i<nCentEstimators;++i)
+	    ((TH2I*)fCentEventsList->At(i))->Fill(14.,isOldCent?centrality->GetCentralityPercentile(Form("%s",estimatorNames[i])):multSelection->GetMultiplicityPercentile(Form("%s",estimatorNames[i])));
     }
     if(!writeEvent && nTracks<fMinSelectedTracks && nTracks2<fMinSelectedBaseTracks) {
       if(isPhysSel) {
         for(Int_t i=0;i<32;++i)
-          if(isPhysSel & (UInt_t(1)<<i)) fEventsHistogram->Fill(13.,Double_t(i));
+          if(isPhysSel & (UInt_t(1)<<i)) fEventsHistogram->Fill(15.,Double_t(i));
         for(Int_t i=0;i<5;++i)
-          if(trdtrgtype[i]!=0) fTRDEventsHistogram->Fill(13.,i);
+          if(trdtrgtype[i]!=0) fTRDEventsHistogram->Fill(15.,i);
         for(Int_t i=0;i<20;++i)
-          if(emcaltrgtype[i]!=0) fEMCalEventsHistogram->Fill(13.,i);
+          if(emcaltrgtype[i]!=0) fEMCalEventsHistogram->Fill(15.,i);
       } else{
-        fEventsHistogram->Fill(13., -1.);
-        fTRDEventsHistogram->Fill(13., -1.);
-        fEMCalEventsHistogram->Fill(13., -1.);
+        fEventsHistogram->Fill(15., -1.);
+        fTRDEventsHistogram->Fill(15., -1.);
+        fEMCalEventsHistogram->Fill(15., -1.);
       }
-      fEventsHistogram->Fill(13.,-2.);
-      fTRDEventsHistogram->Fill(13.,-2.);
-      fEMCalEventsHistogram->Fill(13.,-2.);
-			for (Int_t i=0;i<nCentEstimators;++i)
-				((TH2I*)fCentEventsList->At(i))->Fill(13.,isOldCent?centrality->GetCentralityPercentile(Form("%s",estimatorNames[i])):multSelection->GetMultiplicityPercentile(Form("%s",estimatorNames[i])));
+      fEventsHistogram->Fill(15.,-2.);
+      fTRDEventsHistogram->Fill(15.,-2.);
+      fEMCalEventsHistogram->Fill(15.,-2.);
+         for (Int_t i=0;i<nCentEstimators;++i)
+	    ((TH2I*)fCentEventsList->At(i))->Fill(15.,isOldCent?centrality->GetCentralityPercentile(Form("%s",estimatorNames[i])):multSelection->GetMultiplicityPercentile(Form("%s",estimatorNames[i])));
     }
     
     if(writeEvent) fTree->Fill();
@@ -861,7 +916,7 @@ void AliAnalysisTaskReducedTreeMaker::UserExec(Option_t *option)
   PostData(1, fReducedEvent);
   if(fWriteTree) {
     PostData(2, fTree);
-		PostData(3, fEventsList);
+    PostData(3, fEventsList);
   }
 }
 
@@ -1082,13 +1137,7 @@ void AliAnalysisTaskReducedTreeMaker::FillEventInfo()
   if(event->IsPileupFromSPD(4,0.8,3.,2.,5.)) fReducedEvent->fEventTag |= (ULong64_t(1)<<10);
   if(event->IsPileupFromSPD(5,0.8,3.,2.,5.)) fReducedEvent->fEventTag |= (ULong64_t(1)<<11);
   if(event->IsPileupFromSPD(6,0.8,3.,2.,5.)) fReducedEvent->fEventTag |= (ULong64_t(1)<<12);
-  
-  // Apply the time range cut needed to reject events with bad TPC pid in some chambers
-  // For details see: https://indico.cern.ch/event/830757/contributions/3479738/attachments/1873483/3083952/IArsene_DPG_2019July3.pdf
-  fTimeRangeCut.InitFromEvent(InputEvent());
-  if(fTimeRangeCut.CutEvent(InputEvent())) fReducedEvent->fEventTag |= (ULong64_t(1)<<15);
-  
-  
+    
   fReducedEvent->fRunNo       = event->GetRunNumber();
   AliVVertex* eventVtx = 0x0;
   if(isESD) eventVtx = const_cast<AliESDVertex*>(esdEvent->GetPrimaryVertexTracks());

--- a/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.h
+++ b/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.h
@@ -69,6 +69,7 @@ public:
   
   // Cuts for selection of event to be written to tree
   void SetEventFilter(AliAnalysisCuts * const filter) {fEventFilter=filter;}
+  void SetTimeRangeReject(Bool_t reject=kTRUE) {fTimeRangeReject = reject;}
   // Cuts for selecting tracks included in the tree
   void SetTrackFilter(AliAnalysisCuts * const filter);
   void AddTrackFilter(AliAnalysisCuts * const filter, Bool_t option=kFALSE);
@@ -221,6 +222,7 @@ public:
   TBits* fUsedVars;                       // used variables for the AliDielectronVarManager
   
   AliTimeRangeCut     fTimeRangeCut;      //! time range selection based on OADB
+  Bool_t              fTimeRangeReject;   //  do not accept events if these are marked by fTimeRangeCut
   
   void FillEventInfo();                     // fill reduced event information
   void FillTrackInfo();                     // fill reduced track information

--- a/PWGDQ/reducedTree/AliMixingHandler.cxx
+++ b/PWGDQ/reducedTree/AliMixingHandler.cxx
@@ -173,10 +173,6 @@ void AliMixingHandler::Init() {
   
   fPoolSize.Set(fNParallelCuts*size);
   for(Int_t i=0;i<fNParallelCuts*size;++i) fPoolSize[i] = 0;
-    
-  // Initialize the random number generator for event/track downscaling
-  TTimeStamp time;
-  gRandom->SetSeed(time.GetNanoSec());
   
   fIsInitialized = kTRUE;
 }

--- a/PWGDQ/reducedTree/AliReducedBaseEvent.h
+++ b/PWGDQ/reducedTree/AliReducedBaseEvent.h
@@ -24,6 +24,27 @@ class AliReducedBaseEvent : public TObject {
      kUseReducedTracks            // use AliReducedTrackInfo for the track array
   };
   
+  // bits toggled in the fEventTag data member
+  enum EventTagBits {      
+     kAnaUtils2013pPb=0,   // 0 - 2013 p-Pb event selection
+     kAnaUtilPileupMV,     // 1 - multi-vertexer (MV) pileup 
+     kAnaUtilPileupMV2,    // 2 - MV pileup without bunch-crossing check
+     kAnaUtilPileupMV3,    // 3 - MV pileup with min weighted distance 10 (instead of 15)
+     kAnaUtilPileupMV4,    // 4 - MV pileup with min weighted distance 5 (instead of 15)
+     kIsPileupFromSPD1,    // 5 - event->IsPileupFromSPD(3,0.6,3.,2.,5.)
+     kIsPileupFromSPD2,    // 6 - event->IsPileupFromSPD(4,0.6,3.,2.,5.)
+     kIsPileupFromSPD3,    // 7 - event->IsPileupFromSPD(5,0.6,3.,2.,5.)
+     kIsPileupFromSPD4,    // 8 - event->IsPileupFromSPD(6,0.6,3.,2.,5.)
+     kIsPileupFromSPD5,    // 9 - event->IsPileupFromSPD(3,0.8,3.,2.,5.)
+     kIsPileupFromSPD6,    // 10 - event->IsPileupFromSPD(4,0.8,3.,2.,5.)
+     kIsPileupFromSPD7,    // 11 - event->IsPileupFromSPD(5,0.8,3.,2.,5.)
+     kIsPileupFromSPD8,    // 12 - event->IsPileupFromSPD(6,0.8,3.,2.,5.)
+     kVtxDistanceSelected, // 13 - Improved cut on the distance between SPD and track vertices 
+     kUnbiasedEvent,       // 14 - event selected for writing in the trees on a random basis 
+     kTimeRange,           // 15 - selected by AliTimeRangeCut (to be rejected)
+     kNEventTagBits
+  };
+  
  public:
   AliReducedBaseEvent();
   AliReducedBaseEvent(const Char_t* name, Int_t trackOption=kNoInit, Int_t track2Option=kNoInit);


### PR DESCRIPTION
…me range; few other fixes
Complete list:
1) AliAnalysisTaskReducedTreeMaker
Added option to reject events from writing if they fail the time range cut. The default behaviour is to evaluate the cut and toggle bit 15 (AliReducedBaseEvent::kTimeRange) so the event can be rejected later in analysis. The binning of the event statistics histograms such that two new bins were added which count the number of events passing the time range cut and those failing it. If the time range failing events are written to the trees, then these will all be counted as passing the cut in the statistics histogram.
2) AliMixingHandler
The initialization of the seed for the random number generator was removed from Init(). If the user needs a different initialization, this should be done outside of the class using gRandom->SetSeed().
3) AliReducedBaseEvent
An enumeration was added such that the bits from fEventTags get human readable names which should make it easier when cutting on this map in analysis. 