### PR TITLE
Remove dependency on PWGflowTasks from PWGHFvertexingHF

### DIFF
--- a/PWG/FLOW/Base/AliAnalysisTaskZDCEP.cxx
+++ b/PWG/FLOW/Base/AliAnalysisTaskZDCEP.cxx
@@ -23,9 +23,6 @@
 #define AliAnalysisTaskZDCEP_cxx
 
 #include "Riostream.h"
-#include "AliFlowCommonConstants.h"
-#include "AliFlowCommonHist.h"
-#include "AliFlowCommonHistResults.h"
 #include "TChain.h"
 
 #include "TFile.h"
@@ -41,10 +38,6 @@
 #include "TPaveLabel.h"
 #include "TCanvas.h"
 #include "TVector2.h"
-#include "AliFlowEventSimple.h"
-#include "AliFlowVector.h"
-#include "AliFlowTrackSimple.h"
-#include "AliFlowAnalysisCRC.h"
 #include "TRandom.h"
 #include "TF1.h"
 #include "TNtuple.h"
@@ -55,7 +48,8 @@
 #include "AliAODZDC.h"
 #include "TProfile2D.h"
 #include "TProfile3D.h"
-#include "AliFlowEvent.h"
+#include "AliFlowEventSimple.h"
+#include "AliFlowVector.h"
 
 class TH1;
 class TH2;
@@ -70,7 +64,6 @@ class TCanvas;
 class TSystem;
 class TROOT;
 class TVector2;
-class AliFlowVector;
 
 AliAnalysisTaskZDCEP::AliAnalysisTaskZDCEP () :
 AliAnalysisTaskSE (),
@@ -272,7 +265,7 @@ void AliAnalysisTaskZDCEP::UserCreateOutputObjects ()
     fAnalysisUtils->SetUseMVPlpSelection(kTRUE);
     fAnalysisUtils->SetUseOutOfBunchPileUp(kTRUE);
     
-    fFlowEvent = new AliFlowEvent(1);
+    fFlowEvent = new AliFlowEventSimple(1);
 }
 
 //=====================================================================

--- a/PWG/FLOW/Base/AliAnalysisTaskZDCEP.h
+++ b/PWG/FLOW/Base/AliAnalysisTaskZDCEP.h
@@ -34,7 +34,8 @@ class TProfile;
 class TProfile2D;
 class TProfile3D;
 class TH3D;
