### PR TITLE
first implementation of c-deuteron reconstruction

### DIFF
--- a/PWGHF/vertexingHF/AliAODRecoDecayHF3Prong.h
+++ b/PWGHF/vertexingHF/AliAODRecoDecayHF3Prong.h
@@ -86,6 +86,8 @@ class AliAODRecoDecayHF3Prong : public AliAODRecoDecayHF {
   Double_t CtLc(AliAODVertex *vtx1) const {return AliAODRecoDecay::Ct(4122,vtx1);}
   Double_t InvMassLcpKpi() const {UInt_t pdg[3]={2212,321,211};return InvMass(3,pdg);}
   Double_t InvMassLcpiKp() const {UInt_t pdg[3]={211,321,2212};return InvMass(3,pdg);}
+  Double_t InvMassCdeuterondKpi() const {UInt_t pdg[3]={1000010020,321,211};return InvMass(3,pdg);}
+  Double_t InvMassCdeuteronpiKd() const {UInt_t pdg[3]={211,321,1000010020};return InvMass(3,pdg);}
   Bool_t   SelectLc(const Double_t* cuts,Int_t &okLcpKpi,Int_t &okLcpiKp) 
     const; // same variables as D+, for now
 

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.cxx
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.cxx
@@ -111,6 +111,7 @@ AliAnalysisTaskSEXicTopKpi::AliAnalysisTaskSEXicTopKpi():
   fhistMCSpectrumAccLc(0x0),
   fhistMCSpectrumAccSc(0x0),
   fhistMCSpectrumAccXic(0x0),
+  fhistMCSpectrumAccCdeuteron(0x0),
   fhSparseAnalysis(0x0),
   fhSparseAnalysisSigma(0x0),
   fhSparsePartReco(0x0),
@@ -150,7 +151,8 @@ AliAnalysisTaskSEXicTopKpi::AliAnalysisTaskSEXicTopKpi():
   fLcMassWindowForSigmaC(0.030),
   fSigmaCDeltaMassWindow(0.230),
   fSigmaCfromLcOnTheFly(kTRUE),
-  fCheckOnlyTrackEfficiency(kFALSE)
+  fCheckOnlyTrackEfficiency(kFALSE),
+  fIsCdeuteronAnalysis(kFALSE)
 {
   /// Default constructor
 
@@ -189,6 +191,7 @@ AliAnalysisTaskSEXicTopKpi::AliAnalysisTaskSEXicTopKpi(const char *name,AliRDHFC
   fhistMCSpectrumAccLc(0x0),
   fhistMCSpectrumAccSc(0x0),
   fhistMCSpectrumAccXic(0x0),
+  fhistMCSpectrumAccCdeuteron(0x0),
   fhSparseAnalysis(0x0),
   fhSparseAnalysisSigma(0x0),
   fhSparsePartReco(0x0),
@@ -227,7 +230,8 @@ AliAnalysisTaskSEXicTopKpi::AliAnalysisTaskSEXicTopKpi(const char *name,AliRDHFC
   fLcMassWindowForSigmaC(0.030),
   fSigmaCDeltaMassWindow(0.230),
   fSigmaCfromLcOnTheFly(kTRUE),
-  fCheckOnlyTrackEfficiency(kFALSE)
+  fCheckOnlyTrackEfficiency(kFALSE),
+  fIsCdeuteronAnalysis(kFALSE)
 {
   /// Default constructor
 
@@ -280,6 +284,7 @@ AliAnalysisTaskSEXicTopKpi::~AliAnalysisTaskSEXicTopKpi()
   if(fhistMCSpectrumAccLc)delete fhistMCSpectrumAccLc;
   if(fhistMCSpectrumAccSc)delete fhistMCSpectrumAccSc;
   if(fhistMCSpectrumAccXic)delete fhistMCSpectrumAccXic;
+  if(fhistMCSpectrumAccCdeuteron)delete fhistMCSpectrumAccCdeuteron;
   if(fhSparseAnalysis)delete fhSparseAnalysis;
   if(fhSparseAnalysisSigma)delete fhSparseAnalysisSigma;
   if(fhSparsePartReco)delete fhSparsePartReco; 
@@ -502,11 +507,14 @@ void AliAnalysisTaskSEXicTopKpi::UserCreateOutputObjects()
 
   
   //fhistInvMassCheck=new TH2F("fhistInvMassCheck","InvDistrCheck",1000,1.600,2.800,5,-0.5,4.5);
-  fhistInvMassCheck=new TH2F("fhistInvMassCheck","InvDistrCheck",1000,1.600,2.800,5,-0.5,15.5);
+  if(fIsCdeuteronAnalysis) fhistInvMassCheck=new TH2F("fhistInvMassCheck","InvDistrCheck",1000,2.600,3.800,1010,-0.5,1010);
+  else fhistInvMassCheck=new TH2F("fhistInvMassCheck","InvDistrCheck",1000,1.600,2.800,5,-0.5,15.5);
+  
   //  fhistCheckPIDTOFTPC=new TH3F("fhistCheckPIDTOFTPC","fhistCheckPIDTOFTPC",
   fhistMCSpectrumAccLc=new TH2F("fhistMCSpectrumAccLc","fhistMCSpectrumAccLc",250,0,50,15,-0.5,14.5); // 
   fhistMCSpectrumAccXic=new TH2F("fhistMCSpectrumAccXic","fhistMCSpectrumAccXic",250,0,50,15,-0.5,14.5); // 
   fhistMCSpectrumAccSc=new TH2F("fhistMCSpectrumAccSc","fhistMCSpectrumAccSc",250,0,50,15,-0.5,14.5); // 
+  fhistMCSpectrumAccCdeuteron=new TH2F("fhistMCSpectrumAccCdeuteron","fhistMCSpectrumAccCdeuteron",250,0,50,15,-0.5,14.5); // 
 
   // Sparse histos to study track reco & PID efficiency
   Int_t nbinsSparseTrack[9]={100,20,16,3,3,3,3,3,4};
@@ -529,9 +537,13 @@ void AliAnalysisTaskSEXicTopKpi::UserCreateOutputObjects()
   //if(!fFillTree)  fhSparseAnalysisSigma=new THnSparseF("fhSparseAnalysisSigma","fhSparseAnalysis;pt;deltamass;Lxy;nLxy;cosThetaPoint;normImpParXY;seleFlag;LcMass;CosThetaStarSoftPion",9,nbinsSparseSigma,lowEdgesSigma,upEdgesSigma);
   
   // adding PID cases study
-  Int_t nbinsSparse[8]={16,125,10,16,20,10,19,11};
+  Int_t nbinsSparse[8]={16,125,10,16,20,10,23,11};
   Double_t lowEdges[8]={0,2.15,0.,0,0.8,0,-0.5,-0.5};
-  Double_t upEdges[8]={16,2.65,0.0500,8,1.,5,18.5,10.5};
+  Double_t upEdges[8]={16,2.65,0.0500,8,1.,5,22.5,10.5};
+  if(fIsCdeuteronAnalysis) {
+    lowEdges[1] = 2.95;
+    upEdges[1] = 3.45;
+  }
   if(!fFillTree)  fhSparseAnalysis=new THnSparseF("fhSparseAnalysis","fhSparseAnalysis;pt;mass;Lxy;nLxy;cosThatPoint;normImpParXY;infoMC;PIDcase",8,nbinsSparse,lowEdges,upEdges);
   
   Int_t nbinsSparseSigma[11]={16,400,10,12,10,10,1,11,22,20,16};
@@ -598,6 +610,7 @@ void AliAnalysisTaskSEXicTopKpi::UserCreateOutputObjects()
   fOutput->Add(fhistMCSpectrumAccLc);
   fOutput->Add(fhistMCSpectrumAccSc);
   fOutput->Add(fhistMCSpectrumAccXic);
+  fOutput->Add(fhistMCSpectrumAccCdeuteron);
   if(fhSparseAnalysis)  fOutput->Add(fhSparseAnalysis);
   if(fhSparseAnalysisSigma)  fOutput->Add(fhSparseAnalysisSigma);
   if(fReadMC && !fFillTree)  fOutput->Add(fhSparsePartReco);
@@ -818,6 +831,12 @@ void AliAnalysisTaskSEXicTopKpi::UserExec(Option_t */*option*/)
 	  }	  
 	}
       }	
+      else if(TMath::Abs(pdg)==2010010020){
+        fhistMCSpectrumAccCdeuteron->Fill(mcpart->Pt(),0);// 
+        if(TMath::Abs(mcpart->Y())<0.5){
+          fhistMCSpectrumAccCdeuteron->Fill(mcpart->Pt(),kGenLimAcc);// Gen Level
+        }	  
+      }
     }
     
     // load MC header
@@ -827,6 +846,7 @@ void AliAnalysisTaskSEXicTopKpi::UserExec(Option_t */*option*/)
       return;
     }
   }
