### PR TITLE
Converting the Energy Recalib histogram to 1D histogram

### DIFF
--- a/PWG/CaloTrackCorrBase/AliCalorimeterUtils.h
+++ b/PWG/CaloTrackCorrBase/AliCalorimeterUtils.h
@@ -228,6 +228,8 @@ class AliCalorimeterUtils : public TObject {
   void          SwitchOffRecalibration()                   { fRecalibration = kFALSE;
                   fEMCALRecoUtils->SwitchOffRecalibration()                                                           ; }
 	
+  void          Load1DRecalibration()                      { fLoad1DRecalibFactors=kTRUE; }
+
   void          InitPHOSRecalibrationFactors () ;
 	
   Float_t       GetEMCALChannelRecalibrationFactor(Int_t iSM , Int_t iCol, Int_t iRow) const { 
@@ -246,9 +248,11 @@ class AliCalorimeterUtils : public TObject {
                   ((TH2F*)fPHOSRecalibrationFactors->At(imod))->SetBinContent(iCol,iRow,c)                            ; }
     
   void          SetEMCALChannelRecalibrationFactors(Int_t iSM , TH2F* h) { fEMCALRecoUtils->SetEMCALChannelRecalibrationFactors(iSM,h)      ; }
+  void          SetEMCALChannelRecalibrationFactors1D(TH1S* h) { fEMCALRecoUtils->SetEMCALChannelRecalibrationFactors1D(h)      ; }
   void          SetPHOSChannelRecalibrationFactors(Int_t imod , TH2F* h) { fPHOSRecalibrationFactors ->AddAt(h,imod)                        ; }
 	
   TH2F *        GetEMCALChannelRecalibrationFactors(Int_t iSM)     const { return fEMCALRecoUtils->GetEMCALChannelRecalibrationFactors(iSM) ; }
+  TH1S *        GetEMCALChannelRecalibrationFactors1D()     const { return fEMCALRecoUtils->GetEMCALChannelRecalibrationFactors1D() ; }
   TH2F *        GetPHOSChannelRecalibrationFactors(Int_t imod)     const { return (TH2F*)fPHOSRecalibrationFactors->At(imod)                ; }
 	
   void          SetEMCALChannelRecalibrationFactors(TObjArray *map)      { fEMCALRecoUtils->SetEMCALChannelRecalibrationFactors(map)        ; }
@@ -427,6 +431,8 @@ class AliCalorimeterUtils : public TObject {
   Bool_t             fRemoveBadChannels;        ///<  Check the channel status provided and remove clusters with bad channels.
 
   Bool_t             fLoad1DBadChMap;           ///<  Flag to load 1D bad channel map.
+
+  Bool_t             fLoad1DRecalibFactors;     ///<  Flag to load 1D energy recalibration histogram
 
   TObjArray        * fPHOSBadChannelMap;        ///<  Array of histograms with map of bad channels, PHOS.
 

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -171,18 +171,30 @@ public:
   void     SwitchOffRecalibration()                      { fRecalibration = kFALSE ; }
   void     SwitchOnRecalibration()                       { fRecalibration = kTRUE  ; 
                                                            if(!fEMCALRecalibrationFactors)InitEMCALRecalibrationFactors() ; }
+  void     SetUse1DRecalibration(Bool_t use)             { fUse1Drecalib = use; }
   void     InitEMCALRecalibrationFactors() ;
+  void     InitEMCALRecalibrationFactors1D() ;
   TObjArray* GetEMCALRecalibrationFactorsArray()   const { return fEMCALRecalibrationFactors ; }
-  TH2F *   GetEMCALChannelRecalibrationFactors(Int_t iSM)     const { return (TH2F*)fEMCALRecalibrationFactors->At(iSM) ; }	
+  TH2F *   GetEMCALChannelRecalibrationFactors(Int_t iSM)     const;	
+  TH1S *   GetEMCALChannelRecalibrationFactors1D()            const { return (TH1S*)fEMCALRecalibrationFactors->At(0) ; }	
   void     SetEMCALChannelRecalibrationFactors(const TObjArray *map);
   void     SetEMCALChannelRecalibrationFactors(Int_t iSM , const TH2F* h);
+  void     SetEMCALChannelRecalibrationFactors1D(const TH1S* h);
   Float_t  GetEMCALChannelRecalibrationFactor(Int_t iSM , Int_t iCol, Int_t iRow) const { 
     if(fEMCALRecalibrationFactors) 
       return (Float_t) ((TH2F*)fEMCALRecalibrationFactors->At(iSM))->GetBinContent(iCol,iRow); 
+    else return 1 ; }
+  Float_t  GetEMCALChannelRecalibrationFactor1D(UInt_t iCell ) const { 
+    if(fEMCALRecalibrationFactors) 
+      return (Float_t) ((TH1S*)fEMCALRecalibrationFactors->At(0))->GetBinContent(iCell)/1000; 
     else return 1 ; } 
   void     SetEMCALChannelRecalibrationFactor(Int_t iSM , Int_t iCol, Int_t iRow, Double_t c = 1) { 
     if(!fEMCALRecalibrationFactors) InitEMCALRecalibrationFactors() ;
     ((TH2F*)fEMCALRecalibrationFactors->At(iSM))->SetBinContent(iCol,iRow,c) ; }
+
+  void     SetEMCALChannelRecalibrationFactor1D(UInt_t icell, Double_t c = 1) { 
+    if(!fEMCALRecalibrationFactors) InitEMCALRecalibrationFactors1D() ;
+    ((TH1S*)fEMCALRecalibrationFactors->At(0))->SetBinContent(icell,c) ; }
   
   // Recalibrate channels energy with run dependent corrections
   Bool_t   IsRunDepRecalibrationOn()               const { return fUseRunCorrectionFactors ; }
@@ -266,6 +278,7 @@ public:
   void     SwitchOffBadChannelsRemoval()                 { fRemoveBadChannels = kFALSE     ; }
   void     SwitchOnBadChannelsRemoval ()                 { fRemoveBadChannels = kTRUE ; 
                                                            if(!fEMCALBadChannelMap)InitEMCALBadChannelStatusMap() ; }
+  void     SetUse1DBadChannelMap(Bool_t use)             { fUse1Dmap = use;}
   Bool_t   IsDistanceToBadChannelRecalculated()    const { return fRecalDistToBadChannels   ; }
   void     SwitchOffDistToBadChannelRecalculation()      { fRecalDistToBadChannels = kFALSE ; }
   void     SwitchOnDistToBadChannelRecalculation()       { fRecalDistToBadChannels = kTRUE  ; 
@@ -491,6 +504,7 @@ private:
   // Energy Recalibration 
   Bool_t     fCellsRecalibrated;         ///< Internal bool to check if cells (time/energy) where recalibrated and not recalibrate them when recalculating different things
   Bool_t     fRecalibration;             ///< Switch on or off the recalibration
+  Bool_t     fUse1Drecalib;              ///< Flag to use one dimensional recalibration histogram
   TObjArray* fEMCALRecalibrationFactors; ///< Array of histograms with map of recalibration factors, EMCAL
     
   // Time Recalibration 

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellBadChannel.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellBadChannel.cxx
@@ -68,6 +68,7 @@ Bool_t AliEmcalCorrectionCellBadChannel::Initialize()
 
   // Load 1D bad channel map
   GetProperty("load1DBadChMap", fLoad1DBadChMap);
+  fRecoUtils->SetUse1DBadChannelMap(fLoad1DBadChMap);
   
   return kTRUE;
 }

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellEnergy.h
@@ -46,6 +46,7 @@ private:
   Bool_t                 fUseAutomaticRunDepRecalib; ///< On by default the check in the OADB of the run dependent energy recalibration
   Bool_t                 fUseNewRunDepTempCalib;     ///< Off by default the check in the OADB of the new run dependent temp calib Run1/Run2
   TString                fCustomRecalibFilePath;     ///< Empty string by default the path to the OADB file of the custom energy recalibration
+  Bool_t                 fLoad1DRecalibFactors;      ///< Flag to load 1D energy recalibration factors
   
   AliEmcalCorrectionCellEnergy(const AliEmcalCorrectionCellEnergy &);               // Not implemented
   AliEmcalCorrectionCellEnergy &operator=(const AliEmcalCorrectionCellEnergy &);    // Not implemented
@@ -54,7 +55,7 @@ private:
   static RegisterCorrectionComponent<AliEmcalCorrectionCellEnergy> reg;
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionCellEnergy, 4); // EMCal cell energy correction component
+  ClassDef(AliEmcalCorrectionCellEnergy, 5); // EMCal cell energy correction component
   /// \endcond
 };
 

--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.cxx
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionClusterizer.cxx
@@ -208,6 +208,7 @@ Bool_t AliEmcalCorrectionClusterizer::Initialize()
 
   // Load 1D bad channel map
   GetProperty("load1DBadChMap", fLoad1DBadChMap);
+  fRecoUtils->SetUse1DBadChannelMap(fLoad1DBadChMap);
   
   return kTRUE;
 }

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -61,6 +61,7 @@ CellEnergy:                                         # Cell Energy correction com
     createHistos: false                             # Whether the task should create output histograms
     enableNewTempCalib: false                       # Whether the new temperature calibration parmeters should be used (available for Run1 and Run2)
     customRecalibFilePath: ""                       # Full path including .root file for custom recalibration object