-class AliFlowEvent;
+class AliFlowEventSimple;
+class AliFlowVector;
 
 class  AliAnalysisTaskZDCEP : public  AliAnalysisTaskSE
 {
@@ -87,7 +88,7 @@ private:
     TArrayD fAvVtxPosY;             // average vy position vs run number
     TArrayD fAvVtxPosZ;             // average vz position vs run number
     Bool_t fbFlagIsPosMagField;     //
-    AliFlowEvent* fFlowEvent;       // flowevent
+    AliFlowEventSimple* fFlowEvent; // flowevent
     
     AliAnalysisUtils* fAnalysisUtils; //!
     AliMultSelection* fMultSelection; //!

--- a/PWG/FLOW/Base/CMakeLists.txt
+++ b/PWG/FLOW/Base/CMakeLists.txt
@@ -18,7 +18,9 @@ set(MODULE PWGflowBase)
 add_definitions(-D_MODULE_="${MODULE}")
 
 # Module include folder
-include_directories(${AliPhysics_SOURCE_DIR}/PWG/FLOW/Base)
+include_directories(${AliPhysics_SOURCE_DIR}/PWG/FLOW/Base
+                    ${AliPhysics_SOURCE_DIR}/OADB
+                    ${AliPhysics_SOURCE_DIR}/OADB/COMMON/MULTIPLICITY)
 
 # Additional includes - alphabetical order except ROOT
 include_directories(${ROOT_INCLUDE_DIRS}
@@ -59,6 +61,7 @@ set(SRCS
   AliFlowAnalysisWithNestedLoops.cxx
   AliFlowOnTheFlyEventGenerator.cxx
   AliFlowAnalysisWithMultiparticleCorrelations.cxx
+  AliAnalysisTaskZDCEP.cxx
   )
 
 # Headers from sources
@@ -74,7 +77,7 @@ add_library_tested(${MODULE} SHARED  ${SRCS} G__${MODULE}.cxx)
 
 # Generate the ROOT map
 # Dependecies
-set(LIBDEPS EG Physics Hist MathCore RIO Tree Core)
+set(LIBDEPS EG Physics Hist MathCore RIO Tree Core ANALYSISalice)
 generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
 
 # Generate a PARfile target for this library

--- a/PWG/FLOW/Base/PWGflowBaseLinkDef.h
+++ b/PWG/FLOW/Base/PWGflowBaseLinkDef.h
@@ -45,4 +45,6 @@
 #pragma link C++ class AliFlowOnTheFlyEventGenerator+;
 #pragma link C++ class AliFlowAnalysisWithMultiparticleCorrelations+;
 
+#pragma link C++ class AliAnalysisTaskZDCEP+;
+
 #endif

--- a/PWG/FLOW/Tasks/CMakeLists.txt
+++ b/PWG/FLOW/Tasks/CMakeLists.txt
@@ -74,7 +74,6 @@ set(SRCS
   AliAnalysisTaskMultiparticleFemtoscopy.cxx
   AliAnalysisTaskForStudents.cxx
   AliAnalysisTaskZDCGainEq.cxx
-  AliAnalysisTaskZDCEP.cxx
   AliAnalysisTaskPiKpK0Lamba.cxx
   AliAnalysisTaskCmeEse.cxx
   AliAnalysisTaskCMEV0.cxx

--- a/PWG/FLOW/Tasks/PWGflowTasksLinkDef.h
+++ b/PWG/FLOW/Tasks/PWGflowTasksLinkDef.h
@@ -46,7 +46,6 @@
 #pragma link C++ class AliAnalysisTaskMultiparticleFemtoscopy+;
 #pragma link C++ class AliAnalysisTaskForStudents+;
 #pragma link C++ class AliAnalysisTaskZDCGainEq+;
-#pragma link C++ class AliAnalysisTaskZDCEP+;
 #pragma link C++ class AliAnalysisTaskPiKpK0Lamba+;
 #pragma link C++ class AliAnalysisTaskCmeEse+;
 #pragma link C++ class AliAnalysisTaskCMEV0+;

--- a/PWGHF/vertexingHF/CMakeLists.txt
+++ b/PWGHF/vertexingHF/CMakeLists.txt
@@ -33,8 +33,8 @@ include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrections
                     ${AliPhysics_SOURCE_DIR}/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrectionsInterface/
                     ${AliPhysics_SOURCE_DIR}/PWG/FLOW/Base
-                    ${AliPhysics_SOURCE_DIR}/PWG/FLOW/Tasks
                     ${TREELITE_ROOT}/include
+                    ${YAML_CPP_SOURCE_DIR}/include
   )
 
 # Sources - alphabetical order
@@ -189,7 +189,7 @@ add_library_tested(${MODULE} SHARED  ${SRCS} G__${MODULE}.cxx)
 
 # Generate the ROOT map
 # Dependecies
-set(LIBDEPS ANALYSISalice PWGflowTasks PWGPPevcharQn PWGPPevcharQnInterface TMVA vHFBDT)
+set(LIBDEPS ANALYSISalice PWGflowBase PWGPPevcharQn PWGPPevcharQnInterface TMVA vHFBDT yaml-cpp CORRFW)
 # Dependencies for ROOT6 only
 if(ROOT_VERSION_MAJOR EQUAL 6)
   set(LIBDEPS ${LIBDEPS} ML)

--- a/PWGHF/vertexingHF/CMakeLists.txt
+++ b/PWGHF/vertexingHF/CMakeLists.txt
@@ -189,10 +189,10 @@ add_library_tested(${MODULE} SHARED  ${SRCS} G__${MODULE}.cxx)
 
 # Generate the ROOT map
 # Dependecies
-set(LIBDEPS ANALYSISalice PWGflowBase PWGPPevcharQn PWGPPevcharQnInterface TMVA vHFBDT yaml-cpp CORRFW)
+set(LIBDEPS ANALYSISalice PWGflowBase PWGPPevcharQn PWGPPevcharQnInterface TMVA vHFBDT CORRFW)
 # Dependencies for ROOT6 only
 if(ROOT_VERSION_MAJOR EQUAL 6)
-  set(LIBDEPS ${LIBDEPS} ML)
+  set(LIBDEPS ${LIBDEPS} ML yaml-cpp)
 endif()
 generate_rootmap("${MODULE}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULE}LinkDef.h")
 

--- a/PWGHF/vertexingHF/charmFlow/AliAnalysisTaskHFv1.cxx
+++ b/PWGHF/vertexingHF/charmFlow/AliAnalysisTaskHFv1.cxx
@@ -70,21 +70,14 @@
 #include "AliRDHFCutsLctopKpi.h"
 
 #include "AliEventplane.h"
-#include "AliFlowTrack.h"
-#include "AliFlowVector.h"
-#include "AliFlowTrackCuts.h"
-#include "AliFlowEvent.h"
 
 #include "AliAnalysisVertexingHF.h"
-#include "AliEventplane.h"
-#include "AliFlowTrack.h"
-#include "AliFlowVector.h"
-#include "AliFlowTrackCuts.h"
-#include "AliFlowEvent.h"
 #include "AliMultSelection.h"
 #include "AliQnCorrectionsManager.h"
 #include "AliAnalysisTaskFlowVectorCorrections.h"
 #include "AliAnalysisTaskZDCEP.h"
+#include "AliFlowEventSimple.h"
+#include "AliFlowVector.h"
 
 #include "AliAnalysisTaskHFv1.h"
 
@@ -783,7 +776,7 @@ void AliAnalysisTaskHFv1::UserExec(Option_t */*option*/)
             AliAnalysisTaskZDCEP *fZDCEPTask = dynamic_cast<AliAnalysisTaskZDCEP*>(AliAnalysisManager::GetAnalysisManager()->GetTask("AnalysisTaskZDCEP"));
             if (fZDCEPTask != NULL) {
                 // get ZDC Q-vectors
-                AliFlowEvent* anEvent = dynamic_cast<AliFlowEvent*>(GetInputData(1));
+                AliFlowEventSimple* anEvent = dynamic_cast<AliFlowEventSimple*>(GetInputData(1));
                 if(anEvent) {
                     // Get Q vectors for the subevents
                     AliFlowVector vQarray[2];
@@ -1978,7 +1971,7 @@ Float_t AliAnalysisTaskHFv1::GetEventPlaneForCandidate(AliAODRecoDecayHF* d, Ali
 //   dummy->SetEvent(aodEvent,MCEvent());
 
 //   //////////////// construct the flow event container ////////////
-//   AliFlowEvent flowEvent(cutsRP,dummy);
+//   AliFlowEventSimple flowEvent(cutsRP,dummy);
 //   flowEvent.SetReferenceMultiplicity( 64 );
 //   for(Int_t i=0;i<64&&binx>0;i++){
 //     AliFlowTrack *flowTrack=flowEvent.GetTrack(i);


### PR DESCRIPTION
Remove dependency on PWGflowTasks from PWGHFvertexingHF for an issue on the LEGO trains.

For this purpose move AliAnalysisTaskZDCEP from PWGflowTasks to PWGflowBase since it is needed for the ZDC calibrations in the AliAnalysisTaskHFv1 task.