### PR TITLE
Re-introduce basic jet QA plots running all the time

### DIFF
--- a/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.cxx
+++ b/PWGJE/EMCALJetTasks/Tracks/AliAnalysisTaskEmcalJetEnergySpectrum.cxx
@@ -138,6 +138,13 @@ void AliAnalysisTaskEmcalJetEnergySpectrum::UserCreateOutputObjects(){
     fHistos->CreateTHnSparse("hMaxJetTHnSparse", "jet thnsparse", 6, binnings, fUseSumw2 ? "s" : "");
   }
 
+  // A bit of QA stuff
+  fHistos->CreateTH2("hQANEFPt", "Neutral energy fraction; p_{t} (GeV/c); NEF", 350, 0., 350., 100, 0., 1.);
+  fHistos->CreateTH2("hQAZchPt", "z_{ch,max}; p_{t} (GeV/c); z_{ch,max}", 350, 0., 350., 100, 0., 1.);
+  fHistos->CreateTH2("hQAZnePt", "z_{ne,max}; p_{t} (GeV/c); z_{ne,max}", 350, 0., 350., 100, 0., 1.);
+  fHistos->CreateTH2("hQANChPt", "Number of charged constituents; p_{t} (GeV/c); N_{ch}", 350, 0., 350., 100, 0., 100.);
+  fHistos->CreateTH2("hQANnePt", "Number of neutral constituents; p_{t} (GeV/c); N_{ne}", 350, 0., 350., 100, 0., 100.);
+
   for(auto h : *fHistos->GetListOfHistograms()) fOutput->Add(h);
   PostData(1, fOutput);
 }
@@ -162,6 +169,8 @@ Bool_t AliAnalysisTaskEmcalJetEnergySpectrum::CheckMCOutliers() {
 
 bool AliAnalysisTaskEmcalJetEnergySpectrum::Run(){
   auto datajets = this->GetJetContainer(fNameJetContainer);
+  auto clusters = this->GetClusterContainer(0);
+  auto tracks = this->GetTrackContainer(0);
   if(!datajets) {
     AliErrorStream() << "Jet container " << fNameJetContainer << " not found" << std::endl;
     return false;
@@ -212,6 +221,23 @@ bool AliAnalysisTaskEmcalJetEnergySpectrum::Run(){
         fHistos->FillTHnSparse("hJetTHnSparse", datapoint, weight);
       }
     }
+
+    // Fill QA plots - trigger cluster independent
+    // Those plots have been in before (as part of the THnSparse) but were 
+    // removed in order to reduce the memory consumption.
+    fHistos->FillTH2("hQANEFPt", ptjet, j->NEF(), weight);
+    if(clusters){
+      auto leadcluster = j->GetLeadingCluster(clusters->GetArray());
+      TLorentzVector ptvec;
+      leadcluster->GetMomentum(ptvec, fVertex, (AliVCluster::VCluUserDefEnergy_t)clusters->GetDefaultClusterEnergy());
+      fHistos->FillTH2("hQAZnePt", ptjet, j->GetZ(ptvec.Px(), ptvec.Py(), ptvec.Pz()), weight);
+    }
+    if(tracks){
+      auto leadingtrack = j->GetLeadingTrack(tracks->GetArray());
+      fHistos->FillTH2("hQAZchPt", ptjet, j->GetZ(leadingtrack->Px(), leadingtrack->Py(), leadingtrack->Pz()), weight);
+    }
+    fHistos->FillTH2("hQANChPt", ptjet, j->GetNumberOfTracks(), weight);
+    fHistos->FillTH2("hQANnePt", ptjet, j->GetNumberOfClusters(), weight);
   }
 
   double maxdata[6];


### PR DESCRIPTION
Observables were part of the THnSparse, but when
moving back to ND-histograms in order to reduce
the memory consumption for the large datasets (pp
triggered and jj anchored to pp 13 TeV) they were
dropped. Added as 2D plots (always versus jet pt)
as QA plots always running.