### PR TITLE
PWGHF: Fix Lc->pKpi nSigma PID selection

### DIFF
--- a/PWGHF/vertexingHF/AliRDHFCutsLctopKpi.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCutsLctopKpi.cxx
@@ -468,12 +468,12 @@ Int_t AliRDHFCutsLctopKpi::IsSelectedPID(AliAODRecoDecayHF* obj) {
     for(Int_t i=0;i<3;i++){
      AliAODTrack *track=(AliAODTrack*)obj->GetDaughter(i);
      if(!track) return 0;
-     // identify kaon
-     if(track->P()<0.55){
-      fPidHF->SetTOF(kFALSE);
-      fPidHF->SetTOFdecide(kFALSE);
-     }
      if(i==1) {
+      // identify kaon
+      if(track->P()<0.55){
+       fPidHF->SetTOF(kFALSE);
+       fPidHF->SetTOFdecide(kFALSE);
+      }
       Int_t isKaon=0;
       isKaon=fPIDStrategy==kNSigmaMin?fPidHF->MatchTPCTOFMin(track,3):fPidHF->MakeRawPid(track,3);
       if(isKaon>=1) iskaon1=kTRUE;


### PR DESCRIPTION
Bug found when validating HFTreeCreator for the nSigma and nSigmaMin PID options (the default case). Fix reduces the number of selected candidates with ~30%, using filtering cuts + 3sigma TPC+TOF.

NB: For our published Lc physics papers, more advanced PID selection strategies were used that are not affected by this bug.