### PR TITLE
[ALIROOT-8287] Reduce verbosity related to missing centrality

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.cxx
@@ -103,6 +103,7 @@ AliAnalysisTaskEmcalLight::AliAnalysisTaskEmcalLight() :
   fMaximumEventWeight(1e6),
   fInhibit(kFALSE),
   fLocalInitialized(kFALSE),
+  fWarnMissingCentrality(kTRUE),
   fDataType(kAOD),
   fGeom(0),
   fCaloCells(0),
@@ -181,6 +182,7 @@ AliAnalysisTaskEmcalLight::AliAnalysisTaskEmcalLight(const char *name, Bool_t hi
   fMaximumEventWeight(1e6),
   fInhibit(kFALSE),
   fLocalInitialized(kFALSE),
+  fWarnMissingCentrality(kTRUE),
   fDataType(kAOD),
   fGeom(0),
   fCaloCells(0),
@@ -1053,7 +1055,7 @@ Bool_t AliAnalysisTaskEmcalLight::RetrieveEventObjects()
       fCent = MultSelection->GetMultiplicityPercentile(fCentEst.Data());
     }
     else {
-      AliWarning(Form("%s: Could not retrieve centrality information! Assuming 99", GetName()));
+      if(fWarnMissingCentrality) AliWarning(Form("%s: Could not retrieve centrality information! Assuming 99", GetName()));
     }
   }
   else if (fCentralityEstimation == kOldCentrality) {
@@ -1063,7 +1065,7 @@ Bool_t AliAnalysisTaskEmcalLight::RetrieveEventObjects()
       fCent = aliCent->GetCentralityPercentile(fCentEst.Data());
     }
     else {
-      AliWarning(Form("%s: Could not retrieve centrality information! Assuming 99", GetName()));
+      if(fWarnMissingCentrality) AliWarning(Form("%s: Could not retrieve centrality information! Assuming 99", GetName()));
     }
   }
   if (!fCentBins.empty() && fCentralityEstimation != kNoCentrality) {

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.h
@@ -188,6 +188,7 @@ class AliAnalysisTaskEmcalLight : public AliAnalysisTaskSE {
   void                        SetSwitchOffLHC15oFaultyBranches(Bool_t b)            { fSwitchOffLHC15oFaultyBranches = b                  ; }
 
   // Event selection
+  void                        SetWarnMissingCentrality(Bool_t doWarn)               { fWarnMissingCentrality = doWarn                     ; }
   void                        SetTriggerSelectionBitMap(UInt_t t)                   { fTriggerSelectionBitMap = t                         ; }
   void                        SetCentRange(Double_t min, Double_t max)              { fMinCent           = min  ; fMaxCent     = max      ; }
   void                        SetVzRange(Double_t min, Double_t max)                { fMinVz             = min  ; fMaxVz       = max      ; }
@@ -585,6 +586,7 @@ class AliAnalysisTaskEmcalLight : public AliAnalysisTaskSE {
   // Service fields
   Bool_t                      fInhibit;                    //!<!inhibit execution of the task
   Bool_t                      fLocalInitialized;           //!<!whether or not the task has been already initialized
+  Bool_t                      fWarnMissingCentrality;      //!<!switch for verbosity in centrality information
   EDataType_t                 fDataType;                   //!<!data type (ESD or AOD)
   AliEMCALGeometry           *fGeom;                       //!<!emcal geometry
   AliVCaloCells              *fCaloCells;                  //!<!cells

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerQATask.cxx
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerQATask.cxx
@@ -384,6 +384,7 @@ TObjArray AliEmcalTriggerQATask::AddTaskEmcalTriggerQA_QAtrain(Int_t runnumber)
     tasks.Add(task);
     task->SetForceBeamType(beam);
     task->AddAcceptedTriggerClass(triggerClass.c_str());
+    task->SetWarnMissingCentrality(kFALSE);
     if (runnumber > 197692) {
       task->SetCentralityEstimation(kNewCentrality);
     }


### PR DESCRIPTION
Print warning in case centrality is missing only when requested.
Default: Always print warnings. Disabled for EMCAL trigger QA
in the QA train.