### PR TITLE
modifications for analyses of rare resonances

### DIFF
--- a/PWGLF/RESONANCES/AliRsnCutCascade.cxx
+++ b/PWGLF/RESONANCES/AliRsnCutCascade.cxx
@@ -41,6 +41,7 @@ fV0MaxDaughtersDCA(0.5),
 fCascadeMaxDaughtersDCA(0.5),
 fMinTPCcluster(70),
 fMaxRapidity(0.8),
+fMaxPseudorapidity(1e20),
 fPID(pid),
 fPID2(pid2),
 fPID3(pid3),
@@ -81,6 +82,7 @@ fV0MaxDaughtersDCA(copy.fV0MaxDaughtersDCA),
 fCascadeMaxDaughtersDCA(copy.fCascadeMaxDaughtersDCA),
 fMinTPCcluster(copy.fMinTPCcluster),
 fMaxRapidity(copy.fMaxRapidity),
+fMaxPseudorapidity(copy.fMaxPseudorapidity),
 fPID(copy.fPID),
 fPID2(copy.fPID2),
 fPID3(copy.fPID3),
@@ -137,6 +139,7 @@ AliRsnCutCascade &AliRsnCutCascade::operator=(const AliRsnCutCascade &copy)
     fCascadeMaxDaughtersDCA = copy.fCascadeMaxDaughtersDCA;
     fMinTPCcluster = copy.fMinTPCcluster;
     fMaxRapidity = copy.fMaxRapidity;
+    fMaxPseudorapidity = copy.fMaxPseudorapidity;
     fCutQuality = copy.fCutQuality;
     fPID = copy.fPID;
     fPID2 = copy.fPID2;
@@ -270,6 +273,11 @@ Bool_t AliRsnCutCascade::CheckESD(AliESDcascade *Xi)
     
     if (TMath::Abs(Xi->Y(fHypothesis)) > fMaxRapidity) {
         AliDebugClass(2, "Failed check on Cascade rapidity");
+        return kFALSE;
+    }
+
+    if (TMath::Abs(Xi->Eta()) > fMaxPseudorapidity){
+        AliDebugClass(2, "Failed check on Cascade pseuorapidity");
         return kFALSE;
     }
     //
@@ -506,6 +514,14 @@ Bool_t AliRsnCutCascade::CheckAOD(AliAODcascade *Xi)
             AliDebugClass(2, "Failed check on Cascade rapidity");
             return kFALSE;
         }
+    }
+    
+    Double_t pXi = sqrt(Xi->Ptot2Xi());
+    Double_t pzXi = Xi->MomXiZ();
+    Double_t etaXi = 0.5*TMath::Log((pXi+pzXi)/(pXi-pzXi+1.e-13));
+    if (TMath::Abs(etaXi) > fMaxPseudorapidity){
+        AliDebugClass(2, "Failed check on Cascade pseuorapidity");
+        return kFALSE;
     }
     
     Double_t V0radius = Xi->RadiusV0();

