### PR TITLE
Fix out-of-bounds write, add validation warning

### DIFF
--- a/PWGJE/EMCALJetTasks/AliEmcalJetTaggerTaskFast.cxx
+++ b/PWGJE/EMCALJetTasks/AliEmcalJetTaggerTaskFast.cxx
@@ -79,24 +79,6 @@ namespace PWGJE {
       , fContainerErrorRateTag(nullptr)
 #endif
   {
-    fh3PtJet1VsDeltaEtaDeltaPhi  = new TH3*[fNcentBins];
-    fh2PtJet1VsDeltaR            = new TH2*[fNcentBins];
-    fh2PtJet2VsFraction          = new TH2*[fNcentBins];
-    fh2PtJet1VsLeadPtAllSel      = new TH2*[fNcentBins];
-    fh2PtJet1VsLeadPtTagged      = new TH2*[fNcentBins];
-    fh2PtJet1VsPtJet2            = new TH2*[fNcentBins];
-    fh2PtJet2VsRelPt             = new TH2*[fNcentBins];
-
-    for (Int_t i = 0; i < fNcentBins; i++) {
-      fh3PtJet1VsDeltaEtaDeltaPhi[i] = 0;
-      fh2PtJet1VsDeltaR[i]           = 0;
-      fh2PtJet2VsFraction[i]         = 0;
-      fh2PtJet1VsLeadPtAllSel[i]     = 0;
-      fh2PtJet1VsLeadPtTagged[i]     = 0;
-      fh2PtJet1VsPtJet2[i]           = 0;
-      fh2PtJet2VsRelPt[i]            = 0;
-    }
-
     SetMakeGeneralHistograms(kTRUE);
   }
 
@@ -130,31 +112,14 @@ namespace PWGJE {
       , fContainerErrorRateTag(nullptr)
 #endif
   {
-
-    fh3PtJet1VsDeltaEtaDeltaPhi = new TH3*[fNcentBins];
-    fh2PtJet1VsDeltaR           = new TH2*[fNcentBins];
-    fh2PtJet2VsFraction         = new TH2*[fNcentBins];
-    fh2PtJet1VsLeadPtAllSel     = new TH2*[fNcentBins];
-    fh2PtJet1VsLeadPtTagged     = new TH2*[fNcentBins];
-    fh2PtJet1VsPtJet2           = new TH2*[fNcentBins];
-    fh2PtJet2VsRelPt            = new TH2*[fNcentBins];
-
-    for (Int_t i = 0; i < fNcentBins; i++) {
-      fh3PtJet1VsDeltaEtaDeltaPhi[i] = 0;
-      fh2PtJet1VsDeltaR[i]           = 0;
-      fh2PtJet2VsFraction[i]         = 0;
-      fh2PtJet1VsLeadPtAllSel[i]     = 0;
-      fh2PtJet1VsLeadPtTagged[i]     = 0;
-      fh2PtJet1VsPtJet2[i]           = 0;
-      fh2PtJet2VsRelPt[i]            = 0;
-    }
-
     SetMakeGeneralHistograms(kTRUE);
-
   }
 
   void AliEmcalJetTaggerTaskFast::UserCreateOutputObjects() {
     AliAnalysisTaskEmcalJet::UserCreateOutputObjects();
+
+    // Notify the user to be careful.
+    AliErrorStream() << "This task isn't yet validated. Please use the standard AliAnalysisTaskEmcalJetTagger.\n";
 
     Bool_t oldStatus = TH1::AddDirectoryStatus();
     TH1::AddDirectory(kFALSE);
@@ -175,6 +140,25 @@ namespace PWGJE {
     const Double_t maxDR       =  0.5;
     const Double_t minFraction =  -0.005;
     const Double_t maxFraction =  1.005;
+
+    // Prepare histograms
+    fh3PtJet1VsDeltaEtaDeltaPhi  = new TH3*[fNcentBins];
+    fh2PtJet1VsDeltaR            = new TH2*[fNcentBins];
+    fh2PtJet2VsFraction          = new TH2*[fNcentBins];
+    fh2PtJet1VsLeadPtAllSel      = new TH2*[fNcentBins];
+    fh2PtJet1VsLeadPtTagged      = new TH2*[fNcentBins];
+    fh2PtJet1VsPtJet2            = new TH2*[fNcentBins];
+    fh2PtJet2VsRelPt             = new TH2*[fNcentBins];
+
+    for (Int_t i = 0; i < fNcentBins; i++) {
+      fh3PtJet1VsDeltaEtaDeltaPhi[i] = 0;
+      fh2PtJet1VsDeltaR[i]           = 0;
+      fh2PtJet2VsFraction[i]         = 0;
+      fh2PtJet1VsLeadPtAllSel[i]     = 0;
+      fh2PtJet1VsLeadPtTagged[i]     = 0;
+      fh2PtJet1VsPtJet2[i]           = 0;
+      fh2PtJet2VsRelPt[i]            = 0;
+    }
 
     TString histName = "";
     TString histTitle = "";


### PR DESCRIPTION
If NcentBins was set after constructing the object to anything greater
than 4, it would write the histogram out of bounds.

Also added a warning that the task isn't yet validated and that the
standard tagger should be used.