### PR TITLE
Expand delta eta range

### DIFF
--- a/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.cxx
+++ b/PWGJE/EMCALJetTasks/UserTasks/AliAnalysisTaskEmcalJetHCorrelations.cxx
@@ -910,9 +910,9 @@ void AliAnalysisTaskEmcalJetHCorrelations::GetDimParams(Int_t iEntry, TString &l
 
     case 3:
       label = "#Delta#eta";
-      nbins = 24;
-      xmin = -1.2;
-      xmax = 1.2;
+      nbins = 28;
+      xmin = -1.4;
+      xmax = 1.4;
       break;
 
     case 4:


### PR DESCRIPTION
Allows for the possibility of expanding the background dominated region.
Note that to take advantage and fully fill out to +/- 1.4, the user must
extend the eta acceptance out to +/-0.9. Otherwise, it can't populate
the correlations out to +/-1.4.