### PR TITLE
Comment of TH3F and splitting trains

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.cxx
@@ -847,10 +847,10 @@ void AliAnalysisTaskGammaConvDalitzV1::UserCreateOutputObjects()
       fHistoSPDClusterTrackletBackground[iCut] = new TH2F("SPD tracklets vs SPD clusters","SPD tracklets vs SPD clusters",100,0,200,250,0,1000);
       fQAFolder[iCut]->Add(fHistoSPDClusterTrackletBackground[iCut]);
 
-      hESDDalitzElectronAfterPt[iCut] = new TH1F("ESD_DalitzElectron_After_Pt","ESD_DalitzElectron_After_Pt",1000,0,25);
+      hESDDalitzElectronAfterPt[iCut] = new TH1F("ESD_DalitzElectron_After_Pt","ESD_DalitzElectron_After_Pt",250,0,25);
       fQAFolder[iCut]->Add(hESDDalitzElectronAfterPt[iCut]);
 
-      hESDDalitzPositronAfterPt[iCut] = new TH1F("ESD_DalitzPositron_After_Pt","ESD_DalitzPositron_After_Pt",1000,0,25);
+      hESDDalitzPositronAfterPt[iCut] = new TH1F("ESD_DalitzPositron_After_Pt","ESD_DalitzPositron_After_Pt",250,0,25);
       fQAFolder[iCut]->Add(hESDDalitzPositronAfterPt[iCut]);
 
       hESDDalitzElectronAfterEta[iCut] = new TH1F("ESD_DalitzElectron_After_Eta","ESD_DalitzElectron_After_Eta",600,-1.5,1.5);
@@ -970,7 +970,7 @@ void AliAnalysisTaskGammaConvDalitzV1::UserCreateOutputObjects()
       if(fDoHistoDalitzMassLog) SetLogBinningXTH2(hESDEposEnegInvMassPt[iCut]);
       fQAFolder[iCut]->Add(hESDEposEnegInvMassPt[iCut]);
 
-      hESDEposEnegLikeSignBackInvMassPt[iCut]  = new TH2F("ESD_EposEneg_LikeSignBack_InvMassPt","ESD_EposEneg_LikeSignBack_InvMassPt",4000,0.0,2.,100,0.,10.);
+      hESDEposEnegLikeSignBackInvMassPt[iCut]  = new TH2F("ESD_EposEneg_LikeSignBack_InvMassPt","ESD_EposEneg_LikeSignBack_InvMassPt",1000,0.0,2.,100,0.,10.);
       fQAFolder[iCut]->Add(hESDEposEnegLikeSignBackInvMassPt[iCut]);
 
       if( fDoMesonQA > 1 ) {
@@ -1020,13 +1020,13 @@ void AliAnalysisTaskGammaConvDalitzV1::UserCreateOutputObjects()
     }
 
     if( fDoChicAnalysis) {
-      hESDPi0MotherInvMassPt[iCut] = new TH2F("ESD_Pi0Mother_InvMass_Pt","ESD_Pi0Mother_InvMass_Pt",4000,0,4,200,0,20);
+      hESDPi0MotherInvMassPt[iCut] = new TH2F("ESD_Pi0Mother_InvMass_Pt","ESD_Pi0Mother_InvMass_Pt",1000,0,4,200,0,20);
       fESDList[iCut]->Add(hESDPi0MotherInvMassPt[iCut]);
-      hESDPi0MotherDiffInvMassPt[iCut] = new TH2F("ESD_Pi0Mother_DiffInvMass_Pt","ESD_Pi0Mother_DiffInvMass_Pt",2000,0,2,200,0,20);
+      hESDPi0MotherDiffInvMassPt[iCut] = new TH2F("ESD_Pi0Mother_DiffInvMass_Pt","ESD_Pi0Mother_DiffInvMass_Pt",1000,0,2,200,0,20);
       fESDList[iCut]->Add(hESDPi0MotherDiffInvMassPt[iCut]);
-      hESDPi0MotherDiffLimInvMassPt[iCut] = new TH2F("ESD_Pi0Mother_DiffLimInvMass_Pt","ESD_Pi0Mother_DiffLimInvMass_Pt",2000,0,2,200,0,20);
+      hESDPi0MotherDiffLimInvMassPt[iCut] = new TH2F("ESD_Pi0Mother_DiffLimInvMass_Pt","ESD_Pi0Mother_DiffLimInvMass_Pt",1000,0,2,200,0,20);
       fESDList[iCut]->Add(hESDPi0MotherDiffLimInvMassPt[iCut]);
-      hESDEposEnegInvMassPi0MotherPt[iCut] = new TH2F("ESD_EposEnegInvMass_Pi0MotherPt","ESD_EposEnegInvMass_Pi0MotherPt",4000,0,4,200,0,20);
+      hESDEposEnegInvMassPi0MotherPt[iCut] = new TH2F("ESD_EposEnegInvMass_Pi0MotherPt","ESD_EposEnegInvMass_Pi0MotherPt",1000,0,4,200,0,20);
       fESDList[iCut]->Add(hESDEposEnegInvMassPi0MotherPt[iCut]);
     }
 
