### PR TITLE
D-meson -- HFe correlations task

### DIFF
--- a/PWGHF/correlationHF/AliAnalysisTaskDHFeCorr.cxx
+++ b/PWGHF/correlationHF/AliAnalysisTaskDHFeCorr.cxx
@@ -425,7 +425,7 @@ void AliAnalysisTaskDHFeCorr::FillElectronMCInfo(std::vector<AliDHFeCorr::AliEle
             if (mc_mother->GetMother()>0) {
                 const auto mc_grandmother = dynamic_cast<AliAODMCParticle *>(mc_information->At(mc_mother->GetMother()));
                 candidate.fSecondMotherPDG = mc_grandmother->GetPdgCode();
-                candidate.fSecondMotherPt = mc_mother->Pt();
+                candidate.fSecondMotherPt = mc_grandmother->Pt();
             }
         }
     }

--- a/PWGHF/correlationHF/AliAnalysisTaskDHFeCorr.cxx
+++ b/PWGHF/correlationHF/AliAnalysisTaskDHFeCorr.cxx
@@ -1,0 +1,1280 @@
+#include "AliAnalysisTaskDHFeCorr.h"
+
+//ROOT Includes
+#include "TChain.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TH3F.h"
+#include "TList.h"
+#include "TMath.h"
+#include "TFile.h"
+#include "TClonesArray.h"
+#include "TSystem.h"
+#include "TTree.h"
+
+//AliRoot and AliPhysics includes
+#include "AliVEvent.h"
+#include "AliAnalysisManager.h"
+#include "AliAODEvent.h"
+#include "AliAODMCParticle.h"
+
+//Electron
+#include "AliKFParticle.h"
+
+//Dmeson
+#include "AliRDHFCuts.h"
+#include "AliAnalysisVertexingHF.h"
+#include "AliAODRecoDecayHF.h"
+#include "AliAODRecoDecayHF2Prong.h"
+#include "AliAODRecoDecayHF3Prong.h"
+#include "AliAODRecoCascadeHF.h"
+#include "AliVertexingHFUtils.h"
+
+//PID 
+#include "AliPID.h"
+#include "AliPIDResponse.h"
+#include "AliVEventHandler.h"
+
+//multiplicity
+#include "AliMultSelection.h"
+
+//STL includes
+#include <iostream>
+#include <exception>
+//#include <algorithm>
+
+ClassImp(AliAnalysisTaskDHFeCorr)
+
+AliAnalysisTaskDHFeCorr::AliAnalysisTaskDHFeCorr() : AliAnalysisTaskSE() {}
+
+AliAnalysisTaskDHFeCorr::AliAnalysisTaskDHFeCorr(const char *name) : AliAnalysisTaskSE(name) {
+    DefineInput(0, TChain::Class());
+    DefineOutput(1, TList::Class());
+    DefineOutput(2, TList::Class());
+    DefineOutput(3, TList::Class());
+    DefineOutput(4, TTree::Class());
+    DefineOutput(5, TTree::Class());
+}
+
+//_____________________________________________________________________________
+void AliAnalysisTaskDHFeCorr::UserCreateOutputObjects() {
+    fDMesonRequirements.fDMesonCuts->GetPidHF()->SetPidResponse(fInputHandler->GetPIDResponse());
+    SetGridPID();
+
+    fOptEvent.SetOwner(kTRUE);
+    fOptElectron.SetOwner(kTRUE);
+    fOptDMeson.SetOwner(kTRUE);
+
+    fElectronTree = std::unique_ptr<TTree>(new TTree("electron", "electron"));
+    fDmesonTree = std::unique_ptr<TTree>(new TTree("dmeson", "dmeson"));
+
+    AddElectronVariables(fElectronTree);
+    AddDMesonVariables(fDmesonTree, fDmesonSpecies);
+
+    if (fIsMC) {
+        AddDMesonMCVariables(fDmesonTree);
+        AddElectronMCVariables(fElectronTree);
+    }
+
+    fEventQABeforeCuts = CreateQAEvents("before", fOptEvent);
+    fEventQAAfterCuts = CreateQAEvents("after", fOptEvent);
+
+    fElectronQABeforeCuts = CreateQAElectrons(fElectronOptConfig, "electron", "before", fOptElectron);
+    fElectronQAAfterCuts = CreateQAElectrons(fElectronOptConfig, "electron", "after", fOptElectron);
+
+    fDMesonQABeforeCuts = CreateQADMeson(fDMesonOptConfig, "dmeson", "before", fOptDMeson);
+    fDMesonQAAfterCuts = CreateQADMeson(fDMesonOptConfig, "dmeson", "after", fOptDMeson);
+
+    PostOutput();
+}
+
+void AliAnalysisTaskDHFeCorr::AddElectronVariables(std::unique_ptr<TTree> &tree) {
+    tree->Branch("GridPID", &fElectron.fGridPID);
+    tree->Branch("EventNumber", &fElectron.fEventNumber);
+    tree->Branch("Centrality", &fElectron.fCentrality);
+    tree->Branch("VtxZ", &fElectron.fVtxZ);
+    tree->Branch("Charge", &fElectron.fCharge);
+    tree->Branch("Pt", &fElectron.fPt);
+    tree->Branch("Eta", &fElectron.fEta);
+    tree->Branch("Phi", &fElectron.fPhi);
+    tree->Branch("NClsTPC", &fElectron.fNClsTPC);
+    tree->Branch("NClsTPCDeDx", &fElectron.fNClsTPCDeDx);
+    tree->Branch("NITSCls", &fElectron.fNITSCls);
+    tree->Branch("ITSHitFirstLayer", &fElectron.fITSHitFirstLayer);
+    tree->Branch("ITSHitSecondLayer", &fElectron.fITSHitSecondLayer);
+    tree->Branch("DCAxy", &fElectron.fDCAxy);
+    tree->Branch("DCAz", &fElectron.fDCAz);
+    tree->Branch("TPCNSigma", &fElectron.fTPCNSigma);
+    tree->Branch("TOFNSigma", &fElectron.fTOFNSigma);
+    tree->Branch("InvMassPartnersULS", &fElectron.fInvMassPartnersULS);
+    tree->Branch("InvMassPartnersLS", &fElectron.fInvMassPartnersLS);
+}
+
+void AliAnalysisTaskDHFeCorr::AddDMesonVariables(std::unique_ptr<TTree> &tree,
+                                                 AliAnalysisTaskDHFeCorr::DMeson_t meson_species) {
+    //Event information
+    tree->Branch("GridPID", &fDmeson.fGridPID);
+    tree->Branch("EventNumber", &fDmeson.fEventNumber);
+    tree->Branch("ID", &fDmeson.fID);
+    tree->Branch("IsParticleCandidate", &fDmeson.fIsParticleCandidate);
+
+    //Basic information
+    tree->Branch("Pt", &fDmeson.fPt);
+    tree->Branch("Eta", &fDmeson.fEta);
+    tree->Branch("Phi", &fDmeson.fPhi);
+    tree->Branch("Y", &fDmeson.fY);
+    tree->Branch("InvMass", &fDmeson.fInvMass);
+    tree->Branch("InvMass", &fDmeson.fInvMass);
+    tree->Branch("ReducedChi2", &fDmeson.fReducedChi2);
+
+    //Topological information
+    tree->Branch("DecayLength", &fDmeson.fDecayLength);
+    tree->Branch("DecayLengthXY", &fDmeson.fDecayLengthXY);
+
+    tree->Branch("NormDecayLength", &fDmeson.fNormDecayLength);
+    tree->Branch("NormDecayLengthXY", &fDmeson.fNormDecayLengthXY);
+
+    tree->Branch("CosP", &fDmeson.fCosP);
+    tree->Branch("CosPXY", &fDmeson.fCosPXY);
+
+    tree->Branch("ImpParXY", &fDmeson.fImpParXY);
+    tree->Branch("DCA", &fDmeson.fDCA);
+
+    tree->Branch("Normd0MeasMinusExp", &fDmeson.fNormd0MeasMinusExp);
+    tree->Branch("PtDaughter", &fDmeson.fPtDaughters);
+    tree->Branch("D0Daughter", &fDmeson.fD0Daughters);
+    tree->Branch("NSigmaTPCDaughter", &fDmeson.fNSigmaTPCDaughters);
+    tree->Branch("NSigmaTOFDaughters", &fDmeson.fNSigmaTOFDaughters);
+
+    //PID
+    tree->Branch("SelectionStatusDefaultPID", &fDmeson.fSelectionStatusDefaultPID);
+
+    //Meson depended variables
+    switch (meson_species) {
+        case AliAnalysisTaskDHFeCorr::kD0:
+            tree->Branch("CosTs", &fDmeson.fCosTs);
+            break;
+        case AliAnalysisTaskDHFeCorr::kDplus:
+            tree->Branch("SigmaVertex", &fDmeson.fSigmaVertex);
+            break;
+        case AliAnalysisTaskDHFeCorr::kDstar:
+            tree->Branch("AngleD0dkpPisoft", &fDmeson.fAngleD0dkpPisoft);
+            break;
+    }
+}
+
+void AliAnalysisTaskDHFeCorr::AddElectronMCVariables(std::unique_ptr<TTree> &tree) {
+    tree->Branch("PtMC", &fElectron.fPtMC);
+    tree->Branch("PhiMC", &fElectron.fPhiMC);
+    tree->Branch("EtaMC", &fElectron.fEtaMC);
+    tree->Branch("Origin", &fElectron.fOrigin);
+    tree->Branch("FirstMotherPDG", &fElectron.fFirstMotherPDG);
+    tree->Branch("FirstMotherPt", &fElectron.fFirstMotherPt);
+    tree->Branch("SecondMotherPDG", &fElectron.fSecondMotherPDG);
+    tree->Branch("SecondMotherPt", &fElectron.fSecondMotherPt);
+}
+
+void AliAnalysisTaskDHFeCorr::AddDMesonMCVariables(std::unique_ptr<TTree> &tree) {
+    tree->Branch("PtMC", &fDmeson.fPtMC);
+    tree->Branch("IsD", &fDmeson.fIsD);
+    tree->Branch("IsParticle", &fDmeson.fIsParticle);
+    tree->Branch("IsPrompt", &fDmeson.fIsPrompt);
+}
+
+//_____________________________________________________________________________
+void AliAnalysisTaskDHFeCorr::UserExec(Option_t *) {
+    CheckConfiguration();
+    
+    //Set Global event variables
+    fVtxZ = InputEvent()->GetPrimaryVertex()->GetZ();
+    
+    auto *multiplicity_selection = dynamic_cast<AliMultSelection *>(InputEvent()->FindListObject("MultSelection"));
+    if (multiplicity_selection)
+        fCentrality = multiplicity_selection->GetMultiplicityPercentile(fEventSelection.fMultiEstimator);
+    
+    auto aod_event = dynamic_cast<AliAODEvent *>(InputEvent());
+    if (!aod_event)
+        return;
+
+    FillEventQA(fEventQABeforeCuts);
+
+    if (!IsSelectedEvent(aod_event, fEventSelection)) {
+        PostOutput();
+        return;
+    }
+
+    //Move tracks to a vector
+    std::vector<AliDHFeCorr::AliElectron> tracks;
+    tracks.reserve(static_cast<unsigned long>(aod_event->GetNumberOfTracks()));
+
+    for (int i(0); i < aod_event->GetNumberOfTracks(); i++) {
+        auto particle = AliDHFeCorr::AliElectron();
+        particle.fTrack = dynamic_cast<AliAODTrack *>(aod_event->GetTrack(i));
+        tracks.push_back(particle);
+    }
+    FillElectronInformation(tracks);
+    
+    auto selected_tracks = FilterElectronsTracking(fElectronRequirements, tracks);
+    auto selected_electrons = FilterElectronsPID(fElectronRequirements, selected_tracks);
+
+    //Move D meson candidates to vectors
+    const TClonesArray *dmeson_candidates = dynamic_cast<TClonesArray *>(aod_event->GetList()->FindObject(
+            fgkDMesonListName.at(fDmesonSpecies).c_str()));
+
+    auto d_mesons = FillDMesonInfo(dmeson_candidates, fDmesonSpecies, fDMesonRequirements);
+    //Select D mesons
+    auto selected_d_mesons = FilterDmesons(d_mesons, fDMesonRequirements, aod_event,
+                                           fgkDMesonPDG.at(fDmesonSpecies));
+
+    if (!fIsEffMode) {
+        //Ignores event in case no electron and D meson is found
+        if ((selected_d_mesons.empty()) || (selected_electrons.empty())) {
+            PostOutput();
+            return;
+        }
+    }
+
+    FillDmesonMCInfo(selected_d_mesons, fDmesonSpecies);
+    FillElectronMCInfo(selected_electrons);
+
+    //Filter partner electrons (for Non-HFe tagging)
+    auto selected_partner_tracks = FilterElectronsTracking(fPartnerElectronRequirements, tracks);
+    auto partner_electrons = FilterElectronsPID(fPartnerElectronRequirements, selected_partner_tracks);
+
+    for (auto &electron: selected_electrons)
+        FindNonHFe(electron, partner_electrons);
+
+    //Fill the plots in case both D meson and electron is found the event
+    FillEventQA(fEventQAAfterCuts);
+    //fill the electron (track) QA before applying the cuts
+    FillElectronQA(tracks, fElectronQABeforeCuts);
+    //fill the electron QA after applying the cuts
+    FillElectronQA(selected_electrons, fElectronQAAfterCuts);
+
+    FillElectronTree(selected_electrons);
+
+    //Fill QA before selection
+    FillDmesonQA(d_mesons, fDMesonQABeforeCuts, fDmesonSpecies);
+    //Fill QA after selection
+
+    if (fIsEffMode && fIsMC) {
+        selected_d_mesons = FilterTrueDMesons(selected_d_mesons);
+    }
+
+    FillDmesonQA(selected_d_mesons, fDMesonQAAfterCuts, fDmesonSpecies);
+    FillDMesonTree(selected_d_mesons);
+
+    //Post information to the output
+    PostOutput();
+
+    //increase the number of the event used for the Trees
+    fEventNumber++;
+}
+
+void AliAnalysisTaskDHFeCorr::CheckConfiguration() const {
+    auto event_list = InputEvent()->GetList();
+    auto mc_information = dynamic_cast<TClonesArray *>(event_list->FindObject(AliAODMCParticle::StdBranchName()));
+
+    if (!mc_information) {
+        if (fIsMC && fIsEffMode) {
+            throw std::invalid_argument(
+                    "The analysis has no MC information and it is set as MC analysis. Check the data/configuration.");
+        }
+        return;
+    }
+
+    if (fgkDMesonDaughterAliPID.count(fDmesonSpecies)<1)
+        throw std::invalid_argument("The daughter list (AliPID) is not defined. Check fgkDMesonDaughterAliPID.");
+
+    if (fgkDMesonDaughterPDG.count(fDmesonSpecies)<1)
+        throw std::invalid_argument("The daughter list PDG is not defined. Check fgkDMesonDaughterPDG.");
+
+    if (fgkDMesonListName.count(fDmesonSpecies)<1)
+        throw std::invalid_argument("The daughter AOD list name is not defined. Check fgkDMesonListName.");
+}
+
+void AliAnalysisTaskDHFeCorr::FillElectronInformation(std::vector<AliDHFeCorr::AliElectron> &electrons){
+    auto aod_event = dynamic_cast<AliAODEvent *>(InputEvent());
+    const auto pid_response = fInputHandler->GetPIDResponse();
+    
+    for (auto &candidate: electrons) {
+        const auto track = candidate.fTrack;
+        candidate.fGridPID = fGridPID;
+        candidate.fEventNumber = fEventNumber;
+        candidate.fVtxZ = fVtxZ;
+        candidate.fCentrality = fCentrality;
+        
+        candidate.fCharge = track->Charge();
+        candidate.fPt = track->Pt();
+        candidate.fP =track->P();
+        candidate.fEta = track->Eta();
+        candidate.fPhi = track->Phi();
+        
+        candidate.fNClsTPC = track->GetTPCNcls();
+        candidate.fNClsTPCDeDx = track->GetTPCsignalN();
+        candidate.fNITSCls = track->GetITSNcls();
+        
+        candidate.fITSHitFirstLayer = track->HasPointOnITSLayer(0);
+        candidate.fITSHitSecondLayer = track->HasPointOnITSLayer(1);
+        
+        Double_t d0z0[2] = {-999.,-999.};
+        Double_t cov[3] = {-999., -999., -999.};
+        const AliVVertex *primaryVertex = aod_event->GetPrimaryVertex();
+        AliAODTrack copyTrack = AliAODTrack(*track); //Copy track to not alter its parameters
+        
+        if (copyTrack.PropagateToDCA(primaryVertex, aod_event->GetMagneticField(), 20., d0z0, cov)) {
+            candidate.fDCAxy = d0z0[0];
+            candidate.fDCAz = d0z0[1];
+        }
+        
+        candidate.fTPCNSigma = pid_response->NumberOfSigmasTPC(track, AliPID::kElectron);
+        candidate.fTOFNSigma = pid_response->NumberOfSigmasTOF(track, AliPID::kElectron);
+    }
+}
+
+std::vector<AliDHFeCorr::AliElectron>
+AliAnalysisTaskDHFeCorr::FilterElectronsTracking(AliDHFeCorr::AliElectronSelection electronSelection,
+                                                 const std::vector<AliDHFeCorr::AliElectron> &electrons) {
+    std::vector<AliDHFeCorr::AliElectron> selected_electrons;
+    selected_electrons.reserve(electrons.size());
+
+    for (const auto &candidate: electrons) {
+        if ((candidate.fPt < electronSelection.fPtMin) || (candidate.fPt > electronSelection.fPtMax))
+            continue;
+        
+        if ((candidate.fEta < electronSelection.fEtaMin) || (candidate.fEta > electronSelection.fPtMax))
+            continue;
+
+        if (!candidate.fTrack->TestFilterBit(electronSelection.fFilterBit))
+            continue;
+
+        if (candidate.fNClsTPC < electronSelection.fTPCClsMin)
+            continue;
+
+        if (candidate.fNClsTPCDeDx < electronSelection.fTPCClsDeDxMin)
+            continue;
+
+        if (candidate.fNITSCls < electronSelection.fITSClsMin)
+            continue;
+
+        if (!FulfilPixelSelection(candidate, electronSelection.fITSPixel))
+            continue;
+        
+        if (candidate.fDCAxy > electronSelection.fDCAxy || candidate.fDCAz > electronSelection.fDCAz)
+            continue;
+        
+        auto electron = AliDHFeCorr::AliElectron(candidate);
+        selected_electrons.push_back(electron);
+    }
+
+    selected_electrons.shrink_to_fit();
+    return selected_electrons;
+}
+
+std::vector<AliDHFeCorr::AliElectron>
+AliAnalysisTaskDHFeCorr::FilterElectronsPID(AliDHFeCorr::AliElectronSelection electronSelection,
+                                            const std::vector<AliDHFeCorr::AliElectron> &electrons) {
+
+    std::vector<AliDHFeCorr::AliElectron> selected_electrons;
+    selected_electrons.reserve(electrons.size());
+
+    for (const auto &candidate: electrons) {
+        if ((candidate.fTPCNSigma < electronSelection.fTPCNSigmaMin) ||
+            (candidate.fTPCNSigma > electronSelection.fTPCNSigmaMax))
+            continue;
+
+        if (electronSelection.fRequireTOF) {
+            if ((candidate.fTOFNSigma < electronSelection.fTOFNSigmaMin) ||
+                (candidate.fTOFNSigma > electronSelection.fTOFNSigmaMax))
+                continue;
+        }
+        selected_electrons.push_back(AliDHFeCorr::AliElectron(candidate));
+    }
+
+    selected_electrons.shrink_to_fit();
+    return selected_electrons;
+}
+
+void AliAnalysisTaskDHFeCorr::FillElectronMCInfo(std::vector<AliDHFeCorr::AliElectron> &electrons) {
+    const auto mc_information = dynamic_cast<TClonesArray *>(InputEvent()->GetList()->FindObject(
+            AliAODMCParticle::StdBranchName()));
+
+    if (!mc_information)
+        return;
+
+    for (auto &candidate: electrons) {
+        auto track = candidate.fTrack;
+        auto label = TMath::Abs(track->GetLabel());
+        
+        auto mc_part = dynamic_cast<AliAODMCParticle *>(mc_information->At(label));
+
+        if (!mc_part)
+            continue;
+
+        candidate.fPtMC = mc_part->Pt();
+        candidate.fEtaMC = mc_part->Eta();
+        candidate.fPhiMC = mc_part->Phi();
+        candidate.fPDG = mc_part->PdgCode();
+        candidate.fOrigin = AliVertexingHFUtils::CheckOrigin(mc_information, mc_part, true);
+
+        if (mc_part->GetMother()>0) {
+            const auto mc_mother = dynamic_cast<AliAODMCParticle *>(mc_information->At(mc_part->GetMother()));
+            candidate.fFirstMotherPDG = mc_mother->GetPdgCode();
+            candidate.fFirstMotherPt = mc_mother->Pt();
+
+            if (mc_mother->GetMother()>0) {
+                const auto mc_grandmother = dynamic_cast<AliAODMCParticle *>(mc_information->At(mc_mother->GetMother()));
+                candidate.fSecondMotherPDG = mc_grandmother->GetPdgCode();
+                candidate.fSecondMotherPt = mc_mother->Pt();
+            }
+        }
+    }
+}
+
+
+void AliAnalysisTaskDHFeCorr::FillDmesonMCInfo(std::vector<AliDHFeCorr::AliDMeson> &d_mesons,
+                                               AliAnalysisTaskDHFeCorr::DMeson_t meson_species) const {
+    if (!fIsMC) {
+        return;
+    }
+
+    const auto mc_information = dynamic_cast<TClonesArray *>(InputEvent()->GetList()->FindObject(
+            AliAODMCParticle::StdBranchName()));
+
+    const auto pdg_daughters_int = fgkDMesonDaughterPDG.at(meson_species);
+    const auto pdg_dmeson = fgkDMesonPDG.at(meson_species);
+
+    for (auto &candidate: d_mesons) {
+        const auto reco_cand = candidate.fRecoObj;
+        const Int_t label = reco_cand->MatchToMC(pdg_dmeson, mc_information, pdg_daughters_int.size(), &pdg_daughters_int[0]);
+
+        if (label < 0)
+            continue;
+
+        candidate.fIsD = kTRUE;
+        const auto mc_part = dynamic_cast<AliAODMCParticle *>(mc_information->At(label));
+        candidate.fPtMC = mc_part->Pt();
+        const auto origin = AliVertexingHFUtils::CheckOrigin(mc_information, mc_part, true); //Prompt = 4, FeedDown = 5
+        candidate.fIsParticle = kFALSE;
+        if (mc_part->PdgCode() > 0) {
+            candidate.fIsParticle = kTRUE;
+        }
+        if (origin != 5) {
+            candidate.fIsPrompt = kTRUE;
+        }
+    }
+}
+
+std::vector<AliDHFeCorr::AliDMeson>
+AliAnalysisTaskDHFeCorr::FilterTrueDMesons(const std::vector<AliDHFeCorr::AliDMeson> &d_mesons) {
+    std::vector<AliDHFeCorr::AliDMeson> true_d;
+    true_d.reserve(d_mesons.size());
+
+    for (const auto &candidate: d_mesons) {
+        if (candidate.fIsD) {
+            true_d.push_back(candidate);
+        }
+    }
+    true_d.shrink_to_fit();
+    return true_d;
+}
+
+void AliAnalysisTaskDHFeCorr::SetGridPID() {
+    const char *grid_id = gSystem->Getenv("ALIEN_PROC_ID");
+    if (grid_id) {
+        std::string str(grid_id);
+        fGridPID = static_cast<ULong_t>(std::stoi(str));
+    } else
+        fGridPID = 0;
+}
+
+void AliAnalysisTaskDHFeCorr::PostOutput() {
+    PostData(1, &fOptEvent);
+    PostData(2, &fOptElectron);
+    PostData(3, &fOptDMeson);
+    PostData(4, fElectronTree.get());
+    PostData(5, fDmesonTree.get());
+}
+
+
+void AliAnalysisTaskDHFeCorr::FillElectronQA(const std::vector<AliDHFeCorr::AliElectron> &tracks,
+                                             AliDHFeCorr::AliElectronQAHistograms &histograms) {
+    for (const auto &electron: tracks) {
+        histograms.fPtEtaPhi->Fill(electron.fPt, electron.fEta, electron.fPhi);
+        histograms.fTPCNCls->Fill(electron.fNClsTPC);
+        histograms.fTPCNClsDeDx->Fill(electron.fNClsTPCDeDx);
+        histograms.fITSCls->Fill(electron.fNITSCls);
+        histograms.fDCAz->Fill(electron.fDCAz);
+        histograms.fDCAxy->Fill(electron.fDCAxy);
+        //PID
+        histograms.fTPCNsigmaPt->Fill(electron.fPt, electron.fTPCNSigma);
+        histograms.fTPCNsigmaP->Fill(electron.fP, electron.fTPCNSigma);
+        histograms.fTOFNsigmaPt->Fill(electron.fPt, electron.fTOFNSigma);
+        histograms.fTOFNsigmaP->Fill(electron.fP, electron.fTOFNSigma);
+        histograms.fTPCTOFNSigma->Fill(electron.fTPCNSigma, electron.fTOFNSigma);
+    }
+}
+
+void AliAnalysisTaskDHFeCorr::FillDmesonQA(const std::vector<AliDHFeCorr::AliDMeson> &d_mesons,
+                                           AliDHFeCorr::AliDMesonQAHistos &histograms,
+                                           AliAnalysisTaskDHFeCorr::DMeson_t meson_species) {
+    for (const auto &candidate: d_mesons) {
+        const auto reco_cand = candidate.fRecoObj;
+        histograms.fPtEtaPhi->Fill(reco_cand->Pt(), reco_cand->Eta(), reco_cand->Phi());
+
+        switch (meson_species) {
+            case AliAnalysisTaskDHFeCorr::kD0: {
+                const auto d0_cand = dynamic_cast<AliAODRecoDecayHF2Prong *>(reco_cand);
+                if (candidate.fIsParticleCandidate)
+                    histograms.fPtInvMass->Fill(reco_cand->Pt(), d0_cand->InvMassD0());
+                else
+                    histograms.fPtInvMass->Fill(reco_cand->Pt(), d0_cand->InvMassD0bar());
+                break;
+            }
+            case AliAnalysisTaskDHFeCorr::kDplus: {
+                const auto dplus_cand = dynamic_cast<AliAODRecoDecayHF3Prong *>(reco_cand);
+                histograms.fPtInvMass->Fill(reco_cand->Pt(), dplus_cand->InvMassDplus());
+                break;
+            }
+            case AliAnalysisTaskDHFeCorr::kDstar: {
+                const auto dstar_cand = dynamic_cast<AliAODRecoCascadeHF *>(reco_cand);
+                histograms.fPtInvMass->Fill(reco_cand->Pt(), dstar_cand->InvMassDstarKpipi());
+                break;
+            }
+        }
+    }
+}
+
+void AliAnalysisTaskDHFeCorr::FillEventQA(AliDHFeCorr::AliEventQAHistograms &histograms) {
+    histograms.fNEvents->Fill(0);
+    histograms.fVertexZ->Fill(fVtxZ);
+    histograms.fCentrality->Fill(fCentrality);
+}
+
+void AliAnalysisTaskDHFeCorr::FindNonHFe(AliDHFeCorr::AliElectron &main_electron,
+                                         const std::vector<AliDHFeCorr::AliElectron> &partners) const{
+
+    //Reset all the vectors and reserve 10 (it should not have too many partners)
+    std::vector<Float_t> inv_mass_uls, inv_mass_ls;
+    std::vector<UInt_t> id_uls, id_ls;
+
+    inv_mass_uls.reserve(10);
+    inv_mass_ls.reserve(10);
+    id_uls.reserve(10);
+    id_ls.reserve(10);
+
+    //Set the magnetic field
+    AliKFParticle::SetField(InputEvent()->GetMagneticField());
+
+    const auto track_main = main_electron.fTrack;
+    const auto charge_main = track_main->Charge();
+
+    int pdg_main = 11; //electron pdg is always 11
+    if (charge_main > 0.) { //change sign in case it is a positron
+        pdg_main = -1 * pdg_main;
+    }
+
+    const auto kfparticle_main = AliKFParticle(*static_cast<AliVTrack *>(track_main), pdg_main);
+
+    for (const auto &partner: partners) {
+        const auto track_partner = partner.fTrack;
+
+        if (TMath::Abs(track_partner->GetID()) == TMath::Abs(track_main->GetID()))
+            continue;
+
+        const auto charge_partner = track_partner->Charge();
+
+        int pdg_partner = 11; //electron pdg is always 11
+
+        if (charge_partner > 0.) { //change sign in case it is a positron
+            pdg_partner = -1 * pdg_partner;
+        }
+
+        const auto kfparticle_partner = AliKFParticle(*static_cast<AliVTrack *>(track_partner), pdg_partner);
+
+        AliKFParticle photon(kfparticle_main, kfparticle_partner);
+
+        //Reject in case no degree of freedom is smaller than 1
+        if (photon.GetNDF() < 1)
+            continue;
+
+        const auto reduced_chi2 = photon.GetChi2() / photon.GetNDF();
+
+        if (TMath::Abs(reduced_chi2) > fPhotonSelection.fReducedChi2Max)
+            continue;
+
+        const auto pair_mass = photon.GetMass();
+
+        if (pair_mass > fPhotonSelection.fInvMassMax)
+            continue;
+
+        //If the pair arrived here, it fulfils all the requirements, so it will be saved
+        if ((charge_main * charge_partner) > 0) { //++ or --, Like-sign pair
+            inv_mass_ls.push_back(pair_mass);
+            id_ls.push_back(static_cast<unsigned int &&>(TMath::Abs(track_partner->GetID())));
+        } else {
+            inv_mass_uls.push_back(pair_mass);
+            id_uls.push_back(static_cast<unsigned int &&>(TMath::Abs(track_partner->GetID())));
+        }
+    }
+
+    inv_mass_uls.shrink_to_fit();
+    inv_mass_ls.shrink_to_fit();
+    id_uls.shrink_to_fit();
+    id_ls.shrink_to_fit();
+
+    main_electron.fInvMassPartnersULS = inv_mass_uls;
+    main_electron.fInvMassPartnersLS = inv_mass_ls;
+    main_electron.fPartnersULSID = id_uls;
+    main_electron.fPartnersLSID = id_ls;
+
+}
+
+void AliAnalysisTaskDHFeCorr::FillElectronTree(const std::vector<AliDHFeCorr::AliElectron> &tracks) {
+    for (const auto &electron: tracks) {
+        fElectron = AliDHFeCorr::AliElectron(electron);
+        fElectronTree->Fill();
+    }
+}
+
+
+void AliAnalysisTaskDHFeCorr::FillDMesonTree(const std::vector<AliDHFeCorr::AliDMeson> &d_mesons) {
+    for (const auto &dmeson: d_mesons) {
+        fDmeson =  AliDHFeCorr::AliDMeson(dmeson);
+        fDmesonTree->Fill();
+    }
+}
+
+std::vector<Float_t> AliAnalysisTaskDHFeCorr::MakeBins(Float_t start, Float_t end, Int_t n_bins) {
+    const auto step = (end - start) / n_bins;
+    std::vector<Float_t> bins;
+    bins.reserve(n_bins + 1);
+
+    for (Int_t i(0); i < (n_bins + 1); i++)
+        bins.push_back(start + i * step);
+
+    return bins;
+}
+
+
+std::vector<AliDHFeCorr::AliDMeson> AliAnalysisTaskDHFeCorr::FillDMesonInfo(const TClonesArray *dmeson_candidates,
+                                                                            AliAnalysisTaskDHFeCorr::DMeson_t meson_species,
+                                                                            AliDHFeCorr::AliDMesonSelection &dmeson_selection) const {
+    AliAnalysisVertexingHF vertexing_HF;
+    std::vector<AliDHFeCorr::AliDMeson> d_mesons;
+    d_mesons.reserve(2 * dmeson_candidates->GetEntriesFast());
+
+    const float b_field = InputEvent()->GetMagneticField();
+    
+    const auto pdg_dmeson = fgkDMesonPDG.at(meson_species);
+    const auto pdg_daughters = fgkDMesonDaughterPDG.at(meson_species);
+    const auto id_daughter = fgkDMesonDaughterAliPID.at(fDmesonSpecies);
+    
+    const auto aod_event = dynamic_cast<AliAODEvent*>(InputEvent());
+    const auto pid_response = fInputHandler->GetPIDResponse();
+    
+
+    for (int i(0); i < dmeson_candidates->GetEntriesFast(); i++) {
+        auto cand = AliDHFeCorr::AliDMeson();
+        cand.fRecoObj = dynamic_cast<AliAODRecoDecayHF *>(dmeson_candidates->At(i));
+        cand.fID = static_cast<UInt_t>(i); // ID of the D meson in the event
+        
+        const auto reco_candidate = cand.fRecoObj;
+        if (!reco_candidate)
+            continue;
+
+        //Fill missing info not saved in the AOD
+        switch (meson_species) {
+            case AliAnalysisTaskDHFeCorr::kD0: {
+                if (!vertexing_HF.FillRecoCand(aod_event, dynamic_cast<AliAODRecoDecayHF2Prong *>(reco_candidate)))
+                    continue;
+                if (!reco_candidate->HasSelectionBit(AliRDHFCuts::kD0toKpiCuts))
+                    continue;
+                break;
+            }
+            case AliAnalysisTaskDHFeCorr::kDplus: {
+                if (!vertexing_HF.FillRecoCand(aod_event, dynamic_cast<AliAODRecoDecayHF3Prong *>(reco_candidate)))
+                    continue;
+                if (!reco_candidate->HasSelectionBit(AliRDHFCuts::kDplusCuts))
+                    continue;
+                break;
+            }
+            case AliAnalysisTaskDHFeCorr::kDstar: {
+                if (!vertexing_HF.FillRecoCand(aod_event, dynamic_cast<AliAODRecoCascadeHF *>(reco_candidate)))
+                    continue;
+                if (!reco_candidate->HasSelectionBit(AliRDHFCuts::kDstarCuts))
+                    continue;
+                break;
+            }
+            default: {
+                throw std::invalid_argument("The D meson requested is not defined in the task");
+                break;
+            }
+        }
+
+        //Is it particle or antiparticle? Is positive -> True, Should work for D+
+        //For D0, the Charge() should return 0, but the candidates will be saved twice (to handle reflections)
+        cand.fIsParticleCandidate = reco_candidate->Charge() >= 0;
+        cand.fGridPID = fGridPID;
+        cand.fEventNumber = fEventNumber;
+        
+        const auto reco_cand = cand.fRecoObj;
+        //Recalculate vertex w/o daughters
+        AliAODVertex *original_own_vertex(nullptr);
+        if (reco_cand->GetOwnPrimaryVtx())
+            original_own_vertex = new AliAODVertex(*reco_cand->GetOwnPrimaryVtx());
+        
+        if (!dmeson_selection.fDMesonCuts->RecalcOwnPrimaryVtx(reco_cand, aod_event)) {
+            dmeson_selection.fDMesonCuts->CleanOwnPrimaryVtx(reco_cand, aod_event, original_own_vertex);
+            continue;
+        }
+        
+        cand.fPt = reco_cand->Pt();
+        cand.fEta = reco_cand->Eta();
+        cand.fPhi = reco_cand->Phi();
+        cand.fY = reco_cand->Y(pdg_dmeson);
+        cand.fReducedChi2 = reco_cand->GetReducedChi2();
+        cand.fDecayLength = reco_cand->DecayLength();
+        cand.fDecayLengthXY = reco_cand->DecayLengthXY();
+        cand.fNormDecayLength = reco_cand->NormalizedDecayLength();
+        cand.fNormDecayLengthXY = reco_cand->NormalizedDecayLengthXY();
+        cand.fCosP = reco_cand->CosPointingAngle();
+        cand.fCosPXY = reco_cand->CosPointingAngleXY();
+        cand.fImpParXY = reco_cand->ImpParXY();
+        cand.fDCA = reco_cand->GetDCA();
+        cand.fNormd0MeasMinusExp = GetMaxd0MeasMinusExp(reco_cand, b_field);
+        
+        //Single particle information
+        const auto n_prongs = reco_cand->GetNProngs();
+        std::vector<Float_t> pt_daughters;
+        pt_daughters.reserve(n_prongs);
+        std::vector<Float_t> d0_daughters;
+        d0_daughters.reserve(n_prongs);
+        
+        for (int i = 0; i < n_prongs; i++) {
+            pt_daughters.push_back(reco_cand->PtProng(i));
+            d0_daughters.push_back(reco_cand->Getd0Prong(i));
+        }
+        cand.fPtDaughters = pt_daughters;
+        cand.fD0Daughters = d0_daughters;
+    
+        std::vector<Float_t> pid_info_tpc;
+        std::vector<Float_t> pid_info_tof;
+        pid_info_tpc.reserve(n_prongs);
+        pid_info_tof.reserve(n_prongs);
+        
+        for (int i = 0; i < n_prongs; i++){
+            const auto track = dynamic_cast<AliAODTrack *>(reco_cand->GetDaughter(i));
+            pid_info_tpc.push_back(pid_response->NumberOfSigmasTPC(track, id_daughter[i]));
+            pid_info_tof.push_back(pid_response->NumberOfSigmasTOF(track, id_daughter[i]));
+        }
+        cand.fNSigmaTPCDaughters = pid_info_tpc;
+        cand.fNSigmaTOFDaughters = pid_info_tof;
+        
+        if (meson_species == kD0) { //The reflection will be saved later
+            const auto d0_candidate = dynamic_cast<AliAODRecoDecayHF2Prong *>(reco_cand);
+            cand.fInvMass = d0_candidate->InvMassD0();
+            cand.fCosTs = d0_candidate->CosThetaStarD0();
+        }
+        else if (meson_species == kDplus) {
+            const auto dplus_candidate = dynamic_cast<AliAODRecoDecayHF3Prong *>(reco_cand);
+            cand.fSigmaVertex = dplus_candidate->GetSigmaVert();
+            cand.fInvMass = dplus_candidate->InvMassDplus();
+        }
+        else if (meson_species == kDstar) {
+            //const auto dstar_candidate = dynamic_cast<AliAODRecoCascadeHF *>(reco_cand);
+        }
+        
+        d_mesons.push_back(cand);
+
+        //Duplicate D0 candidates
+        if (meson_species == kD0) {
+            AliDHFeCorr::AliDMeson reflection(cand);
+            reflection.fIsParticleCandidate = kFALSE; //should always be kFALSE, since the first one was kTRUE
+            
+            auto d0bar_candidate = dynamic_cast<AliAODRecoDecayHF2Prong *>(reflection.fRecoObj);
+            reflection.fInvMass = d0bar_candidate->InvMassD0bar();
+            reflection.fCosTs = d0bar_candidate->CosThetaStarD0bar();
+            
+            //Invert the vectors, since we would like to have the pt and d0 for the pion and
+            //kaon in the same position
+            std::reverse(reflection.fPtDaughters.begin(), reflection.fPtDaughters.end());
+            std::reverse(reflection.fD0Daughters.begin(), reflection.fD0Daughters.end());
+            std::reverse(reflection.fNSigmaTPCDaughters.begin(), reflection.fNSigmaTPCDaughters.end());
+            std::reverse(reflection.fNSigmaTOFDaughters.begin(), reflection.fNSigmaTOFDaughters.end());
+            
+            d_mesons.push_back(reflection);
+        }
+        dmeson_selection.fDMesonCuts->CleanOwnPrimaryVtx(reco_cand, aod_event, original_own_vertex);
+    }
+
+    d_mesons.shrink_to_fit();
+    return d_mesons;
+}
+
+std::vector<AliDHFeCorr::AliDMeson>
+AliAnalysisTaskDHFeCorr::FilterDmesons(const std::vector<AliDHFeCorr::AliDMeson> &dmeson_candidates,
+                                       const AliDHFeCorr::AliDMesonSelection &selectionDMeson, AliAODEvent *aod_event,
+                                       int pdg_dmeson) {
+
+    std::vector<AliDHFeCorr::AliDMeson> d_mesons;
+    d_mesons.reserve(dmeson_candidates.size());
+
+    for (const auto &candidate: dmeson_candidates) {
+        const auto d_candidate = candidate.fRecoObj;
+        
+        //Reject in case the pt is smalelr than the minimum fPtMin
+        if (candidate.fPt < selectionDMeson.fPtMin)
+            continue;
+
+        //Check if it is in fiducial acceptance
+        if (!selectionDMeson.fDMesonCuts->IsInFiducialAcceptance(d_candidate->Pt(), d_candidate->Y(pdg_dmeson)))
+            continue;
+
+        //Use PID only for values smaller than fPtMaxPID
+        Bool_t pid_configuration = selectionDMeson.fDMesonCuts->GetIsUsePID();
+        if (candidate.fPt > selectionDMeson.fPtMaxPID)
+            selectionDMeson.fDMesonCuts->SetUsePID(kFALSE);
+
+        auto selection_status = selectionDMeson.fDMesonCuts->IsSelected(d_candidate, AliRDHFCuts::kAll, aod_event);
+        
+        if (selection_status == AliAnalysisTaskDHFeCorr::kNotSelected)
+            continue;
+        
+        if (candidate.fIsParticleCandidate) {
+            if (selection_status == AliAnalysisTaskDHFeCorr::kAntiParticle)
+                continue;
+        }
+        else {
+            if (selection_status == AliAnalysisTaskDHFeCorr::kParticle)
+                continue;
+        }
+        
+        Int_t pid_selection_status = selectionDMeson.fDMesonCuts->IsSelected(d_candidate, AliRDHFCuts::kPID, aod_event);
+
+        AliDHFeCorr::AliDMeson cand(candidate);
+        cand.fSelectionStatusDefaultPID = pid_selection_status;
+        d_mesons.push_back(cand);
+
+        //return the PID selection to the original value
+        selectionDMeson.fDMesonCuts->SetUsePID(pid_configuration);
+    }
+    d_mesons.shrink_to_fit();
+
+    return d_mesons;
+}
+
+bool AliAnalysisTaskDHFeCorr::IsSelectedEvent(AliAODEvent *event, const AliDHFeCorr::AliEventSelection &selection) {
+    if (!event)
+        return false;
+    if ((fVtxZ < selection.fVertexZMin) || (fVtxZ > selection.fVertexZMax))
+        return false;
+
+    if (fCentrality < selection.fMultMin || fCentrality > selection.fMultMax)
+        return false;
+    
+    return true;
+}
+
+bool AliAnalysisTaskDHFeCorr::FulfilPixelSelection(const AliDHFeCorr::AliElectron &track, Int_t requirement) {
+    const bool hasHitFirstLayer = track.fITSHitFirstLayer;
+    const bool hasHitSecondLayer = track.fITSHitSecondLayer;
+
+    if ((hasHitFirstLayer || hasHitSecondLayer) && (requirement == kAny))
+        return kTRUE;
+    if (hasHitFirstLayer && hasHitSecondLayer && (requirement == kBoth))
+        return kTRUE;
+    if (hasHitFirstLayer && (requirement == kFirst))
+        return kTRUE;
+    if (hasHitSecondLayer && (requirement == kSecond))
+        return kTRUE;
+    if (!hasHitFirstLayer && !hasHitSecondLayer && (requirement == kNone))
+        return kTRUE;
+    if (!hasHitFirstLayer && hasHitSecondLayer && (requirement == kExclusiveSecond))
+        return kTRUE;
+    if (hasHitFirstLayer && !hasHitSecondLayer && (requirement == kExclusiveFirst))
+        return kTRUE;
+
+    return kFALSE;
+}
+
+AliAnalysisTaskDHFeCorr *AliAnalysisTaskDHFeCorr::AddTask(const std::string &name, const std::string &config_file) {
+    AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+    if (!mgr) {
+        std::cout << "It was not possible to connect to the AnalysisManager. Returning null pointer." << std::endl;
+        return nullptr;
+    }
+
+    if (!mgr->GetInputEventHandler()) {
+        std::cout << "It was not possible to connect to the InputEventHandler. Returning null pointer." << std::endl;
+        return nullptr;
+    }
+
+    auto *task = new AliAnalysisTaskDHFeCorr(name.c_str());
+    if (!task) {
+        std::cout << "Failed to create the task. Please check the results." << std::endl;
+        return nullptr;
+    }
+    //Configure the task
+    if (!task->Configure(config_file, name)) {
+        std::cout << "Failed to configure the task. Please check the config file and error above." << std::endl;
+        return nullptr;
+    }
+
+    task->SelectCollisionCandidates(AliVEvent::kINT7);
+
+    mgr->AddTask(task);
+
+    mgr->ConnectInput(task, 0, mgr->GetCommonInputContainer());
+
+    std::string fileName = static_cast<std::string>(AliAnalysisManager::GetCommonFileName());
+    fileName += ":DHFeCorrelation_" + name;
+
+    mgr->ConnectOutput(task, 1, mgr->CreateContainer("EventsQA", TList::Class(), AliAnalysisManager::kOutputContainer,
+                                                     fileName.c_str()));
+    mgr->ConnectOutput(task, 2, mgr->CreateContainer("ElectronQA", TList::Class(), AliAnalysisManager::kOutputContainer,
+                                                     fileName.c_str()));
+    mgr->ConnectOutput(task, 3, mgr->CreateContainer("DMesonQA", TList::Class(), AliAnalysisManager::kOutputContainer,
+                                                     fileName.c_str()));
+    mgr->ConnectOutput(task, 4,
+                       mgr->CreateContainer("ElectronTree", TTree::Class(), AliAnalysisManager::kOutputContainer,
+                                            fileName.c_str()));
+    mgr->ConnectOutput(task, 5, mgr->CreateContainer("DMesonTree", TTree::Class(), AliAnalysisManager::kOutputContainer,
+                                                     fileName.c_str()));
+
+    return task;
+}
+
+bool AliAnalysisTaskDHFeCorr::Configure(std::string config_file, std::string config_name, std::string default_file) {
+
+    //restart the configuration every time the function configure is called (for wagons on LEGO-Trains)
+    fYAMLConfig = PWG::Tools::AliYAMLConfiguration();
+
+    fYAMLConfig.AddConfiguration(default_file, "default_configuration");
+    // Will be checked first. This is so it can override values in the first added configuration.
+    fYAMLConfig.AddConfiguration(config_file, config_name);
+    //Read the global task settings
+    fYAMLConfig.GetProperty("mc_mode", fIsMC, true);
+    fYAMLConfig.GetProperty("calculate_only_efficiency", fIsEffMode, true);
+
+    std::string meson_species;
+    fYAMLConfig.GetProperty("d_meson_species", meson_species, true);
+    try {
+        fDmesonSpecies = fgkDMesonNames.at(meson_species);
+    }
+    catch (std::exception &exp) {
+        std::cout
+                << "The D meson chosen is not implemented. The following exception was raised:"
+                << exp.what() << std::endl;
+        return false;
+    }
+
+    if (!ConfigureEventSelection("event", fEventSelection))
+        return false;
+
+    if (!ConfigureElectrons("main_electron", fElectronRequirements))
+        return false;
+
+    if (!ConfigureElectrons("partner_electron", fPartnerElectronRequirements))
+        return false;
+
+    if (!ConfigureElectronOpt("electron_qa", fElectronOptConfig))
+        return false;
+
+    if (!ConfigureDMesons("D_meson", fDMesonRequirements))
+        return false;
+
+    if (!ConfigureDMesonOpt("d_meson_qa", fDMesonOptConfig))
+        return false;
+
+    fYAMLConfig.Initialize();
+
+    return true;
+}
+
+bool
+AliAnalysisTaskDHFeCorr::ConfigureEventSelection(const std::string &name,
+                                                 AliDHFeCorr::AliEventSelection &event_selection) {
+    std::cout << "Configuring event selection for: " << name << std::endl;
+
+    AliDHFeCorr::Utils::GetPropertyRange<Float_t>(fYAMLConfig, {name, "properties", "zvxt_range"},
+                                                  event_selection.fVertexZMin, event_selection.fVertexZMax, true);
+
+    fYAMLConfig.GetProperty({name, "multiplicity", "estimator"}, event_selection.fMultiEstimator, true);
+    auto valid_estimators = fgkMultiplicityEstimators;
+    if (std::find(valid_estimators.begin(), valid_estimators.end(), event_selection.fMultiEstimator) ==
+        valid_estimators.end()) {
+        std::cout
+                << "Check Config file. The multiplicity estimator is not a valid option in AliDHFeCorr::fgkMultiplicityEstimator"
+                << std::endl;
+        return false;
+    }
+
+    AliDHFeCorr::Utils::GetPropertyRange<Float_t>(fYAMLConfig, {name, "multiplicity", "multiplicity_range"},
+                                                  event_selection.fMultMin, event_selection.fMultMax, true);
+    return true;
+
+}
+
+bool
+AliAnalysisTaskDHFeCorr::ConfigureElectrons(const std::string &name,
+                                            AliDHFeCorr::AliElectronSelection &electron_selection) {
+    std::cout << "Configuring track and PID for: " << name << std::endl;
+
+    AliDHFeCorr::Utils::GetPropertyRange<Float_t>(fYAMLConfig, {name, "track", "pt_range"}, electron_selection.fPtMin,
+                                                  electron_selection.fPtMax, true);
+    AliDHFeCorr::Utils::GetPropertyRange<Float_t>(fYAMLConfig, {name, "track", "eta_range"}, electron_selection.fEtaMin,
+                                                  electron_selection.fEtaMax, true);
+
+    //filter_bit
+    std::string filter_bit;
+    if (!fYAMLConfig.GetProperty({name, "track", "filter_bit"}, filter_bit, false)) {
+        std::cout << "Check Config file. It is not possible to set filter_bit for electrons" << std::endl;
+        return false;
+    }
+
+    try {
+        electron_selection.fFilterBit = fgkAODFilterBitMap.at(filter_bit);
+    }
+    catch (std::exception &exp) {
+        std::cout
+                << "Problem to read 'filter_bit'. The following error was raised: " << exp.what() << std::endl;
+        return false;
+    }
+
+    //min_TPC_cls
+    fYAMLConfig.GetProperty({name, "track", "min_TPC_cls"}, electron_selection.fTPCClsMin, true);
+    //min_TPC_cls_dedx
+    fYAMLConfig.GetProperty({name, "track", "min_TPC_cls_dedx"}, electron_selection.fTPCClsDeDxMin, true);
+    //min_ITS_hits
+    fYAMLConfig.GetProperty({name, "track", "min_ITS_hits"}, electron_selection.fITSClsMin, true);
+
+    std::string pixel_req;
+    if (!fYAMLConfig.GetProperty({name, "track", "pixel_req"}, pixel_req, false)) {
+        std::cout << "Check Config file. It is not possible to set pixel_req for electrons" << std::endl;
+        return false;
+    }
+
+    try {
+        electron_selection.fITSPixel = fgkITSPixelMap.at(pixel_req);
+    }
+    catch (std::exception &exp) {
+        std::cout
+                << "Problem to read 'pixel_req'. The following error was raised: "
+                << exp.what() << std::endl;
+        return false;
+    }
+
+    fYAMLConfig.GetProperty({name, "track", "recalculate_dca"}, electron_selection.fRecalculateDCA, true);
+    fYAMLConfig.GetProperty({name, "track", "dca_z"}, electron_selection.fDCAz, true);
+    fYAMLConfig.GetProperty({name, "track", "dca_xy"}, electron_selection.fDCAxy, true);
+
+    //TPC_selection
+    AliDHFeCorr::Utils::GetPropertyRange<Float_t>(fYAMLConfig, {name, "PID", "TPC_selection"},
+                                                  electron_selection.fTPCNSigmaMin, electron_selection.fTPCNSigmaMax,
+                                                  true);
+
+    //TOF Selection
+    fYAMLConfig.GetProperty({name, "PID", "require_TOF"}, electron_selection.fRequireTOF, true);
+    AliDHFeCorr::Utils::GetPropertyRange<Float_t>(fYAMLConfig, {name, "PID", "TPC_selection"},
+                                                  electron_selection.fTOFNSigmaMin, electron_selection.fTOFNSigmaMax,
+                                                  true);
+    return true;
+}
+
+bool AliAnalysisTaskDHFeCorr::ConfigureDMesons(const std::string &name, AliDHFeCorr::AliDMesonSelection &opt_config) {
+    std::cout << "Configuring selection for: " << name << std::endl;
+
+    std::string fileName;
+    if (!fYAMLConfig.GetProperty({name, "selection", "cut_file"}, fileName, false)) {
+        std::cout << "Check Config file. It is not possible to set cut_file for D mesons." << std::endl;
+        return false;
+    }
+
+    auto fileDMeson = std::unique_ptr<TFile>{TFile::Open(fileName.c_str())};
+
+    std::string cut_name;
+    if (!fYAMLConfig.GetProperty({name, "selection", "cut_name"}, cut_name, false)) {
+        std::cout << "Check Config file. It is not possible to set cut_name for D mesons." << std::endl;
+        return false;
+    }
+
+    if (fileDMeson->Get(cut_name.c_str())) {
+        auto cuts = dynamic_cast<AliRDHFCuts *>((fileDMeson->Get(cut_name.c_str())));
+        opt_config.fDMesonCuts = std::unique_ptr<AliRDHFCuts>(cuts);
+        cuts->SaveAs(("Cuts_"+std::string(this->GetName())+".root").c_str());
+    } else {
+        std::cout << "Check Config file. It is not possible to set the cuts for D mesons." << std::endl;
+        return false;
+    }
+
+    fYAMLConfig.GetProperty({name, "selection", "min_pt"}, opt_config.fPtMin, true);
+    fYAMLConfig.GetProperty({name, "selection", "max_pt_pid"}, opt_config.fPtMaxPID, true);
+
+    return true;
+}
+
+bool
+AliAnalysisTaskDHFeCorr::ConfigureElectronOpt(const std::string &name, AliDHFeCorr::AliConfigureElectronOpt &opt_config,
+                                              const std::string &base) {
+    std::cout << "Configuring opt for: " << name << std::endl;
+    fYAMLConfig.GetProperty({base, name, "pt_bins"}, opt_config.fPtBins, true);
+    fYAMLConfig.GetProperty({base, name, "p_bins"}, opt_config.fPBins, true);
+    fYAMLConfig.GetProperty({base, name, "n_eta_bins"}, opt_config.fNBinsEta, true);
+    fYAMLConfig.GetProperty({base, name, "n_phi_bins"}, opt_config.fNBinsPhi, true);
+    fYAMLConfig.GetProperty({base, name, "n_bins_TPC_cls"}, opt_config.fNBinsTPCCls, true);
+    fYAMLConfig.GetProperty({base, name, "n_bins_n_sigma"}, opt_config.fNBinsNsigma, true);
+    return true;
+}
+
+bool AliAnalysisTaskDHFeCorr::ConfigureDMesonOpt(const std::string &name,
+                                                 AliDHFeCorr::AliConfigureDMesonOpt &opt_config,
+                                                 const std::string &base) {
+    std::cout << "Configuring opt for: " << name << std::endl;
+    AliDHFeCorr::Utils::GetPropertyRange<Float_t>(fYAMLConfig, {base, name, "inv_mass_range"}, opt_config.fInvMassMin,
+                                                  opt_config.fInvMassMax, true);
+    fYAMLConfig.GetProperty({base, name, "pt_bins"}, opt_config.fPtBins, true);
+    fYAMLConfig.GetProperty({base, name, "n_bins_inv_mass"}, opt_config.fNBinsInvMass, true);
+    fYAMLConfig.GetProperty({base, name, "n_eta_bins"}, opt_config.fNBinsEta, true);
+    fYAMLConfig.GetProperty({base, name, "n_phi_bins"}, opt_config.fNBinsPhi, true);
+    return true;
+
+}
+
+void AliAnalysisTaskDHFeCorr::Terminate(Option_t *) {}
+
+AliDHFeCorr::AliEventQAHistograms AliAnalysisTaskDHFeCorr::CreateQAEvents(const std::string &stage, TList &opt_list) {
+    AliDHFeCorr::AliEventQAHistograms qa_hists;
+
+    qa_hists.fNEvents = std::unique_ptr<TH1F>(new TH1F((std::string("NEvents_") + stage).c_str(),
+                                                       (std::string("NEvents_") + stage).c_str(),
+                                                       10, 0., 10.));
+    qa_hists.fVertexZ = std::unique_ptr<TH1F>(new TH1F((std::string("VertexZ_") + stage).c_str(),
+                                                       (std::string("VertexZ_") + stage).c_str(),
+                                                       120, -15., 15.));
+    qa_hists.fCentrality = std::unique_ptr<TH1F>(new TH1F((std::string("Centrality_") + stage).c_str(),
+                                                          (std::string("Centrality_") + stage).c_str(),
+                                                          120, -10, 110));
+
+    opt_list.Add(qa_hists.fNEvents.get());
+    opt_list.Add(qa_hists.fVertexZ.get());
+    opt_list.Add(qa_hists.fCentrality.get());
+
+    return qa_hists;
+}
+
+AliDHFeCorr::AliDMesonQAHistos
+AliAnalysisTaskDHFeCorr::CreateQADMeson(AliDHFeCorr::AliConfigureDMesonOpt config, const std::string &type_particle,
+                                        const std::string &stage, TList &opt_list) {
+    AliDHFeCorr::AliDMesonQAHistos qa_hists;
+
+    std::vector<Float_t> phi_bins = MakeBins(0.0, 2 * TMath::Pi(), config.fNBinsPhi);
+    std::vector<Float_t> eta_bins = MakeBins(-0.8, 0.8, config.fNBinsEta);
+
+    qa_hists.fPtEtaPhi = std::unique_ptr<TH3F>(new TH3F((type_particle + "_PtEtaPhi_" + stage).c_str(),
+                                  (type_particle + "_PtEtaPhi_" + stage + ";p_{T};#eta;#varphi").c_str(),
+                                  config.fPtBins.size() - 1, &config.fPtBins[0], config.fNBinsEta, &eta_bins[0],
+                                  config.fNBinsPhi, &phi_bins[0]));
+
+    std::vector<Float_t> inv_mass_bins = MakeBins(config.fInvMassMin, config.fInvMassMax,
+                                                                      config.fNBinsInvMass);
+
+    qa_hists.fPtInvMass = std::unique_ptr<TH2F> (new TH2F((type_particle + "_PtInvMass_" + stage).c_str(),
+                                   (type_particle + "_PtInvMass_" + stage + ";p_{T};mass").c_str(),
+                                   config.fPtBins.size() - 1, &config.fPtBins[0], config.fNBinsInvMass,
+                                   &inv_mass_bins[0]));
+
+    opt_list.Add(qa_hists.fPtEtaPhi.get());
+    opt_list.Add(qa_hists.fPtInvMass.get());
+
+    return qa_hists;
+}
+
+AliDHFeCorr::AliElectronQAHistograms AliAnalysisTaskDHFeCorr::CreateQAElectrons(
+        AliDHFeCorr::AliConfigureElectronOpt config, const std::string &type_particle, const std::string &stage,
+        TList &opt_list) {
+
+    AliDHFeCorr::AliElectronQAHistograms qa_hists;
+
+    std::vector<Float_t> phi_bins = MakeBins(0.0, 2 * TMath::Pi(), config.fNBinsPhi);
+    std::vector<Float_t> eta_bins = MakeBins(-0.8, 0.8, config.fNBinsEta);
+
+    qa_hists.fPtEtaPhi = std::unique_ptr<TH3F>(new TH3F((type_particle + "_PtEtaPhi_" + stage).c_str(),
+                                  (type_particle + "_PtEtaPhi_" + stage + ";p_{T};#eta;#varphi").c_str(),
+                                  config.fPtBins.size() - 1, &config.fPtBins[0], config.fNBinsEta, &eta_bins[0],
+                                  config.fNBinsPhi, &phi_bins[0]));
+
+    qa_hists.fTPCNCls = std::unique_ptr<TH1F>(new TH1F((type_particle + "_TPCNCls_" + stage).c_str(),
+                                 (type_particle + "_TPCNCls_" + stage + ";N cluster TPC").c_str(),
+                                 config.fNBinsTPCCls, 0, 160));
+
+    qa_hists.fTPCNClsDeDx = std::unique_ptr<TH1F>(new TH1F((type_particle + "_TPCNClsDeDx_" + stage).c_str(),
+                                     (type_particle + "_TPCNClsDeDx_" + stage + ";N cluster TPC dE/dx").c_str(),
+                                     config.fNBinsTPCCls, 0, 160));
+
+    qa_hists.fITSCls = std::unique_ptr<TH1F>(new TH1F((type_particle + "_ITSCls_" + stage).c_str(),
+                                (type_particle + "_ITSCls_" + stage + ";N ITS Cls").c_str(), 7, 0, 7));
+
+    qa_hists.fDCAz = std::unique_ptr<TH1F>(new TH1F((type_particle + "_DCAz_" + stage).c_str(),
+                              (type_particle + "_DCAz_" + stage + ";DCA z").c_str(), 25, 0, 5));
+                                           
+
+    qa_hists.fDCAxy = std::unique_ptr<TH1F>(new TH1F((type_particle + "_DCAxy_" + stage).c_str(),
+                               (type_particle + "_DCAxy_" + stage = "; DCA xy").c_str(), 25, 0, 5));
+
+    std::vector<Float_t> n_sigma_bins = MakeBins(-10, 10, config.fNBinsNsigma);
+                                            
+    qa_hists.fTPCNsigmaPt = std::unique_ptr<TH2F>(new TH2F((type_particle + "_TPCNsigmaPt_" + stage).c_str(),
+                                     (type_particle + "_fTPCNsigmaPt_" + stage + ";p_{T};N#sigma TPC").c_str(),
+                                     config.fPtBins.size() - 1, &config.fPtBins[0], config.fNBinsNsigma,
+                                     &n_sigma_bins[0]));
+
+    qa_hists.fTPCNsigmaP = std::unique_ptr<TH2F>(new TH2F((type_particle + "_TPCNsigmaPt_" + stage).c_str(),
+                                    (type_particle + "_fTPCNsigmaPt_" + stage + ";p;N#sigma TPC").c_str(),
+                                    config.fPBins.size() - 1, &config.fPBins[0], config.fNBinsNsigma, &n_sigma_bins[0]));
+
+    qa_hists.fTOFNsigmaPt = std::unique_ptr<TH2F>(new TH2F((type_particle + "_TOFNsigmaPt_" + stage).c_str(),
+                                     (type_particle + "_TOFNsigmaPt_" + stage + ";p_{T};N#sigma TOF").c_str(),
+                                     config.fPBins.size() - 1, &config.fPBins[0], config.fNBinsNsigma,
+                                     &n_sigma_bins[0]));
+
+    qa_hists.fTOFNsigmaP = std::unique_ptr<TH2F>(new TH2F((type_particle + "_TOFNsigmaP_" + stage).c_str(),
+                                    (type_particle + "_TOFNsigmaP_" + stage + ";p;N#sigma TOF").c_str(),
+                                    config.fPBins.size() - 1, &config.fPBins[0], config.fNBinsNsigma, &n_sigma_bins[0]));
+
+    qa_hists.fTPCTOFNSigma = std::unique_ptr<TH2F>(new TH2F((type_particle + "_TPCTOFNSigma_" + stage).c_str(),
+                                      (type_particle + "_TPCTOFNSigma_" + stage + ";N#sigma TPC;N#sigma TOF").c_str(),
+                                      config.fNBinsNsigma, &n_sigma_bins[0], config.fNBinsNsigma, &n_sigma_bins[0]));
+
+    //Add all the histograms to the opt list
+    opt_list.Add(qa_hists.fPtEtaPhi.get());
+    opt_list.Add(qa_hists.fTPCNCls.get());
+    opt_list.Add(qa_hists.fITSCls.get());
+    opt_list.Add(qa_hists.fTPCNClsDeDx.get());
+    opt_list.Add(qa_hists.fDCAz.get());
+    opt_list.Add(qa_hists.fDCAxy.get());
+    opt_list.Add(qa_hists.fTPCNsigmaPt.get());
+    opt_list.Add(qa_hists.fTPCNsigmaP.get());
+    opt_list.Add(qa_hists.fTOFNsigmaPt.get());
+    opt_list.Add(qa_hists.fTOFNsigmaP.get());
+    opt_list.Add(qa_hists.fTPCTOFNSigma.get());
+
+    return qa_hists;
+}
+
+float AliAnalysisTaskDHFeCorr::GetMaxd0MeasMinusExp(AliAODRecoDecayHF *candidate, float b_field) {
+    float d_d0_max = 0;
+    auto n_prongs_candidate = static_cast<unsigned int>(candidate->GetNProngs());
+
+    for (unsigned int i = 0; i < n_prongs_candidate; i++) {
+        double d0_diff, error_d0_diff;
+        candidate->Getd0MeasMinusExpProng(i, b_field, d0_diff, error_d0_diff);
+        float norm_dd0 = d0_diff / error_d0_diff;
+        if (i == 0)
+            d_d0_max = norm_dd0;
+        else if (TMath::Abs(norm_dd0) > TMath::Abs(d_d0_max))
+            d_d0_max = norm_dd0;
+    }
+    return d_d0_max;
+}
+

