### PR TITLE
PWGCF: Remove uncessary methods

### DIFF
--- a/PWG/FLOW/Tasks/AliAnalysisTaskTwoMultiCorrelations.cxx
+++ b/PWG/FLOW/Tasks/AliAnalysisTaskTwoMultiCorrelations.cxx
@@ -14,24 +14,17 @@
 * provided "as is" without express or implied warranty.                  * 
 **************************************************************************/
 
-//--------------------------------------------------------------------------------------//
-// Analysis task for the computation of the multiparticle correlations for the flow     //
-// harmonics v_1 to v_6. This version of the script compute the 2-, 4- and 6- particle  //
-// correlations for all the useful combinations of these six harmonics. It can take     //
-// Monte Carlo simulations data (e.g. HIJING), as well as the experimental Pb-Pb data   //
-// taken by the ALICE experiment.                                                       //
-// The method used to compute the multiparticle correlations is the Generic Framework   //
-// based on Q-vectors. A setter lets open the possibility to cross-check the results    //
-// with nested loops.                                                                   //
-//                                                                                      //
-// Author: Cindy Mordasini (cindy.mordasini@cern.ch)                                    //
-// Version: 27.02.2019                                                                  //
-//--------------------------------------------------------------------------------------//
-
 #include "AliAnalysisTaskTwoMultiCorrelations.h"
 #include "AliLog.h"
 #include "AliAnalysisManager.h"
 #include "Riostream.h"
+#include "TList.h"
+#include "TComplex.h"
+#include "TFile.h"
+#include "TH2I.h"
+#include "TH1F.h"
+#include "TH1I.h"
+#include "TProfile.h"
 #include "AliAODEvent.h"
 #include "AliAODInputHandler.h"
 #include "AliMCEvent.h"
@@ -42,280 +35,189 @@
 #include "AliMCVertex.h"
 #include "AliAODMCParticle.h"
 #include "TMath.h"
-#include "TComplex.h"
-#include "TFile.h"
-#include "TList.h"
 #include <vector>
-#include "TH2I.h"
-#include "TH1D.h"
-#include "TH1I.h"
 
 using std::cout;
 using std::endl;
 
 ClassImp(AliAnalysisTaskTwoMultiCorrelations)
 
-//######################################################################################//
-// Mandatory methods for AliAnalysisTaskSE.
-//======================================================================================//
+/* ========================================================================== /
+/ Mandatory methods needed for AliAnalysisTaskSE.                             /
+/ ========================================================================== */
 AliAnalysisTaskTwoMultiCorrelations::AliAnalysisTaskTwoMultiCorrelations() :
   AliAnalysisTaskSE(),
-// General parameters of the analysis.
+// General parameters for the analysis.
   fMainList(NULL),
+  fHighestHarmonic(8),
+  fLargestCorrelators(8),
+  fComputeEtaGaps(kFALSE),
+  fDoCorrelationsHisto(kFALSE),
+  fUseNonUnitParticleWeights(kFALSE),
   fEfficiency(NULL),
   fFirstEvent(kTRUE),
-  fHighestFlowHarmonic(6),
-  fMaxNumberOfParticlesInCorrelations(8),
-  fProcessOnlyAOD(kFALSE),
-  fProcessOnlyMC(kFALSE),
-  fProcessBothMCandAOD(kFALSE),
-  fComputeEtaGaps(kFALSE),
-  fCrosscheckWithNestedLoops(kFALSE),
-  fDoTDCorrelationHisto(kFALSE),
-  fUseParticleWeights(kFALSE),
-// Parameters related to the number of tracks.
+// Type of files used in the analysis.
+  fAnalyseOnlyAOD(kFALSE),
+  fAnalyseOnlyMC(kFALSE),
+  fAnalyseBothMCandAOD(kFALSE),
+  fAODevent(NULL),
+  fMCevent(NULL),
+// Parameters and histograms related to the centrality.
   fMultiplicityList(NULL),
-  fHistoInitialCentrality(NULL),
-  fHistoFinalCentrality(NULL),
-  fHistoInitialNumberOfTracks(NULL),
-  fHistoInitialNumberOfTracksMain(NULL),
-  fHistoInitialNumberOfTracksGlobal(NULL),
-  fHistoFinalNumberOfTracksMain(NULL),
-  fHistoFinalNumberOfTracksGlobal(NULL),
-  fHistoFinalNumberOfTracks(NULL),
-  fHistoInitialFilterCorrelations(NULL),
-  fHistoFinalFilterCorrelations(NULL),
   fCentralityFromVZero(kFALSE),
-  fCentralityFromSPD(kFALSE),
+  fCentralityFromSPD(kFALSE), 
   fCentralityMin(0.),
   fCentralityMax(100.),
-  fNumberOfBinsHINOT(30000),
-  fMaxBinHINOT(30000.),
-  fNumberOfBinsHFNOT(30000),
-  fMaxBinHFNOT(30000.),
-  fNumberOfBinsHFC(5000),
-  fMaxBinHFC(5000.),
-// Parameters related to the event selection criteria.
+  fMultSelection(NULL),
+// Parameters and histograms related to the number of tracks.
+  fInitialMultiplicity(0),
+// Parameters and histograms related to the event selection.
   fEventSelectionList(NULL),
-  fHistoInitialPVX(NULL),
-  fHistoFinalPVX(NULL),
-  fHistoInitialPVY(NULL),
-  fHistoFinalPVY(NULL),
-  fHistoInitialPVZ(NULL),
-  fHistoFinalPVZ(NULL),
-  fCutOnPVX(kFALSE),
-  fCutOnPVY(kFALSE),
-  fCutOnPVZ(kFALSE),
-  fPVXMin(-44.),
-  fPVXMax(44.),
-  fPVYMin(-44),
-  fPVYMax(44.),
-  fPVZMin(-10.),
-  fPVZMax(10),
-// Parameters related to the track selection criteria.
-  fTrackSelectionList(NULL),
-  fHistoInitialPt(NULL),
-  fHistoFinalPt(NULL),
-  fHistoEfficiencyCorrection(NULL),
-  fHistoInitialEta(NULL),
-  fHistoFinalEta(NULL),
-  fHistoInitialPhi(NULL),
-  fHistoFinalPhi(NULL),
-  fHistoInitialNumberOfTPC(NULL),
-  fHistoFinalNumberOfTPC(NULL),
-  fHistoInitialChiSquare(NULL),
-  fHistoFinalChiSquare(NULL),
-  fHistoInitialDCAxy(NULL),
-  fHistoFinalDCAxy(NULL),
-  fHistoInitialDCAz(NULL),
-  fHistoFinalDCAz(NULL),
-  fHistoInitialCharge(NULL),
-  fHistoFinalCharge(NULL),
-  fHistoInitialNumberOfITS(NULL),
-  fHistoFinalNumberOfITS(NULL),
-  fCutOnTDCorrelations(kFALSE),
-  fCutOnPt(kFALSE),
-  fCutOnEta(kFALSE),
-  fCutOnNumberOfTPC(kFALSE),
-  fCutOnChiSquarePInTPC(kFALSE),
-  fCutOnDCAxy(kFALSE),
-  fCutOnDCAz(kFALSE),
-  fCutOnCharge(kFALSE),
-  fMainFilter(768),
-  fGlobalFilter(256),
+  fCutOnPVx(kFALSE),
+  fPVxMin(-44.),
+  fPVxMax(44.),
+  fCutOnPVy(kFALSE),
+  fPVyMin(-44.),
+  fPVyMax(44.),
+  fCutOnPVz(kFALSE),
+  fPVzMin(-10.),
+  fPVzMax(-10.),
   fMultiplicityMin(6),
+  fMainFilter(128),
+  fGlobalFilter(256),
+  fCutOnHMOs(kFALSE),
   fMultiplicityMinA(0.),
   fMultiplicityMinB(0.),
   fMultiplicityMaxA(0.),
   fMultiplicityMaxB(0.),
+// Parameters and histograms related to the track selection.
+  fTrackSelectionList(NULL),
+  fFilterbitIndex(0),
+  fCutOnPt(kFALSE),
   fPtMin(0.2),
   fPtMax(5.),
+  fHistoEfficiency(NULL),
+  fHistoEffInverse(NULL),
+  fCutOnEta(kFALSE),
   fEtaMin(-0.8),
   fEtaMax(0.8),
-  fNumberOfTPCMin(70),
-  fChiSquarePInTPCMin(0.1),
-  fChiSquarePInTPCMax(4.),
+  fCutOnNTPC(kFALSE),
+  fNTPCMin(70),
+  fCutOnChi(kFALSE),
+  fChiMin(0.1),
+  fChiMax(4.),
+  fCutOnNITS(kFALSE),
+  fNITSMin(2),
+  fCutOnDCAxy(kFALSE),
   fDCAxyMax(3.2),
+  fCutOnDCAz(kFALSE),
   fDCAzMax(2.4),
-  fCharge(0),
-  fCutOnTracksMax(kFALSE),
-  fNumberOfTracksMaxZero(0),
-  fNumberOfTracksMaxFive(0),
-  fNumberOfTracksMaxTen(0),
-  fNumberOfTracksMaxTwenty(0),
-  fNumberOfTracksMaxThirty(0),
-  fNumberOfTracksMaxForty(0),
-  fNumberOfTracksMaxFifty(0),
-  fNumberOfTracksMaxSixty(0),
-  fNumberOfTracksMaxSeventy(0),
+  fCutOnCharge(kFALSE),
+  fKeepPositiveCharges(kFALSE),
 // Parameters related to the multi-particle correlations.
-  fMultiParticleCorrelationsList(NULL),
-  fProfileTwoParticleCorrelations(NULL),
-  fProfileFourParticleCorrelations(NULL),
-  fProfileFourParticleCorrelationsCrossCheck(NULL),
-  fProfileSixParticleCorrelations(NULL),
-  fProfileTwoParticleCorrelationsNestedLoops(NULL),
-  fProfileFourParticleCorrelationsNestedLoops(NULL),
+  fMPCList(NULL),
+  fReducedQPower(0),
+  fProfileTwoPartCorrel(NULL),
+  fProfileFourPartCorrel(NULL),
+  fProfileFourPartCorrelCheck(NULL),
+  fProfileSixPartCorrel(NULL),
 // Parameters related to the 2-particle correlations with eta gaps.
-  fTwoParticleCorrelationsWithEtaGapsList(NULL)
+  fTPCEtaList(NULL)
 {
 /* Dummy constructor of the class. */
-  AliDebug(2, "AliAnalysisTaskTwoMultiCorrelations::AliAnalysisTaskTwoMultiCorrelations(const char *name, Bool_t useParticleWeights)");
+  AliDebug(2, "AliAnalysisTaskTwoMultiCorrelations::AliAnalysisTaskTwoMultiCorrelations()");
 
-// Initialise 'fQvectors' to zero.
+// Initialise all elements in the arrays.
   InitialiseArraysOfQvectors();
-
-// Initialise the pointers of the TProfiles to NULL.
+  InitialiseArraysOfHistos();
   InitialiseArraysOfTProfiles();
 
-}
+}   // End of the dummy constructor.
 
-//======================================================================================//
+/* ------------------------------------------------------------------------- */
 AliAnalysisTaskTwoMultiCorrelations::AliAnalysisTaskTwoMultiCorrelations(const char *name, Bool_t useParticleWeights) :
   AliAnalysisTaskSE(name),
-// General parameters of the analysis.
+// General parameters for the analysis.
   fMainList(NULL),
+  fHighestHarmonic(8),
+  fLargestCorrelators(8),
+  fComputeEtaGaps(kFALSE),
+  fDoCorrelationsHisto(kFALSE),
+  fUseNonUnitParticleWeights(kFALSE),
   fEfficiency(NULL),
   fFirstEvent(kTRUE),
-  fHighestFlowHarmonic(6),
-  fMaxNumberOfParticlesInCorrelations(8),
-  fProcessOnlyAOD(kFALSE),
-  fProcessOnlyMC(kFALSE),
-  fProcessBothMCandAOD(kFALSE),
-  fComputeEtaGaps(kFALSE),
-  fCrosscheckWithNestedLoops(kFALSE),
-  fDoTDCorrelationHisto(kFALSE),
-  fUseParticleWeights(kFALSE),
-// Parameters related to the number of tracks.
+// Type of files used in the analysis.
+  fAnalyseOnlyAOD(kFALSE),
+  fAnalyseOnlyMC(kFALSE),
+  fAnalyseBothMCandAOD(kFALSE),
+  fAODevent(NULL),
+  fMCevent(NULL),
+// Parameters and histograms related to the centrality.
   fMultiplicityList(NULL),
-  fHistoInitialCentrality(NULL),
-  fHistoFinalCentrality(NULL),
-  fHistoInitialNumberOfTracks(NULL),
-  fHistoInitialNumberOfTracksMain(NULL),
-  fHistoInitialNumberOfTracksGlobal(NULL),
-  fHistoFinalNumberOfTracksMain(NULL),
-  fHistoFinalNumberOfTracksGlobal(NULL),
-  fHistoFinalNumberOfTracks(NULL),
-  fHistoInitialFilterCorrelations(NULL),
-  fHistoFinalFilterCorrelations(NULL),
   fCentralityFromVZero(kFALSE),
-  fCentralityFromSPD(kFALSE),
+  fCentralityFromSPD(kFALSE), 
   fCentralityMin(0.),
   fCentralityMax(100.),
-  fNumberOfBinsHINOT(30000),
-  fMaxBinHINOT(30000.),
-  fNumberOfBinsHFNOT(30000),
-  fMaxBinHFNOT(30000.),
-  fNumberOfBinsHFC(5000),
-  fMaxBinHFC(5000.),
-// Parameters related to the event selection criteria.
+  fMultSelection(NULL),
+// Parameters and histograms related to the number of tracks.
+  fInitialMultiplicity(0),
+// Parameters and histograms related to the event selection.
   fEventSelectionList(NULL),
-  fHistoInitialPVX(NULL),
-  fHistoFinalPVX(NULL),
-  fHistoInitialPVY(NULL),
-  fHistoFinalPVY(NULL),
-  fHistoInitialPVZ(NULL),
-  fHistoFinalPVZ(NULL),
-  fCutOnPVX(kFALSE),
-  fCutOnPVY(kFALSE),
-  fCutOnPVZ(kFALSE),
-  fPVXMin(-44.),
-  fPVXMax(44.),
-  fPVYMin(-44),
-  fPVYMax(44.),
-  fPVZMin(-10.),
-  fPVZMax(10.),
-// Parameters related to the track selection criteria.
-  fTrackSelectionList(NULL),
-  fHistoInitialPt(NULL),
-  fHistoFinalPt(NULL),
-  fHistoEfficiencyCorrection(NULL),
-  fHistoInitialEta(NULL),
-  fHistoFinalEta(NULL),
-  fHistoInitialPhi(NULL),
-  fHistoFinalPhi(NULL),
-  fHistoInitialNumberOfTPC(NULL),
-  fHistoFinalNumberOfTPC(NULL),
-  fHistoInitialChiSquare(NULL),
-  fHistoFinalChiSquare(NULL),
-  fHistoInitialDCAxy(NULL),
-  fHistoFinalDCAxy(NULL),
-  fHistoInitialDCAz(NULL),
-  fHistoFinalDCAz(NULL),
-  fHistoInitialCharge(NULL),
-  fHistoFinalCharge(NULL),
-  fHistoInitialNumberOfITS(NULL),
-  fHistoFinalNumberOfITS(NULL),
-  fCutOnTDCorrelations(kFALSE),
-  fCutOnPt(kFALSE),
-  fCutOnEta(kFALSE),
-  fCutOnNumberOfTPC(kFALSE),
-  fCutOnChiSquarePInTPC(kFALSE),
-  fCutOnDCAxy(kFALSE),
-  fCutOnDCAz(kFALSE),
-  fCutOnCharge(kFALSE),
-  fMainFilter(768),
-  fGlobalFilter(256),
+  fCutOnPVx(kFALSE),
+  fPVxMin(-44.),
+  fPVxMax(44.),
+  fCutOnPVy(kFALSE),
+  fPVyMin(-44.),
+  fPVyMax(44.),
+  fCutOnPVz(kFALSE),
+  fPVzMin(-10.),
+  fPVzMax(-10.),
   fMultiplicityMin(6),
+  fMainFilter(128),
+  fGlobalFilter(256),
+  fCutOnHMOs(kFALSE),
   fMultiplicityMinA(0.),
   fMultiplicityMinB(0.),
   fMultiplicityMaxA(0.),
   fMultiplicityMaxB(0.),
+// Parameters and histograms related to the track selection.
+  fTrackSelectionList(NULL),
+  fFilterbitIndex(0),
+  fCutOnPt(kFALSE),
   fPtMin(0.2),
   fPtMax(5.),
+  fHistoEfficiency(NULL),
+  fHistoEffInverse(NULL),
+  fCutOnEta(kFALSE),
   fEtaMin(-0.8),
   fEtaMax(0.8),
-  fNumberOfTPCMin(70),
-  fChiSquarePInTPCMin(0.1),
-  fChiSquarePInTPCMax(4.),
+  fCutOnNTPC(kFALSE),
+  fNTPCMin(70),
+  fCutOnChi(kFALSE),
+  fChiMin(0.1),
+  fChiMax(4.),
+  fCutOnNITS(kFALSE),
+  fNITSMin(2),
+  fCutOnDCAxy(kFALSE),
   fDCAxyMax(3.2),
+  fCutOnDCAz(kFALSE),
   fDCAzMax(2.4),
-  fCharge(0),
-  fCutOnTracksMax(kFALSE),
-  fNumberOfTracksMaxZero(0),
-  fNumberOfTracksMaxFive(0),
-  fNumberOfTracksMaxTen(0),
-  fNumberOfTracksMaxTwenty(0),
-  fNumberOfTracksMaxThirty(0),
-  fNumberOfTracksMaxForty(0),
-  fNumberOfTracksMaxFifty(0),
-  fNumberOfTracksMaxSixty(0),
-  fNumberOfTracksMaxSeventy(0),
+  fCutOnCharge(kFALSE),
+  fKeepPositiveCharges(kFALSE),
 // Parameters related to the multi-particle correlations.
-  fMultiParticleCorrelationsList(NULL),
-  fProfileTwoParticleCorrelations(NULL),
-  fProfileFourParticleCorrelations(NULL),
-  fProfileFourParticleCorrelationsCrossCheck(NULL),
-  fProfileSixParticleCorrelations(NULL),
-  fProfileTwoParticleCorrelationsNestedLoops(NULL),
-  fProfileFourParticleCorrelationsNestedLoops(NULL),
+  fMPCList(NULL),
+  fReducedQPower(0),
+  fProfileTwoPartCorrel(NULL),
+  fProfileFourPartCorrel(NULL),
+  fProfileFourPartCorrelCheck(NULL),
+  fProfileSixPartCorrel(NULL),
 // Parameters related to the 2-particle correlations with eta gaps.
-  fTwoParticleCorrelationsWithEtaGapsList(NULL)
+  fTPCEtaList(NULL)
 {
 /* Constructor of the class. */
   AliDebug(2, "AliAnalysisTaskTwoMultiCorrelations::AliAnalysisTaskTwoMultiCorrelations(const char *name, Bool_t useParticleWeights)");
 
-// Create the mother list with the ownership of everything inside it.
+// Create the mother list with the rights on everything contained inside it.
   fMainList = new TList();
   fMainList->SetName("outputAnalysis");
   fMainList->SetOwner(kTRUE);
@@ -323,75 +225,72 @@ AliAnalysisTaskTwoMultiCorrelations::AliAnalysisTaskTwoMultiCorrelations(const c
 // Define the input and output slots.
   DefineOutput(1, TList::Class());
 
-// Initialise 'fQvectors' to zero.
+// Initialise all elements in the arrays.
   InitialiseArraysOfQvectors();
-
-// Initialise the pointers of the TProfiles to NULL.
+  InitialiseArraysOfHistos();
   InitialiseArraysOfTProfiles();
 
-/// TBA: how to deal with non-unit particle weights.
-}
+}   // End of the constructor.
 
