### PR TITLE
Updated version of the Run3 convertor.

### DIFF
--- a/RUN3/AliAnalysisTaskAO2Dconverter.h
+++ b/RUN3/AliAnalysisTaskAO2Dconverter.h
@@ -27,6 +27,9 @@ public:
   AliAnalysisTaskAO2Dconverter(const AliAnalysisTaskAO2Dconverter &) = default;
   AliAnalysisTaskAO2Dconverter &operator=(const AliAnalysisTaskAO2Dconverter &) = delete;
 
+  void SetUseEventCuts(Bool_t useEventCuts=kTRUE) { fUseEventCuts = useEventCuts;}
+  Bool_t GetUseEventCuts() const {return fUseEventCuts;}
+
   virtual void UserCreateOutputObjects();
   virtual void UserExec(Option_t *option);
   virtual void Terminate(Option_t *option);
@@ -38,6 +41,12 @@ public:
     kEvents = 0,
     kTracks,
     kCalo,
+    kMuon,
+    kMuonCls,
+    kZdc,
+    kVzero,
+    kV0s,
+    kCascades,
     kTOF,
     kKinematics,
     kTrees
@@ -75,6 +84,7 @@ public:
 
   AliAnalysisFilter fTrackFilter; // Standard track filter object
 private:
+  Bool_t fUseEventCuts = kFALSE;         //! Use or not event cuts
   AliEventCuts fEventCuts;      //! Standard event cuts
   AliESDEvent *fESD = nullptr;  //! input event
   TList *fOutputList = nullptr; //! output list
@@ -91,82 +101,102 @@ private:
 
   TaskModes fTaskMode = kStandard; // Running mode of the task. Useful to set for e.g. MC mode
 
-  // fEventTree variables
+  // Data structures
 
-  // Event variables
-  ULong64_t fEventId = 0u;      /// Event unique id
-  Float_t fVtxX = -999.f;       /// Primary vertex x coordinate
-  Float_t fVtxY = -999.f;       /// Primary vertex y coordinate
-  Float_t fVtxZ = -999.f;       /// Primary vertex z coordinate
-  Float_t fCentFwd = -1.f;      /// Centrality/Multiplicity percentile estimated with forward detectors
-  Float_t fCentBarrel = -1.f;   /// Centrality/Multiplicity percentile estimated with barrel detectors
+  struct {
+    // Event data
 
-  Float_t fEventTime[10] = { -999.f };    /// Event time (t0) obtained with different methods (best, T0, T0-TOF, ...) for the whole event as a function of momentum
-  Float_t fEventTimeRes[10] = { -999.f }; /// Resolution on the event time (t0) obtained with different methods (best, T0, T0-TOF, ...) for the whole event as a function of momentum
-  UChar_t fEventTimeMask[10] = { 0u };    /// Mask with the method used to compute the event time (0x1=T0-TOF,0x2=T0A,0x3=TOC) for each momentum bins
+    ULong64_t fEventId = 0u;    /// Event (collision) unique id. Contains peiod, orbit and bunch crossing numbers
+    // Primary vertex position
+    Float_t  fX = -999.f;       /// Primary vertex x coordinate
+    Float_t  fY = -999.f;       /// Primary vertex y coordinate
+    Float_t  fZ = -999.f;       /// Primary vertex z coordinate
+    // Primary vertex covariance matrix
+    Float_t  fCovXX = 999.f;    /// cov[0]
+    Float_t  fCovXY = 0.f;      /// cov[1]
+    Float_t  fCovXZ = 0.f;      /// cov[2]
+    Float_t  fCovYY = 999.f;    /// cov[3]
+    Float_t  fCovYZ = 0.f;      /// cov[4]
+    Float_t  fCovZZ = 999.f;    /// cov[5]
+    // Quality parameters
+    Float_t  fChi2;             /// Chi2 of the vertex
+    UInt_t   fN;                /// Number of contributors
 
+    // The calculation of event time certainly will be modified in Run3
+    // The prototype below can be switched on request
+    Float_t fEventTime = -999.f;    /// Event time (t0) obtained with different methods (best, T0, T0-TOF, ...)
+    Float_t fEventTimeRes = -999.f; /// Resolution on the event time (t0) obtained with different methods (best, T0, T0-TOF, ...)
+    UChar_t fEventTimeMask = 0u;    /// Mask with the method used to compute the event time (0x1=T0-TOF,0x2=T0A,0x3=TOC) for each momentum bins
+
+  } vtx; /// structure to keep the primary vertex (avoid name conflicts)
+
+  // PH: The MC informafion has to be stored separately!
+#ifdef USE_MC
   // MC information on the event
   Short_t fGeneratorID = 0u; /// Generator ID used for the MC
   Float_t fMCVtxX = -999.f;  /// Primary vertex x coordinate from MC
   Float_t fMCVtxY = -999.f;  /// Primary vertex y coordinate from MC
   Float_t fMCVtxZ = -999.f;  /// Primary vertex z coordinate from MC
