### PR TITLE
A new class that allows you to set different cuts on DCA for different ranges of pt

### DIFF
--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoWRzTrackCut.cxx
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoWRzTrackCut.cxx
@@ -1,0 +1,43 @@
+#include "AliFemtoWRzTrackCut.h"
+
+
+AliFemtoWRzTrackCut::AliFemtoWRzTrackCut():
+  AliFemtoMJTrackCut()
+  {
+     fDCA_ptdependence[0]=2.4; fDCA_ptdependence[1]=3.2;
+     fPt_dca[0]=0.5; fPt_dca[1]=4;
+  }
+
+AliFemtoWRzTrackCut::AliFemtoWRzTrackCut(const AliFemtoWRzTrackCut &aCut) : AliFemtoMJTrackCut(aCut)
+{
+    //copy constructor 
+}
+
+AliFemtoWRzTrackCut::~AliFemtoWRzTrackCut()
+{
+  // Destructor
+}
+
+
+AliFemtoWRzTrackCut& AliFemtoWRzTrackCut::operator=(const AliFemtoWRzTrackCut& aCut)
+{
+  // assignment operator
+  if (this == &aCut)
+    return *this;
+
+  AliFemtoMJTrackCut::operator=(aCut);
+ 
+  return *this;
+}
+
+bool AliFemtoWRzTrackCut::Pass( const AliFemtoTrack* track)
+{
+  AliFemtoMJTrackCut::Pass(track);
+
+  float tPt = ::sqrt((track->P().x())*(track->P().x())+(track->P().y())*(track->P().y()));
+
+  if (tPt>fPt_dca[0] && tPt <fPt_dca[1])
+	if( (TMath::Abs(track->ImpactD()) > fDCA_ptdependence[0]) || (TMath::Abs(track->ImpactZ()) > fDCA_ptdependence[1]))
+             return false;
+
+}

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoWRzTrackCut.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoWRzTrackCut.h
@@ -1,0 +1,36 @@
+///////////////////////////////////////////////////////////////////////////
+//                                                                       //
+// AliFemtoWRzTrackCut: An extention to AliFemtoMJTrackCut               //
+// The method allows you to set different cut on DCA for different pt ranges //
+///////////////////////////////////////////////////////////////////////////
+
+#ifndef AliFemtoWRzTrackCut_hh
+#define AliFemtoWRzTrackCut_hh
+
+
+#include "AliFemtoMJTrackCut.h"
+
+class AliFemtoWRzTrackCut : public AliFemtoMJTrackCut{
+
+public:
+   AliFemtoWRzTrackCut();
+   AliFemtoWRzTrackCut(const AliFemtoWRzTrackCut &aCut);
+   virtual ~AliFemtoWRzTrackCut();
+   AliFemtoWRzTrackCut& operator =(const AliFemtoWRzTrackCut &aCut);
+   virtual bool Pass(const AliFemtoTrack* aTrack);
+   virtual AliFemtoString Report();
+   virtual TList *ListSettings();
+   void SetDCAcutPtDependence(const float &DCAxy,const float &DCAz,const float& Pt_min, const float& Pt_max);
+   
+private:
+   float fPt_dca[2]; //bounds for transverse momentum to DCA settings
+   float fDCA_ptdependence[2]; //DCA values (cm) in XY and Z plane for given ranges of pt 
+};
+
+inline void AliFemtoWRzTrackCut::SetDCAcutPtDependence(const float &DCAxy, const float &DCAz, const float& Pt_min,const float& Pt_max){ 
+fPt_dca[0]=Pt_min, fPt_dca[1]=Pt_max,fDCA_ptdependence[0]=DCAxy,fDCA_ptdependence[1]=DCAz;
+}
+
+
+#endif
+

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoWRzTrackCut.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoWRzTrackCut.h
@@ -18,8 +18,7 @@ public:
    virtual ~AliFemtoWRzTrackCut();
    AliFemtoWRzTrackCut& operator =(const AliFemtoWRzTrackCut &aCut);
    virtual bool Pass(const AliFemtoTrack* aTrack);
-   virtual AliFemtoString Report();
-   virtual TList *ListSettings();
+
    void SetDCAcutPtDependence(const float &DCAxy,const float &DCAz,const float& Pt_min, const float& Pt_max);
    
 private:

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoWRzTrackCut.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoWRzTrackCut.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////
 //                                                                       //
-// AliFemtoWRzTrackCut: An extention to AliFemtoMJTrackCut               //
+// AliFemtoWRzTrackCut: An extension to AliFemtoMJTrackCut               //
 // The method allows you to set different cut on DCA for different pt ranges //
 ///////////////////////////////////////////////////////////////////////////
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/CMakeLists.txt
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/CMakeLists.txt
@@ -155,6 +155,7 @@ set(SRCS
   AliFemtoCutMonitorV0CosPointingAngle.cxx
   AliFemtoCutMonitorPairMomRes.cxx
   AliFemtoCorrFctnPairsForCorrFit.cxx
+  AliFemtoWRzTrackCut.cxx
   )
 
 

--- a/PWGCF/FEMTOSCOPY/AliFemtoUser/PWGCFfemtoscopyUserLinkDef.h
+++ b/PWGCF/FEMTOSCOPY/AliFemtoUser/PWGCFfemtoscopyUserLinkDef.h
@@ -184,3 +184,5 @@
 #pragma link C++ class AliFemtoCutMonitorV0CosPointingAngle+;
 #pragma link C++ class AliFemtoCutMonitorV0CosPointingAngle::ParentPIDInfo+;
 #pragma link C++ class AliFemtoCorrFctnPairsForCorrFit;
+
+#pragma link C++ class AliFemtoWRzTrackCut;


### PR DESCRIPTION
A new class that allows you to set in a config file different cuts on DCA for different ranges of pt -- to kanon-proton femto analysis. This class is an extension of AliFemtoMJTrackCut.