### PR TITLE
PWGUD/UPC: Pb-p analysis update.

### DIFF
--- a/PWGUD/UPC/AliAnalysisTaskForMCpPb.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskForMCpPb.cxx
@@ -1190,7 +1190,7 @@ void AliAnalysisTaskForMCpPb::ProcessMCParticles(AliMCEvent* fMCEventArg)
     }
     if (  !mcParticle->IsPrimary()                                ) continue;
     if (   mcParticle->Charge()              == 0                 ) continue;
-    if ( !(mcParticle->Eta() < -2.5 && mcParticle->Eta() > -3.7 ) ) continue;
+    // if ( !(mcParticle->Eta() < -2.5 && mcParticle->Eta() > -3.7 ) ) continue;
     if (   TMath::Abs(mcParticle->PdgCode()) == 13 ) {
       if ( nGoodMuonsMC < 2 ) {
         // cout << "Ok" << nGoodMuonsMC << endl;

--- a/PWGUD/UPC/AliAnalysisTaskForMCpPb.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskForMCpPb.cxx
@@ -1188,8 +1188,9 @@ void AliAnalysisTaskForMCpPb::ProcessMCParticles(AliMCEvent* fMCEventArg)
       AliError(Form("Could not receive track %d", iPart));
       continue;
     }
-    if (  !mcParticle->IsPrimary()                 ) continue;
-    if (   mcParticle->Charge()              == 0  ) continue;
+    if (  !mcParticle->IsPrimary()                                ) continue;
+    if (   mcParticle->Charge()              == 0                 ) continue;
+    if ( !(mcParticle->Eta() < -2.5 && mcParticle->Eta() > -3.7 ) ) continue;
     if (   TMath::Abs(mcParticle->PdgCode()) == 13 ) {
       if ( nGoodMuonsMC < 2 ) {
         // cout << "Ok" << nGoodMuonsMC << endl;

--- a/PWGUD/UPC/AliAnalysisTaskForMCpPb.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskForMCpPb.cxx
@@ -915,6 +915,16 @@ void AliAnalysisTaskForMCpPb::UserExec(Option_t *)
         continue;
     }
 
+
+    /* -
+     * - Compatibility with Run 1 analysis.
+     * -
+     */
+    if ( !( (track[nGoodMuons]->Eta() < -2.5) && (track[nGoodMuons]->Eta() > -3.7) ) ) {
+      continue;
+    }
+
+
     // MUON SELECTION
     /* - This is Eugeny Krishen's MUON selection from the talk in 14/1/2019 for
        - the PWG-UD (UPC oriented) meeting. The event selection requires:

--- a/PWGUD/UPC/AliAnalysisTaskForMCpPb.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskForMCpPb.cxx
@@ -759,7 +759,7 @@ void AliAnalysisTaskForMCpPb::UserExec(Option_t *)
                                           266940, 266915, 266912, 266886, 266885, 266883, 266882, 266880, 266878, 266857,
                                           266807, 266805, 266800, 266776, 266775, 266708, 266706, 266703, 266702, 266676,
                                           266674, 266669, 266668, 266665, 266659, 266658, 266657, 266630, 266621, 266618,
-                                          266615, 266614, 266613, 266595, 266593, 266591, 266588, 266587, 266584, 266549,
+                                          /*266615,*/ 266614, 266613, 266595, 266593, 266591, 266588, 266587, 266584, 266549,
                                           266543, 266539, 266534, 266533, 266525, 266523, 266522, 266520, 266518, 266516,
                                           266514, 266487, 266480, 266479, 266472, 266441, 266439, 295585 };
   Bool_t checkIfGoodRun = kFALSE;
@@ -767,7 +767,7 @@ void AliAnalysisTaskForMCpPb::UserExec(Option_t *)
   // for( Int_t iRunLHC16r = 0; iRunLHC16r <  57; iRunLHC16r++){
   //   if( fRunNum == listOfGoodRunNumbersLHC16r[iRunLHC16r] ) checkIfGoodRun = kTRUE;
   // }
-  for( Int_t iRunLHC16s = 0; iRunLHC16s <  /*77*/ 78; iRunLHC16s++){
+  for( Int_t iRunLHC16s = 0; iRunLHC16s <  77; iRunLHC16s++){
     if( fRunNum == listOfGoodRunNumbersLHC16s[iRunLHC16s] ) checkIfGoodRun = kTRUE;
   }
   if(checkIfGoodRun != 1) {

--- a/PWGUD/UPC/AliAnalysisTaskForMCpPb.h
+++ b/PWGUD/UPC/AliAnalysisTaskForMCpPb.h
@@ -475,7 +475,7 @@ class AliAnalysisTaskForMCpPb : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskForMCpPb, 2);
+        ClassDef(AliAnalysisTaskForMCpPb, 3);
 };
 
 #endif

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardpPb.cxx
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardpPb.cxx
@@ -89,6 +89,8 @@ AliAnalysisTaskUPCforwardpPb::AliAnalysisTaskUPCforwardpPb()
       fInvariantMassDistribution0N0NH(0),
       fInvariantMassDistributionRapidityBins0N0NH{ 0, 0 },
       fInvariantMassDistributionMoreRapidityBins0N0NH{ 0, 0, 0 },
+      fInvariantMassDistributionSmall0N0NH(0),
+      fInvariantMassDistributionRapidityBinsSmall0N0NH{ 0, 0 },
       fEntriesAgainstRunNumberH(0),
       fEntriesAgainstRunNumberProperlyH(0),
       fRunNumberTriggerCMUP11ClassH(0),
@@ -114,6 +116,9 @@ AliAnalysisTaskUPCforwardpPb::AliAnalysisTaskUPCforwardpPb()
       fInvariantMassDistributionIncoherentShiftPlusOneH(0),
       fInvariantMassDistributionIncoherentShiftPlusTwoH(0),
       fDimuonPtDistributionH(0),
+      fDimuonPtDistributionRestrictedRapidity0N0NH(0),
+      fDimuonPtDistributionRestrictedRapidity0N0N36to31H(0),
+      fDimuonPtDistributionRestrictedRapidity0N0N31to26H(0),
       fInvariantMassDistributionExtendedH(0),
       fInvariantMassDistributionCoherentExtendedH(0),
       fInvariantMassDistributionIncoherentExtendedH(0),
@@ -175,6 +180,8 @@ AliAnalysisTaskUPCforwardpPb::AliAnalysisTaskUPCforwardpPb(const char* name)
       fInvariantMassDistribution0N0NH(0),
       fInvariantMassDistributionRapidityBins0N0NH{ 0, 0 },
       fInvariantMassDistributionMoreRapidityBins0N0NH{ 0, 0, 0 },
+      fInvariantMassDistributionSmall0N0NH(0),
+      fInvariantMassDistributionRapidityBinsSmall0N0NH{ 0, 0 },
       fEntriesAgainstRunNumberH(0),
       fEntriesAgainstRunNumberProperlyH(0),
       fRunNumberTriggerCMUP11ClassH(0),
@@ -200,6 +207,9 @@ AliAnalysisTaskUPCforwardpPb::AliAnalysisTaskUPCforwardpPb(const char* name)
       fInvariantMassDistributionIncoherentShiftPlusOneH(0),
       fInvariantMassDistributionIncoherentShiftPlusTwoH(0),
       fDimuonPtDistributionH(0),
+      fDimuonPtDistributionRestrictedRapidity0N0NH(0),
+      fDimuonPtDistributionRestrictedRapidity0N0N36to31H(0),
+      fDimuonPtDistributionRestrictedRapidity0N0N31to26H(0),
       fInvariantMassDistributionExtendedH(0),
       fInvariantMassDistributionCoherentExtendedH(0),
       fInvariantMassDistributionIncoherentExtendedH(0),
@@ -343,6 +353,17 @@ void AliAnalysisTaskUPCforwardpPb::UserCreateOutputObjects()
     fOutputList->Add(fInvariantMassDistributionMoreRapidityBins0N0NH[iRapidity]);
   }
 
