### PR TITLE
Changing the correction framwork and Tedner task to load 1D BC map

### DIFF
--- a/PWG/CaloTrackCorrBase/AliCalorimeterUtils.h
+++ b/PWG/CaloTrackCorrBase/AliCalorimeterUtils.h
@@ -146,6 +146,8 @@ class AliCalorimeterUtils : public TObject {
                                                              if(!fPHOSBadChannelMap) InitPHOSBadChannelStatusMap()    ; }
   void          SwitchOffBadChannelsRemoval()              { fRemoveBadChannels = kFALSE ; 
                                                              fEMCALRecoUtils->SwitchOffBadChannelsRemoval()           ; }
+
+  void          Load1DBadChannelMap()                      { fLoad1DBadChMap=kTRUE; }
   
   Bool_t        IsDistanceToBadChannelRecalculated() const { return fEMCALRecoUtils->IsDistanceToBadChannelRecalculated(); }
   void          SwitchOnDistToBadChannelRecalculation ()   { fEMCALRecoUtils->SwitchOnDistToBadChannelRecalculation() ; }
@@ -168,9 +170,11 @@ class AliCalorimeterUtils : public TObject {
                   ((TH2I*)fPHOSBadChannelMap->At(imod))->SetBinContent(iCol,iRow,c) ; }
     
   void          SetEMCALChannelStatusMap(Int_t iSM , TH2I* h) { fEMCALRecoUtils->SetEMCALChannelStatusMap(iSM,h)      ; }
+  void          SetEMCALChannelStatusMap1D(TH1C* h) { fEMCALRecoUtils->SetEMCALChannelStatusMap1D(h)      ; }
   void          SetPHOSChannelStatusMap(Int_t imod , TH2I* h) { fPHOSBadChannelMap ->AddAt(h,imod)                    ; }
   
   TH2I *        GetEMCALChannelStatusMap(Int_t iSM)  const { return fEMCALRecoUtils->GetEMCALChannelStatusMap(iSM)    ; }
+  TH1C *        GetEMCALChannelStatusMap1D()  const { return fEMCALRecoUtils->GetEMCALChannelStatusMap1D()    ; }
   TH2I *        GetPHOSChannelStatusMap(Int_t imod)  const { return (TH2I*)fPHOSBadChannelMap->At(imod)               ; }
 
   void          SetEMCALChannelStatusMap(TObjArray *map)   { fEMCALRecoUtils->SetEMCALChannelStatusMap(map)           ; }
@@ -421,6 +425,8 @@ class AliCalorimeterUtils : public TObject {
   TGeoHMatrix *      fPHOSMatrix[5];            ///<  Geometry matrices with alignments.
 
   Bool_t             fRemoveBadChannels;        ///<  Check the channel status provided and remove clusters with bad channels.
+
+  Bool_t             fLoad1DBadChMap;           ///<  Flag to load 1D bad channel map.
 
   TObjArray        * fPHOSBadChannelMap;        ///<  Array of histograms with map of bad channels, PHOS.
 

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -272,6 +272,7 @@ public:
                                                            if(!fEMCALBadChannelMap)InitEMCALBadChannelStatusMap() ; }
   TObjArray* GetEMCALBadChannelStatusMapArray()    const { return fEMCALBadChannelMap ; }
   void     InitEMCALBadChannelStatusMap() ;
+  void     InitEMCALBadChannelStatusMap1D() ;
   void     SetEMCALBadChannelStatusSelection(Bool_t all, Bool_t dead, Bool_t hot, Bool_t warm);
   void     SetWarmChannelAsGood() 
            { fBadStatusSelection[0] = kFALSE; fBadStatusSelection[AliCaloCalibPedestal::kWarning] = kFALSE; }
@@ -280,12 +281,18 @@ public:
   void     SetHotChannelAsGood() 
            { fBadStatusSelection[0] = kFALSE; fBadStatusSelection[AliCaloCalibPedestal::kHot]     = kFALSE; } 
   Bool_t   GetEMCALChannelStatus(Int_t iSM , Int_t iCol, Int_t iRow, Int_t & status) const ;
+  Bool_t   GetEMCALChannelStatus1D(Int_t iCell, Int_t & status) const ;
   void     SetEMCALChannelStatus(Int_t iSM , Int_t iCol, Int_t iRow, Double_t status = 1) { 
     if(!fEMCALBadChannelMap)InitEMCALBadChannelStatusMap()               ;
     ((TH2I*)fEMCALBadChannelMap->At(iSM))->SetBinContent(iCol,iRow,status)    ; }
