### PR TITLE
PWGHF: Temporary fixes for ITS3 Lb analysis

### DIFF
--- a/PWGHF/vertexingHF/upgrade/AddTaskLbUPG.C
+++ b/PWGHF/vertexingHF/upgrade/AddTaskLbUPG.C
@@ -1,4 +1,4 @@
-AliAnalysisTaskSELbtoLcpi4 *AddTaskLbUPG(TString finname="LcdaughtersCut.root",Int_t ndebug=0,const char*  postname="")
+AliAnalysisTaskSELbtoLcpi4 *AddTaskLbUPG(TString finname="LcdaughtersCut.root",Int_t ndebug=0,const char*  postname="", Int_t applyFixesITS3Analysis=-1)
  {
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
   if (!mgr) {
@@ -36,6 +36,24 @@ AliAnalysisTaskSELbtoLcpi4 *AddTaskLbUPG(TString finname="LcdaughtersCut.root",I
      
   task->SetCutsond0Lcdaughters(kFALSE);
   task->SetPtConfiguration(0.,30.,2.,14.,0.,999.,4.);
+
+  //temporary to check effect of fixes separately
+  if(applyFixesITS3Analysis == 0){
+    task->SetApplyFixesITS3AnalysisBit(kTRUE);
+    task->SetApplyFixesITS3AnalysiskAll(kTRUE);
+    task->SetApplyFixesITS3AnalysisHijing(kTRUE);
+  } else if(applyFixesITS3Analysis == 1){
+    task->SetApplyFixesITS3AnalysisBit(kTRUE);
+  } else if(applyFixesITS3Analysis == 2){
+    task->SetApplyFixesITS3AnalysiskAll(kTRUE);
+  } else if(applyFixesITS3Analysis == 3){
+    task->SetApplyFixesITS3AnalysisHijing(kTRUE);
+  } else {
+    task->SetApplyFixesITS3AnalysisBit(kFALSE);
+    task->SetApplyFixesITS3AnalysiskAll(kFALSE);
+    task->SetApplyFixesITS3AnalysisHijing(kFALSE);
+  }
+ 
   mgr->AddTask(task);
 
   

--- a/PWGHF/vertexingHF/upgrade/AliAnalysisTaskSELbtoLcpi4.h
+++ b/PWGHF/vertexingHF/upgrade/AliAnalysisTaskSELbtoLcpi4.h
@@ -57,6 +57,11 @@ class AliAnalysisTaskSELbtoLcpi4:public AliAnalysisTaskSE {
   
   //set parameters
    void SetCutsond0Lcdaughters(Bool_t val = kTRUE) {fCutsond0Lcdaughters = val; return;}
+  
+   void SetApplyFixesITS3AnalysisBit(Bool_t val = kTRUE){fApplyFixesITS3AnalysisBit = val;}
+   void SetApplyFixesITS3AnalysiskAll(Bool_t val = kTRUE){fApplyFixesITS3AnalysiskAll = val;}
+   void SetApplyFixesITS3AnalysisHijing(Bool_t val = kTRUE){fApplyFixesITS3AnalysisHijing = val;}
+
    void ApplyD0CutLcdaughters(Double_t d0cutd1, Double_t d0cutd2){fCutD0Daughter[0]=d0cutd1; fCutD0Daughter[1]=d0cutd2;}
    void SetPtConfiguration(Double_t ptbin, Double_t ptlcupper, Double_t ptlclower, Double_t ptpionupper, Double_t ptpionlower, Double_t ptlbupper, Double_t ptlblower){fCutsPerPt[0]=ptbin;fCutsPerPt[1]=ptlcupper;fCutsPerPt[2]=ptlclower;fCutsPerPt[3]=ptpionupper;fCutsPerPt[4]=ptpionlower;fCutsPerPt[5]=ptlbupper;fCutsPerPt[6]=ptlblower;}
    void SetNRotations(Double_t nrotations){fNRotations=nrotations;}
@@ -121,7 +126,13 @@ class AliAnalysisTaskSELbtoLcpi4:public AliAnalysisTaskSE {
   Double_t fCutsPerPt[7];
   Double_t fNRotations;
   Bool_t fIsPromptLc;
-  ClassDef(AliAnalysisTaskSELbtoLcpi4,4);
+
+  //temporary to compare with old ITS2 analysis
+  Bool_t fApplyFixesITS3AnalysisBit;
+  Bool_t fApplyFixesITS3AnalysiskAll;
+  Bool_t fApplyFixesITS3AnalysisHijing;
+
+  ClassDef(AliAnalysisTaskSELbtoLcpi4,5);
 };
 
 #endif


### PR DESCRIPTION
* Added temporary "fix-flags" (related to selected background) to compare old ITS2 analysis with  new ITS3 one. Fixes to be made final after checks+discussions.
* Fixed some memory leaks.
* Only require PID for pion track when PID is also required for the Lc candidate.
* Added possibility to skip the rotational background part, so task is less heavy for running tests.