### PR TITLE
PWGGA/GammaConv: implementation of gamma from pi0 energy cut

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson.cxx
@@ -2742,6 +2742,17 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessNeutralDecayMeson
         if(!fDoLightOutput){
             fHistoGammaGammaInvMassPtBeforeCuts[fiCut]->Fill(NDMcand->M(),NDMcand->Pt(), fWeightJetJetMC);
         }
+
+        if( ((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->DoGammaMinEnergyCut() ){
+          Int_t minDaughters        = ((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->GetNDaughterEnergyCut();
+          Float_t minDaughterEnergy = ((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->GetSingleDaughterMinE();
+          if(minDaughters==1){ // at least one over threshold
+             if( (gamma0->E() < minDaughterEnergy)  && (gamma1->E() < minDaughterEnergy)) continue;
+          } else if (minDaughters==2){ // both over threshold
+             if( (gamma0->E() < minDaughterEnergy)  || (gamma1->E() < minDaughterEnergy)) continue;
+          }
+        }
+
         if((((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->MesonIsSelected(NDMcand,kTRUE,((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift()))){
           if(fIsMC){
             if(fInputEvent->IsA()==AliESDEvent::Class())
@@ -2806,6 +2817,16 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessNeutralPionCandid
 
         if(!fDoLightOutput){
             fHistoGammaGammaInvMassPtBeforeCuts[fiCut]->Fill(NDMcand->M(),NDMcand->Pt(), fWeightJetJetMC);
+        }
+
+        if( ((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->DoGammaMinEnergyCut() ){
+          Int_t minDaughters        = ((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->GetNDaughterEnergyCut();
+          Float_t minDaughterEnergy = ((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->GetSingleDaughterMinE();
+          if(minDaughters==1){ // at least one over threshold
+             if( (gamma0->E() < minDaughterEnergy)  && (gamma1->E() < minDaughterEnergy)) continue;
+          } else if (minDaughters==2){ // both over threshold
+             if( (gamma0->E() < minDaughterEnergy)  || (gamma1->E() < minDaughterEnergy)) continue;
+          }
         }
 
         if((((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->MesonIsSelected(NDMcand,kTRUE,((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift()))){
@@ -3261,6 +3282,16 @@ void AliAnalysisTaskNeutralMesonToPiPlPiMiNeutralMeson::ProcessNeutralPionCandid
 
         if(!fDoLightOutput){
           fHistoGammaGammaInvMassPtBeforeCuts[fiCut]->Fill(NDMcand->M(),NDMcand->Pt(), fWeightJetJetMC);
+        }
+
+        if( ((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->DoGammaMinEnergyCut() ){
+          Int_t minDaughters        = ((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->GetNDaughterEnergyCut();
+          Float_t minDaughterEnergy = ((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->GetSingleDaughterMinE();
+          if(minDaughters==1){ // at least one over threshold
+             if( (gamma0->E() < minDaughterEnergy)  && (gamma1->E() < minDaughterEnergy)) continue;
+          } else if (minDaughters==2){ // both over threshold
+             if( (gamma0->E() < minDaughterEnergy)  || (gamma1->E() < minDaughterEnergy)) continue;
+          }
         }
 
         if((((AliConversionMesonCuts*)fNeutralDecayMesonCutArray->At(fiCut))->MesonIsSelected(NDMcand,kTRUE,((AliConvEventCuts*)fEventCutArray->At(fiCut))->GetEtaShift()))){

--- a/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pp.C
@@ -242,11 +242,9 @@ void AddTask_GammaConvNeutralMesonPiPlPiMiNeutralMeson_CaloMode_pp(
     cuts.AddCutHeavyMesonCalo("00052113","111111105f032230000","32c51070a","0103603b00000000","0153503000000000"); // EMC7 (LHC11 acc)
     cuts.AddCutHeavyMesonCalo("00052113","111111105f032230000","32c51070a","0103603d00000000","0153503000000000"); // EMC7 (LHC11 acc)
   } else if( trainConfig == 118){ // pt cut variation
-    cuts.AddCutHeavyMesonCalo("00052113","111111105f032230000","32c51070a","0103693c00000000","0153503000000000"); // 3.0
-    cuts.AddCutHeavyMesonCalo("00052113","111111105f032230000","32c51070a","01036a3c00000000","0153503000000000"); // 4.0
-    cuts.AddCutHeavyMesonCalo("00052113","111111105f032230000","32c51070a","01036b3c00000000","0153503000000000"); // 6.0
     cuts.AddCutHeavyMesonCalo("00052113","111111105f032230000","32c51070a","01036c3c00000000","0153503000000000"); // 8.0
     cuts.AddCutHeavyMesonCalo("00052113","111111105f032230000","32c51070a","01036d3c00000000","0153503000000000"); // 10.0
+    cuts.AddCutHeavyMesonCalo("00052113","111111105f032230000","32c51070a","01036e3c00000000","0153503000000000"); // new Energy cut
   } else if( trainConfig == 119){ // testbeam nonlin
     cuts.AddCutHeavyMesonCalo("00010113","111111105f032230000","32c51000a","0103603c00000000","0153503000000000"); // INT7 (LHC11 acc) 3 sigma
     // ---------------------------------

--- a/PWGGA/GammaConvBase/AliConversionMesonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConversionMesonCuts.cxx
@@ -164,7 +164,10 @@ AliConversionMesonCuts::AliConversionMesonCuts(const char *name,const char *titl
   fBackgroundUseLikeSign(kFALSE),
   fBackgroundMode(4),
   fDoJetAnalysis(kFALSE),
-  fDoJetQA(kFALSE)
+  fDoJetQA(kFALSE),
+  fDoGammaMinEnergyCut(kFALSE),
+  fNDaughterEnergyCut(0),
+  fSingleDaughterMinE(0.)
 {
   for(Int_t jj=0;jj<kNCuts;jj++){fCuts[jj]=0;}
   fCutString=new TObjString((GetCutNumber()).Data());
@@ -267,7 +270,10 @@ AliConversionMesonCuts::AliConversionMesonCuts(const AliConversionMesonCuts &ref
   fBackgroundUseLikeSign(ref.fBackgroundUseLikeSign),
   fBackgroundMode(4),
   fDoJetAnalysis(ref.fDoJetAnalysis),
-  fDoJetQA(ref.fDoJetQA)
+  fDoJetQA(ref.fDoJetQA),
+  fDoGammaMinEnergyCut(kFALSE),
+  fNDaughterEnergyCut(0),
+  fSingleDaughterMinE(0.)
 
 {
   // Copy Constructor
@@ -1882,6 +1888,13 @@ Bool_t AliConversionMesonCuts::SetMinPtCut(Int_t PtCut){
     fMinPt = 10.0;
     fDoMinPtCut = kTRUE;
     break;
+
+  // Instead of applying pt cut, apply a min energy cut on daughters
+  // (needs to be treated in analysis task)
+  case 14:
+    fDoGammaMinEnergyCut = kTRUE;
+    fNDaughterEnergyCut  = 1;
+    fSingleDaughterMinE  = 5.;
   default:
     cout<<"Warning: pT cut not defined"<<PtCut<<endl;
     return kFALSE;

--- a/PWGGA/GammaConvBase/AliConversionMesonCuts.cxx
+++ b/PWGGA/GammaConvBase/AliConversionMesonCuts.cxx
@@ -1872,29 +1872,30 @@ Bool_t AliConversionMesonCuts::SetMinPtCut(Int_t PtCut){
     fMinPt = 3.0;
     fDoMinPtCut = kTRUE;
     break;
-  case 10: // for triggered omega
+  case 10: // a for triggered omega
     fMinPt = 4.0;
     fDoMinPtCut = kTRUE;
     break;
-  case 11: // for triggered omega
+  case 11: // b for triggered omega
     fMinPt = 6.0;
     fDoMinPtCut = kTRUE;
     break;
-  case 12: // for triggered omega
+  case 12: // c for triggered omega
     fMinPt = 8.0;
     fDoMinPtCut = kTRUE;
     break;
-  case 13: // for triggered omega
+  case 13: // d for triggered omega
     fMinPt = 10.0;
     fDoMinPtCut = kTRUE;
     break;
 
   // Instead of applying pt cut, apply a min energy cut on daughters
   // (needs to be treated in analysis task)
-  case 14:
+  case 14: // e
     fDoGammaMinEnergyCut = kTRUE;
     fNDaughterEnergyCut  = 1;
     fSingleDaughterMinE  = 5.;
+    break;
   default:
     cout<<"Warning: pT cut not defined"<<PtCut<<endl;
     return kFALSE;

--- a/PWGGA/GammaConvBase/AliConversionMesonCuts.h
+++ b/PWGGA/GammaConvBase/AliConversionMesonCuts.h
@@ -215,6 +215,9 @@ class AliConversionMesonCuts : public AliAnalysisCuts {
     Double_t GetSidebandMixingRightLow() const {return fSidebandMixingRightLow;}
     Double_t GetSidebandMixingRightHigh() const {return fSidebandMixingRightHigh;}
     Int_t    GetBackgroundMode() const {return fBackgroundMode;}
+    Bool_t   DoGammaMinEnergyCut() const {return fDoGammaMinEnergyCut;}
+    Int_t    GetNDaughterEnergyCut() const {return fNDaughterEnergyCut;}
+    Int_t    GetSingleDaughterMinE() const {return fSingleDaughterMinE;}
 
   protected:
     TRandom3    fRandom;                        ///<
@@ -312,10 +315,14 @@ class AliConversionMesonCuts : public AliAnalysisCuts {
     Bool_t      fDoJetAnalysis;                 ///< switch to run a jet analysis
     Bool_t      fDoJetQA;                       ///< switch to run a jet QA analysis
 
+    Bool_t      fDoGammaMinEnergyCut;           ///< if enabled, at least fNDaughterEnergyCut daughter contributing to neutral meson need to fulfill fMinSingleDaughterE
+    Int_t       fNDaughterEnergyCut;            ///< if above is enabled, at least fNDaughterEnergyCut daughter contributing to neutral meson needs to fulfill fMinSingleDaughterE
+    Float_t     fSingleDaughterMinE;            ///< if above is enabled, at least fNDaughterEnergyCut daughter contributing to neutral meson needs to fulfill fMinSingleDaughterE
+
   private:
 
     /// \cond CLASSIMP
-    ClassDef(AliConversionMesonCuts,35)
+    ClassDef(AliConversionMesonCuts,36)
     /// \endcond
 };
 


### PR DESCRIPTION
Implemented new cut that allows to select only neutral meson candidates where at least one (or two) gammas from neutral meson fulfill energy threshold. 
Can be set via minPt cut in AliConversionMeson, but has to be treated properly in analysis task itself.