--- a/PWGHF/correlationHF/AliAnalysisTaskDHFeCorr.h
+++ b/PWGHF/correlationHF/AliAnalysisTaskDHFeCorr.h
@@ -405,8 +405,7 @@ public:
     const std::vector<std::string> fgkMultiplicityEstimators = {"ZNA", "V0A"}; ////< Multiplicity estimator supported
 
     bool Configure(std::string config_file, std::string config_name = "custom_config",
-                   //std::string default_file = "$ALICE_PHYSICS/PWGHF/correlationHF/macros/default_config_d_hfe.yaml");
-                   std::string default_file = "default_config_d_hfe.yaml");
+                   std::string default_file = "$ALICE_PHYSICS/PWGHF/correlationHF/macros/default_config_d_hfe.yaml");
 
 private:
     TList fOptEvent; ///< List with histograms from the event QA

--- a/PWGHF/correlationHF/AliAnalysisTaskDHFeCorr.h
+++ b/PWGHF/correlationHF/AliAnalysisTaskDHFeCorr.h
@@ -1,0 +1,535 @@
+/* *
+ * \class AliAnalysisTaskDHFeCorr
+ *
+ * \brief D meson - heavy-flavour electron correlations
+ *
+ * This class performs the data filtering for the D meson - HFe correlations.
+ * The task provides the same interface to analyse D0 mesons and D+. The D* is planned to be implemented.
+ * The electrons are identified and only events with electrons are saved. The non-HF identification is also performed
+ * in this task.
+ *
+ * The configuration is done using a yaml file. The following parameters can be adjusted:
+ *
+ * -# Event selection: corresponds to the yaml parameter 'event'. All the selected events use the trigger kINT7 for
+ * the moment.
+ *   - Vertex Z: corresponds to the yaml parameter 'zvxt_range'. The value should of the format [min,max].
+ *   - Multiplicity: corresponds to the yaml parameters 'estimator' and 'multiplicity_range'. The value of 'estimator'
+ *   should be also defined added to AliAnalysisTaskDHFeCorr::fgkMultiplicityEstimators. The values allowed are set
+ *   using 'multiplicity_range' in the format [min,max].
+ *
+ * -# D-meson selection: corresponds to the yaml parameter 'D_meson' and the sub parameter 'selection'. The cuts are
+ * implemented in the standard D-meson selection framework, with the AliRDHFCuts as the base class.
+ *   - Root file containing the cuts: should be specified in the field 'cut_file'. The name of the object that has the
+ *   cuts should be provided in 'cut_name'.
+ *   - Minimum transverse momentum: the task rejects low momentum D mesons to reduce the size of the output. Please set
+ *   it with 'min_pt'.
+ *   - Maximum transverse momentum used for particle identification: particle identification (PID) is used to reduce
+ *   the size of the output. The 'max_pt_pid' value can be used to set the maximum value which PID will be used. You can
+ *   set the PID selection as usual in the cut file and it will be ignored for pT > max_pt_pid.
+ *
+ * -# Electron selection is divided in 'main' electrons, the electrons which will be used to the correlation, and partner
+ * electrons, which will are the ones used to identify non-HF electrons. The partner electrons usually have looser cuts
+ * to achieve a high non-HF tagging efficiency. They are defined in the yaml file as 'main_electron' and
+ * 'partner_electron'. The selection for both of them share the same parameters. They are:
+ *   - Tracking, under 'track' sub parameter
+ *     - Transverse momentum range: set 'pt_range' with [min, max]
+ *     - Eta: set 'eta_range' with [min, max]
+ *     - AOD filter bit: set with 'filter_bit'. the supported type should cover any declared with AliAODTrack and
+ *     it should be also declared one of the types declared in fgkAODFilterBitMap
+ *     - Minimum number of cluster in the TPC: set with 'min_TPC_cls'
+ *     - Minimum number of cluster in the TPC used for the calculation of the dE/dx: set with 'min_TPC_cls_dedx'
+ *     - Minimum number of clusters in the ITS: set with 'min_ITS_hits'
+ *     - Requirement in the ITS SPD: set with 'pixel_req'. Possible values can be found at
+ *     AliAnalysisTaskDHFeCorr::ITSPixel_t
+ *     - The DCA to the primary vertex can be recalculated (needed if a cut on the DCA is applied) by setting
+ *     'recalculate_dca' to true. The DCA maximum values can be set using 'dca_z' and 'dca_xy'
+ *   - Particle identification, under 'PID' sub parameter
+ *     - TPC N sigma selection: set the maximun and minimum with 'TPC_selection'
+ *     - TOF N sigma selection: set the maximun and minimum with 'TOF_selection'. It can be turned on and off by
+ *     'require_TOF'.
+ */
+#ifndef AliAnalysisTaskDHFeCorr_H
+#define AliAnalysisTaskDHFeCorr_H
+
+//ROOT includes
+#include "TTree.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TH3F.h"
+
+//AliROOT includes
+#include "AliAnalysisTaskSE.h"
+#include "AliAODTrack.h"
+#include "AliPID.h"
+
+//AliPhysics includes
+#include "AliYAMLConfiguration.h"
+#include "AliRDHFCuts.h"
+#include "AliAODRecoDecayHF.h"
+
+class TClonesArray;
+#include <vector>
+#include <memory>
+#include <string>
+
+
+namespace AliDHFeCorr {
+    //structure to hold the D meson or electron during the selection process in the task
+    typedef struct AliDMeson {
+        AliAODRecoDecayHF *fRecoObj{nullptr};
+        Int_t fGridPID{0}; ///<PID of the grid job used to create the tree
+        Int_t fEventNumber{0}; ///< Number of the event
+        UInt_t fID; ///< D meson id in the event
+        Bool_t fIsParticleCandidate{kFALSE}; ///< Particle hypotheses at reconstruction level
+        
+        //Basic Information
+        Float_t fPt{-999.};
+        Float_t fEta{-999.};
+        Float_t fPhi{-999.};
+        Float_t fY{-999.};
+        Float_t fInvMass{0.};
+        Float_t fReducedChi2{-999.};
+        
+        //Topologic information
+        Float_t fDecayLength{-999.};
+        Float_t fDecayLengthXY{-999.};
+        
+        Float_t fNormDecayLength{-999.};
+        Float_t fNormDecayLengthXY{-999.};
+        
+        Float_t fCosP{-999.};
+        Float_t fCosPXY{-999.};
+        
+        Float_t fImpParXY{-999.};
+        Float_t fDCA{-999.};
+        
+        //D0 and D+, D*+ shared information
+        Float_t fNormd0MeasMinusExp{-999.};
+        UChar_t fSelectionStatusDefaultPID{99}; ///< Default PID selection status
+        
+        //D0 information (also used by the D*, since it has a D0)
+        Float_t fCosTs{-999.};
+        
+        //D+ information
+        Float_t fSigmaVertex{-999.};
+        
+        //D* information
+        Float_t fAngleD0dkpPisoft{-999.};
+        
+        //Single-track information
+        std::vector<Float_t> fPtDaughters;
+        std::vector<Float_t> fD0Daughters;
+        
+        std::vector<Float_t> fNSigmaTPCDaughters; ///< The PID response (n sigma)
+        std::vector<Float_t> fNSigmaTOFDaughters; ///< The PID response (n sigma)
+
+        //MC Level information
+        Float_t fPtMC{-999.};///< Transverse momentum (MC information)
+        Bool_t fIsD{kFALSE}; // Is it signal or background? (MC information)
+        Bool_t fIsParticle{kFALSE}; //is it a D0 or D0bar? (MC information)
+        Bool_t fIsPrompt{kFALSE}; // Does it comes from charm? (MC information)
+    } AliDMeson;
+
+    typedef struct AliElectron {
+    public:
+        AliAODTrack *fTrack{nullptr};
+        
+        UInt_t fGridPID{0};
+        UInt_t fEventNumber{0};
+        Float_t fCentrality;
+        Float_t fVtxZ;
+        
+        Char_t fCharge{0};
+        Float_t fPt{-999.};
+        Float_t fP{-999.};
+        Float_t fEta{-999.};
+        Float_t fPhi{-999.};
+        
+        UShort_t fNClsTPC{999};
+        UShort_t fNClsTPCDeDx{999};
+        UChar_t fNITSCls{99};
+        
+        Bool_t fITSHitFirstLayer{kFALSE};
+        Bool_t fITSHitSecondLayer{kFALSE};
+        Float_t fDCAxy{-999.};
+        Float_t fDCAz{-999.};
+        
+        Float_t fTPCNSigma{-999.};
+        Float_t fTOFNSigma{-999.};
+        
+        std::vector<Float_t> fInvMassPartnersULS; //mass of the ULS partners
+        std::vector<Float_t> fInvMassPartnersLS; //mass of the LS partners
+        std::vector<UInt_t> fPartnersULSID; //unique ID of the ULS partners
+        std::vector<UInt_t> fPartnersLSID; //unique ID of the LS partners
+        
+        //MC information
+        Float_t fPtMC{-999.};
+        Float_t fPhiMC{-999.};
+        Float_t fEtaMC{-999.};
+        Char_t fOrigin{0}; // track origin from AliVertexingHFUtils::CheckOrigin
+        Int_t fPDG{0};
+        
+        Int_t fFirstMotherPDG{0};
+        Float_t fFirstMotherPt{-999.};
+        
+        Int_t fSecondMotherPDG{0};
+        Float_t fSecondMotherPt{-999.};
+        
+    } AliElectron;
+    
+    //Structs to hold the selection values ("cuts")
+    typedef struct AliEventSelection {
+        Float_t fVertexZMin{-10.};
+        Float_t fVertexZMax{10.};
+
+        Float_t fMultMin{0.};
+        Float_t fMultMax{101.};
+        std::string fMultiEstimator = "ZNA";
+    } AliEventSelection;
+
+    typedef struct AliElectronSelection {
+        //Track selection
+        Float_t fPtMin{-999.};
+        Float_t fPtMax{999.};
+        Float_t fEtaMin{-1.};
+        Float_t fEtaMax{1.};
+
+        AliAODTrack::AODTrkFilterBits_t fFilterBit{AliAODTrack::kTrkGlobalNoDCA};
+
+        Int_t fTPCClsMin{0};
+        Int_t fTPCClsDeDxMin{0};
+        Int_t fITSClsMin{0};
+
+        Int_t fITSPixel{0};
+
+        Bool_t fRecalculateDCA{kTRUE};
+        Float_t fDCAz{999.};
+        Float_t fDCAxy{999.};
+
+        //PID selection
+        Bool_t fRequireTOF{kFALSE};
+        Float_t fTOFNSigmaMin{-3.};
+        Float_t fTOFNSigmaMax{3.};
+
+        Float_t fTPCNSigmaMin{-1};
+        Float_t fTPCNSigmaMax{3.};
+    } AliElectronSelection;
+
+    typedef struct AliPhotonSelection {
+        Float_t fInvMassMax{0.3};
+        Float_t fReducedChi2Max{3.};
+    } AliPhotonSelection;
+
+    typedef struct AliDMesonSelection {
+        std::unique_ptr<AliRDHFCuts> fDMesonCuts;
+        Float_t fPtMin{-999.};
+        Float_t fPtMaxPID{999.};
+    } AliDMesonSelection;
+
+    //Structs to hold QA plots
+    typedef struct AliEventQAHistograms {
+        std::unique_ptr<TH1F> fNEvents;
+        std::unique_ptr<TH1F> fVertexZ;
+        std::unique_ptr<TH1F> fCentrality;
+
+    } AliEventQAHistograms;
+
+    typedef struct AliElectronQAHistograms {
+        //Tracking
+        std::unique_ptr<TH3F> fPtEtaPhi;
+        std::unique_ptr<TH1F> fTPCNCls;
+        std::unique_ptr<TH1F> fTPCNClsDeDx;
+        std::unique_ptr<TH1F> fITSCls;
+        std::unique_ptr<TH1F> fDCAz;
+        std::unique_ptr<TH1F> fDCAxy;
+
+        //PID
+        std::unique_ptr<TH2F> fTPCNsigmaPt;
+        std::unique_ptr<TH2F> fTPCNsigmaP;
+        std::unique_ptr<TH2F> fTOFNsigmaPt;
+        std::unique_ptr<TH2F> fTOFNsigmaP;
+
+        std::unique_ptr<TH2F> fTPCTOFNSigma;
+    } AliElectronQAHistograms;
+
+    typedef struct AliDMesonQAHistos {
+        std::unique_ptr<TH3F> fPtEtaPhi;
+        std::unique_ptr<TH2F> fPtInvMass;
+    } AliDMesonQAHistos;
+
+    //Structs to hold configurations for output
+    typedef struct AliConfigureElectronOpt {
+        std::vector<Float_t> fPtBins;
+        std::vector<Float_t> fPBins;
+
+        Int_t fNBinsEta{20};
+        Int_t fNBinsPhi{40};
+        Int_t fNBinsTPCCls{160};
+        Int_t fNBinsNsigma{100};
+    } AliConfigureElectronOpt;
+
+    typedef struct AliConfigureDMesonOpt {
+        std::vector<Float_t> fPtBins;
+        Float_t fInvMassMin;
+        Float_t fInvMassMax;
+        Int_t fNBinsInvMass;
+
+        Int_t fNBinsPhi;
+        Int_t fNBinsEta;
+    } AliConfigureDMesonOpt;
+
+    namespace Utils {
+        template<typename T>
+        bool GetPropertyRange(const PWG::Tools::AliYAMLConfiguration &yaml_config,
+                              const std::vector<std::string> property_path, T &property_min, T &property_max,
+                              const bool required_property) {
+
+            std::vector<T> range;
+
+            if (!yaml_config.GetProperty(property_path, range, required_property)) {
+                std::cout << "Check Config file. It is not possible to set " << property_path[property_path.size() - 1]
+                          << std::endl;
+                return false;
+            }
+
+            try {
+                property_min = range[0];
+                property_max = range[1];
+            }
+            catch (std::exception &exp) {
+                std::cout << "Problem to read the " << property_path[property_path.size() - 1]
+                          << "variable. The following error was raised: " << exp.what() << std::endl;
+                return false;
+            }
+            return true;
+        }
+    }
+}
+
+class AliAnalysisTaskDHFeCorr : public AliAnalysisTaskSE {
+public:
+    AliAnalysisTaskDHFeCorr();
+
+    //D-meson species
+    typedef enum {
+        kD0, //D0
+        kDplus, // D+
+        kDstar //D*
+    } DMeson_t; ///< Basic type used to identify the D mesons
+    
+    typedef enum {
+        kNotSelected = 0,
+        kParticle = 1,
+        kAntiParticle = 2,
+        kAmbiguous = 3 //Selected for both
+    } SelectionStatus_t;
+
+    //Electron ITS pixels
+    typedef enum {
+        kFirst = 0, //at least one on first
+        kSecond = 1, // at least one on second
+        kBoth = 2,
+        kNone = 3,
+        kAny = 4, //have at least one hit on layer 1 or 2
+        kExclusiveSecond = 5, // only on layer 2
+        kExclusiveFirst = 6 // only on layer 1
+    } ITSPixel_t;
+    
+    explicit AliAnalysisTaskDHFeCorr(const char *name);
+
+    virtual ~AliAnalysisTaskDHFeCorr() = default;
+
+    static AliAnalysisTaskDHFeCorr *AddTask(const std::string &name = "DHFeCorrelation",
+                                            const std::string &config_file = "$ALICE_PHYSICS/PWGHF/correlationHF/macros/default_config_d_hfe.yaml");
+
+    virtual void UserCreateOutputObjects();
+
+    virtual void UserExec(Option_t *option);
+
+    virtual void Terminate(Option_t *option);
+
+    //D-meson information
+    const std::map<std::string, DMeson_t> fgkDMesonNames{
+            {"D0",    AliAnalysisTaskDHFeCorr::kD0},
+            {"Dplus", AliAnalysisTaskDHFeCorr::kDplus},
+            {"Dstar", AliAnalysisTaskDHFeCorr::kDstar}
+    }; ///< D meson names
+
+    const std::map<DMeson_t, std::string> fgkDMesonListName{
+            {AliAnalysisTaskDHFeCorr::kD0,    "D0toKpi"},
+            {AliAnalysisTaskDHFeCorr::kDplus, "Charm3Prong"},
+            {AliAnalysisTaskDHFeCorr::kDstar, "Dstar"}
+    }; ///< Name of the list (TClonesArray*) containing the pre-filtered mesons
+
+    const std::map<DMeson_t, Int_t> fgkDMesonPDG{
+            {AliAnalysisTaskDHFeCorr::kD0,    421},
+            {AliAnalysisTaskDHFeCorr::kDplus, 411},
+            {AliAnalysisTaskDHFeCorr::kDstar, 413}
+    };///< PDG number of each meson
+
+    const std::map<DMeson_t, std::vector<Int_t>> fgkDMesonDaughterPDG{
+            {AliAnalysisTaskDHFeCorr::kD0,    {211, 321}},
+            {AliAnalysisTaskDHFeCorr::kDplus, {321, 211, 211}},
+            {AliAnalysisTaskDHFeCorr::kDstar, {321, 321, 211}}
+    }; ////< PDG of the D-meson daughters
+
+    //Electron information
+    const std::map<std::string, AliAODTrack::AODTrkFilterBits_t> fgkAODFilterBitMap = {
+            {"kTrkTPCOnly",            AliAODTrack::kTrkTPCOnly},
+            {"kTrkITSsa",              AliAODTrack::kTrkITSsa},
+            {"kTrkITSConstrained",     AliAODTrack::kTrkITSConstrained},
+            {"kTrkElectronsPID",       AliAODTrack::kTrkElectronsPID},
+            {"kTrkGlobalNoDCA",        AliAODTrack::kTrkGlobalNoDCA},
+            {"kTrkGlobal",             AliAODTrack::kTrkGlobal},
+            {"kTrkGlobalSDD",          AliAODTrack::kTrkGlobalSDD},
+            {"kTrkTPCOnlyConstrained", AliAODTrack::kTrkTPCOnlyConstrained}
+    }; ///< AOD filter bits supported
+
+    const std::map<std::string, ITSPixel_t> fgkITSPixelMap = {
+            {"kFirst",           AliAnalysisTaskDHFeCorr::kFirst},
+            {"kSecond",          AliAnalysisTaskDHFeCorr::kSecond},
+            {"kBoth",            AliAnalysisTaskDHFeCorr::kBoth},
+            {"kNone",            AliAnalysisTaskDHFeCorr::kNone},
+            {"kAny",             AliAnalysisTaskDHFeCorr::kAny},
+            {"kExclusiveSecond", AliAnalysisTaskDHFeCorr::kExclusiveSecond},
+            {"kExclusiveFirst",  AliAnalysisTaskDHFeCorr::kExclusiveFirst}
+    }; ///< ITS pixel 
+
+    const std::map<DMeson_t, std::vector<AliPID::EParticleType> > fgkDMesonDaughterAliPID = {
+            {AliAnalysisTaskDHFeCorr::kD0,    {AliPID::kPion, AliPID::kKaon}},
+            {AliAnalysisTaskDHFeCorr::kDplus, {AliPID::kPion, AliPID::kKaon, AliPID::kPion}},
+            {AliAnalysisTaskDHFeCorr::kDstar, {AliPID::kPion, AliPID::kKaon, AliPID::kPion}}
+    };
+
+    //Event information
+    const std::vector<std::string> fgkMultiplicityEstimators = {"ZNA", "V0A"}; ////< Multiplicity estimator supported
+
+    bool Configure(std::string config_file, std::string config_name = "custom_config",
+                   //std::string default_file = "$ALICE_PHYSICS/PWGHF/correlationHF/macros/default_config_d_hfe.yaml");
+                   std::string default_file = "default_config_d_hfe.yaml");
+
+private:
+    TList fOptEvent; ///< List with histograms from the event QA
+    TList fOptElectron; ///< List with with histograms from the electron QA
+    TList fOptDMeson; ///< List with with histograms from the D meson QA
+
+    std::unique_ptr<TTree> fElectronTree; ///< Tree with the electron information
+    std::unique_ptr<TTree> fDmesonTree; ///< Tree with the D meson information
+
+    ULong_t fGridPID{0}; ///< ID of the process on GRID
+    ULong_t fEventNumber{0}; ///< Unique number for each event
+    Float_t fVtxZ{-999.}; ///< Vertex Z
+    Float_t fCentrality{-1.}; ///< Centrality
+
+    AliDHFeCorr::AliElectron fElectron; ///< Electron information that will be used in the fElectronTree
+    AliDHFeCorr::AliDMeson fDmeson;///< D meson information that will be used in the fDmesonTree
+
+    bool fIsMC{false}; //<<Flag for MC analysis
+    bool fIsEffMode{false}; //<<Fills only the trees with true D mesons and electrons. No correlation analysis.
+    DMeson_t fDmesonSpecies{kD0}; ///< The D meson species (D0, D+ or D*)
+
+    //YAML configuration
+    PWG::Tools::AliYAMLConfiguration fYAMLConfig; //<< YAML config object, used to set the parameters of the task
+
+    bool ConfigureEventSelection(const std::string &name, AliDHFeCorr::AliEventSelection &event_selection);
+    bool ConfigureElectrons(const std::string &name, AliDHFeCorr::AliElectronSelection &electron_selection);
+    bool ConfigureElectronOpt(const std::string &name, AliDHFeCorr::AliConfigureElectronOpt &opt_config,
+                              const std::string &base = "output");
+    bool ConfigureDMesonOpt(const std::string &name, AliDHFeCorr::AliConfigureDMesonOpt &opt_config,
+                            const std::string &base = "output");
+    bool ConfigureDMesons(const std::string &name, AliDHFeCorr::AliDMesonSelection &opt_config);
+    
+    void CheckConfiguration() const;
+    
+    void AddElectronVariables(std::unique_ptr<TTree> &tree);
+    void AddDMesonVariables(std::unique_ptr<TTree> &tree, DMeson_t meson_species);
+    void AddElectronMCVariables(std::unique_ptr<TTree> &tree);
+    void AddDMesonMCVariables(std::unique_ptr<TTree> &tree);
+
+    AliDHFeCorr::AliEventSelection fEventSelection; ///<< Event selection configuration
+    
+    AliDHFeCorr::AliElectronSelection fElectronRequirements; ///<< Electron selection configuration
+    AliDHFeCorr::AliElectronSelection fPartnerElectronRequirements; ///<< Partner selection configuration
+    AliDHFeCorr::AliConfigureElectronOpt fElectronOptConfig; ///<< Electron output (histograms) configuration
+
+    AliDHFeCorr::AliPhotonSelection fPhotonSelection; //<< Photon (electron pair) selection configuration
+
+    AliDHFeCorr::AliDMesonSelection fDMesonRequirements; ///<< Electron selection configuration 
+    AliDHFeCorr::AliConfigureDMesonOpt fDMesonOptConfig; ///<< Electron output (histograms) configuration
+
+    //QA histograms
+    AliDHFeCorr::AliEventQAHistograms fEventQABeforeCuts; //! QA histograms for events before the selection
+    AliDHFeCorr::AliEventQAHistograms fEventQAAfterCuts; //! QA histograms for events after the selection
+
+    AliDHFeCorr::AliElectronQAHistograms fElectronQABeforeCuts; //! QA histograms for electrons before the selection
+    AliDHFeCorr::AliElectronQAHistograms fElectronQAAfterCuts;  //! QA histograms for electrons after the selection
+
+    AliDHFeCorr::AliDMesonQAHistos fDMesonQABeforeCuts; //! QA histograms for D mesons before the selection
+    AliDHFeCorr::AliDMesonQAHistos fDMesonQAAfterCuts;  //! QA histograms for D mesons before the selection
+
+    //Functions for the QA
+    static AliDHFeCorr::AliEventQAHistograms CreateQAEvents(const std::string &stage, TList &opt_list);
+
+    static AliDHFeCorr::AliElectronQAHistograms CreateQAElectrons(AliDHFeCorr::AliConfigureElectronOpt config,
+                                                                  const std::string &type_particle,
+                                                                  const std::string &stage, TList &opt_list);
+
+    static AliDHFeCorr::AliDMesonQAHistos
+    CreateQADMeson(AliDHFeCorr::AliConfigureDMesonOpt config, const std::string &type_particle,
+                   const std::string &stage, TList &opt_list);
+
+    void FillEventQA(AliDHFeCorr::AliEventQAHistograms &histograms);
+
+    void FillElectronQA(const std::vector<AliDHFeCorr::AliElectron> &tracks,
+                        AliDHFeCorr::AliElectronQAHistograms &histograms);
+
+    static void FillDmesonQA(const std::vector<AliDHFeCorr::AliDMeson> &d_mesons,
+                             AliDHFeCorr::AliDMesonQAHistos &histogram, DMeson_t meson_species);
+
+    void SetGridPID();
+    void PostOutput(); //< Function to post the data
+
+    //Analysis steps
+    static float GetMaxd0MeasMinusExp(AliAODRecoDecayHF *candidate, float b_field);
+    static std::vector<Float_t> MakeBins(Float_t start, Float_t end, Int_t n_bins);
+
+    //Select Events
+    bool IsSelectedEvent(AliAODEvent *event, const AliDHFeCorr::AliEventSelection &selection);
+
+    //Filter Electrons, Partner Electrons
+    static bool FulfilPixelSelection(const AliDHFeCorr::AliElectron &track, Int_t requirement);
+    void FillElectronInformation(std::vector<AliDHFeCorr::AliElectron> &electrons);
+    
+    std::vector<AliDHFeCorr::AliElectron>
+    FilterElectronsTracking(AliDHFeCorr::AliElectronSelection electronSelection,
+                            const std::vector<AliDHFeCorr::AliElectron> &electrons);
+
+    std::vector<AliDHFeCorr::AliElectron> FilterElectronsPID(AliDHFeCorr::AliElectronSelection electronSelection,
+                                                             const std::vector<AliDHFeCorr::AliElectron> &electrons);
+    void FillElectronMCInfo(std::vector<AliDHFeCorr::AliElectron> &electrons);
+
+    //Filter D mesons
+    std::vector<AliDHFeCorr::AliDMeson>
+    FillDMesonInfo(const TClonesArray *dmeson_candidates, DMeson_t meson_species,
+                        AliDHFeCorr::AliDMesonSelection &dmeson_selection) const;
+
+    void FillDmesonMCInfo(std::vector<AliDHFeCorr::AliDMeson> &d_mesons, AliAnalysisTaskDHFeCorr::DMeson_t meson_species) const;
+
+    static std::vector<AliDHFeCorr::AliDMeson> FilterTrueDMesons(const std::vector<AliDHFeCorr::AliDMeson> &d_mesons);
+
+    static std::vector<AliDHFeCorr::AliDMeson>
+    FilterDmesons(const std::vector<AliDHFeCorr::AliDMeson> &dmeson_candidates,
+                  const AliDHFeCorr::AliDMesonSelection &selectionDMeson, AliAODEvent *aod_event, int pdg_dmeson);
+
+    //Select ULS and LS pairs
+    void FindNonHFe(AliDHFeCorr::AliElectron &main_electron, const std::vector<AliDHFeCorr::AliElectron> &partners) const;
+
+    //Save to tree
+    void FillElectronTree(const std::vector<AliDHFeCorr::AliElectron> &tracks);
+    void FillDMesonTree(const std::vector<AliDHFeCorr::AliDMeson> &d_mesons);
+    
+ClassDef(AliAnalysisTaskDHFeCorr, 1);
+    
+};
+
+#endif

