### PR TITLE
Early execution break when recycling an external event

### DIFF
--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcal.h
@@ -411,7 +411,12 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   void                        SetEventPlaneVsEmcal(Double_t ep)                     { fEventPlaneVsEmcal = ep                             ; }
   void                        SetForceBeamType(BeamType f)                          { fForceBeamType     = f                              ; }
   void                        SetHistoBins(Int_t nbins, Double_t min, Double_t max) { fNbins = nbins; fMinBinPt = min; fMaxBinPt = max    ; }
-  void                        SetRecycleUnusedEmbeddedEventsMode(Bool_t b)          { fRecycleUnusedEmbeddedEventsMode = b                ; }
+  /**
+   * @brief Enables internal event selection in embedding by recycling unused events.
+   * @param[in] b Enables recycled unused embedded events.
+   * @deprecated: This is now handled automatically by the embedding helper, so the option is redundant.
+   */
+  void                        SetRecycleUnusedEmbeddedEventsMode(Bool_t b)          { AliWarning("Enabling recycling of unused embedded events is deprecated. It is now automatically controlled in the embedding helper. You can remove this call."); }
   void                        SetIsEmbedded(Bool_t i)                               { fIsEmbedded        = i                              ; }
 
   /**
@@ -1185,7 +1190,6 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   Double_t                    fMinEventPlane;              ///< minimum event plane value
   Double_t                    fMaxEventPlane;              ///< maximum event plane value
   TString                     fCentEst;                    ///< name of V0 centrality estimator
-  Bool_t                      fRecycleUnusedEmbeddedEventsMode; ///< Allows the recycling of embedded events which fail internal event selection. See the embedding helper.
   Bool_t                      fIsEmbedded;                 ///< trigger, embedded signal
   Bool_t                      fIsPythia;                   ///< trigger, if it is a PYTHIA production
   Bool_t                      fIsHerwig;                   ///< trigger, if it is a HERWIG production
@@ -1268,7 +1272,7 @@ class AliAnalysisTaskEmcal : public AliAnalysisTaskSE {
   AliAnalysisTaskEmcal &operator=(const AliAnalysisTaskEmcal&); // not implemented
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskEmcal, 19) // EMCAL base analysis task
+  ClassDef(AliAnalysisTaskEmcal, 20) // EMCAL base analysis task
   /// \endcond
 };
 

--- a/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
+++ b/PWG/EMCAL/EMCALbase/AliAnalysisTaskEmcalEmbeddingHelper.cxx
@@ -1641,11 +1641,20 @@ void AliAnalysisTaskEmcalEmbeddingHelper::UserExec(Option_t*)
       }
     }
 
-    // If the internal event was rejected, then record and move on.
+    // If the internal event was rejected, then record and skip this internal event by asking the
+    // analysis manager to break the execution.
     if (fEmbeddedEventUsed == false) {
       if (fCreateHisto) {
         PostData(1, fOutput);
       }
+      AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+      if (!mgr) {
+        AliFatal("No analysis manager to connect to.");
+      }
+      // Ask the analysis manager to break execution, which will prevent any downstream tasks
+      // from executing.
+      AliDebugStream(3) << "Internal event rejected due to event selection. Breaking execution early.\n";
+      mgr->BreakExecutionChain(kTRUE);
       return;
     }
   }

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.cxx
@@ -48,7 +48,6 @@ AliEmcalCorrectionTask::AliEmcalCorrectionTask() :
   fConfigurationInitialized(false),
   fIsEsd(false),
   fEventInitialized(false),
-  fRecycleUnusedEmbeddedEventsMode(false),
   fCent(0),
   fCentBin(-1),
   fMinCent(-999),
@@ -94,7 +93,6 @@ AliEmcalCorrectionTask::AliEmcalCorrectionTask(const char * name) :
   fConfigurationInitialized(false),
   fIsEsd(false),
   fEventInitialized(false),
-  fRecycleUnusedEmbeddedEventsMode(false),
   fCent(0),
   fCentBin(-1),
   fMinCent(-999),
@@ -140,7 +138,6 @@ AliEmcalCorrectionTask::AliEmcalCorrectionTask(const AliEmcalCorrectionTask & ta
   fConfigurationInitialized(task.fConfigurationInitialized),
   fIsEsd(task.fIsEsd),
   fEventInitialized(task.fEventInitialized),
-  fRecycleUnusedEmbeddedEventsMode(task.fRecycleUnusedEmbeddedEventsMode),
   fCent(task.fCent),
   fCentBin(task.fCentBin),
   fMinCent(task.fMinCent),
@@ -204,7 +201,6 @@ void swap(AliEmcalCorrectionTask & first, AliEmcalCorrectionTask & second)
   swap(first.fConfigurationInitialized, second.fConfigurationInitialized);
   swap(first.fIsEsd, second.fIsEsd);
   swap(first.fEventInitialized, second.fEventInitialized);
-  swap(first.fRecycleUnusedEmbeddedEventsMode, second.fRecycleUnusedEmbeddedEventsMode);
   swap(first.fCent, second.fCent);
   swap(first.fCentBin, second.fCentBin);
   swap(first.fMinCent, second.fMinCent);
@@ -295,10 +291,6 @@ void AliEmcalCorrectionTask::Initialize(bool removeDummyTask)
 
   // Initialize components
   InitializeComponents();
-
-  // Determine whether to determine event selection via the embedding helper
-  // so embedded events can be "recycled"
-  fYAMLConfig.GetProperty("recycleUnusedEmbeddedEventsMode", fRecycleUnusedEmbeddedEventsMode);
 
   if (removeDummyTask == true) {
     RemoveDummyTask();
@@ -1093,15 +1085,6 @@ void AliEmcalCorrectionTask::UserCreateOutputObjectsComponents()
  */
 void AliEmcalCorrectionTask::UserExec(Option_t *option)
 {
-  // Recycle embedded events which do not pass the internal event selection in the embedding helper
-  if (fRecycleUnusedEmbeddedEventsMode) {
-    auto embeddingHelper = AliAnalysisTaskEmcalEmbeddingHelper::GetInstance();
-    if (embeddingHelper && embeddingHelper->EmbeddedEventUsed() == false) {
-      AliDebugStream(4) << "Embedding helper rejected the internal event. Skipping this event.\n";
-      return;
-    }
-  }
-
   // Initialize the event if not initialized
   if (!fEventInitialized)
     ExecOnce();

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionTask.h
@@ -228,7 +228,6 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
 
   bool                        fIsEsd;                      ///< File type
   bool                        fEventInitialized;           ///< If the event is initialized properly
-  bool                        fRecycleUnusedEmbeddedEventsMode; ///< Allows the recycling of embedded events which fail internal event selection. See the embedding helper.
   Double_t                    fCent;                       //!<! Event centrality
   Int_t                       fCentBin;                    //!<! Event centrality bin
   Double_t                    fMinCent;                    ///< min centrality for event selection
@@ -250,7 +249,7 @@ class AliEmcalCorrectionTask : public AliAnalysisTaskSE {
   TList *                     fOutput;                     //!<! Output for histograms
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionTask, 8); // EMCal correction task
+  ClassDef(AliEmcalCorrectionTask, 9); // EMCal correction task
   /// \endcond
 };
 

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -1,6 +1,6 @@
 configurationName: "Default configuration"          # Optional - Simply for user convenience
 pass: ""                                            # Attempts to automatically retrieve the pass if not specified. Usually of the form "pass#".
