### PR TITLE
Update Lstar macros for PbPb 2018 data to include asymmetry cuts

### DIFF
--- a/PWGLF/RESONANCES/macros/mini/AddTaskLambdaStarWithKinks.C
+++ b/PWGLF/RESONANCES/macros/mini/AddTaskLambdaStarWithKinks.C
@@ -11,14 +11,16 @@ AliRsnMiniAnalysisTask * AddTaskLambdaStarWithKinks
  TString     outNameSuffix = "LambdaStarKink",                         //suffix for output container
  Bool_t      isMC          = kFALSE,                            //MC flag
  AliPIDResponse::EBeamType collSys = AliPIDResponse::kPBPB, //=0, kPPB=1, kPBPB=2 outNameSuffix
- UInt_t      triggerMask   = AliVEvent::kCentral,             //trigger selection
+ Int_t      triggerMask    = 0,             //trigger selection
  Bool_t      enaMultSel    = kTRUE,                        //enable multiplicity axis
  Float_t     nsigma        = 3.0,   //PID cut
  Float_t     masslow       = 1.4,   //inv mass range lower boundary
  Float_t     massup        = 2.2,   //inv mass range upper boundary
  Int_t       nbins         = 2000,  //inv mass: N bins
  Bool_t      enableMonitor = kTRUE, //enable single track QA