+#endif
 
-  // fTrackTree variables
+  struct {
+    // Track data
 
-  // Identifier to associate tracks to collisions.
-  // The inversed association (collisions to tracks) is generated on the fly
+    Int_t   fCollisionID;    /// The index of the collision vertex in the TF, to which the track is attached
 
-  // Coordinate system parameters
-  Float_t fX = -999.f;     /// X coordinate for the point of parametrisation
-  Float_t fAlpha = -999.f; /// Local <--> global coor.system rotation angle
+    // Coordinate system parameters
+    Float_t fX = -999.f;     /// X coordinate for the point of parametrisation
+    Float_t fAlpha = -999.f; /// Local <--> global coor.system rotation angle
 
-  // Track parameters
-  Float_t fY = -999.f;          /// fP[0] local Y-coordinate of a track (cm)
-  Float_t fZ = -999.f;          /// fP[1] local Z-coordinate of a track (cm)
-  Float_t fSnp = -999.f;        /// fP[2] local sine of the track momentum azimuthal angle
-  Float_t fTgl = -999.f;        /// fP[3] tangent of the track momentum dip angle
-  Float_t fSigned1Pt = -999.f;  /// fP[4] 1/pt (1/(GeV/c))
+    // Track parameters
+    Float_t fY = -999.f;          /// fP[0] local Y-coordinate of a track (cm)
+    Float_t fZ = -999.f;          /// fP[1] local Z-coordinate of a track (cm)
+    Float_t fSnp = -999.f;        /// fP[2] local sine of the track momentum azimuthal angle
+    Float_t fTgl = -999.f;        /// fP[3] tangent of the track momentum dip angle
+    Float_t fSigned1Pt = -999.f;  /// fP[4] 1/pt (1/(GeV/c))
 
-  // Covariance matrix
-  Float_t fCYY = -999.f;       /// fC[0]
-  Float_t fCZY = -999.f;       /// fC[1]
-  Float_t fCZZ = -999.f;       /// fC[2]
-  Float_t fCSnpY = -999.f;     /// fC[3]
-  Float_t fCSnpZ = -999.f;     /// fC[4]
-  Float_t fCSnpSnp = -999.f;   /// fC[5]
-  Float_t fCTglY = -999.f;     /// fC[6]
-  Float_t fCTglZ = -999.f;     /// fC[7]
-  Float_t fCTglSnp = -999.f;   /// fC[8]
-  Float_t fCTglTgl = -999.f;   /// fC[9]
-  Float_t fC1PtY = -999.f;     /// fC[10]
-  Float_t fC1PtZ = -999.f;     /// fC[11]
-  Float_t fC1PtSnp = -999.f;   /// fC[12]
-  Float_t fC1PtTgl = -999.f;   /// fC[13]
-  Float_t fC1Pt21Pt2 = -999.f; /// fC[14]
+    // Covariance matrix
+    Float_t fCYY = -999.f;       /// fC[0]
+    Float_t fCZY = -999.f;       /// fC[1]
+    Float_t fCZZ = -999.f;       /// fC[2]
+    Float_t fCSnpY = -999.f;     /// fC[3]
+    Float_t fCSnpZ = -999.f;     /// fC[4]
+    Float_t fCSnpSnp = -999.f;   /// fC[5]
+    Float_t fCTglY = -999.f;     /// fC[6]
+    Float_t fCTglZ = -999.f;     /// fC[7]
+    Float_t fCTglSnp = -999.f;   /// fC[8]
+    Float_t fCTglTgl = -999.f;   /// fC[9]
+    Float_t fC1PtY = -999.f;     /// fC[10]
+    Float_t fC1PtZ = -999.f;     /// fC[11]
+    Float_t fC1PtSnp = -999.f;   /// fC[12]
+    Float_t fC1PtTgl = -999.f;   /// fC[13]
+    Float_t fC1Pt21Pt2 = -999.f; /// fC[14]
 
-  // Additional track parameters
-  Float_t fTPCinnerP = -999.f; /// Full momentum at the inner wall of TPC for dE/dx PID
+    // Additional track parameters
+    Float_t fTPCinnerP = -999.f; /// Full momentum at the inner wall of TPC for dE/dx PID
 
-  // Track quality parameters
-  ULong64_t fFlags = 0u;       /// Reconstruction status flags
+    // Track quality parameters
+    ULong64_t fFlags = 0u;       /// Reconstruction status flags
 
-  // Clusters
-  UChar_t fITSClusterMap = 0u; /// ITS map of clusters, one bit per a layer
-  UShort_t fTPCncls = 0u;      /// number of clusters assigned in the TPC
-  UChar_t fTRDntracklets = 0u; /// number of TRD tracklets used for tracking/PID (TRD/TOF pattern)
+    // Clusters
+    UChar_t fITSClusterMap = 0u; /// ITS map of clusters, one bit per a layer
+    UShort_t fTPCncls = 0u;      /// number of clusters assigned in the TPC
+    UChar_t fTRDntracklets = 0u; /// number of TRD tracklets used for tracking/PID (TRD/TOF pattern)
 
-  // Chi2
-  Float_t fITSchi2Ncl = -999.f; /// chi2/Ncl ITS
-  Float_t fTPCchi2Ncl = -999.f; /// chi2/Ncl TPC
-  Float_t fTRDchi2 = -999.f;    /// chi2 TRD match (?)
-  Float_t fTOFchi2 = -999.f;    /// chi2 TOF match (?)
+    // Chi2
+    Float_t fITSchi2Ncl = -999.f; /// chi2/Ncl ITS
+    Float_t fTPCchi2Ncl = -999.f; /// chi2/Ncl TPC
+    Float_t fTRDchi2 = -999.f;    /// chi2 TRD match (?)
+    Float_t fTOFchi2 = -999.f;    /// chi2 TOF match (?)
 
-  // PID
-  Float_t fTPCsignal = -999.f; /// dE/dX TPC
-  Float_t fTRDsignal = -999.f; /// dE/dX TRD
-  Float_t fTOFsignal = -999.f; /// TOFsignal
-  Float_t fLength = -999.f;    /// Int.Lenght @ TOF
+    // PID
+    Float_t fTPCsignal = -999.f; /// dE/dX TPC
+    Float_t fTRDsignal = -999.f; /// dE/dX TRD
+    Float_t fTOFsignal = -999.f; /// TOFsignal
+    Float_t fLength = -999.f;    /// Int.Lenght @ TOF
+  } tracks;
 
