### PR TITLE
Add HF cut-object like classes for application of ML python models

### DIFF
--- a/PWGHF/hfe/AliAnalysisTaskFlowTPCEMCalRun2.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskFlowTPCEMCalRun2.cxx
@@ -48,7 +48,6 @@
 //#include "AliQnCorrectionsQnVector.h"
 //#include "AliAnalysisTaskQnVectorAnalysis.h"
 #include "AliAnalysisTaskSEHFTenderQnVectors.h"
-#include "AliAnalysisTaskSECharmHadronvn.h"
 #include "AliHFQnVectorHandler.h"
 //#include "AliAODHandler.h"
 //#include "AliAODVertex.h"
@@ -66,8 +65,8 @@ ClassImp(AliAnalysisTaskFlowTPCEMCalRun2) // classimp: necessary for root
 
 //_____________________________________________________________________________
 AliAnalysisTaskFlowTPCEMCalRun2::AliAnalysisTaskFlowTPCEMCalRun2(const char *name) : AliAnalysisTaskSE(name),
-	fAOD(0), 
-	fOutputList(0), 
+	fAOD(0),
+	fOutputList(0),
 	fVevent(0),
 	fpidResponse(0),
 	fHistPt(0),
@@ -183,8 +182,8 @@ AliAnalysisTaskFlowTPCEMCalRun2::AliAnalysisTaskFlowTPCEMCalRun2(const char *nam
 	//fOutplane(0),
         fInplane_ele(0),
         fOutplane_ele(0),
-        fInplane_hfe(0), 
-        fOutplane_hfe(0), 
+        fInplane_hfe(0),
+        fOutplane_hfe(0),
         fInplane_LSpho(0),
         fOutplane_LSpho(0),
         fInplane_ULSpho(0),
@@ -192,7 +191,7 @@ AliAnalysisTaskFlowTPCEMCalRun2::AliAnalysisTaskFlowTPCEMCalRun2(const char *nam
 	DCAxy(3.0),
 	DCAz(3.0),
 	fDCAxy_Pt_ele(0),
-	fDCAxy_Pt_had(0), 
+	fDCAxy_Pt_had(0),
         ftpcnsig(-1.0),
         femceop(0.9),
         femcss_mim(0.01),
@@ -252,7 +251,7 @@ for(int iHisto=0; iHisto<3; iHisto++){
 
 
 	for(int iDet=0; iDet<6; iDet++){
-		
+
 		fqnSplinesList[iDet] = nullptr;
 		fHistqnVsCentrPercCalib[iDet] = nullptr;
 		fHistEvPlaneQncorr[iDet] = nullptr;
@@ -263,16 +262,16 @@ for(int iHisto=0; iHisto<3; iHisto++){
         fvalueElectron = new Double_t[6];
 
 	DefineInput(0, TChain::Class());    // define the input of the analysis: in this case we take a 'chain' of events
-	DefineOutput(1, TList::Class());    // define the ouptut of the analysis: in this case it's a list of histograms 
+	DefineOutput(1, TList::Class());    // define the ouptut of the analysis: in this case it's a list of histograms
 
 }
 
 
 //_____________________________________________________________________________
-AliAnalysisTaskFlowTPCEMCalRun2::AliAnalysisTaskFlowTPCEMCalRun2() : AliAnalysisTaskSE("HFEflowRun2"), 
-	fAOD(0), 
-	fOutputList(0), 
-	fVevent(0), 
+AliAnalysisTaskFlowTPCEMCalRun2::AliAnalysisTaskFlowTPCEMCalRun2() : AliAnalysisTaskSE("HFEflowRun2"),
+	fAOD(0),
+	fOutputList(0),
+	fVevent(0),
 	fpidResponse(0),
 	fHistPt(0),
 	fNevents(0),
@@ -388,8 +387,8 @@ AliAnalysisTaskFlowTPCEMCalRun2::AliAnalysisTaskFlowTPCEMCalRun2() : AliAnalysis
 	//fOutplane(0),
         fInplane_ele(0),
         fOutplane_ele(0),
-        fInplane_hfe(0), 
-        fOutplane_hfe(0), 
+        fInplane_hfe(0),
+        fOutplane_hfe(0),
         fInplane_LSpho(0),
         fOutplane_LSpho(0),
         fInplane_ULSpho(0),
@@ -472,19 +471,19 @@ AliAnalysisTaskFlowTPCEMCalRun2::AliAnalysisTaskFlowTPCEMCalRun2() : AliAnalysis
 	// this is used by root for IO purposes, it needs to remain empty
 	// constructor
 	DefineInput(0, TChain::Class());    // define the input of the analysis: in this case we take a 'chain' of events
-	// this chain is created by the analysis manager, so no need to worry about it, 
+	// this chain is created by the analysis manager, so no need to worry about it,
 	// it does its work automatically
-	DefineOutput(1, TList::Class());    // define the ouptut of the analysis: in this case it's a list of histograms 
+	DefineOutput(1, TList::Class());    // define the ouptut of the analysis: in this case it's a list of histograms
 	// you can add more output objects by calling DefineOutput(2, classname::Class())
 	// if you add more output objects, make sure to call PostData for all of them, and to
 	// make changes to your AddTask macro!
 }
 //_____________________________________________________________________________
 AliAnalysisTaskFlowTPCEMCalRun2::~AliAnalysisTaskFlowTPCEMCalRun2()
-{ 
+{
 	// destructor
   //   if(fOutputList) {
-  // 	    delete fOutputList;   
+  // 	    delete fOutputList;
   // 	//    delete fTracks_tender;
   // // at the end of your task, it is deleted from memory by calling this function
   //   }
@@ -528,7 +527,7 @@ void AliAnalysisTaskFlowTPCEMCalRun2::UserCreateOutputObjects()
     // create output objects
     //
     // this function is called ONCE at the start of your analysis (RUNTIME)
-    // here you ceate the histograms that you want to use 
+    // here you ceate the histograms that you want to use
     //
     // the histograms are in this case added to a tlist, this list is in the end saved
     // to an output file
@@ -544,7 +543,7 @@ void AliAnalysisTaskFlowTPCEMCalRun2::UserCreateOutputObjects()
     fOutputList->Add(fHistPt);          // don't forget to add it to the list! the list will be written to file, so if you want
                                         // your histogram in the output file, add it to the list!
 
-//No of events    
+//No of events
 fNevents = new TH1F("fNevents","No of events",3,-0.5,2.5);
 fOutputList->Add(fNevents);
 fNevents->GetYaxis()->SetTitle("counts");
@@ -940,7 +939,7 @@ const int ncentbins = static_cast<int>(fMaxCentr-fMinCentr);
 TString detConfName[6] = {"TPC","TPCPosEta","TPCNegEta","V0","V0A","V0C"};
 
 TString qnaxisname=Form("#it{q}_{%d}",fHarmonic);
-//cout << "fqnMeth = " << fqnMeth << endl;  
+//cout << "fqnMeth = " << fqnMeth << endl;
 switch(fqnMeth) {
 	case kq2TPC:
 		qnaxisname=Form("#it{q}_{%d}^{TPC}",fHarmonic);
@@ -966,7 +965,7 @@ switch(fqnMeth) {
 
 TString qnpercaxisname = qnaxisname + " (%)";
 TString qnaxisnamefill = qnaxisname;
-if(fPercentileqn) 
+if(fPercentileqn)
 	qnaxisnamefill = qnpercaxisname;
 
 	int nqnbins=1; //single bin if unbiased analysis
@@ -990,9 +989,9 @@ for(int iDet = 0; iDet < 6; iDet++){
 	//fHistEvPlane[iDet] = new TH1F(Form("fHistEvPlane%s",detConfName[iDet].Data()),Form("hEvPlane%s",detConfName[iDet].Data()),200,0.,TMath::Pi());
 	fHistEvPlane[iDet] = new TH1F(Form("fHistEvPlane%s",detConfName[iDet].Data()),Form("hEvPlane%s",detConfName[iDet].Data()),200,-TMath::Pi()/2.,TMath::Pi()/2.);
 	fOutputList->Add(fHistEvPlane[iDet]);
-	
+
 	fHistEvPlaneQncorr[iDet] = new TH2F(Form("fHistEvPlaneQncorr%sVsCent",detConfName[iDet].Data()),Form("hEvPlaneQncorr%s;centrality(%%);#psi_{%d}",detConfName[iDet].Data(),fHarmonic),ncentbins,fMinCentr,fMaxCentr,200,0.,TMath::Pi());
-	
+
 	//fHistEvPlaneQncorr[iDet] = new TH3F(Form("fHistEvPlaneQncorr%sVsqnVsCent",detConfName[iDet].Data()),Form("hEvPlaneQncorr%s;centrality(%%);%s;#psi_{%d}",detConfName[iDet].Data(),qnaxisnamefill.Data(),fHarmonic),ncentbins,fMinCentr,fMaxCentr,nqnbins,qnmin,qnmax,200,0.,TMath::Pi());
 	fOutputList->Add(fHistEvPlaneQncorr[iDet]);
 
@@ -1026,7 +1025,7 @@ for(int iResoHisto=0; iResoHisto<3; iResoHisto++){
 
 
 
-PostData(1, fOutputList);           // postdata will notify the analysis manager of changes / updates to the 
+PostData(1, fOutputList);           // postdata will notify the analysis manager of changes / updates to the
 // fOutputList object. the manager will in the end take care of writing your output to file
 // so it needs to know what's in the output
 }
@@ -1035,7 +1034,7 @@ void AliAnalysisTaskFlowTPCEMCalRun2::UserExec(Option_t *)
 {
 
 //============= Systematic Parameter ================
-//Track cut 
+//Track cut
 Double_t CutDCAxy = DCAxy;
 Double_t CutDCAz = DCAz;
 
@@ -1043,12 +1042,12 @@ Double_t CutDCAz = DCAz;
 Double_t CutEopHad = -3.5;
 
 cout << "cut selections ---------------------" << endl;
-cout << "tpcnsig = " << ftpcnsig << endl; 
-cout << "emceop = " << femceop << endl; 
-cout << "emcss_mim = " << femcss_mim << endl; 
-cout << "emcss_max = " << femcss_max << endl; 
-cout << "invmass = " << finvmass << endl; 
-cout << "invmass_pt = " << finvmass_pt << endl; 
+cout << "tpcnsig = " << ftpcnsig << endl;
+cout << "emceop = " << femceop << endl;
+cout << "emcss_mim = " << femcss_mim << endl;
+cout << "emcss_max = " << femcss_max << endl;
+cout << "invmass = " << finvmass << endl;
+cout << "invmass_pt = " << finvmass_pt << endl;
 cout << "-------------------------------------" << endl;
 
 //===================================================
@@ -1056,14 +1055,14 @@ cout << "-------------------------------------" << endl;
 
     // user exec
     // this function is called once for each event
-    // the manager will take care of reading the events from file, and with the static function InputEvent() you 
-    // have access to the current event. 
+    // the manager will take care of reading the events from file, and with the static function InputEvent() you
+    // have access to the current event.
     // once you return from the UserExec function, the manager will retrieve the next event from the chain
     fAOD = dynamic_cast<AliAODEvent*>(InputEvent());    // get an event (called fAOD) from the input file
                                                         // there's another event format (ESD) which works in a similar wya
                                                         // but is more cpu/memory unfriendly. for now, we'll stick with aod's
     if(!fAOD) return;                                   // if the pointer to the event is empty (getting it failed) skip this event
-        // example part: i'll show how to loop over the tracks in an event 
+        // example part: i'll show how to loop over the tracks in an event
         // and extract some information from them which we'll store in a histogram
     fMCarray = dynamic_cast<TClonesArray*>(fAOD->FindListObject(AliAODMCParticle::StdBranchName()));
     fMCheader = dynamic_cast<AliAODMCHeader*>(fAOD->GetList()->FindObject(AliAODMCHeader::StdBranchName()));
@@ -1073,7 +1072,7 @@ cout << "-------------------------------------" << endl;
     if (!fVevent) {
 	    printf("ERROR: fVEvent not available\n");
 	    return;
-    }  
+    }
 
 
   //TString firedTrigger;
@@ -1093,8 +1092,8 @@ cout << "-------------------------------------" << endl;
     fpidResponse = fInputHandler->GetPIDResponse();
 
     /////////Centrality////////
-     Float_t lPercentile = 300; 
-     AliMultSelection *MultSelection = 0x0; 
+     Float_t lPercentile = 300;
+     AliMultSelection *MultSelection = 0x0;
       MultSelection = (AliMultSelection * ) fAOD->FindListObject("MultSelection");
       if( !MultSelection) {
       	    //If you get this warning (and lPercentiles 300) please check that the AliMultSelectionTask actually ran (before your task)
@@ -1106,10 +1105,10 @@ cout << "-------------------------------------" << endl;
 
     flPercentile -> Fill(lPercentile);
 
-      
+
     //if(TMath::Abs(lPercentile)<30 || TMath::Abs(lPercentile)>50)return;
     if(TMath::Abs(lPercentile)<fMinCentr || TMath::Abs(lPercentile)>fMaxCentr)return;
-     
+
     ///////Event Plane for 2015//////
 //   flowQnVectorTask = dynamic_cast<AliAnalysisTaskFlowVectorCorrections *> (AliAnalysisManager::GetAnalysisManager()->GetTask("FlowQnVectorCorrections"));
 //
@@ -1299,17 +1298,17 @@ cout << "-------------------------------------" << endl;
     //double evCentr = fRDCuts->GetCentrality(fAOD);
 
 	//Get Qn-vectors from tender task
-    AliHFQnVectorHandler *HFQnVectorHandler = nullptr; 
+    AliHFQnVectorHandler *HFQnVectorHandler = nullptr;
     bool isHandlerFound = false;
-  
+
     cout << "<----------- fTenderTaskName = " << fTenderTaskName << endl;
     AliAnalysisTaskSEHFTenderQnVectors *HFQnVectorTask = dynamic_cast<AliAnalysisTaskSEHFTenderQnVectors*>(AliAnalysisManager::GetAnalysisManager()->GetTask(fTenderTaskName.Data()));
- 
-    cout << "<----------- HFQnVectorTask = " << HFQnVectorTask << endl; 
+
+    cout << "<----------- HFQnVectorTask = " << HFQnVectorTask << endl;
 
     if(HFQnVectorTask){
 
-	    //cout << "HFQnVectorTask = " << HFQnVectorTask << endl; 
+	    //cout << "HFQnVectorTask = " << HFQnVectorTask << endl;
 
 	    HFQnVectorHandler = HFQnVectorTask->GetQnVectorHandler();
 
@@ -1352,7 +1351,7 @@ cout << "-------------------------------------" << endl;
     }
 
     else{//create a new handler if not found in tender task
-	    
+
 	    //cout << "isHandlerFound =" << isHandlerFound << endl;
 
 	    AliWarning("Qn-vector tender task not found! Create a new one");
@@ -1517,7 +1516,7 @@ cout << "-------------------------------------" << endl;
     fHistEvPlane[4]->Fill(PsinV0A);
     fHistEvPlane[5]->Fill(PsinV0C);
 
-    
+
     //centrality vs EP
     fHistEvPlaneQncorr[0]->Fill(evCentr,PsinFullTPC);
     fHistEvPlaneQncorr[1]->Fill(evCentr,PsinPosTPC);
@@ -1606,7 +1605,7 @@ int NclustE3 = 0;//Number of cluster E>0.5
 
 for(Int_t icl=0; icl<Nclust; icl++)
 {
-	AliVCluster *clust = 0x0;     
+	AliVCluster *clust = 0x0;
 	//clust = (AliVCluster*)fVevent->GetCaloCluster(icl); // address cluster matched to track
         clust = dynamic_cast<AliVCluster*>(fCaloClusters_tender->At(icl));
 
@@ -1665,7 +1664,7 @@ Double_t cellAmp=-1., cellTimeT=-1., clusterTime=-1., efrac=-1.;
     //Int_t iTracks(fAOD->GetNumberOfTracks());           // see how many tracks there are in the event
     Int_t iTracks(fTracks_tender->GetEntries());           // see how many tracks there are in the event
     for(Int_t i = 0; i < iTracks; i++) {                 // loop over all these tracks
-     
+
 	//AliAODTrack* track = static_cast<AliAODTrack*>(fAOD->GetTrack(i));         // get a track (type AliAODTrack) from the event
 	AliAODTrack* track = dynamic_cast<AliAODTrack*>(fTracks_tender->At(i));         // get a track (type AliAODTrack) from the event
 
@@ -1689,7 +1688,7 @@ Double_t cellAmp=-1., cellTimeT=-1., clusterTime=-1., efrac=-1.;
 	TrkEta = track->Eta();
 	if(TrkEta < -0.6 || TrkEta > 0.6)continue;
 	TrkP = track->P();
-	dEdx = track->GetTPCsignal();     
+	dEdx = track->GetTPCsignal();
 	fTPCnSigma = fpidResponse->NumberOfSigmasTPC(track, AliPID::kElectron);
         fTOFnSigma = fpidResponse->NumberOfSigmasTOF(track, AliPID::kElectron);
 	fITSnSigma = fpidResponse->NumberOfSigmasITS(track, AliPID::kElectron);
@@ -1931,7 +1930,7 @@ Double_t cellAmp=-1., cellTimeT=-1., clusterTime=-1., efrac=-1.;
              {
                 WeightPho = fPi010->Eval(pTmom);
              }
-    
+
             if(lPercentile>=30.0 && lPercentile<50.0)
              {
               if(pTmom<4.0)
@@ -2003,7 +2002,7 @@ Double_t cellAmp=-1., cellTimeT=-1., clusterTime=-1., efrac=-1.;
         if(EMCalIndex>=0) clustMatch = dynamic_cast<AliVCluster*>(fCaloClusters_tender->At(EMCalIndex));
 
 	//cout << "Charge = " << track -> Charge() << endl;
-	
+
 	if(clustMatch && clustMatch->IsEMCAL())
 	{
 	 Double_t clustMatchE = clustMatch->E();
@@ -2013,7 +2012,7 @@ Double_t cellAmp=-1., cellTimeT=-1., clusterTime=-1., efrac=-1.;
 
 
 
-	Double_t emcphi = -999, emceta = -999;        
+	Double_t emcphi = -999, emceta = -999;
 
 	if(clustMatch && clustMatch->IsEMCAL())
 	{
@@ -2088,7 +2087,7 @@ Double_t cellAmp=-1., cellTimeT=-1., clusterTime=-1., efrac=-1.;
 				//if(track->Pt() > 1.5){
 
 				TrkPhiEPV0A_ele = TrkPhiPI - PsinV0A;
-				
+
 				if(TrkPhiEPV0A_ele > TMath::Pi()/2.){
 					TrkPhiEPV0A_ele -= TMath::Pi();
 				}
@@ -2118,10 +2117,10 @@ Double_t cellAmp=-1., cellTimeT=-1., clusterTime=-1., efrac=-1.;
 				//}
 
                                 if(!fFlagNonHFE){
- 
+
                                 fTrkPhicos2_hfehigh -> Fill(track->Pt(),TrkPhicos2_elehigh);
                                 fTrkPhisin2_hfehigh -> Fill(track->Pt(),TrkPhisin2_elehigh);
- 
+
                                 }
 
 
@@ -2130,9 +2129,9 @@ Double_t cellAmp=-1., cellTimeT=-1., clusterTime=-1., efrac=-1.;
 					fInplane_ele -> Fill(track->Pt());
 
                                          if(!fFlagNonHFE){
- 
+
                                                  fInplane_hfe -> Fill(track->Pt());//using this at pt < 3 GeV
- 
+
                                          }
 
 
@@ -2178,8 +2177,8 @@ Double_t cellAmp=-1., cellTimeT=-1., clusterTime=-1., efrac=-1.;
 					}
 
 					else{
-						fHistPhoReco2 -> Fill(track->Pt());		
-					}			
+						fHistPhoReco2 -> Fill(track->Pt());
+					}
 				}
 
 			}
@@ -2198,7 +2197,7 @@ Double_t cellAmp=-1., cellTimeT=-1., clusterTime=-1., efrac=-1.;
                       }
 
 				TrkPhiEPV0A_had = TrkPhiPI - PsinV0A;
-				
+
 				if(TrkPhiEPV0A_had > TMath::Pi()/2.){
 					TrkPhiEPV0A_had -= TMath::Pi();
 				}
@@ -2206,7 +2205,7 @@ Double_t cellAmp=-1., cellTimeT=-1., clusterTime=-1., efrac=-1.;
 				if(TrkPhiEPV0A_had < -TMath::Pi()/2.){
 					TrkPhiEPV0A_had += TMath::Pi();
 				}
-			
+
 				TrkPhicos2_hadhigh = cos(2*TrkPhiEPV0A_had);
 				TrkPhisin2_hadhigh = sin(2*TrkPhiEPV0A_had);
 
@@ -2351,7 +2350,7 @@ Double_t CutmassMin = massMin;
 	Double_t TrkPhicos2_phoLShigh = -999., TrkPhisin2_phoLShigh = -999.;
 	Double_t TrkPhicos2_phoULShigh = -999., TrkPhisin2_phoULShigh = -999.;
 
-	if(fFlagLS && track->Pt()>1){ 
+	if(fFlagLS && track->Pt()>1){
 
 		fInvmassLS->Fill(mass);
 		fInvmassLS_2D->Fill(mass,track->Pt());
@@ -2391,7 +2390,7 @@ Double_t CutmassMin = massMin;
 		}
 	}
 
-	if(fFlagULS && track->Pt()>1){ 
+	if(fFlagULS && track->Pt()>1){
 
 		fInvmassULS->Fill(mass);
 		fInvmassULS_2D->Fill(mass,track->Pt());
@@ -2683,13 +2682,13 @@ void AliAnalysisTaskFlowTPCEMCalRun2::GetMainQnVectorInfo(double &mainPsin,doubl
 	HFQnVectorHandler->GetMultQnVecV0(MultQnFullV0,MultQnV0A,MultQnV0C);
 
 	HFQnVectorHandler->GetEventPlaneAngleTPC(PsinFullTPC,PsinPosTPC,PsinNegTPC);
-	HFQnVectorHandler->GetEventPlaneAngleV0(PsinFullV0,PsinV0A,PsinV0C); 
+	HFQnVectorHandler->GetEventPlaneAngleV0(PsinFullV0,PsinV0A,PsinV0C);
 
 	if(fEtaGapInTPCHalves>0.) {
 		vector<AliAODTrack*> trackstoremove;
 		for(int iTrack=0; iTrack<fAOD->GetNumberOfTracks(); iTrack++) {
 			AliAODTrack* track = dynamic_cast<AliAODTrack*>(fAOD->GetTrack(iTrack));
-			if(TMath::Abs(track->Eta())<fEtaGapInTPCHalves/2)   
+			if(TMath::Abs(track->Eta())<fEtaGapInTPCHalves/2)
 				trackstoremove.push_back(track);
 		}
 		HFQnVectorHandler->RemoveTracksFromQnTPC(trackstoremove, QnFullTPC, QnPosTPC, QnNegTPC, MultQnFullTPC, MultQnPosTPC, MultQnNegTPC, true);
@@ -2709,7 +2708,7 @@ void AliAnalysisTaskFlowTPCEMCalRun2::GetMainQnVectorInfo(double &mainPsin,doubl
 			mainPsin   = PsinPosTPC;
 			mainMultQn = MultQnPosTPC;
 			mainQn[0]  = QnPosTPC[0];
-			mainQn[1]  = QnPosTPC[1];        
+			mainQn[1]  = QnPosTPC[1];
 			break;
 		case kNegTPC:
 			mainPsin   = PsinNegTPC;
@@ -2727,13 +2726,13 @@ void AliAnalysisTaskFlowTPCEMCalRun2::GetMainQnVectorInfo(double &mainPsin,doubl
 			mainPsin   = PsinV0A;
 			mainMultQn = MultQnV0A;
 			mainQn[0]  = QnV0A[0];
-			mainQn[1]  = QnV0A[1];        
+			mainQn[1]  = QnV0A[1];
 			break;
 		case kV0C:
 			mainPsin   = PsinV0C;
 			mainMultQn = MultQnV0C;
 			mainQn[0]  = QnV0C[0];
-			mainQn[1]  = QnV0C[1];        
+			mainQn[1]  = QnV0C[1];
 			break;
 	}
 
@@ -2748,7 +2747,7 @@ void AliAnalysisTaskFlowTPCEMCalRun2::GetMainQnVectorInfo(double &mainPsin,doubl
 			SubAPsin   = PsinPosTPC;
 			SubAMultQn = MultQnPosTPC;
 			SubAQn[0]  = QnPosTPC[0];
-			SubAQn[1]  = QnPosTPC[1];        
+			SubAQn[1]  = QnPosTPC[1];
 			break;
 		case kNegTPC:
 			SubAPsin   = PsinNegTPC;
@@ -2766,13 +2765,13 @@ void AliAnalysisTaskFlowTPCEMCalRun2::GetMainQnVectorInfo(double &mainPsin,doubl
 			SubAPsin   = PsinV0A;
 			SubAMultQn = MultQnV0A;
 			SubAQn[0]  = QnV0A[0];
-			SubAQn[1]  = QnV0A[1];        
+			SubAQn[1]  = QnV0A[1];
 			break;
 		case kV0C:
 			SubAPsin   = PsinV0C;
 			SubAMultQn = MultQnV0C;
 			SubAQn[0]  = QnV0C[0];
-			SubAQn[1]  = QnV0C[1];        
+			SubAQn[1]  = QnV0C[1];
 			break;
 	}
 
@@ -2787,7 +2786,7 @@ void AliAnalysisTaskFlowTPCEMCalRun2::GetMainQnVectorInfo(double &mainPsin,doubl
 			SubBPsin   = PsinPosTPC;
 			SubBMultQn = MultQnPosTPC;
 			SubBQn[0]  = QnPosTPC[0];
-			SubBQn[1]  = QnPosTPC[1];        
+			SubBQn[1]  = QnPosTPC[1];
 			break;
 		case kNegTPC:
 			SubBPsin   = PsinNegTPC;
@@ -2805,13 +2804,13 @@ void AliAnalysisTaskFlowTPCEMCalRun2::GetMainQnVectorInfo(double &mainPsin,doubl
 			SubBPsin   = PsinV0A;
 			SubBMultQn = MultQnV0A;
 			SubBQn[0]  = QnV0A[0];
-			SubBQn[1]  = QnV0A[1];        
+			SubBQn[1]  = QnV0A[1];
 			break;
 		case kV0C:
 			SubBPsin   = PsinV0C;
 			SubBMultQn = MultQnV0C;
 			SubBQn[0]  = QnV0C[0];
-			SubBQn[1]  = QnV0C[1];        
+			SubBQn[1]  = QnV0C[1];
 			break;
 	}
 

--- a/PWGHF/hfe/AliAnalysisTaskFlowTPCEMCalRun2.cxx
+++ b/PWGHF/hfe/AliAnalysisTaskFlowTPCEMCalRun2.cxx
@@ -24,6 +24,7 @@
 #include "TH1F.h"
 #include "TCanvas.h"
 #include "TList.h"
+#include "THnSparse.h"
 #include "AliMultSelection.h"
 #include "AliAnalysisTask.h"
 #include "AliAnalysisManager.h"

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEDs.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEDs.cxx
@@ -35,8 +35,6 @@
 #include <TGrid.h>
 #include <TFile.h>
 
-#include "yaml-cpp/yaml.h"
-
 #include "AliAnalysisManager.h"
 #include "AliAODHandler.h"
 #include "AliAODEvent.h"
@@ -113,11 +111,7 @@ AliAnalysisTaskSEDs::AliAnalysisTaskSEDs() : AliAnalysisTaskSE(),
   fUseFinPtBinsForSparse(kFALSE),
   fApplyML(kFALSE),
   fConfigPath(""),
-  fNumVars(0),
-  fModelPaths(),
-  fModelOutputCuts(),
-  fPtBinsModel(),
-  fModels(),
+  fMLResponse(nullptr),
   fEnablePIDMLSparses(kFALSE),
   fNMLBins(300),
   fMLOutputMin(0.85),
@@ -240,11 +234,7 @@ AliAnalysisTaskSEDs::AliAnalysisTaskSEDs(const char *name, AliRDHFCutsDstoKKpi *
   fUseFinPtBinsForSparse(kFALSE),
   fApplyML(kFALSE),
   fConfigPath(""),
-  fNumVars(0),
-  fModelPaths(),
-  fModelOutputCuts(),
-  fPtBinsModel(),
-  fModels(),
+  fMLResponse(nullptr),
   fEnablePIDMLSparses(kFALSE),
   fNMLBins(300),
   fMLOutputMin(0.85),
@@ -460,6 +450,9 @@ AliAnalysisTaskSEDs::~AliAnalysisTaskSEDs()
   delete fNtupleDs;
   delete fCounter;
   delete fAnalysisCuts;
+
+  if(fApplyML && fMLResponse)
+    delete fMLResponse;
 }
 
 //________________________________________________________________________
@@ -479,11 +472,6 @@ void AliAnalysisTaskSEDs::Init()
 
   fListCuts->Add(analysis);
   PostData(2, fListCuts);
-
-  if(fApplyML) {
-    if(!SetMLVariables(fConfigPath))
-      AliFatal("Problem in configuration of the ML application");
-  }
 
   return;
 }
@@ -762,13 +750,8 @@ void AliAnalysisTaskSEDs::UserCreateOutputObjects()
 
   //Loading of ML models
   if(fApplyML) {
-    for(auto it = fModelPaths.begin(); it != fModelPaths.end(); it++) {
-      std::string model_path = GetFile(*it);
-      AliExternalBDT model = AliExternalBDT();
-      if(!model.LoadXGBoostModel(model_path))
-        AliFatal("Problem in loading model");
-      fModels.push_back(model);
-    }
+    fMLResponse = new AliHFMLResponseDstoKKpi(fConfigPath.Data());
+    fMLResponse->InitModels();
 
     if(fEnablePIDMLSparses)
       CreatePIDMLSparses();
@@ -909,8 +892,6 @@ void AliAnalysisTaskSEDs::UserExec(Option_t * /*option*/)
     }
   }
 
-  Double_t nTracklets = (Double_t)AliVertexingHFUtils::GetNumberOfTrackletsInEtaRange(aod, -1., 1.);
-
   if (fReadMC && fFillSparse)
   {
     if (aod->GetTriggerMask() == 0 && (runNumber >= 195344 && runNumber <= 195677))
@@ -919,7 +900,7 @@ void AliAnalysisTaskSEDs::UserExec(Option_t * /*option*/)
     if (fAnalysisCuts->GetUseCentrality() > 0 && fAnalysisCuts->IsEventSelectedInCentrality(aod) != 0)
       // events not passing the centrality selection can be removed immediately.
       return;
-    FillMCGenAccHistos(arrayMC, mcHeader, nTracklets);
+    FillMCGenAccHistos(arrayMC, mcHeader);
   }
 
   if (!isEvSel) return;
@@ -1267,30 +1248,11 @@ void AliAnalysisTaskSEDs::UserExec(Option_t * /*option*/)
           Double_t normIPprong[nProng]; //to store IP of k,k,pi
           Double_t absimpparxy = TMath::Abs(d->ImpParXY());
           //variables for ML application
-          Double_t nsigTPCPi[nProng] = {-999., -999., -999.};
-          Double_t nsigTPCK[nProng] = {-999., -999., -999.};
-          Double_t nsigTOFPi[nProng] = {-999., -999., -999.};
-          Double_t nsigTOFK[nProng] = {-999., -999., -999.};
-          Double_t sigCombK[nProng] = {-999., -999., -999.};
-          Double_t sigCombPi[nProng] = {-999., -999., -999.};
           AliAODPidHF *Pid_HF = nullptr;
-          Int_t iModel = 0;
-          Double_t modelLim = 0.;
-
+          Double_t modelPred = -1.;
+          bool isMLsel = true;
           if(fApplyML)
-          {
             Pid_HF = fAnalysisCuts->GetPidHF();
-            if(ptCand > fPtBinsModel[0])
-            {
-              for(unsigned int i = 0; i < fPtBinsModel.size() - 1; i++)
-              {
-                if(fPtBinsModel[i] <= ptCand && ptCand < fPtBinsModel[i+1])
-                  break;
-                iModel++;
-              }
-            }
-            modelLim = fModelOutputCuts[iModel];
-          }
 
           for (Int_t ip = 0; ip < nProng; ip++)
           {
@@ -1301,18 +1263,6 @@ void AliAnalysisTaskSEDs::UserExec(Option_t * /*option*/)
               normIP = normIPprong[ip];
             else if (TMath::Abs(normIPprong[ip]) > TMath::Abs(normIP))
               normIP = normIPprong[ip];
-
-            //get PID info for ML application
-            if(fApplyML)
-            {
-              AliAODTrack *track=(AliAODTrack*)d->GetDaughter(ip);
-              Pid_HF->GetnSigmaTPC(track,3,nsigTPCK[ip]);
-              Pid_HF->GetnSigmaTPC(track,2,nsigTPCPi[ip]);
-              Pid_HF->GetnSigmaTOF(track,3,nsigTOFK[ip]);
-              Pid_HF->GetnSigmaTOF(track,2,nsigTOFPi[ip]);
-              sigCombK[ip] = CombineNsigmaDiffDet(nsigTPCK[ip], nsigTOFK[ip]);
-              sigCombPi[ip] = CombineNsigmaDiffDet(nsigTPCPi[ip], nsigTOFPi[ip]);
-            }
           }
 
           if (isPhiKKpi)
@@ -1323,19 +1273,25 @@ void AliAnalysisTaskSEDs::UserExec(Option_t * /*option*/)
             cosPiKPhiNoabs = cosPiKPhi * cosPiKPhi * cosPiKPhi;
             cosPiKPhi = TMath::Abs(cosPiKPhiNoabs);
 
-            Double_t modelPred = 0.;
             if(fApplyML)
             {
-              Double_t features[13] = {cospxy, dlen, normdlxy, sigvert, deltaMassKK, cosPiKPhiNoabs, normIP,
-                                       sigCombPi[0], sigCombPi[1], sigCombPi[2], sigCombK[0], sigCombK[1], sigCombK[2]};
-              modelPred = fModels[iModel].Predict(features, fNumVars);
+              isMLsel = fMLResponse->IsSelectedML(modelPred, d, aod->GetMagneticField(), Pid_HF, 0);
+
               if(fEnablePIDMLSparses && (!fReadMC || (indexMCKKpi == GetSignalHistoIndex(iPtBin) && orig == 4)))
               {
-                Double_t var4nSparsePID[knVarPID] = {ptCand, modelPred, nsigTPCPi[0], nsigTPCK[0], nsigTOFPi[0], nsigTOFK[0],
-                                                     nsigTPCPi[1], nsigTPCK[1], nsigTOFPi[1], nsigTOFK[1],
-                                                     nsigTPCPi[2], nsigTPCK[2], nsigTOFPi[2], nsigTOFK[2]};
-                Double_t var4nSparsePIDcomb[knVarPIDcomb] = {ptCand, modelPred, sigCombPi[0], sigCombK[0],
-                                                             sigCombPi[1], sigCombK[1], sigCombPi[2], sigCombK[2]};
+                Double_t var4nSparsePID[knVarPID] = {ptCand, modelPred,
+                                                    fMLResponse->GetVariable("nsigTPC_Pi_0"), fMLResponse->GetVariable("nsigTPC_K_0"),
+                                                    fMLResponse->GetVariable("nsigTOF_Pi_0"), fMLResponse->GetVariable("nsigTOF_K_0"),
+                                                    fMLResponse->GetVariable("nsigTPC_Pi_1"), fMLResponse->GetVariable("nsigTPC_K_1"),
+                                                    fMLResponse->GetVariable("nsigTOF_Pi_1"), fMLResponse->GetVariable("nsigTOF_K_1"),
+                                                    fMLResponse->GetVariable("nsigTPC_Pi_2"), fMLResponse->GetVariable("nsigTPC_K_2"),
+                                                    fMLResponse->GetVariable("nsigTOF_Pi_2"), fMLResponse->GetVariable("nsigTOF_K_2")};
+
+                Double_t var4nSparsePIDcomb[knVarPIDcomb] = {ptCand, modelPred,
+                                                            fMLResponse->GetVariable("nsigComb_Pi_0"), fMLResponse->GetVariable("nsigComb_K_0"),
+                                                            fMLResponse->GetVariable("nsigComb_Pi_1"), fMLResponse->GetVariable("nsigComb_K_1"),
+                                                            fMLResponse->GetVariable("nsigComb_Pi_2"), fMLResponse->GetVariable("nsigComb_K_2")};
+
                 fnSparseNsigmaPIDVsML[0]->Fill(var4nSparsePID);
                 fnSparseNsigmaPIDVsML[1]->Fill(var4nSparsePIDcomb);
               }
@@ -1345,7 +1301,7 @@ void AliAnalysisTaskSEDs::UserExec(Option_t * /*option*/)
                                                     normdlxy, cosp * 100, cospxy * 100, sigvert * 1000, cosPiDs * 10, cosPiKPhi * 10,
                                                     TMath::Abs(normIP), absimpparxy * 10000, modelPred};
 
-            if(!fApplyML || (modelPred > modelLim))
+            if(!fApplyML || isMLsel)
             {
               if (!fReadMC)
               {
@@ -1378,19 +1334,24 @@ void AliAnalysisTaskSEDs::UserExec(Option_t * /*option*/)
             cosPiKPhiNoabs = cosPiKPhi * cosPiKPhi * cosPiKPhi;
             cosPiKPhi = TMath::Abs(cosPiKPhiNoabs);
 
-            Double_t modelPred = 0.;
             if(fApplyML)
             {
-              Double_t features[13] = {cospxy, dlen, normdlxy, sigvert, deltaMassKK, cosPiKPhiNoabs, normIP,
-                                       sigCombPi[0], sigCombPi[1], sigCombPi[2], sigCombK[0], sigCombK[1], sigCombK[2]};
-              modelPred = fModels[iModel].Predict(features, fNumVars);
-              if(fEnablePIDMLSparses && (!fReadMC || (indexMCpiKK == GetSignalHistoIndex(iPtBin) && orig == 4)))
+              isMLsel = fMLResponse->IsSelectedML(modelPred, d, aod->GetMagneticField(), Pid_HF, 1);
+              if(fEnablePIDMLSparses && (!fReadMC || (indexMCpiKK == GetSignalHistoIndex(iPtBin) && orig==4)))
               {
-                Double_t var4nSparsePID[knVarPID] = {ptCand, modelPred, nsigTPCPi[0], nsigTPCK[0], nsigTOFPi[0], nsigTOFK[0],
-                                                     nsigTPCPi[1], nsigTPCK[1], nsigTOFPi[1], nsigTOFK[1],
-                                                     nsigTPCPi[2], nsigTPCK[2], nsigTOFPi[2], nsigTOFK[2]};
-                Double_t var4nSparsePIDcomb[knVarPIDcomb] = {ptCand, modelPred, sigCombPi[0], sigCombK[0],
-                                                             sigCombPi[1], sigCombK[1], sigCombPi[2], sigCombK[2]};
+                Double_t var4nSparsePID[knVarPID] = {ptCand, modelPred,
+                                                    fMLResponse->GetVariable("nsigTPC_Pi_0"), fMLResponse->GetVariable("nsigTPC_K_0"),
+                                                    fMLResponse->GetVariable("nsigTOF_Pi_0"), fMLResponse->GetVariable("nsigTOF_K_0"),
+                                                    fMLResponse->GetVariable("nsigTPC_Pi_1"), fMLResponse->GetVariable("nsigTPC_K_1"),
+                                                    fMLResponse->GetVariable("nsigTOF_Pi_1"), fMLResponse->GetVariable("nsigTOF_K_1"),
+                                                    fMLResponse->GetVariable("nsigTPC_Pi_2"), fMLResponse->GetVariable("nsigTPC_K_2"),
+                                                    fMLResponse->GetVariable("nsigTOF_Pi_2"), fMLResponse->GetVariable("nsigTOF_K_2")};
+
+                Double_t var4nSparsePIDcomb[knVarPIDcomb] = {ptCand, modelPred,
+                                                            fMLResponse->GetVariable("nsigComb_Pi_0"), fMLResponse->GetVariable("nsigComb_K_0"),
+                                                            fMLResponse->GetVariable("nsigComb_Pi_1"), fMLResponse->GetVariable("nsigComb_K_1"),
+                                                            fMLResponse->GetVariable("nsigComb_Pi_2"), fMLResponse->GetVariable("nsigComb_K_2")};
+
                 fnSparseNsigmaPIDVsML[0]->Fill(var4nSparsePID);
                 fnSparseNsigmaPIDVsML[1]->Fill(var4nSparsePIDcomb);
               }
@@ -1400,7 +1361,7 @@ void AliAnalysisTaskSEDs::UserExec(Option_t * /*option*/)
                                                     normdlxy, cosp * 100, cospxy * 100, sigvert * 1000, cosPiDs * 10, cosPiKPhi * 10,
                                                     TMath::Abs(normIP), absimpparxy * 10000, modelPred};
 
-            if(!fApplyML || (modelPred > modelLim))
+            if(!fApplyML || isMLsel)
             {
               if (!fReadMC)
               {
@@ -1751,7 +1712,7 @@ void AliAnalysisTaskSEDs::Terminate(Option_t * /*option*/)
 }
 
 //_________________________________________________________________
-void AliAnalysisTaskSEDs::FillMCGenAccHistos(TClonesArray *arrayMC, AliAODMCHeader *mcHeader, Double_t nTracklets)
+void AliAnalysisTaskSEDs::FillMCGenAccHistos(TClonesArray *arrayMC, AliAODMCHeader *mcHeader)
 {
   /// Fill MC histos for cuts study
   ///    - at GenLimAccStep and AccStep (if fFillAcceptanceLevel=kFALSE)
@@ -2194,58 +2155,6 @@ Float_t AliAnalysisTaskSEDs::GetTrueImpactParameterDstoPhiPi(const AliAODMCHeade
   Double_t d0dummy[3] = {0., 0., 0.};
   AliAODRecoDecayHF aodDsMC(vtxTrue, origD, 3, charge, pXdauTrue, pYdauTrue, pZdauTrue, d0dummy);
   return aodDsMC.ImpParXY();
-}
-
-//_________________________________________________________________________
-bool AliAnalysisTaskSEDs::SetMLVariables(TString path)
-{
-  std::string config_path = GetFile(path.Data());
-  YAML::Node config_file = YAML::LoadFile(config_path);
-  int num_models = config_file["NumModels"].as<int>();
-  fNumVars = config_file["NumVars"].as<int>();
-  fModelPaths = config_file["ModelNames"].as<vector<std::string> >();
-  fModelOutputCuts = config_file["ModelOutputCuts"].as<vector<double> >();
-  fPtBinsModel = config_file["PtBins"].as<vector<double> >();
-
-  if(((unsigned int)num_models == fModelPaths.size()) && (fModelPaths.size() == fModelOutputCuts.size()) && (fModelOutputCuts.size() == (fPtBinsModel.size()-1)))
-    return kTRUE;
-
-  return kFALSE;
-}
-
-//_________________________________________________________________________
-std::string AliAnalysisTaskSEDs::GetFile(const std::string path)
-{
-  if(path.find("alien:") != std::string::npos) {
-    size_t pos = path.find_last_of("/") + 1;
-    std::string model_name = path.substr(pos);
-    if(gGrid == nullptr) {
-      TGrid::Connect("alien://");
-      if(gGrid == nullptr){
-        std::cerr << "Connection to GRID not established!" << std::endl;
-      }
-    }
-    std::string new_path = gSystem->pwd() + std::string("/") + model_name.data();
-    const char *old_root_dir = gDirectory->GetPath();
-    bool cp_status = TFile::Cp(path.data(), new_path.data());
-    gDirectory->cd(old_root_dir);
-    if(!cp_status){
-      std::cerr << "Error in coping file from Alien!\n";
-      return std::string();
-    }
-    return new_path;
-  } else {
-    return path;
-  }
-}
-
-//________________________________________________________________
-double AliAnalysisTaskSEDs::CombineNsigmaDiffDet(double nsigmaTPC, double nsigmaTOF)
-{
-  if(nsigmaTPC > -998. && nsigmaTOF > -998.) return TMath::Sqrt((nsigmaTPC*nsigmaTPC+nsigmaTOF*nsigmaTOF)/2);
-  else if(nsigmaTPC > -998. && nsigmaTOF < -998.) return TMath::Abs(nsigmaTPC);
-  else if(nsigmaTPC < -998. && nsigmaTOF > -998.) return TMath::Abs(nsigmaTOF);
-  else return -999.;
 }
 
 //_________________________________________________________________________

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEDs.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEDs.h
@@ -22,8 +22,8 @@
 
 #include "AliAnalysisTaskSE.h"
 #include "AliRDHFCutsDstoKKpi.h"
+#include "AliHFMLResponseDstoKKpi.h"
 #include "AliLog.h"
-#include "AliExternalBDT.h"
 
 class AliNormalizationCounter;
 
@@ -57,7 +57,7 @@ class AliAnalysisTaskSEDs : public AliAnalysisTaskSE
   void SetUseCutV0multVsTPCout(Bool_t flag) {fDoCutV0multTPCout=flag;}
   Bool_t CheckDaugAcc(TClonesArray* arrayMC,Int_t nProng, Int_t *labDau);
   Bool_t GetUseWeight() const {return fUseWeight;}
-  void FillMCGenAccHistos(TClonesArray *arrayMC, AliAODMCHeader *mcHeader, Double_t nTracklets);
+  void FillMCGenAccHistos(TClonesArray *arrayMC, AliAODMCHeader *mcHeader);
   void GenerateRotBkg(AliAODRecoDecayHF3Prong *d, Int_t dec, Int_t iPtBin);
   void CreateCutVarsAndEffSparses();
   void CreateImpactParameterSparses();
@@ -101,10 +101,6 @@ class AliAnalysisTaskSEDs : public AliAnalysisTaskSE
   Int_t GetSignalHistoIndex(Int_t iPtBin) const { return iPtBin*4+1;}
   Int_t GetBackgroundHistoIndex(Int_t iPtBin) const { return iPtBin*4+2;}
   Int_t GetReflSignalHistoIndex(Int_t iPtBin) const { return iPtBin*4+3;}
-  /// methods for ML application
-  Bool_t SetMLVariables(TString path);
-  std::string GetFile(const std::string path);
-  double CombineNsigmaDiffDet(double nsigmaTPC, double nsigmaTOF);
 
   enum {kMaxPtBins=36,knVarForSparse=14,knVarForSparseAcc=2,kVarForImpPar=3,knVarPID=14,knVarPIDcomb=8};
 
@@ -216,12 +212,8 @@ class AliAnalysisTaskSEDs : public AliAnalysisTaskSE
   /// variables for ML application
   Bool_t fApplyML;                        /// flag to enable ML application
   TString fConfigPath;                    /// path to ML config file
-  Int_t fNumVars;                         /// number of variables used in the model
-  std::vector<std::string> fModelPaths;   /// vector of model paths
-  std::vector<double> fModelOutputCuts;   /// vector of thresholds on model output
-  std::vector<double> fPtBinsModel;       /// vector of pt bin lims
-  std::vector<AliExternalBDT> fModels;    //!<! vector of ML models (BDTs for now)
-  THnSparseF* fnSparseNsigmaPIDVsML[2];   //!<! THnSparse with PID Nsigma variables vs ML output
+  AliHFMLResponseDstoKKpi* fMLResponse;   //!<! object to handle ML response
+  THnSparseF* fnSparseNsigmaPIDVsML[2];   //!<! histograms with PID Nsigma variables vs ML output
   Bool_t fEnablePIDMLSparses;             /// flag to enable control histograms for PID with ML
   Int_t fNMLBins;                         /// number of bins for ML output axis in THnSparse
   Double_t fMLOutputMin;                  /// min for ML output axis in THnSparse
@@ -231,7 +223,7 @@ class AliAnalysisTaskSEDs : public AliAnalysisTaskSE
   Bool_t fKeepOnlyBkgFromHIJING;          /// flag to keep the background from HIJING only
 
   /// \cond CLASSIMP
-  ClassDef(AliAnalysisTaskSEDs,35);    ///  AliAnalysisTaskSE for Ds mass spectra
+  ClassDef(AliAnalysisTaskSEDs,36);       /// AliAnalysisTaskSE for Ds mass spectra
   /// \endcond
 };
 

--- a/PWGHF/vertexingHF/CMakeLists.txt
+++ b/PWGHF/vertexingHF/CMakeLists.txt
@@ -21,8 +21,8 @@ add_subdirectory (vHFBDT)
 
 # Module include folder
 include_directories(${AliPhysics_SOURCE_DIR}/PWGHF/vertexingHF)
-
 include_directories(${AliPhysics_SOURCE_DIR}/PWGHF/vertexingHF/vHFBDT)
+include_directories(${AliPhysics_SOURCE_DIR}/PWGHF/vertexingHF/vHFML)
 
 # Additional includes - alphabetical order except ROOT
 include_directories(${ROOT_INCLUDE_DIRS}
@@ -52,7 +52,6 @@ set(SRCS
   AliRDHFCuts.cxx
   AliVertexingHFUtils.cxx
   AliHFSystErr.cxx
-  AliRDHFCutsB0toDPi.cxx
   AliRDHFCutsB0toDStarPi.cxx
   AliRDHFCutsBPlustoD0Pi.cxx
   AliRDHFCutsD0toKpi.cxx
@@ -79,7 +78,6 @@ set(SRCS
   AliAnalysisTaskSESelectHF.cxx
   AliAnalysisTaskSECleanupVertexingHF.cxx
   AliAnalysisTaskSECompareHF.cxx
-  AliAnalysisTaskSEDplus.cxx
   AliAnalysisTaskSELambdac.cxx
   AliAnalysisTaskSED0BDT.cxx
   AliAnalysisTaskSED0Mass.cxx
@@ -132,7 +130,6 @@ set(SRCS
   charmFlow/AliAnalysisTaskFlowD2H.cxx
   charmFlow/AliHFQnVectorHandler.cxx
   charmFlow/AliAnalysisTaskSEHFTenderQnVectors.cxx
-  charmFlow/AliAnalysisTaskSECharmHadronvn.cxx  
   cutVarFDsub/AliHFCutVarFDsubAnalysisManager.cxx
   cutVarFDsub/AliHFCutVarFDsubAnalysisManagerD0.cxx
   cutVarFDsub/AliHFCutVarFDsubAnalysisManagerDplus.cxx
@@ -153,7 +150,6 @@ set(SRCS
   AliAnalysisTaskCharmBaryonsMC.cxx
   AliAnalysisTaskSEDvsEventShapes.cxx
   AliAnalysisTaskSEB0toDminuspi.cxx
-  AliAnalysisTaskSEB0toDPi.cxx
   AliAnalysisTaskSEDstoK0sK.cxx
   AliHFVnVsMassFitter.cxx
   AliAnalysisTaskSELc2V0bachelorTMVAApp.cxx
@@ -167,7 +163,12 @@ set(SRCS
 if(ROOT_VERSION_MAJOR EQUAL 6)
   set(SRCS
       ${SRCS}
+      vHFML/AliHFMLResponse.cxx
+      vHFML/AliHFMLResponseDplustoKpipi.cxx
+      vHFML/AliHFMLResponseDstoKKpi.cxx
+      AliAnalysisTaskSEDplus.cxx
       AliAnalysisTaskSEDs.cxx
+      charmFlow/AliAnalysisTaskSECharmHadronvn.cxx
   )
 endif()
 
@@ -249,3 +250,4 @@ install(DIRECTORY
 
 install(DIRECTORY upgrade DESTINATION PWGHF/vertexingHF)
 install(DIRECTORY charmFlow DESTINATION PWGHF/vertexingHF)
+install(DIRECTORY vHFML DESTINATION PWGHF/vertexingHF)

--- a/PWGHF/vertexingHF/PWGHFvertexingHFLinkDef.h
+++ b/PWGHF/vertexingHF/PWGHFvertexingHFLinkDef.h
@@ -17,7 +17,6 @@
 #pragma link C++ class AliVertexingHFUtils+;
 #pragma link C++ class AliHFSystErr+;
 #pragma link C++ class AliRDHFCutsD0toKpi+;
-#pragma link C++ class AliRDHFCutsB0toDPi+;
 #pragma link C++ class AliRDHFCutsB0toDStarPi+;
 #pragma link C++ class AliRDHFCutsBPlustoD0Pi+;
 #pragma link C++ class AliRDHFCutsJpsitoee+;
@@ -38,13 +37,11 @@
 #pragma link C++ class AliAnalysisVertexingHF+;
 #pragma link C++ class AliAnalysisTaskSEVertexingHF+;
 #pragma link C++ class AliAnalysisTaskMEVertexingHF+;
-#pragma link C++ class AliAnalysisTaskSEB0toDPi+;
 #pragma link C++ class AliAnalysisTaskSEB0toDStarPi+;
 #pragma link C++ class AliAnalysisTaskSEBPlustoD0Pi+;
 #pragma link C++ class AliAnalysisTaskSESelectHF+;
 #pragma link C++ class AliAnalysisTaskSECleanupVertexingHF+;
 #pragma link C++ class AliAnalysisTaskSECompareHF+;
-#pragma link C++ class AliAnalysisTaskSEDplus+;
 #pragma link C++ class AliAnalysisTaskSELambdac+;
 #pragma link C++ class AliAnalysisTaskSED0BDT+;
 #pragma link C++ class AliAnalysisTaskSED0Mass+;
@@ -100,7 +97,6 @@
 #pragma link C++ class AliHFAfterBurner+;
 #pragma link C++ class AliHFQnVectorHandler+;
 #pragma link C++ class AliAnalysisTaskSEHFTenderQnVectors+;
-#pragma link C++ class AliAnalysisTaskSECharmHadronvn+;
 #pragma link C++ class AliAnalysisTaskSELambdacUp+;
 #pragma link C++ class AliAnalysisTaskCountLcEta+;
 #pragma link C++ class AliAnalysisTaskSELc2V0bachelorTMVA+;
@@ -129,7 +125,12 @@
 
 //classes working only in ROOT6
 #ifdef __CLING__
+#pragma link C++ class AliAnalysisTaskSEDplus+;
 #pragma link C++ class AliAnalysisTaskSEDs+;
+#pragma link C++ class AliAnalysisTaskSECharmHadronvn+;
+#pragma link C++ class AliHFMLResponse+;
+#pragma link C++ class AliHFMLResponseDplustoKpipi+;
+#pragma link C++ class AliHFMLResponseDstoKKpi+;
 #endif
 
 #endif

--- a/PWGHF/vertexingHF/charmFlow/AliAnalysisTaskSECharmHadronvn.cxx
+++ b/PWGHF/vertexingHF/charmFlow/AliAnalysisTaskSECharmHadronvn.cxx
@@ -5,7 +5,7 @@
 
 //*************************************************************************************
 // \class AliAnalysisTaskSECharmHadronvn
-// \brief task for the analysis of D-meson vn 
+// \brief task for the analysis of D-meson vn
 // \authors:
 // F. Grosa, fabrizio.grosa@cern.ch
 // F. Catalano, fabio.catalano@cern.ch
@@ -45,8 +45,11 @@
 #include "AliVertexingHFUtils.h"
 
 #include "AliAnalysisTaskSEHFTenderQnVectors.h"
-
 #include "AliAnalysisTaskSECharmHadronvn.h"
+
+#include "AliAODPidHF.h"
+#include "AliHFMLResponseDstoKKpi.h"
+#include "AliHFMLResponseDplustoKpipi.h"
 
 ClassImp(AliAnalysisTaskSECharmHadronvn)
 
@@ -86,10 +89,13 @@ AliAnalysisTaskSE(),
     fRemoveDauFromqn(0),
     fRemoveSoftPion(false),
     fEnableDownsamplqn(false),
-    fFracToKeepDownSamplqn(1.1)
+    fFracToKeepDownSamplqn(1.1),
+    fApplyML(false),
+    fConfigPath(""),
+    fMLResponse(nullptr)
 {
     // Default constructor
-    for(int iHisto=0; iHisto<3; iHisto++) { 
+    for(int iHisto=0; iHisto<3; iHisto++) {
         fHistCentrality[iHisto]         = nullptr;
         fHistEPResolVsCentrVsqn[iHisto] = nullptr;
     }
@@ -136,10 +142,13 @@ AliAnalysisTaskSECharmHadronvn::AliAnalysisTaskSECharmHadronvn(const char *name,
     fRemoveDauFromqn(0),
     fRemoveSoftPion(false),
     fEnableDownsamplqn(false),
-    fFracToKeepDownSamplqn(1.1)
+    fFracToKeepDownSamplqn(1.1),
+    fApplyML(false),
+    fConfigPath(""),
+    fMLResponse(nullptr)
 {
     // standard constructor
-    for(int iHisto=0; iHisto<3; iHisto++) { 
+    for(int iHisto=0; iHisto<3; iHisto++) {
         fHistCentrality[iHisto]         = nullptr;
         fHistEPResolVsCentrVsqn[iHisto] = nullptr;
     }
@@ -212,6 +221,9 @@ AliAnalysisTaskSECharmHadronvn::~AliAnalysisTaskSECharmHadronvn()
     for(int iDet=0; iDet<6; iDet++) {
         if(fqnSplinesList[iDet] && fLoadedSplines) delete fqnSplinesList[iDet];
     }
+
+    if(fApplyML && fMLResponse)
+        delete fMLResponse;
 }
 
 //_________________________________________________________________
@@ -241,19 +253,19 @@ void AliAnalysisTaskSECharmHadronvn::LocalInit()
     fRDCuts->SetMaxCentrality(fMaxCentr);
 
     switch(fDecChannel) {
-        case kDplustoKpipi: 
+        case kDplustoKpipi:
             {
                 AliRDHFCutsDplustoKpipi* copycut=new AliRDHFCutsDplustoKpipi(*(static_cast<AliRDHFCutsDplustoKpipi*>(fRDCuts)));
                 PostData(2,copycut);
             }
         break;
-        case kD0toKpi: 
+        case kD0toKpi:
             {
                 AliRDHFCutsD0toKpi* copycut=new AliRDHFCutsD0toKpi(*(static_cast<AliRDHFCutsD0toKpi*>(fRDCuts)));
                 PostData(2,copycut);
             }
         break;
-        case kDstartoKpipi: 
+        case kDstartoKpipi:
             {
                 AliRDHFCutsDStartoKpipi* copycut=new AliRDHFCutsDStartoKpipi(*(static_cast<AliRDHFCutsDStartoKpipi*>(fRDCuts)));
                 PostData(2,copycut);
@@ -266,7 +278,7 @@ void AliAnalysisTaskSECharmHadronvn::LocalInit()
             }
         break;
     }
-  
+
   return;
 }
 
@@ -304,7 +316,7 @@ void AliAnalysisTaskSECharmHadronvn::UserCreateOutputObjects()
     for(int iHisto=0; iHisto<3; iHisto++){
         fOutput->Add(fHistCentrality[iHisto]);
     }
-    
+
     const int ncentbins = static_cast<int>(fMaxCentr-fMinCentr);
 
     fHistCandVsCent=new TH2F("hCandVsCent","number of selected candidates vs. centrality;centrality(%);number of candidates",ncentbins,fMinCentr,fMaxCentr,101,-0.5,100.5);
@@ -336,9 +348,9 @@ void AliAnalysisTaskSECharmHadronvn::UserCreateOutputObjects()
 
     TString qnpercaxisname = qnaxisname + " (%)";
     TString qnaxisnamefill = qnaxisname;
-    if(fPercentileqn) 
+    if(fPercentileqn)
         qnaxisnamefill = qnpercaxisname;
-    
+
     int nqnbins=1; //single bin if unbiased analysis
     double qnmin = 0.;
     double qnmax = 15.;
@@ -433,18 +445,24 @@ void AliAnalysisTaskSECharmHadronvn::UserCreateOutputObjects()
     double Ntrkmin       = 0.;
     double Ntrkmax       = 5000.;
 
+    int nMLbins          = 300;
+    double MLmin         = 0.85;
+    double MLmax         = 1.;
+
     TString massaxisname = "";
     if(fDecChannel==0)      massaxisname = "#it{M}(K#pi#pi) (GeV/#it{c}^{2})";
     else if(fDecChannel==1) massaxisname = "#it{M}(K#pi) (GeV/#it{c}^{2})";
     else if(fDecChannel==2) massaxisname = "#it{M}(K#pi#pi)-#it{M}(K#pi) (GeV/#it{c}^{2})";
     else if(fDecChannel==3) massaxisname = "#it{M}(KK#pi) (GeV/#it{c}^{2})";
 
-    const int naxes=9;
-    
-    int nbins[naxes]     = {fNMassBins, nptbins, ndeltaphibins, nfphibins, nfphibins, nphibins, ncentbins, nNtrkBins, nqnbins};
-    double xmin[naxes]   = {fLowmasslimit, ptmin, mindeltaphi, fphimin, fphimin, phimin, fMinCentr, Ntrkmin, qnmin};
-    double xmax[naxes]   = {fUpmasslimit, ptmax, maxdeltaphi, fphimax, fphimax, phimax, fMaxCentr, Ntrkmax, qnmax};
-    TString axTit[naxes] = {massaxisname, "#it{p}_{T} (GeV/#it{c})", deltaphiname, nfphiname1, nfphiname2, "#varphi_{D}", "Centrality (%)", "#it{N}_{tracklets}", qnaxisnamefill};
+    int naxes=kVarForSparse;
+    if(!fApplyML)
+        naxes--;
+
+    int nbins[kVarForSparse]     = {fNMassBins, nptbins, ndeltaphibins, nfphibins, nfphibins, nphibins, ncentbins, nNtrkBins, nqnbins, nMLbins};
+    double xmin[kVarForSparse]   = {fLowmasslimit, ptmin, mindeltaphi, fphimin, fphimin, phimin, fMinCentr, Ntrkmin, qnmin, MLmin};
+    double xmax[kVarForSparse]   = {fUpmasslimit, ptmax, maxdeltaphi, fphimax, fphimax, phimax, fMaxCentr, Ntrkmax, qnmax, MLmax};
+    TString axTit[kVarForSparse] = {massaxisname, "#it{p}_{T} (GeV/#it{c})", deltaphiname, nfphiname1, nfphiname2, "#varphi_{D}", "Centrality (%)", "#it{N}_{tracklets}", qnaxisnamefill, "ML response"};
 
     fHistMassPtPhiqnCentr = new THnSparseF("fHistMassPtPhiqnCentr",Form("InvMass vs. #it{p}_{T} vs. %s vs. centr vs. #it{q}_{%d} ",deltaphiname.Data(),fHarmonic),naxes,nbins,xmin,xmax);
 
@@ -452,6 +470,34 @@ void AliAnalysisTaskSECharmHadronvn::UserCreateOutputObjects()
         fHistMassPtPhiqnCentr->GetAxis(iAx)->SetTitle(axTit[iAx].Data());
 
     fOutput->Add(fHistMassPtPhiqnCentr);
+
+    //ML model
+    if(fApplyML) {
+        switch(fDecChannel) {
+            case kDplustoKpipi:
+                {
+                    fMLResponse = new AliHFMLResponseDplustoKpipi(fConfigPath.Data());
+                    fMLResponse->InitModels();
+                }
+            break;
+            case kD0toKpi:
+                {
+                    AliFatal("ML application for D0 meson not yet implemented! Exit");
+                }
+            break;
+            case kDstartoKpipi:
+                {
+                    AliFatal("ML application for Dstar meson not yet implemented! Exit");
+                }
+            break;
+            case kDstoKKpi:
+                {
+                    fMLResponse = new AliHFMLResponseDstoKKpi(fConfigPath.Data());
+                    fMLResponse->InitModels();
+                }
+            break;
+        }
+    }
 
     PostData(1,fOutput);
     return;
@@ -522,7 +568,7 @@ void AliAnalysisTaskSECharmHadronvn::UserExec(Option_t */*option*/)
                 break;
             }
         }
-    } 
+    }
     else if(fAOD){
         switch(fDecChannel) {
             case kDplustoKpipi:
@@ -588,7 +634,7 @@ void AliAnalysisTaskSECharmHadronvn::UserExec(Option_t */*option*/)
     AliAnalysisTaskSEHFTenderQnVectors *HFQnVectorTask = dynamic_cast<AliAnalysisTaskSEHFTenderQnVectors*>(AliAnalysisManager::GetAnalysisManager()->GetTask(fTenderTaskName.Data()));
     if(HFQnVectorTask) {
         HFQnVectorHandler = HFQnVectorTask->GetQnVectorHandler();
-        
+
         if(fPercentileqn && !fqnSplinesList[0]) {
             for(int iDet=0; iDet<6; iDet++) {
                 fqnSplinesList[iDet] = dynamic_cast<TList*>(HFQnVectorTask->GetSplineForqnPercentileList(iDet));
@@ -623,7 +669,7 @@ void AliAnalysisTaskSECharmHadronvn::UserExec(Option_t */*option*/)
         HFQnVectorHandler->ComputeCalibratedQnVectorV0();
     }
 
-    if(fPercentileqn && !fqnSplinesList[0]) { //probably qn splines not found in tender task, let's load them here 
+    if(fPercentileqn && !fqnSplinesList[0]) { //probably qn splines not found in tender task, let's load them here
         fLoadedSplines=LoadSplinesForqnPercentile();
     }
 
@@ -664,12 +710,13 @@ void AliAnalysisTaskSECharmHadronvn::UserExec(Option_t */*option*/)
 
     //define vars for candidate loop already here, in case daughter tracks removed from qn
     AliAnalysisVertexingHF *vHF = new AliAnalysisVertexingHF();
-    AliAODRecoDecayHF *d = nullptr; 
+    AliAODRecoDecayHF *d = nullptr;
     AliAODRecoDecayHF2Prong *dD0 = nullptr;
 
     int nCand = arrayProng->GetEntriesFast();
     bool alreadyLooped = false;
     vector<int> isSelByPrevLoop;
+    vector<double> MLPred[2];
     vector<AliAODTrack*> trackstoremove;
 
     if(fFlowMethod==kEvShapeEP || fFlowMethod==kEvShapeSP || fFlowMethod==kEvShapeEPVsMass) {
@@ -677,13 +724,13 @@ void AliAnalysisTaskSECharmHadronvn::UserExec(Option_t */*option*/)
         HFQnVectorHandler->GetqnV0(qnFullV0,qnV0A,qnV0C);
 
         if((fEnableDownsamplqn && fFracToKeepDownSamplqn<1.) || fRemoveDauFromqn==2) {
-    
+
             //random downsampling of tracks for qn
             if(fEnableDownsamplqn && fFracToKeepDownSamplqn<1.) {
                 for(int iTrack=0; iTrack<fAOD->GetNumberOfTracks(); iTrack++) {
                     AliAODTrack* track = dynamic_cast<AliAODTrack*>(fAOD->GetTrack(iTrack));
                     double pseudoRand = track->Pt()*1000.-(long)(track->Pt()*1000);
-                    if(pseudoRand>fFracToKeepDownSamplqn)   
+                    if(pseudoRand>fFracToKeepDownSamplqn)
                         trackstoremove.push_back(track);
                 }
             }
@@ -699,10 +746,12 @@ void AliAnalysisTaskSECharmHadronvn::UserExec(Option_t */*option*/)
                             dD0 = dynamic_cast<AliAODRecoDecayHF2Prong*>(arrayD0toKpi->At(d->GetProngID(1)));
                         else
                             dD0 = (dynamic_cast<AliAODRecoCascadeHF*>(d))->Get2Prong();
-                    }        
-
-                    int isSel = IsCandidateSelected(d, nDau, absPdgMom, vHF, dD0);
+                    }
+                    double modelPred[2] = {-1., -1.};
+                    int isSel = IsCandidateSelected(d, nDau, absPdgMom, vHF, dD0, modelPred);
                     isSelByPrevLoop.push_back(isSel);
+                    MLPred[0].push_back(modelPred[0]);
+                    MLPred[1].push_back(modelPred[1]);
                     if(!isSel) continue;
 
                     GetDaughterTracksToRemove(d,nDau,trackstoremove);
@@ -749,7 +798,7 @@ void AliAnalysisTaskSECharmHadronvn::UserExec(Option_t */*option*/)
             break;
         }
         if(fPercentileqn) {
-            if(qnspline) 
+            if(qnspline)
                 mainpercqn = qnspline->Eval(mainqn);
             else
                 AliWarning("Centrality binning and centrality intervals of qn splines do not match!");
@@ -780,7 +829,7 @@ void AliAnalysisTaskSECharmHadronvn::UserExec(Option_t */*option*/)
 
         if(fPercentileqn) {
             fHistPercqnVsqnVsCentr->Fill(evCentr,mainqn,mainpercqn);
-        }   
+        }
     }
 
     //EP / Qn resolution histos
@@ -788,14 +837,14 @@ void AliAnalysisTaskSECharmHadronvn::UserExec(Option_t */*option*/)
         fHistEPResolVsCentrVsqn[0]->Fill(evCentr,mainpercqn,TMath::Cos(fHarmonic*GetDeltaPsiSubInRange(SubAPsin,SubBPsin)));
         if(nsubevents==3) {
             fHistEPResolVsCentrVsqn[1]->Fill(evCentr,mainpercqn,TMath::Cos(fHarmonic*GetDeltaPsiSubInRange(SubAPsin,SubCPsin)));
-            fHistEPResolVsCentrVsqn[2]->Fill(evCentr,mainpercqn,TMath::Cos(fHarmonic*GetDeltaPsiSubInRange(SubBPsin,SubCPsin)));            
+            fHistEPResolVsCentrVsqn[2]->Fill(evCentr,mainpercqn,TMath::Cos(fHarmonic*GetDeltaPsiSubInRange(SubBPsin,SubCPsin)));
         }
     }
     else if(fFlowMethod==kSP || fFlowMethod==kEvShapeSP) {
         fHistEPResolVsCentrVsqn[0]->Fill(evCentr,mainpercqn,(SubAQn[0]*SubBQn[0]+SubAQn[1]*SubBQn[1])/(SubAMultQn * SubBMultQn));
         if(nsubevents==3) {
             fHistEPResolVsCentrVsqn[1]->Fill(evCentr,mainpercqn,(SubAQn[0]*SubCQn[0]+SubAQn[1]*SubCQn[1])/(SubAMultQn * SubCMultQn));
-            fHistEPResolVsCentrVsqn[2]->Fill(evCentr,mainpercqn,(SubBQn[0]*SubCQn[0]+SubBQn[1]*SubCQn[1])/(SubCMultQn * SubBMultQn));            
+            fHistEPResolVsCentrVsqn[2]->Fill(evCentr,mainpercqn,(SubBQn[0]*SubCQn[0]+SubBQn[1]*SubCQn[1])/(SubCMultQn * SubBMultQn));
         }
     }
 
@@ -810,16 +859,21 @@ void AliAnalysisTaskSECharmHadronvn::UserExec(Option_t */*option*/)
             else
                 dD0 = (dynamic_cast<AliAODRecoCascadeHF*>(d))->Get2Prong();
         }
-        
+
         int isSelected = 0;
-        if(alreadyLooped) //check already here to avoid application of cuts twice
+        double modelPred[2] = {-1., -1.};
+        if(alreadyLooped) {//check already here to avoid application of cuts twice
             isSelected = isSelByPrevLoop[iCand];
-        else
-            isSelected = IsCandidateSelected(d, nDau, absPdgMom, vHF, dD0);
+            modelPred[0] = MLPred[0][iCand];
+            modelPred[1] = MLPred[1][iCand];
+        }
+        else {
+            isSelected = IsCandidateSelected(d, nDau, absPdgMom, vHF, dD0, modelPred);
+        }
         if(!isSelected) continue;
 
-        nSelCand++;                
-        fHistNEvents->Fill(14); // candidate selected
+        nSelCand++;
+        fHistNEvents->Fill(14); // candidate selected (including ML selection if used)
 
         float* invMass = nullptr;
         int nmasses = 0;
@@ -827,7 +881,7 @@ void AliAnalysisTaskSECharmHadronvn::UserExec(Option_t */*option*/)
 
         double ptD = d->Pt();
         double phiD = d->Phi();
-        
+
         double deltaphi = GetPhiInRange(phiD-mainPsin);
         double scalprod = (TMath::Cos(fHarmonic*phiD)*mainQn[0]+TMath::Sin(fHarmonic*phiD)*mainQn[1]) / mainMultQn;
         double cosndeltaphi = TMath::Cos(fHarmonic*deltaphi);
@@ -853,9 +907,9 @@ void AliAnalysisTaskSECharmHadronvn::UserExec(Option_t */*option*/)
         //remove daughter tracks from qn (on top of random downsampling, if enabled)
         double candQnFullTPC[2], candQnPosTPC[2], candQnNegTPC[2];
         double candMultQnFullTPC = -1., candMultQnPosTPC = -1., candMultQnNegTPC = -1.;
-        double candqn = -1., candpercqn = -1.; 
+        double candqn = -1., candpercqn = -1.;
         if(fRemoveDauFromqn==1 && (fqnMeth==kq2TPC || fqnMeth==kq2PosTPC || fqnMeth==kq2NegTPC) && (fFlowMethod==kEvShapeEP || fFlowMethod==kEvShapeSP || fFlowMethod==kEvShapeEPVsMass)) {
-            
+
             vector<AliAODTrack*> trackstoremoveDau(trackstoremove);
             GetDaughterTracksToRemove(d,nDau,trackstoremoveDau);
             HFQnVectorHandler->RemoveTracksFromQnTPC(trackstoremoveDau, candQnFullTPC, candQnPosTPC, candQnNegTPC, candMultQnFullTPC, candMultQnPosTPC, candMultQnNegTPC, true);
@@ -872,7 +926,7 @@ void AliAnalysisTaskSECharmHadronvn::UserExec(Option_t */*option*/)
             }
             trackstoremoveDau.clear();
             if(fPercentileqn) {
-                if(qnspline) 
+                if(qnspline)
                     candpercqn = qnspline->Eval(candqn);
                 else
                     AliWarning("Centrality binning and centrality intervals of qn splines do not match!");
@@ -885,32 +939,42 @@ void AliAnalysisTaskSECharmHadronvn::UserExec(Option_t */*option*/)
             candpercqn = mainpercqn;
         }
 
-        if(fDecChannel==kDplustoKpipi) {
-            double sparsearray[9] = {invMass[0],ptD,vnfunc,phifunc1,phifunc2,phiD,evCentr,static_cast<double>(tracklets),candpercqn};
-            fHistMassPtPhiqnCentr->Fill(sparsearray);
-        }
-        else if(fDecChannel==kD0toKpi) {
-            if(isSelected==1 || isSelected==3) {
-                double sparsearray[9] = {invMass[0],ptD,vnfunc,phifunc1,phifunc2,phiD,evCentr,static_cast<double>(tracklets),candpercqn};
+        switch(fDecChannel) {
+            case kDplustoKpipi:
+            {
+                double sparsearray[10] = {invMass[0],ptD,vnfunc,phifunc1,phifunc2,phiD,evCentr,static_cast<double>(tracklets),candpercqn,modelPred[0]};
                 fHistMassPtPhiqnCentr->Fill(sparsearray);
+                break;
             }
-            if(isSelected==2 || isSelected==3) {
-                double sparsearray[9] = {invMass[1],ptD,vnfunc,phifunc1,phifunc2,phiD,evCentr,static_cast<double>(tracklets),candpercqn};
-                fHistMassPtPhiqnCentr->Fill(sparsearray);
+            case kD0toKpi:
+            {
+                if(isSelected==1 || isSelected==3) {
+                    double sparsearray[10] = {invMass[0],ptD,vnfunc,phifunc1,phifunc2,phiD,evCentr,static_cast<double>(tracklets),candpercqn,modelPred[0]};
+                    fHistMassPtPhiqnCentr->Fill(sparsearray);
+                }
+                if(isSelected==2 || isSelected==3) {
+                    double sparsearray[10] = {invMass[1],ptD,vnfunc,phifunc1,phifunc2,phiD,evCentr,static_cast<double>(tracklets),candpercqn,modelPred[1]};
+                    fHistMassPtPhiqnCentr->Fill(sparsearray);
+                }
+                break;
             }
-        }
-        else if(fDecChannel==kDstartoKpipi) {
-            double sparsearray[9] = {invMass[0],ptD,vnfunc,phifunc1,phifunc2,phiD,evCentr,static_cast<double>(tracklets),candpercqn};
-            fHistMassPtPhiqnCentr->Fill(sparsearray);
-        }
-        else if(fDecChannel==kDstoKKpi) {
-            if(isSelected&4) {
-                double sparsearray[9] = {invMass[0],ptD,vnfunc,phifunc1,phifunc2,phiD,evCentr,static_cast<double>(tracklets),candpercqn};
+            case kDstartoKpipi:
+            {
+                double sparsearray[10] = {invMass[0],ptD,vnfunc,phifunc1,phifunc2,phiD,evCentr,static_cast<double>(tracklets),candpercqn,modelPred[0]};
                 fHistMassPtPhiqnCentr->Fill(sparsearray);
+                break;
             }
-            if(isSelected&8) {
-                double sparsearray[9] = {invMass[1],ptD,vnfunc,phifunc1,phifunc2,phiD,evCentr,static_cast<double>(tracklets),candpercqn};
-                fHistMassPtPhiqnCentr->Fill(sparsearray);
+            case kDstoKKpi:
+            {
+                if(isSelected&4) {
+                    double sparsearray[10] = {invMass[0],ptD,vnfunc,phifunc1,phifunc2,phiD,evCentr,static_cast<double>(tracklets),candpercqn,modelPred[0]};
+                    fHistMassPtPhiqnCentr->Fill(sparsearray);
+                }
+                if(isSelected&8) {
+                    double sparsearray[10] = {invMass[1],ptD,vnfunc,phifunc1,phifunc2,phiD,evCentr,static_cast<double>(tracklets),candpercqn,modelPred[1]};
+                    fHistMassPtPhiqnCentr->Fill(sparsearray);
+                }
+                break;
             }
         }
     }
@@ -919,11 +983,13 @@ void AliAnalysisTaskSECharmHadronvn::UserExec(Option_t */*option*/)
 
     trackstoremove.clear();
     isSelByPrevLoop.clear();
+    MLPred[0].clear();
+    MLPred[1].clear();
 
     delete vHF;
     vHF = nullptr;
     if(!isHandlerFound) { // if not found in the tender task, allocated memory with new --> to be deleted
-        delete HFQnVectorHandler; 
+        delete HFQnVectorHandler;
         HFQnVectorHandler = nullptr;
     }
 
@@ -985,7 +1051,7 @@ void AliAnalysisTaskSECharmHadronvn::SetQnVectorDetConf(int detconf)
 double AliAnalysisTaskSECharmHadronvn::GetPhiInRange(double phi)
 {
     // Sets the phi angle in the range [0,2*pi/harmonic]
-    
+
     double result = phi;
     while(result < 0) {
         result = result + 2. * TMath::Pi() / fHarmonic;
@@ -997,7 +1063,7 @@ double AliAnalysisTaskSECharmHadronvn::GetPhiInRange(double phi)
 }
 
 //________________________________________________________________________
-double AliAnalysisTaskSECharmHadronvn::GetDeltaPsiSubInRange(double psi1, double psi2) 
+double AliAnalysisTaskSECharmHadronvn::GetDeltaPsiSubInRange(double psi1, double psi2)
 {
     // difference of subevents reaction plane angle cannot be bigger than pi / n
 
@@ -1005,7 +1071,7 @@ double AliAnalysisTaskSECharmHadronvn::GetDeltaPsiSubInRange(double psi1, double
     if(TMath::Abs(delta) > TMath::Pi() / fHarmonic) {
         if(delta>0.) delta -= 2.*TMath::Pi() / fHarmonic;
         else delta += 2.*TMath::Pi() / fHarmonic;
-    } 
+    }
 
     return delta;
 }
@@ -1071,13 +1137,13 @@ void AliAnalysisTaskSECharmHadronvn::GetMainQnVectorInfo(double &mainPsin, doubl
     HFQnVectorHandler->GetMultQnVecV0(MultQnFullV0,MultQnV0A,MultQnV0C);
 
     HFQnVectorHandler->GetEventPlaneAngleTPC(PsinFullTPC,PsinPosTPC,PsinNegTPC);
-    HFQnVectorHandler->GetEventPlaneAngleV0(PsinFullV0,PsinV0A,PsinV0C); 
+    HFQnVectorHandler->GetEventPlaneAngleV0(PsinFullV0,PsinV0A,PsinV0C);
 
     if(fEtaGapInTPCHalves>0.) {
         vector<AliAODTrack*> trackstoremove;
         for(int iTrack=0; iTrack<fAOD->GetNumberOfTracks(); iTrack++) {
             AliAODTrack* track = dynamic_cast<AliAODTrack*>(fAOD->GetTrack(iTrack));
-            if(TMath::Abs(track->Eta())<fEtaGapInTPCHalves/2)   
+            if(TMath::Abs(track->Eta())<fEtaGapInTPCHalves/2)
                 trackstoremove.push_back(track);
         }
         HFQnVectorHandler->RemoveTracksFromQnTPC(trackstoremove, QnFullTPC, QnPosTPC, QnNegTPC, MultQnFullTPC, MultQnPosTPC, MultQnNegTPC, true);
@@ -1097,7 +1163,7 @@ void AliAnalysisTaskSECharmHadronvn::GetMainQnVectorInfo(double &mainPsin, doubl
             mainPsin   = PsinPosTPC;
             mainMultQn = MultQnPosTPC;
             mainQn[0]  = QnPosTPC[0];
-            mainQn[1]  = QnPosTPC[1];        
+            mainQn[1]  = QnPosTPC[1];
         break;
         case kNegTPC:
             mainPsin   = PsinNegTPC;
@@ -1115,13 +1181,13 @@ void AliAnalysisTaskSECharmHadronvn::GetMainQnVectorInfo(double &mainPsin, doubl
             mainPsin   = PsinV0A;
             mainMultQn = MultQnV0A;
             mainQn[0]  = QnV0A[0];
-            mainQn[1]  = QnV0A[1];        
+            mainQn[1]  = QnV0A[1];
         break;
         case kV0C:
             mainPsin   = PsinV0C;
             mainMultQn = MultQnV0C;
             mainQn[0]  = QnV0C[0];
-            mainQn[1]  = QnV0C[1];        
+            mainQn[1]  = QnV0C[1];
         break;
     }
 
@@ -1136,7 +1202,7 @@ void AliAnalysisTaskSECharmHadronvn::GetMainQnVectorInfo(double &mainPsin, doubl
             SubAPsin   = PsinPosTPC;
             SubAMultQn = MultQnPosTPC;
             SubAQn[0]  = QnPosTPC[0];
-            SubAQn[1]  = QnPosTPC[1];        
+            SubAQn[1]  = QnPosTPC[1];
         break;
         case kNegTPC:
             SubAPsin   = PsinNegTPC;
@@ -1154,13 +1220,13 @@ void AliAnalysisTaskSECharmHadronvn::GetMainQnVectorInfo(double &mainPsin, doubl
             SubAPsin   = PsinV0A;
             SubAMultQn = MultQnV0A;
             SubAQn[0]  = QnV0A[0];
-            SubAQn[1]  = QnV0A[1];        
+            SubAQn[1]  = QnV0A[1];
         break;
         case kV0C:
             SubAPsin   = PsinV0C;
             SubAMultQn = MultQnV0C;
             SubAQn[0]  = QnV0C[0];
-            SubAQn[1]  = QnV0C[1];        
+            SubAQn[1]  = QnV0C[1];
         break;
     }
 
@@ -1175,7 +1241,7 @@ void AliAnalysisTaskSECharmHadronvn::GetMainQnVectorInfo(double &mainPsin, doubl
             SubBPsin   = PsinPosTPC;
             SubBMultQn = MultQnPosTPC;
             SubBQn[0]  = QnPosTPC[0];
-            SubBQn[1]  = QnPosTPC[1];        
+            SubBQn[1]  = QnPosTPC[1];
         break;
         case kNegTPC:
             SubBPsin   = PsinNegTPC;
@@ -1193,19 +1259,19 @@ void AliAnalysisTaskSECharmHadronvn::GetMainQnVectorInfo(double &mainPsin, doubl
             SubBPsin   = PsinV0A;
             SubBMultQn = MultQnV0A;
             SubBQn[0]  = QnV0A[0];
-            SubBQn[1]  = QnV0A[1];        
+            SubBQn[1]  = QnV0A[1];
         break;
         case kV0C:
             SubBPsin   = PsinV0C;
             SubBMultQn = MultQnV0C;
             SubBQn[0]  = QnV0C[0];
-            SubBQn[1]  = QnV0C[1];        
+            SubBQn[1]  = QnV0C[1];
         break;
     }
 }
 
 //________________________________________________________________________
-void AliAnalysisTaskSECharmHadronvn::GetDaughterTracksToRemove(AliAODRecoDecayHF* d, int nDau, vector<AliAODTrack*> &trackstoremove) 
+void AliAnalysisTaskSECharmHadronvn::GetDaughterTracksToRemove(AliAODRecoDecayHF* d, int nDau, vector<AliAODTrack*> &trackstoremove)
 {
     if(fDecChannel!=kDstartoKpipi) {
         for(int iDau=0; iDau<nDau; iDau++) {
@@ -1222,7 +1288,7 @@ void AliAnalysisTaskSECharmHadronvn::GetDaughterTracksToRemove(AliAODRecoDecayHF
 }
 
 //________________________________________________________________________
-int AliAnalysisTaskSECharmHadronvn::IsCandidateSelected(AliAODRecoDecayHF *&d, int nDau, int absPdgMom, AliAnalysisVertexingHF *vHF, AliAODRecoDecayHF2Prong *dD0) {
+int AliAnalysisTaskSECharmHadronvn::IsCandidateSelected(AliAODRecoDecayHF *&d, int nDau, int absPdgMom, AliAnalysisVertexingHF *vHF, AliAODRecoDecayHF2Prong *dD0, double modelPred[2]) {
 
     if(!d || !vHF || (fDecChannel==kDstartoKpipi && !dD0)) return false;
 
@@ -1237,7 +1303,7 @@ int AliAnalysisTaskSECharmHadronvn::IsCandidateSelected(AliAODRecoDecayHF *&d, i
     }
     else {
         for(int iDau=0; iDau<nDau; iDau++){
-            if(iDau == 0) 
+            if(iDau == 0)
                 track=vHF->GetProng(fAOD,d,iDau); //soft pion
             else
                 track=vHF->GetProng(fAOD,dD0,iDau-1); //D0 daughters
@@ -1263,14 +1329,8 @@ int AliAnalysisTaskSECharmHadronvn::IsCandidateSelected(AliAODRecoDecayHF *&d, i
         break;
         case kDstoKKpi:
             isSelBit = d->HasSelectionBit(AliRDHFCuts::kDsCuts);
-            if(!isSelBit || !vHF->FillRecoCand(fAOD,(AliAODRecoDecayHF3Prong*)d)) return 0;            
+            if(!isSelBit || !vHF->FillRecoCand(fAOD,(AliAODRecoDecayHF3Prong*)d)) return 0;
         break;
-    }
-
-    int isSelected = fRDCuts->IsSelected(d,AliRDHFCuts::kAll,fAOD);
-    if(!isSelected) return 0;
-    if(fDecChannel==kDstoKKpi) {
-        if(!(isSelected&4) && !(isSelected&8)) return 0;
     }
 
     double ptD = d->Pt();
@@ -1283,16 +1343,62 @@ int AliAnalysisTaskSECharmHadronvn::IsCandidateSelected(AliAODRecoDecayHF *&d, i
     bool isFidAcc = fRDCuts->IsInFiducialAcceptance(ptD,yD);
     if(!isFidAcc) return 0;
 
+    int isSelected = fRDCuts->IsSelected(d,AliRDHFCuts::kAll,fAOD);
+
+    //ML application
+    if(fApplyML) {
+        AliAODPidHF* pidHF = fRDCuts->GetPidHF();
+        bool isMLsel = true;
+
+        switch(fDecChannel) {
+            case kDplustoKpipi:
+            {
+                isMLsel = fMLResponse->IsSelectedML(modelPred[0], d, fAOD->GetMagneticField(), pidHF);
+                if(!isMLsel)
+                    isSelected = 0;
+                break;
+            }
+            case kD0toKpi:
+            {
+                AliWarning("ML application for D0 meson not yet implemented! Exit");
+                break;
+            }
+            case kDstartoKpipi:
+            {
+                AliWarning("ML application for Dstar meson not yet implemented! Exit");
+                break;
+            }
+            case kDstoKKpi:
+            {
+                if(isSelected&4) {
+                    isMLsel = fMLResponse->IsSelectedML(modelPred[0], d, fAOD->GetMagneticField(), pidHF, 0);
+                    if(!isMLsel)
+                        isSelected &= ~4; //switch off bit ok KKpi hypo
+                }
+                if(isSelected&8) {
+                    isMLsel = fMLResponse->IsSelectedML(modelPred[1], d, fAOD->GetMagneticField(), pidHF, 1);
+                    if(!isMLsel)
+                        isSelected &= ~8; //switch off bit ok piKK hypo
+                }
+                break;
+            }
+        }
+    }
+
+    if(!isSelected) return 0;
+    if(fDecChannel==kDstoKKpi)
+        if(!(isSelected&4) && !(isSelected&8)) return 0;
+
     return isSelected;
 }
 
 //________________________________________________________________________
-bool AliAnalysisTaskSECharmHadronvn::LoadSplinesForqnPercentile() 
+bool AliAnalysisTaskSECharmHadronvn::LoadSplinesForqnPercentile()
 {
     // load splines from file
 
     TString listname[6] = {"SplineListq2TPC", "SplineListq2TPCPosEta", "SplineListq2TPCNegEta", "SplineListq2V0", "SplineListq2V0A", "SplineListq2V0C"};
-    
+
     if (!gGrid) {
         TGrid::Connect("alien://");
     }

--- a/PWGHF/vertexingHF/charmFlow/AliAnalysisTaskSECharmHadronvn.h
+++ b/PWGHF/vertexingHF/charmFlow/AliAnalysisTaskSECharmHadronvn.h
@@ -8,7 +8,7 @@
 
 //*************************************************************************************
 // \class AliAnalysisTaskSECharmHadronvn
-// \brief task for the analysis of D-meson vn 
+// \brief task for the analysis of D-meson vn
 // \authors:
 // F. Grosa, fabrizio.grosa@cern.ch
 // F. Catalano, fabio.catalano@cern.ch
@@ -30,6 +30,7 @@
 #include "AliAODEvent.h"
 #include "AliHFQnVectorHandler.h"
 #include "AliAnalysisVertexingHF.h"
+#include "AliHFMLResponse.h"
 
 class AliAnalysisTaskSECharmHadronvn : public AliAnalysisTaskSE
 {
@@ -78,7 +79,7 @@ class AliAnalysisTaskSECharmHadronvn : public AliAnalysisTaskSE
     float GetLowerMassLimit() const                                   {return fLowmasslimit;}
     int GetNMassBins() const                                          {return fNMassBins;}
 
-    void SetTPCHalvesEtaGap(double etagap = 0.2)                      {fEtaGapInTPCHalves=etagap;}                             
+    void SetTPCHalvesEtaGap(double etagap = 0.2)                      {fEtaGapInTPCHalves=etagap;}
     void RemoveDauTracksFromqn(int removedau=1, bool remsoftpi=false) {fRemoveDauFromqn=removedau; fRemoveSoftPion=remsoftpi;}
     void SetRandomDownsamplFromqn(double fractokeep = 0.5)            {fEnableDownsamplqn=true; fFracToKeepDownSamplqn=fractokeep;}
 
@@ -94,8 +95,10 @@ class AliAnalysisTaskSECharmHadronvn : public AliAnalysisTaskSE
     void CalculateInvMasses(AliAODRecoDecayHF* d,float* &masses,int& nmasses);
     void GetMainQnVectorInfo(double &mainPsin, double &mainMultQn, double mainQn[2], double &SubAPsin, double &SubAMultQn, double SubAQn[2], double &SubBPsin, double &SubBMultQn, double SubBQn[2], AliHFQnVectorHandler* HFQnVectorHandler);
     void GetDaughterTracksToRemove(AliAODRecoDecayHF* d, int nDau, vector<AliAODTrack*> &trackstoremove);
-    int IsCandidateSelected(AliAODRecoDecayHF *&d, int nDau, int absPdgMom, AliAnalysisVertexingHF *vHF, AliAODRecoDecayHF2Prong *dD0);
+    int IsCandidateSelected(AliAODRecoDecayHF *&d, int nDau, int absPdgMom, AliAnalysisVertexingHF *vHF, AliAODRecoDecayHF2Prong *dD0, double modelPred[2]);
     bool LoadSplinesForqnPercentile();
+
+    static const int kVarForSparse = 10;
 
     AliAODEvent* fAOD;                      /// AOD event
 
@@ -138,14 +141,19 @@ class AliAnalysisTaskSECharmHadronvn : public AliAnalysisTaskSE
     float fLowmasslimit;                    /// lower inv mass limit for histos
     float fUpmasslimit;                     /// upper inv mass limit for histos
     int fNMassBins;                         /// number of bins in the mass histograms
-    
+
     double fEtaGapInTPCHalves;              /// eta gap between TPC subevents
     int fRemoveDauFromqn;                   /// flag to enable removal of D-meson daughter tracks from qn (1->remove single cand, 2->remove all cand of the analysed event)
     bool fRemoveSoftPion;                   /// flag to enable removal of soft pion too (only D*)
     bool fEnableDownsamplqn;                /// flag to enable random downsampling for qn
-    double fFracToKeepDownSamplqn;          /// fraction of tracks to keep in qn with random downsampling 
+    double fFracToKeepDownSamplqn;          /// fraction of tracks to keep in qn with random downsampling
 
-    ClassDef(AliAnalysisTaskSECharmHadronvn,3); // AliAnalysisTaskSE for the HF vn analysis
+    /// variables for ML application
+    bool fApplyML;                          /// flag to enable ML application
+    TString fConfigPath;                    /// path to ML config file
+    AliHFMLResponse* fMLResponse;           //!<! object to handle ML response
+
+    ClassDef(AliAnalysisTaskSECharmHadronvn,4); // AliAnalysisTaskSE for the HF vn analysis
 };
 
 #endif

--- a/PWGHF/vertexingHF/vHFML/AliHFMLResponse.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliHFMLResponse.cxx
@@ -1,0 +1,310 @@
+// Copyright CERN. This software is distributed under the terms of the GNU
+// General Public License v3 (GPL Version 3).
+//
+// See http://www.gnu.org/licenses/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//**************************************************************************************
+// \class AliHFMLResponse
+// \brief helper class to handle application of ML models trained with python libraries
+// \authors:
+// F. Catalano, fabio.catalano@cern.ch
+// F. Grosa, fabrizio.grosa@cern.ch
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#include <TGrid.h>
+#include <TSystem.h>
+#include <TDirectory.h>
+#include <TFile.h>
+
+#include "yaml-cpp/yaml.h"
+
+#include "AliHFMLResponse.h"
+#include "AliLog.h"
+
+/// \cond CLASSIMP
+ClassImp(AliHFMLResponse);
+/// \endcond
+
+//________________________________________________________________
+AliHFMLResponse::AliHFMLResponse() : TObject(),
+                                     fModels{},
+                                     fModelLibraries{},
+                                     fModelVarNames{},
+                                     fModelPaths{},
+                                     fModelOutputCuts{},
+                                     fPtBinsModel{},
+                                     fPtBinCand(-1),
+                                     fVars{}
+{
+    //
+    // Default constructor
+    //
+}
+
+//________________________________________________________________
+AliHFMLResponse::AliHFMLResponse(string configfilename) : TObject(),
+                                                          fModels{},
+                                                          fModelLibraries{},
+                                                          fModelVarNames{},
+                                                          fModelPaths{},
+                                                          fModelOutputCuts{},
+                                                          fPtBinsModel{},
+                                                          fPtBinCand(-1),
+                                                          fVars{}
+{
+    //
+    // Standard constructor
+    //
+
+    if (configfilename != "")
+        SetConfigFile(configfilename);
+}
+
+//________________________________________________________________
+AliHFMLResponse::~AliHFMLResponse()
+{
+    //
+    // Destructor
+    //
+}
+
+//--------------------------------------------------------------------------
+AliHFMLResponse::AliHFMLResponse(const AliHFMLResponse &source) : TObject(source),
+                                                                  fModels(source.fModels),
+                                                                  fModelLibraries(source.fModelLibraries),
+                                                                  fModelVarNames(source.fModelVarNames),
+                                                                  fModelPaths(source.fModelPaths),
+                                                                  fModelOutputCuts(source.fModelOutputCuts),
+                                                                  fPtBinsModel(source.fPtBinsModel),
+                                                                  fPtBinCand(source.fPtBinCand),
+                                                                  fVars(source.fVars)
+{
+    //
+    // Copy constructor
+    //
+}
+
+AliHFMLResponse &AliHFMLResponse::operator=(const AliHFMLResponse &source)
+{
+    //
+    // assignment operator
+    //
+    if (&source == this)
+        return *this;
+
+    TObject::operator=(source);
+
+    fModels = source.fModels;
+    fModelLibraries = source.fModelLibraries;
+    fModelVarNames = source.fModelVarNames;
+    fModelPaths = source.fModelPaths;
+    fModelOutputCuts = source.fModelOutputCuts;
+    fPtBinsModel = source.fPtBinsModel;
+    fPtBinCand = source.fPtBinCand;
+    fVars = source.fVars;
+
+    return *this;
+}
+
+//________________________________________________________________
+void AliHFMLResponse::SetConfigFile(const string configfilename)
+{
+    string configFilePath = GetFile(configfilename);
+    YAML::Node configFile = YAML::LoadFile(configFilePath.data());
+    if (configFile.IsNull())
+        AliFatal("Yaml config file not found! Exit");
+
+    fModelVarNames = configFile["VarNames"].as<vector<string> >();
+    fModelPaths = configFile["ModelNames"].as<vector<string> >();
+    fModelOutputCuts = configFile["ModelOutputCuts"].as<vector<double> >();
+    fPtBinsModel = configFile["PtBins"].as<vector<double> >();
+    fModelLibraries = configFile["ModelLibraries"].as<vector<string> >();
+
+    //for consistency check
+    unsigned int numModels = configFile["NumModels"].as<unsigned int>();
+    unsigned int numVars = configFile["NumVars"].as<unsigned int>();
+
+    if (numModels != fModelPaths.size() || numModels != fModelLibraries.size() || numModels != fModelOutputCuts.size() || numModels != fPtBinsModel.size() - 1)
+        AliFatal("Inconsistency found in the number of models loaded from your yaml config file, please check it! Exit");
+
+    if (numVars != fModelVarNames.size())
+        AliFatal("Inconsistency found in the number of variables (features) loaded from your yaml config file, please check it! Exit");
+}
+
+//________________________________________________________________
+double AliHFMLResponse::PredictProbaML(AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF, int masshypo)
+{
+    fPtBinCand = FindPtBin(cand->Pt());
+    SetMapOfVariables(cand, bfield, pidHF, masshypo);
+    if (fVars.empty())
+    {
+        AliWarning("Map of features empty!");
+        return -999.;
+    }
+
+    vector<double> vecOfFeatures;
+    for (auto varname : fModelVarNames)
+    {
+        if (fVars.find(varname) == fVars.end())
+        { //variable name not found in variables map!
+            AliWarning("Variable (feature) used for ML training not implemented for model application!");
+            return -999.;
+        }
+
+        vecOfFeatures.push_back(fVars[varname]);
+    }
+
+    if (fPtBinCand > fModels.size()-1){
+        AliWarning(Form("Model for pT bin %d not loaded!",fPtBinCand));
+        return -999.;
+    }
+
+    double modelPred = fModels[fPtBinCand].Predict(&vecOfFeatures[0], vecOfFeatures.size());
+
+    return modelPred;
+}
+
+//________________________________________________________________
+double AliHFMLResponse::PredictProbaML(double pt, vector<double> variables)
+{
+    fPtBinCand = FindPtBin(pt);
+    if (fPtBinCand > fModels.size()-1){
+        AliWarning(Form("Model for pT bin %d not loaded!",fPtBinCand));
+        return -999.;
+    }
+
+    double modelPred = fModels[fPtBinCand].Predict(&variables[0], variables.size());
+
+    return modelPred;
+}
+
+//________________________________________________________________
+bool AliHFMLResponse::IsSelectedML(double &prob, AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF, int masshypo)
+{
+    prob = PredictProbaML(cand, bfield, pidHF, masshypo);
+    if (prob > fModelOutputCuts[fPtBinCand])
+        return true;
+
+    return false;
+}
+
+//________________________________________________________________
+bool AliHFMLResponse::IsSelectedML(double &prob, double pt, vector<double> variables)
+{
+    prob = PredictProbaML(pt, variables);
+    if (prob > fModelOutputCuts[fPtBinCand])
+        return true;
+
+    return false;
+}
+
+//_________________________________________________________________________
+string AliHFMLResponse::GetFile(const string path)
+{
+    if (path.find("alien:") != string::npos)
+    {
+        size_t currPos = path.find_last_of("/") + 1;
+        string modelName = path.substr(currPos);
+        if (gGrid == nullptr)
+        {
+            TGrid::Connect("alien://");
+            if (gGrid == nullptr)
+            {
+                AliFatal("Connection to GRID not established! Exit");
+            }
+        }
+        string newPath = gSystem->pwd() + string("/") + modelName.data();
+        const char *OldRootDir = gDirectory->GetPath();
+        bool cpStatus = TFile::Cp(path.data(), newPath.data());
+        gDirectory->cd(OldRootDir);
+        if (!cpStatus)
+        {
+            AliFatal("Error in coping file from Alien! Exit");
+        }
+        return newPath;
+    }
+    else
+    {
+        return path;
+    }
+}
+
+//_________________________________________________________________________
+void AliHFMLResponse::InitModels()
+{
+    for (auto iMod = 0; iMod<fModelPaths.size(); iMod++)
+    {
+        string localpath = GetFile(fModelPaths[iMod]);
+        AliExternalBDT model = AliExternalBDT();
+        bool loadmodel = false;
+        switch (kLibMap[fModelLibraries[iMod]])
+        {
+        case kXGBoost:
+        {
+            loadmodel = model.LoadXGBoostModel(localpath);
+            break;
+        }
+        case kLightGBM:
+        {
+            loadmodel = model.LoadLightGBMModel(localpath);
+            break;
+        }
+        case kModelLibrary:
+        {
+            loadmodel = model.LoadModelLibrary(localpath);
+            break;
+        }
+        default:
+        {
+            loadmodel = model.LoadXGBoostModel(localpath);
+            break;
+        }
+        }
+        if (!loadmodel)
+            AliFatal("Problem in loading model");
+        fModels.push_back(model);
+    }
+}
+
+//_________________________________________________________________________
+int AliHFMLResponse::FindPtBin(double pt)
+{
+    int bin = TMath::BinarySearch(fPtBinsModel.size() - 1, &fPtBinsModel[0], pt);
+    if (bin < 0) //underflow --> equal to min value
+        bin = 0;
+
+    return bin;
+}
+
+//________________________________________________________________
+double AliHFMLResponse::ComputeMaxd0MeasMinusExp(AliAODRecoDecayHF *cand, double bfield)
+{
+    double dd0max = 0;
+    unsigned int fNProngsCand = static_cast<unsigned int>(cand->GetNProngs());
+    for (unsigned int iProng = 0; iProng < fNProngsCand; iProng++)
+    {
+        double d0diff, errd0diff;
+        cand->Getd0MeasMinusExpProng(iProng, bfield, d0diff, errd0diff);
+        double normdd0 = d0diff / errd0diff;
+        if (iProng == 0 || TMath::Abs(normdd0) > TMath::Abs(dd0max))
+            dd0max = normdd0;
+    }
+    return dd0max;
+}
+
+//________________________________________________________________
+double AliHFMLResponse::CombineNsigmaTPCTOF(double nsigmaTPC, double nsigmaTOF)
+{
+    if (nsigmaTPC > -998. && nsigmaTOF > -998.)
+        return TMath::Sqrt((nsigmaTPC * nsigmaTPC + nsigmaTOF * nsigmaTOF) / 2);
+    else if (nsigmaTPC > -998. && nsigmaTOF < -998.)
+        return TMath::Abs(nsigmaTPC);
+    else if (nsigmaTPC < -998. && nsigmaTOF > -998.)
+        return TMath::Abs(nsigmaTOF);
+    else
+        return -999.;
+}

--- a/PWGHF/vertexingHF/vHFML/AliHFMLResponse.h
+++ b/PWGHF/vertexingHF/vHFML/AliHFMLResponse.h
@@ -1,0 +1,88 @@
+#ifndef ALIHFMLRESPONSE_H
+#define ALIHFMLRESPONSE_H
+
+// Copyright CERN. This software is distributed under the terms of the GNU
+// General Public License v3 (GPL Version 3).
+//
+// See http://www.gnu.org/licenses/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//**************************************************************************************
+// \class AliHFMLResponse
+// \brief helper class to handle application of ML models trained with python libraries
+// \authors:
+// F. Catalano, fabio.catalano@cern.ch
+// F. Grosa, fabrizio.grosa@cern.ch
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#include <string>
+#include <vector>
+#include <map>
+
+#include "AliExternalBDT.h"
+#include "AliAODRecoDecayHF.h"
+#include "AliAODPidHF.h"
+
+using std::map;
+using std::string;
+using std::vector;
+
+class AliHFMLResponse : public TObject
+{
+public:
+    enum libraries
+    {
+        kXGBoost,
+        kLightGBM,
+        kModelLibrary
+    };
+
+    AliHFMLResponse();
+    AliHFMLResponse(string configfilename);
+    virtual ~AliHFMLResponse();
+
+    AliHFMLResponse(const AliHFMLResponse &source);
+    AliHFMLResponse& operator=(const AliHFMLResponse& source);
+
+    /// method to set yaml config file
+    void SetConfigFile(const string configfilename);
+    /// method to initialise and compile models (it has to be done run time)
+    void InitModels();
+
+    /// methods to get ML response
+    bool IsSelectedML(double &prob, AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF = nullptr, int masshypo = 0);
+    bool IsSelectedML(double &prob, double pt, vector<double> variables);
+    double PredictProbaML(AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF = nullptr, int masshypo = 0);
+    double PredictProbaML(double pt, vector<double> variables);
+
+    /// method to get variable (feature) from map
+    double GetVariable(string name = "") {return fVars[name];}
+
+protected:
+    string GetFile(const string path);
+    int FindPtBin(double pt);
+    double ComputeMaxd0MeasMinusExp(AliAODRecoDecayHF *cand, double bfield);
+    double CombineNsigmaTPCTOF(double nsigmaTPC, double nsigmaTOF);
+
+    /// method used to define map of name <-> variables (features) --> to be implemented for each derived class
+    virtual void SetMapOfVariables(AliAODRecoDecayHF * /*cand*/, double /*bfield*/, AliAODPidHF * /*pidHF*/, int /*masshypo*/) { return; }
+
+    map<string, int> kLibMap = {{"kXGBoost", kXGBoost}, {"kLightGBM", kLightGBM}, {"kModelLibrary", kModelLibrary}};
+
+    vector<AliExternalBDT> fModels;  /// vector of ML models
+    vector<string> fModelLibraries;  /// python libraries used to train ML model (kXGBoost, kLightGBM, or kModelLibrary)
+    vector<string> fModelVarNames;   /// vector with names of variables (features) used in ML model (in the correct order)
+    vector<string> fModelPaths;      /// vector of paths of the files containing the ML model
+    vector<double> fModelOutputCuts; /// vector of model output cuts
+    vector<double> fPtBinsModel;     /// vector with pT bins defined for the ML model application
+    int fPtBinCand;                  /// pT bin of the analysed candidate
+    map<string, double> fVars;       /// map of variables (features) that can be used for the ML model application
+
+    /// \cond CLASSIMP
+    ClassDef(AliHFMLResponse, 1); ///
+    /// \endcond
+};
+#endif

--- a/PWGHF/vertexingHF/vHFML/AliHFMLResponseDplustoKpipi.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliHFMLResponseDplustoKpipi.cxx
@@ -1,0 +1,102 @@
+// Copyright CERN. This software is distributed under the terms of the GNU
+// General Public License v3 (GPL Version 3).
+//
+// See http://www.gnu.org/licenses/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//**************************************************************************************
+// \class AliHFMLResponseDplustoKpipi
+// \brief helper class to handle application of ML models for D+ analyses trained
+// with python libraries
+// \authors:
+// F. Catalano, fabio.catalano@cern.ch
+// F. Grosa, fabrizio.grosa@cern.ch
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#include <TDatabasePDG.h>
+
+#include "AliHFMLResponseDplustoKpipi.h"
+#include "AliAODRecoDecayHF3Prong.h"
+
+/// \cond CLASSIMP
+ClassImp(AliHFMLResponseDplustoKpipi);
+/// \endcond
+
+//________________________________________________________________
+AliHFMLResponseDplustoKpipi::AliHFMLResponseDplustoKpipi() : AliHFMLResponse()
+{
+    //
+    // Default constructor
+    //
+}
+
+//________________________________________________________________
+AliHFMLResponseDplustoKpipi::AliHFMLResponseDplustoKpipi(string configfilename) : AliHFMLResponse(configfilename)
+{
+    //
+    // Standard constructor
+    //
+
+    if (configfilename != "")
+        SetConfigFile(configfilename);
+}
+
+//________________________________________________________________
+AliHFMLResponseDplustoKpipi::~AliHFMLResponseDplustoKpipi()
+{
+    //
+    // Destructor
+    //
+}
+
+//--------------------------------------------------------------------------
+AliHFMLResponseDplustoKpipi::AliHFMLResponseDplustoKpipi(const AliHFMLResponseDplustoKpipi &source) : AliHFMLResponse(source)
+{
+    //
+    // Copy constructor
+    //
+}
+
+AliHFMLResponseDplustoKpipi &AliHFMLResponseDplustoKpipi::operator=(const AliHFMLResponseDplustoKpipi &source)
+{
+    //
+    // assignment operator
+    //
+    if (&source == this)
+        return *this;
+
+    AliHFMLResponse::operator=(source);
+
+    return *this;
+}
+
+//________________________________________________________________
+void AliHFMLResponseDplustoKpipi::SetMapOfVariables(AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF, int /*masshypo*/)
+{
+    fVars["pt_cand"] = cand->Pt();
+    fVars["d_len"] = cand->DecayLength();
+    fVars["d_len_xy"] = cand->DecayLengthXY();
+    fVars["norm_dl"] = cand->NormalizedDecayLength();
+    fVars["norm_dl_xy"] = cand->NormalizedDecayLengthXY();
+    fVars["cos_p"] = cand->CosPointingAngle();
+    fVars["cos_p_xy"] = cand->CosPointingAngleXY();
+    fVars["imp_par_xy"] = cand->ImpParXY();
+    fVars["sig_vert"] = dynamic_cast<AliAODRecoDecayHF3Prong *>(cand)->GetSigmaVert();
+    fVars["max_norm_d0d0exp"] = ComputeMaxd0MeasMinusExp(cand, bfield);
+
+    for (int iProng = 0; iProng < 3; iProng++)
+    {
+        AliAODTrack *dautrack = dynamic_cast<AliAODTrack *>(cand->GetDaughter(iProng));
+
+        pidHF->GetnSigmaTPC(dautrack, 2, fVars[Form("nsigTPC_Pi_%d", iProng)]);
+        pidHF->GetnSigmaTPC(dautrack, 3, fVars[Form("nsigTPC_K_%d", iProng)]);
+        pidHF->GetnSigmaTOF(dautrack, 2, fVars[Form("nsigTOF_Pi_%d", iProng)]);
+        pidHF->GetnSigmaTOF(dautrack, 3, fVars[Form("nsigTOF_K_%d", iProng)]);
+
+        fVars[Form("nsigComb_Pi_%d", iProng)] = CombineNsigmaTPCTOF(fVars[Form("nsigTPC_Pi_%d", iProng)], fVars[Form("nsigTOF_Pi_%d", iProng)]);
+        fVars[Form("nsigComb_K_%d", iProng)] = CombineNsigmaTPCTOF(fVars[Form("nsigTPC_K_%d", iProng)], fVars[Form("nsigTOF_K_%d", iProng)]);
+    }
+}

--- a/PWGHF/vertexingHF/vHFML/AliHFMLResponseDplustoKpipi.h
+++ b/PWGHF/vertexingHF/vHFML/AliHFMLResponseDplustoKpipi.h
@@ -1,0 +1,41 @@
+#ifndef ALIHFMLRESPONSEDPLUSTOKPIPI_H
+#define ALIHFMLRESPONSEDPLUSTOKPIPI_H
+
+// Copyright CERN. This software is distributed under the terms of the GNU
+// General Public License v3 (GPL Version 3).
+//
+// See http://www.gnu.org/licenses/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//**************************************************************************************
+// \class AliHFMLResponseDplustoKpipi
+// \brief helper class to handle application of ML models for D+ analyses trained
+// with python libraries
+// \authors:
+// F. Catalano, fabio.catalano@cern.ch
+// F. Grosa, fabrizio.grosa@cern.ch
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#include "AliHFMLResponse.h"
+
+class AliHFMLResponseDplustoKpipi : public AliHFMLResponse
+{
+public:
+    AliHFMLResponseDplustoKpipi();
+    AliHFMLResponseDplustoKpipi(string configfilename);
+    virtual ~AliHFMLResponseDplustoKpipi();
+
+    AliHFMLResponseDplustoKpipi(const AliHFMLResponseDplustoKpipi &source);
+    AliHFMLResponseDplustoKpipi& operator=(const AliHFMLResponseDplustoKpipi& source);
+
+protected:
+    virtual void SetMapOfVariables(AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF, int /*masshypo*/);
+
+    /// \cond CLASSIMP
+    ClassDef(AliHFMLResponseDplustoKpipi, 1); ///
+    /// \endcond
+};
+#endif

--- a/PWGHF/vertexingHF/vHFML/AliHFMLResponseDstoKKpi.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliHFMLResponseDstoKKpi.cxx
@@ -1,0 +1,119 @@
+// Copyright CERN. This software is distributed under the terms of the GNU
+// General Public License v3 (GPL Version 3).
+//
+// See http://www.gnu.org/licenses/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//**************************************************************************************
+// \class AliHFMLResponseDstoKKpi
+// \brief helper class to handle application of ML models for Ds analyses trained
+// with python libraries
+// \authors:
+// F. Catalano, fabio.catalano@cern.ch
+// F. Grosa, fabrizio.grosa@cern.ch
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#include <TDatabasePDG.h>
+
+#include "AliHFMLResponseDstoKKpi.h"
+#include "AliAODRecoDecayHF3Prong.h"
+
+/// \cond CLASSIMP
+ClassImp(AliHFMLResponseDstoKKpi);
+/// \endcond
+
+//________________________________________________________________
+AliHFMLResponseDstoKKpi::AliHFMLResponseDstoKKpi() : AliHFMLResponse()
+{
+    //
+    // Default constructor
+    //
+}
+
+//________________________________________________________________
+AliHFMLResponseDstoKKpi::AliHFMLResponseDstoKKpi(string configfilename) : AliHFMLResponse(configfilename)
+{
+    //
+    // Standard constructor
+    //
+
+    if (configfilename != "")
+        SetConfigFile(configfilename);
+}
+
+//________________________________________________________________
+AliHFMLResponseDstoKKpi::~AliHFMLResponseDstoKKpi()
+{
+    //
+    // Destructor
+    //
+}
+
+//--------------------------------------------------------------------------
+AliHFMLResponseDstoKKpi::AliHFMLResponseDstoKKpi(const AliHFMLResponseDstoKKpi &source) : AliHFMLResponse(source)
+{
+    //
+    // Copy constructor
+    //
+}
+
+AliHFMLResponseDstoKKpi &AliHFMLResponseDstoKKpi::operator=(const AliHFMLResponseDstoKKpi &source)
+{
+    //
+    // assignment operator
+    //
+    if (&source == this)
+        return *this;
+
+    AliHFMLResponse::operator=(source);
+
+    return *this;
+}
+
+//________________________________________________________________
+void AliHFMLResponseDstoKKpi::SetMapOfVariables(AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF, int masshypo)
+{
+    fVars["pt_cand"] = cand->Pt();
+    fVars["d_len"] = cand->DecayLength();
+    fVars["d_len_xy"] = cand->DecayLengthXY();
+    fVars["norm_dl"] = cand->NormalizedDecayLength();
+    fVars["norm_dl_xy"] = cand->NormalizedDecayLengthXY();
+    fVars["cos_p"] = cand->CosPointingAngle();
+    fVars["cos_p_xy"] = cand->CosPointingAngleXY();
+    fVars["imp_par_xy"] = cand->ImpParXY();
+    fVars["sig_vert"] = dynamic_cast<AliAODRecoDecayHF3Prong *>(cand)->GetSigmaVert();
+    fVars["max_norm_d0d0exp"] = ComputeMaxd0MeasMinusExp(cand, bfield);
+
+    double massPhi = TDatabasePDG::Instance()->GetParticle(333)->Mass();
+    if (masshypo == 0)
+    {
+        fVars["inv_mass"] = dynamic_cast<AliAODRecoDecayHF3Prong *>(cand)->InvMassDsKKpi();
+        fVars["delta_mass_KK"] = TMath::Abs(dynamic_cast<AliAODRecoDecayHF3Prong *>(cand)->InvMass2Prongs(0, 1, 321, 321) - massPhi);
+        fVars["cos_PiDs"] = dynamic_cast<AliAODRecoDecayHF3Prong *>(cand)->CosPiDsLabFrameKKpi();
+        fVars["cos_PiKPhi_3"] = dynamic_cast<AliAODRecoDecayHF3Prong *>(cand)->CosPiKPhiRFrameKKpi();
+    }
+    else if (masshypo == 1)
+    {
+        fVars["inv_mass"] = dynamic_cast<AliAODRecoDecayHF3Prong *>(cand)->InvMassDspiKK();
+        fVars["delta_mass_KK"] = TMath::Abs(dynamic_cast<AliAODRecoDecayHF3Prong *>(cand)->InvMass2Prongs(1, 2, 321, 321) - massPhi);
+        fVars["cos_PiDs"] = dynamic_cast<AliAODRecoDecayHF3Prong *>(cand)->CosPiDsLabFramepiKK();
+        fVars["cos_PiKPhi_3"] = dynamic_cast<AliAODRecoDecayHF3Prong *>(cand)->CosPiKPhiRFramepiKK();
+    }
+    fVars["cos_PiKPhi_3"] = fVars["cos_PiKPhi_3"] * fVars["cos_PiKPhi_3"] * fVars["cos_PiKPhi_3"];
+
+    for (int iProng = 0; iProng < 3; iProng++)
+    {
+        AliAODTrack *dautrack = dynamic_cast<AliAODTrack *>(cand->GetDaughter(iProng));
+
+        pidHF->GetnSigmaTPC(dautrack, 2, fVars[Form("nsigTPC_Pi_%d", iProng)]);
+        pidHF->GetnSigmaTPC(dautrack, 3, fVars[Form("nsigTPC_K_%d", iProng)]);
+        pidHF->GetnSigmaTOF(dautrack, 2, fVars[Form("nsigTOF_Pi_%d", iProng)]);
+        pidHF->GetnSigmaTOF(dautrack, 3, fVars[Form("nsigTOF_K_%d", iProng)]);
+
+        fVars[Form("nsigComb_Pi_%d", iProng)] = CombineNsigmaTPCTOF(fVars[Form("nsigTPC_Pi_%d", iProng)], fVars[Form("nsigTOF_Pi_%d", iProng)]);
+        fVars[Form("nsigComb_K_%d", iProng)] = CombineNsigmaTPCTOF(fVars[Form("nsigTPC_K_%d", iProng)], fVars[Form("nsigTOF_K_%d", iProng)]);
+    }
+}

--- a/PWGHF/vertexingHF/vHFML/AliHFMLResponseDstoKKpi.h
+++ b/PWGHF/vertexingHF/vHFML/AliHFMLResponseDstoKKpi.h
@@ -1,0 +1,41 @@
+#ifndef ALIHFMLRESPONSEDSTOKKPI_H
+#define ALIHFMLRESPONSEDSTOKKPI_H
+
+// Copyright CERN. This software is distributed under the terms of the GNU
+// General Public License v3 (GPL Version 3).
+//
+// See http://www.gnu.org/licenses/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//**************************************************************************************
+// \class AliHFMLResponseDstoKKpi
+// \brief helper class to handle application of ML models for Ds analyses trained
+// with python libraries
+// \authors:
+// F. Catalano, fabio.catalano@cern.ch
+// F. Grosa, fabrizio.grosa@cern.ch
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#include "AliHFMLResponse.h"
+
+class AliHFMLResponseDstoKKpi : public AliHFMLResponse
+{
+public:
+    AliHFMLResponseDstoKKpi();
+    AliHFMLResponseDstoKKpi(string configfilename);
+    virtual ~AliHFMLResponseDstoKKpi();
+
+    AliHFMLResponseDstoKKpi(const AliHFMLResponseDstoKKpi &source);
+    AliHFMLResponseDstoKKpi& operator=(const AliHFMLResponseDstoKKpi& source);
+
+protected:
+    virtual void SetMapOfVariables(AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF, int masshypo);
+
+    /// \cond CLASSIMP
+    ClassDef(AliHFMLResponseDstoKKpi, 1); ///
+    /// \endcond
+};
+#endif


### PR DESCRIPTION
Co-authored-by: fcatalan92 <fabio.catalano@cern.ch>
1) add mother class for application of ML models trained offline with python on the grid for a generic HF particle that loads the inputs (model paths, pt bins, preselection, list of features on ML output) from a yaml configuration file
2) add classes for Ds and D+ mesons
3) update ML application in Ds task using the object
4) implement application of ML models in D+ and vn (for Ds and D+) tasks