### PR TITLE
Add ML application in Ds task

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSEDs.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEDs.h
@@ -23,6 +23,7 @@
 #include "AliAnalysisTaskSE.h"
 #include "AliRDHFCutsDstoKKpi.h"
 #include "AliLog.h"
+#include "AliExternalBDT.h"
 
 class AliNormalizationCounter;
 
@@ -79,6 +80,10 @@ class AliAnalysisTaskSEDs : public AliAnalysisTaskSE
 
   Double_t GetPtWeightFromHistogram(Double_t pt);
 
+  /// methods for ML application
+  void SetDoMLApplication(Bool_t flag = kTRUE) {fApplyML = flag;}
+  void SetMLConfigFile(TString path = ""){fConfigPath = path;}
+
   /// Implementation of interface methods
   virtual void UserCreateOutputObjects();
   virtual void Init();
@@ -91,8 +96,12 @@ class AliAnalysisTaskSEDs : public AliAnalysisTaskSE
   Int_t GetSignalHistoIndex(Int_t iPtBin) const { return iPtBin*4+1;}
   Int_t GetBackgroundHistoIndex(Int_t iPtBin) const { return iPtBin*4+2;}
   Int_t GetReflSignalHistoIndex(Int_t iPtBin) const { return iPtBin*4+3;}
+  /// methods for ML application
+  Bool_t SetMLVariables(TString path);
+  std::string GetFile(const std::string path);
+  double CombineNsigmaDiffDet(double nsigmaTPC, double nsigmaTOF);
 
-  enum {kMaxPtBins=24,knVarForSparse=15,knVarForSparseAcc=3,kVarForImpPar=3};
+  enum {kMaxPtBins=24,knVarForSparse=16,knVarForSparseAcc=3,kVarForImpPar=3};
     
   AliAnalysisTaskSEDs(const AliAnalysisTaskSEDs &source);
   AliAnalysisTaskSEDs& operator=(const AliAnalysisTaskSEDs& source);
@@ -152,11 +161,11 @@ class AliAnalysisTaskSEDs : public AliAnalysisTaskSE
   TH3F*   fPtProng0Hist3D;   //!<! Pt prong0 vs Ds mass vs pt
   TH3F*   fPtProng1Hist3D;   //!<! Pt prong1 vs Ds mass vs pt
   TH3F*   fPtProng2Hist3D;   //!<! Pt prong2 vs Ds mass vs pt
-  TNtuple *fNtupleDs; //!<! output ntuple
-  Int_t fFillNtuple;                 /// 0 not to fill ntuple
-  /// 1 for filling ntuple for events through Phi
-  /// 2 for filling ntuple for events through K0Star
-  /// 3 for filling all
+  TNtuple *fNtupleDs;        //!<! output ntuple
+  Int_t fFillNtuple;         /// 0 not to fill ntuple
+                             /// 1 for filling ntuple for events through Phi
+                             /// 2 for filling ntuple for events through K0Star
+                             /// 3 for filling all
   Bool_t   fUseCentrAxis; /// off = kFALSE (default)
 
   Int_t   fSystem;                    /// 0 = pp, 1 = pPb,PbPb
@@ -201,8 +210,17 @@ class AliAnalysisTaskSEDs : public AliAnalysisTaskSE
   TString fCentEstName; /// name of the centrality estimator (to fill axis of sparse)
   Bool_t fUseFinPtBinsForSparse; ///flag to fill pt axis of sparse with 0.1 GeV/c wide bins
 
+  /// variables for ML application
+  Bool_t fApplyML;                        /// flag to enable ML application
+  TString fConfigPath;                    /// path to ML config file
+  Int_t fNumVars;                         /// number of variables used in the model
+  std::vector<std::string> fModelPaths;   /// vector of model paths
+  std::vector<double> fModelOutputCuts;    /// vector of thresholds on model output
+  std::vector<double> fPtBinsModel;        /// vector of pt bin lims
+  std::vector<AliExternalBDT> fModels;    //!<! vector of ML models (BDTs for now)
+
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskSEDs,30);    ///  AliAnalysisTaskSE for Ds mass spectra
+  ClassDef(AliAnalysisTaskSEDs,31);    ///  AliAnalysisTaskSE for Ds mass spectra
   /// \endcond
 };
 