-//======================================================================================//
+/* ------------------------------------------------------------------------- */
 AliAnalysisTaskTwoMultiCorrelations::~AliAnalysisTaskTwoMultiCorrelations()
 {
 /* Destructor of the class. */
   if (fMainList) {delete fMainList;}
-}
+}   // End of the destructor.
 
-//======================================================================================//
+/* ------------------------------------------------------------------------- */
 void AliAnalysisTaskTwoMultiCorrelations::UserCreateOutputObjects()
 {
 /* Define the outputs of the task at the beginning of the analysis. */
+  TString sMethodName = "void AliAnalysisTaskTwoMultiCorrelations::UserCreateOutputObjects()";
+
 // Avoid name clashes.
   Bool_t oldHistAddStatus = TH1::AddDirectoryStatus();
   TH1::AddDirectory(kFALSE);
-  // JEfficiency for NUA correction : DongJo
-  fEfficiency = new AliJEfficiency();
-  fEfficiency->SetMode(1) ; // 1: priod should work for you
-  fEfficiency->SetDataPath( "alien:///alice/cern.ch/user/d/djkim/legotrain/efficieny/data" );
-// Book all the lists.
-  this->BookAllLists();
 
-// Book the histograms in each daughter list.
+// JEfficiency for NUA correction : DongJo
+  fEfficiency = new AliJEfficiency();
+  fEfficiency->SetMode(1); // 1: priod should work for you
+  fEfficiency->SetDataPath( "alien:///alice/cern.ch/user/d/djkim/legotrain/efficieny/data" );
+
+// Book the lists, histograms and profiles.
+  this->BookAllLists();
   this->BookMultiplicityList();
   this->BookEventSelectionList();
   this->BookTrackSelectionList();
-  this->BookMultiParticleCorrelationsList();
-  this->BookTwoParticleCorrelationsWithEtaGapsList();
+  this->BookMPCList();
+  this->BookTPCEtaList();
 
 // Continue to avoid name clashes.
   TH1::AddDirectory(oldHistAddStatus);
   PostData(1, fMainList);
   fFirstEvent = kTRUE;
-}
+}   // End of "void UserCreateOutputObjects()".
 
-//======================================================================================//
+/* ------------------------------------------------------------------------- */
 void AliAnalysisTaskTwoMultiCorrelations::UserExec(Option_t *)
 {
 /* Execute the analysis for each event. */
   TString sMethodName = "void AliAnalysisTaskTwoMultiCorrelations::UserExec(Option_t *)";
+  fAODevent = dynamic_cast<AliAODEvent*>(InputEvent());   // Pointer to an AOD event.
+  fMCevent = MCEvent();                                   // Pointer to a MC event.
 
-  AliAODEvent *currentAODEvent = dynamic_cast<AliAODEvent*>(InputEvent());  // Pointer to an AOD event.
-  AliMCEvent  *currentMCEvent = MCEvent();                                  // Pointer to a Monte Carlo event.
-
-// Select the analysis method according to the type of files.
-  if ((Int_t)fProcessOnlyAOD + (Int_t)fProcessOnlyMC + (Int_t)fProcessBothMCandAOD != 1)
-  {
-    Fatal(sMethodName.Data(), "ERROR: only one 'fProcess' must be set to kTRUE.");
-  }
-  else if (fProcessOnlyAOD) {AnalyseAODevent(currentAODEvent);}
-  else if (fProcessOnlyMC) {AnalyseMCevent(currentMCEvent);}
-  else if (fProcessBothMCandAOD) {Fatal(sMethodName.Data(),"ERROR: TBA analysis with both AOD and MC files.");}
+// Select the correct method according to the given type of files.
+  if ((Int_t)fAnalyseOnlyAOD + (Int_t)fAnalyseOnlyMC + (Int_t)fAnalyseBothMCandAOD != 1)
+  {Fatal(sMethodName.Data(), "ERROR: only one 'fProcess' must be set to kTRUE.");}
+  else if (fAnalyseOnlyAOD) {AnalyseAODevent();}
+  else if (fAnalyseOnlyMC) {AnalyseMCevent();}
+  else if (fAnalyseBothMCandAOD) {Fatal(sMethodName.Data(),"TBA: analysis with both AOD and MC files.");}
 
 // PostData.
   PostData(1, fMainList);
-}
+}   // End of "void UserExec()".
 
-//======================================================================================//
+/* ------------------------------------------------------------------------- */
 void AliAnalysisTaskTwoMultiCorrelations::Terminate(Option_t *)
 {
-/* Save the outputs after the running over the events. */
+/* Save the outputs at the end of the execution of the script. */
 // Access the mother list.
   fMainList = (TList*)GetOutputData(1);
   if (!fMainList) {exit(1);}
@@ -400,625 +299,196 @@ void AliAnalysisTaskTwoMultiCorrelations::Terminate(Option_t *)
   TFile *outputFile = new TFile("AnalysisResults.root", "RECREATE");
   fMainList->Write(fMainList->GetName(),TObject::kSingleKey);
   delete outputFile;
-}
+}   // End of "void Terminate()".
 
-//######################################################################################//
-// Methods called in the constructors.
-//======================================================================================//
+/* ========================================================================== /
+/ Methods called in the constructors.                                         /
+/ ========================================================================== */
 void AliAnalysisTaskTwoMultiCorrelations::InitialiseArraysOfQvectors()
 {
-/* Initialise to zero all the elements in 'fQvectors'. */
-  for (Int_t iHarmo = 0; iHarmo < 49; iHarmo++)
+/* Initialise to zero all the elements of "fQvectors". */
+  for (Int_t iHarmo = 0; iHarmo < 65; iHarmo++)
   {
     for (Int_t iPower = 0; iPower < 9; iPower++)
     {
-      fQvectors[iHarmo][iPower] = TComplex(0.,0.);
+      fQvectors[iHarmo][iPower] = TComplex(0., 0.);
     }
   }
-}
+}   // End of "void InitialiseArraysOfQvectors()".
 
-//======================================================================================//
+/* ------------------------------------------------------------------------- */
+void AliAnalysisTaskTwoMultiCorrelations::InitialiseArraysOfHistos()
+{
+/* Initialise to NULL all the histograms inside arrays. */
+  for (Int_t i = 0; i < 2; i++)
+  {
+    fHistoCentrality[i] = NULL;
+    fHistoMultiplicity[i] = NULL;
+    fHistoMultiplicityMain[i] = NULL;
+    fHistoMultiplicityGlobal[i] = NULL;
+    fHistoCorrelatedFilters[i] = NULL;
+    fHistoPVx[i] = NULL;
+    fHistoPVy[i] = NULL;
+    fHistoPVz[i] = NULL;
+    fHistoPt[i] = NULL;
+    fHistoEta[i] = NULL;
+    fHistoPhi[i] = NULL;
+    fHistoNTPC[i] = NULL;
+    fHistoChiSquare[i] = NULL;
+    fHistoNITS[i] = NULL;
+    fHistoDCAxy[i] = NULL;
+    fHistoDCAz[i] = NULL;
+    fHistoCharge[i] = NULL;
+  }
+
+  for (Int_t j = 0; j < 8; j++) {fHistoReducedQvectors[j] = NULL;}
+
+}   // End of "void InitialiseArraysOfHistos()".
+
+/* ------------------------------------------------------------------------- */
 void AliAnalysisTaskTwoMultiCorrelations::InitialiseArraysOfTProfiles()
 {
-/* Initialise to NULL the pointers to the TProfiles inside an array. */
-  for (Int_t i = 0; i < 6; i++) {fProfileTwoParticleCorrelationsWithEtaGaps[i] = NULL;}
-}
+/* Initialise to NULL all the profiles inside arrays. */
+  for (Int_t i = 0; i < 11; i++) {fProfileTPCEta[i] = NULL;}
+}   // End of "void InitialiseArraysOfTProfiles()".
 
-//######################################################################################//
-// Methods called in 'UserCreateOutputObjects'.
-//======================================================================================//
-void AliAnalysisTaskTwoMultiCorrelations::BookAllLists()
+/* ========================================================================== /
+/ Methods called in "UserExec".                                               /
+/ ========================================================================== */
+void AliAnalysisTaskTwoMultiCorrelations::AnalyseAODevent()
 {
-/* Book all the lists in fMainList. */
-// Check if the mother list exists.
-  TString sMethodName = "void AliAnalysisTaskTwoMultiCorrelations::BookAllLists()";
-  if (!fMainList) {Fatal(sMethodName.Data(), "ERROR: 'fMainList' does not exist.");}
+/* Execute the analysis for a given AOD event. */
+  TString sMethodName = "void AliAnalysisTaskTwoMultiCorrelations::AnalyseAODevent()";
 
-// Daughter list for the histograms containing the number of tracks.
-  fMultiplicityList = new TList();
-  fMultiplicityList->SetName("fMultiplicityList");
-  fMultiplicityList->SetOwner(kTRUE);
-  fMainList->Add(fMultiplicityList);
+// Check the presence of an AOD event.
+  if (!fAODevent) {Fatal(sMethodName.Data(), "ERROR: no AOD event found.");}
 
-// Daughter list for the histograms containing the event selection criteria.
-  fEventSelectionList = new TList();
-  fEventSelectionList->SetName("fEventSelectionList");
-  fEventSelectionList->SetOwner(kTRUE);
-  fMainList->Add(fEventSelectionList);
-
-// Daughter list for the histograms containing the track selection criteria.
-  fTrackSelectionList = new TList();
-  fTrackSelectionList->SetName("fTrackSelectionList");
-  fTrackSelectionList->SetOwner(kTRUE);
-  fMainList->Add(fTrackSelectionList);
-
-// Daughter list with the multi-particle correlations.
-  fMultiParticleCorrelationsList = new TList();
-  fMultiParticleCorrelationsList->SetName("fMultiParticleCorrelationsList");
-  fMultiParticleCorrelationsList->SetOwner(kTRUE);
-  fMainList->Add(fMultiParticleCorrelationsList);
-
-// Daughter list with the 2-p correlations computed with eta gaps.
-  fTwoParticleCorrelationsWithEtaGapsList = new TList();
-  fTwoParticleCorrelationsWithEtaGapsList->SetName("fTwoParticleCorrelationsWithEtaGapsList");
-  fTwoParticleCorrelationsWithEtaGapsList->SetOwner(kTRUE);
-  fMainList->Add(fTwoParticleCorrelationsWithEtaGapsList);
-}
-
-//======================================================================================//
-void AliAnalysisTaskTwoMultiCorrelations::BookMultiplicityList()
-{
-/* Book the histograms containing the number of tracks. */
-// Distributions of the centrality.
-  fHistoInitialCentrality = new TH1D("fHistoInitialCentrality",
-    "Centrality before the event selection", 100, 0., 100.);
-  fHistoInitialCentrality->SetStats(kTRUE);
-  fHistoInitialCentrality->GetXaxis()->SetTitle("Centrality percentile");
-  fHistoInitialCentrality->GetYaxis()->SetTitle("Number of events");
-  fMultiplicityList->Add(fHistoInitialCentrality);
-
-  fHistoFinalCentrality = new TH1D("fHistoFinalCentrality",
-    "Centrality after the event selection", 100, 0., 100.);
-  fHistoFinalCentrality->SetStats(kTRUE);
-  fHistoFinalCentrality->GetXaxis()->SetTitle("Centrality percentile");
-  fHistoFinalCentrality->GetYaxis()->SetTitle("Number of events");
-  fMultiplicityList->Add(fHistoFinalCentrality);
-
-// Distribution of the initial, unfiltered number of tracks.
-  fHistoInitialNumberOfTracks = new TH1I("fHistoInitialNumberOfTracks",
-    "Initial number of tracks without filter", fNumberOfBinsHINOT, 0., fMaxBinHINOT);
-  fHistoInitialNumberOfTracks->SetStats(kTRUE);
-  fHistoInitialNumberOfTracks->GetXaxis()->SetTitle("Number of tracks");
-  fHistoInitialNumberOfTracks->GetYaxis()->SetTitle("Number of events");
-  fMultiplicityList->Add(fHistoInitialNumberOfTracks);
-
-// Distributions of the number of tracks for each filter bit before the removal of the high multiplicity outliers.
-  fHistoInitialNumberOfTracksMain = new TH1I("fHistoInitialNumberOfTracksMain",
-    "Number of tracks before the outliers cuts for the main filter bit",
-    fNumberOfBinsHINOT, 0., fMaxBinHINOT);
-  fHistoInitialNumberOfTracksMain->SetStats(kTRUE);
-  fHistoInitialNumberOfTracksMain->GetXaxis()->SetTitle("Number of tracks");
-  fHistoInitialNumberOfTracksMain->GetYaxis()->SetTitle("Number of events");
-  fMultiplicityList->Add(fHistoInitialNumberOfTracksMain);
-
-  fHistoInitialNumberOfTracksGlobal = new TH1I("fHistoInitialNumberOfTracksGlobal",
-    "Number of tracks before the outlier cuts for the global filter bit",
-    fNumberOfBinsHINOT, 0., fMaxBinHINOT);
-  fHistoInitialNumberOfTracksGlobal->SetStats(kTRUE);
-  fHistoInitialNumberOfTracksGlobal->GetXaxis()->SetTitle("Number of tracks");
-  fHistoInitialNumberOfTracksGlobal->GetYaxis()->SetTitle("Number of events");
-  fMultiplicityList->Add(fHistoInitialNumberOfTracksGlobal);
-
-// Distributions of the number of tracks for each filter bit after the removal of the high multiplicity outliers.
-  fHistoFinalNumberOfTracksMain = new TH1I("fHistoFinalNumberOfTracksMain",
-    "Number of tracks after the outliers cuts for the main filter bit",
-    fNumberOfBinsHFNOT, 0., fMaxBinHFNOT);
-  fHistoFinalNumberOfTracksMain->SetStats(kTRUE);
-  fHistoFinalNumberOfTracksMain->GetXaxis()->SetTitle("Number of tracks");
-  fHistoFinalNumberOfTracksMain->GetYaxis()->SetTitle("Number of events");
-  fMultiplicityList->Add(fHistoFinalNumberOfTracksMain);
-
-  fHistoFinalNumberOfTracksGlobal = new TH1I("fHistoFinalNumberOfTracksGlobal",
-    "Number of tracks after the outliers cuts for the global filter bit",
-    fNumberOfBinsHFNOT, 0., fMaxBinHFNOT);
-  fHistoFinalNumberOfTracksGlobal->SetStats(kTRUE);
-  fHistoFinalNumberOfTracksGlobal->GetXaxis()->SetTitle("Number of tracks");
-  fHistoFinalNumberOfTracksGlobal->GetYaxis()->SetTitle("Number of events");
-  fMultiplicityList->Add(fHistoFinalNumberOfTracksGlobal);
-
-// Distribution of the number of tracks used in the analysis itself.
-  fHistoFinalNumberOfTracks = new TH1I("fHistoFinalNumberOfTracks",
-    "Number of tracks used in the analysis for the main filter bit",
-    fNumberOfBinsHFNOT, 0., fMaxBinHFNOT);
-  fHistoFinalNumberOfTracks->SetStats(kTRUE);
-  fHistoFinalNumberOfTracks->GetXaxis()->SetTitle("Number of tracks");
-  fHistoFinalNumberOfTracks->GetYaxis()->SetTitle("Number of events");
-  fMultiplicityList->Add(fHistoFinalNumberOfTracks);
-
-// 2D correlation histograms between two filters.
-  if (fDoTDCorrelationHisto) // Manually enabled only to decide the cuts, as it is memory-greedy.
+// Set the detector for the centrality estimation as set in the task.
+  TString centralityEstimator = "centralityEstimator";
+  if ( (Int_t)fCentralityFromVZero + (Int_t)fCentralityFromSPD != 1 )
   {
-    fHistoInitialFilterCorrelations = new TH2I("fHistoInitialFilterCorrelations",
-      "2D multiplicity correlations between filters before the outliers cuts",
-      fNumberOfBinsHFC, 0., fMaxBinHFC, fNumberOfBinsHFC, 0., fMaxBinHFC);
-    fHistoInitialFilterCorrelations->SetStats(kTRUE);
-    fHistoInitialFilterCorrelations->GetXaxis()->SetTitle(Form("Multiplicity_{Filter %d}", fGlobalFilter));
-    fHistoInitialFilterCorrelations->GetYaxis()->SetTitle(Form("Multiplicity_{Filter %d}", fMainFilter));
-    fHistoInitialFilterCorrelations->SetMarkerSize(0.5);
-    fHistoInitialFilterCorrelations->SetMarkerColor(kBlue);
-    fHistoInitialFilterCorrelations->SetMarkerStyle(kFullCircle);
-    fMultiplicityList->Add(fHistoInitialFilterCorrelations);
-
-    fHistoFinalFilterCorrelations = new TH2I("fHistoFinalFilterCorrelations",
-      "2D multiplicity correlations between filters after the outliers removal",
-      fNumberOfBinsHFC, 0., fMaxBinHFC, fNumberOfBinsHFC, 0., fMaxBinHFC);
-    fHistoFinalFilterCorrelations->SetStats(kTRUE);
-    fHistoFinalFilterCorrelations->GetXaxis()->SetTitle(Form("Multiplicity_{Filter %d}", fGlobalFilter));
-    fHistoFinalFilterCorrelations->GetYaxis()->SetTitle(Form("Multiplicity_{Filter %d}", fMainFilter));
-    fHistoFinalFilterCorrelations->SetMarkerSize(0.5);
-    fHistoFinalFilterCorrelations->SetMarkerColor(kBlue);
-    fHistoFinalFilterCorrelations->SetMarkerStyle(kFullCircle);
-    fMultiplicityList->Add(fHistoFinalFilterCorrelations);
+    Fatal(sMethodName.Data(), "ERROR: only one detector must be set to kTRUE.");
   }
-}
+  else if (fCentralityFromVZero) {centralityEstimator = "V0M";}
+  else if (fCentralityFromSPD) {centralityEstimator = "CL1";}
 
