### PR TITLE
PWGHF: Add filling cand in ITS3Improver

### DIFF
--- a/PWGHF/vertexingHF/upgrade/AliAnalysisTaskSEImproveITS3.cxx
+++ b/PWGHF/vertexingHF/upgrade/AliAnalysisTaskSEImproveITS3.cxx
@@ -33,6 +33,7 @@
 #include "AliAODRecoCascadeHF.h"
 #include "AliNeutralTrackParam.h"
 #include "AliAnalysisTaskSEImproveITS3.h"
+#include "AliAnalysisVertexingHF.h"
 
 //
 // Implementation of the "hybrid-approach" for ITS upgrade studies.
@@ -100,7 +101,7 @@ AliAnalysisTaskSEImproveITS3::AliAnalysisTaskSEImproveITS3(const char *name,
                            const char *resfileCurURI,
                            const char *resfileUpgURI,
                            Bool_t isRunInVertexing,
-			   Int_t ndebug)
+			                     Int_t ndebug)
   :AliAnalysisTaskSE(name),
    fD0ZResPCur  (0),
    fD0ZResKCur  (0),
@@ -277,6 +278,36 @@ void AliAnalysisTaskSEImproveITS3::UserExec(Option_t*) {
   // Smear all tracks
   TClonesArray *mcs=static_cast<TClonesArray*>(ev->GetList()->FindObject(AliAODMCParticle::StdBranchName()));
   if (!mcs) return;
+  
+  // first loop on candidates to fill them in case of reduced AODs
+  // this is done to have the same behaviour of the improver with full (pp, p-Pb) and recuced (Pb-Pb) candidates
+  AliAnalysisVertexingHF *vHF = new AliAnalysisVertexingHF();
+  
+  // D0->Kpi
+  TClonesArray *array2Prong=static_cast<TClonesArray*>(ev->GetList()->FindObject("D0toKpi"));
+  if (array2Prong) {
+    for (Int_t icand=0;icand<array2Prong->GetEntriesFast();++icand) {
+      AliAODRecoDecayHF2Prong *decay=static_cast<AliAODRecoDecayHF2Prong*>(array2Prong->At(icand));
+      vHF->FillRecoCand(ev,(AliAODRecoDecayHF2Prong*)decay);
+    }
+  }
+  // Dstar->Kpipi
+  TClonesArray *arrayCascade=static_cast<TClonesArray*>(ev->GetList()->FindObject("Dstar"));
+  if (arrayCascade) {
+    for (Int_t icand=0;icand<arrayCascade->GetEntriesFast();++icand) {
+      AliAODRecoCascadeHF *decayDstar=static_cast<AliAODRecoCascadeHF*>(arrayCascade->At(icand));
+      vHF->FillRecoCasc(ev,((AliAODRecoCascadeHF*)decayDstar),kTRUE);
+    }
+  }
+  // Three prong
+  TClonesArray *array3Prong=static_cast<TClonesArray*>(ev->GetList()->FindObject("Charm3Prong"));
+  if (array3Prong) {
+    for (Int_t icand=0;icand<array3Prong->GetEntriesFast();++icand) {
+      AliAODRecoDecayHF3Prong *decay=static_cast<AliAODRecoDecayHF3Prong*>(array3Prong->At(icand));
+      vHF->FillRecoCand(ev,(AliAODRecoDecayHF3Prong*)decay);
+    }
+  }
+  
   if (fImproveTracks) {
     for(Int_t itrack=0;itrack<ev->GetNumberOfTracks();++itrack) {
       AliAODTrack * trk = dynamic_cast<AliAODTrack*>(ev->GetTrack(itrack));
@@ -290,14 +321,13 @@ void AliAnalysisTaskSEImproveITS3::UserExec(Option_t*) {
 
   // Recalculate all candidates
   // D0->Kpi
-  TClonesArray *array2Prong=static_cast<TClonesArray*>(ev->GetList()->FindObject("D0toKpi"));
   if (array2Prong) {
       for (Int_t icand=0;icand<array2Prong->GetEntries();++icand) {
       AliAODRecoDecayHF2Prong *decay=static_cast<AliAODRecoDecayHF2Prong*>(array2Prong->At(icand));
+      if(!vHF->FillRecoCand(ev,(AliAODRecoDecayHF2Prong*)decay))continue;
 
       // recalculate vertices
       AliVVertex *oldSecondaryVertex=decay->GetSecondaryVtx();
-
 
       AliExternalTrackParam et1; et1.CopyFromVTrack(static_cast<AliAODTrack*>(decay->GetDaughter(0)));
       AliExternalTrackParam et2; et2.CopyFromVTrack(static_cast<AliAODTrack*>(decay->GetDaughter(1)));
@@ -311,16 +341,12 @@ void AliAnalysisTaskSEImproveITS3::UserExec(Option_t*) {
       // update secondary vertex
       Double_t pos[3];
       Double_t covpos[6];
-          
       v12->GetXYZ(pos);
       v12->GetCovMatrix(covpos);
-          
-      
       decay->GetSecondaryVtx()->SetPosition(pos[0],pos[1],pos[2]);
       if(fUpdateSecVertCovMat) decay->GetSecondaryVtx()->SetCovMatrix(covpos);
       decay->GetSecondaryVtx()->SetChi2perNDF(v12->GetChi2toNDF()); 
      
-
       // update d0 
       Double_t d0z0[2],covd0z0[3];
       Double_t d0[2],d0err[2];
@@ -357,11 +383,10 @@ void AliAnalysisTaskSEImproveITS3::UserExec(Option_t*) {
 
 
   // Dstar->Kpipi
-  TClonesArray *arrayCascade=static_cast<TClonesArray*>(ev->GetList()->FindObject("Dstar"));
-  
   if (arrayCascade) {
     for (Int_t icand=0;icand<arrayCascade->GetEntries();++icand) {
       AliAODRecoCascadeHF *decayDstar=static_cast<AliAODRecoCascadeHF*>(arrayCascade->At(icand));
+      if(!vHF->FillRecoCasc(ev,((AliAODRecoCascadeHF*)decayDstar),kTRUE))continue;
       //Get D0 from D*
       AliAODRecoDecayHF2Prong* decay=(AliAODRecoDecayHF2Prong*)decayDstar->Get2Prong();
       
@@ -396,10 +421,10 @@ void AliAnalysisTaskSEImproveITS3::UserExec(Option_t*) {
        // a run for D*
       Double_t px1[2],py1[2],pz1[2];
       for (Int_t i=0;i<2;++i) {
-	const AliAODTrack *t1=static_cast<AliAODTrack*>(decayDstar->GetDaughter(i));
-	px1[i]=t1->Px();
-	py1[i]=t1->Py();
-	pz1[i]=t1->Pz();
+      	const AliAODTrack *t1=static_cast<AliAODTrack*>(decayDstar->GetDaughter(i));
+      	px1[i]=t1->Px();
+      	py1[i]=t1->Py();
+      	pz1[i]=t1->Pz();
       }
       decayDstar->SetPxPyPzProngs(2,px1,py1,pz1);
       
@@ -408,11 +433,11 @@ void AliAnalysisTaskSEImproveITS3::UserExec(Option_t*) {
 
 
   // Three prong
-  TClonesArray *array3Prong=static_cast<TClonesArray*>(ev->GetList()->FindObject("Charm3Prong"));
   if (array3Prong) {
     for (Int_t icand=0;icand<array3Prong->GetEntries();++icand) {
       AliAODRecoDecayHF3Prong *decay=static_cast<AliAODRecoDecayHF3Prong*>(array3Prong->At(icand));
-
+      if(!vHF->FillRecoCand(ev,(AliAODRecoDecayHF3Prong*)decay))continue;
+      
       // recalculate vertices
       AliVVertex *oldSecondaryVertex=decay->GetSecondaryVtx();
       AliExternalTrackParam et1; et1.CopyFromVTrack(static_cast<AliAODTrack*>(decay->GetDaughter(0)));
@@ -434,7 +459,6 @@ void AliAnalysisTaskSEImproveITS3::UserExec(Option_t*) {
       decay->GetSecondaryVtx()->SetPosition(pos[0],pos[1],pos[2]);
       if(fUpdateSecVertCovMat) decay->GetSecondaryVtx()->SetCovMatrix(covpos);
       decay->GetSecondaryVtx()->SetChi2perNDF(v123->GetChi2toNDF()); 
-      //TODO: covariance matrix
 
       // update d0 for all progs
       Double_t d0z0[2],covd0z0[3];
@@ -459,10 +483,10 @@ void AliAnalysisTaskSEImproveITS3::UserExec(Option_t*) {
       dca[1]=et3.GetDCA(&et2,bz,xdummy,ydummy);
       dca[2]=et1.GetDCA(&et3,bz,xdummy,ydummy);
       decay->SetDCAs(3,dca);
+      
       //update sigmavertex = dispersion
       Float_t sigmaV=v123->GetDispersion();
       decay->SetSigmaVert(sigmaV);
-
       // update dist12 and dist23
       primaryVertex->GetXYZ(pos);
       decay->SetDist12toPrim(TMath::Sqrt((v12->GetX()-pos[0])*(v12->GetX()-pos[0])
@@ -483,9 +507,11 @@ void AliAnalysisTaskSEImproveITS3::UserExec(Option_t*) {
         pz[i]=t.Pz();
       }
       decay->SetPxPyPzProngs(3,px,py,pz);
+
       delete v123;delete v12;delete v23;
     }
   }
+  delete vHF;
 }
 
 void AliAnalysisTaskSEImproveITS3::SmearTrack(AliAODTrack *track,const TClonesArray *mcs) {


### PR DESCRIPTION
ITS3Improver crashes when trying to run over standard PbPb MC's (for example GP PbPb '18). Candidates needs to be filled first.