### PR TITLE
AliAnalysisTaskHFJetIPQA: Add IP based track counting tagger

### DIFF
--- a/PWGJE/FlavourJetTasks/AliAnalysisTaskHFJetIPQA.cxx
+++ b/PWGJE/FlavourJetTasks/AliAnalysisTaskHFJetIPQA.cxx
@@ -81,6 +81,7 @@ fParam_Smear_Mean(0.),
 fGlobalVertex(kFALSE),
 fDoNotCheckIsPhysicalPrimary(kFALSE),
 fDoJetProb(kFALSE),
+fDoLundPlane(kFALSE),
 fGraphMean(nullptr),
 fGraphSigmaData(nullptr),
 fGraphSigmaMC(nullptr),
@@ -93,6 +94,22 @@ fGeant3FlukaAntiProton(nullptr),
 fGeant3FlukaLambda(nullptr),
 fGeant3FlukaAntiLambda(nullptr),
 fGeant3FlukaKMinus(nullptr),
+h1DThresholdsFirst(0),
+h1DThresholdsSecond(0),
+h1DThresholdsThird(0),
+h1DTrueBTagged(nullptr),
+h1DTrueBTaggedSingle1st(nullptr),
+h1DTrueBTaggedSingle2nd(nullptr),
+h1DTrueBTaggedSingle3rd(nullptr),
+h1DTrueBTaggedDouble(nullptr),
+h1DTrueBTaggedTripple(nullptr),
+h1DFalseBTagged(nullptr),
+h1DFalseBTaggedSingle1st(nullptr),
+h1DFalseBTaggedSingle2nd(nullptr),
+h1DFalseBTaggedSingle3rd(nullptr),
+h1DFalseBTaggedDouble(nullptr),
+h1DFalseBTaggedTripple(nullptr),
+kTagLevel(3),
 cCuts(0),
 fMCArray(nullptr),
 fMCEvent(nullptr),
@@ -160,6 +177,7 @@ fParam_Smear_Mean(0.),
 fGlobalVertex(kFALSE),
 fDoNotCheckIsPhysicalPrimary(kFALSE),
 fDoJetProb(kFALSE),
+fDoLundPlane(kFALSE),
 fGraphMean(nullptr),
 fGraphSigmaData(nullptr),
 fGraphSigmaMC(nullptr),
@@ -172,6 +190,22 @@ fGeant3FlukaAntiProton(nullptr),
 fGeant3FlukaLambda(nullptr),
 fGeant3FlukaAntiLambda(nullptr),
 fGeant3FlukaKMinus(nullptr),
+h1DThresholdsFirst(0),
+h1DThresholdsSecond(0),
+h1DThresholdsThird(0), 
+h1DTrueBTagged(nullptr),
+h1DTrueBTaggedSingle1st(nullptr),
+h1DTrueBTaggedSingle2nd(nullptr),
+h1DTrueBTaggedSingle3rd(nullptr),
+h1DTrueBTaggedDouble(nullptr),
+h1DTrueBTaggedTripple(nullptr),
+h1DFalseBTagged(nullptr),
+h1DFalseBTaggedSingle1st(nullptr),
+h1DFalseBTaggedSingle2nd(nullptr),
+h1DFalseBTaggedSingle3rd(nullptr),
+h1DFalseBTaggedDouble(nullptr),
+h1DFalseBTaggedTripple(nullptr),
+kTagLevel(3),
 cCuts(0),
 fMCArray(nullptr),
 fMCEvent(nullptr),
@@ -584,7 +618,7 @@ Bool_t AliAnalysisTaskHFJetIPQA::Run(){
                     else if(jetflavour==4)FillHist("fh1dJetRecPts",           jetpt, 1);    //this->fXsectionWeightingFactor );
                 }
 
-                RecursiveParents(jetrec, jetconrec);
+                if(fDoLundPlane)RecursiveParents(jetrec, jetconrec);
                
 
                 FillHist("fh1dJetRecEtaPhiAccepted",jetrec->Eta(),jetrec->Phi(), 1);   //this->fXsectionWeightingFactor );