+  //return;
   
   //printf("VERTEX Z %f %f\n",vtx1->GetZ(),mcHeader->GetVtxZ());
 
@@ -943,6 +963,7 @@ void AliAnalysisTaskSEXicTopKpi::UserExec(Option_t */*option*/)
 
   
   Int_t pdgDg[3]={211,321,2212};
+  Int_t pdgCd[3]={211,321,1000010020};
   
   if(fDebug>=0 || !fSigmaCfromLcOnTheFly){   
      for(Int_t iLcFilt=0;iLcFilt<lcArray->GetEntriesFast();iLcFilt++){
@@ -1278,9 +1299,9 @@ void AliAnalysisTaskSEXicTopKpi::UserExec(Option_t */*option*/)
 	      else{printf("---> Lc prong label %d\n",prLabel);}
 	    }
 	  }
-	  else {
-	    partind=io3Prong->MatchToMC(4232,fmcArray,3,pdgDg);
-	    if(partind>=0)part=(AliAODMCParticle*)fmcArray->At(partind);
+    partind=io3Prong->MatchToMC(4232,fmcArray,3,pdgDg);
+	  if(partind>=0) {
+      part=(AliAODMCParticle*)fmcArray->At(partind);
 	    if(part){
 	      isTrueLambdaCorXic=3;
 	      Int_t pdgMother_checkQuark = AliVertexingHFUtils::CheckOrigin(fmcArray,part,kTRUE);
@@ -1305,6 +1326,29 @@ void AliAnalysisTaskSEXicTopKpi::UserExec(Option_t */*option*/)
 	      else{printf("---> Xic prong label %d\n",prLabel);}
 	    }
 	  }
+    // c deuteron
+    partind=io3Prong->MatchToMC(2010010020,fmcArray,3,pdgCd);
+	  if(partind>=0) {
+      part=(AliAODMCParticle*)fmcArray->At(partind);
+	    if(part){
+        // found c deuteron - label as 1000 for now
+        isTrueLambdaCorXic=1000;
+        // check daughters - label as 1001 if dKpi, 1002 if piKd
+        AliAODTrack* trk_prong = (AliAODTrack*) io3Prong->GetDaughter(0);
+        Int_t prLabel = TMath::Abs(trk_prong->GetLabel());
+        if(prLabel>0){
+          AliAODMCParticle* partMC_prong = (AliAODMCParticle*) fmcArray->At(prLabel);
+          Int_t pdg_prong = -1;
+          if(partMC_prong)  pdg_prong = TMath::Abs(partMC_prong->GetPdgCode());
+          if(pdg_prong==1000010020){      // 1st prong is a deuteron ---> dKpi
+            isTrueLambdaCorXic+=1;
+          }
+          else if(pdg_prong==211){  // 1st prong is a pion ---> piKd
+            isTrueLambdaCorXic+=2;
+          }
+        }
+      }
+    }
 	  //  static Int_t CheckLcpKpiDecay(TClonesArray* arrayMC, AliAODMCParticle *mcPart, Int_t* arrayDauLab);
 	  //  AliVertexingHFUtils::CheckLcpKpiDecay(fmcArray,)
 	  if(!part) {
@@ -1351,6 +1395,9 @@ void AliAnalysisTaskSEXicTopKpi::UserExec(Option_t */*option*/)
 	if(fReadMC && (isTrueLambdaCorXic==30 || isTrueLambdaCorXic==60 || isTrueLambdaCorXic==120 || isTrueLambdaCorXic==240 || isTrueLambdaCorXic==150 || isTrueLambdaCorXic==300)){
 	  fhistMCSpectrumAccXic->Fill(part->Pt(),kReco);
 	}
+  if(fReadMC && (isTrueLambdaCorXic==1001 || isTrueLambdaCorXic==1002)) { //c deuteron
+	  fhistMCSpectrumAccCdeuteron->Fill(part->Pt(),kReco);
+  }
 	if(fDebug>=0 || fCompute_dist12_dist23){
 	  FillDist12and23(io3Prong,aod->GetMagneticField());
 	}
@@ -1517,6 +1564,7 @@ void AliAnalysisTaskSEXicTopKpi::UserExec(Option_t */*option*/)
 	    if(isTrueLambdaCorXic==1 || isTrueLambdaCorXic==4 || isTrueLambdaCorXic==5)fhistMCSpectrumAccLc->Fill(part->Pt(),kRecoCuts);
 	    //if(isTrueLambdaCorXic==3)fhistMCSpectrumAccXic->Fill(part->Pt(),kRecoCuts);
 	    if(isTrueLambdaCorXic==3 || isTrueLambdaCorXic==12 || isTrueLambdaCorXic==15)fhistMCSpectrumAccXic->Fill(part->Pt(),kRecoCuts);
+      if(isTrueLambdaCorXic==1001 || isTrueLambdaCorXic==1002) fhistMCSpectrumAccCdeuteron->Fill(part->Pt(),kRecoCuts);
 	  }
 	}
       
