### PR TITLE
PWGHF: Loosen mom. consv. check for beauty ITS upgrade studies

### DIFF
--- a/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
+++ b/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
@@ -2617,6 +2617,7 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessBplus(TClonesArray *array2prong, Ali
         
         //To significantly speed up the task when only signal was requested
         if(fWriteOnlySignal){
+          //To check: Might be affected by mom. consv. issue in ITSUpgrade MC's
           if(dfromB->MatchToMC(421,arrMC,2,pdgDgD0toKpi) < 0) continue;
         }
         
@@ -2758,9 +2759,13 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessBplus(TClonesArray *array2prong, Ali
                     if (fReadMC){
                       //Momentum conservation for several beauty decays not satisfied at gen. level in Upgrade MC's.
                       //Effect is per mille level, but big enough to be rejected by MatchToMC() function.
-                      //Momentum conservation check turned off in MatchToMCB2Prong (to fix to loosening cut from 0.001% to 0.5%)
+                      //Fix implemented, loosening cut from 0.001% to 2.0%. If > 2.0%, negative label is returned.
                       labBplus = trackBplus.MatchToMCB2Prong(521,421,pdgDgBplustoD0piInt,pdgDgD0topiK,arrMC);
                       
+                      //Use feed-down bit to flag these candidates for offline study.
+                      //Can be good for analysis or coming from an "incomplete simulated" decay
+                      if(labBplus < -1){ isFD=kTRUE; labBplus=TMath::Abs(labBplus); }
+
                       if(labBplus >= 0) {
                         partBplus = (AliAODMCParticle*)arrMC->At(labBplus);
                         ptGenBplus = partBplus->Pt();
@@ -3002,8 +3007,12 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessBs(TClonesArray *array3Prong, AliAOD
                     if (fReadMC){
                       //Momentum conservation for several beauty decays not satisfied at gen. level in Upgrade MC's.
                       //Effect is per mille level, but big enough to be rejected by MatchToMC() function.
-                      //Temporary fix implemented, loosening cut from 0.001% to 0.5%
+                      //Fix implemented, loosening cut from 0.001% to 2.0%. If > 2.0%, negative label is returned.
                       labBs = trackBs.MatchToMCB3Prong(531,431,pdgDgBstoDspi,pdgDstoKKpi,arrMC);
+
+                      //Use feed-down bit to flag these candidates for offline study.
+                      //Can be good for analysis or coming from an "incomplete simulated" decay
+                      if(labBs < -1){ isFD=kTRUE; labBs=TMath::Abs(labBs); }
 
                       if(labBs >= 0) {
                         partBs = (AliAODMCParticle*)arrMC->At(labBs);
@@ -3241,9 +3250,13 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessLb(TClonesArray *array3Prong, AliAOD
                     if (fReadMC){
                       //Momentum conservation for several beauty decays not satisfied at gen. level in Upgrade MC's.
                       //Effect is per mille level, but big enough to be rejected by MatchToMC() function.
-                      //Temporary fix implemented, loosening cut from 0.001% to 0.5%
+                      //Fix implemented, loosening cut from 0.001% to 2.0%. If > 2.0%, negative label is returned.
                       labLb = trackLb.MatchToMCB3Prong(5122,4122,pdgDgLbtoLcpi,pdgLctopKpi,arrMC);
                       
+                      //Use feed-down bit to flag these candidates for offline study.
+                      //Can be good for analysis or coming from an "incomplete simulated" decay
+                      if(labLb < -1){ isFD=kTRUE; labLb=TMath::Abs(labLb); }
+
                       if(labLb >= 0) {
                         partLb = (AliAODMCParticle*)arrMC->At(labLb);
                         ptGenLb = partLb->Pt();
@@ -3354,6 +3367,13 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessMCGen(TClonesArray *arrayMC){
       }
       else if(absPDG == 521 && fWriteVariableTreeBplus) {
         deca = AliVertexingHFUtils::CheckBplusDecay(arrayMC,mcPart,labDau);
+        
+        //Momentum conservation for several beauty decays not satisfied at gen. level in Upgrade MC's.
+        //Fix implemented, loosening cut from 0.001 to 0.1. If >0.1, (-1*deca - 1) is returned.
+        //Use feed-down bit to flag these candidates for offline study.
+        //Can be good for analysis or coming from an "incomplete simulated" decay
+        if(deca == -2){ isFeeddown=kTRUE; deca=1; }
+
         if(deca!=1 || labDau[0]==-1 || labDau[1]<0) continue;
         isDaugInAcc = CheckDaugAcc(arrayMC,3,labDau,kTRUE);
         fTreeHandlerGenBplus->SetDauInAcceptance(isDaugInAcc);
@@ -3365,6 +3385,13 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessMCGen(TClonesArray *arrayMC){
       else if(absPDG == 531 && fWriteVariableTreeBs) {
         deca = AliVertexingHFUtils::CheckBsDecay(arrayMC,mcPart,labDau4pr);
         //Only accept Bs-> pi Ds(->phipi->KKpi) decays
+
+        //Momentum conservation for several beauty decays not satisfied at gen. level in Upgrade MC's.
+        //Fix implemented, loosening cut from 0.001 to 0.1. If >0.1, (-1*deca - 1) is returned.
+        //Use feed-down bit to flag these candidates for offline study.
+        //Can be good for analysis or coming from an "incomplete simulated" decay
+        if(deca == -2){ isFeeddown=kTRUE; deca=1; }
+        
         if(deca!=1 || labDau4pr[0]==-1 || labDau4pr[1]<0) continue;
         isDaugInAcc = CheckDaugAcc(arrayMC,4,labDau4pr,kTRUE);
         fTreeHandlerGenBs->SetDauInAcceptance(isDaugInAcc);
@@ -3406,6 +3433,13 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessMCGen(TClonesArray *arrayMC){
         }
       } else if(absPDG == 5122 && fWriteVariableTreeLb) {
         deca = AliVertexingHFUtils::CheckLbDecay(arrayMC,mcPart,labDau4pr);
+        
+        //Momentum conservation for several beauty decays not satisfied at gen. level in Upgrade MC's.
+        //Fix implemented, loosening cut from 0.001 to 0.1. If >0.1, (-1*deca - 1) is returned.
+        //Use feed-down bit to flag these candidates for offline study.
+        //Can be good for analysis or coming from an "incomplete simulated" decay
+        if(deca < -1){ isFeeddown=kTRUE; deca=-1*deca-1; }
+        
         if(deca<1 || labDau4pr[0]==-1 || labDau4pr[1]<0) continue;
         isDaugInAcc = CheckDaugAcc(arrayMC,4,labDau4pr,kTRUE);
         fTreeHandlerGenLb->SetDauInAcceptance(isDaugInAcc);

--- a/PWGHF/vertexingHF/AliVertexingHFUtils.cxx
+++ b/PWGHF/vertexingHF/AliVertexingHFUtils.cxx
@@ -2316,6 +2316,9 @@ Int_t AliVertexingHFUtils::CheckXicXipipiDecay(AliMCEvent* mcEvent, Int_t label,
 //____________________________________________________________________________
 Int_t AliVertexingHFUtils::CheckBplusDecay(AliMCEvent* mcEvent, Int_t label, Int_t* arrayDauLab){
   /// Checks the Bplus decay channel. Returns 1 for Bplus->D0pi->Kpipi, -1 in other cases
+  /// If rejected by momentum conservation check, return (-1*decay - 1) (to allow checks at task level)
+  ///
+  /// NB: Loosened cut on mom. conserv. (needed because of small issue in ITS Upgrade productions)
 
   if(label<0) return -1;
   AliMCParticle* mcPart = (AliMCParticle*)mcEvent->GetTrack(label);
@@ -2384,19 +2387,20 @@ Int_t AliVertexingHFUtils::CheckBplusDecay(AliMCEvent* mcEvent, Int_t label, Int
 
   if(nPions!=2) return -1;
   if(nKaons!=1) return -1;
-  //Temp fix for not conserving momentum in ITS upgrade productions
-  if(TMath::Abs(part->Px()-sumPxDau)<0.1) return 1;
-  if(TMath::Abs(part->Py()-sumPyDau)<0.1) return 1;
-  if(TMath::Abs(part->Pz()-sumPzDau)<0.1) return 1;
-  if(TMath::Abs(part->Px()-sumPxDau)>0.001) return -2;
-  if(TMath::Abs(part->Py()-sumPyDau)>0.001) return -2;
-  if(TMath::Abs(part->Pz()-sumPzDau)>0.001) return -2;
+  //Momentum conservation for several beauty decays not satisfied at gen. level in Upgrade MC's.
+  //Fix implemented, loosening cut from 0.001 to 0.1. If >0.1, (-1*decay - 1) is returned.
+  if(TMath::Abs(part->Px()-sumPxDau)>0.1) return -2;
+  if(TMath::Abs(part->Py()-sumPyDau)>0.1) return -2;
+  if(TMath::Abs(part->Pz()-sumPzDau)>0.1) return -2;
   return 1;
 
 }
 //____________________________________________________________________________
 Int_t AliVertexingHFUtils::CheckBplusDecay(TClonesArray* arrayMC, AliAODMCParticle *mcPart, Int_t* arrayDauLab){
   /// Checks the Bplus decay channel. Returns 1 for Bplus->D0pi->Kpipi, -1 in other cases
+  /// If rejected by momentum conservation check, return (-1*decay - 1) (to allow checks at task level)
+  ///
+  /// NB: Loosened cut on mom. conserv. (needed because of small issue in ITS Upgrade productions)
 
   Int_t pdgD=mcPart->GetPdgCode();
   if(TMath::Abs(pdgD)!=521) return -1;
@@ -2460,13 +2464,11 @@ Int_t AliVertexingHFUtils::CheckBplusDecay(TClonesArray* arrayMC, AliAODMCPartic
 
   if(nPions!=2) return -1;
   if(nKaons!=1) return -1;
-  //Temp fix for not conserving momentum in ITS upgrade productions
-  if(TMath::Abs(mcPart->Px()-sumPxDau)<0.1) return 1;
-  if(TMath::Abs(mcPart->Py()-sumPyDau)<0.1) return 1;
-  if(TMath::Abs(mcPart->Pz()-sumPzDau)<0.1) return 1;
-  if(TMath::Abs(mcPart->Px()-sumPxDau)>0.001) return -2;
-  if(TMath::Abs(mcPart->Py()-sumPyDau)>0.001) return -2;
-  if(TMath::Abs(mcPart->Pz()-sumPzDau)>0.001) return -2;
+  //Momentum conservation for several beauty decays not satisfied at gen. level in Upgrade MC's.
+  //Fix implemented, loosening cut from 0.001 to 0.1. If >0.1, (-1*decay - 1) is returned.
+  if(TMath::Abs(mcPart->Px()-sumPxDau)>0.1) return -2;
+  if(TMath::Abs(mcPart->Py()-sumPyDau)>0.1) return -2;
+  if(TMath::Abs(mcPart->Pz()-sumPzDau)>0.1) return -2;
   return 1;
 
 }
@@ -2474,6 +2476,9 @@ Int_t AliVertexingHFUtils::CheckBplusDecay(TClonesArray* arrayMC, AliAODMCPartic
 Int_t AliVertexingHFUtils::CheckBsDecay(AliMCEvent* mcEvent, Int_t label, Int_t* arrayDauLab){
   /// Checks the Bs decay channel. Returns >= 1 for Bs->Dspi->KKpipi, <0 in other cases
   /// Returns 1 for Ds->phipi->KKpi, 2 for Ds->K0*K->KKpi, 3 for the non-resonant case, 4 for Ds->f0pi->KKpi
+  /// If rejected by momentum conservation check, return (-1*decay - 1) (to allow checks at task level)
+  ///
+  /// NB: Loosened cut on mom. conserv. (needed because of small issue in ITS Upgrade productions)
   
   if(label<0) return -1;
   AliMCParticle* mcPart = (AliMCParticle*)mcEvent->GetTrack(label);
@@ -2505,7 +2510,8 @@ Int_t AliVertexingHFUtils::CheckBsDecay(AliMCEvent* mcEvent, Int_t label, Int_t*
       Int_t labDauDs[3] = {-1,-1,-1};
       Int_t decayDs = CheckDsDecay(mcEvent, indDau, labDauDs);
       
-      //Temp fix for not conserving momentum in ITS upgrade productions
+      //Momentum conservation for several beauty decays not satisfied at gen. level in Upgrade MC's.
+      //Fix implemented, to still select correct Ds decay
       if(decayDs==-2){
         AliMCParticle* mcDs = (AliMCParticle*)mcEvent->GetTrack(indDau);
         Int_t labelFirstDauDs = mcDs->GetDaughterFirst();
@@ -2549,19 +2555,22 @@ Int_t AliVertexingHFUtils::CheckBsDecay(AliMCEvent* mcEvent, Int_t label, Int_t*
   
   if(nPions!=2) return -1;
   if(nKaons!=2) return -1;
-  //Temp fix for not conserving momentum in ITS upgrade productions
-  if(TMath::Abs(part->Px()-sumPxDau)<0.1) return decayBs;
-  if(TMath::Abs(part->Py()-sumPyDau)<0.1) return decayBs;
-  if(TMath::Abs(part->Pz()-sumPzDau)<0.1) return decayBs;
-  if(TMath::Abs(part->Px()-sumPxDau)>0.001) return -2;
-  if(TMath::Abs(part->Py()-sumPyDau)>0.001) return -2;
-  if(TMath::Abs(part->Pz()-sumPzDau)>0.001) return -2;
+  //Momentum conservation for several beauty decays not satisfied at gen. level in Upgrade MC's.
+  //Fix implemented, loosening cut from 0.001 to 0.1. If >0.1, (-1*decay - 1) is returned.
+  Int_t decayBstemp = decayBs;
+  if(TMath::Abs(part->Px()-sumPxDau)>0.1) decayBstemp = -1*decayBs - 1;
+  if(TMath::Abs(part->Py()-sumPyDau)>0.1) decayBstemp = -1*decayBs - 1;
+  if(TMath::Abs(part->Pz()-sumPzDau)>0.1) decayBstemp = -1*decayBs - 1;
+  decayBs = decayBstemp;
   return decayBs;
 }
 //____________________________________________________________________________
 Int_t AliVertexingHFUtils::CheckBsDecay(TClonesArray* arrayMC, AliAODMCParticle *mcPart, Int_t* arrayDauLab){
   /// Checks the Bs decay channel. Returns >= 1 for Bs->Dspi->KKpipi, <0 in other cases
   /// Returns 1 for Ds->phipi->KKpi, 2 for Ds->K0*K->KKpi, 3 for the non-resonant case, 4 for Ds->f0pi->KKpi
+  /// If rejected by momentum conservation check, return (-1*decay - 1) (to allow checks at task level)
+  ///
+  /// NB: Loosened cut on mom. conserv. (needed because of small issue in ITS Upgrade productions)
   
   Int_t pdgD=mcPart->GetPdgCode();
   if(TMath::Abs(pdgD)!=531) return -1;
@@ -2589,7 +2598,8 @@ Int_t AliVertexingHFUtils::CheckBsDecay(TClonesArray* arrayMC, AliAODMCParticle 
       Int_t labDauDs[3] = {-1,-1,-1};
       Int_t decayDs = CheckDsDecay(arrayMC, dau, labDauDs);
       
-      //Temp fix for not conserving momentum in ITS upgrade productions
+      //Momentum conservation for several beauty decays not satisfied at gen. level in Upgrade MC's.
+      //Fix implemented, to still select correct Ds decay
       if(decayDs==-2){
         Int_t labelFirstDauDs = dau->GetDaughterLabel(0);
         if(dau->GetNDaughters() > 1){
@@ -2632,19 +2642,22 @@ Int_t AliVertexingHFUtils::CheckBsDecay(TClonesArray* arrayMC, AliAODMCParticle 
   
   if(nPions!=2) return -1;
   if(nKaons!=2) return -1;
-  //Temp fix for not conserving momentum in ITS upgrade productions
-  if(TMath::Abs(mcPart->Px()-sumPxDau)<0.1) return decayBs;
-  if(TMath::Abs(mcPart->Py()-sumPyDau)<0.1) return decayBs;
-  if(TMath::Abs(mcPart->Pz()-sumPzDau)<0.1) return decayBs;
-  if(TMath::Abs(mcPart->Px()-sumPxDau)>0.001) return -2;
-  if(TMath::Abs(mcPart->Py()-sumPyDau)>0.001) return -2;
-  if(TMath::Abs(mcPart->Pz()-sumPzDau)>0.001) return -2;
+  //Momentum conservation for several beauty decays not satisfied at gen. level in Upgrade MC's.
+  //Fix implemented, loosening cut from 0.001 to 0.1. If >0.1, (-1*decay - 1) is returned.
+  Int_t decayBstemp = decayBs;
+  if(TMath::Abs(mcPart->Px()-sumPxDau)>0.1) decayBstemp = -1*decayBs - 1;
+  if(TMath::Abs(mcPart->Py()-sumPyDau)>0.1) decayBstemp = -1*decayBs - 1;
+  if(TMath::Abs(mcPart->Pz()-sumPzDau)>0.1) decayBstemp = -1*decayBs - 1;
+  decayBs = decayBstemp;
   return decayBs;
 }
 //____________________________________________________________________________
 Int_t AliVertexingHFUtils::CheckLbDecay(AliMCEvent* mcEvent, Int_t label, Int_t* arrayDauLab){
   /// Checks the Lb decay channel. Returns >= 1 for Lb->Lcpi->pKpipi, <0 in other cases
   /// Returns 1 for non-resonant Lc decays and 2, 3 or 4 for resonant ones, -1 in other cases
+  /// If rejected by momentum conservation check, return (-1*decay - 1) (to allow checks at task level)
+  ///
+  /// NB: Loosened cut on mom. conserv. (needed because of small issue in ITS Upgrade productions)
   
   if(label<0) return -1;
   AliMCParticle* mcPart = (AliMCParticle*)mcEvent->GetTrack(label);
@@ -2677,7 +2690,8 @@ Int_t AliVertexingHFUtils::CheckLbDecay(AliMCEvent* mcEvent, Int_t label, Int_t*
       //Returns 1 for non-resonant decays and 2, 3 or 4 for resonant ones, -1 in other cases
       Int_t decayLc = CheckLcpKpiDecay(mcEvent, indDau, labDauLc);
       
-      //Temp fix for not conserving momentum in ITS upgrade productions
+      //Momentum conservation for several beauty decays not satisfied at gen. level in Upgrade MC's.
+      //Fix implemented, to still select correct Lc decay
       if(decayLc==-2){
         AliMCParticle* mcLc = (AliMCParticle*)mcEvent->GetTrack(indDau);
         Int_t labelFirstDauLc = mcLc->GetDaughterFirst();
@@ -2723,19 +2737,22 @@ Int_t AliVertexingHFUtils::CheckLbDecay(AliMCEvent* mcEvent, Int_t label, Int_t*
   if(nProtons!=1) return -1;
   if(nKaons!=1) return -1;
   if(nPions!=2) return -1;
-  //Temp fix for not conserving momentum in ITS upgrade productions
-  if(TMath::Abs(part->Px()-sumPxDau)<0.1) return decayLb;
-  if(TMath::Abs(part->Py()-sumPyDau)<0.1) return decayLb;
-  if(TMath::Abs(part->Pz()-sumPzDau)<0.1) return decayLb;
-  if(TMath::Abs(part->Px()-sumPxDau)>0.001) return -2;
-  if(TMath::Abs(part->Py()-sumPyDau)>0.001) return -2;
-  if(TMath::Abs(part->Pz()-sumPzDau)>0.001) return -2;
+  //Momentum conservation for several beauty decays not satisfied at gen. level in Upgrade MC's.
+  //Fix implemented, loosening cut from 0.001 to 0.1. If >0.1, (-1*decay - 1) is returned.
+  Int_t decayLbtemp = decayLb;
+  if(TMath::Abs(part->Px()-sumPxDau)>0.1) decayLbtemp = -1*decayLb - 1;
+  if(TMath::Abs(part->Py()-sumPyDau)>0.1) decayLbtemp = -1*decayLb - 1;
+  if(TMath::Abs(part->Pz()-sumPzDau)>0.1) decayLbtemp = -1*decayLb - 1;
+  decayLb = decayLbtemp;
   return decayLb;
 }
 //____________________________________________________________________________
 Int_t AliVertexingHFUtils::CheckLbDecay(TClonesArray* arrayMC, AliAODMCParticle *mcPart, Int_t* arrayDauLab){
   /// Checks the Lb decay channel. Returns >= 1 for Lb->Lcpi->pKpipi, <0 in other cases
   /// Returns 1 for non-resonant Lc decays and 2, 3 or 4 for resonant ones, -1 in other cases
+  /// If rejected by momentum conservation check, return (-1*decay - 1) (to allow checks at task level)
+  ///
+  /// NB: Loosened cut on mom. conserv. (needed because of small issue in ITS Upgrade productions)
   
   Int_t pdgD=mcPart->GetPdgCode();
   if(TMath::Abs(pdgD)!=5122) return -1;
@@ -2764,7 +2781,8 @@ Int_t AliVertexingHFUtils::CheckLbDecay(TClonesArray* arrayMC, AliAODMCParticle 
       //Returns 1 for non-resonant decays and 2, 3 or 4 for resonant ones, -1 in other cases
       Int_t decayLc = CheckLcpKpiDecay(arrayMC, dau, labDauLc);
       
-      //Temp fix for not conserving momentum in ITS upgrade productions
+      //Momentum conservation for several beauty decays not satisfied at gen. level in Upgrade MC's.
+      //Fix implemented, to still select correct Lc decay
       if(decayLc==-2){
         Int_t labelFirstDauLc = dau->GetDaughterLabel(0);
         if(dau->GetNDaughters() > 1){
@@ -2809,13 +2827,13 @@ Int_t AliVertexingHFUtils::CheckLbDecay(TClonesArray* arrayMC, AliAODMCParticle 
   if(nProtons!=1) return -1;
   if(nKaons!=1) return -1;
   if(nPions!=2) return -1;
-  //Temp fix for not conserving momentum in ITS upgrade productions
-  if(TMath::Abs(mcPart->Px()-sumPxDau)<0.1) return decayLb;
-  if(TMath::Abs(mcPart->Py()-sumPyDau)<0.1) return decayLb;
-  if(TMath::Abs(mcPart->Pz()-sumPzDau)<0.1) return decayLb;
-  if(TMath::Abs(mcPart->Px()-sumPxDau)>0.001) return -2;
-  if(TMath::Abs(mcPart->Py()-sumPyDau)>0.001) return -2;
-  if(TMath::Abs(mcPart->Pz()-sumPzDau)>0.001) return -2;
+  //Momentum conservation for several beauty decays not satisfied at gen. level in Upgrade MC's.
+  //Fix implemented, loosening cut from 0.001 to 0.1. If >0.1, (-1*decay - 1) is returned.
+  Int_t decayLbtemp = decayLb;
+  if(TMath::Abs(mcPart->Px()-sumPxDau)>0.1) decayLbtemp = -1*decayLb - 1;
+  if(TMath::Abs(mcPart->Py()-sumPyDau)>0.1) decayLbtemp = -1*decayLb - 1;
+  if(TMath::Abs(mcPart->Pz()-sumPzDau)>0.1) decayLbtemp = -1*decayLb - 1;
+  decayLb = decayLbtemp;
   return decayLb;
 }
 //________________________________________________________________________


### PR DESCRIPTION
* Several correct beauty candidates in the ITS Upgrade MC's were still rejected by the momentum conservation check. Loosened the check further, and added a strategy to tag and use them add task level (with negative labels).
* Store the still rejected decays in TTreeCreator for offline study (tagging them as "feed-down", as this flag wasn't used for beauty decays)
* Removed resonance check in MatchToMCB3Prong, didn't work as expected