-  TH2I *   GetEMCALChannelStatusMap(Int_t iSM)     const { return (TH2I*)fEMCALBadChannelMap->At(iSM) ; }
+  void     SetEMCALChannelStatus1D(Int_t iCell, Double_t status = 1) { 
+    if(!fEMCALBadChannelMap)InitEMCALBadChannelStatusMap1D()               ;
+    ((TH1C*)fEMCALBadChannelMap->At(0))->SetBinContent(iCell,status)    ; }
+  TH2I *   GetEMCALChannelStatusMap(Int_t iSM)     const;
+  TH1C *   GetEMCALChannelStatusMap1D()     const { return (TH1C*)fEMCALBadChannelMap->At(0) ; }
   void     SetEMCALChannelStatusMap(const TObjArray *map);
   void     SetEMCALChannelStatusMap(Int_t iSM , const TH2I* h);
+  void     SetEMCALChannelStatusMap1D(const TH1C* h);
   Bool_t   ClusterContainsBadChannel(const AliEMCALGeometry* geom, const UShort_t* cellList, Int_t nCells);
  
   //-----------------------------------------------------
@@ -504,6 +511,7 @@ private:
   Bool_t     fRemoveBadChannels;         ///< Check the channel status provided and remove clusters with bad channels
   Bool_t     fRecalDistToBadChannels;    ///< Calculate distance from highest energy tower of cluster to closes bad channel
   TObjArray* fEMCALBadChannelMap;        ///< Array of histograms with map of bad channels, EMCAL
+  Bool_t     fUse1Dmap;                  ///< Flag to use one 1D bad channel map (for all cells)
   Bool_t     fBadStatusSelection[4];     ///< Declare as bad all the types of bad channels or only some. 
                                          ///<   0- Set all types to bad if true
                                          ///<   1- Set dead as good if false
@@ -569,7 +577,7 @@ private:
   Bool_t     fMCGenerToAcceptForTrack;   ///<  Activate the removal of tracks entering the track matching that come from a particular generator
   
   /// \cond CLASSIMP
-  ClassDef(AliEMCALRecoUtils, 30) ;
+  ClassDef(AliEMCALRecoUtils, 31) ;
   /// \endcond
 
 };

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellBadChannel.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellBadChannel.cxx
@@ -65,6 +65,9 @@ Bool_t AliEmcalCorrectionCellBadChannel::Initialize()
   Bool_t warm = kFALSE;
   GetProperty("acceptWarm", warm);
   if ( warm ) fRecoUtils->SetWarmChannelAsGood();
+
+  // Load 1D bad channel map
+  GetProperty("load1DBadChMap", fLoad1DBadChMap);
   
   return kTRUE;
 }

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.cxx
@@ -205,6 +205,9 @@ Bool_t AliEmcalCorrectionClusterizer::Initialize()
   if (fClusterCollArray.GetEntries() > 1) {
     AliFatal("Passed more than one cluster container to the clusterizer, but the clusterizer only supports one cluster container!");
   }
+
+  // Load 1D bad channel map
+  GetProperty("load1DBadChMap", fLoad1DBadChMap);
   
   return kTRUE;
 }

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.cxx
@@ -31,6 +31,7 @@ AliEmcalCorrectionComponent::AliEmcalCorrectionComponent() :
   TNamed("AliEmcalCorrectionComponent", "AliEmcalCorrectionComponent"),
   fYAMLConfig(),
   fCreateHisto(kTRUE),
+  fLoad1DBadChMap(kFALSE),
   fRun(-1),
   fFilepass(""),
   fGetPassFromFileName(kTRUE),
@@ -66,6 +67,7 @@ AliEmcalCorrectionComponent::AliEmcalCorrectionComponent(const char * name) :
   TNamed(name, name),
   fYAMLConfig(),
   fCreateHisto(kTRUE),
+  fLoad1DBadChMap(kFALSE),
   fRun(-1),
   fFilepass(""),
   fGetPassFromFileName(kTRUE),