--- a/PWGLF/RESONANCES/AliRsnCutCascade.h
+++ b/PWGLF/RESONANCES/AliRsnCutCascade.h
@@ -52,6 +52,7 @@ class AliRsnCutCascade : public AliRsnCut {
 
     void           SetMinTPCcluster(Int_t value)            {fMinTPCcluster = value;}
     void           SetMaxRapidity(Double_t value)           {fMaxRapidity = value;}
+    void           SetMaxPseudorapidity(Double_t value)     {fMaxPseudorapidity = value;}
 
     void           SetPIDCutV0Proton(Double_t value)        {fPIDCutV0Proton = value;}
     void           SetPIDCutV0Pion(Double_t value)          {fPIDCutV0Pion = value;}
@@ -88,6 +89,7 @@ protected:
     Double_t         fCascadeMaxDaughtersDCA;  // max allowed DCA between the two Cascade daughers
     Int_t            fMinTPCcluster;           // min allowed TPC cluster
     Double_t         fMaxRapidity;             // max allowed Cascade rapidity
+    Double_t         fMaxPseudorapidity;       // max allowed Cascade pseudorapidity
     
     AliPID::EParticleType fPID;                // PID for track
     AliPID::EParticleType fPID2;               // PID for track

--- a/PWGLF/RESONANCES/AliRsnCutMiniPair.cxx
+++ b/PWGLF/RESONANCES/AliRsnCutMiniPair.cxx
@@ -45,11 +45,11 @@ Bool_t AliRsnCutMiniPair::IsSelected(TObject *obj)
          return OkRangeD();
       case kRapidityFiducialRegion:
          fCutValueD = pair->Y(0);
-	 fRefPtValueD = pair->Pt(0);
+         fRefPtValueD = pair->Pt(0);
          return OkRangeD();
       case kRapidityFiducialRegionMC:
          fCutValueD = pair->Y(1);
-	 fRefPtValueD = pair->Pt(1);
+         fRefPtValueD = pair->Pt(1);
          return OkRangeD();  
       case kMomentumComparison:
          AliWarning("TODO: implement this");
@@ -60,20 +60,26 @@ Bool_t AliRsnCutMiniPair::IsSelected(TObject *obj)
       case kDeltaCosRange:
          fCutValueD = pair->DeltaCos(kFALSE);
          return OkRangeD();
-       case kPhiVRange:
-          fCutValueD = pair->PhiV(kFALSE);
-          return OkRangeD();
+      case kPhiVRange:
+         fCutValueD = pair->PhiV(kFALSE);
+         return OkRangeD();
       case kContainsV0Daughter:
-          return pair->ContainsV0Daughter();
+         return pair->ContainsV0Daughter();
       case kMassRange:
-	  fCutValueD = pair->InvMass(0);
-	  return OkRangeD();
+         fCutValueD = pair->InvMass(0);
+         return OkRangeD();
       case kAsymRange:
-          fCutValueD = pair->PairAsymmetry(0);
-	  return OkRangeD();
+         fCutValueD = pair->PairAsymmetry(0);
+         return OkRangeD();
       case kAsymRangeMC:
-          fCutValueD = pair->PairAsymmetry(1);
-	  return OkRangeD();
+         fCutValueD = pair->PairAsymmetry(1);
+         return OkRangeD();
+      case kPseudorapidityRange:
+         fCutValueD = pair->Eta(0);
+         return OkRangeD();
+      case kPseudorapidityRangeMC:
+         fCutValueD = pair->Eta(1);
+         return OkRangeD();
 
    default:
          AliWarning("Undefined enum value");

--- a/PWGLF/RESONANCES/AliRsnCutMiniPair.h
+++ b/PWGLF/RESONANCES/AliRsnCutMiniPair.h
@@ -28,6 +28,8 @@ public:
       kMassRange,
       kAsymRange,
       kAsymRangeMC,
+      kPseudorapidityRange,
+      kPseudorapidityRangeMC,
       kTypes
    };
 

--- a/PWGLF/RESONANCES/AliRsnCutV0.cxx
+++ b/PWGLF/RESONANCES/AliRsnCutV0.cxx
@@ -64,6 +64,7 @@ AliRsnCutV0::AliRsnCutV0(const char *name, Int_t hypothesis, AliPID::EParticleTy
    fMaxDaughtersDCA(0.5),
    fMinTPCcluster(70),
    fMaxRapidity(0.8),
+   fMaxPseudorapidity(1e20),
    fPID(pid),
    fPID2(pid2),
    fPIDCutProton(0),
@@ -101,6 +102,7 @@ AliRsnCutV0::AliRsnCutV0(const AliRsnCutV0 &copy) :
    fMaxDaughtersDCA(copy.fMaxDaughtersDCA),
    fMinTPCcluster(copy.fMinTPCcluster),
    fMaxRapidity(copy.fMaxRapidity),
+   fMaxPseudorapidity(copy.fMaxPseudorapidity),
    fPID(copy.fPID),
    fPID2(copy.fPID2),
    fPIDCutProton(copy.fPIDCutProton),
@@ -152,6 +154,7 @@ AliRsnCutV0 &AliRsnCutV0::operator=(const AliRsnCutV0 &copy)
    fMaxDaughtersDCA = copy.fMaxDaughtersDCA;
    fMinTPCcluster = copy.fMinTPCcluster;
    fMaxRapidity = copy.fMaxRapidity;
+   fMaxPseudorapidity = copy.fMaxPseudorapidity;
    fCutQuality = copy.fCutQuality;
    fPID = copy.fPID;
    fPID2 = copy.fPID2;
@@ -288,6 +291,10 @@ Bool_t AliRsnCutV0::CheckESD(AliESDv0 *v0)
    }
    if (TMath::Abs(v0->Y(fHypothesis)) > fMaxRapidity) {
       AliDebugClass(2, "Failed check on V0 rapidity");
+      return kFALSE;
+   }
+   if (TMath::Abs(v0->Eta()) > fMaxPseudorapidity) {
+      AliDebugClass(2, "Failed check on V0 pseudorapidity");
       return kFALSE;
    }
    //