+  fInvariantMassDistributionSmall0N0NH = new TH1F("fInvariantMassDistributionSmall0N0NH", "fInvariantMassDistributionSmall0N0NH", 2000, 0, 20);
+  fOutputList->Add(fInvariantMassDistributionSmall0N0NH);
+
+  for( Int_t iRapidity = 0; iRapidity < 2; iRapidity++ ) {
+    fInvariantMassDistributionRapidityBinsSmall0N0NH[iRapidity]
+            = new TH1F( Form("fInvariantMassDistributionRapidityBinsSmall0N0NH_%d", iRapidity),
+                        Form("fInvariantMassDistributionRapidityBinsSmall0N0NH_%d", iRapidity),
+                        2000, 0, 20);
+    fOutputList->Add(fInvariantMassDistributionRapidityBinsSmall0N0NH[iRapidity]);
+  }
+
 
   fEntriesAgainstRunNumberH = new TH1F("fEntriesAgainstRunNumberH", "fEntriesAgainstRunNumberH", 10000, 290000, 300000);
   fOutputList->Add(fEntriesAgainstRunNumberH);
@@ -458,6 +479,14 @@ void AliAnalysisTaskUPCforwardpPb::UserCreateOutputObjects()
   fDimuonPtDistributionShiftPlusOneH = new TH1F("fDimuonPtDistributionShiftPlusOneH", "fDimuonPtDistributionShiftPlusOneH", 4000, 0.02, 20.02);
   fOutputList->Add(fDimuonPtDistributionShiftPlusOneH);
 
