### PR TITLE
PWGUD/UPC: Polarisation update + check for muoncalo_pass3

### DIFF
--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
@@ -289,6 +289,9 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward()
                                                                0, 0, 0, 0, 0 },
       fInvariantMassDistributionOnlyCosThetaHeFrameTwentyfiveBinsH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                                                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                    0, 0, 0, 0, 0 },
+      fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                                                     0, 0, 0, 0, 0 }
 
 {
@@ -473,6 +476,9 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward(const char* name)
                                                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                                                0, 0, 0, 0, 0 },
       fInvariantMassDistributionOnlyCosThetaHeFrameTwentyfiveBinsH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                    0, 0, 0, 0, 0 },
+      fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                                                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                                                     0, 0, 0, 0, 0 }
 {
@@ -1365,6 +1371,14 @@ void AliAnalysisTaskUPCforward::UserCreateOutputObjects()
     fOutputList->Add(fInvariantMassDistributionOnlyPhiHeFrameTwentyfiveBinsH[iPhiBins]);
   }
 
+  for(Int_t iPhiBins = 0; iPhiBins < 25; iPhiBins++ ){
+    fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[iPhiBins] = new TH1F(
+                Form("fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH_%d", iPhiBins),
+                Form("fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH_%d", iPhiBins),
+                2000, 0, 20
+                );
+    fOutputList->Add(fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[iPhiBins]);
+  }
 
   //_______________________________
   // - End of the function
@@ -2830,6 +2844,7 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
    */
   Bool_t controlFlag13 = 0;
   Bool_t controlFlag14 = 0;
+  Bool_t controlFlag15 = 0;
   if ( possibleJPsiCopy.Pt() < 0.25 ) {
         Double_t CosThetaHelicityFrameValue7 = CosThetaHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
         Double_t PhiHelicityFrameValue7      =   CosPhiHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
@@ -2846,6 +2861,13 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
             fInvariantMassDistributionOnlyPhiHeFrameTwentyfiveBinsH[iPhiBins]->Fill(possibleJPsiCopyMag);
             controlFlag14 = 1;
           }
+        }
+        for(Int_t iTildePhiBins = 0; iTildePhiBins < 25; iTildePhiBins++) {
+          if( controlFlag15 == 1) break;
+          // if( (PhiHelicityFrameValue7 + 3.14) < 6.28*((Double_t)iTildePhiBins + 1.)/25. ){
+          //   fInvariantMassDistributionOnlyPhiHeFrameTwentyfiveBinsH[iTildePhiBins]->Fill(possibleJPsiCopyMag);
+          //   controlFlag15 = 1;
+          // }
         }
   }
 

--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
@@ -2850,8 +2850,8 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
         Double_t PhiHelicityFrameValue7      =   CosPhiHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
         // Double_t TildePhiPositiveCosTheta    = CosThetaHelicityFrameValue7 - 0.25 * TMath::Pi();
         // Double_t TildePhiNegativeCosTheta    = CosThetaHelicityFrameValue7 - 0.75 * TMath::Pi();
-        Double_t TildePhiPositiveCosTheta    = CosThetaHelicityFrameValue7 - 0.25 * 3.14;
-        Double_t TildePhiNegativeCosTheta    = CosThetaHelicityFrameValue7 - 0.75 * 3.14;
+        Double_t TildePhiPositiveCosTheta    = PhiHelicityFrameValue7 - 0.25 * 3.14;
+        Double_t TildePhiNegativeCosTheta    = PhiHelicityFrameValue7 - 0.75 * 3.14;
         for(Int_t iCosThetaBins = 0; iCosThetaBins < 25; iCosThetaBins++) {
           if( controlFlag13 == 1) break;
           if( (CosThetaHelicityFrameValue7 + 1.) < 2.*((Double_t)iCosThetaBins + 1.)/25. ){

--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
@@ -2848,6 +2848,10 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
   if ( possibleJPsiCopy.Pt() < 0.25 ) {
         Double_t CosThetaHelicityFrameValue7 = CosThetaHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
         Double_t PhiHelicityFrameValue7      =   CosPhiHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
+        // Double_t TildePhiPositiveCosTheta    = CosThetaHelicityFrameValue7 - 0.25 * TMath::Pi();
+        // Double_t TildePhiNegativeCosTheta    = CosThetaHelicityFrameValue7 - 0.75 * TMath::Pi();
+        Double_t TildePhiPositiveCosTheta    = CosThetaHelicityFrameValue7 - 0.25 * 3.14;
+        Double_t TildePhiNegativeCosTheta    = CosThetaHelicityFrameValue7 - 0.75 * 3.14;
         for(Int_t iCosThetaBins = 0; iCosThetaBins < 25; iCosThetaBins++) {
           if( controlFlag13 == 1) break;
           if( (CosThetaHelicityFrameValue7 + 1.) < 2.*((Double_t)iCosThetaBins + 1.)/25. ){
@@ -2864,10 +2868,69 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
         }
         for(Int_t iTildePhiBins = 0; iTildePhiBins < 25; iTildePhiBins++) {
           if( controlFlag15 == 1) break;
-          // if( (PhiHelicityFrameValue7 + 3.14) < 6.28*((Double_t)iTildePhiBins + 1.)/25. ){
-          //   fInvariantMassDistributionOnlyPhiHeFrameTwentyfiveBinsH[iTildePhiBins]->Fill(possibleJPsiCopyMag);
-          //   controlFlag15 = 1;
-          // }
+          if( CosThetaHelicityFrameValue7 > 0 ){
+            // if( (TildePhiPositiveCosTheta + 3.14*7.0*0.25) < (6.28*10.0*0.25)*((Double_t)iTildePhiBins + 1.)/25. ){
+            //   fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[iTildePhiBins]->Fill(possibleJPsiCopyMag);
+            //   controlFlag15 = 1;
+            // }
+            if( TildePhiPositiveCosTheta > -3.14*7*0.25 && TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*1/25 ) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[0] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*2/25 ) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[1] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*3/25 ) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[2] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*4/25 ) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[3] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*5/25 ) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[4] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*6/25 ) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[5] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*7/25 ) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[6] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*8/25 ) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[7] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*9/25 ) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[8] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*10/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[9] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*11/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[10]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*12/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[11]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*13/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[12]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*14/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[13]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*15/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[14]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*16/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[15]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*17/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[16]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*18/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[17]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*19/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[18]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*20/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[19]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*21/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[20]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*22/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[21]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*23/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[22]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*24/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[23]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiPositiveCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*25/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[24]->Fill(possibleJPsiCopyMag);}
+
+          } else if( CosThetaHelicityFrameValue7 < 0 ){
+            // if( (TildePhiNegativeCosTheta + 3.14*4.0*0.25) < (6.28*10.0*0.25)*((Double_t)iTildePhiBins + 1.)/25. ){
+            //   fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[iTildePhiBins]->Fill(possibleJPsiCopyMag);
+            //   controlFlag15 = 1;
+            // }
+            if( TildePhiNegativeCosTheta > -3.14*7*0.25 && TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*1/25 ) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[0] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*2/25 ) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[1] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*3/25 ) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[2] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*4/25 ) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[3] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*5/25 ) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[4] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*6/25 ) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[5] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*7/25 ) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[6] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*8/25 ) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[7] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*9/25 ) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[8] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*10/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[9] ->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*11/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[10]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*12/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[11]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*13/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[12]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*14/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[13]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*15/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[14]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*16/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[15]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*17/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[16]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*18/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[17]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*19/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[18]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*20/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[19]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*21/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[20]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*22/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[21]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*23/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[22]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*24/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[23]->Fill(possibleJPsiCopyMag);}
+            else if(                                       TildePhiNegativeCosTheta < ( -3.14*7*0.25 + 3.14*10*0.25*25/25) ){fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[24]->Fill(possibleJPsiCopyMag);}
+
+          }
         }
   }
 

