### PR TITLE
Automatic configuration of the energy smearing

### DIFF
--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerKernel.h
@@ -175,6 +175,12 @@ public:
   double GetDataGridDimensionRows() const;
 
   /**
+   * @brief Check whether smear model has already been provided
+   * @return True if mean and width parameterizations are set, false otherwise
+   */
+  bool HasSmearModel() const { return fSmearModelMean && fSmearModelSigma; }
+
+  /**
    * @brief Define whether running on MC or not (for offset)
    * @param isMC Flag for MC
    */

--- a/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.h
+++ b/PWG/EMCAL/EMCALtrigger/AliEmcalTriggerMakerTask.h
@@ -208,6 +208,12 @@ public:
    */
   void SetUseL0Amplitudes(Bool_t b)        { fUseL0Amplitudes = b           ; }
 
+  /**
+   * @brief Switch for smearing mode
+   * @param doRun If true also the smeared patch energy is calculated
+   */
+  void SetRunSmearing(Bool_t doRun) { fRunSmearing = doRun; }
+
 protected:
 
 #if !(defined(__CINT__) || defined(__MAKECINT__))
@@ -284,6 +290,19 @@ protected:
    */
   void InitializeFastORMaskingFromOADB();
 
+  /**
+   * @brief Initialise smearing parameters for generated FastOR ADCs
+   * 
+   * The smear model is used to generate FastOR ADC signals calculated
+   * from the FEE energy using the energy resolution at FastOR level
+   * obtained from data. A gaussian distribution with the mean and 
+   * the width taken from the smear model for a given energy is used
+   * to calculate the smeared energy. The smearing is particularly important
+   * when running on MC in order to properly describe the turnon observed
+   * in data.
+   */
+  void InitializeSmearModel();
+
   AliEmcalTriggerMakerKernel              *fTriggerMaker;             ///< The actual trigger maker kernel
   AliVVZERO                               *fV0;                       //!<! VZERO data
 
@@ -295,6 +314,7 @@ protected:
   Bool_t                                  fLoadFastORMaskingFromOCDB; ///< Load FastOR masking from the OCDB
   TClonesArray                            *fCaloTriggersOut;          //!<! trigger array out
 
+  Bool_t                                  fRunSmearing;               ///< Also calculate smeared patch energy based on FastOR energy resolution
   Bool_t                                  fDoQA;                      ///< Fill QA histograms
   THistManager                            *fQAHistos;                 //!<! Histograms for QA
 


### PR DESCRIPTION
Users no longer need to configure a smear model
by hand if they want to use a smeared patch energy
calculated from the FEE energy with the same
resolution as in data. The smearing is automatically
activated in data and MC. Currently the default
smearing is used - custom smear models would still
work.