### PR TITLE
Tuning of L1 phase extraction for PAR runs in EMCal

### DIFF
--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALTimeCalib.cxx
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALTimeCalib.cxx
@@ -334,10 +334,11 @@ void AliAnalysisTaskEMCALTimeCalib::SetL1PhaseReferencePAR(){
   if(fhRefRuns!=0x0){
     TString refName(fhRefRuns->GetName());
     TString correctName;
-    if(fCurrentPARIndex < fCurrentPARs.numPARs){
-        correctName = Form("h%d_%llu", fRunNumber, fCurrentPARs.PARGlobalBCs[fCurrentPARIndex]);
+    if(fCurrentPARIndex==0){//before any PAR
+      correctName = Form("h%d", fRunNumber);
+      //if(fCurrentPARIndex < fCurrentPARs.numPARs){
     }else{
-        correctName = Form("h%d", fRunNumber);
+      correctName = Form("h%d_%llu", fRunNumber, fCurrentPARs.PARGlobalBCs[fCurrentPARIndex-1]);
     }
     if(refName.CompareTo(correctName)==0) return;
   }
@@ -351,19 +352,18 @@ void AliAnalysisTaskEMCALTimeCalib::SetL1PhaseReferencePAR(){
     AliFatal("Negative run number");
     return;
   }
-    if(fCurrentPARIndex < fCurrentPARs.numPARs){
-    fhRefRuns=(TH1C*)fL1PhaseList->FindObject(Form("h%d_%llu", fRunNumber, fCurrentPARs.PARGlobalBCs[fCurrentPARIndex]));
-  }else{
+  if(fCurrentPARIndex == 0){
     fhRefRuns=(TH1C*)fL1PhaseList->FindObject(Form("h%d", fRunNumber));
+  }else{
+    fhRefRuns=(TH1C*)fL1PhaseList->FindObject(Form("h%d_%llu", fRunNumber, fCurrentPARs.PARGlobalBCs[fCurrentPARIndex-1]));
   }
 
   if(fhRefRuns==0x0){
-      AliFatal(Form("No Reference R-b-R histo found for run %d PAR %d!", fRunNumber, fCurrentPARIndex));
-      return;
-    }
+    AliFatal(Form("No Reference R-b-R histo found for run %d PAR %d!", fRunNumber, fCurrentPARIndex));
+    return;
+  }
   if(fhRefRuns->GetEntries()==0)AliWarning("fhRefRuns->GetEntries() = 0");
   AliDebug(1,Form("hRefRuns entries %d", (Int_t)fhRefRuns->GetEntries() ));
-
 }
 
 //_____________________________________________________________________
@@ -1030,18 +1030,18 @@ void AliAnalysisTaskEMCALTimeCalib::UserExec(Option_t *)
   Int_t mostEneId=-1;
   Float_t mostEneEn=0.;
   
-  fCurrentPARIndex = 0;
+  fCurrentPARIndex = 0;//before any PAR
   if(fIsPARRun){
-      ULong64_t eventBC = (ULong64_t)event->GetBunchCrossNumber();
-      ULong64_t eventOrbit = ((ULong64_t)(3564))*((ULong64_t)event->GetOrbitNumber());
-      ULong64_t eventPeriod = ((ULong64_t)(59793994260))*((ULong64_t)(event->GetPeriodNumber()));
-      //ULong64_t globalBC = event->GetBunchCrossNumber() + 3564*event->GetOrbitNumber() + 59793994260*event->GetPeriodNumber();
-      ULong64_t globalBC = eventBC + eventOrbit + eventPeriod;
-      for(int ipar = 0; ipar < fCurrentPARs.numPARs; ipar++){
-          if(globalBC >= fCurrentPARs.PARGlobalBCs[ipar]){
-              fCurrentPARIndex ++;
-          }
+    ULong64_t eventBC = (ULong64_t)event->GetBunchCrossNumber();
+    ULong64_t eventOrbit = ((ULong64_t)(3564))*((ULong64_t)event->GetOrbitNumber());
+    ULong64_t eventPeriod = ((ULong64_t)(59793994260))*((ULong64_t)(event->GetPeriodNumber()));
+    //ULong64_t globalBC = event->GetBunchCrossNumber() + 3564*event->GetOrbitNumber() + 59793994260*event->GetPeriodNumber();
+    ULong64_t globalBC = eventBC + eventOrbit + eventPeriod;
+    for(int ipar = 0; ipar < fCurrentPARs.numPARs; ipar++){
+      if(globalBC >= fCurrentPARs.PARGlobalBCs[ipar]){
+	fCurrentPARIndex ++;
       }
+    }
   }
   if(fReferenceRunByRunFileName.Length()!=0 && fIsPARRun){
     SetL1PhaseReferencePAR();
@@ -1499,256 +1499,256 @@ void AliAnalysisTaskEMCALTimeCalib::ProduceCalibConsts(TString inputFile,TString
     }
   }
   numPARs = Int_t(counter/4) - 1;
-  printf("number of PARs found to be %d!\n", numPARs);
+  printf("number of PARs found to be %d!\n",numPARs);
 
   if(numPARs == -1) isPAR = kFALSE;
 
   if(!oneHistoAllBCs){
-	  //high gain
-	  TH1F *h1[4];
-	  TH1F *h2[4];
-	  TH1F *h3[4];
-	  TH1F *hAllTimeAvBC[4];
-	  TH1F *hAllTimeRMSBC[4];
-
-	  //low gain
-	  TH1F *h4[4];
-	  TH1F *h5[4];
-	  TH1F *h6[4];
-	  TH1F *hAllTimeAvLGBC[4];
-	  TH1F *hAllTimeRMSLGBC[4];
-
-	  //PAR histos
-	  TH1F *h1PAR[numPARs+1][4];
-	  TH1F *h2PAR[numPARs+1][4];
-	  //TH1F *h3PAR[numPARs+1][4];
-	  TH1F *hAllTimeAvBCPAR[numPARs+1][4];
-	  //TH1F *hAllTimeRMSBCPAR[numPARs+1][4];
-
-	  TH1F *h4PAR[numPARs+1][4];
-	  TH1F *h5PAR[numPARs+1][4];
-	  //TH1F *h6PAR[numPARs+1][4];
-	  TH1F *hAllTimeAvLGBCPAR[numPARs+1][4];
-	  //TH1F *hAllTimeRMSLGBCPAR[numPARs+1][4];
-
-	  TH2D* raw2D[4];
-	  TH2D* rawLG2D[4];
-
-	  if(isFinal==kFALSE){//first itereation
-	    for(Int_t i=0;i<4;i++){
-	      h1[i]=(TH1F *)list->FindObject(Form("RawTimeSumBC%d",i));
-	      h2[i]=(TH1F *)list->FindObject(Form("RawTimeEntriesBC%d",i));
-	      h3[i]=(TH1F *)list->FindObject(Form("RawTimeSumSqBC%d",i));
-	      
-	      h4[i]=(TH1F *)list->FindObject(Form("RawTimeSumLGBC%d",i));
-	      h5[i]=(TH1F *)list->FindObject(Form("RawTimeEntriesLGBC%d",i));
-	      h6[i]=(TH1F *)list->FindObject(Form("RawTimeSumSqLGBC%d",i));
-	      
-	      if(isPAR){ //set-up histograms for different PAR time regions
-		for(Int_t iPAR = 0; iPAR <= numPARs; iPAR++){
-		  raw2D[i] = (TH2D*)list->FindObject(Form("RawTimeBeforePAR%dBC%d", iPAR+1, i));
-		  rawLG2D[i] = (TH2D*)list->FindObject(Form("RawTimeLGBeforePAR%dBC%d", iPAR+1, i));
-		  h1PAR[iPAR][i] = new TH1F(Form("hAllTimeSumPAR%dBC%d",iPAR, i), Form("hAlltimeSumPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
-		  hAllTimeAvBCPAR[iPAR][i] = new TH1F(Form("hAllTimeAvPAR%dBC%d",iPAR, i), Form("hAlltimeAvPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
-		  h2PAR[iPAR][i] = (TH1F*)raw2D[i]->ProjectionX(Form("hAllTimeEntriesPAR%dBC%d",iPAR, i), 0, raw2D[i]->GetYaxis()->GetNbins());
-
-		  h4PAR[iPAR][i] = new TH1F(Form("hAllTimeSumLGPAR%dBC%d",iPAR, i), Form("hAllTimeSumLGPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
-		  hAllTimeAvLGBCPAR[iPAR][i] = new TH1F(Form("hAllTimeAvLGPAR%dBC%d",iPAR, i), Form("hAlltimeAvLGPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
-		  h5PAR[iPAR][i] = (TH1F*)raw2D[i]->ProjectionX(Form("hAllTimeEntriesPAR%dLGBC%d",iPAR, i), 0, raw2D[i]->GetYaxis()->GetNbins());
-		  for(int ixbin = 0; ixbin < raw2D[i]->GetXaxis()->GetNbins(); ixbin++){
-		      float sumtime = 0.0;
-		      float sumLGtime = 0.0;
-		      for(int iybin = 0; iybin < raw2D[i]->GetYaxis()->GetNbins(); iybin++){
-		          sumtime += raw2D[i]->GetBinContent(ixbin, iybin)*raw2D[i]->GetYaxis()->GetBinCenter(iybin);
-		          sumLGtime += rawLG2D[i]->GetBinContent(ixbin, iybin)*rawLG2D[i]->GetYaxis()->GetBinCenter(iybin);
-		      }
-		      h1PAR[iPAR][i]->SetBinContent(ixbin, sumtime);
-		      h4PAR[iPAR][i]->SetBinContent(ixbin, sumLGtime);
-		      if(h2PAR[iPAR][i]->GetBinContent(ixbin) ==0){
-		          hAllTimeAvBCPAR[iPAR][i]->SetBinContent(ixbin, 0);
-		      }else{
-		          hAllTimeAvBCPAR[iPAR][i]->SetBinContent(ixbin, h1PAR[iPAR][i]->GetBinContent(ixbin)/h2PAR[iPAR][i]->GetBinContent(ixbin));
-		      }
-
-		      if(h5PAR[iPAR][i]->GetBinContent(ixbin) ==0){
-		          hAllTimeAvLGBCPAR[iPAR][i]->SetBinContent(ixbin, 0);
-		      }else{
-		          hAllTimeAvLGBCPAR[iPAR][i]->SetBinContent(ixbin, h4PAR[iPAR][i]->GetBinContent(ixbin)/h5PAR[iPAR][i]->GetBinContent(ixbin));
-		      }
-		  }
-
-		}
+    //high gain
+    TH1F *h1[4];
+    TH1F *h2[4];
+    TH1F *h3[4];
+    TH1F *hAllTimeAvBC[4];
+    TH1F *hAllTimeRMSBC[4];
+    
+    //low gain
+    TH1F *h4[4];
+    TH1F *h5[4];
+    TH1F *h6[4];
+    TH1F *hAllTimeAvLGBC[4];
+    TH1F *hAllTimeRMSLGBC[4];
+    
+    //PAR histos
+    TH1F *h1PAR[numPARs+1][4];
+    TH1F *h2PAR[numPARs+1][4];
+    //TH1F *h3PAR[numPARs+1][4];
+    TH1F *hAllTimeAvBCPAR[numPARs+1][4];
+    //TH1F *hAllTimeRMSBCPAR[numPARs+1][4];
+    
+    TH1F *h4PAR[numPARs+1][4];
+    TH1F *h5PAR[numPARs+1][4];
+    //TH1F *h6PAR[numPARs+1][4];
+    TH1F *hAllTimeAvLGBCPAR[numPARs+1][4];
+    //TH1F *hAllTimeRMSLGBCPAR[numPARs+1][4];
+    
+    TH2D* raw2D[4];
+    TH2D* rawLG2D[4];
+    
+    if(isFinal==kFALSE){//first itereation
+      for(Int_t i=0;i<4;i++){
+	h1[i]=(TH1F *)list->FindObject(Form("RawTimeSumBC%d",i));
+	h2[i]=(TH1F *)list->FindObject(Form("RawTimeEntriesBC%d",i));
+	h3[i]=(TH1F *)list->FindObject(Form("RawTimeSumSqBC%d",i));
+	
+	h4[i]=(TH1F *)list->FindObject(Form("RawTimeSumLGBC%d",i));
+	h5[i]=(TH1F *)list->FindObject(Form("RawTimeEntriesLGBC%d",i));
+	h6[i]=(TH1F *)list->FindObject(Form("RawTimeSumSqLGBC%d",i));
+	
+	if(isPAR){ //set-up histograms for different PAR time regions
+	  for(Int_t iPAR = 0; iPAR <= numPARs; iPAR++){
+	    raw2D[i] = (TH2D*)list->FindObject(Form("RawTimeBeforePAR%dBC%d", iPAR+1, i));
+	    rawLG2D[i] = (TH2D*)list->FindObject(Form("RawTimeLGBeforePAR%dBC%d", iPAR+1, i));
+	    h1PAR[iPAR][i] = new TH1F(Form("hAllTimeSumPAR%dBC%d",iPAR, i), Form("hAlltimeSumPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
+	    hAllTimeAvBCPAR[iPAR][i] = new TH1F(Form("hAllTimeAvPAR%dBC%d",iPAR, i), Form("hAlltimeAvPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
+	    h2PAR[iPAR][i] = (TH1F*)raw2D[i]->ProjectionX(Form("hAllTimeEntriesPAR%dBC%d",iPAR, i), 0, raw2D[i]->GetYaxis()->GetNbins());
+	    
+	    h4PAR[iPAR][i] = new TH1F(Form("hAllTimeSumLGPAR%dBC%d",iPAR, i), Form("hAllTimeSumLGPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
+	    hAllTimeAvLGBCPAR[iPAR][i] = new TH1F(Form("hAllTimeAvLGPAR%dBC%d",iPAR, i), Form("hAlltimeAvLGPAR%dBC%d",iPAR, i), raw2D[i]->GetXaxis()->GetNbins(), raw2D[i]->GetXaxis()->GetXmin(), raw2D[i]->GetXaxis()->GetXmax());
+	    h5PAR[iPAR][i] = (TH1F*)raw2D[i]->ProjectionX(Form("hAllTimeEntriesPAR%dLGBC%d",iPAR, i), 0, raw2D[i]->GetYaxis()->GetNbins());
+	    for(int ixbin = 0; ixbin < raw2D[i]->GetXaxis()->GetNbins(); ixbin++){
+	      float sumtime = 0.0;
+	      float sumLGtime = 0.0;
+	      for(int iybin = 0; iybin < raw2D[i]->GetYaxis()->GetNbins(); iybin++){
+		sumtime += raw2D[i]->GetBinContent(ixbin, iybin)*raw2D[i]->GetYaxis()->GetBinCenter(iybin);
+		sumLGtime += rawLG2D[i]->GetBinContent(ixbin, iybin)*rawLG2D[i]->GetYaxis()->GetBinCenter(iybin);
+	      }//end of loop over y-bins
+	      h1PAR[iPAR][i]->SetBinContent(ixbin, sumtime);
+	      h4PAR[iPAR][i]->SetBinContent(ixbin, sumLGtime);
+	      if(h2PAR[iPAR][i]->GetBinContent(ixbin) ==0){
+		hAllTimeAvBCPAR[iPAR][i]->SetBinContent(ixbin, 0);
+	      }else{
+		hAllTimeAvBCPAR[iPAR][i]->SetBinContent(ixbin, h1PAR[iPAR][i]->GetBinContent(ixbin)/h2PAR[iPAR][i]->GetBinContent(ixbin));
 	      }
-	    }
-	  } else {//final iteration
-	    for(Int_t i=0;i<4;i++){
-	      h1[i]=(TH1F *)list->FindObject(Form("hTimeSum%d",i));
-	      h2[i]=(TH1F *)list->FindObject(Form("hTimeEnt%d",i));
-	      h3[i]=(TH1F *)list->FindObject(Form("hTimeSumSq%d",i));
 	      
-	      h4[i]=(TH1F *)list->FindObject(Form("hTimeLGSum%d",i));
-	      h5[i]=(TH1F *)list->FindObject(Form("hTimeLGEnt%d",i));
-	      h6[i]=(TH1F *)list->FindObject(Form("hTimeLGSumSq%d",i));
-	    }
-	  }
-	  //AliWarning("Input histograms read.");
+	      if(h5PAR[iPAR][i]->GetBinContent(ixbin) ==0){
+		hAllTimeAvLGBCPAR[iPAR][i]->SetBinContent(ixbin, 0);
+	      }else{
+		hAllTimeAvLGBCPAR[iPAR][i]->SetBinContent(ixbin, h4PAR[iPAR][i]->GetBinContent(ixbin)/h5PAR[iPAR][i]->GetBinContent(ixbin));
+	      }
+	    }//end of loop over x-bins
 
-	  for(Int_t i=0;i<4;i++){
-	    hAllTimeAvBC[i]=new TH1F(Form("hAllTimeAvBC%d",i),Form("hAllTimeAvBC%d",i),h1[i]->GetNbinsX(),h1[i]->GetXaxis()->GetXmin(),h1[i]->GetXaxis()->GetXmax());
-	    hAllTimeRMSBC[i]=new TH1F(Form("hAllTimeRMSBC%d",i),Form("hAllTimeRMSBC%d",i),h3[i]->GetNbinsX(),h3[i]->GetXaxis()->GetXmin(),h3[i]->GetXaxis()->GetXmax());
+	  }//end of loop over PARs
+	}//end of if(isPAR)
+      }//end of loop over BC 
+    } else {//final iteration
+      for(Int_t i=0;i<4;i++){
+	h1[i]=(TH1F *)list->FindObject(Form("hTimeSum%d",i));
+	h2[i]=(TH1F *)list->FindObject(Form("hTimeEnt%d",i));
+	h3[i]=(TH1F *)list->FindObject(Form("hTimeSumSq%d",i));
+	
+	h4[i]=(TH1F *)list->FindObject(Form("hTimeLGSum%d",i));
+	h5[i]=(TH1F *)list->FindObject(Form("hTimeLGEnt%d",i));
+	h6[i]=(TH1F *)list->FindObject(Form("hTimeLGSumSq%d",i));
+      }
+    }
+    //AliWarning("Input histograms read.");
 
-	    hAllTimeAvLGBC[i]=new TH1F(Form("hAllTimeAvLGBC%d",i),Form("hAllTimeAvLGBC%d",i),h4[i]->GetNbinsX(),h4[i]->GetXaxis()->GetXmin(),h4[i]->GetXaxis()->GetXmax());
-	    hAllTimeRMSLGBC[i]=new TH1F(Form("hAllTimeRMSLGBC%d",i),Form("hAllTimeRMSLGBC%d",i),h6[i]->GetNbinsX(),h6[i]->GetXaxis()->GetXmin(),h6[i]->GetXaxis()->GetXmax());
-	  }
+    for(Int_t i=0;i<4;i++){
+      hAllTimeAvBC[i]=new TH1F(Form("hAllTimeAvBC%d",i),Form("hAllTimeAvBC%d",i),h1[i]->GetNbinsX(),h1[i]->GetXaxis()->GetXmin(),h1[i]->GetXaxis()->GetXmax());
+      hAllTimeRMSBC[i]=new TH1F(Form("hAllTimeRMSBC%d",i),Form("hAllTimeRMSBC%d",i),h3[i]->GetNbinsX(),h3[i]->GetXaxis()->GetXmin(),h3[i]->GetXaxis()->GetXmax());
+      
+      hAllTimeAvLGBC[i]=new TH1F(Form("hAllTimeAvLGBC%d",i),Form("hAllTimeAvLGBC%d",i),h4[i]->GetNbinsX(),h4[i]->GetXaxis()->GetXmin(),h4[i]->GetXaxis()->GetXmax());
+      hAllTimeRMSLGBC[i]=new TH1F(Form("hAllTimeRMSLGBC%d",i),Form("hAllTimeRMSLGBC%d",i),h6[i]->GetNbinsX(),h6[i]->GetXaxis()->GetXmin(),h6[i]->GetXaxis()->GetXmax());
+    }
 	  
-	  //AliWarning("New histograms booked.");
+    //AliWarning("New histograms booked.");
 
-	  //important remark: we use 'underflow bin' for absid=0 in OADB  . That's why there is j-1 below.
-	  for(Int_t i=0;i<4;i++){
-	    for(Int_t j=1;j<=h1[i]->GetNbinsX();j++){
-	      //high gain
-	      if(h2[i]->GetBinContent(j)!=0){
-		hAllTimeAvBC[i]->SetBinContent(j-1,h1[i]->GetBinContent(j)/h2[i]->GetBinContent(j));
-		hAllTimeRMSBC[i]->SetBinContent(j-1,TMath::Sqrt(h3[i]->GetBinContent(j)/h2[i]->GetBinContent(j)) );
-	      } else {
-		hAllTimeAvBC[i]->SetBinContent(j-1,0.);
-		hAllTimeRMSBC[i]->SetBinContent(j-1,0.);
-	      }
-	      //low gain
-	      if(h5[i]->GetBinContent(j)!=0){
-		hAllTimeAvLGBC[i]->SetBinContent(j-1,h4[i]->GetBinContent(j)/h5[i]->GetBinContent(j));
-		hAllTimeRMSLGBC[i]->SetBinContent(j-1,TMath::Sqrt(h6[i]->GetBinContent(j)/h5[i]->GetBinContent(j)) );
-	      } else {
-		hAllTimeAvLGBC[i]->SetBinContent(j-1,0.);
-		hAllTimeRMSLGBC[i]->SetBinContent(j-1,0.);
-	      }
+    //important remark: we use 'underflow bin' for absid=0 in OADB  . That's why there is j-1 below.
+    for(Int_t i=0;i<4;i++){
+      for(Int_t j=1;j<=h1[i]->GetNbinsX();j++){
+	//high gain
+	if(h2[i]->GetBinContent(j)!=0){
+	  hAllTimeAvBC[i]->SetBinContent(j-1,h1[i]->GetBinContent(j)/h2[i]->GetBinContent(j));
+	  hAllTimeRMSBC[i]->SetBinContent(j-1,TMath::Sqrt(h3[i]->GetBinContent(j)/h2[i]->GetBinContent(j)) );
+	} else {
+	  hAllTimeAvBC[i]->SetBinContent(j-1,0.);
+	  hAllTimeRMSBC[i]->SetBinContent(j-1,0.);
+	}
+	//low gain
+	if(h5[i]->GetBinContent(j)!=0){
+	  hAllTimeAvLGBC[i]->SetBinContent(j-1,h4[i]->GetBinContent(j)/h5[i]->GetBinContent(j));
+	  hAllTimeRMSLGBC[i]->SetBinContent(j-1,TMath::Sqrt(h6[i]->GetBinContent(j)/h5[i]->GetBinContent(j)) );
+	} else {
+	  hAllTimeAvLGBC[i]->SetBinContent(j-1,0.);
+	  hAllTimeRMSLGBC[i]->SetBinContent(j-1,0.);
+	}
+	
+      }
+    }
+    
+    //AliWarning("Average and rms calculated.");
+    TFile *fileNew=new TFile(outputFile.Data(),"recreate");
+    for(Int_t i=0;i<4;i++){
+      if(isPAR){
+	for(Int_t iPAR = 0; iPAR <= numPARs; iPAR++){
+	  hAllTimeAvBCPAR[iPAR][i]->Write();
+	  //hAllTimeRMSBCPAR[iPAR][i]->Write();
+	  hAllTimeAvLGBCPAR[iPAR][i]->Write();
+	  //hAllTimeRMSLGBCPAR[iPAR][i]->Write();
+	}
+      }else{
+	hAllTimeAvBC[i]->Write();
+	hAllTimeRMSBC[i]->Write();
+	hAllTimeAvLGBC[i]->Write();
+	hAllTimeRMSLGBC[i]->Write();
+      }
+    }
+    
+    //AliWarning(Form("Histograms saved in %s file.",outputFile.Data()));
 
-	    }
-	  }
-
-	  //AliWarning("Average and rms calculated.");
-	  TFile *fileNew=new TFile(outputFile.Data(),"recreate");
-	  for(Int_t i=0;i<4;i++){
-	    if(isPAR){
-	      for(Int_t iPAR = 0; iPAR <= numPARs; iPAR++){
-		  hAllTimeAvBCPAR[iPAR][i]->Write();
-		  //hAllTimeRMSBCPAR[iPAR][i]->Write();
-		  hAllTimeAvLGBCPAR[iPAR][i]->Write();
-		  //hAllTimeRMSLGBCPAR[iPAR][i]->Write();
-	      }
-	    }else{
-	      hAllTimeAvBC[i]->Write();
-	      hAllTimeRMSBC[i]->Write();
-	      hAllTimeAvLGBC[i]->Write();
-	      hAllTimeRMSLGBC[i]->Write();
-	    }
-	  }
-
-	  //AliWarning(Form("Histograms saved in %s file.",outputFile.Data()));
-
-	  fileNew->Close();
-	  delete fileNew;
-
-	  for(Int_t i=0;i<4;i++){
-	    delete hAllTimeAvBC[i];
-	    delete hAllTimeRMSBC[i];
-	    delete hAllTimeAvLGBC[i];
-	    delete hAllTimeRMSLGBC[i];
-
-	    if(isPAR){ //set-up histograms for different PAR time regions
-	      for(Int_t iPAR = 0; iPAR <= numPARs; iPAR++){
-		delete h1PAR[iPAR][i];
-		delete hAllTimeAvBCPAR[iPAR][i];
-		delete h2PAR[iPAR][i];
-		delete h4PAR[iPAR][i];
-		delete hAllTimeAvLGBCPAR[iPAR][i];
-		delete h5PAR[iPAR][i];
-	      }
-	    }
-	  }
-	  list->SetOwner(1);
-	  delete list;
-	  file->Close();
-	  delete file;
+    fileNew->Close();
+    delete fileNew;
+    
+    for(Int_t i=0;i<4;i++){
+      delete hAllTimeAvBC[i];
+      delete hAllTimeRMSBC[i];
+      delete hAllTimeAvLGBC[i];
+      delete hAllTimeRMSLGBC[i];
+      
+      if(isPAR){ //set-up histograms for different PAR time regions
+	for(Int_t iPAR = 0; iPAR <= numPARs; iPAR++){
+	  delete h1PAR[iPAR][i];
+	  delete hAllTimeAvBCPAR[iPAR][i];
+	  delete h2PAR[iPAR][i];
+	  delete h4PAR[iPAR][i];
+	  delete hAllTimeAvLGBCPAR[iPAR][i];
+	  delete h5PAR[iPAR][i];
+	}
+      }
+    }
+    list->SetOwner(1);
+    delete list;
+    file->Close();
+    delete file;
   }else{
 
-	  //high gain
-	  TH1F *h1;
-	  TH1F *h2;
-	  TH1F *h3;
-	  TH1S *hAllTimeAvBC;
-	  TH1S *hAllTimeRMSBC;
+    //high gain
+    TH1F *h1;
+    TH1F *h2;
+    TH1F *h3;
+    TH1S *hAllTimeAvBC;
+    TH1S *hAllTimeRMSBC;
+    
+    //low gain
+    TH1F *h4;
+    TH1F *h5;
+    TH1F *h6;
+    TH1S *hAllTimeAvLGBC;
+    TH1S *hAllTimeRMSLGBC;
+    
+    h1=(TH1F *)list->FindObject("hTimeSumAllBCs");
+    h2=(TH1F *)list->FindObject("hTimeEntAllBCs");
+    h3=(TH1F *)list->FindObject("hTimeSumSqAllBCs");
+    
+    h4=(TH1F *)list->FindObject("hTimeLGSumAllBCs");
+    h5=(TH1F *)list->FindObject("hTimeLGEntAllBCs");
+    h6=(TH1F *)list->FindObject("hTimeLGSumSqAllBCs");
+    //AliWarning("Input histograms read.");
+    
+    hAllTimeAvBC=new TH1S("hAllTimeAv","hAllTimeAv",h1->GetNbinsX(),h1->GetXaxis()->GetXmin(),h1->GetXaxis()->GetXmax());
+    hAllTimeRMSBC=new TH1S("hAllTimeRMS","hAllTimeRMS",h3->GetNbinsX(),h3->GetXaxis()->GetXmin(),h3->GetXaxis()->GetXmax());
+    
+    hAllTimeAvLGBC=new TH1S("hAllTimeAvLG","hAllTimeAvLG",h4->GetNbinsX(),h4->GetXaxis()->GetXmin(),h4->GetXaxis()->GetXmax());
+    hAllTimeRMSLGBC=new TH1S("hAllTimeRMSLG","hAllTimeRMSLG",h6->GetNbinsX(),h6->GetXaxis()->GetXmin(),h6->GetXaxis()->GetXmax());
+    
+    //AliWarning("New histograms booked.");
+    
+    //important remark: we use 'underflow bin' for absid=0 in OADB  . That's why there is j-1 below.
+    for(Int_t j=1;j<=h1->GetNbinsX();j++){
+      //high gain
+      if(h2->GetBinContent(j)!=0){
+	hAllTimeAvBC->SetBinContent(j-1,h1->GetBinContent(j)/h2->GetBinContent(j));
+	hAllTimeRMSBC->SetBinContent(j-1,TMath::Sqrt(h3->GetBinContent(j)/h2->GetBinContent(j)) );
+      } else {
+	hAllTimeAvBC->SetBinContent(j-1,0.);
+	hAllTimeRMSBC->SetBinContent(j-1,0.);
+      }
+      //low gain
+      if(h5->GetBinContent(j)!=0){
+	hAllTimeAvLGBC->SetBinContent(j-1,h4->GetBinContent(j)/h5->GetBinContent(j));
+	hAllTimeRMSLGBC->SetBinContent(j-1,TMath::Sqrt(h6->GetBinContent(j)/h5->GetBinContent(j)) );
+      } else {
+	hAllTimeAvLGBC->SetBinContent(j-1,0.);
+	hAllTimeRMSLGBC->SetBinContent(j-1,0.);
+      }
+      
+    }
+    
+    //AliWarning("Average and rms calculated.");
+    TFile *fileNew=new TFile(outputFile.Data(),"recreate");
 
-	  //low gain
-	  TH1F *h4;
-	  TH1F *h5;
-	  TH1F *h6;
-	  TH1S *hAllTimeAvLGBC;
-	  TH1S *hAllTimeRMSLGBC;
-
-	  h1=(TH1F *)list->FindObject("hTimeSumAllBCs");
-	  h2=(TH1F *)list->FindObject("hTimeEntAllBCs");
-	  h3=(TH1F *)list->FindObject("hTimeSumSqAllBCs");
-	      
-	  h4=(TH1F *)list->FindObject("hTimeLGSumAllBCs");
-	  h5=(TH1F *)list->FindObject("hTimeLGEntAllBCs");
-	  h6=(TH1F *)list->FindObject("hTimeLGSumSqAllBCs");
-	  //AliWarning("Input histograms read.");
-
-	  hAllTimeAvBC=new TH1S("hAllTimeAv","hAllTimeAv",h1->GetNbinsX(),h1->GetXaxis()->GetXmin(),h1->GetXaxis()->GetXmax());
-	  hAllTimeRMSBC=new TH1S("hAllTimeRMS","hAllTimeRMS",h3->GetNbinsX(),h3->GetXaxis()->GetXmin(),h3->GetXaxis()->GetXmax());
-
-	  hAllTimeAvLGBC=new TH1S("hAllTimeAvLG","hAllTimeAvLG",h4->GetNbinsX(),h4->GetXaxis()->GetXmin(),h4->GetXaxis()->GetXmax());
-	  hAllTimeRMSLGBC=new TH1S("hAllTimeRMSLG","hAllTimeRMSLG",h6->GetNbinsX(),h6->GetXaxis()->GetXmin(),h6->GetXaxis()->GetXmax());
-	  
-	  //AliWarning("New histograms booked.");
-
-	  //important remark: we use 'underflow bin' for absid=0 in OADB  . That's why there is j-1 below.
-	  for(Int_t j=1;j<=h1->GetNbinsX();j++){
-	    //high gain
-	    if(h2->GetBinContent(j)!=0){
-		hAllTimeAvBC->SetBinContent(j-1,h1->GetBinContent(j)/h2->GetBinContent(j));
-		hAllTimeRMSBC->SetBinContent(j-1,TMath::Sqrt(h3->GetBinContent(j)/h2->GetBinContent(j)) );
-	    } else {
-		hAllTimeAvBC->SetBinContent(j-1,0.);
-		hAllTimeRMSBC->SetBinContent(j-1,0.);
-	    }
-	    //low gain
-	    if(h5->GetBinContent(j)!=0){
-		hAllTimeAvLGBC->SetBinContent(j-1,h4->GetBinContent(j)/h5->GetBinContent(j));
-		hAllTimeRMSLGBC->SetBinContent(j-1,TMath::Sqrt(h6->GetBinContent(j)/h5->GetBinContent(j)) );
-	    } else {
-		hAllTimeAvLGBC->SetBinContent(j-1,0.);
-		hAllTimeRMSLGBC->SetBinContent(j-1,0.);
-	    }
-
-	  }
-
-	  //AliWarning("Average and rms calculated.");
-	  TFile *fileNew=new TFile(outputFile.Data(),"recreate");
-
-	  hAllTimeAvBC->Write();
-	  hAllTimeRMSBC->Write();
-	  hAllTimeAvLGBC->Write();
-	  hAllTimeRMSLGBC->Write();
-
-	  //AliWarning(Form("Histograms saved in %s file.",outputFile.Data()));
-
-	  fileNew->Close();
-	  delete fileNew;
-
-	  delete hAllTimeAvBC;
-	  delete hAllTimeRMSBC;
-	  delete hAllTimeAvLGBC;
-	  delete hAllTimeRMSLGBC;
-
-	  list->SetOwner(1);
-	  delete list;
-	  file->Close();
-	  delete file;
-
+    hAllTimeAvBC->Write();
+    hAllTimeRMSBC->Write();
+    hAllTimeAvLGBC->Write();
+    hAllTimeRMSLGBC->Write();
+    
+    //AliWarning(Form("Histograms saved in %s file.",outputFile.Data()));
+    
+    fileNew->Close();
+    delete fileNew;
+    
+    delete hAllTimeAvBC;
+    delete hAllTimeRMSBC;
+    delete hAllTimeAvLGBC;
+    delete hAllTimeRMSLGBC;
+    
+    list->SetOwner(1);
+    delete list;
+    file->Close();
+    delete file;
+    
   }
-
+  
   //AliWarning("Pointers deleted. Memory cleaned.");
 }
 
@@ -1758,7 +1758,7 @@ void AliAnalysisTaskEMCALTimeCalib::ProduceCalibConsts(TString inputFile,TString
 /// output - root file with histograms for given run offset per SM 
 void AliAnalysisTaskEMCALTimeCalib::ProduceOffsetForSMsV2(Int_t runNumber,TString inputFile,TString outputFile, Bool_t offset100, Bool_t justL1phase, TString PARFilename){
 
-const  Double_t lowerLimit[]={
+  const  Double_t lowerLimit[]={
     0,
     1152,
     2304,
@@ -1780,7 +1780,7 @@ const  Double_t lowerLimit[]={
     16896,
     17280};
 
-const  Double_t upperLimit[]={
+  const  Double_t upperLimit[]={
     1151 ,
     2303 ,
     3455 ,
@@ -1806,45 +1806,46 @@ const  Double_t upperLimit[]={
   info.numPARs = 0;
   Bool_t isPAR = kFALSE;
   if(PARFilename.Length() != 0){
-      std::ifstream input;
-      int inputrunnumber = 0, numPARs = 0;
-      ULong64_t PAR = 0;
-      input.open(PARFilename.Data());
-      if(!input.good()){
-          printf("PAR info file not accessable: %s\n", PARFilename.Data());
-          return;
+    std::ifstream input;
+    int inputrunnumber = 0, numPARs = 0;
+    ULong64_t PAR = 0;
+    input.open(PARFilename.Data());
+    if(!input.good()){
+      printf("PAR info file not accessable: %s\n", PARFilename.Data());
+      return;
+    }
+    while(input.good()){
+      input >> inputrunnumber >> numPARs;
+      if(!input.good()) break;
+      info.runNumber = inputrunnumber;
+      info.numPARs = numPARs;
+      //printf("\n\n!!!!\n\n from file: runnumber = %d, numPars = %d\n\n", info.runNumber, info.numPARs);
+      if(numPARs <= 0 || numPARs > 10){
+	printf("Number of PARS incorrectly found to be %d!\n", numPARs);
+	return;
       }
-      while(input.good()){
-          input >> inputrunnumber >> numPARs;
-          if(!input.good()) break;
-          info.runNumber = inputrunnumber;
-          info.numPARs = numPARs;
-          //printf("\n\n!!!!\n\n from file: runnumber = %d, numPars = %d\n\n", info.runNumber, info.numPARs);
-          if(numPARs <= 0 || numPARs > 10){
-              printf("Number of PARS incorrectly found to be %d!\n", numPARs);
-              return;
-          }
-          for(int iPAR = 0; iPAR < numPARs; iPAR++){
-              input >> PAR;
-              if(info.runNumber == runNumber){
-                info.PARGlobalBCs.push_back(PAR);
-              }
-          }
-          if(info.runNumber == runNumber) break;
+      for(int iPAR = 0; iPAR < numPARs; iPAR++){
+	input >> PAR;
+	if(info.runNumber == runNumber){
+	  info.PARGlobalBCs.push_back(PAR);
+	}
       }
-      input.close();
-
-      if(info.runNumber != runNumber){
-          isPAR = kFALSE;
-          info.numPARs = 0;
-      }else{
-        isPAR = kTRUE;
-        printf("info.runNumber = %d\n", info.runNumber);
-        printf("info.numPARs = %d\n", info.numPARs);
-        for(int i = 0; i < info.numPARs; i++){
+      if(info.runNumber == runNumber) break;
+    }
+    input.close();
+    
+    if(info.runNumber != runNumber){
+      isPAR = kFALSE;
+      info.numPARs = 0;
+    }else{
+      isPAR = kTRUE;
+      printf("---- NEW RUN NUMBER ----\n");
+      printf("info.runNumber = %d\n", info.runNumber);
+      printf("info.numPARs = %d\n", info.numPARs);
+      for(int i = 0; i < info.numPARs; i++){
         printf("info.PARGlobalBCs[%d] = %llu\n", i, info.PARGlobalBCs[i]);
-        }
       }
+    }
   }
 
   TFile *file =new TFile(inputFile.Data());
@@ -1866,8 +1867,15 @@ const  Double_t upperLimit[]={
           if(ccBCPAR[iPAR][i]->GetBinContent(j)>0.) emptyCounter++;
         }
         if(emptyCounter<1500) shouldBeEmptyPAR[iPAR][i]=kTRUE;
-        printf("Non-zero channels %d BC %d should be empty: %d \n",emptyCounter,i,shouldBeEmptyPAR[iPAR][i]);
-
+        printf("Non-zero channels %d BC %d PAR %d should be empty: %d \n",emptyCounter,i,iPAR,shouldBeEmptyPAR[iPAR][i]);
+      }
+      //it cannot be empty after par when befor was not empty
+      //need to correct for this for events after PAR(s)
+      for(Int_t iPAR = 1; iPAR <= info.numPARs; iPAR++){
+	if(shouldBeEmptyPAR[iPAR][i] && !shouldBeEmptyPAR[0][i] ) {
+	  shouldBeEmptyPAR[iPAR][i] = kFALSE;
+	  printf("BC %d PAR %d can NOT be empty because before any PAR was filled. Correct to %d \n",i,iPAR,shouldBeEmptyPAR[iPAR][i]);
+	}
       }
     }else{
       ccBC[i]=(TH1F*) file->Get(Form("hAllTimeAvBC%d",i));
@@ -1912,8 +1920,8 @@ const  Double_t upperLimit[]={
           }
         }else{
           if(shouldBeEmpty[j]) {
-	        meanBC[j]=-1;
-	        continue;
+	    meanBC[j]=-1;
+	    continue;
           }
         }
         if(isPAR){
@@ -1922,87 +1930,87 @@ const  Double_t upperLimit[]={
           fitResult=ccBC[j]->Fit("f1","CQN","",lowerLimit[i],upperLimit[i]);
         }
         if(fitResult<0){
-	//hRun->SetBinContent(i,0);//correct it please
-	meanBC[j]=-1;
-	if(isPAR){
-	  printf("Fit failed for SM %d BC%d, integral %f\n",i,j,ccBCPAR[iPAR][j]->Integral(lowerLimit[i],upperLimit[i]));
-	}else{
-	  printf("Fit failed for SM %d BC%d, integral %f\n",i,j,ccBC[j]->Integral(lowerLimit[i],upperLimit[i]));
+	  //hRun->SetBinContent(i,0);//correct it please
+	  meanBC[j]=-1;
+	  if(isPAR){
+	    printf("Fit failed for SM %d BC%d PAR %d, integral %f\n",i,j,iPAR,ccBCPAR[iPAR][j]->Integral(lowerLimit[i],upperLimit[i]));
+	  }else{
+	    printf("Fit failed for SM %d BC%d, integral %f\n",i,j,ccBC[j]->Integral(lowerLimit[i],upperLimit[i]));
+	  }
+	  continue;
+	} else {
+	  fitParameter = f1->GetParameter(0);
 	}
-	continue;
-      } else {
-	fitParameter = f1->GetParameter(0);
-      }
-      if(offset100 && (j==0 || j==1)) {
-	//the 100 ns offset was removed in LHC15n muon_calo_pass1 and further reconstructions 
-	fitParameter+=100;
-      }
-      meanBC[j]=fitParameter;
+	if(offset100 && (j==0 || j==1)) {
+	  //the 100 ns offset was removed in LHC15n muon_calo_pass1 and further reconstructions 
+	  fitParameter+=100;
+	}
+	meanBC[j]=fitParameter;
 	
-      if(fitParameter>0 && fitParameter<minimumValue){
-	minimumValue = fitParameter;
-	minimumIndex = j;
+	if(fitParameter>0 && fitParameter<minimumValue){
+	  minimumValue = fitParameter;
+	  minimumIndex = j;
+	}
       }
-    }
-
-    if( minimumValue/25-(Int_t)(minimumValue/25)>0.5 ) {
-      L1shift=(Int_t)(minimumValue/25.)+1;
-    } else {
-      L1shift=(Int_t)(minimumValue/25.);
-    }
-
-    if(TMath::Abs(minimumValue/25-(Int_t)(minimumValue/25)-0.5)<0.05)
-      printf("Run %d, SM %d, min %f, next_min %f, next+1_min %f, next+2_min %f, min/25 %f, min%%25 %d, next_min/25 %f, next+1_min/25 %f, next+2_min/25 %f, SMmin %d\n",runNumber,i,minimumValue,meanBC[(minimumIndex+1)%4],meanBC[(minimumIndex+2)%4],meanBC[(minimumIndex+3)%4],minimumValue/25., (Int_t)((Int_t)minimumValue%25), meanBC[(minimumIndex+1)%4]/25., meanBC[(minimumIndex+2)%4]/25., meanBC[(minimumIndex+3)%4]/25., L1shift*25);
-
-    if(justL1phase) totalValue = minimumIndex;
-    else totalValue = L1shift<<2 | minimumIndex ;
-    //printf("L1 phase %d, L1 shift %d *25ns= %d, L1p+L1s %d, total %d, L1pback %d, L1sback %d\n",minimumIndex,L1shift,L1shift*25,minimumIndex+L1shift,totalValue,totalValue&3,totalValue>>2);
-
-    if(isPAR){
-      hPARRun[iPAR]->SetBinContent(i,totalValue);
-    }else{
-      hRun->SetBinContent(i,totalValue);
-    }
-    orderTest=kTRUE;
-    for(iorder=minimumIndex;iorder<minimumIndex+4-1;iorder++){
-      if( meanBC[(iorder+1)%4] <= meanBC[iorder%4] ) orderTest=kFALSE;
-    }
-    if(!orderTest)
-      printf("run %d, SM %d, min index %d meanBC %f %f %f %f, order ok? %d\n",runNumber,i,minimumIndex,meanBC[0],meanBC[1],meanBC[2],meanBC[3],orderTest);
-
-    //patch for runs with not filled one, two or three BCs
-    //manual patch for LHC16q - pPb@5TeV - only BC0 is filled and phase rotate
-    if(shouldBeEmpty[0] || shouldBeEmpty[1] || shouldBeEmpty[2] || shouldBeEmpty[3]){
-    Double_t newMean = meanBC[minimumIndex]-600;
-    if(newMean<=12.5){
+      
+      if( minimumValue/25-(Int_t)(minimumValue/25)>0.5 ) {
+	L1shift=(Int_t)(minimumValue/25.)+1;
+      } else {
+	L1shift=(Int_t)(minimumValue/25.);
+      }
+      
+      if(TMath::Abs(minimumValue/25-(Int_t)(minimumValue/25)-0.5)<0.05)
+	printf("Run %d, SM %d, min %f, next_min %f, next+1_min %f, next+2_min %f, min/25 %f, min%%25 %d, next_min/25 %f, next+1_min/25 %f, next+2_min/25 %f, SMmin %d\n",runNumber,i,minimumValue,meanBC[(minimumIndex+1)%4],meanBC[(minimumIndex+2)%4],meanBC[(minimumIndex+3)%4],minimumValue/25., (Int_t)((Int_t)minimumValue%25), meanBC[(minimumIndex+1)%4]/25., meanBC[(minimumIndex+2)%4]/25., meanBC[(minimumIndex+3)%4]/25., L1shift*25);
+      
+      if(justL1phase) totalValue = minimumIndex;
+      else totalValue = L1shift<<2 | minimumIndex ;
+      //printf("L1 phase %d, L1 shift %d *25ns= %d, L1p+L1s %d, total %d, L1pback %d, L1sback %d\n",minimumIndex,L1shift,L1shift*25,minimumIndex+L1shift,totalValue,totalValue&3,totalValue>>2);
+      
       if(isPAR){
-        hPARRun[iPAR]->SetBinContent(i,minimumIndex);
+	hPARRun[iPAR]->SetBinContent(i,totalValue);
       }else{
-        hRun->SetBinContent(i,minimumIndex);
+	hRun->SetBinContent(i,totalValue);
       }
-    } else {
-      Int_t minIndexTmp=-1;
-      if(newMean/25. - (Int_t)(newMean/25.) <0.5)
-	minIndexTmp = (Int_t)(newMean/25.);
-      else
-	minIndexTmp = 1+(Int_t)(newMean/25.);
-
-      if(isPAR){
-        hPARRun[iPAR]->SetBinContent(i,(4-minIndexTmp+minimumIndex)%4);
-      }else{
-        hRun->SetBinContent(i,(4-minIndexTmp+minimumIndex)%4);
+      orderTest=kTRUE;
+      for(iorder=minimumIndex;iorder<minimumIndex+4-1;iorder++){
+	if( meanBC[(iorder+1)%4] <= meanBC[iorder%4] ) orderTest=kFALSE;
       }
-      //cout<<newMean/25.<<" int "<<(Int_t)(newMean/25.)<<" dif "<< newMean/25.-(Int_t)(newMean/25.)<<endl;
-      }
-    if(isPAR){
-      printf("run with missing BC; new L1 phase set to %d\n",(Int_t)hPARRun[iPAR]->GetBinContent(i));
-    }else{
-      printf("run with missing BC; new L1 phase set to %d\n",(Int_t)hRun->GetBinContent(i));
-    }
+      if(!orderTest)
+	printf("run %d, SM %d, min index %d meanBC %f %f %f %f, order ok? %d\n",runNumber,i,minimumIndex,meanBC[0],meanBC[1],meanBC[2],meanBC[3],orderTest);
+      
+      //patch for runs with not filled one, two or three BCs
+      //manual patch for LHC16q - pPb@5TeV - only BC0 is filled and phase rotate
+      if(shouldBeEmpty[0] || shouldBeEmpty[1] || shouldBeEmpty[2] || shouldBeEmpty[3]){
+	Double_t newMean = meanBC[minimumIndex]-600;
+	if(newMean<=12.5){
+	  if(isPAR){
+	    hPARRun[iPAR]->SetBinContent(i,minimumIndex);
+	  }else{
+	    hRun->SetBinContent(i,minimumIndex);
+	  }
+	} else {
+	  Int_t minIndexTmp=-1;
+	  if(newMean/25. - (Int_t)(newMean/25.) <0.5)
+	    minIndexTmp = (Int_t)(newMean/25.);
+	  else
+	    minIndexTmp = 1+(Int_t)(newMean/25.);
+	  
+	  if(isPAR){
+	    hPARRun[iPAR]->SetBinContent(i,(4-minIndexTmp+minimumIndex)%4);
+	  }else{
+	    hRun->SetBinContent(i,(4-minIndexTmp+minimumIndex)%4);
+	  }
+	  //cout<<newMean/25.<<" int "<<(Int_t)(newMean/25.)<<" dif "<< newMean/25.-(Int_t)(newMean/25.)<<endl;
+	}
+	if(isPAR){
+	  printf("run with missing BC; PAR %d; new L1 phase in SM%d set to %d\n",iPAR,i,(Int_t)hPARRun[iPAR]->GetBinContent(i));
+	}else{
+	  printf("run with missing BC; new L1 phase in SM%d set to %d\n",i,(Int_t)hRun->GetBinContent(i));
+	}
       }//end of patch for LHC16q and other runs with not filled BCs
     }//end of loop over SM
   }//end of loop over PARs
-
+  
   delete f1;
   TFile *fileNew=new TFile(outputFile.Data(),"update");
   if(isPAR){

--- a/PWGPP/EMCAL/AliAnalysisTaskEMCALTimeCalib.cxx
+++ b/PWGPP/EMCAL/AliAnalysisTaskEMCALTimeCalib.cxx
@@ -1866,7 +1866,7 @@ void AliAnalysisTaskEMCALTimeCalib::ProduceOffsetForSMsV2(Int_t runNumber,TStrin
         for(Int_t j=0;j<upperLimit[19];j++){
           if(ccBCPAR[iPAR][i]->GetBinContent(j)>0.) emptyCounter++;
         }
-        if(emptyCounter<1500) shouldBeEmptyPAR[iPAR][i]=kTRUE;
+        if(emptyCounter<400) shouldBeEmptyPAR[iPAR][i]=kTRUE;
         printf("Non-zero channels %d BC %d PAR %d should be empty: %d \n",emptyCounter,i,iPAR,shouldBeEmptyPAR[iPAR][i]);
       }
       //it cannot be empty after par when befor was not empty


### PR DESCRIPTION
Main changes: 
- fCurrentPARIndex=0 means events before any PAR. Changed histogram filling according to this scheme. 
- when low number of entries after PAR for some SM -> this SM is not treated as empty if before PAR it was filled
- added clearer printouts in case of problems 