-recycleUnusedEmbeddedEventsMode: false              # True if embedded events should be recycled by using the internal event selection of the embedding helper.
+recycleUnusedEmbeddedEventsMode: false              # DEPRECATED! This is handled directly by the embedding helper. True if embedded events should be recycled by using the internal event selection of the embedding helper.
 # Look at the documentation for a full explanation of the input objects!
 inputObjects:                                       # Define all of the input objects for the corrections
     cells:                                          # Configure cells

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.cxx
@@ -161,8 +161,6 @@ bool AliAnalysisTaskEmcalJetHCorrelations::Initialize()
 void AliAnalysisTaskEmcalJetHCorrelations::RetrieveAndSetTaskPropertiesFromYAMLConfig()
 {
   // Base class options
-  // Recycle unused embedded events
-  fYAMLConfig.GetProperty("recycleUnusedEmbeddedEventsMode", fRecycleUnusedEmbeddedEventsMode, false);
   // Task physics (trigger) selection.
   std::string baseName = "eventCuts";
   std::vector<std::string> physicsSelection;
@@ -1504,7 +1502,6 @@ std::string AliAnalysisTaskEmcalJetHCorrelations::toString() const
 {
   std::stringstream tempSS;
   tempSS << std::boolalpha;
-  tempSS << "Recycle unused embedded events: " << fRecycleUnusedEmbeddedEventsMode << "\n";
   tempSS << "Jet collections:\n";
   TIter next(&fJetCollArray);
   AliJetContainer * jetCont;

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHPerformance.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHPerformance.cxx
@@ -150,8 +150,6 @@ double AliAnalysisTaskEmcalJetHPerformance::DetermineTrackingEfficiency(double t
 void AliAnalysisTaskEmcalJetHPerformance::RetrieveAndSetTaskPropertiesFromYAMLConfig()
 {
   // Base class options
-  // Recycle unused embedded events
-  fYAMLConfig.GetProperty("recycleUnusedEmbeddedEventsMode", fRecycleUnusedEmbeddedEventsMode, false);
   // Task physics (trigger) selection.
   std::vector<std::string> physicsSelection;
   bool res = fYAMLConfig.GetProperty(std::vector<std::string>({"eventCuts", "physicsSelection"}), physicsSelection, false);
@@ -1425,7 +1423,6 @@ std::string AliAnalysisTaskEmcalJetHPerformance::toString() const
 {
   std::stringstream tempSS;
   tempSS << std::boolalpha;
-  tempSS << "Recycle unused embedded events: " << fRecycleUnusedEmbeddedEventsMode << "\n";
   tempSS << "Particle collections:\n";
   TIter nextParticleCont(&fParticleCollArray);
   AliParticleContainer * particleCont;


### PR DESCRIPTION
This takes advantage of a new feature in `AliAnalysisManager`. This way,
the users don't need to enable embedded event recycling. However, this
does slightly change procedure because the later user task internal event
counting won't be accurate - the user task won't be executed.