### PR TITLE
Fix OCDB access with no AliEn (ALIROOT-8290)

### DIFF
--- a/PWGPP/AliESDtools.cxx
+++ b/PWGPP/AliESDtools.cxx
@@ -891,13 +891,13 @@ Int_t AliESDtools::DumpEventVariables() {
   Float_t intrate=-1.;
   static Int_t timeStampCache = -1;
   if (timeStampCache!=Int_t(timeStampS)) timeStampCache=Int_t(timeStampS);
-  if (!gGrid && timeStampCache>0) {
-    AliInfo("Trying to connect to AliEn ...");
+  if (!gSystem->Getenv("OCDB_PATH") && !gGrid && timeStampCache > 0) {
+    AliInfo("Trying to connect to AliEn...");
     TGrid::Connect("alien://");
   } else {
     const char *ocdb = "raw://";
-    TGraph *grLumiGraph = (TGraph*)AliLumiTools::GetLumiFromCTP(runNumber,ocdb);
-    intrate   = grLumiGraph->Eval(timeStamp);
+    TGraph *grLumiGraph = (TGraph*)AliLumiTools::GetLumiFromCTP(runNumber, ocdb);
+    intrate = grLumiGraph->Eval(timeStamp);
     delete grLumiGraph;
   }
 


### PR DESCRIPTION
When using the OCDB from CVMFS, the default storage is set to `raw://` and an
environment variable is set too (`OCDB_PATH`). In case the variable is set, we
should not attempt to connect to AliEn as we will not need it.

This covers the cases where AliEn access is deliberately disabled (e.g. the
release validation).

The fix is the same adopted in alisw/AliDPG#31.