### PR TITLE
Read and access L1 phases for PAR runs in EMCal

### DIFF
--- a/PWG/CaloTrackCorrBase/AliCalorimeterUtils.cxx
+++ b/PWG/CaloTrackCorrBase/AliCalorimeterUtils.cxx
@@ -421,42 +421,59 @@ void AliCalorimeterUtils::AccessOADB(AliVEvent* event)
         if(!trecalpass) 
         {
           AliInfo(Form("L1 phase time recal: No params for run %d and pass %s, try default", fRunNumber, passM.Data())); 
-          
           trecal->Delete();
-          
           trecal=(TObjArray*)contTRF->GetObject(0);
-          
           if(trecal)          
             trecalpass=(TObjArray*)trecal->FindObject("pass1");
-          
           AliInfo("Time L1 phase Recalibrate EMCAL");
         }
         
         if(trecalpass)
         {
-          TH1C *h =GetEMCALL1PhaseInTimeRecalibrationForAllSM();
-          
+          TH1C *h =GetEMCALL1PhaseInTimeRecalibrationForAllSM(0);
           if (h) delete h;
-          
           h = (TH1C*)trecalpass->FindObject(Form("h%d",fRunNumber));
-          
           if (!h) AliError(Form("Could not load h%d",fRunNumber));
-          
           h->SetDirectory(0);
-          
-          SetEMCALL1PhaseInTimeRecalibrationForAllSM(h);
+          SetEMCALL1PhaseInTimeRecalibrationForAllSM(h,0);
+	  fEMCALRecoUtils->SwitchOffParRun();
+	  //Now special case for PAR runs
+	  //access tree from OADB file
+	  TTree *tGID = (TTree*)trecalpass->FindObject(Form("h%d_GID",fRunNumber));
+	  if(tGID){//check whether present = PAR run
+	    fEMCALRecoUtils->SwitchOnParRun();
+	    //access tree branch with PARs
+	    ULong64_t ParGlobalBCs;
+	    tGID->SetBranchAddress("GID",&ParGlobalBCs);
+	    //set number of PARs in run
+	    Short_t nPars = (Short_t) tGID->GetEntries();
+	    fEMCALRecoUtils->SetNPars((Short_t)nPars);
+	    //set global ID for each PAR
+	    for (Short_t iParNumber = 0; iParNumber < nPars; ++iParNumber) {
+	      tGID->GetEntry(iParNumber);
+	      fEMCALRecoUtils->SetGlobalIDPar(ParGlobalBCs,iParNumber);
+	    }//loop over entries
+
+	    //access GlobalID hiostograms for each PAR
+	    for(Short_t iParNumber=1; iParNumber<fEMCALRecoUtils->GetNPars()+1;iParNumber++){
+	      TH1C *hPar = (TH1C*)trecalpass->FindObject( Form("h%d_%llu",fRunNumber,fEMCALRecoUtils->GetGlobalIDPar(iParNumber-1) ) );
+	      if (!hPar) AliError( Form("Could not load h%d_%llu",fRunNumber,fEMCALRecoUtils->GetGlobalIDPar(iParNumber-1) ) );
+	      hPar->SetDirectory(0);
+	      SetEMCALL1PhaseInTimeRecalibrationForAllSM(hPar,iParNumber);
+	    }//loop over PARs
+	  }//end if tGID present
         }
         else 
         {       
           AliError("Do not calibrate L1 phase time");
           fEMCALRecoUtils->SwitchOffL1PhaseInTimeRecalibration();
-        }
+        }//end of if(trecalpass)
       }
       else 
       {       
         AliError("Do not calibrate L1 phase time");
         fEMCALRecoUtils->SwitchOffL1PhaseInTimeRecalibration();
-      }
+      }//end of if(trecal)
       
       delete contTRF;
     }//End of Time L1 phase racalibration 