-//======================================================================================//
-void AliAnalysisTaskTwoMultiCorrelations::BookEventSelectionList()
-{
-/* Book the control histograms for the event selection criteria. */
-// Distributions of the x-position of the PV.
-  fHistoInitialPVX = new TH1D("fHistoInitialPVX",
-    "PV_{x} before the event selection", 1000, -20., 20.);
-  fHistoInitialPVX->SetStats(kTRUE);
-  fHistoInitialPVX->GetXaxis()->SetTitle("PV_{x} [cm]");
-  fHistoInitialPVX->GetYaxis()->SetTitle("Number of events");
-  fEventSelectionList->Add(fHistoInitialPVX);
+// Select only the events belonging to the current centrality range.
+  fMultSelection = (AliMultSelection*)fAODevent->FindListObject("MultSelection");
+  if (!fMultSelection) {return;}
 
-  fHistoFinalPVX = new TH1D("fHistoFinalPVX",
-    "PV_{x} after the event selection", 1000, -20., 20.);
-  fHistoFinalPVX->SetStats(kTRUE);
-  fHistoFinalPVX->GetXaxis()->SetTitle("PV_{x} [cm]");
-  fHistoFinalPVX->GetYaxis()->SetTitle("Number of events");
-  fEventSelectionList->Add(fHistoFinalPVX);
+  Float_t centrality = fMultSelection->GetMultiplicityPercentile(Form("%s", centralityEstimator.Data()));
+  if ( (centrality < fCentralityMin) || (centrality >= fCentralityMax) ) {return;}
 
-// Distributions of the y-position of the PV.
-  fHistoInitialPVY = new TH1D("fHistoInitialPVY",
-    "PV_{y} before the event selection", 1000, -20., 20.);
-  fHistoInitialPVY->SetStats(kTRUE);
-  fHistoInitialPVY->GetXaxis()->SetTitle("PV_{y} [cm]");
-  fHistoInitialPVY->GetYaxis()->SetTitle("Number of events");
-  fEventSelectionList->Add(fHistoInitialPVY);
+  fHistoCentrality[0]->Fill(centrality);
 
-  fHistoFinalPVY = new TH1D("fHistoFinalPVY",
-    "PV_{y} after the event selection", 1000, -20., 20.);
-  fHistoFinalPVY->SetStats(kTRUE);
-  fHistoFinalPVY->GetXaxis()->SetTitle("PV_{y} [cm]");
-  fHistoFinalPVY->GetYaxis()->SetTitle("Number of events");
-  fEventSelectionList->Add(fHistoFinalPVY);
+// Look at the initial observables.
+  fInitialMultiplicity = fAODevent->GetNumberOfTracks();
+  AliAODVertex *primaryVertex = (AliAODVertex*)fAODevent->GetPrimaryVertex();   // 3D position of the PV.
 
-// Distributions of the z-position of the PV.
-  fHistoInitialPVZ = new TH1D("fHistoInitialPVZ",
-    "PV_{z} before the event selection", 1000, -20., 20.);
-  fHistoInitialPVZ->SetStats(kTRUE);
-  fHistoInitialPVZ->GetXaxis()->SetTitle("PV_{z} [cm]");
-  fHistoInitialPVZ->GetYaxis()->SetTitle("Number of events");
-  fEventSelectionList->Add(fHistoInitialPVZ);
+  fHistoMultiplicity[0]->Fill(fInitialMultiplicity);
+  fHistoPVx[0]->Fill(primaryVertex->GetX());
+  fHistoPVy[0]->Fill(primaryVertex->GetY());
+  fHistoPVz[0]->Fill(primaryVertex->GetZ());
 
-  fHistoFinalPVZ = new TH1D("fHistoFinalPVZ",
-    "PV_{z} after the event selection", 1000, -20., 20.);
-  fHistoFinalPVZ->SetStats(kTRUE);
-  fHistoFinalPVZ->GetXaxis()->SetTitle("PV_{z} [cm]");
-  fHistoFinalPVZ->GetYaxis()->SetTitle("Number of events");
-  fEventSelectionList->Add(fHistoFinalPVZ);
-}
+// Apply the event selection.
+  if(!ApplyPhysicsEventSelection()) {return;}
+  if (!RemoveHMOs()) {return;}
 
-//======================================================================================//
-void AliAnalysisTaskTwoMultiCorrelations::BookTrackSelectionList()
-{
-/* Book the control histograms for the track selection criteria. */
-// Distributions of the transverse momentum and the efficiency correction.
-  fHistoInitialPt = new TH1D("fHistoInitialPt",
-    "p_{T} before the track selection", 1000, 0., 20.);
-  fHistoInitialPt->SetStats(kTRUE);
-  fHistoInitialPt->GetXaxis()->SetTitle("p_{T} [GeV/c]");
-  fHistoInitialPt->GetYaxis()->SetTitle("Number of tracks");
-  fTrackSelectionList->Add(fHistoInitialPt);
+  fHistoCentrality[1]->Fill(centrality);
+  fHistoPVx[1]->Fill(primaryVertex->GetX());
+  fHistoPVy[1]->Fill(primaryVertex->GetY());
+  fHistoPVz[1]->Fill(primaryVertex->GetZ());
 
-  fHistoFinalPt = new TH1D("fHistoFinalPt",
-    "p_{T} after the track selection", 1000, 0., 20.);
-  fHistoFinalPt->SetStats(kTRUE);
-  fHistoFinalPt->GetXaxis()->SetTitle("p_{T} [GeV/c]");
-  fHistoFinalPt->GetYaxis()->SetTitle("Number of tracks");
-  fTrackSelectionList->Add(fHistoFinalPt);
-
-  fHistoEfficiencyCorrection = new TH1D("fHistoEfficiencyCorrection",
-    "Efficiency correction before inversion", 1000, 0., 5.);
-  fHistoEfficiencyCorrection->SetStats(kTRUE);
-  fHistoEfficiencyCorrection->GetXaxis()->SetTitle("p_{T} [GeV/c]");
-  fHistoEfficiencyCorrection->GetYaxis()->SetTitle("Number of tracks");
-  fTrackSelectionList->Add(fHistoEfficiencyCorrection);
-
-// Distributions of the pseudorapidity.
-  fHistoInitialEta = new TH1D("fHistoInitialEta",
-    "#eta before the track selection", 1000, -5.5, 5.5);
-  fHistoInitialEta->SetStats(kTRUE);
-  fHistoInitialEta->GetXaxis()->SetTitle("#eta");
-  fHistoInitialEta->GetYaxis()->SetTitle("Number of tracks");
-  fTrackSelectionList->Add(fHistoInitialEta);
-
-  fHistoFinalEta = new TH1D("fHistoFinalEta",
-    "#eta after the track selection", 1000, -5.5, 5.5);
-  fHistoFinalEta->SetStats(kTRUE);
-  fHistoFinalEta->GetXaxis()->SetTitle("#eta");
-  fHistoFinalEta->GetYaxis()->SetTitle("Number of tracks");
-  fTrackSelectionList->Add(fHistoFinalEta);
-
-// Distributions of the azimuthal angles.
-  fHistoInitialPhi = new TH1D("fHistoInitialPhi",
-    "#phi before the track selection", 1000, 0., 6.3);
-  fHistoInitialPhi->SetStats(kTRUE);
-  fHistoInitialPhi->GetXaxis()->SetTitle("#phi");
-  fHistoInitialPhi->GetYaxis()->SetTitle("Number of tracks");
-  fTrackSelectionList->Add(fHistoInitialPhi);
-
-  fHistoFinalPhi = new TH1D("fHistoFinalPhi",
-    "#phi after the track selection", 1000, 0., 6.3);
-  fHistoFinalPhi->SetStats(kTRUE);
-  fHistoFinalPhi->GetXaxis()->SetTitle("#phi");
-  fHistoFinalPhi->GetYaxis()->SetTitle("Number of tracks");
-  fTrackSelectionList->Add(fHistoFinalPhi);
-
-// Distributions of the number of TPC clusters before the track selection.
-  fHistoInitialNumberOfTPC = new TH1I("fHistoInitialNumberOfTPC",
-    "Number of TPC clusters before the track selection", 1000, 0., 170.);
-  fHistoInitialNumberOfTPC->SetStats(kTRUE);
-  fHistoInitialNumberOfTPC->GetXaxis()->SetTitle("Number of TPC clusters");
-  fHistoInitialNumberOfTPC->GetYaxis()->SetTitle("Number of tracks");
-  fTrackSelectionList->Add(fHistoInitialNumberOfTPC);
-
-  fHistoFinalNumberOfTPC = new TH1I("fHistoFinalNumberOfTPC",
-    "Number of TPC clusters after the track selection", 1000, 0., 170.);
-  fHistoFinalNumberOfTPC->SetStats(kTRUE);
-  fHistoFinalNumberOfTPC->GetXaxis()->SetTitle("Number of TPC clusters");
-  fHistoFinalNumberOfTPC->GetYaxis()->SetTitle("Number of tracks");
-  fTrackSelectionList->Add(fHistoFinalNumberOfTPC);
-
-// Distributions of the chi^2 of the track momentum in TPC.
-  fHistoInitialChiSquare = new TH1D("fHistoInitialChiSquare",
-    "#chi^{2}/NDF in the TPC before the track selection", 1000, 0., 20.);
-  fHistoInitialChiSquare->SetStats(kTRUE);
-  fHistoInitialChiSquare->GetXaxis()->SetTitle("#chi^{2}/NDF in TPC");
-  fHistoInitialChiSquare->GetYaxis()->SetTitle("Number of tracks");
-  fTrackSelectionList->Add(fHistoInitialChiSquare);
-
-  fHistoFinalChiSquare = new TH1D("fHistoFinalChiSquare",
-    "#chi^{2}/NDF in the TPC after the track selection", 1000, 0., 20.);
-  fHistoFinalChiSquare->SetStats(kTRUE);
-  fHistoFinalChiSquare->GetXaxis()->SetTitle("#chi^{2}/NDF in TPC");
-  fHistoFinalChiSquare->GetYaxis()->SetTitle("Number of tracks");
-  fTrackSelectionList->Add(fHistoFinalChiSquare);
-
-// Distributions of the xy-coordinate of the DCA.
-  fHistoInitialDCAxy = new TH1D("fHistoInitialDCAxy",
-    "DCA_{xy} before the track selection", 1000, 0., 10.);
-  fHistoInitialDCAxy->SetStats(kTRUE);
-  fHistoInitialDCAxy->GetXaxis()->SetTitle("DCA_{xy} [cm]");
-  fHistoInitialDCAxy->GetYaxis()->SetTitle("Number of tracks");
-  fTrackSelectionList->Add(fHistoInitialDCAxy);
-
-  fHistoFinalDCAxy = new TH1D("fHistoFinalDCAxy",
-    "DCA_{xy} after the track selection", 1000, 0., 10.);
-  fHistoFinalDCAxy->SetStats(kTRUE);
-  fHistoFinalDCAxy->GetXaxis()->SetTitle("DCA_{xy} [cm]");
-  fHistoFinalDCAxy->GetYaxis()->SetTitle("Number of tracks");
-  fTrackSelectionList->Add(fHistoFinalDCAxy);
-
-// Distributions of the z-coordinate of the DCA.
-  fHistoInitialDCAz = new TH1D("fHistoInitialDCAz",
-    "DCA_{z} before the track selection", 1000, 0., 10.);
-  fHistoInitialDCAz->SetStats(kTRUE);
-  fHistoInitialDCAz->GetXaxis()->SetTitle("DCA_{z} [cm]");
-  fHistoInitialDCAz->GetYaxis()->SetTitle("Number of tracks");
-  fTrackSelectionList->Add(fHistoInitialDCAz);
-
-  fHistoFinalDCAz = new TH1D("fHistoFinalDCAz",
-    "DCA_{z} after the track selection", 1000, 0., 10.);
-  fHistoFinalDCAz->SetStats(kTRUE);
-  fHistoFinalDCAz->GetXaxis()->SetTitle("DCA_{z} [cm]");
-  fHistoFinalDCAz->GetYaxis()->SetTitle("Number of tracks");
-  fTrackSelectionList->Add(fHistoFinalDCAz);
-
-// Distributions of the electric charge of the tracks.
-  fHistoInitialCharge = new TH1I("fHistoInitialCharge",
-    "Electric charge before the track selection", 2, -2, 2);
-  fHistoInitialCharge->SetStats(kTRUE);
-  fHistoInitialCharge->GetXaxis()->SetTitle("Charge");
-  fHistoInitialCharge->GetYaxis()->SetTitle("Number of tracks");
-  fTrackSelectionList->Add(fHistoInitialCharge);
-
-  fHistoFinalCharge = new TH1I("fHistoFinalCharge",
-    "Electric charge after the track selection", 2, -2, 2);
-  fHistoFinalCharge->SetStats(kTRUE);
-  fHistoFinalCharge->GetXaxis()->SetTitle("Charge");
-  fHistoFinalCharge->GetYaxis()->SetTitle("Number of tracks");
-  fTrackSelectionList->Add(fHistoFinalCharge);
-
-// Distributions of the number of clusters in the ITS.
-  fHistoInitialNumberOfITS = new TH1I("fHistoInitialNumberOfITS",
-    "Number of ITS clusters before the track selection", 1000, 0., 20.);
-  fHistoInitialNumberOfITS->SetStats(kTRUE);
-  fHistoInitialNumberOfITS->GetXaxis()->SetTitle("Number of ITS clusters");
-  fHistoInitialNumberOfITS->GetYaxis()->SetTitle("Number of tracks");
-  fTrackSelectionList->Add(fHistoInitialNumberOfITS);
-
-  fHistoFinalNumberOfITS = new TH1I("fHistoFinalNumberOfITS",
-    "Number of ITS clusters after the track selection", 1000, 0., 20.);
-  fHistoFinalNumberOfITS->SetStats(kTRUE);
-  fHistoFinalNumberOfITS->GetXaxis()->SetTitle("Number of ITS clusters");
-  fHistoFinalNumberOfITS->GetYaxis()->SetTitle("Number of tracks");
-  fTrackSelectionList->Add(fHistoFinalNumberOfITS);
-}
-
-//======================================================================================//
-void AliAnalysisTaskTwoMultiCorrelations::BookMultiParticleCorrelationsList()
-{
-/* Book the TProfiles with the multiparticle correlations. */
-// 2-particle correlations.
-  fProfileTwoParticleCorrelations = new TProfile("fProfileTwoParticleCorrelations",
-    "#LT#LT2#GT#GT_{n,-n}", 6, 0., 6.);
-  fProfileTwoParticleCorrelations->SetStats(kTRUE);
-  fProfileTwoParticleCorrelations->Sumw2();
-  fProfileTwoParticleCorrelations->GetXaxis()->SetTitle("n");
-  fMultiParticleCorrelationsList->Add(fProfileTwoParticleCorrelations);
-
-  if (fCrosscheckWithNestedLoops)
+// Get the run number and load the correct NUE correction (from DongJo).
+  if (fFirstEvent)
   {
-    fProfileTwoParticleCorrelationsNestedLoops = new TProfile("fProfileTwoParticleCorrelationsNestedLoops",
-      "#LT#LT2#GT#GT_{n,-n} with nested loops", 6, 0., 6.);
-    fProfileTwoParticleCorrelationsNestedLoops->SetStats(kTRUE);
-    fProfileTwoParticleCorrelationsNestedLoops->Sumw2();
-    fProfileTwoParticleCorrelationsNestedLoops->GetXaxis()->SetTitle("n");
-    fMultiParticleCorrelationsList->Add(fProfileTwoParticleCorrelationsNestedLoops);
-  }
-
-// 4-particle correlations.
-  fProfileFourParticleCorrelations = new TProfile("fProfileFourParticleCorrelations",
-    "#LT#LT4#GT#GT_{m,n,-m,-n}", 21, 0., 21.);
-  fProfileFourParticleCorrelations->SetStats(kTRUE);
-  fProfileFourParticleCorrelations->Sumw2();
-  fProfileFourParticleCorrelations->GetXaxis()->SetTitle("(m,n)");
-  fMultiParticleCorrelationsList->Add(fProfileFourParticleCorrelations);
-
-  fProfileFourParticleCorrelationsCrossCheck = new TProfile("fProfileFourParticleCorrelationsCrossCheck",
-    "Cross-check of #LT#LT4#GT#GT_{m,n,-m,-n}", 15, 0., 15.);
-  fProfileFourParticleCorrelationsCrossCheck->SetStats(kTRUE);
-  fProfileFourParticleCorrelationsCrossCheck->Sumw2();
-  fProfileFourParticleCorrelationsCrossCheck->GetXaxis()->SetTitle("(m,n)");
-  fMultiParticleCorrelationsList->Add(fProfileFourParticleCorrelationsCrossCheck);
-
-  if (fCrosscheckWithNestedLoops)
-  {
-    fProfileFourParticleCorrelationsNestedLoops = new TProfile("fProfileFourParticleCorrelationsNestedLoops",
-      "#LT#LT4#GT#GT_{m,n,-m,-n} with nested loops", 21, 0., 21.);
-    fProfileFourParticleCorrelationsNestedLoops->SetStats(kTRUE);
-    fProfileFourParticleCorrelationsNestedLoops->Sumw2();
-    fProfileFourParticleCorrelationsNestedLoops->GetXaxis()->SetTitle("(m,n)");
-    fMultiParticleCorrelationsList->Add(fProfileFourParticleCorrelationsNestedLoops);
-  }
-
-// 6-particle correlations.
-  fProfileSixParticleCorrelations = new TProfile("fProfileSixParticleCorrelations",
-    "#LT#LT6#GT#GT_{l,m,n,-l,-m,-n}", 20, 0., 20.);
-  fProfileSixParticleCorrelations->SetStats(kTRUE);
-  fProfileSixParticleCorrelations->Sumw2();
-  fProfileSixParticleCorrelations->GetXaxis()->SetTitle("(l,m,n)");
-  fMultiParticleCorrelationsList->Add(fProfileSixParticleCorrelations);
-}
-
-//======================================================================================//
-void AliAnalysisTaskTwoMultiCorrelations::BookTwoParticleCorrelationsWithEtaGapsList()
-{
-/* Book the TProfiles for the 2-p correlations with eta gaps if selected. */
-  if (fComputeEtaGaps)
-  {
-    Double_t EtaGaps[11] = {1., 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.}; // Choice of values for the eta gap.
-    for (Int_t i = 0; i < 6; i++)
-    {
-      fProfileTwoParticleCorrelationsWithEtaGaps[i] = new TProfile("", "", 11, 0., 11.);
-      fProfileTwoParticleCorrelationsWithEtaGaps[i]->SetName(Form("fProfileTwoParticleCorrelationsWithEtaGaps_v%d", i+1));
-      fProfileTwoParticleCorrelationsWithEtaGaps[i]->SetTitle(Form("#LT#LT2#GT#GT_{%d,-%d}", i+1, i+1));
-      fProfileTwoParticleCorrelationsWithEtaGaps[i]->SetStats(kTRUE);
-      fProfileTwoParticleCorrelationsWithEtaGaps[i]->Sumw2();
-      fProfileTwoParticleCorrelationsWithEtaGaps[i]->GetXaxis()->SetTitle("#eta gap");
-      fTwoParticleCorrelationsWithEtaGapsList->Add(fProfileTwoParticleCorrelationsWithEtaGaps[i]);
-
-    // Set bin labels.
-      for (Int_t gap = 1; gap < 12; gap++)
-      {
-       fProfileTwoParticleCorrelationsWithEtaGaps[i]->GetXaxis()->SetBinLabel(gap, Form("%.1f", EtaGaps[gap-1]));
-      }
-    }
-  }
-}
-
-//######################################################################################//
-// Methods called in 'UserExec'.
-//======================================================================================//
-void AliAnalysisTaskTwoMultiCorrelations::AnalyseAODevent(AliAODEvent *inputAODevent)
-{
-/* Execute the analysis for the given AOD event. */
-  TString sMethodName = "void AliAnalysisTaskTwoMultiCorrelations::AnalyseAODevent(AliAODEvent *inputAODevent)";
-  if (!inputAODevent) {Fatal(sMethodName.Data(), "ERROR: no AOD event found.");}
-
-// Check if the event passes the event selection criteria.
-  if(!ApplyEventSelectionAOD(inputAODevent)) {return;}
-
-  // Efficiency : DongJo
-  if( fFirstEvent ) {
-    fEfficiency->SetRunNumber( inputAODevent->GetRunNumber() );
+    fEfficiency->SetRunNumber(fAODevent->GetRunNumber());
     fEfficiency->Load();
     fFirstEvent = kFALSE;
   }
 
-// Obtain locally the centrality of the event for the efficiency correction.
-  TString centralityEstimatorAOD = "centralityEstimatorAOD";
-  if ( (Int_t)fCentralityFromVZero + (Int_t)fCentralityFromSPD != 1 )
+// Apply the track selection to classify the tracks.
+  long long multiplicity = fAODevent->GetNumberOfTracks();    // Current number of tracks.
+  long long finalMultiplicity = 0;                            // Number of tracks selected for the analysis.
+  Bool_t *isTrackSelected = new Bool_t[multiplicity]();       // kTRUE: the track passed the selection, kFALSE: the track is rejected.
+
+  for (Int_t iTrack = 0; iTrack < multiplicity; iTrack++)
   {
-    Fatal(sMethodName.Data(), "ERROR: only one detector must be set to kTRUE.");
-  }
-  else if (fCentralityFromVZero) {centralityEstimatorAOD = "V0M";}
-  else if (fCentralityFromSPD) {centralityEstimatorAOD = "CL1";}
-  AliMultSelection *multiplicitySelectionAOD = (AliMultSelection*)inputAODevent->FindListObject("MultSelection");
-  if (!multiplicitySelectionAOD) {return;}
+  // Get the current track belonging to the main filter.
+    AliAODTrack *aTrack = dynamic_cast<AliAODTrack*>(fAODevent->GetTrack(iTrack));
+    if (!aTrack) {continue;}    // No track found.
+    if (!aTrack->TestFilterBit(fMainFilter)) {continue;}    // The track does not belong to the filter.
 
-  Double_t eventCentralityAOD = multiplicitySelectionAOD->GetMultiplicityPercentile(Form("%s", centralityEstimatorAOD.Data()));
+  // Apply the track selection (histograms are filled inside).
+    if (!ApplyTrackSelectionAOD(aTrack)) {isTrackSelected[iTrack] = kFALSE;}
+    else {isTrackSelected[iTrack] = kTRUE; finalMultiplicity++;}
+  }   // End of the first loop over the tracks.
 