@@ -1351,7 +1351,7 @@ void AliAnalysisTaskGammaConvDalitzV1::UserCreateOutputObjects()
           fTrueList[iCut]->Add(hESDTruePi0DalitzConvGammaR[iCut]);
 
           const Int_t nDimDalPlot = 2;
-          Int_t    nBinsDalPlot[nDimDalPlot] = {  4000, 4000};
+          Int_t    nBinsDalPlot[nDimDalPlot] = {  1000, 1000};
           Double_t xMinDalPlot[nDimDalPlot]  = {    0,     0};
           Double_t xMaxDalPlot[nDimDalPlot]  = {  4.0,   4.0};
 
@@ -1363,16 +1363,16 @@ void AliAnalysisTaskGammaConvDalitzV1::UserCreateOutputObjects()
         }
       }
 
-      hESDTruePositronPt[iCut] = new TH1F("ESD_TruePositron_Pt","ESD_TruePositron_Pt",1000,0,25);
+      hESDTruePositronPt[iCut] = new TH1F("ESD_TruePositron_Pt","ESD_TruePositron_Pt",500,0,25);
       fTrueList[iCut]->Add(hESDTruePositronPt[iCut]);
 
-      hESDTrueElectronPt[iCut] = new TH1F("ESD_TrueElectron_Pt","ESD_TrueElectron_Pt",1000,0,25);
+      hESDTrueElectronPt[iCut] = new TH1F("ESD_TrueElectron_Pt","ESD_TrueElectron_Pt",500,0,25);
       fTrueList[iCut]->Add(hESDTrueElectronPt[iCut]);
 
-      hESDTrueSecPositronPt[iCut] = new TH1F("ESD_TrueSecPositron_Pt","ESD_TrueSecPositron_Pt",1000,0,25);
+      hESDTrueSecPositronPt[iCut] = new TH1F("ESD_TrueSecPositron_Pt","ESD_TrueSecPositron_Pt",500,0,25);
       fTrueList[iCut]->Add(hESDTrueSecPositronPt[iCut]);
 
-      hESDTrueSecElectronPt[iCut] = new TH1F("ESD_TrueSecElectron_Pt","ESD_TrueSecElectron_Pt",1000,0,25);
+      hESDTrueSecElectronPt[iCut] = new TH1F("ESD_TrueSecElectron_Pt","ESD_TrueSecElectron_Pt",500,0,25);
       fTrueList[iCut]->Add(hESDTrueSecElectronPt[iCut]);
 
       hESDTrueConvGammaPt[iCut] = new TH1F("ESD_TrueConvGamma_Pt","ESD_TrueConvGamma_Pt",250,0,25);
