### PR TITLE
 ATO-538, ATO-529 - improve pileup vertex finder and add mult. estimators

### DIFF
--- a/PWGPP/AliESDtools.cxx
+++ b/PWGPP/AliESDtools.cxx
@@ -778,10 +778,10 @@ Double_t AliESDtools::CachePileupVertexTPC(Int_t entry, Int_t verbose) {
       if (track->IsOn(0x1)) continue;
       if (track->HasPointOnITSLayer(0)) continue;
       if (track->HasPointOnITSLayer(1)) continue;
-      AliExternalTrackParam *param = track->GetInnerParam();
+      const AliExternalTrackParam *param = track->GetInnerParam();
       if (!param) continue;
       // A-side c side cut
-      if (param->GetTgl()*param->GeATO-538, ATO-529 -  tZ()<0) continue;
+      if (param->GetTgl()*param->GetZ()<0) continue;
       track->GetImpactParameters(dcaXY, dcaZ);
       if (TMath::Abs(dcaXY) > kMinDCA) continue;
       if (TMath::Abs(dcaZ) < kMinDCAZ) continue;


### PR DESCRIPTION

ATO-538, ATO-529 - improve pileup vertex finder and add mult estimators￼…
* Pile-up finder
  * Reject tracks with ITS pixels = most probably not pileup
  * Reject tracks "crossing CE"
      if (param->GetTgl()*param->GetZ()<0) continue;
* New multiplicity estimators. TOF and Calorimeter should be more sensitive o neutral energy
  * calo clusters
  * tof (clusters/hits/matches)