-// Determine how many and which tracks pass the track selection.
-  long long currentNumberOfTracks = inputAODevent->GetNumberOfTracks(); // Number of tracks before the track selection.
-  long long finalNumberOfTracks = 0.; // Number of tracks remaining after the track selection.
-  Int_t *isTrackSelected = new Int_t[currentNumberOfTracks](); // Flag to indicate if the track passed the selection (1) or not (0). 
-  for (long long iTrack = 0; iTrack < currentNumberOfTracks; iTrack++)
+// Select only the events with enough tracks for the event weight.
+  if (finalMultiplicity < fMultiplicityMin) {return;}
+  fHistoMultiplicity[1]->Fill(finalMultiplicity);
+
+// Prepare the variables needed for the rest of the analysis.
+  Float_t   iPt = 0.;                                               // Transverse momentum.
+  Float_t   *iEta = new Float_t[finalMultiplicity]();               // Pseudorapidity for the eta gaps.
+  Float_t   *iPhi = new Float_t[finalMultiplicity]();               // Azimuthal angles.
+  Float_t   *iParticleWeights = new Float_t[finalMultiplicity]();   // Particle weights.
+  Int_t     iIndex = 0;                                             // Index of the selected track in the final arrays.
+  Float_t   iEffCorr = 0.;                                          // Efficiency correction.
+  Float_t   iEffInverse = 0.;                                       // Inverse of the efficiency correction.
+
+  for (Int_t iiTrack = 0; iiTrack < multiplicity; iiTrack++)
   {
-  // Check if the current track belongs to the main filter bit.
-    AliAODTrack *inputTrack = dynamic_cast<AliAODTrack*>(inputAODevent->GetTrack(iTrack));
-    if (!inputTrack) {continue;}
-    if (!inputTrack->TestFilterBit(fMainFilter)) {continue;}
+  // Check if iiTrack corresponds to a selected track or not.
+    if (!isTrackSelected[iiTrack]) {continue;}
 
-  // Check if the track passes the track selection criteria.
-    if (ApplyTrackSelectionAOD(inputTrack))
-    {
-      finalNumberOfTracks++;
-      isTrackSelected[iTrack] = 1;
-    }
-    else {isTrackSelected[iTrack] = 0;}
-  }
+    AliAODTrack *aaTrack = dynamic_cast<AliAODTrack*>(fAODevent->GetTrack(iiTrack));
+    if (!aaTrack) {continue;}
+    if (!aaTrack->TestFilterBit(fMainFilter)) {continue;}
 
-// Check if the event has still enough tracks to have a meaningful event weight.
-  if (finalNumberOfTracks < fMultiplicityMin) {return;}
+    iPt           = aaTrack->Pt();
+    iEta[iIndex]  = aaTrack->Eta();
+    iPhi[iIndex]  = aaTrack->Phi();
+    iEffCorr      = fEfficiency->GetCorrection(iPt, fFilterbitIndex, centrality);
+    iEffInverse   = 1.0/iEffCorr;
+    iParticleWeights[iIndex] = 1.;    // Unit particle weights are used by default.
+    if (fUseNonUnitParticleWeights) {iParticleWeights[iIndex] = iEffInverse;}
 
-// Fill the distribution of the final number of tracks.
-  fHistoFinalNumberOfTracks->Fill(finalNumberOfTracks);
+    fHistoEfficiency->Fill(iEffCorr);
+    fHistoEffInverse->Fill(iEffInverse);
 
-// Prepare the observables for the analysis itself.
-  Double_t *currentEta = new Double_t[finalNumberOfTracks](); // Pseudorapidity for the method of the eta gaps.
-  Double_t *currentPhi = new Double_t[finalNumberOfTracks](); // Azimuthal angles.
-  Double_t *currentParticleWeights = new Double_t[finalNumberOfTracks](); // Particle weights.
-  Int_t finalIndex = 0; // New index of the track if it passed the selection.
-  for (long long iiTrack = 0; iiTrack < currentNumberOfTracks; iiTrack++)
-  {
-    AliAODTrack *currentTrack = dynamic_cast<AliAODTrack*>(inputAODevent->GetTrack(iiTrack));
-    if (!currentTrack) {continue;}
-    if (!currentTrack->TestFilterBit(fMainFilter)) {continue;}
+    iIndex++;
+  }   // End of the second loop over the tracks.
 
-    if (isTrackSelected[iiTrack] == 0) {continue;}  // The track has failed the track selection.
+// Compute the multiparticle correlations for the current event.
+  CalculateQvectors(finalMultiplicity, iPhi, iParticleWeights);
+  ComputeReducedQvectors(finalMultiplicity);
+  ComputeAllCorrelators(finalMultiplicity, iPhi, iParticleWeights);
+  if (fComputeEtaGaps) {ComputeTPCWithEtaGaps(finalMultiplicity, iPhi, iParticleWeights, iEta);}
 
-    currentEta[finalIndex] = currentTrack->Eta();
-    currentPhi[finalIndex] = currentTrack->Phi();
-
-    // Efficiency by DongJo
-    Double_t pt = currentTrack->Pt();
-    Double_t fCent = eventCentralityAOD;// this doesn't work eventCentrality; --> Fixed.
-    Double_t effCorr = fEfficiency->GetCorrection( pt,0, fCent); //filterbitIndex 0 : TPCOnly 6: hybrid(this work for AOD86, i am not sure if it is work for new AOD)
-    Double_t effInv = 1.0/effCorr;
-
-    currentParticleWeights[finalIndex] = 1.;  // Unit particle weights are used by default.
-    if (fUseParticleWeights) {currentParticleWeights[finalIndex] = effInv;}
-
-    fHistoEfficiencyCorrection->Fill(effCorr);
-
-    finalIndex++;
-  }
-
-// Do the analysis for the current event.
-  CalculateQvectors(finalNumberOfTracks, currentPhi, currentParticleWeights);
-  ComputeMultiparticleCorrelations(finalNumberOfTracks, currentPhi, currentParticleWeights);
-  if (fComputeEtaGaps) {ComputeTwoParticleEtaGaps(finalNumberOfTracks, currentPhi, currentParticleWeights, currentEta);}
-
-// Reset the variables before passing to the next event.
-  currentNumberOfTracks = 0;
-  finalNumberOfTracks = 0;
+// Reset the EbE variables.
+  centrality              = 0.;
+  fInitialMultiplicity    = 0;
+  multiplicity            = 0;
+  finalMultiplicity       = 0;
   delete [] isTrackSelected;
-  delete [] currentEta;
-  delete [] currentPhi;
-  delete [] currentParticleWeights;
-  finalIndex = 0;
-}
+  iPt                     = 0.;
+  delete [] iEta;
+  delete [] iPhi;
+  delete [] iParticleWeights;
+  iIndex                  = 0;
+  iEffCorr                = 0.;
+  iEffInverse             = 0.;
+}   // End of "void AnalyseAODevent()".
 
-//======================================================================================//
-void AliAnalysisTaskTwoMultiCorrelations::AnalyseMCevent(AliMCEvent *inputMCevent)
+/* ------------------------------------------------------------------------- */
+void AliAnalysisTaskTwoMultiCorrelations::AnalyseMCevent()
 {
-/* Execute the analysis for the provided MC event. */
-  TString sMethodName = "void AliAnalysisTaskTwoMultiCorrelations::AnalyseMCevent(AliMCEvent *aMCevent)";
-  if (!inputMCevent) {Fatal(sMethodName.Data(), "ERROR: no MC event found.");}
+/* Execute the analysis for a given MC event. */
+  TString sMethodName = "void AliAnalysisTaskTwoMultiCorrelations::AnalyseMCevent()";
 
-// Check if the event passes the event selection criteria.
-  if(!ApplyEventSelectionMC(inputMCevent)) {return;}
-
-// Determine how many and which tracks pass the track selection.
-  long long currentNumberOfTracks = inputMCevent->GetNumberOfTracks();  // Number of tracks before the track selection.
-  long long finalNumberOfTracks = 0.; // Number of tracks remaining after the track selection.
-  Int_t *isTrackSelected = new Int_t[currentNumberOfTracks](); // Flag to indicate if the track passed the selection (1) or not (0). 
-  for (long long iTrack = 0; iTrack < currentNumberOfTracks; iTrack++)
-  {
-  // Check if the current track belongs to the main filter bit.
-    AliAODMCParticle *inputTrack = dynamic_cast<AliAODMCParticle*>(inputMCevent->GetTrack(iTrack));
-    if (!inputTrack) {continue;}
-
-  // Check if the track passes the track selection criteria.
-    if (ApplyTrackSelectionMC(inputTrack))
-    {
-      finalNumberOfTracks++;
-      isTrackSelected[iTrack] = 1;
-    }
-    else {isTrackSelected[iTrack] = 0;}
-  }
-
-// Check if the event has still enough tracks to have a meaningful event weight.
-  if (finalNumberOfTracks < fMultiplicityMin) {return;}
-
-// Fill the distribution of the final number of tracks.
-  fHistoFinalNumberOfTracks->Fill(finalNumberOfTracks);
-
-// Prepare the observables for the analysis itself.
-  Double_t *currentEta = new Double_t[finalNumberOfTracks](); // Pseudorapidity for the method of the eta gaps.
-  Double_t *currentPhi = new Double_t[finalNumberOfTracks](); // Azimuthal angles.
-  Double_t *currentParticleWeights = new Double_t[finalNumberOfTracks](); // Particle weights.
-  Int_t finalIndex = 0; // New index of the track if it passed the selection.
-  for (long long iiTrack = 0; iiTrack < currentNumberOfTracks; iiTrack++)
-  {
-    AliAODMCParticle *currentTrack = dynamic_cast<AliAODMCParticle*>(inputMCevent->GetTrack(iiTrack));
-    if (!currentTrack) {continue;}
-
-    if (isTrackSelected[iiTrack] == 0) {continue;}  // The track has failed the track selection.
-
-    currentEta[finalIndex] = currentTrack->Eta();
-    currentPhi[finalIndex] = currentTrack->Phi();
-    currentParticleWeights[finalIndex] = 1.;  // Unit particle weights are used by default.
-    if (fUseParticleWeights) {Fatal(sMethodName.Data(), "ERROR: TBA use of non-unit particle weights");}
-
-    finalIndex++;
-  }
-
-// Do the analysis for the current event.
-  CalculateQvectors(finalNumberOfTracks, currentPhi, currentParticleWeights);
-  ComputeMultiparticleCorrelations(finalNumberOfTracks, currentPhi, currentParticleWeights);
-  if (fComputeEtaGaps) {ComputeTwoParticleEtaGaps(finalNumberOfTracks, currentPhi, currentParticleWeights, currentEta);}
-
-// Reset the variables before passing to the next event.
-  currentNumberOfTracks = 0;
-  finalNumberOfTracks = 0;
-  delete [] isTrackSelected;
-  delete [] currentEta;
-  delete [] currentPhi;
-  delete [] currentParticleWeights;
-  finalIndex = 0;
-}
-
-//======================================================================================//
-Bool_t AliAnalysisTaskTwoMultiCorrelations::ApplyEventSelectionAOD(AliAODEvent *aAODevent)
-{
-/* Apply the event selection criteria on the given AOD event and return if the event passed it or not. */
-  TString sMethodName = "Bool_t AliAnalysisTaskTwoMultiCorrelations::ApplyEventSelectionAOD(AliAODEvent *aAODevent)";
+// Check the presence of an AOD event.
+  if (!fMCevent) {Fatal(sMethodName.Data(), "ERROR: no MC event found.");}
 
 // Set the detector for the centrality estimation as set in the task.
   TString centralityEstimator = "centralityEstimator";
@@ -1029,349 +499,323 @@ Bool_t AliAnalysisTaskTwoMultiCorrelations::ApplyEventSelectionAOD(AliAODEvent *
   else if (fCentralityFromVZero) {centralityEstimator = "V0M";}
   else if (fCentralityFromSPD) {centralityEstimator = "CL1";}
 
-// Reject events not belonging to the current centrality range.
-  AliMultSelection *multiplicitySelection = (AliMultSelection*)aAODevent->FindListObject("MultSelection");
-  if (!multiplicitySelection) {return kFALSE;}
-
-  Double_t eventCentrality = multiplicitySelection->GetMultiplicityPercentile(Form("%s", centralityEstimator.Data()));
-  if ( (eventCentrality < fCentralityMin) || (eventCentrality >= fCentralityMax) ) {return kFALSE;}
-
-// Get the observables used in the physics event selection.
-  long long unfilteredInitialNumberOfTracks = aAODevent->GetNumberOfTracks(); // Unfiltered number of tracks before any selection.
-  AliAODVertex *eventVertex = (AliAODVertex*)aAODevent->GetPrimaryVertex(); // 3D position of the PV.
-
-// Fill the QA histograms before the event selection.
-  fHistoInitialCentrality->Fill(eventCentrality);
-  fHistoInitialNumberOfTracks->Fill(unfilteredInitialNumberOfTracks);
-  fHistoInitialPVX->Fill(eventVertex->GetX());
-  fHistoInitialPVY->Fill(eventVertex->GetY());
-  fHistoInitialPVZ->Fill(eventVertex->GetZ());
-
-// Apply the physics event selection criteria.
-/// Cuts on the position of the PV.
-  if (fCutOnPVX)
+// Select only the events belonging to the current centrality range.
+  Float_t centrality = 0.;
+  if (!fAnalyseOnlyMC)    // Centrality has no sense for Kine events.
   {
-    if ( (eventVertex->GetX() < fPVXMin) || (eventVertex->GetX() > fPVXMax) ) {return kFALSE;}
+    fMultSelection = (AliMultSelection*)fMCevent->FindListObject("MultSelection");
+    if (!fMultSelection) {return;}
+
+    Double_t centrality = fMultSelection->GetMultiplicityPercentile(Form("%s", centralityEstimator.Data()));
+    if ( (centrality < fCentralityMin) || (centrality >= fCentralityMax) ) {return;}
   }
-  if (fCutOnPVY)
+  fHistoCentrality[0]->Fill(centrality);
+
+// Look at the initial observables.
+  fInitialMultiplicity = fMCevent->GetNumberOfTracks();
+  AliMCVertex *primaryVertex = (AliMCVertex*)fMCevent->GetPrimaryVertex();
+
+  fHistoMultiplicity[0]->Fill(fInitialMultiplicity);
+  fHistoPVx[0]->Fill(primaryVertex->GetX());
+  fHistoPVy[0]->Fill(primaryVertex->GetY());
+  fHistoPVz[0]->Fill(primaryVertex->GetZ());
+
+// Apply the physics event selection. (No need to remove HMOs in MC events.)
+  if(!ApplyPhysicsEventSelection()) {return;}
+
+  fHistoCentrality[1]->Fill(centrality);
+  fHistoPVx[1]->Fill(primaryVertex->GetX());
+  fHistoPVy[1]->Fill(primaryVertex->GetY());
+  fHistoPVz[1]->Fill(primaryVertex->GetZ());
+
+// Apply the track selection to classify the tracks.
+  long long multiplicity = fMCevent->GetNumberOfTracks();   // Current number of tracks.
+  long long finalMultiplicity = 0;                          // Number of tracks selected for the analysis.
+  Bool_t *isTrackSelected = new Bool_t[multiplicity]();     // kTRUE: the track passed the selection, kFALSE: the track is rejected.
+
+  for (Int_t iTrack = 0; iTrack < multiplicity; iTrack++)
   {
-    if ( (eventVertex->GetY() < fPVYMin) || (eventVertex->GetY() > fPVYMax) ) {return kFALSE;}
+  // Get the current track belonging to the main filter.
+    AliAODMCParticle *aTrack = dynamic_cast<AliAODMCParticle*>(fMCevent->GetTrack(iTrack));
+    if (!aTrack) {continue;}    // No track found.
+
+  // Apply the track selection (histograms are filled inside).
+    if (!ApplyTrackSelectionMC(aTrack)) {isTrackSelected[iTrack] = kFALSE;}
+    else {isTrackSelected[iTrack] = kTRUE; finalMultiplicity++;}
+  }   // End of the first loop over the tracks.
+
+// Select only the events with enough tracks for the event weight.
+  if (finalMultiplicity < fMultiplicityMin) {return;}
+  fHistoMultiplicity[1]->Fill(finalMultiplicity);
+
+// Prepare the variables needed for the rest of the analysis.
+  Float_t   iPt = 0.;                                               // Transverse momentum.
+  Float_t   *iEta = new Float_t[finalMultiplicity]();               // Pseudorapidity for the eta gaps.
+  Float_t   *iPhi = new Float_t[finalMultiplicity]();               // Azimuthal angles.
+  Float_t   *iParticleWeights = new Float_t[finalMultiplicity]();   // Particle weights.
+  Int_t     iIndex = 0;                                             // Index of the selected track in the final arrays.
+
+  for (Int_t iiTrack = 0; iiTrack < multiplicity; iiTrack++)
+  {
+  // Check if iiTrack corresponds to a selected track or not.
+    if (!isTrackSelected[iiTrack]) {continue;}
+
+    AliAODMCParticle *aaTrack = dynamic_cast<AliAODMCParticle*>(fMCevent->GetTrack(iiTrack));
+    if (!aaTrack) {continue;}
+
+    iPt           = aaTrack->Pt();
+    iEta[iIndex]  = aaTrack->Eta();
+    iPhi[iIndex]  = aaTrack->Phi();
+    iParticleWeights[iIndex] = 1.;    // Unit particle weights are used by default.
+    if (fUseNonUnitParticleWeights) {Fatal(sMethodName.Data(), "ERROR: TBA use of non-unit particle weights.");}
+
+    iIndex++;
+  }   // End of the second loop over the tracks.
+
+// Compute the multiparticle correlations for the current event.
+  CalculateQvectors(finalMultiplicity, iPhi, iParticleWeights);
+  ComputeReducedQvectors(finalMultiplicity);
+  ComputeAllCorrelators(finalMultiplicity, iPhi, iParticleWeights);
+  if (fComputeEtaGaps) {ComputeTPCWithEtaGaps(finalMultiplicity, iPhi, iParticleWeights, iEta);}
+
+// Do a dummy expression for iPt.
+  iPt++;
+
+// Reset the EbE variables.
+  centrality              = 0.;
+  fInitialMultiplicity    = 0;
+  multiplicity            = 0;
+  finalMultiplicity       = 0;
+  delete [] isTrackSelected;
+  iPt                     = 0.;
+  delete [] iEta;
+  delete [] iPhi;
+  delete [] iParticleWeights;
+  iIndex                  = 0;
+}   // End of "void AnalyseMCevent()".
+
+/* ------------------------------------------------------------------------- */
+Bool_t AliAnalysisTaskTwoMultiCorrelations::ApplyPhysicsEventSelection()
+{
+/* Apply the part of the event selection related to the physics. */
+  TString sMethodName = "void AliAnalysisTaskTwoMultiCorrelations::ApplyPhysicsEventSelection()";
+
+// Select the right method according to the types of files.
+  Float_t PVx = 0.;
+  Float_t PVy = 0.;
+  Float_t PVz = 0.;
+
+  if (fAnalyseOnlyAOD)
+  {
+    AliAODVertex *primaryVertex = (AliAODVertex*)fAODevent->GetPrimaryVertex();
+    PVx = primaryVertex->GetX();
+    PVy = primaryVertex->GetY();
+    PVz = primaryVertex->GetZ();
   }
-  if (fCutOnPVZ)
+  else if (fAnalyseOnlyMC)
   {
-    if ( (eventVertex->GetZ() < fPVZMin) || (eventVertex->GetZ() > fPVZMax) ) {return kFALSE;}
+    AliMCVertex *primaryVertex = (AliMCVertex*)fMCevent->GetPrimaryVertex();
+    PVx = primaryVertex->GetX();
+    PVy = primaryVertex->GetY();
+    PVz = primaryVertex->GetZ();
   }
 
-/// TBI: more physics criteria?
+// Apply the selection.
+  if (fCutOnPVx)
+  {if ( (PVx < fPVxMin) || (PVx > fPVxMax) ) {return kFALSE;}}
+  if (fCutOnPVy)
+  {if ( (PVy < fPVyMin) || (PVy > fPVyMax) ) {return kFALSE;}}
+  if (fCutOnPVz)
+  {if ( (PVz < fPVzMin) || (PVz > fPVzMax) ) {return kFALSE;}}
 
-// Remove the high multiplicity outliers.
-/// Get the number of tracks for the main and the global filter bits.
-  long long numberOfTracks = aAODevent->GetNumberOfTracks();  // Total number of tracks in the given event.
-  long long globalNumberOfTracks = 0; // Number of tracks in the global filter.
-  long long mainNumberOfTracks = 0; // Number of tracks in the main filter bit.
+// Reset the variables.
+  PVx = 0.;
+  PVy = 0.;
+  PVz = 0.;
 
-  for (Int_t iTrack = 0; iTrack < numberOfTracks; iTrack++)
+  return kTRUE;
+}   // End of "Bool_t ApplyPhysicsEventSelection()".
+
+/* ------------------------------------------------------------------------- */
+Bool_t AliAnalysisTaskTwoMultiCorrelations::RemoveHMOs()
+{
+/* Get and apply the criteria to remove the HMOs in AOD events. */
+  long long multiplicity = fAODevent->GetNumberOfTracks();    // Number of tracks after the physics event selection.
+  long long globalMultiplicity = 0;                           // Number of tracks in the global filter.
+  long long mainMultiplicity = 0;                             // Number of tracks in the main filter.
+
+  for (Int_t iTrack = 0; iTrack < multiplicity; iTrack++)
   {
-    AliAODTrack *aTrack = dynamic_cast<AliAODTrack*>(aAODevent->GetTrack(iTrack));
+    AliAODTrack *aTrack = dynamic_cast<AliAODTrack*>(fAODevent->GetTrack(iTrack));
     if (!aTrack) {continue;}
-
-    if (aTrack->TestFilterBit(fGlobalFilter)) {globalNumberOfTracks++;}
-    if (aTrack->TestFilterBit(fMainFilter)) {mainNumberOfTracks++;}
+    if (aTrack->TestFilterBit(fGlobalFilter)) {globalMultiplicity++;}
+    if (aTrack->TestFilterBit(fMainFilter)) {mainMultiplicity++;}
   }
 
-/// Fill the histograms before the application of the cuts.
-  fHistoInitialNumberOfTracksGlobal->Fill(globalNumberOfTracks);
-  fHistoInitialNumberOfTracksMain->Fill(mainNumberOfTracks);
-  if (fDoTDCorrelationHisto) {fHistoInitialFilterCorrelations->Fill(globalNumberOfTracks, mainNumberOfTracks);}
+  fHistoMultiplicityGlobal[0]->Fill(globalMultiplicity);
+  fHistoMultiplicityMain[0]->Fill(mainMultiplicity);
+  if (fDoCorrelationsHisto) {fHistoCorrelatedFilters[0]->Fill(globalMultiplicity, mainMultiplicity);}
 
-/// Apply the cuts.
-  if (fCutOnTDCorrelations)
+// Apply the HMOs cuts.
+  if (fCutOnHMOs)
   {
-    if ( (Double_t)mainNumberOfTracks < (fMultiplicityMinA*(Double_t)globalNumberOfTracks + fMultiplicityMinB) ) {return kFALSE;} // The number of tracks in the main filter is under the accepted band.
-    if ( (Double_t)mainNumberOfTracks > (fMultiplicityMaxA*(Double_t)globalNumberOfTracks + fMultiplicityMaxB) ) {return kFALSE;} // The number of tracks in the main filter is above the accepted band.
+    if ( (Float_t)mainMultiplicity < (fMultiplicityMinA*(Float_t)globalMultiplicity + fMultiplicityMinB) ) {return kFALSE;} // The number of tracks in the main filter is under the accepted band.
+    if ( (Float_t)mainMultiplicity > (fMultiplicityMaxA*(Float_t)globalMultiplicity + fMultiplicityMaxB) ) {return kFALSE;} // The number of tracks in the main filter is above the accepted band.
   }
 
-// Apply of the brute-force method to remove HM outliers?
-  Int_t cutValueMaxNumberOfTracks = 0;  // Value of the cut on the maximum number of tracks.
-  if (fCutOnTracksMax)  // If the cuts on the maximum numbers of tracks are enabled.
-  {
-  // Determine the value to cut depending on the centrality.
-    if ( (eventCentrality >= 0.) && (eventCentrality < 5.) ) {cutValueMaxNumberOfTracks = fNumberOfTracksMaxZero;}
-    else if ( (eventCentrality >= 5.) && (eventCentrality < 10.) ) {cutValueMaxNumberOfTracks = fNumberOfTracksMaxFive;}
-    else if ( (eventCentrality >= 10.) && (eventCentrality < 20.) ) {cutValueMaxNumberOfTracks = fNumberOfTracksMaxTen;}
-    else if ( (eventCentrality >= 20.) && (eventCentrality < 30.) ) {cutValueMaxNumberOfTracks = fNumberOfTracksMaxTwenty;}
-    else if ( (eventCentrality >= 30.) && (eventCentrality < 40.) ) {cutValueMaxNumberOfTracks = fNumberOfTracksMaxThirty;}
-    else if ( (eventCentrality >= 40.) && (eventCentrality < 50.) ) {cutValueMaxNumberOfTracks = fNumberOfTracksMaxForty;}
-    else if ( (eventCentrality >= 50.) && (eventCentrality < 60.) ) {cutValueMaxNumberOfTracks = fNumberOfTracksMaxFifty;}
-    else if ( (eventCentrality >= 60.) && (eventCentrality < 70.) ) {cutValueMaxNumberOfTracks = fNumberOfTracksMaxSixty;}
-    else if ( (eventCentrality >= 70.) && (eventCentrality < 80.) ) {cutValueMaxNumberOfTracks = fNumberOfTracksMaxSeventy;}
-
-  // Apply the cut.
-    if (mainNumberOfTracks > cutValueMaxNumberOfTracks) {return kFALSE;}
-  }
-
-// Fill the histograms after the application of the cuts.
-// No need to get the new numbers of tracks as the events qualified as outliers are normally removed with the last cuts.
-  fHistoFinalNumberOfTracksGlobal->Fill(globalNumberOfTracks);
-  fHistoFinalNumberOfTracksMain->Fill(mainNumberOfTracks);
-  if (fDoTDCorrelationHisto) {fHistoFinalFilterCorrelations->Fill(globalNumberOfTracks, mainNumberOfTracks);}
-
-// Fill the QA histograms after the event selection.
-  fHistoFinalCentrality->Fill(eventCentrality);
-  fHistoFinalPVX->Fill(eventVertex->GetX());
-  fHistoFinalPVY->Fill(eventVertex->GetY());
-  fHistoFinalPVZ->Fill(eventVertex->GetZ());
+  fHistoMultiplicityGlobal[1]->Fill(globalMultiplicity);
+  fHistoMultiplicityMain[1]->Fill(mainMultiplicity);
+  if (fDoCorrelationsHisto) {fHistoCorrelatedFilters[1]->Fill(globalMultiplicity, mainMultiplicity);}
 
 // Reset the variables.
-  numberOfTracks = 0;
-  globalNumberOfTracks = 0;
-  mainNumberOfTracks = 0;
-  cutValueMaxNumberOfTracks = 0;
+  multiplicity        = 0;
+  globalMultiplicity  = 0;
+  mainMultiplicity    = 0;
 
   return kTRUE;
-}
+}   // End of "Bool_t RemoveHMOs()".
 
