### PR TITLE
corrected paircleaner loop

### DIFF
--- a/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPairCleaner.cxx
+++ b/PWGCF/FEMTOSCOPY/FemtoDream/AliFemtoDreamPairCleaner.cxx
@@ -89,7 +89,7 @@ void AliFemtoDreamPairCleaner::CleanDecayAndDecay(
     if (itDecay1->UseParticle()) {
       for (auto itDecay2 = Decay2->begin(); itDecay2 != Decay2->end();
           ++itDecay2) {
-        if (itDecay1->UseParticle()) {
+        if (itDecay2->UseParticle()) {
           std::vector<int> IDDaug1 = itDecay1->GetIDTracks();
           std::vector<int> IDDaug2 = itDecay2->GetIDTracks();
           for (auto itID1s = IDDaug1.begin(); itID1s != IDDaug1.end();


### PR DESCRIPTION
In CleanDecayAndDecay the UseParticle check was done twice on particle1 instead of both