### PR TITLE
PWGHF, Lb: Memory leak fix + cleaning code

### DIFF
--- a/PWGHF/vertexingHF/upgrade/AliAnalysisTaskSELbtoLcpi4.cxx
+++ b/PWGHF/vertexingHF/upgrade/AliAnalysisTaskSELbtoLcpi4.cxx
@@ -51,7 +51,7 @@ ClassImp(AliAnalysisTaskSELbtoLcpi4);
 //  Analysis Task for Lb in Lc and pion
 //
 
-  AliAnalysisTaskSELbtoLcpi4::AliAnalysisTaskSELbtoLcpi4()
+AliAnalysisTaskSELbtoLcpi4::AliAnalysisTaskSELbtoLcpi4()
 :AliAnalysisTaskSE(),
   fPIDResponse(0),
   fOutput(0),
@@ -72,8 +72,7 @@ ClassImp(AliAnalysisTaskSELbtoLcpi4);
   fSelMC(0),
   fCountLc(0),
   fNtupleLambdabUPG(0),
-  //fNtupleDiffD0rot(0)
-  fFillNtupleSignal(kFALSE), 
+  fFillNtupleSignal(kFALSE),
   fFillNtupleBackgroundRotated(kFALSE),
   fFillNtupleBackgroundNonRotated(kFALSE),
   fCutsond0Lcdaughters(kFALSE),
