### PR TITLE
dca to be in abs in the custom dca of V0 daughters

### DIFF
--- a/PWGLF/RESONANCES/AliRsnCutV0.cxx
+++ b/PWGLF/RESONANCES/AliRsnCutV0.cxx
@@ -267,8 +267,8 @@ Bool_t AliRsnCutV0::CheckESD(AliESDv0 *v0)
        covMatNeg[0]=0; covMatNeg[2]=0;
      }
      
-     if(impParPos[0]<fMinDCAPositiveTrack) return kFALSE;
-     if(impParNeg[0]<fMinDCANegativeTrack) return kFALSE;
+     if(TMath::Abs(impParPos[0])<fMinDCAPositiveTrack) return kFALSE;
+     if(TMath::Abs(impParNeg[0])<fMinDCANegativeTrack) return kFALSE;
      
    }
 

--- a/PWGLF/RESONANCES/macros/mini/ConfigSigPM.C
+++ b/PWGLF/RESONANCES/macros/mini/ConfigSigPM.C
@@ -96,7 +96,7 @@ iCutTPCNSigma->GetName()) ) ;
   //esdTrackCuts->SetMinRatioCrossedRowsOverFindableClustersTPC(rowsbycluster);
   esdTrackCuts->SetMaxChi2PerClusterTPC(4);
   esdTrackCuts->SetMinNClustersTPC(70);
-  esdTrackCuts->SetMinDCAToVertexXY(DCAxy); //Use one of the two - pt dependent or fixed value cut.
+//  esdTrackCuts->SetMinDCAToVertexXY(DCAxy); //Use one of the two - pt dependent or fixed value cut.
   
   //V0s
 


### PR DESCRIPTION
1. dca to be in abs in the custom dca of V0 daughters
2. minor change in sigma star config macro for PbPb 2018