--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
@@ -99,6 +99,7 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward()
       fRunNumberTriggerCMUP13ClassProperlyH(0),
       fTriggersVsRunH(0),
       fInvariantMassDistributionCoherentH(0),
+      fInvariantMassDistributionCoherentRapidityBinsH{ 0, 0, 0, 0, 0, 0 },
       fInvariantMassDistributionCoherentShiftMinusTwoH(0),
       fInvariantMassDistributionCoherentShiftMinusOneH(0),
       fInvariantMassDistributionCoherentShiftPlusOneH(0),
@@ -279,7 +280,10 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward()
       fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMyStrictVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0 },
       fInvariantMassDistributionOnlyPhiForSignalExtractionHelicityFrameMyStrictVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
       fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMySeventeenBinsVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
-      fCosThetaHelicityFrameJPsiAlreadyCorrectedH(0)
+      fCosThetaHelicityFrameJPsiAlreadyCorrectedH(0),
+      fDcaAgainstPtOfVectorMesonH(0),
+      fInvariantMassDistributionStrictPtStrictDcaH(0),
+      fInvariantMassDistributionVsPtStrictDcaH(0)
 {
     // default constructor, don't allocate memory here!
     // this is used by root for IO purposes, it needs to remain empty
@@ -310,6 +314,7 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward(const char* name)
       fRunNumberTriggerCMUP13ClassProperlyH(0),
       fTriggersVsRunH(0),
       fInvariantMassDistributionCoherentH(0),
+      fInvariantMassDistributionCoherentRapidityBinsH{ 0, 0, 0, 0, 0, 0 },
       fInvariantMassDistributionCoherentShiftMinusTwoH(0),
       fInvariantMassDistributionCoherentShiftMinusOneH(0),
       fInvariantMassDistributionCoherentShiftPlusOneH(0),
@@ -453,7 +458,10 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward(const char* name)
       fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMyStrictVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0 },
       fInvariantMassDistributionOnlyPhiForSignalExtractionHelicityFrameMyStrictVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
       fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMySeventeenBinsVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
-      fCosThetaHelicityFrameJPsiAlreadyCorrectedH(0)
+      fCosThetaHelicityFrameJPsiAlreadyCorrectedH(0),
+      fDcaAgainstPtOfVectorMesonH(0),
+      fInvariantMassDistributionStrictPtStrictDcaH(0),
+      fInvariantMassDistributionVsPtStrictDcaH(0)
 {
     // FillGoodRunVector(fVectorGoodRunNumbers);
 
@@ -687,6 +695,15 @@ void AliAnalysisTaskUPCforward::UserCreateOutputObjects()
 
   fInvariantMassDistributionCoherentH = new TH1F("fInvariantMassDistributionCoherentH", "fInvariantMassDistributionCoherentH", 2000, 0, 20);
   fOutputList->Add(fInvariantMassDistributionCoherentH);
+
+  for( Int_t iRapidity = 0; iRapidity < 6; iRapidity++ ) {
+    fInvariantMassDistributionCoherentRapidityBinsH[iRapidity]
+            = new TH1F( Form("fInvariantMassDistributionCoherentRapidityBinsH_%d", iRapidity),
+                        Form("fInvariantMassDistributionCoherentRapidityBinsH_%d", iRapidity),
+                        2000, 0, 20);
+    fOutputList->Add(fInvariantMassDistributionCoherentRapidityBinsH[iRapidity]);
+  }
+
 
   fInvariantMassDistributionCoherentShiftMinusTwoH = new TH1F("fInvariantMassDistributionCoherentShiftMinusTwoH", "fInvariantMassDistributionCoherentShiftMinusTwoH", 2000, 0, 20);
   fOutputList->Add(fInvariantMassDistributionCoherentShiftMinusTwoH);
@@ -1308,6 +1325,14 @@ void AliAnalysisTaskUPCforward::UserCreateOutputObjects()
     fOutputList->Add(fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameForAlreadyCorrectedHundredH[iCosThetaBins]);
   }
 
