### PR TITLE
Out-of-Bunch Pileup cut for v0s

### DIFF
--- a/PWGLF/RESONANCES/AliRsnCutV0.h
+++ b/PWGLF/RESONANCES/AliRsnCutV0.h
@@ -46,6 +46,7 @@ public:
    void           SetDifferentDCACutPosNegTrack(Bool_t doDifferentTrackDCACuts){fCustomTrackDCACuts = doDifferentTrackDCACuts;}
    void           SetMinDCAToVtxXYPositiveTrack(Double_t value) {fMinDCAPositiveTrack = value;}
    void           SetMinDCAToVtxXYNegativeTrack(Double_t value) {fMinDCANegativeTrack = value;}
+   void           SetCheckOOBPileup(Bool_t value = true)   {fCheckOOBPileup = value;}
 
    AliRsnCutTrackQuality *CutQuality()                     {return &fCutQuality;}
    void           SetAODTestFilterBit(Int_t value)         {fAODTestFilterBit = value;}
@@ -58,7 +59,7 @@ protected:
 
    Bool_t      CheckESD(AliESDv0 *track);
    Bool_t      CheckAOD(AliAODv0 *track);
-
+   Bool_t      TrackPassesOOBPileupCut(AliESDtrack* t, Double_t b);
    
    Int_t            fHypothesis;       // PDG code corresponding to expected V0 hypothesis
    Int_t            fpT_Tolerance=0;     // Switch to set pT dependent Mass Tolerance
@@ -79,6 +80,7 @@ protected:
    Bool_t           fCustomTrackDCACuts; // Use different DCA cuts for positive and negative V0 tracks
    Double_t         fMinDCAPositiveTrack; // DCA of positive V0 track to vertex
    Double_t         fMinDCANegativeTrack; // DCA of negative V0 track to vertex
+   Bool_t           fCheckOOBPileup;   // Check out-of-bunch pileup
    
    AliPID::EParticleType fPID;         // PID for track
    AliPID::EParticleType fPID2;        // PID for track

--- a/PWGLF/RESONANCES/macros/mini/AddTaskRare_pp13.C
+++ b/PWGLF/RESONANCES/macros/mini/AddTaskRare_pp13.C
@@ -2050,10 +2050,14 @@ Bool_t Config_Lambdak0(
     Bool_t enableMonitor=kTRUE;
     
     // selections for V0 daughters
-    
+
     Int_t K0sCuts=TrackCutsK%1000;
     Bool_t CheckOOBP = true;
-    if(TrackCutsK>1000) CheckOOBP=false;
+    Bool_t CheckOOBPv0 = false;
+    if(TrackCutsK>1000){
+        CheckOOBP=false;
+        CheckOOBPv0=true;
+    }
     
     Int_t v0d_xrows=70;
     Float_t v0d_rtpc=0.8;
@@ -2099,6 +2103,7 @@ Bool_t Config_Lambdak0(
     cutK0s->SetMinCosPointingAngle(k0sCosPoinAn);
     cutK0s->SetMaxPseudorapidity(0.8);
     cutK0s->SetMinTPCcluster(-1);
+    cutK0s->SetCheckOOBPileup(CheckOOBPv0);
     
     AliRsnCutSet* cutSetK0s=new AliRsnCutSet("setK0s",AliRsnTarget::kDaughter);
     cutSetK0s->AddCut(cutK0s);
@@ -2140,6 +2145,7 @@ Bool_t Config_Lambdak0(
     cutLambda->SetMinCosPointingAngle(lambdaCosPoinAn);
     cutLambda->SetMaxPseudorapidity(0.8);
     cutLambda->SetMinTPCcluster(-1);
+    cutLambda->SetCheckOOBPileup(CheckOOBPv0);
     
     AliRsnCutSet* cutSetLambda=new AliRsnCutSet("setLambda",AliRsnTarget::kDaughter);
     cutSetLambda->AddCut(cutLambda);
@@ -2162,6 +2168,7 @@ Bool_t Config_Lambdak0(
     cutAntiLambda->SetMinCosPointingAngle(lambdaCosPoinAn);
     cutAntiLambda->SetMaxPseudorapidity(0.8);
     cutAntiLambda->SetMinTPCcluster(-1);
+    cutAntiLambda->SetCheckOOBPileup(CheckOOBPv0);
     
     AliRsnCutSet* cutSetAntiLambda=new AliRsnCutSet("setAntiLambda",AliRsnTarget::kDaughter);
     cutSetAntiLambda->AddCut(cutAntiLambda);


### PR DESCRIPTION
Introduce alternate way to apply out-of-bunch pileup cut to v0s within resonance package.