@@ -116,8 +115,7 @@ AliAnalysisTaskSELbtoLcpi4::AliAnalysisTaskSELbtoLcpi4(const char *name,
   fSelMC(0),
   fCountLc(0),
   fNtupleLambdabUPG(0),
-  //fNtupleDiffD0rot(0)
-  fFillNtupleSignal(kFALSE), 
+  fFillNtupleSignal(kFALSE),
   fFillNtupleBackgroundRotated(kFALSE),
   fFillNtupleBackgroundNonRotated(kFALSE),
   fCutsond0Lcdaughters(kFALSE),
@@ -140,13 +138,6 @@ AliAnalysisTaskSELbtoLcpi4::AliAnalysisTaskSELbtoLcpi4(const char *name,
   //
   DefineOutput(1,TList::Class());
   DefineOutput(2,TNtuple::Class());
-  //DefineOutput(3,TNtuple::Class());
-  //DefineOutput(4,TNtuple::Class());
-  //DefineOutput(5,TNtuple::Class());
-  //DefineOutput(6,TNtuple::Class());
-  //DefineOutput(7,TNtuple::Class());
-
-
 }
 
 AliAnalysisTaskSELbtoLcpi4::~AliAnalysisTaskSELbtoLcpi4() {
@@ -154,46 +145,16 @@ AliAnalysisTaskSELbtoLcpi4::~AliAnalysisTaskSELbtoLcpi4() {
   // Destructor.
   //
 
-  if (fPIDResponse) {
-    delete  fPIDResponse;
-  }
-  if (fOutput) {
-    delete fOutput;
-    fOutput = 0;
-  }
-  if(fHistNEvents){
-    delete fHistNEvents;
-    fHistNEvents=0;
-  }
-  if(fHistNEventsCuts){
-    delete fHistNEventsCuts;
-    fHistNEventsCuts=0;
-  }
-  if(fHistNEventsCutsLb){
-    delete fHistNEventsCutsLb;
-    fHistNEventsCutsLb=0;
-  }
-
-
-  if(fRDCutsAnalysisLc){
-    delete fRDCutsAnalysisLc;
-    fRDCutsAnalysisLc = 0;
-  }
-
-  if(fRDCutsProductionLb){
-    delete fRDCutsProductionLb;
-    fRDCutsProductionLb = 0;
-  }
-  if (fListCuts) {
-    delete fListCuts;
-    fListCuts = 0;
-  }
-  if(fvtx1){
-    delete fvtx1; 
-    fvtx1 = 0x0;
-  }
- 
- delete fNtupleLambdabUPG;
+  delete fPIDResponse;
+  delete fOutput;
+  delete fHistNEvents;
+  delete fHistNEventsCuts;
+  delete fHistNEventsCutsLb;
+  delete fRDCutsAnalysisLc;
+  delete fRDCutsProductionLb;
+  delete fListCuts;
+  delete fvtx1;
+  delete fNtupleLambdabUPG;
 
 }
 //-----------------------------------------------------
@@ -201,14 +162,10 @@ void AliAnalysisTaskSELbtoLcpi4::Init()
 {
   // Initialization
 
-
   fListCuts=new TList();
-
   fListCuts->Add(new AliRDHFCutsLctopKpi(*fRDCutsAnalysisLc));
   fListCuts->Add(new AliRDHFCutsLctopKpi(*fRDCutsProductionLb));
 
-
-  //PostData(7,fListCuts);
   return;
 }
 
@@ -218,9 +175,10 @@ void AliAnalysisTaskSELbtoLcpi4::UserExec(Option_t*) {
   //
   // The event loop
   //
-
+  
   AliAODEvent *aod=dynamic_cast<AliAODEvent*>(InputEvent());
   fHistNEvents->Fill(0);
+  
   TClonesArray *array3Prong = 0;
   TClonesArray *arrayLikeSign =0;
   if(!aod && AODEvent() && IsStandardAOD()) {
@@ -230,7 +188,7 @@ void AliAnalysisTaskSELbtoLcpi4::UserExec(Option_t*) {
     // in this case the braches in the deltaAOD (AliAOD.VertexingHF.root)
     // have to taken from the AOD event hold by the AliAODExtension
     AliAODHandler* aodHandler = (AliAODHandler*)
-      ((AliAnalysisManager::GetAnalysisManager())->GetOutputEventHandler());
+    ((AliAnalysisManager::GetAnalysisManager())->GetOutputEventHandler());
     if(aodHandler->GetExtensions()) {
       AliAODExtension *ext = (AliAODExtension*)aodHandler->GetExtensions()->FindObject("AliAOD.VertexingHF.root");
       AliAODEvent *aodFromExt = ext->GetAOD();
@@ -241,23 +199,14 @@ void AliAnalysisTaskSELbtoLcpi4::UserExec(Option_t*) {
     array3Prong=(TClonesArray*)aod->GetList()->FindObject("Charm3Prong");
     arrayLikeSign=(TClonesArray*)aod->GetList()->FindObject("LikeSign3Prong");
   }
-
-  if(!aod) return;
+  if(!aod || !array3Prong) return;
+  
   // fix for temporary bug in ESDfilter
   // the AODs with null vertex pointer didn't pass the PhysSel
-  if(!aod->GetPrimaryVertex() || TMath::Abs(aod->GetMagneticField())<0.001) return;
-
   fBzkG = aod->GetMagneticField();
-  // AOD primary vertex
   fvtx1 = (AliAODVertex*)aod->GetPrimaryVertex();
-  if(!fvtx1) return;
-  if(array3Prong==NULL) return;
-  Int_t n3Prong = array3Prong->GetEntriesFast();
-  //if (array3Prong)std::cout<<"the array is there"<<std::endl;
-  //if(!array3Prong==NULL)
-  //Int_t n3Prong = array3Prong->GetEntriesFast();
- // else{return;}
-
+  if(!fvtx1 || TMath::Abs(fBzkG)<0.001) return;
+  
   AliAODMCHeader *mcHeader = 0;
   mcHeader = (AliAODMCHeader*)aod->GetList()->FindObject(AliAODMCHeader::StdBranchName());
   if(!mcHeader) {
@@ -267,12 +216,11 @@ void AliAnalysisTaskSELbtoLcpi4::UserExec(Option_t*) {
   TClonesArray *mcs=static_cast<TClonesArray*>(aod->GetList()->FindObject(AliAODMCParticle::StdBranchName()));
   if (!mcs) return;
 
-  //CheckMCKine(mcs);
-
-  //  loop 3 prongs 
+  //  loop 3 prongs
+  Int_t n3Prong = array3Prong->GetEntriesFast();
   for (Int_t icand = 0; icand < n3Prong; icand++) {
     AliAODRecoDecayHF3Prong *d = (AliAODRecoDecayHF3Prong*)array3Prong->UncheckedAt(icand);
-
+    
     if(fApplyFixesITS3AnalysisBit){
       if(!(d->HasSelectionBit(AliRDHFCuts::kLcCuts))) continue;
     }
@@ -283,61 +231,56 @@ void AliAnalysisTaskSELbtoLcpi4::UserExec(Option_t*) {
       unsetvtx=kTRUE;
     }
     Int_t selection;
-    if(fApplyFixesITS3AnalysiskAll)selection=fRDCutsAnalysisLc->IsSelected(d,AliRDHFCuts::kAll,aod);//is selected for LambdaC
-    else                           selection=fRDCutsAnalysisLc->IsSelected(d,AliRDHFCuts::kCandidate,aod);//is selected for LambdaC
+    //is selected for LambdaC
+    if(fApplyFixesITS3AnalysiskAll)selection=fRDCutsAnalysisLc->IsSelected(d,AliRDHFCuts::kAll,aod);
+    else                           selection=fRDCutsAnalysisLc->IsSelected(d,AliRDHFCuts::kCandidate,aod);
     if(selection==0){
       if(unsetvtx) d->UnsetOwnPrimaryVtx();
       continue;
     }
-      
+    
     //lc preliminary large pt cuts:
     if(d->Pt()>fCutsPerPt[1] || d->Pt()<fCutsPerPt[2]){
       if(unsetvtx) d->UnsetOwnPrimaryVtx();
       continue;
     }
-      
-    //Additional Cut on Lc 
+    
+    //Additional Cut on Lc
     // d0p and d0pi of Lc
     //large pt cuts on the d0's of the Lc daughters //keep them out for the moment
-   if (fCutsond0Lcdaughters)
-   {   
+    if (fCutsond0Lcdaughters){
       if(TMath::Abs(d->Getd0Prong(0))<fCutD0Daughter[0] || (TMath::Abs(d->Getd0Prong(2))<fCutD0Daughter[1])){
         if(unsetvtx) d->UnsetOwnPrimaryVtx();
         continue;
       }
-   }
-     // if(TMath::Abs(d->Getd0Prong(0))<0.002 || (TMath::Abs(d->Getd0Prong(2))<0.002))continue;
-    //Dist12 and Dist23 and DecayLength on Lc are hardcoded at 0.5
-    //     if(d->GetDist12toPrim()>1.) continue;
-    //     if(d->GetDist23toPrim()>1.) continue;
-    //     if(d->DecayLength()>0.6) continue;
+    }
+    
     FillHistos(d,mcs,aod,mcHeader);
     if(unsetvtx) d->UnsetOwnPrimaryVtx();
   }
   return;
 }
 
-
 void AliAnalysisTaskSELbtoLcpi4::FillHistos(AliAODRecoDecayHF3Prong* d,TClonesArray* arrayMC,AliAODEvent *ev,AliAODMCHeader *mcHeader){
   Int_t countLc=0;
- 
+  
   //check ID d prongs
   Int_t idProng1 = d->GetProngID(0);
   Int_t idProng2 = d->GetProngID(1);
   Int_t idProng3 = d->GetProngID(2);
-
+  
   Int_t lc=0;
   fIsPromptLc=kFALSE;
   Int_t labLb=CheckMCLc(d,arrayMC);//after track cuts
   //here we know if it is a prompt Lc
   AliExternalTrackParam *LcCand = new AliExternalTrackParam;
   LcCand->CopyFromVTrack(d);
-
+  
   for(Int_t k = 0 ; k < ev->GetNumberOfTracks() ; k++) {
     Double_t xdummy,ydummy;
     Double_t dzdummy[2];
     Double_t covardummy[3];
-
+    
     AliAODTrack * HPiAODtrk = dynamic_cast<AliAODTrack*>(ev->GetTrack(k));
     if(HPiAODtrk->GetID()==idProng1 || HPiAODtrk->GetID()==idProng2 || HPiAODtrk->GetID()==idProng3){
       HPiAODtrk=0;
@@ -355,7 +298,7 @@ void AliAnalysisTaskSELbtoLcpi4::FillHistos(AliAODRecoDecayHF3Prong* d,TClonesAr
       HPiAODtrk=0;
       continue;
     }
-  
+    
     //basic PID pion
     if(fRDCutsAnalysisLc->GetIsUsePID()){
       Double_t nsigmatofPi= fPIDResponse->NumberOfSigmasTOF(HPiAODtrk,AliPID::kPion);
@@ -363,50 +306,36 @@ void AliAnalysisTaskSELbtoLcpi4::FillHistos(AliAODRecoDecayHF3Prong* d,TClonesAr
       Double_t nsigmatpcPi= fPIDResponse->NumberOfSigmasTPC(HPiAODtrk,AliPID::kPion);
       if(nsigmatpcPi>-990. && (nsigmatpcPi<-3 || nsigmatpcPi>3)){HPiAODtrk=0;continue;}
     }
-    //______________________________________________________________________________________
+    
     // Track cuts
-    //cout << "Applying Track Cuts" << endl;
     AliESDtrackCuts *trackCutsHPi = fRDCutsAnalysisLc->GetTrackCuts();//
     if(!fRDCutsAnalysisLc->IsDaughterSelected(HPiAODtrk,(AliESDVertex*)fvtx1,trackCutsHPi)){
-      //cout << " *** Track Rejected *** " << endl;
       HPiAODtrk=0;
       continue;
     }
-    //AliExternalTrackParam *chargedHPi_old = new AliExternalTrackParam(HPiAODtrk);
+    
     AliExternalTrackParam *chargedHPi = new AliExternalTrackParam;
     chargedHPi->CopyFromVTrack(HPiAODtrk);
-    //______________________________________________________________________________________
-    // implement check for pion here later
-    // Cut on impact parameter of Pion track candidate w.r.t. the primary vertex
-
-    //              Double_t dAtDCA = chargedHPi->GetDCA();
-    //               ((TH1F*)fOutput->FindObject("fDCApionBg"))->Fill(dAtDCA);
+    
     Double_t dAtDCALc = d->GetDCA();
-      //keep this since we know we have bg above this number
+    //keep this since we know we have bg above this number
     if(dAtDCALc>0.05){
       HPiAODtrk=0;
       delete chargedHPi;
       continue;
     }
-      
-       //out for the large pt cuts
+    
+    //out for the large pt cuts
     ((TH1F*)fOutput->FindObject("fDCALcBg"))->Fill(dAtDCALc);
     //further cuts on candidate charged track
+    
     const Double_t max = 1;
     Double_t d0cut[2],covd0cut[3];
     Double_t d0cutLc[2],covd0cutLc[3];
     chargedHPi->PropagateToDCA(fvtx1,fBzkG,max,d0cut,covd0cut);
     LcCand->PropagateToDCA(fvtx1,fBzkG,max,d0cutLc,covd0cutLc);
-  /*    if(TMath::Abs(d0cutLc[0])<0.002||TMath::Abs(d0cutLc[0])>0.04||TMath::Abs(d0cut[0])<0.003||TMath::Abs(d0cut[0])>0.08) {
-      HPiAODtrk=0;
-      delete chargedHPi;
-      continue;
-   }
-      */
- 
+    
     // Construction of Secondary vertex
-    //cout << "Building Secondary Vertex" << endl;
-
     TObjArray *recoArray = new TObjArray(2);
     Double_t dispersion;
 
@@ -422,33 +351,28 @@ void AliAnalysisTaskSELbtoLcpi4::FillHistos(AliAODRecoDecayHF3Prong* d,TClonesAr
       delete recoArray;
       continue;
     }
-
-    // Add daughter information             
-    if(vtxAODNew) {
-      AddDaughterRefs(vtxAODNew,(AliAODEvent*)ev,recoArray);
-    }
+    // Add daughter information
+    AddDaughterRefs(vtxAODNew,(AliAODEvent*)ev,recoArray);
+    
     //______________________________________________________________________________________
     // construction of lb (with secondary vertex)
-    //cout << "Constructing lb Candidate" << endl;
-
+    
     const Double_t maxd = 1;
     //___
     // Propagate candidates to secondary vertex
-    //cout << "Propagating Daughter Tracks to Secondary Vertex" << endl;
-
-    Double_t px[2],py[2],pz[2],d0[2],d0err[2],dcaCand;
-
     chargedHPi->PropagateToDCA(vtxAODNew,fBzkG,maxd,dzdummy,covardummy);
     LcCand->PropagateToDCA(vtxAODNew,fBzkG,maxd,dzdummy,covardummy);
+    
     // Calculate momenta
-    //cout << "Calculating Momenta" << endl;
     Double_t momentum[3];
     chargedHPi->GetPxPyPz(momentum);
+    
+    Double_t px[2],py[2],pz[2],d0[2],d0err[2],dcaCand;
     px[0] = momentum[0]; py[0] = momentum[1]; pz[0] = momentum[2];
     LcCand->GetPxPyPz(momentum);
     px[1] = momentum[0]; py[1] = momentum[1]; pz[1] = momentum[2];
+    
     // Calculate impact parameters
-    //cout << "Calculating Impact Parameters" << endl;
     Double_t d0z0[2],covd0z0[3];
     LcCand->PropagateToDCA(fvtx1,fBzkG,maxd,d0z0,covd0z0);
     d0[1] = d0z0[0];
@@ -456,15 +380,11 @@ void AliAnalysisTaskSELbtoLcpi4::FillHistos(AliAODRecoDecayHF3Prong* d,TClonesAr
     chargedHPi->PropagateToDCA(fvtx1,fBzkG,maxd,d0z0,covd0z0);
     d0[0] = d0z0[0];
     d0err[0] = TMath::Sqrt(covd0z0[0]);
-
-    // Create AliExternalTrackParameter to calculate DCA between both tracks
-
+    
     dcaCand = chargedHPi->GetDCA(LcCand,fBzkG,xdummy,ydummy);
-    //cout << "Calculating DCA between the Tracks dca: " <<dcaCand<< endl;
-
+    
     // Create lbcandidate as AliAODRecoDecayHF2Prong
     AliAODRecoDecayHF2Prong *lbcandProng = new AliAODRecoDecayHF2Prong(vtxAODNew,px,py,pz,d0,d0err,dcaCand);
-    //if(lbcandProng->Pt()<4.){//FOR THE MOMENT ONLY CANDIDATES WITH pt>4GeV/c //old configuration
     if(lbcandProng->Pt()>fCutsPerPt[5]||lbcandProng->Pt()<fCutsPerPt[6]){
       HPiAODtrk=0;
       delete chargedHPi;
@@ -475,29 +395,28 @@ void AliAnalysisTaskSELbtoLcpi4::FillHistos(AliAODRecoDecayHF3Prong* d,TClonesAr
       continue;
     }
     lbcandProng->SetOwnPrimaryVtx(fvtx1);
-
+    
     UShort_t id[2];
     id[0]=(UShort_t)HPiAODtrk->GetID();
     id[1]=(UShort_t)LcCand->GetID();
     lbcandProng->SetProngIDs(2,id);
     AddDaughterRefs(vtxAODNew,(AliAODEvent*)ev,recoArray);
-    Int_t idHardPi=(Int_t)HPiAODtrk->GetID(); 
-    if (idHardPi > -1) { 
-      vtxAODNew->AddDaughter(HPiAODtrk);     
-    } 
-    vtxAODNew->AddDaughter(LcCand); 
+    Int_t idHardPi=(Int_t)HPiAODtrk->GetID();
+    if (idHardPi > -1) {
+      vtxAODNew->AddDaughter(HPiAODtrk);
+    }
+    vtxAODNew->AddDaughter(LcCand);
+    
     Int_t lb=0;
     Int_t labPi2=CheckMCpartPIONaf(HPiAODtrk,arrayMC);
-    if(labPi2==labLb){//signal 
+    if(labPi2==labLb){//signal
       lb=1;
       Float_t DCALc=d->GetDCA();
       ((TH1F*)fOutput->FindObject("fDCALc"))->Fill(DCALc);
       fSelMC->Fill(8);
       lc=1;
     }
-
-
-
+    
     Bool_t isHijing = CheckGenerator(HPiAODtrk,d,mcHeader,arrayMC);
     // JJJ - check whether bkg from hijing
     if(lb==0 && !isHijing){
@@ -509,6 +428,7 @@ void AliAnalysisTaskSELbtoLcpi4::FillHistos(AliAODRecoDecayHF3Prong* d,TClonesAr
       delete lbcandProng;
       continue;
     }
+    
     Double_t pionPt=lbcandProng->PtProng(0);
     Double_t pionP=lbcandProng->PProng(0);
     Double_t LcPt=lbcandProng->PtProng(1);
@@ -516,7 +436,7 @@ void AliAnalysisTaskSELbtoLcpi4::FillHistos(AliAODRecoDecayHF3Prong* d,TClonesAr
     ((TH1F*)fOutput->FindObject("fLcPt"))->Fill(LcPt);
     ((TH1F*)fOutput->FindObject("fpionP"))->Fill(pionP);
     //fill not rotated
-    //CRI
+    
     Int_t selectionlb=IsSelectedLbMY(lbcandProng,AliRDHFCuts::kCandidate,lb,0,isHijing);
     if(selectionlb!=0){
       Int_t dgLabelsnr[3];
@@ -528,7 +448,7 @@ void AliAnalysisTaskSELbtoLcpi4::FillHistos(AliAODRecoDecayHF3Prong* d,TClonesAr
       FillLbHistsnr(lbcandProng,lb,mcHeader,arrayMC,HPiAODtrk,d, lc, ev, fIsPromptLc);
     }
     lbcandProng->UnsetOwnPrimaryVtx();
-   
+    
     UInt_t pdgLb[2]={0,0};
     pdgLb[1] = 4122;
     pdgLb[0] = 211;
@@ -540,62 +460,7 @@ void AliAnalysisTaskSELbtoLcpi4::FillHistos(AliAODRecoDecayHF3Prong* d,TClonesAr
     if(TMath::Abs(massLb - massTrueLB)<1.) ((TH1F*)fOutput->FindObject("fMassLbbkg"))->Fill(massLb);
     
     //Add possibility to skip this heavy operation for checks
-    if(fNRotations>0){
-      //Int_t nRot=13.;
-      //if(lbcandProng->Pt()>10.)nRot=20.;
-      TObjArray *tob=GetArrayCandRotated(ev,lbcandProng,arrayMC,fNRotations);
-
-      Int_t candidates = tob->GetEntriesFast();
-
-      for(Int_t ic = 0; ic < candidates; ic++) {
-        AliAODRecoDecayHF2Prong *lb2 =(AliAODRecoDecayHF2Prong*)tob->At(ic);
-        if(!lb2){
-          delete lb2;
-          continue;
-        }
-        lb2->SetOwnPrimaryVtx(fvtx1);
-
-        Double_t pionPt2=lb2->PtProng(0);
-        Double_t pionP2=lb2->PProng(0);
-        Double_t LcPt2=lb2->PtProng(1);
-
-        ((TH1F*)fOutput->FindObject("fpionPt2"))->Fill(pionPt2);
-        ((TH1F*)fOutput->FindObject("fLcPt2"))->Fill(LcPt2);
-        ((TH1F*)fOutput->FindObject("fpionP2"))->Fill(pionP2);
-        //   if(lb2->PtProng(1)<0.3){
-        //cout << " *** Track Rejected *** " << endl;
-        //   lb2->UnsetOwnPrimaryVtx();
-        //   delete lb2;
-        //   continue;
-        // }
-        Double_t    massLb2 = lb2->InvMass(2,pdgLb2);
-        if(TMath::Abs(massLb2 - massTrueLB)<1.)((TH1F*)fOutput->FindObject("fMassLb2bkg"))->Fill(massLb2);
-        Int_t selectionlbR=IsSelectedLbMY(lb2,AliRDHFCuts::kCandidate,lb,1,isHijing);//analysis cut Lb --> to be improved
-        if(selectionlbR==0){
-          lb2->UnsetOwnPrimaryVtx();
-          delete lb2;
-          continue;
-        }
-
-
-        Int_t dgLabels[3];
-        for(Int_t i=0; i<3; i++) {
-          AliAODTrack *trk = (AliAODTrack*)d->GetDaughter(i);
-           dgLabels[i] = trk->GetLabel();
-        }
-        Int_t LabelPion= HPiAODtrk->GetLabel();
-        // if(CountLc(d,HPiAODtrk,arrayMC,labPi2,labLb))countLc++;
-        FillLbHists(lb2,lb,mcHeader,arrayMC,HPiAODtrk,d, lc, ev, fIsPromptLc);
-
-        //cout << "__________________________________________*Done*__________________________________________" << endl;
-        lb2->UnsetOwnPrimaryVtx();
-        delete lb2;
-      }//loop on candidates lb2
-    
-      if(lbcandProng){
-        lbcandProng->UnsetOwnPrimaryVtx();
-      }
-    }
+    if(fNRotations>0) DoRotations(ev,lbcandProng,d,HPiAODtrk,fNRotations,isHijing,lb,arrayMC,mcHeader);
     
     HPiAODtrk=0;
     delete chargedHPi;
@@ -604,14 +469,12 @@ void AliAnalysisTaskSELbtoLcpi4::FillHistos(AliAODRecoDecayHF3Prong* d,TClonesAr
     if(vtxAODNew){delete vtxAODNew;vtxAODNew=NULL;}
     if(lbcandProng)delete lbcandProng;
   }//loop on pion tracks
-  // if(countLc>0) fCountLc->Fill(countLc); 
+
   delete LcCand;
   PostData(1,fOutput);
-
+  
   return;
-
 }
-
 
 void AliAnalysisTaskSELbtoLcpi4::UserCreateOutputObjects()
 {
@@ -620,12 +483,10 @@ void AliAnalysisTaskSELbtoLcpi4::UserCreateOutputObjects()
   AliAnalysisManager *man    = AliAnalysisManager::GetAnalysisManager();
   AliInputEventHandler* inputHandler = (AliInputEventHandler*) (man->GetInputEventHandler());
   if (!inputHandler) return;
-
-
+  
   fPIDResponse      = inputHandler->GetPIDResponse();
   if(!fPIDResponse) AliFatal("PID response not found.");
-
-
+  
   if(fRDCutsProductionLb->GetIsUsePID()){
     fRDCutsProductionLb->GetPidHF()->SetPidResponse(fPIDResponse);
     fRDCutsProductionLb->GetPidpion()->SetPidResponse(fPIDResponse);
@@ -642,14 +503,12 @@ void AliAnalysisTaskSELbtoLcpi4::UserCreateOutputObjects()
     fRDCutsAnalysisLc->GetPidpion()->SetOldPid(kFALSE);
     fRDCutsAnalysisLc->GetPidprot()->SetOldPid(kFALSE);
   }
-
-
-
+  
   //
   fOutput = new TList();
   fOutput->SetOwner();
   fOutput->SetName("Histos");
-
+  
   fInvMassLbSign0 = new TH1F("fMassLbSign0", "Lb signal invariant mass 0 ; M [GeV]; Entries",20000,5.641-1.,5.641+1.);
   fInvMassLbSign1 = new TH1F("fMassLbSign1", "Lb signal invariant mass 1; M [GeV]; Entries",20000,5.641-1.,5.641+1.);
   fInvMassLbSign2 = new TH1F("fMassLbSign2", "Lb signal invariant mass 2; M [GeV]; Entries",20000,5.641-1.,5.641+1.);
@@ -662,17 +521,10 @@ void AliAnalysisTaskSELbtoLcpi4::UserCreateOutputObjects()
   fOutput->Add(fInvMassLbSign3);
   fOutput->Add(fInvMassLbSign4);
   fOutput->Add(fInvMassLbSign5);
-
-    fNtupleLambdabUPG = new TNtuple("fNtupleLambdabUPG"," Lb ","massCand:ptLb:pt_Prong0:pt_Prong1:d0_Prong1:d0_Prong0:cosThetaStar:Ct:Prodd0:cosp:cospXY:NormDL:ImpPar:dca:signal:rotated:ptLc:d0_Prong0Lc:d0_Prong1Lc:d0_Prong2Lc:pt_Prong0Lc:pt_Prong1Lc:pt_Prong2Lc:dist12Lc:sigmavertLc:distprimsecLc:costhetapointLc:dcaLc:signalLc:promptLc");
+  
+  fNtupleLambdabUPG = new TNtuple("fNtupleLambdabUPG"," Lb ","massCand:ptLb:pt_Prong0:pt_Prong1:d0_Prong1:d0_Prong0:cosThetaStar:Ct:Prodd0:cosp:cospXY:NormDL:ImpPar:dca:signal:rotated:ptLc:d0_Prong0Lc:d0_Prong1Lc:d0_Prong2Lc:pt_Prong0Lc:pt_Prong1Lc:pt_Prong2Lc:dist12Lc:sigmavertLc:distprimsecLc:costhetapointLc:dcaLc:signalLc:promptLc");
   PostData(2,fNtupleLambdabUPG);
-
-  /*fNtupleLambdacUPG = new TNtuple("fNtupleLambdacUPG"," Lc ","ptLc:d0_Prong0:d0_Prong1:d0_Prong2:pt_Prong0:pt_Prong1:pt_Prong2:dist12:sigmavert:distprimsec:costhetapoint:dca:signal");
-  PostData(3,fNtupleLambdacUPG);
-   */
-//  fNtupleDiffD0rot = new TNtuple("fNtupleDiffD0rot"," diff d0 rot vs angle ","d0_1:d0_2:d0_3:d0_4:d0_5:d0_6:d0_7:d0_8:d0_9:d0_10:d0_11:d0_12:d0_13");
-//  PostData(7,fNtupleDiffD0rot);
-
-
+  
   fSelMC = new TH1I("trackSelMC", "SelMC",9,-0.5,8.5);
   fSelMC->GetXaxis()->SetBinLabel(1,"is lc from MTMC");
   fSelMC->GetXaxis()->SetBinLabel(2,"sel lab is negative ") ;
@@ -684,41 +536,38 @@ void AliAnalysisTaskSELbtoLcpi4::UserCreateOutputObjects()
   fSelMC->GetXaxis()->SetBinLabel(8,"lb in lc e pions");
   fSelMC->GetXaxis()->SetBinLabel(9," lc e pions same label");
   fOutput->Add(fSelMC);
-
-
-
+  
   fCountLc = new TH1I("countLc for background","count Lc for background",500,0,499);
   fOutput->Add(fCountLc);
-
+  
   TH1F *fMassUpg_pt0=new TH1F("fMassUpg_pt0","fMassUpg_pt0",100,2.086,2.486);
   TH1F *fMassUpg_pt1=new TH1F("fMassUpg_pt1","fMassUpg_pt1",100,2.086,2.486);
   TH1F *fMassUpg_pt2=new TH1F("fMassUpg_pt2","fMassUpg_pt2",100,2.086,2.486);
   TH1F *fMassUpg_pt3=new TH1F("fMassUpg_pt3","fMassUpg_pt3",100,2.086,2.486);
   TH1F *fMassUpg_pt4=new TH1F("fMassUpg_pt4","fMassUpg_pt4",100,2.086,2.486);
   TH1F *fMassUpg_pt5=new TH1F("fMassUpg_pt5","fMassUpg_pt5",100,2.086,2.486);
-
+  
   fOutput->Add(fMassUpg_pt0);
   fOutput->Add(fMassUpg_pt1);
   fOutput->Add(fMassUpg_pt2);
   fOutput->Add(fMassUpg_pt3);
   fOutput->Add(fMassUpg_pt4);
   fOutput->Add(fMassUpg_pt5);
-
+  
   TH1F *fMassUpg_pt0lcb=new TH1F("fMassUpg_pt0lbNR","fMassUpg_pt0lbNR",20000,5.641-1.,5.641+1.);
   TH1F *fMassUpg_pt1lcb=new TH1F("fMassUpg_pt1lbNR","fMassUpg_pt1lbNR",20000,5.641-1.,5.641+1.);
   TH1F *fMassUpg_pt2lcb=new TH1F("fMassUpg_pt2lbNR","fMassUpg_pt2lbNR",20000,5.641-1.,5.641+1.);
   TH1F *fMassUpg_pt3lcb=new TH1F("fMassUpg_pt3lbNR","fMassUpg_pt3lbNR",20000,5.641-1.,5.641+1.);
   TH1F *fMassUpg_pt4lcb=new TH1F("fMassUpg_pt4lbNR","fMassUpg_pt4lbNR",20000,5.641-1.,5.641+1.);
   TH1F *fMassUpg_pt5lcb=new TH1F("fMassUpg_pt5lbNR","fMassUpg_pt5lbNR",20000,5.641-1.,5.641+1.);
-
+  
   fOutput->Add(fMassUpg_pt0lcb);
   fOutput->Add(fMassUpg_pt1lcb);
   fOutput->Add(fMassUpg_pt2lcb);
   fOutput->Add(fMassUpg_pt3lcb);
   fOutput->Add(fMassUpg_pt4lcb);
   fOutput->Add(fMassUpg_pt5lcb);
-
-
+  
   TH1F *fMassUpg_pt0lb=new TH1F("fMassUpg_pt0lb","fMassUpg_pt0lb",20000,5.641-1.,5.641+1.);
   TH1F *fMassUpg_pt1lb=new TH1F("fMassUpg_pt1lb","fMassUpg_pt1lb",20000,5.641-1.,5.641+1.);
   TH1F *fMassUpg_pt2lb=new TH1F("fMassUpg_pt2lb","fMassUpg_pt2lb",20000,5.641-1.,5.641+1.);
@@ -731,39 +580,35 @@ void AliAnalysisTaskSELbtoLcpi4::UserCreateOutputObjects()
   fOutput->Add(fMassUpg_pt3lb);
   fOutput->Add(fMassUpg_pt4lb);
   fOutput->Add(fMassUpg_pt5lb);
-
-
+  
   TH1F *fMassUpg_pt0lbbgOnly=new TH1F("fMassUpg_pt0lbbgOnly","fMassUpg_pt0lbbgOnly",20000,4.641,6.641);
   TH1F *fMassUpg_pt1lbbgOnly=new TH1F("fMassUpg_pt1lbbgOnly","fMassUpg_pt1lbbgOnly",20000,4.641,6.641);
   TH1F *fMassUpg_pt2lbbgOnly=new TH1F("fMassUpg_pt2lbbgOnly","fMassUpg_pt2lbbgOnly",20000,4.641,6.641);
   TH1F *fMassUpg_pt3lbbgOnly=new TH1F("fMassUpg_pt3lbbgOnly","fMassUpg_pt3lbbgOnly",20000,4.641,6.641);
   TH1F *fMassUpg_pt4lbbgOnly=new TH1F("fMassUpg_pt4lbbgOnly","fMassUpg_pt4lbbgOnly",20000,4.641,6.641);
   TH1F *fMassUpg_pt5lbbgOnly=new TH1F("fMassUpg_pt5lbbgOnly","fMassUpg_pt5lbbgOnly",20000,4.641,6.641);
-
+  
   fOutput->Add(fMassUpg_pt0lbbgOnly);
   fOutput->Add(fMassUpg_pt1lbbgOnly);
   fOutput->Add(fMassUpg_pt2lbbgOnly);
   fOutput->Add(fMassUpg_pt3lbbgOnly);
   fOutput->Add(fMassUpg_pt4lbbgOnly);
   fOutput->Add(fMassUpg_pt5lbbgOnly);
-
+  
   TH1F *fMassUpg_pt0lbbg=new TH1F("fMassUpg_pt0lbbgNR","fMassUpg_pt0lbbgNR",20000,5.641-1.,5.641+1.);
   TH1F *fMassUpg_pt1lbbg=new TH1F("fMassUpg_pt1lbbgNR","fMassUpg_pt1lbbgNR",20000,5.641-1.,5.641+1.);
   TH1F *fMassUpg_pt2lbbg=new TH1F("fMassUpg_pt2lbbgNR","fMassUpg_pt2lbbgNR",20000,5.641-1.,5.641+1.);
   TH1F *fMassUpg_pt3lbbg=new TH1F("fMassUpg_pt3lbbgNR","fMassUpg_pt3lbbgNR",20000,5.641-1.,5.641+1.);
   TH1F *fMassUpg_pt4lbbg=new TH1F("fMassUpg_pt4lbbgNR","fMassUpg_pt4lbbgNR",20000,5.641-1.,5.641+1.);
   TH1F *fMassUpg_pt5lbbg=new TH1F("fMassUpg_pt5lbbgNR","fMassUpg_pt5lbbgNR",20000,5.641-1.,5.641+1.);
-
+  
   fOutput->Add(fMassUpg_pt0lbbg);
   fOutput->Add(fMassUpg_pt1lbbg);
   fOutput->Add(fMassUpg_pt2lbbg);
   fOutput->Add(fMassUpg_pt3lbbg);
   fOutput->Add(fMassUpg_pt4lbbg);
   fOutput->Add(fMassUpg_pt5lbbg);
-
-
-
-
+  
   //
   // JJJ histograms for signal and background
   //
@@ -803,46 +648,6 @@ void AliAnalysisTaskSELbtoLcpi4::UserCreateOutputObjects()
   fOutput->Add(fMassSig_pt3lb_NoCuts);
   fOutput->Add(fMassSig_pt4lb_NoCuts);
   fOutput->Add(fMassSig_pt5lb_NoCuts);
-//  //BDT histograms
-//  // comment out for now
-//  TH2F *fMassBkg_pt0lb_BDT=new TH2F("fMassBkg_pt0lb_BDT","fMassBkg_pt0lb_BDT",2000,-1,1,2000,5.641-1.,5.641+1.);
-//  TH2F *fMassBkg_pt1lb_BDT=new TH2F("fMassBkg_pt1lb_BDT","fMassBkg_pt1lb_BDT",2000,-1,1,2000,5.641-1.,5.641+1.);
-//  TH2F *fMassBkg_pt2lb_BDT=new TH2F("fMassBkg_pt2lb_BDT","fMassBkg_pt2lb_BDT",2000,-1,1,2000,5.641-1.,5.641+1.);
-//  TH2F *fMassBkg_pt3lb_BDT=new TH2F("fMassBkg_pt3lb_BDT","fMassBkg_pt3lb_BDT",2000,-1,1,2000,5.641-1.,5.641+1.);
-//  TH2F *fMassBkg_pt4lb_BDT=new TH2F("fMassBkg_pt4lb_BDT","fMassBkg_pt4lb_BDT",2000,-1,1,2000,5.641-1.,5.641+1.);
-//  TH2F *fMassBkg_pt5lb_BDT=new TH2F("fMassBkg_pt5lb_BDT","fMassBkg_pt5lb_BDT",2000,-1,1,2000,5.641-1.,5.641+1.);
-//  fOutput->Add(fMassBkg_pt0lb_BDT);
-//  fOutput->Add(fMassBkg_pt1lb_BDT);
-//  fOutput->Add(fMassBkg_pt2lb_BDT);
-//  fOutput->Add(fMassBkg_pt3lb_BDT);
-//  fOutput->Add(fMassBkg_pt4lb_BDT);
-//  fOutput->Add(fMassBkg_pt5lb_BDT);
-//  TH2F *fMassBkgRot_pt0lb_BDT=new TH2F("fMassBkgRot_pt0lb_BDT","fMassBkgRot_pt0lb_BDT",2000,-1,1,2000,5.641-1.,5.641+1.);
-//  TH2F *fMassBkgRot_pt1lb_BDT=new TH2F("fMassBkgRot_pt1lb_BDT","fMassBkgRot_pt1lb_BDT",2000,-1,1,2000,5.641-1.,5.641+1.);
-//  TH2F *fMassBkgRot_pt2lb_BDT=new TH2F("fMassBkgRot_pt2lb_BDT","fMassBkgRot_pt2lb_BDT",2000,-1,1,2000,5.641-1.,5.641+1.);
-//  TH2F *fMassBkgRot_pt3lb_BDT=new TH2F("fMassBkgRot_pt3lb_BDT","fMassBkgRot_pt3lb_BDT",2000,-1,1,2000,5.641-1.,5.641+1.);
-//  TH2F *fMassBkgRot_pt4lb_BDT=new TH2F("fMassBkgRot_pt4lb_BDT","fMassBkgRot_pt4lb_BDT",2000,-1,1,2000,5.641-1.,5.641+1.);
-//  TH2F *fMassBkgRot_pt5lb_BDT=new TH2F("fMassBkgRot_pt5lb_BDT","fMassBkgRot_pt5lb_BDT",2000,-1,1,2000,5.641-1.,5.641+1.);
-//  fOutput->Add(fMassBkgRot_pt0lb_BDT);
-//  fOutput->Add(fMassBkgRot_pt1lb_BDT);
-//  fOutput->Add(fMassBkgRot_pt2lb_BDT);
-//  fOutput->Add(fMassBkgRot_pt3lb_BDT);
-//  fOutput->Add(fMassBkgRot_pt4lb_BDT);
-//  fOutput->Add(fMassBkgRot_pt5lb_BDT);
-//  TH2F *fMassSig_pt0lb_BDT=new TH2F("fMassSig_pt0lb_BDT","fMassSig_pt0lb_BDT",2000,-1,1,2000,5.641-1.,5.641+1.);
-//  TH2F *fMassSig_pt1lb_BDT=new TH2F("fMassSig_pt1lb_BDT","fMassSig_pt1lb_BDT",2000,-1,1,2000,5.641-1.,5.641+1.);
-//  TH2F *fMassSig_pt2lb_BDT=new TH2F("fMassSig_pt2lb_BDT","fMassSig_pt2lb_BDT",2000,-1,1,2000,5.641-1.,5.641+1.);
-//  TH2F *fMassSig_pt3lb_BDT=new TH2F("fMassSig_pt3lb_BDT","fMassSig_pt3lb_BDT",2000,-1,1,2000,5.641-1.,5.641+1.);
-//  TH2F *fMassSig_pt4lb_BDT=new TH2F("fMassSig_pt4lb_BDT","fMassSig_pt4lb_BDT",2000,-1,1,2000,5.641-1.,5.641+1.);
-//  TH2F *fMassSig_pt5lb_BDT=new TH2F("fMassSig_pt5lb_BDT","fMassSig_pt5lb_BDT",2000,-1,1,2000,5.641-1.,5.641+1.);
-//  fOutput->Add(fMassSig_pt0lb_BDT);
-//  fOutput->Add(fMassSig_pt1lb_BDT);
-//  fOutput->Add(fMassSig_pt2lb_BDT);
-//  fOutput->Add(fMassSig_pt3lb_BDT);
-//  fOutput->Add(fMassSig_pt4lb_BDT);
-//  fOutput->Add(fMassSig_pt5lb_BDT);
-
-
 
   TH1F *fPtBkg = new TH1F("fPtBkg","fPtBkg",100,0.,100.);
   TH1F *fPtBkg_TC = new TH1F("fPtBkg_TC","fPtBkg_TC",100,0.,100.);
@@ -856,10 +661,7 @@ void AliAnalysisTaskSELbtoLcpi4::UserCreateOutputObjects()
   fOutput->Add(fPtBkgRot_TC);
   fOutput->Add(fPtSig);
   fOutput->Add(fPtSig_TC);
-
-
-
-
+  
   TH1F *fMassLbbkg=new TH1F("fMassLbbkg","fMassLbbkg",500,5.641-1.,5.641+1.);
   fOutput->Add(fMassLbbkg);
   TH1F *fMassLb2bkg=new TH1F("fMassLb2bkg","fMassLb2bkg",500,5.641-1.,5.641+1.);
@@ -876,7 +678,7 @@ void AliAnalysisTaskSELbtoLcpi4::UserCreateOutputObjects()
   fOutput->Add(fLcPt2);
   TH1F *fpionP2=new TH1F("fpionP2","fpionP2",100,0.,25.);
   fOutput->Add(fpionP2);
-
+  
   TH1F *fd0Pion=new TH1F("fd0Pion","fd0Pion",100,-1.,1.);
   TH1F *fd0Lc=new TH1F("fd0Lc","fd0Lc",100,-1.,1.);
   TH1F *fDCApion=new TH1F("fDCApion","fDCApion",100,-1.,1.);
@@ -887,11 +689,11 @@ void AliAnalysisTaskSELbtoLcpi4::UserCreateOutputObjects()
   TH1F *fd0Lcprong1=new TH1F("fd0Lcprong1","fd0Lcprong1",100,-0.09,0.09);
   TH1F *fd0Lcprong0Bg=new TH1F("fd0Lcprong0Bg","fd0Lcprong0Bg",100,-0.09,0.09);
   TH1F *fd0Lcprong1Bg=new TH1F("fd0Lcprong1Bg","fd0Lcprong1Bg",100,-0.09,0.09);
-    TH1F *fd0Lcprong0nr=new TH1F("fd0Lcprong0nr","fd0Lcprong0nr",100,-0.09,0.09);
-    TH1F *fd0Lcprong1nr=new TH1F("fd0Lcprong1nr","fd0Lcprong1nr",100,-0.09,0.09);
-    TH1F *fd0Lcprong0Bgnr=new TH1F("fd0Lcprong0Bgnr","fd0Lcprong0Bgnr",100,-0.09,0.09);
-    TH1F *fd0Lcprong1Bgnr=new TH1F("fd0Lcprong1Bgnr","fd0Lcprong1Bgnr",100,-0.09,0.09);
-    
+  TH1F *fd0Lcprong0nr=new TH1F("fd0Lcprong0nr","fd0Lcprong0nr",100,-0.09,0.09);
+  TH1F *fd0Lcprong1nr=new TH1F("fd0Lcprong1nr","fd0Lcprong1nr",100,-0.09,0.09);
+  TH1F *fd0Lcprong0Bgnr=new TH1F("fd0Lcprong0Bgnr","fd0Lcprong0Bgnr",100,-0.09,0.09);
+  TH1F *fd0Lcprong1Bgnr=new TH1F("fd0Lcprong1Bgnr","fd0Lcprong1Bgnr",100,-0.09,0.09);
+  
   fOutput->Add(fd0Pion);
   fOutput->Add(fd0Lc);
   fOutput->Add(fDCApion);
@@ -902,11 +704,11 @@ void AliAnalysisTaskSELbtoLcpi4::UserCreateOutputObjects()
   fOutput->Add(fd0Lcprong1);
   fOutput->Add(fd0Lcprong0Bg);
   fOutput->Add(fd0Lcprong1Bg);
-    fOutput->Add(fd0Lcprong0nr);
-    fOutput->Add(fd0Lcprong1nr);
-    fOutput->Add(fd0Lcprong0Bgnr);
-    fOutput->Add(fd0Lcprong1Bgnr);
-
+  fOutput->Add(fd0Lcprong0nr);
+  fOutput->Add(fd0Lcprong1nr);
+  fOutput->Add(fd0Lcprong0Bgnr);
+  fOutput->Add(fd0Lcprong1Bgnr);
+  
   fHistNEvents = new TH1F("fHistNEvents", "number of events ",6,-0.5,5.5);
   fHistNEvents->GetXaxis()->SetBinLabel(1,"nEventsAnal");
   fHistNEvents->GetXaxis()->SetBinLabel(2,"n lc");
@@ -918,8 +720,7 @@ void AliAnalysisTaskSELbtoLcpi4::UserCreateOutputObjects()
   fHistNEvents->Sumw2();
   fHistNEvents->SetMinimum(0);
   fOutput->Add(fHistNEvents);
-
-
+  
   fHistNEventsCuts = new TH1F("fHistNEventsCuts", "pass cuts ",14,-0.5,13.5);
   fHistNEventsCuts->GetXaxis()->SetBinLabel(1,"pt inf prong 0");
   fHistNEventsCuts->GetXaxis()->SetBinLabel(2,"pt inf prong 1");
@@ -939,7 +740,7 @@ void AliAnalysisTaskSELbtoLcpi4::UserCreateOutputObjects()
   fHistNEventsCuts->Sumw2();
   fHistNEventsCuts->SetMinimum(0);
   fOutput->Add(fHistNEventsCuts);
-
+  
   fHistNEventsCutsLb= new TH1F("fHistNEventsCutsLb", "pass cuts Lb ",14,-0.5,13.5);
   fHistNEventsCutsLb->GetXaxis()->SetBinLabel(1,"pt inf prong 0");
   fHistNEventsCutsLb->GetXaxis()->SetBinLabel(2,"pt inf prong 1");
@@ -961,27 +762,7 @@ void AliAnalysisTaskSELbtoLcpi4::UserCreateOutputObjects()
   fOutput->Add(fHistNEventsCutsLb);
   PostData(1,fOutput);
 
-//  TString inputVariables = "Ptp,PtK,Ptpi,CosP,DecayL,Dist12Min,SigVert,DCAMax";
-//  AliInfo(Form("adding variables %s to reader",inputVariables.Data()));
-//  TObjArray *tokens = inputVariables.Tokenize(",");
-//  tokens->Print();
-//  std::vector<std::string> inputNamesVec;
-//  for(Int_t i=0; i<tokens->GetEntries(); i++) {
-//    TString variable = ((TObjString*)(tokens->At(i)))->String();
-//    AliInfo(Form("* * * added %s to vector",variable.Data()));
-//    string tmpvar = variable.Data();
-//    inputNamesVec.push_back(tmpvar);
-//  }
-//  fBDTReader[0]= new ReadBDT_pt4to7( inputNamesVec );
-//  fBDTReader[1]= new ReadBDT_pt7to10( inputNamesVec );
-//  fBDTReader[2]= new ReadBDT_pt10to14( inputNamesVec );
-//  fBDTReader[3]= new ReadBDT_pt14to9999( inputNamesVec );
-//  AliInfo("* * * Created BDT reader");
-
-
-
   return;
-
 }
 
 //_____________________________________________
@@ -997,33 +778,31 @@ void AliAnalysisTaskSELbtoLcpi4::Terminate(Option_t */*option*/)
     printf("ERROR: fOutput not available\n");
     return;
   }
-
+  
   return;
 }
+
 //------------------------------------------------------------------------
 void AliAnalysisTaskSELbtoLcpi4::FillLbHists(AliAODRecoDecayHF2Prong *part,Int_t lb,AliAODMCHeader *mcHeader,TClonesArray* arrayMC, AliAODTrack *pion,AliAODRecoDecayHF3Prong *d, Int_t lc, AliAODEvent *ev, Bool_t IsPromptLc){
-  //ptlb cut
+
   Int_t promptLc=0;
   if (IsPromptLc) promptLc=1;
   Bool_t gen = CheckGenerator(pion,d,mcHeader,arrayMC);
+
   Double_t massTrueLB = 5.641;
-  Double_t massCandLb = 0;
-  UInt_t pdgLb[2]={0,0};
-  //lc always at first place
-  pdgLb[1] = 4122;//lambdac
-  pdgLb[0] = 211;//pion
-  massCandLb = part->InvMass(2,pdgLb);
+  UInt_t pdgLb[2]={211,4122};
+  Double_t massCandLb = part->InvMass(2,pdgLb);
   if(TMath::Abs(massCandLb - massTrueLB)>1.) return;
+  
   Int_t iPtBinlb = -1;
   Double_t ptCandlb = part->Pt();
-  //if(ptCandlb<2.) return; // dont save anything with pt<2 //old configuration
   if(ptCandlb>0. && ptCandlb<2.) iPtBinlb=0;
   if(ptCandlb>=2. && ptCandlb<4.) iPtBinlb=1;
   if(ptCandlb>=4. && ptCandlb<7.) iPtBinlb=2;
   if(ptCandlb>=7. && ptCandlb<10.) iPtBinlb=3;
   if(ptCandlb>10. && ptCandlb<14.) iPtBinlb=4;
   if(ptCandlb>=14.) iPtBinlb=5;
-
+  
   //fill ntuple
   Float_t lbVarC[30] = {0};
   lbVarC[0] = massCandLb;
@@ -1033,7 +812,7 @@ void AliAnalysisTaskSELbtoLcpi4::FillLbHists(AliAODRecoDecayHF2Prong *part,Int_t
   lbVarC[4] = part->Getd0Prong(1);
   lbVarC[5] = part->Getd0Prong(0);
   lbVarC[6] = part->CosThetaStar(0,5122,4122,211);
-  lbVarC[7] = part->Ct(5122); 
+  lbVarC[7] = part->Ct(5122);
   lbVarC[8] = part->Prodd0d0();
   lbVarC[9] = part->CosPointingAngle();
   lbVarC[10] = part->CosPointingAngleXY();
@@ -1056,7 +835,7 @@ void AliAnalysisTaskSELbtoLcpi4::FillLbHists(AliAODRecoDecayHF2Prong *part,Int_t
   lbVarC[27] = d->GetDCA();
   lbVarC[28] = lc;
   lbVarC[29] = promptLc;
-
+  
   if(lb==1){ //
     if(iPtBinlb==0)((TH1F*)fOutput->FindObject("fMassUpg_pt0lb"))->Fill(massCandLb);
     if(iPtBinlb==1)((TH1F*)fOutput->FindObject("fMassUpg_pt1lb"))->Fill(massCandLb);
@@ -1064,10 +843,9 @@ void AliAnalysisTaskSELbtoLcpi4::FillLbHists(AliAODRecoDecayHF2Prong *part,Int_t
     if(iPtBinlb==3)((TH1F*)fOutput->FindObject("fMassUpg_pt3lb"))->Fill(massCandLb);
     if(iPtBinlb==4)((TH1F*)fOutput->FindObject("fMassUpg_pt4lb"))->Fill(massCandLb);
     if(iPtBinlb==5)((TH1F*)fOutput->FindObject("fMassUpg_pt5lb"))->Fill(massCandLb);
-      
-      
+    
     // note - don't fill rotated signal (not needed)
-    }
+  }
   if(lb!=1){
     if(gen){
       cout << " gen " << gen << endl;
@@ -1077,18 +855,18 @@ void AliAnalysisTaskSELbtoLcpi4::FillLbHists(AliAODRecoDecayHF2Prong *part,Int_t
       if(iPtBinlb==3)((TH1F*)fOutput->FindObject("fMassUpg_pt3lbbgOnly"))->Fill(massCandLb);
       if(iPtBinlb==4)((TH1F*)fOutput->FindObject("fMassUpg_pt4lbbgOnly"))->Fill(massCandLb);
       if(iPtBinlb==5)((TH1F*)fOutput->FindObject("fMassUpg_pt5lbbgOnly"))->Fill(massCandLb);
-        
-        if(fFillNtupleBackgroundRotated) {
+      
+      if(fFillNtupleBackgroundRotated) {
         fNtupleLambdabUPG->Fill(lbVarC);
-        PostData(2,fNtupleLambdabUPG); 
+        PostData(2,fNtupleLambdabUPG);
       }
     }
   }
-
+  
   return;
-
+  
 }
-//
+
 //-----------------------------------------------------------------------------
 AliAODVertex* AliAnalysisTaskSELbtoLcpi4::ReconstructSecondaryVertex(TObjArray *trkArray,Double_t &dispersion,Bool_t useTRefArray) const {
   // Secondary vertex reconstruction with AliVertexerTracks or AliKFParticle
@@ -1101,16 +879,16 @@ AliAODVertex* AliAnalysisTaskSELbtoLcpi4::ReconstructSecondaryVertex(TObjArray *
   vertexer->SetVtxStart((AliESDVertex*)fvtx1);//primary vertex
   vertexESD = (AliESDVertex*)vertexer->VertexForSelectedESDTracks(trkArray);
   delete vertexer; vertexer=NULL;
-
+  
   if(!vertexESD) return vertexAOD;
-
+  
   if(vertexESD->GetNContributors()!=trkArray->GetEntriesFast()) {
     //AliDebug(2,"vertexing failed"); i
     //cout<< " vertex failed " << endl;
     delete vertexESD; vertexESD=NULL;
     return vertexAOD;
   }
-
+  
   Double_t vertRadius2=vertexESD->GetX()*vertexESD->GetX()+vertexESD->GetY()*vertexESD->GetY();
   if(vertRadius2>8.){//(2.82)^2 radius beam pipe
     //clout<<"  // vertex outside beam pipe, reject candidate to avoid propagation through material "<< endl;
@@ -1142,13 +920,13 @@ void AliAnalysisTaskSELbtoLcpi4::AddDaughterRefs(AliAODVertex *v, const AliVEven
   TObject *dg = 0;
   if(nDg) dg = v->GetDaughter(0);
   if(dg) return; // daughters already added
-
+  
   Int_t nTrks = trkArray->GetEntriesFast();
-
+  
   AliExternalTrackParam *track = 0;
   AliAODTrack *aodTrack = 0;
   Int_t id;
-
+  
   for(Int_t i=0; i<nTrks; i++) {
     track = (AliExternalTrackParam*)trkArray->UncheckedAt(i);
     id = (Int_t)track->GetID();
@@ -1214,7 +992,7 @@ Int_t AliAnalysisTaskSELbtoLcpi4::CheckMCLc(AliAODRecoDecayHF3Prong *d,TClonesAr
   Int_t iPtBinl = -1;
   if(pdgsl[0]==211 && pdgsl[1]==321 && pdgsl[2]==2212) massl=d->InvMassLcpiKp();
   if(pdgsl[0]==2212 && pdgsl[1]==321 && pdgsl[2]==211) massl=d->InvMassLcpKpi();
-
+  
   Double_t ptCandl = d->Pt();
   
   if(ptCandl<2.) iPtBinl=0;
@@ -1223,9 +1001,7 @@ Int_t AliAnalysisTaskSELbtoLcpi4::CheckMCLc(AliAODRecoDecayHF3Prong *d,TClonesAr
   if(ptCandl>6. && ptCandl<14.) iPtBinl=3;
   if(ptCandl>6. && ptCandl<14.) iPtBinl=3;
   if(ptCandl>14.)iPtBinl=4;
-
-
-
+  
   fSelMC->Fill(0);// from MC if label particle is positive
   //in match to mc lc return 0 is not  lambdac
   if(labDpL<0){
@@ -1250,12 +1026,12 @@ Int_t AliAnalysisTaskSELbtoLcpi4::CheckMCLc(AliAODRecoDecayHF3Prong *d,TClonesAr
         Int_t pdgcode0=TMath::Abs(part0dLb->GetPdgCode());
         Int_t pdgcode1=TMath::Abs(part1dLb->GetPdgCode());
         fSelMC->Fill(6);//if lb has 2 daught
-        if((pdgcode0==4122 && pdgcode1==211) || (pdgcode1==4122 && pdgcode0==211)){ 
+        if((pdgcode0==4122 && pdgcode1==211) || (pdgcode1==4122 && pdgcode0==211)){
           if(labDpL<0){
             fSelMC->Fill(1);// from MC if label particle is positive
             return 999;//
           }else{
-            fSelMC->Fill(7);  
+            fSelMC->Fill(7);
             if(iPtBinl==0)((TH1F*)fOutput->FindObject("fMassUpg_pt0"))->Fill(massl);
             if(iPtBinl==1)((TH1F*)fOutput->FindObject("fMassUpg_pt1"))->Fill(massl);
             if(iPtBinl==2)((TH1F*)fOutput->FindObject("fMassUpg_pt2"))->Fill(massl);
@@ -1273,10 +1049,10 @@ Int_t AliAnalysisTaskSELbtoLcpi4::CheckMCLc(AliAODRecoDecayHF3Prong *d,TClonesAr
 Bool_t AliAnalysisTaskSELbtoLcpi4::CheckGenerator(AliAODTrack *p, AliAODRecoDecayHF3Prong *d, AliAODMCHeader *mcHeader,TClonesArray* arrayMC){
   Bool_t LcNotHijing;
   Bool_t pionNotHijing;
-  LcNotHijing=IsCandidateInjected(d, mcHeader,arrayMC); 
+  LcNotHijing=IsCandidateInjected(d, mcHeader,arrayMC);
   pionNotHijing=IsTrackInjected(p,mcHeader,arrayMC);
   //cout << " LcNotHijing "<< LcNotHijing << " pionNotHijing " << pionNotHijing << endl;
-  if(!LcNotHijing && !pionNotHijing) return kTRUE; 
+  if(!LcNotHijing && !pionNotHijing) return kTRUE;
   else return kFALSE;
 }
 //__________________________________________________________________________
@@ -1297,7 +1073,7 @@ Int_t AliAnalysisTaskSELbtoLcpi4::IsSelectedLbMY(TObject* obj,Int_t selectionLev
   UInt_t pdgLb[2]={0,0};
   pdgLb[0] = 211;//lambdac
   pdgLb[1] = 4122;//pion
-
+  
   //
   Int_t iPtBinlb = -1;
   Float_t lbVar[14];
@@ -1309,25 +1085,24 @@ Int_t AliAnalysisTaskSELbtoLcpi4::IsSelectedLbMY(TObject* obj,Int_t selectionLev
   if(ptCandlb>=7. && ptCandlb<10.) iPtBinlb=3;
   if(ptCandlb>=10. && ptCandlb<14.) iPtBinlb=4;
   if(ptCandlb>=14.) iPtBinlb=5;
+  
   Float_t cutV[6][22]=
-    //0,   1     2      3       4      5    6     7      8     9       10    11    12   13        14      15     16     17         18       19     20     21
-    //M, ptp0<, ptp1<, ptp0>, ptp1>, d0p1>,d0p1<,d0p0>,d0p0<,cosTSt<,cosTSt>,ct<, ct>,prodd0d0>,prodd0d0<,cosp>,cospXY<,normDLXY>,normDLXY<,dca>, dca<, ImpParXY>
-/*  {{1., 0.,  0.,     0.,     0.,   0.,     0.,   0.,   0.,   0.,     0.,     0.,  0.,   0.,        0.,   0.,    0.,     0.,       0.,        0., 0.,    0.},
-    {1., 0.,  0.,     0.,     0.,   0.,     0.,   0.,   0.,   0.,     0.,     0.,  0.,   0.,        0.,   0.,    0.,     0.,       0.,        0., 0.,    0.},
-    {1.,1.1,  3.,     5.,    7.5, 0.04,  0.004, 999.,0.002,  -1.,    0.6,   0.02, 0.175, 0.,      -999, 0.9967,  0.998,  13.6,    1.3, 0.0045,0.00009,  26.},//4-7
-    {1.,2. ,  3.,     6.,     8.,  999, 0.0045, 999.,0.0055,-0.6,     1.,  0.015, 9999.,-0.00004, -999,  0.998,  0.999,  13.5,     1.,0.00333,0.00005,18.},//7-10
-    {1.,1. , 2.5,    14.,    22., 0.04,  0.002, 0.08,0.003, -0.7,   1.4,  -999,   0.08,-0.03*1e-3,-999, 0.998,  0.998,  14.,      0.2,  9999, -9999,   22.},//10-14
-    {1.,2. ,  6.,    14.,    22., 0.04,  0.0005, 0.08,0.001, -0.6,   1. ,  0.0018, 9999., 0.,      -0.003,0.998, 0.9993,  14.,      0.3, 0.015,-9999.,  20.}};//>14
+  //0,   1     2      3       4      5    6     7      8     9       10    11    12   13        14      15     16     17         18       19     20     21
+  //M, ptp0<, ptp1<, ptp0>, ptp1>, d0p1>,d0p1<,d0p0>,d0p0<,cosTSt<,cosTSt>,ct<, ct>,prodd0d0>,prodd0d0<,cosp>,cospXY<,normDLXY>,normDLXY<,dca>, dca<, ImpParXY>
+  /*  {{1., 0.,  0.,     0.,     0.,   0.,     0.,   0.,   0.,   0.,     0.,     0.,  0.,   0.,        0.,   0.,    0.,     0.,       0.,        0., 0.,    0.},
+   {1., 0.,  0.,     0.,     0.,   0.,     0.,   0.,   0.,   0.,     0.,     0.,  0.,   0.,        0.,   0.,    0.,     0.,       0.,        0., 0.,    0.},
+   {1.,1.1,  3.,     5.,    7.5, 0.04,  0.004, 999.,0.002,  -1.,    0.6,   0.02, 0.175, 0.,      -999, 0.9967,  0.998,  13.6,    1.3, 0.0045,0.00009,  26.},//4-7
+   {1.,2. ,  3.,     6.,     8.,  999, 0.0045, 999.,0.0055,-0.6,     1.,  0.015, 9999.,-0.00004, -999,  0.998,  0.999,  13.5,     1.,0.00333,0.00005,18.},//7-10
+   {1.,1. , 2.5,    14.,    22., 0.04,  0.002, 0.08,0.003, -0.7,   1.4,  -999,   0.08,-0.03*1e-3,-999, 0.998,  0.998,  14.,      0.2,  9999, -9999,   22.},//10-14
+   {1.,2. ,  6.,    14.,    22., 0.04,  0.0005, 0.08,0.001, -0.6,   1. ,  0.0018, 9999., 0.,      -0.003,0.998, 0.9993,  14.,      0.3, 0.015,-9999.,  20.}};//>14
    // {1.,2. ,  6.,    14.,    22., 0.04,  0.0005, 0.08,0.001, -0.6,   1. ,  0.002, 0.08, 0.,      -0.003,0.998, 0.9993,  14.,      0.3, 0.015,-9999.,  20.}};//>14*/
- {{1., 0.,  0.,   999., 999., 999.,-999.,999.,-999.,         -10., 10.,  0.005, 999.,   0.     -999, 0.96,    0.96,        999., 0.5, 0.008,  0., 50.},
+  {{1., 0.,  0.,   999., 999., 999.,-999.,999.,-999.,         -10., 10.,  0.005, 999.,   0.     -999, 0.96,    0.96,        999., 0.5, 0.008,  0., 50.},
     {1., 0.,  0.,  999., 999., 999.,-999.,999.,-999.,         -10., 10.,  0.005, 999.,   0.,    -999, 0.96,    0.96,        999., 0.5, 0.008,  0., 50.},
     {1.,0.,  0.,   999., 999., 999.,-999.,999.,-999.,        -10.,  10.,  0.005, 999.,   0.,    -999, 0.96,    0.96,        999., 0.5, 0.008,  0., 50.},//4-7
-   {1.,0. ,  0.,  999., 999., 999.,-999.,999.,-999.,       -10,    10.,  0.005, 999.,   0.,    -999, 0.96,    0.96,        999., 0.5, 0.008,  0., 50.},//7-10
+    {1.,0. ,  0.,  999., 999., 999.,-999.,999.,-999.,       -10,    10.,  0.005, 999.,   0.,    -999, 0.96,    0.96,        999., 0.5, 0.008,  0., 50.},//7-10
     {1.,0. , 0.,   999., 999., 999.,-999.,999.,-999.,       -10,    10.,  0.005, 999.,   0.,    -999, 0.96,    0.96,        999., 0.5, 0.008,  0., 50.},//10-14
     {1.,0. ,  0.,  999., 999., 999.,-999.,999.,-999.,        -10,   10.,  0.005, 999.,   0.,    -999, 0.96,    0.96,        999., 0.5, 0.008,  0., 50.}};//>14
- 
-
-
+  
   massCandLb = dd->InvMass(2,pdgLb);
   if(TMath::Abs(massCandLb - massTrueLB)>cutV[iPtBinlb][0]){
     cut=0;
@@ -1350,120 +1125,102 @@ Int_t AliAnalysisTaskSELbtoLcpi4::IsSelectedLbMY(TObject* obj,Int_t selectionLev
   if(dd->PtProng(1) > cutV[iPtBinlb][4]) {
     fHistNEventsCuts->Fill(3);
     if(lb==1)fHistNEventsCutsLb->Fill(3);
-    cut = 0;}
-
-
-    if(TMath::Abs(dd->Getd0Prong(1)) > cutV[iPtBinlb][5] || TMath::Abs(dd->Getd0Prong(1)) < cutV[iPtBinlb][6]){ 
-      fHistNEventsCuts->Fill(5);
-      if(lb==1)fHistNEventsCutsLb->Fill(5);
-      cut = 0;
-    } 
-
-    if(TMath::Abs(dd->Getd0Prong(0)) > cutV[iPtBinlb][7] || TMath::Abs(dd->Getd0Prong(0)) < cutV[iPtBinlb][8]){
-      fHistNEventsCuts->Fill(4);
-      if(lb==1)fHistNEventsCutsLb->Fill(4);
-      cut = 0;
+    cut = 0;
+  }
+  if(TMath::Abs(dd->Getd0Prong(1)) > cutV[iPtBinlb][5] || TMath::Abs(dd->Getd0Prong(1)) < cutV[iPtBinlb][6]){
+    fHistNEventsCuts->Fill(5);
+    if(lb==1)fHistNEventsCutsLb->Fill(5);
+    cut = 0;
+  }
+  if(TMath::Abs(dd->Getd0Prong(0)) > cutV[iPtBinlb][7] || TMath::Abs(dd->Getd0Prong(0)) < cutV[iPtBinlb][8]){
+    fHistNEventsCuts->Fill(4);
+    if(lb==1)fHistNEventsCutsLb->Fill(4);
+    cut = 0;
+  }
+  if(dd->CosThetaStar(0,5122,4122,211)<cutV[iPtBinlb][9] || dd->CosThetaStar(0,5122,4122,211)>cutV[iPtBinlb][10]){//era -0.6
+    fHistNEventsCuts->Fill(6);
+    if(lb==1)fHistNEventsCutsLb->Fill(6);
+    //    cut = 0;
+  }
+  
+  if(dd->Ct(5122)<cutV[iPtBinlb][11] || dd->Ct(5122)>cutV[iPtBinlb][12]) {//
+    fHistNEventsCuts->Fill(7);
+    if(lb==1)fHistNEventsCutsLb->Fill(7);
+    cut = 0;
+  }
+  if((dd->Prodd0d0()) >cutV[iPtBinlb][13] || dd->Prodd0d0() <cutV[iPtBinlb][14]){
+    fHistNEventsCuts->Fill(8);
+    if(lb==1)fHistNEventsCutsLb->Fill(8);
+    cut = 0;
+  }
+  if(dd->CosPointingAngle() <cutV[iPtBinlb][15]) {
+    fHistNEventsCuts->Fill(9);
+    if(lb==1)fHistNEventsCutsLb->Fill(9);
+    cut = 0;
+  }
+  if(dd->CosPointingAngleXY() < cutV[iPtBinlb][16]) {
+    fHistNEventsCuts->Fill(10);
+    if(lb==1)fHistNEventsCutsLb->Fill(10);
+    cut = 0;
+  }
+  if(dd->NormalizedDecayLengthXY()>cutV[iPtBinlb][17] || dd->NormalizedDecayLengthXY()<cutV[iPtBinlb][18]){
+    fHistNEventsCuts->Fill(13);
+    if(lb==1)fHistNEventsCuts->Fill(13);
+    cut =0;//era 30
+  }
+  if(dd->GetDCA() > cutV[iPtBinlb][19] || dd->GetDCA() <cutV[iPtBinlb][20]) {//era 0.01 puo' essere 0.005  0.004
+    fHistNEventsCuts->Fill(11);
+    if(lb==1)fHistNEventsCutsLb->Fill(11);
+    cut= 0;
+  }
+  if(TMath::Abs(dd->ImpParXY())*10000.>cutV[iPtBinlb][21]) {//era 60
+    fHistNEventsCuts->Fill(12);
+    if(lb==1)fHistNEventsCutsLb->Fill(12);
+    cut = 0;
+  }
+  
+  // fill histograms
+  if(lb==0 && isHijing){
+    if(isRot==0) { //not rotated bkg
+      ((TH1F*)fOutput->FindObject("fPtBkg"))->Fill(ptCandlb);
+      if(cut==1)((TH1F*)fOutput->FindObject("fPtBkg_TC"))->Fill(ptCandlb);
+      // these histograms are for the background with no cut
+      if(iPtBinlb==0) ((TH1F*)fOutput->FindObject("fMassBkg_pt0lb_NoCuts"))->Fill(massCandLb);
+      else if(iPtBinlb==1) ((TH1F*)fOutput->FindObject("fMassBkg_pt1lb_NoCuts"))->Fill(massCandLb);
+      else if(iPtBinlb==2) ((TH1F*)fOutput->FindObject("fMassBkg_pt2lb_NoCuts"))->Fill(massCandLb);
+      else if(iPtBinlb==3) ((TH1F*)fOutput->FindObject("fMassBkg_pt3lb_NoCuts"))->Fill(massCandLb);
+      else if(iPtBinlb==4) ((TH1F*)fOutput->FindObject("fMassBkg_pt4lb_NoCuts"))->Fill(massCandLb);
+      else if(iPtBinlb==5) ((TH1F*)fOutput->FindObject("fMassBkg_pt5lb_NoCuts"))->Fill(massCandLb);
     }
-
-    if(dd->CosThetaStar(0,5122,4122,211)<cutV[iPtBinlb][9] || dd->CosThetaStar(0,5122,4122,211)>cutV[iPtBinlb][10]){//era -0.6
-      //    cout << " OUT OUT ------------------- THETA STAR " << dd->CosThetaStar(0,5122,211,4122)<<endl;
-      fHistNEventsCuts->Fill(6);
-      if(lb==1)fHistNEventsCutsLb->Fill(6);
-      //    cut = 0;
+    else if(isRot==1) { //rotated bkg
+      ((TH1F*)fOutput->FindObject("fPtBkgRot"))->Fill(ptCandlb);
+      if(cut==1)((TH1F*)fOutput->FindObject("fPtBkgRot_TC"))->Fill(ptCandlb);
+      // these histograms are for the rotated background with no cut
+      if(iPtBinlb==0) ((TH1F*)fOutput->FindObject("fMassBkgRot_pt0lb_NoCuts"))->Fill(massCandLb);
+      else if(iPtBinlb==1) ((TH1F*)fOutput->FindObject("fMassBkgRot_pt1lb_NoCuts"))->Fill(massCandLb);
+      else if(iPtBinlb==2) ((TH1F*)fOutput->FindObject("fMassBkgRot_pt2lb_NoCuts"))->Fill(massCandLb);
+      else if(iPtBinlb==3) ((TH1F*)fOutput->FindObject("fMassBkgRot_pt3lb_NoCuts"))->Fill(massCandLb);
+      else if(iPtBinlb==4) ((TH1F*)fOutput->FindObject("fMassBkgRot_pt4lb_NoCuts"))->Fill(massCandLb);
+      else if(iPtBinlb==5) ((TH1F*)fOutput->FindObject("fMassBkgRot_pt5lb_NoCuts"))->Fill(massCandLb);
     }
-    if(dd->Ct(5122)<cutV[iPtBinlb][11] || dd->Ct(5122)>cutV[iPtBinlb][12]) {//
-      fHistNEventsCuts->Fill(7);
-      if(lb==1)fHistNEventsCutsLb->Fill(7);
-      //    //cout<< " OUTOUT ------------------------ CTAU "<< dd->Ct(5122)<< endl;
-      cut = 0;}
-
-
-      if((dd->Prodd0d0()) >cutV[iPtBinlb][13] || dd->Prodd0d0() <cutV[iPtBinlb][14]){
-        fHistNEventsCuts->Fill(8);
-        if(lb==1)fHistNEventsCutsLb->Fill(8);
-        //cout << " OUT OUT ------------ PRODDO " << dd->Prodd0d0()<< endl;
-        cut = 0;
-      }
-      if(dd->CosPointingAngle() <cutV[iPtBinlb][15]) {
-        fHistNEventsCuts->Fill(9);
-        if(lb==1)fHistNEventsCutsLb->Fill(9);
-        //cout << " OUT OUT  ---------------- COSP " << dd->CosPointingAngle()<<endl;
-        cut = 0;}
-
-        if(dd->CosPointingAngleXY() < cutV[iPtBinlb][16]) {
-          fHistNEventsCuts->Fill(10);
-          if(lb==1)fHistNEventsCutsLb->Fill(10);
-          //cout << " OUT OUT ---------------------cosp XY  " <<dd->CosPointingAngleXY()<< endl; 
-          cut = 0;}
-
-
-          if(dd->NormalizedDecayLengthXY()>cutV[iPtBinlb][17] || dd->NormalizedDecayLengthXY()<cutV[iPtBinlb][18]){ 
-            fHistNEventsCuts->Fill(13);
-            if(lb==1)fHistNEventsCuts->Fill(13);
-            cut =0;//era 30
-          }
-
-
-          if(dd->GetDCA() > cutV[iPtBinlb][19] || dd->GetDCA() <cutV[iPtBinlb][20]) {//era 0.01 puo' essere 0.005  0.004
-            fHistNEventsCuts->Fill(11);
-            if(lb==1)fHistNEventsCutsLb->Fill(11);
-            //    cout << " OUT OUT ---------------------cosp XY  " <<dd->CosPointingAngleXY()<< endl;
-            cut= 0;}
-
-            if(TMath::Abs(dd->ImpParXY())*10000.>cutV[iPtBinlb][21]) {//era 60
-              fHistNEventsCuts->Fill(12);
-              if(lb==1)fHistNEventsCutsLb->Fill(12);
-              //cout << " OUT OUT ---------------------cosp XY  " <<dd->CosPointingAngleXY()<< endl; 
-              cut = 0;
-            }
-
-
-            // fill histograms
-
-            if(lb==0 && isHijing){
-              if(isRot==0) { //not rotated bkg
-                ((TH1F*)fOutput->FindObject("fPtBkg"))->Fill(ptCandlb);
-                if(cut==1)((TH1F*)fOutput->FindObject("fPtBkg_TC"))->Fill(ptCandlb);
-                // these histograms are for the background with no cut
-                if(iPtBinlb==0) ((TH1F*)fOutput->FindObject("fMassBkg_pt0lb_NoCuts"))->Fill(massCandLb);
-                else if(iPtBinlb==1) ((TH1F*)fOutput->FindObject("fMassBkg_pt1lb_NoCuts"))->Fill(massCandLb);
-                else if(iPtBinlb==2) ((TH1F*)fOutput->FindObject("fMassBkg_pt2lb_NoCuts"))->Fill(massCandLb);
-                else if(iPtBinlb==3) ((TH1F*)fOutput->FindObject("fMassBkg_pt3lb_NoCuts"))->Fill(massCandLb);
-                else if(iPtBinlb==4) ((TH1F*)fOutput->FindObject("fMassBkg_pt4lb_NoCuts"))->Fill(massCandLb);
-                else if(iPtBinlb==5) ((TH1F*)fOutput->FindObject("fMassBkg_pt5lb_NoCuts"))->Fill(massCandLb);
-              }
-              else if(isRot==1) { //rotated bkg
-                ((TH1F*)fOutput->FindObject("fPtBkgRot"))->Fill(ptCandlb);
-                if(cut==1)((TH1F*)fOutput->FindObject("fPtBkgRot_TC"))->Fill(ptCandlb);
-                // these histograms are for the rotated background with no cut
-                if(iPtBinlb==0) ((TH1F*)fOutput->FindObject("fMassBkgRot_pt0lb_NoCuts"))->Fill(massCandLb);
-                else if(iPtBinlb==1) ((TH1F*)fOutput->FindObject("fMassBkgRot_pt1lb_NoCuts"))->Fill(massCandLb);
-                else if(iPtBinlb==2) ((TH1F*)fOutput->FindObject("fMassBkgRot_pt2lb_NoCuts"))->Fill(massCandLb);
-                else if(iPtBinlb==3) ((TH1F*)fOutput->FindObject("fMassBkgRot_pt3lb_NoCuts"))->Fill(massCandLb);
-                else if(iPtBinlb==4) ((TH1F*)fOutput->FindObject("fMassBkgRot_pt4lb_NoCuts"))->Fill(massCandLb);
-                else if(iPtBinlb==5) ((TH1F*)fOutput->FindObject("fMassBkgRot_pt5lb_NoCuts"))->Fill(massCandLb);
-              }
-            }
-            else if(lb==1 && isRot==0){
-              ((TH1F*)fOutput->FindObject("fPtSig"))->Fill(ptCandlb);
-              if(cut==1)((TH1F*)fOutput->FindObject("fPtSig_TC"))->Fill(ptCandlb);
-                // these histograms are for the signal with no cut
-              if(iPtBinlb==0) ((TH1F*)fOutput->FindObject("fMassSig_pt0lb_NoCuts"))->Fill(massCandLb);
-              else if(iPtBinlb==1) ((TH1F*)fOutput->FindObject("fMassSig_pt1lb_NoCuts"))->Fill(massCandLb);
-              else if(iPtBinlb==2) ((TH1F*)fOutput->FindObject("fMassSig_pt2lb_NoCuts"))->Fill(massCandLb);
-              else if(iPtBinlb==3) ((TH1F*)fOutput->FindObject("fMassSig_pt3lb_NoCuts"))->Fill(massCandLb);
-              else if(iPtBinlb==4) ((TH1F*)fOutput->FindObject("fMassSig_pt4lb_NoCuts"))->Fill(massCandLb);
-              else if(iPtBinlb==5) ((TH1F*)fOutput->FindObject("fMassSig_pt5lb_NoCuts"))->Fill(massCandLb);
-            }
-
-
-
-            if(cut==0)return 0;
-            else return 1;//returnvalue;
+  }
+  else if(lb==1 && isRot==0){
+    ((TH1F*)fOutput->FindObject("fPtSig"))->Fill(ptCandlb);
+    if(cut==1)((TH1F*)fOutput->FindObject("fPtSig_TC"))->Fill(ptCandlb);
+    // these histograms are for the signal with no cut
+    if(iPtBinlb==0) ((TH1F*)fOutput->FindObject("fMassSig_pt0lb_NoCuts"))->Fill(massCandLb);
+    else if(iPtBinlb==1) ((TH1F*)fOutput->FindObject("fMassSig_pt1lb_NoCuts"))->Fill(massCandLb);
+    else if(iPtBinlb==2) ((TH1F*)fOutput->FindObject("fMassSig_pt2lb_NoCuts"))->Fill(massCandLb);
+    else if(iPtBinlb==3) ((TH1F*)fOutput->FindObject("fMassSig_pt3lb_NoCuts"))->Fill(massCandLb);
+    else if(iPtBinlb==4) ((TH1F*)fOutput->FindObject("fMassSig_pt4lb_NoCuts"))->Fill(massCandLb);
+    else if(iPtBinlb==5) ((TH1F*)fOutput->FindObject("fMassSig_pt5lb_NoCuts"))->Fill(massCandLb);
+  }
+  
+  if(cut==0)return 0;
+  else return 1;//returnvalue;
 }
 
 //__________________________________________________________________________________
-
 Bool_t AliAnalysisTaskSELbtoLcpi4::CountLc(AliAODRecoDecayHF3Prong* Lc,AliAODTrack* pion, TClonesArray* arrayMC,Int_t motherLabelLc,Int_t motherLabelpione)
 {//if Lc is signal how many time is attached to pion to form background
   const Int_t pdgdaughtersLc[3]={2212,321,211};
@@ -1473,68 +1230,54 @@ Bool_t AliAnalysisTaskSELbtoLcpi4::CountLc(AliAODRecoDecayHF3Prong* Lc,AliAODTra
   else return kFALSE;
 }
 //_____________________________________________________________
-TObjArray* AliAnalysisTaskSELbtoLcpi4::GetArrayCandRotated(AliAODEvent* ev,AliAODRecoDecayHF2Prong *decay,TClonesArray* arrayMC,Int_t nRot) {
+void AliAnalysisTaskSELbtoLcpi4::DoRotations(AliAODEvent* ev, AliAODRecoDecayHF2Prong *decay, AliAODRecoDecayHF3Prong* lc3prong, AliAODTrack* piontrack, Int_t nRot, Bool_t isHijing, Int_t lb, TClonesArray* arrayMC, AliAODMCHeader *mcHeader) {
   //
-  // fill a TObjArray with the rotated candidates
+  // Do full rotation procedure in one function and delete everything at the end to fix memory leak
   //
-  Bool_t rotateFirst = kTRUE;//pion
-  Bool_t rotateSecond = kFALSE;//Lc
+  
   // magnetic field
   Double_t bz=ev->GetMagneticField();
+  
   //primary vertex
   AliVVertex *primaryVertex=ev->GetPrimaryVertex();
-  if(!primaryVertex) return 0x0;
+  AliAODVertex *primaryVertexAOD=ev->GetPrimaryVertex();
+  if(!primaryVertex || !primaryVertexAOD) return;
+  
   Double_t pseudoX2[3], pseudoP2[3];
   Double_t CovPseudo2[21],CovPseudo1[21];
   Double_t pseudoX1[3],pseudoP1[3];
-  // for rotations
-  AliExternalTrackParam * et1;//
-  AliExternalTrackParam * et2;//
-  // positive track to be rotated 
+  
+  // positive track to be rotated
   AliAODTrack* positive = (AliAODTrack*)decay->GetDaughter(0);//pion
   positive->GetCovarianceXYZPxPyPz(CovPseudo2);
   positive->GetXYZ(pseudoX2);
-  /*  TRandom *xg = new TRandom(0);
-      TRandom *yg = new TRandom(0);
-      TRandom *zg = new TRandom(0);
-      Double_t x[3];
-      x[0]=xg->Gaus(pseudoX2[0],TMath::Sqrt(TMath::Abs(CovPseudo2[3])));
-      x[1]=yg->Gaus(pseudoX2[1],TMath::Sqrt(TMath::Abs(CovPseudo2[4])));
-      x[2]=zg->Gaus(pseudoX2[2],TMath::Sqrt(TMath::Abs(CovPseudo2[5])));
-      positive->GetXYZ(x);
-  //cout << " x   " << x << " y   " <<y << " z   " << z << endl;
-  //cout << " xor " << pseudoX2[0] << " y or " <<pseudoX2[1] << " z or " << pseudoX2[2] << endl;
-  */
   positive->GetPxPyPz(pseudoP2);
   Short_t sign = positive->Charge();
-  if(rotateSecond)  et1 = new AliExternalTrackParam(pseudoX2,pseudoP2,CovPseudo2,sign);
-  // negative track 
+  //AliExternalTrackParam* et1 = new AliExternalTrackParam(pseudoX2,pseudoP2,CovPseudo2,sign); //made below
+  
+  // negative track
   AliAODTrack* negative = (AliAODTrack*)decay->GetDaughter(1);//Lc
   negative->GetCovarianceXYZPxPyPz(CovPseudo1);
   negative->GetXYZ(pseudoX1);
   negative->GetPxPyPz(pseudoP1);
   Short_t sign1 = negative->Charge();
-  if(rotateFirst) et2 = new AliExternalTrackParam(pseudoX1,pseudoP1,CovPseudo1,sign1);
+  AliExternalTrackParam* et2 = new AliExternalTrackParam(pseudoX1,pseudoP1,CovPseudo1,sign1);
   Double_t Prot[3];
-
+  
   Double_t fRot=13.;//20
   Double_t fAngle=0.0872;//0.1047
   Double_t fAngleFirst=3.14;
   if(nRot==20){
     fRot=20.;
-    fAngle=0.1047;//0.0872;//5 gradi... 
+    fAngle=0.1047;//0.0872;//5 gradi...
   }
-
-  // vector with rotated candidates
-  TObjArray *charmArray = new TObjArray(fRot);
-
+  
   Double_t d0z0[2],covd0z0[3],d0[2],d0err[2];
   Double_t d0z02[2],covd0z02[3];
   Double_t xdummy=0.,ydummy=0.,dca;
-  // Double_t Angle = (TMath::Pi() - fAngle*(fRot - 1.)/2.);
-  //  Double_t Angle = /*TMath::Pi()*/-6*fAngle;
   Double_t px[2],py[2],pz[2];
   UShort_t id[2];
+  
   // parameters of the actual 2Prong
   for (Int_t i=0;i<2;++i) {
     const AliAODTrack *t=static_cast<AliAODTrack*>(decay->GetDaughter(i));
@@ -1546,123 +1289,106 @@ TObjArray* AliAnalysisTaskSELbtoLcpi4::GetArrayCandRotated(AliAODEvent* ev,AliAO
     id[i]= decay->GetProngID(i);
   }
   dca = decay->GetDCA(); // will be recalculated
+  
   // rotate the first track in the xy plane
   for (Int_t r = 0; r < fRot; r++)
   {
-    TObjArray ta12;
-    if(rotateFirst){
+    AliExternalTrackParam* et1;
+    if(nRot==20){
+      Prot[0] = TMath::Cos(2.*TMath::Pi()-(TMath::Pi()/180.)*(6.*(fRot-1))/2.+ r*fAngle)*pseudoP2[0] - TMath::Sin(2.*TMath::Pi()-(TMath::Pi()/180.)*(6.*(fRot-1))/2.+ r*fAngle)*pseudoP2[1];
+      Prot[1] = TMath::Sin(2.*TMath::Pi()-(TMath::Pi()/180.)*(6.*(fRot-1))/2.+ r*fAngle)*pseudoP2[0] + TMath::Cos(2.*TMath::Pi()-(TMath::Pi()/180.)*(6.*(fRot-1))/2.+ r*fAngle)*pseudoP2[1];
+      Prot[2] = pseudoP2[2];
+      et1 = new AliExternalTrackParam(pseudoX2,Prot,CovPseudo2,sign);
+    } else {
       Prot[0] = TMath::Cos(2.*TMath::Pi()-(TMath::Pi()/180.)*(5.*(fRot-1))/2.+ r*fAngle)*pseudoP2[0] - TMath::Sin(2.*TMath::Pi()-(TMath::Pi()/180.)*(5.*(fRot-1))/2.+ r*fAngle)*pseudoP2[1];
       Prot[1] = TMath::Sin(2.*TMath::Pi()-(TMath::Pi()/180.)*(5.*(fRot-1))/2.+ r*fAngle)*pseudoP2[0] + TMath::Cos(2.*TMath::Pi()-(TMath::Pi()/180.)*(5.*(fRot-1))/2.+ r*fAngle)*pseudoP2[1];
       Prot[2] = pseudoP2[2];
       et1 = new AliExternalTrackParam(pseudoX2,Prot,CovPseudo2,sign);
-    }else{
-      Prot[0] = TMath::Cos(2.*TMath::Pi()-(TMath::Pi()/180.)*(5.*(fRot-1))/2.+ r*fAngle)*pseudoP1[0] - TMath::Sin(2.*TMath::Pi()-(TMath::Pi()/180.)*(5.*(fRot-1))/2.+ r*fAngle)*pseudoP1[1];
-      Prot[1] = TMath::Sin(2.*TMath::Pi()-(TMath::Pi()/180.)*(5.*(fRot-1))/2.+ r*fAngle)*pseudoP1[0] + TMath::Cos(2.*TMath::Pi()-(TMath::Pi()/180.)*(5.*(fRot-1))/2.+ r*fAngle)*pseudoP1[1];
-      Prot[2] = pseudoP1[2];
-      et2 = new AliExternalTrackParam(pseudoX1,Prot,CovPseudo1,sign1);
     }
-    if(nRot==20){
-      if(rotateFirst){
-        Prot[0] = TMath::Cos(2.*TMath::Pi()-(TMath::Pi()/180.)*(6.*(fRot-1))/2.+ r*fAngle)*pseudoP2[0] - TMath::Sin(2.*TMath::Pi()-(TMath::Pi()/180.)*(6.*(fRot-1))/2.+ r*fAngle)*pseudoP2[1];
-        Prot[1] = TMath::Sin(2.*TMath::Pi()-(TMath::Pi()/180.)*(6.*(fRot-1))/2.+ r*fAngle)*pseudoP2[0] + TMath::Cos(2.*TMath::Pi()-(TMath::Pi()/180.)*(6.*(fRot-1))/2.+ r*fAngle)*pseudoP2[1];
-        Prot[2] = pseudoP2[2];
-        et1 = new AliExternalTrackParam(pseudoX2,Prot,CovPseudo2,sign);
-      }else{
-        Prot[0] = TMath::Cos(2.*TMath::Pi()-(TMath::Pi()/180.)*(6.*(fRot-1))/2.+ r*fAngle)*pseudoP1[0] - TMath::Sin(2.*TMath::Pi()-(TMath::Pi()/180.)*(6.*(fRot-1))/2.+ r*fAngle)*pseudoP1[1];
-        Prot[1] = TMath::Sin(2.*TMath::Pi()-(TMath::Pi()/180.)*(6.*(fRot-1))/2.+ r*fAngle)*pseudoP1[0] + TMath::Cos(2.*TMath::Pi()-(TMath::Pi()/180.)*(6.*(fRot-1))/2.+ r*fAngle)*pseudoP1[1];
-        Prot[2] = pseudoP1[2];
-        et2 = new AliExternalTrackParam(pseudoX1,Prot,CovPseudo1,sign1);
-      }
-    }
+    TObjArray ta12;
     ta12.Add(et1); ta12.Add(et2);
-    //recalculate the secondary vertex 
-    // not crucial now but needed if you rotate the momenta
-    //AliAODVertex *vtxt=(AliAODVertex*)primaryVertex; //=RecalculateVertex(primaryVertex,&ta12 ,bz);
+    
+    //recalculate the secondary vertex
+    //not crucial now but needed if you rotate the momenta
     AliAODVertex *vtxt=RecalculateVertex(primaryVertex,&ta12 ,bz);
-    if(!vtxt) 
-    {//cout<<"no vertex---------------------------------******************* " << endl;
-      charmArray->AddAt(0,r);
-      if(rotateFirst) et1->Reset();
-      if(rotateSecond) et2->Reset();
-      ta12.Clear();ta12=0x0;
-      continue;}	
-      // this are the new impact prameters
-      // with relative errors 
-      et1->PropagateToDCA(primaryVertex,bz,100.,d0z0,covd0z0);
-      d0[0]=d0z0[0];
-      d0err[0] = TMath::Sqrt(covd0z0[0]);
-      et2->PropagateToDCA(primaryVertex,bz,100.,d0z02,covd0z02);
-      d0[1]=d0z02[0];
-      d0err[1] = TMath::Sqrt(covd0z02[0]);
-
-      /*   if(r==6){ 
-           cout<< " propagate to DCA et1 vs et2 d00 " << "  d0z0[0]     " <<d0z0[0] << "    d0z02[0]    "<< d0z02[0]<< endl;
-           cout<< " propagate to DCA et1 vs et2 d01 " << "  d0z0[1]     " <<d0z0[1] << "    d0z02[1]    "<< d0z02[1]<< endl;
-           cout<< "  covd0 0 1 vs 2		 " <<covd0z0[0] << "		  "<< covd0z02[0]<<endl;
-           cout<< "  covd0 1        		 " << covd0z0[1] << "  		  " << covd0z02[1]<<endl;
-           cout<< "  covd0 2        		 " << covd0z0[2] << "  		  " << covd0z02[2]<<endl;
-           cout<< "  covd0 3       		 " << covd0z0[3] << "  		  " << covd0z02[3]<<endl;
-           cout<< "  covd0 4        		 " << covd0z0[4] << "  		  " << covd0z02[4]<<endl;
-           cout<< "  covd0 5       		 " << covd0z0[5] << "  		  " << covd0z02[5]<<endl;
-           cout<< "  covd0 6       		 " << covd0z0[6] << "  		  " << covd0z02[6]<<endl;
-           cout<< "  covd0 7        		 " << covd0z0[7] << "  		  " << covd0z02[7]<<endl;
-           cout<< "  covd0 8        		 " << covd0z0[8] << " 		  " << covd0z02[8]<<endl;
-           cout<< "  covd0 9        		 " << covd0z0[9] << "  		  " << covd0z02[9]<<endl;
-           cout<< "  covd0 10      		 " << covd0z0[10] << "  	  " << covd0z02[10]<<endl;
-           cout<< "  covd0 11      		 " << covd0z0[11] << "  	  " << covd0z02[11]<<endl;
-           cout<< "  covd0 12      		 " << covd0z0[12] << "  	  " << covd0z02[12]<<endl;
-           cout<< "  covd0 13       		 " << covd0z0[13] << "  	  " << covd0z02[13]<<endl;
-           cout<< "  covd0 14      		 " << covd0z0[14] << "  	  " << covd0z02[14]<<endl;
-           }
-           */
-      //this is the new DCA      
-      dca=et1->GetDCA(et2,bz,xdummy,ydummy);
-      //daughters momenta
-      Double_t px1[2],py1[2],pz1[2];
-      if(rotateFirst){
-        px1[1]= pseudoP1[0];
-        py1[1]= pseudoP1[1];
-        pz1[1]= pseudoP1[2];
-        px1[0]= Prot[0];
-        py1[0]= Prot[1];
-        pz1[0]= Prot[2];
-      }else{
-        px1[0]= pseudoP2[0];
-        py1[0]= pseudoP2[1];
-        pz1[0]= pseudoP2[2];
-        px1[1]= Prot[0];
-        py1[1]= Prot[1];
-        pz1[1]= Prot[2];
-      }
-      // make the rotated D0 candidate and add to the candidate vector
-      // this is the new rotated candidate
-      AliAODRecoDecayHF2Prong *the2Prong = new AliAODRecoDecayHF2Prong(vtxt,px1,py1,pz1,d0,d0err,dca);
-      //     AliAODRecoDecayHF2Prong *the2Prong = new AliAODRecoDecayHF2Prong(primaryVertex,px1,py1,pz1,d0,d0err,dca);
-      the2Prong->SetCharge(decay->Charge());
-      //   the2Prong->SetPrimaryVtxRef(primaryVertex);
-      the2Prong->GetSecondaryVtx()->AddDaughter(positive);
-      the2Prong->GetSecondaryVtx()->AddDaughter(negative);
-      the2Prong->SetProngIDs(2,id);//
-      charmArray->AddAt(the2Prong,r);
-      //PostData(7,fNtupleDiffD0rot);
-      // delete vtxt; vtxt=NULL;
-      ta12.Clear();
-      ta12.Delete();
-      if(rotateFirst) et1->Reset();
-      if(rotateSecond) et2->Reset();
+    if(!vtxt){
+      et1->Reset(); delete et1; et1=0x0;
+      ta12.Clear(); ta12=0x0;
+      continue;
+    }
+    
+    // this are the new impact prameters
+    // with relative errors
+    et1->PropagateToDCA(primaryVertex,bz,100.,d0z0,covd0z0);
+    d0[0]=d0z0[0];
+    d0err[0] = TMath::Sqrt(covd0z0[0]);
+    et2->PropagateToDCA(primaryVertex,bz,100.,d0z02,covd0z02);
+    d0[1]=d0z02[0];
+    d0err[1] = TMath::Sqrt(covd0z02[0]);
+    
+    //this is the new DCA
+    dca=et1->GetDCA(et2,bz,xdummy,ydummy);
+    //daughters momenta
+    Double_t px1[2],py1[2],pz1[2];
+    px1[1]= pseudoP1[0];
+    py1[1]= pseudoP1[1];
+    pz1[1]= pseudoP1[2];
+    px1[0]= Prot[0];
+    py1[0]= Prot[1];
+    pz1[0]= Prot[2];
+    
+    // make the rotated Lb candidate and add to the candidate vector
+    // this is the new rotated candidate
+    AliAODRecoDecayHF2Prong *the2Prong = new AliAODRecoDecayHF2Prong(vtxt,px1,py1,pz1,d0,d0err,dca);
+    the2Prong->SetCharge(decay->Charge());
+    the2Prong->GetSecondaryVtx()->AddDaughter(positive);
+    the2Prong->GetSecondaryVtx()->AddDaughter(negative);
+    the2Prong->SetProngIDs(2,id);
+    
+    /*Update 20/09/19: From here on copied from FillHistos, instead of using array that has big memory leak*/
+    
+    the2Prong->SetOwnPrimaryVtx(primaryVertexAOD);
+    Double_t pionPt2=the2Prong->PtProng(0);
+    Double_t pionP2=the2Prong->PProng(0);
+    Double_t LcPt2=the2Prong->PtProng(1);
+    
+    ((TH1F*)fOutput->FindObject("fpionPt2"))->Fill(pionPt2);
+    ((TH1F*)fOutput->FindObject("fLcPt2"))->Fill(LcPt2);
+    ((TH1F*)fOutput->FindObject("fpionP2"))->Fill(pionP2);
+    
+    UInt_t pdgLb2[2]={211,4122};
+    Double_t massTrueLB = 5.641;
+    
+    Double_t massLb2 = the2Prong->InvMass(2,pdgLb2);
+    if(TMath::Abs(massLb2 - massTrueLB)<1.)((TH1F*)fOutput->FindObject("fMassLb2bkg"))->Fill(massLb2);
+    
+    Int_t selectionlbR=IsSelectedLbMY(the2Prong,AliRDHFCuts::kCandidate,lb,1,isHijing);//analysis cut Lb --> to be improved
+    if(selectionlbR==0){
+      et1->Reset(); delete et1; et1=0x0;
+      ta12.Clear(); ta12=0x0;
+      the2Prong->UnsetOwnPrimaryVtx();
+      delete the2Prong;
+      delete vtxt;
+      continue;
+    }
+    
+    FillLbHists(the2Prong, lb, mcHeader, arrayMC, piontrack, lc3prong, lb /*is same as lc*/, ev, fIsPromptLc);
+    
+    et1->Reset(); delete et1; et1=0x0;
+    ta12.Clear(); ta12=0x0;
+    the2Prong->UnsetOwnPrimaryVtx();
+    delete the2Prong;
+    delete vtxt;
   }
-
-  et1->Delete(); et1=0x0;
-  et2->Delete(); et2=0x0;
-
-  return charmArray;
+  
+  et2->Reset(); delete et2; et2=0x0;
 }
 //_____________________________________________________________
 AliAODVertex* AliAnalysisTaskSELbtoLcpi4::RecalculateVertex(const AliVVertex *primary,TObjArray *tracks,Double_t bField) {
   //
   // Helper function to recalculate a vertex.
   //
-
+  
   AliESDVertex *vertexESD = 0;
   AliAODVertex *vertexAOD = 0;
   //Double_t covmatrix[6];
@@ -1671,14 +1397,14 @@ AliAODVertex* AliAnalysisTaskSELbtoLcpi4::RecalculateVertex(const AliVVertex *pr
   vertexer->SetVtxStart((AliESDVertex*)primary);//primary vertex
   vertexESD = (AliESDVertex*)vertexer->VertexForSelectedESDTracks(tracks);
   delete vertexer; vertexer=NULL;
-
+  
   if(!vertexESD) return vertexAOD;
-
+  
   if(vertexESD->GetNContributors()!=tracks->GetEntriesFast()) {
     delete vertexESD; vertexESD=NULL;
     return vertexAOD;
   }
-
+  
   Double_t vertRadius2=vertexESD->GetX()*vertexESD->GetX()+vertexESD->GetY()*vertexESD->GetY();
   if(vertRadius2>8.){//(2.82)^2 radius beam pipe
     delete vertexESD; vertexESD=NULL;
@@ -1692,7 +1418,7 @@ AliAODVertex* AliAnalysisTaskSELbtoLcpi4::RecalculateVertex(const AliVVertex *pr
   for(Int_t b=0;b<6;b++)cov[b]=0.;
   chi2perNDF=0;
   //
-
+  
   vertexESD->GetXYZ(pos); // position
   vertexESD->GetCovMatrix(cov); //covariance matrix
   chi2perNDF = vertexESD->GetChi2toNDF();
@@ -1701,29 +1427,25 @@ AliAODVertex* AliAnalysisTaskSELbtoLcpi4::RecalculateVertex(const AliVVertex *pr
   Int_t nprongs= tracks->GetEntriesFast();
   vertexAOD = new AliAODVertex(pos,cov,chi2perNDF,0x0,-1,AliAODVertex::kUndef,nprongs);
   return vertexAOD;
-
+  
 }
-
 //___________________________
 void AliAnalysisTaskSELbtoLcpi4::FillLbHistsnr(AliAODRecoDecayHF2Prong *part,Int_t lb,AliAODMCHeader *mcHeader,TClonesArray* arrayMC, AliAODTrack *pion,AliAODRecoDecayHF3Prong *d, Int_t lc,AliAODEvent *ev, Bool_t IsPromptLc){
   //ptlb cut
-
+  
   Int_t promptLc=0;
   if (IsPromptLc) promptLc=1;
   Bool_t gen = CheckGenerator(pion,d,mcHeader,arrayMC);
+  
   Double_t massTrueLB = 5.641;
-  Double_t massCandLb = 0;
-  UInt_t pdgLb[2]={0,0};
-  //lc always at first place
-  pdgLb[1] = 4122;//lambdac
-  pdgLb[0] = 211;//pion
-  massCandLb = part->InvMass(2,pdgLb);
+  UInt_t pdgLb[2]={211,4122};
+  Double_t massCandLb = part->InvMass(2,pdgLb);
   if(TMath::Abs(massCandLb - massTrueLB)>1.) return;
+
   Int_t iPtBinlb = -1;
   Float_t lbVar[14];
   Float_t lbVarbg[14];
   Double_t ptCandlb = part->Pt();
-  // if(ptCandlb<2.) return; // dont save anything with pt<2
   if(ptCandlb>0. && ptCandlb<2.) iPtBinlb=0;
   if(ptCandlb>=2. && ptCandlb<4.) iPtBinlb=1;
   if(ptCandlb>=4. && ptCandlb<7.) iPtBinlb=2;
@@ -1731,7 +1453,7 @@ void AliAnalysisTaskSELbtoLcpi4::FillLbHistsnr(AliAODRecoDecayHF2Prong *part,Int
   if(ptCandlb>=10. && ptCandlb<14.) iPtBinlb=4;
   if(ptCandlb>=14.) iPtBinlb=5;
   if(ptCandlb<2. || ptCandlb>999.) return;
-
+  
   //fill ntuple
   Float_t lbVarC[30] = {0};
   lbVarC[0] = massCandLb;
@@ -1741,7 +1463,7 @@ void AliAnalysisTaskSELbtoLcpi4::FillLbHistsnr(AliAODRecoDecayHF2Prong *part,Int
   lbVarC[4] = part->Getd0Prong(1);
   lbVarC[5] = part->Getd0Prong(0);
   lbVarC[6] = part->CosThetaStar(0,5122,4122,211);
-  lbVarC[7] = part->Ct(5122); 
+  lbVarC[7] = part->Ct(5122);
   lbVarC[8] = part->Prodd0d0();
   lbVarC[9] = part->CosPointingAngle();
   lbVarC[10] = part->CosPointingAngleXY();
@@ -1764,7 +1486,7 @@ void AliAnalysisTaskSELbtoLcpi4::FillLbHistsnr(AliAODRecoDecayHF2Prong *part,Int
   lbVarC[27] = d->GetDCA();
   lbVarC[28] = lc;
   lbVarC[29] = promptLc;
-
+  
   if(lb==1){
     if(iPtBinlb==0)fInvMassLbSign0->Fill(massCandLb);
     if(iPtBinlb==1)fInvMassLbSign1->Fill(massCandLb);
@@ -1778,23 +1500,23 @@ void AliAnalysisTaskSELbtoLcpi4::FillLbHistsnr(AliAODRecoDecayHF2Prong *part,Int
     if(iPtBinlb==3)((TH1F*)fOutput->FindObject("fMassUpg_pt3lbNR"))->Fill(massCandLb);
     if(iPtBinlb==4)((TH1F*)fOutput->FindObject("fMassUpg_pt4lbNR"))->Fill(massCandLb);
     if(iPtBinlb==5)((TH1F*)fOutput->FindObject("fMassUpg_pt5lbNR"))->Fill(massCandLb);
-      
-      if(fFillNtupleSignal) {
+    
+    if(fFillNtupleSignal) {
       fNtupleLambdabUPG->Fill(lbVarC);
       PostData(2,fNtupleLambdabUPG);
     }
   }
   if(lb!=1){
     if(gen){
-//      cout << " gen " << gen << endl;
+      //      cout << " gen " << gen << endl;
       if(iPtBinlb==0)((TH1F*)fOutput->FindObject("fMassUpg_pt0lbbgNR"))->Fill(massCandLb);
       if(iPtBinlb==1)((TH1F*)fOutput->FindObject("fMassUpg_pt1lbbgNR"))->Fill(massCandLb);
       if(iPtBinlb==2)((TH1F*)fOutput->FindObject("fMassUpg_pt2lbbgNR"))->Fill(massCandLb);
       if(iPtBinlb==3)((TH1F*)fOutput->FindObject("fMassUpg_pt3lbbgNR"))->Fill(massCandLb);
       if(iPtBinlb==4)((TH1F*)fOutput->FindObject("fMassUpg_pt4lbbgNR"))->Fill(massCandLb);
       if(iPtBinlb==5)((TH1F*)fOutput->FindObject("fMassUpg_pt5lbbgNR"))->Fill(massCandLb);
-        
-        if(fFillNtupleBackgroundNonRotated) {
+      
+      if(fFillNtupleBackgroundNonRotated) {
         fNtupleLambdabUPG->Fill(lbVarC);
         PostData(2,fNtupleLambdabUPG);
       }
@@ -1804,9 +1526,9 @@ void AliAnalysisTaskSELbtoLcpi4::FillLbHistsnr(AliAODRecoDecayHF2Prong *part,Int
 }
 //___________________________________________________________
 Int_t AliAnalysisTaskSELbtoLcpi4::IsTrackInjected(AliAODTrack *part,AliAODMCHeader *header,TClonesArray *arrayMC){
-
+  
   AliVertexingHFUtils* ggg=new  AliVertexingHFUtils();
-
+  
   Int_t lab;
   if(fApplyFixesITS3AnalysisHijing)lab=TMath::Abs(part->GetLabel());
   else                             lab=part->GetLabel();
@@ -1834,15 +1556,13 @@ Int_t AliAnalysisTaskSELbtoLcpi4::IsTrackInjected(AliAODTrack *part,AliAODMCHead
     }
   }
   if(nameGen.IsWhitespace() || nameGen.Contains("ijing")){delete ggg; return 0;}
-
-
+  
   delete ggg;
   return 1;
 }
 //_____________________________________________________________
 Bool_t AliAnalysisTaskSELbtoLcpi4::IsCandidateInjected(AliAODRecoDecayHF *part, AliAODMCHeader *header,TClonesArray *arrayMC){
-
-
+  
   Int_t nprongs=part->GetNProngs();
   for(Int_t i=0;i<nprongs;i++){
     AliAODTrack *daugh=(AliAODTrack*)part->GetDaughter(i);
@@ -1854,7 +1574,3 @@ Bool_t AliAnalysisTaskSELbtoLcpi4::IsCandidateInjected(AliAODRecoDecayHF *part, 
   }
   return kFALSE;
 }
-
-//____________________________________________________________
-
-

--- a/PWGHF/vertexingHF/upgrade/AliAnalysisTaskSELbtoLcpi4.h
+++ b/PWGHF/vertexingHF/upgrade/AliAnalysisTaskSELbtoLcpi4.h
@@ -16,13 +16,6 @@
 #include "AliAODRecoDecayHF3Prong.h"
 #include <TH1F.h>
 
-//#include "TMVAClassification_BDT_pt4to7.class.C"
-//#include "TMVAClassification_BDT_pt7to10.class.C"
-//#include "TMVAClassification_BDT_pt10to14.class.C"
-//#include "TMVAClassification_BDT_pt14to9999.class.C"
-//#include "IClassifierReader.C" 
-
-
 class TNtuple;
 class TGraph;
 class TList;
@@ -33,15 +26,15 @@ class AliESDVertex;
 class AliVVertex;
 
 class AliAnalysisTaskSELbtoLcpi4:public AliAnalysisTaskSE {
- public:
+public:
   AliAnalysisTaskSELbtoLcpi4();
   AliAnalysisTaskSELbtoLcpi4(const char *name,
-    Bool_t fillntuple,
-    AliRDHFCutsLctopKpi *lccutsanal,
-    AliRDHFCutsLctopKpi *lccutsprod,
-    Int_t ndebug);
+                             Bool_t fillntuple,
+                             AliRDHFCutsLctopKpi *lccutsanal,
+                             AliRDHFCutsLctopKpi *lccutsprod,
+                             Int_t ndebug);
   virtual ~AliAnalysisTaskSELbtoLcpi4();
-
+  
   // Implementation of interface methods
   virtual void UserCreateOutputObjects();
   // virtual void UserCreateOutputHistos();
@@ -49,30 +42,28 @@ class AliAnalysisTaskSELbtoLcpi4:public AliAnalysisTaskSE {
   //  virtual void LocalInit() {Init();}
   virtual void UserExec(Option_t *option);
   virtual void Terminate(Option_t *option);
-
+  
   // options to fill Ntuple
   void SetFillNtupleSignal(Bool_t val = kTRUE) {fFillNtupleSignal = val;}
   void SetFillNtupleBackgroundRotated(Bool_t val = kTRUE) {fFillNtupleBackgroundRotated = val;}
   void SetFillNtupleBackgroundNonRotated(Bool_t val = kTRUE) {fFillNtupleBackgroundNonRotated = val;}
   
   //set parameters
-   void SetCutsond0Lcdaughters(Bool_t val = kTRUE) {fCutsond0Lcdaughters = val; return;}
+  void SetCutsond0Lcdaughters(Bool_t val = kTRUE) {fCutsond0Lcdaughters = val; return;}
   
-   void SetApplyFixesITS3AnalysisBit(Bool_t val = kTRUE){fApplyFixesITS3AnalysisBit = val;}
-   void SetApplyFixesITS3AnalysiskAll(Bool_t val = kTRUE){fApplyFixesITS3AnalysiskAll = val;}
-   void SetApplyFixesITS3AnalysisHijing(Bool_t val = kTRUE){fApplyFixesITS3AnalysisHijing = val;}
-
-   void ApplyD0CutLcdaughters(Double_t d0cutd1, Double_t d0cutd2){fCutD0Daughter[0]=d0cutd1; fCutD0Daughter[1]=d0cutd2;}
-   void SetPtConfiguration(Double_t ptbin, Double_t ptlcupper, Double_t ptlclower, Double_t ptpionupper, Double_t ptpionlower, Double_t ptlbupper, Double_t ptlblower){fCutsPerPt[0]=ptbin;fCutsPerPt[1]=ptlcupper;fCutsPerPt[2]=ptlclower;fCutsPerPt[3]=ptpionupper;fCutsPerPt[4]=ptpionlower;fCutsPerPt[5]=ptlbupper;fCutsPerPt[6]=ptlblower;}
-   void SetNRotations(Double_t nrotations){fNRotations=nrotations;}
-
- private:
+  void SetApplyFixesITS3AnalysisBit(Bool_t val = kTRUE){fApplyFixesITS3AnalysisBit = val;}
+  void SetApplyFixesITS3AnalysiskAll(Bool_t val = kTRUE){fApplyFixesITS3AnalysiskAll = val;}
+  void SetApplyFixesITS3AnalysisHijing(Bool_t val = kTRUE){fApplyFixesITS3AnalysisHijing = val;}
+  
+  void ApplyD0CutLcdaughters(Double_t d0cutd1, Double_t d0cutd2){fCutD0Daughter[0]=d0cutd1; fCutD0Daughter[1]=d0cutd2;}
+  void SetPtConfiguration(Double_t ptbin, Double_t ptlcupper, Double_t ptlclower, Double_t ptpionupper, Double_t ptpionlower, Double_t ptlbupper, Double_t ptlblower){fCutsPerPt[0]=ptbin;fCutsPerPt[1]=ptlcupper;fCutsPerPt[2]=ptlclower;fCutsPerPt[3]=ptpionupper;fCutsPerPt[4]=ptpionlower;fCutsPerPt[5]=ptlbupper;fCutsPerPt[6]=ptlblower;}
+  void SetNRotations(Double_t nrotations){fNRotations=nrotations;}
+  
+private:
   AliAnalysisTaskSELbtoLcpi4(const AliAnalysisTaskSELbtoLcpi4&);
-  AliAnalysisTaskSELbtoLcpi4& operator=(const AliAnalysisTaskSELbtoLcpi4&); 
-
+  AliAnalysisTaskSELbtoLcpi4& operator=(const AliAnalysisTaskSELbtoLcpi4&);
+  
   // Helper functions
-  //AliESDVertex* RecalculateVertex(const AliVVertex *old,TObjArray *tracks,Double_t bField);
-  //aggiunto
   void AddDaughterRefs(AliAODVertex *v,const AliVEvent *event, const TObjArray *trkArray) const;
   
   Int_t CheckMCLc(AliAODRecoDecayHF3Prong *d, TClonesArray* arrayMC);
@@ -81,27 +72,26 @@ class AliAnalysisTaskSELbtoLcpi4:public AliAnalysisTaskSE {
   void  FillLbHistsnr(AliAODRecoDecayHF2Prong *part,Int_t lb,AliAODMCHeader *mcHeader,TClonesArray* arrayMC,AliAODTrack *p,AliAODRecoDecayHF3Prong *d,Int_t Lc,AliAODEvent *ev, Bool_t IsPromptLc);
   void FillHistos(AliAODRecoDecayHF3Prong* d,TClonesArray* arrayMC,AliAODEvent *ev,AliAODMCHeader *mcHeader);
   Bool_t CheckGenerator(AliAODTrack *p,AliAODRecoDecayHF3Prong *d,AliAODMCHeader *mcHeader,TClonesArray* arrayMC);
-  Int_t IsSelectedLbMY(TObject* obj,Int_t selectionLevel,Int_t lb,Int_t isRot, Bool_t isHijing) const; 
+  Int_t IsSelectedLbMY(TObject* obj,Int_t selectionLevel,Int_t lb,Int_t isRot, Bool_t isHijing) const;
   Bool_t CountLc(AliAODRecoDecayHF3Prong* Lc, AliAODTrack* pion, TClonesArray* arrayMC,Int_t motherLabelLc,Int_t motherLabelpione);
   Bool_t IsCandidateInjected(AliAODRecoDecayHF *part, AliAODMCHeader *header,TClonesArray *arrayMC);
   Int_t IsTrackInjected(AliAODTrack *part,AliAODMCHeader *header,TClonesArray *arrayMC);
-  TObjArray* GetArrayCandRotated(AliAODEvent* ev,AliAODRecoDecayHF2Prong *decay,TClonesArray* arrayMC,Int_t nRot);
   AliAODVertex* RecalculateVertex(const AliVVertex *primary,TObjArray *tracks,Double_t bField);
-
+  AliAODVertex* ReconstructSecondaryVertex(TObjArray *trkArray,Double_t &dispersion,Bool_t useTRefArray=kTRUE) const; //Reconstruct vertex of B
+  void DoRotations(AliAODEvent* ev, AliAODRecoDecayHF2Prong *decay, AliAODRecoDecayHF3Prong* lc3prong, AliAODTrack* piontrack, Int_t nRot, Bool_t isHijing, Int_t lb, TClonesArray* arrayMC, AliAODMCHeader *mcHeader);
 
   AliPIDResponse *fPIDResponse;
   TList   *fOutput; //! list send on output slot 3
-  TH1F    *fHistNEvents; //!hist. for No. of events 
+  TH1F    *fHistNEvents; //!hist. for No. of events
   TH1F    *fHistNEventsCuts; //!hist. for No. of events cuts
   TH1F    *fHistNEventsCutsLb; //!hist. for No. of events Lb
   AliRDHFCutsLctopKpi *fRDCutsAnalysisLc; //Cuts for Analysis
   AliRDHFCutsLctopKpi *fRDCutsProductionLb; //Production Cuts
   TList *fListCuts; //list of cuts
-
-
-  Double_t fBzkG;                     // z component of magnetic field
-  AliAODVertex *fvtx1;                // primary vertex
-  TList    *fOutputList;            //! output slot 8
+  
+  Double_t fBzkG;                // z component of magnetic field
+  AliAODVertex *fvtx1;           // primary vertex
+  TList    *fOutputList;         //! output slot 8
   TH1F     *fInvMassLbSign0;     //!histogram with invariant mass of Lb signal its upgrade
   TH1F     *fInvMassLbSign1;     //!histogram with invariant mass of Lb signal its upgrade
   TH1F     *fInvMassLbSign2;     //!histogram with invariant mass of Lb signal its upgrade
@@ -110,14 +100,8 @@ class AliAnalysisTaskSELbtoLcpi4:public AliAnalysisTaskSE {
   TH1F     *fInvMassLbSign5;     //!histogram with invariant mass of Lb signal its upgrade
   TH1I      *fSelMC;
   TH1I      *fCountLc;
-  TNtuple *fNtupleLambdabUPG; //! output ntuple 
-   //TNtuple *fNtupleDiffD0rot; //! output ntuple
-  //TH2F *fMassHistBDT[8*kMaxPtBins]; //!hist. for inv mass vs BDT response
-
-
-  //IClassifierReader *fBDTReader[4]; //!BDT reader for standalone class
-  AliAODVertex* ReconstructSecondaryVertex(TObjArray *trkArray,Double_t &dispersion,Bool_t useTRefArray=kTRUE) const; //Reconstruct vertex of B
-
+  TNtuple *fNtupleLambdabUPG; //! output ntuple
+  
   Bool_t fFillNtupleSignal; /// flag to fill ntuple with signal candidates
   Bool_t fFillNtupleBackgroundRotated; /// flag to fill ntuple with background rotated candidates
   Bool_t fFillNtupleBackgroundNonRotated; /// flag to fill ntuple with background non rotated candidates
@@ -126,12 +110,12 @@ class AliAnalysisTaskSELbtoLcpi4:public AliAnalysisTaskSE {
   Double_t fCutsPerPt[7];
   Double_t fNRotations;
   Bool_t fIsPromptLc;
-
+  
   //temporary to compare with old ITS2 analysis
   Bool_t fApplyFixesITS3AnalysisBit;
   Bool_t fApplyFixesITS3AnalysiskAll;
   Bool_t fApplyFixesITS3AnalysisHijing;
-
+  
   ClassDef(AliAnalysisTaskSELbtoLcpi4,5);
 };
 


### PR DESCRIPTION
* Fixed the biggest and most obvious memory leak in the Lb rotation procedure by merging the rotate function (that returned an array full off "hidden" pointers) and the histogram filling function (that used the array).
* Cleaned the code

Tested on 1 AOD locally: exact same result as before fix+cleaning.