--- a/PWGHF/correlationHF/CMakeLists.txt
+++ b/PWGHF/correlationHF/CMakeLists.txt
@@ -63,8 +63,14 @@ set(SRCS
     AliHFCorrFitter.cxx
     AliHFCorrFitSystematics.cxx
     AliDhCorrelationExtraction.cxx
-    AliAnalysisTaskDHFeCorr.cxx
-  ) 						
+  )
+
+# Tasks that should only be compiled in ROOT 6
+if(ROOT_VERSION_MAJOR EQUAL 6)
+    set(SRCS ${SRCS}
+	AliAnalysisTaskDHFeCorr.cxx
+	)						
+endif(ROOT_VERSION_MAJOR EQUAL 6)
 
 # Headers from sources
 string(REPLACE ".cxx" ".h" HDRS "${SRCS}")

--- a/PWGHF/correlationHF/CMakeLists.txt
+++ b/PWGHF/correlationHF/CMakeLists.txt
@@ -24,6 +24,8 @@ include_directories(${AliPhysics_SOURCE_DIR}/PWGHF/correlationHF)
 include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/CORRFW
                     ${AliPhysics_SOURCE_DIR}/OADB
+                    ${AliPhysics_SOURCE_DIR}/PWG/Tools
+                    ${AliPhysics_SOURCE_DIR}/PWG/Tools/yaml-cpp/include
                     ${AliPhysics_SOURCE_DIR}/PWGHF/hfe
                     ${AliPhysics_SOURCE_DIR}/PWGHF/vertexingHF
   )