+  fDcaAgainstPtOfVectorMesonH = new TH2F("fDcaAgainstPtOfVectorMesonH", "fDcaAgainstPtOfVectorMesonH", 1000, 0, 10, 4000, 0, 40);
+  fOutputList->Add(fDcaAgainstPtOfVectorMesonH);
+
+  fInvariantMassDistributionStrictPtStrictDcaH = new TH1F("fInvariantMassDistributionStrictPtStrictDcaH", "fInvariantMassDistributionStrictPtStrictDcaH", 8000, 0, 40);
+  fOutputList->Add(fInvariantMassDistributionStrictPtStrictDcaH);
+
+  fInvariantMassDistributionVsPtStrictDcaH = new TH2F("fInvariantMassDistributionVsPtStrictDcaH", "fInvariantMassDistributionVsPtStrictDcaH", 2000, 0, 20, 1000, 0, 10);
+  fOutputList->Add(fInvariantMassDistributionVsPtStrictDcaH);
 
   //_______________________________
   // - End of the function
@@ -1984,7 +2009,14 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
      -
    */
   for(int indexMuonForDCA = 0; indexMuonForDCA < 2; indexMuonForDCA++) {
-        fDcaAgainstInvariantMassH->Fill(possibleJPsi.Mag(), track[indexMuonForDCA]->DCA());
+    fDcaAgainstInvariantMassH  ->Fill(possibleJPsi.Mag(), track[indexMuonForDCA]->DCA());
+    fDcaAgainstPtOfVectorMesonH->Fill(possibleJPsi.Pt(),  track[indexMuonForDCA]->DCA());
+  }
+  if( (track[0]->DCA() < 10) && (track[1]->DCA() < 10) ) {
+    if( (possibleJPsi.Pt() > 0.3) && (possibleJPsi.Pt() < 0.7) ){
+      fInvariantMassDistributionStrictPtStrictDcaH->Fill( possibleJPsi.Mag() );
+    }
+    fInvariantMassDistributionVsPtStrictDcaH->Fill( possibleJPsi.Mag(), possibleJPsi.Pt() );
   }
 
   /* - Now we are evaluating the pt of the dimuon pair. Generally speaking,
@@ -1997,6 +2029,19 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
   if( ptOfTheDimuonPair < 0.25) {
         fInvariantMassDistributionCoherentH->Fill(possibleJPsi.Mag());
         fInvariantMassDistributionCoherentExtendedH->Fill(possibleJPsi.Mag());
+        if (        possibleJPsi.Rapidity() > -4.0  && possibleJPsi.Rapidity() <= -3.75 ) {
+          fInvariantMassDistributionCoherentRapidityBinsH[0]->Fill(possibleJPsi.Mag());
+        } else if ( possibleJPsi.Rapidity() > -3.75 && possibleJPsi.Rapidity() <= -3.50 ) {
+          fInvariantMassDistributionCoherentRapidityBinsH[1]->Fill(possibleJPsi.Mag());
+        } else if ( possibleJPsi.Rapidity() > -3.50 && possibleJPsi.Rapidity() <= -3.25 ) {
+          fInvariantMassDistributionCoherentRapidityBinsH[2]->Fill(possibleJPsi.Mag());
+        } else if ( possibleJPsi.Rapidity() > -3.25 && possibleJPsi.Rapidity() <= -3.00 ) {
+          fInvariantMassDistributionCoherentRapidityBinsH[3]->Fill(possibleJPsi.Mag());
+        } else if ( possibleJPsi.Rapidity() > -3.00 && possibleJPsi.Rapidity() <= -2.75 ) {
+          fInvariantMassDistributionCoherentRapidityBinsH[4]->Fill(possibleJPsi.Mag());
+        } else if ( possibleJPsi.Rapidity() > -2.75 && possibleJPsi.Rapidity() <= -2.50 ) {
+          fInvariantMassDistributionCoherentRapidityBinsH[5]->Fill(possibleJPsi.Mag());
+        }
   } else {
         fInvariantMassDistributionIncoherentH->Fill(possibleJPsi.Mag());
         fInvariantMassDistributionIncoherentExtendedH->Fill(possibleJPsi.Mag());

--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
@@ -283,7 +283,14 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward()
       fCosThetaHelicityFrameJPsiAlreadyCorrectedH(0),
       fDcaAgainstPtOfVectorMesonH(0),
       fInvariantMassDistributionStrictPtStrictDcaH(0),
-      fInvariantMassDistributionVsPtStrictDcaH(0)
+      fInvariantMassDistributionVsPtStrictDcaH(0),
+      fInvariantMassDistributionOnlyPhiHeFrameTwentyfiveBinsH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                               0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                               0, 0, 0, 0, 0 },
+      fInvariantMassDistributionOnlyCosThetaHeFrameTwentyfiveBinsH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                    0, 0, 0, 0, 0 }
+
 {
     // default constructor, don't allocate memory here!
     // this is used by root for IO purposes, it needs to remain empty
@@ -461,7 +468,13 @@ AliAnalysisTaskUPCforward::AliAnalysisTaskUPCforward(const char* name)
       fCosThetaHelicityFrameJPsiAlreadyCorrectedH(0),
       fDcaAgainstPtOfVectorMesonH(0),
       fInvariantMassDistributionStrictPtStrictDcaH(0),
-      fInvariantMassDistributionVsPtStrictDcaH(0)
+      fInvariantMassDistributionVsPtStrictDcaH(0),
+      fInvariantMassDistributionOnlyPhiHeFrameTwentyfiveBinsH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                               0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                               0, 0, 0, 0, 0 },
+      fInvariantMassDistributionOnlyCosThetaHeFrameTwentyfiveBinsH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                                    0, 0, 0, 0, 0 }
 {
     // FillGoodRunVector(fVectorGoodRunNumbers);
 
@@ -1333,6 +1346,25 @@ void AliAnalysisTaskUPCforward::UserCreateOutputObjects()
 
   fInvariantMassDistributionVsPtStrictDcaH = new TH2F("fInvariantMassDistributionVsPtStrictDcaH", "fInvariantMassDistributionVsPtStrictDcaH", 2000, 0, 20, 1000, 0, 10);
   fOutputList->Add(fInvariantMassDistributionVsPtStrictDcaH);
+
+  for(Int_t iCosThetaBins = 0; iCosThetaBins < 25; iCosThetaBins++ ){
+    fInvariantMassDistributionOnlyCosThetaHeFrameTwentyfiveBinsH[iCosThetaBins] = new TH1F(
+                Form("fInvariantMassDistributionOnlyCosThetaHeFrameTwentyfiveBinsH_%d", iCosThetaBins),
+                Form("fInvariantMassDistributionOnlyCosThetaHeFrameTwentyfiveBinsH_%d", iCosThetaBins),
+                2000, 0, 20
+                );
+    fOutputList->Add(fInvariantMassDistributionOnlyCosThetaHeFrameTwentyfiveBinsH[iCosThetaBins]);
+  }
+
+  for(Int_t iPhiBins = 0; iPhiBins < 25; iPhiBins++ ){
+    fInvariantMassDistributionOnlyPhiHeFrameTwentyfiveBinsH[iPhiBins] = new TH1F(
+                Form("fInvariantMassDistributionOnlyPhiHeFrameTwentyfiveBinsH_%d", iPhiBins),
+                Form("fInvariantMassDistributionOnlyPhiHeFrameTwentyfiveBinsH_%d", iPhiBins),
+                2000, 0, 20
+                );
+    fOutputList->Add(fInvariantMassDistributionOnlyPhiHeFrameTwentyfiveBinsH[iPhiBins]);
+  }
+
 
   //_______________________________
   // - End of the function
@@ -2789,6 +2821,30 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
           if( (CosThetaHelicityFrameValue6 + 1.) < 2.*((Double_t)iCosThetaBins + 1.)/100. ) {
             fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameForAlreadyCorrectedHundredH[iCosThetaBins]->Fill(possibleJPsiCopyMag);
             controlFlag12 = 1;
+          }
+        }
+  }
+
+  /* - NEW:
+     -
+   */
+  Bool_t controlFlag13 = 0;
+  Bool_t controlFlag14 = 0;
+  if ( possibleJPsiCopy.Pt() < 0.25 ) {
+        Double_t CosThetaHelicityFrameValue7 = CosThetaHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
+        Double_t PhiHelicityFrameValue7      =   CosPhiHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
+        for(Int_t iCosThetaBins = 0; iCosThetaBins < 25; iCosThetaBins++) {
+          if( controlFlag13 == 1) break;
+          if( (CosThetaHelicityFrameValue7 + 1.) < 2.*((Double_t)iCosThetaBins + 1.)/25. ){
+            fInvariantMassDistributionOnlyCosThetaHeFrameTwentyfiveBinsH[iCosThetaBins]->Fill(possibleJPsiCopyMag);
+            controlFlag13 = 1;
+          }
+        }
+        for(Int_t iPhiBins = 0; iPhiBins < 25; iPhiBins++) {
+          if( controlFlag14 == 1) break;
+          if( (PhiHelicityFrameValue7 + 3.14) < 6.28*((Double_t)iPhiBins + 1.)/25. ){
+            fInvariantMassDistributionOnlyPhiHeFrameTwentyfiveBinsH[iPhiBins]->Fill(possibleJPsiCopyMag);
+            controlFlag14 = 1;
           }
         }
   }