+#ifdef USE_MC
   // Track labels
   Int_t fLabel = -1;           /// Track label
   Int_t fTOFLabel[3] = { -1 }; /// Label of the track matched to TOF
@@ -184,22 +214,128 @@ private:
   Float_t fVy = -999.f; /// y of production vertex
   Float_t fVz = -999.f; /// z of production vertex
   Float_t fVt = -999.f; /// t of production vertex
+#endif
 
-  // TOF
-  Int_t fTOFChannel = -1;        /// Index of the matched channel
-  Short_t fTOFncls = -1;         /// Number of matchable clusters of the track
-  Float_t fDx = -999.f;          /// Residual along x
-  Float_t fDz = -999.f;          /// Residual along z
-  Float_t fToT = -999.f;         /// ToT
-  Float_t fLengthRatio = -999.f; /// Ratio of the integrated track length @ TOF to the cluster with respect to the matched cluster
+  // To test the compilation uncoment the line below
+  // #define USE_TOF_CLUST 1
+#ifdef USE_TOF_CLUST
+  struct {
+    // TOF clusters
+    // PH: Do we store the TOF information per track?
+    Int_t fTOFChannel = -1;        /// Index of the matched channel
+    Short_t fTOFncls = -1;         /// Number of matchable clusters of the track
+    Float_t fDx = -999.f;          /// Residual along x
+    Float_t fDz = -999.f;          /// Residual along z
+    Float_t fToT = -999.f;         /// ToT
+    Float_t fLengthRatio = -999.f; /// Ratio of the integrated track length @ TOF to the cluster with respect to the matched cluster
+  } tofClusters;
+#endif
 
