### PR TITLE
Revise TRD digits filtering

### DIFF
--- a/PWGPP/TRD/AliTRDdigitsFilter.cxx
+++ b/PWGPP/TRD/AliTRDdigitsFilter.cxx
@@ -29,8 +29,10 @@
 #include "AliInputEventHandler.h"
 #include "AliESDInputHandler.h"
 #include "AliESDv0KineCuts.h"
+#include "AliMultSelection.h"
 #include "AliESDv0.h"
 #include "AliCentrality.h"
+#include "AliLog.h"
 
 #include "AliTRDdigitsManager.h"
 #include "AliTRDarrayADC.h"
@@ -38,6 +40,8 @@
 #include "TChain.h"
 #include "TFile.h"
 #include "TRandom.h"
+#include "THnSparse.h"
+
 
 class TCanvas;
 class TAxis;
@@ -62,21 +66,14 @@ ClassImp(AliTRDdigitsFilter)
 
 //________________________________________________________________________
 AliTRDdigitsFilter::AliTRDdigitsFilter(const char *name)
-    : AliAnalysisTaskSE(name), fV0cuts(0x0), fPidTags(0x0),
-    fESDEvent(0), fOutputContainer(0), fESDtrackCuts(0),
-    fESDtrackCutsV0(0), fListQA(0x0),
-    fDigitsInputFile(0), fDigitsOutputFile(0),
-    fEventNoInFile(-1), fDigMan(0)
+    : AliTRDdigitsTask(name)
 {
-  //
-  // Constructor
-  //
-
-  fDigMan = new AliTRDdigitsManager;
-  fDigMan->CreateArrays();
 
   // V0 Kine cuts
   fV0cuts = new AliESDv0KineCuts();
+
+  SetDigitsInputFilename("TRD.Digits.root");
+  SetDigitsOutputFilename("TRD.FltDigits.root");
 
   DefineInput(0, TChain::Class());
   DefineOutput(1, TList::Class());
@@ -91,17 +88,15 @@ AliTRDdigitsFilter::~AliTRDdigitsFilter()
   // Destructor
   //
 
-  delete fDigitsInputFile;
-  delete fDigitsOutputFile;
-  delete fDigMan;
   delete fV0cuts;
 }
 