--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.h
@@ -1394,11 +1394,13 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
         TH1F*                   fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameForAlreadyCorrectedHundredH[100];  //!
 
                                 /**
-                                 * Signal extraction in Phi with 25 bins only...
+                                 * Signal extraction in Phi, CosTheta, and
+                                 * TildePhi, with 25 bins only...
                                  *
                                  */
         TH1F*                   fInvariantMassDistributionOnlyPhiHeFrameTwentyfiveBinsH[25];  //!
         TH1F*                   fInvariantMassDistributionOnlyCosThetaHeFrameTwentyfiveBinsH[25];  //!
+        TH1F*                   fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[25];  //!
 
         //_______________________________
         // CUTS
@@ -1460,7 +1462,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforward, 36);
+        ClassDef(AliAnalysisTaskUPCforward, 37);
 };
 
 #endif

--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.h
@@ -300,8 +300,13 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  * distribution of the dimuon system, only
                                  * coherent component, so as to say, only
                                  * pt < 0.25 GeV/c for pt of the dimuon pair.
+                                 *
+                                 * The array is simply the same plot but
+                                 * divided in rapidity bins.
+                                 * From 0 up to 6 it is Y = -4 to -2.5.
                                  */
-        TH1F*                   fInvariantMassDistributionCoherentH;       //!
+        TH1F*                   fInvariantMassDistributionCoherentH;                      //!
+        TH1F*                   fInvariantMassDistributionCoherentRapidityBinsH[6];       //!
 
                                 /**
                                  * This histogram records the invariant mass
@@ -662,6 +667,25 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
                                  */
         TH2F*                   fDcaAgainstInvariantMassH;         //!
 
+                                /**
+                                 * This histogram records the DCA vs the Pt
+                                 * of the vector meson.
+                                 */
+        TH2F*                   fDcaAgainstPtOfVectorMesonH;         //!
+
+                                /**
+                                 * This histogram records the invariant mass
+                                 * distribution of the dimuon system with a
+                                 * strict Pt and a strics DCA.
+                                 */
+        TH1F*                   fInvariantMassDistributionStrictPtStrictDcaH;         //!
+
+                                /**
+                                 * This histogram records the invariant mass
+                                 * distribution of the dimuon system VS Pt
+                                 * and a strics DCA.
+                                 */
+        TH2F*                   fInvariantMassDistributionVsPtStrictDcaH;         //!
 
         //_______________________________
         // Cloned histograms with EXTENDED Range (0,20)->(0,40).
@@ -1429,7 +1453,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforward, 33);
+        ClassDef(AliAnalysisTaskUPCforward, 35);
 };
 
 #endif

--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.h
@@ -1393,6 +1393,13 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
         TH1F*                   fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameForAlreadyCorrectedFiftyH[50];  //!
         TH1F*                   fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameForAlreadyCorrectedHundredH[100];  //!
 