-  // fCaloTree variables
-  Short_t fCellNumber = -1;     /// Cell absolute Id. number
-  Float_t fAmplitude = -999.f;  /// Cell amplitude (= energy!)
-  Float_t fTime = -999.f;       /// Cell time
-  Char_t fType = -1;            /// Cell type (-1 is undefined, 0 is PHOS, 1 is EMCAL)
+  struct {
+    // Calorimeter data (EMCAL & PHOS)
 
-  ClassDef(AliAnalysisTaskAO2Dconverter, 1);
+    Int_t   fCollisionID;         /// The index of the collision vertex in the TF, to which the track is attached
+
+    Short_t fCellNumber = -1;     /// Cell absolute Id. number
+    Float_t fAmplitude = -999.f;  /// Cell amplitude (= energy!)
+    Float_t fTime = -999.f;       /// Cell time
+    Char_t fType = -1;            /// Cell type (-1 is undefined, 0 is PHOS, 1 is EMCAL)
+  } calo;
+
+  struct {
+    // MUON track data
+
+    Int_t   fCollisionID;            /// The index of the collision vertex, to which the muon is attached
+
+    /// Parameters at vertex
+    Float_t fInverseBendingMomentum; ///< Inverse bending momentum (GeV/c ** -1) times the charge 
+    Float_t fThetaX;                 ///< Angle of track at vertex in X direction (rad)
+    Float_t fThetaY;                 ///< Angle of track at vertex in Y direction (rad)
+    Float_t fZ;                      ///< Z coordinate (cm)
+    Float_t fBendingCoor;            ///< bending coordinate (cm)
+    Float_t fNonBendingCoor;         ///< non bending coordinate (cm)
+
+    /// Reduced covariance matrix of UNCORRECTED track parameters, ordered as follow:      <pre>
+    /// [0] =  <X,X>
+    /// [1] =<X,ThetaX>  [2] =<ThetaX,ThetaX>
+    /// [3] =  <X,Y>     [4] =  <Y,ThetaX>     [5] =  <Y,Y>
+    /// [6] =<X,ThetaY>  [7] =<ThetaX,ThetaY>  [8] =<Y,ThetaY>  [9] =<ThetaY,ThetaY>
+    /// [10]=<X,InvP_yz> [11]=<ThetaX,InvP_yz> [12]=<Y,InvP_yz> [13]=<ThetaY,InvP_yz> [14]=<InvP_yz,InvP_yz>  </pre>
+    Float_t fCovariances[15]; ///< \brief reduced covariance matrix of parameters AT FIRST CHAMBER
+
+    /// Global tracking info
+    Float_t fChi2;                ///< chi2 in the MUON track fit
+    Float_t fChi2MatchTrigger;    ///< chi2 of trigger/track matching
+  } muons;
+
+  struct {
+    // Muon clister data
+    
+    Int_t   fMuTrackID; /// The index of the track to which the clusters are attached
+    Float_t fX;         ///< cluster X position
+    Float_t fY;         ///< cluster Y position
+    Float_t fZ;         ///< cluster Z position
+    Float_t fErrX;      ///< transverse position errors
+    Float_t fErrY;      ///< transverse position errors
+    Float_t fCharge;    ///< cluster charge
+    Float_t fChi2;      ///< cluster chi2
+  } mucls;
+
+  struct {
+    // ZDC: it is not clear what is the minimal set of information (PH)
+
+    Int_t     fCollisionID;          /// The index of the collision vertex
+
+    Float_t   fZEM1Energy;   	     ///< E in ZEM1
+    Float_t   fZEM2Energy;	     ///< E in ZEM2
+
+    Float_t   fZNCTowerEnergy[5];    ///< E in 5 ZNC sectors - high gain chain
+    Float_t   fZNATowerEnergy[5];    ///< E in 5 ZNA sectors - high gain chain
+    Float_t   fZPCTowerEnergy[5];    ///< E in 5 ZPC sectors - high gain chain
+    Float_t   fZPATowerEnergy[5];    ///< E in 5 ZPA sectors - high gain chain
+
+    Float_t   fZNCTowerEnergyLR[5];  ///< E in 5 ZNC sectors - low gain chain
+    Float_t   fZNATowerEnergyLR[5];  ///< E in 5 ZNA sectors - low gain chain
+    Float_t   fZPCTowerEnergyLR[5];  ///< E in 5 ZPC sectors - low gain chain
+    Float_t   fZPATowerEnergyLR[5];  ///< E in 5 ZPA sectors - low gain chain
+
+    Float_t   fZDCTDCCorrected[32][4]; /// ZDC TDC data in ns corrected 4 phase shift
+
+    UChar_t   fFired;                  /// Bits: 0 - ZNA, 1 - ZNC, 2 - ZPA, 3 - ZPC, 4 - ZEM1, 5 - ZEM2
+  } zdc;
+
+  struct {
+    /// VZERO as proxy for FIT
+
+    Int_t   fCollisionID;      /// The index of the collision vertex
+
+    Float_t fAdc[64];          ///  adc for each channel
+    Float_t fTime[64];         ///  time for each channel
+    Float_t fWidth[64];        ///  time width for each channel
+    ULong64_t fBBFlag;         ///  BB Flags from Online V0 Electronics
+    ULong64_t fBGFlag;         ///  BG Flags from Online V0 Electronics
+  } vzero;
+
+  struct {
+    /// V0s (Ks, Lambda)
+
+    Int_t fPosTrackID; // Positive track ID
+    Int_t fNegTrackID; // Negative track ID
+  } v0s;
+
+  struct {
+    /// Cascades
+
+    Int_t fV0ID; // V0 ID
+    Int_t fBachelorID; // Bachelor track ID
+  } cascs;
+
+  /// Offsets to convert the IDs within one collision to global IDs
+  Int_t fOffsetMuTrackID = 0; ///! Offset of MUON track IDs (used in the clusters)
+  Int_t fOffsetTrackID = 0;   ///! Offset of track IDs (used in V0s)
+  Int_t fOffsetV0ID = 0;      ///! Offset of track IDs (used in cascades)
+
+  ClassDef(AliAnalysisTaskAO2Dconverter, 2);
 };
 
 #endif

