### PR TITLE
Implement jet matching in user task

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHPerformance.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHPerformance.cxx
@@ -49,6 +49,7 @@ AliAnalysisTaskEmcalJetHPerformance::AliAnalysisTaskEmcalJetHPerformance():
   fEmbeddingQA(),
   fCreateQAHists(false),
   fCreateCellQAHists(false),
+  fPerformJetMatching(false),
   fCreateResponseMatrix(false),
   fEmbeddedCellsName("emcalCells"),
   fPreviousEventTrigger(0),
@@ -73,6 +74,7 @@ AliAnalysisTaskEmcalJetHPerformance::AliAnalysisTaskEmcalJetHPerformance(const c
   fEmbeddingQA(),
   fCreateQAHists(false),
   fCreateCellQAHists(false),
+  fPerformJetMatching(false),
   fCreateResponseMatrix(false),
   fEmbeddedCellsName("emcalCells"),
   fPreviousEventTrigger(0),
@@ -98,6 +100,7 @@ AliAnalysisTaskEmcalJetHPerformance::AliAnalysisTaskEmcalJetHPerformance(const A
   //fEmbeddingQA(other.fEmbeddingQA), // Cannot use because the THistManager (which is in the class) copy constructor is private.
   fCreateQAHists(other.fCreateQAHists),
   fCreateCellQAHists(other.fCreateCellQAHists),
+  fPerformJetMatching(other.fPerformJetMatching),
   fCreateResponseMatrix(other.fCreateResponseMatrix),
   fEmbeddedCellsName(other.fEmbeddedCellsName),
   fPreviousEventTrigger(other.fPreviousEventTrigger),
@@ -161,6 +164,7 @@ void AliAnalysisTaskEmcalJetHPerformance::RetrieveAndSetTaskPropertiesFromYAMLCo
   // These are disabled by default.
   fYAMLConfig.GetProperty({baseName, "QAHists"}, fCreateQAHists, false);
   fYAMLConfig.GetProperty({baseName, "CellQAHists"}, fCreateCellQAHists, false);
+  fYAMLConfig.GetProperty({baseName, "jetMatching"}, fPerformJetMatching, false);
   fYAMLConfig.GetProperty({baseName, "responseMatrix"}, fCreateResponseMatrix, false);
 
   // Event cuts
@@ -194,6 +198,10 @@ void AliAnalysisTaskEmcalJetHPerformance::RetrieveAndSetTaskPropertiesFromYAMLCo
   if (res) {
     fEfficiencyPeriodIdentifier = AliAnalysisTaskEmcalJetHUtils::fgkEfficiencyPeriodIdentifier.at(tempStr);
   }
+
+  // Jet matching
+  baseName = "jetMatching";
+  fYAMLConfig.GetProperty({baseName, "maxMatchingDistance"}, fMaxJetMatchingDistance, false);
 
   // Response matrix properties
   baseName = "responseMatrix";
@@ -419,6 +427,9 @@ void AliAnalysisTaskEmcalJetHPerformance::UserCreateOutputObjects()
   if (fCreateQAHists) {
     SetupQAHists();
   }
+  if (fPerformJetMatching) {
+    SetupJetMatchingQA();
+  }
   if (fCreateResponseMatrix) {
     SetupResponseMatrixHists();
   }
@@ -582,6 +593,96 @@ void AliAnalysisTaskEmcalJetHPerformance::SetupQAHists()
 }
 
 /**
+ * Setup and allocate histograms related to jet matching.
+ */
+void AliAnalysisTaskEmcalJetHPerformance::SetupJetMatchingQA()
+{
+  // Setup
+  const int nBinsPt        = 40;
+  const int nBinsDPhi      = 72;
+  const int nBinsDEta      = 100;
+  const int nBinsDR        = 50;
+  const int nBinsFraction  = 101;
+
+  const double minPt       = -50.;
+  const double maxPt       = 150.;
+  const double minDPhi     = -0.5;
+  const double maxDPhi     =  0.5;
+  const double minDEta     = -0.5;
+  const double maxDEta     =  0.5;
+  const double minDR       =  0.;
+  const double maxDR       =  0.5;
+  const double minFraction =  -0.005;
+  const double maxFraction =  1.005;
+
+  // Create the histograms
+  // "s" ensures that Sumw2() is called
+  std::string name = "";
+  std::string title = "";
+  std::vector<std::string> matchingTypes = {"hybridToDet", "detToPart"};
+  for (auto matchingType : matchingTypes)
+  {
+    for (unsigned int centBin = 0; centBin < fNcentBins; centBin++)
+    {
+      // Jet 1 pt vs delta eta vs delta phi
+      name = "jetMatching/%s/fh3PtJet1VsDeltaEtaDeltaPhi_%d";
+      title = "fh3PtJet1VsDeltaEtaDeltaPhi_%d;#it{p}_{T,jet1};#it{#Delta#eta};#it{#Delta#varphi}";
+      fHistManager.CreateTH3(TString::Format(name.c_str(), matchingType.c_str(), centBin),
+                  TString::Format(title.c_str(), centBin), nBinsPt, minPt, maxPt, nBinsDEta,
+                  minDEta, maxDEta, nBinsDPhi, minDPhi, maxDPhi, "s");
+
+      // Jet pt 1 vs delta R
+      name = "jetMatching/%s/fh2PtJet1VsDeltaR_%d";
+      title = "fh2PtJet1VsDeltaR_%d;#it{p}_{T,jet1};#it{#Delta R}";
+      fHistManager.CreateTH2(TString::Format(name.c_str(), matchingType.c_str(), centBin),
+                  TString::Format(title.c_str(), centBin), nBinsPt, minPt, maxPt, nBinsDR, minDR,
+                  maxDR, "s");
+
+      // Jet pt 2 vs shared momentum fraction
+      name = "jetMatching/%s/fh2PtJet2VsFraction_%d";
+      title = "fh2PtJet2VsFraction_%d;#it{p}_{T,jet2};#it{f}_{shared}";
+      fHistManager.CreateTH2(TString::Format(name.c_str(), matchingType.c_str(), centBin),
+                  TString::Format(title.c_str(), centBin), nBinsPt, minPt, maxPt, nBinsFraction,
+                  minFraction, maxFraction, "s");
+
+      // Jet pt 1 vs lead pt before checking if the jet has a matched jet.
+      name = "jetMatching/%s/fh2PtJet1VsLeadPtAllSel_%d";
+      title = "fh2PtJet1VsLeadPtAllSel_%d;#it{p}_{T,jet1};#it{p}_{T,lead trk}";
+      fHistManager.CreateTH2(TString::Format(name.c_str(), matchingType.c_str(), centBin),
+                  TString::Format(title.c_str(), centBin), nBinsPt, minPt, maxPt, 20, 0., 20.,
+                  "s");
+
+      // Jet pt 1 vs lead pt after checking if the jet has a matched jet.
+      name = "jetMatching/%s/fh2PtJet1VsLeadPtTagged_%d";
+      title = "fh2PtJet1VsLeadPtTagged_%d;#it{p}_{T,jet1};#it{p}_{T,lead trk}";
+      fHistManager.CreateTH2(TString::Format(name.c_str(), matchingType.c_str(), centBin),
+                  TString::Format(title.c_str(), centBin), nBinsPt, minPt, maxPt, 20, 0., 20.,
+                  "s");
+
+      // Jet pt 1 vs jet pt 2.
+      name = "jetMatching/%s/fh2PtJet1VsPtJet2_%d";
+      title = "fh2PtJet1VsPtJet2_%d;#it{p}_{T,jet1};#it{p}_{T,jet2}";
+      fHistManager.CreateTH2(TString::Format(name.c_str(), matchingType.c_str(), centBin),
+                  TString::Format(title.c_str(), centBin), nBinsPt, minPt, maxPt, nBinsPt, minPt,
+                  maxPt, "s");
+
+      // Jet pt2 residual (aka. the jet energy scale).
+      name = "jetMatching/%s/fh2PtJet2VsRelPt_%d";
+      title = "fh2PtJet2VsRelPt_%d;#it{p}_{T,jet2};(#it{p}_{T,jet1}-#it{p}_{T,jet2})/#it{p}_{T,jet2}";
+      fHistManager.CreateTH2(TString::Format(name.c_str(), matchingType.c_str(), centBin),
+                  TString::Format(title.c_str(), centBin), nBinsPt, minPt, maxPt, 241, -2.41, 2.41,
+                  "s");
+    }
+
+    // Number of jets accepted.
+    name = "jetMatching/%s/fNAccJets";
+    title = "fNAccJets;N/ev";
+    fHistManager.CreateTH1(TString::Format(name.c_str(), matchingType.c_str()), title.c_str(), 11, -0.5, 9.5, "s");
+  }
+
+}
+
+/**
  * Setup and allocate histograms related to creating a response matrix.
  */
 void AliAnalysisTaskEmcalJetHPerformance::SetupResponseMatrixHists()
@@ -656,9 +757,49 @@ Bool_t AliAnalysisTaskEmcalJetHPerformance::Run()
     fEmbeddingQA.RecordEmbeddedEventProperties();
   }
 