+                                /**
+                                 * Signal extraction in Phi with 25 bins only...
+                                 *
+                                 */
+        TH1F*                   fInvariantMassDistributionOnlyPhiHeFrameTwentyfiveBinsH[25];  //!
+        TH1F*                   fInvariantMassDistributionOnlyCosThetaHeFrameTwentyfiveBinsH[25];  //!
+
         //_______________________________
         // CUTS
         /*
@@ -1453,7 +1460,7 @@ class AliAnalysisTaskUPCforward : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforward, 35);
+        ClassDef(AliAnalysisTaskUPCforward, 36);
 };
 
 #endif

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
@@ -237,6 +237,8 @@ AliAnalysisTaskUPCforwardMC::AliAnalysisTaskUPCforwardMC()
       fMCCosThetaHelicityFrameTwentyfiveBinsH(0),
       fPhiHelicityFrameTwentyfiveBinsH(0),
       fMCPhiHelicityFrameTwentyfiveBinsH(0),
+      fTildePhiHelicityFrameTwentyfiveBinsH(0),
+      fMCTildePhiHelicityFrameTwentyfiveBinsH(0),
       fPhiHelicityFrameMyBinningH(0),
       fMCPhiHelicityFrameMyBinningH(0),
       fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMyVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -406,6 +408,8 @@ AliAnalysisTaskUPCforwardMC::AliAnalysisTaskUPCforwardMC( const char* name )
       fMCCosThetaHelicityFrameTwentyfiveBinsH(0),
       fPhiHelicityFrameTwentyfiveBinsH(0),
       fMCPhiHelicityFrameTwentyfiveBinsH(0),
+      fTildePhiHelicityFrameTwentyfiveBinsH(0),
+      fMCTildePhiHelicityFrameTwentyfiveBinsH(0),
       fPhiHelicityFrameMyBinningH(0),
       fMCPhiHelicityFrameMyBinningH(0),
       fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMyVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1234,6 +1238,20 @@ void AliAnalysisTaskUPCforwardMC::UserCreateOutputObjects()
                   );
   fOutputList->Add(fMCPhiHelicityFrameTwentyfiveBinsH);
 
+  fTildePhiHelicityFrameTwentyfiveBinsH =
+        new TH1F( "fTildePhiHelicityFrameTwentyfiveBinsH",
+                  "fTildePhiHelicityFrameTwentyfiveBinsH",
+                  25, -3.14*7.0*0.25, 3.14*3.0*0.25
+                  );
+  fOutputList->Add(fTildePhiHelicityFrameTwentyfiveBinsH);
+
+  fMCTildePhiHelicityFrameTwentyfiveBinsH =
+        new TH1F( "fMCTildePhiHelicityFrameTwentyfiveBinsH",
+                  "fMCTildePhiHelicityFrameTwentyfiveBinsH",
+                  25, -3.14*7.0*0.25, 3.14*3.0*0.25
+                  );
+  fOutputList->Add(fMCTildePhiHelicityFrameTwentyfiveBinsH);
+
   //_______________________________
   // - End of the function
   PostData(1, fOutputList);
@@ -1911,8 +1929,15 @@ void AliAnalysisTaskUPCforwardMC::UserExec(Option_t *)
     if ( (possibleJPsiCopy.Pt() < 0.25) && (possibleJPsiCopy.Mag() < 3.35) && (possibleJPsiCopy.Mag() > 2.85) ) {
           Double_t CosThetaHelicityFrameValue10 = CosThetaHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
           Double_t PhiHelicityFrameValue10      =   CosPhiHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
+          Double_t TildePhiPositiveCosTheta    = PhiHelicityFrameValue10 - 0.25 * 3.14;
+          Double_t TildePhiNegativeCosTheta    = PhiHelicityFrameValue10 - 0.75 * 3.14;
           fCosThetaHelicityFrameTwentyfiveBinsH->Fill( CosThetaHelicityFrameValue10 );
           fPhiHelicityFrameTwentyfiveBinsH     ->Fill( PhiHelicityFrameValue10 );
+          if( CosThetaHelicityFrameValue10 > 0 ){
+            fTildePhiHelicityFrameTwentyfiveBinsH->Fill( TildePhiPositiveCosTheta );
+          } else {
+            fTildePhiHelicityFrameTwentyfiveBinsH->Fill( TildePhiNegativeCosTheta );
+          }
     }
 
     /* - NEW:
@@ -2262,6 +2287,11 @@ void AliAnalysisTaskUPCforwardMC::ProcessMCParticles(AliMCEvent* fMCEventArg)
                                                                                  possibleJPsiMC
                                                                                  )
                                                                                 );
+                  if( CosThetaHelicityFrame(muonsMCcopy[0],muonsMCcopy[1],possibleJPsiMC) > 0 ){
+                    fMCTildePhiHelicityFrameTwentyfiveBinsH->Fill( CosPhiHelicityFrame( muonsMCcopy[0],muonsMCcopy[1],possibleJPsiMC ) - 3.14*0.25 );
+                  } else {
+                    fMCTildePhiHelicityFrameTwentyfiveBinsH->Fill( CosPhiHelicityFrame( muonsMCcopy[0],muonsMCcopy[1],possibleJPsiMC ) - 3.14*0.75 );
+                  }
                   fMCCosThetaHelicityFrameMyBinningSmallH->Fill( CosThetaHelicityFrame(  muonsMCcopy[0],
                                                                                          muonsMCcopy[1],
                                                                                          possibleJPsiMC
@@ -2445,6 +2475,11 @@ void AliAnalysisTaskUPCforwardMC::ProcessMCParticles(AliMCEvent* fMCEventArg)
                                                                                  possibleJPsiMC
                                                                                  )
                                                                                 );
+                  if( CosThetaHelicityFrame(muonsMCcopy[1],muonsMCcopy[0],possibleJPsiMC) > 0 ){
+                    fMCTildePhiHelicityFrameTwentyfiveBinsH->Fill( CosPhiHelicityFrame( muonsMCcopy[1],muonsMCcopy[0],possibleJPsiMC ) - 3.14*0.25 );
+                  } else {
+                    fMCTildePhiHelicityFrameTwentyfiveBinsH->Fill( CosPhiHelicityFrame( muonsMCcopy[1],muonsMCcopy[0],possibleJPsiMC ) - 3.14*0.75 );
+                  }
                   fMCCosThetaHelicityFrameMyBinningSmallH->Fill( CosThetaHelicityFrame(  muonsMCcopy[1],
                                                                                          muonsMCcopy[0],
                                                                                          possibleJPsiMC

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
@@ -171,8 +171,11 @@ AliAnalysisTaskUPCforwardMC::AliAnalysisTaskUPCforwardMC()
       // fVectorCosThetaReconstructed(0),
       fCosThetaGeneratedHelicityFrame(0),
       fCosThetaReconHelicityFrame(0),
+      fPhiGeneratedHelicityFrame(0),
+      fPhiReconHelicityFrame(0),
       fCounterUPCevent(0),
       fBinMigrationHelicityH(0),
+      fBinMigrationForPhiHelicityH(0),
       fCheckHelicityRestFrameJPsiH(0),
       fThetaDistribOfPositiveMuonRestFrameJPsiRapidityBinH{ 0, 0, 0, 0, 0, 0, 0, 0},
       fMCthetaDistribOfPositiveMuonRestFrameJPsiGeneratedTruthRapidityBinH{ 0, 0, 0, 0, 0, 0, 0, 0},
@@ -230,6 +233,10 @@ AliAnalysisTaskUPCforwardMC::AliAnalysisTaskUPCforwardMC()
       fMCCosThetaHelicityFrameMyBinningSmallH(0),
       fCosThetaHelicityFrameMySeventeenBinningH(0),
       fMCCosThetaHelicityFrameMySeventeenBinningH(0),
+      fCosThetaHelicityFrameTwentyfiveBinsH(0),
+      fMCCosThetaHelicityFrameTwentyfiveBinsH(0),
+      fPhiHelicityFrameTwentyfiveBinsH(0),
+      fMCPhiHelicityFrameTwentyfiveBinsH(0),
       fPhiHelicityFrameMyBinningH(0),
       fMCPhiHelicityFrameMyBinningH(0),
       fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMyVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -333,8 +340,11 @@ AliAnalysisTaskUPCforwardMC::AliAnalysisTaskUPCforwardMC( const char* name )
       // fVectorCosThetaReconstructed(0),
       fCosThetaGeneratedHelicityFrame(0),
       fCosThetaReconHelicityFrame(0),
+      fPhiGeneratedHelicityFrame(0),
+      fPhiReconHelicityFrame(0),
       fCounterUPCevent(0),
       fBinMigrationHelicityH(0),
+      fBinMigrationForPhiHelicityH(0),
       fCheckHelicityRestFrameJPsiH(0),
       fThetaDistribOfPositiveMuonRestFrameJPsiRapidityBinH{ 0, 0, 0, 0, 0, 0, 0, 0},
       fMCthetaDistribOfPositiveMuonRestFrameJPsiGeneratedTruthRapidityBinH{ 0, 0, 0, 0, 0, 0, 0, 0},
@@ -392,6 +402,10 @@ AliAnalysisTaskUPCforwardMC::AliAnalysisTaskUPCforwardMC( const char* name )
       fMCCosThetaHelicityFrameMyBinningSmallH(0),
       fCosThetaHelicityFrameMySeventeenBinningH(0),
       fMCCosThetaHelicityFrameMySeventeenBinningH(0),
+      fCosThetaHelicityFrameTwentyfiveBinsH(0),
+      fMCCosThetaHelicityFrameTwentyfiveBinsH(0),
+      fPhiHelicityFrameTwentyfiveBinsH(0),
+      fMCPhiHelicityFrameTwentyfiveBinsH(0),
       fPhiHelicityFrameMyBinningH(0),
       fMCPhiHelicityFrameMyBinningH(0),
       fInvariantMassDistributionOnlyCosThetaForSignalExtractionHelicityFrameMyVariableBinningH{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -585,6 +599,8 @@ void AliAnalysisTaskUPCforwardMC::UserCreateOutputObjects()
   fBinMigrationHelicityH = new TH2F("fBinMigrationHelicityH", "fBinMigrationHelicityH", 1000, -1., 1., 1000, -1., 1.);
   fOutputList->Add(fBinMigrationHelicityH);
 
+  fBinMigrationForPhiHelicityH = new TH2F("fBinMigrationForPhiHelicityH", "fBinMigrationForPhiHelicityH", 1000, -3.14, 3.14, 1000, -3.14, 3.14);
+  fOutputList->Add(fBinMigrationForPhiHelicityH);
 
   //_______________________________
   // - MC-only plots
@@ -1190,7 +1206,33 @@ void AliAnalysisTaskUPCforwardMC::UserCreateOutputObjects()
     fOutputList->Add(fInvariantMassDistributionOnlyPhiForSignalExtractionHelicityFrameMyVariableBinningH[iPhiBins]);
   }
 
+  fCosThetaHelicityFrameTwentyfiveBinsH =
+        new TH1F( "fCosThetaHelicityFrameTwentyfiveBinsH",
+                  "fCosThetaHelicityFrameTwentyfiveBinsH",
+                  25, -1, 1
+                  );
+  fOutputList->Add(fCosThetaHelicityFrameTwentyfiveBinsH);
 
+  fMCCosThetaHelicityFrameTwentyfiveBinsH =
+        new TH1F( "fMCCosThetaHelicityFrameTwentyfiveBinsH",
+                  "fMCCosThetaHelicityFrameTwentyfiveBinsH",
+                  25, -1, 1
+                  );
+  fOutputList->Add(fMCCosThetaHelicityFrameTwentyfiveBinsH);
+
+  fPhiHelicityFrameTwentyfiveBinsH =
+        new TH1F( "fPhiHelicityFrameTwentyfiveBinsH",
+                  "fPhiHelicityFrameTwentyfiveBinsH",
+                  25, -3.14, 3.14
+                  );
+  fOutputList->Add(fPhiHelicityFrameTwentyfiveBinsH);
+
+  fMCPhiHelicityFrameTwentyfiveBinsH =
+        new TH1F( "fMCPhiHelicityFrameTwentyfiveBinsH",
+                  "fMCPhiHelicityFrameTwentyfiveBinsH",
+                  25, -3.14, 3.14
+                  );
+  fOutputList->Add(fMCPhiHelicityFrameTwentyfiveBinsH);
 
   //_______________________________
   // - End of the function
@@ -1863,6 +1905,16 @@ void AliAnalysisTaskUPCforwardMC::UserExec(Option_t *)
 
     }
 
+    /* - NEW: analysis with purity of the binning
+     * - above 80% in CosTheta.
+     */
+    if ( (possibleJPsiCopy.Pt() < 0.25) && (possibleJPsiCopy.Mag() < 3.35) && (possibleJPsiCopy.Mag() > 2.85) ) {
+          Double_t CosThetaHelicityFrameValue10 = CosThetaHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
+          Double_t PhiHelicityFrameValue10      =   CosPhiHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
+          fCosThetaHelicityFrameTwentyfiveBinsH->Fill( CosThetaHelicityFrameValue10 );
+          fPhiHelicityFrameTwentyfiveBinsH     ->Fill( PhiHelicityFrameValue10 );
+    }
+
     /* - NEW:
      * - 1D analysis with
      * - my variable binning.
@@ -1985,7 +2037,13 @@ void AliAnalysisTaskUPCforwardMC::UserExec(Option_t *)
   }
 
   // fVectorCosThetaReconstructed.push_back(cosThetaMuonsRestFrame[0]);
+  fCosThetaReconHelicityFrame = 0;
   fCosThetaReconHelicityFrame = cosThetaMuonsRestFrame[0];
+  fPhiReconHelicityFrame      = 0;
+  fPhiReconHelicityFrame      = CosPhiHelicityFrame( muonsCopy2[0],
+                                                     muonsCopy2[1],
+                                                     possibleJPsiCopy
+                                                     );
   /* - Mind that it could generate segmentation fault without
      - fCounterUPCevent-1, because we are incrementing the counter right after
      - it processes the MC events at Generated level...
@@ -2003,6 +2061,11 @@ void AliAnalysisTaskUPCforwardMC::UserExec(Option_t *)
         fBinMigrationHelicityH->Fill( fCosThetaGeneratedHelicityFrame,
                                       fCosThetaReconHelicityFrame
                                     );
+  }
+  if ( fPhiReconHelicityFrame ) {
+        fBinMigrationForPhiHelicityH->Fill( fPhiGeneratedHelicityFrame,
+                                            fPhiReconHelicityFrame
+                                            );
   }
 
 
@@ -2147,6 +2210,10 @@ void AliAnalysisTaskUPCforwardMC::ProcessMCParticles(AliMCEvent* fMCEventArg)
                   fMCthetaDistribOfNegativeMuonRestFrameJPsiGeneratedTruthH->Fill(cosThetaMuonsRestFrameMC[1]);
                   // fVectorCosThetaGenerated.push_back(cosThetaMuonsRestFrameMC[0]);
                   fCosThetaGeneratedHelicityFrame = cosThetaMuonsRestFrameMC[0];
+                  fPhiGeneratedHelicityFrame      = CosPhiHelicityFrame( muonsMCcopy[0],
+                                                                         muonsMCcopy[1],
+                                                                         possibleJPsiMC
+                                                                       );
                   /* - New part: filling all possible histograms!
                      -
                    */
