### PR TITLE
Fix PR8329 for ESDs: initialization to 1 (instead of 0)

### DIFF
--- a/PWGDQ/dielectron/core/AliDielectronMixingHandler.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronMixingHandler.cxx
@@ -51,7 +51,7 @@ AliDielectronMixingHandler::AliDielectronMixingHandler() :
   fMoveToSameVertex(kFALSE),
   fSkipFirstEvt(kFALSE),
   fPID(0x0),
-  fPIDobjectCount(0)
+  fPIDobjectCount(1)
 {
   //
   // Default Constructor
@@ -73,7 +73,7 @@ AliDielectronMixingHandler::AliDielectronMixingHandler(const char* name, const c
   fMoveToSameVertex(kFALSE),
   fSkipFirstEvt(kFALSE),
   fPID(0x0),
-  fPIDobjectCount(0)
+  fPIDobjectCount(1)
 {
   //
   // Named Constructor
@@ -191,8 +191,8 @@ void AliDielectronMixingHandler::Fill(const AliVEvent *ev, AliDielectron *diele)
       fPIDobjectCount = TProcessID::GetObjectCount();
     }
     else{
-      AliWarning("TProcessID::GetObjectCount() >= UINT_MAX [0xffffffff]; set fPIDobjectCount = 0");
-      fPIDobjectCount = 0;
+      AliWarning("TProcessID::GetObjectCount() >= UINT_MAX [0xffffffff]; set fPIDobjectCount = 1");
+      fPIDobjectCount = 1;
     }
   }
 


### PR DESCRIPTION
- For AODs PR8329 was effective (since the default ID did not appear for AOD tracks apparently)
- For ESDs it seems that tracks have ID 0 by default, which then causes double assignments again
- quick solution: use 1 instead of 0 (helped at least in the test case, where it was observed, and didn't lead to returning of NULL pointers)