--- a/PWGHF/vertexingHF/CMakeLists.txt
+++ b/PWGHF/vertexingHF/CMakeLists.txt
@@ -79,7 +79,6 @@ set(SRCS
   AliAnalysisTaskSECleanupVertexingHF.cxx
   AliAnalysisTaskSECompareHF.cxx
   AliAnalysisTaskSEDplus.cxx
-  AliAnalysisTaskSEDs.cxx
   AliAnalysisTaskSELambdac.cxx
   AliAnalysisTaskSED0BDT.cxx
   AliAnalysisTaskSED0Mass.cxx
@@ -161,6 +160,14 @@ set(SRCS
   AliAnalysisTaskSEXicTopKpi.cxx
   AliRDHFCutsXictopKpi.cxx
    )
+
+# Sources for ROOT6 only - alphabetical order
+if(ROOT_VERSION_MAJOR EQUAL 6)
+  set(SRCS
+      ${SRCS}
+      AliAnalysisTaskSEDs.cxx
+  )
+endif()
 
 # Headers from sources
 string(REPLACE ".cxx" ".h" HDRS "${SRCS}")

--- a/PWGHF/vertexingHF/CMakeLists.txt
+++ b/PWGHF/vertexingHF/CMakeLists.txt
@@ -183,7 +183,11 @@ add_library_tested(${MODULE} SHARED  ${SRCS} G__${MODULE}.cxx)
 
 # Generate the ROOT map
 # Dependecies
-set(LIBDEPS ANALYSISalice PWGflowTasks PWGTRD PWGPPevcharQn PWGPPevcharQnInterface TMVA vHFBDT ML)
+set(LIBDEPS ANALYSISalice PWGflowTasks PWGTRD PWGPPevcharQn PWGPPevcharQnInterface TMVA vHFBDT)
+# Dependencies for ROOT6 only
+if(ROOT_VERSION_MAJOR EQUAL 6)
+  set(LIBDEPS ${LIBDEPS} ML)
+endif()
 generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
 
 # Generate a PARfile target for this library

--- a/PWGHF/vertexingHF/CMakeLists.txt
+++ b/PWGHF/vertexingHF/CMakeLists.txt
@@ -27,14 +27,16 @@ include_directories(${AliPhysics_SOURCE_DIR}/PWGHF/vertexingHF/vHFBDT)
 # Additional includes - alphabetical order except ROOT
 include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/CORRFW
-		    ${AliPhysics_SOURCE_DIR}/OADB
-		    ${AliPhysics_SOURCE_DIR}/OADB/COMMON/MULTIPLICITY
+                    ${AliPhysics_SOURCE_DIR}/ML
+                    ${AliPhysics_SOURCE_DIR}/OADB
+                    ${AliPhysics_SOURCE_DIR}/OADB/COMMON/MULTIPLICITY
                     ${AliPhysics_SOURCE_DIR}/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrections
-		    ${AliPhysics_SOURCE_DIR}/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrectionsInterface/
+                    ${AliPhysics_SOURCE_DIR}/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrectionsInterface/
                     ${AliPhysics_SOURCE_DIR}/PWG/FLOW/Base
                     ${AliPhysics_SOURCE_DIR}/PWG/FLOW/Tasks
                     ${AliPhysics_SOURCE_DIR}/PWG/muon
                     ${AliPhysics_SOURCE_DIR}/PWG/TRD
+                    ${TREELITE_ROOT}/include
   )
 
 # Sources - alphabetical order
@@ -174,7 +176,7 @@ add_library_tested(${MODULE} SHARED  ${SRCS} G__${MODULE}.cxx)
 
 # Generate the ROOT map
 # Dependecies
-set(LIBDEPS ANALYSISalice PWGflowTasks PWGTRD PWGPPevcharQn PWGPPevcharQnInterface TMVA vHFBDT)
+set(LIBDEPS ANALYSISalice PWGflowTasks PWGTRD PWGPPevcharQn PWGPPevcharQnInterface TMVA vHFBDT ML)
 generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
 
 # Generate a PARfile target for this library

--- a/PWGHF/vertexingHF/PWGHFvertexingHFLinkDef.h
+++ b/PWGHF/vertexingHF/PWGHFvertexingHFLinkDef.h
@@ -43,7 +43,6 @@
 #pragma link C++ class AliAnalysisTaskSECleanupVertexingHF+;
 #pragma link C++ class AliAnalysisTaskSECompareHF+;
 #pragma link C++ class AliAnalysisTaskSEDplus+;
