### PR TITLE
Add inverse good phi/eta cut & fix event sel. bug

### DIFF
--- a/PWGDQ/dielectron/macrosLMEE/AddTask_acapon_Efficiency.C
+++ b/PWGDQ/dielectron/macrosLMEE/AddTask_acapon_Efficiency.C
@@ -90,7 +90,7 @@ AliAnalysisTaskElectronEfficiencyV2* AddTask_acapon_Efficiency(TString names    
   // Event selection. Is the same for all the different cutsettings
   task->SetEnablePhysicsSelection(kTRUE);
   task->SetTriggerMask(triggerNames);
-  task->SetEventFilter(cutlib->GetEventCuts()); // All cut sets have same event cuts
+  task->SetEventFilter(cutlib->GetEventCuts(kFALSE, kFALSE)); // All cut sets have same event cuts
 
   Double_t centMin = -99.;
   Double_t centMax = -90.;

--- a/PWGDQ/dielectron/macrosLMEE/Config_acapon.C
+++ b/PWGDQ/dielectron/macrosLMEE/Config_acapon.C
@@ -451,6 +451,12 @@ AliDielectron* Config_acapon(TString cutDefinition,
       die->GetPairFilter().AddCuts(LMcutlib->GetPairCuts(LMEECutLib::kCutSet1));
     }
   }
+  else if(cutDefinition == "kBadEtaPhiRegions"){
+    die->GetTrackFilter().AddCuts(LMcutlib->GetTrackCuts(LMEECutLib::kBadEtaPhi, LMEECutLib::kTheoPID));
+    if(applyPairCuts){
+      die->GetPairFilter().AddCuts(LMcutlib->GetPairCuts(LMEECutLib::kCutSet1));
+    }
+  }
   else{
     cout << " =============================== " << endl;
     cout << " ==== INVALID CONFIGURATION ==== " << endl;


### PR DESCRIPTION
Fix event selection in efficiency task. Arguments were not updated during last update.
Adds a cut selection which is inverse to "kGoodEtaPhi" in its eta/phi selection. All other track and PID cuts are identical.