+  // QA
   if (fCreateQAHists) {
     QAHists();
   }
+
+  // Jet matching
+  if (fPerformJetMatching) {
+    // Setup
+    // We don't perform any additional jet matching initialization because we will restrict
+    // the jets accepted via the jet acceptance cuts (ie. EMCal fiducial cuts)
+    // Retrieve the releveant jet collections
+    AliJetContainer * jetsHybrid = GetJetContainer("hybridLevelJets");
+    AliJetContainer * jetsDetLevel = GetJetContainer("detLevelJets");
+    AliJetContainer * jetsPartLevel = GetJetContainer("partLevelJets");
+    // Validation
+    if (!jetsHybrid) {
+      AliErrorStream() << "Could not retrieve hybrid jet collection.\n";
+      return kFALSE;
+    }
+    if (!jetsDetLevel) {
+      AliErrorStream() << "Could not retrieve det level jet collection.\n";
+      return kFALSE;
+    }
+    if (!jetsPartLevel) {
+      AliErrorStream() << "Could not retrieve part level jet collection.\n";
+      return kFALSE;
+    }
+
+    // First, we reset the tagging
+    ResetMatching(*jetsHybrid);
+    ResetMatching(*jetsDetLevel);
+    ResetMatching(*jetsPartLevel);
+
+    // Next, we perform the matching
+    PerformGeometricalJetMatching(*jetsHybrid, *jetsDetLevel, fMaxJetMatchingDistance);
+    PerformGeometricalJetMatching(*jetsDetLevel, *jetsPartLevel, fMaxJetMatchingDistance);
+
+    // Fill QA hists.
+    FillJetMatchingQA(*jetsHybrid, *jetsDetLevel, "hybridToDet");
+    FillJetMatchingQA(*jetsHybrid, *jetsPartLevel, "detToPart");
+  }
+
+  // Response matrix
   if (fCreateResponseMatrix) {
     ResponseMatrix();
   }
