### PR TITLE
Fix for broken compilation with ROOT6-10-8

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliEmcalStringView.h
+++ b/PWG/EMCAL/EMCALbase/AliEmcalStringView.h
@@ -28,7 +28,7 @@
 #define ALIEMCALSTRINGVIEW_H
 #include "RConfig.h"
 
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,10,0) 
+#if ROOT_VERSION_CODE > ROOT_VERSION(6,10,99)
 #include "RStringView.h"
 #define EMCAL_STRINGVIEW const std::string_view
 #else 


### PR DESCRIPTION
The compilation of AliPhysics with ROOT6-10-08 is broken due to below error.
>/localone/alice/sw/SOURCES/AliPhysics/aliroot6/0/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetIterativeDeclustering.cxx:201:14: error: ambiguous overload for 'operator==' (operand types are 'const string_view {aka const std::experimental::__ROOT::basic_string_view<char>}' and 'const char [5]')
>    if(trigger == "INT7") triggerbits = AliVEvent::kINT7;
>       ~~~~~~~~^~~~~~~~~

The failed production was ordered on today's tag for alidist, AliPhysics and AliRoot with
> aliBuild build AliPhysics --defaults user-root6 -z aliroot6

with the same today's tags the productions with ROOT5 and with ROOT6-16-00
> aliBuild build AliPhysics --defaults user -z aliroot5
> aliBuild build AliPhysics --defaults user-next-root6 -z alinextroot6

finalized correctly.

It seems that the std string comparison required by the new jet
classes is not properly supported by ROOT6-10-8.