### PR TITLE
Filtering for the MC truth of V0, photons and cascades for the Nano

### DIFF
--- a/PWG/DevNanoAOD/AliAnalysisNanoAODCuts.cxx
+++ b/PWG/DevNanoAOD/AliAnalysisNanoAODCuts.cxx
@@ -9,11 +9,13 @@
 #include "AliInputEventHandler.h"
 #include "AliAODv0.h"
 #include "AliEventCuts.h"
+#include "AliAODMCParticle.h"
 
 ClassImp(AliAnalysisNanoAODTrackCuts)
 ClassImp(AliAnalysisNanoAODV0Cuts)
 ClassImp(AliAnalysisNanoAODCascadeCuts)
 ClassImp(AliAnalysisNanoAODEventCuts)
+ClassImp(AliAnalysisNanoAODMCParticleCuts)
 ClassImp(AliNanoAODSimpleSetter)
 
 
@@ -732,6 +734,44 @@ Bool_t AliAnalysisNanoAODEventCuts::IsSelected(TObject* obj)
   }
       
   return kTRUE;
+}
+
+AliAnalysisNanoAODMCParticleCuts::AliAnalysisNanoAODMCParticleCuts()
+    : AliAnalysisCuts(),
+      fDoSelectPrimaries(true),
+      fDoSelectCharged(true),
+      fMinPt(0.f),
+      fMaxEta(999.f),
+      fPDGToKeep(),
+      fPDGV0() {
+}
+
+bool AliAnalysisNanoAODMCParticleCuts::IsSelected(TObject* obj) {
+  // Returns true if the MC particle is to be kept!
+  AliAODMCParticle* part = dynamic_cast<AliAODMCParticle*>(obj);
+  if(!part) {
+    AliFatal("MC particle missing");
+  }
+
+  // if this is activated the specified particles are kept ignoring the cuts
+  for (auto it : fPDGToKeep) {
+    if (it == TMath::Abs(part->PdgCode())) {
+      return true;
+    }
+  }
+  if (part->Pt() < fMinPt) {
+    return false;
+  }
+  if (TMath::Abs(part->Eta()) > fMaxEta) {
+    return false;
+  }
+  if (fDoSelectPrimaries && !part->IsPhysicalPrimary()) {
+    return false;
+  }
+  if (fDoSelectCharged && !part->Charge()) {
+    return false;
+  }
+  return true;
 }
 
 void AliNanoAODSimpleSetter::Init(AliNanoAODHeader* head, TString varListHeader)

--- a/PWG/DevNanoAOD/AliAnalysisNanoAODCuts.h
+++ b/PWG/DevNanoAOD/AliAnalysisNanoAODCuts.h
@@ -223,6 +223,41 @@ private:
   ClassDef(AliAnalysisNanoAODEventCuts, 3); // event cut object for nano AOD filtering
 };
 
