### PR TITLE
PWGHF: Adding PreSelect for pK0s for Pb-Pb

### DIFF
--- a/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
+++ b/PWGHF/treeHF/AliAnalysisTaskSEHFTreeCreator.cxx
@@ -2485,6 +2485,18 @@ void AliAnalysisTaskSEHFTreeCreator::ProcessCasc(TClonesArray *arrayCasc, AliAOD
     
     if (isLc2V0bachelortagged && fWriteVariableTreeLc2V0bachelor){
       
+      if(fFiltCutsLc2V0bachelor->GetUsePreselect()){
+        TObjArray arrTracks(2);
+        for(Int_t ipr=0;ipr<2;ipr++){
+          AliAODTrack *tr;
+          if(ipr==0) tr=vHF->GetProng(aod,d,ipr);
+          else tr = (AliAODTrack*)(aod->GetV0(d->GetProngID(1)));
+          arrTracks.AddAt(tr,ipr);
+        }
+        Int_t PreSelectLc = fFiltCutsLc2V0bachelor->PreSelect(arrTracks);
+        if(PreSelectLc==0) continue;
+      }
+
       fNentries->Fill(33);
       nFilteredLc2V0bachelor++;
       if((vHF->FillRecoCasc(aod,d,kFALSE,fLc2V0bachelorCalcSecoVtx))) {//Fill the data members of the candidate only if they are empty.

--- a/PWGHF/vertexingHF/AliRDHFCutsLctoV0.cxx
+++ b/PWGHF/vertexingHF/AliRDHFCutsLctoV0.cxx
@@ -724,6 +724,53 @@ Int_t AliRDHFCutsLctoV0::IsSelected(TObject* obj,Int_t selectionLevel, AliAODEve
 
 }
 //---------------------------------------------------------------------------
+Int_t AliRDHFCutsLctoV0::PreSelect(TObjArray aodTracks){
+  //
+  // Apply pT and PID pre-selections, used before refilling candidate
+  // Note, PID checks only Lc -> pK0s case
+  //
+
+  if(!fUsePreselect) return 3;
+
+  Int_t retVal=3;
+
+  AliAODTrack *track0 = (AliAODTrack*)aodTracks.At(0);
+  AliAODTrack *track1 = (AliAODTrack*)aodTracks.At(1);
+
+  // calculate pt
+  Double_t px0=track0->Px();
+  Double_t px1=track1->Px();
+
+  Double_t py0=track0->Py();
+  Double_t py1=track1->Py();
+
+  Double_t ptD=TMath::Sqrt((px0+px1)*(px0+px1)+(py0+py1)*(py0+py1));
+
+  if(ptD<fMinPtCand) return 0;
+  if(ptD>fMaxPtCand) return 0;
+
+  Int_t ptbin=PtBin(ptD);
+  if (ptbin==-1) return 0;
+
+  // V0 pT min
+  if (track1->Pt() < fCutsRD[GetGlobalIndex(15,ptbin)]) return 0;
+
+  // bachelor pT min
+  if (track0->Pt() < fCutsRD[GetGlobalIndex(4,ptbin)]) return 0;
+
+  if(fUsePID){
+    Bool_t okLcK0Sp = kTRUE; // K0S case
+    Bool_t okLcLambdaBarPi = kTRUE; // LambdaBar case
+    Bool_t okLcLambdaPi = kTRUE; // Lambda case
+
+    CheckPID(track0,0x0,0x0,okLcK0Sp,okLcLambdaBarPi,okLcLambdaPi);
+
+    retVal = okLcK0Sp;
+  }
+
+  return retVal;
+}
+//---------------------------------------------------------------------------
 Bool_t AliRDHFCutsLctoV0::PreSelect(TObject* obj, AliAODv0 *v0, AliVTrack *bachelorTrack){
   //
   // Apply pre-selections, used in the AOD filtering

--- a/PWGHF/vertexingHF/AliRDHFCutsLctoV0.h
+++ b/PWGHF/vertexingHF/AliRDHFCutsLctoV0.h
@@ -54,6 +54,7 @@ class AliRDHFCutsLctoV0 : public AliRDHFCuts
   virtual Int_t IsSelectedPID(AliAODRecoDecayHF* obj);
 
   using AliRDHFCuts::PreSelect;
+  virtual Int_t PreSelect(TObjArray aodtracks);
   Bool_t PreSelect(TObject* obj, AliAODv0 *v0, AliVTrack *bachelorTrack);
 
   Int_t IsSelectedSingleCut(TObject* obj, Int_t selectionLevel, Int_t cutIndex, AliAODEvent* aod=0x0);


### PR DESCRIPTION
Attempt to speed-up running the Lc->pK0s analyses in Pb-Pb 2018 by adding a similar PreSelect function as used for the D mesons.

Note that we don't call the ReconstructSecondaryVertex() for the pK0s candidate, so the FillRecoCasc function is not as heavy as for the D mesons.