-//======================================================================================//
-Bool_t AliAnalysisTaskTwoMultiCorrelations::ApplyEventSelectionMC(AliMCEvent *aMCevent)
-{
-/* Apply the event selection criteria on the given MC event and return if the event passed it or not. */
-  TString sMethodName = "Bool_t AliAnalysisTaskTwoMultiCorrelations::ApplyEventSelectionMC(AliMCEvent *aMCevent)";
-
-// Set the detector for the centrality estimation as set in the task.
-  TString centralityEstimator = "centralityEstimator";
-  if ( (Int_t)fCentralityFromVZero + (Int_t)fCentralityFromSPD != 1 )
-  {
-    Fatal(sMethodName.Data(), "ERROR: only one detector must be set to kTRUE.");
-  }
-  else if (fCentralityFromVZero) {centralityEstimator = "V0M";}
-  else if (fCentralityFromSPD) {centralityEstimator = "CL1";}
-
-/// Reject events not belonging to the current centrality range.
-  Double_t eventCentrality = 0.;  // Centrality of the given event.
-  if (!fProcessOnlyMC)  // Centrality has no sense for Kine events.
-  {
-    AliMultSelection *multiplicitySelection = (AliMultSelection*)aMCevent->FindListObject("MultSelection");
-    if (!multiplicitySelection) {return kFALSE;}
-
-    eventCentrality = multiplicitySelection->GetMultiplicityPercentile(Form("%s", centralityEstimator.Data()));
-    if ( (eventCentrality < fCentralityMin) || (eventCentrality >= fCentralityMax) ) {return kFALSE;}
-  }
-
-// Get the observables used in the physics event selection.
-  long long unfilteredInitialNumberOfTracks = aMCevent->GetNumberOfTracks();  // Unfiltered number of tracks before any selection.
-  AliMCVertex *eventVertex = (AliMCVertex*)aMCevent->GetPrimaryVertex();  // 3D position of the PV.
-
-// Fill the QA histograms before the event selection.
-  fHistoInitialCentrality->Fill(eventCentrality);
-  fHistoInitialNumberOfTracks->Fill(unfilteredInitialNumberOfTracks);
-  fHistoInitialPVX->Fill(eventVertex->GetX());
-  fHistoInitialPVY->Fill(eventVertex->GetY());
-  fHistoInitialPVZ->Fill(eventVertex->GetZ());
-
-// Apply the physics event selection criteria.
-/// Cuts on the position of the PV.
-  if (fCutOnPVX)
-  {
-    if ( (eventVertex->GetX() < fPVXMin) || (eventVertex->GetX() > fPVXMax) ) {return kFALSE;}
-  }
-  if (fCutOnPVY)
-  {
-    if ( (eventVertex->GetY() < fPVYMin) || (eventVertex->GetY() > fPVYMax) ) {return kFALSE;}
-  }
-  if (fCutOnPVZ)
-  {
-    if ( (eventVertex->GetZ() < fPVZMin) || (eventVertex->GetZ() > fPVZMax) ) {return kFALSE;}
-  }
-
-/// TBI: more physics criteria?
-
-// Apply of the brute-force method to remove HM outliers?
-// The 2d correlation method cannot be used with MC tracks as they have no notion of filter bits.
-  long long numberOfTracks = aMCevent->GetNumberOfTracks();  // Total number of tracks in the given event.
-  Int_t cutValueMaxNumberOfTracks = 0;  // Value of the cut on the maximum number of tracks.
-  if (fCutOnTracksMax)  // If the cuts on the maximum numbers of tracks are enabled.
-  {
-  // Determine the value to cut depending on the centrality.
-    if ( (eventCentrality >= 0.) && (eventCentrality < 5.) ) {cutValueMaxNumberOfTracks = fNumberOfTracksMaxZero;}
-    else if ( (eventCentrality >= 5.) && (eventCentrality < 10.) ) {cutValueMaxNumberOfTracks = fNumberOfTracksMaxFive;}
-    else if ( (eventCentrality >= 10.) && (eventCentrality < 20.) ) {cutValueMaxNumberOfTracks = fNumberOfTracksMaxTen;}
-    else if ( (eventCentrality >= 20.) && (eventCentrality < 30.) ) {cutValueMaxNumberOfTracks = fNumberOfTracksMaxTwenty;}
-    else if ( (eventCentrality >= 30.) && (eventCentrality < 40.) ) {cutValueMaxNumberOfTracks = fNumberOfTracksMaxThirty;}
-    else if ( (eventCentrality >= 40.) && (eventCentrality < 50.) ) {cutValueMaxNumberOfTracks = fNumberOfTracksMaxForty;}
-    else if ( (eventCentrality >= 50.) && (eventCentrality < 60.) ) {cutValueMaxNumberOfTracks = fNumberOfTracksMaxFifty;}
-    else if ( (eventCentrality >= 60.) && (eventCentrality < 70.) ) {cutValueMaxNumberOfTracks = fNumberOfTracksMaxSixty;}
-    else if ( (eventCentrality >= 70.) && (eventCentrality < 80.) ) {cutValueMaxNumberOfTracks = fNumberOfTracksMaxSeventy;}
-
-  // Apply the cut.
-    if (numberOfTracks > cutValueMaxNumberOfTracks) {return kFALSE;}
-  }
-
-// Fill the QA histograms after the event selection.
-  fHistoFinalCentrality->Fill(eventCentrality);
-  fHistoFinalPVX->Fill(eventVertex->GetX());
-  fHistoFinalPVY->Fill(eventVertex->GetY());
-  fHistoFinalPVZ->Fill(eventVertex->GetZ());
-
-// Reset the variables.
-  eventCentrality = 0.;
-  numberOfTracks = 0;
-  cutValueMaxNumberOfTracks = 0;
-
-  return kTRUE;
-}
-
-//======================================================================================//
+/* ------------------------------------------------------------------------- */
 Bool_t AliAnalysisTaskTwoMultiCorrelations::ApplyTrackSelectionAOD(AliAODTrack *aAODtrack)
 {
 /* Apply the track selection criteria and return if the track passed it or not. */
   TString sMethodName = "Bool_t AliAnalysisTaskTwoMultiCorrelations::ApplyTrackSelection(AliAODTrack *aAODtrack)";
 
-// Get the observables needed for the track selection.
-  Double_t  pT = aAODtrack->Pt();                                               // Transverse momentum of the track.
-  Double_t  eta = aAODtrack->Eta();                                             // Pseudorapidity of the track.
-  Double_t  phi = aAODtrack->Phi();                                             // Azimuthal angle of the track.
-  Int_t     numberOfTPCClusters = aAODtrack->GetTPCNcls();                      // Number of TPC clusters gone through by the track.
-  Int_t     numberOfITSClusters = aAODtrack->GetITSNcls();                      // Number of ITS clusters gone through by the track.
-  Double_t  chiSquareInTPC = (aAODtrack->GetTPCchi2())/(aAODtrack->GetNcls(1)); // Chi square in the TPC.
-  Double_t  DCAx = aAODtrack->XAtDCA();                                         // x-coordinate of the DCA.
-  Double_t  DCAy = aAODtrack->YAtDCA();                                         // y-coordinate of the DCA.
-  Double_t  DCAz = aAODtrack->ZAtDCA();                                         // z-coordinate of the DCA.
-  Double_t  DCAxy = TMath::Sqrt( (DCAx*DCAx) + (DCAy*DCAy) );                   // xy-coordinate of the DCA.
-  Int_t     charge = aAODtrack->Charge();                                       // Electric charge.
+// Get all the observables for the given AOD track.
+  Float_t   pT          = aAODtrack->Pt();                            // Transverse momentum.
+  Float_t   eta         = aAODtrack->Eta();                           // Pseudorapidity.
+  Float_t   phi         = aAODtrack->Phi();                           // Azimuthal angle.
+  Int_t     NTPC        = aAODtrack->GetTPCNcls();                    // Number of TPC clusters.
+  Float_t   chiSquare   = (aAODtrack->GetTPCchi2())/(aAODtrack->GetNcls(1));    // Chi square of p in the TPC.
+  Int_t     NITS        = aAODtrack->GetITSNcls();                    // Number of ITS clusters.
+  Float_t   DCAx        = aAODtrack->XAtDCA();                        // DCA along x.
+  Float_t   DCAy        = aAODtrack->YAtDCA();                        // DCA along y.
+  Float_t   DCAz        = aAODtrack->ZAtDCA();                        // DCA along z.
+  Int_t     charge      = aAODtrack->Charge();                        // Electric charge.
+  Float_t   DCAxy       = TMath::Sqrt( (DCAx*DCAx) + (DCAy*DCAy) );   // DCA in the xy-plane.
 
-// Fill the initial histograms before the track selection.
-  fHistoInitialPt->Fill(pT);
-  fHistoInitialEta->Fill(eta);
-  fHistoInitialPhi->Fill(phi);
-  fHistoInitialNumberOfTPC->Fill(numberOfTPCClusters);
-  fHistoInitialChiSquare->Fill(chiSquareInTPC);
-  fHistoInitialDCAxy->Fill(DCAxy);
-  fHistoInitialDCAz->Fill(DCAz);
-  fHistoInitialCharge->Fill(charge);
-  fHistoInitialNumberOfITS->Fill(numberOfITSClusters);
+// Draw the initial distributions.
+  fHistoPt[0]->Fill(pT);
+  fHistoEta[0]->Fill(eta);
+  fHistoPhi[0]->Fill(phi);
+  fHistoNTPC[0]->Fill(NTPC);
+  fHistoChiSquare[0]->Fill(chiSquare);
+  fHistoNITS[0]->Fill(NITS);
+  fHistoDCAxy[0]->Fill(DCAxy);
+  fHistoDCAz[0]->Fill(DCAz);
+  fHistoCharge[0]->Fill(charge);
 
-// Apply the selection to the track.
+// Apply the selection.
   if (fCutOnPt)
-  {
-    if ( (pT < fPtMin) || (pT > fPtMax) ) {return kFALSE;}
-  }
+  {if ( (pT < fPtMin) || (pT > fPtMax) ) {return kFALSE;}}
   if (fCutOnEta)
+  {if ( (eta < fEtaMin) || (eta > fEtaMax) ) {return kFALSE;}}
+  if (fCutOnNTPC)
+  {if (NTPC < fNTPCMin) {return kFALSE;}}
+  if (fCutOnChi)
+  {if ( (chiSquare < fChiMin) || (chiSquare > fChiMax) ) {return kFALSE;}}
+  if (fCutOnNITS)
   {
-    if ( (eta < fEtaMin) || (eta > fEtaMax) ) {return kFALSE;}
-  }
-  if (fCutOnNumberOfTPC)
-  {
-    if (numberOfTPCClusters < fNumberOfTPCMin) {return kFALSE;}
-  }
-  if (fCutOnChiSquarePInTPC)
-  {
-    if ( (chiSquareInTPC < fChiSquarePInTPCMin) || (chiSquareInTPC > fChiSquarePInTPCMax) ) {return kFALSE;}
+    if (fMainFilter == 128) {Fatal(sMethodName.Data(), "ERROR: TPConly tracks do not have ITS information.");}
+    else if (NITS < fNITSMin) {return kFALSE;}
   }
   if (fCutOnDCAxy)
-  {
-    if (DCAxy > fDCAxyMax) {return kFALSE;}
-  }
+  {if (DCAxy > fDCAxyMax) {return kFALSE;}}
   if (fCutOnDCAz)
-  {
-    if (DCAz > fDCAzMax) {return kFALSE;}
-  }
+  {if (DCAz > fDCAzMax) {return kFALSE;}}
   if (fCutOnCharge)
   {
-    if (charge != fCharge) {return kFALSE;}
-  }
-  if (fCutOnNumberOfITS)
-  {
-    if (numberOfITSClusters < fNumberOfITSMin) {return kFALSE;}
+    if (fKeepPositiveCharges) {if (charge < 0) {return kFALSE;}}          // Keep only the positive tracks.
+    else if (!fKeepPositiveCharges) {if (charge > 0) {return kFALSE;}}    // Keep only the negative tracks.
+    else {Fatal(sMethodName.Data(), "ERROR: Select the sign of the charges to keep.");}
   }
 
-// Fill the histograms after the track selection.
-  fHistoFinalPt->Fill(pT);
-  fHistoFinalEta->Fill(eta);
-  fHistoFinalPhi->Fill(phi);
-  fHistoFinalNumberOfTPC->Fill(numberOfTPCClusters);
-  fHistoFinalChiSquare->Fill(chiSquareInTPC);
-  fHistoFinalDCAxy->Fill(DCAxy);
-  fHistoFinalDCAz->Fill(DCAz);
-  fHistoFinalCharge->Fill(charge);
-  fHistoFinalNumberOfITS->Fill(numberOfITSClusters);
+// Draw the final distributions.
+  fHistoPt[1]->Fill(pT);
+  fHistoEta[1]->Fill(eta);
+  fHistoPhi[1]->Fill(phi);
+  fHistoNTPC[1]->Fill(NTPC);
+  fHistoChiSquare[1]->Fill(chiSquare);
+  fHistoNITS[1]->Fill(NITS);
+  fHistoDCAxy[1]->Fill(DCAxy);
+  fHistoDCAz[1]->Fill(DCAz);
+  fHistoCharge[1]->Fill(charge);
 
 // Reset the variables.
-  pT = 0.;
-  eta = 0.;
-  phi = 0.;
-  numberOfTPCClusters = 0;
-  numberOfITSClusters = 0;
-  chiSquareInTPC = 0.;
-  DCAx = 0.;
-  DCAy = 0.;
-  DCAz = 0.;
-  DCAxy = 0.;
-  charge = 0;
+  pT        = 0.;
+  eta       = 0.;
+  phi       = 0.;
+  NTPC      = 0;
+  chiSquare = 0.;
+  NITS      = 0;
+  DCAx      = 0.;
+  DCAy      = 0.;
+  DCAz      = 0.;
+  charge    = 0;
+  DCAxy     = 0.;
 
   return kTRUE;
-}
+}   // End of "Bool_t ApplyTrackSelectionAOD()".
 