@@ -2173,11 +2190,11 @@ void AliCalorimeterUtils::RecalibrateCellTime(Double_t & time, Int_t calo, Int_t
 //____________________________________________________________________________________________________
 /// Recalculate time L1 phase shift if time recalibration available for EMCAL.
 //____________________________________________________________________________________________________
-void AliCalorimeterUtils::RecalibrateCellTimeL1Phase(Double_t & time, Int_t calo, Int_t iSM, Int_t bunchCrossNumber) const
+void AliCalorimeterUtils::RecalibrateCellTimeL1Phase(Double_t & time, Int_t calo, Int_t iSM, Int_t bunchCrossNumber, Short_t parNumber) const
 {  
   if ( calo == AliFiducialCut::kEMCAL && GetEMCALRecoUtils()->IsL1PhaseInTimeRecalibrationOn() ) 
   {
-    GetEMCALRecoUtils()->RecalibrateCellTimeL1Phase(iSM, bunchCrossNumber, time);
+    GetEMCALRecoUtils()->RecalibrateCellTimeL1Phase(iSM, bunchCrossNumber, time, parNumber);
   }
 }
 

--- a/PWG/CaloTrackCorrBase/AliCalorimeterUtils.h
+++ b/PWG/CaloTrackCorrBase/AliCalorimeterUtils.h
@@ -259,7 +259,7 @@ class AliCalorimeterUtils : public TObject {
   void          SetPHOSChannelRecalibrationFactors (TObjArray *map)      { fPHOSRecalibrationFactors  = map;}
 
   void          RecalibrateCellTime       (Double_t & time, Int_t calo, Int_t absId, Int_t bunchCrossNumber) const ;
-  void          RecalibrateCellTimeL1Phase(Double_t & time, Int_t calo, Int_t iSM  , Int_t bunchCrossNumber) const;
+  void          RecalibrateCellTimeL1Phase(Double_t & time, Int_t calo, Int_t iSM  , Int_t bunchCrossNumber, Short_t par=0) const;
   void          RecalibrateCellAmplitude  (Float_t  & amp , Int_t calo, Int_t absId) const ;
   Float_t       RecalibrateClusterEnergy(AliVCluster* cluster, AliVCaloCells * cells);
   Float_t       RecalibrateClusterEnergyWeightCell(AliVCluster* cluster, AliVCaloCells * cells, Float_t energyOrg);
@@ -296,13 +296,21 @@ class AliCalorimeterUtils : public TObject {
   void     SwitchOffL1PhaseInTimeRecalibration()           { fEMCALRecoUtils->SwitchOffL1PhaseInTimeRecalibration()   ; }
   void     SwitchOnL1PhaseInTimeRecalibration()            { fEMCALRecoUtils->SwitchOnL1PhaseInTimeRecalibration()    ; }
 
-  Int_t    GetEMCALL1PhaseInTimeRecalibrationForSM(Int_t iSM) const        { return fEMCALRecoUtils->GetEMCALL1PhaseInTimeRecalibrationForSM(iSM)   ; }
-  void     SetEMCALL1PhaseInTimeRecalibrationForSM(Int_t iSM, Int_t c = 0) { return fEMCALRecoUtils->SetEMCALL1PhaseInTimeRecalibrationForSM(iSM,c) ; }
+  Int_t    GetEMCALL1PhaseInTimeRecalibrationForSM(Int_t iSM, Short_t par=0) const        { return fEMCALRecoUtils->GetEMCALL1PhaseInTimeRecalibrationForSM(iSM,par) ; }
+  void     SetEMCALL1PhaseInTimeRecalibrationForSM(Int_t iSM, Int_t c = 0, Short_t par=0) { return fEMCALRecoUtils->SetEMCALL1PhaseInTimeRecalibrationForSM(iSM,c,par) ; }
   
-  TH1C *   GetEMCALL1PhaseInTimeRecalibrationForAllSM()const          { return fEMCALRecoUtils->GetEMCALL1PhaseInTimeRecalibrationForAllSM() ; }
-  void     SetEMCALL1PhaseInTimeRecalibrationForAllSM(TObjArray *map) { fEMCALRecoUtils->SetEMCALL1PhaseInTimeRecalibrationForAllSM(map)     ; }
-  void     SetEMCALL1PhaseInTimeRecalibrationForAllSM(TH1C* h)        { fEMCALRecoUtils->SetEMCALL1PhaseInTimeRecalibrationForAllSM(h)       ; }
+  TH1C *   GetEMCALL1PhaseInTimeRecalibrationForAllSM(Short_t par=0) const    { return fEMCALRecoUtils->GetEMCALL1PhaseInTimeRecalibrationForAllSM(par) ; }
+  void     SetEMCALL1PhaseInTimeRecalibrationForAllSM(TObjArray *map)         { fEMCALRecoUtils->SetEMCALL1PhaseInTimeRecalibrationForAllSM(map)        ; }
+  void     SetEMCALL1PhaseInTimeRecalibrationForAllSM(TH1C* h, Short_t par=0) { fEMCALRecoUtils->SetEMCALL1PhaseInTimeRecalibrationForAllSM(h,par)      ; }
 
+  Bool_t  IsParRun() { return fEMCALRecoUtils->IsParRun() ; }
+  Short_t GetCurrentParNumber()         { return fEMCALRecoUtils->GetCurrentParNumber() ; }
+  void SetCurrentParNumber(Short_t par) { fEMCALRecoUtils->SetCurrentParNumber(par)     ; }
+  Short_t GetNPars()             { return fEMCALRecoUtils->GetNPars() ; }
+  void SetNPars(Short_t npars)   { fEMCALRecoUtils->SetNPars(npars)   ; }
+  ULong64_t GetGlobalIDPar(Short_t par)            { return fEMCALRecoUtils->GetGlobalIDPar(par) ; }
+  void SetGlobalIDPar(ULong64_t glob, Short_t par) { fEMCALRecoUtils->SetGlobalIDPar(glob,par)   ; }
+  
   //------------------------------
   // EMCAL specific utils for the moment
   //------------------------------

--- a/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
+++ b/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.h
@@ -244,19 +244,38 @@ public:
     if(!fEMCALL1PhaseInTimeRecalibration) InitEMCALL1PhaseInTimeRecalibration() ; }
   void     InitEMCALL1PhaseInTimeRecalibration() ;
 
-  void     RecalibrateCellTimeL1Phase(Int_t iSM, Int_t bc, Double_t & time) const;
+  void     RecalibrateCellTimeL1Phase(Int_t iSM, Int_t bc, Double_t & time, Short_t par=0) const;
   TObjArray* GetEMCALL1PhaseInTimeRecalibrationArray() const { return fEMCALL1PhaseInTimeRecalibration ; }
-  Int_t  GetEMCALL1PhaseInTimeRecalibrationForSM(Int_t iSM) const { 
+  Int_t  GetEMCALL1PhaseInTimeRecalibrationForSM(Int_t iSM, Short_t par=0) const { 
     if(fEMCALL1PhaseInTimeRecalibration) 
-      return (Int_t) ((TH1C*)fEMCALL1PhaseInTimeRecalibration->At(0))->GetBinContent(iSM); 
+      return (Int_t) ((TH1C*)fEMCALL1PhaseInTimeRecalibration->At(par))->GetBinContent(iSM); 
     else return 0 ; } 
-  void     SetEMCALL1PhaseInTimeRecalibrationForSM(Int_t iSM, Int_t c = 0) { 
+  void     SetEMCALL1PhaseInTimeRecalibrationForSM(Int_t iSM, Int_t c = 0, Short_t par=0) { 
     if(!fEMCALL1PhaseInTimeRecalibration) InitEMCALL1PhaseInTimeRecalibration();
-    ((TH1C*)fEMCALL1PhaseInTimeRecalibration->At(0))->SetBinContent(iSM,c) ; }  
+    ((TH1C*)fEMCALL1PhaseInTimeRecalibration->At(par))->SetBinContent(iSM,c) ; }  
   
-  TH1C *   GetEMCALL1PhaseInTimeRecalibrationForAllSM()const       { return (TH1C*)fEMCALL1PhaseInTimeRecalibration->At(0) ; }	
+  TH1C *   GetEMCALL1PhaseInTimeRecalibrationForAllSM(Short_t par=0) const      { return (TH1C*)fEMCALL1PhaseInTimeRecalibration->At(par) ; }	
   void     SetEMCALL1PhaseInTimeRecalibrationForAllSM(const TObjArray *map);
-  void     SetEMCALL1PhaseInTimeRecalibrationForAllSM(const TH1C* h);
+  void     SetEMCALL1PhaseInTimeRecalibrationForAllSM(const TH1C* h, Short_t par=0);
+
+  void SwitchOnParRun()  { fIsParRun = kTRUE ; }
+  void SwitchOffParRun() { fIsParRun = kFALSE ; }
+  Bool_t IsParRun()      { return fIsParRun ; }
+  Short_t GetCurrentParNumber()         { return fCurrentParNumber ; }
+  void SetCurrentParNumber(Short_t par) { fCurrentParNumber = par ; }
+  Short_t GetNPars()                    { return fNPars ; }
+  void SetNPars(Short_t npars)          { fNPars = npars ;
+    if(fGlobalEventID) delete fGlobalEventID;
+    fGlobalEventID = new ULong64_t[npars];
+    for(Short_t i=0;i<npars;i++) fGlobalEventID[i]=0; 
+  }
+  ULong64_t GetGlobalIDPar(Short_t par) {
+    return par<fNPars ? fGlobalEventID[par] : 0 ;
+  }
+  void SetGlobalIDPar(ULong64_t glob, Short_t par) {
+    if(par < fNPars) fGlobalEventID[par] = glob ;
+    else AliInfo("PAR index exceeds max number of PARs in the run");
+  }
 
   //-----------------------------------------------------
   // Modules fiducial region, remove clusters in borders
@@ -516,6 +535,10 @@ private:
   // Time Recalibration with L1 phase 
   Bool_t     fUseL1PhaseInTimeRecalibration;   ///< Switch on or off the L1 phase in time recalibration
   TObjArray* fEMCALL1PhaseInTimeRecalibration; ///< Histogram with map of L1 phase per SM, EMCAL
+  Bool_t     fIsParRun;                        //!<! flag if run contains PAR
+  Short_t    fCurrentParNumber;                //!<! Current par number
+  Short_t    fNPars;                           ///< Number of PARs in run
+  ULong64_t* fGlobalEventID;                   ///< array with globalID for PAR runs
   Bool_t     fDoUseMergedBC;                   ///< flag for using one histo for all BCs
 
   // Recalibrate with run dependent corrections, energy
@@ -591,7 +614,7 @@ private:
   Bool_t     fMCGenerToAcceptForTrack;   ///<  Activate the removal of tracks entering the track matching that come from a particular generator
   
   /// \cond CLASSIMP
-  ClassDef(AliEMCALRecoUtils, 31) ;
+  ClassDef(AliEMCALRecoUtils, 32) ;
   /// \endcond
 
 };

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALTimeCalib.cxx
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALTimeCalib.cxx
@@ -13,6 +13,7 @@
  * provided "as is" without express or implied warranty.                  *
  **************************************************************************/
 
+#include <vector>
 #include <TChain.h>
 #include <TTree.h>
 #include <TFile.h>
@@ -1896,7 +1897,8 @@ const  Double_t upperLimit[]={
     if(iPAR != info.numPARs){
       hPARRun[iPAR] =new TH1C(Form("h%d_%llu", runNumber, info.PARGlobalBCs[iPAR]), Form("h%d_%llu", runNumber, info.PARGlobalBCs[iPAR]),19,0,19);
     }else{
-      hPARRun[iPAR] =new TH1C(Form("h%dp%d", runNumber,iPAR), Form("h%d", runNumber),19,0,19);
+      //hPARRun[iPAR] =new TH1C(Form("h%dp%d", runNumber,iPAR), Form("h%d", runNumber),19,0,19);
+      hPARRun[iPAR] =new TH1C(Form("h%d", runNumber), Form("h%d", runNumber),19,0,19);
     }
     for(Int_t i=0;i<20;i++){
       minimumValue=10000;
@@ -2006,6 +2008,17 @@ const  Double_t upperLimit[]={
       hPARRun[iPAR]->Write();
       delete hPARRun[iPAR];
     }
+    // create tree for PAR global IDs
+    ULong64_t ParGlobalBCs;
+    TTree *treePAR=new TTree(Form("t%d_GID",runNumber),"Tree with Global ID");
+    treePAR->Branch("GID",&ParGlobalBCs,"GID/l");
+
+    for(Int_t iPAR = 0; iPAR < info.numPARs; iPAR++){
+      ParGlobalBCs=(ULong64_t)(info.PARGlobalBCs[iPAR]);
+      //printf("infoPAR %llu in tree %llu",info.PARGlobalBCs[iPAR],ParGlobalBCs);
+      treePAR->Fill();
+    }
+    treePAR->Write();
   }else{
     hRun->Write();
     delete hRun;


### PR DESCRIPTION
L1 phase in EMCal time calibration macro modified to store object with PAR Global IDs.
AliCalorimeterUtils modified to read OADB object with PAR Global IDs for EMCal.
AliEMCALRecoUtils modified to access L1 phases for PAR runs.
Default is still like for the run without PAR.