### PR TITLE
OADB/COMMON/MULTIPLICITY: bug-fix in macro OADB-creation for pPb

### DIFF
--- a/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibratorMC.h
+++ b/OADB/COMMON/MULTIPLICITY/AliMultSelectionCalibratorMC.h
@@ -8,26 +8,27 @@
 using namespace std;
 class AliESDEvent;
 class AliMultSelectionCalibratorMC : public TNamed {
-    
+
 public:
-    
+
     //Constructors/Destructor
     AliMultSelectionCalibratorMC();
     AliMultSelectionCalibratorMC(const char * name, const char * title = "Multiplicity Calibration Class");
     ~AliMultSelectionCalibratorMC();
-    
+
     //void    Print(Option_t *option="") const;
-    
+
     //_________________________________________________________________________
     //Interface: steering functions to be used in calibration macro
-  
+
     //Set Filenames
     void SetInputFileData ( TString lFile ) { fInputFileNameData = lFile.Data(); }
     void SetInputFileOADB ( TString lFile ) { fInputFileNameOADB = lFile.Data(); }
-    void SetInputFileMC   ( TString lFile ) { fInputFileNameMC = lFile.Data(); } 
-    
+    void SetInputFileMC   ( TString lFile ) { fInputFileNameMC = lFile.Data(); }
+
     void SetBufferFileData    ( TString lFile ) { fBufferFileNameData = lFile.Data(); }
-    void SetBufferFileMC      ( TString lFile ) { fBufferFileNameMC   = lFile.Data(); } 
+    void SetBufferFileMC      ( TString lFile ) { fBufferFileNameMC   = lFile.Data(); }
+    void SetDebugFile      ( TString lFile ) { fDebugFileName   = lFile.Data(); }
     void SetOutputFile    ( TString lFile ) { fOutputFileName = lFile.Data(); }
     //Set Boundaries to find
     void SetBoundaries ( Long_t lNB, Double_t *lB ){
@@ -38,68 +39,69 @@ public:
         lDesiredBoundaries = lB;
         lNDesiredBoundaries = lNB;
     }
-    
+
     //Getter for event selection criteria
     AliMultSelectionCuts * GetEventCuts() const { return fMultSelectionCuts;     }
-    
+
     //Getter for MultSelection object
-    //WARNING - should not be used in this case! 
+    //WARNING - should not be used in this case!
     AliMultSelection * GetMultSelection() const { return fSelection;     }
 
     //Getter for MultInput object
     AliMultInput * GetMultInput() const { return fInput;     }
-    
+
     //Setter for golden run
     void SetRunToUseAsDefault ( Int_t lRunNumber ) { fRunToUseAsDefault = lRunNumber; }
-    
+
     //Getter for golden run
     Int_t GetRunToUseAsDefault() const { return fRunToUseAsDefault; }
-    
+
     //Configure standard input
     void SetupStandardInput();
-    
+
     //Switch to configure <Ntracklet> fit type
     void SetUseQuadraticMapping(Bool_t lOpt){ fkUseQuadraticMapping=lOpt; }
-    
+
     //Master Function in this Class: To be called once filenames are set
     Bool_t Calibrate();
-    
+
     //Helper
     Float_t MinVal( Float_t A, Float_t B );
-    
-    void AddV0MCutoff( Int_t lRunNumber, Float_t lV0MCutoff );
-    
-private:
-    AliMultInput     *fInput;     //Object for all input
-    AliMultSelection *fSelection; //Object for all estimators
 
-    //Calibration Boundaries to locate
-    Double_t *lDesiredBoundaries;
-    Long_t   lNDesiredBoundaries;
-    
-    //Run to use as default for scaling factor in this period
-    Int_t fRunToUseAsDefault;
-    
+    void AddV0MCutoff( Int_t lRunNumber, Float_t lV0MCutoff );
+
+private:
     TString fInputFileNameData;  // Filename for TTree object for calibration purposes
     TString fInputFileNameOADB;  // Filename for TTree object for calibration purposes
     TString fInputFileNameMC;    // Filename for TTree object for calibration purposes
     TString fBufferFileNameData; // Filename for TTree object (buffer file)
     TString fBufferFileNameMC;   // Filename for TTree object (buffer file)
+    TString fDebugFileName;      // Filename for debugfile
     TString fOutputFileName;     // Filename for calibration OADB output (MC)
-    
-    //Configuration
-    Bool_t fkUseQuadraticMapping; //switch to toggle quadratic <Ntracklets> fits
-    
+
+    AliMultInput     *fInput;     //Object for all input
+    AliMultSelection *fSelection; //Object for all estimators
+
     // Object for storing event selection configuration
     AliMultSelectionCuts *fMultSelectionCuts;
-    
+
     // TList object for storing histograms
     TList *fCalibHists;
+
+    //Calibration Boundaries to locate
+    Long_t   lNDesiredBoundaries;
+    Double_t *lDesiredBoundaries;
+
+    //Run to use as default for scaling factor in this period
+    Int_t fRunToUseAsDefault;
+
+    //Configuration
+    Bool_t fkUseQuadraticMapping; //switch to toggle quadratic <Ntracklets> fits
 
     //Run maps: for manual V0M cutoff if requested
     Long_t fNV0MCutoffs;
     std::map<int, float> fV0MCutoffs;
-    
-    ClassDef(AliMultSelectionCalibratorMC, 1);
+
+    ClassDef(AliMultSelectionCalibratorMC, 2);
 };
 #endif