-#pragma link C++ class AliAnalysisTaskSEDs+;
 #pragma link C++ class AliAnalysisTaskSELambdac+;
 #pragma link C++ class AliAnalysisTaskSED0BDT+;
 #pragma link C++ class AliAnalysisTaskSED0Mass+;
@@ -125,5 +124,10 @@
 #pragma link C++ class AliAnalysisTaskSELbtoLcpi4+;
 #pragma link C++ class AliAnalysisTaskSEXicTopKpi+;
 #pragma link C++ class AliRDHFCutsXictopKpi+;
+
+//classes working only in ROOT6
+#ifdef __CLING__
+#pragma link C++ class AliAnalysisTaskSEDs+;
+#endif
 
 #endif

--- a/PWGHF/vertexingHF/macros/AddTaskDs.C
+++ b/PWGHF/vertexingHF/macros/AddTaskDs.C
@@ -1,9 +1,9 @@
-AliAnalysisTaskSEDs *AddTaskDs(Int_t system=0/*0=pp,1=PbPb*/,
-			       Int_t storeNtuple=0,Bool_t storeNsparse=kFALSE,Bool_t storeNsparseDplus=kFALSE,Bool_t readMC=kFALSE,
-			       TString filename="", TString postname="", Bool_t doCutVarHistos = kFALSE, Int_t AODProtection = 1,
-			       Bool_t fillNTrklAxis = kFALSE, Bool_t fillCentrAxis = kFALSE,
-			       Bool_t useRotBkg=kFALSE, Bool_t useBkgFromPhiSB=kFALSE, Bool_t useCutV0multTPCout=kFALSE,
-			       Bool_t storeNsparseImpPar = kFALSE)
+AliAnalysisTaskSEDs *AddTaskDs(Int_t system = 0/*0=pp,1=PbPb*/,
+                               Int_t storeNtuple = 0, Bool_t storeNsparse = kFALSE, Bool_t storeNsparseDplus=  kFALSE,Bool_t readMC = kFALSE,
+                               TString filename = "", TString postname = "", Bool_t doCutVarHistos = kFALSE, Int_t AODProtection = 1,
+                               Bool_t fillNTrklAxis = kFALSE, Bool_t fillCentrAxis = kFALSE, Bool_t useRotBkg = kFALSE, Bool_t useBkgFromPhiSB = kFALSE, 
+                               Bool_t useCutV0multTPCout = kFALSE, Bool_t storeNsparseImpPar = kFALSE, Bool_t applyML = kFALSE, TString confFileML = "",
+                               TString cutObjName = "AnalysisCuts")
 {
   //
   // Test macro for the AliAnalysisTaskSE for Ds candidates
@@ -43,9 +43,9 @@ AliAnalysisTaskSEDs *AddTaskDs(Int_t system=0/*0=pp,1=PbPb*/,
     }
     else ::Fatal("AddTaskDs", "Standard cut object not available for PbPb: analysis will not start!\n");
   }
-  else {analysiscuts = (AliRDHFCutsDstoKKpi*)filecuts->Get("AnalysisCuts");
+  else {analysiscuts = (AliRDHFCutsDstoKKpi*)filecuts->Get(cutObjName.Data());
     if (!analysiscuts)
-	{ ::Fatal("AddTaskDs", "Cut object named \"AnalysisCuts\" not found in cutfile.");
+	{ ::Fatal("AddTaskDs", "Cut object not found in cutfile");
 	  return NULL;
 	}
 }
@@ -70,6 +70,9 @@ AliAnalysisTaskSEDs *AddTaskDs(Int_t system=0/*0=pp,1=PbPb*/,
   dsTask->SetSystem(system);
   dsTask->SetFillTracklets(fillNTrklAxis);
   dsTask->SetFillCentralityAxis(fillCentrAxis);
+  dsTask->SetDoMLApplication(applyML);
+  if(applyML)
+    dsTask->SetMLConfigFile(confFileML);
   mgr->AddTask(dsTask);
     
   // Create containers for input/output


### PR DESCRIPTION
First implementation of the application of a BDT model trained in python to the Ds candidate selection.

At the moment treelite is present only in the builds with ROOT6 so the Ds task is constrained to this ROOT version.
Hopefully a temporary fix.