### PR TITLE
Bugs fixed

### DIFF
--- a/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrangeCascadesDiscrete.cxx
+++ b/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrangeCascadesDiscrete.cxx
@@ -25,6 +25,7 @@
 #include "TClonesArray.h"
 #include "TF1.h"
 #include "TFile.h"
+#include "TObject.h"
 
 //AliPhysics/ROOT
 #include "AliAnalysisManager.h"
@@ -47,6 +48,12 @@
 
 //my task
 #include "AliAnalysisTaskStrangeCascadesDiscrete.h"
+
+
+
+ClassImp(AliRunningCascadeCandidate)
+ClassImp(AliRunningCascadeEvent)
+
 
 ClassImp(AliAnalysisTaskStrangeCascadesDiscrete) //not sure, if needed at all
 
@@ -84,40 +91,42 @@ Cascade_Track(0x0),
 Cascade_Event(0x0),
 fTreeCascadeAsEvent(0x0),
 fMagneticField(-100.),
-fPV_X(0), fPV_Y(0), fPV_Z(0), sigmamaxrunning(-100.)
+fPV_X(0), fPV_Y(0), fPV_Z(0), sigmamaxrunning(-100.),fkOmegaCleanMassWindow(0.1)
 {
     
 }
 
 //constructor with task configurations
 AliAnalysisTaskStrangeCascadesDiscrete::AliAnalysisTaskStrangeCascadesDiscrete(
-                                                                                             Bool_t lRunV0Vertexers,
-                                                                                             Bool_t lRunVertexers,
-                                                                                             Bool_t lUseLightVertexer,
-                                                                                             Bool_t lUseOnTheFlyV0Cascading,
-                                                                                             Bool_t lguard_CheckTrackQuality,
-                                                                                             Bool_t lguard_CheckCascadeQuality,
-                                                                                             Bool_t lguard_CheckTPCPID,
-                                                                                             
-                                                                                             Double_t lV0MaxChi2,
-                                                                                             Double_t lV0minDCAfirst,
-                                                                                             Double_t lV0minDCAsecond,
-                                                                                             Double_t lV0maxDCAdaughters,
-                                                                                             Double_t lV0minCosAngle,
-                                                                                             Double_t lV0minRadius,
-                                                                                             Double_t lV0maxRadius,
-                                                                                             
-                                                                                             Double_t lCascaderMaxChi2,
-                                                                                             Double_t lCascaderV0MinImpactParam,
-                                                                                             Double_t lCascaderV0MassWindow,
-                                                                                             Double_t lCascaderBachMinImpactParam,
-                                                                                             Double_t lCascaderMaxDCAV0andBach,
-                                                                                             Double_t lCascaderMinCosAngle,
-                                                                                             Double_t lCascaderMinRadius,
-                                                                                             Double_t lCascaderMaxRadius,
-                                                                                             Float_t sigmaRangeTPC,
-                                                                                             const char *name
-                                                                                             )
+                                                                               Bool_t lRunV0Vertexers,
+                                                                               Bool_t lRunVertexers,
+                                                                               Bool_t lUseLightVertexer,
+                                                                               Bool_t lUseOnTheFlyV0Cascading,
+                                                                               Bool_t lguard_CheckTrackQuality,
+                                                                               Bool_t lguard_CheckCascadeQuality,
+                                                                               Bool_t lguard_CheckTPCPID,
+                                                                               
+                                                                               Double_t lV0MaxChi2,
+                                                                               Double_t lV0minDCAfirst,
+                                                                               Double_t lV0minDCAsecond,
+                                                                               Double_t lV0maxDCAdaughters,
+                                                                               
+                                                                               Double_t lV0minCosAngle,
+                                                                               Double_t lV0minRadius,
+                                                                               Double_t lV0maxRadius,
+                                                                               
+                                                                               Double_t lCascaderMaxChi2,
+                                                                               Double_t lCascaderV0MinImpactParam,
+                                                                               Double_t lCascaderV0MassWindow,
+                                                                               Double_t lCascaderBachMinImpactParam,
+                                                                               Double_t lCascaderMaxDCAV0andBach,
+                                                                               Double_t lCascaderMinCosAngle,
+                                                                               Double_t lCascaderMinRadius,
+                                                                               Double_t lCascaderMaxRadius,
+                                                                               Float_t sigmaRangeTPC,
+                                                                               Float_t lOmegaCleanMassWindow,
+                                                                               const char *name
+                                                                               )
 :AliAnalysisTaskSE(name),
 fguard_CheckTrackQuality(kTRUE),
 fguard_CheckCascadeQuality(kTRUE),
@@ -150,8 +159,9 @@ Cascade_Track(0x0),
 Cascade_Event(0x0),
 fTreeCascadeAsEvent(0x0),
 fMagneticField(-100.),
-fPV_X(0), fPV_Y(0), fPV_Z(0), sigmamaxrunning(-100.)
+fPV_X(0), fPV_Y(0), fPV_Z(0), sigmamaxrunning(-100.),fkOmegaCleanMassWindow(0.1)
 {
+    
     
     fkUseLightVertexer = lUseLightVertexer;
     fkRunV0Vertexers = lRunV0Vertexers;
@@ -162,13 +172,13 @@ fPV_X(0), fPV_Y(0), fPV_Z(0), sigmamaxrunning(-100.)
     fguard_CheckTPCPID = lguard_CheckTPCPID;
     
     //set the variables to rerun V0 vertexer! (Keep in mind, that these V0 are daughters and do not have to point back to the primary vertex!
-   /* fV0VertexerSels[0] =  33.  ;  // max allowed chi2
-    fV0VertexerSels[1] =   0.02;  // min allowed impact parameter for the 1st daughter (LHC09a4 : 0.05)
-    fV0VertexerSels[2] =   0.02;  // min allowed impact parameter for the 2nd daughter (LHC09a4 : 0.05)
-    fV0VertexerSels[3] =   2.0 ;  // max allowed DCA between the daughter tracks       (LHC09a4 : 0.5)
-    fV0VertexerSels[4] =   0.8;  // min allowed cosine of V0's pointing angle         (LHC09a4 : 0.99)
-    fV0VertexerSels[5] =   1.0 ;  // min radius of the fiducial volume                 (LHC09a4 : 0.2)
-    fV0VertexerSels[6] = 200.  ;  // max radius of the fiducial volume                 (LHC09a4 : 100.0)*/
+    /* fV0VertexerSels[0] =  33.  ;  // max allowed chi2
+     fV0VertexerSels[1] =   0.02;  // min allowed impact parameter for the 1st daughter (LHC09a4 : 0.05)
+     fV0VertexerSels[2] =   0.02;  // min allowed impact parameter for the 2nd daughter (LHC09a4 : 0.05)
+     fV0VertexerSels[3] =   2.0 ;  // max allowed DCA between the daughter tracks       (LHC09a4 : 0.5)
+     fV0VertexerSels[4] =   0.8;  // min allowed cosine of V0's pointing angle         (LHC09a4 : 0.99)
+     fV0VertexerSels[5] =   1.0 ;  // min radius of the fiducial volume                 (LHC09a4 : 0.2)
+     fV0VertexerSels[6] = 200.  ;  // max radius of the fiducial volume                 (LHC09a4 : 100.0)*/
     
     fV0VertexerSels[0] = lV0MaxChi2;
     fV0VertexerSels[1] = lV0minDCAfirst;
@@ -177,9 +187,13 @@ fPV_X(0), fPV_Y(0), fPV_Z(0), sigmamaxrunning(-100.)
     fV0VertexerSels[4] = lV0minCosAngle;
     fV0VertexerSels[5] = lV0minRadius;
     fV0VertexerSels[6] = lV0maxRadius;
-    
+
+
     //TPC sigma range, usually just set to 3. Looser cuts? -> set to 4-5
     sigmamaxrunning = sigmaRangeTPC;
+
+    //Mass window for Omega baryons, when extra clean up needed
+    fkOmegaCleanMassWindow = lOmegaCleanMassWindow;
     
     //set the variables for the rerun of cascades
     fCascadeVertexerSels[0] = lCascaderMaxChi2  ;  // max allowed chi2 (same as PDC07) (33)
@@ -285,20 +299,6 @@ AliAnalysisTaskStrangeCascadesDiscrete::~AliAnalysisTaskStrangeCascadesDiscrete(
         lBaryonTrack = nullptr;
     }
     
-    if (fTreeCascadeAsEvent) {
-        delete fTreeCascadeAsEvent;
-        fTreeCascadeAsEvent = nullptr;
-    }
-    
-    if (Cascade_Event) {
-        delete Cascade_Event;
-        Cascade_Event = nullptr;
-    }
-    if (Cascade_Track) {
-        delete Cascade_Track;
-        Cascade_Track = nullptr;
-    }
-    
 }
 
 //----------------------------------------------------------------------------------------------------------