--- a/OADB/COMMON/MULTIPLICITY/macros/calibration/CalibratePeriodMC.C
+++ b/OADB/COMMON/MULTIPLICITY/macros/calibration/CalibratePeriodMC.C
@@ -56,6 +56,7 @@ void CalibratePeriodMC( TString lPeriodName         = "",
   }
 
   //Output OADB
+  lCalib -> SetDebugFile     ( Form("debug-%s%s.root",lPeriodName.Data(),addNameOutput.Data()) );
   lCalib -> SetOutputFile     ( Form("OADB-%s%s.root",lPeriodName.Data(),addNameOutput.Data()) );
   lCalib -> Calibrate     ();
 

--- a/OADB/COMMON/MULTIPLICITY/macros/calibration/CalibratePeriodpPb.C
+++ b/OADB/COMMON/MULTIPLICITY/macros/calibration/CalibratePeriodpPb.C
@@ -157,11 +157,11 @@ void CalibratePeriodpPb(  TString lPeriodName         = "LHC16s",
   for (Int_t i = 0; i < 20; i++){
     if (fitCorrZVtx[i] && enableZVtxCorr[i]){
       TString currentFormula = fitCorrZVtx[i]->GetExpFormula();
-      for (Int_t i = 0; i < fitCorrZVtx[i]->GetNpar(); i++){
+      for (Int_t k = 0; k < fitCorrZVtx[i]->GetNpar(); k++){
         #ifndef __CLING__
-          currentFormula.ReplaceAll(Form("[p%d]",i), Form("(%.10f)",fitCorrZVtx[i]->GetParameter(i)));
+          currentFormula.ReplaceAll(Form("[p%d]",k), Form("(%.10f)",fitCorrZVtx[i]->GetParameter(k)));
         #else
-          currentFormula.ReplaceAll(Form("[%d]",i), Form("(%.10f)",fitCorrZVtx[i]->GetParameter(i)));
+          currentFormula.ReplaceAll(Form("[%d]",k), Form("(%.10f)",fitCorrZVtx[i]->GetParameter(k)));
         #endif
       }
       currentFormula.ReplaceAll("x","(fEvSel_VtxZ)");

--- a/OADB/COMMON/MULTIPLICITY/macros/calibration/CompareVtxPositionDifferentPeriods.C
+++ b/OADB/COMMON/MULTIPLICITY/macros/calibration/CompareVtxPositionDifferentPeriods.C
@@ -263,6 +263,8 @@ void CompareVtxPositionDifferentPeriods(
       collisionSystem = "p-Pb #sqrt{#it{s}_{_{NN}}} = 8.16 TeV";
   else if ( energy.CompareTo("XeXe_5TeV") == 0 )
     collisionSystem = "Xe-Xe #sqrt{#it{s}_{_{NN}}} = 5.44 TeV";
+  else if ( energy.CompareTo("5TeV") == 0 )
+    collisionSystem = "pp #sqrt{#it{s}} = 5.02 TeV";
 
 
   TString nameOutputDir = Form("CalibrationQA/CompareDifferentPeriods%s_%s",addName.Data(), energy.Data());
@@ -295,15 +297,16 @@ void CompareVtxPositionDifferentPeriods(
   }
 
 
-  TString nameCalibrators[14] = { "V0A", "V0C", "V0M", "V0AEq", "V0CEq",
+  TString nameCalibrators[17] = { "V0A", "V0C", "V0M", "V0AEq", "V0CEq",
                                   "V0MEq", "SPDCl0", "SPDCl1", "SPDCl", "RefMultEta5",
-                                  "RefMultEta8", "NTracklets", "ZNA", "ZNC"};
-  TString axislabelPlot[14]   = { "V0A", "V0C", "V0M", "V0AEq", "V0CEq",
+                                  "RefMultEta8", "NTracklets", "ZNA", "ZNC", "V0AOnline", "V0COnline",
+                                  "V0MOnline",};
+  TString axislabelPlot[17]   = { "V0A", "V0C", "V0M", "V0AEq", "V0CEq",
                                   "V0MEq", "CL0", "CL1", "SPD cl.", "mult |#eta| < 0.5",
-                                  "mult |#eta| < 0.8", "SPD tracklets", "ZNA", "ZNC"};
+                                  "mult |#eta| < 0.8", "SPD tracklets", "ZNA", "ZNC", "V0A online", "V0C online", "V0M online",};
   TFile* commonOutputFile     = new TFile(outputFileName.Data(),"UPDATE");
 
-  for (Int_t cal = 0; cal< 14; cal++){
+  for (Int_t cal = 0; cal< 17; cal++){
     TProfile* hprofCalibrator[20] = {NULL};
     TF1* fitCalibrator[20]        = {NULL};
     TString currentNameProf       = Form("hprofVtxZvs%s", nameCalibrators[cal].Data());


### PR DESCRIPTION
- bug fix for the OADB creation macro in pPb to correctly read the parameters of the Z-vertex correction from the root-input file
- inverting axis of the debug output per run for the MC calibration in order to ease comparisons for the supercalib