### PR TITLE
Add flags to apply physics selection and event downsampling

### DIFF
--- a/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
+++ b/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
@@ -1273,7 +1273,7 @@ void AliAnalysisTaskSEHFTreeCreator::UserExec(Option_t */*option*/)
 
   Bool_t isEvRejCent  = fEvSelectionCuts->IsEventRejectedDueToCentrality();
   
-  if(!isEvSel && isEvRejCent || (fApplyPhysicsSelOnline && isEvRejPhysSel)){
+  if(!isEvSel && (isEvRejCent || (fApplyPhysicsSelOnline && isEvRejPhysSel))){
     return; //cut only centrality and physics selection if enabled, else tag only
   }
   if(isEvSel) fNentries->Fill(4);

--- a/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
+++ b/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
@@ -45,6 +45,7 @@
 #include <TH2F.h>
 #include <TDatabasePDG.h>
 #include <THnSparse.h>
+#include <TRandom3.h>
 #include <AliAnalysisDataSlot.h>
 #include <AliAnalysisDataContainer.h>
 #include "TChain.h"
@@ -276,7 +277,11 @@ fDoJetSubstructure(false),
 fEnableNsigmaTPCDataCorr(false),
 fSystemForNsigmaTPCDataCorr(AliAODPidHF::kNone),
 fCorrNtrVtx(false),
-fCorrV0MVtx(false)
+fCorrV0MVtx(false),
+fApplyPhysicsSelOnline(false),
+fEnableEventDownsampling(false),
+fFracToKeepEventDownsampling(1.1),
+fSeedEventDownsampling(0)
 {
   fParticleCollArray.SetOwner(kTRUE);
   fJetCollArray.SetOwner(kTRUE);
@@ -1066,6 +1071,12 @@ void AliAnalysisTaskSEHFTreeCreator::UserExec(Option_t */*option*/)
 {
   /// Execute analysis for current event:
   
+  if(fEnableEventDownsampling) {
+        gRandom->SetSeed(fSeedEventDownsampling);
+        if(gRandom->Rndm() > fFracToKeepEventDownsampling)
+            return;
+  }
+
   AliAODEvent *aod = dynamic_cast<AliAODEvent*> (InputEvent());
   
   fNentries->Fill(0); // all events
@@ -1230,8 +1241,9 @@ void AliAnalysisTaskSEHFTreeCreator::UserExec(Option_t */*option*/)
   
   fCentrality = fEvSelectionCuts->GetCentrality(aod);
   if(fCentrality<0) fCentrality=-1.;
+  bool isEvRejPhysSel = fEvSelectionCuts->IsEventRejectedDuePhysicsSelection();
   //normalisation counter
-  if(!fEvSelectionCuts->IsEventRejectedDuePhysicsSelection()){
+  if(!isEvRejPhysSel){
     if(isEvSel){
       //selected events with primary vertex
       fHistoNormCounter->Fill(0.,fCentrality);
@@ -1258,11 +1270,11 @@ void AliAnalysisTaskSEHFTreeCreator::UserExec(Option_t */*option*/)
       fHistoNormCounter->Fill(3.,fCentrality);
     }
   }
-  
+
   Bool_t isEvRejCent  = fEvSelectionCuts->IsEventRejectedDueToCentrality();
   
-  if(!isEvSel && isEvRejCent){
-    return; //cut only centrality, else tag only
+  if(!isEvSel && isEvRejCent || (fApplyPhysicsSelOnline && isEvRejPhysSel)){
+    return; //cut only centrality and physics selection if enabled, else tag only
   }
   if(isEvSel) fNentries->Fill(4);
   // AOD primary vertex

--- a/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.h
+++ b/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.h
@@ -184,7 +184,14 @@ public:
         fEnableNsigmaTPCDataCorr=true; 
         fSystemForNsigmaTPCDataCorr=syst; 
     }
-  
+
+    void ApplyPhysicsSelectionOnline(bool apply=true) { fApplyPhysicsSelOnline = apply; }
+
+    void EnableEventDownsampling(float fractokeep) {
+        fEnableEventDownsampling = true;
+        fFracToKeepEventDownsampling = fractokeep;
+    }
+
     // Particles (tracks or MC particles)
     //-----------------------------------------------------------------------------------------------
     void                        SetFillParticleTree(Bool_t b) {fFillParticleTree = b;}
@@ -437,8 +444,13 @@ private:
     bool fCorrNtrVtx;
     bool fCorrV0MVtx;
 
+    bool fApplyPhysicsSelOnline;                                   /// flag to apply physics selection in the task
+    bool fEnableEventDownsampling;                                 /// flag to apply event downsampling
+    float fFracToKeepEventDownsampling;                            /// fraction of events to be kept by event downsampling
+    unsigned long fSeedEventDownsampling;                          /// seed for event downsampling
+
     /// \cond CLASSIMP
-    ClassDef(AliAnalysisTaskSEHFTreeCreator,19);
+    ClassDef(AliAnalysisTaskSEHFTreeCreator,20);
     /// \endcond
 };
 

--- a/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.h
+++ b/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.h
@@ -187,9 +187,10 @@ public:
 
     void ApplyPhysicsSelectionOnline(bool apply=true) { fApplyPhysicsSelOnline = apply; }
 
-    void EnableEventDownsampling(float fractokeep) {
+    void EnableEventDownsampling(float fractokeep, unsigned long seed) {
         fEnableEventDownsampling = true;
         fFracToKeepEventDownsampling = fractokeep;
+        fSeedEventDownsampling = seed;
     }
 
     // Particles (tracks or MC particles)


### PR DESCRIPTION
1) add flag to apply physics selection at the task level to avoid the storage of unwanted events (false by default, so nothing changed unless enabled explicitly)

2) add flag to enable random event downsampling (false by default, so nothing changed unless enabled explicitly). Needed in case of a necessity of a homogeneous fraction of the data sample