### PR TITLE
Some development of treelite ML interface 

### DIFF
--- a/ML/AliMLModelHandler.cxx
+++ b/ML/AliMLModelHandler.cxx
@@ -1,0 +1,88 @@
+// Copyright CERN. This software is distributed under the terms of the GNU
+// General Public License v3 (GPL Version 3).
+//
+// See http://www.gnu.org/licenses/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file AliMLModelHandler.cxx
+/// \author pietro.fecchio@cern.ch, maximiliano.puccio@cern.ch, fabio.catalano@cern.ch
+
+#include "AliMLModelHandler.h"
+
+#include <map>
+#include "assert.h"
+#include "yaml-cpp/yaml.h"
+#include <TDirectory.h>
+#include <TFile.h>
+#include <TGrid.h>
+#include <TSystem.h>
+
+namespace {
+
+std::map<std::string, int> kLibraryMap = {{"kXGBoost", AliMLModelHandler::kXGBoost}, {"kLightGBM", AliMLModelHandler::kLightGBM}, 
+                                          {"kModelLibrary", AliMLModelHandler::kModelLibrary}};
+
+std::string ImportFile(std::string path) {
+  std::string modelname = path.substr(path.find_last_of("/") + 1);
+
+  if (path.find("alien:") != std::string::npos) {
+    if (gGrid == nullptr) {
+      TGrid::Connect("alien://");
+      assert(gGrid != nullptr && "Connection to GRID not established! Exit");
+    }
+  }
+
+  std::string newpath = gSystem->pwd() + std::string("/") + modelname.data();
+  std::string oldpath = gDirectory->GetPath();
+
+  bool cpStatus = TFile::Cp(path.data(), newpath.data());
+  assert(cpStatus && "Error in coping file in the working directory! Exit");
+
+  gDirectory->Cd(oldpath.data());
+
+  return newpath;
+}
+}    // namespace
+
+//_______________________________________________________________________________
+AliMLModelHandler::AliMLModelHandler() :  model(), path(), library(), scorecut() {
+  //
+  // Default constructor
+  //
+}
+
+//_______________________________________________________________________________
+AliMLModelHandler::AliMLModelHandler(const YAML::Node &node)
+      : model(), path(node["path"].as<std::string>()), library(node["library"].as<std::string>()),
+        scorecut(node["cut"].as<double>()) {
+  //
+  // Standard constructor
+  //
+}
+
+//_______________________________________________________________________________
+bool AliMLModelHandler::CompileModel() {
+  std::string localpath = ImportFile(this->path);
+
+  switch (kLibraryMap[GetLibrary()]) {
+    case kXGBoost: {
+      return this->model.LoadXGBoostModel(localpath.data());
+      break;
+    }
+    case kLightGBM: {
+      return this->model.LoadLightGBMModel(localpath.data());
+      break;
+    }
+    case kModelLibrary: {
+      return this->model.LoadModelLibrary(localpath.data());
+      break;
+    }
+    default: {
+      return this->model.LoadXGBoostModel(localpath.data());
+      break;
+    }
+  }
+}

--- a/ML/AliMLModelHandler.h
+++ b/ML/AliMLModelHandler.h
@@ -16,12 +16,14 @@
 
 #include <string>
 
+#include "TNamed.h"
+
 namespace YAML {
   class Node;
 }
 class AliExternalBDT;
 