-void AliTRDdigitsFilter::AcceptParticles(TString label, EPID_t pid,
+//________________________________________________________________________
+void AliTRDdigitsFilter::AcceptTracks(TString label, EPID_t pid,
     Float_t minPt, Float_t maxPt, Float_t fraction)
 {
 
-  AcceptCrit crit;
+  TrackCrit crit;
 
   crit.fLabel     = label;
   crit.fPid       = pid;
@@ -109,7 +104,40 @@ void AliTRDdigitsFilter::AcceptParticles(TString label, EPID_t pid,
   crit.fMaxPt     = maxPt;
   crit.fFraction  = fraction;
 
-  fAcceptCriteria.push_back(crit);
+  fTrackCriteria.push_back(crit);
+  AliInfoF("nTrackCrit: %lu", fTrackCriteria.size());
+}
+
+//________________________________________________________________________
+void AliTRDdigitsFilter::AcceptEvents(TString label,
+    Float_t minCent, Float_t maxCent, Float_t fraction)
+{
+
+  EventCrit crit;
+
+  crit.fLabel     = label;
+  crit.fMinCent     = minCent;
+  crit.fMaxCent     = maxCent;
+  crit.fFraction  = fraction;
+
+  fEventCriteria.push_back(crit);
+  AliInfoF("nEventCrit: %lu", fEventCriteria.size());
+}
+
+//________________________________________________________________________
+void AliTRDdigitsFilter::PrintSettings()
+{
+
+  AliInfo("Accept these particle classes:");
+  for (std::vector<TrackCrit>::iterator iCrit = fTrackCriteria.begin();
+       iCrit != fTrackCriteria.end(); iCrit++) {
+
+         AliInfoF("%10s: pidclass=%d, %f < pT(GeV/c) < %f",
+         iCrit->fLabel.Data(), iCrit->fPid, iCrit->fMinPt, iCrit->fMaxPt
+       );
+   }
+
+
 }
 
 //________________________________________________________________________
@@ -126,79 +154,120 @@ void AliTRDdigitsFilter::UserCreateOutputObjects()
 
 
   OpenFile(1);
-  fListQA=new TList;
-  fListQA->SetOwner();
+  fOutputList=new TList;
+  fOutputList->SetOwner();
 
-  // V0 QA histograms
-  fhArmenteros  = new TH2F( "Armenteros","Armenteros plot",
-                            200,-1.,1.,200,0.,0.4);
+  CreateV0Plots();
 
   // statistics of accepted events
-  fhEventCuts = new TH1F("EventCuts","statistics of event cuts",10,0.,10.);
+  int nClasses = fEventCriteria.size() + fTrackCriteria.size();
+  fhEventCuts = new TH1F("EventCuts","statistics of event cuts",
+    nClasses+4, 0., nClasses+4.0);
+
+  fhEventCuts->GetXaxis()->SetBinLabel(1,"event_in");
+  fhEventCuts->GetXaxis()->SetBinLabel(2,"event_esd");
+  fhEventCuts->GetXaxis()->SetBinLabel(3,"event_vtx");
+  fhEventCuts->GetXaxis()->SetBinLabel(4,"event_acc");
+
+  for (Int_t i = 0; i<fEventCriteria.size(); i++) {
+    fhEventCuts->GetXaxis()->SetBinLabel(i+5, "event_acc_"+fEventCriteria[i].fLabel);
+  }
+
+  for (Int_t i = 0; i<fTrackCriteria.size(); i++) {
+    fhEventCuts->GetXaxis()->SetBinLabel( i+5+fEventCriteria.size(),
+    "event_acc_"+fTrackCriteria[i].fLabel);
+  }
+
+
+  // THnSparse for accepted tracks
+  const Int_t ntc = 2<<fTrackCriteria.size();
+  Int_t nbins[]   = { ntc,    30,   10,  10 };
+  Double_t xmin[] = { 0.0,   0.0, -1.0, 0.0 };
+  Double_t xmax[] = { float(ntc),  60.0,  1.0, 2*TMath::Pi() };
+
+  fhAcc = new THnSparseF("fhAcc", "accepted tracks", 4, nbins, xmin, xmax);
+
+  //fhAcc->GetAxis(0)->SetBinLabel(1,"foo");
+  fhAcc->GetAxis(1)->SetTitle("p_{T} (GeV/c)");
+  fhAcc->GetAxis(2)->SetTitle("#eta");
+  fhAcc->GetAxis(3)->SetTitle("#phi (rad)");
 
   // pT histograms
   fhPtTag  = new TH1F("fhPtTag",  "pT of PID-tagged tracks", 100,0.,20.);
   fhPtGood = new TH1F("fhPtGood", "pT after quality cuts",   100,0.,20.);
   fhPtAcc  = new TH1F("fhPtAcc",  "pT of accepted tracks",   100,0.,20.);
 
+  // multiplicity histograms
+  fhCent = new TH1F("fhCentralityAll", "Centrality of Events", 105, 0., 105.);
+  fhCentAcc = new TH1F("fhCentralityAccepted", "Centrality of Accepted Events",
+                       105, 0., 105.);
+
   // add everything to the list
-  fListQA->Add(fhArmenteros);
-  fListQA->Add(fhEventCuts);
-  fListQA->Add(fhPtTag);
-  fListQA->Add(fhPtGood);
-  fListQA->Add(fhPtAcc);
+  fOutputList->Add(fhAcc);
+  fOutputList->Add(fhEventCuts);
+  fOutputList->Add(fhPtTag);
+  fOutputList->Add(fhPtGood);
+  fOutputList->Add(fhPtAcc);
+  fOutputList->Add(fhCent);
+  fOutputList->Add(fhCentAcc);
 
-  PostData(1,fListQA);
+  PostData(1,fOutputList);
 
 
 }
 
-//_____________________________________________________________________________
-Bool_t AliTRDdigitsFilter::UserNotify()
-{
-  delete fDigitsInputFile;
-  delete fDigitsOutputFile;
-
-  AliESDInputHandler *esdH = dynamic_cast<AliESDInputHandler*> (AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler());
-
-  TString ofname = esdH->GetTree()->GetCurrentFile()->GetName();
-  TString ifname = ofname;
-
-  ifname.ReplaceAll("AliESDs.root", "TRD.Digits.root");
-  ofname.ReplaceAll("AliESDs.root", "TRD.FltDigits.root");
-
-  fDigitsInputFile  = new TFile(ifname);
-  fDigitsOutputFile = new TFile(ofname,"RECREATE");
-
-  fEventNoInFile = 0;
-
-  return kTRUE;
-}
+// //_____________________________________________________________________________
+// Bool_t AliTRDdigitsFilter::UserNotify()
+// {
+//   delete fDigitsInputFile;
+//   delete fDigitsOutputFile;
+//
+//   AliESDInputHandler *esdH = dynamic_cast<AliESDInputHandler*> (AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler());
+//
+//   TString ofname = esdH->GetTree()->GetCurrentFile()->GetName();
+//   TString ifname = ofname;
+//
+//   ifname.ReplaceAll("AliESDs.root", "TRD.Digits.root");
+//   ofname.ReplaceAll("AliESDs.root", "TRD.FltDigits.root");
+//
+//   fDigitsInputFile  = new TFile(ifname);
+//   fDigitsOutputFile = new TFile(ofname,"RECREATE");
+//
+//   fEventNoInFile = 0;
+//
+//   return kTRUE;
+// }
 
 //_____________________________________________________________________________
 void AliTRDdigitsFilter::UserExec(Option_t *)
 {
-    //
-    //calls the Process function
-    //
+  // -----------------------------------------------------------------
+  // -----------------------------------------------------------------
+  // IMPORTANT: call NextEvent() for book-keeping
+  // -----------------------------------------------------------------
+  NextEvent();
+  // -----------------------------------------------------------------
+  // -----------------------------------------------------------------
 
-    AliESDInputHandler *esdH = dynamic_cast<AliESDInputHandler*> (AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler());
 
-    if (!esdH) {
-      printf("ERROR: Could not get ESDInputHandler \n");
-    }
-    else fESDEvent = (AliESDEvent *) esdH->GetEvent();
+  //
+  //calls the Process function
+  //
 
-    // allocate space for the PID tags
-    fPidTags.resize(fESDEvent->GetNumberOfTracks());
+  AliESDInputHandler *esdH = dynamic_cast<AliESDInputHandler*> (AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler());
 
-    FillV0PIDlist();
-    Process(fESDEvent);
+  if (!esdH) {
+    printf("ERROR: Could not get ESDInputHandler \n");
+  }
+  else fESDevent = (AliESDEvent *) esdH->GetEvent();
 
-    PostData(1,fListQA);
+  // allocate space for the PID tags
+  fPidTags.resize(fESDevent->GetNumberOfTracks());
 
-    // increment the event counter for this file
-    fEventNoInFile++;
+  FillV0PIDlist();
+  Process(fESDevent);
+
+  PostData(1,fOutputList);
 
 }
 
@@ -222,19 +291,56 @@ void AliTRDdigitsFilter::Process(AliESDEvent *const esdEvent)
 
   // check for a valid event vertex
   const AliESDVertex* fESDEventvertex = esdEvent->GetPrimaryVertexTracks();
-  if (!fESDEventvertex)
-    return;
+  if (!fESDEventvertex) return;
 
   Int_t ncontr = fESDEventvertex->GetNContributors();
   if (ncontr <= 0) return;
 
   fhEventCuts->Fill("event_vtx",1);
 
-  Bool_t keepEvent = kFALSE;
 
-  for (int iTrack=0; iTrack<fPidTags.size(); iTrack++) {
+  //-------------------------------------------------------------------
+  Int_t keepEvent = 0;
+  Int_t keepNTracks = 0;
 
-    Bool_t keepTrack = kFALSE;
+  Int_t nEventCrit = fEventCriteria.size();
+  Int_t nTrackCrit = fTrackCriteria.size();
+
+  //-------------------------------------------------------------------
+
+  AliMultSelection *multSelection =
+    static_cast<AliMultSelection*>(esdEvent->FindListObject("MultSelection"));
+
+  if(multSelection) {
+
+    Float_t centrality = multSelection->GetMultiplicityPercentile("V0M");
+
+    fhCent->Fill(centrality);
+
+    for (Int_t i = 0; i<nEventCrit; i++) {
+
+      // check event criteria
+      if ( fEventCriteria[i].fMinCent > centrality) continue;
+      if ( fEventCriteria[i].fMaxCent <= centrality) continue;
+
+      // accept given fraction of events
+      if ( gRandom->Uniform() > fEventCriteria[i].fFraction ) continue;
+
+      keepEvent |= 1<<i;
+
+   }
+
+   if (keepEvent) {
+     fhCentAcc->Fill(centrality);
+   }
+
+ }
+
+ //-------------------------------------------------------------------
+
+ for (int iTrack=0; iTrack<fPidTags.size(); iTrack++) {
+
+    Int_t keepTrack = 0;
 
     if (fPidTags[iTrack] == kPidUndef) continue;
     if (fPidTags[iTrack] == kPidError) continue;
@@ -248,22 +354,29 @@ void AliTRDdigitsFilter::Process(AliESDEvent *const esdEvent)
 
     fhPtGood->Fill(track->Pt());
 
-    for (std::list<AcceptCrit>::iterator iCrit = fAcceptCriteria.begin();
-         iCrit != fAcceptCriteria.end(); iCrit++) {
+    for (Int_t i = 0; i<nTrackCrit; i++) {
 
         // check track criteria
-        if ( iCrit->fPid != fPidTags[iTrack] ) continue;
-        if ( iCrit->fMinPt > track->Pt()) continue;
-        if ( iCrit->fMaxPt < track->Pt()) continue;
+        if ( fTrackCriteria[i].fPid != fPidTags[iTrack] ) continue;
+        if ( fTrackCriteria[i].fMinPt > track->Pt()) continue;
+        if ( fTrackCriteria[i].fMaxPt < track->Pt()) continue;
 
         // accept given fraction of tracks
-        if ( gRandom->Uniform() > iCrit->fFraction ) continue;
+        if ( gRandom->Uniform() > fTrackCriteria[i].fFraction ) continue;
 
-        keepEvent = kTRUE;
-        keepTrack = kTRUE;
+        keepEvent |= 1<<(nEventCrit + i);
+        keepTrack |= 1<<i;
+        keepNTracks++;
      }
 
      if (keepTrack) {
+       Double_t data[4];
+       data[0] = keepTrack;
+       data[1] = track->Pt();
+       data[2] = track->Eta();
+       data[3] = track->Phi();
+
+       fhAcc->Fill(data);
        fhPtAcc->Fill(track->Pt());
      }
 
@@ -273,110 +386,82 @@ void AliTRDdigitsFilter::Process(AliESDEvent *const esdEvent)
 
     fhEventCuts->Fill("event_acc",1);
 
-    // load the digits from TRD.Digits.root
-    ReadDigits();
+    for (Int_t i = 0; i<nEventCrit; i++) {
+      if (keepEvent & ( 1 << i ) ) {
+        fhEventCuts->Fill("event_acc_"+fEventCriteria[i].fLabel,1);
+      }
+    }
 
-    // store the digits in TRD.FltDigits.root
-    WriteDigits();
-  }
+    for (Int_t i = 0; i<nTrackCrit; i++) {
+      if (keepEvent & ( 1 << (nEventCrit+i) ) ) {
+        fhEventCuts->Fill("event_acc_"+fTrackCriteria[i].fLabel,1);
+      }
+    }
 
-  PostData(1,fListQA);
-}
-
-
-//________________________________________________________________________
-void AliTRDdigitsFilter::ReadDigits()
-{
-  TTree* tr = (TTree*)fDigitsInputFile->Get(Form("Event%d/TreeD",
-						 fEventNoInFile));
-  for (Int_t det=0; det<540; det++) {
-    fDigMan->ClearArrays(det);
-    fDigMan->ClearIndexes(det);
-  }
-
-  fDigMan->ReadDigits(tr);
-  delete tr;
-}
-
-//________________________________________________________________________
-void AliTRDdigitsFilter::WriteDigits()
-{
-  TDirectory* evdir =
-    fDigitsOutputFile->mkdir(Form("Event%d", fEventNoInFile),
-			     Form("Event%d", fEventNoInFile));
-
-  evdir->Write();
-  evdir->cd();
-
-  TTree* tr = new TTree("TreeD", "TreeD");
-  fDigMan->MakeBranch(tr);
-  fDigMan->WriteDigits();
-  delete tr;
-}
-
-
-//________________________________________________________________________
-void AliTRDdigitsFilter::Terminate(const Option_t *)
-{
-    //
-    // Terminate function
-    //
-}
-
-
-//______________________________________________________________________________
-void AliTRDdigitsFilter::FillV0PIDlist(){
-
-  //
-  // Fill the PID object arrays holding the pointers to identified particle tracks
-  //
-
-  // Dynamic cast to ESD events (DO NOTHING for AOD events)
-  AliESDEvent *event = dynamic_cast<AliESDEvent *>(InputEvent());
-  if ( !event )  return;
-
-
-  // V0 selection
-  // set event
-  fV0cuts->SetEvent(event);
-
-
-  // loop over V0 particles
-  for(Int_t iv0=0; iv0<event->GetNumberOfV0s();iv0++){
-
-    AliESDv0 *v0 = (AliESDv0 *) event->GetV0(iv0);
-
-    if(!v0) continue;
-    if(v0->GetOnFlyStatus()) continue;
-
-    // Get the particle selection
-    Bool_t foundV0 = kFALSE;
-    Int_t pdgV0, pdgP, pdgN;
-    foundV0 = fV0cuts->ProcessV0(v0, pdgV0, pdgP, pdgN);
-    if(!foundV0) continue;
-    Int_t iTrackP = v0->GetPindex();  // positive track
-    Int_t iTrackN = v0->GetNindex();  // negative track
-
-    // v0 Armenteros plot (QA)
-    Float_t armVar[2] = {0.0,0.0};
-    fV0cuts->Armenteros(v0, armVar);
-    // if ( !(TMath::Power(armVar[0]/0.95,2)+TMath::Power(armVar[1]/0.05,2) < 1) ) continue;
-
-    if(fListQA&&fhArmenteros) fhArmenteros->Fill(armVar[0],armVar[1]);
-
-    // fill the tags
-
-    if( pdgP ==   -11 ) { fPidTags[iTrackP] = kPidV0Electron; }
-    if( pdgN ==    11 ) { fPidTags[iTrackN] = kPidV0Electron; }
-
-    if( pdgP ==   211 ) { fPidTags[iTrackP] = kPidV0Pion; }
-    if( pdgN ==  -211 ) { fPidTags[iTrackN] = kPidV0Pion; }
-
-    if( pdgP ==  2212 ) { fPidTags[iTrackP] = kPidV0Proton; }
-    if( pdgN == -2212 ) { fPidTags[iTrackN] = kPidV0Proton; }
+    if (ReadDigits()) {
+      WriteDigits();
+    }
 
   }
+
+  PostData(1,fOutputList);
 }
+
+// //________________________________________________________________________
+// Bool_t AliTRDdigitsFilter::ReadDigits()
+// {
+//   if (!fDigitsInputFile) {
+//     AliError("Digits file not open");
+//     return kFALSE;
+//   }
+//
+//   TTree* tr = (TTree*)fDigitsInputFile->Get(Form("Event%d/TreeD",
+// 						 fEventNoInFile));
+//
+//   if (!tr) {
+//     AliErrorF("Digits tree for event %d not found", fEventNoInFile);
+//     return kFALSE;
+//   }
+//
+//   for (Int_t det=0; det<540; det++) {
+//     fDigMan->ClearArrays(det);
+//     fDigMan->ClearIndexes(det);
+//   }
+//
+//   fDigMan->ReadDigits(tr);
+//   delete tr;
+//   return kTRUE;
+// }
+//
+// //________________________________________________________________________
+// void AliTRDdigitsFilter::WriteDigits()
+// {
+//   if (!fDigitsOutputFile) {
+//     AliError("Filtered digits file not open");
+//     return;
+//   }
+//
+//   TDirectory* evdir =
+//     fDigitsOutputFile->mkdir(Form("Event%d", fEventNoInFile),
+// 			     Form("Event%d", fEventNoInFile));
+//
+//   evdir->Write();
+//   evdir->cd();
+//
+//   TTree* tr = new TTree("TreeD", "TreeD");
+//   fDigMan->MakeBranch(tr);
+//   fDigMan->WriteDigits();
+//   delete tr;
+// }
+
+
+// //________________________________________________________________________
+// void AliTRDdigitsFilter::Terminate(const Option_t *)
+// {
+//     //
+//     // Terminate function
+//     //
+// }
 
 
 //________________________________________________________________________

--- a/PWGPP/TRD/AliTRDdigitsFilter.h
+++ b/PWGPP/TRD/AliTRDdigitsFilter.h
@@ -23,10 +23,10 @@
 #ifndef ALITRDDIGITSFILTER_H
 #define ALITRDDIGITSFILTER_H
 
-#include "AliAnalysisTaskSE.h"
+#include "AliTRDdigitsTask.h"
 
-#include <list>
 #include <vector>
+#include <list>
 
 class TTreeStream;
 class AliInputEventHandler;
@@ -47,47 +47,37 @@ class Riostream;
 class TChain;
 class TArrayF;
 class TFile;
+class THnSparse;
 class TH2;
 class TF1;
 class TH1;
 class TObjArray;
 
 
-class AliTRDdigitsFilter : public AliAnalysisTaskSE {
+class AliTRDdigitsFilter : public AliTRDdigitsTask {
 
 public:
 
-  typedef enum {
-    kPidUndef = 0,
-    kPidError = 1,
-    kPidV0Electron = 2,
-    kPidV0Pion = 3,
-    kPidV0Proton = 4
-  } EPID_t;
-
   AliTRDdigitsFilter(const char *name = "trd_digits_filter");
   virtual ~AliTRDdigitsFilter();
+
   virtual void   UserCreateOutputObjects();
-  virtual Bool_t UserNotify();
+  //virtual Bool_t UserNotify();
   virtual void   UserExec(Option_t *);
   virtual void   Process(AliESDEvent *const esdEvent=0);
-  virtual void   Terminate(const Option_t*);
+  //virtual void   Terminate(const Option_t*);
 
-  AliESDv0KineCuts* GetV0cuts() {return fV0cuts;}
+  //AliESDv0KineCuts* GetV0cuts() {return fV0cuts;}
 
-  void AcceptParticles(TString label, EPID_t pid,
+  void AcceptTracks(TString label, EPID_t pid,
       Float_t minPt, Float_t maxPt, Float_t fraction);
 
-  //EPID_t GetPidTag(Int_t trackIndex) const;
+  void AcceptEvents(TString label,
+                    Float_t minCent, Float_t maxCent, Float_t fraction);
 
+  void PrintSettings();
 
-protected:
-
-  AliESDv0KineCuts *fV0cuts;        //! ESD V0 cuts
-
-  std::vector<EPID_t> fPidTags;     //! vector of PID infor for all tracks
-
-  struct AcceptCrit {
+  struct TrackCrit {
     TString fLabel;
     EPID_t fPid;
     Float_t fMinPt;
@@ -95,13 +85,30 @@ protected:
     Float_t fFraction;
   };
 
-  std::list<AcceptCrit> fAcceptCriteria; //! criteria to accept tracks
+  std::vector<TrackCrit> fTrackCriteria; // criteria to accept tracks
 
-  void ReadDigits();
-  void WriteDigits();
+  struct EventCrit {
+    TString fLabel;
+    Float_t fMinCent;
+    Float_t fMaxCent;
+    Float_t fFraction;
+  };
+
+  std::vector<EventCrit> fEventCriteria; // criteria to accept events
+
+
+protected:
+
+  //AliESDv0KineCuts *fV0cuts;        //! ESD V0 cuts
+
+  //std::vector<EPID_t> fPidTags;     //! vector of PID info for all tracks
+
+
+  //Bool_t ReadDigits();
+  //void WriteDigits();
 
   //void SetupV0qa();
-  void FillV0PIDlist();
+  //void FillV0PIDlist();
   //void ClearV0PIDlist();
 
   Bool_t PassTrackCuts(AliESDtrack *fESDTrack=0,Int_t thres=0);
@@ -110,27 +117,30 @@ protected:
 private:
   //
   //
-  AliESDEvent *fESDEvent;              //! ESD object
+  //AliESDEvent *fESDevent;              //! ESD object
 
-  TObjArray *fOutputContainer;         //! output data container
-  AliESDtrackCuts *fESDtrackCuts;      //! basic cut variables for all non-V0 tracks
-  AliESDtrackCuts *fESDtrackCutsV0;    //! basic cut variables for all V0 tracks
+  //TObjArray *fOutputContainer;         //! output data container
+  //AliESDtrackCuts *fESDtrackCuts;      //! basic cut variables for all non-V0 tracks
+  //AliESDtrackCuts *fESDtrackCutsV0;    //! basic cut variables for all V0 tracks
 
-  TList   *fListQA;                    //! List with filter QA histograms
+  //TList   *fListQA;                    //! List with filter QA histograms
 
-  TFile* fDigitsInputFile;             //! Digits file for reading
-  TFile* fDigitsOutputFile;            //! Digits file for writing
+  //TFile* fDigitsInputFile;             //! Digits file for reading
+  //TFile* fDigitsOutputFile;            //! Digits file for writing
 
-  Int_t fEventNoInFile;                //! Bookkeeping
+  //Int_t fEventNoInFile;                //! Bookkeeping
 
-  AliTRDdigitsManager* fDigMan;        //! digits manager
+  //AliTRDdigitsManager* fDigMan;        //! digits manager
 
   // Histograms
-  TH2F *fhArmenteros;                 //! 2D V0 QA Hist
-  TH1F *fhEventCuts;                  //! statistics of event cuts
-  TH1F *fhPtTag;                      //! pT of PID-tagged tracks
-  TH1F *fhPtGood;                     //! pT spectrum after quality cuts
-  TH1F *fhPtAcc;                      //! pT spectrum of accepted tracks
+  THnSparse*  fhAcc;                        //! summary hist of all acc tracks
+  TH1F*       fhEventCuts;                  //! statistics of event cuts
+  TH1F*       fhPtTag;                      //! pT of PID-tagged tracks
+  TH1F*       fhPtGood;                     //! pT spectrum after quality cuts
+  TH1F*       fhPtAcc;                      //! pT spectrum of accepted track
+  TH1F*       fhCent;                       //! Centrality of event
+  TH1F*       fhCentAcc;                    //! Accepted events based on centrality
+  //-------------------------------------------------------------------------
 
   //TH1F *fhPt[fgkNSpecies];            //! pT spectrum for different species
 

--- a/PWGPP/TRD/AliTRDdigitsTask.cxx
+++ b/PWGPP/TRD/AliTRDdigitsTask.cxx
@@ -36,13 +36,16 @@ using namespace std;
 ClassImp(AliTRDdigitsTask)
 
 //________________________________________________________________________
-AliTRDdigitsTask::AliTRDdigitsTask(const char *name) 
+AliTRDdigitsTask::AliTRDdigitsTask(const char *name)
 : AliAnalysisTaskSE(name),
-  fESD(0), fOutputList(0),
-  fV0cuts(0), fV0tags(0), fV0electrons(0), fV0pions(0),
+  fESDevent(0),
+  fOutputList(0),
+  fhArmenteros(0),
+  fDigMan(0),
+  fV0cuts(0),
   fDigitsInputFileName("TRD.Digits.root"), fDigitsOutputFileName(""),
   fDigitsInputFile(0), fDigitsOutputFile(0),
-  fDigMan(0),fGeo(0), fEventNoInFile(-2), fDigitsLoadedFlag(kFALSE)
+  fGeo(0), fEventNoInFile(-2), fDigitsLoadedFlag(kFALSE)
 {
   // Constructor
 
@@ -56,7 +59,7 @@ AliTRDdigitsTask::AliTRDdigitsTask(const char *name)
   // create the digits manager
   fDigMan = new AliTRDdigitsManager;
   fDigMan->CreateArrays();
-  
+
   // create a TRD geometry, needed for matching digits to tracks
   fGeo = new AliTRDgeometry;
   if (! fGeo) {
@@ -127,15 +130,32 @@ void AliTRDdigitsTask::UserCreateOutputObjects()
 
   // At this point, additional histograms can be created, maybe via a
   // virtual function.
+  CreateV0Plots();
 
-  
   PostData(1, fOutputList);
+}
+
+//________________________________________________________________________
+void AliTRDdigitsTask::CreateV0Plots()
+{
+
+  // V0 QA histograms
+  fhArmenteros  = new TH2F( "Armenteros","Armenteros plot",
+                            200,-1.,1.,200,0.,0.4);
+
+  // add everything to the list
+  if (fOutputList) {
+    fOutputList->Add(fhArmenteros);
+  }
+
 }
 
 
 
+
+
 //________________________________________________________________________
-Bool_t AliTRDdigitsTask::NextEvent(Bool_t preload) 
+Bool_t AliTRDdigitsTask::NextEvent(Bool_t preload)
 {
   fEventNoInFile++;
   fDigitsLoadedFlag = kFALSE;
@@ -148,7 +168,7 @@ Bool_t AliTRDdigitsTask::NextEvent(Bool_t preload)
 }
 
 //________________________________________________________________________
-void AliTRDdigitsTask::UserExec(Option_t *) 
+void AliTRDdigitsTask::UserExec(Option_t *)
 {
 
   // -----------------------------------------------------------------
@@ -161,19 +181,19 @@ void AliTRDdigitsTask::UserExec(Option_t *)
 
 
   if ( ! ReadDigits() ) return;
-  
+
   // -----------------------------------------------------------------
   // -----------------------------------------------------------------
   // The following is a generic example how to access digits and match
   // them to tracks found in the ESD
 
 
-  
+
   // -----------------------------------------------------------------
   // prepare event data structures
-  AliESDEvent* fESD = dynamic_cast<AliESDEvent*>(InputEvent());
-  if (!fESD) {
-    printf("ERROR: fESD not available\n");
+  AliESDEvent* fESDevent = dynamic_cast<AliESDEvent*>(InputEvent());
+  if (!fESDevent) {
+    printf("ERROR: fESDevent not available\n");
     return;
   }
 }
@@ -182,36 +202,36 @@ void AliTRDdigitsTask::UserExec(Option_t *)
 void AliTRDdigitsTask::AnalyseEvent()
 {
 
-  
-  printf("There are %d tracks in this event\n", fESD->GetNumberOfTracks());
 
-  if (fESD->GetNumberOfTracks() == 0) {
+  printf("There are %d tracks in this event\n", fESDevent->GetNumberOfTracks());
+
+  if (fESDevent->GetNumberOfTracks() == 0) {
     // skip empty event
     return;
   }
 
   // make digits available
   ReadDigits();
-   
-  
-  
+
+
+
   // -----------------------------------------------------------------
   // Track loop to fill a pT spectrum
-  for (Int_t iTracks = 0; iTracks < fESD->GetNumberOfTracks(); iTracks++) {
-    
+  for (Int_t iTracks = 0; iTracks < fESDevent->GetNumberOfTracks(); iTracks++) {
+
     // ---------------------------------------------------------------
     // gather track information
 
     // we always want the ESD track
-    AliESDtrack* track = fESD->GetTrack(iTracks);
+    AliESDtrack* track = fESDevent->GetTrack(iTracks);
     if (!track) {
       printf("ERROR: Could not receive track %d\n", iTracks);
       continue;
     }
 
     // the friend and TRD tracks are only necessary if we want to
-    // match via tracklets 
-    //AliESDfriendTrack* friendtrack = fESDfriend->GetTrack(iTracks);
+    // match via tracklets
+    //AliESDfriendTrack* friendtrack = fESDeventfriend->GetTrack(iTracks);
     // I do not handle missing friend tracks - I keep checking the
     // pointer when I access it
 
@@ -232,7 +252,7 @@ void AliTRDdigitsTask::AnalyseEvent()
       AliWarning(Form("Track %d has no OuterParam", iTracks));
       continue;
     }
-      
+
     // print some info about the track
     cout << " ====== TRACK " << iTracks
 	 << "   pT = " << track->Pt() << " GeV";
@@ -255,51 +275,51 @@ void AliTRDdigitsTask::AnalyseEvent()
 	det = det1;
 	row = row1;
 	col = col1;
-	
+
 	cout << "    tracklet: "
 	     << det1 << ":" << row1 << ":" << col1 << "   "
 	     << x << " / "<< y << " / "<< z
 	     << endl;
-		
+
       }
 
 
       Int_t det2,row2,col2;
       if ( FindDigits(track->GetOuterParam(),
-		      fESD->GetMagneticField(), ly,
+		      fESDevent->GetMagneticField(), ly,
 		      &det2,&row2,&col2) ) {
 
 	if (det>=0 && det!=det2) {
-	  AliWarning("DET mismatch between tracklet and extrapolation: " 
+	  AliWarning("DET mismatch between tracklet and extrapolation: "
 		     + TString(Form("%d != %d", det, det2)));
 
 	  if (row>=0 && row!=row2) {
-	    AliWarning("ROW mismatch between tracklet and extrapolation: " 
+	    AliWarning("ROW mismatch between tracklet and extrapolation: "
 		       + TString(Form("%d != %d", row, row2)));
 	  }
 	}
-	
+
 	det = det2;
 	row = row2;
 	col = col2;
-	
+
 	cout << "    outparam: "
 	     << det2 << ":" << row2 << ":" << col2 << "   "
 	     << track->GetOuterParam()->GetX() << " / "
 	     << track->GetOuterParam()->GetY() << " / "
-	     << track->GetOuterParam()->GetZ() 
+	     << track->GetOuterParam()->GetZ()
 	     << endl;
       }
-      
+
 
       if (det>=0) {
 	cout << "Found tracklet at "
 	     << det << ":" << row << ":" << col << endl;
-	
+
 	int np = 5;
 	if ( col-np < 0 || col+np >= 144 )
 	  continue;
-	
+
 	for (int c = col-np; c<=col+np;c++) {
 	  cout << "  " << setw(3) << c << " ";
 	  for (int t=0; t<fDigMan->GetDigits(det)->GetNtime(); t++) {
@@ -315,20 +335,20 @@ void AliTRDdigitsTask::AnalyseEvent()
 
   }
 
- 
+
   for (int det=0; det<540; det++) {
 
     if (!fDigMan->GetDigits(det)) {
       AliWarning(Form("No digits found for detector %d", det));
       continue;
     }
-    
+
     AliTRDpadPlane* padplane = fGeo->GetPadPlane(det);
     if (!padplane) {
       AliError(Form("AliTRDpadPlane for detector %d not found",det));
       continue;
     }
-    
+
 //    for (int row=0; row < padplane->GetNrows(); row++) {
 //      for (int col=0; col < padplane->GetNcols(); col++) {
 //	for (int tb=0; tb < fDigMan->GetDigits(det)->GetNtime(); tb++) {
@@ -338,14 +358,14 @@ void AliTRDdigitsTask::AnalyseEvent()
 //    }
 
   }
-   
+
 //  PostData(1, fOutputList);
-}      
+}
 
 
-  
+
 //________________________________________________________________________
-AliTRDtrackV1* AliTRDdigitsTask::FindTRDtrackV1(AliESDfriendTrack* friendtrack) 
+AliTRDtrackV1* AliTRDdigitsTask::FindTRDtrackV1(AliESDfriendTrack* friendtrack)
 {
   if (!friendtrack) {
     //AliWarning("ERROR: Could not receive friend track");
@@ -374,7 +394,7 @@ Int_t AliTRDdigitsTask::FindDigits(const AliExternalTrackParam* paramp,
 {
 
   if ( ! paramp ) return kFALSE;
-  
+
   // create a copy of the track params that we can propagate around
   AliExternalTrackParam par = *paramp;
 
@@ -386,13 +406,13 @@ Int_t AliTRDdigitsTask::FindDigits(const AliExternalTrackParam* paramp,
     AliWarning("Failed to propagate track param");
     return kFALSE;
   }
-      
-  
+
+
   Int_t st  = fGeo->GetStack(par.GetZ(),layer);
   if (st<0) {
     return kFALSE;
   }
-  
+
   *det = 30*sector + 6*st + layer;
   AliTRDpadPlane* padplane = fGeo->GetPadPlane(layer,st);
   *row = padplane->GetPadRowNumber(par.GetZ());
@@ -400,7 +420,7 @@ Int_t AliTRDdigitsTask::FindDigits(const AliExternalTrackParam* paramp,
 
   if (*row == -1) return kFALSE;
   if (*col == -1) return kFALSE;
-  
+
   return kTRUE;
 }
 
@@ -413,17 +433,17 @@ Int_t AliTRDdigitsTask::FindDigitsTrkl(const AliTRDtrackV1* trdTrack,
 {
 
   if ( ! trdTrack ) return kFALSE;
-  
+
   // loop over tracklets
   for(Int_t itr = 0; itr < 6; ++itr) {
-    
+
     AliTRDseedV1* tracklet = 0;
-    
+
     if(!(tracklet = trdTrack->GetTracklet(itr)))
       continue;
     if(!tracklet->IsOK())
       continue;
-    
+
     if ( tracklet->GetDetector()%6 == layer ) {
 
       AliTRDpadPlane *padplane = fGeo->GetPadPlane(tracklet->GetDetector());
@@ -441,9 +461,9 @@ Int_t AliTRDdigitsTask::FindDigitsTrkl(const AliTRDtrackV1* trdTrack,
   }
 
   return kFALSE; // no tracklet found
-  
-}  
-    
+
+}
+
 //    // AliTrackPoint tp;
 //    // for (int ip=0; ip<array->GetNPoints(); ip++) {
 //    //   array->GetPoint(tp,ip);
@@ -453,14 +473,14 @@ Int_t AliTRDdigitsTask::FindDigitsTrkl(const AliTRDtrackV1* trdTrack,
 //    // 	   << "   r = " << TMath::Hypot(tp.GetX(),tp.GetY())
 //    // 	   << endl;
 //    // }
-//    
-//
-//    
 //
 //
-//    
+//
+//
+//
+//
 //    fHistPt->Fill(track->Pt());
-//  } //track loop 
+//  } //track loop
 //
 //  delete geo;
 //
@@ -469,52 +489,24 @@ Int_t AliTRDdigitsTask::FindDigitsTrkl(const AliTRDtrackV1* trdTrack,
 //______________________________________________________________________________
 void AliTRDdigitsTask::FillV0PIDlist(){
 
-  // no need to run if the V0 cuts are not set
-  if (!fV0cuts) {
-    cout << "FillV0PIDlist: skip event - no V0 cuts" << endl;
-    return;
-  }
-  
-  // basic sanity check...
-  if (!fESD) {
-    cout << "FillV0PIDlist: skip event - no ESD event" << endl;
-    return;
-  }
+  //
+  // Fill the PID object arrays holding the pointers to identified particle tracks
+  //
 
-  const Int_t numTracks = fESD->GetNumberOfTracks();
+  // Dynamic cast to ESD events (DO NOTHING for AOD events)
+  AliESDEvent *event = dynamic_cast<AliESDEvent *>(InputEvent());
+  if ( !event )  return;
 
-  if (numTracks < 0) {
-    AliFatal("negative number of tracks?!?");
-  }
-  
-  // Ensure there is sufficient memory for the V0 tags
-  if (!fV0tags) {
-    //cout << "FillV0PIDlist: create fV0tags" << endl;
-    fV0tags = new Int_t[numTracks];
-  } else if ( sizeof(fV0tags)/sizeof(Int_t) < numTracks ) {
-    //cout << "FillV0PIDlist: re-create fV0tags" << endl;
-    delete fV0tags;
-    fV0tags = new Int_t[numTracks];
-  } else {
-    // there is more than enough space to store the tags, no need to
-    // do anything.
-  }
 
-  // Reset the V0 tags and reference particle arrays
-  for (Int_t i = 0; i < numTracks; i++) {
-    fV0tags[i] = 0;
-  }
-
-  fV0electrons->Clear();
-  fV0pions->Clear();
-
-  
   // V0 selection
+  // set event
+  fV0cuts->SetEvent(event);
+
+
   // loop over V0 particles
-  fV0cuts->SetEvent(fESD);
-  for(Int_t iv0=0; iv0<fESD->GetNumberOfV0s();iv0++){
-    
-    AliESDv0 *v0 = (AliESDv0 *) fESD->GetV0(iv0);
+  for(Int_t iv0=0; iv0<event->GetNumberOfV0s();iv0++){
+
+    AliESDv0 *v0 = (AliESDv0 *) event->GetV0(iv0);
 
     if(!v0) continue;
     if(v0->GetOnFlyStatus()) continue;
@@ -524,53 +516,33 @@ void AliTRDdigitsTask::FillV0PIDlist(){
     Int_t pdgV0, pdgP, pdgN;
     foundV0 = fV0cuts->ProcessV0(v0, pdgV0, pdgP, pdgN);
     if(!foundV0) continue;
-
-    Int_t iTrackP = v0->GetPindex();  // positive track inded
+    Int_t iTrackP = v0->GetPindex();  // positive track
     Int_t iTrackN = v0->GetNindex();  // negative track
 
-    if (fV0tags[iTrackP]) {
-      printf("Warning: particle %d tagged more than once\n", iTrackP);
-    }
+    // v0 Armenteros plot (QA)
+    Float_t armVar[2] = {0.0,0.0};
+    fV0cuts->Armenteros(v0, armVar);
+    // if ( !(TMath::Power(armVar[0]/0.95,2)+TMath::Power(armVar[1]/0.05,2) < 1) ) continue;
 
-    if (fV0tags[iTrackN]) {
-      printf("Warning: particle %d tagged more than once\n", iTrackN);
-    }
+    if(fhArmenteros) fhArmenteros->Fill(armVar[0],armVar[1]);
 
-    
-    // fill the Object arrays
-    // positive particles
-    if( pdgP == -11){
-      //DigitsDictionary(iTrackP, iv0, pdgP);
-      fV0electrons->Add(fESD->GetTrack(iTrackP));
-      fV0tags[iTrackP] = pdgP;
-    }
-    else if( pdgP == 211){
-      //DigitsDictionary(iTrackP, iv0, pdgP);
-      fV0pions->Add(fESD->GetTrack(iTrackP));
-      fV0tags[iTrackP] = pdgP;
-    }
+    // fill the tags
 
+    if( pdgP ==   -11 ) { fPidTags[iTrackP] = kPidV0Electron; }
+    if( pdgN ==    11 ) { fPidTags[iTrackN] = kPidV0Electron; }
 
-    // negative particles
-    if( pdgN == 11){
-      //DigitsDictionary(iTrackN, -iv0, pdgN);
-      fV0electrons->Add(fESD->GetTrack(iTrackN));
-      fV0tags[iTrackN] = pdgN;
-    }
-    else if( pdgN == -211){
-      //DigitsDictionary(iTrackN, -iv0, pdgN);
-      fV0pions->Add(fESD->GetTrack(iTrackN));
-      fV0tags[iTrackN] = pdgN;
-    }
+    if( pdgP ==   211 ) { fPidTags[iTrackP] = kPidV0Pion; }
+    if( pdgN ==  -211 ) { fPidTags[iTrackN] = kPidV0Pion; }
+
+    if( pdgP ==  2212 ) { fPidTags[iTrackP] = kPidV0Proton; }
+    if( pdgN == -2212 ) { fPidTags[iTrackN] = kPidV0Proton; }
 
   }
-
 }
 
 
-
 //________________________________________________________________________
-void AliTRDdigitsTask::Terminate(Option_t *) 
+void AliTRDdigitsTask::Terminate(Option_t *)
 {
   // Draw result to the screen
   // Called once at the end of the query
@@ -580,13 +552,13 @@ void AliTRDdigitsTask::Terminate(Option_t *)
 //    printf("ERROR: Output list not available\n");
 //    return;
 //  }
-//  
+//
 //  fHistPt = dynamic_cast<TH1F*> (fOutputList->At(0));
 //  if (!fHistPt) {
 //    printf("ERROR: fHistPt not available\n");
 //    return;
 //  }
-//   
+//
   //TCanvas *c1 = new TCanvas("AliTRDdigitsTask","Pt",10,10,510,510);
   //c1->cd(1)->SetLogy();
   //fHistPt->DrawCopy("E");
@@ -599,12 +571,12 @@ Bool_t AliTRDdigitsTask::ReadDigits()
 
   // don't do anything if the digits have already been loaded
   if (fDigitsLoadedFlag) return kTRUE;
-  
+
   if (!fDigMan) {
     AliError("no digits manager");
     return kFALSE;
   }
-  
+
   // reset digit arrays
   for (Int_t det=0; det<540; det++) {
     fDigMan->ClearArrays(det);
@@ -617,7 +589,7 @@ Bool_t AliTRDdigitsTask::ReadDigits()
     return kFALSE;
   }
 
-  
+
   // read digits from file
   TTree* tr = (TTree*)fDigitsInputFile->Get(Form("Event%d/TreeD",
                                                  fEventNoInFile));
@@ -649,7 +621,7 @@ Bool_t AliTRDdigitsTask::WriteDigits()
     AliError("digits output file not available");
     return kFALSE;
   }
-  
+
   // compress digits for storage
   for (Int_t det=0; det<540; det++) {
     fDigMan->GetDigits(det)->Expand();
@@ -671,4 +643,3 @@ Bool_t AliTRDdigitsTask::WriteDigits()
 
   return kTRUE;
 }
-

--- a/PWGPP/TRD/AliTRDdigitsTask.h
+++ b/PWGPP/TRD/AliTRDdigitsTask.h
@@ -33,9 +33,15 @@
 class AliTRDdigitsManager;
 //class AliESDv0KineCuts;
 class AliESDEvent;
+class AliESDfriendTrack;
+class AliExternalTrackParam;
+class AliTRDtrackV1;
+class AliTRDgeometry;
 
 #include "AliESDv0KineCuts.h"
 #include "AliAnalysisTaskSE.h"
+
+#include <vector>
 
 class AliTRDdigitsTask : public AliAnalysisTaskSE {
 public:
@@ -58,6 +64,13 @@ public:
   void SetV0KineCuts(AliESDv0KineCuts *c) { fV0cuts = c; }
   AliESDv0KineCuts* GetV0KineCuts() {return fV0cuts;}
 
+  typedef enum {
+    kPidUndef = 0,
+    kPidError = 1,
+    kPidV0Electron = 2,
+    kPidV0Pion = 3,
+    kPidV0Proton = 4
+  } EPID_t;
 
 protected:
 
@@ -70,8 +83,16 @@ protected:
   // Interface for analysis functionality
   virtual void AnalyseEvent();
 
-  AliESDEvent *fESD;          //! ESD event object
+  AliESDEvent *fESDevent;     //! ESD event object
   TList       *fOutputList;   //! Output list
+
+  //--------------------------------------------------------------------
+  // Some histograms of general interest, along with functions to create
+  // them
+
+  void CreateV0Plots();
+  TH2F*       fhArmenteros;                 //! 2D V0 QA Hist
+
 
   //--------------------------------------------------------------------
   // TRD digits I/O
@@ -80,15 +101,11 @@ protected:
 
   AliTRDdigitsManager* fDigMan;     //! digits manager
 
-
   //--------------------------------------------------------------------
   // e,pi reference sample generation - to be moved to AliTRDdigitsTask
   AliESDv0KineCuts *fV0cuts; //  V0 cuts
-  Int_t     *fV0tags;        //! tags for identified particles from V0 decays
-  TObjArray *fV0electrons;   //! identified electrons from photon conv
-  TObjArray *fV0pions;       //! identified pions from K0,Lambda decays
-  //TObjArray *fV0protons;         //! identified protons from Lambda decays
 
+  std::vector<EPID_t> fPidTags;  // tags for identified particles
   void FillV0PIDlist();
 
 
@@ -103,6 +120,8 @@ protected:
   Int_t FindDigits(const AliExternalTrackParam* param,
 		   Float_t bfield, Int_t layer,
 		   Int_t* det, Int_t* row, Int_t* col);
+
+
 
 private:
 

--- a/PWGPP/TRD/macros/AddTRDdigitsFilter.C
+++ b/PWGPP/TRD/macros/AddTRDdigitsFilter.C
@@ -15,7 +15,7 @@
 #include <AliTRDdigitsFilter.h>
 #endif
 
-AliAnalysisTask  *AddTRDdigitsFilter(Int_t runNumber)
+AliAnalysisTask  *AddTRDdigitsFilter(TString cfg)
 {
   //gSystem->Load("libTRDrec");
   // pointer to the analysis manager
@@ -36,26 +36,31 @@ AliAnalysisTask  *AddTRDdigitsFilter(Int_t runNumber)
   /////////////////////////
   AliTRDdigitsFilter *filterTask = new AliTRDdigitsFilter();
 
-  if (runNumber >= 295274 && runNumber <= 297624) {
+  //if (runNumber >= 295274 && runNumber <= 29762) {
+  if ( cfg == "PbPb-2018" ) {
 
     // LHC18q,r  -  Pb-Pb 2018
 
-    filterTask->GetV0cuts()->SetMode(AliESDv0KineCuts::kPurity,
+    filterTask->GetV0KineCuts()->SetMode(AliESDv0KineCuts::kPurity,
                                      AliESDv0KineCuts::kPbPb);
 
-    filterTask->AcceptParticles("v0elec", AliTRDdigitsFilter::kPidV0Electron,
-                                1.5, 99999999., 1.0);
+    filterTask->AcceptTracks("v0elec", AliTRDdigitsFilter::kPidV0Electron,
+                                2.0, 99999999., 1.0);
 
-    filterTask->AcceptParticles("v0pilo", AliTRDdigitsFilter::kPidV0Pion,
-                                2.0, 2.5, 0.5);
+    filterTask->AcceptTracks("v0pilo", AliTRDdigitsFilter::kPidV0Pion,
+                                2.0, 2.5, 0.3);
 
-    filterTask->AcceptParticles("v0pihi", AliTRDdigitsFilter::kPidV0Pion,
+    filterTask->AcceptTracks("v0pihi", AliTRDdigitsFilter::kPidV0Pion,
                                 2.5, 99999999., 1.0);
 
-    filterTask->AcceptParticles("v0prot", AliTRDdigitsFilter::kPidV0Proton,
+    filterTask->AcceptTracks("v0prot", AliTRDdigitsFilter::kPidV0Proton,
                                 2.0, 99999999., 1.0);
+
+    filterTask->AcceptEvents("cent", 0.0, 2.0, 1.0e-2);
   }
 
+  cout << "filter task set up" << endl;
+  filterTask->PrintSettings();
 
   mgr->AddTask(filterTask);
 


### PR DESCRIPTION
The classes to filter a small subset of the TRD digits during 
reconstruction for later studies of electron PID and high-pT tracks have 
been revised in preparation for the Pb-Pb production.

The AliTRDdigitsFilter class now inherits from the AliTRDdigitsTask 
class. The selection criteria were made more flexible, and selecting a 
small section of events based on centrality is supported.

The selection criteria still need some tuning.