### PR TITLE
PWGGA/GammaConv: Added TB NL params for 50,150,300 MeV thresholds + configs pp,pPb

### DIFF
--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pPb.C
@@ -2039,6 +2039,7 @@ void AddTask_GammaCalo_pPb(
   } else if (trainConfig == 2027){ // open timing, TB NL
     cuts.AddCutCalo("8008e123","411790000f032230000","01631031000000d0"); // L1 low
     cuts.AddCutCalo("8008d123","411790000f032230000","01631031000000d0"); // L1 high
+
   // no TM
   } else if (trainConfig == 2030){ // EMCAL+DCAL clusters standard cuts, triggers, NL vars
     cuts.AddCutCalo("80010123","4117947050032230000","01631031000000d0"); // INT7
@@ -2064,6 +2065,27 @@ void AddTask_GammaCalo_pPb(
     cuts.AddCutCalo("80010123","4117900050032230000","01631031000000d0"); // INT7
     cuts.AddCutCalo("8008e123","4117900050032230000","01631031000000d0"); // EG2
     cuts.AddCutCalo("8008d123","4117900050032230000","01631031000000d0"); // EG1
+
+  } else if (trainConfig == 2050){ // TB NL tests 100 MeV aggregation
+    cuts.AddCutCalo("80010123","411790105f032230000","01631031000000d0"); // INT7
+  } else if (trainConfig == 2051){ // TB NL tests 100 MeV aggregation
+    cuts.AddCutCalo("8008e123","411790105f032230000","01631031000000d0"); // EG2
+    cuts.AddCutCalo("8008d123","411790105f032230000","01631031000000d0"); // EG1
+  } else if (trainConfig == 2052){ // TB NL tests 50 MeV aggregation
+    cuts.AddCutCalo("80010123","411790205f032230000","01631031000000d0"); // INT7
+  } else if (trainConfig == 2053){ // TB NL tests 50 MeV aggregation
+    cuts.AddCutCalo("8008e123","411790205f032230000","01631031000000d0"); // EG2
+    cuts.AddCutCalo("8008d123","411790205f032230000","01631031000000d0"); // EG1
+  } else if (trainConfig == 2054){ // TB NL tests 150 MeV aggregation
+    cuts.AddCutCalo("80010123","411790305f032230000","01631031000000d0"); // INT7
+  } else if (trainConfig == 2055){ // TB NL tests 150 MeV aggregation
+    cuts.AddCutCalo("8008e123","411790305f032230000","01631031000000d0"); // EG2
+    cuts.AddCutCalo("8008d123","411790305f032230000","01631031000000d0"); // EG1
+  } else if (trainConfig == 2056){ // TB NL tests 300 MeV aggregation
+    cuts.AddCutCalo("80010123","411790405f032230000","01631031000000d0"); // INT7
+  } else if (trainConfig == 2057){ // TB NL tests 300 MeV aggregation
+    cuts.AddCutCalo("8008e123","411790405f032230000","01631031000000d0"); // EG2
+    cuts.AddCutCalo("8008d123","411790405f032230000","01631031000000d0"); // EG1
 
   // standard cut configs with no NL for SM-wise correction
   } else if (trainConfig == 2100){ // EMCAL+DCAL clusters standard cuts, triggers, no NL

--- a/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaCalo_pp.C
@@ -605,28 +605,36 @@ void AddTask_GammaCalo_pp(
     cuts.AddCutCalo("00010113","11111110670322s0000","01631031000000d0"); // M02, pT-dep with  0.32, 0.0238, 0.7
     cuts.AddCutCalo("00010113","11111110670322n0000","01631031000000d0"); // M02, pT-dep with  0.32, 0.0238, 0.7
 
-  } else if (trainConfig == 170){ // EMCAL clusters pp 8 TeV
+  } else if (trainConfig == 170){ // EMCAL clusters pp 8 TeV 100MeV aggregation
     cuts.AddCutCalo("00010113","111110106f032230000","01631031000000d0"); // std
     cuts.AddCutCalo("00052113","111110106f032230000","01631031000000d0"); // std
     cuts.AddCutCalo("00081113","111110106f032230000","01631031000000d0"); // std
-  } else if (trainConfig == 171){ // EMCAL clusters pp 8 TeV
-    cuts.AddCutCalo("00010113","111110106f022230000","01631031000000d0"); // std
-    cuts.AddCutCalo("00052113","111110106f022230000","01631031000000d0"); // std
-    cuts.AddCutCalo("00081113","111110106f022230000","01631031000000d0"); // std
+  } else if (trainConfig == 171){ // EMCAL clusters pp 8 TeV 50MeV aggregation
+    cuts.AddCutCalo("00010113","111110206f032230000","01631031000000d0"); // std
+    cuts.AddCutCalo("00052113","111110206f032230000","01631031000000d0"); // std
+    cuts.AddCutCalo("00081113","111110206f032230000","01631031000000d0"); // std
+  } else if (trainConfig == 172){ // EMCAL clusters pp 8 TeV 150MeV aggregation
+    cuts.AddCutCalo("00010113","111110306f032230000","01631031000000d0"); // std
+    cuts.AddCutCalo("00052113","111110306f032230000","01631031000000d0"); // std
+    cuts.AddCutCalo("00081113","111110306f032230000","01631031000000d0"); // std
+  } else if (trainConfig == 173){ // EMCAL clusters pp 8 TeV 300MeV aggregation
+    cuts.AddCutCalo("00010113","111110406f032230000","01631031000000d0"); // std
+    cuts.AddCutCalo("00052113","111110406f032230000","01631031000000d0"); // std
+    cuts.AddCutCalo("00081113","111110406f032230000","01631031000000d0"); // std
 
-  } else if (trainConfig == 172){ // EMCAL clusters pp 8 TeV, TB+finetuning CCRF
+  } else if (trainConfig == 176){ // EMCAL clusters pp 8 TeV, TB+finetuning CCRF
     cuts.AddCutCalo("00010113","111113106f032230000","01631031000000d0"); // std
     cuts.AddCutCalo("00052113","111113106f032230000","01631031000000d0"); // std
     cuts.AddCutCalo("00081113","111113106f032230000","01631031000000d0"); // std
-  } else if (trainConfig == 173){ // EMCAL clusters pp 8 TeV, TB+finetuning CRF
+  } else if (trainConfig == 177){ // EMCAL clusters pp 8 TeV, TB+finetuning CRF
     cuts.AddCutCalo("00010113","111113206f032230000","01631031000000d0"); // std
     cuts.AddCutCalo("00052113","111113206f032230000","01631031000000d0"); // std
     cuts.AddCutCalo("00081113","111113206f032230000","01631031000000d0"); // std
-  } else if (trainConfig == 174){ // EMCAL clusters pp 8 TeV, TB+finetuning CCMF
+  } else if (trainConfig == 178){ // EMCAL clusters pp 8 TeV, TB+finetuning CCMF
     cuts.AddCutCalo("00010113","111113306f032230000","01631031000000d0"); // std
     cuts.AddCutCalo("00052113","111113306f032230000","01631031000000d0"); // std
     cuts.AddCutCalo("00081113","111113306f032230000","01631031000000d0"); // std
-  } else if (trainConfig == 175){ // EMCAL clusters pp 8 TeV, TB+finetuning CMF
+  } else if (trainConfig == 179){ // EMCAL clusters pp 8 TeV, TB+finetuning CMF
     cuts.AddCutCalo("00010113","111113406f032230000","01631031000000d0"); // std
     cuts.AddCutCalo("00052113","111113406f032230000","01631031000000d0"); // std
     cuts.AddCutCalo("00081113","111113406f032230000","01631031000000d0"); // std
@@ -1811,8 +1819,49 @@ void AddTask_GammaCalo_pp(
     cuts.AddCutCalo("0008d113","411792106f032230000","01631031000000b0"); // EG1 Op. Ang. var
     cuts.AddCutCalo("0008d113","411792106f032230000","01631031000000g0"); // EG1 Op. Ang. var
 
+// EDC settings with TB correction
+  } else if (trainConfig == 2100){ // 100 MeV aggregation
+    cuts.AddCutCalo("00010113","411790106f032230000","01631031000000d0"); // INT7 test beam NL
+  } else if (trainConfig == 2101){ // 100 MeV aggregation
+    cuts.AddCutCalo("0008e113","411790106f032230000","01631031000000d0"); // EG2  test beam NL
+    cuts.AddCutCalo("0008d113","411790106f032230000","01631031000000d0"); // EG1  test beam NL
+  } else if (trainConfig == 2102){ // 50 MeV aggregation
+    cuts.AddCutCalo("00010113","411790206f032230000","01631031000000d0"); // INT7 test beam NL
+  } else if (trainConfig == 2103){ // 50 MeV aggregation
+    cuts.AddCutCalo("0008e113","411790206f032230000","01631031000000d0"); // EG2  test beam NL
+    cuts.AddCutCalo("0008d113","411790206f032230000","01631031000000d0"); // EG1  test beam NL
+  } else if (trainConfig == 2104){ // 150 MeV aggregation
+    cuts.AddCutCalo("00010113","411790306f032230000","01631031000000d0"); // INT7 test beam NL
+  } else if (trainConfig == 2105){ // 150 MeV aggregation
+    cuts.AddCutCalo("0008e113","411790306f032230000","01631031000000d0"); // EG2  test beam NL
+    cuts.AddCutCalo("0008d113","411790306f032230000","01631031000000d0"); // EG1  test beam NL
+  } else if (trainConfig == 2106){ // 300 MeV aggregation
+    cuts.AddCutCalo("00010113","411790406f032230000","01631031000000d0"); // INT7 test beam NL
+  } else if (trainConfig == 2107){ // 300 MeV aggregation
+    cuts.AddCutCalo("0008e113","411790406f032230000","01631031000000d0"); // EG2  test beam NL
+    cuts.AddCutCalo("0008d113","411790406f032230000","01631031000000d0"); // EG1  test beam NL
 
 
+  } else if (trainConfig == 2150){ // EMCAL clusters pp 8 TeV 100MeV aggregation
+    cuts.AddCutCalo("00010113","111110106f032230000","01631031000000d0"); // std
+  } else if (trainConfig == 2151){ // EMCAL clusters pp 8 TeV 100MeV aggregation
+    cuts.AddCutCalo("00052113","111110106f032230000","01631031000000d0"); // std
+    cuts.AddCutCalo("00081113","111110106f032230000","01631031000000d0"); // std
+  } else if (trainConfig == 2152){ // EMCAL clusters pp 8 TeV 50MeV aggregation
+    cuts.AddCutCalo("00010113","111110206f032230000","01631031000000d0"); // std
+  } else if (trainConfig == 2153){ // EMCAL clusters pp 8 TeV 50MeV aggregation
+    cuts.AddCutCalo("00052113","111110206f032230000","01631031000000d0"); // std
+    cuts.AddCutCalo("00081113","111110206f032230000","01631031000000d0"); // std
+  } else if (trainConfig == 2154){ // EMCAL clusters pp 8 TeV 150MeV aggregation
+    cuts.AddCutCalo("00010113","111110306f032230000","01631031000000d0"); // std
+  } else if (trainConfig == 2155){ // EMCAL clusters pp 8 TeV 150MeV aggregation
+    cuts.AddCutCalo("00052113","111110306f032230000","01631031000000d0"); // std
+    cuts.AddCutCalo("00081113","111110306f032230000","01631031000000d0"); // std
+  } else if (trainConfig == 2156){ // EMCAL clusters pp 8 TeV 300MeV aggregation
+    cuts.AddCutCalo("00010113","111110406f032230000","01631031000000d0"); // std
+  } else if (trainConfig == 2157){ // EMCAL clusters pp 8 TeV 300MeV aggregation
+    cuts.AddCutCalo("00052113","111110406f032230000","01631031000000d0"); // std
+    cuts.AddCutCalo("00081113","111110406f032230000","01631031000000d0"); // std
 
 
   } else {

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pPb.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pPb.C
@@ -1944,6 +1944,27 @@ void AddTask_GammaConvCalo_pPb(
     cuts.AddCutPCMCalo("8008e123","00200009f9730000dge0400000","411790105f032230000","0h63103100000010"); // EG2+DG2
     cuts.AddCutPCMCalo("8008d123","00200009f9730000dge0400000","411790105f032230000","0h63103100000010"); // EG1+DG1
 
+  } else if (trainConfig == 2050){  // TB NL tests 100 MeV aggregation
+    cuts.AddCutPCMCalo("80010123","00200009f9730000dge0400000","411790105f032230000","0h63103100000010"); // INT7
+  } else if (trainConfig == 2051){  // TB NL tests 100 MeV aggregation
+    cuts.AddCutPCMCalo("8008e123","00200009f9730000dge0400000","411790105f032230000","0h63103100000010"); // EG2+DG2
+    cuts.AddCutPCMCalo("8008d123","00200009f9730000dge0400000","411790105f032230000","0h63103100000010"); // EG1+DG1
+  } else if (trainConfig == 2052){  // TB NL tests 50 MeV aggregation
+    cuts.AddCutPCMCalo("80010123","00200009f9730000dge0400000","411790205f032230000","0h63103100000010"); // INT7
+  } else if (trainConfig == 2053){  // TB NL tests 50 MeV aggregation
+    cuts.AddCutPCMCalo("8008e123","00200009f9730000dge0400000","411790205f032230000","0h63103100000010"); // EG2+DG2
+    cuts.AddCutPCMCalo("8008d123","00200009f9730000dge0400000","411790205f032230000","0h63103100000010"); // EG1+DG1
+  } else if (trainConfig == 2054){  // TB NL tests 150 MeV aggregation
+    cuts.AddCutPCMCalo("80010123","00200009f9730000dge0400000","411790305f032230000","0h63103100000010"); // INT7
+  } else if (trainConfig == 2055){  // TB NL tests 150 MeV aggregation
+    cuts.AddCutPCMCalo("8008e123","00200009f9730000dge0400000","411790305f032230000","0h63103100000010"); // EG2+DG2
+    cuts.AddCutPCMCalo("8008d123","00200009f9730000dge0400000","411790305f032230000","0h63103100000010"); // EG1+DG1
+  } else if (trainConfig == 2056){  // TB NL tests 300 MeV aggregation
+    cuts.AddCutPCMCalo("80010123","00200009f9730000dge0400000","411790405f032230000","0h63103100000010"); // INT7
+  } else if (trainConfig == 2057){  // TB NL tests 300 MeV aggregation
+    cuts.AddCutPCMCalo("8008e123","00200009f9730000dge0400000","411790405f032230000","0h63103100000010"); // EG2+DG2
+    cuts.AddCutPCMCalo("8008d123","00200009f9730000dge0400000","411790405f032230000","0h63103100000010"); // EG1+DG1
+
   // standard cut configs with no NL for SM-wise correction
   } else if (trainConfig == 2100){  // EMCal+DCAL clusters standard cuts, triggers, no NL, +-50ns timing (5)
     cuts.AddCutPCMCalo("80010123","00200009f9730000dge0400000","4117900057032230000","0h63103100000010"); // INT7

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvCalo_pp.C
@@ -2197,6 +2197,49 @@ void AddTask_GammaConvCalo_pp(
   } else if ( trainConfig == 2301){ // Jet QA
     cuts.AddCutPCMCalo("00010113","00200009327000008250400000","411791107l032230000","3l63103100000010"); //
 
+  // TB NL testconfigs diff aggregation thresholds
+  } else if ( trainConfig == 2400){ // LHC12 100 MeV aggregation TB NL
+    cuts.AddCutPCMCalo("00010113","00200009f9730000dge0400000","111110106f032230000","0163103100000010"); // std
+  } else if ( trainConfig == 2401){ // LHC12 100 MeV aggregation TB NL
+    cuts.AddCutPCMCalo("00052113","00200009f9730000dge0400000","111110106f032230000","0163103100000010"); // std
+    cuts.AddCutPCMCalo("00081113","00200009f9730000dge0400000","111110106f032230000","0163103100000010"); // std
+  } else if ( trainConfig == 2402){ // LHC12 50 MeV aggregation TB NL
+    cuts.AddCutPCMCalo("00010113","00200009f9730000dge0400000","111110206f032230000","0163103100000010"); // std
+  } else if ( trainConfig == 2403){ // LHC12 50 MeV aggregation TB NL
+    cuts.AddCutPCMCalo("00052113","00200009f9730000dge0400000","111110206f032230000","0163103100000010"); // std
+    cuts.AddCutPCMCalo("00081113","00200009f9730000dge0400000","111110206f032230000","0163103100000010"); // std
+  } else if ( trainConfig == 2404){ // LHC12 150 MeV aggregation TB NL
+    cuts.AddCutPCMCalo("00010113","00200009f9730000dge0400000","111110306f032230000","0163103100000010"); // std
+  } else if ( trainConfig == 2405){ // LHC12 150 MeV aggregation TB NL
+    cuts.AddCutPCMCalo("00052113","00200009f9730000dge0400000","111110306f032230000","0163103100000010"); // std
+    cuts.AddCutPCMCalo("00081113","00200009f9730000dge0400000","111110306f032230000","0163103100000010"); // std
+  } else if ( trainConfig == 2406){ // LHC12 300 MeV aggregation TB NL
+    cuts.AddCutPCMCalo("00010113","00200009f9730000dge0400000","111110406f032230000","0163103100000010"); // std
+  } else if ( trainConfig == 2407){ // LHC12 300 MeV aggregation TB NL
+    cuts.AddCutPCMCalo("00052113","00200009f9730000dge0400000","111110406f032230000","0163103100000010"); // std
+    cuts.AddCutPCMCalo("00081113","00200009f9730000dge0400000","111110406f032230000","0163103100000010"); // std
+
+  } else if (trainConfig == 2450){  // 100 MeV aggregation TB NL tests
+    cuts.AddCutPCMCalo("00010113","00200009f9730000dge0400000","411790107f032230000","0163103100000010"); // INT7
+  } else if (trainConfig == 2451){  // 100 MeV aggregation TB NL tests
+    cuts.AddCutPCMCalo("0008e113","00200009f9730000dge0400000","411790107f032230000","0163103100000010"); // EG2
+    cuts.AddCutPCMCalo("0008d113","00200009f9730000dge0400000","411790107f032230000","0163103100000010"); // EG1
+  } else if (trainConfig == 2452){  // 50 MeV aggregation TB NL tests
+    cuts.AddCutPCMCalo("00010113","00200009f9730000dge0400000","411790207f032230000","0163103100000010"); // INT7
+  } else if (trainConfig == 2453){  // 50 MeV aggregation TB NL tests
+    cuts.AddCutPCMCalo("0008e113","00200009f9730000dge0400000","411790207f032230000","0163103100000010"); // EG2
+    cuts.AddCutPCMCalo("0008d113","00200009f9730000dge0400000","411790207f032230000","0163103100000010"); // EG1
+  } else if (trainConfig == 2454){  // 150 MeV aggregation TB NL tests
+    cuts.AddCutPCMCalo("00010113","00200009f9730000dge0400000","411790307f032230000","0163103100000010"); // INT7
+  } else if (trainConfig == 2455){  // 150 MeV aggregation TB NL tests
+    cuts.AddCutPCMCalo("0008e113","00200009f9730000dge0400000","411790307f032230000","0163103100000010"); // EG2
+    cuts.AddCutPCMCalo("0008d113","00200009f9730000dge0400000","411790307f032230000","0163103100000010"); // EG1
+  } else if (trainConfig == 2456){  // 300 MeV aggregation TB NL tests
+    cuts.AddCutPCMCalo("00010113","00200009f9730000dge0400000","411790407f032230000","0163103100000010"); // INT7
+  } else if (trainConfig == 2457){  // 300 MeV aggregation TB NL tests
+    cuts.AddCutPCMCalo("0008e113","00200009f9730000dge0400000","411790407f032230000","0163103100000010"); // EG2
+    cuts.AddCutPCMCalo("0008d113","00200009f9730000dge0400000","411790407f032230000","0163103100000010"); // EG1
+
   } else {
     Error(Form("GammaConvCalo_%i",trainConfig), "wrong trainConfig variable no cuts have been specified for the configuration");
     return;

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.cxx
@@ -5559,26 +5559,36 @@ void AliCaloPhotonCuts::ApplyNonLinearity(AliVCluster* cluster, Int_t isMC, AliV
       }
       break;
 
-    // kPi0MCv3 for MC and kTestBeamv3 for data
     case 2:
-      if (fClusterType == 1|| fClusterType == 3 || fClusterType == 4){
-        if(isMC == 0) energy *= FunctionNL_kTestBeamv3(energy);
-        else energy *= FunctionNL_kPi0MCv3(energy);
-      }
-      break;
-    // kPi0MCv3 for MC and kTestBeamv2 for data
-    case 3:
-      if (fClusterType == 1|| fClusterType == 3 || fClusterType == 4){
-        if(isMC == 0) energy *= FunctionNL_kTestBeamv2(energy);
-        else energy *= FunctionNL_kPi0MCv3(energy);
+      if( fClusterType == 1 || fClusterType == 3 || fClusterType == 4){
+        // TB parametrization from Nico on Martin 50MeV points
+        if(isMC){
+          energy *= FunctionNL_NicoTB_50MeV_MC(energy);
+        } else {
+          energy *= FunctionNL_NicoTB_50MeV_Data(energy);
+        }
       }
       break;
 
-    // kPi0MCv2 for MC and kTestBeamv3 for data
+    case 3:
+      if( fClusterType == 1 || fClusterType == 3 || fClusterType == 4){
+        // TB parametrization from Nico on Martin 150MeV points
+        if(isMC){
+          energy *= FunctionNL_NicoTB_150MeV_MC(energy);
+        } else {
+          energy *= FunctionNL_NicoTB_150MeV_Data(energy);
+        }
+      }
+      break;
+
     case 4:
-      if (fClusterType == 1|| fClusterType == 3 || fClusterType == 4){
-        if(isMC == 0) energy *= FunctionNL_kTestBeamv3(energy);
-        else energy *= FunctionNL_kPi0MCv2(energy);
+      if( fClusterType == 1 || fClusterType == 3 || fClusterType == 4){
+        // TB parametrization from Nico on Martin 300MeV points
+        if(isMC){
+          energy *= FunctionNL_NicoTB_300MeV_MC(energy);
+        } else {
+          energy *= FunctionNL_NicoTB_300MeV_Data(energy);
+        }
       }
       break;
     // kPi0MCv2 for MC and kTestBeamv2 for data
@@ -7016,8 +7026,28 @@ Float_t AliCaloPhotonCuts::FunctionNL_MartinTB_100MeV_Data(Float_t e){
   return ( 0.944965 + 0.0172497 * TMath::Log(e) ) / ( 1 + ( 0.0807799 * TMath::Exp( ( e - 128.776 ) / 68.2001 ) ) );
 }
 
+Float_t AliCaloPhotonCuts::FunctionNL_NicoTB_50MeV_MC(Float_t e){
+  return ( 1.00664 / ( 0.997815 * ( 1. / ( 1. + 0.0519753 * exp( -e / 2.97828 ) ) * 1. / ( 1. + 0.0350962 * exp( ( e - 281.594 ) / 100 ) ) ) ) );
+}
+
 Float_t AliCaloPhotonCuts::FunctionNL_NicoTB_100MeV_MC(Float_t e){
   return ( 1.00939 / ( 0.994991 * ( 1. / ( 1. + 0.0662974 * exp( -e / 4.70055 ) ) * 1. / ( 1. + 0.0289532 * exp( ( e - 316.63 ) / 110.8241 ) ) ) ) );
+}
+Float_t AliCaloPhotonCuts::FunctionNL_NicoTB_150MeV_MC(Float_t e){
+  return ( 1.0117 / ( 0.992572 * ( 1. / ( 1. + 0.0787739 * exp( -e / 5.20746 ) ) * 1. / ( 1. + 0.0158331 * exp( ( e - 347.442 ) / 142.014 ) ) ) ) );
+}
+
+Float_t AliCaloPhotonCuts::FunctionNL_NicoTB_300MeV_MC(Float_t e){
+  return ( 1.01423 / ( 0.990431 * ( 1. / ( 1. + 0.0723383 * exp( -e / 11.4416 ) ) * 1. / ( 1. + 0.0284403 * exp( ( e - 627.687 ) / 241.844 ) ) ) ) );
+}
+
+
+Float_t AliCaloPhotonCuts::FunctionNL_NicoTB_50MeV_Data(Float_t e){
+  if(e<6){
+    return (  1.39159 / (  0.604682 * ( 1. / ( 1. + 0.135802 * exp( -e / 0.588296 ) ) * 1. / ( 1. + -13.075 * exp( ( e - 4548.85 ) / 1438.15 ) ) ) ) );
+  } else {
+    return (  1.00077 / ( 1.00381 * ( 1. / ( 1. + 0.0344409 * exp( -e / 12.683 ) ) * 1. / ( 1. + 0.152798 * exp( ( e - 187.913 ) / 52.4357 ) ) ) ) );
+  }
 }
 
 Float_t AliCaloPhotonCuts::FunctionNL_NicoTB_100MeV_Data(Float_t e){
@@ -7027,6 +7057,19 @@ Float_t AliCaloPhotonCuts::FunctionNL_NicoTB_100MeV_Data(Float_t e){
     return (  0.984722 / ( 1.01604 * ( 1. / ( 1. + 0.0667993 * exp( -e / 41.6903 ) ) * 1. / ( 1. + 0.0630037 * exp( ( e - 112.39 ) / 69.2009 ) ) ) ) );
   }
 }
+
+Float_t AliCaloPhotonCuts::FunctionNL_NicoTB_150MeV_Data(Float_t e){
+  if(e<5){
+    return (  1.00652 / (  0.997787 * ( 1. / ( 1. + 0.131538 * exp( -e / 0.598796 ) ) * 1. / ( 1. + 0.0906299 * exp( ( e - 81.4118 ) / 122.234 ) ) ) ) );
+  } else {
+    return (  0.990574 / ( 1.01352 * ( 1. / ( 1. + 0.0798362 * exp( -e / 36.3556 ) ) * 1. / ( 1. + 0.0823721 * exp( ( e - 134.468 ) / 67.0797 ) ) ) ) );
+  }
+}
+
+Float_t AliCaloPhotonCuts::FunctionNL_NicoTB_300MeV_Data(Float_t e){
+  return (  0.930766 / (  1.07578 * ( 1. / ( 1. + 0.216824 * exp( -e / 88.0602 ) ) * 1. / ( 1. + 0.0748823 * exp( ( e - 56.6679 ) / 91.1971 ) ) ) ) );
+}
+
 
 Float_t AliCaloPhotonCuts::FunctionNL_kPi0MCv1(Float_t e){
   return ( 1.014 * exp( 0.03329 / e ) ) + ( ( -0.3853 / ( 0.5423 * 2. * TMath::Pi() ) * exp( -( e + 0.4335 ) * ( e + 0.4335 ) / (2. * 0.5423 * 0.5423 ) ) ) );

--- a/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
+++ b/PWGGA/GammaConvBase/AliCaloPhotonCuts.h
@@ -306,8 +306,14 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
     Float_t     FunctionNL_kPi0MCMod(Float_t e, Float_t p0, Float_t p1, Float_t p2, Float_t p3, Float_t p4, Float_t p5, Float_t p6);
     Float_t     FunctionNL_MartinTB_100MeV_MC(Float_t e);
     Float_t     FunctionNL_MartinTB_100MeV_Data(Float_t e);
+    Float_t     FunctionNL_NicoTB_50MeV_Data(Float_t e);
     Float_t     FunctionNL_NicoTB_100MeV_Data(Float_t e);
+    Float_t     FunctionNL_NicoTB_150MeV_Data(Float_t e);
+    Float_t     FunctionNL_NicoTB_300MeV_Data(Float_t e);
+    Float_t     FunctionNL_NicoTB_50MeV_MC(Float_t e);
     Float_t     FunctionNL_NicoTB_100MeV_MC(Float_t e);
+    Float_t     FunctionNL_NicoTB_150MeV_MC(Float_t e);
+    Float_t     FunctionNL_NicoTB_300MeV_MC(Float_t e);
     Float_t     FunctionNL_kSDMv5(Float_t e);
     Float_t     FunctionNL_kSDMv6(Float_t e);
     Float_t     FunctionNL_kTestBeamv2(Float_t e);
@@ -636,7 +642,7 @@ class AliCaloPhotonCuts : public AliAnalysisCuts {
 
   private:
 
-    ClassDef(AliCaloPhotonCuts,91)
+    ClassDef(AliCaloPhotonCuts,92)
 };
 
 #endif


### PR DESCRIPTION
The datapoints and fits for the TB NL can be found in the following plots.

[nonlin_Martin_50MeV.pdf](https://github.com/alisw/AliPhysics/files/3505005/nonlin_Martin_50MeV.pdf)
[nonlin_Martin_100MeV.pdf](https://github.com/alisw/AliPhysics/files/3505006/nonlin_Martin_100MeV.pdf)
[nonlin_Martin_150MeV.pdf](https://github.com/alisw/AliPhysics/files/3505007/nonlin_Martin_150MeV.pdf)
[nonlin_Martin_300MeV.pdf](https://github.com/alisw/AliPhysics/files/3505008/nonlin_Martin_300MeV.pdf)