@@ -861,6 +1002,210 @@ void AliAnalysisTaskEmcalJetHPerformance::FillQAHists()
   if (embeddingInstance) {
     fPreviousEmbeddedEventSelected = embeddingInstance->EmbeddedEventUsed();
   }
+}
+
+/**
+ * Reset matching for the jet container.
+ *
+ * @params[in] c Jet container for the matching to be reset.
+ */
+void AliAnalysisTaskEmcalJetHPerformance::ResetMatching(const AliJetContainer &c) const
+{
+  for(auto j : c.all()){
+    j->ResetMatching();
+  }
+}
+
+/**
+ * Perform matching between jet collections.
+ *
+ * This code is basically combined from `AliAnalysisTaskEmcalJetTagger::MatchJetsGeo(...)`` and
+ * ``AliEmcalJetTaggerTaskFast::MatchJetsGeo(...)``. I mainly took the appraoch from the fast tagger,
+ * but I'm not using the KDTrees because they still need some additional work as of to properly wrap
+ * around at 2pi in phi. So for now we just use brute force matching at O(n^2).
+ *
+ * Why copy this code? It's a less than ideal thing to do, but for some unidentified, but well known reason
+ * (present from at least 2018), there is an issue that causes most jobs to fail when embedding into LHC15o
+ * for full jets when using one of the tagger tasks. This particularly seems to occur when embedding LHC16j5.
+ * This can be worked around by not running the standard or fast taggers. Thus, the code is copied.
+ *
+ * NOTE: This makes a number of assumptions about the jet containers that are specific to the jet-hadron analysis
+ *       for full jets. Among other factors, it expects that the acceptances are restricted to the EMCal fiducial
+ *       volume for detector level jets. If these assumptions are not true, matching may not work properly.
+ *
+ * @params[in] contBase Base jet container.
+ * @params[in] contTag Second jet container.
+ * @params[in] maxDist Max distance for matching.
+ * @returns True if the matching was successful.
+ */
+bool AliAnalysisTaskEmcalJetHPerformance::PerformGeometricalJetMatching(AliJetContainer& contBase,
+                                    AliJetContainer& contTag, double maxDist) const
+{
+  // Setup
+  const Int_t kNacceptedBase = contBase.GetNAcceptedJets(), kNacceptedTag = contTag.GetNAcceptedJets();
+  if (!(kNacceptedBase && kNacceptedTag)) {
+    return false;
+  }
+
+  // Build up vectors of jet pointers to use when assigning the closest jets.
+  // The storages are needed later for applying the tagging, in order to avoid multiple occurrence of jet selection
+  std::vector<AliEmcalJet*> jetsBase(kNacceptedBase), jetsTag(kNacceptedTag);
+
+  int countBase(0), countTag(0);
+  for (auto jb : contBase.accepted()) {
+    jetsBase[countBase] = jb;
+    countBase++;
+  }
+  for (auto jt : contTag.accepted()) {
+    jetsTag[countTag] = jt;
+    countTag++;
+  }
+
+  TArrayI faMatchIndexTag(kNacceptedBase), faMatchIndexBase(kNacceptedTag);
+  faMatchIndexBase.Reset(-1);
+  faMatchIndexTag.Reset(-1);
+
+  // find the closest distance to the base jet
+  countBase = 0;
+  for (auto jet1 : contBase.accepted()) {
+    double distance = maxDist;
+
+    // Loop over all accepted jets and brute force search for the closest jet.
+    auto tagAcceptedIt = contTag.accepted();
+    for (AliJetIterableContainer::iterator jetTagIt = tagAcceptedIt.begin(); jetTagIt != tagAcceptedIt.end(); ++jetTagIt) {
+      auto jet2 = *jetTagIt;
+      double dR = jet1->DeltaR(jet2);
+      if (dR < distance && dR < maxDist) {
+        faMatchIndexTag[countBase] = jetTagIt.current_index();
+        distance = dR;
+      }
+    }
+
+    // Let us know whether a match was found successfully.
+    // test whether indices are matching:
+    if (faMatchIndexTag[countBase] >= 0 && distance < maxDist) {
+      AliDebugStream(1) << "Found closest tag jet for " << countBase << " with match index "
+               << faMatchIndexTag[countBase] << " and distance " << distance << "\n";
+    } else {
+      AliDebugStream(1) << "Not found closest tag jet for " << countBase << ".\n";
+    }
+
+    countBase++;
+  }
+
+  // other way around
+  countTag = 0;
+  for (auto jet1 : contTag.accepted()) {
+    double distance = maxDist;
+
+    // Loop over all accepted jets and brute force search for the closest jet.
+    auto baseAcceptedIt = contBase.accepted();
+    for (AliJetIterableContainer::iterator jetBaseIt = baseAcceptedIt.begin(); jetBaseIt != baseAcceptedIt.end(); ++jetBaseIt) {
+      auto jet2 = *jetBaseIt;
+      double dR = jet1->DeltaR(jet2);
+      if (dR < distance && dR < maxDist) {
+        faMatchIndexBase[countTag] = jetBaseIt.current_index();
+        distance = dR;
+      }
+    }
+
+    // Let us know whether a match was found successfully.
+    // test whether indices are matching:
+    if (faMatchIndexBase[countTag] >= 0 && distance < maxDist) {
+      AliDebugStream(1) << "Found closest base jet for " << countTag << " with match index "
+               << faMatchIndexBase[countTag] << " and distance " << distance << "\n";
+    } else {
+      AliDebugStream(1) << "Not found closest base jet for " << countTag << ".\n";
+    }
+
+    countTag++;
+  }
+
+  // check for "true" correlations
+  // these are pairs where the base jet is the closest to the tag jet and vice versa
+  // As the lists are linear a loop over the outer base jet is sufficient.
+  AliDebugStream(1) << "Starting true jet loop: nbase(" << kNacceptedBase << "), ntag(" << kNacceptedTag << ")\n";
+  for (int ibase = 0; ibase < kNacceptedBase; ibase++) {
+    AliDebugStream(2) << "base jet " << ibase << ": match index in tag jet container " << faMatchIndexTag[ibase]
+             << "\n";
+    if (faMatchIndexTag[ibase] > -1) {
+      AliDebugStream(2) << "tag jet " << faMatchIndexTag[ibase] << ": matched base jet "
+               << faMatchIndexBase[faMatchIndexTag[ibase]] << "\n";
+    }
+    // We have a true correlation where each jet points to the other.
+    if (faMatchIndexTag[ibase] > -1 && faMatchIndexBase[faMatchIndexTag[ibase]] == ibase) {
+      AliDebugStream(2) << "found a true match \n";
+      AliEmcalJet *jetBase = jetsBase[ibase], *jetTag = jetsTag[faMatchIndexTag[ibase]];
+      // We have a valid pair of matched jets, so set the closest jet properties.
+      if (jetBase && jetTag) {
+        Double_t dR = jetBase->DeltaR(jetTag);
+        jetBase->SetClosestJet(jetTag, dR);
+        jetTag->SetClosestJet(jetBase, dR);
+      }
+    }
+  }
+  return true;
+}
+
+/**
+ * Fill jet matching QA histograms to describe the matching quality.
+ *
+ * @param[in] contBase Base jet container.
+ * @param[in] contTag Second jet container.
+ */
+void AliAnalysisTaskEmcalJetHPerformance::FillJetMatchingQA(AliJetContainer& contBase, AliJetContainer& contTag,
+                              const std::string& prefix)
+{
+  // Fill histograms.
+  std::string name = "";
+  std::string centBin = std::to_string(fCentBin);
+  for (auto jet1 : contBase.accepted()) {
+    // Setup
+    Double_t ptJet1 = jet1->Pt() - contBase.GetRhoVal() * jet1->Area();
+    // Record jet 1 only properties
+    name = "jetMatching/" + prefix + "/fh2PtJet1VsLeadPtAllSel_" + centBin;
+    fHistManager.FillTH2(name.c_str(), ptJet1, jet1->MaxTrackPt());
+
+    // Retrieve jet 2
+    AliEmcalJet * jet2 = jet1->ClosestJet();
+    if (!jet2) { continue; }
+    Double_t ptJet2 = jet2->Pt() - contTag.GetRhoVal() * jet2->Area();
+    // This will retrieve the fraction of jet2's momentum in jet1.
+    Double_t fraction = contBase.GetFractionSharedPt(jet1);
+
+    name = "jetMatching/" + prefix + "/fh2PtJet2VsFraction_" + centBin;
+    fHistManager.FillTH2(name.c_str(), ptJet2, fraction);
+    AliDebugStream(5) << "Fraction: " << fraction << ", minimum: " << fMinFractionShared << "\n";
+    if (fraction < fMinFractionShared) {
+      continue;
+    }
+    name = "jetMatching/" + prefix + "/fh2PtJet1VsLeadPtTagged_" + centBin;
+    fHistManager.FillTH2(name.c_str(), ptJet1,jet1->MaxTrackPt());
+    name = "jetMatching/" + prefix + "/fh2PtJet1VsPtJet2_" + centBin;
+    fHistManager.FillTH2(name.c_str(), ptJet1, ptJet2);
+    if (ptJet2 > 0.) {
+      name = "jetMatching/" + prefix + "/fh2PtJet2VsRelPt_" + centBin;
+      fHistManager.FillTH2(name.c_str(), ptJet2, (ptJet1 - ptJet2) / ptJet2);
+    }
+
+    // Recall that the arguments are backwards of the expectation.
+    Double_t dPhi = DeltaPhi(jet2->Phi(), jet1->Phi());
+    if (dPhi > TMath::Pi()) {
+      dPhi -= TMath::TwoPi();
+    }
+    if (dPhi < (-1. * TMath::Pi())) {
+      dPhi += TMath::TwoPi();
+    }
+
+    name = "jetMatching/" + prefix + "/fh3PtJet1VsDeltaEtaDeltaPhi_" + centBin;
+    fHistManager.FillTH3(name.c_str(), ptJet1, jet1->Eta() - jet2->Eta(), dPhi);
+    name = "jetMatching/" + prefix + "/fh2PtJet1VsDeltaR_" + centBin;
+    fHistManager.FillTH2(name.c_str(), ptJet1, jet1->DeltaR(jet2));
+  }
+
+  // Number of accepted jets
+  name = "jetMatching/" + prefix + "fNAccJets";
+  fHistManager.FillTH1(name.c_str(), contBase.GetNAcceptedJets());
 }
 
 /**
@@ -1084,16 +1429,24 @@ std::string AliAnalysisTaskEmcalJetHPerformance::toString() const
   while ((jetCont = static_cast<AliJetContainer *>(nextJetCont()))) {
     tempSS << "\t" << jetCont->GetName() << ": " << jetCont->GetArrayName() << "\n";
   }
+  // AliEventCuts
   tempSS << "AliEventCuts\n";
   tempSS << "\tEnabled: " << !fUseBuiltinEventSelection << "\n";
+  // Efficiency
   tempSS << "Efficiency\n";
   tempSS << "\tSingle track efficiency identifier: " << fEfficiencyPeriodIdentifier << "\n";
+  // QA
   tempSS << "QA Hists:\n";
   tempSS << "\tEnabled: " << fCreateQAHists << "\n";
   tempSS << "\tCreate cell QA hists: " << fCreateCellQAHists << "\n";
   // Use whether the pointer as null as a proxy. It's not ideal because it's not fully initialized
   // until after UserCreateOutputObjects(). But it's good enough for these purposes.
-  tempSS << "\tCalculate event plane resolution (proxy - may not be accurate): " << (fFlowQnVectorManager != nullptr) << "\n";
+  tempSS << "\tCalculate event plane resolution (proxy of whether it's enabled - it may not be accurate): " << (fFlowQnVectorManager != nullptr) << "\n";
+  // Jet matching
+  tempSS << "Jet matching:\n";
+  tempSS << "\tEnabled: " << fPerformJetMatching << "\n";
+  tempSS << "\tMax matching distance: " << fMaxJetMatchingDistance << "\n";
+  // Response matrix
   tempSS << "Response matrix:\n";
   tempSS << "\tEnabled: " << fCreateResponseMatrix << "\n";
   tempSS << "\tConstruct response from 3 jet collections: " << fResponseFromThreeJetCollections << "\n";
@@ -1161,6 +1514,7 @@ void swap(PWGJE::EMCALJetTasks::AliAnalysisTaskEmcalJetHPerformance & first, PWG
   //swap(first.fEmbeddingQA, second.fEmbeddingQA); // Skip here, because the THistManager copy constructor is private.
   swap(first.fCreateQAHists, second.fCreateQAHists);
   swap(first.fCreateCellQAHists, second.fCreateCellQAHists);
+  swap(first.fPerformJetMatching, second.fPerformJetMatching);
   swap(first.fCreateResponseMatrix, second.fCreateResponseMatrix);
   swap(first.fEmbeddedCellsName, second.fEmbeddedCellsName);
   swap(first.fPreviousEventTrigger, second.fPreviousEventTrigger);

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHPerformance.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHPerformance.h
@@ -92,10 +92,16 @@ class AliAnalysisTaskEmcalJetHPerformance : public AliAnalysisTaskEmcalJet {
   void FillCellQAHists(const std::string & prefix, AliVCaloCells * cells);
   void FillCellQAHists();
 
+  // Jet matching
+  void SetupJetMatchingQA();
+  void ResetMatching(const AliJetContainer & jetCont) const;
+  bool PerformGeometricalJetMatching(AliJetContainer& contBase, AliJetContainer& contTag, double maxDist) const;
+  void FillJetMatchingQA(AliJetContainer& contBase, AliJetContainer& contTag, const std::string& prefix);
+
   // Response matrix functions
   void SetupResponseMatrixHists();
   void ResponseMatrix();
-  void FillResponseMatrix(AliEmcalJet * jet1, AliEmcalJet * jet2, const double jet1Rho);
+  void FillResponseMatrix(AliEmcalJet* jet1, AliEmcalJet* jet2, const double jet1Rho);
   ResponseMatrixFillWrapper CreateResponseMatrixFillWrapper(AliEmcalJet * jet, const double rho) const;
 
   // Basic configuration
@@ -109,6 +115,7 @@ class AliAnalysisTaskEmcalJetHPerformance : public AliAnalysisTaskEmcalJet {
   // Configuration options
   bool fCreateQAHists;                ///<  If true, create QA histograms.
   bool fCreateCellQAHists;            ///<  If true, create the Cell QA histograms. It doesn't gracefully turn off when not configured like the containers, so we have a switch.
+  bool fPerformJetMatching;           ///<  If true, enables jet matching.
   bool fCreateResponseMatrix;         ///<  If true, create a response matrix with the available jet collections.
 
   // QA variables
@@ -117,6 +124,9 @@ class AliAnalysisTaskEmcalJetHPerformance : public AliAnalysisTaskEmcalJet {
   bool fPreviousEmbeddedEventSelected;            ///<  True if the previous embedded event was selected. Used to determine why a small number of embedded event are double counted.
   AliAnalysisTaskEmcalJetHUtils::EEfficiencyPeriodIdentifier_t fEfficiencyPeriodIdentifier;  ///<  Identifies the period for determining the efficiency correction to apply
   AliQnCorrectionsManager *fFlowQnVectorManager;  //!<! Qn corrections framework manager.
+
+  // Jet matching
+  double fMaxJetMatchingDistance;                 ///<  Matx jet matching distance.
 
   // Response matrix variables
   // Response matrix fill map
@@ -131,7 +141,7 @@ class AliAnalysisTaskEmcalJetHPerformance : public AliAnalysisTaskEmcalJet {
   double fMinFractionShared;             ///<  Minimum fraction of shared jet pt required for matching a hybrid jet to detector level
   AliAnalysisTaskEmcalJetHUtils::ELeadingHadronBiasType_t fLeadingHadronBiasType; ///<  Leading hadron in jet bias type (either charged, neutral, or both)
 
-  ClassDef(AliAnalysisTaskEmcalJetHPerformance, 6);
+  ClassDef(AliAnalysisTaskEmcalJetHPerformance, 7);
 };
 
 } /* namespace EMCALJetTasks */

