### PR TITLE
Fixes in obtaining lund map parameters

### DIFF
--- a/PWGJE/EMCALJetTasks/AliLundPlaneHelper.cxx
+++ b/PWGJE/EMCALJetTasks/AliLundPlaneHelper.cxx
@@ -91,17 +91,17 @@ AliLundPlaneData AliLundPlaneHelper::Evaluate(const AliEmcalJet &jet, const AliP
     fOutputJets=fClustSeqSA.inclusive_jets(0);
   
     fastjet::PseudoJet j1, j2, jj = fOutputJets[0];
-    while(jj.has_parents(j1,j2) && z < fHardCutoff){
-      nall=nall+1;
+    while(jj.has_parents(j1,j2)){
+      nall++;
       if(j1.perp() < j2.perp()) std::swap(j1,j2);
       z=j2.perp()/(j1.perp()+j2.perp());
       double delta_R=j1.delta_R(j2);
       double lndeltaR =log(1.0/delta_R);
       double lnpt_rel=log(j2.perp()*delta_R);
-      AliLundPlaneParameters currentsplitting(lndeltaR, lnpt_rel, fOutputJets[0].perp(), nall);
+      AliLundPlaneParameters currentsplitting(lndeltaR, lnpt_rel, j2.perp(), nall);
       result.InsertSplitting(currentsplitting);
+      jj=j1;
     }
-    jj=j1;
   } catch (fastjet::Error &e) {
     throw AliLundPlaneException(AliLundPlaneException::kFastjetError, e.message().data());
   }

--- a/PWGJE/EMCALJetTasks/AliLundPlaneHelper.h
+++ b/PWGJE/EMCALJetTasks/AliLundPlaneHelper.h
@@ -136,10 +136,10 @@ public:
    * @param nsplitting Splitting number in the cluster tree
    */
   AliLundPlaneParameters(Double_t lndeltaR, Double_t lnprel, Double_t ptlower, int nsplitting):
-    fLnDeltaR(0),
-    fLnPtrel(0),
-    fPtLower(0),
-    fNSplitting(0),
+    fLnDeltaR(lndeltaR),
+    fLnPtrel(lnprel),
+    fPtLower(ptlower),
+    fNSplitting(nsplitting),
     fInitialized(true)
   {
   }

--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetIterativeDeclustering.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetIterativeDeclustering.cxx
@@ -91,8 +91,7 @@ void AliAnalysisTaskEmcalJetIterativeDeclustering::UserCreateOutputObjects()
   fHistos->CreateTH2("hNSplittings", "Number of splittings", 300, 0., 300., 100, 0., 100.);
   fHistos->CreateTHnSparse("hSplittings", "Splittings", 5, binnings);
 
-  for (auto h : *fHistos)
-    fOutput->Add(h);
+  for (auto h : *fHistos->GetListOfHistograms()) fOutput->Add(h);
   PostData(1, fOutput);
 }
 
@@ -125,14 +124,17 @@ Bool_t AliAnalysisTaskEmcalJetIterativeDeclustering::Run()
   {
     if (jet->Pt() < fJetPtMin || jet->Pt() > fJetPtMax)
       continue;
+    AliDebugStream(1) << "Jet found, pt = " << jet->Pt() << " GeV/c" <<  std::endl;
     auto lundplane = fDecluster->Evaluate(*jet, tracks, clusters, fVertex);
     auto splittings = lundplane.GetSplittings();
     fHistos->FillTH2("hNSplittings", jet->Pt(), static_cast<double>(splittings.size()));
     for (auto splitting : splittings)
     {
+      AliDebugStream(2) << "Next splitting: " << splitting.GetNSplittings() << ", angle " << splitting.GetLnDeltaR() << ", rel kt " << splitting.GetLnPtrel() << ", pt lower " << splitting.GetPtLower() << std::endl;
       Double_t point[] = {jet->Pt(), splitting.GetPtLower(), splitting.GetLnDeltaR(), splitting.GetLnPtrel(), static_cast<double>(splitting.GetNSplittings())};
       fHistos->FillTHnSparse("hSplittings", point, weight);
     }
+    AliDebugStream(2) << "Jet done" << std::endl;
   }
 
   return true;


### PR DESCRIPTION
- Don't apply hard cutoff, with current settings
  will reject all subjets
- Correctly use pt of the lower subjet
- Fix constructor of the splitting structure
- Fix iteration over histograms in manager
  when filling the output list