@@ -1392,31 +1392,31 @@ void AliAnalysisTaskGammaConvDalitzV1::UserCreateOutputObjects()
       fHistoDoubleCountTrueEtaInvMassPt[iCut] = new TH2F("ESD_TrueDoubleCountEta_InvMass_Pt","ESD_TrueDoubleCountEta_InvMass_Pt",800,0,0.8,300,0,30);
       fTrueList[iCut]->Add(fHistoDoubleCountTrueEtaInvMassPt[iCut]);
 
-      hESDTruePi0DalitzElectronPt[iCut] = new TH1F("ESD_TruePi0DalitzElectron_Pt","ESD_TruePi0DalitzElectron_Pt",1000,0,25);
+      hESDTruePi0DalitzElectronPt[iCut] = new TH1F("ESD_TruePi0DalitzElectron_Pt","ESD_TruePi0DalitzElectron_Pt",500,0,25);
       fTrueList[iCut]->Add(hESDTruePi0DalitzElectronPt[iCut]);
 
-      hESDTruePi0DalitzElectronPtMB[iCut] = new TH1F("ESD_TruePi0DalitzElectron_Pt_MB","ESD_TruePi0DalitzElectron_Pt_MB",1000,0,25);
+      hESDTruePi0DalitzElectronPtMB[iCut] = new TH1F("ESD_TruePi0DalitzElectron_Pt_MB","ESD_TruePi0DalitzElectron_Pt_MB",500,0,25);
       fTrueList[iCut]->Add(hESDTruePi0DalitzElectronPtMB[iCut]);
 
-      hESDTruePi0DalitzPositronPt[iCut] = new TH1F("ESD_TruePi0DalitzPositron_Pt","ESD_TruePi0DalitzPositron_Pt",1000,0,25);
+      hESDTruePi0DalitzPositronPt[iCut] = new TH1F("ESD_TruePi0DalitzPositron_Pt","ESD_TruePi0DalitzPositron_Pt",500,0,25);
       fTrueList[iCut]->Add(hESDTruePi0DalitzPositronPt[iCut]);
 
-      hESDTruePi0DalitzPositronPtMB[iCut] = new TH1F("ESD_TruePi0DalitzPositron_Pt_MB","ESD_TruePi0DalitzPositron_Pt_MB",1000,0,25);
+      hESDTruePi0DalitzPositronPtMB[iCut] = new TH1F("ESD_TruePi0DalitzPositron_Pt_MB","ESD_TruePi0DalitzPositron_Pt_MB",500,0,25);
       fTrueList[iCut]->Add(hESDTruePi0DalitzPositronPtMB[iCut]);
 
       hESDTruePi0DalitzSecConvGammaPt[iCut] = new TH1F("ESD_TruePi0DalitzSecConvGamma_Pt","ESD_TruePi0DalitzSecConvGamma_Pt",250,0,25);
       fTrueList[iCut]->Add(hESDTruePi0DalitzSecConvGammaPt[iCut]);
 
-      hESDTruePi0DalitzSecElectronPt[iCut] = new TH1F("ESD_TruePi0DalitzSecElectron_Pt","ESD_TruePi0DalitzSecElectron_Pt",1000,0,25);
+      hESDTruePi0DalitzSecElectronPt[iCut] = new TH1F("ESD_TruePi0DalitzSecElectron_Pt","ESD_TruePi0DalitzSecElectron_Pt",500,0,25);
       fTrueList[iCut]->Add(hESDTruePi0DalitzSecElectronPt[iCut]);
 
