### PR TITLE
[ALIROOT-8287] Swap order of internal event- and triggerselection

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.cxx
@@ -847,8 +847,8 @@ AliAnalysisTaskEmcalLight::EBeamType_t AliAnalysisTaskEmcalLight::GetBeamType()
 }
 
 Bool_t AliAnalysisTaskEmcalLight::IsEventSelected(){
-  if(fUseBuiltinEventSelection) return IsEventSelectedInternal();
   if(!IsTriggerSelected()) return false;
+  if(fUseBuiltinEventSelection) return IsEventSelectedInternal();
   if(!CheckMCOutliers()) return false;
   return fAliEventCuts.AcceptEvent(fInputEvent);
 }


### PR DESCRIPTION
For AliAnalysisTaskEmcalLight the trigger selection
is not called within the internal event selection,
consequently it has to be called before. Otherwise
the trigger selection is not applied.