-//======================================================================================//
+/* ------------------------------------------------------------------------- */
 Bool_t AliAnalysisTaskTwoMultiCorrelations::ApplyTrackSelectionMC(AliAODMCParticle *aMCtrack)
 {
 /* Apply the track selection criteria to the given MC track and return if it passed or not. */
   TString sMethodName = "Bool_t AliAnalysisTaskTwoMultiCorrelations::ApplyTrackSelectionMC(AliAODMCParticle *aMCtrack)";
 
-// Get the observables needed for the track selection.
-  Double_t  pT = aMCtrack->Pt();          // Transverse momentum of the track.
-  Double_t  eta = aMCtrack->Eta();        // Pseudorapidity of the track.
-  Double_t  phi = aMCtrack->Phi();        // Azimuthal angle of the track.
-  Int_t     charge = aMCtrack->Charge();  // Electric charge.
+// Get all the observables for the given MC track.
+  Float_t   pT          = aMCtrack->Pt();       // Transverse momentum.
+  Float_t   eta         = aMCtrack->Eta();      // Pseudorapidity.
+  Float_t   phi         = aMCtrack->Phi();      // Azimuthal angle.
+  Int_t     charge      = aMCtrack->Charge();   // Electric charge.
 
-// Fill the initial histograms before the track selection.
-  fHistoInitialPt->Fill(pT);
-  fHistoInitialEta->Fill(eta);
-  fHistoInitialPhi->Fill(phi);
-  fHistoInitialCharge->Fill(charge);
+// Draw the initial distributions.
+  fHistoPt[0]->Fill(pT);
+  fHistoEta[0]->Fill(eta);
+  fHistoPhi[0]->Fill(phi);
+  fHistoCharge[0]->Fill(charge);
 
-// Apply the selection to the track.
+// Apply the track selection.
   if (fCutOnPt)
-  {
-    if ( (pT < fPtMin) || (pT > fPtMax) ) {return kFALSE;}
-  }
+  {if ( (pT < fPtMin) || (pT > fPtMax) ) {return kFALSE;}}
   if (fCutOnEta)
-  {
-    if ( (eta < fEtaMin) || (eta > fEtaMax) ) {return kFALSE;}
-  }
+  {if ( (eta < fEtaMin) || (eta > fEtaMax) ) {return kFALSE;}}
   if (fCutOnCharge)
   {
-    if (charge != fCharge) {return kFALSE;}
+    if (fKeepPositiveCharges) {if (charge < 0) {return kFALSE;}}          // Keep only the positive tracks.
+    else if (!fKeepPositiveCharges) {if (charge > 0) {return kFALSE;}}    // Keep only the negative tracks.
+    else {Fatal(sMethodName.Data(), "ERROR: Select the sign of the charges to keep.");}
   }
 
-// Fill the histograms after the track selection.
-  fHistoFinalPt->Fill(pT);
-  fHistoFinalEta->Fill(eta);
-  fHistoFinalPhi->Fill(phi);
-  fHistoFinalCharge->Fill(charge);
+// Draw the final distributions.
+  fHistoPt[1]->Fill(pT);
+  fHistoEta[1]->Fill(eta);
+  fHistoPhi[1]->Fill(phi);
+  fHistoCharge[1]->Fill(charge);
 
 // Reset the variables.
-  pT = 0.;
-  eta = 0.;
-  phi = 0.;
-  charge = 0;
+  pT        = 0.;
+  eta       = 0.;
+  phi       = 0.;
+  charge    = 0;
 
   return kTRUE;
-}
+}   // End of "Bool_t ApplyTrackSelectionMC()".
 
-//======================================================================================//
-void AliAnalysisTaskTwoMultiCorrelations::CalculateQvectors(long long numberOfParticles, Double_t angles[], Double_t pWeights[])
+/* ------------------------------------------------------------------------- */
+void AliAnalysisTaskTwoMultiCorrelations::CalculateQvectors(long long numberOfParticles, Float_t angles[], Float_t pWeights[])
 {
 /* Calculate all the Q-vectors for the given arrays of azimuthal angles and particle weights. */
-  Double_t iAngle = 0.; // Azimuthal angle of the current particle.
-  Double_t iWeight = 0.;  // Particle weight of the current particle.
-  Double_t iWeightToPowerP = 0.;  // Particle weight rised to the power p.
+  Float_t   iAngle            = 0.;   // Azimuthal angle of the current track.
+  Float_t   iWeight           = 0.;   // Particle weight of the current track.
+  Float_t   iWeightToPowerP   = 0.;   // Particle weight rised to the power p.
 
 // Ensure all the Q-vectors are initially zero.
-  for (Int_t iHarmo = 0; iHarmo < 49; iHarmo++)
+  for (Int_t iHarmo = 0; iHarmo < 65; iHarmo++)
   {
     for (Int_t iPower = 0; iPower < 9; iPower++)
     {
-      fQvectors[iHarmo][iPower] = TComplex(0.,0.);
+      fQvectors[iHarmo][iPower] = TComplex(0., 0.);
     }
   }
 
@@ -1380,192 +824,55 @@ void AliAnalysisTaskTwoMultiCorrelations::CalculateQvectors(long long numberOfPa
   {
     iAngle = angles[iTrack];
     iWeight = pWeights[iTrack];
-    for (Int_t iHarmo = 0; iHarmo < 49; iHarmo++)
+    for (Int_t iHarmo = 0; iHarmo < 65; iHarmo++)
     {
       for (Int_t iPower = 0; iPower < 9; iPower++)
       {
         iWeightToPowerP = TMath::Power(iWeight, iPower);
         fQvectors[iHarmo][iPower] += TComplex(iWeightToPowerP*TMath::Cos(iHarmo*iAngle), iWeightToPowerP*TMath::Sin(iHarmo*iAngle));
-      }
-    }
-  }
-}
+      }   // End of the loop over the powers.
+    }   // End of the loop over the harmonics.
+  }   // End of the loop over the tracks.
 
-//======================================================================================//
+// Reset the variables.
+  iAngle            = 0.;
+  iWeight           = 0.;
+  iWeightToPowerP   = 0.;
+}   // End of "void CalculateQvectors()".
+
+/* ------------------------------------------------------------------------- */
 TComplex AliAnalysisTaskTwoMultiCorrelations::Q(Int_t n, Int_t p)
 {
-/* Simplify the use of the Q-vectors. */
+/* Simplify the use of the Q-vectors in the next methods. */
   if (n >= 0) {return fQvectors[n][p];}
-  return TComplex::Conjugate(fQvectors[-n][p]); // Use that Q*(n,p) = Q(-n,p).
-}
+  return TComplex::Conjugate(fQvectors[-n][p]);   // Use that Q*(n,p) = Q(-n,p).
+}   // End of "TComplex Q()".
 
-//======================================================================================//
-void AliAnalysisTaskTwoMultiCorrelations::ComputeMultiparticleCorrelations(long long numberOfParticles, Double_t angles[], Double_t pWeights[])
+/* ------------------------------------------------------------------------- */
+void AliAnalysisTaskTwoMultiCorrelations::ComputeReducedQvectors(long long numberOfParticles)
 {
-/* Compute the considered 2-, 4- and 6-particle correlations for the harmonics v_1 to v_6. */
-// Compute the 2-particle correlations.
-  Int_t twoZerosArray[2] = {0}; // Zero array for the denominator.
-  Double_t twoParticleDenominator = CalculateRecursion(2, twoZerosArray).Re();  // 2-particle event weight.
+/* Compute the modulus of reduced Q-vector for the current event and save it in the correct histogram. */
+  Double_t  reducedQ    = 0.;   // Modulus of reduced Q-vector.
+  Int_t     iHarmo      = 0;    // Harmonic corresponding to the current histogram.
 
-  Int_t twoParticleArray[2] = {0};  // Array to save the harmonics with the format: cos(nphi1 - nphi2).
-  TComplex twoParticleComplex = TComplex(0., 0.); // Complex value for the 2-particle correlation.
-  Double_t twoParticleValue = 0.; // Real part of the 2-particle correlation.
-  Double_t iBinTwoMiddle = 0.;  // Index of the corresponding bin in the TProfile.
-  for (Int_t n = 1; n < 7; n++)
+// Loop over the harmonics to get each q_n.
+  for (Int_t i = 0; i < 8; i++)
   {
-  // Compute the correlation.
-    twoParticleArray[0] = n;
-    twoParticleArray[1] = -1*n;
-    twoParticleComplex = (CalculateRecursion(2, twoParticleArray))/twoParticleDenominator;
-    twoParticleValue = twoParticleComplex.Re();
-
-  // Fill the corresponding bin in the TProfile.
-    iBinTwoMiddle = (1.*n) - 0.5;
-    fProfileTwoParticleCorrelations->Fill(iBinTwoMiddle, twoParticleValue, twoParticleDenominator);
-    fProfileTwoParticleCorrelations->GetXaxis()->SetBinLabel(n, Form("%d", n));
-
-  // Cross-check with nested loops if needed.
-    if (fCrosscheckWithNestedLoops)
-    {
-    // Fill the corresponding bin in the TProfile.
-      ComputeTwoNestedLoops(numberOfParticles, twoParticleArray, angles, pWeights, fProfileTwoParticleCorrelationsNestedLoops, iBinTwoMiddle);
-      fProfileTwoParticleCorrelationsNestedLoops->GetXaxis()->SetBinLabel(n, Form("%d", n));
-    }
-
-  // Reset of the variables for the next harmonic.
-    twoParticleComplex = TComplex(0., 0.);
-    twoParticleValue = 0.;
-    iBinTwoMiddle = 0.;
+    iHarmo = i + 1;
+    reducedQ = Q(iHarmo, fReducedQPower).Rho()/(TMath::Sqrt(1.*numberOfParticles));
+    fHistoReducedQvectors[i]->Fill(reducedQ);
   }
 
-// Compute the 4-particle correlations.
-  Int_t fourZerosArray[4] = {0};  // Zero array for the denominator.
-  Double_t fourParticleDenominator = CalculateRecursion(4, fourZerosArray).Re();  // 4-particle event weight.
+// Reset the variables.
+  reducedQ  = 0.;
+  iHarmo    = 0;
+}   // End of "void ComputeReducedQvectors()".
 
-  Int_t fourParticleArray[4] = {0}; // Array to save the harmonics with the format: cos(mphi1 + nphi2 - mphi3 - nphi4).
-  TComplex fourParticleComplex = TComplex(0., 0.);  // Complex value for the 4-particle correlation.
-  Double_t fourParticleValue = 0.;  // Real part of the 4-particle correlation.
-  Int_t iBinFour = 1; // Index of the corresponding bin in the TProfile.
-  Int_t iBinFourMiddle = 0.;  // Middle of the corresponding bin in the TProfile.
-  for(Int_t m = 1; m < 7; m++)
-  {
-    for (Int_t n = m; n < 7; n++)
-    {
-    // Compute the correlation.
-      fourParticleArray[0] = m;
-      fourParticleArray[1] = n;
-      fourParticleArray[2] = -1*m;
-      fourParticleArray[3] = -1*n;
-      fourParticleComplex = (CalculateRecursion(4, fourParticleArray))/fourParticleDenominator;
-      fourParticleValue = fourParticleComplex.Re();
-
-    // Fill the corresponding bin in the TProfile.
-      iBinFourMiddle = (1.*iBinFour) - 0.5;
-      fProfileFourParticleCorrelations->Fill(iBinFourMiddle, fourParticleValue, fourParticleDenominator);
-      fProfileFourParticleCorrelations->GetXaxis()->SetBinLabel(iBinFour, Form("(%d,%d)", m, n));
-
-    // Cross-check with nested loops if needed.
-      if (fCrosscheckWithNestedLoops)
-      {
-      // Fill the corresponding bin in the TProfile.
-        ComputeFourNestedLoops(numberOfParticles, fourParticleArray, angles, pWeights, fProfileFourParticleCorrelationsNestedLoops, iBinFourMiddle);
-        fProfileFourParticleCorrelationsNestedLoops->GetXaxis()->SetBinLabel(iBinFour, Form("(%d,%d)", m, n));
-      }
-
-    // Reset of the variables for the next pair of harmonics.
-      iBinFour++;
-      fourParticleComplex = TComplex(0., 0.);
-      fourParticleValue = 0.;
-      iBinFourMiddle = 0.;
-    }
-  }
-
-// Compute the 4-particle correlations for the cross-check if needed.
-  Int_t fourParticleCrossCheckArray[4] = {0}; // Array to save the harmonics with the format: cos(mphi1 + nphi2 - mphi3 - nphi4).
-  TComplex fourParticleCrossCheckComplex = TComplex(0., 0.);  // Complex value for the 4-particle correlation.
-  Double_t fourParticleCrossCheckValue = 0.;  // Real part of the 4-particle correlation.
-  Int_t iBinFourCrossCheck = 1; // Index of the corresponding bin in the TProfile.
-  Int_t iBinFourCrossCheckMiddle = 0.;  // Middle of the corresponding bin in the TProfile.
-  for(Int_t m = 2; m < 7; m++)
-  {
-    for (Int_t n = 1; n < m; n++)
-    {
-    // Compute the correlation.
-      fourParticleCrossCheckArray[0] = m;
-      fourParticleCrossCheckArray[1] = n;
-      fourParticleCrossCheckArray[2] = -1*m;
-      fourParticleCrossCheckArray[3] = -1*n;
-      fourParticleCrossCheckComplex = (CalculateRecursion(4, fourParticleCrossCheckArray))/fourParticleDenominator;
-      fourParticleCrossCheckValue = fourParticleCrossCheckComplex.Re();
-
-    // Fill the corresponding bin in the TProfile.
-      iBinFourCrossCheckMiddle = (1.*iBinFourCrossCheck) - 0.5;
-      fProfileFourParticleCorrelationsCrossCheck->Fill(iBinFourCrossCheckMiddle, fourParticleCrossCheckValue, fourParticleDenominator);
-      fProfileFourParticleCorrelationsCrossCheck->GetXaxis()->SetBinLabel(iBinFourCrossCheck, Form("(%d,%d)", m, n));
-
-    // Reset of the variables for the next pair of harmonics.
-     iBinFourCrossCheck++;
-     fourParticleCrossCheckComplex = TComplex(0., 0.);
-     fourParticleCrossCheckValue = 0.;
-     iBinFourCrossCheckMiddle = 0.;
-    }
-  }
-
-// Compute the 6-particle correlations.
-  Int_t sixZerosArray[6] = {0}; // Zero array for the denominator.
-  Double_t sixParticleDenominator = CalculateRecursion(6, sixZerosArray).Re();  // 6-particle event weight.
-
-  Int_t sixParticleArray[6] = {0};  // Array to save the harmonics with the format: cos(lphi1 + mphi2 + nphi3 - lphi4 - mphi5 - nphi6).
-  TComplex sixParticleComplex = TComplex(0., 0.); // Complex value for the 6-particle correlation.
-  Double_t sixParticleValue = 0.; // Real part of the 6-particle correlation.
-  Int_t iBinSix = 1;  // Index of the corresponding bin in the TProfile.
-  Int_t iBinSixMiddle = 0.; // Middle of the corresponding bin in the TProfile.
-  for (Int_t l = 1; l < 5; l++)
-  {
-    for (Int_t m = 2; m < 6; m++)
-    {
-      if (l >= m) {continue;}
-      for (Int_t n = 3; n < 7; n++)
-      {
-        if ((l >= n) || (m >= n)) {continue;}
-
-      // Compute the correlation.
-        sixParticleArray[0] = l;
-        sixParticleArray[1] = m;
-        sixParticleArray[2] = n;
-        sixParticleArray[3] = -1*l;
-        sixParticleArray[4] = -1*m;
-        sixParticleArray[5] = -1*n;
-        sixParticleComplex = (CalculateRecursion(6, sixParticleArray))/sixParticleDenominator;
-        sixParticleValue = sixParticleComplex.Re();
-
-      // Fill the corresponding bin in the TProfile.
-        iBinSixMiddle = (1.*iBinSix) - 0.5;
-        fProfileSixParticleCorrelations->Fill(iBinSixMiddle, sixParticleValue, sixParticleDenominator);
-        fProfileSixParticleCorrelations->GetXaxis()->SetBinLabel(iBinSix, Form("(%d,%d,%d)", l, m, n));
-
-      // Reset of the variables for the next pair of harmonics.
-        iBinSix++;
-        sixParticleComplex = TComplex(0., 0.);
-        sixParticleValue = 0.;
-        iBinSixMiddle = 0.; 
-      }
-    }
-  }
-
-// Reset the variables for the next event.
-  twoParticleDenominator = 0.;
-  fourParticleDenominator = 0.;
-  sixParticleDenominator = 0.;
-  iBinFour = 1;
-  iBinFourCrossCheck =1;
-  iBinSix = 1;
-}
-
-//======================================================================================//
+/* ------------------------------------------------------------------------- */
 TComplex AliAnalysisTaskTwoMultiCorrelations::CalculateRecursion(Int_t n, Int_t *harmonic, Int_t mult, Int_t skip)
 {
-/* Calculate the multi-particle correlators by using the recursion method (an improved faster version) originally developed by Kristjan Gulbrandsen (gulbrand@nbi.dk). */
+/* Calculate the multi-particle correlators by using the recursion method.                  /
+/ Improved, faster version originally developed by Kristjan Gulbrandsen (gulbrand@nbi.dk). */
   Int_t nm1 = n-1;
   TComplex c(Q(harmonic[nm1], mult));
   if (nm1 == 0) return c;
@@ -1596,142 +903,555 @@ TComplex AliAnalysisTaskTwoMultiCorrelations::CalculateRecursion(Int_t n, Int_t 
 
   if (mult == 1) return c-c2;
   return c-Double_t(mult)*c2;
-}
+}   // End of "TComplex CalculateRecursion()".
 
