### PR TITLE
Bug fixes to jT analysis

### DIFF
--- a/PWGCF/Correlations/JCORRAN/Pro/AliJJetJtAnalysis.cxx
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJJetJtAnalysis.cxx
@@ -2388,14 +2388,18 @@ void AliJJetJtAnalysis::FillJtHistogram( TObjArray *Jets , TObjArray *ChargedJet
       (*fConstLabels)[icon] = -1;
       (*fConstFound)[icon] = -1;
       (*fJetPt)[icon] = -1;
-      (*fLeadJetPhi)[icon] = -1;
-      (*fLeadJetEta)[icon] = -1;
-      (*fSubLeadJetPhi)[icon] = -1;
-      (*fSubLeadJetEta)[icon] = -1;
       (*fTrackFound)[icon] = -1;
       AliJBaseTrack *track = dynamic_cast<AliJBaseTrack*>(trackArray->At(icon));
       if (!track) continue;
       (*fTrackPt)[icon] = track->Pt();
+    }
+    int nAnti = fJetListOfList.GetEntries()-fnkt;
+    for( int iLead=0;iLead<nAnti/2;iLead++ ){
+      (*fLeadJetPhi)[iLead] = -1;
+      (*fLeadJetEta)[iLead] = -1;
+      (*fSubLeadJetPhi)[iLead] = -1;
+      (*fSubLeadJetEta)[iLead] = -1;
+
     }
   }
 

--- a/PWGCF/Correlations/JCORRAN/Pro/AliJJetJtTask.cxx
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJJetJtTask.cxx
@@ -242,20 +242,26 @@ void AliJJetJtTask::UserExec(Option_t* /*option*/)
   float fcent = -999;
   if(fRunTable->IsHeavyIon() || fRunTable->IsPA()){
     if(fDebug > 6) cout << fRunTable->GetPeriodName() << endl;
-    if(fSelector != ""){
-      fcent = sel->GetMultiplicityPercentile(fSelector);
-    }else{
-      if(fRunTable->IsPA() && !(fRunTable->GetPeriodName().BeginsWith("LHC13"))){
-        sel = (AliMultSelection*) InputEvent() -> FindListObject("MultSelection");
-        if (sel) {
+    if(fRunTable->IsPA() && !(fRunTable->GetPeriodName().BeginsWith("LHC13"))){
+      sel = (AliMultSelection*) InputEvent() -> FindListObject("MultSelection");
+      if (sel) {
+        if(fSelector != ""){
+          fcent = sel->GetMultiplicityPercentile(fSelector);
+        }else{
           fcent = sel->GetMultiplicityPercentile("V0A");
         }
-        else{
-          if(fDebug > 2) cout << "Sel not found" << endl;
-        }
+      }
+      else{
+        if(fDebug > 2) cout << "Sel not found" << endl;
+      }
+    }
+    else{
+      AliCentrality *cent = event->GetCentrality();
+      if( ! cent ) return;
+      if(fSelector != ""){
+          fcent = cent->GetCentralityPercentile(fSelector);
+
       }else{
-        AliCentrality *cent = event->GetCentrality();
-        if( ! cent ) return;
         if(fRunTable->GetPeriodName().BeginsWith("LHC13")){
           fcent = cent->GetCentralityPercentile("V0A");
         }else{


### PR DESCRIPTION
Correct crash when using other than V0 for centrality
Remove unnecessary warnings from vector indices