### PR TITLE
Fix compilation when fastjet is disabled

### DIFF
--- a/PWGDQ/dielectron/PWGDQdielectronLinkDef.h
+++ b/PWGDQ/dielectron/PWGDQdielectronLinkDef.h
@@ -68,6 +68,10 @@
 #pragma link C++ class AliAnalysisTaskBeauty+;
 #pragma link C++ class AliAnalysisTaskJpsi+;
 #pragma link C++ class AlimakeJPsiTree+;
+#ifdef HAVE_FASTJET
+// Classes which need direct access only to Fastjet objects (not
+// needed if wrapped into ALICE objects)
 #pragma link C++ class AliAnalysisTaskJpsiJet+;
 #pragma link C++ class AliAnalysisTaskJpsiJetFilter+;
+#endif
 #endif


### PR DESCRIPTION
AliAnalysisTaskJpsiJet depends on fastjet. The class is correctly compiled only when fastjet is found, but the dictionary creation does not have any protection.
This PR fixes it.