@@ -631,13 +665,13 @@ Bool_t AliAnalysisTaskHFJetIPQA::Run(){
 
                     vp = static_cast<AliVParticle*>(jetrec->TrackAt(i, jetconrec->GetParticleContainer()->GetArray()));
                     if (!vp){
-                      Printf("ERROR: AliVParticle associated to constituent not found");
+                      AliError("AliVParticle associated to constituent not found");
                       continue;
                     }
 
                     AliVTrack *vtrack = dynamic_cast<AliVTrack*>(vp);
                     if (!vtrack) {
-                      printf("ERROR: Could not receive track%d\n", i);
+                      AliError(Form("Could not receive track%d\n", i));
                       continue;
                     }
 
@@ -873,10 +907,19 @@ Bool_t AliAnalysisTaskHFJetIPQA::Run(){
                 if((int)sImpParXYSig.size()>1) hasIPs[1]=kTRUE;
                 if((int)sImpParXYSig.size()>2) hasIPs[2]=kTRUE;
 
-                Double_t ipval [3] = {-9999};
-                if(hasIPs[0])ipval[0] =sImpParXYSig.at(0).first;
-                if(hasIPs[1])ipval[1] =sImpParXYSig.at(1).first;
-                if(hasIPs[2])ipval[2] =sImpParXYSig.at(2).first;
+                Double_t ipval [3] = {-9999.,-9999.,-9999.};
+                if(hasIPs[0]){
+                    ipval[0] =sImpParXYSig.at(0).first;
+                    //printf("HasIP0, ipval[0]=%f\n", ipval[0]);
+                  }
+                if(hasIPs[1]){
+                    ipval[1] =sImpParXYSig.at(1).first;
+                    //printf("HasIP1, ipval[1]=%f\n",ipval[1]);
+                  }
+                if(hasIPs[2]){
+                    ipval[2] =sImpParXYSig.at(2).first;
+                    //printf("HasIP2, ipval[2]=%f\n", ipval[2]);
+                  }
                 //if(hasIPs[0])printf("N=1: cursImParXY=%f, TrackWeight=%f,corridx=%i, pt=%f\n",sImpParXYSig.at(0).first, sImpParXYSig.at(0).second, sImpParXYSig.at(0).trackLabel, sImpParXYSig.at(0).trackpt);
                 //if(hasIPs[1])printf("N=2: cursImParXY=%f, TrackWeight=%f, corridx=%i, pt=%f\n",sImpParXYSig.at(1).first, sImpParXYSig.at(1).second, sImpParXYSig.at(1).trackLabel, sImpParXYSig.at(1).trackpt);
                 //if(hasIPs[2])printf("N=3: cursImParXY=%f, TrackWeight=%f, corridx=%i, pt=%f\n",sImpParXYSig.at(2).first, sImpParXYSig.at(2).second, sImpParXYSig.at(2).trackLabel, sImpParXYSig.at(2).trackpt);
@@ -893,6 +936,57 @@ Bool_t AliAnalysisTaskHFJetIPQA::Run(){
                         if(!fIsMixSignalReady_n2 && hasIPs[1]) SetMixDCA(2,ipval[1] );
                         if(!fIsMixSignalReady_n3 && hasIPs[2]) SetMixDCA(3,ipval[2] );
                     }
+                }
+
+                int isBTaggedJet=DoJetTaggingThreshold(jetpt, hasIPs,ipval);
+                //printf("Receiving BTagged decision: %i\n", isBTaggedJet);
+                if(isBTaggedJet>0&&jetflavour==3&&hasIPs[0]){
+                    h1DTrueBTagged->Fill(jetpt);
+                    switch(isBTaggedJet){
+                      case 1:
+                        h1DTrueBTaggedSingle1st->Fill(jetpt);
+                        break;
+                      case 2:
+                        h1DTrueBTaggedSingle2nd->Fill(jetpt);
+                        break;
+                      case 3:
+                        h1DTrueBTaggedSingle3rd->Fill(jetpt);
+                        break;
+                      case 4:
+                        h1DTrueBTaggedDouble->Fill(jetpt);
+                        break;
+                      case 5:
+                        h1DTrueBTaggedTripple->Fill(jetpt);
+                        break;
+                    }
+
+                    //printf("################################ FoundJet with tagindex=%i!\n",isBTaggedJet);
+                }
+                if(isBTaggedJet&&jetflavour!=3&&hasIPs[0]&&jetflavour!=0){
+                    bool udg=kFALSE;
+                    h1DFalseBTagged->Fill(jetpt);
+
+                    switch(isBTaggedJet){
+                      case 1:
+                        h1DFalseBTaggedSingle1st->Fill(jetpt);
+                        break;
+                      case 2:
+                        h1DFalseBTaggedSingle2nd->Fill(jetpt);
+                        break;
+                      case 3:
+                        h1DFalseBTaggedSingle3rd->Fill(jetpt);
+                        break;
+                      case 4:
+                        h1DFalseBTaggedDouble->Fill(jetpt);
+                        break;
+                      case 5:
+                        h1DFalseBTaggedTripple->Fill(jetpt);
+                        break;
+                    }
+                    //printf("################################ Mistagged: flavour is=%i with tagindex=%i!\n",jetflavour,isBTaggedJet);
+                }
+                if(!isBTaggedJet&&jetflavour==3&&hasIPs[0]){
+                    //printf("################################ Missed one: flavour is=%i, ipval[1]=%f, ipval[2]=%f, ipval[3]=%f\n", jetflavour, ipval[0],ipval[2], ipval[2]);
                 }
 
 
@@ -1358,7 +1452,23 @@ void AliAnalysisTaskHFJetIPQA::UserCreateOutputObjects(){
   fHLundIterative = new THnSparseF("fHLundIterative",
                   "LundIterativePlot [log(1/theta),log(z*theta),pTjet,algo]",
                   dimSpec,nBinsSpec,lowBinSpec,hiBinSpec);
-  fOutput->Add(fHLundIterative);
+  if(fDoLundPlane)fOutput->Add(fHLundIterative);
+
+
+  //Histograms for Tagging
+  h1DTrueBTagged=(TH1D*)AddHistogramm("h1DTrueBTagged","h1DTrueBTagged",500, 0, 500);
+  h1DTrueBTaggedSingle1st=(TH1D*)AddHistogramm("h1DTrueBTaggedSingle1st","h1DTrueBTaggedSingle1st",500, 0, 500);
+  h1DTrueBTaggedSingle2nd=(TH1D*)AddHistogramm("h1DTrueBTaggedSingle2nd","h1DTrueBTaggedSingle2nd",500, 0, 500);
+  h1DTrueBTaggedSingle3rd=(TH1D*)AddHistogramm("h1DTrueBTaggedSingle3rd","h1DTrueBTaggedSingle3rd",500, 0, 500);
+  h1DTrueBTaggedDouble=(TH1D*)AddHistogramm("h1DTrueBTaggedDouble","h1DTrueBTaggedDouble",500, 0, 500);
+  h1DTrueBTaggedTripple=(TH1D*)AddHistogramm("h1DTrueBTaggedTripple","h1DTrueBTaggedTripple",500, 0, 500);
+
+  h1DFalseBTagged=(TH1D*)AddHistogramm("h1DFalseBTagged","h1DFalseBTagged",500, 0, 500);
+  h1DFalseBTaggedSingle1st=(TH1D*)AddHistogramm("h1DFalseBTaggedSingle1st","h1DFalseBTaggedSingle1st",500, 0, 500);
+  h1DFalseBTaggedSingle2nd=(TH1D*)AddHistogramm("h1DFalseBTaggedSingle2nd","h1DFalseBTaggedSingle2nd",500, 0, 500);
+  h1DFalseBTaggedSingle3rd=(TH1D*)AddHistogramm("h1DFalseBTaggedSingle3rd","h1DFalseBTaggedSingle3rd",500, 0, 500);
+  h1DFalseBTaggedDouble=(TH1D*)AddHistogramm("h1DFalseBTaggedDouble","h1DFalseBTaggedDouble",500, 0, 500);
+  h1DFalseBTaggedTripple=(TH1D*)AddHistogramm("h1DFalseBTaggedTripple","h1DFalseBTaggedTripple",500, 0, 500);
 
   //Histograms for vertexing factor quicktest
   //fHistManager.CreateTH1("fh1dVERTEXFACTOR_VERTEXZ_FULL","fh1dVERTEXFACTOR_VERTEXZ_FULL;;",400,-100,100,"s");
@@ -2871,14 +2981,14 @@ Bool_t AliAnalysisTaskHFJetIPQA::IsSelectionParticleOmegaXiSigmaP( AliVParticle 
               for(UInt_t i = 0; i < jet->GetNumberOfTracks(); i++) {//start trackloop jet
                 vp = static_cast<AliVParticle*>(jet->Track(i));
                 if (!vp){
-                  Printf("ERROR: AliVParticle associated to constituent not found\n");
+                  AliError("AliVParticle associated to constituent not found\n");
                   continue;
                 }
 
                 AliAODMCParticle * part = static_cast<AliAODMCParticle*>(vp);
 
                 if(!part){
-                    printf("ERROR: Finding no Part!\n");
+                    AliError("Finding no Part!\n");
                     return 0;
                 }       // if(!part->IsPrimary()) continue;
                 pdg = (abs(part->PdgCode()));
@@ -3504,6 +3614,75 @@ Double_t AliAnalysisTaskHFJetIPQA::CalculatePSTrackPID(Double_t sign, Double_t s
     if(TMath::Abs(significance) >99) significance =99; //Limit to function definition range
     retval = sign * ((fResolutionFunction[20*species + 4*trclass +ptbin])).Eval(TMath::Abs(significance));
     return retval;
+}
+
+void AliAnalysisTaskHFJetIPQA::SetThresholds(TObjArray* threshfirst, TObjArray* threshsec, TObjArray* threshthird){
+    for(int iProbSet=0;iProbSet<3;iProbSet++){
+        h1DThresholdsFirst.push_back((TH1D*)threshfirst->At(iProbSet));
+        h1DThresholdsSecond.push_back((TH1D*)threshsec->At(iProbSet));
+        h1DThresholdsThird.push_back((TH1D*)threshthird->At(iProbSet));
+    }
+ }
+
+int AliAnalysisTaskHFJetIPQA::DoJetTaggingThreshold(double jetpt, bool* hasIPs, double* ipval){
+  //threshold values for tracks with largest, second and third largest IP
+  int iJetPtBin=h1DThresholdsFirst[0]->FindBin(jetpt);
+  double IPthresN1[3];  //single tag, double tag, tripple tag
+  double IPthresN2[3];
+  double IPthresN3[3];
+
+  for(int iN=0;iN<3;iN++){
+    IPthresN1[iN]=h1DThresholdsFirst[iN]->GetBinContent(iJetPtBin);
+    IPthresN2[iN]=h1DThresholdsSecond[iN]->GetBinContent(iJetPtBin);
+    IPthresN3[iN]=h1DThresholdsThird[iN]->GetBinContent(iJetPtBin);
+  }
+
+  //printf("DoJetTaggingThreshold:\n");
+  //printf("      Single: iJetPtBin=%i, IPthresN1=%f, IPthresN2=%f, IPthresN3=%f\n", iJetPtBin, IPthresN1[0],IPthresN2[0], IPthresN3[0]);
+  //printf("      Double: iJetPtBin=%i, IPthresN1=%f, IPthresN2=%f, IPthresN3=%f\n", iJetPtBin, IPthresN1[1],IPthresN2[1], IPthresN3[1]);
+  //printf("      Tripple: iJetPtBin=%i, IPthresN1=%f, IPthresN2=%f, IPthresN3=%f\n", iJetPtBin, IPthresN1[2],IPthresN2[2], IPthresN3[2]);
+
+  if(hasIPs[2]){
+      //tripple tag
+      //printf("ipval[0]=%f, ipval[1]=%f, ipval[2]=%f\n", ipval[0],ipval[1],ipval[2]);
+      if(ipval[0]>IPthresN1[2]&&ipval[1]>IPthresN2[2]&&ipval[2]>IPthresN3[2]) return 5;
+      //double tag
+      if(kTagLevel<3){
+        //printf("Double catch\n");
+        if(ipval[2]>IPthresN3[1]&&ipval[1]>IPthresN2[1]) return 4;
+        if(ipval[2]>IPthresN3[1]&&ipval[0]>IPthresN1[1]) return 4;
+      }
+      //single tag
+      if(kTagLevel<2){
+        //printf("Single catch\n");
+        if(ipval[2]>IPthresN3[0]) return 3;
+      }
+  }
+
+  if(hasIPs[1]){
+      //printf("ipval[0]=%f, ipval[1]=%f", ipval[0],ipval[1]);
+      //double tag
+      if(kTagLevel<3){
+        //printf("Double catch\n");
+        if(ipval[0]>IPthresN1[1]&&ipval[1]>IPthresN2[1]) return 4;
+      }
+      //single tag
+      if(kTagLevel<2){
+        //printf("Single catch\n");
+        if(ipval[1]>IPthresN2[0]) return 2;
+      }
+  }
+
+  //single tag
+  if(hasIPs[0]){
+      //printf("ipval[0]=%f", ipval[0]);
+      if(kTagLevel<2){
+        //printf("Single catch\n");
+        if(ipval[0]>IPthresN1[0]) return 1;
+      }
+  }
+
+  return 0;
 }
 
 

--- a/PWGJE/FlavourJetTasks/AliAnalysisTaskHFJetIPQA.h
+++ b/PWGJE/FlavourJetTasks/AliAnalysisTaskHFJetIPQA.h
@@ -152,6 +152,10 @@ public:
     void setfNoJetConstituents(Int_t value){fNoJetConstituents=value;}
 
 
+    //JetTagging
+    int DoJetTaggingThreshold(double jetpt, bool* hasIPs, double* ipval);
+    void SetThresholds(TObjArray* threshfirst, TObjArray* threshsec, TObjArray* threshthird);
+    void setTagLevel(int taglevel){kTagLevel=taglevel;}
 
     Bool_t IsTrackAcceptedJP(AliVTrack *track, Int_t n);
     bool IsFromElectron(AliAODTrack *track);
@@ -178,17 +182,10 @@ public:
         fGlobalVertex = value;
     }
 
-   void setDoNotCheckIsPhysicalPrimary(Bool_t value)
-    {
-        fDoNotCheckIsPhysicalPrimary = value;
-    }
-     void setDoJetProb(Bool_t value)
-    {
-        fDoJetProb = value;
-    }
-    void useTreeForCorrelations(Bool_t value){
-        fUseTreeForCorrelations = value;
-    }
+    void setDoNotCheckIsPhysicalPrimary(Bool_t value){fDoNotCheckIsPhysicalPrimary = value;}
+    void setDoJetProb(Bool_t value){fDoJetProb = value;}
+    void setDoLundPlane(Bool_t dolundplane){fDoLundPlane=dolundplane;}
+    void useTreeForCorrelations(Bool_t value){fUseTreeForCorrelations = value;}
     //virtual Bool_t IsEventSelected();
     void FillCorrelations(bool bn[3], double v[3], double jetpt);
     void setFFillCorrelations(const Bool_t &value);
@@ -266,6 +263,8 @@ private:
     Bool_t   fGlobalVertex;//
     Bool_t fDoNotCheckIsPhysicalPrimary;//
     Bool_t fDoJetProb;
+    Bool_t fDoLundPlane;
+
     TGraph * fGraphMean;//!
     TGraph * fGraphSigmaData;//!
     TGraph * fGraphSigmaMC;//!
@@ -278,6 +277,27 @@ private:
     TGraph * fGeant3FlukaLambda;//!
     TGraph * fGeant3FlukaAntiLambda;//!
     TGraph * fGeant3FlukaKMinus;//!
+
+    //Histograms for tagging
+    std::vector<TH1D*> h1DThresholdsFirst; //0-> single probability, 1-> double probability, 2-> tripple probability
+    std::vector<TH1D*> h1DThresholdsSecond; //
+    std::vector<TH1D*> h1DThresholdsThird;//
+    TH1D* h1DTrueBTagged;//!
+    TH1D* h1DTrueBTaggedSingle1st;//!
+    TH1D* h1DTrueBTaggedSingle2nd;//!
+    TH1D* h1DTrueBTaggedSingle3rd;//!
+    TH1D* h1DTrueBTaggedDouble;//!
+    TH1D* h1DTrueBTaggedTripple;//!
+
+    TH1D* h1DFalseBTagged;//!
+    TH1D* h1DFalseBTaggedSingle1st;//!
+    TH1D* h1DFalseBTaggedSingle2nd;//!
+    TH1D* h1DFalseBTaggedSingle3rd;//!
+    TH1D* h1DFalseBTaggedDouble;//!
+    TH1D* h1DFalseBTaggedTripple;//!
+
+    int kTagLevel; //1: accept single splittings, 2: accept only 2+3, 3: accept only 3
+
     //! \brief cCuts
     TCanvas *cCuts; //
     //! \brief fMCArray
@@ -372,7 +392,7 @@ private:
 
 
 
-    ClassDef(AliAnalysisTaskHFJetIPQA, 37)
+    ClassDef(AliAnalysisTaskHFJetIPQA, 38)
 };
 
 #endif

--- a/PWGJE/FlavourJetTasks/macros/AddTaskHFJetIPQA.C
+++ b/PWGJE/FlavourJetTasks/macros/AddTaskHFJetIPQA.C
@@ -28,6 +28,7 @@ AliAnalysisTaskHFJetIPQA* AddTaskHFJetIPQA(
                                            const char *ntracksMC            = "tracksMC",
                                            const char *nrhoMC               = "RhoMC",
                                            TString PathToWeights = 	"alien:///alice/cern.ch/user/k/kgarner/Weights_18_07_18.root",
+                                           TString PathToThresholds = "alien:///alice/cern.ch/user/k/kgarner/ThresholdHists_LHC16JJ.root",
                                           // TString PathToRunwiseCorrectionParameters = "alien:///alice/cern.ch/user/l/lfeldkam/MeanSigmaImpParFactors.root",
                                           // TString PathToJetProbabilityInput = "/home/katha/Uni/PhD/PhD/LinusCode/Anwendung/data/Binned_ResFct_XYSignificance_pp7TeV.root",
                                            TString PathToFlukaFactor="alien:///alice/cern.ch/user/k/kgarner/FlukaFactors_18_07_18.root",
@@ -141,6 +142,33 @@ AliAnalysisTaskHFJetIPQA* AddTaskHFJetIPQA(
         jetTask->SetFlukaFactor(g[0],g[1],g[2],g[3]);
         Printf("%s :: Weights written to analysis task.",taskname);
         if(fileFlukaCorrection) fileFlukaCorrection->Close();
+    }
+
+    // Load and setup Threshold values for Tagger
+    //==============================================================================
+    TFile* fileThresholds;
+    if( PathToThresholds.EqualTo("") ) {
+      } else {
+        fileThresholds=TFile::Open(PathToThresholds.Data());
+        if(!fileThresholds ||(fileThresholds&& !fileThresholds->IsOpen())){
+        printf("%s :: File with threshold values not found",taskname);
+        return 0x0;
+      }
+    }
+
+    Printf("%s :: File %s successfully loaded, setting up threshold functions.",taskname,PathToThresholds.Data());
+
+    if(fileThresholds){
+        printf("Going here *****************************\n");
+        TObjArray* threshfirst;
+        TObjArray* threshsec;
+        TObjArray* threshthird;
+        fileThresholds->GetObject("Prob_0.65",threshfirst);
+        fileThresholds->GetObject("Prob_0.54",threshsec);
+        fileThresholds->GetObject("Prob_0.50",threshthird);
+        printf("Pointers in the C file: %p, %p, %p\n",threshfirst, threshsec,threshthird);
+
+        jetTask->SetThresholds(threshfirst,threshsec,threshthird);
     }
 
     // Setup input containers


### PR DESCRIPTION
- read in histograms with jetpt dependent threshold variables
- perform tagging on basis of single track, two or three tracks; add switch to exclude tagging via a single or two tracks
- fill histograms with number of correctly and falsely tagged jets for each method

-added switch to turn on and off Lund Plane investigations
-changed printf error outputs to AliError