### PR TITLE
Add cut setting for eta/phi region selection

### DIFF
--- a/PWGDQ/dielectron/macrosLMEE/Config_acapon.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_acapon.C
@@ -444,6 +444,13 @@ AliDielectron* Config_acapon(TString cutDefinition,
     die->GetTrackFilter().AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kTTreeCuts, LMEECutLib::kTheoPID));
     LMcutlib->SetSignalsMC(die);
   }
+  // Cut designed to only use "good" eta/phi regions
+  else if(cutDefinition == "kGoodEtaPhiRegions"){
+    die->GetTrackFilter().AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kGoodEtaPhi, LMEECutLib::kTheoPID));
+    if(applyPairCuts){
+      die->GetPairFilter().AddCuts(LMcutlib->GetPairCuts(LMEECutLib::kCutSet1));
+    }
+  }
   else{
     cout << " =============================== " << endl;
     cout << " ==== INVALID CONFIGURATION ==== " << endl;


### PR DESCRIPTION
Needed for run1 vs run2 comparisons to enable ~direct comparisons
between regions that were operating in similar states. The selected
regions in eta/phi are somewhat consistent between run1 and run2 for
the ITS.