@@ -620,6 +627,11 @@ Bool_t AliRsnCutV0::CheckAOD(AliAODv0 *v0)
 
    if (TMath::Abs(v0->RapLambda()) > fMaxRapidity) {
       AliDebugClass(2, "Failed check on V0 rapidity");
+      return kFALSE;
+   }
+
+   if (TMath::Abs(v0->Eta()) > fMaxPseudorapidity) {
+      AliDebugClass(2, "Failed check on V0 pseusorapidity");
       return kFALSE;
    }
 

--- a/PWGLF/RESONANCES/AliRsnCutV0.h
+++ b/PWGLF/RESONANCES/AliRsnCutV0.h
@@ -38,6 +38,7 @@ public:
    void           SetMaxDaughtersDCA(Double_t value)       {fMaxDaughtersDCA = value;}
    void           SetMinTPCcluster(Int_t value)            {fMinTPCcluster = value;}
    void           SetMaxRapidity(Double_t value)           {fMaxRapidity = value;}
+   void           SetMaxPseudorapidity(Double_t value)           {fMaxPseudorapidity = value;}
    
    void           SetPIDCutProton(Double_t value)          {fPIDCutProton = value;}
    void           SetPIDCutPion(Double_t value)            {fPIDCutPion = value;}
@@ -74,6 +75,7 @@ protected:
    Double_t         fMaxDaughtersDCA;  // max allowed DCA between the two daughers
    Int_t            fMinTPCcluster;    // min allowed TOC cluster
    Double_t         fMaxRapidity;      // max allowed V0 rapidity
+   Double_t         fMaxPseudorapidity; // max allowed V0 pseudorapidity
    Bool_t           fCustomTrackDCACuts; // Use different DCA cuts for positive and negative V0 tracks
    Double_t         fMinDCAPositiveTrack; // DCA of positive V0 track to vertex
    Double_t         fMinDCANegativeTrack; // DCA of negative V0 track to vertex

