### PR TITLE
PWGGA/GammaConv: fixed mem leak in trigger mimicking

### DIFF
--- a/PWGGA/GammaConvBase/AliConvEventCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConvEventCuts.cxx
@@ -3982,7 +3982,7 @@ Bool_t AliConvEventCuts::MimicTrigger(AliVEvent *event, Bool_t isMC ){
         AliFatal("OADB/PWGGA/EMCalTriggerMimicOADB.root was not found");
       }
       if (fileTriggThresh) delete fileTriggThresh;
-      AliOADBContainer *contfileTriggThresh = new AliOADBContainer("");
+      std::unique_ptr<AliOADBContainer> contfileTriggThresh(new AliOADBContainer(""));
       contfileTriggThresh->InitFromFile(AliDataFile::GetFileNameOADB("PWGGA/EMCalTriggerMimicOADB.root").data(),"AliEMCalTriggerMimic");
       TObjArray *arrayTriggThresh=(TObjArray*)contfileTriggThresh->GetObject(runnumber);
       if (!arrayTriggThresh)


### PR DESCRIPTION
AliAODBContainer was never deleted and therefore created for every event