### PR TITLE
Standard ESD track cuts configuration set from outside

### DIFF
--- a/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.cxx
+++ b/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.cxx
@@ -94,8 +94,8 @@ AliAnalysisTrackingUncertaintiesAOT::AliAnalysisTrackingUncertaintiesAOT()
   fCutGeoNcrNclGeom1Pt(1.5),
   fCutGeoNcrNclFractionNcr(0.9),
   fCutGeoNcrNclFractionNcl(0.7),
-  fWhichCuts(kDefault),
-  fTPCclstCut(0)
+  fWhichCuts(kStdITSTPCTrkCuts2011),
+  fTPCclstCut(1)
 {
 
 }
@@ -141,8 +141,8 @@ AliAnalysisTrackingUncertaintiesAOT::AliAnalysisTrackingUncertaintiesAOT(const c
   fCutGeoNcrNclGeom1Pt(1.5),
   fCutGeoNcrNclFractionNcr(0.9),
   fCutGeoNcrNclFractionNcl(0.7),
-  fWhichCuts(kDefault),
-  fTPCclstCut(0)
+  fWhichCuts(kStdITSTPCTrkCuts2011),
+  fTPCclstCut(1)
 {
   //
   // standard constructur
@@ -180,14 +180,15 @@ void AliAnalysisTrackingUncertaintiesAOT::UserCreateOutputObjects()
   //reproduce filtering cuts
   fESDtrackCuts = new AliESDtrackCuts("AliESDtrackCuts","AliESDtrackCuts");
   // choose a standard ESD track cut configuration, otherwise use the ESDtrackCuts object passed with SETESDtrackCuts function 
-  // NB: the default case is kDefault
+  // NB: the default case is kStdITSTPCTrkCuts2011 with fTPCclstCut=1
   switch (fWhichCuts)
   {
-  case kDefault:
-    printf("\n### kDefault case for ESD track cuts\n   fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010(kFALSE,0);   ---> cut on TPC # clusters\n   fESDtrackCuts->SetMinRatioCrossedRowsOverFindableClustersTPC(%.2f);\n\n",fCrossRowsOverFndCltTPC);
-    fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010(kFALSE,0);
-    fESDtrackCuts->SetMinRatioCrossedRowsOverFindableClustersTPC(fCrossRowsOverFndCltTPC);
-    break;
+  // OLD CONFIGURATION
+  //case kDefault:
+    //printf("\n### kDefault case for ESD track cuts\n   fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010(kFALSE,0);   ---> cut on TPC # clusters\n   fESDtrackCuts->SetMinRatioCrossedRowsOverFindableClustersTPC(%.2f);\n\n",fCrossRowsOverFndCltTPC);
+    //fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010(kFALSE,0);
+    //fESDtrackCuts->SetMinRatioCrossedRowsOverFindableClustersTPC(fCrossRowsOverFndCltTPC);
+    //break;
   
   case kStdTPConlyTrkCuts:
     printf("\n### kStdTPConlyTrkCuts case for ESD track cuts\n   fESDtrackCuts = AliESDtrackCuts::GetStandardTPCOnlyTrackCuts();\n\n");

--- a/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.cxx
+++ b/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.cxx
@@ -93,7 +93,9 @@ AliAnalysisTrackingUncertaintiesAOT::AliAnalysisTrackingUncertaintiesAOT()
   fCutGeoNcrNclLength(130.),
   fCutGeoNcrNclGeom1Pt(1.5),
   fCutGeoNcrNclFractionNcr(0.9),
-  fCutGeoNcrNclFractionNcl(0.7)
+  fCutGeoNcrNclFractionNcl(0.7),
+  fWhichCuts(kDefault),
+  fTPCclstCut(0)
 {
 
 }
@@ -138,7 +140,9 @@ AliAnalysisTrackingUncertaintiesAOT::AliAnalysisTrackingUncertaintiesAOT(const c
   fCutGeoNcrNclLength(130.),
   fCutGeoNcrNclGeom1Pt(1.5),
   fCutGeoNcrNclFractionNcr(0.9),
-  fCutGeoNcrNclFractionNcl(0.7)
+  fCutGeoNcrNclFractionNcl(0.7),
+  fWhichCuts(kDefault),
+  fTPCclstCut(0)
 {
   //
   // standard constructur
@@ -175,9 +179,48 @@ void AliAnalysisTrackingUncertaintiesAOT::UserCreateOutputObjects()
   // create track cuts
   //reproduce filtering cuts
   fESDtrackCuts = new AliESDtrackCuts("AliESDtrackCuts","AliESDtrackCuts");
-  fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010(kFALSE,0);
-  fESDtrackCuts->SetEtaRange(-fMaxEta, fMaxEta);
-  fESDtrackCuts->SetMinRatioCrossedRowsOverFindableClustersTPC(fCrossRowsOverFndCltTPC);
+  // choose a standard ESD track cut configuration, otherwise use the ESDtrackCuts object passed with SETESDtrackCuts function 
+  // NB: the default case is kDefault
+  switch (fWhichCuts)
+  {
+  case kDefault:
+    printf("\n### kDefault case for ESD track cuts\n   fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010(kFALSE,0);   ---> cut on TPC # clusters\n   fESDtrackCuts->SetMinRatioCrossedRowsOverFindableClustersTPC(%.2f);\n\n",fCrossRowsOverFndCltTPC);
+    fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010(kFALSE,0);
+    fESDtrackCuts->SetMinRatioCrossedRowsOverFindableClustersTPC(fCrossRowsOverFndCltTPC);
+    break;
+  
+  case kStdTPConlyTrkCuts:
+    printf("\n### kStdTPConlyTrkCuts case for ESD track cuts\n   fESDtrackCuts = AliESDtrackCuts::GetStandardTPCOnlyTrackCuts();\n\n");
+    fESDtrackCuts = AliESDtrackCuts::GetStandardTPCOnlyTrackCuts();
+    break;
+
+  case kStdITSTPCTrkCuts2009:
+    printf("\n### kStdITSTPCTrkCuts2009 case for ESD track cuts\n   fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2009(kFALSE)\n\n");
+    fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2009(kFALSE);
+    break;
+
+  case kStdITSTPCTrkCuts2010:
+    printf("\n### kStdITSTPCTrkCuts2010 case for ESD track cuts\n   fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010(kFALSE,%d)\n",fTPCclstCut);
+    if(fTPCclstCut==0)  printf("   ---> cut on TPC # clusters\n\n");
+    else if(fTPCclstCut==1) printf("   ---> cuts on the number of crossed rows and on the ration crossed rows/findable clusters\n\n");
+    fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010(kFALSE,fTPCclstCut);
+    break;
+
+  case kStdITSTPCTrkCuts2011:
+    printf("\n### kStdITSTPCTrkCuts2011 case for ESD track cuts\n   fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(kFALSE,%d)\n",fTPCclstCut);
+    if(fTPCclstCut==0)  printf("   ---> cut on TPC # clusters\n\n");
+    else if(fTPCclstCut==1) printf("   ---> cuts on the number of crossed rows and on the ration crossed rows/findable clusters\n\n");
+    fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2011(kFALSE,fTPCclstCut);
+    break;
+
+  case kStdITSTPCTrkCuts2015PbPb:
+    printf("\n### kStdITSTPCTrkCuts2015PbPb case for ESD track cuts\n   fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2015PbPb(kFALSE,%d,kTRUE,kFALSE)\n\n",fTPCclstCut);
+    if(fTPCclstCut==0)  printf("   ---> cut on TPC # clusters\n\n");
+    else if(fTPCclstCut==1) printf("   ---> cuts on the number of crossed rows and on the ration crossed rows/findable clusters\n\n");
+    fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2015PbPb(kFALSE,fTPCclstCut,kTRUE,kFALSE);
+    break;
+  }
+  fESDtrackCuts->SetEtaRange(-fMaxEta, fMaxEta);  // common for every ESD track cuts set
   if(fUseCutGeoNcrNcl)  fESDtrackCuts->SetCutGeoNcrNcl( fDeadZoneWidth, fCutGeoNcrNclLength, fCutGeoNcrNclGeom1Pt, fCutGeoNcrNclFractionNcr, fCutGeoNcrNclFractionNcl);
 
   //

--- a/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.cxx
+++ b/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.cxx
@@ -94,7 +94,7 @@ AliAnalysisTrackingUncertaintiesAOT::AliAnalysisTrackingUncertaintiesAOT()
   fCutGeoNcrNclGeom1Pt(1.5),
   fCutGeoNcrNclFractionNcr(0.9),
   fCutGeoNcrNclFractionNcl(0.7),
-  fWhichCuts(kStdITSTPCTrkCuts2011),
+  fWhichCuts(kDefault),
   fTPCclstCut(1)
 {
 
@@ -141,7 +141,7 @@ AliAnalysisTrackingUncertaintiesAOT::AliAnalysisTrackingUncertaintiesAOT(const c
   fCutGeoNcrNclGeom1Pt(1.5),
   fCutGeoNcrNclFractionNcr(0.9),
   fCutGeoNcrNclFractionNcl(0.7),
-  fWhichCuts(kStdITSTPCTrkCuts2011),
+  fWhichCuts(kDefault),
   fTPCclstCut(1)
 {
   //
@@ -183,12 +183,12 @@ void AliAnalysisTrackingUncertaintiesAOT::UserCreateOutputObjects()
   // NB: the default case is kStdITSTPCTrkCuts2011 with fTPCclstCut=1
   switch (fWhichCuts)
   {
-  // OLD CONFIGURATION
-  //case kDefault:
-    //printf("\n### kDefault case for ESD track cuts\n   fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010(kFALSE,0);   ---> cut on TPC # clusters\n   fESDtrackCuts->SetMinRatioCrossedRowsOverFindableClustersTPC(%.2f);\n\n",fCrossRowsOverFndCltTPC);
-    //fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010(kFALSE,0);
-    //fESDtrackCuts->SetMinRatioCrossedRowsOverFindableClustersTPC(fCrossRowsOverFndCltTPC);
-    //break;
+  // backward compatibility
+  case kDefault:
+    printf("\n### kDefault case for ESD track cuts\n   fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010(kFALSE,0);   ---> cut on TPC # clusters\n   fESDtrackCuts->SetMinRatioCrossedRowsOverFindableClustersTPC(%.2f);\n\n",fCrossRowsOverFndCltTPC);
+    fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010(kFALSE,0);
+    fESDtrackCuts->SetMinRatioCrossedRowsOverFindableClustersTPC(fCrossRowsOverFndCltTPC);
+    break;
   
   case kStdTPConlyTrkCuts:
     printf("\n### kStdTPConlyTrkCuts case for ESD track cuts\n   fESDtrackCuts = AliESDtrackCuts::GetStandardTPCOnlyTrackCuts();\n\n");

--- a/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.h
+++ b/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.h
@@ -38,7 +38,22 @@ class AliAnalysisTrackingUncertaintiesAOT : public AliAnalysisTaskSE {
   };
   enum ECentrality {kCentOff,kCentV0M,kCentCL1,kCentZNA,kCentV0A,kCentInvalid};
 
-    
+  // list of possible standard ESD track cuts set
+  enum EtrkCuts {
+    kDefault=0,
+    kStdTPConlyTrkCuts=1,
+    kStdITSTPCTrkCuts2009,
+    kStdITSTPCTrkCuts2010,
+    kStdITSTPCTrkCuts2011,
+    kStdITSTPCTrkCuts2015PbPb
+    // to be implemented, if needed
+    //kStdITSSATrkCuts2009,
+    //kStdITSSATrkCuts2010,
+    //kStdITSSATrkCutsPbPb2010,
+    //kStdITSPureSATrackCuts2009,
+    //kStdITSPureSATrackCuts2010
+  };
+
   AliAnalysisTrackingUncertaintiesAOT(const char *name);
   AliAnalysisTrackingUncertaintiesAOT();
   virtual ~AliAnalysisTrackingUncertaintiesAOT();
@@ -81,6 +96,9 @@ class AliAnalysisTrackingUncertaintiesAOT : public AliAnalysisTaskSE {
     fDeadZoneWidth=dz;  fCutGeoNcrNclLength=len; fCutGeoNcrNclGeom1Pt=onept;
     fCutGeoNcrNclFractionNcr=fncr; fCutGeoNcrNclFractionNcl=fncl;
   }
+
+  // possibility to modify the ESD track cuts set
+  void SetStandardESDtrkCuts(UInt_t whichcuts, UInt_t option_TPCclstcut)  {fWhichCuts=whichcuts; fTPCclstCut=option_TPCclstcut;}
 
   ULong64_t GetTriggerMask() {return fTriggerMask;}
   ULong64_t GetSpecie() {return fspecie;}
@@ -146,6 +164,10 @@ class AliAnalysisTrackingUncertaintiesAOT : public AliAnalysisTaskSE {
   Double_t fCutGeoNcrNclGeom1Pt; /// 3rd parameter of GeoNcrNcl cut
   Double_t fCutGeoNcrNclFractionNcr; /// 4th parameter of GeoNcrNcl cut
   Double_t fCutGeoNcrNclFractionNcl; /// 5th parameter of GeoNcrNcl cut
+
+  // possibility to modify the ESD track cuts set
+  UInt_t fWhichCuts;  ///
+  UInt_t fTPCclstCut; /// 0: cut on TPC clusters; 1: cuts on the number of crossed rows and on the ration crossed rows/findable clusters
 
   AliAnalysisTrackingUncertaintiesAOT(const AliAnalysisTrackingUncertaintiesAOT&);
   AliAnalysisTrackingUncertaintiesAOT& operator=(const AliAnalysisTrackingUncertaintiesAOT&);

--- a/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.h
+++ b/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.h
@@ -40,6 +40,7 @@ class AliAnalysisTrackingUncertaintiesAOT : public AliAnalysisTaskSE {
 
   // list of possible standard ESD track cuts set
   enum EtrkCuts {
+    kDefault=0,
     kStdTPConlyTrkCuts=1,
     kStdITSTPCTrkCuts2009,
     kStdITSTPCTrkCuts2010,

--- a/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.h
+++ b/PWGPP/EvTrkSelection/AliAnalysisTrackingUncertaintiesAOT.h
@@ -40,7 +40,6 @@ class AliAnalysisTrackingUncertaintiesAOT : public AliAnalysisTaskSE {
 
   // list of possible standard ESD track cuts set
   enum EtrkCuts {
-    kDefault=0,
     kStdTPConlyTrkCuts=1,
     kStdITSTPCTrkCuts2009,
     kStdITSTPCTrkCuts2010,


### PR DESCRIPTION
The default setting is kDefault (compatibility with previous versions)

fESDtrackCuts = AliESDtrackCuts::GetStandardITSTPCTrackCuts2010(kFALSE,0);
fESDtrackCuts->SetMinRatioCrossedRowsOverFindableClustersTPC(fCrossRowsOverFndCltTPC);

Now, the fESDtrackCuts object can be set to one of the standard configurations through the function SetStandardESDtrkCuts