### PR TITLE
Remove includes since ESD MC trains cannot run with Root 6

### DIFF
--- a/PWGGA/Hyperon/macros/AddTaskSigma0LowBtest.C
+++ b/PWGGA/Hyperon/macros/AddTaskSigma0LowBtest.C
@@ -1,13 +1,3 @@
-#include <vector>
-#include "AliAnalysisTaskSE.h"
-#include "AliAnalysisManager.h"
-#include "AliFemtoDreamEventCuts.h"
-#include "AliFemtoDreamTrackCuts.h"
-#include "AliSigma0V0Cuts.h"
-#include "AliSigma0PhotonCuts.h"
-#include "AliSigma0PhotonMotherCuts.h"
-#include "AliAnalysisTaskSigma0Run2.h"
-
 AliAnalysisTaskSE *AddTaskSigma0LowBtest(bool isMC = false, TString trigger =
                                              "kINT7",
                                          const char *cutVariation = "0") {


### PR DESCRIPTION
In file included from input_line_79:1:
In file included from /home/alitrain/train-workdir/PWGCF/CF_pp_MC_ESD/247_20190925-2122/config/handlers.C:5:
/cvmfs/alice.cern.ch/el6-x86_64/Packages/AliRoot/v5-09-50_ROOT6-1/ANALYSIS/macros/train/AddMCHandler.C:1:20: error: definition with same mangled name as another definition
AliMCEventHandler* AddMCHandler(Bool_t readTrackRef = kFALSE)
                   ^
/cvmfs/alice.cern.ch/el6-x86_64/Packages/AliRoot/v5-09-50_ROOT6-1/ANALYSIS/macros/train/AddMCHandler.C:1:20: note: previous definition is here
AliMCEventHandler* AddMCHandler(Bool_t readTrackRef = kFALSE)