### PR TITLE
Updates in Make2Prong for V0+bachelor treatement

### DIFF
--- a/PWGHF/vertexingHF/AliAnalysisVertexingHF.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisVertexingHF.cxx
@@ -2324,6 +2324,7 @@ AliAODRecoDecayHF2Prong *AliAnalysisVertexingHF::Make2Prong(
     primVertexAOD  = PrimaryVertex(twoTrackArray,event);
     if(!primVertexAOD) return 0x0;
     Double_t d0z0[2],covd0z0[3];
+    // do not prapagate neutral tracks, which are there for D* and V0+bachelor candidates
     if(postrack->Charge()!=0){
       postrack->PropagateToDCA(primVertexAOD,fBzkG,kVeryBig,d0z0,covd0z0);
       d0[0] = d0z0[0];

--- a/PWGHF/vertexingHF/AliAnalysisVertexingHF.h
+++ b/PWGHF/vertexingHF/AliAnalysisVertexingHF.h
@@ -362,7 +362,9 @@ class AliAnalysisVertexingHF : public TNamed {
 		       const TObjArray *trkArray) const;
   AliAODRecoDecayHF2Prong* Make2Prong(TObjArray *twoTrackArray1,AliVEvent *event,
 				      AliAODVertex *secVert,Double_t dcap1n1,
-				      Bool_t &okD0,Bool_t &okJPSI,Bool_t &okD0fromDstar, Bool_t refill=kFALSE, AliAODRecoDecayHF2Prong *rd=0x0);
+				      Bool_t &okD0,Bool_t &okJPSI,Bool_t &okD0fromDstar,
+				      Bool_t callFromCascade=kFALSE, Bool_t refill=kFALSE,
+				      AliAODRecoDecayHF2Prong *rd=0x0);
   AliAODRecoDecayHF3Prong* Make3Prong(TObjArray *threeTrackArray,AliVEvent *event,
 				      AliAODVertex *secVert,
 				      Double_t dispersion,


### PR DESCRIPTION
Skip second calculation of V0+bachelor invariant mass
Recompute primary vertex for 2prong candidates only when needed
Do not propagate neutral tracks to DCA