### PR TITLE
Fix container access in case of AliAnalysisTaskEmcalLight

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalLight.cxx
@@ -1362,7 +1362,7 @@ Bool_t AliAnalysisTaskEmcalLight::CheckMCOutliers()
 
   // Condition 2 : Reconstructed EMCal cluster pT / pT-hard > factor
   if (fPtHardAndClusterPtFactor > 0.) {
-    AliClusterContainer* mccluscont = GetClusterContainer(0);
+    AliClusterContainer* mccluscont = fClusterCollArray.begin()->second;
     if ((Bool_t)mccluscont) {
       for (auto cluster : mccluscont->all()) {// Not cuts applied ; use accept for cuts
         Float_t ecluster = cluster->E();
@@ -1377,8 +1377,13 @@ Bool_t AliAnalysisTaskEmcalLight::CheckMCOutliers()
   // end condition 2
 
   // condition 3 : Reconstructed track pT / pT-hard >factor
+  std::vector<AliMCParticleContainer *> mcpcont;
+  for(auto cont : fParticleCollArray) {
+    AliMCParticleContainer *mccont = dynamic_cast<AliMCParticleContainer *>(cont.second);
+    if(mccont) mcpcont.push_back(mccont);
+  }
   if (fPtHardAndTrackPtFactor > 0.) {
-    AliMCParticleContainer* mcpartcont = dynamic_cast<AliMCParticleContainer*>(GetParticleContainer(0));
+    AliMCParticleContainer* mcpartcont = *mcpcont.begin();
     if ((Bool_t)mcpartcont) {
       for (auto mctrack : mcpartcont->all()) {// Not cuts applied ; use accept for cuts
         Float_t trackpt = mctrack->Pt();


### PR DESCRIPTION
AliAnalysisTaskEmcalLight stores containers in associative arrays,
access via index meaningless. The default implementation of
CheckMCOutliers takes each the first container it finds in the
container map, but it is not guaranteed that this is indeed the
first container inserted by the user. Users should better
overwrite the function.