--- a/RUN3/convertAO2D.C
+++ b/RUN3/convertAO2D.C
@@ -1,0 +1,121 @@
+R__ADD_INCLUDE_PATH($ALICE_ROOT)
+R__ADD_INCLUDE_PATH($ALICE_PHYSICS)
+#include <ANALYSIS/macros/train/AddESDHandler.C>
+#include <OADB/COMMON/MULTIPLICITY/macros/AddTaskMultSelection.C>
+#include <OADB/macros/AddTaskPhysicsSelection.C>
+#include <ANALYSIS/macros/AddTaskPIDResponse.C>
+#include <RUN3/AddTaskAO2Dconverter.C>
+
+TChain* CreateChain(const char *xmlfile, const char *type="ESD");
+TChain *CreateLocalChain(const char *txtfile, const char *type, int nfiles);
+
+void convertAO2D()
+{
+   const char *anatype = "ESD";
+
+ //  TGrid::Connect("alien:");
+
+   // Create the chain based on xml collection or txt file
+   // The entries in the txt file can be local paths or alien paths
+   TChain *chain = CreateLocalChain("wnlocal.txt", anatype, 10);
+   if (!chain) return;
+   chain->SetNotify(0x0);
+   ULong64_t nentries = chain->GetEntries();
+   cout << nentries << " entries in the chain." << endl;
+
+   AliAnalysisManager *mgr = new AliAnalysisManager("AOD converter");
+   AliESDInputHandler *handler = AddESDHandler();
+      
+   AddTaskMultSelection();
+   AddTaskPhysicsSelection();
+   AddTaskPIDResponse();
+
+   AliAnalysisTaskAO2Dconverter* converter = AddTaskAO2Dconverter("");
+   //converter->SelectCollisionCandidates(AliVEvent::kAny);
+   
+   if (!mgr->InitAnalysis()) return;
+   //PH   mgr->SetBit(AliAnalysisManager::kTrueNotify);
+   mgr->SetRunFromPath(244918);
+   mgr->PrintStatus();
+
+   mgr->SetDebugLevel(1);
+   //   mgr->StartAnalysis("localfile", chain, 123456789, 0);
+   mgr->StartAnalysis("localfile", chain, nentries, 0);
+}
+
+TChain *CreateLocalChain(const char *txtfile, const char *type, int nfiles)
+{
+   TString treename = type;
+   treename.ToLower();
+   treename += "Tree";
+   printf("***************************************\n");
+   printf("    Getting chain of trees %s\n", treename.Data());
+   printf("***************************************\n");
+   // Open the file
+   ifstream in;
+   in.open(txtfile);
+   Int_t count = 0;
+    // Read the input list of files and add them to the chain
+   TString line;
+   TChain *chain = new TChain(treename);
+   while (in.good())
+   {
+      in >> line;
+      if (line.IsNull() || line.BeginsWith("#")) continue;
+      if (count++ == nfiles) break;
+      TString esdFile(line);
+      TFile *file = TFile::Open(esdFile);
+      if (file && !file->IsZombie()) {
+         chain->Add(esdFile);
+         file->Close();
+      } else {
+         Error("GetChainforTestMode", "Skipping un-openable file: %s", esdFile.Data());
+      }   
+   }
+   in.close();
+   if (!chain->GetListOfFiles()->GetEntries()) {
+       Error("CreateLocalChain", "No file from %s could be opened", txtfile);
+       delete chain;
+       return nullptr;
+   }
+   return chain;
+}
+
+//________________________________________________________________________________
+TChain* CreateChain(const char *xmlfile, const char *type)
+{
+// Create a chain using url's from xml file
+   TString filename;
+   Int_t run = 0;
+   TString treename = type;
+   treename.ToLower();
+   treename += "Tree";
+   printf("***************************************\n");
+   printf("    Getting chain of trees %s\n", treename.Data());
+   printf("***************************************\n");
+   TGridCollection *coll = gGrid->OpenCollection(xmlfile);
+   if (!coll) {
+      ::Error("CreateChain", "Cannot create an AliEn collection from %s", xmlfile);
+      return NULL;
+   }
+   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+   TChain *chain = new TChain(treename);
+   coll->Reset();
+   while (coll->Next()) {
+      filename = coll->GetTURL();
+      if (mgr) {
+         Int_t nrun = AliAnalysisManager::GetRunFromAlienPath(filename);
+         if (nrun && nrun != run) {
+            printf("### Run number detected from chain: %d\n", nrun);
+            mgr->SetRunFromPath(nrun);
+            run = nrun;
+         }
+      }
+      chain->Add(filename);
+   }
+   if (!chain->GetNtrees()) {
+      ::Error("CreateChain", "No tree found from collection %s", xmlfile);
+      return NULL;
+   }
+   return chain;
+}


### PR DESCRIPTION
- The use of event cuts is optional
- The collision time is used from the best method without momentium dependency
- MUON, MUON clusters, ZDC, VZERO as proxy for FIT added
- V0s and cascades added as pairs of indexes
- MC information excluded for the moment, to be replaced
- TOF clusters excluded for the moment, to be clarified