@@ -61,6 +63,7 @@ set(SRCS
     AliHFCorrFitter.cxx
     AliHFCorrFitSystematics.cxx
     AliDhCorrelationExtraction.cxx
+    AliAnalysisTaskDHFeCorr.cxx
   ) 						
 
 # Headers from sources

--- a/PWGHF/correlationHF/PWGHFcorrelationHFLinkDef.h
+++ b/PWGHF/correlationHF/PWGHFcorrelationHFLinkDef.h
@@ -37,5 +37,21 @@
 #pragma link C++ class AliHFCorrFitter+;
 #pragma link C++ class AliHFCorrFitSystematics+;
 #pragma link C++ class AliDhCorrelationExtraction+;
+
+#if ROOT_VERSION_CODE > ROOT_VERSION(6,4,0)
+#pragma link C++ namespace AliDHFeCorr+;
+#pragma link C++ typedef AliDHFeCorr::AliDMeson+;
+#pragma link C++ typedef AliDHFeCorr::AliElectron+;
+#pragma link C++ typedef AliDHFeCorr::AliEventSelection+;
+#pragma link C++ typedef AliDHFeCorr::AliElectronSelection+;
+#pragma link C++ typedef AliDHFeCorr::AliPhotonSelection+;
+#pragma link C++ typedef AliDHFeCorr::AliDMesonSelection+;
+#pragma link C++ typedef AliDHFeCorr::AliEventQAHistograms+;
+#pragma link C++ typedef AliDHFeCorr::AliElectronQAHistograms+;
+#pragma link C++ typedef AliDHFeCorr::AliDMesonQAHistos+;
+#pragma link C++ typedef AliDHFeCorr::AliConfigureElectronOpt+;
+#pragma link C++ typedef AliDHFeCorr::AliConfigureDMesonOpt+;
 #pragma link C++ class AliAnalysisTaskDHFeCorr+;