+  fDimuonPtDistributionRestrictedRapidity0N0NH = new TH1F("fDimuonPtDistributionRestrictedRapidity0N0NH", "fDimuonPtDistributionRestrictedRapidity0N0NH", 4000, 0, 20);
+  fOutputList->Add(fDimuonPtDistributionRestrictedRapidity0N0NH);
+
+  fDimuonPtDistributionRestrictedRapidity0N0N36to31H = new TH1F("fDimuonPtDistributionRestrictedRapidity0N0N36to31H", "fDimuonPtDistributionRestrictedRapidity0N0N36to31H", 4000, 0, 20);
+  fOutputList->Add(fDimuonPtDistributionRestrictedRapidity0N0N36to31H);
+
+  fDimuonPtDistributionRestrictedRapidity0N0N31to26H = new TH1F("fDimuonPtDistributionRestrictedRapidity0N0N31to26H", "fDimuonPtDistributionRestrictedRapidity0N0N31to26H", 4000, 0, 20);
+  fOutputList->Add(fDimuonPtDistributionRestrictedRapidity0N0N31to26H);
 
   /* - These histograms have an EXTENDED range (0,20)->(0,40)
      -
@@ -940,6 +969,15 @@ void AliAnalysisTaskUPCforwardpPb::UserExec(Option_t *)
         continue;
     }
 
+
+    /* -
+     * - Compatibility with Run 1 analysis.
+     * -
+     */
+    if ( !( (track[nGoodMuons]->Eta() < -2.5) && (track[nGoodMuons]->Eta() > -3.7) ) ) {
+      continue;
+    }
+
     // MUON SELECTION
     /* - This is Eugeny Krishen's MUON selection from the talk in 14/1/2019 for
        - the PWG-UD (UPC oriented) meeting. The event selection requires:
@@ -1247,7 +1285,33 @@ void AliAnalysisTaskUPCforwardpPb::UserExec(Option_t *)
                 } else if ( possibleJPsi.Rapidity() > -3.00 && possibleJPsi.Rapidity() <= -2.50 ) {
                   fInvariantMassDistributionMoreRapidityBins0N0NH[2]->Fill(possibleJPsi.Mag());
                 }
+                /**
+                 * - Pt-integrated analysis
+                 * - in 2 rapidity bins.
+                 * -
+                 */
+                if (        possibleJPsi.Rapidity() > -3.60 && possibleJPsi.Rapidity() <= -3.10 ) {
+                  fInvariantMassDistributionSmall0N0NH               ->Fill(possibleJPsi.Mag());
+                  fInvariantMassDistributionRapidityBinsSmall0N0NH[0]->Fill(possibleJPsi.Mag());
+                  // fDimuonPtDistributionRestrictedRapidity0N0NH       ->Fill(ptOfTheDimuonPair);
+                  // fDimuonPtDistributionRestrictedRapidity0N0N36to31H ->Fill(ptOfTheDimuonPair);
+                } else if ( possibleJPsi.Rapidity() > -3.10 && possibleJPsi.Rapidity() <= -2.60 ) {
+                  fInvariantMassDistributionSmall0N0NH               ->Fill(possibleJPsi.Mag());
+                  fInvariantMassDistributionRapidityBinsSmall0N0NH[1]->Fill(possibleJPsi.Mag());
+                  // fDimuonPtDistributionRestrictedRapidity0N0NH       ->Fill(ptOfTheDimuonPair);
+                  // fDimuonPtDistributionRestrictedRapidity0N0N31to26H ->Fill(ptOfTheDimuonPair);
+                }
+
             }