@@ -2185,6 +2252,16 @@ void AliAnalysisTaskUPCforwardMC::ProcessMCParticles(AliMCEvent* fMCEventArg)
                                                                                    possibleJPsiMC
                                                                                    )
                                                                                   );
+                  fMCCosThetaHelicityFrameTwentyfiveBinsH->Fill( CosThetaHelicityFrame( muonsMCcopy[0],
+                                                                                        muonsMCcopy[1],
+                                                                                        possibleJPsiMC
+                                                                                        )
+                                                                                       );
+                  fMCPhiHelicityFrameTwentyfiveBinsH->Fill( CosPhiHelicityFrame( muonsMCcopy[0],
+                                                                                 muonsMCcopy[1],
+                                                                                 possibleJPsiMC
+                                                                                 )
+                                                                                );
                   fMCCosThetaHelicityFrameMyBinningSmallH->Fill( CosThetaHelicityFrame(  muonsMCcopy[0],
                                                                                          muonsMCcopy[1],
                                                                                          possibleJPsiMC
@@ -2316,6 +2393,10 @@ void AliAnalysisTaskUPCforwardMC::ProcessMCParticles(AliMCEvent* fMCEventArg)
                   fMCthetaDistribOfPositiveMuonRestFrameJPsiGeneratedTruthH->Fill(cosThetaMuonsRestFrameMC[1]);
                   // fVectorCosThetaGenerated.push_back(cosThetaMuonsRestFrameMC[1]);
                   fCosThetaGeneratedHelicityFrame = cosThetaMuonsRestFrameMC[1];
+                  fPhiGeneratedHelicityFrame      = CosPhiHelicityFrame( muonsMCcopy[1],
+                                                                         muonsMCcopy[0],
+                                                                         possibleJPsiMC
+                                                                         );
                   /* - New part: filling all possible histograms!
                      -
                    */
@@ -2354,6 +2435,16 @@ void AliAnalysisTaskUPCforwardMC::ProcessMCParticles(AliMCEvent* fMCEventArg)
                                                                                    possibleJPsiMC
                                                                                    )
                                                                                   );
