### PR TITLE
PWGUD/UPC: Fix invariant mass range in templates pol.

### DIFF
--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardMC.cxx
@@ -2119,7 +2119,7 @@ void AliAnalysisTaskUPCforwardMC::UserExec(Option_t *)
      - dealing with negative values... -4.0 < Y < -2.5 !!!
      -
    */
-  if ( (possibleJPsiCopy.Mag() > 2.8) && (possibleJPsiCopy.Mag() < 3.3) && (possibleJPsiCopy.Pt() < 0.25) ) {
+  if ( (possibleJPsiCopy.Mag() > 2.85) && (possibleJPsiCopy.Mag() < 3.35) && (possibleJPsiCopy.Pt() < 0.25) ) {
     fAngularDistribOfPositiveMuonRestFrameJPsiH->Fill(cosThetaMuonsRestFrame[0]);
     fAngularDistribOfNegativeMuonRestFrameJPsiH->Fill(cosThetaMuonsRestFrame[1]);
     fCheckHelicityRestFrameJPsiH->Fill( muonsCopy[0].Dot(muonsCopy[1]) );
@@ -2276,162 +2276,6 @@ void AliAnalysisTaskUPCforwardMC::UserExec(Option_t *)
     }
 
 
-    /* - 2D ANALYSIS for POLARISATION.
-     * - Comparing HELICITY frame with
-     * - COLLINS-SOPER.
-     * - Using a really rough binning
-     * - to compensate the lack of statistics.
-     * -
-     */
-    Bool_t controlFlag4    = 0;
-    Bool_t controlFlag4_CS = 0;
-    Double_t MyVariableCosThetaBinning[] = { -0.65, -0.35, -0.15, -0.05,
-                                              0.05,  0.15,  0.35,  0.65 };
-    Double_t MyVariablePhiBinning[] = { -3.14*1,       -3.14*19*0.05, -3.14*18*0.05, -3.14*17*0.05,
-                                        -3.14*13*0.05, -3.14*9*0.05,  -3.14*6*0.05,  -3.14*4*0.05,
-                                        -3.14*2*0.05,  -3.14*1*0.05,   0,            +3.14*1*0.05,
-                                        +3.14*2*0.05,  +3.14*4*0.05,  +3.14*6*0.05,  +3.14*9*0.05,
-                                        +3.14*13*0.05, +3.14*17*0.05, +3.14*18*0.05, +3.14*19*0.05,
-                                        +3.14*1 };
-    if ( possibleJPsiCopy.Pt() < 0.25 ) {
-          Double_t CosThetaHelicityFrameValue3 = CosThetaHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
-          Double_t PhiHelicityFrameValue3      =   CosPhiHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
-          Double_t CosThetaCollinsSoperValue   =  CosThetaCollinsSoper( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
-          Double_t PhiCollinsSoperValue        =    CosPhiCollinsSoper( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
-          for(Int_t iCosThetaBins = 0; iCosThetaBins < 7; iCosThetaBins++) {
-            if( controlFlag4 == 1) break;
-            if( CosThetaHelicityFrameValue3 < MyVariableCosThetaBinning[iCosThetaBins + 1] ){
-              for(Int_t iPhiBins = 0; iPhiBins < 20; iPhiBins++) {
-                if( controlFlag4 == 1) break;
-                if( PhiHelicityFrameValue3  < MyVariablePhiBinning[iPhiBins + 1] ){
-                    fInvariantMassDistributionForSignalExtractionHelicityFrameMyBinningH[iCosThetaBins][iPhiBins]->Fill(possibleJPsiCopy.Mag());
-                    controlFlag4 = 1;
-                }
-              }
-            }
-          }
-          for(Int_t iCosThetaBins = 0; iCosThetaBins < 7; iCosThetaBins++) {
-            if( controlFlag4_CS == 1) break;
-            if( CosThetaCollinsSoperValue < MyVariableCosThetaBinning[iCosThetaBins + 1] ){
-              for(Int_t iPhiBins = 0; iPhiBins < 20; iPhiBins++) {
-                if( controlFlag4_CS == 1) break;
-                if( PhiCollinsSoperValue  < MyVariablePhiBinning[iPhiBins + 1] ){
-                    fInvariantMassDistributionForSignalExtractionCsFrameMyBinningH[iCosThetaBins][iPhiBins]->Fill(possibleJPsiCopy.Mag());
-                    controlFlag4_CS = 1;
-                }
-              }
-            }
-          }
-    }
-
-
-    /* - NEW:
-     * - TEMPLATES needed for signal extraction.
-     * -
-     */
-    Bool_t controlFlag13 = 0;
-    Bool_t controlFlag14 = 0;
-    Bool_t controlFlag15 = 0;
-    Bool_t controlFlag16 = 0;
-    Bool_t controlFlag17 = 0;
-    Bool_t controlFlag18 = 0;
-    if ( possibleJPsiCopy.Pt() < 0.25 ) {
-          Double_t CosThetaHelicityFrameValue7 = CosThetaHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
-          Double_t PhiHelicityFrameValue7      =   CosPhiHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
-          // Double_t TildePhiPositiveCosTheta    = CosThetaHelicityFrameValue7 - 0.25 * TMath::Pi();
-          // Double_t TildePhiNegativeCosTheta    = CosThetaHelicityFrameValue7 - 0.75 * TMath::Pi();
-          Double_t TildePhiPositiveCosTheta    = PhiHelicityFrameValue7 - 0.25 * 3.14;
-          Double_t TildePhiNegativeCosTheta    = PhiHelicityFrameValue7 - 0.75 * 3.14;
-
-          Double_t CosThetaCollinsSoperValue   = CosThetaCollinsSoper(  muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
-          Double_t PhiCollinsSoperValue        =   CosPhiCollinsSoper(  muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
-          Double_t TildePhiPositiveCosThetaCS  = PhiCollinsSoperValue - 0.25 * 3.14;
-          Double_t TildePhiNegativeCosThetaCS  = PhiCollinsSoperValue - 0.75 * 3.14;
-
-          if( TildePhiPositiveCosTheta < 0. ) {
-            TildePhiPositiveCosTheta += 2. * TMath::Pi();
-          }
-          if( TildePhiNegativeCosTheta < 0. ) {
-            TildePhiNegativeCosTheta += 2. * TMath::Pi();
-          }
-
-          if( TildePhiPositiveCosThetaCS < 0. ) {
-            TildePhiPositiveCosThetaCS += 2. * TMath::Pi();
-          }
-          if( TildePhiNegativeCosThetaCS < 0. ) {
-            TildePhiNegativeCosThetaCS += 2. * TMath::Pi();
-          }
-
-          /* - HELICITY FRAME ANALYSIS
-           * -
-           */
-          for(Int_t iCosThetaBins = 0; iCosThetaBins < 25; iCosThetaBins++) {
-            if( controlFlag13 == 1) break;
-            if( (CosThetaHelicityFrameValue7 + 1.) < 2.*((Double_t)iCosThetaBins + 1.)/25. ) {
-              fInvariantMassDistributionOnlyCosThetaHeFrameTwentyfiveBinsH[iCosThetaBins]->Fill(possibleJPsiCopy.Mag());
-              controlFlag13 = 1;
-            }
-          }
-          for(Int_t iPhiBins = 0; iPhiBins < 25; iPhiBins++) {
-            if( controlFlag14 == 1) break;
-            if( (PhiHelicityFrameValue7 + 3.14) < 6.28*((Double_t)iPhiBins + 1.)/25. ){
-              fInvariantMassDistributionOnlyPhiHeFrameTwentyfiveBinsH[iPhiBins]->Fill(possibleJPsiCopy.Mag());
-              controlFlag14 = 1;
-            }
-          }
-          if( (CosThetaHelicityFrameValue7 > 0) || (CosThetaHelicityFrameValue7 == 0) ){
-            for(Int_t iTildePhiBins = 0; iTildePhiBins < 25; iTildePhiBins++) {
-              if( controlFlag15 == 1) break;
-              if( (TildePhiPositiveCosTheta) < 6.28*((Double_t)iTildePhiBins + 1.)/25. ){
-                fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[iTildePhiBins]->Fill(possibleJPsiCopy.Mag());
-                controlFlag15 = 1;
-              }
-            }
-          } else if ( CosThetaHelicityFrameValue7 < 0 ){
-            for(Int_t iTildePhiBins = 0; iTildePhiBins < 25; iTildePhiBins++) {
-              if( controlFlag15 == 1) break;
-              if( (TildePhiNegativeCosTheta) < 6.28*((Double_t)iTildePhiBins + 1.)/25. ){
-                fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[iTildePhiBins]->Fill(possibleJPsiCopy.Mag());
-                controlFlag15 = 1;
-              }
-            }
-          }
-
-          /* - COLLINS SOPER ANALYSIS
-           * -
-           */
-          for(Int_t iCosThetaBins = 0; iCosThetaBins < 25; iCosThetaBins++) {
-            if( controlFlag16 == 1) break;
-            if( (CosThetaCollinsSoperValue + 1.) < 2.*((Double_t)iCosThetaBins + 1.)/25. ) {
-              fInvariantMassDistributionOnlyCosThetaCsFrameTwentyfiveBinsH[iCosThetaBins]->Fill(possibleJPsiCopy.Mag());
-              controlFlag16 = 1;
-            }
-          }
-          for(Int_t iPhiBins = 0; iPhiBins < 25; iPhiBins++) {
-            if( controlFlag17 == 1) break;
-            if( (PhiCollinsSoperValue + 3.14) < 6.28*((Double_t)iPhiBins + 1.)/25. ){
-              fInvariantMassDistributionOnlyPhiCsFrameTwentyfiveBinsH[iPhiBins]->Fill(possibleJPsiCopy.Mag());
-              controlFlag17 = 1;
-            }
-          }
-          if( (CosThetaCollinsSoperValue > 0) || (CosThetaCollinsSoperValue == 0) ){
-            for(Int_t iTildePhiBins = 0; iTildePhiBins < 25; iTildePhiBins++) {
-              if( controlFlag18 == 1) break;
-              if( (TildePhiPositiveCosThetaCS) < 6.28*((Double_t)iTildePhiBins + 1.)/25. ){
-                fInvariantMassDistributionOnlyTildePhiCsFrameTwentyfiveBinsH[iTildePhiBins]->Fill(possibleJPsiCopy.Mag());
-                controlFlag18 = 1;
-              }
-            }
-          } else if ( CosThetaCollinsSoperValue < 0 ){
-            for(Int_t iTildePhiBins = 0; iTildePhiBins < 25; iTildePhiBins++) {
-              if( controlFlag18 == 1) break;
-              if( (TildePhiNegativeCosThetaCS) < 6.28*((Double_t)iTildePhiBins + 1.)/25. ){
-                fInvariantMassDistributionOnlyTildePhiCsFrameTwentyfiveBinsH[iTildePhiBins]->Fill(possibleJPsiCopy.Mag());
-                controlFlag18 = 1;
-              }
-            }
-          }
-    }
 
 
     /* - NEW:
@@ -2554,6 +2398,177 @@ void AliAnalysisTaskUPCforwardMC::UserExec(Option_t *)
     fPhiHeFrameForSignalExH     ->Fill( CosPhiHelicityFrame(   muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy ) );
 
   }
+
+
+
+
+
+
+  /* - NEW:
+   * - TEMPLATES needed for signal extraction.
+   * -
+   */
+  Bool_t controlFlag13 = 0;
+  Bool_t controlFlag14 = 0;
+  Bool_t controlFlag15 = 0;
+  Bool_t controlFlag16 = 0;
+  Bool_t controlFlag17 = 0;
+  Bool_t controlFlag18 = 0;
+  if ( possibleJPsiCopy.Pt() < 0.25 ) {
+        Double_t CosThetaHelicityFrameValue7 = CosThetaHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
+        Double_t PhiHelicityFrameValue7      =   CosPhiHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
+        // Double_t TildePhiPositiveCosTheta    = CosThetaHelicityFrameValue7 - 0.25 * TMath::Pi();
+        // Double_t TildePhiNegativeCosTheta    = CosThetaHelicityFrameValue7 - 0.75 * TMath::Pi();
+        Double_t TildePhiPositiveCosTheta    = PhiHelicityFrameValue7 - 0.25 * 3.14;
+        Double_t TildePhiNegativeCosTheta    = PhiHelicityFrameValue7 - 0.75 * 3.14;
+
+        Double_t CosThetaCollinsSoperValue   = CosThetaCollinsSoper(  muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
+        Double_t PhiCollinsSoperValue        =   CosPhiCollinsSoper(  muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
+        Double_t TildePhiPositiveCosThetaCS  = PhiCollinsSoperValue - 0.25 * 3.14;
+        Double_t TildePhiNegativeCosThetaCS  = PhiCollinsSoperValue - 0.75 * 3.14;
+
+        if( TildePhiPositiveCosTheta < 0. ) {
+          TildePhiPositiveCosTheta += 2. * TMath::Pi();
+        }
+        if( TildePhiNegativeCosTheta < 0. ) {
+          TildePhiNegativeCosTheta += 2. * TMath::Pi();
+        }
+
+        if( TildePhiPositiveCosThetaCS < 0. ) {
+          TildePhiPositiveCosThetaCS += 2. * TMath::Pi();
+        }
+        if( TildePhiNegativeCosThetaCS < 0. ) {
+          TildePhiNegativeCosThetaCS += 2. * TMath::Pi();
+        }
+
+        /* - HELICITY FRAME ANALYSIS
+         * -
+         */
+        for(Int_t iCosThetaBins = 0; iCosThetaBins < 25; iCosThetaBins++) {
+          if( controlFlag13 == 1) break;
+          if( (CosThetaHelicityFrameValue7 + 1.) < 2.*((Double_t)iCosThetaBins + 1.)/25. ) {
+            fInvariantMassDistributionOnlyCosThetaHeFrameTwentyfiveBinsH[iCosThetaBins]->Fill(possibleJPsiCopy.Mag());
+            controlFlag13 = 1;
+          }
+        }
+        for(Int_t iPhiBins = 0; iPhiBins < 25; iPhiBins++) {
+          if( controlFlag14 == 1) break;
+          if( (PhiHelicityFrameValue7 + 3.14) < 6.28*((Double_t)iPhiBins + 1.)/25. ){
+            fInvariantMassDistributionOnlyPhiHeFrameTwentyfiveBinsH[iPhiBins]->Fill(possibleJPsiCopy.Mag());
+            controlFlag14 = 1;
+          }
+        }
+        if( (CosThetaHelicityFrameValue7 > 0) || (CosThetaHelicityFrameValue7 == 0) ){
+          for(Int_t iTildePhiBins = 0; iTildePhiBins < 25; iTildePhiBins++) {
+            if( controlFlag15 == 1) break;
+            if( (TildePhiPositiveCosTheta) < 6.28*((Double_t)iTildePhiBins + 1.)/25. ){
+              fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[iTildePhiBins]->Fill(possibleJPsiCopy.Mag());
+              controlFlag15 = 1;
+            }
+          }
+        } else if ( CosThetaHelicityFrameValue7 < 0 ){
+          for(Int_t iTildePhiBins = 0; iTildePhiBins < 25; iTildePhiBins++) {
+            if( controlFlag15 == 1) break;
+            if( (TildePhiNegativeCosTheta) < 6.28*((Double_t)iTildePhiBins + 1.)/25. ){
+              fInvariantMassDistributionOnlyTildePhiHeFrameTwentyfiveBinsH[iTildePhiBins]->Fill(possibleJPsiCopy.Mag());
+              controlFlag15 = 1;
+            }
+          }
+        }
+
+        /* - COLLINS SOPER ANALYSIS
+         * -
+         */
+        for(Int_t iCosThetaBins = 0; iCosThetaBins < 25; iCosThetaBins++) {
+          if( controlFlag16 == 1) break;
+          if( (CosThetaCollinsSoperValue + 1.) < 2.*((Double_t)iCosThetaBins + 1.)/25. ) {
+            fInvariantMassDistributionOnlyCosThetaCsFrameTwentyfiveBinsH[iCosThetaBins]->Fill(possibleJPsiCopy.Mag());
+            controlFlag16 = 1;
+          }
+        }
+        for(Int_t iPhiBins = 0; iPhiBins < 25; iPhiBins++) {
+          if( controlFlag17 == 1) break;
+          if( (PhiCollinsSoperValue + 3.14) < 6.28*((Double_t)iPhiBins + 1.)/25. ){
+            fInvariantMassDistributionOnlyPhiCsFrameTwentyfiveBinsH[iPhiBins]->Fill(possibleJPsiCopy.Mag());
+            controlFlag17 = 1;
+          }
+        }
+        if( (CosThetaCollinsSoperValue > 0) || (CosThetaCollinsSoperValue == 0) ){
+          for(Int_t iTildePhiBins = 0; iTildePhiBins < 25; iTildePhiBins++) {
+            if( controlFlag18 == 1) break;
+            if( (TildePhiPositiveCosThetaCS) < 6.28*((Double_t)iTildePhiBins + 1.)/25. ){
+              fInvariantMassDistributionOnlyTildePhiCsFrameTwentyfiveBinsH[iTildePhiBins]->Fill(possibleJPsiCopy.Mag());
+              controlFlag18 = 1;
+            }
+          }
+        } else if ( CosThetaCollinsSoperValue < 0 ){
+          for(Int_t iTildePhiBins = 0; iTildePhiBins < 25; iTildePhiBins++) {
+            if( controlFlag18 == 1) break;
+            if( (TildePhiNegativeCosThetaCS) < 6.28*((Double_t)iTildePhiBins + 1.)/25. ){
+              fInvariantMassDistributionOnlyTildePhiCsFrameTwentyfiveBinsH[iTildePhiBins]->Fill(possibleJPsiCopy.Mag());
+              controlFlag18 = 1;
+            }
+          }
+        }
+  }
+
+  /* - 2D ANALYSIS for POLARISATION.
+   * - Comparing HELICITY frame with
+   * - COLLINS-SOPER.
+   * - Using a really rough binning
+   * - to compensate the lack of statistics.
+   * -
+   */
+  Bool_t controlFlag4    = 0;
+  Bool_t controlFlag4_CS = 0;
+  Double_t MyVariableCosThetaBinning[] = { -0.65, -0.35, -0.15, -0.05,
+                                            0.05,  0.15,  0.35,  0.65 };
+  Double_t MyVariablePhiBinning[] = { -3.14*1,       -3.14*19*0.05, -3.14*18*0.05, -3.14*17*0.05,
+                                      -3.14*13*0.05, -3.14*9*0.05,  -3.14*6*0.05,  -3.14*4*0.05,
+                                      -3.14*2*0.05,  -3.14*1*0.05,   0,            +3.14*1*0.05,
+                                      +3.14*2*0.05,  +3.14*4*0.05,  +3.14*6*0.05,  +3.14*9*0.05,
+                                      +3.14*13*0.05, +3.14*17*0.05, +3.14*18*0.05, +3.14*19*0.05,
+                                      +3.14*1 };
+  if ( possibleJPsiCopy.Pt() < 0.25 ) {
+        Double_t CosThetaHelicityFrameValue3 = CosThetaHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
+        Double_t PhiHelicityFrameValue3      =   CosPhiHelicityFrame( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
+        Double_t CosThetaCollinsSoperValue   =  CosThetaCollinsSoper( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
+        Double_t PhiCollinsSoperValue        =    CosPhiCollinsSoper( muonsCopy2[0], muonsCopy2[1], possibleJPsiCopy );
+        for(Int_t iCosThetaBins = 0; iCosThetaBins < 7; iCosThetaBins++) {
+          if( controlFlag4 == 1) break;
+          if( CosThetaHelicityFrameValue3 < MyVariableCosThetaBinning[iCosThetaBins + 1] ){
+            for(Int_t iPhiBins = 0; iPhiBins < 20; iPhiBins++) {
+              if( controlFlag4 == 1) break;
+              if( PhiHelicityFrameValue3  < MyVariablePhiBinning[iPhiBins + 1] ){
+                  fInvariantMassDistributionForSignalExtractionHelicityFrameMyBinningH[iCosThetaBins][iPhiBins]->Fill(possibleJPsiCopy.Mag());
+                  controlFlag4 = 1;
+              }
+            }
+          }
+        }
+        for(Int_t iCosThetaBins = 0; iCosThetaBins < 7; iCosThetaBins++) {
+          if( controlFlag4_CS == 1) break;
+          if( CosThetaCollinsSoperValue < MyVariableCosThetaBinning[iCosThetaBins + 1] ){
+            for(Int_t iPhiBins = 0; iPhiBins < 20; iPhiBins++) {
+              if( controlFlag4_CS == 1) break;
+              if( PhiCollinsSoperValue  < MyVariablePhiBinning[iPhiBins + 1] ){
+                  fInvariantMassDistributionForSignalExtractionCsFrameMyBinningH[iCosThetaBins][iPhiBins]->Fill(possibleJPsiCopy.Mag());
+                  controlFlag4_CS = 1;
+              }
+            }
+          }
+        }
+  }
+
+
+
+
+
+
+
+
+
+
 
   // fVectorCosThetaReconstructed.push_back(cosThetaMuonsRestFrame[0]);
   fCosThetaReconHelicityFrame = 0;


### PR DESCRIPTION
The code for the template was using an invariant mass selection a priori...
I had not realised this when running on the CohJPsi MC because they are already in that range.
Considering that I am dealing with rapidity integrated invariant mass plots, I can use them for the fits, but this has to be amended...

IMPORTANT: tested.