@@ -1549,12 +1597,13 @@ void AliAnalysisTaskSEXicTopKpi::UserExec(Option_t */*option*/)
 
 	if(massHypothesis==1 || massHypothesis ==3) {
 	  mass1=io3Prong->InvMassLcpKpi();
+	  if(fIsCdeuteronAnalysis) mass1=io3Prong->InvMassCdeuterondKpi();
 	  fhistInvMassCheck->Fill(mass1,isTrueLambdaCorXic);
 	  point[1]=mass1;
 	  point[7]=0;
 	  // this two filling fill the sparse with PID in cut object always
 	  if(fhSparseAnalysis && !fExplore_PIDstdCuts){
-      if(fReadMC && (converted_isTrueLcXic==2 || converted_isTrueLcXic==6 || converted_isTrueLcXic==8 || converted_isTrueLcXic==11 || converted_isTrueLcXic==15 || converted_isTrueLcXic==17))  fhSparseAnalysis->Fill(point);
+      if(fReadMC && (converted_isTrueLcXic==2 || converted_isTrueLcXic==6 || converted_isTrueLcXic==8 || converted_isTrueLcXic==11 || converted_isTrueLcXic==15 || converted_isTrueLcXic==17 || converted_isTrueLcXic==21))  fhSparseAnalysis->Fill(point);
       if(!fReadMC)  fhSparseAnalysis->Fill(point);
     }
 	  if(fExplore_PIDstdCuts){
@@ -1571,12 +1620,13 @@ void AliAnalysisTaskSEXicTopKpi::UserExec(Option_t */*option*/)
 	}
 	if(massHypothesis==2 || massHypothesis ==3){
 	  mass2=io3Prong->InvMassLcpiKp();
+	  if(fIsCdeuteronAnalysis) mass2=io3Prong->InvMassCdeuteronpiKd();
 	  fhistInvMassCheck->Fill(mass2,isTrueLambdaCorXic);
 	  point[1]=mass2;
 	  point[7]=0;
 	  // this two filling fill the sparse with PID in cut object always
 	  if(fhSparseAnalysis && !fExplore_PIDstdCuts){
-      if(fReadMC && (converted_isTrueLcXic==3 || converted_isTrueLcXic==7 || converted_isTrueLcXic==9 || converted_isTrueLcXic==12 || converted_isTrueLcXic==16 || converted_isTrueLcXic==18))  fhSparseAnalysis->Fill(point);
+      if(fReadMC && (converted_isTrueLcXic==3 || converted_isTrueLcXic==7 || converted_isTrueLcXic==9 || converted_isTrueLcXic==12 || converted_isTrueLcXic==16 || converted_isTrueLcXic==18 || converted_isTrueLcXic==22))  fhSparseAnalysis->Fill(point);
       if(!fReadMC)  fhSparseAnalysis->Fill(point);
     }
 	  if(fExplore_PIDstdCuts){
@@ -2020,7 +2070,7 @@ void AliAnalysisTaskSEXicTopKpi::IsSelectedPID(AliAODTrack *track,Int_t &iSelPio
   
   if (status == AliPIDResponse::kDetPidOk){
     if(iSelProtonCuts>=0){
-      Double_t nsigma=fPidResponse->NumberOfSigmasTOF(track,AliPID::kProton);
+      Double_t nsigma=fPidResponse->NumberOfSigmasTOF(track,fIsCdeuteronAnalysis?AliPID::kDeuteron:AliPID::kProton);
       if(fillHistos)fnSigmaPIDtofProton->Fill(trpt,nsigma);
       //      Printf("nsigma Proton TOF: %f",nsigma);
       if(-3.<=nsigma&&nsigma<=3)iSelProton++;
@@ -2052,7 +2102,7 @@ void AliAnalysisTaskSEXicTopKpi::IsSelectedPID(AliAODTrack *track,Int_t &iSelPio
   status = fPidResponse->CheckPIDStatus(AliPIDResponse::kTPC,track);
   if (status == AliPIDResponse::kDetPidOk){
     if(iSelProtonCuts>=0){
-      Double_t nsigma=fPidResponse->NumberOfSigmasTPC(track,AliPID::kProton);
+      Double_t nsigma=fPidResponse->NumberOfSigmasTPC(track,fIsCdeuteronAnalysis?AliPID::kDeuteron:AliPID::kProton);
       if(fillHistos)fnSigmaPIDtpcProton->Fill(trpt,nsigma);
       //      Printf("nsigma Proton TPC: %f",nsigma);
       if(-3.<=nsigma&&nsigma<=3)iSelProton++;
@@ -2230,6 +2280,10 @@ void AliAnalysisTaskSEXicTopKpi::FillTree(AliAODRecoDecayHF3Prong *cand,Int_t ma
     // modified
   Double_t mass_pKpi = cand->InvMassLcpKpi();
   Double_t mass_piKp = cand->InvMassLcpiKp();
+  if(fIsCdeuteronAnalysis) {
+    mass_pKpi = cand->InvMassCdeuterondKpi();
+    mass_piKp = cand->InvMassCdeuteronpiKd();
+  }
 
   varPointer[19] = mass_pKpi;
   varPointer[20] = mass_piKp;
@@ -2576,7 +2630,24 @@ Int_t AliAnalysisTaskSEXicTopKpi::ConvertXicMCinfo(Int_t infoMC){
   case 300:
     returnValue = 18;
     break;
+
+  ////////////////////////////////////////////////////////
+  //  C-deuteron case (task version November 11th, 2019)//
+  ////////////////////////////////////////////////////////
+  //    - 1000:   matched c-deuteron, dKpi         ---> 20
+  //    - 1001:   matched c-deuteron, dKpi         ---> 21
+  //    - 1002:   matched c-deuteron, dKpi         ---> 22
+  case 1000:
+    returnValue = 20;
+    break;
+  case 1001:
+    returnValue = 21;
+    break;
+  case 1002:
+    returnValue = 22;
+    break;
   }
+
 
   return returnValue;
 }

--- a/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.h
+++ b/PWGHF/vertexingHF/AliAnalysisTaskSEXicTopKpi.h
@@ -109,6 +109,7 @@ class AliAnalysisTaskSEXicTopKpi : public AliAnalysisTaskSE
   void SetSigmaCDeltaMassWindow(Double_t maxDeltaM){fSigmaCDeltaMassWindow=maxDeltaM;}
   void SetOnTheFlyLcCandidatesForSigmaC(Bool_t onthefly){fSigmaCfromLcOnTheFly=onthefly;}
   void SetFillOnlyTrackSparse(Bool_t fillonlysparse){fCheckOnlyTrackEfficiency=fillonlysparse;}
+  void SetIsCdeuteronAnalysis(Bool_t iscd){fIsCdeuteronAnalysis=iscd;}
 /*   void SetDoMCAcceptanceHistos(Bool_t doMCAcc=kTRUE){fStepMCAcc=doMCAcc;} */
 /*   void SetCutOnDistr(Bool_t cutondistr=kFALSE){fCutOnDistr=cutondistr;} */
 /*   void SetUsePid4Distr(Bool_t usepid=kTRUE){fUsePid4Distr=usepid;} */
@@ -195,6 +196,7 @@ class AliAnalysisTaskSEXicTopKpi : public AliAnalysisTaskSE
   TH2F *fhistMCSpectrumAccLc;//! hist with MC spectrum of cand in acceptance
   TH2F *fhistMCSpectrumAccSc;//! hist with MC spectrum of cand in acceptance
   TH2F *fhistMCSpectrumAccXic;//! hist with MC spectrum of cand in acceptance
+  TH2F *fhistMCSpectrumAccCdeuteron;//! hist with MC spectrum of cand in acceptance
   THnSparseF* fhSparseAnalysis;//! sparse for analysis
   THnSparseF* fhSparseAnalysisSigma;//! sparse for analysis of SigmaC (with deltaM)
   THnSparseF* fhSparsePartReco;//! sparse for single track efficiency (reco spectra)
@@ -284,6 +286,7 @@ class AliAnalysisTaskSEXicTopKpi : public AliAnalysisTaskSE
   Double_t fSigmaCDeltaMassWindow; /// mass window for accetping sigma_C candidate
   Bool_t fSigmaCfromLcOnTheFly; /// switch to use on-the-fly Lc or filtered Lc from delta file
   Bool_t fCheckOnlyTrackEfficiency;// flag for filling only the single-track sparse and return
+  Bool_t fIsCdeuteronAnalysis;// flag for doing the c deuteron analysis (inv mass)
   /// \cond CLASSIMP
   ClassDef(AliAnalysisTaskSEXicTopKpi,5); /// AliAnalysisTaskSE for Xic->pKpi
   /// \endcond

--- a/PWGHF/vertexingHF/AliRDHFCutsCdeuterontodKpi.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCutsCdeuterontodKpi.cxx
@@ -1,0 +1,530 @@
+/**************************************************************************
+ * Copyright(c) 1998-2010, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: The ALICE Off-line Project.                                    *
+ * Contributors are mentioned in the code where appropriate.              *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+/* $Id$ */
+
+/////////////////////////////////////////////////////////////
+// \class for cuts on reconstructed c-deuteron -> dKpi
+// \First implementation by copying the AliRDHFCutsXicTopKpi class
+// \inheriting from this class
+// \author Author: J. Norman (jaime.norman@cern.ch)
+/////////////////////////////////////////////////////////////
+
+#include <TDatabasePDG.h>
+#include <Riostream.h>
+#include <AliAnalysisManager.h>
+#include <AliInputEventHandler.h>
+#include <AliPIDResponse.h>
+
+#include "AliRDHFCutsCdeuterontodKpi.h"
+#include "AliRDHFCutsXictopKpi.h"
+#include "AliAODRecoDecayHF3Prong.h"
+#include "AliRDHFCuts.h"
+#include "AliAODTrack.h"
+#include "AliESDtrack.h"
+#include "AliKFParticle.h"
+#include "AliESDVertex.h"
+#include "AliVertexerTracks.h"
+
+using std::cout;
+using std::endl;
+
+/// \cond CLASSIMP
+ClassImp(AliRDHFCutsCdeuterontodKpi);
+/// \endcond
+
+//--------------------------------------------------------------------------
+AliRDHFCutsCdeuterontodKpi::AliRDHFCutsCdeuterontodKpi(const char* name) : 
+AliRDHFCutsXictopKpi(name)
+{
+  //
+  // Default Constructor
+  //
+//  Int_t nvars=13;
+//  SetNVars(nvars);
+//  TString varNames[13]={"inv. mass [GeV]",
+//			"pTK [GeV/c]",
+//			"pTP [GeV/c]",
+//			"d0K [cm]   lower limit!",
+//			"d0Pi [cm]  lower limit!",
+//			"dist12 (cm)",
+//			"sigmavert (cm)",
+//			"dist prim-sec (cm)",
+//			"pM=Max{pT1,pT2,pT3} (GeV/c)",
+//			"cosThetaPoint",
+//			"Sum d0^2 (cm^2)",
+//			"dca cut (cm)",
+//			"cut on pTpion [GeV/c]"};
+//  Bool_t isUpperCut[13]={kTRUE,
+//			 kFALSE,
+//			 kFALSE,
+//			 kFALSE,
+//			 kFALSE,
+//			 kFALSE,
+//			 kTRUE,
+//			 kFALSE,
+//			 kFALSE,
+//			 kFALSE,
+//			 kFALSE,
+//			 kTRUE,
+//			 kFALSE
+//			 };
+//  SetVarNames(nvars,varNames,isUpperCut);
+//  Bool_t forOpt[13]={kFALSE,
+//		     kTRUE,
+//		     kTRUE,
+//		     kFALSE,
+//		     kFALSE,
+//		     kFALSE,
+//		     kFALSE,
+//		     kTRUE,
+//		     kFALSE,
+//		     kFALSE,
+//		     kFALSE,
+//		     kFALSE,
+//		     kTRUE};
+//  SetVarsForOpt(4,forOpt);
+//  Float_t limits[2]={0,999999999.};
+//  SetPtBins(2,limits);
+//  for (Int_t ispecies=0;ispecies<AliPID::kSPECIES;++ispecies)
+//      fPIDThreshold[ispecies]=0.;
+}
+//--------------------------------------------------------------------------
+AliRDHFCutsCdeuterontodKpi::AliRDHFCutsCdeuterontodKpi(const AliRDHFCutsCdeuterontodKpi &source) :
+  AliRDHFCutsXictopKpi(source)
+{
+  //
+  // Copy constructor
+  //
+//  if (source.fPidObjprot) fPidObjprot = new AliAODPidHF(*(source.fPidObjprot));
+//  else fPidObjprot = new AliAODPidHF();
+//  if (source.fPidObjpion) fPidObjpion = new AliAODPidHF(*(source.fPidObjpion));
+//  else fPidObjpion = new AliAODPidHF();
+//  memcpy(fPIDThreshold,source.fPIDThreshold,AliPID::kSPECIES*sizeof(Double_t));
+}
+//--------------------------------------------------------------------------
+AliRDHFCutsCdeuterontodKpi &AliRDHFCutsCdeuterontodKpi::operator=(const AliRDHFCutsCdeuterontodKpi &source)
+{
+  //
+  // assignment operator
+  //
+  if(this != &source) {
+    AliRDHFCuts::operator=(source);
+  }
+    
+  return *this;
+}
+//---------------------------------------------------------------------------
+AliRDHFCutsCdeuterontodKpi::~AliRDHFCutsCdeuterontodKpi() {
+ //
+ //  // Default Destructor
+ //   
+
+}
+
+//---------------------------------------------------------------------------
+void AliRDHFCutsCdeuterontodKpi::GetCutVarsForOpt(AliAODRecoDecayHF *d,Float_t *vars,Int_t nvars,Int_t *pdgdaughters, AliAODEvent *aod) {
+  // 
+  // Fills in vars the values of the variables 
+  //
+
+  if(nvars!=fnVarsForOpt) {
+    printf("AliRDHFCutsCdeuterontodKpi::GetCutsVarsForOpt: wrong number of variables\n");
+    return;
+  }
+
+  AliAODRecoDecayHF3Prong *dd = (AliAODRecoDecayHF3Prong*)d;
+
+  Int_t iter=-1;
+  if(fVarsForOpt[0]){
+    iter++;
+    vars[iter]=dd->InvMassCdeuterondKpi();
+  }
+  if(fVarsForOpt[1]){
+    iter++;
+    for(Int_t iprong=0;iprong<3;iprong++){
+      if(TMath::Abs(pdgdaughters[iprong])==321) {
+	vars[iter]=dd->PtProng(iprong);
+      }
+    }
+  }
+  if(fVarsForOpt[2]){
+    iter++;
+    for(Int_t iprong=0;iprong<3;iprong++){
+      if(TMath::Abs(pdgdaughters[iprong])==1000010020) {
+	vars[iter]=dd->PtProng(iprong);
+      }
+    }
+  }
+  if(fVarsForOpt[3]){
+    iter++;
+    for(Int_t iprong=0;iprong<3;iprong++){
+      if(TMath::Abs(pdgdaughters[iprong])==1000010020) {
+	vars[iter]=dd->Getd0Prong(iprong);
+      }
+    }
+  }
+  if(fVarsForOpt[4]){
+    iter++;
+    for(Int_t iprong=0;iprong<3;iprong++){
+      if(TMath::Abs(pdgdaughters[iprong])==211) {
+	vars[iter]=dd->Getd0Prong(iprong);
+      }
+    }
+  }
+  if(fVarsForOpt[5]){
+    iter++;
+    vars[iter]=dd->GetDist12toPrim();
+  }
+  if(fVarsForOpt[6]){
+    iter++;
+    vars[iter]=dd->GetSigmaVert(aod);
+  }
+  if(fVarsForOpt[7]){
+    iter++;
+    vars[iter] = dd->DecayLength();
+  }
+  if(fVarsForOpt[8]){
+    iter++;
+    Float_t ptmax=0;
+    for(Int_t i=0;i<3;i++){
+      if(dd->PtProng(i)>ptmax)ptmax=dd->PtProng(i);
+    }
+    vars[iter]=ptmax;
+  }
+  if(fVarsForOpt[9]){
+    iter++;
+    vars[iter]=dd->CosPointingAngle();
+  }
+  if(fVarsForOpt[10]){
+    iter++;
+    vars[iter]=dd->Getd0Prong(0)*dd->Getd0Prong(0)+dd->Getd0Prong(1)*dd->Getd0Prong(1)+dd->Getd0Prong(2)*dd->Getd0Prong(2);
+  }
+  if(fVarsForOpt[11]){
+    iter++;
+    vars[iter]=dd->GetDCA();
+  }
+  if(fVarsForOpt[12]){
+    iter++;
+    for(Int_t iprong=0;iprong<3;iprong++){
+      if(TMath::Abs(pdgdaughters[iprong])==211) {
+	vars[iter]=dd->PtProng(iprong);
+      }
+    }
+  }
+
+  return;
+}
+//---------------------------------------------------------------------------
+Int_t AliRDHFCutsCdeuterontodKpi::IsSelected(TObject* obj,Int_t selectionLevel,AliAODEvent *aod) {
+  //
+  // Apply selection
+  //
+
+  //Printf("---- WE ARE IN THE C-DEUTERON CLASS - WELL DONE ---");
+  if(!fCutsRD){
+    AliError("Cut matrice not inizialized. Exit...\n");
+    return 0;
+  }
+  //PrintAll();
+  AliAODRecoDecayHF3Prong* d=(AliAODRecoDecayHF3Prong*)obj;
+
+  if(!d){
+    AliError("AliAODRecoDecayHF3Prong null \n");
+    return 0;
+  }
+
+  //
+  // NB: pdg code of Lc... shall we change it ???
+  //
+  if(fKeepSignalMC) if(IsSignalMC(d,aod,4122)) return 3;
+
+  Int_t returnvalue=3;
+  Int_t returnvaluePID=3;
+
+  if(d->Pt()<fMinPtCand) return 0;
+  if(d->Pt()>fMaxPtCand) return 0;
+  //Printf("1: Pt cut passed");
+
+  if(fUseTrackSelectionWithFilterBits && d->HasBadDaughters()) return 0;
+  //Printf("2: track selection filter bit and bad daughter passed");
+
+
+  // selection on daughter tracks 
+  if(selectionLevel==AliRDHFCuts::kAll || 
+     selectionLevel==AliRDHFCuts::kTracks) {
+    if(!AreDaughtersSelected(d,aod)) return 0;
+  }
+  //Printf("3: selection on daughter tracks passed");
+
+
+  // PID selection
+  if(selectionLevel==AliRDHFCuts::kAll ||
+     selectionLevel==AliRDHFCuts::kCandidate|| 
+     selectionLevel==AliRDHFCuts::kPID) {
+    switch (fPIDStrategy) {
+      Printf("check PID strategy = %i",fPIDStrategy);
+    case kNSigma:
+      returnvaluePID = IsSelectedPID(d);
+      break;
+    case kNSigmaMin:
+      returnvaluePID = IsSelectedPID(d);
+      break;
+    case kNSigmaPbPb:
+      returnvaluePID = IsSelectedNSigmaPbPb(d);
+      break;
+    case kCombined:
+      returnvaluePID = IsSelectedCombinedPID(d);
+      break;
+    case kCombinedSoft:
+      returnvaluePID = IsSelectedCombinedPIDSoft(d);
+      break;
+    case kNSigmaStrong:
+      returnvaluePID = IsSelectedPIDStrong(d);
+      break;
+    case kCombinedpPb:
+      returnvaluePID = IsSelectedCombinedPIDpPb(d);
+      break;
+    case kCombinedpPb2:
+      returnvaluePID = IsSelectedCombinedPIDpPb2(d);
+      break;
+    case kCombinedProb:
+      returnvaluePID = IsSelectedCombinedPIDProb(d);
+      break;
+    }
+    fIsSelectedPID=returnvaluePID;
+    //Printf("is selected PID = %i",fIsSelectedPID);
+  }
+  //  if(fUsePID || selectionLevel==AliRDHFCuts::kPID) returnvaluePID = IsSelectedCombinedPID(d);   // to test!!
+  if(returnvaluePID==0) return 0;
+  //Printf("4: passed PID selection");
+
+
+
+
+  // selection on candidate
+  if(selectionLevel==AliRDHFCuts::kAll || 
+     selectionLevel==AliRDHFCuts::kCandidate) {
+
+    Double_t pt=d->Pt();
+    //Printf("\tcandidate selection");
+    //Printf("\tpt = %f",pt);
+    
+    Int_t ptbin=PtBin(pt);
+    
+    Double_t mCdeuterondKpi=0.,mCdeuteronpiKd=0.;
+    Int_t okCdeuterondKpi=1,okCdeuteronpiKd=1;
+
+    Double_t mLcPDG = 3.226;
+
+    mCdeuterondKpi=d->InvMassCdeuterondKpi();
+    mCdeuteronpiKd=d->InvMassCdeuteronpiKd();
+    //Printf("\tmass c deuteron dKpi = %f",mCdeuterondKpi);
+    //Printf("\tmass c deuteron piKd = %f",mCdeuteronpiKd);
+
+    // Comparison with Lc mass from PDG.
+    // From the cutobject, only the upper limit is set.
+    // The lower limit is hardocoded, in order to discard candidates with 
+    // mass lower than the Lc.
+    if(TMath::Abs(mCdeuterondKpi-mLcPDG) > fCutsRD[GetGlobalIndex(0,ptbin)]) okCdeuterondKpi = 0;
+    if(TMath::Abs(mCdeuteronpiKd-mLcPDG) > fCutsRD[GetGlobalIndex(0,ptbin)]) okCdeuteronpiKd = 0;
+    if(!okCdeuterondKpi && !okCdeuteronpiKd) return 0;
+    //Printf("5: passed invariant mass selection");
+
+  switch (fCutsStrategy) {
+
+    case kStandard:
+    if(TMath::Abs(d->PtProng(1)) < fCutsRD[GetGlobalIndex(1,ptbin)] || TMath::Abs(d->Getd0Prong(1))<fCutsRD[GetGlobalIndex(3,ptbin)]) return 0;//Kaon
+    if(d->Pt()>=3. && d->PProng(1)<0.55) return 0;
+    if(fUseSpecialCut) {
+      if(TMath::Abs(d->PtProng(0)) < TMath::Abs(d->PtProng(2)) )okCdeuterondKpi=0;
+      if(TMath::Abs(d->PtProng(2)) < TMath::Abs(d->PtProng(0)) )okCdeuteronpiKd=0;
+    }
+    if((TMath::Abs(d->PtProng(0)) < fCutsRD[GetGlobalIndex(2,ptbin)]) || (TMath::Abs(d->PtProng(2)) < fCutsRD[GetGlobalIndex(12,ptbin)])) okCdeuterondKpi=0;
+    if((TMath::Abs(d->PtProng(2)) < fCutsRD[GetGlobalIndex(2,ptbin)]) || (TMath::Abs(d->PtProng(0)) < fCutsRD[GetGlobalIndex(12,ptbin)]))okCdeuteronpiKd=0;
+    if(!okCdeuterondKpi && !okCdeuteronpiKd) return 0;
+    //2track cuts
+      // postponed
+    //if(d->GetDist12toPrim()<fCutsRD[GetGlobalIndex(5,ptbin)]|| d->GetDist23toPrim()<fCutsRD[GetGlobalIndex(5,ptbin)]) return 0;
+    //if(d->GetDist12toPrim()>0.5) return 0;
+    //if(d->GetDist23toPrim()>0.5) return 0;
+    if(fUseImpParProdCorrCut){
+      if(d->Getd0Prong(0)*d->Getd0Prong(1)<0. && d->Getd0Prong(2)*d->Getd0Prong(1)<0.) return 0;
+    }
+    //sec vert
+    if(d->DecayLength()<fCutsRD[GetGlobalIndex(7,ptbin)]) return 0;
+    if(d->DecayLength()>0.5) return 0;
+
+  //  Double_t sumd0s=d->Getd0Prong(0)*d->Getd0Prong(0)+d->Getd0Prong(1)*d->Getd0Prong(1)+d->Getd0Prong(2)*d->Getd0Prong(2);
+  //  if(sumd0s<fCutsRD[GetGlobalIndex(10,ptbin)]) return 0;
+    if((d->Getd0Prong(0)*d->Getd0Prong(0)+d->Getd0Prong(1)*d->Getd0Prong(1)+d->Getd0Prong(2)*d->Getd0Prong(2))<fCutsRD[GetGlobalIndex(10,ptbin)]) return 0;
+    
+    if(TMath::Abs(d->PtProng(0))<fCutsRD[GetGlobalIndex(8,ptbin)] && TMath::Abs(d->PtProng(1))<fCutsRD[GetGlobalIndex(8,ptbin)] && TMath::Abs(d->PtProng(2))<fCutsRD[GetGlobalIndex(8,ptbin)]) return 0;
+    if(d->CosPointingAngle()< fCutsRD[GetGlobalIndex(9,ptbin)]) return 0;
+    if(d->GetSigmaVert(aod)>fCutsRD[GetGlobalIndex(6,ptbin)]) return 0;
+    
+    //DCA
+    for(Int_t i=0;i<3;i++) if(d->GetDCA(i)>fCutsRD[GetGlobalIndex(11,ptbin)]) return 0;
+
+    // dist12 and dist23
+    if(d->GetDist12toPrim()<fCutsRD[GetGlobalIndex(5,ptbin)]|| d->GetDist23toPrim()<fCutsRD[GetGlobalIndex(5,ptbin)]) return 0;
+    if(d->GetDist12toPrim()>0.5) return 0;
+    if(d->GetDist23toPrim()>0.5) return 0;
+
+    break;
+
+
+   case kKF:
+    Int_t pdgs[3]={0,321,0};
+    Bool_t constraint=kFALSE;
+    if(fCutsRD[GetGlobalIndex(1,ptbin)]>0.) constraint=kTRUE;
+    Double_t field=aod->GetMagneticField();
+    if (returnvaluePID==1 || returnvaluePID==3){
+
+      pdgs[0]=2122;pdgs[2]=211;
+      AliKFParticle *lc1=ReconstructKF(d,pdgs,field,constraint);
+      if(!lc1){
+	okCdeuterondKpi=0;
+      }else{
+	if(lc1->GetChi2()/lc1->GetNDF()>fCutsRD[GetGlobalIndex(2,ptbin)]) okCdeuterondKpi=0;
+      }
+    } else if(returnvaluePID>=2){
+
+      pdgs[0]=211;pdgs[2]=1000010020;
+      AliKFParticle *lc2=ReconstructKF(d,pdgs,field,constraint);
+      if(!lc2){ 
+	okCdeuteronpiKd=0;
+      }else{
+	if(lc2->GetChi2()/lc2->GetNDF()>fCutsRD[GetGlobalIndex(2,ptbin)])okCdeuteronpiKd=0; 
+      }
+    }
+    break;
+
+   }
+
+    if(okCdeuterondKpi) returnvalue=1; //cuts passed as Xic->pKpi
+    if(okCdeuteronpiKd) returnvalue=2; //cuts passed as Xic->piKp
+    if(okCdeuterondKpi && okCdeuteronpiKd) returnvalue=3; //cuts passed as both pKpi and piKp
+   
+  }
+
+
+  Int_t returnvalueTot=CombinePIDCuts(returnvalue,returnvaluePID);
+  //Printf("\tcuts return value = %i",returnvalue);
+  //Printf("\tPID  return value = %i",returnvaluePID);
+  //Printf("\tfinal cuts return value = %i",returnvalueTot);
+  return returnvalueTot;
+}
+
+
+
+Int_t AliRDHFCutsCdeuterontodKpi::IsSelectedPID(AliAODRecoDecayHF* obj) {
+
+  //Printf(" -- IN THE PID SELECTION FUNCTION - SICK");
+
+    if(!fUsePID || !obj) return 3;
+    Int_t okLcpKpi=0,okLcpiKp=0;
+    Int_t returnvalue=0;
+    Bool_t isMC=fPidHF->GetMC();
+    Bool_t ispion0=kTRUE,ispion2=kTRUE;
+    Bool_t isdeuteron0=kFALSE,isdeuteron2=kFALSE;
+    Bool_t iskaon1=kFALSE;
+    if(isMC) {
+     fPidObjprot->SetMC(kTRUE);
+     fPidObjpion->SetMC(kTRUE);
+    }
+
+   if(fPidObjprot->GetPidResponse()==0x0){
+      AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+      AliInputEventHandler *inputHandler=(AliInputEventHandler*)mgr->GetInputEventHandler();
+      AliPIDResponse *pidResp=inputHandler->GetPIDResponse();
+      fPidObjprot->SetPidResponse(pidResp);
+    }
+    if(fPidObjpion->GetPidResponse()==0x0){
+      AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+      AliInputEventHandler *inputHandler=(AliInputEventHandler*)mgr->GetInputEventHandler();
+      AliPIDResponse *pidResp=inputHandler->GetPIDResponse();
+      fPidObjpion->SetPidResponse(pidResp);
+    }
+    if(fPidHF->GetPidResponse()==0x0){
+      AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+      AliInputEventHandler *inputHandler=(AliInputEventHandler*)mgr->GetInputEventHandler();
+      AliPIDResponse *pidResp=inputHandler->GetPIDResponse();
+      fPidHF->SetPidResponse(pidResp);
+    }
+
+    for(Int_t i=0;i<3;i++){
+     AliAODTrack *track=(AliAODTrack*)obj->GetDaughter(i);
+     if(!track) return 0;
+     if(i==1) {
+      // identify kaon
+      //if(track->P()<0.55){
+      // fPidHF->SetTOF(kFALSE);
+      // fPidHF->SetTOFdecide(kFALSE);
+      //}
+      Int_t isKaon=0;
+      isKaon=fPIDStrategy==kNSigmaMin?fPidHF->MatchTPCTOFMin(track,3):fPidHF->MakeRawPid(track,3);
+      if(isKaon>=1) iskaon1=kTRUE;
+    //  if(track->P()<0.55){
+    //   fPidHF->SetTOF(kTRUE);
+    //   fPidHF->SetTOFdecide(kTRUE);
+    //  }
+
+
+      if(isKaon>=1) iskaon1=kTRUE;
+
+      if(!iskaon1) return 0;
+
+     }else{
+     //pion or deuteron
+    //if(track->P()<1.){
+    //  fPidObjprot->SetTOF(kFALSE);
+    //  fPidObjprot->SetTOFdecide(kFALSE);
+    // }
+
+     Int_t isDeuteron=0;
+     isDeuteron=fPIDStrategy==kNSigmaMin?fPidObjprot->MatchTPCTOFMin(track,5):fPidObjprot->MakeRawPid(track,5);
+     Int_t isPion=0;
+     isPion=fPIDStrategy==kNSigmaMin?fPidObjpion->MatchTPCTOFMin(track,2):fPidObjpion->MakeRawPid(track,2);
+
+    // if(track->P()<1.){
+    //  fPidObjprot->SetTOF(kTRUE);
+    //  fPidObjprot->SetTOFdecide(kTRUE);
+    // }
+
+
+     if(i==0) {
+      if(isPion<0) ispion0=kFALSE;
+      if(isDeuteron>=1) isdeuteron0=kTRUE;
+
+     }
+      if(!ispion0 && !isdeuteron0) return 0;
+     if(i==2) {
+      if(isPion<0) ispion2=kFALSE;
+      if(isDeuteron>=1) isdeuteron2=kTRUE;
+     }
+
+    }
+   }
+
+    //Printf("isdeuteron0 = %i, isdeuteron2 = %i, ispion0 = %i, iskaon2 = %i", isdeuteron0, isdeuteron2, ispion0, ispion2);
+    if(ispion2 && isdeuteron0 && iskaon1) okLcpKpi=1;
+    if(ispion0 && isdeuteron2 && iskaon1) okLcpiKp=1;
+    if(okLcpKpi) returnvalue=1; //cuts passed as Lc->pKpi
+    if(okLcpiKp) returnvalue=2; //cuts passed as Lc->piKp
+    if(okLcpKpi && okLcpiKp) returnvalue=3; //cuts passed as both pKpi and piKp
+
+ return returnvalue;
+}

--- a/PWGHF/vertexingHF/AliRDHFCutsCdeuterontodKpi.h
+++ b/PWGHF/vertexingHF/AliRDHFCutsCdeuterontodKpi.h
@@ -1,0 +1,59 @@
+#ifndef ALIRDHFCUTSCDEUTERONTODKPI_H
+#define ALIRDHFCUTSCDEUTERONTODKPI_H
+/* Copyright(c) 1998-2010, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
+
+/* $Id$ */ 
+
+//***********************************************************
+/// \class Class AliRDHFCutsCdeuterontodKpi
+/// \brief class for cuts on AOD reconstructed c-deuteron -> dKpi
+/// \First implementation by copying the AliRDHFCutsXicTopKpi class
+/// \inheriting from this class
+/// \author Author: J. Norman (jaime.norman@cern.ch)
+//***********************************************************
+
+#include "AliRDHFCuts.h"
+#include "AliAODPidHF.h"
+#include "AliAODRecoDecayHF3Prong.h"
+#include "AliRDHFCutsXictopKpi.h"
+//#include "AliVertexerTracks.h"
+
+class AliRDHFCutsCdeuterontodKpi : public AliRDHFCutsXictopKpi
+{
+ public:
+
+  AliRDHFCutsCdeuterontodKpi(const char* name="CutsLctopKpi");
+  
+  virtual ~AliRDHFCutsCdeuterontodKpi();
+
+  AliRDHFCutsCdeuterontodKpi(const AliRDHFCutsCdeuterontodKpi& source);
+  AliRDHFCutsCdeuterontodKpi& operator=(const AliRDHFCutsCdeuterontodKpi& source); 
+
+  // c deuteron specific
+ 
+  using AliRDHFCuts::GetCutVarsForOpt;
+  virtual void GetCutVarsForOpt(AliAODRecoDecayHF *d,Float_t *vars,Int_t nvars,Int_t *pdgdaughters){
+    return GetCutVarsForOpt(d,vars,nvars,pdgdaughters,0x0);
+  }
+  virtual void GetCutVarsForOpt(AliAODRecoDecayHF *d,Float_t *vars,Int_t nvars,Int_t *pdgdaughters,AliAODEvent *aod);
+
+
+  using AliRDHFCuts::IsSelected;
+  virtual Int_t IsSelected(TObject* obj,Int_t selectionLevel)
+                           {return IsSelected(obj,selectionLevel,0);}
+  virtual Int_t IsSelected(TObject* obj,Int_t selectionLevel,AliAODEvent *aod);
+
+  Int_t IsSelectedPID(AliAODRecoDecayHF* obj);
+
+ protected:
+
+
+private:
+
+  /// \cond CLASSIMP    
+  ClassDef(AliRDHFCutsCdeuterontodKpi,1);  /// class for cuts 
+  /// \endcond
+};
+
+#endif

--- a/PWGHF/vertexingHF/AliRDHFCutsXictopKpi.h
+++ b/PWGHF/vertexingHF/AliRDHFCutsXictopKpi.h
@@ -215,11 +215,12 @@ class AliRDHFCutsXictopKpi : public AliRDHFCuts
   //-------------------------
 
 
-private:
   EPIDStrategy fPIDStrategy;                /// PIS strategy (nsigma, combined)
   Double_t fPIDThreshold[AliPID::kSPECIES]; /// PID threshold for each species
   ECutsStrategy fCutsStrategy;              /// cut strategy (standard or KF)
   Bool_t fUseSpecialCut;
+
+private:
 
   /// \cond CLASSIMP    
   ClassDef(AliRDHFCutsXictopKpi,1);  /// class for cuts on AOD reconstructed Xic->pKpi

--- a/PWGHF/vertexingHF/CMakeLists.txt
+++ b/PWGHF/vertexingHF/CMakeLists.txt
@@ -159,6 +159,7 @@ set(SRCS
   AliAnalysisTaskSEDmesonPIDSysProp.cxx
   AliAnalysisTaskSEXicTopKpi.cxx
   AliRDHFCutsXictopKpi.cxx
+  AliRDHFCutsCdeuterontodKpi.cxx
    )
 
 # Sources for ROOT6 only - alphabetical order

--- a/PWGHF/vertexingHF/PWGHFvertexingHFLinkDef.h
+++ b/PWGHF/vertexingHF/PWGHFvertexingHFLinkDef.h
@@ -124,6 +124,7 @@
 #pragma link C++ class AliAnalysisTaskSELbtoLcpi4+;
 #pragma link C++ class AliAnalysisTaskSEXicTopKpi+;
 #pragma link C++ class AliRDHFCutsXictopKpi+;
+#pragma link C++ class AliRDHFCutsCdeuterontodKpi+;
 
 //classes working only in ROOT6
 #ifdef __CLING__


### PR DESCRIPTION
C-deuteron reconstruction from AOD tracks using the XiC->pKpi class

- Implement option in AliAnalysisTaskSEXicTopKpi to run c-deuteron analysis, with c-deuteron MC ID and matching, deuteron ID and invariant mass window change
- new cuts class for c-deuteron, AliRDHFCutsCdeuterontodKpi, inheriting from AliRDHFCutsXictopKpi. Contains first function for 3sigma PID, and modifications in IsSelected for deuteron ID and invariant mass window
- Add function in AliAODRecoDecayHF3Prong to calculate c-deuteron mass from 3 prong decay
- change inheritence of member variables in AliRDHFCutsXictopKpi to allow for inheritence
