### PR TITLE
Out-of-Bunch Pileup cut for resonances

### DIFF
--- a/PWGLF/RESONANCES/AliRsnCutMiniPair.cxx
+++ b/PWGLF/RESONANCES/AliRsnCutMiniPair.cxx
@@ -80,6 +80,8 @@ Bool_t AliRsnCutMiniPair::IsSelected(TObject *obj)
       case kPseudorapidityRangeMC:
          fCutValueD = pair->Eta(1);
          return OkRangeD();
+      case kPassesOOBPileupCut:
+         return pair->PassesOOBPileupCut();
 
    default:
          AliWarning("Undefined enum value");

--- a/PWGLF/RESONANCES/AliRsnCutMiniPair.h
+++ b/PWGLF/RESONANCES/AliRsnCutMiniPair.h
@@ -30,6 +30,7 @@ public:
       kAsymRangeMC,
       kPseudorapidityRange,
       kPseudorapidityRangeMC,
+      kPassesOOBPileupCut,
       kTypes
    };
 

--- a/PWGLF/RESONANCES/AliRsnMiniPair.cxx
+++ b/PWGLF/RESONANCES/AliRsnMiniPair.cxx
@@ -70,6 +70,9 @@ void AliRsnMiniPair::Fill
       if (p1->IndexBachelor() == p2->IndexV0Neg()) fContainsV0Daughter = kTRUE;
       if (p1->IndexBachelor() == p2->IndexBachelor()) fContainsV0Daughter = kTRUE;
    }
+
+   fPassesOOBPileupCut = kFALSE;
+   if (p1->PassesOOBPileupCut() || p2->PassesOOBPileupCut()) fPassesOOBPileupCut = kTRUE;
 }
 
 //__________________________________________________________________________________________________

--- a/PWGLF/RESONANCES/AliRsnMiniPair.h
+++ b/PWGLF/RESONANCES/AliRsnMiniPair.h
@@ -20,13 +20,14 @@ class AliRsnMiniEvent;
 class AliRsnMiniPair : public TObject {
 public:
 
- AliRsnMiniPair() : fDCA1(0), fDCA2(0), fMother(-1), fMotherPDG(0), fNSisters(-1), fIsFromB(kFALSE), fIsQuarkFound(kFALSE),fContainsV0Daughter(kFALSE) {for (Int_t i = 0; i<3; i++) fPmother[i] = 0.0;}
+ AliRsnMiniPair() : fDCA1(0), fDCA2(0), fMother(-1), fMotherPDG(0), fNSisters(-1), fIsFromB(kFALSE), fIsQuarkFound(kFALSE),fContainsV0Daughter(kFALSE), fPassesOOBPileupCut(kFALSE) {for (Int_t i = 0; i<3; i++) fPmother[i] = 0.0;}
   
    Int_t          &Mother()    {return fMother;}
    Long_t         &MotherPDG() {return fMotherPDG;}
    Bool_t         &IsFromB()      {return fIsFromB;}
    Bool_t         &IsQuarkFound() {return fIsQuarkFound;}
    Bool_t         &ContainsV0Daughter() {return fContainsV0Daughter;}
+   Bool_t         &PassesOOBPileupCut() {return fPassesOOBPileupCut;}
    Float_t        &PmotherX()  {return fPmother[0];}
    Float_t        &PmotherY()  {return fPmother[1];}
    Float_t        &PmotherZ()  {return fPmother[2];} 
@@ -83,6 +84,7 @@ public:
    Bool_t         fIsQuarkFound;      // is the particle from a quark flag (used to reject or accept Hijing event)
    Float_t        fPmother[3];// MC momentum of the pair corresponding mother
    Bool_t         fContainsV0Daughter; // Flag if one of particle is part of V0's daughter
+   Bool_t         fPassesOOBPileupCut; // At least one daughter passes the out-of-bunch pileup cut
    
    ClassDef(AliRsnMiniPair, 6)
      };

--- a/PWGLF/RESONANCES/AliRsnMiniParticle.h
+++ b/PWGLF/RESONANCES/AliRsnMiniParticle.h
@@ -11,12 +11,14 @@
 #include <TObject.h>
 #include <TLorentzVector.h>
 
+#include "AliESDtrack.h"
+
 class AliRsnDaughter;
 
 class AliRsnMiniParticle : public TObject {
 public:
 
-   AliRsnMiniParticle() : fIndex(-1), fCharge(0), fPDG(0), fMother(0), fMotherPDG(0), fDCA(0), fNTotSisters(0), fIsFromB(kFALSE), fIsQuarkFound(kFALSE), fCutBits(0x0) {
+   AliRsnMiniParticle() : fIndex(-1), fCharge(0), fPDG(0), fMother(0), fMotherPDG(0), fDCA(0), fNTotSisters(0), fIsFromB(kFALSE), fIsQuarkFound(kFALSE), fCutBits(0x0), fPassesOOBPileupCut(kTRUE) {
        Int_t i = 3; while (i--) fPsim[i] = fPrec[i] = fPmother[i] = 0.0;
        fIndexDaughters[0] = fIndexDaughters[1] = fIndexDaughters[2] = -1;
        fMass[0] = fMass[1] = -1.0;
@@ -55,6 +57,7 @@ public:
    Bool_t        HasCutBit(Int_t i)         {UShort_t bit = 1 << i; return ((fCutBits & bit) != 0);}
    void          SetCutBit(Int_t i)         {UShort_t bit = 1 << i; fCutBits |=   bit;}
    void          ClearCutBit(Int_t i)       {UShort_t bit = 1 << i; fCutBits &= (~bit);}
+   Bool_t        &PassesOOBPileupCut()      {return fPassesOOBPileupCut;}
 
    void          Clear(Option_t *opt="");
 
@@ -62,6 +65,8 @@ public:
    void          CopyDaughter(AliRsnDaughter *daughter);
 
 private:
+    
+   Bool_t    TrackPassesOOBPileupCut(AliESDtrack* t, Double_t b);
 
    Int_t     fIndex;        // ID of track in its event
    Int_t     fIndexDaughters[3]; // daugher indices (0:pos, 1:neg, 2: bachelor) (if not V0/resonance then 0:ESD/AOD label, 1:(-1))
@@ -78,6 +83,7 @@ private:
    Bool_t    fIsFromB;	    // is the particle from B meson flag
    Bool_t    fIsQuarkFound; // is the particle from a quark flag (used to reject or accept Hijing event)
    UShort_t  fCutBits;      // list of bits used to know what cuts were passed by this track
+   Bool_t    fPassesOOBPileupCut; // passes out-of-bunch pileup cut
 
    ClassDef(AliRsnMiniParticle, 9)
 };


### PR DESCRIPTION
Introduced out-of-bunch pileup cut for resonance analyses. At least one final-state decay product of the resonance must have an ITS or TOF hit.