### PR TITLE
Small fixes. In tree maker: protection agains null pointer for MCEven…

### DIFF
--- a/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
+++ b/PWGDQ/reducedTree/AliAnalysisTaskReducedTreeMaker.cxx
@@ -1692,6 +1692,7 @@ void AliAnalysisTaskReducedTreeMaker::FillMCTruthInfo()
    AliInputEventHandler* inputHandler = (AliInputEventHandler*) (AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler());
    
    AliMCEvent* event = AliDielectronMC::Instance()->GetMCEvent();
+   if(!event) return;
    
     AliReducedEventInfo* eventInfo = NULL; 
     if(fTreeWritingOption==kFullEventsWithBaseTracks || fTreeWritingOption==kFullEventsWithFullTracks) {

--- a/PWGDQ/reducedTree/AliReducedAnalysisFilterTrees.cxx
+++ b/PWGDQ/reducedTree/AliReducedAnalysisFilterTrees.cxx
@@ -268,7 +268,7 @@ void AliReducedAnalysisFilterTrees::WriteFilteredTracks(Int_t array /*=1*/) {
       fHistosManager->FillHistClass("Track_BeforeCuts", fValues);
       
       Bool_t writeTrack = IsTrackSelected(track, fValues);
-      writeTrack |= TrackIsCandidateLeg(track);
+      writeTrack |= (fWriteFilteredPairs && TrackIsCandidateLeg(track));
       
       if(writeTrack) {
          for(Int_t icut=0; icut<fTrackCuts.GetEntries(); ++icut) {


### PR DESCRIPTION
…t. In tree filter: changed behaviour such that V0 pairs are not written by default whenever tracks are needed in the filtered event.

The current behaviout is that V0 legs are written without any explicit request from user, if the V0 candidates writting is required.