### PR TITLE
Added a DeltaR matching check for dijet components

### DIFF
--- a/PWGCF/Correlations/JCORRAN/Pro/AliJJetJtAnalysis.h
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJJetJtAnalysis.h
@@ -77,6 +77,7 @@ class AliJJetJtAnalysis{
     void SetInputList(TObjArray * ilist){ fInputList = ilist;}
     void SetTrackOrMCParticle( UInt_t i, int v ){ fTrackOrMCParticle[i] = v; }
     void SetLeadingJets(UInt_t i){fLeadingJets = i;}
+    void SetMaxDeltaRCorr(double maxDeltaR){fMaxDeltaRCorr = maxDeltaR;}
     int  GetTrackOrMCParticle( UInt_t i ){ return fTrackOrMCParticle.at( i ); }
     double  GetConeSize( UInt_t i ){ return fConeSizes.at( i ); }
     //void SetTrackJetMap(std::vector<int> * v){ fTrackJetMap=v;}
@@ -152,6 +153,7 @@ class AliJJetJtAnalysis{
     TClonesArray     fpythiaJets;
     double fJetEtaCut;
     int fLeadingJets;
+    double fMaxDeltaRCorr;
     TRandom3 *frandom; // comment me
 
     TVector  *fJetTriggPtBorders; ///< Jet pT bin borders
@@ -187,6 +189,10 @@ class AliJJetJtAnalysis{
     TVector *fConstPt; ///< Store constituent jT values
     TVector *fConstLabels;
     TVector *fJetPt; ///< Store jet pT values
+    TVector *fLeadJetPhi; ///< Store phi of leading jet
+    TVector *fLeadJetEta; ///< Store eta of leading jet
+    TVector *fSubLeadJetPhi; ///< Store phi of subleading jet
+    TVector *fSubLeadJetEta; ///< Store eta of subleading jet
     TVector *fDiJetMjj; ///< Store di-jet invariant mass values
     TVector *fDiJetMjjSubtr; ///< Store di-jet bg-subtracted invariant mass values
     TVector *fTrackFound; ///< Keep track of which tracks were matched with MC tracks

--- a/PWGCF/Correlations/JCORRAN/Pro/AliJJetJtTask.cxx
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJJetJtTask.cxx
@@ -183,6 +183,7 @@ void AliJJetJtTask::UserCreateOutputObjects()
   fJJetJtAnalysis->SetMC(fDoMC);
   if(fDoLog) fJJetJtAnalysis->SetLog(fDoLog);
   fJJetJtAnalysis->SetLeadingJets(fLeadingJets);
+  fJJetJtAnalysis->SetMaxDeltaRCorr(fmaxDeltaRCorr);
   fJJetJtAnalysis->SetSide(fSide);
   fJJetJtAnalysis->SetnR(fJetTask->GetnR());
   fJJetJtAnalysis->Setnkt(fJetTask->Getnkt());

--- a/PWGCF/Correlations/JCORRAN/Pro/AliJJetJtTask.h
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJJetJtTask.h
@@ -59,6 +59,7 @@ class AliJJetJtTask : public AliAnalysisTaskSE {
   void SetNrandom( int Nrand) { NRandom = Nrand;}
   void SetMoveJet( int move) { moveJet = move;}
   void SetLeadingJets(int leading){fLeadingJets = leading;}
+  void SetMaxDeltaRCorr(double maxDeltaR){fmaxDeltaRCorr = maxDeltaR;}
   void SetCentCut(double cent){fCentCut = cent;}
   void FindDaughters(AliJJet * jet, AliAODMCParticle * track, AliMCParticleContainer * mcTracksCont);
   void SetSide(int side) {fSide = side;} // 0 = both sides, -1 A side, +1 C side
@@ -83,6 +84,7 @@ class AliJJetJtTask : public AliAnalysisTaskSE {
     int fDoMC; ///< Whether or not MC analysis is performed
     int fSide; ///< Possible to use only one side for analysis, 0: both sides, -1: A side, +1, C side
     int fLeadingJets; ///< Do only leading jets if >0
+    double  fmaxDeltaRCorr; ///<
     double fCentCut; ///<
     double zVert; ///< Vertex position
     bool fDoLog; ///< Whether or not logarithmic histograms should be filled/created

--- a/PWGCF/Correlations/macros/jcorran/AddTaskJJetJt.C
+++ b/PWGCF/Correlations/macros/jcorran/AddTaskJJetJt.C
@@ -10,7 +10,8 @@ AliJJetJtTask* AddTaskJJetJt(
 		Int_t	    moveJet =  1,
 		Int_t	    doMC       = 0,
     Int_t     leading = 0,
-		Int_t       debug 		 = 1	
+		Int_t       debug 		 = 1,
+        double     maxDeltaR = 0.5
 		)
 {  
 
@@ -48,7 +49,8 @@ AliJJetJtTask* AddTaskJJetJt(
 	jtTask->SelectCollisionCandidates(trigger);
 	jtTask->SetNrandom(Nrandom);
 	jtTask->SetMoveJet(moveJet);
-  jtTask->SetLeadingJets(leading);
+    jtTask->SetLeadingJets(leading);
+    jtTask->SetMaxDeltaRCorr(maxDeltaR);
 	mgr->AddTask(jtTask);
 
 	// Create containers for input/output


### PR DESCRIPTION
The detector level leading and subleading jets are compared to MC truth
counterparts in phi-eta plane. The maximum was added as an argument in
the macro.