### PR TITLE
Multiplicity class compatible only to MultSelection

### DIFF
--- a/PWGCF/Correlations/JCORRAN/Pro/AliJJetJtTask.cxx
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJJetJtTask.cxx
@@ -241,38 +241,20 @@ void AliJJetJtTask::UserExec(Option_t* /*option*/)
 
   // centrality
   float fcent = -999;
-  if(fRunTable->IsHeavyIon() || fRunTable->IsPA()){ //Only check centrality for PbPb and pPb events
-    if(fDebug > 6) cout << fRunTable->GetPeriodName() << endl;
-    if(fRunTable->IsPA() && !(fRunTable->GetPeriodName().BeginsWith("LHC13"))){ //LHC13 datasets use the AliCentrality class, newer datasets use the AliMultSelection class
-      sel = (AliMultSelection*) InputEvent() -> FindListObject("MultSelection"); 
-      if (sel) {
-        if(fSelector != ""){ //If centrality selector is set in wagon configuration, otherwise default to V0A
-          fcent = sel->GetMultiplicityPercentile(fSelector);
-        }else{
-          fcent = sel->GetMultiplicityPercentile("V0A");
-        }
-      }
-      else{
-        if(fDebug > 2) cout << "Sel not found" << endl;
-      }
-    }
-    else{ //For LHC13 datasets
-      AliCentrality *cent = event->GetCentrality();
-      if( ! cent ) return;
-      if(fSelector != ""){
-          fcent = cent->GetCentralityPercentile(fSelector);
-      }else{
-        if(fRunTable->GetPeriodName().BeginsWith("LHC13")){
-          fcent = cent->GetCentralityPercentile("V0A");
-        }else{
-          fcent = cent->GetCentralityPercentile("V0M");
-        }
-      }
-    }
-  }
-  else {
-    fcent = -1;
-  }
+	if(fDebug > 6) cout << fRunTable->GetPeriodName() << endl;
+	sel = (AliMultSelection*) InputEvent() -> FindListObject("MultSelection");
+	if (sel) {
+		if(!fSelector.IsNull()){ //If centrality selector is set in wagon configuration, otherwise default to V0A
+			fcent = sel->GetMultiplicityPercentile(fSelector.Data());
+		}else{
+			fcent = sel->GetMultiplicityPercentile("V0A");
+		}
+	}
+	else {
+		if(fDebug > 2) cout << "Sel not found" << endl;
+		fcent = -1;
+	}
+
   if(fcent > fCentCut){
     if(fDebug > 2) cout << "Skip event, Centrality was " << fcent << " and cut is " << fCentCut << endl;
     return;


### PR DESCRIPTION
LHC13 b c d e now calls MultSelection to get multiplicity information. The old method GetCentrality was removed.  