### PR TITLE
AliAnalysisTaskHFJetIPQA: add probability tagging

### DIFF
--- a/PWGJE/FlavourJetTasks/AliAnalysisTaskHFJetIPQA.h
+++ b/PWGJE/FlavourJetTasks/AliAnalysisTaskHFJetIPQA.h
@@ -175,6 +175,7 @@ public:
     void FillRecHistograms(int jetflavour, double jetpt, double eta, double phi);
     void FillGenHistograms(int jetflavour, AliEmcalJet* jetgen);
     void FillIPTypePtHists(int jetflavour, double jetpt, bool* nTracks);
+    void FillIPTemplateHists(double jetpt, int iN,int jetflavour,double* params);
     void FillTrackTypeResHists();
 
     //________________________________
@@ -197,6 +198,7 @@ public:
     void setDoNotCheckIsPhysicalPrimary(Bool_t value){fDoNotCheckIsPhysicalPrimary = value;}
     void setDoJetProb(Bool_t value){fDoJetProb = value;}
     void setDoTCTagging(Bool_t value) {fDoTCTagging=value;}
+    void setDoProbTagging(Int_t value) {fDoProbTagging=value;}
 
     void setfDaughterRadius(Double_t value){fDaughtersRadius=value;}
     void setfNoJetConstituents(Int_t value){fNoJetConstituents=value;}
@@ -217,10 +219,13 @@ public:
           Triple,
     };
 
-    void DoJetTaggingThreshold(double jetpt, bool* hasIPs, double* ipval, bool **kTagDec);
-    void FillTCEfficiencyHists(bool** kTagDec, int jetflavour, double jetpt,bool hasIPs);
-    void SetThresholds(int nthresh, TObjArray** &threshs);
+    void DoTCTagging(double jetpt, bool* hasIPs, double* ipval, bool **kTagDec);
+    void DoProbTagging(double probval, double jetpt, bool** kTagDec);
+    void FillEfficiencyHists(bool** kTagDec, int jetflavour, double jetpt,bool hasIPs);
+    void SetTCThresholds(TObjArray** &threshs);
+    void SetProbThresholds(TObjArray** &threshs);
     void ReadProbvsIPLookup(TObjArray *&oLookup);
+    void ReadThresholdHists(TString PathToThresholds, TString taskname, int nTCThresh);
     void setTagLevel(int taglevel){kTagLevel=taglevel;}
 
     //________________________________
@@ -304,7 +309,7 @@ private:
     Bool_t   fFillCorrelations;//
     Bool_t fDoLundPlane;//
     Bool_t fDoTCTagging;//
-    Bool_t fDoProbTagging;//
+    Int_t fDoProbTagging;//  //0: no probability tagging, 1: use JP for tagging, 2: use lnJP for tagging
 
     //_____________________
     //variables
@@ -359,6 +364,8 @@ private:
     TH2D* h2DLNProbDistsb;//!
     TH2D* h2DLNProbDistss;//!
     TH2D* h2DLNProbDists;//!
+
+    std::vector<TH1D*> h1DProbThresholds;//
 
     //______________________________
     //Cut Histograms
@@ -459,7 +466,7 @@ private:
     return kTRUE;
     }
 
-   ClassDef(AliAnalysisTaskHFJetIPQA, 44)
+   ClassDef(AliAnalysisTaskHFJetIPQA, 45)
 };
 
 #endif

--- a/PWGJE/FlavourJetTasks/macros/AddTaskHFJetIPQA.C
+++ b/PWGJE/FlavourJetTasks/macros/AddTaskHFJetIPQA.C
@@ -12,7 +12,7 @@ Bool_t DefineCutsTaskpp(AliJetContainer* cont, double radius)
 }
 
 
-//
+
 
 
 AliAnalysisTaskHFJetIPQA* AddTaskHFJetIPQA(
@@ -28,7 +28,7 @@ AliAnalysisTaskHFJetIPQA* AddTaskHFJetIPQA(
                                            const char *njetsMC              = "Jets",
                                            const char *ntracksMC            = "tracksMC",
                                            const char *nrhoMC               = "RhoMC",
-                                           int nThresh                      =1,
+                                           int nTCThresh                      =1,
                                            TString PathToWeights = 	"alien:///alice/cern.ch/user/k/kgarner/Weights_18_07_18.root",
                                            TString PathToThresholds = "alien:///alice/cern.ch/user/k/kgarner/ThresholdHists_LHC16JJ_new.root",
                                           // TString PathToRunwiseCorrectionParameters = "alien:///alice/cern.ch/user/l/lfeldkam/MeanSigmaImpParFactors.root",
@@ -146,40 +146,8 @@ AliAnalysisTaskHFJetIPQA* AddTaskHFJetIPQA(
         if(fileFlukaCorrection) fileFlukaCorrection->Close();
     }
 
-    // Load and setup Threshold values for Tagger
-    //==============================================================================
-    TFile* fileThresholds;
-    if( PathToThresholds.EqualTo("") ) {
-      } else {
-        fileThresholds=TFile::Open(PathToThresholds.Data());
-        if(!fileThresholds ||(fileThresholds&& !fileThresholds->IsOpen())){
-        printf("%s :: File with threshold values not found",taskname);
-        return 0x0;
-      }
-    }
+    jetTask->ReadThresholdHists(PathToThresholds, taskname, nTCThresh);
 
-    Printf("%s :: File %s successfully loaded, setting up threshold functions.",taskname,PathToThresholds.Data());
-
-    if(fileThresholds){
-        printf("Reading threshold histograms for track counting...\n");
-
-        TObjArray** thresh=new TObjArray*[nThresh];
-        for(int iThresh=0;iThresh<nThresh;iThresh++){
-          fileThresholds->GetObject(Form("Thres_%i",iThresh),thresh[iThresh]);
-        }
-
-        printf("Pointers in the C file: %p, %p, %p\n",thresh[0], thresh[1],thresh[2]);
-
-        printf("Reading prob <-> IP lookup histograms...\n");
-        TObjArray* oLookup;
-        fileThresholds->GetObject("ProbLookup",oLookup);
-        //printf("Lookup Pointer in Read file:%p\n", oLookup);
-
-
-        jetTask->SetThresholds(nThresh,thresh);
-        jetTask->setfNThresholds(nThresh);
-        jetTask->ReadProbvsIPLookup(oLookup);
-    }
 
     // Setup input containers
     //==============================================================================


### PR DESCRIPTION
- enable reading of track probability threshold histograms
- move setting of thresholds to dedicated function ReadThresholdHists 
- introduce DoProbTagging for track probability tagging, same efficiency histograms as for TC tagging are utilised