-      hESDTruePi0DalitzSecPositronPt[iCut] = new TH1F("ESD_TruePi0DalitzSecPositron_Pt","ESD_TruePi0DalitzSecPositron_Pt",1000,0,25);
+      hESDTruePi0DalitzSecPositronPt[iCut] = new TH1F("ESD_TruePi0DalitzSecPositron_Pt","ESD_TruePi0DalitzSecPositron_Pt",500,0,25);
       fTrueList[iCut]->Add(hESDTruePi0DalitzSecPositronPt[iCut]);
 
       if( fDoChicAnalysis) {
-        hESDTrueMotherChiCInvMassPt[iCut] = new TH2F("ESD_TrueMotherChiC_InvMass_Pt","ESD_TrueMotherChiC_InvMass_Pt",4000,0,4,250,0,25);
+        hESDTrueMotherChiCInvMassPt[iCut] = new TH2F("ESD_TrueMotherChiC_InvMass_Pt","ESD_TrueMotherChiC_InvMass_Pt",1000,0,4,250,0,25);
         fTrueList[iCut]->Add(hESDTrueMotherChiCInvMassPt[iCut]);
-        hESDTrueMotherChiCDiffInvMassPt[iCut] = new TH2F("ESD_TrueMotherChiCDiff_InvMass_Pt","ESD_TrueMotherChiCDiff_InvMass_Pt",2000,0,2,250,0,25);
+        hESDTrueMotherChiCDiffInvMassPt[iCut] = new TH2F("ESD_TrueMotherChiCDiff_InvMass_Pt","ESD_TrueMotherChiCDiff_InvMass_Pt",1000,0,2,250,0,25);
         fTrueList[iCut]->Add(hESDTrueMotherChiCDiffInvMassPt[iCut]);
       }
 

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.cxx
@@ -258,7 +258,7 @@ AliAnalysisTaskGammaConvDalitzV1::AliAnalysisTaskGammaConvDalitzV1():
   hNGoodESDTracksVsNGoodVGammas(NULL),
   fHistoSPDClusterTrackletBackground(NULL),
   hNV0Tracks(NULL),
-  hESDEposEnegPsiPairpTleptonsDPhi(NULL),
+  //hESDEposEnegPsiPairpTleptonsDPhi(NULL),
   hEtaShift(NULL),
   fHistoDoubleCountTruePi0InvMassPt(NULL),
   fHistoDoubleCountTrueEtaInvMassPt(NULL),