+                  fMCCosThetaHelicityFrameTwentyfiveBinsH->Fill( CosThetaHelicityFrame( muonsMCcopy[0],
+                                                                                        muonsMCcopy[1],
+                                                                                        possibleJPsiMC
+                                                                                        )
+                                                                                       );
+                  fMCPhiHelicityFrameTwentyfiveBinsH->Fill( CosPhiHelicityFrame( muonsMCcopy[0],
+                                                                                 muonsMCcopy[1],
+                                                                                 possibleJPsiMC
+                                                                                 )
+                                                                                );
                   fMCCosThetaHelicityFrameMyBinningSmallH->Fill( CosThetaHelicityFrame(  muonsMCcopy[1],
                                                                                          muonsMCcopy[0],
                                                                                          possibleJPsiMC

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
@@ -1048,6 +1048,22 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
         TH1F*                   fMCPhiHelicityFrameTwentyfiveBinsH;   //!
 
                                 /**
+                                 * This histogram shows the TildePhi
+                                 * distribution with 25 bins.
+                                 * This implies a purity well above 80% (?).
+                                 * RECON level.
+                                 */
+        TH1F*                   fTildePhiHelicityFrameTwentyfiveBinsH;   //!
+
+                                /**
+                                 * This histogram shows the TildePhi
+                                 * distribution with 25 bins.
+                                 * This implies a purity well above 80% (?).
+                                 * GENERATED level.
+                                 */
+        TH1F*                   fMCTildePhiHelicityFrameTwentyfiveBinsH;   //!
+
+                                /**
                                  * This histogram shows  Phi
                                  * distribution with my variable binning.
                                  * RECON level.
@@ -1164,7 +1180,7 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforwardMC, 27);
+        ClassDef(AliAnalysisTaskUPCforwardMC, 28);
 };
 
 #endif

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.h
@@ -442,39 +442,6 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
         TH1F*                   fMCthetaDistribOfPositiveMuonRestFrameJPsiGeneratedTruthRapidityBinH[8];
 
                                 /**
-                                 * This is the vector containing the GENERATED
-                                 * values of the cos(theta). It should be
-                                 * needed for the "bin migration" study...
-                                 * As far as I can imagine, in each event there
-                                 * should only be a single J/Psi because these
-                                 * are all UPC events, as such I should record
-                                 * all possible values for cos(theta) and plot
-                                 * only when the corresponding J/Psi falls
-                                 * inside the detector acceptance...
-                                 * The resulting plot should be TH2F and be like
-                                 * a lego plot. See for an example:
-                                 *https://www.researchgate.net/figure/The-migration-matrix-for-leading-p-jet-T-Element-i-j-is-the-probability-for-a-particle_fig1_222896619
-                                 */
-        // std::vector<Double_t>   fVectorCosThetaGenerated;           //!
-
-                                /**
-                                 * This is the vector containing the
-                                 * RECONSTRUCTED
-                                 * values of the cos(theta). It should be
-                                 * needed for the "bin migration" study...
-                                 * Actually if I fill everytime the TH2F
-                                 * as soon as I compute the cos(theta)
-                                 * there should be no real need for it...
-                                 * The only thing that matters is a counter to
-                                 * give me the proper value of the vector for
-                                 * the generated value I should consider inside
-                                 * the vector of the GENERATED level.
-                                 * It is important to remember there is at MOST
-                                 * a single J/Psi for UPC event!!!
-                                 */
-        // std::vector<Double_t>   fVectorCosThetaReconstructed;           //!
-
-                                /**
                                  * This is the GENERATED
                                  * value of the cos(theta) in the HELICITY
                                  * frame. It should be
@@ -490,6 +457,7 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
                                  *https://www.researchgate.net/figure/The-migration-matrix-for-leading-p-jet-T-Element-i-j-is-the-probability-for-a-particle_fig1_222896619
                                  */
         Double_t                fCosThetaGeneratedHelicityFrame;           //!
+        Double_t                fPhiGeneratedHelicityFrame;           //!
 
                                 /**
                                  * This is the RECONSTRUCTED
@@ -507,6 +475,7 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
                                  *https://www.researchgate.net/figure/The-migration-matrix-for-leading-p-jet-T-Element-i-j-is-the-probability-for-a-particle_fig1_222896619
                                  */
         Double_t                fCosThetaReconHelicityFrame;           //!
+        Double_t                fPhiReconHelicityFrame;           //!
 
                                 /**
                                  * Counter for the UPC events to access vectors.
@@ -522,8 +491,16 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
                                 /**
                                  * This histogram shows the bin migration for
                                  * the helicity Analysis...
+                                 * NOTE: this is only in CosTheta.
                                  */
         TH2F*                   fBinMigrationHelicityH;           //!
+
+                                /**
+                                 * This histogram shows the bin migration for
+                                 * the helicity Analysis...
+                                 * NOTE: this is only in Phi.
+                                 */
+        TH2F*                   fBinMigrationForPhiHelicityH;           //!
 
         //_______________________________
         // HELICITY AND COLLINS-SOPER
@@ -1039,6 +1016,38 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
         TH1F*                   fMCCosThetaHelicityFrameMyBinningSmallH;   //!
 
                                 /**
+                                 * This histogram shows CosTheta
+                                 * distribution with 25 bins.
+                                 * This implies a purity well above 80%.
+                                 * RECON level.
+                                 */
+        TH1F*                   fCosThetaHelicityFrameTwentyfiveBinsH;   //!
+
+                                /**
+                                 * This histogram shows CosTheta
+                                 * distribution with 25 bins.
+                                 * This implies a purity well above 80%.
+                                 * GENERATED level.
+                                 */
+        TH1F*                   fMCCosThetaHelicityFrameTwentyfiveBinsH;   //!
+
+                                /**
+                                 * This histogram shows Phi
+                                 * distribution with 25 bins.
+                                 * This implies a purity well above 80% (?).
+                                 * RECON level.
+                                 */
+        TH1F*                   fPhiHelicityFrameTwentyfiveBinsH;   //!
+
+                                /**
+                                 * This histogram shows Phi
+                                 * distribution with 25 bins.
+                                 * This implies a purity well above 80% (?).
+                                 * GENERATED level.
+                                 */
+        TH1F*                   fMCPhiHelicityFrameTwentyfiveBinsH;   //!
+
+                                /**
                                  * This histogram shows  Phi
                                  * distribution with my variable binning.
                                  * RECON level.
@@ -1155,7 +1164,7 @@ class AliAnalysisTaskUPCforwardMC : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforwardMC, 26);
+        ClassDef(AliAnalysisTaskUPCforwardMC, 27);
 };
 
 #endif


### PR DESCRIPTION
Added the supposedly final binning for the 1D polarisation analysis. Things seem to work pretty nicely...

Added a further check on the muoncalo_pass3 => Invariant Mass Distributions in rapidity bins, to check if the fraction of PsiPrime to J/Psi changes at all.

IMPORTANT: tested.