### PR TITLE
PWGHF: Apply ML decision on GRID for TTreeCreator

### DIFF
--- a/PWGHF/vertexingHF/macros/AddTaskHFTreeCreatorApply.C
+++ b/PWGHF/vertexingHF/macros/AddTaskHFTreeCreatorApply.C
@@ -1,0 +1,151 @@
+AliAnalysisTaskSEHFTreeCreatorApply *AddTaskHFTreeCreatorApply(Bool_t readMC=kFALSE,
+                                                               Int_t system=0 /*0=pp,1=PbPb*/,
+                                                               TString finDirname="HFTreeCreator",
+                                                               TString cutsfile="",
+                                                               TString confFileML = "",
+                                                               Int_t AODProtection = 1,
+                                                               Bool_t writeOnlySignalTree=kFALSE,
+                                                               Bool_t fillMGgenTrees=kFALSE,
+                                                               Int_t fillTreeDs=0,
+                                                               Int_t fillTreeLc2V0bachelor=0,
+                                                               Int_t pidOpt=AliHFTreeHandlerApply::kNsigmaPID,
+                                                               Int_t singletrackvarsopt=AliHFTreeHandlerApply::kRedSingleTrackVars)
+{
+  //
+  //
+  
+  if(fillTreeDs && fillTreeLc2V0bachelor && confFileML != ""){
+    ::Error("AddTaskHFTreeCreatorApply", "Not possible to enable more than one hadron when applying.");
+    return NULL;
+  }
+  
+  // Get the pointer to the existing analysis manager via the static access method.
+  //==============================================================================
+  AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
+  if (!mgr) {
+    ::Error("AddTaskHFTreeCreatorApply", "No analysis manager to connect to.");
+    return NULL;
+  }
+  
+  //getting the cuts
+  TFile* filecuts;
+  if( cutsfile.EqualTo("") ) {
+    ::Fatal("AddTaskHFTreeCreatorApply", "Input file not provided");
+  } else {
+    filecuts=TFile::Open(cutsfile.Data());
+    if(!filecuts || (filecuts && !filecuts->IsOpen())){
+      ::Fatal("AddTaskHFTreeCreatorApply", "Input file not found : check your cut object");
+    }
+  }
+  
+  AliRDHFCutsDstoKKpi*     looseCutsDstoKKpi       =(AliRDHFCutsDstoKKpi*)filecuts->Get("DstoKKpiFilteringCuts");
+  if(!looseCutsDstoKKpi && fillTreeDs)        ::Fatal("AddTaskHFTreeCreatorApply", "looseCutsDstoKKpi : check your cut file");
+  AliRDHFCutsLctoV0* looseCutsLc2V0bachelor        =(AliRDHFCutsLctoV0*)filecuts->Get("Lc2V0bachelorFilteringCuts");
+  if(!looseCutsLc2V0bachelor && fillTreeLc2V0bachelor)    ::Fatal("AddTaskHFTreeCreatorApply", "looseCutsLc2V0bachelor : check your cut file");
+  AliRDHFCutsDstoKKpi*     analysisCutsDstoKKpi    =(AliRDHFCutsDstoKKpi*)filecuts->Get("DstoKKpiAnalysisCuts");
+  if(!analysisCutsDstoKKpi && fillTreeDs)     ::Fatal("AddTaskHFTreeCreatorApply", "analysisCutsDstoKKpi : check your cut file");
+  AliRDHFCutsLctoV0* analysisCutsLc2V0bachelor=(AliRDHFCutsLctoV0*)filecuts->Get("Lc2V0bachelorAnalysisCuts");
+  if(!analysisCutsLc2V0bachelor && fillTreeLc2V0bachelor) ::Fatal("AddTaskHFTreeCreatorApply", "analysisCutsLc2V0bachelor : check your cut file");
+  
+  TList *cutsList=new TList();
+  cutsList->SetOwner(kTRUE);
+  cutsList->SetName("cut_objects");
+  cutsList->Add(looseCutsDstoKKpi);
+  cutsList->Add(looseCutsLc2V0bachelor);
+  cutsList->Add(analysisCutsDstoKKpi);
+  cutsList->Add(analysisCutsLc2V0bachelor);
+  
+  AliAnalysisTaskSEHFTreeCreatorApply *task = new AliAnalysisTaskSEHFTreeCreatorApply("TreeCreatorTask",cutsList);
+  
+  task->SetReadMC(readMC);
+  if(readMC) {
+    task->SetFillMCGenTrees(fillMGgenTrees);
+  }
+  task->SetSystem(system);
+  task->SetAODMismatchProtection(AODProtection);
+  task->SetWriteOnlySignalTree(writeOnlySignalTree);
+  task->SetFillDsTree(fillTreeDs);
+  task->SetFillLc2V0bachelorTree(fillTreeLc2V0bachelor);
+  task->SetPIDoptDsTree(pidOpt);
+  task->SetPIDoptLc2V0bachelorTree(pidOpt);
+  task->SetTreeSingleTrackVarsOpt(singletrackvarsopt);
+
+  task->SetMLConfigFile(confFileML);
+  //task->SetDebugLevel(4);
+  
+  mgr->AddTask(task);
+  
+  // Create containers for input/output
+  
+  TString inname = "cinput";
+  TString histoname = "coutputEntries";
+  TString countername = "coutputNormCounterHisto";
+  TString cutsname = "coutputCuts";
+  TString normname = "coutputNorm";
+  TString treeevcharname = "coutputTreeEvChar";
+  TString treeDsname = "coutputTreeDs";
+  TString treeLc2V0bachelorname = "coutputTreeLc2V0bachelor";
+  TString treeGenDsname = "coutputTreeGenDs";
+  TString treeGenLc2V0bachelorname = "coutputTreeGenLc2V0bachelor";
+  
+  inname += finDirname.Data();
+  histoname += finDirname.Data();
+  countername += finDirname.Data();
+  cutsname += finDirname.Data();
+  normname += finDirname.Data();
+  treeevcharname += finDirname.Data();
+  treeDsname += finDirname.Data();
+  treeLc2V0bachelorname += finDirname.Data();
+  treeGenDsname += finDirname.Data();
+  treeGenLc2V0bachelorname += finDirname.Data();
+  
+  AliAnalysisDataContainer *cinput = mgr->CreateContainer(inname,TChain::Class(),AliAnalysisManager::kInputContainer);
+  TString outputfile = AliAnalysisManager::GetCommonFileName();
+  outputfile += ":PWGHF_TreeCreatorApply";
+  
+  AliAnalysisDataContainer *coutputEntries = mgr->CreateContainer(histoname,TH1F::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
+  AliAnalysisDataContainer *coutputCounter = mgr->CreateContainer(countername,TH2F::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
+  AliAnalysisDataContainer *coutputCuts    = mgr->CreateContainer(cutsname,TList::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
+  AliAnalysisDataContainer *coutputNorm    = mgr->CreateContainer(normname,TList::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
+  AliAnalysisDataContainer *coutputTreeEvChar    = mgr->CreateContainer(treeevcharname,TTree::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
+  
+  AliAnalysisDataContainer *coutputTreeDs = 0x0;
+  AliAnalysisDataContainer *coutputTreeGenDs = 0x0;
+  AliAnalysisDataContainer *coutputTreeLc2V0bachelor = 0x0;
+  AliAnalysisDataContainer *coutputTreeGenLc2V0bachelor = 0x0;
+
+  if(fillTreeDs) {
+    coutputTreeDs = mgr->CreateContainer(treeDsname,TTree::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
+    coutputTreeDs->SetSpecialOutput();
+    if(readMC && fillMGgenTrees) {
+      coutputTreeGenDs = mgr->CreateContainer(treeGenDsname,TTree::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
+      coutputTreeGenDs->SetSpecialOutput();
+    }
+  }
+  
+  if(fillTreeLc2V0bachelor) {
+    coutputTreeLc2V0bachelor = mgr->CreateContainer(treeLc2V0bachelorname,TTree::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
+    coutputTreeLc2V0bachelor->SetSpecialOutput();
+    if(readMC && fillMGgenTrees) {
+      coutputTreeGenLc2V0bachelor = mgr->CreateContainer(treeGenLc2V0bachelorname,TTree::Class(),AliAnalysisManager::kOutputContainer,outputfile.Data());
+      coutputTreeGenLc2V0bachelor->SetSpecialOutput();
+    }
+  }
+  
+  mgr->ConnectInput(task,0,mgr->GetCommonInputContainer());
+  mgr->ConnectOutput(task,1,coutputEntries);
+  mgr->ConnectOutput(task,2,coutputCounter);
+  mgr->ConnectOutput(task,3,coutputCuts);
+  mgr->ConnectOutput(task,4,coutputNorm);
+  mgr->ConnectOutput(task,5,coutputTreeEvChar);
+  if(fillTreeDs) {
+    mgr->ConnectOutput(task,6,coutputTreeDs);
+    if(readMC && fillMGgenTrees) mgr->ConnectOutput(task,7,coutputTreeGenDs);
+  }
+  if(fillTreeLc2V0bachelor) {
+    mgr->ConnectOutput(task,8,coutputTreeLc2V0bachelor);
+    if(readMC && fillMGgenTrees) mgr->ConnectOutput(task,9,coutputTreeGenLc2V0bachelor);
+  }
+  
+  return task;
+}

--- a/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEHFTreeCreatorApply.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEHFTreeCreatorApply.cxx
@@ -1,0 +1,1411 @@
+/**************************************************************************
+ * Copyright(c) 1998-2009, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: The ALICE Off-line Project.                                    *
+ * Contributors are mentioned in the code where appropriate.              *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+/* $Id$ */
+
+/////////////////////////////////////////////////////////////
+//
+// \authors:
+// L. Vermunt, luuk.vermunt@cern.ch
+////////////////////////////////////////////////////////////
+
+#include <Riostream.h>
+#include <TProcessID.h>
+#include <TClonesArray.h>
+#include <TCanvas.h>
+#include <TNtuple.h>
+#include <TTree.h>
+#include <TList.h>
+#include <TFile.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TDatabasePDG.h>
+#include <THnSparse.h>
+#include <TRandom3.h>
+#include <AliAnalysisDataSlot.h>
+#include <AliAnalysisDataContainer.h>
+#include "TChain.h"
+#include "AliVertexingHFUtils.h"
+#include "AliAnalysisManager.h"
+#include "AliESDtrack.h"
+#include "AliVertexerTracks.h"
+#include "AliAODHandler.h"
+#include "AliVEvent.h"
+#include "AliAODEvent.h"
+#include "AliAODVertex.h"
+#include "AliAODTrack.h"
+#include "AliMCEvent.h"
+#include "AliHeader.h"
+#include "AliExternalTrackParam.h"
+#include "AliAODMCHeader.h"
+#include "AliAODMCParticle.h"
+#include "AliAODRecoDecay.h"
+#include "AliAODRecoDecayHF2Prong.h"
+#include "AliAODRecoDecayHF3Prong.h"
+#include "AliAODRecoCascadeHF.h"
+#include "AliAnalysisVertexingHF.h"
+#include "AliNormalizationCounter.h"
+#include "AliInputEventHandler.h"
+#include "AliAnalysisTaskSE.h"
+#include "AliHFTreeHandlerApply.h"
+#include "AliHFTreeHandlerApplyDstoKKpi.h"
+#include "AliHFTreeHandlerApplyLc2V0bachelor.h"
+#include "AliHFMLResponseDstoKKpi.h"
+#include "AliHFMLResponseLctoV0bachelor.h"
+#include "AliAnalysisTaskSEHFTreeCreatorApply.h"
+#include "AliAODPidHF.h"
+#include "AliESDUtils.h"
+#include "AliMultSelection.h"
+
+#include "AliCDBManager.h"
+#include "AliCDBEntry.h"
+#include "AliTriggerConfiguration.h"
+#include "AliTriggerInput.h"
+
+using std::cout;
+using std::endl;
+
+/// \cond CLASSIMP
+ClassImp(AliAnalysisTaskSEHFTreeCreatorApply);
+/// \endcond
+
+//________________________________________________________________________
+AliAnalysisTaskSEHFTreeCreatorApply::AliAnalysisTaskSEHFTreeCreatorApply():
+AliAnalysisTaskSEHFTreeCreatorApply("", nullptr)
+{
+
+  /// Default constructor
+
+}
+//________________________________________________________________________
+AliAnalysisTaskSEHFTreeCreatorApply::AliAnalysisTaskSEHFTreeCreatorApply(const char *name, TList *cutsList):
+AliAnalysisTaskSE(name),
+fEventNumber(0),
+fNentries(0x0),
+fHistoNormCounter(0x0),
+fListCounter(0x0),
+fCounter(0x0),
+fListCuts(cutsList),
+fFiltCutsDstoKKpi(0x0),
+fFiltCutsLc2V0bachelor(0x0),
+fCutsDstoKKpi(0x0),
+fCutsLc2V0bachelor(0x0),
+fEvSelectionCuts(0x0),
+fReadMC(0),
+fUseSelectionBit(kTRUE),
+fSys(0),
+fAODProtection(1),
+fWriteOnlySignal(kFALSE),
+fFillMCGenTrees(kTRUE),
+fWriteVariableTreeDs(0),
+fWriteVariableTreeLc2V0bachelor(0),
+fVariablesTreeDs(0x0),
+fVariablesTreeLc2V0bachelor(0x0),
+fGenTreeDs(0x0),
+fGenTreeLc2V0bachelor(0x0),
+fTreeEvChar(0x0),
+fTreeHandlerDs(0x0),
+fTreeHandlerLc2V0bachelor(0x0),
+fTreeHandlerGenDs(0x0),
+fTreeHandlerGenLc2V0bachelor(0x0),
+fPIDresp(0x0),
+fPIDoptDs(AliHFTreeHandlerApply::kRawAndNsigmaPID),
+fPIDoptLc2V0bachelor(AliHFTreeHandlerApply::kRawAndNsigmaPID),
+fEventID(0),
+fFileName(""),
+fDirNumber(0),
+fCentrality(-999.),
+fzVtxReco(0.),
+fzVtxGen(0.),
+fNcontributors(0),
+fNtracks(0),
+fIsEvRej(0),
+fIsEvRej_INT7(0),
+fIsEvRej_HighMultSPD(0),
+fIsEvRej_HighMultV0(0),
+fRunNumber(0),
+fRunNumberCDB(0),
+fnTracklets(0),
+fnTrackletsCorr(0),
+fnTrackletsCorrSHM(0),
+fnV0A(0),
+fMultGen(0),
+fMultGenV0A(0),
+fMultGenV0C(0),
+fTriggerMask(0),
+fTriggerOnlineINT7(false),
+fTriggerOnlineHighMultSPD(false),
+fTriggerOnlineHighMultV0(false),
+fTriggerBitINT7(false),
+fTriggerBitHighMultSPD(false),
+fTriggerBitHighMultV0(false),
+fTriggerBitCentral(false),
+fTriggerBitSemiCentral(false),
+fTriggerClasses(""),
+fTriggerClassINT7(false),
+fTriggerClassHighMultSPD(false),
+fTriggerClassHighMultV0m(false),
+fnV0M(0),
+fnV0MEq(0),
+fnV0MCorr(0),
+fnV0MEqCorr(0),
+fPercV0M(0.),
+fMultV0M(0.),
+fRefMult(9.26),
+fRefMultSHM(9.26),
+fMultEstimatorAvg(),
+fMultEstimatorAvgSHM(),
+fCorrNtrVtx(false),
+fCorrV0MVtx(false),
+fCdbEntry(nullptr),
+fDsMassKKOpt(1),
+fLc2V0bachelorCalcSecoVtx(0),
+fV0typeForLc2V0bachelor(1),
+fTreeSingleTrackVarsOpt(AliHFTreeHandlerApply::kRedSingleTrackVars),
+fGoodTrackFilterBit(-1),
+fGoodTrackEtaRange(999.),
+fGoodTrackMinPt(0.),
+fITSUpgradeStudy(0),
+fEnableNsigmaTPCDataCorr(false),
+fSystemForNsigmaTPCDataCorr(AliAODPidHF::kNone),
+fApplyPhysicsSelOnline(false),
+fEnableEventDownsampling(false),
+fFracToKeepEventDownsampling(1.1),
+fSeedEventDownsampling(0),
+fConfigPath(""),
+fMLResponse(0x0)
+{
+
+  if (fListCuts) {
+    fFiltCutsDstoKKpi     =(AliRDHFCutsDstoKKpi*)fListCuts->FindObject("DstoKKpiFilteringCuts");
+    fFiltCutsLc2V0bachelor=(AliRDHFCutsLctoV0*)fListCuts->FindObject("Lc2V0bachelorFilteringCuts");
+    fCutsDstoKKpi         =(AliRDHFCutsDstoKKpi*)fListCuts->FindObject("DstoKKpiAnalysisCuts");
+    fCutsLc2V0bachelor    =(AliRDHFCutsLctoV0*)fListCuts->FindObject("Lc2V0bachelorAnalysisCuts");
+
+    if(fWriteVariableTreeDs) fEvSelectionCuts = (AliRDHFCuts*)fFiltCutsDstoKKpi->Clone();
+    else if(fWriteVariableTreeLc2V0bachelor) fEvSelectionCuts = (AliRDHFCuts*)fFiltCutsLc2V0bachelor->Clone();
+    else {
+      if(fWriteVariableTreeDs) fEvSelectionCuts = (AliRDHFCuts*)fFiltCutsDstoKKpi->Clone();
+      else if(fFiltCutsLc2V0bachelor) fEvSelectionCuts = (AliRDHFCuts*)fFiltCutsLc2V0bachelor->Clone();
+      else printf("AliAnalysisTaskSEHFTreeCreatorApply:: Constructor: No event selection cuts could be stored, code will crash!\n");
+    }
+  }
+
+  DefineInput(0, TChain::Class());
+  // Output slot #1 writes into a TH1F container (number of events)
+  DefineOutput(1,TH1F::Class());
+  // Output slot #2 writes into a TH2F container (number of events)
+  DefineOutput(2,TH2F::Class());
+  // Output slot #3 writes into a TList container (cuts)
+  DefineOutput(3,TList::Class());
+  // Output slot #4 writes Normalization Counter
+  DefineOutput(4,TList::Class());
+  // Output slot #5 stores the tree of the event-characterisation variables
+  DefineOutput(5,TTree::Class());
+  // Output slot #6 stores the tree of the Ds+ candidate variables after track selection
+  DefineOutput(6,TTree::Class());
+  // Output slot #7 stores the tree of the gen Ds+ variables
+  DefineOutput(7,TTree::Class());
+  // Output slot #8 stores the tree of the Lc2V0bachelor candidate variables after track selection
+  DefineOutput(8,TTree::Class());
+  // Output slot #9 stores the tree of the gen Lc2V0bachelor variables
+  DefineOutput(9,TTree::Class());
+
+}
+
+//________________________________________________________________________
+AliAnalysisTaskSEHFTreeCreatorApply::~AliAnalysisTaskSEHFTreeCreatorApply()
+{
+  delete fListCuts;
+  delete fFiltCutsDstoKKpi;
+  delete fFiltCutsLc2V0bachelor;
+  delete fCutsDstoKKpi;
+  delete fCutsLc2V0bachelor;
+  delete fEvSelectionCuts;
+  delete fNentries;
+  delete fHistoNormCounter;
+  delete fListCounter;
+  delete fCounter;
+  delete fTreeHandlerDs;
+  delete fTreeHandlerLc2V0bachelor;
+
+  delete fTreeHandlerGenDs;
+  delete fTreeHandlerGenLc2V0bachelor;
+  delete fTreeEvChar;
+  
+  delete fMLResponse;
+}
+
+//________________________________________________________________________
+void AliAnalysisTaskSEHFTreeCreatorApply::Init()
+{
+  /// Initialization
+
+  if(fDebug > 1) printf("AliAnalysisTaskSEHFTreeCreatorApply::Init() \n");
+
+  AliInfo(Form(" Resetting NsigmaDataDrivenCorrection of cutobjects to %d for system %d \n", fEnableNsigmaTPCDataCorr,fSystemForNsigmaTPCDataCorr));
+  if(fFiltCutsDstoKKpi) fFiltCutsDstoKKpi->EnableNsigmaDataDrivenCorrection(fEnableNsigmaTPCDataCorr,fSystemForNsigmaTPCDataCorr);
+  if(fFiltCutsLc2V0bachelor) fFiltCutsLc2V0bachelor->EnableNsigmaDataDrivenCorrection(fEnableNsigmaTPCDataCorr,fSystemForNsigmaTPCDataCorr);
+  if(fCutsDstoKKpi) fCutsDstoKKpi->EnableNsigmaDataDrivenCorrection(fEnableNsigmaTPCDataCorr,fSystemForNsigmaTPCDataCorr);
+  if(fCutsLc2V0bachelor) fCutsLc2V0bachelor->EnableNsigmaDataDrivenCorrection(fEnableNsigmaTPCDataCorr,fSystemForNsigmaTPCDataCorr);
+  
+  PostData(3,fListCuts);
+
+  return;
+}
+
+//________________________________________________________________________
+void AliAnalysisTaskSEHFTreeCreatorApply::UserCreateOutputObjects()
+{
+
+  /// Create the output container
+
+  if(fDebug > 1) printf("AliAnalysisTaskSEHFTreeCreatorApply::UserCreateOutputObjects() \n");
+
+  const char* nameoutput=GetOutputSlot(1)->GetContainer()->GetName();
+  fNentries=new TH1F(nameoutput, "Number of events", 44,-0.5,43.5);
+  fNentries->GetXaxis()->SetBinLabel(1,"n. evt. read");
+  fNentries->GetXaxis()->SetBinLabel(2,"n. evt. matched dAOD");
+  fNentries->GetXaxis()->SetBinLabel(3,"n. evt. mismatched dAOD");
+  fNentries->GetXaxis()->SetBinLabel(4,"n. evt. analised");
+  fNentries->GetXaxis()->SetBinLabel(5,"n. evt. passing IsEvSelected (including pileup)");
+  fNentries->GetXaxis()->SetBinLabel(6,"n. evt. rejected due to trigger");
+  fNentries->GetXaxis()->SetBinLabel(7,"n. evt. rejected due to not reco vertex");
+  fNentries->GetXaxis()->SetBinLabel(8,"n. evt. rejected for contr vertex");
+  fNentries->GetXaxis()->SetBinLabel(9,"n. evt. rejected for vertex out of accept");
+  fNentries->GetXaxis()->SetBinLabel(10,"n. evt. rejected for pileup events");
+  fNentries->GetXaxis()->SetBinLabel(11,"n. evt. of out centrality events");
+  fNentries->GetXaxis()->SetBinLabel(12,"n. of 2 prong candidates");
+  fNentries->GetXaxis()->SetBinLabel(13,"n. D0 after filtering");
+  fNentries->GetXaxis()->SetBinLabel(14,"n. D0 after selection");
+  fNentries->GetXaxis()->SetBinLabel(15,"n. of not on-the-fly rec D0");
+  fNentries->GetXaxis()->SetBinLabel(16,"n. of 3 prong candidates");
+  fNentries->GetXaxis()->SetBinLabel(17,"n. Ds after filtering");
+  fNentries->GetXaxis()->SetBinLabel(18,"n. Ds after selection");
+  fNentries->GetXaxis()->SetBinLabel(19,"n. of not on-the-fly rec Ds");
+  fNentries->GetXaxis()->SetBinLabel(20,"n. Dplus after filtering");
+  fNentries->GetXaxis()->SetBinLabel(21,"n. Dplus after selection");
+  fNentries->GetXaxis()->SetBinLabel(22,"n. of not on-the-fly rec Dplus");
+  fNentries->GetXaxis()->SetBinLabel(23,"n. LctopKpi after filtering");
+  fNentries->GetXaxis()->SetBinLabel(24,"n. LctopKpi after selection");
+  fNentries->GetXaxis()->SetBinLabel(25,"n. of not on-the-fly rec LctopKpi");
+  fNentries->GetXaxis()->SetBinLabel(26,"n. Bplus D0's after filtering");
+  fNentries->GetXaxis()->SetBinLabel(27,"n. Bplus after selection");
+  fNentries->GetXaxis()->SetBinLabel(28,"n. of not on-the-fly rec Bplus");
+  fNentries->GetXaxis()->SetBinLabel(29,"n. of Dstar candidates");
+  fNentries->GetXaxis()->SetBinLabel(30,"n. Dstar after filtering");
+  fNentries->GetXaxis()->SetBinLabel(31,"n. Dstar after selection");
+  fNentries->GetXaxis()->SetBinLabel(32,"n. of not on-the-fly rec Dstar");
+  fNentries->GetXaxis()->SetBinLabel(33,"n. of cascade candidates");
+  fNentries->GetXaxis()->SetBinLabel(34,"n. Lc2V0bachelor after filtering");
+  fNentries->GetXaxis()->SetBinLabel(35,"n. Lc2V0bachelor after selection");
+  fNentries->GetXaxis()->SetBinLabel(36,"n. of not on-the-fly rec Lc2V0bachelor");
+  fNentries->GetXaxis()->SetBinLabel(37,"n. Bs Ds's after filtering");
+  fNentries->GetXaxis()->SetBinLabel(38,"n. Bs after selection");
+  fNentries->GetXaxis()->SetBinLabel(39,"n. of not on-the-fly rec Bs");
+  fNentries->GetXaxis()->SetBinLabel(40,"n. Lb Lc's after filtering");
+  fNentries->GetXaxis()->SetBinLabel(41,"n. Lb after selection");
+  fNentries->GetXaxis()->SetBinLabel(42,"n. of not on-the-fly rec Lb");
+  
+  nameoutput=GetOutputSlot(2)->GetContainer()->GetName();
+  fHistoNormCounter=new TH2F(nameoutput, "Number of events for norm;;centrality", 5,-0.5,4.5,102,-1.,101.);
+  fHistoNormCounter->GetXaxis()->SetBinLabel(1,"n. evt. w primary V");
+  fHistoNormCounter->GetXaxis()->SetBinLabel(2,"n. evt. w/o primary V");
+  fHistoNormCounter->GetXaxis()->SetBinLabel(3,"n. evt. w primary V z>10cm");
+  fHistoNormCounter->GetXaxis()->SetBinLabel(4,"n. evt. for norm.");
+  fHistoNormCounter->GetXaxis()->SetBinLabel(5,"n. evt. pileup");
+  
+  fListCounter=new TList();
+  fListCounter->SetOwner(kTRUE);
+  fListCounter->SetName("NormCounter");
+  fCounter = new AliNormalizationCounter("norm_counter");
+  fCounter->Init();
+  fListCounter->Add(fCounter);
+  
+  //count number of enabled trees
+  Int_t nEnabledTrees = 1; // event tree always enabled
+  if(fWriteVariableTreeDs) nEnabledTrees++;
+  if(fWriteVariableTreeLc2V0bachelor) nEnabledTrees++;
+  if(fReadMC && fFillMCGenTrees) {
+    nEnabledTrees = (nEnabledTrees-1)*2+1;
+  }
+  
+  //
+  // Output slot 4-9 : trees of the candidate and event-characterization variables
+  //
+  OpenFile(5);
+  fTreeEvChar = new TTree("tree_event_char","tree_event_char");
+  //set variables
+  fTreeEvChar->Branch("centrality", &fCentrality);
+  fTreeEvChar->Branch("z_vtx_reco", &fzVtxReco);
+  fTreeEvChar->Branch("n_vtx_contributors", &fNcontributors);
+  fTreeEvChar->Branch("n_tracks", &fNtracks);
+  fTreeEvChar->Branch("is_ev_rej", &fIsEvRej);
+  fTreeEvChar->Branch("is_ev_rej_INT7", &fIsEvRej_INT7);
+  fTreeEvChar->Branch("is_ev_rej_HighMultSPD", &fIsEvRej_HighMultSPD);
+  fTreeEvChar->Branch("is_ev_rej_HighMultV0", &fIsEvRej_HighMultV0);
+  fTreeEvChar->Branch("run_number", &fRunNumber);
+  fTreeEvChar->Branch("ev_id", &fEventID);
+  fTreeEvChar->Branch("n_tracklets", &fnTracklets);
+  fTreeEvChar->Branch("V0Amult", &fnV0A);
+  fTreeEvChar->Branch("trigger_bitmap", &fTriggerMask);
+  fTreeEvChar->Branch("trigger_online_INT7", &fTriggerOnlineINT7);
+  fTreeEvChar->Branch("trigger_online_HighMultSPD", &fTriggerOnlineHighMultSPD);
+  fTreeEvChar->Branch("trigger_online_HighMultV0", &fTriggerOnlineHighMultV0);
+  fTreeEvChar->Branch("trigger_hasbit_INT7", &fTriggerBitINT7);
+  fTreeEvChar->Branch("trigger_hasbit_HighMultSPD", &fTriggerBitHighMultSPD);
+  fTreeEvChar->Branch("trigger_hasbit_HighMultV0", &fTriggerBitHighMultV0);
+  fTreeEvChar->Branch("trigger_hasbit_Central", &fTriggerBitCentral);
+  fTreeEvChar->Branch("trigger_hasbit_SemiCentral", &fTriggerBitSemiCentral);
+  fTreeEvChar->Branch("trigger_classes", &fTriggerClasses);
+  fTreeEvChar->Branch("trigger_hasclass_INT7", &fTriggerClassINT7);
+  fTreeEvChar->Branch("trigger_hasclass_HighMultSPD", &fTriggerClassHighMultSPD);
+  fTreeEvChar->Branch("trigger_hasclass_HighMultV0", &fTriggerClassHighMultV0m);
+  fTreeEvChar->Branch("z_vtx_gen", &fzVtxGen);
+  fTreeEvChar->Branch("n_tracklets_corr", &fnTrackletsCorr);
+  fTreeEvChar->Branch("n_tracklets_corr_shm", &fnTrackletsCorrSHM);
+  fTreeEvChar->Branch("v0m", &fnV0M);
+  fTreeEvChar->Branch("v0m_eq", &fnV0MEq);
+  fTreeEvChar->Branch("v0m_corr", &fnV0MCorr);
+  fTreeEvChar->Branch("v0m_eq_corr", &fnV0MEqCorr);
+  fTreeEvChar->Branch("mult_gen", &fMultGen);
+  fTreeEvChar->Branch("mult_gen_v0a", &fMultGenV0A);
+  fTreeEvChar->Branch("mult_gen_v0c", &fMultGenV0C);
+  fTreeEvChar->Branch("perc_v0m", &fPercV0M);
+  fTreeEvChar->Branch("mult_v0m", &fMultV0M);
+  fTreeEvChar->SetMaxVirtualSize(1.e+8/nEnabledTrees);
+  
+  if(fWriteVariableTreeDs){
+    if(fConfigPath != ""){
+      fMLResponse = new AliHFMLResponseDstoKKpi("DstoKKpiMLResponse", "DstoKKpiMLResponse", fConfigPath.Data());
+      fMLResponse->MLResponseInit();
+    }
+
+    OpenFile(6);
+    TString nameoutput = "tree_Ds";
+    fTreeHandlerDs = new AliHFTreeHandlerApplyDstoKKpi(fPIDoptDs);
+    fTreeHandlerDs->SetOptSingleTrackVars(fTreeSingleTrackVarsOpt);
+    if(fReadMC && fWriteOnlySignal) fTreeHandlerDs->SetFillOnlySignal(fWriteOnlySignal);
+    if(fEnableNsigmaTPCDataCorr) fTreeHandlerDs->EnableNsigmaTPCDataDrivenCorrection(fSystemForNsigmaTPCDataCorr);
+    fTreeHandlerDs->SetMassKKOption(fDsMassKKOpt);
+    fVariablesTreeDs = (TTree*)fTreeHandlerDs->BuildTree(nameoutput,nameoutput);
+    fVariablesTreeDs->SetMaxVirtualSize(1.e+8/nEnabledTrees);
+    fTreeEvChar->AddFriend(fVariablesTreeDs);
+    
+    if(fFillMCGenTrees && fReadMC) {
+      OpenFile(7);
+      TString nameoutput = "tree_Ds_gen";
+      fTreeHandlerGenDs = new AliHFTreeHandlerApplyDstoKKpi(0);
+      fGenTreeDs = (TTree*)fTreeHandlerGenDs->BuildTreeMCGen(nameoutput,nameoutput);
+      fGenTreeDs->SetMaxVirtualSize(1.e+8/nEnabledTrees);
+      fTreeEvChar->AddFriend(fGenTreeDs);
+    }
+  }
+  if(fWriteVariableTreeLc2V0bachelor){
+    if(fConfigPath != ""){
+      fMLResponse = new AliHFMLResponseLctoV0bachelor("LctoV0bachelorMLResponse", "LctoV0bachelorMLResponse", fConfigPath.Data());
+      fMLResponse->MLResponseInit();
+    }
+
+    OpenFile(8);
+    TString nameoutput = "tree_Lc2V0bachelor";
+    fTreeHandlerLc2V0bachelor = new AliHFTreeHandlerApplyLc2V0bachelor(fPIDoptLc2V0bachelor);
+    fTreeHandlerLc2V0bachelor->SetOptSingleTrackVars(fTreeSingleTrackVarsOpt);
+    if(fReadMC && fWriteOnlySignal) fTreeHandlerLc2V0bachelor->SetFillOnlySignal(fWriteOnlySignal);
+    if(fEnableNsigmaTPCDataCorr) fTreeHandlerLc2V0bachelor->EnableNsigmaTPCDataDrivenCorrection(fSystemForNsigmaTPCDataCorr);
+    fTreeHandlerLc2V0bachelor->SetCalcSecoVtx(fLc2V0bachelorCalcSecoVtx);
+    fVariablesTreeLc2V0bachelor = (TTree*)fTreeHandlerLc2V0bachelor->BuildTree(nameoutput,nameoutput);
+    fVariablesTreeLc2V0bachelor->SetMaxVirtualSize(1.e+8/nEnabledTrees);
+    fTreeEvChar->AddFriend(fVariablesTreeLc2V0bachelor);
+    if(fFillMCGenTrees && fReadMC) {
+      OpenFile(9);
+      TString nameoutput = "tree_Lc2V0bachelor_gen";
+      fTreeHandlerGenLc2V0bachelor = new AliHFTreeHandlerApplyLc2V0bachelor(0);
+      fGenTreeLc2V0bachelor = (TTree*)fTreeHandlerGenLc2V0bachelor->BuildTreeMCGen(nameoutput,nameoutput);
+      fGenTreeLc2V0bachelor->SetMaxVirtualSize(1.e+8/nEnabledTrees);
+      fTreeEvChar->AddFriend(fGenTreeLc2V0bachelor);
+    }
+  }
+    
+  // Post the data
+  PostData(1,fNentries);
+  PostData(2,fHistoNormCounter);
+  PostData(4,fListCounter);
+  PostData(5,fTreeEvChar);
+  if(fWriteVariableTreeDs){
+    PostData(6,fVariablesTreeDs);
+    if(fFillMCGenTrees && fReadMC) PostData(7,fGenTreeDs);
+  }
+  if(fWriteVariableTreeLc2V0bachelor){
+    PostData(8,fVariablesTreeLc2V0bachelor);
+    if(fFillMCGenTrees && fReadMC) PostData(9,fGenTreeLc2V0bachelor);
+  }
+
+  return;
+}
+//________________________________________________________________________
+void AliAnalysisTaskSEHFTreeCreatorApply::UserExec(Option_t */*option*/){
+
+  /// Execute analysis for current event:
+
+  if(fEnableEventDownsampling) {
+    gRandom->SetSeed(fSeedEventDownsampling);
+    if(gRandom->Rndm() > fFracToKeepEventDownsampling)
+      return;
+  }
+  
+  AliAODEvent *aod = dynamic_cast<AliAODEvent*> (InputEvent());
+  
+  fNentries->Fill(0); // all events
+  if(fAODProtection>=0){
+    //   Protection against different number of events in the AOD and deltaAOD
+    //   In case of discrepancy the event is rejected.
+    Int_t matchingAODdeltaAODlevel = AliRDHFCuts::CheckMatchingAODdeltaAODevents();
+    if (matchingAODdeltaAODlevel<0 || (matchingAODdeltaAODlevel==0 && fAODProtection==1)) {
+      // AOD/deltaAOD trees have different number of entries || TProcessID do not match while it was required
+      fNentries->Fill(2);
+      return;
+    }
+    fNentries->Fill(1);
+  }
+
+  TString candidates2prongArrayName="D0toKpi";
+  TString candidates3prongArrayName="Charm3Prong";
+  TString candidatesCascArrayDstarName="Dstar";
+  TString candidatesCascArrayName="CascadesHF";
+  TClonesArray *array2prong=0;
+  TClonesArray *array3Prong=0;
+  TClonesArray *arrayDstar=0;
+  TClonesArray *arrayCasc=0;
+  
+  if(!aod && AODEvent() && IsStandardAOD()) {
+    // In case there is an AOD handler writing a standard AOD, use the AOD
+    // event in memory rather than the input (ESD) event.
+    aod = dynamic_cast<AliAODEvent*> (AODEvent());
+    // in this case the braches in the deltaAOD (AliAOD.VertexingHF.root)
+    // have to taken from the AOD event hold by the AliAODExtension
+    AliAODHandler* aodHandler = (AliAODHandler*)
+    ((AliAnalysisManager::GetAnalysisManager())->GetOutputEventHandler());
+    
+    if(aodHandler->GetExtensions()) {
+      AliAODExtension *ext = (AliAODExtension*)aodHandler->GetExtensions()->FindObject("AliAOD.VertexingHF.root");
+      AliAODEvent* aodFromExt = ext->GetAOD();
+      array2prong=(TClonesArray*)aodFromExt->GetList()->FindObject(candidates2prongArrayName.Data());
+      array3Prong=(TClonesArray*)aodFromExt->GetList()->FindObject(candidates3prongArrayName.Data());
+      arrayDstar=(TClonesArray*)aodFromExt->GetList()->FindObject(candidatesCascArrayDstarName.Data());
+      arrayCasc=(TClonesArray*)aodFromExt->GetList()->FindObject(candidatesCascArrayName.Data());
+    }
+  } else if(aod) {
+    array2prong=(TClonesArray*)aod->GetList()->FindObject(candidates2prongArrayName.Data());
+    array3Prong=(TClonesArray*)aod->GetList()->FindObject(candidates3prongArrayName.Data());
+    arrayDstar=(TClonesArray*)aod->GetList()->FindObject(candidatesCascArrayDstarName.Data());
+    arrayCasc=(TClonesArray*)aod->GetList()->FindObject(candidatesCascArrayName.Data());
+  }
+  
+  if(!array2prong || !array3Prong || !arrayDstar || !arrayCasc || !aod) {
+    printf("AliAnalysisTaskSEHFTreeCreatorApply::UserExec: input branches not found!\n");
+    return;
+  }
+
+  // fix for temporary bug in ESDfilter
+  // the AODs with null vertex pointer didn't pass the PhysSel
+  if(!aod->GetPrimaryVertex() || TMath::Abs(aod->GetMagneticField())<0.001) return;
+  fNentries->Fill(3); // count events
+  
+  TClonesArray *mcArray = 0;
+  AliAODMCHeader *mcHeader = 0;
+  
+  if(fReadMC) {
+    // load MC particles
+    mcArray = (TClonesArray*)aod->GetList()->FindObject(AliAODMCParticle::StdBranchName());
+    if(!mcArray) {
+      printf("AliAnalysisTaskSEHFTreeCreatorApply::UserExec: MC particles branch not found!\n");
+      return;
+    }
+    
+    // load MC header
+    mcHeader = (AliAODMCHeader*)aod->GetList()->FindObject(AliAODMCHeader::StdBranchName());
+    if(!mcHeader) {
+      printf("AliAnalysisTaskSEHFTreeCreatorApply::UserExec: MC header branch not found!\n");
+      return;
+    }
+    fzVtxGen = mcHeader->GetVtxZ();
+  }
+  
+  Bool_t isSameEvSelDs=kTRUE;
+  Bool_t isSameEvSelLc2V0bachelor=kTRUE;
+
+  if(fWriteVariableTreeDs)
+    isSameEvSelDs=!((fFiltCutsDstoKKpi->IsEventSelected(aod) && !fCutsDstoKKpi->IsEventSelected(aod))||(!fFiltCutsDstoKKpi->IsEventSelected(aod) && fCutsDstoKKpi->IsEventSelected(aod)));
+  if(fWriteVariableTreeLc2V0bachelor)
+    isSameEvSelLc2V0bachelor=!((fFiltCutsLc2V0bachelor->IsEventSelected(aod) && !fCutsLc2V0bachelor->IsEventSelected(aod))||(!fFiltCutsLc2V0bachelor->IsEventSelected(aod) && fCutsLc2V0bachelor->IsEventSelected(aod)));
+  
+  Bool_t isSameEvSel = isSameEvSelDs && isSameEvSelLc2V0bachelor;
+  if(!isSameEvSel) {
+    Printf("AliAnalysisTaskSEHFTreeCreatorApply::UserExec: differences in the event selection cuts same meson");
+    return;
+  }
+  
+  if((fWriteVariableTreeDs && fWriteVariableTreeLc2V0bachelor && (fFiltCutsDstoKKpi->IsEventSelected(aod)!=fFiltCutsLc2V0bachelor->IsEventSelected(aod)))){
+    Printf("AliAnalysisTaskSEHFTreeCreatorApply::UserExec: differences in the event selection cuts different meson");
+    return;
+  }
+  
+  fCounter->StoreEvent(aod,fEvSelectionCuts,fReadMC);
+  Bool_t isEvSel=fEvSelectionCuts->IsEventSelected(aod);
+  
+  if(fEvSelectionCuts->IsEventRejectedDueToTrigger())fNentries->Fill(5);
+  if(fEvSelectionCuts->IsEventRejectedDueToNotRecoVertex())fNentries->Fill(6);
+  if(fEvSelectionCuts->IsEventRejectedDueToVertexContributors())fNentries->Fill(7);
+  if(fEvSelectionCuts->IsEventRejectedDueToZVertexOutsideFiducialRegion())fNentries->Fill(8);
+  if(fEvSelectionCuts->IsEventRejectedDueToPileup())fNentries->Fill(9);
+  if(fEvSelectionCuts->IsEventRejectedDueToCentrality())fNentries->Fill(10);
+  
+  fCentrality = fEvSelectionCuts->GetCentrality(aod);
+  if(fCentrality<0) fCentrality=-1.;
+  bool isEvRejPhysSel = fEvSelectionCuts->IsEventRejectedDuePhysicsSelection();
+  //normalisation counter
+  if(!isEvRejPhysSel){
+    if(isEvSel){
+      //selected events with primary vertex
+      fHistoNormCounter->Fill(0.,fCentrality);
+    }
+    else{
+      if(fEvSelectionCuts->GetWhyRejection()==0){
+        //rejected events bc no primary vertex
+        fHistoNormCounter->Fill(1.,fCentrality);
+      }
+      //rejected events bc good primary vertex but >10cm
+      if(fEvSelectionCuts->GetWhyRejection()==6){
+        //nPrimaryV++;
+        fHistoNormCounter->Fill(0.,fCentrality);
+        //nzVtxGT10++;
+        fHistoNormCounter->Fill(2.,fCentrality);
+      }
+      if(fEvSelectionCuts->GetWhyRejection()==1){
+        //nPileup++;
+        fHistoNormCounter->Fill(4.,fCentrality);
+      }
+    }
+    if(fEvSelectionCuts->CountEventForNormalization()){
+      //nCountForNorm++;
+      fHistoNormCounter->Fill(3.,fCentrality);
+    }
+  }
+  
+  Bool_t isEvRejCent  = fEvSelectionCuts->IsEventRejectedDueToCentrality();
+  
+  if(!isEvSel && (isEvRejCent || (fApplyPhysicsSelOnline && isEvRejPhysSel))){
+    return; //cut only centrality and physics selection if enabled, else tag only
+  }
+  if(isEvSel) fNentries->Fill(4);
+
+  AliAODVertex *vtx = (AliAODVertex*)aod->GetPrimaryVertex();
+  fNcontributors = vtx->GetNContributors();
+  fzVtxReco = vtx->GetZ();
+  fNtracks = aod->GetNumberOfTracks();
+  fIsEvRej = fEvSelectionCuts->GetEventRejectionBitMap();
+  
+  auto trig_mask_cuts = fEvSelectionCuts->GetTriggerMask();
+  
+  fEvSelectionCuts->SetTriggerMask(AliVEvent::kINT7);
+  fIsEvRej_INT7 = fEvSelectionCuts->GetEventRejectionBitMap();
+  
+  fEvSelectionCuts->SetTriggerMask(AliVEvent::kHighMultSPD);
+  fIsEvRej_HighMultSPD = fEvSelectionCuts->GetEventRejectionBitMap();
+  
+  fEvSelectionCuts->SetTriggerMask(AliVEvent::kHighMultV0);
+  fIsEvRej_HighMultV0 = fEvSelectionCuts->GetEventRejectionBitMap();
+  
+  fEvSelectionCuts->SetTriggerMask(trig_mask_cuts);
+  
+  fRunNumber=aod->GetRunNumber();
+  //n tracklets
+  AliAODTracklets* tracklets=aod->GetTracklets();
+  Int_t nTr=tracklets->GetNumberOfTracklets();
+  Int_t countTreta1=0;
+  for(Int_t iTr=0; iTr<nTr; iTr++){
+    Double_t theta=tracklets->GetTheta(iTr);
+    Double_t eta=-TMath::Log(TMath::Tan(theta/2.));
+    if(eta>-1.0 && eta<1.0) countTreta1++;//count at central rapidity
+  }
+  fnTracklets=countTreta1;
+  fnTrackletsCorr = -1.;
+  TProfile *estimatorAvg = fMultEstimatorAvg[GetPeriod(aod)];
+  if (fCorrNtrVtx && estimatorAvg)
+    fnTrackletsCorr = static_cast<Int_t>(AliVertexingHFUtils::GetCorrectedNtracklets(estimatorAvg, countTreta1, vtx->GetZ(), fRefMult));
+  TProfile *estimatorAvgSHM = fMultEstimatorAvgSHM[GetPeriod(aod)];
+  if (fCorrNtrVtx && estimatorAvgSHM)
+    fnTrackletsCorrSHM = static_cast<Int_t>(AliVertexingHFUtils::GetCorrectedNtracklets(estimatorAvgSHM, countTreta1, vtx->GetZ(), fRefMultSHM));
+  
+  //V0 multiplicities
+  AliAODVZERO *vzeroAOD = (AliAODVZERO*)aod->GetVZEROData();
+  Double_t vzeroA = vzeroAOD ? vzeroAOD->GetMTotV0A() : 0.;
+  Double_t vzeroC = vzeroAOD ? vzeroAOD->GetMTotV0C() : 0.;
+  Double_t vzeroAEq = AliVertexingHFUtils::GetVZEROAEqualizedMultiplicity(aod);
+  Double_t vzeroCEq = AliVertexingHFUtils::GetVZEROCEqualizedMultiplicity(aod);
+  fnV0A = static_cast<Int_t>(vzeroA);
+  fnV0M = static_cast<Int_t>(vzeroA + vzeroC);
+  fnV0MEq = static_cast<Int_t>(vzeroAEq + vzeroCEq);
+  fnV0MCorr = -1;
+  fnV0MEqCorr = -1;
+  if (fCorrV0MVtx) {
+    fnV0MCorr = static_cast<Int_t>(AliESDUtils::GetCorrV0A(vzeroA, vtx->GetZ()) + AliESDUtils::GetCorrV0C(vzeroC, vtx->GetZ()));
+    fnV0MEqCorr = static_cast<Int_t>(AliESDUtils::GetCorrV0A(vzeroAEq, vtx->GetZ()) + AliESDUtils::GetCorrV0C(vzeroCEq, vtx->GetZ()));
+  }
+  
+  // multiplicity percentiles
+  const auto multSel = static_cast<AliMultSelection*>(aod->FindListObject("MultSelection"));
+  fPercV0M = multSel ? multSel->GetMultiplicityPercentile("V0M") : -1.;
+  // multiplicity from mult selection task
+  const auto multEst = multSel ? multSel->GetEstimator("V0M") : nullptr;
+  fMultV0M = multEst ? multEst->GetValue() : -1.;
+  
+  // generated multiplicity
+  fMultGen = -1;
+  fMultGenV0A = -1;
+  fMultGenV0C = -1;
+  if (fReadMC) {
+    TClonesArray *arrayMC =  (TClonesArray*)aod->GetList()->FindObject(AliAODMCParticle::StdBranchName());
+    fMultGen = AliVertexingHFUtils::GetGeneratedMultiplicityInEtaRange(arrayMC,-1.0,1.0);
+    fMultGenV0A = AliVertexingHFUtils::GetGeneratedMultiplicityInEtaRange(arrayMC,2.8,5.1);
+    fMultGenV0C = AliVertexingHFUtils::GetGeneratedMultiplicityInEtaRange(arrayMC,-3.7,-1.7);
+  }
+  
+  fEventID = GetEvID();
+  // Extract fired triggers
+  fTriggerMask = static_cast<AliVAODHeader*>(aod->GetHeader())->GetOfflineTrigger();
+  fTriggerBitINT7 = static_cast<bool>(fTriggerMask & AliVEvent::kINT7);
+  fTriggerBitHighMultSPD = static_cast<bool>(fTriggerMask & AliVEvent::kHighMultSPD);
+  fTriggerBitHighMultV0 = static_cast<bool>(fTriggerMask & AliVEvent::kHighMultV0);
+  fTriggerBitCentral = static_cast<bool>(fTriggerMask & AliVEvent::kCentral);
+  fTriggerBitSemiCentral = static_cast<bool>(fTriggerMask & AliVEvent::kSemiCentral);
+  
+  fTriggerClasses = aod->GetFiredTriggerClasses();
+  fTriggerClassINT7 = fTriggerClasses.Contains("CINT7-B");
+  fTriggerClassHighMultSPD = fTriggerClasses.Contains("CVHMSH2-B");
+  fTriggerClassHighMultV0m = fTriggerClasses.Contains("CVHMV0M-B");
+  
+  // bits for CTP inputs
+  if (fRunNumberCDB != fRunNumber) {
+    fCdbEntry = AliCDBManager::Instance()->Get("GRP/CTP/Config", fRunNumber);
+    fRunNumberCDB = fRunNumber;
+  }
+  
+  AliTriggerConfiguration *trgCfg = fCdbEntry ? static_cast<AliTriggerConfiguration*>(fCdbEntry->GetObject()) : nullptr;
+  TObjArray inputs;
+  if (trgCfg)
+    inputs = trgCfg->GetInputs();
+  const auto inputSHM = trgCfg ? static_cast<AliTriggerInput*>(inputs.FindObject("0SHM")) : nullptr;
+  const auto inputV0M = trgCfg ? static_cast<AliTriggerInput*>(inputs.FindObject("0VHM")) : nullptr;
+  const auto inputV0A = trgCfg ? static_cast<AliTriggerInput*>(inputs.FindObject("0V0A")) : nullptr;
+  const auto inputV0C = trgCfg ? static_cast<AliTriggerInput*>(inputs.FindObject("0V0C")) : nullptr;
+  const auto triggerBits = aod->GetHeader()->GetL0TriggerInputs();
+  fTriggerOnlineHighMultSPD = inputSHM ? TESTBIT(triggerBits, inputSHM->GetIndexCTP() - 1) : -1;
+  fTriggerOnlineHighMultV0 = inputV0M ? TESTBIT(triggerBits, inputV0M->GetIndexCTP() - 1) : -1;
+  fTriggerOnlineINT7 = (inputV0C && inputV0A) ?
+                       (TESTBIT(triggerBits, inputV0C->GetIndexCTP() - 1) &&
+                        TESTBIT(triggerBits, inputV0A->GetIndexCTP() - 1)) : -1;
+  
+  fTreeEvChar->Fill();
+  
+  //get PID response
+  if(!fPIDresp) fPIDresp = ((AliInputEventHandler*)(AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler()))->GetPIDResponse();
+  
+  if(fWriteVariableTreeDs) Process3Prong(array3Prong,aod,mcArray,aod->GetMagneticField());
+  if(fWriteVariableTreeLc2V0bachelor) ProcessCasc(arrayCasc,aod,mcArray,aod->GetMagneticField());
+  if(fFillMCGenTrees && fReadMC) ProcessMCGen(mcArray);
+  
+  // Post the data
+  PostData(1,fNentries);
+  PostData(2,fHistoNormCounter);
+  PostData(4,fListCounter);
+  PostData(5,fTreeEvChar);
+  if(fWriteVariableTreeDs){
+    PostData(6,fVariablesTreeDs);
+    if(fFillMCGenTrees && fReadMC) PostData(7,fGenTreeDs);
+  }
+  if(fWriteVariableTreeLc2V0bachelor){
+    PostData(8,fVariablesTreeLc2V0bachelor);
+    if(fFillMCGenTrees && fReadMC) PostData(9,fGenTreeLc2V0bachelor);
+  }
+  
+  return;
+}
+//________________________________________________________________________
+void AliAnalysisTaskSEHFTreeCreatorApply::Terminate(Option_t */*option*/)
+{
+  /// Terminate analysis
+  //
+  if(fDebug > 1) printf("AliAnalysisTaskSEHFTreeCreatorApply: Terminate() \n");
+  
+  fNentries = dynamic_cast<TH1F*>(GetOutputData(1));
+  if(!fNentries){
+    printf("ERROR: fNEntries not available\n");
+    return;
+  }
+  fHistoNormCounter = dynamic_cast<TH2F*>(GetOutputData(2));
+  if(!fHistoNormCounter){
+    printf("ERROR: fHistoNormCounter not available\n");
+    return;
+  }
+  fListCuts = dynamic_cast<TList*>(GetOutputData(3));
+  if(!fListCuts){
+    printf("ERROR: fListCuts not available\n");
+    return;
+  }
+  fListCounter = dynamic_cast<TList*>(GetOutputData(4));
+  if(!fListCounter){
+    printf("ERROR: fListCounter not available\n");
+    return;
+  }
+  return;
+}
+//--------------------------------------------------------
+void AliAnalysisTaskSEHFTreeCreatorApply::Process3Prong(TClonesArray *array3Prong, AliAODEvent *aod, TClonesArray *arrMC, Float_t bfield){
+  
+  AliAODVertex *vtx1 = (AliAODVertex*)aod->GetPrimaryVertex();
+  
+  Int_t n3prong = array3Prong->GetEntriesFast();
+  if(fDebug>1) printf("Number of 3prongs: %d\n",n3prong);
+  
+  Int_t pdgDstoKKpi[3]={321,321,211};
+  Int_t nSelectedDs=0;
+  Int_t nFilteredDs=0;
+  
+  // vHF object is needed to call the method that refills the missing info of the candidates
+  // if they have been deleted in dAOD reconstruction phase
+  // in order to reduce the size of the file
+  AliAnalysisVertexingHF *vHF=new AliAnalysisVertexingHF();
+  
+  for (Int_t i3prong = 0; i3prong < n3prong; i3prong++) {
+    fNentries->Fill(15);
+    
+    //Ds
+    Bool_t isDstagged=kTRUE;
+    AliAODRecoDecayHF3Prong *ds    = (AliAODRecoDecayHF3Prong*)array3Prong->UncheckedAt(i3prong);
+    if(fUseSelectionBit && !(ds->HasSelectionBit(AliRDHFCuts::kDsCuts))){
+      isDstagged=kFALSE;
+    }
+    
+    if(isDstagged && fWriteVariableTreeDs){
+      fNentries->Fill(16);
+      nFilteredDs++;
+      if((vHF->FillRecoCand(aod,ds))) {////Fill the data members of the candidate only if they are empty.
+        
+        Int_t isSelectedFilt=fFiltCutsDstoKKpi->IsSelected(ds,AliRDHFCuts::kAll,aod);
+        Int_t isKKpi=isSelectedFilt&1;
+        Int_t ispiKK=isSelectedFilt&2;
+        Int_t isPhiKKpi=isSelectedFilt&4;
+        Int_t isPhipiKK=isSelectedFilt&8;
+        Int_t isK0starKKpi=isSelectedFilt&16;
+        Int_t isK0starpiKK=isSelectedFilt&32;
+        
+        if(isSelectedFilt>0){
+          
+          Double_t modelPred0 = -1.;
+          Double_t modelPred1 = -1.;
+          AliAODPidHF *Pid_HF = fFiltCutsDstoKKpi->GetPidHF();
+          Bool_t isSelectedMLFilt0 = kTRUE;
+          Bool_t isSelectedMLFilt1 = kTRUE;
+          if(fMLResponse){
+            isSelectedMLFilt0 = fMLResponse->IsSelected(modelPred0, ds, aod->GetMagneticField(), Pid_HF, 0);
+            isSelectedMLFilt1 = fMLResponse->IsSelected(modelPred1, ds, aod->GetMagneticField(), Pid_HF, 1);
+          }
+          if(isSelectedMLFilt0 || isSelectedMLFilt1){
+            
+            fNentries->Fill(17);
+            nSelectedDs++;
+            
+            //test analysis cuts
+            Bool_t isSelAnCutsKKpi=kFALSE;
+            Bool_t isSelAnCutspiKK=kFALSE;
+            Bool_t isSelAnPidCutsKKpi=kFALSE;
+            Bool_t isSelAnPidCutspiKK=kFALSE;
+            Bool_t isSelAnTopoCutsKKpi=kFALSE;
+            Bool_t isSelAnTopoCutspiKK=kFALSE;
+            Int_t isSelectedAnalysis=fCutsDstoKKpi->IsSelected(ds,AliRDHFCuts::kAll,aod);
+            Int_t isSelectedPidAnalysis=fCutsDstoKKpi->IsSelectedPID(ds);
+            bool isUsePidAn = fCutsDstoKKpi->GetIsUsePID();
+            if(isUsePidAn) fCutsDstoKKpi->SetUsePID(kFALSE);
+            Int_t isSelectedTopoAnalysis = fCutsDstoKKpi->IsSelected(ds,AliRDHFCuts::kAll,aod);
+            fCutsDstoKKpi->SetUsePID(isUsePidAn);
+            Bool_t isSelTracksAnCuts=kFALSE;
+            Int_t isSelectedTrackAnalysis = fCutsDstoKKpi->IsSelected(ds,AliRDHFCuts::kTracks,aod);
+            if(isSelectedTrackAnalysis > 0) isSelTracksAnCuts=kTRUE;
+            
+            if(fWriteVariableTreeDs==1) {
+              if(isSelectedAnalysis&4) isSelAnCutsKKpi=kTRUE;
+              if(isSelectedAnalysis&8) isSelAnCutspiKK=kTRUE;
+              if(isSelectedPidAnalysis==1 || isSelectedPidAnalysis==3) isSelAnPidCutsKKpi=kTRUE;
+              if(isSelectedPidAnalysis==2 || isSelectedPidAnalysis==3) isSelAnPidCutspiKK=kTRUE;
+              if(isSelectedTopoAnalysis&4) isSelAnTopoCutsKKpi=kTRUE;
+              if(isSelectedTopoAnalysis&8) isSelAnTopoCutspiKK=kTRUE;
+            }
+            else if(fWriteVariableTreeDs==2) {
+              if(isSelectedAnalysis&16) isSelAnCutsKKpi=kTRUE;
+              if(isSelectedAnalysis&32) isSelAnCutspiKK=kTRUE;
+              if(isSelectedPidAnalysis==1 || isSelectedPidAnalysis==3) isSelAnPidCutsKKpi=kTRUE;
+              if(isSelectedPidAnalysis==2 || isSelectedPidAnalysis==3) isSelAnPidCutspiKK=kTRUE;
+              if(isSelectedTopoAnalysis&16) isSelAnTopoCutsKKpi=kTRUE;
+              if(isSelectedTopoAnalysis&32) isSelAnTopoCutspiKK=kTRUE;
+            }
+            else if(fWriteVariableTreeDs==3) {
+              if(isSelectedAnalysis&1) isSelAnCutsKKpi=kTRUE;
+              if(isSelectedAnalysis&2) isSelAnCutspiKK=kTRUE;
+              if(isSelectedPidAnalysis==1 || isSelectedPidAnalysis==3) isSelAnPidCutsKKpi=kTRUE;
+              if(isSelectedPidAnalysis==2 || isSelectedPidAnalysis==3) isSelAnPidCutspiKK=kTRUE;
+              if(isSelectedTopoAnalysis&1) isSelAnTopoCutsKKpi=kTRUE;
+              if(isSelectedTopoAnalysis&2) isSelAnTopoCutspiKK=kTRUE;
+            }
+            
+            Bool_t unsetvtx=kFALSE;
+            if(!ds->GetOwnPrimaryVtx()){
+              ds->SetOwnPrimaryVtx(vtx1);
+              unsetvtx=kTRUE;
+              // NOTE: the own primary vertex should be unset, otherwise there is a memory leak
+              // Pay attention if you use continue inside this loop!!!
+            }
+            Bool_t recVtx=kFALSE;
+            AliAODVertex *origownvtx=0x0;
+            if(fFiltCutsDstoKKpi->GetIsPrimaryWithoutDaughters()){
+              if(ds->GetOwnPrimaryVtx()) origownvtx=new AliAODVertex(*ds->GetOwnPrimaryVtx());
+              if(fFiltCutsDstoKKpi->RecalcOwnPrimaryVtx(ds,aod))recVtx=kTRUE;
+              else fFiltCutsDstoKKpi->CleanOwnPrimaryVtx(ds,aod,origownvtx);
+            }
+            
+            Int_t labDs=-1;
+            Int_t labDplus=-1;
+            Int_t pdgCode0=-999;
+            Int_t orig=0;
+            Float_t ptGenDs = -99.;
+            //checking origin
+            AliAODMCParticle *partDs = 0x0;
+            if(fReadMC){
+              labDs = ds->MatchToMC(431,arrMC,3,pdgDstoKKpi);
+              labDplus = ds->MatchToMC(411,arrMC,3,pdgDstoKKpi);
+              
+              if(labDs>=0){
+                Int_t labDau0=((AliAODTrack*)ds->GetDaughter(0))->GetLabel();
+                AliAODMCParticle* p=(AliAODMCParticle*)arrMC->UncheckedAt(TMath::Abs(labDau0));
+                pdgCode0=TMath::Abs(p->GetPdgCode());
+                partDs = (AliAODMCParticle*)arrMC->At(labDs);
+                ptGenDs = partDs->Pt();
+              }
+              else{
+                if(labDplus>=0) {
+                  Int_t labDau0=((AliAODTrack*)ds->GetDaughter(0))->GetLabel();
+                  AliAODMCParticle* p=(AliAODMCParticle*)arrMC->UncheckedAt(TMath::Abs(labDau0));
+                  pdgCode0=TMath::Abs(p->GetPdgCode());
+                  partDs = (AliAODMCParticle*)arrMC->At(labDplus);
+                  ptGenDs = partDs->Pt();
+                }
+              }
+              if(partDs) orig = AliVertexingHFUtils::CheckOrigin(arrMC,partDs,!fITSUpgradeStudy);
+            }
+            
+            //filling the Ds tree
+            if ((fWriteVariableTreeDs==1 && (isPhiKKpi || isPhipiKK)) || (fWriteVariableTreeDs==2 && (isK0starKKpi || isK0starpiKK)) || (fWriteVariableTreeDs==3 && (isKKpi || ispiKK))){
+              
+              bool issignal = kFALSE;
+              bool isbkg = kFALSE;
+              bool isprompt = kFALSE;
+              bool isFD = kFALSE;
+              bool isrefl = kFALSE;
+              
+              if((fWriteVariableTreeDs==3 && isKKpi) || (fWriteVariableTreeDs==1 && isPhiKKpi) || (fWriteVariableTreeDs==2 && isK0starKKpi)) {
+                if(fReadMC) {
+                  if(labDs>=0) {
+                    if(orig==4 || orig==5) {
+                      if(pdgCode0==321) issignal = kTRUE;
+                      else if(pdgCode0==211) isrefl = kTRUE;
+                      if(orig==4) isprompt = kTRUE;
+                      else if(orig==5) isFD = kTRUE;
+                    }
+                  }
+                  else {
+                    isbkg = kTRUE;
+                    if(labDplus>=0) fTreeHandlerDs->SetIsDplustoKKpi(kTRUE);//put also D+ -->KKpi in bkg
+                  }
+                  //do not apply cuts, but enable flag if is selected
+                  if(issignal || isbkg || isrefl) fTreeHandlerDs->SetCandidateType(issignal,isbkg,isprompt,isFD,isrefl);
+                }
+                if(!fReadMC || (issignal || isbkg || isrefl)) {
+                  fTreeHandlerDs->SetIsSelectedStd(isSelAnCutsKKpi,isSelAnTopoCutsKKpi,isSelAnPidCutsKKpi,isSelTracksAnCuts);
+                  fTreeHandlerDs->SetVariables(fRunNumber,fEventID,ptGenDs,modelPred0,ds,bfield,0,fPIDresp);
+                  if(isSelectedMLFilt0) fTreeHandlerDs->FillTree();
+                }
+              }
+              issignal = kFALSE;
+              isbkg = kFALSE;
+              isprompt = kFALSE;
+              isFD = kFALSE;
+              isrefl = kFALSE;
+              if((fWriteVariableTreeDs==3 && ispiKK) || (fWriteVariableTreeDs==1 && isPhipiKK) || (fWriteVariableTreeDs==2 && isK0starpiKK)) {
+                if(fReadMC) {
+                  if(labDs>=0) {
+                    if(orig==4 || orig==5) {
+                      if(pdgCode0==211) issignal = kTRUE;
+                      else if(pdgCode0==321) isrefl = kTRUE;
+                      if(orig==4) isprompt = kTRUE;
+                      else if(orig==5) isFD = kTRUE;
+                    }
+                  }
+                  else {
+                    isbkg = kTRUE;
+                    if(labDplus>=0) fTreeHandlerDs->SetIsDplustoKKpi(kTRUE);//put also D+ -->KKpi in bkg
+                  }
+                  //do not apply cuts, but enable flag if is selected
+                  if(issignal || isbkg || isrefl) fTreeHandlerDs->SetCandidateType(issignal,isbkg,isprompt,isFD,isrefl);
+                }
+                if(!fReadMC || (issignal || isbkg || isrefl)) {
+                  fTreeHandlerDs->SetIsSelectedStd(isSelAnCutspiKK,isSelAnTopoCutspiKK,isSelAnPidCutspiKK,isSelTracksAnCuts);
+                  fTreeHandlerDs->SetVariables(fRunNumber,fEventID,ptGenDs,modelPred1,ds,bfield,1,fPIDresp);
+                  if(isSelectedMLFilt1) fTreeHandlerDs->FillTree();
+                }
+              }
+            }//end fill tree
+            if(recVtx)fFiltCutsDstoKKpi->CleanOwnPrimaryVtx(ds,aod,origownvtx);
+            if(unsetvtx) ds->UnsetOwnPrimaryVtx();
+          }//end ML selection
+        }//end is selected
+      }
+      else{
+        fNentries->Fill(18); //monitor how often this fails
+      }
+    }//end Ds
+  }//end loop on cadidates
+  
+  delete vHF;
+  return;
+}
+//________________________________________________________________
+void AliAnalysisTaskSEHFTreeCreatorApply::ProcessCasc(TClonesArray *arrayCasc, AliAODEvent *aod, TClonesArray *arrMC, Float_t bfield){
+  
+  AliAODVertex *vtx1 = (AliAODVertex*)aod->GetPrimaryVertex();
+  
+  Int_t nCasc = arrayCasc->GetEntriesFast();
+  if(fDebug>2) printf("Number of Cascade: %d\n",nCasc);
+  
+  Int_t pdgDgLc2K0Spr[2]={2212,310};
+  Int_t pdgDgK0stoDaughters[2]={211,211};
+  Int_t nSelectedLc2V0bachelor=0;
+  Int_t nFilteredLc2V0bachelor=0;
+  
+  // vHF object is needed to call the method that refills the missing info of the candidates
+  // if they have been deleted in dAOD reconstruction phase
+  // in order to reduce the size of the file
+  AliAnalysisVertexingHF *vHF = new AliAnalysisVertexingHF();
+  
+  for (Int_t iCasc = 0; iCasc < nCasc; iCasc++) {
+    fNentries->Fill(32);
+    
+    //Lc2V0bachelor
+    Bool_t isLc2V0bachelortagged=kTRUE;
+    AliAODRecoCascadeHF *d = (AliAODRecoCascadeHF*)arrayCasc->UncheckedAt(iCasc);
+    if(fUseSelectionBit && d->GetSelectionMap()) if(!d->HasSelectionBit(AliRDHFCuts::kLctoV0Cuts)){
+      isLc2V0bachelortagged=kFALSE;
+    }
+    
+    if (isLc2V0bachelortagged && fWriteVariableTreeLc2V0bachelor){
+      
+      AliAODv0 * v0part;
+      if(d->GetIsFilled() == 0) v0part = (AliAODv0*)(aod->GetV0(d->GetProngID(1)));
+      else                      v0part = d->Getv0();
+      Bool_t isOnFlyV0 = v0part->GetOnFlyStatus();
+      
+      if(fV0typeForLc2V0bachelor==1 && isOnFlyV0 == kTRUE) continue;
+      if(fV0typeForLc2V0bachelor==2 && isOnFlyV0 == kFALSE) continue;
+      
+      if(fFiltCutsLc2V0bachelor->GetUsePreselect() && d->GetIsFilled() == 0){
+        TObjArray arrTracks(2);
+        for(Int_t ipr=0;ipr<2;ipr++){
+          AliAODTrack *tr;
+          if(ipr==0) tr=vHF->GetProng(aod,d,ipr);
+          else tr = (AliAODTrack*)(aod->GetV0(d->GetProngID(1)));
+          arrTracks.AddAt(tr,ipr);
+        }
+        Int_t PreSelectLc = fFiltCutsLc2V0bachelor->PreSelect(arrTracks);
+        if(PreSelectLc==0) continue;
+      }
+      
+      fNentries->Fill(33);
+      nFilteredLc2V0bachelor++;
+      if((vHF->FillRecoCasc(aod,d,kFALSE,fLc2V0bachelorCalcSecoVtx))) {//Fill the data members of the candidate only if they are empty.
+        
+        //To calculate secondary vertex for pp/pPb if requested
+        //Remember to run also CleanUpTask!
+        if(d->GetIsFilled()==1 && fLc2V0bachelorCalcSecoVtx) vHF->RecoSecondaryVertexForCascades(aod, d);
+        
+        //To be added in AliRDHFCutsLctoV0 IsSelected. If the case, move down after isSelectedFilt as for other mesons
+        Bool_t unsetvtx=kFALSE;
+        if(!d->GetOwnPrimaryVtx()){
+          d->SetOwnPrimaryVtx(vtx1);
+          unsetvtx=kTRUE;
+          // NOTE: the own primary vertex should be unset, otherwise there is a memory leak
+          // Pay attention if you use continue inside this loop!!!
+        }
+        Bool_t recVtx=kFALSE;
+        AliAODVertex *origownvtx=0x0;
+        if(fFiltCutsLc2V0bachelor->GetIsPrimaryWithoutDaughters()){
+          if(d->GetOwnPrimaryVtx()) origownvtx=new AliAODVertex(*d->GetOwnPrimaryVtx());
+          if(fFiltCutsLc2V0bachelor->RecalcOwnPrimaryVtx(d,aod))recVtx=kTRUE;
+          else fFiltCutsLc2V0bachelor->CleanOwnPrimaryVtx(d,aod,origownvtx);
+        }
+        
+        Int_t isSelectedFilt = fFiltCutsLc2V0bachelor->IsSelected(d,AliRDHFCuts::kAll,aod); //selected
+        
+        if(isSelectedFilt > 0){
+          
+          Double_t modelPred = -1.;
+          AliAODPidHF *Pid_HF = fFiltCutsLc2V0bachelor->GetPidHF();
+          Bool_t isSelectedMLFilt = kTRUE;
+          if(fMLResponse) isSelectedMLFilt = fMLResponse->IsSelected(modelPred, d, aod->GetMagneticField(), Pid_HF, 0);
+          if(isSelectedMLFilt){
+            fNentries->Fill(34);
+            nSelectedLc2V0bachelor++;
+            
+            //test analysis cuts
+            Bool_t isSelAnCutstopK0s = kFALSE;
+            Bool_t isSelAnCutstoLpi = kFALSE;
+            Bool_t isSelAnPidCutstopK0s = kFALSE;
+            Bool_t isSelAnPidCutstoLpi = kFALSE;
+            Bool_t isSelAnTopolCutstopK0s = kFALSE;
+            Bool_t isSelAnTopolCutstoLpi = kFALSE;
+            Int_t isSelectedAnalysis = fCutsLc2V0bachelor->IsSelected(d,AliRDHFCuts::kAll,aod);
+            Int_t isSelectedPidAnalysis = fCutsLc2V0bachelor->IsSelectedPID(d);
+            Bool_t isUsePidAn = fCutsLc2V0bachelor->GetIsUsePID();
+            if(isUsePidAn) fCutsLc2V0bachelor->SetUsePID(kFALSE);
+            Int_t isSelectedTopoAnalysis = fCutsLc2V0bachelor->IsSelected(d,AliRDHFCuts::kAll,aod);
+            
+            //Standard selection Lc->pK0s, but keep also Lc->Lpi (different bit)
+            if( (isSelectedAnalysis&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr))                                                                                                       isSelAnCutstopK0s = kTRUE;
+            if( ((isSelectedAnalysis&(AliRDHFCutsLctoV0::kLcToLpi)) == (AliRDHFCutsLctoV0::kLcToLpi)) || ((isSelectedAnalysis&(AliRDHFCutsLctoV0::kLcToLBarpi)) == (AliRDHFCutsLctoV0::kLcToLBarpi)) )         isSelAnCutstoLpi = kTRUE;
+            if( (isSelectedPidAnalysis&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr))                                                                                                    isSelAnPidCutstopK0s = kTRUE;
+            if( ((isSelectedPidAnalysis&(AliRDHFCutsLctoV0::kLcToLpi)) == (AliRDHFCutsLctoV0::kLcToLpi)) || ((isSelectedPidAnalysis&(AliRDHFCutsLctoV0::kLcToLBarpi)) == (AliRDHFCutsLctoV0::kLcToLBarpi)))    isSelAnPidCutstoLpi = kTRUE;
+            if( (isSelectedTopoAnalysis&(AliRDHFCutsLctoV0::kLcToK0Spr)) == (AliRDHFCutsLctoV0::kLcToK0Spr))                                                                                                   isSelAnTopolCutstopK0s = kTRUE;
+            if( ((isSelectedTopoAnalysis&(AliRDHFCutsLctoV0::kLcToLpi)) == (AliRDHFCutsLctoV0::kLcToLpi)) || ((isSelectedTopoAnalysis&(AliRDHFCutsLctoV0::kLcToLBarpi)) == (AliRDHFCutsLctoV0::kLcToLBarpi)) ) isSelAnTopolCutstoLpi = kTRUE;
+            
+            fCutsLc2V0bachelor->SetUsePID(isUsePidAn);
+            Bool_t isSelTracksAnCuts=kFALSE;
+            Int_t isSelectedTrackAnalysis = fCutsLc2V0bachelor->IsSelected(d,AliRDHFCuts::kTracks,aod);
+            if(isSelectedTrackAnalysis > 0) isSelTracksAnCuts=kTRUE;
+            
+            Int_t labLc2V0bachelor = -1;
+            Int_t pdgLc2V0bachelor = -99;
+            Int_t origin= -1;
+            Float_t ptGenLc2V0bachelor = -99;
+            
+            AliAODMCParticle *partLc2V0bachelor=0x0;
+            if(fReadMC) {
+              labLc2V0bachelor = d->MatchToMC(4122,310,pdgDgLc2K0Spr, pdgDgK0stoDaughters, arrMC, kTRUE);
+              if(labLc2V0bachelor>=0){
+                partLc2V0bachelor = (AliAODMCParticle*)arrMC->At(labLc2V0bachelor);
+                pdgLc2V0bachelor = TMath::Abs(partLc2V0bachelor->GetPdgCode());
+                ptGenLc2V0bachelor = partLc2V0bachelor->Pt();
+                origin = AliVertexingHFUtils::CheckOrigin(arrMC,partLc2V0bachelor,!fITSUpgradeStudy);
+              }
+            }
+            
+            bool issignal = kFALSE;
+            bool isbkg =    kFALSE;
+            bool isFD =     kFALSE;
+            bool isprompt = kFALSE;
+            bool isrefl =   kFALSE;
+            Int_t masshypo = 0;
+            
+            if(fReadMC){
+              if(labLc2V0bachelor>=0){
+                if(origin==4 || origin==5) {
+                  if(origin==4) isprompt=kTRUE;
+                  else if(origin==5) isFD=kTRUE;
+                  if(pdgLc2V0bachelor==4122){
+                    issignal=kTRUE;
+                  }
+                }
+              }//end labLc2V0bachelor check
+              else{//background
+                isbkg=kTRUE;
+              }
+              if(issignal || isbkg || isrefl) fTreeHandlerLc2V0bachelor->SetCandidateType(issignal,isbkg,isprompt,isFD,isrefl);
+            }//end read MC
+            if(!fReadMC || (issignal || isbkg || isrefl)) {
+              fTreeHandlerLc2V0bachelor->SetIsSelectedStd(isSelAnCutstopK0s,isSelAnTopolCutstopK0s,isSelAnPidCutstopK0s,isSelTracksAnCuts);
+              fTreeHandlerLc2V0bachelor->SetIsLctoLpi(isSelAnCutstoLpi, isSelAnTopolCutstoLpi, isSelAnPidCutstoLpi);
+              fTreeHandlerLc2V0bachelor->SetVariables(fRunNumber,fEventID,ptGenLc2V0bachelor,modelPred,d,bfield,masshypo,fPIDresp);
+              fTreeHandlerLc2V0bachelor->FillTree();
+            }
+          }//end is selected filt
+          if(recVtx)fFiltCutsLc2V0bachelor->CleanOwnPrimaryVtx(d,aod,origownvtx);
+          if(unsetvtx) d->UnsetOwnPrimaryVtx();
+        } //end ML selection
+      } // end Lc IsSelected
+      else {
+        fNentries->Fill(35); //monitor how often this fails
+      }
+    }//end Lc2V0bachelor
+  }//end loop on candidates
+  
+  delete vHF;
+  return;
+}
+//_________________________________________________________________
+void AliAnalysisTaskSEHFTreeCreatorApply::ProcessMCGen(TClonesArray *arrayMC){
+  /// Fill MC gen trees
+  
+  for(Int_t iPart=0; iPart<arrayMC->GetEntriesFast(); iPart++){
+    
+    AliAODMCParticle* mcPart = dynamic_cast<AliAODMCParticle*>(arrayMC->At(iPart));
+    Int_t absPDG = TMath::Abs(mcPart->GetPdgCode());
+    
+    if(absPDG == 431 || absPDG == 4122) {
+      Bool_t isPrimary = kFALSE;
+      Bool_t isFeeddown = kFALSE;
+
+      Int_t orig = AliVertexingHFUtils::CheckOrigin(arrayMC,mcPart,!fITSUpgradeStudy);//Prompt = 4, FeedDown = 5
+      if(orig!=4 && orig!=5) continue; //keep only prompt or feed-down
+        
+      if(orig==4){
+        isPrimary = kTRUE;
+        isFeeddown = kFALSE;
+      }
+      else if(orig==5){
+        isPrimary = kFALSE;
+        isFeeddown = kTRUE;
+      }
+      
+      Int_t  deca = 0;
+      Int_t  labDau[3] = {-1,-1,-1};
+      Bool_t isDaugInAcc = kFALSE;
+      
+      if(absPDG == 431 && fWriteVariableTreeDs) {
+        deca = AliVertexingHFUtils::CheckDsDecay(arrayMC,mcPart,labDau);
+        if(deca!=fWriteVariableTreeDs || labDau[0]<0 || labDau[1]<0) continue;
+        isDaugInAcc = CheckDaugAcc(arrayMC,3,labDau,fITSUpgradeStudy);
+        fTreeHandlerGenDs->SetDauInAcceptance(isDaugInAcc);
+        fTreeHandlerGenDs->SetCandidateType(kTRUE,kFALSE,isPrimary,isFeeddown,kFALSE);
+        fTreeHandlerGenDs->SetMCGenVariables(fRunNumber,fEventID, mcPart);
+        fTreeHandlerGenDs->FillTree();
+      } else if(absPDG == 4122 && fWriteVariableTreeLc2V0bachelor) {
+        deca = AliVertexingHFUtils::CheckLcV0bachelorDecay(arrayMC,mcPart,labDau);
+        if(deca!=1 || labDau[0]<0 || labDau[1]<0) continue;
+        isDaugInAcc = CheckDaugAcc(arrayMC,3,labDau,fITSUpgradeStudy);
+        fTreeHandlerGenLc2V0bachelor->SetDauInAcceptance(isDaugInAcc);
+        fTreeHandlerGenLc2V0bachelor->SetCandidateType(kTRUE,kFALSE,isPrimary,isFeeddown,kFALSE);
+        fTreeHandlerGenLc2V0bachelor->SetMCGenVariables(fRunNumber,fEventID, mcPart);
+        fTreeHandlerGenLc2V0bachelor->FillTree();
+      }
+    }
+  }
+}
+//________________________________________________________________________
+std::string AliAnalysisTaskSEHFTreeCreatorApply::GetPeriod(const AliVEvent* event){
+
+  /// Get the period name corresponding to the runnumber that is being analysed
+
+  Int_t runNo  = event->GetRunNumber();
+  // pp: 0-LHC10b, 1-LHC10c, 2-LHC10d, 3-LHC10e
+  // pPb 2013: 0-LHC13b, 1-LHC13c
+  // pPb 2016: 0-LHC16q: 265499->265525; 265309->265387, 1-LHC16q:265435, 2-LHC16q:265388->265427, LHC16t: 267163->267166
+  
+  if (runNo>195343 && runNo<195484) return "LHC13b";
+  if (runNo>195528 && runNo<195678) return "LHC13c";
+  if ((runNo>=265499 && runNo<=265525) || (runNo>=265309 && runNo<=265387)) return "LHC16q_0";
+  if (runNo == 265435) return "LHC16q_1";
+  if (runNo>=265388 && runNo<=265427) return "LHC16q_2";
+  if (runNo>=267163 && runNo<=267166) return "LHC16t";
+  
+  // if(runNo>114930 && runNo<117223) period = 0;
+  // if(runNo>119158 && runNo<120830) period = 1;
+  // if(runNo>122373 && runNo<126438) period = 2;
+  // if(runNo>127711 && runNo<130851) period = 3;
+  
+  if (runNo>=252235 && runNo<=252375) return "LHC16d";
+  if (runNo>=252603 && runNo<=253591) return "LHC16e";
+  if (runNo>=254124 && runNo<=254332) return "LHC16g";
+  if (runNo>=254378 && runNo<=255469) return "LHC16h_1";
+  if (runNo>=254418 && runNo<=254422) return "LHC16h_2";
+  if (runNo>=256146 && runNo<=256420) return "LHC16j";
+  if (runNo>=256504 && runNo<=258537) return "LHC16k";
+  if (runNo>=258883 && runNo<=260187) return "LHC16l";
+  if (runNo>=262395 && runNo<=264035) return "LHC16o";
+  if (runNo>=264076 && runNo<=264347) return "LHC16p";
+  
+  if (runNo>=270822 && runNo<=270830) return "LHC17e";
+  if (runNo>=270854 && runNo<=270865) return "LHC17f";
+  if (runNo>=271868 && runNo<=273103) return "LHC17h";
+  if (runNo>=273591 && runNo<=274442) return "LHC17i";
+  if (runNo>=274593 && runNo<=274671) return "LHC17j";
+  if (runNo>=274690 && runNo<=276508) return "LHC17k";
+  if (runNo>=276551 && runNo<=278216) return "LHC17l";
+  if (runNo>=278914 && runNo<=280140) return "LHC17m";
+  if (runNo>=280282 && runNo<=281961) return "LHC17o";
+  if (runNo>=282504 && runNo<=282704) return "LHC17r";
+  
+  if(runNo>=285008 && runNo<=285447) return "LHC18b";
+  if(runNo>=285978 && runNo<=286350) return "LHC18d";
+  if(runNo>=286380 && runNo<=286937) return "LHC18e";
+  if(runNo>=287000 && runNo<=287977) return "LHC18f";
+  if(runNo>=288619 && runNo<=288750) return "LHC18g";
+  if(runNo>=288804 && runNo<=288806) return "LHC18h";
+  if(runNo>=288861 && runNo<=288909) return "LHC18i";
+  if(runNo==288943) return "LHC18j";
+  if(runNo>=289165 && runNo<=289201) return "LHC18k";
+  if(runNo>=289240 && runNo<=289971) return "LHC18l";
+  if(runNo>=290222 && runNo<=292839) return "LHC18m";
+  if(runNo>=293357 && runNo<=293359) return "LHC18n";
+  if(runNo>=293368 && runNo<=293898) return "LHC18o";
+  if(runNo>=294009 && runNo<=294925) return "LHC18p";
+  
+  return "undefined";
+}
+//--------------------------------------------------------
+Bool_t AliAnalysisTaskSEHFTreeCreatorApply::CheckDaugAcc(TClonesArray* arrayMC,Int_t nProng, Int_t *labDau, Bool_t ITSUpgradeStudy){
+  /// check if the decay products are in the good eta and pt range
+  
+  for (Int_t iProng = 0; iProng<nProng; iProng++){
+    AliAODMCParticle* mcPartDaughter=dynamic_cast<AliAODMCParticle*>(arrayMC->At(labDau[iProng]));
+    if(!mcPartDaughter) {
+      return kFALSE;
+    }
+    Double_t eta = mcPartDaughter->Eta();
+    if(ITSUpgradeStudy){
+      if (TMath::Abs(eta) >= 1) return kFALSE;
+    } else {
+      Double_t pt = mcPartDaughter->Pt();
+      if (TMath::Abs(eta) > 0.9 || pt < 0.1) return kFALSE;
+    }
+  }
+  return kTRUE;
+}
+//________________________________________________________________________
+Bool_t AliAnalysisTaskSEHFTreeCreatorApply::IsCandidateFromHijing(AliAODRecoDecayHF *cand, AliAODMCHeader *mcHeader, TClonesArray* arrMC, AliAODTrack *tr){
+  //
+  // Returns true if candidate (or cand + track for on-the-fly reconstruction) are from Hijing, so not injected.
+  //
+  
+  Bool_t candNotHijing = AliVertexingHFUtils::IsCandidateInjected(cand, mcHeader,arrMC);
+  if(tr){
+    Bool_t trackNotHijing = AliVertexingHFUtils::IsTrackInjected(tr,mcHeader,arrMC);
+    if(!candNotHijing && !trackNotHijing) return kTRUE;
+  } else {
+    if(!candNotHijing) return kTRUE;
+  }
+  return kFALSE;
+  
+}
+//________________________________________________________________________
+void AliAnalysisTaskSEHFTreeCreatorApply::SelectGoodTrackForReconstruction(AliAODEvent *aod, Int_t trkEntries, Int_t &nSeleTrks,Bool_t *seleFlags)
+{
+  //
+  // Select good tracks for on the fly reconstruction (Bplus, Bs, Lb, ..) and return the array of their ids
+  //
+  
+  nSeleTrks=0;
+  for(Int_t i=0; i<trkEntries; i++) {
+    seleFlags[i] = kFALSE;
+    
+    AliAODTrack* track = dynamic_cast<AliAODTrack*>(aod->GetTrack(i));
+    
+    // skip tracks with negative ID
+    // (these are duplicated TPC-only AOD tracks, for jet analysis...)
+    if(track->GetID()<0) continue;
+    
+    // TEMPORARY: check that the cov matrix is there
+    Double_t covtest[21];
+    if(!track->GetCovarianceXYZPxPyPz(covtest)) continue;
+    
+    // skip pure ITS SA tracks
+    if(track->GetStatus()&AliESDtrack::kITSpureSA) continue;
+    // skip tracks without ITS
+    if(!(track->GetStatus()&AliESDtrack::kITSin)) continue;
+    // avoid ghost TPC tracks
+    if(!(track->GetStatus()&AliESDtrack::kTPCrefit)) continue;
+    
+    if(fGoodTrackFilterBit>=0 && !track->TestFilterMask(BIT(fGoodTrackFilterBit))) continue;
+    if(fabs(track->Eta())>fGoodTrackEtaRange) continue;
+    if(track->Pt()<fGoodTrackMinPt) continue;
+    
+    seleFlags[i]=kTRUE;
+    nSeleTrks++;
+    
+  } // end loop on tracks
+}
+//________________________________________________________________
+AliAODVertex* AliAnalysisTaskSEHFTreeCreatorApply::ReconstructDisplVertex(const AliVVertex *primary, TObjArray *tracks, Double_t bField, Double_t dispersion) {
+  //
+  // Helper function to recalculate a vertex.
+  //
+  
+  AliESDVertex *vertexESD = 0;
+  AliAODVertex *vertexAOD = 0;
+  
+  AliVertexerTracks vertexer;
+  vertexer.SetFieldkG(bField);
+  
+  vertexer.SetVtxStart((AliESDVertex*)primary); //primary vertex
+  vertexESD = (AliESDVertex*)vertexer.VertexForSelectedESDTracks(tracks);
+  
+  if (!vertexESD) return vertexAOD;
+  
+  if (vertexESD->GetNContributors() != tracks->GetEntriesFast()){
+    delete vertexESD; vertexESD = nullptr;
+    return vertexAOD;
+  }
+  
+  // convert to AliAODVertex
+  Double_t pos[3], cov[6], chi2perNDF;
+  for (Int_t a = 0; a < 3; a++)pos[a] = 0.;
+  for (Int_t b = 0; b < 6; b++)cov[b] = 0.;
+  chi2perNDF = 0;
+  
+  vertexESD->GetXYZ(pos); // position
+  vertexESD->GetCovMatrix(cov); //covariance matrix
+  
+  Double_t vertRadius2 = pos[0] * pos[0] + pos[1] * pos[1];
+  if (vertRadius2 > 8.){ //(2.82)^2 radius beam pipe
+    delete vertexESD; vertexESD = nullptr;
+    return vertexAOD;
+  }
+  
+  chi2perNDF = vertexESD->GetChi2toNDF();
+  dispersion = vertexESD->GetDispersion();
+  delete vertexESD; vertexESD = nullptr;
+  Int_t nprongs = tracks->GetEntriesFast();
+  vertexAOD = new AliAODVertex(pos, cov, chi2perNDF, 0x0, -1, AliAODVertex::kUndef, nprongs);
+  
+  return vertexAOD;
+}
+
+//________________________________________________________________
+unsigned int AliAnalysisTaskSEHFTreeCreatorApply::GetEvID() {
+  
+  TString currentfilename = ((AliAnalysisManager::GetAnalysisManager()->GetInputEventHandler()->GetTree()->GetCurrentFile()))->GetName();
+  if(!fFileName.EqualTo(currentfilename)) {
+    fEventNumber = 0;
+    fFileName = currentfilename;
+    TObjArray *path = fFileName.Tokenize("/");
+    TString s = ((TObjString*)path->At( ((path->GetLast())-1) ))->GetString();
+    fDirNumber = (unsigned int)s.Atoi();
+    delete path;
+  }
+  Long64_t ev_number = Entry();
+  if(fReadMC){
+    ev_number = fEventNumber;
+  }
+  unsigned int evID = (unsigned int)ev_number + (unsigned int)(fDirNumber<<17);
+  fEventNumber++;
+  return evID;
+}

--- a/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEHFTreeCreatorApply.h
+++ b/PWGHF/vertexingHF/vHFML/AliAnalysisTaskSEHFTreeCreatorApply.h
@@ -1,0 +1,269 @@
+#ifndef AliAnalysisTaskSEHFTreeCreatorApply_H
+#define AliAnalysisTaskSEHFTreeCreatorApply_H
+
+/* Copyright(c) 1998-2009, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
+
+/* $Id$ */
+
+///*************************************************************************
+/// \class AliAnalysisTaskSEHFTreeCreatorApply
+/// 
+// \authors:
+// L. Vermunt, luuk.vermunt@cern.ch
+///*************************************************************************
+
+#include <TROOT.h>
+#include <TSystem.h>
+#include <TNtuple.h>
+#include <TTree.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TH3F.h>
+#include "TProfile.h"
+
+#include "AliAnalysisTaskSE.h"
+#include "AliRDHFCutsLctoV0.h"
+#include "AliRDHFCutsDstoKKpi.h"
+#include "AliNormalizationCounter.h"
+#include "AliPIDResponse.h"
+#include "AliHFTreeHandlerApply.h"
+#include "AliHFTreeHandlerApplyLc2V0bachelor.h"
+#include "AliHFTreeHandlerApplyDstoKKpi.h"
+#include "AliHFMLResponse.h"
+
+class AliAODMCHeader;
+class AliAODEvent;
+class TClonesArray;
+class AliCDBEntry;
+
+class AliAnalysisTaskSEHFTreeCreatorApply : public AliAnalysisTaskSE
+{
+public:
+  
+  AliAnalysisTaskSEHFTreeCreatorApply();
+  AliAnalysisTaskSEHFTreeCreatorApply(const char *name, TList *cutsList);
+  virtual ~AliAnalysisTaskSEHFTreeCreatorApply();
+  
+  /// Implementation of interface methods
+  virtual void UserCreateOutputObjects();
+  virtual void Init();
+  virtual void LocalInit() {Init();}
+  virtual void UserExec(Option_t *option);
+  virtual void Terminate(Option_t *option);
+
+  void SetReadMC(Bool_t opt=kFALSE){fReadMC=opt;}
+  Bool_t GetReadMC() const {return fReadMC;}
+  void SetUseSelectionBit(Bool_t opt=kFALSE){fUseSelectionBit=opt;}
+  Bool_t GetUseSelectionBit() const {return fUseSelectionBit;}
+  void SetSystem(Int_t opt){fSys=opt;}
+  Int_t GetSystem() const {return fSys;}
+  void SetAODMismatchProtection(Int_t opt=1) {fAODProtection=opt;}
+  Int_t GetAODMismatchProtection() const {return fAODProtection;}
+
+  void SetFillDsTree(Int_t opt){fWriteVariableTreeDs=opt;}
+  Int_t GetFillDsTree() const {return fWriteVariableTreeDs;}
+  void SetFillLc2V0bachelorTree(Int_t opt){fWriteVariableTreeLc2V0bachelor=opt;}
+  Int_t GetFillLc2V0bachelorTree() const {return fWriteVariableTreeLc2V0bachelor;}
+  void SetPIDoptDsTree(Int_t opt){fPIDoptDs=opt;}
+  Int_t GetPIDoptDsTree() const {return fPIDoptDs;}
+  void SetPIDoptLc2V0bachelorTree(Int_t opt){fPIDoptLc2V0bachelor=opt;}
+  Int_t GetPIDoptLc2V0bachelorTree() const {return fPIDoptLc2V0bachelor;}
+  void SetWriteOnlySignalTree(Bool_t opt){fWriteOnlySignal=opt;}
+  Bool_t GetWriteOnlySignalTree() const {return fWriteOnlySignal;}
+  void SetFillMCGenTrees(Bool_t fillMCgen) {fFillMCGenTrees=fillMCgen;}
+  Bool_t GetFillMCGenTrees() const {return fFillMCGenTrees;}
+
+  unsigned int GetEvID();
+  std::string GetPeriod(const AliVEvent *ev);
+  void SetMultiplVsZProfile(std::string period, TProfile *hprof)
+  {
+    delete fMultEstimatorAvg[period];
+    fMultEstimatorAvg[period] = new TProfile(*hprof);
+  }
+  void SetMultiplVsZProfileSHM(std::string period, TProfile *hprof)
+  {
+    delete fMultEstimatorAvgSHM[period];
+    fMultEstimatorAvgSHM[period] = new TProfile(*hprof);
+  }
+
+  void SetRefMult(Double_t refMult) { fRefMult = refMult; }
+  Double_t GetRefMult() { return fRefMult; }
+  void SetRefMultSHM(Double_t refMult) { fRefMultSHM = refMult; }
+  Double_t GetRefMultSHM() { return fRefMultSHM; }
+  void SetCorrNtrVtx(Bool_t corr = true) { fCorrNtrVtx = corr; }
+  Bool_t GetCorrNtrVtx() const { return fCorrNtrVtx; }
+  void SetCorrV0MVtx(Bool_t corr = true) { fCorrV0MVtx = corr; }
+  Bool_t GetCorrV0MVtx() const { return fCorrV0MVtx; }
+  
+  void SetDsMassKKOption(AliHFTreeHandlerApplyDstoKKpi::massKKopt opt) {fDsMassKKOpt=opt;}
+  Int_t GetDsMassKKOption() const {return fDsMassKKOpt;}
+  void SetLc2V0bachelorCalcSecoVtx(Int_t opt=1) {fLc2V0bachelorCalcSecoVtx=opt;}
+  Int_t GetLc2V0bachelorCalcSecoVtx() const {return fLc2V0bachelorCalcSecoVtx;}
+  void SetLc2V0type(Int_t opt=1) {fV0typeForLc2V0bachelor=opt;}
+  Int_t GetLc2V0type() const {return fV0typeForLc2V0bachelor;}
+  void SetTreeSingleTrackVarsOpt(Int_t opt) {fTreeSingleTrackVarsOpt=opt;}
+  Int_t GetTreeSingleTrackVarsOpt() const {return fTreeSingleTrackVarsOpt;}
+
+  void SetGoodTrackFilterBit(Int_t i) { fGoodTrackFilterBit = i; }
+  Int_t GetGoodTrackFilterBit() const { return fGoodTrackFilterBit; }
+  void SetGoodTrackEtaRange(Double_t d) { fGoodTrackEtaRange = d; }
+  Double_t GetGoodTrackEtaRange() const { return fGoodTrackEtaRange; }
+  void SetGoodTrackMinPt(Double_t d) { fGoodTrackMinPt = d; }
+  Double_t GetGoodTrackMinPt() const { return fGoodTrackMinPt; }
+  void SetITSUpgradeStudy(Bool_t b) { fITSUpgradeStudy = b; }
+  Double_t GetITSUpgradeStudy() const { return fITSUpgradeStudy; }
+
+  void ApplyPhysicsSelectionOnline(bool apply=true) { fApplyPhysicsSelOnline = apply; }
+  Bool_t GetApplyPhysicsSelOnline() const { return fApplyPhysicsSelOnline; }
+  void EnableEventDownsampling(float fractokeep, unsigned long seed) {
+    fEnableEventDownsampling = true;
+    fFracToKeepEventDownsampling = fractokeep;
+    fSeedEventDownsampling = seed;
+  }
+  Bool_t GetEnableEventDownsampling() const { return fEnableEventDownsampling; }
+  Float_t GetFracToKeepEventDownsampling() const { return fFracToKeepEventDownsampling; }
+  unsigned long GetSeedEventDownsampling() const { return fSeedEventDownsampling; }
+  void SetMLConfigFile(TString path = ""){fConfigPath = path;}
+  TString GetMLConfigFile() const { return fConfigPath; }
+
+  void SetNsigmaTPCDataDrivenCorrection(Int_t syst) {
+    fEnableNsigmaTPCDataCorr=true;
+    fSystemForNsigmaTPCDataCorr=syst;
+  }
+  Bool_t GetEnableNsigmaTPCDataCorr() const { return fEnableNsigmaTPCDataCorr; }
+  Int_t GetSystemForNsigmaTPCDataCorr() const { return fSystemForNsigmaTPCDataCorr; }
+  
+  void Process3Prong(TClonesArray *array3Prong, AliAODEvent *aod, TClonesArray *arrMC, Float_t bfield);
+  void ProcessCasc(TClonesArray *arrayCasc, AliAODEvent *aod, TClonesArray *arrMC, Float_t bfield);
+  void ProcessMCGen(TClonesArray *mcarray);
+
+  Bool_t CheckDaugAcc(TClonesArray* arrayMC,Int_t nProng, Int_t *labDau, Bool_t ITSUpgradeStudy);
+  Bool_t IsCandidateFromHijing(AliAODRecoDecayHF *cand, AliAODMCHeader *mcHeader, TClonesArray* arrMC, AliAODTrack *tr = 0x0);
+  void SelectGoodTrackForReconstruction(AliAODEvent *aod, Int_t trkEntries, Int_t &nSeleTrks,Bool_t *seleFlags);
+  AliAODVertex* ReconstructDisplVertex(const AliVVertex *primary, TObjArray *tracks, Double_t bField, Double_t dispersion);
+
+private:
+
+  AliAnalysisTaskSEHFTreeCreatorApply(const AliAnalysisTaskSEHFTreeCreatorApply&);
+  AliAnalysisTaskSEHFTreeCreatorApply& operator=(const AliAnalysisTaskSEHFTreeCreatorApply&);
+
+  unsigned int            fEventNumber;
+  TH1F                    *fNentries;                            //!<!   histogram with number of events on output slot 1
+  TH2F                    *fHistoNormCounter;                    //!<!   histogram with number of events on output slot 1
+  TList                   *fListCounter;                         //!<!   list for normalization counter on output slot 3
+  AliNormalizationCounter *fCounter;                             //!<!   AliNormalizationCounter
+
+  TList                   *fListCuts;                            /// list of cuts sent to output slot 2
+  AliRDHFCutsDstoKKpi     *fFiltCutsDstoKKpi;                    /// DstoKKpi filtering (or loose) cuts
+  AliRDHFCutsLctoV0       *fFiltCutsLc2V0bachelor;               /// Lc2V0bachelor filtering (or loose) cuts
+  AliRDHFCutsDstoKKpi     *fCutsDstoKKpi;                        /// DstoKKpi analysis cuts
+  AliRDHFCutsLctoV0       *fCutsLc2V0bachelor;                   /// Lc2V0bachelor analysis cuts
+  AliRDHFCuts             *fEvSelectionCuts;                     /// Event selection cuts
+
+  Bool_t                  fReadMC;                               /// flag for MC array: kTRUE = read it, kFALSE = do not read it
+  Bool_t                  fUseSelectionBit;                      /// flag to use selection bit when looping over TClonesArray
+  Int_t                   fSys;                                  /// fSys=0 -> p-p; fSys=1 ->PbPb
+  Int_t                   fAODProtection;                        /// flag to activate protection against AOD-dAOD mismatch.
+  // -1: no protection,  0: check AOD/dAOD nEvents only,  1: check AOD/dAOD nEvents + TProcessID names
+
+  Bool_t                  fWriteOnlySignal;                       /// flag to decide wether to write only signal or signal+background
+  Bool_t                  fFillMCGenTrees;                        /// flag to enable fill of the generated trees
+  Int_t                   fWriteVariableTreeDs;                   /// flag to decide whether to write the Ds variables on a tree variables
+  Int_t                   fWriteVariableTreeLc2V0bachelor;        /// flag to decide whether to write the Lc->pK0s variables on a tree variables
+  // 0 don't fill
+  // 1 fill standard tree
+
+  TTree                   *fVariablesTreeDs;                     //!<! tree of the candidate variables
+  TTree                   *fVariablesTreeLc2V0bachelor;          //!<! tree of the candidate variables
+  TTree                   *fGenTreeDs;                           //!<! tree of the gen Ds variables
+  TTree                   *fGenTreeLc2V0bachelor;                //!<! tree of the gen Lc2V0bachelor variables
+  TTree                   *fTreeEvChar;                          //!<! tree of event variables
+
+  AliHFTreeHandlerApplyDstoKKpi       *fTreeHandlerDs;                //!<! handler object for the tree with topological variables
+  AliHFTreeHandlerApplyLc2V0bachelor  *fTreeHandlerLc2V0bachelor;     //!<! handler object for the tree with topological variables
+  AliHFTreeHandlerApplyDstoKKpi       *fTreeHandlerGenDs;             //!<! handler object for the tree with topological variables
+  AliHFTreeHandlerApplyLc2V0bachelor  *fTreeHandlerGenLc2V0bachelor;  //!<! handler object for the tree with topological variables
+
+  AliPIDResponse          *fPIDresp;                             /// PID response
+  Int_t                   fPIDoptDs;                             /// PID option for Ds tree
+  Int_t                   fPIDoptLc2V0bachelor;                  /// PID option for Lc2V0bachelor tree
+
+  UInt_t                  fEventID;                              /// event ID (unique when combined with run number)
+  TString                 fFileName;                             /// Store filename for an unique event ID
+  unsigned int            fDirNumber;                            /// Store directory number for an unique event ID
+
+  Float_t                 fCentrality;                           /// event centrality
+  Float_t                 fzVtxReco;                             /// reconstructed Zvtx
+  Float_t                 fzVtxGen;                              /// generated Zvtx
+  Int_t                   fNcontributors;                        /// number of contributors
+  Int_t                   fNtracks;                              /// number of tracks
+  Int_t                   fIsEvRej;                              /// flag with information about rejection of the event
+  Int_t                   fIsEvRej_INT7;                         /// flag with information about rejection of the event
+  Int_t                   fIsEvRej_HighMultSPD;                  /// flag with information about rejection of the event
+  Int_t                   fIsEvRej_HighMultV0;                   /// flag with information about rejection of the event
+  Int_t                   fRunNumber;                            /// run number
+  Int_t                   fRunNumberCDB;                         /// run number (for OCDB)
+  Int_t                   fnTracklets;                           /// number of tracklets
+  Int_t                   fnTrackletsCorr;                       /// number of tracklets (corrected)
+  Int_t                   fnTrackletsCorrSHM;                    /// number of tracklets (corrected)
+  Int_t                   fnV0A;                                 /// V0A multiplicity
+  Int_t                   fMultGen;                              /// generated multiplicity around mid-rapidity [-1,1]
+  Int_t                   fMultGenV0A;                           /// generated multiplicity in V0A range
+  Int_t                   fMultGenV0C;                           /// generated multiplicity in V0C range
+  ULong64_t               fTriggerMask;                          /// Trigger mask bitmap
+  Bool_t                  fTriggerOnlineINT7;                    /// Flag explicitly whether bitmap contains INT7
+  Bool_t                  fTriggerOnlineHighMultSPD;             /// Flag explicitly whether bitmap contains HighMultSPD
+  Bool_t                  fTriggerOnlineHighMultV0;              /// Flag explicitly whether bitmap kHighMultV0
+  Bool_t                  fTriggerBitINT7;                       /// Flag explicitly whether bitmap contains INT7
+  Bool_t                  fTriggerBitHighMultSPD;                /// Flag explicitly whether bitmap contains HighMultSPD
+  Bool_t                  fTriggerBitHighMultV0;                 /// Flag explicitly whether bitmap kHighMultV0
+  Bool_t                  fTriggerBitCentral;                    /// Flag explicitly whether bitmap contains kCentral
+  Bool_t                  fTriggerBitSemiCentral;                /// Flag explicitly whether bitmap contains kSemiCentral
+  TString                 fTriggerClasses;                       /// Collect all trigger classes
+  Bool_t                  fTriggerClassINT7;                     /// Flag explicitly whether classes contain INT7
+  Bool_t                  fTriggerClassHighMultSPD;              /// Flag explicitly whether classes contain HighMultSPD
+  Bool_t                  fTriggerClassHighMultV0m;              /// Flag explicitly whether classes contain HighMultV0
+  Int_t                   fnV0M;                                 /// V0M multiplicity
+  Int_t                   fnV0MEq;                               /// V0M multiplicity (equalized)
+  Int_t                   fnV0MCorr;                             /// V0M multiplicity (corrected)
+  Int_t                   fnV0MEqCorr;                           /// V0M multiplicity (equalized + corrected)
+  Float_t                 fPercV0M;                              /// V0M multiplicity percentile
+  Float_t                 fMultV0M;                              /// V0M multiplicity from mult selection task
+
+  Double_t                fRefMult;                              /// reference multiplicity
+  Double_t                fRefMultSHM;                           /// reference multiplicity
+  std::map<std::string, TProfile*> fMultEstimatorAvg;
+  std::map<std::string, TProfile*> fMultEstimatorAvgSHM;
+  Bool_t fCorrNtrVtx;
+  Bool_t fCorrV0MVtx;
+  AliCDBEntry *fCdbEntry;
+
+  Int_t                   fDsMassKKOpt;                          /// option for Ds massKK (mass or delta mass)
+  Int_t                   fLc2V0bachelorCalcSecoVtx;             /// option to calculate the secondary vertex for Lc2V0bachelor. False by default, has to be added to AddTask in case we want to start using it.
+  Int_t                   fV0typeForLc2V0bachelor;               /// option to select Offline+OnTheFly (0), only Offline (1=default), only OnTheFly (2) V0's for the Lc->V0bachelor decay
+  Int_t                   fTreeSingleTrackVarsOpt;               /// option for single-track variables to be filled in the trees
+  
+  Int_t                   fGoodTrackFilterBit;                   /// Setting filter bit for bachelor on-the-fly reconstruction candidate
+  Double_t                fGoodTrackEtaRange;                    /// Setting eta-range for bachelor on-the-fly reconstruction candidate
+  Double_t                fGoodTrackMinPt;                       /// Setting min pT for bachelor on-the-fly reconstruction candidate
+  Bool_t                  fITSUpgradeStudy;                      /// Setting for analysing an ITS Upgrade production
+
+  Bool_t fEnableNsigmaTPCDataCorr;                               /// flag to enable data-driven NsigmaTPC correction
+  Int_t fSystemForNsigmaTPCDataCorr;                             /// system for data-driven NsigmaTPC correction
+
+  Bool_t fApplyPhysicsSelOnline;                                 /// flag to apply physics selection in the task
+  Bool_t fEnableEventDownsampling;                               /// flag to apply event downsampling
+  Float_t fFracToKeepEventDownsampling;                          /// fraction of events to be kept by event downsampling
+  unsigned long fSeedEventDownsampling;                          /// seed for event downsampling
+
+  TString fConfigPath;                                           /// path to ML config file
+  AliHFMLResponse* fMLResponse;                                  //!<! object to handle ML response
+
+  /// \cond CLASSIMP
+  ClassDef(AliAnalysisTaskSEHFTreeCreatorApply,1);
+  /// \endcond
+};
+
+#endif
+

--- a/PWGHF/vertexingHF/vHFML/AliHFMLResponseLctoV0bachelor.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliHFMLResponseLctoV0bachelor.cxx
@@ -1,0 +1,157 @@
+// Copyright CERN. This software is distributed under the terms of the GNU
+// General Public License v3 (GPL Version 3).
+//
+// See http://www.gnu.org/licenses/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//**************************************************************************************
+// \class AliHFMLResponseLctoV0bachelor
+// \brief helper class to handle application of ML models for LctopK0s analyses trained
+// with python libraries
+// \authors:
+// L. Vermunt, luuk.vermunt@cern.ch
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#include <TDatabasePDG.h>
+
+#include "AliHFMLResponseLctoV0bachelor.h"
+#include "AliAODRecoCascadeHF.h"
+#include "AliVertexingHFUtils.h"
+
+/// \cond CLASSIMP
+ClassImp(AliHFMLResponseLctoV0bachelor);
+/// \endcond
+
+//--------------------------------------------------------------------------
+AliHFMLResponseLctoV0bachelor::AliHFMLResponseLctoV0bachelor() : AliHFMLResponse()
+{
+  //
+  // Default constructor
+  //
+}
+
+//--------------------------------------------------------------------------
+AliHFMLResponseLctoV0bachelor::AliHFMLResponseLctoV0bachelor(const Char_t *name, const Char_t *title,
+                                                             const std::string configfilepath) : AliHFMLResponse(name, title, configfilepath)
+{
+  //
+  // Standard constructor
+  //
+}
+
+//--------------------------------------------------------------------------
+AliHFMLResponseLctoV0bachelor::~AliHFMLResponseLctoV0bachelor()
+{
+  //
+  // Destructor
+  //
+}
+
+//--------------------------------------------------------------------------
+AliHFMLResponseLctoV0bachelor::AliHFMLResponseLctoV0bachelor(const AliHFMLResponseLctoV0bachelor &source) : AliHFMLResponse(source)
+{
+  //
+  // Copy constructor
+  //
+}
+
+//--------------------------------------------------------------------------
+AliHFMLResponseLctoV0bachelor &AliHFMLResponseLctoV0bachelor::operator=(const AliHFMLResponseLctoV0bachelor &source)
+{
+  //
+  // assignment operator
+  //
+  if (&source == this)
+    return *this;
+  
+  AliHFMLResponse::operator=(source);
+  
+  return *this;
+}
+
+//--------------------------------------------------------------------------
+void AliHFMLResponseLctoV0bachelor::SetMapOfVariables(AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF, int /*masshypo*/)
+{
+  fVars["pt_cand"] = cand->Pt();
+  fVars["d_len"] = cand->DecayLength();
+  fVars["d_len_xy"] = cand->DecayLengthXY();
+  fVars["norm_dl"] = cand->NormalizedDecayLength();
+  fVars["norm_dl_xy"] = cand->NormalizedDecayLengthXY();
+  fVars["cos_p"] = cand->CosPointingAngle();
+  fVars["cos_p_xy"] = cand->CosPointingAngleXY();
+  fVars["imp_par_xy"] = cand->ImpParXY();
+  fVars["dca"] = cand->GetDCA();
+  fVars["inv_mass"] = dynamic_cast<AliAODRecoCascadeHF *>(cand)->InvMassLctoK0sP();
+  
+  AliAODv0 * v0part = ((AliAODRecoCascadeHF*)cand)->Getv0();
+  fVars["imp_par_prong0"] = cand->Getd0Prong(0);
+  fVars["imp_par_prong1"] = v0part->Getd0Prong(0);
+  fVars["imp_par_prong2"] = v0part->Getd0Prong(1);
+
+  fVars["inv_mass_K0s"] = v0part->MassK0Short();
+  fVars["dca_K0s"] = v0part->GetDCA();
+  fVars["imp_par_K0s"] = cand->Getd0Prong(1);
+  fVars["d_len_K0s"] = ((AliAODRecoCascadeHF*)cand)->DecayLengthV0();
+  fVars["ctau_K0s"] = ((AliAODRecoCascadeHF*)cand)->DecayLengthV0()*0.497/(v0part->P());
+  fVars["cos_p_K0s"] = ((AliAODRecoCascadeHF*)cand)->CosV0PointingAngle();
+  fVars["pt_K0s"] = v0part->Pt();
+
+  // Cosine of proton emission angle (theta*) in the rest frame of the mother particle
+  // (from AliRDHFCutsLctoV0)
+  TLorentzVector vpr, vk0s,vlc;
+  Double_t massK0SPDG = TDatabasePDG::Instance()->GetParticle(310)->Mass();    // mass K0S PDG
+  Double_t massPrPDG = TDatabasePDG::Instance()->GetParticle(2212)->Mass();    // mass Proton PDG
+  vpr.SetXYZM(cand->PxProng(0), cand->PyProng(0), cand->PzProng(0), massPrPDG);
+  vk0s.SetXYZM(cand->PxProng(1), cand->PyProng(1), cand->PzProng(1), massK0SPDG);
+  vlc = vpr + vk0s;
+  TVector3 vboost = vlc.BoostVector();
+  vpr.Boost(-vboost);
+  fVars["cos_t_star"] = TMath::Cos(vpr.Angle(vlc.Vect()));
+
+  // Sign of d0 proton (different from regular d0)
+  // (from AliRDHFCutsLctoV0)
+  AliAODTrack *bachelor = (AliAODTrack*)((AliAODRecoCascadeHF*)cand)->GetBachelor();
+  AliAODVertex *primvert = dynamic_cast<AliAODVertex*>(cand->GetPrimaryVtx());
+  Double_t d0z0bach[2], covd0z0bach[3];
+  bachelor->PropagateToDCA(primvert, bfield, kVeryBig, d0z0bach, covd0z0bach); // HOW DO WE SET THE B FIELD?; kVeryBig should come from AliExternalTrackParam
+  Double_t tx[3];
+  bachelor->GetXYZ(tx);
+  tx[0] -= primvert->GetX();
+  tx[1] -= primvert->GetY();
+  tx[2] -= primvert->GetZ();
+  Double_t innerpro = tx[0]*cand->Px()+tx[1]*cand->Py();
+  Double_t signd0 = 1.;
+  if(innerpro<0.) signd0 = -1.;
+  fVars["signd0"] = signd0*TMath::Abs(d0z0bach[0]);
+  
+  //Armenteros qT/|alpha|
+  fVars["armenteros_K0s"] = v0part->PtArmV0()/TMath::Abs(v0part->AlphaV0());
+
+  for(int iProng = 0; iProng < 3; iProng++){
+    AliAODTrack *dautrack;
+    if(iProng == 0) dautrack = dynamic_cast<AliAODTrack *>(cand->GetDaughter(iProng));
+    else            dautrack = dynamic_cast<AliAODTrack *>(v0part->GetDaughter(iProng-1));
+    
+    double nsigmaTPCpi = -999., nsigmaTPCK = -999., nsigmaTPCp = -999., nsigmaTOFpi = -999., nsigmaTOFK = -999., nsigmaTOFp = -999.;
+    pidHF->GetnSigmaTPC(dautrack, 2, nsigmaTPCpi);
+    pidHF->GetnSigmaTPC(dautrack, 3, nsigmaTPCK);
+    pidHF->GetnSigmaTPC(dautrack, 4, nsigmaTPCp);
+    pidHF->GetnSigmaTOF(dautrack, 2, nsigmaTOFpi);
+    pidHF->GetnSigmaTOF(dautrack, 3, nsigmaTOFK);
+    pidHF->GetnSigmaTOF(dautrack, 4, nsigmaTOFp);
+
+    fVars[Form("nsigTPC_Pi_%d", iProng)] = nsigmaTPCpi;
+    fVars[Form("nsigTPC_K_%d", iProng)]  = nsigmaTPCK;
+    fVars[Form("nsigTPC_Pr_%d", iProng)]  = nsigmaTPCp;
+    fVars[Form("nsigTOF_Pi_%d", iProng)] = nsigmaTOFpi;
+    fVars[Form("nsigTOF_K_%d", iProng)]  = nsigmaTOFK;
+    fVars[Form("nsigTOF_Pr_%d", iProng)]  = nsigmaTOFp;
+
+    fVars[Form("nsigComb_Pi_%d", iProng)] = AliVertexingHFUtils::CombineNsigmaTPCTOF(nsigmaTPCpi, nsigmaTOFpi);
+    fVars[Form("nsigComb_K_%d", iProng)]  = AliVertexingHFUtils::CombineNsigmaTPCTOF(nsigmaTPCK, nsigmaTOFK);
+    fVars[Form("nsigComb_Pr_%d", iProng)]  = AliVertexingHFUtils::CombineNsigmaTPCTOF(nsigmaTPCp, nsigmaTOFp);
+  }
+}

--- a/PWGHF/vertexingHF/vHFML/AliHFMLResponseLctoV0bachelor.h
+++ b/PWGHF/vertexingHF/vHFML/AliHFMLResponseLctoV0bachelor.h
@@ -1,0 +1,40 @@
+#ifndef ALIHFMLRESPONSELCTOV0BACHELOR_H
+#define ALIHFMLRESPONSELCTOV0BACHELOR_H
+
+// Copyright CERN. This software is distributed under the terms of the GNU
+// General Public License v3 (GPL Version 3).
+//
+// See http://www.gnu.org/licenses/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//**************************************************************************************
+// \class AliHFMLResponseLctoV0bachelor
+// \brief helper class to handle application of ML models for Ds analyses trained
+// with python libraries
+// \authors:
+// L. Vermunt, luuk.vermunt@cern.ch
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#include "AliHFMLResponse.h"
+
+class AliHFMLResponseLctoV0bachelor : public AliHFMLResponse
+{
+public:
+  AliHFMLResponseLctoV0bachelor();
+  AliHFMLResponseLctoV0bachelor(const Char_t *name, const Char_t *title, const std::string configfilepath);
+  virtual ~AliHFMLResponseLctoV0bachelor();
+  
+  AliHFMLResponseLctoV0bachelor(const AliHFMLResponseLctoV0bachelor &source);
+  AliHFMLResponseLctoV0bachelor& operator=(const AliHFMLResponseLctoV0bachelor& source);
+  
+protected:
+  virtual void SetMapOfVariables(AliAODRecoDecayHF *cand, double bfield, AliAODPidHF *pidHF, int /*masshypo*/);
+  
+  /// \cond CLASSIMP
+  ClassDef(AliHFMLResponseLctoV0bachelor, 1); ///
+  /// \endcond
+};
+#endif

--- a/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApply.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApply.cxx
@@ -1,0 +1,605 @@
+/* Copyright(c) 1998-2008, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
+
+/* $Id$ */
+
+//*************************************************************************
+// \class AliHFTreeHandlerApply
+// \brief helper class to handle a tree for cut optimisation and MVA analyses
+// \authors:
+// L. Vermunt, luuk.vermunt@cern.ch
+/////////////////////////////////////////////////////////////
+
+#include <cmath>
+#include <limits>
+#include "AliHFTreeHandlerApply.h"
+#include "AliPID.h"
+#include "AliAODRecoDecayHF.h"
+#include "AliPIDResponse.h"
+#include "AliESDtrack.h"
+#include "TMath.h"
+
+/// \cond CLASSIMP
+ClassImp(AliHFTreeHandlerApply);
+/// \endcond
+
+//________________________________________________________________
+AliHFTreeHandlerApply::AliHFTreeHandlerApply():
+AliHFTreeHandlerApply(kNsigmaPID)
+{
+  //
+  // Default constructor
+  //
+}
+
+//________________________________________________________________
+AliHFTreeHandlerApply::AliHFTreeHandlerApply(int PIDopt):
+TObject(),
+fTreeVar(nullptr),
+fNProngs(-1),
+fCandType(0),
+fInvMass(-9999.),
+fPt(-9999.),
+fPtGen(-9999.),
+fY(-9999.),
+fEta(-9999.),
+fPhi(-9999.),
+fMLProb(-9999.),
+fDecayLength(-9999.),
+fDecayLengthXY(-9999.),
+fNormDecayLengthXY(-9999.),
+fCosP(-9999.),
+fCosPXY(-9999.),
+fImpParXY(-9999.),
+fDCA(-9999.),
+fPProng{},
+fSPDhitsProng{},
+fTPCPProng{},
+fTOFPProng{},
+fPtProng{},
+fEtaProng{},
+fPhiProng{},
+fNTPCclsProng{},
+fNTPCclsPidProng{},
+fNTPCCrossedRowProng{},
+fChi2perNDFProng{},
+fNITSclsProng{},
+fITSclsMapProng{},
+fTrackIntegratedLengthProng{},
+fStartTimeResProng{},
+fPIDNsigmaVector{},
+fPIDNsigmaIntVector{},
+fPIDrawVector{},
+fPidOpt(PIDopt),
+fSingleTrackOpt(kRedSingleTrackVars),
+fFillOnlySignal(false),
+fIsMCGenTree(false),
+fDauInAcceptance(false),
+fEvID(9999),
+fRunNumber(9999),
+fRunNumberPrevCand(9999),
+fApplyNsigmaTPCDataCorr(false),
+fSystNsigmaTPCDataCorr(AliAODPidHF::kNone),
+fMeanNsigmaTPCPionData{},
+fMeanNsigmaTPCKaonData{},
+fMeanNsigmaTPCProtonData{},
+fSigmaNsigmaTPCPionData{},
+fSigmaNsigmaTPCKaonData{},
+fSigmaNsigmaTPCProtonData{},
+fPlimitsNsigmaTPCDataCorr{},
+fNPbinsNsigmaTPCDataCorr(0),
+fEtalimitsNsigmaTPCDataCorr{},
+fNEtabinsNsigmaTPCDataCorr(0)
+{
+  //
+  // Default constructor
+  //
+  for(unsigned int iProng=0; iProng<knMaxProngs; iProng++) {
+    fPProng[iProng] = -9999.;
+    fTPCPProng[iProng] = -9999.;
+    fTOFPProng[iProng] = -9999.;
+    fPtProng[iProng] = -9999.;
+    fEtaProng[iProng] = -9999.;
+    fPhiProng[iProng] = -9999.;
+    fNTPCclsProng[iProng] = -9999;
+    fNTPCclsPidProng[iProng] = -9999;
+    fNTPCCrossedRowProng[iProng] = -9999.;
+    fChi2perNDFProng[iProng] = -9999.;
+    fNITSclsProng[iProng] = -9999;
+    fITSclsMapProng[iProng] = -9999;
+    fTrackIntegratedLengthProng[iProng] = -9999.;
+    fStartTimeResProng[iProng] = -9999.;
+    for(unsigned int iDet=0; iDet<knMaxDet4Pid; iDet++)
+      fPIDrawVector[iProng][iDet] = -999.;
+    for(unsigned int iDet=0; iDet<knMaxDet4Pid+1; iDet++) {
+      for(unsigned int iHypo=0; iHypo<knMaxHypo4Pid; iHypo++) {
+        fPIDNsigmaVector[iProng][iDet][iHypo] = -999.;
+        fPIDNsigmaIntVector[iProng][iDet][iHypo] = -999;
+      }
+    }
+  }
+  
+  for(int iP=0; iP<=AliAODPidHF::kMaxPBins; iP++) {
+    fPlimitsNsigmaTPCDataCorr[iP] = 0.;
+  }
+  for(int iEta=0; iEta<=AliAODPidHF::kMaxEtaBins; iEta++) {
+    fEtalimitsNsigmaTPCDataCorr[iEta] = 0.;
+  }
+}
+
+//________________________________________________________________
+AliHFTreeHandlerApply::~AliHFTreeHandlerApply()
+{
+  //
+  // Destructor
+  //
+  
+  delete fTreeVar;
+}
+
+//________________________________________________________________
+TTree* AliHFTreeHandlerApply::BuildTreeMCGen(TString name, TString title) {
+  
+  fIsMCGenTree = true;
+  
+  if(fTreeVar) {
+    delete fTreeVar;
+    fTreeVar=nullptr;
+  }
+  fTreeVar = new TTree(name.Data(),title.Data());
+  fTreeVar->Branch("run_number",&fRunNumber);
+  fTreeVar->Branch("ev_id",&fEvID);
+  fTreeVar->Branch("cand_type",&fCandType);
+  fTreeVar->Branch("pt_cand",&fPt);
+  fTreeVar->Branch("y_cand",&fY);
+  fTreeVar->Branch("eta_cand",&fEta);
+  fTreeVar->Branch("phi_cand",&fPhi);
+  fTreeVar->Branch("dau_in_acc",&fDauInAcceptance);
+  
+  return fTreeVar;
+}
+
+//________________________________________________________________
+bool AliHFTreeHandlerApply::SetMCGenVariables(int runnumber, unsigned int eventID, AliAODMCParticle* mcpart) {
+  
+  if(!mcpart) return false;
+  if(!(fCandType&kSignal)) return true; // fill only signal in the generated
+  
+  fRunNumber = runnumber;
+  fEvID = eventID;
+  fPt = mcpart->Pt();
+  fY = mcpart->Y();
+  fEta = mcpart->Eta();
+  fPhi = mcpart->Phi();
+  
+  return true;
+}
+
+//________________________________________________________________
+void AliHFTreeHandlerApply::SetCandidateType(bool issignal, bool isbkg, bool isprompt, bool isFD, bool isreflected)
+{  
+  if(issignal) fCandType |= kSignal;
+  else fCandType &= ~kSignal;
+  if(isbkg && !fIsMCGenTree) fCandType |= kBkg;
+  else fCandType &= ~kBkg;
+  if(isprompt) fCandType |= kPrompt;
+  else fCandType &= ~kPrompt;
+  if(isFD) fCandType |= kFD;
+  else fCandType &= ~kFD;
+  if(isreflected && !fIsMCGenTree) fCandType |= kRefl;
+  else fCandType &= ~kRefl;
+}
+
+//________________________________________________________________
+void AliHFTreeHandlerApply::AddCommonDmesonVarBranches(Bool_t HasSecVtx) {
+  
+  fTreeVar->Branch("run_number",&fRunNumber);
+  fTreeVar->Branch("ev_id",&fEvID);
+  fTreeVar->Branch("cand_type",&fCandType);
+  fTreeVar->Branch("inv_mass",&fInvMass);
+  fTreeVar->Branch("pt_cand",&fPt);
+  fTreeVar->Branch("pt_gen_cand",&fPtGen);
+  fTreeVar->Branch("y_cand",&fY);
+  fTreeVar->Branch("eta_cand",&fEta);
+  fTreeVar->Branch("phi_cand",&fPhi);
+  fTreeVar->Branch("ml_prob",&fMLProb);
+  if(HasSecVtx){
+    fTreeVar->Branch("d_len",&fDecayLength);
+    fTreeVar->Branch("d_len_xy",&fDecayLengthXY);
+    fTreeVar->Branch("norm_dl_xy",&fNormDecayLengthXY);
+    fTreeVar->Branch("cos_p",&fCosP);
+    fTreeVar->Branch("cos_p_xy",&fCosPXY);
+    fTreeVar->Branch("imp_par_xy",&fImpParXY);
+    fTreeVar->Branch("dca",&fDCA);
+  }
+} 
+
+//________________________________________________________________
+void AliHFTreeHandlerApply::AddSingleTrackBranches() {
+  
+  if(fSingleTrackOpt==kNoSingleTrackVars) return;
+  
+  for(unsigned int iProng=0; iProng<fNProngs; iProng++) {
+    
+    if(fSingleTrackOpt==kRedSingleTrackVars) {
+      fTreeVar->Branch(Form("pt_prong%d",iProng),&fPtProng[iProng]);
+      fTreeVar->Branch(Form("eta_prong%d",iProng),&fEtaProng[iProng]);
+      fTreeVar->Branch(Form("phi_prong%d",iProng),&fPhiProng[iProng]);
+      fTreeVar->Branch(Form("p_prong%d",iProng),&fPProng[iProng]);
+      fTreeVar->Branch(Form("spdhits_prong%d",iProng),&fSPDhitsProng[iProng]);
+    }
+    else if(fSingleTrackOpt==kAllSingleTrackVars) {
+      fTreeVar->Branch(Form("pt_prong%d",iProng),&fPtProng[iProng]);
+      fTreeVar->Branch(Form("eta_prong%d",iProng),&fEtaProng[iProng]);
+      fTreeVar->Branch(Form("phi_prong%d",iProng),&fPhiProng[iProng]);
+      fTreeVar->Branch(Form("p_prong%d",iProng),&fPProng[iProng]);
+      fTreeVar->Branch(Form("spdhits_prong%d",iProng),&fSPDhitsProng[iProng]);
+      fTreeVar->Branch(Form("nTPCcls_prong%d",iProng),&fNTPCclsProng[iProng]);
+      fTreeVar->Branch(Form("nTPCclspid_prong%d",iProng),&fNTPCclsPidProng[iProng]);
+      fTreeVar->Branch(Form("nTPCcrossrow_prong%d",iProng),&fNTPCCrossedRowProng[iProng]);
+      fTreeVar->Branch(Form("chi2perndf_prong%d",iProng),&fChi2perNDFProng[iProng]);
+      fTreeVar->Branch(Form("nITScls_prong%d",iProng),&fNITSclsProng[iProng]);
+      fTreeVar->Branch(Form("ITSclsmap_prong%d",iProng),&fITSclsMapProng[iProng]);
+    }
+  }
+}
+
+//________________________________________________________________
+void AliHFTreeHandlerApply::AddPidBranches(bool usePionHypo, bool useKaonHypo, bool useProtonHypo, bool useTPC, bool useTOF)
+{
+  
+  if(fPidOpt==kNoPID) return;
+  if(fPidOpt>kNsigmaDetAndCombPID) {
+    AliWarning("Wrong PID setting!");
+    return;
+  }
+  
+  bool useHypo[knMaxHypo4Pid] = {usePionHypo,useKaonHypo,useProtonHypo};
+  bool useDet[knMaxDet4Pid] = {useTPC,useTOF};
+  TString partHypoName[knMaxHypo4Pid] = {"Pi","K","Pr"};
+  TString detName[knMaxDet4Pid] = {"TPC","TOF"};
+  TString rawPidName[knMaxDet4Pid] = {"dEdxTPC","ToF"};
+  
+  for(unsigned int iProng=0; iProng<fNProngs; iProng++) {
+    if((fPidOpt>=kNsigmaPID && fPidOpt<=kNsigmaPIDfloatandint) || fPidOpt>=kRawAndNsigmaPID) {
+      for(unsigned int iDet=0; iDet<knMaxDet4Pid; iDet++) {
+        if(!useDet[iDet]) continue;
+        for(unsigned int iPartHypo=0; iPartHypo<knMaxHypo4Pid; iPartHypo++) {
+          if(!useHypo[iPartHypo]) continue;
+          if(fPidOpt==kNsigmaPID || fPidOpt==kNsigmaPIDfloatandint || fPidOpt>=kRawAndNsigmaPID)
+            fTreeVar->Branch(Form("nsig%s_%s_%d",detName[iDet].Data(),partHypoName[iPartHypo].Data(),iProng),&fPIDNsigmaVector[iProng][iDet][iPartHypo]);
+          if(fPidOpt==kNsigmaPIDint || fPidOpt==kNsigmaPIDfloatandint)
+            fTreeVar->Branch(Form("int_nsig%s_%s_%d",detName[iDet].Data(),partHypoName[iPartHypo].Data(),iProng),&fPIDNsigmaIntVector[iProng][iDet][iPartHypo]);
+        }
+      }
+    }
+    if((fPidOpt>=kNsigmaCombPID && fPidOpt<=kNsigmaCombPIDfloatandint) || fPidOpt==kNsigmaDetAndCombPID) {
+      for(unsigned int iPartHypo=0; iPartHypo<knMaxHypo4Pid; iPartHypo++) {
+        if(!useHypo[iPartHypo]) continue;
+        if(fPidOpt==kNsigmaCombPID || fPidOpt==kNsigmaCombPIDfloatandint || fPidOpt==kNsigmaDetAndCombPID)
+          fTreeVar->Branch(Form("nsigComb_%s_%d",partHypoName[iPartHypo].Data(),iProng),&fPIDNsigmaVector[iProng][kCombTPCTOF][iPartHypo]);
+        if(fPidOpt==kNsigmaCombPIDint || fPidOpt==kNsigmaCombPIDfloatandint)
+          fTreeVar->Branch(Form("int_nsigComb_%s_%d",partHypoName[iPartHypo].Data(),iProng),&fPIDNsigmaIntVector[iProng][kCombTPCTOF][iPartHypo]);
+      }
+    }
+    if(fPidOpt==kRawPID || fPidOpt==kRawAndNsigmaPID) {
+      for(unsigned int iDet=0; iDet<knMaxDet4Pid; iDet++) {
+        if(!useDet[iDet]) continue;
+        fTreeVar->Branch(Form("%s_%d",rawPidName[iDet].Data(),iProng),&fPIDrawVector[iProng][iDet]);
+      }
+      if(useTPC) fTreeVar->Branch(Form("pTPC_prong%d",iProng),&fTPCPProng[iProng]);
+      if(useTOF) {
+        fTreeVar->Branch(Form("pTOF_prong%d",iProng),&fTOFPProng[iProng]);
+        fTreeVar->Branch(Form("trlen_prong%d",iProng),&fTrackIntegratedLengthProng[iProng]);
+        fTreeVar->Branch(Form("start_time_res_prong%d",iProng),&fStartTimeResProng[iProng]);
+      }
+    }
+  }
+}
+
+//________________________________________________________________
+bool AliHFTreeHandlerApply::SetSingleTrackVars(AliAODTrack* prongtracks[]) {
+  
+  //Impact parameters of the prongs are defined as a species dependent variable because the prongs
+  //cannot be obtained in similar way for the different AliAODRecoDecay objects (AliAODTrack cannot
+  //be used because of recomputation PV)
+  
+  if(fSingleTrackOpt==kNoSingleTrackVars) return true;
+  
+  for(unsigned int iProng=0; iProng<fNProngs; iProng++) {
+    if(!prongtracks[iProng]) {
+      AliWarning("Prong track not found!");
+      return false;
+    }
+  }
+  
+  for(unsigned int iProng=0; iProng<fNProngs; iProng++) {
+    
+    if(fSingleTrackOpt==kRedSingleTrackVars) {
+      fPtProng[iProng]=prongtracks[iProng]->Pt();
+      fEtaProng[iProng]=prongtracks[iProng]->Eta();
+      fPhiProng[iProng]=prongtracks[iProng]->Phi();
+      fPProng[iProng]=prongtracks[iProng]->P();
+      fSPDhitsProng[iProng] = prongtracks[iProng]->GetITSClusterMap() & 0x3;
+    }
+    else if(fSingleTrackOpt==kAllSingleTrackVars) {
+      fPtProng[iProng]=prongtracks[iProng]->Pt();
+      fEtaProng[iProng]=prongtracks[iProng]->Eta();
+      fPhiProng[iProng]=prongtracks[iProng]->Phi();
+      fPProng[iProng]=prongtracks[iProng]->P();
+      fSPDhitsProng[iProng] = prongtracks[iProng]->GetITSClusterMap() & 0x3;
+      fNTPCclsProng[iProng]=prongtracks[iProng]->GetTPCNcls();
+      fNTPCclsPidProng[iProng]=prongtracks[iProng]->GetTPCsignalN();
+      fNTPCCrossedRowProng[iProng]=prongtracks[iProng]->GetTPCNCrossedRows();
+      fChi2perNDFProng[iProng]=prongtracks[iProng]->Chi2perNDF();
+      fNITSclsProng[iProng]=prongtracks[iProng]->GetITSNcls();
+      fITSclsMapProng[iProng]=static_cast<int>(prongtracks[iProng]->GetITSClusterMap());
+    }
+  }
+  
+  return true;
+}
+
+//________________________________________________________________
+bool AliHFTreeHandlerApply::SetPidVars(AliAODTrack* prongtracks[], AliPIDResponse* pidrespo, bool usePionHypo, bool useKaonHypo, bool useProtonHypo, bool useTPC, bool useTOF)
+{
+  if(!pidrespo) return false;
+  for(unsigned int iProng=0; iProng<fNProngs; iProng++) {
+    if(!prongtracks[iProng]) {
+      AliWarning("Prong track not found!");
+      return false;
+    }
+  }
+  
+  //PID variables
+  double sig[knMaxProngs][knMaxDet4Pid][knMaxHypo4Pid];
+  double sigComb[knMaxProngs][knMaxHypo4Pid];
+  double rawPID[knMaxProngs][knMaxDet4Pid];
+  bool useHypo[knMaxHypo4Pid] = {usePionHypo,useKaonHypo,useProtonHypo};
+  bool useDet[knMaxDet4Pid] = {useTPC,useTOF};
+  AliPID::EParticleType parthypo[knMaxHypo4Pid] = {AliPID::kPion,AliPID::kKaon,AliPID::kProton};
+  
+  //compute PID variables for different options
+  for(unsigned int iProng=0; iProng<fNProngs; iProng++) {
+    if((fPidOpt>=kNsigmaPID && fPidOpt<=kNsigmaCombPIDfloatandint) || fPidOpt>=kRawAndNsigmaPID) {
+      for(unsigned int iPartHypo=0; iPartHypo<knMaxHypo4Pid; iPartHypo++) {
+        if(useHypo[iPartHypo]) {
+          if(useTPC) {
+            float nSigmaTPC = pidrespo->NumberOfSigmasTPC(prongtracks[iProng],parthypo[iPartHypo]);
+            if(fApplyNsigmaTPCDataCorr && nSigmaTPC>-990.) {
+              float sigma=1., mean=0.;
+              GetNsigmaTPCMeanSigmaData(mean, sigma, parthypo[iPartHypo], prongtracks[iProng]->GetTPCmomentum(), prongtracks[iProng]->Eta());
+              nSigmaTPC = (nSigmaTPC-mean)/sigma;
+            }
+            sig[iProng][kTPC][iPartHypo] = nSigmaTPC;
+          }
+          if(useTOF) sig[iProng][kTOF][iPartHypo] = pidrespo->NumberOfSigmasTOF(prongtracks[iProng],parthypo[iPartHypo]);
+          if(((fPidOpt>=kNsigmaCombPID && fPidOpt<=kNsigmaCombPIDfloatandint) || fPidOpt==kNsigmaDetAndCombPID) && useTPC && useTOF) {
+            sigComb[iProng][iPartHypo] = CombineNsigmaDiffDet(sig[iProng][kTPC][iPartHypo],sig[iProng][kTOF][iPartHypo]);
+          }
+        }
+      }
+    }
+    if(fPidOpt==kRawPID || fPidOpt==kRawAndNsigmaPID) {
+      if(useTPC) rawPID[iProng][kTPC] = prongtracks[iProng]->GetTPCsignal();
+      if(useTOF) {
+        if (!(prongtracks[iProng]->GetStatus() & AliESDtrack::kTOFout) || !(prongtracks[iProng]->GetStatus() & AliESDtrack::kTIME)) {
+          rawPID[iProng][kTOF] = -1.;
+        }
+        else {
+          float len = prongtracks[iProng]->GetIntegratedLength();
+          if (len < 350.f) {
+            rawPID[iProng][kTOF] = -1.;
+          }
+          else {
+            rawPID[iProng][kTOF] = prongtracks[iProng]->GetTOFsignal();
+            float time0 = pidrespo->GetTOFResponse().GetStartTime(prongtracks[iProng]->P());
+            rawPID[iProng][kTOF] -= time0;
+          }
+        }
+      }
+    }
+  }
+  
+  //fill PID arrays for different options
+  switch(fPidOpt) {
+    case 1: //kNsigmaPID
+      for(unsigned int iProng=0; iProng<fNProngs; iProng++) {
+        for(int iDet=kTPC; iDet<=kTOF; iDet++) {
+          if(!useDet[iDet]) continue;
+          for(unsigned int iPartHypo=0; iPartHypo<knMaxHypo4Pid; iPartHypo++) {
+            if(!useHypo[iPartHypo]) continue;
+            fPIDNsigmaVector[iProng][iDet][iPartHypo]=sig[iProng][iDet][iPartHypo];
+          }
+        }
+      }
+      break;
+    case 2: //kNsigmaPIDint
+      for(unsigned int iProng=0; iProng<fNProngs; iProng++) {
+        for(int iDet=kTPC; iDet<=kTOF; iDet++) {
+          if(!useDet[iDet]) continue;
+          for(unsigned int iPartHypo=0; iPartHypo<knMaxHypo4Pid; iPartHypo++) {
+            if(!useHypo[iPartHypo]) continue;
+            fPIDNsigmaIntVector[iProng][iDet][iPartHypo]=RoundFloatToInt(sig[iProng][iDet][iPartHypo]*100);
+          }
+        }
+      }
+      break;
+    case 3: //kNsigmaPIDfloatandint
+      for(unsigned int iProng=0; iProng<fNProngs; iProng++) {
+        for(int iDet=kTPC; iDet<=kTOF; iDet++) {
+          if(!useDet[iDet]) continue;
+          for(unsigned int iPartHypo=0; iPartHypo<knMaxHypo4Pid; iPartHypo++) {
+            if(!useHypo[iPartHypo]) continue;
+            fPIDNsigmaVector[iProng][iDet][iPartHypo]=sig[iProng][iDet][iPartHypo]*100;
+            fPIDNsigmaIntVector[iProng][iDet][iPartHypo]=RoundFloatToInt(sig[iProng][iDet][iPartHypo]*100);
+          }
+        }
+      }
+      break;
+    case 4: //kNsigmaCombPID
+      for(unsigned int iProng=0; iProng<fNProngs; iProng++) {
+        for(unsigned int iPartHypo=0; iPartHypo<knMaxHypo4Pid; iPartHypo++) {
+          if(!useHypo[iPartHypo]) continue;
+          fPIDNsigmaVector[iProng][kCombTPCTOF][iPartHypo]=sigComb[iProng][iPartHypo];
+        }
+      }
+      break;
+    case 5: //kNsigmaCombPIDint
+      for(unsigned int iProng=0; iProng<fNProngs; iProng++) {
+        for(unsigned int iPartHypo=0; iPartHypo<knMaxHypo4Pid; iPartHypo++) {
+          if(!useHypo[iPartHypo]) continue;
+          fPIDNsigmaIntVector[iProng][kCombTPCTOF][iPartHypo]=RoundFloatToInt(sigComb[iProng][iPartHypo]*100);
+        }
+      }
+      break;
+    case 6: //kNsigmaCombPIDfloatandint
+      for(unsigned int iProng=0; iProng<fNProngs; iProng++) {
+        for(unsigned int iPartHypo=0; iPartHypo<knMaxHypo4Pid; iPartHypo++) {
+          if(!useHypo[iPartHypo]) continue;
+          fPIDNsigmaVector[iProng][kCombTPCTOF][iPartHypo]=sigComb[iProng][iPartHypo]*100;
+          fPIDNsigmaIntVector[iProng][kCombTPCTOF][iPartHypo]=RoundFloatToInt(sigComb[iProng][iPartHypo]*100);
+        }
+      }
+      break;
+    case 7: //kRawPID
+      for(unsigned int iProng=0; iProng<fNProngs; iProng++) {
+        for(int iDet=kTPC; iDet<=kTOF; iDet++) {
+          if(!useDet[iDet]) continue;
+          fPIDrawVector[iProng][iDet]=rawPID[iProng][iDet];
+        }
+        if(useTPC) fTPCPProng[iProng]=prongtracks[iProng]->GetTPCmomentum();
+        if(useTOF) {
+          fTOFPProng[iProng]=GetTOFmomentum(prongtracks[iProng],pidrespo);
+          fTrackIntegratedLengthProng[iProng]=prongtracks[iProng]->GetIntegratedLength();
+          fStartTimeResProng[iProng]=pidrespo->GetTOFResponse().GetStartTimeRes(prongtracks[iProng]->P());
+        }
+      }
+      break;
+    case 8: //kRawAndNsigmaPID
+      for(unsigned int iProng=0; iProng<fNProngs; iProng++) {
+        for(int iDet=kTPC; iDet<=kTOF; iDet++) {
+          if(!useDet[iDet]) continue;
+          for(unsigned int iPartHypo=0; iPartHypo<knMaxHypo4Pid; iPartHypo++) {
+            if(!useHypo[iPartHypo]) continue;
+            fPIDNsigmaVector[iProng][iDet][iPartHypo]=sig[iProng][iDet][iPartHypo];
+          }
+          fPIDrawVector[iProng][iDet]=rawPID[iProng][iDet];
+        }
+        if(useTPC) fTPCPProng[iProng]=prongtracks[iProng]->GetTPCmomentum();
+        if(useTOF) {
+          fTOFPProng[iProng]=GetTOFmomentum(prongtracks[iProng],pidrespo);
+          fTrackIntegratedLengthProng[iProng]=prongtracks[iProng]->GetIntegratedLength();
+          fStartTimeResProng[iProng]=pidrespo->GetTOFResponse().GetStartTimeRes(prongtracks[iProng]->P());
+        }
+      }
+      break;
+    case 9: //kNsigmaDetAndCombPID
+      for(unsigned int iProng=0; iProng<fNProngs; iProng++) {
+        for(unsigned int iPartHypo=0; iPartHypo<knMaxHypo4Pid; iPartHypo++) {
+          if(!useHypo[iPartHypo]) continue;
+          fPIDNsigmaVector[iProng][kCombTPCTOF][iPartHypo]=sigComb[iProng][iPartHypo];
+          for(int iDet=kTPC; iDet<=kTOF; iDet++) {
+            if(!useDet[iDet]) continue;
+            fPIDNsigmaVector[iProng][iDet][iPartHypo]=sig[iProng][iDet][iPartHypo];
+          }
+        }
+      }
+      break;
+    default:
+      AliWarning("Wrong PID setting!");
+      return false;
+      break;
+  }
+  
+  return true;
+}
+
+//________________________________________________________________
+double AliHFTreeHandlerApply::CombineNsigmaDiffDet(double nsigmaTPC, double nsigmaTOF)
+{
+  if(nsigmaTPC > -998. && nsigmaTOF > -998.) return TMath::Sqrt((nsigmaTPC*nsigmaTPC+nsigmaTOF*nsigmaTOF)/2);
+  else if(nsigmaTPC > -998. && nsigmaTOF < -998.) return TMath::Abs(nsigmaTPC);
+  else if(nsigmaTPC < -998. && nsigmaTOF > -998.) return TMath::Abs(nsigmaTOF);
+  else return -999.;
+}
+
+//________________________________________________________________
+int AliHFTreeHandlerApply::RoundFloatToInt(double num)
+{
+  if(num>=static_cast<double>(std::numeric_limits<int>::max())) return std::numeric_limits<int>::max();
+  else if(num<=static_cast<double>(std::numeric_limits<int>::min())) return std::numeric_limits<int>::min();
+  
+  return static_cast<int>(num);
+}
+
+//________________________________________________________________
+float AliHFTreeHandlerApply::ComputeMaxd0MeasMinusExp(AliAODRecoDecayHF* cand, float bfield)
+{
+  float dd0max=0;
+  unsigned int fNProngs_cand = (unsigned int)cand->GetNProngs();
+  for(unsigned int iProng=0; iProng<fNProngs_cand; iProng++) {
+    double d0diff, errd0diff;
+    cand->Getd0MeasMinusExpProng(iProng,bfield,d0diff,errd0diff);
+    float normdd0 = d0diff/errd0diff;
+    if(iProng==0) dd0max=normdd0;
+    else if(TMath::Abs(normdd0)>TMath::Abs(dd0max)) dd0max=normdd0;
+  }
+  return dd0max;
+}
+
+//________________________________________________________________
+float AliHFTreeHandlerApply::GetTOFmomentum(AliAODTrack* track, AliPIDResponse* pidrespo)
+{
+  float t_d = pidrespo->GetTOFResponse().GetExpectedSignal(track, AliPID::kTriton); //largest mass possible with Z=1
+  float len = track->GetIntegratedLength();
+  float beta_d = len / (t_d * kCSPEED);
+  float mass = AliPID::ParticleMassZ(AliPID::kTriton); //largest mass possible with Z=1
+  
+  if(TMath::Abs(beta_d-1.) < 1.e-12) return track->GetTPCmomentum();
+  else return mass*beta_d/sqrt(1.-(beta_d*beta_d));
+}
+
+//________________________________________________________________
+void AliHFTreeHandlerApply::GetNsigmaTPCMeanSigmaData(float &mean, float &sigma, AliPID::EParticleType species, float pTPC, float eta) {
+  
+  if(fRunNumber!=fRunNumberPrevCand)
+    AliAODPidHF::SetNsigmaTPCDataDrivenCorrection(fRunNumber, fSystNsigmaTPCDataCorr, fNPbinsNsigmaTPCDataCorr, fPlimitsNsigmaTPCDataCorr,
+                                                  fNEtabinsNsigmaTPCDataCorr, fEtalimitsNsigmaTPCDataCorr, fMeanNsigmaTPCPionData, fMeanNsigmaTPCKaonData,
+                                                  fMeanNsigmaTPCProtonData, fSigmaNsigmaTPCPionData, fSigmaNsigmaTPCKaonData, fSigmaNsigmaTPCProtonData);
+  
+  int bin = TMath::BinarySearch(fNPbinsNsigmaTPCDataCorr,fPlimitsNsigmaTPCDataCorr,pTPC);
+  if(bin<0) bin=0; //underflow --> equal to min value
+  else if(bin>fNPbinsNsigmaTPCDataCorr-1) bin=fNPbinsNsigmaTPCDataCorr-1; //overflow --> equal to max value
+  
+  int etabin = TMath::BinarySearch(fNEtabinsNsigmaTPCDataCorr,fEtalimitsNsigmaTPCDataCorr,TMath::Abs(eta));
+  if(etabin<0) etabin=0; //underflow --> equal to min value
+  else if(etabin>fNEtabinsNsigmaTPCDataCorr-1) etabin=fNEtabinsNsigmaTPCDataCorr-1; //overflow --> equal to max value
+  
+  switch(species) {
+    case AliPID::kPion:
+    {
+      mean = fMeanNsigmaTPCPionData[etabin][bin];
+      sigma = fSigmaNsigmaTPCPionData[etabin][bin];
+      break;
+    }
+    case AliPID::kKaon:
+    {
+      mean = fMeanNsigmaTPCKaonData[etabin][bin];
+      sigma = fSigmaNsigmaTPCKaonData[etabin][bin];
+      break;
+    }
+    case AliPID::kProton:
+    {
+      mean = fMeanNsigmaTPCProtonData[etabin][bin];
+      sigma = fSigmaNsigmaTPCProtonData[etabin][bin];
+      break;
+    }
+    default:
+    {
+      mean = 0.;
+      sigma = 1.;
+      break;
+    }
+  }
+}

--- a/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApply.h
+++ b/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApply.h
@@ -1,0 +1,239 @@
+#ifndef ALIHFTREEHANDLERAPPLY_H
+#define ALIHFTREEHANDLERAPPLY_H
+
+/* Copyright(c) 1998-2008, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
+
+/* $Id$ */
+
+//*************************************************************************
+// \class AliHFTreeHandlerApply
+// \brief helper class to handle a tree for cut optimisation and MVA analyses
+// \authors:
+// L. Vermunt, luuk.vermunt@cern.ch
+/////////////////////////////////////////////////////////////
+
+#include <TTree.h>
+#include "AliAODTrack.h"
+#include "AliPIDResponse.h"
+#include "AliAODRecoDecayHF.h"
+#include "AliAODMCParticle.h"
+#include "AliAODPidHF.h"
+
+class AliHFTreeHandlerApply : public TObject
+{
+public:
+  
+  enum candtype {
+    kSelected        = BIT(0),
+    kSignal          = BIT(1),
+    kBkg             = BIT(2),
+    kPrompt          = BIT(3),
+    kFD              = BIT(4),
+    kRefl            = BIT(5),
+    kSelectedTopo    = BIT(6),
+    kSelectedPID     = BIT(7),
+    kSelectedTracks  = BIT(8) //up to BIT(10) included for general flags, following BITS particle-specific
+  };
+  
+  enum optpid {
+    kNoPID,
+    kNsigmaPID,
+    kNsigmaPIDint,
+    kNsigmaPIDfloatandint, //--> to test
+    kNsigmaCombPID,
+    kNsigmaCombPIDint,
+    kNsigmaCombPIDfloatandint, //--> to test
+    kRawPID,
+    kRawAndNsigmaPID,
+    kNsigmaDetAndCombPID
+  };
+  
+  enum piddet {
+    kTPC,
+    kTOF,
+    kCombTPCTOF // must be the last element in the enum
+  };
+  
+  enum optsingletrack {
+    kNoSingleTrackVars, // single-track vars off
+    kRedSingleTrackVars, // only pT, p, eta, phi
+    kAllSingleTrackVars // all single-track vars
+  };
+  
+  AliHFTreeHandlerApply();
+  AliHFTreeHandlerApply(int PIDopt);
+  virtual ~AliHFTreeHandlerApply();
+  
+  AliHFTreeHandlerApply(const AliHFTreeHandlerApply &source) = delete;
+  AliHFTreeHandlerApply& operator=(const AliHFTreeHandlerApply &source) = delete;
+  
+  //core methods --> implemented in each derived class
+  virtual TTree* BuildTree(TString name, TString title) = 0;
+  virtual bool SetVariables(int runnumber, unsigned int eventID, float ptgen, float mlprob, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse* pidrespo) = 0;
+
+  //for MC gen --> common implementation
+  TTree* BuildTreeMCGen(TString name, TString title);
+  bool SetMCGenVariables(int runnumber, unsigned int eventID, AliAODMCParticle* mcpart);
+
+  //to be called for each candidate
+  void SetCandidateType(bool issignal, bool isbkg, bool isprompt, bool isFD, bool isreflected);
+  void FillTree() { //to be called for each candidate!
+    if(fFillOnlySignal && !(fCandType&kSignal) && !(fCandType&kRefl)) { //if fill only signal and not signal/reflection candidate, do not store
+      fCandType=0;
+    }
+    else {
+      fTreeVar->Fill();
+      fCandType=0;
+      fRunNumberPrevCand = fRunNumber;
+    }
+  }
+  
+  //common methods
+  void SetOptPID(int PIDopt) {fPidOpt=PIDopt;}
+  void SetOptSingleTrackVars(int opt) {fSingleTrackOpt=opt;}
+  void SetFillOnlySignal(bool fillopt=true) {fFillOnlySignal=fillopt;}
+  void SetDauInAcceptance(bool dauinacc = true) {fDauInAcceptance=dauinacc;}
+
+  void SetIsSelectedStd(bool isselected, bool isselectedTopo, bool isselectedPID, bool isselectedTracks) {
+    if(isselected) fCandType |= kSelected;
+    else fCandType &= ~kSelected;
+    if(isselectedTopo) fCandType |= kSelectedTopo;
+    else fCandType &= ~kSelectedTopo;
+    if(isselectedPID) fCandType |= kSelectedPID;
+    else fCandType &= ~kSelectedPID;
+    if(isselectedTracks) fCandType |= kSelectedTracks;
+    else fCandType &= ~kSelectedTracks;
+  }
+  
+  static bool IsSelectedStd(int candtype) {
+    if(candtype&1) return true;
+    return false;
+  }
+  static bool IsSignal(int candtype) {
+    if(candtype>>1&1) return true;
+    return false;
+  }
+  static bool IsBkg(int candtype) {
+    if(candtype>>2&1) return true;
+    return false;
+  }
+  static bool IsPrompt(int candtype) {
+    if(candtype>>3&1) return true;
+    return false;
+  }
+  static bool IsFD(int candtype) {
+    if(candtype>>4&1) return true;
+    return false;
+  }
+  static bool IsRefl(int candtype) {
+    if(candtype>>5&1) return true;
+    return false;
+  }
+  static bool IsSelectedStdTopo(int candtype) {
+    if(candtype>>6&1) return true;
+    return false;
+  }
+  static bool IsSelectedStdPID(int candtype) {
+    if(candtype>>7&1) return true;
+    return false;
+  }
+  static bool IsSelectedStdTracks(int candtype) {
+    if(candtype>>8&1) return true;
+    return false;
+  }
+  
+  void EnableNsigmaTPCDataDrivenCorrection(int syst) {
+    fApplyNsigmaTPCDataCorr=true;
+    fSystNsigmaTPCDataCorr=syst;
+  }
+  
+protected:
+  //constant variables
+  static const unsigned int knMaxProngs   = 4;
+  static const unsigned int knMaxDet4Pid  = 2;
+  static const unsigned int knMaxHypo4Pid = 3;
+  
+  const float kCSPEED = 2.99792457999999984e-02; // cm / ps
+  
+  //helper methods for derived clases (to be used in BuildTree and SetVariables functions)
+  void AddCommonDmesonVarBranches(Bool_t HasSecVtx = kTRUE);
+  void AddSingleTrackBranches();
+  void AddPidBranches(bool usePionHypo, bool useKaonHypo, bool useProtonHypo, bool useTPC, bool useTOF);
+  bool SetSingleTrackVars(AliAODTrack* prongtracks[]);
+  bool SetPidVars(AliAODTrack* prongtracks[], AliPIDResponse* pidrespo, bool usePionHypo, bool useKaonHypo, bool useProtonHypo, bool useTPC, bool useTOF);
+  
+  //utils methods
+  double CombineNsigmaDiffDet(double nsigmaTPC, double nsigmaTOF);
+  int RoundFloatToInt(double num);
+  float ComputeMaxd0MeasMinusExp(AliAODRecoDecayHF* cand, float bfield);
+  float GetTOFmomentum(AliAODTrack* track, AliPIDResponse* pidrespo);
+  
+  void GetNsigmaTPCMeanSigmaData(float &mean, float &sigma, AliPID::EParticleType species, float pTPC, float eta);
+  
+  TTree* fTreeVar;                                                     //!<! tree with variables
+  unsigned int fNProngs;                                               /// number of prongs
+  
+  int fCandType;                                                       /// flag for candidate type (bit map above)
+  float fInvMass;                                                      /// candidate invariant mass
+  float fPt;                                                           /// candidate pt
+  float fPtGen;                                                        /// generated candidate pt
+  float fY;                                                            /// candidate rapidity
+  float fEta;                                                          /// candidate pseudorapidity
+  float fPhi;                                                          /// candidate azimuthal angle
+  float fMLProb;                                                       /// candidate's applied ML probability
+  float fDecayLength;                                                  /// candidate decay length
+  float fDecayLengthXY;                                                /// candidate decay length in the transverse plane
+  float fNormDecayLengthXY;                                            /// candidate normalised decay length in the transverse plane
+  float fCosP;                                                         /// candidate cosine of pointing angle
+  float fCosPXY;                                                       /// candidate cosine of pointing angle in the transcverse plane
+  float fImpParXY;                                                     /// candidate impact parameter in the transverse plane
+  float fDCA;                                                          /// DCA of candidates prongs
+  
+  float fPProng[knMaxProngs];                                          /// prong momentum
+  int fSPDhitsProng[knMaxProngs];                                      /// prong hits in the SPD
+  float fTPCPProng[knMaxProngs];                                       /// prong TPC momentum
+  float fTOFPProng[knMaxProngs];                                       /// prong TOF momentum
+  float fPtProng[knMaxProngs];                                         /// prong pt
+  float fEtaProng[knMaxProngs];                                        /// prong pseudorapidity
+  float fPhiProng[knMaxProngs];                                        /// prong azimuthal angle
+  int fNTPCclsProng[knMaxProngs];                                      /// prong track number of clusters in TPC
+  int fNTPCclsPidProng[knMaxProngs];                                   /// prong track number of clusters in TPC used for PID
+  float fNTPCCrossedRowProng[knMaxProngs];                             /// prong track crossed row in TPC
+  float fChi2perNDFProng[knMaxProngs];                                 /// prong track chi2/ndf
+  int fNITSclsProng[knMaxProngs];                                      /// prong track number of clusters in ITS
+  int fITSclsMapProng[knMaxProngs];                                    /// prong track ITS cluster map
+  float fTrackIntegratedLengthProng[knMaxProngs];                      /// prong track integrated lengths
+  float fStartTimeResProng[knMaxProngs];                               /// prong track start time resolutions (for TOF)
+  float fPIDNsigmaVector[knMaxProngs][knMaxDet4Pid+1][knMaxHypo4Pid];  /// PID nsigma variables
+  int fPIDNsigmaIntVector[knMaxProngs][knMaxDet4Pid+1][knMaxHypo4Pid]; /// PID nsigma variables (integers)
+  float fPIDrawVector[knMaxProngs][knMaxDet4Pid];                      /// raw PID variables
+  
+  int fPidOpt;                                                         /// option for PID variables
+  int fSingleTrackOpt;                                                 /// option for single-track variables
+  bool fFillOnlySignal;                                                /// flag to enable only signal filling
+  bool fIsMCGenTree;                                                   /// flag to know if is a tree for MC generated particles
+  bool fDauInAcceptance;                                               /// flag to know if the daughter are in acceptance in case of MC gen
+  
+  unsigned int fEvID;                                                  /// event ID corresponding to the one set in fTreeEvChar
+  int fRunNumber;                                                      /// run number
+  int fRunNumberPrevCand;                                              /// run number of previous candidate
+
+  bool fApplyNsigmaTPCDataCorr;                                        /// flag to enable data-driven NsigmaTPC correction
+  int fSystNsigmaTPCDataCorr;                                          /// system for data-driven NsigmaTPC correction
+  vector<vector<float> > fMeanNsigmaTPCPionData;                       /// array of NsigmaTPC pion mean in data
+  vector<vector<float> > fMeanNsigmaTPCKaonData;                       /// array of NsigmaTPC kaon mean in data
+  vector<vector<float> > fMeanNsigmaTPCProtonData;                     /// array of NsigmaTPC proton mean in data
+  vector<vector<float> > fSigmaNsigmaTPCPionData;                      /// array of NsigmaTPC pion mean in data
+  vector<vector<float> > fSigmaNsigmaTPCKaonData;                      /// array of NsigmaTPC kaon mean in data
+  vector<vector<float> > fSigmaNsigmaTPCProtonData;                    /// array of NsigmaTPC proton mean in data
+  float fPlimitsNsigmaTPCDataCorr[AliAODPidHF::kMaxPBins+1];           /// array of p limits for data-driven NsigmaTPC correction
+  int fNPbinsNsigmaTPCDataCorr;                                        /// number of p bins for data-driven NsigmaTPC correction
+  float fEtalimitsNsigmaTPCDataCorr[AliAODPidHF::kMaxEtaBins+1];       /// vector of eta limits for data-driven NsigmaTPC correction
+  int fNEtabinsNsigmaTPCDataCorr;                                      /// number of eta bins for data-driven NsigmaTPC correction
+  
+  /// \cond CLASSIMP
+  ClassDef(AliHFTreeHandlerApply,1); ///
+  /// \endcond
+};
+#endif

--- a/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyDstoKKpi.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyDstoKKpi.cxx
@@ -1,0 +1,157 @@
+/* Copyright(c) 1998-2008, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
+
+/* $Id$ */
+
+//*************************************************************************
+// \class AliHFTreeHandlerApplyDstoKKpi
+// \brief helper class to handle a tree for Ds cut optimisation and MVA analyses
+// \authors:
+// L. Vermunt, luuk.vermunt@cern.ch
+/////////////////////////////////////////////////////////////
+
+#include <TString.h>
+#include <TDatabasePDG.h>
+#include "AliHFTreeHandlerApplyDstoKKpi.h"
+#include "AliAODRecoDecayHF3Prong.h"
+
+/// \cond CLASSIMP
+ClassImp(AliHFTreeHandlerApplyDstoKKpi);
+/// \endcond
+
+//________________________________________________________________
+AliHFTreeHandlerApplyDstoKKpi::AliHFTreeHandlerApplyDstoKKpi():
+AliHFTreeHandlerApplyDstoKKpi(kNsigmaPID)
+{
+  //
+  // Default constructor
+  //
+}
+
+//________________________________________________________________
+AliHFTreeHandlerApplyDstoKKpi::AliHFTreeHandlerApplyDstoKKpi(int PIDopt):
+AliHFTreeHandlerApply(PIDopt),
+fImpParProng{},
+fSigmaVertex(-9999.),
+fMassKK(-9999.),
+fCosPiDs(-9999.),
+fCosPiKPhi(-9999.),
+fNormd0MeasMinusExp(-9999.),
+fMassKKOpt(kMassKK)
+{  
+  //
+  // Standard constructor
+  //
+  
+  fNProngs=3; // --> cannot be changed
+  for(unsigned int iProng=0; iProng<fNProngs; iProng++)
+    fImpParProng[iProng] = -9999.;
+}
+
+//________________________________________________________________
+AliHFTreeHandlerApplyDstoKKpi::~AliHFTreeHandlerApplyDstoKKpi()
+{
+  //
+  // Default Destructor
+  //
+}
+
+//________________________________________________________________
+TTree* AliHFTreeHandlerApplyDstoKKpi::BuildTree(TString name, TString title)
+{
+  fIsMCGenTree=false;
+  
+  if(fTreeVar) {
+    delete fTreeVar;
+    fTreeVar=nullptr;
+  }
+  fTreeVar = new TTree(name.Data(),title.Data());
+  
+  //set common variables
+  AddCommonDmesonVarBranches();
+  
+  //set Ds variables
+  TString massKKname="";
+  if(fMassKKOpt==kMassKK) massKKname = "mass_KK";
+  else if(fMassKKOpt==kDeltaMassKKPhi) massKKname = "delta_mass_KK";
+  fTreeVar->Branch("sig_vert",&fSigmaVertex);
+  fTreeVar->Branch(massKKname.Data(),&fMassKK);
+  fTreeVar->Branch("cos_PiDs",&fCosPiDs);
+  fTreeVar->Branch("cos_PiKPhi_3",&fCosPiKPhi);
+  fTreeVar->Branch("max_norm_d0d0exp",&fNormd0MeasMinusExp);
+  for(unsigned int iProng=0; iProng<fNProngs; iProng++){
+    fTreeVar->Branch(Form("imp_par_prong%d",iProng),&fImpParProng[iProng]);
+  }
+  
+  //set single-track variables
+  AddSingleTrackBranches();
+  
+  //sed pid variables
+  if(fPidOpt!=kNoPID) AddPidBranches(true,true,false,true,true);
+  
+  return fTreeVar;
+}
+
+//________________________________________________________________
+bool AliHFTreeHandlerApplyDstoKKpi::SetVariables(int runnumber, unsigned int eventID, float ptgen, float mlprob, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse *pidrespo)
+{
+  if(!cand) return false;
+  if(fFillOnlySignal) { //if fill only signal and not signal candidate, do not store
+    if(!(fCandType&kSignal || fCandType&kRefl)) return true;
+  }
+  fRunNumber=runnumber;
+  fEvID=eventID;
+  fPtGen=ptgen;
+  fMLProb=mlprob;
+  
+  //topological variables
+  //common
+  fPt=cand->Pt();
+  fY=cand->Y(431);
+  fEta=cand->Eta();
+  fPhi=cand->Phi();
+  fDecayLength=cand->DecayLength();
+  fDecayLengthXY=cand->DecayLengthXY();
+  fNormDecayLengthXY=cand->NormalizedDecayLengthXY();
+  fCosP=cand->CosPointingAngle();
+  fCosPXY=cand->CosPointingAngleXY();
+  fImpParXY=cand->ImpParXY();
+  fDCA=cand->GetDCA();
+  fNormd0MeasMinusExp=ComputeMaxd0MeasMinusExp(cand,bfield);
+  
+  //Ds+ -> KKpi variables
+  fSigmaVertex=((AliAODRecoDecayHF3Prong*)cand)->GetSigmaVert();
+  float massPhi = 0;
+  float cospikphi=-2;
+  if(fMassKKOpt==kDeltaMassKKPhi) massPhi = TDatabasePDG::Instance()->GetParticle(333)->Mass();
+  if(masshypo==0){ //phiKKpi
+    fInvMass=((AliAODRecoDecayHF3Prong*)cand)->InvMassDsKKpi();
+    fMassKK=TMath::Abs(((AliAODRecoDecayHF3Prong*)cand)->InvMass2Prongs(0,1,321,321)-massPhi);
+    fCosPiDs=((AliAODRecoDecayHF3Prong*)cand)->CosPiDsLabFrameKKpi();
+    cospikphi = ((AliAODRecoDecayHF3Prong*)cand)->CosPiKPhiRFrameKKpi();
+  }
+  else if(masshypo==1){ //phipiKK
+    fInvMass=((AliAODRecoDecayHF3Prong*)cand)->InvMassDspiKK();
+    fMassKK=TMath::Abs(((AliAODRecoDecayHF3Prong*)cand)->InvMass2Prongs(1,2,321,321)-massPhi);
+    fCosPiDs=((AliAODRecoDecayHF3Prong*)cand)->CosPiDsLabFramepiKK();
+    cospikphi = ((AliAODRecoDecayHF3Prong*)cand)->CosPiKPhiRFramepiKK();
+  }
+  fCosPiKPhi=cospikphi*cospikphi*cospikphi;
+  for(unsigned int iProng=0; iProng<fNProngs; iProng++) {
+    fImpParProng[iProng]=cand->Getd0Prong(iProng);
+  }
+  
+  //single-track variables
+  AliAODTrack* prongtracks[3];
+  for(unsigned int iProng=0; iProng<fNProngs; iProng++) prongtracks[iProng] = (AliAODTrack*)cand->GetDaughter(iProng);
+  bool setsingletrack = SetSingleTrackVars(prongtracks);  
+  if(!setsingletrack) return false;
+  
+  //pid variables
+  if(fPidOpt==kNoPID) return true;
+  
+  bool setpid = SetPidVars(prongtracks,pidrespo,true,true,false,true,true);
+  if(!setpid) return false;
+  
+  return true;
+}

--- a/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyDstoKKpi.h
+++ b/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyDstoKKpi.h
@@ -1,0 +1,61 @@
+#ifndef ALIHFTREEHANDLERAPPLYDSTOKKPI_H
+#define ALIHFTREEHANDLERAPPLYDSTOKKPI_H
+
+/* Copyright(c) 1998-2008, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
+
+/* $Id$ */
+
+//*************************************************************************
+// \class AliHFTreeHandlerApplyDstoKKpi
+// \brief helper class to handle a tree for Ds cut optimisation and MVA analyses
+// \authors:
+// L. Vermunt, luuk.vermunt@cern.ch
+/////////////////////////////////////////////////////////////
+
+#include "AliHFTreeHandlerApply.h"
+
+class AliHFTreeHandlerApplyDstoKKpi : public AliHFTreeHandlerApply
+{
+public:
+  
+  enum massKKopt {kMassKK,kDeltaMassKKPhi};
+  
+  static const int kDplustoKKpi = BIT(11);
+  
+  AliHFTreeHandlerApplyDstoKKpi();
+  AliHFTreeHandlerApplyDstoKKpi(int PIDopt);
+  virtual ~AliHFTreeHandlerApplyDstoKKpi();
+  
+  AliHFTreeHandlerApplyDstoKKpi(const AliHFTreeHandlerApplyDstoKKpi &source) = delete;
+  AliHFTreeHandlerApplyDstoKKpi& operator=(const AliHFTreeHandlerApplyDstoKKpi &source) = delete;
+  
+  virtual TTree* BuildTree(TString name="tree", TString title="tree");
+  virtual bool SetVariables(int runnumber, unsigned int eventID, float ptgen, float mlprob, AliAODRecoDecayHF* cand, float bfield, int masshypo=0, AliPIDResponse *pidrespo=nullptr);
+  
+  void SetMassKKOption(int opt) {fMassKKOpt=opt;}
+  void SetIsDplustoKKpi(bool isDplus) {
+    if(isDplus) fCandType |= kDplustoKKpi;
+    else fCandType &= ~kDplustoKKpi;
+  }
+  
+  static bool IsDplustoKKpi(int candtype) {
+    if(candtype>>11&1) return true;
+    return false;
+  }
+  
+private:
+  
+  float fImpParProng[knMaxProngs];       /// prong impact parameter
+  float fSigmaVertex;                    /// candidate sigma vertex
+  float fMassKK;                         /// candidate massKK
+  float fCosPiDs;                        /// candidate cos3piDs
+  float fCosPiKPhi;                      /// candidate cospiKphi
+  float fNormd0MeasMinusExp;             /// candidate topomatic variable
+  int fMassKKOpt;                        /// option for massKK variable (mass or delta mass wrt phi)
+  
+  /// \cond CLASSIMP
+  ClassDef(AliHFTreeHandlerApplyDstoKKpi,1); ///
+  /// \endcond
+};
+#endif

--- a/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyLc2V0bachelor.cxx
+++ b/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyLc2V0bachelor.cxx
@@ -1,0 +1,202 @@
+/* Copyright(c) 1998-2008, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
+
+/* $Id$ */
+
+//*************************************************************************
+// \class AliHFTreeHandlerApplyLc2V0bachelor
+// \brief helper class to handle a tree for Lc->K0sp cut optimisation and MVA analyses
+// \authors:
+// L. Vermunt, luuk.vermunt@cern.ch
+/////////////////////////////////////////////////////////////
+
+#include <TString.h>
+#include <TDatabasePDG.h>
+#include "AliHFTreeHandlerApplyLc2V0bachelor.h"
+#include "AliAODRecoCascadeHF.h"
+
+/// \cond CLASSIMP
+ClassImp(AliHFTreeHandlerApplyLc2V0bachelor);
+/// \endcond
+
+//________________________________________________________________
+AliHFTreeHandlerApplyLc2V0bachelor::AliHFTreeHandlerApplyLc2V0bachelor():
+AliHFTreeHandlerApplyLc2V0bachelor(kNsigmaPID)
+{
+  //
+  // Default constructor
+  //
+}
+
+//________________________________________________________________
+AliHFTreeHandlerApplyLc2V0bachelor::AliHFTreeHandlerApplyLc2V0bachelor(int PIDopt):
+AliHFTreeHandlerApply(PIDopt),
+fImpParProng{},
+fImpParK0s(-9999.),
+fDecayLengthK0s(-9999.),
+fInvMassK0s(-9999.),
+fDCAK0s(-9999.),
+fPtK0s(-9999.),
+fEtaK0s(-9999.),
+fPhiK0s(-9999.),
+fcTauK0s(-9999.),
+fV0PointingAngle(-9999.),
+fCosThetaStar(-9999.),
+fsignd0(-9999.),
+fArmqTOverAlpha(-9999.),
+fCalcSecoVtx(0)
+{
+  //
+  // Standard constructor
+  //
+  
+  fNProngs = 3; // --> cannot be changed (prong 0 is the bachelor, 1,2 are prongs of the K0s)
+  for(unsigned int iProng=0; iProng<fNProngs; iProng++)
+    fImpParProng[iProng] = -9999.;
+}
+
+//________________________________________________________________
+AliHFTreeHandlerApplyLc2V0bachelor::~AliHFTreeHandlerApplyLc2V0bachelor()
+{
+  //
+  // Default Destructor
+  //
+}
+
+//________________________________________________________________
+TTree* AliHFTreeHandlerApplyLc2V0bachelor::BuildTree(TString name, TString title)
+{
+  fIsMCGenTree=false;
+  
+  if (fTreeVar) {
+    delete fTreeVar;
+    fTreeVar = nullptr;
+  }
+  fTreeVar = new TTree(name.Data(), title.Data());
+  
+  //set common variables
+  AddCommonDmesonVarBranches(fCalcSecoVtx);
+  
+  //set Lc variables
+  fTreeVar->Branch("cos_t_star", &fCosThetaStar);
+  fTreeVar->Branch("signd0", &fsignd0);
+  fTreeVar->Branch("inv_mass_K0s", &fInvMassK0s);
+  fTreeVar->Branch("dca_K0s", &fDCAK0s);
+  fTreeVar->Branch("imp_par_K0s", &fImpParK0s);
+  fTreeVar->Branch("d_len_K0s", &fDecayLengthK0s);
+  fTreeVar->Branch("armenteros_K0s", &fArmqTOverAlpha);
+  fTreeVar->Branch("ctau_K0s", &fcTauK0s);
+  fTreeVar->Branch("cos_p_K0s", &fV0PointingAngle);
+  fTreeVar->Branch("pt_K0s", &fPtK0s);
+  fTreeVar->Branch("eta_K0s", &fEtaK0s);
+  fTreeVar->Branch("phi_K0s", &fPhiK0s);
+  for(unsigned int iProng=0; iProng<fNProngs; iProng++){
+    fTreeVar->Branch(Form("imp_par_prong%d", iProng), &fImpParProng[iProng]);
+  }
+  
+  //set single-track variables
+  AddSingleTrackBranches();
+  
+  //set PID variables
+  if(fPidOpt != kNoPID) AddPidBranches(true, true, true, true, true);
+  
+  return fTreeVar;
+}
+
+//________________________________________________________________
+bool AliHFTreeHandlerApplyLc2V0bachelor::SetVariables(int runnumber, unsigned int eventID, float ptgen, float mlprob, AliAODRecoDecayHF* cand, float bfield, int masshypo, AliPIDResponse* pidrespo)
+{
+  if(!cand) return false;
+  if(fFillOnlySignal) { //if fill only signal and not signal candidate, do not store
+    if(!(fCandType&kSignal)) return true;
+  }
+  fRunNumber=runnumber;
+  fEvID=eventID;
+  fPtGen=ptgen;
+  fMLProb=mlprob;
+
+  //topological variables
+  //common
+  fPt=cand->Pt();
+  fY=cand->Y(4122);
+  fEta=cand->Eta();
+  fPhi=cand->Phi();
+  if(fCalcSecoVtx){
+    fDecayLength=cand->DecayLength();
+    fDecayLengthXY=cand->DecayLengthXY();
+    fNormDecayLengthXY=cand->NormalizedDecayLengthXY();
+    fCosP=cand->CosPointingAngle();
+    fCosPXY=cand->CosPointingAngleXY();
+    fImpParXY=cand->ImpParXY();
+    fDCA=cand->GetDCA();
+  }
+  
+  //Lc -> K0sp variables
+  fInvMass=((AliAODRecoCascadeHF*)cand)->InvMassLctoK0sP();
+  
+  AliAODv0 * v0part = ((AliAODRecoCascadeHF*)cand)->Getv0();
+  for(unsigned int iProng = 0; iProng < fNProngs; iProng++) {
+    if(iProng==0) fImpParProng[iProng]=cand->Getd0Prong(iProng);
+    else          fImpParProng[iProng]=v0part->Getd0Prong(iProng-1);
+  }
+  fImpParK0s=cand->Getd0Prong(1);
+  fDecayLengthK0s=((AliAODRecoCascadeHF*)cand)->DecayLengthV0();
+  fInvMassK0s=v0part->MassK0Short();
+  fDCAK0s=v0part->GetDCA();
+  fPtK0s=v0part->Pt();
+  fEtaK0s=v0part->Eta();
+  fPhiK0s=v0part->Phi();
+  
+  fcTauK0s=((AliAODRecoCascadeHF*)cand)->DecayLengthV0()*0.497/(v0part->P());
+  fV0PointingAngle=((AliAODRecoCascadeHF*)cand)->CosV0PointingAngle();
+  
+  // Cosine of proton emission angle (theta*) in the rest frame of the mother particle
+  // (from AliRDHFCutsLctoV0)
+  TLorentzVector vpr, vk0s,vlc;
+  Double_t massK0SPDG = TDatabasePDG::Instance()->GetParticle(310)->Mass();    // mass K0S PDG
+  Double_t massPrPDG = TDatabasePDG::Instance()->GetParticle(2212)->Mass();    // mass Proton PDG
+  vpr.SetXYZM(cand->PxProng(0), cand->PyProng(0), cand->PzProng(0), massPrPDG);
+  vk0s.SetXYZM(cand->PxProng(1), cand->PyProng(1), cand->PzProng(1), massK0SPDG);
+  vlc = vpr + vk0s;
+  TVector3 vboost = vlc.BoostVector();
+  vpr.Boost(-vboost);
+  Double_t cts = TMath::Cos(vpr.Angle(vlc.Vect()));
+  fCosThetaStar=cts;
+  
+  // Sign of d0 proton (different from regular d0)
+  // (from AliRDHFCutsLctoV0)
+  AliAODTrack *bachelor = (AliAODTrack*)((AliAODRecoCascadeHF*)cand)->GetBachelor();
+  AliAODVertex *primvert = dynamic_cast<AliAODVertex*>(cand->GetPrimaryVtx());
+  Double_t d0z0bach[2], covd0z0bach[3];
+  bachelor->PropagateToDCA(primvert, bfield, kVeryBig, d0z0bach, covd0z0bach); // HOW DO WE SET THE B FIELD?; kVeryBig should come from AliExternalTrackParam
+  Double_t tx[3];
+  bachelor->GetXYZ(tx);
+  tx[0] -= primvert->GetX();
+  tx[1] -= primvert->GetY();
+  tx[2] -= primvert->GetZ();
+  Double_t innerpro = tx[0]*cand->Px()+tx[1]*cand->Py();
+  Double_t signd0 = 1.;
+  if(innerpro<0.) signd0 = -1.;
+  signd0 = signd0*TMath::Abs(d0z0bach[0]);
+  fsignd0=signd0;
+  
+  //Armenteros qT/|alpha|
+  fArmqTOverAlpha= v0part->PtArmV0()/TMath::Abs(v0part->AlphaV0());
+  
+  //single track variables
+  AliAODTrack* prongtracks[3];
+  for(unsigned int iProng = 0; iProng < fNProngs; iProng++){
+    if(iProng==0) prongtracks[iProng] = (AliAODTrack*)cand->GetDaughter(iProng);
+    else          prongtracks[iProng] = (AliAODTrack*)v0part->GetDaughter(iProng-1);
+  }
+  bool setsingletrack = SetSingleTrackVars(prongtracks);
+  if(!setsingletrack) return false;
+  
+  //pid variables
+  if(fPidOpt == kNoPID) return true;
+  
+  bool setpid = SetPidVars(prongtracks, pidrespo, true, true, true, true, true);
+  if(!setpid) return false;
+  
+  return true;
+}

--- a/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyLc2V0bachelor.h
+++ b/PWGHF/vertexingHF/vHFML/AliHFTreeHandlerApplyLc2V0bachelor.h
@@ -1,0 +1,71 @@
+#ifndef ALIHFTREEHANDLERAPPLYLC2V0BACHELOR_H
+#define ALIHFTREEHANDLERAPPLYLC2V0BACHELOR_H
+
+/* Copyright(c) 1998-2008, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
+
+/* $Id$ */
+
+//*************************************************************************
+// \class AliHFTreeHandlerApplyLc2V0bachelor
+// \brief helper class to handle a tree for Lc cut optimisation and MVA analyses
+// \authors:
+// L. Vermunt, luuk.vermunt@cern.ch
+/////////////////////////////////////////////////////////////
+
+#include "AliHFTreeHandlerApply.h"
+
+class AliHFTreeHandlerApplyLc2V0bachelor : public AliHFTreeHandlerApply
+{
+public:
+  
+  //Standard kSelected of AliHFTreeHandlerApply is Lc->pK0s, but keep possibility to enable also Lc->Lpi (and charge conjugate together)
+  enum isLctoLpi {
+    kLctoLpi       = BIT(11),
+    kLcTopotoLpi   = BIT(12),
+    kLcPIDtoLpi    = BIT(13),
+  };
+  
+  AliHFTreeHandlerApplyLc2V0bachelor();
+  AliHFTreeHandlerApplyLc2V0bachelor(int PIDopt);
+  virtual ~AliHFTreeHandlerApplyLc2V0bachelor();
+  
+  AliHFTreeHandlerApplyLc2V0bachelor(const AliHFTreeHandlerApplyLc2V0bachelor &source) = delete;
+  AliHFTreeHandlerApplyLc2V0bachelor& operator=(const AliHFTreeHandlerApplyLc2V0bachelor &source) = delete;
+  
+  virtual TTree* BuildTree(TString name = "tree", TString title = "tree");
+  virtual bool SetVariables(int runnumber, unsigned int eventID, float ptgen, float mlprob, AliAODRecoDecayHF* cand, float bfield, int masshypo = 0, AliPIDResponse* pidrespo = nullptr);
+  
+  void SetCalcSecoVtx(int opt) {fCalcSecoVtx=opt;}
+  
+  void SetIsLctoLpi(int isSeltoLpi, int isSelTopotoLpi, int isSelPIDtoLpi) {
+    if(isSeltoLpi) fCandType |= kLctoLpi;
+    else fCandType &= ~kLctoLpi;
+    if(isSelTopotoLpi) fCandType |= kLcTopotoLpi;
+    else fCandType &= ~kLcTopotoLpi;
+    if(isSelPIDtoLpi) fCandType |= kLcPIDtoLpi;
+    else fCandType &= ~kLcPIDtoLpi;
+  }
+  
+private:
+  
+  float fImpParProng[knMaxProngs];         /// prong impact parameter
+  float fImpParK0s;                        /// impact parameter K0s
+  float fDecayLengthK0s;                   /// decay length K0s
+  float fInvMassK0s;                       /// invariant mass of K0s
+  float fDCAK0s;                           /// DCA K0s prongs
+  float fPtK0s;                            /// K0s pt
+  float fEtaK0s;                           /// K0s pseudorapidity
+  float fPhiK0s;                           /// K0s azimuthal angle
+  float fcTauK0s;                          /// cTau of the K0s
+  float fV0PointingAngle;                  /// K0s pointing angle
+  float fCosThetaStar;                     /// cos theta star (proton - Lc)
+  float fsignd0;                           /// signed d0 proton (different from standard d0)
+  float fArmqTOverAlpha;                   /// Armenteros qT/|alpha| of the K0s
+  int fCalcSecoVtx;                        /// flag to calculate secondary vertex for Lc (if false, CommonDmesonVarBranches are not filled)
+  
+  /// \cond CLASSIMP
+  ClassDef(AliHFTreeHandlerApplyLc2V0bachelor, 1); ///
+  /// \endcond
+};
+#endif

--- a/PWGHF/vertexingHF/vHFML/CMakeLists.txt
+++ b/PWGHF/vertexingHF/vHFML/CMakeLists.txt
@@ -39,12 +39,17 @@ set(SRCS
     AliHFMLResponse.cxx
     AliHFMLResponseDplustoKpipi.cxx
     AliHFMLResponseDstoKKpi.cxx
+    AliHFMLResponseLctoV0bachelor.cxx
     AliHFMLVarHandler.cxx
     AliHFMLVarHandlerDplustoKpipi.cxx
     AliHFMLVarHandlerDstoKKpi.cxx
     AliAnalysisTaskSEDplus.cxx
     AliAnalysisTaskSEDs.cxx
     AliAnalysisTaskSECharmHadronvn.cxx
+    AliAnalysisTaskSEHFTreeCreatorApply.cxx
+    AliHFTreeHandlerApply.cxx
+    AliHFTreeHandlerApplyDstoKKpi.cxx
+    AliHFTreeHandlerApplyLc2V0bachelor.cxx
 )
 
 # Headers from sources

--- a/PWGHF/vertexingHF/vHFML/PWGHFvertexingHFMLLinkDef.h
+++ b/PWGHF/vertexingHF/vHFML/PWGHFvertexingHFMLLinkDef.h
@@ -8,11 +8,15 @@
 #pragma link C++ class AliAnalysisTaskSEDplus+;
 #pragma link C++ class AliAnalysisTaskSEDs+;
 #pragma link C++ class AliAnalysisTaskSECharmHadronvn+;
+#pragma link C++ class AliAnalysisTaskSEHFTreeCreatorApply+;
 #pragma link C++ class AliHFMLResponse+;
 #pragma link C++ class AliHFMLResponseDplustoKpipi+;
 #pragma link C++ class AliHFMLResponseDstoKKpi+;
+#pragma link C++ class AliHFMLResponseLctoV0bachelor+;
 #pragma link C++ class AliHFMLVarHandler+;
 #pragma link C++ class AliHFMLVarHandlerDplustoKpipi+;
 #pragma link C++ class AliHFMLVarHandlerDstoKKpi+;
-
+#pragma link C++ class AliHFTreeHandlerApply+;
+#pragma link C++ class AliHFTreeHandlerApplyDstoKKpi+;
+#pragma link C++ class AliHFTreeHandlerApplyLc2V0bachelor+;
 #endif


### PR DESCRIPTION
Using the newly developed tools in the vHFML directory to apply a filtering XGBoost probability cut on the GRID before filling the TTrees.

**Note:**
Because of the treelite dependency of PWGHF/vertexingHF/vHFML dir, and the fastjet and EMCALjet dependencies of the PWGHF/treeHF dir, it was not (easily) possible to integrate the AliHFMLResponse class in the existing TTreeCreator task. I therefore made a stripped version of the TTreeCreator and TTreeHandler tasks and located them in the vHFML directory. Hopefully this is a temporary solution, as this duplicates code.