### PR TITLE
EMCal low gain cells calibration

### DIFF
--- a/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellTimeCalib.h
+++ b/PWG/EMCAL/EMCALtasks/AliEmcalCorrectionCellTimeCalib.h
@@ -45,6 +45,7 @@ private:
   Bool_t                 fCalibrateTimeL1Phase;   ///< flag cell time calibration with L1phase shift
   Bool_t                 fDoMergedBCs;            ///< flag to use one histogram for all BCs
   Bool_t                 fDoCalibrateLowGain;     ///< flag to calibrate the low gain cells
+  Bool_t                 fDoCalibMergedLG;        ///< flag to calibrate the low gain cells using a period merged histogram for LG calibration
   
   // Change to false if experts
   Bool_t                 fUseAutomaticTimeCalib;     ///< On by default the check in the OADB of the time recalibration
@@ -56,7 +57,7 @@ private:
   static RegisterCorrectionComponent<AliEmcalCorrectionCellTimeCalib> reg;
 
   /// \cond CLASSIMP
-  ClassDef(AliEmcalCorrectionCellTimeCalib, 3); // EMCal cell time calibration component
+  ClassDef(AliEmcalCorrectionCellTimeCalib, 4); // EMCal cell time calibration component
   /// \endcond
 };
 

--- a/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
+++ b/PWG/EMCAL/config/AliEmcalCorrectionConfiguration.yaml
@@ -79,6 +79,7 @@ CellTimeCalib:                                      # Cell Time Calibration comp
     createHistos: false                             # Whether the task should create output histograms
     doMergedBCs: false                              # Whether the task should create output histograms
     doCalibrateLowGain: false                       # Whether the task should calibrate the low gain cells
+    doCalibMergedLG: false                          # Whether the task should calibrate the low gain cells
     cellsNames:                                     # Names of the cells input objects which should be attached to the correction
         - defaultCells                              # This object is defined above in the cells section of the input objects
 CellEmulateCrosstalk:                               # Component to emulate crosstalk


### PR DESCRIPTION
I modified the correction framework so it calibrates the LG cells. The correction framework reads from OADB a file "EMCALTimeCalibMergedBCLG.root" which contains the histograms containing the LG time calibration coefficients for all the periods merged in one histogram.