### PR TITLE
AliAnalysisTaskOmegaToPiZeroGamma compatible with correction task

### DIFF
--- a/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
@@ -1427,7 +1427,6 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserExec(Option_t *)
   }
 
   fReaderGammas = fV0Reader->GetReconstructedGammas(); // Gammas from default Cut
-  std::cout << "GetNReconstructedGammas = " << fV0Reader->GetNReconstructedGammas() << '\n';
 
   // ------------------- BeginEvent ----------------------------
   AliEventplane *EventPlane = fInputEvent->GetEventplane();
@@ -1463,15 +1462,10 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserExec(Option_t *)
       fWeightJetJetMC       = 1;
       Float_t pthard = -1;
   //     cout << fMCEvent << endl;
-<<<<<<< HEAD
-      Bool_t isMCJet        = ((AliConvEventCuts*)fEventCutArray->At(iCut))->IsJetJetMCEventAccepted( fMCEvent, fWeightJetJetMC,pthard );
-=======
       Bool_t isMCJet        = ((AliConvEventCuts*)fEventCutArray->At(iCut))->IsJetJetMCEventAccepted( fMCEvent, fWeightJetJetMC, fInputEvent );
->>>>>>> Made OmegaToPiZeroGamma compatible with the current correction task
       if (fIsMC == 3){
         Double_t weightMult   = ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetWeightForMultiplicity(fV0Reader->GetNumberOfPrimaryTracks());
         fWeightJetJetMC       = fWeightJetJetMC*weightMult;
-        std::cout << "fWeightJetJetMC = " << fWeightJetJetMC << '\n';
       }
       if(fIsMC==1) fWeightJetJetMC = 1;
       if (!isMCJet){
@@ -1808,7 +1802,6 @@ void AliAnalysisTaskOmegaToPiZeroGamma::ProcessPhotonCandidates()
     if(!((AliConversionPhotonCuts*)fCutArray->At(fiCut))->InPlaneOutOfPlaneCut(PhotonCandidate->GetPhotonPhi(),fEventPlaneAngle)) continue;
     if(!((AliConversionPhotonCuts*)fCutArray->At(fiCut))->UseElecSharingCut() &&
     !((AliConversionPhotonCuts*)fCutArray->At(fiCut))->UseToCloseV0sCut()){
-      std::cout << "1 Adding a PhotonCandidate!" << '\n';
       fGammaCandidates->Add(PhotonCandidate); // if no second loop is required add to events good gammas
 
       if(fIsFromMBHeader){
@@ -1846,7 +1839,6 @@ void AliAnalysisTaskOmegaToPiZeroGamma::ProcessPhotonCandidates()
       }
       if(!((AliConversionPhotonCuts*)fCutArray->At(fiCut))->RejectSharedElectronV0s(PhotonCandidate,i,GammaCandidatesStepOne->GetEntries())) continue;
       if(!((AliConversionPhotonCuts*)fCutArray->At(fiCut))->UseToCloseV0sCut()){ // To Colse v0s cut diabled, step two not needed
-        std::cout << "2 Adding a PhotonCandidate!" << '\n';
         fGammaCandidates->Add(PhotonCandidate);
         if(fIsFromMBHeader){
           fHistoConvGammaPt[fiCut]->Fill(PhotonCandidate->Pt(),fWeightJetJetMC);
@@ -1875,7 +1867,6 @@ void AliAnalysisTaskOmegaToPiZeroGamma::ProcessPhotonCandidates()
         if( (isNegFromMBHeader+isPosFromMBHeader) != 4) fIsFromMBHeader = kFALSE;
       }
       if(!((AliConversionPhotonCuts*)fCutArray->At(fiCut))->RejectToCloseV0s(PhotonCandidate,GammaCandidatesStepTwo,i)) continue;
-      std::cout << "3 Adding a PhotonCandidate!" << '\n';
       fGammaCandidates->Add(PhotonCandidate); // Add gamma to current cut TList
       if(fIsFromMBHeader){
         fHistoConvGammaPt[fiCut]->Fill(PhotonCandidate->Pt(),fWeightJetJetMC);

--- a/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
+++ b/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.cxx
@@ -1462,7 +1462,7 @@ void AliAnalysisTaskOmegaToPiZeroGamma::UserExec(Option_t *)
       fWeightJetJetMC       = 1;
       Float_t pthard = -1;
   //     cout << fMCEvent << endl;
-      Bool_t isMCJet        = ((AliConvEventCuts*)fEventCutArray->At(iCut))->IsJetJetMCEventAccepted( fMCEvent, fWeightJetJetMC, fInputEvent );
+      Bool_t isMCJet        = ((AliConvEventCuts*)fEventCutArray->At(iCut))->IsJetJetMCEventAccepted( fMCEvent, fWeightJetJetMC, pthard, fInputEvent);
       if (fIsMC == 3){
         Double_t weightMult   = ((AliConvEventCuts*)fEventCutArray->At(iCut))->GetWeightForMultiplicity(fV0Reader->GetNumberOfPrimaryTracks());
         fWeightJetJetMC       = fWeightJetJetMC*weightMult;

--- a/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.h
+++ b/PWGGA/GammaConv/AliAnalysisTaskOmegaToPiZeroGamma.h
@@ -34,14 +34,17 @@ class AliAnalysisTaskOmegaToPiZeroGamma : public AliAnalysisTaskSE {
 
     void SetV0ReaderName(TString name){fV0ReaderName=name; return;}
     void SetIsHeavyIon(Int_t flag){
-      fIsHeavyIon = flag;    
+      fIsHeavyIon = flag;
     }
+    // Function to set correction task setting
+    void SetCorrectionTaskSetting(TString setting) {fCorrTaskSetting = setting;}
+
 
     // base functions for selecting photon and meson candidates in reconstructed data
     void ProcessClusters();
     void ProcessPhotonCandidates();
     void CalculateOmegaCandidates();
-    
+
     // MC functions
     void SetIsMC                        ( Int_t isMC)                                       { fIsMC = isMC                              ;}
     void ProcessMCParticles             ();
@@ -52,40 +55,40 @@ class AliAnalysisTaskOmegaToPiZeroGamma : public AliAnalysisTaskSE {
     void ProcessTrueClusterCandidatesAOD( AliAODConversionPhoton* TruePhotonCandidate);
     void RelabelAODPhotonCandidates     ( Bool_t mode);
     void ProcessTrueMesonCandidates     ( AliAODConversionMother *OmegaCandidate,
-                                          AliAODConversionPhoton *TrueGammaCandidate0, 
-                                          AliAODConversionPhoton *TrueGammaCandidate1, 
+                                          AliAODConversionPhoton *TrueGammaCandidate0,
+                                          AliAODConversionPhoton *TrueGammaCandidate1,
                                           AliAODConversionPhoton *TrueGammaCandidate2);
     void ProcessTrueMesonCandidatesAOD  ( AliAODConversionMother *OmegaCandidate,
                                           AliAODConversionPhoton *TrueGammaCandidate0,
                                           AliAODConversionPhoton *TrueGammaCandidate1,
                                           AliAODConversionPhoton *TrueGammaCandidate2);
-    
+
     // switches for additional analysis streams or outputs
     void SetDoMesonQA                   ( Int_t flag )                                      { fDoMesonQA = flag                           ;}
     void SetDoPhotonQA                  ( Int_t flag )                                      { fDoPhotonQA = flag                          ;}
     void SetPlotHistsExtQA              ( Bool_t flag )                                     { fSetPlotHistsExtQA = flag                   ;}
 
     // Setting the cut lists for the conversion photons
-    void SetEventCutList                ( Int_t nCuts, 
+    void SetEventCutList                ( Int_t nCuts,
                                           TList *CutArray)                                  {
                                                                                               fnCuts = nCuts                              ;
                                                                                               fEventCutArray = CutArray                   ;
                                                                                             }
 
     // Setting the cut lists for the conversion photons
-    void SetConversionCutList           ( Int_t nCuts, 
+    void SetConversionCutList           ( Int_t nCuts,
                                           TList *CutArray)                                  {
                                                                                               fnCuts = nCuts                              ;
                                                                                               fCutArray = CutArray                        ;
                                                                                             }
 
       // Setting the cut lists for the calo photons
-    void SetCaloCutList                 ( Int_t nCuts, 
+    void SetCaloCutList                 ( Int_t nCuts,
                                           TList *CutArray)                                  {
                                                                                               fnCuts = nCuts                              ;
                                                                                               fClusterCutArray = CutArray                 ;
                                                                                             }
-    
+
     // Setting cut lists for the neutral pion
     void SetNeutralPionCutList          ( Int_t nCuts,
                                           TList *CutArray)                                  {
@@ -103,17 +106,17 @@ class AliAnalysisTaskOmegaToPiZeroGamma : public AliAnalysisTaskSE {
     // BG HandlerSettings
     void CalculateBackground            ();
     void SetMoveParticleAccordingToVertex       ( Bool_t flag )                             { fMoveParticleAccordingToVertex = flag       ;}
-    void MoveParticleAccordingToVertex          ( AliAODConversionPhoton* particle, 
+    void MoveParticleAccordingToVertex          ( AliAODConversionPhoton* particle,
                                                   const AliGammaConversionAODBGHandler::GammaConversionVertex *vertex);
     void MoveParticleAccordingToVertex          (AliAODConversionMother* particle,
                                                   const AliGammaConversionAODBGHandler::GammaConversionVertex *vertex);
     void UpdateEventByEventData         ();
-    
+
     // Additional functions for convenience
     void SetLogBinningXTH2              ( TH2* histoRebin );
-    Int_t GetSourceClassification       (Int_t daughter, 
+    Int_t GetSourceClassification       (Int_t daughter,
                                          Int_t pdgCode );
-    Bool_t CheckVectorOnly              ( vector<Int_t> &vec, 
+    Bool_t CheckVectorOnly              ( vector<Int_t> &vec,
                                           Int_t tobechecked );
     Bool_t CheckVectorForDoubleCount    ( vector<Int_t> &vec,
                                           Int_t tobechecked );
@@ -136,13 +139,16 @@ class AliAnalysisTaskOmegaToPiZeroGamma : public AliAnalysisTaskSE {
     // set scaling factors for pi0-gamma angle cut
     void SetlowerFactor                  (Double_t lowerFactor){ flowerFactor = lowerFactor;}
     void SetupperFactor                  (Double_t upperFactor){ fupperFactor = upperFactor;}
-    
+
     void SetTrackMatcherRunningMode(Int_t mode){fTrackMatcherRunningMode = mode;}
 
   protected:
     AliV0ReaderV1*                      fV0Reader;              // basic photon Selection Task
+
     TString                             fV0ReaderName;
-    AliGammaConversionAODBGHandler**    fBGHandler;             // BG handler for Conversion 
+    TString                             fCorrTaskSetting;                       // Correction Task Special Name
+
+    AliGammaConversionAODBGHandler**    fBGHandler;             // BG handler for Conversion
     AliGammaConversionAODBGHandler**    fBGClusHandler;         // BG handler for Cluster
     AliGammaConversionAODBGHandler**    fBGPi0Handler;          // BG handler for pi0's
     AliVEvent*                          fInputEvent;            // current event
@@ -173,8 +179,8 @@ class AliAnalysisTaskOmegaToPiZeroGamma : public AliAnalysisTaskSE {
                       // 0: garbage,
                       // 1: background
                       // 2: secondary photon not from eta or k0s,
-                      // 3: secondary photon from eta, 
-                      // 4: secondary photon from k0s, 
+                      // 3: secondary photon from eta,
+                      // 4: secondary photon from k0s,
                       // 5: dalitz
                       // 6: primary gamma
 
@@ -205,7 +211,7 @@ class AliAnalysisTaskOmegaToPiZeroGamma : public AliAnalysisTaskSE {
     // histograms for rec photon clusters
     TH1F**                  fHistoClusGammaPt;                  //! array of histos with cluster, pt
     TH1F**                  fHistoClusOverlapHeadersGammaPt;    //! array of histos with cluster, pt overlapping with other headers
-                    
+
     //histograms for pure MC quantities
     TH1F**                  fHistoMCAllGammaPt;                 //! array of histos with all gamma, pT
     TH1F**                  fHistoMCAllGammaEMCALAccPt;         //! array of histos with all gamma in EMCAL acceptance, pT
@@ -299,7 +305,7 @@ class AliAnalysisTaskOmegaToPiZeroGamma : public AliAnalysisTaskSE {
     Int_t*                  fESDArrayPos;                                       //[fNGammaCandidates]
     Int_t*                  fESDArrayNeg;                                       //[fNGammaCandidates]
     Int_t                   fnCuts;                                             // number of cuts to be analysed in parallel
-    Int_t                   fiCut;                                              // current cut  
+    Int_t                   fiCut;                                              // current cut
     Bool_t                  fMoveParticleAccordingToVertex;                     // boolean for BG calculation
     Int_t                   fIsHeavyIon;                                        // switch for pp = 0, PbPb = 1, pPb = 2
     Int_t                   fDoMesonQA;                                         // flag for meson QA
@@ -308,7 +314,7 @@ class AliAnalysisTaskOmegaToPiZeroGamma : public AliAnalysisTaskSE {
     Bool_t                  fIsOverlappingWithOtherHeader;                      // flag for particles in MC overlapping between headers
     Int_t                   fIsMC;                                              // flag for MC information
     Bool_t                  fSetPlotHistsExtQA;                                 // flag for extended QA hists
-    Double_t                fWeightJetJetMC;                                    // weight for Jet-Jet MC 
+    Double_t                fWeightJetJetMC;                                    // weight for Jet-Jet MC
     Bool_t                  fEnableSortForClusMC;                               // switch on sorting for MC labels in cluster
     Int_t                   fReconMethod;                                       // switch for combining photons: PCM-cal,cal = 0; PCM-cal,PCM = 1; cal-cal,cal = 2;
                                                                                 // cal-cal,PCM = 3; PCM-PCM,cal = 4; PCM-PCM,PCM = 5
@@ -324,7 +330,7 @@ class AliAnalysisTaskOmegaToPiZeroGamma : public AliAnalysisTaskSE {
     AliAnalysisTaskOmegaToPiZeroGamma(const AliAnalysisTaskOmegaToPiZeroGamma&); // Prevent copy-construction
     AliAnalysisTaskOmegaToPiZeroGamma &operator=(const AliAnalysisTaskOmegaToPiZeroGamma&); // Prevent assignment
 
-    ClassDef(AliAnalysisTaskOmegaToPiZeroGamma, 12);
+    ClassDef(AliAnalysisTaskOmegaToPiZeroGamma, 13);
 };
 
 #endif

--- a/PWGGA/GammaConv/macros/AddTask_OmegaToPiZeroGamma_pp.C
+++ b/PWGGA/GammaConv/macros/AddTask_OmegaToPiZeroGamma_pp.C
@@ -63,6 +63,7 @@ class CutHandlerPiZeroGamma{
 void AddTask_OmegaToPiZeroGamma_pp(
                                 Int_t     trainConfig                   = 1,                      // change different set of cuts
                                 Int_t     isMC                          = 0,                      // run MC
+                                TString   photonCutNumberV0Reader       = "",                     // 00000008400000000100000000 nom. B, 00000088400000000100000000 low B
                                 Int_t     enableQAMesonTask             = 1,                      // enable QA in AliAnalysisTaskGammaConvV1
                                 Int_t     enableQAPhotonTask            = 1,                      // enable additional QA task
                                 Int_t     DoPiZeroGammaAngleCut         = kFALSE,                 // flag for enabling cut on pi0-gamma angle
@@ -71,7 +72,7 @@ void AddTask_OmegaToPiZeroGamma_pp(
                                 TString   cutnumberAODBranch            = "000000006008400001001500000",
                                 Int_t     enableExtMatchAndQA           = 0,                      // disabled (0), extMatch (1), extQA_noCellQA (2), extMatch+extQA_noCellQA (3), extQA+cellQA (4), extMatch+extQA+cellQA (5)
                                 Bool_t    enableV0findingEffi           = kFALSE,                 // enables V0finding efficiency histograms
-                                Bool_t    enableTriggerMimicking        = kFALSE,                 // enable trigger mimicking
+                                Int_t     enableTriggerMimicking        = 0,                      // enable trigger mimicking
                                 Bool_t    enableTriggerOverlapRej       = kFALSE,                 // enable trigger overlap rejection
                                 TString   settingMaxFacPtHard           = "3.",                   // maximum factor between hardest jet and ptHard generated
                                 TString   periodNameV0Reader            = "",                     // period Name for V0 Reader
@@ -165,9 +166,6 @@ void AddTask_OmegaToPiZeroGamma_pp(
 
   // fReconMethod = first digit of trainconfig
   Int_t ReconMethod = trainConfig/100;
-  std::cout << "############################################################################################################################# " << "\n";
-  std::cout << "ReconMethod = " <<  ReconMethod << "\n";
-  std::cout << "trainConfig = " <<  trainConfig << "\n";
 
   // ================== GetAnalysisManager ===============================
   AliAnalysisManager *mgr = AliAnalysisManager::GetAnalysisManager();
@@ -181,31 +179,9 @@ void AddTask_OmegaToPiZeroGamma_pp(
 
   Bool_t isMCForOtherSettings = 0;
   if (isMC > 0) isMCForOtherSettings = 1;
-  //========= Add PID Reponse to ANALYSIS manager ====
-  if(!(AliPIDResponse*)mgr->GetTask("PIDResponseTask")){
-
-    #if !defined (__CINT__) || defined (__CLING__)
-      AliAnalysisTaskPIDResponse *pidRespTask=reinterpret_cast<AliAnalysisTaskPIDResponse*>(
-          gInterpreter->ExecuteMacro(Form("$ALICE_ROOT/ANALYSIS/macros/AddTaskPIDResponse.C (%i)",isMCForOtherSettings)));
-    #else
-      gROOT->LoadMacro("$ALICE_ROOT/ANALYSIS/macros/AddTaskPIDResponse.C");
-      AddTaskPIDResponse(isMCForOtherSettings);
-    #endif
-
-    // gROOT->LoadMacro("$ALICE_ROOT/ANALYSIS/macros/AddTaskPIDResponse.C");
-    // AliAnalysisTaskPIDResponse* taskPIDResponse =  AddTaskPIDResponse(isMCForOtherSettings);
-  }
-
-  Printf("here \n");
 
   //=========  Set Cutnumber for V0Reader ================================
-  TString cutnumberPhoton = "10000008400100001500000000";// 00000008400100001500000000
-  if (  periodNameV0Reader.CompareTo("LHC16f") == 0 || periodNameV0Reader.CompareTo("LHC17g")==0 || periodNameV0Reader.CompareTo("LHC18c")==0 ||
-        periodNameV0Reader.CompareTo("LHC17d1") == 0  || periodNameV0Reader.CompareTo("LHC17d12")==0 ||
-        periodNameV0Reader.CompareTo("LHC17h3")==0 || periodNameV0Reader.CompareTo("LHC17k1")==0 ||
-        periodNameV0Reader.CompareTo("LHC17f8b") == 0 ||
-        periodNameV0Reader.CompareTo("LHC16P1JJLowB") == 0 || periodNameV0Reader.CompareTo("LHC16P1Pyt8LowB") == 0 )
-    cutnumberPhoton         = "10000008400100001500000000"; // 00000088400000000100000000
+  TString cutnumberPhoton = photonCutNumberV0Reader.Data();
   TString cutnumberEvent = "00000003";
   Bool_t doEtaShift = kFALSE;
   AliAnalysisDataContainer *cinput = mgr->GetCommonInputContainer();


### PR DESCRIPTION
I made the AliAnalysisTaskOmegaToPiZeroGamma compatible with the current correction task and updated the pp 13 TeV train config for EMCal to now use EMCal + DCal.
The second commit is for removing some couts which I forgot to delete in the first commit.