### PR TITLE
PWGDQ: Added TimeRangeCut

### DIFF
--- a/PWGDQ/dielectron/core/AliDielectronEventCuts.cxx
+++ b/PWGDQ/dielectron/core/AliDielectronEventCuts.cxx
@@ -68,6 +68,8 @@ AliDielectronEventCuts::AliDielectronEventCuts() :
   fkVertex(0x0),
   fkVertexAOD(0x0),
   fRequireAliEventCuts(0),
+  fRequireTimeRangeCutForLHC18r(kFALSE),
+  fAODeventCuts(),
   fparMean(0x0),
   fparSigma(0x0),
   fcutSigma(3.),
@@ -109,6 +111,8 @@ AliDielectronEventCuts::AliDielectronEventCuts(const char* name, const char* tit
   fkVertex(0x0),
   fkVertexAOD(0x0),
   fRequireAliEventCuts(0),
+  fRequireTimeRangeCutForLHC18r(kFALSE),
+  fAODeventCuts(),
   fparMean(0x0),
   fparSigma(0x0),
   fcutSigma(3.),
@@ -467,6 +471,9 @@ Bool_t AliDielectronEventCuts::IsSelectedAOD(TObject* event)
   
   // cut on AliEventCuts (consistency to Run 1 Pb-Pb LMee analysis)
   if(fRequireAliEventCuts){
+    if (fRequireTimeRangeCutForLHC18r){
+      fAODeventCuts.UseTimeRangeCut();
+    }
     if (!fAODeventCuts.AcceptEvent(ev)){
       return kFALSE;
     }

--- a/PWGDQ/dielectron/core/AliDielectronEventCuts.h
+++ b/PWGDQ/dielectron/core/AliDielectronEventCuts.h
@@ -57,7 +57,8 @@ public:
   void SetCutOnV0MultipicityNTrks(TF1* parMean, TF1* parSigma, Double_t cutSigma=3.) { fparMean=parMean; fparSigma=parSigma; fcutSigma=cutSigma; }
   void SetCutOnNVtxContributorsGloablTPC(TF1* parMin, TF1* parMax) { fparMinVtxContributors=parMin; fparMaxVtxContributors=parMax; }
   void SetRequire2013vertexandevent(Bool_t req13 = kTRUE) {fRequire13sel = req13; }
-  void SetRequireAliEventCuts(Bool_t reqAliEventCuts = kTRUE, Bool_t reqAliEventCutsCorrelated = kFALSE) {fRequireAliEventCuts = reqAliEventCuts; fAODeventCuts.fUseVariablesCorrelationCuts = reqAliEventCutsCorrelated;}
+  void SetRequireAliEventCuts(Bool_t reqAliEventCuts = kTRUE, Bool_t reqAliEventCutsCorrelated = kFALSE, Bool_t reqTimingRangeCutForLHC18r = kFALSE) 
+                              {fRequireAliEventCuts = reqAliEventCuts; fAODeventCuts.fUseVariablesCorrelationCuts = reqAliEventCutsCorrelated; reqTimingRangeCutForLHC18r;}
   void SetMinCorrCutFunction(TF1 *fun, UInt_t varx, UInt_t vary=0);
   void SetMaxCorrCutFunction(TF1 *fun, UInt_t varx, UInt_t vary=0);
 
@@ -108,6 +109,7 @@ private:
   const AliAODVertex *fkVertexAOD;      //! current vertex AOD
 
   Bool_t  fRequireAliEventCuts;     // use AliEventCuts to reject events
+  Bool_t  fRequireTimeRangeCutForLHC18r; // use time range cut for LHC18r to recover 7 runs
   AliEventCuts fAODeventCuts;       // use AliEventCuts to reject events
   
   TH1D* fCorrCutMin[5];       //parametrization of lower limit correlation cut


### PR DESCRIPTION
Adds TimeRangeCut to AliEventCuts object for recovering statistics in LHC18r period. Should not change default behaviour.