--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHUtils.h
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHUtils.h
@@ -5,7 +5,7 @@
  * @class AliAnalysisTaskEmcalJetHUtils
  * @brief Jet-hadron correlations utilities class
  *
- * Contains funtionality that is shared between the various classes. Could have been
+ * Contains functionality that is shared between the various classes. Could have been
  * a namespace except it wouldn't play nice with ROOT.
  *
  * @author Raymond Ehlers <raymond.ehlers@cern.ch>, Yale University
@@ -20,7 +20,7 @@
 // NOTE: AliAnalysisTaskSE is just needed for AliQnCorrectionsVarManagerTask...
 #include "AliAnalysisTaskSE.h"
 #include "AliQnCorrectionsVarManagerTask.h"
-class AliEmcalJet;
+#include "AliEmcalJet.h"
 class AliEmcalContainer;
 class AliParticleContainer;
 class AliTrackContainer;
@@ -63,6 +63,9 @@ class AliAnalysisTaskEmcalJetHUtils {
                              AliClusterContainer* clusterCont,
                              PWG::Tools::AliYAMLConfiguration& yamlConfig,
                              std::string taskName);
+  // Determine jet acceptance from YAML
+  static const std::map<std::string, AliEmcalJet::JetAcceptanceType> fgkJetAcceptanceMap;
+  static UInt_t DetermineJetAcceptanceFromYAML(const std::vector<std::string> & selections);
 
   // AddTask for Qn flow vector corrections
   static AliAnalysisTaskFlowVectorCorrections * AddTaskFlowQnVectorCorrections(const std::string & configFilename);


### PR DESCRIPTION
Moving the matching to the user task is a work around for issues with LHC15o embedding when using full jets