-class AliMLModelHandler {
+class AliMLModelHandler : public TNamed {
 public:
   enum {kXGBoost, kLightGBM, kModelLibrary};
 
@@ -41,12 +43,16 @@ public:
   static std::string ImportFile(std::string path);
 
 private:
-  AliExternalBDT *fModel;
+  AliExternalBDT *fModel;  //!<!
 
-  std::string fPath;
-  std::string fLibrary;
+  std::string fPath;       ///
+  std::string fLibrary;    ///
 
-  double fScoreCut;
+  double fScoreCut;        ///
+
+/// \cond CLASSIMP
+ClassDef(AliMLModelHandler, 1);    ///
+/// \endcond
 };
 
 #endif

--- a/ML/AliMLModelHandler.h
+++ b/ML/AliMLModelHandler.h
@@ -38,6 +38,7 @@ public:
   double const &GetScoreCut() const { return fScoreCut; }
 
   bool CompileModel();
+  static std::string ImportFile(std::string path);
 
 private:
   AliExternalBDT *fModel;

--- a/ML/AliMLModelHandler.h
+++ b/ML/AliMLModelHandler.h
@@ -11,17 +11,15 @@
 // or submit itself to any jurisdiction.
 
 /// \file AliMLModelHandler.h
-/// \brief Implementation of a C++ interface in AliPhysics for the
-///        configuration of ML application on grid
+/// \brief Utility class to store the compiled model and it's information
 /// \author pietro.fecchio@cern.ch, maximiliano.puccio@cern.ch, fabio.catalano@cern.ch
 
 #include <string>
 
-#include "AliExternalBDT.h"
-
 namespace YAML {
   class Node;
 }
+class AliExternalBDT;
 
 class AliMLModelHandler {
 public:
@@ -29,21 +27,25 @@ public:
 
   AliMLModelHandler();
   AliMLModelHandler(const YAML::Node &node);
+  virtual ~AliMLModelHandler();
 
-  std::string const &GetPath() const { return path; }
-  std::string const &GetLibrary() const { return library; }
-  double const &GetScoreCut() const { return scorecut; }
-  AliExternalBDT &GetModel() { return model; }
+  AliMLModelHandler(const AliMLModelHandler &source);
+  AliMLModelHandler &operator=(const AliMLModelHandler &source);
+
+  AliExternalBDT *GetModel() { return fModel; }
+  std::string const &GetPath() const { return fPath; }
+  std::string const &GetLibrary() const { return fLibrary; }
+  double const &GetScoreCut() const { return fScoreCut; }
 
   bool CompileModel();
 
 private:
-  AliExternalBDT model;
+  AliExternalBDT *fModel;
 
-  std::string path;
-  std::string library;
+  std::string fPath;
+  std::string fLibrary;
 
-  double scorecut;
+  double fScoreCut;
 };
 
 #endif

--- a/ML/AliMLModelHandler.h
+++ b/ML/AliMLModelHandler.h
@@ -1,0 +1,49 @@
+#ifndef ALIMLMODELHANDLER_H
+#define ALIMLMODELHANDLER_H
+
+// Copyright CERN. This software is distributed under the terms of the GNU
+// General Public License v3 (GPL Version 3).
+//
+// See http://www.gnu.org/licenses/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file AliMLModelHandler.h
+/// \brief Implementation of a C++ interface in AliPhysics for the
+///        configuration of ML application on grid
+/// \author pietro.fecchio@cern.ch, maximiliano.puccio@cern.ch, fabio.catalano@cern.ch
+
+#include <string>
+
+#include "AliExternalBDT.h"
+
+namespace YAML {
+  class Node;
+}
+
+class AliMLModelHandler {
+public:
+  enum {kXGBoost, kLightGBM, kModelLibrary};
+
+  AliMLModelHandler();
+  AliMLModelHandler(const YAML::Node &node);
+
+  std::string const &GetPath() const { return path; }
+  std::string const &GetLibrary() const { return library; }
+  double const &GetScoreCut() const { return scorecut; }
+  AliExternalBDT &GetModel() { return model; }
+
+  bool CompileModel();
+
+private:
+  AliExternalBDT model;
+
+  std::string path;
+  std::string library;
+
+  double scorecut;
+};
+
+#endif

--- a/ML/AliMLResponse.cxx
+++ b/ML/AliMLResponse.cxx
@@ -10,15 +10,16 @@
 /// \file AliMLResponse.cxx
 /// \author pietro.fecchio@cern.ch, maximiliano.puccio@cern.ch
 
+#include "AliMLResponse.h"
+
+#include "assert.h"
+#include "yaml-cpp/yaml.h"
+
 #include <TDirectory.h>
 #include <TFile.h>
 #include <TGrid.h>
 #include <TSystem.h>
-
 #include "AliLog.h"
-#include "AliMLResponse.h"
-
-#include "assert.h"
 
 using std::map;
 using std::pair;
@@ -26,10 +27,6 @@ using std::string;
 using std::vector;
 
 namespace {
-
-enum kLibrary { kXGBoost, kLightGBM, kModelLibrary };
-
-map<string, int> kLibraryMap = {{"kXGBoost", kXGBoost}, {"kLightGBM", kLightGBM}, {"kModelLibrary", kModelLibrary}};
 
 string ImportFile(string path) {
   string modelname = path.substr(path.find_last_of("/") + 1);
@@ -52,29 +49,6 @@ string ImportFile(string path) {
   return newpath;
 }
 }    // namespace
-
-bool ModelHandler::CompileModel() {
-  string localpath = ImportFile(this->path);
-
-  switch (kLibraryMap[GetLibrary()]) {
-  case kXGBoost: {
-    return this->model.LoadXGBoostModel(localpath.data());
-    break;
-  }
-  case kLightGBM: {
-    return this->model.LoadLightGBMModel(localpath.data());
-    break;
-  }
-  case kModelLibrary: {
-    return this->model.LoadModelLibrary(localpath.data());
-    break;
-  }
-  default: {
-    return this->model.LoadXGBoostModel(localpath.data());
-    break;
-  }
-  }
-}
 
 /// \cond CLASSIMP
 ClassImp(AliMLResponse);
@@ -177,7 +151,7 @@ void AliMLResponse::MLResponseInit() {
   fBinsBegin = fBins.begin();
 
   for (const auto &model : nodeList["MODELS"]) {
-    fModels.push_back(ModelHandler{model});
+    fModels.push_back(AliMLModelHandler{model});
   }
 
   for (auto &model : fModels) {

--- a/ML/AliMLResponse.cxx
+++ b/ML/AliMLResponse.cxx
@@ -12,13 +12,8 @@
 
 #include "AliMLResponse.h"
 
-#include "assert.h"
 #include "yaml-cpp/yaml.h"
 
-#include <TDirectory.h>
-#include <TFile.h>
-#include <TGrid.h>
-#include <TSystem.h>
 #include "AliLog.h"
 #include "AliExternalBDT.h"
 
@@ -26,30 +21,6 @@ using std::map;
 using std::pair;
 using std::string;
 using std::vector;
-
-namespace {
-
-string ImportFile(string path) {
-  string modelname = path.substr(path.find_last_of("/") + 1);
-
-  if (path.find("alien:") != string::npos) {
-    if (gGrid == nullptr) {
-      TGrid::Connect("alien://");
-      assert(gGrid != nullptr && "Connection to GRID not established! Exit");
-    }
-  }
-
-  string newpath = gSystem->pwd() + string("/") + modelname.data();
-  string oldpath = gDirectory->GetPath();
-
-  bool cpStatus = TFile::Cp(path.data(), newpath.data());
-  assert(cpStatus && "Error in coping file in the working directory! Exit");
-
-  gDirectory->Cd(oldpath.data());
-
-  return newpath;
-}
-}    // namespace
 
 /// \cond CLASSIMP
 ClassImp(AliMLResponse);
@@ -132,7 +103,7 @@ void AliMLResponse::CheckConfigFile(YAML::Node nodelist) {
 //_______________________________________________________________________________
 void AliMLResponse::MLResponseInit() {
   /// import config file from alien path
-  string configPath = ImportFile(fConfigFilePath);
+  string configPath = AliMLModelHandler::ImportFile(fConfigFilePath);
   YAML::Node nodeList;
   /// manage wrong config file path
   try {

--- a/ML/AliMLResponse.cxx
+++ b/ML/AliMLResponse.cxx
@@ -144,7 +144,7 @@ int AliMLResponse::FindBin(double binvar) {
 //_______________________________________________________________________________
 double AliMLResponse::Predict(double binvar, map<string, double> varmap) {
   if ((int)varmap.size() < fNVariables) {
-    AliFatal("The variables map you provided to the predictor have a size different from the variable list size! Exit");
+    AliFatal("The variable map you provided to the predictor has a size smaller than the variable list size! Exit");
   }
 
   vector<double> features;
@@ -162,4 +162,31 @@ double AliMLResponse::Predict(double binvar, map<string, double> varmap) {
   }
 
   return fModels[bin - 1].GetModel()->Predict(&features[0], fNVariables, fRaw);
+}
+
+//________________________________________________________________
+double AliMLResponse::Predict(double binvar, vector<double> variables) {
+  if ((int)variables.size() != fNVariables) {
+    AliFatal(Form("Number of variables passed (%d) different from the one used in the model (%d)! Exit", (int)variables.size(), fNVariables));
+  }
+
+  int bin = FindBin(binvar);
+  if (bin == 0 || bin == fNBins) {
+    AliWarning("Binned variable outside range, no model available!");
+    return -999.;
+  }
+
+  return fModels[bin - 1].GetModel()->Predict(&variables[0], fNVariables, fRaw);
+}
+
+//________________________________________________________________
+bool AliMLResponse::IsSelected(double binvar, std::map<std::string, double> varmap) {
+  double score{0.};
+  return IsSelected(binvar, varmap, score);
+}
+
+//________________________________________________________________
+bool AliMLResponse::IsSelected(double binvar, std::vector<double> variables) {
+  double score{0.};
+  return IsSelected(binvar, variables, score);
 }

--- a/ML/AliMLResponse.cxx
+++ b/ML/AliMLResponse.cxx
@@ -95,7 +95,7 @@ void AliMLResponse::CheckConfigFile(YAML::Node nodelist) {
   }
   /// error for variables/numberofvariable inconsistency
   if (nodelist["NUM_VAR"].as<unsigned int>() != nodelist["VAR_NAMES"].size()) {
-    AliFatal("Inconsistency found in the number of varibles, please check it! Exit");
+    AliFatal("Inconsistency found in the number of variables, please check it! Exit");
   }
   return;
 }

--- a/ML/AliMLResponse.cxx
+++ b/ML/AliMLResponse.cxx
@@ -20,6 +20,7 @@
 #include <TGrid.h>
 #include <TSystem.h>
 #include "AliLog.h"
+#include "AliExternalBDT.h"
 
 using std::map;
 using std::pair;
@@ -189,5 +190,5 @@ double AliMLResponse::Predict(double binvar, map<string, double> varmap) {
     return -999.;
   }
 
-  return fModels[bin - 1].GetModel().Predict(&features[0], fNVariables, fRaw);
+  return fModels[bin - 1].GetModel()->Predict(&features[0], fNVariables, fRaw);
 }

--- a/ML/AliMLResponse.h
+++ b/ML/AliMLResponse.h
@@ -15,46 +15,18 @@
 ///        configuration of ML application on grid
 /// \author pietro.fecchio@cern.ch, maximiliano.puccio@cern.ch
 
-#include <algorithm>
-#include <iostream>
 #include <map>
 #include <string>
-#include <utility>
 #include <vector>
-
-#include "yaml-cpp/yaml.h"
-
-#include "AliExternalBDT.h"
 
 #include "TNamed.h"
 
-/////////////////////////////////////////////////////////////////////////////////////////
+#include "AliExternalBDT.h"
+#include "AliMLModelHandler.h"
 
-class ModelHandler {
-public:
-  ModelHandler() : model(), path(), library(), scorecut() {}
-  ModelHandler(const YAML::Node &node)
-      : model(), path(node["path"].as<std::string>()), library(node["library"].as<std::string>()),
-        scorecut(node["cut"].as<double>()) {}
-
-  std::string const &GetPath() const { return path; }
-  std::string const &GetLibrary() const { return library; }
-  double const &GetScoreCut() const { return scorecut; }
-
-  AliExternalBDT &GetModel() { return model; }
-
-  bool CompileModel();
-
-private:
-  AliExternalBDT model;    //!
-
-  std::string path;
-  std::string library;
-
-  double scorecut;
-};
-
-/////////////////////////////////////////////////////////////////////////////////////////
+namespace YAML {
+  class Node;
+}
 
 class AliMLResponse : public TNamed {
 public:
@@ -86,7 +58,7 @@ public:
 protected:
   std::string fConfigFilePath;    /// path of the config file
 
-  std::vector<ModelHandler> fModels;
+  std::vector<AliMLModelHandler> fModels;
   std::vector<int> fCentClasses;         /// centrality classes ([cent_min, cent_max])
   std::vector<float> fBins;              /// bin edges for the binned variable (pt/ct)
   std::vector<std::string> fVariableNames;    /// bin edges for the binned variable (pt/ct)

--- a/ML/AliMLResponse.h
+++ b/ML/AliMLResponse.h
@@ -62,22 +62,22 @@ public:
   bool IsSelected(double binvar, std::vector<double> variables, F &score);
 
 protected:
-  std::string fConfigFilePath;    /// path of the config file
+  std::string fConfigFilePath;              /// path of the config file
 
-  std::vector<AliMLModelHandler> fModels;
-  std::vector<int> fCentClasses;         /// centrality classes ([cent_min, cent_max])
-  std::vector<float> fBins;              /// bin edges for the binned variable (pt/ct)
-  std::vector<std::string> fVariableNames;    /// bin edges for the binned variable (pt/ct)
+  std::vector<AliMLModelHandler> fModels;   //!<! vector of models
+  std::vector<int> fCentClasses;            /// centrality classes ([cent_min, cent_max])
+  std::vector<float> fBins;                 /// bin edges for the binned variable (pt/ct)
+  std::vector<std::string> fVariableNames;  /// bin edges for the binned variable (pt/ct)
 
-  int fNBins;         /// number of bins stored for consistency checks
-  int fNVariables;    /// number of variables (features) stored for checks
+  int fNBins;                               /// number of bins stored for consistency checks
+  int fNVariables;                          /// number of variables (features) stored for checks
 
-  std::vector<float>::iterator fBinsBegin;    /// evaluate just once is better
+  std::vector<float>::iterator fBinsBegin;  /// evaluate just once is better
 
-  bool fRaw;
+  bool fRaw;                                /// set to true to use raw score instead of probability
 
   /// \cond CLASSIMP
-  ClassDef(AliMLResponse, 1);    ///
+  ClassDef(AliMLResponse, 2);    ///
   /// \endcond
 };
 

--- a/ML/AliMLResponse.h
+++ b/ML/AliMLResponse.h
@@ -46,13 +46,20 @@ public:
 
   /// return the bin index
   int FindBin(double binvar);
-  /// return the MLModel predicted score (raw or proba, depending on useraw)
+  /// return the ML model predicted score (raw or proba, depending on useraw)
   double Predict(double binvar, std::map<std::string, double> varmap);
+  /// overload to pass directly a vector of variables
+  double Predict(double binvar, std::vector<double> variables);
   /// return true if predicted score for map is above the threshold given in the config
   bool IsSelected(double binvar, std::map<std::string, double> varmap);
   /// overload for getting the model score too
   template<typename F>
   bool IsSelected(double binvar, std::map<std::string, double> varmap, F &score);
+  /// overload to pass directly a vector of variables
+  bool IsSelected(double binvar, std::vector<double> variables);
+  /// overload for getting the model score too
+  template<typename F>
+  bool IsSelected(double binvar, std::vector<double> variables, F &score);
 
 protected:
   std::string fConfigFilePath;    /// path of the config file
@@ -76,14 +83,16 @@ protected:
 
 template<typename F>
 bool AliMLResponse::IsSelected(double binvar, std::map<std::string, double> varmap, F &score) {
-  int bin     = FindBin(binvar);
+  int bin = FindBin(binvar);
   score = Predict(binvar, varmap);
   return score >= fModels[bin - 1].GetScoreCut();
 }
 
-inline bool AliMLResponse::IsSelected(double binvar, std::map<std::string, double> varmap) {
-  float score{0.f};
-  return IsSelected(binvar, varmap, score);
+template<typename F>
+bool AliMLResponse::IsSelected(double binvar, std::vector<double> variables, F &score) {
+  int bin = FindBin(binvar);
+  score = Predict(binvar, variables);
+  return score >= fModels[bin - 1].GetScoreCut();
 }
 
 #endif

--- a/ML/AliMLResponse.h
+++ b/ML/AliMLResponse.h
@@ -21,7 +21,6 @@
 
 #include "TNamed.h"
 
-#include "AliExternalBDT.h"
 #include "AliMLModelHandler.h"
 
 namespace YAML {

--- a/ML/CMakeLists.txt
+++ b/ML/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SRCS
 if(ROOT_VERSION_MAJOR EQUAL 6)
     set(SRCS
 	    ${SRCS}
+        AliMLModelHandler.cxx
         AliMLResponse.cxx
     )
 endif()

--- a/ML/MLLinkDef.h
+++ b/ML/MLLinkDef.h
@@ -9,8 +9,7 @@
 /// classes working in  ROOT6 only
 #ifdef __CLING__
 #pragma link C++ class AliMLResponse+;
-#pragma link C++ class ModelHandler+;
-#pragma link C++ class std::vector<ModelHandler>+;
+#pragma link C++ class AliMLModelHandler+;
 #endif
 
 #endif

--- a/PWGHF/vertexingHF/vHFML/CMakeLists.txt
+++ b/PWGHF/vertexingHF/vHFML/CMakeLists.txt
@@ -30,9 +30,7 @@ include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrections
                     ${AliPhysics_SOURCE_DIR}/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrectionsInterface/
                     ${AliPhysics_SOURCE_DIR}/PWG/FLOW/Base
-                    ${TREELITE_ROOT}/include
-                    ${TREELITE_ROOT}/runtime/native/include
-                    ${YAML_CPP_SOURCE_DIR}/include         
+                    ${TREELITE_ROOT}/include 
 )
 
 # Sources - alphabetical order
@@ -66,7 +64,7 @@ add_library_tested(${MODULEHFML} SHARED  ${SRCS} G__${MODULEHFML}.cxx)
 
 # Generate the ROOT map
 # Dependecies
-set(LIBDEPS ML yaml-cpp PWGHFvertexingHF)
+set(LIBDEPS ML PWGHFvertexingHF)
 generate_rootmap("${MODULEHFML}" "${LIBDEPS}" "${CMAKE_CURRENT_SOURCE_DIR}/${MODULEHFML}LinkDef.h")
 
 # Generate a PARfile target for this library

--- a/PWGHF/vertexingHF/vHFML/CMakeLists.txt
+++ b/PWGHF/vertexingHF/vHFML/CMakeLists.txt
@@ -30,7 +30,6 @@ include_directories(${ROOT_INCLUDE_DIRS}
                     ${AliPhysics_SOURCE_DIR}/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrections
                     ${AliPhysics_SOURCE_DIR}/PWGPP/EVCHAR/FlowVectorCorrections/QnCorrectionsInterface/
                     ${AliPhysics_SOURCE_DIR}/PWG/FLOW/Base
-                    ${TREELITE_ROOT}/include 
 )
 
 # Sources - alphabetical order


### PR DESCRIPTION
This PR introduces some improvements to the treelite interface:
- it is no more needed to add the treelite and yaml-cpp include path in the makefile of the package that use AliMLResponse
- it is possible to pass directly a vector of variables to the model predict (can be useful to debug)
- the case in which the config file is in the current directory is now supported


@mpuccio @pfecchio What do you think?