+class AliAnalysisNanoAODMCParticleCuts : public AliAnalysisCuts
+{
+public:
+  AliAnalysisNanoAODMCParticleCuts();
+  virtual ~AliAnalysisNanoAODMCParticleCuts() {}
+  virtual bool IsSelected(TObject* obj);  // TObject should be an AliAODMCParticle
+  virtual bool IsSelected(TList* /* list */) {
+    return kTRUE;
+  }
+  bool GetSelectPrimaries() const { return fDoSelectPrimaries; }
+  void SetSelectPrimaries(bool doIt) { fDoSelectPrimaries = doIt; }
+  bool GetSelectChargedParticles() const { return fDoSelectCharged; }
+  void SetSelectChargedParticles(bool doIt) { fDoSelectCharged = doIt; }
+  float GetMinPt() const { return fMinPt; }
+  void SetMinPt(float var) { fMinPt = var; }
+  float GetMaxEta() const { return fMaxEta; }
+  void SetMaxEta(float var) { fMaxEta = var; }
+  std::vector<int> &GetKeepParticles() { return fPDGToKeep; }
+  void SetKeepParticles(std::vector<int> pdgCodes) { fPDGToKeep = pdgCodes; }
+  void AddKeepParticles(int pdgCode) { fPDGV0.push_back(pdgCode); }
+  std::vector<int> &GetKeepV0s() { return fPDGV0; }
+  void SetKeepV0s(std::vector<int> pdgCodes) { fPDGV0 = pdgCodes; }
+  void AddKeepV0(int pdgCode) { fPDGV0.push_back(pdgCode); }
+
+private:
+  bool fDoSelectPrimaries; // switch to only select IsPhysicalPrimary() particles
+  bool fDoSelectCharged; // switch to only select charged particles
+  float fMinPt;  // miminum pt of the tracks
+  float fMaxEta; // MaxEta
+  std::vector<int> fPDGToKeep;  // vector of PDG codes that we want to keep anyways
+  std::vector<int> fPDGV0;  // vector of PDG codes that we want to match the V0s to
+
+  ClassDef(AliAnalysisNanoAODMCParticleCuts,1); // MC particle cut object for nano AOD filtering
+};
+
 class AliNanoAODSimpleSetter : public AliNanoAODCustomSetter
 {
 public:

--- a/PWG/DevNanoAOD/AliAnalysisTaskNanoAODFilter.h
+++ b/PWG/DevNanoAOD/AliAnalysisTaskNanoAODFilter.h
@@ -53,6 +53,7 @@ public:
   void  SaveV0s(Bool_t var, AliAnalysisCuts* v0Cuts = 0)  { fReplicator->SetSaveV0s(var); fReplicator->SetV0Cuts(v0Cuts); if (fSaveCutsFlag && v0Cuts) fQAOutput->Add(v0Cuts); }
   void  SaveCascades(Bool_t var, AliAnalysisCuts* cuts = 0) { fReplicator->SetSaveCascades(var); fReplicator->SetCascadeCuts(cuts); if (fSaveCutsFlag && cuts) fQAOutput->Add(cuts); }
   void  SaveConversionPhotons(Bool_t var, AliAnalysisCuts* cuts = 0) { fReplicator->SetSaveConversionPhotons(var); fReplicator->SetConversionPhotonCuts(cuts); if (fSaveCutsFlag && cuts) fQAOutput->Add(cuts); }
+  void  FilterMCStack(AliAnalysisCuts* cuts = nullptr) { fReplicator->SetMCParticleCuts(cuts); if (fSaveCutsFlag && cuts) fQAOutput->Add(cuts); }
   
   AliNanoAODReplicator* GetReplicator() { return fReplicator; }
 

--- a/PWG/DevNanoAOD/AliNanoAODReplicator.h
+++ b/PWG/DevNanoAOD/AliNanoAODReplicator.h
@@ -16,7 +16,6 @@
 
 #include <iostream>
 #include <list>
-
 //
 // Implementation of a branch replicator 
 // to produce nano AOD.
@@ -45,6 +44,7 @@ class AliAODVertex;
 class AliVertexerTracks;
 class AliESDv0; 
 class AliAODv0; 
+class AliAODConversionPhoton;
 class AliAODHeader;
 class AliNanoAODHeader;
 class AliAnalysisTaskSE;
@@ -77,6 +77,7 @@ class AliNanoAODReplicator : public AliAODBranchReplicator
   void SetV0Cuts(AliAnalysisCuts* cuts) { fV0Cuts = cuts; }
   void SetCascadeCuts(AliAnalysisCuts* cuts) { fCascadeCuts = cuts; }
   void SetConversionPhotonCuts(AliAnalysisCuts* cuts) { fConversionPhotonCuts = cuts; }
+  void SetMCParticleCuts(AliAnalysisCuts* cuts) { fMCParticleCuts = cuts; }
 
   void AddCustomSetter(AliNanoAODCustomSetter * var) { fCustomSetters.push_back(var);  }
     
@@ -99,6 +100,7 @@ class AliNanoAODReplicator : public AliAODBranchReplicator
   Bool_t IsParticleSelected(Int_t i);
   void CreateLabelMap(const AliAODEvent& source);
   Int_t GetNewLabel(Int_t i);
+  void RelabelAODPhotonCandidates(AliAODConversionPhoton *PhotonCandidate);
   void FilterMC(const AliAODEvent& source);
   AliAODVertex* CloneAndStoreVertex(AliAODVertex* toClone);
  
@@ -106,6 +108,9 @@ class AliNanoAODReplicator : public AliAODBranchReplicator
   AliAnalysisCuts* fV0Cuts;    // decides which V0s to keep
   AliAnalysisCuts* fCascadeCuts; // decides which cascades to keep
   AliAnalysisCuts* fConversionPhotonCuts; // decides which conversion photons to keep
+  AliAnalysisCuts* fMCParticleCuts;  // decides which particles from the MC stack to keep
+                                                      // Here we need the actual object because we retrieve the MC
+                                                      // matching of the V0s from here
   
   mutable TClonesArray* fTracks; //! internal array of arrays of NanoAOD tracks
   mutable AliNanoAODHeader* fHeader; //! internal array of headers

--- a/PWG/DevNanoAOD/PWGDevNanoAODLinkDef.h
+++ b/PWG/DevNanoAOD/PWGDevNanoAODLinkDef.h
@@ -13,6 +13,7 @@
 #pragma link C++ class AliAnalysisNanoAODCascadeCuts+;
 #pragma link C++ class AliAnalysisNanoAODCascadeParametricCuts+;
 #pragma link C++ class AliAnalysisNanoAODEventCuts+;
+#pragma link C++ class AliAnalysisNanoAODMCParticleCuts+;
 #pragma link C++ class AliNanoAODSimpleSetter+;
 #pragma link C++ class AliAnalysisNanoAODTrackCutsCRCZDC+;
 #pragma link C++ class AliAnalysisNanoAODEventCutsCRCZDC+;


### PR DESCRIPTION
o implementation of a AliAnalysisCut class for the MC stack
o matchig of the photons and v0
o to be done: cascades

The filtering can be steered from the AddTask e.g.
AliAnalysisNanoAODMCParticleCuts* mcCuts = new AliAnalysisNanoAODMCParticleCuts;
mcCuts->SetMinPt(0.1);
mcCuts->SetMaxEta(2);
mcCuts->SetKeepParticles( {333, 3212} );
mcCuts->SetKeepV0s( {3122} );
filterTask->FilterMCStack(mcCuts);