+    load1DRecalibFactors: false                     # Flag to load a 1D energy recalibration histogram
     cellsNames:                                     # Names of the cells input objects which should be attached to the correction
         - defaultCells                              # This object is defined above in the cells section of the input objects
 CellBadChannel:                                     # Bad channel removal at the cell level component

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALClusterize.h
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALClusterize.h
@@ -316,6 +316,8 @@ class AliAnalysisTaskEMCALClusterize : public AliAnalysisTaskSE {
   void           PrintTCardParam();
 
   void     SwitchUseMergedBCs(Bool_t doUseMergedBC)     { fDoMergedBCs     = doUseMergedBC; }
+
+  void     SetUse1DRecalibration(Bool_t use1D)     { fLoad1DRecalibFactors     = use1D; }
   
   //------------------------------------------
   
@@ -453,6 +455,7 @@ private:
   Bool_t                fPrintOnce;                ///< Print once analysis parameters
 
   Bool_t                fDoMergedBCs;              ///< flag whether to load four histos for the time calib or one merged histo
+  Bool_t                fLoad1DRecalibFactors;     ///< Flag to load 1D energy recalibration factors
   
   /// Copy constructor not implemented.
   AliAnalysisTaskEMCALClusterize(           const AliAnalysisTaskEMCALClusterize&) ;

--- a/TENDER/TenderSupplies/AliEMCALTenderSupply.h
+++ b/TENDER/TenderSupplies/AliEMCALTenderSupply.h
@@ -159,7 +159,9 @@ public:
   void     SwitchOffClusterExoticChannelCheck()           { fRejectExoticClusters = kFALSE   ;}  
 
   void     SwitchOnCalibrateEnergy()                      { fCalibrateEnergy = kTRUE         ;} 
-  void     SwitchOffCalibrateEnergy()                     { fCalibrateEnergy = kFALSE        ;}  
+  void     SwitchOffCalibrateEnergy()                     { fCalibrateEnergy = kFALSE        ;}
+
+  void     Load1DRecalibration()                          { fLoad1DRecalibFactors = kTRUE    ;}  
 
   void     SwitchOnCalibrateTime()                        { fCalibrateTime = kTRUE           ;} 
   void     SwitchOffCalibrateTime()                       { fCalibrateTime = kFALSE          ;}  
@@ -244,6 +246,7 @@ private:
   Bool_t                 fDoNonLinearity;         // nNon linearity correction flag
   Bool_t                 fBadCellRemove;          // zero bad cells
   Bool_t                 fLoad1DBadChMap;         // Flag to load 1D bad channel map
+  Bool_t                 fLoad1DRecalibFactors;   // Falg to load 1D energy recalibration histogram
   Bool_t                 fRejectExoticCells;      // reject exotic cells
   Bool_t                 fRejectExoticClusters;   // recect clusters with exotic cells
   Bool_t                 fClusterBadChannelCheck; // check clusters for bad channels


### PR DESCRIPTION
We converted the 2D histogram of the energy recalibration into a 1D histogram. Also the correction framework has been modified so it can read 1D histogram. By default this option is disabled and it be enabled in the yaml file by setting "load1DRecalibFactors" to "true".