### PR TITLE
Fix for compilation in DEBUG mode.

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisPionPion.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisPionPion.cxx
@@ -460,7 +460,7 @@ AliFemtoAnalysisPionPion::DefaultCutConfig()
 
   // sanity checks
   assert(params.event_mult == default_event.multiplicity);
-  assert(params.pion_1_pt == default_pion.pt);
+  assert(params.pion_1_pt.first == default_pion.pt.first && params.pion_1_pt.second == default_pion.pt.second);
   assert(params.pair_TPCOnly == default_pair.TPCOnly);
   // assert(params.pair_TPCExitSepMin == default_pair_TPCExitSepMin);
   assert(params.pair_delta_eta_min == default_pair.min_delta_eta);


### PR DESCRIPTION
The error was:
/home/zampolli/SOFT/alibuild/ali-master/sw/SOURCES/AliPhysics/master/0/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoAnalysisPionPion.cxx:463:27: error: no match for 'operator==' (operand types are 'std::pair<double, double>' and 'const RangeF_t {aka const std::pair<float, float>}')
   assert(params.pion_1_pt == default_pion.pt);

The two pairs are made one of doubles and one of floats. The comparison operator
does not know how to resolve this.

Thanks also to @shahor02 for the hints.
