### PR TITLE
Important fixes for Xic->pKpi task

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.cxx
@@ -775,6 +775,14 @@ void AliAnalysisTaskSEXicTopKpi::UserExec(Option_t */*option*/)
   //     FillMCAcceptanceHistos(mcArray, mcHeader);
   //   }
   
+  // 
+  //  We need to call the IsEventSelected function
+  //  using the cutobject used for the PID selections
+  //  ---> it sets the Bayes PID correctly!
+  //    (dirty solution, we'll clean it)
+  //
+  fCutsXic->IsEventSelected(aod);
+
   if(!fCuts->IsEventSelected(aod)) {
     if(fCuts->GetWhyRejection()==1) // rejected for pileup
       fNentries->Fill(13);

--- a/PWGHF/vertexingHF/AliRDHFCutsXictopKpi.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCutsXictopKpi.cxx
@@ -481,12 +481,13 @@ Int_t AliRDHFCutsXictopKpi::IsSelectedPID(AliAODRecoDecayHF* obj) {
     for(Int_t i=0;i<3;i++){
      AliAODTrack *track=(AliAODTrack*)obj->GetDaughter(i);
      if(!track) return 0;
-     // identify kaon
-     if(track->P()<0.55){
-      fPidHF->SetTOF(kFALSE);
-      fPidHF->SetTOFdecide(kFALSE);
-     }
      if(i==1) {
+      // identify kaon
+      if(track->P()<0.55){
+        fPidHF->SetTOF(kFALSE);
+        fPidHF->SetTOFdecide(kFALSE);
+      }
+      //if(i==1) {
       Int_t isKaon=0;
       isKaon=fPIDStrategy==kNSigmaMin?fPidHF->MatchTPCTOFMin(track,3):fPidHF->MakeRawPid(track,3);
       if(isKaon>=1) iskaon1=kTRUE;

--- a/PWGHF/vertexingHF/macros/AddTaskSEXicTopKpi.C
+++ b/PWGHF/vertexingHF/macros/AddTaskSEXicTopKpi.C
@@ -42,6 +42,10 @@ AliAnalysisTaskSEXicTopKpi *AddTaskSEXicTopKpi(Bool_t readMC=kFALSE,
     inname="cinputmassD0_1";
 
     inname += finDirname.Data();
+    inname += suffix.Data();
+    out1name += suffix.Data();
+    out2name += suffix.Data();
+    out3name += suffix.Data();
 
    //setting my cut values
 


### PR DESCRIPTION
 1) AddTask modified - container name can be set by the user
 2) fix in AliRDHFCutsXictopKpi::IsSelectedPID about the kaon PID
 3) in AliAnalysisTaskSEXicTopKpi::UserExec() the fCutsXic->IsEventSelected has been added
    ---> mandatory to correctly set the Bayes PID
    ---> we'll remove the AliRDHFCutsDtoKpi object soon (still temporary solution)