@@ -309,7 +309,7 @@ AliAnalysisTaskStrangeCascadesDiscrete::~AliAnalysisTaskStrangeCascadesDiscrete(
 
 void AliAnalysisTaskStrangeCascadesDiscrete::UserCreateOutputObjects()
 {
-//------------------------------------------------------------------------------------------------------------------------------
+    //------------------------------------------------------------------------------------------------------------------------------
     man=AliAnalysisManager::GetAnalysisManager();
     inputHandler = (AliInputEventHandler*) (man->GetInputEventHandler());
     if (!inputHandler) {
@@ -351,16 +351,15 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserCreateOutputObjects()
     if( !fESDtrackCutsITSsa2010 && fkDebugOOBPileup ) {
         fESDtrackCutsITSsa2010 = AliESDtrackCuts::GetStandardITSSATrackCuts2010();
     }
-//----------------------------------------------------------------------------------------
+    //----------------------------------------------------------------------------------------
     
     
-    
-    Cascade_Event = new AliRunningCascadeEvent(1);
-    Cascade_Track = new AliRunningCascadeTrack(2);
+    Int_t iii = 0;
+    Cascade_Event = new AliRunningCascadeEvent(iii);
+    Cascade_Track = new AliRunningCascadeCandidate(iii);
     fTreeCascadeAsEvent = NULL;
     fTreeCascadeAsEvent = new TTree("fTreeCascadeAsEvent", "cascade tree as event");
-    fTreeCascadeAsEvent->Branch("fTreeCascadeAsEvent_branch", "Cascade_Event" ,Cascade_Event);
-  //  auto branch = fTreeCascadeAsEvent -> Branch("fPV_X", &fPV_X, "fPV_X/F");
+    fTreeCascadeAsEvent->Branch("fTreeCascadeAsEvent_branch", "Cascade_Event" , Cascade_Event);
     
     PostData(1, fTreeCascadeAsEvent);
 }
@@ -369,8 +368,8 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserCreateOutputObjects()
 
 void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
 {
-//----------------------EVENT SELECTION--------------------------------------------------------
-//First of all, call the events and deal with events, only "good events" should be selected!
+    //----------------------EVENT SELECTION--------------------------------------------------------
+    //First of all, call the events and deal with events, only "good events" should be selected!
     lESDevent = dynamic_cast<AliESDEvent*>(InputEvent());
     if (!lESDevent) {
         AliWarning("ERROR: lESDevent not available \n");
@@ -385,15 +384,15 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
     Bool_t goodevent = kTRUE;
     goodevent = GoodESDEvent(lESDevent, lPrimaryBestESDVtx, esdtrackcuts);
     if (!goodevent) return;
-//========================================================================================
-//------------------------------------------------
-// Multiplicity Information Acquistion
-//------------------------------------------------
-//Comment: fCentrality, lEvSelCode, fkUseOldCentrality should be declared in the header, so that the variables can be stored
-// we do not use any information about centralities.
+    //========================================================================================
+    //------------------------------------------------
+    // Multiplicity Information Acquistion
+    //------------------------------------------------
+    //Comment: fCentrality, lEvSelCode, fkUseOldCentrality should be declared in the header, so that the variables can be stored
+    // we do not use any information about centralities.
     Float_t lPercentile = 500;
     Float_t fCentrality = -10;
-   // Int_t lEvSelCode = 100;
+    // Int_t lEvSelCode = 100;
     MultSelection = (AliMultSelection*) lESDevent -> FindListObject("MultSelection");
     if( !MultSelection) {
         //If you get this warning (and lPercentiles 300) please check that the AliMultSelectionTask actually ran (before your task)
@@ -401,7 +400,7 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
     } else {
         //V0M Multiplicity Percentile
         lPercentile = MultSelection->GetMultiplicityPercentile("V0M");
-       // lEvSelCode = MultSelection->GetEvSelCode();
+        // lEvSelCode = MultSelection->GetEvSelCode();
     }
     
     //just ask AliMultSelection. It will know.
@@ -419,8 +418,8 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
             fCentrality = centrality->GetCentralityPercentile( "V0M" );
         }
     }
-//=============================================================================================
-
+    //=============================================================================================
+    
     
     //Access the variables needed from the event:
     //1)Primary vertex; we deal with pp collisions, so vertex exists and |z| < 10 cm
@@ -440,7 +439,8 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
     fkESDTrackMultiplicity = esdtrackcuts->GetReferenceMultiplicity(lESDevent, AliESDtrackCuts::kTracklets, 0.8, 0.);
     Long64_t fkESDEventTriggerWord =lESDevent->GetTriggerMask();
     
-   //set all the event variables into the cascade event, which will be stored.
+    
+    //set all the event variables into the cascade event, which will be stored.
     Cascade_Event -> ClearTrackList();
     Cascade_Event -> setx(fPV_X);
     Cascade_Event -> sety(fPV_Y);
@@ -453,20 +453,21 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
     Cascade_Event -> setmultiplicity(fkESDTrackMultiplicity);
     Cascade_Event -> settrigger_word(fkESDEventTriggerWord);
     Cascade_Event -> setmagfield(fMagneticField);
-
-    
- //=======================================================================================================
-//======================================EVENT DATA AQUISITION IS OVER HERE================================
-//=========================SELECTION OF CASCADES BEGINS!==================================================
     
     
-   
+    
+    //=======================================================================================================
+    //======================================EVENT DATA AQUISITION IS OVER HERE================================
+    //=========================SELECTION OF CASCADES BEGINS!==================================================
+    
+    
+    
     //HINT: light vertexers might be still in the development mode, so use them at your own risk
     
     //-----------------------------------------------------
     //-------- 1)Rerun the V0 vertexer! -------------------
     //-----------------------------------------------------
-   if( fkRunV0Vertexers ) {
+    if( fkRunV0Vertexers ) {
         //Remove existing cascades
         lESDevent->ResetV0s();
         AliV0vertexer lV0Vtxer;
@@ -474,7 +475,7 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
         lV0Vtxer.SetCuts(fV0VertexerSels);
         lV0Vtxer.Tracks2V0vertices(lESDevent);
     }
-
+    
     //-----------------------------------------------------
     //-------- 2)Rerun the cascade vertexer! --------------
     //-----------------------------------------------------
@@ -500,16 +501,20 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
     //-----------------------------------------------------------------
     //---------- 2) Start the loop over the cascades ------------------
     //-----------------------------------------------------------------
-    
-    Long_t ncascades = -1;
-    ncascades = lESDevent->GetNumberOfCascades();
+
+    Int_t ncascades = lESDevent -> GetNumberOfCascades();
     if(ncascades <= 0) return;
+    Cascade_Event -> setNumCascadeCandidates((UShort_t)ncascades);
+    
+    
     Short_t lChargeXi = 3.;
+    int iXi_passed(0);
+
     for (Int_t iXi=0; iXi<ncascades; iXi++) {
         
         xi = lESDevent -> GetCascade(iXi);
-        lChargeXi = xi -> Charge();
         if(!xi) continue;
+        lChargeXi = xi -> Charge();
         
         if (TMath::Abs(lChargeXi) != 1) continue;
         
@@ -531,7 +536,7 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
         nTrackXi        = lESDevent->GetTrack( lIdxNegXi );
         bachTrackXi    = lESDevent->GetTrack( lBachIdx );
         
-//------------CLEANUP guards----------------------------------------------------------------------------------------
+        //------------CLEANUP guards----------------------------------------------------------------------------------------
         //check if tracks are good!
         Bool_t goodPos = kFALSE; Bool_t goodNeg = kFALSE; Bool_t goodBach = kFALSE;
         Double_t rapidity_range = 0.5;
@@ -552,31 +557,31 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
         
         //extra cleanup for the omega!
         Bool_t extracleanupOmega = kFALSE;
-        Double_t Omegamasswindow = 0.05;
-        Double_t Ximasswindow = 0.2;
-        extracleanupOmega = ExtraCleanupCascade(xi, pTrackXi, nTrackXi, bachTrackXi, Omegamasswindow, Ximasswindow);
-       if((extracleanupOmega == kFALSE) && fguard_CheckCascadeQuality) continue;
+        //  Double_t Omegamasswindow = 0.1;
+        extracleanupOmega = ExtraCleanupCascade(xi, pTrackXi, nTrackXi, bachTrackXi, fkOmegaCleanMassWindow);
+        if((extracleanupOmega == kFALSE) && fguard_CheckCascadeQuality) continue;
         
         //TPC PID (might be the strongest one)
         Bool_t extracleanupTPCPID = kFALSE;
         extracleanupTPCPID = GoodCandidatesTPCPID(pTrackXi, nTrackXi, bachTrackXi, sigmamaxrunning);
         if((extracleanupTPCPID == kFALSE) && fguard_CheckTPCPID) continue;
         
-//----------cleanup guards over--------------------------------------------------------------------------------------
+        //----------cleanup guards over--------------------------------------------------------------------------------------
         
         //Some of the Cascade properties. We need the hCascTraj object for DCA
         Double_t xyzCascade[3], pxpypzCascade[3], cvCascade[21];
         for(Int_t ii=0;ii<21;ii++) cvCascade[ii]=0.0; //something small
+        
         xi->GetXYZcascade( xyzCascade[0],  xyzCascade[1], xyzCascade[2] );
         xi->GetPxPyPz( pxpypzCascade[0], pxpypzCascade[1], pxpypzCascade[2] );
         AliExternalTrackParam lCascTrajObject(xyzCascade,pxpypzCascade,cvCascade,lChargeXi);
         hCascTraj = &lCascTrajObject;
         
-//Get all the information for the tracks needed for the tree here:
+        //Get all the information for the tracks needed for the tree here:
         //First, declare all of them
         //1) Momentum of the daughters
         Double_t lBMom[3], lNMom[3], lPMom[3];
-    //    Float_t clBMom[3], clNMom[3], clPMom[3];
+        //    Float_t clBMom[3], clNMom[3], clPMom[3];
         //2) dcas
         Float_t RunningDCAxy_z[2] = {-1.,-1.}; //running one, the first component is the transverse DCA and the second - z component
         Float_t fTreeCascVarDCAPosToPrimVtx(-1), //transverse dca of positive track to prim. vertex.
@@ -587,7 +592,7 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
         fTreeCascVarDCABachToPrimVtxZ(-1), //z component of the dca of bachelor track to prim. vertex.
         fTreeCascVarDCAV0ToPrimVtx(-1), //transverse DCA of the V0 to prim vertex
         fTreeCascVarCascDCAtoPVxy(-1),  //transverse DCA of the Cascade to PV
-        fTreeCascVarCascDCAtoPVz(-1),   //z component of the DCA of Cascade to PV
+       // fTreeCascVarCascDCAtoPVz(-1),   //z component of the DCA of Cascade to PV
         fTreeCascVarDCAV0Daughters(-1),  //DCA between positive and negative tracks
         fTreeCascVarDCACascDaughters(-1), //DCA between Lambda and bach
         fTreeCascVarDCABachToBaryon(-1); //DCA of the bachelor track to the proton (baryon in general from v0)
@@ -650,8 +655,9 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
         //dca Casc prim
         hCascTraj->GetDZ(lBestPrimaryVtxPos[0],lBestPrimaryVtxPos[1],lBestPrimaryVtxPos[2], fMagneticField, RunningDCAxy_z);
         fTreeCascVarCascDCAtoPVxy = RunningDCAxy_z[0];
-        fTreeCascVarCascDCAtoPVz = RunningDCAxy_z[1];
-        RunningDCAxy_z[0] = -1.; RunningDCAxy_z[1] = -1.;
+      //  fTreeCascVarCascDCAtoPVz = RunningDCAxy_z[1];
+        RunningDCAxy_z[0] = -1.;
+        //RunningDCAxy_z[1] = -1.;
         
         //pos and neg
         fTreeCascVarDCAV0Daughters = xi->GetDcaV0Daughters();
@@ -667,7 +673,7 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
         }
         Double_t xn, xp; //reference planes at the DCA
         fTreeCascVarDCABachToBaryon = lBaryonTrack->GetDCA(bachTrackXi, fMagneticField, xn, xp);
-    
+        
         
         //positions
         fTreeCascVarCascCosPointingAngle = xi->GetCascadeCosineOfPointingAngle(lBestPrimaryVtxPos[0], lBestPrimaryVtxPos[1], lBestPrimaryVtxPos[2]);
@@ -688,9 +694,9 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
         TrackLengthInActiveZone[0]= pTrackXi->GetLengthInActiveZone(1, 2.0, 220.0, lESDevent->GetMagneticField());
         TrackLengthInActiveZone[1]= nTrackXi->GetLengthInActiveZone(1, 2.0, 220.0, lESDevent->GetMagneticField());
         TrackLengthInActiveZone[2]= bachTrackXi->GetLengthInActiveZone(1, 2.0, 220.0, lESDevent->GetMagneticField());
-      
         
-    //----------------------------ACCESS DATA: ITS------------------------------------------
+        
+        //----------------------------ACCESS DATA: ITS------------------------------------------
         //access status on all ITS layers
         Int_t pITS[6], nITS[6], bITS[6];
         for (int k=0; k<6; k++) {
@@ -708,17 +714,7 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
         else ITSrefitflag[1]=1;
         if((status[2] & AliESDtrack::kITSrefit) == 0) ITSrefitflag[2] = 0;
         else ITSrefitflag[2]=1;
-        //shared points; we do not really need it?
-       /* Bool_t itssharedpoint[6];
-        Int_t itsshared[6];
-        for (int i(0); i<6; i++)
-        {
-            itssharedpoint[i] = pTrackXi -> HasPointOnITSLayer(i);
-            if (itssharedpoint[i] == kTRUE) itsshared[i] = 1;
-            else itsshared[i] = 0;
-            
-        }*/
-        
+
         
         //its chi2
         Double_t itschi2[3];
@@ -731,7 +727,7 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
         itssignal[0] = pTrackXi -> GetITSsignal();
         itssignal[1] = nTrackXi -> GetITSsignal();
         itssignal[2] = bachTrackXi -> GetITSsignal();
-     
+        
         //number of sigmas
         fTreeCascVarPosITSNSigmaPion   = fPIDResponse->NumberOfSigmasITS( pTrackXi, AliPID::kPion );
         fTreeCascVarPosITSNSigmaProton = fPIDResponse->NumberOfSigmasITS( pTrackXi, AliPID::kProton );
@@ -740,14 +736,8 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
         fTreeCascVarBachITSNSigmaPion  = fPIDResponse->NumberOfSigmasITS( bachTrackXi, AliPID::kPion );
         fTreeCascVarBachITSNSigmaKaon  = fPIDResponse->NumberOfSigmasITS( bachTrackXi, AliPID::kKaon );
         
-        //track probabilities in its
-     /*   Double_t ITSprobabilityPos[AliPID::kSPECIES], ITSprobabilityNeg[AliPID::kSPECIES],ITSprobabilityBach[AliPID::kSPECIES];
-        pidstatus = fPIDResponse -> ComputeITSProbability(pTrackXi, 5, ITSprobabilityPos);
-        pidstatus = fPIDResponse -> ComputeITSProbability(nTrackXi, 5, ITSprobabilityNeg);
-        pidstatus = fPIDResponse -> ComputeITSProbability(bachTrackXi, 5, ITSprobabilityBach);*/
         
-        
-//----------------------------------ACCESS DATA: TPC---------------------------------------------------------
+        //----------------------------------ACCESS DATA: TPC---------------------------------------------------------
         //PID
         fTreeCascVarPosNSigmaPion   = fPIDResponse->NumberOfSigmasTPC( pTrackXi, AliPID::kPion );
         fTreeCascVarPosNSigmaProton = fPIDResponse->NumberOfSigmasTPC( pTrackXi, AliPID::kProton );
@@ -755,114 +745,10 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
         fTreeCascVarNegNSigmaProton = fPIDResponse->NumberOfSigmasTPC( nTrackXi, AliPID::kProton );
         fTreeCascVarBachNSigmaPion  = fPIDResponse->NumberOfSigmasTPC( bachTrackXi, AliPID::kPion );
         fTreeCascVarBachNSigmaKaon  = fPIDResponse->NumberOfSigmasTPC( bachTrackXi, AliPID::kKaon );
+        
 
-        //The positive particle should be either proton or pion dependent on the charge!
-        //If the TPC hypothesis assigns the positive track to any other particle, the array value is set 0.
-        //this is for test! Test h
-        Char_t posTPCpid[7] = {0x07,0x07,0x07,0x07,0x07,0x07,0x07};
-        Char_t negTPCpid[7] = {0x07,0x07,0x07,0x07,0x07,0x07,0x07};
-        Char_t bachTPCpid[7] = {0x07,0x07,0x07,0x07,0x07,0x07,0x07};
         
-        //Check the positive track
-        Float_t Pos_Electron = fPIDResponse->NumberOfSigmasTPC( pTrackXi, AliPID::kElectron );
-        Float_t Pos_Muon = fPIDResponse->NumberOfSigmasTPC( pTrackXi, AliPID::kMuon );
-        Float_t Pos_Pion = fPIDResponse->NumberOfSigmasTPC( pTrackXi, AliPID::kPion );
-        Float_t Pos_Kaon = fPIDResponse->NumberOfSigmasTPC( pTrackXi, AliPID::kPion );
-        Float_t Pos_Proton = fPIDResponse->NumberOfSigmasTPC( pTrackXi, AliPID::kProton );
-        Float_t Pos_Deuteron = fPIDResponse->NumberOfSigmasTPC( pTrackXi, AliPID::kDeuteron);
-        Float_t Pos_Triton = fPIDResponse->NumberOfSigmasTPC( pTrackXi, AliPID::kTriton);
-        
-        if(Pos_Electron < 3) posTPCpid[0] = 0;
-        else posTPCpid[0] = 1;
-        
-        if(Pos_Muon < 3) posTPCpid[1] = 0;
-        else posTPCpid[1] = 1;
-        
-        if((Pos_Pion < 3) && (lChargeXi == -1) ) posTPCpid[2] = 0;
-        if((Pos_Pion > 3) && (lChargeXi == -1) ) posTPCpid[2] = 1;
-        if((Pos_Pion < 3) && (lChargeXi == 1) ) posTPCpid[2] = 2;
-        if((Pos_Pion > 3) && (lChargeXi == 1) ) posTPCpid[2] = 3;
-        
-        if(Pos_Kaon < 3) posTPCpid[3] = 0;
-        else posTPCpid[3] = 1;
-        
-        if((Pos_Proton < 3) && (lChargeXi == -1)) posTPCpid[4] = 0;
-        if((Pos_Proton > 3) && (lChargeXi == -1)) posTPCpid[4]= 1;
-        if((Pos_Proton < 3) && (lChargeXi == 1)) posTPCpid[4] = 2;
-        if((Pos_Proton > 3) && (lChargeXi == 1)) posTPCpid[4]= 3;
-        
-        if(Pos_Deuteron < 3) posTPCpid[5] = 0;
-        else posTPCpid[5] = 1;
-        if(Pos_Triton < 3) posTPCpid[6] = 0;
-        else posTPCpid[6] = 1;
-        
-        //check the negative track
-        Float_t Neg_Electron = fPIDResponse->NumberOfSigmasTPC( nTrackXi, AliPID::kElectron );
-        Float_t Neg_Muon = fPIDResponse->NumberOfSigmasTPC( nTrackXi, AliPID::kMuon );
-        Float_t Neg_Pion = fPIDResponse->NumberOfSigmasTPC( nTrackXi, AliPID::kPion );
-        Float_t Neg_Kaon = fPIDResponse->NumberOfSigmasTPC( nTrackXi, AliPID::kPion );
-        Float_t Neg_Proton = fPIDResponse->NumberOfSigmasTPC( nTrackXi, AliPID::kProton );
-        Float_t Neg_Deuteron = fPIDResponse->NumberOfSigmasTPC( nTrackXi, AliPID::kDeuteron );
-        Float_t Neg_Triton = fPIDResponse->NumberOfSigmasTPC( nTrackXi, AliPID::kTriton);
-        
-        if(Neg_Electron < 3) negTPCpid[0] = 0;
-        else negTPCpid[0] = 1;
-        
-        if(Neg_Muon < 3) negTPCpid[1] = 0;
-        else negTPCpid[1] = 1;
-        
-        if((Neg_Pion < 3) && (lChargeXi == -1) ) negTPCpid[2] = 0;
-        if((Neg_Pion > 3) && (lChargeXi == -1) ) negTPCpid[2] = 1;
-        if((Neg_Pion < 3) && (lChargeXi == 1) ) negTPCpid[2] = 2;
-        if((Neg_Pion > 3) && (lChargeXi == 1) ) negTPCpid[2] = 3;
-        
-        if(Neg_Kaon < 3) negTPCpid[3] = 0;
-        else negTPCpid[3] = 1;
-        
-        if((Neg_Proton < 3) && (lChargeXi == -1)) negTPCpid[4] = 0;
-        if((Neg_Proton > 3) && (lChargeXi == -1)) negTPCpid[4]= 1;
-        if((Neg_Proton < 3) && (lChargeXi == 1)) negTPCpid[4] = 2;
-        if((Neg_Proton > 3) && (lChargeXi == 1)) negTPCpid[4]= 3;
-        
-        if(Neg_Deuteron < 3) negTPCpid[5] = 0;
-        else negTPCpid[5] = 1;
-        if(Neg_Triton < 3) negTPCpid[6] = 0;
-        else negTPCpid[6] = 1;
-        
-        
-        //check the bachelor track
-        Float_t Bach_Electron = fPIDResponse->NumberOfSigmasTPC( bachTrackXi, AliPID::kElectron );
-        Float_t Bach_Muon = fPIDResponse->NumberOfSigmasTPC( bachTrackXi, AliPID::kMuon );
-        Float_t Bach_Pion = fPIDResponse->NumberOfSigmasTPC( bachTrackXi, AliPID::kPion );
-        Float_t Bach_Kaon = fPIDResponse->NumberOfSigmasTPC( bachTrackXi, AliPID::kKaon );
-        Float_t Bach_Proton = fPIDResponse->NumberOfSigmasTPC( bachTrackXi, AliPID::kProton );
-        Float_t Bach_Deuteron = fPIDResponse->NumberOfSigmasTPC( bachTrackXi, AliPID::kDeuteron );
-        Float_t Bach_Triton = fPIDResponse->NumberOfSigmasTPC( bachTrackXi, AliPID::kTriton);
-        
-        if(Bach_Electron < 3) bachTPCpid[0] = 0;
-        else bachTPCpid[0] = 1;
-        
-        if(Bach_Muon < 3) bachTPCpid[1] = 0;
-        else bachTPCpid[1] = 1;
-        
-        if((Bach_Pion < 3) && (lChargeXi == -1) ) bachTPCpid[2] = 0;
-        if((Bach_Pion > 3) && (lChargeXi == -1) ) bachTPCpid[2] = 1;
-        if((Bach_Pion < 3) && (lChargeXi == 1) ) bachTPCpid[2] = 2;
-        if((Bach_Pion > 3) && (lChargeXi == 1) ) bachTPCpid[2] = 3;
-        
-        if((Bach_Kaon < 3) && (lChargeXi == -1)) bachTPCpid[3] = 0;
-        if((Bach_Kaon > 3) && (lChargeXi == -1)) bachTPCpid[3]= 1;
-        if((Bach_Kaon < 3) && (lChargeXi == 1)) bachTPCpid[3] = 2;
-        if((Bach_Kaon > 3) && (lChargeXi == 1)) bachTPCpid[3]= 3;
-        
-        if(Bach_Proton < 3) bachTPCpid[4] = 0;
-        else bachTPCpid[4] = 1;
-        if(Bach_Deuteron < 3) bachTPCpid[5] = 0;
-        else bachTPCpid[5] = 1;
-        if(Bach_Triton < 3) bachTPCpid[6] = 0;
-        else bachTPCpid[6] = 1;
-        
-//-------------continue with TPC signal, etc.-------------
+        //-------------continue with TPC signal, etc.-------------
         Double_t tpcsignal[3];
         tpcsignal[0] = pTrackXi -> GetTPCsignal();
         tpcsignal[1] = nTrackXi -> GetTPCsignal();
@@ -882,15 +768,15 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
         tpcclsF[0] = pTrackXi -> GetTPCNclsF();
         tpcclsF[1] = nTrackXi -> GetTPCNclsF();
         tpcclsF[2] = bachTrackXi -> GetTPCNclsF();
-
-        
-      /*  Double_t TPCprobabilityPos[AliPID::kSPECIES], TPCprobabilityNeg[AliPID::kSPECIES],TPCprobabilityBach[AliPID::kSPECIES];
-        pidstatus = fPIDResponse -> ComputeTPCProbability(pTrackXi, 5, TPCprobabilityPos);
-        pidstatus = fPIDResponse -> ComputeTPCProbability(nTrackXi, 5, TPCprobabilityNeg);
-        pidstatus = fPIDResponse -> ComputeTPCProbability(bachTrackXi, 5, TPCprobabilityBach);*/
         
         
-//------data from TOF------------------------
+        /*  Double_t TPCprobabilityPos[AliPID::kSPECIES], TPCprobabilityNeg[AliPID::kSPECIES],TPCprobabilityBach[AliPID::kSPECIES];
+         pidstatus = fPIDResponse -> ComputeTPCProbability(pTrackXi, 5, TPCprobabilityPos);
+         pidstatus = fPIDResponse -> ComputeTPCProbability(nTrackXi, 5, TPCprobabilityNeg);
+         pidstatus = fPIDResponse -> ComputeTPCProbability(bachTrackXi, 5, TPCprobabilityBach);*/
+        
+        
+        //------data from TOF------------------------
         ULong_t statustof[3]; Int_t TOFrefitflag[3];
         statustof[0] = pTrackXi ->GetStatus(); statustof[1] = nTrackXi ->GetStatus(); statustof[2] = bachTrackXi ->GetStatus();
         //refitflag
@@ -905,19 +791,25 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
         tofsignal[0] = pTrackXi -> GetTOFsignal();
         tofsignal[1] = nTrackXi -> GetTOFsignal();
         tofsignal[2] = bachTrackXi -> GetTOFsignal();
-        
-        
+
+      
+
         fTreeCascVarNegTOFNSigmaPion   = fPIDResponse->NumberOfSigmasTOF( nTrackXi, AliPID::kPion );
         fTreeCascVarNegTOFNSigmaProton = fPIDResponse->NumberOfSigmasTOF( nTrackXi, AliPID::kProton );
         fTreeCascVarPosTOFNSigmaPion   = fPIDResponse->NumberOfSigmasTOF( pTrackXi, AliPID::kPion );
         fTreeCascVarPosTOFNSigmaProton = fPIDResponse->NumberOfSigmasTOF( pTrackXi, AliPID::kProton );
         fTreeCascVarBachTOFNSigmaPion  = fPIDResponse->NumberOfSigmasTOF( bachTrackXi, AliPID::kPion );
         fTreeCascVarBachTOFNSigmaKaon  = fPIDResponse->NumberOfSigmasTOF( bachTrackXi, AliPID::kKaon );
-
         
         
-//-------------------set the variables to the track object and fill the tree!--------------------------------
-        Cascade_Track = Cascade_Event -> createTrack();
+        
+        //-------------------set the variables to the track object and fill the tree!--------------------------------
+        
+      
+        if(iXi_passed > 10000) continue; //see the AliRunningCascadeEvent class and the boundaries of Track array!
+        Cascade_Track = Cascade_Event -> AddCandidate(iXi_passed);
+        iXi_passed++;
+        
         Cascade_Track -> set_PMom(lPMom[0],lPMom[1],lPMom[2]);
         Cascade_Track -> set_NMom(lNMom[0],lNMom[1],lNMom[2]);
         Cascade_Track -> set_BMom(lBMom[0],lBMom[1],lBMom[2]);
@@ -926,12 +818,12 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
         Cascade_Track -> set_dca_neg_to_prim(fTreeCascVarDCANegToPrimVtx, fTreeCascVarDCANegToPrimVtxZ);
         Cascade_Track -> set_dca_bach_to_prim(fTreeCascVarDCABachToPrimVtx, fTreeCascVarDCABachToPrimVtxZ);
         Cascade_Track -> set_dca_V0_to_prim(fTreeCascVarDCAV0ToPrimVtx);
-        Cascade_Track -> set_dca_Omega_to_prim(fTreeCascVarCascDCAtoPVxy, fTreeCascVarCascDCAtoPVz);
+        Cascade_Track -> set_dca_Omega_to_prim(fTreeCascVarCascDCAtoPVxy);
         Cascade_Track -> set_dca_pos_to_neg(fTreeCascVarDCAV0Daughters);
         Cascade_Track -> set_dca_bach_to_Lambda(fTreeCascVarDCACascDaughters);
         Cascade_Track -> set_dca_bach_to_baryon(fTreeCascVarDCABachToBaryon);
-       
-       
+        
+        
         
         //fill with the positions of the V0 and Xi.
         Cascade_Track -> set_CosPointingAngle(fTreeCascVarCascCosPointingAngle);
@@ -947,7 +839,7 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
         Cascade_Track -> set_ITSrefitFlag(ITSrefitflag[0], ITSrefitflag[1], ITSrefitflag[2]);
         Cascade_Track -> set_ITSchi2(itschi2[0], itschi2[1], itschi2[2]);
         Cascade_Track -> set_ITSsignal(itssignal[0], itssignal[1], itssignal[2]);
-
+        
         Cascade_Track -> set_nSigma_ITS_pos(fTreeCascVarPosITSNSigmaProton, fTreeCascVarPosITSNSigmaPion);
         Cascade_Track -> set_nSigma_ITS_neg(fTreeCascVarNegITSNSigmaPion, fTreeCascVarNegITSNSigmaProton);
         Cascade_Track -> set_nSigma_ITS_bach(fTreeCascVarBachITSNSigmaKaon, fTreeCascVarBachITSNSigmaPion);
@@ -961,10 +853,6 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
         Cascade_Track -> set_nSigma_dEdx_pos(fTreeCascVarPosNSigmaProton, fTreeCascVarPosNSigmaPion); //[0] Casc charge = -1, [1] Casc +
         Cascade_Track -> set_nSigma_dEdx_neg(fTreeCascVarNegNSigmaPion,  fTreeCascVarNegNSigmaProton);
         Cascade_Track -> set_nSigma_dEdx_bach(fTreeCascVarBachNSigmaKaon, fTreeCascVarBachNSigmaPion);
-        Cascade_Track -> set_TPC_PartVar_Pos(posTPCpid[0],posTPCpid[1],posTPCpid[2],posTPCpid[3],posTPCpid[4],posTPCpid[5],posTPCpid[6]);
-        Cascade_Track -> set_TPC_PartVar_Neg(negTPCpid[0],negTPCpid[1],negTPCpid[2],negTPCpid[3],negTPCpid[4],negTPCpid[5],negTPCpid[6]);
-        Cascade_Track -> set_TPC_PartVar_Bach(bachTPCpid[0],bachTPCpid[1],bachTPCpid[2],bachTPCpid[3],bachTPCpid[4],bachTPCpid[5],bachTPCpid[6]);
-
         
         
         //TOF
@@ -974,25 +862,16 @@ void AliAnalysisTaskStrangeCascadesDiscrete::UserExec(Option_t *option)
         Cascade_Track -> set_nSigma_TOF_neg(fTreeCascVarNegTOFNSigmaPion, fTreeCascVarNegTOFNSigmaProton);
         Cascade_Track -> set_nSigma_TOF_bach(fTreeCascVarBachTOFNSigmaKaon, fTreeCascVarBachTOFNSigmaPion);
         
-        
-        
-        //do not implement it, just use the sigma deviations
-     /*   Cascade_Track -> set_TPCPIDProbPos(TPCprobabilityPos[4], TPCprobabilityPos[2]); //4 -proton, 2 -pion, 3-kaon
-        Cascade_Track -> set_TPCPIDProbNeg(TPCprobabilityNeg[4], TPCprobabilityNeg[2]);
-        Cascade_Track -> set_TPCPIDProbBach(TPCprobabilityBach[2], TPCprobabilityBach[3]);*/
-        /*   Cascade_Track -> set_ITSPIDProbPos(ITSprobabilityPos[4], ITSprobabilityPos[2]); //4 -proton, 2 -pion, 3-kaon
-         Cascade_Track -> set_ITSPIDProbNeg(ITSprobabilityNeg[4], ITSprobabilityNeg[2]);
-         Cascade_Track -> set_ITSPIDProbBach(ITSprobabilityBach[2], ITSprobabilityBach[3]);*/
-
-
-     
-
         fTreeCascadeAsEvent -> Fill();
-     
+        
+        
     }//end of the cascade loop.
+
     
     
     PostData(1, fTreeCascadeAsEvent);
+    
+    
 }
 
 void AliAnalysisTaskStrangeCascadesDiscrete::Terminate(Option_t *){}
@@ -1005,7 +884,7 @@ void AliAnalysisTaskStrangeCascadesDiscrete::Terminate(Option_t *){}
 
 Bool_t AliAnalysisTaskStrangeCascadesDiscrete::GoodESDEvent(AliESDEvent* lESDevent, const AliESDVertex *lPrimaryBestESDVtx,AliESDtrackCuts* esdtrackcuts1){
     
-   
+    
     //general var to return
     Bool_t goodevent = kTRUE;
     
@@ -1015,7 +894,7 @@ Bool_t AliAnalysisTaskStrangeCascadesDiscrete::GoodESDEvent(AliESDEvent* lESDeve
     if(!lmagneticfield) goodevent = kFALSE;
     
     //PRIMARY VERTEX can be got, should be changed for PbPb collisions
-   // const AliESDVertex *lPrimaryBestESDVtx  = lESDevent->GetPrimaryVertex();
+    // const AliESDVertex *lPrimaryBestESDVtx  = lESDevent->GetPrimaryVertex();
     if (!lPrimaryBestESDVtx) goodevent = kFALSE;
     Double_t lBestPrimaryVtxPos[3] = {-100.0, -100.0, -100.0};
     lPrimaryBestESDVtx->GetXYZ( lBestPrimaryVtxPos );
@@ -1038,7 +917,10 @@ Bool_t AliAnalysisTaskStrangeCascadesDiscrete::GoodESDEvent(AliESDEvent* lESDeve
     Int_t fNtracks  = lESDevent ->GetNumberOfTracks();
     if(fNtracks < 0) goodevent = kFALSE;
     
-
+    //Number of cascades
+    Int_t ncascades = lESDevent -> GetNumberOfCascades();
+    if(ncascades < 1) goodevent = kFALSE;
+    
     return goodevent;
 }
 
@@ -1061,28 +943,12 @@ Bool_t AliAnalysisTaskStrangeCascadesDiscrete::GoodESDTrack(AliESDtrack* trackES
     ULong_t status = trackESD->GetStatus();
     if((status & AliESDtrack::kTPCrefit) == 0) goodtrack = kFALSE;
     
-    //check the ITS status, do later in the analysis.(output is light)
-  //  Int_t statusITS1 = GetITSstatus(trackESD, 0);
-  //  Int_t statusITS2 = GetITSstatus(trackESD, 1);
-  //  if((statusITS1!=1)&&(statusITS2!=1)) goodtrack = kFALSE; //-> the hit is in the first OR second ITS layer
-    
-    //check the ITS innermost layers, do later in the analysis
-  //  Bool_t lits1 = trackESD -> HasPointOnITSLayer(0);
-  //  Bool_t lits2 = trackESD -> HasPointOnITSLayer(1);
-  //  if ((lits1==0)&&(lits2==0)) goodtrack = kFALSE;  //if the ITS layer info is saved, then we do not need it
-    
     //TPC clusters
     Int_t tpcnclus=trackESD->GetTPCNcls();
     Int_t tpcnclusF = trackESD -> GetTPCNclsF();
     if(tpcnclusF<70) goodtrack = kFALSE;
     if(tpcnclus<70) goodtrack = kFALSE; //looser because of V0
-    
-    //cluster ratio
-   /* Float_t ratio = -1;
-    if(tpcnclusF != 0.) ratio = tpcnclus/tpcnclusF;
-    if(ratio < 0.6) goodtrack = kFALSE;*/
-    
-    
+ 
     //filter out the noise, cross check (done automatically?) AliPerformanceTPC
     if(trackESD -> GetTPCsignal() < 5) goodtrack = kFALSE;
     
@@ -1090,11 +956,6 @@ Bool_t AliAnalysisTaskStrangeCascadesDiscrete::GoodESDTrack(AliESDtrack* trackES
     Float_t tpcchi2 = 1000;
     if(tpcnclus!=0) tpcchi2= trackESD->GetTPCchi2()/tpcnclus; //was with (Float_t)trackESD->...
     if(tpcchi2 > 4)goodtrack = kFALSE;
-    
-    
-    //rapidity, no cut on the rapidity of daughters! (can be switched on again, but we do not need it)
-   // Double_t y = trackESD->Y();
-   // if (!y || TMath::Abs(y) > raprange) goodtrack = kFALSE;
     
     //pseudorapity
     Double_t eta = trackESD->Eta();
@@ -1122,55 +983,70 @@ Int_t AliAnalysisTaskStrangeCascadesDiscrete::GetITSstatus(AliESDtrack* esdtrack
 }
 
 Bool_t AliAnalysisTaskStrangeCascadesDiscrete::ExtraCleanupCascade(AliESDcascade* Xi,
-                                                                          AliESDtrack* gPtrack,
-                                                                          AliESDtrack* gNtrack,
-                                                                          AliESDtrack* gBtrack,
-                                                                          Double_t OmegaMassWindow,
-                                                                          Double_t XiMassWindow)
+                                                                   AliESDtrack* gPtrack,
+                                                                   AliESDtrack* gNtrack,
+                                                                   AliESDtrack* gBtrack,
+                                                                   Double_t OmegaMassWindow)
 {
     //extra cleanup is needed to reduce the weight of the output file.
     //in this analysis we want to study the central prod. omega baryons, d.h. rapidity of omega |y| < 0.5
-    //note: used code = 3334 or -3334
     //this cut won't be made for the Xi (using the same trio of tracks as for the omega under change of mass hypothesis!)
     //note: input tracks should have gone through the good track selection (Bool_t GoodESDTrack)
-    //note: magnetic field is just a parameter, the charges of the tracks are REAL PHYSICAL charges, so do not check for the magnetic field polarity
-    //note: the omega mass window is : 1.67 pm 0.05
+    //note: since magnetic field is just a parameter, the charges of the tracks are REAL PHYSICAL charges, so do not check for the magnetic field polarity
     Bool_t cleaned = kTRUE;
-    TLorentzVector vXi; Double_t vXiarr[4];
-   // TLorentzVector vXi2; Double_t vXiarr2[4]; //cuts for Xi, not used but - can be - in general.
-    Double_t y(1.);
-    Double_t mOmega(-1.);
-    
-    Int_t runningcode = - 3334 * gBtrack->Charge(); //if negative Kaon -> +3334, positive kaon -> -3334
-    
+
     if(!Xi){AliWarning("No cascade found, no clean up"); cleaned = kFALSE; }
     if(!gPtrack){AliWarning("No positive track found, no clean up"); cleaned = kFALSE; }
     if(!gNtrack){AliWarning("No negative track found, no clean up"); cleaned = kFALSE; }
     if(!gBtrack){AliWarning("No bachelor track found, no clean up"); cleaned = kFALSE; }
     
-    if (TMath::Abs(runningcode)!=3334) {AliWarning("Bachelor track is neutral, no clean up"); cleaned = kFALSE;}
-    Double_t lv0q = 0;
-    Xi->ChangeMassHypothesis(lv0q, runningcode);
-    Xi->GetPxPyPz(vXiarr[0], vXiarr[1], vXiarr[2]);
-    vXiarr[3] = Xi->E(); //needs the hypothesis
-    vXi.SetPxPyPzE(vXiarr[0], vXiarr[1], vXiarr[2], vXiarr[3]);
-   
+  
+    TLorentzVector vXi;
+    Double_t y(1.);
+    Double_t mOmega(-1.);
+    
+    Double_t massproton = 0.9382;
+    Double_t masspion = 0.1395;
+    Double_t masskaon = 0.4937;
+    
+    Double_t Epos(0), Eneg(0),Ebach(0), EOmega(0);
+    Double_t Ppos(0), Pneg(0), Pbach(0);
+    //momentum of omega
+    Double_t POmega[4];
+    Xi -> GetPxPyPz(POmega[0], POmega[1], POmega[2]);
+    POmega[3] = TMath::Sqrt(POmega[0]*POmega[0] + POmega[1]*POmega[1] + POmega[2]*POmega[2]);
+    //momenta of tracks
+    Ppos = gPtrack -> P();
+    Pneg = gNtrack -> P();
+    Pbach = gBtrack -> P();
+    
+    if(gBtrack -> Charge() == -1){ //omega:proton-pos, pion-neg, kaon-bach
+        Epos = TMath::Sqrt(massproton*massproton + Ppos*Ppos);
+        Eneg = TMath::Sqrt(masspion*masspion + Pneg*Pneg);
+        Ebach = TMath::Sqrt(masskaon*masskaon + Pbach*Pbach);
+        EOmega = Epos + Eneg + Ebach;
+        if(EOmega <= POmega[3]) cleaned = kFALSE;
+        mOmega = TMath::Sqrt(TMath::Abs(EOmega*EOmega - POmega[3]*POmega[3]));
+        vXi.SetPxPyPzE(POmega[0], POmega[1], POmega[2], EOmega);
+    }
+    
+    if(gBtrack -> Charge() == +1){ //omega:proton-pos, pion-neg, kaon-bach
+        Epos = TMath::Sqrt(masspion*masspion + Ppos*Ppos);
+        Eneg = TMath::Sqrt(massproton*massproton + Pneg*Pneg);
+        Ebach = TMath::Sqrt(masskaon*masskaon + Pbach*Pbach);
+        EOmega = Epos + Eneg + Ebach;
+        if(EOmega <= POmega[3]) cleaned = kFALSE;
+        mOmega = TMath::Sqrt(TMath::Abs(EOmega*EOmega - POmega[3]*POmega[3]));
+        vXi.SetPxPyPzE(POmega[0], POmega[1], POmega[2], EOmega);
+    }
+    
     //RAPIDITY check
     y = vXi.Rapidity();
     if (TMath::Abs(y)>0.5) cleaned = kFALSE;
     
     //MASS WINDOW for OMEGA
     mOmega = TMath::Abs(vXi.M()); //M() already returns positive values only, but just in case
-    if(TMath::Abs(mOmega - 1.6725) > TMath::Abs(OmegaMassWindow)) cleaned = kFALSE;
-    
-    //Use LOOSER cut on XI MASS; do not need to implement it! Check later in the analysis, looking at analysis
-   /* runningcode = - 3312 * gBtrack->Charge();
-    Xi->ChangeMassHypothesis(lv0q, runningcode);
-    Xi->GetPxPyPz(vXiarr2[0], vXiarr2[1], vXiarr2[2]);
-    vXiarr2[3] = Xi->E(); //needs the hypothesis
-    vXi2.SetPxPyPzE(vXiarr2[0], vXiarr2[1], vXiarr2[2], vXiarr2[3]);
-    mXi = TMath::Abs(vXi2.M());*/
-   // if(TMath::Abs(mXi - 1.3217) > TMath::Abs(XiMassWindow)) cleaned = kFALSE;
+    if(TMath::Abs(mOmega - 1.672) > TMath::Abs(OmegaMassWindow)) cleaned = kFALSE;
     
     
     return cleaned;
@@ -1188,14 +1064,14 @@ Bool_t AliAnalysisTaskStrangeCascadesDiscrete::GoodCandidatesTPCPID(AliESDtrack*
     if (!pTrackXi)goodTPCtrio = kFALSE;
     if (!nTrackXi)goodTPCtrio = kFALSE;
     if (!bachTrackXi)goodTPCtrio = kFALSE;
-
+    
     Short_t chargeCascade = bachTrackXi -> Charge();
     if(TMath::Abs(chargeCascade)!=1)goodTPCtrio = kFALSE; //cross-check
     Float_t PID_Pos_Pion  = fPIDResponse->NumberOfSigmasTPC( pTrackXi, AliPID::kPion );
     Float_t PID_Pos_Proton = fPIDResponse->NumberOfSigmasTPC( pTrackXi, AliPID::kProton );
     Float_t PID_Neg_Pion   = fPIDResponse->NumberOfSigmasTPC( nTrackXi, AliPID::kPion );
     Float_t PID_Neg_Proton = fPIDResponse->NumberOfSigmasTPC( nTrackXi, AliPID::kProton );
-   // Float_t PID_Bach_Pion  = fPIDResponse->NumberOfSigmasTPC( bachTrackXi, AliPID::kPion );
+    // Float_t PID_Bach_Pion  = fPIDResponse->NumberOfSigmasTPC( bachTrackXi, AliPID::kPion );
     Float_t PID_Bach_Kaon  = fPIDResponse->NumberOfSigmasTPC( bachTrackXi, AliPID::kKaon );
     
     if (chargeCascade == -1)
@@ -1204,10 +1080,6 @@ Bool_t AliAnalysisTaskStrangeCascadesDiscrete::GoodCandidatesTPCPID(AliESDtrack*
         if(TMath::Abs(PID_Pos_Proton) > sigmamax) goodTPCtrio = kFALSE;
         if(TMath::Abs(PID_Neg_Pion) > sigmamax) goodTPCtrio = kFALSE;
         if(TMath::Abs(PID_Bach_Kaon) > sigmamax) goodTPCtrio = kFALSE;
-        
-   /*     if(TMath::Abs(PID_Pos_Pion) < 3.) goodTPCtrio = kFALSE;
-        if(TMath::Abs(PID_Neg_Proton) < 3.) goodTPCtrio = kFALSE;
-        if(TMath::Abs(PID_Bach_Pion) < 4.) goodTPCtrio = kFALSE; //allow for small contamination*/
         
     }
     
@@ -1218,11 +1090,8 @@ Bool_t AliAnalysisTaskStrangeCascadesDiscrete::GoodCandidatesTPCPID(AliESDtrack*
         if(TMath::Abs(PID_Neg_Proton) > sigmamax) goodTPCtrio = kFALSE;
         if(TMath::Abs(PID_Bach_Kaon) > sigmamax) goodTPCtrio = kFALSE;
         
-      /* if(TMath::Abs(PID_Pos_Proton) < 3.) goodTPCtrio = kFALSE;
-        if(TMath::Abs(PID_Neg_Pion) < 3.) goodTPCtrio = kFALSE;
-        if(TMath::Abs(PID_Bach_Pion) < 4.) goodTPCtrio = kFALSE;*/
-        
     }
     
     return goodTPCtrio;
 }
+

--- a/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrangeCascadesDiscrete.h
+++ b/PWGLF/STRANGENESS/Cascades/Run2/AliAnalysisTaskStrangeCascadesDiscrete.h
@@ -1,5 +1,3 @@
-//---completely from scratch, this SHOULD BE REMOVED before pushing!
-
 #ifndef ALIANALYSISTASKSTRANGECASCADESDISCRETE_H
 #define ALIANALYSISTASKSTRANGECASCADESDISCRETE_H
 
@@ -7,87 +5,81 @@ class AliAnalysisManager;
 class AliMultSelection;
 
 //Class which saves the cascade daughter tracks
-class AliRunningCascadeTrack : public TObject
+class AliRunningCascadeCandidate : public TObject
 {
 private:
-    Float_t PMom[3];
-    Float_t NMom[3];
-    Float_t BMom[3];
+    Float_t PMom[3]; //
+    Float_t NMom[3]; //
+    Float_t BMom[3]; //
     Short_t dca_pos_to_prim[2];  // xy, z, range is 0..180 cm
     Short_t dca_neg_to_prim[2]; // xy, z, range is 0..180 cm
     Short_t dca_bach_to_prim[2]; // xy, z, range is 0..180 cm
     Short_t dca_V0_to_prim;  // 0..120
-    Short_t dca_Omega_to_prim[2]; // xy, z; 0..40, pm40
+    Short_t dca_Omega_to_prim; // xy, z; 0..40, pm40
     Short_t dca_pos_to_neg; //0..1.5 cm
     Short_t dca_bach_to_Lambda; //0...2.0 cm
     Short_t dca_bach_to_baryon; // 0..500.0 cm
     
     Short_t CosPointingAngle; //also stores the charge of the bachelor track! (cos(THeta)*e_bach)
-    Float_t CascadeDecayPos[3];
-    Float_t V0fromCascadePos[3];
+    Float_t CascadeDecayPos[3]; //
+    Float_t V0fromCascadePos[3];  //
     Short_t TrackLengthTPC[3]; // 0 - pos, 1 - neg, 2-bach
-
+    
     
     //extra PID info
     //ITS
-    UShort_t ITSstatusPosTrack[6], ITSstatusNegTrack[6], ITSstatusBachTrack[6];//2 byte, unsigned out:from 0 to 6.
-    Char_t ITSrefitFlag[3];
-    Char_t ITSPosSharedPoints[6], ITSNegSharedPoints[6], ITSBachSharedPoints[6];
-    Short_t ITSchi2[3], ITSsignal[3];
-    Short_t nSigma_ITS_pos[2];
-    Short_t nSigma_ITS_neg[2];
-    Short_t nSigma_ITS_bach[2];
-  /*  Short_t ITSPIDProbPos[2]; //computed probability (AliPIDResponse; see AliPID.h for info)
-    Short_t ITSPIDProbNeg[2];
-    Short_t ITSPIDProbBach[2];*/
-    
+    UShort_t ITSstatusPosTrack[6], ITSstatusNegTrack[6], ITSstatusBachTrack[6];// 2 byte, unsigned out:from 0 to 6.
+    Char_t ITSrefitFlag[3]; //
+    Char_t ITSPosSharedPoints[6], ITSNegSharedPoints[6], ITSBachSharedPoints[6]; //
+    Short_t ITSchi2[3], ITSsignal[3]; //
+    Short_t nSigma_ITS_pos[2]; //
+    Short_t nSigma_ITS_neg[2]; //
+    Short_t nSigma_ITS_bach[2];//
+ 
     //TPC
-    Short_t TPCsignal[3]; //[0]: pos track, [1]: neg track, [2]: bach track
-    UShort_t TPCcls[3]; //->GetTPCNcls() (not TPCNclsF())
-    UShort_t TPCclsF[3]; //findable clusters! theoretically to expect
-    UShort_t TPCchi2[3];
-    Short_t nSigma_dEdx_pos[2]; //pos is either [0]=proton(if Omega-) or [1]=pion(if Omega+)
-    Short_t nSigma_dEdx_neg[2]; //neg is either [0]=pion(Omega-) or [1]=proton
-    Short_t nSigma_dEdx_bach[2]; //bach is either [0]=kaon(Omega) or [1]=pion(Xi)
-   /* Short_t TPCPIDProbPos[2]; //computed probability (AliPIDResponse; see AliPID.h for info)
-    Short_t TPCPIDProbNeg[2];
-    Short_t TPCPIDProbBach[2];*/
-    Char_t posTPC[7];
-    Char_t negTPC[7];
-    Char_t bachTPC[7];
+    Short_t TPCsignal[3]; // [0]: pos track, [1]: neg track, [2]: bach track
+    UShort_t TPCcls[3]; // GetTPCNcls() (not TPCNclsF())
+    UShort_t TPCclsF[3]; // findable clusters! theoretically to expect
+    UShort_t TPCchi2[3]; //
+    Short_t nSigma_dEdx_pos[2]; // pos is either [0]=proton(if Omega-) or [1]=pion(if Omega+)
+    Short_t nSigma_dEdx_neg[2]; // neg is either [0]=pion(Omega-) or [1]=proton
+    Short_t nSigma_dEdx_bach[2]; // bach is either [0]=kaon(Omega) or [1]=pion(Xi)
     
     //TOF
-    Short_t TOFsignal[3];
-    Char_t TOFrefitFlag[3];
-    Short_t nSigma_TOF_pos[2];
-    Short_t nSigma_TOF_neg[2];
-    Short_t nSigma_TOF_bach[2];
+    Float_t TOFsignal[3];//
+    Char_t TOFrefitFlag[3]; //
+    Short_t nSigma_TOF_pos[2]; //
+    Short_t nSigma_TOF_neg[2]; //
+    Short_t nSigma_TOF_bach[2]; //
+    
     
     
     
     
 public:
     //default constructor: for my classed, inherited by TOBject, should be empty as possible
-    AliRunningCascadeTrack():dca_V0_to_prim(-10),dca_pos_to_neg(-10),dca_bach_to_Lambda(-10),dca_bach_to_baryon(-10),CosPointingAngle(-10.){}
+    AliRunningCascadeCandidate():dca_V0_to_prim(-10),dca_Omega_to_prim(-10),dca_pos_to_neg(-10),dca_bach_to_Lambda(-10),dca_bach_to_baryon(-10),CosPointingAngle(-10.)
+    {}
     //explicit contructor: should do at least something
-    AliRunningCascadeTrack(Int_t iii):dca_V0_to_prim(-10),dca_pos_to_neg(-10),dca_bach_to_Lambda(-10),dca_bach_to_baryon(-10),CosPointingAngle(-10.)
+    AliRunningCascadeCandidate(Int_t i):dca_V0_to_prim(-10),dca_Omega_to_prim(-10),dca_pos_to_neg(-10),dca_bach_to_Lambda(-10),dca_bach_to_baryon(-10),CosPointingAngle(-10.)
     {
-       // Float_t sum = dca_V0_to_prim + dca_pos_to_neg; //does not have any physic.interp.
+        // Float_t sum = dca_V0_to_prim + dca_pos_to_neg; //does not have any physic.interp.
         dca_V0_to_prim = -5;
         
     }
     //copy constructor
-    AliRunningCascadeTrack(const AliRunningCascadeTrack&):TObject(),dca_V0_to_prim(-10),dca_pos_to_neg(-10),dca_bach_to_Lambda(-10),dca_bach_to_baryon(-10),CosPointingAngle(-10.){}
+    AliRunningCascadeCandidate(const AliRunningCascadeCandidate&):TObject(),dca_V0_to_prim(-10),dca_Omega_to_prim(-10),dca_pos_to_neg(-10),dca_bach_to_Lambda(-10),dca_bach_to_baryon(-10),CosPointingAngle(-10.){}
     //copy assignment
-    AliRunningCascadeTrack& operator = (const AliRunningCascadeTrack&){return *this;}
+    AliRunningCascadeCandidate& operator = (const AliRunningCascadeCandidate&){return *this;}
     //default destructor
-    virtual ~AliRunningCascadeTrack()
+    virtual ~AliRunningCascadeCandidate()
     {
+        
         
     }
     
-//----------------------------------------------------------------
-
+    //----------------------------------------------------------------
+    
     //setters
     void set_PMom(Double_t px, Double_t py, Double_t pz)   {PMom[0] = (Float_t)px; PMom[1] = (Float_t)py; PMom[2] = (Float_t)pz;}
     void set_NMom(Float_t px, Float_t py, Float_t pz)   {NMom[0] = (Float_t)px; NMom[1] = (Float_t)py; NMom[2] = (Float_t)pz;}
@@ -96,14 +88,11 @@ public:
     void set_dca_neg_to_prim(Float_t f1, Float_t f2)   { dca_neg_to_prim[0]   = (Short_t)(f1*100.0); dca_neg_to_prim[1]   = (Short_t)(f2*100.0); }
     void set_dca_bach_to_prim(Float_t f1, Float_t f2)   { dca_bach_to_prim[0]   = (Short_t)(f1*100.0); dca_bach_to_prim[1]   = (Short_t)(f2*100.0); }
     void set_dca_V0_to_prim(Float_t f)  { dca_V0_to_prim  = (Short_t)(f*100.0); }
-    void set_dca_Omega_to_prim(Float_t f1, Float_t f2)   { dca_Omega_to_prim[0]   = (Short_t)(f1*100.0); dca_Omega_to_prim[1]   = (Short_t)(f2*100.0); }
+    void set_dca_Omega_to_prim(Float_t f1) { dca_Omega_to_prim  = (Short_t)(f1*100.0);}
     void set_dca_pos_to_neg(Float_t f)  { dca_pos_to_neg = (Short_t)(f*100.0); }
     void set_dca_bach_to_Lambda(Float_t f)  { dca_bach_to_Lambda = (Short_t)(f*100.0); }
     void set_dca_bach_to_baryon(Float_t f)  { dca_bach_to_baryon = (Short_t)(f*10.0); }
     void set_CosPointingAngle(Float_t f)    {CosPointingAngle = (Short_t)(f*1000.);} //pay attention to this!
-   // void set_LeastNumberOfTPCclus(Int_t i)      {LeastNumberOfTPCclus = i; }
-   // void set_MaxChi2perclus(Float_t f)   {MaxChi2perclus = (Short_t)(f*100.); }
-   // void set_MinTrackLength(Float_t f)    {MinTrackLength = (Short_t)(f*100.); }
     void set_CascadeDecayPos(Float_t f1, Float_t f2, Float_t f3)
     {
         CascadeDecayPos[0] = f1;
@@ -166,22 +155,7 @@ public:
     void set_nSigma_ITS_pos(Float_t f1, Float_t f2)   { nSigma_ITS_pos[0]   = (Short_t)(f1*100); nSigma_ITS_pos[1]   = (Short_t)(f2*100); }
     void set_nSigma_ITS_neg(Float_t f1, Float_t f2)   { nSigma_ITS_neg[0]   = (Short_t)(f1*100); nSigma_ITS_neg[1]   = (Short_t)(f2*100); }
     void set_nSigma_ITS_bach(Float_t f1, Float_t f2)   { nSigma_ITS_bach[0]   = (Short_t)(f1*100); nSigma_ITS_bach[1]   = (Short_t)(f2*100); }
-   /* void set_ITSPIDProbPos(Double_t probProton, Double_t probPion){
-        ITSPIDProbPos[0] = (Short_t)(probProton*10000);
-        ITSPIDProbPos[1] = (Short_t)(probPion*10000);
-    }
-    void set_ITSPIDProbNeg(Double_t probProton, Double_t probPion){
-        ITSPIDProbNeg[0] = (Short_t)(probProton*10000);
-        ITSPIDProbNeg[1] = (Short_t)(probPion*10000);
-    }
-    void set_ITSPIDProbBach(Double_t probPion, Double_t probKaon){
-        ITSPIDProbBach[0] = (Short_t)(probPion*10000);
-        ITSPIDProbBach[1] = (Short_t)(probKaon*10000);
-    }*/
-    
-    
-    
-    
+ 
     //TPC setters
     void set_TPCsignal(Double_t TPCsignalPos, Double_t TPCsignalNeg, Double_t TPCsignalBach){
         TPCsignal[0] = (Short_t)(TPCsignalPos*10.); TPCsignal[1] = (Short_t)(TPCsignalNeg*10.); TPCsignal[2] = (Short_t)(TPCsignalBach*10.);
@@ -200,30 +174,6 @@ public:
     void set_nSigma_dEdx_pos(Float_t f1, Float_t f2)   { nSigma_dEdx_pos[0]   = (Short_t)(f1*100); nSigma_dEdx_pos[1]   = (Short_t)(f2*100); }
     void set_nSigma_dEdx_neg(Float_t f1, Float_t f2)   { nSigma_dEdx_neg[0]   = (Short_t)(f1*100); nSigma_dEdx_neg[1]   = (Short_t)(f2*100); }
     void set_nSigma_dEdx_bach(Float_t f1, Float_t f2)   { nSigma_dEdx_bach[0]   = (Short_t)(f1*100); nSigma_dEdx_bach[1]   = (Short_t)(f2*100); }
-   /* void set_TPCPIDProbPos(Double_t probProton, Double_t probPion){
-        TPCPIDProbPos[0] = (Short_t)(probProton*10000);
-        TPCPIDProbPos[1] = (Short_t)(probPion*10000);
-    }
-    void set_TPCPIDProbNeg(Double_t probProton, Double_t probPion){
-        TPCPIDProbNeg[0] = (Short_t)(probProton*10000);
-        TPCPIDProbNeg[1] = (Short_t)(probPion*10000);
-    }
-    void set_TPCPIDProbBach(Double_t probPion, Double_t probKaon){
-        TPCPIDProbBach[0] = (Short_t)(probPion*10000);
-        TPCPIDProbBach[1] = (Short_t)(probKaon*10000);
-    }*/
-    void set_TPC_PartVar_Pos(Char_t p0, Char_t p1, Char_t p2, Char_t p3, Char_t p4, Char_t p5, Char_t p6)
-    {
-        posTPC[0] = p0; posTPC[1] = p1; posTPC[2] = p2; posTPC[3] = p3; posTPC[4] = p4; posTPC[5] = p5; posTPC[6] = p6;
-    }
-    void set_TPC_PartVar_Neg(Char_t n0, Char_t n1, Char_t n2, Char_t n3, Char_t n4, Char_t n5, Char_t n6)
-    {
-        negTPC[0] = n0; negTPC[1] = n1; negTPC[2] = n2; negTPC[3] = n3; negTPC[4] = n4; negTPC[5] = n5; negTPC[6] = n6;
-    }
-    void set_TPC_PartVar_Bach(Char_t b0, Char_t b1, Char_t b2, Char_t b3, Char_t b4, Char_t b5, Char_t b6)
-    {
-        bachTPC[0] = b0; bachTPC[1] = b1; bachTPC[2] = b2; bachTPC[3] = b3; bachTPC[4] = b4; bachTPC[5] = b5; bachTPC[6] = b6;
-    }
     
     
     //TOF
@@ -231,7 +181,7 @@ public:
         TOFrefitFlag[0] = (Char_t)refitPos; TOFrefitFlag[1]= (Char_t)refitNeg; TOFrefitFlag[2] = (Char_t)refitBach;
     }
     void set_TOFsignal(Double_t TOFsignalPos, Double_t TOFsignalNeg, Double_t TOFsignalBach){
-        TOFsignal[0] = (Float_t)(TOFsignalPos); TOFsignal[1] = (Float_t)(TOFsignalNeg); TOFsignal[2] = (Float_t)(TOFsignalBach);
+        TOFsignal[0] = (Float_t)TOFsignalPos; TOFsignal[1] = (Float_t)TOFsignalNeg; TOFsignal[2] = (Float_t)TOFsignalBach;
     }
     void set_nSigma_TOF_pos(Float_t f1, Float_t f2)   { nSigma_TOF_pos[0]   = (Short_t)(f1*100); nSigma_TOF_pos[1]   = (Short_t)(f2*100); }
     void set_nSigma_TOF_neg(Float_t f1, Float_t f2)   { nSigma_TOF_neg[0]   = (Short_t)(f1*100); nSigma_TOF_neg[1]   = (Short_t)(f2*100); }
@@ -239,7 +189,8 @@ public:
     
     
     
-    
+
+
     //getters
     Float_t get_PMom(Int_t i) const     { return PMom[i]; }
     Float_t get_NMom(Int_t i) const     { return NMom[i]; }
@@ -248,17 +199,14 @@ public:
     Float_t get_dca_neg_to_prim(Int_t i) const   { return ((Float_t)dca_neg_to_prim[i])/100.0; }
     Float_t get_dca_bach_to_prim(Int_t i)  const { return ((Float_t)dca_bach_to_prim[i])/100.0; }
     Float_t get_dca_V0_to_prim() const  { return ((Float_t)dca_V0_to_prim)/100.0; }
-    Float_t get_dca_Omega_to_prim(Int_t i) const  { return ((Float_t)dca_pos_to_prim[i])/100.0; }
+    Float_t get_dca_Omega_to_prim() const  { return ((Float_t)dca_Omega_to_prim)/100.0; }
     Float_t get_dca_pos_to_neg() const { return ((Float_t)dca_pos_to_neg)/100.0; }
     Float_t get_dca_bach_to_Lambda()  const { return ((Float_t)dca_bach_to_Lambda)/100.0; }
     Float_t get_dca_bach_to_baryon() const { return ((Float_t)dca_bach_to_baryon)/10.0; }
-  
-   
+    
+    
     
     Float_t get_CosPointingAngle()  const  {return ((Float_t)CosPointingAngle)/1000.;} //pay attention to cos! should not be negative
-   // Int_t get_LeastNumberOfTPCclus()   const   {return LeastNumberOfTPCclus; }
-   // Float_t get_MaxChi2perclus() const  {return ((Float_t)MaxChi2perclus)/100.; }
-   // Float_t get_MinTrackLength() const   {return ((Float_t)MinTrackLength)/100.; }
     Float_t  get_CascadeDecayPos(Int_t i) const {return CascadeDecayPos[i];}
     Float_t  get_V0fromCascadePos(Int_t i) const {return V0fromCascadePos[i];}
     Float_t get_TrackLengthTPC(Int_t i) const{return (Float_t)TrackLengthTPC[i];}
@@ -273,9 +221,6 @@ public:
     Float_t get_nSigma_ITS_pos(Int_t i) const  { return ((Float_t)nSigma_ITS_pos[i])/100.;}
     Float_t get_nSigma_ITS_neg(Int_t i) const  { return ((Float_t)nSigma_ITS_neg[i])/100.;}
     Float_t get_nSigma_ITS_bach(Int_t i) const  {return ((Float_t)nSigma_ITS_bach[i])/100.;}
- /*   Float_t get_ITSPIDProbPos(Int_t i)const {return ((Float_t)ITSPIDProbPos[i])/10000.;}
-    Float_t get_ITSPIDProbNeg(Int_t i)const {return ((Float_t)ITSPIDProbNeg[i])/10000.;}
-    Float_t get_ITSPIDProbBach(Int_t i)const {return ((Float_t)ITSPIDProbBach[i])/10000.;}*/
     
     //TPC
     Float_t get_TPCsignal(Int_t i) const {return ((Float_t)TPCsignal[i])/10.;}
@@ -285,25 +230,20 @@ public:
     Float_t get_nSigma_dEdx_pos(Int_t i)  const { return ((Float_t)nSigma_dEdx_pos[i])/100.; }
     Float_t get_nSigma_dEdx_neg(Int_t i)  const {return ((Float_t)nSigma_dEdx_neg[i])/100.;}
     Float_t get_nSigma_dEdx_bach(Int_t i)const   { return ((Float_t)nSigma_dEdx_bach[i])/100.; }
-  /*  Float_t get_TPCPIDProbPos(Int_t i)const {return ((Float_t)TPCPIDProbPos[i])/10000.;}
-    Float_t get_TPCPIDProbNeg(Int_t i)const {return ((Float_t)TPCPIDProbNeg[i])/10000.;}
-    Float_t get_TPCPIDProbBach(Int_t i)const {return ((Float_t)TPCPIDProbBach[i])/10000.;}*/
-    Int_t get_TPC_PartVar_Pos(Int_t i) const {return (Int_t)posTPC[i];}
-    Int_t get_TPC_PartVar_Neg(Int_t i) const {return (Int_t)negTPC[i];}
-    Int_t get_TPC_PartVar_Bach(Int_t i) const {return (Int_t)bachTPC[i];}
+  
     
     //TOF
-    Float_t get_TOFsignal(Int_t i) const {return (Float_t)TOFsignal[i];}
+    Float_t get_TOFsignal(Int_t i) const {return TOFsignal[i];}
     Int_t get_TOFrefitFlag(Int_t i)const {return (Int_t)TOFrefitFlag[i];}
     Float_t get_nSigma_TOF_pos(Int_t i) const  { return ((Float_t)nSigma_TOF_pos[i])/100.;}
     Float_t get_nSigma_TOF_neg(Int_t i) const  { return ((Float_t)nSigma_TOF_neg[i])/100.;}
     Float_t get_nSigma_TOF_bach(Int_t i) const  {return ((Float_t)nSigma_TOF_bach[i])/100.;}
     
-
-
-  //  ClassDef(AliRunningCascadeTrack,2);
     
-//----------------------------------------------------------------
+    
+    ClassDef(AliRunningCascadeCandidate,2);
+    
+    //----------------------------------------------------------------
 };
 
 
@@ -311,44 +251,45 @@ public:
 class AliRunningCascadeEvent : public TObject
 {
 private:
-    Float_t x;
-    Float_t y;
-    Float_t z;
+    Float_t x; //
+    Float_t y; //
+    Float_t z; //
     Int_t N_tracks; // total number of tracks
     Int_t idi; // run id
-    UInt_t periodnumber;
-    Float_t   centrality;
-    Bool_t    MVPPileUpFlag;
-    Int_t     multiplicity;
-    Long64_t  trigger_word;
-    Short_t magfield;
-    UShort_t fNumTracks;
+    UInt_t periodnumber; //
+    Float_t   centrality; //
+    Bool_t    MVPPileUpFlag;//
+    Int_t     multiplicity;//
+    Long64_t  trigger_word;//
+    Short_t magfield; //
+    UShort_t fNumCascadeCandidates; // number of cascade candidates in the event
+  //  UShort_t fNumSelectedCascadeCandidates; //number of preselected candidates
     TClonesArray* fTracks; //->
+    
     
 public:
     //default constructor
-    AliRunningCascadeEvent():x(-100),y(-100),z(-100),N_tracks(-1),
+    AliRunningCascadeEvent()
+    :x(-100),y(-100),z(-100),N_tracks(-1),
     idi(-1),periodnumber(-1),centrality(-1), MVPPileUpFlag(kFALSE), multiplicity(-1), trigger_word(0), magfield(0),
-    fNumTracks(-1),fTracks(0)
+    fNumCascadeCandidates(0),fTracks(0)
     {
         
     }
-    
     //explicit constructor
-    AliRunningCascadeEvent(Int_t iii):x(-100),y(-100),z(-100),N_tracks(-1),
+    AliRunningCascadeEvent(Int_t i):x(-100),y(-100),z(-100),N_tracks(-1),
     idi(-1),periodnumber(-1),centrality(-1), MVPPileUpFlag(kFALSE), multiplicity(-1), trigger_word(0), magfield(0),
-    fNumTracks(-1),fTracks(0)
+    fNumCascadeCandidates(0),fTracks(0)
     {
-        fTracks = new TClonesArray( "AliRunningCascadeTrack", 10 );
+        fTracks = new TClonesArray( "AliRunningCascadeCandidate", 10000);
         
     }
     //copy constructor
     AliRunningCascadeEvent(const AliRunningCascadeEvent&):TObject(),x(-100),y(-100),z(-100),N_tracks(-1),
     idi(-1),periodnumber(-1),centrality(-1), MVPPileUpFlag(kFALSE), multiplicity(-1), trigger_word(0), magfield(0),
-    fNumTracks(-1),fTracks(0)
+    fNumCascadeCandidates(0),fTracks(0)
     {
-        fTracks = new TClonesArray( "AliRunningCascadeTrack", 10 );
-        
+        // fTracks = new TClonesArray( "AliRunningCascadeCandidate", 10000 );
     }
     //copy assignment
     AliRunningCascadeEvent& operator =(const AliRunningCascadeEvent&)
@@ -356,14 +297,12 @@ public:
         return *this;
     }
     //destructor
-    virtual ~AliRunningCascadeEvent() {
-        delete fTracks;
-        fTracks = NULL;
+    virtual ~AliRunningCascadeEvent(){
     }
     
     
-//setters and getters
-//-----------------------------------------------------------------------------
+    //setters and getters
+    //-----------------------------------------------------------------------------
     void       setx(Float_t r)                    { x = r;                         }
     Float_t    getx() const                       { return x;                      }
     
@@ -397,37 +336,34 @@ public:
     void       setmagfield(Short_t r)             { magfield = r;                }
     Long64_t      getmagfield() const              { return magfield;             }
     
-    UShort_t getNumTracks() const        {return fNumTracks;}
-//-----------------------------------------------------------------------------
+    void     setNumCascadeCandidates(UShort_t r)      {fNumCascadeCandidates = r;}
+    UShort_t getNumCascadeCandidates() const        {return fNumCascadeCandidates;}
+
+    //-----------------------------------------------------------------------------
     
     void ClearTrackList()
     {
-        fNumTracks   = 0;
-        fTracks      ->Clear();
+        fNumCascadeCandidates = 0;
+        fTracks ->Clear();
     }
     
     
-   AliRunningCascadeTrack* createTrack()
+    AliRunningCascadeCandidate* AddCandidate(Int_t i){
+        
+        new ((*fTracks)[i]) AliRunningCascadeCandidate();
+        return (AliRunningCascadeCandidate*)((*fTracks)[i]);
+        
+    }
+    
+    
+    AliRunningCascadeCandidate* getTrack(UShort_t i) const
     {
-        if (fNumTracks == fTracks->GetSize())
-            fTracks->Expand( fNumTracks + 10 );
-        if (fNumTracks >= 10000)
-        {
-            Fatal( "AliRunningCascadeEvent::createTrack()", "ERROR: Too many tracks (>10000)!" );
-            exit( 2 );
-        }
-        AliRunningCascadeTrack* track = new ((*fTracks)[fNumTracks++])AliRunningCascadeTrack;
-        return track;
+        return i < fNumCascadeCandidates ? (AliRunningCascadeCandidate*)((*fTracks)[i]) : NULL;
     }
     
-    AliRunningCascadeTrack* getTrack(UShort_t i) const
-    {
-        return i < fNumTracks ? (AliRunningCascadeTrack*)((*fTracks)[i]) : NULL;
-    }
-    
-  //  ClassDef(AliRunningCascadeEvent, 2);
+    ClassDef(AliRunningCascadeEvent, 2);
 };
- 
+
 
 
 //=========================================================================================================
@@ -454,12 +390,12 @@ private:
     AliAnalysisUtils *fUtils;         //!
     TRandom3 *fRand; //!
     Bool_t fkDebugOOBPileup; //for studying the pileup with standard cuts
-
+    
     //pointers
-    AliAnalysisManager *man;                    
+    AliAnalysisManager *man;
     AliInputEventHandler* inputHandler;         //!
     AliESDEvent *lESDevent;                     //!
-    AliMultSelection *MultSelection;            
+    AliMultSelection *MultSelection;
     AliCentrality* centrality;                  //!
     const AliESDVertex* lPrimaryBestESDVtx;     //!
     AliESDtrackCuts* esdtrackcuts;              //!
@@ -469,9 +405,9 @@ private:
     AliESDtrack *bachTrackXi;                   //!
     AliExternalTrackParam *hCascTraj;           //!
     AliESDtrack *lBaryonTrack;                  //!
-    AliRunningCascadeTrack* Cascade_Track;      //!
-    AliRunningCascadeEvent* Cascade_Event;      //!
-    TTree* fTreeCascadeAsEvent;                 // (written to a file)
+    AliRunningCascadeCandidate* Cascade_Track;
+    AliRunningCascadeEvent* Cascade_Event;
+    TTree* fTreeCascadeAsEvent;
     
     //variables used in the userexec
     Float_t fMagneticField; //magnetic field in an event
@@ -479,41 +415,43 @@ private:
     Float_t fPV_Y; //event primary vertex y coordinate
     Float_t fPV_Z; //event primary vertex z coordinate
     Float_t sigmamaxrunning;
+    Float_t fkOmegaCleanMassWindow;
     
     
     
     
     //variables which are not necessarily defined in the impl.file
-   Double_t fV0VertexerSels[7];
+    Double_t fV0VertexerSels[7];
     Double_t fCascadeVertexerSels[8]; // Array to store the 8 values for the different selections Casc. related
     
 public:
     //constructors, copies and destructor
     AliAnalysisTaskStrangeCascadesDiscrete();
     AliAnalysisTaskStrangeCascadesDiscrete(Bool_t lRunV0Vertexers,
-                                                  Bool_t lRunVertexers, //to rerun the cascade vertexers
-                                                  Bool_t lUseLightVertexer, //use light cascade vertexer
-                                                  Bool_t lUseOnTheFlyV0Cascading,
-                                                  Bool_t lguard_CheckTrackQuality,
-                                                  Bool_t lguard_CheckCascadeQuality,
-                                                  Bool_t lguard_CheckTPCPID,
-                                                  Double_t lV0MaxChi2,
-                                                  Double_t lV0minDCAfirst,
-                                                  Double_t lV0minDCAsecond,
-                                                  Double_t lV0maxDCAdaughters,
-                                                  Double_t lV0minCosAngle,
-                                                  Double_t lV0minRadius,
-                                                  Double_t lV0maxRadius,
-                                                  Double_t lCascaderMaxChi2,
-                                                  Double_t lCascaderV0MinImpactParam,
-                                                  Double_t lCascaderV0MassWindow,
-                                                  Double_t lCascaderBachMinImpactParam,
-                                                  Double_t lCascaderMaxDCAV0andBach,
-                                                  Double_t lCascaderMinCosAngle,
-                                                  Double_t lCascaderMinRadius,
-                                                  Double_t lCascaderMaxRadius,
-                                                  Float_t sigmaRangeTPC,
-                                                  const char *name);
+                                           Bool_t lRunVertexers, //to rerun the cascade vertexers
+                                           Bool_t lUseLightVertexer, //use light cascade vertexer
+                                           Bool_t lUseOnTheFlyV0Cascading,
+                                           Bool_t lguard_CheckTrackQuality,
+                                           Bool_t lguard_CheckCascadeQuality,
+                                           Bool_t lguard_CheckTPCPID,
+                                           Double_t lV0MaxChi2,
+                                           Double_t lV0minDCAfirst,
+                                           Double_t lV0minDCAsecond,
+                                           Double_t lV0maxDCAdaughters,
+                                           Double_t lV0minCosAngle,
+                                           Double_t lV0minRadius,
+                                           Double_t lV0maxRadius,
+                                           Double_t lCascaderMaxChi2,
+                                           Double_t lCascaderV0MinImpactParam,
+                                           Double_t lCascaderV0MassWindow,
+                                           Double_t lCascaderBachMinImpactParam,
+                                           Double_t lCascaderMaxDCAV0andBach,
+                                           Double_t lCascaderMinCosAngle,
+                                           Double_t lCascaderMinRadius,
+                                           Double_t lCascaderMaxRadius,
+                                           Float_t sigmaRangeTPC,
+                                           Float_t lOmegaCleanMassWindow,
+                                           const char *name);
     AliAnalysisTaskStrangeCascadesDiscrete(const AliAnalysisTaskStrangeCascadesDiscrete&);
     AliAnalysisTaskStrangeCascadesDiscrete& operator =(const AliAnalysisTaskStrangeCascadesDiscrete&);
     virtual ~AliAnalysisTaskStrangeCascadesDiscrete();
@@ -531,14 +469,13 @@ public:
     Bool_t GoodESDEvent(AliESDEvent* lESDevent, const AliESDVertex *lPrimaryBestESDVtx,AliESDtrackCuts* esdtrackcuts1);
     Bool_t GoodESDTrack(AliESDtrack* trackESD, Double_t raprange, Double_t etarange);
     Int_t GetITSstatus(AliESDtrack* esdtrack, Int_t layer) const;
-    Bool_t ExtraCleanupCascade(AliESDcascade* Xi,AliESDtrack* gPtrack,AliESDtrack* gNtrack,AliESDtrack* gBtrack,Double_t Omegamasswindow,Double_t Ximasswindow);
+    Bool_t ExtraCleanupCascade(AliESDcascade* Xi,AliESDtrack* gPtrack,AliESDtrack* gNtrack,AliESDtrack* gBtrack,Double_t Omegamasswindow);
     Bool_t GoodCandidatesTPCPID(AliESDtrack* pTrackXi, AliESDtrack* nTrackXi, AliESDtrack* bachTrackXi, Float_t sigmamax);
-   // Int_t TPCPIDlogArray(AliESDtrack* pTrackXi, AliESDtrack* nTrackXi, AliESDtrack* bachTrackXi);
-                               
-                               
     
-   
-    ClassDef(AliAnalysisTaskStrangeCascadesDiscrete, 1);
+    
+    
+    
+    ClassDef(AliAnalysisTaskStrangeCascadesDiscrete, 2);
 };
 
 

--- a/PWGLF/STRANGENESS/Cascades/Run2/macros/AddTaskStrangeCascadesDiscrete.C
+++ b/PWGLF/STRANGENESS/Cascades/Run2/macros/AddTaskStrangeCascadesDiscrete.C
@@ -23,6 +23,7 @@ AliAnalysisTaskStrangeCascadesDiscrete *AddTaskStrangeCascadesDiscrete(
                                                                        Double_t lCascaderMinRadius = 0.4, //0.4 per def
                                                                        Double_t lCascaderMaxRadius =100., //100. per def
                                                                        Float_t sigmaRangeTPC = 3.,
+                                                                       Float_t lOmegaCleanMassWindow = 0.1,
                                                                        TString lExtraOutputName = ""
                                                                        )
 {
@@ -67,7 +68,7 @@ AliAnalysisTaskStrangeCascadesDiscrete *AddTaskStrangeCascadesDiscrete(
                                                lCascaderMaxDCAV0andBach,
                                                lCascaderMinCosAngle,
                                                lCascaderMinRadius,
-                                               lCascaderMaxRadius, sigmaRangeTPC, "taskAuxiliary");  // const*charname =  Form("taskAuxiliary%s",lExtraOutputName.Data())
+                                               lCascaderMaxRadius, sigmaRangeTPC,lOmegaCleanMassWindow, "taskAuxiliary");  // const*charname =  Form("taskAuxiliary%s",lExtraOutputName.Data())
     
     mgr->AddTask(taskAuxiliary);
     

--- a/PWGLF/STRANGENESS/PWGLFSTRANGENESSLinkDef.h
+++ b/PWGLF/STRANGENESS/PWGLFSTRANGENESSLinkDef.h
@@ -34,6 +34,8 @@
 #pragma link C++ class AliAnalysisTaskStrangenessVsMultiplicityMCRun2+;
 #pragma link C++ class AliAnalysisTaskStrangenessVsMultiplicityRun2pPb+;
 #pragma link C++ class AliAnalysisTaskStrangenessVsMultiplicityMCRun2pPb+;
+#pragma link C++ class AliRunningCascadeCandidate+;
+#pragma link C++ class AliRunningCascadeEvent+;
 #pragma link C++ class AliAnalysisTaskStrangeCascadesDiscrete+;
 #pragma link C++ class AliAnalysisTaskPPVsMultCrossCheckMC+;
 #pragma link C++ class AliAnalysisTaskpANormalizationCheckMC+;
@@ -62,6 +64,8 @@
 #pragma link C++ class Lifetimes::HyperTriton2Body+;
 #pragma link C++ class std::vector<Lifetimes::HyperTriton2Body>+;
 #pragma link C++ class Lifetimes::MiniEvent+;
+//#pragma link C++ class AliRunningCascadeEvent+;
+//#pragma link C++ class AliRunningCascadeTrack+;
 #endif
 
 #ifdef __CLING__


### PR DESCRIPTION
1. Complementary classes (AliRunningCascadeEvent & AliRunningCascadeCandidate) are added to the PWGLFSTRANGENESSLinkDef.h
2. The Cascade z-component of DCA to the primary vertex is not saved any longer. Transverse component is enough.
3. TOF signal is stored as a float variable.
4. Cascade selection "clean up" (mass window) is added, this will reduce the output.