- Float_t     kaonPIDCut=4.)        //nsigma kaon daughters 
+ Float_t     kaonPIDCut=4.,        //nsigma kaon daughters 
+ Double_t    minAsym = 0.0,           //pair lower abs(asym)
+ Double_t    maxAsym=0.7)            //pair maximum abs(asym)
 
 {  
 
@@ -42,7 +44,7 @@ AliRsnMiniAnalysisTask * AddTaskLambdaStarWithKinks
   //-------------------------------------------
   Double_t minYlab = -0.5;
   Double_t maxYlab =  0.5;
-      
+
   // if (pairCutSetID==pairYCutSet::kCentralTight) { //|y_cm|<0.3
   //   minYlab = -0.3;    maxYlab = 0.3;
   // }
@@ -77,7 +79,15 @@ AliRsnMiniAnalysisTask * AddTaskLambdaStarWithKinks
   AliRsnMiniAnalysisTask *task = new AliRsnMiniAnalysisTask(taskName.Data(), isMC);
 
   //trigger 
-  if (!isMC) task->UseESDTriggerMask(triggerMask); //ESD
+  if (!isMC) {
+  
+        if (triggerMask==0) task->UseESDTriggerMask(AliVEvent::kCentral); //ESD
+        if (triggerMask==1) task->UseESDTriggerMask(AliVEvent::kSemiCentral);
+        if (triggerMask==3) task->UseESDTriggerMask(AliVEvent::kINT7);
+        if (triggerMask==4) task->UseESDTriggerMask(AliVEvent::kSemiCentral|AliVEvent::kCentral|AliVEvent::kINT7);
+  
+  }   
+
   if(isMC) task->UseESDTriggerMask(AliVEvent::kAnyINT);
 //  task->SelectCollisionCandidates(triggerMask); //AOD
   
@@ -104,7 +114,7 @@ AliRsnMiniAnalysisTask * AddTaskLambdaStarWithKinks
 
   AliRsnEventCuts * rsnEventCuts = new AliRsnEventCuts("rsnEventCuts");
   rsnEventCuts->ForceSetupPbPb2018();
-  rsnEventCuts->SetUseMultSelectionEvtSel();
+//  rsnEventCuts->SetUseMultSelectionEvtSel();
   eventCuts->AddCut(rsnEventCuts);
   eventCuts->SetCutScheme(Form("%s", rsnEventCuts->GetName()));
 
@@ -166,13 +176,22 @@ AliRsnMiniAnalysisTask * AddTaskLambdaStarWithKinks
   AliRsnCutMiniPair *cutY = new AliRsnCutMiniPair("cutRapidity", AliRsnCutMiniPair::kRapidityRange);
   cutY->SetRangeD(minYlab, maxYlab);
 
+  AliRsnCutMiniPair *cutAsym = new AliRsnCutMiniPair("cutAsymmetry", AliRsnCutMiniPair::kAsymRange);
+  cutAsym->SetRangeD(minAsym, maxAsym);
+
   //AliRsnCutMiniPair* cutV0=new AliRsnCutMiniPair("cutV0", AliRsnCutMiniPair::kContainsV0Daughter);
 
   AliRsnCutSet *cutsPair = new AliRsnCutSet("pairCuts", AliRsnTarget::kMother);
   cutsPair->AddCut(cutY);
+  cutsPair->AddCut(cutAsym);
   //cutsPair->AddCut(cutV0);
   //cutsPair->SetCutScheme(TString::Format("%s&(!%s)",cutY->GetName(),cutV0->GetName()).Data());
-  cutsPair->SetCutScheme(cutY->GetName());
+  cutsPair->SetCutScheme(Form("%s & %s ",cutY->GetName(), cutAsym->GetName()));
+//   cutsPair->SetCutScheme(cutY->GetName());
+
+  AliRsnCutSet *cutsPairY = new AliRsnCutSet("pairCutsY", AliRsnTarget::kMother);
+  cutsPairY->AddCut(cutY);
+  cutsPairY->SetCutScheme(cutY->GetName());
 
   // AliRsnCutSet* PairCutsMix=new AliRsnCutSet("PairCutsMix",AliRsnTarget::kMother);
   // PairCutsMix->AddCut(cutY);
@@ -181,9 +200,9 @@ AliRsnMiniAnalysisTask * AddTaskLambdaStarWithKinks
   //-----------------------------------------------------------------------------------------------
   // -- CONFIG ANALYSIS --------------------------------------------------------------------------
   //-----------------------------------------------------------------------------------------------
- gROOT->LoadMacro("$ALICE_PHYSICS/PWGLF/RESONANCES/macros/mini/ConfigLambdaStarWithKinks.C");
-//  gROOT->LoadMacro("ConfigLambdaStarWithKinks.C");
-  if (!ConfigLambdaStarWithKinks(task, isMC, collSys, cutsPair, enaMultSel, masslow, massup, nbins, nsigma, 
+// gROOT->LoadMacro("$ALICE_PHYSICS/PWGLF/RESONANCES/macros/mini/ConfigLambdaStarWithKinks.C");
+  gROOT->LoadMacro("ConfigLambdaStarWithKinks.C");
+  if (!ConfigLambdaStarWithKinks(task, isMC, collSys, cutsPair, cutsPairY, enaMultSel, masslow, massup, nbins, nsigma, 
 enableMonitor, kaonPIDCut)) 
 return 0x0;
   

--- a/PWGLF/RESONANCES/macros/mini/ConfigLambdaStarWithKinks.C
+++ b/PWGLF/RESONANCES/macros/mini/ConfigLambdaStarWithKinks.C
@@ -8,6 +8,7 @@ Bool_t ConfigLambdaStarWithKinks(AliRsnMiniAnalysisTask *task,
 		Bool_t                 isMC, 
 		AliPIDResponse::EBeamType collSys = AliPIDResponse::kPBPB, //=0, kPPB=1, kPBPB=2
                 AliRsnCutSet           *cutsPair,             //cuts on the pair
+                AliRsnCutSet           *cutsPairY,             //cuts on the pair
 		Bool_t                 enaMultSel = kTRUE,    //enable multiplicity axis
       		Float_t                masslow = 1.4,         //inv mass axis low edge 
 		Float_t                massup = 2.2,           //inv mass axis upper edge 
@@ -132,6 +133,9 @@ Bool_t ConfigLambdaStarWithKinks(AliRsnMiniAnalysisTask *task,
   /* 1st daughter p       */ Int_t fdp    = task->CreateValue(AliRsnMiniValue::kFirstDaughterP, kFALSE);
   /* 2nd daughter p       */ Int_t sdp    = task->CreateValue(AliRsnMiniValue::kSecondDaughterP, kFALSE);
    /* gener. transv. mom.  */
+  /* Asymmetry data       */ Int_t asymd   = task->CreateValue(AliRsnMiniValue::kAsym, kFALSE);
+  /* Asymmetry            */ Int_t asym   = task->CreateValue(AliRsnMiniValue::kAsym, kTRUE);
+
   if (isMC) Int_t ptIDgen= task->CreateValue(AliRsnMiniValue::kPt, kTRUE);
 
   TString output[6] = {"HIST",      "HIST",          "HIST",      "HIST",          "HIST",        "HIST"          }; // or "SPARSE"
@@ -160,10 +164,23 @@ Bool_t ConfigLambdaStarWithKinks(AliRsnMiniAnalysisTask *task,
     // axis X: invmass 
     out->AddAxis(imID, nbins, masslow, massup);
     //axis Y: mother pt
-    out->AddAxis(ptID, 100, 0.0, 10.0); //default use mother pt
+    out->AddAxis(ptID, 150, 0.0, 15.0); //default use mother pt
     //axis Z: multiplicity
       if (enaMultSel) out->AddAxis(multID, 100, 0.0, 100.0);
   }
+
+    AliRsnMiniOutput *outasmd = task->CreateOutput("hAsymmetryDAtaLambda", "HIST", "PAIR");
+    outasmd->SetDaughter(0, AliRsnDaughter::kProton);
+    outasmd->SetDaughter(1, AliRsnDaughter::kKaon);
+    outasmd->SetCutID(0, icutPr);
+    outasmd->SetCutID(1, icutKaon);
+    outasmd->SetMotherPDG(3124);
+    outasmd->SetMotherMass(1.5195);
+    outasmd->SetPairCuts(cutsPair);
+    outasmd->SetCharge(0, charge1[0]);
+    outasmd->SetCharge(1, charge2[0]);
+    outasmd->AddAxis(asymd, 200, -1.0, 1.0);
+    if (enaMultSel) outasmd->AddAxis(multID, 100, 0.0, 100.0);   
  
   // AddMonitorOutput_LambdaPt(cutSetLs->GetMonitorOutput());
 
@@ -185,7 +202,7 @@ Bool_t ConfigLambdaStarWithKinks(AliRsnMiniAnalysisTask *task,
     out->SetPairCuts(cutsPair);
     // binnings
     out->AddAxis(imID, 800, 1.4, 2.2);
-    out->AddAxis(ptID, 100, 0.0, 10.0);
+    out->AddAxis(ptID, 150, 0.0, 15.0);
     
     if (enaMultSel) out->AddAxis(multID, 100, 0.0, 100.0);
 
@@ -204,20 +221,29 @@ Bool_t ConfigLambdaStarWithKinks(AliRsnMiniAnalysisTask *task,
     out->SetPairCuts(cutsPair);
     // binnings
     out->AddAxis(imID, 800, 1.4, 2.2);
-    out->AddAxis(ptID, 100, 0.0, 10.0);
+    out->AddAxis(ptID, 150, 0.0, 15.0);
     //out->AddAxis(lambdaDCA, 10, 0.0, 1.0);
     
     if (enaMultSel) out->AddAxis(multID, 100, 0.0, 100.0);
     
     //GENERATED PAIRS
+    AliRsnMiniOutput *outasm = task->CreateOutput("hAsymmetryMCLambda", "HIST", "MOTHER");
+    outasm->SetDaughter(0, AliRsnDaughter::kProton);
+    outasm->SetDaughter(1, AliRsnDaughter::kKaon);
+    outasm->SetMotherPDG(3124);
+    outasm->SetMotherMass(1.5195);
+    outasm->SetPairCuts(cutsPairY);
+    outasm->AddAxis(asym, 200, -1.0, 1.0);
+    if (enaMultSel) outasm->AddAxis(multID, 100, 0.0, 100.0);
+
     output[0] = "HIST";
     AliRsnMiniOutput * outm = task->CreateOutput(Form("motherLambda1520Kinkpt_%s", name[0].Data()), output[0].Data(),"MOTHER");
     outm->SetDaughter(0, AliRsnDaughter::kProton);
     outm->SetDaughter(1, AliRsnDaughter::kKaon);
     outm->SetMotherPDG(3124);
     outm->SetMotherMass(1.5195);
-    outm->SetPairCuts(cutsPair);
-    outm->AddAxis(ptIDgen, 100, 0.0, 10.0);
+    outm->SetPairCuts(cutsPairY);
+    outm->AddAxis(ptIDgen, 150, 0.0, 15.0);
     if (enaMultSel) outm->AddAxis(multID, 100, 0.0, 100.0);
 
     output[1] = "HIST";
@@ -226,8 +252,8 @@ Bool_t ConfigLambdaStarWithKinks(AliRsnMiniAnalysisTask *task,
     outm->SetDaughter(1, AliRsnDaughter::kKaon);
     outm->SetMotherPDG(-3124);
     outm->SetMotherMass(1.5195);
-    outm->SetPairCuts(cutsPair);
-    outm->AddAxis(ptIDgen, 100, 0.0, 10.0);
+    outm->SetPairCuts(cutsPairY);
+    outm->AddAxis(ptIDgen, 150, 0.0, 15.0);
     if (enaMultSel) outm->AddAxis(multID, 100, 0.0, 100.0);
  
   }


### PR DESCRIPTION
Update Lstar macros for PbPb 2018 data to include asymmetry cuts