-//======================================================================================//
-void AliAnalysisTaskTwoMultiCorrelations::ComputeTwoNestedLoops(long long nParticles, Int_t *harmonic, Double_t aAngles[], Double_t weights[], TProfile *profile, Double_t middleBin)
+/* ------------------------------------------------------------------------- */
+void AliAnalysisTaskTwoMultiCorrelations::ComputeAllCorrelators(long long numberOfParticles, Float_t angles[], Float_t pWeights[])
 {
-/* Compute the 2-particle correlations using nested loops. */
-  Double_t twoParticleCosine = 0.;  // cos(kphi_1 + lphi_2)).
-  Double_t twoParticleWeight = 1.;  // Total particle weights.
+/* Compute and save all the multiparticle correlators for the current event. */
+  Int_t       twoZerosArray[2]    = {0};                // 2d array with zeros for the denominator.
+  Int_t       twoPartArray[2]     = {0};                // 2d array for the current harmonic.
+  Int_t       fourZerosArray[4]   = {0};                // 4d array with zeros for the denominator.
+  Int_t       fourPartArray[4]    = {0};                // 4d array for the current couple of harmonics.
+  Int_t       sixZerosArray[6]    = {0};                // 6d array with zeros for the denominator.
+  Int_t       sixPartArray[6]     = {0};                // 6d array for the current triplet of harmonics.
+  Double_t    eventWeight         = 0.;                 // Event weight and denominator of the correlator.
+  TComplex    complexCorrelator   = TComplex(0., 0.);   // Complex form of the correlator.
+  Double_t    realCorrelator      = 0.;                 // Real part of the correlator.
+  Int_t       iBin                = 1;                  // Bin for the current correlator.
+  Double_t    iMiddleBin          = 0.;                 // Middle of the bin for the current correlator.
 
-  for (long long m = 0; m < nParticles; m++)
+// Compute the 2-particle correlators for v_1 to v_8.
+  eventWeight = (CalculateRecursion(2, twoZerosArray)).Re();
+  for (Int_t n = 1; n < 9; n++)   // Loop over the harmonics.
   {
-    for (long long n = 0; n < nParticles; n++)
-    {
-      if (m == n) {continue;} // Remove the autocorrelations.
+  // Compute the correlator.
+    twoPartArray[0]     = n;
+    twoPartArray[1]     = -1*n;
+    complexCorrelator   = (CalculateRecursion(2, twoPartArray))/eventWeight;
+    realCorrelator      = complexCorrelator.Re();
 
-      twoParticleCosine = TMath::Cos(harmonic[0]*aAngles[m] + harmonic[1]*aAngles[n]);
-      twoParticleWeight = weights[m] + weights[n];
-      profile->Fill(middleBin, twoParticleCosine, twoParticleWeight);
+  // Fill the corresponding bin in the profile.
+    iMiddleBin          = (1.*n) - 0.5;
+    fProfileTwoPartCorrel->Fill(iMiddleBin, realCorrelator, eventWeight);
+    fProfileTwoPartCorrel->GetXaxis()->SetBinLabel(n, Form("%d", n));
 
-    // Reset the variables.
-      twoParticleCosine = 0.;
-      twoParticleWeight = 1.;
-    }
-  }
-}
+  // Reset the variables for the next harmonic.
+    complexCorrelator   = TComplex(0., 0.);
+    realCorrelator      = 0.;
+    iMiddleBin          = 0.;
+  }   // End of the loop over the harmonics for the 2-p correlators.
 
-//======================================================================================//
-void AliAnalysisTaskTwoMultiCorrelations::ComputeFourNestedLoops(long long nParticles, Int_t *harmonic, Double_t aAngles[], Double_t weights[], TProfile *profile, Double_t middleBin)
-{
-/* Compute the 4-particle correlations using nested loops. */
-  Double_t fourParticleCosine = 0.; // cos(kphi_1 +l phi_2 + mphi_3 + nphi_4).
-  Double_t fourParticleWeight = 1.; // Total particle weights.
+  eventWeight           = 0.;   // Reset of the denominator.
 
-  for (long long k = 0; k < nParticles; k++)
+// Compute the 4-particle correlators.
+  eventWeight           = (CalculateRecursion(4, fourZerosArray)).Re();
+  for(Int_t m = 1; m < 9; m++)
   {
-    for (long long l = 0; l < nParticles; l++)
+    for (Int_t n = m; n < 9; n++)
     {
-      if (k == l) {continue;} // Remove the autocorrelations.
-      for (long long m = 0; m < nParticles; m++)
+    // Compute the correlator.
+      fourPartArray[0]  = m;
+      fourPartArray[1]  = n;
+      fourPartArray[2]  = -1*m;
+      fourPartArray[3]  = -1*n;
+      complexCorrelator = (CalculateRecursion(4, fourPartArray))/eventWeight;
+      realCorrelator    = complexCorrelator.Re();
+
+    // Fill the corresponding bin in the profile.
+      iMiddleBin        = (1.*iBin) - 0.5;
+      fProfileFourPartCorrel->Fill(iMiddleBin, realCorrelator, eventWeight);
+      fProfileFourPartCorrel->GetXaxis()->SetBinLabel(iBin, Form("(%d,%d)", m, n));
+
+    // Reset of the variables for the next pair of harmonics.
+      iBin++;
+      complexCorrelator = TComplex(0., 0.);
+      realCorrelator    = 0.;
+      iMiddleBin        = 0.;
+    }   // End of the loop over the second harmonic for the 4-p correlators.
+  }   // End of the loop over the first harmonic for the 4-p correlators.
+
+  iBin                  = 1;
+
+  for(Int_t m = 2; m < 9; m++)
+  {
+    for (Int_t n = 1; n < m; n++)
+    {
+    // Compute the correlator.
+      fourPartArray[0]  = m;
+      fourPartArray[1]  = n;
+      fourPartArray[2]  = -1*m;
+      fourPartArray[3]  = -1*n;
+      complexCorrelator = (CalculateRecursion(4, fourPartArray))/eventWeight;
+      realCorrelator    = complexCorrelator.Re();
+
+    // Fill the corresponding bin in the profile.
+      iMiddleBin        = (1.*iBin) - 0.5;
+      fProfileFourPartCorrelCheck->Fill(iMiddleBin, realCorrelator, eventWeight);
+      fProfileFourPartCorrelCheck->GetXaxis()->SetBinLabel(iBin, Form("(%d,%d)", m, n));
+
+    // Reset of the variables for the next pair of harmonics.
+     iBin++;
+     complexCorrelator  = TComplex(0., 0.);
+     realCorrelator     = 0.;
+     iMiddleBin         = 0.;
+    }   // End of the loop over the second harmonic for cross-check.
+  }   // End of the loop over the first harmonic for cross-check.
+
+  eventWeight           = 0.;
+  iBin                  = 1;
+
+// Compute the needed 6-particle correlators.
+  eventWeight           = (CalculateRecursion(6, sixZerosArray)).Re();
+  for (Int_t l = 1; l < 7; l++)
+  {
+    for (Int_t m = 2; m < 8; m++)
+    {
+      if (l >= m) {continue;}   // Remove the cases in (l,l,n).
+      for (Int_t n = 3; n < 9; n++)
       {
-        if ((k == m) || (l == m)) {continue;}
-        for (long long n = 0; n < nParticles; n++)
-        {
-          if ((k == n) || (l == n) || (m == n)) {continue;}
+        if ((l >= n) || (m >= n)) {continue;}   // Remove the cases in (l,m,l) or (l,m,m).
 
-          fourParticleCosine = TMath::Cos(harmonic[0]*aAngles[k] + harmonic[1]*aAngles[l] + harmonic[2]*aAngles[m] + harmonic[3]*aAngles[n]);
-          fourParticleWeight = weights[k] + weights[l] + weights[m] + weights[n];
-          profile->Fill(middleBin, fourParticleCosine, fourParticleWeight);
+      // Compute the correlator.
+        sixPartArray[0] = l;
+        sixPartArray[1] = m;
+        sixPartArray[2] = n;
+        sixPartArray[3] = -1*l;
+        sixPartArray[4] = -1*m;
+        sixPartArray[5] = -1*n;
+        complexCorrelator = (CalculateRecursion(6, sixPartArray))/eventWeight;
+        realCorrelator  = complexCorrelator.Re();
 
-        // Reset the variables.
-          fourParticleCosine = 0.;
-          fourParticleWeight = 1.;
-        }
-      }
-    }
-  }
-}
+      // Fill the corresponding bin in the TProfile.
+        iMiddleBin = (1.*iBin) - 0.5;
+        fProfileSixPartCorrel->Fill(iMiddleBin, realCorrelator, eventWeight);
+        fProfileSixPartCorrel->GetXaxis()->SetBinLabel(iBin, Form("(%d,%d,%d)", l, m, n));
 
-//======================================================================================//
-void AliAnalysisTaskTwoMultiCorrelations::ComputeTwoParticleEtaGaps(long long nParticles, Double_t angles[], Double_t pWeights[], Double_t pseudorapidity[])
+      // Reset of the variables for the next pair of harmonics.
+        iBin++;
+        complexCorrelator = TComplex(0., 0.);
+        realCorrelator  = 0.;
+        iMiddleBin      = 0.; 
+      }   // End of the loop over the third harmonic of the triplet.
+    }   // End of the loop over the second harmonic of the triplet.
+  }   // End of the loop over for the first harmonic of the triplet.
+
+// Reset the variables for the next event.
+  eventWeight           = 0.;
+  complexCorrelator     = TComplex(0., 0.);
+  realCorrelator        = 0.;
+  iBin                  = 1;
+  iMiddleBin            = 0.;
+
+}   // End of "void ComputeAllCorrelators()".
+
+/* ------------------------------------------------------------------------- */
+void AliAnalysisTaskTwoMultiCorrelations::ComputeTPCWithEtaGaps(long long numberOfParticles, Float_t angles[], Float_t pWeights[], Float_t pseudorapidity[])
 {
-/* Compute the 2-particle correlations with eta gaps. */
-  TComplex Qminus[6][11] = {{TComplex(0., 0.)}};  // Q-vectors for the negative subset of the eta range, for v_1 to v_6.
-  TComplex Qplus[6][11] = {{TComplex(0., 0.)}}; // Q-vectors for the positive subset of the eta range, for v_1 to v_6.
-  Double_t Mminus[6][11] = {{0.}};  // Number of particles in the negative subset of the eta range.
-  Double_t Mplus[6][11] = {{0.}}; // Number of particle in the positive subset of the eta range.
-  Double_t EtaGaps[11] = {1., 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.}; // Choice of values of the eta gap.
-  Double_t iAngle = 0.; // Azimuthal angle of the current particle.
-  Double_t iWeight = 0.;  // Particle weight of the current particle.
-  Double_t iEta = 0.; // Pseudorapidity of the current particle.
-  Double_t iWeightToPowerP = 1.;  // Particle weight rised to the power p. TBA: use of non-unit particle weights.
-  TComplex twoParticleComplex = TComplex(0., 0.); // Complex value of the 2-p correlations.
-  Double_t twoParticleValue = 0.; // Real value of the 2-p correlations.
+/* Compute the 2-particle correlators using eta gaps for the current event. */
+  TComplex  Qminus[11][8]   = {{TComplex(0., 0.)}};   // Q-vectors for the negative subset of the eta range, for v_1 to v_8.
+  TComplex  Qplus[11][8]    = {{TComplex(0., 0.)}};   // Q-vectors for the positive subset of the eta range, for v_1 to v_8.
+  Float_t   Mminus[11][8]   = {{0.}};                 // Multiplicity in the negative subset of the eta range.
+  Float_t   Mplus[11][8]    = {{0.}};                 // Multiplicity in the positive subset of the eta range.
+  Float_t   etaGaps[11]     = {1., 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.};  // Possible values for the gaps.
+  Float_t   iAngle          = 0.;                     // Azimuthal angle of the current particle.
+  Float_t   iWeight         = 1.;                     // Particle weight of the current particle (default: unit weight).
+  Float_t   iEta            = 0.;                     // Pseudorapidity of the current particle.
+  Float_t   iWeightToP      = 1.;                     // Particle weight rised to the power p.
+  TComplex  complexCorrel   = TComplex(0., 0.);       // Complex value of the 2-p correlator.
+  Double_t  realCorrel      = 0.;                     // Real value of the 2-p correlator.
 
 // Compute the Q-vectors for the negative and positive subsets of the eta range.
-  for (Int_t iParticle = 0; iParticle < nParticles; iParticle++)
+  for (Int_t iPart = 0; iPart < numberOfParticles; iPart++)
   {
-    iAngle = angles[iParticle];
-    iWeight = pWeights[iParticle];
-    iEta = pseudorapidity[iParticle];
+  // Read the right elements in the provided arrays.
+    iAngle  = angles[iPart];
+    iWeight = pWeights[iPart];
+    iEta    = pseudorapidity[iPart];
+    if (fUseNonUnitParticleWeights) {iWeightToP = iWeight;}   // All weights are multiplied to get the final one.
 
-    if (iEta < 0.)  // Negative subset of the eta range.
+  // Compute the Q-vectors.
+    if (iEta < 0.)    // Negative subset of the eta range.
     {
-      for (Int_t iHarmo = 0; iHarmo < 6; iHarmo++)
+      for (Int_t iHarmo = 0; iHarmo < 8; iHarmo++)
       {
         for (Int_t iGap = 0; iGap < 11; iGap++)
         {
-          if (iEta < ((-0.5)*EtaGaps[iGap]))
+          if (iEta < ((-0.5)*etaGaps[iGap]))    // Compute only if the particle is in the range.
           {
-            Qminus[iHarmo][iGap] += TComplex(iWeightToPowerP*TMath::Cos((iHarmo+1)*iAngle), iWeightToPowerP*TMath::Sin((iHarmo+1)*iAngle));
-            Mminus[iHarmo][iGap] += iWeightToPowerP;
+            Qminus[iGap][iHarmo] += TComplex(iWeightToP*TMath::Cos((iHarmo+1)*iAngle), iWeightToP*TMath::Sin((iHarmo+1)*iAngle));
+            Mminus[iGap][iHarmo] += iWeightToP;
           }
-        }
-      }
-    }
-    else if (iEta > 0.) // Positive subset of the eta range.
+          else {continue;}
+        }   // End of the loop over the gaps.
+      }   // End of the loop over the harmonics.
+    }   // End of the condition "negative subset".
+    else if (iEta > 0.)   // Positive subset of the eta range.
     {
-      for (Int_t iHarmo = 0; iHarmo < 6; iHarmo++)
+      for (Int_t iHarmo = 0; iHarmo < 8; iHarmo++)
       {
         for (Int_t iGap = 0; iGap < 11; iGap++)
         {
-          if (iEta > (0.5*EtaGaps[iGap]))
+          if (iEta > (0.5*etaGaps[iGap]))   // Compute only if the particle is in the range.
           {
-            Qplus[iHarmo][iGap] += TComplex(iWeightToPowerP*TMath::Cos((iHarmo+1)*iAngle), iWeightToPowerP*TMath::Sin((iHarmo+1)*iAngle));
-            Mplus[iHarmo][iGap] += iWeightToPowerP;
+            Qplus[iGap][iHarmo] += TComplex(iWeightToP*TMath::Cos((iHarmo+1)*iAngle), iWeightToP*TMath::Sin((iHarmo+1)*iAngle));
+            Mplus[iGap][iHarmo] += iWeightToP;
           }
-        }
-      }
-    }
-    else {continue;}  // Particle with iEta = 0.
-  }
+        }   // End of the loop over the gaps.
+      }   // End of the loop over the harmonics.
+    }   // End of the condition "positive subset".
+    else {continue;}    // Particle with iEta = 0.
+  }   // End of the loop over the particles for the Q-vectors.
 
