### PR TITLE
Use kError for the log level only for the filteredTrees task.

### DIFF
--- a/PWGPP/macros/AddTaskFilteredTree.C
+++ b/PWGPP/macros/AddTaskFilteredTree.C
@@ -22,9 +22,7 @@ AliAnalysisTask* AddTaskFilteredTree(TString outputFile="")
   }
 
   // Switch off all AliInfo (too much output!!!)
-  AliLog::SetGlobalLogLevel(AliLog::kError);
-  mgr->SetDebugLevel(0);
-
+  AliLog::SetClassDebugLevel("AliAnalysisTaskFilteredTree", AliLog::kError);
   
 
   //


### PR DESCRIPTION
The previous settings were affecting all tasks in the QA and AOD
trains.