--- a/PWGLF/RESONANCES/AliRsnMiniAnalysisTask.cxx
+++ b/PWGLF/RESONANCES/AliRsnMiniAnalysisTask.cxx
@@ -1352,12 +1352,17 @@ void AliRsnMiniAnalysisTask::FillTrueMotherESD(AliRsnMiniEvent *miniEvent)
    for (id = 0; id < ndef; id++) {
       def = (AliRsnMiniOutput *)fHistograms[id];
       if (!def) continue;
-      if (!def->IsMother() && !def->IsMotherInAcc()) continue;
+      if (!def->IsMother() && !def->IsMotherInAcc() && !def->IsSingle()) continue;
       for (ip = 0; ip < npart; ip++) {
          AliMCParticle *part = (AliMCParticle *)fMCEvent->GetTrack(ip);
 	 
          //get mother pdg code
          if (!AliRsnDaughter::IsEquivalentPDGCode(part->Particle()->GetPdgCode() , def->GetMotherPDG())) continue;
+         if(def->IsSingle()) {
+           def->FillSingle(part, miniEvent, &fValues);
+           continue;
+         }
+
          // check that daughters match expected species
          if (part->Particle()->GetNDaughters() < 2) continue;
 	      if (fMaxNDaughters > 0 && part->Particle()->GetNDaughters() > fMaxNDaughters) continue;
@@ -1477,11 +1482,16 @@ void AliRsnMiniAnalysisTask::FillTrueMotherAOD(AliRsnMiniEvent *miniEvent)
    for (id = 0; id < ndef; id++) {
       def = (AliRsnMiniOutput *)fHistograms[id];
       if (!def) continue;
-      if (!def->IsMother() && !def->IsMotherInAcc()) continue;
+      if (!def->IsMother() && !def->IsMotherInAcc() && !def->IsSingle()) continue;
       for (ip = 0; ip < npart; ip++) {
          AliAODMCParticle *part = (AliAODMCParticle *)list->At(ip);
 	 
          if (!AliRsnDaughter::IsEquivalentPDGCode(part->GetPdgCode() , def->GetMotherPDG())) continue;
+         if(def->IsSingle()) {
+           def->FillSingle(part, miniEvent, &fValues);
+           continue;
+         }
+
          // check that daughters match expected species
          if (part->GetNDaughters() < 2) continue;
 	 if (fMaxNDaughters > 0 && part->GetNDaughters() > fMaxNDaughters) continue;

--- a/PWGLF/RESONANCES/AliRsnMiniOutput.h
+++ b/PWGLF/RESONANCES/AliRsnMiniOutput.h
@@ -45,6 +45,7 @@ public:
       kTruePair,
       kMother,
       kMotherInAcc,
+      kSingle,
       kComputations
    };
 
@@ -60,6 +61,7 @@ public:
    Bool_t          IsTruePair()         const {return (fComputation == kTruePair);}
    Bool_t          IsMother()           const {return (fComputation == kMother);}
    Bool_t          IsMotherInAcc()      const {return (fComputation == kMotherInAcc);}
+   Bool_t          IsSingle()           const {return (fComputation == kSingle);}
    Bool_t          IsDefined()          const {return (IsEventOnly() || IsTrackPair() || IsTrackPairMix() || IsTruePair() || IsMother());}
    Bool_t          IsLikeSign()         const {return (fCharge[0] == fCharge[1]);}
    Bool_t          IsSameCut()          const {return (fCutID[0] == fCutID[1]);}
@@ -80,6 +82,7 @@ public:
    Double_t        GetMotherMass()      const {return fMotherMass;}
    Bool_t          GetFillHistogramOnlyInRange() { return fCheckHistRange; }
    Short_t         GetMaxNSisters()           {return fMaxNSisters;}
+   Bool_t          GetCheckSameCutID()  const {return fCheckSameCutID;}
 
    void            SetOutputType(EOutputType type)    {fOutputType = type;}
    void            SetComputation(EComputation src)   {fComputation = src;}
@@ -96,7 +99,8 @@ public:
    void            SetCheckMomentumConservation(Bool_t checkP) {fCheckP = checkP;}
    void            SetCheckFeedDown(Bool_t checkFeedDown)      {fCheckFeedDown = checkFeedDown;}
    void            SetDselection(UShort_t originDselection);
-   void 	   SetRejectCandidateIfNotFromQuark(Bool_t opt){fRejectIfNoQuark=opt;}
+   void            SetRejectCandidateIfNotFromQuark(Bool_t opt){fRejectIfNoQuark=opt;}
+   void            SetCheckSameCutID(Bool_t opt=true) {fCheckSameCutID=opt;}
 
    void            AddAxis(Int_t id, Int_t nbins, Double_t min, Double_t max);
    void            AddAxis(Int_t id, Double_t min, Double_t max, Double_t step);
@@ -108,6 +112,8 @@ public:
    Bool_t          Init(const char *prefix, TList *list);
    Bool_t          FillMother(const AliRsnMiniPair *pair, AliRsnMiniEvent *event, TClonesArray *valueList);
    Bool_t          FillMotherInAcceptance(const AliRsnMiniPair *pair, AliRsnMiniEvent *event, TClonesArray *valueList);
+   Bool_t          FillSingle(const AliMCParticle *particle, AliRsnMiniEvent *event, TClonesArray *valueList);
+   Bool_t          FillSingle(const AliAODMCParticle *particle, AliRsnMiniEvent *event, TClonesArray *valueList);
    Bool_t          FillEvent(AliRsnMiniEvent *event, TClonesArray *valueList);
    Int_t           FillPair(AliRsnMiniEvent *event1, AliRsnMiniEvent *event2, TClonesArray *valueList, Bool_t refFirst = kTRUE);
 
@@ -141,9 +147,10 @@ private:
    Bool_t           fCheckFeedDown;    // flag to set in order to check the particle feed down (specific for D meson analysis)
    UShort_t 	    fOriginDselection; // flag to select D0 origins. 0 Only from charm 1 only from beauty 2 both from charm and beauty (specific for D meson analysis)
    Bool_t   	    fKeepDfromB;       // flag for the feed down from b quark decay (specific for D meson analysis)			  
-   Bool_t   	    fKeepDfromBOnly;   // flag to keep only the charm particles that comes from beauty decays (specific for D meson analysis)
-   Bool_t 	    fRejectIfNoQuark;  // flag to remove events not generated with PYTHIA
+   Bool_t           fKeepDfromBOnly;   // flag to keep only the charm particles that comes from beauty decays (specific for D meson analysis)
+   Bool_t           fRejectIfNoQuark;  // flag to remove events not generated with PYTHIA
    Bool_t           fCheckHistRange;   //  check if values is in histogram range
+   Bool_t           fCheckSameCutID; // alternate check for whether the two daughters are of the same type, using fCutID instead of fDaughter
 
    ClassDef(AliRsnMiniOutput, 7)  // AliRsnMiniOutput class
 };


### PR DESCRIPTION
Introduction of Pseudorapidity cuts on resonance daughters, method for extracting generated long-lived particles (pi±, K±, p) from MC, modification for Lambda+Lambda analysis