+
+            if (        possibleJPsi.Rapidity() > -3.60 && possibleJPsi.Rapidity() <= -3.10 ) {
+              fDimuonPtDistributionRestrictedRapidity0N0NH       ->Fill(ptOfTheDimuonPair);
+              fDimuonPtDistributionRestrictedRapidity0N0N36to31H ->Fill(ptOfTheDimuonPair);
+            } else if ( possibleJPsi.Rapidity() > -3.10 && possibleJPsi.Rapidity() <= -2.60 ) {
+              fDimuonPtDistributionRestrictedRapidity0N0NH       ->Fill(ptOfTheDimuonPair);
+              fDimuonPtDistributionRestrictedRapidity0N0N31to26H ->Fill(ptOfTheDimuonPair);
+            }
+
         }
   }
 

--- a/PWGUD/UPC/AliAnalysisTaskUPCforwardpPb.h
+++ b/PWGUD/UPC/AliAnalysisTaskUPCforwardpPb.h
@@ -155,15 +155,18 @@ class AliAnalysisTaskUPCforwardpPb : public AliAnalysisTaskSE
         TH1F*                   fInvariantMassDistributionRapidityBins0N0NH[2];       //!
         TH1F*                   fInvariantMassDistributionMoreRapidityBins0N0NH[3];   //!
 
-                /**
-                 * This histogram records the energy distri-
-                 * bution of the neutron ZDC. This plot should
-                 * show the relative components of the 0 neutron
-                 * peak, the 1 neutron peak and possibly the
-                 * 2 neutrons peak. Anything higher than that,
-                 * requires help from the user and is more like
-                 * a guess...
-                 */
+        TH1F*                   fInvariantMassDistributionSmall0N0NH;                 //!
+        TH1F*                   fInvariantMassDistributionRapidityBinsSmall0N0NH[2];  //!
+
+                                /**
+                                 * This histogram records the energy distri-
+                                 * bution of the neutron ZDC. This plot should
+                                 * show the relative components of the 0 neutron
+                                 * peak, the 1 neutron peak and possibly the
+                                 * 2 neutrons peak. Anything higher than that,
+                                 * requires help from the user and is more like
+                                 * a guess...
+                                 */
         TH1F*                   fZNCEnergyAgainstEntriesH;                 //!
         TH1F*                   fZNCEnergyAgainstEntriesExtendedH;         //!
         TH1F*                   fZNCEnergyAgainstEntriesExtendedHv2;       //!
@@ -366,9 +369,15 @@ class AliAnalysisTaskUPCforwardpPb : public AliAnalysisTaskSE
                                  * of the dimuon pairs.
                                  *
                                  * Shift +1 => 20 Mev/c shift
+                                 *
+                                 * Restricted rapidity: -3.6 < y < -2.6
                                  */
-        TH1F*                   fDimuonPtDistributionH;                     //!
-        TH1F*                   fDimuonPtDistributionShiftPlusOneH;         //!
+        TH1F*                   fDimuonPtDistributionH;                              //!
+        TH1F*                   fDimuonPtDistributionShiftPlusOneH;                  //!
+
+        TH1F*                   fDimuonPtDistributionRestrictedRapidity0N0NH;        //!
+        TH1F*                   fDimuonPtDistributionRestrictedRapidity0N0N36to31H;  //!
+        TH1F*                   fDimuonPtDistributionRestrictedRapidity0N0N31to26H;  //!
 
 
         //_______________________________
@@ -460,7 +469,7 @@ class AliAnalysisTaskUPCforwardpPb : public AliAnalysisTaskSE
          * If I happen to encounter it again in the future, I will make sure to
          * record it!
          */
-        ClassDef(AliAnalysisTaskUPCforwardpPb, 3);
+        ClassDef(AliAnalysisTaskUPCforwardpPb, 6);
 };
 
 #endif


### PR DESCRIPTION
Strict eta requirement per muon track both in data and MC.
Rapidity-wise analysis in data for -3.6 < y < -2.6.