@@ -484,7 +484,7 @@ AliAnalysisTaskGammaConvDalitzV1::AliAnalysisTaskGammaConvDalitzV1( const char* 
   hNGoodESDTracksVsNGoodVGammas(NULL),
   fHistoSPDClusterTrackletBackground(NULL),
   hNV0Tracks(NULL),
-  hESDEposEnegPsiPairpTleptonsDPhi(NULL),
+  //hESDEposEnegPsiPairpTleptonsDPhi(NULL),
   hEtaShift(NULL),
   fHistoDoubleCountTruePi0InvMassPt(NULL),
   fHistoDoubleCountTrueEtaInvMassPt(NULL),
@@ -713,7 +713,7 @@ void AliAnalysisTaskGammaConvDalitzV1::UserCreateOutputObjects()
     hESDDalitzElectronAfterTPCdEdxVsPhi     = new TH2F*[fnCuts];
     hESDDalitzPositronAfterTPCdEdxVsPhi     = new TH2F*[fnCuts];
     hESDEposEnegPsiPairDPhi        = new TH2F*[fnCuts];
-    hESDEposEnegPsiPairpTleptonsDPhi    = new TH3F*[fnCuts];
+    //hESDEposEnegPsiPairpTleptonsDPhi    = new TH3F*[fnCuts];
     hESDEposEnegPsiPairEta        = new TH2F*[fnCuts];
     hESDEposEnegDPhiEta        = new TH2F*[fnCuts];
     hESDEposEnegDPhiEta        = new TH2F*[fnCuts];
@@ -957,8 +957,8 @@ void AliAnalysisTaskGammaConvDalitzV1::UserCreateOutputObjects()
       hESDEposEnegPsiPairDPhi[iCut] = new TH2F("ESD_EposEneg_PsiPair_DPhi","ESD_EposEneg_PsiPair_DPhi",100,-1.0,1.0,100,-1.0,1.0 );
       fQAFolder[iCut]->Add(hESDEposEnegPsiPairDPhi[iCut]);
 
-      hESDEposEnegPsiPairpTleptonsDPhi[iCut] = new TH3F("ESD_EposEneg_PsiPair_pTleptons_DPhi","ESD_EposEneg_PsiPair_DPhi",100,-1.0,1.0,100,-1.0,1.0,100,0,10);
-      fQAFolder[iCut]->Add(hESDEposEnegPsiPairpTleptonsDPhi[iCut]);
+      //hESDEposEnegPsiPairpTleptonsDPhi[iCut] = new TH3F("ESD_EposEneg_PsiPair_pTleptons_DPhi","ESD_EposEneg_PsiPair_DPhi",100,-1.0,1.0,100,-1.0,1.0,100,0,10);
+      //fQAFolder[iCut]->Add(hESDEposEnegPsiPairpTleptonsDPhi[iCut]);
 
       hESDEposEnegPsiPairEta[iCut] = new TH2F("ESD_EposEneg_PsiPair_Eta","ESD_EposEneg_PsiPair_Eta",100,-1.0,1.0,600,-1.5,1.5);
       fQAFolder[iCut]->Add(hESDEposEnegPsiPairEta[iCut]);
@@ -1943,7 +1943,7 @@ void AliAnalysisTaskGammaConvDalitzV1::ProcessVirtualGammasCandidates(){ //NOTE 
 //      momPos[0]= trackPos->GetParamG(fAODEvent->GetPrimaryVertex(),fAODEvent->GetMagneticField())->Px();
       Double_t deltaPhi = GetdeltaPhi(electronVgamma.get(),positronVgamma.get());
       hESDEposEnegPsiPairDPhi[fiCut]->Fill(deltaPhi,psiPair);
-      hESDEposEnegPsiPairpTleptonsDPhi[fiCut]->Fill(deltaPhi,psiPair,Vgamma->Pt());
+      //hESDEposEnegPsiPairpTleptonsDPhi[fiCut]->Fill(deltaPhi,psiPair,Vgamma->Pt());
       hESDEposEnegPsiPairEta[fiCut]->Fill(psiPair,Vgamma->Eta());
       hESDEposEnegDPhiEta[fiCut]->Fill(deltaPhi,Vgamma->Eta());
       hESDEposEnegInvMassPt[fiCut]->Fill(Vgamma->M(),Vgamma->Pt());

--- a/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskGammaConvDalitzV1.h
@@ -293,7 +293,7 @@ class AliAnalysisTaskGammaConvDalitzV1: public AliAnalysisTaskSE {
     TH2F                              **hNGoodESDTracksVsNGoodVGammas;
     TH2F                              **fHistoSPDClusterTrackletBackground;        //! array of histos with SPD tracklets vs SPD clusters for background rejection
     TH1I                              **hNV0Tracks;
-    TH3F                              **hESDEposEnegPsiPairpTleptonsDPhi;
+    //TH3F                              **hESDEposEnegPsiPairpTleptonsDPhi;
     TProfile                          **hEtaShift;
     TH2F                              **fHistoDoubleCountTruePi0InvMassPt;      //! array of histos with double counted pi0s, invMass, pT
     TH2F                              **fHistoDoubleCountTrueEtaInvMassPt;      //! array of histos with double counted etas, invMass, pT

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvDalitzV1_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvDalitzV1_pp.C
@@ -335,44 +335,50 @@ void AddTask_GammaConvDalitzV1_pp(  Int_t trainConfig = 1,  //change different s
     cuts.AddCutPCMDalitz("00010113", "0d200079227300008250404000", "204c4640263202223710", "0152103500000000"); // min pT no cut
     cuts.AddCutPCMDalitz("00010113", "0d200049227300008250404000", "204c4640263202223710", "0152103500000000"); // min pT 75 MeV
     cuts.AddCutPCMDalitz("00010113", "0d200019227300008250404000", "204c4640263202223710", "0152103500000000"); // min pT 100 MeV
-    cuts.AddCutPCMDalitz("00010113", "0d200008227300008250404000", "204c4640263202223710", "0152103500000000"); // TPC cluster 35%
-    cuts.AddCutPCMDalitz("00010113", "0d200006227300008250404000", "204c4640263202223710", "0152103500000000"); // TPC cluster 70%
   } else if (trainConfig == 413){
     cuts.AddCutPCMDalitz("00010113", "0d200009327300008250404000", "204c4640263202223710", "0152103500000000"); // edEdx -4,5
     cuts.AddCutPCMDalitz("00010113", "0d200009627300008250404000", "204c4640263202223710", "0152103500000000"); // edEdx -2.5,4
     cuts.AddCutPCMDalitz("00010113", "0d200009257300008250404000", "204c4640263202223710", "0152103500000000"); // pidEdx 2,-10
     cuts.AddCutPCMDalitz("00010113", "0d200009217300008250404000", "204c4640263202223710", "0152103500000000"); // pidEdx 0,-10
-    cuts.AddCutPCMDalitz("00010113", "0d200009226300008250404000", "204c4640263202223710", "0152103500000000"); // pion nsig min mom 0.25 GeV/c
-    cuts.AddCutPCMDalitz("00010113", "0d200009227600008250404000", "204c4640263202223710", "0152103500000000"); // pion nsig max mom 2.00 GeV/c
   } else if (trainConfig == 414){
     cuts.AddCutPCMDalitz("00010113", "0d200009227300002250404000", "204c4640263202223710", "0152103500000000"); // qT max 0.06 2D
     cuts.AddCutPCMDalitz("00010113", "0d200009227300009250404000", "204c4640263202223710", "0152103500000000"); // qT max 0.03 2D
     cuts.AddCutPCMDalitz("00010113", "0d200009227300008260404000", "204c4640263202223710", "0152103500000000"); // Psi pair 0.05 2D, chi2 30.
     cuts.AddCutPCMDalitz("00010113", "0d200009227300008280404000", "204c4640263202223710", "0152103500000000"); // Psi pair 0.2  2D, chi2 30.
-    cuts.AddCutPCMDalitz("00010113", "0d200009227300008850404000", "204c4640263202223710", "0152103500000000"); // chi2 20. psi pair 0.1 2D
-    cuts.AddCutPCMDalitz("00010113", "0d200009227300008150404000", "204c4640263202223710", "0152103500000000"); // chi2 50. psi pair 0.1 2D
   } else if (trainConfig == 415){
     cuts.AddCutPCMDalitz("00010113", "0d200009227300008254404000", "204c4640263202223710", "0152103500000000"); // Photon Asymmetry Cut
     cuts.AddCutPCMDalitz("00010113", "0d200009227300008250604000", "204c4640263202223710", "0152103500000000"); // CosPA 0.9
     cuts.AddCutPCMDalitz("00010113", "0d200009227300008250004000", "204c4640263202223710", "0152103500000000"); // no CosPA
     cuts.AddCutPCMDalitz("00010113", "0d200009227300008250400000", "204c4640263202223710", "0152103500000000"); // no double counting
-    cuts.AddCutPCMDalitz("00010113", "0d200009227300008250404000", "204c4640263202223710", "0152101500000000"); // meson alpha pt dep
-    cuts.AddCutPCMDalitz("00010113", "0d200009227300008250404000", "204c4640263202223710", "0152107500000000"); // meson alpha < 0.85
   } else if (trainConfig == 416) {//Primary cut, dE/dx sigma, min pT, max pT for pions.
     cuts.AddCutPCMDalitz("00010113", "0d200009227300008250404000", "204c4640863202223710", "0152103500000000");//Standard with kBoth on electrons
     cuts.AddCutPCMDalitz("00010113", "0d200009227300008250404000", "204c4640863002223710", "0152103500000000");//No PsiPair cut with kBoth on electrons
     cuts.AddCutPCMDalitz("00010113", "0d200009227300008250404000", "204c4640263202223710", "0152103500000000");//Standard
     cuts.AddCutPCMDalitz("00010113", "0d200009227300008250404000", "204c4640263002223710", "0152103500000000");//No PsiPair on electrons
+  } else if (trainConfig == 417) {//Systematic for TPC cluster and pion energy
+    cuts.AddCutPCMDalitz("00010113", "0d200008227300008250404000", "204c4640263202223710", "0152103500000000"); // TPC cluster 35%
+    cuts.AddCutPCMDalitz("00010113", "0d200006227300008250404000", "204c4640263202223710", "0152103500000000"); // TPC cluster 70%
+    cuts.AddCutPCMDalitz("00010113", "0d200009226300008250404000", "204c4640263202223710", "0152103500000000"); // pion nsig min mom 0.25 GeV/c
+    cuts.AddCutPCMDalitz("00010113", "0d200009227600008250404000", "204c4640263202223710", "0152103500000000"); // pion nsig max mom 2.00 GeV/c
+  } else if (trainConfig == 418) {//Systematic for chi2 psi pair on Photons
+    cuts.AddCutPCMDalitz("00010113", "0d200009227300008850404000", "204c4640263202223710", "0152103500000000"); // chi2 20. psi pair 0.1 2D
+    cuts.AddCutPCMDalitz("00010113", "0d200009227300008150404000", "204c4640263202223710", "0152103500000000"); // chi2 50. psi pair 0.1 2D
+    cuts.AddCutPCMDalitz("00010113", "0d200009227300008250404000", "204c4640263202223710", "0152101500000000"); // meson alpha pt dep
+    cuts.AddCutPCMDalitz("00010113", "0d200009227300008250404000", "204c4640263202223710", "0152107500000000"); // meson alpha < 0.85
+  } else if (trainConfig == 419) {//Cross chech of efficiency show for range on TPC.
+    cuts.AddCutPCMDalitz("00010113", "0d200009227300008250404000", "204c4640263202223710", "0152103500000000");// Standard
+    cuts.AddCutPCMDalitz("00010113", "0dm00009227300008250404000", "204c4640263202223710", "0152103500000000");// exclusion of range o transition between chambers of TPC 52 to 72 cm.
 
-    //  6XX for lowB,    65X  lowB and MBW
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////  6XX for lowB,    65X  lowB and MBW ////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
   } else if (trainConfig == 606) {  // low B   eta<0.8
     cuts.AddCutPCMDalitz("00010113", "0d200089266300008850404000", "10477400234202361710", "0263103100900000"); //prim electron Pt > 0.05 GeV & sec. electrons pt > 0.02 GeV
   } else if ( trainConfig ==607 ) { // low B
     cuts.AddCutPCMDalitz("00010113", "0da00089266300008850404000", "10477400234202361710", "0263103100900000"); //prim electron Pt >
     cuts.AddCutPCMDalitz("00010113", "0db00089266300008850404000", "10477400234202361710", "0263103100900000"); //prim electron Pt
     cuts.AddCutPCMDalitz("00010113", "0dc00089266300008850404000", "10477400234202361710", "0263103100900000");
-
-
     // to be used with weights
   } else if (trainConfig == 656) {  // low B   eta<0.8
     cuts.AddCutPCMDalitz("00010113", "0d200089266300008850404000", "10477400234202361710", "0263103100900000"); //prim electron Pt > 0.05 GeV & sec. electrons pt > 0.02 GeV


### PR DESCRIPTION
Systematics trains for MC were too heavy, so I believe that splitting them and remove one TH3F histogram will do the job.
Regards
Ed