### PR TITLE
Allow usage of the jet task in subwagons

### DIFF
--- a/PWGJE/EMCALJetTasks/AliEmcalJetTask.cxx
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetTask.cxx
@@ -1054,6 +1054,7 @@ void AliEmcalJetTask::LoadTrackEfficiencyFunction(const std::string & path, cons
  * @param minJetPt cut on the minimum jet pt
  * @param lockTask lock the task - no further changes are possible if kTRUE
  * @param bFillGhosts add ghosts particles among the jet constituents in the output
+ * @param suffix Additional suffix (for subwagons) - not yet added to the jet container name
  * @return a pointer to the new AliEmcalJetTask instance
  */
 AliEmcalJetTask* AliEmcalJetTask::AddTaskEmcalJet(
@@ -1062,7 +1063,7 @@ AliEmcalJetTask* AliEmcalJetTask::AddTaskEmcalJet(
   const Double_t minTrPt, const Double_t minClPt,
   const Double_t ghostArea, const AliJetContainer::ERecoScheme_t reco,
   const TString tag, const Double_t minJetPt,
-  const Bool_t lockTask, const Bool_t bFillGhosts
+  const Bool_t lockTask, const Bool_t bFillGhosts, const char *suffix
 )
 {
   // Get the pointer to the existing analysis manager via the static access method.
@@ -1167,14 +1168,16 @@ AliEmcalJetTask* AliEmcalJetTask::AddTaskEmcalJet(
     break;
   }
 
-  TString name = AliJetContainer::GenerateJetName(jetType, jetAlgo, reco, radius, partCont, clusCont, tag);
+  TString name = AliJetContainer::GenerateJetName(jetType, jetAlgo, reco, radius, partCont, clusCont, tag),
+          taskname = name;
+  if(strlen(suffix)) taskname += TString::Format("_%s", suffix);
 
   Printf("Jet task name: %s", name.Data());
 
-  AliEmcalJetTask* mgrTask = static_cast<AliEmcalJetTask *>(mgr->GetTask(name.Data()));
+  AliEmcalJetTask* mgrTask = static_cast<AliEmcalJetTask *>(mgr->GetTask(taskname.Data()));
   if (mgrTask) return mgrTask;
 
-  AliEmcalJetTask* jetTask = new AliEmcalJetTask(name);
+  AliEmcalJetTask* jetTask = new AliEmcalJetTask(taskname);
   jetTask->SetJetType(jetType);
   jetTask->SetJetAlgo(jetAlgo);
   jetTask->SetRecombScheme(reco);

--- a/PWGJE/EMCALJetTasks/AliEmcalJetTask.h
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetTask.h
@@ -171,7 +171,8 @@ class AliEmcalJetTask : public AliAnalysisTaskEmcal {
       const TString tag                          = "Jet",
       const Double_t minJetPt                    = 0.,
       const Bool_t lockTask                      = kTRUE,
-      const Bool_t bFillGhosts                   = kFALSE
+      const Bool_t bFillGhosts                   = kFALSE,
+      const char *suffix                         = ""
     );
 
 #if !defined(__CINT__) && !defined(__MAKECINT__)

--- a/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJet.C
+++ b/PWGJE/EMCALJetTasks/macros/AddTaskEmcalJet.C
@@ -11,9 +11,10 @@ AliEmcalJetTask* AddTaskEmcalJet(
   const char *tag                            = "Jet",
   const Double_t minJetPt                    = 0.,
   const Bool_t lockTask                      = kTRUE,
-  const Bool_t bFillGhosts                   = kFALSE
+  const Bool_t bFillGhosts                   = kFALSE,
+  const char *suffix                         = ""
 )
 {
   return AliEmcalJetTask::AddTaskEmcalJet(nTracks, nClusters, jetAlgo, radius, jetType, minTrPt, minClPt, ghostArea,
-                                          reco, tag, minJetPt, lockTask, bFillGhosts);
+                                          reco, tag, minJetPt, lockTask, bFillGhosts, suffix);
 }


### PR DESCRIPTION
Add necessary suffix parameter required for
the usage as subwagon. Attention: Suffix
parameter not yet added to the jets collection
name - this currently prevents to run more
than one jetfinder with the same jet definition
at the time.