### PR TITLE
PWGUD/UPC: Introducing fV0CDecision.

### DIFF
--- a/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforward.cxx
@@ -2116,6 +2116,13 @@ void AliAnalysisTaskUPCforward::UserExec(Option_t *)
        PostData(1, fOutputList);
        return;
   }
+  /* - Empty V0C decision
+   * - or at least in beam timing.
+   */
+  if( !(fV0CDecision == 0 || fV0CDecision == 1) ) {
+       PostData(1, fOutputList);
+       return;
+  }
   /* - 0 tracklets in SPD
      - Is it like this?? Not too sure what fTracklets was!
    */


### PR DESCRIPTION
Introducing fV0CDecision for empty decision and beam timing.