### PR TITLE
PWGGA/GammaConv: Fixed trigger mimicking width for Run2 datasets (EG1)

### DIFF
--- a/PWGGA/GammaConvBase/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.cxx
@@ -4062,7 +4062,6 @@ Bool_t AliConvEventCuts::MimicTrigger(AliVEvent *event, Bool_t isMC ){
                                     0.5,
                                     /*0.4*/ 0.6,
                                     0.0,                        // LS1
-                                    1.2, 0.8,                   // LHC16r (265589-266318)
                                     0.0,                        // LHC15a-h
                                     1.0,                        // LHC15i-m
                                     1.0,                        // LHC15n
@@ -4071,6 +4070,7 @@ Bool_t AliConvEventCuts::MimicTrigger(AliVEvent *event, Bool_t isMC ){
                                     0.8,                        // LHC16l (258883-260187)
                                     0.7,                        // LHC16m-p (260216-)
                                     1.0, 1.2,                   // LHC16q (265015-265525)
+                                    1.2, 0.8,                   // LHC16r (265589-266318)
                                     0.9,                        // LHC16s (266405-267131)
                                     0.9,                        // LHC16t (267161-267166)
                                     0.7,                        // LHC17c-o (270531-281961)


### PR DESCRIPTION
For some reason in https://github.com/alisw/AliPhysics/commit/55ed2880fe01cbc8124ae26fb15a53cad22c3537 the array entries were shuffled which lead to the wrong width being loaded for all Run2 datasets.