-// Compute the 2-p correlations using Qminus and Qplus.
-  for (Int_t iHarmo = 0; iHarmo < 6; iHarmo++)
+// Compute the 2-p correlators using Qminus and Qplus.
+  for (Int_t iHarmo = 0; iHarmo < 8; iHarmo++)
   {
     for (Int_t iGap = 0; iGap < 11; iGap++)
     {
-      if (!( (Qminus[iHarmo][iGap].TComplex::Rho() > 0.) && (Qplus[iHarmo][iGap].TComplex::Rho() > 0.) )) {continue;}
-      if (!( (Mminus[iHarmo][iGap] > 0.) && (Mplus[iHarmo][iGap] > 0.) )) {continue;}
+      if (!( (Qminus[iGap][iHarmo].TComplex::Rho() > 0.) && (Qplus[iGap][iHarmo].TComplex::Rho() > 0.) )) {continue;}
+      if (!( (Mminus[iGap][iHarmo] > 0.) && (Mplus[iGap][iHarmo] > 0.) )) {continue;}
 
-      twoParticleComplex = Qminus[iHarmo][iGap]*TComplex::Conjugate(Qplus[iHarmo][iGap]);
-      twoParticleValue = (twoParticleComplex.Re())/(Mminus[iHarmo][iGap]*Mplus[iHarmo][iGap]);
-      fProfileTwoParticleCorrelationsWithEtaGaps[iHarmo]->Fill(iGap + 0.5, twoParticleValue, Mminus[iHarmo][iGap]*Mplus[iHarmo][iGap]);
+      complexCorrel = Qminus[iGap][iHarmo]*TComplex::Conjugate(Qplus[iGap][iHarmo]);
+      realCorrel    = (complexCorrel.Re())/(Mminus[iGap][iHarmo]*Mplus[iGap][iHarmo]);
+      fProfileTPCEta[iGap]->Fill(iHarmo + 0.5, realCorrel, Mminus[iGap][iHarmo]*Mplus[iGap][iHarmo]);
 
-    // Reset of the value of the 2-p correlations.
-      twoParticleComplex = TComplex(0.,0.);
-      twoParticleValue = 0.;
+    // Reset the 2-particle correlator.
+      complexCorrel = TComplex(0.,0.);
+      realCorrel    = 0.;
+    }   // End of the loop over the gaps.
+  }   // End of the loop over the harmonics.
+
+}   // End of "void ComputeTPCWithEtaGaps()".
+
+/* ========================================================================== /
+/ Methods called in "Terminate".                                              /
+/ ========================================================================== */
+
+/* ========================================================================== /
+/ Methods called in "UserCreateOutputObjects".                                /
+/ ========================================================================== */
+void AliAnalysisTaskTwoMultiCorrelations::BookAllLists()
+{
+/* Book all the lists in fMainList. */
+  TString sMethodName = "void AliAnalysisTaskTwoMultiCorrelations::BookAllLists()";
+
+// Check if the mother list exists.
+  if (!fMainList) {Fatal(sMethodName.Data(), "ERROR: 'fMainList' does not exist.");}
+
+// Daughter list with the multiplicity histograms.
+  fMultiplicityList = new TList();
+  fMultiplicityList->SetName("fMultiplicityList");
+  fMultiplicityList->SetOwner(kTRUE);
+  fMainList->Add(fMultiplicityList);
+
+// Daughter list for the event histograms.
+  fEventSelectionList = new TList();
+  fEventSelectionList->SetName("fEventSelectionList");
+  fEventSelectionList->SetOwner(kTRUE);
+  fMainList->Add(fEventSelectionList);
+
+// Daughter list for the track histograms.
+  fTrackSelectionList = new TList();
+  fTrackSelectionList->SetName("fTrackSelectionList");
+  fTrackSelectionList->SetOwner(kTRUE);
+  fMainList->Add(fTrackSelectionList);
+
+// Daughter list for the MPC histograms.
+  fMPCList = new TList();
+  fMPCList->SetName("fMPCList");
+  fMPCList->SetOwner(kTRUE);
+  fMainList->Add(fMPCList);
+
+// Daughter list for the eta gaps profiles.
+  fTPCEtaList = new TList();
+  fTPCEtaList->SetName("fTPCEtaList");
+  fTPCEtaList->SetOwner(kTRUE);
+  fMainList->Add(fTPCEtaList);
+}   // End of "void BookAllLists()".
+
+/* ------------------------------------------------------------------------- */
+void AliAnalysisTaskTwoMultiCorrelations::BookMultiplicityList()
+{
+/* Book the histograms related to the multiplicity distributions. */
+  for (Int_t i = 0; i < 2; i++)
+  {
+    TString iState = "Final";
+    if (i == 0) {iState = "Initial";}
+
+  // Centrality distributions.
+    fHistoCentrality[i] = new TH1F("", "", 100, 0., 100.);
+    fHistoCentrality[i]->SetName(Form("fHistoCentrality%s", iState.Data()));
+    fHistoCentrality[i]->SetTitle(Form("%s distribution of the centrality", iState.Data()));
+    fHistoCentrality[i]->SetStats(kTRUE);
+    fHistoCentrality[i]->GetXaxis()->SetTitle("Centrality percentile");
+    fHistoCentrality[i]->GetYaxis()->SetTitle("Number of events");
+    fMultiplicityList->Add(fHistoCentrality[i]);
+
+  // Multiplicity distributions.
+    fHistoMultiplicity[i] = new TH1I("", "", 30000, 0., 30000.);
+    fHistoMultiplicity[i]->SetName(Form("fHistoMultiplicity%s", iState.Data()));
+    fHistoMultiplicity[i]->SetTitle(Form("%s distribution of the number of tracks", iState.Data()));
+    fHistoMultiplicity[i]->SetStats(kTRUE);
+    fHistoMultiplicity[i]->GetXaxis()->SetTitle("Number of tracks");
+    fHistoMultiplicity[i]->GetYaxis()->SetTitle("Number of events");
+    fMultiplicityList->Add(fHistoMultiplicity[i]);
+
+  // Multiplicity distributions meaningful only for AOD files.
+    if (fAnalyseOnlyAOD)
+    {
+    // Main filter bit.
+      fHistoMultiplicityMain[i] = new TH1I("", "", 30000, 0., 30000.);
+      fHistoMultiplicityMain[i]->SetName(Form("fHistoMultiplicityMain%s", iState.Data()));
+      fHistoMultiplicityMain[i]->SetTitle(Form("%s distribution of the number of tracks (filter %d)", iState.Data(), fMainFilter));
+      fHistoMultiplicityMain[i]->SetStats(kTRUE);
+      fHistoMultiplicityMain[i]->GetXaxis()->SetTitle("Number of tracks");
+      fHistoMultiplicityMain[i]->GetYaxis()->SetTitle("Number of events");
+      fMultiplicityList->Add(fHistoMultiplicityMain[i]);
+
+    // Multiplicity distributions for the global filter bit.
+      fHistoMultiplicityGlobal[i] = new TH1I("", "", 30000, 0., 30000.);
+      fHistoMultiplicityGlobal[i]->SetName(Form("fHistoMultiplicityGlobal%s", iState.Data()));
+      fHistoMultiplicityGlobal[i]->SetTitle(Form("%s distribution of the number of tracks (filter %d)", iState.Data(), fGlobalFilter));
+      fHistoMultiplicityGlobal[i]->SetStats(kTRUE);
+      fHistoMultiplicityGlobal[i]->GetXaxis()->SetTitle("Number of tracks");
+      fHistoMultiplicityGlobal[i]->GetYaxis()->SetTitle("Number of events");
+      fMultiplicityList->Add(fHistoMultiplicityGlobal[i]);
     }
-  }
 
-  iWeight++;  // Dummy operation to use iWeight.
+  // Correlations between filters.
+    if (fDoCorrelationsHisto)   // Manually enabled only to decide the cuts, as it is memory-greedy.
+    {
+      fHistoCorrelatedFilters[i] = new TH2I("", "", 5000, 0., 5000., 5000, 0., 5000.);
+      fHistoCorrelatedFilters[i]->SetName(Form("fHistoCorrelatedFilters%s", iState.Data()));
+      fHistoCorrelatedFilters[i]->SetTitle(Form("%s correlated tracks", iState.Data()));
+      fHistoCorrelatedFilters[i]->SetStats(kTRUE);
+      fHistoCorrelatedFilters[i]->GetXaxis()->SetTitle(Form("Multiplicity_{Filter %d}", fGlobalFilter));
+      fHistoCorrelatedFilters[i]->GetYaxis()->SetTitle(Form("Multiplicity_{Filter %d}", fMainFilter));
+      fHistoCorrelatedFilters[i]->SetMarkerSize(0.5);
+      fHistoCorrelatedFilters[i]->SetMarkerColor(kBlue);
+      fHistoCorrelatedFilters[i]->SetMarkerStyle(kFullCircle);
+      fMultiplicityList->Add(fHistoCorrelatedFilters[i]);
+    }
+  }   // End of the loop over the states (initial, final).
+}   // End of "void BookMultiplicityList()".
 
-}
+/* ------------------------------------------------------------------------- */
+void AliAnalysisTaskTwoMultiCorrelations::BookEventSelectionList()
+{
+/* Book the control histograms for the event selection criteria. */
+  for (Int_t i = 0; i < 2; i++)
+  {
+    TString iState = "Final";
+    if (i == 0) {iState = "Initial";}
 
-//######################################################################################//
-// Methods called in 'Terminate'.
-//======================================================================================//
+  // Primary Vertex x.
+    fHistoPVx[i] = new TH1F("", "", 1000, -20., 20.);
+    fHistoPVx[i]->SetName(Form("fHistoPVx%s", iState.Data()));
+    fHistoPVx[i]->SetTitle(Form("%s distribution of PV_{x}", iState.Data()));
+    fHistoPVx[i]->SetStats(kTRUE);
+    fHistoPVx[i]->GetXaxis()->SetTitle("PV_{x} [cm]");
+    fHistoPVx[i]->GetYaxis()->SetTitle("dN/dPV_{x}");
+    fEventSelectionList->Add(fHistoPVx[i]);
+
+  // Primary Vertex y.
+    fHistoPVy[i] = new TH1F("", "", 1000, -20., 20.);
+    fHistoPVy[i]->SetName(Form("fHistoPVy%s", iState.Data()));
+    fHistoPVy[i]->SetTitle(Form("%s distribution of PV_{y}", iState.Data()));
+    fHistoPVy[i]->SetStats(kTRUE);
+    fHistoPVy[i]->GetXaxis()->SetTitle("PV_{y} [cm]");
+    fHistoPVy[i]->GetYaxis()->SetTitle("dN/dPV_{y}");
+    fEventSelectionList->Add(fHistoPVy[i]);
+
+  // Primary Vertex z.
+    fHistoPVz[i] = new TH1F("", "", 1000, -20., 20.);
+    fHistoPVz[i]->SetName(Form("fHistoPVz%s", iState.Data()));
+    fHistoPVz[i]->SetTitle(Form("%s distribution of PV_{z}", iState.Data()));
+    fHistoPVz[i]->SetStats(kTRUE);
+    fHistoPVz[i]->GetXaxis()->SetTitle("PV_{z} [cm]");
+    fHistoPVz[i]->GetYaxis()->SetTitle("dN/dPV_{z}");
+    fEventSelectionList->Add(fHistoPVz[i]);
+  }   // End of the loop over the states (initial, final).
+}   // End of "void BookEventSelectionList()".
+
+/* ------------------------------------------------------------------------- */
+void AliAnalysisTaskTwoMultiCorrelations::BookTrackSelectionList()
+{
+/* Book the control histograms for the track selection criteria. */
+  for (Int_t i = 0; i < 2; i++)
+  {
+    TString iState = "Final";
+    if (i == 0) {iState = "Initial";}
+
+  // Transverse momentum.
+    fHistoPt[i] = new TH1F("", "", 1000, 0., 20.);
+    fHistoPt[i]->SetName(Form("fHistoPt%s", iState.Data()));
+    fHistoPt[i]->SetTitle(Form("%s distribution of p_{T}", iState.Data()));
+    fHistoPt[i]->SetStats(kTRUE);
+    fHistoPt[i]->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+    fHistoPt[i]->GetYaxis()->SetTitle("dN/dp_{T}");
+    fTrackSelectionList->Add(fHistoPt[i]);
+
+  // Pseudorapidity.
+    fHistoEta[i] = new TH1F("", "", 1000, -1., 1.);
+    fHistoEta[i]->SetName(Form("fHistoEta%s", iState.Data()));
+    fHistoEta[i]->SetTitle(Form("%s distribution of #eta", iState.Data()));
+    fHistoEta[i]->SetStats(kTRUE);
+    fHistoEta[i]->GetXaxis()->SetTitle("#eta");
+    fHistoEta[i]->GetYaxis()->SetTitle("dN/d#eta");
+    fTrackSelectionList->Add(fHistoEta[i]);
+
+  // Azimuthal angles.
+    fHistoPhi[i] = new TH1F("", "", 1000, 0., 6.3);
+    fHistoPhi[i]->SetName(Form("fHistoPhi%s", iState.Data()));
+    fHistoPhi[i]->SetTitle(Form("%s distribution of #phi", iState.Data()));
+    fHistoPhi[i]->SetStats(kTRUE);
+    fHistoPhi[i]->GetXaxis()->SetTitle("#phi");
+    fHistoPhi[i]->GetYaxis()->SetTitle("dN/d#phi");
+    fTrackSelectionList->Add(fHistoPhi[i]);
+
+  // Number of TPC clusters.
+    fHistoNTPC[i] = new TH1I("", "", 170, 0., 170.);
+    fHistoNTPC[i]->SetName(Form("fHistoNTPC%s", iState.Data()));
+    fHistoNTPC[i]->SetTitle(Form("%s distribution of N_{TPC}", iState.Data()));
+    fHistoNTPC[i]->SetStats(kTRUE);
+    fHistoNTPC[i]->GetXaxis()->SetTitle("N_{TPC}");
+    fHistoNTPC[i]->GetYaxis()->SetTitle("dN/dN_{TPC}");
+    fTrackSelectionList->Add(fHistoNTPC[i]);
+
+  // chi^2/NDF of p per TPC clusters.
+    fHistoChiSquare[i] = new TH1F("", "", 1000, 0., 20.);
+    fHistoChiSquare[i]->SetName(Form("fHistoChiSquare%s", iState.Data()));
+    fHistoChiSquare[i]->SetTitle(Form("%s distribution of #chi^{2}/NDF", iState.Data()));
+    fHistoChiSquare[i]->SetStats(kTRUE);
+    fHistoChiSquare[i]->GetXaxis()->SetTitle("#chi^{2}/NDF of p in TPC");
+    fHistoChiSquare[i]->GetYaxis()->SetTitle("Number of tracks");
+    fTrackSelectionList->Add(fHistoChiSquare[i]);
+
+  // Number of ITS clusters.
+    fHistoNITS[i] = new TH1I("", "", 14, 0., 7.);
+    fHistoNITS[i]->SetName(Form("fHistoNITS%s", iState.Data()));
+    fHistoNITS[i]->SetTitle(Form("%s distribution of N_{ITS}", iState.Data()));
+    fHistoNITS[i]->SetStats(kTRUE);
+    fHistoNITS[i]->GetXaxis()->SetTitle("Number of ITS clusters");
+    fHistoNITS[i]->GetYaxis()->SetTitle("dN/dN_{ITS}");
+    fTrackSelectionList->Add(fHistoNITS[i]);
+
+  // DCA in the xy-plane.
+    fHistoDCAxy[i] = new TH1F("", "", 1000, 0., 10.);
+    fHistoDCAxy[i]->SetName(Form("fHistoDCAxy%s", iState.Data()));
+    fHistoDCAxy[i]->SetTitle(Form("%s distribution of DCA_{xy}", iState.Data()));
+    fHistoDCAxy[i]->SetStats(kTRUE);
+    fHistoDCAxy[i]->GetXaxis()->SetTitle("DCA_{xy} [cm]");
+    fHistoDCAxy[i]->GetYaxis()->SetTitle("dN/dDCA_{xy}");
+    fTrackSelectionList->Add(fHistoDCAxy[i]);
+
+  // DCA along z.
+    fHistoDCAz[i] = new TH1F("", "", 1000, 0., 10.);
+    fHistoDCAz[i]->SetName(Form("fHistoDCAz%s", iState.Data()));
+    fHistoDCAz[i]->SetTitle(Form("%s distribution of DCA_{z}", iState.Data()));
+    fHistoDCAz[i]->SetStats(kTRUE);
+    fHistoDCAz[i]->GetXaxis()->SetTitle("DCA_{z} [cm]");
+    fHistoDCAz[i]->GetYaxis()->SetTitle("dN/dDCA_{z}");
+    fTrackSelectionList->Add(fHistoDCAz[i]);
+
+  // Electric charge of the tracks.
+    fHistoCharge[i] = new TH1I("", "", 2, -2, 2);
+    fHistoCharge[i]->SetName(Form("fHistoCharge%s", iState.Data()));
+    fHistoCharge[i]->SetTitle(Form("%s distribution of the charges", iState.Data()));
+    fHistoCharge[i]->SetStats(kTRUE);
+    fHistoCharge[i]->GetXaxis()->SetTitle("Charge");
+    fHistoCharge[i]->GetYaxis()->SetTitle("Number of tracks");
+    fTrackSelectionList->Add(fHistoCharge[i]);
+  }   // End of the loop over the states (initial, final).
+
+  fHistoEfficiency = new TH1F("fHistoEfficiency",
+    "Distribution of the efficiency correction", 1000, 0., 20.);
+  fHistoEfficiency->SetStats(kTRUE);
+  fHistoEfficiency->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+  fHistoEfficiency->GetYaxis()->SetTitle("dN/dp_{T}");
+  fTrackSelectionList->Add(fHistoEfficiency);
+
+  fHistoEffInverse = new TH1F("fHistoEffInverse",
+    "Distribution of the inverse of the efficiency correction", 1000, 0., 20.);
+  fHistoEffInverse->SetStats(kTRUE);
+  fHistoEffInverse->GetXaxis()->SetTitle("p_{T} [GeV/c]");
+  fHistoEffInverse->GetYaxis()->SetTitle("dN/dp_{T}");
+  fTrackSelectionList->Add(fHistoEffInverse);
+
+}   // End of "void BookTrackSelectionList()".
+/* ------------------------------------------------------------------------- */
+void AliAnalysisTaskTwoMultiCorrelations::BookMPCList()
+{
+/* Book the histograms and profiles for the MPC. */
+// Modulus of reduced Q-vectors.
+  for (Int_t i = 0; i < 8; i++)
+  {
+    fHistoReducedQvectors[i] = new TH1F("", "", 1000, 0., 10.);
+    fHistoReducedQvectors[i]->SetName(Form("fHistoReducedQvectors%d", i));
+    fHistoReducedQvectors[i]->SetTitle(Form("Distribution of q_{%d}", i+1));
+    fHistoReducedQvectors[i]->SetStats(kTRUE);
+    fHistoReducedQvectors[i]->GetXaxis()->SetTitle(Form("q_{%d}", i+1));
+    fHistoReducedQvectors[i]->GetYaxis()->SetTitle(Form("dN/dq_{%d}", i+1));
+    fMPCList->Add(fHistoReducedQvectors[i]);
+  }   // Enf of the loop for the q_n distributions.
+
+// Profile with the 2-particle correlators.
+  fProfileTwoPartCorrel = new TProfile("fProfileTwoPartCorrel",
+    "#LT#LT2#GT#GT_{n,-n} (no #eta gap)", 8, 0., 8.);
+  fProfileTwoPartCorrel->Sumw2();
+  fProfileTwoPartCorrel->SetStats(kTRUE);
+  fProfileTwoPartCorrel->GetXaxis()->SetTitle("n");
+  fMPCList->Add(fProfileTwoPartCorrel);
+
+// Profiles with the 4-particle correlators.
+  fProfileFourPartCorrel = new TProfile("fProfileFourPartCorrel",
+    "#LT#LT4#GT#GT_{m,n,-m,-n}", 36, 0., 36.);
+  fProfileFourPartCorrel->Sumw2();
+  fProfileFourPartCorrel->SetStats(kTRUE);
+  fProfileFourPartCorrel->GetXaxis()->SetTitle("(m,n)");
+  fMPCList->Add(fProfileFourPartCorrel);
+
+  fProfileFourPartCorrelCheck = new TProfile("fProfileFourPartCorrelCheck",
+    "#LT#LT4#GT#GT_{m,n,-m,-n}", 28, 0., 28.);
+  fProfileFourPartCorrelCheck->Sumw2();
+  fProfileFourPartCorrelCheck->SetStats(kTRUE);
+  fProfileFourPartCorrelCheck->GetXaxis()->SetTitle("(m,n)");
+  fMPCList->Add(fProfileFourPartCorrelCheck);
+
+// Profile with the needed 6-particle correlators.
+  fProfileSixPartCorrel = new TProfile("fProfileSixPartCorrel",
+    "#LT#LT6#GT#GT_{m,n,o,-m,-n,-o}", 56, 0., 56.);
+  fProfileSixPartCorrel->Sumw2();
+  fProfileSixPartCorrel->SetStats(kTRUE);
+  //fProfileSixPartCorrel->GetXaxis()->SetTitle("(m,n,o)");
+  fMPCList->Add(fProfileSixPartCorrel);
+}   // End of "void BookMPCList()".
+
+/* ------------------------------------------------------------------------- */
+void AliAnalysisTaskTwoMultiCorrelations::BookTPCEtaList()
+{
+/* Book the profiles for the 2-particle correlators with eta gaps. */
+  if (fComputeEtaGaps)
+  {
+    Float_t etaGaps[11] = {1., 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.};  // Possible values for the eta gap.
+    for (Int_t i = 0; i < 11; i++)
+    {
+      fProfileTPCEta[i] = new TProfile("", "", 8, 0., 8.);
+      fProfileTPCEta[i]->SetName(Form("fProfileTPCEta_EtaGap%d", i));
+      fProfileTPCEta[i]->SetTitle(Form("#LT#LT2#GT#GT_{n,-n} (#eta gap: %.1f)", etaGaps[i]));
+      fProfileTPCEta[i]->SetStats(kTRUE);
+      fProfileTPCEta[i]->Sumw2();
+      fProfileTPCEta[i]->GetXaxis()->SetTitle("n");
+      fTPCEtaList->Add(fProfileTPCEta[i]);
+
+    // Set bin labels.
+      for (Int_t gap = 1; gap < 9; gap++)
+      {
+       fProfileTPCEta[i]->GetXaxis()->SetBinLabel(gap, Form("%d", gap));
+      }   // End of the loop to set the labels.
+    }   // End of the loop to setup the profiles.
+  }   // End of the if.
+}   // End of "void BookTPCEtaList()".
+
 
 


### PR DESCRIPTION
Major cleaning of the code with:
* Changed the Double_t and TH1D into Float_t and TH1F where it was possible
* Gathered the TH1 into different arrays to ease maintenance and future possible additions of control histograms
* Added support to compute correlators with v7 and v8 (previously up to v6)
* Removed unnecessary methods like nested loops to ease the readability