@@ -330,10 +332,10 @@ Int_t AliEmcalCorrectionComponent::InitBadChannels()
   { //if fBasePath specified in the ->SetBasePath()
     AliInfo(Form("Loading Bad Channels OADB from given path %s",fBasePath.Data()));
     
-    fbad = std::unique_ptr<TFile>(TFile::Open(Form("%s/EMCALBadChannels.root",fBasePath.Data()),"read"));
+    fbad = std::unique_ptr<TFile>(TFile::Open(Form("%s/EMCALBadChannels%s.root",fBasePath.Data(), fLoad1DBadChMap ? "_1D" : ""),"read"));
     if (!fbad || fbad->IsZombie())
     {
-      AliFatal(Form("EMCALBadChannels.root was not found in the path provided: %s",fBasePath.Data()));
+      AliFatal(Form("EMCALBadChannels%s.root was not found in the path provided: %s", fLoad1DBadChMap ? "_1D" : "", fBasePath.Data()));
       return 0;
     }
     
@@ -356,10 +358,10 @@ Int_t AliEmcalCorrectionComponent::InitBadChannels()
   { // Else choose the one in the $ALICE_PHYSICS directory
     AliInfo("Loading Bad Channels OADB from $ALICE_PHYSICS/OADB/EMCAL");
     
-    fbad = std::unique_ptr<TFile>(TFile::Open(AliDataFile::GetFileNameOADB("EMCAL/EMCALBadChannels.root").data(),"read"));
+    fbad = std::unique_ptr<TFile>(TFile::Open(AliDataFile::GetFileNameOADB(Form("EMCAL/EMCALBadChannels%s.root", fLoad1DBadChMap ? "_1D" : "")).data(),"read"));
     if (!fbad || fbad->IsZombie())
     {
-      AliFatal("OADB/EMCAL/EMCALBadChannels.root was not found");
+      AliFatal(Form("OADB/EMCAL/EMCALBadChannels%s.root was not found", fLoad1DBadChMap ? "_1D" : ""));
       return 0;
     }
     
@@ -378,23 +380,37 @@ Int_t AliEmcalCorrectionComponent::InitBadChannels()
     return 2;
   }
   
-  Int_t sms = fGeom->GetEMCGeometry()->GetNumberOfSuperModules();
-  for (Int_t i=0; i<sms; ++i)
-  {
-    TH2I *h = fRecoUtils->GetEMCALChannelStatusMap(i);
+  if(fLoad1DBadChMap){
+    TH1C *h = fRecoUtils->GetEMCALChannelStatusMap1D();
     if (h)
       delete h;
-    h=(TH2I*)arrayBC->FindObject(Form("EMCALBadChannelMap_Mod%d",i));
-    
+    h=(TH1C*)arrayBC->FindObject("EMCALBadChannelMap");
+      
     if (!h)
     {
-      AliError(Form("Can not get EMCALBadChannelMap_Mod%d",i));
-      continue;
+      AliError("Can not get EMCALBadChannelMap");
     }
     h->SetDirectory(0);
-    fRecoUtils->SetEMCALChannelStatusMap(i,h);
+    fRecoUtils->SetEMCALChannelStatusMap1D(h);
+  }else{
+    Int_t sms = fGeom->GetEMCGeometry()->GetNumberOfSuperModules();
+    for (Int_t i=0; i<sms; ++i)
+    {
+      TH2I *h = fRecoUtils->GetEMCALChannelStatusMap(i);
+      if (h)
+        delete h;
+      h=(TH2I*)arrayBC->FindObject(Form("EMCALBadChannelMap_Mod%d",i));
+      
+      if (!h)
+      {
+        AliError(Form("Can not get EMCALBadChannelMap_Mod%d",i));
+        continue;
+      }
+      h->SetDirectory(0);
+      fRecoUtils->SetEMCALChannelStatusMap(i,h);
+    }
   }
-  
+    
   return 1;
 }
 

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.h
@@ -112,6 +112,7 @@ class AliEmcalCorrectionComponent : public TNamed {
  protected:
   PWG::Tools::AliYAMLConfiguration fYAMLConfig;           ///< Contains the %YAML configuration used to configure the component
   Bool_t                  fCreateHisto;                   ///< Flag to make some basic histograms
+  Bool_t                  fLoad1DBadChMap;                ///< Flag to load 1D bad channel map
   Int_t                   fRun;                           //!<! Run number
   TString                 fFilepass;                      ///< Input data pass number
   Bool_t                  fGetPassFromFileName;           ///< Get fFilepass from file name

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionComponent.h
@@ -142,7 +142,7 @@ class AliEmcalCorrectionComponent : public TNamed {
   AliEmcalCorrectionComponent &operator=(const AliEmcalCorrectionComponent &);    // Not implemented
   
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionComponent, 8); // EMCal correction component
+  ClassDef(AliEmcalCorrectionComponent, 9); // EMCal correction component
   /// \endcond
 };
 

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -66,6 +66,7 @@ CellEnergy:                                         # Cell Energy correction com
 CellBadChannel:                                     # Bad channel removal at the cell level component
     enabled: false                                  # Whether to enable the task
     createHistos: false                             # Whether the task should create output histograms
+    load1DBadChMap: false                           # Flag to load 1D bad channel map
     customBadChannelFilePath: ""                    # Full path to a custom bad channel OADB object
     acceptDead: false                               # Declare dead channels as good
     acceptHot: false                                # Declare hot channels as good
@@ -157,6 +158,7 @@ CellCombineCollections:                             # Utility task to combine tw
 Clusterizer:                                        # Clusterizer component
     enabled: false                                  # Whether to enable the task
     createHistos: false                             # Whether the task should create output histograms
+    load1DBadChMap: false                           # Flag to load 1D bad channel map
     clusterizer: kClusterizerv3                     # Type of clusterizer to use. Possible options are defined in the header of the clusterizer
     unfold: false                                   # Activate cluster unfolding
     unfoldRejectBelowThreshold: false               #  split (false-default) or reject (true) cell energy below threshold after UF

--- a/PWG/EMCAL/macros/AddTaskEMCALTender.C
+++ b/PWG/EMCAL/macros/AddTaskEMCALTender.C
@@ -35,7 +35,8 @@ AliAnalysisTaskSE *AddTaskEMCALTender(
   Bool_t useNewRWTempCalib    = kFALSE,   // switch for usage of new temperature calib parameters (available for run1 and run2)
   TString customSMtemps       = "",       // location of custom SM-wise temperature OADB file (full path including file)
   TString customTempParams    = "",        // location of custom temperature calibration parameters OADB file (full path including file)
-  Bool_t useOneHistAllBCS     = kFALSE    // flag to use on histogram for the all the BCs
+  Bool_t useOneHistAllBCS     = kFALSE,    // flag to use on histogram for the all the BCs
+  Bool_t load1DBCmap          = kFALSE     // Flag to load 1D bad channel map
 ) 
 {
   // Get the pointer to the existing analysis manager via the static access method.
@@ -94,6 +95,8 @@ AliAnalysisTaskSE *AddTaskEMCALTender(
   #endif
 
   EMCALSupply->SwitchUseMergedBCs(useOneHistAllBCS);
+
+  if(load1DBCmap) EMCALSupply->Load1DBadChannelMap();
 
   if (pass) 
     EMCALSupply->SetPass(pass);

--- a/TENDER/TenderSupplies/AliEMCALTenderSupply.h
+++ b/TENDER/TenderSupplies/AliEMCALTenderSupply.h
@@ -147,6 +147,8 @@ public:
   void     SwitchOnBadCellRemove()                        { fBadCellRemove = kTRUE           ;} 
   void     SwitchOffBadCellRemove()                       { fBadCellRemove = kFALSE          ;}  
 
+  void     Load1DBadChannelMap()                          { fLoad1DBadChMap = kTRUE          ;}
+
   void     SwitchOnClusterBadChannelCheck()               { fClusterBadChannelCheck = kTRUE  ;} 
   void     SwitchOffClusterBadChannelCheck()              { fClusterBadChannelCheck = kFALSE ;}  
 
@@ -241,6 +243,7 @@ private:
   Bool_t                 fCalibrateTimeL1Phase;   // flag cell time calibration with L1phase shift
   Bool_t                 fDoNonLinearity;         // nNon linearity correction flag
   Bool_t                 fBadCellRemove;          // zero bad cells
+  Bool_t                 fLoad1DBadChMap;         // Flag to load 1D bad channel map
   Bool_t                 fRejectExoticCells;      // reject exotic cells
   Bool_t                 fRejectExoticClusters;   // recect clusters with exotic cells
   Bool_t                 fClusterBadChannelCheck; // check clusters for bad channels
@@ -307,6 +310,6 @@ private:
   AliEMCALTenderSupply(            const AliEMCALTenderSupply&c);
   AliEMCALTenderSupply& operator= (const AliEMCALTenderSupply&c);
   
-  ClassDef(AliEMCALTenderSupply, 23); // EMCAL tender task
+  ClassDef(AliEMCALTenderSupply, 24); // EMCAL tender task
 };
 #endif


### PR DESCRIPTION
The correction framework was changed so that it loads one dimensional Bad Channel Map.
In order to use it you have to set the flag "load1DBadChMap" to true in the yaml configuration file.