+#endif
+
 #endif

--- a/PWGHF/correlationHF/PWGHFcorrelationHFLinkDef.h
+++ b/PWGHF/correlationHF/PWGHFcorrelationHFLinkDef.h
@@ -37,4 +37,5 @@
 #pragma link C++ class AliHFCorrFitter+;
 #pragma link C++ class AliHFCorrFitSystematics+;
 #pragma link C++ class AliDhCorrelationExtraction+;
+#pragma link C++ class AliAnalysisTaskDHFeCorr+;
 #endif

--- a/PWGHF/correlationHF/macros/AddTaskDHFeCorr.C
+++ b/PWGHF/correlationHF/macros/AddTaskDHFeCorr.C
@@ -1,0 +1,6 @@
+#include "AliAnalysisTaskDHFeCorr.h"
+#include <string>
+
+AliAnalysisTaskDHFeCorr* AddTaskDHFeCorr(std::string name, std::string config_file){
+    return AliAnalysisTaskMyTask::AddTask(name,config_file);
+}

--- a/PWGHF/correlationHF/macros/default_config_d_hfe.yaml
+++ b/PWGHF/correlationHF/macros/default_config_d_hfe.yaml
@@ -1,0 +1,70 @@
+# General task configuration
+mc_mode: false
+calculate_only_efficiency: false #ignore background, saves space in MC
+
+d_meson_species: 'D0'
+
+
+event:
+    properties:
+        zvxt_range: [-10.,10.]
+    multiplicity:
+        estimator: "ZNA"
+        multiplicity_range: [-2.,101.]
+
+D_meson:
+    selection:
+        cut_file: "PreselectionDHFe.root" 
+        cut_name: "D0toKpiCuts"
+        min_pt: 2.0
+        max_pt_pid: 5.0
+
+main_electron:
+    track:
+        pt_range: [0.5,10.0]
+        eta_range: [-0.8,0.8] 
+        filter_bit: kTrkGlobalNoDCA #as defined in AliAODTrack
+        min_TPC_cls: 100
+        min_TPC_cls_dedx: 80
+        min_ITS_hits: 2
+        pixel_req: kAny #check possibilities in AliAnalysisTaskDHFeCorr::ITSPixel_t
+        recalculate_dca: true
+        dca_z: 5.0
+        dca_xy: 5.0
+    PID:
+        TPC_selection: [-1.0,3.0]
+        TOF_selection: [-3.0,3.0]
+        require_TOF: false
+
+partner_electron:
+    track:
+        pt_range: [0.2,100.0]
+        eta_range: [-0.8,0.8] 
+        filter_bit: kTrkGlobalNoDCA #as defined in AliAODTrack
+        min_TPC_cls: 80
+        min_TPC_cls_dedx: 60
+        min_ITS_hits: 2
+        pixel_req: kAny #check possibilities in AliAnalysisTaskDHFeCorr::ITSPixel_t
+        recalculate_dca: true
+        dca_z: 5.0
+        dca_xy: 5.0
+    PID:
+        TPC_selection: [-3.0,3.0]
+        TOF_selection: [-3.0,3.0]
+        require_TOF: false
+
+output:
+    electron_qa:
+        pt_bins: [0.2,0.3,0.4,0.5,0.75,1.0,1.5,2.0,3.0,4.0,6.0,8.0,10.0]
+        p_bins: [0.5,0.55,0.6,0.65,0.70,0.75,0.8,0.9,1.0,1.25,1.5,2.0,2.5,3.0,3.5,4.0,5.0,6.0,7.0,8.0,10.0]
+        n_eta_bins: 16 # bins have the same size
+        n_phi_bins: 20 
+        n_bins_TPC_cls: 40
+        n_bins_n_sigma: 100
+    d_meson_qa:
+        pt_bins: [0.,1.,1.5,2.,3.,4.,5.,6.,8.,10.,12.,16.,20.,24.,32.,50.,100.]
+        inv_mass_range: [1.4,2.2]
+        n_bins_inv_mass: 100
+        n_eta_bins: 16 # bins have the same size
+        n_phi_bins: 20 
+


### PR DESCRIPTION
Hi all,

I have corrected the previous pull request (#10867). The main problem is that I have used some C++11 features that ROOT5 cannot handle. I tried to port the conflicting parts, but this would involve doing quite some changes to the code. So I have preferred to keep the C++11 and disable the build for ROOT 5. The task works with no problem in ROOT 6. This is done by some changes in the PWGHFcorrelationHFLinkDef.h and CMakeLists.txt and it does not affect other tasks.
Please let me know if you have any comments.

Best,
Henrique