### PR TITLE
C-Array with non constexpr dimension are forbidden

### DIFF
--- a/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetAna.cxx
+++ b/PWGCF/Correlations/JCORRAN/Pro/AliJCDijetAna.cxx
@@ -493,7 +493,7 @@ void AliJCDijetAna::CalculateResponse(AliJCDijetAna *anaDetMC, AliJCDijetHistos 
     double ptTrue, ptDetMC;
     unsigned maxptIndex;
     bool bfound;
-    bool bJetMatch[NjetsDetMC] = {false};
+    std::vector<bool> bJetMatch(NjetsDetMC, false);
     bool bLeadingMatch    = false;
     bool bSubleadingMatch = false;
     bool bSubleadingMatchDeltaPhi = false;


### PR DESCRIPTION
This fix the compilation for AliPhysics with the latest clang shipped with XCode